### PR TITLE
Two holdout-boundary fixes, and one resolver for a declared candidate-set generation

### DIFF
--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -7,7 +7,7 @@ from .causal import (
     causal_supersedes,
     supersedes_for,
 )
-from .comparison import CandidateSet
+from .comparison import CandidateSet, candidate_set_supersedes
 from .configs import (
     declared_labels,
     load_model_configs,
@@ -125,6 +125,7 @@ __all__ = [
     "planned_model_plan",
     "prediction_rows_at",
     "primary_label",
+    "candidate_set_supersedes",
     "population_supersedes",
     "research_name",
     "resolved_model_plan",

--- a/case_studies/research/comparison.py
+++ b/case_studies/research/comparison.py
@@ -28,6 +28,48 @@ def _unsuperseded_hash(db: sqlite3.Connection, name: str) -> str | None:
     return heads[0] if len(heads) == 1 else None
 
 
+def candidate_set_supersedes(study: Study, *, name: str, declared: str | None) -> str | None:
+    """Whether a declared candidate-set generation may be offered to :meth:`CandidateSet.create`.
+
+    The same decision :func:`case_studies.research.population.population_supersedes` makes for an
+    official population, applied to a candidate set. It exists because the declaration is
+    committed source that has to be right in three situations the notebook cannot tell apart:
+
+    - **A clean clone.** ``run_log/`` is gitignored, so a reader starts with an empty registry -
+      often with no ``candidate_sets`` table at all, which raises ``OperationalError`` rather
+      than ``ValueError``. ``create`` refuses a first generation that claims to supersede
+      something, so the declared hash must be withheld and the reader's run publishes generation
+      one. **This is the ordinary case for anyone who is not the author**, and offering the hash
+      unconditionally is what stops a published notebook running for the people it is published
+      for.
+    - **The re-run.** The generation in force is the one this declaration produced, so
+      ``current.supersedes == declared``, and offering the hash resolves to the set already
+      published rather than writing a new one.
+    - **The refit.** The declaration names the tip itself, and offering it publishes the next
+      generation over that tip.
+
+    Anything else is withheld, and ``create`` then refuses and names the hash it requires, which
+    is a better answer than this function guessing.
+
+    ``CandidateSet.create`` already takes and enforces ``supersedes``; what had no shared
+    implementation is this decision, so every notebook that declares a lineage either resolved it
+    itself or - four in ``crypto_perps_funding`` alone - did not resolve it and would have stopped
+    on a reader's first run.
+    """
+    if not declared:
+        return None
+    try:
+        current = CandidateSet.one(study, name=name)
+    except (ValueError, KeyError, sqlite3.OperationalError):
+        # No generation under this name, or no table at all: `one` raises `ValueError` when the
+        # name resolves to other than exactly one head, `open` raises `KeyError` for a hash the
+        # table does not hold, and a clean clone has no `candidate_sets` table for either to read.
+        return None
+    if declared in (current.supersedes, current.hash):
+        return declared
+    return None
+
+
 @dataclass(frozen=True)
 class CandidateSet:
     study: Study

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -541,6 +541,21 @@ def build_holdout_cv(
     buffer, buffer_label = widest_label_buffer(case_study, setup)
     holdout_open = _on_panel_clock(pd.Timestamp(holdout_start), panel_zone)
     holdout_close = _on_panel_clock(pd.Timestamp(holdout_end), panel_zone)
+    # `evaluation.holdout_end` is a DATE, and a date on an intraday panel means the whole of that
+    # day. Parsed, it is that date at midnight, and every window filter downstream is
+    # `timestamp <= val_end`, so the final session sorts after the boundary and is dropped from
+    # the interval the holdout is evaluated over. `utils/modeling.py::_inclusive_end_of` says the
+    # same thing with a nanosecond sentinel; this says it with an observation the panel actually
+    # holds, which is what `train_end` already is and what makes the fold readable as a pair of
+    # settlements rather than one settlement and a fencepost.
+    #
+    # A daily panel is untouched by construction: its last observation of that date IS midnight,
+    # so the widening condition is false and the rendering does not move. That matters because
+    # this value is inside the hashed fold, and `fx_pairs` and `sp500_equity_option_analytics`
+    # each hold a research lock derived from it. ml4t/agent-workspace#986.
+    within_close = [value for value in observations if value.date() <= holdout_close.date()]
+    if within_close and within_close[-1] > holdout_close:
+        holdout_close = within_close[-1]
 
     # Counted in OBSERVATIONS and stepped back along the panel's own dates, never subtracted as
     # calendar time. `utils/cv_splits.py` already carries this bug's epitaph: "21D" as a

--- a/tests/test_candidate_set_supersedes.py
+++ b/tests/test_candidate_set_supersedes.py
@@ -1,0 +1,120 @@
+"""Whether a declared candidate-set generation may be offered to `CandidateSet.create`.
+
+A notebook that has published a candidate set and then changed its membership has to name the
+generation it replaces, or `create` refuses the write. The hash it names is committed source, so
+the same declaration reaches three situations the notebook cannot tell apart, and offering it
+unconditionally is wrong in the one that matters most for a published repository - a reader's
+clean clone, where `run_log/` is gitignored and there is no generation to supersede.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.research import CandidateSet, candidate_set_supersedes
+from case_studies.research.workspace import Study
+
+
+@pytest.fixture
+def study(tmp_path: Path) -> Study:
+    case_dir = tmp_path / "cs"
+    (case_dir / "run_log").mkdir(parents=True)
+    return Study(
+        case_study="cs",
+        root=case_dir,
+        release_root=tmp_path,
+        output_root=tmp_path,
+        read_only=False,
+        entry_point="test",
+        manifest={},
+    )
+
+
+def _generations(study: Study, rows: list[tuple[str, str | None]]) -> None:
+    """Write a lineage directly, so the test states the registry rather than building one."""
+    db = sqlite3.connect(study.root / "run_log" / "registry.db")
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS candidate_sets ("
+        "set_hash TEXT PRIMARY KEY, name TEXT, member_kind TEXT, comparison_contract_json TEXT, "
+        "created_at TEXT, git_commit TEXT, supersedes_hash TEXT)"
+    )
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS candidate_set_members "
+        "(set_hash TEXT, member_hash TEXT, ordinal INTEGER)"
+    )
+    for index, (set_hash, supersedes) in enumerate(rows):
+        db.execute(
+            "INSERT INTO candidate_sets VALUES (?,?,?,?,?,?,?)",
+            (
+                set_hash,
+                "the-set",
+                "backtest",
+                '{"protocol": {}}',
+                f"2026-01-0{index + 1}",
+                "abc",
+                supersedes,
+            ),
+        )
+        db.execute("INSERT INTO candidate_set_members VALUES (?, ?, 0)", (set_hash, "member"))
+    db.commit()
+    db.close()
+
+
+def test_a_clean_clone_withholds_the_declaration(study: Study) -> None:
+    """No `candidate_sets` table at all, which is what a reader starts with.
+
+    `create` refuses a first generation that claims to supersede something, so a notebook that
+    offers its committed hash here stops on the reader's first run.
+    """
+    assert not (study.root / "run_log" / "registry.db").exists()
+
+    assert candidate_set_supersedes(study, name="the-set", declared="aaaaaaaaaaaa") is None
+
+
+def test_an_empty_lineage_withholds_the_declaration(study: Study) -> None:
+    """The table exists and holds no generation of this name."""
+    _generations(study, [])
+
+    assert candidate_set_supersedes(study, name="the-set", declared="aaaaaaaaaaaa") is None
+
+
+def test_the_re_run_offers_the_hash_its_own_generation_replaced(study: Study) -> None:
+    """The generation in force is the one this declaration produced."""
+    _generations(study, [("aaaaaaaaaaaa", None), ("bbbbbbbbbbbb", "aaaaaaaaaaaa")])
+
+    assert (
+        candidate_set_supersedes(study, name="the-set", declared="aaaaaaaaaaaa") == "aaaaaaaaaaaa"
+    )
+
+
+def test_the_refit_offers_a_hash_that_names_the_tip(study: Study) -> None:
+    """The declaration names the current head, so the next generation goes over it."""
+    _generations(study, [("aaaaaaaaaaaa", None)])
+
+    assert (
+        candidate_set_supersedes(study, name="the-set", declared="aaaaaaaaaaaa") == "aaaaaaaaaaaa"
+    )
+
+
+def test_a_hash_naming_neither_the_tip_nor_its_predecessor_is_withheld(study: Study) -> None:
+    """`create` then refuses and names the hash it wants, which beats this guessing."""
+    _generations(study, [("aaaaaaaaaaaa", None), ("bbbbbbbbbbbb", "aaaaaaaaaaaa")])
+
+    assert candidate_set_supersedes(study, name="the-set", declared="cccccccccccc") is None
+
+
+def test_no_declaration_is_no_declaration(study: Study) -> None:
+    _generations(study, [("aaaaaaaaaaaa", None)])
+
+    assert candidate_set_supersedes(study, name="the-set", declared=None) is None
+    assert candidate_set_supersedes(study, name="the-set", declared="") is None
+
+
+def test_the_resolver_is_exported_beside_create() -> None:
+    """It is the decision `CandidateSet.create`'s own `supersedes` parameter needs made."""
+    assert "supersedes" in CandidateSet.create.__code__.co_varnames
+    assert pl is not None

--- a/tests/test_holdout_cv_derivation.py
+++ b/tests/test_holdout_cv_derivation.py
@@ -800,6 +800,10 @@ def test_an_intraday_panel_derives_its_holdout_rather_than_raising_on_the_compar
     fold = _fold(cv)
 
     assert pd.Timestamp(fold["val_start"]).date() == pd.Timestamp(declared["holdout_start"]).date()
+    # The declared end is a date and the panel is 8-hourly, so the interval closes on the last
+    # settlement of that day rather than at its midnight - otherwise the two settlements after
+    # midnight are dropped from the window the holdout is evaluated over.
+    assert pd.Timestamp(fold["val_end"]) == SETTLEMENTS[-1]
     assert pd.Timestamp(fold["val_end"]).date() == pd.Timestamp(declared["holdout_end"]).date()
     # The buffer is the case study's widest - fwd_ret_24h at 24H, three settlements - and it is
     # counted along the panel, so the boundary is a settlement rather than a calendar date.
@@ -832,4 +836,18 @@ def test_a_tz_naive_panel_hashes_exactly_as_it_did_before_the_zone_was_resolved(
     }
     # The identity is what the two locks pin, so it is asserted rather than left implied by
     # the boundaries. Measured against the derivation as it stood before the zone was resolved.
+    assert cv["identity"] == "d4175e174c170bb8"
+
+
+def test_a_daily_panel_still_closes_its_holdout_on_the_declared_date() -> None:
+    """The widening is intraday-only, and the two live locks depend on that.
+
+    A daily panel's last observation of the declared end date is midnight of it, so the
+    boundary does not move and the fold renders exactly as it did.
+    """
+    cv = build_holdout_cv(
+        _validation_spec(), case_study="us_firm_characteristics", timeline=MONTH_ENDS
+    )
+
+    assert _fold(cv)["val_end"] == "2016-12-31"
     assert cv["identity"] == "d4175e174c170bb8"


### PR DESCRIPTION
Two shared-code changes split out of `crypto_perps_funding`'s backtesting work under REVIEW.md's rule. Each has tests that fail without it.

## 1. An intraday holdout closed on the midnight before its last settlements

`evaluation.holdout_end` is a date. Parsed, it is that date at midnight, and every window filter downstream is `timestamp <= val_end` - so on an intraday panel the settlements after midnight sort past the boundary and the final session is dropped from the interval the holdout is evaluated over. For `crypto_perps_funding` that is 2025-12-31 08:00 and 16:00.

`utils/modeling.py::_inclusive_end_of` already says a declared date means the whole day, using a nanosecond sentinel. This says it with an observation the panel actually holds, which is what `train_end` already is - so `append_holdout_fold_if_needed` and `build_holdout_cv` stop disagreeing about where an intraday holdout ends.

**A daily panel is untouched by construction**: its last observation of the declared date is midnight of it, so the widening condition is false. Asserted rather than argued - `us_firm_characteristics` still closes on `"2016-12-31"` with identity `d4175e174c170bb8`, which is what `fx_pairs`' and `sp500_equity_option_analytics`' research locks depend on.

Closes ml4t/agent-workspace#986, which was filed rather than fixed on the assumption that the holdout was one-shot and a live lock could not be disturbed. It is repeatable, so a result computed under a boundary that has since been corrected is deleted and recomputed rather than defended.

## 2. `CandidateSet.create` enforced a lineage nothing resolved

`create` already takes `supersedes` and refuses a changed set without it. What had no shared implementation is the decision of whether a *committed* declaration may be offered at all - and that is not the notebook's to make case by case, because the hash is source and it reaches three registries the notebook cannot tell apart.

The one that matters is **a reader's clean clone**. `run_log/` is gitignored, so a reader starts with an empty registry - often with no `candidate_sets` table at all, which raises `OperationalError` rather than `ValueError` - and `create` refuses a first generation claiming to supersede something. A notebook that offers its hash unconditionally stops on the first run of the person it was published for. Four notebooks in `crypto_perps_funding` did exactly that, which is how this was found.

The other two are the author's: the re-run, where the generation in force is the one this declaration produced; and the refit, where the declaration names the tip. Anything else is withheld so `create` refuses and names the hash it wants.

`population_supersedes` has made this decision for official populations since #380. `candidate_set_supersedes` is the same rule against `candidate_sets`, written once beside `create` rather than seven times in seven case studies.

## Verification

    tests/test_holdout_cv_derivation.py        33 passed  (3 new)
    tests/test_holdout_boundary.py             40 passed, 2 skipped
    tests/test_candidate_set_supersedes.py      7 passed  (new file)

Every new test was run against the previous implementation and fails there.