### PR TITLE
sync_notebooks: a change confined to prose is drift too

### DIFF
--- a/scripts/sync_notebooks.py
+++ b/scripts/sync_notebooks.py
@@ -135,8 +135,14 @@ def py_markdown_cells(py: Path) -> list[str]:
 
 
 def _normalized(cells: list[str]) -> list[str]:
-    """Trim each cell and drop the empty ones, so trailing-newline differences are not drift."""
-    return [c.strip() for c in cells if c.strip()]
+    """Drop only the cell-terminating newline, and skip cells that are empty after that.
+
+    Not `strip()`: leading indentation makes a code block, and two trailing spaces make a
+    markdown hard break, so trimming either hides a change that alters what the reader
+    sees. Jupytext's `# ` prefix and the `.ipynb`'s source list disagree about the final
+    newline and about nothing else, so that is all this removes.
+    """
+    return [t for c in cells if (t := c.rstrip("\r\n"))]
 
 
 def prose_drift(py: Path, ipynb: Path) -> bool:

--- a/scripts/sync_notebooks.py
+++ b/scripts/sync_notebooks.py
@@ -101,6 +101,55 @@ def py_code_cells(py: Path) -> list[str]:
     return [c for c in cells if c]
 
 
+def ipynb_markdown_cells(ipynb: Path) -> list[str]:
+    nb = json.loads(ipynb.read_text(encoding="utf-8"))
+    return [
+        "".join(c.get("source", []))
+        for c in nb.get("cells", [])
+        if c.get("cell_type") == "markdown"
+    ]
+
+
+def py_markdown_cells(py: Path) -> list[str]:
+    """Markdown-cell bodies from a Jupytext percent `.py`, with the comment prefix removed.
+
+    Jupytext writes a markdown cell as a `# %% [markdown]` marker followed by lines each
+    prefixed `# ` (a blank line in the prose is a bare `#`). Stripping that prefix is what
+    makes the text comparable to the `.ipynb`'s own markdown source.
+    """
+    cells: list[str] = []
+    current: list[str] = []
+    in_markdown = False
+    for raw in py.read_text(encoding="utf-8").splitlines():
+        if raw.startswith("# %%"):
+            if in_markdown and current:
+                cells.append("\n".join(current))
+            current = []
+            in_markdown = "[markdown]" in raw
+            continue
+        if in_markdown:
+            current.append(raw[2:] if raw.startswith("# ") else raw.lstrip("#"))
+    if in_markdown and current:
+        cells.append("\n".join(current))
+    return cells
+
+
+def _normalized(cells: list[str]) -> list[str]:
+    """Trim each cell and drop the empty ones, so trailing-newline differences are not drift."""
+    return [c.strip() for c in cells if c.strip()]
+
+
+def prose_drift(py: Path, ipynb: Path) -> bool:
+    """True if the pair's markdown cells disagree.
+
+    `code_drift` compares code cells only, so a change confined to prose was invisible:
+    the tool printed `Nothing to sync` and the `.ipynb` kept the old text. The `doc_only`
+    category below was written for exactly this case and nothing could reach it, because
+    `classify` returned `None` whenever the code matched.
+    """
+    return _normalized(py_markdown_cells(py)) != _normalized(ipynb_markdown_cells(ipynb))
+
+
 def code_drift(py: Path, ipynb: Path) -> bool:
     """True if the .py's code cells don't match the .ipynb's embedded code cells.
 
@@ -145,7 +194,7 @@ def classify(py: Path, ipynb: Path) -> Drift | None:
     mtime ordering. When code differs, mtime becomes a hint for direction.
     """
     cd = code_drift(py, ipynb)
-    if not cd:
+    if not cd and not prose_drift(py, ipynb):
         return None
 
     py_mt = py.stat().st_mtime

--- a/tests/test_sync_notebooks_prose_drift.py
+++ b/tests/test_sync_notebooks_prose_drift.py
@@ -98,3 +98,21 @@ def test_code_drift_still_wins_its_own_category(tmp_path):
     drift = sn.classify(py, ipynb)
     assert drift.code_diff is True
     assert drift.category == "code_drift_no_outputs"
+
+
+def test_leading_indentation_is_not_trimmed_away(tmp_path):
+    """Four leading spaces make a markdown code block. Trimming them would let the pair
+    diverge between prose and a rendered code block with nothing reported."""
+    py, ipynb = _pair(tmp_path, "    uv run pytest", "uv run pytest")
+    assert sn.classify(py, ipynb) is not None
+
+
+def test_a_markdown_hard_break_is_not_trimmed_away(tmp_path):
+    """Two trailing spaces are a hard line break; without them the lines run together."""
+    py, ipynb = _pair(tmp_path, "first  \nsecond", "first\nsecond")
+    assert sn.classify(py, ipynb) is not None
+
+
+def test_only_the_terminating_newline_is_normalized(tmp_path):
+    py, ipynb = _pair(tmp_path, PROSE + "\n", PROSE)
+    assert sn.classify(py, ipynb) is None

--- a/tests/test_sync_notebooks_prose_drift.py
+++ b/tests/test_sync_notebooks_prose_drift.py
@@ -1,0 +1,100 @@
+"""`sync_notebooks.py` must see a change confined to prose, not only to code.
+
+The tool compared code cells alone, so editing a markdown cell in the `.py` left the
+`.ipynb` holding the old text while the tool printed `Nothing to sync` and the pair was
+committed divergent. Measured on `nasdaq100_microstructure`: renumbering `16_costs` and
+`17_risk_management` changed prose in three `.py` files and the tool reported two.
+
+The `doc_only` category was written for this case and was unreachable, because `classify`
+returned `None` whenever the code matched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+spec = importlib.util.spec_from_file_location(
+    "_sync_notebooks_under_test", REPO_ROOT / "scripts" / "sync_notebooks.py"
+)
+sn = importlib.util.module_from_spec(spec)
+# `Drift` is a dataclass, and `dataclasses` resolves its annotations through
+# `sys.modules[cls.__module__]`. Registering the module before executing it is what
+# makes that lookup succeed for a module loaded by path.
+sys.modules[spec.name] = sn
+spec.loader.exec_module(sn)
+
+CODE = "x = 1"
+PROSE = "The holdout is resolved in 17 and read in 18."
+
+
+def _pair(tmp_path: Path, py_prose: str, nb_prose: str) -> tuple[Path, Path]:
+    py = tmp_path / "12_causal_dml.py"
+    py.write_text(
+        f"# %% [markdown]\n# {py_prose}\n\n# %%\n{CODE}\n",
+        encoding="utf-8",
+    )
+    ipynb = tmp_path / "12_causal_dml.ipynb"
+    ipynb.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {"cell_type": "markdown", "metadata": {}, "source": [nb_prose]},
+                    {
+                        "cell_type": "code",
+                        "metadata": {},
+                        "source": [CODE],
+                        "outputs": [],
+                        "execution_count": 1,
+                    },
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return py, ipynb
+
+
+def test_a_pair_whose_prose_agrees_is_not_drift(tmp_path):
+    py, ipynb = _pair(tmp_path, PROSE, PROSE)
+    assert sn.classify(py, ipynb) is None
+
+
+def test_prose_only_drift_is_reported(tmp_path):
+    py, ipynb = _pair(tmp_path, "The holdout is resolved in 19 and read in 20.", PROSE)
+    drift = sn.classify(py, ipynb)
+    assert drift is not None, "a markdown-only change was invisible to the tool"
+    assert drift.code_diff is False
+    assert drift.category == "doc_only"
+
+
+def test_doc_only_drift_is_safe_to_sync_forward(tmp_path):
+    """`--safe-only` already listed `doc_only` as a target; nothing could produce one."""
+    py, ipynb = _pair(tmp_path, "Renumbered: 19 and 20.", PROSE)
+    assert sn.classify(py, ipynb).category in ("doc_only", "code_drift_no_outputs")
+
+
+@pytest.mark.parametrize("marker", ["# %% [markdown]", '# %% [markdown] tags=["intro"]'])
+def test_the_comment_prefix_is_stripped_before_comparing(tmp_path, marker):
+    """A `.py` markdown cell is comment-prefixed and the `.ipynb`'s is not. Comparing the
+    two without stripping `# ` would report every pair in the repo as drifted."""
+    py = tmp_path / "n.py"
+    py.write_text(f"{marker}\n# Line one.\n#\n# Line two.\n", encoding="utf-8")
+    assert sn.py_markdown_cells(py) == ["Line one.\n\nLine two."]
+
+
+def test_code_drift_still_wins_its_own_category(tmp_path):
+    py, ipynb = _pair(tmp_path, PROSE, PROSE)
+    py.write_text(f"# %% [markdown]\n# {PROSE}\n\n# %%\nx = 2\n", encoding="utf-8")
+    drift = sn.classify(py, ipynb)
+    assert drift.code_diff is True
+    assert drift.category == "code_drift_no_outputs"


### PR DESCRIPTION
Closes ml4t/agent-workspace#1014.

`scripts/sync_notebooks.py` compared code cells only, and `classify` returned `None` whenever they matched. A change confined to a markdown cell was therefore invisible: the tool printed `Nothing to sync` and the `.ipynb` kept the old prose, so the pair was committed divergent. Renumbering nasdaq's `16_costs` and `17_risk_management` changed prose in three `.py` files; the tool reported two.

The `doc_only` category was written for exactly this case and nothing could reach it. `--safe-only` has always listed it as a sync target, because `jupytext --update` preserves outputs when the cell structure matches - so making it reachable is all that was needed.

Comparing the two sides needs jupytext's comment prefix stripped (`# ` per line, a bare `#` for a blank one). Normalization removes the cell-terminating newline and nothing else: `strip()` would have hidden four leading spaces (a markdown code block) and two trailing ones (a hard line break).

**Verified**: 480 paired notebooks in the repo, 0 with drift under the new comparison - the extra sensitivity adds no false positive to a tree already in sync. 9 focused tests in `tests/test_sync_notebooks_prose_drift.py`, including one that fails if a prose-only change stops being reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQUuNRz572ohmUwscwmzp