### PR TITLE
sweep_config: a long-short top_k above half the panel is not feasible

### DIFF
--- a/case_studies/utils/sweep_config.py
+++ b/case_studies/utils/sweep_config.py
@@ -22,6 +22,8 @@ Usage:
 
 from __future__ import annotations
 
+import re
+
 import polars as pl
 import yaml
 
@@ -612,7 +614,12 @@ def get_signal_nasdaq100_schemes_for(
             for direction in directions:
                 ls = direction == "long_short"
                 for top_k in top_k_grid:
-                    if top_k >= n_assets:
+                    # `signals.py` clamps each side of a long-short selection to
+                    # `n_assets // 2`, so a k above half the panel executes with
+                    # fewer names than it registers under. Two declared k values
+                    # then collapse to the same portfolio while registering as
+                    # distinct rows. Same test as `get_entry_schemes_for`.
+                    if top_k >= n_assets or (ls and 2 * top_k > n_assets):
                         continue
                     dtag = "ls" if ls else direction[0]
                     schemes.append(
@@ -645,6 +652,20 @@ def get_signal_nasdaq100_schemes_for(
     return schemes
 
 
+def is_long_short(case_study: str) -> bool:
+    """Whether ``case_study`` builds cross-sectional long-short portfolios.
+
+    Reads the same field, by the same token rule, as
+    ``backtest_loaders.load_backtest_config``: ``mapping.position_state_space``
+    is long-short only when it names both sides, so a one-sided short state
+    (``short_straddle_hedged``) does not count.
+    """
+    setup = _load_setup(case_study)
+    space = str((setup.get("mapping") or {}).get("position_state_space", "long_only"))
+    tokens = [tok for tok in re.split(r"[^a-z0-9]+", space.strip().lower()) if tok]
+    return "long" in tokens and "short" in tokens
+
+
 def get_top_k_values_for(
     case_study: str,
     label: str,
@@ -653,7 +674,10 @@ def get_top_k_values_for(
     """Return the top-K grid for ``(case_study, label)`` used by Ch17.
 
     Filters out k >= n_assets (holding everything is the equal-weight
-    benchmark, not a prediction-based portfolio). Raises ``KeyError`` if
+    benchmark, not a prediction-based portfolio), and, for a long-short case
+    study, k above half the panel: ``signals.py`` clamps each side to
+    ``n_assets // 2``, so such a k executes with fewer names than it registers
+    under. Raises ``KeyError`` if
     ``backtest.sweep.top_k_grid[label]`` is not declared, and ``ValueError``
     when the filter empties the grid.
 
@@ -672,13 +696,23 @@ def get_top_k_values_for(
             f"backtest.sweep.top_k_grid[{label!r}] not declared in "
             f"case_studies/{case_study}/config/setup.yaml"
         )
-    values = [int(k) for k in grid if int(k) < n_assets]
+    long_short = is_long_short(case_study)
+    values = [
+        int(k) for k in grid if int(k) < n_assets and not (long_short and 2 * int(k) > n_assets)
+    ]
     if not values:
         raise ValueError(
             f"top_k_grid[{label!r}] = {list(grid)} is empty after filtering against "
-            f"n_assets={n_assets} for case_studies/{case_study}: every declared k holds "
-            f"the whole universe. Raise the universe cap (MAX_SYMBOLS) above "
-            f"{min(int(k) for k in grid)} or declare a smaller k."
+            f"n_assets={n_assets} for case_studies/{case_study}: every declared k "
+            + (
+                "needs more than half the panel a side, which a long-short "
+                f"selection cannot fill. Raise the universe above "
+                f"{2 * min(int(k) for k in grid)} or declare a smaller k."
+                if long_short
+                else "holds the whole universe. Raise the universe cap "
+                f"(MAX_SYMBOLS) above {min(int(k) for k in grid)} or declare a "
+                "smaller k."
+            )
         )
     return values
 

--- a/tests/test_sweep_config_seam.py
+++ b/tests/test_sweep_config_seam.py
@@ -320,3 +320,55 @@ def test_sweep_read_does_not_create_case_study_dir(tmp_path, monkeypatch):
     with pytest.raises((FileNotFoundError, KeyError)):
         load_sweep("etfs")  # no config seeded under tmp_path
     assert not (tmp_path / "etfs").exists()
+
+
+# ---------------------------------------------------------------------------
+# Long-short feasibility: a k above half the panel cannot be filled
+# ---------------------------------------------------------------------------
+
+
+class TestLongShortHalfPanel:
+    """`signals.py` clamps each side of a long-short selection to `n_assets // 2`.
+
+    A k above half the panel therefore executes with fewer names than the spec
+    it registers under, and two declared k values collapse to the same
+    portfolio while registering as distinct rows. The sweep helpers must not
+    offer such a k. Production universes are wide enough that none of the
+    declared grids is affected; the CI fixture is not, which is where this
+    first surfaced (nasdaq100 at 12 symbols admitted top_k=10 and realized 6
+    a side).
+    """
+
+    def test_long_short_case_study_drops_k_above_half_the_panel(self):
+        # nasdaq100 declares [5, 10, 20] and is long-short. At 12 symbols only
+        # k=5 is fillable: k=10 needs 20 names, k=20 needs 40.
+        assert get_top_k_values_for("nasdaq100_microstructure", "fwd_ret_15m", 12) == [5]
+
+    def test_long_only_case_study_keeps_k_up_to_the_whole_panel(self):
+        # etfs declares the same grid and is long-only, so half-panel does not
+        # apply and only k >= n_assets is dropped.
+        assert get_top_k_values_for("etfs", "fwd_ret_21d", 12) == [5, 10]
+
+    def test_the_empty_grid_error_names_the_long_short_cause(self):
+        with pytest.raises(ValueError, match="cannot fill"):
+            get_top_k_values_for("nasdaq100_microstructure", "fwd_ret_15m", 8)
+
+    @pytest.mark.parametrize(
+        ("case_study", "label", "n_assets"),
+        [
+            ("us_firm_characteristics", "fwd_ret_1m", 2500),
+            ("nasdaq100_microstructure", "fwd_ret_15m", 100),
+            ("fx_pairs", "fwd_ret_5d", 20),
+            ("cme_futures", "fwd_ret_5d", 30),
+            ("crypto_perps_funding", "fwd_ret_8h", 19),
+            ("us_equities_panel", "fwd_ret_5d", 2000),
+        ],
+    )
+    def test_every_offered_k_is_fillable_at_production_width(self, case_study, label, n_assets):
+        # The guard must not silently shrink a production grid: every value it
+        # still offers has to be executable as declared.
+        for k in get_top_k_values_for(case_study, label, n_assets):
+            assert 2 * k <= n_assets, (
+                f"{case_study}/{label}: top_k={k} needs {2 * k} names a side "
+                f"but the panel holds {n_assets}"
+            )


### PR DESCRIPTION
`signals.py:217` clamps each side of a long-short selection to `n_assets // 2`. A `top_k` above half the panel therefore executes with fewer names than the spec it registers under, and two declared `k` values collapse to the same portfolio while registering as distinct `backtest_runs` rows.

`get_entry_schemes_for` already had the right test (`long_short and 2 * k > n_assets`). Two siblings in the same file did not:

- `get_signal_nasdaq100_schemes_for`'s `eq_w_topk` branch tested only `top_k >= n_assets`, while setting `long_short` from its own direction axis.
- `get_top_k_values_for` tested only `k < n_assets` and had no way to know the direction. Rather than add a parameter that twelve call sites could forget, it now derives it from the case study's own `mapping.position_state_space` via a new `is_long_short()`, using the same token rule as `backtest_loaders.load_backtest_config` - so sp500_options' one-sided `short_straddle_hedged` correctly does not count.

## No production value moves and no registered row is invalidated

Verified against all nine case studies at production width; every declared grid was already feasible.

| case study | long-short | n | offered |
|---|---|---|---|
| us_firm_characteristics | yes | 2500 | 5, 10, 20, 50 |
| nasdaq100_microstructure | yes | 100 | 5, 10, 20 |
| fx_pairs | yes | 20 | 5, 10 |
| cme_futures | yes | 30 | 5, 10 |
| crypto_perps_funding | yes | 19 | 3, 5 |
| us_equities_panel | yes | 2000 | 20, 50 |
| etfs | no | 60 | 5, 10, 20 |
| sp500_equity_option_analytics | no | 200 | 5, 10, 20 |

crypto's `[3, 5]` is exactly what its registry holds, as are cme's `[5, 10]` and fx's `[5, 10]`.

The only value that moves is at CI fixture width, which is where this surfaced: nasdaq100 at 12 symbols offered `top_k=10`, executed it with six a side, and registered it as ten. It now offers `[5]`.

The empty-grid error also stopped claiming the wrong cause - for a long-short case study it now says the k needs more than half the panel a side, and names the universe size that would admit it.

## Tests

`TestLongShortHalfPanel` in `tests/test_sweep_config_seam.py`: the long-short drop, the long-only non-drop, the corrected error message, and a parametrized check that every k still offered at production width is fillable. 109 tests pass across the sweep surface.

No notebook changed, so nothing needs re-running.