### PR TITLE
fx_pairs: scope the cohort statistics to the admitted population

### DIFF
--- a/case_studies/fx_pairs/19_strategy_analysis.ipynb
+++ b/case_studies/fx_pairs/19_strategy_analysis.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "39b4e63f",
+   "id": "330e563d",
    "metadata": {
     "papermill": {
-     "duration": 0.00265,
-     "end_time": "2026-08-31T03:19:55.128728+00:00",
+     "duration": 0.001525,
+     "end_time": "2026-09-01T05:11:59.481039+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:19:55.126078+00:00",
+     "start_time": "2026-09-01T05:11:59.479514+00:00",
      "status": "completed"
     }
    },
@@ -41,19 +41,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "c0b2f31d",
+   "id": "ac9ef753",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:19:55.132194Z",
-     "iopub.status.busy": "2026-08-31T03:19:55.132021Z",
-     "iopub.status.idle": "2026-08-31T03:19:58.624798Z",
-     "shell.execute_reply": "2026-08-31T03:19:58.623337Z"
+     "iopub.execute_input": "2026-09-01T05:11:59.484548Z",
+     "iopub.status.busy": "2026-09-01T05:11:59.484436Z",
+     "iopub.status.idle": "2026-09-01T05:12:02.466377Z",
+     "shell.execute_reply": "2026-09-01T05:12:02.465832Z"
     },
     "papermill": {
-     "duration": 3.496375,
-     "end_time": "2026-08-31T03:19:58.626413+00:00",
+     "duration": 2.984301,
+     "end_time": "2026-09-01T05:12:02.466802+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:19:55.130038+00:00",
+     "start_time": "2026-09-01T05:11:59.482501+00:00",
      "status": "completed"
     }
    },
@@ -109,19 +109,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "2c8dfdc6",
+   "id": "edb57afe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:19:58.638740Z",
-     "iopub.status.busy": "2026-08-31T03:19:58.638432Z",
-     "iopub.status.idle": "2026-08-31T03:19:58.641892Z",
-     "shell.execute_reply": "2026-08-31T03:19:58.641312Z"
+     "iopub.execute_input": "2026-09-01T05:12:02.470037Z",
+     "iopub.status.busy": "2026-09-01T05:12:02.469950Z",
+     "iopub.status.idle": "2026-09-01T05:12:02.471939Z",
+     "shell.execute_reply": "2026-09-01T05:12:02.471548Z"
     },
     "papermill": {
-     "duration": 0.010605,
-     "end_time": "2026-08-31T03:19:58.642366+00:00",
+     "duration": 0.003994,
+     "end_time": "2026-09-01T05:12:02.472220+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:19:58.631761+00:00",
+     "start_time": "2026-09-01T05:12:02.468226+00:00",
      "status": "completed"
     },
     "tags": [
@@ -138,13 +138,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86d6d423",
+   "id": "7b7445f7",
    "metadata": {
     "papermill": {
-     "duration": 0.001586,
-     "end_time": "2026-08-31T03:19:58.646061+00:00",
+     "duration": 0.002217,
+     "end_time": "2026-09-01T05:12:02.475678+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:19:58.644475+00:00",
+     "start_time": "2026-09-01T05:12:02.473461+00:00",
      "status": "completed"
     }
    },
@@ -172,19 +172,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6e92ee84",
+   "id": "0821271b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:19:58.650463Z",
-     "iopub.status.busy": "2026-08-31T03:19:58.650263Z",
-     "iopub.status.idle": "2026-08-31T03:20:14.930253Z",
-     "shell.execute_reply": "2026-08-31T03:20:14.929710Z"
+     "iopub.execute_input": "2026-09-01T05:12:02.480342Z",
+     "iopub.status.busy": "2026-09-01T05:12:02.480263Z",
+     "iopub.status.idle": "2026-09-01T05:12:16.585702Z",
+     "shell.execute_reply": "2026-09-01T05:12:16.584965Z"
     },
     "papermill": {
-     "duration": 16.283019,
-     "end_time": "2026-08-31T03:20:14.930707+00:00",
+     "duration": 14.108315,
+     "end_time": "2026-09-01T05:12:16.586205+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:19:58.647688+00:00",
+     "start_time": "2026-09-01T05:12:02.477890+00:00",
      "status": "completed"
     },
     "tags": [
@@ -236,6 +236,20 @@
     "# intersection and change which admitted row is reported.\n",
     "holdout_candidates = CandidateSet.one(study, name=CANDIDATE_SET_NAME)\n",
     "ADMITTED = frozenset(holdout_candidates.members)\n",
+    "# The prediction sets behind the admitted backtests. `compute_and_register` scopes cohorts by\n",
+    "# prediction rather than by backtest, and left unscoped it computes the effective trial count and\n",
+    "# the deflated Sharpe over the whole registry - every retired generation and every configuration\n",
+    "# no population publishes included. K is what the deflation divides by, so an unscoped call\n",
+    "# reports a correction computed over a population this page does not describe.\n",
+    "with sqlite3.connect(str(get_case_study_dir(CASE_STUDY_ID) / \"run_log\" / \"registry.db\")) as _con:\n",
+    "    ADMITTED_PREDICTIONS = [\n",
+    "        row[0]\n",
+    "        for row in _con.execute(\n",
+    "            \"SELECT DISTINCT prediction_hash FROM backtest_runs \"\n",
+    "            f\"WHERE backtest_hash IN ({','.join('?' * len(ADMITTED))})\",\n",
+    "            tuple(sorted(ADMITTED)),\n",
+    "        )\n",
+    "    ]\n",
     "carrier = resolve_solvent_carrier(CASE_STUDY_ID, admitted=ADMITTED)\n",
     "\n",
     "selected_validation = study.results.open(str(carrier[\"val_backtest_hash\"]))\n",
@@ -285,13 +299,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9520b149",
+   "id": "8e778b61",
    "metadata": {
     "papermill": {
-     "duration": 0.001225,
-     "end_time": "2026-08-31T03:20:14.934535+00:00",
+     "duration": 0.001437,
+     "end_time": "2026-09-01T05:12:16.589365+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:14.933310+00:00",
+     "start_time": "2026-09-01T05:12:16.587928+00:00",
      "status": "completed"
     }
    },
@@ -308,19 +322,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "67cbe2b8",
+   "id": "a47f6708",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:20:14.937679Z",
-     "iopub.status.busy": "2026-08-31T03:20:14.937544Z",
-     "iopub.status.idle": "2026-08-31T03:20:14.941796Z",
-     "shell.execute_reply": "2026-08-31T03:20:14.941385Z"
+     "iopub.execute_input": "2026-09-01T05:12:16.593148Z",
+     "iopub.status.busy": "2026-09-01T05:12:16.592935Z",
+     "iopub.status.idle": "2026-09-01T05:12:16.598526Z",
+     "shell.execute_reply": "2026-09-01T05:12:16.597900Z"
     },
     "papermill": {
-     "duration": 0.006365,
-     "end_time": "2026-08-31T03:20:14.942148+00:00",
+     "duration": 0.008297,
+     "end_time": "2026-09-01T05:12:16.598988+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:14.935783+00:00",
+     "start_time": "2026-09-01T05:12:16.590691+00:00",
      "status": "completed"
     },
     "tags": [
@@ -404,13 +418,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78ee194a",
+   "id": "9673b95b",
    "metadata": {
     "papermill": {
-     "duration": 0.00124,
-     "end_time": "2026-08-31T03:20:14.944798+00:00",
+     "duration": 0.00145,
+     "end_time": "2026-09-01T05:12:16.602147+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:14.943558+00:00",
+     "start_time": "2026-09-01T05:12:16.600697+00:00",
      "status": "completed"
     }
    },
@@ -424,19 +438,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "35d06afe",
+   "id": "1886a7a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:20:14.947818Z",
-     "iopub.status.busy": "2026-08-31T03:20:14.947735Z",
-     "iopub.status.idle": "2026-08-31T03:20:53.055396Z",
-     "shell.execute_reply": "2026-08-31T03:20:53.054878Z"
+     "iopub.execute_input": "2026-09-01T05:12:16.605764Z",
+     "iopub.status.busy": "2026-09-01T05:12:16.605594Z",
+     "iopub.status.idle": "2026-09-01T05:12:47.241733Z",
+     "shell.execute_reply": "2026-09-01T05:12:47.241283Z"
     },
     "papermill": {
-     "duration": 38.110845,
-     "end_time": "2026-08-31T03:20:53.056915+00:00",
+     "duration": 30.639847,
+     "end_time": "2026-09-01T05:12:47.243427+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:14.946070+00:00",
+     "start_time": "2026-09-01T05:12:16.603580+00:00",
      "status": "completed"
     },
     "tags": [
@@ -562,19 +576,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "212ec6b4",
+   "id": "f4ce867e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:20:53.060519Z",
-     "iopub.status.busy": "2026-08-31T03:20:53.060423Z",
-     "iopub.status.idle": "2026-08-31T03:20:55.314368Z",
-     "shell.execute_reply": "2026-08-31T03:20:55.313883Z"
+     "iopub.execute_input": "2026-09-01T05:12:47.247104Z",
+     "iopub.status.busy": "2026-09-01T05:12:47.246950Z",
+     "iopub.status.idle": "2026-09-01T05:12:48.943561Z",
+     "shell.execute_reply": "2026-09-01T05:12:48.943140Z"
     },
     "papermill": {
-     "duration": 2.257232,
-     "end_time": "2026-08-31T03:20:55.315723+00:00",
+     "duration": 1.699801,
+     "end_time": "2026-09-01T05:12:48.944683+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:53.058491+00:00",
+     "start_time": "2026-09-01T05:12:47.244882+00:00",
      "status": "completed"
     },
     "tags": [
@@ -9399,13 +9413,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c968c784",
+   "id": "48fce073",
    "metadata": {
     "papermill": {
-     "duration": 0.003293,
-     "end_time": "2026-08-31T03:20:55.322642+00:00",
+     "duration": 0.003303,
+     "end_time": "2026-09-01T05:12:48.951540+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:55.319349+00:00",
+     "start_time": "2026-09-01T05:12:48.948237+00:00",
      "status": "completed"
     }
    },
@@ -9420,19 +9434,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "67696fb4",
+   "id": "abf42aab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:20:55.330332Z",
-     "iopub.status.busy": "2026-08-31T03:20:55.330180Z",
-     "iopub.status.idle": "2026-08-31T03:20:55.935967Z",
-     "shell.execute_reply": "2026-08-31T03:20:55.935485Z"
+     "iopub.execute_input": "2026-09-01T05:12:48.959048Z",
+     "iopub.status.busy": "2026-09-01T05:12:48.958939Z",
+     "iopub.status.idle": "2026-09-01T05:12:49.443465Z",
+     "shell.execute_reply": "2026-09-01T05:12:49.442958Z"
     },
     "papermill": {
-     "duration": 0.610838,
-     "end_time": "2026-08-31T03:20:55.936735+00:00",
+     "duration": 0.488825,
+     "end_time": "2026-09-01T05:12:49.443838+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:55.325897+00:00",
+     "start_time": "2026-09-01T05:12:48.955013+00:00",
      "status": "completed"
     },
     "tags": [
@@ -9542,19 +9556,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "0f715370",
+   "id": "2bab1ae4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:20:55.945919Z",
-     "iopub.status.busy": "2026-08-31T03:20:55.945696Z",
-     "iopub.status.idle": "2026-08-31T03:20:57.803473Z",
-     "shell.execute_reply": "2026-08-31T03:20:57.802728Z"
+     "iopub.execute_input": "2026-09-01T05:12:49.452540Z",
+     "iopub.status.busy": "2026-09-01T05:12:49.452419Z",
+     "iopub.status.idle": "2026-09-01T05:12:50.886424Z",
+     "shell.execute_reply": "2026-09-01T05:12:50.886117Z"
     },
     "papermill": {
-     "duration": 1.862865,
-     "end_time": "2026-08-31T03:20:57.803849+00:00",
+     "duration": 1.439292,
+     "end_time": "2026-09-01T05:12:50.886843+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:55.940984+00:00",
+     "start_time": "2026-09-01T05:12:49.447551+00:00",
      "status": "completed"
     },
     "tags": [
@@ -9732,19 +9746,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "7f6cd727",
+   "id": "abe5bbfe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:20:57.814796Z",
-     "iopub.status.busy": "2026-08-31T03:20:57.814630Z",
-     "iopub.status.idle": "2026-08-31T03:20:57.907179Z",
-     "shell.execute_reply": "2026-08-31T03:20:57.906147Z"
+     "iopub.execute_input": "2026-09-01T05:12:50.896023Z",
+     "iopub.status.busy": "2026-09-01T05:12:50.895906Z",
+     "iopub.status.idle": "2026-09-01T05:12:50.966461Z",
+     "shell.execute_reply": "2026-09-01T05:12:50.966076Z"
     },
     "papermill": {
-     "duration": 0.099383,
-     "end_time": "2026-08-31T03:20:57.908358+00:00",
+     "duration": 0.075704,
+     "end_time": "2026-09-01T05:12:50.966981+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:57.808975+00:00",
+     "start_time": "2026-09-01T05:12:50.891277+00:00",
      "status": "completed"
     },
     "tags": [
@@ -9820,19 +9834,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "b50bccaf",
+   "id": "cc0b0fa5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:20:57.924397Z",
-     "iopub.status.busy": "2026-08-31T03:20:57.924183Z",
-     "iopub.status.idle": "2026-08-31T03:20:59.846092Z",
-     "shell.execute_reply": "2026-08-31T03:20:59.845712Z"
+     "iopub.execute_input": "2026-09-01T05:12:50.976861Z",
+     "iopub.status.busy": "2026-09-01T05:12:50.976751Z",
+     "iopub.status.idle": "2026-09-01T05:12:52.384032Z",
+     "shell.execute_reply": "2026-09-01T05:12:52.383492Z"
     },
     "papermill": {
-     "duration": 1.928839,
-     "end_time": "2026-08-31T03:20:59.846430+00:00",
+     "duration": 1.412048,
+     "end_time": "2026-09-01T05:12:52.384438+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:57.917591+00:00",
+     "start_time": "2026-09-01T05:12:50.972390+00:00",
      "status": "completed"
     },
     "tags": [
@@ -10021,13 +10035,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d87d552",
+   "id": "7ee558f0",
    "metadata": {
     "papermill": {
-     "duration": 0.007941,
-     "end_time": "2026-08-31T03:20:59.858826+00:00",
+     "duration": 0.004327,
+     "end_time": "2026-09-01T05:12:52.393567+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:59.850885+00:00",
+     "start_time": "2026-09-01T05:12:52.389240+00:00",
      "status": "completed"
     }
    },
@@ -10040,19 +10054,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "ea421d2c",
+   "id": "5b3e2742",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:20:59.874905Z",
-     "iopub.status.busy": "2026-08-31T03:20:59.874742Z",
-     "iopub.status.idle": "2026-08-31T03:20:59.879668Z",
-     "shell.execute_reply": "2026-08-31T03:20:59.879234Z"
+     "iopub.execute_input": "2026-09-01T05:12:52.402728Z",
+     "iopub.status.busy": "2026-09-01T05:12:52.402584Z",
+     "iopub.status.idle": "2026-09-01T05:12:52.407530Z",
+     "shell.execute_reply": "2026-09-01T05:12:52.407025Z"
     },
     "papermill": {
-     "duration": 0.013639,
-     "end_time": "2026-08-31T03:20:59.880021+00:00",
+     "duration": 0.010152,
+     "end_time": "2026-09-01T05:12:52.407875+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:59.866382+00:00",
+     "start_time": "2026-09-01T05:12:52.397723+00:00",
      "status": "completed"
     },
     "tags": [
@@ -10122,13 +10136,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76b1ab3e",
+   "id": "a2346142",
    "metadata": {
     "papermill": {
-     "duration": 0.00976,
-     "end_time": "2026-08-31T03:20:59.897793+00:00",
+     "duration": 0.003964,
+     "end_time": "2026-09-01T05:12:52.416518+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:59.888033+00:00",
+     "start_time": "2026-09-01T05:12:52.412554+00:00",
      "status": "completed"
     }
    },
@@ -10146,19 +10160,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "82842370",
+   "id": "52aeb548",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:20:59.920643Z",
-     "iopub.status.busy": "2026-08-31T03:20:59.920228Z",
-     "iopub.status.idle": "2026-08-31T03:21:08.422525Z",
-     "shell.execute_reply": "2026-08-31T03:21:08.421691Z"
+     "iopub.execute_input": "2026-09-01T05:12:52.425700Z",
+     "iopub.status.busy": "2026-09-01T05:12:52.425585Z",
+     "iopub.status.idle": "2026-09-01T05:12:58.625733Z",
+     "shell.execute_reply": "2026-09-01T05:12:58.625286Z"
     },
     "papermill": {
-     "duration": 8.515349,
-     "end_time": "2026-08-31T03:21:08.423328+00:00",
+     "duration": 6.205312,
+     "end_time": "2026-09-01T05:12:58.626056+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:20:59.907979+00:00",
+     "start_time": "2026-09-01T05:12:52.420744+00:00",
      "status": "completed"
     },
     "tags": [
@@ -10337,13 +10351,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "979ac619",
+   "id": "801f4669",
    "metadata": {
     "papermill": {
-     "duration": 0.009651,
-     "end_time": "2026-08-31T03:21:08.443680+00:00",
+     "duration": 0.004293,
+     "end_time": "2026-09-01T05:12:58.634972+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:21:08.434029+00:00",
+     "start_time": "2026-09-01T05:12:58.630679+00:00",
      "status": "completed"
     }
    },
@@ -10358,19 +10372,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "9fc9f54e",
+   "id": "a1f391ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:21:08.459707Z",
-     "iopub.status.busy": "2026-08-31T03:21:08.459199Z",
-     "iopub.status.idle": "2026-08-31T03:21:08.477187Z",
-     "shell.execute_reply": "2026-08-31T03:21:08.476103Z"
+     "iopub.execute_input": "2026-09-01T05:12:58.645204Z",
+     "iopub.status.busy": "2026-09-01T05:12:58.645089Z",
+     "iopub.status.idle": "2026-09-01T05:12:58.654110Z",
+     "shell.execute_reply": "2026-09-01T05:12:58.653781Z"
     },
     "papermill": {
-     "duration": 0.027089,
-     "end_time": "2026-08-31T03:21:08.478197+00:00",
+     "duration": 0.014469,
+     "end_time": "2026-09-01T05:12:58.654687+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:21:08.451108+00:00",
+     "start_time": "2026-09-01T05:12:58.640218+00:00",
      "status": "completed"
     },
     "tags": [
@@ -10388,21 +10402,21 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (2, 12)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>period</th><th>backtest_hash</th><th>sharpe_ci95_lo</th><th>max_dd_ci95_lo</th><th>volatility</th><th>max_drawdown</th><th>num_trades</th><th>avg_turnover</th><th>sharpe_ci95_hi</th><th>max_dd_ci95_hi</th><th>sharpe</th><th>total_return</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;validation&quot;</td><td>&quot;29fde1a598c9&quot;</td><td>-0.261634</td><td>-0.259604</td><td>0.060624</td><td>-0.122617</td><td>304.0</td><td>0.014408</td><td>1.029418</td><td>-0.068194</td><td>0.374504</td><td>0.184312</td></tr><tr><td>&quot;holdout&quot;</td><td>&quot;8e8315cc603b&quot;</td><td>-0.422549</td><td>-0.088803</td><td>0.041362</td><td>-0.039693</td><td>29.0</td><td>0.00578</td><td>2.019648</td><td>-0.023102</td><td>0.767299</td><td>0.065666</td></tr></tbody></table></div>"
+       "<small>shape: (2, 12)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>period</th><th>backtest_hash</th><th>total_return</th><th>max_dd_ci95_lo</th><th>volatility</th><th>max_drawdown</th><th>sharpe_ci95_hi</th><th>avg_turnover</th><th>max_dd_ci95_hi</th><th>sharpe</th><th>num_trades</th><th>sharpe_ci95_lo</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;validation&quot;</td><td>&quot;29fde1a598c9&quot;</td><td>0.184312</td><td>-0.259604</td><td>0.060624</td><td>-0.122617</td><td>1.029418</td><td>0.014408</td><td>-0.068194</td><td>0.374504</td><td>304.0</td><td>-0.261634</td></tr><tr><td>&quot;holdout&quot;</td><td>&quot;8e8315cc603b&quot;</td><td>0.065666</td><td>-0.088803</td><td>0.041362</td><td>-0.039693</td><td>2.019648</td><td>0.00578</td><td>-0.023102</td><td>0.767299</td><td>29.0</td><td>-0.422549</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (2, 12)\n",
-       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬──────────┬───────────┐\n",
-       "│ period    ┆ backtest_ ┆ sharpe_ci ┆ max_dd_ci ┆ … ┆ sharpe_ci ┆ max_dd_ci ┆ sharpe   ┆ total_ret │\n",
-       "│ ---       ┆ hash      ┆ 95_lo     ┆ 95_lo     ┆   ┆ 95_hi     ┆ 95_hi     ┆ ---      ┆ urn       │\n",
-       "│ str       ┆ ---       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ f64      ┆ ---       │\n",
-       "│           ┆ str       ┆ f64       ┆ f64       ┆   ┆ f64       ┆ f64       ┆          ┆ f64       │\n",
-       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪══════════╪═══════════╡\n",
-       "│ validatio ┆ 29fde1a59 ┆ -0.261634 ┆ -0.259604 ┆ … ┆ 1.029418  ┆ -0.068194 ┆ 0.374504 ┆ 0.184312  │\n",
-       "│ n         ┆ 8c9       ┆           ┆           ┆   ┆           ┆           ┆          ┆           │\n",
-       "│ holdout   ┆ 8e8315cc6 ┆ -0.422549 ┆ -0.088803 ┆ … ┆ 2.019648  ┆ -0.023102 ┆ 0.767299 ┆ 0.065666  │\n",
-       "│           ┆ 03b       ┆           ┆           ┆   ┆           ┆           ┆          ┆           │\n",
-       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴──────────┴───────────┘"
+       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬──────────┬───────────┬───────────┐\n",
+       "│ period    ┆ backtest_ ┆ total_ret ┆ max_dd_ci ┆ … ┆ max_dd_ci ┆ sharpe   ┆ num_trade ┆ sharpe_ci │\n",
+       "│ ---       ┆ hash      ┆ urn       ┆ 95_lo     ┆   ┆ 95_hi     ┆ ---      ┆ s         ┆ 95_lo     │\n",
+       "│ str       ┆ ---       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ f64      ┆ ---       ┆ ---       │\n",
+       "│           ┆ str       ┆ f64       ┆ f64       ┆   ┆ f64       ┆          ┆ f64       ┆ f64       │\n",
+       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪══════════╪═══════════╪═══════════╡\n",
+       "│ validatio ┆ 29fde1a59 ┆ 0.184312  ┆ -0.259604 ┆ … ┆ -0.068194 ┆ 0.374504 ┆ 304.0     ┆ -0.261634 │\n",
+       "│ n         ┆ 8c9       ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
+       "│ holdout   ┆ 8e8315cc6 ┆ 0.065666  ┆ -0.088803 ┆ … ┆ -0.023102 ┆ 0.767299 ┆ 29.0      ┆ -0.422549 │\n",
+       "│           ┆ 03b       ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
+       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴──────────┴───────────┴───────────┘"
       ]
      },
      "execution_count": 13,
@@ -10444,19 +10458,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "a7b0dadf",
+   "id": "2e49c574",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:21:08.494077Z",
-     "iopub.status.busy": "2026-08-31T03:21:08.493770Z",
-     "iopub.status.idle": "2026-08-31T03:21:10.337090Z",
-     "shell.execute_reply": "2026-08-31T03:21:10.336280Z"
+     "iopub.execute_input": "2026-09-01T05:12:58.668516Z",
+     "iopub.status.busy": "2026-09-01T05:12:58.668399Z",
+     "iopub.status.idle": "2026-09-01T05:13:00.025784Z",
+     "shell.execute_reply": "2026-09-01T05:13:00.025447Z"
     },
     "papermill": {
-     "duration": 1.852427,
-     "end_time": "2026-08-31T03:21:10.337914+00:00",
+     "duration": 1.363694,
+     "end_time": "2026-09-01T05:13:00.026495+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:21:08.485487+00:00",
+     "start_time": "2026-09-01T05:12:58.662801+00:00",
      "status": "completed"
     },
     "tags": [
@@ -10646,13 +10660,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13a65ec5",
+   "id": "770f487a",
    "metadata": {
     "papermill": {
-     "duration": 0.007699,
-     "end_time": "2026-08-31T03:21:10.355259+00:00",
+     "duration": 0.006825,
+     "end_time": "2026-09-01T05:13:00.041980+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:21:10.347560+00:00",
+     "start_time": "2026-09-01T05:13:00.035155+00:00",
      "status": "completed"
     }
    },
@@ -10672,19 +10686,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "8b4009c7",
+   "id": "2f144730",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:21:10.375922Z",
-     "iopub.status.busy": "2026-08-31T03:21:10.375680Z",
-     "iopub.status.idle": "2026-08-31T03:37:42.844006Z",
-     "shell.execute_reply": "2026-08-31T03:37:42.842800Z"
+     "iopub.execute_input": "2026-09-01T05:13:00.051645Z",
+     "iopub.status.busy": "2026-09-01T05:13:00.051526Z",
+     "iopub.status.idle": "2026-09-01T05:14:42.193430Z",
+     "shell.execute_reply": "2026-09-01T05:14:42.193084Z"
     },
     "papermill": {
-     "duration": 992.478422,
-     "end_time": "2026-08-31T03:37:42.844592+00:00",
+     "duration": 102.147707,
+     "end_time": "2026-09-01T05:14:42.194051+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:21:10.366170+00:00",
+     "start_time": "2026-09-01T05:13:00.046344+00:00",
      "status": "completed"
     },
     "tags": [
@@ -10710,168 +10724,168 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [1/24] family stage=signal label=fwd_ret_1d family=linear leader=4fa103a0 K=134 K_eff_mp=4.0 K_eff_er=2.7290515042614762 dsr_er=-0.03628105965861746 (0.9s)\n"
+      "    [1/24] family stage=signal label=fwd_ret_1d family=linear leader=e8fb2b90 K=56 K_eff_mp=3.0 K_eff_er=2.2791206075564716 dsr_er=-0.03132815432460723 (0.1s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [2/24] family stage=allocation label=fwd_ret_1d family=linear leader=7c66099a K=117 K_eff_mp=4.0 K_eff_er=2.358038173410081 dsr_er=-0.03427747582828945 (3.5s)\n"
+      "    [2/24] family stage=allocation label=fwd_ret_1d family=linear leader=93244f92 K=63 K_eff_mp=3.0 K_eff_er=2.304011876853524 dsr_er=-0.033437502258957946 (1.6s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [3/24] family stage=signal label=fwd_ret_21d family=linear leader=2cfe1a10 K=112 K_eff_mp=4.0 K_eff_er=2.1083896959681314 dsr_er=0.007788247022019069 (0.4s)\n"
+      "    [3/24] family stage=signal label=fwd_ret_21d family=linear leader=19dacab5 K=56 K_eff_mp=2.0 K_eff_er=2.1083896959681323 dsr_er=0.007765196420426271 (0.1s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [4/24] family stage=allocation label=fwd_ret_21d family=linear leader=28c0de65 K=91 K_eff_mp=4.0 K_eff_er=2.226178891961088 dsr_er=0.020381542520851014 (2.7s)\n"
+      "    [4/24] family stage=allocation label=fwd_ret_21d family=linear leader=a655504c K=49 K_eff_mp=3.0 K_eff_er=2.1860516011555737 dsr_er=0.02055571014996412 (1.4s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [5/24] family stage=cost_sensitivity label=fwd_ret_21d family=linear leader=a71441a3 K=22 K_eff_mp=2.0 K_eff_er=1.492004873400119 dsr_er=0.028067769496716386 (1.2s)\n"
+      "    [5/24] family stage=risk_overlay label=fwd_ret_21d family=linear leader=29fde1a5 K=28 K_eff_mp=3.0 K_eff_er=2.911828135967659 dsr_er=0.01173052248633855 (1.0s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [6/24] family stage=risk_overlay label=fwd_ret_21d family=linear leader=29fde1a5 K=42 K_eff_mp=3.0 K_eff_er=2.771841911238118 dsr_er=0.011486511657660774 (1.2s)\n"
+      "    [6/24] family stage=cost_sensitivity label=fwd_ret_21d family=linear leader=a71441a3 K=11 K_eff_mp=1.0 K_eff_er=1.0419883131183736 dsr_er=0.03943133461256006 (1.1s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [7/24] family stage=signal label=fwd_ret_5d family=linear leader=781a09ed K=104 K_eff_mp=4.0 K_eff_er=2.092344881806741 dsr_er=-0.005082511391588988 (0.3s)\n"
+      "    [7/24] family stage=signal label=fwd_ret_5d family=linear leader=fe262059 K=52 K_eff_mp=2.0 K_eff_er=2.0923448818067416 dsr_er=-0.005096266241852927 (0.2s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [8/24] family stage=allocation label=fwd_ret_5d family=linear leader=b9f48174 K=13 K_eff_mp=1.0 K_eff_er=1.5492504222208798 dsr_er=-0.0036942669981759628 (1.3s)\n"
+      "    [8/24] family stage=allocation label=fwd_ret_5d family=linear leader=b9f48174 K=7 K_eff_mp=1.0 K_eff_er=1.5255571109381858 dsr_er=-0.003581895969185594 (1.6s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [9/24] family stage=signal label=fwd_ret_1d family=tabular_dl leader=017169cc K=115 K_eff_mp=5.0 K_eff_er=3.688766374895895 dsr_er=-0.1192055485493173 (0.4s)\n"
+      "    [9/24] family stage=signal label=fwd_ret_1d family=gbm leader=ccb131f3 K=300 K_eff_mp=6.0 K_eff_er=2.998843463490665 dsr_er=-0.0669172668732944 (8.0s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [10/24] family stage=signal label=fwd_ret_1d family=deep_learning leader=48c8c7f4 K=194 K_eff_mp=7.0 K_eff_er=5.706162151858752 dsr_er=-0.03814417533551777 (1.1s)\n"
+      "    [10/24] family stage=signal label=fwd_ret_21d family=gbm leader=927f2825 K=300 K_eff_mp=4.0 K_eff_er=2.0534838648085003 dsr_er=0.0111628903969761 (8.4s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [11/24] family stage=allocation label=fwd_ret_1d family=deep_learning leader=1cbb4214 K=85 K_eff_mp=None K_eff_er=None dsr_er=None (2.4s)\n"
+      "    [11/24] family stage=allocation label=fwd_ret_21d family=gbm leader=c998c0ee K=7 K_eff_mp=1.0 K_eff_er=1.5534645575398915 dsr_er=0.015523044829797477 (1.3s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [12/24] family stage=signal label=fwd_ret_1d family=gbm leader=0833f41e K=730 K_eff_mp=13.0 K_eff_er=3.990190745189588 dsr_er=-0.0748163803804344 (61.6s)\n"
+      "    [12/24] family stage=signal label=fwd_ret_5d family=gbm leader=29d070d8 K=300 K_eff_mp=5.0 K_eff_er=2.3520937527166637 dsr_er=-0.004540665994738003 (5.3s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [13/24] family stage=signal label=fwd_ret_21d family=gbm leader=dcfdf23c K=600 K_eff_mp=6.0 K_eff_er=2.0534838648085048 dsr_er=0.011165836024638262 (81.7s)\n"
+      "    [13/24] family stage=allocation label=fwd_ret_5d family=gbm leader=3b6219e8 K=35 K_eff_mp=3.0 K_eff_er=2.6527308825720177 dsr_er=-0.006767050245710194 (1.4s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [14/24] family stage=allocation label=fwd_ret_21d family=gbm leader=c998c0ee K=13 K_eff_mp=1.0 K_eff_er=1.5760749738462432 dsr_er=0.015534210065181724 (2.3s)\n"
+      "    [14/24] family stage=signal label=fwd_ret_1d family=tabular_dl leader=64e1c8fb K=48 K_eff_mp=3.0 K_eff_er=2.9630064865717665 dsr_er=-0.11606412836580168 (0.1s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [15/24] family stage=signal label=fwd_ret_5d family=gbm leader=e080eec9 K=600 K_eff_mp=6.0 K_eff_er=2.352093752716664 dsr_er=-0.0045371127439096486 (71.3s)\n"
+      "    [15/24] family stage=signal label=fwd_ret_5d family=tabular_dl leader=c14ceed6 K=48 K_eff_mp=3.0 K_eff_er=2.453700482760607 dsr_er=-0.020603787954826317 (0.1s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [16/24] family stage=allocation label=fwd_ret_5d family=gbm leader=3b6219e8 K=65 K_eff_mp=4.0 K_eff_er=2.717231409760097 dsr_er=-0.006975729644170146 (4.2s)\n"
+      "    [16/24] family stage=signal label=fwd_ret_21d family=tabular_dl leader=a5589c3d K=48 K_eff_mp=2.0 K_eff_er=2.0729362970329395 dsr_er=-0.002826966183308132 (0.1s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [17/24] family stage=signal label=fwd_ret_5d family=tabular_dl leader=b9f956ef K=96 K_eff_mp=4.0 K_eff_er=2.4537004827606066 dsr_er=-0.02057417215749277 (0.8s)\n"
+      "    [17/24] family stage=signal label=fwd_ret_1d family=deep_learning leader=58576e46 K=80 K_eff_mp=4.0 K_eff_er=4.39541475118437 dsr_er=-0.028496646272824923 (0.2s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [18/24] family stage=signal label=fwd_ret_21d family=tabular_dl leader=3047ce25 K=96 K_eff_mp=4.0 K_eff_er=2.0729362970329412 dsr_er=-0.0027964676583184106 (0.8s)\n"
+      "    [18/24] family stage=allocation label=fwd_ret_1d family=deep_learning leader=cb95c12b K=7 K_eff_mp=1.0 K_eff_er=1.666121469974259 dsr_er=0.008731998225463711 (1.3s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [19/24] family stage=cost_sensitivity label=fwd_ret_1d family=deep_learning leader=8ea38f1d K=22 K_eff_mp=1.0 K_eff_er=1.0688069127740363 dsr_er=0.09867050450095036 (2.4s)\n"
+      "    [19/24] family stage=risk_overlay label=fwd_ret_1d family=deep_learning leader=7bc34036 K=14 K_eff_mp=1.0 K_eff_er=1.1819567841782774 dsr_er=0.021463806560089515 (1.0s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [20/24] family stage=risk_overlay label=fwd_ret_1d family=deep_learning leader=efbea889 K=28 K_eff_mp=1.0 K_eff_er=1.1819567841782743 dsr_er=0.021412377286077967 (2.4s)\n"
+      "    [20/24] family stage=cost_sensitivity label=fwd_ret_1d family=deep_learning leader=8ea38f1d K=11 K_eff_mp=1.0 K_eff_er=1.0570539091733393 dsr_er=0.10470472398261052 (0.9s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [21/24] family stage=signal label=fwd_ret_5d family=deep_learning leader=eea79035 K=160 K_eff_mp=6.0 K_eff_er=3.4955469840407574 dsr_er=-0.0007836568626573143 (1.3s)\n"
+      "    [21/24] family stage=signal label=fwd_ret_5d family=deep_learning leader=a8cd9ca6 K=80 K_eff_mp=4.0 K_eff_er=3.4955469840407596 dsr_er=-0.0008142639371955807 (0.2s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [22/24] family stage=allocation label=fwd_ret_5d family=deep_learning leader=ff96994e K=26 K_eff_mp=2.0 K_eff_er=2.7104223094527073 dsr_er=0.0008374305494780569 (2.8s)\n"
+      "    [22/24] family stage=allocation label=fwd_ret_5d family=deep_learning leader=0c6a32a2 K=14 K_eff_mp=2.0 K_eff_er=2.6626438339452014 dsr_er=0.0009760907083356113 (1.2s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [23/24] family stage=signal label=fwd_ret_21d family=deep_learning leader=eeff10df K=160 K_eff_mp=5.0 K_eff_er=3.3977913922678784 dsr_er=0.015239070317199437 (1.1s)\n"
+      "    [23/24] family stage=signal label=fwd_ret_21d family=deep_learning leader=ee210a38 K=80 K_eff_mp=4.0 K_eff_er=3.3977913922678775 dsr_er=0.015225803471329666 (0.2s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [24/24] family stage=allocation label=fwd_ret_21d family=deep_learning leader=ab59603e K=26 K_eff_mp=2.0 K_eff_er=3.0876024174915404 dsr_er=0.011575200495331027 (2.9s)\n"
+      "    [24/24] family stage=allocation label=fwd_ret_21d family=deep_learning leader=ce0b8f90 K=14 K_eff_mp=2.0 K_eff_er=3.053394800659157 dsr_er=0.01167627877893199 (1.2s)\n"
      ]
     },
     {
@@ -10885,70 +10899,70 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [1/10] stagelabel stage=signal label=fwd_ret_1d family=None leader=48c8c7f4 K=1173 K_eff_mp=20.0 K_eff_er=7.002233711952888 dsr_er=-0.0439856771279995 (127.5s)\n"
+      "    [1/10] stagelabel stage=signal label=fwd_ret_1d family=None leader=58576e46 K=484 K_eff_mp=12.0 K_eff_er=5.228302370533931 dsr_er=-0.03580782155286511 (7.1s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [2/10] stagelabel stage=allocation label=fwd_ret_1d family=None leader=1cbb4214 K=202 K_eff_mp=None K_eff_er=None dsr_er=None (12.2s)\n"
+      "    [2/10] stagelabel stage=allocation label=fwd_ret_1d family=None leader=cb95c12b K=70 K_eff_mp=4.0 K_eff_er=2.892756399687641 dsr_er=-0.009546955357982025 (1.6s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [3/10] stagelabel stage=signal label=fwd_ret_21d family=None leader=eeff10df K=968 K_eff_mp=13.0 K_eff_er=3.3235155106629817 dsr_er=0.011698871352800011 (108.8s)\n"
+      "    [3/10] stagelabel stage=signal label=fwd_ret_21d family=None leader=ee210a38 K=484 K_eff_mp=10.0 K_eff_er=3.3235155106629795 dsr_er=0.011694866620206336 (5.7s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [4/10] stagelabel stage=allocation label=fwd_ret_21d family=None leader=28c0de65 K=130 K_eff_mp=7.0 K_eff_er=3.8173669047100236 dsr_er=0.016435299957407955 (7.8s)\n"
+      "    [4/10] stagelabel stage=allocation label=fwd_ret_21d family=None leader=a655504c K=70 K_eff_mp=6.0 K_eff_er=3.739817045970046 dsr_er=0.016670098462905646 (1.5s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [5/10] stagelabel stage=cost_sensitivity label=fwd_ret_21d family=None leader=a71441a3 K=22 K_eff_mp=2.0 K_eff_er=1.492004873400119 dsr_er=0.028067769496716386 (2.5s)\n"
+      "    [5/10] stagelabel stage=risk_overlay label=fwd_ret_21d family=None leader=29fde1a5 K=28 K_eff_mp=3.0 K_eff_er=2.911828135967659 dsr_er=0.01173052248633855 (0.9s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [6/10] stagelabel stage=risk_overlay label=fwd_ret_21d family=None leader=29fde1a5 K=42 K_eff_mp=3.0 K_eff_er=2.771841911238118 dsr_er=0.011486511657660774 (2.1s)\n"
+      "    [6/10] stagelabel stage=cost_sensitivity label=fwd_ret_21d family=None leader=a71441a3 K=11 K_eff_mp=1.0 K_eff_er=1.0419883131183736 dsr_er=0.03943133461256006 (0.9s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [7/10] stagelabel stage=signal label=fwd_ret_5d family=None leader=eea79035 K=960 K_eff_mp=14.0 K_eff_er=3.9734746437562167 dsr_er=-0.0005112195253111317 (113.0s)\n"
+      "    [7/10] stagelabel stage=signal label=fwd_ret_5d family=None leader=a8cd9ca6 K=480 K_eff_mp=10.0 K_eff_er=3.9734746437562096 dsr_er=-0.000516131958526107 (5.5s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [8/10] stagelabel stage=allocation label=fwd_ret_5d family=None leader=ff96994e K=104 K_eff_mp=7.0 K_eff_er=4.245077897089228 dsr_er=-0.0016091878788385867 (5.6s)\n"
+      "    [8/10] stagelabel stage=allocation label=fwd_ret_5d family=None leader=0c6a32a2 K=56 K_eff_mp=6.0 K_eff_er=4.1357324681401995 dsr_er=-0.0013593226552172152 (1.5s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [9/10] stagelabel stage=cost_sensitivity label=fwd_ret_1d family=None leader=8ea38f1d K=22 K_eff_mp=1.0 K_eff_er=1.0688069127740363 dsr_er=0.09867050450095036 (2.8s)\n"
+      "    [9/10] stagelabel stage=risk_overlay label=fwd_ret_1d family=None leader=7bc34036 K=14 K_eff_mp=1.0 K_eff_er=1.1819567841782774 dsr_er=0.021463806560089515 (1.0s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [10/10] stagelabel stage=risk_overlay label=fwd_ret_1d family=None leader=efbea889 K=28 K_eff_mp=1.0 K_eff_er=1.1819567841782743 dsr_er=0.021412377286077967 (2.4s)\n"
+      "    [10/10] stagelabel stage=cost_sensitivity label=fwd_ret_1d family=None leader=8ea38f1d K=11 K_eff_mp=1.0 K_eff_er=1.0570539091733393 dsr_er=0.10470472398261052 (1.0s)\n"
      ]
     },
     {
@@ -10962,21 +10976,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [1/3] label stage=None label=fwd_ret_1d family=None leader=efbea889 K=1403 K_eff_mp=None K_eff_er=None dsr_er=None (58.0s)\n"
+      "    [1/3] label stage=None label=fwd_ret_1d family=None leader=7bc34036 K=568 K_eff_mp=13.0 K_eff_er=5.775351700253793 dsr_er=-0.04365993563939814 (9.3s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [2/3] label stage=None label=fwd_ret_21d family=None leader=28c0de65 K=1140 K_eff_mp=15.0 K_eff_er=4.048173730768014 dsr_er=0.013715435607640712 (142.6s)\n"
+      "    [2/3] label stage=None label=fwd_ret_21d family=None leader=a655504c K=582 K_eff_mp=13.0 K_eff_er=4.1219064222661475 dsr_er=0.013422772698268434 (8.9s)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    [3/3] label stage=None label=fwd_ret_5d family=None leader=ff96994e K=1064 K_eff_mp=15.0 K_eff_er=4.328153244599362 dsr_er=-0.000597409873353499 (117.3s)\n"
+      "    [3/3] label stage=None label=fwd_ret_5d family=None leader=0c6a32a2 K=536 K_eff_mp=12.0 K_eff_er=4.327870258921656 dsr_er=-0.0007056641310483874 (4.4s)\n"
      ]
     },
     {
@@ -11039,12 +11053,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cohort_metrics: 37 rows; backtest_paired_metrics: 5 pairs\n",
-      "  undefined on a constant-position cohort: dsr_er failed x3\n",
-      "  undefined on a constant-position cohort: dsr_mp failed x3\n",
-      "  undefined on a constant-position cohort: dsr_raw failed x3\n",
-      "  undefined on a constant-position cohort: n_trials_effective_er failed x3\n",
-      "  undefined on a constant-position cohort: n_trials_effective_mp failed x3\n"
+      "cohort_metrics: 37 rows; backtest_paired_metrics: 5 pairs\n"
      ]
     }
    ],
@@ -11061,7 +11070,7 @@
     "# notebook. What they mean is a count, so a count is what is reported.\n",
     "with warnings.catch_warnings(record=True) as _cohort_warnings:\n",
     "    warnings.simplefilter(\"always\")\n",
-    "    _cohort_counts = compute_and_register(CASE_STUDY_ID)\n",
+    "    _cohort_counts = compute_and_register(CASE_STUDY_ID, prediction_hashes=ADMITTED_PREDICTIONS)\n",
     "_undefined = Counter(str(entry.message).split(\" for \")[0] for entry in _cohort_warnings)\n",
     "_paired_rows = populate_paired_metrics(\n",
     "    CASE_STUDY_ID,\n",
@@ -11080,19 +11089,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "d86a7e14",
+   "id": "c16435f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:37:42.861163Z",
-     "iopub.status.busy": "2026-08-31T03:37:42.860981Z",
-     "iopub.status.idle": "2026-08-31T03:37:42.897856Z",
-     "shell.execute_reply": "2026-08-31T03:37:42.895251Z"
+     "iopub.execute_input": "2026-09-01T05:14:42.205485Z",
+     "iopub.status.busy": "2026-09-01T05:14:42.205376Z",
+     "iopub.status.idle": "2026-09-01T05:14:42.213191Z",
+     "shell.execute_reply": "2026-09-01T05:14:42.212715Z"
     },
     "papermill": {
-     "duration": 0.045616,
-     "end_time": "2026-08-31T03:37:42.899822+00:00",
+     "duration": 0.014207,
+     "end_time": "2026-09-01T05:14:42.213528+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:37:42.854206+00:00",
+     "start_time": "2026-09-01T05:14:42.199321+00:00",
      "status": "completed"
     },
     "tags": [
@@ -11110,29 +11119,29 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (3, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>comparison</th><th>ret_diff_ci95_hi</th><th>ret_diff_ci95_lo</th><th>sharpe_diff_ci95_hi</th><th>p_value</th><th>sharpe_diff_ci95_lo</th><th>ret_diff</th><th>sharpe_diff</th><th>prob_challenger_wins</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;holdout minus validation&quot;</td><td>0.069513</td><td>-0.050653</td><td>1.678095</td><td>0.5325</td><td>-0.869997</td><td>0.010329</td><td>0.393443</td><td>0.7395</td></tr><tr><td>&quot;holdout minus equal weight&quot;</td><td>0.037089</td><td>-0.029292</td><td>0.776239</td><td>0.7535</td><td>-1.067843</td><td>0.001662</td><td>-0.144206</td><td>0.368</td></tr><tr><td>&quot;validation minus equal weight&quot;</td><td>0.047381</td><td>-0.016328</td><td>0.669247</td><td>0.591</td><td>-0.403913</td><td>0.013453</td><td>0.14936</td><td>0.693</td></tr></tbody></table></div>"
+       "<small>shape: (3, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>comparison</th><th>ret_diff_ci95_hi</th><th>sharpe_diff</th><th>ret_diff</th><th>p_value</th><th>ret_diff_ci95_lo</th><th>prob_challenger_wins</th><th>sharpe_diff_ci95_lo</th><th>sharpe_diff_ci95_hi</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;holdout minus validation&quot;</td><td>0.069513</td><td>0.393443</td><td>0.010329</td><td>0.5325</td><td>-0.050653</td><td>0.7395</td><td>-0.869997</td><td>1.678095</td></tr><tr><td>&quot;holdout minus equal weight&quot;</td><td>0.037089</td><td>-0.144206</td><td>0.001662</td><td>0.7535</td><td>-0.029292</td><td>0.368</td><td>-1.067843</td><td>0.776239</td></tr><tr><td>&quot;validation minus equal weight&quot;</td><td>0.047381</td><td>0.14936</td><td>0.013453</td><td>0.591</td><td>-0.016328</td><td>0.693</td><td>-0.403913</td><td>0.669247</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (3, 9)\n",
-       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬──────────┬───────────┬───────────┐\n",
-       "│ compariso ┆ ret_diff_ ┆ ret_diff_ ┆ sharpe_di ┆ … ┆ sharpe_di ┆ ret_diff ┆ sharpe_di ┆ prob_chal │\n",
-       "│ n         ┆ ci95_hi   ┆ ci95_lo   ┆ ff_ci95_h ┆   ┆ ff_ci95_l ┆ ---      ┆ ff        ┆ lenger_wi │\n",
-       "│ ---       ┆ ---       ┆ ---       ┆ i         ┆   ┆ o         ┆ f64      ┆ ---       ┆ ns        │\n",
-       "│ str       ┆ f64       ┆ f64       ┆ ---       ┆   ┆ ---       ┆          ┆ f64       ┆ ---       │\n",
-       "│           ┆           ┆           ┆ f64       ┆   ┆ f64       ┆          ┆           ┆ f64       │\n",
-       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪══════════╪═══════════╪═══════════╡\n",
-       "│ holdout   ┆ 0.069513  ┆ -0.050653 ┆ 1.678095  ┆ … ┆ -0.869997 ┆ 0.010329 ┆ 0.393443  ┆ 0.7395    │\n",
-       "│ minus val ┆           ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
-       "│ idation   ┆           ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
-       "│ holdout   ┆ 0.037089  ┆ -0.029292 ┆ 0.776239  ┆ … ┆ -1.067843 ┆ 0.001662 ┆ -0.144206 ┆ 0.368     │\n",
-       "│ minus     ┆           ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
-       "│ equal     ┆           ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
-       "│ weight    ┆           ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
-       "│ validatio ┆ 0.047381  ┆ -0.016328 ┆ 0.669247  ┆ … ┆ -0.403913 ┆ 0.013453 ┆ 0.14936   ┆ 0.693     │\n",
-       "│ n minus   ┆           ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
-       "│ equal     ┆           ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
-       "│ weight    ┆           ┆           ┆           ┆   ┆           ┆          ┆           ┆           │\n",
-       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴──────────┴───────────┴───────────┘"
+       "┌───────────┬───────────┬───────────┬──────────┬───┬───────────┬───────────┬───────────┬───────────┐\n",
+       "│ compariso ┆ ret_diff_ ┆ sharpe_di ┆ ret_diff ┆ … ┆ ret_diff_ ┆ prob_chal ┆ sharpe_di ┆ sharpe_di │\n",
+       "│ n         ┆ ci95_hi   ┆ ff        ┆ ---      ┆   ┆ ci95_lo   ┆ lenger_wi ┆ ff_ci95_l ┆ ff_ci95_h │\n",
+       "│ ---       ┆ ---       ┆ ---       ┆ f64      ┆   ┆ ---       ┆ ns        ┆ o         ┆ i         │\n",
+       "│ str       ┆ f64       ┆ f64       ┆          ┆   ┆ f64       ┆ ---       ┆ ---       ┆ ---       │\n",
+       "│           ┆           ┆           ┆          ┆   ┆           ┆ f64       ┆ f64       ┆ f64       │\n",
+       "╞═══════════╪═══════════╪═══════════╪══════════╪═══╪═══════════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ holdout   ┆ 0.069513  ┆ 0.393443  ┆ 0.010329 ┆ … ┆ -0.050653 ┆ 0.7395    ┆ -0.869997 ┆ 1.678095  │\n",
+       "│ minus val ┆           ┆           ┆          ┆   ┆           ┆           ┆           ┆           │\n",
+       "│ idation   ┆           ┆           ┆          ┆   ┆           ┆           ┆           ┆           │\n",
+       "│ holdout   ┆ 0.037089  ┆ -0.144206 ┆ 0.001662 ┆ … ┆ -0.029292 ┆ 0.368     ┆ -1.067843 ┆ 0.776239  │\n",
+       "│ minus     ┆           ┆           ┆          ┆   ┆           ┆           ┆           ┆           │\n",
+       "│ equal     ┆           ┆           ┆          ┆   ┆           ┆           ┆           ┆           │\n",
+       "│ weight    ┆           ┆           ┆          ┆   ┆           ┆           ┆           ┆           │\n",
+       "│ validatio ┆ 0.047381  ┆ 0.14936   ┆ 0.013453 ┆ … ┆ -0.016328 ┆ 0.693     ┆ -0.403913 ┆ 0.669247  │\n",
+       "│ n minus   ┆           ┆           ┆          ┆   ┆           ┆           ┆           ┆           │\n",
+       "│ equal     ┆           ┆           ┆          ┆   ┆           ┆           ┆           ┆           │\n",
+       "│ weight    ┆           ┆           ┆          ┆   ┆           ┆           ┆           ┆           │\n",
+       "└───────────┴───────────┴───────────┴──────────┴───┴───────────┴───────────┴───────────┴───────────┘"
       ]
      },
      "execution_count": 16,
@@ -11197,13 +11206,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9076ac69",
+   "id": "5fd99482",
    "metadata": {
     "papermill": {
-     "duration": 0.018656,
-     "end_time": "2026-08-31T03:37:42.937774+00:00",
+     "duration": 0.004903,
+     "end_time": "2026-09-01T05:14:42.223913+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:37:42.919118+00:00",
+     "start_time": "2026-09-01T05:14:42.219010+00:00",
      "status": "completed"
     }
    },
@@ -11217,19 +11226,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "cb2c7561",
+   "id": "5192682a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:37:42.980803Z",
-     "iopub.status.busy": "2026-08-31T03:37:42.980423Z",
-     "iopub.status.idle": "2026-08-31T03:37:43.616726Z",
-     "shell.execute_reply": "2026-08-31T03:37:43.615381Z"
+     "iopub.execute_input": "2026-09-01T05:14:42.234727Z",
+     "iopub.status.busy": "2026-09-01T05:14:42.234562Z",
+     "iopub.status.idle": "2026-09-01T05:14:42.496390Z",
+     "shell.execute_reply": "2026-09-01T05:14:42.495991Z"
     },
     "papermill": {
-     "duration": 0.664189,
-     "end_time": "2026-08-31T03:37:43.622084+00:00",
+     "duration": 0.267919,
+     "end_time": "2026-09-01T05:14:42.496886+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:37:42.957895+00:00",
+     "start_time": "2026-09-01T05:14:42.228967+00:00",
      "status": "completed"
     },
     "tags": [
@@ -11280,13 +11289,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4847aee",
+   "id": "6064c2b1",
    "metadata": {
     "papermill": {
-     "duration": 0.019857,
-     "end_time": "2026-08-31T03:37:43.665499+00:00",
+     "duration": 0.005028,
+     "end_time": "2026-09-01T05:14:42.507554+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:37:43.645642+00:00",
+     "start_time": "2026-09-01T05:14:42.502526+00:00",
      "status": "completed"
     }
    },
@@ -11300,19 +11309,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "1d2c1e0a",
+   "id": "9c262ad5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-31T03:37:43.709235Z",
-     "iopub.status.busy": "2026-08-31T03:37:43.708815Z",
-     "iopub.status.idle": "2026-08-31T03:37:43.726374Z",
-     "shell.execute_reply": "2026-08-31T03:37:43.724619Z"
+     "iopub.execute_input": "2026-09-01T05:14:42.518408Z",
+     "iopub.status.busy": "2026-09-01T05:14:42.518307Z",
+     "iopub.status.idle": "2026-09-01T05:14:42.522754Z",
+     "shell.execute_reply": "2026-09-01T05:14:42.522453Z"
     },
     "papermill": {
-     "duration": 0.041968,
-     "end_time": "2026-08-31T03:37:43.729218+00:00",
+     "duration": 0.010533,
+     "end_time": "2026-09-01T05:14:42.523162+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:37:43.687250+00:00",
+     "start_time": "2026-09-01T05:14:42.512629+00:00",
      "status": "completed"
     },
     "tags": [
@@ -11399,13 +11408,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63e8b54a",
+   "id": "8afd2765",
    "metadata": {
     "papermill": {
-     "duration": 0.018798,
-     "end_time": "2026-08-31T03:37:43.775138+00:00",
+     "duration": 0.005336,
+     "end_time": "2026-09-01T05:14:42.534480+00:00",
      "exception": false,
-     "start_time": "2026-08-31T03:37:43.756340+00:00",
+     "start_time": "2026-09-01T05:14:42.529144+00:00",
      "status": "completed"
     }
    },
@@ -11442,24 +11451,24 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-01T05:14:51.595269+00:00",
+   "executor": "local-uv",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "0e4dc570cc24f23cfe9dcc67fe07052220b32d0d"
+  },
   "papermill": {
    "default_parameters": {},
-   "duration": 1073.111666,
-   "end_time": "2026-08-31T03:37:47.442967+00:00",
+   "duration": 166.253014,
+   "end_time": "2026-09-01T05:14:45.037488+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "case_studies/fx_pairs/19_strategy_analysis.ipynb",
-   "output_path": "~/scratch/prod_19_strategy_analysis_137927.ipynb",
+   "input_path": "~/ml4t/public-s6-fx_pairs/case_studies/fx_pairs/19_strategy_analysis.ipynb",
+   "output_path": "~/ml4t/public-s6-fx_pairs/case_studies/fx_pairs/.19_strategy_analysis.papermill.3459172.ipynb",
    "parameters": {},
-   "start_time": "2026-08-31T03:19:54.331301+00:00",
+   "start_time": "2026-09-01T05:11:58.784474+00:00",
    "version": "2.7.0"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "cf63ba0be97cdfbe613820c3c73e7616dd04dd44",
-   "executed_at": "2026-08-31T03:37:49.860148+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/19_strategy_analysis.py
+++ b/case_studies/fx_pairs/19_strategy_analysis.py
@@ -124,6 +124,20 @@ study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKS
 # intersection and change which admitted row is reported.
 holdout_candidates = CandidateSet.one(study, name=CANDIDATE_SET_NAME)
 ADMITTED = frozenset(holdout_candidates.members)
+# The prediction sets behind the admitted backtests. `compute_and_register` scopes cohorts by
+# prediction rather than by backtest, and left unscoped it computes the effective trial count and
+# the deflated Sharpe over the whole registry - every retired generation and every configuration
+# no population publishes included. K is what the deflation divides by, so an unscoped call
+# reports a correction computed over a population this page does not describe.
+with sqlite3.connect(str(get_case_study_dir(CASE_STUDY_ID) / "run_log" / "registry.db")) as _con:
+    ADMITTED_PREDICTIONS = [
+        row[0]
+        for row in _con.execute(
+            "SELECT DISTINCT prediction_hash FROM backtest_runs "
+            f"WHERE backtest_hash IN ({','.join('?' * len(ADMITTED))})",
+            tuple(sorted(ADMITTED)),
+        )
+    ]
 carrier = resolve_solvent_carrier(CASE_STUDY_ID, admitted=ADMITTED)
 
 selected_validation = study.results.open(str(carrier["val_backtest_hash"]))
@@ -676,7 +690,7 @@ _periods_per_year = int(
 # notebook. What they mean is a count, so a count is what is reported.
 with warnings.catch_warnings(record=True) as _cohort_warnings:
     warnings.simplefilter("always")
-    _cohort_counts = compute_and_register(CASE_STUDY_ID)
+    _cohort_counts = compute_and_register(CASE_STUDY_ID, prediction_hashes=ADMITTED_PREDICTIONS)
 _undefined = Counter(str(entry.message).split(" for ")[0] for entry in _cohort_warnings)
 _paired_rows = populate_paired_metrics(
     CASE_STUDY_ID,


### PR DESCRIPTION
fx_pairs: scope the cohort statistics to the admitted population

compute_and_register was called without prediction_hashes, so the effective
trial count and the deflated Sharpe were computed over the whole registry -
every superseded training generation and every configuration no population
publishes included. K is what the deflation divides by, so the correction this
page reports was measured over a population it does not describe.

The scope is the prediction sets behind the frozen candidate set, which is the
field the carrier is already resolved over three lines above. Nothing else about
the page changes.