### PR TITLE
Retire the last causal-menu exemption, which main no longer earns

### DIFF
--- a/tests/test_causal_menu_not_on_classification_labels.py
+++ b/tests/test_causal_menu_not_on_classification_labels.py
@@ -31,7 +31,12 @@ SETUPS = sorted((REPO_ROOT / "case_studies").glob("*/config/setup.yaml"))
 # exemption here is asserted to still be needed by `test_every_exemption_is_still_earned`, so
 # the entry has to be deleted in the same change that fixes the config rather than outliving
 # it as a permanently unread allowance.
-KNOWN_UNFIXED = {("us_firm_characteristics", "fwd_class_1m")}
+#
+# Empty since 2026-09-02, and the emptiness is the point: `us_firm_characteristics/fwd_class_1m`
+# was the last entry, and #717 removed that declaration in the window between this file being
+# written and merged. The exemption assertion is what caught it - it failed on `main` the moment
+# both landed, which is exactly the regression it exists to find, one step earlier than expected.
+KNOWN_UNFIXED: set[tuple[str, str]] = set()
 
 
 def _classification_labels(setup_path) -> list[str]:


### PR DESCRIPTION
`test-unit` is red on `main` and on every open PR - #719, #720, #721 and `fix/nasdaq-fixture-universe-12` all inherit it.

Two PRs that were each green alone. #718 landed `tests/test_causal_menu_not_on_classification_labels.py` carrying `KNOWN_UNFIXED = {("us_firm_characteristics", "fwd_class_1m")}`, and #717 had already removed that declaration. `test_every_exemption_is_still_earned` then asserts a config declares `causal_dml` when it no longer does.

**The test worked.** Refusing an exemption that outlives the defect it allows is its entire purpose, and it found one within hours - just in the direction nobody plans for, the fix landing before the guard rather than after.

`KNOWN_UNFIXED` is now empty, so every classification label in the corpus is guarded and none is skipped. The parametrized exemption test reports as a pytest empty-parameter-set skip, which is what an empty allowance should look like. Verified locally: 7 passed, 1 skipped, no failures.