### PR TITLE
Guard the canonical population on the declared catalog, not a row count

### DIFF
--- a/case_studies/cme_futures/06_linear.ipynb
+++ b/case_studies/cme_futures/06_linear.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fe5b02ed",
+   "id": "25634ad1",
    "metadata": {
     "papermill": {
-     "duration": 0.002774,
-     "end_time": "2026-08-30T20:53:43.589741+00:00",
+     "duration": 0.002682,
+     "end_time": "2026-09-02T17:35:17.912272+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:43.586967+00:00",
+     "start_time": "2026-09-02T17:35:17.909590+00:00",
      "status": "completed"
     }
    },
@@ -71,19 +71,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "7e4b8bf7",
+   "id": "436d7085",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:53:43.594970Z",
-     "iopub.status.busy": "2026-08-30T20:53:43.594791Z",
-     "iopub.status.idle": "2026-08-30T20:53:46.508061Z",
-     "shell.execute_reply": "2026-08-30T20:53:46.507516Z"
+     "iopub.execute_input": "2026-09-02T17:35:17.916992Z",
+     "iopub.status.busy": "2026-09-02T17:35:17.916878Z",
+     "iopub.status.idle": "2026-09-02T17:35:24.771717Z",
+     "shell.execute_reply": "2026-09-02T17:35:24.771323Z"
     },
     "papermill": {
-     "duration": 2.917013,
-     "end_time": "2026-08-30T20:53:46.509064+00:00",
+     "duration": 6.857636,
+     "end_time": "2026-09-02T17:35:24.772303+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:43.592051+00:00",
+     "start_time": "2026-09-02T17:35:17.914667+00:00",
      "status": "completed"
     }
    },
@@ -103,6 +103,7 @@
     "    declared_labels,\n",
     "    load_model_configs,\n",
     "    model_requests,\n",
+    "    narrows_declared_catalog,\n",
     "    open_study,\n",
     "    population_supersedes,\n",
     "    primary_label,\n",
@@ -115,19 +116,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "fdce31b3",
+   "id": "1c7df63f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:53:46.514946Z",
-     "iopub.status.busy": "2026-08-30T20:53:46.514741Z",
-     "iopub.status.idle": "2026-08-30T20:53:46.517216Z",
-     "shell.execute_reply": "2026-08-30T20:53:46.516829Z"
+     "iopub.execute_input": "2026-09-02T17:35:24.775464Z",
+     "iopub.status.busy": "2026-09-02T17:35:24.775297Z",
+     "iopub.status.idle": "2026-09-02T17:35:24.777220Z",
+     "shell.execute_reply": "2026-09-02T17:35:24.776989Z"
     },
     "papermill": {
-     "duration": 0.005899,
-     "end_time": "2026-08-30T20:53:46.517833+00:00",
+     "duration": 0.003965,
+     "end_time": "2026-09-02T17:35:24.777689+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:46.511934+00:00",
+     "start_time": "2026-09-02T17:35:24.773724+00:00",
      "status": "completed"
     },
     "tags": [
@@ -148,19 +149,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b909785b",
+   "id": "a790d5bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:53:46.523242Z",
-     "iopub.status.busy": "2026-08-30T20:53:46.523139Z",
-     "iopub.status.idle": "2026-08-30T20:53:48.280902Z",
-     "shell.execute_reply": "2026-08-30T20:53:48.280452Z"
+     "iopub.execute_input": "2026-09-02T17:35:24.782814Z",
+     "iopub.status.busy": "2026-09-02T17:35:24.782729Z",
+     "iopub.status.idle": "2026-09-02T17:35:24.812990Z",
+     "shell.execute_reply": "2026-09-02T17:35:24.812720Z"
     },
     "papermill": {
-     "duration": 1.761267,
-     "end_time": "2026-08-30T20:53:48.281455+00:00",
+     "duration": 0.0339,
+     "end_time": "2026-09-02T17:35:24.813918+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:46.520188+00:00",
+     "start_time": "2026-09-02T17:35:24.780018+00:00",
      "status": "completed"
     }
    },
@@ -171,13 +172,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3eefdc5a",
+   "id": "f1471767",
    "metadata": {
     "papermill": {
-     "duration": 0.001142,
-     "end_time": "2026-08-30T20:53:48.284188+00:00",
+     "duration": 0.001216,
+     "end_time": "2026-09-02T17:35:24.817606+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:48.283046+00:00",
+     "start_time": "2026-09-02T17:35:24.816390+00:00",
      "status": "completed"
     }
    },
@@ -207,19 +208,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "e1f20aca",
+   "id": "923db27f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:53:48.287073Z",
-     "iopub.status.busy": "2026-08-30T20:53:48.286983Z",
-     "iopub.status.idle": "2026-08-30T20:53:48.301788Z",
-     "shell.execute_reply": "2026-08-30T20:53:48.301318Z"
+     "iopub.execute_input": "2026-09-02T17:35:24.820708Z",
+     "iopub.status.busy": "2026-09-02T17:35:24.820604Z",
+     "iopub.status.idle": "2026-09-02T17:35:24.834981Z",
+     "shell.execute_reply": "2026-09-02T17:35:24.834692Z"
     },
     "papermill": {
-     "duration": 0.016844,
-     "end_time": "2026-08-30T20:53:48.302190+00:00",
+     "duration": 0.016625,
+     "end_time": "2026-09-02T17:35:24.835439+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:48.285346+00:00",
+     "start_time": "2026-09-02T17:35:24.818814+00:00",
      "status": "completed"
     }
    },
@@ -241,13 +242,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06ce8091",
+   "id": "e360ab1f",
    "metadata": {
     "papermill": {
-     "duration": 0.001224,
-     "end_time": "2026-08-30T20:53:48.304963+00:00",
+     "duration": 0.001219,
+     "end_time": "2026-09-02T17:35:24.838048+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:48.303739+00:00",
+     "start_time": "2026-09-02T17:35:24.836829+00:00",
      "status": "completed"
     }
    },
@@ -277,19 +278,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "ff26ad59",
+   "id": "18b63605",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:53:48.308056Z",
-     "iopub.status.busy": "2026-08-30T20:53:48.307966Z",
-     "iopub.status.idle": "2026-08-30T20:53:48.338393Z",
-     "shell.execute_reply": "2026-08-30T20:53:48.338007Z"
+     "iopub.execute_input": "2026-09-02T17:35:24.841037Z",
+     "iopub.status.busy": "2026-09-02T17:35:24.840943Z",
+     "iopub.status.idle": "2026-09-02T17:35:24.875932Z",
+     "shell.execute_reply": "2026-09-02T17:35:24.875420Z"
     },
     "papermill": {
-     "duration": 0.032961,
-     "end_time": "2026-08-30T20:53:48.339144+00:00",
+     "duration": 0.037211,
+     "end_time": "2026-09-02T17:35:24.876507+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:48.306183+00:00",
+     "start_time": "2026-09-02T17:35:24.839296+00:00",
      "status": "completed"
     }
    },
@@ -344,13 +345,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7dd2bd6",
+   "id": "b2e0d0c5",
    "metadata": {
     "papermill": {
-     "duration": 0.002412,
-     "end_time": "2026-08-30T20:53:48.344374+00:00",
+     "duration": 0.00136,
+     "end_time": "2026-09-02T17:35:24.879669+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:48.341962+00:00",
+     "start_time": "2026-09-02T17:35:24.878309+00:00",
      "status": "completed"
     }
    },
@@ -366,40 +367,41 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "21c2f017",
+   "id": "d2159d14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:53:48.349900Z",
-     "iopub.status.busy": "2026-08-30T20:53:48.349792Z",
-     "iopub.status.idle": "2026-08-30T20:53:48.375127Z",
-     "shell.execute_reply": "2026-08-30T20:53:48.374533Z"
+     "iopub.execute_input": "2026-09-02T17:35:24.883376Z",
+     "iopub.status.busy": "2026-09-02T17:35:24.883209Z",
+     "iopub.status.idle": "2026-09-02T17:35:24.912609Z",
+     "shell.execute_reply": "2026-09-02T17:35:24.912276Z"
     },
     "papermill": {
-     "duration": 0.029012,
-     "end_time": "2026-08-30T20:53:48.375783+00:00",
+     "duration": 0.032061,
+     "end_time": "2026-09-02T17:35:24.913174+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:48.346771+00:00",
+     "start_time": "2026-09-02T17:35:24.881113+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "if configs.height < load_model_configs(study, \"linear\").height and not POPULATION_NAME:\n",
+    "if narrows_declared_catalog(study, \"linear\", configs) and not POPULATION_NAME:\n",
     "    raise ValueError(\n",
-    "        f\"this run fits {configs.height} of the declared configurations, so it cannot publish \"\n",
-    "        \"the canonical population; pass POPULATION_NAME to give it its own\"\n",
+    "        f\"this run declares {configs.height} label-configuration pairs, which is not the \"\n",
+    "        \"complete declared catalog, so it cannot publish the canonical population; pass \"\n",
+    "        \"POPULATION_NAME to give it its own\"\n",
     "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "043bc0d4",
+   "id": "6fe6f2a8",
    "metadata": {
     "papermill": {
-     "duration": 0.001382,
-     "end_time": "2026-08-30T20:53:48.378993+00:00",
+     "duration": 0.001271,
+     "end_time": "2026-09-02T17:35:24.916005+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:48.377611+00:00",
+     "start_time": "2026-09-02T17:35:24.914734+00:00",
      "status": "completed"
     }
    },
@@ -445,19 +447,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "21662d67",
+   "id": "1c672c4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:53:48.382591Z",
-     "iopub.status.busy": "2026-08-30T20:53:48.382443Z",
-     "iopub.status.idle": "2026-08-30T20:53:58.198689Z",
-     "shell.execute_reply": "2026-08-30T20:53:58.198072Z"
+     "iopub.execute_input": "2026-09-02T17:35:24.919105Z",
+     "iopub.status.busy": "2026-09-02T17:35:24.919010Z",
+     "iopub.status.idle": "2026-09-02T17:35:33.992980Z",
+     "shell.execute_reply": "2026-09-02T17:35:33.992319Z"
     },
     "papermill": {
-     "duration": 9.818582,
-     "end_time": "2026-08-30T20:53:58.199049+00:00",
+     "duration": 9.076569,
+     "end_time": "2026-09-02T17:35:33.993902+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:48.380467+00:00",
+     "start_time": "2026-09-02T17:35:24.917333+00:00",
      "status": "completed"
     }
    },
@@ -535,13 +537,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cde7296",
+   "id": "d0dea9c9",
    "metadata": {
     "papermill": {
-     "duration": 0.001414,
-     "end_time": "2026-08-30T20:53:58.202240+00:00",
+     "duration": 0.00178,
+     "end_time": "2026-09-02T17:35:33.999739+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:58.200826+00:00",
+     "start_time": "2026-09-02T17:35:33.997959+00:00",
      "status": "completed"
     }
    },
@@ -622,19 +624,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e656abb1",
+   "id": "21b37c77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:53:58.205754Z",
-     "iopub.status.busy": "2026-08-30T20:53:58.205651Z",
-     "iopub.status.idle": "2026-08-30T20:55:11.375878Z",
-     "shell.execute_reply": "2026-08-30T20:55:11.375317Z"
+     "iopub.execute_input": "2026-09-02T17:35:34.003161Z",
+     "iopub.status.busy": "2026-09-02T17:35:34.003039Z",
+     "iopub.status.idle": "2026-09-02T17:35:34.849251Z",
+     "shell.execute_reply": "2026-09-02T17:35:34.848804Z"
     },
     "papermill": {
-     "duration": 73.173668,
-     "end_time": "2026-08-30T20:55:11.377334+00:00",
+     "duration": 0.848568,
+     "end_time": "2026-09-02T17:35:34.849695+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:53:58.203666+00:00",
+     "start_time": "2026-09-02T17:35:34.001127+00:00",
      "status": "completed"
     }
    },
@@ -643,7 +645,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "56 configurations: 280 folds fitted, 0 reused\n",
+      "56 configurations: 0 folds fitted, 280 reused\n",
       "population cme_futures-linear-validation-v1: 56 prediction sets\n"
      ]
     }
@@ -667,13 +669,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5bf9b99a",
+   "id": "332f2814",
    "metadata": {
     "papermill": {
-     "duration": 0.001415,
-     "end_time": "2026-08-30T20:55:11.380333+00:00",
+     "duration": 0.00195,
+     "end_time": "2026-09-02T17:35:34.853279+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:11.378918+00:00",
+     "start_time": "2026-09-02T17:35:34.851329+00:00",
      "status": "completed"
     }
    },
@@ -713,13 +715,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51428916",
+   "id": "8f3f6f37",
    "metadata": {
     "papermill": {
-     "duration": 0.001273,
-     "end_time": "2026-08-30T20:55:11.382982+00:00",
+     "duration": 0.001302,
+     "end_time": "2026-09-02T17:35:34.856030+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:11.381709+00:00",
+     "start_time": "2026-09-02T17:35:34.854728+00:00",
      "status": "completed"
     }
    },
@@ -752,19 +754,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "41c66750",
+   "id": "fb24487b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:11.386429Z",
-     "iopub.status.busy": "2026-08-30T20:55:11.386332Z",
-     "iopub.status.idle": "2026-08-30T20:55:11.392913Z",
-     "shell.execute_reply": "2026-08-30T20:55:11.392493Z"
+     "iopub.execute_input": "2026-09-02T17:35:34.859748Z",
+     "iopub.status.busy": "2026-09-02T17:35:34.859600Z",
+     "iopub.status.idle": "2026-09-02T17:35:34.869028Z",
+     "shell.execute_reply": "2026-09-02T17:35:34.868601Z"
     },
     "papermill": {
-     "duration": 0.008902,
-     "end_time": "2026-08-30T20:55:11.393255+00:00",
+     "duration": 0.011925,
+     "end_time": "2026-09-02T17:35:34.869440+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:11.384353+00:00",
+     "start_time": "2026-09-02T17:35:34.857515+00:00",
      "status": "completed"
     },
     "tags": [
@@ -868,13 +870,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01a58f86",
+   "id": "5492fd85",
    "metadata": {
     "papermill": {
-     "duration": 0.001627,
-     "end_time": "2026-08-30T20:55:11.396636+00:00",
+     "duration": 0.001422,
+     "end_time": "2026-09-02T17:35:34.872586+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:11.395009+00:00",
+     "start_time": "2026-09-02T17:35:34.871164+00:00",
      "status": "completed"
     }
    },
@@ -887,19 +889,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "f3bf04d9",
+   "id": "d3accd95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:11.400496Z",
-     "iopub.status.busy": "2026-08-30T20:55:11.400386Z",
-     "iopub.status.idle": "2026-08-30T20:55:11.403933Z",
-     "shell.execute_reply": "2026-08-30T20:55:11.403500Z"
+     "iopub.execute_input": "2026-09-02T17:35:34.876044Z",
+     "iopub.status.busy": "2026-09-02T17:35:34.875957Z",
+     "iopub.status.idle": "2026-09-02T17:35:34.878927Z",
+     "shell.execute_reply": "2026-09-02T17:35:34.878562Z"
     },
     "papermill": {
-     "duration": 0.006218,
-     "end_time": "2026-08-30T20:55:11.404436+00:00",
+     "duration": 0.005131,
+     "end_time": "2026-09-02T17:35:34.879232+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:11.398218+00:00",
+     "start_time": "2026-09-02T17:35:34.874101+00:00",
      "status": "completed"
     },
     "tags": [
@@ -948,13 +950,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ff97e5d",
+   "id": "5463de3b",
    "metadata": {
     "papermill": {
-     "duration": 0.001463,
-     "end_time": "2026-08-30T20:55:11.407568+00:00",
+     "duration": 0.001423,
+     "end_time": "2026-09-02T17:35:34.882211+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:11.406105+00:00",
+     "start_time": "2026-09-02T17:35:34.880788+00:00",
      "status": "completed"
     }
    },
@@ -971,19 +973,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "d6d14348",
+   "id": "45b4be87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:11.411331Z",
-     "iopub.status.busy": "2026-08-30T20:55:11.411162Z",
-     "iopub.status.idle": "2026-08-30T20:55:11.415395Z",
-     "shell.execute_reply": "2026-08-30T20:55:11.415004Z"
+     "iopub.execute_input": "2026-09-02T17:35:34.886115Z",
+     "iopub.status.busy": "2026-09-02T17:35:34.886038Z",
+     "iopub.status.idle": "2026-09-02T17:35:34.889256Z",
+     "shell.execute_reply": "2026-09-02T17:35:34.888969Z"
     },
     "papermill": {
-     "duration": 0.006783,
-     "end_time": "2026-08-30T20:55:11.415828+00:00",
+     "duration": 0.005754,
+     "end_time": "2026-09-02T17:35:34.889777+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:11.409045+00:00",
+     "start_time": "2026-09-02T17:35:34.884023+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1039,14 +1041,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "677f976e",
+   "id": "c2dc1f1b",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001548,
-     "end_time": "2026-08-30T20:55:11.419109+00:00",
+     "duration": 0.001473,
+     "end_time": "2026-09-02T17:35:34.894253+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:11.417561+00:00",
+     "start_time": "2026-09-02T17:35:34.892780+00:00",
      "status": "completed"
     }
    },
@@ -1074,19 +1076,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "bb77f389",
+   "id": "197a08d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:11.422870Z",
-     "iopub.status.busy": "2026-08-30T20:55:11.422779Z",
-     "iopub.status.idle": "2026-08-30T20:55:12.891457Z",
-     "shell.execute_reply": "2026-08-30T20:55:12.890935Z"
+     "iopub.execute_input": "2026-09-02T17:35:34.897770Z",
+     "iopub.status.busy": "2026-09-02T17:35:34.897690Z",
+     "iopub.status.idle": "2026-09-02T17:35:36.493982Z",
+     "shell.execute_reply": "2026-09-02T17:35:36.493580Z"
     },
     "papermill": {
-     "duration": 1.471374,
-     "end_time": "2026-08-30T20:55:12.892068+00:00",
+     "duration": 1.598758,
+     "end_time": "2026-09-02T17:35:36.494517+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:11.420694+00:00",
+     "start_time": "2026-09-02T17:35:34.895759+00:00",
      "status": "completed"
     }
    },
@@ -1571,14 +1573,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf45eac9",
+   "id": "8e4e8c18",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002083,
-     "end_time": "2026-08-30T20:55:12.898565+00:00",
+     "duration": 0.002003,
+     "end_time": "2026-09-02T17:35:36.498819+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:12.896482+00:00",
+     "start_time": "2026-09-02T17:35:36.496816+00:00",
      "status": "completed"
     }
    },
@@ -1594,19 +1596,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "c1d19b9c",
+   "id": "ceac9fce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:12.903701Z",
-     "iopub.status.busy": "2026-08-30T20:55:12.903544Z",
-     "iopub.status.idle": "2026-08-30T20:55:12.909016Z",
-     "shell.execute_reply": "2026-08-30T20:55:12.908622Z"
+     "iopub.execute_input": "2026-09-02T17:35:36.503405Z",
+     "iopub.status.busy": "2026-09-02T17:35:36.503322Z",
+     "iopub.status.idle": "2026-09-02T17:35:36.507746Z",
+     "shell.execute_reply": "2026-09-02T17:35:36.507484Z"
     },
     "papermill": {
-     "duration": 0.008884,
-     "end_time": "2026-08-30T20:55:12.909565+00:00",
+     "duration": 0.007286,
+     "end_time": "2026-09-02T17:35:36.508094+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:12.900681+00:00",
+     "start_time": "2026-09-02T17:35:36.500808+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1669,13 +1671,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8015c01",
+   "id": "0d3ea4bb",
    "metadata": {
     "papermill": {
-     "duration": 0.003975,
-     "end_time": "2026-08-30T20:55:12.917756+00:00",
+     "duration": 0.002005,
+     "end_time": "2026-09-02T17:35:36.512214+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:12.913781+00:00",
+     "start_time": "2026-09-02T17:35:36.510209+00:00",
      "status": "completed"
     }
    },
@@ -1695,19 +1697,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "28a7a4ec",
+   "id": "5688b483",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:12.924151Z",
-     "iopub.status.busy": "2026-08-30T20:55:12.924053Z",
-     "iopub.status.idle": "2026-08-30T20:55:14.392926Z",
-     "shell.execute_reply": "2026-08-30T20:55:14.392360Z"
+     "iopub.execute_input": "2026-09-02T17:35:36.517916Z",
+     "iopub.status.busy": "2026-09-02T17:35:36.517815Z",
+     "iopub.status.idle": "2026-09-02T17:35:37.843291Z",
+     "shell.execute_reply": "2026-09-02T17:35:37.842891Z"
     },
     "papermill": {
-     "duration": 1.472157,
-     "end_time": "2026-08-30T20:55:14.393400+00:00",
+     "duration": 1.329513,
+     "end_time": "2026-09-02T17:35:37.843818+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:12.921243+00:00",
+     "start_time": "2026-09-02T17:35:36.514305+00:00",
      "status": "completed"
     }
    },
@@ -2000,13 +2002,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "500096eb",
+   "id": "84ff79ef",
    "metadata": {
     "papermill": {
-     "duration": 0.002644,
-     "end_time": "2026-08-30T20:55:14.401343+00:00",
+     "duration": 0.002548,
+     "end_time": "2026-09-02T17:35:37.850745+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:14.398699+00:00",
+     "start_time": "2026-09-02T17:35:37.848197+00:00",
      "status": "completed"
     }
    },
@@ -2129,22 +2131,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-08-30T20:55:23.359580+00:00",
+   "executed_at": "2026-09-02T17:35:45.425930+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "0b5b9eaa9e2d24f56f3dd395317b33015a32717d"
+   "source_py_blob": "57040ea85fc41caf226cdd3ea1700a16c93990e4"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 94.248788,
-   "end_time": "2026-08-30T20:55:17.100781+00:00",
+   "duration": 23.650286,
+   "end_time": "2026-09-02T17:35:40.251188+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-cme_futures/case_studies/cme_futures/06_linear.ipynb",
-   "output_path": "~/ml4t/public-s6-cme_futures/case_studies/cme_futures/.06_linear.papermill.2688662.ipynb",
+   "input_path": "~/ml4t/public-catalog-guard/case_studies/cme_futures/06_linear.ipynb",
+   "output_path": "~/ml4t/public-catalog-guard/case_studies/cme_futures/.06_linear.papermill.132490.ipynb",
    "parameters": {},
-   "start_time": "2026-08-30T20:53:42.851993+00:00",
+   "start_time": "2026-09-02T17:35:16.600902+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/cme_futures/06_linear.py
+++ b/case_studies/cme_futures/06_linear.py
@@ -83,6 +83,7 @@ from case_studies.research import (
     declared_labels,
     load_model_configs,
     model_requests,
+    narrows_declared_catalog,
     open_study,
     population_supersedes,
     primary_label,
@@ -168,10 +169,11 @@ configs
 # either knob, and says so here rather than several cells later in a message about hashes.
 
 # %%
-if configs.height < load_model_configs(study, "linear").height and not POPULATION_NAME:
+if narrows_declared_catalog(study, "linear", configs) and not POPULATION_NAME:
     raise ValueError(
-        f"this run fits {configs.height} of the declared configurations, so it cannot publish "
-        "the canonical population; pass POPULATION_NAME to give it its own"
+        f"this run declares {configs.height} label-configuration pairs, which is not the "
+        "complete declared catalog, so it cannot publish the canonical population; pass "
+        "POPULATION_NAME to give it its own"
     )
 
 # %% [markdown]

--- a/case_studies/cme_futures/07_gbm.ipynb
+++ b/case_studies/cme_futures/07_gbm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "09584a1d",
+   "id": "062a3a74",
    "metadata": {
     "papermill": {
-     "duration": 0.00169,
-     "end_time": "2026-08-30T20:55:26.066984+00:00",
+     "duration": 0.006237,
+     "end_time": "2026-09-02T17:35:47.950691+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:26.065294+00:00",
+     "start_time": "2026-09-02T17:35:47.944454+00:00",
      "status": "completed"
     }
    },
@@ -79,19 +79,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6b0a8461",
+   "id": "1b8d8f32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:26.070547Z",
-     "iopub.status.busy": "2026-08-30T20:55:26.070439Z",
-     "iopub.status.idle": "2026-08-30T20:55:29.103568Z",
-     "shell.execute_reply": "2026-08-30T20:55:29.103017Z"
+     "iopub.execute_input": "2026-09-02T17:35:47.955830Z",
+     "iopub.status.busy": "2026-09-02T17:35:47.955718Z",
+     "iopub.status.idle": "2026-09-02T17:35:50.170611Z",
+     "shell.execute_reply": "2026-09-02T17:35:50.170046Z"
     },
     "papermill": {
-     "duration": 3.035655,
-     "end_time": "2026-08-30T20:55:29.104046+00:00",
+     "duration": 2.217801,
+     "end_time": "2026-09-02T17:35:50.171113+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:26.068391+00:00",
+     "start_time": "2026-09-02T17:35:47.953312+00:00",
      "status": "completed"
     }
    },
@@ -108,6 +108,7 @@
     "    declared_labels,\n",
     "    load_model_configs,\n",
     "    model_requests,\n",
+    "    narrows_declared_catalog,\n",
     "    open_study,\n",
     "    population_supersedes,\n",
     "    primary_label,\n",
@@ -120,19 +121,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f041b2d2",
+   "id": "765ce609",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:29.107771Z",
-     "iopub.status.busy": "2026-08-30T20:55:29.107583Z",
-     "iopub.status.idle": "2026-08-30T20:55:29.109693Z",
-     "shell.execute_reply": "2026-08-30T20:55:29.109326Z"
+     "iopub.execute_input": "2026-09-02T17:35:50.174844Z",
+     "iopub.status.busy": "2026-09-02T17:35:50.174658Z",
+     "iopub.status.idle": "2026-09-02T17:35:50.176726Z",
+     "shell.execute_reply": "2026-09-02T17:35:50.176382Z"
     },
     "papermill": {
-     "duration": 0.004232,
-     "end_time": "2026-08-30T20:55:29.109937+00:00",
+     "duration": 0.004397,
+     "end_time": "2026-09-02T17:35:50.177023+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:29.105705+00:00",
+     "start_time": "2026-09-02T17:35:50.172626+00:00",
      "status": "completed"
     },
     "tags": [
@@ -153,19 +154,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6a109a21",
+   "id": "898a5e2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:29.113569Z",
-     "iopub.status.busy": "2026-08-30T20:55:29.113487Z",
-     "iopub.status.idle": "2026-08-30T20:55:30.682467Z",
-     "shell.execute_reply": "2026-08-30T20:55:30.681912Z"
+     "iopub.execute_input": "2026-09-02T17:35:50.180028Z",
+     "iopub.status.busy": "2026-09-02T17:35:50.179952Z",
+     "iopub.status.idle": "2026-09-02T17:35:50.515252Z",
+     "shell.execute_reply": "2026-09-02T17:35:50.514762Z"
     },
     "papermill": {
-     "duration": 1.571441,
-     "end_time": "2026-08-30T20:55:30.682873+00:00",
+     "duration": 0.337413,
+     "end_time": "2026-09-02T17:35:50.515726+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:29.111432+00:00",
+     "start_time": "2026-09-02T17:35:50.178313+00:00",
      "status": "completed"
     }
    },
@@ -176,13 +177,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f85c3e81",
+   "id": "036b4703",
    "metadata": {
     "papermill": {
-     "duration": 0.0013,
-     "end_time": "2026-08-30T20:55:30.685871+00:00",
+     "duration": 0.001213,
+     "end_time": "2026-09-02T17:35:50.518417+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:30.684571+00:00",
+     "start_time": "2026-09-02T17:35:50.517204+00:00",
      "status": "completed"
     }
    },
@@ -201,19 +202,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "fcf74f2a",
+   "id": "119e4934",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:30.689236Z",
-     "iopub.status.busy": "2026-08-30T20:55:30.689073Z",
-     "iopub.status.idle": "2026-08-30T20:55:30.704729Z",
-     "shell.execute_reply": "2026-08-30T20:55:30.704372Z"
+     "iopub.execute_input": "2026-09-02T17:35:50.521422Z",
+     "iopub.status.busy": "2026-09-02T17:35:50.521350Z",
+     "iopub.status.idle": "2026-09-02T17:35:50.535761Z",
+     "shell.execute_reply": "2026-09-02T17:35:50.535401Z"
     },
     "papermill": {
-     "duration": 0.017816,
-     "end_time": "2026-08-30T20:55:30.705019+00:00",
+     "duration": 0.016447,
+     "end_time": "2026-09-02T17:35:50.536108+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:30.687203+00:00",
+     "start_time": "2026-09-02T17:35:50.519661+00:00",
      "status": "completed"
     }
    },
@@ -235,13 +236,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7eb0595b",
+   "id": "9ad6d2d1",
    "metadata": {
     "papermill": {
-     "duration": 0.001354,
-     "end_time": "2026-08-30T20:55:30.707975+00:00",
+     "duration": 0.001272,
+     "end_time": "2026-09-02T17:35:50.538831+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:30.706621+00:00",
+     "start_time": "2026-09-02T17:35:50.537559+00:00",
      "status": "completed"
     }
    },
@@ -265,19 +266,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d1cf5ca9",
+   "id": "a2e900c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:30.711220Z",
-     "iopub.status.busy": "2026-08-30T20:55:30.711128Z",
-     "iopub.status.idle": "2026-08-30T20:55:30.746702Z",
-     "shell.execute_reply": "2026-08-30T20:55:30.746423Z"
+     "iopub.execute_input": "2026-09-02T17:35:50.541994Z",
+     "iopub.status.busy": "2026-09-02T17:35:50.541921Z",
+     "iopub.status.idle": "2026-09-02T17:35:50.571705Z",
+     "shell.execute_reply": "2026-09-02T17:35:50.571228Z"
     },
     "papermill": {
-     "duration": 0.037925,
-     "end_time": "2026-08-30T20:55:30.747210+00:00",
+     "duration": 0.031814,
+     "end_time": "2026-09-02T17:35:50.571983+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:30.709285+00:00",
+     "start_time": "2026-09-02T17:35:50.540169+00:00",
      "status": "completed"
     }
    },
@@ -332,13 +333,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d0dbb2f",
+   "id": "2dc08ded",
    "metadata": {
     "papermill": {
-     "duration": 0.001465,
-     "end_time": "2026-08-30T20:55:30.751166+00:00",
+     "duration": 0.001381,
+     "end_time": "2026-09-02T17:35:50.574915+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:30.749701+00:00",
+     "start_time": "2026-09-02T17:35:50.573534+00:00",
      "status": "completed"
     }
    },
@@ -353,40 +354,41 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b1be9ae7",
+   "id": "96db3181",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:30.755280Z",
-     "iopub.status.busy": "2026-08-30T20:55:30.755163Z",
-     "iopub.status.idle": "2026-08-30T20:55:30.780934Z",
-     "shell.execute_reply": "2026-08-30T20:55:30.780539Z"
+     "iopub.execute_input": "2026-09-02T17:35:50.578162Z",
+     "iopub.status.busy": "2026-09-02T17:35:50.578075Z",
+     "iopub.status.idle": "2026-09-02T17:35:50.603570Z",
+     "shell.execute_reply": "2026-09-02T17:35:50.603214Z"
     },
     "papermill": {
-     "duration": 0.028366,
-     "end_time": "2026-08-30T20:55:30.781331+00:00",
+     "duration": 0.027677,
+     "end_time": "2026-09-02T17:35:50.603975+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:30.752965+00:00",
+     "start_time": "2026-09-02T17:35:50.576298+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "if configs.height < load_model_configs(study, \"gbm\").height and not POPULATION_NAME:\n",
+    "if narrows_declared_catalog(study, \"gbm\", configs) and not POPULATION_NAME:\n",
     "    raise ValueError(\n",
-    "        f\"this run fits {configs.height} of the declared configurations, so it cannot publish \"\n",
-    "        \"the canonical population; pass POPULATION_NAME to give it its own\"\n",
+    "        f\"this run declares {configs.height} label-configuration pairs, which is not the \"\n",
+    "        \"complete declared catalog, so it cannot publish the canonical population; pass \"\n",
+    "        \"POPULATION_NAME to give it its own\"\n",
     "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f9c9a5ad",
+   "id": "82b3ca99",
    "metadata": {
     "papermill": {
-     "duration": 0.00141,
-     "end_time": "2026-08-30T20:55:30.784376+00:00",
+     "duration": 0.001325,
+     "end_time": "2026-09-02T17:35:50.606797+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:30.782966+00:00",
+     "start_time": "2026-09-02T17:35:50.605472+00:00",
      "status": "completed"
     }
    },
@@ -421,19 +423,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a9817e59",
+   "id": "736b29aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:30.787869Z",
-     "iopub.status.busy": "2026-08-30T20:55:30.787750Z",
-     "iopub.status.idle": "2026-08-30T20:55:50.273398Z",
-     "shell.execute_reply": "2026-08-30T20:55:50.272862Z"
+     "iopub.execute_input": "2026-09-02T17:35:50.612905Z",
+     "iopub.status.busy": "2026-09-02T17:35:50.612804Z",
+     "iopub.status.idle": "2026-09-02T17:36:09.667549Z",
+     "shell.execute_reply": "2026-09-02T17:36:09.666554Z"
     },
     "papermill": {
-     "duration": 19.487906,
-     "end_time": "2026-08-30T20:55:50.273732+00:00",
+     "duration": 19.059206,
+     "end_time": "2026-09-02T17:36:09.668715+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:30.785826+00:00",
+     "start_time": "2026-09-02T17:35:50.609509+00:00",
      "status": "completed"
     }
    },
@@ -512,13 +514,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6a9f0e9",
+   "id": "d6205495",
    "metadata": {
     "papermill": {
-     "duration": 0.001474,
-     "end_time": "2026-08-30T20:55:50.276996+00:00",
+     "duration": 0.003362,
+     "end_time": "2026-09-02T17:36:09.676853+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:50.275522+00:00",
+     "start_time": "2026-09-02T17:36:09.673491+00:00",
      "status": "completed"
     }
    },
@@ -605,19 +607,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ddead0ba",
+   "id": "c40555f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T20:55:50.280677Z",
-     "iopub.status.busy": "2026-08-30T20:55:50.280552Z",
-     "iopub.status.idle": "2026-08-30T21:05:50.228168Z",
-     "shell.execute_reply": "2026-08-30T21:05:50.227435Z"
+     "iopub.execute_input": "2026-09-02T17:36:09.681908Z",
+     "iopub.status.busy": "2026-09-02T17:36:09.681793Z",
+     "iopub.status.idle": "2026-09-02T17:36:12.852107Z",
+     "shell.execute_reply": "2026-09-02T17:36:12.851679Z"
     },
     "papermill": {
-     "duration": 599.950441,
-     "end_time": "2026-08-30T21:05:50.228931+00:00",
+     "duration": 3.173144,
+     "end_time": "2026-09-02T17:36:12.852524+00:00",
      "exception": false,
-     "start_time": "2026-08-30T20:55:50.278490+00:00",
+     "start_time": "2026-09-02T17:36:09.679380+00:00",
      "status": "completed"
     }
    },
@@ -626,2107 +628,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,200 n_val=7,038 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=59,857 n_val=7,684 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=59,564 n_val=7,676 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,210 n_val=7,692 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,325 n_val=7,692 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=? obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=? obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=? obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=7 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=7 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=7 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=15 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=15 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=15 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=31 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=31 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=31 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=63 obj=regression\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=63 obj=regression_l1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: training n_train=60,680 n_val=7,518 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: training n_train=60,337 n_val=7,684 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: done in 7s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: training n_train=60,044 n_val=7,676 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: done in 4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: training n_train=59,738 n_val=7,692 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: done in 5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: training n_train=58,879 n_val=7,692 trees=500 num_leaves=63 obj=huber\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: done in 6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "30 configurations: 150 folds fitted, 0 reused\n",
+      "30 configurations: 0 folds fitted, 150 reused\n",
       "population cme_futures-gbm-validation-v1: 300 prediction sets\n"
      ]
     }
@@ -2753,13 +655,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a732060",
+   "id": "d44786f0",
    "metadata": {
     "papermill": {
-     "duration": 0.00866,
-     "end_time": "2026-08-30T21:05:50.245518+00:00",
+     "duration": 0.001515,
+     "end_time": "2026-09-02T17:36:12.855792+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:50.236858+00:00",
+     "start_time": "2026-09-02T17:36:12.854277+00:00",
      "status": "completed"
     }
    },
@@ -2792,13 +694,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2946fe17",
+   "id": "3d1359a5",
    "metadata": {
     "papermill": {
-     "duration": 0.008202,
-     "end_time": "2026-08-30T21:05:50.264599+00:00",
+     "duration": 0.001378,
+     "end_time": "2026-09-02T17:36:12.858692+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:50.256397+00:00",
+     "start_time": "2026-09-02T17:36:12.857314+00:00",
      "status": "completed"
     }
    },
@@ -2825,19 +727,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "48702634",
+   "id": "b4f5af47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T21:05:50.280647Z",
-     "iopub.status.busy": "2026-08-30T21:05:50.280429Z",
-     "iopub.status.idle": "2026-08-30T21:05:50.304201Z",
-     "shell.execute_reply": "2026-08-30T21:05:50.303315Z"
+     "iopub.execute_input": "2026-09-02T17:36:12.862217Z",
+     "iopub.status.busy": "2026-09-02T17:36:12.862107Z",
+     "iopub.status.idle": "2026-09-02T17:36:12.880065Z",
+     "shell.execute_reply": "2026-09-02T17:36:12.879674Z"
     },
     "papermill": {
-     "duration": 0.032336,
-     "end_time": "2026-08-30T21:05:50.304704+00:00",
+     "duration": 0.020248,
+     "end_time": "2026-09-02T17:36:12.880369+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:50.272368+00:00",
+     "start_time": "2026-09-02T17:36:12.860121+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2940,13 +842,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b678136",
+   "id": "7b81b694",
    "metadata": {
     "papermill": {
-     "duration": 0.008115,
-     "end_time": "2026-08-30T21:05:50.320739+00:00",
+     "duration": 0.001541,
+     "end_time": "2026-09-02T17:36:12.883634+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:50.312624+00:00",
+     "start_time": "2026-09-02T17:36:12.882093+00:00",
      "status": "completed"
     }
    },
@@ -2967,19 +869,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ff6b5d4c",
+   "id": "1c1c8296",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T21:05:50.341608Z",
-     "iopub.status.busy": "2026-08-30T21:05:50.341434Z",
-     "iopub.status.idle": "2026-08-30T21:05:52.409638Z",
-     "shell.execute_reply": "2026-08-30T21:05:52.408452Z"
+     "iopub.execute_input": "2026-09-02T17:36:12.887373Z",
+     "iopub.status.busy": "2026-09-02T17:36:12.887239Z",
+     "iopub.status.idle": "2026-09-02T17:36:15.560961Z",
+     "shell.execute_reply": "2026-09-02T17:36:15.560202Z"
     },
     "papermill": {
-     "duration": 2.082676,
-     "end_time": "2026-08-30T21:05:52.411182+00:00",
+     "duration": 2.680327,
+     "end_time": "2026-09-02T17:36:15.565530+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:50.328506+00:00",
+     "start_time": "2026-09-02T17:36:12.885203+00:00",
      "status": "completed"
     }
    },
@@ -4415,13 +2317,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02e336fc",
+   "id": "a9c403ad",
    "metadata": {
     "papermill": {
-     "duration": 0.011029,
-     "end_time": "2026-08-30T21:05:52.433333+00:00",
+     "duration": 0.018549,
+     "end_time": "2026-09-02T17:36:15.600344+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:52.422304+00:00",
+     "start_time": "2026-09-02T17:36:15.581795+00:00",
      "status": "completed"
     }
    },
@@ -4437,19 +2339,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "acb60c7c",
+   "id": "c42cd0ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T21:05:52.457780Z",
-     "iopub.status.busy": "2026-08-30T21:05:52.457626Z",
-     "iopub.status.idle": "2026-08-30T21:05:52.464641Z",
-     "shell.execute_reply": "2026-08-30T21:05:52.463915Z"
+     "iopub.execute_input": "2026-09-02T17:36:15.633658Z",
+     "iopub.status.busy": "2026-09-02T17:36:15.633458Z",
+     "iopub.status.idle": "2026-09-02T17:36:15.664414Z",
+     "shell.execute_reply": "2026-09-02T17:36:15.663963Z"
     },
     "papermill": {
-     "duration": 0.020556,
-     "end_time": "2026-08-30T21:05:52.465164+00:00",
+     "duration": 0.048795,
+     "end_time": "2026-09-02T17:36:15.667441+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:52.444608+00:00",
+     "start_time": "2026-09-02T17:36:15.618646+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4518,13 +2420,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a572e71",
+   "id": "12280ef8",
    "metadata": {
     "papermill": {
-     "duration": 0.012614,
-     "end_time": "2026-08-30T21:05:52.491783+00:00",
+     "duration": 0.021532,
+     "end_time": "2026-09-02T17:36:15.704474+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:52.479169+00:00",
+     "start_time": "2026-09-02T17:36:15.682942+00:00",
      "status": "completed"
     }
    },
@@ -4546,19 +2448,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "01fe19b7",
+   "id": "40915b5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T21:05:52.541067Z",
-     "iopub.status.busy": "2026-08-30T21:05:52.540408Z",
-     "iopub.status.idle": "2026-08-30T21:05:54.484982Z",
-     "shell.execute_reply": "2026-08-30T21:05:54.484147Z"
+     "iopub.execute_input": "2026-09-02T17:36:15.736484Z",
+     "iopub.status.busy": "2026-09-02T17:36:15.736244Z",
+     "iopub.status.idle": "2026-09-02T17:36:20.197585Z",
+     "shell.execute_reply": "2026-09-02T17:36:20.197168Z"
     },
     "papermill": {
-     "duration": 1.973365,
-     "end_time": "2026-08-30T21:05:54.485712+00:00",
+     "duration": 4.474655,
+     "end_time": "2026-09-02T17:36:20.198427+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:52.512347+00:00",
+     "start_time": "2026-09-02T17:36:15.723772+00:00",
      "status": "completed"
     }
    },
@@ -4963,13 +2865,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a4eb2a3",
+   "id": "96eb605a",
    "metadata": {
     "papermill": {
-     "duration": 0.010302,
-     "end_time": "2026-08-30T21:05:54.511356+00:00",
+     "duration": 0.01353,
+     "end_time": "2026-09-02T17:36:20.227102+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.501054+00:00",
+     "start_time": "2026-09-02T17:36:20.213572+00:00",
      "status": "completed"
     }
    },
@@ -4985,19 +2887,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "d3614333",
+   "id": "270d95be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T21:05:54.533326Z",
-     "iopub.status.busy": "2026-08-30T21:05:54.533088Z",
-     "iopub.status.idle": "2026-08-30T21:05:54.538125Z",
-     "shell.execute_reply": "2026-08-30T21:05:54.537511Z"
+     "iopub.execute_input": "2026-09-02T17:36:20.264800Z",
+     "iopub.status.busy": "2026-09-02T17:36:20.263767Z",
+     "iopub.status.idle": "2026-09-02T17:36:20.285104Z",
+     "shell.execute_reply": "2026-09-02T17:36:20.284226Z"
     },
     "papermill": {
-     "duration": 0.016615,
-     "end_time": "2026-08-30T21:05:54.538714+00:00",
+     "duration": 0.042758,
+     "end_time": "2026-09-02T17:36:20.286870+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.522099+00:00",
+     "start_time": "2026-09-02T17:36:20.244112+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5050,13 +2952,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67dc2f3c",
+   "id": "06f0efad",
    "metadata": {
     "papermill": {
-     "duration": 0.011729,
-     "end_time": "2026-08-30T21:05:54.560655+00:00",
+     "duration": 0.007566,
+     "end_time": "2026-09-02T17:36:20.303714+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.548926+00:00",
+     "start_time": "2026-09-02T17:36:20.296148+00:00",
      "status": "completed"
     }
    },
@@ -5072,19 +2974,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "8719e90d",
+   "id": "ab18e88a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T21:05:54.582616Z",
-     "iopub.status.busy": "2026-08-30T21:05:54.582359Z",
-     "iopub.status.idle": "2026-08-30T21:05:54.588117Z",
-     "shell.execute_reply": "2026-08-30T21:05:54.587448Z"
+     "iopub.execute_input": "2026-09-02T17:36:20.321518Z",
+     "iopub.status.busy": "2026-09-02T17:36:20.321296Z",
+     "iopub.status.idle": "2026-09-02T17:36:20.363457Z",
+     "shell.execute_reply": "2026-09-02T17:36:20.362955Z"
     },
     "papermill": {
-     "duration": 0.017456,
-     "end_time": "2026-08-30T21:05:54.588512+00:00",
+     "duration": 0.054073,
+     "end_time": "2026-09-02T17:36:20.365500+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.571056+00:00",
+     "start_time": "2026-09-02T17:36:20.311427+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5141,13 +3043,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f21d055b",
+   "id": "f27e33f6",
    "metadata": {
     "papermill": {
-     "duration": 0.009743,
-     "end_time": "2026-08-30T21:05:54.609227+00:00",
+     "duration": 0.013591,
+     "end_time": "2026-09-02T17:36:20.395536+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.599484+00:00",
+     "start_time": "2026-09-02T17:36:20.381945+00:00",
      "status": "completed"
     }
    },
@@ -5179,19 +3081,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "5698587e",
+   "id": "73f34319",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T21:05:54.630529Z",
-     "iopub.status.busy": "2026-08-30T21:05:54.630412Z",
-     "iopub.status.idle": "2026-08-30T21:05:54.687683Z",
-     "shell.execute_reply": "2026-08-30T21:05:54.686883Z"
+     "iopub.execute_input": "2026-09-02T17:36:20.419747Z",
+     "iopub.status.busy": "2026-09-02T17:36:20.419545Z",
+     "iopub.status.idle": "2026-09-02T17:36:20.653212Z",
+     "shell.execute_reply": "2026-09-02T17:36:20.651767Z"
     },
     "papermill": {
-     "duration": 0.068152,
-     "end_time": "2026-08-30T21:05:54.688045+00:00",
+     "duration": 0.244085,
+     "end_time": "2026-09-02T17:36:20.653904+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.619893+00:00",
+     "start_time": "2026-09-02T17:36:20.409819+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5255,13 +3157,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8807380b",
+   "id": "d93f820d",
    "metadata": {
     "papermill": {
-     "duration": 0.010848,
-     "end_time": "2026-08-30T21:05:54.708471+00:00",
+     "duration": 0.019721,
+     "end_time": "2026-09-02T17:36:20.702705+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.697623+00:00",
+     "start_time": "2026-09-02T17:36:20.682984+00:00",
      "status": "completed"
     }
    },
@@ -5284,19 +3186,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "1101e84e",
+   "id": "f90c741a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T21:05:54.735241Z",
-     "iopub.status.busy": "2026-08-30T21:05:54.734966Z",
-     "iopub.status.idle": "2026-08-30T21:05:54.744637Z",
-     "shell.execute_reply": "2026-08-30T21:05:54.744025Z"
+     "iopub.execute_input": "2026-09-02T17:36:20.730561Z",
+     "iopub.status.busy": "2026-09-02T17:36:20.729441Z",
+     "iopub.status.idle": "2026-09-02T17:36:20.770844Z",
+     "shell.execute_reply": "2026-09-02T17:36:20.770085Z"
     },
     "papermill": {
-     "duration": 0.023576,
-     "end_time": "2026-08-30T21:05:54.745066+00:00",
+     "duration": 0.058797,
+     "end_time": "2026-09-02T17:36:20.772846+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.721490+00:00",
+     "start_time": "2026-09-02T17:36:20.714049+00:00",
      "status": "completed"
     }
    },
@@ -5357,19 +3259,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "b11a9dc2",
+   "id": "7dc9bc60",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-30T21:05:54.772130Z",
-     "iopub.status.busy": "2026-08-30T21:05:54.771939Z",
-     "iopub.status.idle": "2026-08-30T21:05:54.777272Z",
-     "shell.execute_reply": "2026-08-30T21:05:54.776552Z"
+     "iopub.execute_input": "2026-09-02T17:36:20.793993Z",
+     "iopub.status.busy": "2026-09-02T17:36:20.793744Z",
+     "iopub.status.idle": "2026-09-02T17:36:20.811454Z",
+     "shell.execute_reply": "2026-09-02T17:36:20.810652Z"
     },
     "papermill": {
-     "duration": 0.022437,
-     "end_time": "2026-08-30T21:05:54.777648+00:00",
+     "duration": 0.028815,
+     "end_time": "2026-09-02T17:36:20.812044+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.755211+00:00",
+     "start_time": "2026-09-02T17:36:20.783229+00:00",
      "status": "completed"
     },
     "tags": [
@@ -5420,13 +3322,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e01a891f",
+   "id": "7d03e5de",
    "metadata": {
     "papermill": {
-     "duration": 0.010068,
-     "end_time": "2026-08-30T21:05:54.797521+00:00",
+     "duration": 0.010157,
+     "end_time": "2026-09-02T17:36:20.835678+00:00",
      "exception": false,
-     "start_time": "2026-08-30T21:05:54.787453+00:00",
+     "start_time": "2026-09-02T17:36:20.825521+00:00",
      "status": "completed"
     }
    },
@@ -5537,22 +3439,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-08-30T21:06:06.069461+00:00",
+   "executed_at": "2026-09-02T17:36:39.945151+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "ab4f1d2211155373ad978cdf85c80865018d5f78"
+   "source_py_blob": "0a215598a9b23530abd35f9f44bae0c9f55f6c16"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 632.330037,
-   "end_time": "2026-08-30T21:05:57.741400+00:00",
+   "duration": 37.192048,
+   "end_time": "2026-09-02T17:36:24.453079+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-cme_futures/case_studies/cme_futures/07_gbm.ipynb",
-   "output_path": "~/ml4t/public-s6-cme_futures/case_studies/cme_futures/.07_gbm.papermill.2705591.ipynb",
+   "input_path": "~/ml4t/public-catalog-guard/case_studies/cme_futures/07_gbm.ipynb",
+   "output_path": "~/ml4t/public-catalog-guard/case_studies/cme_futures/.07_gbm.papermill.134327.ipynb",
    "parameters": {},
-   "start_time": "2026-08-30T20:55:25.411363+00:00",
+   "start_time": "2026-09-02T17:35:47.261031+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/cme_futures/07_gbm.py
+++ b/case_studies/cme_futures/07_gbm.py
@@ -88,6 +88,7 @@ from case_studies.research import (
     declared_labels,
     load_model_configs,
     model_requests,
+    narrows_declared_catalog,
     open_study,
     population_supersedes,
     primary_label,
@@ -155,10 +156,11 @@ configs
 # message about hashes.
 
 # %%
-if configs.height < load_model_configs(study, "gbm").height and not POPULATION_NAME:
+if narrows_declared_catalog(study, "gbm", configs) and not POPULATION_NAME:
     raise ValueError(
-        f"this run fits {configs.height} of the declared configurations, so it cannot publish "
-        "the canonical population; pass POPULATION_NAME to give it its own"
+        f"this run declares {configs.height} label-configuration pairs, which is not the "
+        "complete declared catalog, so it cannot publish the canonical population; pass "
+        "POPULATION_NAME to give it its own"
     )
 
 # %% [markdown]

--- a/case_studies/sp500_equity_option_analytics/06_linear.ipynb
+++ b/case_studies/sp500_equity_option_analytics/06_linear.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "95e14279",
+   "id": "329bd788",
    "metadata": {
     "papermill": {
-     "duration": 0.001417,
-     "end_time": "2026-08-25T22:41:52.113040+00:00",
+     "duration": 0.009369,
+     "end_time": "2026-09-02T17:36:48.041266+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:52.111623+00:00",
+     "start_time": "2026-09-02T17:36:48.031897+00:00",
      "status": "completed"
     }
    },
@@ -73,19 +73,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "758e447f",
+   "id": "9ce1576a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:52.116403Z",
-     "iopub.status.busy": "2026-08-25T22:41:52.116221Z",
-     "iopub.status.idle": "2026-08-25T22:41:54.848976Z",
-     "shell.execute_reply": "2026-08-25T22:41:54.848303Z"
+     "iopub.execute_input": "2026-09-02T17:36:48.062393Z",
+     "iopub.status.busy": "2026-09-02T17:36:48.062056Z",
+     "iopub.status.idle": "2026-09-02T17:36:55.748306Z",
+     "shell.execute_reply": "2026-09-02T17:36:55.747100Z"
     },
     "papermill": {
-     "duration": 2.73506,
-     "end_time": "2026-08-25T22:41:54.849370+00:00",
+     "duration": 7.701149,
+     "end_time": "2026-09-02T17:36:55.749774+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:52.114310+00:00",
+     "start_time": "2026-09-02T17:36:48.048625+00:00",
      "status": "completed"
     }
    },
@@ -104,6 +104,7 @@
     "    declared_labels,\n",
     "    load_model_configs,\n",
     "    model_requests,\n",
+    "    narrows_declared_catalog,\n",
     "    open_study,\n",
     "    primary_label,\n",
     "    resolved_model_plan,\n",
@@ -115,19 +116,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e73cd4a4",
+   "id": "1d1a32a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:54.852642Z",
-     "iopub.status.busy": "2026-08-25T22:41:54.852465Z",
-     "iopub.status.idle": "2026-08-25T22:41:54.854720Z",
-     "shell.execute_reply": "2026-08-25T22:41:54.854355Z"
+     "iopub.execute_input": "2026-09-02T17:36:55.765379Z",
+     "iopub.status.busy": "2026-09-02T17:36:55.764795Z",
+     "iopub.status.idle": "2026-09-02T17:36:55.771856Z",
+     "shell.execute_reply": "2026-09-02T17:36:55.771219Z"
     },
     "papermill": {
-     "duration": 0.004197,
-     "end_time": "2026-08-25T22:41:54.854996+00:00",
+     "duration": 0.012717,
+     "end_time": "2026-09-02T17:36:55.772960+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:54.850799+00:00",
+     "start_time": "2026-09-02T17:36:55.760243+00:00",
      "status": "completed"
     },
     "tags": [
@@ -148,19 +149,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "c562978d",
+   "id": "1aa85ce2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:54.857699Z",
-     "iopub.status.busy": "2026-08-25T22:41:54.857627Z",
-     "iopub.status.idle": "2026-08-25T22:41:56.656545Z",
-     "shell.execute_reply": "2026-08-25T22:41:56.655890Z"
+     "iopub.execute_input": "2026-09-02T17:36:55.788958Z",
+     "iopub.status.busy": "2026-09-02T17:36:55.788737Z",
+     "iopub.status.idle": "2026-09-02T17:36:55.825845Z",
+     "shell.execute_reply": "2026-09-02T17:36:55.821639Z"
     },
     "papermill": {
-     "duration": 1.800899,
-     "end_time": "2026-08-25T22:41:56.657080+00:00",
+     "duration": 0.04882,
+     "end_time": "2026-09-02T17:36:55.828187+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:54.856181+00:00",
+     "start_time": "2026-09-02T17:36:55.779367+00:00",
      "status": "completed"
     }
    },
@@ -176,13 +177,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c731fb25",
+   "id": "db67c63b",
    "metadata": {
     "papermill": {
-     "duration": 0.001874,
-     "end_time": "2026-08-25T22:41:56.660487+00:00",
+     "duration": 0.0062,
+     "end_time": "2026-09-02T17:36:55.843672+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:56.658613+00:00",
+     "start_time": "2026-09-02T17:36:55.837472+00:00",
      "status": "completed"
     }
    },
@@ -206,19 +207,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "991961bc",
+   "id": "e23efa29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:56.663867Z",
-     "iopub.status.busy": "2026-08-25T22:41:56.663689Z",
-     "iopub.status.idle": "2026-08-25T22:41:56.693640Z",
-     "shell.execute_reply": "2026-08-25T22:41:56.693065Z"
+     "iopub.execute_input": "2026-09-02T17:36:55.860425Z",
+     "iopub.status.busy": "2026-09-02T17:36:55.859025Z",
+     "iopub.status.idle": "2026-09-02T17:36:55.934979Z",
+     "shell.execute_reply": "2026-09-02T17:36:55.934206Z"
     },
     "papermill": {
-     "duration": 0.032494,
-     "end_time": "2026-08-25T22:41:56.694180+00:00",
+     "duration": 0.091994,
+     "end_time": "2026-09-02T17:36:55.942733+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:56.661686+00:00",
+     "start_time": "2026-09-02T17:36:55.850739+00:00",
      "status": "completed"
     }
    },
@@ -244,13 +245,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b256ba33",
+   "id": "e89f68ba",
    "metadata": {
     "papermill": {
-     "duration": 0.00196,
-     "end_time": "2026-08-25T22:41:56.698631+00:00",
+     "duration": 0.005968,
+     "end_time": "2026-09-02T17:36:55.960683+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:56.696671+00:00",
+     "start_time": "2026-09-02T17:36:55.954715+00:00",
      "status": "completed"
     }
    },
@@ -280,19 +281,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "bafe66da",
+   "id": "7b144bfd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:56.703606Z",
-     "iopub.status.busy": "2026-08-25T22:41:56.703452Z",
-     "iopub.status.idle": "2026-08-25T22:41:56.757158Z",
-     "shell.execute_reply": "2026-08-25T22:41:56.756518Z"
+     "iopub.execute_input": "2026-09-02T17:36:55.979191Z",
+     "iopub.status.busy": "2026-09-02T17:36:55.978861Z",
+     "iopub.status.idle": "2026-09-02T17:36:56.193022Z",
+     "shell.execute_reply": "2026-09-02T17:36:56.192403Z"
     },
     "papermill": {
-     "duration": 0.057022,
-     "end_time": "2026-08-25T22:41:56.757674+00:00",
+     "duration": 0.23295,
+     "end_time": "2026-09-02T17:36:56.199766+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:56.700652+00:00",
+     "start_time": "2026-09-02T17:36:55.966816+00:00",
      "status": "completed"
     }
    },
@@ -357,13 +358,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f832bea6",
+   "id": "6e020c16",
    "metadata": {
     "papermill": {
-     "duration": 0.0018,
-     "end_time": "2026-08-25T22:41:56.762003+00:00",
+     "duration": 0.008913,
+     "end_time": "2026-09-02T17:36:56.217859+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:56.760203+00:00",
+     "start_time": "2026-09-02T17:36:56.208946+00:00",
      "status": "completed"
     }
    },
@@ -379,41 +380,42 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "40b39dfa",
+   "id": "0f8fd58f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:56.765486Z",
-     "iopub.status.busy": "2026-08-25T22:41:56.765321Z",
-     "iopub.status.idle": "2026-08-25T22:41:56.821185Z",
-     "shell.execute_reply": "2026-08-25T22:41:56.820714Z"
+     "iopub.execute_input": "2026-09-02T17:36:56.250562Z",
+     "iopub.status.busy": "2026-09-02T17:36:56.250258Z",
+     "iopub.status.idle": "2026-09-02T17:36:56.437966Z",
+     "shell.execute_reply": "2026-09-02T17:36:56.437235Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.0587,
-     "end_time": "2026-08-25T22:41:56.821974+00:00",
+     "duration": 0.20709,
+     "end_time": "2026-09-02T17:36:56.441346+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:56.763274+00:00",
+     "start_time": "2026-09-02T17:36:56.234256+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "if configs.height < load_model_configs(study, \"linear\").height and not POPULATION_NAME:\n",
+    "if narrows_declared_catalog(study, \"linear\", configs) and not POPULATION_NAME:\n",
     "    raise ValueError(\n",
-    "        f\"this run fits {configs.height} of the declared configurations, so it cannot publish \"\n",
-    "        \"the canonical population; pass POPULATION_NAME to give it its own\"\n",
+    "        f\"this run declares {configs.height} label-configuration pairs, which is not the \"\n",
+    "        \"complete declared catalog, so it cannot publish the canonical population; pass \"\n",
+    "        \"POPULATION_NAME to give it its own\"\n",
     "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "58445859",
+   "id": "d71b79e4",
    "metadata": {
     "papermill": {
-     "duration": 0.001306,
-     "end_time": "2026-08-25T22:41:56.824908+00:00",
+     "duration": 0.010647,
+     "end_time": "2026-09-02T17:36:56.461997+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:56.823602+00:00",
+     "start_time": "2026-09-02T17:36:56.451350+00:00",
      "status": "completed"
     }
    },
@@ -450,19 +452,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "1c142ae5",
+   "id": "c56fab37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:56.828010Z",
-     "iopub.status.busy": "2026-08-25T22:41:56.827927Z",
-     "iopub.status.idle": "2026-08-25T22:42:27.276771Z",
-     "shell.execute_reply": "2026-08-25T22:42:27.276063Z"
+     "iopub.execute_input": "2026-09-02T17:36:56.498310Z",
+     "iopub.status.busy": "2026-09-02T17:36:56.497986Z",
+     "iopub.status.idle": "2026-09-02T17:38:24.232875Z",
+     "shell.execute_reply": "2026-09-02T17:38:24.232502Z"
     },
     "papermill": {
-     "duration": 30.452211,
-     "end_time": "2026-08-25T22:42:27.278409+00:00",
+     "duration": 87.759592,
+     "end_time": "2026-09-02T17:38:24.237503+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:56.826198+00:00",
+     "start_time": "2026-09-02T17:36:56.477911+00:00",
      "status": "completed"
     }
    },
@@ -538,13 +540,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1566894a",
+   "id": "b56cf06e",
    "metadata": {
     "papermill": {
-     "duration": 0.001234,
-     "end_time": "2026-08-25T22:42:27.281103+00:00",
+     "duration": 0.001382,
+     "end_time": "2026-09-02T17:38:24.240632+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:27.279869+00:00",
+     "start_time": "2026-09-02T17:38:24.239250+00:00",
      "status": "completed"
     }
    },
@@ -586,19 +588,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "308d2519",
+   "id": "b455b445",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:42:27.284513Z",
-     "iopub.status.busy": "2026-08-25T22:42:27.284390Z",
-     "iopub.status.idle": "2026-08-25T22:42:30.164693Z",
-     "shell.execute_reply": "2026-08-25T22:42:30.163889Z"
+     "iopub.execute_input": "2026-09-02T17:38:24.243805Z",
+     "iopub.status.busy": "2026-09-02T17:38:24.243686Z",
+     "iopub.status.idle": "2026-09-02T17:38:26.764697Z",
+     "shell.execute_reply": "2026-09-02T17:38:26.764223Z"
     },
     "papermill": {
-     "duration": 2.885887,
-     "end_time": "2026-08-25T22:42:30.168276+00:00",
+     "duration": 2.523328,
+     "end_time": "2026-09-02T17:38:26.765275+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:27.282389+00:00",
+     "start_time": "2026-09-02T17:38:24.241947+00:00",
      "status": "completed"
     }
    },
@@ -626,13 +628,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "546b5e25",
+   "id": "9ed44273",
    "metadata": {
     "papermill": {
-     "duration": 0.003617,
-     "end_time": "2026-08-25T22:42:30.177968+00:00",
+     "duration": 0.001331,
+     "end_time": "2026-09-02T17:38:26.768190+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:30.174351+00:00",
+     "start_time": "2026-09-02T17:38:26.766859+00:00",
      "status": "completed"
     }
    },
@@ -672,13 +674,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb5e88a6",
+   "id": "fd8de203",
    "metadata": {
     "papermill": {
-     "duration": 0.003203,
-     "end_time": "2026-08-25T22:42:30.184644+00:00",
+     "duration": 0.001507,
+     "end_time": "2026-09-02T17:38:26.771066+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:30.181441+00:00",
+     "start_time": "2026-09-02T17:38:26.769559+00:00",
      "status": "completed"
     }
    },
@@ -710,19 +712,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "55f4edf6",
+   "id": "cb76b89e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:42:30.201534Z",
-     "iopub.status.busy": "2026-08-25T22:42:30.200945Z",
-     "iopub.status.idle": "2026-08-25T22:42:30.237163Z",
-     "shell.execute_reply": "2026-08-25T22:42:30.236181Z"
+     "iopub.execute_input": "2026-09-02T17:38:26.774256Z",
+     "iopub.status.busy": "2026-09-02T17:38:26.774179Z",
+     "iopub.status.idle": "2026-09-02T17:38:26.791029Z",
+     "shell.execute_reply": "2026-09-02T17:38:26.790755Z"
     },
     "papermill": {
-     "duration": 0.047512,
-     "end_time": "2026-08-25T22:42:30.237768+00:00",
+     "duration": 0.01901,
+     "end_time": "2026-09-02T17:38:26.791404+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:30.190256+00:00",
+     "start_time": "2026-09-02T17:38:26.772394+00:00",
      "status": "completed"
     },
     "tags": [
@@ -849,13 +851,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aaca7e56",
+   "id": "e0c1d78a",
    "metadata": {
     "papermill": {
-     "duration": 0.004533,
-     "end_time": "2026-08-25T22:42:30.245995+00:00",
+     "duration": 0.001267,
+     "end_time": "2026-09-02T17:38:26.794110+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:30.241462+00:00",
+     "start_time": "2026-09-02T17:38:26.792843+00:00",
      "status": "completed"
     }
    },
@@ -889,19 +891,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "0b1b8620",
+   "id": "7ea08a21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:42:30.257797Z",
-     "iopub.status.busy": "2026-08-25T22:42:30.257479Z",
-     "iopub.status.idle": "2026-08-25T22:42:30.267521Z",
-     "shell.execute_reply": "2026-08-25T22:42:30.266759Z"
+     "iopub.execute_input": "2026-09-02T17:38:26.797214Z",
+     "iopub.status.busy": "2026-09-02T17:38:26.797117Z",
+     "iopub.status.idle": "2026-09-02T17:38:26.800831Z",
+     "shell.execute_reply": "2026-09-02T17:38:26.800491Z"
     },
     "papermill": {
-     "duration": 0.017242,
-     "end_time": "2026-08-25T22:42:30.268046+00:00",
+     "duration": 0.005853,
+     "end_time": "2026-09-02T17:38:26.801282+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:30.250804+00:00",
+     "start_time": "2026-09-02T17:38:26.795429+00:00",
      "status": "completed"
     },
     "tags": [
@@ -970,14 +972,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64dc9357",
+   "id": "9fca1262",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008054,
-     "end_time": "2026-08-25T22:42:30.280462+00:00",
+     "duration": 0.001329,
+     "end_time": "2026-09-02T17:38:26.805085+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:30.272408+00:00",
+     "start_time": "2026-09-02T17:38:26.803756+00:00",
      "status": "completed"
     }
    },
@@ -996,19 +998,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "47cd86f3",
+   "id": "ff39c91d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:42:30.295273Z",
-     "iopub.status.busy": "2026-08-25T22:42:30.295141Z",
-     "iopub.status.idle": "2026-08-25T22:42:32.283197Z",
-     "shell.execute_reply": "2026-08-25T22:42:32.282673Z"
+     "iopub.execute_input": "2026-09-02T17:38:26.808363Z",
+     "iopub.status.busy": "2026-09-02T17:38:26.808294Z",
+     "iopub.status.idle": "2026-09-02T17:38:28.278424Z",
+     "shell.execute_reply": "2026-09-02T17:38:28.278150Z"
     },
     "papermill": {
-     "duration": 1.995517,
-     "end_time": "2026-08-25T22:42:32.284819+00:00",
+     "duration": 1.472593,
+     "end_time": "2026-09-02T17:38:28.279050+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:30.289302+00:00",
+     "start_time": "2026-09-02T17:38:26.806457+00:00",
      "status": "completed"
     }
    },
@@ -1849,13 +1851,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99587394",
+   "id": "835c04ec",
    "metadata": {
     "papermill": {
-     "duration": 0.004955,
-     "end_time": "2026-08-25T22:42:32.295691+00:00",
+     "duration": 0.002491,
+     "end_time": "2026-09-02T17:38:28.284186+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:32.290736+00:00",
+     "start_time": "2026-09-02T17:38:28.281695+00:00",
      "status": "completed"
     }
    },
@@ -1872,19 +1874,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "233a3c62",
+   "id": "37927a05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:42:32.308609Z",
-     "iopub.status.busy": "2026-08-25T22:42:32.308306Z",
-     "iopub.status.idle": "2026-08-25T22:42:34.248813Z",
-     "shell.execute_reply": "2026-08-25T22:42:34.247741Z"
+     "iopub.execute_input": "2026-09-02T17:38:28.289427Z",
+     "iopub.status.busy": "2026-09-02T17:38:28.289325Z",
+     "iopub.status.idle": "2026-09-02T17:38:29.787275Z",
+     "shell.execute_reply": "2026-09-02T17:38:29.785323Z"
     },
     "papermill": {
-     "duration": 1.948501,
-     "end_time": "2026-08-25T22:42:34.249463+00:00",
+     "duration": 1.504329,
+     "end_time": "2026-09-02T17:38:29.790796+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:32.300962+00:00",
+     "start_time": "2026-09-02T17:38:28.286467+00:00",
      "status": "completed"
     }
    },
@@ -2258,13 +2260,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b171ca86",
+   "id": "add43ac3",
    "metadata": {
     "papermill": {
-     "duration": 0.003092,
-     "end_time": "2026-08-25T22:42:34.258002+00:00",
+     "duration": 0.00467,
+     "end_time": "2026-09-02T17:38:29.809389+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:42:34.254910+00:00",
+     "start_time": "2026-09-02T17:38:29.804719+00:00",
      "status": "completed"
     }
    },
@@ -2352,22 +2354,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-08-25T22:42:45.104678+00:00",
+   "executed_at": "2026-09-02T17:38:37.700474+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "c3c9edc7b538dc31298dc27027f4232e19d60f00"
+   "source_py_blob": "25b92a87b4a71153146710b542139b4c95c2ea3b"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 46.181945,
-   "end_time": "2026-08-25T22:42:37.635614+00:00",
+   "duration": 105.612289,
+   "end_time": "2026-09-02T17:38:32.272980+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/06_linear.ipynb",
-   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/.06_linear.papermill.3993382.ipynb",
+   "input_path": "~/ml4t/public-catalog-guard/case_studies/sp500_equity_option_analytics/06_linear.ipynb",
+   "output_path": "~/ml4t/public-catalog-guard/case_studies/sp500_equity_option_analytics/.06_linear.papermill.139346.ipynb",
    "parameters": {},
-   "start_time": "2026-08-25T22:41:51.453669+00:00",
+   "start_time": "2026-09-02T17:36:46.660691+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/06_linear.py
+++ b/case_studies/sp500_equity_option_analytics/06_linear.py
@@ -84,6 +84,7 @@ from case_studies.research import (
     declared_labels,
     load_model_configs,
     model_requests,
+    narrows_declared_catalog,
     open_study,
     primary_label,
     resolved_model_plan,
@@ -167,10 +168,11 @@ configs
 # either knob, and says so here rather than several cells later in a message about hashes.
 
 # %%
-if configs.height < load_model_configs(study, "linear").height and not POPULATION_NAME:
+if narrows_declared_catalog(study, "linear", configs) and not POPULATION_NAME:
     raise ValueError(
-        f"this run fits {configs.height} of the declared configurations, so it cannot publish "
-        "the canonical population; pass POPULATION_NAME to give it its own"
+        f"this run declares {configs.height} label-configuration pairs, which is not the "
+        "complete declared catalog, so it cannot publish the canonical population; pass "
+        "POPULATION_NAME to give it its own"
     )
 
 

--- a/case_studies/sp500_equity_option_analytics/07_gbm.ipynb
+++ b/case_studies/sp500_equity_option_analytics/07_gbm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "93ecf0b1",
+   "id": "567f5b45",
    "metadata": {
     "papermill": {
-     "duration": 0.002493,
-     "end_time": "2026-08-25T22:41:53.241648+00:00",
+     "duration": 0.00149,
+     "end_time": "2026-09-02T17:38:40.270482+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:53.239155+00:00",
+     "start_time": "2026-09-02T17:38:40.268992+00:00",
      "status": "completed"
     }
    },
@@ -78,19 +78,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "c0dcbad9",
+   "id": "561494ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:53.246820Z",
-     "iopub.status.busy": "2026-08-25T22:41:53.246705Z",
-     "iopub.status.idle": "2026-08-25T22:41:55.889356Z",
-     "shell.execute_reply": "2026-08-25T22:41:55.888767Z"
+     "iopub.execute_input": "2026-09-02T17:38:40.273751Z",
+     "iopub.status.busy": "2026-09-02T17:38:40.273551Z",
+     "iopub.status.idle": "2026-09-02T17:38:42.591028Z",
+     "shell.execute_reply": "2026-09-02T17:38:42.590513Z"
     },
     "papermill": {
-     "duration": 2.646391,
-     "end_time": "2026-08-25T22:41:55.890195+00:00",
+     "duration": 2.320039,
+     "end_time": "2026-09-02T17:38:42.591779+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:53.243804+00:00",
+     "start_time": "2026-09-02T17:38:40.271740+00:00",
      "status": "completed"
     }
    },
@@ -107,6 +107,7 @@
     "    declared_labels,\n",
     "    load_model_configs,\n",
     "    model_requests,\n",
+    "    narrows_declared_catalog,\n",
     "    open_study,\n",
     "    primary_label,\n",
     "    resolved_model_plan,\n",
@@ -118,19 +119,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "679fb070",
+   "id": "633ba60b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:55.896662Z",
-     "iopub.status.busy": "2026-08-25T22:41:55.896322Z",
-     "iopub.status.idle": "2026-08-25T22:41:55.899347Z",
-     "shell.execute_reply": "2026-08-25T22:41:55.898831Z"
+     "iopub.execute_input": "2026-09-02T17:38:42.595895Z",
+     "iopub.status.busy": "2026-09-02T17:38:42.595701Z",
+     "iopub.status.idle": "2026-09-02T17:38:42.597919Z",
+     "shell.execute_reply": "2026-09-02T17:38:42.597586Z"
     },
     "papermill": {
-     "duration": 0.00828,
-     "end_time": "2026-08-25T22:41:55.901352+00:00",
+     "duration": 0.004335,
+     "end_time": "2026-09-02T17:38:42.598276+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:55.893072+00:00",
+     "start_time": "2026-09-02T17:38:42.593941+00:00",
      "status": "completed"
     },
     "tags": [
@@ -151,19 +152,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "195b0b2c",
+   "id": "d04bc02b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:55.907611Z",
-     "iopub.status.busy": "2026-08-25T22:41:55.907467Z",
-     "iopub.status.idle": "2026-08-25T22:41:57.690822Z",
-     "shell.execute_reply": "2026-08-25T22:41:57.690370Z"
+     "iopub.execute_input": "2026-09-02T17:38:42.601167Z",
+     "iopub.status.busy": "2026-09-02T17:38:42.601089Z",
+     "iopub.status.idle": "2026-09-02T17:38:43.572946Z",
+     "shell.execute_reply": "2026-09-02T17:38:43.572402Z"
     },
     "papermill": {
-     "duration": 1.787407,
-     "end_time": "2026-08-25T22:41:57.691766+00:00",
+     "duration": 0.974012,
+     "end_time": "2026-09-02T17:38:43.573442+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:55.904359+00:00",
+     "start_time": "2026-09-02T17:38:42.599430+00:00",
      "status": "completed"
     }
    },
@@ -179,13 +180,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14202a33",
+   "id": "ed342712",
    "metadata": {
     "papermill": {
-     "duration": 0.002024,
-     "end_time": "2026-08-25T22:41:57.696288+00:00",
+     "duration": 0.001066,
+     "end_time": "2026-09-02T17:38:43.575811+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:57.694264+00:00",
+     "start_time": "2026-09-02T17:38:43.574745+00:00",
      "status": "completed"
     }
    },
@@ -202,19 +203,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "bfd259fd",
+   "id": "bcd291ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:57.701762Z",
-     "iopub.status.busy": "2026-08-25T22:41:57.701412Z",
-     "iopub.status.idle": "2026-08-25T22:41:57.729981Z",
-     "shell.execute_reply": "2026-08-25T22:41:57.729533Z"
+     "iopub.execute_input": "2026-09-02T17:38:43.578889Z",
+     "iopub.status.busy": "2026-09-02T17:38:43.578718Z",
+     "iopub.status.idle": "2026-09-02T17:38:43.594915Z",
+     "shell.execute_reply": "2026-09-02T17:38:43.594519Z"
     },
     "papermill": {
-     "duration": 0.03209,
-     "end_time": "2026-08-25T22:41:57.730500+00:00",
+     "duration": 0.018274,
+     "end_time": "2026-09-02T17:38:43.595218+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:57.698410+00:00",
+     "start_time": "2026-09-02T17:38:43.576944+00:00",
      "status": "completed"
     }
    },
@@ -240,13 +241,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52d76b6f",
+   "id": "ac2ef895",
    "metadata": {
     "papermill": {
-     "duration": 0.002068,
-     "end_time": "2026-08-25T22:41:57.735010+00:00",
+     "duration": 0.001138,
+     "end_time": "2026-09-02T17:38:43.597736+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:57.732942+00:00",
+     "start_time": "2026-09-02T17:38:43.596598+00:00",
      "status": "completed"
     }
    },
@@ -271,19 +272,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "8b6cfbcd",
+   "id": "b32465f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:57.740104Z",
-     "iopub.status.busy": "2026-08-25T22:41:57.740011Z",
-     "iopub.status.idle": "2026-08-25T22:41:57.794227Z",
-     "shell.execute_reply": "2026-08-25T22:41:57.793727Z"
+     "iopub.execute_input": "2026-09-02T17:38:43.600715Z",
+     "iopub.status.busy": "2026-09-02T17:38:43.600628Z",
+     "iopub.status.idle": "2026-09-02T17:38:43.643407Z",
+     "shell.execute_reply": "2026-09-02T17:38:43.642929Z"
     },
     "papermill": {
-     "duration": 0.057768,
-     "end_time": "2026-08-25T22:41:57.794898+00:00",
+     "duration": 0.045033,
+     "end_time": "2026-09-02T17:38:43.643909+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:57.737130+00:00",
+     "start_time": "2026-09-02T17:38:43.598876+00:00",
      "status": "completed"
     }
    },
@@ -338,13 +339,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12cb82b1",
+   "id": "d04da957",
    "metadata": {
     "papermill": {
-     "duration": 0.002133,
-     "end_time": "2026-08-25T22:41:57.799611+00:00",
+     "duration": 0.001254,
+     "end_time": "2026-09-02T17:38:43.646642+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:57.797478+00:00",
+     "start_time": "2026-09-02T17:38:43.645388+00:00",
      "status": "completed"
     }
    },
@@ -360,41 +361,42 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "cbea4120",
+   "id": "1a97de99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:57.804990Z",
-     "iopub.status.busy": "2026-08-25T22:41:57.804841Z",
-     "iopub.status.idle": "2026-08-25T22:41:57.860200Z",
-     "shell.execute_reply": "2026-08-25T22:41:57.859308Z"
+     "iopub.execute_input": "2026-09-02T17:38:43.650252Z",
+     "iopub.status.busy": "2026-09-02T17:38:43.650039Z",
+     "iopub.status.idle": "2026-09-02T17:38:43.693284Z",
+     "shell.execute_reply": "2026-09-02T17:38:43.692781Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.05915,
-     "end_time": "2026-08-25T22:41:57.860992+00:00",
+     "duration": 0.046055,
+     "end_time": "2026-09-02T17:38:43.693993+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:57.801842+00:00",
+     "start_time": "2026-09-02T17:38:43.647938+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "if configs.height < load_model_configs(study, \"gbm\").height and not POPULATION_NAME:\n",
+    "if narrows_declared_catalog(study, \"gbm\", configs) and not POPULATION_NAME:\n",
     "    raise ValueError(\n",
-    "        f\"this run fits {configs.height} of the declared configurations, so it cannot publish \"\n",
-    "        \"the canonical population; pass POPULATION_NAME to give it its own\"\n",
+    "        f\"this run declares {configs.height} label-configuration pairs, which is not the \"\n",
+    "        \"complete declared catalog, so it cannot publish the canonical population; pass \"\n",
+    "        \"POPULATION_NAME to give it its own\"\n",
     "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7ecad63d",
+   "id": "274d4505",
    "metadata": {
     "papermill": {
-     "duration": 0.002206,
-     "end_time": "2026-08-25T22:41:57.865928+00:00",
+     "duration": 0.001304,
+     "end_time": "2026-09-02T17:38:43.696775+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:57.863722+00:00",
+     "start_time": "2026-09-02T17:38:43.695471+00:00",
      "status": "completed"
     }
    },
@@ -421,19 +423,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a0303236",
+   "id": "368de00e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:41:57.872044Z",
-     "iopub.status.busy": "2026-08-25T22:41:57.871861Z",
-     "iopub.status.idle": "2026-08-25T22:43:13.077666Z",
-     "shell.execute_reply": "2026-08-25T22:43:13.076755Z"
+     "iopub.execute_input": "2026-09-02T17:38:43.700209Z",
+     "iopub.status.busy": "2026-09-02T17:38:43.700034Z",
+     "iopub.status.idle": "2026-09-02T17:39:32.906428Z",
+     "shell.execute_reply": "2026-09-02T17:39:32.905983Z"
     },
     "papermill": {
-     "duration": 75.213151,
-     "end_time": "2026-08-25T22:43:13.081497+00:00",
+     "duration": 49.211277,
+     "end_time": "2026-09-02T17:39:32.909313+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:41:57.868346+00:00",
+     "start_time": "2026-09-02T17:38:43.698036+00:00",
      "status": "completed"
     }
    },
@@ -511,13 +513,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62750b65",
+   "id": "7f2b813a",
    "metadata": {
     "papermill": {
-     "duration": 0.002442,
-     "end_time": "2026-08-25T22:43:13.086500+00:00",
+     "duration": 0.00118,
+     "end_time": "2026-09-02T17:39:32.912317+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:13.084058+00:00",
+     "start_time": "2026-09-02T17:39:32.911137+00:00",
      "status": "completed"
     }
    },
@@ -558,19 +560,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "95bc11f5",
+   "id": "81b5afb5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:43:13.091190Z",
-     "iopub.status.busy": "2026-08-25T22:43:13.091067Z",
-     "iopub.status.idle": "2026-08-25T22:43:22.549703Z",
-     "shell.execute_reply": "2026-08-25T22:43:22.549372Z"
+     "iopub.execute_input": "2026-09-02T17:39:32.915449Z",
+     "iopub.status.busy": "2026-09-02T17:39:32.915351Z",
+     "iopub.status.idle": "2026-09-02T17:39:41.377284Z",
+     "shell.execute_reply": "2026-09-02T17:39:41.376774Z"
     },
     "papermill": {
-     "duration": 9.461336,
-     "end_time": "2026-08-25T22:43:22.550227+00:00",
+     "duration": 8.464073,
+     "end_time": "2026-09-02T17:39:41.377649+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:13.088891+00:00",
+     "start_time": "2026-09-02T17:39:32.913576+00:00",
      "status": "completed"
     }
    },
@@ -596,13 +598,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ebdd81e",
+   "id": "0905ce0e",
    "metadata": {
     "papermill": {
-     "duration": 0.0015,
-     "end_time": "2026-08-25T22:43:22.553461+00:00",
+     "duration": 0.00166,
+     "end_time": "2026-09-02T17:39:41.380775+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:22.551961+00:00",
+     "start_time": "2026-09-02T17:39:41.379115+00:00",
      "status": "completed"
     }
    },
@@ -635,13 +637,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "874dae3d",
+   "id": "367d49ff",
    "metadata": {
     "papermill": {
-     "duration": 0.001265,
-     "end_time": "2026-08-25T22:43:22.556206+00:00",
+     "duration": 0.001191,
+     "end_time": "2026-09-02T17:39:41.383219+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:22.554941+00:00",
+     "start_time": "2026-09-02T17:39:41.382028+00:00",
      "status": "completed"
     }
    },
@@ -675,19 +677,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "3e5c2878",
+   "id": "b6a375e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:43:22.560870Z",
-     "iopub.status.busy": "2026-08-25T22:43:22.560641Z",
-     "iopub.status.idle": "2026-08-25T22:43:22.587171Z",
-     "shell.execute_reply": "2026-08-25T22:43:22.586660Z"
+     "iopub.execute_input": "2026-09-02T17:39:41.386224Z",
+     "iopub.status.busy": "2026-09-02T17:39:41.386151Z",
+     "iopub.status.idle": "2026-09-02T17:39:41.407637Z",
+     "shell.execute_reply": "2026-09-02T17:39:41.407253Z"
     },
     "papermill": {
-     "duration": 0.029485,
-     "end_time": "2026-08-25T22:43:22.587582+00:00",
+     "duration": 0.02349,
+     "end_time": "2026-09-02T17:39:41.407949+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:22.558097+00:00",
+     "start_time": "2026-09-02T17:39:41.384459+00:00",
      "status": "completed"
     },
     "tags": [
@@ -795,13 +797,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecebfa81",
+   "id": "1f674fd1",
    "metadata": {
     "papermill": {
-     "duration": 0.001493,
-     "end_time": "2026-08-25T22:43:22.590797+00:00",
+     "duration": 0.001324,
+     "end_time": "2026-09-02T17:39:41.410839+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:22.589304+00:00",
+     "start_time": "2026-09-02T17:39:41.409515+00:00",
      "status": "completed"
     }
    },
@@ -829,19 +831,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "afb4547d",
+   "id": "d13520fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:43:22.594696Z",
-     "iopub.status.busy": "2026-08-25T22:43:22.594538Z",
-     "iopub.status.idle": "2026-08-25T22:43:22.600162Z",
-     "shell.execute_reply": "2026-08-25T22:43:22.599659Z"
+     "iopub.execute_input": "2026-09-02T17:39:41.414076Z",
+     "iopub.status.busy": "2026-09-02T17:39:41.413987Z",
+     "iopub.status.idle": "2026-09-02T17:39:41.417792Z",
+     "shell.execute_reply": "2026-09-02T17:39:41.417515Z"
     },
     "papermill": {
-     "duration": 0.008399,
-     "end_time": "2026-08-25T22:43:22.600764+00:00",
+     "duration": 0.005986,
+     "end_time": "2026-09-02T17:39:41.418173+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:22.592365+00:00",
+     "start_time": "2026-09-02T17:39:41.412187+00:00",
      "status": "completed"
     },
     "tags": [
@@ -911,13 +913,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ea759a4",
+   "id": "5e095e7b",
    "metadata": {
     "papermill": {
-     "duration": 0.002778,
-     "end_time": "2026-08-25T22:43:22.606733+00:00",
+     "duration": 0.001317,
+     "end_time": "2026-09-02T17:39:41.420911+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:22.603955+00:00",
+     "start_time": "2026-09-02T17:39:41.419594+00:00",
      "status": "completed"
     }
    },
@@ -938,19 +940,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "63274c8f",
+   "id": "23912ec0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:43:22.613108Z",
-     "iopub.status.busy": "2026-08-25T22:43:22.612934Z",
-     "iopub.status.idle": "2026-08-25T22:43:24.590021Z",
-     "shell.execute_reply": "2026-08-25T22:43:24.589244Z"
+     "iopub.execute_input": "2026-09-02T17:39:41.424442Z",
+     "iopub.status.busy": "2026-09-02T17:39:41.424352Z",
+     "iopub.status.idle": "2026-09-02T17:39:42.931219Z",
+     "shell.execute_reply": "2026-09-02T17:39:42.929278Z"
     },
     "papermill": {
-     "duration": 1.985912,
-     "end_time": "2026-08-25T22:43:24.595429+00:00",
+     "duration": 1.52122,
+     "end_time": "2026-09-02T17:39:42.943554+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:22.609517+00:00",
+     "start_time": "2026-09-02T17:39:41.422334+00:00",
      "status": "completed"
     }
    },
@@ -3475,13 +3477,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3b9e730",
+   "id": "3fbb1d60",
    "metadata": {
     "papermill": {
-     "duration": 0.013064,
-     "end_time": "2026-08-25T22:43:24.625869+00:00",
+     "duration": 0.010435,
+     "end_time": "2026-09-02T17:39:42.977597+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:24.612805+00:00",
+     "start_time": "2026-09-02T17:39:42.967162+00:00",
      "status": "completed"
     }
    },
@@ -3503,19 +3505,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "deb5a951",
+   "id": "1497f68f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:43:24.657310Z",
-     "iopub.status.busy": "2026-08-25T22:43:24.657077Z",
-     "iopub.status.idle": "2026-08-25T22:43:26.980289Z",
-     "shell.execute_reply": "2026-08-25T22:43:26.979713Z"
+     "iopub.execute_input": "2026-09-02T17:39:42.989350Z",
+     "iopub.status.busy": "2026-09-02T17:39:42.989243Z",
+     "iopub.status.idle": "2026-09-02T17:39:44.413209Z",
+     "shell.execute_reply": "2026-09-02T17:39:44.410472Z"
     },
     "papermill": {
-     "duration": 2.341323,
-     "end_time": "2026-08-25T22:43:26.982793+00:00",
+     "duration": 1.433538,
+     "end_time": "2026-09-02T17:39:44.415611+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:24.641470+00:00",
+     "start_time": "2026-09-02T17:39:42.982073+00:00",
      "status": "completed"
     }
    },
@@ -4188,13 +4190,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0d2e896",
+   "id": "bd489bd4",
    "metadata": {
     "papermill": {
-     "duration": 0.016093,
-     "end_time": "2026-08-25T22:43:27.015333+00:00",
+     "duration": 0.00494,
+     "end_time": "2026-09-02T17:39:44.437308+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:26.999240+00:00",
+     "start_time": "2026-09-02T17:39:44.432368+00:00",
      "status": "completed"
     }
    },
@@ -4212,19 +4214,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "30fad792",
+   "id": "e1445853",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-25T22:43:27.045436Z",
-     "iopub.status.busy": "2026-08-25T22:43:27.045231Z",
-     "iopub.status.idle": "2026-08-25T22:43:27.054863Z",
-     "shell.execute_reply": "2026-08-25T22:43:27.053771Z"
+     "iopub.execute_input": "2026-09-02T17:39:44.447490Z",
+     "iopub.status.busy": "2026-09-02T17:39:44.447367Z",
+     "iopub.status.idle": "2026-09-02T17:39:44.453501Z",
+     "shell.execute_reply": "2026-09-02T17:39:44.453150Z"
     },
     "papermill": {
-     "duration": 0.025486,
-     "end_time": "2026-08-25T22:43:27.055994+00:00",
+     "duration": 0.011867,
+     "end_time": "2026-09-02T17:39:44.453834+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:27.030508+00:00",
+     "start_time": "2026-09-02T17:39:44.441967+00:00",
      "status": "completed"
     },
     "tags": [
@@ -4302,13 +4304,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c87d121",
+   "id": "805ff179",
    "metadata": {
     "papermill": {
-     "duration": 0.013384,
-     "end_time": "2026-08-25T22:43:27.083073+00:00",
+     "duration": 0.004599,
+     "end_time": "2026-09-02T17:39:44.463311+00:00",
      "exception": false,
-     "start_time": "2026-08-25T22:43:27.069689+00:00",
+     "start_time": "2026-09-02T17:39:44.458712+00:00",
      "status": "completed"
     }
    },
@@ -4394,22 +4396,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-08-25T22:43:36.724869+00:00",
+   "executed_at": "2026-09-02T17:39:51.952512+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "2d613f870a2a8d0f905d3b58758babe82d32b075"
+   "source_py_blob": "c3ce38c641a7ad408e68dbbcc031ffade0414834"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 98.24294,
-   "end_time": "2026-08-25T22:43:30.813848+00:00",
+   "duration": 67.163866,
+   "end_time": "2026-09-02T17:39:46.784241+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/07_gbm.ipynb",
-   "output_path": "~/ml4t/public-s6-sp500_equity_option_analytics/case_studies/sp500_equity_option_analytics/.07_gbm.papermill.3993495.ipynb",
+   "input_path": "~/ml4t/public-catalog-guard/case_studies/sp500_equity_option_analytics/07_gbm.ipynb",
+   "output_path": "~/ml4t/public-catalog-guard/case_studies/sp500_equity_option_analytics/.07_gbm.papermill.149964.ipynb",
    "parameters": {},
-   "start_time": "2026-08-25T22:41:52.570908+00:00",
+   "start_time": "2026-09-02T17:38:39.620375+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/07_gbm.py
+++ b/case_studies/sp500_equity_option_analytics/07_gbm.py
@@ -87,6 +87,7 @@ from case_studies.research import (
     declared_labels,
     load_model_configs,
     model_requests,
+    narrows_declared_catalog,
     open_study,
     primary_label,
     resolved_model_plan,
@@ -158,10 +159,11 @@ configs
 # either knob, and says so here rather than several cells later in a message about hashes.
 
 # %%
-if configs.height < load_model_configs(study, "gbm").height and not POPULATION_NAME:
+if narrows_declared_catalog(study, "gbm", configs) and not POPULATION_NAME:
     raise ValueError(
-        f"this run fits {configs.height} of the declared configurations, so it cannot publish "
-        "the canonical population; pass POPULATION_NAME to give it its own"
+        f"this run declares {configs.height} label-configuration pairs, which is not the "
+        "complete declared catalog, so it cannot publish the canonical population; pass "
+        "POPULATION_NAME to give it its own"
     )
 
 


### PR DESCRIPTION
`06_linear` and `07_gbm` in `cme_futures` and `sp500_equity_option_analytics` were the last four notebooks refusing to publish the canonical population on a height comparison:

    if configs.height < load_model_configs(study, "linear").height and not POPULATION_NAME:

A height comparison answers a different question from the one the surrounding markdown already states. It passes any run that loads the same *number* of label-configuration pairs as the declared catalog while loading a different *set* - which is what `LABELS` and `CONFIG_NAMES` produce when one narrows and the other widens. That run then registers an incomplete snapshot under the canonical name on a fresh workspace, or is refused several cells later in a message about hashes rather than here.

`narrows_declared_catalog` compares the loaded pairs against the complete catalog as sets, so it catches either knob. It was introduced for etfs, fx_pairs and sp500_options and extended to crypto_perps_funding in #723; this finishes the fleet.

## Nothing moves

The guard is not part of any training spec, so all four re-executions resolved to hashes the registry already held:

| notebook | configurations | folds fitted | reused |
|---|---|---|---|
| cme_futures/06_linear | 56 | 0 | 280 |
| cme_futures/07_gbm | 30 | 0 | 150 |
| seoa/06_linear | 104 | 0 | 208 |
| seoa/07_gbm | population intact, 550 prediction sets | 0 | - |

Registry row counts are identical before and after: cme_futures 101 / 497 / 1152 and sp500_equity_option_analytics 248 / 1405 / 4730 across `training_runs`, `prediction_sets` and `backtest_runs`. Every population resolved to the name it already carried.