### PR TITLE
Two causal defects nasdaq100_microstructure's run would have baked in

### DIFF
--- a/case_studies/nasdaq100_microstructure/12_causal_dml.ipynb
+++ b/case_studies/nasdaq100_microstructure/12_causal_dml.ipynb
@@ -451,15 +451,25 @@
     "# p-value computed in run_dml_analysis (no duplication)\n",
     "p_value = results[\"p_value_hac\"]\n",
     "\n",
+    "# An absent refutation is a missing measurement, not a p-value of 1. `run_dml_analysis`\n",
+    "# leaves `refutation` empty when fewer than `MIN_PLACEBO_DRAWS` placebo draws returned a\n",
+    "# finite effect, and defaulting to 1.0 here publishes that non-result as if the permutation\n",
+    "# test had run and failed to reject - in the summary below and to a reader who cannot tell\n",
+    "# the difference. `register_causal_run` already writes NULL for it; None keeps the notebook\n",
+    "# saying the same thing (ml4t/agent-workspace#914).\n",
     "ref = results.get(\"refutation\", {})\n",
-    "p_value_perm = ref.get(\"empirical_p\", 1.0)\n",
-    "ref_class = ref.get(\"refutation_class\", classify_refutation(p_value_perm))\n",
+    "p_value_perm = ref.get(\"empirical_p\")\n",
+    "ref_class = None\n",
+    "if p_value_perm is not None:\n",
+    "    ref_class = ref.get(\"refutation_class\") or classify_refutation(p_value_perm)\n",
     "\n",
     "print(\"Statistical significance:\")\n",
     "print(f\"  p-value (HAC): {p_value:.4f}\")\n",
     "print(f\"  Significant at 5%: {'Yes' if p_value < 0.05 else 'No'}\")\n",
     "if ref:\n",
-    "    print(f\"  Refutation: {ref_class} (p={p_value_perm:.4f})\")"
+    "    print(f\"  Refutation: {ref_class} (p={p_value_perm:.4f})\")\n",
+    "else:\n",
+    "    print(\"  Refutation: did not run - too few placebo draws returned a finite effect\")"
    ]
   },
   {
@@ -586,7 +596,10 @@
     "print(f\"Adjusted (DML) slope: {dml_effect:+.3e}  (Newey-West SE {se_hac:.3e})\")\n",
     "print(f\"Confounding bias: {bias_pct:+.1f}%\")\n",
     "print(f\"Newey-West p-value: {p_value:.4f}  (lags {results.get('hac_maxlags', 0)})\")\n",
-    "print(f\"Permutation p-value: {p_value_perm:.4f}  ({ref_class})\")"
+    "if p_value_perm is None:\n",
+    "    print(\"Permutation p-value: not run\")\n",
+    "else:\n",
+    "    print(f\"Permutation p-value: {p_value_perm:.4f}  ({ref_class})\")"
    ]
   },
   {

--- a/case_studies/nasdaq100_microstructure/12_causal_dml.py
+++ b/case_studies/nasdaq100_microstructure/12_causal_dml.py
@@ -358,15 +358,25 @@ bias_pct = results["confounding_bias_pct"]
 # p-value computed in run_dml_analysis (no duplication)
 p_value = results["p_value_hac"]
 
+# An absent refutation is a missing measurement, not a p-value of 1. `run_dml_analysis`
+# leaves `refutation` empty when fewer than `MIN_PLACEBO_DRAWS` placebo draws returned a
+# finite effect, and defaulting to 1.0 here publishes that non-result as if the permutation
+# test had run and failed to reject - in the summary below and to a reader who cannot tell
+# the difference. `register_causal_run` already writes NULL for it; None keeps the notebook
+# saying the same thing (ml4t/agent-workspace#914).
 ref = results.get("refutation", {})
-p_value_perm = ref.get("empirical_p", 1.0)
-ref_class = ref.get("refutation_class", classify_refutation(p_value_perm))
+p_value_perm = ref.get("empirical_p")
+ref_class = None
+if p_value_perm is not None:
+    ref_class = ref.get("refutation_class") or classify_refutation(p_value_perm)
 
 print("Statistical significance:")
 print(f"  p-value (HAC): {p_value:.4f}")
 print(f"  Significant at 5%: {'Yes' if p_value < 0.05 else 'No'}")
 if ref:
     print(f"  Refutation: {ref_class} (p={p_value_perm:.4f})")
+else:
+    print("  Refutation: did not run - too few placebo draws returned a finite effect")
 
 # %% [markdown]
 # > **When should you be suspicious of large DML corrections?** A naive-to-DML
@@ -448,7 +458,10 @@ print(f"Naive slope: {naive_effect:+.3e}")
 print(f"Adjusted (DML) slope: {dml_effect:+.3e}  (Newey-West SE {se_hac:.3e})")
 print(f"Confounding bias: {bias_pct:+.1f}%")
 print(f"Newey-West p-value: {p_value:.4f}  (lags {results.get('hac_maxlags', 0)})")
-print(f"Permutation p-value: {p_value_perm:.4f}  ({ref_class})")
+if p_value_perm is None:
+    print("Permutation p-value: not run")
+else:
+    print(f"Permutation p-value: {p_value_perm:.4f}  ({ref_class})")
 
 # %% [markdown]
 # ## Key Takeaways

--- a/case_studies/nasdaq100_microstructure/config/training/fwd_dir_15m.yaml
+++ b/case_studies/nasdaq100_microstructure/config/training/fwd_dir_15m.yaml
@@ -27,5 +27,12 @@ deep_learning:
 - lstm_h64
 - tcn
 - patchtst
-causal_dml:
-- dml
+# No `causal_dml`. The DML nuisance models are regressors - `case_studies/utils/causal.py`
+# builds both as `HistGradientBoostingRegressor` - and there is no classification branch, so
+# running a declared causal menu on this label fits a regressor to a class target and banks the
+# result as a canonical causal estimate. `12_causal_dml` estimates on `labels.primary`
+# (`fwd_ret_15m`) and never reads this file, so the key ran nothing; what it did was tell the
+# next reader, comparing the declared menu against the production count, that a causal result
+# for the direction label was missing and the notebook should be extended to produce it.
+# ml4t/agent-workspace#396. The three return labels keep theirs: a continuous target is what
+# DML as implemented estimates.

--- a/tests/test_causal_menu_not_on_classification_labels.py
+++ b/tests/test_causal_menu_not_on_classification_labels.py
@@ -1,0 +1,75 @@
+"""A `causal_dml` menu declared on a classification label is an instruction to run nonsense.
+
+`case_studies/utils/causal.py` builds both DML nuisance models as
+`HistGradientBoostingRegressor` and has no classification branch, so estimating the declared
+menu on a class target fits a regressor to it and registers the result as a canonical causal
+estimate. Nothing runs these declarations today - every causal notebook estimates on
+`labels.primary`, which is continuous everywhere - so the cost is not a wrong number on disk.
+It is that the declaration and the production count disagree, and only the declaration is
+discoverable: the next reader sees a causal result that the config says should exist, and
+extends a notebook to produce it. That is ml4t/agent-workspace#396, and comments alone did not
+stop it coming back.
+
+A classification label is identified by `labels.classification_eval_label` in
+`config/setup.yaml`, which names the continuous return each class target is derived from. That
+is the corpus's own declaration of which labels are classification, so the check does not
+depend on how a label happens to be named.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from utils.paths import REPO_ROOT
+
+# Anchored to REPO_ROOT rather than the working directory, so running pytest from elsewhere
+# cannot silently collect nothing and pass.
+SETUPS = sorted((REPO_ROOT / "case_studies").glob("*/config/setup.yaml"))
+
+# `(case_study, label)` pairs that still declare the key, each owned by another lane. An
+# exemption here is asserted to still be needed by `test_every_exemption_is_still_earned`, so
+# the entry has to be deleted in the same change that fixes the config rather than outliving
+# it as a permanently unread allowance.
+KNOWN_UNFIXED = {("us_firm_characteristics", "fwd_class_1m")}
+
+
+def _classification_labels(setup_path) -> list[str]:
+    setup = yaml.safe_load(setup_path.read_text()) or {}
+    declared = (setup.get("labels") or {}).get("classification_eval_label") or {}
+    return sorted(declared)
+
+
+def _declares_causal_dml(case_study: str, label: str) -> bool:
+    menu = REPO_ROOT / "case_studies" / case_study / "config" / "training" / f"{label}.yaml"
+    if not menu.exists():
+        return False
+    return "causal_dml" in (yaml.safe_load(menu.read_text()) or {})
+
+
+CASES = [(path.parts[-3], label) for path in SETUPS for label in _classification_labels(path)]
+
+
+def test_the_corpus_declares_classification_labels_at_all():
+    """Without this the parametrized check below can pass on an empty list."""
+    assert SETUPS, "no case studies discovered"
+    assert CASES, "no classification labels discovered; the setup.yaml key must have moved"
+
+
+@pytest.mark.parametrize("case_study,label", CASES, ids=lambda v: str(v))
+def test_no_causal_menu_on_a_classification_label(case_study: str, label: str):
+    if (case_study, label) in KNOWN_UNFIXED:
+        pytest.skip(f"{case_study}/{label} is a known unfixed instance of #396")
+    assert not _declares_causal_dml(case_study, label), (
+        f"{case_study}/config/training/{label}.yaml declares `causal_dml` on a classification "
+        "label; the DML nuisances are regressors and there is no classification branch"
+    )
+
+
+@pytest.mark.parametrize("case_study,label", sorted(KNOWN_UNFIXED), ids=lambda v: str(v))
+def test_every_exemption_is_still_earned(case_study: str, label: str):
+    """An exemption for a config that no longer declares the key hides the next regression."""
+    assert _declares_causal_dml(case_study, label), (
+        f"{case_study}/{label} no longer declares `causal_dml`; remove it from KNOWN_UNFIXED "
+        "so the check guards it"
+    )


### PR DESCRIPTION
Both are pre-run: `nasdaq100_microstructure` has never run stage 06+, so these would be reproduced into a fresh registry rather than found in one.

## `causal_dml` declared on a classification label (ml4t/agent-workspace#396)

`config/training/fwd_dir_15m.yaml` declared `causal_dml: [dml]`. The DML nuisances are both `HistGradientBoostingRegressor` and `case_studies/utils/causal.py` has no classification branch, so estimating that menu fits a regressor to a class target and registers the result as a canonical causal estimate.

Nothing ran it - `12_causal_dml` estimates on `labels.primary`, which is `fwd_ret_15m` - so the cost was not a wrong number on disk. It was that the declared menu and the production count disagreed while only the declaration was discoverable, which is how the next reader is led to extend the notebook and produce the nonsense.

`crypto_perps_funding` removed its two by comment alone. `tests/test_causal_menu_not_on_classification_labels.py` reads which labels are classification out of `labels.classification_eval_label` in each `config/setup.yaml` - the corpus's own declaration, so the check does not depend on how a label is named - and makes the removal hold. `us_firm_characteristics/fwd_class_1m` is another lane's and is exempted by an entry that is itself asserted to still be earned, so fixing it there forces the exemption out rather than leaving it as a permanently unread allowance.

## A permutation p-value published for a test that did not run (ml4t/agent-workspace#914)

`12_causal_dml.py` read it as `ref.get("empirical_p", 1.0)`. `run_dml_analysis` leaves `refutation` empty when fewer than `MIN_PLACEBO_DRAWS` placebo draws return a finite effect, so the summary cell printed `Permutation p-value: 1.0000` for a test that never ran.

The registry was already safe - `register_causal_run` writes NULL - which is what made the printed number the only place the fabrication surfaced, and why nothing caught it. It now reads `None` and prints `not run`. The three other notebooks named in #914 were fixed by their rewrites onto `case_studies.research`; this was the last one.

## Verification

- `tests/test_causal_menu_not_on_classification_labels.py`: 7 passed, 1 skipped. Mutation-checked - restoring `causal_dml: [dml]` to `fwd_dir_15m.yaml` fails it by name.
- `tests/test_research_declared_menu_coverage.py`, `tests/test_causal_completeness_refutation.py`: 65 passed, 2 skipped together with the new file.
- `.ipynb` regenerated with `scripts/sync_notebooks.py`; pre-commit's notebook pairing and provenance gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ltde4brozrjqTFuw3GSpgj