### PR TITLE
Conformal widths could not be computed on a panel keyed by integer identifiers

### DIFF
--- a/case_studies/utils/conformal.py
+++ b/case_studies/utils/conformal.py
@@ -396,9 +396,16 @@ def compute_conformal_widths(
     grid = preds.select("timestamp").unique().sort("timestamp").with_row_index("step")
     preds = preds.join(grid, on="timestamp", how="inner")
 
+    # The entity literal carries the source column's dtype rather than whatever polars infers
+    # from the Python value. `join_asof` compares its `by` columns by dtype and raises on a
+    # mismatch, and a panel keyed on integer identifiers - permnos on us_firm_characteristics -
+    # infers Int32 from an unannotated literal against a UInt32 column.
+    entity_dtype = preds.schema[id_col]
     per_entity = pl.concat(
         [
-            _expanding_calibration(group, alpha=alpha).with_columns(pl.lit(entity).alias(id_col))
+            _expanding_calibration(group, alpha=alpha).with_columns(
+                pl.lit(entity, dtype=entity_dtype).alias(id_col)
+            )
             for (entity,), group in preds.group_by([id_col], maintain_order=True)
         ]
     )

--- a/tests/test_conformal_calibration.py
+++ b/tests/test_conformal_calibration.py
@@ -362,3 +362,31 @@ def test_a_missing_prediction_still_names_the_directory_it_was_expected_in(
 
     with pytest.raises(FileNotFoundError, match=str(workspace)):
         conformal.compute_conformal_widths("demo", "candidate", write=False)
+
+
+def test_widths_compute_on_a_panel_keyed_by_integer_identifiers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An entity column that is not a string must still calibrate.
+
+    `join_asof` matches its `by` columns by dtype. The per-entity calibration table builds
+    its key from a Python value, so an unannotated literal infers Int32 and a panel keyed on
+    UInt32 identifiers - permnos, on us_firm_characteristics - raises rather than sizing
+    anything. Every conformal cell of that case study's allocation stage failed on it.
+    """
+    rows = [{**row, "symbol": 1001 if row["symbol"] == "A" else 1002} for row in _panel_rows()]
+    case_dir = tmp_path / "case_studies" / "demo"
+    pred_dir = case_dir / "run_log" / "predictions" / "candidate"
+    pred_dir.mkdir(parents=True)
+    pl.DataFrame(rows).with_columns(pl.col("symbol").cast(pl.UInt32)).write_parquet(
+        pred_dir / "predictions.parquet"
+    )
+    monkeypatch.setattr(conformal, "get_case_study_dir", lambda _: case_dir)
+
+    widths = conformal.compute_conformal_widths(
+        "demo", "candidate", min_calibration_n=3, embargo_steps=2, alpha=0.0, write=False
+    )
+
+    assert not widths.is_empty()
+    assert widths.schema["symbol"] == pl.UInt32
+    assert set(widths["symbol"].unique().to_list()) == {1001, 1002}


### PR DESCRIPTION
`compute_conformal_widths` builds its per-entity calibration table with `pl.lit(entity)`, which infers Int32 from the Python value. `join_asof` compares its `by` columns by dtype and raises on a mismatch, so a panel whose entity column is anything else fails outright: `us_firm_characteristics` is keyed on permnos stored as UInt32, and every one of its forty conformal allocation cells failed with `mismatching dtypes in 'by' parameter of asof-join: u32 and i32`. The literal now carries the source column's dtype.

Nothing selected this before because every case study that had computed conformal widths had string symbols, and the artifacts predating `walk_forward_v3` are served from disk rather than recomputed. The v3 bump in #638 is what makes every one of them recompute.

Test: `tests/test_conformal_calibration.py::test_widths_compute_on_a_panel_keyed_by_integer_identifiers`, the existing two-symbol fixture re-keyed to UInt32 identifiers. Mutation-checked - it fails on the unannotated literal.

Related, not fixed here and raised separately: the same v3 bump leaves every pre-v3 `conformal_widths.parquet` unusable, because `load_conformal_widths` auto-generates only when the file is absent while `_write_widths` refuses to mix versions in one file. The documented procedure is to snapshot and remove the stale artifact, which is what `us_firm_characteristics` did; whether that should be automatic is a fleet decision rather than this PR's.