### PR TITLE
Read the cost-sensitivity tag before inferring a risk overlay

### DIFF
--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -435,13 +435,22 @@ def _infer_stage(
             # Registry not initialized yet — fall through to spec inference.
             pass
     strategy = spec.get("strategy", spec)
-    risk = strategy.get("risk", {})
-    if risk and risk.get("name") != "baseline":
-        return "risk_overlay"
-    # Cost sensitivity: explicit chapter tag of ch18, or caller should set explicitly
+    # The explicit tag is read before the risk block, because it states what the caller is
+    # doing while the risk block only says what the strategy contains. Once cost sensitivity
+    # runs on the winner of the risk stage - which is the order the backtest sequence now
+    # takes, risk before costs - every cost row carries an overlay, and inferring from the
+    # overlay first made `cost_sensitivity` unreachable for exactly the runs that are cost
+    # sensitivity. Measured on sp500_equity_option_analytics: a 17-point cost surface over a
+    # `trailing_5pct` carrier registered all 17 rows as `risk_overlay`.
+    #
+    # This did not bite while costs and risk were parallel branches off allocation, because a
+    # cost run then carried no overlay and fell through to the tag.
     chapter = spec.get("chapter", "")
     if chapter == "ch18":
         return "cost_sensitivity"
+    risk = strategy.get("risk", {})
+    if risk and risk.get("name") != "baseline":
+        return "risk_overlay"
     if "allocation" in strategy:
         alloc = strategy["allocation"]
         if isinstance(alloc, dict) and alloc.get("method", "equal_weight") != "equal_weight":

--- a/tests/test_backtest_presets.py
+++ b/tests/test_backtest_presets.py
@@ -249,3 +249,43 @@ def test_normalize_prediction_columns_maps_causal_and_legacy_fields() -> None:
     assert "fold_id" in normalized.columns
     assert normalized["y_score"].to_list() == [0.02]
     assert normalized["y_true"].to_list() == [0.01]
+
+
+def test_cost_sensitivity_on_a_risk_overlay_carrier_is_not_read_as_risk_overlay() -> None:
+    """A ch18 cost run keeps its stage when its carrier carries an overlay.
+
+    Cost sensitivity runs on the winner of the risk stage, so once the backtest sequence
+    puts risk before costs every cost row carries a risk block. Inferring from that block
+    before reading the explicit ``chapter`` tag made ``cost_sensitivity`` unreachable for
+    exactly the runs that are cost sensitivity: measured on sp500_equity_option_analytics, a
+    17-point cost surface over a ``trailing_5pct`` carrier registered all 17 rows as
+    ``risk_overlay``. The tag states what the caller is doing; the risk block only says what
+    the strategy contains, so the tag is read first.
+    """
+    spec = {
+        "version": 2,
+        "chapter": "ch18",
+        "strategy": {
+            "signal": {"method": "equal_weight_top_k", "top_k": 5},
+            "rebalance": {"mode": "engine", "cadence": "weekly_friday_close"},
+            "allocation": {"method": "mvo_ledoit_wolf", "top_k": 5},
+            "risk": {"name": "trailing_5pct", "position_rules": [{"type": "trailing_stop"}]},
+        },
+        "backtest_config": {"commission": {"rate": 0.0025}, "slippage": {"rate": 0.0025}},
+    }
+    assert _infer_stage(spec) == "cost_sensitivity"
+
+
+def test_risk_overlay_without_a_cost_tag_is_still_a_risk_overlay() -> None:
+    """The reorder must not swallow the risk stage: no ch18 tag, still risk_overlay."""
+    spec = {
+        "version": 2,
+        "chapter": "ch19",
+        "strategy": {
+            "signal": {"method": "equal_weight_top_k", "top_k": 5},
+            "allocation": {"method": "mvo_ledoit_wolf", "top_k": 5},
+            "risk": {"name": "trailing_5pct", "position_rules": [{"type": "trailing_stop"}]},
+        },
+        "backtest_config": {"commission": {"rate": 0.0006}, "slippage": {"rate": 0.0004}},
+    }
+    assert _infer_stage(spec) == "risk_overlay"


### PR DESCRIPTION
`_infer_stage` checked the strategy's risk block before the explicit `chapter` tag, so a run tagged `ch18` returned `risk_overlay` whenever its carrier carried an overlay. The `chapter == "ch18"` branch was unreachable for exactly the runs it exists to label.

## Why it surfaces now

It did not bite while cost sensitivity and risk management were parallel branches off allocation: a cost run then carried no overlay and fell through to the tag. It bites as soon as the backtest sequence puts risk before costs and cost sensitivity runs on the winner of the risk stage, because every cost row then carries a risk block by construction.

Measured on `sp500_equity_option_analytics`: a 17-point cost surface over a `trailing_5pct` carrier registered all 17 rows as `risk_overlay`. The cost notebook's own assertion caught it - "A planned cost hash was registered under the wrong stage" - one stage downstream of the cause. Those rows have been removed from that registry and re-register correctly once this lands.

Every case study adopting the risk-before-costs sequence hits this, not only the one it was measured on.

## The ordering is not arbitrary

The `chapter` tag states what the caller is *doing*. The risk block only says what the strategy *contains*. Explicit intent outranks structural inference, which is why the holdout check - keyed on the prediction set's own `split` - already precedes both. This moves the cost tag into the same position relative to the risk block.

## Tests

Two, in `tests/test_backtest_presets.py`, and the first fails without the change (`+ risk_overlay`):

- `test_cost_sensitivity_on_a_risk_overlay_carrier_is_not_read_as_risk_overlay` - a `ch18` spec whose carrier holds a `trailing_5pct` overlay infers `cost_sensitivity`
- `test_risk_overlay_without_a_cost_tag_is_still_a_risk_overlay` - a risk spec with no cost tag still infers `risk_overlay`, so the reorder cannot swallow the stage it moved behind

The existing `test_stage_inference_supports_v2_specs` continues to pass unchanged.

## Blast radius

No hash moves and no registered row is invalidated: `stage` is a label on `backtest_runs`, not part of the identity projection that `backtest_hash_from_parts` computes. Existing rows keep whatever stage they were written with; only newly registered cost runs are affected.
