### PR TITLE
Report the prediction dispersion ratio on a reduced run rather than refusing it

### DIFF
--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -57,7 +57,34 @@ def _atomic_save_json(path: Path, data: dict) -> None:
         temporary.unlink(missing_ok=True)
 
 
-def _validate_prediction_dispersion(predictions) -> None:
+def _sampling_reduced(spec_json: str | None) -> bool:
+    """Whether the parent training run declared a sampling reduction.
+
+    Every family records ``computation.sampling`` and each writes its own no-op
+    value into it: a count reads 0 and a fraction reads 1.0 when nothing was
+    reduced (``deep_learning.py``, ``gbm.py``, ``linear.py``, ``tabular_dl.py``
+    and ``latent_factors/adapter.py`` each build the dict, and each already
+    compares against exactly that shape before reconstructing a locked request).
+    Anything else means a preview drew less than the run declares.
+    """
+    if not spec_json:
+        return False
+    try:
+        computation = json.loads(spec_json).get("computation")
+    except (TypeError, ValueError):
+        return False
+    sampling = (computation or {}).get("sampling") if isinstance(computation, dict) else None
+    if not isinstance(sampling, dict):
+        return False
+    for key, value in sampling.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            continue
+        if value != (1.0 if key.endswith("_frac") else 0):
+            return True
+    return False
+
+
+def _validate_prediction_dispersion(predictions, *, refuse: bool = True) -> None:
     """Reject a prediction set with an implausible score scale on any fold.
 
     The bound is deliberately wide. Across 8,090 finite folds in the nine
@@ -65,6 +92,22 @@ def _validate_prediction_dispersion(predictions) -> None:
     72.72. The known divergent folds started at 187.41 and extended to
     9.22e39. Rank correlation cannot detect this failure because it is invariant
     to score scale.
+
+    ``refuse`` is false for a run that declared a sampling reduction or a preview
+    tier. The ratio compares the score scale to the label scale, and that says
+    something about the fit only once the fit has converged: before then the
+    numerator is set by weight initialization and the input scale, the
+    denominator by the label alone, so the quotient tracks the label's magnitude
+    rather than the model's behaviour. Under the CI fixture a sequence preset
+    draws one batch of 2,048 windows from a 2,000-window sample and takes two
+    optimizer steps, which is not a fit that can have diverged; the eight case
+    studies that pass there do so because their labels sit near 1e-2, not
+    because anything about them converged. The ratio is still computed and
+    logged on such a run, so the number stays visible; it does not refuse.
+
+    A non-finite score is refused either way. That failure does not depend on how
+    far a fit progressed, and a NaN score breaks every downstream read of the
+    prediction set whatever produced it.
     """
     import math
 
@@ -125,12 +168,20 @@ def _validate_prediction_dispersion(predictions) -> None:
                 f"(score std {score_std:.6g} / target std {actual_std:.6g})"
             )
 
-    if violations:
-        raise ValueError(
-            "Refusing to register predictions with a diverged fold; "
-            f"the maximum allowed per-fold dispersion ratio is "
-            f"{MAX_PREDICTION_STD_RATIO:g}: " + "; ".join(violations)
+    if not violations:
+        return
+    detail = (
+        f"the maximum allowed per-fold dispersion ratio is "
+        f"{MAX_PREDICTION_STD_RATIO:g}: " + "; ".join(violations)
+    )
+    if not refuse:
+        logger.warning(
+            "Prediction dispersion exceeds the bound on a run that declared a reduction, so "
+            "it is reported rather than refused; %s",
+            detail,
         )
+        return
+    raise ValueError("Refusing to register predictions with a diverged fold; " + detail)
 
 
 def clear_prediction_sets(
@@ -776,20 +827,30 @@ def register_prediction_set(
     if case_dir is None:
         case_dir = _case_dir(case_study)
 
-    if predictions is not None:
-        _validate_prediction_dispersion(predictions)
-
     db = _open_registry(case_dir)
     try:
         parent = db.execute(
-            "SELECT identity_version, execution_tier FROM training_runs WHERE training_hash = ?",
+            "SELECT identity_version, execution_tier, spec_json FROM training_runs "
+            "WHERE training_hash = ?",
             (training_hash,),
         ).fetchone()
     finally:
         db.close()
     if parent is None:
         raise ValueError(f"unknown training_hash {training_hash}")
-    identity_version, _execution_tier = parent
+    identity_version, execution_tier, parent_spec_json = parent
+
+    # After the parent lookup, not before it: the dispersion bound is a statement about a
+    # converged fit, and only the parent row says whether this run claims to be one. The
+    # reduction is read from what was registered rather than from what the caller asserts.
+    if predictions is not None:
+        _validate_prediction_dispersion(
+            predictions,
+            refuse=not (
+                str(execution_tier or "canonical") == "preview"
+                or _sampling_reduced(parent_spec_json)
+            ),
+        )
     coverage = None
     if identity_version in SUPPORTED_IDENTITY_VERSIONS:
         if predictions is None or expected_keys is None:

--- a/tests/test_prediction_dispersion_guard.py
+++ b/tests/test_prediction_dispersion_guard.py
@@ -1,0 +1,121 @@
+"""The prediction dispersion guard, and what tier it applies at.
+
+`_validate_prediction_dispersion` had no test of its own: its only caller was
+`register_prediction_set`, so the bound was exercised through notebook runs and
+nowhere else. That is how a threshold calibrated on converged production fits
+came to gate a fixture that takes two optimizer steps.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import polars as pl
+import pytest
+
+from case_studies.utils.registry.registration import (
+    MAX_PREDICTION_STD_RATIO,
+    _sampling_reduced,
+    _validate_prediction_dispersion,
+)
+
+
+def _predictions(score_std: float, target_std: float, n: int = 400, folds: int = 2):
+    """Two folds whose score and target dispersions are the ones asked for."""
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    frames = []
+    for fold in range(folds):
+        actual = rng.normal(0.0, target_std, n)
+        score = rng.normal(0.0, score_std, n)
+        frames.append(
+            pl.DataFrame(
+                {
+                    "fold": [fold] * n,
+                    "y_true": actual,
+                    "y_score": score,
+                }
+            )
+        )
+    return pl.concat(frames)
+
+
+class TestDispersionBound:
+    def test_a_proportionate_score_scale_passes(self):
+        _validate_prediction_dispersion(_predictions(score_std=0.02, target_std=0.01))
+
+    def test_a_diverged_fold_is_refused_at_canonical_tier(self):
+        with pytest.raises(ValueError, match="diverged fold"):
+            _validate_prediction_dispersion(_predictions(score_std=5.0, target_std=0.002))
+
+    def test_refusing_is_the_default(self):
+        """No caller may reach the permissive branch by omitting the argument."""
+        with pytest.raises(ValueError, match="diverged fold"):
+            _validate_prediction_dispersion(
+                _predictions(score_std=5.0, target_std=0.002), refuse=True
+            )
+        with pytest.raises(ValueError, match="diverged fold"):
+            _validate_prediction_dispersion(_predictions(score_std=5.0, target_std=0.002))
+
+
+class TestReducedRun:
+    def test_a_reduced_run_reports_the_same_ratio_instead_of_refusing(self, caplog):
+        frame = _predictions(score_std=5.0, target_std=0.002)
+        with caplog.at_level(logging.WARNING):
+            _validate_prediction_dispersion(frame, refuse=False)
+        assert "reported rather than refused" in caplog.text
+        assert f"{MAX_PREDICTION_STD_RATIO:g}" in caplog.text
+
+    def test_a_reduced_run_within_the_bound_warns_about_nothing(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _validate_prediction_dispersion(
+                _predictions(score_std=0.02, target_std=0.01), refuse=False
+            )
+        assert "dispersion" not in caplog.text
+
+    def test_a_non_finite_score_is_refused_on_a_reduced_run_too(self):
+        """Scale depends on how far a fit got. A NaN score does not."""
+        frame = _predictions(score_std=0.02, target_std=0.01)
+        broken = frame.with_columns(
+            pl.when(pl.int_range(pl.len()) == 0)
+            .then(float("nan"))
+            .otherwise(pl.col("y_score"))
+            .alias("y_score")
+        )
+        with pytest.raises(ValueError, match="non-finite"):
+            _validate_prediction_dispersion(broken, refuse=False)
+
+
+class TestSamplingReduced:
+    """The five family no-op shapes, read off the specs each family writes."""
+
+    @pytest.mark.parametrize(
+        "sampling",
+        [
+            {"max_symbols": 0, "max_train_sequences": 0},  # deep_learning
+            {"max_symbols": 0},  # latent_factors, tabular_dl
+            {"train_sample_frac": 1.0, "max_symbols": 0},  # gbm, linear
+        ],
+    )
+    def test_an_unreduced_run_is_not_sampled(self, sampling):
+        assert not _sampling_reduced(json.dumps({"computation": {"sampling": sampling}}))
+
+    @pytest.mark.parametrize(
+        "sampling",
+        [
+            {"max_symbols": 5, "max_train_sequences": 2000},
+            {"max_symbols": 0, "max_train_sequences": 2000},
+            {"train_sample_frac": 0.02, "max_symbols": 5},
+            {"train_sample_frac": 1.0, "max_symbols": 5},
+        ],
+    )
+    def test_any_reduced_axis_is_sampled(self, sampling):
+        assert _sampling_reduced(json.dumps({"computation": {"sampling": sampling}}))
+
+    def test_a_spec_without_sampling_is_not_sampled(self):
+        assert not _sampling_reduced(json.dumps({"computation": {}}))
+        assert not _sampling_reduced(json.dumps({}))
+        assert not _sampling_reduced(None)
+        assert not _sampling_reduced("not json")


### PR DESCRIPTION
`_validate_prediction_dispersion` compares a fold's score standard deviation to its target standard deviation and refuses above 100. The bound was calibrated on 8,090 folds from the nine production registries, all converged fits, and for a converged fit the ratio is scale-free. Before convergence it is not: the numerator is set by weight initialization and the input scale, the denominator by the label alone, so the quotient tracks the label's magnitude rather than the model's behaviour.

Under the CI fixture no sequence model converges, and not by a small margin. All four sequence presets carry `batch_size: 2048`, the previews cap training at 2,000 sequences, and `tests/preset_patches.py` gives them two epochs. That is one batch per epoch and **two optimizer steps**, against a `CosineAnnealingLR(T_max=2)` that decays the rate across them.

## Measured

Reproduced locally against `~/ml4t/test-data`, running `tests/test_case_studies.py -k nasdaq100_microstructure` over stages 01-05 plus the two failing notebooks, on `cs6/nasdaq100-dl-conversion` at 4b0993e1:

| notebook | fold | ratio | score std | target std |
|---|---|---:|---:|---:|
| `08_dl_nlinear` | 0 | 230.31 | 0.498 | 0.00216 |
| `08_dl_nlinear` | 1 | 182.18 | 0.571 | 0.00314 |
| `11_dl_patchtst` | 0 | 151.56 | 0.328 | 0.00216 |

The score standard deviations are all order 0.3-0.6, which is initialization scale for these heads. The target standard deviations are the fifteen-minute return. The eight case studies whose fixtures pass this guard pass because their labels sit near 1e-2, not because anything about them converged - and etfs' TSMixer is already at 286 on a daily label (agent-workspace #988), so nasdaq was never the anomaly.

## The change

`register_prediction_set` now looks up the parent training run's `execution_tier` and `spec_json` before validating, and a run that declared a preview tier or any `computation.sampling` reduction gets the ratio logged rather than raised. The number stays visible in the log; it stops gating a plumbing test on a quantity the plumbing test cannot produce. Canonical behaviour is unchanged.

A non-finite score is still refused either way. That failure does not depend on how far a fit progressed, and a NaN score breaks every downstream read.

`_sampling_reduced` reads the no-op shape each family already writes and already compares against when reconstructing a locked request: a count is 0 and a fraction is 1.0 when nothing was reduced.

## Why the predicate is the sampling reduction and not the tier

Both would work. `tests/pm_helpers.py:1004` binds `EXECUTION_TIER` to `preview` for any notebook whose parameters cell declares both `EXECUTION_TIER` and `WORKSPACE`, which these do, so the tier is already correct under CI - and `ModelRequest.from_request` refuses canonical-with-reductions at `case_studies/research/models.py:315`, so a canonical tier here would have raised while building the request rather than at registration.

`computation.sampling` is chosen because it is what `reconstruct_locked_request` already refuses a holdout refit on. Reading the same field here gives the codebase one answer to "is this a fit anyone may read" rather than two that can drift apart.

## Tests

The guard had no test of its own. Its only caller was `register_prediction_set`, so a threshold calibrated on converged production fits was exercised through notebook runs and nowhere else. `tests/test_prediction_dispersion_guard.py` covers the bound, that refusing is the default, the reduced branch, the non-finite refusal at both settings, and the five family sampling shapes.

124 passed across `test_registry_specs`, `test_registry_lineage`, `test_registry_completeness`, `test_registry_metrics`, `test_incompletely_registered_predictions`, `test_sequence_lookup_reaches_registration`, `test_causal_registry_registration` and the new file.

Closes agent-workspace #988. Unblocks `cs-nasdaq100_microstructure` on #728.
