### PR TITLE
crypto_perps_funding: guard the canonical population on the declared catalog, not a row count

### DIFF
--- a/case_studies/crypto_perps_funding/06_linear.ipynb
+++ b/case_studies/crypto_perps_funding/06_linear.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d6b4a2ea",
+   "id": "8e4f2912",
    "metadata": {
     "papermill": {
-     "duration": 0.001407,
-     "end_time": "2026-09-02T16:01:52.979761+00:00",
+     "duration": 0.001597,
+     "end_time": "2026-09-02T16:49:47.028010+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:52.978354+00:00",
+     "start_time": "2026-09-02T16:49:47.026413+00:00",
      "status": "completed"
     }
    },
@@ -72,19 +72,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "e3337cdd",
+   "id": "9fb7da7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:01:52.982877Z",
-     "iopub.status.busy": "2026-09-02T16:01:52.982771Z",
-     "iopub.status.idle": "2026-09-02T16:01:55.439313Z",
-     "shell.execute_reply": "2026-09-02T16:01:55.438699Z"
+     "iopub.execute_input": "2026-09-02T16:49:47.031301Z",
+     "iopub.status.busy": "2026-09-02T16:49:47.031168Z",
+     "iopub.status.idle": "2026-09-02T16:49:49.221629Z",
+     "shell.execute_reply": "2026-09-02T16:49:49.221180Z"
     },
     "papermill": {
-     "duration": 2.458878,
-     "end_time": "2026-09-02T16:01:55.439844+00:00",
+     "duration": 2.193289,
+     "end_time": "2026-09-02T16:49:49.222723+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:52.980966+00:00",
+     "start_time": "2026-09-02T16:49:47.029434+00:00",
      "status": "completed"
     }
    },
@@ -104,6 +104,7 @@
     "    declared_labels,\n",
     "    load_model_configs,\n",
     "    model_requests,\n",
+    "    narrows_declared_catalog,\n",
     "    open_study,\n",
     "    primary_label,\n",
     "    resolved_model_plan,\n",
@@ -115,19 +116,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "0d058c7f",
+   "id": "3b5332f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:01:55.444113Z",
-     "iopub.status.busy": "2026-09-02T16:01:55.443836Z",
-     "iopub.status.idle": "2026-09-02T16:01:55.446919Z",
-     "shell.execute_reply": "2026-09-02T16:01:55.446385Z"
+     "iopub.execute_input": "2026-09-02T16:49:49.226610Z",
+     "iopub.status.busy": "2026-09-02T16:49:49.226419Z",
+     "iopub.status.idle": "2026-09-02T16:49:49.228445Z",
+     "shell.execute_reply": "2026-09-02T16:49:49.228173Z"
     },
     "papermill": {
-     "duration": 0.005264,
-     "end_time": "2026-09-02T16:01:55.447226+00:00",
+     "duration": 0.003919,
+     "end_time": "2026-09-02T16:49:49.228747+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.441962+00:00",
+     "start_time": "2026-09-02T16:49:49.224828+00:00",
      "status": "completed"
     },
     "tags": [
@@ -148,19 +149,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "db6c0288",
+   "id": "b4f32654",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:01:55.449956Z",
-     "iopub.status.busy": "2026-09-02T16:01:55.449884Z",
-     "iopub.status.idle": "2026-09-02T16:01:55.485822Z",
-     "shell.execute_reply": "2026-09-02T16:01:55.485489Z"
+     "iopub.execute_input": "2026-09-02T16:49:49.231509Z",
+     "iopub.status.busy": "2026-09-02T16:49:49.231430Z",
+     "iopub.status.idle": "2026-09-02T16:49:49.351131Z",
+     "shell.execute_reply": "2026-09-02T16:49:49.350736Z"
     },
     "papermill": {
-     "duration": 0.038326,
-     "end_time": "2026-09-02T16:01:55.486758+00:00",
+     "duration": 0.121995,
+     "end_time": "2026-09-02T16:49:49.351865+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.448432+00:00",
+     "start_time": "2026-09-02T16:49:49.229870+00:00",
      "status": "completed"
     }
    },
@@ -173,13 +174,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfe4967f",
+   "id": "067a9c15",
    "metadata": {
     "papermill": {
-     "duration": 0.001657,
-     "end_time": "2026-09-02T16:01:55.490744+00:00",
+     "duration": 0.001879,
+     "end_time": "2026-09-02T16:49:49.356087+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.489087+00:00",
+     "start_time": "2026-09-02T16:49:49.354208+00:00",
      "status": "completed"
     }
    },
@@ -209,19 +210,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b74d1a4f",
+   "id": "1dd7e29f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:01:55.493531Z",
-     "iopub.status.busy": "2026-09-02T16:01:55.493444Z",
-     "iopub.status.idle": "2026-09-02T16:01:55.507519Z",
-     "shell.execute_reply": "2026-09-02T16:01:55.507272Z"
+     "iopub.execute_input": "2026-09-02T16:49:49.359082Z",
+     "iopub.status.busy": "2026-09-02T16:49:49.358931Z",
+     "iopub.status.idle": "2026-09-02T16:49:49.373211Z",
+     "shell.execute_reply": "2026-09-02T16:49:49.372846Z"
     },
     "papermill": {
-     "duration": 0.01602,
-     "end_time": "2026-09-02T16:01:55.507873+00:00",
+     "duration": 0.016115,
+     "end_time": "2026-09-02T16:49:49.373434+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.491853+00:00",
+     "start_time": "2026-09-02T16:49:49.357319+00:00",
      "status": "completed"
     }
    },
@@ -243,13 +244,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6865eafc",
+   "id": "0780425c",
    "metadata": {
     "papermill": {
-     "duration": 0.001091,
-     "end_time": "2026-09-02T16:01:55.510210+00:00",
+     "duration": 0.001078,
+     "end_time": "2026-09-02T16:49:49.375736+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.509119+00:00",
+     "start_time": "2026-09-02T16:49:49.374658+00:00",
      "status": "completed"
     }
    },
@@ -282,19 +283,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "23f3ac8e",
+   "id": "bdf8bc2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:01:55.512853Z",
-     "iopub.status.busy": "2026-09-02T16:01:55.512769Z",
-     "iopub.status.idle": "2026-09-02T16:01:55.577892Z",
-     "shell.execute_reply": "2026-09-02T16:01:55.577347Z"
+     "iopub.execute_input": "2026-09-02T16:49:49.378466Z",
+     "iopub.status.busy": "2026-09-02T16:49:49.378393Z",
+     "iopub.status.idle": "2026-09-02T16:49:49.413435Z",
+     "shell.execute_reply": "2026-09-02T16:49:49.413094Z"
     },
     "papermill": {
-     "duration": 0.066935,
-     "end_time": "2026-09-02T16:01:55.578250+00:00",
+     "duration": 0.037401,
+     "end_time": "2026-09-02T16:49:49.414227+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.511315+00:00",
+     "start_time": "2026-09-02T16:49:49.376826+00:00",
      "status": "completed"
     }
    },
@@ -349,13 +350,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "041b50fb",
+   "id": "f33273a0",
    "metadata": {
     "papermill": {
-     "duration": 0.001175,
-     "end_time": "2026-09-02T16:01:55.580859+00:00",
+     "duration": 0.002204,
+     "end_time": "2026-09-02T16:49:49.419051+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.579684+00:00",
+     "start_time": "2026-09-02T16:49:49.416847+00:00",
      "status": "completed"
     }
    },
@@ -371,40 +372,41 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "de5f2c9e",
+   "id": "7b5775f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:01:55.584052Z",
-     "iopub.status.busy": "2026-09-02T16:01:55.583905Z",
-     "iopub.status.idle": "2026-09-02T16:01:55.615265Z",
-     "shell.execute_reply": "2026-09-02T16:01:55.614796Z"
+     "iopub.execute_input": "2026-09-02T16:49:49.423768Z",
+     "iopub.status.busy": "2026-09-02T16:49:49.423662Z",
+     "iopub.status.idle": "2026-09-02T16:49:49.454882Z",
+     "shell.execute_reply": "2026-09-02T16:49:49.454549Z"
     },
     "papermill": {
-     "duration": 0.033591,
-     "end_time": "2026-09-02T16:01:55.615660+00:00",
+     "duration": 0.034163,
+     "end_time": "2026-09-02T16:49:49.455471+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.582069+00:00",
+     "start_time": "2026-09-02T16:49:49.421308+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "if configs.height < load_model_configs(study, \"linear\").height and not POPULATION_NAME:\n",
+    "if narrows_declared_catalog(study, \"linear\", configs) and not POPULATION_NAME:\n",
     "    raise ValueError(\n",
-    "        f\"this run fits {configs.height} of the declared configurations, so it cannot publish \"\n",
-    "        \"the canonical population; pass POPULATION_NAME to give it its own\"\n",
+    "        f\"this run declares {configs.height} label-configuration pairs, which is not the \"\n",
+    "        \"complete declared catalog, so it cannot publish the canonical population; pass \"\n",
+    "        \"POPULATION_NAME to give it its own\"\n",
     "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b21b956a",
+   "id": "4a8ce5e3",
    "metadata": {
     "papermill": {
-     "duration": 0.00122,
-     "end_time": "2026-09-02T16:01:55.618490+00:00",
+     "duration": 0.001157,
+     "end_time": "2026-09-02T16:49:49.458060+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.617270+00:00",
+     "start_time": "2026-09-02T16:49:49.456903+00:00",
      "status": "completed"
     }
    },
@@ -441,19 +443,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "de34b7a0",
+   "id": "7e78fe43",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:01:55.621466Z",
-     "iopub.status.busy": "2026-09-02T16:01:55.621386Z",
-     "iopub.status.idle": "2026-09-02T16:01:59.669833Z",
-     "shell.execute_reply": "2026-09-02T16:01:59.669302Z"
+     "iopub.execute_input": "2026-09-02T16:49:49.461092Z",
+     "iopub.status.busy": "2026-09-02T16:49:49.460993Z",
+     "iopub.status.idle": "2026-09-02T16:49:53.702689Z",
+     "shell.execute_reply": "2026-09-02T16:49:53.702202Z"
     },
     "papermill": {
-     "duration": 4.050398,
-     "end_time": "2026-09-02T16:01:59.670135+00:00",
+     "duration": 4.243685,
+     "end_time": "2026-09-02T16:49:53.703010+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:55.619737+00:00",
+     "start_time": "2026-09-02T16:49:49.459325+00:00",
      "status": "completed"
     }
    },
@@ -531,13 +533,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "963a0df2",
+   "id": "63a6be7a",
    "metadata": {
     "papermill": {
-     "duration": 0.001225,
-     "end_time": "2026-09-02T16:01:59.672824+00:00",
+     "duration": 0.001687,
+     "end_time": "2026-09-02T16:49:53.706234+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:59.671599+00:00",
+     "start_time": "2026-09-02T16:49:53.704547+00:00",
      "status": "completed"
     }
    },
@@ -594,19 +596,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "d9a6e87d",
+   "id": "f5d799ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:01:59.675935Z",
-     "iopub.status.busy": "2026-09-02T16:01:59.675838Z",
-     "iopub.status.idle": "2026-09-02T16:02:00.694589Z",
-     "shell.execute_reply": "2026-09-02T16:02:00.694107Z"
+     "iopub.execute_input": "2026-09-02T16:49:53.709828Z",
+     "iopub.status.busy": "2026-09-02T16:49:53.709716Z",
+     "iopub.status.idle": "2026-09-02T16:49:55.299009Z",
+     "shell.execute_reply": "2026-09-02T16:49:55.298608Z"
     },
     "papermill": {
-     "duration": 1.020688,
-     "end_time": "2026-09-02T16:02:00.694957+00:00",
+     "duration": 1.591686,
+     "end_time": "2026-09-02T16:49:55.299321+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:01:59.674269+00:00",
+     "start_time": "2026-09-02T16:49:53.707635+00:00",
      "status": "completed"
     }
    },
@@ -637,13 +639,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61214ba2",
+   "id": "360cba58",
    "metadata": {
     "papermill": {
-     "duration": 0.001238,
-     "end_time": "2026-09-02T16:02:00.697719+00:00",
+     "duration": 0.00128,
+     "end_time": "2026-09-02T16:49:55.302074+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:00.696481+00:00",
+     "start_time": "2026-09-02T16:49:55.300794+00:00",
      "status": "completed"
     }
    },
@@ -683,13 +685,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c5f753a",
+   "id": "54477048",
    "metadata": {
     "papermill": {
-     "duration": 0.001183,
-     "end_time": "2026-09-02T16:02:00.700163+00:00",
+     "duration": 0.001159,
+     "end_time": "2026-09-02T16:49:55.304527+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:00.698980+00:00",
+     "start_time": "2026-09-02T16:49:55.303368+00:00",
      "status": "completed"
     }
    },
@@ -745,19 +747,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1cfe72ec",
+   "id": "b162cb1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:02:00.703218Z",
-     "iopub.status.busy": "2026-09-02T16:02:00.703130Z",
-     "iopub.status.idle": "2026-09-02T16:02:00.711865Z",
-     "shell.execute_reply": "2026-09-02T16:02:00.711379Z"
+     "iopub.execute_input": "2026-09-02T16:49:55.307700Z",
+     "iopub.status.busy": "2026-09-02T16:49:55.307621Z",
+     "iopub.status.idle": "2026-09-02T16:49:55.313650Z",
+     "shell.execute_reply": "2026-09-02T16:49:55.313311Z"
     },
     "papermill": {
-     "duration": 0.010936,
-     "end_time": "2026-09-02T16:02:00.712363+00:00",
+     "duration": 0.008165,
+     "end_time": "2026-09-02T16:49:55.313944+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:00.701427+00:00",
+     "start_time": "2026-09-02T16:49:55.305779+00:00",
      "status": "completed"
     },
     "tags": [
@@ -879,13 +881,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db999073",
+   "id": "b2731902",
    "metadata": {
     "papermill": {
-     "duration": 0.001412,
-     "end_time": "2026-09-02T16:02:00.715332+00:00",
+     "duration": 0.001298,
+     "end_time": "2026-09-02T16:49:55.316674+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:00.713920+00:00",
+     "start_time": "2026-09-02T16:49:55.315376+00:00",
      "status": "completed"
     }
    },
@@ -901,19 +903,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "928dabc3",
+   "id": "47ba113b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:02:00.718691Z",
-     "iopub.status.busy": "2026-09-02T16:02:00.718593Z",
-     "iopub.status.idle": "2026-09-02T16:02:00.723130Z",
-     "shell.execute_reply": "2026-09-02T16:02:00.722857Z"
+     "iopub.execute_input": "2026-09-02T16:49:55.320222Z",
+     "iopub.status.busy": "2026-09-02T16:49:55.320139Z",
+     "iopub.status.idle": "2026-09-02T16:49:55.323490Z",
+     "shell.execute_reply": "2026-09-02T16:49:55.323131Z"
     },
     "papermill": {
-     "duration": 0.006799,
-     "end_time": "2026-09-02T16:02:00.723519+00:00",
+     "duration": 0.005782,
+     "end_time": "2026-09-02T16:49:55.323874+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:00.716720+00:00",
+     "start_time": "2026-09-02T16:49:55.318092+00:00",
      "status": "completed"
     },
     "tags": [
@@ -974,14 +976,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "961096e1",
+   "id": "ebdbec3c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001377,
-     "end_time": "2026-09-02T16:02:00.726394+00:00",
+     "duration": 0.001417,
+     "end_time": "2026-09-02T16:49:55.327007+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:00.725017+00:00",
+     "start_time": "2026-09-02T16:49:55.325590+00:00",
      "status": "completed"
     }
    },
@@ -1010,19 +1012,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "c0e11c8c",
+   "id": "3b60df52",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:02:00.729724Z",
-     "iopub.status.busy": "2026-09-02T16:02:00.729639Z",
-     "iopub.status.idle": "2026-09-02T16:02:02.128181Z",
-     "shell.execute_reply": "2026-09-02T16:02:02.127740Z"
+     "iopub.execute_input": "2026-09-02T16:49:55.330250Z",
+     "iopub.status.busy": "2026-09-02T16:49:55.330177Z",
+     "iopub.status.idle": "2026-09-02T16:49:56.776694Z",
+     "shell.execute_reply": "2026-09-02T16:49:56.775013Z"
     },
     "papermill": {
-     "duration": 1.400695,
-     "end_time": "2026-09-02T16:02:02.128492+00:00",
+     "duration": 1.450132,
+     "end_time": "2026-09-02T16:49:56.778501+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:00.727797+00:00",
+     "start_time": "2026-09-02T16:49:55.328369+00:00",
      "status": "completed"
     }
    },
@@ -1722,13 +1724,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "622cbc7c",
+   "id": "197276a2",
    "metadata": {
     "papermill": {
-     "duration": 0.002115,
-     "end_time": "2026-09-02T16:02:02.133003+00:00",
+     "duration": 0.003198,
+     "end_time": "2026-09-02T16:49:56.787132+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:02.130888+00:00",
+     "start_time": "2026-09-02T16:49:56.783934+00:00",
      "status": "completed"
     }
    },
@@ -1746,19 +1748,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "3433332f",
+   "id": "5ecd3dcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:02:02.137830Z",
-     "iopub.status.busy": "2026-09-02T16:02:02.137743Z",
-     "iopub.status.idle": "2026-09-02T16:02:02.183727Z",
-     "shell.execute_reply": "2026-09-02T16:02:02.183200Z"
+     "iopub.execute_input": "2026-09-02T16:49:56.798388Z",
+     "iopub.status.busy": "2026-09-02T16:49:56.798161Z",
+     "iopub.status.idle": "2026-09-02T16:49:56.849784Z",
+     "shell.execute_reply": "2026-09-02T16:49:56.849409Z"
     },
     "papermill": {
-     "duration": 0.048898,
-     "end_time": "2026-09-02T16:02:02.184049+00:00",
+     "duration": 0.057428,
+     "end_time": "2026-09-02T16:49:56.850049+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:02.135151+00:00",
+     "start_time": "2026-09-02T16:49:56.792621+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1880,19 +1882,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "bfc98de7",
+   "id": "533d5687",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T16:02:02.189858Z",
-     "iopub.status.busy": "2026-09-02T16:02:02.189703Z",
-     "iopub.status.idle": "2026-09-02T16:02:03.608506Z",
-     "shell.execute_reply": "2026-09-02T16:02:03.608023Z"
+     "iopub.execute_input": "2026-09-02T16:49:56.855524Z",
+     "iopub.status.busy": "2026-09-02T16:49:56.855439Z",
+     "iopub.status.idle": "2026-09-02T16:49:58.284661Z",
+     "shell.execute_reply": "2026-09-02T16:49:58.283422Z"
     },
     "papermill": {
-     "duration": 1.422127,
-     "end_time": "2026-09-02T16:02:03.608813+00:00",
+     "duration": 1.434016,
+     "end_time": "2026-09-02T16:49:58.286589+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:02.186686+00:00",
+     "start_time": "2026-09-02T16:49:56.852573+00:00",
      "status": "completed"
     }
    },
@@ -2199,13 +2201,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d3463b4",
+   "id": "4f2af408",
    "metadata": {
     "papermill": {
-     "duration": 0.002631,
-     "end_time": "2026-09-02T16:02:03.614540+00:00",
+     "duration": 0.005126,
+     "end_time": "2026-09-02T16:49:58.310027+00:00",
      "exception": false,
-     "start_time": "2026-09-02T16:02:03.611909+00:00",
+     "start_time": "2026-09-02T16:49:58.304901+00:00",
      "status": "completed"
     }
    },
@@ -2325,23 +2327,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-02T16:02:11.233817+00:00",
+   "executed_at": "2026-09-02T16:50:04.892745+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "62ceab73b8b02826d38c255f74fc56e8f4ba92f7",
-   "notes": "prose synced from the .py at 2026-09-02T16:07:41.775862+00:00 without re-executing; every code cell is identical to blob 5eef518e0e9b"
+   "source_py_blob": "57626ed77a6161a5102062c7191d918ab233b0d7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 12.79682,
-   "end_time": "2026-09-02T16:02:05.134295+00:00",
+   "duration": 13.365125,
+   "end_time": "2026-09-02T16:49:59.738276+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "~/ml4t/public/case_studies/crypto_perps_funding/06_linear.ipynb",
-   "output_path": "~/ml4t/public/case_studies/crypto_perps_funding/.06_linear.papermill.3971473.ipynb",
+   "output_path": "~/ml4t/public/case_studies/crypto_perps_funding/.06_linear.papermill.4099455.ipynb",
    "parameters": {},
-   "start_time": "2026-09-02T16:01:52.337475+00:00",
+   "start_time": "2026-09-02T16:49:46.373151+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/crypto_perps_funding/06_linear.py
+++ b/case_studies/crypto_perps_funding/06_linear.py
@@ -84,6 +84,7 @@ from case_studies.research import (
     declared_labels,
     load_model_configs,
     model_requests,
+    narrows_declared_catalog,
     open_study,
     primary_label,
     resolved_model_plan,
@@ -173,10 +174,11 @@ configs
 # either knob, and says so here rather than several cells later in a message about hashes.
 
 # %%
-if configs.height < load_model_configs(study, "linear").height and not POPULATION_NAME:
+if narrows_declared_catalog(study, "linear", configs) and not POPULATION_NAME:
     raise ValueError(
-        f"this run fits {configs.height} of the declared configurations, so it cannot publish "
-        "the canonical population; pass POPULATION_NAME to give it its own"
+        f"this run declares {configs.height} label-configuration pairs, which is not the "
+        "complete declared catalog, so it cannot publish the canonical population; pass "
+        "POPULATION_NAME to give it its own"
     )
 
 # %% [markdown]

--- a/case_studies/crypto_perps_funding/07_gbm.ipynb
+++ b/case_studies/crypto_perps_funding/07_gbm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "34b7b82a",
+   "id": "6b8cab07",
    "metadata": {
     "papermill": {
-     "duration": 0.001812,
-     "end_time": "2026-08-30T19:54:00.528291+00:00",
+     "duration": 0.011429,
+     "end_time": "2026-09-02T16:50:07.366887+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:00.526479+00:00",
+     "start_time": "2026-09-02T16:50:07.355458+00:00",
      "status": "completed"
     }
    },
@@ -76,19 +76,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b13e2902",
+   "id": "b070a6a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:54:00.531997Z",
-     "iopub.status.busy": "2026-08-30T19:54:00.531884Z",
-     "iopub.status.idle": "2026-08-30T19:54:03.123240Z",
-     "shell.execute_reply": "2026-08-30T19:54:03.122816Z"
+     "iopub.execute_input": "2026-09-02T16:50:07.381749Z",
+     "iopub.status.busy": "2026-09-02T16:50:07.381506Z",
+     "iopub.status.idle": "2026-09-02T16:50:09.596915Z",
+     "shell.execute_reply": "2026-09-02T16:50:09.596296Z"
     },
     "papermill": {
-     "duration": 2.594336,
-     "end_time": "2026-08-30T19:54:03.124056+00:00",
+     "duration": 2.222807,
+     "end_time": "2026-09-02T16:50:09.597975+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:00.529720+00:00",
+     "start_time": "2026-09-02T16:50:07.375168+00:00",
      "status": "completed"
     }
    },
@@ -105,6 +105,7 @@
     "    declared_labels,\n",
     "    load_model_configs,\n",
     "    model_requests,\n",
+    "    narrows_declared_catalog,\n",
     "    open_study,\n",
     "    primary_label,\n",
     "    resolved_model_plan,\n",
@@ -117,19 +118,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "7a004eef",
+   "id": "b57f5b63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:54:03.128500Z",
-     "iopub.status.busy": "2026-08-30T19:54:03.128334Z",
-     "iopub.status.idle": "2026-08-30T19:54:03.130671Z",
-     "shell.execute_reply": "2026-08-30T19:54:03.130316Z"
+     "iopub.execute_input": "2026-09-02T16:50:09.603282Z",
+     "iopub.status.busy": "2026-09-02T16:50:09.603109Z",
+     "iopub.status.idle": "2026-09-02T16:50:09.605347Z",
+     "shell.execute_reply": "2026-09-02T16:50:09.605087Z"
     },
     "papermill": {
-     "duration": 0.004724,
-     "end_time": "2026-08-30T19:54:03.130892+00:00",
+     "duration": 0.005309,
+     "end_time": "2026-09-02T16:50:09.605788+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.126168+00:00",
+     "start_time": "2026-09-02T16:50:09.600479+00:00",
      "status": "completed"
     },
     "tags": [
@@ -163,19 +164,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "782516b8",
+   "id": "f9ca49fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:54:03.133925Z",
-     "iopub.status.busy": "2026-08-30T19:54:03.133858Z",
-     "iopub.status.idle": "2026-08-30T19:54:03.664712Z",
-     "shell.execute_reply": "2026-08-30T19:54:03.664274Z"
+     "iopub.execute_input": "2026-09-02T16:50:09.610561Z",
+     "iopub.status.busy": "2026-09-02T16:50:09.610489Z",
+     "iopub.status.idle": "2026-09-02T16:50:09.746839Z",
+     "shell.execute_reply": "2026-09-02T16:50:09.746207Z"
     },
     "papermill": {
-     "duration": 0.533073,
-     "end_time": "2026-08-30T19:54:03.665313+00:00",
+     "duration": 0.139903,
+     "end_time": "2026-09-02T16:50:09.747939+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.132240+00:00",
+     "start_time": "2026-09-02T16:50:09.608036+00:00",
      "status": "completed"
     }
    },
@@ -188,13 +189,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0eedbb08",
+   "id": "9ce6c089",
    "metadata": {
     "papermill": {
-     "duration": 0.001227,
-     "end_time": "2026-08-30T19:54:03.668008+00:00",
+     "duration": 0.002792,
+     "end_time": "2026-09-02T16:50:09.754302+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.666781+00:00",
+     "start_time": "2026-09-02T16:50:09.751510+00:00",
      "status": "completed"
     }
    },
@@ -211,19 +212,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7ddf89c4",
+   "id": "3503a4f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:54:03.670930Z",
-     "iopub.status.busy": "2026-08-30T19:54:03.670845Z",
-     "iopub.status.idle": "2026-08-30T19:54:03.685160Z",
-     "shell.execute_reply": "2026-08-30T19:54:03.684781Z"
+     "iopub.execute_input": "2026-09-02T16:50:09.759183Z",
+     "iopub.status.busy": "2026-09-02T16:50:09.758992Z",
+     "iopub.status.idle": "2026-09-02T16:50:09.777007Z",
+     "shell.execute_reply": "2026-09-02T16:50:09.776616Z"
     },
     "papermill": {
-     "duration": 0.016259,
-     "end_time": "2026-08-30T19:54:03.685484+00:00",
+     "duration": 0.020613,
+     "end_time": "2026-09-02T16:50:09.777495+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.669225+00:00",
+     "start_time": "2026-09-02T16:50:09.756882+00:00",
      "status": "completed"
     }
    },
@@ -245,13 +246,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4b586a5",
+   "id": "9a392ab6",
    "metadata": {
     "papermill": {
-     "duration": 0.001221,
-     "end_time": "2026-08-30T19:54:03.688121+00:00",
+     "duration": 0.001257,
+     "end_time": "2026-09-02T16:50:09.780229+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.686900+00:00",
+     "start_time": "2026-09-02T16:50:09.778972+00:00",
      "status": "completed"
     }
    },
@@ -277,19 +278,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "00217931",
+   "id": "5444b856",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:54:03.691386Z",
-     "iopub.status.busy": "2026-08-30T19:54:03.691304Z",
-     "iopub.status.idle": "2026-08-30T19:54:03.727946Z",
-     "shell.execute_reply": "2026-08-30T19:54:03.727582Z"
+     "iopub.execute_input": "2026-09-02T16:50:09.783439Z",
+     "iopub.status.busy": "2026-09-02T16:50:09.783349Z",
+     "iopub.status.idle": "2026-09-02T16:50:09.818952Z",
+     "shell.execute_reply": "2026-09-02T16:50:09.818578Z"
     },
     "papermill": {
-     "duration": 0.038628,
-     "end_time": "2026-08-30T19:54:03.728202+00:00",
+     "duration": 0.037831,
+     "end_time": "2026-09-02T16:50:09.819393+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.689574+00:00",
+     "start_time": "2026-09-02T16:50:09.781562+00:00",
      "status": "completed"
     }
    },
@@ -344,13 +345,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2552af4",
+   "id": "f62023d0",
    "metadata": {
     "papermill": {
-     "duration": 0.001354,
-     "end_time": "2026-08-30T19:54:03.731098+00:00",
+     "duration": 0.001394,
+     "end_time": "2026-09-02T16:50:09.822418+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.729744+00:00",
+     "start_time": "2026-09-02T16:50:09.821024+00:00",
      "status": "completed"
     }
    },
@@ -366,40 +367,41 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "516a61bb",
+   "id": "c3667867",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:54:03.734319Z",
-     "iopub.status.busy": "2026-08-30T19:54:03.734234Z",
-     "iopub.status.idle": "2026-08-30T19:54:03.765144Z",
-     "shell.execute_reply": "2026-08-30T19:54:03.764662Z"
+     "iopub.execute_input": "2026-09-02T16:50:09.825758Z",
+     "iopub.status.busy": "2026-09-02T16:50:09.825664Z",
+     "iopub.status.idle": "2026-09-02T16:50:09.858778Z",
+     "shell.execute_reply": "2026-09-02T16:50:09.858379Z"
     },
     "papermill": {
-     "duration": 0.033134,
-     "end_time": "2026-08-30T19:54:03.765560+00:00",
+     "duration": 0.035654,
+     "end_time": "2026-09-02T16:50:09.859462+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.732426+00:00",
+     "start_time": "2026-09-02T16:50:09.823808+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "if configs.height < load_model_configs(study, \"gbm\").height and not POPULATION_NAME:\n",
+    "if narrows_declared_catalog(study, \"gbm\", configs) and not POPULATION_NAME:\n",
     "    raise ValueError(\n",
-    "        f\"this run fits {configs.height} of the declared configurations, so it cannot publish \"\n",
-    "        \"the canonical population; pass POPULATION_NAME to give it its own\"\n",
+    "        f\"this run declares {configs.height} label-configuration pairs, which is not the \"\n",
+    "        \"complete declared catalog, so it cannot publish the canonical population; pass \"\n",
+    "        \"POPULATION_NAME to give it its own\"\n",
     "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1936746a",
+   "id": "4dcb25a5",
    "metadata": {
     "papermill": {
-     "duration": 0.001356,
-     "end_time": "2026-08-30T19:54:03.768528+00:00",
+     "duration": 0.001365,
+     "end_time": "2026-09-02T16:50:09.862481+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.767172+00:00",
+     "start_time": "2026-09-02T16:50:09.861116+00:00",
      "status": "completed"
     }
    },
@@ -426,19 +428,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "2bb04644",
+   "id": "e30545af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:54:03.771887Z",
-     "iopub.status.busy": "2026-08-30T19:54:03.771806Z",
-     "iopub.status.idle": "2026-08-30T19:54:13.858699Z",
-     "shell.execute_reply": "2026-08-30T19:54:13.858311Z"
+     "iopub.execute_input": "2026-09-02T16:50:09.865826Z",
+     "iopub.status.busy": "2026-09-02T16:50:09.865685Z",
+     "iopub.status.idle": "2026-09-02T16:50:19.817613Z",
+     "shell.execute_reply": "2026-09-02T16:50:19.817071Z"
     },
     "papermill": {
-     "duration": 10.08909,
-     "end_time": "2026-08-30T19:54:13.859000+00:00",
+     "duration": 9.954206,
+     "end_time": "2026-09-02T16:50:19.818072+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:03.769910+00:00",
+     "start_time": "2026-09-02T16:50:09.863866+00:00",
      "status": "completed"
     }
    },
@@ -527,13 +529,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5c98dab",
+   "id": "4ce00183",
    "metadata": {
     "papermill": {
-     "duration": 0.001406,
-     "end_time": "2026-08-30T19:54:13.862052+00:00",
+     "duration": 0.001933,
+     "end_time": "2026-09-02T16:50:19.822224+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:13.860646+00:00",
+     "start_time": "2026-09-02T16:50:19.820291+00:00",
      "status": "completed"
     }
    },
@@ -582,415 +584,23 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "1779348d",
+   "id": "33501340",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:54:13.865604Z",
-     "iopub.status.busy": "2026-08-30T19:54:13.865422Z",
-     "iopub.status.idle": "2026-08-30T19:58:31.912775Z",
-     "shell.execute_reply": "2026-08-30T19:58:31.909379Z"
+     "iopub.execute_input": "2026-09-02T16:50:19.825643Z",
+     "iopub.status.busy": "2026-09-02T16:50:19.825549Z",
+     "iopub.status.idle": "2026-09-02T16:50:24.155420Z",
+     "shell.execute_reply": "2026-09-02T16:50:24.154849Z"
     },
     "papermill": {
-     "duration": 258.050013,
-     "end_time": "2026-08-30T19:58:31.913475+00:00",
+     "duration": 4.332074,
+     "end_time": "2026-09-02T16:50:24.155741+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:54:13.863462+00:00",
+     "start_time": "2026-09-02T16:50:19.823667+00:00",
      "status": "completed"
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 0s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 0s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 0s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 0s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 0s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=31,402 n_val=18,542 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 11s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=23,681 n_val=16,738 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 9s\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1027,13 +637,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "708f0f59",
+   "id": "3f0ca46a",
    "metadata": {
     "papermill": {
-     "duration": 0.005288,
-     "end_time": "2026-08-30T19:58:31.924306+00:00",
+     "duration": 0.001454,
+     "end_time": "2026-09-02T16:50:24.159008+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:31.919018+00:00",
+     "start_time": "2026-09-02T16:50:24.157554+00:00",
      "status": "completed"
     }
    },
@@ -1066,13 +676,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d346e4c5",
+   "id": "bff7e499",
    "metadata": {
     "papermill": {
-     "duration": 0.003882,
-     "end_time": "2026-08-30T19:58:31.933785+00:00",
+     "duration": 0.001375,
+     "end_time": "2026-09-02T16:50:24.161862+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:31.929903+00:00",
+     "start_time": "2026-09-02T16:50:24.160487+00:00",
      "status": "completed"
     }
    },
@@ -1121,19 +731,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "369beb65",
+   "id": "5655cce2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:58:31.942166Z",
-     "iopub.status.busy": "2026-08-30T19:58:31.941981Z",
-     "iopub.status.idle": "2026-08-30T19:58:31.983931Z",
-     "shell.execute_reply": "2026-08-30T19:58:31.983434Z"
+     "iopub.execute_input": "2026-09-02T16:50:24.165186Z",
+     "iopub.status.busy": "2026-09-02T16:50:24.165103Z",
+     "iopub.status.idle": "2026-09-02T16:50:24.181208Z",
+     "shell.execute_reply": "2026-09-02T16:50:24.180753Z"
     },
     "papermill": {
-     "duration": 0.047502,
-     "end_time": "2026-08-30T19:58:31.984965+00:00",
+     "duration": 0.018351,
+     "end_time": "2026-09-02T16:50:24.181641+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:31.937463+00:00",
+     "start_time": "2026-09-02T16:50:24.163290+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1251,13 +861,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a2bcd0e",
+   "id": "8606ebaf",
    "metadata": {
     "papermill": {
-     "duration": 0.004995,
-     "end_time": "2026-08-30T19:58:31.998343+00:00",
+     "duration": 0.001504,
+     "end_time": "2026-09-02T16:50:24.184829+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:31.993348+00:00",
+     "start_time": "2026-09-02T16:50:24.183325+00:00",
      "status": "completed"
     }
    },
@@ -1278,19 +888,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "3c8a90ad",
+   "id": "347617da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:58:32.009159Z",
-     "iopub.status.busy": "2026-08-30T19:58:32.008965Z",
-     "iopub.status.idle": "2026-08-30T19:58:34.629204Z",
-     "shell.execute_reply": "2026-08-30T19:58:34.628452Z"
+     "iopub.execute_input": "2026-09-02T16:50:24.189083Z",
+     "iopub.status.busy": "2026-09-02T16:50:24.188967Z",
+     "iopub.status.idle": "2026-09-02T16:50:25.634776Z",
+     "shell.execute_reply": "2026-09-02T16:50:25.634290Z"
     },
     "papermill": {
-     "duration": 2.626841,
-     "end_time": "2026-08-30T19:58:34.630080+00:00",
+     "duration": 1.450149,
+     "end_time": "2026-09-02T16:50:25.636617+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:32.003239+00:00",
+     "start_time": "2026-09-02T16:50:24.186468+00:00",
      "status": "completed"
     }
    },
@@ -3197,13 +2807,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb436a3d",
+   "id": "b9bbde1a",
    "metadata": {
     "papermill": {
-     "duration": 0.012901,
-     "end_time": "2026-08-30T19:58:34.660228+00:00",
+     "duration": 0.004152,
+     "end_time": "2026-09-02T16:50:25.648162+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:34.647327+00:00",
+     "start_time": "2026-09-02T16:50:25.644010+00:00",
      "status": "completed"
     }
    },
@@ -3219,19 +2829,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "8369ee03",
+   "id": "ef02df4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:58:34.685740Z",
-     "iopub.status.busy": "2026-08-30T19:58:34.685592Z",
-     "iopub.status.idle": "2026-08-30T19:58:34.693961Z",
-     "shell.execute_reply": "2026-08-30T19:58:34.693532Z"
+     "iopub.execute_input": "2026-09-02T16:50:25.656045Z",
+     "iopub.status.busy": "2026-09-02T16:50:25.655941Z",
+     "iopub.status.idle": "2026-09-02T16:50:25.661252Z",
+     "shell.execute_reply": "2026-09-02T16:50:25.660838Z"
     },
     "papermill": {
-     "duration": 0.022228,
-     "end_time": "2026-08-30T19:58:34.694445+00:00",
+     "duration": 0.00968,
+     "end_time": "2026-09-02T16:50:25.661495+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:34.672217+00:00",
+     "start_time": "2026-09-02T16:50:25.651815+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3304,13 +2914,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d38a939",
+   "id": "68a5a387",
    "metadata": {
     "papermill": {
-     "duration": 0.010359,
-     "end_time": "2026-08-30T19:58:34.715765+00:00",
+     "duration": 0.003423,
+     "end_time": "2026-09-02T16:50:25.668656+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:34.705406+00:00",
+     "start_time": "2026-09-02T16:50:25.665233+00:00",
      "status": "completed"
     }
    },
@@ -3330,19 +2940,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "1a76c697",
+   "id": "b52b9098",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:58:34.737944Z",
-     "iopub.status.busy": "2026-08-30T19:58:34.737778Z",
-     "iopub.status.idle": "2026-08-30T19:58:37.102562Z",
-     "shell.execute_reply": "2026-08-30T19:58:37.099157Z"
+     "iopub.execute_input": "2026-09-02T16:50:25.676437Z",
+     "iopub.status.busy": "2026-09-02T16:50:25.676325Z",
+     "iopub.status.idle": "2026-09-02T16:50:27.094433Z",
+     "shell.execute_reply": "2026-09-02T16:50:27.092321Z"
     },
     "papermill": {
-     "duration": 2.37798,
-     "end_time": "2026-08-30T19:58:37.104562+00:00",
+     "duration": 1.425839,
+     "end_time": "2026-09-02T16:50:27.098004+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:34.726582+00:00",
+     "start_time": "2026-09-02T16:50:25.672165+00:00",
      "status": "completed"
     }
    },
@@ -3897,13 +3507,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b6a8601",
+   "id": "e2c39d7d",
    "metadata": {
     "papermill": {
-     "duration": 0.011319,
-     "end_time": "2026-08-30T19:58:37.134679+00:00",
+     "duration": 0.004605,
+     "end_time": "2026-09-02T16:50:27.117624+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:37.123360+00:00",
+     "start_time": "2026-09-02T16:50:27.113019+00:00",
      "status": "completed"
     }
    },
@@ -3917,19 +3527,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "fd2f45c2",
+   "id": "dacd0064",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:58:37.162904Z",
-     "iopub.status.busy": "2026-08-30T19:58:37.162743Z",
-     "iopub.status.idle": "2026-08-30T19:58:37.168823Z",
-     "shell.execute_reply": "2026-08-30T19:58:37.168201Z"
+     "iopub.execute_input": "2026-09-02T16:50:27.130036Z",
+     "iopub.status.busy": "2026-09-02T16:50:27.129922Z",
+     "iopub.status.idle": "2026-09-02T16:50:27.133935Z",
+     "shell.execute_reply": "2026-09-02T16:50:27.133425Z"
     },
     "papermill": {
-     "duration": 0.020877,
-     "end_time": "2026-08-30T19:58:37.169583+00:00",
+     "duration": 0.011587,
+     "end_time": "2026-09-02T16:50:27.134217+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:37.148706+00:00",
+     "start_time": "2026-09-02T16:50:27.122630+00:00",
      "status": "completed"
     },
     "tags": [
@@ -3988,13 +3598,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94590a47",
+   "id": "63c0e337",
    "metadata": {
     "papermill": {
-     "duration": 0.011227,
-     "end_time": "2026-08-30T19:58:37.192731+00:00",
+     "duration": 0.004233,
+     "end_time": "2026-09-02T16:50:27.142908+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:37.181504+00:00",
+     "start_time": "2026-09-02T16:50:27.138675+00:00",
      "status": "completed"
     }
    },
@@ -4021,19 +3631,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "254b6d51",
+   "id": "833df323",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:58:37.215957Z",
-     "iopub.status.busy": "2026-08-30T19:58:37.215571Z",
-     "iopub.status.idle": "2026-08-30T19:58:37.221116Z",
-     "shell.execute_reply": "2026-08-30T19:58:37.220530Z"
+     "iopub.execute_input": "2026-09-02T16:50:27.152848Z",
+     "iopub.status.busy": "2026-09-02T16:50:27.152684Z",
+     "iopub.status.idle": "2026-09-02T16:50:27.156527Z",
+     "shell.execute_reply": "2026-09-02T16:50:27.156192Z"
     },
     "papermill": {
-     "duration": 0.017785,
-     "end_time": "2026-08-30T19:58:37.221553+00:00",
+     "duration": 0.009437,
+     "end_time": "2026-09-02T16:50:27.156998+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:37.203768+00:00",
+     "start_time": "2026-09-02T16:50:27.147561+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4090,19 +3700,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "8207c7e6",
+   "id": "75220fe7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:58:37.254703Z",
-     "iopub.status.busy": "2026-08-30T19:58:37.254023Z",
-     "iopub.status.idle": "2026-08-30T19:58:37.448926Z",
-     "shell.execute_reply": "2026-08-30T19:58:37.447936Z"
+     "iopub.execute_input": "2026-09-02T16:50:27.169007Z",
+     "iopub.status.busy": "2026-09-02T16:50:27.168833Z",
+     "iopub.status.idle": "2026-09-02T16:50:27.274260Z",
+     "shell.execute_reply": "2026-09-02T16:50:27.273022Z"
     },
     "papermill": {
-     "duration": 0.210144,
-     "end_time": "2026-08-30T19:58:37.449508+00:00",
+     "duration": 0.113129,
+     "end_time": "2026-09-02T16:50:27.275278+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:37.239364+00:00",
+     "start_time": "2026-09-02T16:50:27.162149+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4168,13 +3778,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5ed5d9d",
+   "id": "5c973ef6",
    "metadata": {
     "papermill": {
-     "duration": 0.010405,
-     "end_time": "2026-08-30T19:58:37.472148+00:00",
+     "duration": 0.005157,
+     "end_time": "2026-09-02T16:50:27.292351+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:37.461743+00:00",
+     "start_time": "2026-09-02T16:50:27.287194+00:00",
      "status": "completed"
     }
    },
@@ -4196,19 +3806,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "13613380",
+   "id": "c6dff44d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:58:37.495748Z",
-     "iopub.status.busy": "2026-08-30T19:58:37.495584Z",
-     "iopub.status.idle": "2026-08-30T19:58:37.503806Z",
-     "shell.execute_reply": "2026-08-30T19:58:37.503012Z"
+     "iopub.execute_input": "2026-09-02T16:50:27.302047Z",
+     "iopub.status.busy": "2026-09-02T16:50:27.301934Z",
+     "iopub.status.idle": "2026-09-02T16:50:27.307327Z",
+     "shell.execute_reply": "2026-09-02T16:50:27.306820Z"
     },
     "papermill": {
-     "duration": 0.020406,
-     "end_time": "2026-08-30T19:58:37.504239+00:00",
+     "duration": 0.010798,
+     "end_time": "2026-09-02T16:50:27.307594+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:37.483833+00:00",
+     "start_time": "2026-09-02T16:50:27.296796+00:00",
      "status": "completed"
     }
    },
@@ -4271,19 +3881,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "9d2cf6a8",
+   "id": "99f05533",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T19:58:37.533138Z",
-     "iopub.status.busy": "2026-08-30T19:58:37.532799Z",
-     "iopub.status.idle": "2026-08-30T19:58:37.539079Z",
-     "shell.execute_reply": "2026-08-30T19:58:37.538363Z"
+     "iopub.execute_input": "2026-09-02T16:50:27.317384Z",
+     "iopub.status.busy": "2026-09-02T16:50:27.317265Z",
+     "iopub.status.idle": "2026-09-02T16:50:27.320672Z",
+     "shell.execute_reply": "2026-09-02T16:50:27.320362Z"
     },
     "papermill": {
-     "duration": 0.021619,
-     "end_time": "2026-08-30T19:58:37.539522+00:00",
+     "duration": 0.008717,
+     "end_time": "2026-09-02T16:50:27.320958+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:37.517903+00:00",
+     "start_time": "2026-09-02T16:50:27.312241+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4335,13 +3945,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42f1ea89",
+   "id": "38702aa4",
    "metadata": {
     "papermill": {
-     "duration": 0.010825,
-     "end_time": "2026-08-30T19:58:37.561683+00:00",
+     "duration": 0.004384,
+     "end_time": "2026-09-02T16:50:27.329717+00:00",
      "exception": false,
-     "start_time": "2026-08-30T19:58:37.550858+00:00",
+     "start_time": "2026-09-02T16:50:27.325333+00:00",
      "status": "completed"
     }
    },
@@ -4447,22 +4057,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-08-30T19:58:53.172828+00:00",
+   "executed_at": "2026-09-02T16:50:35.063245+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "f66b19d98a96fd95b813483bb718eae860471cb2"
+   "source_py_blob": "517983cdd1706b7faa6153b296f02a1c95ca4695"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 280.268532,
-   "end_time": "2026-08-30T19:58:40.104521+00:00",
+   "duration": 23.150207,
+   "end_time": "2026-09-02T16:50:29.835889+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-crypto_perps_funding-bt/case_studies/crypto_perps_funding/07_gbm.ipynb",
-   "output_path": "~/ml4t/public-s6-crypto_perps_funding-bt/case_studies/crypto_perps_funding/.07_gbm.papermill.2293428.ipynb",
+   "input_path": "~/ml4t/public/case_studies/crypto_perps_funding/07_gbm.ipynb",
+   "output_path": "~/ml4t/public/case_studies/crypto_perps_funding/.07_gbm.papermill.4100810.ipynb",
    "parameters": {},
-   "start_time": "2026-08-30T19:53:59.835989+00:00",
+   "start_time": "2026-09-02T16:50:06.685682+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/crypto_perps_funding/07_gbm.py
+++ b/case_studies/crypto_perps_funding/07_gbm.py
@@ -85,6 +85,7 @@ from case_studies.research import (
     declared_labels,
     load_model_configs,
     model_requests,
+    narrows_declared_catalog,
     open_study,
     primary_label,
     resolved_model_plan,
@@ -168,10 +169,11 @@ configs
 # either knob, and says so here rather than several cells later in a message about hashes.
 
 # %%
-if configs.height < load_model_configs(study, "gbm").height and not POPULATION_NAME:
+if narrows_declared_catalog(study, "gbm", configs) and not POPULATION_NAME:
     raise ValueError(
-        f"this run fits {configs.height} of the declared configurations, so it cannot publish "
-        "the canonical population; pass POPULATION_NAME to give it its own"
+        f"this run declares {configs.height} label-configuration pairs, which is not the "
+        "complete declared catalog, so it cannot publish the canonical population; pass "
+        "POPULATION_NAME to give it its own"
     )
 
 # %% [markdown]


### PR DESCRIPTION
`06_linear` and `07_gbm` compared `configs.height` against `load_model_configs(...).height`. That is a count, so it passes a run that fits the right *number* of the wrong label-configuration pairs. `narrows_declared_catalog` compares the `(label, config_name)` set, which is what the guard means.

`fx_pairs` already uses it. `cme_futures` is now the last holder and needs its own `--case-study` worktree, so it gets a separate PR.

Both notebooks were re-executed as reuse passes: the guard is not part of a training spec, so all 139 registered configurations were reused and the registry is unchanged (population `398c52b935f3` intact).

The error message also stopped describing a count: it now names label-configuration pairs, matching what is compared and matching fx's wording.