### PR TITLE
open_study says which branch it took

### DIFF
--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -479,7 +479,22 @@ def open_study(
     workspace = Path(workspace).expanduser().resolve()
     case_dir = release_root / "case_studies" / case_study
     generated = tuple(case_dir / name for name in ("features", "labels", "run_log"))
-    if not all(path.is_symlink() for path in generated):
+    linked = all(path.is_symlink() for path in generated)
+    # Say which branch this took. The two read their inputs from different places, and which
+    # one runs is decided by the checkout rather than by anything the caller asked for: a
+    # maintainer worktree symlinks its generated directories to shared artifacts and reads
+    # them in place, a CI checkout has real directories and adopts the workspace. Neither is
+    # wrong. A run that does not say which it took is, because the same notebook then reports
+    # different inputs on the two and nothing in the log tells them apart.
+    print(
+        f"open_study({case_study}): generated directories under {case_dir} are "
+        + (
+            "symlinks - reading inputs in place, writes redirected to the workspace"
+            if linked
+            else "real directories - the workspace is the study root"
+        )
+    )
+    if not linked:
         return Study.open(
             case_study,
             workspace=workspace,

--- a/tests/test_research_workspace.py
+++ b/tests/test_research_workspace.py
@@ -787,6 +787,55 @@ def test_preview_records_the_entry_point_when_generated_dirs_are_not_symlinks(
     assert recorded == ("06_linear",)
 
 
+def test_open_study_says_it_read_inputs_in_place(tmp_path: Path, capsys) -> None:
+    """`open_study` takes one of two branches and used to say nothing about which.
+
+    A maintainer worktree symlinks its generated directories to shared artifacts, so it reads
+    inputs in place; a CI checkout has real directories and adopts the workspace. Which branch
+    ran is decided by the checkout, not by the caller, so the same notebook reports different
+    inputs on the two with nothing in the log telling them apart (ml4t/agent-workspace#974).
+    """
+    release, _ = _seed_regeneration_release(tmp_path)
+    generated = release / "case_studies" / "etfs"
+    assert all((generated / name).is_symlink() for name in ("features", "labels", "run_log")), (
+        "fixture must exercise the symlink branch"
+    )
+    capsys.readouterr()
+
+    open_study(
+        "etfs",
+        execution_tier=ExecutionTier.PREVIEW,
+        workspace=tmp_path / "ws",
+        release_root=release,
+    )
+
+    reported = capsys.readouterr().out
+    assert "open_study(etfs)" in reported
+    assert "symlinks - reading inputs in place" in reported
+    assert str(generated) in reported
+
+
+def test_open_study_says_the_workspace_is_the_root(tmp_path: Path, capsys) -> None:
+    """The other branch, which is the one CI takes and the one no worktree here exercises."""
+    release = _seed_release(tmp_path)
+    generated = release / "case_studies" / "etfs"
+    assert not any((generated / name).is_symlink() for name in ("features", "labels", "run_log")), (
+        "fixture must exercise the regular-directory branch"
+    )
+    capsys.readouterr()
+
+    open_study(
+        "etfs",
+        execution_tier=ExecutionTier.PREVIEW,
+        workspace=tmp_path / "ws",
+        release_root=release,
+    )
+
+    reported = capsys.readouterr().out
+    assert "open_study(etfs)" in reported
+    assert "real directories - the workspace is the study root" in reported
+
+
 def test_a_second_study_previewing_into_one_workspace_repoints_the_input_links(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes ml4t/agent-workspace#974.

`case_studies/research/workspace.py` reads a preview study's inputs from one of two places, and said nothing about which. A maintainer worktree symlinks `features/`, `labels/` and `run_log/` into shared artifacts and reads them in place; a CI checkout has real directories and adopts the workspace as the study root.

Which branch runs is decided by the checkout, not by anything the caller asked for. `scripts/new-worktree.sh --case-study` symlinks all three, so every case-study worktree on this machine takes the branch CI never takes - the same notebook reports different inputs on the two, and nothing in the log tells them apart.

Neither branch is wrong, so this reports rather than changes anything: one line naming the directory and which of the two shapes it has. Two tests, one per branch, using the fixtures that already existed for each (`_seed_regeneration_release` symlinks, `_seed_release` does not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQUuNRz572ohmUwscwmzp