### PR TITLE
us_firm_characteristics/16: the executed holdout backtest, reproducing the same hash

### DIFF
--- a/case_studies/us_firm_characteristics/16_holdout_backtest.ipynb
+++ b/case_studies/us_firm_characteristics/16_holdout_backtest.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0dda689c",
+   "id": "d00e64ce",
    "metadata": {
     "papermill": {
-     "duration": 0.001029,
-     "end_time": "2026-08-30T19:42:28.860707+00:00",
+     "duration": 0.001044,
+     "end_time": "2026-08-30T21:09:42.551517+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:42:28.859678+00:00",
+     "start_time": "2026-08-30T21:09:42.550473+00:00",
      "status": "completed"
     }
    },
@@ -40,9 +40,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "15fd6e09",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "60db3a1b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T21:09:42.554168Z",
+     "iopub.status.busy": "2026-08-30T21:09:42.554017Z",
+     "iopub.status.idle": "2026-08-30T21:09:45.057913Z",
+     "shell.execute_reply": "2026-08-30T21:09:45.057273Z"
+    },
+    "papermill": {
+     "duration": 2.506015,
+     "end_time": "2026-08-30T21:09:45.058461+00:00",
+     "exception": false,
+     "start_time": "2026-08-30T21:09:42.552446+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"US Firm Characteristics: Holdout Backtest.\"\"\"\n",
@@ -76,9 +90,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c0defe85",
+   "execution_count": 2,
+   "id": "ff356cc2",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T21:09:45.060931Z",
+     "iopub.status.busy": "2026-08-30T21:09:45.060760Z",
+     "iopub.status.idle": "2026-08-30T21:09:45.063105Z",
+     "shell.execute_reply": "2026-08-30T21:09:45.062621Z"
+    },
+    "papermill": {
+     "duration": 0.003982,
+     "end_time": "2026-08-30T21:09:45.063547+00:00",
+     "exception": false,
+     "start_time": "2026-08-30T21:09:45.059565+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -96,9 +123,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "920a732a",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "8a54b5ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T21:09:45.066738Z",
+     "iopub.status.busy": "2026-08-30T21:09:45.066625Z",
+     "iopub.status.idle": "2026-08-30T21:09:53.021955Z",
+     "shell.execute_reply": "2026-08-30T21:09:53.021428Z"
+    },
+    "papermill": {
+     "duration": 7.957571,
+     "end_time": "2026-08-30T21:09:53.022729+00:00",
+     "exception": false,
+     "start_time": "2026-08-30T21:09:45.065158+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)\n",
@@ -135,13 +176,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40364311",
+   "id": "b115f28d",
    "metadata": {
     "papermill": {
-     "duration": 0.001806,
-     "end_time": "2026-08-30T19:42:34.809821+00:00",
+     "duration": 0.001611,
+     "end_time": "2026-08-30T21:09:53.026135+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:42:34.808015+00:00",
+     "start_time": "2026-08-30T21:09:53.024524+00:00",
      "status": "completed"
     }
    },
@@ -162,9 +203,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d7aa674c",
-   "metadata": {},
+   "execution_count": 4,
+   "id": "f9852b82",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T21:09:53.029759Z",
+     "iopub.status.busy": "2026-08-30T21:09:53.029665Z",
+     "iopub.status.idle": "2026-08-30T21:09:58.668393Z",
+     "shell.execute_reply": "2026-08-30T21:09:58.667659Z"
+    },
+    "papermill": {
+     "duration": 5.641267,
+     "end_time": "2026-08-30T21:09:58.668860+00:00",
+     "exception": false,
+     "start_time": "2026-08-30T21:09:53.027593+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "carrier = resolve_solvent_carrier(CASE_STUDY_ID)\n",
@@ -187,10 +242,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "27de7acc",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "7a305835",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T21:09:58.671943Z",
+     "iopub.status.busy": "2026-08-30T21:09:58.671724Z",
+     "iopub.status.idle": "2026-08-30T21:09:58.677236Z",
+     "shell.execute_reply": "2026-08-30T21:09:58.676687Z"
+    },
+    "papermill": {
+     "duration": 0.007514,
+     "end_time": "2026-08-30T21:09:58.677532+00:00",
+     "exception": false,
+     "start_time": "2026-08-30T21:09:58.670018+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Carrier:            2a0b06e45e26  leaves_63_mse (fwd_ret_1m)\n",
+      "Holdout training:   9a36f2daabb3\n",
+      "Holdout prediction: 6d996324b41a\n"
+     ]
+    }
+   ],
    "source": [
     "from case_studies.utils.registry import training_hash_from_spec\n",
     "\n",
@@ -222,13 +301,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6345618f",
+   "id": "07b8e63c",
    "metadata": {
     "papermill": {
-     "duration": 0.000724,
-     "end_time": "2026-08-30T19:42:39.013171+00:00",
+     "duration": 0.000768,
+     "end_time": "2026-08-30T21:09:58.679312+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:42:39.012447+00:00",
+     "start_time": "2026-08-30T21:09:58.678544+00:00",
      "status": "completed"
     }
    },
@@ -262,14 +341,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9617a484",
+   "execution_count": 6,
+   "id": "e4e5b9f7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T21:09:58.681616Z",
+     "iopub.status.busy": "2026-08-30T21:09:58.681487Z",
+     "iopub.status.idle": "2026-08-30T21:09:58.684707Z",
+     "shell.execute_reply": "2026-08-30T21:09:58.684124Z"
+    },
+    "papermill": {
+     "duration": 0.004959,
+     "end_time": "2026-08-30T21:09:58.685038+00:00",
+     "exception": false,
+     "start_time": "2026-08-30T21:09:58.680079+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conformal carrier: embargo 0 observation(s), widths written below.\n"
+     ]
+    }
+   ],
    "source": [
     "allocation = strategy_view(json.loads(carrier[\"spec_json\"])).get(\"allocation\") or {}\n",
     "NEEDS_CALIBRATION = allocation.get(\"method\") == \"conformal_weighted\"\n",
@@ -282,13 +382,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0c2d7ff",
+   "id": "3284c5bb",
    "metadata": {
     "papermill": {
-     "duration": 0.001688,
-     "end_time": "2026-08-30T19:42:39.046773+00:00",
+     "duration": 0.000741,
+     "end_time": "2026-08-30T21:09:58.686713+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:42:39.045085+00:00",
+     "start_time": "2026-08-30T21:09:58.685972+00:00",
      "status": "completed"
     }
    },
@@ -317,14 +417,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9e475da0",
+   "execution_count": 7,
+   "id": "22307874",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T21:09:58.689119Z",
+     "iopub.status.busy": "2026-08-30T21:09:58.688979Z",
+     "iopub.status.idle": "2026-08-30T21:09:58.897976Z",
+     "shell.execute_reply": "2026-08-30T21:09:58.897502Z"
+    },
+    "papermill": {
+     "duration": 0.210885,
+     "end_time": "2026-08-30T21:09:58.898381+00:00",
+     "exception": false,
+     "start_time": "2026-08-30T21:09:58.687496+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prices: 23,648 rows, 2,098 assets\n",
+      "Predictions: 23,648 rows, 12 dates\n",
+      "Conformal widths: 23,648 rows over 2,098 names, embargo 0 observation(s)\n",
+      "  calibration_n: median 110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=b2acfd5420c8)) — reusing cached result\n",
+      "Holdout backtest: b2acfd5420c8\n"
+     ]
+    }
+   ],
    "source": [
     "prices = load_backtest_prices_for(CASE_STUDY_ID, LABEL, split=\"holdout\", max_symbols=MAX_SYMBOLS)\n",
     "predictions = read_predictions(CASE_STUDY_ID, HOLDOUT_PREDICTION_HASH)\n",
@@ -428,13 +560,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d7457c9",
+   "id": "6976c826",
    "metadata": {
     "papermill": {
-     "duration": 0.00083,
-     "end_time": "2026-08-30T19:42:39.146220+00:00",
+     "duration": 0.000865,
+     "end_time": "2026-08-30T21:09:58.900338+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:42:39.145390+00:00",
+     "start_time": "2026-08-30T21:09:58.899473+00:00",
      "status": "completed"
     }
    },
@@ -452,14 +584,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "73f60bfa",
+   "execution_count": 8,
+   "id": "d629a73e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-30T21:09:58.902977Z",
+     "iopub.status.busy": "2026-08-30T21:09:58.902865Z",
+     "iopub.status.idle": "2026-08-30T21:09:58.906616Z",
+     "shell.execute_reply": "2026-08-30T21:09:58.905973Z"
+    },
+    "papermill": {
+     "duration": 0.00559,
+     "end_time": "2026-08-30T21:09:58.906901+00:00",
+     "exception": false,
+     "start_time": "2026-08-30T21:09:58.901311+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation Sharpe over its 109 months:  2.870\n",
+      "  the same run re-ranked on common support: 3.063\n",
+      "Holdout Sharpe over 12 months:        4.281\n",
+      "Holdout: CAGR 250.6%, max drawdown -0.16%, win rate 92%\n"
+     ]
+    }
+   ],
    "source": [
     "metrics = result.metrics\n",
     "# The carrier's own registered Sharpe, not the resolver's. `resolve_solvent_carrier` reports\n",
@@ -492,13 +648,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be6df343",
+   "id": "8f94a62b",
    "metadata": {
     "papermill": {
-     "duration": 0.000895,
-     "end_time": "2026-08-30T19:42:39.154572+00:00",
+     "duration": 0.000843,
+     "end_time": "2026-08-30T21:09:58.908845+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:42:39.153677+00:00",
+     "start_time": "2026-08-30T21:09:58.908002+00:00",
      "status": "completed"
     }
    },
@@ -542,6 +698,25 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-08-30T21:10:07.173113+00:00",
+   "executor": "local-uv",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "62eccd8476af1f7e398dae1b329a77f8ccb75eb3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 18.838825,
+   "end_time": "2026-08-30T21:10:00.726775+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-s6-us_firm_characteristics/case_studies/us_firm_characteristics/16_holdout_backtest.ipynb",
+   "output_path": "~/ml4t/public-s6-us_firm_characteristics/case_studies/us_firm_characteristics/.16_holdout_backtest.papermill.2768515.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-30T21:09:41.887950+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
One notebook execution, cut fresh from `main`. Replaces #682, which went DIRTY
when #681's squash merge diverged the case-study branch.

#681 moved `16_holdout_backtest`'s conformal widths write below the replacement
guard - a run that changed the embargo used to overwrite the calibration artifact
and could then raise, leaving the registered holdout backtest sized by a
calibration that no longer existed. That moved a code cell, so the notebook merged
with cleared provenance and claimed nothing.

This is that run. It reproduces `b2acfd5420c8` exactly: the same backtest hash
against the same holdout prediction set `6d996324b41a`, and one holdout row in the
registry rather than two. Moving the write changes when the artifact lands and
nothing about the specification, and the identical hash is what confirms that
rather than an argument that it should be so.

exit 0, largest single process 2.3 GB. Registry: signal 1252, allocation 120,
cost_sensitivity 22, holdout 1.

Separately and not a defect in this notebook: the holdout it renders reports
Sharpe 4.28 and CAGR 251%, and that number is the right tail of an unscreened
cross-section rather than a model result - mean rank IC is an ordinary 0.0395, but
the five largest contributors carry 282% of the monthly long-short spread. Filed
as a scope question, since it changes what the chapter teaches rather than whether
this code is correct.