### PR TITLE
Bound the holdout training window at the features it actually has

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -17,7 +17,7 @@
 
 # ---------------------------------------------------------------------------
 # Needs the modelling environment - run by test-unit-image, in ml4t/ml4t:latest.
-# 32 files. The 26 that existed on 2026-08-24 measured 392 tests, 3m21s.
+# 33 files. The 26 that existed on 2026-08-24 measured 392 tests, 3m21s.
 #
 # `case_studies/utils/gbm.py` imports torch at module scope, so the LightGBM
 # files are behind this boundary too even though LightGBM itself is a small

--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -46,6 +46,7 @@ tests/test_gbm_runtime.py
 tests/test_insight_chapter.py
 tests/test_latent_factors_no_leak.py
 tests/test_latent_input_identity.py
+tests/test_family_hook_dispatch.py
 # Imports `_install_fixture_adapter` and `_locked_study` from
 # test_locked_holdout_execution, so it inherits that module's torch dependency
 # transitively rather than importing torch itself. Same boundary, same reason.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -921,7 +921,7 @@ jobs:
   # ---------------------------------------------------------------------------
   test-unit-image:
     runs-on: ubuntu-latest
-    # The 26 files measured on 2026-08-24 ran in 3m21s; the list now contains 30.
+    # The 26 files measured on 2026-08-24 ran in 3m21s; the list now contains 31.
     # --timeout=900 bounds a hung test but not a hung
     # import, collection or image pull, which would otherwise fall through to
     # GitHub's six-hour default.
@@ -963,6 +963,7 @@ jobs:
             tests/test_insight_chapter.py \
             tests/test_latent_factors_no_leak.py \
             tests/test_latent_input_identity.py \
+            tests/test_family_hook_dispatch.py \
             tests/test_holdout_evaluation_driver.py \
             tests/test_locked_holdout_execution.py \
             tests/test_model_analysis_selection.py \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -921,7 +921,7 @@ jobs:
   # ---------------------------------------------------------------------------
   test-unit-image:
     runs-on: ubuntu-latest
-    # The 26 files measured on 2026-08-24 ran in 3m21s; the list now contains 31.
+    # The 26 files measured on 2026-08-24 ran in 3m21s; the list now contains 33.
     # --timeout=900 bounds a hung test but not a hung
     # import, collection or image pull, which would otherwise fall through to
     # GitHub's six-hour default.

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -430,6 +430,7 @@ def build_holdout_cv(
     case_study: str,
     timeline: Sequence[Any],
     label: str | None = None,
+    train_start_floor: Any | None = None,
 ) -> dict[str, Any]:
     """Derive the one holdout CV interval that retrains the selected validation configuration.
 
@@ -446,6 +447,18 @@ def build_holdout_cv(
     would hand the retrain the shortest window it could have had rather than the longest.
     :func:`utils.cv_splits.earliest_train_start` is that read, and this calls it rather than
     repeating it.
+
+    ``train_start_floor`` bounds that below, and exists because "the whole history available"
+    is a claim about the FEATURES, not about the calendar. A configuration fitted on fold-scoped
+    model-based features has no history before the fold that produced them: stage 04 emits each
+    fold over a rolling window, so on sp500_equity_option_analytics the deriver asks for
+    2017-01-05..2020-12-16 and the artifact's holdout fold begins 2019-01-02, leaving 495 of 977
+    training dates covered. Fitting the other 482 on null columns is not the configuration that
+    was ranked - every validation fold saw a fully populated three-year window - so the holdout
+    would evaluate an estimator nobody selected. Clamping to the producer's geometry applies the
+    same rule correctly rather than contradicting it: take everything available, where available
+    is what the features actually span. Families with no fold-scoped features supply no floor and
+    are unaffected. ml4t/agent-workspace#977 has the measurement and the rejected alternative.
 
     Training ends one label buffer before the holdout opens, using the same buffer the
     validation folds were built with. That gap is what stops the last training label's outcome
@@ -480,6 +493,14 @@ def build_holdout_cv(
     folds = _validation_folds(validation_spec)
     validation_cv = dict(validation_spec["computation"]["cv"])
     train_start = earliest_train_start(folds)
+    floor_applied = None
+    if train_start_floor is not None:
+        floor = pd.Timestamp(train_start_floor)
+        if floor > train_start:
+            # Recorded, not silent: the clamp changes the interval the lock is taken over, so a
+            # reader of the spec has to be able to see that the window is the producer's and why.
+            floor_applied = _boundary_iso(floor)
+            train_start = floor
 
     # Both resolvers fall back to setup.yaml's own labels block, and return None without it
     # for every case study whose label carries no separate spec artifact - which is all nine
@@ -575,6 +596,9 @@ def build_holdout_cv(
             "observation_cadence": str(cadence),
             "periods_per_year": periods_per_year,
             "holdout_window": [str(holdout_start), str(holdout_end)],
+            # Present only when it moved the boundary, so a spec that needed no clamp hashes
+            # exactly as it did before this existed and no recorded lock is disturbed.
+            **({"train_start_floor": floor_applied} if floor_applied else {}),
         },
     }
 
@@ -645,6 +669,7 @@ def evaluate_holdout(
         validation_spec,
         case_study=str(case_study if case_study is not None else study.case_study),
         timeline=timeline,
+        train_start_floor=_holdout_training_floor(study, validation_spec),
     )
     _rekey_holdout_spec(study, holdout_spec, validation_spec)
 
@@ -713,6 +738,21 @@ _FOLD_DERIVED_FIELDS = (
     ("model", "effective_params_by_fold"),
     ("macro_context", "resolved_fold_digest"),
 )
+
+
+def _holdout_training_floor(study: Any, validation_spec: Mapping[str, Any]) -> Any | None:
+    """Ask the family how far back its features actually reach, or None if nothing bounds it.
+
+    Dispatches through ``_family_module`` exactly as ``_rekey_holdout_spec`` does. Absence is the
+    answer for most families and is not an error: a configuration whose features are defined over
+    the whole panel has no floor, and returning None leaves the derivation exactly as it was.
+    Only a family whose features are fold-scoped can answer, because only it knows which artifact
+    holds them.
+    """
+    from .models import _family_module
+
+    hook = getattr(_family_module(validation_spec.get("family")), "holdout_training_floor", None)
+    return None if hook is None else hook(study, validation_spec=validation_spec)
 
 
 def _rekey_holdout_spec(study: Any, spec: dict[str, Any], validation_spec: dict[str, Any]) -> None:

--- a/case_studies/utils/latent_factors/__init__.py
+++ b/case_studies/utils/latent_factors/__init__.py
@@ -21,7 +21,10 @@ from case_studies.utils.latent_factors.adapter import (
 )
 from case_studies.utils.latent_factors.cae import run_cae_fold
 from case_studies.utils.latent_factors.cv import load_fold_extras, run_latent_factor_cv
-from case_studies.utils.latent_factors.holdout import rekey_holdout_spec
+from case_studies.utils.latent_factors.holdout import (
+    holdout_training_floor,
+    rekey_holdout_spec,
+)
 from case_studies.utils.latent_factors.ipca import run_ipca_fold
 from case_studies.utils.latent_factors.panel import (
     compute_managed_portfolios,
@@ -44,6 +47,7 @@ __all__ = [
     "prepare_ragged_panel_data",
     "rank_normalize_cross_section",
     "reconstruct_locked_request",
+    "holdout_training_floor",
     "rekey_holdout_spec",
     "run_cae_fold",
     "run_ipca_fold",

--- a/case_studies/utils/latent_factors/holdout.py
+++ b/case_studies/utils/latent_factors/holdout.py
@@ -42,14 +42,13 @@ def rekey_holdout_spec(
       restricted to the fold being fitted, so the validation folds' digest describes a different
       panel slice.
 
-    The hook is necessary and not sufficient. On sp500_equity_option_analytics the lock still
-    cannot be taken, for a reason underneath it: ``build_holdout_cv`` derives the holdout
-    training window from the EARLIEST validation fold's start, deliberately, so the final fit
-    gets the longest history - 2017-01-05..2020-12-16 there - while stage 04 emits each
-    fold-scoped temporal fold over a rolling three-year window, so its fold 2 begins 2019-01-02.
-    Measured 2026-08-29 against the committed artifact: 495 of 977 training dates covered
-    (50.7%), and 252 of 252 evaluation dates (100%). The producer and the deriver disagree about
-    the holdout's training interval, and this refuses rather than fitting on half-null features.
+    The hook was necessary and not sufficient. Underneath it the deriver and the producer
+    disagreed about the holdout's training interval - ``build_holdout_cv`` asked for
+    2017-01-05..2020-12-16 while stage 04's fold 2 begins 2019-01-02, leaving 495 of 977 training
+    dates covered - and this refused rather than fit on half-null features.
+    :func:`holdout_training_floor` below resolves that by bounding the derived window at the
+    artifact's own start, so the refusal now fires only for a real gap. ml4t/agent-workspace#977
+    has the measurement.
 
     ``validation_spec`` is unused here. The linear hook needs it to replay a data-derived penalty
     against a recorded fold before trusting the preset; latent-factor models resolve no parameter
@@ -111,3 +110,59 @@ def _require_holdout_temporal_features(case: Any, split: dict[str, Any]) -> None
         source_timeline=case.dataset.get_column(case.date_col),
         date_col=case.date_col,
     )
+
+
+def holdout_training_floor(study: Study, *, validation_spec: dict[str, Any]) -> Any | None:
+    """The earliest date this configuration's fold-scoped features actually reach.
+
+    ``build_holdout_cv`` starts the holdout training window at the earliest validation fold's
+    start so the final fit gets the longest history. For a latent-factor configuration that is
+    the right rule read against the wrong quantity: the model-based features are fold-scoped, and
+    stage 04 emits each fold over a rolling window, so there is no feature history before the
+    fold the holdout will be joined against. On sp500_equity_option_analytics the deriver asks
+    for 2017-01-05 and the artifact's holdout fold begins 2019-01-02; training the difference
+    means fitting 482 of 977 dates on null columns, which is not the configuration selection
+    ranked - every validation fold saw a fully populated window.
+
+    So this returns the artifact's own start for the fold the holdout will carry, and
+    ``build_holdout_cv`` takes the later of the two. Returning ``None`` leaves the derivation
+    untouched, which is the answer whenever the configuration has no fold-scoped features.
+
+    The case-study context is loaded here and again in :func:`rekey_holdout_spec`. That is
+    deliberate rather than overlooked: a lock is derived once per case study, and threading a
+    cache through two hooks with different dispatch points would buy nothing and couple them.
+    """
+    from case_studies.utils.latent_factors.case_study import load_case_study_context
+
+    computation = validation_spec.get("computation") or {}
+    model = computation.get("model")
+    model_name = str(model.get("class", "")) if isinstance(model, dict) else ""
+    if validation_spec.get("family") != "latent_factors" or model_name not in _LATENT_MODELS:
+        return None
+
+    folds = ((computation.get("cv") or {}).get("folds")) or []
+    if not folds:
+        return None
+    # The fold id build_holdout_cv is about to mint, derived the same way it derives it.
+    fold_id = max(int(entry["fold"]) for entry in folds) + 1
+
+    case = load_case_study_context(
+        study.case_study,
+        primary_label=str(validation_spec.get("label") or ""),
+        max_symbols=0,
+        use_macro=False,
+    )
+    if case.temporal_by_fold is None or not case.temporal_keys or not case.temporal_feature_names:
+        return None
+
+    import polars as pl
+
+    frame = case.temporal_by_fold
+    if isinstance(frame, pl.LazyFrame):
+        frame = frame.select(["fold", case.date_col]).collect()
+    elif not isinstance(frame, pl.DataFrame):
+        frame = pl.from_pandas(frame.loc[:, ["fold", case.date_col]])
+    dates = frame.filter(pl.col("fold") == fold_id).get_column(case.date_col)
+    # An absent fold is not this hook's refusal to make. `require_fold_scoped_temporal_holdout
+    # _coverage` says so with the numbers; returning None here lets it.
+    return None if dates.is_empty() else dates.min()

--- a/tests/test_family_hook_dispatch.py
+++ b/tests/test_family_hook_dispatch.py
@@ -1,0 +1,36 @@
+"""A model-family hook the package does not export is not a hook, and `getattr` says so silently.
+
+`case_studies.research.models._family_module` returns the family's PACKAGE, so a function
+defined in a submodule and left out of `__init__.py` resolves to `None`. Every caller then
+degrades quietly: `_holdout_training_floor` returns no floor, `_rekey_holdout_spec` raises
+`NotImplementedError`. Both read as "this family does not implement it" rather than as the
+export bug they are, and that is exactly how the missing `holdout_training_floor` export
+shipped once already.
+
+Resolving the way production resolves is the only check that can tell those two apart, which
+is why this imports the real packages instead of asserting against `__all__`. It therefore
+needs the modelling environment: `case_studies.utils.latent_factors` imports torch at module
+scope on purpose, so this file runs in `test-unit-image` and is quarantined out of `test-unit`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Every family that `_family_module` can be asked for, and the hooks the dispatch calls on it.
+FAMILY_HOOKS = {
+    "latent_factors": ("rekey_holdout_spec", "holdout_training_floor"),
+    "linear": ("rekey_holdout_spec",),
+}
+
+
+@pytest.mark.parametrize("family", sorted(FAMILY_HOOKS))
+def test_every_family_hook_is_reachable_through_the_dispatch_that_calls_it(family: str) -> None:
+    from case_studies.research.models import _family_module
+
+    module = _family_module(family)
+    for hook in FAMILY_HOOKS[family]:
+        assert callable(getattr(module, hook, None)), (
+            f"{family}.{hook} is defined in a submodule but not exported from the package "
+            f"`_family_module` returns, so the dispatch cannot see it"
+        )

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -714,3 +714,26 @@ def test_a_floor_that_swallows_the_training_interval_is_refused_not_silently_emp
             timeline=MONTH_ENDS,
             train_start_floor=pd.Timestamp(fold["train_end"]) + pd.Timedelta(days=1),
         )
+
+
+def test_every_family_hook_is_reachable_through_the_dispatch_that_calls_it() -> None:
+    """A hook the package does not export is not a hook, and `getattr` says so silently.
+
+    `_family_module` returns the family's PACKAGE, so a function defined in a submodule and left
+    out of `__init__.py` resolves to None - `_holdout_training_floor` then returns no floor and
+    `_rekey_holdout_spec` raises NotImplementedError, both of which read as "this family does not
+    implement it" rather than as the export bug they are. Resolving the way production resolves
+    is the only check that can tell those apart.
+    """
+    from case_studies.research.models import _family_module
+
+    for family, hooks in {
+        "latent_factors": ("rekey_holdout_spec", "holdout_training_floor"),
+        "linear": ("rekey_holdout_spec",),
+    }.items():
+        module = _family_module(family)
+        for hook in hooks:
+            assert callable(getattr(module, hook, None)), (
+                f"{family}.{hook} is defined in a submodule but not exported from the package "
+                f"`_family_module` returns, so the dispatch cannot see it"
+            )

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -714,26 +714,3 @@ def test_a_floor_that_swallows_the_training_interval_is_refused_not_silently_emp
             timeline=MONTH_ENDS,
             train_start_floor=pd.Timestamp(fold["train_end"]) + pd.Timedelta(days=1),
         )
-
-
-def test_every_family_hook_is_reachable_through_the_dispatch_that_calls_it() -> None:
-    """A hook the package does not export is not a hook, and `getattr` says so silently.
-
-    `_family_module` returns the family's PACKAGE, so a function defined in a submodule and left
-    out of `__init__.py` resolves to None - `_holdout_training_floor` then returns no floor and
-    `_rekey_holdout_spec` raises NotImplementedError, both of which read as "this family does not
-    implement it" rather than as the export bug they are. Resolving the way production resolves
-    is the only check that can tell those apart.
-    """
-    from case_studies.research.models import _family_module
-
-    for family, hooks in {
-        "latent_factors": ("rekey_holdout_spec", "holdout_training_floor"),
-        "linear": ("rekey_holdout_spec",),
-    }.items():
-        module = _family_module(family)
-        for hook in hooks:
-            assert callable(getattr(module, hook, None)), (
-                f"{family}.{hook} is defined in a submodule but not exported from the package "
-                f"`_family_module` returns, so the dispatch cannot see it"
-            )

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -653,3 +653,64 @@ def test_coverage_refuses_both_cases_the_fold_id_check_refuses() -> None:
         require_fold_scoped_temporal_holdout_coverage(
             {**holdout, "fold": 8}, artifact, source_timeline=source
         )
+
+
+# --- The training floor: "the longest history" is a claim about features, not the calendar ----
+#
+# build_holdout_cv starts the holdout training window at the earliest validation fold so the
+# final fit gets the most history. For a configuration whose model-based features are fold-scoped
+# there is no feature history before the producer's fold, and training the difference fits null
+# columns - a different estimator from any that was ranked. The floor bounds the window below.
+# ml4t/agent-workspace#977 carries the measurement that produced these tests.
+
+
+def test_a_floor_later_than_the_earliest_fold_moves_the_training_start() -> None:
+    earliest = min(pd.Timestamp(entry["train_start"]) for entry in FOLDS)
+    floor = earliest + pd.Timedelta(days=400)
+
+    cv = build_holdout_cv(
+        _validation_spec(),
+        case_study="us_firm_characteristics",
+        timeline=MONTH_ENDS,
+        train_start_floor=floor,
+    )
+    fold = _fold(cv)
+
+    assert pd.Timestamp(fold["train_start"]) == floor
+    assert pd.Timestamp(fold["train_start"]) > earliest
+    # Recorded, so a reader of the locked spec can see the window is the producer's.
+    assert cv["request"]["train_start_floor"] == floor.date().isoformat()
+
+
+def test_a_floor_earlier_than_the_earliest_fold_changes_nothing_at_all() -> None:
+    """Including the identity: a spec that needed no clamp must hash as it did before this."""
+    earliest = min(pd.Timestamp(entry["train_start"]) for entry in FOLDS)
+    unclamped = build_holdout_cv(
+        _validation_spec(), case_study="us_firm_characteristics", timeline=MONTH_ENDS
+    )
+    clamped = build_holdout_cv(
+        _validation_spec(),
+        case_study="us_firm_characteristics",
+        timeline=MONTH_ENDS,
+        train_start_floor=earliest - pd.Timedelta(days=400),
+    )
+
+    assert _fold(clamped) == _fold(unclamped)
+    assert clamped["identity"] == unclamped["identity"]
+    assert "train_start_floor" not in clamped["request"]
+    assert "train_start_floor" not in unclamped["request"]
+
+
+def test_a_floor_that_swallows_the_training_interval_is_refused_not_silently_empty() -> None:
+    fold = _fold(
+        build_holdout_cv(
+            _validation_spec(), case_study="us_firm_characteristics", timeline=MONTH_ENDS
+        )
+    )
+    with pytest.raises(ValueError, match="holdout training interval is empty"):
+        build_holdout_cv(
+            _validation_spec(),
+            case_study="us_firm_characteristics",
+            timeline=MONTH_ENDS,
+            train_start_floor=pd.Timestamp(fold["train_end"]) + pd.Timedelta(days=1),
+        )


### PR DESCRIPTION
`_family_module` returns the family's PACKAGE, and
`case_studies/utils/latent_factors/__init__.py` exported only
`rekey_holdout_spec`. `holdout_training_floor` was defined in the
submodule and invisible to `getattr`, so `_holdout_training_floor`
resolved None and returned no floor - the previous commit's clamp never
fired. Caught by the pre-push gate.

The failure mode is why the test is a reachability test rather than
another assertion about clamping. An unexported hook reads exactly like a
family that does not implement one: the floor lookup returns None and
`_rekey_holdout_spec` raises NotImplementedError, both of which are the
documented behaviour for a family with no hook. Resolving the way
production resolves is the only check that separates them, so the test
walks both families through `_family_module` and requires every hook to be
callable from there. Confirmed to fail with the export removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgUb6jPjpCGbon6kGDQKCj