### PR TITLE
Chapter 2: say what adj_close is anchored to

### DIFF
--- a/02_financial_data_universe/02_corporate_actions.ipynb
+++ b/02_financial_data_universe/02_corporate_actions.ipynb
@@ -250,7 +250,13 @@
     }
    },
    "source": [
-    "Stock splits in the AAPL history."
+    "Stock splits in the AAPL history. `close` is the price as it traded that\n",
+    "day; `adj_close` is that same price carried back through every split and\n",
+    "dividend that came after it. The series is therefore anchored at the last\n",
+    "observation, 2018-03-27, where the two are equal, and gets smaller the\n",
+    "further back you look: the 1987 close of \\$41.50 divided by the\n",
+    "$2 \\times 2 \\times 7 = 28$ of the three later splits is \\$1.48, and the\n",
+    "dividends paid since bring it to \\$1.22."
    ]
   },
   {
@@ -322,7 +328,8 @@
     }
    },
    "source": [
-    "First ten of 54 cash dividends."
+    "First ten of 54 cash dividends. The dividend is in the dollars of its own\n",
+    "ex-date, so it is not comparable to `adj_close` on the same row."
    ]
   },
   {
@@ -1561,12 +1568,12 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "5244dda2626a535b19d1e1600b26d481a1c5f2c0",
+   "source_py_blob": "ae2cf58b88748fbc912affe9d029d4e42f034780",
    "executed_at": "2026-07-31T20:39:09.281106+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {},
-   "notes": "house palette; crypto premium panels rebinned inside the central 99%"
+   "notes": "prose synced from the .py at 2026-09-03T20:15:14.098876+00:00 without re-executing; every code cell is identical to blob 5244dda2626a"
   },
   "papermill": {
    "default_parameters": {},

--- a/02_financial_data_universe/02_corporate_actions.py
+++ b/02_financial_data_universe/02_corporate_actions.py
@@ -96,14 +96,21 @@ aapl = raw_wiki.filter(pl.col("symbol") == "AAPL").sort("timestamp")
 print(f"AAPL records: {len(aapl):,}  ({aapl['timestamp'].min()} to {aapl['timestamp'].max()})")
 
 # %% [markdown]
-# Stock splits in the AAPL history.
+# Stock splits in the AAPL history. `close` is the price as it traded that
+# day; `adj_close` is that same price carried back through every split and
+# dividend that came after it. The series is therefore anchored at the last
+# observation, 2018-03-27, where the two are equal, and gets smaller the
+# further back you look: the 1987 close of \$41.50 divided by the
+# $2 \times 2 \times 7 = 28$ of the three later splits is \$1.48, and the
+# dividends paid since bring it to \$1.22.
 
 # %%
 splits = aapl.filter(pl.col("split_ratio") != 1.0)
 splits.select(["timestamp", "close", "split_ratio", "adj_close"])
 
 # %% [markdown]
-# First ten of 54 cash dividends.
+# First ten of 54 cash dividends. The dividend is in the dollars of its own
+# ex-date, so it is not comparable to `adj_close` on the same row.
 
 # %%
 dividends = aapl.filter(pl.col(dividend_col) > 0)


### PR DESCRIPTION
A reader (#726) read the split and dividend tables in `02_corporate_actions` as
showing volume rather than price: a 1987 AAPL close of \$41.50 sits next to an
`adj_close` of \$1.22, and the page says nothing about why. The columns are the
ones the code selects, and the values match the dataset; the small number is the
cumulative back-adjustment.

The markdown above each table now states that `adj_close` carries that day's
price back through every split and dividend that followed, that the series is
anchored at the last observation (2018-03-27, where `close` and `adj_close` are
equal), and works the 1987 row through: 41.50 / 28 for the three later splits is
1.48, and the dividends since bring it to 1.22. The dividend note adds that the
payment is in the dollars of its own ex-date.

Prose only. Folded into the executed notebook with
`notebook_provenance.py sync-prose`, so no code cell moved, no output changed and
the original execution stamp stands.

Closes #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrZh29HnkfR6LXVfAs6Lcc