### PR TITLE
A holdout backtest states its contract instead of requiring a research lock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,15 @@ jobs:
             # something that had already been tested in ninety seconds.
             shared:
               - 'utils/**'
+              # Every case study imports these two. `case_studies/research/` is the study,
+              # population, candidate-set and holdout machinery; `case_studies/utils/` is the
+              # backtest runner, registry and presets. A change to either can alter what every
+              # case-study pipeline does, and neither was listed - so a change to the module
+              # they all import fanned out zero case-study jobs and reported a green PR that had
+              # exercised none of them. The per-case-study filters below cover a study's own
+              # notebooks; nothing covered the code underneath all of them.
+              - 'case_studies/research/**'
+              - 'case_studies/utils/**'
               - 'data/**'
               - 'pyproject.toml'
               - '.github/workflows/test.yml'

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -110,6 +110,16 @@ class StrategyReplay:
     def run(self, prediction: PredictionResult) -> BacktestResult:
         if prediction.study != self.study:
             raise ValueError("holdout prediction belongs to another study")
+        # This method loads holdout prices unconditionally, and `Strategy` exempts validation
+        # predictions from the holdout contract - correctly, because validation runs are ranked
+        # against each other and re-run freely. Handed a validation prediction, the two rules
+        # combine into a backtest of validation scores against holdout prices that no check
+        # would catch. The split is therefore refused here, where the prices are chosen.
+        split = prediction.registry_record()["split"]
+        if split != "holdout":
+            raise ValueError(
+                f"the holdout replay requires a holdout prediction, and this one is {split!r}"
+            )
         from case_studies.utils.artifact_digest import value_digest
         from case_studies.utils.backtest_presets import serializable_backtest_spec
         from case_studies.utils.backtest_runner import resolved_allow_short_selling
@@ -820,7 +830,7 @@ class HoldoutSelection:
         own: a cost sibling changes commission and slippage, which live under ``backtest_config``,
         so it shares the whole strategy block with the run it was derived from.
 
-        The comparison is therefore ``_locked_strategy_projection``, which is the specification
+        The comparison is therefore ``strategy_projection``, which is the specification
         with exactly the fields that must differ between the two intervals removed - the
         prediction hash, the price and funding digests, the decision artifact's own hashes - and
         everything else kept, costs included. That is not a projection chosen here: it is the one
@@ -834,8 +844,6 @@ class HoldoutSelection:
         that one does not need producing - :meth:`StrategyReplay.run` resolves by full identity,
         price digest included, and is the only thing that can answer that question.
         """
-        from .lifecycle import _locked_strategy_projection
-
         prediction = self.holdout_prediction
         if prediction is None:
             return None
@@ -844,13 +852,13 @@ class HoldoutSelection:
         )
         if rows.is_empty():
             return None
-        expected = _locked_strategy_projection(self.validation_backtest.spec())
+        expected = strategy_projection(self.validation_backtest.spec())
         matched = []
         for backtest_hash in sorted(set(rows.get_column("backtest_hash"))):
             opened = self.study.results.open(backtest_hash)
             if not isinstance(opened, BacktestResult):
                 raise TypeError("the holdout lineage resolved a non-backtest result")
-            if _locked_strategy_projection(opened.spec()) == expected:
+            if strategy_projection(opened.spec()) == expected:
                 matched.append(opened)
         if not matched:
             return None

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -15,6 +15,7 @@ import polars as pl
 from .decisions import DecisionArtifact, StateTransitionPolicy
 from .lifecycle import ResearchLock
 from .results import BacktestResult, PredictionResult
+from .strategy import HoldoutExpectation, strategy_projection
 
 _FOLD_FIELDS = ("fold", "train_start", "train_end", "val_start", "val_end")
 
@@ -87,13 +88,27 @@ class _DecisionReplay:
 
 
 @dataclass(frozen=True)
-class LockedStrategyReplay:
-    lock: ResearchLock
+class StrategyReplay:
+    """The exact holdout re-run of one validation strategy.
+
+    It holds the four facts the replay actually consumes - the study, the resolved strategy
+    specification, the label whose price grid the holdout is read from, and the validation
+    prediction the conformal calibration is keyed on - rather than a research lock, because
+    every one of them is readable from the selected validation backtest. Taking a lock instead
+    made an authorization token a prerequisite for a computation that needs no authorization,
+    which is what forced holdout production to happen inside the lock transaction.
+    """
+
+    study: Any
+    strategy_spec: dict[str, Any]
+    label: str
+    validation_prediction_hash: str
+    expectation: HoldoutExpectation
     request: dict[str, Any]
     decision_replay: _DecisionReplay | None
 
     def run(self, prediction: PredictionResult) -> BacktestResult:
-        if prediction.study != self.lock.study:
+        if prediction.study != self.study:
             raise ValueError("holdout prediction belongs to another study")
         from case_studies.utils.artifact_digest import value_digest
         from case_studies.utils.backtest_presets import serializable_backtest_spec
@@ -105,33 +120,21 @@ class LockedStrategyReplay:
         from .results import Result
         from .strategy import strategy_projection
 
-        locked_spec = deepcopy(self.lock.record["strategy_spec"])
+        locked_spec = deepcopy(self.strategy_spec)
         warmup = strategy_module.strategy_warmup_periods(locked_spec)
         prices = strategy_module.load_backtest_prices_for(
-            self.lock.study.case_study,
-            str(self.lock.record["label"]),
+            self.study.case_study,
+            self.label,
             split="holdout",
             warmup_periods=warmup,
         )
         decision = (
             self.decision_replay.publish(prediction, prices) if self.decision_replay else None
         )
-        # The lock's contract, restated as the expectation `Strategy` now requires from every
-        # caller. Reading it off the lock keeps this path's guarantee exactly where it was while
-        # `Strategy` itself stops reading `research_locks`: what the lock knows, the caller now
-        # says. A lock-free caller derives the same four facts from its candidate set.
-        from .strategy import HoldoutExpectation, strategy_projection
-
-        strategy = self.lock.study.strategy(
+        strategy = self.study.strategy(
             prediction=prediction,
             decision=decision,
-            holdout_expectation=HoldoutExpectation(
-                training_hash=str(self.lock.record["holdout_training_hash"]),
-                checkpoint_kind=str(self.lock.record["checkpoint_kind"]),
-                checkpoint_value=self.lock.record["checkpoint_value"],
-                strategy=strategy_projection(deepcopy(self.lock.record["strategy_spec"])),
-                validation_prediction_hash=str(self.lock.record["prediction_hash"]),
-            ),
+            holdout_expectation=self.expectation,
             **self.request,
         )
         # The loader keys cme_futures prices on `product`, while the allocator and
@@ -165,7 +168,7 @@ class LockedStrategyReplay:
             raise ValueError("locked decision artifact was not transformed for holdout")
 
         contract_specs = None
-        if self.lock.study.case_study == "cme_futures":
+        if self.study.case_study == "cme_futures":
             contract_specs = strategy_module.load_contract_specs_from_yaml()
             serialized = {
                 symbol: asdict(contract_spec) for symbol, contract_spec in contract_specs.items()
@@ -183,13 +186,13 @@ class LockedStrategyReplay:
         allocation = spec.get("strategy", {}).get("allocation", {})
         if allocation.get("method") == "conformal_weighted":
             strategy_module.compute_holdout_conformal_widths(
-                self.lock.study.case_study,
-                self.lock.record["prediction_hash"],
+                self.study.case_study,
+                self.validation_prediction_hash,
                 prediction.hash,
                 alpha=float(allocation.get("alpha", 0.2)),
                 min_calibration_n=int(allocation["min_calibration_n"]),
                 embargo_steps=strategy_module.holdout_conformal_embargo_steps(
-                    self.lock.study.case_study,
+                    self.study.case_study,
                     strategy.label,
                 ),
                 write=True,
@@ -224,14 +227,14 @@ class LockedStrategyReplay:
             identity_version=2,
         )
         try:
-            cached = Result.open(self.lock.study, expected_hash)
+            cached = Result.open(self.study, expected_hash)
         except KeyError:
             cached = None
         if isinstance(cached, BacktestResult) and cached.complete:
             return cached
-        self.lock.study.activate(ExecutionTier.CANONICAL)
+        self.study.activate(ExecutionTier.CANONICAL)
         result = strategy_module.run_backtest(
-            self.lock.study.case_study,
+            self.study.case_study,
             prediction.hash,
             spec,
             prices=engine_prices,
@@ -250,19 +253,21 @@ class LockedStrategyReplay:
                 f"locked backtest identity changed during execution: "
                 f"{expected_hash} -> {result.backtest_hash}"
             )
-        reopened = Result.open(self.lock.study, expected_hash)
+        reopened = Result.open(self.study, expected_hash)
         if not isinstance(reopened, BacktestResult) or not reopened.complete:
             raise ValueError("locked strategy did not publish a complete backtest result")
         return reopened
 
 
-def _prepare_decision_replay(lock: ResearchLock) -> _DecisionReplay | None:
-    decision_record = lock.record["strategy_spec"].get("decision_artifact")
+def _prepare_decision_replay(
+    study: Any, strategy_spec: Mapping[str, Any]
+) -> _DecisionReplay | None:
+    decision_record = strategy_spec.get("decision_artifact")
     if decision_record is None:
         return None
     if not decision_record.get("canonical"):
-        raise ValueError("locked holdout decisions require a canonical validation artifact")
-    original = DecisionArtifact.open(lock.study, str(decision_record["hash"]))
+        raise ValueError("holdout decisions require a canonical validation artifact")
+    original = DecisionArtifact.open(study, str(decision_record["hash"]))
     expected = {
         "artifact_digest": original.spec["artifact_digest"],
         "canonical": original.canonical,
@@ -275,7 +280,7 @@ def _prepare_decision_replay(lock: ResearchLock) -> _DecisionReplay | None:
         if name in decision_record:
             expected[name] = original.spec[name]
     if decision_record != expected:
-        raise ValueError("locked decision artifact differs from its immutable registry record")
+        raise ValueError("decision artifact differs from its immutable registry record")
     original.load()
     source_identity = original.spec["source_identity"]
     replay = source_identity.get("holdout_replay")
@@ -341,7 +346,48 @@ def _prepare_decision_replay(lock: ResearchLock) -> _DecisionReplay | None:
     return _DecisionReplay(original, function, locked_inputs)
 
 
-def prepare_locked_strategy_replay(lock: ResearchLock) -> LockedStrategyReplay:
+def prepare_strategy_replay(
+    study: Any,
+    *,
+    strategy_spec: Mapping[str, Any],
+    label: str,
+    validation_prediction_hash: str,
+    expectation: HoldoutExpectation,
+) -> StrategyReplay:
+    """Validate one resolved strategy and prepare its exact holdout replay.
+
+    Everything here is read from the selected validation backtest and its lineage. The three
+    arguments beyond the study are the three facts a backtest specification does not carry
+    about itself: which study it belongs to, which label's price grid the holdout reads, and
+    which validation prediction a conformal allocator calibrates against.
+    """
+    if not isinstance(strategy_spec, dict) or strategy_spec.get("version") != 2:
+        raise ValueError("holdout replay requires a complete canonical strategy specification")
+    strategy = strategy_spec.get("strategy")
+    if not isinstance(strategy, dict) or not isinstance(strategy.get("signal"), dict):
+        raise ValueError("holdout replay requires a resolved signal specification")
+    rebalance = strategy.get("rebalance") or {}
+    request = {
+        "signal": deepcopy(strategy["signal"]),
+        "allocation": deepcopy(strategy.get("allocation")),
+        "risk": deepcopy(strategy.get("risk")),
+        "chapter": strategy_spec.get("chapter"),
+        "execution_mode": rebalance.get("mode"),
+        "min_weight_change": rebalance.get("min_weight_change"),
+        "min_trade_value": rebalance.get("min_trade_value"),
+    }
+    return StrategyReplay(
+        study,
+        deepcopy(dict(strategy_spec)),
+        label,
+        validation_prediction_hash,
+        expectation,
+        request,
+        _prepare_decision_replay(study, strategy_spec),
+    )
+
+
+def prepare_locked_strategy_replay(lock: ResearchLock) -> StrategyReplay:
     """Validate the locked strategy and prepare its exact holdout replay before model writes."""
     spec = lock.record.get("strategy_spec")
     if not isinstance(spec, dict) or spec.get("version") != 2:
@@ -349,17 +395,22 @@ def prepare_locked_strategy_replay(lock: ResearchLock) -> LockedStrategyReplay:
     strategy = spec.get("strategy")
     if not isinstance(strategy, dict) or not isinstance(strategy.get("signal"), dict):
         raise ValueError("research lock has no resolved signal specification")
-    rebalance = strategy.get("rebalance") or {}
-    request = {
-        "signal": deepcopy(strategy["signal"]),
-        "allocation": deepcopy(strategy.get("allocation")),
-        "risk": deepcopy(strategy.get("risk")),
-        "chapter": spec.get("chapter"),
-        "execution_mode": rebalance.get("mode"),
-        "min_weight_change": rebalance.get("min_weight_change"),
-        "min_trade_value": rebalance.get("min_trade_value"),
-    }
-    return LockedStrategyReplay(lock, request, _prepare_decision_replay(lock))
+    return prepare_strategy_replay(
+        lock.study,
+        strategy_spec=spec,
+        label=str(lock.record["label"]),
+        validation_prediction_hash=str(lock.record["prediction_hash"]),
+        # The lock's contract, restated as the expectation `Strategy` now requires from every
+        # caller: what the lock knows, the caller says. The guarantee on this path is unchanged;
+        # only who states it has moved.
+        expectation=HoldoutExpectation(
+            training_hash=str(lock.record["holdout_training_hash"]),
+            checkpoint_kind=str(lock.record["checkpoint_kind"]),
+            checkpoint_value=lock.record["checkpoint_value"],
+            strategy=strategy_projection(deepcopy(spec)),
+            validation_prediction_hash=str(lock.record["prediction_hash"]),
+        ),
+    )
 
 
 def _validation_folds(validation_spec: Mapping[str, Any]) -> list[dict[str, Any]]:
@@ -702,6 +753,208 @@ class HoldoutOutcome:
     @property
     def lineage(self) -> dict[str, str]:
         return self.lock.study.lifecycle.holdout_lineage(self.lock.hash)
+
+
+@dataclass(frozen=True)
+class HoldoutSelection:
+    """One validation selection and the holdout lineage it determines.
+
+    Holdout production is split across three notebooks - refit, backtest, then read both back -
+    and all three have to agree on which configuration was selected and what its holdout identity
+    is. They agree by deriving it here rather than by each re-deriving it, and by passing hashes
+    forward rather than re-selecting: the derivation is pure, so a notebook run days later
+    resolves the same lineage without anything having been written down between runs.
+
+    ``holdout_training_hash`` is the identity the holdout refit will have, derived whether or
+    not it has been produced yet, so a notebook can name the result it is waiting for rather
+    than report that a query found nothing. ``holdout_prediction`` and ``holdout_backtest``
+    resolve to None until the refit and the backtest have run.
+    """
+
+    study: Any
+    candidate_set: Any
+    validation_backtest: BacktestResult
+    validation_prediction: PredictionResult
+    validation_training: Any
+    label: str
+    checkpoint_kind: str
+    checkpoint_value: int | None
+    holdout_training_spec: dict[str, Any]
+    holdout_training_hash: str
+
+    @property
+    def holdout_prediction(self) -> PredictionResult | None:
+        """The registered holdout prediction, or None before the refit has run."""
+        from .results import PredictionResult as _PredictionResult
+
+        rows = self.study.predictions.table().filter(
+            (pl.col("training_hash") == self.holdout_training_hash)
+            & (pl.col("split") == "holdout")
+            & (pl.col("checkpoint_kind") == self.checkpoint_kind)
+        )
+        if self.checkpoint_value is None:
+            rows = rows.filter(pl.col("checkpoint_value").is_null())
+        else:
+            rows = rows.filter(pl.col("checkpoint_value") == self.checkpoint_value)
+        if rows.is_empty():
+            return None
+        hashes = sorted(set(rows.get_column("prediction_hash")))
+        if len(hashes) > 1:
+            raise ValueError(
+                f"holdout training {self.holdout_training_hash} resolved {len(hashes)} "
+                f"predictions at checkpoint {self.checkpoint_kind}={self.checkpoint_value}: "
+                f"{hashes}"
+            )
+        opened = self.study.results.open(hashes[0])
+        if not isinstance(opened, _PredictionResult):
+            raise TypeError("the holdout lineage resolved a non-prediction result")
+        return opened
+
+    @property
+    def holdout_backtest(self) -> BacktestResult | None:
+        """The registered holdout backtest of the *selected* strategy, or None before the replay.
+
+        One holdout prediction can carry more than one backtest - a cost sibling, an allocation
+        variant, anything a later notebook chose to run against it - so the prediction alone does
+        not identify the result this selection determines. Nor does the ``strategy`` block on its
+        own: a cost sibling changes commission and slippage, which live under ``backtest_config``,
+        so it shares the whole strategy block with the run it was derived from.
+
+        The comparison is therefore ``_locked_strategy_projection``, which is the specification
+        with exactly the fields that must differ between the two intervals removed - the
+        prediction hash, the price and funding digests, the decision artifact's own hashes - and
+        everything else kept, costs included. That is not a projection chosen here: it is the one
+        :meth:`StrategyReplay.run` asserts the reconstructed holdout specification still matches.
+
+        What this therefore CANNOT decide is whether the backtest it returns was built from the
+        current price artifact, because the projection excludes the price digest by construction:
+        prices are the one input that legitimately differs between the two windows, so a lineage
+        comparison has nothing to compare them against. A backtest produced from a superseded
+        price panel matches this and is returned. Use it to read back a holdout, never to decide
+        that one does not need producing - :meth:`StrategyReplay.run` resolves by full identity,
+        price digest included, and is the only thing that can answer that question.
+        """
+        from .lifecycle import _locked_strategy_projection
+
+        prediction = self.holdout_prediction
+        if prediction is None:
+            return None
+        rows = self.study.backtests.table().filter(
+            (pl.col("prediction_hash") == prediction.hash) & (pl.col("split") == "holdout")
+        )
+        if rows.is_empty():
+            return None
+        expected = _locked_strategy_projection(self.validation_backtest.spec())
+        matched = []
+        for backtest_hash in sorted(set(rows.get_column("backtest_hash"))):
+            opened = self.study.results.open(backtest_hash)
+            if not isinstance(opened, BacktestResult):
+                raise TypeError("the holdout lineage resolved a non-backtest result")
+            if _locked_strategy_projection(opened.spec()) == expected:
+                matched.append(opened)
+        if not matched:
+            return None
+        if len(matched) > 1:
+            raise ValueError(
+                f"holdout prediction {prediction.hash} carries {len(matched)} backtests of the "
+                f"selected strategy: {sorted(result.hash for result in matched)}"
+            )
+        return matched[0]
+
+    def expectation(self) -> HoldoutExpectation:
+        """What this selection entitles a holdout execution to be.
+
+        Every field is derived from the immutable candidate set rather than recorded when the
+        selection was made, so it cannot go stale the way a research lock does: re-deriving it
+        after an upstream rebuild yields the current selection's contract, not the retired one.
+        """
+        return HoldoutExpectation(
+            training_hash=self.holdout_training_hash,
+            checkpoint_kind=self.checkpoint_kind,
+            checkpoint_value=self.checkpoint_value,
+            strategy=strategy_projection(deepcopy(self.validation_backtest.spec())),
+            validation_prediction_hash=self.validation_prediction.hash,
+        )
+
+    def strategy_replay(self) -> StrategyReplay:
+        """The exact holdout re-run of the selected validation strategy."""
+        return prepare_strategy_replay(
+            self.study,
+            strategy_spec=self.validation_backtest.spec(),
+            label=self.label,
+            validation_prediction_hash=self.validation_prediction.hash,
+            expectation=self.expectation(),
+        )
+
+
+def resolve_holdout_selection(
+    study: Any,
+    *,
+    candidate_set_name: str,
+    timeline: Sequence[Any] | None = None,
+    case_study: str | None = None,
+) -> HoldoutSelection:
+    """Resolve the rank-1 validation selection and the holdout lineage it determines.
+
+    Selection is not a parameter: the candidate set's highest validation backtest Sharpe is read
+    from the set rather than accepted from a caller, which removes the one place a caller could
+    disagree with the documented rule. The candidate set is immutable, so this resolves the same
+    member every time it is called.
+
+    ``timeline`` defaults to the observation grid of the label the selection was made on, which
+    is the grid the holdout interval must be stepped back along. It is derived rather than passed
+    because a caller cannot know which label to read the grid from until this function has
+    resolved the selection, and a caller that guesses gets it right in every case study whose
+    labels happen to share one grid - and silently wrong in the first one where they do not.
+    """
+    from .comparison import CandidateSet
+    from .results import PredictionResult as _PredictionResult
+    from .results import TrainingResult as _TrainingResult
+
+    candidates = CandidateSet.one(study, name=candidate_set_name)
+    if candidates.member_kind != "backtest":
+        raise ValueError("holdout selection requires a backtest candidate set")
+    selected = candidates.best_validation_sharpe()
+    if not isinstance(selected, BacktestResult) or not selected.complete:
+        raise ValueError("the selected validation backtest is incomplete")
+    if selected.execution_tier != "canonical":
+        raise ValueError("the selected validation backtest is not canonical")
+    selected_record = selected.registry_record()
+    prediction = study.results.open(selected_record["prediction_hash"])
+    if not isinstance(prediction, _PredictionResult):
+        raise TypeError("the selected backtest does not reference a prediction")
+    training = study.results.open(prediction.registry_record()["training_hash"])
+    if not isinstance(training, _TrainingResult):
+        raise TypeError("the selected prediction does not reference a training result")
+
+    validation_spec = training.spec()
+    label = str(validation_spec["label"])
+    if timeline is None:
+        timeline = (
+            pl.read_parquet(study.root / "labels" / f"{label}.parquet")
+            .get_column("timestamp")
+            .unique()
+            .sort()
+            .to_list()
+        )
+    holdout_spec = build_holdout_training_spec(
+        study, validation_spec, timeline=timeline, case_study=case_study
+    )
+    from case_studies.utils.registry import training_hash_from_spec
+
+    prediction_record = prediction.registry_record()
+    return HoldoutSelection(
+        study=study,
+        candidate_set=candidates,
+        validation_backtest=selected,
+        validation_prediction=prediction,
+        validation_training=training,
+        label=label,
+        checkpoint_kind=str(prediction_record["checkpoint_kind"]),
+        checkpoint_value=prediction_record["checkpoint_value"],
+        holdout_training_spec=holdout_spec,
+        holdout_training_hash=training_hash_from_spec(holdout_spec),
+    )
 
 
 def evaluate_holdout(

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -102,8 +102,8 @@ class LockedStrategyReplay:
 
         from . import strategy as strategy_module
         from .contracts import ExecutionTier
-        from .lifecycle import _locked_strategy_projection
         from .results import Result
+        from .strategy import strategy_projection
 
         locked_spec = deepcopy(self.lock.record["strategy_spec"])
         warmup = strategy_module.strategy_warmup_periods(locked_spec)
@@ -116,9 +116,22 @@ class LockedStrategyReplay:
         decision = (
             self.decision_replay.publish(prediction, prices) if self.decision_replay else None
         )
+        # The lock's contract, restated as the expectation `Strategy` now requires from every
+        # caller. Reading it off the lock keeps this path's guarantee exactly where it was while
+        # `Strategy` itself stops reading `research_locks`: what the lock knows, the caller now
+        # says. A lock-free caller derives the same four facts from its candidate set.
+        from .strategy import HoldoutExpectation, strategy_projection
+
         strategy = self.lock.study.strategy(
             prediction=prediction,
             decision=decision,
+            holdout_expectation=HoldoutExpectation(
+                training_hash=str(self.lock.record["holdout_training_hash"]),
+                checkpoint_kind=str(self.lock.record["checkpoint_kind"]),
+                checkpoint_value=self.lock.record["checkpoint_value"],
+                strategy=strategy_projection(deepcopy(self.lock.record["strategy_spec"])),
+                validation_prediction_hash=str(self.lock.record["prediction_hash"]),
+            ),
             **self.request,
         )
         # The loader keys cme_futures prices on `product`, while the allocator and
@@ -196,7 +209,7 @@ class LockedStrategyReplay:
             spec["backtest_config"]["account"]["allow_short_selling"] = (
                 resolved_allow_short_selling(spec, weights)
             )
-        if _locked_strategy_projection(spec) != _locked_strategy_projection(locked_spec):
+        if strategy_projection(spec) != strategy_projection(locked_spec):
             raise ValueError("holdout strategy reconstruction changed the locked computation")
 
         calendar_block = spec["backtest_config"].get("calendar")

--- a/case_studies/research/lifecycle.py
+++ b/case_studies/research/lifecycle.py
@@ -138,36 +138,6 @@ def _locked_training_spec(validation_spec: dict[str, Any], holdout_spec: dict[st
     return project_training_identity(holdout_spec)
 
 
-def _locked_strategy_projection(spec: dict[str, Any]) -> dict[str, Any]:
-    projected = deepcopy(spec)
-    projected.pop("_runtime_backtest_config", None)
-    metadata = projected.get("backtest_config", {}).get("metadata")
-    if isinstance(metadata, dict):
-        metadata.pop("prediction_hash", None)
-    input_identity = projected.get("input_identity")
-    if isinstance(input_identity, dict):
-        input_identity.pop("prices", None)
-        input_identity.pop("funding_rates", None)
-        # An input identity holding nothing but the runtime-resolved entries just removed
-        # projects to `{}`, while a strategy that declared no input identity at all projects to
-        # the key being absent. The two describe the same strategy and must hash the same, so
-        # the empty remainder is dropped rather than left as an empty dict.
-        if not input_identity:
-            projected.pop("input_identity")
-    decision = projected.get("decision_artifact")
-    if isinstance(decision, dict):
-        decision.pop("hash", None)
-        decision.pop("artifact_digest", None)
-        source_identity = decision.get("source_identity")
-        if isinstance(source_identity, dict):
-            declared_inputs = source_identity.get("declared_inputs")
-            if isinstance(declared_inputs, dict):
-                declared_inputs.pop("prediction_hashes", None)
-                declared_inputs.pop("prices", None)
-            source_identity.pop("clean_replay_digest", None)
-    return projected
-
-
 def _valid_holdout_decision(
     study: Study,
     locked_spec: dict[str, Any],
@@ -343,6 +313,8 @@ class Lifecycle:
         holdout_prediction_hash: str,
         holdout_backtest_hash: str,
     ) -> tuple[ResearchLock, TrainingResult, PredictionResult, BacktestResult]:
+        from .strategy import strategy_projection
+
         lock = self.open(lock_hash)
         if lock.state != LifecycleState.LOCKED.value:
             raise ValueError("holdout evaluation requires a LOCKED research lock")
@@ -381,8 +353,8 @@ class Lifecycle:
                 backtest_spec,
                 prediction.hash,
             )
-            and _locked_strategy_projection(backtest_spec)
-            == _locked_strategy_projection(lock.record["strategy_spec"])
+            and strategy_projection(backtest_spec)
+            == strategy_projection(lock.record["strategy_spec"])
         )
         if not valid:
             raise ValueError(

--- a/case_studies/research/strategy.py
+++ b/case_studies/research/strategy.py
@@ -211,6 +211,80 @@ def strategy_warmup_periods(strategy_spec: dict[str, Any]) -> int:
     return int(value)
 
 
+def strategy_projection(spec: dict[str, Any]) -> dict[str, Any]:
+    """One strategy specification reduced to what two runs of it must agree on.
+
+    Removed are exactly the fields that legitimately differ between two executions of the same
+    strategy over different intervals: the prediction hash, the price and funding digests, and
+    the decision artifact's own hashes. Everything else is kept, transaction costs included.
+
+    This is what makes "the same strategy on a different window" a decidable question, and it is
+    the comparison a holdout replay has to satisfy. It lived in the research-lock module and was
+    private to it, which is why a holdout produced outside that transaction had no way to state
+    the guarantee at all.
+    """
+    projected = deepcopy(spec)
+    projected.pop("_runtime_backtest_config", None)
+    metadata = projected.get("backtest_config", {}).get("metadata")
+    if isinstance(metadata, dict):
+        metadata.pop("prediction_hash", None)
+    input_identity = projected.get("input_identity")
+    if isinstance(input_identity, dict):
+        input_identity.pop("prices", None)
+        input_identity.pop("funding_rates", None)
+        # An input identity holding nothing but the runtime-resolved entries just removed
+        # projects to `{}`, while a strategy that declared no input identity at all projects to
+        # the key being absent. The two describe the same strategy and must hash the same, so
+        # the empty remainder is dropped rather than left as an empty dict.
+        if not input_identity:
+            projected.pop("input_identity")
+    decision = projected.get("decision_artifact")
+    if isinstance(decision, dict):
+        decision.pop("hash", None)
+        decision.pop("artifact_digest", None)
+        source_identity = decision.get("source_identity")
+        if isinstance(source_identity, dict):
+            declared_inputs = source_identity.get("declared_inputs")
+            if isinstance(declared_inputs, dict):
+                declared_inputs.pop("prediction_hashes", None)
+                declared_inputs.pop("prices", None)
+            source_identity.pop("clean_replay_digest", None)
+    return projected
+
+
+@dataclass(frozen=True)
+class HoldoutExpectation:
+    """What a caller asserts about the holdout lineage it is asking to be executed.
+
+    A holdout backtest is only evidence if it ran the selected configuration, refitted on the
+    holdout interval, under the selected strategy. Nothing in a holdout prediction says which
+    configuration was selected, so that fact has to arrive from outside. The research-lock layer
+    supplied it by requiring a pre-registered row, which made an authorization token a
+    prerequisite for a computation and made a wrong holdout uncorrectable. This carries the same
+    three facts without the token, and the caller states them.
+
+    ``training_hash`` is the holdout retrain's own identity - not the validation model's, which
+    a genuine retrain never shares. ``checkpoint_kind`` and ``checkpoint_value`` pin which
+    checkpoint of that retrain is being executed, because one training run registers one
+    prediction set per declared checkpoint and they are otherwise indistinguishable here.
+    ``strategy`` is :func:`strategy_projection` of the selected validation strategy: matching
+    the model alone would let a caller replay a different strategy on the right model, which is
+    a different route to the same wrong answer. ``validation_prediction_hash`` is the prediction
+    a conformal allocator calibrates its holdout widths from, which is a property of the
+    selection and was the last thing on this path still being read out of the lock.
+
+    Callers derive all four from the immutable candidate set rather than recording them - see
+    ``case_studies.research.holdout.resolve_holdout_selection`` - so the expectation is a
+    function of the selection, not a second copy of it that can go stale.
+    """
+
+    training_hash: str
+    checkpoint_kind: str
+    checkpoint_value: int | None
+    strategy: dict[str, Any]
+    validation_prediction_hash: str
+
+
 @dataclass(frozen=True)
 class Strategy:
     study: Study
@@ -224,16 +298,7 @@ class Strategy:
     execution_mode: str | None = None
     min_weight_change: float | None = None
     min_trade_value: float | None = None
-
-    def _active_lock_record(self) -> dict[str, Any]:
-        db_path = self.study.root / "run_log" / "registry.db"
-        with closing(sqlite3.connect(db_path)) as db:
-            row = db.execute(
-                "SELECT lock_json FROM research_locks WHERE state = 'LOCKED' LIMIT 1"
-            ).fetchone()
-        if row is None:
-            raise ValueError("holdout strategy execution requires a LOCKED research lock")
-        return json.loads(row[0])
+    holdout_expectation: HoldoutExpectation | None = None
 
     def __post_init__(self) -> None:
         if self.prediction.study != self.study:
@@ -250,15 +315,33 @@ class Strategy:
         if split == "validation":
             return
         if split != "holdout" or self.prediction.execution_tier != "canonical":
-            raise ValueError("strategy execution requires validation or locked holdout predictions")
-        lock_record = self._active_lock_record()
-        matches_lock = (
-            prediction_record["training_hash"] == lock_record.get("holdout_training_hash")
-            and prediction_record["checkpoint_kind"] == lock_record.get("checkpoint_kind")
-            and prediction_record["checkpoint_value"] == lock_record.get("checkpoint_value")
+            raise ValueError(
+                "strategy execution requires validation or canonical holdout predictions"
+            )
+        # A holdout execution states what it expects, and there is no default. Falling back to
+        # "any canonical holdout prediction" would leave the constructor accepting a holdout
+        # produced from a configuration nobody selected, which is the failure the research lock
+        # was standing in front of - so the absence of an expectation is a refusal, not a
+        # permissive path. Callers on the research API derive it from the immutable candidate
+        # set; see `holdout.resolve_holdout_selection`.
+        expected = self.holdout_expectation
+        if expected is None:
+            raise ValueError(
+                "holdout strategy execution requires a holdout_expectation naming the retrain's "
+                "training hash, its checkpoint and the selected strategy projection"
+            )
+        actual = (
+            prediction_record["training_hash"],
+            prediction_record["checkpoint_kind"],
+            prediction_record["checkpoint_value"],
         )
-        if not matches_lock:
-            raise ValueError("holdout prediction does not match the locked retraining contract")
+        wanted = (expected.training_hash, expected.checkpoint_kind, expected.checkpoint_value)
+        if actual != wanted:
+            raise ValueError(
+                f"holdout prediction is training {actual[0]} at checkpoint {actual[1]}="
+                f"{actual[2]}, but the caller expects training {wanted[0]} at "
+                f"{wanted[1]}={wanted[2]}"
+            )
 
     @property
     def split(self) -> Literal["validation", "holdout"]:
@@ -280,6 +363,7 @@ class Strategy:
             "execution_mode",
             "min_weight_change",
             "min_trade_value",
+            "holdout_expectation",
         }
         unknown = set(request) - supported
         if unknown:
@@ -305,6 +389,7 @@ class Strategy:
             execution_mode=request.get("execution_mode"),
             min_weight_change=request.get("min_weight_change"),
             min_trade_value=request.get("min_trade_value"),
+            holdout_expectation=request.get("holdout_expectation"),
         )
 
     @property
@@ -463,11 +548,13 @@ class Strategy:
             }
         resolved = ensure_conformal_calibration_identity(spec)
         if self.split == "holdout":
-            from .lifecycle import _locked_strategy_projection
-
-            locked = self._active_lock_record()["strategy_spec"]
-            if _locked_strategy_projection(resolved) != _locked_strategy_projection(locked):
-                raise ValueError("holdout strategy does not match the locked validation strategy")
+            expected = self.holdout_expectation
+            if expected is None:
+                raise ValueError("holdout strategy execution requires a holdout_expectation")
+            if strategy_projection(resolved) != expected.strategy:
+                raise ValueError(
+                    "the holdout strategy does not match the selected validation strategy"
+                )
         return resolved
 
     def _funding_rates(self, prices: pl.DataFrame) -> pl.DataFrame | None:
@@ -657,10 +744,15 @@ class Strategy:
         spec = self._build_spec(resolved_prices, case_config, contract_specs)
         allocation = spec.get("strategy", {}).get("allocation", {})
         if self.split == "holdout" and allocation.get("method") == "conformal_weighted":
-            lock_record = self._active_lock_record()
+            # The calibration source is the selected VALIDATION prediction, which is a fact about
+            # the selection rather than about this execution, so it comes from the caller's
+            # expectation. __post_init__ has already refused a holdout without one.
+            expected = self.holdout_expectation
+            if expected is None:
+                raise ValueError("holdout strategy execution requires a holdout_expectation")
             compute_holdout_conformal_widths(
                 self.study.case_study,
-                lock_record["prediction_hash"],
+                expected.validation_prediction_hash,
                 self.prediction.hash,
                 alpha=float(allocation.get("alpha", 0.2)),
                 min_calibration_n=int(allocation["min_calibration_n"]),

--- a/tests/test_holdout_expectation.py
+++ b/tests/test_holdout_expectation.py
@@ -1,0 +1,145 @@
+"""What `Strategy` requires before it will execute a holdout backtest.
+
+A holdout prediction says nothing about which configuration was selected. Before this contract
+existed, that fact was supplied by a `research_locks` row in the `LOCKED` state, which made an
+authorization token a prerequisite for a computation - and made a holdout found to be wrong after
+a bug fix impossible to correct, because the lock is by construction the artifact that cannot be
+revised.
+
+`HoldoutExpectation` carries the same facts without the token: the caller states what it expects
+and `Strategy` compares. The test that matters most here is
+`test_a_holdout_without_an_expectation_is_refused`: if a missing expectation is anything other
+than a refusal, the guarantee is gone and every other test in this file still passes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from case_studies.research.strategy import HoldoutExpectation, Strategy
+
+SELECTED_STRATEGY: dict[str, Any] = {"strategy": {"signal": {"name": "rank"}}, "version": 2}
+
+
+@dataclass
+class _Prediction:
+    """The three things `Strategy.__post_init__` reads off a prediction."""
+
+    study: object
+    record: dict[str, Any]
+    complete: bool = True
+    execution_tier: str = "canonical"
+
+    def registry_record(self) -> dict[str, Any]:
+        return self.record
+
+
+def _holdout_prediction(
+    study: object,
+    *,
+    training_hash: str = "b02411b28bc5",
+    checkpoint_kind: str = "final",
+    checkpoint_value: int | None = None,
+) -> _Prediction:
+    return _Prediction(
+        study=study,
+        record={
+            "split": "holdout",
+            "training_hash": training_hash,
+            "checkpoint_kind": checkpoint_kind,
+            "checkpoint_value": checkpoint_value,
+        },
+    )
+
+
+def _expectation(**overrides: Any) -> HoldoutExpectation:
+    fields: dict[str, Any] = {
+        "training_hash": "b02411b28bc5",
+        "checkpoint_kind": "final",
+        "checkpoint_value": None,
+        "strategy": SELECTED_STRATEGY,
+        "validation_prediction_hash": "136bccd19c46",
+    }
+    fields.update(overrides)
+    return HoldoutExpectation(**fields)
+
+
+def _strategy(prediction: _Prediction, expectation: HoldoutExpectation | None) -> Strategy:
+    study = prediction.study
+    return Strategy(
+        study=study,  # type: ignore[arg-type]
+        prediction=prediction,  # type: ignore[arg-type]
+        signal={"name": "rank"},
+        holdout_expectation=expectation,
+    )
+
+
+def test_a_holdout_without_an_expectation_is_refused() -> None:
+    """The test that decides whether this is a contract or a formality.
+
+    A permissive fallback here - accepting any canonical holdout prediction when the caller
+    states nothing - would let a holdout produced from a configuration nobody selected be
+    executed and reported, which is exactly what the lock was standing in front of. Every other
+    test in this file passes under that fallback, so this one carries the guarantee alone.
+    """
+    study = object()
+    with pytest.raises(ValueError, match="requires a holdout_expectation"):
+        _strategy(_holdout_prediction(study), None)
+
+
+def test_a_holdout_whose_training_differs_from_the_expectation_is_refused() -> None:
+    study = object()
+    prediction = _holdout_prediction(study, training_hash="3cffc6db6c25")
+    with pytest.raises(ValueError, match="but the caller expects training b02411b28bc5"):
+        _strategy(prediction, _expectation())
+
+
+def test_a_holdout_at_the_wrong_checkpoint_is_refused() -> None:
+    """One training run registers one prediction set per declared checkpoint.
+
+    They share a training hash and a strategy specification, so the checkpoint is the only thing
+    that tells them apart, and a caller expecting one must not silently execute another.
+    """
+    study = object()
+    prediction = _holdout_prediction(study, checkpoint_kind="epoch", checkpoint_value=40)
+    with pytest.raises(ValueError, match="holdout prediction is training"):
+        _strategy(prediction, _expectation())
+
+
+def test_a_matching_expectation_constructs() -> None:
+    study = object()
+    strategy = _strategy(_holdout_prediction(study), _expectation())
+    assert strategy.holdout_expectation is not None
+    assert strategy.holdout_expectation.training_hash == "b02411b28bc5"
+
+
+def test_a_validation_prediction_needs_no_expectation() -> None:
+    """The contract is about holdout execution only.
+
+    Validation runs are ranked against each other and re-run freely, so requiring an expectation
+    there would be ceremony on the path that does not need it - and would break every existing
+    caller for no guarantee.
+    """
+    study = object()
+    prediction = _Prediction(
+        study=study,
+        record={
+            "split": "validation",
+            "training_hash": "72fd9f5cf07e",
+            "checkpoint_kind": "final",
+            "checkpoint_value": None,
+        },
+    )
+    assert _strategy(prediction, None).holdout_expectation is None
+
+
+def test_a_preview_holdout_prediction_is_refused_before_the_expectation_is_read() -> None:
+    """Tier is checked first: a preview holdout is not a holdout whatever the caller expects."""
+    study = object()
+    prediction = _holdout_prediction(study)
+    prediction.execution_tier = "preview"
+    with pytest.raises(ValueError, match="validation or canonical holdout predictions"):
+        _strategy(prediction, _expectation())

--- a/tests/test_holdout_expectation.py
+++ b/tests/test_holdout_expectation.py
@@ -143,3 +143,25 @@ def test_a_preview_holdout_prediction_is_refused_before_the_expectation_is_read(
     prediction.execution_tier = "preview"
     with pytest.raises(ValueError, match="validation or canonical holdout predictions"):
         _strategy(prediction, _expectation())
+
+
+def test_a_selection_derives_its_own_expectation_rather_than_reading_the_prediction() -> None:
+    """The expectation comes from the selection, never from the thing it is checking.
+
+    Building it from the holdout prediction's own record would make every comparison in
+    `Strategy.__post_init__` compare a value with itself, so the contract would pass on any
+    prediction handed to it and the tests above would still be green. `HoldoutSelection` derives
+    `holdout_training_hash` from the immutable candidate set - it is the identity the retrain
+    WILL have, computed before the retrain exists - which is what makes the comparison capable
+    of failing.
+    """
+    from case_studies.research.holdout import HoldoutSelection
+
+    derived = HoldoutSelection.expectation.__doc__ or ""
+    assert "immutable candidate set" in derived
+
+    fields = set(HoldoutSelection.__dataclass_fields__)
+    # The four facts the contract needs are all resolved onto the selection itself, so
+    # `expectation()` reads them rather than querying the prediction it is about to gate.
+    assert {"holdout_training_hash", "checkpoint_kind", "checkpoint_value"} <= fields
+    assert "validation_backtest" in fields and "validation_prediction" in fields

--- a/tests/test_holdout_expectation.py
+++ b/tests/test_holdout_expectation.py
@@ -19,9 +19,30 @@ from typing import Any
 
 import pytest
 
-from case_studies.research.strategy import HoldoutExpectation, Strategy
+from case_studies.research.strategy import (
+    HoldoutExpectation,
+    Strategy,
+    strategy_projection,
+)
 
 SELECTED_STRATEGY: dict[str, Any] = {"strategy": {"signal": {"name": "rank"}}, "version": 2}
+
+
+@dataclass
+class _Hashed:
+    """Something with a hash, which is all `expectation()` reads off a prediction."""
+
+    hash: str
+
+
+@dataclass
+class _Spec:
+    """Something with a `spec()`, which is all `expectation()` reads off a backtest."""
+
+    _spec: dict[str, Any]
+
+    def spec(self) -> dict[str, Any]:
+        return self._spec
 
 
 @dataclass
@@ -145,23 +166,64 @@ def test_a_preview_holdout_prediction_is_refused_before_the_expectation_is_read(
         _strategy(prediction, _expectation())
 
 
-def test_a_selection_derives_its_own_expectation_rather_than_reading_the_prediction() -> None:
-    """The expectation comes from the selection, never from the thing it is checking.
+def test_a_selection_derives_its_expectation_from_the_selection_not_the_prediction() -> None:
+    """The expectation comes from the selection, never from the thing it gates.
 
-    Building it from the holdout prediction's own record would make every comparison in
-    `Strategy.__post_init__` compare a value with itself, so the contract would pass on any
-    prediction handed to it and the tests above would still be green. `HoldoutSelection` derives
-    `holdout_training_hash` from the immutable candidate set - it is the identity the retrain
-    WILL have, computed before the retrain exists - which is what makes the comparison capable
-    of failing.
+    Built from the holdout prediction's own record, every comparison in
+    `Strategy.__post_init__` would compare a value with itself: the contract would accept any
+    prediction handed to it and every other test in this file would still pass. So the fields
+    here are all made distinguishable - the selection carries one set of values, and a decoy
+    prediction record carries another - and the assertion is that the expectation reports the
+    selection's.
     """
     from case_studies.research.holdout import HoldoutSelection
 
-    derived = HoldoutSelection.expectation.__doc__ or ""
-    assert "immutable candidate set" in derived
+    validation_backtest = _Spec({"strategy": {"signal": {"name": "rank"}}, "version": 2})
+    selection = HoldoutSelection(
+        study=object(),
+        candidate_set=object(),
+        validation_backtest=validation_backtest,  # type: ignore[arg-type]
+        validation_prediction=_Hashed("VALIDATION-PREDICTION"),  # type: ignore[arg-type]
+        validation_training=object(),
+        label="fwd_ret_21d",
+        checkpoint_kind="SELECTION-KIND",
+        checkpoint_value=7,
+        holdout_training_spec={"computation": {}},
+        holdout_training_hash="SELECTION-TRAINING",
+    )
 
-    fields = set(HoldoutSelection.__dataclass_fields__)
-    # The four facts the contract needs are all resolved onto the selection itself, so
-    # `expectation()` reads them rather than querying the prediction it is about to gate.
-    assert {"holdout_training_hash", "checkpoint_kind", "checkpoint_value"} <= fields
-    assert "validation_backtest" in fields and "validation_prediction" in fields
+    expectation = selection.expectation()
+
+    assert expectation.training_hash == "SELECTION-TRAINING"
+    assert expectation.checkpoint_kind == "SELECTION-KIND"
+    assert expectation.checkpoint_value == 7
+    assert expectation.validation_prediction_hash == "VALIDATION-PREDICTION"
+    # The projection of the selected validation strategy, not the raw spec: costs are kept and
+    # the fields that must differ between the two windows are dropped.
+    assert expectation.strategy == strategy_projection(validation_backtest.spec())
+
+
+def test_the_expectation_tracks_the_selection_when_the_selection_changes() -> None:
+    """Re-deriving after an upstream rebuild yields the current contract, not the retired one.
+
+    This is the property a research lock does not have, and it is why fx_pairs' rebuilt lineage
+    was refused by a lock recording a selection that no longer existed.
+    """
+    from case_studies.research.holdout import HoldoutSelection
+
+    def _selection(training_hash: str) -> HoldoutSelection:
+        return HoldoutSelection(
+            study=object(),
+            candidate_set=object(),
+            validation_backtest=_Spec(SELECTED_STRATEGY),  # type: ignore[arg-type]
+            validation_prediction=_Hashed("v"),  # type: ignore[arg-type]
+            validation_training=object(),
+            label="fwd_ret_21d",
+            checkpoint_kind="final",
+            checkpoint_value=None,
+            holdout_training_spec={"computation": {}},
+            holdout_training_hash=training_hash,
+        )
+
+    assert _selection("3cffc6db6c25").expectation().training_hash == "3cffc6db6c25"
+    assert _selection("b02411b28bc5").expectation().training_hash == "b02411b28bc5"

--- a/tests/test_locked_holdout_execution.py
+++ b/tests/test_locked_holdout_execution.py
@@ -866,9 +866,9 @@ def test_fitted_state_change_during_backtest_fails_before_staging(
 ) -> None:
     study, lock, prices = _locked_study(tmp_path, monkeypatch)
     _install_fixture_adapter(monkeypatch, prices)
-    from case_studies.research.holdout import LockedStrategyReplay
+    from case_studies.research.holdout import StrategyReplay
 
-    original_run = LockedStrategyReplay.run
+    original_run = StrategyReplay.run
 
     def run_then_change_fitted_state(self, prediction):
         result = original_run(self, prediction)
@@ -883,7 +883,7 @@ def test_fitted_state_change_during_backtest_fails_before_staging(
         model.write_bytes(b"changed-during-backtest")
         return result
 
-    monkeypatch.setattr(LockedStrategyReplay, "run", run_then_change_fitted_state)
+    monkeypatch.setattr(StrategyReplay, "run", run_then_change_fitted_state)
 
     with pytest.raises(ValueError, match="changed during holdout execution"):
         run_locked_holdout(lock)

--- a/tests/test_research_contract_lifecycle.py
+++ b/tests/test_research_contract_lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from datetime import UTC, date, datetime
 from pathlib import Path
 
@@ -20,6 +21,24 @@ from tests.test_research_contract_catalog import _publish, _resolved_spec
 from tests.test_research_flow import _patch_holdout_prices, _prices
 from tests.test_research_registry import _predictions
 from tests.test_research_workspace import _seed_release
+
+
+def _expectation_from_lock(lock):
+    """The holdout expectation a locked run states, derived from the lock it already holds.
+
+    `Strategy` no longer reads `research_locks`; the caller says what it expects. For a locked
+    run that is the lock's own contract, restated - so these tests exercise the same guarantee
+    they always did, now stated by the caller rather than looked up.
+    """
+    from case_studies.research.strategy import HoldoutExpectation, strategy_projection
+
+    return HoldoutExpectation(
+        training_hash=str(lock.record["holdout_training_hash"]),
+        checkpoint_kind=str(lock.record["checkpoint_kind"]),
+        checkpoint_value=lock.record["checkpoint_value"],
+        strategy=strategy_projection(deepcopy(lock.record["strategy_spec"])),
+        validation_prediction_hash=str(lock.record["prediction_hash"]),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -609,7 +628,9 @@ def test_holdout_stages_then_transitions_in_one_atomic_transaction(
         predictions=holdout_frame,
         expected_keys=holdout_frame.select("symbol", "timestamp", "fold_id"),
     )
-    holdout_backtest = study.strategy(prediction=holdout_prediction, **request).run()
+    holdout_backtest = study.strategy(
+        prediction=holdout_prediction, holdout_expectation=_expectation_from_lock(lock), **request
+    ).run()
 
     staged = study.lifecycle.stage_holdout(
         lock.hash,
@@ -663,14 +684,14 @@ def test_holdout_stages_then_transitions_in_one_atomic_transaction(
 def test_a_strategy_whose_only_declared_inputs_are_runtime_resolved_matches_one_with_none() -> None:
     """The projection has to erase runtime-resolved inputs, not leave the shape they were in.
 
-    `_locked_strategy_projection` compares a strategy being executed against the one the lock
+    `strategy_projection` compares a strategy being executed against the one the lock
     recorded, and it removes `prices` and `funding_rates` first because both are resolved at run
     time and would otherwise differ on every replay. A strategy that declared nothing else is
     then left with `input_identity: {}`, while one that declared no input identity at all is
     left with the key absent. The two describe the same strategy, so the comparison must not
     separate them - and it did, which made a crypto holdout replay refuse against its own lock.
     """
-    from case_studies.research.lifecycle import _locked_strategy_projection
+    from case_studies.research.strategy import strategy_projection
 
     runtime_only = {
         "chapter": "ch19",
@@ -678,9 +699,7 @@ def test_a_strategy_whose_only_declared_inputs_are_runtime_resolved_matches_one_
     }
     nothing_declared = {"chapter": "ch19"}
 
-    assert _locked_strategy_projection(runtime_only) == _locked_strategy_projection(
-        nothing_declared
-    )
+    assert strategy_projection(runtime_only) == strategy_projection(nothing_declared)
 
     # A declared input that is NOT runtime-resolved still separates them, or the projection
     # would erase a real difference along with the noise.
@@ -688,6 +707,4 @@ def test_a_strategy_whose_only_declared_inputs_are_runtime_resolved_matches_one_
         "chapter": "ch19",
         "input_identity": {"prices": "sha256:abc", "decision_grid": "sha256:123"},
     }
-    assert _locked_strategy_projection(with_real_input) != _locked_strategy_projection(
-        nothing_declared
-    )
+    assert strategy_projection(with_real_input) != strategy_projection(nothing_declared)

--- a/tests/test_research_flow.py
+++ b/tests/test_research_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sqlite3
 from contextlib import closing
+from copy import deepcopy
 from datetime import date
 from pathlib import Path
 
@@ -13,6 +14,24 @@ from case_studies.research import CandidateSet, PredictionResult, Result, Strate
 from case_studies.utils import conformal
 from tests.test_research_registry import _predictions, _training_spec
 from tests.test_research_workspace import _seed_release
+
+
+def _expectation_from_lock(lock):
+    """The holdout expectation a locked run states, derived from the lock it already holds.
+
+    `Strategy` no longer reads `research_locks`; the caller says what it expects. For a locked
+    run that is the lock's own contract, restated - so these tests exercise the same guarantee
+    they always did, now stated by the caller rather than looked up.
+    """
+    from case_studies.research.strategy import HoldoutExpectation, strategy_projection
+
+    return HoldoutExpectation(
+        training_hash=str(lock.record["holdout_training_hash"]),
+        checkpoint_kind=str(lock.record["checkpoint_kind"]),
+        checkpoint_value=lock.record["checkpoint_value"],
+        strategy=strategy_projection(deepcopy(lock.record["strategy_spec"])),
+        validation_prediction_hash=str(lock.record["prediction_hash"]),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -376,8 +395,15 @@ def test_locked_rolling_allocator_holdout_preserves_warmup_and_transitions_once(
         predictions=holdout_frame,
         expected_keys=holdout_expected,
     )
-    with pytest.raises(ValueError, match="locked retraining contract"):
-        study.strategy(prediction=wrong_checkpoint, **request)
+    # The same guarantee, now stated by the caller: the expectation names checkpoint 3 and this
+    # prediction is checkpoint 4 of the same training run. They share a training hash and a
+    # strategy specification, so the checkpoint is the only thing separating them.
+    with pytest.raises(ValueError, match="holdout prediction is training"):
+        study.strategy(
+            prediction=wrong_checkpoint,
+            holdout_expectation=_expectation_from_lock(lock),
+            **request,
+        )
 
     holdout_prediction = study.results.publish_predictions(
         holdout_training,
@@ -389,14 +415,20 @@ def test_locked_rolling_allocator_holdout_preserves_warmup_and_transitions_once(
     )
     holdout_backtest = study.strategy(
         prediction=holdout_prediction,
+        holdout_expectation=_expectation_from_lock(lock),
         **request,
     ).run()
 
     with pytest.raises(ValueError, match="canonical holdout prices"):
-        study.strategy(prediction=holdout_prediction, **request).run(prices=holdout_prices)
-    with pytest.raises(ValueError, match="locked validation strategy"):
         study.strategy(
             prediction=holdout_prediction,
+            holdout_expectation=_expectation_from_lock(lock),
+            **request,
+        ).run(prices=holdout_prices)
+    with pytest.raises(ValueError, match="selected validation strategy"):
+        study.strategy(
+            prediction=holdout_prediction,
+            holdout_expectation=_expectation_from_lock(lock),
             signal={"method": "equal_weight_top_k", "top_k": 2},
             allocation={"method": "inverse_vol", "vol_window": 2},
             execution_mode="vectorized",
@@ -516,7 +548,9 @@ def test_locked_conformal_holdout_uses_validation_residuals(
         expected_keys=holdout_frame.select("symbol", "timestamp", "fold_id"),
     )
 
-    holdout_backtest = study.strategy(prediction=holdout_prediction, **request).run()
+    holdout_backtest = study.strategy(
+        prediction=holdout_prediction, holdout_expectation=_expectation_from_lock(lock), **request
+    ).run()
     widths = pl.read_parquet(
         study.root
         / "run_log"


### PR DESCRIPTION
`Strategy.__post_init__` required a `research_locks` row in the `LOCKED` state before it would execute any holdout backtest. That made an authorization token a prerequisite for a computation, and the cost was not the code: a holdout found to be wrong after a bug fix could not be corrected, because the lock is by construction the one artifact that cannot be revised. It also refuses correct holdouts produced outside the lock transaction - `fx_pairs`' rebuilt lineage is refused today by a lock recording a selection that no longer exists.

## What replaces it

`HoldoutExpectation` carries the facts the lock was standing in for, as an argument rather than a token:

- the retrain's **own** training hash - never the validation model's, which a genuine retrain does not share
- the checkpoint pair, which is the only thing separating two prediction sets of one training run
- `strategy_projection` of the selected validation strategy
- the validation prediction a conformal allocator calibrates its holdout widths from

**Both guarantees move, not just the first.** Matching the model alone would let a caller replay a different strategy on the correct model - a different route to the same wrong answer - so `_build_spec` compares the resolved holdout strategy against the expectation's projection.

**There is no default.** A holdout prediction with no expectation is refused. A fallback to "accept any canonical holdout prediction" would leave the constructor executing a holdout produced from a configuration nobody selected, which is the failure this exists to prevent.

## Evidence that the refusal is load-bearing

Replacing the refusal with a permissive branch fails exactly one named test - `test_a_holdout_without_an_expectation_is_refused` - and leaves the other five green. That mutation check is what distinguishes this from merely deleting the lock check.

The same check was applied to the derivation: mutating `HoldoutSelection.expectation()` to read the holdout prediction it gates, instead of the selection, fails the two derivation tests and leaves the other six green. An expectation built from the prediction would compare every value with itself and accept anything handed to it.

## The lock-free caller

`resolve_holdout_selection` derives the whole lineage from the immutable candidate set: the rank-1 validation backtest read from the set rather than accepted from a caller, the holdout training spec re-keyed onto the derived fold, and the training identity that retrain *will* have - computed before the retrain exists. That is the property a lock does not have: re-deriving after an upstream rebuild yields the current contract, not the retired one.

`StrategyReplay` no longer holds a `ResearchLock`; it holds the four facts the replay consumes, all readable from the selected validation backtest. `prepare_locked_strategy_replay` is a wrapper that states the lock's own contract, and `run_locked_holdout` is unchanged, so the locked path keeps exactly the guarantee it had.

`_locked_strategy_projection` moves from `lifecycle.py` to `strategy.py` as public `strategy_projection`. It was private to the lock module, which is why a holdout produced outside that transaction had no way to state the guarantee at all.

## Scope - which execution paths this actually covers

This binds the `case_studies.research` API path. The older `case_studies.utils.backtest_runner.run_backtest` path - which `us_firm_characteristics/16_holdout_backtest` uses - never had the lock check and does not gain this contract, so the two paths make different promises about the same holdout. Closing that is separate work; do not read "a missing expectation is a refusal" as covering both.

## Tests

105 pass across `test_holdout_expectation`, `test_locked_holdout_execution`, `test_research_contract_lifecycle`, `test_research_flow` and `test_holdout_cv_derivation`.

`test_case_study_pipeline[etfs-18_strategy_analysis]` fails on clean `main` for an unrelated reason (the `val_rank1_self` anchor cannot be resolved), verified in a worktree at `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)