### PR TITLE
Stop handing a causal preview a fold key its resolver rejects (#968)

### DIFF
--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -1003,10 +1003,17 @@ def resolved_registry_path(
 # reported unreachable on MAX_FOLDS and MAX_SYMBOLS, which do reach them.
 TRANSLATION_TARGET = "PREVIEW_REDUCTIONS"
 
-PREVIEW_TRANSLATED_PARAMETERS: dict[str, tuple[str, Callable[[Any], Any]]] = {
-    "MAX_FOLDS": ("folds", lambda value: list(range(int(value)))),
-    "MAX_SYMBOLS": ("max_symbols", int),
-    "TRAIN_SAMPLE_FRAC": ("train_sample_frac", float),
+# The third element is every reduction name that states the same quantity. A translated default
+# is dropped when the notebook's own mapping already carries one of them, because two consumers
+# read this mapping and they do not spell the fold count the same way: the model families take
+# `folds`, an explicit list, and the DML resolver takes `n_folds`, a count, and rejects any key
+# outside its four (`case_studies/utils/causal.py:_DML_PREVIEW_FIELDS`). Without the aliases the
+# `MAX_FOLDS` in `_QUICK_PARAMS` reached a complete causal mapping as a fifth key and
+# `resolve_causal_request` refused the request before any fit.
+PREVIEW_TRANSLATED_PARAMETERS: dict[str, tuple[str, Callable[[Any], Any], tuple[str, ...]]] = {
+    "MAX_FOLDS": ("folds", lambda value: list(range(int(value))), ("folds", "n_folds")),
+    "MAX_SYMBOLS": ("max_symbols", int, ("max_symbols",)),
+    "TRAIN_SAMPLE_FRAC": ("train_sample_frac", float, ("train_sample_frac",)),
 }
 
 
@@ -1021,10 +1028,11 @@ def _collect_preview_reductions(parameters: dict) -> dict:
     """
     resolved = dict(parameters)
     reductions = dict(resolved.get("PREVIEW_REDUCTIONS") or {})
-    for name, (key, cast) in PREVIEW_TRANSLATED_PARAMETERS.items():
+    for name, (key, cast, aliases) in PREVIEW_TRANSLATED_PARAMETERS.items():
         value = resolved.pop(name, None)
-        if value is not None:
-            reductions.setdefault(key, cast(value))
+        if value is None or any(alias in reductions for alias in aliases):
+            continue
+        reductions[key] = cast(value)
     # A preview run that reduces nothing is a canonical run wearing the wrong tier, and the
     # request builder rejects it. Reducing the universe is the reduction that always applies.
     if not reductions:

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -1280,3 +1280,49 @@ def test_unusable_parameters_catches_a_preview_mapping_rebound_above_every_reade
     assert set(problems) == set(PREVIEW_TRANSLATED_PARAMETERS)
     for name, reason in problems.items():
         assert "PREVIEW_REDUCTIONS" in reason, name
+
+
+def test_a_complete_causal_mapping_is_not_given_a_fold_key_its_resolver_rejects(
+    tmp_path: Path,
+) -> None:
+    """`MAX_FOLDS` must not reach a mapping that already states its fold count as `n_folds`.
+
+    `_QUICK_PARAMS` sets `MAX_FOLDS` for every model notebook, and the translation used to
+    add `folds` to any mapping that lacked that exact key. A causal override declares the four
+    fields `resolve_causal_request` requires and none of them is named `folds`, so the default
+    fired and the request was refused with "unsupported DML preview reductions: ['folds']"
+    before any fit. The consumer's own field set is the assertion, so this stays true if that
+    set changes.
+    """
+    from case_studies.utils.causal import _DML_PREVIEW_FIELDS
+
+    declared = {
+        "PREVIEW_REDUCTIONS": {
+            "max_samples": 5000,
+            "max_symbols": 5,
+            "n_folds": 2,
+            "n_placebo": 25,
+        },
+        "MAX_FOLDS": 2,
+        "MAX_SYMBOLS": 5,
+    }
+    resolved = injected_parameters(
+        REPO_ROOT / "case_studies/cme_futures/11_causal_dml.py",
+        declared,
+        tmp_path,
+        research_preview=True,
+    )
+    reductions = resolved["PREVIEW_REDUCTIONS"]
+    assert set(reductions) == _DML_PREVIEW_FIELDS
+    assert reductions["n_folds"] == 2
+
+
+def test_a_model_mapping_without_a_fold_count_still_gets_one(tmp_path: Path) -> None:
+    """The translation still applies where the notebook states no fold count of its own."""
+    resolved = injected_parameters(
+        REPO_ROOT / "case_studies/cme_futures/10a_pca.py",
+        {"PREVIEW_REDUCTIONS": {"max_samples": 5000}, "MAX_FOLDS": 2},
+        tmp_path,
+        research_preview=True,
+    )
+    assert resolved["PREVIEW_REDUCTIONS"]["folds"] == [0, 1]


### PR DESCRIPTION
`_QUICK_PARAMS` sets `MAX_FOLDS` for every model notebook and `_collect_preview_reductions` translated it into the reduction key `folds` on any mapping that lacked that exact key. A causal override declares the four fields `resolve_causal_request` requires - and none of them is named `folds` - so the default fired, added a fifth key, and the request was refused before any fit:

```
tests/test_model_registry.py::test_model_notebook[cme_futures::11_causal_dml]
  Cell 6 (ValueError): unsupported DML preview reductions: ['folds']
```

One quantity, two consumers, two spellings: the model families take `folds`, an explicit list, and the DML resolver takes `n_folds`, a count, and rejects anything outside its four fields. The translation table now carries the reduction names that state the same quantity, and a translated default is dropped when the mapping already carries one of them. A notebook that states no fold count of its own still gets one, so the model path is unchanged.

## Evidence

- `test_model_notebook[cme_futures::11_causal_dml]` passes with the fix (`1 passed in 27.92s`); it was the reproduction in ml4t/agent-workspace#968.
- The new regression test fails against the previous translation, with `folds` as the extra key, and passes with it.
- `tests/test_pm_helpers.py` 90 passed.

Both migrated causal notebooks were affected - `cme_futures` and `crypto_perps_funding` are the two that declare `PREVIEW_REDUCTIONS` - and neither was red in CI, because `test_model_notebook` is deselected in `.github/ci/unit-test-quarantine.txt`.

The regression test asserts the resolved mapping against `_DML_PREVIEW_FIELDS` itself rather than a literal, so it stays true if the resolver's field set changes.

Closes ml4t/agent-workspace#968.