### PR TITLE
Equity-option analytics: the causal estimate the panel supports, not the one a 9.9% sample gave

### DIFF
--- a/case_studies/config/dml/dml.yaml
+++ b/case_studies/config/dml/dml.yaml
@@ -1,3 +1,13 @@
+# `max_samples` reaches a canonical causal run nowhere. `resolve_causal_request` ignores it
+# deliberately (`case_studies/utils/causal.py:1313-1318`); a cap arrives only as a declared
+# preview reduction, and a canonical request refuses those outright. So the key below is read
+# by the notebooks that still build their own specification and apply it by hand - etfs,
+# nasdaq100_microstructure and sp500_options - and by nothing else.
+#
+# It is not dead until those three convert, so it stays. Expect their estimates to move when
+# they do, and not only in magnitude: sp500_equity_option_analytics was fitting 37,240 of the
+# 376,871 rows its estimand admits, and taking the cap off flipped the sign of the point
+# estimate. Do not reintroduce the hand-application to keep an old number.
 max_samples: 50000
 n_folds: 5
 n_placebo: 100

--- a/case_studies/config/dml/dml.yaml
+++ b/case_studies/config/dml/dml.yaml
@@ -1,10 +1,10 @@
 # `max_samples` reaches a canonical causal run nowhere. `resolve_causal_request` ignores it
 # deliberately (`case_studies/utils/causal.py:1313-1318`); a cap arrives only as a declared
 # preview reduction, and a canonical request refuses those outright. So the key below is read
-# by the notebooks that still build their own specification and apply it by hand - etfs,
+# by the two notebooks that still build their own specification and apply it by hand -
 # nasdaq100_microstructure and sp500_options - and by nothing else.
 #
-# It is not dead until those three convert, so it stays. Expect their estimates to move when
+# It is not dead until those two convert, so it stays. Expect their estimates to move when
 # they do, and not only in magnitude: sp500_equity_option_analytics was fitting 37,240 of the
 # 376,871 rows its estimand admits, and taking the cap off flipped the sign of the point
 # estimate. Do not reintroduce the hand-application to keep an old number.

--- a/case_studies/config/dml/dml_250k.yaml
+++ b/case_studies/config/dml/dml_250k.yaml
@@ -1,3 +1,6 @@
+# `max_samples` reaches a canonical causal run nowhere - see the note in `dml.yaml`. The one
+# case study on this configuration, us_firm_characteristics, resolves through the shared causal
+# request, so the cap below is read by nothing.
 max_samples: 250000
 n_folds: 5
 n_placebo: 100

--- a/case_studies/sp500_equity_option_analytics/12_causal_dml.ipynb
+++ b/case_studies/sp500_equity_option_analytics/12_causal_dml.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b0694c8c",
+   "id": "4bbecbb6",
    "metadata": {
     "papermill": {
-     "duration": 0.002443,
-     "end_time": "2026-08-31T02:26:49.090993+00:00",
+     "duration": 0.005534,
+     "end_time": "2026-08-31T04:16:26.399909+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:49.088550+00:00",
+     "start_time": "2026-08-31T04:16:26.394375+00:00",
      "status": "completed"
     }
    },
@@ -47,13 +47,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff479f0e",
+   "id": "0303f7a3",
    "metadata": {
     "papermill": {
-     "duration": 0.000851,
-     "end_time": "2026-08-31T02:26:49.093468+00:00",
+     "duration": 0.002318,
+     "end_time": "2026-08-31T04:16:26.406406+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:49.092617+00:00",
+     "start_time": "2026-08-31T04:16:26.404088+00:00",
      "status": "completed"
     }
    },
@@ -74,19 +74,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "abad54ec",
+   "id": "59a5745f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T02:26:49.097950Z",
-     "iopub.status.busy": "2026-08-31T02:26:49.097641Z",
-     "iopub.status.idle": "2026-08-31T02:26:52.401113Z",
-     "shell.execute_reply": "2026-08-31T02:26:52.400511Z"
+     "iopub.execute_input": "2026-08-31T04:16:26.410794Z",
+     "iopub.status.busy": "2026-08-31T04:16:26.410498Z",
+     "iopub.status.idle": "2026-08-31T04:16:35.296676Z",
+     "shell.execute_reply": "2026-08-31T04:16:35.295702Z"
     },
     "papermill": {
-     "duration": 3.307194,
-     "end_time": "2026-08-31T02:26:52.401764+00:00",
+     "duration": 8.889897,
+     "end_time": "2026-08-31T04:16:35.297742+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:49.094570+00:00",
+     "start_time": "2026-08-31T04:16:26.407845+00:00",
      "status": "completed"
     }
    },
@@ -108,19 +108,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e5096300",
+   "id": "24f24262",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T02:26:52.405035Z",
-     "iopub.status.busy": "2026-08-31T02:26:52.404933Z",
-     "iopub.status.idle": "2026-08-31T02:26:52.407610Z",
-     "shell.execute_reply": "2026-08-31T02:26:52.407116Z"
+     "iopub.execute_input": "2026-08-31T04:16:35.301507Z",
+     "iopub.status.busy": "2026-08-31T04:16:35.301252Z",
+     "iopub.status.idle": "2026-08-31T04:16:35.304723Z",
+     "shell.execute_reply": "2026-08-31T04:16:35.304327Z"
     },
     "papermill": {
-     "duration": 0.004304,
-     "end_time": "2026-08-31T02:26:52.407883+00:00",
+     "duration": 0.006374,
+     "end_time": "2026-08-31T04:16:35.305437+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:52.403579+00:00",
+     "start_time": "2026-08-31T04:16:35.299063+00:00",
      "status": "completed"
     },
     "tags": [
@@ -132,7 +132,6 @@
     "CASE_STUDY_ID = \"sp500_equity_option_analytics\"\n",
     "PRIMARY_LABEL = \"\"\n",
     "MAX_SYMBOLS = 0\n",
-    "RANDOM_SEED = 42\n",
     "CV_FOLDS = 0\n",
     "MAX_SAMPLES = 0\n",
     "N_PLACEBO = 0\n",
@@ -161,13 +160,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd5c6a0c",
+   "id": "a11011cf",
    "metadata": {
     "papermill": {
-     "duration": 0.000684,
-     "end_time": "2026-08-31T02:26:52.409371+00:00",
+     "duration": 0.001522,
+     "end_time": "2026-08-31T04:16:35.308990+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:52.408687+00:00",
+     "start_time": "2026-08-31T04:16:35.307468+00:00",
      "status": "completed"
     }
    },
@@ -182,19 +181,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "9e79332c",
+   "id": "1d59e945",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T02:26:52.411341Z",
-     "iopub.status.busy": "2026-08-31T02:26:52.411251Z",
-     "iopub.status.idle": "2026-08-31T02:26:56.302540Z",
-     "shell.execute_reply": "2026-08-31T02:26:56.301971Z"
+     "iopub.execute_input": "2026-08-31T04:16:35.312920Z",
+     "iopub.status.busy": "2026-08-31T04:16:35.312806Z",
+     "iopub.status.idle": "2026-08-31T04:16:49.526373Z",
+     "shell.execute_reply": "2026-08-31T04:16:49.525485Z"
     },
     "papermill": {
-     "duration": 3.89332,
-     "end_time": "2026-08-31T02:26:56.303412+00:00",
+     "duration": 14.216402,
+     "end_time": "2026-08-31T04:16:49.526990+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:52.410092+00:00",
+     "start_time": "2026-08-31T04:16:35.310588+00:00",
      "status": "completed"
     }
    },
@@ -207,13 +206,12 @@
       "Treatment: ivrv_spread\n",
       "Outcome: fwd_ret_5d (horizon 5 days 00:00:00)\n",
       "Confounders: rv_20, mom_21d, skew_rr_30_25d\n",
-      "Execution tier: canonical\n",
+      "Execution tier: canonical | seed 42\n",
       "Last admissible outcome endpoint: 2020-12-17T00:00:00\n"
      ]
     }
    ],
    "source": [
-    "set_global_seeds(RANDOM_SEED)\n",
     "setup = yaml.safe_load((get_case_study_dir(CASE_STUDY_ID) / \"config\" / \"setup.yaml\").read_text())\n",
     "label = PRIMARY_LABEL or setup[\"labels\"][\"primary\"]\n",
     "\n",
@@ -248,24 +246,31 @@
     "resolved = request.resolve()\n",
     "computation = resolved.spec[\"computation\"]\n",
     "estimand = computation[\"estimand\"]\n",
+    "# Seeded from the identity rather than from a notebook parameter. The seed the estimate depends\n",
+    "# on is `dml.yaml`'s, and it is in the resolved specification and therefore in the hash; a\n",
+    "# parameter beside it would be a dial a reader can turn that changes nothing, and worse, turning\n",
+    "# it would leave the identity untouched and reload the cached result under a seed it was not fit\n",
+    "# with. The nuisance estimator and the placebo permutation carry this seed explicitly; the global\n",
+    "# call covers whatever else in the stack reads a process-wide one.\n",
+    "set_global_seeds(int(resolved.spec[\"seed\"]))\n",
     "\n",
     "print(f\"Case study: {CASE_STUDY_ID}\")\n",
     "print(f\"Treatment: {estimand['treatment']}\")\n",
     "print(f\"Outcome: {estimand['outcome']} (horizon {estimand['outcome_horizon']})\")\n",
     "print(f\"Confounders: {', '.join(estimand['confounders'])}\")\n",
-    "print(f\"Execution tier: {tier.value}\")\n",
+    "print(f\"Execution tier: {tier.value} | seed {resolved.spec['seed']}\")\n",
     "print(f\"Last admissible outcome endpoint: {estimand['holdout_endpoint_cutoff']}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "164f18e9",
+   "id": "0fec6a98",
    "metadata": {
     "papermill": {
-     "duration": 0.002251,
-     "end_time": "2026-08-31T02:26:56.307569+00:00",
+     "duration": 0.001795,
+     "end_time": "2026-08-31T04:16:49.530559+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:56.305318+00:00",
+     "start_time": "2026-08-31T04:16:49.528764+00:00",
      "status": "completed"
     }
    },
@@ -285,13 +290,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1ad93b6",
+   "id": "3ad43298",
    "metadata": {
     "papermill": {
-     "duration": 0.001687,
-     "end_time": "2026-08-31T02:26:56.311093+00:00",
+     "duration": 0.00118,
+     "end_time": "2026-08-31T04:16:49.533300+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:56.309406+00:00",
+     "start_time": "2026-08-31T04:16:49.532120+00:00",
      "status": "completed"
     }
    },
@@ -325,19 +330,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "ae2f3ef0",
+   "id": "e1b6b1cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T02:26:56.316066Z",
-     "iopub.status.busy": "2026-08-31T02:26:56.315820Z",
-     "iopub.status.idle": "2026-08-31T02:26:56.326574Z",
-     "shell.execute_reply": "2026-08-31T02:26:56.325731Z"
+     "iopub.execute_input": "2026-08-31T04:16:49.537643Z",
+     "iopub.status.busy": "2026-08-31T04:16:49.537438Z",
+     "iopub.status.idle": "2026-08-31T04:16:49.544384Z",
+     "shell.execute_reply": "2026-08-31T04:16:49.543942Z"
     },
     "papermill": {
-     "duration": 0.014346,
-     "end_time": "2026-08-31T02:26:56.327125+00:00",
+     "duration": 0.010497,
+     "end_time": "2026-08-31T04:16:49.545386+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:56.312779+00:00",
+     "start_time": "2026-08-31T04:16:49.534889+00:00",
      "status": "completed"
     }
    },
@@ -397,13 +402,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41f98411",
+   "id": "b628becc",
    "metadata": {
     "papermill": {
-     "duration": 0.001603,
-     "end_time": "2026-08-31T02:26:56.330825+00:00",
+     "duration": 0.001723,
+     "end_time": "2026-08-31T04:16:49.549290+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:56.329222+00:00",
+     "start_time": "2026-08-31T04:16:49.547567+00:00",
      "status": "completed"
     }
    },
@@ -418,19 +423,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "71a60449",
+   "id": "6378b6a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T02:26:56.335838Z",
-     "iopub.status.busy": "2026-08-31T02:26:56.335560Z",
-     "iopub.status.idle": "2026-08-31T02:26:57.375728Z",
-     "shell.execute_reply": "2026-08-31T02:26:57.374700Z"
+     "iopub.execute_input": "2026-08-31T04:16:49.554119Z",
+     "iopub.status.busy": "2026-08-31T04:16:49.553929Z",
+     "iopub.status.idle": "2026-08-31T04:16:51.925063Z",
+     "shell.execute_reply": "2026-08-31T04:16:51.924522Z"
     },
     "papermill": {
-     "duration": 1.043983,
-     "end_time": "2026-08-31T02:26:57.376401+00:00",
+     "duration": 2.37468,
+     "end_time": "2026-08-31T04:16:51.925807+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:56.332418+00:00",
+     "start_time": "2026-08-31T04:16:49.551127+00:00",
      "status": "completed"
     },
     "tags": [
@@ -465,13 +470,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c354670",
+   "id": "a5ac5b44",
    "metadata": {
     "papermill": {
-     "duration": 0.001925,
-     "end_time": "2026-08-31T02:26:57.381652+00:00",
+     "duration": 0.005545,
+     "end_time": "2026-08-31T04:16:51.934192+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:57.379727+00:00",
+     "start_time": "2026-08-31T04:16:51.928647+00:00",
      "status": "completed"
     }
    },
@@ -515,19 +520,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "57e7e24a",
+   "id": "cefbe21c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T02:26:57.386945Z",
-     "iopub.status.busy": "2026-08-31T02:26:57.386576Z",
-     "iopub.status.idle": "2026-08-31T02:26:57.391719Z",
-     "shell.execute_reply": "2026-08-31T02:26:57.391112Z"
+     "iopub.execute_input": "2026-08-31T04:16:51.946335Z",
+     "iopub.status.busy": "2026-08-31T04:16:51.945964Z",
+     "iopub.status.idle": "2026-08-31T04:16:51.952456Z",
+     "shell.execute_reply": "2026-08-31T04:16:51.951799Z"
     },
     "papermill": {
-     "duration": 0.008703,
-     "end_time": "2026-08-31T02:26:57.392230+00:00",
+     "duration": 0.013109,
+     "end_time": "2026-08-31T04:16:51.952816+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:57.383527+00:00",
+     "start_time": "2026-08-31T04:16:51.939707+00:00",
      "status": "completed"
     }
    },
@@ -570,13 +575,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b88a38c2",
+   "id": "9dcb0969",
    "metadata": {
     "papermill": {
-     "duration": 0.001744,
-     "end_time": "2026-08-31T02:26:57.396183+00:00",
+     "duration": 0.001191,
+     "end_time": "2026-08-31T04:16:51.955449+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:57.394439+00:00",
+     "start_time": "2026-08-31T04:16:51.954258+00:00",
      "status": "completed"
     }
    },
@@ -602,13 +607,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bef4977a",
+   "id": "2d630819",
    "metadata": {
     "papermill": {
-     "duration": 0.00174,
-     "end_time": "2026-08-31T02:26:57.399802+00:00",
+     "duration": 0.00236,
+     "end_time": "2026-08-31T04:16:51.958874+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:57.398062+00:00",
+     "start_time": "2026-08-31T04:16:51.956514+00:00",
      "status": "completed"
     }
    },
@@ -622,19 +627,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "37dd2509",
+   "id": "c6416012",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T02:26:57.405125Z",
-     "iopub.status.busy": "2026-08-31T02:26:57.404898Z",
-     "iopub.status.idle": "2026-08-31T02:26:57.604182Z",
-     "shell.execute_reply": "2026-08-31T02:26:57.603544Z"
+     "iopub.execute_input": "2026-08-31T04:16:51.982484Z",
+     "iopub.status.busy": "2026-08-31T04:16:51.981757Z",
+     "iopub.status.idle": "2026-08-31T04:16:52.355457Z",
+     "shell.execute_reply": "2026-08-31T04:16:52.354407Z"
     },
     "papermill": {
-     "duration": 0.202998,
-     "end_time": "2026-08-31T02:26:57.604755+00:00",
+     "duration": 0.389089,
+     "end_time": "2026-08-31T04:16:52.356529+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:57.401757+00:00",
+     "start_time": "2026-08-31T04:16:51.967440+00:00",
      "status": "completed"
     }
    },
@@ -690,13 +695,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7658067",
+   "id": "d73583c7",
    "metadata": {
     "papermill": {
-     "duration": 0.001852,
-     "end_time": "2026-08-31T02:26:57.608950+00:00",
+     "duration": 0.002404,
+     "end_time": "2026-08-31T04:16:52.362308+00:00",
      "exception": false,
-     "start_time": "2026-08-31T02:26:57.607098+00:00",
+     "start_time": "2026-08-31T04:16:52.359904+00:00",
      "status": "completed"
     }
    },
@@ -713,8 +718,9 @@
     "   cross-sectional dependence.\n",
     "\n",
     "3. **Compare naive OLS and DML on the same rows**: `confounding_bias_pct` is the gap\n",
-    "   between them as a share of the adjusted estimate. Both are computed on the same\n",
-    "   analysis population, so the difference is adjustment rather than sample.\n",
+    "   between them as a share of the adjusted estimate. Both are computed on the cross-fitted\n",
+    "   observations - the smaller of the two counts reported above, not the analysis population\n",
+    "   - so the difference between them is adjustment rather than sample.\n",
     "\n",
     "4. **The estimand is part of the identity**: treatment, confounders, temporal geometry and\n",
     "   refutation design all enter the hashed specification, so a run at a different block size,\n",
@@ -751,19 +757,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 12.182323,
-   "end_time": "2026-08-31T02:27:00.462853+00:00",
+   "duration": 30.870894,
+   "end_time": "2026-08-31T04:16:55.445550+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "case_studies/sp500_equity_option_analytics/12_causal_dml.ipynb",
-   "output_path": "~/scratch/prod_12_causal_dml_3958857.ipynb",
+   "output_path": "~/scratch/prod_12_causal_dml_323313.ipynb",
    "parameters": {},
-   "start_time": "2026-08-31T02:26:48.280530+00:00",
+   "start_time": "2026-08-31T04:16:24.574656+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "fa414096811ad65e94eea8401ae44e0afb59a731",
-   "executed_at": "2026-08-31T02:27:01.643295+00:00",
+   "source_py_blob": "6f796190c0177462121b0d2f08e7d538bef91daf",
+   "executed_at": "2026-08-31T04:16:58.302395+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/sp500_equity_option_analytics/12_causal_dml.ipynb
+++ b/case_studies/sp500_equity_option_analytics/12_causal_dml.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e8d22cfa",
+   "id": "b0694c8c",
    "metadata": {
     "papermill": {
-     "duration": 0.002136,
-     "end_time": "2026-08-29T12:59:13.447505+00:00",
+     "duration": 0.002443,
+     "end_time": "2026-08-31T02:26:49.090993+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:13.445369+00:00",
+     "start_time": "2026-08-31T02:26:49.088550+00:00",
      "status": "completed"
     }
    },
@@ -27,9 +27,17 @@
     "30d) confound this relationship because all three co-move with investor fear\n",
     "and positioning.\n",
     "\n",
+    "The estimand, the analysis population, the cross-fitting geometry and the\n",
+    "refutation design are resolved by the shared causal request rather than\n",
+    "assembled here. The request verifies that the treatment and every confounder\n",
+    "exist, excludes outcomes whose horizon reaches the holdout, keeps complete\n",
+    "decision-time panels, cross-fits with an embargo, and records the placebo\n",
+    "block design in the causal identity. This notebook inspects what it resolved,\n",
+    "runs it, and reports the result.\n",
+    "\n",
     "**Learning Objectives**:\n",
     "- Keep the holdout outside an exploratory causal analysis\n",
-    "- Cross-fit a panel by complete decision time with a time-based embargo\n",
+    "- Read the estimand and its temporal controls off the resolved specification\n",
     "- Compare the adjusted estimate with naive OLS and a block-permutation null\n",
     "\n",
     "**Book Reference**: Chapter 15, Section 15.6 (Cross-Dataset Causal Evidence)\n",
@@ -39,13 +47,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d641656a",
+   "id": "ff479f0e",
    "metadata": {
     "papermill": {
-     "duration": 0.001148,
-     "end_time": "2026-08-29T12:59:13.450161+00:00",
+     "duration": 0.000851,
+     "end_time": "2026-08-31T02:26:49.093468+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:13.449013+00:00",
+     "start_time": "2026-08-31T02:26:49.092617+00:00",
      "status": "completed"
     }
    },
@@ -66,65 +74,53 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6022f624",
+   "id": "abad54ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:13.453543Z",
-     "iopub.status.busy": "2026-08-29T12:59:13.453433Z",
-     "iopub.status.idle": "2026-08-29T12:59:15.766993Z",
-     "shell.execute_reply": "2026-08-29T12:59:15.766487Z"
+     "iopub.execute_input": "2026-08-31T02:26:49.097950Z",
+     "iopub.status.busy": "2026-08-31T02:26:49.097641Z",
+     "iopub.status.idle": "2026-08-31T02:26:52.401113Z",
+     "shell.execute_reply": "2026-08-31T02:26:52.400511Z"
     },
     "papermill": {
-     "duration": 2.316629,
-     "end_time": "2026-08-29T12:59:15.767987+00:00",
+     "duration": 3.307194,
+     "end_time": "2026-08-31T02:26:52.401764+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:13.451358+00:00",
+     "start_time": "2026-08-31T02:26:49.094570+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "\"\"\"Causal DML walk-forward estimation with refutation tests.\"\"\"\n",
-    "\n",
-    "import warnings\n",
+    "\"\"\"Estimate and register the configured equity-option causal DML specification.\"\"\"\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import pandas as pd\n",
+    "import polars as pl\n",
     "import yaml\n",
     "\n",
-    "from case_studies.utils.causal import (\n",
-    "    classify_refutation,\n",
-    "    embargo_from_buffer,\n",
-    "    format_dml_summary,\n",
-    "    register_causal_run,\n",
-    "    run_dml_analysis,\n",
-    ")\n",
-    "from utils.artifact_specs import resolve_label_horizon\n",
-    "from utils.modeling import load_configs, load_modeling_dataset\n",
+    "from case_studies.research import ExecutionTier, causal_supersedes, open_study\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.reproducibility import set_global_seeds\n",
-    "from utils.style import COLORS, FIGSIZE, add_message_title\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\")"
+    "from utils.style import COLORS, FIGSIZE, add_message_title"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "80e14ae8",
+   "id": "e5096300",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:15.773621Z",
-     "iopub.status.busy": "2026-08-29T12:59:15.773519Z",
-     "iopub.status.idle": "2026-08-29T12:59:15.775705Z",
-     "shell.execute_reply": "2026-08-29T12:59:15.775234Z"
+     "iopub.execute_input": "2026-08-31T02:26:52.405035Z",
+     "iopub.status.busy": "2026-08-31T02:26:52.404933Z",
+     "iopub.status.idle": "2026-08-31T02:26:52.407610Z",
+     "shell.execute_reply": "2026-08-31T02:26:52.407116Z"
     },
     "papermill": {
-     "duration": 0.005487,
-     "end_time": "2026-08-29T12:59:15.776098+00:00",
+     "duration": 0.004304,
+     "end_time": "2026-08-31T02:26:52.407883+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:15.770611+00:00",
+     "start_time": "2026-08-31T02:26:52.403579+00:00",
      "status": "completed"
     },
     "tags": [
@@ -134,56 +130,71 @@
    "outputs": [],
    "source": [
     "CASE_STUDY_ID = \"sp500_equity_option_analytics\"\n",
+    "PRIMARY_LABEL = \"\"\n",
     "MAX_SYMBOLS = 0\n",
-    "# Each of these is zero or empty for \"take the declared value\". A run that passes one\n",
-    "# overrides the declaration; a run that passes none reproduces the published analysis.\n",
-    "LABEL = \"\"\n",
-    "SEED = 0\n",
-    "N_FOLDS = 0\n",
+    "RANDOM_SEED = 42\n",
+    "CV_FOLDS = 0\n",
     "MAX_SAMPLES = 0\n",
-    "N_PLACEBO = 0"
+    "N_PLACEBO = 0\n",
+    "FORCE_RETRAIN = False\n",
+    "# The tier is declared, not inferred from whether a reduction happens to be set: a reduced run\n",
+    "# that still opened the case study's own artifacts in place would be writing down the\n",
+    "# production path. WORKSPACE is the other half - a preview has nowhere else to write.\n",
+    "EXECUTION_TIER = \"canonical\"\n",
+    "WORKSPACE: str | None = None\n",
+    "# Empty because this registry holds no *current* causal identity for the label, not because\n",
+    "# nothing came before. `b47bd0ec208a` is the capped fit of 2026-08-26 - 37,240 rows, 9.9% of\n",
+    "# the panel this request resolves - and it was written by the previous notebook under a spec\n",
+    "# with no `identity_version`, so `current_causal_identities` does not return it and no reader\n",
+    "# resolves it. There is nothing to retire: it is stranded rather than superseded, and naming it\n",
+    "# would fail the write for declaring a predecessor that is not current.\n",
+    "#\n",
+    "# Declare the hash here once this run leaves a current identity and a later change moves it -\n",
+    "# a refit under a changed block size, fold count or population - or registration refuses the\n",
+    "# write after the fit and all 100 placebo refits have been paid for. `causal_supersedes` then\n",
+    "# withholds the declaration against a reader's clone, which holds no causal rows at all, so one\n",
+    "# committed value is right for both. That resolution has to happen against the registry rather\n",
+    "# than at run time: `run-production-notebook.sh` executes with no parameter overrides, so a\n",
+    "# value supplied only as an override could never be stamped.\n",
+    "SUPERSEDES_CAUSAL: str = \"\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "64ec4de1",
+   "id": "dd5c6a0c",
    "metadata": {
     "papermill": {
-     "duration": 0.001148,
-     "end_time": "2026-08-29T12:59:15.778678+00:00",
+     "duration": 0.000684,
+     "end_time": "2026-08-31T02:26:52.409371+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:15.777530+00:00",
+     "start_time": "2026-08-31T02:26:52.408687+00:00",
      "status": "completed"
     }
    },
    "source": [
-    "### What is asked for, and what it resolves to\n",
+    "## Resolve the estimand and analysis population\n",
     "\n",
-    "The parameters above are the request. The values the analysis runs on are resolved below and\n",
-    "carry different names, so the two can be read side by side and neither can quietly overwrite\n",
-    "the other. Precedence is: an injected parameter wins, otherwise the case study's declaration.\n",
-    "\n",
-    "The declaration is read with `[...]` rather than `.get(key, literal)`. A literal default here\n",
-    "would substitute a number the case study never declared - silently, and only on the\n",
-    "configurations that happen to omit the key - so a missing key raises instead."
+    "Nonzero fold, sample, symbol, or placebo limits declare a preview. They are recorded in\n",
+    "identity and excluded from canonical evidence, so the published estimate cannot silently be a\n",
+    "reduced one."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "0cf81a34",
+   "id": "9e79332c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:15.781675Z",
-     "iopub.status.busy": "2026-08-29T12:59:15.781597Z",
-     "iopub.status.idle": "2026-08-29T12:59:15.797061Z",
-     "shell.execute_reply": "2026-08-29T12:59:15.796658Z"
+     "iopub.execute_input": "2026-08-31T02:26:52.411341Z",
+     "iopub.status.busy": "2026-08-31T02:26:52.411251Z",
+     "iopub.status.idle": "2026-08-31T02:26:56.302540Z",
+     "shell.execute_reply": "2026-08-31T02:26:56.301971Z"
     },
     "papermill": {
-     "duration": 0.017572,
-     "end_time": "2026-08-29T12:59:15.797468+00:00",
+     "duration": 3.89332,
+     "end_time": "2026-08-31T02:26:56.303412+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:15.779896+00:00",
+     "start_time": "2026-08-31T02:26:52.410092+00:00",
      "status": "completed"
     }
    },
@@ -192,197 +203,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DML config: dml\n",
-      "  folds 5 | placebo reps 100 | row cap 50,000 | seed 42\n"
+      "Case study: sp500_equity_option_analytics\n",
+      "Treatment: ivrv_spread\n",
+      "Outcome: fwd_ret_5d (horizon 5 days 00:00:00)\n",
+      "Confounders: rv_20, mom_21d, skew_rr_30_25d\n",
+      "Execution tier: canonical\n",
+      "Last admissible outcome endpoint: 2020-12-17T00:00:00\n"
      ]
     }
    ],
    "source": [
-    "CASE_DIR = get_case_study_dir(CASE_STUDY_ID)\n",
-    "\n",
-    "setup = yaml.safe_load((CASE_DIR / \"config\" / \"setup.yaml\").read_text())\n",
-    "PRIMARY_LABEL = LABEL or setup[\"labels\"][\"primary\"]\n",
-    "\n",
-    "causal_configs = load_configs(CASE_STUDY_ID, PRIMARY_LABEL, \"causal_dml\")\n",
-    "dml_cfg = causal_configs[0]\n",
-    "\n",
-    "CV_FOLDS = N_FOLDS or int(dml_cfg[\"n_folds\"])\n",
-    "PLACEBO_REPS = N_PLACEBO or int(dml_cfg[\"n_placebo\"])\n",
-    "ROW_CAP = MAX_SAMPLES or int(dml_cfg[\"max_samples\"])\n",
-    "RANDOM_SEED = SEED or int(dml_cfg[\"seed\"])\n",
-    "\n",
-    "print(f\"DML config: {dml_cfg['config_name']}\")\n",
-    "print(\n",
-    "    f\"  folds {CV_FOLDS} | placebo reps {PLACEBO_REPS} | row cap {ROW_CAP:,} | seed {RANDOM_SEED}\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "987a5a88",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001265,
-     "end_time": "2026-08-29T12:59:15.800198+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T12:59:15.798933+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "The case-study configuration defines the treatment and confounders. Keeping\n",
-    "these choices visible makes the conditional estimand explicit."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "d7de825b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:15.803192Z",
-     "iopub.status.busy": "2026-08-29T12:59:15.803118Z",
-     "iopub.status.idle": "2026-08-29T12:59:15.836126Z",
-     "shell.execute_reply": "2026-08-29T12:59:15.835692Z"
-    },
-    "papermill": {
-     "duration": 0.035135,
-     "end_time": "2026-08-29T12:59:15.836575+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T12:59:15.801440+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Causal DML Configuration:\n",
-      "  Case study: sp500_equity_option_analytics\n",
-      "  Treatment: ivrv_spread\n",
-      "  Outcome: fwd_ret_5d\n",
-      "  Confounders: ['rv_20', 'mom_21d', 'skew_rr_30_25d']\n",
-      "  CV folds: 5\n",
-      "  Placebo reps: 100\n"
-     ]
-    }
-   ],
-   "source": [
-    "causal_cfg = setup.get(\"causal\", {})\n",
-    "TREATMENT_COL = causal_cfg.get(\"treatment\", \"\")\n",
-    "CONFOUNDER_COLS = causal_cfg.get(\"confounders\", [])\n",
-    "DML_METHOD = causal_cfg.get(\"method\", \"walk_forward_dml\")\n",
-    "\n",
-    "if not TREATMENT_COL:\n",
-    "    raise ValueError(\n",
-    "        f\"No causal.treatment in {CASE_STUDY_ID}/setup.yaml. \"\n",
-    "        \"Add a 'causal:' section with treatment and confounders.\"\n",
-    "    )\n",
-    "\n",
     "set_global_seeds(RANDOM_SEED)\n",
+    "setup = yaml.safe_load((get_case_study_dir(CASE_STUDY_ID) / \"config\" / \"setup.yaml\").read_text())\n",
+    "label = PRIMARY_LABEL or setup[\"labels\"][\"primary\"]\n",
     "\n",
-    "print(\"Causal DML Configuration:\")\n",
-    "print(f\"  Case study: {CASE_STUDY_ID}\")\n",
-    "print(f\"  Treatment: {TREATMENT_COL}\")\n",
-    "print(f\"  Outcome: {PRIMARY_LABEL}\")\n",
-    "print(f\"  Confounders: {CONFOUNDER_COLS}\")\n",
-    "print(f\"  CV folds: {CV_FOLDS}\")\n",
-    "print(f\"  Placebo reps: {PLACEBO_REPS}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f1977859",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001257,
-     "end_time": "2026-08-29T12:59:15.839297+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T12:59:15.838040+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## 1. Load Artifacts\n",
+    "if FORCE_RETRAIN:\n",
+    "    raise ValueError(\"an identical complete causal request is reused; change the request to refit\")\n",
     "\n",
-    "Load pre-computed features, temporal features, and labels using the\n",
-    "shared modeling infrastructure."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "e60b5e93",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:15.842314Z",
-     "iopub.status.busy": "2026-08-29T12:59:15.842231Z",
-     "iopub.status.idle": "2026-08-29T12:59:16.827220Z",
-     "shell.execute_reply": "2026-08-29T12:59:16.826766Z"
-    },
-    "papermill": {
-     "duration": 0.987014,
-     "end_time": "2026-08-29T12:59:16.827585+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T12:59:15.840571+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Dataset: 478,233 rows x 48 features\n",
-      "Label: fwd_ret_5d | Date: timestamp | Entities: ['symbol']\n"
-     ]
-    }
-   ],
-   "source": [
-    "mds = load_modeling_dataset(CASE_STUDY_ID, PRIMARY_LABEL, max_symbols=MAX_SYMBOLS)\n",
+    "REDUCTION_PARAMETERS = {\n",
+    "    \"max_symbols\": MAX_SYMBOLS or None,\n",
+    "    \"n_folds\": CV_FOLDS or None,\n",
+    "    \"max_samples\": MAX_SAMPLES or None,\n",
+    "    \"n_placebo\": N_PLACEBO or None,\n",
+    "}\n",
+    "reductions = {key: value for key, value in REDUCTION_PARAMETERS.items() if value is not None}\n",
+    "tier = ExecutionTier(EXECUTION_TIER)\n",
+    "if tier is ExecutionTier.PREVIEW and not reductions:\n",
+    "    raise ValueError(\"preview execution must declare at least one reduction\")\n",
+    "if tier is ExecutionTier.CANONICAL and reductions:\n",
+    "    raise ValueError(f\"canonical execution cannot carry reductions: {sorted(reductions)}\")\n",
     "\n",
-    "dataset = mds.dataset\n",
-    "feature_names = mds.feature_names\n",
-    "label_col = mds.label_col\n",
-    "date_col = mds.date_col\n",
-    "entity_cols = mds.entity_cols\n",
-    "\n",
-    "# Verify treatment and confounders are in features\n",
-    "available = set(dataset.columns)\n",
-    "assert TREATMENT_COL in available, (\n",
-    "    f\"Treatment '{TREATMENT_COL}' not found in features: {sorted(available)}\"\n",
+    "study = open_study(CASE_STUDY_ID, execution_tier=tier, workspace=WORKSPACE or None)\n",
+    "request = study.causal(\n",
+    "    method=\"dml\",\n",
+    "    label=label,\n",
+    "    config_name=\"dml\",\n",
+    "    execution_tier=tier,\n",
+    "    preview_reductions=reductions,\n",
+    "    overrides={},\n",
+    "    supersedes=causal_supersedes(\n",
+    "        study, SUPERSEDES_CAUSAL, label, labels=[label], execution_tier=tier.value\n",
+    "    ),\n",
     ")\n",
+    "resolved = request.resolve()\n",
+    "computation = resolved.spec[\"computation\"]\n",
+    "estimand = computation[\"estimand\"]\n",
     "\n",
-    "missing_conf = [c for c in CONFOUNDER_COLS if c not in available]\n",
-    "if missing_conf:\n",
-    "    print(f\"WARNING: Missing confounders {missing_conf}, dropping them\")\n",
-    "    CONFOUNDER_COLS = [c for c in CONFOUNDER_COLS if c in available]\n",
-    "\n",
-    "assert len(CONFOUNDER_COLS) >= 1, \"Need at least 1 confounder for DML\"\n",
-    "\n",
-    "print(f\"\\nDataset: {len(dataset):,} rows x {len(feature_names)} features\")\n",
-    "print(f\"Label: {label_col} | Date: {date_col} | Entities: {entity_cols}\")"
+    "print(f\"Case study: {CASE_STUDY_ID}\")\n",
+    "print(f\"Treatment: {estimand['treatment']}\")\n",
+    "print(f\"Outcome: {estimand['outcome']} (horizon {estimand['outcome_horizon']})\")\n",
+    "print(f\"Confounders: {', '.join(estimand['confounders'])}\")\n",
+    "print(f\"Execution tier: {tier.value}\")\n",
+    "print(f\"Last admissible outcome endpoint: {estimand['holdout_endpoint_cutoff']}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "27fcaf87",
+   "id": "164f18e9",
    "metadata": {
     "papermill": {
-     "duration": 0.001479,
-     "end_time": "2026-08-29T12:59:16.830768+00:00",
+     "duration": 0.002251,
+     "end_time": "2026-08-31T02:26:56.307569+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:16.829289+00:00",
+     "start_time": "2026-08-31T02:26:56.305318+00:00",
      "status": "completed"
     }
    },
    "source": [
-    "## 2. Prepare Analysis Data\n",
-    "\n",
-    "Convert to pandas, seal the holdout, sort by time and entity, and retain the\n",
-    "most recent complete decision times when the production cap applies.\n",
+    "> **Scope**: This is a development-period sensitivity analysis, not a holdout\n",
+    "> evaluation. The request excludes every observation whose outcome window could\n",
+    "> reach past `holdout_endpoint_cutoff`, and it keeps complete cross-sections, so\n",
+    "> neither folds nor embargoes cut through a decision time.\n",
     "\n",
     "> **Population scope**: The source universe is a current-constituent roster,\n",
     "> not point-in-time S&P 500 membership. Firms removed from the index before\n",
@@ -393,199 +284,250 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "d5ab6041",
+   "cell_type": "markdown",
+   "id": "c1ad93b6",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:16.834014Z",
-     "iopub.status.busy": "2026-08-29T12:59:16.833918Z",
-     "iopub.status.idle": "2026-08-29T12:59:16.871676Z",
-     "shell.execute_reply": "2026-08-29T12:59:16.870920Z"
-    },
     "papermill": {
-     "duration": 0.040025,
-     "end_time": "2026-08-29T12:59:16.872110+00:00",
+     "duration": 0.001687,
+     "end_time": "2026-08-31T02:26:56.311093+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:16.832085+00:00",
+     "start_time": "2026-08-31T02:26:56.309406+00:00",
      "status": "completed"
     }
    },
-   "outputs": [],
    "source": [
-    "analysis_cols = [date_col] + entity_cols + [TREATMENT_COL, label_col] + CONFOUNDER_COLS\n",
-    "analysis_cols = list(dict.fromkeys(analysis_cols))  # deduplicate\n",
+    "## 1. Inspect the temporal controls\n",
     "\n",
-    "merged_clean = (\n",
-    "    dataset.select([c for c in analysis_cols if c in available])\n",
-    "    .drop_nulls()\n",
-    "    .sort(date_col)\n",
-    "    .to_pandas()\n",
+    "Three quantities decide how this estimate is measured, and they answer different questions.\n",
+    "\n",
+    "The **embargo** separates a fold's training window from its test window, so a label measured\n",
+    "in training cannot still be running when testing starts. `labels.buffer` sets it, and that\n",
+    "buffer is declared deliberately longer than the outcome it protects, so it is not a statement\n",
+    "about the outcome. The **outcome horizon** is how long one outcome stays open, and it is what\n",
+    "the Driscoll-Kraay bandwidth is sized by: a bandwidth shorter than the overlap between\n",
+    "successive outcomes understates the standard error. The **permutation block size** is the\n",
+    "scale of the dependence the placebo has to preserve: shuffling in blocks shorter than that\n",
+    "scale pulls dependent observations apart and the placebo degrades towards an independent draw\n",
+    "- the permutation that is too easy to pass and therefore proves nothing.\n",
+    "\n",
+    "**Two scales qualify for the block size, and it has to cover both.** One is the outcome\n",
+    "horizon. The other is the treatment's own persistence: `ivrv_spread` subtracts a 20-session\n",
+    "rolling realized volatility from implied, so consecutive values share most of their input and\n",
+    "stay dependent over that rolling window whatever the label does. It is the longer of the two\n",
+    "here, and `causal.treatment_window` in `config/setup.yaml` declares it beside the derivation\n",
+    "that produced it, because no rule can read a construction window off a column name.\n",
+    "\n",
+    "The table prints the block the run used beside both scales it has to span, read from the\n",
+    "resolved specification rather than from `setup.yaml`, so it shows what the run used rather\n",
+    "than what the file asks for."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ae2f3ef0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-31T02:26:56.316066Z",
+     "iopub.status.busy": "2026-08-31T02:26:56.315820Z",
+     "iopub.status.idle": "2026-08-31T02:26:56.326574Z",
+     "shell.execute_reply": "2026-08-31T02:26:56.325731Z"
+    },
+    "papermill": {
+     "duration": 0.014346,
+     "end_time": "2026-08-31T02:26:56.327125+00:00",
+     "exception": false,
+     "start_time": "2026-08-31T02:26:56.312779+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1, 14)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>cross_fitting_folds</th><th>embargo_periods</th><th>fold_unit</th><th>label_buffer_steps</th><th>label_horizon_steps</th><th>treatment_window_steps</th><th>placebo_method</th><th>placebo_block_size</th><th>block_size_basis</th><th>placebo_draws</th><th>analysis_rows</th><th>analysis_timestamps</th><th>analysis_key_digest</th></tr><tr><td>str</td><td>i64</td><td>i64</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>str</td><td>i64</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_5d&quot;</td><td>5</td><td>10</td><td>&quot;complete_timestamp_panel&quot;</td><td>10</td><td>5</td><td>20</td><td>&quot;within_symbol_contiguous_block…</td><td>20</td><td>&quot;treatment_window&quot;</td><td>100</td><td>376871</td><td>976</td><td>&quot;0be1c07ea5541f12&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (1, 14)\n",
+       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐\n",
+       "│ label     ┆ cross_fit ┆ embargo_p ┆ fold_unit ┆ … ┆ placebo_d ┆ analysis_ ┆ analysis_ ┆ analysis │\n",
+       "│ ---       ┆ ting_fold ┆ eriods    ┆ ---       ┆   ┆ raws      ┆ rows      ┆ timestamp ┆ _key_dig │\n",
+       "│ str       ┆ s         ┆ ---       ┆ str       ┆   ┆ ---       ┆ ---       ┆ s         ┆ est      │\n",
+       "│           ┆ ---       ┆ i64       ┆           ┆   ┆ i64       ┆ i64       ┆ ---       ┆ ---      │\n",
+       "│           ┆ i64       ┆           ┆           ┆   ┆           ┆           ┆ i64       ┆ str      │\n",
+       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
+       "│ fwd_ret_5 ┆ 5         ┆ 10        ┆ complete_ ┆ … ┆ 100       ┆ 376871    ┆ 976       ┆ 0be1c07e │\n",
+       "│ d         ┆           ┆           ┆ timestamp ┆   ┆           ┆           ┆           ┆ a5541f12 │\n",
+       "│           ┆           ┆           ┆ _panel    ┆   ┆           ┆           ┆           ┆          │\n",
+       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pl.DataFrame(\n",
+    "    {\n",
+    "        \"label\": [resolved.spec[\"label\"]],\n",
+    "        \"cross_fitting_folds\": [computation[\"cv\"][\"n_folds\"]],\n",
+    "        \"embargo_periods\": [computation[\"cv\"][\"embargo_periods\"]],\n",
+    "        \"fold_unit\": [computation[\"cv\"][\"fold_unit\"]],\n",
+    "        \"label_buffer_steps\": [computation[\"refutation\"][\"label_buffer_steps\"]],\n",
+    "        \"label_horizon_steps\": [computation[\"refutation\"][\"label_horizon_steps\"]],\n",
+    "        \"treatment_window_steps\": [computation[\"refutation\"][\"treatment_window_steps\"]],\n",
+    "        \"placebo_method\": [computation[\"refutation\"][\"method\"]],\n",
+    "        \"placebo_block_size\": [computation[\"refutation\"][\"block_size\"]],\n",
+    "        \"block_size_basis\": [computation[\"refutation\"][\"block_size_basis\"]],\n",
+    "        \"placebo_draws\": [computation[\"refutation\"][\"n_placebo\"]],\n",
+    "        \"analysis_rows\": [computation[\"analysis_population\"][\"n_rows\"]],\n",
+    "        \"analysis_timestamps\": [computation[\"analysis_population\"][\"n_timestamps\"]],\n",
+    "        \"analysis_key_digest\": [computation[\"analysis_population\"][\"key_digest\"]],\n",
+    "    }\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "73e80562",
+   "id": "41f98411",
    "metadata": {
     "papermill": {
-     "duration": 0.001337,
-     "end_time": "2026-08-29T12:59:16.875128+00:00",
+     "duration": 0.001603,
+     "end_time": "2026-08-31T02:26:56.330825+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:16.873791+00:00",
+     "start_time": "2026-08-31T02:26:56.329222+00:00",
      "status": "completed"
     }
    },
    "source": [
-    "The forward-label buffer closes the development sample early enough that no\n",
-    "outcome interval crosses into the holdout."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "88aa94a8",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00122,
-     "end_time": "2026-08-29T12:59:16.877671+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T12:59:16.876451+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "Three quantities decide how this estimate is measured, and they answer different questions.\n",
+    "## 2. Estimate or reload the causal result\n",
     "\n",
-    "The **embargo** separates a fold's training window from its test window, so a label measured in\n",
-    "training cannot still be running when testing starts. `labels.buffer` sets it, and that buffer is\n",
-    "declared deliberately longer than the outcome it protects, so it is not a statement about the\n",
-    "outcome. The **outcome horizon** is how long one outcome stays open: `labels.horizons` names it\n",
-    "per label, and for the primary label it is the shorter of the two. The **permutation block size** is the scale of the dependence\n",
-    "the placebo has to preserve: shuffling in blocks shorter than that scale pulls dependent\n",
-    "observations apart, and the placebo degrades towards an independent draw - the permutation that\n",
-    "is too easy to pass and therefore proves nothing.\n",
-    "\n",
-    "**Two scales qualify for the block size, and it has to cover both.** One is the outcome horizon.\n",
-    "The other is the treatment's own persistence: `ivrv_spread` subtracts a rolling realized\n",
-    "volatility from implied, so consecutive values share most of their input and stay dependent over\n",
-    "that rolling window whatever the label does. It is the longer of the two here. The block size\n",
-    "below takes the larger, so the placebo keeps whichever dependence runs longer.\n",
-    "\n",
-    "The treatment's persistence does not follow from `causal.treatment` alone - it follows from how\n",
-    "that column is built in the feature stage, which no rule can read off the column name. So it is\n",
-    "declared: `causal.treatment_window` in `config/setup.yaml` states the number of bars, beside the\n",
-    "treatment it describes and beside the derivation that produced it. The assignment below refuses a\n",
-    "treatment with no declared window rather than substituting the buffer, which would size the block\n",
-    "by the wrong scale and leave a refutation that reads stronger than it is.\n",
-    "\n",
-    "The **Newey-West bandwidth** in the second stage has to cover the overlap between successive\n",
-    "outcomes, which is the outcome horizon and not the buffer. The buffer is a cross-validation\n",
-    "device that holds a fold's training rows clear of its validation labels; it says nothing about\n",
-    "how far apart two outcomes stop sharing a return window. A bandwidth shorter than the overlap\n",
-    "understates the standard error, and a longer one moves it in whichever direction the extra\n",
-    "sample autocovariances happen to point, so the notebook passes the horizon itself.\n",
-    "\n",
-    "The **development cutoff** is counted in sessions, because that is the unit the labels are\n",
-    "built in. `forward_return` in `02_labels.py` takes the close a fixed number of sessions ahead\n",
-    "and keeps a row only where the session index spans exactly that many. Subtracting the buffer\n",
-    "as a calendar duration answers a different question: ten days is about seven sessions on this\n",
-    "calendar, so the notebook delivered seven where it declared ten, and a label variant whose\n",
-    "horizon exceeded seven resolved its return inside the holdout with nothing to show it."
+    "Registration happens only after the fit returns a finite effect and HAC standard error. A\n",
+    "missing treatment, confounder, or valid analysis population fails before any causal row is\n",
+    "written."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "7dd03ff0",
+   "execution_count": 5,
+   "id": "71a60449",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:16.881050Z",
-     "iopub.status.busy": "2026-08-29T12:59:16.880928Z",
-     "iopub.status.idle": "2026-08-29T12:59:16.963247Z",
-     "shell.execute_reply": "2026-08-29T12:59:16.962736Z"
+     "iopub.execute_input": "2026-08-31T02:26:56.335838Z",
+     "iopub.status.busy": "2026-08-31T02:26:56.335560Z",
+     "iopub.status.idle": "2026-08-31T02:26:57.375728Z",
+     "shell.execute_reply": "2026-08-31T02:26:57.374700Z"
     },
     "papermill": {
-     "duration": 0.084826,
-     "end_time": "2026-08-29T12:59:16.963784+00:00",
+     "duration": 1.043983,
+     "end_time": "2026-08-31T02:26:57.376401+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:16.878958+00:00",
+     "start_time": "2026-08-31T02:26:56.332418+00:00",
      "status": "completed"
-    }
+    },
+    "tags": [
+     "results"
+    ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Registered causal identity: b8e949f2cbc5\n"
+     ]
+    }
+   ],
    "source": [
-    "BUFFER_PERIODS = embargo_from_buffer(mds.label_buffer)\n",
-    "EMBARGO_PERIODS = BUFFER_PERIODS\n",
-    "OUTCOME_HORIZON = embargo_from_buffer(resolve_label_horizon(CASE_STUDY_ID, PRIMARY_LABEL, setup))\n",
-    "if OUTCOME_HORIZON > BUFFER_PERIODS:\n",
-    "    raise ValueError(\n",
-    "        f\"Outcome horizon {OUTCOME_HORIZON} exceeds the label buffer {BUFFER_PERIODS}. \"\n",
-    "        \"The cutoff below subtracts the buffer to keep development labels clear of the \"\n",
-    "        \"holdout, so a longer outcome would still reach into it. Raise labels.buffer in \"\n",
-    "        \"setup.yaml, or correct labels.horizons.\"\n",
-    "    )\n",
-    "declared_window = causal_cfg.get(\"treatment_window\")\n",
-    "if declared_window is None:\n",
-    "    raise ValueError(\n",
-    "        f\"No causal.treatment_window in {CASE_STUDY_ID}/setup.yaml, so the block size below \"\n",
-    "        f\"cannot be shown to span the persistence of treatment '{TREATMENT_COL}'. Declare the \"\n",
-    "        \"number of bars the treatment's own construction spans, read off the code that builds \"\n",
-    "        \"the column.\"\n",
-    "    )\n",
-    "TREATMENT_PERSISTENCE = max(1, int(declared_window))\n",
-    "BLOCK_SIZE = max(OUTCOME_HORIZON, TREATMENT_PERSISTENCE)\n",
-    "HOLDOUT_START = pd.Timestamp(setup[\"evaluation\"][\"holdout_start\"])\n",
-    "pre_holdout = np.sort(merged_clean.loc[merged_clean[date_col] < HOLDOUT_START, date_col].unique())\n",
-    "if len(pre_holdout) <= BUFFER_PERIODS:\n",
-    "    raise ValueError(\n",
-    "        f\"The panel holds {len(pre_holdout)} sessions before {HOLDOUT_START.date()}, which \"\n",
-    "        f\"cannot absorb a {BUFFER_PERIODS}-session buffer and leave anything to analyse.\"\n",
-    "    )\n",
-    "DEVELOPMENT_CUTOFF = pd.Timestamp(pre_holdout[-BUFFER_PERIODS])\n",
+    "result = resolved.run()\n",
+    "if not result.complete:\n",
+    "    raise RuntimeError(f\"the causal result for {label} is incomplete\")\n",
+    "# Compare the identity-bearing computation, not the whole specification. `provenance` records\n",
+    "# the git commit of the run that registered the result, so a full-spec comparison fails on any\n",
+    "# re-run made after any commit - it would assert that nothing had been committed since, which is\n",
+    "# not a property of the causal estimate.\n",
+    "if result.spec[\"computation\"] != computation:\n",
+    "    raise RuntimeError(f\"the registered causal computation for {label} differs\")\n",
+    "reloaded = request.resolve().run()\n",
+    "if reloaded.hash != result.hash:\n",
+    "    raise RuntimeError(f\"reloading the causal request for {label} changed its identity\")\n",
     "\n",
-    "# Labels at or after this cutoff can overlap the holdout return window.\n",
-    "merged_clean = merged_clean.loc[merged_clean[date_col] < DEVELOPMENT_CUTOFF].copy()\n",
-    "\n",
-    "sort_cols = [date_col, *entity_cols]\n",
-    "merged_clean = merged_clean.sort_values(sort_cols).reset_index(drop=True)\n",
-    "\n",
-    "if entity_cols and merged_clean.duplicated([date_col, entity_cols[0]]).any():\n",
-    "    raise ValueError(\"Causal panel must contain at most one row per decision time and entity\")"
+    "print(f\"Registered causal identity: {result.hash}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4b3c0042",
+   "id": "8c354670",
    "metadata": {
     "papermill": {
-     "duration": 0.001302,
-     "end_time": "2026-08-29T12:59:16.966699+00:00",
+     "duration": 0.001925,
+     "end_time": "2026-08-31T02:26:57.381652+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:16.965397+00:00",
+     "start_time": "2026-08-31T02:26:57.379727+00:00",
      "status": "completed"
     }
    },
    "source": [
-    "When a row cap is active, retain whole recent cross-sections so that sample\n",
-    "construction cannot cut through a decision time."
+    "## 3. Statistical Assessment\n",
+    "\n",
+    "Confounding bias is defined as:\n",
+    "\n",
+    "$$\\text{Bias \\%} = \\frac{\\hat{\\theta}_{\\text{naive}} - \\hat{\\theta}_{\\text{DML}}}{|\\hat{\\theta}_{\\text{DML}}|} \\times 100$$\n",
+    "\n",
+    "Positive values mean the naive coefficient is more positive than the adjusted\n",
+    "coefficient; interpret the sign alongside both coefficients.\n",
+    "\n",
+    "The two diagnostics answer different questions. Driscoll-Kraay inference asks whether the\n",
+    "adjusted coefficient is distinguishable from zero after allowing for panel dependence. The\n",
+    "block permutation asks whether its magnitude is unusual after disrupting the treatment-outcome\n",
+    "timing while preserving each entity's short-run treatment dependence. Neither test validates\n",
+    "the unobserved-confounding assumption.\n",
+    "\n",
+    "\n",
+    "Two numbers below are populations and they are not the same one. The **analysis population** is\n",
+    "what the request resolved: every row admissible under the estimand and the holdout cutoff.\n",
+    "**Cross-fitted observations** is the subset carrying an out-of-fold residual, which is what the\n",
+    "coefficient is computed on - a row outside every fold's validation window contributes nothing\n",
+    "to it by construction.\n",
+    "\n",
+    "The refutation verdict is derived from the p-value **and** the number of placebo refits that\n",
+    "succeeded, because a p-value alone cannot say whether the draws could have rejected at all.\n",
+    "\n",
+    "**Read the refutation against the warning the run prints above it**, which reports the share of\n",
+    "treatment rows the permutation could not move. A row is frozen when its symbol's segment is too\n",
+    "short to hold two blocks, and a 20-session block needs 40 clean sessions to have anywhere to go,\n",
+    "so a daily option panel freezes a large share: every gap in a symbol's quotes starts a new\n",
+    "segment. A frozen row keeps its observed treatment in every placebo, which pulls the placebo\n",
+    "distribution towards the observed estimate and biases the p-value **towards 1**. The bias works\n",
+    "against rejecting, so a refutation that passes with a large frozen share has passed a harder\n",
+    "test than the number suggests - which is the opposite of the reading a frozen share usually\n",
+    "warrants, and the reason it is worth checking rather than assuming."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "a05cb295",
+   "execution_count": 6,
+   "id": "57e7e24a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:16.969948Z",
-     "iopub.status.busy": "2026-08-29T12:59:16.969814Z",
-     "iopub.status.idle": "2026-08-29T12:59:16.980730Z",
-     "shell.execute_reply": "2026-08-29T12:59:16.980360Z"
+     "iopub.execute_input": "2026-08-31T02:26:57.386945Z",
+     "iopub.status.busy": "2026-08-31T02:26:57.386576Z",
+     "iopub.status.idle": "2026-08-31T02:26:57.391719Z",
+     "shell.execute_reply": "2026-08-31T02:26:57.391112Z"
     },
     "papermill": {
-     "duration": 0.012976,
-     "end_time": "2026-08-29T12:59:16.980983+00:00",
+     "duration": 0.008703,
+     "end_time": "2026-08-31T02:26:57.392230+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:16.968007+00:00",
+     "start_time": "2026-08-31T02:26:57.383527+00:00",
      "status": "completed"
     }
    },
@@ -594,196 +536,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Taking 127 most recent complete decision times (49,753 rows) from 378,179\n"
+      "Analysis population: 376,871 rows\n",
+      "Cross-fitted observations: 313,237\n",
+      "Naive OLS effect:  -0.018040\n",
+      "Adjusted (DML):    +0.015345  (HAC SE 0.016828)\n",
+      "95% interval:      [-0.017638, +0.048328]\n",
+      "Confounding bias:  -217.56%\n",
+      "p-value (HAC):     0.3621\n",
+      "  Significant at 5%: No\n",
+      "Refutation:        Passes (p=0.0099, 100 successful draws)\n"
      ]
     }
    ],
    "source": [
-    "if ROW_CAP > 0 and len(merged_clean) > ROW_CAP:\n",
-    "    date_counts = merged_clean.groupby(date_col, sort=True).size()\n",
-    "    reverse_cumulative = date_counts.iloc[::-1].cumsum()\n",
-    "    selected_dates = reverse_cumulative[reverse_cumulative <= ROW_CAP].index\n",
-    "    if len(selected_dates) == 0:\n",
-    "        raise ValueError(f\"ROW_CAP={ROW_CAP:,} cannot fit one complete decision time\")\n",
-    "    print(\n",
-    "        f\"Taking {len(selected_dates):,} most recent complete decision times \"\n",
-    "        f\"({int(date_counts.loc[selected_dates].sum()):,} rows) from {len(merged_clean):,}\"\n",
-    "    )\n",
-    "    merged_clean = merged_clean.loc[merged_clean[date_col].isin(selected_dates)].reset_index(\n",
-    "        drop=True\n",
-    "    )\n",
+    "metrics = result.metrics\n",
+    "dml_effect = metrics[\"dml_effect\"]\n",
+    "se_hac = metrics[\"dml_se_hac\"]\n",
+    "refutation_p = metrics[\"refutation_p\"]\n",
     "\n",
-    "assert merged_clean[date_col].max() < DEVELOPMENT_CUTOFF"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f50cd406",
-   "metadata": {
-    "papermill": {
-     "duration": 0.0013,
-     "end_time": "2026-08-29T12:59:16.983809+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T12:59:16.982509+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "> **Scope**: This is a development-period sensitivity analysis, not a holdout\n",
-    "> evaluation. The label buffer removes observations whose forward returns could\n",
-    "> overlap the holdout. `ROW_CAP` keeps complete cross-sections, so\n",
-    "> neither folds nor embargoes cut through a decision time."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "b1566a42",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:16.986977Z",
-     "iopub.status.busy": "2026-08-29T12:59:16.986909Z",
-     "iopub.status.idle": "2026-08-29T12:59:16.990790Z",
-     "shell.execute_reply": "2026-08-29T12:59:16.990425Z"
-    },
-    "papermill": {
-     "duration": 0.005941,
-     "end_time": "2026-08-29T12:59:16.991088+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T12:59:16.985147+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Analysis data: 49,753 rows\n",
-      "Date range: 2020-06-18 00:00:00 to 2020-12-16 00:00:00\n",
-      "Holdout begins: 2021-01-01\n",
-      "Development cutoff after label buffer: 2020-12-17\n",
-      "Embargo: 10 decision times | Block size: 20 (outcome horizon 5, treatment window 20) | HAC horizon: 5\n",
-      "Entities: 508\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f\"\\nAnalysis data: {len(merged_clean):,} rows\")\n",
-    "print(f\"Date range: {merged_clean[date_col].min()} to {merged_clean[date_col].max()}\")\n",
-    "print(f\"Holdout begins: {HOLDOUT_START.date()}\")\n",
-    "print(f\"Development cutoff after label buffer: {DEVELOPMENT_CUTOFF.date()}\")\n",
+    "print(f\"Analysis population: {computation['analysis_population']['n_rows']:,} rows\")\n",
+    "print(f\"Cross-fitted observations: {metrics['n_obs']:,}\")\n",
+    "print(f\"Naive OLS effect:  {metrics['naive_effect']:+.6f}\")\n",
+    "print(f\"Adjusted (DML):    {dml_effect:+.6f}  (HAC SE {se_hac:.6f})\")\n",
+    "print(f\"95% interval:      [{dml_effect - 1.96 * se_hac:+.6f}, {dml_effect + 1.96 * se_hac:+.6f}]\")\n",
+    "print(f\"Confounding bias:  {metrics['confounding_bias_pct']:+.2f}%\")\n",
+    "print(f\"p-value (HAC):     {metrics['p_value_hac']:.4f}\")\n",
+    "print(f\"  Significant at 5%: {'Yes' if metrics['p_value_hac'] < 0.05 else 'No'}\")\n",
     "print(\n",
-    "    f\"Embargo: {EMBARGO_PERIODS} decision times | Block size: {BLOCK_SIZE} \"\n",
-    "    f\"(outcome horizon {OUTCOME_HORIZON}, treatment window {TREATMENT_PERSISTENCE}) | \"\n",
-    "    f\"HAC horizon: {OUTCOME_HORIZON}\"\n",
-    ")\n",
-    "if entity_cols:\n",
-    "    print(f\"Entities: {merged_clean[entity_cols[0]].nunique()}\")"
+    "    f\"Refutation:        {metrics['refutation_class']} \"\n",
+    "    f\"(p={refutation_p:.4f}, {metrics['refutation_n_successful']} successful draws)\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f6e0261f",
+   "id": "b88a38c2",
    "metadata": {
     "papermill": {
-     "duration": 0.001347,
-     "end_time": "2026-08-29T12:59:16.993933+00:00",
+     "duration": 0.001744,
+     "end_time": "2026-08-31T02:26:57.396183+00:00",
      "exception": false,
-     "start_time": "2026-08-29T12:59:16.992586+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## 3. Run DML Analysis\n",
-    "\n",
-    "Full pipeline: naive OLS baseline, DML with walk-forward cross-fitting and\n",
-    "embargo, and a block-permutation refutation test. Cross-fitting keeps complete\n",
-    "dates together. Driscoll-Kraay covariance accounts for serial and\n",
-    "cross-sectional dependence in the residualized panel."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "3d3281ef",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T12:59:16.997559Z",
-     "iopub.status.busy": "2026-08-29T12:59:16.997460Z",
-     "iopub.status.idle": "2026-08-29T13:00:11.695465Z",
-     "shell.execute_reply": "2026-08-29T13:00:11.695100Z"
-    },
-    "papermill": {
-     "duration": 54.701491,
-     "end_time": "2026-08-29T13:00:11.696941+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T12:59:16.995450+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "============================================================\n",
-      "DML ANALYSIS SUMMARY\n",
-      "============================================================\n",
-      "Analysis rows: 49,753\n",
-      "Second-stage rows: 37,240\n",
-      "Second-stage decision times: 96\n",
-      "Covariance: Driscoll-Kraay\n",
-      "HAC bandwidth: 4 lags (max of horizon-1 and cube-root)\n",
-      "\n",
-      "Naive OLS rows:    37,240\n",
-      "Naive OLS effect:  -0.028260\n",
-      "DML effect:        -0.028764\n",
-      "  SE (IID):        0.003179\n",
-      "  SE (HAC):        0.033558\n",
-      "  t-stat (HAC):    -0.86\n",
-      "  p-value (HAC):   0.3935\n",
-      "\n",
-      "Confounding bias:  0.000503 (+1.7%)\n",
-      "\n",
-      "Refutation (block permutation):\n",
-      "  Z-score:      -4.52\n",
-      "  Empirical p:  0.0099\n",
-      "  Classification: Passes\n",
-      "  Placebos:     100\n",
-      "============================================================\n"
-     ]
-    }
-   ],
-   "source": [
-    "results = run_dml_analysis(\n",
-    "    merged_clean,\n",
-    "    treatment_col=TREATMENT_COL,\n",
-    "    outcome_col=label_col,\n",
-    "    confounder_cols=CONFOUNDER_COLS,\n",
-    "    n_folds=CV_FOLDS,\n",
-    "    embargo=EMBARGO_PERIODS,\n",
-    "    n_placebo=PLACEBO_REPS,\n",
-    "    block_size=BLOCK_SIZE,\n",
-    "    seed=RANDOM_SEED,\n",
-    "    horizon=OUTCOME_HORIZON,\n",
-    "    time_col=date_col,\n",
-    "    entity_col=entity_cols[0] if entity_cols else None,\n",
-    ")\n",
-    "\n",
-    "print(format_dml_summary(results))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1f8a2bfb",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001341,
-     "end_time": "2026-08-29T13:00:11.699831+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.698490+00:00",
+     "start_time": "2026-08-31T02:26:57.394439+00:00",
      "status": "completed"
     }
    },
@@ -794,110 +587,10 @@
     "the naive and adjusted coefficients to see how observed confounders change the\n",
     "estimated association.\n",
     "\n",
-    "The two diagnostics answer different questions. Driscoll-Kraay inference asks\n",
-    "whether the adjusted coefficient is distinguishable from zero after allowing\n",
-    "for panel dependence. The block permutation asks whether its magnitude is\n",
-    "unusual after disrupting the treatment-outcome timing while preserving each\n",
-    "entity's short-run treatment dependence. Neither test validates the\n",
-    "unobserved-confounding assumption.\n",
-    "\n",
     "Compare this result with the S&P 500 Options case study to see why confounding\n",
     "must be assessed for each treatment-outcome pair rather than inferred from the\n",
-    "market alone."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5479e224",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001276,
-     "end_time": "2026-08-29T13:00:11.702462+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.701186+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## 4. Statistical Assessment\n",
+    "market alone.\n",
     "\n",
-    "Confounding bias is defined as:\n",
-    "\n",
-    "$$\\text{Bias \\%} = \\frac{\\hat{\\theta}_{\\text{naive}} - \\hat{\\theta}_{\\text{DML}}}{|\\hat{\\theta}_{\\text{DML}}|} \\times 100$$\n",
-    "\n",
-    "Positive values mean the naive coefficient is more positive than the adjusted\n",
-    "coefficient; interpret the sign alongside both coefficients."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "67810c8d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T13:00:11.706094Z",
-     "iopub.status.busy": "2026-08-29T13:00:11.705977Z",
-     "iopub.status.idle": "2026-08-29T13:00:11.709229Z",
-     "shell.execute_reply": "2026-08-29T13:00:11.708904Z"
-    },
-    "papermill": {
-     "duration": 0.00572,
-     "end_time": "2026-08-29T13:00:11.709557+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.703837+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Statistical significance:\n",
-      "  p-value (HAC): 0.3935\n",
-      "  Significant at 5%: No\n",
-      "  Refutation: Passes (p=0.0099)\n"
-     ]
-    }
-   ],
-   "source": [
-    "dml_result = results[\"dml_result\"]\n",
-    "naive_effect = results[\"naive_effect\"]\n",
-    "dml_effect = dml_result[\"theta\"]\n",
-    "se_hac = dml_result[\"se_hac\"]\n",
-    "bias_pct = results[\"confounding_bias_pct\"]\n",
-    "\n",
-    "# p-value computed in run_dml_analysis (no duplication)\n",
-    "p_value = results[\"p_value_hac\"]\n",
-    "\n",
-    "ref = results.get(\"refutation\") or {}\n",
-    "if \"empirical_p\" not in ref:\n",
-    "    # Defaulting to 1.0 here would report \"cannot reject\" for a refutation that never ran,\n",
-    "    # which is the one reading a missing test must not produce.\n",
-    "    raise RuntimeError(\"the DML run published no block-permutation refutation\")\n",
-    "p_value_perm = ref[\"empirical_p\"]\n",
-    "ref_class = ref.get(\"refutation_class\", classify_refutation(p_value_perm, ref.get(\"n_successful\")))\n",
-    "\n",
-    "print(\"Statistical significance:\")\n",
-    "print(f\"  p-value (HAC): {p_value:.4f}\")\n",
-    "print(f\"  Significant at 5%: {'Yes' if p_value < 0.05 else 'No'}\")\n",
-    "if ref:\n",
-    "    print(f\"  Refutation: {ref_class} (p={p_value_perm:.4f})\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "18a0c822",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001301,
-     "end_time": "2026-08-29T13:00:11.712398+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.711097+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
     "> **When should you be suspicious of large DML corrections?** A naive-to-DML\n",
     "> amplification exceeding 5x warrants scrutiny. Possible causes:\n",
     "> (1) nuisance models overfitting and stripping outcome-relevant variation,\n",
@@ -909,13 +602,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1184a8ac",
+   "id": "bef4977a",
    "metadata": {
     "papermill": {
-     "duration": 0.001284,
-     "end_time": "2026-08-29T13:00:11.715085+00:00",
+     "duration": 0.00174,
+     "end_time": "2026-08-31T02:26:57.399802+00:00",
      "exception": false,
-     "start_time": "2026-08-29T13:00:11.713801+00:00",
+     "start_time": "2026-08-31T02:26:57.398062+00:00",
      "status": "completed"
     }
    },
@@ -928,27 +621,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "f5053f94",
+   "execution_count": 7,
+   "id": "37dd2509",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T13:00:11.718490Z",
-     "iopub.status.busy": "2026-08-29T13:00:11.718364Z",
-     "iopub.status.idle": "2026-08-29T13:00:11.824395Z",
-     "shell.execute_reply": "2026-08-29T13:00:11.823887Z"
+     "iopub.execute_input": "2026-08-31T02:26:57.405125Z",
+     "iopub.status.busy": "2026-08-31T02:26:57.404898Z",
+     "iopub.status.idle": "2026-08-31T02:26:57.604182Z",
+     "shell.execute_reply": "2026-08-31T02:26:57.603544Z"
     },
     "papermill": {
-     "duration": 0.10831,
-     "end_time": "2026-08-29T13:00:11.824784+00:00",
+     "duration": 0.202998,
+     "end_time": "2026-08-31T02:26:57.604755+00:00",
      "exception": false,
-     "start_time": "2026-08-29T13:00:11.716474+00:00",
+     "start_time": "2026-08-31T02:26:57.401757+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFVCAYAAAAUvhB3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAWmNJREFUeJzt3XV0FFcDxuHfEsUDQRIICe7u7hSHIoXiWpziENydIsW9WIu3UKDIV4rT4u5QnCAJgSix/f4IbMkmhECzBOj7nMM5ZOfOXJnZzZs7szOGoKAXRkRERETEJF5cN0BERETkY6OAJCIiImJGAUlERETEjAKSiIiIiJlPKiCtWrsJB5d8HD5y4oPVOWbSLBxc8nHrzj0AylX/mpYd+nyw+qOyZ/+fOLjkY9XaTRar42Popzmj0cigkZNJn6sMuYp8gafX0zeWvXXnHg4u+RgzaRbwz7GzZ/+fH6q5MbZp6/9wy1WaYyfORLnc/Bh8X6/GZPKMBf9qOx+zPMWrU61eq3deb/x3c3FwyceNv29boFWRj0cR+fh9VAGpc6+hOLjki/Lf/kNH47p5AMyZOpoRA3v8q20EBARaPOC8iyUr1uLgki/Ca7HRzzfJWqAi47+b+87rHT5ykjkLV1KscD5GDemFY/JkFmhd7IlpPyuVL8mqRdPJmztHrNbftkt/ajZsF6vbtKTKtZvTudfQuG6GiAgA1nHdgNd1bNuUmlUrEBoaRquOfShTsggd2zYFIGf2zNy+ez+OWwi5cmT519t49MQzFloSex4+itye2OhnVEJDQ3ni+eaZn+jcvH0XgPatvqZKxdKx2axY9y79TJQwAaVLFI71NkS1Xz9mDx97kiVzhrhuhogI8JHNIOXPk4Na1SpSs2p5AFzSOlOrWkVqVasYYbbg6PEzVP2yFemyl6Rtl/4EBwcD4b+Ups5aTO5i1cicrzzuwycRFBQcqZ51P2+jeoM2uOYsTe6iVVn+40bTMj9/f3r0H4VbrtKU/qIRJ0+fj7Du61P4+w8dxcEln2l982n023fvU/frDqTJUozCZeswa8Fy9h08Qr4SNQDo2nuY6dSJ0Whk+U8bKVSmNm65StPh20E89/EFwk8tzV64gpyFq5CryBf8uG7zG8fQ2/s5XfsMI0PushQoVStC3zZu3k6BUrVwyVaCmg3bcfL0eTr3GsrEafMAcHDJZ5pxiKqfv2zZSY0GbUmfqwydeg7h1p17NG7VDdccpWjdqZ9prC9duU6H7gPJXawarjlK0a7rAHx8/bh15x6ObgUJCwtj4rR5EWYGf9u1h5KVG+KaoxSNW3fH4+HjCP1atXYTXV7OLnzVsiudew3F66k3w8dOo1iFeqTJUoyqX7bi6vWbbxyb1505f4nKtZvjnLkYJSs1YO3GrZHK+Pr502/IeLIVrES2gpXoP3QCvn7+Ue7rV+PXofvAN/bT+9lzmrfvRbrsJclbojqjJ84kKCg40um/tx2D0e3jV/IUr87BP49x8M9jOLjkizCT9cDjEa069sU1Z2kq1WrG3fsepmVv2w8QfjyuXPMLxSvWI23W4lSv35q/b94Bwvd93a874JKtBOWqf83R42cijNfSleto1q4nrjlLU7l2c1PdDi75uHP3Pj+t22yaXX113P2x7zBf1G1JsQr1CAkJYdGyNVSs2RSXbCUoWLo2v+3a89b9/WqMl/+4kZKVGpA+Vxl6DxzDixdBUZb/3x8Hqd+sExnzlCNrgYqm98j79v+Vq9dvUqfxN6TLXpIvm3SMMPanz12k1lftcMlWgpKVGvDLlp1Rtq1mw3a06zqA6bOXkClvedb/8tsb33Ov9/33PQepUqcF6bKXpF3XAabPzaCgYPoOHkeG3GUjzNq/Oq7+OnaKyrWb45KtBDUatI3xe0zkU/dRBaSYWrD0J76qV4MSRQuycfMOtv9vHwCz5i9n1ITvqVm1AgP7dOHHtZtY8MNPkdY/fOQERQrkZczQ3jg6JqPXwDGm6ztGjJ3Osh830K5FI9q1/Ior/+LDYPSEmZw4dY4xw/pQq1pFAgNfkCtHFtx7dwagQ5smrFw0jZQpkvPLlp18228khQrkYczQPhw4dNT0y3fz1v8xeOQUChXIw5AB3bl3/2GU9RmNRr7pPpAt23fTs0sbGtStxrf9R3LqzAX8/P3p2GMwaZxTM254P9I4pcJoNNKxbVNKFisEwMpF0xjSv+sb+9PLfQy1q1eiWOF8rF7/K2WrNaZksUKULlmEX7bs5LedewC4e88DP/8A+vfoQMMvq7Nh03bmLV5FyhTJ+W7cYADq16nKykXTyJk9M0eOn6Zp2564pHFi3Ih+3Llzn57uoyPUXbZUUTq0aQKAe+/OdGzblNDQUI6dPEfrZg3p37MjZ89fou/gcTHaN/0Gj8fj4WMmjOxP6ZJFCAgIjFSmZ/9RLP9pI13aN6dzu2b8sGo9vc3aFZU39XPmvGVs27kH9z6dafpVXfz8A7CxiTyJG90xGN0+ft2MiUNJ5pCUHNkysXLRNBrUrWZatmrtJnJmz0yrJvU5fuocM+ctA4jRfgD4cd1muvUZTuaM6Rk/sj+5cmQldeoUeD97zpdNOvLw0WNGD+2Nq0samrbrgX9AgGndgcMnkzd3dlo1qc+xk2dNdS+b/x0AZUoWYeWiaZQtVdS0TqtO/ShTsgiTxrhjZWXFnv1/UqViGUYN6RV+DPcYYgqubzNj7lI6tGlC/TpVWbJiXZSfDwDHTp4lY3pXRg3pRY5smRn/3VzTtY//pv+79x6ifJni9O/ZkUN/Hae3+xgAHj56Qt3GHfB+5sPE0e5kyuhG6079+GPf4Sjbt/P3/WzYvJ2Rg3tSrnTRN77nXtej/ygaN6hFiaIF2bBpu+lzc+b8ZSxatob2rRrTvlVjAIYO6E65MsW4efsu9Zp0JF68eIwb0Q+DwUDrTv0wGnV/Yfn8fVSn2GJq2oShVKlYmry5s7Nz937TXzQLlv5EmZJFGNgnPIAc/PMYW7fvpluHlhHWnzp+CAEBgZw8c4GC+XJx+uxFTp4+T7q0zqxau4kvKpZhmPu3AFz/+zaz5i9/r3YmTpwQgEwZ3WjT/CsMBgMAxYvkByDfyxmzV23PmN6VSaPcwQBXr91kw6bfmDTanRWrf8YhaRIWzhyPvb0dyRyScPDPY5Hqu3nrLrv+OEC/Hh1o1awBGOHHtZvYsmM3fbN+Q/z48bG3s6Vi+ZK0bFrftJ5LmtQApra8yZD+3WjXshHFCudjx+/7ad20AT26tOHk6fNs2/EHl6/dAKByhVJUKl+Sy1dvED++PStW/8zR42dIED8+FcoUByBLpgym+gaOmEyC+PbM+m4ktrY2+PsHMGDYRIKCgrG1tQEgXVpn8uXJYRq//C//v3X9Yu4/eMjpcxdJ55KGo8dPx+jDO3GihGAwkC9PjvCxMuP11Jv1m36jQd1q9OjSBoBTZy+y9udtTBzlHu2239TPxIkSYjAYSOucmlptKmJtHfntFxYWFu0xGN0+zp83p2k7FcuVJL69HcmTJTPV/+qPgE5tmzKgVyfTbMzV638DsGjZmrfuB4DZC1aQMb0ry+ZPwcrKyvT6+l9+w+PhY+ZMHUXB/LkpVCAPZas25ujxM6R3cwGgY9smUdZtPmv8qq8AX31ZnaEDupvqWbloGs99fDl55jy5c2bl199+58rVGxTMnzva/QIwZlgfqlcpT3BwMKvX/8q2nXvo3jHyRd3uvTsRHBzMqTMXKVooH3sP/MXR42coUbTgv+p/y6b16d0tfJb2j/2H2fXHAYKCgln781a8nz1n8ewJVCpfilrVKrJt5x7mL/2JCmVLRGpfcHAIqxZPx9UlDfDm99zr3vS5eeT4aTJndGNwv66EhITw49pNxI9vj1u6tIyZPAv/gEBmThlB6lQpSOGYnKZte3Dz1l0ypE/31vEW+ZR9kgHp1V/dKV6ednvxIoigoGDuPXjIvQcPSZ+rjKls5oxukdafv+RHxn03h3iGeGR4+cH1/LkvTzyf4h8QSMYMrrHSzlFDepM8uQPN2/XCzdWF0UN6RflhB+G/DB48fEz63P+0/dUvpdt37+OS1hl7e7to63t1jc7kGQsifFPpyRMv7O3t+G3DUkaOn0G+EjX4ql4NRg3uRaqUjjHuj83LX+iOjuHjbmMT3r7kyR0ATKfYLl6+RvtuA7l89QYF8ubExtqa5z4+b9zurdv38PMPIGuBiAHN66k3TqlTvnG95z6+dOo5hO279pI5oxv+AYH4BwQSGhr61r7MmzGGiVPn8cWXLSlcIC9jh/WhQL5cpuWvfjnne+3C6QJ5c/LLlp3cvH3X1Od30bVDC6ysreg7eBwjxs9gaP9uNKhbPUKZtx2D0e3jmHq136ytrUnmkIQXL8L3W0z3w81bd6hYrmSEcPBqfYD6zTpHeP3xEy9TQHhT3dF5fR8YjUbGTJrFnIUrSZo0senU+6vT0W/z6o8UGxsbMmV0w8vLO8pyv2zZyYBhE/Hz8ydXjqwR6vg3/X9VP0C2LJnYvfcwz54/N6376o+ApEkSkzmjG7de7m9zyZMlNYUjiNl7LqrPTYA8ubLxvz8OsvfgXzx65Il/QCBpncL/aLp1K7xdxSrUi9gnTy8FJPnsfZIBKSq2tjakcUpF2jROpr+8IfwC2NfdunOPAcMmMsz9W3p2acPBP49Tu1F7IPxDx9ramtPnLprKRzcb8SrAvLro2sfHL8LyRAkTMKRfN77t1JpOPYfQpE0PbpzbS7x44Wc2X7x4YSrr5poWG1sbZk0ZafoQtbYO/wBOldKRv46dIiAgkPjx7d/YJrd0aQFo2+Ir6tWuano9rXP4h12uHFlYu3wW5y5coUbDtgDMmz6GeC8/6AMDX7w1hMVE38HjsbKKx9/n9pE4UULyFP8nBMSziqLv6dJw/uIVVi6aFuGXTgrH6L+lNnvBCnbvOcSxvZvImMGVzr2G8lM012e9LoVjciaPHcSA3p34uvW3tOjQh3N/bTctf/UL7dTZf05dnXx5Giu9qwuBL9v/6HH4vjf/BR1VP21sbOjesRXftPqawaOm0K6rOwXzRZz1eNsx+LZ9HLENVhHqf5uY7gfXdGm4ePkaoaGhEcq9atu0CUPInDG96fWc2TO/9RTYq2P+be09cPgY381cxMKZ42n4ZXV+XLeZrr2Hxah/rwsICOTWnfuUKFog0rLAwBd07DGYZo3qMmm0O/cePDRdNwix1/8rV2+QOFFCUjgmx801fN1TZy5SuUIpnj334dqNWzH+MkJ077m3adv8K2bOW0bdxh0AqFqpDDWrVQjv08t2rVg4FYekSV7rk2W+xCHyMflsAhJA+9ZfM2rC96zZsIXiRQtw6cp1Gpr9hf7qWpNTZy7w47rNLF6+1rTM2tqamlUrsGX7bqZ8v5AECeKzYvUvb6wvY/p0WFlZsWL1zxgMBtZu3Gr6oA8ODubr1t+SP29OsmRKj5fXUwwGAwYMpg+dn9b9SvJkDlSuUJr2rb6mfTd3Fv6wmioVS3P7zn2KFwn/8K5bswoHDh+j18AxlCpeiDkLV0TZngzp01GxXAnW/bwNh6RJSO/mwplzlxg+sAcnT59nwLCJNKpfE4PBQEhwMFYvf4mndw0PAxOnzaNC2RIRrv94HwEBATx54sXmbf/jxKlz3Ll7n7TOqQBInTIF9nZ2bNm+m7y5s1OqeGHatmzEul9+Y+qsxdSvXZVHTzxxS5c2ylNQEesJJPDFC3bu3o+ffwBbfvvdtCyFYzKsra05efo8vn7+pHEKr//A4WPkz5uTr1t3p0rFMjg7pcLXz880Fq8kT+ZAw7rV+XX778yYsxSj0ci2nX/QqF4NkiVLSkhICEmTJmbrjj9I5+LM1h1/RLieyLyfJYsVYtiYqSRPnoz8eXJw3+MRBoPBFKReedsxGN0+NpfeNS1Hjp9m5ZpfyJ8np+mU75vEdD+0bdGI/kMn0LbLAGp8UZ5Df52gV9e21K5eiTGTZzFr/nJaN2uIjY01T72fU6ZkkbcGJCsrK1zTpWHfwSOs3biVwgXyRFnu1fv38JET+Pn58/3La5heSeOUijt3H3Dz9l3Tcf267+cu46n3c7bt+IPnz31o1bSBaT0IPz7q1alKcHAIl6/+zdqft7Hu54gX8P+b/m/a+j8ypk/H3Xse/L73EF07tMBgMPDVlzWY8v1CRoyfwcPHT9i+ay+hoaF0fHnd3dtE9557m8XL1+KQNAntWzXG2sqKAvly4ePjR7JkSWn6VR1mL1jBdzMX0fSrOgQGvsDGxoYyJYvEaNsin7JP8iLtN/m2UytGDOzBgT+P0X/IeA7/dSLSX/bZs2bi206t+WPfYeYsWEHnds0iLJ8ydiBfVCrDjDlL2bRlFx3afP3G+lKmcGRo/254P3vOhl9+Y+ywvqa/5K2trWnaqA47d++nl/sYnj33Yem8SaZz++69O3P1+k0GjZjMtRu3aFC3GjOnjODKtb8ZMHQi23buwdcvfEaqdbMGdOvYkl27DzB99hLatWwcZXsMBgOLZ02kXu2qrFzzC0PHTOXufQ+8nnqTOVN68uXJwbRZixkxbjrlyhRn2IDwmbb2rRpRukRh5i/5kWmzF7/3+L8yakhvbGxtGD52Gra2tlSrUs60LH58eyaOGsCz5z70HzqBk2fOU7xIAX5cMp2n3s8YOGIyazZsidEpk87tm1G0UD7GTp7N8VPnTBeYAiRMkIDGDWpy6K8TXLp8jaKF85E7ZzYWL19L4kQJ+bLWF6zduJU+A8eSIH58Fs2cEGn70yYOpcXX9Zi1YDlzFq2kVZP6TJ0Q/k06a2trJo1yx2AID7od2zalcMG8b+znqbMXaNqoLsdPnqX3wDFcvHyNmVNGmGYdXhfdMRjdPjY3YmAPXF3SMHD4JDZt3fXW8YzpfmjfqjFjh/flzLlL9Bk0ljv37hMcEkKyZEnZvGYhbq5pmTR9PjPmLOWJp1eU3ySNyqTR7tjb2dFv6Hj2HTwSZZlK5UvSqH5N1mzYworVP/Ntp4jXDzX9qg7ez57z62th+XWu6dIwZuJMjp88y/gR/an+8tisVKEUbq5pmb/0JxInSsi44X05f/EKk6cvoHb1SqRMkTxW+t+8cV2W/biRJSvW0aZ5Qwb3C/9ShFPqlGxes5AkiRPRf8h4rl7/myVzJr7xlLy56N5zb1OpfCkeP/FiyvcLGTnhe75s0pGcRb7g9LmLZMzgyi+r52Nna8vI8TNYuGwNXk+9dZG2/CcYgoJe6Eh/B9kKViJLpvRsWffvg4SIfBir1m6ia+9h/PLTfMq/vIBewlWu3ZyC+XMzabQ7RqORI8dPU/XLVowd3peu37SI6+aJxJnP6hSbJXk8fMy2nX/w8NETalatENfNERGJFXfve4RfdO2WDnt7WzZu3oGdna3pm5gi/1Wf1Sk2S9p38AhDRn1Hofy56dm1bVw3R0QkVsz/fizJHJIyYvx0xkyajY2NNZtWL9CF2PKfp1NsIiIiImY0gyQiIiJi5qMKSGOnLmTRig2mn3sOmsik75eafh45aR7rNu3E08ub/sOnmr4dMnrKfE6c/ud+NV36jWHvoch3mg4KCqb/8Kl4vuHmcLGtS78xPPD451lWIyfN5frLZzZt3bkvQl/f5oHHY6rU7xDlshOnL9Cy86D3bufWnfsYMGLae6//oZmP65s88HhMl35jTD9fv3mHkZPmRrNG7Nn++wFadh7Et+4TCA0NM71uvt8XrdjAtLlR37YhJkpUbY6Prx+Tvl/KwuURj6fZi1Yzd8maSOucOH2BcrXb0LLzIOq37EXzTgM5+NdJnng+pXydtgQG/nMvIl8/fyrVa49fDB/l8aHsPXQswr4VEYltH1VAypktI1eu3QLCb6X/4OFjzly4Ylp++erf5MyWCcfkDkwa2TvC4w9iwtbWhkkje+P4HndBjg3D+3cmk+4+G2cypU/H8P6d314wFmzZsY+mDWvw/QT3SPdYsoTypQpz6Mgp089Go5F9h49RsWyxKMu7uTizfO44NiybinuPdgwdN4vEiROSNZMbx07988fGoSOnKJQ3JwnNbrgqIvK5+6i+xZYre2aW/RR+J+QLl6+TOYMrN+/c56n3c+ztbbn/8DFZMrri4+vHFw06cnjHSuYuWcMf+49w+txl0jqnYsb48Odknb1wlZ+3/M7lazdpULsy7VuE3xCuSv0OLJ8zFmenlNRr2ZP2Leqzdec+bty8S5e2jalTPepvqG3ZsZdV67cSGhpGkYK56dOlJfHixaNqw050bNWQ7bsPcu/BIwb1ak+pYgUYPWU+Zy9cpffQyeTMlomhfTvSsvMgenZqznMfP+a8/Mt+36Hj9OzcguET5vDz8mlYW1sTEBjIV236sHbJdySIb29qQ2hoKN/PX8Wpc5cICHxBr84tKVow8vOnzl64yvcLVuEfEEhyh6T06dqK9K7hjyX489gZ5v+wjpCQUFI4OjB+aMQbDF69fouBo2cwa9IgnFKlML0+esp8EiVMwI2bd3n42JNc2TPj3rMtdra23Lpzn0nfL8Xz6TOSJE7IkD4dcHVxZvSU+WTLnJ4/Dhwld/bMlCiSl5XrtuLslJJjJ8+ROmUKun/ThEUrNnL+8jVqVC5Dl3bh9/wpUbU5OzfMJ3GihFy5fosBI6fx8/LpUY7rqnVb+X3fXwQEBpLGKSWjBnbDx9eP7u7j8Xr6jJadB9G2WT3SOKcybQfgwJ8nWbhiPSEhobikSU3fbq1J6ZiME6cvsHLdVtKlTc2xkxfAAJNH9jbdTPCVm7fvM2X2Dzz1fk6C+PHp0bEZuXNkZu6SNVy4fJ37Ho958PAJbZp+CcCeA0cj7PdJI3sD8NjzKUPHzeLcpWtkdEvLxOG9sLa2fuO4RqVgvhzc93iMp5c3jskduHn7PqGhYWTNFPlRO68zGAzkzpEZGxsbHj32okLpIhw6corSxcNvUrr34DEqlo1449Cbt+8xctI8/PwDcEiamJHuXXFOnYKKddvR7Kua/HnsDN7PfGjfogFVK5bkgcdjBo/9nlLFCrDv8HEmDO1JUHBwlH07fPQ0y1dvxs8/AAwGRvTvTMb04Td8XL95F2t+3k7SJIlI5pAkUl9ERGLTRzWDlNEtLd7PfXj23Idjpy6QM1smcmbLxKmzl7h6/TaZ0qeLNGvUuW1jsmfNwKBe7U3hCMIf/TBldF9mThjIDz9uinDa4HUeD58we9JgBvf+JtIpildOn7/C9t0HWTprDD8tnISvrz/7Dh831WNnZ8v8qcNo9XUdfngZ8Ib27UgKx2RMHd2PoX07Rthe+dJFqFezIvVqVmT53HEUzJuDHFkycOCvkwDsP3yC4oXyRghHAMEhIVQsW4wlM0fT/ZumjJo8lxCz54499/HDfdR0enZqzqr5E6hfqxLuo6YTGhrG3fsPGTlpLoP7dGDFvHEM7dsxwqNFvLyfMWTcLEa6d4kQjl554vmUKaP78OOCCdy9/5AtO/YSEhrK0HGz6NW5BasXTaJts3rMWvjPE9LXb97FpBG96No+PPicu3iVutUrsGr+BHz9/Jg2bwXD+nVk4fSRrFy3FS/vZ1Hug1eiGteC+XKwYNowflwwkdDQMLb/fgCnVCkY1Ks92bNmYPnccZQvHfHOv3fueTBu2kLGDv6WVfMnkC9XNsZMmW9afu7iVWpUKcuKeeNwTevMpm1/RFg/JDSUASOn0qBWZVbNn0DPTs1wHzUNH18/0zHZo1MzUziKar+/GuMHHo/p07UVPy2YyJXrtzl++uJbx9WctbU1pYsX4NDR00D4KaiKZYtFePZXVIxGI//b8ye2NtY4pUpBuVKFOXz0FEajkRdBQRw/fYHSxQtGWGfjlt/JnSMza5dMYaR7V1KnDL+JYkDgCzKlT8fC6SOYNKI346cvwvtZ+PPALl+7SZLEiVg2eywpUyZ/Y9/SOKVkwvBeLJ87joplirJ45UYATpy5yKr1W5n33VAWzRhJ/tzZo+2XiMi/9VHNIFlbW5M9c3quXL/FybMX6druaxwcEnPq3CXSpXUmZ7aMMd5WqWIFsLayIlOGdNjY2PD0mQ/OUTxnrEyJQi//is7Ck5fXJm3a9gcbfg2/83DbZvU4f+k6t27fp0PPEQAEvgiK0JayJQuZ/hJfvXG7eRUx0rheNVau20L5UkXY+cdhmjasEamMvZ0duXNkBqBIgdz4+gXw8JFnhDLnLl4lXZrU5MoeXq5CmaJMm7eCO/cecOL0RYoWzEPmDOGn+ZInS2paLyg4mEGjZlAoX07Tuuby5MyKna0tAKWK5ufcxesUypeTW3ceMGryPACMRiKErrrVK5A40T+PuHBKlcI0q5EjWyaSJU1MwoQJSJgwAY7JHfD09Ca5Q1LehauLM9t/P8jp81e4e/8hd+8/fOs6R06cpVihPLikCb/zecM6VZizZA0BgYGmdmbLnB6AXDkycfPlQztfuXPXg8DAICqUCZ9dyZU9M2mdU3Pu4jVKFMn3Tu3PmysrDkkTA5A1kytPvJ5y955HtOMalfKli7B15z5qVy3HvkPHGfBtGwAmzFjMhUvXAUyzVrfuPqBl50E8euJFGqdUfDemHzY21qRxSkXSJIm5/vcdHj3xIk/OLJGeZ1ipbDEmzFjM4pU/U79WJdOzBQEK5c8JQAa3tKR0TMa1v2+T1ikV9nZ2NKxTBSDavrmkceKv42f489gZLl65QVBw+HWGh46colrFUqbT4y5pIz97TkQkNn1UAQkgZ7ZMXLtxmzt3PciSyY2kSRKxYfMuQkJCyZPz3e/LYTAYwh/6+pZb4796MCxA3RoVqFvjn1Nt5y5do3L54vTo2Pwt27DGyPvdNaFgvhzMWLCKa3/f4c49D/LnzhZteSureBgwED8GD5c1YAAMhBmNvGlC4a/jZ2nRqBa/7/uLO/c8SJfWKdptWltbEd/ezvTL7YfZYyL8ovynnVZRrP1yG2bLrK2tIoxeSEjE2bGoBAQG0r7HcOpUK0/zr2qSKkXytz73603eNDbWVtYx2qvRz9XEjLWVNRh567hGpWjB3EyasYQHHo/x8fUj68uA596jXYRy9x88Ml2DtPOPQ6zbtDPCtXHlSxXhwF8nefTYi4plIl/DlC93Nn6YPYYdvx+kVdfBjBjQhYJ5c0Tuy8tjBCBevHim2azo+jZ6yjzsbG2pU708pYsVYNai8JmlkJBQ7O1sYzQOIiKx4aM6xQaQM3smdu8/SuaMrlhbWeGcOiXPffy4eOUGObNlinIdp1QpePDwicXaVKpYAbbtOsDtuw8AePDwSYRvJr1JeLui/raVeZsNBgON6n7BqElz+aJCySh/KQYFB+PxKHydLTv2kt41Tfi1GIbw8AOQO0cW7j54yPmXMwZ7Dh4lfnx70qV1omjB3Px57Aw3b98H4O79h6Z+5MmZhU5tGtG5bWMmTF8c5bOW7j14SFhYGL5+/mzbtZ8SRfORzsUJh6SJWL1xO0ajkaCgYB498Xrr2LxNiuQOnD53mZDQUH773/4oxi58XG/feYD3Mx++qvsFqVOl4Or1W/+US52CR4+9otxXRQvm4ciJc9x78AiADVv+R8G8OYhvbx+pbFTSuThhb2/LnoNHATh/6Tr3HjwyzfC9SUyP1fcZVztbW/Lnyc73C36kQukibz29BlClfAkSJUzA2k07TK+VL12Y/YdPcOTEWcqUKBhpnTPnr2DAQO1q5cmfO1uEb5DeuecBwJET5/DzDyBTBtd36tv+P0/QsE4VcmbLxMWrf5vWyZ8nG7v3HcHPzx+j0cjZC1ff2jcRkX/jo5tBypUtE+cuXqVb+/CnWL86dXXoyKk3zmrUrFKWERPnsG3XfmZMcI+yzL9RIE92un/ThAEjp2FtZU3SJIkYPqAzKR2TRbvelzUqMnT8bArmzcHoQd0iLCtRJB8/rt9Gy86DGNavE5kzulK5fAkmzVzKxMqlo9yeUypHFixbz7Ubt0kQ356R7l0wGAxkyehKUFAwew8do1zJwowf2pNpc5cT+CIIh6SJmTCsJ1ZW8XB1cWZgr/YMGTeTeAYDqVI6Mqh3ewAckiTGYDBQsUxRtuzYy+bf9kSYRQO4ffcBXfqOwfPpM2pWKUvpYgUwGAxMHN6bKbN/4Ncde7C1taFFo9pULvfvHlPwTcsGjJu2CNd1TjRvVIs9B/+5bcPr4zq8fydKFs1Ps44DcXNxJm2aVISFhYe7NE6pyJQ+HY3b9aVts3pkzvjPL+t0aZ0Y2LM9A0fPIDQ0FBfn1Awxu1YsOtZWVuH9nvUDC5dvIEF8e8YP6xnhdGJUzPf7W7f/juNarlRhho6bxdJZo2PUD4PBQL/urWn37XDKFC+IS5rUpHdNi39AAOld00Y6vQZw9cYtps1dgX9AACkdk0eYWd3w6/+Y+P0SDBgYP7RHlLM+0fWtXbP6DBk3k1QpHCle+J+H/5YrWZizF67SsstgUqVITp5cWWPUPxGR96U7aX9EtuzYy7FT5xkxoEtcNyWS0VPmkyWjG1/XrxbXTZGP1OvfPBQR+dR9dDNI/0UhoaF06DkCa2trJgzrGdfNERER+c/TDJKIiIiImY/uIm0RERGRuKaAJCIiImJGAUlERETEzEcTkIxGIyEhIVHef0dERETkQ/poAlJoaChlarYmNPTtd09+H/4tWuJXoyb+LVpaZPsiIiLy+fhoApKIiIjIx0IBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYsY6rhsg8l81fMJsfHz9Yn27iRMlZKR711jfrojIf4kCkkgc8fH1Y0jvdrG+3TFTF8eoXMlqLciUPh0+vn64pXNmYK/2OKVKQb2WPVk6czQOSRP/67ZUrNuO3Zti1p6YmLNkDYeOnKJDy4YkTpyQaXOWkzNbJtx7xnwcu/Qbw9A+HXF2Shlr7RKRz48Cksh/lL2dLSvmjSMsLIwNv/6POYvXMGrgxz3ztGHzLravm4eNjTUTpi+mcf1q1KxSNq6bJSKfIQUkkf+4ePHiUShfTnbsPhhp2fwf1vHX8bM89/GlY+uvqFK+BKGhYcxduoZDf53Czs6WoX074prOmelzV3L05DmSJE7EKPcuODulJDQsjKlzlnPq7CUckiZh9KCuJE2SmPOXrvHd7OW8eBFEofw5+bZjM6ytrEz1ej19xqjJ83jw8AlZMroyvH9nRk+ZT0DgC9p9O4ymDWuwe/8R/jpxlrAwI5XKFmP8tEVcuX4L59QpGDWwG0kSJ2TH7kMsX72ZePHi0bxRLS5fu8nZC1fpPXQy1SqVpnqlUriPmoGvnz/Zs6RneP8uWFnp0sx/411PHeuUsHysFJBE/uNCQ8PYsfsgObNlirSsfOkidGjVkLv3H9Jj4ESqlC/B1l37uH3nAcvnjSMgIBB7Ozu27NiLra0NqxdN4tS5yyxf8ysDerQlNDSMGlXK0LtLS6bNXcHaX3bSukldBo+ZyeSRvcmc0ZXBY75n64591K1RwVTv9HkraVCnCqWLFWDJql/Yc/AoowZ25cCfJ1g+dxwAR0+ep1SxAlQsU5S5S9aQN1dWRg/qxrZd+/ll2++ULVGYRSs2sGDacJIkToSvnx9VK5bkjwNHmDq6H85OKflx/TZyZstEn64tefjYU+EoFrzrqeOYnhIW+dAUkET+owJfBNGy8yDCjEZyZ89Mt2+aRCqTMkUyVq3fyoXLN3j0xAuAP4+doX7tylhbWZE4UUIAjhw/y9Ubtzl28hxGI7i6OAFga2NN9iwZACheOC/rN+/i9r0H2NvbkSWTGwBVypdg194/IwSkoyfP8feteyxctp6g4BC+rFEx2r4cOXGOFy+C+HX7HkJDwyhWKA/HTp2nQpmiJHNIAkDSJJGvqSpeOC/DJsxm9cbfqFez0rsOoYh8xhSQRP6j7O1sTbMxUfHz86drv7G0+roOA75tw9ET5wAwhhkxGAwRyhqN0KNjc0oXL/DG7VlZWWFvZ4vRCGarR2ne1KEkTBA/Rn0xGo2MHtyNTOnTmV5bt2knb6smY3oXFk0fwc/bdtOi8yCWzhpNooQJYlSniHzeNJ8sIhEYMBBmDOP2PQ9sbGyoWrEUXk+f8yIoCICC+XKwadtuQkPD8PMP4Kn3c4oUyMX6zTsJDg4hODgEr6fPAAgJDeXRY0+MRiNbduylcIFcuLk4ExDwgms3bmM0Gtm190+KFMgVoQ2F8uVk9cbfAPDyfmaq+02KFMjN6o3bCQsLb9NzHz8K5MnO7v1HePbcl7CwMB54PAYgdYrkptmwy9duYohnoPGXVbG1teHeg0exOpYi8unSDJJIHEmcKKFFrr94ddrrfRUrlIeNv/6PVl/XxcU5Fa26DKZgvpykTukIwJc1KvL3rXs06+hO4kQJ6NW5BXVqVODv2/do3smd+Pb2dGjVkJJF85PSMRmzF6/h6vVb5M6ZmdpVy2Ftbc2Ywd0ZN20hL14EUyBvDmpXKx+hDb06t2Ds1IU06xBex/D+naP9Wn7rpnWZOGMJTTu4kyC+Pf26tyZH1ow0aVCDDr1GEt/ejgZ1qlDbqRw1q5ZjyNiZ1K5WniwZXZk4YzHPffwomC8HWTK6/quxE5HPhyEo6IUxrhsBEBISQpmardm/9QesrWM/t/m3aInR0xODoyMJViyP9e2LiAj0HjLpnS/SnjqmvwVbJPJ+dIpNRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhGJZdt/P4DHoydx3Yz38su23Xh5P4vrZojEOQUkkf+wYeNn0XfYd29cPmDENE6cvkBQUDDuo6YTFBT8znXUa9nzncq/qvN9nDh9gdFT5pt+njF/Jddu3H6vbb3uXfoQFhbGjt2HSJUieaRl5y9dp2WXwbToNIgjLx/d8rrAF0EMGj2DZh3cmT5vJUajkRdBQUyYvpiWnQfR7tvh3LpzH4CAwED6DJ1M/Za96DN0MoGB4Xcnb9l5kOlfpS/bs+fAUQD2HTpO804Dadl5EDt2H4pQb+8hk03j5pImNZt/2xPj/op8rhSQRP6jgoND8HjkiaeXN/4BgdGWtbW1YcKwntja2nyg1sWOHh2bk/kD3x37+OkL5M6RhXjxIn68Go1Gxk9fxIj+nZkyqg8Tpi8mLCwsQpmft/wPZ6eUrJw/npu373H0RPhDe4sUzM3yueOoXrk085etB+C3/x0kZYrkbFg2lSwZ3dix+xCZM7qyfO44ls8dx5RRfcieJQNlShTiqfdzZi/+iVkTB7FwxghyZstoqvPQkVM8fvLU9HPBvDk4euIcRuNHcQ9hkTijgCTyH3XizEWyZU5PruyZOXL8rOn1dZt28lWbPnQbMI679x+aXq9YN/zuyCdOX6DP0Cmm1+u17In3Mx/8/PzpPmA8X7XpQ4+BE/APCOSbniN54vmUlp0HceT4WfwDAhk6bhaN2/Wj56CJPPfxi7bOV27ffUCHXiNp3K4vU+csx2g0cvX6LZp1cKdxu77MmL+SO/c8GDV5PvsPn6Bl50E89/GjS78xXLxyA4Am3/Rn9qLVNGrbl+9mL2PH7kO07DKYdt8Ox9fP39SOtt2H8VWbPvy0YRsAw8bPxuPhE1p2HsTWXfsICQ1lyqxlNG7Xj296jjQ94+2Vi1duUCBPtkh9ePTYi8dPnpIxvQupUzlibW3F9b/vRChz8Mgp8ufJjsFgIH+e7Bw6eprsWTJQqWwxAPLkzGIKMwkTxCdZ0iQYDAYyZ3DF2toqwrYWLFtPh9ZfYWUVj937/6JC6aI4JE2Mna0t6dI6AeFPMFi0YgPNG9UyrRcvXjxSpXTkqffzSH0Q+S/Rs9hE4kDAtz0wPn369oLvyZAsGfG/nxFtmX2Hj1Mkfy6MRiP7Dh+nfOkiXPv7Dus27WTJzFHY2trQpe/YGNd55MQ5bG1tWLf0Ox4+8iRBfHtGuXehS/+xLJ87DoC5S9aQN1dWRg/qxrZd+/ll2++ULFrgrXWOm7qQvt1akyWjK+OmLeL8pevs2H2QGlXK0KRBdZ54PiVVSke+admAE2cuMrRvx0jbuH33AaV7FKBdi/rUadqd1CkdWTZ7DH2GTuHAnyeoVqk0BfJkp16tSrwIfEG9lj2pX7syowZ2Zdeew6Y+/LJtN7a2NqxeNIlT5y6zfM2vDOjR1lTP/QePqVS2eKT6n3h54+ribPrZ1cWZJ17eZMnkZnrN08sbt5dl3FycI50ePH7qAnlzZQGgQuki9Br8B9PnrcTTyxv319rw7LkvN27dJW/O8LL3PR4TzxCP7gPGE/giCPeebcmUPh3rN/+PCqWLktLRIUI9TqkcuffgEcmTJY1iT4v8NyggicQB49OnGD09465+o5FDf52kQ8uGgJHJM38gJDSUk2cuUqF0EdMDb1Mkd4jxNvPmysrSnzaxYNl6vq5fPcoyR06c48WLIH7dvofQ0DCKFcrz1jr9/AO4eOVvxry8RibwRRAli+SjfKkiTJ+3kiRJElG9cum3ts/O1pZ8ucNndtK7pqFQ/pwYDAayZnLD62n4bIlz6hT8snU3Z85fJjQ0jKfez3FKlSJiH46f5eqN2xw7eQ6jEVxdnCIsf/jYkxQvA8ew8bO5efseWTK50aB2ZYzGf06pGY1hGAyGCOsaMBAWFn5qK8xoJF68f5Y/8XzKz1t/Z/7UYUD4DGAGNxcyZ0jHX8fPcM/jMVlfhq0/j52hYL6cpu37+wfi9fQZk0f14cCfJ5izeA1D+3Zk157DzJ0yhHMXr0ZoR0rHZDx85EmelwFL5L9IAUkkDhiSJYvT7V++dpOnz3zoPiB8VsQ/MJAz568QEhr61uuRAEJDQyO95pjcgSUzR7H9fwdo3XUIsyYNxEDEAGA0Ghk9uBuZ0qczvfbTxt+ir9NoJEECe5bNGRspUMyePJhV67bwTY8RLP5+5Fvb/crrp6Osra0wGo0YjUa69h9Hrarl6N6hGTdv38cYFvk6HKMx/Nqm0sULRLntpEkS4ePjh52jLaMGdjW9/uiJF7fvemA0GjEYDNy+60EKx4j7KYVjMu7ce0B61zTcuetBiuThywMDXzBw9Az6dWttmtVZuXYLIwZ0JoVjMpImScTaX3YwpE8HAC5dvUG2zOkjbDdlimTY29lSpEBuFq/cyMG/TuLr50+XfmPw8w/A+5kPK9b8SovGtXnu60c6s+An8l+jgCQSB952+svS9h06TusmdWndpC4AP/y4if2Hj1OhdFF+2fo7L4KCCAoK5s49j0jrJnNIyo1bdwkMfMGFKzfw8gr/Svjft+6RwtGBml+U5Y8DR7ly/RbFC+XFz8+foKBgbG1tKFIgN6s3bmdgz3YEBL4gNDSMXNkyRVtnwoQJSOOUim3/20/NKmV5+MiTVCmTc+HyDbJnyUD7Fg34eetufHz9SZUyOY8ee5lCyLt49twXj0dP+LJmRby8vCN81T1ViuQ8euxJqpSOFCmQi/Wbd1KsUB4AfHz9IpyKSuOU6uUsUsTwkypFcpxSp+D6zbskShgfo9FIRre0nDh9gQN/neLbDk0pVSw/J89conTxgpw6d4nmjWoRFhbG6CnzqVK+BEVf1gnh1wodO3WeqhVLcePWvQh1PXzkScmi+U0/ly5eIPybcI1rc/TEOTK6uVDzi7LU/KIsEH5d2dZd+2nRuDYAHo+eULVCyXcaP5HPjQKSyH/Q/sMnGDO4m+nnCmWK0GfoFL7t0IyyJQrTotMg3NI545Q6RaR107umIU+OLDRu14/K5YuTI2sGALyf+zBu2iKe+/jg6uJM8cL5sLezpULpojTtMIBu7ZvQumldJs5YQtMO7iSIb0+/7q3JkzPLW+sc1q8j46ct4sf123BM5sC4od9y6eoNJs9ciq+fPw3rVCFpkkTkyZEFH18/WnYezMQRPd9pTJImSUSlssVo1XkwObJlJK1zatOyOtUr0KHXKFo0rkXdGhX5+/Y9mndyJ769PR1aNYwQRtK7puH633fIlT1zpDoG9WrP6CnzCAs1MqhXe+LFi8fTZz7ce3lh+pc1KzJq0jyadxxIscJ5KZQvJ7/97wB7Dx3H45EnW3bsBWDskG/p3aUFY75bwMLlG3BKlYJh/TqZ6vHzD8Dezs70c7bM6cP71mUIdnY2jBrYjeg88HhMypSRb1Mg8l9iCAp68VF8lzMkJIQyNVuzf+sPWFvHfm7zb9ESo6cnBkdHEqxYHuvbF/mcPXvuS7tvh7H+h6lx3ZSPXkBgIMPGz2byyD5x3ZT3cvvuA1Zv3E7/b9u81/q9h0xiSO92MS4/Zupipo7p/151iViSvuYvItG6duM27XsMp0aVMnHdlE9CfHt70qV1jvT1/0/Frj2HaVCnclw3QyTO6RSbiEQrc0ZX1i198922JbIubRtZZCb8Q2j1dZ1Ptu0iscli74L1m3fx04ZtWFtbM7BnO/LnyW6pqkREPiqfcsD4lNsuEpsscorNPyCQJat+ZsW88Uwa0Yt5S9daohoRERERi7BIQLK2siJ5sqTY2ljjksaJhAkTWKIaEREREYuwyFyqra0N9WpWpHPfseTImoGGdapEWW795l1s+HUXgB6MKCKfnOETZuPj6xejsokTJWSke9e3F/wAPtV2i3xIFglIfn7+/HXsLG2bfcmq9VtxSJqYEkXyRSrXsE4VU3h69TV/EZFPhY+vX4y/0j5m6mILtybmPtV2i3xIFjnFtvfQcXLlyEyJIvmYNqY/W3bsI/BFkCWqEhEREYl1FplBsrKKx5nzlwkKCsbz6TOe+/jyjnf9FxEREYkzFglIlcuV4NTZy3zdvj9WVvEY2Ks9dra2lqhKREREJNZZbAZpQI+2lti0iIiIiMXpUSMiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjHVcN0BERD5e9z0e03vIpBiXf+LlbbnGiHxACkgiIvJGNtZWDOndLsblewyabMHWiHw4OsUmIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJixttSGz164ynezlxEaGkb1yqVp2rCGpaoSERERiVUWCUjBwSGM+W4+343uh3PqlNy++8AS1YiIiIhYhEUC0tGT58ieJSMuaVIDkMEtrSWqEREREbEIi1yDdN/jMfHj29F/+FRadR3MiTMXLVGNiIiIiEVYZAbJPyCAazduM3VMf+7c82Dc1IWsWjAhUrn1m3ex4dddABiNRks0RUTkkzR8wmx8fP1iVDZxooSMdO9q4RaJ/LdYJCClSJ6MDG4uJEmckJzZMuL93CfKcg3rVKFhnSoAhISEUKZma0s0R0Tkk+Pj68eQ3u1iVHbM1MUWbo3If49FTrEVK5SHk2cu4ucfwIXL10md0tES1YiIiIhYhEVmkByTO9C+RX069BqJMczIkL4dLFGNiIiIiEVY7D5I1SqVplql0pbavIiIiIjF6E7aIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImaiDUgbft0V6bVV67ZarDEiIiIiH4NoA9Lm7Xsi/PwiKIgNv/7Pku0RERERiXPWUb1Yv2UvDAZ44ulNg1a9TK/7+gVQtWLJD9Y4ERERkbgQZUDauHwaAE2/GcB3Y/qZXk+eLAl2trYfpmUiIiIicSTKgPTKinnjsbLSddwiIiLy3xJtQHr0xIvNv/3BEy9vjEaj6fUhfTpYvGEiIiIicSXagNRv+He4pnUiV/bMWFtbfag2iYjEieETZuPj6xfj8k+8vGNc9r7HY3oPmfTJbVvkvyragGQ0Ghk3tMeHaouISJzy8fVjSO92MS7fY9DkGJe1sbb6JLct8l8V7QVGhfPn4tqN2x+qLSIiIiIfhWhnkO7e96Br/3E4pXaM8Pqy2WMt2igRERGRuBRtQGr2Va0P1Q4RERGRj0a0Aalg3hwfqh0iIiIiH41oA1LXfmMxGAyRXp81aZDFGiQiIiIS16INSI3rVYvw884/DlGmREGLNkhEREQkrkUbkMqWLBTh5+KF89Jr8CSqVixl0UaJiIiIxKV3eo7IzTv3ufb3HUu1RUREROSjEO0M0hcNOgDh1yCFhIQQHBJCm6ZffoBmiYiIiMSdaAPSsjnjTP83GMAhaRLs7Wwt3igRERGRuBRtQHJOnQI/P3/OXryGwWAgccIEoIAkIiIin7loA9L5S9dwHzkdlzSpAbjn8YgJw3qSM1umD9I4ERERkbgQbUD6fsGPTBjei1zZwwPR+UvXmT5vJQumDf8gjRMRERGJC9F+i83PP8AUjgByZc+Ef0CgxRslIiIiEpeiDUjJkiZh76Fjpp/3HTqOQ9LEFm+UiIiISFyK9hRb326t6D9iGtPnrgDAzs6OSSN6fZCGiYiIiMSVKAPSg4dPsLOzwS1dGn5cMJE79x4A8PCxFzbW0WYqERERkU9elKfYps1Zzv0HjwGwsopHete0pHdNi0OSREx7OZskIiIi8rmKMiB5PPYkd47MkV7PliUDj554WbxRIiIiInHpjRdph4SGRnotODj8cSMiIiIin7MoA1K5koWYMH0xgS+CTK8FBr5g4vdLKFWswAdrnIiIiEhciPKK61Zf12HKrGXUa9GDjG4uGDFy4+ZdypQoRIeWDT50G0VEREQ+qCgDkrW1Ne4929Gm6Zdc+/s2AJkypMMpVYoP2jgRERGRuBDtjSJTp3KkVLEClCpW4L3C0QOPx5Sr3YYTpy+8dwNFREREPrRoA9K/NXvxatKldbJkFSIiIiKxzmIB6dTZS4SFhZEtc3pLVSEiIiJiERa5LXZoaBhzlqxh5IAuLFq58Y3l1m/exYZfdwFgNBot0RQR+QQMnzAbH1+/GJV99NiLVCmTx3jbiRMlZKR71/dtmljYfY/H9B4yKUZl33Xfv0t5HVdiziIBaeuufRQtmBtnp5TRlmtYpwoN61QBICQkhDI1W1uiOSLykfPx9WNI73YxKttj0OQYlwUYM3Xx+zZLPgAbayuL7ft3Ka/jSsxZJCDtPXgUT69n/HnsDPcePOLC5euMGdydTOnTWaI6ERERkVhlkYD03eh+pv+PnjKfmlXKKByJiIjIJ8Oi32ITERER+RRZZAbpdUP7drR0FSIiIiKxSjNIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIx1XDdARGLH8Amz8fH1i3H5xIkSMtK9qwVb9HG47/GY3kMmxajsEy9vyzZGRD4ZCkginwkfXz+G9G4X4/Jjpi62YGs+HjbWVjEelx6DJlu4NSLyqdApNhEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjLUlNvrcx48JMxZz564HSZMkYtTAriRPltQSVYmIiIjEOovMIJ27eJWv6n7BinnjyJYlPavWb7VENSIiIiIWYZEZpJJF85v+nydnFnbvO2KJakREREQswuLXIB0/dYG8ubJauhoRERGRWGORGaRXrt+8w9GT5+n2TZMol6/fvIsNv+4CwGg0WrIpIp+k4RNm4+PrF6OyT7y8P4p2ACROlJCR7l0t1h6RuHbf4zG9h0yKUdl3fT+8y/vt0WMvUqVMHuNtf0zvzXfpZ1y022IB6an3c4ZPmMOYwd2xs7WNskzDOlVoWKcKACEhIZSp2dpSzRH5JPn4+jGkd7sYle0xaPJH0Q6AMVMXW6wtIh8DG2urGL8n3vX98K7v+0/1vfku/YyLdlvkFFtQUDCDRs/gm5YNyJwhnSWqEBEREbEYi8wgrVi7hcvXbrLsp00sXrERgAXThmNvb2eJ6kRERERilUUCUrvm9WjXvJ4lNi0iIiJicbqTtoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJixjquGyDyqRs+YTY+vn4xKps4UUJGune1cIti5r7HY3oPmRSjsk+8vC227ffZvsin5GN6P7xrWz6mz6wPTQFJ5F/y8fVjSO92MSo7ZupiC7cm5mysrWLc7h6DJlts2++zfZFPycf0fnjXtnxMn1kfmk6xiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmrC214V+27Wbdpp0kSpiA0QO7kiqlo6WqEhEREYlVFplB8nr6jBVrfmXxjJE0rFOF2YvXWKIaEREREYuwyAzSX8fPkjVTeuzt7cifJzuTZy596zpGoxGAkJAQSzSJEKMRoxEMRqPF6pD/prAwIyEhoe9QNubH37ts22iMedl3LW/JbX9MbdG2P+y2P6a2aNtRe9fPrHdhyc/O92VlZYXBYADAEBT0whjbFaxcuwUfXz86t22M0Wikcv1v2Lp6DvZ2thHKrd+8iw2/7gIgLCyM23c9YrspIiIiIjGyf+sPWFuHzx1Z5hokwz8zQgDGMCMvA1kEDetUoWGdKkB4QAoKCoqQ3l7XvNNAVs4bb5Hmfso0LpFpTKKmcYlMYxI1jUvUNC6RfW5jYmVlZfq/RQJSSsdknLt4DYDHnk+xsbHBztY22nXixYuHvb39G5cbDAZTqpN/aFwi05hETeMSmcYkahqXqGlcIvucx8QiF2kXLZiHq9dvERj4gpNnLlGyaH5LVCMiIiJiERaJfckcktC66Ze06zGcxAkTMHpw93+9zQa1q8RCyz4/GpfINCZR07hEpjGJmsYlahqXyD7nMbHIRdoiIiIinzLdSVtERETEjAKSiIiIiBkFJBEREREzcf7dPO9nPgwdNwuvp8+oXqU0zb+qFWG50Whkyaqf2b3vCKlSJmf0oG4kiG/P8tW/sufgUZ75+NK0QQ2+qvtFlGUTJUwQRz37d95nXBIlTMDqjdvZ+cdB/PwD6db+a8qUKMQDj8d8/U1/3FycAahUrjitvq4TF936V2JzTHSsJODS1b+ZNncFvr7+rFowAeCzOVYgdsflczle3ndM7t5/yIiJcwgIfEGLRrWoVqn0Z3OsRPfc0Kj6/S5j9KmKrTEZPWU+J89cIlHC+ADMmjSYJIkTxlW33lmczyAtWfUz5UoVZtmcMfz2vwPcvvsgwvIr125y6Mhpls8dR4G82Vm5dgsGg4Ec2TKydNZoFn8/knlL1xIcHBJl2U/V+4yLn38AL4KCWDh9JOOH9mDctEWmG3bmzJqR5XPHsXzuuE/yQwxid0z+68cKgGNyB9ONWl/3ORwrELvj8rkcL+87JjPmr6RN0y9ZMHUY839Yh6+fP/DpHytve25oVP1+1zH61MTmmAAM6t3edIx8SuEIPoKAdOjIKfLnyY61tTV5cmTh8NHTEZYfPHKKfLmyYmUVj/y5s3Po6GkMBgPFCuUhODiEazfu4JbOGRsb6yjLfqreZ1wSJohPq6/rYGUVjwxuaQkNDeVFUDAASZMmjotuxKrYHJP/+rEC4Td0zZ09c6TtfQ7HCsTuuHwux8v7jEloaBh/HjtD/tzZSJgwAa4uzpw4fRH49I8V8+eGHj56yrTsTf1+1zH61MTWmLzikOTTPUbi/BSb19NnuKRJDYCrizNPPL0jLPf08iZLJjcA3NI588TzqWlZq66D8XjoyZKZo95a9lPzb8YF4PK1m7ikSW16/t21G7dp020oCRPGp2/XVqR3TWv5TsSy2BwTHStv9jkcKxC74/K5HC/vMybPfHxwSJKYhC9PKYav95QsGV0/+WPF08sbVxcnAFIkdyA0LIzAF0HY29m+sd/vMkafotgak1dmLvyRh4+9+KJCCdo0/TLKR4l9rD5oQPrhx00cPhbxL5aAwBfw8jRQmDEMQzyzwTMYCAt7uTzMSLzXlv+4YCIXr9yg/4ipLJw+ItqyH7PYHpeQ0FBmzF9Fx9aNAEiV0pGh/TqRI0sGVv/8G5NmLmXO5CEW7NG/Z+kx0bEStU/xWAHLj8uneLzE1pgYMBD22rM1w4xGDPEMn+yxEkE0zw19U7/fZYw+SbE0JgAtG9cmQYL4hIaG0rXfWPLnzkbBfDk/XF/+pQ8akFo3rUvrpnUjvPZVmz7cvf+QzBlduXPXg8wZXSMsT5k8GXfuhZ8nv33PgxTJk5mWGQwGcmbLREY3Fy5euRFt2Y9ZbI/L9LkrKZQvB8UK5QHAyioe+XJlBaBu9Yqs+XmHJbsTKyw9JjpWovYpHitg+XH5FI+X2BqTpEkS4ePrh6+fP4kSJuDOXQ+KF877yR4rr4vuuaFv6vezZ74xHqNPUWyNCYBbujSm7ZYqVoCbdx58UgEpzq9BKlWsACfPXiIkJIRzF69Rokg+nno/p8/QKYSEhlKqWH5On7tMaGgYJ89cpGTR/Nx78IhV67YSGhqGl/czzly4Qrq0TlGW/VS9z7gArN+8C08vb9o2q2fa1q49h/H08sZoNLL/8HGyZ0kfN536l2JzTHSsRO1zOVYgdsflczle3mdM4sWLR4ki+Th59hK+fv7cufeAgnlzfBbHSlTPDV21bis7/zj0xn6/yxh9imJrTJ56P2fH7kMYjUa8n/lw+vxlsmVOH9fdeydx/qiRZ899GTpuFp5e3tSqWpYmDWrw4OETug8Yx8p547G3t2Ppj7/wvz1/4pTakVEDu2FrY8OcJas5fuoCz338aNm4NvVrVwaIVDZhgvhx2b339j7j4v3Mh8Zt+5LBzcU0JdqicW1SpXRk3tK1eHp545jcgWF9O+LslDJuO/geYnNMqpQv8Z8+VhImiM+4aQs5e+Eq9x88xi2dM326tQb4LI4ViN1xyZcr62dxvLzvmDzweMywCbPxDwik1dd1+KJCSU6fv/JZHCu/7tjL6o2/mZ4bumLNrzilSkHThjWi7DdE/XvmTWU/RbExJtbWVsxbupaTZy6Ffw7Xq0qTBjXiuGfvJs4DkoiIiMjHJs5PsYmIiIh8bBSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJPkk1GvZk8bt+tGy8yBadh7E6fNXYrRelfodeODx+F/X/+P6bTTr6M7ISXP/9bZi0+qN2xk9Zf6/2ka9lj1jpzEfyNkLV+k2YBwlq7XAx9cvyjIhoaFMmbWMZh3c+abnSO7c8/jArYyZRSs2MG3uCgCu37wTa8dXy86DOHH6QoTXHng8pkr9DgD0GjyJLTv2Rlg+ZOxMftm2O9K2tu7cR+V639Cy8yC+bN6D9j2Gc+7iNc5fuka9Fj0iPLfr5u171G7anbCwsFjpR2yJjfeJ/Pd80Gexifwb3493J3Uqxzipe8OvuxjWrxP5cmeLk/rlH6lSJKdt0y85furCG8ts27kPj0dPWDl/PL/v+4ux3y1g3tRhH7CV7y5T+nQM79/5g9RVvlQRDh05Ra2q5QAICgrmyImz9OnaKsryhfLlZOKIXoSFhfHHgaMMnzCbdUu/IzQsjBu37pIpfToA9h46TsUyRYgXT397y6dPAUk+GQ4Oid9a5trfd5g4YwmBgS/I4JaW4JAQ07JV67by+76/CAgMJI1TSkYN7MZT7+d07juGn5dPw9ramoDAQL5q04e1S74jQXx7AEZPmc+jJ16Mm7aQ5o1qU+uLsixbvZldfxzGaDRSvHBeOrdtjI2NNYtWbMBgMHD2wlWSOSTF3z+AMiUKUqtqOfYfPk7/EdPYuno2yZMlZdrc5bikcaJW1bLMmLeKK9dv4ePrR/lSReja/msAuvQbQ/XKZdj82x9ULlecr+p+wcLlG9i15zCOyR2ws7UlZYrID06t17Innds0YvXG32jeqDbFCubmuznLuXD5BgYDdG3XhOJF8tKi00CeeD6lZedB1K5WnkzpXZg+byXL544Dwv/yvnrjFkP7dmTrzn1cvPI3T72f4evnz/RxA6j2VWc6tmrI9t0HuffgEYN6tadUsQIR2jJ6ynwSJUzAjZt3efjYk1zZM+Pesy12trbcunOfSd8vxfPpM5IkTsiQPh1wdXFm9JT5ZMucnj8OHCV39sym8QBIncrxrUF59/4j1K5WHoPBQPnSRRg/bRFe3s9I7pDUVGbbrv38vPV3AgJfkDBBfMYM7k5Kx2Rs3bmPk2cvYTQaOXvhKg5JEzNlVF+SJE7IohUbCHwRxP0Hj7h49W8yurkwcXhPrK2t6dJvDI3rVaNcycJA+Ozl8jljcXZKGeWxZ/6okivXbzFg5DR+Xj6d3/f9xbKfNgHg8ciTQvlyMn5YD85dvMbUOcvx8w/AOXUKhvXrRPJkSfF49IQJ0xfz+MlT0jqnwvu5T7TjU6ZkQWYv/ong4BBsbKw5duo82TJnIJlDkmjXixcvHsUL52XI2JmEhoaFB62/Tv0TkA4eo0fHZhHWOXX2EpO+X0poWCjOqVMyZnB3fHz8+HbgBEoWzc/ZC1cICHxBr84tKVowNydOX2Ddpl0kc0jCpas3mDNlKNdu3I6y32/ah2FhYTF6n4hERzFfPglW8eIxZOxMGrfry3ezlxEUFBypTEhoKANHTafRl1+wYt44urRrHGH6v2C+HCyYNowfF0wkNDSM7b8fwCVNanJkycCBv04CsP/wCYoXymsKRwBD+3YkhWMyRg/qTu2q5dix+yAH/jzBou9HsHzuWO55PGLV+q2m8us372JAj3YM79+JYoXzcvz0RQCOnTpPoXw5Of7y1MexUxcoWjA39nZ21KpajsXfj2T53LFs+m03f9+6Z9re1h17mT1pMI3rVeO33w/w57EzLJszlrlThuCWzvmNY3bgzxMsnD6SimWKMnPhT+TJmYWfFk5kzuQhfDf7BwwYmDq6Hykck7F87ji+qvvFW/fDrzv20LxRLWaMd8dgMPDcxxc7O1vmTx1Gq6/r8MNPm6Nc74nnU6aM7sOPCyZw9/5DtuzYS0hoKEPHzaJX5xasXjSJts3qMWvhTxHGcdKIXhHCUUw9euxFqhTJAbC2ssIxuQOPHntFKJM1kxvfT3Bn5bzxZHBNy5qft5uWHT99gXbN6/HjggmEhISye/9f/yw7dYH+37blpwUTuXL9lmn/RieqYy86lcoWY/nccUwd04+ECezp9k0TfHz9GDd1IeOH9mDN4smUK1WYZavDQ9ToyfMpmC8HqxZMYHCfb7B6ywxOcoekZM7oyunzlwHYd+g4FcsWfWs/wsLC+Hnr72TPkgEbG2vKlyrMoSOnAHj02JMnXk/JkzNLhHVWrd9KrarlWL1oMv2/bUOihAkA8Hj0hCrlS7Bk5mi6f9OU0ZPnERIaCsD+w8cpUSQvS2aOJjg4+I39ftM+fJf3icibaAZJPgkj3bvgksaJwMAXjJo8j7W/7KBIwdyM/W4BACWK5KNapdK8CAqicrniADilSoGtjY1pG64uzmz//SCnz1/h7v2H3L3/EIDG9aqxct0Wypcqws4/DtO0YfQPVNx/+AR1qlcgvn14iGpQuwrzf1hH6yZ1AahUtjjOqVMAULxwHn746ReMRiOnzl2mTZMvOXz0NIXy5cQ/IBBXF2cMBgMpHZOxav1Wrly7CcDd+x5kcEsLQKN61bC1De/Hob9OUa9mRdPsQ1rn1Fy9cSvKdjZpUAMrq/BflPsOH+fshav8vOV3AMLCjHg/ex7T4TcpnD8XObJmjPBa2ZKFMBgM5M6RmdUbt0e5Xp6cWbGztQWgVNH8nLt4nUL5cnLrzgNGTZ4HgNEI9vZ2pnXqVq9A4kQJ37mNAIZ4hgg/G41GDGZl0rk4sf/QCY6fvsC5S9dwSZPatCxrRjfSOKUCIEe2jHh6eZuW5c2VFYek4bOZWTO58sTr6Vvb86ZjLzpGo5Fx0xbRusmXpHVOxeGjp3n4xJN+w78DIDQ0jAxuafEPCOT0uctMHdsPgKRJEsdo3CqULsrBv05SMG8ODh09RYfWDQHoO+w7Hj32BGDJrNFAeGBs2XkQ9zwekSdHFsYN+RaAfLmzc/f+Q54992X/nycoXyry6bUalcuwcPkG4sWLR+1q5Uyv29vZkTtHZgCKFMiNj58/Dx+F1+uWLg1lShQC4NzFa1H2G968D9/lfSLyJgpI8knIlT38gzRpkkSUL12EC5ev07xRLdOpIICr129hZWWFwWD+qxACAgNp32M4daqVp/lXNUmVIjm+fv5A+F/3Mxas4trfd7hzz4P873idkcEQ/u+VV6EEII1TKuLb23PmwlXsbG0pUiAXc5as4eTZSxQtkBuDwcCV67cYMnYmHVo2pHql0jzxmkXYazNfr28vJDQUKyurGLUrQjljeMjMnNE1QplIF7AbDISEhL5xm9bR1G1tbY2Rtz/72traivj2dqZA9MPsMVFesxLTfkYldUpHHj72JA9ZCAkJwevpM1Kl/Oe0nNFo5Fv3CRTIk536tSqRM3smDhw+EXV7rawizERGXGbNqy4biHrsojv2orPptz8wGKBO9fKmNrukSc2y2WMjlHu1rXcdr3IlC9HdfTyVyhbH1cXZdPpxyqg+kcq+ugZp2erNXL1+C2enlC/rjEfJovn589gZDvx5klZf14m0boUyRSlSMDe/bt9D43Z9mTVxMHa2NhHKWFnFw4CB+C8D8uvH/Jv6Hd0+fJf3icib6BSbfPSOnDjH2QtXAXj23Je9h46RJ0eWSOXSuTjz4kUQR0+eA+DytZsEvngBwO07D/B+5sNXdb8gdaoUXL3+z1+TBoOBRnW/YNSkuXxRoeRbLzAtU6Igv27fQ2DgC0JCQ9nw6/8oXbzgG8sXL5yXtT9vp2DeHCRMmIBECROw9+BRihbKA8DxU+fJ4JaWyuWLExoWZvorOir582Tnt98PEBwcQkhoKBcuX4+2ra+UKl6AxSt/Jjg4BKPRyH2PRwAkS5YUPz9/Al8EAZAiuQO373ng6eWNj68few8ejdH23+beg4eEhYXh6+fPtl37KVE0H+lcnHBImojVG7djNBoJCgrm0ROvt2/sDVZv3G46xVKxTFF++98BjEYjew4cI1uW9BGur3nu48e5i1dp0qAGGdOn49KVG/+6j47JHTh97jJGo5H/7f2TgIBA4O3HXlTh6+79hyz7aRMDe7Y3Bf5c2TPz8JEnu/cfAcDPP4Cn3s9JlDABGdxc+O1/4aft7ns84slrM15vkiqlI4kTJWTVuq1ULFMsRn1s1rAGf9++x57XjovypYuw849D3LrzgLy5skZa58SZiySIb8/X9avjnDoV5y9dAyAoOJgHD58AsGXHXtzSOUd5DdSb+h3dPnzf94nI6zSDJB89lzSpmLVoNVNm/8BT7+d8UaEkdWtUjFTO3s6Wke5dmDZnBXZ2tuTKnhmnVOGnujJlSEfJovlp1nEgbi7OpE2TirCwf34xVS5fgkkzlzKxcum3tqdqxVJ4PPKkbfdhGAwGihbKTbOGNd9YvnjhvPQdNoVpYwcA4X+Nr/75N/p0bQ2E/4V98K9TtOwymKyZ3Mjg5vLGbdWvVYnrN27T5Jv+OKVKQcb0Lvj5B7y1zT06NmP63BU06+iOvb0dxQrmoWv7r7G3s6VqxVI0ad+PBrWr0LxRLWpWKUPzTgPJljk9FcsW49LVv9+6/be5ffcBXfqOwfPpM2pWKUvpYgUwGAxMHN6bKbN/4Ncde7C1taFFo9qmU6RvMnDUDO49CD9F1anPaPLnzka/7m14+PiJqUz1ymW4fO0mzTsOJEGC+Azv3ynCNpIkTsjX9avTodcInFOnJHeOzDzx9P5XfWzSoDqDxnzPkRPnqF21HFkyuQHRH3sF8uZg3NSFkY6f2YtW4+cfSO8hk4HwMDNlVB8mj+zDjPkrWbxiI3Z2NnRt14RC+XMytF9Hxk9bxLpfdpApQzrSpXWKUZvLlyrC3KVr6Pdt6xiVt7a2ZmDP9gwcPYMCeXKQNEkiCufPxbDxs6lWqVSkPy5CQ8M4cfoCM+avxM8vgMwZXalYtije3j4YDAbm/7CW63/fJWECe0YN7Brl7G/SJImi7HfBfDneuA/f930i8jpDUNCLt8+Ji3zmtuzYy7FT5xkxoEtcN+WzM3rKfLJkdOPr+tXiuinykXjg8ZiWXQaza+OCuG6KyBtpBkn+00JCQ+nQcwTW1tZMGNYzrpsjIiIfCc0giYiIiJjRRdoiIiIiZhSQRERERMwoIImIiIiY+T/uPYzHirV2IAAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFVCAYAAAAUvhB3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAWRpJREFUeJzt3XV0FFcDxuHfEoXgLsFdg7tLcXd3p8XdIbi7Q7EWL1CgSAtFCsXd3QMJIcR9vz8CW7KEJNAEQr/3OaenZPfOXJnd2XfvzM4Y/P39jIiIiIiISayv3QARERGRmEYBSURERMSMApKIiIiIGQUkERERETPfVEBav2kHCe0dOHHq3Ber03HqfBLaO/Dw8VMAylVvRpsu/b9Y/WH58+jfJLR3YP2mHdFWR0zopzmj0ciwsdPIkLsMuYt8xyvX1x8t+/DxUxLaO+A4dT7wz2vnz6N/f6nmRtqO3b+TPndpzpy7FObz5q/Bz/VuTKbNWfqv1hOT5S1enWr1237ycpNmLCKhvQP37j+KhlZ9+HoUkZgvRgWk7n1HktDeIcz/jh4//bWbB8DCmeMZM7T3v1qHj49vtAecT7Fy7SYS2juEeiwq+vkx2QpUZNKMRZ+83IlT51m4bB3FCjswbkRfkiROFA2tizqR7Wel8iVZv3w2+fLkjNL6O/QYRM1GHaN0ndGpcu1WdO878ms3Q0QEAMuv3YD3de3QgppVKxAUFEzbrv0pU7IIXTu0ACBXjiw8evLsK7cQcufM+q/X8dLlVRS0JOq8ePlhe6Kin2EJCgrC5dXHZ37C8+DREwA6tW1GlYqlo7JZUe5T+hnXLg6lSxSO8jaEtV1jshfOr8iaJePXboaICBDDZpDy581JrWoVqVm1PAD2aVJRq1pFalWrGGq24PTZS1St15a0OUrSoccgAgICgJAPpZnzV5CnWDWyOJRnyOip+PsHfFDP5l/2UL1he9LlKk2eolVZ89M203Ne3t70HjSO9LlLU/q7Jpy/eDXUsu9P4R89fpqE9g6m5c2n0R89eUbdZl1InbUYhcvWYf7SNRz56xQOJWoA0LPfKNOhE6PRyJqft1GoTG3S5y5Nlx+G4e7hCYQcWlqwbC25Clchd5Hv+Gnzzo+OoZubOz37jyJjnrIUKFUrVN+27dxLgVK1sM9egpqNOnL+4lW69x3JlFmLAUho72CacQirn9t37adGww5kyF2Gbn1G8PDxU5q27UW6nKVo122gaaxv3LpLl++HkqdYNdLlLEXHnoPx8PTi4eOnJElfkODgYKbMWhxqZvC3A39SsnIj0uUsRdN23+P0wjlUv9Zv2kGPt7MLjdv0pHvfkbi+dmP0hFkUq1Cf1FmLUbVeW27fffDRsXnfpas3qFy7FamyFKNkpYZs2rb7gzKeXt4MHDGJ7AUrkb1gJQaNnIynl3eY2/rd+HX5fuhH++n2xp1WnfqSNkdJ8pWozvgp8/D3D/jg8F9Er8HwtvE7eYtX56+/z/DX32dIaO8QaibrudNL2nYdQLpcpalUqyVPnjmZnotoO0DI63Hdxu0Ur1ifNNmKU71BO+4/eAyEbPu6zbpgn70E5ao34/TZS6HGa9W6zbTs2Id0uUpTuXYrU90J7R14/OQZP2/eaZpdffe6O3TkBN/VbUOxCvUJDAxk+eqNVKzZAvvsJShYuja/Hfgzwu39bozX/LSNkpUakiF3GfoNdcTPzz/M8r8f+osGLbuRKW85shWoaHqPfG7/37l99wF1mnYmbY6S1GveNdTYX7xynVqNO2KfvQQlKzVk+679YbatZqOOdOw5mNkLVpI5X3m2bP/to++59/v+x59/UaVOa9LmKEnHnoNN+01//wAGDJ9IxjxlQ83av3tdnTxzgcq1W2GfvQQ1GnaI9HtM5FsXowJSZC1d9TON69egRNGCbNu5j72/HwFg/pI1jJs8l5pVKzC0fw9+2rSDpT/+/MHyJ06do0iBfDiO7EeSJInoO9TRdH7HmAmzWf3TVjq2bkLHNo259S92BuMnz+PchSs4jupPrWoV8fX1I3fOrAzp1x2ALu2bs275LJIlTcz2Xfv5YeBYChXIi+PI/hw7ftr04btz9+8MHzudQgXyMmLw9zx99iLM+oxGI52/H8quvQfp06M9DetW44dBY7lw6Rpe3t507T2c1KlSMHH0QFKnTI7RaKRrhxaULFYIgHXLZzFiUM+P9qfvEEdqV69EscIObNjyK2WrNaVksUKULlmE7bv289v+PwF48tQJL28fBvXuQqN61dm6Yy+LV6wnWdLEzJg4HIAGdaqybvkscuXIwqmzF2nRoQ/2qVMyccxAHj9+Rp8h40PVXbZUUbq0bw7AkH7d6dqhBUFBQZw5f4V2LRsxqE9XLl+9wYDhEyO1bQYOn4TTC2cmjx1E6ZJF8PHx/aBMn0HjWPPzNnp0akX3ji35cf0W+pm1Kywf6+e8xavZs/9PhvTvTovGdfHy9sHK6sNJ3PBeg+Ft4/fNmTKSRAkTkDN7ZtYtn0XDutVMz63ftINcObLQtnkDzl64wrzFqwEitR0Aftq8k179R5MlUwYmjR1E7pzZSJEiKW5v3KnXvCsvXjozfmQ/0tmnpkXH3nj7+JiWHTp6Gvny5KBt8wacOX/ZVPfqJTMAKFOyCOuWz6JsqaKmZdp2G0iZkkWY6jgECwsL/jz6N1UqlmHciL4hr+HeI0zBNSJzFq2iS/vmNKhTlZVrN4e5fwA4c/4ymTKkY9yIvuTMnoVJMxaZzn38N/0/ePg45csUZ1Cfrhw/eZZ+QxwBePHShbpNu+D2xoMp44eQOVN62nUbyKEjJ8Js3/4/jrJ1517GDu9DudJFP/qee1/vQeNo2rAWJYoWZOuOvab95rwlq1m+eiOd2jalU9umAIwc/D3lyhTjwaMn1G/elVixYjFxzEAMBgPtug3EaNT1heW/L0YdYousWZNHUqViafLlycH+g0dN32iWrvqZMiWLMLR/SAD56+8z7N57kF5d2oRafuakEfj4+HL+0jUKOuTm4uXrnL94lbRpUrF+0w6+q1iGUUN+AODu/UfMX7Lms9oZL54dAJkzpad9q8YYDAYAihfJD4DD2xmzd23PlCEdU8cNAQPcvvOArTt+Y+r4Iazd8AsJE8Rn2bxJ2NrakChhfP76+8wH9T14+IQDh44xsHcX2rZsCEb4adMOdu07yIBsnYkdOza2NtZULF+SNi0amJazT50CwNSWjxkxqBcd2zShWGEH9v1xlHYtGtK7R3vOX7zKnn2HuHnnHgCVK5SiUvmS3Lx9j9ixbVm74RdOn71EnNixqVCmOABZM2c01Td0zDTixLZl/oyxWFtb4e3tw+BRU/D3D8Da2gqAtGlS4ZA3p2n88r/99+4tK3j2/AUXr1wnrX1qTp+9GKmdd7y4dmAw4JA3Z8hYmXF97caWHb/RsG41evdoD8CFy9fZ9MsepowbEu66P9bPeHHtMBgMpEmVglrtK2Jp+eHbLzg4ONzXYHjbOH++XKb1VCxXkti2NiROlMhU/7svAd06tGBw326m2Zjbd+8DsHz1xgi3A8CCpWvJlCEdq5dMx8LCwvT4lu2/4fTCmYUzx1Ewfx4KFchL2apNOX32EhnS2wPQtUPzMOs2nzV+11eAxvWqM3Lw96Z61i2fhbuHJ+cvXSVPrmz8+tsf3Lp9j4L584S7XQAcR/WnepXyBAQEsGHLr+zZ/yffd/3wpO4h/boREBDAhUvXKVrIgcPHTnL67CVKFC34r/rfpkUD+vUKmaU9dPQEBw4dw98/gE2/7MbtjTsrFkymUvlS1KpWkT37/2TJqp+pULbEB+0LCAhk/YrZpLNPDXz8Pfe+j+03T529SJZM6Rk+sCeBgYH8tGkHsWPbkj5tGhynzcfbx5d508eQInlSkiZJTIsOvXnw8AkZM6SNcLxFvmXfZEB696076dvDbn5+/vj7B/D0+QuePn9BhtxlTGWzZEr/wfJLVv7ExBkLiWWIRca3Oy53d09cXr3G28eXTBnTRUk7x43oR+LECWnVsS/p09kzfkTfMHd2EPJh8PyFMxny/NP2dx9Kj548wz5NKmxtbcKt7905OtPmLA31SyUXF1dsbW34besqxk6ag0OJGjSuX4Nxw/uSPFmSSPfH6u0HepIkIeNuZRXSvsSJEwKYDrFdv3mHTr2GcvP2PQrky4WVpSXuHh4fXe/DR0/x8vYhW4HQAc31tRspUyT76HLuHp506zOCvQcOkyVTerx9fPH28SUoKCjCviye48iUmYv5rl4bChfIx4RR/SngkNv0/LsPZ4f3TpwukC8X23ft58GjJ6Y+f4qeXVpjYWnBgOETGTNpDiMH9aJh3eqhykT0GgxvG0fWu+1maWlJooTx8fML2W6R3Q4PHj6mYrmSocLBu+UBGrTsHupxZxdXU0D4WN3heX8bGI1GHKfOZ+GydSRIEM906P3d4eiIvPuSYmVlReZM6XF1dQuz3PZd+xk8agpeXt7kzpktVB3/pv/v6gfInjUzBw+f4I27u2nZd18CEsSPR5ZM6Xn4dnubS5wogSkcQeTec2HtNwHy5s7O74f+4vBfJ3n58hXePr6kSRnypenhw5B2FatQP3SfXrkqIMl/3jcZkMJibW1F6pTJSZM6pembN4ScAPu+h4+fMnjUFEYN+YE+Pdrz199nqd2kExCy07G0tOTileum8uHNRrwLMO9Ouvbw8Ar1fFy7OIwY2IsfurWjW58RNG/fm3tXDhMrVsiRTT8/P1PZ9OnSYGVtxfzpY007UUvLkB1w8mRJOHnmAj4+vsSObfvRNqVPmwaADq0bU792VdPjaVKF7Oxy58zKpjXzuXLtFjUadQBg8WxHYr3d0fv6+kUYwiJjwPBJWFjE4v6VI8SLa0fe4v+EgFgWYfQ9bWquXr/FuuWzQn3oJE0S/q/UFixdy8E/j3Pm8A4yZUxH974j+Tmc87PelzRJYqZNGMbgft1o1u4HWnfpz5WTe03Pv/tAu3D5n0NX598exsqQzh7ft+1/6Ryy7c0/oMPqp5WVFd93bUvnts0YPm46HXsOoaBD6FmPiF6DEW3j0G2wCFV/RCK7HdKlTc31m3cICgoKVe5d22ZNHkGWTBlMj+fKkSXCQ2DvXvMRtffYiTPMmLecZfMm0ahedX7avJOe/UZFqn/v8/Hx5eHjZ5QoWuCD53x9/ejaezgtm9Rl6vghPH3+wnTeIERd/2/dvke8uHYkTZKY9OlClr1w6TqVK5TijbsHd+49jPSPEcJ7z0WkQ6vGzFu8mrpNuwBQtVIZalarENKnt+1au2wmCRPEf69P0fMjDpGY5D8TkAA6tWvGuMlz2bh1F8WLFuDGrbs0MvuG/u5ckwuXrvHT5p2sWLPJ9JylpSU1q1Zg196DTJ+7jDhxYrN2w/aP1pcpQ1osLCxYu+EXDAYDm7btNu3oAwICaNbuB/Lny0XWzBlwdX2NwWDAgMG00/l5868kTpSQyhVK06ltMzr1GsKyHzdQpWJpHj1+RvEiITvvujWrcOzEGfoOdaRU8UIsXLY2zPZkzJCWiuVKsPmXPSRMEJ8M6e25dOUGo4f25vzFqwweNYUmDWpiMBgIDAjA4u2HeIZ0IWFgyqzFVChbItT5H5/Dx8cHFxdXdu75nXMXrvD4yTPSpEoOQIpkSbG1sWHX3oPky5ODUsUL06FNEzZv/42Z81fQoHZVXrq8In3aNGEeggpdjy++fn7sP3gUL28fdv32h+m5pEkSYWlpyfmLV/H08iZ1ypD6j504Q/58uWjW7nuqVCxDqpTJ8fTyMo3FO4kTJaRR3er8uvcP5ixchdFoZM/+QzSpX4NEiRIQGBhIggTx2L3vEGntU7F736FQ5xOZ97NksUKMcpxJ4sSJyJ83J8+cXmIwGExB6p2IXoPhbWNzGdKl4dTZi6zbuJ38eXOZDvl+TGS3Q4fWTRg0cjIdegymxnflOX7yHH17dqB29Uo4TpvP/CVraNeyEVZWlrx2c6dMySIRBiQLCwvSpU3Nkb9OsWnbbgoXyBtmuXfv3xOnzuHl5c3ct+cwvZM6ZXIeP3nOg0dPTK/r981dtJrXbu7s2XcId3cP2rZoaFoOQl4f9etUJSAgkJu377Pplz1s/iX0Cfz/pv87dv9OpgxpefLUiT8OH6dnl9YYDAYa16vB9LnLGDNpDi+cXdh74DBBQUF0fXveXUTCe89FZMWaTSRMEJ9ObZtiaWFBAYfceHh4kShRAlo0rsOCpWuZMW85LRrXwdfXDysrK8qULBKpdYt8y77Jk7Q/5odubRkztDfH/j7DoBGTOHHy3Aff7HNky8wP3dpx6MgJFi5dS/eOLUM9P33CUL6rVIY5C1exY9cBurRv9tH6kiVNwshBvXB7487W7b8xYdQA0zd5S0tLWjSpw/6DR+k7xJE37h6sWjzVdGx/SL/u3L77gGFjpnHn3kMa1q3GvOljuHXnPoNHTmHP/j/x9AqZkWrXsiG9urbhwMFjzF6wko5tmobZHoPBwIr5U6hfuyrrNm5npONMnjxzwvW1G1kyZ8Ahb05mzV/BmImzKVemOKMGh8y0dWrbhNIlCrNk5U/MWrDis8f/nXEj+mFlbcXoCbOwtramWpVypudix7ZlyrjBvHH3YNDIyZy/dJXiRQrw08rZvHZ7w9Ax09i4dVekDpl079SSooUcmDBtAWcvXDGdYApgFycOTRvW5PjJc9y4eYeihR3Ikys7K9ZsIl5cO+rV+o5N23bTf+gE4sSOzfJ5kz9Y/6wpI2ndrD7zl65h4fJ1tG3egJmTQ35JZ2lpydRxQzAYQoJu1w4tKFww30f7eeHyNVo0qcvZ85fpN9SR6zfvMG/6GNOsw/vCew2Gt43NjRnam3T2qRk6eio7dh+IcDwjux06tW3KhNEDuHTlBv2HTeDx02cEBAaSKFECdm5cRvp0aZg6ewlzFq7C5ZVrmL8kDcvU8UOwtbFh4MhJHPnrVJhlKpUvSZMGNdm4dRdrN/zCD91Cnz/UonEd3N648+t7Yfl96dKmxnHKPM6ev8ykMYOo/va1WalCKdKnS8OSVT8TL64dE0cP4Or1W0ybvZTa1SuRLGniKOl/q6Z1Wf3TNlau3Uz7Vo0YPjDkRxEpUyRj58ZlxI8Xl0EjJnH77n1WLpzy0UPy5sJ7z0WkUvlSOLu4Mn3uMsZOnku95l3JVeQ7Ll65TqaM6di+YQk21taMnTSHZas34vraTSdpy/8Fg7+/n17pnyB7wUpkzZyBXZv/fZAQkS9j/aYd9Ow3iu0/L6H82xPoJUTl2q0omD8PU8cPwWg0cursRarWa8uE0QPo2bn1126eyFfznzrEFp2cXjizZ/8hXrx0oWbVCl+7OSIiUeLJM6eQk67Tp8XW1pptO/dhY2Nt+iWmyP+r/9Qhtuh05K9TjBg3g0L589CnZ4ev3RwRkSixZO4EEiVMwJhJs3GcugArK0t2bFiqE7Hl/54OsYmIiIiY0QySiIiIiJkYFZAmzFzG8rVbTX/3GTaFqXNXmf4eO3Uxm3fs55WrG4NGzzT9OmT89CWcu/jP9Wp6DHTk8PEPrzTt7x/AoNEzefWRi8NFtR4DHXnu9M+9rMZOXcTdt/ds2r3/SKi+fkvOXbzG+OlLIlXWfNvMXfoTZy5cDWeJyDtz4Spzl/70ScvUb9OHW3cfhvlciaqtTPev+lTPnZyp0qDLZy0bnrlLf6JllyEsWL7B9Jivnz/T56+mXc8RNOkwgK2//vMLtcdPnejabxwtOg9m2vwfCYzERTOjwt0Hjxk7dVHEBUVEvhEx6iTtXNkzceLURSDkUvrPXzjj8l6YuXn7Po3qVCFJ4oRMHdvvk9dvbW31WctFldGDukdc6D/uhy4tomxdhfPnpnD+3BEX/IZt2PYb29fODnXF81t3HpAze0b692yD86vXNG7Xn2KF8mGfOgWOM5bStH41ypcqzMDRM9hz4Ch1qpWP9nZmzpBWr28R+U+JUQEpd44srP455ErI127eJUvGdDx4/IzXbu7Y2lrz7IUzWTOlw8PTi+8aduXEvnUsWrmRQ0dPcfHKTdKkSs6cSSH3ybp87Ta/7PqDm3ce0LB2ZTq1DrkgXJUGXVizcAKpUiajfps+dGrdgN37j3DvwRN6dGhKneph/0Jt177DrN+ym6CgYIoUzEP/Hm2IFSsWVRt1o2vbRuw9+BdPn79kWN9OlCpWgPHTl3D52m36jZxGruyZGTmgK226D6NPt1a4e3ixcOVGAI4cP0uf7q0ZPXkhv6yZhaWlJT6+vjRu359NK2cQJ7YtEDJD8cPQyZQsmp/L127h4+tH3+5tKFowD0ajkdUbdvLb78cwGo1Ur1ya9i3q8dzJmeET5lKqWAGOnDjL5JF9GD9jCRVKF+XwX2d4/NSJ7h2a4PLKjQOHT+DnF8DkUX3IkC41y9duxcPTm77dQ37mO3jMLMqWLET6tKkZN20J3j6+tOk+jEE/dCBe3DjMX/4zzi6v8fL2oVv7JlQqWyzMbfNuPTW/K4unlzezFq3lxq37GGIZaFa/GrWqhly/pcdARyqVLcaR42e5ffcRDetUpmOrBqG2yeHjZ9j4y14WThvBuYvXWLd5N2nTpODM+WtggGlj+5kuAPi+3fuPMOP2fVxevaZBrcq0bFzzgzLOr14zfd6PPHn+AktLC7q0aUSpYiEX7nz81IkZC1bj/Oo1NtbWjOjfhdjvXYHcy8ubbv0d6dGxKUUL5mXK3BWcOX8NKysL2jWvR/XKoa+OfOzv8yxbu4XAwCDsU6dgQK92JEuSiN5DJ2M0Guk7Yhq9OjWnRBEHAPLlzka+3CG3v0ieNDH2qVPw0vkVtjbW3Ln/iLIlCxErViyqVyrDnt9DB6RXrm6MmDgfl1eviRPHlmF9O5M9SwauXL/DzIVr8PL2IVWKpIwa2I3EiRKwZPVm9v5+DGtrK2pXLU+rJrX489hp5i//GQuLWGTPkoFRA7tx7+FTBo+dxS9rZofbp/C204XLN5g6dxVBwUGkSpEMx+Hff3AlfBGRLyVGBaRM6dPg5u7BG3cPzly4Rq7smYkTJzYXLt8gSeKEZM6QFmtrK/z8/U3LdO/QlMvXb9OpVQMKOvxzs053D0+mjx/Ag4dPaddzBK0a1wrzNhpOL1xYMHU4x/4+x9S5q8IMSBev3mLvwb9YNd8RK0tLxk1bzJETZylfqgjuHp7Y2FizZOYoNu/Yz48/76RUsQKMHNCVc5euM3P8QFKlDH0/sfKli3Dn/iMAU3DLmTUjx06ep3ypIhw9cY7ihfKZwpGprS9dqFK+BH27t+b4qQuMn7aYX9bN4Y/DJ3n4+Bnrl0zCaCQkSBVxIH68uNy884DqlcuwesEE03pu33vI7EmDOX7yAoPHzmLK6L78ON+RCTOWsmXnAQb0+vDmne/kyZmFzm0acu7SdUYO6ArAG3dPenVqTvq0qbl09RZDxs6mYpmiH90278xdup44sW1Zt2QSbm886NxnDGnTpMQhT3YAbt55wAzHgaZt2LJRzXBvhXLl+m26tmtM766tGO44jx17DtG9w4cX1UyZIil9urXitZs7jdv3p3iRfGQ2u6/UuKmLKVHEgSlj+vLk2Qu69hvHkpmjSJkiKYPGzKRlo5rUqlqON+4e2MWJjbPLawCCgoIZNXkhtauVo0QRB27evs+fx06zZ+NC/AMCTfe/eufxUycmzlrG0lmjsU+dgp+27MFx+hLmTBrCnElDKFG1FYtnjAy5uW4Ynj5/iYurG9mzZODhk+ckTZwQS4t3t6hJzIu3t0J5Z/+h49jFic3CacN55epGvHh2eHh6MXHmMmZNGESK5En4ZfcfrN6wgw4tG/DjTzvYs3EhdnFi8+btRSOXr9tGz47NKF+6CE4vXD640nZ4fQpvO63fsptaVcvRvGF1nr9wVjgSka8qRp2DZGlpSY4sGbh19yHnL1+noENO8ufNzoUrN7h19yG5smeK9LpKFSuApYUFmTOmxcrKitdvwr5ZapkShTAYDOTJmdV0OG/HnkO06T6MNt2H8eex0xw7cY6Hj57Rpc8Y2vcawfVb93jx8p8PnrIl360jy2ef39S0fjV27DkEwP5DJ6jxXdkPytja2JAnZxYAihTIg4eXNy9evuLoibNcuHKTDt+PouMPo3B2ceX5CxfTMo3qVAlzbPLmyhqq/XlzZcP5VeRvevpOgvhx8fX1Y9HKjazfvJvXb9zx9vaJcLljJ87TtH41DAYDiRLGp0r5Ehz7+/wH7YxoG76TMnlSsmfJQKxYscidM/NHt0Uhh1wYDAYSJ0pA7hxZuHbzXqjnvX18OX/5hmnc7FOnoEiB3Jw6e5knT53w9PKh5tvtkyB+vFABYfGqTTx9/pLGdb8DQu5llSNrJkZNXsj9h09IlDB+qLpOnbtMsUJ5sU8dcgX2RnWqcPbidXx8fSMcv4CAQCbOXEa39o2xs4tjusffO0ZC3xwVoGTR/Dx3cmbesp8JDArCxtqaK9fv8MLlFQNHz6BN92Fs2XGAV65viB/PjqoVSzJmykIuXL5B0rc36K1bvQKrftrOrv1HSBLGTXsj6tPHtlONymXYte8wG3/ZR4L48SLsv4hIdIpRM0gAubJn5s69Rzx+4kTWzOlJED8uW3ceIDAwyPSB/ikMBkPITV8juDT+uxvDAtStUYG6Nf6ZSbpy4w6Vyxend9dWEazDEiOfd9WEgg45mbN0PXfuP+bxUyfyv51F+RgLi1gYMBDb1gaj0UjzBtVpUq9qqDLPnZyJFSvWBx+S/7TX4sO/3zbfYDBE+gTfHXsO8dvvR2nfsj5tm9elUr1OBH/OrQgMEFZTI7sN32dpYRmpLWFpaUFsm7Bnpd4fN4MhpHHBwUZC/vlhQz29vLlz/xFpUiVn/6ETVK1YElsba+ZOHsKlq7dYsGIDGdPbM7BXu3Db9JHNFUpgUBCjpywkd47M1K9ZCQg53Obi6kZgUBCWFha8dH5FivfOXYKQG9KuXjSBP4+dptegiXRu04h4ceNgnzpFqFnGd8YM7sHdB49ZtmYrG7fvZcb4gTSu+x2VyhZj8479NO00kJVzx0XY3o/16f3tVKFMUYoUzMOve/+kaccBzJ8ynAzpUoe9oIhINItRM0gAuXJk5uDR02TJlA5LCwtSpUiGu4cX12/dI1f2zGEukzJ5UtOMSXQoVawAew4c49GT5wA8f+FCUFBwhMuFtMs5nOf+abPBYKBJ3e8YN3UR31Uo+cFsAIB/QIBpmV37DpM+bSoSJYxP6eIF2bR9n+mb+DOnl5/axQ8kSZyQ6zfv4ufvz70HT7h6806otju9cDHdj+nYyXNUKFOUYoXycvf+43D7+b7SJQqwecc+jEYjbm88OHDoBKWKF/zXbY/I46dOANx78IRrN++SP+8/YTQ42Eic2LYUyJuDLW9/Hfb0+UtOnbtC0YJ5SGefEmsrK/YdPA6Au4cXr93cgZAfATgO68WAnm1ZvGojr93cee7kzDOnl+TLnY02Tetw/NSFUG0pWjAvp85d4enzkG22ddfvFMyXk9i2oQ+vvi84OJjJs5YTP65dqEOIiRMlIFvmDBz+6wxGo5Hffj9GxTKhbzx8/dY9/Pz8qVyuOBXLFuPUucvkzpGFFy9fcfBoyP3PvLx9eO3m/vaO8o/InCEt3ds34eTZK/j7B3Du0nUSJYxPx9YNCA4K5v7DJ/+6TwDnLl0nTmxbmjWoTqoUybl640645UVEolOMm0HKnT0zV67fplenkLtYvzt0dfzUBdKmSRnmMjWrlGXMlIXsOXCUOZOHRHmbCuTNwfedmzN47CwsLSxJED8uowd3J1mSROEuV69GRUZOWkDBfDkZP6xXqOdKFHHgpy17aNN9GKMGdiNLpnRULl+CqfNWMcXsJN53DAYDS37cxN37T7CLY8u4oT0xGAxUq1QK51eu9BjoiI21NcmSJmbC8O//VZ8rlinG7v1HadJ+AEUL5aVcqX/u3p03V1b8AwJo0WUwfbq1plGd71iw/Gf+OHKSogXzhJq1CG/b/NClJTMXrqFV16EYYhlo17wuDm9PPo5ON2/fZ/3m3fj6+jFyQFeSvt2O5UoVZs3GnXzfuQWjBnVj2txV7Np3GEtLC4b17WQ6ZDR1TD+mzf+RNRt3YhcnNr27tiRxwgRYW1lhZxcHO7s4NKhVmdmL19G6SS3mLfsJ19fu+Pn707tr6Jsjp02TkqF9OjF0/ByCgoKwT5WCEW/P7fqYbbv+YPeBo+TMlom2PYYDIdtk4PftGd6vM+OnL2HF2m0UdMhFtUqhX0vPX7gwff5qvH18iG1ry6iBXUkQPy7TxvZnzpJ1rFi7DRsbK3p2bE7qlMlYtmYrz1+64OXlTb/urQkODubQ0VPMXrwOT09vShRxIF+e7Nx78E9I+pw+BQUFc+7iNeYsWYeXlw9ZMqWjYtmi4S4jIhKddCXtGGTXvsOcuXCVMYN7fPDccydn2vQYzoFtS79Cy0RERP6/xLgZpP9HgUFBdOkzBktLSyaP6vO1myMiIvJ/TzNIIiIiImZi3EnaIiIiIl+bApKIiIiIGQUkERERETMxJiAZjUYCAwNN19YRERER+VpiTEAKCgqiTM12BEXy6s0iIiLy3+dwfAHJD03G4fiCL1pvjAlIIiIiIjGFApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSM5dduwOcYPXkBHp5eUb7eeHHtGDukZ5SvV0RERL4t32RA8vD0YkS/jlG+XseZKyJVrmS11mTOkBYPTy/Sp03F0L6dSJk8KfXb9GHVvPEkTBDvX7elYt2OHNwRufZExsKVGzl+6gJd2jQiXjw7Zi1cQ67smRnSJ/Lj2GOgIyP7dyVVymRR1i4REZGY6JsMSF+brY01axdPJDg4mK2//s7CFRsZNzRmzzxt3XmAvZsXY2VlyeTZK2jaoBo1q5T92s0SERGJkRSQ/oVYsWJRyCEX+w7+9cFzS37czMmzl3H38KRru8ZUKV+CoKBgFq3ayPGTF7CxsWbkgK6kS5uK2YvWcfr8FeLHi8u4IT1IlTIZQcHBzFy4hguXb5AwQXzGD+tJgvjxuHrjDjMWrMHPz59C+XPxQ9eWWFpYmOp1ff2GcdMW8/yFC1kzpWP0oO6Mn74EH18/Ov4wihaNanDw6ClOnrtMcLCRSmWLMWnWcm7dfUiqFEkZN7QX8ePZse/gcdZs2EmsWLFo1aQWN+884PK12/QbOY1qlUpTvVIphoybg6eXNzmyZmD0oB5YWOiUti8lsoeZddhYROTzKCD9C0FBwew7+Be5smf+4LnypYvQpW0jnjx7Qe+hU6hSvgS7Dxzh0ePnrFk8ER8fX2xtbNi17zDW1lZsWD6VC1dusmbjrwzu3YGgoGBqVClDvx5tmLVoLZu276dd87oMd5zHtLH9yJIpHcMd57J73xHq1qhgqnf24nU0rFOF0sUKsHL9dv786zTjhvbk2N/nWLNoIgCnz1+lVLECVCxTlEUrN5IvdzbGD+vFngNH2b7nD8qWKMzytVtZOms08ePFxdPLi6oVS3Lo2Clmjh9IqpTJ+GnLHnJlz0z/nm144fxK4egLi+xh5sgeNhYRkdAUkD6Dr58/bboPI9hoJE+OLPTq3PyDMsmSJmL9lt1cu3mPly6uAPx95hINalfG0sKCeHHtADh19jK37z3izPkrGI2Qzj4lANZWluTImhGA4oXzsWXnAR49fY6trQ1ZM6cHoEr5Ehw4/HeogHT6/BXuP3zKstVb8A8IpF6NiuH25dS5K/j5+fPr3j8JCgqmWKG8nLlwlQplipIoYXwAEsT/8Jyq4oXzMWryAjZs+436NSt96hCKiIjEaApIn8HWxto0GxMWLy9veg6cQNtmdRj8Q3tOn7sCgDHYiMFgCFXWaITeXVtRuniBj67PwsICWxtrjEYwWzxMi2eOxC5O7Ej1xWg0Mn54LzJnSGt6bPOO/URUTaYM9iyfPYZf9hykdfdhrJo/nrh2cSJVp4iISEyn4yJRyICBYGMwj546YWVlRdWKpXB97Y6fvz8ABR1ysmPPQYKCgvHy9uG1mztFCuRmy879BAQEEhAQiOvrNwAEBgXx0vkVRqORXfsOU7hAbtLbp8LHx4879x5hNBo5cPhvihTIHaoNhRxysWHbbwC4ur0x1f0xRQrkYcO2vQQHh7TJ3cOLAnlzcPDoKd64exIcHMxzJ2cAUiRNbJoNu3nnAYZYBprWq4q1tRVPn7+M0rEUERH5mr7JGaR4ce2i5dyKd4e9PlexQnnZ9uvvtG1WF/tUyWnbYzgFHXKRIlkSAOrVqMj9h09p2XUI8eLGoW/31tSpUYH7j57SqtsQYtva0qVtI0oWzU+yJIlYsGIjt+8+JE+uLNSuWg5LS0sch3/PxFnL8PMLoEC+nNSuVj5UG/p2b82Emcto2SWkjtGDuof7s/x2LeoyZc5KWnQZQpzYtgz8vh05s2WiecMadOk7lti2NjSsU4XaKctRs2o5RkyYR+1q5cmaKR1T5qzA3cOLgg45yZop3b8aOxERkZjE4O/vZ/zajQAIDAykTM12HN39I5aW32RuE/li+o2YGumTtGc6DvoCLRIRiR4Oxxfw3M+DVDbxuFjyy/0qV4fYRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJIlR9v5xDKeXLl+7GZHi6+vHz1v3fO1miIhINFBA+kyjJs1nwKgZH31+8JhZnLt4DX//AIaMm42/f8An11G/TZ9PKv+uzs9x7uI1xk9fYvp7zpJ13Ln36LPW9b5P6UNwcDD7Dh4nedLEBAUFM2XOSlp2GcLoyQsJCAj8oPzRv8/RqttQ2vUcYWrrG3dPhjvOpUzNtri98QjVjpZdh9Cm+zCGjpsDwKWrt+jWbxyN2vVjwKgZePv4msoHBgXRsusQlq/dCoSMT+X6nWnTfRhtug9j94Ej2NracO7SdXx8fRERkf8WXZHxMwQEBOL08hUBAYF4+/gSJ7btR8taW1sxeVSfL9e4KNK7a6svXufZi9fIkzMrsWLF4s9jp3nj4cn6pZOZMmclew4cDXVT3oCAQGbMX83K+eN49tyZqfNWsXTWaGysrWhYuzIXrtwMtW4DBlYvnIClhYXpMSsrSyaP7kuC+HEZ7jiXg0dOUqtqOQB27DlILEPo7w9lShRi9KBuoR4rX7oIvx8+Se23y4mIyH+DZpA+w7lL18meJQO5c2Th1NnLpsc379hP4/b96TV4Ik+evTA9XrFuyBWPz128Rv+R002P12/TB7c3Hnh5efP94Ek0bt+f3kMn4+3jS+c+Y3F59Zo23Ydx6uxlvH18GTlxPk07DqTPsCm4e3iFW+c7j548p0vfsTTtOICZC9dgNBq5ffchLbsMoWnHAcxZso7HT50YN20JR0+co033Ybh7eNFjoCPXb90DoHnnQSxYvoEmHQYwY8Fq9h08Tpsew+n4w2g8vbxN7ejw/Sgat+9vOuw0atICnF64mGZcAoOCmD5/NU07DqRzn7Gme7y9c/3WPQrkzQ7AX6cuUCBvDgDy583B8dMXQpW9euMOCRPEI3HCBOTMlombdx7g4emFra0NBR1yYW1tFap8vHhxQoUjgJzZMpEgflyeOTnj5u5hul2Ku4cXO377k3o1K4QqnzBB3A/GN3+eHFy/ee+Dx0VE5Nv2zc0gVTnzIy/9vaJt/cmt7ThQuF24ZY6cOEuR/LkxGo0cOXGW8qWLcOf+Yzbv2M/KeeOwtraix4AJka7z1LkrWFtbsXnVDF68fEWc2LaMG9KDHoMmsGbRRAAWrdxIvtzZGD+sF3sOHGX7nj8oWbRAhHVOnLmMAb3akTVTOibOWs7VG3fZd/AvalQpQ/OG1XF59ZrkyZLQuU1Dzl26zsgBXT9Yx6MnzynduwAdWzegTovvSZEsCasXONJ/5HSO/X2OapVKUyBvDurXqoSfrx/12/ShQe3KjBvakwN/njD1Yfueg1hbW7Fh+VQuXLnJmo2/Mrh3B1M9z547U6lscQBeubqRrlzIv9OnTYXLK7dQbXJxdSOdfSoALCxiYZ86Ba9c3T56P73AwCB6DZ6Iu7snnds0pEyJQgCs27SLhSs30ql1Q7JnzQjAinXbaNOk9gc3+j117gqtuw0jVYqkDPyhPcmSJCJ50sQ8f+H8QX0iIvJt++YC0kt/L577eURcMJoYjUaOnzxPlzaNACPT5v1IYFAQ5y9dp0LpIqYP6KSJE0Z6nflyZ2PVzztYunoLzRpUD7PMqXNX8PPz59e9fxIUFEyxQnkjrNPL24frt+7j+PbcIl8/f0oWcaB8qSLMXryO+PHjUr1y6QjbZ2NtjUOekJmdDOlSUyh/LgwGA9kyp8f1tTsAqVIkZfvug1y6epOgoGBeu7mTMnnS0H04e5nb9x5x5vwVjEZIZ58y1PMvnF+RNElIHwyGkHOSIOT/sWIZQpU1GAwYjf/cRtAYbMRgCF3mfcP7dSZj+jTcuP2AASOn8+vP84kT25bWTWtTp3oFHGcsYff+I+TOkYX7D5/Sp1sr9hw4alo+V44sDOvbicwZ0zF/2c8sXrWJkQO6YmVl+Vnnl4mISMz2zQWk5NZhzxB8qfXfvPOA1288+H5wyKyIt68vl67eIjAoKNRJvh8TFBT0wWNJEidk5bxx7P39GO16jmD+1KEYCP1hbzQaGT+8F5kzpDU99vO238Kv02gkThxbVi+c8EF4WDBtOOs376Jz7zGsmDs2wna/Y2lpEerfRqMRo9FIz0ETqVW1HN93acmDR88wBn94D2SjMeTcptLFC4S57gTx4+Lh4YVNEmuSJk7E46dOlCjiwOOnTiRNnChU2aRJEvHo6XMAgoKCeer0MtxQmit7ZgAK5M1BqpTJeOnsSoZ0qU311qpajgOHTvDSxZVXrm507jMGtzce+AcEkDplcmpUKUPuHFkAqF21LNPm/wi8C286Ui0i8l/zzQWkiA5/Rbcjx8/Srnld2jWvC8CPP+3g6ImzVChdlO27/8DP3x9//wAeP3X6YNlECRNw7+ETfH39uHbrHq6ubwC4//ApSZMkpOZ3ZTl07DS37j6keKF8eHl54+8fgLW1FUUK5GHDtr0M7dMRH18/goKCyZ09c7h12tnFIXXK5Oz5/Sg1q5TlxctXJE+WmGs375Eja0Y6tW7IL7sP4uHpTfJkiXnp7IrRGP5MTFjeuHvi9NKFejUr4urqhqvbG9NzyZMm5qXzK5InS0KRArnZsnM/xQrlBcDD04vEiRKYyqZOmfztLFIiShUrwG+/H6NJvaqcv3SDksXyAzB26iLaNqtD7uyZcPfwwvX1G548e0GubJmws4sTZvsuXb2FhYUFuXNk5s79x3h4eJE6ZTKW/LiZpvWrETduHI4eP0v6tKlp36Ie7VvUA2D3/iM8f+FMjSpl+HXfYSqWLoKtrS3HTp43HY5zff2G5MkSf9J4iYhIzPfNBaSv7eiJczgO72X6u0KZIvQfOZ0furSkbInCtO42jPRpU5EyRdIPls2QLjV5c2alaceBVC5fnJzZQj5k3dw9mDhrOe4eHqSzT0Xxwg7Y2lhToXRRWnQZTK9OzWnXoi5T5qykRZchxIlty8Dv25E3V9YI6xw1sCuTZi3npy17SJIoIRNH/sCN2/eYNm8Vnl7eNKpThQTx45I3Z1Y8PL1o0304U8b0+aQxSRA/LpXKFqNt9+HkzJ6JNKlSmJ6rU70CXfqOo3XTWtStUZH7j57SqtsQYtva0qVtI0oWzR9qfO7ef0zuHFkoXbwAJ89eomWXIWTLkp7qlUoB8ODRMzw8vbG0tGRgr3b8MHQyVpaWpnOntu36g+27/8Dl1Wt6DpxAnerlqVCmKLMWruXJsxf4BwQwvH8XrK2tyJU9EwNGTee1mztZM6enb6MaH+9jvLj0GT6N125vyJg+DSP6h9R398ET0qdN9UnjJSIiMZ/B39/vw2MhX0FgYCBlarbj6O4fsbT87+S2N+6edPxhFFt+nPm1mxLj+fj6MmrSAqaN7f+1mxJp46Ytplu7xiRPluSL1ttvxFRG9OsYYTnHmSuY6TjoC7RIRCR6OBxfwHM/D1LZxONiyZ5frF6dPBGN7tx7RKfeo6lRpczXbso3IbatLWnTpPrg5/8xla+vH8AXD0ciIhL9/jtTNTFQlkzp2Lzq41fblg/16NDkm5lBtLW1YVjfTl+7GSIiEg2i7ZNoy84D/Lx1D5aWlgzt05H8by/6JxKebyUcvfOttVdERCInWg6xefv4snL9L6xdPImpY/qyeNWm6KhGREREJFpES0CytLAgcaIEWFtZYp865Ud/fi0iIiISE0XL8QFrayvq16xI9wETyJktI43qVAmz3JadB9j66wGAUFdFlm/b6MkL8PCM+HYw8eLaMXZI1P0i4WvVKyIi/z3REpC8vLw5eeYyHVrWY/2W3SRMEI8SRRw+KNeoThVTeHr3M3/59nl4ekX6J+j/hXpFROS/J1oOsR0+fpbcObNQoogDsxwHsWvfEXz9/CNeUERERCQGiJYZJAuLWFy6ehN//wBevX6Du4cnn3j3ChEREZGvJloCUuVyJbhw+SbNOg3CwiIWQ/t2wsbaOjqqEhEREYly0TaDNLh3h+hYtYiIiEi0061GRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBnLr90AEfnH6MkL8PD0irCci6tbpNb3zMmZfiOmRlguXlw7xg7pGal1ioj8P1BAEolBPDy9GNGvY4Tleg+bFqn1WVlaRGp9jjNXRGp9IiL/L3SITURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExYxldK7587TYzFqwmKCiY6pVL06JRjeiqSkRERCRKRUtACggIxHHGEmaMH0iqFMl49OR5dFQjIiIiEi2iJSCdPn+FHFkzYZ86BQAZ06eJjmpEREREokW0nIP0zMmZ2LFtGDR6Jm17DufcpevRUY2IiIhItIiWGSRvHx/u3HvETMdBPH7qxMSZy1i/dPIH5bbsPMDWXw8AYDQao6MpIp9l9OQFeHh6RVguXlw7xg7pGWXrc3F1i0zzREQkmkVLQEqaOBEZ09sTP54dubJnws3dI8xyjepUoVGdKgAEBgZSpma76GiOyCfz8PRiRL+OEZZznLkiStfXe9i0SK1PRESiV7QcYitWKC/nL13Hy9uHazfvkiJZkuioRkRERCRaRMsMUpLECenUugFd+o7FGGxkxIAu0VGNiIiISLSItusgVatUmmqVSkfX6kVERESija6kLSIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImIm3IC09dcDHzy2fvPuaGuMiIiISEwQbkDauffPUH/7+fuz9dffo7M9IiIiIl+dZVgPNmjTF4MBXF650bBtX9Pjnl4+VK1Y8os1TkRERORrCDMgbVszC4AWnQczw3Gg6fHEieJjY239ZVomIiIi8pWEGZDeWbt4EhYWOo9bRERE/r+EG5Beuriy87dDuLi6YTQaTY+P6N8l2hsmIiIi8rWEG5AGjp5BujQpyZ0jC5aWFl+qTRJDjZ68AA9PrwjLubi6RX9j/oVnTs70GzE13DKR7UNk1vUp6xMRkZgh3IBkNBqZOLL3l2qLxHAenl6M6NcxwnK9h037Aq35fFaWFhH2I7J9iMy6PmV9IiISM4R7glHh/Lm5c+/Rl2qLiIiISIwQ7gzSk2dO9Bw0kZQpkoR6fPWCCdHaKBEREZGvKdyA1LJxrS/VDhEREZEYI9yAVDBfzi/VDhEREZEYI9yA1HPgBAwGwwePz586LNoaJCIiIvK1hRuQmtavFurv/YeOU6ZEwWhtkIiIiMjXFm5AKluyUKi/ixfOR9/hU6lasVS0NkpERETka/qk+4g8ePyMO/cfR1dbRERERGKEcGeQvmvYBQg5BykwMJCAwEDat6j3BZolIiIi8vWEG5BWL5xo+rfBAAkTxMfWxjraGyUiIiLyNYUbkFKlSIqXlzeXr9/BYDAQzy4OKCCJiIjIf1y4AenqjTsMGTsb+9QpAHjq9JLJo/qQK3vmL9I4ERERka8h3IA0d+lPTB7dl9w5QgLR1Rt3mb14HUtnjf4ijRMRERH5GsL9FZuXt48pHAHkzpEZbx/faG+UiIiIyNcUbkBKlCA+h4+fMf195PhZEiaIF+2NEhEREfmawj3ENqBXWwaNmcXsRWsBsLGxYeqYvl+kYSIiIiJfS5gB6fkLF2xsrEifNjU/LZ3C46fPAXjh7IqVZbiZSkREROSbF+YhtlkL1/DsuTMAFhaxyJAuDRnSpSFh/LjMejubJCIiIvJfFWZAcnJ+RZ6cWT54PHvWjLx0cY32RomIiIh8TR89STswKOiDxwICQm43IiIiIvJfFmZAKleyEJNnr8DXz9/0mK+vH1PmrqRUsQJfrHEiIiIiX0OYZ1y3bVaH6fNXU791bzKlt8eIkXsPnlCmRCG6tGn4pdsoIiIi8kWFGZAsLS0Z0qcj7VvU4879RwBkzpiWlMmTftHGiYiIiHwN4V4oMkXyJJQqVoBSxQp8Vjh67uRMudrtOXfx2mc3UERERORLCzcg/VsLVmwgbZqU0VmFiIiISJSLtoB04fINgoODyZ4lQ3RVISIiIhItouWy2EFBwSxcuZGxg3uwfN22j5bbsvMAW389AIDRaIyOpkgkjJ68AA9PrwjLubi6RWm9z5yc6TdiaoTlXjq7kjxZ4gjLRXX7JPpF9rUXL64dY4f0/AItEhEJES0BafeBIxQtmIdUKZOFW65RnSo0qlMFgMDAQMrUbBcdzZEIeHh6MaJfxwjL9R42LUrrtbK0iHS9X6N9Ev0i+9pznLniC7RGROQf0RKQDv91mleub/j7zCWePn/JtZt3cRz+PZkzpI2O6kRERESiVLQEpBnjB5r+PX76EmpWKaNwJCIiIt+MaP0Vm4iIiMi3KFpmkN43ckDX6K5CREREJEppBklERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYsfzaDRCRb8foyQvw8PSKsFy8uHaMHdLzC7RIRCR6KCCJSKR5eHoxol/HCMs5zlzxBVojIhJ9dIhNRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETFjGR0rdffwYvKcFTx+4kSC+HEZN7QniRMliI6qRERERKJctMwgXbl+m8Z1v2Pt4olkz5qB9Vt2R0c1IiIiItEiWmaQShbNb/p33lxZOXjkVHRUIyIiIhItov0cpLMXrpEvd7borkZEREQkykTLDNI7dx885vT5q/Tq3DzM57fsPMDWXw8AYDQao7MpX9XoyQvw8PSKsFy8uHaMHdIzytb30tmV5MkSR1jOxdUtwjIi/yVR/Z4Ukf+eaAtIr93cGT15IY7Dv8fG2jrMMo3qVKFRnSoABAYGUqZmu+hqzlfl4enFiH4dIyznOHNFlK6v97BpkS4n8v8kqt+TIvLfEy2H2Pz9Axg2fg6d2zQkS8a00VGFiIiISLSJlhmktZt2cfPOA1b/vIMVa7cBsHTWaGxtbaKjOhEREZEoFS0BqWOr+nRsVT86Vi0iIiIS7XQlbREREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjOXXbsCXNHryAjw8vSIsFy+uHWOH9PwCLRKJGZ45OdNvxNQIy7m4un2V9UVWZN/jUd2Pl86uJE+WOErKaf8jEjP8XwUkD08vRvTrGGE5x5krvkBrRGIOK0uLSL03eg+b9lXWF1mRfY9HRz+iqpz2PyIxgw6xiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmLKNrxdv3HGTzjv3EtYvD+KE9SZ4sSXRVJSIiIhKlomUGyfX1G9Zu/JUVc8bSqE4VFqzYGB3ViIiIiESLaJlBOnn2MtkyZ8DW1ob8eXMwbd6qCJcxGo0ABAYGRkeTAAgONhIYGBTJclHXjqiuN7LrMxpV7nPLxeS2/T+W+396b0T1/kfkmxcUDEFGCAqO9veGhYUFBoMBAIO/v58xqitYt2kXHp5edO/QFKPRSOUGndm9YSG2Ntahym3ZeYCtvx4AIDg4mEdPnKK6KSIiIiKRcnT3j1hahswdRc85SIZ/ZoQAjMFG3gayUBrVqUKjOlWAkIDk7+8fKr1JiFbdhrJu8aSv3YwYT+MUMY1RxDRGEdMYRY7GKWIxbYwsLCxM/46WgJQsSSKuXL8DgPOr11hZWWFjbR3uMrFixcLW1jY6mvPNMxgMpkQrH6dxipjGKGIao4hpjCJH4xSxmDxG0XKSdtGCebl99yG+vn6cv3SDkkXzR0c1IiIiItEiWmJbooTxadeiHh17jyaeXRzGD/8+Oqr5v9GwdpWv3YRvgsYpYhqjiGmMIqYxihyNU8Ri8hhFy0naIiIiIt8yXUlbRERExIwCkoiIiIgZBSQRERERMzHzt3X/YeHdo+7JsxeMmbIQH18/WjepRbVKpTEajaxc/wsHj5wiebLEjB/Wi7h2cT6p7LcmqsZow7a97D/0F17evvTq1IwyJQrx3MmZZp0Hkd4+FQCVyhWnbbM6X6urny2qxmj89CWcv3SDuHaxAZg/dTjx49n9J+6lGBVjFBgYxA9D/rlGywtnV9o1r0PzhjUoVb01mTOkBcAhT3b692z7xfsYFT51nAAWrtjA9j2HGNKnIxXLFP1o2f/XfRKEPUbaJ0U8RjFpn6QZpC8oonvUzVmyjvYt6rF05iiW/LgZTy9vbt15wPFTF1mzaCIF8uVg3aZdn1z2WxJVY+Tl7YOfvz/LZo9l0sjeTJy13HTx0lzZMrFm0UTWLJr4Te6IovJ1BDCsXyfTeMSPZ/efuJdiVI1RwgTxTGOzeOYo0tmnom6NigAkS5LY9Ny3Go4+Z5wAShcvSK7smSIs+/+6T4IPx0j7pMi9jiDm7JMUkL4g83vUnTh9wfRcUFAwf5+5RP482bGzi0M6+1Scu3idv05dwCF3NiwsYpE/Tw6On774SWW/NVE1RnZxYtO2WR0sLGKRMX0agoKC8PMPACBBgnhfqXdRI6rG6J2E8eNFev3fiqgeI4Cft+6hUZ3KxIkdckHbBAnifskuRYvPGSeAfLmzkSRxwgjL/r/uk+DDMdI+KeIxeiem7JMUkL6gV65upLNPCUDSxAkJCg7G188fgDceHiSMHw+7t9PP6exT4fLqdcgyaUOmXtOnDXnsU8p+a6JqjN53884D7FOnMN0L8M69R7TvNZJegyfy4NHTL9W1KBPVYzRv2U806zSIlet/wWg0hrv+b0VUj1FgUBCHjp2mQumioero3GcsnfuM4eLVW1+qa1Hqc8YpLNonRTxG79M+Kfwxiin7JJ2D9CWFc486AwaC33su2GjEEMsABgPBwSGPBwcbiRXL8EllvzlRNEbvBAYFMWfJerq2awJA8mRJGDmwGzmzZmTDL78xdd4qFk4b8QU6FoWicIzaNK1NnDixCQoKoufACeTPkz3S91KM0aL4dXTtxl3S26fC2trK9NiEEb3JkTUDfx47zZgpC/llzezo7VN0+JxxCnM12idB+GP0jvZJ4Y9RTNonaQbpC0qWJBGPnjoBH96jLkH8uHh4epmOzT5+4kTSJIlIljgRj58+B+DRUyeSJk70SWW/NVE1Ru/MXrSOQg45KVYoLwAWFrFwyJ0Na2sr6lavyMPHz79k96JEVI5R+rSpSZYkESmTJ6VUsQI8ePw83PV/K6L6dXTj9n2yZEoXqg6H3NmwsbamSvkSeHp6f3OzbPB54xQW7ZMiHqN3tE8Kf4xi0j5JAekLCusedes372b/oePEihWLEkUcOH/5Bp5e3jx++pyC+XJSqlh+Ll65SVBQMOcvXadk0fyfVPZbE1VjBLBl5wFeubrRoWV90/oP/HmCV65uGI1Gjp44S46sGb5OR/+FqBqj127u7Dt4HKPRiNsbDy5evUn2LBn+E/dSjMrXEYDTy1ehzpX46+R5Hr/dYZ+9eI3kSRObDpd8Sz5nnMKifVLEYwTaJ0U0RjFtn6RbjXxhv+47zIZtv5nuUbd246+kTJ6UFo1q8NzJmVGTF+Dt40vbZnX4rkJJAFb9tJ3f//yblCmSMG5oL+zixP6kst+aqBgjtzceNO0wgIzp7U1Tsa2b1iZ5siQsXrWJV65uJEmckFEDupIqZbKv2NvPExVjZGlpweJVmzh/6UbIeNWvSvOGNcJcf7IIvhXHRFH1XgOYPHsFBR1ymsrdf/iUOUvW8dLZFStrS4b17Uz2LBm+Vlf/lU8dp+u37jFp1nKcXr7Czi42+fNkZ/Sg7tonRTBGnVo31D4pgjEa0qdjjNonKSCJiIiImNEhNhEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSfBPqt+lD044DadN9GG26D4v0zUGrNOjCcyfnf13/T1v20LLrEMZOXfSv1xWVNmzby/jpS/7VOuq36RM1jflCLl+7Ta/BEylZrTUenl5hlgkMCmL6/NW07DKEzn3Gmq56HdMsX7uVWYvWAnD3weMoe3216T6McxevhXrsuZMzVRp0AaDv8Kns2nc41PMjJsxj+56DH6xr9/4jVK7fmTbdh1GvVW869R7Nlet3uHrjDvVb9w51j6wHj55Su8X3BAcHR0k/okpUvE/k/49uVivfjLmThpAieZKvUvfWXw8wamA3HPJk/yr1yz+SJ01Mhxb1OHvh2kfL7Nl/BKeXLqxbMok/jpxkwoylLJ456gu28tNlzpCW0YO6f5G6ypcqwvFTF6hVtRwA/v4BnDp3mf4924ZZvpBDLqaM6UtwcDCHjp1m9OQFbF41g6DgYO49fELmDGkBOHz8LBXLFCFWLH33lm+fApJ8MxImjBdhmTv3HzNlzkp8ff3ImD4NAYGBpufWb97NH0dO4uPrS+qUyRg3tBev3dzpPsCRX9bMwtLSEh9fXxq378+mlTOIE9sWgPHTl/DSxZWJs5bRqkltan1XltUbdnLg0AmMRiPFC+eje4emWFlZsnztVgwGA5ev3SZRwgR4e/tQpkRBalUtx9ETZxk0Zha7NywgcaIEzFq0BvvUKalVtSxzFq/n1t2HeHh6Ub5UEXp2agZAj4GOVK9chp2/HaJyueI0rvsdy9Zs5cCfJ0iSOCE21tYkS/rhJffrt+lD9/ZN2LDtN1o1qU2xgnmYsXAN127ew2CAnh2bU7xIPlp3G4rLq9e06T6M2tXKkzmDPbMXr2PNoolAyDfv2/ceMnJAV3bvP8L1W/d57fYGTy9vZk8cTLXG3enathF7D/7F0+cvGda3E6WKFQjVlvHTlxDXLg73HjzhhfMrcufIwpA+HbCxtubh42dMnbuKV6/fED+eHSP6dyGdfSrGT19C9iwZOHTsNHlyZDGNB0CK5EkiDMoHj56idrXyGAwGypcuwqRZy3F1e0PihAlMZfYcOMovu//Ax9cPuzixcXx7+4Ld+49w/vINjEYjl6/dJmGCeEwfN4D48exYvnYrvn7+PHv+kuu375MpvT1TRvfB0tKSHgMdaVq/GuVKFgZCZi/XLJxAqpTJwnztmd9y49bdhwweO4tf1szmjyMnWf3zDiDkPnCFHHIxaVRvrly/w8yFa/Dy9iFViqSMGtiNxIkS4PTShcmzV+Ds8po0qZLj5u4R7viUKVmQBSt+JiAgECsrS85cuEr2LBlJlDB+uMvFihWL4oXzMWLCPIKCgkOC1skL/wSkv87Qu2vLUMtcuHyDqXNXERQcRKoUyXAc/j0eHl78MHQyJYvm5/K1W/j4+tG3exuKFszDuYvX2LzjAIkSxufG7XssnD6SO/cehdnvj23D4ODgSL1PRMKjmC/fBItYsRgxYR5NOw5gxoLV+PsHfFAmMCiIoeNm06Ted6xdPJEeHZuGmv4v6JCTpbNG8dPSKQQFBbP3j2PYp05BzqwZOXbyPABHT5yjeKF8pnAEMHJAV5ImScT4Yd9Tu2o59h38i2N/n2P53DGsWTSBp04vWb9lt6n8lp0HGNy7I6MHdaNY4XycvXgdgDMXrlLIIRdn3x76OHPhGkUL5sHWxoZaVcuxYu5Y1iyawI7fDnL/4VPT+nbvO8yCqcNpWr8av/1xjL/PXGL1wgksmj6C9GlTfXTMjv19jmWzx1KxTFHmLfuZvLmy8vOyKSycNoIZC37EgIGZ4weSNEki1iyaSOO630W4HX7d9yetmtRizqQhGAwG3D08sbGxZsnMUbRtVocff94Z5nIur14zfXx/flo6mSfPXrBr32ECg4IYOXE+fbu3ZsPyqXRoWZ/5y34ONY5Tx/QNFY4i66WzK8mTJgbA0sKCJIkT8tLZNVSZbJnTM3fyENYtnkTGdGnY+Mte03NnL16jY6v6/LR0MoGBQRw8evKf5y5cY9APHfh56RRu3X1o2r7hCeu1F55KZYuxZtFEZjoOxC6OLb06N8fD04uJM5cxaWRvNq6YRrlShVm9ISREjZ+2hIIOOVm/dDLD+3fGIoIZnMQJE5AlUzouXr0JwJHjZ6lYtmiE/QgODuaX3X+QI2tGrKwsKV+qMMdPXQDgpfMrXFxfkzdX1lDLrN+ym1pVy7Fh+TQG/dCeuHZxAHB66UKV8iVYOW8833duwfhpiwkMCgLg6ImzlCiSj5XzxhMQEPDRfn9sG37K+0TkYzSDJN+EsUN6YJ86Jb6+foybtphN2/dRpGAeJsxYCkCJIg5Uq1QaP39/KpcrDkDK5EmxtrIyrSOdfSr2/vEXF6/e4smzFzx59gKApvWrsW7zLsqXKsL+Qydo0ahGuG05euIcdapXILZtSIhqWLsKS37cTLvmdQGoVLY4qVIkBaB44bz8+PN2jEYjF67cpH3zepw4fZFCDrnw9vElnX0qDAYDyZIkYv2W3dy68wCAJ8+cyJg+DQBN6lfD2jqkH8dPXqB+zYqm2Yc0qVJw+97DMNvZvGENLCxCPiiPnDjL5Wu3+WXXHwAEBxtxe+Me2eE3KZw/NzmzZQr1WNmShTAYDOTJmYUN2/aGuVzeXNmwsQ65232povm5cv0uhRxy8fDxc8ZNWwyA0Qi2tjamZepWr0C8uHaf3EYAQyxDqL+NRiMGszJp7VNy9Pg5zl68xpUbd7BPncL0XLZM6UmdMjkAObNn4pWrm+m5fLmzkTBByGxmtszpcHF9HWF7PvbaC4/RaGTirOW0a16PNKmSc+L0RV64vGLg6BkABAUFkzF9Grx9fLl45SYzJwwEIEH8eJEatwqli/LXyfMUzJeT46cv0KVdIwAGjJrBS+dXAKycPx4ICYxtug/jqdNL8ubMysQRPwDgkCcHT5694I27J0f/Pkf5Uh8eXqtRuQzL1mwlVqxY1K5WzvS4rY0NeXJmAaBIgTx4eHnz4mVIvenTpqZMiUIAXLl+J8x+w8e34ae8T0Q+RgFJvgm5c4TsSBPEj0v50kW4dvMurZrUMh0KArh99yEWFhYYDOYfheDj60un3qOpU608rRrXJHnSxHh6eQMh3+7nLF3PnfuPefzUifyfeJ6RwQDvV/kulACkTpmc2La2XLp2Gxtra4oUyM3ClRs5f/kGRQvkwWAwcOvuQ0ZMmEeXNo2oXqk0Lq7zCX5v5uv99QUGBWFhYRGpdoUqZwwJmVkypQtV5oMT2A0GAgODPrpOy3DqtrS0xEjE9762tLQgtq2NKRD9uMAxzHNWItvPsKRIloQXzq/IS1YCAwNxff2G5Mn+OSxnNBr5YchkCuTNQYNalciVIzPHTpwLu70WFqFmIkM/Z8m7LhsIe+zCe+2FZ8dvhzAYoE718qY226dOweoFE0KVe7euTx2vciUL8f2QSVQqW5x09qlMhx+nj+v/Qdl35yCt3rCT23cfmu42b2ERi5JF8/P3mUsc+/s8bZvV+WDZCmWKUqRgHn7d+ydNOw5g/pTh2FhbhSpjYRELAwZivw3I77/mP9bv8Lbhp7xPRD5Gh9gkxjt17gqXr90G4I27J4ePnyFvzqwflEtrnwo/P39On78CwM07D/D18wPg0ePnuL3xoHHd70iRPCm37/7zbdJgMNCk7neMm7qI7yqUjPAE0zIlCvLr3j/x9fUjMCiIrb/+TuniBT9avnjhfGz6ZS8F8+XEzi4Oce3icPiv0xQtlBeAsxeukjF9GiqXL05QcLDpW3RY8ufNwW9/HCMgIJDAoCCu3bwbblvfKVW8ACvW/UJAQCBGo5FnTi8BSJQoAV5e3vj6+QOQNHFCHj114pWrGx6eXhz+63Sk1h+Rp89fEBwcjKeXN3sOHKVEUQfS2qckYYK4bNi2F6PRiL9/AC9dXCNe2Uds2LbXdIilYpmi/Pb7MYxGI38eO0P2rBlCnV/j7uHFleu3ad6wBpkypOXGrXv/uo9JEifk4pWbGI1Gfj/8Nz4+vkDEr72wwteTZy9Y/fMOhvbpZAr8uXNk4cXLVxw8egoAL28fXru5E9cuDhnT2/Pb7yGH7Z45vcTlvRmvj0meLAnx4tqxfvNuKpYpFqk+tmxUg/uPnvLne6+L8qWLsP/QcR4+fk6+3Nk+WObcpevEiW1LswbVSZUiOVdv3AHAPyCA5y9cANi17zDp06YK8xyoj/U7vG34ue8TkfdpBkliPPvUyZm/fAPTF/zIazd3vqtQkro1Kn5QztbGmrFDejBr4VpsbKzJnSMLKZOHHOrKnDEtJYvmp2XXoaS3T0Wa1MkJDv7ng6ly+RJMnbeKKZVLR9ieqhVL4fTyFR2+H4XBYKBooTy0bFTzo+WLF87HgFHTmTVhMBDybXzDL7/Rv2c7IOQb9l8nL9Cmx3CyZU5PxvT2H11Xg1qVuHvvEc07DyJl8qRkymCPl7dPhG3u3bUlsxetpWXXIdja2lCsYF56dmqGrY01VSuWonmngTSsXYVWTWpRs0oZWnUbSvYsGahYthg3bt+PcP0RefTkOT0GOPLq9RtqVilL6WIFMBgMTBndj+kLfuTXfX9ibW1F6ya1TYdIP2bouDk8fR5yiKpb//Hkz5Odgd+354Wzi6lM9cpluHnnAa26DiVOnNiMHtQt1Drix7OjWYPqdOk7hlQpkpEnZxZcXrn9qz42b1idYY5zOXXuCrWrliNr5vRA+K+9AvlyMnHmsg9ePwuWb8DL25d+I6YBIWFm+rj+TBvbnzlL1rFi7TZsbKzo2bE5hfLnYuTArkyatZzN2/eROWNa0qZJGak2ly9VhEWrNjLwh3aRKm9pacnQPp0YOn4OBfLmJEH8uBTOn5tRkxZQrVKpD75cBAUFc+7iNeYsWYeXlw9ZMqWjYtmiuLl5YDAYWPLjJu7ef4JdHFvGDe0Z5uxvgvhxw+x3QYecH92Gn/s+EXmfwd/fL+I5cZH/uF37DnPmwlXGDO7xtZvynzN++hKyZkpPswbVvnZTJIZ47uRMmx7DObBt6dduishHaQZJ/q8FBgXRpc8YLC0tmTyqz9dujoiIxBCaQRIRERExo5O0RURERMwoIImIiIiYUUASERERMfM/27h9wDDkwzcAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 583.3x340 with 1 Axes>"
       ]
@@ -958,8 +651,13 @@
     }
    ],
    "source": [
-    "placebo_arr = np.array(ref.get(\"placebo_effects\", []))\n",
-    "if len(placebo_arr) > 0:\n",
+    "placebo_arr = np.asarray(metrics[\"placebo_effects\"], dtype=float)\n",
+    "if placebo_arr.size == 0:\n",
+    "    # The registry stores the draws beside the p-value, so an empty array here is a row written\n",
+    "    # before that column existed rather than a refutation that did not run. Say which, instead\n",
+    "    # of showing an empty axis.\n",
+    "    print(\"This causal row predates the stored placebo draws; the p-value above is the test.\")\n",
+    "else:\n",
     "    fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
     "    ax.hist(\n",
     "        placebo_arr,\n",
@@ -975,11 +673,14 @@
     "        linewidth=2,\n",
     "        label=f\"Adjusted estimate ({dml_effect:.6f})\",\n",
     "    )\n",
-    "    relation = \"outside\" if p_value_perm < 0.05 else \"inside\"\n",
+    "    relation = \"outside\" if refutation_p < 0.05 else \"inside\"\n",
     "    add_message_title(\n",
     "        ax,\n",
     "        f\"The adjusted estimate falls {relation} the central placebo range\",\n",
-    "        subtitle=\"Within-entity block permutation of the IV-RV spread\",\n",
+    "        subtitle=(\n",
+    "            f\"Within-entity permutation in blocks of \"\n",
+    "            f\"{computation['refutation']['block_size']} sessions\"\n",
+    "        ),\n",
     "    )\n",
     "    ax.set_xlabel(\"5-day forward return per 1.0 annualized IV-RV spread\")\n",
     "    ax.set_ylabel(\"Count\")\n",
@@ -989,307 +690,40 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0cb9be2b",
+   "id": "d7658067",
    "metadata": {
     "papermill": {
-     "duration": 0.001497,
-     "end_time": "2026-08-29T13:00:11.828091+00:00",
+     "duration": 0.001852,
+     "end_time": "2026-08-31T02:26:57.608950+00:00",
      "exception": false,
-     "start_time": "2026-08-29T13:00:11.826594+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## 5. Register Results\n",
-    "\n",
-    "First align the out-of-fold residuals with the analysis panel and construct\n",
-    "the standardized per-observation artifact."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "d559e516",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T13:00:11.831903Z",
-     "iopub.status.busy": "2026-08-29T13:00:11.831762Z",
-     "iopub.status.idle": "2026-08-29T13:00:11.841754Z",
-     "shell.execute_reply": "2026-08-29T13:00:11.841236Z"
-    },
-    "papermill": {
-     "duration": 0.012574,
-     "end_time": "2026-08-29T13:00:11.842208+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.829634+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "T_res = dml_result.get(\"T_res\", np.full(len(merged_clean), np.nan))\n",
-    "Y_res = dml_result.get(\"Y_res\", np.full(len(merged_clean), np.nan))\n",
-    "\n",
-    "n_analysis = len(merged_clean)\n",
-    "if len(T_res) > n_analysis:\n",
-    "    T_res = T_res[-n_analysis:]\n",
-    "    Y_res = Y_res[-n_analysis:]\n",
-    "\n",
-    "symbol_col = entity_cols[0] if entity_cols else None\n",
-    "\n",
-    "predictions = pd.DataFrame(\n",
-    "    {\n",
-    "        \"timestamp\": pd.to_datetime(merged_clean[date_col]),\n",
-    "        \"symbol\": merged_clean[symbol_col].values if symbol_col else \"ALL\",\n",
-    "        \"y_true\": merged_clean[label_col].values,\n",
-    "        \"treatment_value\": merged_clean[TREATMENT_COL].values,\n",
-    "        \"treatment_residual\": T_res,\n",
-    "        \"outcome_residual\": Y_res,\n",
-    "        \"treatment_contribution\": T_res * dml_effect,\n",
-    "        \"ate\": dml_effect,\n",
-    "        \"ate_se\": se_hac,\n",
-    "    }\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d0712948",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002754,
-     "end_time": "2026-08-29T13:00:11.848250+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.845496+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "The compact summary carries the estimand, panel-aware uncertainty, and\n",
-    "refutation result into the registry."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "ad1a84c2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T13:00:11.854536Z",
-     "iopub.status.busy": "2026-08-29T13:00:11.854436Z",
-     "iopub.status.idle": "2026-08-29T13:00:11.856748Z",
-     "shell.execute_reply": "2026-08-29T13:00:11.856399Z"
-    },
-    "papermill": {
-     "duration": 0.006229,
-     "end_time": "2026-08-29T13:00:11.857310+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.851081+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "summary = {\n",
-    "    \"treatment\": TREATMENT_COL,\n",
-    "    \"outcome\": label_col,\n",
-    "    \"confounders\": CONFOUNDER_COLS,\n",
-    "    \"n_observations\": dml_result[\"n_obs\"],\n",
-    "    \"n_decision_times\": dml_result[\"n_periods\"],\n",
-    "    \"naive_effect\": float(naive_effect),\n",
-    "    \"dml_effect\": float(dml_effect),\n",
-    "    \"dml_se_iid\": float(dml_result[\"se_iid\"]),\n",
-    "    \"dml_se_hac\": float(se_hac),\n",
-    "    \"confounding_bias_pct\": float(bias_pct),\n",
-    "    \"p_value_hac\": float(p_value),\n",
-    "    \"hac_maxlags\": int(results.get(\"hac_maxlags\", 0)),\n",
-    "    \"covariance_type\": dml_result[\"covariance_type\"],\n",
-    "    \"refutation_p_value\": float(p_value_perm),\n",
-    "    \"refutation_class\": ref_class,\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b8ce40f7",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00259,
-     "end_time": "2026-08-29T13:00:11.862938+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.860348+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "Every argument below that changes what the estimate is enters the hashed causal specification,\n",
-    "so a run at a different block size, placebo count, seed, bandwidth, row cap, entity cap or\n",
-    "development cutoff registers as its own result rather than overwriting the one before it. Leaving one out is not a\n",
-    "smaller record: it is two runs sharing an identity, and the registry cannot tell them apart\n",
-    "afterwards."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "1e8d5961",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T13:00:11.866531Z",
-     "iopub.status.busy": "2026-08-29T13:00:11.866434Z",
-     "iopub.status.idle": "2026-08-29T13:00:11.897164Z",
-     "shell.execute_reply": "2026-08-29T13:00:11.896659Z"
-    },
-    "papermill": {
-     "duration": 0.03306,
-     "end_time": "2026-08-29T13:00:11.897503+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.864443+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  -> registered causal_dml (causal_hash=b47bd0ec208a, p_hac=0.3935)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'b47bd0ec208a'"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "register_causal_run(\n",
-    "    case_study_id=CASE_STUDY_ID,\n",
-    "    label=PRIMARY_LABEL,\n",
-    "    results=results,\n",
-    "    predictions=predictions,\n",
-    "    treatment_col=TREATMENT_COL,\n",
-    "    confounder_cols=CONFOUNDER_COLS,\n",
-    "    n_folds=CV_FOLDS,\n",
-    "    embargo=EMBARGO_PERIODS,\n",
-    "    time_col=date_col,\n",
-    "    block_size=BLOCK_SIZE,\n",
-    "    n_placebo=PLACEBO_REPS,\n",
-    "    seed=RANDOM_SEED,\n",
-    "    horizon=OUTCOME_HORIZON,\n",
-    "    max_samples=ROW_CAP,\n",
-    "    max_symbols=MAX_SYMBOLS,\n",
-    "    development_end=str(DEVELOPMENT_CUTOFF.date()),\n",
-    "    notebook=\"12_causal_dml\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "19d2405b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001544,
-     "end_time": "2026-08-29T13:00:11.900986+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.899442+00:00",
+     "start_time": "2026-08-31T02:26:57.607098+00:00",
      "status": "completed"
     }
    },
    "source": [
     "## Key Takeaways\n",
     "\n",
-    "1. **The holdout is never read**: The analysis ends before the\n",
-    "   label-buffer cutoff, so exploratory causal diagnostics cannot influence or\n",
-    "   consume the final evaluation window.\n",
+    "1. **The holdout is never read**: the request drops every observation whose outcome window\n",
+    "   could reach past the holdout endpoint cutoff, so exploratory causal diagnostics cannot\n",
+    "   influence or consume the final evaluation window.\n",
     "\n",
     "2. **Read the coefficient against its panel-aware standard error, not against zero**:\n",
     "   the DML estimate is a five-day return per one annualized unit of IV-RV spread, and the\n",
     "   Driscoll-Kraay standard error beside it is the one that allows for both serial and\n",
-    "   cross-sectional dependence. The summary cell above prints both, with the p-value.\n",
+    "   cross-sectional dependence.\n",
     "\n",
     "3. **Compare naive OLS and DML on the same rows**: `confounding_bias_pct` is the gap\n",
     "   between them as a share of the adjusted estimate. Both are computed on the same\n",
-    "   out-of-fold sample, which is what stops an apparent large correction that is really\n",
-    "   two estimators reading different numbers of rows.\n",
+    "   analysis population, so the difference is adjustment rather than sample.\n",
     "\n",
-    "4. **The permutation disturbs timing, not confounding**: its block size is the longer of the\n",
-    "   outcome horizon and the treatment's own rolling window, so the placebo series retain whichever\n",
-    "   dependence runs longer and the null they generate is not narrowed by the shuffle itself. Its\n",
-    "   p-value still has a floor of one over the number of placebo draws plus one, so a run of this\n",
-    "   size cannot report zero however extreme the estimate is, and it does not override the\n",
-    "   coefficient's own uncertainty.\n",
+    "4. **The estimand is part of the identity**: treatment, confounders, temporal geometry and\n",
+    "   refutation design all enter the hashed specification, so a run at a different block size,\n",
+    "   placebo count, seed, fold count or population registers as its own result rather than\n",
+    "   overwriting the one before it.\n",
     "\n",
-    "5. **Diagnostics do not establish identification**: Complete-date cross-fitting\n",
-    "   and both uncertainty checks strengthen the sensitivity analysis, but a\n",
-    "   causal reading still requires conditional ignorability, overlap, and SUTVA.\n",
-    "\n",
-    "**Next**: See the case-study insights notebook for comparison across all nine\n",
-    "case studies.\n",
-    "\n",
-    "**Book**: Section 15.6 contrasts this with S&P 500 Options."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "2ebc078a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-29T13:00:11.904908Z",
-     "iopub.status.busy": "2026-08-29T13:00:11.904771Z",
-     "iopub.status.idle": "2026-08-29T13:00:11.907605Z",
-     "shell.execute_reply": "2026-08-29T13:00:11.907189Z"
-    },
-    "papermill": {
-     "duration": 0.005381,
-     "end_time": "2026-08-29T13:00:11.907907+00:00",
-     "exception": false,
-     "start_time": "2026-08-29T13:00:11.902526+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Causal DML registry summary: sp500_equity_option_analytics\n",
-      "  treatment: ivrv_spread\n",
-      "  outcome: fwd_ret_5d\n",
-      "  confounders: ['rv_20', 'mom_21d', 'skew_rr_30_25d']\n",
-      "  n_observations: 37240\n",
-      "  n_decision_times: 96\n",
-      "  naive_effect: -0.028260\n",
-      "  dml_effect: -0.028764\n",
-      "  dml_se_iid: 0.003179\n",
-      "  dml_se_hac: 0.033558\n",
-      "  confounding_bias_pct: 1.749896\n",
-      "  p_value_hac: 0.393547\n",
-      "  hac_maxlags: 4\n",
-      "  covariance_type: driscoll_kraay\n",
-      "  refutation_p_value: 0.009901\n",
-      "  refutation_class: Passes\n",
-      "\n",
-      "Causal DML analysis complete for sp500_equity_option_analytics\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f\"\\nCausal DML registry summary: {CASE_STUDY_ID}\")\n",
-    "for key, value in summary.items():\n",
-    "    if isinstance(value, float):\n",
-    "        print(f\"  {key}: {value:.6f}\")\n",
-    "    else:\n",
-    "        print(f\"  {key}: {value}\")\n",
-    "\n",
-    "print(f\"\\nCausal DML analysis complete for {CASE_STUDY_ID}\")"
+    "5. **A refutation is evidence about timing, not about confounding**: a causal reading still\n",
+    "   requires conditional ignorability, overlap, and SUTVA, none of which any test here can\n",
+    "   establish."
    ]
   }
  ],
@@ -1315,24 +749,24 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
-  "ml4t_provenance": {
-   "executed_at": "2026-08-29T13:00:18.934175+00:00",
-   "executor": "local-uv",
-   "parameters": {},
-   "production": true,
-   "source_py_blob": "1ca9f827a02b95ec60e68fb646b1184dcbb02b54"
-  },
   "papermill": {
    "default_parameters": {},
-   "duration": 60.628263,
-   "end_time": "2026-08-29T13:00:13.426576+00:00",
+   "duration": 12.182323,
+   "end_time": "2026-08-31T02:27:00.462853+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/12_causal_dml.ipynb",
-   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/.12_causal_dml.papermill.1197169.ipynb",
+   "input_path": "case_studies/sp500_equity_option_analytics/12_causal_dml.ipynb",
+   "output_path": "~/scratch/prod_12_causal_dml_3958857.ipynb",
    "parameters": {},
-   "start_time": "2026-08-29T12:59:12.798313+00:00",
+   "start_time": "2026-08-31T02:26:48.280530+00:00",
    "version": "2.7.0"
+  },
+  "ml4t_provenance": {
+   "source_py_blob": "fa414096811ad65e94eea8401ae44e0afb59a731",
+   "executed_at": "2026-08-31T02:27:01.643295+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_equity_option_analytics/12_causal_dml.py
+++ b/case_studies/sp500_equity_option_analytics/12_causal_dml.py
@@ -76,7 +76,6 @@ from utils.style import COLORS, FIGSIZE, add_message_title
 CASE_STUDY_ID = "sp500_equity_option_analytics"
 PRIMARY_LABEL = ""
 MAX_SYMBOLS = 0
-RANDOM_SEED = 42
 CV_FOLDS = 0
 MAX_SAMPLES = 0
 N_PLACEBO = 0
@@ -110,7 +109,6 @@ SUPERSEDES_CAUSAL: str = ""
 # reduced one.
 
 # %%
-set_global_seeds(RANDOM_SEED)
 setup = yaml.safe_load((get_case_study_dir(CASE_STUDY_ID) / "config" / "setup.yaml").read_text())
 label = PRIMARY_LABEL or setup["labels"]["primary"]
 
@@ -145,12 +143,19 @@ request = study.causal(
 resolved = request.resolve()
 computation = resolved.spec["computation"]
 estimand = computation["estimand"]
+# Seeded from the identity rather than from a notebook parameter. The seed the estimate depends
+# on is `dml.yaml`'s, and it is in the resolved specification and therefore in the hash; a
+# parameter beside it would be a dial a reader can turn that changes nothing, and worse, turning
+# it would leave the identity untouched and reload the cached result under a seed it was not fit
+# with. The nuisance estimator and the placebo permutation carry this seed explicitly; the global
+# call covers whatever else in the stack reads a process-wide one.
+set_global_seeds(int(resolved.spec["seed"]))
 
 print(f"Case study: {CASE_STUDY_ID}")
 print(f"Treatment: {estimand['treatment']}")
 print(f"Outcome: {estimand['outcome']} (horizon {estimand['outcome_horizon']})")
 print(f"Confounders: {', '.join(estimand['confounders'])}")
-print(f"Execution tier: {tier.value}")
+print(f"Execution tier: {tier.value} | seed {resolved.spec['seed']}")
 print(f"Last admissible outcome endpoint: {estimand['holdout_endpoint_cutoff']}")
 
 # %% [markdown]
@@ -365,8 +370,9 @@ else:
 #    cross-sectional dependence.
 #
 # 3. **Compare naive OLS and DML on the same rows**: `confounding_bias_pct` is the gap
-#    between them as a share of the adjusted estimate. Both are computed on the same
-#    analysis population, so the difference is adjustment rather than sample.
+#    between them as a share of the adjusted estimate. Both are computed on the cross-fitted
+#    observations - the smaller of the two counts reported above, not the analysis population
+#    - so the difference between them is adjustment rather than sample.
 #
 # 4. **The estimand is part of the identity**: treatment, confounders, temporal geometry and
 #    refutation design all enter the hashed specification, so a run at a different block size,

--- a/case_studies/sp500_equity_option_analytics/12_causal_dml.py
+++ b/case_studies/sp500_equity_option_analytics/12_causal_dml.py
@@ -29,9 +29,17 @@
 # 30d) confound this relationship because all three co-move with investor fear
 # and positioning.
 #
+# The estimand, the analysis population, the cross-fitting geometry and the
+# refutation design are resolved by the shared causal request rather than
+# assembled here. The request verifies that the treatment and every confounder
+# exist, excludes outcomes whose horizon reaches the holdout, keeps complete
+# decision-time panels, cross-fits with an embargo, and records the placebo
+# block design in the causal identity. This notebook inspects what it resolved,
+# runs it, and reports the result.
+#
 # **Learning Objectives**:
 # - Keep the holdout outside an exploratory causal analysis
-# - Cross-fit a panel by complete decision time with a time-based embargo
+# - Read the estimand and its temporal controls off the resolved specification
 # - Compare the adjusted estimate with naive OLS and a block-permutation null
 #
 # **Book Reference**: Chapter 15, Section 15.6 (Cross-Dataset Causal Evidence)
@@ -52,133 +60,104 @@
 # but cannot prove the assumptions hold.
 
 # %%
-"""Causal DML walk-forward estimation with refutation tests."""
-
-import warnings
+"""Estimate and register the configured equity-option causal DML specification."""
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
+import polars as pl
 import yaml
 
-from case_studies.utils.causal import (
-    classify_refutation,
-    embargo_from_buffer,
-    format_dml_summary,
-    register_causal_run,
-    run_dml_analysis,
-)
-from utils.artifact_specs import resolve_label_horizon
-from utils.modeling import load_configs, load_modeling_dataset
+from case_studies.research import ExecutionTier, causal_supersedes, open_study
 from utils.paths import get_case_study_dir
 from utils.reproducibility import set_global_seeds
 from utils.style import COLORS, FIGSIZE, add_message_title
 
-warnings.filterwarnings("ignore")
-
 # %% tags=["parameters"]
 CASE_STUDY_ID = "sp500_equity_option_analytics"
+PRIMARY_LABEL = ""
 MAX_SYMBOLS = 0
-# Each of these is zero or empty for "take the declared value". A run that passes one
-# overrides the declaration; a run that passes none reproduces the published analysis.
-LABEL = ""
-SEED = 0
-N_FOLDS = 0
+RANDOM_SEED = 42
+CV_FOLDS = 0
 MAX_SAMPLES = 0
 N_PLACEBO = 0
+FORCE_RETRAIN = False
+# The tier is declared, not inferred from whether a reduction happens to be set: a reduced run
+# that still opened the case study's own artifacts in place would be writing down the
+# production path. WORKSPACE is the other half - a preview has nowhere else to write.
+EXECUTION_TIER = "canonical"
+WORKSPACE: str | None = None
+# Empty because this registry holds no *current* causal identity for the label, not because
+# nothing came before. `b47bd0ec208a` is the capped fit of 2026-08-26 - 37,240 rows, 9.9% of
+# the panel this request resolves - and it was written by the previous notebook under a spec
+# with no `identity_version`, so `current_causal_identities` does not return it and no reader
+# resolves it. There is nothing to retire: it is stranded rather than superseded, and naming it
+# would fail the write for declaring a predecessor that is not current.
+#
+# Declare the hash here once this run leaves a current identity and a later change moves it -
+# a refit under a changed block size, fold count or population - or registration refuses the
+# write after the fit and all 100 placebo refits have been paid for. `causal_supersedes` then
+# withholds the declaration against a reader's clone, which holds no causal rows at all, so one
+# committed value is right for both. That resolution has to happen against the registry rather
+# than at run time: `run-production-notebook.sh` executes with no parameter overrides, so a
+# value supplied only as an override could never be stamped.
+SUPERSEDES_CAUSAL: str = ""
 
 # %% [markdown]
-# ### What is asked for, and what it resolves to
+# ## Resolve the estimand and analysis population
 #
-# The parameters above are the request. The values the analysis runs on are resolved below and
-# carry different names, so the two can be read side by side and neither can quietly overwrite
-# the other. Precedence is: an injected parameter wins, otherwise the case study's declaration.
-#
-# The declaration is read with `[...]` rather than `.get(key, literal)`. A literal default here
-# would substitute a number the case study never declared - silently, and only on the
-# configurations that happen to omit the key - so a missing key raises instead.
+# Nonzero fold, sample, symbol, or placebo limits declare a preview. They are recorded in
+# identity and excluded from canonical evidence, so the published estimate cannot silently be a
+# reduced one.
 
 # %%
-CASE_DIR = get_case_study_dir(CASE_STUDY_ID)
-
-setup = yaml.safe_load((CASE_DIR / "config" / "setup.yaml").read_text())
-PRIMARY_LABEL = LABEL or setup["labels"]["primary"]
-
-causal_configs = load_configs(CASE_STUDY_ID, PRIMARY_LABEL, "causal_dml")
-dml_cfg = causal_configs[0]
-
-CV_FOLDS = N_FOLDS or int(dml_cfg["n_folds"])
-PLACEBO_REPS = N_PLACEBO or int(dml_cfg["n_placebo"])
-ROW_CAP = MAX_SAMPLES or int(dml_cfg["max_samples"])
-RANDOM_SEED = SEED or int(dml_cfg["seed"])
-
-print(f"DML config: {dml_cfg['config_name']}")
-print(
-    f"  folds {CV_FOLDS} | placebo reps {PLACEBO_REPS} | row cap {ROW_CAP:,} | seed {RANDOM_SEED}"
-)
-
-# %% [markdown]
-# The case-study configuration defines the treatment and confounders. Keeping
-# these choices visible makes the conditional estimand explicit.
-
-# %%
-causal_cfg = setup.get("causal", {})
-TREATMENT_COL = causal_cfg.get("treatment", "")
-CONFOUNDER_COLS = causal_cfg.get("confounders", [])
-DML_METHOD = causal_cfg.get("method", "walk_forward_dml")
-
-if not TREATMENT_COL:
-    raise ValueError(
-        f"No causal.treatment in {CASE_STUDY_ID}/setup.yaml. "
-        "Add a 'causal:' section with treatment and confounders."
-    )
-
 set_global_seeds(RANDOM_SEED)
+setup = yaml.safe_load((get_case_study_dir(CASE_STUDY_ID) / "config" / "setup.yaml").read_text())
+label = PRIMARY_LABEL or setup["labels"]["primary"]
 
-print("Causal DML Configuration:")
-print(f"  Case study: {CASE_STUDY_ID}")
-print(f"  Treatment: {TREATMENT_COL}")
-print(f"  Outcome: {PRIMARY_LABEL}")
-print(f"  Confounders: {CONFOUNDER_COLS}")
-print(f"  CV folds: {CV_FOLDS}")
-print(f"  Placebo reps: {PLACEBO_REPS}")
+if FORCE_RETRAIN:
+    raise ValueError("an identical complete causal request is reused; change the request to refit")
 
-# %% [markdown]
-# ## 1. Load Artifacts
-#
-# Load pre-computed features, temporal features, and labels using the
-# shared modeling infrastructure.
+REDUCTION_PARAMETERS = {
+    "max_symbols": MAX_SYMBOLS or None,
+    "n_folds": CV_FOLDS or None,
+    "max_samples": MAX_SAMPLES or None,
+    "n_placebo": N_PLACEBO or None,
+}
+reductions = {key: value for key, value in REDUCTION_PARAMETERS.items() if value is not None}
+tier = ExecutionTier(EXECUTION_TIER)
+if tier is ExecutionTier.PREVIEW and not reductions:
+    raise ValueError("preview execution must declare at least one reduction")
+if tier is ExecutionTier.CANONICAL and reductions:
+    raise ValueError(f"canonical execution cannot carry reductions: {sorted(reductions)}")
 
-# %%
-mds = load_modeling_dataset(CASE_STUDY_ID, PRIMARY_LABEL, max_symbols=MAX_SYMBOLS)
-
-dataset = mds.dataset
-feature_names = mds.feature_names
-label_col = mds.label_col
-date_col = mds.date_col
-entity_cols = mds.entity_cols
-
-# Verify treatment and confounders are in features
-available = set(dataset.columns)
-assert TREATMENT_COL in available, (
-    f"Treatment '{TREATMENT_COL}' not found in features: {sorted(available)}"
+study = open_study(CASE_STUDY_ID, execution_tier=tier, workspace=WORKSPACE or None)
+request = study.causal(
+    method="dml",
+    label=label,
+    config_name="dml",
+    execution_tier=tier,
+    preview_reductions=reductions,
+    overrides={},
+    supersedes=causal_supersedes(
+        study, SUPERSEDES_CAUSAL, label, labels=[label], execution_tier=tier.value
+    ),
 )
+resolved = request.resolve()
+computation = resolved.spec["computation"]
+estimand = computation["estimand"]
 
-missing_conf = [c for c in CONFOUNDER_COLS if c not in available]
-if missing_conf:
-    print(f"WARNING: Missing confounders {missing_conf}, dropping them")
-    CONFOUNDER_COLS = [c for c in CONFOUNDER_COLS if c in available]
-
-assert len(CONFOUNDER_COLS) >= 1, "Need at least 1 confounder for DML"
-
-print(f"\nDataset: {len(dataset):,} rows x {len(feature_names)} features")
-print(f"Label: {label_col} | Date: {date_col} | Entities: {entity_cols}")
+print(f"Case study: {CASE_STUDY_ID}")
+print(f"Treatment: {estimand['treatment']}")
+print(f"Outcome: {estimand['outcome']} (horizon {estimand['outcome_horizon']})")
+print(f"Confounders: {', '.join(estimand['confounders'])}")
+print(f"Execution tier: {tier.value}")
+print(f"Last admissible outcome endpoint: {estimand['holdout_endpoint_cutoff']}")
 
 # %% [markdown]
-# ## 2. Prepare Analysis Data
-#
-# Convert to pandas, seal the holdout, sort by time and entity, and retain the
-# most recent complete decision times when the production cap applies.
+# > **Scope**: This is a development-period sensitivity analysis, not a holdout
+# > evaluation. The request excludes every observation whose outcome window could
+# > reach past `holdout_endpoint_cutoff`, and it keeps complete cross-sections, so
+# > neither folds nor embargoes cut through a decision time.
 #
 # > **Population scope**: The source universe is a current-constituent roster,
 # > not point-in-time S&P 500 membership. Firms removed from the index before
@@ -187,164 +166,129 @@ print(f"Label: {label_col} | Date: {date_col} | Entities: {entity_cols}")
 # > to the historical index-membership process or a prospective S&P 500
 # > population.
 
-# %%
-analysis_cols = [date_col] + entity_cols + [TREATMENT_COL, label_col] + CONFOUNDER_COLS
-analysis_cols = list(dict.fromkeys(analysis_cols))  # deduplicate
-
-merged_clean = (
-    dataset.select([c for c in analysis_cols if c in available])
-    .drop_nulls()
-    .sort(date_col)
-    .to_pandas()
-)
-
 # %% [markdown]
-# The forward-label buffer closes the development sample early enough that no
-# outcome interval crosses into the holdout.
-
-# %% [markdown]
+# ## 1. Inspect the temporal controls
+#
 # Three quantities decide how this estimate is measured, and they answer different questions.
 #
-# The **embargo** separates a fold's training window from its test window, so a label measured in
-# training cannot still be running when testing starts. `labels.buffer` sets it, and that buffer is
-# declared deliberately longer than the outcome it protects, so it is not a statement about the
-# outcome. The **outcome horizon** is how long one outcome stays open: `labels.horizons` names it
-# per label, and for the primary label it is the shorter of the two. The **permutation block size** is the scale of the dependence
-# the placebo has to preserve: shuffling in blocks shorter than that scale pulls dependent
-# observations apart, and the placebo degrades towards an independent draw - the permutation that
-# is too easy to pass and therefore proves nothing.
+# The **embargo** separates a fold's training window from its test window, so a label measured
+# in training cannot still be running when testing starts. `labels.buffer` sets it, and that
+# buffer is declared deliberately longer than the outcome it protects, so it is not a statement
+# about the outcome. The **outcome horizon** is how long one outcome stays open, and it is what
+# the Driscoll-Kraay bandwidth is sized by: a bandwidth shorter than the overlap between
+# successive outcomes understates the standard error. The **permutation block size** is the
+# scale of the dependence the placebo has to preserve: shuffling in blocks shorter than that
+# scale pulls dependent observations apart and the placebo degrades towards an independent draw
+# - the permutation that is too easy to pass and therefore proves nothing.
 #
-# **Two scales qualify for the block size, and it has to cover both.** One is the outcome horizon.
-# The other is the treatment's own persistence: `ivrv_spread` subtracts a rolling realized
-# volatility from implied, so consecutive values share most of their input and stay dependent over
-# that rolling window whatever the label does. It is the longer of the two here. The block size
-# below takes the larger, so the placebo keeps whichever dependence runs longer.
+# **Two scales qualify for the block size, and it has to cover both.** One is the outcome
+# horizon. The other is the treatment's own persistence: `ivrv_spread` subtracts a 20-session
+# rolling realized volatility from implied, so consecutive values share most of their input and
+# stay dependent over that rolling window whatever the label does. It is the longer of the two
+# here, and `causal.treatment_window` in `config/setup.yaml` declares it beside the derivation
+# that produced it, because no rule can read a construction window off a column name.
 #
-# The treatment's persistence does not follow from `causal.treatment` alone - it follows from how
-# that column is built in the feature stage, which no rule can read off the column name. So it is
-# declared: `causal.treatment_window` in `config/setup.yaml` states the number of bars, beside the
-# treatment it describes and beside the derivation that produced it. The assignment below refuses a
-# treatment with no declared window rather than substituting the buffer, which would size the block
-# by the wrong scale and leave a refutation that reads stronger than it is.
-#
-# The **Newey-West bandwidth** in the second stage has to cover the overlap between successive
-# outcomes, which is the outcome horizon and not the buffer. The buffer is a cross-validation
-# device that holds a fold's training rows clear of its validation labels; it says nothing about
-# how far apart two outcomes stop sharing a return window. A bandwidth shorter than the overlap
-# understates the standard error, and a longer one moves it in whichever direction the extra
-# sample autocovariances happen to point, so the notebook passes the horizon itself.
-#
-# The **development cutoff** is counted in sessions, because that is the unit the labels are
-# built in. `forward_return` in `02_labels.py` takes the close a fixed number of sessions ahead
-# and keeps a row only where the session index spans exactly that many. Subtracting the buffer
-# as a calendar duration answers a different question: ten days is about seven sessions on this
-# calendar, so the notebook delivered seven where it declared ten, and a label variant whose
-# horizon exceeded seven resolved its return inside the holdout with nothing to show it.
+# The table prints the block the run used beside both scales it has to span, read from the
+# resolved specification rather than from `setup.yaml`, so it shows what the run used rather
+# than what the file asks for.
 
 # %%
-BUFFER_PERIODS = embargo_from_buffer(mds.label_buffer)
-EMBARGO_PERIODS = BUFFER_PERIODS
-OUTCOME_HORIZON = embargo_from_buffer(resolve_label_horizon(CASE_STUDY_ID, PRIMARY_LABEL, setup))
-if OUTCOME_HORIZON > BUFFER_PERIODS:
-    raise ValueError(
-        f"Outcome horizon {OUTCOME_HORIZON} exceeds the label buffer {BUFFER_PERIODS}. "
-        "The cutoff below subtracts the buffer to keep development labels clear of the "
-        "holdout, so a longer outcome would still reach into it. Raise labels.buffer in "
-        "setup.yaml, or correct labels.horizons."
-    )
-declared_window = causal_cfg.get("treatment_window")
-if declared_window is None:
-    raise ValueError(
-        f"No causal.treatment_window in {CASE_STUDY_ID}/setup.yaml, so the block size below "
-        f"cannot be shown to span the persistence of treatment '{TREATMENT_COL}'. Declare the "
-        "number of bars the treatment's own construction spans, read off the code that builds "
-        "the column."
-    )
-TREATMENT_PERSISTENCE = max(1, int(declared_window))
-BLOCK_SIZE = max(OUTCOME_HORIZON, TREATMENT_PERSISTENCE)
-HOLDOUT_START = pd.Timestamp(setup["evaluation"]["holdout_start"])
-pre_holdout = np.sort(merged_clean.loc[merged_clean[date_col] < HOLDOUT_START, date_col].unique())
-if len(pre_holdout) <= BUFFER_PERIODS:
-    raise ValueError(
-        f"The panel holds {len(pre_holdout)} sessions before {HOLDOUT_START.date()}, which "
-        f"cannot absorb a {BUFFER_PERIODS}-session buffer and leave anything to analyse."
-    )
-DEVELOPMENT_CUTOFF = pd.Timestamp(pre_holdout[-BUFFER_PERIODS])
-
-# Labels at or after this cutoff can overlap the holdout return window.
-merged_clean = merged_clean.loc[merged_clean[date_col] < DEVELOPMENT_CUTOFF].copy()
-
-sort_cols = [date_col, *entity_cols]
-merged_clean = merged_clean.sort_values(sort_cols).reset_index(drop=True)
-
-if entity_cols and merged_clean.duplicated([date_col, entity_cols[0]]).any():
-    raise ValueError("Causal panel must contain at most one row per decision time and entity")
+pl.DataFrame(
+    {
+        "label": [resolved.spec["label"]],
+        "cross_fitting_folds": [computation["cv"]["n_folds"]],
+        "embargo_periods": [computation["cv"]["embargo_periods"]],
+        "fold_unit": [computation["cv"]["fold_unit"]],
+        "label_buffer_steps": [computation["refutation"]["label_buffer_steps"]],
+        "label_horizon_steps": [computation["refutation"]["label_horizon_steps"]],
+        "treatment_window_steps": [computation["refutation"]["treatment_window_steps"]],
+        "placebo_method": [computation["refutation"]["method"]],
+        "placebo_block_size": [computation["refutation"]["block_size"]],
+        "block_size_basis": [computation["refutation"]["block_size_basis"]],
+        "placebo_draws": [computation["refutation"]["n_placebo"]],
+        "analysis_rows": [computation["analysis_population"]["n_rows"]],
+        "analysis_timestamps": [computation["analysis_population"]["n_timestamps"]],
+        "analysis_key_digest": [computation["analysis_population"]["key_digest"]],
+    }
+)
 
 # %% [markdown]
-# When a row cap is active, retain whole recent cross-sections so that sample
-# construction cannot cut through a decision time.
+# ## 2. Estimate or reload the causal result
+#
+# Registration happens only after the fit returns a finite effect and HAC standard error. A
+# missing treatment, confounder, or valid analysis population fails before any causal row is
+# written.
 
-# %%
-if ROW_CAP > 0 and len(merged_clean) > ROW_CAP:
-    date_counts = merged_clean.groupby(date_col, sort=True).size()
-    reverse_cumulative = date_counts.iloc[::-1].cumsum()
-    selected_dates = reverse_cumulative[reverse_cumulative <= ROW_CAP].index
-    if len(selected_dates) == 0:
-        raise ValueError(f"ROW_CAP={ROW_CAP:,} cannot fit one complete decision time")
-    print(
-        f"Taking {len(selected_dates):,} most recent complete decision times "
-        f"({int(date_counts.loc[selected_dates].sum()):,} rows) from {len(merged_clean):,}"
-    )
-    merged_clean = merged_clean.loc[merged_clean[date_col].isin(selected_dates)].reset_index(
-        drop=True
-    )
+# %% tags=["results"]
+result = resolved.run()
+if not result.complete:
+    raise RuntimeError(f"the causal result for {label} is incomplete")
+# Compare the identity-bearing computation, not the whole specification. `provenance` records
+# the git commit of the run that registered the result, so a full-spec comparison fails on any
+# re-run made after any commit - it would assert that nothing had been committed since, which is
+# not a property of the causal estimate.
+if result.spec["computation"] != computation:
+    raise RuntimeError(f"the registered causal computation for {label} differs")
+reloaded = request.resolve().run()
+if reloaded.hash != result.hash:
+    raise RuntimeError(f"reloading the causal request for {label} changed its identity")
 
-assert merged_clean[date_col].max() < DEVELOPMENT_CUTOFF
+print(f"Registered causal identity: {result.hash}")
 
 # %% [markdown]
-# > **Scope**: This is a development-period sensitivity analysis, not a holdout
-# > evaluation. The label buffer removes observations whose forward returns could
-# > overlap the holdout. `ROW_CAP` keeps complete cross-sections, so
-# > neither folds nor embargoes cut through a decision time.
+# ## 3. Statistical Assessment
+#
+# Confounding bias is defined as:
+#
+# $$\text{Bias \%} = \frac{\hat{\theta}_{\text{naive}} - \hat{\theta}_{\text{DML}}}{|\hat{\theta}_{\text{DML}}|} \times 100$$
+#
+# Positive values mean the naive coefficient is more positive than the adjusted
+# coefficient; interpret the sign alongside both coefficients.
+#
+# The two diagnostics answer different questions. Driscoll-Kraay inference asks whether the
+# adjusted coefficient is distinguishable from zero after allowing for panel dependence. The
+# block permutation asks whether its magnitude is unusual after disrupting the treatment-outcome
+# timing while preserving each entity's short-run treatment dependence. Neither test validates
+# the unobserved-confounding assumption.
+#
+#
+# Two numbers below are populations and they are not the same one. The **analysis population** is
+# what the request resolved: every row admissible under the estimand and the holdout cutoff.
+# **Cross-fitted observations** is the subset carrying an out-of-fold residual, which is what the
+# coefficient is computed on - a row outside every fold's validation window contributes nothing
+# to it by construction.
+#
+# The refutation verdict is derived from the p-value **and** the number of placebo refits that
+# succeeded, because a p-value alone cannot say whether the draws could have rejected at all.
+#
+# **Read the refutation against the warning the run prints above it**, which reports the share of
+# treatment rows the permutation could not move. A row is frozen when its symbol's segment is too
+# short to hold two blocks, and a 20-session block needs 40 clean sessions to have anywhere to go,
+# so a daily option panel freezes a large share: every gap in a symbol's quotes starts a new
+# segment. A frozen row keeps its observed treatment in every placebo, which pulls the placebo
+# distribution towards the observed estimate and biases the p-value **towards 1**. The bias works
+# against rejecting, so a refutation that passes with a large frozen share has passed a harder
+# test than the number suggests - which is the opposite of the reading a frozen share usually
+# warrants, and the reason it is worth checking rather than assuming.
 
 # %%
-print(f"\nAnalysis data: {len(merged_clean):,} rows")
-print(f"Date range: {merged_clean[date_col].min()} to {merged_clean[date_col].max()}")
-print(f"Holdout begins: {HOLDOUT_START.date()}")
-print(f"Development cutoff after label buffer: {DEVELOPMENT_CUTOFF.date()}")
+metrics = result.metrics
+dml_effect = metrics["dml_effect"]
+se_hac = metrics["dml_se_hac"]
+refutation_p = metrics["refutation_p"]
+
+print(f"Analysis population: {computation['analysis_population']['n_rows']:,} rows")
+print(f"Cross-fitted observations: {metrics['n_obs']:,}")
+print(f"Naive OLS effect:  {metrics['naive_effect']:+.6f}")
+print(f"Adjusted (DML):    {dml_effect:+.6f}  (HAC SE {se_hac:.6f})")
+print(f"95% interval:      [{dml_effect - 1.96 * se_hac:+.6f}, {dml_effect + 1.96 * se_hac:+.6f}]")
+print(f"Confounding bias:  {metrics['confounding_bias_pct']:+.2f}%")
+print(f"p-value (HAC):     {metrics['p_value_hac']:.4f}")
+print(f"  Significant at 5%: {'Yes' if metrics['p_value_hac'] < 0.05 else 'No'}")
 print(
-    f"Embargo: {EMBARGO_PERIODS} decision times | Block size: {BLOCK_SIZE} "
-    f"(outcome horizon {OUTCOME_HORIZON}, treatment window {TREATMENT_PERSISTENCE}) | "
-    f"HAC horizon: {OUTCOME_HORIZON}"
+    f"Refutation:        {metrics['refutation_class']} "
+    f"(p={refutation_p:.4f}, {metrics['refutation_n_successful']} successful draws)"
 )
-if entity_cols:
-    print(f"Entities: {merged_clean[entity_cols[0]].nunique()}")
-
-# %% [markdown]
-# ## 3. Run DML Analysis
-#
-# Full pipeline: naive OLS baseline, DML with walk-forward cross-fitting and
-# embargo, and a block-permutation refutation test. Cross-fitting keeps complete
-# dates together. Driscoll-Kraay covariance accounts for serial and
-# cross-sectional dependence in the residualized panel.
-
-# %%
-results = run_dml_analysis(
-    merged_clean,
-    treatment_col=TREATMENT_COL,
-    outcome_col=label_col,
-    confounder_cols=CONFOUNDER_COLS,
-    n_folds=CV_FOLDS,
-    embargo=EMBARGO_PERIODS,
-    n_placebo=PLACEBO_REPS,
-    block_size=BLOCK_SIZE,
-    seed=RANDOM_SEED,
-    horizon=OUTCOME_HORIZON,
-    time_col=date_col,
-    entity_col=entity_cols[0] if entity_cols else None,
-)
-
-print(format_dml_summary(results))
 
 # %% [markdown]
 # **Interpretation**: The DML coefficient is an adjusted conditional estimate,
@@ -353,52 +297,10 @@ print(format_dml_summary(results))
 # the naive and adjusted coefficients to see how observed confounders change the
 # estimated association.
 #
-# The two diagnostics answer different questions. Driscoll-Kraay inference asks
-# whether the adjusted coefficient is distinguishable from zero after allowing
-# for panel dependence. The block permutation asks whether its magnitude is
-# unusual after disrupting the treatment-outcome timing while preserving each
-# entity's short-run treatment dependence. Neither test validates the
-# unobserved-confounding assumption.
-#
 # Compare this result with the S&P 500 Options case study to see why confounding
 # must be assessed for each treatment-outcome pair rather than inferred from the
 # market alone.
-
-# %% [markdown]
-# ## 4. Statistical Assessment
 #
-# Confounding bias is defined as:
-#
-# $$\text{Bias \%} = \frac{\hat{\theta}_{\text{naive}} - \hat{\theta}_{\text{DML}}}{|\hat{\theta}_{\text{DML}}|} \times 100$$
-#
-# Positive values mean the naive coefficient is more positive than the adjusted
-# coefficient; interpret the sign alongside both coefficients.
-
-# %%
-dml_result = results["dml_result"]
-naive_effect = results["naive_effect"]
-dml_effect = dml_result["theta"]
-se_hac = dml_result["se_hac"]
-bias_pct = results["confounding_bias_pct"]
-
-# p-value computed in run_dml_analysis (no duplication)
-p_value = results["p_value_hac"]
-
-ref = results.get("refutation") or {}
-if "empirical_p" not in ref:
-    # Defaulting to 1.0 here would report "cannot reject" for a refutation that never ran,
-    # which is the one reading a missing test must not produce.
-    raise RuntimeError("the DML run published no block-permutation refutation")
-p_value_perm = ref["empirical_p"]
-ref_class = ref.get("refutation_class", classify_refutation(p_value_perm, ref.get("n_successful")))
-
-print("Statistical significance:")
-print(f"  p-value (HAC): {p_value:.4f}")
-print(f"  Significant at 5%: {'Yes' if p_value < 0.05 else 'No'}")
-if ref:
-    print(f"  Refutation: {ref_class} (p={p_value_perm:.4f})")
-
-# %% [markdown]
 # > **When should you be suspicious of large DML corrections?** A naive-to-DML
 # > amplification exceeding 5x warrants scrutiny. Possible causes:
 # > (1) nuisance models overfitting and stripping outcome-relevant variation,
@@ -414,8 +316,13 @@ if ref:
 # within-entity block permutations of the treatment.
 
 # %%
-placebo_arr = np.array(ref.get("placebo_effects", []))
-if len(placebo_arr) > 0:
+placebo_arr = np.asarray(metrics["placebo_effects"], dtype=float)
+if placebo_arr.size == 0:
+    # The registry stores the draws beside the p-value, so an empty array here is a row written
+    # before that column existed rather than a refutation that did not run. Say which, instead
+    # of showing an empty axis.
+    print("This causal row predates the stored placebo draws; the p-value above is the test.")
+else:
     fig, ax = plt.subplots(figsize=FIGSIZE["single"])
     ax.hist(
         placebo_arr,
@@ -431,11 +338,14 @@ if len(placebo_arr) > 0:
         linewidth=2,
         label=f"Adjusted estimate ({dml_effect:.6f})",
     )
-    relation = "outside" if p_value_perm < 0.05 else "inside"
+    relation = "outside" if refutation_p < 0.05 else "inside"
     add_message_title(
         ax,
         f"The adjusted estimate falls {relation} the central placebo range",
-        subtitle="Within-entity block permutation of the IV-RV spread",
+        subtitle=(
+            f"Within-entity permutation in blocks of "
+            f"{computation['refutation']['block_size']} sessions"
+        ),
     )
     ax.set_xlabel("5-day forward return per 1.0 annualized IV-RV spread")
     ax.set_ylabel("Count")
@@ -443,126 +353,26 @@ if len(placebo_arr) > 0:
     plt.show()
 
 # %% [markdown]
-# ## 5. Register Results
-#
-# First align the out-of-fold residuals with the analysis panel and construct
-# the standardized per-observation artifact.
-
-# %%
-T_res = dml_result.get("T_res", np.full(len(merged_clean), np.nan))
-Y_res = dml_result.get("Y_res", np.full(len(merged_clean), np.nan))
-
-n_analysis = len(merged_clean)
-if len(T_res) > n_analysis:
-    T_res = T_res[-n_analysis:]
-    Y_res = Y_res[-n_analysis:]
-
-symbol_col = entity_cols[0] if entity_cols else None
-
-predictions = pd.DataFrame(
-    {
-        "timestamp": pd.to_datetime(merged_clean[date_col]),
-        "symbol": merged_clean[symbol_col].values if symbol_col else "ALL",
-        "y_true": merged_clean[label_col].values,
-        "treatment_value": merged_clean[TREATMENT_COL].values,
-        "treatment_residual": T_res,
-        "outcome_residual": Y_res,
-        "treatment_contribution": T_res * dml_effect,
-        "ate": dml_effect,
-        "ate_se": se_hac,
-    }
-)
-
-# %% [markdown]
-# The compact summary carries the estimand, panel-aware uncertainty, and
-# refutation result into the registry.
-
-# %%
-summary = {
-    "treatment": TREATMENT_COL,
-    "outcome": label_col,
-    "confounders": CONFOUNDER_COLS,
-    "n_observations": dml_result["n_obs"],
-    "n_decision_times": dml_result["n_periods"],
-    "naive_effect": float(naive_effect),
-    "dml_effect": float(dml_effect),
-    "dml_se_iid": float(dml_result["se_iid"]),
-    "dml_se_hac": float(se_hac),
-    "confounding_bias_pct": float(bias_pct),
-    "p_value_hac": float(p_value),
-    "hac_maxlags": int(results.get("hac_maxlags", 0)),
-    "covariance_type": dml_result["covariance_type"],
-    "refutation_p_value": float(p_value_perm),
-    "refutation_class": ref_class,
-}
-
-# %% [markdown]
-# Every argument below that changes what the estimate is enters the hashed causal specification,
-# so a run at a different block size, placebo count, seed, bandwidth, row cap, entity cap or
-# development cutoff registers as its own result rather than overwriting the one before it. Leaving one out is not a
-# smaller record: it is two runs sharing an identity, and the registry cannot tell them apart
-# afterwards.
-
-# %%
-register_causal_run(
-    case_study_id=CASE_STUDY_ID,
-    label=PRIMARY_LABEL,
-    results=results,
-    predictions=predictions,
-    treatment_col=TREATMENT_COL,
-    confounder_cols=CONFOUNDER_COLS,
-    n_folds=CV_FOLDS,
-    embargo=EMBARGO_PERIODS,
-    time_col=date_col,
-    block_size=BLOCK_SIZE,
-    n_placebo=PLACEBO_REPS,
-    seed=RANDOM_SEED,
-    horizon=OUTCOME_HORIZON,
-    max_samples=ROW_CAP,
-    max_symbols=MAX_SYMBOLS,
-    development_end=str(DEVELOPMENT_CUTOFF.date()),
-    notebook="12_causal_dml",
-)
-
-# %% [markdown]
 # ## Key Takeaways
 #
-# 1. **The holdout is never read**: The analysis ends before the
-#    label-buffer cutoff, so exploratory causal diagnostics cannot influence or
-#    consume the final evaluation window.
+# 1. **The holdout is never read**: the request drops every observation whose outcome window
+#    could reach past the holdout endpoint cutoff, so exploratory causal diagnostics cannot
+#    influence or consume the final evaluation window.
 #
 # 2. **Read the coefficient against its panel-aware standard error, not against zero**:
 #    the DML estimate is a five-day return per one annualized unit of IV-RV spread, and the
 #    Driscoll-Kraay standard error beside it is the one that allows for both serial and
-#    cross-sectional dependence. The summary cell above prints both, with the p-value.
+#    cross-sectional dependence.
 #
 # 3. **Compare naive OLS and DML on the same rows**: `confounding_bias_pct` is the gap
 #    between them as a share of the adjusted estimate. Both are computed on the same
-#    out-of-fold sample, which is what stops an apparent large correction that is really
-#    two estimators reading different numbers of rows.
+#    analysis population, so the difference is adjustment rather than sample.
 #
-# 4. **The permutation disturbs timing, not confounding**: its block size is the longer of the
-#    outcome horizon and the treatment's own rolling window, so the placebo series retain whichever
-#    dependence runs longer and the null they generate is not narrowed by the shuffle itself. Its
-#    p-value still has a floor of one over the number of placebo draws plus one, so a run of this
-#    size cannot report zero however extreme the estimate is, and it does not override the
-#    coefficient's own uncertainty.
+# 4. **The estimand is part of the identity**: treatment, confounders, temporal geometry and
+#    refutation design all enter the hashed specification, so a run at a different block size,
+#    placebo count, seed, fold count or population registers as its own result rather than
+#    overwriting the one before it.
 #
-# 5. **Diagnostics do not establish identification**: Complete-date cross-fitting
-#    and both uncertainty checks strengthen the sensitivity analysis, but a
-#    causal reading still requires conditional ignorability, overlap, and SUTVA.
-#
-# **Next**: See the case-study insights notebook for comparison across all nine
-# case studies.
-#
-# **Book**: Section 15.6 contrasts this with S&P 500 Options.
-
-# %%
-print(f"\nCausal DML registry summary: {CASE_STUDY_ID}")
-for key, value in summary.items():
-    if isinstance(value, float):
-        print(f"  {key}: {value:.6f}")
-    else:
-        print(f"  {key}: {value}")
-
-print(f"\nCausal DML analysis complete for {CASE_STUDY_ID}")
+# 5. **A refutation is evidence about timing, not about confounding**: a causal reading still
+#    requires conditional ignorability, overlap, and SUTVA, none of which any test here can
+#    establish.

--- a/case_studies/sp500_equity_option_analytics/13_model_analysis.ipynb
+++ b/case_studies/sp500_equity_option_analytics/13_model_analysis.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "218f25d8",
+   "id": "47f6e3ec",
    "metadata": {
     "papermill": {
-     "duration": 0.01551,
-     "end_time": "2026-08-30T17:56:24.411010+00:00",
+     "duration": 0.016279,
+     "end_time": "2026-08-31T03:11:02.093825+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:24.395500+00:00",
+     "start_time": "2026-08-31T03:11:02.077546+00:00",
      "status": "completed"
     }
    },
@@ -68,19 +68,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "519adb98",
+   "id": "5009a2ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:24.419743Z",
-     "iopub.status.busy": "2026-08-30T17:56:24.419630Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.434827Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.434323Z"
+     "iopub.execute_input": "2026-08-31T03:11:02.120561Z",
+     "iopub.status.busy": "2026-08-31T03:11:02.119773Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.090958Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.090332Z"
     },
     "papermill": {
-     "duration": 3.01983,
-     "end_time": "2026-08-30T17:56:27.435536+00:00",
+     "duration": 9.985836,
+     "end_time": "2026-08-31T03:11:12.091605+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:24.415706+00:00",
+     "start_time": "2026-08-31T03:11:02.105769+00:00",
      "status": "completed"
     }
    },
@@ -136,19 +136,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "7eba9ace",
+   "id": "fccb56e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.442702Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.442619Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.444692Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.444451Z"
+     "iopub.execute_input": "2026-08-31T03:11:12.100991Z",
+     "iopub.status.busy": "2026-08-31T03:11:12.100552Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.104695Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.104061Z"
     },
     "papermill": {
-     "duration": 0.006052,
-     "end_time": "2026-08-30T17:56:27.444982+00:00",
+     "duration": 0.009683,
+     "end_time": "2026-08-31T03:11:12.105374+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.438930+00:00",
+     "start_time": "2026-08-31T03:11:12.095691+00:00",
      "status": "completed"
     },
     "tags": [
@@ -187,13 +187,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d1b6560",
+   "id": "948c86f4",
    "metadata": {
     "papermill": {
-     "duration": 0.003622,
-     "end_time": "2026-08-30T17:56:27.451759+00:00",
+     "duration": 0.009015,
+     "end_time": "2026-08-31T03:11:12.127619+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.448137+00:00",
+     "start_time": "2026-08-31T03:11:12.118604+00:00",
      "status": "completed"
     }
    },
@@ -215,19 +215,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d70686be",
+   "id": "2c409696",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.458831Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.458749Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.471062Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.470817Z"
+     "iopub.execute_input": "2026-08-31T03:11:12.150997Z",
+     "iopub.status.busy": "2026-08-31T03:11:12.150517Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.196285Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.186476Z"
     },
     "papermill": {
-     "duration": 0.016326,
-     "end_time": "2026-08-30T17:56:27.471380+00:00",
+     "duration": 0.063872,
+     "end_time": "2026-08-31T03:11:12.201426+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.455054+00:00",
+     "start_time": "2026-08-31T03:11:12.137554+00:00",
      "status": "completed"
     }
    },
@@ -269,13 +269,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b8291d2",
+   "id": "6f5b008a",
    "metadata": {
     "papermill": {
-     "duration": 0.003623,
-     "end_time": "2026-08-30T17:56:27.478278+00:00",
+     "duration": 0.017469,
+     "end_time": "2026-08-31T03:11:12.237685+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.474655+00:00",
+     "start_time": "2026-08-31T03:11:12.220216+00:00",
      "status": "completed"
     }
    },
@@ -316,13 +316,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58a7cc4c",
+   "id": "bec6991c",
    "metadata": {
     "papermill": {
-     "duration": 0.003049,
-     "end_time": "2026-08-30T17:56:27.484697+00:00",
+     "duration": 0.0104,
+     "end_time": "2026-08-31T03:11:12.260100+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.481648+00:00",
+     "start_time": "2026-08-31T03:11:12.249700+00:00",
      "status": "completed"
     }
    },
@@ -350,19 +350,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "f43ad0ec",
+   "id": "5fcb1240",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.492166Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.492003Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.512054Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.511758Z"
+     "iopub.execute_input": "2026-08-31T03:11:12.278295Z",
+     "iopub.status.busy": "2026-08-31T03:11:12.277982Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.394422Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.379073Z"
     },
     "papermill": {
-     "duration": 0.024939,
-     "end_time": "2026-08-30T17:56:27.512781+00:00",
+     "duration": 0.1306,
+     "end_time": "2026-08-31T03:11:12.399279+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.487842+00:00",
+     "start_time": "2026-08-31T03:11:12.268679+00:00",
      "status": "completed"
     }
    },
@@ -375,19 +375,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4db49c84",
+   "id": "e3b08046",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.521453Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.521361Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.552541Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.552225Z"
+     "iopub.execute_input": "2026-08-31T03:11:12.443246Z",
+     "iopub.status.busy": "2026-08-31T03:11:12.438784Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.514378Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.513639Z"
     },
     "papermill": {
-     "duration": 0.035509,
-     "end_time": "2026-08-30T17:56:27.552991+00:00",
+     "duration": 0.095067,
+     "end_time": "2026-08-31T03:11:12.515036+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.517482+00:00",
+     "start_time": "2026-08-31T03:11:12.419969+00:00",
      "status": "completed"
     }
    },
@@ -501,13 +501,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a6faefa",
+   "id": "0e305902",
    "metadata": {
     "papermill": {
-     "duration": 0.004123,
-     "end_time": "2026-08-30T17:56:27.560988+00:00",
+     "duration": 0.016448,
+     "end_time": "2026-08-31T03:11:12.539117+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.556865+00:00",
+     "start_time": "2026-08-31T03:11:12.522669+00:00",
      "status": "completed"
     }
    },
@@ -519,19 +519,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "34cf65f8",
+   "id": "141f7689",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.568009Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.567920Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.570086Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.569710Z"
+     "iopub.execute_input": "2026-08-31T03:11:12.583915Z",
+     "iopub.status.busy": "2026-08-31T03:11:12.583329Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.590658Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.589514Z"
     },
     "papermill": {
-     "duration": 0.006081,
-     "end_time": "2026-08-30T17:56:27.570355+00:00",
+     "duration": 0.035723,
+     "end_time": "2026-08-31T03:11:12.598284+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.564274+00:00",
+     "start_time": "2026-08-31T03:11:12.562561+00:00",
      "status": "completed"
     }
    },
@@ -562,19 +562,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a0e994f8",
+   "id": "cd3db5ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.577390Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.577312Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.582136Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.581689Z"
+     "iopub.execute_input": "2026-08-31T03:11:12.625925Z",
+     "iopub.status.busy": "2026-08-31T03:11:12.625489Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.653867Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.652106Z"
     },
     "papermill": {
-     "duration": 0.008812,
-     "end_time": "2026-08-30T17:56:27.582383+00:00",
+     "duration": 0.04787,
+     "end_time": "2026-08-31T03:11:12.657127+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.573571+00:00",
+     "start_time": "2026-08-31T03:11:12.609257+00:00",
      "status": "completed"
     }
    },
@@ -615,19 +615,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ce144acd",
+   "id": "e1359d4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.589649Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.589524Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.597046Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.596628Z"
+     "iopub.execute_input": "2026-08-31T03:11:12.673041Z",
+     "iopub.status.busy": "2026-08-31T03:11:12.672839Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.684089Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.683424Z"
     },
     "papermill": {
-     "duration": 0.011617,
-     "end_time": "2026-08-30T17:56:27.597298+00:00",
+     "duration": 0.018705,
+     "end_time": "2026-08-31T03:11:12.685466+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.585681+00:00",
+     "start_time": "2026-08-31T03:11:12.666761+00:00",
      "status": "completed"
     }
    },
@@ -652,19 +652,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "8d585e4c",
+   "id": "c500c833",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.604702Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.604630Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.723333Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.722893Z"
+     "iopub.execute_input": "2026-08-31T03:11:12.741633Z",
+     "iopub.status.busy": "2026-08-31T03:11:12.739981Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.951629Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.950979Z"
     },
     "papermill": {
-     "duration": 0.122874,
-     "end_time": "2026-08-30T17:56:27.723627+00:00",
+     "duration": 0.241103,
+     "end_time": "2026-08-31T03:11:12.952335+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.600753+00:00",
+     "start_time": "2026-08-31T03:11:12.711232+00:00",
      "status": "completed"
     }
    },
@@ -673,15 +673,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Loaded tabular_dl/tabm_m: 194,813 predictions\n",
-      "  Loaded latent_factors/pca: 177,682 predictions\n",
-      "  Loaded deep_learning/lstm_h64: 126,185 predictions\n"
+      "  Loaded tabular_dl/tabm_m: 194,813 predictions\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  Loaded latent_factors/pca: 177,682 predictions\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Loaded deep_learning/lstm_h64: 126,185 predictions\n",
       "  Loaded gbm/leaves_7_mse: 194,813 predictions\n",
       "  Loaded linear/enet_f0.08: 194,813 predictions\n",
       "\n",
@@ -721,19 +727,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "fd96996d",
+   "id": "20ad8119",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.735037Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.734855Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.752330Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.751792Z"
+     "iopub.execute_input": "2026-08-31T03:11:12.969863Z",
+     "iopub.status.busy": "2026-08-31T03:11:12.969429Z",
+     "iopub.status.idle": "2026-08-31T03:11:12.980006Z",
+     "shell.execute_reply": "2026-08-31T03:11:12.979251Z"
     },
     "papermill": {
-     "duration": 0.025439,
-     "end_time": "2026-08-30T17:56:27.753165+00:00",
+     "duration": 0.020345,
+     "end_time": "2026-08-31T03:11:12.980926+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.727726+00:00",
+     "start_time": "2026-08-31T03:11:12.960581+00:00",
      "status": "completed"
     }
    },
@@ -760,13 +766,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "baa7c4c0",
+   "id": "c8e0b504",
    "metadata": {
     "papermill": {
-     "duration": 0.003852,
-     "end_time": "2026-08-30T17:56:27.764107+00:00",
+     "duration": 0.006596,
+     "end_time": "2026-08-31T03:11:12.994551+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.760255+00:00",
+     "start_time": "2026-08-31T03:11:12.987955+00:00",
      "status": "completed"
     }
    },
@@ -777,19 +783,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "ab674c24",
+   "id": "2e9717ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.771485Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.771372Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.844184Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.843827Z"
+     "iopub.execute_input": "2026-08-31T03:11:13.003226Z",
+     "iopub.status.busy": "2026-08-31T03:11:13.003019Z",
+     "iopub.status.idle": "2026-08-31T03:11:13.250108Z",
+     "shell.execute_reply": "2026-08-31T03:11:13.244946Z"
     },
     "papermill": {
-     "duration": 0.07717,
-     "end_time": "2026-08-30T17:56:27.844598+00:00",
+     "duration": 0.258911,
+     "end_time": "2026-08-31T03:11:13.257201+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.767428+00:00",
+     "start_time": "2026-08-31T03:11:12.998290+00:00",
      "status": "completed"
     }
    },
@@ -821,13 +827,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bf135f2",
+   "id": "fa010dd1",
    "metadata": {
     "papermill": {
-     "duration": 0.003348,
-     "end_time": "2026-08-30T17:56:27.851596+00:00",
+     "duration": 0.012707,
+     "end_time": "2026-08-31T03:11:13.285282+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.848248+00:00",
+     "start_time": "2026-08-31T03:11:13.272575+00:00",
      "status": "completed"
     }
    },
@@ -848,13 +854,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e0c3dd2",
+   "id": "2bb3f4d7",
    "metadata": {
     "papermill": {
-     "duration": 0.003246,
-     "end_time": "2026-08-30T17:56:27.858205+00:00",
+     "duration": 0.013928,
+     "end_time": "2026-08-31T03:11:13.311486+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.854959+00:00",
+     "start_time": "2026-08-31T03:11:13.297558+00:00",
      "status": "completed"
     }
    },
@@ -872,19 +878,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "14dd630b",
+   "id": "31da4777",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.865554Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.865453Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.871027Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.870592Z"
+     "iopub.execute_input": "2026-08-31T03:11:13.342181Z",
+     "iopub.status.busy": "2026-08-31T03:11:13.341632Z",
+     "iopub.status.idle": "2026-08-31T03:11:13.362142Z",
+     "shell.execute_reply": "2026-08-31T03:11:13.361153Z"
     },
     "papermill": {
-     "duration": 0.009851,
-     "end_time": "2026-08-30T17:56:27.871423+00:00",
+     "duration": 0.040387,
+     "end_time": "2026-08-31T03:11:13.364196+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.861572+00:00",
+     "start_time": "2026-08-31T03:11:13.323809+00:00",
      "status": "completed"
     }
    },
@@ -958,19 +964,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "b36e0cae",
+   "id": "6979d950",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.879679Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.879538Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.886475Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.885979Z"
+     "iopub.execute_input": "2026-08-31T03:11:13.385280Z",
+     "iopub.status.busy": "2026-08-31T03:11:13.384889Z",
+     "iopub.status.idle": "2026-08-31T03:11:13.404831Z",
+     "shell.execute_reply": "2026-08-31T03:11:13.403295Z"
     },
     "papermill": {
-     "duration": 0.011345,
-     "end_time": "2026-08-30T17:56:27.886887+00:00",
+     "duration": 0.034555,
+     "end_time": "2026-08-31T03:11:13.407684+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.875542+00:00",
+     "start_time": "2026-08-31T03:11:13.373129+00:00",
      "status": "completed"
     }
    },
@@ -983,7 +989,7 @@
       "Primary label (fwd_ret_5d):\n",
       "  Predictive families: ['deep_learning', 'gbm', 'linear', 'tabular_dl']\n",
       "  Structural families: ['latent_factors']\n",
-      "  Causal families: none\n",
+      "  Causal families: ['causal_dml']\n",
       "\n",
       "All labels trained: ['fwd_dir_10d', 'fwd_dir_5d', 'fwd_ret_10d', 'fwd_ret_5d', 'fwd_ret_risk_adj_5d']\n"
      ]
@@ -1034,13 +1040,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2a1db5a",
+   "id": "d22f1d28",
    "metadata": {
     "papermill": {
-     "duration": 0.003515,
-     "end_time": "2026-08-30T17:56:27.895665+00:00",
+     "duration": 0.009844,
+     "end_time": "2026-08-31T03:11:13.427507+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.892150+00:00",
+     "start_time": "2026-08-31T03:11:13.417663+00:00",
      "status": "completed"
     }
    },
@@ -1060,13 +1066,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba064b1a",
+   "id": "be5f39d8",
    "metadata": {
     "papermill": {
-     "duration": 0.00332,
-     "end_time": "2026-08-30T17:56:27.902351+00:00",
+     "duration": 0.00884,
+     "end_time": "2026-08-31T03:11:13.447675+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.899031+00:00",
+     "start_time": "2026-08-31T03:11:13.438835+00:00",
      "status": "completed"
     }
    },
@@ -1080,13 +1086,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa278dee",
+   "id": "8adc0a14",
    "metadata": {
     "papermill": {
-     "duration": 0.003314,
-     "end_time": "2026-08-30T17:56:27.909058+00:00",
+     "duration": 0.00723,
+     "end_time": "2026-08-31T03:11:13.463187+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.905744+00:00",
+     "start_time": "2026-08-31T03:11:13.455957+00:00",
      "status": "completed"
     }
    },
@@ -1104,19 +1110,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "63b8cb49",
+   "id": "551e6ff9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.916668Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.916568Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.920055Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.919783Z"
+     "iopub.execute_input": "2026-08-31T03:11:13.502153Z",
+     "iopub.status.busy": "2026-08-31T03:11:13.501672Z",
+     "iopub.status.idle": "2026-08-31T03:11:13.521897Z",
+     "shell.execute_reply": "2026-08-31T03:11:13.520290Z"
     },
     "papermill": {
-     "duration": 0.007816,
-     "end_time": "2026-08-30T17:56:27.920426+00:00",
+     "duration": 0.038898,
+     "end_time": "2026-08-31T03:11:13.523382+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.912610+00:00",
+     "start_time": "2026-08-31T03:11:13.484484+00:00",
      "status": "completed"
     }
    },
@@ -1152,19 +1158,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "e2dd3f9d",
+   "id": "0df94cef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.927790Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.927703Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.930133Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.929610Z"
+     "iopub.execute_input": "2026-08-31T03:11:13.553595Z",
+     "iopub.status.busy": "2026-08-31T03:11:13.553102Z",
+     "iopub.status.idle": "2026-08-31T03:11:13.575400Z",
+     "shell.execute_reply": "2026-08-31T03:11:13.570253Z"
     },
     "papermill": {
-     "duration": 0.006701,
-     "end_time": "2026-08-30T17:56:27.930602+00:00",
+     "duration": 0.040512,
+     "end_time": "2026-08-31T03:11:13.577860+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.923901+00:00",
+     "start_time": "2026-08-31T03:11:13.537348+00:00",
      "status": "completed"
     }
    },
@@ -1174,7 +1180,13 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Full ranking (289 model × checkpoint variants):\n",
+      "Full ranking (289 model × checkpoint variants):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "shape: (15, 5)\n",
       "┌────────────────┬─────────────┬──────────────────┬───────────────┬───────────┐\n",
       "│ family         ┆ config_name ┆ checkpoint_value ┆ ic_mean_daily ┆ ic_se_hac │\n",
@@ -1208,13 +1220,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e01972f6",
+   "id": "7db91e1b",
    "metadata": {
     "papermill": {
-     "duration": 0.003362,
-     "end_time": "2026-08-30T17:56:27.937861+00:00",
+     "duration": 0.011166,
+     "end_time": "2026-08-31T03:11:13.600590+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.934499+00:00",
+     "start_time": "2026-08-31T03:11:13.589424+00:00",
      "status": "completed"
     }
    },
@@ -1234,19 +1246,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "64a1a470",
+   "id": "06daa478",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.945657Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.945533Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.952558Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.952107Z"
+     "iopub.execute_input": "2026-08-31T03:11:13.624728Z",
+     "iopub.status.busy": "2026-08-31T03:11:13.623458Z",
+     "iopub.status.idle": "2026-08-31T03:11:13.669664Z",
+     "shell.execute_reply": "2026-08-31T03:11:13.665912Z"
     },
     "papermill": {
-     "duration": 0.011437,
-     "end_time": "2026-08-30T17:56:27.952796+00:00",
+     "duration": 0.060613,
+     "end_time": "2026-08-31T03:11:13.671771+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.941359+00:00",
+     "start_time": "2026-08-31T03:11:13.611158+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1327,13 +1339,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24cf7c53",
+   "id": "fdf154bc",
    "metadata": {
     "papermill": {
-     "duration": 0.004334,
-     "end_time": "2026-08-30T17:56:27.961807+00:00",
+     "duration": 0.01261,
+     "end_time": "2026-08-31T03:11:13.697600+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.957473+00:00",
+     "start_time": "2026-08-31T03:11:13.684990+00:00",
      "status": "completed"
     }
    },
@@ -1352,13 +1364,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6dc7bf12",
+   "id": "66914fd3",
    "metadata": {
     "papermill": {
-     "duration": 0.003434,
-     "end_time": "2026-08-30T17:56:27.968787+00:00",
+     "duration": 0.014105,
+     "end_time": "2026-08-31T03:11:13.723637+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.965353+00:00",
+     "start_time": "2026-08-31T03:11:13.709532+00:00",
      "status": "completed"
     }
    },
@@ -1376,19 +1388,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "cc117883",
+   "id": "d082dc79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.976965Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.976813Z",
-     "iopub.status.idle": "2026-08-30T17:56:27.980971Z",
-     "shell.execute_reply": "2026-08-30T17:56:27.980504Z"
+     "iopub.execute_input": "2026-08-31T03:11:13.755525Z",
+     "iopub.status.busy": "2026-08-31T03:11:13.754987Z",
+     "iopub.status.idle": "2026-08-31T03:11:13.765348Z",
+     "shell.execute_reply": "2026-08-31T03:11:13.764327Z"
     },
     "papermill": {
-     "duration": 0.009083,
-     "end_time": "2026-08-30T17:56:27.981465+00:00",
+     "duration": 0.028678,
+     "end_time": "2026-08-31T03:11:13.768552+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.972382+00:00",
+     "start_time": "2026-08-31T03:11:13.739874+00:00",
      "status": "completed"
     }
    },
@@ -1433,13 +1445,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f4a24f4",
+   "id": "5598dd54",
    "metadata": {
     "papermill": {
-     "duration": 0.003537,
-     "end_time": "2026-08-30T17:56:27.988684+00:00",
+     "duration": 0.009229,
+     "end_time": "2026-08-31T03:11:13.793987+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.985147+00:00",
+     "start_time": "2026-08-31T03:11:13.784758+00:00",
      "status": "completed"
     }
    },
@@ -1450,19 +1462,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "1d79b0ce",
+   "id": "ba888056",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:27.996476Z",
-     "iopub.status.busy": "2026-08-30T17:56:27.996349Z",
-     "iopub.status.idle": "2026-08-30T17:56:28.079599Z",
-     "shell.execute_reply": "2026-08-30T17:56:28.079068Z"
+     "iopub.execute_input": "2026-08-31T03:11:13.814750Z",
+     "iopub.status.busy": "2026-08-31T03:11:13.814550Z",
+     "iopub.status.idle": "2026-08-31T03:11:13.995382Z",
+     "shell.execute_reply": "2026-08-31T03:11:13.993534Z"
     },
     "papermill": {
-     "duration": 0.08762,
-     "end_time": "2026-08-30T17:56:28.079882+00:00",
+     "duration": 0.192515,
+     "end_time": "2026-08-31T03:11:13.996234+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:27.992262+00:00",
+     "start_time": "2026-08-31T03:11:13.803719+00:00",
      "status": "completed"
     }
    },
@@ -1508,19 +1520,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "0a46d917",
+   "id": "a76ffea1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:28.088155Z",
-     "iopub.status.busy": "2026-08-30T17:56:28.088070Z",
-     "iopub.status.idle": "2026-08-30T17:56:28.091219Z",
-     "shell.execute_reply": "2026-08-30T17:56:28.090838Z"
+     "iopub.execute_input": "2026-08-31T03:11:14.017533Z",
+     "iopub.status.busy": "2026-08-31T03:11:14.017038Z",
+     "iopub.status.idle": "2026-08-31T03:11:14.025990Z",
+     "shell.execute_reply": "2026-08-31T03:11:14.025460Z"
     },
     "papermill": {
-     "duration": 0.007734,
-     "end_time": "2026-08-30T17:56:28.091576+00:00",
+     "duration": 0.02355,
+     "end_time": "2026-08-31T03:11:14.028518+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:28.083842+00:00",
+     "start_time": "2026-08-31T03:11:14.004968+00:00",
      "status": "completed"
     }
    },
@@ -1573,13 +1585,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66cc84e7",
+   "id": "10002561",
    "metadata": {
     "papermill": {
-     "duration": 0.003674,
-     "end_time": "2026-08-30T17:56:28.099140+00:00",
+     "duration": 0.007409,
+     "end_time": "2026-08-31T03:11:14.045307+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:28.095466+00:00",
+     "start_time": "2026-08-31T03:11:14.037898+00:00",
      "status": "completed"
     }
    },
@@ -1597,13 +1609,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eee807c1",
+   "id": "00f04972",
    "metadata": {
     "papermill": {
-     "duration": 0.003814,
-     "end_time": "2026-08-30T17:56:28.106748+00:00",
+     "duration": 0.009678,
+     "end_time": "2026-08-31T03:11:14.064506+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:28.102934+00:00",
+     "start_time": "2026-08-31T03:11:14.054828+00:00",
      "status": "completed"
     }
    },
@@ -1619,13 +1631,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3a2383d",
+   "id": "e507146d",
    "metadata": {
     "papermill": {
-     "duration": 0.003604,
-     "end_time": "2026-08-30T17:56:28.114025+00:00",
+     "duration": 0.006001,
+     "end_time": "2026-08-31T03:11:14.077558+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:28.110421+00:00",
+     "start_time": "2026-08-31T03:11:14.071557+00:00",
      "status": "completed"
     }
    },
@@ -1636,19 +1648,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "267d69a8",
+   "id": "c410946f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:28.121963Z",
-     "iopub.status.busy": "2026-08-30T17:56:28.121869Z",
-     "iopub.status.idle": "2026-08-30T17:56:28.188471Z",
-     "shell.execute_reply": "2026-08-30T17:56:28.188072Z"
+     "iopub.execute_input": "2026-08-31T03:11:14.091068Z",
+     "iopub.status.busy": "2026-08-31T03:11:14.090896Z",
+     "iopub.status.idle": "2026-08-31T03:11:14.380592Z",
+     "shell.execute_reply": "2026-08-31T03:11:14.377689Z"
     },
     "papermill": {
-     "duration": 0.071102,
-     "end_time": "2026-08-30T17:56:28.188829+00:00",
+     "duration": 0.299761,
+     "end_time": "2026-08-31T03:11:14.382471+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:28.117727+00:00",
+     "start_time": "2026-08-31T03:11:14.082710+00:00",
      "status": "completed"
     }
    },
@@ -1678,13 +1690,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b9c04d8",
+   "id": "1807abfc",
    "metadata": {
     "papermill": {
-     "duration": 0.003874,
-     "end_time": "2026-08-30T17:56:28.196863+00:00",
+     "duration": 0.009155,
+     "end_time": "2026-08-31T03:11:14.409997+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:28.192989+00:00",
+     "start_time": "2026-08-31T03:11:14.400842+00:00",
      "status": "completed"
     }
    },
@@ -1704,13 +1716,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1afd9e9",
+   "id": "87e23ef7",
    "metadata": {
     "papermill": {
-     "duration": 0.003763,
-     "end_time": "2026-08-30T17:56:28.204567+00:00",
+     "duration": 0.008962,
+     "end_time": "2026-08-31T03:11:14.429192+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:28.200804+00:00",
+     "start_time": "2026-08-31T03:11:14.420230+00:00",
      "status": "completed"
     }
    },
@@ -1732,19 +1744,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "f37922f7",
+   "id": "0657c592",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:28.213029Z",
-     "iopub.status.busy": "2026-08-30T17:56:28.212928Z",
-     "iopub.status.idle": "2026-08-30T17:56:30.541838Z",
-     "shell.execute_reply": "2026-08-30T17:56:30.541228Z"
+     "iopub.execute_input": "2026-08-31T03:11:14.449082Z",
+     "iopub.status.busy": "2026-08-31T03:11:14.448618Z",
+     "iopub.status.idle": "2026-08-31T03:11:19.482627Z",
+     "shell.execute_reply": "2026-08-31T03:11:19.481682Z"
     },
     "papermill": {
-     "duration": 2.334338,
-     "end_time": "2026-08-30T17:56:30.542809+00:00",
+     "duration": 5.045322,
+     "end_time": "2026-08-31T03:11:19.483418+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:28.208471+00:00",
+     "start_time": "2026-08-31T03:11:14.438096+00:00",
      "status": "completed"
     }
    },
@@ -1767,13 +1779,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f51dbe41",
+   "id": "4cc68d0d",
    "metadata": {
     "papermill": {
-     "duration": 0.004365,
-     "end_time": "2026-08-30T17:56:30.551829+00:00",
+     "duration": 0.006462,
+     "end_time": "2026-08-31T03:11:19.498275+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:30.547464+00:00",
+     "start_time": "2026-08-31T03:11:19.491813+00:00",
      "status": "completed"
     }
    },
@@ -1784,19 +1796,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "6fe638af",
+   "id": "efe576cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:30.561291Z",
-     "iopub.status.busy": "2026-08-30T17:56:30.561039Z",
-     "iopub.status.idle": "2026-08-30T17:56:30.666475Z",
-     "shell.execute_reply": "2026-08-30T17:56:30.666074Z"
+     "iopub.execute_input": "2026-08-31T03:11:19.522063Z",
+     "iopub.status.busy": "2026-08-31T03:11:19.521553Z",
+     "iopub.status.idle": "2026-08-31T03:11:19.853381Z",
+     "shell.execute_reply": "2026-08-31T03:11:19.848709Z"
     },
     "papermill": {
-     "duration": 0.111218,
-     "end_time": "2026-08-30T17:56:30.667052+00:00",
+     "duration": 0.349012,
+     "end_time": "2026-08-31T03:11:19.854490+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:30.555834+00:00",
+     "start_time": "2026-08-31T03:11:19.505478+00:00",
      "status": "completed"
     }
    },
@@ -1843,13 +1855,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5034b099",
+   "id": "c10b2c15",
    "metadata": {
     "papermill": {
-     "duration": 0.004519,
-     "end_time": "2026-08-30T17:56:30.677357+00:00",
+     "duration": 0.00751,
+     "end_time": "2026-08-31T03:11:19.870555+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:30.672838+00:00",
+     "start_time": "2026-08-31T03:11:19.863045+00:00",
      "status": "completed"
     }
    },
@@ -1868,19 +1880,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "154cca1a",
+   "id": "c5658902",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:30.687238Z",
-     "iopub.status.busy": "2026-08-30T17:56:30.687118Z",
-     "iopub.status.idle": "2026-08-30T17:56:31.581057Z",
-     "shell.execute_reply": "2026-08-30T17:56:31.580666Z"
+     "iopub.execute_input": "2026-08-31T03:11:19.917739Z",
+     "iopub.status.busy": "2026-08-31T03:11:19.917206Z",
+     "iopub.status.idle": "2026-08-31T03:11:22.644578Z",
+     "shell.execute_reply": "2026-08-31T03:11:22.643763Z"
     },
     "papermill": {
-     "duration": 0.899612,
-     "end_time": "2026-08-30T17:56:31.581476+00:00",
+     "duration": 2.754073,
+     "end_time": "2026-08-31T03:11:22.645790+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:30.681864+00:00",
+     "start_time": "2026-08-31T03:11:19.891717+00:00",
      "status": "completed"
     }
    },
@@ -1910,13 +1922,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c74a40f",
+   "id": "7d74a9b8",
    "metadata": {
     "papermill": {
-     "duration": 0.004349,
-     "end_time": "2026-08-30T17:56:31.590398+00:00",
+     "duration": 0.007696,
+     "end_time": "2026-08-31T03:11:22.661777+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:31.586049+00:00",
+     "start_time": "2026-08-31T03:11:22.654081+00:00",
      "status": "completed"
     }
    },
@@ -1927,19 +1939,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "d2e48ec9",
+   "id": "701fcfea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:31.599671Z",
-     "iopub.status.busy": "2026-08-30T17:56:31.599563Z",
-     "iopub.status.idle": "2026-08-30T17:56:31.681193Z",
-     "shell.execute_reply": "2026-08-30T17:56:31.680715Z"
+     "iopub.execute_input": "2026-08-31T03:11:22.675972Z",
+     "iopub.status.busy": "2026-08-31T03:11:22.675815Z",
+     "iopub.status.idle": "2026-08-31T03:11:22.831536Z",
+     "shell.execute_reply": "2026-08-31T03:11:22.827338Z"
     },
     "papermill": {
-     "duration": 0.086759,
-     "end_time": "2026-08-30T17:56:31.681500+00:00",
+     "duration": 0.168105,
+     "end_time": "2026-08-31T03:11:22.836680+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:31.594741+00:00",
+     "start_time": "2026-08-31T03:11:22.668575+00:00",
      "status": "completed"
     }
    },
@@ -1979,13 +1991,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9567224",
+   "id": "ade2934b",
    "metadata": {
     "papermill": {
-     "duration": 0.004586,
-     "end_time": "2026-08-30T17:56:31.705920+00:00",
+     "duration": 0.014559,
+     "end_time": "2026-08-31T03:11:23.053907+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:31.701334+00:00",
+     "start_time": "2026-08-31T03:11:23.039348+00:00",
      "status": "completed"
     }
    },
@@ -2007,13 +2019,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a069e01e",
+   "id": "de257f85",
    "metadata": {
     "papermill": {
-     "duration": 0.004242,
-     "end_time": "2026-08-30T17:56:31.714681+00:00",
+     "duration": 0.009438,
+     "end_time": "2026-08-31T03:11:23.075407+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:31.710439+00:00",
+     "start_time": "2026-08-31T03:11:23.065969+00:00",
      "status": "completed"
     }
    },
@@ -2028,19 +2040,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "63bd2999",
+   "id": "383f2dac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:31.724318Z",
-     "iopub.status.busy": "2026-08-30T17:56:31.724202Z",
-     "iopub.status.idle": "2026-08-30T17:56:31.728975Z",
-     "shell.execute_reply": "2026-08-30T17:56:31.728517Z"
+     "iopub.execute_input": "2026-08-31T03:11:23.091857Z",
+     "iopub.status.busy": "2026-08-31T03:11:23.091436Z",
+     "iopub.status.idle": "2026-08-31T03:11:23.119057Z",
+     "shell.execute_reply": "2026-08-31T03:11:23.118106Z"
     },
     "papermill": {
-     "duration": 0.010257,
-     "end_time": "2026-08-30T17:56:31.729396+00:00",
+     "duration": 0.038065,
+     "end_time": "2026-08-31T03:11:23.120119+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:31.719139+00:00",
+     "start_time": "2026-08-31T03:11:23.082054+00:00",
      "status": "completed"
     }
    },
@@ -2073,13 +2085,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4f42777",
+   "id": "0009bb6f",
    "metadata": {
     "papermill": {
-     "duration": 0.004302,
-     "end_time": "2026-08-30T17:56:31.738217+00:00",
+     "duration": 0.006137,
+     "end_time": "2026-08-31T03:11:23.145667+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:31.733915+00:00",
+     "start_time": "2026-08-31T03:11:23.139530+00:00",
      "status": "completed"
     }
    },
@@ -2090,19 +2102,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "6968bc46",
+   "id": "deaa99e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:31.747751Z",
-     "iopub.status.busy": "2026-08-30T17:56:31.747658Z",
-     "iopub.status.idle": "2026-08-30T17:56:32.072263Z",
-     "shell.execute_reply": "2026-08-30T17:56:32.071751Z"
+     "iopub.execute_input": "2026-08-31T03:11:23.177783Z",
+     "iopub.status.busy": "2026-08-31T03:11:23.177472Z",
+     "iopub.status.idle": "2026-08-31T03:11:24.267382Z",
+     "shell.execute_reply": "2026-08-31T03:11:24.265640Z"
     },
     "papermill": {
-     "duration": 0.33049,
-     "end_time": "2026-08-30T17:56:32.073059+00:00",
+     "duration": 1.127454,
+     "end_time": "2026-08-31T03:11:24.283643+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:31.742569+00:00",
+     "start_time": "2026-08-31T03:11:23.156189+00:00",
      "status": "completed"
     }
    },
@@ -2133,13 +2145,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f853197",
+   "id": "c6756f5a",
    "metadata": {
     "papermill": {
-     "duration": 0.005267,
-     "end_time": "2026-08-30T17:56:32.084390+00:00",
+     "duration": 0.010224,
+     "end_time": "2026-08-31T03:11:24.314926+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:32.079123+00:00",
+     "start_time": "2026-08-31T03:11:24.304702+00:00",
      "status": "completed"
     }
    },
@@ -2170,13 +2182,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f23f446",
+   "id": "ffd332a4",
    "metadata": {
     "papermill": {
-     "duration": 0.005208,
-     "end_time": "2026-08-30T17:56:32.094808+00:00",
+     "duration": 0.014106,
+     "end_time": "2026-08-31T03:11:24.342256+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:32.089600+00:00",
+     "start_time": "2026-08-31T03:11:24.328150+00:00",
      "status": "completed"
     }
    },
@@ -2194,19 +2206,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "0ba54c8d",
+   "id": "4bb37094",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:32.106325Z",
-     "iopub.status.busy": "2026-08-30T17:56:32.106204Z",
-     "iopub.status.idle": "2026-08-30T17:56:32.185075Z",
-     "shell.execute_reply": "2026-08-30T17:56:32.184630Z"
+     "iopub.execute_input": "2026-08-31T03:11:24.380835Z",
+     "iopub.status.busy": "2026-08-31T03:11:24.380452Z",
+     "iopub.status.idle": "2026-08-31T03:11:24.564821Z",
+     "shell.execute_reply": "2026-08-31T03:11:24.563685Z"
     },
     "papermill": {
-     "duration": 0.085327,
-     "end_time": "2026-08-30T17:56:32.185474+00:00",
+     "duration": 0.210722,
+     "end_time": "2026-08-31T03:11:24.566227+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:32.100147+00:00",
+     "start_time": "2026-08-31T03:11:24.355505+00:00",
      "status": "completed"
     }
    },
@@ -2243,13 +2255,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "132809ff",
+   "id": "3e37988e",
    "metadata": {
     "papermill": {
-     "duration": 0.005373,
-     "end_time": "2026-08-30T17:56:32.196564+00:00",
+     "duration": 0.014494,
+     "end_time": "2026-08-31T03:11:24.592289+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:32.191191+00:00",
+     "start_time": "2026-08-31T03:11:24.577795+00:00",
      "status": "completed"
     }
    },
@@ -2261,19 +2273,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "575840e4",
+   "id": "0a38d427",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:32.207701Z",
-     "iopub.status.busy": "2026-08-30T17:56:32.207615Z",
-     "iopub.status.idle": "2026-08-30T17:56:33.355900Z",
-     "shell.execute_reply": "2026-08-30T17:56:33.355426Z"
+     "iopub.execute_input": "2026-08-31T03:11:24.613820Z",
+     "iopub.status.busy": "2026-08-31T03:11:24.613522Z",
+     "iopub.status.idle": "2026-08-31T03:11:28.229431Z",
+     "shell.execute_reply": "2026-08-31T03:11:28.228374Z"
     },
     "papermill": {
-     "duration": 1.154961,
-     "end_time": "2026-08-30T17:56:33.356847+00:00",
+     "duration": 3.628819,
+     "end_time": "2026-08-31T03:11:28.230485+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:32.201886+00:00",
+     "start_time": "2026-08-31T03:11:24.601666+00:00",
      "status": "completed"
     }
    },
@@ -2301,13 +2313,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3fce9e39",
+   "id": "17877390",
    "metadata": {
     "papermill": {
-     "duration": 0.005264,
-     "end_time": "2026-08-30T17:56:33.369659+00:00",
+     "duration": 0.020587,
+     "end_time": "2026-08-31T03:11:28.280058+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.364395+00:00",
+     "start_time": "2026-08-31T03:11:28.259471+00:00",
      "status": "completed"
     }
    },
@@ -2319,19 +2331,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "06a183f2",
+   "id": "2ada4b0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:33.381256Z",
-     "iopub.status.busy": "2026-08-30T17:56:33.381153Z",
-     "iopub.status.idle": "2026-08-30T17:56:33.386289Z",
-     "shell.execute_reply": "2026-08-30T17:56:33.385932Z"
+     "iopub.execute_input": "2026-08-31T03:11:28.337510Z",
+     "iopub.status.busy": "2026-08-31T03:11:28.337094Z",
+     "iopub.status.idle": "2026-08-31T03:11:28.356111Z",
+     "shell.execute_reply": "2026-08-31T03:11:28.355336Z"
     },
     "papermill": {
-     "duration": 0.011548,
-     "end_time": "2026-08-30T17:56:33.386672+00:00",
+     "duration": 0.056324,
+     "end_time": "2026-08-31T03:11:28.360295+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.375124+00:00",
+     "start_time": "2026-08-31T03:11:28.303971+00:00",
      "status": "completed"
     }
    },
@@ -2375,13 +2387,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df3607d8",
+   "id": "4728eaa6",
    "metadata": {
     "papermill": {
-     "duration": 0.005437,
-     "end_time": "2026-08-30T17:56:33.397940+00:00",
+     "duration": 0.007741,
+     "end_time": "2026-08-31T03:11:28.383211+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.392503+00:00",
+     "start_time": "2026-08-31T03:11:28.375470+00:00",
      "status": "completed"
     }
    },
@@ -2392,19 +2404,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "4e806c69",
+   "id": "aab5d4ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:33.410206Z",
-     "iopub.status.busy": "2026-08-30T17:56:33.410088Z",
-     "iopub.status.idle": "2026-08-30T17:56:33.524560Z",
-     "shell.execute_reply": "2026-08-30T17:56:33.524077Z"
+     "iopub.execute_input": "2026-08-31T03:11:28.424140Z",
+     "iopub.status.busy": "2026-08-31T03:11:28.422231Z",
+     "iopub.status.idle": "2026-08-31T03:11:28.748675Z",
+     "shell.execute_reply": "2026-08-31T03:11:28.747775Z"
     },
     "papermill": {
-     "duration": 0.121426,
-     "end_time": "2026-08-30T17:56:33.524891+00:00",
+     "duration": 0.357911,
+     "end_time": "2026-08-31T03:11:28.749112+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.403465+00:00",
+     "start_time": "2026-08-31T03:11:28.391201+00:00",
      "status": "completed"
     }
    },
@@ -2479,13 +2491,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4f9f5b9",
+   "id": "b08d00aa",
    "metadata": {
     "papermill": {
-     "duration": 0.00586,
-     "end_time": "2026-08-30T17:56:33.537413+00:00",
+     "duration": 0.015494,
+     "end_time": "2026-08-31T03:11:28.774673+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.531553+00:00",
+     "start_time": "2026-08-31T03:11:28.759179+00:00",
      "status": "completed"
     }
    },
@@ -2529,13 +2541,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88e6e175",
+   "id": "cdc043d0",
    "metadata": {
     "papermill": {
-     "duration": 0.005938,
-     "end_time": "2026-08-30T17:56:33.549184+00:00",
+     "duration": 0.013913,
+     "end_time": "2026-08-31T03:11:28.802908+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.543246+00:00",
+     "start_time": "2026-08-31T03:11:28.788995+00:00",
      "status": "completed"
     }
    },
@@ -2548,13 +2560,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f229d66",
+   "id": "7762d713",
    "metadata": {
     "papermill": {
-     "duration": 0.005447,
-     "end_time": "2026-08-30T17:56:33.560207+00:00",
+     "duration": 0.008328,
+     "end_time": "2026-08-31T03:11:28.819902+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.554760+00:00",
+     "start_time": "2026-08-31T03:11:28.811574+00:00",
      "status": "completed"
     }
    },
@@ -2573,19 +2585,19 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "8be243cb",
+   "id": "06e14017",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:33.573018Z",
-     "iopub.status.busy": "2026-08-30T17:56:33.572841Z",
-     "iopub.status.idle": "2026-08-30T17:56:33.591777Z",
-     "shell.execute_reply": "2026-08-30T17:56:33.591430Z"
+     "iopub.execute_input": "2026-08-31T03:11:28.835539Z",
+     "iopub.status.busy": "2026-08-31T03:11:28.835274Z",
+     "iopub.status.idle": "2026-08-31T03:11:28.882725Z",
+     "shell.execute_reply": "2026-08-31T03:11:28.881534Z"
     },
     "papermill": {
-     "duration": 0.026521,
-     "end_time": "2026-08-30T17:56:33.592532+00:00",
+     "duration": 0.057488,
+     "end_time": "2026-08-31T03:11:28.884698+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.566011+00:00",
+     "start_time": "2026-08-31T03:11:28.827210+00:00",
      "status": "completed"
     }
    },
@@ -2600,7 +2612,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (19, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>ic_mean_daily</th><th>ic_ci_lo</th><th>ic_ci_hi</th><th>ic_t_hac</th></tr><tr><td>str</td><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;lstm_h64&quot;</td><td>0.006587</td><td>-0.014277</td><td>0.027451</td><td>0.620313</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_mse&quot;</td><td>0.004976</td><td>-0.020052</td><td>0.030003</td><td>0.390624</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.08&quot;</td><td>-0.002206</td><td>-0.037908</td><td>0.033497</td><td>-0.121375</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;latent_factors&quot;</td><td>&quot;pca&quot;</td><td>0.009925</td><td>-0.019295</td><td>0.039145</td><td>0.667359</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>0.015481</td><td>-0.002188</td><td>0.03315</td><td>1.721463</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;lstm_h64&quot;</td><td>0.003284</td><td>-0.017863</td><td>0.02443</td><td>0.305098</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>0.01058</td><td>-0.007987</td><td>0.029146</td><td>1.119594</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;ridge_a1000000.0&quot;</td><td>0.023502</td><td>-0.006934</td><td>0.053938</td><td>1.51714</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>0.019869</td><td>0.003637</td><td>0.036102</td><td>2.404997</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;latent_factors&quot;</td><td>&quot;sae&quot;</td><td>0.02858</td><td>0.009126</td><td>0.048033</td><td>2.88651</td></tr></tbody></table></div>"
+       "<small>shape: (19, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>family</th><th>config_name</th><th>ic_mean_daily</th><th>ic_ci_lo</th><th>ic_ci_hi</th><th>ic_t_hac</th></tr><tr><td>str</td><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;enet_f0.08&quot;</td><td>-0.002206</td><td>-0.037908</td><td>0.033497</td><td>-0.121375</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;lstm_h64&quot;</td><td>0.006587</td><td>-0.014277</td><td>0.027451</td><td>0.620313</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>0.015481</td><td>-0.002188</td><td>0.03315</td><td>1.721463</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;latent_factors&quot;</td><td>&quot;pca&quot;</td><td>0.009925</td><td>-0.019295</td><td>0.039145</td><td>0.667359</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_mse&quot;</td><td>0.004976</td><td>-0.020052</td><td>0.030003</td><td>0.390624</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;latent_factors&quot;</td><td>&quot;sae&quot;</td><td>0.02858</td><td>0.009126</td><td>0.048033</td><td>2.88651</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>0.01058</td><td>-0.007987</td><td>0.029146</td><td>1.119594</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;linear&quot;</td><td>&quot;ridge_a1000000.0&quot;</td><td>0.023502</td><td>-0.006934</td><td>0.053938</td><td>1.51714</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;deep_learning&quot;</td><td>&quot;lstm_h64&quot;</td><td>0.003284</td><td>-0.017863</td><td>0.02443</td><td>0.305098</td></tr><tr><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>0.019869</td><td>0.003637</td><td>0.036102</td><td>2.404997</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (19, 7)\n",
@@ -2609,23 +2621,23 @@
        "│ ---           ┆ ---           ┆ ---           ┆ ---           ┆ ---       ┆ ---      ┆ ---       │\n",
        "│ str           ┆ str           ┆ str           ┆ f64           ┆ f64       ┆ f64      ┆ f64       │\n",
        "╞═══════════════╪═══════════════╪═══════════════╪═══════════════╪═══════════╪══════════╪═══════════╡\n",
-       "│ fwd_ret_5d    ┆ deep_learning ┆ lstm_h64      ┆ 0.006587      ┆ -0.014277 ┆ 0.027451 ┆ 0.620313  │\n",
-       "│ fwd_ret_5d    ┆ gbm           ┆ leaves_7_mse  ┆ 0.004976      ┆ -0.020052 ┆ 0.030003 ┆ 0.390624  │\n",
        "│ fwd_ret_5d    ┆ linear        ┆ enet_f0.08    ┆ -0.002206     ┆ -0.037908 ┆ 0.033497 ┆ -0.121375 │\n",
+       "│ fwd_ret_5d    ┆ deep_learning ┆ lstm_h64      ┆ 0.006587      ┆ -0.014277 ┆ 0.027451 ┆ 0.620313  │\n",
+       "│ fwd_ret_5d    ┆ tabular_dl    ┆ tabm_m        ┆ 0.015481      ┆ -0.002188 ┆ 0.03315  ┆ 1.721463  │\n",
        "│ fwd_ret_5d    ┆ latent_factor ┆ pca           ┆ 0.009925      ┆ -0.019295 ┆ 0.039145 ┆ 0.667359  │\n",
        "│               ┆ s             ┆               ┆               ┆           ┆          ┆           │\n",
-       "│ fwd_ret_5d    ┆ tabular_dl    ┆ tabm_m        ┆ 0.015481      ┆ -0.002188 ┆ 0.03315  ┆ 1.721463  │\n",
+       "│ fwd_ret_5d    ┆ gbm           ┆ leaves_7_mse  ┆ 0.004976      ┆ -0.020052 ┆ 0.030003 ┆ 0.390624  │\n",
        "│ …             ┆ …             ┆ …             ┆ …             ┆ …         ┆ …        ┆ …         │\n",
-       "│ fwd_ret_risk_ ┆ deep_learning ┆ lstm_h64      ┆ 0.003284      ┆ -0.017863 ┆ 0.02443  ┆ 0.305098  │\n",
-       "│ adj_5d        ┆               ┆               ┆               ┆           ┆          ┆           │\n",
+       "│ fwd_ret_risk_ ┆ latent_factor ┆ sae           ┆ 0.02858       ┆ 0.009126  ┆ 0.048033 ┆ 2.88651   │\n",
+       "│ adj_5d        ┆ s             ┆               ┆               ┆           ┆          ┆           │\n",
        "│ fwd_ret_risk_ ┆ gbm           ┆ leaves_7_hube ┆ 0.01058       ┆ -0.007987 ┆ 0.029146 ┆ 1.119594  │\n",
        "│ adj_5d        ┆               ┆ r             ┆               ┆           ┆          ┆           │\n",
        "│ fwd_ret_risk_ ┆ linear        ┆ ridge_a100000 ┆ 0.023502      ┆ -0.006934 ┆ 0.053938 ┆ 1.51714   │\n",
        "│ adj_5d        ┆               ┆ 0.0           ┆               ┆           ┆          ┆           │\n",
+       "│ fwd_ret_risk_ ┆ deep_learning ┆ lstm_h64      ┆ 0.003284      ┆ -0.017863 ┆ 0.02443  ┆ 0.305098  │\n",
+       "│ adj_5d        ┆               ┆               ┆               ┆           ┆          ┆           │\n",
        "│ fwd_ret_risk_ ┆ tabular_dl    ┆ tabm_s        ┆ 0.019869      ┆ 0.003637  ┆ 0.036102 ┆ 2.404997  │\n",
        "│ adj_5d        ┆               ┆               ┆               ┆           ┆          ┆           │\n",
-       "│ fwd_ret_risk_ ┆ latent_factor ┆ sae           ┆ 0.02858       ┆ 0.009126  ┆ 0.048033 ┆ 2.88651   │\n",
-       "│ adj_5d        ┆ s             ┆               ┆               ┆           ┆          ┆           │\n",
        "└───────────────┴───────────────┴───────────────┴───────────────┴───────────┴──────────┴───────────┘"
       ]
      },
@@ -2665,19 +2677,19 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "ed3a47d1",
+   "id": "2cda3f88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:33.607036Z",
-     "iopub.status.busy": "2026-08-30T17:56:33.606926Z",
-     "iopub.status.idle": "2026-08-30T17:56:33.808452Z",
-     "shell.execute_reply": "2026-08-30T17:56:33.807939Z"
+     "iopub.execute_input": "2026-08-31T03:11:28.921097Z",
+     "iopub.status.busy": "2026-08-31T03:11:28.920843Z",
+     "iopub.status.idle": "2026-08-31T03:11:29.629077Z",
+     "shell.execute_reply": "2026-08-31T03:11:29.628344Z"
     },
     "papermill": {
-     "duration": 0.208305,
-     "end_time": "2026-08-30T17:56:33.808869+00:00",
+     "duration": 0.72417,
+     "end_time": "2026-08-31T03:11:29.629729+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.600564+00:00",
+     "start_time": "2026-08-31T03:11:28.905559+00:00",
      "status": "completed"
     }
    },
@@ -2715,13 +2727,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db204d5b",
+   "id": "8e336fff",
    "metadata": {
     "papermill": {
-     "duration": 0.005944,
-     "end_time": "2026-08-30T17:56:33.821095+00:00",
+     "duration": 0.006802,
+     "end_time": "2026-08-31T03:11:29.646423+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.815151+00:00",
+     "start_time": "2026-08-31T03:11:29.639621+00:00",
      "status": "completed"
     }
    },
@@ -2751,13 +2763,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b78cdc5d",
+   "id": "71bd4e23",
    "metadata": {
     "papermill": {
-     "duration": 0.005822,
-     "end_time": "2026-08-30T17:56:33.832813+00:00",
+     "duration": 0.008955,
+     "end_time": "2026-08-31T03:11:29.664588+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.826991+00:00",
+     "start_time": "2026-08-31T03:11:29.655633+00:00",
      "status": "completed"
     }
    },
@@ -2776,19 +2788,19 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "13e31dec",
+   "id": "68dbcd9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:33.845603Z",
-     "iopub.status.busy": "2026-08-30T17:56:33.845486Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.076303Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.075957Z"
+     "iopub.execute_input": "2026-08-31T03:11:29.687249Z",
+     "iopub.status.busy": "2026-08-31T03:11:29.687030Z",
+     "iopub.status.idle": "2026-08-31T03:11:30.702449Z",
+     "shell.execute_reply": "2026-08-31T03:11:30.701407Z"
     },
     "papermill": {
-     "duration": 0.238422,
-     "end_time": "2026-08-30T17:56:34.077084+00:00",
+     "duration": 1.031008,
+     "end_time": "2026-08-31T03:11:30.704015+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:33.838662+00:00",
+     "start_time": "2026-08-31T03:11:29.673007+00:00",
      "status": "completed"
     }
    },
@@ -2815,13 +2827,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3dbd9630",
+   "id": "436ea431",
    "metadata": {
     "papermill": {
-     "duration": 0.008022,
-     "end_time": "2026-08-30T17:56:34.097305+00:00",
+     "duration": 0.016796,
+     "end_time": "2026-08-31T03:11:30.774599+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.089283+00:00",
+     "start_time": "2026-08-31T03:11:30.757803+00:00",
      "status": "completed"
     }
    },
@@ -2832,19 +2844,19 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "ce61af74",
+   "id": "a232c327",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.109747Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.109643Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.213157Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.212753Z"
+     "iopub.execute_input": "2026-08-31T03:11:30.796005Z",
+     "iopub.status.busy": "2026-08-31T03:11:30.795854Z",
+     "iopub.status.idle": "2026-08-31T03:11:31.001365Z",
+     "shell.execute_reply": "2026-08-31T03:11:30.999785Z"
     },
     "papermill": {
-     "duration": 0.110359,
-     "end_time": "2026-08-30T17:56:34.213562+00:00",
+     "duration": 0.217576,
+     "end_time": "2026-08-31T03:11:31.002419+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.103203+00:00",
+     "start_time": "2026-08-31T03:11:30.784843+00:00",
      "status": "completed"
     }
    },
@@ -2874,13 +2886,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "449faf3c",
+   "id": "69c5023f",
    "metadata": {
     "papermill": {
-     "duration": 0.005957,
-     "end_time": "2026-08-30T17:56:34.226000+00:00",
+     "duration": 0.023002,
+     "end_time": "2026-08-31T03:11:31.056218+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.220043+00:00",
+     "start_time": "2026-08-31T03:11:31.033216+00:00",
      "status": "completed"
     }
    },
@@ -2898,13 +2910,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79983738",
+   "id": "9d203055",
    "metadata": {
     "papermill": {
-     "duration": 0.006019,
-     "end_time": "2026-08-30T17:56:34.237967+00:00",
+     "duration": 0.013929,
+     "end_time": "2026-08-31T03:11:31.091050+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.231948+00:00",
+     "start_time": "2026-08-31T03:11:31.077121+00:00",
      "status": "completed"
     }
    },
@@ -2918,13 +2930,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0733bcc8",
+   "id": "57bbb177",
    "metadata": {
     "papermill": {
-     "duration": 0.006629,
-     "end_time": "2026-08-30T17:56:34.250990+00:00",
+     "duration": 0.045319,
+     "end_time": "2026-08-31T03:11:31.156086+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.244361+00:00",
+     "start_time": "2026-08-31T03:11:31.110767+00:00",
      "status": "completed"
     }
    },
@@ -2943,19 +2955,19 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "eaa7a3b3",
+   "id": "7bfbf24d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.277334Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.277174Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.308843Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.308238Z"
+     "iopub.execute_input": "2026-08-31T03:11:31.224912Z",
+     "iopub.status.busy": "2026-08-31T03:11:31.224697Z",
+     "iopub.status.idle": "2026-08-31T03:11:31.300473Z",
+     "shell.execute_reply": "2026-08-31T03:11:31.298425Z"
     },
     "papermill": {
-     "duration": 0.047822,
-     "end_time": "2026-08-30T17:56:34.309258+00:00",
+     "duration": 0.100723,
+     "end_time": "2026-08-31T03:11:31.302204+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.261436+00:00",
+     "start_time": "2026-08-31T03:11:31.201481+00:00",
      "status": "completed"
     }
    },
@@ -3051,13 +3063,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed25d385",
+   "id": "642b9623",
    "metadata": {
     "papermill": {
-     "duration": 0.006714,
-     "end_time": "2026-08-30T17:56:34.325105+00:00",
+     "duration": 0.027909,
+     "end_time": "2026-08-31T03:11:31.354854+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.318391+00:00",
+     "start_time": "2026-08-31T03:11:31.326945+00:00",
      "status": "completed"
     }
    },
@@ -3068,19 +3080,19 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "5171e60c",
+   "id": "7bb42598",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.338098Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.337937Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.449195Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.448711Z"
+     "iopub.execute_input": "2026-08-31T03:11:31.428001Z",
+     "iopub.status.busy": "2026-08-31T03:11:31.427582Z",
+     "iopub.status.idle": "2026-08-31T03:11:31.947229Z",
+     "shell.execute_reply": "2026-08-31T03:11:31.946480Z"
     },
     "papermill": {
-     "duration": 0.118589,
-     "end_time": "2026-08-30T17:56:34.449492+00:00",
+     "duration": 0.559549,
+     "end_time": "2026-08-31T03:11:31.947893+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.330903+00:00",
+     "start_time": "2026-08-31T03:11:31.388344+00:00",
      "status": "completed"
     }
    },
@@ -3124,13 +3136,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a972087a",
+   "id": "129024d7",
    "metadata": {
     "papermill": {
-     "duration": 0.008035,
-     "end_time": "2026-08-30T17:56:34.464193+00:00",
+     "duration": 0.009269,
+     "end_time": "2026-08-31T03:11:31.968702+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.456158+00:00",
+     "start_time": "2026-08-31T03:11:31.959433+00:00",
      "status": "completed"
     }
    },
@@ -3146,13 +3158,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "919ceaff",
+   "id": "7b85a828",
    "metadata": {
     "papermill": {
-     "duration": 0.020494,
-     "end_time": "2026-08-30T17:56:34.490846+00:00",
+     "duration": 0.007717,
+     "end_time": "2026-08-31T03:11:32.018410+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.470352+00:00",
+     "start_time": "2026-08-31T03:11:32.010693+00:00",
      "status": "completed"
     }
    },
@@ -3168,19 +3180,19 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "3f1446b4",
+   "id": "0c9757cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.504212Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.504099Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.507800Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.507395Z"
+     "iopub.execute_input": "2026-08-31T03:11:32.054151Z",
+     "iopub.status.busy": "2026-08-31T03:11:32.053774Z",
+     "iopub.status.idle": "2026-08-31T03:11:32.068262Z",
+     "shell.execute_reply": "2026-08-31T03:11:32.067111Z"
     },
     "papermill": {
-     "duration": 0.011006,
-     "end_time": "2026-08-30T17:56:34.508227+00:00",
+     "duration": 0.032632,
+     "end_time": "2026-08-31T03:11:32.069235+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.497221+00:00",
+     "start_time": "2026-08-31T03:11:32.036603+00:00",
      "status": "completed"
     }
    },
@@ -3230,13 +3242,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20972ac0",
+   "id": "ac8f25b4",
    "metadata": {
     "papermill": {
-     "duration": 0.006048,
-     "end_time": "2026-08-30T17:56:34.520529+00:00",
+     "duration": 0.0177,
+     "end_time": "2026-08-31T03:11:32.116573+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.514481+00:00",
+     "start_time": "2026-08-31T03:11:32.098873+00:00",
      "status": "completed"
     }
    },
@@ -3251,13 +3263,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33a5325f",
+   "id": "ea7ae083",
    "metadata": {
     "papermill": {
-     "duration": 0.006137,
-     "end_time": "2026-08-30T17:56:34.532793+00:00",
+     "duration": 0.03505,
+     "end_time": "2026-08-31T03:11:32.159812+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.526656+00:00",
+     "start_time": "2026-08-31T03:11:32.124762+00:00",
      "status": "completed"
     }
    },
@@ -3275,19 +3287,19 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "07ee9c58",
+   "id": "fd089682",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.546158Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.546020Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.549004Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.548505Z"
+     "iopub.execute_input": "2026-08-31T03:11:32.212091Z",
+     "iopub.status.busy": "2026-08-31T03:11:32.211806Z",
+     "iopub.status.idle": "2026-08-31T03:11:32.222972Z",
+     "shell.execute_reply": "2026-08-31T03:11:32.221692Z"
     },
     "papermill": {
-     "duration": 0.010399,
-     "end_time": "2026-08-30T17:56:34.549264+00:00",
+     "duration": 0.035122,
+     "end_time": "2026-08-31T03:11:32.227685+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.538865+00:00",
+     "start_time": "2026-08-31T03:11:32.192563+00:00",
      "status": "completed"
     }
    },
@@ -3317,13 +3329,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "018c1135",
+   "id": "d59deb8b",
    "metadata": {
     "papermill": {
-     "duration": 0.00635,
-     "end_time": "2026-08-30T17:56:34.561985+00:00",
+     "duration": 0.012785,
+     "end_time": "2026-08-31T03:11:32.257106+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.555635+00:00",
+     "start_time": "2026-08-31T03:11:32.244321+00:00",
      "status": "completed"
     }
    },
@@ -3339,13 +3351,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7188cda",
+   "id": "8ba0d6fa",
    "metadata": {
     "papermill": {
-     "duration": 0.006124,
-     "end_time": "2026-08-30T17:56:34.575178+00:00",
+     "duration": 0.009144,
+     "end_time": "2026-08-31T03:11:32.274448+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.569054+00:00",
+     "start_time": "2026-08-31T03:11:32.265304+00:00",
      "status": "completed"
     }
    },
@@ -3356,19 +3368,19 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "65df351b",
+   "id": "0d270fcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.588146Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.587987Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.591497Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.591016Z"
+     "iopub.execute_input": "2026-08-31T03:11:32.306937Z",
+     "iopub.status.busy": "2026-08-31T03:11:32.306762Z",
+     "iopub.status.idle": "2026-08-31T03:11:32.310343Z",
+     "shell.execute_reply": "2026-08-31T03:11:32.309641Z"
     },
     "papermill": {
-     "duration": 0.010639,
-     "end_time": "2026-08-30T17:56:34.591806+00:00",
+     "duration": 0.021872,
+     "end_time": "2026-08-31T03:11:32.311060+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.581167+00:00",
+     "start_time": "2026-08-31T03:11:32.289188+00:00",
      "status": "completed"
     }
    },
@@ -3393,13 +3405,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4dad3dfb",
+   "id": "45393087",
    "metadata": {
     "papermill": {
-     "duration": 0.006117,
-     "end_time": "2026-08-30T17:56:34.604292+00:00",
+     "duration": 0.01753,
+     "end_time": "2026-08-31T03:11:32.350902+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.598175+00:00",
+     "start_time": "2026-08-31T03:11:32.333372+00:00",
      "status": "completed"
     }
    },
@@ -3416,13 +3428,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1831220c",
+   "id": "296e7a16",
    "metadata": {
     "papermill": {
-     "duration": 0.006233,
-     "end_time": "2026-08-30T17:56:34.616822+00:00",
+     "duration": 0.021832,
+     "end_time": "2026-08-31T03:11:32.399447+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.610589+00:00",
+     "start_time": "2026-08-31T03:11:32.377615+00:00",
      "status": "completed"
     }
    },
@@ -3433,19 +3445,19 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "a6ffeac4",
+   "id": "15ac438a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.630604Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.630488Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.636701Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.636121Z"
+     "iopub.execute_input": "2026-08-31T03:11:32.454334Z",
+     "iopub.status.busy": "2026-08-31T03:11:32.453782Z",
+     "iopub.status.idle": "2026-08-31T03:11:32.471707Z",
+     "shell.execute_reply": "2026-08-31T03:11:32.470434Z"
     },
     "papermill": {
-     "duration": 0.014104,
-     "end_time": "2026-08-30T17:56:34.637059+00:00",
+     "duration": 0.04913,
+     "end_time": "2026-08-31T03:11:32.473317+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.622955+00:00",
+     "start_time": "2026-08-31T03:11:32.424187+00:00",
      "status": "completed"
     }
    },
@@ -3454,9 +3466,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "No causal evidence is reported: causal selection for 'fwd_ret_5d' resolved to 0 identities\n",
       "1 causal row(s) for fwd_ret_5d do not resolve and are not reported below. b47bd0ec208a: identity version absent, not 3 - registered through `register_causal_run`, which cannot stamp one.\n",
-      "No causal DML results available for this case study\n"
+      "Causal DML - 1 run(s):\n",
+      "  fwd_ret_5d     treatment=ivrv_spread              ATE=+0.015345  SE_HAC=0.016828  t=+0.91  p=0.362  bias%=-217.6  refutation_p=0.01\n"
      ]
     }
    ],
@@ -3578,13 +3590,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e01224be",
+   "id": "8d51ab14",
    "metadata": {
     "papermill": {
-     "duration": 0.006368,
-     "end_time": "2026-08-30T17:56:34.651128+00:00",
+     "duration": 0.022037,
+     "end_time": "2026-08-31T03:11:32.509599+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.644760+00:00",
+     "start_time": "2026-08-31T03:11:32.487562+00:00",
      "status": "completed"
     }
    },
@@ -3612,13 +3624,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab9d90e6",
+   "id": "c0912036",
    "metadata": {
     "papermill": {
-     "duration": 0.006194,
-     "end_time": "2026-08-30T17:56:34.664040+00:00",
+     "duration": 0.034998,
+     "end_time": "2026-08-31T03:11:32.594381+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.657846+00:00",
+     "start_time": "2026-08-31T03:11:32.559383+00:00",
      "status": "completed"
     }
    },
@@ -3647,19 +3659,19 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "4ffa2cba",
+   "id": "35502229",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.678067Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.677961Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.738418Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.737910Z"
+     "iopub.execute_input": "2026-08-31T03:11:32.635702Z",
+     "iopub.status.busy": "2026-08-31T03:11:32.635411Z",
+     "iopub.status.idle": "2026-08-31T03:11:32.796325Z",
+     "shell.execute_reply": "2026-08-31T03:11:32.795630Z"
     },
     "papermill": {
-     "duration": 0.068046,
-     "end_time": "2026-08-30T17:56:34.738748+00:00",
+     "duration": 0.187032,
+     "end_time": "2026-08-31T03:11:32.796838+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.670702+00:00",
+     "start_time": "2026-08-31T03:11:32.609806+00:00",
      "status": "completed"
     }
    },
@@ -3711,19 +3723,19 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "86ea942a",
+   "id": "d098dafe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.752763Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.752643Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.755937Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.755472Z"
+     "iopub.execute_input": "2026-08-31T03:11:32.824559Z",
+     "iopub.status.busy": "2026-08-31T03:11:32.823804Z",
+     "iopub.status.idle": "2026-08-31T03:11:32.836543Z",
+     "shell.execute_reply": "2026-08-31T03:11:32.835914Z"
     },
     "papermill": {
-     "duration": 0.011079,
-     "end_time": "2026-08-30T17:56:34.756628+00:00",
+     "duration": 0.032277,
+     "end_time": "2026-08-31T03:11:32.839913+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.745549+00:00",
+     "start_time": "2026-08-31T03:11:32.807636+00:00",
      "status": "completed"
     }
    },
@@ -3767,13 +3779,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f0734f8",
+   "id": "442b02c2",
    "metadata": {
     "papermill": {
-     "duration": 0.010143,
-     "end_time": "2026-08-30T17:56:34.780262+00:00",
+     "duration": 0.008527,
+     "end_time": "2026-08-31T03:11:32.860158+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.770119+00:00",
+     "start_time": "2026-08-31T03:11:32.851631+00:00",
      "status": "completed"
     }
    },
@@ -3798,13 +3810,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23a49e7e",
+   "id": "c91004ff",
    "metadata": {
     "papermill": {
-     "duration": 0.006805,
-     "end_time": "2026-08-30T17:56:34.794556+00:00",
+     "duration": 0.022096,
+     "end_time": "2026-08-31T03:11:32.896687+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.787751+00:00",
+     "start_time": "2026-08-31T03:11:32.874591+00:00",
      "status": "completed"
     }
    },
@@ -3819,14 +3831,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b114f9f",
+   "id": "1891cfa5",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006339,
-     "end_time": "2026-08-30T17:56:34.807640+00:00",
+     "duration": 0.026293,
+     "end_time": "2026-08-31T03:11:32.934524+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.801301+00:00",
+     "start_time": "2026-08-31T03:11:32.908231+00:00",
      "status": "completed"
     }
    },
@@ -3838,19 +3850,19 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "067f14b3",
+   "id": "5b14da31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.821832Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.821725Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.824451Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.823993Z"
+     "iopub.execute_input": "2026-08-31T03:11:32.997438Z",
+     "iopub.status.busy": "2026-08-31T03:11:32.995960Z",
+     "iopub.status.idle": "2026-08-31T03:11:33.015696Z",
+     "shell.execute_reply": "2026-08-31T03:11:33.013516Z"
     },
     "papermill": {
-     "duration": 0.010351,
-     "end_time": "2026-08-30T17:56:34.824788+00:00",
+     "duration": 0.058734,
+     "end_time": "2026-08-31T03:11:33.017153+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.814437+00:00",
+     "start_time": "2026-08-31T03:11:32.958419+00:00",
      "status": "completed"
     }
    },
@@ -3876,13 +3888,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2dd59b5d",
+   "id": "3f58f159",
    "metadata": {
     "papermill": {
-     "duration": 0.006536,
-     "end_time": "2026-08-30T17:56:34.837816+00:00",
+     "duration": 0.027166,
+     "end_time": "2026-08-31T03:11:33.062984+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.831280+00:00",
+     "start_time": "2026-08-31T03:11:33.035818+00:00",
      "status": "completed"
     }
    },
@@ -3894,19 +3906,19 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "cd9f4440",
+   "id": "51e8c524",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.852196Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.852075Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.857749Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.857377Z"
+     "iopub.execute_input": "2026-08-31T03:11:33.127673Z",
+     "iopub.status.busy": "2026-08-31T03:11:33.126719Z",
+     "iopub.status.idle": "2026-08-31T03:11:33.149914Z",
+     "shell.execute_reply": "2026-08-31T03:11:33.148502Z"
     },
     "papermill": {
-     "duration": 0.01344,
-     "end_time": "2026-08-30T17:56:34.858115+00:00",
+     "duration": 0.060825,
+     "end_time": "2026-08-31T03:11:33.155160+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.844675+00:00",
+     "start_time": "2026-08-31T03:11:33.094335+00:00",
      "status": "completed"
     }
    },
@@ -3982,13 +3994,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4e7c68c",
+   "id": "227ff322",
    "metadata": {
     "papermill": {
-     "duration": 0.006249,
-     "end_time": "2026-08-30T17:56:34.871124+00:00",
+     "duration": 0.018735,
+     "end_time": "2026-08-31T03:11:33.194826+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.864875+00:00",
+     "start_time": "2026-08-31T03:11:33.176091+00:00",
      "status": "completed"
     }
    },
@@ -4003,19 +4015,19 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "6a5be51e",
+   "id": "f729d56f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T17:56:34.884259Z",
-     "iopub.status.busy": "2026-08-30T17:56:34.884131Z",
-     "iopub.status.idle": "2026-08-30T17:56:34.888349Z",
-     "shell.execute_reply": "2026-08-30T17:56:34.887935Z"
+     "iopub.execute_input": "2026-08-31T03:11:33.223629Z",
+     "iopub.status.busy": "2026-08-31T03:11:33.223291Z",
+     "iopub.status.idle": "2026-08-31T03:11:33.251429Z",
+     "shell.execute_reply": "2026-08-31T03:11:33.250346Z"
     },
     "papermill": {
-     "duration": 0.011551,
-     "end_time": "2026-08-30T17:56:34.888787+00:00",
+     "duration": 0.044144,
+     "end_time": "2026-08-31T03:11:33.255915+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.877236+00:00",
+     "start_time": "2026-08-31T03:11:33.211771+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4092,13 +4104,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f11d81c7",
+   "id": "c0f437b4",
    "metadata": {
     "papermill": {
-     "duration": 0.006375,
-     "end_time": "2026-08-30T17:56:34.901681+00:00",
+     "duration": 0.027216,
+     "end_time": "2026-08-31T03:11:33.306031+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.895306+00:00",
+     "start_time": "2026-08-31T03:11:33.278815+00:00",
      "status": "completed"
     }
    },
@@ -4146,13 +4158,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8912d273",
+   "id": "2922bb3f",
    "metadata": {
     "papermill": {
-     "duration": 0.006477,
-     "end_time": "2026-08-30T17:56:34.914944+00:00",
+     "duration": 0.023441,
+     "end_time": "2026-08-31T03:11:33.358382+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.908467+00:00",
+     "start_time": "2026-08-31T03:11:33.334941+00:00",
      "status": "completed"
     }
    },
@@ -4205,13 +4217,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73742f26",
+   "id": "d2995607",
    "metadata": {
     "papermill": {
-     "duration": 0.006686,
-     "end_time": "2026-08-30T17:56:34.927978+00:00",
+     "duration": 0.024301,
+     "end_time": "2026-08-31T03:11:33.410079+00:00",
      "exception": false,
-     "start_time": "2026-08-30T17:56:34.921292+00:00",
+     "start_time": "2026-08-31T03:11:33.385778+00:00",
      "status": "completed"
     }
    },
@@ -4268,19 +4280,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 12.909113,
-   "end_time": "2026-08-30T17:56:36.651493+00:00",
+   "duration": 36.5558,
+   "end_time": "2026-08-31T03:11:37.063083+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "case_studies/sp500_equity_option_analytics/13_model_analysis.ipynb",
-   "output_path": "~/scratch/prod_13_model_analysis_1586764.ipynb",
+   "output_path": "~/scratch/prod_13_model_analysis_101013.ipynb",
    "parameters": {},
-   "start_time": "2026-08-30T17:56:23.742380+00:00",
+   "start_time": "2026-08-31T03:11:00.507283+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
    "source_py_blob": "8097636f5a688ab8386760e928e9687a5f42e358",
-   "executed_at": "2026-08-30T17:56:37.342032+00:00",
+   "executed_at": "2026-08-31T03:11:40.297659+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1310,8 +1310,8 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     seed = int(config.get("seed", RANDOM_SEED))
     n_folds = int(reductions.get("n_folds", config.get("n_folds", 5)))
     n_placebo = int(reductions.get("n_placebo", config.get("n_placebo", 100)))
-    # The shared preset still declares max_samples for the six case-study DML stages that have
-    # not migrated to this path and read it as their own default. This path ignores it: a
+    # The shared preset still declares max_samples for the case-study DML stages that have not
+    # migrated to this path and read it as their own default. This path ignores it: a
     # canonical run uses the full declared population, and a reduction reaches it only through
     # preview_reductions, which research/causal.py refuses for a canonical request. So the
     # preset cannot cap a canonical sample, and the resolved spec records max_samples: 0.

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2117,8 +2117,12 @@ case_studies/sp500_equity_option_analytics/11e_supervised_autoencoder:
   timeout: 900
 
 case_studies/sp500_equity_option_analytics/12_causal_dml:
-  # CV_FOLDS was renamed N_FOLDS: the notebook now separates the request from the resolved
-  # value, so the parameter and the number the analysis runs on no longer share a name.
+  # N_FOLDS is back to CV_FOLDS. The notebook resolves its population through the shared causal
+  # request now, and the request's four preview fields are named for the reductions they become,
+  # so the parameter carries the resolver's name rather than the notebook's own. The harness sets
+  # EXECUTION_TIER and WORKSPACE itself, which makes every run here a preview, and a preview
+  # causal request must declare all four - papermill only warns on a parameter the notebook does
+  # not read, so a stale name here fails inside the resolver rather than at injection.
   # N_PLACEBO was 5, below the ten successful draws run_dml_analysis assembles a refutation
   # from at all, so it published none and this notebook's guard against a missing refutation
   # fired on every CI run. The bar is not that a refutation is computed but that a verdict below
@@ -2128,9 +2132,9 @@ case_studies/sp500_equity_option_analytics/12_causal_dml:
   # draws above it are a chosen margin, because a draw can fail and drop the survivors below the
   # bar. Measured at 14s against a 300s cap.
   parameters:
+    CV_FOLDS: 2
     MAX_SAMPLES: 3000
     MAX_SYMBOLS: 5
-    N_FOLDS: 2
     N_PLACEBO: 25
   timeout: 300
 case_studies/sp500_equity_option_analytics/13_model_analysis:

--- a/tests/test_causal_rows_are_resolvable.py
+++ b/tests/test_causal_rows_are_resolvable.py
@@ -15,8 +15,11 @@ Measured against the fleet registries on 2026-08-25: crypto 2/2 rows visible, cm
 wrapper; etfs' one row was written by the wrapper and its notebook has since been converted,
 so its next run registers a resolvable one. sp500_options holds one visible row, but it was written by the resolver before
 that notebook moved to the wrapper, so its next run registers an invisible one;
-nasdaq100_microstructure and sp500_equity_option_analytics have registered nothing yet and
-would register invisible rows on their first run.
+nasdaq100_microstructure has registered nothing yet and would register an invisible row on
+its first run. sp500_equity_option_analytics registered one through the wrapper on 2026-08-26
+and replaced it through the resolver on 2026-08-31; the wrapper row is still in its table,
+stranded rather than superseded, because a row no reader resolves cannot be named as a
+predecessor.
 
 The guard keys on `register_causal_run` rather than on any particular call spelling. An
 earlier version matched the literal `results = run_dml_analysis(`, which a notebook slips
@@ -39,7 +42,6 @@ REPO = Path(__file__).resolve().parent.parent
 UNCONVERTED = {
     "case_studies/nasdaq100_microstructure/12_causal_dml.py",
     "case_studies/sp500_options/10_causal_dml.py",
-    "case_studies/sp500_equity_option_analytics/12_causal_dml.py",
 }
 
 WRAPPER = "register_causal_run"


### PR DESCRIPTION
`sp500_equity_option_analytics/12_causal_dml` was the last case-study causal notebook
building its own DML specification and registering it through `register_causal_run`,
which cannot stamp an identity version. The row it wrote, `b47bd0ec208a`, is invisible
to `current_causal_identities` and therefore to every reader: `CausalResult.one`
resolved the label to zero identities.

It was also measured on a sample the notebook cut by hand. `dml.yaml` declares
`max_samples: 50000`, the notebook applied it, and the published estimate came from
**37,240 rows - 9.9% of the 376,871 the estimand admits**. The canonical resolver
ignores `max_samples` deliberately; a cap reaches it only as a declared preview
reduction, which a canonical request refuses.

## What moved

Routing the notebook through `study.causal(...).resolve().run()` changes both, measured
against the row it replaces:

| | before `b47bd0ec208a` | after `b8e949f2cbc5` |
|---|---|---|
| analysis population | 37,240 | 376,871 |
| cross-fitted rows | 37,240 | 313,237 |
| naive OLS | -0.028260 | -0.018040 |
| **DML effect** | **-0.028764** | **+0.015345** |
| HAC standard error | 0.033558 | 0.016828 |
| 95% interval | [-0.0945, +0.0370] | [-0.0176, +0.0483] |
| p-value (HAC) | 0.3935 | 0.3621 |
| confounding bias | +1.75% | -217.56% |
| refutation p / draws | 0.0099 / 100 | 0.0099 / 100 |

**The sign of the point estimate flipped.** Both intervals cover zero and both p-values
are far from any threshold, so the reading the case study publishes - no effect
distinguishable from zero after adjustment - survives unchanged. But the negative
coefficient it published was a property of the 9.9% subsample rather than of the panel,
and `confounding_bias_pct` moved from a rounding difference to a sign reversal because
the naive and adjusted estimates now sit on opposite sides of zero.

The placebo block moves too, and independently: sizing it by the treatment window rather
than the label buffer put `refutation.block_size` into the causal identity under #623, so
the block is 20 sessions - the realized-volatility leg of `ivrv_spread` - rather than the
5 the buffer implies.

## `SUPERSEDES_CAUSAL` stays empty, and not for the usual reason

A refit normally has to name the identity it retires. There is none to name here:
`b47bd0ec208a` carries no identity version, so it is not in the current set, and
declaring it would fail the write for naming a predecessor that is not current. The
wrapper row stays in the table, stranded rather than superseded. The notebook says to
declare a hash the next time this identity moves.

## Two things the conversion broke, both caught before the push

`tests/overrides.yaml` still passed `N_FOLDS`, the pre-migration name. Papermill only
*warns* on a parameter a notebook does not read, so the stale name failed inside the
resolver as `preview causal requests must declare every reduction; missing ['n_folds']`
- a message pointing nowhere near its cause. **Converting a causal notebook is a
two-file change**; `nasdaq100_microstructure` and `sp500_options` will each hit this.

`13_model_analysis` resolves the causal row and counts it as coverage, so its committed
output was a statement about the wrapper row's invisibility. On `main` it prints
"Causal families: none" and "No causal DML results available for this case study", two
cells before markdown reading "1 causal family (causal_dml)" and two sections before
prose explaining how to read an estimate the output denies. Nothing detects that: the
contradiction is between a markdown cell and a code cell's output. Re-run, it publishes

```
Causal families: ['causal_dml']
Causal DML - 1 run(s):
  fwd_ret_5d  treatment=ivrv_spread  ATE=+0.015345  SE_HAC=0.016828
              t=+0.91  p=0.362  bias%=-217.6  refutation_p=0.01
```

beside the diagnostic it already carried, which now names a row that is stranded rather
than merely absent.

## Also here

`RANDOM_SEED` was a notebook parameter reaching nothing the estimate depends on. The
seed is `dml.yaml`'s and is in the identity, so overriding the parameter left the hash
untouched and returned the cached fit under the seed it was meant to replace. Removed;
`set_global_seeds` now takes `resolved.spec["seed"]`. `fx_pairs/11_causal_dml` carries
the same parameter with the same non-effect and is untouched.

`case_studies/config/dml/dml.yaml` is annotated: its `max_samples` reaches no canonical
run and is read only by the two notebooks still on the wrapper. It cannot be deleted
until they convert, and the note says not to reintroduce the hand-application to recover
an old number.

## Verification

- Full 23-notebook fixture lane at the branch tip, in a plain detached checkout with `ML4T_DATA_PATH` pointed at the test data: **22 passed, 2 skipped**, with `11d_stochastic_discount_factor` timing out at its 1800s cell cap under a load average of 30 and 25 concurrent ipykernels. Untouched by this branch, passed in both earlier runs of the same lane, and passes alone in 899s.
- 181 causal unit tests pass. `tests/test_causal_rows_are_resolvable.py` drops the notebook from `UNCONVERTED`; its second test exists to fail when a converted notebook is left there.
- Both production runs of `12` and the run of `13` diffed against a `.dump` backup: the registry gained exactly one row, `b8e949f2cbc5`, and is byte-identical otherwise.

## Known gap, filed separately

`run_dml_analysis` computes `placebo_frozen_fraction` and warns on it, but persists it
nowhere - not a registry column, not in `CausalResult.metrics`. This panel freezes 35.6%
of treatment rows, because a 20-session block needs 40 clean sessions and a daily option
panel starts a new segment at every quote gap. The bias runs **towards 1**, so passing at
the 1/101 floor with that handicap is conservative rather than suspect - but nothing
downstream can tell. `ml4t/agent-workspace#999`.