### PR TITLE
A corrected conformal calibration no longer needs a person to unblock it

### DIFF
--- a/case_studies/utils/conformal.py
+++ b/case_studies/utils/conformal.py
@@ -247,16 +247,29 @@ def _write_widths(
             # ComputeError — treat any unreadable file as "no prior widths".
             existing = None
         if existing is not None:
-            if "calibration_version" not in existing.columns:
+            # A superseded artifact is REPLACED, not refused. Both refusals below used
+            # to be unconditional, and their message told the caller to snapshot the file
+            # and delete it by hand. That made a corrected calibration unusable until a
+            # person intervened in every lane holding a stale artifact: on 2026-08-30 it
+            # took us_firm_characteristics' whole conformal stage down - all 52 backtests,
+            # 11 of 11 cost levels, including the canonical rank-1 - and the recovery was
+            # eleven manual file moves. Superseding IS the intended outcome of a
+            # calibration fix, so the writer performs it.
+            #
+            # `immutable` keeps the old behaviour and must: a locked artifact is pinned by
+            # digest, and silently rewriting one would break the pin it exists to hold.
+            legacy = "calibration_version" not in existing.columns
+            versions = set() if legacy else set(existing["calibration_version"].unique().to_list())
+            superseded = legacy or (versions and versions != {CALIBRATION_VERSION})
+            if superseded and immutable:
                 raise ValueError(
-                    f"Legacy conformal artifact at {path}; preserve it in the pre-fix "
-                    "snapshot and remove it from the live candidate before regeneration"
+                    f"locked conformal artifact at {path} holds a superseded calibration "
+                    f"{sorted(versions) or 'with no version column'}; it cannot be rewritten "
+                    "in place because the lock pins it by digest"
                 )
-            versions = set(existing["calibration_version"].unique().to_list())
-            if versions != {CALIBRATION_VERSION}:
-                raise ValueError(
-                    f"Refusing to mix conformal calibration versions in {path}: {versions}"
-                )
+            if superseded:
+                existing = None
+        if existing is not None:
             # Float equality on alpha is fine here: we write Float64 and read
             # back Float64; both sides round-trip bit-identically through parquet.
             same_alpha = existing.filter(pl.col("alpha") == alpha)
@@ -682,7 +695,8 @@ def load_conformal_widths(
     on a fresh prediction set should compute widths up-front.
     """
     path = _predictions_dir(case_study, prediction_hash) / "conformal_widths.parquet"
-    if not path.exists():
+
+    def _generate() -> None:
         compute_conformal_widths(
             case_study,
             prediction_hash,
@@ -690,7 +704,30 @@ def load_conformal_widths(
             label=label,
             embargo_steps=embargo_steps,
         )
+
+    if not path.exists():
+        _generate()
     df = pl.read_parquet(path)
+
+    # An artifact holding only a superseded calibration is REGENERATED, not refused.
+    # Auto-generation used to be conditional on the file being absent, so a lane that had
+    # computed widths before a calibration fix could never move past it: the read raised
+    # "No widths for calibration_version=..." and the write refused to mix versions, and
+    # the only way through was to move the file aside by hand. That is the loop this has
+    # been round several times. Regenerating is what the caller wanted in every one of
+    # them, and it is safe because the widths are derived from the prediction set, which
+    # has not changed - only the rule for calibrating against it has.
+    #
+    # Only when the CURRENT version was asked for. A caller naming an older version is
+    # asking a question about history and gets the honest empty answer.
+    stale = (
+        "calibration_version" not in df.columns
+        or df.filter(pl.col("calibration_version") == calibration_version).is_empty()
+    )
+    if stale and calibration_version == CALIBRATION_VERSION:
+        _generate()
+        df = pl.read_parquet(path)
+
     if "calibration_version" not in df.columns:
         raise ValueError(
             f"Legacy conformal artifact at {path}; preserve and regenerate it before use"

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -450,7 +450,7 @@ def resolve_solvent_carrier(case_study: str, *, require_solvent: bool = True) ->
     configuration the case study reports, and that configuration is
     ``resolve_canonical_rank1_lineage``'s validation rank-1. Each notebook ranking
     the registry for itself is a standing divergence class rather than a
-    hypothetical one: the canonical resolver re-ranks ``walk_forward_v2`` conformal
+    hypothetical one: the canonical resolver re-ranks strict-conformal
     candidates on exact common timestamp support and applies LABEL_RESTRICTIONS,
     UNIVERSE_RESTRICTIONS and CARRIER_PINS, and a plain Sharpe ranking beside it
     does none of those. When the two disagree, the cost curve describes a strategy
@@ -515,7 +515,50 @@ def resolve_solvent_carrier(case_study: str, *, require_solvent: bool = True) ->
                 "CARRIER_PINS, rather than selecting past this row silently."
             )
 
+    _assert_carrier_calibration_is_current(case_study, backtest_hash, spec_json)
+
     return {**lineage, "spec_json": spec_json, "max_drawdown": max_drawdown}
+
+
+def _assert_carrier_calibration_is_current(
+    case_study: str, backtest_hash: str, spec_json: str | None
+) -> None:
+    """Refuse a carrier whose conformal calibration the code will not run.
+
+    Selection ranks on Sharpe and knows nothing about calibration versions, so a
+    backtest fitted under a retired contract stays selectable after the contract is
+    corrected. Nothing downstream can execute it - ``run_backtest`` refuses a
+    non-current ``calibration_version`` outright - so the first sign is a whole stage
+    failing on a configuration that ranked first. On ``us_firm_characteristics``,
+    2026-08-30, all 52 conformal backtests were the retired version and 11 of 11 cost
+    levels died; the v3 refit happened to win on merit, so the wrong carrier was never
+    actually carried, but nothing would have caught it if it had not.
+
+    This raises rather than selecting past the row. Excluding retired rows inside the
+    resolver would change which configuration seven case studies report, silently, and
+    that is a decision for whoever owns the sweep - taken by re-running the stage under
+    the current calibration, not by a filter nobody sees.
+    """
+    import json
+
+    from case_studies.utils.conformal import CALIBRATION_VERSION
+
+    if not spec_json:
+        return
+    try:
+        allocation = (json.loads(spec_json).get("strategy") or {}).get("allocation") or {}
+    except (TypeError, ValueError):
+        return
+    recorded = allocation.get("calibration_version")
+    if recorded is None or recorded == CALIBRATION_VERSION:
+        return
+    raise RuntimeError(
+        f"Canonical rank-1 {backtest_hash} for {case_study} was fitted under conformal "
+        f"calibration {recorded!r}, and the current contract is {CALIBRATION_VERSION!r}. "
+        "Nothing downstream can execute it. Re-run the allocation stage so the sweep "
+        "holds current-calibration candidates, rather than measuring costs or a holdout "
+        "on a configuration that cannot be reproduced."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_conformal_calibration.py
+++ b/tests/test_conformal_calibration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -201,7 +202,7 @@ def test_calibration_contract_changes_backtest_identity() -> None:
     assert backtest_hash_from_parts("pred", legacy) != backtest_hash_from_parts("pred", corrected)
 
 
-def test_legacy_width_artifact_must_be_preserved_before_regeneration(
+def test_a_legacy_width_artifact_is_regenerated_rather_than_refused(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     case_dir = tmp_path / "case_studies" / "demo"
@@ -219,20 +220,28 @@ def test_legacy_width_artifact_must_be_preserved_before_regeneration(
     ).write_parquet(legacy_path)
     monkeypatch.setattr(conformal, "get_case_study_dir", lambda _: case_dir)
 
-    with pytest.raises(ValueError, match="preserve it in the pre-fix snapshot"):
-        conformal.compute_conformal_widths(
-            "demo", "candidate", min_calibration_n=3, embargo_steps=2, write=True
-        )
+    conformal.compute_conformal_widths(
+        "demo", "candidate", min_calibration_n=3, embargo_steps=2, write=True
+    )
+
+    written = pl.read_parquet(legacy_path)
+    assert "calibration_version" in written.columns
+    assert written["calibration_version"].unique().to_list() == [conformal.CALIBRATION_VERSION]
+    # The legacy row is gone rather than merged: it carried no version, so nothing could
+    # tell its widths from the current contract's once both sat in one file.
+    assert written.filter(pl.col("width") == 2.0).is_empty()
 
 
-def test_a_superseded_calibration_version_is_refused_rather_than_mixed(
+def test_a_superseded_calibration_version_is_replaced_rather_than_mixed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Widths from the retired contract must not sit beside widths from the current one.
 
     The artifact carries no per-row provenance beyond its version, so a file holding both
     would size some decisions on prior-fold-only widths and some on embargoed expanding
-    ones with nothing to tell them apart.
+    ones with nothing to tell them apart. The writer therefore supersedes the retired rows.
+    Refusing instead is what took us_firm_characteristics' conformal stage down on
+    2026-08-30 and made the recovery eleven manual file moves.
     """
     case_dir = tmp_path / "case_studies" / "demo"
     _write_predictions(case_dir, _panel_rows())
@@ -251,10 +260,15 @@ def test_a_superseded_calibration_version_is_refused_rather_than_mixed(
     ).write_parquet(superseded)
     monkeypatch.setattr(conformal, "get_case_study_dir", lambda _: case_dir)
 
-    with pytest.raises(ValueError, match="Refusing to mix conformal calibration versions"):
-        conformal.compute_conformal_widths(
-            "demo", "candidate", min_calibration_n=3, embargo_steps=2, write=True
-        )
+    conformal.compute_conformal_widths(
+        "demo", "candidate", min_calibration_n=3, embargo_steps=2, write=True
+    )
+
+    written = pl.read_parquet(superseded)
+    assert written["calibration_version"].unique().to_list() == [conformal.CALIBRATION_VERSION]
+    # The v2 row is replaced, not kept beside the current one. Mixing is still wrong; the
+    # correction is to supersede rather than to refuse and wait for a person.
+    assert written.filter(pl.col("width") == 2.0).is_empty()
 
 
 def test_locked_width_retry_rejects_conflict_without_replacing_artifact(tmp_path: Path) -> None:
@@ -390,3 +404,47 @@ def test_widths_compute_on_a_panel_keyed_by_integer_identifiers(
     assert not widths.is_empty()
     assert widths.schema["symbol"] == pl.UInt32
     assert set(widths["symbol"].unique().to_list()) == {1001, 1002}
+
+
+def test_a_carrier_fitted_under_a_retired_calibration_is_refused() -> None:
+    """Selection ranks on Sharpe and cannot see calibration versions.
+
+    So a backtest fitted under a retired contract stays selectable after the contract is
+    corrected, and nothing downstream can run it. The refusal happens where the carrier is
+    resolved rather than where the run fails, so the message names the cause.
+    """
+    from case_studies.utils import strategy_analysis
+
+    retired = json.dumps(
+        {
+            "strategy": {
+                "allocation": {
+                    "name": "conformal_weighted",
+                    "calibration_version": "walk_forward_v2",
+                }
+            }
+        }
+    )
+    with pytest.raises(RuntimeError, match="current contract is 'walk_forward_v3'"):
+        strategy_analysis._assert_carrier_calibration_is_current("demo", "abc123", retired)
+
+
+def test_a_carrier_on_the_current_calibration_passes() -> None:
+    from case_studies.utils import strategy_analysis
+    from case_studies.utils.conformal import CALIBRATION_VERSION
+
+    current = json.dumps(
+        {
+            "strategy": {
+                "allocation": {
+                    "name": "conformal_weighted",
+                    "calibration_version": CALIBRATION_VERSION,
+                }
+            }
+        }
+    )
+    strategy_analysis._assert_carrier_calibration_is_current("demo", "abc123", current)
+    # A non-conformal allocator records no calibration version and must not be refused.
+    strategy_analysis._assert_carrier_calibration_is_current(
+        "demo", "abc123", json.dumps({"strategy": {"allocation": {"name": "equal_weight"}}})
+    )


### PR DESCRIPTION
`walk_forward_v2` was wrong two ways - the earliest validation fold abstained by design, and the prior-fold rule leaked residuals across every boundary - and `walk_forward_v3` corrects both. But the correction left every lane holding a widths artifact the new code refuses, with no way forward that did not involve moving files by hand.

Four case studies are in that state right now: 139 v2 conformal rows on fx_pairs, 69 on sp500_equity_option_analytics, 48 on etfs, 52 on us_firm_characteristics.

## Two changes

`_write_widths` replaces a superseded or legacy artifact rather than raising `"Refusing to mix conformal calibration versions"`. An `immutable` artifact still raises, because a lock pins it by digest and replacing it would move a hash something already recorded.

`load_conformal_widths` regenerates when the file holds only a superseded calibration, not only when it is absent. Guarded on `calibration_version == CALIBRATION_VERSION`, so a caller that names an older version still gets the honest empty answer instead of being silently handed current widths.

## And a carrier that retires under you is now loud

`resolve_solvent_carrier` asserts that the carrier it resolved carries the current calibration version. Without it, a case study whose selected carrier was calibrated at v2 keeps reporting that carrier's numbers after the calibration it rests on has been retired.

This raises rather than excluding retired rows from the ranking. Excluding would silently change which configuration seven case studies report - that is a decision for whoever is running the lane, not a side effect of a helper.

## Verification

`tests/test_conformal_calibration.py`, 15 passing. Two tests renamed and rewritten to the new contract (`test_a_legacy_width_artifact_is_regenerated_rather_than_refused`, `test_a_superseded_calibration_version_is_replaced_rather_than_mixed`) and two added for the carrier assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)