### PR TITLE
Let a case study declare how many training windows a sequence run draws

### DIFF
--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -41,6 +41,7 @@ import pandas as pd
 import polars as pl
 import torch
 import torch.nn as nn
+import yaml
 from ml4t.diagnostic.metrics import cross_sectional_ic
 from torch.utils.data import DataLoader
 
@@ -316,6 +317,53 @@ def resolve_dl_device(config: Mapping[str, Any] | None, requested: str | None = 
     return device
 
 
+def resolve_dl_max_train_sequences(
+    config: Mapping[str, Any] | None, reduction: int = 0
+) -> tuple[int, int]:
+    """Resolve how many training windows a sequence configuration draws per fold.
+
+    Returns ``(effective, reduction)``. ``config`` is a case study's ``modeling.dl``
+    block; ``reduction`` is what a preview asked for, 0 meaning it asked for nothing.
+
+    **The cap is a property of the model, not of the execution tier.** Every row of a
+    panel starts a window, so on a minute panel an uncapped fold builds tens of millions
+    of near-identical overlapping sequences - consecutive windows share all but one
+    observation. How many windows are drawn therefore changes what is fitted, and the
+    same named configuration must not mean one model when someone previews it and a
+    different one when it runs for real. This is `modeling.gbm.max_bin` one axis over:
+    that value used to be read off whichever device was visible until it was made an
+    explicit declaration, for exactly this reason.
+
+    Until this existed the only source was ``preview_reductions``, so a canonical run was
+    necessarily uncapped and the declaration had nowhere to live.
+
+    Absent means uncapped, which is what the daily panels want and what every converted
+    case study already registers, so adding the key moves no existing identity. A preview
+    may only lower the effective cap: raising it would let a reduced run fit on more
+    windows than the canonical one it is rehearsing.
+    """
+    declared_raw = (config or {}).get("max_train_sequences")
+    declared = 0 if declared_raw is None else int(declared_raw)
+    if declared < 0:
+        raise ValueError(
+            f"modeling.dl.max_train_sequences must be zero (uncapped) or positive, not {declared}"
+        )
+    reduction = int(reduction or 0)
+    if reduction < 0:
+        raise ValueError(
+            f"the max_train_sequences preview reduction must be zero or positive, not {reduction}"
+        )
+    if declared and reduction:
+        if reduction > declared:
+            raise ValueError(
+                f"a preview asked for {reduction} training sequences where "
+                f"modeling.dl.max_train_sequences declares {declared}. A preview "
+                "rehearses the canonical run and cannot fit on more windows than it."
+            )
+        return reduction, reduction
+    return (reduction or declared), reduction
+
+
 def _sequence_runtime_spec(
     device: str,
     *,
@@ -410,7 +458,11 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         seed=seed,
         num_threads=int(request["overrides"].get("num_threads", 8)),
     )
-    max_train_sequences = int(reductions.get("max_train_sequences", 0))
+    setup = yaml.safe_load((study.root / "config" / "setup.yaml").read_text()) or {}
+    max_train_sequences, sequence_reduction = resolve_dl_max_train_sequences(
+        (setup.get("modeling") or {}).get("dl") or {},
+        int(reductions.get("max_train_sequences", 0)),
+    )
     calendar_id = make_walk_forward_config(study.case_study, date_col=mds.date_col).calendar_id
     lookback = int(config["params"].get("lookback", 60))
     dataset_pd = dataset.to_pandas()
@@ -512,9 +564,13 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
             "n_folds": expected["fold"].n_unique(),
         },
         "input_data_spec": sequence_identity,
+        # `sampling` records what a PREVIEW reduced, not what the configuration
+        # declares. The locked holdout runner reads it as "was this run reduced" and
+        # refuses anything non-zero, so a declared cap - which is part of the model and
+        # applies to the holdout refit too - rides in `input_data_spec` instead.
         "sampling": {
             "max_symbols": int(reductions.get("max_symbols", 0)),
-            "max_train_sequences": max_train_sequences,
+            "max_train_sequences": sequence_reduction,
         },
         "numerics": runtime,
         "source_identity": _sequence_source_identity(config),
@@ -581,6 +637,15 @@ def reconstruct_locked_request(
     computation = spec["computation"]
     if computation.get("sampling") != {"max_symbols": 0, "max_train_sequences": 0}:
         raise ValueError("locked sequence holdout requires unreduced canonical inputs")
+    # `sampling` above proves no PREVIEW reduced this run. A cap the configuration
+    # DECLARES is a different thing and has to reach the refit: it is part of the model,
+    # so a holdout drawing a different number of windows than the validation fit is not a
+    # cheaper run, it is a different model answering the holdout - and nothing in the
+    # output would show it. Taken from the stored spec rather than re-read from
+    # setup.yaml, so an edit since selection cannot silently change what is refitted.
+    locked_max_train_sequences = int(
+        (computation.get("input_data_spec") or {}).get("max_train_sequences", 0)
+    )
     label_ref = study.labels.get(spec["label"], execution_tier=ExecutionTier.CANONICAL)
     mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=0)
     if mds.date_col != "timestamp" or mds.entity_cols[:1] not in (["symbol"], ["product"]):
@@ -718,7 +783,7 @@ def reconstruct_locked_request(
             mds.label_col,
             case_study=study.case_study,
             input_data_spec=mds.input_lineage,
-            max_train_sequences=0,
+            max_train_sequences=locked_max_train_sequences,
         )
         expected_preprocessing = {
             "class": "fold_train_standardization",
@@ -741,7 +806,7 @@ def reconstruct_locked_request(
         input_data_spec = {
             "input_data_spec": mds.input_lineage,
             "lookback": lookback,
-            "max_train_sequences": 0,
+            "max_train_sequences": locked_max_train_sequences,
         }
         expected_preprocessing = {
             "class": "fold_train_standardization",
@@ -781,7 +846,7 @@ def reconstruct_locked_request(
         temporal_keys=tuple(mds.temporal_keys),
         temporal_feature_names=tuple(mds.temporal_feature_names),
         expected_keys=expected,
-        max_train_sequences=0,
+        max_train_sequences=locked_max_train_sequences,
         runtime_provenance=_sequence_runtime_provenance(study, config),
         prediction_split="holdout",
         published_checkpoints=(int(checkpoint_value),),
@@ -908,7 +973,13 @@ def _reconstruct_pytorch_predictions(
             date_col=context.date_col,
             entity_col=context.entity_col,
             lookback=lookback,
-            max_train_sequences=0,
+            # The reconstruction only asserts a training store exists - the
+            # standardization it checks comes from the stored checkpoint, not from these
+            # rows. Drawing the cap the run declared rather than every window keeps that
+            # assertion from materializing millions of sequences on a minute panel.
+            max_train_sequences=int(
+                (computation.get("input_data_spec") or {}).get("max_train_sequences", 0)
+            ),
             temporal_by_fold=context.temporal_by_fold,
             temporal_keys=list(context.temporal_keys),
             temporal_feature_names=list(context.temporal_feature_names),

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -12,6 +12,7 @@ import pytest
 
 from case_studies.research import CVSpec, LabelDefinition, Study
 from case_studies.utils import deep_learning, tabular_dl
+from case_studies.utils.deep_learning import resolve_dl_max_train_sequences
 from tests.test_research_workspace import _seed_release
 
 
@@ -590,3 +591,46 @@ def test_sequence_resolver_keeps_a_preview_request_inside_the_preview_root(
     assert Path(os.environ["ML4T_OUTPUT_DIR"]) == preview_root
     assert study.storage_root("preview") == preview_root / study.case_study
     assert resolved.spec["execution_tier"] == "preview"
+
+
+class TestDeclaredMaxTrainSequences:
+    """`modeling.dl.max_train_sequences` is a model property, not a preview knob.
+
+    Before it existed the only source was `preview_reductions`, so a canonical run was
+    necessarily uncapped. On a minute panel that is the difference between drawing
+    hundreds of thousands of training windows and drawing millions of near-identical
+    overlapping ones, which is a different model rather than a slower run.
+    """
+
+    def test_absent_declaration_is_uncapped_so_no_registered_identity_moves(self):
+        assert resolve_dl_max_train_sequences({}) == (0, 0)
+        assert resolve_dl_max_train_sequences(None) == (0, 0)
+
+    def test_a_declaration_caps_a_canonical_run_that_asks_for_no_reduction(self):
+        assert resolve_dl_max_train_sequences({"max_train_sequences": 373_000}) == (373_000, 0)
+
+    def test_the_reduction_is_reported_separately_so_sampling_records_only_a_preview(self):
+        """`sampling` is what the locked holdout runner reads as 'was this reduced'.
+
+        A declared cap must leave it at zero or a holdout could never be run against a
+        capped configuration at all.
+        """
+        effective, reduction = resolve_dl_max_train_sequences({"max_train_sequences": 373_000}, 8)
+        assert (effective, reduction) == (8, 8)
+
+        effective, reduction = resolve_dl_max_train_sequences({"max_train_sequences": 373_000})
+        assert effective == 373_000
+        assert reduction == 0
+
+    def test_a_preview_may_lower_the_cap_but_never_raise_it(self):
+        with pytest.raises(ValueError, match="cannot fit on more windows"):
+            resolve_dl_max_train_sequences({"max_train_sequences": 1_000}, 5_000)
+
+    def test_a_preview_of_an_uncapped_configuration_still_reduces(self):
+        assert resolve_dl_max_train_sequences({}, 8) == (8, 8)
+
+    def test_a_negative_declaration_is_refused_rather_than_read_as_uncapped(self):
+        with pytest.raises(ValueError, match="zero .uncapped. or positive"):
+            resolve_dl_max_train_sequences({"max_train_sequences": -1})
+        with pytest.raises(ValueError, match="zero or positive"):
+            resolve_dl_max_train_sequences({}, -1)


### PR DESCRIPTION
`max_train_sequences` had exactly one source - `preview_reductions`, at `deep_learning.py:413`. There is no preset key and no `setup.yaml` key. So a **canonical sequence run was necessarily uncapped** and the declaration had nowhere to live.

That is harmless on the daily panels, which is why it survived: all 62 registered `deep_learning` runs across the seven converted case studies carry 0.

It is not harmless on a minute panel. Every training row starts a window and consecutive windows share all but one observation. Measured from `nasdaq100_microstructure`'s canonical plan for nlinear on `fwd_ret_15m`:

| | |
|---|---|
| eligible rows | 6,548,013 |
| fold 0 training window | 4,066,041 rows |
| fold 1 training window | 3,997,571 rows |

That is about 4.0M sequences per fold against the 750,000 its notebooks cap at - **5.4x**, or roughly 110 hours for the stage instead of 20.

## Why this belongs to the model rather than to the tier

How many windows are drawn changes what is fitted. This is `modeling.gbm.max_bin` one axis over: that value was read off whichever device was visible until it was made an explicit declaration, because the same named configuration must not fit different models in different places. A cap that exists only as a preview reduction has the same defect - the configuration means 750,000 windows when someone previews it and 4.0M when it runs for real, and only one of those is what the chapter describes.

## What changes

- `modeling.dl.max_train_sequences` is the declaration, alongside `modeling.dl.device`. **Absent means uncapped**, so no registered identity moves.
- A preview may lower the effective cap and is refused if it tries to raise it: a preview rehearses the canonical run and cannot fit on more windows than it.
- `sampling` keeps recording only what a preview reduced. The locked holdout runner reads it as "was this run reduced" and refuses anything non-zero, so a declared cap rides in `input_data_spec` instead.
- **`reconstruct_locked_request` takes the cap from the stored spec rather than hardcoding 0.** This half matters more than the cost: a holdout drawing a different number of windows than the validation fit is not a cheaper run, it is a different model answering the holdout, and nothing in the output would have shown it. Taken from the spec rather than re-read from `setup.yaml`, so an edit after selection cannot change what is refitted.
- `_reconstruct_pytorch_predictions` takes it too. It builds a training store only to assert one exists, and uncapped that assertion would materialize millions of sequences.

## Verified, not asserted

Checked against every production registry: 62 registered `deep_learning` runs in seven case studies, every one carrying `max_train_sequences` 0 in both `sampling` and `input_data_spec`. **Zero rows change identity under this change.**

Six unit tests cover the resolver, including that a preview cannot raise the cap and that a negative declaration is refused rather than read as uncapped.

## Follow-up

Declaring the cap as a stride in label horizons rather than as a count is ml4t/agent-workspace#1015. `darts_forecasting.py:535` already turns the count into a stride, so a count can express the intent today - but 750,000 works out to a window every 5.4 minutes on a 15-minute label, which is a value nobody chose.