### PR TITLE
Upgrade econml to 0.17.0, which lifts the scikit-learn<1.7 and shap<0.49 ceilings

### DIFF
--- a/.github/workflows/reader-install.yml
+++ b/.github/workflows/reader-install.yml
@@ -14,15 +14,15 @@
 # If a step here fails, the corresponding paragraph of docs/installation.md is
 # wrong. Fix the docs or fix the dependency; do not relax the job.
 #
-# Two kinds of job, because two platforms are documented as unsupported:
+# Two kinds of job, because one documented platform is still unsupported:
 #
 #   ubuntu-latest, macos-15   walk the whole path and expect it to work
-#   windows-latest            assert `uv sync` fails, and fails on scikit-learn
-#   macos-15-intel            assert `uv sync` fails, and fails on torch
+#   windows-latest            walks it too, since econml 0.17.0 made `uv sync` complete
+#   macos-15-intel            asserts `uv sync` fails, and fails on torch
 #
-# The asserting jobs are green while the docs are accurate and red the day either
-# platform becomes installable, which is the day the docs need rewriting. They also
-# fail when the cause changes, so an unrelated break cannot quietly certify the claim.
+# The asserting job is green while the docs are accurate and red the day the platform
+# becomes installable, which is the day the docs need rewriting. It also fails when the
+# cause changes, so an unrelated break cannot quietly certify the claim.
 #
 # What this workflow cannot see. GitHub-hosted Windows runners have no WSL2 and no
 # Docker Desktop, so the recommended Windows path and the Docker path are covered by
@@ -152,18 +152,23 @@ jobs:
           du -sh .venv data 2>/dev/null || true
           df -h . | tail -1
 
-  # docs/installation.md states that installing into Windows Python does not work. This
-  # job is what keeps that statement true, by asserting the failure rather than tolerating
-  # it: `uv sync` is expected to fail, so the job is green while the docs are accurate and
-  # goes red the day native Windows starts installing, which is the day the docs need to
-  # change. `continue-on-error` on the job would have accepted a broken installer or a
-  # regression anywhere else just as happily.
+  # Native Windows used to be asserted unsupported here: `uv sync` died building
+  # scikit-learn 1.6.1, which has no Windows wheel for Python 3.14, and the job's
+  # purpose was to go red the day that stopped being true. It did, on run
+  # 33801342717, once econml 0.17.0 lifted the `scikit-learn<1.7` ceiling.
   #
-  # The observed failure: scikit-learn 1.6.1 has no Windows wheel for Python 3.14 and its
-  # meson build dies on a generated path past the 260-character limit, even on this runner,
-  # which already has the Visual Studio Build Tools.
+  # So this job now walks the same path the unix matrix walks, in pwsh, rather than
+  # asserting a failure. A sync that completes is not a supported platform: the rest
+  # of the documented path - the data-root anchor, the free download, the first
+  # notebook, the LightGBM OpenMP smoke - has never run on native Windows, and
+  # docs/installation.md must describe whatever this job proves, not the sync alone.
+  #
+  # Still outside this job's reach: GitHub-hosted Windows runners have no WSL2 and no
+  # Docker Desktop, so the recommended Windows path stays covered by the manual VM
+  # walk. The runner also arrives with the Visual Studio Build Tools, so the compiler
+  # requirement the docs state is never tested here either.
   windows:
-    name: Windows native (asserted unsupported)
+    name: Windows native
     runs-on: windows-latest
     timeout-minutes: 90
     defaults:
@@ -172,46 +177,87 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The docs give no Windows uv command, because there is no supported Windows path.
-      - name: Install uv
+      # docs/installation.md, "Local Setup with uv" - the PowerShell line of the same step.
+      - name: Install uv as the docs instruct
         run: |
           irm https://astral.sh/uv/install.ps1 | iex
           "$env:USERPROFILE\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
 
-      - name: uv sync is expected to fail here, for the documented reason
+      - name: uv sync
         run: |
-          uv sync 2>&1 | Tee-Object -Variable out
-          $code = $LASTEXITCODE
-          $text = $out -join "`n"
+          uv sync
+          if ($LASTEXITCODE -ne 0) { throw "uv sync failed with exit $LASTEXITCODE" }
 
-          if ($code -eq 0) {
-            Write-Error @"
-          uv sync SUCCEEDED on native Windows.
-
-          docs/installation.md tells readers that installing into Windows Python is not
-          supported and does not work. That is no longer true, so the documentation is now
-          wrong and should be updated to describe the native Windows path.
-          "@
-            exit 1
+      # The unix half of this check caught a data root that resolved relative to the
+      # working directory, which is what every Jupyter kernel gives a notebook. Windows
+      # resolves paths through a different branch of pathlib, so it is checked separately
+      # rather than assumed to follow.
+      - name: The data root is anchored to the repo, not to the working directory
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repo = (Get-Location).Path
+          $root = uv run python -c "import os;print(os.environ['ML4T_DATA_PATH'])"
+          Push-Location 01_process_is_edge
+          $chapter = uv run python -c "import os;print(os.environ['ML4T_DATA_PATH'])"
+          Pop-Location
+          $hook = uv run python -c "import sitecustomize;print(sitecustomize.__file__)"
+          Write-Host "repo root:     $root"
+          Write-Host "chapter:       $chapter"
+          Write-Host "sitecustomize: $hook"
+          # Compare resolved paths, not strings: pathlib and PowerShell disagree on
+          # separators and on drive-letter case, and neither disagreement is a defect.
+          function Norm($p) { [IO.Path]::GetFullPath($p).TrimEnd('\').ToLowerInvariant() }
+          if ((Norm $root) -ne (Norm (Join-Path $repo 'data'))) {
+            throw "ML4T_DATA_PATH is $root, expected $(Join-Path $repo 'data')"
+          }
+          if ((Norm $chapter) -ne (Norm $root)) {
+            throw "ML4T_DATA_PATH moved to $chapter inside a chapter directory; it must stay $root"
+          }
+          if ((Norm $hook) -ne (Norm (Join-Path $repo 'sitecustomize.py'))) {
+            throw "sitecustomize resolved to $hook, expected $(Join-Path $repo 'sitecustomize.py')"
           }
 
-          # Any failure would otherwise read as proof of the documented one. A network
-          # blip, a bad lockfile or a broken installer must not quietly certify the claim.
-          if ($text -notmatch 'Failed to build `?scikit-learn') {
-            Write-Error @"
-          uv sync failed on native Windows, but not for the documented reason.
+      - name: Copy the environment template
+        run: Copy-Item .env.example .env
 
-          Expected a scikit-learn build failure, which is what makes native Windows
-          unsupported. Something else broke instead, and this job cannot tell you the
-          documented claim still holds. Read the output above.
-          "@
-            exit 1
+      - name: Verify the installation
+        run: |
+          uv run python scripts/verify_installation.py
+          if ($LASTEXITCODE -ne 0) { throw "verify_installation.py failed with exit $LASTEXITCODE" }
+
+      - name: Download the free datasets
+        run: |
+          uv run python data/download_all.py --free-only
+          if ($LASTEXITCODE -ne 0) { throw "download_all.py failed with exit $LASTEXITCODE" }
+
+      - name: Run the first notebook
+        env:
+          MPLBACKEND: Agg
+          PLOTLY_RENDERER: json
+        run: |
+          uv run python 01_process_is_edge/factor_regimes.py
+          if ($LASTEXITCODE -ne 0) { throw "factor_regimes.py failed with exit $LASTEXITCODE" }
+
+      # LightGBM's OpenMP runtime is the macOS failure this smoke test was written for,
+      # but Windows links a third OpenMP (the MSVC one) and has never been checked.
+      - name: LightGBM fits multithreaded after scikit-learn is on the path
+        run: |
+          uv run python .github/scripts/smoke_lightgbm_openmp.py
+          if ($LASTEXITCODE -ne 0) { throw "smoke_lightgbm_openmp.py failed with exit $LASTEXITCODE" }
+
+      - name: Report the footprint a reader pays
+        if: always()
+        run: |
+          foreach ($dir in '.venv', 'data') {
+            if (Test-Path $dir) {
+              $mb = (Get-ChildItem $dir -Recurse -File -ErrorAction SilentlyContinue |
+                     Measure-Object -Property Length -Sum).Sum / 1MB
+              Write-Host ("{0,-8} {1:N0} MB" -f $dir, $mb)
+            }
           }
-
-          Write-Host "uv sync failed building scikit-learn, as documented (exit $code); native Windows remains unsupported."
-          # GitHub's pwsh shell appends `exit $LASTEXITCODE`, so the non-zero status from
-          # the expected failure would fail this step. Clear it deliberately.
-          exit 0
+          Get-PSDrive -Name (Get-Location).Drive.Name |
+            Select-Object Name, @{n='UsedGB';e={[math]::Round($_.Used/1GB)}},
+                                @{n='FreeGB';e={[math]::Round($_.Free/1GB)}}
 
   # docs/installation.md tells Intel Mac readers to use Docker because the local uv path
   # cannot work there: PyTorch publishes no macOS x86_64 wheel and torch has no sdist, so

--- a/case_studies/utils/runtime.py
+++ b/case_studies/utils/runtime.py
@@ -14,13 +14,22 @@ from __future__ import annotations
 
 import os
 import platform
-import resource
 import subprocess
 import sys
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
+
+# POSIX only, and this module is imported by every model runner, so a bare import made
+# `import case_studies.utils.gbm` fail outright on native Windows - found by the Reader
+# install walk once econml 0.17.0 made `uv sync` complete there. The two readings it
+# provides have exact Windows equivalents below; nothing here influences a fitted result,
+# so a platform difference in how a cost is measured is not a difference in the result.
+try:
+    import resource
+except ModuleNotFoundError:  # pragma: no cover - Windows
+    resource = None
 
 __all__ = [
     "ResourceUsage",
@@ -78,6 +87,41 @@ class ResourceUsage(dict):
         return float(self.get("elapsed_s", 0.0))
 
 
+def _windows_peak_working_set() -> int:
+    """Peak working set of this process, in bytes - the Windows reading of `ru_maxrss`.
+
+    `PROCESS_MEMORY_COUNTERS` is `cb`, `PageFaultCount`, then eight `SIZE_T` fields, of which
+    `PeakWorkingSetSize` is the first. Reported in bytes already, so no scale is applied.
+    Returning 0 on failure would be a false measurement, so this raises nothing and the
+    caller sees the zero only if the API itself refused.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    class _Counters(ctypes.Structure):
+        _fields_ = [
+            ("cb", wintypes.DWORD),
+            ("PageFaultCount", wintypes.DWORD),
+            ("PeakWorkingSetSize", ctypes.c_size_t),
+            ("WorkingSetSize", ctypes.c_size_t),
+            ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+            ("PagefileUsage", ctypes.c_size_t),
+            ("PeakPagefileUsage", ctypes.c_size_t),
+        ]
+
+    counters = _Counters()
+    counters.cb = ctypes.sizeof(_Counters)
+    ok = ctypes.windll.psapi.GetProcessMemoryInfo(
+        ctypes.windll.kernel32.GetCurrentProcess(),
+        ctypes.byref(counters),
+        counters.cb,
+    )
+    return int(counters.PeakWorkingSetSize) if ok else 0
+
+
 def peak_rss_bytes() -> int:
     """Peak resident set size of this process, in bytes.
 
@@ -91,6 +135,8 @@ def peak_rss_bytes() -> int:
     reports a peak 1024 times too large, and `scripts/pre_run_gate.py` prints that figure in GB
     as a check it passes on.
     """
+    if resource is None:  # pragma: no cover - Windows
+        return _windows_peak_working_set()
     usage = resource.getrusage(resource.RUSAGE_SELF)
     scale = 1 if sys.platform == "darwin" else 1024
     return int(usage.ru_maxrss) * scale
@@ -98,6 +144,9 @@ def peak_rss_bytes() -> int:
 
 def cpu_seconds() -> float:
     """CPU time consumed by this process so far. Differences between two readings are the run."""
+    if resource is None:  # pragma: no cover - Windows
+        # User plus system CPU for this process, which is what ru_utime + ru_stime sums.
+        return float(time.process_time())
     usage = resource.getrusage(resource.RUSAGE_SELF)
     return float(usage.ru_utime + usage.ru_stime)
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -53,6 +53,35 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent
 
+
+def _force_utf8_console() -> None:
+    """Make stdout and stderr UTF-8 on Windows, where they default to the ANSI code page.
+
+    A Windows console interpreter encodes ``print`` through ``cp1252``, so the first
+    non-ASCII character in a progress line raises ``UnicodeEncodeError`` and takes the
+    process with it. ``data/futures/positioning/cot_download.py:135`` prints
+    ``f" {len(df):,} rows -> {out_path.name}"`` with a real arrow, and on the Reader
+    install walk that killed the CFTC download *after* all seven years had been fetched
+    and written - the data was on disk and the script died reporting it. Twenty-odd other
+    scripts under ``data/`` print non-ASCII too, so this belongs at the interpreter, not
+    at each print.
+
+    Not ``PYTHONUTF8=1``: that only helps a reader who sets it before every command, and
+    ``.env`` is read too late - the streams already exist by then.
+    """
+    if sys.platform != "win32":
+        return
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+
+
+try:
+    _force_utf8_console()
+except Exception:  # noqa: BLE001 - startup hook: never break the interpreter
+    pass
+
 for _chapter_dir in sorted(_REPO_ROOT.glob("[0-9][0-9]_*")):
     if _chapter_dir.is_dir():
         _entry = str(_chapter_dir)

--- a/tests/test_runtime_without_posix_resource.py
+++ b/tests/test_runtime_without_posix_resource.py
@@ -1,0 +1,81 @@
+"""`case_studies.utils.runtime` must import where the POSIX `resource` module does not exist.
+
+Every model runner imports it, so a bare `import resource` made `import case_studies.utils.gbm`
+fail outright on native Windows - `ModuleNotFoundError: No module named 'resource'`, found by the
+Reader install walk once econml 0.17.0 made `uv sync` complete there.
+
+The two readings it provides are costs, not results: this module states that nothing in it may
+influence a fitted result, so measuring a cost differently per platform is not a difference in
+the numbers a reader gets.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+import time
+
+import pytest
+
+MODULE = "case_studies.utils.runtime"
+
+
+@pytest.fixture
+def runtime_without_resource(monkeypatch):
+    """Import the module with `resource` absent, the way a Windows interpreter sees it."""
+    real_import = builtins.__import__
+
+    def _import(name, *args, **kwargs):
+        if name == "resource":
+            raise ModuleNotFoundError("No module named 'resource'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+    monkeypatch.delitem(sys.modules, MODULE, raising=False)
+    monkeypatch.delitem(sys.modules, "resource", raising=False)
+    module = importlib.import_module(MODULE)
+    yield module
+    # Leave the real module behind for everything else in the session.
+    monkeypatch.undo()
+    importlib.reload(importlib.import_module(MODULE))
+
+
+def test_the_module_imports_without_the_posix_resource_module(runtime_without_resource):
+    assert runtime_without_resource.resource is None
+
+
+def test_cpu_seconds_still_reports_process_cpu_time(runtime_without_resource):
+    """`time.process_time()` sums user and system CPU for the process, which is what
+    `ru_utime + ru_stime` sums. A difference between two readings is still the run."""
+    before = runtime_without_resource.cpu_seconds()
+    deadline = time.process_time() + 0.02
+    while time.process_time() < deadline:
+        pass
+    after = runtime_without_resource.cpu_seconds()
+
+    assert before >= 0.0
+    assert after > before
+
+
+def test_resource_measurement_still_records_every_field(runtime_without_resource, monkeypatch):
+    """`process_peak_rss_bytes` is read through the Windows helper on that platform; here the
+    helper cannot run, so it is stubbed to prove the field is still populated and `cores_used`
+    is still derived."""
+    monkeypatch.setattr(runtime_without_resource, "_windows_peak_working_set", lambda: 4096)
+
+    measured = runtime_without_resource.resource_measurement(elapsed_s=2.0, cpu_s=8.0)
+
+    assert measured["process_peak_rss_bytes"] == 4096
+    assert measured["cpu_s"] == 8.0
+    assert measured["cores_used"] == 4.0
+    assert measured["cpu_count"] == runtime_without_resource.os.cpu_count()
+
+
+def test_the_posix_reading_is_unchanged_where_resource_exists():
+    """The platform this runs on keeps `getrusage`, so the recorded numbers do not move."""
+    runtime = importlib.import_module(MODULE)
+    if runtime.resource is None:  # pragma: no cover - only on Windows
+        pytest.skip("no POSIX resource module on this platform")
+    assert runtime.peak_rss_bytes() > 0
+    assert runtime.cpu_seconds() > 0.0

--- a/tests/test_sitecustomize_console_encoding.py
+++ b/tests/test_sitecustomize_console_encoding.py
@@ -13,6 +13,7 @@ here rather than only on a Windows runner.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
@@ -36,12 +37,15 @@ class _Stream:
         self.calls.append(kwargs)
 
 
-def _run(code: str, encoding: str | None) -> subprocess.CompletedProcess:
-    env = {"PATH": "", "SystemRoot": ""}
-    if encoding is not None:
-        env["PYTHONIOENCODING"] = encoding
+def _run(code: str, encoding: str) -> subprocess.CompletedProcess:
+    # `-S` skips `site`, which is what imports `sitecustomize`. Without it this checkout's
+    # own hook would run first and apply the fix on Windows, so the test meant to reproduce
+    # the failure would pass by never reaching it - green on every platform but the one
+    # under repair. The environment is inherited rather than replaced because Windows needs
+    # `SystemRoot` to start an interpreter at all.
+    env = {**os.environ, "PYTHONIOENCODING": encoding}
     return subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, env=env, check=False
+        [sys.executable, "-S", "-c", code], capture_output=True, text=True, env=env, check=False
     )
 
 

--- a/tests/test_sitecustomize_console_encoding.py
+++ b/tests/test_sitecustomize_console_encoding.py
@@ -1,0 +1,102 @@
+"""`sitecustomize` forces UTF-8 on stdout, which is what keeps Windows readers' scripts alive.
+
+A Windows console interpreter encodes `print` through the ANSI code page - `cp1252` on a
+default install - so the first non-ASCII character in a progress line raises
+`UnicodeEncodeError` and takes the process down. The Reader install walk hit exactly that:
+`data/futures/positioning/cot_download.py:135` prints an arrow, and the CFTC download died
+reporting seven years of data it had already fetched and written.
+
+The repro below is platform-independent: `PYTHONIOENCODING=cp1252` puts any interpreter in
+the same position a Windows console puts one, so the failure and the fix are both provable
+here rather than only on a Windows runner.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from tests.test_sitecustomize_data_root import load_sitecustomize
+
+sc = load_sitecustomize()
+
+# The character that actually broke the run, not a stand-in.
+ARROW = "→"
+
+
+class _Stream:
+    """A stdout that records what it was reconfigured to, the way `TextIOWrapper` accepts it."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def reconfigure(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+
+
+def _run(code: str, encoding: str | None) -> subprocess.CompletedProcess:
+    env = {"PATH": "", "SystemRoot": ""}
+    if encoding is not None:
+        env["PYTHONIOENCODING"] = encoding
+    return subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env, check=False
+    )
+
+
+def test_an_ansi_code_page_kills_a_script_on_the_first_non_ascii_character():
+    """The defect itself. Without this the fix below is a change with nothing behind it."""
+    result = _run(f"print('rows {ARROW} out.parquet')", encoding="cp1252")
+    assert result.returncode != 0
+    assert "UnicodeEncodeError" in result.stderr
+
+
+def test_reconfiguring_to_utf8_is_what_lets_the_same_script_finish():
+    result = _run(
+        f"import sys; sys.stdout.reconfigure(encoding='utf-8'); print('rows {ARROW} out.parquet')",
+        encoding="cp1252",
+    )
+    assert result.returncode == 0
+    assert ARROW in result.stdout
+
+
+def test_the_hook_reconfigures_both_streams_on_windows(monkeypatch):
+    out, err = _Stream(), _Stream()
+    monkeypatch.setattr(sc.sys, "platform", "win32")
+    monkeypatch.setattr(sc.sys, "stdout", out)
+    monkeypatch.setattr(sc.sys, "stderr", err)
+
+    sc._force_utf8_console()
+
+    for stream in (out, err):
+        assert stream.calls == [{"encoding": "utf-8", "errors": "backslashreplace"}]
+
+
+@pytest.mark.parametrize("platform", ["linux", "darwin"])
+def test_the_hook_leaves_posix_streams_alone(monkeypatch, platform):
+    """Posix already gives UTF-8, and reconfiguring a redirected stream there would be a
+    change nobody asked for - a reader piping output to a file chose that encoding."""
+    out, err = _Stream(), _Stream()
+    monkeypatch.setattr(sc.sys, "platform", platform)
+    monkeypatch.setattr(sc.sys, "stdout", out)
+    monkeypatch.setattr(sc.sys, "stderr", err)
+
+    sc._force_utf8_console()
+
+    assert out.calls == []
+    assert err.calls == []
+
+
+def test_a_stream_that_cannot_be_reconfigured_is_not_an_error(monkeypatch):
+    """Under papermill and under pytest's capture, stdout is not a `TextIOWrapper` and has
+    no `reconfigure`. The hook runs at interpreter startup, so it must never raise."""
+
+    class _NoReconfigure:
+        pass
+
+    monkeypatch.setattr(sc.sys, "platform", "win32")
+    monkeypatch.setattr(sc.sys, "stdout", _NoReconfigure())
+    monkeypatch.setattr(sc.sys, "stderr", _NoReconfigure())
+
+    sc._force_utf8_console()

--- a/tests/test_sitecustomize_console_encoding.py
+++ b/tests/test_sitecustomize_console_encoding.py
@@ -44,8 +44,16 @@ def _run(code: str, encoding: str) -> subprocess.CompletedProcess:
     # under repair. The environment is inherited rather than replaced because Windows needs
     # `SystemRoot` to start an interpreter at all.
     env = {**os.environ, "PYTHONIOENCODING": encoding}
+    # Decode explicitly. `text=True` alone decodes with the *parent's* locale encoding,
+    # which on Windows is the same cp1252 this test is about, so the arrow the second
+    # subprocess deliberately writes as UTF-8 would come back as mojibake and the
+    # assertion would fail on the platform being fixed.
     return subprocess.run(
-        [sys.executable, "-S", "-c", code], capture_output=True, text=True, env=env, check=False
+        [sys.executable, "-S", "-c", code],
+        capture_output=True,
+        encoding="utf-8",
+        env=env,
+        check=False,
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = "==3.14.*"
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "platform_machine != 'x86_64' or sys_platform != 'darwin'",
+]
 
 [options]
 prerelease-mode = "if-necessary"
@@ -722,7 +726,7 @@ name = "build"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "colorama", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
@@ -786,7 +790,7 @@ wheels = [
 
 [[package]]
 name = "causalml"
-version = "0.16.0"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "black" },
@@ -803,12 +807,13 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
-    { name = "shap" },
+    { name = "shap", version = "0.49.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "shap", version = "0.52.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "statsmodels" },
     { name = "tqdm" },
     { name = "xgboost" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/55/19e54981b64057453254f1bdc94104b0148c33e9c7b0ccb774000c11c9d0/causalml-0.16.0.tar.gz", hash = "sha256:fb2ea2da2a37c5597b3f292d086f1ed4b1989e9b473577b10724abc90f31b060", size = 2024129, upload-time = "2026-02-06T17:50:12.875Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/26/7422e3d87d39fc795efd47f56f119a0629c8e2078c16f1b823747b9c9997/causalml-0.17.0.tar.gz", hash = "sha256:638e9a1d5feadf3c441dadb24bfd26451100b95b4edec5f7dab1f6d326152d95", size = 1931750, upload-time = "2026-07-04T06:54:57.963Z" }
 
 [[package]]
 name = "ccxt"
@@ -1305,7 +1310,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
@@ -1450,7 +1455,8 @@ dependencies = [
     { name = "requests" },
     { name = "scikit-learn" },
     { name = "scipy" },
-    { name = "shap" },
+    { name = "shap", version = "0.49.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "shap", version = "0.52.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "statsmodels" },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -1747,21 +1753,31 @@ wheels = [
 
 [[package]]
 name = "econml"
-version = "0.16.0"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
     { name = "lightgbm" },
+    { name = "numba" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pandas" },
     { name = "scikit-learn" },
     { name = "scipy" },
-    { name = "shap" },
+    { name = "shap", version = "0.49.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "shap", version = "0.52.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "sparse" },
     { name = "statsmodels" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/99/16d00b532e2f499538df7ab7ed5da7447692e29a03ae60823714aed2383f/econml-0.16.0.tar.gz", hash = "sha256:4ca862a25e4dd789fd7356adaa04bfed3683056e5d25e90ea75cdab0535d56ff", size = 1703353, upload-time = "2025-07-10T15:07:08.821Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/fa3f0bd1f0ee613f81f4442bab98dc39f486a28865d300b35124506c1ed7/econml-0.17.0.tar.gz", hash = "sha256:b637b6166d290203775954c3af58c45a728a932315df3c334a625ab94e6e0b30", size = 1767740, upload-time = "2026-07-31T20:56:30.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/e9/0094621a70b246bc0a26956c7a7539786442540b4ac9caf66d209cd5fc04/econml-0.17.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8582c059b735867de0ee39359f8f7ac54d8451ffde3bf5ae9cfaf26b86d64894", size = 2398628, upload-time = "2026-07-31T20:56:13.264Z" },
+    { url = "https://files.pythonhosted.org/packages/61/42/de30058d2f53e22d5c94d598da2789d3278a52d20a607166a9f6915f7adc/econml-0.17.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c135f2f58b089acb2c44bc51432956dfcdf5a0d642ec6f364ef009dcb97ef51", size = 5565547, upload-time = "2026-07-31T20:56:14.996Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/bd/317e584748378aac4a7b481512425be618c5586ecfffc1791780e64b10e1/econml-0.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:5e2b5eb5cd19fa628805e4a6064e74784116cd2e30ee69532461320ea63f0ecf", size = 2313378, upload-time = "2026-07-31T20:56:16.733Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/96/fcde612e5430ad9694992dfa92c9fd49d5689dd127cfe56057a62c17dfa7/econml-0.17.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:110ca11fa8f0fecba514b87747db03b2e4a385e68ca1ffc83e6f27f743824a4e", size = 2434451, upload-time = "2026-07-31T20:56:18.787Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8e/4edd4a2d8b458ddeceed37a712414d3d0d2c336544f1195672509d78f505/econml-0.17.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34539aa17ed4fec2f35c4f7314925ca670f32a64a8546a59a53a7b9b53856265", size = 5551979, upload-time = "2026-07-31T20:56:20.476Z" },
+    { url = "https://files.pythonhosted.org/packages/59/89/f499ab47cbb57465ce3ec8dd7b260200a113f21ab1f36e85f991f1b968be/econml-0.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a613a3b9eeb33a9bd860032a5352a3ba327b271d609793b076e277d279937e51", size = 2354549, upload-time = "2026-07-31T20:56:22.493Z" },
+]
 
 [[package]]
 name = "edgartools"
@@ -3294,7 +3310,7 @@ dependencies = [
     { name = "nbformat" },
     { name = "packaging" },
     { name = "prometheus-client" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "pyzmq" },
     { name = "send2trash" },
     { name = "terminado" },
@@ -3312,7 +3328,7 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
@@ -4216,7 +4232,8 @@ dependencies = [
     { name = "secedgar" },
     { name = "sentence-transformers" },
     { name = "sentencepiece" },
-    { name = "shap" },
+    { name = "shap", version = "0.49.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "shap", version = "0.52.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "skfolio" },
     { name = "sktime" },
     { name = "stable-baselines3" },
@@ -4634,7 +4651,7 @@ name = "mlx"
 version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-metal", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
@@ -5205,7 +5222,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -5216,7 +5233,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -5243,9 +5260,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -5256,7 +5273,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -7366,7 +7383,7 @@ wheels = [
 
 [[package]]
 name = "scikit-learn"
-version = "1.6.1"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -7374,7 +7391,14 @@ dependencies = [
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/a5/4ae3b3a0755f7b35a280ac90b28817d1f380318973cff14075ab41ef50d9/scikit_learn-1.6.1.tar.gz", hash = "sha256:b4fc2525eca2c69a59260f583c56a7557c6ccdf8deafdba6e060f94c1c59738e", size = 7068312, upload-time = "2025-01-10T08:07:55.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/82/dee5acf66837852e8e68df6d8d3a6cb22d3df997b733b032f513d95205b7/scikit_learn-1.7.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fa8f63940e29c82d1e67a45d5297bdebbcb585f5a5a50c4914cc2e852ab77f33", size = 9208906, upload-time = "2025-09-09T08:21:18.557Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/30/9029e54e17b87cb7d50d51a5926429c683d5b4c1732f0507a6c3bed9bf65/scikit_learn-1.7.2-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f95dc55b7902b91331fa4e5845dd5bde0580c9cd9612b1b2791b7e80c3d32615", size = 8627836, upload-time = "2025-09-09T08:21:20.695Z" },
+    { url = "https://files.pythonhosted.org/packages/60/18/4a52c635c71b536879f4b971c2cedf32c35ee78f48367885ed8025d1f7ee/scikit_learn-1.7.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9656e4a53e54578ad10a434dc1f993330568cfee176dff07112b8785fb413106", size = 9426236, upload-time = "2025-09-09T08:21:22.645Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7e/290362f6ab582128c53445458a5befd471ed1ea37953d5bcf80604619250/scikit_learn-1.7.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96dc05a854add0e50d3f47a1ef21a10a595016da5b007c7d9cd9d0bffd1fcc61", size = 9312593, upload-time = "2025-09-09T08:21:24.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/87/24f541b6d62b1794939ae6422f8023703bbf6900378b2b34e0b4384dfefd/scikit_learn-1.7.2-cp314-cp314-win_amd64.whl", hash = "sha256:bb24510ed3f9f61476181e4db51ce801e2ba37541def12dc9333b946fc7a9cf8", size = 8820007, upload-time = "2025-09-09T08:21:26.713Z" },
+]
 
 [[package]]
 name = "scipy"
@@ -7465,8 +7489,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "jeepney", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -7536,21 +7560,58 @@ wheels = [
 
 [[package]]
 name = "shap"
-version = "0.48.0"
+version = "0.49.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cloudpickle" },
-    { name = "numba" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "scikit-learn" },
-    { name = "scipy" },
-    { name = "slicer" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'darwin'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/79/edeb71f5ee8a936a1d40413188000640ab91da72771e837f1ded141a0ed4/shap-0.48.0.tar.gz", hash = "sha256:f169dc73fe144e70a0331b5507f9fd290d7695a3c7935fa8e4862e376321baf9", size = 3061913, upload-time = "2025-06-12T13:05:35.055Z" }
+dependencies = [
+    { name = "cloudpickle", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numba", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pandas", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "scikit-learn", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "scipy", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "slicer", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/c6/9823a7f483aa9f3179fc359c10d22da9e418b1a7a3fc99a42b705d05e82a/shap-0.49.1.tar.gz", hash = "sha256:1114ecd804fff29f50d522ce6031082fcf42fe4a32fb1b5da233b2415d784c8c", size = 4084725, upload-time = "2025-10-14T10:04:49.75Z" }
+
+[[package]]
+name = "shap"
+version = "0.52.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine != 'x86_64' or sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "cloudpickle", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "llvmlite", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numba", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "packaging", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "pandas", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "scikit-learn", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "scipy", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "slicer", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/0a/aa278f42c08cb47f2bb503085be0c521da2886929c6605b6105748a7590f/shap-0.52.0.tar.gz", hash = "sha256:81d4ae478f67f8122de1bb411dc4e3ddff0604cbc27dc9cb8ea66d5c73462fd2", size = 4192842, upload-time = "2026-05-28T14:17:49.011Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/61/ddbe6fb40120fc7d3dbd702f5f4e0ef1c0795e39f208afbc928ce46a0246/shap-0.52.0-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:334cdc36a925db2242875f69267b88eb6108ec47a6c259f4f87a6b022b6188dc", size = 496146, upload-time = "2026-05-28T14:17:33.352Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d1/b020cb524513496d046a9711ec466c0fdd479b722c09ceb1162c138d0db7/shap-0.52.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a1116361c01fc5a045cf34681673f6c79100e2e648a6fbde7da084d18193d2e", size = 490868, upload-time = "2026-05-28T14:17:35.075Z" },
+    { url = "https://files.pythonhosted.org/packages/88/58/6e7f8d13b6078485a4bc3c5e6ae97ef52c9208315206982fd0fedabe2db4/shap-0.52.0-cp312-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61e431aed9de5f2deae1b7847b00edd739b8d85df9c4d04b137230d20dbbd4d3", size = 495268, upload-time = "2026-05-28T14:17:36.312Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/8aad9c7cc4c09a3841496def5434f56d1b172ad55dbb42fc839c25798f1c/shap-0.52.0-cp312-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20b3d09fdff3e94e418abec1f6033522189e4ca554f1014a2b320f80b5454ad2", size = 498042, upload-time = "2026-05-28T14:17:37.664Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/78/f8f86c768a2fae213d99721666eb01653347b1398cf6e24afd84743899a8/shap-0.52.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6b843d61e18ad4659584e004a4e681fff0648d4cf371830e3019709722190467", size = 1570560, upload-time = "2026-05-28T14:17:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/20/f5824640d8e7bf6bffb2ed8f6221c8c6fb2d39b638ba72f01b60e934e40f/shap-0.52.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2828d18366db812599a5d8340ce93fed9c95d97337d90568597b2e96d01ce516", size = 1627401, upload-time = "2026-05-28T14:17:40.435Z" },
+    { url = "https://files.pythonhosted.org/packages/58/bf/6be16d28ef1b6ff69078a1d7ea58892e9d40a4680c1077563f74ebd31c9e/shap-0.52.0-cp312-abi3-win_amd64.whl", hash = "sha256:07d44ace491ca6204dac6ce4fda128bcaeff27553a279bca67c55a14987cc957", size = 499853, upload-time = "2026-05-28T14:17:41.786Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bc/677a58515255ed9d418f35406f42bb73434481d533b3408f9aba787e7a39/shap-0.52.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:514140e2b89f8d4600637cdff8242ac194b96f8ef820b06ab6584d105c1f9b68", size = 494655, upload-time = "2026-05-28T14:17:43.24Z" },
+    { url = "https://files.pythonhosted.org/packages/28/59/e59a449a53217840fa21c7072d6535d85805b77c9f27ab10cedba8e3d5ca/shap-0.52.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb34bf01572048213d60d75d9329c62112d77a5190c18c05f572044dda8e0d83", size = 499315, upload-time = "2026-05-28T14:17:44.528Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/7f/60c047319846fd144bb9ed1adcb1121a3ff1f36158847d0dfe9c94c7f241/shap-0.52.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:09fca6cc9d8d4b9921bf6b56d381a5df0e26cb1b3cd572b2b2f6e48cf9c5d4ad", size = 1576710, upload-time = "2026-05-28T14:17:46.051Z" },
+    { url = "https://files.pythonhosted.org/packages/63/90/e676b9315bee9f6278ac6662c276710c41a3c5b8fb6c21aa89240e04356e/shap-0.52.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59b201ef00ce38359997eb9363ff561c89a98461bd81d9fdae8b5350a176eee5", size = 1633807, upload-time = "2026-05-28T14:17:47.544Z" },
+]
 
 [[package]]
 name = "shellingham"
@@ -7828,13 +7889,12 @@ wheels = [
 
 [[package]]
 name = "statsforecast"
-version = "2.0.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloudpickle" },
     { name = "coreforecast" },
     { name = "fugue" },
-    { name = "numba" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "scipy" },
@@ -7843,7 +7903,14 @@ dependencies = [
     { name = "tqdm" },
     { name = "utilsforecast" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/5b/7fbf787cc947ff358d3a4ec81911f0386aca66d643fdd5128f599a901479/statsforecast-2.0.1.tar.gz", hash = "sha256:dd856ad584f4d561b233da0db2b8e52b3a5cfa27109b0e0cb780293a836ad0b0", size = 2880305, upload-time = "2025-02-18T19:42:44.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/6f/25a1874c72d68c84a3cce1920fb29819090d8276ab9d896cbdebdfa68923/statsforecast-2.1.1.tar.gz", hash = "sha256:3b4c91ac4e2a51a614596226df3cb210f99a152601f8235e0459248d05a42045", size = 2903236, upload-time = "2026-07-16T18:20:47.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/62/ae74c47e684eba0dc2d6c0a7c161be01957651d07a8a79488ce8682687cc/statsforecast-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a063096f9403b36f94975e1676be1aff63b620a3e71c91e1dc910813edf80684", size = 439552, upload-time = "2026-07-16T18:20:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c8/65f891a745b0496053d34ceb2086be0f61ff575d89ec37e847d9300e95a1/statsforecast-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3393ee930dc49a80649869340c6b549bff92c399595071c6bbcb512d44d525c7", size = 428929, upload-time = "2026-07-16T18:20:40.026Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9d/683e32ded2550ec81e54a2e838965d34ae4a2dbff6b82166ee474b5a1f27/statsforecast-2.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fd5f52d9d396027236af4152317ce3eac7c1c5f4c2b01248da10a74a193e0e2", size = 470454, upload-time = "2026-07-16T18:20:41.984Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/71/b9b3c01c19ebad53d47f0b3be82d18976ab66293445dff4dd1e36ae50418/statsforecast-2.1.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fce69a9ba74adf4ad8b3a48071dae9e50bc8313a30380ad20bc723e31cd6f58c", size = 502587, upload-time = "2026-07-16T18:20:43.761Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3a/feef6d3772b906ec033a914cfae7652f6c3154c1a5ac4cf94905db2d7542/statsforecast-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b00906992bba9c1ac779bf414801ad7f6df59754a1ab12c2869b1bc04de2cd0a", size = 601618, upload-time = "2026-07-16T18:20:45.813Z" },
+]
 
 [[package]]
 name = "statsmodels"
@@ -8015,7 +8082,7 @@ version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess", marker = "os_name != 'nt'" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }


### PR DESCRIPTION
`econml==0.16.0` capped `scikit-learn<1.7` and `shap<0.49.0` in its own metadata. Those are exactly the versions with no Python 3.14 wheels, so that single pin is why the shipped `uv.lock` builds twelve packages from source and why `uv sync` cannot complete on native Windows at all: it dies building `scikit-learn 1.6.1`.

econml 0.17.0 has released and both ceilings are gone. Re-resolving the lock moves:

| package | before | after |
|---|---|---|
| econml | 0.16.0 | 0.17.0 |
| causalml | 0.16.0 | 0.17.0 |
| scikit-learn | 1.6.1 (no cp314 wheel) | 1.7.2 (cp314 wheels) |
| shap | 0.48.0 | 0.52.0 |
| statsforecast | 2.0.1 | 2.1.1 |

`pyproject.toml` needs no edit - its own constraints (`econml>=0.15`, `scikit-learn>=1.4`, `shap>=0.45`) were already permissive, and the cap came entirely from econml's metadata.

## Verification

- `tests/test_causal_adapter.py`: 28 passed.
- The six econml notebooks under `tests/test_chapter_notebooks.py`: 5 passed, 1 skipped (`15_causal_estimation/05_momentum_causal_trading`, a pre-existing declared skip in `tests/overrides.yaml:668-674`).
- Full unit suite run twice on the same machine and the same command, once on the baseline lock and once on the upgraded one: 96 and 100 failures. The four that differ are all `test_model_registry.py::test_model_notebook[*latent_factors]`, and all four pass when run on their own against the upgraded lock, so they are full-suite ordering effects rather than an upgrade regression. Every pre-existing failure is an `AssertionError` or `FileNotFoundError` from local registry and fixture state (ml4t/agent-workspace#913, #976); there is no import or version error anywhere in either run.

## What this PR does not yet settle

The `Reader install` workflow's Windows job asserts the failure **by name** - it requires the output to match `Failed to build scikit-learn` and fails if `uv sync` succeeds instead. This PR touches `uv.lock`, so that workflow runs on it. Whether native Windows now installs is unmeasured: shap, hmmlearn, ruptures, causalml and econml itself still compile there. `docs/installation.md` needs updating to whatever that job proves, and the assertion needs rewriting (or the Windows half deleted, if the platform becomes supported) in the same change.

Refs ml4t/agent-workspace#166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQUuNRz572ohmUwscwmzp