### PR TITLE
The GBM family could not re-key a training spec to the holdout fold

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -39,6 +39,9 @@
 # test file is gated the moment it is added, which is what this file inverting
 # the default is for.
 #
+# `test_gbm_holdout_rekey` was added on 2026-08-30 with the GBM holdout re-keying
+# hook. It imports `case_studies/utils/gbm.py`, which is the boundary itself.
+#
 # `test_holdout_expected_keys` loads `20_strategy_synthesis/holdout.py`, whose
 # module scope reaches lightgbm and torch through the family training paths it
 # dispatches to. It tests two pure functions and needs none of that, but the
@@ -54,6 +57,7 @@ tests/test_deep_model_state.py
 tests/test_dl_device_contract.py
 tests/test_dl_force_retrain_identity.py
 tests/test_gbm_classification_target.py
+tests/test_gbm_holdout_rekey.py
 tests/test_gbm_identity.py
 tests/test_gbm_runtime.py
 tests/test_holdout_expected_keys.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -958,6 +958,7 @@ jobs:
             tests/test_dl_device_contract.py \
             tests/test_dl_force_retrain_identity.py \
             tests/test_gbm_classification_target.py \
+            tests/test_gbm_holdout_rekey.py \
             tests/test_gbm_identity.py \
             tests/test_gbm_runtime.py \
             tests/test_insight_chapter.py \

--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -1925,6 +1925,132 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
     )
 
 
+def _gbm_fold_invariant_params(
+    recorded: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], bool]:
+    """The parameters every recorded fold agreed on, and whether the Huber delta varied.
+
+    Almost every LightGBM parameter comes from the preset and is the same on every fold.
+    The one exception is ``alpha`` under a ``huber`` objective without a declared alpha:
+    :func:`_scaled_huber_alpha` resolves it from the fold's own training labels, so it is a
+    different number on every fold and cannot be carried across one.
+
+    Anything else differing between folds means the recorded parameters were not produced by
+    the rule this understands, and re-keying them would invent a configuration nobody ran. So
+    it refuses and names the parameters, rather than picking one fold's values.
+    """
+    if not isinstance(recorded, dict) or not recorded:
+        raise ValueError("GBM training spec records no effective parameters to re-key")
+    witness = dict(recorded[sorted(recorded)[0]])
+    divergent = {
+        name
+        for fold_params in recorded.values()
+        for name in set(witness) | set(fold_params)
+        if witness.get(name) != fold_params.get(name)
+    }
+    unexpected = divergent - {"alpha"}
+    if unexpected:
+        raise ValueError(
+            f"GBM parameters differ across the recorded folds in {sorted(unexpected)}. Only the "
+            "Huber delta is derived per fold, so there is no rule here that reproduces these on "
+            "the holdout fold, and carrying one fold's values forward would evaluate a "
+            "configuration that was never ranked."
+        )
+    return witness, "alpha" in divergent
+
+
+def rekey_holdout_spec(
+    study: Study,
+    spec: dict[str, Any],
+    *,
+    validation_spec: dict[str, Any],
+) -> None:
+    """Recompute the fold-derived fields against the holdout fold, in place.
+
+    ``spec`` arrives with its CV already replaced by the single derived holdout fold, and with
+    ``expected_prediction_keys`` and ``effective_params_by_fold`` still describing the
+    VALIDATION folds. :func:`reconstruct_locked_request` checks both against the holdout fold
+    before it will build a request, so carrying them forward produces a spec that fails at
+    execution. They have to be recomputed.
+
+    The eligibility manifest is recomputed from the dataset over the holdout window, by the
+    same call the validation request used.
+
+    The parameters are re-keyed rather than re-derived from the preset, which is the same
+    choice :func:`reconstruct_locked_request` makes and for the same reason: a request can
+    carry overrides the spec does not record separately, so a preset reloaded by name is not
+    guaranteed to be the configuration that ran. What the spec does record is every fold's
+    resolved parameters, and those are enough - see :func:`_gbm_fold_invariant_params` for
+    what varies across folds and what refuses.
+    """
+    from case_studies.research.models import locked_holdout_split
+    from utils.modeling import load_modeling_dataset
+
+    computation = spec["computation"]
+    label_ref = study.labels.get(spec["label"], execution_tier=ExecutionTier.CANONICAL)
+    mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=0)
+    if mds.date_col != "timestamp" or not mds.entity_cols:
+        raise ValueError("GBM holdout re-keying requires timestamp and an entity key")
+
+    split = locked_holdout_split(spec, mds.dataset, mds.date_col, study.case_study)
+    expected = _gbm_expected_keys_from_dataset(mds, [split])
+    computation["expected_prediction_keys"] = {
+        "digest": value_digest(expected, ("symbol", "timestamp", "fold")),
+        "n_rows": expected.height,
+        "n_folds": expected.get_column("fold").n_unique(),
+    }
+
+    model = computation.get("model")
+    if not isinstance(model, dict) or "effective_params_by_fold" not in model:
+        return
+    recorded = model["effective_params_by_fold"]
+    if isinstance(recorded, dict):
+        declared = {
+            str(int(fold["fold"]))
+            for fold in validation_spec["computation"]["cv"]["folds"]
+            if isinstance(fold, dict)
+        }
+        stray = set(recorded) - declared
+        if stray:
+            raise ValueError(
+                f"GBM spec records parameters for folds {sorted(stray)}, which the validation CV "
+                "does not declare. These are not the validation folds this re-keys from."
+            )
+    params, alpha_is_fold_derived = _gbm_fold_invariant_params(recorded)
+
+    if alpha_is_fold_derived:
+        scale = model.get("huber_alpha_scale")
+        if params.get("objective") != "huber" or scale is None:
+            raise ValueError(
+                "GBM alpha varies across the recorded folds but the spec declares no "
+                "huber_alpha_scale to re-derive it from, so the holdout delta cannot be "
+                "computed by the rule that produced the validation ones"
+            )
+        entity_col = mds.entity_cols[0]
+        folds = prepare_gbm_folds(
+            mds.dataset.to_pandas(),
+            [split],
+            mds.feature_names,
+            mds.label_col,
+            mds.date_col,
+            entity_col,
+            task_type=mds.task_type,
+            class_values=mds.class_values,
+            temporal_by_fold=mds.temporal_by_fold,
+            temporal_keys=mds.temporal_keys,
+            temporal_feature_names=mds.temporal_feature_names,
+            train_sample_frac=1.0,
+            eval_label_col=mds.eval_label_col,
+            seed=RANDOM_SEED,
+        )
+        if len(folds) != 1 or not folds[0]["n_train"]:
+            raise ValueError("GBM holdout fold could not be prepared to re-derive the Huber delta")
+        params["alpha"] = _scaled_huber_alpha(float(scale), folds[0]["y_train"])
+
+    _validate_lightgbm_params(params)
+    model["effective_params_by_fold"] = {str(int(split["fold"])): params}
+
+
 def reconstruct_locked_request(
     study: Study,
     spec: dict[str, Any],

--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -2026,26 +2026,16 @@ def rekey_holdout_spec(
                 "huber_alpha_scale to re-derive it from, so the holdout delta cannot be "
                 "computed by the rule that produced the validation ones"
             )
-        entity_col = mds.entity_cols[0]
-        folds = prepare_gbm_folds(
-            mds.dataset.to_pandas(),
-            [split],
-            mds.feature_names,
-            mds.label_col,
-            mds.date_col,
-            entity_col,
-            task_type=mds.task_type,
-            class_values=mds.class_values,
-            temporal_by_fold=mds.temporal_by_fold,
-            temporal_keys=mds.temporal_keys,
-            temporal_feature_names=mds.temporal_feature_names,
-            train_sample_frac=1.0,
-            eval_label_col=mds.eval_label_col,
-            seed=RANDOM_SEED,
-        )
-        if len(folds) != 1 or not folds[0]["n_train"]:
-            raise ValueError("GBM holdout fold could not be prepared to re-derive the Huber delta")
-        params["alpha"] = _scaled_huber_alpha(float(scale), folds[0]["y_train"])
+        # The same selection the request planner derives its own thresholds from
+        # (`_gbm_sampled_training_labels`), and for the reason recorded there: reading the
+        # labels through fold preparation casts them to LightGBM's float32, which quantizes
+        # to a different delta than the float64 labels validation resolved its alpha from,
+        # and one declared configuration would then carry two identities. It also reads the
+        # labels without materializing the fold's feature matrix.
+        labels = training_labels_for_split(mds, split, train_sample_frac=1.0, seed=RANDOM_SEED)
+        if not len(labels):
+            raise ValueError("GBM holdout fold has no training labels to re-derive the Huber delta")
+        params["alpha"] = _scaled_huber_alpha(float(scale), labels)
 
     _validate_lightgbm_params(params)
     model["effective_params_by_fold"] = {str(int(split["fold"])): params}

--- a/tests/test_gbm_holdout_rekey.py
+++ b/tests/test_gbm_holdout_rekey.py
@@ -177,3 +177,73 @@ def test_parameters_keyed_to_folds_the_validation_cv_never_declared_are_refused(
     spec = _spec({"7": dict(BASE_PARAMS)})
     with pytest.raises(ValueError, match=r"records parameters for folds \['7'\]"):
         gbm.rekey_holdout_spec(study, spec, validation_spec=_validation_spec())
+
+
+def test_the_huber_delta_is_rederived_from_the_holdout_folds_own_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`alpha` is a scaled standard deviation of the training labels, so it moves per fold.
+
+    It is read through `training_labels_for_split`, the same selection the request planner
+    derives its own thresholds from. Reading the labels through fold preparation instead
+    would cast them to LightGBM's float32, and the delta is quantized to twelve significant
+    digits - far past where float32 stops carrying information - so the two paths resolve
+    different alphas from identical labels and give one declared configuration two
+    training identities. The labels below are the case: their float32 standard deviation
+    quantizes to something else entirely.
+    """
+    import numpy as np
+
+    from case_studies.utils.derived_params import quantize_derived
+
+    timestamps = pl.datetime_range(
+        pl.datetime(2005, 1, 31), pl.datetime(2016, 12, 30), interval="1mo", eager=True
+    )
+    rng = np.random.default_rng(0)
+    values = rng.normal(0.0, 0.03, size=2 * len(timestamps))
+    dataset = pl.DataFrame(
+        {
+            "timestamp": [t for t in timestamps for _ in ("A", "B")],
+            "symbol": ["A", "B"] * len(timestamps),
+            "feature": [0.1] * (2 * len(timestamps)),
+            "fwd_ret_1m": values,
+        }
+    )
+    mds = SimpleNamespace(
+        dataset=dataset,
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        label_col="fwd_ret_1m",
+        feature_names=["feature"],
+        task_type="regression",
+        class_values=[],
+        eval_label_col=None,
+        temporal_by_fold=None,
+        temporal_keys=None,
+        temporal_feature_names=None,
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *a, **k: mds)
+    monkeypatch.setattr(
+        "case_studies.utils.cv_window.canonical_window",
+        lambda *a, **k: (date(2016, 1, 29), date(2016, 12, 30)),
+    )
+    study = SimpleNamespace(
+        case_study="fixture_case_study",
+        labels=SimpleNamespace(get=lambda name, **_: SimpleNamespace(name=name)),
+    )
+
+    huber = {**BASE_PARAMS, "objective": "huber"}
+    spec = _spec(
+        {"0": {**huber, "alpha": 0.031}, "1": {**huber, "alpha": 0.029}},
+        huber_alpha_scale=1.0,
+    )
+    gbm.rekey_holdout_spec(study, spec, validation_spec=_validation_spec())
+
+    train = dataset.filter(pl.col("timestamp") <= pl.datetime(2015, 12, 31))
+    expected = quantize_derived(float(np.nanstd(train["fwd_ret_1m"].to_numpy())))
+    resolved = spec["computation"]["model"]["effective_params_by_fold"]["2"]["alpha"]
+    assert resolved == expected
+    float32_delta = quantize_derived(
+        float(np.nanstd(train["fwd_ret_1m"].to_numpy().astype(np.float32)))
+    )
+    assert resolved != float32_delta, "the two paths must be distinguishable here"

--- a/tests/test_gbm_holdout_rekey.py
+++ b/tests/test_gbm_holdout_rekey.py
@@ -1,0 +1,179 @@
+"""Re-keying a GBM training spec from the validation folds to the derived holdout fold.
+
+Without this the GBM family cannot produce a holdout prediction at all: the spec that
+selection ranked carries an eligibility manifest and a parameter set describing the
+validation folds, and `reconstruct_locked_request` checks both against the holdout fold
+before it will build a request.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+
+import polars as pl
+import pytest
+
+from case_studies.utils import gbm
+
+VALIDATION_CV = {
+    "folds": [
+        {
+            "fold": "0",
+            "train_start": "2005-01-31T00:00:00",
+            "train_end": "2014-12-31T00:00:00",
+            "val_start": "2015-01-30T00:00:00",
+            "val_end": "2015-12-31T00:00:00",
+        },
+        {
+            "fold": "1",
+            "train_start": "2005-01-31T00:00:00",
+            "train_end": "2013-12-31T00:00:00",
+            "val_start": "2014-01-31T00:00:00",
+            "val_end": "2014-12-31T00:00:00",
+        },
+    ],
+    "identity": "validation_identity",
+    "request": {"source": "case_study_default"},
+}
+
+HOLDOUT_CV = {
+    "folds": [
+        {
+            "fold": "2",
+            "train_start": "2005-01-31T00:00:00",
+            "train_end": "2015-12-31T00:00:00",
+            "val_start": "2016-01-29T00:00:00",
+            "val_end": "2016-12-30T00:00:00",
+        }
+    ],
+    "identity": "holdout_identity",
+    "split": "holdout",
+    "request": {"source": "case_study_holdout"},
+}
+
+BASE_PARAMS = {
+    "objective": "regression",
+    "num_leaves": 63,
+    "learning_rate": 0.05,
+    "verbosity": -1,
+    "metric": "None",
+}
+
+
+def _dataset() -> pl.DataFrame:
+    timestamps = pl.datetime_range(
+        pl.datetime(2005, 1, 31),
+        pl.datetime(2016, 12, 30),
+        interval="1mo",
+        eager=True,
+    )
+    return pl.DataFrame(
+        {
+            "timestamp": [t for t in timestamps for _ in ("A", "B")],
+            "symbol": ["A", "B"] * len(timestamps),
+            "feature": [0.1] * (2 * len(timestamps)),
+            "fwd_ret_1m": [0.01, -0.01] * len(timestamps),
+        }
+    )
+
+
+@pytest.fixture
+def study(monkeypatch: pytest.MonkeyPatch) -> Any:
+    dataset = _dataset()
+    mds = SimpleNamespace(
+        dataset=dataset,
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        label_col="fwd_ret_1m",
+        feature_names=["feature"],
+        task_type="regression",
+        class_values=[],
+        eval_label_col=None,
+        temporal_by_fold=None,
+        temporal_keys=None,
+        temporal_feature_names=None,
+    )
+    monkeypatch.setattr("utils.modeling.load_modeling_dataset", lambda *a, **k: mds)
+    # The canonical window is what binds `locked_holdout_split`; the fixture case study has
+    # no setup.yaml, so it is declared here rather than left to fail before re-keying runs.
+    monkeypatch.setattr(
+        "case_studies.utils.cv_window.canonical_window",
+        lambda *a, **k: (date(2016, 1, 29), date(2016, 12, 30)),
+    )
+    return SimpleNamespace(
+        case_study="fixture_case_study",
+        labels=SimpleNamespace(get=lambda name, **_: SimpleNamespace(name=name)),
+    )
+
+
+def _spec(params_by_fold: dict[str, dict[str, Any]], **model_extra: Any) -> dict[str, Any]:
+    return {
+        "label": "fwd_ret_1m",
+        "computation": {
+            "cv": HOLDOUT_CV,
+            "expected_prediction_keys": {
+                "digest": "the_validation_digest",
+                "n_rows": 48,
+                "n_folds": 2,
+            },
+            "model": {
+                "class": "lightgbm.Booster",
+                "implementation": "lightgbm",
+                "effective_params_by_fold": params_by_fold,
+                "huber_alpha_scale": None,
+                "max_iterations": 500,
+                **model_extra,
+            },
+        },
+    }
+
+
+def _validation_spec() -> dict[str, Any]:
+    return {"computation": {"cv": VALIDATION_CV}}
+
+
+def test_manifest_and_parameters_are_rekeyed_to_the_holdout_fold(study: Any) -> None:
+    spec = _spec({"0": dict(BASE_PARAMS), "1": dict(BASE_PARAMS)})
+    gbm.rekey_holdout_spec(study, spec, validation_spec=_validation_spec())
+
+    computation = spec["computation"]
+    manifest = computation["expected_prediction_keys"]
+    assert manifest["n_folds"] == 1
+    assert manifest["digest"] != "the_validation_digest"
+    # The holdout window closes 2016-12-30, so the December month-end falls outside it:
+    # eleven of the twelve 2016 dates, two symbols.
+    assert manifest["n_rows"] == 22
+    assert computation["model"]["effective_params_by_fold"] == {"2": BASE_PARAMS}
+
+
+def test_parameters_that_vary_for_no_known_reason_are_refused(study: Any) -> None:
+    """Carrying one fold's values forward would evaluate a configuration nobody ranked."""
+    spec = _spec({"0": dict(BASE_PARAMS), "1": {**BASE_PARAMS, "num_leaves": 31}})
+    with pytest.raises(ValueError, match=r"differ across the recorded folds in \['num_leaves'\]"):
+        gbm.rekey_holdout_spec(study, spec, validation_spec=_validation_spec())
+
+
+def test_a_varying_huber_delta_needs_the_scale_that_derives_it(study: Any) -> None:
+    """`alpha` is the one parameter resolved per fold, and only from a declared scale.
+
+    Without the scale there is no rule that produces the holdout fold's delta, so the spec
+    cannot be re-keyed at all - and silently reusing a validation fold's delta would size the
+    Huber transition against the wrong training labels.
+    """
+    varying = {
+        "0": {**BASE_PARAMS, "objective": "huber", "alpha": 0.031},
+        "1": {**BASE_PARAMS, "objective": "huber", "alpha": 0.029},
+    }
+    with pytest.raises(ValueError, match="no huber_alpha_scale"):
+        gbm.rekey_holdout_spec(study, _spec(varying), validation_spec=_validation_spec())
+
+
+def test_parameters_keyed_to_folds_the_validation_cv_never_declared_are_refused(
+    study: Any,
+) -> None:
+    """A spec already re-keyed once must not be re-keyed again from its own output."""
+    spec = _spec({"7": dict(BASE_PARAMS)})
+    with pytest.raises(ValueError, match=r"records parameters for folds \['7'\]"):
+        gbm.rekey_holdout_spec(study, spec, validation_spec=_validation_spec())


### PR DESCRIPTION
`_rekey_holdout_spec` dispatches to the family, and gbm had no hook, so every gbm-carried case study refused before it could produce a holdout prediction at all - `us_firm_characteristics` among them, whose carrier is `leaves_63_mse`. Only `linear` and `latent_factors` implemented it.

A validation spec reaches the holdout carrying two fold-derived fields that still describe the validation folds: the eligibility manifest, and one parameter set per fold. `reconstruct_locked_request` checks both against the holdout fold before it will build a request, so they have to be recomputed.

The manifest is recomputed from the dataset over the holdout window, by the same call the validation request used.

The parameters are re-keyed rather than re-derived from the preset - the choice `reconstruct_locked_request` already makes deliberately, since a request can carry overrides the spec does not record separately. LightGBM parameters are fold-invariant with one exception: `alpha` under a `huber` objective without a declared alpha is resolved from the fold's own training labels, so it is re-derived from the holdout fold's labels through `training_labels_for_split` - the same selection the request planner uses, and for the reason recorded at `_gbm_sampled_training_labels`: reading the labels through fold preparation casts them to float32, and a delta quantized to twelve significant digits then differs, giving one declared configuration two training identities. Anything else differing between folds is refused with the parameters named.

Verified against the real registry: deriving the holdout CV for `us_firm_characteristics`' carrier and re-keying it reconstructs a canonical request with training identity `9a36f2daabb3`, distinct from the validation `a90f3c75fc76` it was derived from. That distinctness is the point - the case study's registered holdout prediction was generated from the validation-fitted training hash.

Tests: `tests/test_gbm_holdout_rekey.py`, five cases. Mutation-checked, including one whose labels distinguish the float32 path (0.0303788501769 against 0.0303788507461).