### PR TITLE
Project the VWAP, and define what a resampled one means

### DIFF
--- a/data/equities/loader.py
+++ b/data/equities/loader.py
@@ -203,12 +203,29 @@ def load_us_equities(
 
 
 # Resampling aggregation specs for group_by_dynamic
+# A resampled vwap is the volume-weighted mean of its constituents, not any positional pick
+# among them. Every other entry here is a first, a last, an extremum or a sum, and each is
+# right for its column - which is exactly why this one is a trap: the shape of the list
+# invites a fifth positional pick, and `.mean()` is the one that looks correct. `.mean()` is
+# right only when volume is flat across the window, and intraday volume is U-shaped across
+# the session, so its error is largest at the open and the close - where a microstructure
+# case study is most interested.
+#
+# Minutes with no trade contribute nothing rather than dragging the weight down: `vwap` is
+# null exactly when `volume` is 0, and a null weight is excluded from both sums rather than
+# counted as a zero-priced share. A window in which nothing traded at all has no
+# volume-weighted price, and resolves to null rather than to a division by zero.
+_VWAP_WEIGHT = pl.when(pl.col("vwap").is_not_null()).then(pl.col("volume")).otherwise(None)
 _TRADE_OHLCV_AGGS = [
     pl.col("open").first().alias("open"),
     pl.col("high").max().alias("high"),
     pl.col("low").min().alias("low"),
     pl.col("close").last().alias("close"),
     pl.col("volume").sum().alias("volume"),
+    pl.when(_VWAP_WEIGHT.sum() > 0)
+    .then((pl.col("vwap") * _VWAP_WEIGHT).sum() / _VWAP_WEIGHT.sum())
+    .otherwise(None)
+    .alias("vwap"),
 ]
 
 _QUOTE_OHLCV_AGGS = [
@@ -371,6 +388,13 @@ def load_nasdaq100_bars(
         pl.col("low_trade_price").alias("low"),
         pl.col("last_trade_price").alias("close"),
         pl.col("volume"),
+        # The AlgoSeek `VolumeWeightPrice`, projected because a backtest that fills at VWAP
+        # needs it on the bar it fills. It is null exactly when `volume` is 0 - a minute in
+        # which nothing traded - and the OHLC filter below does not drop those rows, because
+        # the trade prices are carried from the last print and are not null. So a null vwap
+        # reaches the caller by design: a minute with no trade has no volume-weighted price,
+        # and the alternative to a null is a stale carried close standing in for one.
+        pl.col("vwap"),
     ]
     quote_cols = [
         pl.col("open_bid_price").alias("bid_open"),

--- a/tests/test_loader_vwap_projection.py
+++ b/tests/test_loader_vwap_projection.py
@@ -1,0 +1,70 @@
+"""A backtest that fills at VWAP needs the VWAP on the bar it fills, and a real one when resampled.
+
+`load_nasdaq100_bars` projected seven trade columns and dropped `vwap`, so the column existed on
+disk and never reached a caller. Adding it to the projection is what makes the resample question
+live: there was no wrong aggregation before, because there was no column to aggregate.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from data.equities.loader import _TRADE_OHLCV_AGGS
+
+
+def _window(volumes: list[int], vwaps: list[float | None]) -> pl.DataFrame:
+    n = len(volumes)
+    return pl.DataFrame(
+        {
+            "timestamp": pl.datetime_range(
+                pl.datetime(2021, 3, 1, 10, 0),
+                pl.datetime(2021, 3, 1, 10, 0) + pl.duration(minutes=n - 1),
+                "1m",
+                eager=True,
+            ),
+            "symbol": ["AAPL"] * n,
+            "open": [10.0] * n,
+            "high": [10.0] * n,
+            "low": [10.0] * n,
+            "close": [10.0] * n,
+            "volume": volumes,
+            "vwap": vwaps,
+        }
+    )
+
+
+def _resample(frame: pl.DataFrame) -> pl.DataFrame:
+    return frame.group_by_dynamic("timestamp", every="15m", group_by="symbol").agg(
+        _TRADE_OHLCV_AGGS
+    )
+
+
+def test_a_resampled_vwap_is_volume_weighted_not_averaged():
+    """The distinction the aggregation exists for, on volumes lopsided enough to show it."""
+    out = _resample(_window([100, 300], [10.0, 12.0]))
+    assert out["vwap"][0] == (10.0 * 100 + 12.0 * 300) / 400 == 11.5
+    # The reading that looks right and is not: the unweighted mean of the same two minutes.
+    assert out["vwap"][0] != (10.0 + 12.0) / 2
+
+
+def test_a_minute_with_no_trade_contributes_no_weight():
+    """`vwap` is null exactly when `volume` is 0, and a null must not count as a zero price.
+
+    Counting it would drag the window's price toward zero in proportion to how much of the
+    window did not trade, which is the opposite of ignoring it.
+    """
+    with_gap = _resample(_window([100, 0, 300], [10.0, None, 12.0]))
+    without_gap = _resample(_window([100, 300], [10.0, 12.0]))
+    assert with_gap["vwap"][0] == without_gap["vwap"][0] == 11.5
+
+
+def test_a_window_that_never_traded_has_no_vwap():
+    """Null rather than a division by zero, and never a substituted price."""
+    out = _resample(_window([0, 0], [None, None]))
+    assert out["vwap"][0] is None
+
+
+def test_volume_still_sums_across_a_window_that_did_not_trade():
+    """The weight exclusion is scoped to the vwap; `volume` keeps its own aggregation."""
+    out = _resample(_window([100, 0, 300], [10.0, None, 12.0]))
+    assert out["volume"][0] == 400

--- a/tests/test_nasdaq100_session_hours.py
+++ b/tests/test_nasdaq100_session_hours.py
@@ -113,6 +113,12 @@ class TestThroughTheLoader:
                         "low_trade_price": 99.0,
                         "last_trade_price": 100.5,
                         "volume": 1_000.0,
+                        # The archive always carries it (AlgoSeek `VolumeWeightPrice`), and the
+                        # loader projects it, so a fixture without it no longer stands in for
+                        # one. Distinct from every other price here, so a test that confuses
+                        # the vwap with the close or a trade price fails rather than passing
+                        # on a coincidence.
+                        "vwap": 100.25,
                     }
                 )
                 stamp += dt.timedelta(minutes=15)


### PR DESCRIPTION
`load_nasdaq100_bars` projected seven trade columns and dropped `vwap`, so the AlgoSeek `VolumeWeightPrice` existed on disk and reached no caller. A backtest that fills at VWAP - the execution assumption `config/setup.yaml` has always declared through `execution_price_assumption: next_bar_open_or_vwap` - needs it on the bar it fills.

`include_microstructure=True` is not an alternative: it returns all 60 raw columns, refuses to combine with resampling or quotes (`loader.py:337-342`), and is ~28 GB on a full-universe scan.

Item 3 of the [#187](https://github.com/ml4t/agent-workspace/issues/187) work list. The projection is needed on every path regardless of how the no-print fill rule resolves.

## Adding the column is what creates the aggregation question

Both halves are here because neither ships alone. There was no wrong resample before, because there was nothing to resample.

A fifteen-minute VWAP is `sum(vwap * volume) / sum(volume)` over its minutes. Every other entry in `_TRADE_OHLCV_AGGS` is a first, a last, an extremum or a sum, and each is right for its column - which is exactly why this one is a trap: the shape of the list invites a fifth positional pick, and **`.mean()` is the one that looks correct**. It is right only when volume is flat across the window, and intraday volume is U-shaped across the session, so its error is largest at the open and the close - where a microstructure case study is most interested. That reasoning is in the source rather than only here, because the next reader sees four positional picks and reaches for a fifth.

## A minute that did not trade contributes no weight, rather than a zero price

`vwap` is null exactly when `volume` is 0 - measured across all 1,632,198 fixture rows, zero exceptions - and those rows are **not** dropped by the existing OHLC null filter, because the trade prices are carried from the last print and are not null.

So a null vwap reaches the caller by design. A minute with no trade has no volume-weighted price, and the alternative to a null is a stale carried close standing in for one. A window in which nothing traded at all resolves to null rather than to a division by zero.

The rate is small on the population this case study trades and not on the raw file:

| population | rows surviving the OHLC filter | null vwap | rate |
|---|---|---|---|
| all hours (04:00-20:00) | 1,334,019 | 50,264 | 3.77% |
| 09:30-16:00 | 664,236 | 140 | **0.0211%** |

The difference is pre- and post-market, which `02_labels` already filters away.

## Verification

- `tests/test_loader_vwap_projection.py`, 4 passed. The weighting check uses volumes 100 and 300 at vwaps 10.00 and 12.00, which give **11.50** weighted against **11.00** unweighted - so the test fails if anyone reaches for `.mean()`, rather than passing on a coincidence. Around it: a no-trade minute inserted into that window changes nothing, a window that never traded resolves to null, and `volume` keeps summing across it.
- End-to-end on the fixture: `frequency="1m"` returns the column with 2 nulls in 2,340 rows; `frequency="15m"` returns 156 rows with none, so the resample absorbs the no-trade minutes correctly.
- `tests/test_nasdaq100_session_hours.py` and `tests/test_algoseek_convert.py`: 37 passed together with the new file.

## The fixture gains the column rather than the projection gaining tolerance

`test_nasdaq100_session_hours.py` builds a synthetic archive of eight columns, which the projection broke with `ColumnNotFoundError`. Adding `vwap` there is the right direction: making the projection tolerant would mean a real archive missing the column silently loses it instead of failing, which is the same silent substitution this change exists to remove. Its value is distinct from every other price in that fixture, so a test that confuses the vwap with the close fails rather than passing on a coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ltde4brozrjqTFuw3GSpgj