### PR TITLE
fx_pairs 11_causal_dml: seed from the identity, and refit the two stale labels

### DIFF
--- a/case_studies/fx_pairs/11_causal_dml.ipynb
+++ b/case_studies/fx_pairs/11_causal_dml.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "486eb33c",
+   "id": "83e5d9a8",
    "metadata": {
     "papermill": {
-     "duration": 0.002334,
-     "end_time": "2026-08-27T23:04:13.587680+00:00",
+     "duration": 0.001559,
+     "end_time": "2026-08-31T04:25:43.454938+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:13.585346+00:00",
+     "start_time": "2026-08-31T04:25:43.453379+00:00",
      "status": "completed"
     }
    },
@@ -38,19 +38,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "2daebee0",
+   "id": "6294c3b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T23:04:13.592812Z",
-     "iopub.status.busy": "2026-08-27T23:04:13.592521Z",
-     "iopub.status.idle": "2026-08-27T23:04:17.070071Z",
-     "shell.execute_reply": "2026-08-27T23:04:17.069406Z"
+     "iopub.execute_input": "2026-08-31T04:25:43.458728Z",
+     "iopub.status.busy": "2026-08-31T04:25:43.458547Z",
+     "iopub.status.idle": "2026-08-31T04:25:46.087702Z",
+     "shell.execute_reply": "2026-08-31T04:25:46.087318Z"
     },
     "papermill": {
-     "duration": 3.48177,
-     "end_time": "2026-08-27T23:04:17.071522+00:00",
+     "duration": 2.632249,
+     "end_time": "2026-08-31T04:25:46.088477+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:13.589752+00:00",
+     "start_time": "2026-08-31T04:25:43.456228+00:00",
      "status": "completed"
     }
    },
@@ -69,19 +69,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d16e286c",
+   "id": "413c82ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T23:04:17.076137Z",
-     "iopub.status.busy": "2026-08-27T23:04:17.075913Z",
-     "iopub.status.idle": "2026-08-27T23:04:17.079687Z",
-     "shell.execute_reply": "2026-08-27T23:04:17.079049Z"
+     "iopub.execute_input": "2026-08-31T04:25:46.090644Z",
+     "iopub.status.busy": "2026-08-31T04:25:46.090538Z",
+     "iopub.status.idle": "2026-08-31T04:25:46.093154Z",
+     "shell.execute_reply": "2026-08-31T04:25:46.092620Z"
     },
     "papermill": {
-     "duration": 0.006691,
-     "end_time": "2026-08-27T23:04:17.080087+00:00",
+     "duration": 0.004521,
+     "end_time": "2026-08-31T04:25:46.093835+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:17.073396+00:00",
+     "start_time": "2026-08-31T04:25:46.089314+00:00",
      "status": "completed"
     },
     "tags": [
@@ -93,7 +93,6 @@
     "CASE_STUDY_ID = \"fx_pairs\"\n",
     "PRIMARY_LABEL = \"\"\n",
     "MAX_SYMBOLS = 0\n",
-    "RANDOM_SEED = 42\n",
     "CV_FOLDS = 0\n",
     "MAX_SAMPLES = 0\n",
     "N_PLACEBO = 0\n",
@@ -117,19 +116,19 @@
     "# empty: `run-production-notebook.sh` executes with no parameter overrides, so a value\n",
     "# supplied only at run time could never be stamped.\n",
     "SUPERSEDES_CAUSAL: str = (\n",
-    "    '{\"fwd_ret_1d\": \"6e17a9b4644c\", \"fwd_ret_5d\": \"e9623aa44d9a\", \"fwd_ret_21d\": \"f53540351b6b\"}'\n",
+    "    '{\"fwd_ret_1d\": \"25f8bdd775de\", \"fwd_ret_5d\": \"c797f741134a\", \"fwd_ret_21d\": \"3547657669ca\"}'\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1d8d8e49",
+   "id": "4e580faf",
    "metadata": {
     "papermill": {
-     "duration": 0.000725,
-     "end_time": "2026-08-27T23:04:17.081951+00:00",
+     "duration": 0.001173,
+     "end_time": "2026-08-31T04:25:46.096636+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:17.081226+00:00",
+     "start_time": "2026-08-31T04:25:46.095463+00:00",
      "status": "completed"
     }
    },
@@ -143,19 +142,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "bff53e78",
+   "id": "90ae8eb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T23:04:17.084670Z",
-     "iopub.status.busy": "2026-08-27T23:04:17.084470Z",
-     "iopub.status.idle": "2026-08-27T23:04:22.076142Z",
-     "shell.execute_reply": "2026-08-27T23:04:22.075417Z"
+     "iopub.execute_input": "2026-08-31T04:25:46.099992Z",
+     "iopub.status.busy": "2026-08-31T04:25:46.099814Z",
+     "iopub.status.idle": "2026-08-31T04:25:50.020450Z",
+     "shell.execute_reply": "2026-08-31T04:25:50.020052Z"
     },
     "papermill": {
-     "duration": 4.994317,
-     "end_time": "2026-08-27T23:04:22.077020+00:00",
+     "duration": 3.923041,
+     "end_time": "2026-08-31T04:25:50.020904+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:17.082703+00:00",
+     "start_time": "2026-08-31T04:25:46.097863+00:00",
      "status": "completed"
     }
    },
@@ -168,6 +167,7 @@
       "Treatment: mom_skip_recent\n",
       "Confounders: vol_gk_21d, vol_gk_63d, zscore_21d\n",
       "Execution tier: canonical\n",
+      "Seed (from the resolved identity): 42\n",
       "  fwd_ret_1d: outcome horizon 1 days 00:00:00, last admissible endpoint 2023-12-29T00:00:00\n",
       "  fwd_ret_5d: outcome horizon 5 days 00:00:00, last admissible endpoint 2023-12-22T00:00:00\n",
       "  fwd_ret_21d: outcome horizon 21 days 00:00:00, last admissible endpoint 2023-11-30T00:00:00\n"
@@ -175,7 +175,6 @@
     }
    ],
    "source": [
-    "set_global_seeds(RANDOM_SEED)\n",
     "case_dir = get_case_study_dir(CASE_STUDY_ID)\n",
     "setup = yaml.safe_load((case_dir / \"config\" / \"setup.yaml\").read_text())\n",
     "labels = (\n",
@@ -215,6 +214,21 @@
     "    for label in labels\n",
     "}\n",
     "resolutions = {label: request.resolve() for label, request in requests.items()}\n",
+    "\n",
+    "# Seeded from the RESOLVED specification rather than from a notebook constant. The seed the\n",
+    "# estimate depends on is `dml.yaml`'s, and it is inside the identity hash - so a constant here\n",
+    "# that only reached `set_global_seeds` was a dial that turned without moving the number: change\n",
+    "# it and the identity is unchanged, the cached result fit under the configured seed is served\n",
+    "# back, and nothing says so. Seeding from the resolved value makes the seed this notebook\n",
+    "# announces the seed its results were actually fit under.\n",
+    "RANDOM_SEED = int(resolutions[labels[0]].spec[\"seed\"])\n",
+    "if any(int(resolved.spec[\"seed\"]) != RANDOM_SEED for resolved in resolutions.values()):\n",
+    "    raise RuntimeError(\n",
+    "        \"the configured labels resolved to different seeds, so one global seed cannot describe \"\n",
+    "        f\"them: {sorted({int(r.spec['seed']) for r in resolutions.values()})}\"\n",
+    "    )\n",
+    "set_global_seeds(RANDOM_SEED)\n",
+    "\n",
     "computations = {label: resolved.spec[\"computation\"] for label, resolved in resolutions.items()}\n",
     "computation = computations[labels[0]]\n",
     "\n",
@@ -223,6 +237,7 @@
     "print(f\"Treatment: {estimand['treatment']}\")\n",
     "print(f\"Confounders: {', '.join(estimand['confounders'])}\")\n",
     "print(f\"Execution tier: {tier.value}\")\n",
+    "print(f\"Seed (from the resolved identity): {RANDOM_SEED}\")\n",
     "for horizon, values in computations.items():\n",
     "    print(\n",
     "        f\"  {horizon}: outcome horizon {values['estimand']['outcome_horizon']}, \"\n",
@@ -232,13 +247,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ce709b1",
+   "id": "5a6375fc",
    "metadata": {
     "papermill": {
-     "duration": 0.000798,
-     "end_time": "2026-08-27T23:04:22.078989+00:00",
+     "duration": 0.00061,
+     "end_time": "2026-08-31T04:25:50.022375+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:22.078191+00:00",
+     "start_time": "2026-08-31T04:25:50.021765+00:00",
      "status": "completed"
     }
    },
@@ -268,19 +283,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8a65cd26",
+   "id": "f5f8eea1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T23:04:22.081898Z",
-     "iopub.status.busy": "2026-08-27T23:04:22.081672Z",
-     "iopub.status.idle": "2026-08-27T23:04:22.089227Z",
-     "shell.execute_reply": "2026-08-27T23:04:22.088589Z"
+     "iopub.execute_input": "2026-08-31T04:25:50.024190Z",
+     "iopub.status.busy": "2026-08-31T04:25:50.024095Z",
+     "iopub.status.idle": "2026-08-31T04:25:50.030102Z",
+     "shell.execute_reply": "2026-08-31T04:25:50.029455Z"
     },
     "papermill": {
-     "duration": 0.01006,
-     "end_time": "2026-08-27T23:04:22.089838+00:00",
+     "duration": 0.007408,
+     "end_time": "2026-08-31T04:25:50.030400+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:22.079778+00:00",
+     "start_time": "2026-08-31T04:25:50.022992+00:00",
      "status": "completed"
     }
    },
@@ -361,13 +376,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3972ccb4",
+   "id": "5755d020",
    "metadata": {
     "papermill": {
-     "duration": 0.001409,
-     "end_time": "2026-08-27T23:04:22.093182+00:00",
+     "duration": 0.000622,
+     "end_time": "2026-08-31T04:25:50.031816+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:22.091773+00:00",
+     "start_time": "2026-08-31T04:25:50.031194+00:00",
      "status": "completed"
     }
    },
@@ -381,19 +396,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "f3833317",
+   "id": "1fa41ce2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T23:04:22.097443Z",
-     "iopub.status.busy": "2026-08-27T23:04:22.097213Z",
-     "iopub.status.idle": "2026-08-27T23:04:25.322966Z",
-     "shell.execute_reply": "2026-08-27T23:04:25.322074Z"
+     "iopub.execute_input": "2026-08-31T04:25:50.033833Z",
+     "iopub.status.busy": "2026-08-31T04:25:50.033687Z",
+     "iopub.status.idle": "2026-08-31T04:30:15.982926Z",
+     "shell.execute_reply": "2026-08-31T04:30:15.982416Z"
     },
     "papermill": {
-     "duration": 3.228937,
-     "end_time": "2026-08-27T23:04:25.323571+00:00",
+     "duration": 265.950969,
+     "end_time": "2026-08-31T04:30:15.983460+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:22.094634+00:00",
+     "start_time": "2026-08-31T04:25:50.032491+00:00",
      "status": "completed"
     },
     "tags": [
@@ -405,9 +420,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Registered causal identity, fwd_ret_1d: 25f8bdd775de\n",
-      "Registered causal identity, fwd_ret_5d: c797f741134a\n",
-      "Registered causal identity, fwd_ret_21d: 3547657669ca\n",
+      "Registered causal identity, fwd_ret_1d: 10d126fd5ea8\n",
+      "Registered causal identity, fwd_ret_5d: b877252e48cf\n",
+      "Registered causal identity, fwd_ret_21d: de180a8f377f\n",
       "Effect estimates and their interpretation are reported in 12_model_analysis.\n"
      ]
     }
@@ -439,13 +454,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d75cda5",
+   "id": "f5673979",
    "metadata": {
     "papermill": {
-     "duration": 0.001361,
-     "end_time": "2026-08-27T23:04:25.326738+00:00",
+     "duration": 0.000658,
+     "end_time": "2026-08-31T04:30:15.985005+00:00",
      "exception": false,
-     "start_time": "2026-08-27T23:04:25.325377+00:00",
+     "start_time": "2026-08-31T04:30:15.984347+00:00",
      "status": "completed"
     }
    },
@@ -481,19 +496,19 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 16.190078,
-   "end_time": "2026-08-27T23:04:28.922062+00:00",
+   "duration": 274.816572,
+   "end_time": "2026-08-31T04:30:17.601742+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "case_studies/fx_pairs/11_causal_dml.ipynb",
-   "output_path": "~/scratch/prod_11_causal_dml_3483146.ipynb",
+   "output_path": "~/scratch/prod_11_causal_dml_416812.ipynb",
    "parameters": {},
-   "start_time": "2026-08-27T23:04:12.731984+00:00",
+   "start_time": "2026-08-31T04:25:42.785170+00:00",
    "version": "2.7.0"
   },
   "ml4t_provenance": {
-   "source_py_blob": "df6804ab541f49081bc24af05c01db356b1602e3",
-   "executed_at": "2026-08-27T23:04:37.258305+00:00",
+   "source_py_blob": "2d9de363e2bea72f1ec2abb385fb34c70c6f34ba",
+   "executed_at": "2026-08-31T04:30:18.265767+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {}

--- a/case_studies/fx_pairs/11_causal_dml.py
+++ b/case_studies/fx_pairs/11_causal_dml.py
@@ -49,7 +49,6 @@ from utils.reproducibility import set_global_seeds
 CASE_STUDY_ID = "fx_pairs"
 PRIMARY_LABEL = ""
 MAX_SYMBOLS = 0
-RANDOM_SEED = 42
 CV_FOLDS = 0
 MAX_SAMPLES = 0
 N_PLACEBO = 0
@@ -73,7 +72,7 @@ WORKSPACE: str | None = None
 # empty: `run-production-notebook.sh` executes with no parameter overrides, so a value
 # supplied only at run time could never be stamped.
 SUPERSEDES_CAUSAL: str = (
-    '{"fwd_ret_1d": "6e17a9b4644c", "fwd_ret_5d": "e9623aa44d9a", "fwd_ret_21d": "f53540351b6b"}'
+    '{"fwd_ret_1d": "25f8bdd775de", "fwd_ret_5d": "c797f741134a", "fwd_ret_21d": "3547657669ca"}'
 )
 
 # %% [markdown]
@@ -83,7 +82,6 @@ SUPERSEDES_CAUSAL: str = (
 # and excluded from canonical evidence.
 
 # %%
-set_global_seeds(RANDOM_SEED)
 case_dir = get_case_study_dir(CASE_STUDY_ID)
 setup = yaml.safe_load((case_dir / "config" / "setup.yaml").read_text())
 labels = (
@@ -123,6 +121,21 @@ requests = {
     for label in labels
 }
 resolutions = {label: request.resolve() for label, request in requests.items()}
+
+# Seeded from the RESOLVED specification rather than from a notebook constant. The seed the
+# estimate depends on is `dml.yaml`'s, and it is inside the identity hash - so a constant here
+# that only reached `set_global_seeds` was a dial that turned without moving the number: change
+# it and the identity is unchanged, the cached result fit under the configured seed is served
+# back, and nothing says so. Seeding from the resolved value makes the seed this notebook
+# announces the seed its results were actually fit under.
+RANDOM_SEED = int(resolutions[labels[0]].spec["seed"])
+if any(int(resolved.spec["seed"]) != RANDOM_SEED for resolved in resolutions.values()):
+    raise RuntimeError(
+        "the configured labels resolved to different seeds, so one global seed cannot describe "
+        f"them: {sorted({int(r.spec['seed']) for r in resolutions.values()})}"
+    )
+set_global_seeds(RANDOM_SEED)
+
 computations = {label: resolved.spec["computation"] for label, resolved in resolutions.items()}
 computation = computations[labels[0]]
 
@@ -131,6 +144,7 @@ print(f"Labels: {', '.join(labels)}")
 print(f"Treatment: {estimand['treatment']}")
 print(f"Confounders: {', '.join(estimand['confounders'])}")
 print(f"Execution tier: {tier.value}")
+print(f"Seed (from the resolved identity): {RANDOM_SEED}")
 for horizon, values in computations.items():
     print(
         f"  {horizon}: outcome horizon {values['estimand']['outcome_horizon']}, "


### PR DESCRIPTION
Two defects in `11_causal_dml`, one reported by the eoa lane and one that surfaced while fixing it.

## The seed was a dial that turned without moving the number

`RANDOM_SEED = 42` sat in the parameters cell and reached `set_global_seeds` and nothing else. The
seed the estimate depends on is the configured one, and that is inside the identity hash.

So a reader who set `RANDOM_SEED = 7` got the global seeds set to 7, an identity that still said
42, the cached 42 result served back, and nothing printed to say so. Both values are 42 today, so
no published number was ever wrong - the notebook was advertising a control it did not have.

It now seeds from the resolved specification and prints the seed the results were actually fit
under. The parameters cell no longer offers the knob, because nothing honoured it.

**There is one seed here, not two.** `case_studies/utils/causal.py:1310` reads `config["seed"]`
once; that value reaches the nuisance estimator (`:1191`) and the block permutation (`:917`), and
is recorded in the refutation block (`:1552`). The specification carries it twice because it is
written twice, not because two independent knobs happen to agree - so seeding from
`resolved.spec["seed"]` covers both uses, and there is no reachable state where they disagree.

## Two of the three labels were still fit on the old feature artifact

Found by re-running the notebook. The refit that repointed fx's model populations at
`928edb89accd` did not carry `11_causal_dml`, and a later partial run got `fwd_ret_1d` across
before dying on a stale supersedes declaration. Before:

| label | head | model_based |
|---|---|---|
| `fwd_ret_1d` | `10d126fd5ea8` | `928edb89accd` |
| `fwd_ret_5d` | `c797f741134a` | `750be3347992` (superseded) |
| `fwd_ret_21d` | `3547657669ca` | `750be3347992` (superseded) |

After: `fwd_ret_1d` reproduces `10d126fd5ea8`, `fwd_ret_5d` is `b877252e48cf`, `fwd_ret_21d` is
`de180a8f377f`, and all three name `928edb89accd`.

`SUPERSEDES_CAUSAL` was stale by a generation for `5d` and `21d`. `fwd_ret_1d` names
`25f8bdd775de` rather than the head `10d126fd5ea8`, because this run reproduces that head and a
generation cannot supersede itself - the declaration has to describe what the generation it
produces retires. The registry says so directly: *"causal run 10d126fd5ea8 already declares it
supersedes 25f8bdd775de; it cannot also supersede 10d126fd5ea8"*.

## Verification

Executed on production data and stamped. Nothing overrides `RANDOM_SEED` anywhere in
`tests/overrides.yaml` or `.github/`, so removing it from the parameters cell changes no caller.
