### PR TITLE
compare_families could not tell a family's Sharpe from its survivors'

### DIFF
--- a/case_studies/utils/backtest_explorer.py
+++ b/case_studies/utils/backtest_explorer.py
@@ -398,20 +398,52 @@ class BacktestExplorer:
     # compare_families: model family comparison at a stage
     # -----------------------------------------------------------------
 
-    def compare_families(self, stage: str = "signal") -> pl.DataFrame:
+    def compare_families(
+        self, stage: str = "signal", *, exclude_insolvent: bool = False
+    ) -> pl.DataFrame:
         """Compare model families by backtest Sharpe at a given stage.
+
+        Parameters
+        ----------
+        exclude_insolvent : bool, default False
+            Compute the Sharpe statistics over the runs that stayed solvent,
+            and report how many did not in an added ``insolvent`` column. A run
+            whose ``max_drawdown`` reached -100% took its equity to zero or
+            past it; there is no capital left to earn a later return, so every
+            subsequent period is arithmetic on zero or a negative balance and
+            the Sharpe is a number without a meaning. Leaving those in distorts
+            a median and can top a maximum.
+
+            The count is reported rather than the runs silently dropped,
+            because dropping them alone would rank a family by its survivors: a
+            family that went to zero in nine runs out of ten would show the
+            Sharpe of the tenth and nothing to say so. ``n`` counts the solvent
+            runs the statistics are computed over and ``insolvent`` the rest,
+            so a reader can see what the median is conditional on. A family
+            with no solvent run has null statistics and sorts last.
+
+            A run with no recorded drawdown is counted under ``unknown`` and
+            kept out of the statistics. It cannot be shown to have stayed
+            solvent, but neither did it fail: putting it under ``insolvent``
+            would report a bankruptcy that was never measured. ``n``,
+            ``insolvent`` and ``unknown`` together are every run of the family.
+
+            Off by default, so a caller that has already reported on the full
+            population keeps reporting on it, with the same columns as before.
 
         Returns
         -------
         pl.DataFrame
             Columns: family, n, sharpe_median, sharpe_max, sharpe_q75,
-            pct_positive
+            pct_positive - and ``insolvent``, ``unknown`` when
+            ``exclude_insolvent``.
         """
         df = self._query(
             f"""
             SELECT
                 t.family,
-                bm.sharpe
+                bm.sharpe,
+                bm.max_drawdown
             FROM backtest_metrics bm
             JOIN backtest_runs b ON bm.backtest_hash = b.backtest_hash
             JOIN prediction_sets p ON b.prediction_hash = p.prediction_hash
@@ -432,16 +464,43 @@ class BacktestExplorer:
         if df.is_empty():
             return df
 
+        if not exclude_insolvent:
+            return (
+                df.group_by("family")
+                .agg(
+                    n=pl.len(),
+                    sharpe_median=pl.col("sharpe").median(),
+                    sharpe_max=pl.col("sharpe").max(),
+                    sharpe_q75=pl.col("sharpe").quantile(0.75),
+                    pct_positive=((pl.col("sharpe") > 0).sum() / pl.len() * 100),
+                )
+                .sort("sharpe_median", descending=True)
+            )
+
+        # Three outcomes, counted separately, because a run with no recorded drawdown
+        # is not a bankruptcy: reporting it under `insolvent` would put a failure on
+        # the record that was never measured. Each comparison is null for that run, so
+        # the sums skip it and it lands only in `unknown`. n + insolvent + unknown is
+        # every run of the family.
+        solvent = pl.col("max_drawdown") > -1.0
+        # Filtering needs a mask with no nulls; the counts above do not, and take the
+        # null-skipping behaviour instead.
+        solvent_mask = solvent.fill_null(False)
         return (
             df.group_by("family")
             .agg(
-                n=pl.len(),
-                sharpe_median=pl.col("sharpe").median(),
-                sharpe_max=pl.col("sharpe").max(),
-                sharpe_q75=pl.col("sharpe").quantile(0.75),
-                pct_positive=((pl.col("sharpe") > 0).sum() / pl.len() * 100),
+                n=solvent.sum(),
+                insolvent=(pl.col("max_drawdown") <= -1.0).sum(),
+                unknown=pl.col("max_drawdown").is_null().sum(),
+                sharpe_median=pl.col("sharpe").filter(solvent_mask).median(),
+                sharpe_max=pl.col("sharpe").filter(solvent_mask).max(),
+                sharpe_q75=pl.col("sharpe").filter(solvent_mask).quantile(0.75),
+                # `mean` rather than `sum() / len()`: a family whose runs all went
+                # insolvent divides by zero, and mean over an empty selection is null,
+                # which is what "no solvent run to report a rate over" means.
+                pct_positive=(pl.col("sharpe").filter(solvent_mask) > 0).mean() * 100,
             )
-            .sort("sharpe_median", descending=True)
+            .sort("sharpe_median", descending=True, nulls_last=True)
         )
 
     # -----------------------------------------------------------------

--- a/case_studies/utils/backtest_explorer.py
+++ b/case_studies/utils/backtest_explorer.py
@@ -426,7 +426,12 @@ class BacktestExplorer:
             kept out of the statistics. It cannot be shown to have stayed
             solvent, but neither did it fail: putting it under ``insolvent``
             would report a bankruptcy that was never measured. ``n``,
-            ``insolvent`` and ``unknown`` together are every run of the family.
+            ``insolvent`` and ``unknown`` together are every run of the family:
+            the query does not drop a run for having no Sharpe when this is on,
+            because a bankrupt run can carry a null one and dropping it would take
+            a wiped-out family off the table entirely. The Sharpe statistics skip
+            any solvent run without a recorded Sharpe, so they can rest on fewer
+            than ``n`` runs: these columns count runs, not measurements.
 
             Off by default, so a caller that has already reported on the full
             population keeps reporting on it, with the same columns as before.
@@ -438,6 +443,12 @@ class BacktestExplorer:
             pct_positive - and ``insolvent``, ``unknown`` when
             ``exclude_insolvent``.
         """
+        # A run that went bankrupt can carry a null Sharpe, and dropping those in SQL would
+        # remove it before `insolvent` counts it - so a family that went bankrupt in every
+        # run would leave the comparison entirely, which is the survivorship bias this
+        # option exists to expose. Under the flag the rows are kept, and the Sharpe
+        # aggregates skip the nulls themselves.
+        sharpe_sql = "" if exclude_insolvent else "AND bm.sharpe IS NOT NULL"
         df = self._query(
             f"""
             SELECT
@@ -453,7 +464,7 @@ class BacktestExplorer:
               AND p.split != 'holdout'
               {excluded_family_sql(self.case_study, "t.family")[0]}
               {full_coverage_prediction_sql("p", "t", "pm")}
-              AND bm.sharpe IS NOT NULL
+              {sharpe_sql}
               AND (bm.num_trades IS NULL OR bm.num_trades > 0)
             """,
             (stage, *excluded_family_sql(self.case_study, "t.family")[1]),

--- a/tests/test_compare_families_solvency.py
+++ b/tests/test_compare_families_solvency.py
@@ -26,6 +26,10 @@ ROWS = [
     ("no_drawdown", "gbm", 8.0, None),
     # A family with nothing left. It has no Sharpe to report, and must not vanish.
     ("wiped", "tabular_dl", 5.0, -2.0),
+    # Bankrupt with no Sharpe at all. The query must not drop it for that: dropping it
+    # would remove the run before `insolvent` counts it, and a family in which every run
+    # ended this way would leave the comparison without a trace.
+    ("wiped_no_sharpe", "tabular_dl", None, -4.0),
 ]
 
 
@@ -129,6 +133,9 @@ def test_default_keeps_every_run_and_its_columns(tmp_path) -> None:
     gbm = families.filter(family="gbm")
     assert gbm["n"].item() == 5
     assert gbm["sharpe_max"].item() == 9.0
+    # The default path still drops a run with no Sharpe, which is what its callers have
+    # always aggregated: `wiped_no_sharpe` is absent, so tabular_dl counts one run.
+    assert families.filter(family="tabular_dl")["n"].item() == 1
 
 
 def test_exclude_insolvent_reports_the_ruined_rather_than_dropping_them(tmp_path) -> None:
@@ -158,7 +165,10 @@ def test_exclude_insolvent_reports_the_ruined_rather_than_dropping_them(tmp_path
     wiped = families.filter(family="tabular_dl")
     assert wiped.height == 1
     assert wiped["n"].item() == 0
-    assert wiped["insolvent"].item() == 1
+    # Both of its runs are counted, including the one with no Sharpe. Were that run
+    # dropped by the query, this family would show a single failure instead of two - and
+    # a family whose runs ALL ended without a Sharpe would not appear here at all.
+    assert wiped["insolvent"].item() == 2
     assert wiped["unknown"].item() == 0
     assert wiped["sharpe_median"].item() is None
     assert wiped["pct_positive"].item() is None

--- a/tests/test_compare_families_solvency.py
+++ b/tests/test_compare_families_solvency.py
@@ -1,0 +1,182 @@
+"""``compare_families`` can exclude runs whose equity went negative.
+
+A long-short book can lose more than its capital: the short leg's loss is unbounded
+and the engine has no margin call, so equity compounds through zero and later periods
+are arithmetic on a negative balance. Those runs still carry a Sharpe, and it is large
+often enough to top a family maximum and pull a median. ``max_drawdown`` below -100% is
+that condition.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from case_studies.utils.backtest_explorer import BacktestExplorer
+
+# (prediction_hash, family, sharpe, max_drawdown)
+ROWS = [
+    ("solvent_a", "gbm", 1.0, -0.2),
+    ("solvent_b", "gbm", 0.5, -0.3),
+    ("ruined", "gbm", 9.0, -3.0),
+    # Equity exactly at zero. It cannot earn a later return, so it is ruin and not the
+    # edge of solvency - the boundary notebook 12 already applies at the allocation stage.
+    ("exactly_zero", "gbm", 7.0, -1.0),
+    # No recorded drawdown: held out of the statistics, but counted apart from the
+    # ruined - it was never measured, so calling it a bankruptcy would invent one.
+    ("no_drawdown", "gbm", 8.0, None),
+    # A family with nothing left. It has no Sharpe to report, and must not vanish.
+    ("wiped", "tabular_dl", 5.0, -2.0),
+]
+
+
+def _build_registry(case_dir) -> None:
+    run_log = case_dir / "run_log"
+    run_log.mkdir(parents=True)
+    with sqlite3.connect(run_log / "registry.db") as db:
+        db.executescript(
+            """
+            CREATE TABLE training_runs (
+                training_hash TEXT PRIMARY KEY,
+                family TEXT,
+                config_name TEXT,
+                label TEXT
+            );
+            CREATE TABLE prediction_sets (
+                prediction_hash TEXT PRIMARY KEY,
+                training_hash TEXT,
+                split TEXT,
+                checkpoint_value REAL
+            );
+            CREATE TABLE prediction_metrics (
+                prediction_hash TEXT PRIMARY KEY,
+                ic_mean REAL,
+                ic_mean_daily REAL,
+                ic_ci_lo REAL,
+                ic_ci_hi REAL,
+                ic_n_days REAL
+            );
+            CREATE TABLE fold_metrics (prediction_hash TEXT, ic REAL);
+            CREATE TABLE backtest_runs (
+                backtest_hash TEXT PRIMARY KEY,
+                prediction_hash TEXT,
+                spec_json TEXT,
+                stage TEXT
+            );
+            CREATE TABLE backtest_metrics (
+                backtest_hash TEXT PRIMARY KEY,
+                sharpe REAL,
+                cagr REAL,
+                max_drawdown REAL,
+                total_return REAL,
+                volatility REAL,
+                num_trades REAL
+            );
+            CREATE TABLE backtest_fold_metrics (
+                backtest_hash TEXT,
+                fold_id INTEGER,
+                sharpe REAL
+            );
+            """
+        )
+        for prediction_hash, family, sharpe, max_drawdown in ROWS:
+            training_hash = f"train_{prediction_hash}"
+            db.execute(
+                "INSERT INTO training_runs VALUES (?, ?, ?, 'fwd_ret_5d')",
+                (training_hash, family, prediction_hash),
+            )
+            db.execute(
+                "INSERT INTO prediction_sets VALUES (?, ?, 'validation', 0)",
+                (prediction_hash, training_hash),
+            )
+            # Equal ic_n_days across rows, so coverage filtering keeps all four and
+            # solvency is the only thing separating them.
+            db.execute(
+                "INSERT INTO prediction_metrics VALUES (?, 0.1, 0.1, 0.0, 0.2, 4.0)",
+                (prediction_hash,),
+            )
+            db.execute(
+                """
+                INSERT INTO backtest_runs VALUES (
+                    ?, ?, '{"allocation":{"method":"score_weighted"}}', 'signal'
+                )
+                """,
+                (f"bt_{prediction_hash}", prediction_hash),
+            )
+            db.execute(
+                "INSERT INTO backtest_metrics VALUES (?, ?, 0.1, ?, 0.2, 0.1, 1)",
+                (f"bt_{prediction_hash}", sharpe, max_drawdown),
+            )
+
+
+def test_default_keeps_every_run_and_its_columns(tmp_path) -> None:
+    """Off by default, so callers that reported on the full population still do.
+
+    The column set is part of that: the five other case studies that call this print
+    the frame, and an added column would change what their notebooks render.
+    """
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+    families = BacktestExplorer("test", case_dir=case_dir).compare_families()
+
+    assert families.columns == [
+        "family",
+        "n",
+        "sharpe_median",
+        "sharpe_max",
+        "sharpe_q75",
+        "pct_positive",
+    ]
+    gbm = families.filter(family="gbm")
+    assert gbm["n"].item() == 5
+    assert gbm["sharpe_max"].item() == 9.0
+
+
+def test_exclude_insolvent_reports_the_ruined_rather_than_dropping_them(tmp_path) -> None:
+    """The statistics come from the solvent runs; the count of the rest sits beside them.
+
+    Dropping the ruined runs and saying nothing would rank a family by its survivors.
+    ``tabular_dl`` is the case that shows it: every run went to zero, so it has no
+    Sharpe at all, and it has to remain visible as a family that was wiped out rather
+    than disappear from the comparison.
+    """
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+    families = BacktestExplorer("test", case_dir=case_dir).compare_families(exclude_insolvent=True)
+
+    gbm = families.filter(family="gbm")
+    # solvent_a and solvent_b carry the statistics. `ruined` and `exactly_zero` are the
+    # measured failures; `no_drawdown` is held out of both, because a run that was never
+    # measured is not a bankruptcy. The three counts add up to every run of the family.
+    assert gbm["n"].item() == 2
+    assert gbm["insolvent"].item() == 2
+    assert gbm["unknown"].item() == 1
+    assert gbm["n"].item() + gbm["insolvent"].item() + gbm["unknown"].item() == 5
+    assert gbm["sharpe_max"].item() == 1.0
+    assert gbm["sharpe_median"].item() == 0.75
+    assert gbm["pct_positive"].item() == 100.0
+
+    wiped = families.filter(family="tabular_dl")
+    assert wiped.height == 1
+    assert wiped["n"].item() == 0
+    assert wiped["insolvent"].item() == 1
+    assert wiped["unknown"].item() == 0
+    assert wiped["sharpe_median"].item() is None
+    assert wiped["pct_positive"].item() is None
+
+    # A family with no solvent run sorts last rather than heading the table on a null.
+    assert families["family"].to_list() == ["gbm", "tabular_dl"]
+
+
+def test_equity_at_exactly_zero_is_ruin(tmp_path) -> None:
+    """``max_drawdown`` of exactly -1.0 is the boundary, and it is on the ruined side.
+
+    A drawdown of -100% means the trough reached zero. Nothing is left to earn a return,
+    so its Sharpe is no more meaningful than that of a run that went further negative.
+    """
+    case_dir = tmp_path / "case"
+    _build_registry(case_dir)
+    families = BacktestExplorer("test", case_dir=case_dir).compare_families(exclude_insolvent=True)
+
+    # `exactly_zero` carries Sharpe 7.0, so it would top the family maximum if the
+    # boundary were treated as solvent.
+    assert families.filter(family="gbm")["sharpe_max"].item() == 1.0


### PR DESCRIPTION
A long-short book with no margin call compounds through zero, so a run's equity can reach zero and every later period is arithmetic on nothing left. `max_drawdown` at or past -100% is that condition, and the Sharpe those runs carry is not a return. Left in a family aggregate they distort a median and can top a maximum.

`compare_families` gains an opt-in `exclude_insolvent`. It computes the Sharpe statistics over the solvent runs and **reports** the rest, because dropping them alone would rank a family by its survivors: one that went to zero in nine runs out of ten would show the Sharpe of the tenth with nothing to say so.

| column | meaning |
|---|---|
| `n` | solvent runs, the ones behind the statistics |
| `insolvent` | measured failures (`max_drawdown <= -1.0`) |
| `unknown` | no recorded drawdown - held out of the statistics, but not called a bankruptcy that was never measured |

The three sum to every run of the family. A family with no solvent run keeps its row, with null statistics, and sorts last rather than heading the table on a null.

The second commit fixes a defect found by review on the first: the query drops rows with no Sharpe, and a bankrupt run can carry a null one, so it was removed *before* `insolvent` could count it - and a family whose runs all ended that way left the comparison without a trace. That is the same survivorship bias one layer down. Under the flag the Sharpe filter is dropped and the aggregates skip the nulls themselves, which they already did.

**Default is off and the column set is unchanged there**, so the six case studies calling this render exactly what they rendered before; `test_full_coverage_selection` pins that. The boundary is `> -1.0` for solvent, matching what `us_firm_characteristics/12` already applied at the allocation stage - 11 and 12 disagreed at exactly -100% before this.

Extracted from `cs6/us_firm_characteristics` per REVIEW.md section H, which requires a `case_studies/utils/` fix to leave the case-study branch the same day as its own PR. `11_backtest` needs it: that notebook excluded the ruined runs from its two figures while ranking its top-ten table and aggregating its families on them. Measured there: 20 of 1252 signal-stage runs insolvent, Sharpe 0.27-1.43 against a top-ten floor of 2.65, so only the family medians move.

Tests: three cases covering the survivorship counts, a wiped-out family, a run exactly on the -1.0 boundary carrying a Sharpe high enough to top its family, and a bankrupt run with a null Sharpe. The last fails without the fix and passes with it.