### PR TITLE
One selector for the carrier every downstream notebook runs

### DIFF
--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -434,6 +434,90 @@ def resolve_canonical_rank1_lineage(case_study: str) -> dict[str, Any]:
     }
 
 
+INSOLVENT_MAX_DRAWDOWN = -1.0
+"""Drawdown at or past which a run's equity reached zero.
+
+A long-short book with no margin call keeps compounding through zero, so every
+metric a run reports after that point is arithmetic on a balance that no longer
+exists - including a Sharpe high enough to top a ranking.
+"""
+
+
+def resolve_solvent_carrier(case_study: str, *, require_solvent: bool = True) -> dict[str, Any]:
+    """The configuration downstream notebooks run, with its spec and drawdown.
+
+    Cost sensitivity, holdout prediction and holdout backtest all have to run the
+    configuration the case study reports, and that configuration is
+    ``resolve_canonical_rank1_lineage``'s validation rank-1. Each notebook ranking
+    the registry for itself is a standing divergence class rather than a
+    hypothetical one: the canonical resolver re-ranks ``walk_forward_v2`` conformal
+    candidates on exact common timestamp support and applies LABEL_RESTRICTIONS,
+    UNIVERSE_RESTRICTIONS and CARRIER_PINS, and a plain Sharpe ranking beside it
+    does none of those. When the two disagree, the cost curve describes a strategy
+    the chapter does not report and the strategy-analysis notebook finds no cost
+    rows for the carrier it selected.
+
+    Solvency is checked here rather than inside the canonical resolver because the
+    two questions are different: the resolver decides which configuration the case
+    study is about, and this decides whether that configuration is one anything can
+    be measured on. An insolvent or unmeasured carrier raises. It deliberately does
+    not fall through to the runner-up - that would hand downstream notebooks a
+    configuration the chapter does not report, which is the divergence this
+    function exists to close. Selecting past a bankrupt rank-1 is a decision for
+    whoever owns the sweep, taken by fixing the sweep or pinning a carrier.
+
+    Returns ``resolve_canonical_rank1_lineage``'s dict with ``spec_json`` and
+    ``max_drawdown`` for the validation rank-1 added.
+    """
+    import sqlite3
+
+    from utils.paths import get_case_study_dir
+
+    lineage = resolve_canonical_rank1_lineage(case_study)
+    backtest_hash = lineage["val_backtest_hash"]
+
+    db_path = get_case_study_dir(case_study) / "run_log" / "registry.db"
+    db = sqlite3.connect(str(db_path))
+    try:
+        row = db.execute(
+            """
+            SELECT b.spec_json, bm.max_drawdown
+            FROM backtest_runs b
+            LEFT JOIN backtest_metrics bm ON bm.backtest_hash = b.backtest_hash
+            WHERE b.backtest_hash = ?
+            """,
+            (backtest_hash,),
+        ).fetchone()
+    finally:
+        db.close()
+    if row is None:
+        raise RuntimeError(
+            f"Canonical rank-1 {backtest_hash} for {case_study} is not in backtest_runs "
+            f"of {db_path}. The resolver and this lookup read the same registry, so this "
+            "means the registry changed under the process."
+        )
+    spec_json, max_drawdown = row
+
+    if require_solvent:
+        if max_drawdown is None:
+            raise RuntimeError(
+                f"Canonical rank-1 {backtest_hash} for {case_study} has no recorded "
+                "max_drawdown, so it cannot be shown to have survived. Re-run the backtest "
+                "so its metrics are registered, rather than sweeping a run whose equity path "
+                "is unknown."
+            )
+        if max_drawdown <= INSOLVENT_MAX_DRAWDOWN:
+            raise RuntimeError(
+                f"Canonical rank-1 {backtest_hash} for {case_study} reached zero equity "
+                f"(max_drawdown={max_drawdown:.4f}). Its Sharpe of {lineage['val_sharpe']:.3f} "
+                "is computed on a balance that no longer exists, so nothing measured "
+                "downstream of it means anything. Fix the sweep, or pin a carrier in "
+                "CARRIER_PINS, rather than selecting past this row silently."
+            )
+
+    return {**lineage, "spec_json": spec_json, "max_drawdown": max_drawdown}
+
+
 # ---------------------------------------------------------------------------
 # Spine CI / kill-gate helpers (tri-state contract)
 # ---------------------------------------------------------------------------

--- a/tests/test_carrier_solvency.py
+++ b/tests/test_carrier_solvency.py
@@ -1,0 +1,143 @@
+"""The carrier every downstream notebook runs, and the solvency check on it.
+
+`resolve_solvent_carrier` exists so cost sensitivity, holdout prediction and holdout
+backtest do not each rank the registry for themselves. The tests below fix the two
+things that makes it worth having: it returns what the canonical resolver returned,
+and it refuses a carrier whose equity reached zero rather than passing it on.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from case_studies.utils import strategy_analysis
+
+FIXTURE_CASE_STUDY = "fixture_case_study"
+
+
+def _registry(
+    path: Path,
+    rows: list[tuple[str, str, float, float | None]],
+) -> None:
+    """A registry the canonical resolver can select from.
+
+    Each row is ``(backtest_hash, stage, sharpe, max_drawdown)``; a ``None`` drawdown
+    is a run whose metrics row exists but records no equity path. Every table the
+    resolver joins is present and populated, so the only thing distinguishing the
+    rows is what the test sets.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(path)) as db:
+        db.executescript(
+            """
+            CREATE TABLE training_runs (
+                training_hash TEXT PRIMARY KEY, config_name TEXT, family TEXT, label TEXT
+            );
+            CREATE TABLE prediction_sets (
+                prediction_hash TEXT PRIMARY KEY, training_hash TEXT, split TEXT,
+                checkpoint_value TEXT, checkpoint_kind TEXT
+            );
+            CREATE TABLE backtest_runs (
+                backtest_hash TEXT PRIMARY KEY, prediction_hash TEXT, stage TEXT, spec_json TEXT
+            );
+            CREATE TABLE backtest_metrics (
+                backtest_hash TEXT PRIMARY KEY, sharpe REAL, max_drawdown REAL
+            );
+            CREATE TABLE fold_metrics (prediction_hash TEXT, ic REAL);
+            INSERT INTO training_runs VALUES ('train_us', 'owner_config', 'gbm', 'fwd_ret_1m');
+            INSERT INTO prediction_sets VALUES ('pred_us', 'train_us', 'validation', NULL, NULL);
+            INSERT INTO fold_metrics VALUES ('pred_us', 0.02);
+            """
+        )
+        for backtest_hash, stage, sharpe, max_drawdown in rows:
+            db.execute(
+                "INSERT INTO backtest_runs VALUES (?, 'pred_us', ?, ?)",
+                (backtest_hash, stage, '{"strategy": {"signal": {}}}'),
+            )
+            db.execute(
+                "INSERT INTO backtest_metrics VALUES (?, ?, ?)",
+                (backtest_hash, sharpe, max_drawdown),
+            )
+
+
+@pytest.fixture
+def case_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(
+        "utils.paths.get_case_study_dir", lambda case_study, **_: tmp_path / case_study
+    )
+    return tmp_path / FIXTURE_CASE_STUDY
+
+
+def test_carrier_is_the_canonical_rank1_with_its_spec_and_drawdown(case_dir: Path) -> None:
+    _registry(
+        case_dir / "run_log" / "registry.db",
+        [
+            ("signal_run", "signal", 1.10, -0.31),
+            ("alloc_run", "allocation", 2.40, -0.22),
+            ("overlay_run", "risk_overlay", 1.75, -0.18),
+        ],
+    )
+
+    carrier = strategy_analysis.resolve_solvent_carrier(FIXTURE_CASE_STUDY)
+
+    lineage = strategy_analysis.resolve_canonical_rank1_lineage(FIXTURE_CASE_STUDY)
+    assert carrier["val_backtest_hash"] == lineage["val_backtest_hash"] == "alloc_run"
+    assert carrier["val_stage"] == "allocation"
+    assert carrier["max_drawdown"] == pytest.approx(-0.22)
+    assert carrier["spec_json"] == '{"strategy": {"signal": {}}}'
+
+
+def test_a_bankrupt_rank1_raises_rather_than_being_swept(case_dir: Path) -> None:
+    """The highest Sharpe here belongs to a run whose equity reached zero.
+
+    Nothing downstream of it means anything, and quietly selecting the solvent run
+    behind it would hand the cost sweep a configuration the chapter does not report -
+    the divergence this resolver exists to close. So it refuses, and names the row.
+    """
+    _registry(
+        case_dir / "run_log" / "registry.db",
+        [
+            ("ruined_run", "allocation", 9.90, -1.42),
+            ("solvent_run", "signal", 1.10, -0.31),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="ruined_run.*reached zero equity"):
+        strategy_analysis.resolve_solvent_carrier(FIXTURE_CASE_STUDY)
+
+    # The check is what refuses, not the resolution: the same rank-1 comes back when
+    # solvency is not asserted, so a caller that opts out gets no silent substitution.
+    assert (
+        strategy_analysis.resolve_solvent_carrier(FIXTURE_CASE_STUDY, require_solvent=False)[
+            "val_backtest_hash"
+        ]
+        == "ruined_run"
+    )
+
+
+def test_exactly_minus_one_is_ruin_and_just_above_it_is_not(case_dir: Path) -> None:
+    """-1.0 is zero equity, not the last solvent point. The boundary is `<=`."""
+    _registry(case_dir / "run_log" / "registry.db", [("edge_run", "allocation", 2.0, -1.0)])
+    with pytest.raises(RuntimeError, match="reached zero equity"):
+        strategy_analysis.resolve_solvent_carrier(FIXTURE_CASE_STUDY)
+
+    other = case_dir.parent / "second_fixture"
+    _registry(other / "run_log" / "registry.db", [("edge_run", "allocation", 2.0, -0.9999)])
+    assert (
+        strategy_analysis.resolve_solvent_carrier("second_fixture")["val_backtest_hash"]
+        == "edge_run"
+    )
+
+
+def test_an_unmeasured_drawdown_is_refused_rather_than_read_as_solvent(case_dir: Path) -> None:
+    """A NULL drawdown is a run that cannot be shown to have survived.
+
+    `max_drawdown IS NULL` compares False against any threshold, so a solvency test
+    written as an inequality alone lets it through as if it had been measured.
+    """
+    _registry(case_dir / "run_log" / "registry.db", [("unmeasured_run", "allocation", 2.0, None)])
+    with pytest.raises(RuntimeError, match="no recorded max_drawdown"):
+        strategy_analysis.resolve_solvent_carrier(FIXTURE_CASE_STUDY)


### PR DESCRIPTION
Cost sensitivity, holdout prediction and holdout backtest each have to run the configuration the case study reports. Today each ranks the registry for itself, and a plain Sharpe ranking is not what `resolve_canonical_rank1_lineage` does - the canonical resolver re-ranks `walk_forward_v2` conformal candidates on exact common timestamp support and applies `LABEL_RESTRICTIONS`, `UNIVERSE_RESTRICTIONS` and `CARRIER_PINS`, none of which live in the copies. `etfs/16_costs.py` ranks `stage="allocation"` alone, which cannot reach an un-overlaid or baseline carrier at all.

`resolve_solvent_carrier` resolves through the canonical resolver and adds the `spec_json` and `max_drawdown` a caller needs, so the copies can go.

It also asserts what the canonical resolver does not: that the carrier survived. The resolver ranks on Sharpe, and a long-short book with no margin call compounds through zero, so a run whose equity reached zero can carry the highest Sharpe in the registry. That carrier raises rather than being swept, and deliberately does not fall through to the runner-up - substituting a different configuration silently is the divergence this closes. A NULL drawdown raises too: it compares False against any threshold, so an inequality alone reads "never measured" as "survived".

Shared code only, per REVIEW.md. The first caller is `us_firm_characteristics/14_costs`, landing on `cs6/us_firm_characteristics`; the other six cost notebooks pick it up by import as their lanes reach them.

Tests: `tests/test_carrier_solvency.py`, four cases. Mutation-checked - reverting the `<=` boundary or the NULL guard turns two of them red.