### PR TITLE
Bound the validation forward pass with max_predict_sequences

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -79,6 +79,10 @@ tests/test_lightning_announcement_silence.py
 tests/test_family_hook_dispatch.py
 tests/test_model_analysis_selection.py
 tests/test_model_source_identity_versions.py
+# `test_prediction_sequence_cap` tests the same module as `test_sequence_dataset`
+# below. `case_studies/utils/sequence_dataset.py` imports torch at :10 for the
+# Dataset subclass; these cases exercise the index builders, which never touch it.
+tests/test_prediction_sequence_cap.py
 tests/test_registry_metrics.py
 tests/test_research_contract_execution.py
 tests/test_research_model_planning.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -996,6 +996,7 @@ jobs:
             tests/test_family_hook_dispatch.py \
             tests/test_model_analysis_selection.py \
             tests/test_model_source_identity_versions.py \
+            tests/test_prediction_sequence_cap.py \
             tests/test_registry_metrics.py \
             tests/test_research_contract_execution.py \
             tests/test_research_model_planning.py \

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -75,7 +75,12 @@ from utils.modeling import RANDOM_SEED, seed_everything
 if TYPE_CHECKING:
     from case_studies.research.workspace import Study
 
-_SEQUENCE_PREVIEW_FIELDS = {"folds", "max_symbols", "max_train_sequences"}
+_SEQUENCE_PREVIEW_FIELDS = {
+    "folds",
+    "max_symbols",
+    "max_train_sequences",
+    "max_predict_sequences",
+}
 
 SEQUENCE_RUNNER_VERSION = 1
 SEQUENCE_PREPARATION_VERSION = 1
@@ -110,6 +115,9 @@ class SequenceResearchContext:
     runtime_provenance: dict[str, Any]
     prediction_split: str = "validation"
     published_checkpoints: tuple[int, ...] | None = None
+    # Preview-only, and deliberately absent from `sequence_identity_params`: capping how
+    # many validation windows are scored changes what the run covers, never what it fits.
+    max_predict_sequences: int = 0
 
 
 def _sha256(path: Path) -> str:
@@ -463,6 +471,16 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         (setup.get("modeling") or {}).get("dl") or {},
         int(reductions.get("max_train_sequences", 0)),
     )
+    # Preview-only, with no counterpart under `modeling.dl`: a declared cap on the
+    # training sample is a property of the model, while a cap on how much of validation
+    # gets scored is only ever a reduction in coverage. There is nothing for a
+    # configuration to declare here, so this reads from the preview alone.
+    predict_reduction = int(reductions.get("max_predict_sequences", 0))
+    if predict_reduction < 0:
+        raise ValueError(
+            "the max_predict_sequences preview reduction must be zero or positive, "
+            f"not {predict_reduction}"
+        )
     calendar_id = make_walk_forward_config(study.case_study, date_col=mds.date_col).calendar_id
     lookback = int(config["params"].get("lookback", 60))
     dataset_pd = dataset.to_pandas()
@@ -479,6 +497,15 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         # than fail later on a key that is missing from the digest.
         if entity_col != "symbol":
             raise ValueError(f"Darts presets require the symbol entity key, not {entity_col!r}")
+        # Refused rather than ignored. Darts forecasts whole series, so thinning the key
+        # set would not shorten the forward pass - it would only publish fewer keys than
+        # the model produced. A reduction that silently does nothing is worse than one
+        # that is unavailable, because the preview would still look reduced.
+        if predict_reduction:
+            raise ValueError(
+                "max_predict_sequences is not supported for Darts presets: they forecast "
+                "whole series, so capping prediction keys saves no work"
+            )
 
         expected = darts_validation_keys(
             dataset_pd,
@@ -518,6 +545,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
             entity_col=entity_col,
             lookback=lookback,
             calendar_id=calendar_id,
+            max_predict_sequences=predict_reduction,
         )
         sequence_identity = {
             "input_data_spec": mds.input_lineage,
@@ -568,9 +596,14 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         # declares. The locked holdout runner reads it as "was this run reduced" and
         # refuses anything non-zero, so a declared cap - which is part of the model and
         # applies to the holdout refit too - rides in `input_data_spec` instead.
+        # The key is omitted when unused rather than written as zero: `computation` is
+        # hashed whole, so an unconditional third key would move the training_hash of
+        # every sequence run ever registered. A preview that sets it gets a spec the
+        # locked holdout runner already refuses, which is the behaviour we want.
         "sampling": {
             "max_symbols": int(reductions.get("max_symbols", 0)),
             "max_train_sequences": sequence_reduction,
+            **({"max_predict_sequences": predict_reduction} if predict_reduction else {}),
         },
         "numerics": runtime,
         "source_identity": _sequence_source_identity(config),
@@ -603,6 +636,7 @@ def resolve_model_request(study: Study, request: dict[str, Any]):
         temporal_feature_names=tuple(mds.temporal_feature_names),
         expected_keys=expected,
         max_train_sequences=max_train_sequences,
+        max_predict_sequences=predict_reduction,
         runtime_provenance=runtime_provenance,
     )
     return spec, context
@@ -1275,6 +1309,7 @@ def run_resolved_request(
                 device=computation["numerics"]["device"],
                 save_dir=train_dir / "diagnostics",
                 max_train_sequences=context.max_train_sequences,
+                max_predict_sequences=context.max_predict_sequences,
                 register=False,
                 case_study=study.case_study,
                 temporal_by_fold=context.temporal_by_fold,
@@ -1850,6 +1885,7 @@ def run_dl_cv(
     device: str = "cuda",
     save_dir: Path | None = None,
     max_train_sequences: int = 0,
+    max_predict_sequences: int = 0,
     register: bool = False,
     case_study: str | None = None,
     notebook: str | None = None,
@@ -2165,6 +2201,7 @@ def run_dl_cv(
             entity_col=entity_col,
             lookback=lookback,
             max_train_sequences=max_train_sequences,
+            max_predict_sequences=max_predict_sequences,
             temporal_by_fold=temporal_by_fold if _has_fold_temporal else None,
             temporal_keys=temporal_keys,
             temporal_feature_names=temporal_feature_names,

--- a/case_studies/utils/sequence_dataset.py
+++ b/case_studies/utils/sequence_dataset.py
@@ -465,8 +465,16 @@ def sequence_validation_keys(
     entity_col: str,
     lookback: int,
     calendar_id: str | None = None,
+    max_predict_sequences: int = 0,
 ) -> pl.DataFrame:
-    """Return exact validation keys eligible for gap-free sequence prediction."""
+    """Return exact validation keys eligible for gap-free sequence prediction.
+
+    ``max_predict_sequences`` caps the windows drawn per fold, using the same
+    even-spacing rule and full-symbol-coverage guarantee that
+    ``max_train_sequences`` applies to training. It must match what
+    :func:`prepare_fold_sequence_stores` is given for the same fold, because these
+    keys are the contract the published predictions are checked against.
+    """
     _ensure_sequence_periods(dataset_pd, date_col=date_col, calendar_id=calendar_id)
     use_cols = [date_col, entity_col, label_col, _SEQUENCE_PERIOD_COL]
     frames: list[pl.DataFrame] = []
@@ -490,6 +498,10 @@ def sequence_validation_keys(
             entity_col=entity_col,
             lookback=lookback,
         )
+        sampled = _sample_sequence_positions(
+            np.asarray([len(positions) for positions in valid_positions], dtype=np.int64),
+            max_predict_sequences,
+        )
         rows = [
             {
                 "symbol": entities[symbol_id],
@@ -497,7 +509,9 @@ def sequence_validation_keys(
                 "fold": int(split["fold"]),
             }
             for symbol_id, positions in enumerate(valid_positions)
-            for position in positions
+            for position in (
+                positions if sampled[symbol_id] is None else positions[sampled[symbol_id]]
+            )
         ]
         if rows:
             frames.append(pl.from_dicts(rows))
@@ -522,6 +536,7 @@ def prepare_fold_sequence_stores(
     entity_col: str,
     lookback: int,
     max_train_sequences: int = 0,
+    max_predict_sequences: int = 0,
     temporal_by_fold=None,
     temporal_keys: list[str] | None = None,
     temporal_feature_names: list[str] | None = None,
@@ -650,7 +665,9 @@ def prepare_fold_sequence_stores(
     train_symbol_idx, train_end_idx = _build_sequence_index(
         train_positions, train_entities, max_train_sequences
     )
-    val_symbol_idx, val_end_idx = _build_sequence_index(val_positions, val_entities, 0)
+    val_symbol_idx, val_end_idx = _build_sequence_index(
+        val_positions, val_entities, max_predict_sequences
+    )
 
     train_store = SequenceStore(
         features=train_features,

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1996,6 +1996,12 @@ case_studies/nasdaq100_microstructure/11_dl_patchtst:
       folds: [0, 1]
       max_symbols: 5
       max_train_sequences: 2000
+      # The training cap bounded the fit and left the forward pass over validation
+      # scaling with the panel, which is why this cell sat at its 600s budget while
+      # nlinear, lstm and tcn finished in 92-94s: patchtst pays the most per window
+      # and was scoring every one of them. Matched to the training cap, three orders
+      # below the panel, and above the symbol count so the cross-section is intact.
+      max_predict_sequences: 2000
   timeout: 600
 case_studies/nasdaq100_microstructure/12_causal_dml:
   parameters:

--- a/tests/test_prediction_sequence_cap.py
+++ b/tests/test_prediction_sequence_cap.py
@@ -1,0 +1,138 @@
+"""The prediction-side preview cap: `max_predict_sequences`.
+
+`max_train_sequences` bounds how many windows a fold trains on. Nothing bounded how
+many it *scores*: `prepare_fold_sequence_stores` built its validation index with a
+hardcoded zero, and `sequence_validation_keys` had no cap to take. For an architecture
+whose per-window forward pass is expensive the validation pass then scales with the
+panel, which is why `nasdaq100_microstructure`'s patchtst notebook sat at its 600s cell
+budget while its three siblings finished in 92-94s.
+
+These tests pin the two halves separately and then together, because the failure mode
+that matters is not "too slow" - it is the two halves disagreeing, which publishes a
+prediction set that does not match the keys it was registered against.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from case_studies.utils.sequence_dataset import (
+    materialize_store_metadata,
+    prepare_fold_sequence_stores,
+    sequence_validation_keys,
+)
+from tests.test_sequence_dataset import _synthetic_fold_df
+
+LOOKBACK = 20
+FOLD = 3
+
+
+def _fixture():
+    df, train_mask, val_mask, val_start_ts, val_end_ts = _synthetic_fold_df()
+    split = {
+        "fold": FOLD,
+        "train_start": pd.Timestamp("2020-01-01"),
+        "train_end": pd.Timestamp("2020-12-31"),
+        "val_start": val_start_ts,
+        "val_end": val_end_ts,
+    }
+    return df, train_mask, val_mask, val_start_ts, split
+
+
+def _declared(df, split, cap):
+    return sequence_validation_keys(
+        df,
+        [split],
+        label_col="y",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=LOOKBACK,
+        max_predict_sequences=cap,
+    )
+
+
+def _stored(df, train_mask, val_mask, val_start_ts, cap):
+    train_store, val_store, _ = prepare_fold_sequence_stores(
+        df,
+        train_mask=train_mask,
+        val_mask=val_mask,
+        feature_names=["feat0", "feat1"],
+        label_col="y",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=LOOKBACK,
+        val_start=val_start_ts,
+        max_predict_sequences=cap,
+    )
+    _, timestamps, symbols = materialize_store_metadata(val_store)
+    keys = {
+        (str(symbol), pd.Timestamp(timestamp), FOLD)
+        for symbol, timestamp in zip(symbols, timestamps, strict=True)
+    }
+    return train_store, keys
+
+
+class TestTheTwoHalvesAgree:
+    """The declared keys and the scored windows must be the same set, capped or not."""
+
+    @pytest.mark.parametrize("cap", [0, 12, 60])
+    def test_declared_keys_equal_the_validation_store(self, cap):
+        df, train_mask, val_mask, val_start_ts, split = _fixture()
+        declared = set(_declared(df, split, cap).iter_rows())
+        _, stored = _stored(df, train_mask, val_mask, val_start_ts, cap)
+        assert declared == stored
+
+    def test_a_cap_applied_to_only_one_half_desynchronises_them(self):
+        """The regression this guards: capping keys without capping the store."""
+        df, train_mask, val_mask, val_start_ts, split = _fixture()
+        declared = set(_declared(df, split, 12).iter_rows())
+        _, stored_uncapped = _stored(df, train_mask, val_mask, val_start_ts, 0)
+        assert declared != stored_uncapped
+
+
+class TestTheCapActuallyBinds:
+    def test_it_draws_no_more_than_the_cap(self):
+        df, _, _, _, split = _fixture()
+        assert _declared(df, split, 12).height == 12
+
+    def test_it_draws_strictly_fewer_than_uncapped(self):
+        df, _, _, _, split = _fixture()
+        assert _declared(df, split, 12).height < _declared(df, split, 0).height
+
+    def test_zero_means_uncapped(self):
+        """Canonical runs pass zero, so this is the no-change guarantee."""
+        df, _, _, _, split = _fixture()
+        without = sequence_validation_keys(
+            df,
+            [split],
+            label_col="y",
+            date_col="timestamp",
+            entity_col="symbol",
+            lookback=LOOKBACK,
+        )
+        assert set(_declared(df, split, 0).iter_rows()) == set(without.iter_rows())
+
+
+class TestWhatTheCapMustNotDo:
+    def test_every_symbol_survives_the_cap(self):
+        """A cap that dropped symbols would change the cross-section, not just its size."""
+        df, _, _, _, split = _fixture()
+        uncapped = {row[0] for row in _declared(df, split, 0).iter_rows()}
+        capped = {row[0] for row in _declared(df, split, 12).iter_rows()}
+        assert capped == uncapped
+        assert len(capped) == 3
+
+    def test_it_leaves_the_training_store_alone(self):
+        """It is a coverage reduction, not a model property: the fit must not move."""
+        df, train_mask, val_mask, val_start_ts, _ = _fixture()
+        uncapped, _ = _stored(df, train_mask, val_mask, val_start_ts, 0)
+        capped, _ = _stored(df, train_mask, val_mask, val_start_ts, 12)
+        np.testing.assert_array_equal(capped.end_idx, uncapped.end_idx)
+        np.testing.assert_array_equal(capped.symbol_idx, uncapped.symbol_idx)
+        np.testing.assert_array_equal(capped.feature_mean, uncapped.feature_mean)
+
+    def test_a_cap_below_the_symbol_count_is_refused(self):
+        """Silently dropping symbols to honour the number would be worse than failing."""
+        df, _, _, _, split = _fixture()
+        with pytest.raises(ValueError, match="cannot preserve full universe coverage"):
+            _declared(df, split, 2)


### PR DESCRIPTION
## The defect

`max_train_sequences` bounds how many windows a fold **trains** on. Nothing bounded how many it **scores**. `prepare_fold_sequence_stores` built its validation index with a hardcoded zero on the line directly below the one that passes the cap:

```python
train_symbol_idx, train_end_idx = _build_sequence_index(train_positions, train_entities, max_train_sequences)
val_symbol_idx,   val_end_idx   = _build_sequence_index(val_positions,   val_entities,   0)
```

and `sequence_validation_keys` had no cap to take. So the validation forward pass scaled with the panel while the fit did not.

`max_train_sequences` reaches exactly two places - the training call and the identity hash - and neither `sequence_validation_keys` nor `darts_validation_keys` is one of them. Those build `expected_keys`, which is what the prediction pass covers.

## Why it matters now

`cs-nasdaq100_microstructure` is flaky, and this is why. Across the last 40 workflow runs:

| outcome | branch | job |
|---|---|---|
| failure | cs6/nasdaq100-vwap-loader | 24.0m |
| success | main | 22.9m |
| success | cs6/nasdaq100-dl-conversion | 22.3m |
| failure | cs6/nasdaq100-dl-conversion | 14.9m |
| failure | cs6/nasdaq100-dl-conversion | 14.6m |
| success | cs6/nasdaq100-dl-conversion | 13.9m |
| success | main x4, and 4 other branches | 13.0-14.7m |

**3 failures in 15, on two branches, and `cs6/nasdaq100-dl-conversion` both passed twice and failed twice** - the same code with both outcomes, so no diff explains it. Duration does not predict it either: the three failures are at 24.0m, 14.9m and 14.6m while 22.9m and 22.3m passed.

`11_dl_patchtst`'s population cell sits at its 600s budget. On a run that **passed**, the notebook took 737s, and its three siblings finish start-to-finish in 92-94s - so the population cell was within single-digit seconds of the cap on a passing run. The runner's per-cell variance decides each run. PatchTST pays the most per window, being channel-independent, and was scoring every window in validation.

## The change

`max_predict_sequences`, a preview-only reduction, threaded into both halves. It reuses the sampler `max_train_sequences` already uses: evenly spaced endpoints, deterministic, every symbol keeps at least one window, and a cap below the symbol count raises rather than silently thinning the cross-section.

**Two things it deliberately does not do.**

- **It never enters the training identity.** Capping how much of validation is scored changes what a run *covers*, not what it *fits*. So it is preview-only and has no counterpart under `modeling.dl`, unlike `max_train_sequences`, which is legitimately both.
- **It is written into `computation["sampling"]` only when non-zero.** `computation` is hashed whole by `project_training_identity`, so an unconditional third key would move the `training_hash` of every sequence run already registered. A canonical run keeps its exact two-key dict; a preview that sets the cap produces a spec the locked-holdout guard already refuses on the check it performs today, so that guard needed no change.

**Darts presets refuse the field rather than ignoring it.** They forecast whole series, so thinning the key set would publish fewer keys than the model produced without shortening anything. A reduction that silently does nothing is worse than one that is unavailable, because the preview still looks reduced.

## Verification

`tests/test_prediction_sequence_cap.py`, 10 cases. The load-bearing one asserts the declared keys equal the validation store at three cap values, because the failure that matters is not slowness - it is the two halves disagreeing, which publishes a prediction set that does not match the keys it was registered against.

Mutation-checked: reverting the one-line store fix fails `test_declared_keys_equal_the_validation_store` at both non-zero caps and passes at zero, then passes again on restore.

63 tests pass across the seven affected suites (`test_sequence_dataset`, `test_deep_learning_adapter`, `test_sequence_identity_roundtrip`, `test_latent_input_identity`, `test_deep_learning_state`, `test_sequence_lookup_reaches_registration`, and the new file), plus 94 in `test_pm_helpers` for the overrides change.

**Measured on this PR's own run.** `cs-nasdaq100_microstructure` passed with patchtst at **188s** (03:12:39 to 03:15:47), against 618s before the cap and a 600s budget - 412s of margin where there had been single-digit seconds. Its three siblings are unchanged at 66-67s.

One green run does not settle the flakiness on its own: the job has a measured 1.85x duration spread, and `cs6/nasdaq100-dl-conversion` has both passed and failed twice on identical code. What this run establishes is the mechanism - the cell no longer sits at its budget. A second green run is worth having before treating the intermittency as closed.

A later commit quarantines `tests/test_prediction_sequence_cap.py` from `test-unit` and lists it in `test-unit-image`. `case_studies/utils/sequence_dataset.py` imports torch at module scope for its `Dataset` subclass, and `test-unit` installs no torch, so the file failed at collection and took the job down with exit 2. `tests/test_sequence_dataset.py` already sits behind exactly that boundary; this follows it rather than adding a new mechanism.

