### PR TITLE
Store the placebo draws behind refutation_p

### DIFF
--- a/case_studies/research/causal.py
+++ b/case_studies/research/causal.py
@@ -104,9 +104,15 @@ class CausalResult:
                     if "refutation_n_successful" in columns
                     else "NULL AS refutation_n_successful"
                 )
+                placebo_column = (
+                    "refutation_placebo_json"
+                    if "refutation_placebo_json" in columns
+                    else "NULL AS refutation_placebo_json"
+                )
                 row = db.execute(
                     "SELECT n_obs, dml_effect, dml_se_hac, p_value_hac, naive_effect, "
-                    f"confounding_bias_pct, refutation_p, {draws_column}, spec_json "
+                    f"confounding_bias_pct, refutation_p, {draws_column}, spec_json, "
+                    f"{placebo_column} "
                     "FROM causal_runs WHERE causal_hash = ?",
                     (causal_hash,),
                 ).fetchone()
@@ -127,6 +133,11 @@ class CausalResult:
                     "confounding_bias_pct": row[5],
                     "refutation_p": row[6],
                     "refutation_n_successful": row[7],
+                    # The draws behind refutation_p, so a reader can render the
+                    # permutation distribution rather than describing a figure that is
+                    # not there. An empty list rather than None when the column exists
+                    # but the run predates it, so callers need one check, not two.
+                    "placebo_effects": json.loads(row[9]) if row[9] else [],
                     # Derived here so every reader gets the same verdict from the same
                     # rule. A p-value alone cannot say whether the draws could have
                     # rejected at all, so a caller that re-applies a bare threshold

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1608,6 +1608,25 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     return spec, context
 
 
+def _placebo_draws_json(refutation: dict) -> str | None:
+    """Serialize the placebo draws behind ``refutation_p``, or None when there are none.
+
+    ``causal_runs`` stored only the scalars - the p-value and the successful draw count -
+    so the permutation-distribution figure every causal notebook draws had no source in
+    the registry. Each notebook read ``ref.get("placebo_effects", [])`` from an in-memory
+    result, which is populated on the run that fits and empty on every reader afterwards,
+    so the figure rendered blank behind its guard while the prose described it.
+
+    The draws are the evidence for the refutation verdict, not a diagnostic byproduct: a
+    p-value cannot say whether the draws could have rejected at all, and the distribution
+    is what shows a reader the observed effect against what noise produces.
+    """
+    draws = refutation.get("placebo_effects")
+    if not draws:
+        return None
+    return json.dumps([float(value) for value in draws])
+
+
 def run_resolved_causal_request(
     study: Study,
     spec: dict[str, Any],
@@ -1734,6 +1753,7 @@ def run_resolved_causal_request(
         confounding_bias_pct=float(results["confounding_bias_pct"]),
         refutation_p=float(refutation_p) if refutation_p is not None else None,
         refutation_n_successful=int(refutation_n) if refutation_n is not None else None,
+        refutation_placebo_json=_placebo_draws_json(refutation),
         spec_json=canonical_json(spec),
         notebook="case_studies.utils.causal",
         started_at=results.get("started_at"),
@@ -1877,6 +1897,7 @@ def register_causal_run(
         confounding_bias_pct=float(results.get("confounding_bias_pct", 0.0)),
         refutation_p=float(refutation_p) if refutation_p is not None else None,
         refutation_n_successful=int(refutation_n) if refutation_n is not None else None,
+        refutation_placebo_json=_placebo_draws_json(ref),
         spec_json=canonical_json(spec),
         notebook=notebook,
         started_at=started_at or results.get("started_at"),

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -44,7 +44,7 @@ VALID_PREDICTION_SPLITS = frozenset({"validation", "holdout"})
 # Columns a schema migration added, which an immutable row may therefore be missing
 # through no change of its own. Nothing else is filled on NULL: see the comment at the
 # backfill itself for why a nullable column is not the same as a migrated one.
-MIGRATION_BACKFILLED_COLUMNS = frozenset({"refutation_n_successful"})
+MIGRATION_BACKFILLED_COLUMNS = frozenset({"refutation_n_successful", "refutation_placebo_json"})
 MAX_PREDICTION_STD_RATIO = 100.0
 
 
@@ -1926,6 +1926,7 @@ def register_causal_run(
     confounding_bias_pct: float | None,
     refutation_p: float | None,
     refutation_n_successful: int | None = None,
+    refutation_placebo_json: str | None = None,
     spec_json: str,
     notebook: str | None,
     started_at: str | None,
@@ -2072,10 +2073,10 @@ def register_causal_run(
                 causal_hash, label, treatment, confounders_json, embargo,
                 n_folds, n_obs, dml_effect, dml_se_hac, p_value_hac,
                 naive_effect, confounding_bias_pct, refutation_p,
-                refutation_n_successful,
+                refutation_n_successful, refutation_placebo_json,
                 spec_json, notebook, started_at, elapsed_s, git_commit,
                 supersedes_hash, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(causal_hash) DO UPDATE SET
                 label=excluded.label,
                 treatment=excluded.treatment,
@@ -2090,6 +2091,12 @@ def register_causal_run(
                 confounding_bias_pct=excluded.confounding_bias_pct,
                 refutation_p=excluded.refutation_p,
                 refutation_n_successful=excluded.refutation_n_successful,
+                -- Fill-once, like supersedes_hash. A row registered before this column
+                -- existed carries NULL, and a re-registration that recomputes the draws
+                -- should fill it; one that does not must not erase them.
+                refutation_placebo_json=COALESCE(
+                    excluded.refutation_placebo_json, causal_runs.refutation_placebo_json
+                ),
                 spec_json=excluded.spec_json,
                 notebook=excluded.notebook,
                 started_at=excluded.started_at,
@@ -2134,6 +2141,7 @@ def register_causal_run(
                 confounding_bias_pct,
                 refutation_p,
                 refutation_n_successful,
+                refutation_placebo_json,
                 spec_json,
                 notebook,
                 started_at,

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -166,6 +166,7 @@ CREATE TABLE IF NOT EXISTS causal_runs (
     confounding_bias_pct REAL,
     refutation_p     REAL,
     refutation_n_successful INTEGER,
+    refutation_placebo_json TEXT,
     spec_json        TEXT,
     notebook         TEXT,
     started_at       TEXT,
@@ -753,6 +754,14 @@ def _migrate_registry(db: sqlite3.Connection) -> None:
         db, "candidate_sets", "supersedes_hash"
     ):
         db.execute("ALTER TABLE candidate_sets ADD COLUMN supersedes_hash TEXT")
+
+    # The placebo draws behind refutation_p. Only the scalars were stored, so the
+    # permutation-distribution figure every causal notebook draws had no source in the
+    # registry and rendered empty behind its guard while the prose described it.
+    if "causal_runs" in tables and not _table_has_column(
+        db, "causal_runs", "refutation_placebo_json"
+    ):
+        db.execute("ALTER TABLE causal_runs ADD COLUMN refutation_placebo_json TEXT")
 
     # Migration 3: tall → wide metric tables
     if "prediction_metrics" in tables:

--- a/tests/test_causal_placebo_draws.py
+++ b/tests/test_causal_placebo_draws.py
@@ -1,0 +1,103 @@
+"""The placebo draws behind ``refutation_p`` must survive into the registry.
+
+Only the scalars were stored - the p-value and the successful draw count - so every
+causal notebook's permutation-distribution figure read ``placebo_effects`` off an
+in-memory result. That key is populated on the run that fits and absent on every read
+afterwards, so the figure rendered empty behind its guard while the prose described the
+distribution it was meant to show.
+
+The draws are the evidence for the refutation verdict rather than a diagnostic
+byproduct: a p-value cannot say whether the draws could have rejected at all, and the
+distribution is what shows a reader the observed effect against what noise produces.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+from case_studies.research.causal import CausalResult
+from case_studies.utils.causal import _placebo_draws_json
+from case_studies.utils.registry.registration import register_causal_run
+
+SPEC = '{"family":"causal_dml","identity_version":3}'
+DRAWS = [0.011, -0.004, 0.002, -0.017, 0.009]
+
+
+def _register(case_dir, *, placebo_json, started_at="first") -> None:
+    register_causal_run(
+        "test_case",
+        "causal_placebo",
+        label="fwd_ret_5d",
+        treatment="ivrv_spread",
+        confounders_json='["rv_20"]',
+        embargo=10,
+        n_folds=5,
+        n_obs=100,
+        dml_effect=-0.02,
+        dml_se_hac=0.02,
+        p_value_hac=0.25,
+        naive_effect=-0.02,
+        confounding_bias_pct=-0.5,
+        refutation_p=0.4,
+        refutation_n_successful=len(DRAWS),
+        refutation_placebo_json=placebo_json,
+        spec_json=SPEC,
+        notebook="12_causal_dml",
+        started_at=started_at,
+        elapsed_s=1.0,
+        case_dir=case_dir,
+    )
+
+
+def _study(case_dir):
+    return SimpleNamespace(root=case_dir, output_root=None)
+
+
+def _stored(case_dir):
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        return db.execute(
+            "SELECT refutation_placebo_json FROM causal_runs WHERE causal_hash = ?",
+            ("causal_placebo",),
+        ).fetchone()[0]
+
+
+def test_the_draws_round_trip_from_the_fit_to_the_reader(tmp_path) -> None:
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, placebo_json=_placebo_draws_json({"placebo_effects": DRAWS}))
+
+    result = CausalResult.open(_study(case_dir), "causal_placebo")
+
+    assert result.metrics["placebo_effects"] == DRAWS
+
+
+def test_a_run_registered_before_the_column_existed_reads_as_empty(tmp_path) -> None:
+    """An empty list, not None, so a caller needs one check rather than two."""
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, placebo_json=None)
+
+    result = CausalResult.open(_study(case_dir), "causal_placebo")
+
+    assert result.metrics["placebo_effects"] == []
+
+
+def test_re_registration_without_draws_does_not_erase_them(tmp_path) -> None:
+    """Fill-once. A re-registration that recomputes the draws fills the column; one
+    that does not - a metadata correction, a supersedes declaration - must not blank
+    evidence the earlier run established."""
+    case_dir = tmp_path / "test_case"
+    _register(case_dir, placebo_json=_placebo_draws_json({"placebo_effects": DRAWS}))
+
+    _register(case_dir, placebo_json=None, started_at="second")
+
+    assert _stored(case_dir) is not None
+    assert CausalResult.open(_study(case_dir), "causal_placebo").metrics["placebo_effects"] == DRAWS
+
+
+def test_a_fit_that_produced_no_draws_stores_nothing(tmp_path) -> None:
+    """`_placebo_draws_json` distinguishes 'no draws' from 'draws that were all zero'
+    only by emptiness, which is the right rule: a refutation that ran no successful
+    placebo has no distribution to show, and storing `[]` would claim it did."""
+    assert _placebo_draws_json({"placebo_effects": []}) is None
+    assert _placebo_draws_json({}) is None
+    assert _placebo_draws_json({"placebo_effects": [0.0, 0.0]}) == "[0.0, 0.0]"


### PR DESCRIPTION
Every causal notebook draws a permutation-distribution figure from `ref.get("placebo_effects", [])`. That key exists on the in-memory result of the run that fits and nowhere else: `causal_runs` stored only the scalars, the p-value and the successful draw count. So the figure rendered empty behind its guard on every read after the fitting run, while the prose beside it described the distribution it was meant to show.

The draws are the evidence for the refutation verdict rather than a diagnostic byproduct. A p-value alone cannot say whether the draws could have rejected at all, and the distribution is what shows a reader the observed effect against what noise produces.

## What changed

- `refutation_placebo_json` on `causal_runs`, added by migration.
- `_placebo_draws_json` serializes the draws, or `None` when a refutation produced none. Storing `[]` would claim a distribution that does not exist.
- Both registering callers pass it: `run_resolved_causal_request` and `register_causal_run`.
- `CausalResult.open` selects it conditionally, the way it already handles `refutation_n_successful`, so a pre-migration registry still reads rather than raising `OperationalError`. Absent, it yields `[]` rather than `None`, so a caller needs one check not two.
- The upsert fills once, like `supersedes_hash`: a re-registration that recomputes the draws fills the column; one that does not must not erase them.
- Added to `MIGRATION_BACKFILLED_COLUMNS`, since an immutable row can be missing it through no change of its own.

## Identity

Moves no causal hash and invalidates no registered row. The column is outside the identity projection.

## Tests

4 new in `tests/test_causal_placebo_draws.py`: the round trip from fit to reader, the pre-migration read, the fill-once upsert, and the no-draws case. 67 passed across the causal suite (`test_causal_result_read`, `test_causal_registry_registration`, `test_causal_refutation_pvalue`, `test_causal_supersedes`).