### PR TITLE
Let a holdout training spec be built without taking a lock

### DIFF
--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -628,6 +628,42 @@ def build_holdout_cv(
     }
 
 
+def build_holdout_training_spec(
+    study: Any,
+    validation_spec: Mapping[str, Any],
+    *,
+    timeline: Sequence[Any],
+    case_study: str | None = None,
+) -> dict[str, Any]:
+    """Re-key one validation training specification onto the derived holdout fold.
+
+    Three steps have to happen together and in this order, and each of them already refuses
+    on its own terms: derive the holdout interval from the case study's declared window,
+    bound its training start at whatever the family's features actually reach, and recompute
+    the fields the resolver derived per validation fold. Doing two of the three produces a
+    specification that looks complete and fits the wrong estimator - a manifest describing
+    the validation folds, or a training window half of which has no features - so they are
+    one call rather than three a caller assembles.
+
+    This takes a ``study`` and a specification, not a lock. A holdout fit is a computation,
+    and the question of how many times a case study may run one is a separate question about
+    its lifecycle: :func:`evaluate_holdout` is the answer for a case study that wants the
+    holdout spent once and calls this to build what it locks, and a case study whose holdout
+    notebooks re-run like any other stage calls this directly.
+
+    Returns a new specification; ``validation_spec`` is not modified.
+    """
+    holdout_spec = deepcopy(dict(validation_spec))
+    holdout_spec["computation"]["cv"] = build_holdout_cv(
+        validation_spec,
+        case_study=str(case_study if case_study is not None else study.case_study),
+        timeline=timeline,
+        train_start_floor=_holdout_training_floor(study, validation_spec),
+    )
+    _rekey_holdout_spec(study, holdout_spec, dict(validation_spec))
+    return holdout_spec
+
+
 @dataclass(frozen=True)
 class HoldoutOutcome:
     """One case study's holdout evaluation, and whether this call is what produced it."""
@@ -689,14 +725,12 @@ def evaluate_holdout(
     training = study.results.open(prediction.registry_record()["training_hash"])
 
     validation_spec = training.spec()
-    holdout_spec = deepcopy(validation_spec)
-    holdout_spec["computation"]["cv"] = build_holdout_cv(
+    holdout_spec = build_holdout_training_spec(
+        study,
         validation_spec,
-        case_study=str(case_study if case_study is not None else study.case_study),
         timeline=timeline,
-        train_start_floor=_holdout_training_floor(study, validation_spec),
+        case_study=case_study,
     )
-    _rekey_holdout_spec(study, holdout_spec, validation_spec)
 
     # selection_evidence is hashed into the lock identity, so anything put here that is already
     # recorded elsewhere gives one fact two sources and makes the lock unreproducible by any

--- a/tests/test_holdout_training_spec.py
+++ b/tests/test_holdout_training_spec.py
@@ -1,0 +1,163 @@
+"""What a validation training specification must have done to it before it can fit a holdout.
+
+Three things have to happen, and each is a separate refusal somewhere else in the codebase:
+derive the holdout interval, bound its training start at whatever the family's features
+actually reach, and recompute the fields the resolver derived per validation fold. A
+specification carrying two of the three is not obviously broken - it has a holdout CV and a
+manifest, and it fits - which is why ``build_holdout_training_spec`` exists as one call and why
+these tests check that all three happened rather than that the function returned something.
+
+The case study is a real one, so the declared holdout window is a declared one. The family is a
+stand-in installed at the dispatch point, because what is under test is whether this composes
+the family's answers, not what any particular family answers.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from case_studies.research.holdout import build_holdout_training_spec
+from tests.test_holdout_cv_derivation import MONTH_ENDS, _validation_spec
+
+CASE_STUDY = "us_firm_characteristics"
+
+
+def _install_family(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    floor: Any,
+    rekey: Any,
+) -> list[dict[str, Any]]:
+    """Install a stand-in family at the hook dispatch point, and record what it was asked.
+
+    ``_holdout_training_floor`` and ``_rekey_holdout_spec`` both resolve the family through
+    ``case_studies.research.models._family_module`` at call time, so replacing that replaces
+    both hooks at once and leaves the composition under test untouched.
+    """
+    seen: list[dict[str, Any]] = []
+
+    def holdout_training_floor(study, *, validation_spec):
+        seen.append({"hook": "floor", "spec": deepcopy(validation_spec)})
+        return floor
+
+    def rekey_holdout_spec(study, spec, *, validation_spec):
+        seen.append({"hook": "rekey", "spec": deepcopy(spec)})
+        rekey(spec)
+
+    monkeypatch.setattr(
+        "case_studies.research.models._family_module",
+        lambda family: SimpleNamespace(
+            holdout_training_floor=holdout_training_floor,
+            rekey_holdout_spec=rekey_holdout_spec,
+        ),
+    )
+    return seen
+
+
+def _rekey_to_one_fold(spec: dict[str, Any]) -> None:
+    """The minimum a family hook must do for ``_require_holdout_keyed_fields`` to accept it."""
+    spec["computation"]["expected_prediction_keys"] = {
+        "digest": "re-keyed-to-the-holdout-fold",
+        "n_rows": 11,
+        "n_folds": 1,
+    }
+
+
+def _build(monkeypatch: pytest.MonkeyPatch, *, floor: Any = None) -> tuple[dict, dict, list]:
+    validation_spec = _validation_spec()
+    validation_spec["computation"]["expected_prediction_keys"] = {
+        "digest": "describes-the-validation-folds",
+        "n_rows": 33,
+        "n_folds": 3,
+    }
+    seen = _install_family(monkeypatch, floor=floor, rekey=_rekey_to_one_fold)
+    holdout_spec = build_holdout_training_spec(
+        SimpleNamespace(case_study=CASE_STUDY),
+        validation_spec,
+        timeline=MONTH_ENDS,
+        case_study=CASE_STUDY,
+    )
+    return validation_spec, holdout_spec, seen
+
+
+def test_the_families_training_floor_reaches_the_derived_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The floor is the whole reason the hook exists, and it is invisible in the result shape.
+
+    A composition that derived the interval and then forgot to pass the floor returns a spec
+    that looks complete: one fold, correct window, re-keyed manifest. What it describes is a
+    fit over a training window the family has no features for - on
+    sp500_equity_option_analytics, 482 of 977 dates on null columns. So the assertion is on the
+    boundary the floor moved, not on the call having been made.
+    """
+    _, unclamped, _ = _build(monkeypatch)
+    _, clamped, _ = _build(monkeypatch, floor="2010-06-30")
+
+    assert unclamped["computation"]["cv"]["folds"][0]["train_start"].startswith("2003-05-30")
+    assert clamped["computation"]["cv"]["folds"][0]["train_start"].startswith("2010-06-30")
+    assert clamped["computation"]["cv"]["request"]["train_start_floor"].startswith("2010-06-30")
+
+
+def test_the_family_is_asked_to_re_key_and_the_result_carries_its_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Carrying the validation manifest forward is the failure this rules out.
+
+    It is the one that survives execution: the fit runs, the predictions publish, and the
+    eligibility manifest describes three folds that are not the fold that was fitted.
+    """
+    validation_spec, holdout_spec, seen = _build(monkeypatch)
+
+    assert [entry["hook"] for entry in seen] == ["floor", "rekey"]
+    assert holdout_spec["computation"]["expected_prediction_keys"]["n_folds"] == 1
+    assert (
+        holdout_spec["computation"]["expected_prediction_keys"]["digest"]
+        != validation_spec["computation"]["expected_prediction_keys"]["digest"]
+    )
+
+
+def test_the_hook_is_handed_the_holdout_cv_and_not_the_validation_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The family re-keys against the fold it is given, so the order of the two steps is load-bearing."""
+    _, _, seen = _build(monkeypatch)
+
+    handed = next(entry for entry in seen if entry["hook"] == "rekey")["spec"]
+    assert handed["computation"]["cv"]["split"] == "holdout"
+    assert len(handed["computation"]["cv"]["folds"]) == 1
+
+
+def test_the_validation_specification_is_not_modified(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The caller still needs it: ``evaluate_holdout`` compares the two, and a notebook prints both."""
+    validation_spec, holdout_spec, _ = _build(monkeypatch)
+
+    assert validation_spec["computation"]["cv"]["identity"] == "validation-cv-identity"
+    assert len(validation_spec["computation"]["cv"]["folds"]) == 3
+    assert validation_spec["computation"]["expected_prediction_keys"]["n_folds"] == 3
+    assert holdout_spec is not validation_spec
+
+
+def test_a_family_that_cannot_re_key_refuses_rather_than_returning_a_validation_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook that returns without recomputing leaves fields that look present and are wrong."""
+    validation_spec = _validation_spec()
+    validation_spec["computation"]["expected_prediction_keys"] = {
+        "digest": "describes-the-validation-folds",
+        "n_rows": 33,
+        "n_folds": 3,
+    }
+    _install_family(monkeypatch, floor=None, rekey=lambda spec: None)
+
+    with pytest.raises(ValueError, match="was not re-keyed to one fold"):
+        build_holdout_training_spec(
+            SimpleNamespace(case_study=CASE_STUDY),
+            validation_spec,
+            timeline=MONTH_ENDS,
+            case_study=CASE_STUDY,
+        )


### PR DESCRIPTION
Three steps turn a validation training specification into one that fits the holdout: derive the interval from the case study's declared window, bound its training start at whatever the family's features actually reach, and recompute the fields the resolver derived per validation fold. They only existed inside `evaluate_holdout`, wired to a lifecycle lock, so a case study whose holdout notebooks re-run like any other stage had no way to reach them.

`build_holdout_training_spec` is those three steps and nothing else. `evaluate_holdout` now calls it, so the locked path and the lock-free one derive the same specification by construction rather than by two callers agreeing.

Doing two of the three produces a spec that looks complete and fits the wrong estimator - a manifest describing the validation folds, or a training window the family has no features for. On `sp500_equity_option_analytics` the second one is not hypothetical: the holdout lock taken on 2026-08-27 recorded `train_start 2017-01-05` with no floor, while the stage-04 artifact's holdout fold begins 2019-01-02, so that fit covered 495 of 977 training dates.

Tests assert on the boundary the floor moved and on the manifest the hook rewrote, not on the calls having been made. Three mutations verified: dropping the floor, dropping the re-key, and mutating the caller's spec in place each fail at least one test.

No behaviour change to `evaluate_holdout` - the 131 tests across the six holdout suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)