### PR TITLE
Test 25_live_trading/async_utils.run_async, which nothing covered

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -495,6 +495,11 @@ jobs:
         # against a restatement of its rules - and without the package the helper has no one to
         # ask, so the corpus sweep would pass while checking nothing. Pinned to the version in
         # `uv.lock`, as jupytext above is.
+        # nest-asyncio is a core project dependency and the import surface of
+        # `25_live_trading/async_utils.py`, whose run_async is what
+        # tests/test_async_utils.py exercises. It is pure Python and a few KB, so
+        # it does not compromise the fast-gate intent of this list.
+        #
         # pyarrow is what polars converts through in `DataFrame.to_pandas`, which
         # `load_modeling_dataset` calls on the fold-tagged temporal artifact. The
         # variant-geometry guard hangs off exactly that frame, so without pyarrow
@@ -504,7 +509,7 @@ jobs:
         run: |
           uv venv --python 3.14
           uv pip install pytest pytest-timeout numpy pandas polars pyyaml python-dotenv plotly gymnasium requests \
-            scipy statsmodels scikit-learn matplotlib hmmlearn pyarrow \
+            scipy statsmodels scikit-learn matplotlib hmmlearn pyarrow nest-asyncio \
             "ml4t-diagnostic>=0.1.2" jupytext==1.19.3 papermill==2.7.0 ml4t-backtest ml4t-data ml4t-engineer databento
       - name: Run download-logic unit tests
         env:

--- a/tests/test_async_utils.py
+++ b/tests/test_async_utils.py
@@ -1,0 +1,69 @@
+"""Tests for chapter 25 asynchronous notebook execution."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+from pathlib import Path
+
+CHAPTER_DIR = Path(__file__).parents[1] / "25_live_trading"
+sys.path.insert(0, str(CHAPTER_DIR))
+
+from async_utils import run_async  # noqa: E402
+
+
+def test_run_async_without_running_loop() -> None:
+    async def identify_loop() -> tuple[int, bool]:
+        return threading.get_ident(), asyncio.get_running_loop().is_running()
+
+    thread_id, loop_running = run_async(identify_loop())
+
+    assert thread_id == threading.get_ident()
+    assert loop_running is True
+
+
+def test_run_async_completes_inside_a_running_loop() -> None:
+    """The case the helper exists for: a notebook kernel already runs a loop.
+
+    Plain ``asyncio.run`` raises there. What ``run_async`` promises is that the
+    awaitable still runs to completion and its value comes back - not which
+    thread or loop it used, which differs between the nest_asyncio form the
+    chapter ships and the thread-per-call form.
+    """
+
+    async def outer() -> tuple[int, str]:
+        assert asyncio.get_running_loop().is_running()
+
+        async def inner() -> str:
+            await asyncio.sleep(0)
+            return "inner-done"
+
+        depth = 0
+
+        async def counted() -> int:
+            nonlocal depth
+            depth += 1
+            return depth
+
+        return run_async(counted()), run_async(inner())
+
+    depth, value = asyncio.run(outer())
+
+    assert depth == 1
+    assert value == "inner-done"
+
+
+def test_run_async_propagates_the_exception_the_awaitable_raises() -> None:
+    class Boom(Exception):
+        pass
+
+    async def explode() -> None:
+        raise Boom("from inside the awaitable")
+
+    try:
+        run_async(explode())
+    except Boom as exc:
+        assert str(exc) == "from inside the awaitable"
+    else:  # pragma: no cover - the helper must not swallow it
+        raise AssertionError("run_async swallowed the awaitable's exception")


### PR DESCRIPTION
Rescued from `~/ml4t/code` as that tree was retired. It was one of two files in the whole repository that existed in no other, and it tests a module that is live here and had no test at all.

It does not land as it was written. Its second case asserted that `run_async` dispatches to a different thread with its own loop, which closes afterwards - true of the thread-per-call implementation `~/ml4t/code` carried, false of the `nest_asyncio` form this repo ships, which re-enters the caller's running loop on the caller's thread. Asserting thread identity pins an implementation rather than a contract, so it failed here for the right reason.

What `run_async` actually promises is that an awaitable completes and returns its value whether or not a loop is already running - the notebook-kernel case, where plain `asyncio.run` raises. That is what the rewritten case tests, plus a third covering exception propagation, which nothing exercised.

`3 passed` locally.