### PR TITLE
etfs: remove the 5-symbol fixture cap that made every top_k scheme identical

### DIFF
--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1451,15 +1451,22 @@ case_studies/etfs/02_labels:
 case_studies/etfs/03_financial_features:
   timeout: 300
 case_studies/etfs/04_model_based_features:
+  # No MAX_SYMBOLS, for the reason 02_labels gives: the CI fixture is already only 24
+  # ETFs, so it IS the reduction. Cutting to 5 on top of it made every downstream
+  # backtest degenerate rather than fast. etfs declares top_k_grid [5, 10, 20] against a
+  # 24-fund price panel, so all three schemes pass the feasibility filter - but the
+  # predictions they rank covered 5 symbols, so top-5, top-10 and top-20 each held the
+  # whole cross-section, the basket never changed, and 12 of 12 backtests recorded
+  # num_trades=0. Four notebooks (14, 15, 17, 18) were blocked on that as
+  # ml4t/agent-workspace#989. The selection has to have something to reject.
   parameters:
     GARCH_MIN_OBS: 50
-    MAX_SYMBOLS: 5
     N_RESTARTS: 1
-  timeout: 300
+  timeout: 900
 case_studies/etfs/05_evaluation:
-  parameters:
-    MAX_SYMBOLS: 5
-  timeout: 300
+  # Same reason as 04 above: this stage feeds the same predictions, so reducing it
+  # re-narrows the cross-section that 04 was widened to preserve.
+  timeout: 900
 case_studies/etfs/06_linear:
   timeout: 120
 case_studies/etfs/07_gbm:


### PR DESCRIPTION
`tests/overrides.yaml` capped `case_studies/etfs/04_model_based_features` and `05_evaluation` at `MAX_SYMBOLS: 5` while the fixture price panel holds 24 symbols. Every scheme in the `top_k_grid` [5, 10, 20] therefore passed the feasibility filter and each one held the entire five-symbol prediction cross-section, so the notebook registered 12 backtests, 12 Sharpes and 0 trades - a sweep whose arms cannot differ.

Removing the cap restores the notebooks' own no-cap default (`MAX_SYMBOLS = 0`). Timeouts raised 300 -> 900 to cover the wider cross-section.

Unblocks etfs 14_backtest, 15_portfolio_management, 17_risk_management and 18_strategy_analysis (ml4t/agent-workspace#989).

Not fixed here, deliberately: `get_entry_schemes_for` (`case_studies/utils/sweep_config.py:367`) filters `k >= n_assets` against the price panel rather than the prediction cross-section. With a narrow cross-section the honest filter drops every scheme and registers nothing, which is a different failure. It wants fixing once the cross-section is wide.

Verified: 90 passed in `tests/test_pm_helpers.py`.