### PR TITLE
etfs: let both declared labels compete at selection, and pin the paired producer to the winner

### DIFF
--- a/case_studies/etfs/20_strategy_analysis.ipynb
+++ b/case_studies/etfs/20_strategy_analysis.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5017448d",
+   "id": "d0470ca3",
    "metadata": {
     "papermill": {
-     "duration": 0.005266,
-     "end_time": "2026-08-31T18:17:57.686293+00:00",
+     "duration": 0.012271,
+     "end_time": "2026-09-01T05:35:13.690822+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:17:57.681027+00:00",
+     "start_time": "2026-09-01T05:35:13.678551+00:00",
      "status": "completed"
     }
    },
@@ -60,19 +60,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "66fafd68",
+   "id": "f4ac2289",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:17:57.694865Z",
-     "iopub.status.busy": "2026-08-31T18:17:57.694523Z",
-     "iopub.status.idle": "2026-08-31T18:18:02.209569Z",
-     "shell.execute_reply": "2026-08-31T18:18:02.208901Z"
+     "iopub.execute_input": "2026-09-01T05:35:13.699890Z",
+     "iopub.status.busy": "2026-09-01T05:35:13.699719Z",
+     "iopub.status.idle": "2026-09-01T05:35:16.385636Z",
+     "shell.execute_reply": "2026-09-01T05:35:16.384896Z"
     },
     "papermill": {
-     "duration": 4.520476,
-     "end_time": "2026-08-31T18:18:02.210866+00:00",
+     "duration": 2.690137,
+     "end_time": "2026-09-01T05:35:16.386295+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:17:57.690390+00:00",
+     "start_time": "2026-09-01T05:35:13.696158+00:00",
      "status": "completed"
     }
    },
@@ -131,6 +131,7 @@
     "    plot_concentration_curve,\n",
     "    plot_equity_drawdown,\n",
     "    plot_sharpe_waterfall,\n",
+    "    resolve_canonical_rank1_lineage,\n",
     "    resolve_holdout_self_backtest,\n",
     "    write_strategy_assessment,\n",
     ")\n",
@@ -141,19 +142,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8364627d",
+   "id": "df7be3ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:02.221583Z",
-     "iopub.status.busy": "2026-08-31T18:18:02.221458Z",
-     "iopub.status.idle": "2026-08-31T18:18:02.223872Z",
-     "shell.execute_reply": "2026-08-31T18:18:02.223331Z"
+     "iopub.execute_input": "2026-09-01T05:35:16.391670Z",
+     "iopub.status.busy": "2026-09-01T05:35:16.391595Z",
+     "iopub.status.idle": "2026-09-01T05:35:16.393589Z",
+     "shell.execute_reply": "2026-09-01T05:35:16.393184Z"
     },
     "papermill": {
-     "duration": 0.008561,
-     "end_time": "2026-08-31T18:18:02.224359+00:00",
+     "duration": 0.00507,
+     "end_time": "2026-09-01T05:35:16.393913+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:02.215798+00:00",
+     "start_time": "2026-09-01T05:35:16.388843+00:00",
      "status": "completed"
     },
     "tags": [
@@ -172,13 +173,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3970729e",
+   "id": "b572dd8b",
    "metadata": {
     "papermill": {
-     "duration": 0.006407,
-     "end_time": "2026-08-31T18:18:02.236663+00:00",
+     "duration": 0.002187,
+     "end_time": "2026-09-01T05:35:16.398392+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:02.230256+00:00",
+     "start_time": "2026-09-01T05:35:16.396205+00:00",
      "status": "completed"
     }
    },
@@ -192,19 +193,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "785ae400",
+   "id": "fa874a6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:02.251733Z",
-     "iopub.status.busy": "2026-08-31T18:18:02.251326Z",
-     "iopub.status.idle": "2026-08-31T18:18:04.761303Z",
-     "shell.execute_reply": "2026-08-31T18:18:04.760780Z"
+     "iopub.execute_input": "2026-09-01T05:35:16.403349Z",
+     "iopub.status.busy": "2026-09-01T05:35:16.403285Z",
+     "iopub.status.idle": "2026-09-01T05:35:18.151972Z",
+     "shell.execute_reply": "2026-09-01T05:35:18.151550Z"
     },
     "papermill": {
-     "duration": 2.517938,
-     "end_time": "2026-08-31T18:18:04.761784+00:00",
+     "duration": 1.752079,
+     "end_time": "2026-09-01T05:35:18.152733+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:02.243846+00:00",
+     "start_time": "2026-09-01T05:35:16.400654+00:00",
      "status": "completed"
     }
    },
@@ -213,7 +214,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BacktestExplorer('etfs', 1290 runs: allocation=288, cost_sensitivity=34, holdout=1, risk_overlay=40, signal=927)\n"
+      "BacktestExplorer('etfs', 2235 runs: allocation=468, cost_sensitivity=68, holdout=1, risk_overlay=60, signal=1638)\n"
      ]
     }
    ],
@@ -235,13 +236,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec794c96",
+   "id": "58884044",
    "metadata": {
     "papermill": {
-     "duration": 0.002387,
-     "end_time": "2026-08-31T18:18:04.766662+00:00",
+     "duration": 0.004284,
+     "end_time": "2026-09-01T05:35:18.161777+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:04.764275+00:00",
+     "start_time": "2026-09-01T05:35:18.157493+00:00",
      "status": "completed"
     }
    },
@@ -257,19 +258,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "cc5708c7",
+   "id": "7f4e18cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:04.773230Z",
-     "iopub.status.busy": "2026-08-31T18:18:04.772902Z",
-     "iopub.status.idle": "2026-08-31T18:18:54.812416Z",
-     "shell.execute_reply": "2026-08-31T18:18:54.811852Z"
+     "iopub.execute_input": "2026-09-01T05:35:18.168735Z",
+     "iopub.status.busy": "2026-09-01T05:35:18.168662Z",
+     "iopub.status.idle": "2026-09-01T05:35:18.189504Z",
+     "shell.execute_reply": "2026-09-01T05:35:18.188993Z"
     },
     "papermill": {
-     "duration": 50.043502,
-     "end_time": "2026-08-31T18:18:54.812674+00:00",
+     "duration": 0.024211,
+     "end_time": "2026-09-01T05:35:18.190050+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:04.769172+00:00",
+     "start_time": "2026-09-01T05:35:18.165839+00:00",
      "status": "completed"
     }
    },
@@ -278,220 +279,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Live prediction sets: 257\n",
-      "[cohort_metrics] etfs (ppy=252)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  family: 13 cohorts\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [1/13] family stage=signal label=fwd_ret_21d family=linear leader=4456db56 K=78 K_eff_mp=3.0 K_eff_er=1.6975744551277836 dsr_er=0.031899779494152784 (0.2s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [2/13] family stage=signal label=fwd_ret_21d family=gbm leader=cdbe4855 K=450 K_eff_mp=4.0 K_eff_er=2.053043111263182 dsr_er=0.049039776384147964 (9.7s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [3/13] family stage=allocation label=fwd_ret_21d family=gbm leader=9725639d K=108 K_eff_mp=4.0 K_eff_er=2.7842869796825997 dsr_er=0.04193201001091844 (2.3s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [4/13] family stage=cost_sensitivity label=fwd_ret_21d family=gbm leader=0f7ee5f2 K=17 K_eff_mp=1.0 K_eff_er=1.0117163027112368 dsr_er=0.06020620348762341 (1.2s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [5/13] family stage=risk_overlay label=fwd_ret_21d family=gbm leader=fb287093 K=20 K_eff_mp=2.0 K_eff_er=2.4254114773915867 dsr_er=0.06257925276377653 (1.3s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [6/13] family stage=signal label=fwd_ret_21d family=deep_learning leader=b155df13 K=120 K_eff_mp=3.0 K_eff_er=2.3637346062947695 dsr_er=0.047207274451195096 (0.5s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [7/13] family stage=allocation label=fwd_ret_21d family=deep_learning leader=c797d871 K=36 K_eff_mp=4.0 K_eff_er=3.3371807973580876 dsr_er=0.04396867181922681 (2.2s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [8/13] family stage=cost_sensitivity label=fwd_ret_21d family=deep_learning leader=d887a5fd K=17 K_eff_mp=1.0 K_eff_er=1.0116932186080125 dsr_er=0.06317420352712469 (1.1s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [9/13] family stage=risk_overlay label=fwd_ret_21d family=deep_learning leader=342ef892 K=20 K_eff_mp=2.0 K_eff_er=2.400459317965626 dsr_er=0.05908338771397757 (1.0s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [10/13] family stage=signal label=fwd_ret_21d family=tabular_dl leader=bfa7b798 K=72 K_eff_mp=3.0 K_eff_er=1.7293513555773796 dsr_er=0.0413264039325915 (0.2s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [11/13] family stage=allocation label=fwd_ret_21d family=tabular_dl leader=3d676423 K=36 K_eff_mp=2.0 K_eff_er=2.4877340603087355 dsr_er=0.04103952110933623 (1.2s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [12/13] family stage=signal label=fwd_ret_21d family=latent_factors leader=c4642dcf K=51 K_eff_mp=2.0 K_eff_er=2.2524528678163 dsr_er=0.03845907993441784 (0.1s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [13/13] family stage=allocation label=fwd_ret_21d family=latent_factors leader=e9c7f7d0 K=18 K_eff_mp=1.0 K_eff_er=1.6449436984362167 dsr_er=0.04049062769942621 (1.1s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  stagelabel: 4 cohorts\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [1/4] stagelabel stage=signal label=fwd_ret_21d family=None leader=cdbe4855 K=771 K_eff_mp=9.0 K_eff_er=2.73628249149826 dsr_er=0.046859101548219026 (9.7s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [2/4] stagelabel stage=allocation label=fwd_ret_21d family=None leader=c797d871 K=198 K_eff_mp=9.0 K_eff_er=4.346596114312541 dsr_er=0.04134751012769011 (2.5s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [3/4] stagelabel stage=cost_sensitivity label=fwd_ret_21d family=None leader=d887a5fd K=34 K_eff_mp=2.0 K_eff_er=1.4658414477903818 dsr_er=0.05486749770941583 (1.1s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [4/4] stagelabel stage=risk_overlay label=fwd_ret_21d family=None leader=fb287093 K=40 K_eff_mp=3.0 K_eff_er=3.7340111918428045 dsr_er=0.0589513937088136 (1.1s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  label: 1 cohorts\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    [1/1] label stage=None label=fwd_ret_21d family=None leader=fb287093 K=1009 K_eff_mp=13.0 K_eff_er=3.580229599354818 dsr_er=0.06314021043144387 (9.4s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[cohort_metrics] etfs: family=13 stagelabel=4 label=1 errors=0 dangling_pruned=0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cohort_metrics: recomputed 18 rows across ['dangling_pruned', 'errors', 'family', 'label', 'stagelabel'] (11 row(s) led by a retired prediction)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  skip risk_overlay -> cost_sensitivity: the cost_sensitivity leader is not built on the risk_overlay leader\n",
-      "[paired_metrics] etfs: 5 pairs written, 0 skipped\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    + equal_weight_side_artifact: sharpe_diff=0.5586034094788075\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    + equal_weight_holdout_side_artifact: sharpe_diff=-1.221056280668593\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    + val_rank1_self: sharpe_diff=-0.9146324023057602\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    + signal_leader: sharpe_diff=-0.028951904363806347\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    + allocation_leader: sharpe_diff=0.34955578663785636\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "backtest_paired_metrics: wrote 5 pairs (missing equal_weight_holdout_side_artifact, val_rank1_self)\n",
-      "derived tables still hold 11 cohort row(s) and 2 pair(s) from retired generations; no reader below resolves either\n"
+      "Live prediction sets: 494\n"
      ]
     }
    ],
@@ -499,15 +287,15 @@
     "LIVE_PREDICTIONS = (\n",
     "    split_unpublished_members(\n",
     "        study,\n",
-    "        load_prediction_index(CASE_STUDY, label=PRIMARY_LABEL, split=\"validation\"),\n",
+    "        load_prediction_index(CASE_STUDY, split=\"validation\"),\n",
     "    )\n",
     "    .live[\"prediction_hash\"]\n",
     "    .to_list()\n",
     ")\n",
     "if not LIVE_PREDICTIONS:\n",
     "    raise RuntimeError(\n",
-    "        f\"no live prediction sets for {CASE_STUDY}/{PRIMARY_LABEL}/validation; run the model \"\n",
-    "        \"stage and 14_backtest first\"\n",
+    "        f\"no live prediction sets for {CASE_STUDY}/validation; run the model stage and \"\n",
+    "        \"14_backtest first\"\n",
     "    )\n",
     "print(f\"Live prediction sets: {len(LIVE_PREDICTIONS):,}\")\n",
     "\n",
@@ -607,6 +395,441 @@
     "    return stale_cohort, stale_paired\n",
     "\n",
     "\n",
+    "# §1 reports the configuration the validation stages ranked first, and the paired-metrics\n",
+    "# producer below has to be told what it is. Left to itself the producer ranks the registry on\n",
+    "# raw Sharpe, which is a second selector beside this one - it applies neither the common-support\n",
+    "# re-ranking a conformal candidate forces nor the restrictions the resolver holds. The two agree\n",
+    "# on this registry today, which is why the published rows are right; etfs now has a second fully\n",
+    "# backtested label, so agreement is a fact about this registry rather than a property of either\n",
+    "# ranking. So the selection is resolved here, before anything is written, and the two rankings\n",
+    "# are required to agree rather than assumed to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0d72c981",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T05:35:18.200319Z",
+     "iopub.status.busy": "2026-09-01T05:35:18.200176Z",
+     "iopub.status.idle": "2026-09-01T05:35:22.798487Z",
+     "shell.execute_reply": "2026-09-01T05:35:22.797908Z"
+    },
+    "papermill": {
+     "duration": 4.604982,
+     "end_time": "2026-09-01T05:35:22.799299+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T05:35:18.194317+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "_HOLDOUT_STAGES = (\"signal\", \"allocation\", \"risk_overlay\")\n",
+    "_FIELD = (\n",
+    "    pl.concat(\n",
+    "        [\n",
+    "            explorer.best(stage=s, top_n=2000, prediction_hashes=LIVE_PREDICTIONS)\n",
+    "            for s in _HOLDOUT_STAGES\n",
+    "        ],\n",
+    "        how=\"diagonal_relaxed\",\n",
+    "    )\n",
+    "    .filter(pl.col(\"family\") != \"benchmark\")\n",
+    "    .sort(\"sharpe\", descending=True)\n",
+    "    .unique(subset=[\"prediction_hash\"], keep=\"first\", maintain_order=True)\n",
+    ")\n",
+    "ADMITTED = frozenset(_FIELD[\"backtest_hash\"].to_list())\n",
+    "top_signal = _FIELD.head(1)\n",
+    "TOP_HASH = top_signal.row(0, named=True)[\"backtest_hash\"]\n",
+    "TOP_PHASH = top_signal.row(0, named=True)[\"prediction_hash\"]\n",
+    "RANK1_FAMILY = top_signal.row(0, named=True)[\"family\"]\n",
+    "RANK1_CONFIG = top_signal.row(0, named=True)[\"config_name\"]\n",
+    "# Every label the case study declares is backtested equal-weight and competes here; what wins\n",
+    "# decides the label everything below is keyed to. Reading `labels.primary` instead was only ever\n",
+    "# right by coincidence, and etfs has a second fully backtested label, so the coincidence is not\n",
+    "# one to rely on. The primary is kept as the declared value, to say when the two differ.\n",
+    "SELECTED_LABEL = top_signal.row(0, named=True)[\"label\"]\n",
+    "\n",
+    "# The resolver is given the same field, not the whole registry: it re-ranks on common timestamp\n",
+    "# support wherever a conformal candidate is present, so a row this notebook never admitted would\n",
+    "# otherwise decide how far the intersection reaches and therefore which admitted row wins.\n",
+    "CARRIER = resolve_canonical_rank1_lineage(CASE_STUDY, admitted=ADMITTED)\n",
+    "if CARRIER[\"val_backtest_hash\"] != TOP_HASH:\n",
+    "    raise RuntimeError(\n",
+    "        \"this notebook's ranking and the canonical resolver disagree on the carrier: \"\n",
+    "        f\"{TOP_HASH} against {CARRIER['val_backtest_hash']}. Everything below reports the \"\n",
+    "        \"first and the paired rows would be written against the second, so the decay would \"\n",
+    "        \"compare the right holdout against a different strategy.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "54c8b386",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-01T05:35:22.805360Z",
+     "iopub.status.busy": "2026-09-01T05:35:22.805203Z",
+     "iopub.status.idle": "2026-09-01T05:36:18.615792Z",
+     "shell.execute_reply": "2026-09-01T05:36:18.615427Z"
+    },
+    "papermill": {
+     "duration": 55.814049,
+     "end_time": "2026-09-01T05:36:18.616054+00:00",
+     "exception": false,
+     "start_time": "2026-09-01T05:35:22.802005+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[cohort_metrics] etfs (ppy=252)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  family: 25 cohorts\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [1/25] family stage=signal label=fwd_ret_21d family=linear leader=4456db56 K=78 K_eff_mp=3.0 K_eff_er=1.6975744551277836 dsr_er=0.031899779494152784 (0.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [2/25] family stage=signal label=fwd_ret_5d family=linear leader=19b52078 K=78 K_eff_mp=3.0 K_eff_er=1.7037293887851392 dsr_er=0.03613842718099892 (0.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [3/25] family stage=allocation label=fwd_ret_5d family=linear leader=0bbf342b K=36 K_eff_mp=2.0 K_eff_er=1.8327111870545678 dsr_er=0.04102787984274224 (1.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [4/25] family stage=signal label=fwd_ret_21d family=gbm leader=cdbe4855 K=450 K_eff_mp=4.0 K_eff_er=2.053043111263182 dsr_er=0.049039776384147964 (1.8s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [5/25] family stage=allocation label=fwd_ret_21d family=gbm leader=9725639d K=108 K_eff_mp=4.0 K_eff_er=2.7842869796825997 dsr_er=0.04193201001091844 (1.5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [6/25] family stage=cost_sensitivity label=fwd_ret_21d family=gbm leader=b8aa1cdd K=34 K_eff_mp=2.0 K_eff_er=1.381879198855917 dsr_er=0.07544591697336488 (1.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [7/25] family stage=risk_overlay label=fwd_ret_21d family=gbm leader=fb287093 K=20 K_eff_mp=2.0 K_eff_er=2.4254114773915867 dsr_er=0.06257925276377653 (1.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [8/25] family stage=signal label=fwd_ret_5d family=gbm leader=a334e079 K=438 K_eff_mp=8.0 K_eff_er=2.675821351923053 dsr_er=0.03311558586953407 (3.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [9/25] family stage=allocation label=fwd_ret_5d family=gbm leader=4162ab34 K=36 K_eff_mp=2.0 K_eff_er=2.0852009462802927 dsr_er=0.0358831020858736 (1.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [10/25] family stage=signal label=fwd_ret_21d family=deep_learning leader=b155df13 K=120 K_eff_mp=3.0 K_eff_er=2.3637346062947695 dsr_er=0.047207274451195096 (0.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [11/25] family stage=allocation label=fwd_ret_21d family=deep_learning leader=c797d871 K=36 K_eff_mp=4.0 K_eff_er=3.3371807973580876 dsr_er=0.04396867181922681 (1.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [12/25] family stage=cost_sensitivity label=fwd_ret_21d family=deep_learning leader=d887a5fd K=17 K_eff_mp=1.0 K_eff_er=1.0116932186080125 dsr_er=0.06317420352712469 (1.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [13/25] family stage=risk_overlay label=fwd_ret_21d family=deep_learning leader=342ef892 K=20 K_eff_mp=2.0 K_eff_er=2.400459317965626 dsr_er=0.05908338771397757 (1.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [14/25] family stage=signal label=fwd_ret_5d family=deep_learning leader=15299b68 K=60 K_eff_mp=2.0 K_eff_er=1.8370068651716327 dsr_er=0.04120444898446834 (0.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [15/25] family stage=allocation label=fwd_ret_5d family=deep_learning leader=a99028b3 K=18 K_eff_mp=2.0 K_eff_er=1.9983379630094584 dsr_er=0.04632137928955507 (1.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [16/25] family stage=signal label=fwd_ret_21d family=tabular_dl leader=bfa7b798 K=72 K_eff_mp=3.0 K_eff_er=1.7293513555773796 dsr_er=0.0413264039325915 (0.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [17/25] family stage=allocation label=fwd_ret_21d family=tabular_dl leader=3d676423 K=36 K_eff_mp=2.0 K_eff_er=2.4877340603087355 dsr_er=0.04103952110933623 (1.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [18/25] family stage=signal label=fwd_ret_5d family=tabular_dl leader=b6f6b43e K=72 K_eff_mp=3.0 K_eff_er=1.8760917088906819 dsr_er=0.037334595457228066 (0.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [19/25] family stage=allocation label=fwd_ret_5d family=tabular_dl leader=0db4f062 K=18 K_eff_mp=2.0 K_eff_er=2.1348078124009677 dsr_er=0.03396442072336022 (1.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [20/25] family stage=signal label=fwd_ret_21d family=latent_factors leader=c4642dcf K=51 K_eff_mp=2.0 K_eff_er=2.2524528678163 dsr_er=0.03845907993441784 (0.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [21/25] family stage=signal label=fwd_ret_5d family=latent_factors leader=536dfc6e K=51 K_eff_mp=2.0 K_eff_er=2.2443400259685182 dsr_er=0.04520385652960712 (0.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [22/25] family stage=allocation label=fwd_ret_5d family=latent_factors leader=719fb3e8 K=72 K_eff_mp=5.0 K_eff_er=3.5489427987295588 dsr_er=0.04926157765239922 (1.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [23/25] family stage=allocation label=fwd_ret_21d family=latent_factors leader=e9c7f7d0 K=18 K_eff_mp=1.0 K_eff_er=1.6449436984362167 dsr_er=0.04049062769942621 (1.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [24/25] family stage=risk_overlay label=fwd_ret_5d family=latent_factors leader=2fd43050 K=20 K_eff_mp=2.0 K_eff_er=3.1986401356491303 dsr_er=0.058643836815128914 (1.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [25/25] family stage=cost_sensitivity label=fwd_ret_5d family=latent_factors leader=92d84ee4 K=17 K_eff_mp=1.0 K_eff_er=1.0050329414312755 dsr_er=0.07910872253816342 (1.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  stagelabel: 8 cohorts\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [1/8] stagelabel stage=signal label=fwd_ret_21d family=None leader=cdbe4855 K=771 K_eff_mp=9.0 K_eff_er=2.73628249149826 dsr_er=0.046859101548219026 (4.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [2/8] stagelabel stage=signal label=fwd_ret_5d family=None leader=536dfc6e K=699 K_eff_mp=11.0 K_eff_er=3.3629044262781194 dsr_er=0.039870799677865 (3.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [3/8] stagelabel stage=allocation label=fwd_ret_5d family=None leader=719fb3e8 K=180 K_eff_mp=10.0 K_eff_er=5.005994109174936 dsr_er=0.04284007013869561 (2.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [4/8] stagelabel stage=allocation label=fwd_ret_21d family=None leader=c797d871 K=198 K_eff_mp=9.0 K_eff_er=4.346596114312541 dsr_er=0.04134751012769011 (2.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [5/8] stagelabel stage=cost_sensitivity label=fwd_ret_21d family=None leader=b8aa1cdd K=51 K_eff_mp=3.0 K_eff_er=1.8191931120313556 dsr_er=0.07129946924327457 (1.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [6/8] stagelabel stage=risk_overlay label=fwd_ret_21d family=None leader=fb287093 K=40 K_eff_mp=3.0 K_eff_er=3.7340111918428045 dsr_er=0.0589513937088136 (1.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [7/8] stagelabel stage=risk_overlay label=fwd_ret_5d family=None leader=2fd43050 K=20 K_eff_mp=2.0 K_eff_er=3.1986401356491303 dsr_er=0.058643836815128914 (1.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [8/8] stagelabel stage=cost_sensitivity label=fwd_ret_5d family=None leader=92d84ee4 K=17 K_eff_mp=1.0 K_eff_er=1.0050329414312755 dsr_er=0.07910872253816342 (0.9s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  label: 2 cohorts\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [1/2] label stage=None label=fwd_ret_21d family=None leader=fb287093 K=1009 K_eff_mp=13.0 K_eff_er=3.580229599354818 dsr_er=0.06314021043144387 (4.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    [2/2] label stage=None label=fwd_ret_5d family=None leader=2fd43050 K=899 K_eff_mp=17.0 K_eff_er=4.3436740144482195 dsr_er=0.0581803786432725 (6.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[cohort_metrics] etfs: family=25 stagelabel=8 label=2 errors=0 dangling_pruned=0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cohort_metrics: recomputed 35 rows across ['dangling_pruned', 'errors', 'family', 'label', 'stagelabel'] (11 row(s) led by a retired prediction)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[paired_metrics] etfs: 6 pairs written, 0 skipped\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    + equal_weight_side_artifact: sharpe_diff=0.5586034094788075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    + equal_weight_holdout_side_artifact: sharpe_diff=-1.221056280668593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    + val_rank1_self: sharpe_diff=-0.9146324023057602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    + signal_leader: sharpe_diff=-0.028951904363806347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    + allocation_leader: sharpe_diff=0.34955578663785636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    + risk_overlay_leader: sharpe_diff=0.07297148309889478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "backtest_paired_metrics: wrote 6 pairs (2 pair(s) challenged by a retired prediction)\n",
+      "derived tables still hold 23 cohort row(s) and 2 pair(s) from retired generations; no reader below resolves either\n"
+     ]
+    }
+   ],
+   "source": [
     "have_kinds, have_cohorts = _derived_table_state()\n",
     "stale_cohort, stale_paired = _stale_derived_rows(LIVE_PREDICTIONS)\n",
     "missing_kinds = sorted(set(PAIRED_KINDS) - have_kinds)\n",
@@ -632,7 +855,7 @@
     "        if missing_kinds\n",
     "        else f\"{stale_paired} pair(s) challenged by a retired prediction\"\n",
     "    )\n",
-    "    rows = populate_paired_metrics(CASE_STUDY, prediction_hashes=LIVE_PREDICTIONS)\n",
+    "    rows = populate_paired_metrics(CASE_STUDY, prediction_hashes=LIVE_PREDICTIONS, carrier=CARRIER)\n",
     "    written = sum(1 for r in rows if \"skip\" not in r)\n",
     "    print(f\"backtest_paired_metrics: wrote {written} pairs ({reason})\")\n",
     "else:\n",
@@ -750,13 +973,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "740f46f2",
+   "id": "a5340005",
    "metadata": {
     "papermill": {
-     "duration": 0.002693,
-     "end_time": "2026-08-31T18:18:54.818240+00:00",
+     "duration": 0.002998,
+     "end_time": "2026-09-01T05:36:18.622337+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:54.815547+00:00",
+     "start_time": "2026-09-01T05:36:18.619339+00:00",
      "status": "completed"
     }
    },
@@ -779,20 +1002,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "82b5a481",
+   "execution_count": 7,
+   "id": "08e151fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:54.824193Z",
-     "iopub.status.busy": "2026-08-31T18:18:54.824105Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.011335Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.011005Z"
+     "iopub.execute_input": "2026-09-01T05:36:18.628884Z",
+     "iopub.status.busy": "2026-09-01T05:36:18.628799Z",
+     "iopub.status.idle": "2026-09-01T05:36:18.631782Z",
+     "shell.execute_reply": "2026-09-01T05:36:18.631468Z"
     },
     "papermill": {
-     "duration": 0.19077,
-     "end_time": "2026-08-31T18:18:55.011725+00:00",
+     "duration": 0.006837,
+     "end_time": "2026-09-01T05:36:18.632167+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:54.820955+00:00",
+     "start_time": "2026-09-01T05:36:18.625330+00:00",
      "status": "completed"
     }
    },
@@ -813,25 +1036,6 @@
     }
    ],
    "source": [
-    "_HOLDOUT_STAGES = (\"signal\", \"allocation\", \"risk_overlay\")\n",
-    "top_signal = (\n",
-    "    pl.concat(\n",
-    "        [\n",
-    "            explorer.best(stage=s, top_n=2000, prediction_hashes=LIVE_PREDICTIONS)\n",
-    "            for s in _HOLDOUT_STAGES\n",
-    "        ],\n",
-    "        how=\"diagonal_relaxed\",\n",
-    "    )\n",
-    "    .filter(pl.col(\"family\") != \"benchmark\")\n",
-    "    .sort(\"sharpe\", descending=True)\n",
-    "    .unique(subset=[\"prediction_hash\"], keep=\"first\", maintain_order=True)\n",
-    "    .head(1)\n",
-    ")\n",
-    "TOP_HASH = top_signal.row(0, named=True)[\"backtest_hash\"]\n",
-    "TOP_PHASH = top_signal.row(0, named=True)[\"prediction_hash\"]\n",
-    "RANK1_FAMILY = top_signal.row(0, named=True)[\"family\"]\n",
-    "RANK1_CONFIG = top_signal.row(0, named=True)[\"config_name\"]\n",
-    "\n",
     "_db = CASE_DIR / \"run_log\" / \"registry.db\"\n",
     "with sqlite3.connect(str(_db)) as _con:\n",
     "    _row = _con.execute(\n",
@@ -842,7 +1046,7 @@
     "    ).fetchone()\n",
     "ic_mean, ic_lo, ic_hi, ic_t, ic_p, ic_ndays, ic_lag, ic_pct = _row\n",
     "\n",
-    "print(f\"Rank-1: family={RANK1_FAMILY}, config={RANK1_CONFIG}, label={PRIMARY_LABEL}\")\n",
+    "print(f\"Rank-1: family={RANK1_FAMILY}, config={RANK1_CONFIG}, label={SELECTED_LABEL}\")\n",
     "print(f\"        prediction_hash={TOP_PHASH}, backtest_hash={TOP_HASH}\")\n",
     "print()\n",
     "print(\"Daily-pooled IC (validation):\")\n",
@@ -854,13 +1058,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbdc0f91",
+   "id": "129bf6be",
    "metadata": {
     "papermill": {
-     "duration": 0.002739,
-     "end_time": "2026-08-31T18:18:55.017443+00:00",
+     "duration": 0.003019,
+     "end_time": "2026-09-01T05:36:18.638171+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.014704+00:00",
+     "start_time": "2026-09-01T05:36:18.635152+00:00",
      "status": "completed"
     }
    },
@@ -884,13 +1088,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bfafe51f",
+   "id": "2a76cd15",
    "metadata": {
     "papermill": {
-     "duration": 0.002619,
-     "end_time": "2026-08-31T18:18:55.022759+00:00",
+     "duration": 0.00293,
+     "end_time": "2026-09-01T05:36:18.644125+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.020140+00:00",
+     "start_time": "2026-09-01T05:36:18.641195+00:00",
      "status": "completed"
     }
    },
@@ -909,20 +1113,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "d7a6b025",
+   "execution_count": 8,
+   "id": "fb681edb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.028734Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.028650Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.145692Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.145297Z"
+     "iopub.execute_input": "2026-09-01T05:36:18.650805Z",
+     "iopub.status.busy": "2026-09-01T05:36:18.650710Z",
+     "iopub.status.idle": "2026-09-01T05:36:18.931023Z",
+     "shell.execute_reply": "2026-09-01T05:36:18.930627Z"
     },
     "papermill": {
-     "duration": 0.120616,
-     "end_time": "2026-08-31T18:18:55.146051+00:00",
+     "duration": 0.28427,
+     "end_time": "2026-09-01T05:36:18.931412+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.025435+00:00",
+     "start_time": "2026-09-01T05:36:18.647142+00:00",
      "status": "completed"
     }
    },
@@ -938,11 +1142,11 @@
       "│ ---                         ┆ ---    │\n",
       "│ str                         ┆ str    │\n",
       "╞═════════════════════════════╪════════╡\n",
-      "│ Total signal backtests      ┆ 771    │\n",
-      "│ Mean Sharpe                 ┆ 0.479  │\n",
-      "│ Median Sharpe               ┆ 0.484  │\n",
-      "│ P90 Sharpe                  ┆ 0.617  │\n",
-      "│ % positive Sharpe           ┆ 100.0% │\n",
+      "│ Total signal backtests      ┆ 1,470  │\n",
+      "│ Mean Sharpe                 ┆ 0.434  │\n",
+      "│ Median Sharpe               ┆ 0.450  │\n",
+      "│ P90 Sharpe                  ┆ 0.596  │\n",
+      "│ % positive Sharpe           ┆ 99.5%  │\n",
       "│ Top-by-Sharpe in this sweep ┆ 0.830  │\n",
       "│ Top-by-Sharpe percentile    ┆ 100.0% │\n",
       "└─────────────────────────────┴────────┘\n"
@@ -968,20 +1172,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "edb35299",
+   "execution_count": 9,
+   "id": "341a23ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.152890Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.152737Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.160028Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.159523Z"
+     "iopub.execute_input": "2026-09-01T05:36:18.938361Z",
+     "iopub.status.busy": "2026-09-01T05:36:18.938260Z",
+     "iopub.status.idle": "2026-09-01T05:36:18.946560Z",
+     "shell.execute_reply": "2026-09-01T05:36:18.946196Z"
     },
     "papermill": {
-     "duration": 0.011327,
-     "end_time": "2026-08-31T18:18:55.160564+00:00",
+     "duration": 0.01223,
+     "end_time": "2026-09-01T05:36:18.946955+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.149237+00:00",
+     "start_time": "2026-09-01T05:36:18.934725+00:00",
      "status": "completed"
     }
    },
@@ -997,11 +1201,11 @@
       "│ ---            ┆ --- ┆ ---           ┆ ---        ┆ ---        ┆ ---        ┆ ---          │\n",
       "│ str            ┆ u32 ┆ f64           ┆ f64        ┆ f64        ┆ f64        ┆ f64          │\n",
       "╞════════════════╪═════╪═══════════════╪════════════╪════════════╪════════════╪══════════════╡\n",
-      "│ deep_learning  ┆ 120 ┆ 0.552737      ┆ 0.470588   ┆ 0.608157   ┆ 0.82009    ┆ 100.0        │\n",
-      "│ tabular_dl     ┆ 72  ┆ 0.540976      ┆ 0.459494   ┆ 0.646378   ┆ 0.70409    ┆ 100.0        │\n",
-      "│ gbm            ┆ 450 ┆ 0.48336       ┆ 0.414337   ┆ 0.540908   ┆ 0.829972   ┆ 100.0        │\n",
-      "│ latent_factors ┆ 51  ┆ 0.456659      ┆ 0.401196   ┆ 0.518595   ┆ 0.675562   ┆ 100.0        │\n",
-      "│ linear         ┆ 78  ┆ 0.38652       ┆ 0.329161   ┆ 0.441738   ┆ 0.542015   ┆ 100.0        │\n",
+      "│ deep_learning  ┆ 180 ┆ 0.541641      ┆ 0.46654    ┆ 0.601555   ┆ 0.82009    ┆ 100.0        │\n",
+      "│ latent_factors ┆ 102 ┆ 0.519974      ┆ 0.447733   ┆ 0.596431   ┆ 0.770525   ┆ 100.0        │\n",
+      "│ tabular_dl     ┆ 144 ┆ 0.461838      ┆ 0.35058    ┆ 0.562468   ┆ 0.70409    ┆ 98.611111    │\n",
+      "│ gbm            ┆ 900 ┆ 0.432401      ┆ 0.33523    ┆ 0.49916    ┆ 0.829972   ┆ 99.444444    │\n",
+      "│ linear         ┆ 156 ┆ 0.392353      ┆ 0.312382   ┆ 0.475464   ┆ 0.615671   ┆ 100.0        │\n",
       "└────────────────┴─────┴───────────────┴────────────┴────────────┴────────────┴──────────────┘\n"
      ]
     }
@@ -1050,27 +1254,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "7849b9fd",
+   "execution_count": 10,
+   "id": "4dac484d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.172322Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.172214Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.247867Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.247480Z"
+     "iopub.execute_input": "2026-09-01T05:36:18.954145Z",
+     "iopub.status.busy": "2026-09-01T05:36:18.954051Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.061149Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.060546Z"
     },
     "papermill": {
-     "duration": 0.082194,
-     "end_time": "2026-08-31T18:18:55.248454+00:00",
+     "duration": 0.112437,
+     "end_time": "2026-09-01T05:36:19.062806+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.166260+00:00",
+     "start_time": "2026-09-01T05:36:18.950369+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3MAAAF/CAYAAADjFJAoAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAVMxJREFUeJzt3XmAzPUfx/HXXHuya3fdN4t1HwkJFZLKUVRISIQoUlFyJFEUuogcIaRc+cnRoahUWCGRex3rWDe77DXn7w/tZrFrHbuzM/t8/JWZ7/GemW+z8/p+Pt/312C1JrsEAAAAAPAoRncXAAAAAAC4cYQ5AAAAAPBAhDkAAAAA8ECEOQAAAADwQIS5LLZkxU8a8d6nWbqPFT/8qi69B2fpPrJDmy79tW7jVneXkWrz1h1q1rbnLW9n1ryleuCxnureb7hcrtvXb2jEe59qyYqfJN16rVarTV16D9buvQduV3k52pRZCzVl1kJJUszxU6rfvJMuXIx3c1U5w/nYC257P06dOaeOPV7TqTPnsn3fAAB4IrO7C/AGMcdP6f3Js7V1+24FBvjrzlpV1fuZdgoNCVabFk3VpkVTd5d4TTHHT6nPq29ryewPs22fq9dG6rM5X+v4ydMqVrSQHn2osR5t0URGo3eeV4iPT9DU2Ys0fuQA1bmjqgwGw23b9vBXn7tt2/LxsWj25Hcyvfz0OYslSc92fuy21ZCV6jfvpHXfz039d6+uT7ixGqSnQFiI5k17191lAADgMQhzt8HwdyepdMmiWjjzfblcLv1v5WrFnDit0JBgd5eWoxyMPqo3Rn+iMW/0V73a1XTo8DGtXLVWNrtdvj4+7i4vS8RdiJfL5VKViuVkNpncXQ4AAAC8CGHuNog6eFhPd2it4KA8kqSuTz6S+tzCpT9ozW+RmjR2qCRp3cat+njqF4o+EiOn0yUfH4seaHy3hrzcQ/Wbd9Kn44fp05kLtHd/tBrVr61hA3rKaDTq9Jlz+mzuEm3csl1xFy6qyT31NOCFrpkKCIcOH9Oo8dO0/+BhFStaSH17PCmL2awXB78rq9WmJo90V4N6tTRy8AvauGW75i5Yrt37DirA31/9n+uke+6uLUk6fPS43v1ohrbt2CurzSaz2aQihQpowYxxOh97Qe9Pmq0Nm7YpNCRIL/Xuorp3VE1Tx8HoY8oXnEd31akus8mkcmVLql+vp9Isc+TYCb005D39s2ufqlYqr1FD+irA308X4xP0+ZffaO36zTpz9rzq1KqiIa/0VGCAvzZv3aFPZy1U6wfv0/Q5X6vH049JLmn12g0qU6q4vl/9h3wsZvV8+gk1b3K3JGWqXklyupz6cvFKLfpmlaw2u55s+5A6Pv6wvvnuZy3//hdN/WB46rKvDBunBnVrqm2r+yVJMSdO68mer0mSHnmqn7o99ajatGya4euYPHOBWj5wr+YsWCaTyaSBfbsqNu6iZsxdonPn49S3Z0c9dH9DSdLgkR+pbOniV42OZVRb5Yrheu3NDzTtozdVMH9omvUefOI5vTO0n+6oUVnT5yxWQmKyzCajvl/9h8xmk94Y+JxqVI3QmI8+0/LvfpHBaNC8RSs14vXn1eiuO7Tprx36eNoXijl+SrWqV9Lr/Z9VvuC8WvHDr4rcvF1lShXTwqU/aOTrz6t61QjNmLtE33y3RmaTWQ81a6hFS1dp1ddTJV2actv/uU669+47r3qtN3osjJ0wS5LU5JHuCi9TQtM+fFMfT52n2LgLGjag11Wfud3h0Mwv/qdl3/8sgwxq3+ZBdXz84auWq9+8k6a8/4bGTZyliPJlNPCFrvry62/148/rFXPilCpVKKvhrz6n/GEhijl+Sj1eelNDXu6pabMX6fDRE2rToon6dO8gSUpKStbYibP06x+bdDE+QUajQb4+Ppo9+R0VLpT/uvW4XC4tWf6Tlv/wi6KPHFfJ4kX0xsDnVLpk0dRa0/tucblcWrj0B325eKXsDqea3lPvqteaok2X/nq5d2fNX/K9og4e1sPNGqndI8313oRL3wt1alXViEF9ZDab0/3Oksulp58fqvaPNlfrhxrr8NHj6t5vuL6YOkaBAf5q+uiz+vrzD1SkcAGNHDdFZUoV0/6DR7Ru49Z/39PemjZ7sVb/ukGFC+XX20P7qUih/Nq8dYdeG/Fh6jGUkJh009sCAMBTeOfctmzWqvl9evv9aZq/5DvFxyeku1zchXgNGfWxOrVrqZXzJ6nRXXeoc7uWGvJyj9RlZs//RiMG9dGcye/ohzW/a9PWHZIkp8uliPKlNWPCSM2dMka//P6nfv1jU6bqm/L5IpUpVVQrF0zSW4OeV8H8oapZraI+GDVQhQvl1+qln2nk4BckSfEJiXqm46NaNm+iuj7ZWqPGT5XVapMkjRo/VSWLF9HyryaqR5fHVK1yeS2YMU4ul0vDx3yivHkC9M28j/Xmq701ctwUXbzivbijRmX5WHzU97XR2rhl+zWvH1u5aq36P9dJC2eO1649B/Tjz+skSUajUWGh+TRp3BB9PfsDHYw+pv+tWJ26XtSBw9q45R/NnTJaDzW9FHY2bd2pMqWKadGs8erfu7NGjZ+i4ydPZ7peSUpMTJbLJc2dMlqjh72oabMX6+9/9qjpPfW0b3+0jh0/KenSD8fNW3fqvkZ1UtctUii/vpx6acrYN/M+Vuf2ra77OnbsjtLxk6c199PRuqd+bQ0a8aH+/me3pn7whrp3bqP3J82Ww+HM8PPOqLYAfz+VLF4kUyOhS1euVrmyJbVw5njVqVVVk2fMlyQNerG7mjdtoKc7tNbqpZ+p0V136MixExr01od6vvuTWjl/ksqWKq5PPvsqdVt/RP6l87EXtPjzD1SreiUtXPqDfljzhyaNHaovp7+r5CTrdetJcaPHQspnsHrpZ5r24ZvX3f7cBcsVuXmbZk0cpZkTR2rlj2v117Zd11x2wrR5enf4S3q9f3eZTCb5+Fg09q2XtfyrT+SSS7O+/CZ12TNnY/XTrxv0/qhXNe6tVzRnwXIdPnpckvT5V9/o0OFj+nLau/p4zCAFBvhr6Rcfq3jRQpmqx2AwyCWXhr/aW98umKwypYppwrR5aZZJ77vl5982asYXSzRqSD8tmjVehQtmHGY+/+obDX75WU0aO1TzFq3UsNET9cKzHfXltPe0/s+/9dv6LZLS/84ym816tV83fTpzoS5cjNfUzxepc7uWKhAWcs39fbn4W7Vodo8WzRyv6CMx6vr8ENW7s5qWzP1QFotZXy5emWG9WbUtAAByAsLcbfBir6c04IWuWv79r2rVsa9mzVsqm81+1XIxx0/K6XLpwSYNFRyUV/ffd5d27knbcKLn00+oYIEwFSlcQGVKFVf0kRhJUsH8oXr04SZyuZw6fOS4CoSFZLpZRaECoYo+HKOzZ2NVumRRlSpRNN1l72tQRzWqRijmxCmZzWZduBiv4ydPS5L2HYjWw80aKW+eQLV+8D7t+rf2I8dOaPPfO/VCjyfl6+OjiPJlFFGutP7ZFZVm20F5AzXn03dUtWI5DRn1sZ7qOUib//1BmeLpJ1urVImiCg7KqyqVwhX974/dAH8/dWj7oHwtFu0/eET5w0K0e9/B1PXsdodeef5p5QkMSL3+rmSxwmrR7B75+vio0V13qHzZUorctC3T9UpSYIC/Oj7+sPz9/FS1UjndXbeG1m3cqsAAfzVpVFc/rLkUNjf8+beqViqn0HwZT6293uvw9/NTr65PyM/PV3fXq6n4hET1f66zAgMD1KBeLV2MT9DZ87EZ7iOj2koWL6IJ776eOoqckdo1KuuBxnfLx8eiu+6srugjx9NddsUPv6pBvZqqe0dVmc1mdWj7oNZf1szG399Xz3fvID9fHxkMBi1duUbPPPWoShYvIn8/P93b4M7r1pPiZo6FG/H18h/Vo8vjCg0JVmhIsB6+v1G6jXm6PdVGRQoXkNFolMlk1JNtH1K+oLyKOhCt/KH50tQlSf16PqV8wXlVrXJ5BQb4p4a5fQeidc/dtZU/LER1alVVSL4gHTl24obqeaxVMxUtXFD7Dx1RUN5A7bli3+l9t3zz3c964pEHVKViuHx9fNTkshMS19KpXUsVLVxQZUoVU9HCBdT6wftUplQxhYXmU6UKZXXw8DFJGX9n1ahSQQ3uqqU3352s3fsOqn2bB9Pd3/331lPtmpUVGBigmtUqqlb1Smp01x3y9fFR3TsuTdfOrNu5LQAAcgKmWd4GBoNBTRrVVeOGdRS5ebvGTZylE6fO6LUXu6VZrkyp4sobGKBl3/+se+rX1nc//a4qFctdta0UQXkDZbM5JEmxcRc1+sPp2rc/WjWrRshsNikp+erRjHUbt2rIqI8lSfnDQrRgxjj1fqa9ln67Rs+/+o6qVymv555pl+7Z98hN2/TR1C/k5+urO2tWlqTU/dS7o5q++W6NShQrpK+X/6TKEeGSpGPHT8nhcKp1x36p27HZ7alTGi8XGOCv55/toG6dHtX8Jd+r36Axmjx+mKpVLn+N158nNRQnW60a/8nn2rh5e+qyyZe9fh8fi4LyBl7zNaUIyZdXsXEXb6jeK+XLF6S4CxclSa0evE/vfjRDT3dorV/XbVbTe9Ofnpbieq/jys//8seC8l4KYPZrnCi40s3UdqWrjkV7+vs9GnNSv/z+p37fcKmjpsvlSjPymi8oryyW/75uYk6cUqni6Z9UyMjtOBbSY7PZder0Ob0+8kMZDZeCoMPhSJ3aeqWw0Hyp/+10OvXpzAVa9fM6VQgvLZPJqOTk5DTLp7ylRqNReS97T+veUU0rV61V88YNtP/QEZ09F6eSxQrfUD1ffv2tFv7vB5UsXlj5w0Ku+n5I77sl5sRpPdysUabfoyv/H71yu/Z/X9P1vrMeaFxf/QaNUZ9u7eXjY8loj2n2Fxt3Ie3ryOC4zNptAQDgfoS528hgMKhe7Wrq3qmN5sxfftXzPj4W1a1dTV8v+1FTP1+k+nVq6KlrXItzLZNnzpePxaKFM8fLYDBo5Lgp11yufp0aWr30s6v2+8QjD6hNiyaaOP0rvfP+dH08ZpBkMMjl/O8Ht81m16C3PtQ7w17UXXdWlyTNnr8s9fkG9Wpp1pdL1bHnIJUpWUyD+neXdGk6oY+PRcu/mpjpRib+fn7q+uQj2vTXDv39z57UH+Xp+err7xR9OEYLZ46X2WzW9DmLtTcqOlP7ki6Fi+gjx9XigXtvqt4U0YdjUt+b6lUqyOF0/Dutb5v69ex43fVv9XVk1s3UdiMMkpyXHTtFCuXXA03uTjNlOCNhIfl04tQZVa1U7prPW8xmxV34rzX+5VNLb/g9/DdsOJ3O647UWSxm5Q/Np5GDX1DNahUz9VpS/PjLeq35baO+mPquAvz9tOKHXzV/yXeZWrfuHVU1d8Fy9Rk4Sr4+Pho5+AUFBgZIUqbq2bZjr2bMXaL5n41VaEiwNm/doV9+/zNT+w4LCdaJU2cyteyNyOg761LwXainO7TWgqU/qG3Lpqmv92aZzWYlJiUr2WqVr4+PHA7Hrb4EAAByPKZZ3qKog4fVo/8Ibdm2S8lWqw4dPqZVP69XzWoRVy0bH5+gH39erw/eflUr50/SsAG95Ofnm6n9xMZelN3hkNVm01/bdqWZnujjY1Gy1XbNa9DsDodmz/9Gx46flMPplMVsltV66ex4WEiwTp4+q+gjMUq2WpVstSoxKVlJyclKTErS3IVpA+nCpT/o+Wc7aPmXEzXxvcEqXrSQJKlEscKqWrGcxn48Uxcuxuvs+dhrTgOb8vlCfTB5to7GnFSy1aoNm7ZpT9QhVa9SIROv/4IcTpdsdrv27Y/WL79f/3rBE6fOavPWHbLZ7Ppy8bdKSkrWXXdWz3S9kpSYlKxf/vhTdrtdP/6yXv/s2qdmjetLuhTeWz5wryZO/1LlypRUSL6gLHkdmeHj4yOb3Z4aetKr7fDR4+o3aEyaoHQzQkPzafvOfUpKSpbValOLB+7R6rUb9PNvG2V3OLRvf7T2RB1Kd/37GtbRnPnLdPrMOZ07H6cF//s+zfMlihXSusi/dDE+Qf9buTr1+i7pxt/D4KA8MhmN+vOvHUq2Xj2anTIqlHJt6KMtmuqjKV/oyLETSkpK1rqNW5WQmHTd9yQ27qLsdrvsdoeOxpzUtz/+dt11UixduUZN7qmrBTPGa960d1NPGGS2nvNxF2S3O2Sz2XX2XKyWXHYN4fXc17COFi/7UdFHYnQxPkFfLLo9141l9J217Ltf5O/nq15dn9Ad1StpyueLbnl/xYoUlNPp1LrIrTp56ozGTpgpo/H23QoEAICciDB3i8qWKq7HWzfTlJkL1OrJF/TCa6NVtHABPf/sk1ctGxgYoMoVw9Wu+wA1bt1dzdr21DMvDNPWf/Zcdz9dn2ytqAOH9WinF7Vi1Vo1uazj3KUz9i4tXvbjVeuZjEYF582rgW+8r4fb9dGWbTsvdZSTVKpEUbV+6D516/uG3hwzWXkCA9S7WzuNGjdV3fq+obyBgSpZvHDqthrUq6UR736qJo88q6aPPqsnnnlFS1b8dOms++AX5HA61a7bAHXpPVir10Zedd1gp8dbSDJowBvj9NATvTVh2jwNfKHrdUflJOmJRx6Q3W7XI0/104wvlmRqSmSeQH99893PatGhj378ZZ3GvfWKAvz9Ml2vJJUtXVybt+5Qq459NfOL/+ndN19K0wXywfsbauOW7Wk+j9v9OjKjQngplSlZTJNm/Nd05Fq1XYxP0KHDx5R0xfS/G9Xm4SY6dz5Oj3Z+UWt+26iSxYto7Jsva/b8b9T8sV4a+s5EHYw+mu763Tu1UdnSxdWx5yC9+PoYlStbMs3zz3Z+THv3R6vDswN14uQZtW35370ab/Q9DPD3U7dObTR45Ed6fuDbcjrTNpAJC82nu+vW1PuTZkuSnu7QSg3q1VTf195R66f6av6S73Q+Nu6678mDTRuoWJFCatulv8ZOmKkH/g39mdGgXi19vewn3d+mh5o80l2tOvbV2Imz5HA4M1XPXbWrq37dGurY8zW9PvIj3dcw4+veLtemRRPd1+BO9Xr5LXXvN1zly5aUn2/mTjJlJL3vrNi4C5oya6H69XpKBoNBfXs8qe9++k079+y/pf2FhebTs53b6u33p2nA8Pf16MNNrnsNKwAAns5gtSZfPZyDLLH57536avG3GjO8v4xGo+LjEzTuk9mKj0/QeyNednd5GboYn6BeL7+lT8cPU948gbLZ7Fr23c+aNGO+flwyzd3lXSVlituN3Aj7ZsTGXdATz7yihTPHKzgob5bu60bl5NqutHPPfvUbNCa1rXxu88Jr76hPt/aqHBEup9Opvfuj1a3vMM2YMFIR5Uq7uzwAAJBDMTKXjQ4eOqrzcRcUfeS4bDa7DkQf04FDR1S96vWnGbrb6TPndObsee0/dFRWq03Hjp/U9l37VMMDas8KLpdL8QmJmjB1ntq0aJqjwlJOrg3Xtv/gER2IPqqL8Qk6dz5Om//eqeC8eVWiWOHrrwwAAHItGqBko4cfuEd79h9SnwGjlJiUrEIFw9T6wfvUoW36bblzilIliqrrk4/qrfcm6/TZ8woJDlLDu+5Q/+c6u7s0tzgYfUzP9h+uWtUqqX/vnPUe5OTacG1vvtpbk2bM19gJsxTg76dqlctr4nuDFeDv5+7SAABADsY0SwAAAADwQEyzBAAAAAAPRJgDAAAAAA9EmAMAAAAAD0SYuwUul0t2u/2aN+sGAAAAgKxEmLsFDodDjVp0lcPhcHcpki7Vs3Xr3zmmHgAAAABZhzDnRRwOp7Zt2yaHw+nuUgAAAABkMcIcAAAAAHggwpwXMZmMqlatmkwmPlYAAADA25ndXQBuH5PJpBo1qru7DAAAAADZgCEcL2K32/XTT6tlt9vdXQoAAACALEaY8yJOp0sxMTFyOrlVAgAAAODtCHMAAAAA4IEIcwAAAADggQhzXsRkMqpevXp0swQAAAD+FRcZKXtsbIbL2GNjFRcZmU0V3T786vciJpNJ5cuXk8lkcncpAAAAgNvFRUZqb+8+2tOjZ7qBzh4bqz09empv7z4eF+gyHeZee/MDbd66I8sKGTluilavzbo3b8R7k3X6zLks235OYLPZtGzZctlsNneXAgAAALhdQESE/MPDlbBr1zUDXUqQS9i1S/7h4QqIiHBTpTcn14zMDX+1t/KHhbi7jCzlckmxsbFy0cwSAAC3OHPBprW7YnXmAidWgZzAHBysCtOmKqBixasC3eVBLqBiRVWYNlXm4GA3V3xjMrxp+MKlP2jB/75XoYJhOncuTpL02/otmvTZV3I4HXqm46N6sGlDnT0Xq7fGfqqYE6dVvmxJDX+1t7bt2KO5C1fIYjbr4OFjqlOrql55vosMBsN1i4o+EqNR46cqNu6C6tWurpd6d9bxk2f0/qTPdeLkGVksFo0Z3l8FwkLUZ+AoNW/cQEtW/KRRQ/rqtREfqFXz+7Tih19lsZj10ejXlDdPoNp06a+ZE0YqMTFJoz/8TMWLFlLk5m2qWa2ihr7SUy6XS+M/ma3fI7foxMkzKlQwTC88+6Sa3lPv9rzTAADAq81Ze0JvLDogq90lH7NBbz1eRp0bFXJ3WUCulxLoUoLbnh49VXbcWO0fMNCjg5yUQZjbd+CwFi79QTMmvCUfH4v6DHhb5+Mu6rO5X2v6xyNkNpn03Csjdf+9d+nDT+fqsdbN1LBeLc344n/6+feNCgsJ1tGYE5o8bpiC8gbq2Rff1OatO1W7ZuXrFvXO+9M04IWuKl+2pN75YLr+2RWlsqWLq2+PjipZvIg+nblA33y7Rt07tZUkbdu5VzMnjpTBYFBCYpJC8gVp9uS3NeCN8fp9wxY92LRhmu3v2B2ll3p3Vr9eT+mRp/rp5Kkzijl5Rtt27tHCmeP12/rN+uX3TQQ5AADS8f0/5/T9jvPuLiPHSLI6tWzdSaXc6tVqd2nw/P1aF31Rfj6eNxGqeeV8al7Fu2c0IXe5MtBtb9lKkjw6yEkZhLktf+9U44Z1lDdPoCQpf2g++VgsOn3mvJ57+S1J0oX4BJ2PvaCNW7brwKGjmvb5Illtdj36cBOFhQSreNHCCg259MbUqVVVu/cdvG6Yi09I1M49BzRq3BRJUlKyVXfXqaGqlcrpwsV4ffjpXG3dvlvhZUqkrtOmRZM0I371aleTwWBQhfBSOvvviOLlChUIU5lSxSRJpUsW1dnzcQrNF6TkZJuSk5J17vzV66RY9M0qLV62SpLkymHzGc1mk5o0aSyzmQYoAICslWhz6lyCw91l5BhnYq2pQS6F0yUdOZussCAf9xR1CxJtTneXANx25uBglR03NjXISVLZcWM9NshJGYQ5u8OhhMSkNI+55FLtGpX0zrAXr1r+0/eHKTDAP/XfVzZLMZtN8vW1XL8il0sBAX76fNLbaQLamrWRWvTNKvXo8piqVS6vPyL/Sn3OaLz2GS+TyXjdwJWyTLEiBZU3T4D6DhqtPIGBer1/92su/3jrZnq8dTNJkt1uV6MWXa//mrKJ0WhU0aJF3V0GACAX8LcYFRLAycMU/mZfbTEoTaAzGqQSob7y9cCROX+L59UMXI89Nlb7BwxM89j+AQO9c2SuSkS4/rfiJyVbrbJabTp89LiSk636a9tuHYw+qtIli6VeW1a7RmV99fW36t6prc6ej00NdWfPxSop2SqH3a41v23U6GuEwBQGSU6nU4GBASpauKBW/rhWLZrdoxMnz6hggVBt2rpT99xdWzWqRmjq7EW3/Y2IPhKjvHkC9f6ogddfOIeyWm1asuRrtWnTVj4+mQjOAADcpOZVQpiGd4X6JfNo+KIDSra75Gs2aATXzAE5xpXNTi6/Zm5Pj54eG+jSDXPVKpfXPfXvVOfnBqtUiSIqXCi/QvMFafDLPTRk1ASZTEZVq1xeA/s+o5d6d9bb70/TUz0HKW+eAA1/tbckKSk5Wa+9+b6Onzytx1s/kDq18Vpq1aikZd/9rPvvvUtvDOyl0R9M17xFKxUWkk/vDOunB5s20Hsfz9Avf/ypGlVuf8vQwgXza9eeA+rY4zX5+FhUumRRdXuqjUoWL3Lb95WVbDa7u0sAACBX6tyokB6uGaqdxxJUqWiAwvJyYhXICdLrWnllUxRPDHQGqzU5Sy782rx1h75YtFLjRw7Iis3fdsu+/0UX4xP0ZNuHZLfbNeTtCbqzZhU98cgD6a6TMs1y7YpZMpszbAyaLaxWmxYsWKB27doxMgcAAIBc73q3H/D02xNkewIZ8MZ4nTx1Js1jndu3UrP76md3KWlUq1RO4z75XN/++JuSk62qVb2iWjW/1601AQAAALh5Cbt3KzEqKt2gdvkIXWJUlBJ271ZQ3bpuqvbGZdnIXG6Q00bmnE6n4uLiFBQUlG5TGAAAACA3iYuMVEBERIYjbvbYWI8LcpIbRuaQdQwGgwICAjN1Y3YAAAAgN8hMQDMHB3tckJMkhm+8iM1m14IFC2iCAgAAAOQChDkAAAAA8ECEOQAAAADwQIQ5AAAAAPBAhDkvYrGY1a5dO1ks9LUBAAAAvB1hzou4XC4lJMTL5eJuEwAAAIC3I8x5EbvdoeXLV8hud7i7FAAAAABZjDAHAAAAAB6IMAcAAAAAHogw52VofgIAAADkDvzy9yI+Pha1b9/e3WUAAAAAyAaMzHkRp9OpY8eOyel0ursUAAAAAFmMMOdF7HaHVq9eQzdLAAAAIBcgzAEAAACAByLMAQAAAIAHIsx5EYNBCg4OlsHg7koAAAAAZDW6WXoRi8WiVq1aursMAAAAANmAkTkv4nA4tHfvPjkcNEABAAAAvB1hzos4HE5t2LBBDge3JgAAAAC8HWEOAAAAADwQYQ4AAAAAPBBhzosYjQYVKVJERiPtLAEAAABvRzdLL2I2m9W0aRN3lwEAAAAgGzAy50UcDoe2bv2bbpYAAABALkCY8yIOh1Pbtm2jmyUAAACQCxDmAAAAAMADEeYAAAAAwAMR5ryI0WhQeHg43SwBAACAXIBull7EbDarfv273F0GAAAAgGzAyJwXsdvtWrduvex2u7tLAQAAAJDFCHNexOl0KSoqSk6ny92lAAAAAMhihDkAAAAA8ECEOQAAAADwQIQ5L2IyGVWtWjWZTHysAAAAgLejm6UXMZlMqlGjurvLAAAAAJANGMLxIna7XT/9tJpulgAAAEAuQJjzIk6nSzExMXSzBAAAAHIBwhwAAAAAeCDCHAAAAAB4IMKcFzGZjKpXrx7dLAEAAIBcgG6WXsRkMql8+XLuLgMAAABANmAIx4vYbDYtW7ZcNpvN3aUAAAAAyGKEOS/ickmxsbFy0cwSAAAA8HqEOQAAAADwQIQ5AAAAAPBAhDkvYjab1KRJY5nNJneXAgAAACCL0c3SixiNRhUtWtTdZQAAAADIBozMeRGr1ab58+fLaqWbJQAAAODtCHNexmazu7sEAAAAANmAMAcAAAAAHogwBwAAAAAeiDDnRcxmk1q2bEE3SwAAACAXIMx5EYPBoICAQBkMBneXAgAAACCLEea8iM1m14IFC2iCAgAAAOQChDkAAAAA8ECEOQAAAADwQIQ5AAAAAPBAhDkvYrGY1a5dO1ksZneXAgAAACCLEea8iMvlUkJCvFwul7tLAQAAAJDFCHNexG53aPnyFbLbHe4uBQAAIFeKi4yUPTY2w2XssbGKi4zMporgzQhzAAAAwG0QFxmpvb37aE+PnukGOntsrPb06Km9vfsQ6HDLCHMAAADAbRAQESH/8HAl7Np1zUCXEuQSdu2Sf3i4AiIi3FQpvEWWh7k+A0cp5vipdJ8fOW6KVq/N/FmJFT/8qnETP78dpaW6cDFebbr0z7LtZyeanwAAcPuduWDT2l2xOnPB5u5SkIOZg4NVYdpUBVSseFWguzzIBVSsqArTpsocHOzmiuHpGJnzIj4+FrVv314+PhZ3lwIAgNeYs/aE7hy6SR0m7NCdQzdpztoT7i4JOdi1Al1SdDRBDlkiS4dxPp46T9t27NXLw8bqwaYNFXUgWoeOxMhud2jk6y+obOnikqTfN2zRV19/q/OxF/Ryny66687qmj5nsfz9/PTUEy0Uc/yUBrwxXl9MHZNm+3ujDunjqfN0LjZOofmCNWZ4fwX4+6nzc4PV6sF79e2Pv2nSuCHy9/O7qraL8QkaOXaKjsScUPi/dXg6p9Op48ePq3DhwjIayekAgBv3/T/n9P2O8+4uI8dIsjq1bN1JOf9tFG21uzR4/n6ti74oPx/+1mal5pXzqXmVEHeXcVNSAl1KgNvespUkEeRw22VpmOvXs6PW/Bap90cOVMECYdp/8LDKh5fS0pVrNG/RCg0d0EuSFJw3j4a+/4b27o/Wa2++r69nf5ip7YeGBOuNV59TgbAQDR8zSWt+i1SLZvfoYkKC4i5c1IwJb8lgMFxz3Znz/qdiRQvp3Tdf0p6oQ3ptxAeZ2ueib1Zp8bJVkpTjbgFgtzu0evUatWvXTj78gQEA3IREm1PnEuiKnOJMrDU1yKVwuqQjZ5MVFuTjnqJyiUSb090l3BJzcLDKjhubGuQkqey4sQQ53FbZdoGVyWSU2WzWpBnztW3HXpkuGzmqWrm8DAaDypctqWSrTbFxFzO1zdCQYEVu3q5Z8/6n3fsOqmTxIqnPtW15f7pBTpI2/bVDb73+vCSpSKH8mX4dj7dupsdbN5Mk2e12NWrRNdPrAgCQ0/lbjAoJMLm7jBzD3+yrLQalCXRGg1Qi1Fe+nDjNUv4Wz35/7bGx2j9gYJrH9g8YyMgcbqtsC3Pbd+7TuImz1LtbezW66w5Nnjn/qmUMBoMsZrN8fS9d82V3ZHxm8Kuvv9W2nfvUuV1LFS9aSPEJianPXW+aocPhVEJi0k28EgAAvFfzKiEeO7Utq9QvmUfDFx1Qst0lX7NBIx4vo86NCrm7LORgVzY7KTturPYPGJh6DR2BDrdLlp/yKJQ/VCdPn9XW7btVs1pF1atdTQeij6ZZ5tjxk5KkDZu2qWCBUPn7+SkkX5B27z0gp9OpH39Z/9/CBsnlujTs/udfO/RgkwaqEF5a+w4cvqG6qlQM19p1myVJO/ccuOb2PY3BIAUHByuDAUkAAHCDOjcqpI2jamt+v8raOKo2QQ4ZulbXSr+SJdPtcgnciiwPcy2a36uhb0/Q7n0HtX3nXvXoP0Jnz6Y9eI8cO6FufYdpyqyFGvxSD0lS40Z1FX30uJ7s8ZrCQvNJ/waUSuXLKnLzdsXGXdCjLZpo8sz5ennoe8oTGHBDdXXr1Eab/vpHTz8/RH9u2S4fi+Wq7Xsai8WiVq1aymKhmyUAALdTWF6LGkYEKywvf2ORvoxuP5DRbQuAm2WwWpNzVhcPD5JyzdzaFbNkNrv//m4Oh0P79x9Q2bJlZDJxvQMAAEB2iouM1N7efeQfHp7uVMqUwJcYFaXykycpqG5dN1QKb+H+BJLFxnz0mXbsikrz2EP3N9STjz3spoqyjsPh1IYNG1SqVCnCHAAAQDYLqltX5SdPUkBERLrXxKWM0CXs3k2Qwy3z+jA36MXu7i4BAAAAuURmApo5OJggh9vCs3u+AgAAAEAuRZjzIkajQUWKFJHRSDtLAAAAwNt5/TTL3MRsNqtp0ybuLgMAAABANmBkzos4HA5t3fq3HNe52ToAAAAAz0eY8yIOh1Pbtm2Tw+GZNz0HAAAAkHmEOQAAAADwQIQ5AAAAAPBAhDkvYjQaFB4eTjdLAAAAIBegm6UXMZvNql//LneXAQAAACAbMDLnRex2u9atWy+73e7uUgAAAABkMcKcF3E6XYqKipLT6XJ3KQAAAACyGGEOAAAAADwQYQ4AAAAAPBBhzouYTEZVq1ZNJhMfKwAAAODt6GbpRUwmk2rUqO7uMgAAAABkA4ZwvIjdbtdPP62mmyUAAACQCxDmvIjT6VJMTAzdLAEAAIBcgDAHAAAAAB6IMAcAAAAAHogw50VMJqPq1atHN0sAAAAgF6CbpRcxmUwqX76cu8sAAAAAkA0YwvEiNptNy5Ytl81mc3cpAAAAALIYYc6LuFxSbGysXDSzBAAAALweYQ4AAAAAPBBhDgAAAAA8EGHOi5jNJjVp0lhms8ndpQAAAADIYnSz9CJGo1FFixZ1dxkAAAAAsgEjc17EarVp/vz5slrpZgkAAAB4O8Kcl7HZ7O4uAQAAAEA2IMwBAAAAgAcizAEAAACAByLMeRGz2aSWLVvQzRIAAADIBQhzXsRgMCggIFAGg8HdpQAAAADIYoQ5L2Kz2bVgwQKaoAAAAAC5AGEOAAAAADwQYQ4AAAAAPBBhDgAAAAA8EGHOi1gsZrVr104Wi9ndpQAAAADIYoQ5L+JyuZSQEC+Xy+XuUgAAAABkMcKcF7HbHVq+fIXsdoe7SwEAAACQxQhzAAAAAOCBCHMAAAAA4IEIc16G5icAAABA7sAvfy/i42NR+/bt3V0GAAAAgGzAyJwXcTqdOnbsmJxOp7tLAQAAAJDFCHNexG53aPXqNXSzBAAAAHIBwhwAAAAAeCDCHAAAAAB4IMKcFzEYpODgYBkM7q4EAAAAQFajm6UXsVgsatWqpbvLAAAAAJANGJnzIg6HQ3v37pPDQQMUAAAAwNsR5ryIw+HUhg0b5HBwawIAAADA2xHmAAAAAMADEeYAAAAAwAMR5ryI0WhQkSJFZDTSzhIAAADwdnSz9CJms1lNmzZxdxkAAAAAsgEjc17E4XBo69a/6WYJAAAA5AKEOS/icDi1bds2ulkCAAAAuQBhDgAAAAA8EGEOAAAAQK4WFxkpe2xshsvYY2MVFxmZTRVlDmHOixiNBoWHh9PNEgAAAMikuMhI7e3dR3t69Ew30NljY7WnR0/t7d0nRwU6rw9z0+cs1hcLV7i7jGxhNptVv/5dMptpUgoAAABkRkBEhPzDw5Wwa9c1A11KkEvYtUv+4eEKiIhwU6VX8/owl5vY7XatW7dedrvd3aUAACBJOnPBprW7YnXmgs3dpQDANZmDg1Vh2lQFVKx4VaC7PMgFVKyoCtOmyhwc7OaK/+NVQzgul0vjP5mt3yO36MTJMypUMEz+vr4qXbKoXnj1HR0/eVrPdHxULR64Ryt++FW79x3UseOnFHUgWi8//7T+2PCX1v+5VS0euEfPdn7M3S/nhjmdLkVFRal27druLgUAAM1Ze0JvLDogq90lH7NBbz1eRp0bFXJ3WQBwlZRAlxLc9vToqbLjxmr/gIE5NshJXhbm/t6xV9t27tHCmeP12/rN+uX3TSpWpIAOHDqqD995VbFxF9Wx5yDd17COJGnbjr2a+N5grYvcqpFjP9XUD97Us53bqm2Xl/RMxzYymRi4BADcXt//c07f7zjv7jKyXJLVqWXrTsrpuvRvq92lwfP3a130Rfn5eObf1+aV86l5lRB3lwEgi1wZ6La3bCVJOTbISV4W5kLzBSk52abkpGSdOx+X+njliHCZzWaFheZT8aKFFH0kRpJUpWI5BQb4K6J8aRUIC1XpkkUlSUFBeXQxPl7BQXmv2seib1Zp8bJVki6NBAIAcCMSbU6dS3C4u4wsdybWmhrkUjhd0pGzyQoL8nFPUbco0cZ9XAFvZw4OVtlxY1ODnCSVHTc2RwY5ycvCXLEiBZU3T4D6DhqtPIGBer1/d61Y9WuaZcxmk/x8fdM+ZjJdtUx6Oe3x1s30eOtmki5do9aoRdfbVv+tMpmMqlatGiOKAJCD+VuMCgkwXX9BD+dv9tUWg9IEOqNBKhHqK18PHZnzt3hm3QAyzx4bq/0DBqZ5bP+AgYzMZYfoIzHKmydQ749K+wHEnDgtl8ulA4eO6szZ8ypRrJB27I5yU5VZx2QyqUaN6u4uAwCQgeZVQnLNVL36JfNo+KIDSra75Gs2aATXzAHIwa5sdnL5NXN7evTMkYHOq8Jc4YL5tWvPAXXs8Zp8fCwqXbKonE6XTCaTer40QgmJSRo2oJfXtu632+365Zdfde+993jtawQAeI7OjQrp4Zqh2nksQZWKBigsr8XdJQHANaXXtfLKpig5LdAZrNZkr7nwa9n3v+hifIKebPuQ7Ha7hrw9QXfWrKInHnkgS/aXMs1y7YpZOSI8Wa02LViwQO3atZOPD38wAQAAgOu53u0HcvLtCbxq8ne1SuX0+4Yt6tJniJ7q9bpC8gWpVfN73V0WAAAAgBwqYfduJUZFpRvULr8PXWJUlBJ273ZTpVdz/3DSbVS6ZDFNfHewu8sAAAAA4CGC6tZV+cmTFBARke6IW0qgS9i9W0F162ZzhenzqjCX25lMRtWrV49ulgAAAMANyExAMwcH56ggJxHmvIrJZFL58uXcXQYAAACAbMAQjhex2Wxatmy5bDabu0sBAAAAkMUIc17E5ZJiY2PTveE5AAAAAO9BmAMAAAAAD0SYAwAAAAAPRJjzImazSU2aNJbZbHJ3KQAAAACyGN0svYjRaFTRokXdXQYAAACAbMDInBexWm2aP3++rFa6WQIAAADejjDnZWw2u7tLAAAAAJANCHMAAAAA4IEIcwAAAADggQhzXsRsNqllyxZ0swQAAAByAcKcFzEYDAoICJTBYHB3KQAAAACyGGHOi9hsdi1YsIAmKAAAAEAuQJgDAAAAAA9EmAMAAAAAD0SYAwAAAAAPRJjzIhaLWe3atZPFYnZ3KQAAAACyGGHOi7hcLiUkxMvlcrm7FAAAAABZjDDnRex2h5YvXyG73eHuUgAAAABkMcIcAAAAAHggwhwAAAAAeCDCnJeh+QkAAACQO/DL34v4+FjUvn17d5cBAAAAIBswMudFnE6njh07JqfT6e5SAAAAAGQxwpwXsdsdWr16Dd0sAQAAgFyAMAcAAAAAHogwBwAAAAAeiDDnRQwGKTg4WAaDuysBAAAAkNXoZulFLBaLWrVq6e4yAAAAAGQDRua8iMPh0N69++Rw0AAFAAAA8HaEOS/icDi1YcMGORzcmgAAAADwdoQ5AAAAAPBAhDkAAAAA8ECEOS9iNBpUpEgRGY20swQAAAC8Hd0svYjZbFbTpk3cXQYAAACAbMDInBdxOBzauvVvulkCAAAAuQBhzos4HE5t27aNbpYAAABALkCYAwAAAAAPRJgDAAAAAA9EmPMiRqNB4eHhdLMEAAAAcgG6WXoRs9ms+vXvcncZAAAAALIBI3NexG63a9269bLb7e4uBQAAAEAWI8x5EafTpaioKDmdLneXAgAAACCLEeYAAAAAwAMR5gAAAADAAxHmvIjJZFS1atVkMvGxAgAAAN6ObpZexGQyqUaN6u4uAwAAAEA2YAjHi9jtdv3002q6WQIAAAC5AGHOizidLsXExNDNEgAAAMgFCHMAAAAA4IEIcwAAAADggQhzXsRkMqpevXp0swQAAAByAbpZehGTyaTy5cu5uwwAAAAA2YAhHC9is9m0bNly2Ww2d5cCAAAAIIsR5ryIyyXFxsbKRTNLAAAAwOsR5gAAAADAAxHmAAAAAMADEea8iNlsUpMmjWU2m9xdCgAAAIAsRpjzIkajUUWLFpXRyMcKAABwpbjISNljYzNcxh4bq7jIyGyqCLg1/Or3IlarTfPnz5fVSjdLAACAy8VFRmpv7z7a06NnuoHOHhurPT16am/vPgQ6eATCnJex2ezuLgEAACDHCYiIkH94uBJ27bpmoEsJcgm7dsk/PFwBERFuqhTIvAzDXMzxU3qq56B0n9+8dYdGjpty0ztv06X/dZf56dcN6vTc65o+Z/ENbXvkuCnavHXHTVYGAEDucOaCTWt3xerMBWZ1wLuZg4NVYdpUBVSseFWguzzIBVSsqArTpsocHOzmioHry/Ejc998u0Yv9+miZzs/5u5SAADwKnPWntCdQzepw4QdunPoJs1Ze8LdJQFZ6lqBLik6miAHj2WwWpPTvcV0zPFTGvDGeE0eP0zjJs7UoSMxstsdGvn6C7JYzOr72mglJCapcMEwTXxviM7HxmnU+KmKjbugerWr66XenbVy1VrtiTqo4yfOaMfuKD3b+TE98nBj9eg/Qrv27leZksX0wrNPqm7talft/8vFKzVt9mLlDwvRS707y8di0fQ5ixUbd1HhZUpoxKA+MhqNity8XROnfymX06XmTe+WyWjUtNmLFRoSrPp1auiV55/Wsu9/0VeLv5UkPfnYQ2rZ/F7FHD+l8ZNmK19wXtntdvXp1l6D3vpIF+MTVLF8aQ1/tY9MpvTzrt1uV6MWXbV2xSyZzebb8HHcGqfTqbi4OAUFBdEEBQCy0ff/nNP3O867u4wbkmR1atm6k3Je9ivAaJBa1S8oPx/v+RvSvHI+Na8S4u4ykMNcPhKXgiAHT5SpBBIY4K/O7VqpfHgpLV25RvMWrdDQAb3Uo8tj2vz3Tg0b0EuS9Orw8RrwQleVL1tS73wwXf/sipIk/f3PXk1893UdOhKjN0Z/okcebqy3BvVRn1ff1uzJ76S73ycfe1hr129W3x4dValCWR2NOan3RrysPIEBeu6Vkfpr+26Fly6ud96fponvDVaxIgV1PvaCQvIFae36zXq2U1vdUaOy9h88olnz/qfZk96WJHV9YZiqVionXx8frdv4lz585zXVqVVV8xatVOWIcL3yfBedOHXmmkFu0TertHjZKkmSy5VuDnYLg8GggIBAGQwGd5cCALlKos2pcwkOd5dxQ87EWtMEOUlyuqQjZ5MVFuTjnqKyQKLN6e4SkAOZg4NVdtxYbW/ZKvWxsuPGEuTgcTIV5kwmo8xmsybNmK9tO/bKdI1Rn/iERO3cc0Cj/r2GLinZqrvr1JAkValYToGBAapQrrTOnY+76WILF8yvX//4U+v+3KqTp87o+InTSkxMUvUq5VW8aCFJUki+oKvW27R1h+rVrq7AwABJ0l13Vteff+1Qg7o1VaJYEdWpVTX18TfGfKKvvv5WbVo0vWYNj7dupsdbN5P038hcTmGz2bVgwQK1a9dOPj4Wd5cDALmGv8WokADPusenv9lXWwy6amSuRKivfL1oZM7f4j2vBbePPTZW+wcMTPPY/gEDGZmDx8lUmNu+c5/GTZyl3t3aq9Fdd2jyzPlXL+RyKSDAT59PejvNyNCKH379b2cm0y2NZn00Za4cTqc6tHlI/n6+crlccrpckq4/EpXeYNXlwbRs6eKa/uGbWrJytTr3HqyZE0cqz78BEACA9DSvEuKRU/nql8yj4YsOKNnukq/ZoBGPl1HnRoXcXRaQpa5sdlJ23FjtHzAw9Ro6Ah08ScanqwwGOV1Obd2+WzWrVVS92tV0IPpo6tMFC4Tq5KmzcrlcCgwMUNHCBbXyx7WSpBMnz2QY3ELyBSk+PuGG7om26a8devShxipWtKAOHDomSaoSEa4t23Yp5sRpuVwuHTt+UpJUqECYTp4+K0m6o0Ylrf/zb8UnJCo+IVHr//xbtWtUvmr7u/cdlMFoUPtHm8vHx6KjMSczXRsAAJ6mc6NC2jiqtub3q6yNo2oT5OD1rtW10q9kyXS7XAI5XYZhrmD+UJlNZuXNE6DtO/eqR/8ROnv2v4O7WqXyunAxXl16D9Gx4yf1xsBeWvbtz3qq1yC9/f40xSckprttPz9fNW5YVx17vqaff9uYqWLbt2muYaM/0ZBRE1SwQKgkKTQkWANeeFqvDB2rri8M1fer/5AkNW/SQBOmfanRH0xXeOkSerpDa/XsP0I9+49Q5/atVKZUsau2fyzmpHq/MlLtug1QlYrhKl+2ZKbqAgDAU4XltahhRLDC8jI9H94to9sPZHTbAiAny7CbJTKW07pZulwu2Wx2WSxmmqAAAABcJi4yUnt795F/eHi6UylTAl9iVJTKT56koLp13VApkHnuTyC6NL3x7fFTr3p86gfD5efn64aKPJPL5VJCQryCgoIIcwAAAJcJqltX5SdPUkBERLrXxKWM0CXs3k2Qg0dgZO4W5LSROavVRjdLAAAAIJegXy8AAAAAeCDCHAAAAAB4IMKcl7FY3D/dEwAAAEDW45e/F/Hxsah9+/buLgMAAABANmBkzos4nU4dO3ZMTqfT3aUAAAAAyGKEOS9itzu0evUa2e0Od5cCAAAAIIsR5gAAAADAAxHmAAAAAMADEea8iMEgBQcHy2BwdyUAAAAAshrdLL2IxWJRq1Yt3V0GAAAAgGzAyJwXcTgc2rt3nxwOGqAAAAAA3o4w50UcDqc2bNggh4NbEwAAAADejjAHAAAAAB6IMAcAAAAAHogw50WMRoOKFCkio5F2lgAAAIC3o5ulFzGbzWratIm7ywAAAACQDRiZ8yIOh0Nbt/5NN0sAAAAgFyDMeRGHw6lt27bRzRIAAADIBQhzAAAAAOCBCHMAAAAA4IEIc17EaDQoPDycbpYAAABALkA3Sy9iNptVv/5d7i4DAAAAQDZgZM6L2O12rVu3Xna73d2lAAAAAMhihDkv4nS6FBUVJafT5e5SAAAAAGQxwhwAAAAAeCDCHAAAAAB4IMKcFzGZjKpWrZpMJj5WAAAAwNvRzdKLmEwm1ahR3d1lAAAAAMgGDOF4Ebvdrp9+Wk03SwAAACAXIMx5EafTpZiYGLpZAgAAALkAYQ4AAAAAPBBhDgAAAAA8EGHOi5hMRtWrV49ulgAAAEAuQDdLL2IymVS+fDl3lwEAAAAgGzCE40VsNpuWLVsum83m7lIAAAAAZDHCnBdxuaTY2Fi5aGYJAAAAeD3CHAAAAAB4IMIcAAAAAHggwpwXMZtNatKkscxmk7tLAQAAAJDF6GbpRYxGo4oWLeruMgAAAABkA0bmvIjVatP8+fNltdLNEgAAAPB2hDkvY7PZ3V0CAAAAgGxAmAMAAAAAD0SYAwAAAJBpcZGRssfGZriMPTZWcZGR2VRR7kWY8yJms0ktW7agmyUAAACyRFxkpPb27qM9PXqmG+jssbHa06On9vbuQ6DLYoQ5L2IwGBQQECiDweDuUgAAAOCFAiIi5B8eroRdu64Z6FKCXMKuXfIPD1dARISbKs0dCHNexGaza8GCBTRBAQAAQJYwBwerwrSpCqhY8apAd3mQC6hYURWmTZU5OPim9xVz/JT6vjZaYz78TI89/ZJmz/9GX379rTr2eE0vDXlPDodTU2YtVLe+b+jxri9r1c/rJEmDR36ktes3y+VyqdfLb+nAoaO35bXnRIQ5AAAAAJl2rUCXFB19W4Ncil17D6hD24c09YPh+nTmQhUIDdHsT9/RydNntX3nXt3XsI4++3iEPnj7VU2esUCS9PyzT2r6nMVa/+ffKlOqmMqUKnbLdeRU3DQcAAAAwA1JCXQpAW57y1aSdFuDnCQVzB+q0iWLSpLCQvPpzlpVZDaZVK5MSZ09F6sa1SL0xaIV2rF7v06ePitJKlakoGrXqKIxH36mzz4ecVvqyKkYmQMAAABww8zBwSo7bmyax8qOG3vbgtxV+7usyZ/ZbFJiUrKeH/i28ofm02v9npG/n2/q80djTsjPz1fJVluW1JJTEOa8iMViVrt27WSxMOAKAACArGWPjdX+AQPTPLZ/wMDr3rbgdjl3Pk4Wi0XNmzTQ2XNxSrZaJUl//vWPfH181K9nR02YNi9banEXwpwXcblcSkiIl8vlcncpAAAA8GJXNjupunzZNZuiZKVCBcNUvEhBPd1niJZ+u0aFCoTJ6XRq0mfz1aPLY7q7bk0lJiZp45btWV6Luxis1mR++d8ku92uRi26au2KWTKb3T8aZrXatGDBArVr104+PhZ3lwMAAAAvlF7XytvdzRLXx8gcAAAAgEzJKLBldNsCZA3CHAAAAIBMSdi9W4lRUemOvF0e6BKjopSwe7ebKs0d3D83ELcVzU8AAACQVYLq1lX5yZMUEBGR7hTKlECXsHu3gurWzeYKcxeumbsFOe2aOQAAAAC5B9MsvYjT6dSxY8fkdDrdXQoAAACALEaY8yJ2u0OrV6+R3e5wdykAAAAAshhhDgAA4BriIiOv24nPHhuruMjIbKoIANLiQi8AAIArxEVGam/vPvIPD0/3XlkpLdoTo6JUfvIkGj0g1zpzwaYdRxNUuViAwvLmrHsd74k6pA8/naNJY4dq5aq1kqSHmzW6rfvYvHWHvli0UuNHDkjd5/uffK6LCYnKF5RXA/t2VakSRSVJbbr0V4Cfn5KtVuUJDNCg/t1VsXyZm963x47MxRw/pad6DtK+/dH6aMpcd5eTIxgMUnBwsAwGd1cCAIBnC4iIkH94eLr3yrr8Xlv+4eEKiIhwU6WAe81Ze0J3Dt2kDhN26M6hmzRn7Ql3l5Suh5s1ui1BbsUPv2rFD79e87n4+AQNGvGhXn7+ac39dLR6dX1CA94Yr2SrNXWZT8YO0cKZ49W9c1uNmzjrlmrx+JG5cmVL6sVendxdRo5gsVjUqlVLd5cBAB4rJ59dRvZKaa2eEtj29OiZOkKX0U2TAW/3/T/n9P2O85KkJKtTy9adlPPf3vhWu0uD5+/XuuiL8vMxqnnlfGpeJeSm9hNz/JTe+WC6ihUpqI1btuuRhxvLYrFo2bc/q1DBMI17a4BMJqN+W79Fkz77Sg6nQ890fFQPNm2ok6fOaMR7n+rCxXgVLVIwdZvT5yyWv5+fnnqihX76dYO++vpbxV2I1911a+jFXp0Uc/yURn/4mYoXLaTIzdtUs1pFDX2l5429P2vWqeFdtVQhvJQkqVrl8qpepYJ++f1PPdD47tTlDAaD7qxZWaPfn35T708Kjx2ZS7F56w69MmycpEsf0LTZi9V/8Ltq0eF5/b5hiyQpITFJw96ZqPbdB6r/4HcVdyFedrtdYz76TN36DlO7bgO0eeuO1G3Mnv+NevQfoVU/r3Pb67oZDodDe/fuk8NBAxQAuFGedHYZ2ePymx+nBLqk6GiCHHK1RJtT5xIcOpfg0JEzyalBLoXTJR05m6xzCQ4l2m6tw/quvQfUoe1DmvrBcH06c6EKhIZo9qfv6OTps9q+c6/Ox17Q5JnzNf3jEZozebQW/O8H2e12fTjlC93XsI5mT35HD93f8JrbDi9dXBPeHawvpozWz7//qZjjpyRJO3ZH6YlHHtDcKWO0dt1mnTx1JnWdn3/bqC69B2va7EuZo0vvwfr5t41ptht9JEbl/w1yKSqEl9LB6GNpHnO5XPp21W+qUC7tsjfK40fmrrRr736NHfGKfl23SV99/Z0a1Kulz79cqupVKmjk4Be0ctVa/W/lT+rSvrXaPNxEEeXLKHLTNn02d4nuqFFZkvTtj79p5oSR8vPzdfOruTEOh1MbNmxQqVKlZDKZ3F0OgFzm8rO1nuZ6Z5c9ya2cCcfVrhyh296ylSQR5JBr+VuMCgm49DvT3+yrLQalCXRGg1Qi1Fe+Pkb5W27t+7Ng/lCVLnnpWrOw0Hy6s1YVmU0mlStTUmfPxerCxQSdPnNez738liTpQnyCzsde0Ja/d2r4q89JkooUKnDNbRcpXEA//rJef27ZoeQkq46fOqPCBcJUqECYypQqJkkqXbKozp6PU8ECYZKk+xrW0X0N66ROsWzxwD2SlDooJOmatwhzudI+/vzAt3UuNk6VKpTVm6/1uaX3yOvC3B3VK8tiMatCeCmdPX9pfnvk5u1KTrZq2Xc/y+Fwql7tapKkoKC8+mzu19qxe7+Onzyduo2H72+UbpBb9M0qLV62StKlRA0AuCTlbK0nOhNrTffscliQj3uKukm3eiYcVzMHB6vsuLGpQU6Syo4bS5BDrtS8SkiaE0b1S+bR8EUHlGx3ydds0IjHy6hzo0K3fb9msynNf7skueRS7RqV9M6wF9Msa7c7lJiYLF+f9L+/h749QRXLl1H3Tm2UkJAo1zVCmMlkvOHf+yWKFda+/dFpHtt3IFp3VK+U+u9Pxg7R9p37tGTFT8oXnPeGtn8lrwtzKcwmk/Tve+9yuTRyyAsKL10i9fljx0/qlWHj1PuZ9mr5wL16bsDI1OeMxvTPIjzeupkeb91MkmS329WoRdcsqR8APM3lZ2s9zfXOLnuSWz0TjqvZY2O1f8DANI/tHzCQkTlAUudGhfRwzVDtPJagSkWz93rjKhXDNfr96ToYfVSlSxbTiZNnVKhgmCpHlNVv6zerZfN7tWvP/muuu/nvnRo24NLo3ZGYG5tWnzIidy3N7quvp/sM0WOt7lfJ4kW0N+qQ/tzyj17u0yXNcg3q1dSXi1dq3catql+nxg3t/3KeG+YMBjldmTv7WKdWVX319Xd6vX93JSYly+FwatfegypZvIjuubu2Nm7ZnsXFZg+j0aAiRYrIaKSdJYDsd+XZWk+TXWeX4VmubHZSdtxY7R8w8KqmKEBuFpbXooYR2f//QWi+YA1+uYeGjJogk8moapXLa2DfZ/Rir056873J+nr5j7qzZpVrrvvU4y3U86URKlemhIoXydx3/c+/bdSML5akeazbU20UlDcw9d/5gvNq6ICeGjTiQ/n4WORwODVqSF8F+PulWc9gMKhfz44a/u5k3VmziiyWm4tlBqs12SPnCjocTnV9fqj69uyo+Uu+0/iRA9J0qIk5fkoD3hivL6aOUXxCot79aIb2RB1SgL+fBvbtqqKFC2ro2xMUn5CgBvXu0E+/rNe8ae+m2cb1pIzMrV0xS2az5+ZiAMAlZy7Y3HJ2GTlTel0r6WYJ4HqcTqfeGP2JIsqVVvs2D8piMcuQBfcP89gwlxPktDDncDi0ffs/qlq1Cg1QAAC4BdcLbAQ6ANdzMT5B4ybO0j+7onT/vXepV9cnbvs+3J9AcNs4HE5t27ZNlSpVIswBAHALEnbvVmJUVLpB7fIul4lRUUrYvVtBdeu6qVoAOVGewIBb7lZ5PYQ5AACAKwTVravykycpICIi3RG3lEBHkAPgLoQ5AACAa8hMQDMHBxPkALgN/Yu9iNFoUHh4ON0sAQAAgFyAkTkvYjabVb/+Xe4uAwAAAEA2YGTOi9jtdq1bt152u93dpQAAAADIYoQ5L+J0uhQVFSWnk7tNAAAAAN6OMAcAAAAAHohr5m6By3VpBCynTGu02+1yOJ2y2+00QQEAAAC8jMlkksHw3+98g9WazJy8m5SUlKTGjzzr7jIAAAAA5AJrV8yS2fzfeBxh7hY4nU5ZrdarErI7dXrudc39dLS7ywBuGMcuPBXHLjwVxy48VW4+dq/MHUyzvAVGo1F+fn7uLiMNg8GQJq0DnoJjF56KYxeeimMXnopj9z80QAEAAAAAD0SY8zKPtWrm7hKAm8KxC0/FsQtPxbELT8Wx+x+umQMAAAAAD8TIHAAAAAB4IMIcAAAAAHgg2sB4sP+tXK2FS39QnsAAjXz9eRUsEJb63JFjJ/Tmu5OUmJSszu1a6sGmDd1YKZBWRsfuV19/px/W/K74hCS98GwHNapf242VAv/J6LhN8fLQsQrJF6RhA3q5oULg2jI6duMTEjX6g+k6ePiYChUI01uD+igwMMCN1QL/yejYPXDoqIaP+UTxCYlqeu9d6tOtvRsrdR9G5jzU2XOxmjN/mT77aIQeb91Mn3w2P83zH02Zq2c6Pqqp77+hKbMW6mJ8gpsqBdLK6NiNT0hUstWqaR+O0OhhL+qdD6bL5eKyXrjf9b5zJemPyL906vQ5N1QHpO96x+5nc5eoYoUymvvpaD3fvYMCAvzdVCmQ1vWO3RlfLFGndi311fSx2r5zrw4fPe6mSt2LMOehNmzapgrhpeXn56ua1Spq3ca/Up9zOJxa/+ffqlk1QoGBASpZvIg2b93pvmKBy2R07AYG+OvpDq1lMhlVplQxORwOJVtt7isW+FdGx60k2e12TZ+zWJ3atXRPgUA6rnfs/vjLOj3W6n5JUtnSxdPcjBhwp+sdu4EB/soXHCSLxazSJYrJbDK5p1A3I8x5qDNnz6tk8cKSpPyh+eRwOpWUbJUkxV64oHxBeVOnSZQsXkSnz3C2GDlDRsfu5XbvO6jiRQvJz9cnu0sErnK943bRNz+qccO6KhCWz00VAteW0bGbmJQko8GoeYu+VZfegzVpxtUjzoC7XO97t2vHRzT+k1maNW+pnC6nihQu4K5S3Yow56kMSjP9zOV0KeVkmkEGOS97zulyyWDkTBtyiAyO3RR2h0MfTflCvbq2y+bigHRkcNyej72gVT+vU/s2D7qpOCADGRy7CQlJOhcbpxpVK2j6RyO0/s+/tXPPfjcVClzhOr8XVvywVu3bPKRkq1V7o6Jz7SVFhDkPVSAsRNH/zg0+deacLBaLfH0ujWAEB+XRhYvxqQf14SPHlT8sxG21ApfL6NhN8eHkuapdo5Lq1a7mjhKBq2R03P6+YYsuxieoz8BRGjtxlv6I/Etz5i9zZ7lAqoyO3XzBQbKYzapeuYJ8fCyqWTVCR2NOurNcIFVGx25SUrJ+Xfen2rZsql5dn1D1KuX16x+b3Fmu2xDmPFTdO6ppb9QhJSUla8vfu3R33Zr6YuEK/bDmDxmNRtWvU0Nbtu3SxfgEHT4aozuqV3J3yYCkjI9dSVr0zSqdOXte3Z5q4+ZKgf9kdNy2eOAezf9srKZ/NEIDX+iqu+vWVOf2rdxdMiAp42PXZDKqdo3K+mPjX0pKtmrrP7tVtlRxd5cMSLr+b92Y46d15NgJ2R0ORR+JcXe5bsOtCTxUSL4gde34qLq/OFx5AwM0ckhfzZm/LPXC5f69OumNMZ/o05kL1LtbewXSnQo5REbH7tGYk/pw8hyVKVVcXZ8fKknq3L6Vmt1X381VI7e73ncukFNd9/dC7856673JmjjtS7V44B6VLU2YQ86Q0bHr42PR0Fd66qUh78npdKpW9Up6oHHu/K1gsFqT6fsNAAAAAB6GaZYAAAAA4IEIcwAAAADggQhzAAAAAOCBCHMAAAAA4IEIcwAAAADggQhzAAAAAOCBCHMAAAAA4IEIcwAAj9Th2Ve16a8daR7r3m+4Nmzalu46McdPqVnbnqn/HvHeZEUdPHzNZbv0HqzNW3dc87nLtenSP/W/z5w9r1eHvy+r1Xbd9TLjyLET6vvaaLXvPlBd+gzRrHlL5XA4r3odAIDcyezuAgAAuBn3NbhTv0f+pdo1K0uSTp4+q2PHT6p2jUqZ3sbwV3vf1prCQvPpvREv37btvffxTN1dr6Y6tHlQVptNf2z4S0aj4bZtHwDg2QhzAACP1LhhHQ1/d7L69ewoSVq7bpMa1b9DZrNZ/+zapymzFul83AXZbDa92q+balWreNU2uvQerP7PddIdNSrr+MnTGvPhZzp1+pyKFSmo83EXUpdbuWqtlqz4SYlJyQoM8NeoIX0Vki9InZ97XafPnFOX3oPV6sH79GDTBnrgsV5a9/1cSdK2HXv18dQvlJCYpNB8wXrl+adVumRRxRw/pddGfKB7G9TRb+s3Kzbuot4e2leVKpRNU19CYqLiLlyUJPn6+Khxo7qpzzldTs2at1S/rvtT52Iv6O0hfVU5IlyHDh/TxOlf6tTpc4pPSNRzz7RT03vqSZIeatdbvbo+of+tWK2X+3TR0m/XKE9ggPYfPKITp86oSsVyGtS/m3x9fHTo8DG99/FMnTkXq6C8gRr6Sk+VLF7k9n6IAIBbwjRLAIBHqlCutKxWm47GnJQk/frHJjVpdCm05A8N0dBXemj2pLfV9clHNWHqvOtub+TYKbqjRiV9MXWMhrzSQybjf38iK4SX0sdjBmnup6NVpmQxzV/yncwmk94fOVD5w0I0e/I7euKRB9JsL+5CvAa99aH6P9dJX0wZo7Ytm2rQWx/K4XBKkvYfPKJqlcppxoS3dG+D2vpy8bdX1fRyny5atWaduvV9Q9/99JucTmfqc8lJVlWOKKvPPn5L9zW4U199/Z0kKV9wkF549knN+mSUhg3opfETP5fL5ZIknY+9oCPHTmjmxJGqXqWCJOn0mXMaN/IVzZs6RkeOndDy73+R3eHQsHcm6qXenfXV9PfU7ak2mjjty0x/NgCA7EGYAwB4JIPBcGmq5YYtuhifoH0HDuvOf6dcFiwQqiMxJ/Xx1Hla/v0vOnLsRIbbSkhM0tbtu9W+zYOSpOCgvMqbJzD1+RLFC+v39X/p3Y9maPuufdfdniRt37lXJYoWUpWK5SRJjRvVVUJiog4fjZEk+fv7qW7tajIYDKpaqbzOnD1/1TYqR4Rr3tR31e7R5pr91TL1enmkEpOSMlw/OCiPkpKSNXnGfH2xcIXOxcYpISExdZudnmgpg+G/qZrVKleQr4+PzGazGtStqe07o3Tk6HEdOhyjt8Z+qi69B+uT6V/pXOwFAQByFqZZAgA81r0N62jG3K8Vmi9Yd9etKbP50p+1qZ8v0v5DR9Sh7UNq/eB96tH/zQy3kzLiZTKZrnrO5XKp36AxqlWtotq2bKrKFcP127rNN1WvQQZJV1/zZjab5JLrmuv4+Fj00P0N1axxfbV7ZoA2/LlNEeVKp7v+0pVr9O2Pa/XMU2309JOPqOmjz8rp+m/bJlP653HNZpP8/Xzlckl+fr6a9ckoGY2c9wWAnIpvaACAx6pWqZyij8Tou9W/q8ll15OtXb9ZLZrdo1rVKmpP1MH/VjAY5HQ5r9pOnsAAlSlVXN/++Jsk6djxkzr970hX3IV4bd+5V08+9rDKli6hXXv2p64XEhKs+PgEJSVbr9pm1UrldSTmhP7ZFSVJ+vn3jfL391OJYoUz9driLsRrwrR5iv332r24uItKSExU0SIFM1zvtw2b1bhRXdWrXU1RB67dqfNyR2NOyOl06mJ8glauWqv6dWuoRPHCyhecR199/Z1cLpesVptOnj6bqboBANmHkTkAgMcyGo26u25Nrfp5vca88WLq452eaKHJM+frqyXf6t6770wdjSpUIFQlixXRwqU/XHWN27CBvTT6g+la+L/vFV6mRGroCsobqA5tH1LPl95UkUIFVLVSOZ0+c16S5Ofro+ZNGujJZwfqsVbN9MjDjVO3F5Q3UKOH9dcHk2crKdmqfMF5NeaN/hmOjF0uT6C/ShYropeGjFVyslV2h119undQhfBSijl+Kt31Hm/9gD6Z/qV++nWD6t5RVYUKhGW4n+gjMeozYJTOnItVi2b3qGG9WjIYDHp3+Msa98ksLfv+Z/n4WNS5XSvdf+9dmaodAJA9DFZr8rXndQAAAK82ctwUlS9bSh3aPujuUgAAN4FplgAAAADggRiZAwAAAAAPxMgcAAAAAHggwhwAAAAAeCDCHAAAAAB4IMIcAAAAAHig/wM9fAhx7wp5JAAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3MAAAF/CAYAAADjFJAoAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAVOJJREFUeJzt3XmAzPUfx/HXXHuyi3WTa7HuIyGhQlI5SgcSEiGKn4qSI4miUIrIEULKUZKjQ6hUWCGRex3rWDez7DXn7w/tZmPXYndnZ/b5+Csz3/l+39+Zb7Pz+n4+3/fXYLMluQUAAAAA8CpGTxcAAAAAALhxhDkAAAAA8EKEOQAAAADwQoQ5AAAAAPBChLkstmTFao149+Ms3caKH35Rl96Ds3Qb2aFtl/5av2mbp8tIsWXbTjV/tOctr2f2/KW6/7Ge6t5vuNzuzOs3NOLdj7VkxWpJt16rzWZXl96DtWffwcwqL0ebOnuRps5eJEmKOXFaDVp00sVLcR6uKme4YL3osffj9Nnz6tjjVZ0+ez7btw0AgDcye7oAXxBz4rTemzJH23bsUXBQoO6oXU29n2mnAvlD1bZlM7Vt2czTJV5TzInT6vPKW1oyZ0K2bXPNukh9MvcrnTh1RiWKF9EjDzbRIy2bymj0zfMKcXHxmjZnscaPHKC6t1eTwWDItHUPf+W5TFuXn59Fc6a8neHlZ8z9UpL0bOfHMq2GrNSgRSet/35eyr97dX3Cg9UgLYXC8mv+9Hc8XQYAAF6DMJcJhr8zWWVKFdeiWe/J7Xbr65VrFHPyjArkD/V0aTnKoehjen30Rxrzen/Vr1Ndh48c18pV62R3OOTv5+fp8rJE7MU4ud1uVa1UXmaTydPlAAAAwIcQ5jJB1KEjerpDG4WG5JEkdX3y4ZTnFi39QWt/jdTksUMlSes3bdOH0z5T9NEYuVxu+flZdH+TuzTkpR5q0KKTPh4/TB/PWqh9B6LVuEEdDRvQU0ajUWfOntcn85Zo09Ydir14SU3vrq8BL3TNUEA4fOS4Ro2frgOHjqhE8SLq2+NJWcxm/W/wO7LZ7Gr6cHc1rF9bIwe/oE1bd2jewuXas/+QggID1f+5Trr7rjqSpCPHTuidD2Zq+859stntMptNKlakkBbOHKcL1ot6b/Icbdy8XQXyh+jF3l1U7/Zqqeo4FH1c+ULz6M66NWQ2mVS+XCn16/VUqmWOHj+pF4e8q79371e1yhU0akhfBQUG6FJcvD79/But27BFZ89dUN3aVTXk5Z4KDgrUlm079fHsRWrzwL2aMfcr9Xj6McktrVm3UWVLl9T3a36Xn8Wsnk8/oRZN75KkDNUrSS63S59/uVKLv1klm92hJx99UB0ff0jffPeTln//s6a9Pzxl2ZeHjVPDerX0aOv7JEkxJ8/oyZ6vSpIefqqfuj31iNq2apbufkyZtVCt7r9Hcxcuk8lk0sC+XWWNvaSZ85bo/IVY9e3ZUQ/e10iSNHjkBypXpuRVo2Pp1ValUrhefeN9Tf/gDRUuWCDV6x544jm9PbSfbq9ZRTPmfqn4hCSZTUZ9v+Z3mc0mvT7wOdWsFqExH3yi5d/9LIPRoPmLV2rEa8+r8Z23a/OfO/Xh9M8Uc+K0ateorNf6P6t8oXm14odfFLllh8qWLqFFS3/QyNeeV41qEZo5b4m++W6tzCazHmzeSIuXrtKqr6ZJujzltv9znXTPXXdcta83eiyMnThbktT04e4KL3ubpk94Qx9Omy9r7EUNG9Drqs/c4XRq1mdfa9n3P8kgg9q3fUAdH3/oquUatOikqe+9rnGTZiuiQlkNfKGrPv/qW/340wbFnDytyhXLafgrz6lgWH7FnDitHi++oSEv9dT0OYt15NhJtW3ZVH26d5AkJSYmaeyk2frl9826FBcvo9Egfz8/zZnytooWKXjdetxut5YsX63lP/ys6KMnVKpkMb0+8DmVKVU8pda0vlvcbrcWLf1Bn3+5Ug6nS83urn/VviZr26W/XurdWQuWfK+oQ0f0UPPGavdwC7078fL3Qt3a1TRiUB+ZzeY0v7Pkduvp54eq/SMt1ObBJjpy7IS69xuuz6aNUXBQoJo98qy++vR9FStaSCPHTVXZ0iV04NBRrd+07Z/3tLemz/lSa37ZqKJFCuqtof1UrEhBbdm2U6+OmJByDMUnJN70ugAA8Ba+Obctm7Vuca/eem+6Fiz5TnFx8WkuF3sxTkNGfahO7Vpp5YLJanzn7ercrpWGvNQjZZk5C77RiEF9NHfK2/ph7W/avG2nJMnldiuiQhnNnDhS86aO0c+//aFfft+cofqmfrpYZUsX18qFk/XmoOdVuGAB1apeSe+PGqiiRQpqzdJPNHLwC5KkuPgEPdPxES2bP0ldn2yjUeOnyWazS5JGjZ+mUiWLafkXk9Sjy2OqXqWCFs4cJ7fbreFjPlLePEH6Zv6HeuOV3ho5bqou/ee9uL1mFflZ/NT31dHatHXHNa8fW7lqnfo/10mLZo3X7r0H9eNP6yVJRqNRYQXyafK4Ifpqzvs6FH1cX69Yk/K6qINHtGnr35o3dbQebHY57GzetktlS5fQ4tnj1b93Z40aP1UnTp3JcL2SlJCQJLdbmjd1tEYP+5+mz/lSf/29V83urq/9B6J1/MQpSZd/OG7Ztkv3Nq6b8tpiRQrq82mXp4x9M/9DdW7f+rr7sXNPlE6cOqN5H4/W3Q3qaNCICfrr7z2a9v7r6t65rd6bPEdOpyvdzzu92oICA1SqZLEMjYQuXblG5cuV0qJZ41W3djVNmblAkjTof93VollDPd2hjdYs/USN77xdR4+f1KA3J+j57k9q5YLJKle6pD765IuUdf0e+acuWC/qy0/fV+0albVo6Q/6Ye3vmjx2qD6f8Y6SEm3XrSfZjR4LyZ/BmqWfaPqEN667/nkLlytyy3bNnjRKsyaN1Mof1+nP7buvuezE6fP1zvAX9Vr/7jKZTPLzs2jsmy9p+RcfyS23Zn/+TcqyZ89ZtfqXjXpv1Csa9+bLmrtwuY4cOyFJ+vSLb3T4yHF9Pv0dfThmkIKDArX0sw9VsniRDNVjMBjkllvDX+mtbxdOUdnSJTRx+vxUy6T13fLTr5s087MlGjWknxbPHq+ihdMPM59+8Y0Gv/SsJo8dqvmLV2rY6El64dmO+nz6u9rwx1/6dcNWSWl/Z5nNZr3Sr5s+nrVIFy/Fadqni9W5XSsVCst/ze19/uW3atn8bi2eNV7RR2PU9fkhqn9HdS2ZN0EWi1mff7ky3Xqzal0AAOQEhLlM8L9eT2nAC121/Ptf1LpjX82ev1R2u+Oq5WJOnJLL7dYDTRspNCSv7rv3Tu3am7rhRM+nn1DhQmEqVrSQypYuqeijMZKkwgUL6JGHmsrtdunI0RMqFJY/w80qihQqoOgjMTp3zqoypYqr9G3F01z23oZ1VbNahGJOnpbZbNbFS3E6ceqMJGn/wWg91Lyx8uYJVpsH7tXuf2o/evyktvy1Sy/0eFL+fn6KqFBWEeXL6O/dUanWHZI3WHM/flvVKpXXkFEf6qmeg7Tlnx+UyZ5+so1K31ZcoSF5VbVyuKL/+bEbFBigDo8+IH+LRQcOHVXBsPzas/9QyuscDqdefv5p5QkOSrn+rlSJomrZ/G75+/mp8Z23q0K50orcvD3D9UpScFCgOj7+kAIDAlStcnndVa+m1m/apuCgQDVtXE8/rL0cNjf+8ZeqVS6vAvnSn1p7vf0IDAhQr65PKCDAX3fVr6W4+AT1f66zgoOD1LB+bV2Ki9e5C9Z0t5FebaVKFtPEd15LGUVOT52aVXR/k7vk52fRnXfUUPTRE2kuu+KHX9Swfi3Vu72azGazOjz6gDZc0cwmMNBfz3fvoAB/PxkMBi1duVbPPPWISpUspsCAAN3T8I7r1pPsZo6FG/HV8h/Vo8vjKpA/VAXyh+qh+xqn2Zin21NtVaxoIRmNRplMRj356IPKF5JXUQejVbBAvlR1SVK/nk8pX2heVa9SQcFBgSlhbv/BaN19Vx0VDMuvurWrKX++EB09fvKG6nmsdXMVL1pYBw4fVUjeYO39z7bT+m755ruf9MTD96tqpXD5+/mp6RUnJK6lU7tWKl60sMqWLqHiRQupzQP3qmzpEgorkE+VK5bToSPHJaX/nVWzakU1vLO23nhnivbsP6T2bR9Ic3v33VNfdWpVUXBwkGpVr6TaNSqr8Z23y9/PT/VuvzxdO6Myc10AAOQETLPMBAaDQU0b11OTRnUVuWWHxk2arZOnz+rV/3VLtVzZ0iWVNzhIy77/SXc3qKPvVv+mqpXKX7WuZCF5g2W3OyVJ1thLGj1hhvYfiFatahEym01KTLp6NGP9pm0aMupDSVLBsPxaOHOcej/TXku/XavnX3lbNapW0HPPtEvz7Hvk5u36YNpnCvD31x21qkhSynbq315d33y3VreVKKKvlq9WlYhwSdLxE6fldLrUpmO/lPXYHY6UKY1XCg4K1PPPdlC3To9owZLv1W/QGE0ZP0zVq1S4xv7nSQnFSTabxn/0qTZt2ZGybNIV++/nZ1FI3uBr7lOy/Pnyyhp76Ybq/a98+UIUe/GSJKn1A/fqnQ9m6ukObfTL+i1qdk/a09OSXW8//vv5X/lYSN7LAcxxjRMF/3Uztf3XVceiI+3tHos5pZ9/+0O/bbzcUdPtdqcaec0XklcWy79fNzEnT6t0ybRPKqQnM46FtNjtDp0+c16vjZwgo+FyEHQ6nSlTW/8rrEC+lP92uVz6eNZCrfppvSqGl5HJZFRSUlKq5ZPfUqPRqLxXvKf1bq+ulavWqUWThjpw+KjOnY9VqRJFb6iez7/6Vou+/kGlShZVwbD8V30/pPXdEnPyjB5q3jjD79F//x/973od/+zT9b6z7m/SQP0GjVGfbu3l52dJb4uptmeNvZh6P9I5LrN2XQAAeB5hLhMZDAbVr1Nd3Tu11dwFy6963s/Ponp1quurZT9q2qeL1aBuTT11jWtxrmXKrAXys1i0aNZ4GQwGjRw39ZrLNahbU2uWfnLVdp94+H61bdlUk2Z8obffm6EPxwySDAa5Xf/+4LbbHRr05gS9Pex/uvOOGpKkOQuWpTzfsH5tzf58qTr2HKSypUpoUP/uki5PJ/Tzs2j5F5My3MgkMCBAXZ98WJv/3Km//t6b8qM8LV989Z2ij8Ro0azxMpvNmjH3S+2Lis7QtqTL4SL66Am1vP+em6o3WfSRmJT3pkbVinK6nP9M69uufj07Xvf1t7ofGXUztd0IgyTXFcdOsSIFdX/Tu1JNGU5PWP58Onn6rKpVLn/N5y1ms2Iv/tsa/8qppTf8Hv4TNlwu13VH6iwWswoWyKeRg19QreqVMrQvyX78eYPW/rpJn017R0GBAVrxwy9asOS7DL223u3VNG/hcvUZOEr+fn4aOfgFBQcHSVKG6tm+c59mzluiBZ+MVYH8odqybad+/u2PDG07LH+oTp4+m6Flb0R631mXg+8iPd2hjRYu/UGPtmqWsr83y2w2KyExSUk2m/z9/OR0Om91FwAAyPGYZnmLog4dUY/+I7R1+24l2Ww6fOS4Vv20QbWqR1y1bFxcvH78aYPef+sVrVwwWcMG9FJAgH+GtmO1XpLD6ZTNbtef23enmp7o52dRks1+zWvQHE6n5iz4RsdPnJLT5ZLFbJbNdvnseFj+UJ06c07RR2OUZLMpyWZTQmKSEpOSlJCYqHmLUgfSRUt/0PPPdtDyzydp0ruDVbJ4EUnSbSWKqlql8hr74SxdvBSncxes15wGNvXTRXp/yhwdizmlJJtNGzdv196ow6pRtWIG9v+inC637A6H9h+I1s+/Xf96wZOnz2nLtp2y2x36/MtvlZiYpDvvqJHheiUpITFJP//+hxwOh378eYP+3r1fzZs0kHQ5vLe6/x5NmvG5ypctpfz5QrJkPzLCz89PdocjJfSkVduRYyfUb9CYVEHpZhQokE87du1XYmKSbDa7Wt5/t9as26ifft0kh9Op/QeitTfqcJqvv7dRXc1dsExnzp7X+QuxWvj196mev61EEa2P/FOX4uL19co1Kdd3STf+HoaG5JHJaNQff+5Uku3q0ezkUaHka0MfadlMH0z9TEePn1RiYpLWb9qm+ITE674n1thLcjgccjicOhZzSt/++Ot1X5Ns6cq1anp3PS2cOV7zp7+TcsIgo/VciL0oh8Mpu92hc+etWnLFNYTXc2+juvpy2Y+KPhqjS3Hx+mxx5lw3lt531rLvflZggL96dX1Ct9eorKmfLr7l7ZUoVlgul0vrI7fp1OmzGjtxlozGzLsVCAAAORFh7haVK11Sj7dprqmzFqr1ky/ohVdHq3jRQnr+2SevWjY4OEhVKoWrXfcBatKmu5o/2lPPvDBM2/7ee93tdH2yjaIOHtEjnf6nFavWqekVHecun7F368tlP171OpPRqNC8eTXw9ff0ULs+2rp91+WOcpJK31ZcbR68V936vq43xkxRnuAg9e7WTqPGTVO3vq8rb3CwSpUsmrKuhvVra8Q7H6vpw8+q2SPP6olnXtaSFasvn3Uf/IKcLpfadRugLr0Ha826yKuuG+z0eEtJBg14fZwefKK3Jk6fr4EvdL3uqJwkPfHw/XI4HHr4qX6a+dmSDE2JzBMcqG+++0ktO/TRjz+v17g3X1ZQYECG65WkcmVKasu2nWrdsa9mffa13nnjxVRdIB+4r5E2bd2R6vPI7P3IiIrhpVW2VAlNnvlv05Fr1XYpLl6HjxxX4n+m/92otg811fkLsXqk8/+09tdNKlWymMa+8ZLmLPhGLR7rpaFvT9Kh6GNpvr57p7YqV6akOvYcpP+9Nkbly5VK9fyznR/TvgPR6vDsQJ08dVaPtvr3Xo03+h4GBQaoW6e2GjzyAz0/8C25XKkbyIQVyKe76tXSe5PnSJKe7tBaDevXUt9X31abp/pqwZLvdMEae9335IFmDVWiWBE92qW/xk6cpfv/Cf0Z0bB+bX21bLXua9tDTR/urtYd+2rspNlyOl0ZqufOOjXUoF5Ndez5ql4b+YHubZT+dW9Xatuyqe5teId6vfSmuvcbrgrlSinAP2MnmdKT1neWNfaips5epH69npLBYFDfHk/qu9W/atfeA7e0vbAC+fRs50f11nvTNWD4e3rkoabXvYYVAABvZ7DZkq4ezkGW2PLXLn3x5bcaM7y/jEaj4uLiNe6jOYqLi9e7I17ydHnpuhQXr14vvamPxw9T3jzBstsdWvbdT5o8c4F+XDLd0+VdJXmK243cCPtmWGMv6olnXtaiWeMVGpI3S7d1o3Jybf+1a+8B9Rs0JqWtfG7zwqtvq0+39qoSES6Xy6V9B6LVre8wzZw4UhHly3i6PAAAkEMxMpeNDh0+pguxFxV99ITsdocORh/XwcNHVaPa9acZetqZs+d19twFHTh8TDabXcdPnNKO3ftV0wtqzwput1tx8QmaOG2+2rZslqPCUk6uDdd24NBRHYw+pktx8Tp/IVZb/tql0Lx5dVuJotd/MQAAyLVogJKNHrr/bu09cFh9BoxSQmKSihQOU5sH7lWHR9Nuy51TlL6tuLo++YjefHeKzpy7oPyhIWp05+3q/1xnT5fmEYeij+vZ/sNVu3pl9e+ds96DnFwbru2NV3pr8swFGjtxtoICA1S9SgVNenewggIDPF0aAADIwZhmCQAAAABeiGmWAAAAAOCFCHMAAAAA4IUIcwAAAADghQhzt8DtdsvhcFzzZt0AAAAAkJUIc7fA6XSqccuucjqdni5F0uV6tm37K8fUAwAAACDrEOZ8iNPp0vbt2+V0ujxdCgAAAIAsRpgDAAAAAC9EmPMhJpNR1atXl8nExwoAAAD4OrOnC0DmMZlMqlmzhqfLAAAAAJANGMLxIQ6HQ6tXr5HD4fB0KQAAAACyGGHOh7hcbsXExMjl4lYJAAAAgK8jzAEAAACAFyLMAQAAAIAXIsz5EJPJqPr169PNEgAAAPhHbGSkHFZruss4rFbFRkZmU0WZh1/9PsRkMqlChfIymUyeLgUAAADwuNjISO3r3Ud7e/RMM9A5rFbt7dFT+3r38bpAl+Ew9+ob72vLtp1ZVsjIcVO1Zl3WvXkj3p2iM2fPZ9n6cwK73a5ly5bLbrd7uhQAAADA44IiIhQYHq743buvGeiSg1z87t0KDA9XUESEhyq9OblmZG74K71VMCy/p8vIUm63ZLVa5aaZJQAAme7sRbvW7bbq7EVOmgLewhwaqorTpymoUqWrAt2VQS6oUiVVnD5N5tBQD1d8Y9K9afiipT9o4dffq0jhMJ0/HytJ+nXDVk3+5As5XU490/ERPdCskc6dt+rNsR8r5uQZVShXSsNf6a3tO/dq3qIVspjNOnTkuOrWrqaXn+8ig8Fw3aKij8Zo1PhpssZeVP06NfRi7846ceqs3pv8qU6eOiuLxaIxw/urUFh+9Rk4Si2aNNSSFas1akhfvTrifbVuca9W/PCLLBazPhj9qvLmCVbbLv01a+JIJSQkavSET1SyeBFFbtmuWtUraejLPeV2uzX+ozn6LXKrTp46qyKFw/TCs0+q2d31M+edBgAAXmvuupN6ffFB2Rxu+ZkNevPxsurcuIinywKQAcmBLjm47e3RU+XGjdWBAQO9OshJ6YS5/QePaNHSHzRz4pvy87Ooz4C3dCH2kj6Z95VmfDhCZpNJz708Uvfdc6cmfDxPj7Vprkb1a2vmZ1/rp982KSx/qI7FnNSUccMUkjdYz/7vDW3Ztkt1alW5blFvvzddA17oqgrlSunt92fo791RKlempPr26KhSJYvp41kL9c23a9W906OSpO279mnWpJEyGAyKT0hU/nwhmjPlLQ14fbx+27hVDzRrlGr9O/dE6cXendWv11N6+Kl+OnX6rGJOndX2XXu1aNZ4/bphi37+bTNBDgCAf3z/93l9v/OCp8vwiESbS8vWn1LybVxtDrcGLzig9dGXFODn3ZOcWlTJpxZVfXvmEiBdHeh2tGotSV4d5KR0wtzWv3apSaO6ypsnWJJUsEA++VksOnP2gp576U1J0sW4eF2wXtSmrTt08PAxTf90sWx2hx55qKnC8oeqZPGiKpD/8htTt3Y17dl/6LphLi4+Qbv2HtSocVMlSYlJNt1Vt6aqVS6vi5fiNOHjedq2Y4/Cy96W8pq2LZumGvGrX6e6DAaDKoaX1rl/RhSvVKRQmMqWLiFJKlOquM5diFWBfCFKSrIrKTFJ5y9c/Zpki79ZpS+XrZIkuXPYfEaz2aSmTZvIbKYBCgAgcyXYXTof7/R0GR5x1mpLCXLJXG7p6LkkhYX4eaaoTJJgd3m6BCDbmENDVW7c2JQgJ0nlxo312iAnpRPmHE6n4hMSUz3mllt1albW28P+d9XyH783TMFBgSn//m+zFLPZJH9/y/UrcrsVFBSgTye/lSqgrV0XqcXfrFKPLo+pepUK+j3yz5TnjMZrnxUzmYzXDVzJy5QoVlh58wSp76DRyhMcrNf6d7/m8o+3aa7H2zSXJDkcDjVu2fX6+5RNjEajihcv7ukyAAA+KNBiVP6g3HmyMNDsr60GpQp0RoN0WwF/+Xv5yFygxbvrB26Ew2rVgQEDUz12YMBA3xyZqxoRrq9XrFaSzSabza4jx04oKcmmP7fv0aHoYypTqkTKtWV1albRF199q+6dHtW5C9aUUHfuvFWJSTY5HQ6t/XWTRl8jBCYzSHK5XAoODlLxooW18sd1atn8bp08dVaFCxXQ5m27dPdddVSzWoSmzVmc6W9E9NEY5c0TrPdGDbz+wjmUzWbXkiVfqW3bR+Xnl4HgDABABrWomj9XT8drUCqPhi8+qCSHW/5mg0ZwzRzgVf7b7OTKa+b29ujptYEuzTBXvUoF3d3gDnV+brBK31ZMRYsUVIF8IRr8Ug8NGTVRJpNR1atU0MC+z+jF3p311nvT9VTPQcqbJ0jDX+ktSUpMStKrb7ynE6fO6PE296dMbbyW2jUra9l3P+m+e+7U6wN7afT7MzR/8UqF5c+nt4f10wPNGurdD2fq59//UM2qmd8ytGjhgtq996A69nhVfn4WlSlVXN2eaqtSJYtl+raykt3u8HQJAAD4nM6Ni+ihWgW063i8KhcPUlheTpoC3iKtrpX/bYrijYHOYLMlZcmFX1u27dRni1dq/MgBWbH6TLfs+591KS5eTz76oBwOh4a8NVF31KqqJx6+P83XJE+zXLditszmdBuDZgubza6FCxeqXbt2jMwBAAAg17ve7Qe8/fYE2Z5ABrw+XqdOn031WOf2rdX83gbZXUoq1SuX17iPPtW3P/6qpCSbateopNYt7vFoTQAAAABuXvyePUqIikozqF05QpcQFaX4PXsUUq+eh6q9cVk2Mpcb5LSROZfLpdjYWIWEhKTZFAYAAADITWIjIxUUEZHuiJvDavW6ICd5YGQOWcdgMCgoKDhDN2YHAAAAcoOMBDRzaKjXBTlJYvjGh9jtDi1cuJAmKAAAAEAuQJgDAAAAAC9EmAMAAAAAL0SYAwAAAAAvRJjzIRaLWe3atZPFQl8bAAAAwNcR5nyI2+1WfHyc3G7uNgEAAAD4OsKcD3E4nFq+fIUcDqenSwEAAACQxQhzAAAAAOCFCHMAAAAA4IUIcz6G5icAAABA7sAvfx/i52dR+/btPV0GAAAAgGzAyJwPcblcOn78uFwul6dLAQAAAJDFCHM+xOFwas2atXSzBAAAAHIBwhwAAAAAeCHCHAAAAAB4IcKcDzEYpNDQUBkMnq4EAAAAQFajm6UPsVgsat26lafLAAAAAJANGJnzIU6nU/v27ZfTSQMUAAAAwNcR5nyI0+nSxo0b5XRyawIAAADA1xHmAAAAAMALEeYAAAAAwAsR5nyI0WhQsWLFZDTSzhIAAADwdXSz9CFms1nNmjX1dBkAAAAAsgEjcz7E6XRq27a/6GYJAAAA5AKEOR/idLq0fft2ulkCAAAAuQBhDgAAAAC8EGEOAAAAALwQYc6HGI0GhYeH080SAAAAyAXoZulDzGazGjS409NlAAAAAMgGjMz5EIfDofXrN8jhcHi6FAAAAABZjDDnQ1wut6KiouRyuT1dCgAAAIAsRpgDAAAAAC9EmAMAAAAAL0SY8yEmk1HVq1eXycTHCgAAAPg6uln6EJPJpJo1a3i6DAAAAADZgCEcH+JwOLR69Rq6WQIAAAC5AGHOh7hcbsXExNDNEgAAAMgFCHMAAAAA4IUIcwAAAADghQhzPsRkMqp+/fp0swQAAAByAbpZ+hCTyaQKFcp7ugwAAAAA2YAhHB9it9u1bNly2e12T5cCAAAAIIsR5nyI2y1ZrVa5aWYJAAAA+DzCHAAAAAB4IcIcAAAAAHghwpwPMZtNatq0icxmk6dLAQAAAJDF6GbpQ4xGo4oXL+7pMgAAAABkA0bmfIjNZteCBQtks9HNEgAAAPB1hDkfY7c7PF0CAAAAgGxAmAMAAAAAL0SYAwAAAAAvRJjzIWazSa1ataSbJQAAAJALEOZ8iMFgUFBQsAwGg6dLAQAAAJDFCHM+xG53aOHChTRBAQAAAHIBwhwAAAAAeCHCHAAAAAB4IcIcAAAAAHghwpwPsVjMateunSwWs6dLAQAAAJDFCHM+xO12Kz4+Tm6329OlAAAAAMhihDkf4nA4tXz5CjkcTk+XAgAAAB8WGxkph9Wa7jIOq1WxkZHZVFHuRJgDAAAAkGGxkZHa17uP9vbomWagc1it2tujp/b17kOgy0KEOQAAAAAZFhQRocDwcMXv3n3NQJcc5OJ371ZgeLiCIiI8VKnvSzfMxZw4rad6Dkrz+S3bdmrkuKk3vfG2Xfpfd5nVv2xUp+de04y5X97QukeOm6ot23beZGXei+YnAAD86+xFu9bttursRbunSwF8hjk0VBWnT1NQpUpXBborg1xQpUqqOH2azKGhHq7Yd+X4kblvvl2rl/p00bOdH/N0KTmen59F7du3l5+fxdOlAADgcXPXndQdQzerw8SdumPoZs1dd9LTJQE+41qBLjE6miCXzTI0jBN7MU7jJs3S4aMxcjicGvnaC7JYzHpz7FTFJySqS+/BmvTuEF2wxmrU+Gmyxl5U/To19GLvzlq5ap32Rh3SiZNntXNPlJ7t/JgefqiJevQfoTNnz6tL78F64dknVa9O9au2+/mXK7V95z6NmfCJXuzdWX4Wi2bM/VLW2EsKL3ubRgzqI6PRqMgtOzRpxudyu9xq0ewumYxGrV0XqW079qhB3Zp6+fmntez7n/XFl99Kkp587EG1anGPYk6c1vjJc5QvNK8cDof6dGuvQW9+oEtx8apUoYyGv9JHJlOOz7spXC6XTpw4oaJFi8po9J66AQBZ7/u/z+v7nRc8XUa2SbS5tGz9Kbn+afBsc7g1eMEBrY++pAC/3Ps3skWVfGpRNb+ny4CPSA50yQFuR6vWkkSQy0YZCnPBQYHq3K61KoSX1tKVazV/8QoNHdBLPbo8pi1/7dKwAb0kSa8MH68BL3RVhXKl9Pb7M/T37ihJ0l9/79Okd17T4aMxen30R3r4oSZ6c1Af9XnlLc2Z8naa233ysYe0bsMW9e3RUZUrltOxmFN6d8RLyhMcpOdeHqk/d+xReJmSevu96Zr07mCVKFZYF6wXlT9fiNZt2KJnOz2q22tW0YFDRzV7/teaM/ktSVLXF4apWuXy8vfz0/pNf2rC26+qbu1qmr94papEhOvl57vo5Omz1wxyi79ZpS+XrZKkHHcLAIfDqTVr1qpdu3byy8V/qAAAV0uwu3Q+Pvd0Oz5rtaUEuWQut3T0XJLCQvw8U1QOkGB3eboE+BhzaKjKjRubEuQkqdy4sQS5bJKhMGcyGWU2mzV55gJt37lPpmuM+sTFJ2jX3oMa9c81dIlJNt1Vt6YkqWql8goODlLF8mV0/kLsTRdbtHBB/fL7H1r/xzadOn1WJ06eUUJCompUraCSxYtIkvLnC7nqdZu37VT9OjUUHBwkSbrzjhr648+dalivlm4rUUx1a1dLefz1MR/pi6++VduWza5Zw+NtmuvxNs0lSQ6HQ41bdr3p/QEAILsEWozKH2TydBnZJtDsr60GpQp0RoN0WwF/+efiE56Blty778gaDqtVBwYMTPXYgQEDGZnLJhkKczt27de4SbPVu1t7Nb7zdk2ZteDqhdxuBQUF6NPJb8lgMKQ8vOKHX/7dmMl0S6NZH0ydJ6fLpQ5tH1RggL/cbrdcbrckw3Vfa0hjkSuDabkyJTVjwhtasnKNOvcerFmTRirPPwEQAABv1qJq/lw3va5BqTwavvigkhxu+ZsNGvF4WXVuXMTTZQE+47/NTsqNG6sDAwamXENHoMt66Z+eMRjkcru0bcce1apeSfXrVNfB6GMpTxcuVECnTp+T2+1WcHCQihctrJU/rpMknTx1Nt3glj9fiOLi4mWzZby71OY/d+qRB5uoRPHCOnj4uCSpakS4tm7frZiTZ+R2u3X8xClJUpFCYTp15pwk6faalbXhj78UF5+guPgEbfjjL9WpWeWq9e/Zf0gGo0HtH2khPz+LjsWcynBtOYHBIIWGhqYZXAEAyE06Ny6iTaPqaEG/Kto0qg5BDshE1+paGVCqVJpdLpE10g1zhQsWkNlkVt48Qdqxa5969B+hc+f+/UCqV66gi5fi1KX3EB0/cUqvD+ylZd/+pKd6DdJb701XXHxCmusOCPBXk0b11LHnq/rp100ZKrZ92xYaNvojDRk1UYULFZAkFcgfqgEvPK2Xh45V1xeG6vs1v0uSWjRtqInTP9fo92covMxterpDG/XsP0I9+49Q5/atVbZ0iavWfzzmlHq/PFLtug1Q1UrhqlCuVIbqyiksFotat24li4VulgAASFJYXosaRYQqLC9/G4HMkt7tB9K7bQEyn8FmS8pZXTy8SPI1c+tWzJbZ7Pn7uzmdTh04cFDlypWVyZR7rosAAABA9omNjNS+3n0UGB6e5lTK5MCXEBWlClMmK6RePQ9U6vs8n0B0eXrjW+OnXfX4tPeHKyDA3wMVeSen06WNGzeqdOnShDkAAABkiZB69VRhymQFRUSkeU1c8ghd/J49BLkslCPCXET5MuneogAAAABAzpGRgGYODSXIZTH60wIAAACAFyLM+RCj0aBixYrJaKSdJQAAAODrcsQ0S2QOs9msZs2aeroMAAAAANmAkTkf4nQ6tW3bX3I6nZ4uBQAAAEAWI8z5EKfTpe3bt8vpdHm6FAAAAABZjDAHAAAAAF6IMAcAAAAAXogw50OMRoPCw8PpZgkAAADkAnSz9CFms1kNGtzp6TIAAAAAZANG5nyIw+HQ+vUb5HA4PF0KAAAAgCxGmPMhLpdbUVFRcrncni4FAAAAQBYjzAEAAACAFyLMAQAAAIAXIsz5EJPJqOrVq8tk4mMFAAAAfB3dLH2IyWRSzZo1PF0GAAAAgGzAEI4PcTgcWr16Dd0sAQAAgFyAMOdDXC63YmJi6GYJAAAA5AKEOQAAAADwQoQ5AAAAAPBChDkfYjIZVb9+fbpZAgAAALkA3Sx9iMlkUoUK5T1dBgAAAIBswBCOD7Hb7Vq2bLnsdrunSwEAAACQxQhzPsTtlqxWq9w0swQAAAB8HmEOAAAAALwQYQ4AAAAAvBBhzoeYzSY1bdpEZrPJ06UAAAAAyGJ0s/QhRqNRxYsX93QZAAAAALIBI3M+xGaza8GCBbLZ6GYJAAAA+DrCnI+x2x2eLgEAAABANiDMAQAAAIAXIswBAAAAgBcizPkQs9mkVq1a0s0SAAAAyAUIcz7EYDAoKChYBoPB06UAAAAAyGKEOR9itzu0cOFCmqAAAAAAuQBhDgAAAAC8EGEOAAAAALwQYQ4AAAAAvBBhzodYLGa1a9dOFovZ06UAAAAAyGKEOR/idrsVHx8nt9vt6VIAAAAAZDHCnA9xOJxavnyFHA6np0sBAAAAkMUIcwAAAADghQhzAAAAAOCFCHM+huYnAAAAQO7AL38f4udnUfv27T1dBgAAAIBswMicD3G5XDp+/LhcLpenSwEAAACQxQhzPsThcGrNmrV0swQAAAByAcIcAAAAAHghwhwAAAAAeCHCnA8xGKTQ0FAZDJ6uBAAAAEBWo5ulD7FYLGrdupWnywAAAACQDRiZ8yFOp1P79u2X00kDFAAAAMDXEeZ8iNPp0saNG+V0cmsCAAAAwNcR5gAAAADACxHmAAAAAMALEeZ8iNFoULFixWQ00s4SAAAA8HV0s/QhZrNZzZo19XQZAAAAALIBI3M+xOl0atu2v+hmCQAAAOQChDkf4nS6tH37drpZAgAAALkAYQ4AAAAAvBBhDgAAAMgksZGRclit6S7jsFoVGxmZTRXBlxHmfIjRaFB4eDjdLAEAADwgNjJS+3r30d4ePdMMdA6rVXt79NS+3n0IdLhlhDkfYjab1aDBnTKbaVIKAACQ3YIiIhQYHq743buvGeiSg1z87t0KDA9XUESEhyqFr8jyMNdn4CjFnDid5vMjx03VmnUZPyux4odfNG7Sp5lRWoqLl+LUtkv/LFt/dnE4HFq/foMcDoenSwEAeLGzF+1at9uqsxftni4F8Crm0FBVnD5NQZUqXRXorgxyQZUqqeL0aTKHhnq4Yng7RuZ8iMvlVlRUlFwut6dLAQB4qbnrTuqOoZvVYeJO3TF0s+auO+npkgCvcq1AlxgdTZBDlsjS+XgfTpuv7Tv36aVhY/VAs0aKOhitw0dj5HA4NfK1F1SuTElJ0m8bt+qLr77VBetFvdSni+68o4ZmzP1SgQEBeuqJloo5cVoDXh+vz6aNSbX+fVGH9eG0+TpvjVWBfKEaM7y/ggID1Pm5wWr9wD369sdfNXncEAUGBFxV26W4eI0cO1VHY04q/J86AAA5w/d/n9f3Oy94uoxcJ9Hm0rL1p5R8TtDmcGvwggNaH31JAX6c/81MLarkU4uq+T1dBrJIcqBLDnA7WrWWJIIcMl2Whrl+PTtq7a+Rem/kQBUuFKYDh46oQnhpLV25VvMXr9DQAb0kSaF582joe69r34FovfrGe/pqzoQMrb9A/lC9/spzKhSWX8PHTNbaXyPVsvnduhQfr9iLlzRz4psyGK7dDGTW/K9VongRvfPGi9obdVivjng/Q9tc/M0qfblslSTJ7WYEDACyQoLdpfPxTk+Xkeuctdr038kdLrd09FySwkL8PFOUj0qwc09YX2cODVW5cWNTgpwklRs3liCHTJVtnTJMJqPMZrMmz1yg7Tv3yWT89wxftSoVZDAYVKFcKSXZ7LLGXsrQOgvkD1Xklh2aPf9r7dl/SKVKFkt57tFW96UZ5CRp85879eZrz0uSihUpmOH9eLxNcz3eprmky9eoNW7ZNcOvzWomk1HVq1eXycTZUwDeLdBiVP4gk6fLyHUCzf7aalCqQGc0SLcV8Jc/I3OZKtDC++nrHFarDgwYmOqxAwMGMjKHTJVtYW7Hrv0aN2m2endrr8Z33q4psxZctYzBYJDFbJa/v0WS5HCmf1b2i6++1fZd+9W5XSuVLF5EcfEJKc8Zjel/STqdLsUnJN7EnuRcJpNJNWvW8HQZAHDLWlTNzxQ0D2lQKo+GLz6oJIdb/maDRjxeVp0bF/F0WYBX+W+zk3LjxurAgIEp19AR6JBZsvy0UJGCBXTqzDlt27FHtapXUv061XUw+liqZY6fOCVJ2rh5uwoXKqDAgADlzxeiPfsOyuVy6cefN/y7sEFyuy9PTfjjz516oGlDVQwvo/0Hj9xQXVUrhWvd+i2SpF17D15z/d7G4XBo9eo1dLMEANy0zo2LaNOoOlrQr4o2japDkANu0LW6VgaUKpVml0vgVmR5mGvZ4h4NfWui9uw/pB279qlH/xE6dy71wXv0+El16ztMU2cv0uAXe0iSmjSup+hjJ/Rkj1cVViCf9M+MycoVyilyyw5ZYy/qkZZNNWXWAr009F3lCQ66obq6dWqrzX/+raefH6I/tu6Qn8Vy1fq9jcvlVkxMDN0sAQC3JCyvRY0iQhWW1+LpUgCvkt7tB9K7bQFwsww2WxK//G9S8jVz61bMzhE36rbZ7Fq4cKHatWsnPz/+AAMAAGSn2MhI7evdR4Hh4WlOpUwOfAlRUaowZbJC6tXzQKXwFZ5PIFlszAefaOfuqFSPPXhfIz352EMeqggAAAC+KKRePVWYMllBERFpXhOXPEIXv2cPQQ63jJG5W5DTRuacTqcOHDiocuXKymSiCxwAAADgyzyfQJBpTCaTKlQo7+kyAAAAAGQDbnLiQ+x2u5YtWy673e7pUgAAAABkMcKcD3G7JavVKjcTZwEAAACfR5gDAAAAAC9EmAMAAAAAL0SY8yFms0lNmzaR2UwnSwAAAMDX0c3ShxiNRhUvXtzTZQAAAADIBozM+RCbza4FCxbIZqObJQAAAODrCHM+xm53eLoEAAAAANmAMAcAAAAAXogwBwAAAABeiDDnQ8xmk1q1akk3SwAAACAXIMz5EIPBoKCgYBkMBk+XAgAAACCLEeZ8iN3u0MKFC2mCAgAAAOQChDkAAAAA8EKEOQAAAADwQoQ5AAAAAPBChDkfYrGY1a5dO1ksZk+XAgAAACCLEeZ8iNvtVnx8nNxut6dLAQAAAJDFCHM+xOFwavnyFXI4nJ4uBQAAAEAWI8wBAAAAgBcizAEAAACAFyLM+RianwAAAAC5A7/8fYifn0Xt27f3dBkAAAAAsgEjcz7E5XLp+PHjcrlcni4FAAAAQBYjzPkQh8OpNWvW0s0SAAAAyAUIcwAAAADghQhzAAAAAOCFCHM+xGCQQkNDZTB4uhIAAAAAWY1ulj7EYrGodetWni4DAAAAQDZgZM6HOJ1O7du3X04nDVAAAAAAX0eY8yFOp0sbN26U08mtCQAAAABfR5gDAAAAAC9EmAMAAAAAL0SY8yFGo0HFihWT0Ug7SwAAAMDX0c3Sh5jNZjVr1tTTZQAAAADIBozM+RCn06lt2/6imyUAAACQCxDmfIjT6dL27dvpZgkAAADkAoQ5AAAAAPBChDkAAAAA8EKEOR9iNBoUHh5ON0sAAAAgF6CbpQ8xm81q0OBOT5cBAAAAIBswMudDHA6H1q/fIIfD4elSAAAAAGQxwpwPcbncioqKksvl9nQpAAAAALIYYQ4AAAAAvBBhDgAAAAC8EGHOh5hMRlWvXl0mEx8rAAAA4OvoZulDTCaTatas4ekyAAAAAGQDhnB8iMPh0OrVa+hmCQAAAOQChDkf4nK5FRMTQzdLAAAAIBcgzAEAAACAFyLMAQAAAIAXIsz5EJPJqPr169PNEgAAAMgF6GbpQ0wmkypUKO/pMgAAAABkA4ZwfIjdbteyZctlt9s9XQoAAACALEaY8yFut2S1WuWmmSUAAADg8whzAAAAAOCFCHMAAAAA4IUIcz7EbDapadMmMptNni4FAAAAQBYjzPkQo9Go4sWLy2jkYwUAAAAyKjYyUg6rNd1lHFarYiMjs6mijOFXvw+x2exasGCBbDa6WQIAAAAZERsZqX29+2hvj55pBjqH1aq9PXpqX+8+OSrQ+XyYmzH3S322aIWny8g2drvD0yUAAAAAXiMoIkKB4eGK3737moEuOcjF796twPBwBUVEeKjSq/l8mAMAwFecvWjXut1Wnb3IDAwAyCzm0FBVnD5NQZUqXRXorgxyQZUqqeL0aTKHhnq44n+ZPV1AZnK73Rr/0Rz9FrlVJ0+dVZHCYQr091eZUsX1witv68SpM3qm4yNqef/dWvHDL9qz/5COnzitqIPReun5p/X7xj+14Y9tann/3Xq282Oe3h0AAFLMXXdSry8+KJvDLT+zQW8+XladGxfxdFkA4BOSA11ycNvbo6fKjRurAwMG5tggJ/lYmPtr5z5t37VXi2aN168btujn3zarRLFCOnj4mCa8/YqssZfUsecg3duoriRp+859mvTuYK2P3KaRYz/WtPff0LOdH9WjXV7UMx3bymTyroFLs9mkVq1a0s0SQI7x/d/n9f3OC54uw+sl2lxatv6UXO7L/7Y53Bq84IDWR19SgJ93/a26ES2q5FOLqvk9XQaAXOK/gW5Hq9aSlGODnORjYa5AvhAlJdmVlJik8xdiUx6vEhEus9mssAL5VLJ4EUUfjZEkVa1UXsFBgYqoUEaFwgqoTKnikqSQkDy6FBen0JC8V21j8Ter9OWyVZIujwTmJAaDQUFBwTIYDJ4uBQAkSQl2l87HOz1dhtc7a7WlBLlkLrd09FySwkL8PFNUNkiwuzxdAoBcxhwaqnLjxqYEOUkqN25sjgxyko+FuRLFCitvniD1HTRaeYKD9Vr/7lqx6pdUy5jNJgX4+6d+zGS6apm0ctrjbZrr8TbNJUkOh0ONW3bNtPpvld3u0MKFC9WuXTv5+Vk8XQ4AKNBiVP4gZgvcqkCzv7YalCrQGQ3SbQX85e/DI3OBFt/dNwA5k8Nq1YEBA1M9dmDAQEbmskP00RjlzROs90al/gBiTp6R2+3WwcPHdPbcBd1Wooh27onyUJUAkHu0qJqfaXKZpEGpPBq++KCSHG75mw0awTVzAJCp/tvs5Mpr5vb26JkjA51PhbmihQtq996D6tjjVfn5WVSmVHG5XG6ZTCb1fHGE4hMSNWxAL5nNPrXbAIBcoHPjInqoVgHtOh6vysWDFJaXGRgAkFnS6lr536YoOS3QGWy2pJx14dctWPb9z7oUF68nH31QDodDQ96aqDtqVdUTD9+fJdtLnma5bsXsHBEQbTY70ywBAACAG3C92w/k5NsT+NRk9OqVy+u3jVvVpc8QPdXrNeXPF6LWLe7xdFnZxmIxq127drJYPB8sAQAAAG8Qv2ePEqKi0gxqV96HLiEqSvF79nio0qv51MhcdstpI3Mul0uxsbEKCQmR0ehTOR0AAADIMrGRkQqKiEh3xM1htSp+zx6F1KuXjZWlj1/8PsThcGr58hVyOGgDDgAAAGRUSL161506aQ4NzVFBTiLMAQAAAIBXIswBAAAAgBcizPkYmp8AAAAAuQO//H2In59F7du393QZAAAAALIBI3M+xOVy6fjx43K5XJ4uBQAAAEAWI8z5EIfDqTVr1tLNEgAAAMgFCHMAAAAA4IUIcwAAAADghQhzPsRgkEJDQ2UweLoSAAAAAFmNbpY+xGKxqHXrVp4uAwAAAEA2YGTOhzidTu3bt19OJw1QAAAAAF9HmPMhTqdLGzdulNPJrQkAAAAAX0eYAwAAAAAvRJgDAAAAAC9EmPMhRqNBxYoVk9FIO0sAAADA19HN0oeYzWY1a9bU02UAAAAAyAaMzPkQp9Opbdv+opslAAAAkAsQ5nyI0+nS9u3b6WYJAAAA5AKEOQAAAADwQoQ5AAAAAPBChDkfYjQaFB4eTjdLAAAAIBegm6UPMZvNatDgTk+XAQAAACAbMDLnQxwOh9av3yCHw+HpUgAAAABkMcKcD3G53IqKipLL5fZ0KQAAAACyGGEOAAAAALwQYQ4AAAAAvBBhzoeYTEZVr15dJhMfKwAAAODr6GbpQ0wmk2rWrOHpMgAAAABkA4ZwfIjD4dDq1WvoZgkAAADkAoQ5H+JyuRUTE0M3SwAAACAXIMwBAAAAgBcizAEAAACAFyLM+RCTyaj69evTzRIAAADIBehm6UNMJpMqVCjv6TIAAAAAZAOGcHyI3W7XsmXLZbfbPV0KAAAAgCxGmPMhbrdktVrlppklAAAA4PMIcwAAAADghQhzAAAAAOCFCHM+xGw2qWnTJjKbTZ4uBQAAAEAWo5ulDzEajSpevLinywAAAACQDRiZ8yE2m10LFiyQzUY3SwAAAMDXEeZ8jN3u8HQJAAAAALIBYQ4AAAAAvBBhDgAAAECGxUZGymG1pruMw2pVbGRkNlWUexHmfIjZbFKrVi3pZgkAAIAsERsZqX29+2hvj55pBjqH1aq9PXpqX+8+BLosRpjzIQaDQUFBwTIYDJ4uBQAAAD4oKCJCgeHhit+9+5qBLjnIxe/ercDwcAVFRHio0tyBMOdD7HaHFi5cSBMUAAAAZAlzaKgqTp+moEqVrgp0Vwa5oEqVVHH6NJlDQ296WzEnTqvvq6M1ZsIneuzpFzVnwTf6/Ktv1bHHq3pxyLtyOl2aOnuRuvV9XY93fUmrflovSRo88gOt27BFbrdbvV56UwcPH8uUfc+JCHMAAAAAMuxagS4xOjpTg1yy3fsOqsOjD2ra+8P18axFKlQgv+Z8/LZOnTmnHbv26d5GdfXJhyP0/luvaMrMhZKk5599UjPmfqkNf/ylsqVLqGzpErdcR07FTcMBAAAA3JDkQJcc4Ha0ai1JmRrkJKlwwQIqU6q4JCmsQD7dUbuqzCaTypctpXPnrapZPUKfLV6hnXsO6NSZc5KkEsUKq07Nqhoz4RN98uGITKkjp2JkDgAAAMANM4eGqty4sakeKzdubKYFuau2d0WTP7PZpITEJD0/8C0VLJBPr/Z7RoEB/inPH4s5qYAAfyXZ7FlSS05BmPMhFotZ7dq1k8XCgCsAAACylsNq1YEBA1M9dmDAwOvetiCznL8QK4vFohZNG+rc+Vgl2WySpD/+/Fv+fn7q17OjJk6fny21eAphzoe43W7Fx8fJ7XZ7uhQAAAD4sP82O6m2fNk1m6JkpSKFw1SyWGE93WeIln67VkUKhcnlcmnyJwvUo8tjuqteLSUkJGrT1h1ZXounGGy2JH753ySHw6HGLbtq3YrZMps9Pxpms9m1cOFCtWvXTn5+Fk+XAwAAAB+UVtfKzO5mietjZA4AAABAhqQX2NK7bQGyBmEOAAAAQIbE79mjhKioNEfergx0CVFRit+zx0OV5g6enxuITEXzEwAAAGSVkHr1VGHKZAVFRKQ5hTI50MXv2aOQevWyucLchWvmbkFOu2YOAAAAQO7BNEsf4nK5dPz4cblcLk+XAgAAACCLEeZ8iMPh1Jo1a+VwOD1dCgAAAIAsRpgDAADAVWIjI6/bidBhtSo2MjKbKgLwX1zoBQAAgFRiIyO1r3cfBYaHp3mvsOQW9QlRUaowZTKNLnKxsxft2nksXlVKBCksb8661/HeqMOa8PFcTR47VCtXrZMkPdS8caZuY8u2nfps8UqNHzkgZZvvffSpLsUnKF9IXg3s21WlbysuSWrbpb+CAgKUZLMpT3CQBvXvrkoVyt70tr12ZC7mxGk91XOQ9h+I1gdT53m6nBzBYJBCQ0NlMHi6EgAA4M2CIiIUGB6e5r3CrrzXWGB4uIIiIjxUKTxt7rqTumPoZnWYuFN3DN2suetOerqkND3UvHGmBLkVP/yiFT/8cs3n4uLiNWjEBL30/NOa9/Fo9er6hAa8Pl5JNlvKMh+NHaJFs8are+dHNW7S7FuqxetH5sqXK6X/9erk6TJyBIvFotatW3m6DADwKTn5jDOQVZJbyycHtr09eqaM0KV302j4vu//Pq/vd16QJCXaXFq2/pRc//TGtzncGrzggNZHX1KAn1EtquRTi6r5b2o7MSdO6+33Z6hEscLatHWHHn6oiSwWi5Z9+5OKFA7TuDcHyGQy6tcNWzX5ky/kdDn1TMdH9ECzRjp1+qxGvPuxLl6KU/FihVPWOWPulwoMCNBTT7TU6l826ouvvlXsxTjdVa+m/terk2JOnNboCZ+oZPEiityyXbWqV9LQl3ve2Puzdr0a3VlbFcNLS5KqV6mgGlUr6uff/tD9Te5KWc5gMOiOWlU0+r0ZN/X+JPPakblkW7bt1MvDxkm6/AFNn/Ol+g9+Ry07PK/fNm6VJMUnJGrY25PUvvtA9R/8jmIvxsnhcGjMB5+oW99hatdtgLZs25myjjkLvlGP/iO06qf1Htuvm+F0OrVv3345nTRAAYDM4E1nnIHMduXNn5MDXWJ0NEEul0uwu3Q+3qnz8U4dPZuUEuSSudzS0XNJOh/vVIL91jqs7953UB0efVDT3h+uj2ctUqEC+TXn47d16sw57di1TxesFzVl1gLN+HCE5k4ZrYVf/yCHw6EJUz/TvY3qas6Ut/XgfY2uue7wMiU18Z3B+mzqaP302x+KOXFakrRzT5SeePh+zZs6RuvWb9Gp02dTXvPTr5vUpfdgTZ9zOXN06T1YP/26KdV6o4/GqMI/QS5ZxfDSOhR9PNVjbrdb3676VRXLp172Rnn9yNx/7d53QGNHvKxf1m/WF199p4b1a+vTz5eqRtWKGjn4Ba1ctU5fr1ytLu3bqO1DTRVRoawiN2/XJ/OW6PaaVSRJ3/74q2ZNHKmAAH8P782NcTpd2rhxo0qXLi2TyeTpcgB4oSvPuOZ21zvjjNRu5Qw8cq7/jtDtaNVakghyuVigxaj8QZd/Zwaa/bXVoFSBzmiQbivgL38/owItt/ZdWbhgAZUpdflas7AC+XRH7aoym0wqX7aUzp236uKleJ05e0HPvfSmJOliXLwuWC9q61+7NPyV5yRJxYoUuua6ixUtpB9/3qA/tu5UUqJNJ06fVdFCYSpSKExlS5eQJJUpVVznLsSqcKEwSdK9jerq3kZ1U6ZYtrz/bklKGRSSdM1bhLndqR9/fuBbOm+NVeWK5fTGq31u6T3yuTB3e40qsljMqhheWucuXJ7fHbllh5KSbFr23U9yOl2qX6e6JCkkJK8+mfeVdu45oBOnzqSs46H7GqcZ5BZ/s0pfLlsl6XKiBgBfknzGFdJZqy3NM85hIX6eKSoHu9Uz8Mi5zKGhKjdubEqQk6Ry48YS5HKpFlXzpzpx06BUHg1ffFBJDrf8zQaNeLysOjcukunbNZtNqf7bLcktt+rUrKy3h/0v1bIOh1MJCUny90v7u3roWxNVqUJZde/UVvHxCXJfI4SZTMYb/r1/W4mi2n8gOtVj+w9G6/YalVP+/dHYIdqxa7+WrFitfKF5b2j9/+VzYS6Z2WSS/nnv3W63Rg55QeFlbkt5/viJU3p52Dj1fqa9Wt1/j54bMDLlOaMx7bMIj7dprsfbNJckORwONW7ZNUvqBwBPuPKMa253vTPOSO1Wz8Aj53JYrTowYGCqxw4MGMjIHCRJnRsX0UO1CmjX8XhVLp691xZXrRSu0e/N0KHoYypTqoROnjqrIoXDVCWinH7dsEWtWtyj3XsPXPO1W/7apWEDLo/eHY25sSn0ySNy19L83gZ6us8QPdb6PpUqWUz7og7rj61/66U+XVIt17B+LX3+5Uqt37RNDerWvKHtX8l7w5zBIJc7Y2cB69aupi+++k6v9e+uhMQkOZ0u7d53SKVKFtPdd9XRpq07srjY7GE0GlSsWDEZjbSzBHBz/nvGNbfLrjPOQE7132Yn5caN1YEBA69qioLcLSyvRY0isv84KJAvVINf6qEhoybKZDKqepUKGtj3Gf2vVye98e4UfbX8R91Rq+o1X/vU4y3V88URKl/2NpUslrHv9Z9+3aSZny1J9Vi3p9oqJG9wyr/zhebV0AE9NWjEBPn5WeR0ujRqSF8FBQakep3BYFC/nh01/J0puqNWVVksNxfLDDZbklfOFXQ6Xer6/FD17dlRC5Z8p/EjB6TqUBNz4rQGvD5en00bo7j4BL3zwUztjTqsoMAADezbVcWLFtbQtyYqLj5eDevfrtU/b9D86e+kWsf1JI/MrVsxW2az9+ZiAEDazl60e+SMM+BpaXWtpJslcH0ul0uvj/5IEeXLqH3bB2SxmGXIgvuHeW2YywlyWphzOp3aseNvVatWlQYoAADgpl0vsBHogOu7FBevcZNm6+/dUbrvnjvVq+sTmb4NzycQZBqn06Xt27ercuXKhDkAAHDT4vfsUUJUVJpB7coulwlRUYrfs0ch9ep5qFogZ8oTHHTL3SqvhzAHAACAVELq1VOFKZMVFBGR5ohbcqAjyAGeQ5gDAADAVTIS0MyhoQQ5wIPoI+xDjEaDwsPD6WYJAAAA5AKMzPkQs9msBg3u9HQZAAAAALIBI3M+xOFwaP36DXI4HJ4uBQAAAEAWI8z5EJfLraioKLlc3G0CAAAA8HWEOQAAAADwQlwzdwvc7ssjYDllWqPD4ZDT5ZLD4aAJCgAAAOBjTCaTDIZ/f+cbbLYk5uTdpMTERDV5+FlPlwEAAAAgF1i3YrbM5n/H4whzt8Dlcslms12VkD2p03Ovad7Hoz1dBnDDOHbhrTh24a04duGtcvOx+9/cwTTLW2A0GhUQEODpMlIxGAyp0jrgLTh24a04duGtOHbhrTh2/0UDFAAAAADwQoQ5H/NY6+aeLgG4KRy78FYcu/BWHLvwVhy7/+KaOQAAAADwQozMAQAAAIAXIswBAAAAgBeiDYwX+3rlGi1a+oPyBAdp5GvPq3ChsJTnjh4/qTfemayExCR1btdKDzRr5MFKgdTSO3a/+Oo7/bD2N8XFJ+qFZzuocYM6HqwU+Fd6x22yl4aOVf58IRo2oJcHKgSuLb1jNy4+QaPfn6FDR46rSKEwvTmoj4KDgzxYLfCv9I7dg4ePafiYjxQXn6Bm99ypPt3ae7BSz2FkzkudO2/V3AXL9MkHI/R4m+b66JMFqZ7/YOo8PdPxEU1773VNnb1Il+LiPVQpkFp6x25cfIKSbDZNnzBCo4f9T2+/P0NuN5f1wvOu950rSb9H/qnTZ857oDogbdc7dj+Zt0SVKpbVvI9H6/nuHRQUFOihSoHUrnfszvxsiTq1a6UvZozVjl37dOTYCQ9V6lmEOS+1cfN2VQwvo4AAf9WqXknrN/2Z8pzT6dKGP/5SrWoRCg4OUqmSxbRl2y7PFQtcIb1jNzgoUE93aCOTyaiypUvI6XQqyWb3XLHAP9I7biXJ4XBoxtwv1aldK88UCKThesfujz+v12Ot75MklStTMtXNiAFPut6xGxwUqHyhIbJYzCpzWwmZTSbPFOphhDkvdfbcBZUqWVSSVLBAPjldLiUm2SRJ1osXlS8kb8o0iVIli+nMWc4WI2dI79i90p79h1SyeBEF+Ptld4nAVa533C7+5kc1aVRPhcLyeahC4NrSO3YTEhNlNBg1f/G36tJ7sCbPvHrEGfCU633vdu34sMZ/NFuz5y+Vy+1SsaKFPFWqRxHmvJVBqaafuV1uJZ9MM8gg1xXPudxuGYycaUMOkc6xm8zhdOqDqZ+pV9d22VwckIZ0jtsL1ota9dN6tW/7gIeKA9KRzrEbH5+o89ZY1axWUTM+GKENf/ylXXsPeKhQ4D+u83thxQ/r1L7tg0qy2bQvKjrXXlJEmPNShcLyK/qfucGnz56XxWKRv9/lEYzQkDy6eCku5aA+cvSECobl91itwJXSO3aTTZgyT3VqVlb9OtU9USJwlfSO2982btWluHj1GThKYyfN1u+Rf2rugmWeLBdIkd6xmy80RBazWTWqVJSfn0W1qkXoWMwpT5YLpEjv2E1MTNIv6//Qo62aqVfXJ1SjagX98vtmT5brMYQ5L1Xv9uraF3VYiYlJ2vrXbt1Vr5Y+W7RCP6z9XUajUQ3q1tTW7bt1KS5eR47F6PYalT1dMiAp/WNXkhZ/s0pnz11Qt6faerhS4F/pHbct779bCz4ZqxkfjNDAF7rqrnq11Ll9a0+XDEhK/9g1mYyqU7OKft/0pxKTbNr29x6VK13S0yUDkq7/WzfmxBkdPX5SDqdT0UdjPF2ux3BrAi+VP1+IunZ8RN3/N1x5g4M0ckhfzV2wLOXC5f69Oun1MR/p41kL1btbewXTnQo5RHrH7rGYU5owZa7Kli6prs8PlSR1bt9aze9t4OGqkdtd7zsXyKmu+3uhd2e9+e4UTZr+uVref7fKlSHMIWdI79j187No6Ms99eKQd+VyuVS7RmXd3yR3/lYw2GxJ9P0GAAAAAC/DNEsAAAAA8EKEOQAAAADwQoQ5AAAAAPBChDkAAAAA8EKEOQAAAADwQoQ5AAAAAPBChDkAAAAA8EKEOQCAV+rw7Cva/OfOVI917zdcGzdvT/M1MSdOq/mjPVP+PeLdKYo6dOSay3bpPVhbtu285nNXatulf8p/nz13Qa8Mf082m/26r8uIo8dPqu+ro9W++0B16TNEs+cvldPpumo/AAC5k9nTBQAAcDPubXiHfov8U3VqVZEknTpzTsdPnFKdmpUzvI7hr/TO1JrCCuTTuyNeyrT1vfvhLN1Vv5Y6tH1ANrtdv2/8U0ajIdPWDwDwboQ5AIBXatKoroa/M0X9enaUJK1bv1mNG9wus9msv3fv19TZi3Uh9qLsdrte6ddNtatXumodXXoPVv/nOun2mlV04tQZjZnwiU6fOa8SxQrrQuzFlOVWrlqnJStWKyExScFBgRo1pK/y5wtR5+de05mz59Wl92C1fuBePdCsoe5/rJfWfz9PkrR95z59OO0zxSckqkC+UL38/NMqU6q4Yk6c1qsj3tc9Devq1w1bZI29pLeG9lXliuVS1RefkKDYi5ckSf5+fmrSuF7Kcy63S7PnL9Uv6//QeetFvTWkr6pEhOvwkeOaNONznT5zXnHxCXrumXZqdnd9SdKD7XqrV9cn9PWKNXqpTxct/Xat8gQH6cChozp5+qyqViqvQf27yd/PT4ePHNe7H87S2fNWheQN1tCXe6pUyWKZ+yECAG4J0ywBAF6pYvkystnsOhZzSpL0y++b1bTx5dBSsEB+DX25h+ZMfktdn3xEE6fNv+76Ro6dqttrVtZn08ZoyMs9ZDL++yeyYnhpfThmkOZ9PFplS5XQgiXfyWwy6b2RA1UwLL/mTHlbTzx8f6r1xV6M06A3J6j/c5302dQxerRVMw16c4KcTpck6cCho6peubxmTnxT9zSso8+//Paqml7q00Wr1q5Xt76v67vVv8rlcqU8l5RoU5WIcvrkwzd1b8M79MVX30mS8oWG6IVnn9Tsj0Zp2IBeGj/pU7ndbknSBetFHT1+UrMmjVSNqhUlSWfOnte4kS9r/rQxOnr8pJZ//7McTqeGvT1JL/burC9mvKtuT7XVpOmfZ/izAQBkD8IcAMArGQyGy1MtN27Vpbh47T94RHf8M+WycKECOhpzSh9Om6/l3/+so8dPpruu+IREbduxR+3bPiBJCg3Jq7x5glOev61kUf224U+988FM7di9/7rrk6Qdu/bptuJFVLVSeUlSk8b1FJ+QoCPHYiRJgYEBqlenugwGg6pVrqCz5y5ctY4qEeGaP+0dtXukheZ8sUy9XhqphMTEdF8fGpJHiYlJmjJzgT5btELnrbGKj09IWWenJ1rJYPh3qmb1KhXl7+cns9mshvVqaceuKB09dkKHj8TozbEfq0vvwfpoxhc6b70oAEDOwjRLAIDXuqdRXc2c95UK5AvVXfVqyWy+/Gdt2qeLdeDwUXV49EG1eeBe9ej/RrrrSR7xMplMVz3ndrvVb9AY1a5eSY+2aqYqlcL16/otN1WvQQZJV1/zZjab5Jb7mq/x87PowfsaqXmTBmr3zABt/GO7IsqXSfP1S1eu1bc/rtMzT7XV008+rGaPPCuX+991m0xpn8c1m00KDPCX2y0FBPhr9kejZDRy3hcAciq+oQEAXqt65fKKPhqj79b8pqZXXE+2bsMWtWx+t2pXr6S9UYf+fYHBIJfbddV68gQHqWzpkvr2x18lScdPnNKZf0a6Yi/GaceufXrysYdUrsxt2r33QMrr8ucPVVxcvBKTbFets1rlCjoac1J/746SJP302yYFBgbothJFM7RvsRfjNHH6fFn/uXYvNvaS4hMSVLxY4XRf9+vGLWrSuJ7q16muqIPX7tR5pWMxJ+VyuXQpLl4rV61Tg3o1dVvJosoXmkdffPWd3G63bDa7Tp05l6G6AQDZh5E5AIDXMhqNuqteLa36aYPGvP6/lMc7PdFSU2Yt0BdLvtU9d92RMhpVpFABlSpRTIuW/nDVNW7DBvbS6PdnaNHX3yu87G0poSskb7A6PPqger74hooVKaRqlcvrzNkLkqQAfz+1aNpQTz47UI+1bq6HH2qSsr6QvMEaPay/3p8yR4lJNuULzasxr/dPd2TsSnmCA1WqRDG9OGSskpJscjgd6tO9gyqGl1bMidNpvu7xNvfroxmfa/UvG1Xv9moqUigs3e1EH41RnwGjdPa8VS2b361G9WvLYDDoneEvadxHs7Xs+5/k52dR53atdd89d2aodgBA9jDYbEnXntcBAAB82shxU1WhXGl1ePQBT5cCALgJTLMEAAAAAC/EyBwAAAAAeCFG5gAAAADACxHmAAAAAMALEeYAAAAAwAsR5gAAAADAC/0f8BwlRawAj3kAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 900x400 with 1 Axes>"
       ]
@@ -1113,13 +1317,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee7fb589",
+   "id": "a89572a8",
    "metadata": {
     "papermill": {
-     "duration": 0.005561,
-     "end_time": "2026-08-31T18:18:55.259769+00:00",
+     "duration": 0.006793,
+     "end_time": "2026-09-01T05:36:19.076221+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.254208+00:00",
+     "start_time": "2026-09-01T05:36:19.069428+00:00",
      "status": "completed"
     }
    },
@@ -1143,20 +1347,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "803e3040",
+   "execution_count": 11,
+   "id": "efa0aa20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.271311Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.271200Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.284111Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.283702Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.085326Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.085153Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.101670Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.101220Z"
     },
     "papermill": {
-     "duration": 0.019255,
-     "end_time": "2026-08-31T18:18:55.284457+00:00",
+     "duration": 0.02106,
+     "end_time": "2026-09-01T05:36:19.102191+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.265202+00:00",
+     "start_time": "2026-09-01T05:36:19.081131+00:00",
      "status": "completed"
     }
    },
@@ -1169,7 +1373,7 @@
       "  signal: hash=cdbe4855bfc1, Sharpe=0.830 [0.131, 1.582]\n",
       "  allocation: hash=9725639de4ea, Sharpe=0.801 [0.094, 1.635]\n",
       "  risk_overlay: hash=fb287093aa02, Sharpe=1.150 [0.495, 1.900]\n",
-      "  cost_sensitivity: hash=0f7ee5f2c59e, Sharpe=0.852 [0.142, 1.698]\n"
+      "  cost_sensitivity: hash=b8aa1cdd7daa, Sharpe=1.223 [0.574, 1.965]\n"
      ]
     }
    ],
@@ -1192,27 +1396,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "1e40c360",
+   "execution_count": 12,
+   "id": "77b47e43",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.291167Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.291071Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.380421Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.380088Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.116257Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.116126Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.206675Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.206194Z"
     },
     "papermill": {
-     "duration": 0.093277,
-     "end_time": "2026-08-31T18:18:55.380819+00:00",
+     "duration": 0.098127,
+     "end_time": "2026-09-01T05:36:19.207066+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.287542+00:00",
+     "start_time": "2026-09-01T05:36:19.108939+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+kAAAH1CAYAAACKtr+2AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZT5JREFUeJzt3Xd0FFUfxvFnN5teCCWQQEiAAKGH3kGKgNKxoaCIggWw994LWF47iIBIlaKCVCmCCNKkd6khCZBQ0+vuzvtHcDWGICpJJvD9nMMJO3Nn5nc3M9l9du7MWrKzswwBAAAAAIBiZy3uAgAAAAAAQC5COgAAAAAAJkFIBwAAAADAJAjpAAAAAACYxBUT0k+dOacB9zytU2fOFXcpl02rbrcrOuZ4cZdxyfoNekTrft1e3GVo4dKfNfThl//zei7XPrVl+x51ueFe1+OxX83W2K9m/9fyAAAAAFyBbMVdwD81/Mk31L5VU916w3V5pgeVLa3p40YVU1X/3nfzl2v6t4t0LilZVSpX0oCbuqtTu+ayWCzFXVoeJxJOa+C9T0uS7A6H7HaHvDw9JEk39LpWDwy9rTjL+9f6DXpEZ88mSRbJ08NDtWtW1fC7+yuyRtVC26fuG3zzZV/ngUNH9dHYadp34IhKBwaoXcvGGnLHDfL18daW7Xs0fup3Gv3uC5d9uwAAAAAurxIX0q8kGzfv1CfjvtYno55VZPUq2rv/sNZu3KaObZuZLqSHVCinFd9PkJR7pnrmnB80ecxbxVzV5fHacyPUvlUTxSec1vwlq/TEy//TvGkfm+53UBCn06nHX3pPPbteo1GvPKq09Ax9M2+ZEpNS5OvjXdzlAQAAAPgHrpiQnp6Rqc59h+q7SR8oJDhIr783VtXCQxV7LF4/r9us0oEBevP5B1UlrJKk3DOP7382SYei4xRZvYqee2yoKgaXV2pauiZ9PU+r12/RmbOJataorp5//F5X2Jk6e4FmfveDTp9NlCR5e3nq8RF3qkfX9vrx5w0aN/lbJSYlq12rJnp8+CB5eXlq9IQZOh5/Sm88/2Cemg9Fx6pqeCXVrRUhi8WiBnVrqkHdmnna7N1/WKM+mqCDR2LVtmUjvfjEfbJarTp95pwmTJ2jX7fuUnJKqjq1b6EnHhgsm5ubFi79WRu37FLV8Eqa/f1Svf7sCG3ZsVcJp87KYpHWrNuqUqX89NjwQWrWqJ4k6UT8Kb376VfatfeAQitW0NMPD1Fk9Sr/+PcQdzxBjz7/jnbvO6h6tWvojecflI+3l7Zs36PPv5qt3td10Pgp3+meO29Ujy7ttWDJKk2eOV+JSSlq2rCOHh0+SEFlS0vKHe4/afSbqhkRLkm664EXdVPvLurRtb0cDqc+G/+1Fv+4RolJKbJYLPLy9NC7rz4uSXI6DU2bvVBzF61QekamHh9xpzq1a15g3RaLRSHBQerXs7MmTp+r5JQ0ubvb8u1TZUuXUtyJk9q0dbcqhZTXs48OddVX0D71Vx9/MV1JySl68Yn7dCL+lO559BU9/9i9Gjf5G8UeS1C/Hp00fMitknJHLUycNlfzl/wkiyzq3+86Dbipe571paSm69Tpc7r2mpby9fGWr4+3ht/dX5L0w49r9NYH4+VwONSpzxDXqIcff96gWXOX6MjROJUtE6hnHxnq2vf2/HZI7336lfYfipHD4ZCHu7ui6kXq45HPFLifZGZm6Y33v9CGzTvl7+erW/p2yzfaBQAAAMDfu2KuSb+Qad8sVMd2zfX91I8VVLa0Js2YJ0lKTknTw8+NUp/unbR49hhd26Gl3vpgvCTJarWqbJlAjX7veX03+QNFxxzX3IUrJEkbt+zSxGlz9cGbT2n2xPcVUiFI7776uHp0ba/tu37Tu59M1GvPjtD30z6Ww+HQ9G8XSZKCypVRxZD8Ya1966aKO56gZ179ULv3HbpgH5as+EWvPjNck0e/qaUr12rTtj2SJKdhKLJGFX35yeuaOnakVv2yST+v3exabu3GbUpMStG3kz5Qowa1JUmr121W+1ZNNXfqR7q5d1c9/8YnSs/IVE6OXY+/+J4a1K2pRTNH655BN+mltz+Vw+H8x8/5omWr9cj9t2v2xPe1b/8RLf9pnWveoSOx+nXrbk0d+7au79xWq9dv0egJM/XasyM0b9rHCipXWs+8+uElbXfh0lX66ZdNGv/Rq5oy5i35+Xpr0ug31aRhHUnS/oPRstncNOXzt3VT7y768PMpF12f0+lUdMxxTZ21QFXDKqlUgN8F2y1ftUH9+12n+V9/omaN6+mltz+T0+m86D71d86cTdKPP2/Q/954Su+99rimzFqg2GPxkqSpsxZo45ad+urTNzTx09e1aPlqbdu5L8/ypQL81L51Ez358vtauPRnZWVnu+Zd17mtnn7obkXVi9SK7ye4LkvIysrWY8MHadHM0erQtplGffSlJMkwDD372kdq16qJFs8arb7dO+naDi318chnLrqfLFj6s47GntDsie/ry09eU+3IapfUdwAAAAB5XdEhvUuHlmrRpL7c3W1q0aS+jsaekCT9tGajKlcK1vXXtpXNzU19ru+o3w5EKys7Wz7eXrr1huvk6e6uw9FxKle2tH47GC1JOnQkRvXr1FD1amEKrVhBzZvU074DRyRJcxb+qH49OqtmRLg8PTx0S99uWvfrDknSzX26us5s/lmlkPKaMf4dlS4doBFPval7H31VBw4dzdNm2N39VT6orEKCg1Q1PFSxx3L7UL5cGfXt3kmG4VRsXLyCypbWb+drkSRvb0+NGHKrvDw9XMO2o+pGqm3LRvLwcFffHp1ks7lp196D2rpzn1LT03Xnrb1ls9nUqlmUbDabjp1I+MfP+Z239VZ45YoqFeCvurUjFHM+bEqS3e7Q4yPulJ+vj6xWq+Yu/FE39emiWjWqysvLU8OH3KromGPafyj6b7dz8EisWjSpr0oh5VW9WpjqREbowOEY1/yq4aHq3+86eXl6qHWzKJ06fU6ZmVkXXNcrI8eoy4336sFn3taZs4l697XHC9xuu1aNFVW3pjw9PDT4tj46Gntcx06cvOg+dSkeunegAkv5q36dGvL18XaF9O8WLNc9g25SmdKlVKZ0KXW/tt0Fb8739osP647+vTRx+lz1GfiQ5iz8UU5nwR92dO/STtWrhulo3An5envr8NE4ZWfnKDklTSdPn1Xv6zrI389X3bu00779ufvVxfaTCkFldPrsOcUdT1BgKX9F/WVECAAAAIBLc8UMd7+wP64pDvD3k91ulyQdO3FSe347lOeO278HlAB/6f3PJunXLbtUv04NSblnHSWpScO6mjB1jvbuPywfby+t/3WHuj7V+vw6T+mnXzbpm3nLJElOw6ngoHJ/W2GZ0qX0zMNDNOyu/po4fa6GPPyyZo5/VyHBQbk9sPy5D77KyXFIkpKSU/X2h+N18HCMGtaLlM3mpsysPwJhYIC/3N0L/vVarVYFBvgrOTlVqenpOns2SV1vvO+P5yMnR0nJqX9b/1/lrddPOTl212MPD3cF+Pu6Hh+PP6Vundq4Hnt6eKh8UBkdjz+l2jUvfia2eeP6eu/Tr3Q09rjSMzK1a+9BPfHA4D/V8UfbAP/cs+I5dru85JlvXa88M0zXtG56yX38nY+3l7w8PZWcknrRfepS/F6v1WqVv7+vcux25eTYder0OT37+oeyWnI/T3M4HLr+2rb5lrdarerbvZN6X9dBK1Zv1P9GT1ZKapoG9e99we0tWfGLxk/5TkHlSqt61TBJUlZ2tkoF+KlWjar6dv5y3dK3m+b98JPrrPjx+JMF7iftWjXR8xarPhgzRTabm4YPuZWgDgAAAPwLV3hIv7CQ4CBF1YvUp6Oeyzdv0ox5ijk/bNdms2n8lG914FDuGdqwSsEKrlBOb384QUlJKbq5b1c1Pj+UPKRCObVq1kB3D+z3r2oqFeCnR+6/XWvWb9HeA0dcIb0gYybOlIe7u2ZPfF8Wi0Wvvzf2H20vMytbCafOqFLF8kpOSVNwhXKudRWVisFBOnbipOtxVna2Tp4+q4rn+26zuSk55Y8PChwOh+v/dWpVk83mpqdf/VA5OTl6fMSdCq1Yochql6STp84oMytLlUIqXHSfio078a/W7+5uU7kygXr9uQfUsH6tS1rGarXq2mtaKvZYvLbv2i/1l2SRDKfxR92nz+q1dz/XtLEjVSWskk7En9Ls75e65rdp0VArft6ouYtWqH7tGnrmkSGSpJAKQRfdT9q2bKQ2LRrqpzW/6tHnRmnx7DHy9PD4V30HAAAArlZX9HD3gnRo00yHj8Tp2/nLlJNjV+yxeO3cc0CSlJSUIofTUI7droOHY7Tqlz+u8/512255enjoiw9e1vfTPtbtN/d0zevbo5NmfPeDtuzYK7vDod37DrqGLH8zb5nGfDkzXx1vvP+Fvpw2RydPnVFGZqaWr1qvc0nJql2j6t/2ISkpVXaHQ9k5Odq2c5+2bN/zt8scio7Vbwdzh2B/PnGWKoWUV82IKmpUv5bc3Nw09qvZyszMUsLJM9q0bfffru+/6tu9k2Z/v1S/HYxWZla2xnw5S+GhFVUzoookqXLFYK1Zv1VJyan6ctocxR77Y/j9j6s2qGZEuKaMeUvfTvrggmeXC8POPfsVeyxeaekZ+mjsNLVr2ViBpfwvuk95eHgox27/V9f49+3RWR+Nnaa44wnKzMzSul+3Kz0jM0+bDZt36pHnRmnfgSPKybFr/6GjWr1uixqdD/ZlSwfq8NFjOnsuSVnZ2UpOSZPTaSgzK1spqWmaMeeHPOub/f0yvfz0MC2aOVqjXnlUpQMDJOmi+8n8Jau0a+9BORwOubm5ye5wXHS4PQAAAIALK5Fn0j8aO1UfjZ3qevzY8EHq0bX9JS8fWMpfH739tD74fIrGfDlLpQL8dHOfbqpfp4Zu7tNVW3fuU5+BD6lpw7rq1qm1K2w1qFNTcccT1OPW4TKchjw9PRRZvYpeevJ+NW5QW08/fLfe/3SS4k+eVmilChox5DZVrhSshJNndCLhVL46ht11i8ZMnKXhT76pc4nJqhJWSW+/+MjfnkWXpMG39dZLI0er7+0Pq23LxurUvoXsdsdFlwnw99O4yd9q+67fFFm9it5+6RG5uVnl5mbVB28+qQ/GTFHvgQ/K28tLXTu2VpOoOoV6Zr1dqyZKTE7VC29+oqTkFDWOqqORL+fWJEkP3jtAb30wXqvWbtKAG7urXavGrmVbNm2gzybMULebcodee3t7qXGD2nrusaGFVq+U+xy+9cF4HToSo8ZRdfTso7nbu9g+VTMiXFXDKmn0lzP04D0D/tH27ry1lwzDqQeffktp6RmqExmh8Moh8vH2crVp1qiuYuJO6N1PvlJ07DEF+Pvp+s5tdeuN10uSmjaso6i6NdV/yJPq3qWtHrn/Dt3Uu4tGPPmmQitV0N0D+7lujijlnkkf9vjrMgzJ6mZRcFA53Tv4Jl3TummB+0lYpWB9Mm66Dh2JVWApf7381DB5e3nl6w8AAACAi7NkZ2cZf98MkvTltDny8HDX7Tf3lGEYOnsuScOffFN9e3TSbTdcX9zlXdTvw/ZHvfJocZdyWbz5v3Fq2bSBOrdvIcMwdDz+lO564EU999hQdWjTrFC2+fp7Y+Xn66NHh91RKOs3g9hj8Xrt3bH67J3n5OHhrszMLE2cPldrN27XlM/fKu7yAAAAgCveVTnc/d86HB2n+IQzOnXmnDIys7Rn/2ElJaeoXq3qxV3aVedwdJxij8UrMSlFySlp2rF7vwzDUOT5ofL4d+KOJygpOUXRscdlt+cO299/6Kga1OMmcAAAAEBRKJHD3YvL8CH99c7HE3Xr0CdltVhVJaySXnj8Ptdd4FF0nnpwsP43ZoomfT1Pnp7uqhlRRe+//sQlXSqAgjVvXF8d2zbT4y++p+SUVAWVLa0uHVpp8IA+xV0aAAAAcFVguDsAAAAAACbBcHcAAAAAAEyCkA4AAAAAgEkQ0gEAAAAAMIkSE9INw5DdbpdhcAk9AAAAAODKVGJCusPhULseg+VwOIq7FAAAAAAACkWJCekAAAAAAFzpCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmYSvuAgAAAPDPbN+9X9/NX66f1vwqNzerVnw/ocC2OTl2zV+ySguWrNLe/Yd1Y68ueuKBO13z+w16RPEJp/Ms89k7z6lxVB05nU5NmDpH85f8JIss6nXdNbp7YD9ZrZznAYDCQkgHAAAoYcZP/labtu2WJHm7eV607bnEJL37ycS/XWfXjq1lseT+v0zpUpKkb+Yt05fT5qhaeKgkacLUOQrw99Mtfbv9h+oBABdDSAcAAChhXnzyPsUdi9eIp97627ZlygRq1pfvafb3SzX7+6UXbOPn66NXnxmeb/rs75fKw91dYz94SZLUvf9wfTt/GSEdAAoRIR0AAKCEKV+ujBx2xyW1tbm5qXKlYAX4+xbYJjMrS937D5fValGv6zronjtulN3u0LETJxVRpbL8fH0kSWGhITocHSe73S6bjbeRAFAYCuWva3JKmkZ+NEGxcfEqFeCn154d4Ro2JUlxxxP0yqjRysjM0h239NR1ndsWRhkAAAD4GxFVKstwGgoJDtKO3b/pq+nfq1JwebVs2kCGYcjHx8vV1sfbS4ZhKDEpReXKli7GqgHgylUod/3YtfeAbu7TVVM+f0uRNapo2jcL88z/aOxU3TWgr77430sa+9VspaalF0YZAAAA+BujXn5U303+QGPee0E39e4iSdq0bbdKBfjLYrEoLT3D1TYtPUNWq0WBpfyLq1wAuOIVSkhv3byhGtWvJUmqX6eGTp0+55rncDi1ftMONawXKV9fH4WFhmjL9r2FUQYAAMBVZ+vOfXromZHaunPf37a1OxzavH2P627tDochSSoV4Cd3d5vCQkN0NPa4kpJTlZScqpi4EwoLDWGoOwAUokL/C7t52x41qFvT9TgpJUWBAf7y/dO1TafPnCtocQAAAPzFK6NGKyMjS5KUnZ2jV0aNVlS9SPXr0VnffL9Uv27dpQB/XzWqX0tbd+7T94tW6OCRWEnSxi079cqo0Rp8Wx+t27RDH4+dplo1qsrTw1079hyQm9Wqrh3bSJJu6dNV7376lYY9/rokyW536OY+3DQOAApToYb0Q9Gx+nXrbj1wz22uaRZZ5DQM12OnYchitVxw+W/mLdO385dJkow/LQMAAHA1W7Jirev/DqdTS1aslZubm/r16KxO7Vto196D6tiuuSTp+ImTedrHHotX7LF49b6ug/p276jTZ85pw+adio45rpoR4br3zptUt1aEJKlfz846l5SieYtXSpLuGXSj+vXoVIQ9BYCrjyU7O6tQ0u+5xGQ9+MzbeuXp4apetbJrutPpVIfed2vRzNHy8/XRQ8+M1M19u6pdy8YXXZ/dble7HoO1euFXDLECAAAAAFyRCuWa9OzsHD33+ke6Z9CNroA+bfZCLV25VlarVa2aRWnrzn1KTUtX7LETatygdmGUAQAAAABAiVIop6SnzFqg3w5Ga9LX32vClO8kSXUiI2Sx5A5rf+S+2/XSyM/0+cRZGnZ3f/n6eBdGGQAAAAAAlCiFNtz9cmO4OwAAAADgSlcow90BAAAAAMA/R0gHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAFxFBgwYqAEDBhZ3GQCAAhDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmYSvuAgAAAADganPy9Fm9/cF47dxzQKEVK+jRYXcoql7kBdtO/2aRZs1dopTUNDVqUFtPP3y3gsqW1on4U7rhzkfztV+3ZKokadXaTZo2e6EOHYlVWGiIHrznNjWOqlOo/cJ/x5l0AAAAAChChmHoyZff1/pNO1S/Tg3FHo/XQ8+O1NlzSfnart+0Q5+Mm64cu11Vwyvplw1b9dHnU/O0KR0YoG6dWrv+SdLh6Dg99/pHOnM2UVXCKmnfgSN66pUPdDYx/zZgLpxJBwAAAIAitGPPAe0/eFRdOrTUa88+oDkLf9Q7H0/U/CWrdOetvfO0jY45Lkl68J7b1K1TG9181+OKPR6fp0392jX0ytPD80yrViVU7776uJo1qid3d5uGPPSy9vx2SLv2HFT71k0Kt4P4TziTDgAAAABF6GjMMUlS7cgISVKdmtUkSdHnp/9Ziyb1ZbO5af4Pq7T/0FGdPH1W3Tq2ydNm68696txvqPoPeVI//rzBNb1184Zyd889L2u1WiRJpUr5X/4O4bIipAMAAABAETqXlCJJ8vX2kiT5+HjnTk9Mzte2SlhFXde5rbbs2KvBI16Ql6eHOrZtlru8r48qBJVVSHCQQioEKSbuhF4eOVoxcSfyrGPD5p3atfegqoWHqm6tiMLsGi4DQjoAAAAAFKHSgQGSpLT0jDw/y5Qula/tjO8Wa8GSVZrw8at68sG7ZLc7NPypN+V0OhXg76tvJv1Pkz57U1PGvKXqVcPkcDi0bec+1/KHo+P06qgx8vHx0ktP3iebm1sR9BD/BSEdAAAAAIpQRJVQSdLOvQclSbvO/6wWHqqf1vyqR54bpcPRcZKkZT+tk4eHu8JCQ3RDz86qUytC8QmndfjoMSWcPKOjscdd63U6nZKkgAA/SbkB/YGn3lJaeobeefkxRdaoWmR9xL/HjeMAAAAAoAjViYxQncgIrVy9UY88N0o79xyQl6enena7Ro+98K727j+sxcvXaMTQW1UtPFR79x/RoGHPq2JIkLZs3yt/P1+FVCinV0eN0frNO9Sgbk2dOZuo6JjjKl+ujJo2rKuYuBN64Km3dC4pWTWrh2vxj2s0f8lPKhXgr0eH3VHcTwEugjPpAAAAAFCELBaL3nnlUbVuHqVdew8qLDREn4x6VoGl/NWtU2sFly+rNi0aSpIeHXaH+lzfUZlZWdr722E1rB+pD996Sr4+3np02B3q0KaZTsSf0qnT59SqWZQ+evtp+fn6aOeeAzqXlHuN+/6DR7Vw6c9asmKtfl63uRh7jkthyc7OMoq7iEtht9vVrsdgrV74lWw2BgAAAAD8GwMGDJQkTZ8+rZgrAQBcCGfSAQAAAAAwCU5JA8BV6uTps3r7g/HaueeAQitW0KPD7lBUvcgLtp3+zSLNmrtEKalpatSgtp5++G4FlS0tSdq2c58++HyKjh0/qQZ1a+rZR4e65m3fvV/fzV+un9b8Kjc3q1Z8P6HI+gcAAFAScSYdAK5ChmHoyZff1/pNO1S/Tg3FHo/XQ8+O1NlzSfnart+0Q5+Mm64cu11Vwyvplw1b9dHnUyVJZ84m6uHnRinueILq16mhdb9u15MvvS/DyL2Savzkb7V05Vpl5+QUaf8AAABKKkI6AFyFduw5oP0Hj6pLh5b64M2n9MDQ25SdnaP5S1blaxsdk/vVLg/ec5vGffiKKoWUV+zxeEnS/B9WKTs7Rw8MvU0fvPmUunRoqd8ORru+SubFJ+/TZ+88V3QdAwAAKOEI6QBwFToac0ySVDsyQpJUp2Y1SVL0+el/1qJJfdlsbpr/wyrtP3RUJ0+fVbeObXLbx+a2r3N+PbXPr+fI+fWUL1dGIRWCCrEnAAAAVxZCOgBchc4lpUiSfL29JEk+Pt650xOT87WtElZR13Vuqy079mrwiBfk5emhjm2bSZISz6/H5/f1eBe8HgAAAPw9QjoAXIVKBwZIktLSM/L8LFO6VL62M75brAVLVmnCx6/qyQfvkt3u0PCn3pTT6XStJ/0v6yl7gfUAAADg7xHSAeAqFFElVJK08/y1479fQ14tPFQ/rflVjzw3Soej4yRJy35aJw8Pd4WFhuiGnp1Vp1aE4hNO6/DRY6oW/pf17Mv9WfX8dAAAAPwzfAUbAFyF6kRGqE5khFau3qhHnhulnXsOyMvTUz27XaPHXnhXe/cf1uLlazRi6K2qFh6qvfuPaNCw51UxJEhbtu+Vv5+vQiqUU89u1+jLaXM15suZWrN+izZs3qm6tSJUJzL32vRXRo1WRkaWJCk7O0evjBqtqHqR6tejc3F2HwAAwLQ4kw4AVyGLxaJ3XnlUrZtHadfegwoLDdEno55VYCl/devUWsHly6pNi4aSpEeH3aE+13dUZlaW9v52WA3rR+rDt56Sr4+3SgcG6OORz6hypWDt2ntQrZtHadTLj8pisUiSlqxYq5/XbZYkOZxOLVmx1nXWHgAAAPlZsrOzjOIu4lLY7Xa16zFYqxd+JZuNAQAAAAD/xoABAyVJ06dPK+ZKAAAXQtrFv3by9Fm9/cF47dxzQKEVK+jRYXcoql7kBdtO/2aRZs1dopTUNDVqUFtPP3y3gsqW1tnEJI2eMFO/btml1PR01akZoQfvHaCaEeH/eBsAAAAAUNIx3B3/imEYevLl97V+0w7Vr1NDscfj9dCzI3X2XFK+tus37dAn46Yrx25X1fBK+mXDVn30+VRJ0k9rNumH5WsUXrmiQioEadO23Xr61Q9kGMY/2gYAAAAAXAkI6fhXduw5oP0Hj6pLh5b64M2n9MDQ25SdnaP5S1blaxsdc1yS9OA9t2nch6+oUkh5xR6PlyTd0LOz5k79SB+PfEb/e/0JSVJycqrsdsc/2gYAAABwNRgwYKDrshVcmRjujn/laMwxSVLtyAhJUp2auXdyjj4//c9aNKkvm81N839YparhoTp5+qzu73mLa76vr7ceemakDh6Okaenhx645za5u9v+0TYAAAAA4ErAmXT8K+eSUiRJvt5ekiQfH+/c6YnJ+dpWCauo6zq31ZYdezV4xAvy8vRQx7bNXPPtdod+3bpL55KSVcrfTxWCyv7jbQAAAADAlYCQjn+ldGCAJCktPSPPzzKlS+VrO+O7xVqwZJUmfPyqnnzwLtntDg1/6k05nU5Jkp+vj5bPGaeP3n5GqWnpevLl9xV3POEfbQMAAAAArgSEdPwrEVVCJUk7z3/f8e/fe1wtPFQ/rflVjzw3Soej4yRJy35aJw8Pd4WFhuiGnp1Vp1aE4hNO6/DRY4o7nqDDR+Pk6+OtJlF1VCrAX06noeMnTl50GwAAAABwJeKadPwrdSIjVCcyQitXb9Qjz43Szj0H5OXpqZ7drtFjL7yrvfsPa/HyNRox9FZVCw/V3v1HNGjY86oYEqQt2/fK389XIRXK6cmX39euvQcVVTdSZ88l6UTCKQWW8lftyGry8/UpcBsAAAAAcCXiTDr+FYvFondeeVStm0dp196DCgsN0SejnlVgKX9169RaweXLqk2LhpKkR4fdoT7Xd1RmVpb2/nZYDetH6sO3npKvj7eeGDFYLZrUV3TMMSWcOqMWTerro7efkb+f70W3AQAAAABXIkt2dpZR3EVcCrvdrnY9Bmv1wq9kszEAAAAA4N/4/aubpk+fVsyVAPg3OIavfJxJBwAAAADAJAjpAAAAAACYBCEdAAAAAACTIKQDAP6RAQMGuq6HAwAAwOVFSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZBSEeRGzBgoAYMGFjcZQAAAACA6RDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCVthrfjr7xZr+uyFuvWG6zXw5h555r3+3lht3bFPfr7ekqRP33leAf6+hVUKAAAAAAAlQqGF9Mb1a+ng4ZgC5z/32FA1bVi3sDYPAAAAAECJU2jD3SNrVFVIhXIFzg8M8C+sTQMAAAAAUCIV2pn0v/PJuOlKOHVWXTu20l0D+spisRRXKQAAAAAAmEKxhPRB/XvJx8dbDodDI558Uw3rRapxVJ187b6Zt0zfzl8mSTIMo6jLBAAAAACgSBVLSA+vXNH1/zYtGik69sQFQ/pNvbvopt5dJEl2u13tegwuqhIBAAAAAChyRfYVbNNmL9TSlWt1LjFZS1aslWEYSkxK0fbdvymyepWiKgMAAAAAANMqlDPpp86c0+MvvKsz55JktVi0btN2VQsPlcVikY+Pl/YdOKyvv12kxKQU9e/XTXVrRRRGGQAAAAAAlCiFEtKDypbW5DFvFTj/4ftuL4zNAgAAAABQohXZcHcAAAAAAHBxhHQAAAAAAEyCkA4AAAAAgEkQ0gEAAAAAMAlCOgAAAAAAJkFIBwAAAADAJAjpAAAAAACYBCEdAAAAAACTIKQDAAAAAGAShHQAAAAAAEyCkA4AAAAAgEkQ0gEAAAAAMAlCOgAAAAAAJkFIBwAAAADAJAjpAAAAAACYBCEdAAAAAACTIKQDAAAAAGAShHQAAAAAAEyCkA4AAAAAgEkQ0gEAAAAAMAlCOgAAAAAAJkFIBwAAAADAJAjpAAAAAACYhK24CwAAAIUvx2nXV3sma/XxXxTg4a9BtW9X8wpN87WLT4vX5H3TtevMbklSo6Ao3VdvqHzcfVxtRm56VxsTNinIO0hjO30qSfoxdqVmHvhGWfYstanYSnfWvl2ebp5F0zngCmfExcj+wdsyjhyWpW592R59RpYy5fK1cx74TY5xn8o4uF+WCsFyu/dBWRvlHueOJQvlmD5RysyUtX0nuQ0ZLouXl4zMTDk+fU/O9b9INpvcet0g64DBslgsRd1NAOdxJh0AgCvQjP2zdd+KB1yPFxxZqMVHl6h9pbbydffVe5v/pzOZZ/Mtl5qTpqSsJPWp1lPVS1XT6uO/aO7h+a75O0/v0saETbJZ3FzTDiUd1ugdY1XeO0gtg5vrh6NLNXP/N4XbQeAqYTidsr/+vIxjcXK7eYCMndtk/3BU/naGIcfEzyWnU9a+N8s4fUr2N16QkZYm58Hf5PholCzlg2Vt3V7OBXPkmDZRkuScO0vOH5fI2q6DLDVqyTH1Sxl7dhZ1NwH8CSEdAICrwKpjq+Vhddfdde5Ur6rdZTccWnt8Xb521QMj9FrLlxRVroHKepWVJJX1KiNJchpOfbV3ikJ8glUjsIZrmd1n9siQoTtqDdD99e9RJd+KWh67omg6BlzhjEMHZMREy9rmGrnddqcs9aJk/LpeRnJSnnYWi0W2F9+UbdRHsg0aKmv7TlJ6mozjcTJ2bJUMQ253D5PbQ09KlcPlXLIgd/3Z2ZIkt3795XbLwNyV2e1F2kcAeTHcHQCAK0hKdqqyHFnKsGfIYTh0OuOMpNxh7CG+IbJarArxDZEkJWScvOA6zmSe0VO/PCdJuqZSO3UNu1aS9FPczzqSHK3HGj2kJUeXu9r72HKHwv+asFmGYSjDkanUnFSlZKfI38O/0PoKXKmMtDQpPS33QcIJSZKlUuj5n5VlbN4o42S8LAGl8ixn8c49Fg2nU8b+vZK7hywVQ2UcPiBJcm5YI6vhlNLTpZRkGclJcuveR86ff1TOkw/IUq68LK3by1Ivqoh6CuBCCOkAAFxBvto7WSvjVrke37tiuCTJx+Ytp+GUJNdPiy58zWkpz1IaUmewtp3eoVXHVivIu5xuiOirab/NUI3A6moYFKVF0UtkGE6l56SrVUhLzTk8T98dmquF0YtV2jNQkuTBNenAv+KYM1PO88PR5eOb+9NpnP+Ze/zKUvCAWOfXk2Qc3C+3QUNl8fWVtW0HOWZPk3PmVDnnfiOVyR0lI08vGcfipMwsWdt2kHPNT9KZUzKOHJSlemThdA7A3yKkAwBwBelZpbtaBbfQ6uO/aPvpnXqgwf2SpIl7pyg+PUFOw6kTafGSpAo+5SVJWY5sWSR5uHkoy5Etp+FUj6rXq12lNhq87B5tiP9VDcrV17msczqXdU6Dlg5xbe/R1U9pbKdP9b927+hg4kGF+Ibo9Y1vqYJ3eXm6eRR5/4ErgVuHa2WtcT4klysv+wN3yzgeJ0m5odpikaV8cO7j1BTJ1891ozfH15PlmPqlrNdeJ2v/OyRJFl8/uX/2lYz9e2WpFCr784/LCA6RxdNT9klfSD4+sj34hIybByjnrv5yfv+NrI8/X/QdByCJkA4AwBWlaqkqqlqqig4mHda+c/vVtEITSdKJtHhN3DtZE3Z/pQOJB2Wz2tQmpLVyHDkasfIhyWLRmA4fa9pvX2vLya1qX6md9p/LHSJbs3QNVQ2ootdavuTazv+2fiRJeqzRQ8q0Z+rTHWMU7FNBy2NX6GhKjO6pe3fRdx64QlhCw2QJDZOUe0M4S9UIOX9ZJUdQeRm7t8vSoo0s/v5yrl8j+2vPyXpDf9mGjpB90jg5Z0yWygbJUru+nIvn5a4rsrYc/3tbCqko/XBKRvRhuY14LHdj7h5S7FHZP/9YSjl/nbu3TwGVASgKhHQAAK5At9a8WbfWvNn1+Poq3XQy45RWHVutAA9/Pd3kCZX2CpTDcCrIO0iySFarm9pVbKOjyTFacGShrBarOod21F21B8nH3Uf1ytZ1rc/dmnuWPLJ0TSVmJcpqsWp57Aq5Wz00MPJWdQvvUuR9Bq5EFotFthfekP39t+SYPV2WqMayPfxU7ky/ACmwtCzlckfFOGdMzp1+5pQcn7wrSbJee53cwqpIVqucPyyQPDzlNvheWbv3kSTZHnpC9k//J+fShZK7u6ydr5PbnfcWdTcB/IklOzvLKO4iLoXdble7HoO1euFXstn4bKEkGzAg986h06dPK+ZKAPwbHMNAycYxDJRsHMNXPr6CDQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZhK+4CAAAALrcUe6rSctKLuwxTsjvtkqT4jJPFXIl5+br7yN/mV9xlALhKEdIBAMAVJy0nXcNXPFjcZZjSqbQTksTzcxGjO31CSAdQbC4a0pf9tE6r122WZFG7Vo3VpUOrIioLAAAAAICrT4EhffLMeVq9bot6XddBFotFs+YuVcLJM7r9lp5FWR8AAAAAAFeNAkP60pXrNP7DV+Tl5SlJuvaaFrrnkVcJ6QAAAAAAFJIC7+5uOA15eLi7Hnu4e8hwGkVSFAAAAAAAV6MCz6S3aFJfz7/xiW7q3UWS9O2C5WrepF6RFQYAAAAAwNWmwJA+fEh/TZm1QKO/nClJateysW6/pUeRFQYAAAAAwNWmwJBus9l014C+umtA3yIsBwAAAACAq1e+kL505Vp17dhaE6bOueACQ27vV+hFAQAAAABwNcoX0k+fSZQkpaSmFXUtAAAAAABc1fKF9AE3dZckPXTvAFmteW/+npiUUjRVAQAAAABwFSrwK9juevDFfNOeeOm9Qi0GAAAAAICrWb4z6YuWrZYkJSenuv4vSScSTunsueSiqwwAAAAAgKtMvpB+IuGUJCk9I0tbtu9xTQ+uUE7vv/5E0VUGAAAAAMBVJl9IH3L7DZKkUgH+uql3lyIvCAAAAACAq1WB35N+U+8uSktLV/ypMzKchmt69WphRVIYAAAAAABXmwJD+uzvl+rTcV/LYrWoTGAppaSmKbxyiMZ/9GpR1gcAAAAAwFWjwJA+a+4Szf7qfX30+VQ9/fAQnT2XqO8XryzK2gAAAAAAuKoU+BVs/n6+Kl+ujCKqVtbOPftVJaySdu45UJS1AQAAAABwVSnwTHpoxQraf+iorr2mpZ5/4xNt3rZHFkuBmR4AAAAAAPxHBabuR+6/XdXCKyksNETDh/SXw+nQEw/cWZS1AQAAAABwVblgSM/JsSs9I1OyWCRJrZpF6dFhg+Tv5/OPVv71d4vV67YHNG32wnzz4o4naOjDL2vgfc/ohx/X/IvSAQAAAAC4suQb7r524za9+Nancne3ycPDXf974ylFVAnVzDlLNHnmPC2aOfqSV964fi0dPBxzwXkfjZ2quwb0VcN6kbr9/mfVtmVj+fn+sw8BAAAAAAC4kuQL6Z9PnKWPRz6jurWqa/lP6zXyw/GyWq3y9/PRhH/49WuRNaoqpEK5fNMdDqfWb9qhV54aJl9fH4WFhmjL9r1q37rJv+8JAAAAAAAlXL6Qnpaeobq1qkuSru3QUu+PnqTHhg9Slw6tLttGk1JSFBjgL9/zZ87DQkN0+sy5fO2+mbdM385fJkkyDOOybR8AAAAAADPKF9L9/nLdefmgMpc1oEuSRRY5/xS6nYYhi9WSr91Nvbvopt5dJEl2u13tegy+rHUAAAAAAGAm+UL60dgTunPE8wU+nvTZm/95o6UC/JSSmqbUtHT5+fooNi5eLZs2+M/rBQAAAACgJMsX0v/3xpOFtrFpsxcqqFxpde3YWq2aRWnrzn1qVL+WYo+dUOMGtQttuwAAAAAAlAT5QvrlCsunzpzT4y+8qzPnkmS1WLRu03ZVCw+V5fzXuj1y3+16aeRn+nziLA27u798fbwvy3YBAAAAACip8oX0yyWobGlNHvNWgfNDgoM07sNXCmvzAC4jIy5G9g/elnHksCx168v26DOylMn/zQ1GTo4c4z6V86flUkAp2YYOl7VlWxmGIed3M+VYskA6c1qWRk1le/AJWUoFykhPl+Oz9+Vc/4tUuoxsd94ja7uOxdBLAAAAoPhZi7sAAOZmOJ2yv/68jGNxcrt5gIyd22T/cNQF2zrnzpJz/neyduwii5+f7G++KOP0KSn2qBxfT5K1YRNZW7aR8csqOSaMkSQ5poyXc8VSWa/rKYuXl+wjX5Ez+nBRdhEAAAAwjQJDelZ2tmZ894M+Hf+1JCkjM1NHjh4rssIAmINx6ICMmGhZ21wjt9vulKVelIxf18tITsrX1rliqeThIbf7HpK17y2S3S7n6hWyhFWR+6TZsg1/VG6PPSt5ecs4sC93/ds2S6Fhst3zgNweeFxyOuVctqiouwkAAACYQoEh/c33v1BiUrLWbtgmScrKytGojyYUVV0AipGRlibj1EkZp05KCSckSZZKoed/Vs5tczI+/3IJJ2SpGCqL1SpL6Pl28eeX9/XLfXw0WsrMkKVKRO5Cvn7SyXg5d+2QsXd3bpu42ELrGwAAAGBmBV6Tvv9QjF579gGt/XW7JCmwlL/SMzKLrDAAxccxZ6ac0ybmPvDxzf3pNM7/dOb+tFzgMz6LVTLOt3Pkb2ekpcnx/puSp5fcBg6WJLnddJvsb74o+5MjZKlWPXcRb24kCQAAgKtTgSHdw92m1LR0nb8Zu3btPVhUNQEoZm4drpW1RmTug3LlZX/gbhnH4yRJxrE4yWKRpXxw7uPUFMnXTxaLRZbgEBmxMTKcTld7S3BIbruUFNlfeFxGTLRsr4yUJTRMkmRt2VbuX86UkRAvubnJ/tj9slQOL+IeAwAAAOZQYEi//65b9MBTb+nkqbN67vWPtHHLLr327IiirA1AMbGEhrlCtGEYslSNkPOXVXIElZexe7ssLdrI4u8v5/o1sr/2nKw39Jdt6AhZr71Oji8+lePzj2T8tleyucvavpOMxHOyP/+4jMMHZG3XUUZCghwL5+be+f1kvBxTv5S1QaPca9q9vGXt3qeYnwEAAACgeBQY0ls3b6gqYRW1ftNOyTA07O7+qlwpuChrA2ACFotFthfekP39t+SYPV2WqMayPfxU7ky/ACmwtCzlykuSrL1ulJEQnxu2A0rJ9uKbspQpK8eyRTIOH5AkOVevlFavzF135XApJ0dKTZVjxhRZKofL9vYHspQuUyx9BQAAAIrbRb8nPTs7R54e7vLy8pSvD9eIAlcrS8VQub8/Ot90a70G8pj+/R/tbDbZ7n9Yuv/hPO3cunSXW5fuBa7f2qT55SsWAAAAKMEKvLv79G8WaejDr2jZT+u0aNnPGnjfM1p3/iZyAAAAAADg8ivwTPp3C5Zr1sT3VCawlCTpcHScXnz7U7VqFlVkxQEAAAAAcDUp8Ex6uTKBroAuSdWqhMrTw6NIigIAAAAA4GpU4Jn0Vs0bauacH9Qkqo4kKfZYvEIrVtDBwzGSpOrVwoqmQgAAAAAArhIFhvTvF+XefXnmnCV5pj/1ygeyWKRvJ31QuJUBAAAAAHCVKTCkfz1+FMPbAQAAAAAoQgVekz78iTeLsg4AAAAAAK56BYb0WjWq6JcNW4uyFgAAAAAArmoFDnc/l5isp1/9UFXCKsrN7Y8sP+kzzrADAAAAAFAYCgzpN/Xpqpv6dC3KWgAAAAAAuKoVGNIbN6hdlHUAAAAAAHDVKzCkR8cc04SpcxR3PEFOw+maznB3AAAAAAAKR4Eh/ZVRY9SxXXPFnzyjewbdqH0HDsvdVmBzAAAAALgsrMnJUlpqcZdhTvYcSZL1xPFiLsTEfP3kDAgo7ir+tQJTtyFDd97aW2fPJcrP11uD+vfWw8+O1G03di/K+gAAAABcbdJSlXl3/+KuwpSMZIck8fxchNeXM6UrMaT7eHsrJTVNLZtGad4PP8nDw0PxJ88UZW0AAAAAAFxVCgzpg/r3UmJSilo0qa8lK37R/Y+9piF33FCUtZVo57LclJJtFHcZppRz/hYHMSnWize8yvl7WFTa01HcZQAAAAAoQgWG9FbNolz/f+Xp4UVSzJUkJdtQl5mZxV2GKQUk5X54wfNzccv6e6m0Z3FXAQAAAKAoFRjSU9PSteLnDTp9NlHGn04ID7m9X1HUBQAAAADAVafAkP7YC+/K4XCqds1qstncirImAAAAAACuSgWG9KTkVE3/YpTc3LhuGAAAAACAolBgSG9YL1KnzpxVcPlyRVkPAJgC3896EXw/66Up4d/RCgAAike+kP70qx/IYrEoJSVNI558UzUiwvPMH/nSI0VVGwAUH76ftUB8P+ulKenf0QoAAIpHvpDevnWT4qgDAAAAAICrXr6Q3qNL+3yNUlLT5OvjLauV69MBAAAAACgs+VL36nWbtWX7HtfjDz+fqutuvl89b3tAu/cdLNLiAAAAAAC4muQL6ZNnLlCVsEqSpO2792vpyrWaMf5dvfrMcH0wZkqRFwgAAAAAwNUiX0jPyMxUmdKlJEkzvl2sW2+4TpUrBatZo3pKTcso8gIBAAAAALha5AvpVotF+w8d1aZtu7V5+271ub6jJMlut8vDw73ICwQAAAAA4GqR78Zxw4fcquFPvKHsnBw98/AQlQrwlyTNnLNELRrXL/ICAQAAAAC4WuQL6S2bNtDiWWNkd9jl7eXlmt6kYR1VqVyxSIsDAAAAAOBqki+kS5K7u03u7nln1apRtUgKAgAAAADgasUXnwMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmYSusFc9dtEKzv18qP18fvf7sCJUPKuua9/p7Y7V1xz75+XpLkj5953kF+PsWVikAAAAAAJQIhRLSz55L0pSZ8zVt7EitXr9Fn02YqVefGZ6nzXOPDVXThnULY/MAAAAAAJRIhTLcfcPmnaoZUUVeXp5qWL+W1v26LV+bwAD/wtg0AAAAAAAlVqGcST9zNlFhocGSpHJlAuVwOpWZlS0vTw9Xm0/GTVfCqbPq2rGV7hrQVxaLJd96vpm3TN/OXyZJMgyjMEoFAAAAAMA0CueadEveUG04Df05gw/q30s+Pt5yOBwa8eSbalgvUo2j6uRbzU29u+im3l0kSXa7Xe16DC6UcgEAAK4WQfeHFHcJAICLKJTh7kFlSyvmWLwk6dSZc3J3d5enxx9n0cMrV1RQ2dIKLl9ObVo0UnTsicIoAwAAAACAEqVQQnrzxvV14NBRZWZmaeuOfWrdvKGmzV6opSvX6lxispasWCvDMJSYlKLtu39TZPUqhVEGAAAAAAAlSqEMdy8dGKDBA/pqyMMvy9/XR68//6CmzJwvi8UiHx8v7TtwWF9/u0iJSSnq36+b6taKKIwyAAAAAAAoUQrte9J7dbtGvbpd43r82PBBrv8/fN/thbVZAAAAAABKrEIZ7g4AAAAAAP45QjoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMgpAOAAAAAIBJENIBAAAAADAJQjoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0AAAAAABMwlbcBQAAAAAALs2kALfiLgGFjDPpAAAAAACYBGfSUeSSb/yquEsAAAAAAFPiTDoAAAAAACZBSAcAAAAAwCQI6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEtzdHQDwj/D9rAAAAIWHM+kAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATMJWWCueu2iFZn+/VH6+Pnr92REqH1TWNS/ueIJeGTVaGZlZuuOWnrquc9vCKgMAAAAAgBKjUM6knz2XpCkz52vCR6/qpt5d9NmEmXnmfzR2qu4a0Fdf/O8ljf1qtlLT0gujDAAAAAAASpRCOZO+YfNO1YyoIi8vTzWsX0vvfjLRNc/hcGr9ph165alh8vX1UVhoiLZs36v2rZtc0rqzs3PkdBqSJKvVIpvNJrvd7pomSW5uVrm5uRU4PScnR8Yfk2WzuclqtSo7OyfPtmw2N1ksFuXk2PNMd3e3yTAM2e2OPNM9PNzldDpltztkyPOS+gNczF/3yUvZ935nsUju7u5yOBxyOJyu6b8fNwVNN+PxVBx98vhzp4B/ieOp+PpkiGMY/54hQ4ZhcDwVY58MXofxHxiGIYfDUWKOp78qlJB+5myiwkKDJUnlygTK4XQqMytbXp4eSkpJUWCAv3x9fSRJYaEhOn3m3AXX8828Zfp2/jJJch2os7/5Rm7W3AEAERERatWqpX79dZMOHTrkWq5+/fqKimqgVat+1okTJ1zTW7RooRo1quuHH5YoKSnJNb1Tp46qWLGi5sz5Ls+T37NnD/n4+GrWrFl56rrllluUnp6mBQsWuqa5u9vUv39/xcfHa8WKlWrctou+7e4rq9UqP19fZefkKDMz09Xe5maTj4+3srKylZWd9af1uMvby0sZmZnKyfljB/H08JSnp4fS0zNkd/xRo5eXlzzc3ZWalian849fuI+Pj2xubkpOSclTu69vbk0pf5nu7+8vp9OptLS0PNMD/P1ldziUnv7HaAf6VDR98nU3/tW+97tSpUqpV6+eOnz4iDZs2OCaHhISos6dO2nXrt3auXOna7qZj6fi6FPzmjXk++E4Sed/TzabUlJS8rxp8PPzlcVy4X3PMJxKTf1j37NYLPL395fdbs+/7/n5KTs7O+++Z7PJx8dHWVlZysr6y77n7a2MjIy8+56npzw9PZWeni67/S/7noeHUlNT8+979KlQ+yRfP46nYuyT4WVoZNM3JRX8e/LwcJeXl7cyMzPyvCkraN/z9vaSu7uH0tJS87zJ+mPfS87zhs/Pz1cWq1UpyX/Z9wL8ZTj/uu9J/v4B+fY9NzerfH39lJOTrYyMv9/36NPl6VPK6WSVrVCG46kY+5SQmiaf86/DEq9P9Omf9elcSqriT+0uMcfTX1mys7Mu+8dUU2cvUHJyqoYPuVWGYahz36FaPHuMPD08dC4xWbff/6wWzvhMkvTup1+petXK6tej80XXabfb1a7HYP04Z5zr0wY+haRP9Ik+0Sf6RJ/oE32iT/SJPtEn+lSS+/RXhRLSl6z4RSvX/KqRLz2ik6fP6o77n9OSbz6XJDmdTnXofbcWzRwtP18fPfTMSN3ct6vatWx80XX+HtJXL/zqgh0BAAAAAKCkK5QbxzVvXF8HDh1VZmaWtu7Yp9bNG2ra7IVaunKtrFarWjWL0tad+5Salq7YYyfUuEHtwigDAAAAAIASpVBCeunAAA0e0FdDHn5ZcxYs1/Ah/ZVw6oxOn0mUJD1y3+2aPGOe7nvsNQ27u798fbwLowwAAAAAAEqUQhnuXhgY7g4AAAAAuNIVypl0AAAAAADwzxHSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmQUgHAAAAAMAkCOkAAAAAAJgEIR0AAAAAAJMgpAMAAAAAYBKEdAAAAAAATIKQDgAAAACASRDSAQAAAAAwCUI6AAAAAAAmYSvuAi6VYRiSJLvdXsyVAAAAAABw+bi5uclisUgqQSHd4XBIkjr2GVrMlQAAAAAAcPmsXviVbLbceG7Jzs4yirmeS+J0OpWdnZ3nEwaUXLff/6ymfv52cZcB4F/iGAZKNo5hoGTjGL7ylMgz6VarVV5eXsVdBi4Ti8Xi+qQIQMnDMQyUbBzDQMnGMXxl48ZxAAAAAACYBCEdxeLGXl2KuwQA/wHHMFCycQwDJRvH8JWtxFyTDgAAAADAlY4z6QAAAAAAmAQhHQAAAAAAkyCkAwAAAABgEoR0XBY//rxB/Yc8oYH3PaOX3v5MJ0+f1avvfH7Z1n8i/pQG3vvMZVsfcDV56e1P9cRL70vKeyxt2b5Hj7/43mXbzsKlP2v8lG9dj199Z4xOnzl32dYPXOlaX3eHBg17Tv3ueFjDnnhDx06clHTxY2nh0p/13qeTLrreH35co0HDn9fA+57Rq++MUWpa+n+udfiTb2jv/sP/eT0A/pCWlq433v9Ct9//rAaPeEFLVqz9R8u//t5Ybdm+p5CqQ1Hiy/Xwn2VlZ+udjydq+hcjVbZMoNZv2iF/Px+9/NT9xV0acNXLybEr/uQZ5eTYlZ6RWaTbfvmpYUW6PaCk8/L00OQxb8npdOrb+cv1+cRZev25B/7TsbR15z59/d1ifTLyWQX4+2rW3CV64/0vNPKlRy5f4QAui9feHavGUbX1/GP3KDMrS/sORBd3SSgmhHT8Z/YcuzKzspSekamyklo2baAT8ac09KVXNO2LkUpKTtULb36imLgTOnn6rKqFh+rd1x7TG+9/oc7tW2jRsjVKTUvTh28+rZDgIP348wbN+G6xklPS1Lp5lB6+7/bi7iJQYm3ZsVeR1avIMKSNm3cqsnqVC7azOxz6eOw0bd62R56eHnp8xJ2qWytCDodTYybO1NoN2+Tp6aEXn7hP3t5e+t/oSUo4eUbu7u4a+fIjijueoNFfzpQkbdi8U+M+fEX9Bj2iiZ+8rsBS/pq/ZJVmfLtYknTbjderZ7drdCL+lN7+cIJCK1bQxi071bB+Lb3w+L1F9dQApmW1WtUkqo4WL18jSa5jyd3mpmde+0jxJ0+rYnCQ3v5L0J4wdY4yM7M0YuitrmnffL9Udw/sp1IBfpKkm/t01ezvl+rkqTN69IV39cGbT6l8uTI6kXBaL739qcZ9+IrWrN+q0RNmyOF06K4BfXVd57Z6/b2xiqxeRT/8uEYP3Tswz3Znf79Ui5evUUpqmm7o2Vm33dhddz/4ol5/7kFVCimv+JOn9fLI0Rr7v5cK94kDSrDYY/GKPRavkS8/IovFIm8vLzWqX0sxcSf09ocTlJySqhrVwvTUQ3fLx9tL02Yv1Lfzl8vL00OPjRikA4eOauXqjdq+6ze1ahal+wffnO/vhY+3V3F3E5eIkI7/zNfXRw8MvU1DHnpZPbtdo0H9e+WZP2fBj6pWpZI+HvmMPvx8iqpXC1fF4PKSpJTUdI3/6BW999kk/bDiF901oK8iqoTqk1HPyeZm1c13P6Fb+nQrjm4BV4Sf121Ws4Z1ZRiGfl63ucCQPm/xTzp5+qymjn1bh6Lj9NTL/9OsL9/VouVrFBN7QpM/f0sZGZny8vRUjt2uB+8ZoLDQEH0+cZbmLV6pIbffoH49OkmSht5xY551H46O01fT52ry6DclSYMfeFH1aleXp4eH9vx2SI8Ou0MP3TdQfQY+pJOnzqh8UNlCfU4As3M6nfphxS/5jteNW3bJw8Ndsye+r4STZ/K84d62c59+3bJTn77zXJ5lYo/Fq3rVMNdjq9WqiKqVFR17Qh3aNNPajdvUt3sn/bJhq65p01SJSSkaM3Gmxn/8qmxubrr/8dd17TUtJUmr123RFx++IpubW55tNKpfS/16dlZWZpb6DXpEN/S6Vj27XqOlK9fqrgF9tXrdFnVu3+IyP0vAlSU65pgia1SRxWLJM/21dz/XoP691b51E338xXRNnjFP9991i76cPkffTPyf3N1z41zThnW1ev0WDb39BjWOqqOVqzcW+PcC5sc16bgsbu7TVRM/fV3JKam6Y9hzysjMcs0rU6aUklPSlJNjV3JKWp7lWjSpL4vFosiIcJ09lyRJ58+mr9eb/xuvrMxsxZ86U6R9Aa4UhmFo7YatatSgthpH1db6X3fI7nBcsO2mrbt0bfuWslgsql61sry9PRUTF6/1m3bohl7XyubmJn8/X7m72+Tj7aWU1DR9+PlUbdi8UycSTl+0js3b96hFkwby9fWRr6+PWjZtoE3bcq+ZqxBUVlXDK8nL00NVwirqbGLyZX8egJIiMytbg4Y9p+tuvl9nzyXpwXsH5JnfoG5NnTpzTl9M+kbef3rDnZySqpdHjtZdA/vJZst7/sVitcgwjDzTDKchN6tVHds20y8btkpSbkhv3VS79h7U6TOJuv+x1zT04Zd1LilZiUkpkqQ+13fMF9AlKaRCOc1duEKjPv5SDodT5xKT1aVjK636ZZMMw9DqdVvUsV3zy/IcAVeTtPQMHYk5ptbNoyRJXTu20sYtOyVJPbu21xvvj1Xc8QT5+frkW7agvxcoGQjpuKDPPhut9PR/dmOZSiHl9cLj96rLNS311ddzXdNbNYvSzj0HdM8jL8nmTFe3jq3zLevm5ibDkKZOnaaX3/pI8QmnNeT2fqpfp4YMp1MHDuxXUKDnJdV9uf2b5wIwg98ORutcUooefPotPfj020rPzNSpAm4+ZRiSLBeY7jTyfaq/cvVGjZ4wUx3aNNXtt/TMFwAuxHKBdf+Vm5v1ktYF/FNTp05TYmLiJbdfvny5Tp7MvWnbu+/m3lwxNTVV8+bNL4zyXH6/Jv2eQTfJy9Mz35mvsmUC9eUnr6licJAGj3hBx+Nza/zx5/XqfX0Hff3tonzHUHhoiPYfOup67HA4dfBIrMoHldaObZsV6JGlE/EnlZySpsqVgnX6dILaNqqiDs1q6L1XH9GcyR+qXNnSkiSrW963jfPmfCvDMDTiqbckSQ/eO1CVQsrLcBrycLepRiU/zV+0RE7DqcAAP3377Xf64otxWrZs+UWP9cTERH311SR98cU4/fzzz3/7d+HUqdMaP36CRo8eo5Urf7r4k1yA+fMX6OjRo3/fELhMtm7dqnHjxmvy5ClKTk5WeOWK+u1AtGt/P3funGbOmKEWdUO1e/fufMvbU0/q3kE36YMxUzRzzg/55hf09wIlAyEd/9n+Q0f13fzlcjqdsjscOnXmnBrWr+2av3rtZvXt3kmTRr+t5595XB4e7hdd374D0bq5TzcF+Psp7kTC+an5zwQAuLDfw8TPazdr8G19NHnMW5o85i0NvrWPFi39WU7DmdvQ8sdx1axRXf24aoMMw9Ch6Filp2eocqVgNY6qre8XrZDD4VRaeobOJSZr8/a9at+6iaLqRergkRjXdssHldXJ02fz1dM4qrbWb9qhtPQMpaVnaP2mHWoSVedv+/F7OAKK2rXXXqvy5cvnmebn56fevXsVsMTl1a9HJ23evlsHj8TmmX7k6DFlZGSqR9f2qhpeyRW+O7dvqSG33yBfH2/9smFbnmVu6t1VE6fNVVJyqgzD0Mw5P6hOZDUFly+nJk0ay+pm07TZC9S6eZQcDodiDh/Qpt1xahDVSD/88IMSTl54NJvl/Kd6Scmpij95Wn17dJLhdOpsYu6ouF9++UUB/v5avHyNOrRppi1btiowMFD33DNUZ86cVnR0dIH9X7FipZo1a6qhQ4fo6NEYxcTEFNhWktasWaNWrVrqvvvu1bFjx3T2bP6/Q4CZpKamad269Ro8+E41adJEK1euVFhoiEKCy+mbectkGIaWLl0mD+9SOpliaPnyFcrMzNSyn9apaaN6ysrOltNpKLJGVfXvd502/2l02u+vwwX9vUDJwDXpJdy2bdu1YcMGSVLXrl3k5+evBQsWyOl0qmzZMnJzs6lXr56aP3+Bqlevrtq1a+no0aPasGGDbrnlFiUkJOjHH1coLS1Nvr6+uummG+Xh4XHRbdrtdn366Wd66KEHZRiG5n47SxbPQA0a/rxCSnuoTLkQNaxXUxvWrdHnn4+Vm81d3yxerx9XrVV4BV/5lw3V3QP6qJyfVT8snKc532TIy8tHhs1Pkk0dWzXQqHf/J29Pd1UOCdLZM6e1e+c2lQ3w1Geffa4RIy581/hJkyYrJSVF48dPUOfOnVSpUiUtXrxYJ0+ekpeXl3r06K4yZcro559XKy0tTWfOnFFKSrLatGmjBg0a/O1znZqapunTp+vWW/srICDgH/+ugKLye5i44/7n9MbzD7imd2zXTI8+/658fby1ccsu1YwI17ETCTocHafe3Tvq8NFjuv2+Z+Xp6a7Xn3tQ7u429e3eSUeOHtPA+56Rv5+PHh12h67r3EbvfPylVq3dpKi6ka71t2zaQFNmztfdD76kz97947rYiCqVdeetvXXvI69Kku7o30tVwyvpRPypontScNX68ccfFRcXp5kzZ6l+/XpKTExSenqaSpcuo6ZNm2jp0qVKSkqWzeamG2+8Uf7+/po6dZo6d+6kkJAQ13oSExM1a9Zs3XvvPdqxY4fi4xOUnJyk48dPqF27dmrUqKEyMjI0Z87c868vKSpXrpxuueVmBQYG5qvr6NGj2rZtm5xOQ8ePH1e7dm0VUbmsxowZo7CwcN1/1y36cMwUde/QSHXCy2ja1CmKrFNfb32wQqmpKYoMD9LeHZuV4zDk75c71PX+u27RM69+qBZN6ruuUz16eL86tKytd9//UG5Wyc2zlJ59dKjc3d0VHh4uLy9PzVu6WuM+fk3Hjh2Xn5+fnnxoiD4YO0O1wwI0acZcPfXQkHz1N2tUT8ei92j7tq1q36SaXnrlTfmUqqBKIRWUnJykuLg4NWhQT1v2RKtj22b6YfEiNW/eTBaLRZUrh+ngwUOqWrXqBX9np06d0vXXXyer1aratWtr//4DCg8P1+efj1WtWrV0+PBhWa0W9e3bV4GBgfL09JSPj4/c3NxUtmxZWa1WJSYmas6cuSpTpowSEhIUFBSkXr16ymaz6ciRI1qxYqUMw1C9enVlsVi1b98+xcXFqlq1CHXr1vUy7HlAwY4cOawKFSrI3d1dYWGVtWTJEknSy08N1/ufTdKcBT+qbpVSatSsjV584j6NnzBRjzzzhspXCNYzjwxVVlaO7A67nnj2VXl7WFU9tKLS09PVrVMbLZw/V1s2b1aAr4dOnj6rI8eTFBxcQTYjW599Nlru7u7q2rWLqlSpUrxPAi6KkF6CnT59Wjt27NDQoUOUk5OjmTNnyuk01LZtG9WoUUMbN25UQsLFh7b4+vqqV6+e8vf31/fff699+/b9bWC12WwqX768Tp06JYfDoeDgYFWrVlVPPnyPPv98rO65Z6hWr16tm/r2ULNmTfXayI80YnBftW/XWjNmzNSi1ZtUMzxIbVs1U5cu12rZsuWqUKG8oqKiNHXqNDVtVF+tW7fSkiVL5efnp7Zt28jDlvuJffv27Qqsq0+f3po2bbqGDs19M7Fy5Ur5+Pjqnnv66MCBA1qwYIEGDRokScrIyNBtt92qjIwMjRs3TpGRkfL0LHg4vWEYWrBggTp27EBAh+n9HiaeHH6rftu7W79uWOsKErMnvqcxYz5X4wa1ZLPZ9M5LD2nr1k2qVqWvrm3bUP7uufeT8PXKve505syZ6tKukcr5Sf369dWmTZt14MABXdO0unr16qny5ctr27btGjv2C0nSOy894HrjPWfyh66ael/fUQlxh3Trrf3l7++vpKQkLV2ySNO+GKmDBw/qp59WqWGNCjp7Kl6qWa1onzBc0Tp37qx9+35T//63KCkpSWvW/KK77rpLQUHllJ2drU6dOqls2bL66adV2rZtm9q1K/h15s/i4uI0cOAAnTlzRt9//70aNWqoLVu2qFy5crrttltdr20XCuh/rOOY7rxzkJKSkjRlylS99PRDCg6uoE8++VRDh7bVNa2bKj4+Xt27X68jR47ol1/WatyHL+unn36Sr6+fmjVrqp07dyolJVWSVLlSsKZ9MTLfdsJDQ3T3nbfr5MmTmj37mzzD6D3c3bVw5mfy8fHRnj17VaZMGbVt2UhtWzbSuHHj1a9fH0nSi0/cl2edgwf00dtv71XVqlXUrl1bTZjwpa67rpsqV66sb775Vp06ddIv6zYqvHJFlS0TqNTUVJUpU0aSVLZsGdflBBcSGBio6Oho1ahRQ8ePH5PdnnsvDYfDoYoVQ9ShwzXauHGjVq9erV69eqlNm9b6+usZql+/ngzDUGBgoBITE5WYmKg+fXqrdOnS+vbbb7V79x7VqFFdCxcu0sCBAxQYGKj09Az5+vrowIEDateurcLDwy/p9w/8F6mpaSpbNvd48PPzk9PpVE5OjgL8ffXqM8OVlpamCRO+VPeu10iS2rZqpnLlcke//M7NatXjD92rkJAQLVu2TJs2bVL79u21ecMadelyrWrWrHk+CySoV69eeu+99zVs2DC5uTGQuiQgpJdg0dHROnfunCZO/EqSlJ2dLbvdrho1akiSSpUKvKSQnvvC/4vi4xNUpsyl3VU5LCxMsbFxcjodatgwSrt371FycrL8/f3l5uamw4ePyG63a/v27fL3suiXDVs094dfFBrkrdtu7K7KoSGKiYmRw+FQZmZGnnVXq1ZVFotFwcEV/rb+izlyJNr1aXhERITmz1+grKzcAFKxYkW5ubnJz89PpUuX1tmzZ/OcMfmrDRs2Kisry/XcAiXFhYJEeHiYYmJiVK1aNR08eFCRkZEX/NDv97B97Ngx3XXXYGVkZGjHjh169NFHlJGRIU9Pz4su91eRkTV18OBBNWrUSAcO5G43LS1dCxcu0t133yUfHx9NnTpVFSuGFLgO4L8KCwtTUFA5SZKHh0fuENJlyxUbG5tviPvFVKpUUZ6engoODlZaWu59S3x9/XTmzJkLvrZdSFBQOfn5+cnb21tubm6qXDlUklSuXFmlpaUpICBA3t7eWr16tU6cOKHk5NwbK/75NdbpdKpatYt/sFWpUqgsFovKly8vu92ujIwM+fjkv9GUxaI8l5YZRv57UvyZzWZTWFjunePLly+vtLQ0HTkSLU9PT81bskYH9u9T3x7Xnl+3Rb+vOne9BdfbqVNHLV68WJs3b1FYWJhSUlJc80JDc5+jatWqafv2HZKkHTt2qnnzZkpOTtHJkwnKzMyUlPse5/cPBqpWrab4+Hj5+vooNLSSSpcufb5N/ucBKGx/f6xZ/vZYdHNzc713rVatmjZv3uyad6HjpEGDBlqwYIHat2930fe8MAdCeglmGFK9enXVuXNnSblnh0ePHiOn0ymrNf+nZE5n/rs6b9z4q44dO6ZWrVqqdOkyrhD7d8LDw7Rly1Y5nU516dJFv/66SbGxcQoLq+xq07dvX5UvH+R6/PvZvdtuuF4pKSlau3adJk78SiEhwapbt26+beT24b9dh36xNxd/bMdNNtvFr5M/duyYPD09FBsb53oTBZQEFwoSkZG1dPDgQVWrVk3R0dFq166tduzYke9Dv981atQw9ztbvb0VHh6u+fMXqF27tvL19b3gh4UFqVWrllatWqVGjRrp4MGD6tq1i44fP6YKFSrI39/f1ebw4SOEdBQaq/WP14V9+/Zp06bNat++vUJDK+ngwUP/Yn1/3PAwIqKa1q5de9HXtgtx+8sd063W3MeJiYmaOXOWOnbsoKioKE2ZMtXV5q+vsZfCYrHIzc0t3x3gf+fn5++6ntvpdCoxMVF+fn6XtO7c50Hau3evEhIS5GOzqVpoOe3etVNhlSvJz89PZ8+eVblyZXX27Fn5+fkXuK6goCDXyLf16zcoMLDUBbdns9mUk5Oj/fv3a8iQuyVJy5fn6MCBA6pcuXKe9m5uVrm7287/ri7hTpZAIfLz81Nc3DFJufeRsdnyHpc+Pt7KzMxUZmamvLy8dPbsWUVEFPxhXO7xkP+97O/HiZR7WWx8fLyWLl2mWrVqqXnzZpe5V7icGO9QgoWHh2vPnr1KTc29GUxOTo58fX0UE5N7o5kTJ0642vr6+ujEiXg5nU7t3bvPNf3o0WjVq1dXFSpUyDf07GI3agsJCdHZs2eVkZEhPz9fBQWV0549e1S5cu4n6lWqVNGvv26UYRjKyspSRkbeMwr79x9Qo0aNdM89Q9WzZ88C3zD8LiAgIM8n6Rfi6+urrKws2e12Vw179uTeSOPw4cMqW7aMa0h7UlKiDMPQqVOnzg/BK33RdXfvfr06deqkH3/8kRvYoUT6c5CoVq2qjh6N0blz5xQQECAPDw/Xh35Dhw7R0KFDNHz4sDzLSrlv8G+66UZFRUXpu+/maN++3y663F8FBQUpKSlZ6enpyszMcJ3hupQ7vwP/hb+//wVfQ44ePaqaNWuqcuXQiw6/vlT/9LXt75w4Ea+yZcuqZs2aOnPmj5uh/d1r7F8lJSVKyn0t9Pf3L/DeMxUrhigzM1OpqWk6fvy4QkJCLnop2IV07369hg4dosGD71RUVJTatm2jqlWrqnr16oqJiZFhGIqJiVX16hEFruPMmTOy2+3KzMzUjh07VK9ePde83+/Sv2PHDlWpEi6LxaKkpCSdO3dOTqczz/P0+3PjcDi0c+cuhYeHKySkomJiYpSUlCTDMFzrCwi48D4CFIaqVavp5MmTysnJUUxMjCIiqkvK/VBq9+7dslgsioiIUGxsrDIzM3X27FnXqJXfOZ1OJScnyzAMbd++I8815n89Tux2u+Lj4xUcHKxmzZrxTQYlAGfSS7Dy5YPUrl07TZ06Te7u7oqMjNT113fX4sWL5e3trdKlS7vOJDdoEKWZM2cqOjpaTZs2UXJy7t1XGzVqpBUrVmrz5s0qV66ca925w2a2FHgNuM1mk5eXp3x8fCXlDqX78ccf1bdv7rVrbdq01uLFP+iLL8bJw8ND113XTd7e3q7lg4Mr6OuvZ2jXrl3y8PBQcHCwOnXqWGBfIyKqad263DPvAwcOuOAbDHd3d9WqFakvvhinTp06na9hscaNGy8vLy/17NnT1fb06TOaPHmysrKy1bNnz3xnMf7K29tbPj4+KleunHbu3HlJN5oDzMpms6lcuXLauPFXRUbWlJT7od/MmTPVokUL+fr6KiUlJd/9F9LT05WRkaEqVcJVr149xcTEqGHDhn+73O8sFouqVaum1avXKCIi9w16xYoVtWjRYqWmpsrb21v79u275GuCgUsVFdVAc+bMVenSpeXp+cfrR7169bR48Q/av3+/a3joX1WuHKodO3bke4N8IQW9trm7X3y0VkGqVAnX1q1bNXHiRFWvXsO1nr97jf2ro0djtHfvXklSz565d6jfsmWLtmzZqpSUFE2dOk0NGzZU8+bN1K1bV3399ddyc3NTr149C1znP9W4cSPNmzdf48aNV0REtYte+33ixAnNmTNXhmGoTZs2KlXqjzPpGzf+qtOnTyswsJTrg5CePXtoxoyZMgxDYWFhqlOnjlJSUlz3kzlz5qwiIyNVrVo1WSwWdevWTTNnzpKbm5siIyPVtm0b1atXT/PnL1BMTIy6d+9+2foNXIivr4/atGmtr76aJE9PT/Xr11eSlJyc5Prg+tprO+v7779XdnaOOnbskO8DM39/f61cuVIJCSdVqVIlRUX98d70r8dJTk6O1q/foNOnT8vhcKhHD/Zxs7NkZ2dxWvAK9dtv+7V///7L+iJ7ucybN1/NmzdTcHCwMjIyNH78BPXv3/8fD937N37+ebU8PDzUsmWLQt8WUBx+v7SkZcsWOnHihLp16yYp9yvNnnzyCUnSnj17NX/+fD300IOuN/fbtm3X+vXrXR/6tW3bJs9drpOTk/XDD0uUlJQkq9Wqvn37qGzZshdcriDHjx/XpEmTNWTI3a7rfw8cOKBVq36W0+lUnTp1XMvPmDFDderU4UMxlBjF+dpWkD9/u0tJ99lno3XXXYMveD39X/35bvzA1eSfHCcwL0L6FexyhPRFixbr+PHjeabVr19fLVo0/0+17du3Txs2bFROTo6cTqcaNoxSs2bNLuka8tWrV+u33/bnmVa1ahXXtfl/50IhPTU1TTNmzMjX9oYb+rmG5AIAcDEXem1zd/fIc0MnSSpXrpxr5NnlMmvWbNeN5X7XqlUrHT58+D+F9Pj4eC1YsDDf9DvvHPSvRwj87p++xyCkA3+PkH5lIKQDAC6rrVu3FUkoAQAAuBIR0gEAAAAAMAluHIdC80+Gmr399kgFBeVes1e5cmXX95sDAAAAwNWEkA5T8Pf319ChQ4q7DAAAAAAoVoR0FIno6KNavHix3NzcXN+5LEnVq0eoQ4cOF/3qGAAAAAC4WhDSUejS0tK1bNkyDRhwW57vOv2z1NRUTZo0WZKhTp06q3LlC39fLQAAAABcyax/3wT4bxYuXKAaNaoXGNAl6YYbbtDAgQPUpEkTzZs3rwirAwAAAADz4Ew6CtXp06cVHh6u/fsPqEmTJpo5c1ae+b8Pd//9zHndunW1ZMlS5eTk/OfvXwUAAACAkoaQjkIVEBCgLl2u1datW7Vx48YL3hzu4MGDKlOmjMqUKaPo6KPy9/cnoAMAAAC4KhHSUag8PDxktVrVsGFDTZjwpRo1aqQyZcrkaVOqVKCWLl2q5OQUubm5qXfvXsVULQAAAAAUL0t2dpZR3EUAAAAAAABuHAcAAAAAgGkQ0gEAAAAAMAlCOgAAAAAAJkFIBwAAAADAJAjpAAAAAACYxP8BOitT/SASTbsAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+kAAAH1CAYAAACKtr+2AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZUBJREFUeJzt3Xd0FFUfxvFnN5teSAKBhBZ66KF3kCJFOjYUFFHAAvZeXhU7qKhYQAQEaVJEOkgRRJDeu9RAgBQIpNct7x+R1RgCqCSZwPdzjgd35u6d393MJPvs3Jk1ZWZmOAQAAAAAAAqdubALAAAAAAAA2QjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQN0xIPxd3Uf2GvKRzcRcLu5Trpnnn+xRx6mxhl3HN+gx4Whu37i7sMrRkxa8a/NSb/7mf67VP7dh9QB1vf9j5eNzkORo3ec5/LQ8AAADADchS2AX8U0NfeFdtmjfSPbd3ybE8qHiAZowfWUhV/Xs/LlqlGXOX6mJCoiqUK6N+d3ZV+9ZNZDKZCru0HKJizqv/wy9Jkqw2m6xWmzzc3SRJt/e4VY8Pvrcwy/vX+gx4WhcuJEgmyd3NTTWqVdTQh/oqrGrFfNunHhl413Xv88ixkxo9broOHTmhAH8/tW7WQIPuv13eXp7asfuAJkz7UWM++t913y4AAACA66vIhfQbyZbte/XF+O/1xchXFFalgg4ePq4NW3apXavGhgvpIaVKaPWCiZKyz1TPmveTpox9v5Cruj7efnWY2jRvqOiY81q0fK2ef/MTLZz+ueF+Bnmx2+167o2P1b3TLRo5/BmlpKbph4UrFZ+QJG8vz8IuDwAAAMA/cMOE9NS0dHXoPVg/fvepQoKD9M7H41QptKwiz0Tr143bFeDvp/dee0IVypeRlH3mcdRX3+lYxGmFVamgV58drNLBJZWckqrvvl+odZt2KO5CvBrXr6XXnnvYGXamzVmsWT/+pPMX4iVJnh7uem7YA+rWqY1+/nWzxk+Zq/iERLVu3lDPDR0gDw93jZk4U2ejz+nd157IUfOxiEhVDC2jWtUry2QyqW6taqpbq1qONgcPH9fI0RN19ESkWjWrr9eff0Rms1nn4y5q4rR52rpznxKTktW+TVM9//hAWVxctGTFr9qyY58qhpbRnAUr9M4rw7Rjz0HFnLsgk0lav3GnihXz0bNDB6hx/dqSpKjoc/roy8nad/CIypYupZeeGqSwKhX+8c/h9NkYPfPah9p/6Khq16iqd197Ql6eHtqx+4C+njxHPbu01YSpP2rIA3eoW8c2Wrx8rabMWqT4hCQ1qldTzwwdoKDiAZKyp/t/N+Y9VascKkl68PHXdWfPjurWqY1sNru+mvC9lv28XvEJSTKZTPJwd9NHbz0nSbLbHZo+Z4nmL12t1LR0PTfsAbVv3STPuk0mk0KCg9SnewdNmjFfiUkpcnW15NqnigcU0+moWG3buV9lQkrqlWcGO+vLa5/6u8+/maGExCS9/vwjioo+pyHPDNdrzz6s8VN+UOSZGPXp1l5DB90jKXvWwqTp87Vo+S8yyaS+fbqo351dc/SXlJyqc+cv6tZbmsnby1PeXp4a+lBfSdJPP6/X+59OkM1mU/teg5yzHn7+dbNmz1+uEydPq3igv155erBz3zvw+zF9/OVkHT52SjabTW6urgqvHabPR7yc536Snp6hd0d9o83b98rXx1t39+6ca7YLAAAAgKu7Ya5Jv5zpPyxRu9ZNtGDa5woqHqDvZi6UJCUmpeipV0eqV9f2WjZnrG5t20zvfzpBkmQ2m1U80F9jPn5NP075VBGnzmr+ktWSpC079mnS9Pn69L0XNWfSKIWUCtJHbz2nbp3aaPe+3/XRF5P09ivDtGD657LZbJoxd6kkKahEoEqH5A5rbVo00umzMXr5rc+0/9Cxy45h+erf9NbLQzVlzHtasWaDtu06IEmyOxwKq1pB337xjqaNG6G1v23Trxu2O5+3YcsuxSckae53n6p+3RqSpHUbt6tN80aaP2207urZSa+9+4VS09KVlWXVc69/rLq1qmnprDEaMuBOvfHBl7LZ7P/4NV+6cp2efvQ+zZk0SocOn9CqXzY61x07EamtO/dr2rgPdFuHVlq3aYfGTJylt18ZpoXTP1dQiQC9/NZn17TdJSvW6pfftmnC6Lc0dez78vH21Hdj3lPDejUlSYePRshicdHUrz/QnT076rOvp16xP7vdrohTZzVt9mJVLF9Gxfx8Lttu1drN6tunixZ9/4UaN6itNz74Sna7/Yr71NXEXUjQz79u1ifvvqiP335OU2cvVuSZaEnStNmLtWXHXk3+8l1N+vIdLV21Trv2Hsrx/GJ+PmrToqFeeHOUlqz4VRmZmc51XTq00ktPPqTw2mFavWCi87KEjIxMPTt0gJbOGqO2rRpr5OhvJUkOh0OvvD1arZs31LLZY9S7a3vd2raZPh/x8hX3k8UrftXJyCjNmTRK337xtmqEVbqmsQMAAADI6YYO6R3bNlPThnXk6mpR04Z1dDIySpL0y/otKlcmWLfd2koWFxf1uq2dfj8SoYzMTHl5euie27vI3dVVxyNOq0TxAP1+NEKSdOzEKdWpWVVVKpVX2dKl1KRhbR06ckKSNG/Jz+rTrYOqVQ6Vu5ub7u7dWRu37pEk3dWrk/PM5l+VCSmpmRM+VECAn4a9+J4efuYtHTl2Mkebxx7qq5JBxRUSHKSKoWUVeSZ7DCVLBKp31/ZyOOyKPB2toOIB+v2PWiTJ09NdwwbdIw93N+e07fBaYWrVrL7c3FzVu1t7WSwu2nfwqHbuPaTk1FQ9cE9PWSwWNW8cLovFojNRMf/4NX/g3p4KLVdaxfx8VatGZZ36I2xKktVq03PDHpCPt5fMZrPmL/lZd/bqqOpVK8rDw11DB92jiFNndPhYxFW3c/REpJo2rKMyISVVpVJ51QyrrCPHTznXVwwtq759usjD3U0tGofr3PmLSk/PuGxfw0eMVcc7HtYTL3+guAvx+ujt5/LcbuvmDRReq5rc3dw08N5eOhl5VmeiYq+4T12LJx/uL/9ivqpTs6q8vTydIf3Hxas0ZMCdCgwopsCAYup6a+vL3pzvg9ef0v19e2jSjPnq1f9JzVvys+z2vD/s6NqxtapULK+Tp6Pk7emp4ydPKzMzS4lJKYo9f0E9u7SVr4+3unZsrUOHs/erK+0npYICdf7CRZ0+GyP/Yr4K/9uMEAAAAADX5oaZ7n55f15T7OfrI6vVKkk6ExWrA78fy3HH7UsBxc9XGvXVd9q6Y5/q1KwqKfusoyQ1rFdLE6fN08HDx+Xl6aFNW/eo04st/ujznH75bZt+WLhSkmR32BUcVOKqFQYGFNPLTw3SYw/21aQZ8zXoqTc1a8JHCgkOyh6B6a9j8FZWlk2SlJCYrA8+m6Cjx0+pXu0wWSwuSs/4MxD6+/nK1TXvH6/ZbJa/n68SE5OVnJqqCxcS1OmOR/58PbKylJCYfNX6/y5nvT7KyrI6H7u5ucrP19v5+Gz0OXVu39L52N3NTSWDAnU2+pxqVLvymdgmDero4y8n62TkWaWmpWvfwaN6/vGBf6njz7Z+vtlnxbOsVnnIPVdfw19+TLe0aHTNY7zEy9NDHu7uSkxKvuI+dS0u1Ws2m+Xr660sq1VZWVadO39Rr7zzmcym7M/TbDabbru1Va7nm81m9e7aXj27tNXqdVv0yZgpSkpO0YC+PS+7veWrf9OEqT8qqESAqlQsL0nKyMxUMT8fVa9aUXMXrdLdvTtr4U+/OM+Kn42OzXM/ad28oV4zmfXp2KmyWFw0dNA9BHUAAADgX7jBQ/rlhQQHKbx2mL4c+Wqudd/NXKhTf0zbtVgsmjB1ro4cyz5DW75MsIJLldAHn01UQkKS7urdSQ3+mEoeUqqEmjeuq4f69/lXNRXz89HTj96n9Zt26OCRE86Qnpexk2bJzdVVcyaNkslk0jsfj/tH20vPyFTMuTiVKV1SiUkpCi5VwtlXQSkdHKQzUbHOxxmZmYo9f0Gl/xi7xeKixKQ/Pyiw2WzO/69ZvZIsFhe99NZnysrK0nPDHlDZ0qUKrHZJij0Xp/SMDJUJKXXFfSrydNS/6t/V1aISgf5659XHVa9O9Wt6jtls1q23NFPkmWjt3ndY6ivJJDnsjj/rPn9Bb3/0taaPG6EK5csoKvqc5ixY4Vzfsmk9rf51i+YvXa06Narq5acHSZJCSgVdcT9p1ay+Wjatp1/Wb9Uzr47Usjlj5e7m9q/GDgAAANysbujp7nlp27Kxjp84rbmLViory6rIM9Hae+CIJCkhIUk2u0NZVquOHj+ltb/9eZ331l375e7mpm8+fVMLpn+u++7q7lzXu1t7zfzxJ+3Yc1BWm037Dx11Tln+YeFKjf12Vq463h31jb6dPk+x5+KUlp6uVWs36WJCompUrXjVMSQkJMtqsykzK0u79h7Sjt0HrvqcYxGR+v1o9hTsryfNVpmQkqpWuYLq16kuFxcXjZs8R+npGYqJjdO2Xfuv2t9/1btre81ZsEK/H41Qekamxn47W6FlS6ta5QqSpHKlg7V+004lJCbr2+nzFHnmz+n3P6/drGqVQzV17Pua+92nlz27nB/2HjisyDPRSklN0+hx09W6WQP5F/O94j7l5uamLKv1X13j37tbB40eN12nz8YoPT1DG7fuVmpaeo42m7fv1dOvjtShIyeUlWXV4WMntW7jDtX/I9gXD/DX8ZNndOFigjIyM5WYlCK73aH0jEwlJado5ryfcvQ3Z8FKvfnSY1o6a4xGDn9GAf5+knTF/WTR8rXad/CobDabXFxcZLXZrjjdHgAAAMDlFckz6aPHTdPocdOcj58dOkDdOrW55uf7F/PV6A9e0qdfT9XYb2ermJ+P7urVWXVqVtVdvTpp595D6tX/STWqV0ud27dwhq26Navp9NkYdbtnqBx2h9zd3RRWpYLeeOFRNahbQy899ZBGffmdomPPq2yZUho26F6VKxOsmNg4RcWcy1XHYw/erbGTZmvoC+/pYnyiKpQvow9ef/qqZ9ElaeC9PfXGiDHqfd9TatWsgdq3aSqr1XbF5/j5+mj8lLnave93hVWpoA/eeFouLma5uJj16Xsv6NOxU9Wz/xPy9PBQp3Yt1DC8Zr6eWW/dvKHiE5P1v/e+UEJikhqE19SIN7NrkqQnHu6n9z+doLUbtqnfHV3VunkD53ObNaqrrybOVOc7s6dee3p6qEHdGnr12cH5Vq+U/Rq+/+kEHTtxSg3Ca+qVZ7K3d6V9qlrlUFUsX0Zjvp2pJ4b0+0fbe+CeHnI47HripfeVkpqmmmGVFVouRF6eHs42jevX0qnTUfroi8mKiDwjP18f3dahle654zZJUqN6NRVeq5r6DnpBXTu20tOP3q87e3bUsBfeU9kypfRQ/z7OmyNK2WfSH3vuHTkcktnFpOCgEnp44J26pUWjPPeT8mWC9cX4GTp2IlL+xXz15ouPydPDI9d4AAAAAFyZKTMzw3H1ZpCkb6fPk5ubq+67q7scDocuXEzQ0BfeU+9u7XXv7bcVdnlXdGna/sjhzxR2KdfFe5+MV7NGddWhTVM5HA6djT6nBx9/Xa8+O1htWzbOl22+8/E4+Xh76ZnH7s+X/o0g8ky03v5onL768FW5ubkqPT1Dk2bM14YtuzX16/cLuzwAAADghndTTnf/t45HnFZ0TJzOxV1UWnqGDhw+roTEJNWuXqWwS7vpHI84rcgz0YpPSFJiUor27D8sh8OhsD+myuPfOX02RgmJSYqIPCurNXva/uFjJ1W3NjeBAwAAAApCkZzuXliGDuqrDz+fpHsGvyCzyawK5cvof8894rwLPArOi08M1Cdjp+q77xfK3d1V1SpX0Kh3nr+mSwWQtyYN6qhdq8Z67vWPlZiUrKDiAerYtrkG9utV2KUBAAAANwWmuwMAAAAAYBBMdwcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgygyId3hcMhqtcrh4BJ6AAAAAMCNqciEdJvNptbdBspmsxV2KQAAAAAA5IsiE9IBAAAAALjREdIBAAAAADAIQjoAAAAAAAZBSAcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0AAAAAAAMgpAOAAAAAIBBENIBAAAAADAIQjoAAAAAAAZBSAcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0AAAAAAAMgpAOAAAAAIBBENIBAAAAADAIQjoAAAAAAAZBSAcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0AAAAAAAMgpAOAAAAAIBBENIBAAAAADAIQjoAAAAAAAZBSAcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0AAAAAAAMwlLYBQAAAADAzWT3/sP6cdEq/bJ+q1xczFq9YGKebZNTUjV63HRt3r5HNptd7Vo10eND7pWHu5skacHSNZq35GdFnolWtSoV9Oxj96tq5VBJ0rZd+zVx2jwdPhohL08PtW3VWI8PuVfubm4FMk78O5xJBwAAAIACNGHKXK1Ys0GZWVlXbTty9Lf66ef1Kl82RJmZWZq7aKUmTZ8nSdq4dbdGjJ6oLKtVwaVKaNfeQ3px+CfKyrLKarNp/JS5OnU6SvXr1lBmllU/LFypKTMX5ffw8B9xJh0AAAAACtDrLzyi02eiNezF96/a9pnH7tddvTqpbq1q2rh1t57930fauG2PHnuor5o1qquRbz6jVs3qy+GQet33hKJj4xRx6oyqVg7VqHeel4uLWZ4eHpo0Y76++e4HXbiYUAAjxH9BSAcAAACAAlSyRKBsVts1tQ0MKKbAgGKSJJPJJEny9/N1Pm7ToqEkyeFwyKTs9cWKZa/38fbS+k079e30eTpy/KQqli+jvn26XNex4PojpAMAAACAwdlsdk2eMV+S1LNL21zrFy77RecvxKtZo7oqWSLQufz02RgdPHxcklS2dCl5eboXRLn4D7gmHQAAAAAMzOFw6NOxU7V7/2F16dBSHW5pmmP9jt0H9OnXU1WieIBefPKhHOvu6tVJi7//Uv3v6qZ1m3Zo+IdjC7J0/AuEdAAAAAAwiJ17D+nJl0do595DkrID+qivpmjuopVq0aSeXnt2iHPau5Qd0J97fZTcXF01+v2XFFKqhHPd5u17lWW1qnigv5o1qitJijwTU7ADwj/GdHcAAAAAKEDDR45RWlqGJCkzM0vDR45ReO0w9enWQT8sWKGtO/fJz9db9etU1+hx0zV30UqZzSYF+PvpvU/Gy+FwqFfX9nIxm/Xc66OUnpGhGmEVNeOHJbLabKpQrozat2mi517/WAH+fqpWubz2HTwmSWrROLwwh45rQEgHAAAAgAK0fPUG5//b7HYtX71BLi4u6tOtg9q3aap9B4+qXesmkqS1G7ZJkux2h5as+NX5vMb1aysq5pzSM7LD/s49h7RT2Wff69etrgfu7akXHh+oRct/0c49h+Tj46W+t3bRowPvKqhh4l8yZWZmOAq7iGthtVrVuttArVsyWRYLny0AAAAAAG48XJMOAAAAAIBBENIBAAAAADAI5o0DAAAUMbv3H9aPi1bpl/Vb5eJi1uoFE/Nsm5Vl1aLla7V4+VodPHxcd/ToqOcff8C5vs+ApxUdcz7Hc7768FU1CK8pu92uidPmadHyX2SSST263KKH+veR2cx5HgDIL4R0AACAImbClLnatmu/JMnTxf2KbS/GJ+ijLyZdtc9O7Vro0rc6BQYUkyT9sHClvp0+T5VCy0qSJk6bJz9fH93du/N/qB4AcCWEdAAAgCLm9Rce0ekz0Rr24vtXbRsY6K/Z336sOQtWaM6CFZdt4+PtpbdeHppr+ZwFK+Tm6qpxn74hSerad6jmLlpJSAeAfERIBwAAKGJKlgiUzWq7prYWFxeVKxMsP1/vPNukZ2Soa9+hMptN6tGlrYbcf4esVpvORMWqcoVy8vH2kiSVLxui4xGnZbVa+bYdAMgn+fLbNTEpRSNGT1Tk6WgV8/PR268Mc06bkqTTZ2M0fOQYpaVn6P67u6tLh1b5UQYAAACuonKFcnLYHQoJDtKe/b9r8owFKhNcUs0a1ZXD4ZCXl4ezrZenhxwOh+ITklSieEAhVg0AN658uevHvoNHdFevTpr69fsKq1pB039YkmP96HHT9GC/3vrmkzc0bvIcJaek5kcZAAAAuIqRbz6jH6d8qrEf/0939uwoSdq2a7+K+fnKZDIpJTXN2TYlNU1ms0n+xXwLq1wAuOHlS0hv0aSe6tepLkmqU7Oqzp2/6Fxns9m1adse1asdJm9vL5UvG6Iduw/mRxkAAAA3nZ17D+nJl0do595DV21rtdm0ffcB593abTaHJKmYn49cXS0qXzZEJyPPKiExWQmJyTp1Okrly4Yw1R0A8lG+/4bdvuuA6taq5nyckJQkfz9fef/l2qbzcRcv+9wfFq7U3EUrJUkOhyO/SwUAACgSho8co7S0DElSZmaWho8co/DaYerTrYN+WLBCW3fuk5+vt+rXqa6dew9pwdLVOnoiUpK0ZcdeDR85RgPv7aWN2/bo83HTVb1qRbm7uWrPgSNyMZvVqV1LSdLdvTrpoy8n67Hn3pEkWa023dWLm8YBQH7K15B+LCJSW3fu1+ND7nUuM8kk+18Ct93hkMlsuuzz7+zZ0Tntymq1qnW3gflZLgAAQJGwfPUG5//b7HYtX71BLi4u6tOtg9q3aap9B4+qXesmkqSzUbE52keeiVbkmWj17NJWvbu20/m4i9q8fa8iTp1VtcqheviBO1WremVJUp/uHXQxIUkLl62RJA0ZcIf6dGtfgCMFgJuPKTMzI19OUV+MT9QTL3+g4S8NVZWK5ZzL7Xa72vZ8SEtnjZGPt5eefHmE7urdSa2bNbhif5dC+rolk5liBQAAAAC4IeXLNemZmVl69Z3RGjLgDmdAnz5niVas2SCz2azmjcO1c+8hJaekKvJMlBrUrZEfZQAAAAAAUKTkyynpqbMX6/ejEfru+wWaOPVHSVLNsMoymbKntT/9yH16Y8RX+nrSbD32UF95e3nmRxkAAAAAABQp+Tbd/XpjujsAAAAA4EaXL9PdAQAAAADXX79+/dWvX//CLgP5iJAOAAAAAIBBENIBAAAAADAIQjoAAAAAAAZBSAcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0AAAAAAAMgpAOAAAAAIBBENIBAABuIv369Ve/fv0LuwwAQB4I6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0AAAAAAAMgpAOAAAAAIBBENIBAAAAADAIQjoAAAAAAAZBSAcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0AAAAAAAMgpAOAAAAAIBBENIBAAAAADAIQjoAAAAAAAZBSAcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0AAAAAAAMgpAOAAAAAIBBWAq7AABA4Yg9f0EffDpBew8cUdnSpfTMY/crvHbYZdvO+GGpZs9frqTkFNWvW0MvPfWQgooHSJJ27T2kT7+eqjNnY1W3VjW98sxg57rd+w/rx0Wr9Mv6rXJxMWv1gokFNj4AAICiiDPpAHATcjgceuHNUdq0bY/q1KyqyLPRevKVEbpwMSFX203b9uiL8TOUZbWqYmgZ/bZ5p0Z/PU2SFHchXk+9OlKnz8aoTs2q2rh1t154Y5QcDockacKUuVqxZoMys7IKdHwAAABFFSEdAG5Cew4c0eGjJ9WxbTN9+t6LenzwvcrMzNKi5WtztY04dVaS9MSQezX+s+EqE1JSkWejJUmLflqrzMwsPT74Xn363ovq2LaZfj8aoX0Hj0qSXn/hEX314asFNzAAAIAijpAOADehk6fOSJJqhFWWJNWsVkmSFPHH8r9q2rCOLBYXLfpprQ4fO6nY8xfUuV3L7PaR2e1r/tFPjT/6OfFHPyVLBCqkVFA+jgQAAODGQkgHgJvQxYQkSZK3p4ckycvLM3t5fGKuthXKl1aXDq20Y89BDRz2P3m4u6ldq8aSpPg/+vG61I9n3v0AAADg6gjpAHATCvD3kySlpKbl+DcwoFiutjN/XKbFy9dq4udv6YUnHpTVatPQF9+T3W539pP6t36KX6YfAAAAXB0hHQBuQpUrlJUk7f3j2vFL15BXCi2rX9Zv1dOvjtTxiNOSpJW/bJSbm6vKlw3R7d07qGb1yoqOOa/jJ8+oUujf+jmU/W/FP5YDAADgn+Er2ADgJlQzrLJqhlXWmnVb9PSrI7X3wBF5uLure+db9Oz/PtLBw8e1bNV6DRt8jyqFltXBwyc04LHXVDokSDt2H5Svj7dCSpVQ98636Nvp8zX221lav2mHNm/fq1rVK6tmWPa16cNHjlFaWoYkKTMzS8NHjlF47TD16dahMIcPAABgWJxJB4CbkMlk0ofDn1GLJuHad/CoypcN0RcjX5F/MV91bt9CwSWLq2XTepKkZx67X71ua6f0jAwd/P246tUJ02fvvyhvL08F+Pvp8xEvq1yZYO07eFQtmoRr5JvPyGQySZKWr96gXzdulyTZ7HYtX73BedYeAAAAuZkyMzMchV3EtbBarWrdbaDWLZksi4UJAEYQe/6CPvh0gvYeOKKypUvpmcfuV3jtsMu2nfHDUs2ev1xJySmqX7eGXnrqIQUVD9CF+ASNmThLW3fsU3JqqmpWq6wnHu6napVD//E2AADA1fXr11+SNGPG9EKuBMC/wTF84+NMOv4Vh8OhF94cpU3b9qhOzaqKPButJ18ZoQsXE3K13bRtj74YP0NZVqsqhpbRb5t3avTX0yRJv6zfpp9WrVdoudIKKRWkbbv266W3PpXD4fhH2wAAAACAGwEhHf/KngNHdPjoSXVs20yfvveiHh98rzIzs7Ro+dpcbSNOnZUkPTHkXo3/bLjKhJRU5NloSdLt3Tto/rTR+nzEy/rkneclSYmJybJabf9oGwAAAABwI2DeOP6Vk6fOSJJqhFWWJNWsln2TqIg/lv9V04Z1ZLG4aNFPa1UxtKxiz1/Qo93vdq739vbUky+P0NHjp+Tu7qbHh9wrV1fLP9oGAAAAANwIOJOOf+ViQpIkydvTQ5Lk5eWZvTw+MVfbCuVLq0uHVtqx56AGDvufPNzd1K5VY+d6q9WmrTv36WJCoor5+qhUUPF/vA0AAAAAuBEQ0vGvBPj7SZJSUtNy/BsYUCxX25k/LtPi5Ws18fO39MITD8pqtWnoi+/JbrdLkny8vbRq3niN/uBlJaek6oU3R+n02Zh/tA0AAAAAuBEQ0vGvVK5QVpK094+vUrr0lUqVQsvql/Vb9fSrI3U84rQkaeUvG+Xm5qryZUN0e/cOqlm9sqJjzuv4yTM6fTZGx0+elreXpxqG11QxP1/Z7Q6djYq94jYAAAAA4EbENen4V2qGVVbNsMpas26Lnn51pPYeOCIPd3d173yLnv3fRzp4+LiWrVqvYYPvUaXQsjp4+IQGPPaaSocEacfug/L18VZIqRJ64c1R2nfwqMJrhenCxQRFxZyTfzFf1QirJB9vrzy3AQAAAAA3Is6k418xmUz6cPgzatEkXPsOHlX5siH6YuQr8i/mq87tWyi4ZHG1bFpPkvTMY/er123tlJ6RoYO/H1e9OmH67P0X5e3lqeeHDVTThnUUceqMYs7FqWnDOhr9wcvy9fG+4jYAAAAA4EZkyszMcBR2EdfCarWqdbeBWrdksiwWJgAAAAD8G/369ZckzZgxvZArAfBvcAzf+DiTDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGQUgHAPwj/fr1d14PBwAAgOuLkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkI4C169ff/Xr17+wywAAAAAAwyGkAwAAAABgEIR0AAAAAAAMgpAOAAAAAIBBENIBAAAAADAIQjoAAAAAAAZBSAcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEJb86vj7H5dpxpwluuf229T/rm451r3z8Tjt3HNIPt6ekqQvP3xNfr7e+VUKAAAAAABFQr6F9AZ1quvo8VN5rn/12cFqVK9Wfm0eAAAAAIAiJ9+mu4dVraiQUiXyXO/v55tfmwYAAAAAoEjKtzPpV/PF+BmKOXdBndo114P9estkMuVq88PClZq7aKUkyeFwFHSJAAAAAAAUqEIJ6QP69pCXl6dsNpuGvfCe6tUOU4Pwmrna3dmzo+7s2VGSZLVa1brbwAKuFAAAAACAglMod3cPLVdaQcUDFFyyhFo2ra+IyKjCKAMAAAAAAEMpsJA+fc4SrVizQRfjE7V89QY5HA7FJyRp9/7fFValQkGVAQAAAACAYeXLdPdzcRf13P8+UtzFBJlNJm3ctluVQsvKZDLJy8tDh44c1/dzlyo+IUl9+3RWreqV86MMAAAAAACKlHwJ6UHFAzRl7Pt5rn/qkfvyY7MAAAAAABRphXJNOgAAAAAAyI2QDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGQUgHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBCWwi4AAAAAwJVl2a2afGCK1p39TX5uvhpQ4z41KdXosm23xGzTlIPTlJiZpNalW2pgzQFyNVt0+5K+udreXfVOdQntqGmHvteOc7uUactQjcAaerTOEBX3CMzvYQG4DM6kAwAAAAYz8/AcPbL6cefjxSeWaNnJ5WpTppW8Xb318fZPFJd+IdfzzqfF6ePtn8jb1VttyrTSspPLteTEUknSI7UHO/+r5l9VFrNFTYMbK92WoaiUaHUJ7agGJetre+wOTTs0o8DGCiAnQjoAAABgcGvPrJOb2VUP1XxAPSp2ldVh04azG3O1+y1qg6wOm3pU7KqHaj4gN7Or1p5ZJ0nqHNpRnUM7Kiygmo4nHFe/aveool8FBXuV0nst3lLjUo1U0rOkJCmQs+hAoWG6OwAAAGAQSZnJyrBlKM2aJpvDpvNpcZKk6JRohXiHyGwyK8Q7RJIUkxab6/mxqeckKUfb2LRzOdpM/32mvFy9dFuFzjmWP7fuJUlS7eK1dG+1u6/72ABcG0I6AAAAYBCTD07RmtNrnY8fXj1UkuRl8ZTdYZck578mmXI932zKnijrcDicbf/aLjY1Vttjd6hj+Q5yd3HL8dxH6wzRgbiD+vXsen25e6yerv/EdRwZgGtFSAcAAAAMonuFrmoe3FTrzv6m3ef36vG6j0qSJh2cqujUGNkddkWlREuSSnllT03PsGXKJMnNxU0lvYIkSVEp0apUrKKiU2NU1qeMs//9Fw5Kkir5VXQuszvsSspMVqfyt+rWcu21NXa7tsRsLYjhArgMQjoAAABgEBWLVVDFYhV0NOG4Dl08rEalGkrKDt2TDk7RxP2TdST+qCxmi1qGtFCWLUvD1jwpmUwa2/ZztQxpoamHZmjhicU6dPF3Zdmz1LZMG2f/kUmnJUkBHgHOZUsjftL8Ywt1a/n2ik6JUZo1TXWL1y7YgQNwIqQDAAAABnNPtbt0T7W7nI9vq9BZsWnntPbMOvm5+eqlhs8rwMNfNoddQZ5Bkkkym10U6BGgFxs8p8kHs7+urVuF29S1QhdnPynWFEmSm/nPqe4Nguppz/l9Wn5ylbLsWWoW3FSDag0ssLECyImQDgAAABicxWzRoFoDc4VnF5NZH7R8J8eyRqUaqFGpBpft57E6D+uxOg/nWFbap7Rebfzida0XwL/HV7ABAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhuHAcAwE0gy27V5APZd3v2c/PVgBr3qUmpRrnaRadEa8qhGdoXt1+SVD8oXI/UHiwvVy9nmxHbPtKWmG0K8gzSuPZfSpJ+jlyjWUd+UIY1Qy1LN9cDNe6Tu4t7wQwOAIAbCGfSAQC4Ac08PEePrH7c+XjxiSVadnK52pRpJW9Xb328/RPFpV/I9bzkrBQlZCSoV6XuqlKsktad/U3zjy9yrt97fp+2xGyTxeTiXHYs4bjG7Bmnkp5BahbcRD+dXKFZh3/I3wECAHCDIqQDAHATWHtmndzMrnqo5gPqUbGrrA6bNpzdmKtdFf/KervZGwovUVfFPYpLkop7BEqS7A67Jh+cqhCvYFX1r+p8zv64A3LIofur99OjdYaojHdprYpcXTADAwDgBsN0dwAAbiBJmcnKsGUozZomm8Om82lxkrKnsYd4h8hsMivEO0SSFJMWe9k+4tLj9OJvr0qSbinTWp3K3ypJ+uX0rzqRGKFn6z+p5SdXOdt7WbKnwm+N2S6Hw6E0W7qSs5KVlJkkXzfffBsrAAA3IkI6AAA3kMkHp2jN6bXOxw+vHipJ8rJ4yu6wS5LzX5NMl+2jmHsxDao5ULvO79HaM+sU5FlCt1furem/z1RV/yqqFxSupRHL5XDYlZqVquYhzTTv+EL9eGy+lkQsU4C7vyTJjWvSAQD4xwjpAADcQLpX6KrmwU217uxv2n1+rx6v+6gkadLBqYpOjZHdYVdUSrQkqZRXSUlShi1TJkluLm7KsGXK7rCrW8Xb1LpMSw1cOUSbo7eqbok6uphxURczLmrAikHO7T2z7kWNa/+lPmn9oY7GH1WId4je2fK+SnmWlLuLW4GPHwCAoo6QDgDADaRisQqqWKyCjiYc16GLh9WoVENJUlRKtCYdnKKJ+yfrSPxRWcwWtQxpoSxbloateVIymTS27eea/vv32hG7U23KtNbhi0ckSdUCqqqiXwW93ewN53Y+2TlakvRs/SeVbk3Xl3vGKtirlFZFrtbJpFMaUuuhgh88AAA3AEI6AAA3oHuq3aV7qt3lfHxbhc6KTTuntWfWyc/NVy81fF4BHv6yOewK8gySTJLZ7KLWpVvqZOIpLT6xRGaTWR3KttODNQbIy9VLtYvXcvbnas4+Sx4WUE3xGfEym8xaFblarmY39Q+7R51DOxb4mAEAuBEQ0gEAuAlYzBYNqjVQg2oNzLHcxWTWBy3fcT6u6l9FbzV7/ar9Xfp+dEnyd/fXs/Wfum61AgBwM+Mr2AAAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhLYRcAAAAAAH+VZE1WSlZqYZdhSFa7VZIUnRZbyJUYl7erl3wtPoVdxr9GSAcAAABgKClZqRq6+onCLsOQzqVESRKvzxWMaf9FkQ7pTHcHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBCEdAAAAAAADIKQDgAAAACAQVzxK9hW/rJR6zZul2RS6+YN1LFt8wIqCwAAAACAm0+eIX3KrIVat3GHenRpK5PJpNnzVygmNk733d29IOsDAAAAAOCmkWdIX7FmoyZ8NlweHu6SpFtvaaohT79FSAcAAAAAIJ/keU26w+6Qm5ur87Gbq5scdkeBFAUAAAAAwM0ozzPpTRvW0WvvfqE7e3aUJM1dvEpNGtYusMIAAAD+rSRrslKyUgu7DEOy2q2SpOi02EKuxLi8Xb3ka/Ep7DIA3KTyDOlDB/XV1NmLNebbWZKk1s0a6L67uxVYYQAAAP9WSlaqhq5+orDLMKRzKVGSxOtzBWPaf0FIB1Bo8gzpFotFD/brrQf79S7AcgAAAAAAuHnlCukr1mxQp3YtNHHavMs+YdB9ffK9KAAAAAAAbka5Qvr5uHhJUlJySkHXAgAAAADATS1XSO93Z1dJ0pMP95PZnPPm7/EJSQVTFQAAAAAAN6E8v4LtwSdez7Xs+Tc+ztdiAAAAAAC4meU6k7505TpJUmJisvP/JSkq5pwuXEwsuMoAAAAAALjJ5ArpUTHnJEmpaRnasfuAc3lwqRIa9c7zBVcZAAAAAAA3mVwhfdB9t0uSivn56s6eHQu8IAAAAAAAblZ5fk/6nT07KiUlVdHn4uSwO5zLq1QqXyCFAQAAAABws8kzpM9ZsEJfjv9eJrNJgf7FlJScotByIZow+q2CrA8AAAAAgJtGniF99vzlmjN5lEZ/PU0vPTVIFy7Ga8GyNQVZGwAAAAAAN5U8v4LN18dbJUsEqnLFctp74LAqlC+jvQeOFGRtAAAAAADcVPI8k162dCkdPnZSt97STK+9+4W27zogkynPTA8AAAAAAP6jPFP304/ep0qhZVS+bIiGDuorm92m5x9/oCBrAwAAAADgpnLZM+lZWValpqXLz89HktS8cbiaNw7X2ejYAi0OAAAAAICbSa4z6Ru27FKXux7V4Kfe1O0DntbRE5FyOBya+eNPGvzU8EIoEQAAAACAm0OuM+lfT5qtz0e8rFrVq2jVL5s04rMJMpvN8vXx0kS+fg0AAAAAgHyT60x6SmqaalWvIkm6tW0znYmK1V29OmnUOy8oJDiowAsEAAAAAOBmkSuk+/h45XhcMihQHds2L7CCAAAAAAC4WeWa7n4yMkoPDHstz8ffffVewVQGAAAAAMBNJldI/+TdF65b59//uEwz5izRPbffpv53dcux7vTZGA0fOUZp6Rm6/+7u6tKh1XXbLgAAAAAARVGukN6gbo3r1nmDOtV19Pipy64bPW6aHuzXW/Vqh+m+R19Rq2YN5OPtddm2AAAAAADcDHJdk349hVWtqJBSJXItt9ns2rRtj+rVDpO3t5fKlw3Rjt0H87MUAAAAAAAML9eZ9IKQkJQkfz9fef9x5rx82RCdj7uYq90PC1dq7qKVkiSHw1GgNQIAAAAAUNDyDOkZmZmat3i1zl+4qMcH36u09HRFx8SpYmiZ/7xRk0yy/yV02x0OmcymXO3u7NlRd/bsKEmyWq1q3W3gf942AAAAAABGled09/dGfaP4hERt2LxLkpSRkaWRoydel40W8/NRUnKKklNSJUmRp6NVonjAdekbAAAAAICiKs+QfvjYKT364N2yuGafbPcv5qvUtPT/tLHpc5ZoxZoNMpvNat44XDv3HlJySqoiz0Rd1xvWAQAAAABQFOU53d3N1aLklFSZ/piFvu/g0X/U8bm4i3rufx8p7mKCzCaTNm7brUqhZWX6o8OnH7lPb4z4Sl9Pmq3HHuorby/Pfz8KAPnKcfqUrJ9+IMeJ4zLVqiPLMy/LFJj7ppCOrCzZxn8p+y+rJL9isgweKnOzVnI4HLL/OEu25YuluPMy1W8kyxPPy1TMX47UVNm+GiX7pt+kgEBZHhgic+t2hTBKAAAAoPDlGdIfffBuPf7i+4o9d0GvvjNaW3bs09uvDLvmjoOKB2jK2PfzXB8SHKTxnw3/R8UCKHgOu13Wd16TIyFeLnf1k23WVFk/GynXtz/K1dY+f7bsi36Uuecdcvx+QNb3XpfrpNlSaops338nc/tOUkqy7KtXyOblLcuzr8g2dYLsq1fIfHtfOXbvkHXEcFnKhcpcoVIhjBYAAAAoXHmG9BZN6qlC+dLatG2v5HDosYf6qlyZ4IKsDYABOI4dkeNUhMxde8nl3gdk379Hjq2b5EhMkMmvWI629tUrJDc3uTzypOy/rpZt5Fuyr1stlz595frdHJm8feSwWWXfsE6OI4ey+9+1XSpbXpYhj8t+aL+szzwq+8qlMg95vDCGCwAAABSqK35PemZmltzdXFWsmC/T0YGbiCMlRY5zsXKci5VioiRJpjJl//i3XHab2Ojcz4uJkql0WZnMZpnK/tEu+o/ne/tkPz4ZIaWnyVShcvaTvH2k2GjZ9+2R4+D+7DanI/NtbAAAAICR5XkmfcYPS/Xt9HmqXaOKXFzM+vjLyXrjhUfVvHF4QdYHoBDY5s2Sffqk7Ade3tn/2v/42kS7Pftf02U+4zOZpUtfr2jL3c6RkiLbqPckdw+59B8oSXK5815Z33td1heGyVSpSvZTPPlQEAAAADenPEP6j4tXafakjxXonz2d9XjEab3+wZeEdOAm4NL2VpmrhmU/KFFS1scfkuPsaUmS48xpyWSSqWT25S+O5CTJ20cmk0mm4BA5Ik/JYbc725uCQ7LbJSXJ+r/n5DgVIcvwETKVLS9JMjdrJddvZ8kREy25uMj67KMylQst4BEDAAAAxpBnSC8R6O8M6JJUqUJZubu5FUhRAAqXqWx5Z4h2OBwyVaws+29rZQsqKcf+3TI1bSmTr6/sm9bL+varMt/eV5bBw2S+tYts33wp29ej5fj9oGRxlblNezniL8r62nNyHD8ic+t2csTEyLZkfvad32OjZZv2rcx162df0+7hKXPXXoX8CgAAAACFI8+Q3rxJPc2a95MahteUJEWeiVbZ0qV09PgpSVKVSuULpkIAhcpkMsnyv3dlHfW+bHNmyBTeQJanXsxe6eMn+QfIVKKkJMnc4w45YqKzw7ZfMVlef0+mwOKyrVwqx/EjkiT7ujXSujXZfZcLlbKypORk2WZOlalcqCwffCpTQGChjBUAAAAobHmG9AVLs99Ez5q3PMfyF4d/KpNJmvvdp/lbGQDDMJUuK9dRY3ItN9euK7cZC/5sZ7HI8uhT0qNP5Wjn0rGrXDp2zbN/c8Mm169YAAAAoAjLM6R/P2Ek09sBAAAAAChAeX4F29Dn3yvIOgAAAAAAuOnlGdKrV62g3zbvLMhaAAAAAAC4qeU53f1ifKJeeuszVShfWi4uf2b5777iDDsAAAAAAPkhz5B+Z69OurNXp4KsBQAAAACAm1qeIb1B3RoFWQcAAAAAADe9PEN6xKkzmjhtnk6fjZHdYXcuZ7o7AAAAAAD5I8+QPnzkWLVr3UTRsXEaMuAOHTpyXK6WPJsDAAAAAID/KM+7uzvk0AP39FTNsIry8fbUgL49tWnbnoKsDQAAAACAm0qep8a9PD2VlJyiZo3CtfCnX+Tm5qbo2LiCrA0AAAAAgJtKnmfSB/TtofiEJDVtWEfp6Rl69Nm31btb+4KsDQAAAACAm0qeZ9KbNw53/v/wl4YWSDEAAAAAANzM8gzpySmpWv3rZp2/EC+H48/lg+7rUxB1AQAAAABw08kzpD/7v49ks9lVo1olWSwuBVkTAAAAAAA3pTxDekJismZ8M1IuLnletg4AAAAAAK6jPEN6vdphOhd3QcElSxRkPTeMixkuSsp0XL3hTSjLnv3vqSQ+ALoSXzeTAtxthV0GAAAAgAKUK6S/9NanMplMSkpK0bAX3lPVyqE51o944+mCqq1IS8p0qOOs9MIuw5D8ErI/vOD1ubKVfT0U4F7YVQAAAAAoSLlCepsWDQujDgAAAAAAbnq5Qnq3jm1yNUpKTpG3l6fMZqYnAwAAAACQX3Kl7nUbt2vH7gPOx599PU1d7npU3e99XPsPHS3Q4gAAAAAAuJnkOpM+ZdZijXzzaUnS7v2HtWLNBs2c8JGiY8/r07FTNWH0WwVdIwAUOHNiopSSXNhlGJM1S5JkjjpbyIUYnLeP7H5+hV0FAAAoYnKF9LT0dAUGFJMkzZy7TPfc3kXlygSrXJlgjfpqSoEXCACFIiVZ6Q/1LewqDMmRmP2tA7w+V+bx7SyJkA4AAP6hXNPdzSaTDh87qW279mv77v3qdVs7SZLVapWbm2uBFwgAAAAAwM0i15n0oYPu0dDn31VmVpZefmqQivn5SpJmzVuupg3qFHiBAAAAAADcLHKF9GaN6mrZ7LGy2qzy9PBwLm9Yr6YqlCtdoMUBAAAAAHAzyRXSJcnV1SJX15yrqletWCAFAQAAAABws+KLzwEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAzCUtgFAAAAAACuTdCjIYVdAvIZZ9IBAAAAADAIQjoAAAAAAAZBSAcAAAAAwCAI6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0AAAAAAAMgpAOAAAAAIBBWPKr4/lLV2vOghXy8fbSO68MU8mg4s5173w8Tjv3HJKPt6ck6csPX5Ofr3d+lQIAAAAAQJGQLyH9wsUETZ21SNPHjdC6TTv01cRZeuvloTnavPrsYDWqVys/Ng8AAAAAQJGUL9PdN2/fq2qVK8jDw1316lTXxq27crXx9/PNj00DAAAAAFBk5cuZ9LgL8SpfNliSVCLQXza7XekZmfJwd3O2+WL8DMWcu6BO7ZrrwX69ZTKZcvXzw8KVmrtopSTJ4XDkR6kAAAAAABhG/lyTbsoZqh12h/6awQf07SEvL0/ZbDYNe+E91asdpgbhNXN1c2fPjrqzZ0dJktVqVetuA/OlXAAAgJtF0KMhhV0CAOAK8mW6e1DxAJ06Ey1JOhd3Ua6urnJ3+/Msemi50goqHqDgkiXUsml9RURG5UcZAAAAAAAUKfkS0ps0qKMjx04qPT1DO/ccUosm9TR9zhKtWLNBF+MTtXz1BjkcDsUnJGn3/t8VVqVCfpQBAAAAAECRki/T3QP8/TSwX28NeupN+Xp76Z3XntDUWYtkMpnk5eWhQ0eO6/u5SxWfkKS+fTqrVvXK+VEGAAAAAABFSr59T3qPzreoR+dbnI+fHTrA+f9PPXJffm0WAAAAAIAiK1+muwMAAAAAgH+OkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDIKQDAAAAAGAQhHQAAAAAAAyCkA4AAAAAgEEQ0gEAAAAAMAhCOgAAAAAABkFIBwAAAADAIAjpAAAAAAAYBCEdAAAAAACDsBR2Abj5JN4xubBLAAAAAABD4kw6AAAAAAAGQUgHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBDc3R0A8I985+dS2CUAAADcsDiTDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGQUgHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBCEdAAAAAAADIKQDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGYcmvjucvXa05C1bIx9tL77wyTCWDijvXnT4bo+EjxygtPUP3391dXTq0yq8yAAAAAAAoMvLlTPqFiwmaOmuRJo5+S3f27KivJs7KsX70uGl6sF9vffPJGxo3eY6SU1LzowwAAAAAAIqUfDmTvnn7XlWrXEEeHu6qV6e6PvpiknOdzWbXpm17NPzFx+Tt7aXyZUO0Y/dBtWnR8Jr6zszMkt3ukCSZzSZZLBZZrVbnMklycTHLxcUlz+VZWVly/LlYFouLzGazMjOzcmzLYnGRyWRSVpY1x3JXV4scDoesVluO5W5urrLb7bJabXLI/ZrGA1zJ3/fJa9n3LjGZJFdXV9lsNtlsdufyS8dNXsuNeDwVxpjc/joo4F/ieCq8MTnEMYx/zyGHHA4Hx1MhjoljGP+FQw7ZbLYiczz9Xb6E9LgL8SpfNliSVCLQXza7XekZmfJwd1NCUpL8/Xzl7e0lSSpfNkTn4y5etp8fFq7U3EUrJUmOP17BOT/8IBdz9gSAypUrq3nzZtq6dZuOHTvmfF6dOnUUHl5Xa9f+qqioKOfypk2bqmrVKvrpp+VKSEhwLm/fvp1Kly6tefN+zPHid+/eTV5e3po9e3aOuu6++26lpqZo8eIlzmWurhb17dtX0dHRWr16jRq06qi5Xb1lNpvl4+2tzKwspaenO9tbXCzy8vJURkamMjIz/tKPqzw9PJSWnq6srD93EHc3d7m7uyk1NU1W2581enh4yM3VVckpKbLb//yBe3l5yeLiosSkpBy1e3tn15T0t+W+vr6y2+1KSUnJsdzP11dWm02pqX/OdmBMBTMmb1fHv9r3LilWrJh69Oiu48dPaPPmzc7lISEh6tChvfbt26+9e/c6lxv5eCqMMTWpVlXen42X9MfPyWJRUlKS83eRJPn4eMtkuvy+53DYlZz8575nMpnk6+srq9Wae9/z8VFmZmbOfc9ikZeXlzIyMpSR8bd9z9NTaWlpOfc9d3e5u7srNTVVVuvf9j03NyUnJ+fe9xhTvo5J3j4cT4U4JoeHQyMavScp75+Tm5urPDw8lZ6eluNNWV77nqenh1xd3ZSSkpzjTdaf+15ijjd8Pj7eMpnNSkr8277n5yuH/e/7nuTr65dr33NxMcvb20dZWZlKS7v6vseYrs+Yks4nqnipQI6nQhxTclyS8xiWbp59jzFdnzElnU9U7IWYInM8/Z0pMzPjun9MNW3OYiUmJmvooHvkcDjUofdgLZszVu5ubroYn6j7Hn1FS2Z+JUn66MvJqlKxnPp063DFPq1Wq1p3G6if5413ftrAp5CMiTExJsbEmBgTY2JMjIkxMSbGxJiK8pj+Ll9C+vLVv2nN+q0a8cbTij1/Qfc/+qqW//C1JMlut6ttz4e0dNYY+Xh76cmXR+iu3p3UulmDK/Z5KaSvWzL5sgMBAAAAAKCoy5cbxzVpUEdHjp1UenqGdu45pBZN6mn6nCVasWaDzGazmjcO1869h5SckqrIM1FqULdGfpQBAAAAAECRki8hPcDfTwP79dagp97UvMWrNHRQX8Wci9P5uHhJ0tOP3KcpMxfqkWff1mMP9ZW3l2d+lAEAAAAAQJGSL9Pd8wPT3QEAAAAAN7p8OZMOAAAAAAD+OUI6AAAAAAAGQUgHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBCEdAAAAAAADIKQDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGQUgHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBCEdAAAAAAADIKQDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGQUgHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBCEdAAAAAAADIKQDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGQUgHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBCEdAAAAAAADIKQDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGQUgHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBCEdAAAAAAADIKQDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGQUgHAAAAAMAgCOkAAAAAABgEIR0AAAAAAIMgpAMAAAAAYBCEdAAAAAAADIKQDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAGQUgHAAAAAMAgLIVdwLVyOBySJKvVWsiVAAAAAABw/bi4uMhkMkkqQiHdZrNJktr1GlzIlQAAAAAAcP2sWzJZFkt2PDdlZmY4Crmea2K325WZmZnjEwYUXfc9+oqmff1BYZcB4F/iGAaKNo5hoGjjGL7xFMkz6WazWR4eHoVdBq4Tk8nk/KQIQNHDMQwUbRzDQNHGMXxj48ZxAAAAAAAYBCEdheKOHh0LuwQA/wHHMFC0cQwDRRvH8I2tyFyTDgAAAADAjY4z6QAAAAAAGAQhHQAAAAAAgyCkAwAAAABgEIR0XBc//7pZfQc9r/6PvKw3PvhKsecv6K0Pv75u/UdFn1P/h1++bv0BN5M3PvhSz78xSlLOY2nH7gN67vWPr9t2lqz4VROmznU+fuvDsTofd/G69Q/c6Fp0uV8DHntVfe5/So89/67ORMVKuvKxtGTFr/r4y++u2O9PP6/XgKGvqf8jL+utD8cqOSX1P9c69IV3dfDw8f/cD4A/paSk6t1R3+i+R1/RwGH/0/LVG/7R89/5eJx27D6QT9WhIPHlevjPMjIz9eHnkzTjmxEqHuivTdv2yNfHS2+++Ghhlwbc9LKyrIqOjVNWllWpaekFuu03X3ysQLcHFHUe7m6aMvZ92e12zV20Sl9Pmq13Xn38Px1LO/ce0vc/LtMXI16Rn6+3Zs9frndHfaMRbzx9/QoHcF28/dE4NQivodeeHaL0jAwdOhJR2CWhkBDS8Z9Zs6xKz8hQalq6iktq1qiuoqLPafAbwzX9mxFKSEzW/977QqdORyn2/AVVCi2rj95+Vu+O+kYd2jTV0pXrlZySos/ee0khwUH6+dfNmvnjMiUmpahFk3A99ch9hT1EoMjaseegwqpUkMMhbdm+V2FVKly2ndVm0+fjpmv7rgNyd3fTc8MeUK3qlWWz2TV20ixt2LxL7u5uev35R+Tp6aFPxnynmNg4ubq6asSbT+v02RiN+XaWJGnz9r0a/9lw9RnwtCZ98Y78i/lq0fK1mjl3mSTp3jtuU/fOtygq+pw++GyiypYupS079qpener633MPF9RLAxiW2WxWw/CaWrZqvSQ5jyVXi4tefnu0omPPq3RwkD74W9CeOG2e0tMzNGzwPc5lPyxYoYf691ExPx9J0l29OmnOghWKPRenZ/73kT5970WVLBGoqJjzeuODLzX+s+Fav2mnxkycKZvdpgf79VaXDq30zsfjFFalgn76eb2efLh/ju3OWbBCy1atV1Jyim7v3kH33tFVDz3xut559QmVCSmp6NjzenPEGI375I38feGAIizyTLQiz0RrxJtPy2QyydPDQ/XrVNep01H64LOJSkxKVtVK5fXikw/Jy9ND0+cs0dxFq+Th7qZnhw3QkWMntWbdFu3e97uaNw7XowPvyvX7wsvTo7CHiWtESMd/5u3tpccH36tBT76p7p1v0YC+PXKsn7f4Z1WqUEafj3hZn309VVUqhap0cElJUlJyqiaMHq6Pv/pOP63+TQ/2663KFcrqi5GvyuJi1l0PPa+7e3UujGEBN4RfN25X43q15HA49OvG7XmG9IXLflHs+QuaNu4DHYs4rRff/ESzv/1IS1et16nIKE35+n2lpaXLw91dWVarnhjST+XLhujrSbO1cNkaDbrvdvXp1l6SNPj+O3L0fTzitCbPmK8pY96TJA18/HXVrlFF7m5uOvD7MT3z2P168pH+6tX/ScWei1PJoOL5+poARme32/XT6t9yHa9bduyTm5ur5kwapZjYuBxvuHftPaStO/bqyw9fzfGcyDPRqlKxvPOx2WxW5YrlFBEZpbYtG2vDll3q3bW9ftu8U7e0bKT4hCSNnTRLEz5/SxYXFz363Du69ZZmkqR1G3fom8+Gy+LikmMb9etUV5/uHZSRnqE+A57W7T1uVfdOt2jFmg16sF9vrdu4Qx3aNL3OrxJwY4k4dUZhVSvIZDLlWP72R19rQN+eatOioT7/ZoamzFyoRx+8W9/OmKcfJn0iV9fsONeoXi2t27RDg++7XQ3Ca2rNui15/r6A8XFNOq6Lu3p10qQv31FiUrLuf+xVpaVnONcFBhZTYlKKsrKsSkxKyfG8pg3ryGQyKaxyqC5cTJCkP86mb9J7n0xQRnqmos/FFehYgBuFw+HQhs07Vb9uDTUIr6FNW/fIarNdtu22nft0a5tmMplMqlKxnDw93XXqdLQ2bduj23vcKouLi3x9vOXqapGXp4eSklP02dfTtHn7XkXFnL9iHdt3H1DThnXl7e0lb28vNWtUV9t2ZV8zVyqouCqGlpGHu5sqlC+tC/GJ1/11AIqK9IxMDXjsVXW561FduJigJx7ul2N93VrVdC7uor757gd5/uUNd2JSst4cMUYP9u8jiyXn+ReT2SSHw5FjmcPukIvZrHatGuu3zTslKTukt2ikfQeP6nxcvB599m0NfupNXUxIVHxCkiSp123tcgV0SQopVULzl6zWyM+/lc1m18X4RHVs11xrf9smh8OhdRt3qF3rJtflNQJuJimpaTpx6oxaNAmXJHVq11xbduyVJHXv1Ebvjhqn02dj5OPtleu5ef2+QNFASMdlffXVGKWm/rMby5QJKan/PfewOt7STJO/n+9c3rxxuPYeOKIhT78hiz1Vndu1yPVcFxcXORzStGnT9eb7oxUdc16D7uujOjWrymG368iRwwryd7+muq+3f/NaAEbw+9EIXUxI0hMvva8nXvpAqenpOpfHzaccDkmmyyy3O3J9qr9m3RaNmThLbVs20n13d88VAC7HdJm+/87FxXxNfQH/1LRp0xUfH3/N7VetWqXY2Oybtn30UfbNFZOTk7Vw4aL8KM/p0jXpQwbcKQ9391xnvooH+uvbL95W6eAgDRz2P52Nzq7x5183qedtbfX93KW5jqHQsiE6fOyk87HNZtfRE5EqGRSgPbu2y98tQ1HRsUpMSlG5MsE6fz5GrepXUNvGVfXxW09r3pTPVKJ4gCTJ7JLzbePCeXPlcDg07MX3JUlPPNxfZUJKymF3yM3VoqplfLRo6XLZHXb5+/lo7twf9c0347Vy5aorHuvx8fGaPPk7ffPNeP36669X/b1w7tx5TZgwUWPGjNWaNb9c+UXOw6JFi3Xy5MmrNwSuk507d2r8+AmaMmWqEhMTFVqutH4/EuHc3y9evKhZM2eqaa2y2r9/f67nW5Nj9fCAO/Xp2KmaNe+nXOvz+n2BooGQjv/s8LGT+nHRKtntdlltNp2Lu6h6dWo416/bsF29u7bXd2M+0GsvPyc3N9cr9nfoSITu6tVZfr4+Oh0V88fS3GcCAFzepTDx64btGnhvL00Z+76mjH1fA+/ppaUrfpXdYc9uaPrzuGpcv5Z+XrtZDodDxyIilZqapnJlgtUgvIYWLF0tm82ulNQ0XYxP1PbdB9WmRUOF1w7T0ROnnNstGVRcsecv5KqnQXgNbdq2RympaUpJTdOmbXvUMLzmVcdxKRwBBe3WW29VyZIlcyzz8fFRz5498njG9dWnW3tt371fR09E5lh+4uQZpaWlq1unNqoYWsYZvju0aaZB990uby9P/bZ5V47n3NmzkyZNn6+ExGQ5HA7NmveTaoZVUnDJEmrYsIHMLhZNn7NYLZqEy2az6dTxI9q2/7TqhtfXTz/9pJjYy89mM/3xqV5CYrKiY8+rd7f2ctjtuhCfPSvut99+k5+vr5atWq+2LRtrx46d8vf315AhgxUXd14RERF5jn/16jVq3LiRBg8epJMnT+nUqVN5tpWk9evXq3nzZnrkkYd15swZXbiQ+/cQYCTJySnauHGTBg58QA0bNtSaNWtUvmyIQoJL6IeFK+VwOLRixUq5eRZTbJJDq1atVnp6ulb+slGN6tdWRmam7HaHwqpWVN8+XbT9L7PTLv0dzuv3BYoGrkkv4nbt2q3NmzdLkjp16igfH18tXrxYdrtdxYsHysXFoh49umvRosWqUqWKatSorpMnT2rz5s26++67FRMTo59/Xq2UlBR5e3vrzjvvkJub2xW3abVa9eWXX+nJJ5+Qw+HQ/LmzZXL314ChrykkwE2BJUJUr3Y1bd64Xl9/PU4uFlf9sGyTfl67QaGlvOVbvKwe6tdLJXzM+mnJQs37IU0eHl5yWHwkWdSueV2N/OgTebq7qlxIkC7Endf+vbtU3M9dX331tYYNu/xd47/7boqSkpI0YcJEdejQXmXKlNGyZcsUG3tOHh4e6tatqwIDA/Xrr+uUkpKiuLg4JSUlqmXLlqpbt+5VX+vk5BTNmDFD99zTV35+fv/4ZwUUlEth4v5HX9W7rz3uXN6udWM989pH8vby1JYd+1StcqjORMXoeMRp9ezaTsdPntF9j7wid3dXvfPqE3J1tah31/Y6cfKM+j/ysnx9vPTMY/erS4eW+vDzb7V2wzaF1wpz9t+sUV1NnbVIDz3xhr766M/rYitXKKcH7umph59+S5J0f98eqhhaRlHR5wruRcFN6+eff9bp06c1a9Zs1alTW/HxCUpNTVFAQKAaNWqoFStWKCEhURaLi+644w75+vpq2rTp6tChvUJCQpz9xMfHa/bsOXr44SHas2ePoqNjlJiYoLNno9S6dWvVr19PaWlpmjdv/h9/X5JUokQJ3X33XfL3989V18mTJ7Vr1y7Z7Q6dPXtWrVu3UuVyxTV27FiVLx+qRx+8W5+NnaqubeurZmigpk+bqrCadfT+p6uVnJyksNAgHdyzXVk2h3x9sqe6Pvrg3Xr5rc/UtGEd53WqJ48fVttmNfTRqM/kYpZc3IvplWcGy9XVVaGhofLwcNfCFes0/vO3debMWfn4+OiFJwfp03EzVaO8n76bOV8vPjkoV/2N69fWmYgD2r1rp9o0rKQ3hr8nr2KlVCaklBITE3T69GnVrVtbOw5EqF2rxvpp2VI1adJYJpNJ5cqV19Gjx1SxYsXL/szOnTun227rIrPZrBo1aujw4SMKDQ3V11+PU/Xq1XX8+HGZzSb17t1b/v7+cnd3l5eXl1xcXFS8eHGZzWbFx8dr3rz5CgwMVExMjIKCgtSjR3dZLBadOHFCq1evkcPhUO3atWQymXXo0CGdPh2pSpUqq3PnTtdhzwPyduLEcZUqVUqurq4qX76cli9fLkl688WhGvXVd5q3+GfVqlBM9Ru31OvPP6IJEyfp6ZffVclSwXr56cHKyMiS1WbV86+8JU83s6qULa3U1FR1bt9SSxbN147t2+Xn7abY8xd04myCgoNLyeLI1FdfjZGrq6s6deqoChUqFO6LgCsipBdh58+f1549ezR48CBlZWVp1qxZstsdatWqpapWraotW7YoJubKU1u8vb3Vo0d3+fr6asGCBTp06NBVA6vFYlHJkiV17tw52Ww2BQcHq1KlinrhqSH6+utxGjJksNatW6c7e3dT48aN9PaI0Ro2sLfatG6hmTNnaem6baoWGqRWzRurY8dbtXLlKpUqVVLh4eGaNm26GtWvoxYtmmv58hXy8fFRq1Yt5WbJ/sS+TZvWedbVq1dPTZ8+Q4MHZ7+ZWLNmjby8vDVkSC8dOXJEixcv1oABAyRJaWlpuvfee5SWlqbx48crLCxM7u55T6d3OBxavHix2rVrS0CH4V0KEy8MvUe/H9yvrZs3OIPEnEkfa+zYr9WgbnVZLBZ9+MaT2rlzmypV6K1bW9WTr2v2/SS8PbKvO501a5Y6tq6vEj5Snz69tW3bdh05ckS3NKqiHj26q2TJktq1a7fGjftGkvThG48733jPm/KZs6aet7VTzOljuueevvL19VVCQoJWLF+q6d+M0NGjR/XLL2tVr2opXTgXLVWrVLAvGG5oHTp00KFDv6tv37uVkJCg9et/04MPPqigoBLKzMxU+/btVbx4cf3yy1rt2rVLrVvn/Xfmr06fPq3+/fspLi5OCxYsUP369bRjxw6VKFFC9957j/Nv2+UC+p99nNEDDwxQQkKCpk6dpjdeelLBwaX0xRdfavDgVrqlRSNFR0era9fbdOLECf322waN/+xN/fLLL/L29lHjxo20d+9eJSUlS5LKlQnW9G9G5NpOaNkQPfTAfYqNjdWcOT/kmEbv5uqqJbO+kpeXlw4cOKjAwEC1alZfrZrV1/jxE9SnTy9J0uvPP5Kjz4H9eumDDw6qYsUKat26lSZO/FZdunRWuXLl9MMPc9W+fXv9tnGLQsuVVvFAfyUnJyswMFCSVLx4oPNygsvx9/dXRESEqlatqrNnz8hqzb6Xhs1mU+nSIWrb9hZt2bJF69atU48ePdSyZQt9//1M1alTWw6HQ/7+/oqPj1d8fLx69eqpgIAAzZ07V/v3H1DVqlW0ZMlS9e/fT/7+/kpNTZO3t5eOHDmi1q1bKTQ09Jp+/sB/kZycouLFs48HHx8f2e12ZWVlyc/XW2+9PFQpKSmaOPFbde10iySpVfPGKlEie/bLJS5ms5578mGFhIRo5cqV2rZtm9q0aaPtm9erY8dbVa1atT+yQIx69Oihjz8epccee0wuLkykLgoI6UVYRESELl68qEmTJkuSMjMzZbVaVbVqVUlSsWL+1xTSs//w/6bo6BgFBl7bXZXLly+vyMjTstttqlcvXPv3H1BiYqJ8fX3l4uKi48dPyGq1avfu3fL1MOm3zTs0/6ffVDbIU/fe0VXlyobo1KlTstlsSk9Py9F3pUoVZTKZFBxc6qr1X8mJExHOT8MrV66sRYsWKyMjO4CULl1aLi4u8vHxUUBAgC5cuJDjjMnfbd68RRkZGc7XFigqLhckQkPL69SpU6pUqZKOHj2qsLCwy37odylsnzlzRg8+OFBpaWnas2ePnnnmaaWlpcnd3f2Kz/u7sLBqOnr0qOrXr68jR7K3m5KSqiVLluqhhx6Ul5eXpk2bptKlQ/LsA/ivypcvr6CgEpIkNze37CmkK1cpMjIy1xT3KylTprTc3d0VHByslJTs+5Z4e/soLi7usn/bLicoqIR8fHzk6ekpFxcXlStXVpJUokRxpaSkyM/PT56enlq3bp2ioqKUmJh9Y8W//o212+2qVOnKH2yVKVNWJpNJJUuWlNVqVVpamry8ct9oymRSjkvLHI7c96T4K4vFovLls+8cX7JkSaWkpOjEiQi5u7tr4fL1OnL4kHp3u/WPvk261HV2v3nX2759Oy1btkzbt+9Q+fLllZSU5FxXtmz2a1SpUiXt3r1HkrRnz141adJYiYlJio2NUXp6uqTs9ziXPhioWLGSoqOj5e3tpbJlyyggIOCPNrlfByC/Xf1YM131WHRxcXG+d61UqZK2b9/uXHe546Ru3bpavHix2rRpfcX3vDAGQnoR5nBItWvXUocOHSRlnx0eM2as7Ha7zObcn5LZ7bnv6rxly1adOXNGzZs3U0BAoDPEXk1oaHnt2LFTdrtdHTt21Nat2xQZeVrly5dztundu7dKlgxyPr50du/e229TUlKSNmzYqEmTJiskJFi1atXKtY3sMfy369Cv9Obiz+24yGK58nXyZ86ckbu7myIjTzvfRAFFweWCRFhYdR09elSVKlVSRESEWrdupT179uT60O+S+vXrZX9nq6enQkNDtWjRYrVu3Ure3t6X/bAwL9WrV9fatWtVv359HT16VJ06ddTZs2dUqlQp+fr6OtscP36CkI58Yzb/+Xfh0KFD2rZtu9q0aaOyZcvo6NFj/6K/P294WLlyJW3YsOGKf9sux+Vvd0w3m7Mfx8fHa9as2WrXrq3Cw8M1deo0Z5u//429FiaTSS4uLrnuAH+Jj4+v83puu92u+Ph4+fj4XFPf2a+DdPDgQcXExMjLYlGlsiW0f99elS9XRj4+Prpw4YJKlCiuCxcuyMfHN8++goKCnDPfNm3aLH//YpfdnsViUVZWlg4fPqxBgx6SJK1alaUjR46oXLlyOdq7uJjl6mr542d1DXeyBPKRj4+PTp8+Iyn7PjIWS87j0svLU+np6UpPT5eHh4cuXLigypXz/jAu+3jI/V720nEiZV8WGx0drRUrVqp69epq0qTxdR4VrifmOxRhoaGhOnDgoJKTs28Gk5WVJW9vL506lX2jmaioKGdbb28vRUVFy2636+DBQ87lJ09GqHbtWipVqlSuqWdXulFbSEiILly4oLS0NPn4eCsoqIQOHDigcuWyP1GvUKGCtm7dIofDoYyMDKWl5TyjcPjwEdWvX19DhgxW9+7d83zDcImfn1+OT9Ivx9vbWxkZGbJarc4aDhzIvpHG8ePHVbx4oHNKe0JCvBwOh86dO/fHFLyAK/bdtettat++vX7++WduYIci6a9BolKlijp58pQuXrwoPz8/ubm5OT/0Gzx4kAYPHqShQx/L8Vwp+w3+nXfeofDwcP344zwdOvT7FZ/3d0FBQUpISFRqaqrS09OcZ7iu5c7vwH/h6+t72b8hJ0+eVLVq1VSuXNkrTr++Vv/0b9vVREVFq3jx4qpWrZri4v68GdrV/sb+XUJCvKTsv4W+vr553numdOkQpaenKzk5RWfPnlVISMgVLwW7nK5db9PgwYM0cOADCg8PV6tWLVWxYkVVqVJFp06dksPh0KlTkapSpXKefcTFxclqtSo9PV179uxR7dq1nesu3aV/z549qlAhVCaTSQkJCbp48aLsdnuO1+nSa2Oz2bR37z6FhoYqJKS0Tp06pYSEBDkcDmd/fn6X30eA/FCxYiXFxsYqKytLp06dUuXKVSRlfyi1f/9+mUwmVa5cWZGRkUpPT9eFCxecs1YusdvtSkxMlMPh0O7de3JcY/7348RqtSo6OlrBwcFq3Lgx32RQBHAmvQgrWTJIrVu31rRp0+Xq6qqwsDDddltXLVu2TJ6engoICHCeSa5bN1yzZs1SRESEGjVqqMTE7Luv1q9fX6tXr9H27dtVokQJZ9/Z02Z25HkNuMVikYeHu7y8vCVlT6X7+eef1bt39rVrLVu20LJlP+mbb8bLzc1NXbp0lqenp/P5wcGl9P33M7Vv3z65ubkpODhY7du3y3OslStX0saN2Wfe+/fvd9k3GK6urqpePUzffDNe7du3/6OGZRo/foI8PDzUvXt3Z9vz5+M0ZcoUZWRkqnv37rnOYvydp6envLy8VKJECe3du/eabjQHGJXFYlGJEiW0ZctWhYVVk5T9od+sWbPUtGlTeXt7KykpKdf9F1JTU5WWlqYKFUJVu3ZtnTp1SvXq1bvq8y4xmUyqVKmS1q1br8qVs9+gly5dWkuXLlNycrI8PT116NCha74mGLhW4eF1NW/efAUEBMjd/c+/H7Vr19ayZT/p8OHDzumhf1euXFnt2bMn1xvky8nrb5ur65Vna+WlQoVQ7dy5U5MmTVKVKlWd/Vztb+zfnTx5SgcPHpQkde+efYf6HTt2aMeOnUpKStK0adNVr149NWnSWJ07d9L3338vFxcX9ejRPc8+/6kGDepr4cJFGj9+gipXrnTFa7+joqI0b958ORwOtWzZUsWK/XkmfcuWrTp//rz8/Ys5Pwjp3r2bZs6cJYfDofLly6tmzZpKSkpy3k8mLu6CwsLCVKlSJZlMJnXu3FmzZs2Wi4uLwsLC1KpVS9WuXVuLFi3WqVOn1LVr1+s2buByvL291LJlC02e/J3c3d3Vp09vSVJiYoLzg+tbb+2gBQsWKDMzS+3atc31gZmvr6/WrFmjmJhYlSlTRuHhf743/ftxkpWVpU2bNuv8+fOy2Wzq1o193OhMmZkZnBa8Qf3++2EdPnz4uv6RvV4WLlykJk0aKzg4WGlpaZowYaL69u37j6fu/Ru//rpObm5uatasab5vCygMly4tadasqaKiotS5c2dJ2V9p9sILz0uSDhw4qEWLFunJJ59wvrnftWu3Nm3a5PzQr1Wrljnucp2YmKifflquhIQEmc1m9e7dS8WLF7/s8/Jy9uxZfffdFA0a9JDz+t8jR45o7dpfZbfbVbNmTefzZ86cqZo1a/KhGIqMwvzblpe/frtLUffVV2P04IMDL3s9/d/99W78wM3knxwnMC5C+g3seoT0pUuX6ezZszmW1alTR02bNvlPtR06dEibN29RVlaW7Ha76tULV+PGja/pGvJ169bp998P51hWsWIF57X5V3O5kJ6cnKKZM2fmanv77X2cU3IBALiSy/1tc3V1y3FDJ0kqUaKEc+bZ9TJ79hznjeUuad68uY4fP/6fQnp0dLQWL16Sa/kDDwz41zMELvmn7zEI6cDVEdJvDIR0AMB1tXPnrgIJJQAAADciQjoAAAAAAAbBjeOQb/7JVLMPPhihoKDsa/bKlSvn/H5zAAAAALiZENJhCL6+vho8eFBhlwEAAAAAhYqQjgIREXFSy5Ytk4uLi/M7lyWpSpXKatu27RW/OgYAAAAAbhaEdOS7lJRUrVy5Uv363Zvju07/Kjk5Wd99N0WSQ+3bd1C5cpf/vloAAAAAuJGZr94E+G+WLFmsqlWr5BnQJen2229X//791LBhQy1cuLAAqwMAAAAA4+BMOvLV+fPnFRoaqsOHj6hhw4aaNWt2jvWXprtfOnNeq1YtLV++QllZWf/5+1cBAAAAoKghpCNf+fn5qWPHW7Vz505t2bLlsjeHO3r0qAIDAxUYGKiIiJPy9fUloAMAAAC4KRHSka/c3NxkNptVr149TZz4rerXr6/AwMAcbYoV89eKFSuUmJgkFxcX9ezZo5CqBQAAAIDCZcrMzHAUdhEAAAAAAIAbxwEAAAAAYBiEdAAAAAAADIKQDgAAAACAQRDSAQAAAAAwCEI6AAAAAAAG8X9qhD/rtlddgQAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1000x500 with 1 Axes>"
       ]
@@ -1228,20 +1432,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "5b498cdd",
+   "execution_count": 13,
+   "id": "536bdf69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.387711Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.387627Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.394380Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.394104Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.219617Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.219526Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.227995Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.227659Z"
     },
     "papermill": {
-     "duration": 0.010632,
-     "end_time": "2026-08-31T18:18:55.394721+00:00",
+     "duration": 0.014508,
+     "end_time": "2026-09-01T05:36:19.228270+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.384089+00:00",
+     "start_time": "2026-09-01T05:36:19.213762+00:00",
      "status": "completed"
     }
    },
@@ -1264,7 +1468,14 @@
       "  CI status: straddles_zero\n",
       "  axes that differ: risk overlay\n",
       "\n",
-      "Stage cost_sensitivity: not paired against risk_overlay_leader - this run does not descend from the risk_overlay leader, so the two are siblings and the difference between them is not a stage effect.\n"
+      "cost_sensitivity challenger vs risk_overlay_leader:\n",
+      "  sharpe_diff = 0.073 [0.063, 0.084]\n",
+      "  p_value = 0.000\n",
+      "  prob_challenger_wins = 1.000\n",
+      "  CI status: excludes_zero_strong\n",
+      "  axes that differ: cost model\n",
+      "  the challenger is the frictionless member of the cost grid and the benchmark is priced, so what this measures is the price of friction: 0.073 Sharpe, not a gain the cost stage produced\n",
+      "\n"
      ]
     }
    ],
@@ -1336,13 +1547,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b93a413",
+   "id": "f534b0eb",
    "metadata": {
     "papermill": {
-     "duration": 0.00301,
-     "end_time": "2026-08-31T18:18:55.400834+00:00",
+     "duration": 0.003287,
+     "end_time": "2026-09-01T05:36:19.235041+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.397824+00:00",
+     "start_time": "2026-09-01T05:36:19.231754+00:00",
      "status": "completed"
     }
    },
@@ -1365,20 +1576,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "67fcbf8e",
+   "execution_count": 14,
+   "id": "6c83a85c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.407342Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.407258Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.561736Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.561446Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.242395Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.242279Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.398564Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.398261Z"
     },
     "papermill": {
-     "duration": 0.158469,
-     "end_time": "2026-08-31T18:18:55.562331+00:00",
+     "duration": 0.160495,
+     "end_time": "2026-09-01T05:36:19.398849+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.403862+00:00",
+     "start_time": "2026-09-01T05:36:19.238354+00:00",
      "status": "completed"
     }
    },
@@ -1425,13 +1636,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "796e3e2e",
+   "id": "4fec8314",
    "metadata": {
     "papermill": {
-     "duration": 0.003279,
-     "end_time": "2026-08-31T18:18:55.569094+00:00",
+     "duration": 0.003509,
+     "end_time": "2026-09-01T05:36:19.406156+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.565815+00:00",
+     "start_time": "2026-09-01T05:36:19.402647+00:00",
      "status": "completed"
     }
    },
@@ -1449,13 +1660,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1484b616",
+   "id": "b78149fe",
    "metadata": {
     "papermill": {
-     "duration": 0.003071,
-     "end_time": "2026-08-31T18:18:55.575453+00:00",
+     "duration": 0.003423,
+     "end_time": "2026-09-01T05:36:19.413058+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.572382+00:00",
+     "start_time": "2026-09-01T05:36:19.409635+00:00",
      "status": "completed"
     }
    },
@@ -1474,20 +1685,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "54fe86d4",
+   "execution_count": 15,
+   "id": "97973716",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.582562Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.582464Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.587755Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.587402Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.420939Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.420807Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.426722Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.426393Z"
     },
     "papermill": {
-     "duration": 0.009498,
-     "end_time": "2026-08-31T18:18:55.588104+00:00",
+     "duration": 0.010452,
+     "end_time": "2026-09-01T05:36:19.427020+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.578606+00:00",
+     "start_time": "2026-09-01T05:36:19.416568+00:00",
      "status": "completed"
     }
    },
@@ -1522,7 +1733,7 @@
     "    \"case_study\": CASE_STUDY,\n",
     "    \"family\": RANK1_FAMILY,\n",
     "    \"config_name\": RANK1_CONFIG,\n",
-    "    \"label\": PRIMARY_LABEL,\n",
+    "    \"label\": SELECTED_LABEL,\n",
     "    \"signal_method\": lineage[\"signal\"].get(\"signal_method\"),\n",
     "    \"top_k\": lineage[\"signal\"].get(\"top_k\"),\n",
     "    \"allocation\": lineage.get(\"allocation\", {}).get(\"allocator\"),\n",
@@ -1550,20 +1761,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "d16ff55c",
+   "execution_count": 16,
+   "id": "4a67cf7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.595314Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.595224Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.598889Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.598526Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.435352Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.435258Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.438952Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.438668Z"
     },
     "papermill": {
-     "duration": 0.0077,
-     "end_time": "2026-08-31T18:18:55.599148+00:00",
+     "duration": 0.008268,
+     "end_time": "2026-09-01T05:36:19.439304+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.591448+00:00",
+     "start_time": "2026-09-01T05:36:19.431036+00:00",
      "status": "completed"
     }
    },
@@ -1679,20 +1890,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "008b07a2",
+   "execution_count": 17,
+   "id": "2d7836c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.606382Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.606297Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.662547Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.662173Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.447043Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.446969Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.502671Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.502000Z"
     },
     "papermill": {
-     "duration": 0.060423,
-     "end_time": "2026-08-31T18:18:55.662925+00:00",
+     "duration": 0.060154,
+     "end_time": "2026-09-01T05:36:19.503065+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.602502+00:00",
+     "start_time": "2026-09-01T05:36:19.442911+00:00",
      "status": "completed"
     }
    },
@@ -1710,7 +1921,7 @@
    ],
    "source": [
     "# Forest plot: rank-1 metrics with CI bars + reference lines\n",
-    "ew_val = load_benchmark_metrics(CASE_STUDY, PRIMARY_LABEL, period=\"validation\")\n",
+    "ew_val = load_benchmark_metrics(CASE_STUDY, SELECTED_LABEL, period=\"validation\")\n",
     "forest_metrics = [\n",
     "    (\"Sharpe\", full[\"sharpe\"], full[\"sharpe_ci95_lo\"], full[\"sharpe_ci95_hi\"]),\n",
     "    (\"Sortino\", full[\"sortino\"], full[\"sortino_ci95_lo\"], full[\"sortino_ci95_hi\"]),\n",
@@ -1763,20 +1974,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "8f1f1f06",
+   "execution_count": 18,
+   "id": "f6d7424d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.670828Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.670744Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.759673Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.759325Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.511583Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.511438Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.604286Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.603584Z"
     },
     "papermill": {
-     "duration": 0.093211,
-     "end_time": "2026-08-31T18:18:55.759970+00:00",
+     "duration": 0.097617,
+     "end_time": "2026-09-01T05:36:19.604702+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.666759+00:00",
+     "start_time": "2026-09-01T05:36:19.507085+00:00",
      "status": "completed"
     }
    },
@@ -1810,7 +2021,7 @@
     ")\n",
     "\n",
     "bench_val = (\n",
-    "    load_benchmark_returns(CASE_STUDY, PRIMARY_LABEL, period=\"validation\")\n",
+    "    load_benchmark_returns(CASE_STUDY, SELECTED_LABEL, period=\"validation\")\n",
     "    .with_columns(pl.col(\"timestamp\").cast(pl.Date).alias(\"ts\"))\n",
     "    .select(pl.col(\"ts\"), pl.col(\"ew_return\").alias(\"benchmark\"))\n",
     ")\n",
@@ -1841,13 +2052,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a940bb16",
+   "id": "93be6664",
    "metadata": {
     "papermill": {
-     "duration": 0.004088,
-     "end_time": "2026-08-31T18:18:55.768174+00:00",
+     "duration": 0.003978,
+     "end_time": "2026-09-01T05:36:19.613094+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.764086+00:00",
+     "start_time": "2026-09-01T05:36:19.609116+00:00",
      "status": "completed"
     }
    },
@@ -1873,13 +2084,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39e8c3cd",
+   "id": "e52ab437",
    "metadata": {
     "papermill": {
-     "duration": 0.003808,
-     "end_time": "2026-08-31T18:18:55.775808+00:00",
+     "duration": 0.004029,
+     "end_time": "2026-09-01T05:36:19.621168+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.772000+00:00",
+     "start_time": "2026-09-01T05:36:19.617139+00:00",
      "status": "completed"
     }
    },
@@ -1897,20 +2108,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "ae76eba9",
+   "execution_count": 19,
+   "id": "ba183f7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.784156Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.784057Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.787248Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.786924Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.630107Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.629934Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.633860Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.633451Z"
     },
     "papermill": {
-     "duration": 0.007874,
-     "end_time": "2026-08-31T18:18:55.787522+00:00",
+     "duration": 0.00908,
+     "end_time": "2026-09-01T05:36:19.634325+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.779648+00:00",
+     "start_time": "2026-09-01T05:36:19.625245+00:00",
      "status": "completed"
     }
    },
@@ -1971,20 +2182,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "f95f505f",
+   "execution_count": 20,
+   "id": "4f4e939c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.795709Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.795625Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.961225Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.960836Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.647117Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.647032Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.813754Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.813241Z"
     },
     "papermill": {
-     "duration": 0.170192,
-     "end_time": "2026-08-31T18:18:55.961530+00:00",
+     "duration": 0.171849,
+     "end_time": "2026-09-01T05:36:19.814255+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.791338+00:00",
+     "start_time": "2026-09-01T05:36:19.642406+00:00",
      "status": "completed"
     }
    },
@@ -2007,20 +2218,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "576d60ea",
+   "execution_count": 21,
+   "id": "d3f5bc50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.970544Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.970465Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.976036Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.975778Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.824322Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.824153Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.832852Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.832296Z"
     },
     "papermill": {
-     "duration": 0.010568,
-     "end_time": "2026-08-31T18:18:55.976468+00:00",
+     "duration": 0.014122,
+     "end_time": "2026-09-01T05:36:19.833164+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.965900+00:00",
+     "start_time": "2026-09-01T05:36:19.819042+00:00",
      "status": "completed"
     }
    },
@@ -2115,20 +2326,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "fb636e20",
+   "execution_count": 22,
+   "id": "9ed79a79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:55.985897Z",
-     "iopub.status.busy": "2026-08-31T18:18:55.985815Z",
-     "iopub.status.idle": "2026-08-31T18:18:55.988972Z",
-     "shell.execute_reply": "2026-08-31T18:18:55.988636Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.843458Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.843279Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.848659Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.847955Z"
     },
     "papermill": {
-     "duration": 0.008722,
-     "end_time": "2026-08-31T18:18:55.989370+00:00",
+     "duration": 0.011122,
+     "end_time": "2026-09-01T05:36:19.849039+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.980648+00:00",
+     "start_time": "2026-09-01T05:36:19.837917+00:00",
      "status": "completed"
     }
    },
@@ -2179,13 +2390,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4608efca",
+   "id": "c2fe7afd",
    "metadata": {
     "papermill": {
-     "duration": 0.004024,
-     "end_time": "2026-08-31T18:18:55.997537+00:00",
+     "duration": 0.004787,
+     "end_time": "2026-09-01T05:36:19.858815+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:55.993513+00:00",
+     "start_time": "2026-09-01T05:36:19.854028+00:00",
      "status": "completed"
     }
    },
@@ -2207,13 +2418,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "620a107b",
+   "id": "329f568e",
    "metadata": {
     "papermill": {
-     "duration": 0.004066,
-     "end_time": "2026-08-31T18:18:56.005714+00:00",
+     "duration": 0.004919,
+     "end_time": "2026-09-01T05:36:19.868790+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.001648+00:00",
+     "start_time": "2026-09-01T05:36:19.863871+00:00",
      "status": "completed"
     }
    },
@@ -2232,20 +2443,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "88451518",
+   "execution_count": 23,
+   "id": "091eeff9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.014668Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.014575Z",
-     "iopub.status.idle": "2026-08-31T18:18:56.021221Z",
-     "shell.execute_reply": "2026-08-31T18:18:56.020874Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.879496Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.879210Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.888062Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.887526Z"
     },
     "papermill": {
-     "duration": 0.012039,
-     "end_time": "2026-08-31T18:18:56.021835+00:00",
+     "duration": 0.014839,
+     "end_time": "2026-09-01T05:36:19.888369+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.009796+00:00",
+     "start_time": "2026-09-01T05:36:19.873530+00:00",
      "status": "completed"
     }
    },
@@ -2261,17 +2472,17 @@
       "│ ---      ┆ ---        ┆ ---        ┆ ---           ┆ ---          ┆ ---          ┆ --- │\n",
       "│ f64      ┆ f64        ┆ f64        ┆ f64           ┆ f64          ┆ f64          ┆ u32 │\n",
       "╞══════════╪════════════╪════════════╪═══════════════╪══════════════╪══════════════╪═════╡\n",
-      "│ 0.0      ┆ 0.896752   ┆ 0.60474    ┆ 0.827822      ┆ -0.066652    ┆ 1.697874     ┆ 14  │\n",
-      "│ 1.0      ┆ 0.886033   ┆ 0.84222    ┆ 0.864127      ┆ 0.133393     ┆ 1.68573      ┆ 2   │\n",
-      "│ 2.0      ┆ 0.876211   ┆ 0.832383   ┆ 0.854297      ┆ 0.124699     ┆ 1.673248     ┆ 2   │\n",
-      "│ 3.0      ┆ 0.864954   ┆ 0.822016   ┆ 0.843485      ┆ 0.113437     ┆ 1.660378     ┆ 2   │\n",
-      "│ 5.0      ┆ 0.844328   ┆ 0.801513   ┆ 0.82292       ┆ 0.093295     ┆ 1.635758     ┆ 2   │\n",
+      "│ 0.0      ┆ 1.223148   ┆ 0.60474    ┆ 0.892022      ┆ -0.066652    ┆ 1.965193     ┆ 28  │\n",
+      "│ 1.0      ┆ 1.209262   ┆ 0.84222    ┆ 1.019219      ┆ 0.133393     ┆ 1.951379     ┆ 4   │\n",
+      "│ 2.0      ┆ 1.195313   ┆ 0.832383   ┆ 1.010418      ┆ 0.124699     ┆ 1.937938     ┆ 4   │\n",
+      "│ 3.0      ┆ 1.180956   ┆ 0.822016   ┆ 1.00094       ┆ 0.113437     ┆ 1.924367     ┆ 4   │\n",
+      "│ 5.0      ┆ 1.15125    ┆ 0.801513   ┆ 0.982584      ┆ 0.093295     ┆ 1.897915     ┆ 4   │\n",
       "│ …        ┆ …          ┆ …          ┆ …             ┆ …            ┆ …            ┆ …   │\n",
-      "│ 10.0     ┆ 0.792554   ┆ 0.750389   ┆ 0.771471      ┆ 0.050932     ┆ 1.575617     ┆ 2   │\n",
-      "│ 15.0     ┆ 0.739983   ┆ 0.698756   ┆ 0.71937       ┆ 0.008125     ┆ 1.514545     ┆ 2   │\n",
-      "│ 20.0     ┆ 0.687887   ┆ 0.647558   ┆ 0.667722      ┆ -0.034149    ┆ 1.453995     ┆ 2   │\n",
-      "│ 30.0     ┆ 0.583069   ┆ 0.545011   ┆ 0.56404       ┆ -0.129902    ┆ 1.339179     ┆ 2   │\n",
-      "│ 50.0     ┆ 0.375301   ┆ 0.339949   ┆ 0.357625      ┆ -0.320898    ┆ 1.103777     ┆ 2   │\n",
+      "│ 10.0     ┆ 1.080929   ┆ 0.750389   ┆ 0.935164      ┆ 0.050932     ┆ 1.824193     ┆ 4   │\n",
+      "│ 15.0     ┆ 1.040959   ┆ 0.698756   ┆ 0.871962      ┆ 0.008125     ┆ 1.746885     ┆ 4   │\n",
+      "│ 20.0     ┆ 1.001184   ┆ 0.647558   ┆ 0.809164      ┆ -0.034149    ┆ 1.671695     ┆ 4   │\n",
+      "│ 30.0     ┆ 0.921178   ┆ 0.545011   ┆ 0.682361      ┆ -0.129902    ┆ 1.586206     ┆ 4   │\n",
+      "│ 50.0     ┆ 0.75928    ┆ 0.339949   ┆ 0.431475      ┆ -0.320898    ┆ 1.417132     ┆ 4   │\n",
       "└──────────┴────────────┴────────────┴───────────────┴──────────────┴──────────────┴─────┘\n"
      ]
     }
@@ -2342,27 +2553,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "7ed598cf",
+   "execution_count": 24,
+   "id": "854f9456",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.036444Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.036294Z",
-     "iopub.status.idle": "2026-08-31T18:18:56.126392Z",
-     "shell.execute_reply": "2026-08-31T18:18:56.125609Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.900271Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.900112Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.984355Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.983959Z"
     },
     "papermill": {
-     "duration": 0.096999,
-     "end_time": "2026-08-31T18:18:56.127176+00:00",
+     "duration": 0.091472,
+     "end_time": "2026-09-01T05:36:19.984604+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.030177+00:00",
+     "start_time": "2026-09-01T05:36:19.893132+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3MAAAF+CAYAAAAoSEONAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAArABJREFUeJzs3Xd4VMUax/Hv2Z6yqZtAQgi9916kI6CgIGIFRVFpAgqKiKAoRRRBUbCBKIqiInZFvdgVBRTpvRNaSO/Zes79Y5OFmGQJSAnwfp4nN+TU2WLu/jIz7yhOp0NDCCGEEEIIIcQlRXexGyCEEEIIIYQQ4sxJmBNCCCGEEEKIS5CEOSGEEEIIIYS4BEmYE5eVpJS0i90EIUQpcnLzyMu3X+xmCCGEEJcNCXOXsNGPzuSPtRtK3b/g7eUseHv5aa9T1uMuFE3TeG7eYq7uP5RJ018q83mbt+1m/sL3/9O92/W6g937DgHwx9oNjH50ZqnHznn5Hea+9u5Z3ed01z6fLsTrvejdT3j0qbn/+Tqnvh4rVv7G4JGT/vM1z0RyajoDhz5Kcmr6Bb3v5Wrlz6tZ/sXKi90MIYQQ4rJxRYS5Tdt2M+qRp+l10whuvfcR3n7/C9wez1lf73hiMv0Hjz13DTxLL8+axFVtmvl+btfrjiL7h999M8Pvvvm01/n3cfc/MoP1m7afu4aeRv/BYzmemOz7ef+hI3y24kfeePEppk0aXebrvPvRV9x4/dXnrF1XtWnGy7POTXj493N6Lq99psr6vrgSLXr3Exa9+4nv56jIcN5/YxZRkeEXsVVn7t+PoywuxO+1Xt3a8/X/fsXucJ7X+wghhBBXiss+zK1Zt5lHpjxP/z7d+eK9l5g/6zHy7HbsdsfFbpooRWZmNkGBAVSrUgmDXl+mcw4mHOVYYjJNG9Y5z60TQpytoMAAWjdvyLc//H6xmyKEEEJcFgwXuwHnk6ZpzH1tCSOG3MLVXdoCYLGYuf+eW33HJKemM/fVJazbuJ2wUCt33daXPj07AXDo8DFmPP8G+w8eplJsBcYMvR2jwcCDk2bhdLro1u9ermrTjOmn9B55PCovvLaE739ejcVi4pruHRg55BYUReGfjduZ98ZSjicm06xxPR4bex9hoVZWrPyNNes2U7dWNT5b8SN2h4OH77+Lrh1bA/Dltz/z5nufYXc4adm0PhMeGEJoiJUho5/gpr49aN6kPrcPnQBAt373UqNaZd548SnmLXyfzKxsJo0byg13PMBTj95Pi6b1Adi2cx8Tp87l8/fm8cqbH5KZlc0T44dz+9AJHEw4xrjHZ6PX6Xj5uUmMHD+Dbz58haCgQACWLl/Bjt37mTF5TJlfiz37DvH8K++w7+AR6tSsyqSH7iO2YjTd+t1Lvt3B7cMexRocxPTHRjHu8dm+5/excfdRu0aVYq9Dq2YNi1x/9brNNGtUD0VRWP33Jp6b9xafLnkRRVEAmD1/MUGBAYy851Y++/pHvl75KwlHEomPi2HKIyOoGh9brM2r1mzg+Vff4bMlLwLenotZ895i28591Kwej9FgoFqVSgA4nS4++PRbfvhlDcdPJFOvdnWenDACW2R4sef0i6Xz2LR1d5Fr+3sfnu79UZot2/fw3LzFHDuRRM1q8Tx0/2Dq1Kzqe188MX44AN/+sIo3lnxCYlIKmqZhMZu545br6H11B4aOe4rJDw3jjSUfc/joCfr36cb9994GwOGjibz53qds2rqLfLuDG6+7mmF33eS3Tf0Hj/U9ZvD+N1rW1+PfsnNymf/G+6xavQGzxcSA667m9gG90eu9f6P6a/1WXl+8jIQjiVSvGsekcUOpGh/Lj7+t5aPP/8eBQ0eIjAjjsbH30bhBbZ596U2+/u5XFJ3C+x9/w9THRtGiSX2633Afn74zl5iKUTicTha+8zErf14NeHuahg4egNlk4nhist/nq9D0OQvo06MjzZvU921zudwsfv9zvv3hdxwOF52vasn40Xej1+v4Y+0GXl+8nMSkFOrXqc64kYN9z09JvxteW/xRscfRsW1z373O5Pfa3xu28t5HX7Nr70ECAwIYO+IOOrVv4Xv9Z730Flu278HpcmEw6ImpEMVHb80hIzObF15dwtp/thARHsK4kYNp3dz732zzJvVZ+fOf9O/T/bSvsRBCCCH8u6x75tLSM0k4kkj3TiV/6PV4VB596gUiI8L4cuk8pj02ilfe/NA3D23BOx9TrUos33z0KtMmjiLaFkHTRnWZO+MRKlaw8dMXbxYJcgBr1m3i59//4r0Fz/DBG8/RunlDFEXhyLETTJz2IqPuvZ1vlr1K9SpxvPLmh77zfvnjbwwGPe8teJYB1/fgxdffAyA3N49Z895i8sPDWPHhy/S9tqsvVBWKqWDjg4WzAPjpizd548WniuzX63V069SGn1f9ffJ+q/6mW6fWvg++hT544zkqVrAxd8Yj/PTFm9SvU4P6dWrwy5/rfMf8tvofru7ctiwvAQBZ2bk8OGkW/Xp349vlr3F1l7bMnLvI116ADxbO4qv35/ue3+CgQH764k16dGlX4uvwb7v3HiK2YhQArZo1IN/uYOeeAwCoqsqvf66je+e2KIqChsaTE0by7UevUa1KJea/cfp5dh6PyqNT5xJTIYov35/HxAfvIT0jy7dfr9djMhmZPe0hvv7wFTQ03v7gyxKfU2twUPFr+3kfQunvD3/mvraEzle14LuPXmfsiDuICA8tdszBhGM8/cIbTHroPr5cOo/6dWowfvRd3HtHfwBS0zL58be1vDBjAnOmPcy7H33N4aOJANjtDjq0ac7ShbN4/fknWPLhl+zYvf+07TrV2b4eADNfWERWdi4fLZ7D/Gcf46v//cpnK34EYO/+BCY89QJ33HI93y1/jZH33IotMgwAh8PJQ/cP5ptlr9KlQytmvfQWABMfvJde3a/irtv68tMXbxYJQIUWLF7Olu17ePvl6bz98nS2bN/Dwnc+9u3393z588aSj1m1Zj3zZ03i0yVz6drR+9/mrr0HmfLMK4weejsrPnyFVs0bMm7yLPLt9lJ/N5zucZzJ77XcvHyGDLyBr95/mbtv78uM5xfidLoAmPH8QuLjYvj6w5cZOngAjerX4qO35qBpGk8++wrW4EC+fH8eT00YyfQ5C8jJzQMgtmKUbx6kEEIIIf6byzrMJSalYjQaCLEGl7h/194DHEw4xqj7bsdiMVO3VjVu6deLT7/2fiCsEBVBwuHjpKVlUjU+liqVT99bYIsMJz/fwd79CQQGWGjZtAHg7V25qk1TWjdviMFg4LYbr2HN35t851WtXIlb+1+DxWyifasmJKWkYbc7MJlMhIWGsH3nPtwelTYtGpV56OGpenZtx69/rkNVVTRN45c//ubqzu3KdO51vTqx8qc/AUjLyGTfgcO0bdWkzPf+ZdVfVK5UkWuv7oBBr6fftV3ZtecgDmfZ5s2U5XXIzMompoINAIPBQLeObfilILxu2bGXoMAAateoAsCA63sQWzGa/YeOEGINYvfeg6dtw849+zl89AQPDh9EgMVClcqx1KtTzbdfr9dx+43XEhZiZd+BBGwRYewqw3Xh9O9DKP394U90VCT7DhwhOyeXerWrlzjv62DCUSrFRNOyaQNskeF0at+CHbsPFDnmgWGDCAu10qh+LYICA3zhpFaNKlzdpS15efkkJqUSHh5a4mNe9O4n9LhxGD1uHMaJpFTfv7/636/A2b0e6RlZ/PLH34wbcSfBQYHExVbgnkE38FnBc/b5Nz/TtUMrunVsjcFgoFmjugQX/BGkd4+O1KwWz6EjxwkKCGD/oSO+gOKPqqp8/s1P3H/PrURGhBEZEcb9997G5yt+QtM0v89XwpHjvse98uc/GT/leXrcOIwxjz6Dqqp88vUPjBk2kLjYClgsZl8v1pff/UK3Tm1o06IRJpORQTf1wWg0svrvzWf9u+FMfq91uaoVTRrW4fiJZAwGA9k5uSQmpQCw90ACvXt0xBocRN9rurCz4H1z5NgJ1m/eweiht2M2mahTqxp1alZl2859AMRUiCIjI/u07RRCCCHE6V3WwywrRkficrnJys4hNMRabP+xxGSibOFYzCbftrhKFVj5sze4jBxyK198+zOjJsykcYNajBhyCxWjbX7vWadmVV6cOYG3ln7Gq28tY/jdN9OxbXOOHk/i1z/W8cfaYYB3eNmpHwALRgMC+MKny+3GYjGz6MWnePuDL7j1nvHcckMvbh9wLTrdmeXw+nVqYDIa2LZzHwEWM263m4b1apbp3G4dW/PS6++RmpbBn39von3rpkWeM4CnZr3Kb3/+A8Cgm6/z9ewAHD2exPZd++hx4zDfNqfTRVZ2LlGRRa9TkrK8DqqqYjCc/CB7dZe2zHrpTUYMuYVfVv1F905tfUMuP/j0W5Z/vpL4uIrYIsPLVIzheGIK0VERWCzmEverqsrriz/i+19WU7tGVfR6HQ5H2eZlnu59CH7eH5TcHoAnxg/no8//x92jH6djuxYMG3wToSFF/7DRsF5NUlLTWf33JqpVqcTPv//FLTf0KnJM4b11Oh1WaxAutxvwDjt9+oU3SE5Np0WT+phNRuz24s/lfXcO4L47BwDFh1nC2b0exxKTMRoNREed7KWNi63IsYJCOscSk2jcoHaJ5/7vpz9Y9O6nRNnCqVktHgCH04nJZPR7z4ysbPLtDuJiK/i2Va5Ugbx8OxmZJ8NJSc9XfFwM33+6ECg+zDItI5O8PDtV4ysVu+fxxGSanDIPVFEU4mIrcCwxCaPRcFa/G87k99pf/2zhpYVLsZjNtCwYol34+rRp3ogvv/uZypUq8OnXP1K/Tg3A+9p4PCp9Bz7gu47L7aZXt/YAGA16VFX120YhhBBClM1lHeYiwkOpFBPNj7+uLbHKYWzFKJJT0nE4nZhN3g/SR46dIKZguJ7JZOTmfj3p36cbLy/6kJkvLGLesxNBUdBUrdj1CjVpWIeXnpnIlu17GP3oTD5cNJuYCjZ6dmvP5IeGnvHjiKkYxWPj7iMpJY0xj87EFhlGr25XFT2o4BOkqqolfphTFIWrO7fltz//ISDA7BtyWBIFBfWUoBlgsdCtYxt++v0v1m/awTVXX1XsnKcevd9v+5s0rOO3euOp9/u3Ul+HU4RYg0hMSvX93LRhHfLyHRxMOMbvq9fz3FMPAd55ZG+99xnL3pxNRHgo6zdt59c/1nE6ERGhpKZl4Ha7MRiK/2fzw69r+HnV3yxdOIvAAAsrVv7Gss++8+3/93N6qtO9D89WUGAAQwbewO03XsuM5xfy6psf8ti4+4o+rvBQ6tWuzoK3l5OSlk7PLu25pnvx17cks+a9Rf26NXxzUO9/ZMYZt/FsX4/YilG4XG6SU9KIjooEvM9Z4VDbitE2jpQwvDEpJY1ps19n6YJnqRpfieOJyUVK5SuAWsp/22EhVgIsZo4eT8JW0Mt55OgJAgMshIVaSTzLokphIVYsZjOHjyYW6z2NqRjF0eMnfD9rmsbR4ye4rldn3/6Sfjf4exxl/b3mcrmZOO1FZj7xIG1bNgZgybKvfPuvatOMtz/4goHDJlItvhITx97rbVMFGyaTka8/fNn3fj7V8RMphISUPFpCCCGEEGfmsh5mqSgKY0fcyetvf8QPv67B7nCSmpbBnJffYcfu/dSpWY2q8bG8+uaH2B1Odu87xPIvVtK/T3fcHg9Lln3JscQkPKqK0WDAWTAsMDI8lKSUNBKOHC82VPCXVX+z9p8tuFxuDAY9Ho+K2+2mT89O/PT7Wn5Z9Tduj4e9+xPKNG9k/8EjfP7NT+Tm5aPX6QAFRwlDwkJDgtHrdKzbuL3U4Ys9urTj9zXr+fOvjX7nvEVGhPLPpu04nS48Hu9f0K+/pjMrf/6T7bv2+T7YlVWXq1qx/8ARPvnqe1wuN4ePJrJl+56i99u4rcR2+3sdTlWtShzHEpN8P+t0Oq7u3Ialy7/GbDZRvWoc4O1dcbs9uFxu0tIz+WzFT0WuYzIaSxxy16BuDQIDLbz9wRc4nS42b9vNmnWbffszs3Jwu9243R6OHk/i2x9WFTm/pOe0kL/3YVnMnr+4yJBMgLx8O+98+CWpaRmomobBoMfpKv649h86SsLR47wyezJff/AKDwwfVOZe34zMbFwuF06ni9/XrGfv/gTfPpPJWKZhtGfyeniv6ULTNMLDQuhyVStefP09cnPzOHo8icXvf84NfboB3qHB3/+6ht/+/Ae3282mbbvZe+AwWdm5qKqG3eEkOyeXD08J3AAREWFs3bEXu91R7H2g0+m4oXc3Xn1rGWnpmaRlZPLaW8vo17tbqX8YKQudTsf113Rm/sL3OX4iBbvdwXc/rsLt8dD3mi78+Ota/t6wFZfLzQeffIvT6aJdq8Z+fzeU9jjO5Peaw+kk3+7A7nCQb7fz3vKvi7R7+RcrGXXfbXz9wcu8/NwkX49l5UoVaVi3JrPnLSY7J5e0jExWnzKk/FhiMtWrFO+FFEIIIcSZu6zDHECHts2Y+cSDfPzFSvoOHM2oCTOJCA/xDYV79slxnEhOo+/A0UyeMY8RQ26hQ9tm6HU6Qq1WHpnyAr1vuZ8NW3YwfvTdAFSpHEvfa7twz5gpPPXsa0XuVzmuIh988g19bhvFo1Pn8uDwQVSuVJH4uBhmP/UQS5Z9Sa8Bw3l85sscTDh62vZHRoSybec+brv3EQYOm0jThnW4tnuHYscFBli4547+TJr+EqMeebrEYUw1qlVGpyhkZuVQp2bVUu95z6D+fP3dr9xyz3hfr0D9OjXIzc2neZN6Jf613Z+wUCsvPfMoP/62lmtvGcnYSbN882cAht99C6+8uYw7R0zyFUko5O91OFWLJvXZsato8Y0eXdqx4vvfiwTXti0a0651EwYOe5THpr9Elw6tipxzXa9OvPh68YXAzSYTz04Zy6o1G7ju9lF8+Om3dO/Uxrf/mu5XUSmmAjcOHsvs+Yvp2bXofMSSnlPfY/TzPiyLgwnH+PTrH4psM5mMaJrGyPEzuH7gaNLSs0pcW65KXAxmk4l+gx6gW7976TlgOCMemsbBhGOnve+IIbfw029/MeDuh9iweWeRNQ/btmzCwYRjrFpTdFH7fw+xPJPXo2mjuoDGJ195H+ukh+4jMDCAm4Y8zOgJT9O7RwduvM7bA1+/Tg2mPTaKBe8s55qbR/L64o9A06hRNY6b+vZg1CNPM/rRmTRvUg+T8eTwyv69u5GekcUNdz5YpGBQoeFDbqZB3ZoMvn8Sg0dOol6dGgy/238Fz397YvzwIpUsAe6/9zaaNKzD0LFPctOQh9i6Yx9ul5s6NasydeIoXnz9Pa69ZSSr/97E3KcfJcBi8fu7obTHcSa/14KDAhl5zy3MmLOQe8ZMwRoURHxcRd+1rmrTjKmzXqdbv/vofsN93DzkYT5b8SOKojB90mg8qsot94xn8MhJ/PT7X7hc3uG5O3bvL/b4hRBCCHF2FKfTUfr4NiEKaJrGvQ9MYejgm2h3BsVPLhRv+57k8YeH+XrhrhT7Dh7mlUUf8sKMR8743G9/WMXWnXt5pOADfWZWDpOfnkeNqnGMGzn4HLdUXC5ycvMY/tA0Xn/+CazBQbhcbr767hdefWsZP3z2Rqnnud1ubrtvAm+8+BThYSEXsMVCCCHE5emy75kT/53b4+GzFT+h1xvOeIjlhaIoCnfccl2x4YaXu/SMLJ5+fiH33nHjWZ2//+AR0tIyOZ6YjMPpZO/+BI4eT6JR/ZKLhwgBkJKaTmpaBvsPHcXpdHEsMYmtO/fSpKH/982vf/5Du1ZNJMgJIYQQ54j0zAm/VFVlwN0PYQ0K5MlHR1KjauWL3aRSeTwqG7bs8C0HcSVwudwkpaRRKSb6rM7PzMpm9vy3+Wv9FjwelUqxFbi1fy/69Oh0jlsqLieaprHss/+x/Iv/kZKWQXhoCB3aNmfYXTcRYg0q9bwDh44SFGjxFa0RQgghxH8jYU4IIYQQQgghLkEyzFIIIYQQQgghLkES5oQQQgghhBDiEiRhTgghhBBCCCEuQZdtmNM0DbfbjabJlEAhhBBCCCHE5cdwsRtwvng8Hjr2uZvfV7yNwVA+H2Zafjou1VXm4406IxEB4Wd3s5xEUJ1nd+7FojNBcMXTHyeEEEIIIcQVqHymnCuES3VhUPRndPxZU52gu8Re7kstfAohhBBCCHEBXbbDLIUQQgghhBDiciZhTgghhBBCCCEuQRdl3N0Hn37L+8tXcNuN1zLo5j6+7RmZ2Tww8RnfzyeS07j79r7cPqA3V117JzWqVgagScM6PDzqrgvebiGEEEIIIYQoLy5KmGveqC579ycU2x4WamXJazMByMu38+Bjs+jXuxsAUZERvn1CCCGEEEIIcaW7KMMs69SqRkwFm99jPvjkG27qezWBARYAQkODL0TThBBCCCGEEOKSUC7LG7o9Hn5e9TdvzZvm25aalsHQsVMBjdFDB9KkQe1i53385fd88tX3ALK+nBBCCCGEEOKyVi7D3Pad+6gSF4PJZPRte/rxB6lbqyq/rPqbp2a9ymdLXix23k19e3BT3x4AuN1uOva5+wK1WAghhBBCCCEurHJZzXLnngPUrB5fZFuTBrUxm0z06NKOnJw87A5Zg0wIIYQQQghx5SoXPXNLl68gyhZOz67tAUhMSqVqfKxv/x9rNxAfF0PlShX5Z9N2om0RWMymi9VcIYQQQgjxL8cynNjdnnN+XYtBT2yYfO4ToiQXPMwlp6bz8OOzSU3PRKcorF63iepV4lAUxXdMXl5+kbAWWzGa5195h6TkNIwmA1MmjLjQzRZCCCGEEH7Y3R6MunM/6KssAfF4YjLjpzzP0oXPnvV9Fr37CTEVoujTs9NZX+O/mD5nAX16dKR5k/pFtquqynvLv+aHX9YA0KZFY0YMuYXvflzFjt0HGD/6/C/XtX7TdpZ+/A3PTx9/3u91qZr63OvsO3iYRx8Ywrsffc20iaOKTBk7Xy54mIuKDD/tEgMTx95b5OdqVSrx4sxHz2ezhBBCCCGEKHc++nwlu/Yc5M150zAY9KxZtxmdTjn9ieKCSU5NZ9PWXXy6ZC4Az04Ze8HuXS6GWQohhBBCCPFf5NntTJv9Orv2HKRalUo88chwzCYTq9Zs4NU3P8Sjehgy8Aau6d6B//30Bwvf+RiDwcA9g/qj0yl89PlKAgMsrFqzgWemPFjs+ieSUhk3+Tnef2MWyanp9B04ho/ffoFKMdHc+8CTPPvkWHSKwsy5i0hMSqFitI3JDw0lIjyU6XMWUKdmVb77cRUPDBvEtp37+OSrH7CYTTw0ajB79h3i59//YtPWXbRr1YSHR53sbVv22be88eJTGI3ej+3tWjXx+zy8tfQzVv68GpPRwOSHh1GnZlUGDZ/I9b26sGLlbxiNBl565lG++u5XnC4Xd9/eD4BRjzzNI2OGEGINYtrs1zl+IoVa1eN5csLIItd3ezzMW7CUfzZux2w28fCou2hQtwYrVv7G2n+2kJWdw7HEZHr36Oi7dkltKvTPxu0sevcTMrNyqFGtMlMn3o9Op+Ov9Vt5edEHaKpGr+7tuePm67hzxCTatW7C9l37mP/sY3y98jc+/ORbAG4fcC3X9epMbm4eE6e9RGJSCrEVo3hmyliOHjvBU7New+1x0751Ux4cfofv/h6PymuLl/Hn2o2YzSaeGD+c+MoxpT7G3fsOkngile279nHfnQPo17srk6bPIzUtg3vGTOGt+dPo1u9efvriTZxOF1Ofe43tu/aRmJRK5UoVmfzwMBJPJBd5//Xq1v4M3ulFSZi7wLLy3WQ7VMwGhRyHB4tRh14HegV0ivyVRQghhBDibOTn27lnUH8qxUQzceqLfP/zajq0bc5ri5exaN5UDHo9Ix6eztWd27Jk2VfMmDyGalXiyM+3Ex4Wwpp1m2neuF6pwywrREficrvJzMph87bdNG5Qm83bdhMZEUZefj5RkeE8MfNlWjdvyK39r2H5Fyt5acFSpk68H4DfV69n4YtPYdDreXjKHD5e/IIvoLVs2oDf16znvjtuLDLMMjc3D1XVsEWGl+k5WPvPFvYeOMz7C58lMSmF5195h+enP0JewWNc8trTjJ/yPH+s3UDnq1ry1KzXuPv2fmTn5JKVnUvV+FimPPMKA/r2oEObZry19HN++eNvIsNDfff48ttfSEpJ470Fz7Dv4BEmPPkCH701G4Ck5FReeHoCALffN4GrO7fl6PGkEttUqGIFG89NfYjgoEBGPDydjVt3UaNqHDNfeIOXn5tEpZhoMjKzAdh/6DA339CT+++5lf0Hj/D2+5+z5NWnAbh79BM0rFeTA4eOYjIZWb74eU4kpRIYYOHL736hd4+O3D7gWlJS04s8Zyu+/42Ew8dZ8vpM8vPtWMxmv49x87Y9vDzrMQ4dOc6UZ16hX++uTJt4P+OnPM9b86cVufbPq/7C7fbw6ZIX+fCz78jOzqVJg9o8N++tIu+//0LC3AWW51RxuFQcLo2UXBc6xQM6BQVQAJ1OwaCAwaDDrNdhMijodQo6naydJ4QQQghRmsjwMOJiKwDQpkUjdu45SFhoCCmpGYx4yPshOzs3j4zMbHpf3ZF5C5Zyzx39adWsYbFrff/Lat5d9lWRbUtem0mzxnXZumMPm7ftpu81Xdi0bRcxFWw0rFcLgHUbtzF2hLfX5+rObVm89HPf+f2u7YpBrwfgup6dmPH8AoYOvom6taqV+pjO9JPf2n+2sGPXPu4e9TgAAQEW3742LRqhKAq1a1QhLT2LSjHReDxu0jOy+Gfjdjq0awbA3xu2cuDQUd5452OcLjc39O5WJMyt27CVqzu1RVEUalarTECAmYQjiQDUrF6FwIJ7Nqpfiz37DrFlx95S2wRQMdrGb3+uY/W6TSQlp5J4IoX8fDuNG9TyvZ7hYSEAGI1Gru/VGYB/Nm2nTYvGBAUFAtC2ZWPWbdxO1w6tWPzBFyx852Nuu/FaALpc1YoXX3+PkJBgrr26Q5H7r1m3mRuvvxqDXo81OOi0j7FB3ZoEBQVSu2ZV0jOy/L4eEeGh5OTm4XC6yMjIQl/w+p/u/XcmJMxdBDoF9DodZqMOvaIvtl/TNOxOlTzNg6qBogAaeDQPefZ89IqCQa/DbFAwGRSMeh0GnYJeJ717QgghhBAGgx6LxYSGRosm9Zj5RNFhk4Nu7kOn9i2Yt3Apf/61sciwO4AeXdrRo0u7Ytdt3rgeW3fsZd/Bw4y851Y++ep74mIr0LRRHcD7GU4p5bOYTn+yOMy4kYPZtecAL7z2Lt06tubW/teUeE5wQVBJSU0vW++cpjHwpj7c3K9nqYfo9TpfB0Gndi358++NrNuwzRd8AF5/4QmCAgN8P6/ftP3UW3h7IE7DYNBjNptO26aXFryHR1W5rf+1BFjMaJqGWspNdIpS5Pkt6amOjAjjrfnT+O6HVdw96nFefu4xWjStzyuzJ7N0+dcMffAp3pw3FV1BsR5NLf6aleUxGvT603a0NKpXi/SMLIaNfYrYmGgeG3sfcPr335kol+vMXekURcGgUzDpdVgKeujMBu+XUadDpyi4PSpZ+W5OZLo4nGrnQKqdfUl29iXnczDVzuF0O8nZTjLy3OQ7VZxuFVWVnj0hhBBCXJ6yc71DBV0uN9/++ActmzagQd0abNyyi4MJRwHvvDdVVdm6Yy+VK1XknkH9WbfBG1SioyJISknze49mjeqxY/d+TEYjFrMJi8XMhs07adaoLuAdLvnDr96qkz/+tpaWzeoXu4bD6WTXngPUqVWNW/tfwz8bvfevEBVZ4v1vvqEnLy1YitvtRtM0vv1hFTm5eSW2r1Xzhnz57S8FwzPV0z6eLh1asvqvTSQcSaR2jSoAtGhSnw8/9c5DS8vIxOF0gqL4gkurZg348de1aJrGvoOHycvLp3KlioB3mKXb4yGloCBI/To1TtumfzZu54Zru1IpNpoDh44B0KBODTZs2cnxEylomsaxxKRibW/epB5r1m0mNy+f3Lx81qzbTIsm9Tlw6Cj5+Xb69OxEtSqV2L3vENt27iMoMID77hzA0eNJZOfkFbnOF9/8hMejkpuXT3pGlt/HeCY2bNlJs8Z1WfLaTJ6dMpbQkOBS339nS3rmLlE6RUGnVzAW79gDQFU1cuwqHs2Dqmnocx0oOhWd4u0ZNOgUDAYdJr0OswH0OgW94h3SKYQQQghxpiwG/XlbZ64sbBFhzJizgISjiXS5qqVvWOGkh4YyecZ89HodjerX4sHhd/DtD7/z3PzF5OXlM2bYQAC6dmjN+Clz2LJ9D89PH19iD1uF6EiOn0ima4fWADSoU5MffltDTIUoAMaNvJOnX3iDL779mQpRkUx+aGixazgcLpZ+/A0HE47icrt9vTW9ul3F9DkL2LB5J4+Nu893/O039mbx+58xeORkjCYDbZo3okfX4r2G4B1quHPPAYaMmYLFYubmfj19wxJLUjW+EgcPH6N1s4a+x1v4GAYNm4g1OJAnJ4ykepU4jh4/wf6DR+jbuyv7Dx3ljuGPYTYbmT5pjG/uX2p6JmMmzCQtI4sHhg0iLNR62jbd2r8XTzzzCnGxFYiOigC8wxPHj76Lhx+fjdFkoMtVrRgy8IYiba9RtTJ33daXYWOnAnDnrddTrUolNmzZycy5i8jKziY+Loa2LZuwYuWvzJ6/mJzcPG7q24PQkGDfdW7o3Y0Dh44yaLj38Y4beaffx3gmqleJ4/Gn57Nxyy7MZhM1qlVm5JBbSnz/nS3F6XRclt01brebjn3u5vcVb2MwlJ/MmpjpxO5S0esUUvOTSxxmWRqP5iEyIOqs7qvPSQDdybUuNE3Do4FH0zi1w06neIuxGHTeoZwmgzfs6QrCnuFChj3VDSHxF+5+QgghhBDirKxY+dsFW/fuUrHwnY+pXbMKXa5qhd3h5P7x07ln0I10aNvsnN2j/KQccUEpSkGhlVIGBGuahsOlkuf04CmYt6cVfNcreHvx9DosBgWDXsGoVwp692TenhBCCCGEEK2bN2TB28t5673PcLrcdG7f4rRLS5wp6Zm7wMpLz9y5oGoaHtXbw6cBKKBo3t49nU7BoAOj3juU03Q2QzmlZ04IIYQQQohSlZ+UIy45vnl7pezXVI18j0pOQVXOQoW9ewalcN6egkmvoNd7h3HqFUqtBCWEEEIIIYTwkjAnzpvTDeUEcLpU7M6TvXtKwf/qFdDhBo8di0GHsaCip15X0MMnhVqEEEIIIcQVTsKcuKj0OgU9pfTuqQoulSJVOQsX/fAO5fT27hkNOsx675p7hlPW3JPePSGEEEIIcTmTMCfKNe9QTv+9ew6XSp7DW5Xz1N49na8XD+ndE0IIIYQQlx0Jc+KSd7pg9u8196R3TwghhBAl2b3vEC++/i6vzn6cb77/HYDePTqe9fX2HjjMzBfewG53EB4WwriRd1Kzejz9B49l8fzphIVaz1XTxRVKwpy47J1N7x5oKAW9e4WVOU2+dfcUX4CUYi1CCCHE5em/hLhCc19dwpCB/ejYrgUHDh1FPjKIc03CnBCcvndPUzXyPCo59pPr7hWkPt+wTYPOuwRDYeiT4ZxCCCGuFLUfWovLc35WuzLqFXa/0MbvMccTk5k5dxGVYqL5e8NW+vXuitFo5Ktvf6FCdCRzpo1Hr9exas0GXn3zQzyqhyEDb+Ca7h1ISk5l6nOvk52TS2xMtO+ai979hACLhUE39+HH39by4affkpWdS/vWTXhw+B0cT0zmmRffJC62An+t30LTRnV5/OFhRdqVb7eTk5sPQLUqlYrs++SrH/j1z3UY9DpeemYi1uAgln+xkm9/WEV2Ti43Xted2wf0Zv2m7az8eTXpGVnEVapA9SpxrP1nC1nZORxLTKZ3j47cfXs/AN5a+hkrf16NyWhg8sPDqFOz6jl4BUR5prvYDRDiUqAo3mUTTAYdAUYdFoMOi9H7ZdTr0CkKblUlx66SnOPicLqdg6kO9iXb2ZOUz/6UfA6l2jma4SQlx0WW3U2+S8XlUVHVy3KpRyGEEOKC2rnnALfdeC0L5z7J64uXExURzpLXZ5KUksbWHXvIyMzmtcXLWDRvKu++9gwffb4St9vNiwuW0qVDK5a8NpNrr+5Q4rVrVI1j/qxJLF3wDL/8sY7jickAbN+1j5v79eS9Bc/y++r1JCWnFjlvzLBBvPrmh0yaMY/9B48U2RcXW4F3XplBeFgof6zdAECzRnVZ+OKTvP3ydBa//zkOpxOA7376gxFDbmHM0IEAJCWnMvOJB3n7lRl89vWPHDl2grX/bGHvgcO8v/BZnn1yLAvfWX5On19RPknPnBDnSFmGc7rcKg6XhkcF0LyDORXvX1V0OtAr3sBoMnjX3pP5e0IIIS4Fp+s5uxCibRFUjY8FIDIijJbNGmDQ66lZLZ609Eyyc/JISc1gxEPTAMjOzSMjM5sNm3fw5IQRAMRUiCrx2jEVo/jh1zWs27Adh91JYnIqFaMiqRAV6etxqxofS1pGFtFRkb7zmjWqyweLnuPjL77n/kdm8ND9g+nZtT0AbVo0QlEUateoQlp6VsH9bXy+4ic2b9uFx6OSnpHlu86pPXs1q1chMMACQKP6tdiz7xBbduxlx6593D3qcQACCvaLy5uEOSEuIN9SDPqS92uaht2lkltKdU6ZvyeEEEKcnsGgL/JvDe+fUFs0qcfMJx4scqzb7SE/34HZZCr1eo8/PZ+6tapx7x39ycvLR1PVYsfo9To0rfhom+CgQO4e2I8a1Suz5MMvfWHu3+dpmsaoCTO5rldnxgwbxMGEY2gFo3d0utIH0xkMesxmE2gaA2/qw839epZ6rLj8yDBLIcoRRfEGM1PBMM4Aow6LUY/FqMOk12FQFDQV8pwqqTkujqQ7SUhzcCDZzt4k+8nhnOlOUnKcZOXLcE4hhBACoEHdGmzcsouDCUcBOJHkHRJZv051Vq1ZD8DO3ftLPHf95h3c3K8XIdZgjhw/Uab75ebls+Cd5eTb7WiaxomkVCpG20o9PjMrh8SkFG7o0w1NVUnLyCz12KTkVNweDymp6Wzauov6dWrQqnlDvvz2F3Jz81BVlaSUtDK1U1zapGdOiEuMoigYFDD4KaziVlUc+eBRPZQ0nNOgU7zr7hl1mPRg0OnQ66V3TwghxOUrIiyUSQ8NZfKM+ej1OhrVr8UjY4bw4PA7eOq51/j06x9o2bRBiecOuqkPw8ZNpWa1ysTFVCjT/QIDLESGhzHi4enY7Q4qRtuYNG5oqceHhgTTvVMb7ho5mXp1qlPJz31S0zMZM2EmaRlZPDBsEGGhVtq2bMzOPQcYMmYKFouZm/v15PpencvUVnHpUpxOx2X553q3203HPnfz+4q3MRjKT2ZNzHRid6nodQqp+cnolVLG25XAo3mIDCh5LPfp6HMSQGc8q3MvGtWFJzj+YrfisqRp3mGcHlXDA6Dhm+l3anVOs9E7pNOo12HQe+f06aQ6pxBCCHHRrFj5Gzt2H2D86LsudlNEOVB+Uo4Q4oJRFG8vnL9lEwp791TNUzAHwDt7T68U7d0zGRTMBkV694QQQgghLjAJc0KIEhVW56SU6pynFmvxAIrmG9BZbO09s0F694QQQohzoU/PTvTp2eliN0OUExLmhBBnpcy9e3bIPKV3D0CnFF+Kwde7J0sxCCGEEEKUiYQ5IcR5c0a9ewXz9qR3TwghhBCibCTMCSEumjPt3VM1b9DznltQrOVfC60b9dK7J4QQQogrw0UJcx98+i3vL1/BbTdey6Cb+xTZN33OAjZs3klwUAAALz83mRBrEJ9/8xPLv1hJcFAg0x8bRXRU5MVouhDiAjsfvXv6ggIu0rsnhBBCiEvZRQlzzRvVZe/+hFL3T3roviLrfKSlZ/Lusq9YuuBZfl+znlfeXMbUifdfiKYKIcq5svbuOU/p3aOgf08prMypKBgNOsx6BZNBwaDXYZDePSGEEEKUc7qLcdM6taoRU8FW6v6wEGuRn9f+s4XaNapisZhp2qguq//eeJ5bKIS4nOgUBYNewWzQEWDUE2DUYTHqvD11Oh2KouBwqaTnuTme6SIhzcGBlHz2JtnZl5zPwVQ7h9PtnMhykpHnJs/pweFW8aiX5TKdQghxyTmemMygYRP/0zUWvfsJK1b+do5aVJzb7WbspFkMGf0Ex0+kMPW518t83oznF3LzkIe5c8Qkln+x0tfepctXnLf2iktDuZwzN/+N9zmRnEbPru0YMvAGUtMyiI+rCIAtIgyPqmJ3OLGYTUXO+/jL7/nkq+8BCirnCSFE2Xjn2ZXeC6epGnkelWy7h1Mz3Klz9wx6HRaDgtHgnbtX2Lunk949IYS44m3ftR+Xy83il6cD8OSEEWU6738//0leXj7L3pyN0+li/eYd57OZ4hJT7sLc4FuvJzAwAI/Hw6hHnqZpwzqgFA1nmqpR0mejm/r24Ka+PQDvXzE69rn7ArVaCHG5UxQFg+Kda1cat0cl06XhUQE0NMU7nFMH6PTe840Gb4+g2aD4AqQstC6EuByk5aeRlp9eZFuwKYiKwRVxepwkZB4udk7NiBoAHMk6gt3tKLKvQlA0VrO12DmlybPbmTb7dXbtOUi1KpV44pHhmE0mVq3ZwKtvfohH9TBk4A1c070D//vpDxa+8zEGg4F7BvVHp1P46POVBAZYWLVmA89MebDIte12B8+/uoTtO/cRFBTAzMcfIDAwgFkvvcXeAwmEWIOZNO4+KleqyKJ3P0HTYNvOvezZn8CkcffRokl9ps1+nfTMLB59ai5jR9zB+CnPs3Ths2Rm5fD40/NJOHKcpJQ0qleJY/a0h4itGA1Afr6DvHw7qqZhsZhp37qpr10HDh3hocdns3PPASY/NJSr2jRjz75DzFv4PumZWUSEhfLsk2MJDLBw54hJXH9NZ779YRWvzpnMwGETad+qCVu27yEsNITpk0YRGmJl2869zJq3GIfDwXU9O3PnrdeX+TUQF165C3NVKsf6/n1Vm2YcPHycqMhwtu7YC0ByajpGoxGzyVTaJYQQ4qLwFmtRMOpL3q9pGvlOlVy7Bw+AdrKsi75gyQVZikEIcan6Zs93LN36YZFtXat2ZkL7h0nJS2HMd+OKnfPtwC8BeH71S+xM3VVk3yPtxtGtWtcy3z8/3849g/pTKSaaiVNf5PufV9OhbXNeW7yMRfOmYtDrGfHwdK7u3JYly75ixuQxVKsSR36+nfCwENas20zzxvVKXJD7nWVfYjaZeG/BM2Rm5RAaEsxrby0jPCyEpQueZdWaDUyfs4CFc58EYOee/cye+jC/rf6HDz/9jqvaNGPSuPtY+vE3zHpqHMcTk33X/uzrH6letRLznp3Ii6+/S83qVXxBDuDaqzuwas16Bg2byJCB/ejV7SrfHwDTM7OY9eS4IveJCA9lyoQRREWG8+Szr/Lzqr/o06MTOXl5ZGXn8Nb8aSiKQnJKOtf16swjY4Yw97V3+ejzldx9ez9mzl3E3KcnEBEeyvgn5nDN1R2Iigwv8+sgLqxyEeaWLl9BlC2cVs0a8tf6rfTs2o7MrBw2bdtFr25XEVsxioXvfIzd7mDD5p1F/iIhhBCXisLePc5iofXSlmKQYi1CiPKid61raBvXpsi2YFMQALZAG/OvmVvquQ+3e7DEnrkzERkeRlxsBQDatGjEzj0HCQsNISU1gxEPTQMgOzePjMxsel/dkXkLlnLPHf1p1axhsWt9/8tq3l32FQDPTX2Ites28+SEkSiKQliot7fw7w3bGD/6LgDatmrMtNmvkZuXD0DzxvUxGg3UrlGFtIxMv+2OiAjl0JFjuFxusrJzi+0PCgxg7tMT+GPtRha8vZyffvuLWU+NK/U+EeGh/LV+K2+//zm79h4kPi7Gd60br7va9/8VJqOBerWre9vfsjGffPUDCUePk3gihfFPzAEgL99OUnKahLly7IKHueTUdB5+fDap6ZnoFIXV6zZRvUociqIQGGhh5579fPDJN2RkZnNr/140qOvtfr974A3c++CTWIMCmT55zIVuthBCXBBnsxQDeEOfXge6gmBnKejZMxmUgrDnf06gEEL8VxEBEUQERJS4z6Q3+YZUliQuJO6ctsVg0GOxmNDQaNGkHjOfKDpsctDNfejUvgXzFi7lz7828uDwO4rs79GlHT26tPP9rKpasT+YnfoHt1Lbodd7f0X70a5VE5Z8+CVDxjxBvVrV6NW1fbFjFEWhQ9tmtGnRiBvufJCEI8dLvc+Hn37Llh17ufOW64iLreALmAA6Xcm1D/V6PWaTEU2D+LgY37w+Uf5d8DAXFRnOktdmlrr/3/8xFbq+V2eu79X5fDVLCCEuCWVZikFVNXLsKp5TlmLwnnuyd8+o987bMxoUTKcstC7FWoQQl6rs3FyysnMJsJj59sc/uOu2vtSuWYVnXljEwYSjVI2vxImkVKJs4WzftZ+G9Wpyz6D+zHxhEQDRUREkpaSVeO3mTerz2YofeWDYINIzsggIMNOqWUN++HU1DerWYO26zVSpHEtQYMAZt/v3P//hht7duOOW60rc/9Hn/6N543rUrB5PVnYOqqoSER5a6vXWbdxOv2u7UrtGVT7+8vtSK8i7PR6SklOJskXw9f9+pUXTBsRXqkhGZhbrN22neZP6nEhKpUK0rO1cnpWLYZZCCCHOncLePYOfvxg73Sr2gmItGoACiuZdd0+nUzDoKAh8Okx6MOhOBj4ZzimEKI9sEWHMmLOAhKOJdLmqJW1aNEJRFCY9NJTJM+aj1+toVL8WDw6/g29/+J3n5i8mLy+fMcMGAtC1Q2vGT5nDlu17eH76+CK/6+4ZdAPPzF3EoGETCQuzMmncUO4e2I9ZL73JoOETCQkO4onxw8+q3bVrVuXBx57lu5/+IMBioW6tqoy69zYsFjMAzRrV5aUFS0nLyMTt9jBhzBCswUGlXu+GPt149c0P+eSr76kaX8nvvV9e9AF79x+mQb2aXN+rM0ajgemTxjDn5bfxeFQqxUbz9OQH0OsvympmogwUp9NxWdbwL6xm+fuKtzEYyk9mTcx0Ynep6HUKqfnJ6JVSKiWUwKN5iAyIOqv76nMSQGc8q3MvGtWFJzj+YrdCiCuSpnmHcaqqhgdv0CsczukLfAXVOU16mb8nhBBna+pzr3PbjddQp2ZVsrJzuWPEROY+PYEaVSuf1/t263cvP33x5nm9hzj/yk/KEUIIUW6UpViLrzqnWnz+XpHApy9asEWGdAohxEmd2jVnzsvvYLc78Hg83D6gN9WrnNs5hOLyJWFOCCHEWSlr4Du1YEvBVhQUdMop6+9J4BNCXKG6dmxN146tL/h9pVfu8iBhTgghxHlTloItpwY+VTtlDh8FC64XFm0x6DDrFW+FTgl8QgghhIQ5IYQQF1dZA5/DpZJXhsBn0nurdBr1Ogw6WXRdCCHE5UvCnBBCiHKvLIEPwOFSyXcWVOnUNFAUFEUCnxBCiMuThDkhhBCXDb1OQY+C0U+h4FMDX2HBFvCuw6fTgUHxDuMsXIdPAp8QQojySsKcEEKIK0pZAt+p6/CVFPj0vsAHJr3OG/j0EvjElS0tPx2X6jrn1zXqjEQEhJ/z617pXC43H33+Pwbd3OdiN+WMJCalsH7TDnr36Hixm1IuSJgTQggh/qUsgc/tUXG4wKN6KGvg0+sKri2BT1yGXKoLwxmsn3sm170Y+g8ey2dLXix13+L50wkMsDDl2VeYNnEUJtOZrefrdLpKPXfwyEnMenIcMRVPri98/yMzSEnNwGI2AXDzDb1IS8/kx1/XkJWdi93hINoWQa0aVXhi/HD6Dx5LoMXiW/B75D230q5VE9/1fl71F6EhwQBs27mPWfPeQlM1xgwbSOvmDYu0Z93GbSx852Mys7K5unM7hg4eUOrjOno8iTkvv83m7bv58bNFpT53YaHWM3q+CkVFRrDy5z+5pvtV6HSymLmEOSGEEOIs6BQFnR6M+tKDWWHgUzUPqlY08Okl8AlxyTOZjDw7ZewFO3fqxPupV7t6kW133daXFSt/Y8fuA4wffVeRfa/MnlxqaPrfT38wfdIYNE3jmRcXMW3iKIICAxg5fgYfv/18kaC0bec+XpjxCEajgVuGjKdbp9alLmoeHBTInbdcx/gpz5/RYysrvV5Ho/q1WL95By2bNjgv97iUSJgTQgghzpPCwFcY4kpSpsCn02EygNkggU+IkhxPTGbm3EVUionm7w1b6de7K0ajka++/YUK0ZHMmTYevV7HH2s38Pri5aiqSo+u7bj79n64PR6mznqNHbv3Ex4WytOPj+HlNz4g8UQKg0dO4tYbr6FPj06l3rtbv3v56Ys30TSNBW8v5+dVf1EhykZ6RhbPPTUOgPFTnmfpwmcBbw/bmKEDqVe7epFzX1v8Eb/+8TdxsRXJyMo+r8+XqqqoqkZggIUTSakkp6RTvap3oXKDQc++A4epVaOK7/i7buvr+3edmlVJSc0oNcyFhgTTvEl9v/df/P7nbNq6C71ez/RJo4itGM39j8ygSYM6/LV+K3aHgynjh1OnVjX+99MfLHznYwwGA/cM6k+vbu1p0rAOO3btlzCHhDkhhBDioipT4FNVHHbILEPgK1yAvTDs6RVvNVAhLnc79xzg4VF3MXTwAK4fOIZpE0ex5PWZ3HX/ZLbu2EN8XAwz5y7i7VdmEBZi5f5HZlC/dnVCQoLZf+gIyxc/T3JKGraIMKY9Norvf1nNktdmlvn+q//exPrNO3j3tWdwulzcOeKxMp/7518b2bhl52nPffLZV7GYTRgMBt6aP63M1/+31PRMwkJDAEhJyyA+Lsa3Lz4uhpS0jCJhrpDd7mDPgQTq1Kx61vcGaNm0PuNG3smHn37Honc/ZcojIwAIC7Xy5ryp/PrnOl5csJTX5jzOkmVfMWPyGKpViSM/3w5AhahIfvh1zX9qw+VCwpwQQghRzpU18Dnt4NE8qNrJ7RL4xJUi2hZB1fhYACIjwmjZrAEGvZ6a1eJJS88kOyeP2jWqEBXpLabStUNr1q7fwtA7BxAcFMiLr7/LHbdcX+I8rCnPvMLBhKO++WglWbdhG717dMRkMmIyGbEGB5W57f9s3F6mc0saZunPqEeeRq/XEVMhilkFvYQAScmpREWGAd7fEZqm+vZpmlrq74PF739Or67tCQu18v0vq3l32VdF9pc1/DaqXxuAti0b8dV3v/i2N27g3d6qWUNmzFkIQO+rOzJvwVLuuaM/rZp55/JF2SI4kZRapntd7iTMCSGEEJeBwsBnOIPApygUrMDuDXw6nYJBp2DSK5gMEvjEpctg0Bf5twZoaCW+hy0WM68//wS//rmO+8fP4MkJI2lYr2aRY6Y9Nuq09/SoHvLy7CXuc3vcZ33uf1HanLkQazBZObkA2CLDSTiSiKZ5n5+EI4nYIotXD/3xt7Xs2H2AF2aMB6BHl3b06NLuP7VPr9djLijociqDXu8rCjPo5j50at+CeQuX8udfG3lw+B1k5+SedQGVy42UgBFCCCGuEDpFwaBXMBt0BBh1WAw6LEbvl1GvQ68oeFSNXIdKSo6LI+lOEtIcHEi2szfJzv7kfA6m2jmcbudElpP0PDd5Tg8Ot4pb1bwLtQtRTjWoW4Ndew+SkpqO2+3m51V/0apZQ44nJpOSlkGXq1rRpkVjtuzYA3h7+pKSS+79UVBQT+nNAqhfpyZ//rURj0clKTmVlLQMAEJCgkk8kUpGZjb7Dx5h34Ejxa5X2rnnS8VoG8kp6YD3cVasYGPfwSMkJqWgaRrVq1Ri/abtzFv4PgDbd+1j8fufM33SKAyG/94XdCwxCYCv//crLZs1OGV7MgDf/PA7zRvXQ1VVtu7YS+VKFblnUH/WbdgOQOKJFCrFRP/ndlwOpGdOCCGEED5l6eHTVI08j0q2/dQhnRoKiq+HT6/zVug0GbwLsOuVwl4+6eG7XBl1xvO2zty5EBEWymNj72Pc5NmoqsrVXdrStmVj9h08zNwX3iUtPZPQkGDuueMGAPpe25Vh46Zx563XMeD6HkWu1aZFIz796gfuu/Nkif7unVqzZt1mBg2fSJ2aVQmwmAEICgzgxuu7c8eIibRt0ZhWzYoX7ejeqTVr//GeW7tGPDEVooodAyfnzAF079y2SGGSM2E0GnA6Xaiqik6nY9K4+5g+53VUj8akcfeh0+lIz8zm6LETADwx82UAxkx8FjSNls0a8sCwgSVee+E7H7NqzXrsDieDR07irtv70b1TG9/+ALOZFSt/45m5bxIbE8WUU4atfv/LapYs+5KgwACeevR+3G4P3/7wO8/NX0xeXj5jCu657+BhqlSOPavHfrlRnE7HZflnNLfbTcc+d/P7irfPyV8QzpXETCd2l4pep5Can4z+DNZj8WgeIgNK/o/7dPQ5CXCOfhleMKoLT3D8xW6FEEKIs6BpGh4NVFXDAyhawTC3EgKfWYZ0istQSWvFlSfvfPgl9etU981Du9hOrfJ5OuOnPM+MSaOxFATmK1n5STlCCCGEuGwoioJBAfwsn/DvHr5/z+HT64oXbTHoFFmWQYhzoO81XXhjySflJsyV1fHEZKpUjpEgV0B65i4w6Zk7A9IzJ4QQVzxV01BV8GhamRdeN+i923US+ITwy+12l6vPyWV1qbb7fJBnQQghhBDlVpmqdP5r4XXllMCn04HBF/gUjAbFG/h0EviEuFQD0aXa7vNBngkhhBBCXNLKsg6f061id2l4VPDN3lO8Zb11BcHOZNAVLMvgDX+FBVt0Mn9PCFFOSZgTQgghxGVPr1PQo2AsZXaDpmnYXSq5Dg1VK5y65+3l0xWuwaecnLtnNnjn80mFTiHExSRhTgghhBBXPEXxVtH0V1jl1MBXWKHTG/v8LMkgFTqFEOeRhDkhhBBCiDIoU+A7iwqd3m1SoVMIceYkzAkhhBBCnCOFSzIY/AQzt6ritHurVJe1Qqde571muS7YkpMIqvPcX1dnguCK5/66l4jvflxF00Z1qRhtu9hNOSOapvHOB19y98B+F7splzUJc0IIIYQQF9DZVOikoEZnYYVOveKtylmuKnSqTtCdh4+WZQyI9z8ygyceHn5Wi3RPfe41Rt17G7bI8DKfs+jdTwiwWBh0cx/ftvWbtvPIUy9QqWI04K26+OLMRxk94WkADiQcJb5SDHq9jgkP3MOhw8eY/8b7RNsiAIipEMWsp8b5rqeqKv/76U96dm3P3v0JvPDaEtLSs2jSoDaPPngPOp2uyL1XfP87T4wfXqb2r1j5Gy8v+oCogsc8+r7bad2ikW//9DkLuKpNM7p1bF3m5+RUiqJw5FgiiUkpl1wQvZRclDD3waff8v7yFdx247VF/gMA+PDT71j58x/k5tkZfd9tdGzXguOJydw2dAJV4mIA6N65LXfd1vdiNF0IIYQQ4rw7VxU6jQYdZqnQeVpPThh5zq7VtGFdnp8+vsi2Ja/NBKD/4LG8MnsyYaFWAA4dPsbVndsxfvRdJV7rn03baVivFjqdjg1bdvLUo/cTGR7GsHFTWf33Jq5q0+w/tbV/n+4Mu+um/3QNf3r37MSX3/5yXu9xpbsoYa55o7rs3Z9QbHtuXj4Op5M3XpzKocPHGDXhab5p2xyA+rWr89rzT1zopgohhBBClEunq9AJ4HCp5J1aoVPxxkOdUrxCp0mvFAzpvPQqdM5b+D5btu/hoSdmc033Dvz6x99MnzSGSjHRJCal8OSzr7LghSn0HzyW9q2asGX7HsJCQ5g+aRShIVb6Dx7L4vnTCQu18r+f/mTJh1+i0+m445br6N6pNXNeeYfdew+Sk5vPxAfvoXmT+hfkce3YvZ9mjeoAcHO/nr7tDevVIDk13ffz4aOJTJu9gLx8O4NHTuLl5yaTkZnFMy++SVZ2DrWqxzPhgXsIDLAUuX5hqCzNH2s38OGn35KRmc1D9w+mbcvGLHr3E1LTMkk4cpwTyakMGXgDfXp2Ys++Qzw16zXcHjftWzflweF30Lh+LZYu//ocPiPi3y5KmKtTqxoxFYp3twYFBvh63KpVqYTH48HhdAEQepo3mxBCCCGEKEp/msIqRSp0aoX9gJdehc4Hhg3k51V/8cL0R4ipGIU1KJCVP//JkIE38Pvq9XTv1AaA5JR0ruvVmUfGDGHua+/y0ecrGTp4gO86BxOOsejdT1g490lCrMHk5OZiMBjo37sbdWpV469/tvDme5/5DXMbt+5k8MhJANx8Qy+u79X5rB/XsePJdO/Utsg2VVXZsHknfa/t6ttWuVJFhg4ewPrNO3zDLB96/DkG39qXTu1bMG/h+yz58EtGDLmlyLW++/EPvvjmZ2rXrML40XcTFBhQZH+oNZjHX5jCnv0JPPrUC3y65EUAsrJzeOmZR8nMymHgsIl06dCKL7/7hd49OnL7gGtJKQiaBoMBp9N91o9fnF65nTO3a+9B4mIrYDGbANi7P4Eho58gKCiA8aPuomp8pWLnfPzl93zy1feA95eTEEIIIYQo3bms0GmxOzEYFEyGwl6/i1ehs0fXdox59Bnuvr0fv69ezxOPeAOOyWigXu3qALRt2ZhPvvqhyHnrNm6ja8fWhIeFABAa4u1MCAmx8uZ7n7J9134Sk1L83rukYZb+/PDrajZv2wXAyHtupV2rJr59J5JTsUWGFTn+y+9+oVqVOGpUrVzqNXPz8jmQcJT2rb3X6tm1Hc/Ne6tImOvQtpm3gyU6kunPL+SDT77hvjsHFLlOw/q1UBSFWtXjcThdZGblAFC/Tg0MBgOREWHExVbg8NFEulzVihdff4+QkGCuvbqD7xqqqpb5uRBnrlyGObfHw0sLljL8bu8bLjoqkiceGUG9WtX48LNveW7+Yl6d/Xix827q24Ob+vbwXsPtpmOfuy9ks4UQQgghLjtlrdCZ61DxOF2o2qnn4g2LioJer8OkL6zQqfjm9Z2PwGcNDqJalUps2LITVVN9RT5OpdfrMZuMRbZpmlZsluKxxCQefmIOI4fcynU9OzNi/PRz2lZ/c+ZCQ4LJzs7FHOnt3Ni0bTdffPMzLz83yf9Fy9CpERpi9YXVa7pdxY+/rS31WEVRMBoMmM3GYvsMBj1mk4m6tarxyuzJLF3+NUMffIo3501Fp9OhlOcKrJcB3ekPufBefO09WjSpR5uCijp6vY4mDWpjMhnpd203Dh0+fpFbKIQQQgghCukU71p5Zr2OAMPJL4teh1GnQ6coeDwqOXaVlFwXRzMdHE53cijNwYFUO4fS7BxJd5CY5SItz022w4PdreJSVVS1bKOtKtgiSEpJ8/18fa/OzJ6/mC5XtfJtc3s8JCWnomkaX//vV1o0bVDkGs0a1eWn3/8iMysHVVU5npjMzj0HiY+LoVP7FiQcPfkZVFGU8z4SLLZiNCeSUwFvqHxm7iJmTB5TbDgkQHRUBEnJaWiaRlBQIFUrV2L135sA+P6X1bRs1tB3rKqqfPr1jzidLpxOF6v/3kSdWlWLXfNYYhIAa//ZQnRUBAEW75y74ydS0DSN/QePkJKaTlxsBbbt3EdQYAD33TmAo8eTyM7JQ1VVDHo/kzrFf1YueuaWLl9BlC2cnl3b8/GX35OalsFD99/p2//9L6tp3rgeEeGh/L76H+qW8GYTQgghhBAXj6o3o/M4St2vw1t4BSi5SKcGLpeGw1lYobNg9p7ejObMP22Fzj69OvP40/O5/pouDLvrJpo1rkdWdi5dO7QqcpuXF33A3v2HaVCvZrH5bDWrx3P7gN4MGzeVAIuZAX170KldCz77+kfuGfMEV7VpToDZDECj+rV5acF7DLq5T5G5g6fOmQN4+bnJhFiDyvo0FlE1PpZ9Bw7ToG5NZr6wiNy8fCbNeAlN1agaX4lpj43yHduoXi2yc3IZPHIys54ay5RHhvPM3EW8/vZyalSNY+LY+3zHKgVLWIwcP4P0jCyaNqrDLf16Fbv/kWMnuGfME4BSZMmDgwlHGTZuKnl5dp4YPxyj0cDOPfuZPX8xObl53NS3B6EhwSQcOU5MhTNfKkKUneJ0Oi7o5LLk1HQefnw2qemZ6BSFKvGxVK8SR8VoG52vasmt94ynWpU4Cv+buPPW64mOiuT1xR+RmpZBZEQYU8affg2RwmGWv694G4OhXGRWABIzndhdKnqdQmp+Mnql7H+t8GgeIgPO7j8IfU4C6Ip3jZdrqgtPcPzFboUQQgghyhGPquFRS6jQCej0Jyt07ty5i/+t/JmnJo72Bb7uN9zHT1+8eXEfwBnIt9uZ8swrzJ768MVuik9J6+uV5vXFH9GxXXMa1K15AVp2ZbrgKScqMty31kZJVn27pMTtr80pPkdOCCGEEEJcWcpSoXPxux+xYeMWHnhwFAlpDgordKoaHEy1F6/QqSjo9eWrQidAgMVC5UoxHE9MPqvF0C8mTdM4fDSR+nVqXOymXNYueM/chSI9c0VJz5wQQgghhJemeZdiUNWCJRlKqNCp1ymYDYpvHb7Cbf4KwZwPbre7XH2WPROXctsvFfLsCiGEEEKIK0phhU78BDOPqpFj1/BonuIVOgvm7xkKKnSaDbqCBddP33N4pi7lMHQpt/1SIc+wEEIIIYQQ/6JTFHR6MJRYrcXL7VFxuCBT86Bq3qGc3nPxFWwx6L1DOU16b/EWQ8F2nZTsF+eAhDkhhBBCCCHOQmHgK7k8p5c38BVW6PQGPg3v+nv/rtBpLBjWWViwRVeO5u+J8knCnBBCCCGEEOeJN/ApGP2USXC4VPIcp6/QaSro4TPodRgKAl95KtgiLjwJc0IIIYQQQlxEZanQaXep5DoKCrZ4twKKt3evINhdChU6xbklYU4IIYQQQohyTFG8ocxv4FM18jwqOXYPHgDt5OBPvQ50BZU4TXoFk+HiVugU546EOSGEEEIIIS5xZa3QmevWyLL7qdCp02EynN8KneLckTAnhBBCCCHEFaBMFTpVFYddKnReKiTMCSGEEEIIIYDzU6Hz1IItUqHz3JIwJ4QQQgghhCizslbozHd6A59U6Dx/JMwJIYQQQgghzim9TkFP6YHvdBU6vQVbvIHPfGqFTgl8RUiYE0IIIYQQQlxQZa3Qme9RyT2LCp1XypIMEuaEEEIIIYQQ5c65rtBZuA7f5VShU8KcEEIIIYQQ4pJ0JhU61X9V6CwS+PQ6zAWBz6jXYTYql0SxFglzQgghhBBCiMtW2St0gkf14FY1YkNNhAaW/6hU/lsohBBCCCGEEOdRYeAz6hUcbhXt9KeUC7qL3QAhhBBCCCGEEGdOwpwQQgghhBBCXIIkzAkhhBBCCCHEJUjCnBBCCCGEEEJcgiTMCSGEEEIIIcQlSMKcEEIIIYQQQlyCJMwJIYQQQgghxCVIwpwQQgghhBBCXIIkzAkhhBBCCCHEJUjCnBBCCCGEEEJcgk4b5rKyc9mxez8nklLP2U0/+PRbrr99NEuXryi278ixE9z34JMMGj6R735cBYCmabz53qcMGjaRcZOfIyc375y1RQghhBBCCCEuRYaSNm7buY8ly77kyLETBAUGEG2LICMrm7S0TIKDAxlw/dX06NIOne7sOvaaN6rL3v0JJe57acF7DBl4A00b1uGOEY/RoW1zjh47wZ9/bWLJazNZ+vHXvPfR14wYcstZ3VsIIYQQQgghLgfFwtyrb35IZlYOQwffRM1qlYudkJGZzecrfuLBx2Yxd+YEDHr9Gd+0Tq1qxFSwFdvu8aisWbeZpyaMJCgokPi4GNZv2sHeAwk0aVAbvV5H04Z1mfPKOxLmhBBCCCGEEFe0YmFu5D23oihKqSeEhVq5e2A/7rq9r9/jzkZmdjZhIVaCggIBiI+LISU1ndS0DGrVqAJAlcrebSX5+Mvv+eSr7wHv0EwhhBBCCCGEuFwVC3OnBrSc3Dx++m0tKWkZnJqN7r2j/zkPcgAKCuopN1I1DUWngKKgqt7tqqqh05V875v69uCmvj0AcLvddOxz9zlvoxBCCCGEEEKUByXOmSs0/ok5uNwe6tWujsFw5sMpz1RoSDDZObnk5OYRHBTI4SOJtG3ZmMzMHA4fPQ5AwtFEbBHh570tQgghhBBCCFGe+Q1z6ZlZvL/wOfT687uCwdLlK4iyhdOza3vatWrChi07adaoLoePHqd543pUjIrkmRcX4fGobNi8g/atm57X9gghhBBCCCFEeec3zDWqV4vk1DQqRhcvVnK2klPTefjx2aSmZ6JTFFav20T1KnG+YZtjh9/BlGdf4fXFHzHynlsJCgygVo0qdGzXgsEjJ1GxQiTTHht9ztojhBBCCCGEEJcixel0lFop5OkX3mD9pu2+4iOFnp0y9ny36z8rnDP3+4q3MRj8ZtYLKjHTid2lotcppOYno1fKPnzVo3mIDIg6q/vqcxJAZzyrcy8a1YUnOP5it0IIIYQQQlxBHG4VW7CRsMDykyFK47eFTRvVoWmjOheqLUIIIYQQQgghyshvmOvTo9OFaocQQgghhBBCiDPgN8zl5uUz/433WbVmPQoKHdu1YPTQ2wkMsFyo9gkhhBBCCCGEKIHfMpUvvv4eJqOR15+fwmvPP4HRaOCFV5dcqLYJIYQQQgghhCiF3zC3Y/d+Hrp/MHGxFYiLrcDYEXewc8+BC9U2IYQQQgghhBClOO0CcplZOb5/Z2XnntfGCCGEEEIIIYQoG79z5m7tfw33PfgkPbu2B+D7X1Zz1219L0jDhBBCCCGEEEKUzm+Yu75XZyrHVuCPtRsBmPzQUJo0lKUK/ouj2YdxeSAyIPJiN0UIIYQQQghxCTvtSnhNG9WlaaO6F6ItV4R3t77BrrTtAJj0ZkJMYfSufiMNo5pyNDuBA5l7CDGFEWIOI8QUSog5FMOltti3EEIIIYQQ4rwrMcy9vOgDRt93O6MeeRpFUYrvf27SeW/Y5eq+JqM5np1EljOdYzmHyXZmEmoOA+Bw9kG+2f8ZbtXlO75ORAPubfwAdnc+721biC2wAqHmMEJMYYSaw2haoRUGnRGX6sKgGEp8vYQQQgghhBCXnxLDXLuWTQDvnDlxbtkCowk22tDrFFLzk9Eret++trGdaBPTkXx3HlmODLKcmZj0JgDcqguDzkBizhF2pW0l05GBR3XzSs/3AZj79zQSsg74Ql6IOYyrq/ahVng9TuQeJzltOxEWG2HmUIINQRL6hBBCCCGEuMSVGOZaNK0PQGREGA3q1iiy76/1W89/q65giqIQaAwi0BhERSr5tgebQriz4QgiA6IA0DSNfHceBp33Jbym2g0k5SWS5Ugn05FBpiMDVVUB2HDiLz7d/Z7vWgbFQNvolgypM5B8t52vE/5HuDnM+2Xyfg8zhUjgE0IIIYQQohzzO2fuuflv8c4rTxfZ9tLr77F04bPntVHiJKdb5e+9+fyyPZeEZCeR1nQig43eL6uByGA7kVYjEcH1aG5rTFigAZ2uaAjrUfU62oVWI8OVS7ozk3RHBmGmUABy3bn8k7KRdEcGbs0DgILCgo4voEfPu3uWke3KIdQUSpgphFBTKPXDahNhCcetetArOgl9QgghhBBCXAQlhrkZcxaAonAiKZUZzy/0bU88kUJgYMAFa9yVyqNqbDxo55dtufyxK5c8h+bbdyglx8+ZoNdBRJCRCKvBF/oigg1Em8zYQoKJDo6lkVVPZLB3iUGbJZJnWz+JpmnkuHNJd2SQ5cz2Df8MMASQlJ9CYl4Smc4scty5jGkwlAhLOCuP/MTnh74h1BRCmCmEMFMoDcLr0SX2KpweJ7sy9xJmCiXUFEKwMQidctplDYUQQgghhBBlVGKY692zEwD/bNxGs8YnK1nGRNtoVL/2hWnZFUbTNHYcdfDLtlx+25FLRq53iKQCNKlioUuDIBrEG9FroaRmu0jLcZOa4/J+ZbtIzXEXfHeRnO39gvxS76cAEUE6oq16bMHe71FWHVHBEURZo9jrcREVrGdA1euL9Ly5VBcK3p8bRdTHYjCT4cgiw5lJpjOTbJc3bCbZU3hx6+u+8/SKjnBTGM+2fhJFUfju8I84VWdB2PP2+lUIjMaiN5/z51YIIYQQQojLUYlhrnnjegDMmDyGBnVrXtAGXWkOJDn5eVsuv27L5USm27e9doyJLg2C6FQvCFuI92XyaB4iA4L8Xk/TNHIdKikFwS6tMOilppKcq5GcrZKc4yE5WyU11/vlj9kAtmA9UcE6bMHeHr2TP9uID46mRbieEItSJPTFBlZkduupZDgzyXBmkenMJN9j9x2zK3MvB7MTyHbloOHteXygwXCaRDbgp2O/sSpxDWHGEEKCYgg1h1MjrA4NopriVt1kOzMJMYWh1+lLbLMQQgghhBBXAr9z5urXqcHqvzdx5NgJNO3kUL9bbuh13ht2OTua5uDHrel8tymZQyknA1zlSCNdGgTRpUEQlSLObm05RVEItugJtuipGmXxbdfn2OGU9eq8oU8jOcdDUrZKSsH35GyPL+wl53hIzVE5muHhaIYHcJVwRy+THiKDvb18tmA9tiAdtmADNms0tqCKVArWExWmQ9U0dIrCgw2HA96AmuXMJtOZRXSADfAO/awSHE+mI4OErANkOtaT48qmQVRTEnOPMu2P8SgoBJtCCDWHEWGxMar5oyiKwj+Jq9EpOkLN4YSawwkxh2GUdfqEEEIIIcRlyG+Ym/H8Qnbs2k9OXh6tmzXk4OFjVI2v5O8U4cfbvyXywZ9JbD2c69sWHaKnc4MgutQPonoF0wUrJuINfQrBFh3VbKUf51E10vNUUnO84S4lxxv8inzP9X4/nunheKb/0KfXQWSQ7l+9fXqigm0FQdBFbHBdGtSsjx43nuD4IudHBkQxuvnEgoqd6WQ60r1DPwuet092LSUl/0SRcx5s+TgNbE3469gqtqVsJNQcRqg5glBLOLHBccQGVz7r51EIIYQQQoiLxW+Y27ZzH0sXPMvTLyxk6OCbCAiwMOflxReqbZed7zensfVwLmGBBro3DKNNHR0NKwegK8fVIPU6xdvTFqynDqX3cKmaRma+WhDyTvbqpeR4SC74XhgIk7JVkrL9D+/UKd45fZEhudisRu9XsBFbiJHI4BrYrEbqRBmJCDZi0J98/mZ0mkeuK9sb9uzesFepIBA6PA6S8hLZnb6dTEcGbtVF58o9GdRgKIezDjLnrycJNYcTVtCrFxFgo3/tgQAczjqA2RBAqDkcs8zrE0IIIYQQ5YDfMBcYYEGv11G/Tg3WbdxGn56d2H/o6IVq22XnwWviGNAmisbxwZiNOlLzk8t1kDsTOkUhPFBPeKCeWtGlH6dpGll2rXjv3r++n+wFzGeXv0IuCoQFGk4GPquRSKsRmzUQmzUUm7UW+XYDgQaVjpW707Fyd1878ty5qJo3VFpNIVxb/UYyHWlkOtJJs6eQZk/x3efl9bNIt6cCEGAIJMwczpDGo6kaWpMdqVs4mp3gDYGWcF8gNEnoE0IIIYQQ55HfMNeiSX2279pHjy5tGTp2Ksu/WEmlGD+f1IVfrWuGEJ/pxO7y3yt1OVMUhdAAhdAAHTWiSj9O0zRy7U5OqBVJzXaRcspXakG1ztRsFyk5LtJz3aTnutmTWHroAwgN1GMLLgh7IUbfv6OsHiKtJhqFXUOk1YjFWHwJhbEtnyCjIOhl2NPJdKQRbAwBYHfaNlYe+AqX6vQd3yW+FwPr38fxnKN8sONNX29fWEGPX7MKbQBwqy4MMqdPCCGEEEKcBb9h7v57b/XNRXr5uUls37WPVk0bXJCGiSuboigEm3UEBFuKFHIpSZ7DQ0rBEg1FQ5+7SADMzPOQmedhX5Ld7/WsFn1B715hT5+BKKuJSGslbNaqNAj1bg8weatp9qt1G31r3kq+O88b9hzpWE0hBVfTCDYGk5KfxL6MXWTY0wkxhfrC3KRfR+P0OLzz+CwRhJrDuK7GzVQIiuFYzmFyXTmEmb3bpadPCCGEEEKcym+YO7UYR7QtgmhbxHlvkBBnKtCsJ96sJz7Sf+izu1Rf4Pt3715qtouULO+/M/M8ZNs9HEz2H/oCzTqiCod1Fs7nsxqxBVfCFmLEY7djs8YwtMk4339Lmqbh8Jy87oA6d5BuTyPTkUaGI53U/GS0gqGfPx36lt8Of3/yfoYgelS7nj41BpCSd4LfDn/vrdppiSDMHE6YOQJboPScCyGEEEJcKUoMc+2vuZPSpnIFWCz88Nkb57NNQpwXFqOOShFmKkX47+FyutWCxdjdRXr6Tu3lS8n2Du885HBwKMXh93oBJh2RwcZ/zesrnOfXhDpWI7YYI8EWfZE/oAyocwfdqlxbMKzT+xUfUg2ADEc66xJX+6p5AtgCopnZ+RUAnv/rKfSKgVBzGGGWCELN4bSs2J4Qcyj57jyMOqMM7xRCCCGEuMSVGOZWfrIATdN44dV3ubV/L+JiKwCwedtutu7Ye0EbKMSFZjLoiAkzExPmP/S5PRppOaf08JUS/NJy3RxJc3AkzX/oMxuUUwq4nBr8vMM7a1mN2AKNaJpGzfC6zOz8iq+QS6YjHafn5PXjrFVIt6dyIu84u9O2k+FIo25EQ0LMoXy8cwm/H/mRYKPVF/TaxXamdWwHshyZ7M/YTVhBIRerKRSDzm8HvhBCCCGEuEhK/JQWHBQIwMGEo9StVc23vX3rpix+/3OG3XXThWmdEOWYQa8QHWoiOtTk9zi3RyM919vTl5ztLPK9aOhzcTTdydF0p9/rGfVKscBnK6jgmWjNwmY10iv+TkID9UWGdxbqVLkH1cPq+Aq6ZDrS8WgeAA5k7uHVDc/5jlVQqBJag0ntngFg+c53MOsDCLOEF8zl867VZ9T7fw6EEEIIIcS55/dP7h5VZcv2PTSqXwuAQ4ePkZWdc0EaJsTlwqBXiAoxERVioi6BpR7nUTUyct1+K3emZLlIzXGRmOEkMeNsQ18YUSFR1Ak2EhVjJCTgZOhrFNWcOV3f8BVyybCnFwmEe9J3kmFPJdORgYY3IE7tMJeY4Dg+2fUeO1O3FgQ9b89efVsTqofVxuFx4HDbCTZZ0SnFq4UKIYQQQogz5zfMjR1xB49OnUuVuBj0ej279x1kwph7/tMNP//mJ5Z/sZLgoECmPzaK6KhIADIys3lg4jO+404kp3H37X25fUBvrrr2TmpUrQxAk4Z1eHjUXf+pDUKUR3qdN3xFWo3U8XOcqmpk5rt9BVtSskoZ4pnjPqPQF3XKOn1R1gBsISHYrDWxWY1k5rkJCdD7euhUzUOWI4tMRzq2QO8w7DhrFXJdOWQ60tmfuZdMexomvZnqYbXZnrKJ1zbMRqfovfP4zBFUCa3OwPr3AbD22O8EG62EFvT4BRmDi8wfFEIIIYQQxfkNc80b12PZm7PZumMvbreberWrY4sMP+ubpaVn8u6yr1i64Fl+X7OeV95cxtSJ9wMQFmplyWszAcjLt/PgY7Po17sbAFGREb59QlzpdDqF8CAj4UFGavk5zhf6CgNeKaEvJbtsPX0mg1K0kEuIEVtwILaQrIJtLalbvV2Rnr5CNcJqc3+zCaes1ZeGSecdmulW3by1eb6vpw/AoBh4quNcogMr8kvC/0jMPVqwTl/h0M7KhFnO/neREEIIIcTloMQw53a7MRi8u6zBQbRr1eSc3GztP1uoXaMqFouZpo3qMnv+4hKP++CTb7ip79UEBnhLzYeGBp+T+wtxJSkS+iqWftypPX3J/x7a+a9/H89wcrysoS/E6Fu6wdvrV51Iax3iQ4zY4oxYLd51+gw6Ay/3XEqWI4MMexqZjgwyHGmEmr1hLd2eys7UrWQ40shz5QJwU53B9Kx2PZuT/uHDHYtPGdoZQSVrZTrEdQfgRO5xQs1hWAwB5+AZFUIIIYQoX0oMc5Ofns+sJ8cVW6JA00BR4I9v3z2rm6WmZRAf5/1UaYsIw6Oq2B1OLOaTxRPcHg8/r/qbt+ZNK3Le0LFTAY3RQwfSpEHtEq//8Zff88lX3xe0VSvxGCFEUUVCX0zpx6mqRkae2xf2ivTuZRWd01fW0Fd8Pl8oNqsNW4iRY6kqkVY3N9S6nf61BwLg9DjIdGRgMXj/0BNuiaRFxbbeHj97OkeyE0jOS6RDXHdcqosnfn8AALPeTKjZux7f0KZjCTWHsy15I7munIKhnd45fhL6hBBCCHEpKTHMPfqAd17cyk8WnNu7KUVDlqZqxdaz275zH1XiYjCZTq6B9fTjD1K3VlV+WfU3T816lc+WvFji5W/q24Ob+vYAvL2LHfvcfW7bL8QVTKdTiAg2EhFcttBXWtg7OafPxbF0J8dOU73z1CUbfIu0WzWiQtxEWiNoHj4Am7X4On06dIxvPZUMRzqZ9rSCgi5pmPXeIPjL4ZVsSvq7yL1urXs33av2YXfadn47vNK7KHtBCIwOqkjV0Jpn/wQKIYQQQpxjJYa5iPBQ4OQSBafasXs/9WpXP6ubRUWG+9apS05Nx2g0YjYVLWm+c88BalaPL7KtsCeuR5d2zHn5nWK9eUKI8uPU0Ff7NKEvvaCnLyXbRXJWyUM803LKtmRDYejzzuUr+G6NwGatgM1qpGaEt/fPrPcO7xzVfAJ2d76vcmemPZ3KBYuyuzxOMuzpHMrcT4YjDYfHQZ2IBjzc+ilcqouHf7yXUHMYoZYIwsxhhJoj6FNjAIHGIBJzjqIoOhneKYQQQojzruSeualzS6wkp6ka+w8dYfni58/qZq2bN2LhOx9jtzvYsHkn7Vs3ZenyFUTZwunZtT0AiUmpVI2P9Z3zx9oNxMfFULlSRf7ZtJ1oW4QEOSEuAzqdd25d5GlCn6ewp69gCGfyvwq5pJ5p6DMqJ8NecGFPXyQ2a0XIN5Kfm0/lkIY83LqJ7/eg3Z2Pw2MHQNVUrqt5M5mONDLs3uUbDmbup2/NWwD4YMdb7EjdDIBFH0CoJZx+tW6jZcV2HMk+xI6UzQUhMLygqEs45oJho0IIIYQQZ6LEMNepfYsSD1ZQGHXfbWd9s/CwEO4eeAP3Pvgk1qBApk8ew7vLvioSHPPy8ouEtdiK0Tz/yjskJadhNBmYMmHEWd9fCHHp0Z8S+vw5NfSVVrUzJavsi7OfWsjlZPhzeId7hnSmepiRqBBjseqddzYYRkp+sm9B9gx7GuHmCAASsg7wxd5lOD0O3/F1IxryUOsncXoczP/nmYKKnWG+wNc0uhVGvQmP6kGv0/+HZ1IIIYQQlxvF6XRclpVCCufM/b7ibV9lzvIgMdOJ3aWi1ymk5iejV8r+4cyjeYgMiDqr++pzEkDn/8NwuaO68ATHn/44Ic7AqYuzF/b0/Xt4Z+E+j3r66xn1J0NfZLCBqBDTye9Wgy8IhgYY0OkUNE3D7sknw+4NewadgZrhdcl15fD+tkUnl29wpOP0OHi5x3uY9GZe+HsahzL3+XrzQs3hdIrvQa3weqTmJ5Oan+zdbonArDef/ydSCCGEuEw53Cq2YCNhgeUnQ5TGbwtT0zJY9tl3HDl2AvWUwiXPThl7vtslhBDnxamLs/vz7+qdJQa+bDcpOS4SM50kZvrv6dPrKF7IJTgSW4iRJGsmNquRG2uOIjywaOgzFQSzq6v0ITH3KBkFxVzS7Ck43N6hnxtO/MVHO9/23SvAEEjzCm24q9H9OD0Ovtz7kS8EFvb82QIroFN0/+3JFEIIIcRF5TfMPf70fKrEx3Lk2AluuaEXO/YcICIs9EK1TQghLpozqd6Zle8hOdvpDXfZJc/pS812cSLT++WPXgcRwUWXbPD2/FXBZq1JfKh3W3iQAb3OO7yzY1x3Gtiakuk4uU5fWMHQzjxXLhtOrCXDno5LPRk4X+mxFJ3exNtbXiUtP5lQS7hvYfZGUc2pEBTjDYuKIj19QgghRDnlN8zl5uUz8cF7eW7eYurWrk7vHh0ZP+Xsip8IIcTlSKdTCAsyEBZk8Ls4u6Z5Q19pQa/we2pBZc/kLP+hT6d4Q1+k1XBK8PMWcokMNhJiMpKU5SQiKJynO72Mpmnku/PIdKST5cjEqPfOTa4YFIvTYyc1P5n9GbvJsKcTbomkQlAMvx3+nuW7lhBoCPKtx9fA1pSe1fri8jjZnPzPyTl+5nDfNYUQQghxYfgNc2azGbvDSfMm9fjxtzVUGNCbo8eTLlTbhBDisqEoCqGBBkIDDdSoUPqSBZqmkW33FA16BZU8Tx3emZzt9P28i3w/94XwoJOBzzvMM5yt1mSirEYqW3vQvJq3B9Kg9w7v1PAOq28c3YJgU8jJYi6OdNyqG4A0eyoLNr5Q5F5BxmBmd30Dg87At/s/w+7O9/X2hVnCqRhUiUBj0Dl4NoUQQggBpwlzN17XnaPHT9CpXQuWf7GSd5d9ze03Xnuh2iaEEFccRVEICTAQEmCgWrT/0JfrUEnOcpKaU3yRdl9xlxwXaTlu0nLc7D7uP/SFBRpKWKC9PjarkTirEVuMt8gLQHRgReZ2X0ymPZ0Mh3ceX64zG4POu/9I1iFvT58jDY/mAWBE0/E0r9iGXxO+59fD/ytYlN3b41c9rDaNo1vgUT1kOtIJMYf5riWEEEKIkvn9f8prr+7g+/eCF6aQlZ1LiFX+qiqEEBeboigEW/QEWwKoFu3/2FyHx7tkQ46ryPfU7KLb0nPdpOe62ZNYeuiDk6GvcJH2yGAbUSGxRAYb2Ho4l0irgbsaPoDJoEPTNHJc2WQ60omw2ACICqxAzfC6ZDrSOZ5zhB2pm8l2ZtE4ugXJeYlMWTUWBYVgU4i3aIslglHNH0Wn6Nh44m9Q8Pb2mcOxmkJlyQYhhBBXLP89c4PH0atbe3p1a0/V+EoS5IQQ4hIUZNYTFKWnSpT/xcnzHJ4Sg96/q3hm5LnJyHOz98TpQ1+k1UCUtWCZBmsGNmsuNmtlGlmrY4v1FncxGU5W1QyzRDCmxSTfouyZjjTsHruv8uYnu9/jRO4x3/EKCqNbTKRRVHM2nFjL1uSN3t4+i3d4Z4WgWCoE+algI4QQQlzC/Ia5V2ZP5qff1jJt9gI0TaNXt6vo0aUtkRFhF6h5QgghLpRAs554s574SP+hL9/pKXVR9tQct2/oZ2Ho23fC7vd6oYF633p83iGe0URaK2GzGokv6AF0ulVMBh1TO7xAtjPLW7XT7q3eGWetAkCOM4eErP1kONLJcmSgodEhrhuDG44kMecoL/w9ldCC+XveHr9Iele/EUVRSMo9jsUQSLDJKks2CCGEuGSUedHw44nJfLbiR5Z9/j9+/Wrx+W7XfyaLhhcli4YLIS40u1M9OYyzpPBX0OOXbfeU6XohAfqTc/lCjL4A6PtesIyD2ahD1TxkObIACLOEk2FP47fDP3h7/AoKunhUD0928FZonvzbaJLzTqBT9L7qnLfXu4dqYbXYl76L47lHfUM+Q83hBButKIpy3p47IYQQF89ls2g4QEpqOj+v+psff11DTl4+Q+8ccCHaJYQQ4hJnMemIizATF+F/nTq7U/UWbDllOGdyVvGF2rPyPWTle9iX5L+nLyRA/69CLnkFc/x6UMVq9A7vtBqxGE/2wA1r8hDpjlRfQZdMR7qv8ubm5H/4dv9nRe7RMe5q7mw4nOS8E3y8611CzWEFyzSEE26JoL6tyVk+a0IIIUTZ+Q1zIx+ezpHjSfTo3JZx9w+mTs2qF6hZQgghrhQWk45KEWYqnS70udQic/dKWq/v1NC3/zShz2opGvpsIbHYrFWwWY1UsRpxO4zYTSr9aw/k+po3k+XILOjVO7kou0t14vTY2Zu+kwx7GjmubELMYczp+gYAT/4+Fqfq9K3HF2aOoFuVa4kOiiElLwmnx0GoJZxAQ5D09AkhhDhjfsPc4Nv60rp5I/R6mT8ghBDi4rIYyxb6HC715Lp8pVTxTC4Ifdl2DweSTx/6In0LsxuxWeOwWY3ss6Zjs4YzoPoj2IKNWEw6XKqLXGeO79xuVfqQZk8mw+4d3pmYu5Wr4roB8MOhr/np0LcAGHVGQs3hdKrck2uq9yPDnsaaY797A6DFW7kz1Bwu6/QJIYQooliYe/WtZQQGWOjfpxvtWhUfJuL2ePjx17X8+OsaZk55EINeSkILIYQoP8xGHbHhZmLDyxb6CsNdsV6+ggCYmecNfQdPE/qCLXoigw1EhZiIDM7AFmIkytqESKuBaiGFFT2NBJi8/795bfX+tKzY3tvbV1C5s0JQRQBS8pP4bv9n5LlzfdcPM4fzXNeFACzY+AIKSpF5fPVtTbCaQvCoHlmuQQghrhDFwtyIu2/mx9/W8vATc1AUHZViooiOiiQzM5ujiUmkZ2TRo3M7nnhkuAQ5IYQQl6yyhj6nu6Cnr4RCLqnZbpKznaRmeyt35tg9HEpx+L1ekFl3Si+fGZu1MraQ6tiCjZBvJCHVTiVrLV68+m0cHgeZBWHPqTp917DoLaTkJ3E4+yCZjnTs7nweb/8cVlMIH+18mz+P/uJbkD3MEk6zCm1pUbEtua4cjmQf8q3TZzb4r1wqhBCifCsW5nQ6HT26tKNHl3bk5uWTcOQ4xxKTCQ8LoUpcjCxLIIQQ4opiMuiICTMTE+Y/9LncKqk57lIrdxaGwYw8N7kOx2lDX6BZd7J6p9WCzWplk/UEUVYjjax3Yov1VvIMNOuxu/Mx6kwAtIxpjy0g2je/L8OeTrYzE4CDGXt56Z+nffewGAKoElKdh1s/BcCKfZ9g1lt8wzpDLeFEWGwYdOW/opsQQlyJ/P52DgoMoF7t6tSrXf1CtUcIIYS4JBkNOiqGmagYZvJ7XGmh79+FXNJz3RwqY+grukyDlUhra6KsRqqHGImq5A2EALUj6jOtw4u+5RkyHGno8M6L1zSNv479Tkp+Mq5TegGfaP8clUOqsWLfJ+xK2+bt7TOHE2qOoGZ4XaqEVsetutA0DaPe/2MXQghxbsmf2oQQQogL6ExCX1qu+7SFXDLy3CSkOkhIPU3oM+lOKeQShM0ahs1aG5vVyD/7s7FZjUxo/TyBJh357ryCsJdOdFAsAKHmcIKMwSTnnfBW73Sk06fGAKqEVmdH6lbm/zOTIGNwwfDOCOKs8dxUdzAAm5P+IcgYTJglghBzGMZLbd1TIYQopyTMCSGEEOWQ0aCjQqiJCqH+Q5/bo5GWU8rQzlO+0nPdHE51cPg0oS/AdOqcvmAirckFwz2b0jKkFZGVvEs5BJgUVFQA4qzx3N1oVEEhF2+PX2HxFlVTeXXDbFTt5OLwQUYrE9vOoEJQLKuP/kpi7lFfCAyzhBMVWBGrKeQ/PoNCCHH58xvmHE4nn339Eylp6Yy+73by7XYST6RSrUqlC9U+IYQQQvhh0CtEh5qILkvoyy1ayOXUoZ2F39PKGPosxlNDnxGbtSa2ECORwQZqhpqIDDaQY/cQaFKY0/UN72LsvrCXjtUUCsDRnATWHf+TTEc6noLAd0Ot2+ld40Z2pG7hox1ve4OexTuPr2JQJdpV6gxAWn4KVnOo9PQJIa5YfsPc088vJLZiNH+u3cjo+27H4XAx66U3ef2FKReqfUIIIYQ4Bwx6hegQE9Ehpw996bn+e/lSs92k5bg4kubgSFrZQ1+kNQSbNRKb1civ2XZsVg8twm+iZ/ztBJt15LlzyXCkEWy0AhBsDKZ2RH3vGn05R9mVuo3IgCjaVeqMqnl47Nf70dCKDO+8q9FIwi2R7ErdRo4ru0gxFwl9QojLjd8wt3tfAtMeG82ff28CICzUSl6+/3V2hBBCCHHpMugVokJMRJUh9GXkuYvO5ysh+JU19JkNyilz+jxEWnOJsgYQab2B6lajt3qn1UhIwMllkR5oOZlMexqZjgwyHN6F2U16b9XRHw+tYGPS30XucVOdwfSsdj37M/bwa8L/fGv0hZrDsQVEUyVUCr4JIS4tfsOcyWggJzcPRfH+vHXH3gvRJiGEEEKUcwa94utx88ejaqTnuotV7iwp9B1Ld3Is3en3eiaDQkSwsWAenxWbNcLXjmpWI8dSddisLoY3GU++x9vTl+nIINOeRnxBWLO78ziRd5zdadvJdKTj1tzUCKvDo21n4FE9TPhlGFZTqG+tvlBzOL2q9/MVgFFQpKdPCFEu+A1zI4bcwugJM0lKTmPS9Jf4a/1Wpj026kK1TQghhBCXOL2u7KEvI89dYtA7dU5fao6bxAwniRn+Q59BrxAZbDilkEt4wb9TsFmrcmOVyURajYQF6Mn35OLweEceqZqHq6tc5yvkciLvOLvTt9OrWl8Alu1YzObkfwB8wzt71xhA65irOJZzmJ2pWwk1hxFmjpDhnUKI885vmGvfuilV42NZs24LaBoj77mVypUqXqi2CSGEEOIKodcpRAYbiQw2Ujum9ONUVSMz311k/l7J8/pcnMj0fvm/L6f09GUVBL62RFqNNLIaiazgDaIWg/cj0y1176JblWt9a/Vl2tMJNYcBkJB1gI93LsGtuX3XP7XHb94/M0/O4Sso6tIoqjkmvRlV86BT9CU1UQghSnXapQmcThdmkxGLxUxQYMCFaJMQQgghRIl0OoXwICPhQUZq+fn7sqZpZOV7Su3h8/X0ZbtIzvJ++b2v4g193kIuRdfpS0oyoubnUsPalpe6d8Cp5vrm8el13o9aTtVBgCGQpLxEdqdvJ9ORgVt18WL3tzHpzby8fhb7M3YX9Oh5e/auiuvmLQBjTyMlP8kXBGVxdiFEIb9h7v2Pv+GtpZ/RsF5N9Hodc15+mymPjKBdqyYXqn1CCCGEEGdMURRCAw2EBhqoUaH0P0Zrmka23VMk4JVUvTM52+n72f99ITyocHhnUMH3Y0RajdS33ktklLcXMDzIgFPNJcAQCECXyr2oFV7PO7zTnk5SXiJ5Lu9afRuT/ub97Yt89wg0BtEkqiVDGo/Grbr5cs+HhJojCLV45/iFmcOJCLBJT58QVwC/Ye7Tr3/go8VziAjzrgWz/+ARnnjmZQlzQgghhLgsKIpCSICBkAAD1aL9h75ch1pqT1/RYi5u0nLc7D6e7+e+EBZoKOjpMxJltRFpjcFmNVLXasRmM2IzG3G5VdrGdqJ2eH1fMZcMRxqhpjAA8ly5rEtcTYYjHbd6Mmi+dPU7BBgCWbptISfyEn0hL9QcTgNbUyoGV8Lp8VYYLawAKoS49PgNc7aIMF+QA6heNQ6z6b937X/+zU8s/2IlwUGBTH9sFNFRkb590+csYMPmnQQHeX+hvvzcZEKsQX7PEUIIIYQ4nxRFIdiiJ9iip2qUxe+xuY7T9fR5v6fnuknPdbMnsfTQBxAaqC/o4QvEZg3FZq1JpNXIT5np2KxGRjd+gYggAx4ln0y7d1F2i977OcoWWIEcVw7JeSfYm76TTEc6waYQKgZX4o8jP/PBjjcJNAQRWrAoe72IRlxboz9u1c3GpL9PKeYSJqFPiHLIb5hr17opyz77jhZN6gNw+GgicbEV2Ls/AYCa1ePP+IZp6Zm8u+wrli54lt/XrOeVN5cxdeL9RY6Z9NB9tGza4IzOEUIIIYQoD4LMeoLMeuJt/kNfvvPfc/q8wzlPLeqSmu0iM89DZp6HfSf8r/UbEqAv6OkLIMp6qGDdvnbUtHYiMsY7vDMi2IC5oLhmA1sThjQa7S3k4vCGwMLiLZmOdBZufKHI9QMNQczqugCz3sz/DnxBjrPoouyxwZUJMgaf/RMnhDhjfsPcF9/8DMCyz/5XZPuEp+aiKPDJO3PP+IZr/9lC7RpVsVjMNG1Ul9nzFxc7JizEesbnCCGEEEJcSgJMeipH6qkc6T/02V1qiT19/96Wle8hK9/D/iT/oS/YovctF2GzViHSWgOb1ehdnN1g5HCqncjgcOZ2X+ybw5fpSCfbmYW5oHfuWPZh9qTvJNORhqtgeOd9jR+kdWwHVh35ke8PfOULeWHmCKqF1qJ5xTZ4VA+p9mRCzeG+awkhzp7fMPfBolnnZFjlqVLTMoiP85afskWE4VFV7A4nFvPJ+8x/431OJKfRs2s7hgy8oUznAHz85fd88tX3gHdsuxBCCCHEpc5i1FEpwkylCP/hx+FSSc3xvzh7arabjDw3OXYPB5P9h75As65gyQYLNms8NquR5GMniLIaaWy9i+6x3p4+nd7hncdnDgcgOjCG+rYmZDrSSc1PZl/6bnJd2TSv2IZ0eyqP/zYGgABDoK9n74GWkzHoDKxPXIuqeXxBUEKfEP75DXP3j3+aN+dNPbd3VIoGLU3VUJSTuwffej2BgQF4PB5GPfI0TRvWOe05hW7q24Ob+vYAwO1207HP3ee27UIIIYQQ5ZTZqCM23ExsuP/w43KrpOYUX5/v3z196bluDjkcHEpx+L1egElX0MuXXzDMMwSbtTfxViPNo4y+XkBN07CaQxnXagoZdm8xl0xHGnmuXAwFSzh8s/8TErIOFLn+8KYP0aJiOzacWMv6E2u9a/QVzOOLCY4jzlrlvz1xQlzC/Ia5urWq8sfaDVzVptk5u2FUZDhbd+wFIDk1HaPRWKT3r0rlWN+/r2rTjIOHj5/2HCGEEEIIUTZGg46KYSYqhvn/LOX2aKTllF7IpTAApuW6OZzq4HCq/9BnNipEWU1EWk3YrJWxWasTGWykYoiRv/ZlEWU1Mqbp0xgMDrKcGWQ40smwp1E1tCYATo+TtPwU9mfsJsOejkt10ia2I/c2foCUvBNM/3NCQdA7OY/vxtqD0Ck6jmQfwqQzEWqJkJ4+cVnxG+bSM7J4dOqLVI2PRa/X+ba/88rTZ33D1s0bsfCdj7HbHWzYvJP2rZuydPkKomzhtGrWkL/Wb6Vn13ZkZuWwadsuenW7itiKUcXOEUIIIYQQ549BrxAdaiI69PShLz235EIupxZ0SctxcSTNwZG004Q+g0Kk1Uik1USUtTKRVju24ERsIfXpFNnE2/sXbMBkdOLBXXCOhd41bvTN70uzp3As9wg6xfv59Y1NL3I85wjgHd4Zag5nUP2h1IlswJ70HRzM3OcLgWHmcAl94pLhN8zd1K8nN/XreU5vGB4Wwt0Db+DeB5/EGhTI9MljeHfZVyiKQmCghZ179vPBJ9+QkZnNrf170aBuDYBi5wghhBBCiIvPoFeICjERFeI/9HlUjYxct6+nr7SCLmk5Lo6lOzmW7vR7PaNeKajYmVgwlLM5kcEGYkNMNIrwruGXnusiNMDA/c0eId2eSkZh5U57OiHmMAD2pe/iq73Lcakn79cutjNDGo8mNT+Zt7e8UiTkhZnDaVmxPYqi4FZdGHTG//wcCnG2FKfTcVlWCimcM/f7ircxGPxm1gsqMdOJ3aWi1ymk5iejV/RlPtejeYgMiDqr++pzEuBS+2WjuvAEn/nyF0IIIYS4dKmqRkZeyXP6ivyc48btOf3HWINeITLYULA4u3eRdluwEVvIyfl8EcEGAkwuslzeeXyBxmDiQ6qRkneCT3e/X2T5BoPOwIvd3wZgyu9jyXCk+ebwhZkj6FW9H3HWKiTmHCXLmekLgmaD/6qlovxwuFVswUbCAstPhiiN3xYeTDjKm+99xpFjJ1A11bf9vwyzFEIIIYQQojQ6nUJEsJGIYCO1Y0o/TlU1svI9xdbmK6mgy4lM75c/eh1EBBcGPBWbNYHIYCPRIXdSP8zoG94ZZPH4zulX61ZS8pN8i7Wn2VN8n5lXHfmRlQe/8h1rMQTQpXJPbqxzBxn2NH44+HXB3L6TQbBCkJ8HLEQJ/Ia5p2a9RteOrUlMSmXo4AHs3LMfYznq5RJCCCGEEFcmnU4hLMhAWJCBWhVLP07TvKHPXy+fL/xleb/83lfxhr5IqwGbNQqbNRZbsJGoECN1Q4zkZhtJwsk11W7mqrjup/TqpRETFAdAtjOTjUnryHCk4fR45xAGGa3M7f4WAC+texqX6ioyj69lTHvCLZHkuXLRKToshoBz80SKS5rfZKahcddtfUlLzyA4KIDBt/blwcee5fYBvS9U+4QQQgghhDhriqIQGmggNNBAjQqlByBN08ixe0oIee5Se/92ke/nvhAeZCgY0hlDpDWeKKuRPdZkbMHh3F79mf+3d99xUlX3/8dfd+7MbF+20nsTBARBQcQWDVEj1qhYsEX9WdBobIm9oFjQqN+ISIzGRiI2YiG2iLFBEBERiIgg0mQp21hYdmdu+f0xZXfYQtnd2Rl4Px8PHrhn7tw5Z+e6zHvPuecTmulLs9gWLKPSqow+t1t2TzZVbqCsqoSfyldQXl1Cr9z9yE3NZ+aK1/jwp3dINdOitfiGdxjFEV1GszVQwf82LwwXaw89ptC3d2s0zKWnpVGxdRuHHDSYt977D36/n6KNxfHqm4iIiIhIXBiGQVaal6w0Lz3aNh76KqudBjdyiSnbsNWiZKvFsqKGQx+EQl9+po+C7OXhZZ5HUpDlo3eml8KOfvKzvORlhD62j+p0NF2ze9bM+FWVRnftXLd1NX/99vGYcxektWXikZMBmP7dc3gMgzYpedGw161NTwW+JNZomDt/7ImUlVcwYtgg3p/1BZdfdw8Xn3davPomIiIiIpJQDMMgI9UkI9Wke2Hjm5psq7brbtxSTwAs3WZRus1i+YbGQ1+bdDM809ee/Kwu0Q1dAmU+vnW2UpDVm0lHPsd2u4zy6jLKqkuwHSv6/A2VP7NpWxFl1SVUh5d33nzIRHrk9OGfy/7B/KI54R07c2iTksf+BYMZUDCYaquKsuoSzfQloEbD3MiDB0f/+64/XNninRERERER2VtkpJhkpJh0LWg89G0P2Dtd0llcEaS80qa80mbFxqpGz5edZoZn+tpTkOljQfY6CrJ87J95BQUFoc1cMlMtqt1y8lILAOiZ05egE4jO9q0q/5EMXyYDCgazsvwH/jTvHgBSzFRyUnLpmNWVKw68AYDP1vwbv5lSs6tnap5CX5w0Gua2bqtk1qdz2VxShltr59eLx53a0v0SEREREdknpPlNuuSbdMlv/LiqoFPvTN+OwW/Ldpst221Wbmo89GWmmuRnllKY7Sc/M4+C7GMoyPLRLdNHQbvQrF9ltU3X7J5cf/Bd0fIM5dUlMeW13vzhZbYEymPOfcvIB+jephcfr3qPFWVLQzt3hv90ze5Jh8xOuK6LYRh7/H2TnYS5626bhG079O/bE6931+uhiYiIiIhI80r1eeiUl0KnvJRGj6sOOhRvbag4e83sX1mlxdYqm1Wbqxs9X3qKJ7y8sy0FmZ0oyA4FvferSijI9nH1oCfITLew2BIKe1WltE0PbTHquA5l1WWs2rKS8qpSquztjOl1Oif1Gct3xYuYsmBSTVH2lFw6ZHZmTO/TgVBB9wxfpmb6GtFomCvfspW//+VBTNMTr/6IiIiIiEgTpPg8dMxNoWNu46EvaDkUb7V2OtNXVmmxuria1cWNh740v4f8TB+F2W3Jz9wYLsw+jAGZIygs8JOf6SU73SEt3K226e04qfeZ4dm+0KyfVRG6x891XR6ZdzeWEyoVkWKm0CYlj6uH/ZF2GR1ZsGEumyo3xMz45aXm73PF2RsNc0MG7sem4hLaty2IV39ERERERCQOfF4P7XP8tM/xN3qcZbuUbG14I5fI36XbLNaWVLO2pPHQl+IzwjN9PgoyB4Rm+jJ97J8Vavtxw3bys7zccejDlAdKKa8uo7yqhLLqUjJ8WQB8X7yE2T//hyqrZtOYE3ufyYm9z2BF6fe8sWxazD18hentObDdcACqrO2kmKl7xRLPesPcH+5+FMMwqKjYxvgb76NPr24xjz9wx7Xx6JuIiIiIiLQyr2nQto2ftm12HvpKt8Uu5dxxQ5fiiiDFW4OsKw2wrjTQ6Pn8XiO8kUsBBZkdKMj28fqGbeRnBeiRfToHDTyb7Awbx9jClkAZOal5AJgeL7mp+ZRXl7K6YiXl1aW0S+/Ige2G47ou1330W0yPGTOrd0a/88lNzeen8hW4rklBZq9m+/61pHrD3BGHDot3P0REREREJIl5TYPCbD+F2X76kd7gcbbjUrat7o6dOy7zLN4aZH1ZgPVljYc+nxkJfeXkZ24Lb+hyJn2zfBS091GQ6SMn08BxXDAcLjzgqlCdvvBsX3l1KV5PKBa9++MMMn05HNA+icPcCaOPqNNWsXUbGelpeDy6f05ERERERPaM6THID9fI26+R4xzHpazSqndJZ+0NXTZvDVJUHqCovPHQZ3oIh758CjLbh5d5+uid5WPRT5CfWckpPS/D73MbPU8iqTfMfTZnPhnpaQwdvD8Ajz31Eq+++T5tsrOYdPd1DOjXO66dFBERERGRfYvHY5CX6SMv00efDg0f5zguW7bbO53p21wRZOOW0J/GmAaMO7wdE8f2bOYRNb96w9wL09/hwTuvBWDhkmV88PFsXv7rJIo2bubRKS/y18fvjmcfRURERERE6uXxGORkeMnJ8NK7fcMlDFw3FPrqn+GLnf1L9SXHasR6w9z2qiryctsA8PLr73LWacfRpVN7unRqzyOTX4hrB0VERERERJrKMAzapHtpk+6lZ7uGQ19V0CYnvdFN/xNGvZHTYxgsW7GKr75ZwvyFSzj5+F8AYFkWfr8vrh0UERERERGJF8Mw8CVJne16I+eVF5/FlTfcSyAY5I/XXEyb7FA9h+kz3mfE0EFx7aCIiIiIiIjUVW+YO+SgA3j3lSlYtkVaak0V9WFD9qd7l45x65yIiIiIiIjUr8HFoD6fF58v9uF+fXq0eIdERERERERk55JjMaiIiIiIiIjEUJgTERERERFJQgpzIiIiIiIiSUhhTkREREREJAkpzImIiIiIiCQhhTkREREREZEk1GBpgpb0z3/N4tU3PyAzI50JN4+nbWF+9LGX33iPDz7+gm2VVVx1yVkcPnIY64s2cdalN9GtcwcAjjnyEC4466TW6LqIiIiIiEhCiHuYKykt58XpbzNt6gN89t+vmfzMdO7+45UAbKvcTnUgwNOP3c2qNT8z/qb7+NchQwHYv29Ppjxye7y7KyIiIiIikpDivsxy7vxF9O3VndTUFIYM6seced9EH8tIT+OCs07CND306NYJ27apDgQBaNMmK95dFRERERERSVhxn5krLimja+f2ABTk5WA7DlXVAVJT/DHHfb/8Jzp3bBdtX/7jai666nYyMtK4YfwFdO/aqc65X3vrQ15/+0MAXNdt4ZGIiIiIiIi0nvjfM2fEBi3XcTGM2EMs2+bxqdO47MIzAWhbmM/tN15O/z49eHnGuzz057/x5KTb6pz69JNGc/pJo0PnsCwOP+HCFhuGiIiIiIhIa4r7MsvC/FxWrysCYFNxKT6fjxR/7KzcY1NeYtjg/owYNggA0/QweEBf/H4fJx9/NKvWrI93t0VERERERBJK3MPc8KGD+GHFKqqqqlnw7VIOHT6Eaa/O5IOPZwOhpZLFJWX89txTo8/58D9zKC4pw3VdPpszn359use72yIiIiIiIgkl7sssc3OyufCcU7j4mjvJykhnwq1X8+L0tzEMg3XrN/LYlBfp0a0zF44PLaM8b+yJtC3M57aJT1BcUkZ+Xg533HBZvLstIiIiIiKSUIxAoHqv3Ckkcs/cZzOfw+ttlXJ69SoqD1AVdDA9BsXbN2Ea5i4/13Zt8tMK9+h1za2rwePbo+e2GieIndm1tXshIiIiIvuQasuhINNHTnriZIiGxH2ZpYiIiIiIiDSdwpyIiIiIiEgSUpgTERERERFJQgpzIiIiIiIiSUhhTkREREREJAkpzImIiIiIiCQhhTkREREREZEkpDAnIiIiIiKShBTmREREREREkpDCnIiIiIiISBJSmBMREREREUlC3tbugOy6gOVQFXRwAYxQEvcY4DEMPAYYhtHKPRQRERERkXhRmEsStuPi9xp0L0jBdsBxXYKWS9BxsWyXoOPgOC626+I64LjgAgahv03bweM6mOHg51HwExERERFJagpzSSJoO3TI8eMzPfjMcKO/4eNd18VxQ6HPdsDx+gk4XoK2Q9B2Q8HPcbEB140+KzTLh4HpUeATEREREUlkCnNJwHJc0vwmPu+uhyvDMDANMDFC4c9nku4xATPmONd1sV2w3VDAC1oQdBwCNti2E2p3Q4HPjUzzEVreaWLgUegTEREREWkVCnNJwHIcOuSkAk6zn9swDLwGeDHAhDQf7Bj4gNBMHuFZPscNhT3HIWCF/naiM4EALhgGrhu+p4/Q0k7To9AnIiIiItJcFOYSnGW7pPu9+DwGlrvz41uKxxNafukL73+aDtQb+sKhLjLTZ9mhmb5geKbPcsF1QrOBkeEY4bv7PAbRe/q0mYuIiIiISOMU5hKc5bp0yEyetymys2Zkpo8GZvoiyzsd18VxqNnIxXaxopu5OASt0O6drhsKfJHgZ9TaxVPhT0RERET2RcmTEvZBQdslM9XEtxcuT4ws7yQc+lLrO8gxITstGvicyP19tkPQAcsOz/g5kXv7anbyhMhuni4uRkwJB4U/EREREdkbKMwlMMd1yUvXW+QxDDwmhAotQHStZwOis35OTfiznNC9h0GbWjN/9ZdxUA0/EREREUkGSgoJKmA7ZKeZePfCWbmWFp318+xe+HMjZRzCNfwsJ7TsM1LDL7rJS3gfGtcAwwUHN7rJi8ejOn4iIiIiEh8KcwnKdSFHs3JxUXvJ567U8IOaWb/IDJ8Vc89fuKwDoc1eIjN/uu9PRERERJqT0kICCs3KeTH14T5hhXb3BMxde48auu/Pjiz9tJ3wY6Gln3b4vr9apf1iQp9m/0REREREYS4BObjkptfdAVKS157c9+eEd/uMLP2MzPwFHRc7cu+f6+K64fDnglvr7j9DSz9FRERE9moKcwmm2nbIS/Ppg/c+zjAMTAPM2ks/dyK69DNa7sFpcOlnZOYPN1LgvVb4Mww8HoU/ERERkUSnMJdgDBey0zQrJ7svuvQzPPuXRuOzf5HQZ4f/tpzwrp+2QyBc5N2pdZzu+xMRERFJLApzCSRgO+RmaFZO4iOy9NMbWfq5i+FvT+r9RWYAVe9PREREpPm0Spj7579m8eqbH5CZkc6Em8fTtjA/+tjanzdw14NPsr2qmvPOHMNxxxyG67o8O20Gsz79kraFeUy45SoyM9Jbo+stJjTjAVmpjX+gFmktTa3359Sq81ffpi+q9yciIiKye+Ie5kpKy3lx+ttMm/oAn/33ayY/M527/3hl9PHHp77EReecwpCB+zHu8ps57JChrPt5A7O/XMgLUyYy7bV3eOmVd7j8ojPj3fUWFbRd8jM1Kyd7jzr1/nYy81dfvb+A5WLvUO/PDm/6Eln6CTUBUDt+ioiIyL4k7mFu7vxF9O3VndTUFIYM6sekP/8t+phtO/z3q2+566YryMhIp2vnDny98DuWr1zN4AF9MU0PQwb24+HJz+9ymAsEgjjh9V4ej4HX68WyrGgbgGl6ME2zwfZgMIhb04zXa+LxeAgEgjGv5fWaGIZBMGjFtPt8XlzXxbJsrGAQy3Jwwx8yXcfBtm1sxyXVY2JZLl6vF8dxsG0neg7DAEwjdGyt9l0eU9ACT7jd4yFoWbFjMj2hMe3Qd6/XxACClh07Jq+JC1g7tPt9ob5bO/Td5/WGluHV7rth4PWaoY05nB3GZJpYto1T63scz/cpZkx+X2hMtdoNA3w+X4Pvxx6/T/vwmGr33QP4vSZpvki7AZg7jMmK2fHT9HoJBG2qAhaW7WDbEHRdDNPEsmuN1Qjd9WeYZjgROtH7DU3TxDRNbNvGjbkmPXhME9uyorPoAB4z1Pcd203TxPB4sIKx75PpDf3ItS1rl9q9Pl/0Z0TN+2Rghn9GOPW12zZOrb4bHo/GpDFpTBqTxqQxaUy7MSbLdggGIRh0E+rznt/vY0dxD3PFJWV07dwegIK8HGzHoao6QGqKn/KKCnKys8gIL6Hs2rkDm4tLKS4po0+vbgB06xJqq89rb33I629/CNQsW3z1tdcwPaEZgV69ejFy5CHMm/cVK1asiD5v0KBBDB58AJ988inr16+Pto8YMYI+fXrz3nvvU15eHm0/+uhf0LFjR2bMeCPmA+iYMSeQnp7BK6+8EtOvM888k8rKbbzzzsxom+n10v/wUVSUlrJy4UIAlgGZWZkcPvow1q1ax+IFS6LHF7TN58BRQ1m8eAmLFi2Ktu/2mIbsR5/uHXnvk/mUV1TWjGnkAXRsl8+M92fHBLcxRw8nPS2FV2Z+FjumEw6ncns178z6Mtrm85qMHXMERZtKmTXn22h7m6x0TjxmBD+uLmLuN99H2zu0zeWYQ4eweNkqFn3/U82YunVg5IH9mLdoBStWz975mFrwffL5vIwdO5aioiJmzfq4Zkxt2nDiiWP48ceVzJ07t2ZMHTpwzDFHN/190pj2aExlmzfUO6YffljO/Fpjate+PaOOOIrFixax7Lua/8/ad+5Or0HD+GHx12xctyra3rFnP7r06s/Sr2dTXrwx2t5n4FA6du3J17NnUbl1S8334ODDyCtsz38/nhnzj8VBh48mJTWdLz58M2ZMo0afTHVVJV999mG0zfR6OexXp1BavJFF8z6PtqdnZnPwEb9iw7pVLFs0P9qeW9COA4YfzuoVS1m1/LuYMe13wEEsX7KAorU/Rdu79e5P974DWPL1HEo3b4i29x00jA5demhMGpPGpDFpTBrTPj+mRPtsNG7cuezICASq3TqtLeilV99hy5atXHnxWbiuyzGnXMK7r04hxe+ntGwL4y6/mZkvTwZg0hPP0btHF5avXEOv7l04bcwxlJZt4bwrbuadf0xu9HUsy+LwEy7koxlP4w0n8ESYHdm4JUCV5WAaBuVWGTgQtB265PjBCO0O2NjMXEFq/p79BqBiDXi8yTUzF6zGyejc8Jh2aN+XZrE0pviMySW8k6dhYBgm1YEAAdsNbf5ih9pdw0MwGFoBEBmuxxP6LaFtBcM7foaud5/Xi2EY+s2nxqQxaUwak8akMSXwmKpth/wMHznp3oT6bJQQM3OF+bks/m45AJuKS/H5fKT4/QC0yc6kYus2tm6rJDMjnTVrizjkoAMoL9/KmnWhFLt6XREFebm7/Hp+vy8a5iJ2/Hpn7T5f3W9c5Ny72m4YBn6/B6/PxYuD6THAAss1aJeTis8fW47A4wmFq9os144uA9vVvkfbfV7w1Bzja+B4v2/X240G2j0eD35P3fujTI8nOksa0256MM267V7ThPou2ji8TzvyeDz1tjf0fuzx+7QDjSmxxpTmT623HULttTd9CS0B9ROw3FDZB5vwfX/gmmbMfX9Byw3f9xf65Umk2Lvjung8Hrz1/H9T388ICP9j18BYqa+9gbE21O5t4P3bnXZDY9KY0Jga6uPutmtMGhNoTA31cXfbI2OyDQefz4cv/Dk30T4bxZxzp0c0s+FDB/GX51+jqqqaBd8u5dDhQ5j26kwKC3L51S8OZeTBg1mwaCkHDurHmnXrGXpAf9oX5nP/Y3/Fth0WfPsdhw4fEu9utwjHdfF6PGT4614EIpJ86m76Aun+ho93XTd631+k5p9lh/4EHRcrvPunQ02xd9clVOdPxd5FRET2eXEPc7k52Vx4zilcfM2dZGWkM+HWq3lx+tvRLcevvWwcdzwwmaf+9gpX/HYsGelp9OnVjcNHDuP8K26hfbt87rn5qnh3u0UELJfOOTtP3CKydzIMA9MgNB+3i7/Ticz6NVTs3XGc0OxgpNi76v2JiIjsteJ+z1y8RO6Z+2zmcw1OabaGovIAVUEHw4Di7Zvolrfr9fIs16ZdRts9e+Etq2OWWSYFx4Lsrq3dC5Gk5kRm/5yaYu+Ws2O9P+rU+6stEv5MzfyJiMg+oNpyKMgM3TOX6BK/h3upKsulIEOzciLSsiIzcNGln7tQ7L12yQc7HPqC4Zk/23awCS/7dHYo9A6YWvIpIiISNwpzrcBxXdJ99W/gICLSmmov/fSZ0Fix9x2Dn2U7BGst+bRtJ7QctE6R91AEjGz0ogLvIiIie0ZhrhVUWy6dclMoq27tnoiI7Lk6wa+RWb/aO31GlnsGbJegXWujl/B9fk7t+/yotcmLgp+IiEgMhblWkJVikuL1gMKciOwj6uz0uavBzwmVdLBsl0B4p0/bcXe4x8/F2GF3TzMc/LS5i4iI7M0U5uIszechPVPLK0VEGrJj8EtrZKln7bIOjhO6ty8S/EJ1/dzoY5EdPUNV/Yju5hm5r1DBT0REko3CXJy1SYJdcUREkoXHMPCY4GU3gl844FnhZZ6hP5H7+2ot9TTACO/uqXIOIiKSiJQsRERknxANfubOg1jk3r7IzF7QCs30Rco5hGb7QsfgghvZ0tMIbRkTCX6mR6FPRERajsKciIjIDjweIzTHFwl+/oaPjQQ+2wnN/gWs0ExfNPjRcCkHjwGmSjmIiMgeUpgTERFpglDwi5RygPRGgp/tuE0r5aDgJyIitSjMiYiIxInpMXa5lIPjRu7vCwW9oANBKzzjFynlEA5+EJn1Uw0/EZF9icKciIhIgonW8NuDUg6W40Q3donU8NuxlENksadKOYiIJDeFORERkSRWp4ZfIzt6uuElntFSDo6DZTVeygHDwHHd0L19KuUgIpJQFOZERET2EYZh4N3dUg5uqFB7TCkHx4ne/xcJfpGi7SrlICISPwpzIiIiUseONfwas2Mph1Dh9sZLORjhv1XKQURkzynMiYiISJPUKeXQiEioi8zsBSwXy3EIWGA7DpYbLuUQCX61Xyc842dqR08REUBhTkREROIoEvx84eC3q6Uc7HDR9mDtUg40XMPPVCkHEdkHKMyJiIhIQoop5bCTjV0cF9XwE5F9jsKciIiIJLVoKYddrOFXc3+faviJSHJTmBMREZF9Rp1SDrsR/Cy78Rp+EJn1q6nhp+AnIi1JYU5ERESkHnsS/GynVg0/O1zDz66p4Ve7eLthGNGSDireLiJ7QmFOREREpIkiwc/r2b0afo4T2tQlGvwaKd7uukRr96l4u4iAwpyIiIhIXO1Yw2+Xgl+tGn7R4u3RjV1qFW8nXMMPFW8X2RcozImIiIgkqGjw240afrHF2yP3+NUEP9shtng7scFPxdtFkofCnIiIiMheQMXbRfY9CnMiIiIi+5jdKd4emelT8XaRxKMwJyIiIiINCgU/FW8XSUQKcyIiIiLSZLtbvN1xIxu7qHi7yJ6Ka5grK6/g9olPUFJazvGjD2PcGWNiHi/auJkHH3+WjZtK6NypHXf/4UpSU1OY8PBUFny7lMyMNACeeOhWsrMy4tl1EREREWkm0eC3B8XbbduptbGLirfLvi2uYe7ZaTM4ctRBnPLrX3DB+Ns4YuQwunbuEH3864XfcfWl59CjWyduve/PvPPBp5x+0mgAbrnuEg4aMiCe3RURERGRVtZcxdst242WeFDxdtlbxDXMzf7yG046/hd4vV4G9e/DnHkLY8Lcr0cfHv3vQfv3YdPmkujXOdlZ8eyqiIiIiCQZFW+XfU1cw1xJaTmdO7YDoGvnDmwuLmvw2Pnf/I9TTzg6+vWfn/47GzaV8KtfjOSic06p93+a1976kNff/hAI/WZGRERERKQ+e1S83Q3N7sUUb3ecaImHaPH28ExfTQ0/BT9pGS0W5p77+5vM+WphTNv2qurQbzUAx3UwGihKOXf+Iiq2buPQ4UMAOH/siaSnp2HbNuNvvI8hA/dj6OD96zzv9JNGR5dlWpbF4Sdc2HwDEhEREZF90o7BrzEq3i7x1GJh7sJzTubCc06OaTvjoutZ+/MGevfsypq1RfTu2bXO81avXc//TZ3GoxNviv7moluXjtHHR404kJ/WrK83zImIiIiItKY9Kd4eCX6R4u1BO1TSocHi7UaoSISKt0vD88ktYNSIA1mwaCmWZbH4u+WMPHgwpWVbuP72h7Fsm/ItW7n13j9zy3WX0LYgD4DSsi28P2s2rutSVl7BwiXfs1/v7vHstoiIiIhIs/N4DHymQYrPQ7rfJCfdS0Gmnw5t/HTJS6VHfio9C9Po0zaNXoWp9ChIoWteCp1z/BRk+shK9eA1Pbiui+W6BG2HqqDD9mDN39uDDtVW6H5AR7ch7XXies/cReecwu0Tn+CfM2cx5tgj6NyxHes3bGbVmp+xghZ/fvrvbCou4eEnnse2bTIz03n0vptY+sOP/OP1f1FWXsHYU49lQL9e8ey2iIiIiEirii3eDun+ho+N3MPXYPF2QrOBkXv8QvN6Kt6ejIxAoHqvjOiRe+Y+m/kcXm9i1kbfsG0jXsPc5eMt16ZdRts9e7Etq8GTmN+HBjkWZNddiisiIiIiTRcp3u64LpZTU7zdsh0CVt3i7ZHQsLcXb6+2HAoyfeSkJ/5n58TvoYiIiIiINLto8fbIjF8Ti7dHdvRU8fb4UZgTEREREZFGqXh7YlKYExERERGRZtOk4u2Og2XtvHi747qYhrHP1/BTmBMRERERkVah4u1NozAnIiIiIiIJb7eKt4d389yT4u22kzz7QyrMiYiIiIjIXiUS/Pa0eHtGSlzLce8xhTkREREREdlnhWr4EQ1+jdXwSzTJETlFREREREQkhsKciIiIiIhIElKYExERERERSUIKcyIiIiIiIklIYU5ERERERCQJKcyJiIiIiIgkIYU5ERERERGRJKQwJyIiIiIikoQU5kRERERERJKQwpyIiIiIiEgSUpgTERERERFJQt7W7kBLcV0XAMuyWrknDbMsG4zdON6193w8lg2e3XixRODYkMDvn4iIiIhIPJmmiWHUfKbfa8OcbdsA/OLkS1q5JyIiIiIiIk332czn8HprIpwRCFS7rdifFuM4DoFAoE56bW3jLr+Zl566v7W7IXsZXVfSEnRdSXPTNSUtQdeVtIREva72mZk5j8dDampqa3ejDsMwYtK0SHPQdSUtQdeVNDddU9ISdF1JS0iW60oboIiIiIiIiCQhhbk4+82Jo1u7C7IX0nUlLUHXlTQ3XVPSEnRdSUtIlutqr71nTkREREREZG+mmTkREREREZEkpDAnIiIiIiKShBTmREREREREklDi77e5F/nnv2bx6psfkJmRzoSbx9O2ML+1uyRJ6h9vvMvfX53JWacdz7lnnEBZeQW3T3yCktJyjh99GOPOGNPaXZQksqViGw88/gxr1hbRJjuTe24ej8fj0TUlTbJxcwmPTH6eNWuL8Pm93HHj5eTn5ui6kmaxvmgTZ116E4/eeyM9u3fRdSVNMur48+jVvQsAgwfux/hLzuaeh6awas16Dh46kGsuOzeh6lbXppm5OCkpLefF6W/zzON3c/pJo5n8zPTW7pIksaGD+jF82KDo189Om8GRow7i+Sfv5d1/f87qtetbsXeSbBZ/9wNnnPwrXnxqIvv16c6012bqmpImMwyDS8/7DX9/+kHG/OpIpr2q60qaz+RnXqZLp/aA/g2UpivMz+OFKRN5YcpErh9/ATPe+Tcd2hfy0tT7+Wn1OuZ9vbi1u9gghbk4mTt/EX17dSc1NYUhg/oxZ943rd0lSWL79elBh3YF0a9nf/kNQwb1w+v1Mqh/H+bMW9iKvZNkc+jwIRw4qB8Ag/bvw6bNpbqmpMkK83Pp3bMrpWVbWPtzEX17ddd1Jc3im0VLcRyH/Xp3B/RvoDRdmzaZMV9/Eb6mDMNgyKB+zE7ga0phLk6KS8ro2jn0G6SCvBxsx6GqOtDKvZK9RUlpOZ07tgOga+cObC4ua90OSdKa/83/OGBAX11T0iwWLlnGiWdfxcpVP3PGyb/SdSVNZtsOTz47nasvPSfaputKmqq4pIxLr72bS6+9i4VLllFcUka3zh0A6Na5A5uLS1u5hw1TmIsXA1y3pqSf67gk6NJbSUKGYUD4+nJcB8Oji0t234qf1jBvwRJOPO5IXVPSLAYP6MvHbz3L4IF9uf/Rp3VdSZPN/PBThg8dSIf2hdE2XVfSVPfddg1PPHQzp580mrsefBIDA8eJXFMungS+phTm4qQwP5fV64oA2FRcis/nI8Xvb+Veyd4iL7cNa3/eAMCatUUU5ue2co8k2ZSWbeHOB57k3luvJsXv1zUlzcbn83LmKccye95CXVfSZJ98MY/P/7uAS665k9lffsOkJ56jcnuVritpksED+pLi9zP6qJFs3VpJQX4ua9aF7r1cs7aIgrzEvaYU5uJk+NBB/LBiFVVV1Sz4dimHDh/S2l2SvcioEQeyYNFSLMti8XfLGXnw4NbukiSRQCDILRMe59Lzf0PvHqHdvHRNSVPNmPkR3/+wEtd1+fjzeXTr0lHXlTTZIxNu5LnJ9/LXx+/m0OFDuPGqCxl76nG6rmSPfTF3AWvCEy7zF/6PtgV5jBoxhAXfLsV1Xb5ZvJRDRwxp3U42wggEqt2dHybN4e33P+HlN94lKyOdCbderd8cyR7ZVFzK9bdNori0HI9h0K1rR+679XfcPvEJikvKGHPsEZz9m1+3djcliTzz0gymvfoO3bt2xLJsAB6590YmTJqqa0r22E+rf+bRKS9QtLGYjPRUbr/hcvJy2+hnlTSbCQ9P5YTRh9OrR1ddV7LHVq5ax+NTX2LjphJ8fi+3/P5SunftyD0PPcVPq39mxEEHcPWlZydsaQKFORERERERkSSkZZYiIiIiIiJJSGFOREREREQkCSnMiYiIiIiIJCGFORERERERkSSkMCciIiIiIpKEFOZERERERESSkMKciIiIiIhIElKYExERSTALlyzjk9lfNes5P5n9FQuXLGvWc4qISOtSmBMRkYRy6vnXMvbiGxh78Y2cMu4annzmZRzHadI5//ri6zw65cVm6mHTrS/axJU33tvg48//40369uwGwMhjx1GxdVuTX7NPz6688PKbTT6PiIgkDoU5ERFJOBNuuZrpz0zihSkTmb/wO96fNbu1uxQ33/+wkhS/nw7tC5v1vB3bt8Xv87NsxapmPa+IiLQeb2t3QEREpCHZWRkMHrgfq9etB2Dxd8v505MvsK1yOx3aFXDHjZeTl9uGK2+8l+N/eThvvfsxvzzyEMaeelyD53Rdl+dffot3//05ruty/C8P46JzTsGyLB78v7/x1TdLKCkpJyXFR/++PXn8/j/GPPflN97lrff+g8/r5aAhA/jdZeeydVslj055kaXLVmJ4DM469TjGHHskAFOff5X3/v05fr+PE489il8edQhX//F+SkrLOf+KW/jtuady1GEHR19j4ZJlHDx0YEyfX3j5bRYs+o7yLVu55LzTOPboUawv2sTvbn6AQ4cPYdH/lrG9qprfX3E+w4cO5KfV67j7oafYVrmdnDZZ3P3H8XRoV8DBBw5g4eLv6durW3O+TSIi0koU5kREJGFt2FjMF3O/5rorL6Bi6zYm/ulpHr3vJtq1zWfGzI94/uU3+f0V5wMw8/1PmPzQrfj9vkbP+cHHc1i15memTb0f1yUUiA4ezKq16/lu2Y+8+uzDlJSWM+7yW3jwzt/HPPfD/8zh3X9/zlOP3EF2VgYlpeUA/N9fppGelspLU++nrLyCS6+9iy6d2tO9ayee+/ub/Gv6k2Skp1FesZXC/Fxu+f0l/PWlN3hy0m11+rdq7XqOGDkspm1A/16Mv+QsVq5ax4VX3caIYQcAULRxM6OPGsnvrziP2V9+w4RJTzHjpcd5452PGNi/N9ePv4D1GzbTrjAPgI4d2vLF3AV79maIiEjCUZgTEZGEc/vEP+Pz+UhLTeH8sScxYtgg5sxbyIbNxdx45yMA2LZDj26dos8589TjokHuhjseYeOmYgCefWJCzLk/mzOfJd+v4LdX3wFA5faqcODJp6qqmsrt1ZSWV2DbNobHiHnup7Pn85sTR9MmOxOA/LwcAD6fs4C/PHYnhmGQm5PN6KNG8vl/F3DAgL4ce/Sh3PXgk5x7+gl1Ztzqs75oUzR8RQwbvD8APbp1om1BHstXrqZT+7akpqQwsH9vAA4+cCAV2yrZsLGYY44YwQOPP8MzL83gtDHH4PGE7qpoV5jPuvUbd9oHERFJDgpzIiKScCbccnWdpYCu69K5Yzuen3xfvc8xzZrbwB++5/oGz+26LmefdjxnnnJsTHswaJGRkcb1t08iGLS4+4/jSfH7Y45xXBcjNt/VzwDDAMMwuOsPV7LipzU8/cLrTP/nezwy4cZGn5qbk01ZeUWDj3u9JmmpKXXaTdODgUFaagqDB+7Hc5Pv5f2PvuCC8bdy1x+uZOgB/SnbUkFeTvYuDEBERJKBNkAREZGkMKBfbzZsLGbWZ18CsK1yO6VlW3bpuYZh4LouAIcdMpRX/vk+xSVlAPxcFJqpWrx0Obltsnn6sbt4bvK9HHbIgXXOM2r4EGbMnMXWbZUArFlXFDrnyAN59c33cV2XsvIKPvx4DqMOGUr5lgqW/7iaXt27cMVFZzJ3/mIsy6J9uwI2birBtuvu0tm1cwd+LtoU0xZ5nS+/XkxlZRW9enQFIBAMsn7DZgDeef8TunXpQG5ONt8uWYaBwYnHHcWQgfvx9cL/RcfapXOHXfqeiYhI4tPMnIiIJIU22ZlMuvt6Hp/6Es+8+AYpKT7GX3w2w4bsv9PnHnhAfyb+6WnOPf0EjjtmFJuKS7jyxntJ8fspLMjjvluvpme3zvzv+x8565Kb8Pu8FBbkMfLgwZx+0ujoeX49+nCKNhZz8e/uIDU1hUH9+3L9+PP53f87lz89+QLjLrsZw2Nw4dknM3hAX9YXbeLpF15n/cbNbNtWyXVXnIfX66Vj+7b06t6FsRffwG/PPZVfjz48+hq9e3Thy68XRduyMtN576MveOj//gbAxNt/R2pKaMbQMAymPvcKK1auJSM9lXtuHo9hGPzw4yoenfIildu3U5ifxzWXjQNg2fKfGD50ULO9JyIi0rqMQKDabe1OiIiItLZnp83A7/cx7owxOI7Dh//5L49PfYl/TX8yrv2wbYdLr72LJx66hfS01AaPW1+0ifOvvJUP3/jLLp23cnsVV900kacfuytmSaqIiCQvzcyJiIgAI4YNYsqzr/DBx3MIBoPk5bRh4m2/i3s/TNPDqWOO4aNP53JiuLxBc/jo07mcNuYYBTkRkb2IZuZEREQSjGXbGBjNGrxs28HFxWuazXZOERFpXZqZExERSTAtEbg0IycisvfRT3YREREREZEkpDAnIiIiIiKShP4/nIoGjkAN98YAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3MAAAF+CAYAAAAoSEONAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAoQZJREFUeJzs3Xd4FFUXx/HvzPbd9ErovffeREABBQWxF0RFQRFRUEBERQREUGxYKBYQREXsyqtiV1RABJHeO4T0ns22ef/YzSZLCqEkEDif54kmOzszd5MY88u59x7F4cjTEEIIIYQQQghRqajnegBCCCGEEEIIIU6dhDkhhBBCCCGEqIQkzAkhhBBCCCFEJSRhTpz3EpJSzvUQhBAlyMrOISfXfq6HIYQQQlyUJMydZx54dAZ/rNlQ4vH5i5Yzf9Hyk16nrM+rKJqm8dychVw+eDiTpr1S5vP+27KTVxe8f0b37tJvCDv3HADgjzUbeODRGSU+d/Zr7/LS3CWndZ+TXbs8VcTX+60ln/DolJfO+DqFvx4rVv7G0JGTzviapyIxOZVbhz9KYnJqhd73QrXy579Y/sXKcz0MIYQQ4qJUacPcxi07GTX+Gfpdfx833T2eRe9/gcvtPu3rHYtPZPDQMWdvgKfptVmT6Napjf/jLv2GBBy/984buPfOG056nROfd//46azfuPXsDfQkBg8dw7H4RP/Hew8c5rMVP/Lmy1OYOumBMl9nyUdfce3Vl5+1cXXr1IbXZp2d8HDi5/RsXvtUlfX74mL01pJPeGvJJ/6PoyPDef/NWURHhp/DUZ26E19HWVTEz7V+vbvy9Xe/Ys9zlOt9hBBCCFFUpQxzq9f9x/jJLzB4wGV88d4rvDrrMXLsduz2vHM9NFGC9PRMbFYLdWpVQ6/Tlemc/QePcDQ+kdbNG5Xz6IQQp8tmtdCxbXO++eH3cz0UIYQQ4qKjP9cDOFWapvHS3MXcd9eNXN6zMwBms4n7h93kf05iciovvbGYdf9uJSw0mDtuHsiAvj0AOHDoKNNfeJO9+w9RrWoso4ffgkGv56FJs3A4nPQedDfdOrVhWqHqkdvt4cW5i/n+578wm41ccVl3Rt51I4qi8M+/W5nz5lKOxSfSpmUTHhtzD2GhwaxY+Rur1/1H4wZ1+GzFj9jz8njk/jvodUlHAL785mfefu8z7HkO2rduyoQH7yI0JJi7HniS6wf2oW2rptwyfAIAvQfdTb06NXjz5SnMWfA+6RmZTBo7nGuGPMiUR++nXeumAGzZvoeJT7/E5+/N4fW3PyQ9I5Mnx93LLcMnsP/gUcY+8Tw6VeW15yYxctx0/vfh69hsVgCWLl/Btp17mf746DJ/LXbtOcALr7/Lnv2HaVS/NpMevoeqVWLoPehucu153DLiUYKDbEx7bBRjn3je//l9bOw9NKxXq8jXoUOb5gHX/2vdf7Rp0QRFUfjr7408N+cdPl38MoqiAPD8qwuxWS2MHHYTn339I1+v/JWDh+OpWT2OyePvo3bNqkXGvGr1Bl54410+W/wy4K1czJrzDlu276F+3ZoY9Hrq1KoGgMPh5INPv+GHX1Zz7HgiTRrW5akJ9xEVGV7kc/rF0jls3Lwz4NqlfR+e7PujJJu27uK5OQs5ejyB+nVq8vD9Q2lUv7b/++LJcfcC8M0Pq3hz8SfEJyShaRpmk4khN15F/8u7M3zsFB5/eARvLv6YQ0eOM3hAb+6/+2YADh2J5+33PmXj5h3k2vO49qrLGXHH9aWOafDQMf7XDN7/Rsv69ThRZlY2r775Pqv+2oDJbOS6qy7nluv6o9N5/+60dv1m5i1cxsHD8dStXZ1JY4dTu2ZVfvxtDR99/h37DhwmMiKMx8bcQ8tmDZn5ytt8/e2vKKrC+x//j6cfG0W7Vk257Jp7+PTdl4irEk2ew8GCdz9m5c9/Ad5K0/Ch12EyGjkWn1jq5yvftNnzGdDnEtq2aup/zOl0sfD9z/nmh9/Jy3Nyabf2jHvgTnQ6lT/WbGDewuXEJyTRtFFdxo4c6v/8FPezYe7Cj4q8jks6t/Xf61R+rv29YTPvffQ1O3bvx2qxMOa+IfTo2s7/9Z/1yjts2roLh9OJXq8jLjaaj96ZTVp6Ji++sZg1/2wiIjyEsSOH0rGt97/Ztq2asvLnPxk84LKTfo2FEEIIcfZUuspcSmo6Bw/Hc1mP4n/pdbs9PDrlRSIjwvhy6RymPjaK19/+0L8Obf67H1OnVlX+99EbTJ04ipioCFq3aMxL08dTJTaKn754OyDIAaxet5Gff1/Le/Of5YM3n6Nj2+YoisLho8eZOPVlRt19C/9b9gZ1a1Xn9bc/9J/3yx9/o9freG/+TK67ug8vz3sPgOzsHGbNeYfHHxnBig9fY+CVvfyhKl9cbBQfLJgFwE9fvM2bL08JOK7TqfTu0YmfV/1dcL9Vf9O7R0f/L775PnjzOarERvHS9PH89MXbNG1Uj6aN6vHLn+v8z/ntr3+4/NLOZfkSAJCRmc1Dk2YxqH9vvlk+l8t7dmbGS2/5xwvwwYJZfPX+q/7Pb5DNyk9fvE2fnl2K/TqcaOfuA1StEg1AhzbNyLXnsX3XPgA8Hg+//rmOyy7tjKIoaGg8NWEk33w0lzq1qvHqmydfZ+d2e3j06ZeIi43my/fnMPGhYaSmZfiP63Q6jEYDz099mK8/fB0NjUUffFns5zQ4yFb02qV8H0LJ3x+leWnuYi7t1o5vP5rHmPuGEBEeWuQ5+w8e5ZkX32TSw/fw5dI5NG1Uj3EP3MHdQwYDkJySzo+/reHF6ROYPfURlnz0NYeOxANgt+fRvVNbli6YxbwXnmTxh1+ybefek46rsNP9egDMePEtMjKz+WjhbF6d+Rhfffcrn634EYDdew8yYcqLDLnxar5dPpeRw24iKjIMgLw8Bw/fP5T/LXuDnt07MOuVdwCY+NDd9LusG3fcPJCfvng7IADlm79wOZu27mLRa9NY9No0Nm3dxYJ3P/YfL+3zVZo3F3/MqtXreXXWJD5d/BK9LvH+t7lj934mP/s6Dwy/hRUfvk6Hts0Z+/gscu32En82nOx1nMrPteycXO669Rq+ev817rxlINNfWIDD4QRg+gsLqFk9jq8/fI3hQ6+jRdMGfPTObDRN46mZrxMcZOXL9+cwZcJIps2eT1Z2DgBVq0T710EKIYQQouJUujAXn5CMwaAnJDio2OM7du9j/8GjjLrnFsxmE40b1OHGQf349GvvL4Sx0REcPHSMlJR0atesSq0aJ68WREWGk5ubx+69B7FazLRv3QzwVle6dWpNx7bN0ev13HztFaz+e6P/vNo1qnHT4Cswm4x07dCKhKQU7PY8jEYjYaEhbN2+B5fbQ6d2Lco89bCwvr268Ouf6/B4PGiaxi9//M3ll3Yp07lX9evByp/+BCAlLZ09+w7RuUOrMt/7l1VrqVGtClde3h29TsegK3uxY9d+8hxlWzdTlq9DekYmcbFRAOj1enpf0olffOF107bd2KwWGtarBcB1V/ehapUY9h44TEiwjZ279590DNt37eXQkeM8dO9tWMxmatWoSpNGdfzHdTqVW669krCQYPbsO0hURBg7ynBdOPn3IZT8/VGamOhI9uw7TGZWNk0a1i123df+g0eoFhdD+9bNiIoMp0fXdmzbuS/gOQ+OuI2w0GBaNG2AzWrxh5MG9Wpxec/O5OTkEp+QTHh4aLGv+a0ln9Dn2hH0uXYExxOS/e9/9d2vwOl9PVLTMvjlj78Ze9/tBNmsVK8ay7DbruEz3+fs8//9TK/uHeh9SUf0ej1tWjQmyPdHkP59LqF+nZocOHwMm8XC3gOH/QGlNB6Ph8//9xP3D7uJyIgwIiPCuP/um/l8xU9omlbq5+vg4WP+173y5z8ZN/kF+lw7gtGPPovH4+GTr39g9IhbqV41FrPZ5K9iffntL/Tu0YlO7VpgNBq47foBGAwG/vr7v9P+2XAqP9d6dutAq+aNOHY8Eb1eT2ZWNvEJSQDs3neQ/n0uITjIxsArerLd931z+Ohx1v+3jQeG34LJaKRRgzo0ql+bLdv3ABAXG01aWuZJxymEEEKIs6vSTbOsEhOJ0+kiIzOL0JDgIsePxicSHRWO2WT0P1a9Wiwrf/YGl5F33cQX3/zMqAkzaNmsAffddSNVYqJKvWej+rV5ecYE3ln6GW+8s4x777yBSzq35cixBH79Yx1/rBkBeKeXFf4F0DcbEMAfPp0uF2azibdensKiD77gpmHjuPGaftxy3ZWo6qll66aN6mE06NmyfQ8WswmXy0XzJvXLdG7vSzryyrz3SE5J48+/N9K1Y+uAzxnAlFlv8Nuf/wBw2w1X+Ss7AEeOJbB1xx76XDvC/5jD4SQjM5voyMDrFKcsXwePx4NeX/CL7OU9OzPrlbe5764b+WXVWi7r0dk/5fKDT79h+ecrqVm9ClGR4WXajOFYfBIx0RGYzaZij3s8HuYt/Ijvf/mLhvVqo9Op5OWVbV3myb4PoZTvD4ofD8CT4+7lo8+/484HnuCSLu0YMfR6QkMC/7DRvEl9kpJT+evvjdSpVY2ff1/Ljdf0C3hO/r1VVSU42IbT5QK8006fefFNEpNTadeqKSajAbu96Ofyntuv457brwOKTrOE0/t6HI1PxGDQExNdUKWtXrUKR30b6RyNT6Bls4bFnvvdT3/w1pJPiY4Kp36dmgDkORwYjYZS75mWkUmuPY/qVWP9j9WoFktOrp209IJwUtznq2b1OL7/dAFQdJplSlo6OTl2atesVuSex+ITaVVoHaiiKFSvGsvR+AQMBv1p/Ww4lZ9ra//ZxCsLlmI2mWjvm6Kd//Xp1LYFX377MzWqxfLp1z/StFE9wPu1cbs9DLz1Qf91nC4X/Xp3BcCg1+HxeEodoxBCCCHOvkoX5iLCQ6kWF8OPv64pdpfDqlWiSUxKJc/hwGT0/iJ9+Ohx4nzT9YxGAzcM6svgAb157a0PmfHiW8yZOREUBc2jFblevlbNG/HKsxPZtHUXDzw6gw/fep642Cj69u7K4w8PP+XXEVclmsfG3kNCUgqjH51BVGQY/Xp3C3yS7zdIj8dT7C9ziqJw+aWd+e3Pf7BYTP4ph8VRUPAUCpoWs5nel3Tip9/Xsn7jNq64vFuRc6Y8en+p42/VvFGpuzcWvt+JSvw6FBISbCM+Idn/cevmjcjJzWP/waP8/td6npvyMOBdR/bOe5+x7O3niQgPZf3Grfz6xzpOJiIilOSUNFwuF3p90f8Ufvh1NT+v+pulC2ZhtZhZsfI3ln32rf/4iZ/Twk72fXi6bFYLd916DbdceyXTX1jAG29/yGNj7wl8XeGhNGlYl/mLlpOUkkrfnl254rKiX9/izJrzDk0b1/OvQb1//PRTHuPpfj2qVonG6XSRmJRCTHQk4P2c5U+1rRITxeFipjcmJKUw9fl5LJ0/k9o1q3EsPjFgq3wF8JTw33ZYSDAWs4kjxxKI8lU5Dx85jtViJiw0mPjT3FQpLCQYs8nEoSPxRaqncVWiOXLsuP9jTdM4cuw4V/W71H+8uJ8Npb2Osv5cczpdTJz6MjOefIjO7VsCsHjZV/7j3Tq1YdEHX3DriInUqVmNiWPu9o4pNgqj0cDXH77m/34u7NjxJEJCip8tIYQQQojyU+mmWSqKwpj7bmfeoo/44dfV2PMcJKekMfu1d9m2cy+N6tehds2qvPH2h9jzHOzcc4DlX6xk8IDLcLndLF72JUfjE3B7PBj0ehy+aYGR4aEkJKVw8PCxIlMFf1n1N2v+2YTT6UKv1+F2e3C5XAzo24Offl/DL6v+xuV2s3vvwTKtG9m7/zCf/+8nsnNy0akqoJBXzJSw0JAgdKrKun+3ljh9sU/PLvy+ej1/rv231DVvkRGh/LNxKw6HE7fb+xf0q6+4lJU//8nWHXv8v9iVVc9uHdi77zCffPU9TqeLQ0fi2bR1V+D9/t1S7LhL+zoUVqdWdY7GJ/g/VlWVyy/txNLlX2MyGalbuzrgra64XG6cThcpqel8tuKngOsYDYZip9w1a1wPq9XMog++wOFw8t+Wnaxe95//eHpGFi6XC5fLzZFjCXzzw6qA84v7nOYr7fuwLJ5/dWHAlEyAnFw77374JckpaXg0Db1eh8NZ9HXtPXCEg0eO8frzj/P1B6/z4L23lbnqm5aeidPpxOFw8vvq9ezee9B/zGg0lGka7al8PbzXdKJpGuFhIfTs1oGX571HdnYOR44lsPD9z7lmQG/AOzX4+19X89uf/+Byudi4ZSe79x0iIzMbj0fDnucgMyubDwsFboCIiDA2b9uN3Z5X5PtAVVWu6d+bN95ZRkpqOilp6cx9ZxmD+vcu8Q8jZaGqKldfcSmvLnifY8eTsNvz+PbHVbjcbgZe0ZMff13D3xs243S6+OCTb3A4nHTp0LLUnw0lvY5T+bmW53CQa8/DnpdHrt3Oe8u/Dhj38i9WMuqem/n6g9d47blJ/opljWpVaN64Ps/PWUhmVjYpaen8VWhK+dH4ROrWKlqFFEIIIUT5qnRhDqB75zbMePIhPv5iJQNvfYBRE2YQER7inwo386mxHE9MYeCtD/D49Dncd9eNdO/cBp2qEhoczPjJL9L/xvvZsGkb4x64E4BaNaoy8MqeDBs9mSkz5wbcr0b1Knzwyf8YcPMoHn36JR669zZqVKtCzepxPD/lYRYv+5J+193LEzNeY//BIycdf2REKFu27+Hmu8dz64iJtG7eiCsv617keVaLmWFDBjNp2iuMGv9MsdOY6tWpgaoopGdk0ah+7RLvOey2wXz97a/cOGycvyrQtFE9srNzaduqSbF/bS9NWGgwrzz7KD/+toYrbxzJmEmz/OtnAO6980Zef3sZt983yb9JQr7Svg6FtWvVlG07Ajff6NOzCyu+/z0guHZu15IuHVtx64hHeWzaK/Ts3iHgnKv69eDleUUbgZuMRmZOHsOq1Ru46pZRfPjpN1zWo5P/+BWXdaNaXCzXDh3D868upG+vwPWIxX1O/a+xlO/Dsth/8Ciffv1DwGNGowFN0xg5bjpX3/oAKakZxfaWq1U9DpPRyKDbHqT3oLvpe9293PfwVPYfPHrS+95314389NtarrvzYTb8tz2g52Hn9q3Yf/Aoq1YHNrU/cYrlqXw9WrdoDGh88pX3tU56+B6sVgvX3/UID0x4hv59unPtVd4KfNNG9Zj62Cjmv7ucK24YybyFH4GmUa92da4f2IdR45/hgUdn0LZVE4yGgumVg/v3JjUtg2tufyhgw6B89951A80a12fo/ZMYOnISTRrV4947S9/B80RPjrs3YCdLgPvvvplWzRsxfMxTXH/Xw2zetgeX00Wj+rV5euIoXp73HlfeOJK//t7IS888isVsLvVnQ0mv41R+rgXZrIwcdiPTZy9g2OjJBNts1KxexX+tbp3a8PSsefQedA+XXXMPN9z1CJ+t+BFFUZg26QHcHg83DhvH0JGT+On3tTid3um523buLfL6hRBCCFH+FIcjr+S5cOKCpmkadz84meFDr6fLKWx+UlG843uKJx4Z4a/CXSz27D/E6299yIvTx5/yud/8sIrN23cz3vcLfXpGFo8/M4d6taszduTQszxScaHIys7h3oenMu+FJwkOsuF0uvjq2194451l/PDZmyWe53K5uPmeCbz58hTCw0IqcMRCCCGEqJSVOXHmXG43n634CZ1Of8pTLCuKoigMufGqItMNL3SpaRk888IC7h5y7Wmdv3f/YVJS0jkWn0iew8HuvQc5ciyBFk2L3zxECICk5FSSU9LYe+AIDoeTo/EJbN6+m1bNS/+++fXPf+jSoZUEOSGEEOIckMrcRcjj8XDdnQ8TbLPy1KMjqVe7xrkeUoncbg8bNm3zt4O4GDidLhKSUqgWF3Na56dnZPL8q4tYu34TbreHalVjuWlwPwb06XGWRyouJJqmseyz71j+xXckpaQRHhpC985tGXHH9YQE20o8b9+BI9isZv+mNUIIIYSoOBLmhBBCCCGEEKISkmmWQgghhBBCCFEJSZgTQgghhBBCiEpIwpwQQgghhBBCVEKVKsxpmobL5ULTZJmfEEIIIYQQ4uKmP9cDOBVut5tLBtzJ7ysWodefv0NPyU3F6XGW+fkG1UCEJfz0bpYVDx7H6Z17LqlGCKpy8ucJIYQQQgghinX+JqJKzOlxold0p/T80+ZxgFoJv4yVMYAKIYQQQghxHqlU0yyFEEIIIYQQQnhJmBNCCCGEEEKISkjCnBBCCCGEEEJUQhLmhBBCCCGEEKISkjAnhBBCCCGEEJVQuW2DmJGZzcxX3ubQ4XhCQ4KY+tgoIsJD/ccPHz3OlFlvkGvP4/Ybr+KKy7qX11CEEEIIIYQQ4oJTbpW5zdt2ccOgviyZN4NGDWqz9OMVAcdfmf8ed916DQtenMz8RcvJys4pr6EIIYQQQgghxAWn3MJc146tadOiMQAtmjYgMSnVf8zt9rB63X+0bt4Im81KzepxrN+4rbyGIoQQQgghhBAXnArpNv3Pv1tp2ayh/+P0zEzCQoKx2awA1KweR1JyarHnfvzl93zy1fcAaJpW/oMVQgghhBCn7GiaA7vLfdava9brqBpmPOvXFeJCUO4boOzZf4i/N2zh6isu9T+moOApFMw8moaiKsWef/3APnzw5nN88OZzvDfv2fIerhBCCCGEOA12lxuDqp71t7IExGPxidw2YuIZjf+tJZ+wYuVvZ3SNMzFt9nzWb9xa5HGPx8PiZV8ydOQkho6cxOtvfYjb7WHFyt+Y/dq7FTK29Ru38siTsyvkXpXV08/NY+j9j7Nl+24mTn0Zh8NZIfct18pcaloGT818g+mPj8ZkLPiLSmhIEJlZ2WRl5xBks3LocDyd27csz6EIIYQQQghR6Xz0+Up27NrP23OmotfrWL3uP9QSiiDi3EhMTmXj5h18uvglAGZOHlNh9y63MOdwOJk07RWGD72O+nVqALB0+Qqio8Lp26srXTq0YsOm7bRp0ZhDR47RtmWT8hqKEEIIIYS4wOXY7Ux9fh47du2nTq1qPDn+XkxGI6tWb+CNtz/E7XFz163XcMVl3fnupz9Y8O7H6PV6ht02GFVV+OjzlVgtZlat3sCzkx8qcv3jCcmMffw53n9zFonJqQy8dTQfL3qRanEx3P3gU8x8agyqojDjpbeIT0iiSkwUjz88nIjwUKbNnk+j+rX59sdVPDjiNrZs38MnX/2A2WTk4VFD2bXnAD//vpaNm3fQpUMrHhl1h/++yz77hjdfnoLB4P21vUuHVqV+Ht5Z+hkrf/4Lo0HP44+MoFH92tx270Su7teTFSt/w2DQ88qzj/LVt7/icDq585ZBAIwa/wzjR99FSLCNqc/P49jxJBrUrclTE0YGXN/ldjNn/lL++XcrJpORR0bdQbPG9Vix8jfW/LOJjMwsjsYn0r/PJf5rFzemfP/8u5W3lnxCekYW9erU4OmJ96OqKmvXb+a1tz5A82j0u6wrQ264itvvm0SXjq3YumMPr858jK9X/saHn3wDwC3XXclV/S4lOzuHiVNfIT4hiapVonl28hiOHD3OlFlzcblddO3YmofuHeK/v9vtYe7CZfy55l9MJiNPjruXmjXiSnyNO/fsJ/54Mlt37OGe269jUP9eTJo2h+SUNIaNnsw7r06l96C7+emLt3E4nDz93Fy27thDfEIyNapV4fFHRhB/PDHg+69f766n8J0eqNzC3JKPvmbH7v28+8EXvL3kUwCaNqqHonj/kjDm3iFMnvk68xZ+xMhhN2GzWsprKOXOo2nEpzvQqQpGvYrd4cGoV1FV0IH/NQshhBBCiPKRm2tn2G2DqRYXw8SnX+b7n/+ie+e2zF24jLfmPI1ep+O+R6Zx+aWdWbzsK6Y/Ppo6taqTm2snPCyE1ev+o23LJgzo26PY68fGROJ0uUjPyOK/LTtp2awh/23ZSWREGDm5uURHhvPkjNfo2LY5Nw2+guVfrOSV+Ut5euL9APz+13oWvDwFvU7HI5Nn8/HCF/0BrX3rZvy+ej33DLmWtq2a+u+ZnZ2Dx6MRFRleps/Bmn82sXvfId5fMJP4hCReeP1dXpg2nhzfa1w89xnGTX6BP9Zs4NJu7Zkyay533jKIzKxsMjKzqV2zKpOffZ3rBvahe6c2vLP0c375428iC7UX+/KbX0hISuG9+c+yZ/9hJjz1Ih+98zwACYnJvPjMBABuuWcCl1/amSPHEoodU74qsVE89/TDBNms3PfINP7dvIN6tasz48U3ee25SVSLiyEtPROAvQcOccM1fbl/2E3s3X+YRe9/zuI3ngHgzgeepHmT+uw7cASj0cDyhS9wPCEZq8XMl9/+Qv8+l3DLdVcW2adjxfe/cfDQMRbPm0Furh2zyVTqa/xvyy5em/UYBw4fY/KzrzOofy+mTryfcZNf4J1XpwZc++dVa3G53Hy6+GU+/OxbMjOzadWsIc/NeSfg++9MlFuYu3vIYO4eMrjE43FVonnz5SnldfsKpWmQlefBoFPIsrtJzHGg17lBAxRQFdApCnpVxWjAOwdcp6LTgU5ynhBCCCHEGYsMD6N61VgAOrVrwfZd+wkLDSEpOY37Hvb+kp2ZnUNaeib9L7+EOfOXMmzIYDq0aV7kWt//8hdLln0V8NjiuTNo07Ixm7ft4r8tOxl4RU82btlBXGwUzZs0AGDdv1sYc5+36nP5pZ1ZuPRz//mDruyFXqcD4Kq+PZj+wnyGD72exg3qlPiaTnXrvzX/bGLbjj3cOeoJACwWs/9Yp3YtUBSFhvVqkZKaQbW4GNxuF6lpGfzz71a6d2kDwN8bNrPvwBHefPdjHE4X1/TvHRDm1m3YzOU9OqMoCvXr1MBiMXHwcDwA9evWwuq7Z4umDdi15wCbtu0ucUwAVWKi+O3Pdfy1biMJicnEH08iN9dOy2YN/F/P8LAQAAwGA1f38+7D8c/GrXRq19K/oWLn9i1Z9+9WenXvwMIPvmDBux9z87VXAtCzWwdenvceISFBXHl5YG/r1ev+49qrL0ev0xEcZDvpa2zWuD42m5WG9WuTmpZR6tcjIjyUrOwc8hxO0tIy0Pm+/if7/jsVFbKb5cVCr3qTm9mgolOK7i3j8njIywUNt29nTm+S82hucnJz0SkKBr2KUadg0CsYdCp6VUGngirVPSGEEEKIMtHrdZjNRjQ02rVqwownA6dN3nbDAHp0bcecBUv5c+2/AdPuAPr07EKfnl2KXLdtyyZs3rabPfsPMXLYTXzy1fdUrxpL6xaNAO/O6yXNyFJ1Bb8bjh05lB279vHi3CX0vqQjNw2+othzgnxBJSk5tWzVOU3j1usHcMOgviU+RadT/TvE9+jSnj///pd1G7b4gw/AvBefDJg1V3hjlkK/wpZKr9dhMhlPOqZX5r+H2+Ph5sFXYjGb0DTNt1Fi0ZuoihLw+S3uUx0ZEcY7r07l2x9WceeoJ3jtucdo17oprz//OEuXf83wh6bw9pynUVXv10PzFP2aleU16nW6k+6036JJA1LTMhgxZgpV42J4bMw9wMm//05Fue9mKQqoioJBp2DUqZj0Okx6FZNexahX0asqiqKQ5/SQnuvieLqTQ8l29iXb2ZNoZ09CLvuScjmYbCc+3UFKtpMsuwu7y4PTowXsDiqEEEIIcbHJzPZOFXQ6XXzz4x+0b92MZo3r8e+mHew/eATwrnvzeDxs3rabGtWqMOy2wazb4A0qMdERJCSllHqPNi2asG3nXowGA2aTEbPZxIb/tvt7K7dv3Ywffl0NwI+/raF9m6ZFrpHncLBj1z4aNajDTYOv4J9/vfePjY4s9v43XNOXV+YvxeVyoWka3/ywiqzsnGLH16Ftc7785hff9EzPSV9Pz+7t+WvtRg4ejqdhvVoAtGvVlA8/9a5DS0lLJ8/hAEXxB5cObZrx469r0DSNPfsPkZOTS41qVQDvNEuX202Sb0OQpo3qnXRM//y7lWuu7EW1qjHsO3AUgGaN6rFh03aOHU9C0zSOxicUGXvbVk1Yve4/snNyyc7JZfW6/2jXqin7DhwhN9fOgL49qFOrGjv3HGDL9j3YrBbuuf06jhxLIDMrJ+A6X/zvJ9xuD9k5uaSmZZT6Gk/Fhk3badOyMYvnzmDm5DGEhgSV+P13uqQyd57RqQo6FAy64o9rmobd6SE7T8OjgZqdB6obBQVVAVVV0Cug16sYdSpGne+aqoJOkfV7QgghhCgfZr2u3PrMlUVURBjTZ8/n4JF4enZr759WOOnh4Tw+/VV0OpUWTRvw0L1D+OaH33nu1YXk5OQyesStAPTq3pFxk2ezaesuXpg2rtjfmWJjIjl2PJFe3TsC0KxRfX74bTVxsdEAjB15O8+8+CZffPMzsdGRPP7w8CLXyMtzsvTj/7H/4BGcLpe/WtOvdzemzZ7Phv+289jYe/zPv+Xa/ix8/zOGjnwcg1FPp7Yt6NOraNUQvFMNt+/ax12jJ2M2m7hhUF//tMTi1K5Zjf2HjtKxTXP/681/DbeNmEhwkJWnJoykbq3qHDl2nL37DzOwfy/2HjjCkHsfw2QyMG3SaP/av+TUdEZPmEFKWgYPjriNsNDgk47ppsH9ePLZ16leNZaY6AjAOz1x3AN38MgTz2Mw6unZrQN33XpNwNjr1a7BHTcPZMSYpwG4/aarqVOrGhs2bWfGS2+RkZlJzepxdG7fihUrf+X5VxeSlZ3D9QP7EBoS5L/ONf17s+/AEW671/t6x468vdTXeCrq1qrOE8+8yr+bdmAyGalXpwYj77qx2O+/06U4HHmVpqTjcrm4ZMCd/L5iEXr9+ZND3R6NPYl2LAZvoTM5NxGdUrYfPABuzU2kJfq07q3LOgiqIeAxTdNwa96NWdyAooGGhoI30Km+qZtGnXftnlHve0ypwMDncUFIzfK/jxBCCCGEKHcrVv7Gtp37GPfAHSd/8kViwbsf07B+LXp264A9z8H946Yx7LZr6d65zVm7x/mTiMRZoyje6lxpk309Ho0clwc3bjyab86xL9afN4FPCCGEEEKISqpj2+bMX7Scd977DIfTxaVd2520tcSpksrcWXC+VebOFo+m4fGAG63UwGfwBT7TqQQ+qcwJIYQQQghxRs6fRCTOO6qioOpAf5IKX67LQ9ZJKnwBgU9R0KGhK2XHJyGEEEIIIUTpJMyJM1LmwOf2kKV5Ax+A4nHizrP7eu15e/CZDL5pnXoVverduEVaMgghhBBCCFE8CXOi3KmKd6fNgMDnUXEbCjpj5Pfgc3vc+LdrUby9M1Sddw2gQadiMqiY9Irs0CmEEEIIIS56EubEeSG/wmfQFR/MNE0j1+khO8+Nu/B0TgV0qq+655vGadSr0nBdCCGEEEJc8CTMiUrBv0OnWnIwc7k95DkLVfcUBYVC1T3f7pzeRu0KetX7ppZyTSGEEEJcPHbuOcDL85bwxvNP8L/vfwegf59LTvt6u/cdYsaLb2K35xEeFsLYkbdTv25NBg8dw8JXpxEWGny2hi4uUhLmxAXjpNU9j0aO20Om3Y1H85X18G3U4gt75vxm63oVvU7W7QkhhBAXqzMJcfleemMxd906iEu6tGPfgSPIrxTibJMwJy4a+dU9fQmVOM2jkWX34NYKwp6ieIuBOlXBoHr77Zn0+Zu0eAOgrNkTQghxsWv48Bqc7vLpdmXQKex8sVOpzzkWn8iMl96iWlwMf2/YzKD+vTAYDHz1zS/ExkQye+o4dDqVVas38MbbH+L2uLnr1mu44rLuJCQm8/Rz88jMyqZqXIz/mm8t+QSL2cxtNwzgx9/W8OGn35CRmU3Xjq146N4hHItP5NmX36Z61VjWrt9E6xaNeeKREQHjyrXbycrOBaBOrWoBxz756gd+/XMdep3KK89OJDjIxvIvVvLND6vIzMrm2qsu45br+rN+41ZW/vwXqWkZVK8WS91a1VnzzyYyMrM4Gp9I/z6XcOctgwB4Z+lnrPz5L4wGPY8/MoJG9Wufha+AOJ+pJ3+KEBcHRVHQ6xRMehWLQYfFoPordTpFweXxkGn3cDzDyeEUO/uS7exOsLM3MZcDyXaOpDpIynKQYXdhd3pwuTU0rdK0cRRCCCEqte279nHztVey4KWnmLdwOdER4SyeN4OEpBQ2b9tFWnomcxcu4605T7Nk7rN89PlKXC4XL89fSs/uHVg8dwZXXt692GvXq12dV2dNYun8Z/nlj3Uci08EYOuOPdwwqC/vzZ/J73+tJyExOeC80SNu4423P2TS9Dns3X844Fj1qrG8+/p0wsNC+WPNBgDatGjMgpefYtFr01j4/ufkORwAfPvTH9x3142MHn4rAAmJycx48iEWvT6dz77+kcNHj7Pmn03s3neI9xfMZOZTY1jw7vKz+vkV5yepzAlRRiebxll4R05vXc/7T52vzYJep2LWK5j03vfzN2iRyp4QQojK7mSVs4oQExVB7ZpVAYiMCKN9m2bodTrq16lJSmo6mVk5JCWncd/DUwHIzM4hLT2TDf9t46kJ9wEQFxtd7LXjqkTzw6+rWbdhK3l2B/GJyVSJjiQ2OtJfcatdsyopaRnEREf6z2vTojEfvPUcH3/xPfePn87D9w+lb6+uAHRq1wJFUWhYrxYpqRm++0fx+Yqf+G/LDtxuD6lpGf7rFK7s1a9bC6vFDECLpg3YtecAm7btZtuOPdw56gkALL7j4sImYU6Is+SkYc/tId2p4fZ4P/Y1YPD32jPqVUw6BaNewaBT0emUEqeECiGEEKJker0u4H0N7/9327VqwownHwp4rsvlJjc3D5PRWOL1nnjmVRo3qMPdQwaTk5OL5vEUeY5OpxY7IyfIZuXOWwdRr24NFn/4pT/MnXiepmmMmjCDq/pdyugRt7H/4FE0X4NeVS15Mp1er8NkMoKmcev1A7hhUN8SnysuPDLNUogKoirekGY2eN8sBh1mg4pBVVEVhTynh9QcF0cznBxIyWNvop1dCbnsTcrlYLKd+HQHqTkuchxu8lwePB6ZwimEEEKUVbPG9fh30w72HzwCwPEE75TIpo3qsmr1egC279xb7Lnr/9vGDYP6ERIcxOFjx8t0v+ycXOa/u5xcux1N0ziekEyVmKgSn5+ekUV8QhLXDOiN5vGQkpZe4nMTEpNxud0kJaeycfMOmjaqR4e2zfnym1/Izs7B4/GQkJRSpnGKyk0qc0KcJ/IboRdH0zTshfrsgXcvTrXQTpwmf9sF2YlTCCGEOFFEWCiTHh7O49NfRadTadG0AeNH38VD9w5hynNz+fTrH2jfulmx5952/QBGjH2a+nVqUD0utkz3s1rMRIaHcd8j07Db86gSE8WkscNLfH5oSBCX9ejEHSMfp0mjulQr5T7JqemMnjCDlLQMHhxxG2GhwXRu35Ltu/Zx1+jJmM0mbhjUl6v7XVqmsYrKS3E48irNn/ddLheXDLiT31csQq8/f3Ko26OxJ9GOxeAtdCbnJqJTdCc5q9D5mptIS/FztE9Gl3UQVMNpnXtOeZy4g2qe61FcMDTNO33TrWkFO3ECqlqwE6fJ4G2obpT1ekIIIUSltWLlb2zbuY9xD9xxrocizgPnTyISQpw2706coKdsm7NQ3Hq9Qpuz6FRZryeEEEIIcb6TMCfEReBkm7PkOT3k5Gm48U7f1LT8/nrevnwGva9Ng17x9ddTUCXsCSGEEBVuQN8eDOjb41wPQ5wnJMwJIU66Xi/X4SHLXtBMHUBXaL2eWa9KM3UhhBBCiAomYU4IUSpFUdArlDjt0uPRyLR7SPO4AQ1NUVA0b1VPVfKret4pnPktF3SKhD0hhBBCiDMlYU4IcUZOtb8eAPlTOH3r9Yx6BbOhYK1eSVVCIYQQQghRQMKcEKJcecOegqGEDV69LRc0f8sF7zm+sKdTMPpaLpik5YIQQgghRAAJc0KIc6rU9XoejRy3h8xC6/UUJT/sScsFIYQQQlzcJMwJIc5bJ1uvd2LLBcX3z/yWC3pdwXo9vYQ9IYS4YB2LT2Tc5BdYumDmaV/jrSWfEBcbXW47RbpcLsZNfoH0jCxmPPkQC979mKcm3Fem82a+8g4bN+/AbDIx8Mqe3DCoL28t+QSL2cxtNwwol/GKykHCnBCi0jrV9XraCf31DLqC/nqyOYsQQojytHXHXpxOFwtfmwZQpiAH8N3Pf5KTk8uyt5/H4XCy/r9t5TlMUclImBNCXLBOtl7P4fKQ69DwaIGPn9hM3agrCHvSTF0IIYqXkptCSm5qwGNBRhtVgqrgcDs4mH6oyDn1I+oBcDjjMHZXXsCxWFsMwabgMt8/x25n6vPz2LFrP3VqVePJ8fdiMhpZtXoDb7z9IW6Pm7tuvYYrLuvOdz/9wYJ3P0av1zPstsGoqsJHn6/EajGzavUGnp38UMC17fY8XnhjMVu378FmszDjiQexWi3MeuUddu87SEhwEJPG3kONalV4a8knaBps2b6bXXsPMmnsPbRr1ZSpz88jNT2DR6e8xJj7hvgriekZWTzxzKscPHyMhKQU6taqzvNTH6ZqlRgAcnPzyMm149E0zGYTXTu29o9r34HDPPzE82zftY/HHx5Ot05t2LXnAHMWvE9qegYRYaHMfGoMVouZ2++bxNVXXMo3P6zijdmPc+uIiXTt0IpNW3cRFhrCtEmjCA0JZsv23cyas5C8vDyu6nspt990dZm/BqLiSZgTQly0SluvB4HN1NF8HfYK7cRp0BdU9vS6gt04hRDiYvS/Xd+ydPOHAY/1qn0pE7o+QlJOEqO/HVvknG9u/RKAF/56he3JOwKOje8ylt51epX5/rm5dobdNphqcTFMfPplvv/5L7p3bsvchct4a87T6HU67ntkGpdf2pnFy75i+uOjqVOrOrm5dsLDQli97j/atmxS7DTLd5d9iclo5L35z5KekUVoSBBz31lGeFgIS+fPZNXqDUybPZ8FLz0FwPZde3n+6Uf47a9/+PDTb+nWqQ2Txt7D0o//x6wpYzkWn+i/9mdf/0jd2tWYM3MiL89bQv26tfxBDuDKy7uzavV6bhsxkbtuHUS/3t38M0hS0zOY9dTYgPtEhIcyecJ9REeG89TMN/h51VoG9OlBVk4OGZlZvPPqVBRFITEplav6Xcr40Xfx0twlfPT5Su68ZRAzXnqLl56ZQER4KOOenM0Vl3cnOjK8zF8HUbEkzAkhRAlOJewpgKaBUkzbhcA1exL2hBAXpv4NrqBz9U4BjwUZbQBEWaN49YqXSjz3kS4PFVuZOxWR4WFUrxoLQKd2Ldi+az9hoSEkJadx38NTAcjMziEtPZP+l1/CnPlLGTZkMB3aNC9yre9/+Ysly74C4LmnH2bNuv94asJIFEUhLNRbLfx7wxbGPXAHAJ07tGTq83PJzskFoG3LphgMehrWq0VKWnqp446ICOXA4aM4nS4yMrOLHLdZLbz0zAT+WPMv8xct56ff1jJrytgS7xMRHsra9ZtZ9P7n7Ni9n5rV4/zXuvaqy/1B0GjQ06RhXe/427fkk69+4OCRY8QfT2Lck7MByMm1k5CYImHuPCZhTgghTtPJwl7htguK4g17qgJqobBnMnire9JjTwhR2UVYIoiwRBR7zKgz+qdUFqd6SPWzOha9XofZbERDo12rJsx4MnDa5G03DKBH13bMWbCUP9f+y0P3Dgk43qdnF/r07OL/2OPRiqyn1ny7LJc6Dp0OtFKfQpcOrVj84ZfcNfpJmjSoQ79eXYs8R1EUunduQ6d2Lbjm9oc4ePhYiff58NNv2LRtN7ffeBXVq8b6AyaAqqrFjkGn02EyGtA0qFk9zr+uT5z/iv+KCiGEOGM61RvYLAYVs+/fJr2Kwfc/U7vTQ0qWk8OpDg4k57En0c7uhFz2JeVyKMVOfLqD1BwXOQ43DpcHz4mL+4QQQvhlZmeTkZmN0+nimx//oH3rZjRrXI9/N+1g/8EjABxPSMbj8bB5225qVKvCsNsGs27DVgBioiNISEop9tptWzXlsxU/omkaKanp5NrtdGjTnB9+/QuANev+o1aNqtisllMe9+9//sM1/XuzdP5Mnhh3L0ajIeD4R59/x+69BwHIyMzC4/EQER5a4vXW/buVK3p3o2G92uzeV3SdYj6X201CYjKapvH1d7/SrnUzalarQlp6Bus3ej8nxxOST/n1iIollTkhhDgHFMW7c2aJPfY0jVynh6w8d8AGLf6G6mr+Bi3eqZx6X2VPlcqeEOIiFRURxvTZ8zl4JJ6e3drTqV0LFEVh0sPDeXz6q+h0Ki2aNuChe4fwzQ+/89yrC8nJyWX0iFsB6NW9I+Mmz2bT1l28MG1cQCVu2G3X8OxLb3HbiImEhQUzaexw7rx1ELNeeZvb7p1ISJCNJ8fde1rjbli/Ng89NpNvf/oDi9lM4wa1GXX3zZjNJgDatGjMK/OXkpKWjsvlZsLouwgOspV4vWsG9OaNtz/kk6++p3bNaqXe+7W3PmD33kM0a1Kfq/tdisGgZ9qk0cx+bRFut4dqVWN45vEH0emk/nO+UhyOvErzp16Xy8UlA+7k9xWL0OvPnxzq9mjsSbRjMXi/0ZNzE9EpJWyfV9z5mptIS/Rp3VuXdRBUw8mfeL7xOHEH1TzXoxCi0tI07/RNt0craKiObxqnTkGvglHnDXsmvYret0OnhD0hhDi/PP3cPG6+9goa1a9NRmY2Q+6byEvPTKBe7Rrlet/eg+7mpy/eLtd7iPJ3/iQiIYQQZXayhuqaRyPH7SHT7vaHPQBdMWHPqFdQFMVb9fP9W0KfEEJUjB5d2jL7tXex2/Nwu93ccl1/6tY6u2sIxYVLwpwQQlyAyhT2XPlhDxR/S/WC4KcqoKi+fn2ATqei903xNOgU9DrFP11UlRAohBCnpdclHel1SccKv69U5S4MEuaEEOIipCgKeh3oT7ITW2EutweHy7urmwYlh0DVu3unmh/0VG8INKjeACghUAghhDg7JMwJIYQok/zgxSkGr+JCYH5TvoIwWBACC6Z6+kKgzrfBi04pCH8SAoUQQggJc0IIIcrXWQuB4CsHFgqBim86qIRAIYQQFyEJc0IIIc5LpxMCNU3zhkAneLRClcCCZ/i3Gy8uBBp1+Bu4FwmBvvWDQgghxPlCwpwQQogLhqL4pmzqgFNYDyghUIgzl5KbitPjPOvXNagGIizhZ/26Fzun08VHn3/HbTcMONdDOSXxCUms37iN/n0uOddDOS9ImBNCCHHRO5MQ6HQVhECPBoHNWwNDYOGpnjpVxVBSCFQLwqAQlYXT40R/Cn12T+W658LgoWP4bPHLJR5b+Oo0rBYzk2e+ztSJozAaT63vr8PhLPHcoSMnMeupscRVKehDfP/46SQlp2E2GQG44Zp+pKSm8+Ovq8nIzMael0dMVAQN6tXiyXH3MnjoGKxms7/h98hhN9GlQyv/9X5etZbQkCAAtmzfw6w576B5NEaPuJWObZsHjGfdv1tY8O7HpGdkcvmlXRg+9LoSX9eRYwnMfm0R/23dyY+fvVXi5y4sNPiUPl/5oiMjWPnzn1xxWTdUVZqZS5gTQgghTlP+rpy+j8p8nqZpOFwe8iQEClGpGY0GZk4eU2HnPj3xfpo0rBvw2B03D2TFyt/YtnMf4x64I+DY688/XmJo+u6nP5g2aTSapvHsy28xdeIobFYLI8dN5+NFLwQEpS3b9/Di9PEYDHpuvGscvXt0LLGpeZDNyu03XsW4yS+c0msrK51OpUXTBqz/bxvtWzcrl3tUJhLmhBBCiApWXiFQKXQ5nVLQIkJVQO/rE6jLbxGhekOgTsXfNF5CoKisjsUnMuOlt6gWF8PfGzYzqH8vDAYDX33zC7ExkcyeOg6dTuWPNRuYt3A5Ho+HPr26cOctg3C53Tw9ay7bdu4lPCyUZ54YzWtvfkD88SSGjpzETddewYA+PUq8d+9Bd/PTF2+jaRrzFy3n51VriY2OIjUtg+emjAVg3OQXWLpgJuCtsI0efitNGtYNOHfuwo/49Y+/qV61CmkZmeX6+fJ4PHg8GlaLmeMJySQmpVK3trdRuV6vY8++QzSoV8v//DtuHuh/v1H92iQlp5UY5kJDgmjbqmmp91/4/uds3LwDnU7HtEmjqFolhvvHT6dVs0asXb8Ze14ek8fdS6MGdfjupz9Y8O7H6PV6ht02mH69u9KqeSO27dgrYQ4Jc0IIIUSlcSYhMM/pwa4VDYEnXi4gBKqgVyUEisph+659PDLqDoYPvY6rbx3N1ImjWDxvBnfc/zibt+2iZvU4Zrz0Foten05YSDD3j59O04Z1CQkJYu+Bwyxf+AKJSSlERYQx9bFRfP/LXyyeO6PM9//r742s/28bS+Y+i8Pp5Pb7HivzuX+u/Zd/N20/6blPzXwDs8mIXq/nnVenlvn6J0pOTScsNASApJQ0alaP8x+rWT2OpJS0gDCXz27PY9e+gzSqX/u07w3QvnVTxo68nQ8//Za3lnzK5PH3ARAWGszbc57m1z/X8fL8pcyd/QSLl33F9MdHU6dWdXJz7QDERkfyw6+rz2gMFwoJc0IIIcQF7rRDoEcjz31mIVCvU9GpSAgU5S4mKoLaNasCEBkRRvs2zdDrdNSvU5OU1HQys3JoWK8W0ZHezVR6de/ImvWbGH77dQTZrLw8bwlDbry62HVYk599nf0Hj/jXoxVn3YYt9O9zCUajAaPRQHCQrcxj/+ffrWU6t7hplqUZNf4ZdDqVuNhoZvmqhAAJiclER4YB3v9uNc3jP6ZpHv807xMtfP9z+vXqSlhoMN//8hdLln0VcLys4bdF04YAdG7fgq++/cX/eMtm3sc7tGnO9NkLAOh/+SXMmb+UYUMG06GNdy1fdFQExxOSy3SvC52EOSGEEEIU60xDYK4GmuYuewg82ZpA2R1UlJFerwt4XwNvd8pivnfMZhPzXniSX/9cx/3jpvPUhJE0b1I/4DlTHxt10nu6PW5ycuzFHnO5Xad97pkoac1cSHAQGVnZAERFhnPwcDya5v38HDwcT1Rk0d1Df/xtDdt27uPF6eMA6NOzC316djmj8el0Oky+DV0K0+t0/k1hbrthAD26tmPOgqX8ufZfHrp3CJlZ2ae9gcqFRraAEUIIIcRZpSgKOlXBoFMw6lXMBhWL782c/6b3vhl0KnpVRVUUNA0cLg9Zdg+p2S6OZzg5nOrgYEoe+5Pz2JuUy55EO7sSctmTmMvepFwOJNs5lGLnSJqDhAwHKdlOMnJd5Djc2J0eHC4PLreGJ7DXhLgINWtcjx2795OUnIrL5eLnVWvp0KY5x+ITSUpJo2e3DnRq15JN23YB3kpfQmLx1R8FBU+hahZA00b1+XPtv7jdHhISk0lKSQMgJCSI+OPJpKVnsnf/YfbsO1zkeiWdW16qxESRmJQKeF9nldgo9uw/THxCEpqmUbdWNdZv3MqcBe8DsHXHHha+/znTJo1Crz/zWtDR+AQAvv7uV9q3aVbo8UQA/vfD77Rt2QSPx8PmbbupUa0Kw24bzLoNWwGIP55EtbiYMx7HhUAqc0IIIYQ4L5zJmsBi+wRqGigKircm46sAFlQCdb4+gXoVDPlrAnWKfxpoQS9BqQSWhUE1lFufubMhIiyUx8bcw9jHn8fj8XB5z850bt+SPfsP8dKLS0hJTSc0JIhhQ64BYOCVvRgxdiq333QV113dJ+Bandq14NOvfuCe2wu26L+sR0dWr/uP2+6dSKP6tbGYTQDYrBauvfoyhtw3kc7tWtKhTdFNOy7r0ZE1/3jPbVivJnGx0UWeAwVr5gAuu7RzwMYkp8Jg0ONwOPF4PKiqyqSx9zBt9jw8bo1JY+9BVVVS0zM5cvQ4AE/OeA2A0RNngqbRvk1zHhxxa7HXXvDux6xavR57noOhIydxxy2DuKxHJ/9xi8nEipW/8exLb1M1LprJhaatfv/LXyxe9iU2q4Upj96Py+Xmmx9+57lXF5KTk8to3z337D9ErRpVT+u1X2gUhyOv0vypyuVyccmAO/l9xaKz8leBs8Xt0diTaMdi8BY6k3MT0Z1CnxW35ibSUvx/tCejyzoIZ+mHXIXyOHEH1TzXoxBCCHGRy18L6PEUhEB/+EMjP1SqCii+KZ4q3umgep13LaB3Sqh3y3S1UFBUFEpceyQufMX1ijufvPvhlzRtVNe/Du1cK7zL58mMm/wC0yc9gNkXmC9m508iEkIIIYSoYPnr8TjF6pvL48Hh9lYFPVpBCERR0DRvCMy/7IkhUKeCQVcoBKqqfy2g6q8eSggU5WvgFT15c/En502YK6tj8YnUqhEnQc5HKnNngVTmToNU5oQQQlyE/LuC+v9dsDGHBv6dYnS+EKgoCjoKQqBe59skJj8EKgQEQQmB4lS4XK7z6nfqsqqs4y4P8lkQQgghhKgg/krgKawJBG8l0OkGjwM8mrsgBPomg+Zf0b8uUPVWAlUVDL4pobr8dhGFQqDinxIqIfBiVFkDUWUdd3ko18/EB59+w/vLV3DztVdy2w0DAo5Nmz2fDf9tJ8hmAeC15x4nJLjs/TiEEEIIIS4WqqKAAt55P2UPXh6Pht3tweMo3CZC800Cxb8q8MTNYaRXoBCVQ7mGubYtGrN778ESj096+B7aty66o48QQgghhDhzpxsCS+oVGHCFEnoF6nWqby2gb4dQtVCvQFVCoBBnU7mGuUYN6hAXG1Xi8bAQafYnhBBCCHG+yZ9+ecohUNPIc3qwa4XWBxa+bqHL5W/2UuaG8dImQogizumE01fffJ/jiSn07dWFu269ptj52h9/+T2ffPU9gG93KCGEEEIIcT46k16BDpeHvBN7BRY8w/97Yv500II+gMX3CtRJCBQXgXMW5obedDVWqwW3282o8c/Qunkj2rZqWuR51w/sw/UDvY0a83ezFEIIIYQQ5xcl9ziqO++sX9ejM6FZYos95m8Y7ypDr0C10HRQvH0B9b61gHpVwaAv2jD+fOgV+O2Pq2jdojFVYkqe7XY+0jSNdz/4kjtvHXSuh3JBO2dhrnDX9m6d2rD/0LFiw5wQQgghhDj/qe68cmmXpLrzcJdwTFEK+vlNmf48948cRkx02UJPfgjUNI035r7NjTddR3hYqL9XoFJKw3idDj5a/gVWi5mbr73S3ytw46btPPb0i1SLiwG8uy6+PONRHpjwDAD7Dh6hZrU4dDqVCQ8O48Cho7z65vvEREUAEBcbzawpY/1j9Hg8fPfTn/Tt1ZXdew/y4tzFpKRm0KpZQx59aBiqqvqfu37jVlZ8/ztPjru3TK9/xcrfeO2tD4iODAfggXtuoWO7Fv7j02bPp1unNvS+pGOZrnciRVE4fDSe+ISkShdEK5MKDXNLl68gOiqcDm2as3b9Zvr26kJ6RhYbt+ygX+9uFTkUIYQQQghxESvcJuKhB4aX+bz8hvF5Tg+a6uZoutPfMP5YhoMGDRvwyCMP+kNgskNh+vTJ6FSVkaPHM3XKeCLDQtGrsGvfEXpd0pmHR93hX0NY2D8bt9K8SQNUVWXDpu1MefR+IsPDGDH2af76eyPdOrU5o8/B4AGXMeKO68/oGqXp37cHX37zS7ne42JXbmEuMTmVR554nuTUdFRF4a91G6lbqzqKomC1mtm+ay8ffPI/0tIzuWlwP5o1rldeQxFCCCGEEBewxe8tY8fO3Tw762V6dO/C2r/XM+bB+4iNjSYpKZlXXlvAtCmPMWr0BNq0bsGOXXsICQ5mzIP3EhwcxKjRE3j2mScJCQlm1R+r+ezzFaiqyqCBV9K5U3veWfQ++/YdICcnlxHDh9KsaWNU3xo9i6GgOmbSKehUBXOhx/K5PB40DbLsbrQsJ5oGKTlOMvPc7Eu2g1aoTYSv/cNf/+6kUYN6xKc76HVZT3SqSq7TQ+OG9TiWkILT7UFRFI4dO87U5+eTk2tn6MhJvPbc46SlZ/Dsy2+TkZlFg7o1mfDgMKwWc8CYwkJL34zwjzUb+PDTb0hLz+Th+4fSuX1L3lryCckp6Rw8fIzjicncdes1DOjbg117DjBl1lxcbhddO7bmoXuH0LJpA5Yu//qsfI1F8cotzEVHhrN47owSjz9075DyurUQQgghhLiIDB1yE2vW/MNjj44hJjoKm83Kqj9Wc921V/P3un/p0rkDACmpafTqeQn33H07i979gG++/YEbb7jGf50jR47x0cdfMP3pSQQF2cjOzkGv13P5ZZdSt04t/vtvCx9/8iXNmjYucSzbtu9k/MQpAFzZ7zJ697oE8FYCFbz9+0x6b9gz+lo3WPRFwx9AQkISnTt1wO70+BvGu90e1m3cSvsuXdmX5F2jqOhDGXjN1WzfvoORI+8m1QFPPjuX6wYPoGunNixa8hFvvvc5w++4wbseUAW3pvHtj3/wxf9+pmH9Wox74E5sVkvA/UODg3jixcns2nuQR6e8yKeLXwYgIzOLV559lPSMLG4dMZGe3Tvw5be/0L/PJdxy3ZUkJacC3mmmDofrlL6W4tRI+3QhhBBCCHFB6da1E1Ofmc21g69i3T//MmrkMMAbLurVqw1Aq1bN+e77nwPO27RlG507tifE1z4rODjI++8gG8s//oI9e/eTmJRc6r2bNG7IxAkPlXmsf/65lu07dgFw283X0bp1wbq15OQUIiPC0amKv03ED7/+Ts0a1ahfp0bAdQy+Vg56RSE3N5fDR47SrHkzMu0e2rRrzzsLl3DFwIGovrWA1es1ZcgdVYmOjmTBgoW8seRLbrx+kL9hvN3poVXdOmTmualWvRp5DidJqRl4NGjSqC56vZ7IiDCqV43l0JF4enbrwMvz3iMkJIgrL+/uH5fH4ynz50KcuuL/DCCEEEIIIUQlZbNZqV4tjm3bdqJpHiIiwos8R6fTYTQEbtiiebQiHRUSEhKZMetlateuyT133+59zlnUtWtHnp85hednTgkIcgBBQUFkZ2f7P96+Yxc//Pgrw+++vdRr5nfz0qkKBp3iD3pWgw6zQcVsUImOCKFB3ZqEBdu49JIuxB+LR1UUNI93PaDLrZGd5+F4upMjaU4UVUd8lkZqtovkLBe7EnLZm5iLS1NIztGIqVmXJ58Yz859R7lr9FOkZTvIcbjRUHC4vNfzSJuxs07CnBBCCCGEqPQiIyNI8U3vA+jd6xLefGcJHTu28z/mdrtJTk5B0zR+/mUVzZs1CbhG0yYNWb1mHVlZWXg8HhISk9i77wBV46rQoX0bjh2L9z9XgbMe7E4UGxtNUnIK4A2V8xe8y9iHRmKxWIo8NzIygpSUVDRNw2q1UK1qHP/+uxmAP/5aS4vmBbvGezweVn7/C06nE6fTyYZ/N1G3Tm3v61K86/4UBVKSkzEbVHZu20pkZDhhQRb0OoXUlBRMOoX4o8dIS0ujalwsu3btRW80MXDQ1RyLT2BffAYHk+24NIX9yXnsTcplT6KdXQm57EnMZW9SLgeS7RxKsXMkzUFChoOUbCcZuS5yHG5ynZ6CEFjOn+fKTKZZCiGEEEKIM+bRmcqtz1xZ9Ly0Gy+9MpfevXtw0w3X0LRJI7KysulcKMwBLFm6nIMHD9OgQV169+oecKxWrRpc1b8fTzz1LCaTiX59etGxQxu+/+EXHnt8Gu3atsJk8o6nUaMGvLvkQwZefUVAL7rCa+YAnnpiPEFBttN67dWqxnnHWr8uc+cvIic3lxdffgOPplG9WlUeGj3C/9yGDeqRlZ3DhIlTGP/IAzxw/z3MW7CIDz76lBrVq3HfiDv8z1UUBVVVeOrpWaRnZNKkcUOuvOKyIvePP57AY49PA0Vh1H3D/I8fPnyUJ56agT3XzqiRd6PX69m77wBvLVxKTnYOV/S7jKjwYI4eiyc2Jipgk5gT+XsFFm4YD76GgUpBz0CloGG8mt8UXi3oFWgo1DC+cK/AC71hvOJw5FWaqJvfNPz3FYvQ68+fHOr2aOxJtPu/UZNzE9EpurKfr7mJtESf1r11WQfLpadLufM4cQfVPNejEEIIIcQFasvW7Xz/wy+MefA+/2O333k/Sxa9cQ5HdWrs9jxeeXU+j45/8FwPxe+jj7/AbDYx8KorTvrcD5Z9Svt2rWlQv265jMWjaXi0MjSML6ZXoF7nDYE6VUGvepvIqwFBsXKEwPMnEQkhhBBCCHEWLP3gYzZs2MT4Rx4410M5I2azibi4WBISk8rcDP18oWkax44dp369OuV2D3+vwFMMXvm9ArX8MOgLgSjeCKhTFOpFm096nfOBVObOAqnMnQapzAkhhBBCnJTL5Tqvfu89FZV17A6Xh3oxRdclno9kAxQhhBBCCCHOU5UxDOWrzGOvLCTMCSGEEEIIIUQlJGFOCCGEEEIIISohCXNCCCGEEEIIUQlJmBNCCCGEEEKISkjCnBBCCCGEEEJUQhLmhBBCCCGEEKISkjAnhBBCCCGEEJWQhDkhhBBCCCGEqIQkzAkhhBBCCCFEJSRhTgghhBBCCCEqIQlzQgghhBBCCFEJSZgTQgghhBBCiEpIwpwQQgghhBBCVEIS5oQQQgghhBCiEpIwJ4QQQgghhBCVkIQ5IYQQQgghhKiEJMwJIYQQQgghRCUkYU4IIYQQQgghKiEJc0IIIYQQQghRCUmYE0IIIYQQQohKSMLcWZDrzOVI5n6ynVlomnauhyOEEEIIIYS4COjP9QAuBLtSdvPc2icAMOnMhJrCiLNV57ZmwwHYnLgBi95KmDmCUFMYetVwLocrhBBCCCGEuABImDsLGkTUZ2z76WS7UkjJTeJo1iF0irfoqWkaH2x7B6fH4X9+sDGE4S3HUCWoGluSNpKUe5zqwbWJtEQRYY4m2BiCoijn6uUIIYQQQgghKgEJc2eBxWChdmgDLAZvgEvOTUSn6ABQFIUp3V4gLS+VtLwU0uwppOWlEGIKA2B36nbWHvsdp8fpv96AetcxqMHNHMrYx48H/keEOYoISxQR5iiiLDHE2OIq/DUKIYQQQgghzi8S5iqAQWck2hpLtDW2yLFBDW5iQL3rMOnNpOQmkWJPIsZaBYAcVw7xWUfYmrSR9Lw0NDRqhNThya7PoWkas9Y8QYhqINIcRaQ5nEhTBM0jmmDWmSr6JQohhBBCCCEq2EnDXEZmNkeOHSciLJTYmMiKGNNFR1EUgo0hBBtDqBVa1/94o4hmTOwyAwCXx0maPYU8d573Y81FtaCapGYfZmvadpLtqTg8DmZ3moZZZ+LtHe+xN2M/keYIIk0RRJjCaRXZjJpB1XF5XCiK4q8eCiGEEEIIISqfYsPclu17WLzsSw4fPY7NaiEmKoK0jExSUtIJCrJy3dWX06dnF1RVNsOsKHrVQFShyp5BNXB783vRZR0E1YCmaWS5srHprQC0CG+KTW8l2Z7CgayDrE/eSKgxmJpB1VmT8A8Ld75PuCmMKHMEUaZI6oXUpmfV7miaRpI9mXBTOHpVwp4QQgghhBDnqyJh7o23PyQ9I4vhQ6+nfp0aRU5IS8/k8xU/8dBjs3hpxgT0OvmF/3ygKArBhiD/xx1j2tIxpm3Ac/LbJtQPrcvtDW4kyZ5Csj2FBHsiOl8wz3JlM/HvqSgohJvCiDRFEGWOYEiDGzHrTBzOPopRNRBhCkevyixdIYQQQgghzpUiv42PHHZTqTsphoUGc+etg7jjloGy42Ilk//1irVEE2uJLvY5Zp2Jh1vcT7I9xRv28rxvRl87hXd3fsDezAMoKIQZQ4k0R3BNrf40CW/I8dwEku2pRJojiDCFYZAWDEIIIYQQQpSbImGucEDLys7hp9/WkJSSRuFe2HcPGSxB7gJlUA00C29c4vERje8k0Z7kDXt5KSTZkzH5NlxZm7Cezw/8DwAFhVBjCJ1j2nND3UHkuuysTVzvndZpjiDCECwd64UQQgghhDgDpc6TG/fkbJwuN00a1kWvl+mUAqItkURbit8I58oal9M5pj1J9hSS8pJJtqcQa4kBIDkvhSW7lqFR8FeBSHM0My59HUVR+PnAtyiKQqQl2vtmjsakN1fIaxJCCCGEEKIyKjXMpaZn8P6C59DppIYiTk6v6om2RBFtiSpyrLqtKvO6v0hqXhpJ9mSS7Ylk6cz+Cu/qo79xIGMvHs3tP2dM+ydpGtWSf+JXszdtB5GWGCIsUUSao4myxmDxbfYihBBCCCHExajUMNeiSQMSk1OoElP0l3MhTpVe1RVU9jx1cAfV9B97rMsMPJqbNHsqybmJJNsTqRFSC4CU3ET+S/iHZHsSLl9z9d41r+TmpsM4lnWET3e+R6Q5mghfVS/aGkvNkDrn5DUKIYQQQghRUUoNc4qqMmr8MzSoVyvg8ZmTx5TnmMRFSlV0RFiiiLBE0YAm/sf71LmaPnWuxqN5yMhLJ8WeiFVvA7z999weN9tSNpGSm0ieO48oSwwzLn0dgNlrp2DUGYk0e4NehDmKZtGtsRmC0DRN1n4KIYQQQohKq9Qw17pFI1q3aFRRYxGiVKqiEmYOJ8wc7n+sRkhtHmw/CfC2XshyZpLjzPJ/XCO4Fkm5CexJ28HaY6vIdeXwdPeXsBmCWLr1TTYlrifcHEmEOYoIcyQtY9rTMKIpee488lx2go0hEviEEEIIIcR5qdQwN6BPj4oahxBnTFEUgo0hBBtD/B/f1OSugOfkOLMx+zZWaRXTgWBjCCm5SaTYkziYsZdwcxQNI5qyLek/3tjwHAbVQLg5knBzJLVD63NdoyEAbEveRKgxjHBLpKzdE0IIIYQQ50SpYS47J5dX33yfVavXo6BwSZd2PDD8FqwW2WVQVE5Wg83/fovoNrSIblPs8+qGNWBkm3Gk5CaTYk8i1Z5EntsOgNPj5KW/p/qfa9FbCTdH8lD7xwk3R/Jfwj9kO7O8FT9LFOHmSOm5J4QQQgghzrpSw9zL897DYjYx74XJACz/YiUvvrGYJx4ZUSGDE+JcCTGF0Sa2U7HHdIqOZy99g1R7sq+ql0yqPcm/ju/PI7+w/vjqgHNubjKM3rWuZF/aLtYc+50IczQRvrAXaYkm1BRe3K2EEEIIIYQoUalhbtvOvbw371n/x2PuG8LtIyeV+6CEOJ+piurvh0cxGey+No+Q584jzZ7sDXq5SdQOrQ9Ael4a25L+I8We7K/0NQxvyrhOT/srfhHmSMLNUf7KXrOo1hhUAw53HgbVKGv4hBBCCCEEcJIwB5CekUVoSBAAGZnZ5T4gIS4EJp2JWFtVYm1VAx5vHduB1rEd0DSNHFc2qfZkNM0DgNPtINISTUpuEnvTdpFqT8atuXn18iWgGnh9/Sx2pGzBordhM9iwGmz0r3cdrWM6sD99NxuOr8VmCMJqsGHVBxFhiaJ2aD00TSPPbcdUqK+fEEIIIYSo/EoNczcNvoJ7HnqKvr26AvD9L39xx80DK2RgQlzIFEXBZgjCZgjyP2Y12Li75YP+jz2ah0xHOibfhi396gyibWxncpzZZLuyyHFm+6d2JuYcZ+3RVWS7srC7cgFoEtmCsR0m43Dn8eAPQ1EVHVa9Fasv8I1u9xjBxhBWHf6RpJwE/+M2g40awXWIssbgdDtwa24JgkIIIYQQ56FSw9zV/S6lRtVY/ljzLwCPPzycVs2lVYEQFUFV1IC1dE2jWpX43A5x3egQ1w0At8dNjisbj+b2XkfVcU+rMeQ4vQEwx5lFjisbo84EwP70PWxJ/JdsZxZ2tzcI5q/xW398DW//NwdV0XmrgXob9cIbcWeLUWiaxrJtC7EYrFj1Nn8YbBrZEpPeTI4zG1VRJQgKIYQQQpSTk06zbN2iMa1bNK6IsQghzgKdqvO3ZwAwqAY6+oJecYY0K9jQKD8I5u++WT+8sT8IZvvCYH7AdHmc7Ezd6n88fw3grJ7zMOnNLN48j/XHV6NTdP6g16/OILpX782hjH38fvhH37TQIGx6G+GWKJpEtgAgzZ6KxWDFKGsEhRBCCCFKVGyYe+2tD3jgnlsYNf6ZYn+Reu052QRFiAvRiUHQv9FLMQw6I5O7zfZ/7PK4yHVl+6eO9qszkDaxHb3VQJe3Iph/rUxHBrtStvkfz3PnUSukLo93nYWmaUz8dSQezY1e0XvXABqCeKDdRGKsVVh1+CcOZ+z3P2412KgdUo+qwTVwuPO8008NNn/lUQghhBDiQlVsmOvS3jud66bBV1ToYIQQlZde1RNsDPV/XCesAXXCGhT73KZRrXiq+wv+j10eJw63AwANjVFtJ3jXBvqqftnOLP/6wOTcBLanbPY/7vQ4GNTgZqoG12BHyhZe/edZ33gMWA02agTX4qH2TwDw/ta3UBUVqz7It4lMEC2j22IzBpORl45Hc0sQFEIIIUSlUWyYa9e6KQCREWE0a1wv4Nja9ZvLf1RCiIuKXjWg903tVBWVFtFtS3zuoAY3M6jBzf6PnR6nf0fQ2qH1eKDtRF/Fzxv2TIWCWXzWETIc6b5po9k4PQ6e6vYCNmMwX+z6gN8P/+gfj9Vg4/JaA7ii7jUcyzrM//Z+ik3vmxZqsBFqCqd9nHdzqITsYxh1JgmCQgghhKhQpa6Ze+7Vd3j39WcCHntl3nssXTCzXAd1sfBoGl//k8n+hDyigx2EWvUFbxad//0gsw6dKuuGhChO/vo+gGBjKC1j2pX43Ic7PhXwsdPjRKeoAFxe+2paxXTwB8EcZxY1QuoAkOfOIzk3kUPO/f4gGGYuCHOz1jxBpiMDKAiCD7SdSO3Qevx5+Ge2pWzyBUFvNbB2aD3qhzf2Xjcnwfe4BEEhhBBCnJpiw9z02fNBUTiekMz0Fxb4H48/noTVajmlG3zw6Te8v3wFN197JbfdMCDg2OGjx5ky6w1y7XncfuNVXHFZ99N4CZWTpmm8+UMqn63N8D1Scg8/RYFgs44Qi55Qqy/kWbxBL0yfQ7hNT5hFJdSqEm5VCbOohFhU9BIAhShV4SAYF1SNuKBqxT6vdmg9JnSaFvCYy+Pyvz+q7aNkOTIDgmCYb6MYu9teJAj2rNmX+uGNOZyxn1lrnvBfR68aiLbG8nT3lwBYsnk+Dk9eQBBsG9uJCEsUqfZkcp05EgSFEEKIi1ixYa5/3x4A/PPvFtq0LNjJMi4mihZNG57SDdq2aMzuvQeLPfbK/Pe469ZraN28EUPue4zundsSZLOe0vUrq6W/p/PZ2gzMBoW7eoVi1geRnuPyvblJz/W+n+F7PyPXTUaum8MpZbu+AoSYlYCAF2b1vVm8b+FWlVBLwWM2kyI7BwpRRnq14Mdn3bCSfy72rnUlvWtdGfCYxzcttFpwTR7tNN27NtAXBDVN8z/P5XGSkpsUEARrhdQlwhLFTwe+4bt9XxQaj4FLa/TlpiZ3kpSTwAfb3vb2DfRNDQ0yBvvHcShjn7fvoMGGzRAkQVAIIYSopIoNc21bNgFg+uOjada4/hndoFGDOsTFRhV53O32sHrdf0yZMBKbzUrN6nGs37iNHl1LniJ1ofhsbTrv/Z6GQQeTb4ihVW1jiTsG5nO4PN5wl+suCH25bjJSk0izK6TneEjL9ZDq+3d6jod0u0a63c3BFHeZxqVT8YY7S2DIC7UoASFQAqAQZ0b1Te006y3UCy+5d+ddLR8o8lh+2LusVn9ax3QICIKxtqoAeDQ3qqIWCoLZKIriD3ML/n2J4znH/NfUqwbubzOe5tFtWH30N/4+9oevbYQNq947LbRlTDucbgf7M/Z4j/k2kTHojGft8yKEEEKIU1Pqmrmmjerx198bOXz0eMBfi2+8pt8Z3zg9M5OwkGBsvkpczepxJCWnFnnex19+zydffQ8QMIbKauXGTOZ/n4qqwGODo2lbx4JbO3nYMupVokOMRIcEPq7LyoFCU8UKy3NppOd6SMvxhrz89/2hLz/45RYcS8n2vpVVWQJg/vGAAFjmOwghCsv/40mYOYIwc0Sxz4mxxTGq7aMlXuOBdo+R5cgICIJxQdUB0Ck6FBSSchPIyfBOGc10pNMyph1JuQk8v2ZywLVMOjNzLl+Moigs2Tyf9LzUgiBoCKJ9lS7EBVUnOTeRNHuKf1qo1RAUMM1VCCGEEKeu1DA3/YUFbNuxl6ycHDq2ac7+Q0epXbP4NSWnSkHBUyiceTQNpZg1XtcP7MP1A/sA4HK5uGTAnWfl/ufC79uyeXlFMgAPXx1F10a2cr2fSa8QE6wjJlhXpudrmobdqZGW6yEtxxcEfSHP/36h4HdmAVAh1JpFmE1PiEVHmE1PmFVPiNX771Br/sc6wqx6gkw6VFkDKMRZEWuLI9YWV+yxDnHd6FBCk/koayxTur/oWxfo3S3U4c7zB0yrwUZ6XioJOfHkuLzHa4fWIy6oOmuPruKzXe8HXK99la6MaD2WTEcG8zbM9lUCbb4dQ4O4ou416FU9+9N34/a4/TuJWg02/+6nQgghxMWs1DC3Zfsels6fyTMvLmD40OuxWMzMfm3hWblxaEgQmVnZZGXnEGSzcuhwPJ3btzwr1z4frduTy6zPE/FocH/fCC5vEXSuh1SEoihYjAoWo0pc6MmfD2cSADVSsu2QWLb76FR8G8B4N4EJK7TzZ8H7uoCPg80SAIU4mwyqgapBNUo8fl2jISUeu7RmX1rFtCfbleXvH5i/SYymeYiwRJHjzOZ4zjFynNnYXTn0r3ctAO9vfZv96bsDrjes5Wg6V+3BP/F/8dOBb/wB0GawUSOkDp2r9sDlcbEteZP/cavBhkVvC1jvKIQQQlRmpf4fzWoxo9OpNG1Uj3X/bmFA3x7sPXDkjG64dPkKoqPC6durK106tGLDpu20adGYQ0eO+dfqXWg2H7Iz7eMEXB6449IwBnYIOflJlcRpB8A8J8lqFe9mL741gGk5LtKzvWsB07Jd3k1gfP9Oy3aR6nsrK1UhYAfQMKueUF8FMMymJzz/3za9vzJoMZatiimEODX50yuLE2IK4+6WD5Z47qi2E8h0ZPgrgjnOLP+mM2a9lXBzJDnObOKzDpPtmzbauWoPshyZvPrPjCLXe/myRVgNNt7f+hZHsw57g56vItghriu1Q+uTnJtIfNYR/5TQ/KqhTpWfEUIIIc4fpYa5dq2asnXHHvr07MzwMU+z/IuVVIuLKfPFE5NTeeSJ50lOTUdVFP5at5G6tar7p+SMuXcIk2e+zryFHzFy2E3YTrHtQWWwOz6PycuOk+fSuK5zCDd3K2PiuYDlB8C4IBNxYWU/z+7w+INdftBL8+3+mZbjIiM/EOa6SM/2Ppb/BnlluofJoBBuNXjDXaHAF3Zi8PMdCzLrZAMYIcpZqCmcUF8V70TNolrRLKpVscdCTCHMvHSuf8pn/tRQs977/5ooS4x/l9A0eyo5zizqhDWgdmh9NiduYOnWNwOu1yiiGY90nILT7WDmmiew6W0BYW9Aveuw6K3sTduJ3ZXrf9ymt2ExWFEVCYJCCCHOLsXhyCtxVxFN0/y/qCYkpbB1xx46tG7m37SkouWvmft9xSL0+vNnmozbo7En0Y7F4N2hLjk3EZ2i41CSg3FL4knP8XBl6yAe7B9Z7C/+bs190t0sS6LLOljiBijnNY8Td1DNcr+N3ekhw1f5S80pCIBp2d6P8yt+af5g6MJzCvvs6FQKBT1DQOgLtRaEv/xQGGrVSwN4ISoBp9tBhiM9YH2gxWClSWQL7K5cPtnxnvdYoWmjj3edhUVv5ZV109mStDHgejc1vpPLag/gv4R/+HL3Mm/Q03tbQ1QNqsFltfsD8E/8aix6KzZf2wirIQiL3ip/NBJCiArkcHmoF1M5ikylJqLC//OIiYogJqr4ndNEUcfTXTz2/nHSczxc2tTKA1cWH+RE+TIbVMyhRmJCy7Z9usejkWl3+wNearbTH/7ScgoFv0JhMDnL+wb2k15fUfBu+FKo4hduMxRU/QIe975v1Ktn+FkQQpwqg87bMqa4P7SZ9RZuaza8xHPvbf0I2c78kOet/FUPrgVAkDGEOqH1fcezSc5NxOHxzhxwuh3M//eFItd79tI3iLREs2zbInanbiu0EUwQ7ap0oUlkC1LtyexN2+kPgFa9DZvRGwSFEEJcuIoNc12vuJ2ScofFbOaHz94s/qAAIDXLzWNLE0jKdNOhnoVxA6OlGlNJqKri31iFMhRLNU0jx+EpqPAFBD9nkeCXPy00PcfNgaSyTf20mVSigg1EhxiJCTEQHeJ9PzrY+35MqJFwm1T8hDhfmPUWzHpLsUGwblgD6oY1KPY8vWrg5csW+QOgt21EFiGmMMDbZN7hzvNPG03MOe5fO7grdTtvbXw54HrVg2sxudtsAKasehijzohV75v6abAxoN4NhJnD2ZO6g/S8NP/j3ibzIZikmbwQQpz3ig1zKz+Zj6ZpvPjGEm4a3I/qVWMB+G/LTjZv213cKcInI9fFkx8mcjTVRYuaJh6/LhqDTn7JvlApioLNpMNm0lEtomy/+OQ5vQ3gU0+s9uUUrQamZnsbxWfn5ZUa/nQqRAYVCnohhoKwF2IkOtRATLARs1GqfEKcrxRF8W8UE1XM8e7Ve9O9eu9iz21fpQvNolr5N4jJdmb7m9N7NDfNo9v4j2U5MjiecwwNb0uZHw/8j3XxfwZc7+r6N3J1/RvYkbyFJVvmFwQ9fRAxtioManAzAGuPrsKgMxQKiUGEmMJkx1AhhKggxf60DfKtidt/8AiNG9TxP961Y2sWvv85I+64vmJGV8nk5Ll5ZMke9iU4aVDFyJQbYzEb5JdnEchkUIk5hamfLrdGUqaTxAwHiRlOEjOdJOS/739zkJDhJCHDCeSUeK1gs84X+AKre/kfx4R41/1JSwchKhdVUX0tGIKA2BOO6bi+0e0lnnt3ywe5tek9vhDoXf8XZfVudhZsCqF1THt/g/l0RxoaBQuL3938Bk6PM+B6T3Z9jhohdfh0x3tsOL7WP/XTZgiidWxH2lXpTJo9la3JG30bxPjaShiDStzoRgghRPFK/dOZ2+Nh09ZdtGjqnRJy4NBRMjKzKmRglY3D5eGJZfvYdCibGpF6pt8Si80kQU6cOb1OoUqYkSphJYc/TdPIyHX7wl7xQS8xw1vxy7S72ZtQ8vo+vU7xTes0EBNcqNIXUlDpiwo2YJI/VAhxQdCpOoKMwQQZg4scqxpUg+sbDy3x3FcuX0yuK3+TGG/lL9paBYA6YQ1wa27/4yn2JLIcGQAcyTrIok2vB1wr0hzNsz3fAGDanxNwe1z+ap9V790tNMYWx960nSTmHA84FmIKK7H1hRBCXMhKDXNj7hvCo0+/RK3qceh0Onbu2c+E0cMqamyVhsutMe2TA/y9J5O4MCPTb40k1CpbUIuKoygFa/3qVyl59yWHy0NSptMX7gJDX361LynTSXyag/g0R6n3DLXqiA4ODHqF1/XFhBgJsUjrBiEuZHpVT7AxlGBj0bY7bWI70Sa2U7HnNYtqxRt93/fvFJrjzMatuf3H28V2JsOR5j+WkBOPW/NOC1199Dd+OfhdwPUuq9Wfm5rcxYH0vczd8HxB0DMEEW6O4OYm3t9d/j72B0DBRjEGG+HmSAyVcVdoIYTgJK0JADKzstm8bTcul4smDesSFXnupkCcj60JPB6NMUt288naJCKD9Mwf3giLJQPdKfQTktYE4nyiaRppOa6i1b1MJ4npvhCY6SQj133Sa5n0in/zloDQF2wkJtT7flSQAYPs2CmEKCNN03B4HAHTQoONocQFVSMpJ4FVh3/0P57jykKvGhjV9lEAJvx8L2l5KQHXe6TDFBpFNmPFnk/44/DPvqDnXSPYPLotXav1JNuRyXr/lNGCjWJO9//dQojzW6VvTeByufxhKTjIRpcOxTdkFfDx2kQ+WZtEsFnHnDsbUD3CRHLuuR6VEKdPURTCbQbCbQYaxpX8PLvDEzilM9NJQnrBur7EDAdJmU6OpDo4klp6lS/cpg+Yxlmwlq+g0icN2oUQ4P0ZZdKZMOlMhJsjA45FWWO4puEtJZ47s+dc7K5cX9DzVgVrhNQGoHZIPexVcv0byGQ5MslyZAKQmHucJVvmBVzLrLcw5/LFADy35kkyHRneRvLGIGz6IPrWGUiNkNrsT9/D0axD/mqhTe/dJKa4aa1CCHGqig1zjz/zKrOeGlukRYGmeftk/fHNkooa33nvuo7RbDqUTft6wdSLrRwJXoizwWxUqRFppkakucTneDwaqdku/zRO//TOzMCqX6pv586dx0r+S4jZoBaq7BVU+2IKhb6IIAN62T1WCFECVVH9O4aeqFl0a5pFty72vNqh9Znb90NyXTn+iqDDU/BHqnaxnUmxJ5HtmzaaYk/CrbkA2JjwNyv2fBJwvS5VL+Wulg+QkBPP7DWT/RvEeANfMHc0H4miKPwTvxqXx1nQW1BvI9wSJW0jhBB+xU6zTElNJyI8lKzs4nfFy9/tsqKdj9MsAdwejT2Jdiy+DSGScxNlmuXJyDRLUUhOnrvE6l5+6EvOcuIpdVI4qApEBBUOfAWhLyq4IPjZTKpU+YQQFcbpcZJbaH2gRW+lanANMvLS+OXgSm9AdHmPuTxOxnaYDMDUP8ZxOPNAwLVGthlHm9hO/HTgG1bu+9IfAq2GIBpHNKdXrSvIc9lZffR3bEZfA3lfVTDSEiM/+4Qog0o/zTIi3LuQubjQtm3nXpo0rFu+oxJCXFSsJh21onXUii65yudya6Rk+zZrSS9a3csPgEm+t22l3M9iVIuEvcIVP6nyCSHOJoNqwGAK8zeAzxdiCmNggxtLPO/Jrs8HNIrPdmZRNagGADWCa9Op6iW+/oH5x73TQtPzUnl/65sBbSQA5vX7EAUdc9bN4HjO0YD+gJfV6k+98EYczjzA/vQ9/r6CNmMQIcbQImMXQpwfig1zjz79UrF/udE8GnsPHGb5whfKfWBCCFGYXqcQE2IkJsRIs+rFb0GuaRrZeZ6AdgzFTetMyXZxMDmPg8klN2Ivqcrnb9sgVT4hRDlTFAWT3oxJby6yPrBBRBMaRDQp9rwYWxxz+33oXx+Y7czC7spF9c0aahPbiYScY/4po1mODH+/wG3Jm1i+/d2A67WMbscD7SaS6UhnyqpHfP0BC9YH3t78Xow6E/8e/5tcV06h3URtRJijMOsrR4VDiMqo2DDXo2u7Yp+soDDqnpvLdUBCCHG6FEUhyKwjyGyhTinTI1xujeSswJYM+W0ZpMonhLgQFF4fGEVMwLFLalxW4nl9al9F75pXkuvK8U0LzcKg8/Y51Sl6ete60h8Cs53ZpNiT0KveXyd/PLCCHSlbAq53R/P76Va9F38e+YXPd74fsD6wblhDrqw7GLfHzW+Hvg+YMmozBBFtjfEHUCFE8YoNcwP69KjocQghRIXR6xRiQ43EhhqBiq/yRZWwiYtU+YQQ54OSGslbDd7m7SV5pOMUnB4nOfmtIZzZRFm9QbJqUA26V788YH1gjjMbgFxXDh9tXxTQaxDgpcsWYjMEseDfF9mXttsfTm2GIHrU6EPTqFYcyzrCrtSt3r6Beu+xEFNokUqmEBeqUncRSU5JY9ln33L46HE8WsG865mTx5T3uIQQ4pw6kypfUqas5RNCXJwMqoFQUzihpsC+xLVD61E7tF6x5wQZg3mj7wdF1gda9N69G1rHdCTaWiWgybzL490tdF/6LpZuCVwf2CC8CeM7TcXlcTH+5+HeEKgvqAje0vRugo0hbEpcT3pemr9voM0QRIQ5qtjdToU4X5Ua5p545lVq1azK4aPHufGafmzbtY+IsNCKGpsQQpz3zlWVL8of+qTKJ4So/EpbH9ixavcSz+tarSedq/bwrQ/0Tv3Uqd6pmZrmoW+dgYVCoHd9YP6O438c/on1x9cEXO+GRkPpU+dqNhxfw3tb3gxY/1cjuDaDG94KwM8HvsWstxSaGmojxloFfWXcYVxUaqWGueycXCY+dDfPzVlI44Z16d/nEsZNls1PhBDiVJxOla+4sHdilW/70ZLvKVU+IcTFInB9YAGDzsiVdQeXeN59bcbh9rjJcWX7pn1mEWaOACDWWpXeta4k25HpqxZmY3d5e6G6PC4+2fkeDnfgH96e6fEa0dZYFm+ey+bEDQHrA7tU7UnbKp1IyjnOpsQNhfoKBhFsDCHKGnvWPy/i4lBqmDOZTNjzHLRt1YQff1tN7HX9OXIsoaLGJoQQF5WKrvIpCkTY9MSEGosEv5hC79tMsgGBEOLCpFN1BBtDCDaGBDxeNbgGVYNrFHuOXtXzWp/3AtYHZhcKgi2j2xNmivA+7vJOGXX5msgfzjpYZH1gtaCaPNXdWywZ//MI9Io+oCJ4Q+M7iLREszVpI0m5CQUhUW8jwhJVZOzi4lJqmLv2qss4cuw4Pbq0Y/kXK1my7GtuufbKihqbEEKIE5xKlS8ly+kLfCVX+ZKzXCRnuUpdy2c1qcSUUN3LfzzcpkdVpconhLh4lLQ+sHVsB1rHdij2nNYxHYqsD9Q0D+D9Y12f2lf51wXm/1tVVAD+if+LVYd/ClgfOKDedQxqcDPbkzcx/98XC0KgPogYWxVubXoPAL8e/B6dqguoCMZYq2DUmcrjUyMqkOJw5Gknf5pXRmY2IcHnblGoy+XikgF38vuKRej1pebQCuX2aOxJtGMxeP9jS85N9M/HLtP5mptIS/Rp3VuXdRAq4/xsjxN3UM1zPQohLmrFVfkKt2pIzHSQkO4kNdt10mvpVIgKNgSGvpCCil9MqLdHn9n3c1IIIcSp82iegPWBQcZgIi3RJOYcZ138nwHrAy16K3e0uB/wVvzS81IDrvV4l5nUCq3HR9sWsebYqoD1f+2rdKVrtZ6k2pNZH786YMpokCGYKkHVzsXLrzAOl4d6pfzB9HxSemVu6Fj69e5Kv95dqV2z2jkNckIIIc6uslb5nC4PSVkFlb2AwFeo8nc83ftWmhCLzh/0YgqFvvz3Y0KMhFh0snmLEEIUo6T1gdHW2FLXBz7fa0Gh9YHeIFjF5g1kzaPbYDUEeaeM+qqFHt800ISceD7dudTfVB4g3BzJrJ7zAHjytwfJc+cVmhYaxOCGt1A1qAY7UrZwLOswVn1BS4lwcxRh5vCiAxSnrdQw9/rzj/PTb2uY+vx8NE2jX+9u9OnZmciIsAoanhBCiHPNoFeJCzMRF1bydBxN00jPcfuDXUKGk8R0BwkntGnIyHWTketmz3F7idcy6RXfbp1F1+/lv0UFGTDopconhBBlVdL6wKZRrWga1arYcxpFNOP1vu/jdDvI9m0SUzjYXVZ7ABl5af6KYLYrCwXvz+YtiRtYuf9rfzAE6FXzCm5pejcH0vfwwt9PY9MHFQp6kdzV8gEAVh3+EY/mCVgfGGuLw6yvHNWyilTmaZbH4hP5bMWPLPv8O379amF5j6tYMs2yKJlmKYSoTOxOT8GaPd+6vcQM73TO/PeTMp24PaVfR1Eg3Kb3reErGvry1/PZzLJ5ixBCnCuappHntvvX/1n0VqKsMaTZU1h7bJV/Smi2b23gPa0eAmDKqoc5lnU4YH3g2A6TaRLZgi93fcTPB78JWB/YMqYdvWtdSZYjkz+P/BIwZdRmCKJ6cK1TGvcFM80SICk5lZ9X/c2Pv64mKyeX4bdfVxHjEkIIcQEyG1RqRJqpEWku8Tluj0Zatss/nbPwJi4J6QXvp2S5SMlysYPcEq9lNarFrt+LLtSnLyLIgE42bxFCiLNOURTMegtmvSWgcBFmjqBvnYElnjel+4t4NA+5rhx/24gYWxwATaJaYNAZ/AExx5nlPy8tL4Wvdy/H7i74/4JJZ+LVPu8BMP3PCaTZU7AW2gjmqnrXUyesAXtSd7A/fQ9Wg40WUR2BCyDMjXxkGoePJdDn0s6MvX8ojerXrqBhCSGEuFjpVIXIYAORwQaalLLGPjvPXcwavsAAmJLt4kBSHgeSSm7RoFMhMuiEnnzBvtCXv5Yv2IjZKNM6hRCioqiKis03zRIK+vA1CG9Cg/AmxZ5TPbgWc/osxuVxkevKJtuRRZ67YFp/71r9SclN8lUDvWsE83cL3Zm6la93L8fpcTKzx1vl+trOplKnWf7190Y6tm2BTnd+/A9MplkWJdMshRCiZIUbsSek56/nK7qBS57r5CsOgs26YtfvFd7BM8yql81bhBCiEnO6HXg8OurHWs/1UMqkSCJ6451lWC1mBg/oTZcORRdDutxufvx1DT/+upoZkx9Cr5P1CEIIIc5PAY3Ya5TciD0j1x3QjiH//cI7eKbnuMm0u9mTUPLmLQadd/OWmNCCtXxFQl+wbN4ihBDnK4POiEM7ycLt80iRMHffnTfw429reOTJ2SiKSrW4aGKiI0lPz+RIfAKpaRn0ubQLT46/V4KcEEKISk9RFEKtekKteupXKXmNRJ7TQ1Kh3TkTClX2Cu/aeSzN+wbZJV4r3Kb3rtsL9YW84KJtGoLM0qJBCCFE6YqEOVVV6dOzC316diE7J5eDh49xND6R8LAQalWPk7YEQgghLkomg0q1CBPVIkpu0eDxaKTmuIpdv1d4B8/UbBep2S52xpe8eYvZoBY7lTPa17YhJtRAhM2AXieBTwghLlalLjyzWS00aViXJg3rVtR4hBBCiEpLVRUigwxEBhloXLXk9RY5eW4Kt2YoLvQlZzk5lJzHoeSSN29RlcKbtxRtxp5f8bOaZCaNEEJciM6fXUSEEEKIi4TVpKNWtI5a0SW3aHC5NVKyAlszFF7DF9CrL9MJR0q+X5BZF9COIaDS53s/3KpHlRYNQghRqUiYE0IIIc5Dep1CTKiRmFAjUPLmLVl2d9HKXv6unekF0zqz7G72JZa8eYvet3mLtxVDYAP2/Pejgg2YDLJ5ixBCnC9KDXN5Dgefff0TSSmpPHDPLeTa7cQfT6ZOrVIa/wghhBCiQiiKQrBFT7BFT93YkjdvcbgKNm8p0prBt4NnUqaT+DQH8WmOUu8ZatWdsIbPF/oK7eAZYpHNW4QQoiKUGuaeeWEBVavE8Oeaf3ngnlvIy3My65W3mffi5IoanxBCCCHOkFGvUjXcRNXwkjdv0TSNNP/mLcX340vIcJKe4yY9J5ddpWzeYjIoBa0ZggOnc+a/RQVJiwYhhDhTpYa5nXsOMvWxB/jz740AhIUGk5Nb8hQNIYQQQlROiqIQbjMQbjPQMK7k59kdHhIK9+BLL7yez+HfvOVwSh6HU0revAV8LRpOqPCd+LFU+YQQomSlhjmjQU9Wdg75P0M3b9tdEWMSQgghxHnKbFSpGWmmZmTJm7e4Pd7NWwI2aTlhE5fEDEdBi4ZjpVT59EpBVS/YQFRx4U8asQshLlKlhrn77rqRBybMICExhUnTXmHt+s1MfWxURY1NCCGEEJWQTs0PYMZSn1dSi4akzNOs8hWa0hlVaPfO/B08pconhLjQlBrmunZsTe2aVVm9bhNoGiOH3USNalUqamxCCCGEuICVpUWD26ORmu0q2o8v00nSKTZiN+nzd+wsqOpFFQqAMb6PjVLlE0JUEidtTeBwODEZDZjNJmzWknfKEkIIIYQ423SqN4BFBRtoUspm2jl57qI7dhazlu9IqoMjqaXv2Blm1Re7fq9gQxcjoVap8gkhzr1Sw9z7H/+Pd5Z+RvMm9dHpVGa/tojJ4++jS4dWFTU+IYQQQoiTspp01DTpqBlVepUvLdtVEPhOCHv5ATAtx0VajqvUHTuN+oK+fEU2bwkxetf3SV8+IUQ5KzXMffr1D3y0cDYRYaEA7N1/mCeffU3CnBBCCCEqHZ2qEBlsIDLYQONq1hKfl+twF9ms5cTNXJIynRxNdXA01QFkl3itUKuu2LAXI1U+IcRZUGqYi4oI8wc5gLq1q2Mylr6YWQghhBCiMrMYddSM1JW6Y6fHo5Hq78tXNOzlf5zfl2/38ZKrfAadcsKGLb5G7IXW90mVTwhRnFLDXJeOrVn22be0a9UUgENH4qleNZbdew8CUL9uzfIfoRBCCCHEeUZVFSKDDEQGGWhcteQqX35fvqQSwp73MQfH0rxvpQmx6EoMe/lvYVa9VPmEuIiUGua++N/PACz77LuAxydMeQlFgU/efan8RiaEEEIIUcmVpS9f4SpfUnFhz7e+LyPXTUaumz3H7SVey6DzTiUtKezlt20wS5VPiAtCqWHug7dmybRKIYQQQohyVLjKVxq7w0NipqNQ6CsIewm+j5MyncSnOYgvS5WvhLCX368vzKpHVaXKJ8T5rNQwd/+4Z3h7ztMVNRYhhBBCCFECs1GlRqSZGiep8qXlr+XL36wlw+kPe/lVP3+VL6HkKp++8Fq+4KJhL/9jqfIJce6UGuYaN6jNH2s20K1Tm4oajxBCCCGEOE2qqhARZCAiyECjUp5nd3qKn9KZWfDx6Vb5itvMJVyqfEKUi1LDXGpaBo8+/TK1a1ZFpyv4q8u7rz9T7gMTQgghhBDlw2xQqR5honqEqcTnaFqhKt8JUzqTCoW/9JwyVvmCDMWu38v/OCbYiNkoVT4hTkWpYe76QX25flDfihqLEEIIIYQ4TyiKQrjNQLjNQMO4kp+X56/yBa7fy6/65R+LT3cQn156lS/YrCt2/V5UsIGY/CqfTap8QuQrNcy1bdmkosYhhBBCCCEqIZNBpVqEiWonqfKl57j9O3MmnNifzxf60nJcZNrd7C2lyqdT8VX0iq7fK/yxxagrj5crxHml1DC3/+AR3n7vMw4fPY5H8/gfl2mWQgghhBCirBRFIcymJ8ymp8FJqnzJWcWHvcI7eR5P976VJsisKxr2fJu5xIQYifJV+XRS5ROVWKlhbsqsufS6pCPxCckMH3od23ftxaAv9RQhhBBCCCFOi8mgUjXcRNXw0qt8GbluEkrZvCUxw1vly7K72ZdYepUvMqho2IsOKZjWGRVswGqSKp84P5WazDQ07rh5ICmpaQTZLAy9aSAPPTaTW67rX1HjE0IIIYQQwk9RFEKtekKtehpUKfl5DpcnsB9fZvHN2BMyvG+QU+K1bCY1sCefb5pnTKGqn1T5xLlQapizWixkZmXTuX0rvvz2F4xGI/EJyRU1NiGEEEIIIU6LUV/2Kl+JYc/Xry8120V2op39J6nyRQSVHPbyK35S5RNnU6lhbuhNV5OWnkmndi347qc/uO/hqdx9+7Vlvvjn//uJ5V+sJMhmZdpjo4iJjvQfmzZ7Phv+206QzQLAa889Tkiw7TRfhhBCCCGEEKemcJWvfhVLic8rXOVLyiwa9hJPWONXmvwqn3eHzuI3b4kIMkiVT5RJqWGuS4dW/venPHr/KV04JTWdJcu+Yun8mfy+ej2vv72MpycGXmPSw/fQvnWzU7quEEIIIYQQFel0q3xJvrBXeH3f6Vb5itvMxSZVvoteqWEuKzuHn35bQ1JKGppW8PjdQwaf9MJr/tlEw3q1MZtNtG7RmOdfXVjkOWEhwac+YiGEEEIIIc4zZa3yOV0ekrKcpW7eUvjj0lhNaqlhLzrEQITNgF4nVb4LValh7uEnnsft9tCkYV30+lNL/skpadSs7l2VGhURhtvjwZ7nwGwy+p/z6pvvczwxhb69unDXrdegKEW/0T7+8ns++ep7wPsXDyGEEEIIISorg14lLsxEXFjpVb5Mu7vY9XuFw15qtosDSXkcSMor8VqqUnjHToN/imfhzVxiQozYzFLlq4xKDXPpGVm8v2AWOp166ldWAsOX5tEonNWG3nQ1VqsFt9vNqPHP0Lp5I9q2alrkMtcP7MP1A/sA4HK5uGTAnac+FiGEEEIIISoJRVEIsegJseipF1tylc/l1nxr+ArCXv6UzsCdPL1vHCn5nlajWmT9XtQJm7lEBEmV73xTaphr3bwRickpVImJOuULR0eGs3nbbgASk1MxGAyYjAVVuVo1qvrf79apDfsPHSs2zAkhhBBCCCGK0usUqoQZqRJmLPE5mqaRlV/l8wW8wmv48sNgShmrfIFr+QIrfTG+j20mtdgZd+LsKzbMPfr0SyiKQmZmNqPGP0ODerUCjs+cPOakF+7YtgUL3v0Yuz2PDf9tp2vH1ixdvoLoqHA6tGnO2vWb6durC+kZWWzcsoN+vbudlRckhBBCCCGE8FIUhWCLnmCLnronqfIlZxUNe/n9+AqHv6RMJ9tKuafFqAaEvRP780WHGIiUKt9ZUWyY69G13RlfODwshDtvvYa7H3qKYJuVaY+PZsmyr1AUBavVzPZde/ngk/+Rlp7JTYP70axxvTO+pxBCCCGEEOLU6XUKsaFGYkONQPHtwjRNIzvPQ2KGg4QSwl5+le9gch4Hk0uu8ikKRNj0JYa9mBADUcEGgsw6qfKVQnE48sq0q0hmVjY2qwVVPY31c2dJ/pq531csQq8vdYZohXJ7NPYk2rEYvJ+b5NxEdErZF5G6NTeRlujTurcu6yCohtM695zyOHEH1TzXoxBCCCGEEGeZy62RkuX0Bb6iYS9/ymeuw3PSa5kNarFhzxv4yqfK53B5qBdTchXzfFJsIvr9r3+wWS3+NWwvz3uP5V98R2hIMM8//TDNGtev0EEKIYQQQgghKge9TiEm1EhMGat8JYW9xAwnKVlODiXncegkVb5wm94X+IqGvfwpnxdila/YMLd42dfMemoMABu37GTlz3/y4VvPE5+QxEtzl/DWK09X5BiFEEIIIYQQFxBFUQgy6wgyW6hTShUsv8pXEPgcgbt0+j5OyXKRkuViB7klXstsUAPbMuQHvhM2c6lMig1zuXY7EeGhAHz4yTfcfO0V1KhWhRrVqvDC64srdIBCCCGEEEKIi1Ngla9k2Xa3d+OWTCdJxYS9xAwnyVlODqfkcTjlJFU+q54fH2910nueD4oNc6qisHPPATIys/hn4xYmjhkGeNesGY2VK60KIYQQQgghLmw2s446ZanyZQfuzJkf9gqv70vNdhEedP7sz1GaYkd5/903c/+46TicTiY+dDehIcEALPvsOzq1bVGhAxRCCCGEEEKIM6XXKcSEGIkJKb3ilpbjxKA7d5s+nopiw1zn9i355qO5uNwuLGaz//F2rZtSu1CzbyGEEEIIIYS4kFiNZd+V/lwrsX5oMOgxGAIPN25Qp9wHJIQQQgghhBDi5CpH/VAIIYQQQgghRAAJc0IIIYQQQghRCUmYE0IIIYQQQohKSMKcEEIIIYQQQlRCEuaEEEIIIYQQohKSMCeEEEIIIYQQlZCEOSGEEEIIIYSohCTMCSGEEEIIIUQlJGFOCCGEEEIIISohCXNCCCGEEEIIUQlJmBNCCPH/9u48Pqrq7uP49947MwkBAiHssikIUgggCojiUikuFVutVrSiXdSnKnV7LH2qVkVR3GotfQSlFuuCfVRaqVWq1oK1KoioiEBFFJFNIhBCWAJk7r3n+WOWZCCBQCaZucnn/XppzJmZO+dkjpP55nfuPQAAIIAIcwAAAAAQQIQ5AAAAAAggwhwAAAAABBBhDgAAAAACiDAHAAAAAAFEmAMAAACAACLMAQAAAEAAEeYAAAAAIIAIcwAAAAAQQIQ5AAAAAAggwhwAAAAABBBhDgAAAAACiDAHAAAAAAFEmAMAAACAACLMAQAAAEAAEeYAAAAAIIAIcwAAAAAQQIQ5AAAAAAggwhwAAAAABBBhDgAAAAACiDAHAAAAAAFEmAMAAACAACLMAQAAAEAAhTLdgabO8412e75c35dvJN/E2o0xkqzk/Wwr9p1tW7Itybasao8HAAAAoGkgzGVY1DPq0jpHXVo1S7b5xsj3419N7Kvrxf6J+kauL/m+L89IvvFlPF++JBkjEw+AthUru9pWLPxZhD8AAACgUSHMZVCF5ys/z1E4lBq0bMuS7UhVK3M1CjeT7FAy+HnGyPeNXE+K+kZRz8jzfLnGyPhGniRjYkc2yeeTbCUqfgQ/AAAAIAgIcxlijJGM1CYvpHhdrU4SFbiQLMmRFK75vp5v5MvI8yXfN4p6kmf82FfPl2+MPGNkqi77lGTF/21VCX+OTfADAAAAMoEwlyF7PKN2LcKyLSsZmBqKY1tyZCmccvkbp9r7GmPiyznjlT/PKOpLnh8Lf5XLPWO3G1We75cIf8nKn825fgAAAEC6EOYywPONwo6llrnVB6hsYlmWYqtA4yEsOWOq73vV5Z7Gj401Ef4qPMn3/PhST19R11e8QKnEM8TO+qs8z4+lnwAAAED1CHMZEPV9dSnIzXQ36sU+yz2T9gp/viPlN5OpcpGX2EVfJNf35cYDYOzcP1++b+RLMn68AmgSSz/jh5NJLv0kBAIAAKApIMw1sArPV8vckCIOIUOKhS3HkpyU8Hfg7Q8Tyz9NPAR6xsj1Y+cBul4sDLqJEFjl/D+z15LWRCAkBAIAACBoCHMNKHHRk8Lm/NjrKmX550GsVk2e21elEhj1fXlVzgN091MJjD9jcjmoZVXd/oFzAgEAANBwSBUNqMLz1bZFhA/8GZQIXlVDYLNaVgITm7r78YDn+ZUVQNdTMhB68fubeFg08aezYgeS2WsbCDaBBwAAwKEgzDUQzzcKObZa5Bw4OCD7VC4HlZRcIlu7EGiMUq746ccrgJ4fWxrq+vEtIaTKJaHJ3SriG8EbI9mWbMWXhdqEQAAAgKaOMNdAKnxfXQtyOReribGsxL58UuXlWmoX6BMVQL/K+YGuF/snGg+BVbeGqC4EWqISCAAA0FgR5hoAFz3BobDjlbjKEFg7yWWgVc4PJAQCAAA0PoS5BmDERU/QcBIhMJSGEBh1E0tBq1kOGj8nUIpHQMvinEAAAIAGVK8J469/n6uZL/5DLZrnaeJN49S+XWHytnVffa0J903Vrt17dMkFo3XGyBH12ZWM2eN6KmwRkcOHWWS5akNgZP+Pqe6cQM9L7BMYqwR6XuzCMHuHQC4MAwAAUDf1Fua2lJbp6ede0jPT7tVb736oKdOf0x2/vDp5++RpM/TjH5yjQf37aOyVN2nEcYPVonlefXUnI3xjFLJtteSiJ2ikqj0nMHxoF4Y5lBBoTNUtImLhjy0iAABAU1FvYW7BB0vUu2cP5ebmaFDRUXrgf/+YvM3zfL37/sea8Iur1Lx5nrp16aQPF3+ik44/plbHrqiIyo+v77JtS6FQSK7rJtskyXFsOY5TY3s0Gk3ZQDoUcmTbtioqoinPFQo5sixL0aib0h4Oh2LnIrle7AIVblSubIXCYRnfyDOudrmeDsvPked5CoVCsfOUvOTJSbIsxdo9P+V5D2pMUVdO2JZj24q6buqYHDs2pr36Hgo5siRFXS91TCFHRpK7V3skHOu7u1ffw6FQ7FL8Vdpty1Io5MjzfHl+lXbbUshx5HperO++K1VEG/R1ShlTJBwbU5V2y5LC4bA8z0sdU/z1qKk9k3OvMYzJkpQbDsk4dpW+W/Ex5e41pljwc0Jhua6rqOsnt4jwjCTLVjTqKRqNxraIkJGMLct25HmeYrsHSjJGlu0o5DgynivFA6ltWbKdWN89143tDZkcqyPLtuVGU8fkhGJvo57r1qo99h7hy/Oqvk6WnPh7hF9du+fJr/L/k2XHfu6e58mk/H9my3acffrOmBgTY2JMjIkxMabaj8l1XVVUhOJ9z57Pe5FIWHurtzBXsmWrunXpKElq26a1PN/X7j0Vys2JqGz7drXOb6nm8Upcty6dtLmktNrj/Plvr+svL70uSckXeeaf/yzHjv31v2fPnho+/DgtXPi+Vq5cmXxcUVGRBg4coDff/Lc2bNiQbB82bJiOPLKXXn31NZWVlSXbTz31m+rcubNmzXoh5Yc5evRZystrrueffz6lXxdccIHKy3fq5ZdnJ9ucUEgjTjtHO0pLtfrjJZKklZJatGyhE0eN0PrV67V00bLk/du2L9SQEUO0asUqzVk+J9l+0GMa1EdH9uisV9/8QGXbyyvHNHyAOnco1KzX5qUEt9GnDlVesxw9P/ut1DGddaLKd+3Ry3PfS7aFQ47GjD5JxZtKNXf+x8n2Vi3zdPbIYfpiTbEWfPRpsr1T+wKNPH6Qlq5YrSWfflk5pu6dNPzoo7Tw48+0cnWi7/Mz8jqFwyGNGTNGxcXFmjv3jcoxtWqls88erS++WKUFCxZUjqlTJ40ceaqWLl2mJUuWVI4pi+ZeUxzTl1+srnZMixd/vM+YjjtumOa/u0BfVBlTn779dGTf/nr37Xe0eePXyfZe/QerfZceWvTOHO3aub3y/oNPUOvC9lo4d7Z8r3JMg0eMUrNmeXrn9RdTxnTCqO9qz+5yvf/W68m2xHtEaclGLVn4drI9r0W+hpx0mr5ev1orlnyQbC9o20EDhp6oNSuXa/XnnyTbO3bpoT4DjtXnyxapeN2XyfbuvfqqR+9+WvbhfJVurhxT76Jj1Knr4fpw3lyV79iWbC8aMkJt2nXUu2/MTvkFeOyJo5STy5gYE2NiTIyJMTXdMS2Mt2fTZ6OxYy/W3qyKij1mn9Y0mDHzZW3btkNXX3ahjDEaec7lemXmI8qJRFS6dZvGXnmTZj87RZL0wMNPqNfhXXXuWSP3e0zXdXXiWT/SnFmPKRTKnrTsG6NVm3crNxSrzG3euVF7XE/dCnKTy772V5mrcKMqzK08n/CgxrR9rZxwJJiVuZZdqWIxpiwfU/xqn0aSbUuWrYqKiuSFYTzfyNgheZ6vqOvKV+XVQR0nJMnE/xpopPhy0HAoHLtaqO8ll4M21b98MibGxJgYE2NiTNk4pt1RV4e3bRbve/Z8NmrQyly7wgIt/eRzSdKmklKFw2HlRGJXU2iV30Lbd+zUjp3latE8T2vXFeu4YwfU+tiRSDgZ5hL2/v5A7eHwvj+MxLFr225ZliIRW55v5IQ8heLnCkU9o/b5ecqJOCn3t+1YuNqb7djVvzi1GVM4FPuQqVi4qrbv4dq3WzW027atSDV9d2w7WSVNaXdsOc6+7SHHie287UuqMuaGeJ32Ztt2te2O48hxnFq3Z3Lu7Y0x1f+YmoVzq23f24H3CYz/IolfQdTzYv8ty4n/QrNiGTDqx/8o5MSWgdqVm1U4jiNV9zOoYUw1tYdqGOvBtFu2rVB17281vu85smt4/RgTY2JMjIkxMaaa+niw7YcyppCx9vmskk2fjVKef7+31sHQwUX6/ZN/1u7de7To4+U6fuggPTNzttq1LdBp3zxew4cM1KIly3V00VFau36DBg/oW19daVC+MbIdS/m5XPQEaMrquk9g4sIwfiIExiuB0cSFYYypcp/4gxMXiImztPeFYWK/GAAAQONQb2GuoHW+fvSDc3TZdberZfM8TbzlGj393EvJDxLX/3Ssbrt3ih794/O66idj1DyvWX11pUHtifrq0CLMByYAh+SQQ2Ai2FUJg64fC4JefJ9A1/fjt1deTVRSMgSmbhafulUEAADIPvV2zlx9SJwz99bsJ2osaWaC5xut3LRbIdtSs7AtO7xVIWvf0nJNXOOpQ/P2h/bk29ZIdvb8LGrNd6X8bpnuBdDkVQ2BXpUtIlzfl+tJUd+X78eWgibOB0xuD5EMgfEKoM3+gACA4KtwffVsH4xCUwBTQPZyfV/t8nNUsivTPQGA2klU4GL/0gH3CTRVlnbGAmDlMtCoF6sAep4f2xoiXiU0UvI8QKp/AACkD2EuTaKer86tcxSy+UACoPGyLEuOFbuOkZzavd/5xsj3Ky8GU7X6F/Uql396e28Or/jm8KL6BwBAdQhzadIy11HrZrVfWgkATUVsM3YpeR5grat/JrnEM+VKoPGLwCSqf5Xn/sWqflaVrSCo/gEAGjPCXBo4tqUuBTl8UACANKis/iVKgAdWNfj58epf1JfcRBXQ8+OVwdTqX+Jd2yge+ET1DwAQHIS5NOGXPgBkTqL6FzqE6p/nV9kCwjOq8I28xPJP7Vv9k2XFvsbP/bOo/gEAMoQwBwBocqpW/8K1rf7FL+jiJaqAfmX1L7H/nxff/2/v6l8iC1YNfVT/AAB1RZgDAKAWEnsAJqt/OnD1zzPxr1Wqf9H4uX/J6l+Vff+Mie33J8uSMbEzANn4HQBQE8IcAAD1wLIshSxJdaj+uX7lOX+1qv5ZsYiZGgAJfwDQWBHmAADIEumo/kXdqvv+GXm+qdwc3kgyiu32V031z7YJfwAQJIQ5AAACqtrqX2T/j/HjF3RJXAE06vtyvVjoq/Ak3/dTbjfxE/5MlWMkzv1LbP3A0k8AyAzCHAAATUii+pfYmKFZLat/iSWgvjGqiFf/Ynv/+fHb4rf78ccl135S/QOA+kKYAwAANUpW/+zKAJZX2+pfPADuXf3zvNi2D9VW/+LbP1D9A4ADI8wBAIC0Slb/nNpV/yqrepXnAFL9A4ADI8wBAICMSlTfqP4BwMEhzAEAgMCh+gcAhDkAANAEUP0D0BgR5gAAAKpR1+qf78c2e6f6B6C+EOYAAADSYN/q3/7Dn1Rz9S8W/qj+Adg/whwAAECGUP0DUBeEOQAAgICg+gegKsIcAABAI0b1D2i8CHMAAABIovoHBAdhDgAAAHVC9Q/IDMIcAAAAGhTVPyA9CHMAAADIeumr/vlyPe23+mcZyVD9QwAQ5gAAANDoUP1DU0CYAwAAAET1D8FDmAMAAAAOAdU/ZBphDgAAAGggVP+QToQ5AAAAIEtltvpXWQWk+pedCHMAAABAI9LQ1T9fRjbVv4wgzAEAAABN2MFW/4wxMkbJ6p9nTHLDd6p/DYswBwAAAKDWLMuSZSml+ncgVP/qB2EOAAAAQL2qr+qfF79vU63+EeYAAAAAZJVMVv+ChDAHAAAAIPDSVf2Tqfeupg1hDgAAAECTcyjVv2xz4I0qAAAAAABZhzAHAAAAAAFEmAMAAACAACLMAQAAAEAAEeYAAAAAIIAIcwAAAAAQQIQ5AAAAAAggwhwAAAAABBBhDgAAAAACiDAHAAAAAAFEmAMAAACAAAplugMHwxgjSXJdN8M92T/X9STrIO5vvEMfk+tJ9kE8WbbwPSnLX0cAAAAgmziOI8uq/OwfqDDneZ4k6ZvfvTzDPQEAAACAhvXW7CcUClVGOKuiYo/JYH8Oiu/7qqio2CeRZoOxV96kGY/ek+luoBFibqE+Mb9Qn5hfqC/MLdSnbJ5fga7M2bat3NzcTHejWpZlpaRkIF2YW6hPzC/UJ+YX6gtzC/UpSPOLC6AAAAAAQAAR5tLkvLNHZboLaKSYW6hPzC/UJ+YX6gtzC/UpSPMrUOfMAQAAAABiqMwBAAAAQAAR5gAAAAAggAhzAAAAABBAwbjmZpb769/nauaL/1CL5nmaeNM4tW9XmOkuIeD+74VX9KeZs3Xh987Uxd8/S1vLtuvWSQ9rS2mZzhw1QmO/PzrTXUQAbdu+U/dOnq6164rVKr+F7rxpnGzbZm4hLTZu3qIHpzypteuKFY6EdNv4K1VY0Jr5hbTZULxJF17xCz1013gd0aMrcwtpc8KZl6hnj66SpIH9+2jc5Rfpzvsf0eq1GzRkcH9d99OLs26P6wQqc3W0pbRMTz/3kqZPvkPnf2eUpkx/LtNdQiMwuOgoDT2mKPn948/M0sknHKsnp96lV/75ttas25DB3iGoln7ymb7/3dP09KOT1OfIHnrmz7OZW0gby7J0xSXn6U+P3afRp52sZ2Yyv5BeU6Y/q66HdZTE70WkV7vCNnrqkUl66pFJunHcDzXr5X+qU8d2mjHtHn25Zr0Wfrg0012sEWGujhZ8sES9e/ZQbm6OBhUdpfkLP8p0l9AI9DnycHXq0Db5/bz3PtKgoqMUCoVU1PdIzV+4OIO9Q1AdP3SQji46SpJU9I0jtWlzKXMLadOusEC9juim0q3btO6rYvXu2YP5hbT5aMly+b6vPr16SOL3ItKrVasWKd+/E59flmVpUNFRmpfF84swV0clW7aqW5fYX4natmktz/e1e09FhnuFxmZLaZm6dO4gSerWpZM2l2zNbIcQeB989B8N6NebuYW0Wrxshc6+6Gdatforff+7pzG/kBae52vq48/pmit+kGxjbiGdSrZs1RXX36Errp+gxctWqGTLVnXv0kmS1L1LJ20uKc1wD2tGmKsrSzKmcqs+4xtl6ZJaBJhlWVJ8nvnGl2UzyXDoVn65VgsXLdPZZ5zM3EJaDezXW2/87XEN7N9b9zz0GPMLaTH79X9r6OD+6tSxXbKNuYV0uvtX1+nh+2/S+d8ZpQn3TZUlS76fmF9GdhbPL8JcHbUrLNCa9cWSpE0lpQqHw8qJRDLcKzQ2bQpaad1XX0uS1q4rVrvCggz3CEFVunWbbr93qu665RrlRCLMLaRdOBzSBeecrnkLFzO/kBZvvrNQb7+7SJdfd7vmvfeRHnj4CZXv2s3cQtoM7NdbOZGIRp0yXDt2lKttYYHWro+dh7l2XbHatsne+UWYq6Ohg4v02crV2r17jxZ9vFzHDx2U6S6hETph2NFatGS5XNfV0k8+1/AhAzPdJQRQRUVUN0+crCsuPU+9Do9dtYu5hXSZNXuOPv1slYwxeuPtheretTPzC2nx4MTxemLKXfrD5Dt0/NBBGv+zH2nMuWcwt5AW7yxYpLXxwswHi/+j9m3b6IRhg7To4+Uyxuijpct1/LBBme3kflgVFXvMge+G/XnptTf17AuvqGXzPE285Rr+OoQ62VRSqht/9YBKSstkW5a6d+usu2+5VrdOelglW7Zq9Okn6aLzvp3pbiKAps+YpWdmvqwe3TrLdT1J0oN3jdfEB6Yxt1BnX675Sg898pSKN5aoeV6ubv35lWpT0Ir3LqTVxF9P01mjTlTPw7sxt5AWq1av1+RpM7Rx0xaFIyHdfMMV6tGts+68/1F9ueYrDTt2gK654qKs3ZqAMAcAAAAAAcQySwAAAAAIIMIcAAAAAAQQYQ4AAAAAAogwBwAAAAABRJgDAAAAgAAizAEAAABAABHmAAAAACCACHMAAGTQ4mUr9Oa899N6zDfnva/Fy1ak9ZgAgOxDmAMAZMy5l16vMZf9XGMuG69zxl6nqdOfle/7dTrmH57+ix565Ok09bDuNhRv0tXj76rx9if/70X1PqK7JGn46WO1fcfOOj/nkUd001PPvljn4wAAshthDgCQURNvvkbPTX9ATz0ySR8s/kSvzZ2X6S41mE8/W6WcSESdOrZL63E7d2yvSDiiFStXp/W4AIDsEsp0BwAAkKT8ls01sH8frVm/QZK09JPP9ZupT2ln+S516tBWt42/Um0KWunq8XfpzG+dqL+98oa+dfJxGnPuGTUe0xijJ5/9m17559syxujMb43Qj39wjlzX1X2/+6Pe/2iZtmwpU05OWH17H6HJ9/wy5bHPvvCK/vbqvxQOhXTsoH669qcXa8fOcj30yNNavmKVLNvSheeeodGnnyxJmvbkTL36z7cViYR19umn6FunHKdrfnmPtpSW6dKrbtZPLj5Xp4wYknyOxctWaMjg/il9furZl7RoyScq27ZDl1/yPZ1+6gnaULxJ1950r44fOkhL/rNCu3bv0Q1XXaqhg/vryzXrdcf9j2pn+S61btVSd/xynDp1aKshR/fT4qWfqnfP7ul8mQAAWYQwBwDICl9vLNE7Cz7Uf1/9Q23fsVOTfvOYHrr7F+rQvlCzZs/Rk8++qBuuulSSNPu1NzXl/lsUiYT3e8x/vDFfq9d+pWem3SNjFAtEQwZq9boN+mTFF5r5+K+1pbRMY6+8WffdfkPKY1//13y98s+39eiDtym/ZXNtKS2TJP3u988or1muZky7R1vLtuuK6yeo62Ed1aPbYXriTy/q789NVfO8ZirbvkPtCgt08w2X6w8zXtDUB361T/9Wr9ugk4Yfk9LWr29Pjbv8Qq1avV4/+tmvNOyYAZKk4o2bNeqU4brhqks0772PNPGBRzVrxmS98PIc9e/bSzeO+6E2fL1ZHdq1kSR17tRe7yxYdGgvBgAgEAhzAICMunXS/yocDqtZbo4uHfMdDTumSPMXLtbXm0s0/vYHJUme5+vw7oclH3PBuWckg9zPb3tQGzeVSJIef3hiyrHfmv+Bln26Uj+55jZJUvmu3fHAU6jdu/eofNcelZZtl+d5smwr5bH/nveBzjt7lFrlt5AkFbZpLUl6e/4i/f63t8uyLBW0zteoU4br7XcXaUC/3jr91OM14b6puvj8s/apuFVnQ/GmZPhKOGbgNyRJh3c/TO3bttHnq9bosI7tlZuTo/59e0mShhzdX9t3luvrjSUaedIw3Tt5uqbPmKXvjR4p246dQdGhXaHWb9h4wD4AAIKLMAcAyKiJN1+zz1JAY4y6dO6gJ6fcXe1jHKfylO9f33ljjcc2xuii752pC845PaU9GnXVvHkz3XjrA4pGXd3xy3HKiURS7uMbIys131XPkixLsixLE/7naq38cq0ee+oveu6vr+rBieP3+9CC1vnaWra9xttDIUfNcnP2aXccW5YsNcvN0cD+ffTElLv02px39MNxt2jC/1ytwQP6auu27WrTOr8WAwAABBUXQAEAZJ1+R/XS1xtLNPet9yRJO8t3qXTrtlo91rIsGWMkSSOOG6zn//qaSrZslSR9VRyrVC1d/rkKWuXrsd9O0BNT7tKI447e5zgnDB2kWbPnasfOcknS2vXFsWMOP1ozX3xNxhhtLduu19+YrxOOG6yybdv1+Rdr1LNHV1314wu04IOlcl1XHTu01cZNW+R5+16ls1uXTvqqeFNKW+J53vtwqcrLd6vn4d0kSRXRqDZ8vVmS9PJrb6p7104qaJ2vj5etkCVLZ59xigb176MPF/8nOdauXTrV6mcGAAgmKnMAgKzTKr+FHrjjRk2eNkPTn35BOTlhjbvsIh0z6BsHfOzRA/pq0m8e08Xnn6UzRp6gTSVbdPX4u5QTiahd2za6+5ZrdET3LvrPp1/owst/oUg4pHZt22j4kIE6/zujksf59qgTVbyxRJdde5tyc3NU1Le3bhx3qa79r4v1m6lPaexPb5JlW/rRRd/VwH69taF4kx576i/asHGzdu4s139fdYlCoZA6d2yvnj26asxlP9dPLj5X3x51YvI5eh3eVe99uCTZ1rJFnl6d847u/90fJUmTbr1WuTmxiqFlWZr2xPNauWqdmufl6s6bxsmyLH32xWo99MjTKt+1S+0K2+i6n46VJK34/EsNHVyUttcEAJB9rIqKPSbTnQAAoCE9/swsRSJhjf3+aPm+r9f/9a4mT5uhvz83tUH74Xm+rrh+gh6+/2blNcut8X4bijfp0qtv0esv/L5Wxy3ftVs/+8UkPfbbCSlLUgEAjQuVOQBAkzPsmCI98vjz+scb8xWNRtWmdStN+tW1Dd4Px7F17uiRmvPvBTo7vr1BOsz59wJ9b/RIghwANHJU5gAAyCDX82TJSmvw8jxfRkYhx0nbMQEA2YfKHAAAGVQfgYuKHAA0DbzbAwAAAEAAEeYAAAAAIID+Hx6gouqLo4E4AAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 900x400 with 1 Axes>"
       ]
@@ -2413,20 +2624,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "d5c84b74",
+   "execution_count": 25,
+   "id": "504aefd0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.138002Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.137899Z",
-     "iopub.status.idle": "2026-08-31T18:18:56.141273Z",
-     "shell.execute_reply": "2026-08-31T18:18:56.140748Z"
+     "iopub.execute_input": "2026-09-01T05:36:19.995327Z",
+     "iopub.status.busy": "2026-09-01T05:36:19.995236Z",
+     "iopub.status.idle": "2026-09-01T05:36:19.998327Z",
+     "shell.execute_reply": "2026-09-01T05:36:19.997891Z"
     },
     "papermill": {
-     "duration": 0.009231,
-     "end_time": "2026-08-31T18:18:56.141578+00:00",
+     "duration": 0.009083,
+     "end_time": "2026-09-01T05:36:19.998582+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.132347+00:00",
+     "start_time": "2026-09-01T05:36:19.989499+00:00",
      "status": "completed"
     }
    },
@@ -2470,13 +2681,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d95ec074",
+   "id": "c0bea76c",
    "metadata": {
     "papermill": {
-     "duration": 0.00495,
-     "end_time": "2026-08-31T18:18:56.151534+00:00",
+     "duration": 0.004488,
+     "end_time": "2026-09-01T05:36:20.007739+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.146584+00:00",
+     "start_time": "2026-09-01T05:36:20.003251+00:00",
      "status": "completed"
     }
    },
@@ -2490,13 +2701,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3950815",
+   "id": "79c0e536",
    "metadata": {
     "papermill": {
-     "duration": 0.004851,
-     "end_time": "2026-08-31T18:18:56.161509+00:00",
+     "duration": 0.004422,
+     "end_time": "2026-09-01T05:36:20.016728+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.156658+00:00",
+     "start_time": "2026-09-01T05:36:20.012306+00:00",
      "status": "completed"
     }
    },
@@ -2515,13 +2726,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f55407d",
+   "id": "4b39d826",
    "metadata": {
     "papermill": {
-     "duration": 0.004473,
-     "end_time": "2026-08-31T18:18:56.170504+00:00",
+     "duration": 0.004396,
+     "end_time": "2026-09-01T05:36:20.025670+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.166031+00:00",
+     "start_time": "2026-09-01T05:36:20.021274+00:00",
      "status": "completed"
     }
    },
@@ -2541,20 +2752,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "235bf55f",
+   "execution_count": 26,
+   "id": "c921e2e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.180275Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.180104Z",
-     "iopub.status.idle": "2026-08-31T18:18:56.186422Z",
-     "shell.execute_reply": "2026-08-31T18:18:56.185946Z"
+     "iopub.execute_input": "2026-09-01T05:36:20.035594Z",
+     "iopub.status.busy": "2026-09-01T05:36:20.035445Z",
+     "iopub.status.idle": "2026-09-01T05:36:20.040754Z",
+     "shell.execute_reply": "2026-09-01T05:36:20.040255Z"
     },
     "papermill": {
-     "duration": 0.011618,
-     "end_time": "2026-08-31T18:18:56.186745+00:00",
+     "duration": 0.010809,
+     "end_time": "2026-09-01T05:36:20.041002+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.175127+00:00",
+     "start_time": "2026-09-01T05:36:20.030193+00:00",
      "status": "completed"
     }
    },
@@ -2589,13 +2800,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24132e21",
+   "id": "4b245437",
    "metadata": {
     "papermill": {
-     "duration": 0.005135,
-     "end_time": "2026-08-31T18:18:56.196956+00:00",
+     "duration": 0.004569,
+     "end_time": "2026-09-01T05:36:20.050436+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.191821+00:00",
+     "start_time": "2026-09-01T05:36:20.045867+00:00",
      "status": "completed"
     }
    },
@@ -2608,20 +2819,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "id": "336a5f12",
+   "execution_count": 27,
+   "id": "056ce585",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.207228Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.207063Z",
-     "iopub.status.idle": "2026-08-31T18:18:56.211745Z",
-     "shell.execute_reply": "2026-08-31T18:18:56.211474Z"
+     "iopub.execute_input": "2026-09-01T05:36:20.060715Z",
+     "iopub.status.busy": "2026-09-01T05:36:20.060615Z",
+     "iopub.status.idle": "2026-09-01T05:36:20.065064Z",
+     "shell.execute_reply": "2026-09-01T05:36:20.064752Z"
     },
     "papermill": {
-     "duration": 0.010373,
-     "end_time": "2026-08-31T18:18:56.212067+00:00",
+     "duration": 0.010314,
+     "end_time": "2026-09-01T05:36:20.065311+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.201694+00:00",
+     "start_time": "2026-09-01T05:36:20.054997+00:00",
      "status": "completed"
     }
    },
@@ -2747,20 +2958,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "af5c7174",
+   "execution_count": 28,
+   "id": "7e79f66e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.221808Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.221726Z",
-     "iopub.status.idle": "2026-08-31T18:18:56.225176Z",
-     "shell.execute_reply": "2026-08-31T18:18:56.224750Z"
+     "iopub.execute_input": "2026-09-01T05:36:20.075329Z",
+     "iopub.status.busy": "2026-09-01T05:36:20.075250Z",
+     "iopub.status.idle": "2026-09-01T05:36:20.078588Z",
+     "shell.execute_reply": "2026-09-01T05:36:20.078327Z"
     },
     "papermill": {
-     "duration": 0.00864,
-     "end_time": "2026-08-31T18:18:56.225469+00:00",
+     "duration": 0.008815,
+     "end_time": "2026-09-01T05:36:20.078894+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.216829+00:00",
+     "start_time": "2026-09-01T05:36:20.070079+00:00",
      "status": "completed"
     }
    },
@@ -2801,7 +3012,7 @@
     "if not HO_VS_EW_AVAILABLE:\n",
     "    print(\"No holdout strategy-versus-benchmark comparison to report.\")\n",
     "else:\n",
-    "    ew_ho = load_benchmark_metrics(CASE_STUDY, PRIMARY_LABEL, period=\"holdout\")\n",
+    "    ew_ho = load_benchmark_metrics(CASE_STUDY, SELECTED_LABEL, period=\"holdout\")\n",
     "    print(\"Holdout strategy against the holdout-window equal-weight universe:\")\n",
     "    print(f\"  strategy Sharpe:  {ho_full['sharpe']:.3f}\")\n",
     "    print(f\"  EW Sharpe:        {ew_ho['sharpe']:.3f}\")\n",
@@ -2820,13 +3031,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f28839d9",
+   "id": "fd45ecc4",
    "metadata": {
     "papermill": {
-     "duration": 0.004518,
-     "end_time": "2026-08-31T18:18:56.234608+00:00",
+     "duration": 0.00489,
+     "end_time": "2026-09-01T05:36:20.088555+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.230090+00:00",
+     "start_time": "2026-09-01T05:36:20.083665+00:00",
      "status": "completed"
     }
    },
@@ -2858,13 +3069,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "722b52c4",
+   "id": "420e7635",
    "metadata": {
     "papermill": {
-     "duration": 0.004452,
-     "end_time": "2026-08-31T18:18:56.243919+00:00",
+     "duration": 0.004872,
+     "end_time": "2026-09-01T05:36:20.098156+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.239467+00:00",
+     "start_time": "2026-09-01T05:36:20.093284+00:00",
      "status": "completed"
     }
    },
@@ -2883,20 +3094,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "id": "5d3ee21d",
+   "execution_count": 29,
+   "id": "fcbacb82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.253887Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.253717Z",
-     "iopub.status.idle": "2026-08-31T18:18:56.260963Z",
-     "shell.execute_reply": "2026-08-31T18:18:56.260670Z"
+     "iopub.execute_input": "2026-09-01T05:36:20.108378Z",
+     "iopub.status.busy": "2026-09-01T05:36:20.108270Z",
+     "iopub.status.idle": "2026-09-01T05:36:20.112767Z",
+     "shell.execute_reply": "2026-09-01T05:36:20.112431Z"
     },
     "papermill": {
-     "duration": 0.01299,
-     "end_time": "2026-08-31T18:18:56.261421+00:00",
+     "duration": 0.010176,
+     "end_time": "2026-09-01T05:36:20.113068+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.248431+00:00",
+     "start_time": "2026-09-01T05:36:20.102892+00:00",
      "status": "completed"
     }
    },
@@ -2940,20 +3151,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "id": "30fc3828",
+   "execution_count": 30,
+   "id": "f131b25f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.271519Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.271433Z",
-     "iopub.status.idle": "2026-08-31T18:18:56.274749Z",
-     "shell.execute_reply": "2026-08-31T18:18:56.274471Z"
+     "iopub.execute_input": "2026-09-01T05:36:20.123256Z",
+     "iopub.status.busy": "2026-09-01T05:36:20.123171Z",
+     "iopub.status.idle": "2026-09-01T05:36:20.126395Z",
+     "shell.execute_reply": "2026-09-01T05:36:20.126118Z"
     },
     "papermill": {
-     "duration": 0.008943,
-     "end_time": "2026-08-31T18:18:56.275136+00:00",
+     "duration": 0.008675,
+     "end_time": "2026-09-01T05:36:20.126660+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.266193+00:00",
+     "start_time": "2026-09-01T05:36:20.117985+00:00",
      "status": "completed"
     }
    },
@@ -2992,13 +3203,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbf8c4a8",
+   "id": "fbbb9009",
    "metadata": {
     "papermill": {
-     "duration": 0.004372,
-     "end_time": "2026-08-31T18:18:56.284178+00:00",
+     "duration": 0.008334,
+     "end_time": "2026-09-01T05:36:20.139897+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.279806+00:00",
+     "start_time": "2026-09-01T05:36:20.131563+00:00",
      "status": "completed"
     }
    },
@@ -3008,20 +3219,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "id": "a9a68584",
+   "execution_count": 31,
+   "id": "27344547",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.294438Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.294325Z",
-     "iopub.status.idle": "2026-08-31T18:18:56.311723Z",
-     "shell.execute_reply": "2026-08-31T18:18:56.311410Z"
+     "iopub.execute_input": "2026-09-01T05:36:20.166256Z",
+     "iopub.status.busy": "2026-09-01T05:36:20.165862Z",
+     "iopub.status.idle": "2026-09-01T05:36:20.259023Z",
+     "shell.execute_reply": "2026-09-01T05:36:20.257686Z"
     },
     "papermill": {
-     "duration": 0.023138,
-     "end_time": "2026-08-31T18:18:56.312057+00:00",
+     "duration": 0.114603,
+     "end_time": "2026-09-01T05:36:20.264140+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.288919+00:00",
+     "start_time": "2026-09-01T05:36:20.149537+00:00",
      "status": "completed"
     }
    },
@@ -3030,7 +3241,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Factor attribution period: 2015-12-29 → 2023-11-29, n=1994\n",
+      "Factor attribution period: 2015-12-29 → 2023-11-29, n=1994\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "=== FF5+MOM Factor Attribution (HAC) ===\n",
       "Observations:     1994\n",
@@ -3082,20 +3299,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "0921c811",
+   "execution_count": 32,
+   "id": "5a6984ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:56.322217Z",
-     "iopub.status.busy": "2026-08-31T18:18:56.322125Z",
-     "iopub.status.idle": "2026-08-31T18:18:57.998592Z",
-     "shell.execute_reply": "2026-08-31T18:18:57.998093Z"
+     "iopub.execute_input": "2026-09-01T05:36:20.299003Z",
+     "iopub.status.busy": "2026-09-01T05:36:20.298791Z",
+     "iopub.status.idle": "2026-09-01T05:36:24.503538Z",
+     "shell.execute_reply": "2026-09-01T05:36:24.497143Z"
     },
     "papermill": {
-     "duration": 1.68231,
-     "end_time": "2026-08-31T18:18:57.999255+00:00",
+     "duration": 4.223861,
+     "end_time": "2026-09-01T05:36:24.508034+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:56.316945+00:00",
+     "start_time": "2026-09-01T05:36:20.284173+00:00",
      "status": "completed"
     }
    },
@@ -3124,13 +3341,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f4fbcad",
+   "id": "e9214c66",
    "metadata": {
     "papermill": {
-     "duration": 0.005189,
-     "end_time": "2026-08-31T18:18:58.010495+00:00",
+     "duration": 0.03806,
+     "end_time": "2026-09-01T05:36:24.581630+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:58.005306+00:00",
+     "start_time": "2026-09-01T05:36:24.543570+00:00",
      "status": "completed"
     }
    },
@@ -3140,20 +3357,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "0186a984",
+   "execution_count": 33,
+   "id": "06461cd5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:58.022214Z",
-     "iopub.status.busy": "2026-08-31T18:18:58.022108Z",
-     "iopub.status.idle": "2026-08-31T18:18:58.686222Z",
-     "shell.execute_reply": "2026-08-31T18:18:58.685490Z"
+     "iopub.execute_input": "2026-09-01T05:36:24.666156Z",
+     "iopub.status.busy": "2026-09-01T05:36:24.665352Z",
+     "iopub.status.idle": "2026-09-01T05:36:27.445457Z",
+     "shell.execute_reply": "2026-09-01T05:36:27.444564Z"
     },
     "papermill": {
-     "duration": 0.670892,
-     "end_time": "2026-08-31T18:18:58.686651+00:00",
+     "duration": 2.820174,
+     "end_time": "2026-09-01T05:36:27.445956+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:58.015759+00:00",
+     "start_time": "2026-09-01T05:36:24.625782+00:00",
      "status": "completed"
     }
    },
@@ -3226,20 +3443,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "id": "08bab649",
+   "execution_count": 34,
+   "id": "5a6a1c88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:58.701775Z",
-     "iopub.status.busy": "2026-08-31T18:18:58.701596Z",
-     "iopub.status.idle": "2026-08-31T18:18:59.265827Z",
-     "shell.execute_reply": "2026-08-31T18:18:59.265241Z"
+     "iopub.execute_input": "2026-09-01T05:36:27.467076Z",
+     "iopub.status.busy": "2026-09-01T05:36:27.466883Z",
+     "iopub.status.idle": "2026-09-01T05:36:27.845391Z",
+     "shell.execute_reply": "2026-09-01T05:36:27.844948Z"
     },
     "papermill": {
-     "duration": 0.573139,
-     "end_time": "2026-08-31T18:18:59.267048+00:00",
+     "duration": 0.388505,
+     "end_time": "2026-09-01T05:36:27.846446+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:58.693909+00:00",
+     "start_time": "2026-09-01T05:36:27.457941+00:00",
      "status": "completed"
     }
    },
@@ -3284,20 +3501,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "2cb925c1",
+   "execution_count": 35,
+   "id": "8810dcce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:59.293294Z",
-     "iopub.status.busy": "2026-08-31T18:18:59.293141Z",
-     "iopub.status.idle": "2026-08-31T18:18:59.446779Z",
-     "shell.execute_reply": "2026-08-31T18:18:59.446110Z"
+     "iopub.execute_input": "2026-09-01T05:36:27.860606Z",
+     "iopub.status.busy": "2026-09-01T05:36:27.860498Z",
+     "iopub.status.idle": "2026-09-01T05:36:27.954212Z",
+     "shell.execute_reply": "2026-09-01T05:36:27.953757Z"
     },
     "papermill": {
-     "duration": 0.167008,
-     "end_time": "2026-08-31T18:18:59.447213+00:00",
+     "duration": 0.10102,
+     "end_time": "2026-09-01T05:36:27.954603+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:59.280205+00:00",
+     "start_time": "2026-09-01T05:36:27.853583+00:00",
      "status": "completed"
     }
    },
@@ -3320,13 +3537,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02bf4c92",
+   "id": "fb1805ad",
    "metadata": {
     "papermill": {
-     "duration": 0.008066,
-     "end_time": "2026-08-31T18:18:59.463897+00:00",
+     "duration": 0.005801,
+     "end_time": "2026-09-01T05:36:27.966494+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:59.455831+00:00",
+     "start_time": "2026-09-01T05:36:27.960693+00:00",
      "status": "completed"
     }
    },
@@ -3348,13 +3565,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17bf7e40",
+   "id": "337f265d",
    "metadata": {
     "papermill": {
-     "duration": 0.007652,
-     "end_time": "2026-08-31T18:18:59.480299+00:00",
+     "duration": 0.00606,
+     "end_time": "2026-09-01T05:36:27.978592+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:59.472647+00:00",
+     "start_time": "2026-09-01T05:36:27.972532+00:00",
      "status": "completed"
     }
    },
@@ -3377,20 +3594,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "id": "59923a07",
+   "execution_count": 36,
+   "id": "d0d72122",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:18:59.497573Z",
-     "iopub.status.busy": "2026-08-31T18:18:59.497391Z",
-     "iopub.status.idle": "2026-08-31T18:19:02.193649Z",
-     "shell.execute_reply": "2026-08-31T18:19:02.192892Z"
+     "iopub.execute_input": "2026-09-01T05:36:27.991679Z",
+     "iopub.status.busy": "2026-09-01T05:36:27.991559Z",
+     "iopub.status.idle": "2026-09-01T05:36:30.606474Z",
+     "shell.execute_reply": "2026-09-01T05:36:30.606113Z"
     },
     "papermill": {
-     "duration": 2.705886,
-     "end_time": "2026-08-31T18:19:02.194179+00:00",
+     "duration": 2.622251,
+     "end_time": "2026-09-01T05:36:30.606855+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:18:59.488293+00:00",
+     "start_time": "2026-09-01T05:36:27.984604+00:00",
      "status": "completed"
     }
    },
@@ -3410,7 +3627,7 @@
      "output_type": "stream",
      "text": [
       "Tear sheet written to: ~/ml4t/public-s6-etfs/case_studies/ch20_etfs/etfs_tearsheet.html\n",
-      "HTML size: 1,134,023 bytes\n"
+      "HTML size: 1,134,024 bytes\n"
      ]
     }
    ],
@@ -3431,7 +3648,7 @@
     "\n",
     "meta = BacktestReportMetadata(\n",
     "    title=\"ETFs - The selected configuration Lineage\",\n",
-    "    strategy_name=f\"{RANK1_FAMILY}/{RANK1_CONFIG} - {PRIMARY_LABEL}\",\n",
+    "    strategy_name=f\"{RANK1_FAMILY}/{RANK1_CONFIG} - {SELECTED_LABEL}\",\n",
     "    universe=f\"{setup['universe'].get('size', 100)} ETFs across categories\",\n",
     "    benchmark_name=\"ETF equal-weight universe (validation window)\",\n",
     "    evaluation_window=f\"{aligned['ts'].min()} to {aligned['ts'].max()}\",\n",
@@ -3454,13 +3671,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20b50739",
+   "id": "acc7d5d8",
    "metadata": {
     "papermill": {
-     "duration": 0.00592,
-     "end_time": "2026-08-31T18:19:02.206233+00:00",
+     "duration": 0.005699,
+     "end_time": "2026-09-01T05:36:30.618328+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:19:02.200313+00:00",
+     "start_time": "2026-09-01T05:36:30.612629+00:00",
      "status": "completed"
     }
    },
@@ -3474,20 +3691,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "id": "25d4b2e1",
+   "execution_count": 37,
+   "id": "46725512",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:19:02.217989Z",
-     "iopub.status.busy": "2026-08-31T18:19:02.217869Z",
-     "iopub.status.idle": "2026-08-31T18:19:02.221068Z",
-     "shell.execute_reply": "2026-08-31T18:19:02.220650Z"
+     "iopub.execute_input": "2026-09-01T05:36:30.630120Z",
+     "iopub.status.busy": "2026-09-01T05:36:30.630016Z",
+     "iopub.status.idle": "2026-09-01T05:36:30.632762Z",
+     "shell.execute_reply": "2026-09-01T05:36:30.632459Z"
     },
     "papermill": {
-     "duration": 0.009477,
-     "end_time": "2026-08-31T18:19:02.221389+00:00",
+     "duration": 0.009489,
+     "end_time": "2026-09-01T05:36:30.633350+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:19:02.211912+00:00",
+     "start_time": "2026-09-01T05:36:30.623861+00:00",
      "status": "completed"
     }
    },
@@ -3537,20 +3754,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "id": "f36b78b4",
+   "execution_count": 38,
+   "id": "dce7b168",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:19:02.233700Z",
-     "iopub.status.busy": "2026-08-31T18:19:02.233545Z",
-     "iopub.status.idle": "2026-08-31T18:19:02.237437Z",
-     "shell.execute_reply": "2026-08-31T18:19:02.236951Z"
+     "iopub.execute_input": "2026-09-01T05:36:30.651033Z",
+     "iopub.status.busy": "2026-09-01T05:36:30.650922Z",
+     "iopub.status.idle": "2026-09-01T05:36:30.654187Z",
+     "shell.execute_reply": "2026-09-01T05:36:30.653884Z"
     },
     "papermill": {
-     "duration": 0.010442,
-     "end_time": "2026-08-31T18:19:02.237758+00:00",
+     "duration": 0.013093,
+     "end_time": "2026-09-01T05:36:30.654511+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:19:02.227316+00:00",
+     "start_time": "2026-09-01T05:36:30.641418+00:00",
      "status": "completed"
     }
    },
@@ -3608,13 +3825,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f395e75a",
+   "id": "198d326e",
    "metadata": {
     "papermill": {
-     "duration": 0.005391,
-     "end_time": "2026-08-31T18:19:02.248981+00:00",
+     "duration": 0.005684,
+     "end_time": "2026-09-01T05:36:30.665981+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:19:02.243590+00:00",
+     "start_time": "2026-09-01T05:36:30.660297+00:00",
      "status": "completed"
     }
    },
@@ -3646,13 +3863,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff425240",
+   "id": "4d4c6c5d",
    "metadata": {
     "papermill": {
-     "duration": 0.005545,
-     "end_time": "2026-08-31T18:19:02.260088+00:00",
+     "duration": 0.005663,
+     "end_time": "2026-09-01T05:36:30.677177+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:19:02.254543+00:00",
+     "start_time": "2026-09-01T05:36:30.671514+00:00",
      "status": "completed"
     }
    },
@@ -3669,20 +3886,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "id": "328202a2",
+   "execution_count": 39,
+   "id": "ab9d37ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T18:19:02.272483Z",
-     "iopub.status.busy": "2026-08-31T18:19:02.272366Z",
-     "iopub.status.idle": "2026-08-31T18:19:02.277247Z",
-     "shell.execute_reply": "2026-08-31T18:19:02.276896Z"
+     "iopub.execute_input": "2026-09-01T05:36:30.689455Z",
+     "iopub.status.busy": "2026-09-01T05:36:30.689349Z",
+     "iopub.status.idle": "2026-09-01T05:36:30.696429Z",
+     "shell.execute_reply": "2026-09-01T05:36:30.696015Z"
     },
     "papermill": {
-     "duration": 0.012031,
-     "end_time": "2026-08-31T18:19:02.277583+00:00",
+     "duration": 0.013714,
+     "end_time": "2026-09-01T05:36:30.696737+00:00",
      "exception": false,
-     "start_time": "2026-08-31T18:19:02.265552+00:00",
+     "start_time": "2026-09-01T05:36:30.683023+00:00",
      "status": "completed"
     }
    },
@@ -3704,7 +3921,7 @@
     "    \"rank1\": {\n",
     "        \"family\": RANK1_FAMILY,\n",
     "        \"config_name\": RANK1_CONFIG,\n",
-    "        \"label\": PRIMARY_LABEL,\n",
+    "        \"label\": SELECTED_LABEL,\n",
     "        \"prediction_hash\": TOP_PHASH,\n",
     "        \"validation_backtest_hash\": TOP_HASH,\n",
     "        \"holdout_backtest_hash\": HO_HASH,  # None until the holdout has been evaluated\n",
@@ -3833,22 +4050,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-08-31T18:19:09.555159+00:00",
+   "executed_at": "2026-09-01T05:36:38.354226+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "dd3091d9e80766a920e7506bf57bf51024d8ae6c"
+   "source_py_blob": "95174931419f114bebaafef5a93b450f367f82ba"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 66.860522,
-   "end_time": "2026-08-31T18:19:03.698681+00:00",
+   "duration": 80.192246,
+   "end_time": "2026-09-01T05:36:33.214905+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "~/ml4t/public-s6-etfs/case_studies/etfs/20_strategy_analysis.ipynb",
-   "output_path": "~/ml4t/public-s6-etfs/case_studies/etfs/.20_strategy_analysis.papermill.2029419.ipynb",
+   "output_path": "~/ml4t/public-s6-etfs/case_studies/etfs/.20_strategy_analysis.papermill.3577629.ipynb",
    "parameters": {},
-   "start_time": "2026-08-31T18:17:56.838159+00:00",
+   "start_time": "2026-09-01T05:35:13.022659+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/etfs/20_strategy_analysis.py
+++ b/case_studies/etfs/20_strategy_analysis.py
@@ -111,6 +111,7 @@ from case_studies.utils.strategy_analysis import (
     plot_concentration_curve,
     plot_equity_drawdown,
     plot_sharpe_waterfall,
+    resolve_canonical_rank1_lineage,
     resolve_holdout_self_backtest,
     write_strategy_assessment,
 )
@@ -158,15 +159,15 @@ print(explorer)
 LIVE_PREDICTIONS = (
     split_unpublished_members(
         study,
-        load_prediction_index(CASE_STUDY, label=PRIMARY_LABEL, split="validation"),
+        load_prediction_index(CASE_STUDY, split="validation"),
     )
     .live["prediction_hash"]
     .to_list()
 )
 if not LIVE_PREDICTIONS:
     raise RuntimeError(
-        f"no live prediction sets for {CASE_STUDY}/{PRIMARY_LABEL}/validation; run the model "
-        "stage and 14_backtest first"
+        f"no live prediction sets for {CASE_STUDY}/validation; run the model stage and "
+        "14_backtest first"
     )
 print(f"Live prediction sets: {len(LIVE_PREDICTIONS):,}")
 
@@ -266,6 +267,54 @@ def _stale_derived_rows(live: list[str]) -> tuple[int, int]:
     return stale_cohort, stale_paired
 
 
+# §1 reports the configuration the validation stages ranked first, and the paired-metrics
+# producer below has to be told what it is. Left to itself the producer ranks the registry on
+# raw Sharpe, which is a second selector beside this one - it applies neither the common-support
+# re-ranking a conformal candidate forces nor the restrictions the resolver holds. The two agree
+# on this registry today, which is why the published rows are right; etfs now has a second fully
+# backtested label, so agreement is a fact about this registry rather than a property of either
+# ranking. So the selection is resolved here, before anything is written, and the two rankings
+# are required to agree rather than assumed to.
+
+# %%
+_HOLDOUT_STAGES = ("signal", "allocation", "risk_overlay")
+_FIELD = (
+    pl.concat(
+        [
+            explorer.best(stage=s, top_n=2000, prediction_hashes=LIVE_PREDICTIONS)
+            for s in _HOLDOUT_STAGES
+        ],
+        how="diagonal_relaxed",
+    )
+    .filter(pl.col("family") != "benchmark")
+    .sort("sharpe", descending=True)
+    .unique(subset=["prediction_hash"], keep="first", maintain_order=True)
+)
+ADMITTED = frozenset(_FIELD["backtest_hash"].to_list())
+top_signal = _FIELD.head(1)
+TOP_HASH = top_signal.row(0, named=True)["backtest_hash"]
+TOP_PHASH = top_signal.row(0, named=True)["prediction_hash"]
+RANK1_FAMILY = top_signal.row(0, named=True)["family"]
+RANK1_CONFIG = top_signal.row(0, named=True)["config_name"]
+# Every label the case study declares is backtested equal-weight and competes here; what wins
+# decides the label everything below is keyed to. Reading `labels.primary` instead was only ever
+# right by coincidence, and etfs has a second fully backtested label, so the coincidence is not
+# one to rely on. The primary is kept as the declared value, to say when the two differ.
+SELECTED_LABEL = top_signal.row(0, named=True)["label"]
+
+# The resolver is given the same field, not the whole registry: it re-ranks on common timestamp
+# support wherever a conformal candidate is present, so a row this notebook never admitted would
+# otherwise decide how far the intersection reaches and therefore which admitted row wins.
+CARRIER = resolve_canonical_rank1_lineage(CASE_STUDY, admitted=ADMITTED)
+if CARRIER["val_backtest_hash"] != TOP_HASH:
+    raise RuntimeError(
+        "this notebook's ranking and the canonical resolver disagree on the carrier: "
+        f"{TOP_HASH} against {CARRIER['val_backtest_hash']}. Everything below reports the "
+        "first and the paired rows would be written against the second, so the decay would "
+        "compare the right holdout against a different strategy."
+    )
+
+# %%
 have_kinds, have_cohorts = _derived_table_state()
 stale_cohort, stale_paired = _stale_derived_rows(LIVE_PREDICTIONS)
 missing_kinds = sorted(set(PAIRED_KINDS) - have_kinds)
@@ -291,7 +340,7 @@ if missing_kinds or stale_paired:
         if missing_kinds
         else f"{stale_paired} pair(s) challenged by a retired prediction"
     )
-    rows = populate_paired_metrics(CASE_STUDY, prediction_hashes=LIVE_PREDICTIONS)
+    rows = populate_paired_metrics(CASE_STUDY, prediction_hashes=LIVE_PREDICTIONS, carrier=CARRIER)
     written = sum(1 for r in rows if "skip" not in r)
     print(f"backtest_paired_metrics: wrote {written} pairs ({reason})")
 else:
@@ -424,25 +473,6 @@ def _changed(challenger_hash: str, benchmark_hash: str) -> list[str]:
 # than about the signal - and the interval on the IC is what says which case this is.
 
 # %%
-_HOLDOUT_STAGES = ("signal", "allocation", "risk_overlay")
-top_signal = (
-    pl.concat(
-        [
-            explorer.best(stage=s, top_n=2000, prediction_hashes=LIVE_PREDICTIONS)
-            for s in _HOLDOUT_STAGES
-        ],
-        how="diagonal_relaxed",
-    )
-    .filter(pl.col("family") != "benchmark")
-    .sort("sharpe", descending=True)
-    .unique(subset=["prediction_hash"], keep="first", maintain_order=True)
-    .head(1)
-)
-TOP_HASH = top_signal.row(0, named=True)["backtest_hash"]
-TOP_PHASH = top_signal.row(0, named=True)["prediction_hash"]
-RANK1_FAMILY = top_signal.row(0, named=True)["family"]
-RANK1_CONFIG = top_signal.row(0, named=True)["config_name"]
-
 _db = CASE_DIR / "run_log" / "registry.db"
 with sqlite3.connect(str(_db)) as _con:
     _row = _con.execute(
@@ -453,7 +483,7 @@ with sqlite3.connect(str(_db)) as _con:
     ).fetchone()
 ic_mean, ic_lo, ic_hi, ic_t, ic_p, ic_ndays, ic_lag, ic_pct = _row
 
-print(f"Rank-1: family={RANK1_FAMILY}, config={RANK1_CONFIG}, label={PRIMARY_LABEL}")
+print(f"Rank-1: family={RANK1_FAMILY}, config={RANK1_CONFIG}, label={SELECTED_LABEL}")
 print(f"        prediction_hash={TOP_PHASH}, backtest_hash={TOP_HASH}")
 print()
 print("Daily-pooled IC (validation):")
@@ -738,7 +768,7 @@ spec_block = {
     "case_study": CASE_STUDY,
     "family": RANK1_FAMILY,
     "config_name": RANK1_CONFIG,
-    "label": PRIMARY_LABEL,
+    "label": SELECTED_LABEL,
     "signal_method": lineage["signal"].get("signal_method"),
     "top_k": lineage["signal"].get("top_k"),
     "allocation": lineage.get("allocation", {}).get("allocator"),
@@ -849,7 +879,7 @@ print(headline)
 
 # %%
 # Forest plot: rank-1 metrics with CI bars + reference lines
-ew_val = load_benchmark_metrics(CASE_STUDY, PRIMARY_LABEL, period="validation")
+ew_val = load_benchmark_metrics(CASE_STUDY, SELECTED_LABEL, period="validation")
 forest_metrics = [
     ("Sharpe", full["sharpe"], full["sharpe_ci95_lo"], full["sharpe_ci95_hi"]),
     ("Sortino", full["sortino"], full["sortino_ci95_lo"], full["sortino_ci95_hi"]),
@@ -910,7 +940,7 @@ strat_df = (
 )
 
 bench_val = (
-    load_benchmark_returns(CASE_STUDY, PRIMARY_LABEL, period="validation")
+    load_benchmark_returns(CASE_STUDY, SELECTED_LABEL, period="validation")
     .with_columns(pl.col("timestamp").cast(pl.Date).alias("ts"))
     .select(pl.col("ts"), pl.col("ew_return").alias("benchmark"))
 )
@@ -1344,7 +1374,7 @@ HO_VS_EW_AVAILABLE = he is not None
 if not HO_VS_EW_AVAILABLE:
     print("No holdout strategy-versus-benchmark comparison to report.")
 else:
-    ew_ho = load_benchmark_metrics(CASE_STUDY, PRIMARY_LABEL, period="holdout")
+    ew_ho = load_benchmark_metrics(CASE_STUDY, SELECTED_LABEL, period="holdout")
     print("Holdout strategy against the holdout-window equal-weight universe:")
     print(f"  strategy Sharpe:  {ho_full['sharpe']:.3f}")
     print(f"  EW Sharpe:        {ew_ho['sharpe']:.3f}")
@@ -1597,7 +1627,7 @@ bench_series = aligned["benchmark"].to_numpy()
 
 meta = BacktestReportMetadata(
     title="ETFs - The selected configuration Lineage",
-    strategy_name=f"{RANK1_FAMILY}/{RANK1_CONFIG} - {PRIMARY_LABEL}",
+    strategy_name=f"{RANK1_FAMILY}/{RANK1_CONFIG} - {SELECTED_LABEL}",
     universe=f"{setup['universe'].get('size', 100)} ETFs across categories",
     benchmark_name="ETF equal-weight universe (validation window)",
     evaluation_window=f"{aligned['ts'].min()} to {aligned['ts'].max()}",
@@ -1724,7 +1754,7 @@ assessment = {
     "rank1": {
         "family": RANK1_FAMILY,
         "config_name": RANK1_CONFIG,
-        "label": PRIMARY_LABEL,
+        "label": SELECTED_LABEL,
         "prediction_hash": TOP_PHASH,
         "validation_backtest_hash": TOP_HASH,
         "holdout_backtest_hash": HO_HASH,  # None until the holdout has been evaluated


### PR DESCRIPTION
etfs: let both declared labels compete, and tell the paired producer what won

Two scope defects, one cause: this notebook resolved its selection over the
primary label alone while etfs now backtests two.

The field was restricted to fwd_ret_21d's live predictions, so fwd_ret_5d could
not win no matter how it scored. Every declared label is backtested equal-weight
and that is what makes them comparable, so all of them belong in the field. The
label everything downstream is keyed to - the benchmark, the returns, the tear
sheet, the assessment - now comes off the winner rather than off labels.primary,
which was only the winner's label by coincidence.

The outcome is unchanged and is now verified rather than assumed: with 494 live
prediction sets across both labels, rank-1 is still gbm/default_mae on
fwd_ret_21d, backtest fb287093aa02, and its holdout is re-used untouched.
fwd_ret_21d's best across the selection stages is 1.1503 against fwd_ret_5d's
1.1182 - close enough that the restriction was carrying the result.

populate_paired_metrics was called without carrier=, which falls back to ranking
the registry on raw Sharpe. That is a second selector beside this notebook's,
applying neither the common-support re-ranking a conformal candidate forces nor
the resolver's restrictions. It happened to agree here, which is why the
published pairs were right. The selection is resolved before anything is written
and the two rankings now have to agree rather than being assumed to.

replace_all is deliberately NOT passed: the run is scoped to this notebook's
population, and pruning to a partial write would delete the pairs Chapter 20
registered for other labels.

Verification: rank-1 is unchanged (gbm/default_mae, fwd_ret_21d, backtest fb287093aa02) with 494 live prediction sets across both labels, so the holdout is re-used untouched at zero cost.
