### PR TITLE
Cut the PatchTST fixture window to 24, which the boundary conversion dropped

### DIFF
--- a/tests/preset_patches.py
+++ b/tests/preset_patches.py
@@ -20,7 +20,16 @@ _TEST_PRESET_PATCHES: dict[str, dict] = {
     "tsmixer": {"n_epochs": 2, "checkpoint_interval": 1},
     "tcn": {"n_epochs": 2, "checkpoint_interval": 1},
     "nlinear": {"n_epochs": 2, "checkpoint_interval": 1},
-    "patchtst": {"n_epochs": 2, "checkpoint_interval": 1},
+    # PatchTST additionally has its window cut. It is channel-independent, so the encoder
+    # sees `batch_size x n_features` sequences - 2048 x 88 on this fixture's nasdaq panel -
+    # and the cost of each is set by the window. At the preset's 60 it does not finish a
+    # two-fold fit inside a 600s cell budget on a CPU runner. 24 holds two patches at the
+    # preset's patch_size 16 and stride 8, which is the smallest window that still exercises
+    # patching rather than degenerating to one patch. This is the reduction the research-
+    # boundary conversion dropped: `tests/overrides.yaml` carried `LOOKBACK: 24` for this
+    # notebook before it stopped binding the name, and no preview reduction can set it -
+    # `_SEQUENCE_PREVIEW_FIELDS` is {folds, max_symbols, max_train_sequences}.
+    "patchtst": {"n_epochs": 2, "checkpoint_interval": 1, "params": {"lookback": 24}},
     # TabDL: 2 epochs
     "tabm": {"n_epochs": 2, "checkpoint_interval": 1},
     # Latent factors: 2 epochs
@@ -61,7 +70,12 @@ def _patch_presets_for_testing(config_dir: Path) -> None:
             preset = yaml.safe_load(preset_path.read_text())
             if preset is None:
                 continue
-            preset.update(overrides)
+            # `params` is merged rather than replaced: an entry that reduces one architecture
+            # parameter must not drop the rest of the block with it.
+            nested = overrides.get("params")
+            preset.update({k: v for k, v in overrides.items() if k != "params"})
+            if nested:
+                preset["params"] = {**(preset.get("params") or {}), **nested}
             with open(preset_path, "w") as f:
                 yaml.dump(preset, f, default_flow_style=False)
 

--- a/tests/test_preset_patches.py
+++ b/tests/test_preset_patches.py
@@ -1,0 +1,79 @@
+"""What `_patch_presets_for_testing` writes into a copied preset.
+
+The table was flat until PatchTST needed its window cut, and `lookback` lives
+inside `params`. A shallow `dict.update` would have replaced the whole block -
+`architecture` included, which `deep_learning.py` subscripts without a default -
+and produced a network that is not the one the preset names. Nothing would have
+raised; the run would simply have been fitting something else.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tests.preset_patches import _TEST_PRESET_PATCHES, _patch_presets_for_testing
+
+
+def _write(config_dir: Path, model_type: str, preset: dict) -> Path:
+    model_dir = config_dir / model_type
+    model_dir.mkdir(parents=True)
+    path = model_dir / f"{model_type}.yaml"
+    path.write_text(yaml.safe_dump(preset))
+    return path
+
+
+class TestNestedParams:
+    def test_a_params_override_merges_and_keeps_its_siblings(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "patchtst",
+            {
+                "batch_size": 2048,
+                "n_epochs": 100,
+                "params": {
+                    "architecture": "patchtst",
+                    "d_model": 64,
+                    "lookback": 60,
+                    "n_heads": 4,
+                    "patch_size": 16,
+                },
+            },
+        )
+        _patch_presets_for_testing(tmp_path)
+        written = yaml.safe_load(path.read_text())
+
+        assert written["params"]["lookback"] == 24
+        assert written["params"] == {
+            "architecture": "patchtst",
+            "d_model": 64,
+            "lookback": 24,
+            "n_heads": 4,
+            "patch_size": 16,
+        }
+        assert written["n_epochs"] == 2
+        assert written["batch_size"] == 2048, "the batch is a production number and is not patched"
+
+    def test_a_flat_entry_leaves_params_untouched(self, tmp_path):
+        """nlinear declares no `params` override, so its block must survive whole."""
+        params = {"architecture": "nlinear", "dropout": 0.1, "lookback": 60}
+        path = _write(tmp_path, "nlinear", {"n_epochs": 100, "params": dict(params)})
+        _patch_presets_for_testing(tmp_path)
+        written = yaml.safe_load(path.read_text())
+
+        assert written["params"] == params
+        assert written["n_epochs"] == 2
+
+
+class TestTableShape:
+    def test_every_params_override_is_a_dict(self):
+        """A scalar under `params` would silently replace the block it merges into."""
+        for model_type, overrides in _TEST_PRESET_PATCHES.items():
+            nested = overrides.get("params")
+            assert nested is None or isinstance(nested, dict), model_type
+
+    def test_no_entry_patches_architecture(self):
+        """The patcher reduces a workload. Naming a different network is not that."""
+        for model_type, overrides in _TEST_PRESET_PATCHES.items():
+            assert "architecture" not in (overrides.get("params") or {}), model_type


### PR DESCRIPTION
`11_dl_patchtst` fails `cs-nasdaq100_microstructure` on the 600s cell budget. Not memory: with 125 GB available it trains, predicts and registers, so the `Kernel died` seen on a runner is that runner's ceiling. It is the clock.

## What the conversion dropped

Before the research-boundary conversion, `tests/overrides.yaml` gave this notebook `BATCH_SIZE: 32` and `LOOKBACK: 24`, with a comment recording that CPU overran the budget at 625s even so - which is why it carried `gpu: true`, was therefore skipped on every runner, and why neither this nor the dispersion refusal above it (#731) had ever been seen. The conversion dropped `gpu: true`, which is right, and dropped both reductions along with the parameters that bound them. The notebook now runs the preset's window of 60 on CPU. Its three siblings ran at `LOOKBACK: 5` and now also run at 60; `08_dl_nlinear` survives that because it is one linear layer.

No preview reduction can put the window back - `_SEQUENCE_PREVIEW_FIELDS` is `{folds, max_symbols, max_train_sequences}` - and `tests/preset_patches.py` is where a fixture reduction of a preset now lives.

## Why 24, and why not the batch

24 is the smallest window that still exercises patching. The count is `int((lookback - patch_len) / stride + 1)`, plus one when `padding_patch == "end"` (`_reference/backbone.py:78-81`), so **60 gives 7 patches and 24 gives 3**; anything shorter degenerates toward a single patch and stops testing what the architecture is.

Two of the three numbers in that formula are not in the preset, which declares only `architecture`, `d_model`, `dropout`, `lookback`, `n_heads`, `n_layers` and `patch_size`. `stride` is `max(1, patch_size // 2)` = 8, resolved at `patchtst.py:70-71` from a `None` default, and `padding_patch` defaults to `"end"` at `patchtst.py:66`. A reader who checks the patch count against the preset alone finds no `padding_patch`, drops the extra patch, and under-counts the activation. Worth stating because the count propagates into `head_nf = d_model * patch_num` as well as the encoder activation.

The cut is therefore 2.33x on the stored activation, not 3x.

The batch stays at 2048. Under the fixture an epoch is one batch, so `n_epochs: 2` is two optimizer steps; lowering the batch to 64 would make it sixty-two on a run already over budget. It is the wrong direction here as well as a production number.

## Measured

Fixture chain, stages 01-05 plus the notebook, against `~/ml4t/test-data`:

| window | result |
|---|---|
| 60 (preset) | cell timed out at 600s on `run_model_population` |
| 24 | **6 passed, 636s total** |

### Why this was two failures wearing one face

The runner and this machine bind on different resources, and `gpu: true` meant neither had ever been seen.

- **125 GB local:** the notebook trains, predicts and reaches registration, then overruns the 600s cell budget. The clock binds; memory does not.
- **`ubuntu-latest`, 16 GB:** the kernel dies at 11m43s into a job whose budget it has not exhausted. Memory binds; the clock does not.

Measured on the nasdaq100_microstructure lane's `cs6/nasdaq100-dl-conversion` at c190485a, where `cs-nasdaq100_microstructure` is 1 failed / 14 passed with `11_dl_patchtst` the only red. Cutting the window addresses both: it is 2.33x off the stored activation and it is what brought the local run inside the budget.

This is the argument for why skipping the job was more expensive than a red one. While it was `gpu: true` it ran on no runner, so the attention architecture had no coverage at all, and two independent defects sat behind that skip - this one and the dispersion refusal fixed in #731.

The margin on a GitHub runner is not measured. This machine is faster than one, and pytest was not run with `--durations`, so there is no per-notebook breakdown of the 636s. The precedent cuts both ways: main's comment recorded 625s at lookback 24 **with batch 32**, and at 2048 the step count is 63x lower, which is where the headroom should come from. If the runner still overruns, the answer is a validation-side reduction field rather than a shorter window - `max_train_sequences` caps training windows, the validation store is uncapped, and nothing a preview declares bounds the forward pass.

## The merge

`_patch_presets_for_testing` now merges `params` rather than replacing it. The table held only top-level keys until now, and a shallow update would have dropped `architecture`, `d_model`, `n_heads` and `patch_size`. `deep_learning.py` subscripts `params["architecture"]` without a default on five paths and with a `.get("architecture", "")` default on a sixth, so the run would either raise somewhere unrelated or quietly fit a network the preset does not name.

`tests/test_preset_patches.py` is new - the file had no test - and covers the merge, that a flat entry leaves `params` whole, that no entry patches `architecture`, and that the batch is not patched.
