### PR TITLE
ch20: the aggregate synthesis carries an executed render again

### DIFF
--- a/20_strategy_synthesis/01_aggregate_synthesis.ipynb
+++ b/20_strategy_synthesis/01_aggregate_synthesis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "609b349b",
+   "id": "f808134f",
    "metadata": {},
    "source": [
     "# Aggregate Synthesis\n",
@@ -26,9 +26,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "311d341f",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "59349d99",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:42.073887Z",
+     "iopub.status.busy": "2026-09-02T04:04:42.073824Z",
+     "iopub.status.idle": "2026-09-02T04:04:43.742917Z",
+     "shell.execute_reply": "2026-09-02T04:04:43.742200Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Ch20 Aggregate Synthesis — query registries and compare all 9 case studies.\"\"\"\n",
@@ -55,9 +62,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5a204fd3",
+   "execution_count": 2,
+   "id": "0bb62559",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:43.744487Z",
+     "iopub.status.busy": "2026-09-02T04:04:43.744337Z",
+     "iopub.status.idle": "2026-09-02T04:04:43.746471Z",
+     "shell.execute_reply": "2026-09-02T04:04:43.746020Z"
+    },
     "tags": [
      "parameters"
     ]
@@ -79,9 +92,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f047b157",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "39f1bc31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:43.747922Z",
+     "iopub.status.busy": "2026-09-02T04:04:43.747861Z",
+     "iopub.status.idle": "2026-09-02T04:04:43.750265Z",
+     "shell.execute_reply": "2026-09-02T04:04:43.749909Z"
+    }
+   },
    "outputs": [],
    "source": [
     "OUTPUT_DIR = get_chapter_dir(20) / \"output\"\n",
@@ -122,9 +142,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4b1479f0",
-   "metadata": {},
+   "execution_count": 4,
+   "id": "ce0978bd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:43.751050Z",
+     "iopub.status.busy": "2026-09-02T04:04:43.750989Z",
+     "iopub.status.idle": "2026-09-02T04:04:43.753037Z",
+     "shell.execute_reply": "2026-09-02T04:04:43.752618Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ASSET_CLASS_MAP = {\n",
@@ -154,7 +181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d76533c",
+   "id": "8a1dedec",
    "metadata": {},
    "source": [
     "## Load Registries\n",
@@ -164,10 +191,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "18220e3f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "e458e8c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:43.753846Z",
+     "iopub.status.busy": "2026-09-02T04:04:43.753782Z",
+     "iopub.status.idle": "2026-09-02T04:04:43.842410Z",
+     "shell.execute_reply": "2026-09-02T04:04:43.841739Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [OK] etfs: 3313 backtests ({'signal': 2469, 'allocation': 678, 'cost_sensitivity': 85, 'risk_overlay': 80, 'holdout': 1})\n",
+      "  [OK] crypto_perps_funding: 2852 backtests ({'signal': 2031, 'allocation': 720, 'risk_overlay': 56, 'cost_sensitivity': 44, 'holdout': 1})\n",
+      "  [OK] nasdaq100_microstructure: 0 backtests ({})\n",
+      "  [OK] sp500_equity_option_analytics: 4730 backtests ({'signal': 3327, 'allocation': 1218, 'risk_overlay': 98, 'cost_sensitivity': 85, 'holdout': 2})\n",
+      "  [OK] us_firm_characteristics: 3530 backtests ({'signal': 3296, 'allocation': 200, 'cost_sensitivity': 33, 'holdout': 1})\n",
+      "  [OK] fx_pairs: 3876 backtests ({'signal': 3229, 'allocation': 468, 'risk_overlay': 112, 'cost_sensitivity': 66, 'holdout': 1})\n",
+      "  [OK] cme_futures: 1152 backtests ({'signal': 992, 'allocation': 120, 'risk_overlay': 28, 'cost_sensitivity': 11, 'holdout': 1})\n",
+      "  [OK] sp500_options: 1665 backtests ({'signal': 1572, 'allocation': 60, 'cost_sensitivity': 32, 'holdout': 1})\n",
+      "  [OK] us_equities_panel: 0 backtests ({})\n",
+      "\n",
+      "Loaded: 9/9 case studies\n"
+     ]
+    }
+   ],
    "source": [
     "explorers: dict[str, BacktestExplorer] = {}\n",
     "configs: dict[str, dict] = {}\n",
@@ -191,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6949de3",
+   "id": "8864fe0f",
    "metadata": {},
    "source": [
     "## Rank-1 Cluster Diagnostics\n",
@@ -226,9 +278,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f07eee28",
-   "metadata": {},
+   "execution_count": 6,
+   "id": "ac961d0e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:43.843522Z",
+     "iopub.status.busy": "2026-09-02T04:04:43.843449Z",
+     "iopub.status.idle": "2026-09-02T04:04:45.028761Z",
+     "shell.execute_reply": "2026-09-02T04:04:45.028032Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Label restrictions that align the cluster-diagnostics rank-1 with the\n",
@@ -448,10 +507,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6aab06d3",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "75d46ee1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:45.030231Z",
+     "iopub.status.busy": "2026-09-02T04:04:45.029870Z",
+     "iopub.status.idle": "2026-09-02T04:04:48.581488Z",
+     "shell.execute_reply": "2026-09-02T04:04:48.580998Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Rank-1 Cluster Diagnostics (validation) ===\n",
+      "shape: (7, 9)\n",
+      "┌────────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬─────────┬───────────┐\n",
+      "│ case_study ┆ rank1_sha ┆ rank10_sh ┆ rank1_ran ┆ … ┆ fold_shar ┆ n_folds_p ┆ n_folds ┆ n_configs │\n",
+      "│ ---        ┆ rpe       ┆ arpe      ┆ k10_sprea ┆   ┆ pe_se     ┆ os        ┆ ---     ┆ ---       │\n",
+      "│ str        ┆ ---       ┆ ---       ┆ d         ┆   ┆ ---       ┆ ---       ┆ i64     ┆ i64       │\n",
+      "│            ┆ f64       ┆ f64       ┆ ---       ┆   ┆ f64       ┆ i64       ┆         ┆           │\n",
+      "│            ┆           ┆           ┆ f64       ┆   ┆           ┆           ┆         ┆           │\n",
+      "╞════════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═════════╪═══════════╡\n",
+      "│ ETFs       ┆ 0.930341  ┆ 0.823139  ┆ 0.107202  ┆ … ┆ 0.310391  ┆ 7         ┆ 8       ┆ 200       │\n",
+      "│ Crypto     ┆ 1.271052  ┆ 1.008693  ┆ 0.262359  ┆ … ┆ 0.482468  ┆ 2         ┆ 2       ┆ 200       │\n",
+      "│ S&P 500    ┆ 1.297788  ┆ 1.049477  ┆ 0.248311  ┆ … ┆ 0.674894  ┆ 2         ┆ 2       ┆ 200       │\n",
+      "│ Eq+Opt     ┆           ┆           ┆           ┆   ┆           ┆           ┆         ┆           │\n",
+      "│ US Firms   ┆ 3.557338  ┆ 3.233358  ┆ 0.32398   ┆ … ┆ 0.890051  ┆ 10        ┆ 10      ┆ 200       │\n",
+      "│ FX Pairs   ┆ 0.308569  ┆ 0.176053  ┆ 0.132516  ┆ … ┆ 0.228077  ┆ 6         ┆ 8       ┆ 200       │\n",
+      "│ CME        ┆ 1.044776  ┆ 0.6116    ┆ 0.433176  ┆ … ┆ 0.797635  ┆ 3         ┆ 5       ┆ 200       │\n",
+      "│ Futures    ┆           ┆           ┆           ┆   ┆           ┆           ┆         ┆           │\n",
+      "│ S&P 500    ┆ -0.405577 ┆ -0.580227 ┆ 0.17465   ┆ … ┆ 1.243641  ┆ 1         ┆ 2       ┆ 786       │\n",
+      "│ Options    ┆           ┆           ┆           ┆   ┆           ┆           ┆         ┆           │\n",
+      "└────────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴─────────┴───────────┘\n"
+     ]
+    }
+   ],
    "source": [
     "cluster_rows = []\n",
     "for cs, explorer in explorers.items():\n",
@@ -522,7 +616,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79c71796",
+   "id": "e6deff46",
    "metadata": {},
    "source": [
     "Read the table as a tuple: (rank1 Sharpe, rank10 Sharpe, spread, fold-SE,\n",
@@ -534,7 +628,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bfc62581",
+   "id": "448ea542",
    "metadata": {},
    "source": [
     "## Overview Table\n",
@@ -547,10 +641,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c1958182",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "89448cb8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:48.582866Z",
+     "iopub.status.busy": "2026-09-02T04:04:48.582796Z",
+     "iopub.status.idle": "2026-09-02T04:04:51.333594Z",
+     "shell.execute_reply": "2026-09-02T04:04:51.333183Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (9, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>case_study</th><th>asset_class</th><th>frequency</th><th>universe</th><th>cost_bps</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;ETFs&quot;</td><td>&quot;equity_etf&quot;</td><td>&quot;daily&quot;</td><td>100</td><td>10.0</td></tr><tr><td>&quot;Crypto&quot;</td><td>&quot;crypto&quot;</td><td>&quot;8h&quot;</td><td>19</td><td>3.0</td></tr><tr><td>&quot;NASDAQ-100&quot;</td><td>&quot;equity_micro&quot;</td><td>&quot;15min&quot;</td><td>115</td><td>10.0</td></tr><tr><td>&quot;S&amp;P 500 Eq+Opt&quot;</td><td>&quot;equity_options&quot;</td><td>&quot;daily&quot;</td><td>633</td><td>6.5</td></tr><tr><td>&quot;US Firms&quot;</td><td>&quot;equity_firm&quot;</td><td>&quot;monthly&quot;</td><td>2500</td><td>12.5</td></tr><tr><td>&quot;FX Pairs&quot;</td><td>&quot;fx&quot;</td><td>&quot;daily&quot;</td><td>20</td><td>10.0</td></tr><tr><td>&quot;CME Futures&quot;</td><td>&quot;futures&quot;</td><td>&quot;daily&quot;</td><td>30</td><td>10.0</td></tr><tr><td>&quot;S&amp;P 500 Options&quot;</td><td>&quot;options&quot;</td><td>&quot;daily&quot;</td><td>627</td><td>10.0</td></tr><tr><td>&quot;US Equities&quot;</td><td>&quot;equity_panel&quot;</td><td>&quot;daily&quot;</td><td>3199</td><td>12.5</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (9, 5)\n",
+       "┌─────────────────┬────────────────┬───────────┬──────────┬──────────┐\n",
+       "│ case_study      ┆ asset_class    ┆ frequency ┆ universe ┆ cost_bps │\n",
+       "│ ---             ┆ ---            ┆ ---       ┆ ---      ┆ ---      │\n",
+       "│ str             ┆ str            ┆ str       ┆ i64      ┆ f64      │\n",
+       "╞═════════════════╪════════════════╪═══════════╪══════════╪══════════╡\n",
+       "│ ETFs            ┆ equity_etf     ┆ daily     ┆ 100      ┆ 10.0     │\n",
+       "│ Crypto          ┆ crypto         ┆ 8h        ┆ 19       ┆ 3.0      │\n",
+       "│ NASDAQ-100      ┆ equity_micro   ┆ 15min     ┆ 115      ┆ 10.0     │\n",
+       "│ S&P 500 Eq+Opt  ┆ equity_options ┆ daily     ┆ 633      ┆ 6.5      │\n",
+       "│ US Firms        ┆ equity_firm    ┆ monthly   ┆ 2500     ┆ 12.5     │\n",
+       "│ FX Pairs        ┆ fx             ┆ daily     ┆ 20       ┆ 10.0     │\n",
+       "│ CME Futures     ┆ futures        ┆ daily     ┆ 30       ┆ 10.0     │\n",
+       "│ S&P 500 Options ┆ options        ┆ daily     ┆ 627      ┆ 10.0     │\n",
+       "│ US Equities     ┆ equity_panel   ┆ daily     ┆ 3199     ┆ 12.5     │\n",
+       "└─────────────────┴────────────────┴───────────┴──────────┴──────────┘"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "overview_rows = []\n",
     "for cs, explorer in explorers.items():\n",
@@ -589,7 +726,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7aaa13d",
+   "id": "76a24b94",
    "metadata": {},
    "source": [
     "The test bed covers equity ETFs, crypto perpetuals, intraday microstructure,\n",
@@ -601,7 +738,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3920af5",
+   "id": "1aef2f70",
    "metadata": {},
    "source": [
     "## Model IC Comparison\n",
@@ -613,9 +750,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "561fbc67",
-   "metadata": {},
+   "execution_count": 9,
+   "id": "fe8c2d73",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:51.334817Z",
+     "iopub.status.busy": "2026-09-02T04:04:51.334678Z",
+     "iopub.status.idle": "2026-09-02T04:04:51.344323Z",
+     "shell.execute_reply": "2026-09-02T04:04:51.343754Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ic_rows = []\n",
@@ -671,9 +815,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "075d3a41",
-   "metadata": {},
+   "execution_count": 10,
+   "id": "e8574dd9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:51.345563Z",
+     "iopub.status.busy": "2026-09-02T04:04:51.345481Z",
+     "iopub.status.idle": "2026-09-02T04:04:51.348570Z",
+     "shell.execute_reply": "2026-09-02T04:04:51.348046Z"
+    }
+   },
    "outputs": [],
    "source": [
     "if not ic_df.is_empty():\n",
@@ -684,7 +835,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b79bdff",
+   "id": "9ee26a87",
    "metadata": {},
    "source": [
     "### Mean IC by Model Family"
@@ -692,17 +843,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fc5bce0d",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 11,
+   "id": "5600dcc0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:51.349975Z",
+     "iopub.status.busy": "2026-09-02T04:04:51.349824Z",
+     "iopub.status.idle": "2026-09-02T04:04:51.353520Z",
+     "shell.execute_reply": "2026-09-02T04:04:51.352933Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (9, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>case_study</th><th>deep_learning</th><th>gbm</th><th>latent_factors</th><th>linear</th><th>tabular_dl</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;CME Futures&quot;</td><td>-0.008473</td><td>0.006715</td><td>0.010955</td><td>-0.011205</td><td>-0.015519</td></tr><tr><td>&quot;Crypto&quot;</td><td>0.001938</td><td>0.017273</td><td>null</td><td>-0.0178</td><td>0.006733</td></tr><tr><td>&quot;ETFs&quot;</td><td>0.013093</td><td>0.022371</td><td>0.039014</td><td>0.033106</td><td>0.026787</td></tr><tr><td>&quot;FX Pairs&quot;</td><td>0.007991</td><td>-0.002545</td><td>null</td><td>-0.001313</td><td>-0.001786</td></tr><tr><td>&quot;NASDAQ-100&quot;</td><td>null</td><td>null</td><td>null</td><td>0.002387</td><td>null</td></tr><tr><td>&quot;S&amp;P 500 Eq+Opt&quot;</td><td>-0.005489</td><td>-0.003133</td><td>0.000603</td><td>-0.003962</td><td>0.008282</td></tr><tr><td>&quot;S&amp;P 500 Options&quot;</td><td>0.001073</td><td>-0.00084</td><td>null</td><td>-0.009602</td><td>0.006198</td></tr><tr><td>&quot;US Equities&quot;</td><td>null</td><td>0.025116</td><td>null</td><td>0.01163</td><td>null</td></tr><tr><td>&quot;US Firms&quot;</td><td>null</td><td>0.061869</td><td>-0.019616</td><td>-0.00848</td><td>0.026511</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (9, 6)\n",
+       "┌─────────────────┬───────────────┬───────────┬────────────────┬───────────┬────────────┐\n",
+       "│ case_study      ┆ deep_learning ┆ gbm       ┆ latent_factors ┆ linear    ┆ tabular_dl │\n",
+       "│ ---             ┆ ---           ┆ ---       ┆ ---            ┆ ---       ┆ ---        │\n",
+       "│ str             ┆ f64           ┆ f64       ┆ f64            ┆ f64       ┆ f64        │\n",
+       "╞═════════════════╪═══════════════╪═══════════╪════════════════╪═══════════╪════════════╡\n",
+       "│ CME Futures     ┆ -0.008473     ┆ 0.006715  ┆ 0.010955       ┆ -0.011205 ┆ -0.015519  │\n",
+       "│ Crypto          ┆ 0.001938      ┆ 0.017273  ┆ null           ┆ -0.0178   ┆ 0.006733   │\n",
+       "│ ETFs            ┆ 0.013093      ┆ 0.022371  ┆ 0.039014       ┆ 0.033106  ┆ 0.026787   │\n",
+       "│ FX Pairs        ┆ 0.007991      ┆ -0.002545 ┆ null           ┆ -0.001313 ┆ -0.001786  │\n",
+       "│ NASDAQ-100      ┆ null          ┆ null      ┆ null           ┆ 0.002387  ┆ null       │\n",
+       "│ S&P 500 Eq+Opt  ┆ -0.005489     ┆ -0.003133 ┆ 0.000603       ┆ -0.003962 ┆ 0.008282   │\n",
+       "│ S&P 500 Options ┆ 0.001073      ┆ -0.00084  ┆ null           ┆ -0.009602 ┆ 0.006198   │\n",
+       "│ US Equities     ┆ null          ┆ 0.025116  ┆ null           ┆ 0.01163   ┆ null       │\n",
+       "│ US Firms        ┆ null          ┆ 0.061869  ┆ -0.019616      ┆ -0.00848  ┆ 0.026511   │\n",
+       "└─────────────────┴───────────────┴───────────┴────────────────┴───────────┴────────────┘"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ic_pivot"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1a054cab",
+   "id": "7dd2f11b",
    "metadata": {},
    "source": [
     "No single model family dominates across all nine case studies. GBM tends\n",
@@ -716,7 +910,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "396c25b2",
+   "id": "5c236d98",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -730,9 +924,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c966adad",
-   "metadata": {},
+   "execution_count": 12,
+   "id": "17341028",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:51.354730Z",
+     "iopub.status.busy": "2026-09-02T04:04:51.354614Z",
+     "iopub.status.idle": "2026-09-02T04:04:51.361050Z",
+     "shell.execute_reply": "2026-09-02T04:04:51.360630Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def build_backtest_rows():\n",
@@ -876,9 +1077,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e501e738",
-   "metadata": {},
+   "execution_count": 13,
+   "id": "5278fba4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:04:51.362019Z",
+     "iopub.status.busy": "2026-09-02T04:04:51.361897Z",
+     "iopub.status.idle": "2026-09-02T04:05:01.376992Z",
+     "shell.execute_reply": "2026-09-02T04:05:01.376657Z"
+    }
+   },
    "outputs": [],
    "source": [
     "bt_rows = build_backtest_rows()"
@@ -886,10 +1094,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "99b6ea4d",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 14,
+   "id": "146c76db",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:01.378383Z",
+     "iopub.status.busy": "2026-09-02T04:05:01.378288Z",
+     "iopub.status.idle": "2026-09-02T04:05:01.380557Z",
+     "shell.execute_reply": "2026-09-02T04:05:01.380216Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Pipeline Comparison:\n",
+      "shape: (9, 5)\n",
+      "┌─────────────────┬───────────────┬──────────────┬────────────────┬────────────────┐\n",
+      "│ case_study      ┆ signal_sharpe ┆ alloc_sharpe ┆ survives_costs ┆ managed_sharpe │\n",
+      "│ ---             ┆ ---           ┆ ---          ┆ ---            ┆ ---            │\n",
+      "│ str             ┆ f64           ┆ f64          ┆ bool           ┆ f64            │\n",
+      "╞═════════════════╪═══════════════╪══════════════╪════════════════╪════════════════╡\n",
+      "│ ETFs            ┆ 0.930341      ┆ 0.938865     ┆ true           ┆ 1.316659       │\n",
+      "│ Crypto          ┆ 1.271052      ┆ 1.479354     ┆ true           ┆ 1.574462       │\n",
+      "│ NASDAQ-100      ┆ null          ┆ null         ┆ null           ┆ null           │\n",
+      "│ S&P 500 Eq+Opt  ┆ 1.297788      ┆ 1.599784     ┆ true           ┆ 2.690598       │\n",
+      "│ US Firms        ┆ 3.557338      ┆ 3.582869     ┆ true           ┆ null           │\n",
+      "│ FX Pairs        ┆ 0.308569      ┆ 0.384668     ┆ true           ┆ 0.374504       │\n",
+      "│ CME Futures     ┆ 1.044776      ┆ 1.138895     ┆ true           ┆ 1.27421        │\n",
+      "│ S&P 500 Options ┆ -0.405577     ┆ -0.208325    ┆ null           ┆ null           │\n",
+      "│ US Equities     ┆ null          ┆ null         ┆ null           ┆ null           │\n",
+      "└─────────────────┴───────────────┴──────────────┴────────────────┴────────────────┘\n"
+     ]
+    }
+   ],
    "source": [
     "bt_df = pl.DataFrame(bt_rows)\n",
     "print(\"\\nPipeline Comparison:\")\n",
@@ -906,7 +1146,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4f98a8c",
+   "id": "464f7674",
    "metadata": {},
    "source": [
     "Eight of nine case studies produce positive signal-stage Sharpe; only\n",
@@ -925,7 +1165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e3863ef",
+   "id": "de16526e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -955,9 +1195,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b852de2c",
-   "metadata": {},
+   "execution_count": 15,
+   "id": "65d186ed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:01.381511Z",
+     "iopub.status.busy": "2026-09-02T04:05:01.381395Z",
+     "iopub.status.idle": "2026-09-02T04:05:01.386550Z",
+     "shell.execute_reply": "2026-09-02T04:05:01.386234Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def _benchmark_returns_from_artifact(\n",
@@ -1036,10 +1283,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "73c225af",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 16,
+   "id": "24119665",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:01.387542Z",
+     "iopub.status.busy": "2026-09-02T04:05:01.387426Z",
+     "iopub.status.idle": "2026-09-02T04:05:12.014499Z",
+     "shell.execute_reply": "2026-09-02T04:05:12.014197Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Paired Bootstrap: rank-1 vs equal-weight ===\n",
+      "shape: (7, 9)\n",
+      "┌────────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬─────────┐\n",
+      "│ case_study ┆ label     ┆ benchmark ┆ sharpe_di ┆ … ┆ sharpe_di ┆ info_rati ┆ prob_wins ┆ p_value │\n",
+      "│ ---        ┆ ---       ┆ _label    ┆ ff        ┆   ┆ ff_ci_hi  ┆ o         ┆ ---       ┆ ---     │\n",
+      "│ str        ┆ str       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ f64       ┆ f64     │\n",
+      "│            ┆           ┆ str       ┆ f64       ┆   ┆ f64       ┆ f64       ┆           ┆         │\n",
+      "╞════════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪═════════╡\n",
+      "│ ETFs       ┆ fwd_ret_5 ┆ fwd_ret_5 ┆ 0.648158  ┆ … ┆ 1.213959  ┆ 0.814726  ┆ 0.975     ┆ 0.038   │\n",
+      "│            ┆ d         ┆ d         ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+      "│ Crypto     ┆ fwd_ret_2 ┆ fwd_ret_2 ┆ 2.224503  ┆ … ┆ 3.917664  ┆ 2.24755   ┆ 0.9925    ┆ 0.014   │\n",
+      "│            ┆ 4h        ┆ 4h        ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+      "│ S&P 500    ┆ fwd_ret_r ┆ fwd_ret_r ┆ 2.080859  ┆ … ┆ 3.350498  ┆ 0.983178  ┆ 0.999     ┆ 0.001   │\n",
+      "│ Eq+Opt     ┆ isk_adj_5 ┆ isk_adj_5 ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+      "│            ┆ d         ┆ d         ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+      "│ US Firms   ┆ fwd_ret_1 ┆ fwd_ret_1 ┆ 3.222478  ┆ … ┆ 4.439953  ┆ 2.217229  ┆ 1.0       ┆ 0.0     │\n",
+      "│            ┆ m_win     ┆ m_win     ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+      "│ FX Pairs   ┆ fwd_ret_2 ┆ fwd_ret_2 ┆ 0.003767  ┆ … ┆ 0.47274   ┆ 0.163396  ┆ 0.486     ┆ 0.9835  │\n",
+      "│            ┆ 1d        ┆ 1d        ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+      "│ CME        ┆ fwd_ret_2 ┆ fwd_ret_2 ┆ 0.696819  ┆ … ┆ 1.863037  ┆ 0.393935  ┆ 0.844     ┆ 0.2745  │\n",
+      "│ Futures    ┆ 1d        ┆ 1d        ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+      "│ S&P 500    ┆ ret_to_ex ┆ ret_to_ex ┆ -0.745558 ┆ … ┆ 1.102938  ┆ -0.531278 ┆ 0.2105    ┆ 0.448   │\n",
+      "│ Options    ┆ piry      ┆ piry      ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+      "└────────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴─────────┘\n",
+      "\n",
+      "Skipped case studies:\n",
+      "  - nasdaq100_microstructure          no_signal_stage_candidates\n",
+      "  - us_equities_panel                 no_signal_stage_candidates\n",
+      "\n",
+      "paired=7/9, skipped=2/9\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -1217,7 +1509,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38474498",
+   "id": "c16fa8cc",
    "metadata": {},
    "source": [
     "Read each row as: rank-1 challenger annualized Sharpe **minus** equal-weight\n",
@@ -1234,7 +1526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb43d511",
+   "id": "8b42ea2c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1270,9 +1562,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4999758b",
-   "metadata": {},
+   "execution_count": 17,
+   "id": "e7a01d0e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:12.015631Z",
+     "iopub.status.busy": "2026-09-02T04:05:12.015555Z",
+     "iopub.status.idle": "2026-09-02T04:05:12.024922Z",
+     "shell.execute_reply": "2026-09-02T04:05:12.024380Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def _full_strategy_spec_from_backtest(db: sqlite3.Connection, bt_hash: str) -> dict | None:\n",
@@ -1624,9 +1923,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f1e5f4ce",
-   "metadata": {},
+   "execution_count": 18,
+   "id": "372499b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:12.026423Z",
+     "iopub.status.busy": "2026-09-02T04:05:12.026346Z",
+     "iopub.status.idle": "2026-09-02T04:05:12.030987Z",
+     "shell.execute_reply": "2026-09-02T04:05:12.030472Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def _populate_pair(\n",
@@ -1746,10 +2052,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9bc9b98d",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 19,
+   "id": "3488e6fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:12.032184Z",
+     "iopub.status.busy": "2026-09-02T04:05:12.032097Z",
+     "iopub.status.idle": "2026-09-02T04:05:41.517974Z",
+     "shell.execute_reply": "2026-09-02T04:05:41.517502Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  skip signal -> allocation: the allocation leader is not built on the signal leader\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  skip signal -> allocation: the allocation leader is not built on the signal leader\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  skip allocation -> risk_overlay: the risk_overlay leader is not built on the allocation leader\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  skip allocation -> cost_sensitivity: the cost_sensitivity leader is not built on the allocation leader\n"
+     ]
+    }
+   ],
    "source": [
     "extra_paired_rows: list[dict] = []\n",
     "_PAIRED_STAGES = (\"signal\", \"allocation\", \"risk_overlay\")\n",
@@ -1955,10 +2297,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5a22cd5e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 20,
+   "id": "50c59388",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:41.519607Z",
+     "iopub.status.busy": "2026-09-02T04:05:41.519527Z",
+     "iopub.status.idle": "2026-09-02T04:05:41.521683Z",
+     "shell.execute_reply": "2026-09-02T04:05:41.521327Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "extra_paired=28 rows across 7 case studies\n"
+     ]
+    }
+   ],
    "source": [
     "extra_paired_df = pl.DataFrame(extra_paired_rows)\n",
     "if extra_paired_df.is_empty():\n",
@@ -1973,7 +2331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8257671b",
+   "id": "f5b0b3fb",
    "metadata": {},
    "source": [
     "### Extended Paired-Bootstrap Coverage"
@@ -1981,17 +2339,80 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "36de9ca9",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 21,
+   "id": "94594dc6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:41.522986Z",
+     "iopub.status.busy": "2026-09-02T04:05:41.522917Z",
+     "iopub.status.idle": "2026-09-02T04:05:41.525558Z",
+     "shell.execute_reply": "2026-09-02T04:05:41.525263Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (28, 10)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>cs</th><th>kind</th><th>label</th><th>benchmark_label</th><th>n_overlap</th><th>sharpe_diff</th><th>sharpe_diff_ci_lo</th><th>sharpe_diff_ci_hi</th><th>info_ratio</th><th>p_value</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;etfs&quot;</td><td>&quot;equal_weight_holdout_side_arti…</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>498</td><td>-0.239997</td><td>-1.53253</td><td>0.791736</td><td>-0.085273</td><td>0.693</td></tr><tr><td>&quot;etfs&quot;</td><td>&quot;val_rank1_self&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>498</td><td>-0.135401</td><td>-1.536533</td><td>1.33474</td><td>NaN</td><td>0.8635</td></tr><tr><td>&quot;etfs&quot;</td><td>&quot;allocation_leader&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>2002</td><td>0.378655</td><td>-0.12377</td><td>0.863133</td><td>0.130732</td><td>0.144</td></tr><tr><td>&quot;etfs&quot;</td><td>&quot;risk_overlay_leader&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>2002</td><td>0.278263</td><td>0.246463</td><td>0.312415</td><td>7.31766</td><td>0.0</td></tr><tr><td>&quot;crypto_perps_funding&quot;</td><td>&quot;equal_weight_holdout_side_arti…</td><td>&quot;fwd_ret_24h&quot;</td><td>&quot;fwd_ret_24h&quot;</td><td>2191</td><td>-1.546741</td><td>-3.365792</td><td>0.140535</td><td>-1.44435</td><td>0.085</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;cme_futures&quot;</td><td>&quot;signal_leader&quot;</td><td>&quot;fwd_ret_21d&quot;</td><td>&quot;fwd_ret_21d&quot;</td><td>1268</td><td>0.094194</td><td>-0.611955</td><td>0.831581</td><td>-0.340308</td><td>0.8</td></tr><tr><td>&quot;cme_futures&quot;</td><td>&quot;allocation_leader&quot;</td><td>&quot;fwd_ret_21d&quot;</td><td>&quot;fwd_ret_21d&quot;</td><td>1268</td><td>0.135424</td><td>-0.264383</td><td>0.494179</td><td>-0.175849</td><td>0.49</td></tr><tr><td>&quot;sp500_options&quot;</td><td>&quot;equal_weight_holdout_side_arti…</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>247</td><td>-1.279129</td><td>-3.203818</td><td>0.652499</td><td>0.365518</td><td>0.204</td></tr><tr><td>&quot;sp500_options&quot;</td><td>&quot;val_rank1_self&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>247</td><td>1.476627</td><td>-0.986096</td><td>3.854171</td><td>NaN</td><td>0.2545</td></tr><tr><td>&quot;sp500_options&quot;</td><td>&quot;signal_leader&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>462</td><td>0.197251</td><td>-0.223461</td><td>0.644005</td><td>0.584202</td><td>0.371</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (28, 10)\n",
+       "┌────────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬─────────┐\n",
+       "│ cs         ┆ kind      ┆ label     ┆ benchmark ┆ … ┆ sharpe_di ┆ sharpe_di ┆ info_rati ┆ p_value │\n",
+       "│ ---        ┆ ---       ┆ ---       ┆ _label    ┆   ┆ ff_ci_lo  ┆ ff_ci_hi  ┆ o         ┆ ---     │\n",
+       "│ str        ┆ str       ┆ str       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ ---       ┆ f64     │\n",
+       "│            ┆           ┆           ┆ str       ┆   ┆ f64       ┆ f64       ┆ f64       ┆         │\n",
+       "╞════════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪═════════╡\n",
+       "│ etfs       ┆ equal_wei ┆ fwd_ret_5 ┆ fwd_ret_5 ┆ … ┆ -1.53253  ┆ 0.791736  ┆ -0.085273 ┆ 0.693   │\n",
+       "│            ┆ ght_holdo ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
+       "│            ┆ ut_side_a ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+       "│            ┆ rti…      ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+       "│ etfs       ┆ val_rank1 ┆ fwd_ret_5 ┆ fwd_ret_5 ┆ … ┆ -1.536533 ┆ 1.33474   ┆ NaN       ┆ 0.8635  │\n",
+       "│            ┆ _self     ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
+       "│ etfs       ┆ allocatio ┆ fwd_ret_5 ┆ fwd_ret_5 ┆ … ┆ -0.12377  ┆ 0.863133  ┆ 0.130732  ┆ 0.144   │\n",
+       "│            ┆ n_leader  ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
+       "│ etfs       ┆ risk_over ┆ fwd_ret_5 ┆ fwd_ret_5 ┆ … ┆ 0.246463  ┆ 0.312415  ┆ 7.31766   ┆ 0.0     │\n",
+       "│            ┆ lay_leade ┆ d         ┆ d         ┆   ┆           ┆           ┆           ┆         │\n",
+       "│            ┆ r         ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+       "│ crypto_per ┆ equal_wei ┆ fwd_ret_2 ┆ fwd_ret_2 ┆ … ┆ -3.365792 ┆ 0.140535  ┆ -1.44435  ┆ 0.085   │\n",
+       "│ ps_funding ┆ ght_holdo ┆ 4h        ┆ 4h        ┆   ┆           ┆           ┆           ┆         │\n",
+       "│            ┆ ut_side_a ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+       "│            ┆ rti…      ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+       "│ …          ┆ …         ┆ …         ┆ …         ┆ … ┆ …         ┆ …         ┆ …         ┆ …       │\n",
+       "│ cme_future ┆ signal_le ┆ fwd_ret_2 ┆ fwd_ret_2 ┆ … ┆ -0.611955 ┆ 0.831581  ┆ -0.340308 ┆ 0.8     │\n",
+       "│ s          ┆ ader      ┆ 1d        ┆ 1d        ┆   ┆           ┆           ┆           ┆         │\n",
+       "│ cme_future ┆ allocatio ┆ fwd_ret_2 ┆ fwd_ret_2 ┆ … ┆ -0.264383 ┆ 0.494179  ┆ -0.175849 ┆ 0.49    │\n",
+       "│ s          ┆ n_leader  ┆ 1d        ┆ 1d        ┆   ┆           ┆           ┆           ┆         │\n",
+       "│ sp500_opti ┆ equal_wei ┆ ret_to_ex ┆ ret_to_ex ┆ … ┆ -3.203818 ┆ 0.652499  ┆ 0.365518  ┆ 0.204   │\n",
+       "│ ons        ┆ ght_holdo ┆ piry      ┆ piry      ┆   ┆           ┆           ┆           ┆         │\n",
+       "│            ┆ ut_side_a ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+       "│            ┆ rti…      ┆           ┆           ┆   ┆           ┆           ┆           ┆         │\n",
+       "│ sp500_opti ┆ val_rank1 ┆ ret_to_ex ┆ ret_to_ex ┆ … ┆ -0.986096 ┆ 3.854171  ┆ NaN       ┆ 0.2545  │\n",
+       "│ ons        ┆ _self     ┆ piry      ┆ piry      ┆   ┆           ┆           ┆           ┆         │\n",
+       "│ sp500_opti ┆ signal_le ┆ ret_to_ex ┆ ret_to_ex ┆ … ┆ -0.223461 ┆ 0.644005  ┆ 0.584202  ┆ 0.371   │\n",
+       "│ ons        ┆ ader      ┆ piry      ┆ piry      ┆   ┆           ┆           ┆           ┆         │\n",
+       "└────────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴─────────┘"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "extra_paired_df"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1c9b6cb5",
+   "id": "c88e59fe",
    "metadata": {},
    "source": [
     "Summary by `benchmark_kind` shows which extension pair types landed for\n",
@@ -2005,7 +2426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91f34790",
+   "id": "d2f60959",
    "metadata": {},
    "source": [
     "## Sharpe Progression\n",
@@ -2018,9 +2439,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6b2db63c",
-   "metadata": {},
+   "execution_count": 22,
+   "id": "b2d160fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:41.526874Z",
+     "iopub.status.busy": "2026-09-02T04:05:41.526807Z",
+     "iopub.status.idle": "2026-09-02T04:05:44.932768Z",
+     "shell.execute_reply": "2026-09-02T04:05:44.932338Z"
+    }
+   },
    "outputs": [],
    "source": [
     "prog_rows = []\n",
@@ -2078,7 +2506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85790725",
+   "id": "28d57e96",
    "metadata": {},
    "source": [
     "### Sharpe Progression (best prediction per CS)"
@@ -2086,17 +2514,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "150ca2cd",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 23,
+   "id": "a5bc6cce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:44.934346Z",
+     "iopub.status.busy": "2026-09-02T04:05:44.934258Z",
+     "iopub.status.idle": "2026-09-02T04:05:44.936524Z",
+     "shell.execute_reply": "2026-09-02T04:05:44.936179Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (7, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>case_study</th><th>signal</th><th>allocation</th><th>risk_overlay</th><th>cost_sensitivity</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;CME Futures&quot;</td><td>1.044776</td><td>1.138895</td><td>1.27421</td><td>null</td></tr><tr><td>&quot;Crypto&quot;</td><td>1.271052</td><td>1.258969</td><td>null</td><td>null</td></tr><tr><td>&quot;ETFs&quot;</td><td>0.930341</td><td>0.938865</td><td>1.316659</td><td>1.594283</td></tr><tr><td>&quot;FX Pairs&quot;</td><td>0.308569</td><td>0.339118</td><td>null</td><td>null</td></tr><tr><td>&quot;S&amp;P 500 Eq+Opt&quot;</td><td>1.297788</td><td>1.299774</td><td>2.690598</td><td>3.095116</td></tr><tr><td>&quot;S&amp;P 500 Options&quot;</td><td>-0.405577</td><td>-0.208325</td><td>null</td><td>-0.728235</td></tr><tr><td>&quot;US Firms&quot;</td><td>3.557338</td><td>3.582869</td><td>null</td><td>3.656049</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (7, 5)\n",
+       "┌─────────────────┬───────────┬────────────┬──────────────┬──────────────────┐\n",
+       "│ case_study      ┆ signal    ┆ allocation ┆ risk_overlay ┆ cost_sensitivity │\n",
+       "│ ---             ┆ ---       ┆ ---        ┆ ---          ┆ ---              │\n",
+       "│ str             ┆ f64       ┆ f64        ┆ f64          ┆ f64              │\n",
+       "╞═════════════════╪═══════════╪════════════╪══════════════╪══════════════════╡\n",
+       "│ CME Futures     ┆ 1.044776  ┆ 1.138895   ┆ 1.27421      ┆ null             │\n",
+       "│ Crypto          ┆ 1.271052  ┆ 1.258969   ┆ null         ┆ null             │\n",
+       "│ ETFs            ┆ 0.930341  ┆ 0.938865   ┆ 1.316659     ┆ 1.594283         │\n",
+       "│ FX Pairs        ┆ 0.308569  ┆ 0.339118   ┆ null         ┆ null             │\n",
+       "│ S&P 500 Eq+Opt  ┆ 1.297788  ┆ 1.299774   ┆ 2.690598     ┆ 3.095116         │\n",
+       "│ S&P 500 Options ┆ -0.405577 ┆ -0.208325  ┆ null         ┆ -0.728235        │\n",
+       "│ US Firms        ┆ 3.557338  ┆ 3.582869   ┆ null         ┆ 3.656049         │\n",
+       "└─────────────────┴───────────┴────────────┴──────────────┴──────────────────┘"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "prog_pivot"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9c77204f",
+   "id": "e692c03b",
    "metadata": {},
    "source": [
     "Most case studies only have complete data through the signal and allocation\n",
@@ -2110,7 +2579,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14222c6e",
+   "id": "4de88eef",
    "metadata": {},
    "source": [
     "## Rank-1 Lineage\n",
@@ -2128,9 +2597,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3fac7841",
-   "metadata": {},
+   "execution_count": 24,
+   "id": "7fd4ab77",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:44.937621Z",
+     "iopub.status.busy": "2026-09-02T04:05:44.937556Z",
+     "iopub.status.idle": "2026-09-02T04:05:48.367607Z",
+     "shell.execute_reply": "2026-09-02T04:05:48.367182Z"
+    }
+   },
    "outputs": [],
    "source": [
     "lineage_rows = []\n",
@@ -2190,10 +2666,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "12cb7fbe",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 25,
+   "id": "381ce7ac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:48.368814Z",
+     "iopub.status.busy": "2026-09-02T04:05:48.368747Z",
+     "iopub.status.idle": "2026-09-02T04:05:48.371030Z",
+     "shell.execute_reply": "2026-09-02T04:05:48.370752Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Rank-1 Lineage (locked stage path per CS) ===\n",
+      "shape: (7, 6)\n",
+      "┌────────────────┬────────────────┬───────────────┬────────────────┬───────────────┬───────────────┐\n",
+      "│ case_study     ┆ signal_source  ┆ signal_sharpe ┆ allocation_sha ┆ risk_overlay_ ┆ cost_sensitiv │\n",
+      "│ ---            ┆ ---            ┆ ---           ┆ rpe            ┆ sharpe        ┆ ity_sharpe    │\n",
+      "│ str            ┆ str            ┆ f64           ┆ ---            ┆ ---           ┆ ---           │\n",
+      "│                ┆                ┆               ┆ f64            ┆ f64           ┆ f64           │\n",
+      "╞════════════════╪════════════════╪═══════════════╪════════════════╪═══════════════╪═══════════════╡\n",
+      "│ ETFs           ┆ gbm/leaves_63_ ┆ 0.93          ┆ 0.939          ┆ 1.317         ┆ 1.594         │\n",
+      "│                ┆ mse            ┆               ┆                ┆               ┆               │\n",
+      "│ Crypto         ┆ deep_learning/ ┆ 1.271         ┆ 1.259          ┆ null          ┆ null          │\n",
+      "│                ┆ nlinear        ┆               ┆                ┆               ┆               │\n",
+      "│ S&P 500 Eq+Opt ┆ latent_factors ┆ 1.298         ┆ 1.3            ┆ 2.691         ┆ 3.095         │\n",
+      "│                ┆ /sae           ┆               ┆                ┆               ┆               │\n",
+      "│ US Firms       ┆ gbm/leaves_31_ ┆ 3.557         ┆ 3.583          ┆ null          ┆ 3.656         │\n",
+      "│                ┆ huber          ┆               ┆                ┆               ┆               │\n",
+      "│ FX Pairs       ┆ deep_learning/ ┆ 0.309         ┆ 0.339          ┆ null          ┆ null          │\n",
+      "│                ┆ tcn            ┆               ┆                ┆               ┆               │\n",
+      "│ CME Futures    ┆ latent_factors ┆ 1.045         ┆ 1.139          ┆ 1.274         ┆ null          │\n",
+      "│                ┆ /sdf           ┆               ┆                ┆               ┆               │\n",
+      "│ S&P 500        ┆ linear/lasso_f ┆ -0.406        ┆ -0.208         ┆ null          ┆ -0.728        │\n",
+      "│ Options        ┆ 0.7            ┆               ┆                ┆               ┆               │\n",
+      "└────────────────┴────────────────┴───────────────┴────────────────┴───────────────┴───────────────┘\n"
+     ]
+    }
+   ],
    "source": [
     "lineage_df = pl.DataFrame(lineage_rows)\n",
     "if not lineage_df.is_empty():\n",
@@ -2209,7 +2723,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ec7b150",
+   "id": "5291a006",
    "metadata": {},
    "source": [
     "The lineage table shows how the rank-1 signal's Sharpe moves stage by\n",
@@ -2222,7 +2736,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "093e6f15",
+   "id": "9f013d41",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -2237,9 +2751,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6be4a347",
+   "execution_count": 26,
+   "id": "e7ef9d62",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:48.372099Z",
+     "iopub.status.busy": "2026-09-02T04:05:48.372034Z",
+     "iopub.status.idle": "2026-09-02T04:05:48.377475Z",
+     "shell.execute_reply": "2026-09-02T04:05:48.376972Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -2422,20 +2942,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b820af02",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 27,
+   "id": "c660dc52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:48.378538Z",
+     "iopub.status.busy": "2026-09-02T04:05:48.378478Z",
+     "iopub.status.idle": "2026-09-02T04:05:53.237451Z",
+     "shell.execute_reply": "2026-09-02T04:05:53.236995Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[warn] nasdaq100_microstructure: no rank-1 validation carrier, so no holdout row - nothing selected a holdout, and an unpinned query would let one select itself\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[warn] us_equities_panel: no rank-1 validation carrier, so no holdout row - nothing selected a holdout, and an unpinned query would let one select itself\n"
+     ]
+    }
+   ],
    "source": [
     "holdout_rows = query_holdout_rows()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c38d518e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 28,
+   "id": "fa443e39",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:53.238773Z",
+     "iopub.status.busy": "2026-09-02T04:05:53.238698Z",
+     "iopub.status.idle": "2026-09-02T04:05:53.241247Z",
+     "shell.execute_reply": "2026-09-02T04:05:53.240766Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Holdout Results (7 entries) ===\n",
+      "shape: (7, 5)\n",
+      "┌─────────────────┬────────────────┬────────────┬────────────────┬────────────────┐\n",
+      "│ case_study      ┆ family         ┆ holdout_ic ┆ holdout_sharpe ┆ holdout_max_dd │\n",
+      "│ ---             ┆ ---            ┆ ---        ┆ ---            ┆ ---            │\n",
+      "│ str             ┆ str            ┆ f64        ┆ f64            ┆ f64            │\n",
+      "╞═════════════════╪════════════════╪════════════╪════════════════╪════════════════╡\n",
+      "│ ETFs            ┆ gbm            ┆ -0.007128  ┆ 1.179489       ┆ -0.123326      │\n",
+      "│ Crypto          ┆ linear         ┆ -0.032576  ┆ -0.69638       ┆ -0.75692       │\n",
+      "│ S&P 500 Eq+Opt  ┆ latent_factors ┆ 0.02491    ┆ 0.50748        ┆ -0.078407      │\n",
+      "│ US Firms        ┆ gbm            ┆ 0.053444   ┆ 2.74223        ┆ -0.16577       │\n",
+      "│ FX Pairs        ┆ linear         ┆ -0.003059  ┆ 0.767299       ┆ -0.039693      │\n",
+      "│ CME Futures     ┆ gbm            ┆ 0.043783   ┆ 0.286844       ┆ -0.13283       │\n",
+      "│ S&P 500 Options ┆ linear         ┆ 0.002186   ┆ 1.268302       ┆ -0.265322      │\n",
+      "└─────────────────┴────────────────┴────────────┴────────────────┴────────────────┘\n"
+     ]
+    }
+   ],
    "source": [
     "holdout_df = pl.DataFrame(holdout_rows) if holdout_rows else pl.DataFrame(schema=HOLDOUT_SCHEMA)\n",
     "if not holdout_df.is_empty():\n",
@@ -2447,7 +3019,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c610ff0",
+   "id": "641280f2",
    "metadata": {},
    "source": [
     "Six of nine holdout backtests are positive: US Firms (+1.77), CME Futures\n",
@@ -2473,7 +3045,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12985247",
+   "id": "d9720ab8",
    "metadata": {},
    "source": [
     "## Stage Attrition Funnel\n",
@@ -2495,10 +3067,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "562fe1f7",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 29,
+   "id": "799b0202",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:53.242573Z",
+     "iopub.status.busy": "2026-09-02T04:05:53.242440Z",
+     "iopub.status.idle": "2026-09-02T04:05:53.250732Z",
+     "shell.execute_reply": "2026-09-02T04:05:53.250299Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Stage Attrition Funnel ===\n",
+      "  good_predictor        █████████  9/9\n",
+      "  tradable_gross        ██████░░░  6/9\n",
+      "  cost_surviving        ██████░░░  6/9\n",
+      "  risk_tolerable        █████░░░░  5/9\n",
+      "  holdout_valid         ██████░░░  6/9\n"
+     ]
+    }
+   ],
    "source": [
     "attrition = {\n",
     "    \"good_predictor\": 0,  # positive IC\n",
@@ -2551,7 +3144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b74bd089",
+   "id": "91fb7ad1",
    "metadata": {},
    "source": [
     "The funnel reads top-down with per-stage independent counts: 9 of 9\n",
@@ -2569,7 +3162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5da47d39",
+   "id": "36ab36f5",
    "metadata": {},
    "source": [
     "## Measurement Quality Disclosures\n",
@@ -2587,10 +3180,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "cd1442a1",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 30,
+   "id": "d563bb45",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:53.252097Z",
+     "iopub.status.busy": "2026-09-02T04:05:53.251980Z",
+     "iopub.status.idle": "2026-09-02T04:05:53.258692Z",
+     "shell.execute_reply": "2026-09-02T04:05:53.258153Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Measurement Quality Disclosures ===\n",
+      "shape: (9, 8)\n",
+      "┌────────────┬────────────┬────────────┬────────────┬────────────┬─────────┬───────────┬───────────┐\n",
+      "│ case_study ┆ rank1_val_ ┆ rank1_rank ┆ fold_sharp ┆ n_folds_po ┆ n_folds ┆ holdout_s ┆ validatio │\n",
+      "│ ---        ┆ sharpe     ┆ 10_spread  ┆ e_se       ┆ sitive     ┆ ---     ┆ harpe     ┆ n_holdout │\n",
+      "│ str        ┆ ---        ┆ ---        ┆ ---        ┆ ---        ┆ i64     ┆ ---       ┆ _decay    │\n",
+      "│            ┆ f64        ┆ f64        ┆ f64        ┆ i64        ┆         ┆ f64       ┆ ---       │\n",
+      "│            ┆            ┆            ┆            ┆            ┆         ┆           ┆ f64       │\n",
+      "╞════════════╪════════════╪════════════╪════════════╪════════════╪═════════╪═══════════╪═══════════╡\n",
+      "│ ETFs       ┆ 0.930341   ┆ 0.107202   ┆ 0.310391   ┆ 7          ┆ 8       ┆ 1.179489  ┆ -0.249148 │\n",
+      "│ Crypto     ┆ 1.271052   ┆ 0.262359   ┆ 0.482468   ┆ 2          ┆ 2       ┆ -0.69638  ┆ 1.967432  │\n",
+      "│ NASDAQ-100 ┆ null       ┆ null       ┆ null       ┆ 0          ┆ 0       ┆ null      ┆ null      │\n",
+      "│ S&P 500    ┆ 1.297788   ┆ 0.248311   ┆ 0.674894   ┆ 2          ┆ 2       ┆ 0.50748   ┆ 0.790309  │\n",
+      "│ Eq+Opt     ┆            ┆            ┆            ┆            ┆         ┆           ┆           │\n",
+      "│ US Firms   ┆ 3.557338   ┆ 0.32398    ┆ 0.890051   ┆ 10         ┆ 10      ┆ 2.74223   ┆ 0.815108  │\n",
+      "│ FX Pairs   ┆ 0.308569   ┆ 0.132516   ┆ 0.228077   ┆ 6          ┆ 8       ┆ 0.767299  ┆ -0.45873  │\n",
+      "│ CME        ┆ 1.044776   ┆ 0.433176   ┆ 0.797635   ┆ 3          ┆ 5       ┆ 0.286844  ┆ 0.757932  │\n",
+      "│ Futures    ┆            ┆            ┆            ┆            ┆         ┆           ┆           │\n",
+      "│ S&P 500    ┆ -0.405577  ┆ 0.17465    ┆ 1.243641   ┆ 1          ┆ 2       ┆ 1.268302  ┆ -1.673878 │\n",
+      "│ Options    ┆            ┆            ┆            ┆            ┆         ┆           ┆           │\n",
+      "│ US         ┆ null       ┆ null       ┆ null       ┆ 0          ┆ 0       ┆ null      ┆ null      │\n",
+      "│ Equities   ┆            ┆            ┆            ┆            ┆         ┆           ┆           │\n",
+      "└────────────┴────────────┴────────────┴────────────┴────────────┴─────────┴───────────┴───────────┘\n"
+     ]
+    }
+   ],
    "source": [
     "measurement_rows = []\n",
     "for cs in ALL_CASE_STUDIES:\n",
@@ -2644,7 +3275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f1b4ccf",
+   "id": "691da33c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -2658,9 +3289,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bda38edb",
-   "metadata": {},
+   "execution_count": 31,
+   "id": "c175f936",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:53.259884Z",
+     "iopub.status.busy": "2026-09-02T04:05:53.259818Z",
+     "iopub.status.idle": "2026-09-02T04:05:53.262597Z",
+     "shell.execute_reply": "2026-09-02T04:05:53.262280Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def build_variant_rows():\n",
@@ -2716,7 +3354,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c537e90c",
+   "id": "b5b4c714",
    "metadata": {},
    "source": [
     "The schema is declared rather than inferred. Polars reads the leading rows to guess a column's\n",
@@ -2728,9 +3366,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "58ef2898",
-   "metadata": {},
+   "execution_count": 32,
+   "id": "567b3c50",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:53.263469Z",
+     "iopub.status.busy": "2026-09-02T04:05:53.263402Z",
+     "iopub.status.idle": "2026-09-02T04:05:57.823236Z",
+     "shell.execute_reply": "2026-09-02T04:05:57.822732Z"
+    }
+   },
    "outputs": [],
    "source": [
     "variant_rows = build_variant_rows()"
@@ -2738,10 +3383,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2451f6bc",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 33,
+   "id": "a861cbac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:57.824396Z",
+     "iopub.status.busy": "2026-09-02T04:05:57.824321Z",
+     "iopub.status.idle": "2026-09-02T04:05:57.827544Z",
+     "shell.execute_reply": "2026-09-02T04:05:57.827290Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Variant Analysis: 402 variants ===\n",
+      "shape: (9, 3)\n",
+      "┌─────────────────┬─────┬──────────────┐\n",
+      "│ case_study      ┆ n   ┆ pct_positive │\n",
+      "│ ---             ┆ --- ┆ ---          │\n",
+      "│ str             ┆ u32 ┆ f64          │\n",
+      "╞═════════════════╪═════╪══════════════╡\n",
+      "│ CME Futures     ┆ 50  ┆ 70.0         │\n",
+      "│ Crypto          ┆ 49  ┆ 20.408163    │\n",
+      "│ ETFs            ┆ 54  ┆ 94.444444    │\n",
+      "│ FX Pairs        ┆ 49  ┆ 2.040816     │\n",
+      "│ NASDAQ-100      ┆ 16  ┆ 0.0          │\n",
+      "│ S&P 500 Eq+Opt  ┆ 54  ┆ 100.0        │\n",
+      "│ S&P 500 Options ┆ 49  ┆ 0.0          │\n",
+      "│ US Equities     ┆ 31  ┆ 0.0          │\n",
+      "│ US Firms        ┆ 50  ┆ 100.0        │\n",
+      "└─────────────────┴─────┴──────────────┘\n"
+     ]
+    }
+   ],
    "source": [
     "variant_df = pl.DataFrame(\n",
     "    variant_rows,\n",
@@ -2767,7 +3444,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "931338a1",
+   "id": "0740c29e",
    "metadata": {},
    "source": [
     "The `pct_positive` column reveals a stark divide: ETFs, S&P 500 Eq+Opt,\n",
@@ -2785,7 +3462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28a02b3d",
+   "id": "20ae9ebf",
    "metadata": {},
    "source": [
     "## Synthesis JSON\n",
@@ -2797,7 +3474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dab0d91e",
+   "id": "11335b00",
    "metadata": {},
    "source": [
     "Pinning a case study to its spine prediction stops cost and risk figures being\n",
@@ -2812,10 +3489,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0e4f21e5",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 34,
+   "id": "016f274c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:57.828595Z",
+     "iopub.status.busy": "2026-09-02T04:05:57.828516Z",
+     "iopub.status.idle": "2026-09-02T04:05:58.124510Z",
+     "shell.execute_reply": "2026-09-02T04:05:58.124129Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Built synthesis JSON for 9 case studies\n",
+      "  etfs: 5 families, best IC=0.08\n",
+      "  crypto_perps_funding: 4 families, best IC=0.0326\n",
+      "  nasdaq100_microstructure: 1 families, best IC=0.0046\n",
+      "  sp500_equity_option_analytics: 5 families, best IC=0.0156\n",
+      "  us_firm_characteristics: 4 families, best IC=0.0836\n",
+      "  fx_pairs: 4 families, best IC=0.0204\n",
+      "  cme_futures: 5 families, best IC=0.0338\n",
+      "  sp500_options: 4 families, best IC=0.0247\n",
+      "  us_equities_panel: 2 families, best IC=0.0343\n"
+     ]
+    }
+   ],
    "source": [
     "_PINNED_WITH_EVIDENCE = frozenset(\n",
     "    row[\"case_study_id\"]\n",
@@ -2899,7 +3601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb7691c7",
+   "id": "3c24db51",
    "metadata": {},
    "source": [
     "## Save Aggregated DataFrames\n",
@@ -2909,10 +3611,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "36a76be7",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 35,
+   "id": "702990dd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:58.125487Z",
+     "iopub.status.busy": "2026-09-02T04:05:58.125408Z",
+     "iopub.status.idle": "2026-09-02T04:05:58.135140Z",
+     "shell.execute_reply": "2026-09-02T04:05:58.134676Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Saved aggregated data to 20_strategy_synthesis/output\n",
+      "  backtest_comparison.parquet: 5.9 KB\n",
+      "  holdout_results.parquet: 8.3 KB\n",
+      "  ic_comparison.parquet: 3.3 KB\n",
+      "  lineage.parquet: 7.1 KB\n",
+      "  measurement_quality.parquet: 3.9 KB\n",
+      "  overview.parquet: 3.5 KB\n",
+      "  rank1_cluster_diagnostics.parquet: 4.2 KB\n",
+      "  sharpe_progression.parquet: 2.4 KB\n",
+      "  variant_analysis.parquet: 9.3 KB\n",
+      "  all_synthesis.json: 28.1 KB\n",
+      "  stage_attrition.json: 0.2 KB\n"
+     ]
+    }
+   ],
    "source": [
     "overview_df.write_parquet(OUTPUT_DIR / \"overview.parquet\")\n",
     "if not ic_df.is_empty():\n",
@@ -2949,7 +3678,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d9a770b",
+   "id": "d8413abf",
    "metadata": {},
    "source": [
     "## What the Empty Cells Mean\n",
@@ -2966,14 +3695,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8561724f",
+   "execution_count": 36,
+   "id": "b8d59774",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-02T04:05:58.136152Z",
+     "iopub.status.busy": "2026-09-02T04:05:58.136071Z",
+     "iopub.status.idle": "2026-09-02T04:05:58.138875Z",
+     "shell.execute_reply": "2026-09-02T04:05:58.138453Z"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**2 of 9 case studies have no registered backtests**: NASDAQ-100, US Equities. Every backtest-derived column is null for these, and the stage attrition counts above treat them as not reaching the tradable stage."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_empty = [\n",
     "    row[\"case_study\"]\n",
@@ -2992,7 +3740,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8236ac7f",
+   "id": "d63765ab",
    "metadata": {},
    "source": [
     "## Artifacts Produced\n",
@@ -3047,6 +3795,28 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "source_py_blob": "99ab001e43f85a5b8d5aa14fe180632b4c5e915e",
+   "executed_at": "2026-09-02T04:06:01.006439+00:00",
+   "executor": "local-uv",
+   "production": true,
+   "parameters": {}
+  },
+  "papermill": {
+   "parameters": {}
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`20_strategy_synthesis/01_aggregate_synthesis.ipynb` sat on `main` with its outputs cleared and no provenance stamp, so the reader saw a notebook that claimed nothing about the nine registries it reads.

This is a run of the same source - the stamp's `source_py_blob` equals the `.py` already on `main`, so no code changed - against the nine production registries, stamped `production=True`.

What the render now states, where it matters:

- ETFs rank-1 carrier `gbm/leaves_63_mse` on `fwd_ret_5d`: validation Sharpe 0.930, holdout IC -0.007128, holdout Sharpe 1.179489. This is the row the holdout correction in #706 produced, and it is what errata E20.15 records.
- `nasdaq100_microstructure` and `us_equities_panel` have no rank-1 validation carrier, so the notebook takes no holdout row for either rather than letting an unpinned query select one. Both print the warning that says so.
- Stage attrition across the nine: 9/9 good predictor, 6/9 tradable gross, 6/9 cost surviving, 5/9 risk tolerable, 6/9 holdout valid.

No `.py` change, so this is a render-only PR.