### PR TITLE
us_firm: stop declaring a causal menu on the class label

### DIFF
--- a/case_studies/us_firm_characteristics/config/training/fwd_class_1m.yaml
+++ b/case_studies/us_firm_characteristics/config/training/fwd_class_1m.yaml
@@ -33,10 +33,12 @@ latent_factors:
 - cae
 - sdf
 - sae
-causal_dml:
-# A DML row cap is spent on whole decision months, so the history it buys is the cap
-# divided by the width of the cross-section. This panel is a monthly cross-section
-# thousands of firms wide, and the fleet default preset leaves it under two years of
-# decision months to compute a time-clustered standard error and a block permutation
-# over. dml_250k is that same design with a cap sized for a panel this wide.
-- dml_250k
+# No `causal_dml`. The DML nuisance models are regressors - `case_studies/utils/causal.py`
+# builds both as `HistGradientBoostingRegressor` - and there is no classification branch, so
+# running a declared causal menu on this label fits a regressor to a class target and banks the
+# result as a canonical causal estimate. Nothing has ever run it here: all six rows in
+# `causal_runs` are on `fwd_ret_1m`. The trap was that the declaration outlived the absence of a
+# path to honour it, so a reader comparing the declared menu against the production count sees a
+# missing causal result and extends the notebook to produce it. The return labels keep their
+# `causal_dml` - a continuous target is what DML as implemented estimates. See
+# ml4t/agent-workspace#396.


### PR DESCRIPTION
`case_studies/us_firm_characteristics/config/training/fwd_class_1m.yaml` declared
`causal_dml: [dml_250k]` on a classification label. The DML nuisance models have no
classification branch - `case_studies/utils/causal.py:1705-1706` builds both as
`HistGradientBoostingRegressor`, and `grep -n "Classifier" case_studies/utils/causal.py` returns
nothing - so honouring that declaration fits a regressor to a class target and registers the
result as a canonical causal estimate.

Nothing ever ran it. All six rows in the us_firm registry's `causal_runs` are on `fwd_ret_1m`.
So this removes dead configuration rather than a result, and no identity, hash or registered
value moves.

The reason to remove it rather than leave it is the trap it sets: the declared menu and the
production count disagree, and only the config side is discoverable, so the next reader sees one
missing causal result and extends the notebook to produce it. `crypto_perps_funding` reached the
same conclusion for `fwd_dir_8h` and `fwd_dir_8h_3c` and replaced the key with a comment
explaining the absence; this follows that precedent so the gap is documented rather than silent.
The two continuous labels, `fwd_ret_1m` and `fwd_ret_1m_win`, keep their `causal_dml`.

Verified: `tests/test_research_declared_menu_coverage.py`, `tests/test_research_configs.py`,
`tests/test_causal_adapter.py`, `tests/test_us_firm_research_workflow.py` and
`tests/test_causal_registry_registration.py` - 156 passed, 1 skipped. No test requires a
`causal_dml` key on every label.

Closes the `us_firm_characteristics` half of ml4t/agent-workspace#396. The
`nasdaq100_microstructure` half is still open: `config/training/fwd_dir_15m.yaml:30` declares
`causal_dml` on a direction label, and that case study's causal notebook has not been executed
yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnCNZKaL67feojG5k6Ltjt