### PR TITLE
Make the CI fixture path say what it did, and the workflow say what it checked

### DIFF
--- a/.github/scripts/check_env_matches_lock.py
+++ b/.github/scripts/check_env_matches_lock.py
@@ -176,8 +176,9 @@ def main() -> int:
 
     if not mismatched:
         print(
-            "every installed distribution is at its locked version, or at one its "
-            "declared override allows"
+            f"all {compared} compared distributions are at their locked version, and "
+            f"{len(overridden)} at a version their override allows. Not compared: the "
+            "declared off-lock names above, and anything the lock does not pin."
         )
         return 0
 

--- a/.github/scripts/check_env_matches_lock.py
+++ b/.github/scripts/check_env_matches_lock.py
@@ -175,7 +175,10 @@ def main() -> int:
         print(f"held to pyproject's override instead of the lock: {requirement} ({state})")
 
     if not mismatched:
-        print("every installed distribution the lock pins is at its locked version")
+        print(
+            "every installed distribution is at its locked version, or at one its "
+            "declared override allows"
+        )
         return 0
 
     print(f"\n{len(mismatched)} installed distributions do not match what is declared:")

--- a/.github/scripts/check_env_matches_lock.py
+++ b/.github/scripts/check_env_matches_lock.py
@@ -33,6 +33,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import tomllib
 from importlib.metadata import distributions
@@ -50,9 +51,30 @@ DECLARED_OFF_LOCK = {
     "torchaudio": "pinned by the cu128 torch wheel",
     "triton": "pinned by the cu128 torch wheel",
     "setuptools": "held below 82 by the cu128 torch wheel",
+    "pip": "the environment's own installer, from the interpreter, not resolved by the project",
 }
 # The CUDA runtime wheels the torch build pins strictly, by prefix.
 DECLARED_OFF_LOCK_PREFIXES = ("nvidia-",)
+
+
+def overridden_dependencies(pyproject_path: Path) -> dict[str, str]:
+    """Distributions `[tool.uv] override-dependencies` forces the lock to resolve.
+
+    An override is uv asserting a version against what the dependency graph asks
+    for, and pip has no equivalent: `protobuf>=5.0` is overridden here because
+    protobuf 4.x has a C-extension metaclass bug on Python 3.14, and the lock then
+    resolves protobuf 7.35.0 while `opentelemetry-proto` requires `<7.0`. A pip
+    install into the image resolves 6.33.6 and is right to. Comparing an overridden
+    distribution against the lock therefore reports the override, not drift.
+    """
+    if not pyproject_path.is_file():
+        return {}
+    project = tomllib.loads(pyproject_path.read_text())
+    overrides = (project.get("tool", {}).get("uv", {}) or {}).get("override-dependencies", [])
+    return {
+        canonical(re.split(r"[<>=!~ \[]", spec, maxsplit=1)[0]): f"overridden to {spec}"
+        for spec in overrides
+    }
 
 
 def canonical(name: str) -> str:
@@ -80,11 +102,19 @@ def installed_versions() -> dict[str, str]:
     return found
 
 
-def is_declared_off_lock(name: str) -> bool:
-    return name in DECLARED_OFF_LOCK or name.startswith(DECLARED_OFF_LOCK_PREFIXES)
+def is_declared_off_lock(name: str, overridden: dict[str, str] | None = None) -> bool:
+    return (
+        name in DECLARED_OFF_LOCK
+        or name in (overridden or {})
+        or name.startswith(DECLARED_OFF_LOCK_PREFIXES)
+    )
 
 
-def drift(locked: dict[str, str], installed: dict[str, str]) -> list[tuple[str, str, str]]:
+def drift(
+    locked: dict[str, str],
+    installed: dict[str, str],
+    overridden: dict[str, str] | None = None,
+) -> list[tuple[str, str, str]]:
     """(name, locked version, installed version) for every distribution that disagrees.
 
     Only distributions that are both locked and installed are compared. The lock
@@ -96,13 +126,14 @@ def drift(locked: dict[str, str], installed: dict[str, str]) -> list[tuple[str, 
     return sorted(
         (name, locked[name], version)
         for name, version in installed.items()
-        if name in locked and not is_declared_off_lock(name) and locked[name] != version
+        if name in locked and not is_declared_off_lock(name, overridden) and locked[name] != version
     )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--lock", type=Path, default=REPO_ROOT / "uv.lock")
+    parser.add_argument("--pyproject", type=Path, default=REPO_ROOT / "pyproject.toml")
     args = parser.parse_args()
 
     if not args.lock.is_file():
@@ -111,11 +142,17 @@ def main() -> int:
 
     locked = locked_versions(args.lock)
     installed = installed_versions()
-    mismatched = drift(locked, installed)
-    compared = sum(1 for name in installed if name in locked and not is_declared_off_lock(name))
+    overridden = overridden_dependencies(args.pyproject)
+    mismatched = drift(locked, installed, overridden)
+    compared = sum(
+        1 for name in installed if name in locked and not is_declared_off_lock(name, overridden)
+    )
 
     print(f"{args.lock} resolves {len(locked)} packages; {len(installed)} are installed here")
-    print(f"compared {compared}, off-lock by declaration {len(DECLARED_OFF_LOCK)} + nvidia-*")
+    print(
+        f"compared {compared}, off-lock by declaration {len(DECLARED_OFF_LOCK)} + nvidia-*"
+        f"{f', overridden in pyproject: {", ".join(sorted(overridden))}' if overridden else ''}"
+    )
 
     if not mismatched:
         print("every installed distribution the lock pins is at its locked version")

--- a/.github/scripts/check_env_matches_lock.py
+++ b/.github/scripts/check_env_matches_lock.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Fail when the environment's installed distributions do not match uv.lock.
+
+`ml4t/ml4t:latest` is the container every chapter and case-study job runs in. It
+is built from the lock and drifts from it silently the moment the lock moves: the
+image built 2026-07-16 carried `ml4t-models==0.1.0a4` while pyproject moved to
+`>=0.1.0a6` on 2026-07-21, so for eleven days public CI ran a dependency set the
+repository did not declare. `0.1.0a4`'s IPCA solver was genuinely broken, and the
+notebook that failed on it read as a numerical problem, which cost four rounds of
+investigation aimed at the notebook.
+
+Nothing compared the two. This does, from inside the environment, with no network:
+every installed distribution the lock pins must be at the locked version.
+
+The general trap it closes: when a dev machine and CI disagree on the same code
+and data, "different hardware" and "different dependency set" produce identical
+symptoms, and only one of them is cheap to check.
+
+## The carve-out is declared, not implicit
+
+`envs/ml4t/Dockerfile` builds the torch stack from the CUDA index rather than from
+the lock, so those distributions are a newer build than the lock's by design. They
+are named here because an undeclared carve-out is what the LightGBM 4.7 nvlink
+failure cost: `lightgbm` was excluded from the lock-derived constraint and then
+installed as a floating `>=4.6`, which drifted to a version that could not build.
+It is deliberately NOT exempt here - the Dockerfile now pins it to the lock's exact
+version, and this check is what holds that.
+
+Usage:
+    python .github/scripts/check_env_matches_lock.py [--lock uv.lock]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from importlib.metadata import distributions
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Distributions the image deliberately installs off-lock, and why. A name here is
+# a statement that the lock's version is not the one this environment is supposed
+# to have - see envs/ml4t/Dockerfile, which installs the cu128 build of torch from
+# download.pytorch.org and lets that wheel's own strict pins choose the rest.
+DECLARED_OFF_LOCK = {
+    "torch": "built from the cu128 index, newer than the lock's generic build",
+    "torchvision": "pinned by the cu128 torch wheel",
+    "torchaudio": "pinned by the cu128 torch wheel",
+    "triton": "pinned by the cu128 torch wheel",
+    "setuptools": "held below 82 by the cu128 torch wheel",
+}
+# The CUDA runtime wheels the torch build pins strictly, by prefix.
+DECLARED_OFF_LOCK_PREFIXES = ("nvidia-",)
+
+
+def canonical(name: str) -> str:
+    """PEP 503 normalization: distribution names compare case- and separator-insensitively."""
+    return name.lower().replace("_", "-").replace(".", "-")
+
+
+def locked_versions(lock_path: Path) -> dict[str, str]:
+    """{canonical name: version} for every package uv.lock resolves."""
+    lock = tomllib.loads(lock_path.read_text())
+    return {
+        canonical(package["name"]): package["version"]
+        for package in lock.get("package", [])
+        if "version" in package
+    }
+
+
+def installed_versions() -> dict[str, str]:
+    """{canonical name: version} for every distribution importable here."""
+    found: dict[str, str] = {}
+    for dist in distributions():
+        name = dist.metadata["Name"]
+        if name and dist.version:
+            found.setdefault(canonical(name), dist.version)
+    return found
+
+
+def is_declared_off_lock(name: str) -> bool:
+    return name in DECLARED_OFF_LOCK or name.startswith(DECLARED_OFF_LOCK_PREFIXES)
+
+
+def drift(locked: dict[str, str], installed: dict[str, str]) -> list[tuple[str, str, str]]:
+    """(name, locked version, installed version) for every distribution that disagrees.
+
+    Only distributions that are both locked and installed are compared. The lock
+    resolves platform- and extra-specific packages this environment is not meant to
+    carry, and an image that deliberately installs less than the lock is a size
+    decision rather than drift; installing a *different version* of something the
+    lock pins is what makes a CI result unattributable.
+    """
+    return sorted(
+        (name, locked[name], version)
+        for name, version in installed.items()
+        if name in locked and not is_declared_off_lock(name) and locked[name] != version
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lock", type=Path, default=REPO_ROOT / "uv.lock")
+    args = parser.parse_args()
+
+    if not args.lock.is_file():
+        print(f"no lock file at {args.lock}", file=sys.stderr)
+        return 2
+
+    locked = locked_versions(args.lock)
+    installed = installed_versions()
+    mismatched = drift(locked, installed)
+    compared = sum(1 for name in installed if name in locked and not is_declared_off_lock(name))
+
+    print(f"{args.lock} resolves {len(locked)} packages; {len(installed)} are installed here")
+    print(f"compared {compared}, off-lock by declaration {len(DECLARED_OFF_LOCK)} + nvidia-*")
+
+    if not mismatched:
+        print("every installed distribution the lock pins is at its locked version")
+        return 0
+
+    print(f"\n{len(mismatched)} installed distributions do not match {args.lock}:")
+    for name, want, have in mismatched:
+        print(f"  {name}: lock says {want}, installed {have}")
+    print(
+        "\nThis environment is not the one the repository declares, so a result "
+        "measured in it is not evidence about this commit. Rebuild the image, or "
+        "declare the difference in DECLARED_OFF_LOCK with the reason."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_env_matches_lock.py
+++ b/.github/scripts/check_env_matches_lock.py
@@ -26,18 +26,24 @@ installed as a floating `>=4.6`, which drifted to a version that could not build
 It is deliberately NOT exempt here - the Dockerfile now pins it to the lock's exact
 version, and this check is what holds that.
 
+A distribution `[tool.uv] override-dependencies` names is held to that override's
+specifier rather than to the lock, because an override is uv asserting a version
+against what the dependency graph asks for and a pip install cannot reproduce it.
+
 Usage:
-    python .github/scripts/check_env_matches_lock.py [--lock uv.lock]
+    python .github/scripts/check_env_matches_lock.py [--lock uv.lock] [--pyproject pyproject.toml]
 """
 
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 import tomllib
 from importlib.metadata import distributions
 from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -57,24 +63,25 @@ DECLARED_OFF_LOCK = {
 DECLARED_OFF_LOCK_PREFIXES = ("nvidia-",)
 
 
-def overridden_dependencies(pyproject_path: Path) -> dict[str, str]:
+def overridden_dependencies(pyproject_path: Path) -> dict[str, Requirement]:
     """Distributions `[tool.uv] override-dependencies` forces the lock to resolve.
 
     An override is uv asserting a version against what the dependency graph asks
     for, and pip has no equivalent: `protobuf>=5.0` is overridden here because
     protobuf 4.x has a C-extension metaclass bug on Python 3.14, and the lock then
     resolves protobuf 7.35.0 while `opentelemetry-proto` requires `<7.0`. A pip
-    install into the image resolves 6.33.6 and is right to. Comparing an overridden
-    distribution against the lock therefore reports the override, not drift.
+    install into the image resolves 6.33.6 and is right to.
+
+    So an overridden distribution is held to the override rather than to the lock.
+    It is not exempt from checking: exempting it outright would let protobuf 4.x
+    through, which is the version the override exists to keep out.
     """
     if not pyproject_path.is_file():
         return {}
     project = tomllib.loads(pyproject_path.read_text())
     overrides = (project.get("tool", {}).get("uv", {}) or {}).get("override-dependencies", [])
-    return {
-        canonical(re.split(r"[<>=!~ \[]", spec, maxsplit=1)[0]): f"overridden to {spec}"
-        for spec in overrides
-    }
+    parsed = [Requirement(spec) for spec in overrides]
+    return {canonical(requirement.name): requirement for requirement in parsed}
 
 
 def canonical(name: str) -> str:
@@ -102,7 +109,8 @@ def installed_versions() -> dict[str, str]:
     return found
 
 
-def is_declared_off_lock(name: str, overridden: dict[str, str] | None = None) -> bool:
+def is_declared_off_lock(name: str, overridden: dict[str, Requirement] | None = None) -> bool:
+    """Whether this distribution is compared against something other than the lock."""
     return (
         name in DECLARED_OFF_LOCK
         or name in (overridden or {})
@@ -113,21 +121,33 @@ def is_declared_off_lock(name: str, overridden: dict[str, str] | None = None) ->
 def drift(
     locked: dict[str, str],
     installed: dict[str, str],
-    overridden: dict[str, str] | None = None,
+    overridden: dict[str, Requirement] | None = None,
 ) -> list[tuple[str, str, str]]:
-    """(name, locked version, installed version) for every distribution that disagrees.
+    """(name, what is required, installed version) for every distribution that disagrees.
 
-    Only distributions that are both locked and installed are compared. The lock
+    Only distributions that are both required and installed are compared. The lock
     resolves platform- and extra-specific packages this environment is not meant to
     carry, and an image that deliberately installs less than the lock is a size
-    decision rather than drift; installing a *different version* of something the
-    lock pins is what makes a CI result unattributable.
+    decision rather than drift; installing a *different version* of something that
+    is pinned is what makes a CI result unattributable.
+
+    An overridden distribution is compared against the override's specifier instead
+    of the lock's version, because that is what the repository actually declares
+    for it - see :func:`overridden_dependencies`.
     """
-    return sorted(
+    overridden = overridden or {}
+    mismatched = [
         (name, locked[name], version)
         for name, version in installed.items()
         if name in locked and not is_declared_off_lock(name, overridden) and locked[name] != version
-    )
+    ]
+    mismatched += [
+        (name, str(requirement.specifier), installed[name])
+        for name, requirement in overridden.items()
+        if name in installed
+        and not requirement.specifier.contains(Version(installed[name]), prereleases=True)
+    ]
+    return sorted(mismatched)
 
 
 def main() -> int:
@@ -149,18 +169,18 @@ def main() -> int:
     )
 
     print(f"{args.lock} resolves {len(locked)} packages; {len(installed)} are installed here")
-    print(
-        f"compared {compared}, off-lock by declaration {len(DECLARED_OFF_LOCK)} + nvidia-*"
-        f"{f', overridden in pyproject: {", ".join(sorted(overridden))}' if overridden else ''}"
-    )
+    print(f"compared {compared}, off-lock by declaration {len(DECLARED_OFF_LOCK)} + nvidia-*")
+    for name, requirement in sorted(overridden.items()):
+        state = installed.get(name, "not installed")
+        print(f"held to pyproject's override instead of the lock: {requirement} ({state})")
 
     if not mismatched:
         print("every installed distribution the lock pins is at its locked version")
         return 0
 
-    print(f"\n{len(mismatched)} installed distributions do not match {args.lock}:")
+    print(f"\n{len(mismatched)} installed distributions do not match what is declared:")
     for name, want, have in mismatched:
-        print(f"  {name}: lock says {want}, installed {have}")
+        print(f"  {name}: {want} required, installed {have}")
     print(
         "\nThis environment is not the one the repository declares, so a result "
         "measured in it is not evidence about this commit. Rebuild the image, or "

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -592,6 +592,7 @@ jobs:
           .venv/bin/python -m pytest \
             tests/test_pm_helpers.py \
             tests/test_fork_pull_request_gating.py \
+            tests/test_env_matches_lock.py \
             tests/test_create_test_data.py \
             tests/test_generate_intermediates.py \
             tests/test_sample_registry_for_tests.py \
@@ -959,6 +960,18 @@ jobs:
       - name: Install git (for checkout inside container)
         run: apt-get update && apt-get install -y git
       - uses: actions/checkout@v6
+      # The image is built from uv.lock and drifts from it silently the moment the
+      # lock moves. It carried ml4t-models 0.1.0a4 for eleven days after the repo
+      # declared >=0.1.0a6, so public CI measured a dependency set the repository
+      # did not declare - and the notebook that failed on it read as a numerical
+      # problem, which cost four rounds of investigation aimed at the notebook.
+      #
+      # This is the check that would have caught it on the day the pin moved. It
+      # runs first because everything after it is only evidence about this commit
+      # if it passes: a green job in a drifted image is not evidence of green under
+      # the declared lock.
+      - name: The image's installed distributions match uv.lock
+        run: python .github/scripts/check_env_matches_lock.py
       - name: Run modelling-environment unit tests
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -592,6 +592,7 @@ jobs:
           .venv/bin/python -m pytest \
             tests/test_pm_helpers.py \
             tests/test_create_test_data.py \
+            tests/test_generate_intermediates.py \
             tests/test_sample_registry_for_tests.py \
             tests/test_toolchain_pins.py \
             tests/test_conformal_embargo_coverage.py \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -904,6 +904,7 @@ jobs:
           .venv/bin/python -m pytest \
             tests/test_eoa_universe_roster.py \
             tests/test_fixture_registry_identity.py \
+            tests/test_reduced_universe_is_shared.py \
             -m "not production_extract" \
             -v --tb=short -rs --junitxml=unit-data.xml
       # A skip here is a failure: these tests run in this job and nowhere else,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -591,6 +591,7 @@ jobs:
         run: |
           .venv/bin/python -m pytest \
             tests/test_pm_helpers.py \
+            tests/test_fork_pull_request_gating.py \
             tests/test_create_test_data.py \
             tests/test_generate_intermediates.py \
             tests/test_sample_registry_for_tests.py \
@@ -1038,12 +1039,42 @@ jobs:
       image: ml4t/ml4t:latest
 
     steps:
+      # secrets.TEST_DATA_DEPLOY_KEY is not exposed to a pull_request from a fork,
+      # so the "Checkout test data" step below cannot succeed there: actions/checkout
+      # falls back to the default token, which cannot see a private repository, and
+      # the job fails at a step that has nothing to do with the contribution. On #595,
+      # a two-line packaging fix from an outside contributor, that was 26 red checks -
+      # ch01 through ch26, all eight cs-* jobs and test-py312 - none of them the
+      # contributor's.
+      #
+      # Deciding once whether the run can reach the data, and gating the
+      # data-dependent steps on that, is the same shape as the fix #613 landed for
+      # test-unit-data. It is a step-level gate rather than a job-level `if:` for the
+      # reason recorded there: a job-level `if:` that evaluates false creates no check
+      # run at all, which is unsatisfiable when the context is required.
+      #
+      # What this does not fix, and is said out loud in the notice: a fork pull request
+      # is then green having exercised none of these notebooks. That is the honest
+      # state - it is what happens today, dressed as failure rather than as a skip -
+      # and the merge decision has to account for it.
+      - name: Can this run reach the test data?
+        id: reach
+        run: |
+          if [ -n "${{ secrets.TEST_DATA_DEPLOY_KEY }}" ]; then
+            echo "have_key=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_key=" >> "$GITHUB_OUTPUT"
+            echo "::notice::No test-data deploy key in this context, which is a fork pull request. This job checked out no test data and executed no notebook, so it asserts nothing about this change; the notebooks run on the branch once it is merged."
+          fi
       - name: Install git (for checkout inside container)
+        if: steps.reach.outputs.have_key
         run: apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null
 
       - uses: actions/checkout@v6
+        if: steps.reach.outputs.have_key
 
       - name: Checkout test data
+        if: steps.reach.outputs.have_key
         uses: actions/checkout@v6
         with:
           repository: ml4t/third-edition-test-data
@@ -1052,6 +1083,7 @@ jobs:
           lfs: false
 
       - name: Seed case study intermediates
+        if: steps.reach.outputs.have_key
         run: |
           mkdir -p $ML4T_OUTPUT_DIR
           if [ -d test-data/intermediates ]; then
@@ -1074,6 +1106,7 @@ jobs:
           fi
 
       - name: Run chapter notebooks (${{ matrix.name }})
+        if: steps.reach.outputs.have_key
         env:
           PYTHONPATH: ${{ github.workspace }}
           TEST_FILTER_INPUT: ${{ github.event.inputs.test_filter }}
@@ -1104,12 +1137,42 @@ jobs:
       image: ml4t/ml4t:latest
 
     steps:
+      # secrets.TEST_DATA_DEPLOY_KEY is not exposed to a pull_request from a fork,
+      # so the "Checkout test data" step below cannot succeed there: actions/checkout
+      # falls back to the default token, which cannot see a private repository, and
+      # the job fails at a step that has nothing to do with the contribution. On #595,
+      # a two-line packaging fix from an outside contributor, that was 26 red checks -
+      # ch01 through ch26, all eight cs-* jobs and test-py312 - none of them the
+      # contributor's.
+      #
+      # Deciding once whether the run can reach the data, and gating the
+      # data-dependent steps on that, is the same shape as the fix #613 landed for
+      # test-unit-data. It is a step-level gate rather than a job-level `if:` for the
+      # reason recorded there: a job-level `if:` that evaluates false creates no check
+      # run at all, which is unsatisfiable when the context is required.
+      #
+      # What this does not fix, and is said out loud in the notice: a fork pull request
+      # is then green having exercised none of these notebooks. That is the honest
+      # state - it is what happens today, dressed as failure rather than as a skip -
+      # and the merge decision has to account for it.
+      - name: Can this run reach the test data?
+        id: reach
+        run: |
+          if [ -n "${{ secrets.TEST_DATA_DEPLOY_KEY }}" ]; then
+            echo "have_key=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_key=" >> "$GITHUB_OUTPUT"
+            echo "::notice::No test-data deploy key in this context, which is a fork pull request. This job checked out no test data and executed no notebook, so it asserts nothing about this change; the notebooks run on the branch once it is merged."
+          fi
       - name: Install git
+        if: steps.reach.outputs.have_key
         run: apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null
 
       - uses: actions/checkout@v6
+        if: steps.reach.outputs.have_key
 
       - name: Checkout test data
+        if: steps.reach.outputs.have_key
         uses: actions/checkout@v6
         with:
           repository: ml4t/third-edition-test-data
@@ -1118,6 +1181,7 @@ jobs:
           lfs: false
 
       - name: Seed case study intermediates
+        if: steps.reach.outputs.have_key
         run: |
           mkdir -p $ML4T_OUTPUT_DIR
           if [ -d test-data/intermediates ]; then
@@ -1130,9 +1194,11 @@ jobs:
       # Without it, overrides.yaml's `reruns:` key (tests/conftest.py) silently adds no
       # retry marker, so a notebook marked flaky just fails outright here.
       - name: Install pytest-rerunfailures
+        if: steps.reach.outputs.have_key
         run: pip install --no-cache-dir "pytest-rerunfailures>=15.0"
 
       - name: Run pipeline (${{ matrix.case-study }})
+        if: steps.reach.outputs.have_key
         env:
           PYTHONPATH: ${{ github.workspace }}
           TEST_FILTER_INPUT: ${{ github.event.inputs.test_filter }}
@@ -1158,12 +1224,42 @@ jobs:
       image: ml4t/ml4t-py312:latest
 
     steps:
+      # secrets.TEST_DATA_DEPLOY_KEY is not exposed to a pull_request from a fork,
+      # so the "Checkout test data" step below cannot succeed there: actions/checkout
+      # falls back to the default token, which cannot see a private repository, and
+      # the job fails at a step that has nothing to do with the contribution. On #595,
+      # a two-line packaging fix from an outside contributor, that was 26 red checks -
+      # ch01 through ch26, all eight cs-* jobs and test-py312 - none of them the
+      # contributor's.
+      #
+      # Deciding once whether the run can reach the data, and gating the
+      # data-dependent steps on that, is the same shape as the fix #613 landed for
+      # test-unit-data. It is a step-level gate rather than a job-level `if:` for the
+      # reason recorded there: a job-level `if:` that evaluates false creates no check
+      # run at all, which is unsatisfiable when the context is required.
+      #
+      # What this does not fix, and is said out loud in the notice: a fork pull request
+      # is then green having exercised none of these notebooks. That is the honest
+      # state - it is what happens today, dressed as failure rather than as a skip -
+      # and the merge decision has to account for it.
+      - name: Can this run reach the test data?
+        id: reach
+        run: |
+          if [ -n "${{ secrets.TEST_DATA_DEPLOY_KEY }}" ]; then
+            echo "have_key=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_key=" >> "$GITHUB_OUTPUT"
+            echo "::notice::No test-data deploy key in this context, which is a fork pull request. This job checked out no test data and executed no notebook, so it asserts nothing about this change; the notebooks run on the branch once it is merged."
+          fi
       - name: Install git
+        if: steps.reach.outputs.have_key
         run: apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null
 
       - uses: actions/checkout@v6
+        if: steps.reach.outputs.have_key
 
       - name: Checkout test data
+        if: steps.reach.outputs.have_key
         uses: actions/checkout@v6
         with:
           repository: ml4t/third-edition-test-data
@@ -1172,6 +1268,7 @@ jobs:
           lfs: false
 
       - name: Run py312 notebooks
+        if: steps.reach.outputs.have_key
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
@@ -1214,12 +1311,42 @@ jobs:
           --health-retries 10
 
     steps:
+      # secrets.TEST_DATA_DEPLOY_KEY is not exposed to a pull_request from a fork,
+      # so the "Checkout test data" step below cannot succeed there: actions/checkout
+      # falls back to the default token, which cannot see a private repository, and
+      # the job fails at a step that has nothing to do with the contribution. On #595,
+      # a two-line packaging fix from an outside contributor, that was 26 red checks -
+      # ch01 through ch26, all eight cs-* jobs and test-py312 - none of them the
+      # contributor's.
+      #
+      # Deciding once whether the run can reach the data, and gating the
+      # data-dependent steps on that, is the same shape as the fix #613 landed for
+      # test-unit-data. It is a step-level gate rather than a job-level `if:` for the
+      # reason recorded there: a job-level `if:` that evaluates false creates no check
+      # run at all, which is unsatisfiable when the context is required.
+      #
+      # What this does not fix, and is said out loud in the notice: a fork pull request
+      # is then green having exercised none of these notebooks. That is the honest
+      # state - it is what happens today, dressed as failure rather than as a skip -
+      # and the merge decision has to account for it.
+      - name: Can this run reach the test data?
+        id: reach
+        run: |
+          if [ -n "${{ secrets.TEST_DATA_DEPLOY_KEY }}" ]; then
+            echo "have_key=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_key=" >> "$GITHUB_OUTPUT"
+            echo "::notice::No test-data deploy key in this context, which is a fork pull request. This job checked out no test data and executed no notebook, so it asserts nothing about this change; the notebooks run on the branch once it is merged."
+          fi
       - name: Install git
+        if: steps.reach.outputs.have_key
         run: apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null
 
       - uses: actions/checkout@v6
+        if: steps.reach.outputs.have_key
 
       - name: Checkout test data
+        if: steps.reach.outputs.have_key
         uses: actions/checkout@v6
         with:
           repository: ml4t/third-edition-test-data
@@ -1228,6 +1355,7 @@ jobs:
           lfs: false
 
       - name: Run Ch23 Knowledge Graph notebooks (pipeline order)
+        if: steps.reach.outputs.have_key
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
@@ -1316,13 +1444,43 @@ jobs:
           --health-retries 5
 
     steps:
+      # secrets.TEST_DATA_DEPLOY_KEY is not exposed to a pull_request from a fork,
+      # so the "Checkout test data" step below cannot succeed there: actions/checkout
+      # falls back to the default token, which cannot see a private repository, and
+      # the job fails at a step that has nothing to do with the contribution. On #595,
+      # a two-line packaging fix from an outside contributor, that was 26 red checks -
+      # ch01 through ch26, all eight cs-* jobs and test-py312 - none of them the
+      # contributor's.
+      #
+      # Deciding once whether the run can reach the data, and gating the
+      # data-dependent steps on that, is the same shape as the fix #613 landed for
+      # test-unit-data. It is a step-level gate rather than a job-level `if:` for the
+      # reason recorded there: a job-level `if:` that evaluates false creates no check
+      # run at all, which is unsatisfiable when the context is required.
+      #
+      # What this does not fix, and is said out loud in the notice: a fork pull request
+      # is then green having exercised none of these notebooks. That is the honest
+      # state - it is what happens today, dressed as failure rather than as a skip -
+      # and the merge decision has to account for it.
+      - name: Can this run reach the test data?
+        id: reach
+        run: |
+          if [ -n "${{ secrets.TEST_DATA_DEPLOY_KEY }}" ]; then
+            echo "have_key=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_key=" >> "$GITHUB_OUTPUT"
+            echo "::notice::No test-data deploy key in this context, which is a fork pull request. This job checked out no test data and executed no notebook, so it asserts nothing about this change; the notebooks run on the branch once it is merged."
+          fi
       - name: Install git
+        if: steps.reach.outputs.have_key
         run: |
           apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null 2>&1 || true
 
       - uses: actions/checkout@v6
+        if: steps.reach.outputs.have_key
 
       - name: Checkout test data
+        if: steps.reach.outputs.have_key
         uses: actions/checkout@v6
         with:
           repository: ml4t/third-edition-test-data
@@ -1331,6 +1489,7 @@ jobs:
           lfs: false
 
       - name: Run Ch02 database benchmark notebooks
+        if: steps.reach.outputs.have_key
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -905,6 +905,7 @@ jobs:
             tests/test_eoa_universe_roster.py \
             tests/test_fixture_registry_identity.py \
             tests/test_reduced_universe_is_shared.py \
+            tests/test_fixture_manifest_matches_builders.py \
             -m "not production_extract" \
             -v --tb=short -rs --junitxml=unit-data.xml
       # A skip here is a failure: these tests run in this job and nowhere else,

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -81,6 +81,11 @@ class Dataset:
             directory.
         budget: Manifest ``subsets`` entry describing the reduction (e.g.
             ``{"max_entities": 200}``). Recorded verbatim in the manifest.
+        entities: ``{path: (column, count)}`` the built fixture has to carry, taken
+            from the builder's own constants. Checked against the data on disk, which
+            is the only place the drift shows: the manifest and the
+            ``nasdaq100_minute_bars`` builder agreed with each other on six symbols
+            while the fixture carried twelve, so comparing the two proved nothing.
     """
 
     name: str
@@ -88,6 +93,7 @@ class Dataset:
     build: Callable[[Path, Path], list[Path]]
     owns: tuple[Path, ...]
     budget: dict[str, object] = field(default_factory=dict)
+    entities: dict[str, tuple[str, int]] = field(default_factory=dict)
 
 
 # --- firm characteristics -----------------------------------------------------
@@ -466,37 +472,44 @@ def build_nasdaq100_minute_bars(source: Path, output: Path) -> list[Path]:
     if spacing != [timedelta(minutes=1)]:
         raise ValueError(f"fixture grid is not one-minute within a session: {sorted(spacing)}")
 
-    # Any year= directory already here is removed first. The loader globs
-    # '**/*.parquet' under the hive root, so a part left over from a previous
-    # generation is silently unioned into the panel rather than replaced - and a
-    # rebuild that narrows the universe or renames a part would leave the fixture
-    # reading two generations at once.
+    # Written to a staging directory and moved into place only once every part is
+    # written and under the blob limit. The hive root has to be emptied - the loader
+    # globs '**/*.parquet' under it, so a part left over from a previous generation
+    # is silently unioned into the panel rather than replaced - and emptying it
+    # before the build could leave the fixture with no bars at all, or with half a
+    # year, if a part turns out to be too large to push.
     root = output / NASDAQ100_MINUTE_DIR
-    if root.is_dir():
-        shutil.rmtree(root)
+    staging = root.parent / f"{root.name}.staging"
+    if staging.is_dir():
+        shutil.rmtree(staging)
 
-    written: list[Path] = []
+    staged: list[Path] = []
     for year, year_frame in frame.group_by(pl.col("date").dt.year(), maintain_order=True):
         sessions_in_year = year_frame["date"].unique().sort()
         blocks = _contiguous_session_blocks(sessions_in_year, NASDAQ100_MINUTE_PARTS_PER_YEAR)
         for index, block in enumerate(blocks):
             part = year_frame.filter(pl.col("date").is_in(block.implode()))
-            dst = root / f"year={year[0]}" / f"data-{index:02d}.parquet"
+            dst = staging / f"year={year[0]}" / f"data-{index:02d}.parquet"
             dst.parent.mkdir(parents=True, exist_ok=True)
             part.write_parquet(dst)
             size = dst.stat().st_size
             if size > NASDAQ100_MINUTE_MAX_BLOB_BYTES:
+                shutil.rmtree(staging)
                 raise ValueError(
-                    f"{dst} is {size / 1e6:.1f} MB, above GitHub's 100 MB blob limit. "
-                    f"Raise NASDAQ100_MINUTE_PARTS_PER_YEAR above "
+                    f"year={year[0]} part {index} is {size / 1e6:.1f} MB, above GitHub's "
+                    f"100 MB blob limit. Raise NASDAQ100_MINUTE_PARTS_PER_YEAR above "
                     f"{NASDAQ100_MINUTE_PARTS_PER_YEAR}."
                 )
             print(
                 f"    year={year[0]} part {index}: {len(part):,} rows ({size / 1e6:.1f} MB), "
                 f"{part['date'].n_unique()} sessions, {part['symbol'].n_unique()} symbols"
             )
-            written.append(dst)
-    return written
+            staged.append(dst)
+
+    if root.is_dir():
+        shutil.rmtree(root)
+    staging.rename(root)
+    return [root / path.relative_to(staging) for path in staged]
 
 
 # --- S&P 500 share bars and the option chains built on them -------------------
@@ -689,6 +702,13 @@ DATASETS: tuple[Dataset, ...] = (
             "raw_chain": "contracts entered by options_straddles_daily, full lifecycle",
             "min_surface_symbols_per_date": SP500_MIN_SURFACE_SYMBOLS_PER_DATE,
         },
+        # options_straddles_daily is deliberately not here: an underlying with no
+        # straddle meeting the pairing rule drops out of that panel, so it is a
+        # subset of the roster by construction rather than equal to it.
+        entities={
+            SP500_BARS.as_posix(): ("symbol", len(SP500_SYMBOLS)),
+            SP500_SURFACE.as_posix(): ("symbol", len(SP500_SYMBOLS)),
+        },
     ),
     Dataset(
         name="nasdaq100_minute_bars",
@@ -709,6 +729,9 @@ DATASETS: tuple[Dataset, ...] = (
             "bar_spacing": "1m (unchanged from production)",
             "parts_per_year": NASDAQ100_MINUTE_PARTS_PER_YEAR,
         },
+        entities={
+            NASDAQ100_MINUTE_DIR.as_posix(): ("symbol", len(NASDAQ100_MINUTE_SYMBOLS)),
+        },
     ),
     Dataset(
         name="firm_characteristics",
@@ -719,6 +742,13 @@ DATASETS: tuple[Dataset, ...] = (
         build=build_firm_characteristics,
         owns=(Path("equities") / "firm_characteristics",),
         budget={"max_entities": FIRM_CHAR_MAX_ENTITIES},
+        entities={
+            f"equities/firm_characteristics/firm_characteristics_{split}.parquet": (
+                "symbol",
+                FIRM_CHAR_MAX_ENTITIES,
+            )
+            for split, _, _ in FIRM_CHAR_SPLITS
+        },
     ),
     Dataset(
         name="institutional_holdings_13f",
@@ -1033,6 +1063,8 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.reconcile_manifest:
+        if args.dry_run:
+            parser.error("--dry-run and --reconcile-manifest are mutually exclusive")
         output = args.output.expanduser().resolve()
         manifest_path, report = reconcile_manifest(output)
         print(f"Manifest: {manifest_path}")

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -12,12 +12,18 @@ repo, which is rewritten from DATASETS on every run so the manifest cannot drift
 from what was actually generated.
 
 DATASETS covers the fixtures whose absence or staleness has taken a CI job red,
-not every fixture the test-data repo carries. The rest - equities bars, crypto,
-futures, FX, the nasdaq minute set, options - were produced before this script
-existed and have no spec here yet, so this is not a from-empty rebuild of the
-fixture repo: it operates on a checkout of ml4t/third-edition-test-data and
-replaces the datasets it knows. Reconstructing the remaining specs is tracked in
-``agents/issues`` (test-data regeneration coverage).
+not every fixture the test-data repo carries. The rest - the ETF, crypto, FX, US
+equity and CME panels - were produced before this script existed, by paths that
+were not kept, so this is not a from-empty rebuild of the fixture repo: it
+operates on a checkout of ml4t/third-edition-test-data and replaces the datasets
+it knows. Those are declared in UNBUILT_FIXTURES with what the fixture actually
+carries and why there is no builder, so the manifest describes the whole set and
+``tests/test_fixture_manifest_matches_builders.py`` can check every entry of it
+against the declarations and against the data on disk.
+
+``--reconcile-manifest`` rewrites the manifest from those declarations and the
+files that are there, building nothing. Use it when a declaration moves without
+a regeneration; use a real regeneration when the data has to move.
 
 Usage:
     # Every dataset declared below, over an existing test-data checkout
@@ -383,7 +389,21 @@ def build_institutional_holdings_13f(source: Path, output: Path) -> list[Path]:
 # they had, so nothing the microstructure case study reads changes.
 
 NASDAQ100_MINUTE_DIR = Path("equities") / "market" / "nasdaq100" / "minute_bars"
-NASDAQ100_MINUTE_SYMBOLS = ("AAPL", "AMD", "AMZN", "FB", "GOOGL", "MSFT")
+# Twelve, not six. Six cannot carry a long-short cross-sectional sweep: signals.py
+# clamps each side to n_assets // 2, so the smallest k in nasdaq100_microstructure's
+# top_k_grid - 5 - needs ten distinct names, and at six the fixture could only ever
+# trade three a side while CI registered a top_k=5 identity it had not run. The six
+# added are the highest-volume nasdaq100 members not already present, so the widened
+# cross-section carries dispersion rather than six more of the same regime.
+NASDAQ100_MINUTE_SYMBOLS = (
+    "AAPL", "AMD", "AMZN", "CMCSA", "CSCO", "FB",
+    "GOOGL", "INTC", "MSFT", "QCOM", "SIRI", "TSLA",
+)  # fmt: skip
+# GitHub rejects any blob over 100 MB, and the widened year=2021 is 142 MB whole. Each
+# year is written as this many contiguous blocks of sessions instead. load_nasdaq100_bars
+# globs '**/*.parquet' under the hive root, so the split reads back as one panel.
+NASDAQ100_MINUTE_PARTS_PER_YEAR = 2
+NASDAQ100_MINUTE_MAX_BLOB_BYTES = 100_000_000
 # Six consecutive sessions kept per six skipped runs: one week in six, which
 # keeps a fifth of the fixture's sessions preceded by their true predecessor.
 NASDAQ100_MINUTE_RUN_SESSIONS = 6
@@ -401,6 +421,18 @@ def _session_runs(sessions: pl.Series, run: int, stride: int, dense_from: date) 
         keep.extend(strided[start : start + run].to_list())
     keep.extend(sessions.filter(sessions >= dense_from).to_list())
     return pl.Series("date", keep, dtype=sessions.dtype)
+
+
+def _contiguous_session_blocks(sessions: pl.Series, parts: int) -> list[pl.Series]:
+    """Split sorted sessions into ``parts`` contiguous, near-equal blocks.
+
+    Contiguous on the date axis so each part is a date range rather than a stripe:
+    a reader who opens one file sees a continuous stretch of the panel, and the
+    split is reproducible from the session list alone.
+    """
+    total = len(sessions)
+    size = -(-total // parts)  # ceiling, so the last block is the short one
+    return [sessions[start : start + size] for start in range(0, total, size)]
 
 
 def build_nasdaq100_minute_bars(source: Path, output: Path) -> list[Path]:
@@ -434,16 +466,36 @@ def build_nasdaq100_minute_bars(source: Path, output: Path) -> list[Path]:
     if spacing != [timedelta(minutes=1)]:
         raise ValueError(f"fixture grid is not one-minute within a session: {sorted(spacing)}")
 
+    # Any year= directory already here is removed first. The loader globs
+    # '**/*.parquet' under the hive root, so a part left over from a previous
+    # generation is silently unioned into the panel rather than replaced - and a
+    # rebuild that narrows the universe or renames a part would leave the fixture
+    # reading two generations at once.
+    root = output / NASDAQ100_MINUTE_DIR
+    if root.is_dir():
+        shutil.rmtree(root)
+
     written: list[Path] = []
-    for year, part in frame.group_by(pl.col("date").dt.year(), maintain_order=True):
-        dst = output / NASDAQ100_MINUTE_DIR / f"year={year[0]}" / "data.parquet"
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        part.write_parquet(dst)
-        print(
-            f"    year={year[0]}: {len(part):,} rows ({dst.stat().st_size / 1e6:.1f} MB), "
-            f"{part['date'].n_unique()} sessions, {part['symbol'].n_unique()} symbols"
-        )
-        written.append(dst)
+    for year, year_frame in frame.group_by(pl.col("date").dt.year(), maintain_order=True):
+        sessions_in_year = year_frame["date"].unique().sort()
+        blocks = _contiguous_session_blocks(sessions_in_year, NASDAQ100_MINUTE_PARTS_PER_YEAR)
+        for index, block in enumerate(blocks):
+            part = year_frame.filter(pl.col("date").is_in(block.implode()))
+            dst = root / f"year={year[0]}" / f"data-{index:02d}.parquet"
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            part.write_parquet(dst)
+            size = dst.stat().st_size
+            if size > NASDAQ100_MINUTE_MAX_BLOB_BYTES:
+                raise ValueError(
+                    f"{dst} is {size / 1e6:.1f} MB, above GitHub's 100 MB blob limit. "
+                    f"Raise NASDAQ100_MINUTE_PARTS_PER_YEAR above "
+                    f"{NASDAQ100_MINUTE_PARTS_PER_YEAR}."
+                )
+            print(
+                f"    year={year[0]} part {index}: {len(part):,} rows ({size / 1e6:.1f} MB), "
+                f"{part['date'].n_unique()} sessions, {part['symbol'].n_unique()} symbols"
+            )
+            written.append(dst)
     return written
 
 
@@ -655,6 +707,7 @@ DATASETS: tuple[Dataset, ...] = (
             "run_stride": NASDAQ100_MINUTE_RUN_STRIDE,
             "dense_from": NASDAQ100_MINUTE_DENSE_FROM.isoformat(),
             "bar_spacing": "1m (unchanged from production)",
+            "parts_per_year": NASDAQ100_MINUTE_PARTS_PER_YEAR,
         },
     ),
     Dataset(
@@ -682,6 +735,122 @@ DATASETS: tuple[Dataset, ...] = (
 )
 
 DATASETS_BY_NAME = {dataset.name: dataset for dataset in DATASETS}
+
+
+@dataclass(frozen=True)
+class UnbuiltFixture:
+    """A fixture the test-data repo carries that this script cannot rebuild.
+
+    Attributes:
+        name: Manifest ``subsets`` key.
+        description: What the fixture holds, mirrored into the manifest.
+        covers: Paths under the output root the fixture occupies.
+        entities: ``{path: (column, count)}`` measured on the fixture itself, so
+            the declaration is a measurement rather than an intention and a test
+            can check it against the files on disk.
+        reason: Why there is no ``Dataset`` spec.
+    """
+
+    name: str
+    description: str
+    covers: tuple[Path, ...]
+    entities: dict[str, tuple[str, int]]
+    reason: str
+
+
+# The fixtures produced before this script existed, by paths that were not kept.
+#
+# They are declared rather than left implicit because the manifest is the only
+# record of what the fixture set is supposed to contain, and an entry nothing can
+# confirm is worse than no entry: every one of these carried a budget the fixture
+# did not satisfy - "15 most liquid ETFs" over 56 symbols, "8 major/cross FX pairs"
+# over 20, "50 most liquid US equities" over 56, "8 most liquid CME products" over
+# a 30-product daily panel. What is recorded here is measured on the fixture.
+#
+# Why none of them has a builder, measured 2026-09-03 by filtering current
+# production to each fixture's own symbol set: the row counts match exactly, but
+# the shipped fixtures are snapshots of an older production state, so a builder
+# that filtered production today would not reproduce them. `etfs` and `fx` carry a
+# Datetime date column where production now carries Date; `crypto` ends
+# 2025-12-29 against production's 2025-12-31. Writing the specs is therefore a
+# regeneration of each fixture rather than a description of it - per-dataset work
+# with per-dataset verification against the notebooks that read it, and one push to
+# ml4t/third-edition-test-data that changes CI inputs for every open branch at once.
+UNBUILT_FIXTURES: tuple[UnbuiltFixture, ...] = (
+    UnbuiltFixture(
+        name="etfs",
+        description="56 ETFs across categories, of the 100 production carries",
+        covers=(Path("etfs") / "market",),
+        entities={
+            "etfs/market/etf_universe.parquet": ("symbol", 56),
+            "etfs/market/etf_universe_unadjusted.parquet": ("symbol", 56),
+        },
+        reason="produced before this script existed; the shipped extract predates the "
+        "current production schema (Datetime date column against production's Date)",
+    ),
+    UnbuiltFixture(
+        name="crypto",
+        description="5 perpetual futures of the 19 production carries, hourly bars "
+        "with their 8-hour premium index and funding rate",
+        covers=(Path("crypto") / "market",),
+        entities={
+            "crypto/market/perps_1h.parquet": ("symbol", 5),
+            "crypto/market/premium_index_8h.parquet": ("symbol", 5),
+            "crypto/market/funding_rate.parquet": ("symbol", 5),
+        },
+        reason="produced before this script existed; the shipped extract ends two "
+        "sessions before production, so filtering production does not reproduce it",
+    ),
+    UnbuiltFixture(
+        name="fx",
+        description="the whole production FX panel, 20 major and cross pairs at 4h "
+        "and daily - not reduced on any axis",
+        covers=(Path("fx") / "market",),
+        entities={
+            "fx/market/4h.parquet": ("symbol", 20),
+            "fx/market/daily.parquet": ("symbol", 20),
+        },
+        reason="produced before this script existed, and reduced on no axis: the row "
+        "counts equal production's exactly, so this fixture measures nothing about "
+        "reduction and only pins the panel",
+    ),
+    UnbuiltFixture(
+        name="us_equities",
+        description="56 tickers of the 3,199 production carries, full date range",
+        covers=(Path("equities") / "market" / "us_equities",),
+        entities={"equities/market/us_equities/us_equities.parquet": ("ticker", 56)},
+        reason="produced before this script existed; the reduction rule that chose "
+        "these 56 was not kept",
+    ),
+    UnbuiltFixture(
+        name="cme_futures",
+        description="the whole 30-product production daily panel, with the hourly "
+        "bars reduced to 8 products",
+        covers=(Path("futures") / "market" / "continuous",),
+        entities={
+            "futures/market/continuous/daily/continuous_daily.parquet": ("product", 30),
+        },
+        reason="produced before this script existed, and the two halves disagree: the "
+        "daily panel is byte-identical to production (same md5, 312,859 rows over 30 "
+        "products) while the hourly bars carry 8. cme_futures reads the daily one, and "
+        "config/setup.yaml declares 30 products with initial_cash and top_k_grid sized "
+        "for them, so the daily panel is the one that matches the study",
+    ),
+)
+
+UNBUILT_BY_NAME = {fixture.name: fixture for fixture in UNBUILT_FIXTURES}
+
+# Manifest entries that describe a fixture another dataset already owns, and are
+# dropped rather than declared. `sp500_daily` describes
+# equities/market/sp500/daily_bars.parquet, which build_sp500_options writes;
+# `nasdaq100` describes the minute bars build_nasdaq100_minute_bars writes. Both
+# still carried their pre-reorganization paths and their pre-widening budgets - 20
+# and 3 symbols against the 30 and 12 on disk - so a reader consulting the manifest
+# got a wrong answer about a fixture that does have a builder.
+SUPERSEDED_SUBSETS = {
+    "sp500_daily": "sp500_options",
+    "nasdaq100": "nasdaq100_minute_bars",
+}
 
 
 def _owned_by(dataset: Dataset, rel: str) -> bool:
@@ -726,6 +895,88 @@ def write_manifest(output: Path, built: dict[str, list[Path]]) -> Path:
     return manifest_path
 
 
+def declared_subsets() -> dict[str, dict]:
+    """What ``manifest.json``'s ``subsets`` block has to say, from the declarations.
+
+    One entry per registered ``Dataset`` and one per ``UnbuiltFixture``, and nothing
+    else. This is the comparison that would have fired the day #652 landed: the
+    manifest still said sp500_options kept 3 "most liquid" underlyings while the
+    builder declared 30 named ones, and nothing noticed until a case study spent a
+    day on five notebooks that were failing on the stale fixture rather than on
+    anything in the notebooks.
+    """
+    subsets = {
+        dataset.name: {**dataset.budget, "description": dataset.description} for dataset in DATASETS
+    }
+    subsets.update(
+        {
+            fixture.name: {
+                "description": fixture.description,
+                "entities": {
+                    path: {"column": column, "count": count}
+                    for path, (column, count) in fixture.entities.items()
+                },
+                "no_builder": fixture.reason,
+            }
+            for fixture in UNBUILT_FIXTURES
+        }
+    )
+    return subsets
+
+
+def reconcile_manifest(output: Path) -> tuple[Path, dict]:
+    """Rewrite ``manifest.json`` so it describes the fixture set that is on disk.
+
+    Two things go stale on their own and nothing was checking either. The ``subsets``
+    block drifts from the declarations whenever a builder changes without a
+    regeneration. The ``files`` block keeps every path it ever recorded, because
+    :func:`write_manifest` only drops entries under the dataset being rebuilt - so a
+    reorganization of the tree (``crypto/`` to ``crypto/market/``, and the same for
+    equities, etfs, fx and futures) left the manifest listing files that are not
+    there, which is the same wrong answer as a stale budget.
+
+    Sizes are re-read for the paths that do exist; a path that does not is dropped.
+    Every file under a declared dataset's own paths is then recorded, so the block
+    describes the declared fixture set completely rather than whatever the last
+    per-dataset run happened to write. Files under no declaration are kept if they
+    exist and never added, because what belongs in the fixture set is a declaration
+    and not whatever is in the directory.
+    """
+    manifest_path = output / "manifest.json"
+    manifest: dict = {"version": "1", "subsets": {}, "files": {}}
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+
+    manifest["subsets"] = declared_subsets()
+
+    def record(rel: str, path: Path) -> None:
+        size = path.stat().st_size
+        files[rel] = {"size_bytes": size, "size_mb": round(size / 1e6, 2)}
+
+    files: dict[str, dict] = {}
+    for rel in sorted(manifest.get("files", {})):
+        path = output / rel
+        if path.is_file():
+            record(rel, path)
+    dropped = sorted(set(manifest.get("files", {})) - set(files))
+
+    declared_paths = [owned for dataset in DATASETS for owned in dataset.owns]
+    declared_paths += [covered for fixture in UNBUILT_FIXTURES for covered in fixture.covers]
+    added = []
+    for declared in declared_paths:
+        root = output / declared
+        found = [root] if root.is_file() else sorted(f for f in root.rglob("*") if f.is_file())
+        for path in found:
+            rel = path.relative_to(output).as_posix()
+            if rel not in files:
+                added.append(rel)
+            record(rel, path)
+
+    manifest["files"] = dict(sorted(files.items()))
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return manifest_path, {"kept": len(files), "dropped": dropped, "added": sorted(added)}
+
+
 def roots_overlap(source: Path, output: Path) -> str | None:
     """Return why these roots cannot be used together, or None.
 
@@ -750,8 +1001,8 @@ def main() -> int:
     parser.add_argument(
         "--source",
         type=Path,
-        required=True,
-        help="Production data root to subsample from (e.g. ~/ml4t/code/data)",
+        help="Production data root to subsample from (e.g. ~/ml4t/code/data). "
+        "Required unless --reconcile-manifest, which reads no production data.",
     )
     parser.add_argument(
         "--output",
@@ -771,8 +1022,31 @@ def main() -> int:
         help="Remove each selected dataset's output directory before writing it",
     )
     parser.add_argument("--dry-run", action="store_true", help="Report the plan, write nothing")
+    parser.add_argument(
+        "--reconcile-manifest",
+        action="store_true",
+        help=(
+            "Rewrite data/manifest.json from the declarations and the files on disk, "
+            "building nothing. --source is not read."
+        ),
+    )
     args = parser.parse_args()
 
+    if args.reconcile_manifest:
+        output = args.output.expanduser().resolve()
+        manifest_path, report = reconcile_manifest(output)
+        print(f"Manifest: {manifest_path}")
+        print(f"  subsets: {', '.join(sorted(declared_subsets()))}")
+        print(
+            f"  files: {report['kept']} recorded, {len(report['dropped'])} dropped as "
+            f"not on disk, {len(report['added'])} added from a declared path"
+        )
+        for rel in report["dropped"]:
+            print(f"  dropped, not on disk: {rel}")
+        return 0
+
+    if args.source is None:
+        parser.error("--source is required unless --reconcile-manifest is given")
     source = args.source.expanduser().resolve()
     output = args.output.expanduser().resolve()
     if not source.is_dir():

--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -855,36 +855,22 @@ def _reference_panels(cs_dir: Path, hash_rows: list, survives, _pl) -> dict:
     agrees on is what makes the seeded sets joinable with the copied ones rather
     than only with each other.
 
-    Artifacts this function will not rewrite are preferred, so the panel is normally
-    one that survives seeding. A group whose only on-disk artifacts WILL be rewritten
-    still uses one of them as the panel rather than falling back to the fabricated
-    grid: rewriting an artifact onto its own keys changes the scores and not the
-    grid, so the group stays joinable and keeps a real one.
-
-    That fallback is not cosmetic. crypto_perps_funding sets ``rewrite_existing``, so
-    only its cohort leaders survive - and its ``fwd_ret_8h`` leader has no artifact on
-    disk at all. Without the fallback the whole label fell to ``_weekday_grid``, which
-    emits about sixty *dates* across the window, roughly eight weekdays apart. An 8H
-    label cannot live on that grid, and 13_backtest rejected it in CI with
-    "decision intervals [9 days, 10 days, 12 days] do not match horizon 8H" while four
-    real artifacts on the correct 8-hour grid sat in the same group unused.
+    A real panel matters, not just any panel. When a group had none, its whole label
+    fell to ``_weekday_grid``, which emits about sixty *dates* across the window,
+    roughly eight weekdays apart. An 8H label cannot live on that grid, and
+    13_backtest rejected it in CI with "decision intervals [9 days, 10 days, 12 days]
+    do not match horizon 8H" while four real artifacts on the correct 8-hour grid sat
+    in the same case study unused. Every artifact on disk now survives seeding, so a
+    group with any artifact of its own has a real panel to be seeded onto.
 
     The dates are subsampled to ``SEEDED_DATE_BUDGET``; they are a subset of the
     reference's own dates, which the registry places inside the split window, so the
     split boundary the fabricated grid enforces still holds.
     """
     groups: dict = {}
-    fallback_groups: dict = {}
     for p_hash, split, label in hash_rows:
         if survives(p_hash):
             groups.setdefault((split, label), []).append(p_hash)
-        elif (cs_dir / "run_log" / "predictions" / p_hash / "predictions.parquet").is_file():
-            fallback_groups.setdefault((split, label), []).append(p_hash)
-    fallback_only = set()
-    for key, hashes in fallback_groups.items():
-        if key not in groups:
-            groups[key] = hashes
-            fallback_only.add(key)
 
     panels = {}
     for key, hashes in groups.items():
@@ -895,12 +881,6 @@ def _reference_panels(cs_dir: Path, hash_rows: list, survives, _pl) -> dict:
             )
             entity = next((c for c in ENTITY_COLUMN_CANDIDATES if c in frame.columns), None)
             if entity is None or not {"timestamp", "actual"} <= set(frame.columns):
-                continue
-            # A rewritten artifact is only worth keeping as the panel because it
-            # carries a real decision grid. One with a single timestamp carries no
-            # grid - it is the placeholder a superseded set leaves behind - so the
-            # group is better served by the fabricated one than by inheriting it.
-            if key in fallback_only and frame["timestamp"].n_unique() < 2:
                 continue
             # Only ever compared for equality, so stringifying the identifiers is
             # enough and keeps a column carrying nulls from raising in sorted().
@@ -1477,7 +1457,6 @@ def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
         templates[(window, n_folds)] = (frame, n)
         return templates[(window, n_folds)]
 
-    rewrite_existing = cs_id == "crypto_perps_funding"
     missing_leaders = sorted(
         p_hash
         for p_hash in cohort_leader_hashes
@@ -1512,9 +1491,27 @@ def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
         )
 
     def _survives(p_hash: str) -> bool:
-        """True when the loop below leaves this artifact exactly as it is."""
+        """True when the loop below leaves this artifact exactly as it is.
+
+        An artifact the fixture already carries is the one its registry row
+        describes, so replacing it makes the fixture contradict itself: the row
+        keeps reporting the coverage and the IC of a prediction set that is no
+        longer on disk, and a notebook obeying `rules/notebook-standards.md` C9 -
+        validate that the artifact you read is the one the registry describes -
+        then cannot pass under CI. `16_strategy_simulation/08_signal_method_comparison`
+        hit exactly that and had to weaken its check.
+
+        crypto_perps_funding used to be exempt from this, via a
+        `rewrite_existing = cs_id == "crypto_perps_funding"` line that arrived in a
+        bulk release commit (70924077) with no isolated rationale and none recorded
+        anywhere since. Measured across the shipped fixture: it was the only thing
+        rewriting an artifact the fixture ships - five of them, all crypto - and it
+        redrew their scores while their registry rows went on describing the old
+        ones. The other eight case studies already behaved this way, so dropping it
+        makes crypto agree with them rather than introducing a new rule.
+        """
         pred_file = cs_dir / "run_log" / "predictions" / p_hash / "predictions.parquet"
-        return pred_file.is_file() and (p_hash in cohort_leader_hashes or not rewrite_existing)
+        return pred_file.is_file()
 
     # Two prediction sets of one (split, label) have to be joinable on
     # (timestamp, entity), or a notebook that pairs them measures nothing:

--- a/tests/generate_intermediates.py
+++ b/tests/generate_intermediates.py
@@ -23,6 +23,14 @@ Usage:
     uv run python tests/generate_intermediates.py \
         --output ~/ml4t/test-data/intermediates \
         --through-stage 12 --no-skip-dl
+
+Exit status is 0 only when every stage of every requested case study was
+generated. A stage that failed, and a pipeline stage (01-05) that
+``tests/overrides.yaml`` marks ``skip`` so that nothing downstream of it is
+regenerated, both exit 1: the fixture then holds whatever an earlier run wrote,
+which is a stale fixture that looks freshly built. ``--ignore-skips`` runs those
+stages anyway - the skips exist to keep the timed CI job inside its budget, and
+generation has no budget to protect.
 """
 
 import argparse
@@ -32,6 +40,7 @@ import re
 import shutil
 import sys
 import time
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -76,16 +85,21 @@ DL_STAGE_PATTERNS = re.compile(
 # regularization), silently regenerating fixtures against the stale values.
 
 
-def seed_configs(output_dir: Path) -> None:
+def seed_configs(output_dir: Path, case_studies: Iterable[str] = CASE_STUDIES) -> None:
     """Copy case study configs and global model presets into output_dir.
 
     Replicates the logic of conftest.py's seeded_output_dir fixture so that
     notebooks executed via generate_intermediates.py find patched configs.
+
+    Only ``case_studies`` are seeded. Seeding all nine regardless of what the run
+    was scoped to rewrote 51 tracked files under eight other case studies from a
+    single ``--case-studies cme_futures`` run, so an agent could not regenerate
+    its own fixture without touching committed state it does not own.
     """
     cs_root = REPO_ROOT / "case_studies"
 
     # Copy per-case-study config files (setup.yaml, training menus, backtest presets, etc.)
-    for cs_id in CASE_STUDIES:
+    for cs_id in case_studies:
         src_config_dir = cs_root / cs_id / "config"
         if not src_config_dir.exists():
             continue
@@ -103,7 +117,7 @@ def seed_configs(output_dir: Path) -> None:
         shutil.copytree(global_config_src, global_config_dst)
         _patch_presets_for_testing(global_config_dst)
 
-    print(f"Seeded configs into {output_dir}")
+    print(f"Seeded configs into {output_dir} for: {', '.join(case_studies)}")
 
 
 def discover_stages(cs_dir: Path, through_stage: int, skip_dl: bool) -> list[Path]:
@@ -127,6 +141,44 @@ def discover_stages(cs_dir: Path, through_stage: int, skip_dl: bool) -> list[Pat
         stages.append(notebook)
 
     return stages
+
+
+# Outcomes a stage can end a generation run with. `incomplete` is the one this
+# script used to have no name for: the stage did not run and nothing downstream
+# of it could, so the fixture on disk is whatever a previous run left there.
+# Counting that as a skip is how a default regeneration reported success while
+# producing nothing for cme_futures stages 04-08.
+OK = "ok"
+FAILED = "failed"
+SKIPPED = "skipped"
+INCOMPLETE = "incomplete"
+NOT_RUN = "not_run"
+
+# A generation run has not produced the fixture it claims unless every stage
+# either ran or was skipped for a reason that leaves nothing downstream unbuilt.
+EARNS_NONZERO_EXIT = (FAILED, INCOMPLETE)
+
+
+def resolve_case_studies(requested: Iterable[str]) -> list[str]:
+    """Return the requested case studies, rejecting any name that is not one.
+
+    A name that matches nothing used to be skipped without entering ``results``,
+    so the failure count stayed zero and the run exited 0 - a typo produced a
+    green run that generated nothing.
+    """
+    requested = list(requested)
+    unknown = [name for name in requested if name not in CASE_STUDIES]
+    if unknown:
+        raise ValueError(
+            f"unknown case study {', '.join(sorted(unknown))} - "
+            f"choose from {', '.join(CASE_STUDIES)}"
+        )
+    return requested
+
+
+def exit_code(results: dict[str, str]) -> int:
+    """0 only when every stage of every requested case study is accounted for."""
+    return 1 if any(v in EARNS_NONZERO_EXIT for v in results.values()) else 0
 
 
 def main():
@@ -161,14 +213,29 @@ def main():
         dest="skip_dl",
         help="Include DL/latent/causal stages",
     )
+    parser.add_argument(
+        "--ignore-skips",
+        action="store_true",
+        help=(
+            "Run stages that overrides.yaml marks skip. Those skips exist to keep the "
+            "timed CI job inside its budget; generation has no such budget and its whole "
+            "purpose is to produce the artifact that job then consumes."
+        ),
+    )
     args = parser.parse_args()
+
+    try:
+        case_studies = resolve_case_studies(args.case_studies)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     output_dir = args.output.expanduser().resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Seed configs (setup.yaml, label configs, model presets) into output dir
-    # so notebooks find patched configs when ML4T_OUTPUT_DIR is set.
-    seed_configs(output_dir)
+    # so notebooks find patched configs when ML4T_OUTPUT_DIR is set. Scoped to the
+    # requested case studies: see seed_configs.
+    seed_configs(output_dir, case_studies)
 
     # Set ML4T_OUTPUT_DIR so all pipeline writes go to our output directory
     os.environ["ML4T_OUTPUT_DIR"] = str(output_dir)
@@ -178,15 +245,20 @@ def main():
     results = {}
     total_start = time.time()
 
-    for cs in args.case_studies:
+    for cs in case_studies:
         cs_dir = REPO_ROOT / "case_studies" / cs
         if not cs_dir.exists():
-            print(f"\nSKIP {cs}: directory not found")
+            # resolve_case_studies has already accepted the name, so the directory
+            # is missing rather than mistyped: nothing gets generated for it and
+            # the run has not done what it was asked to.
+            print(f"\nINCOMPLETE {cs}: directory not found")
+            results[cs] = INCOMPLETE
             continue
 
         stages = discover_stages(cs_dir, args.through_stage, args.skip_dl)
         if not stages:
-            print(f"\nSKIP {cs}: no stages found")
+            print(f"\nINCOMPLETE {cs}: no stages found through stage {args.through_stage}")
+            results[cs] = INCOMPLETE
             continue
 
         print(f"\n{'=' * 60}")
@@ -198,22 +270,35 @@ def main():
             stage = notebook.stem
 
             if cs_failed:
-                print(f"  {stage}: SKIP (earlier stage failed)")
-                results[f"{cs}::{stage}"] = "skipped"
+                print(f"  {stage}: NOT RUN (an earlier stage did not complete)")
+                results[f"{cs}::{stage}"] = NOT_RUN
                 continue
 
             rel_path = notebook.relative_to(REPO_ROOT).with_suffix("")
             overrides = get_overrides(str(rel_path))
 
-            # Skip if overrides say so
-            if overrides.get("skip"):
+            # Skip if overrides say so, unless the operator asked for the whole
+            # pipeline. overrides.yaml's `skip` is read by the timed CI job and by
+            # this generator, and the two want different answers from it: the job
+            # is protecting a time budget, and generation is producing the artifact
+            # that job consumes.
+            if overrides.get("skip") and not args.ignore_skips:
                 reason = overrides.get("skip_reason", "marked skip")
-                print(f"  {stage}: SKIP ({reason})")
-                results[f"{cs}::{stage}"] = "skipped"
-                # Pipeline stages (01-05) cascade their skip
                 stage_num = int(stage[:2])
+                # A pipeline stage (01-05) that does not run leaves every later
+                # stage of this case study unbuilt, so the fixture keeps whatever
+                # the previous run wrote. That is an incomplete generation, not a
+                # skipped one, and the exit code has to say so.
                 if stage_num <= 5:
+                    print(f"  {stage}: INCOMPLETE, skipped by overrides ({reason})")
+                    print("    Nothing downstream of it is regenerated; the fixture keeps")
+                    print("    whatever an earlier run left on disk. Re-run with --ignore-skips")
+                    print("    to generate it anyway.")
+                    results[f"{cs}::{stage}"] = INCOMPLETE
                     cs_failed = True
+                else:
+                    print(f"  {stage}: SKIP ({reason})")
+                    results[f"{cs}::{stage}"] = SKIPPED
                 continue
 
             timeout = overrides.get("timeout", 300)
@@ -234,11 +319,11 @@ def main():
 
             if result["status"] == "ok":
                 print(f" OK ({elapsed:.0f}s)")
-                results[f"{cs}::{stage}"] = "ok"
+                results[f"{cs}::{stage}"] = OK
             else:
                 print(f" FAILED ({elapsed:.0f}s)")
                 print(f"    Error: {result['error']}")
-                results[f"{cs}::{stage}"] = "failed"
+                results[f"{cs}::{stage}"] = FAILED
                 cs_failed = True
 
     total_elapsed = time.time() - total_start
@@ -247,16 +332,21 @@ def main():
     print(f"\n{'=' * 60}")
     print(f"Summary ({total_elapsed:.0f}s total)")
     print(f"{'=' * 60}")
-    ok = sum(1 for v in results.values() if v == "ok")
-    failed = sum(1 for v in results.values() if v == "failed")
-    skipped = sum(1 for v in results.values() if v == "skipped")
-    print(f"  OK: {ok}  Failed: {failed}  Skipped: {skipped}")
+    counts = {
+        state: sum(1 for v in results.values() if v == state)
+        for state in (OK, FAILED, INCOMPLETE, SKIPPED, NOT_RUN)
+    }
+    print(
+        f"  OK: {counts[OK]}  Failed: {counts[FAILED]}  Incomplete: {counts[INCOMPLETE]}  "
+        f"Skipped: {counts[SKIPPED]}  Not run: {counts[NOT_RUN]}"
+    )
 
-    if failed:
-        print("\nFailed stages:")
-        for k, v in results.items():
-            if v == "failed":
-                print(f"  - {k}")
+    for state, heading in ((FAILED, "Failed stages"), (INCOMPLETE, "Incomplete units")):
+        if counts[state]:
+            print(f"\n{heading}:")
+            for k, v in results.items():
+                if v == state:
+                    print(f"  - {k}")
 
     # Show output size
     total_bytes = sum(f.stat().st_size for f in output_dir.rglob("*") if f.is_file())
@@ -276,11 +366,12 @@ def main():
         json.dump(metadata, f, indent=2)
     print(f"Metadata: {metadata_path}")
 
-    # A failed stage leaves whatever the previous run wrote in place, so exiting 0
-    # reports success while the fixture set still holds the stale artifact. That
-    # is how the sp500_options temporal artifact shipped without a `fold` column:
-    # the stage timed out, the wrapper ran under `set -e` and saw nothing.
-    return 1 if failed else 0
+    # A failed or skipped stage leaves whatever the previous run wrote in place, so
+    # exiting 0 reports success while the fixture set still holds the stale
+    # artifact. That is how the sp500_options temporal artifact shipped without a
+    # `fold` column: the stage timed out, the wrapper ran under `set -e` and saw
+    # nothing.
+    return exit_code(results)
 
 
 if __name__ == "__main__":

--- a/tests/generate_intermediates.py
+++ b/tests/generate_intermediates.py
@@ -348,9 +348,37 @@ def main():
                 if v == state:
                     print(f"  - {k}")
 
-    # Show output size
+    # Show output size, and what this run did to it. The fixture is git-stored and
+    # unreduced production data reaches it silently: regenerating cme_futures stage 03
+    # replaced an 86,110-row, 8-product, 19.5 MB features artifact with a 310,947-row,
+    # 30-product, 75.9 MB one whose content digest equalled production's exactly, and
+    # nothing in the run said so. Whether that growth is wanted is a decision; it can
+    # only be made if the run reports it.
+    metadata_path = output_dir / "_metadata.json"
+    previous = {}
+    if metadata_path.is_file():
+        try:
+            previous = json.loads(metadata_path.read_text()).get("size_mb_by_case_study", {})
+        except (OSError, json.JSONDecodeError):
+            previous = {}
+
     total_bytes = sum(f.stat().st_size for f in output_dir.rglob("*") if f.is_file())
+    sizes = {
+        cs: round(
+            sum(f.stat().st_size for f in (output_dir / cs).rglob("*") if f.is_file()) / 1e6, 1
+        )
+        for cs in case_studies
+        if (output_dir / cs).is_dir()
+    }
     print(f"\nOutput: {output_dir} ({total_bytes / 1e6:.1f} MB)")
+    for cs, size in sizes.items():
+        before = previous.get(cs)
+        if before is None:
+            print(f"  {cs}: {size:.1f} MB")
+        else:
+            change = size - before
+            factor = f", {size / before:.1f}x" if before else ""
+            print(f"  {cs}: {before:.1f} -> {size:.1f} MB ({change:+.1f} MB{factor})")
 
     # Write metadata for staleness tracking
     metadata = {
@@ -360,8 +388,8 @@ def main():
         "results": results,
         "total_seconds": round(total_elapsed),
         "size_mb": round(total_bytes / 1e6, 1),
+        "size_mb_by_case_study": sizes,
     }
-    metadata_path = output_dir / "_metadata.json"
     with open(metadata_path, "w") as f:
         json.dump(metadata, f, indent=2)
     print(f"Metadata: {metadata_path}")

--- a/tests/sample_registry_for_tests.py
+++ b/tests/sample_registry_for_tests.py
@@ -125,6 +125,20 @@ SYMBOL_COLUMN_CANDIDATES = ("ticker", "symbol")
 PREDICTION_TARGET_COLUMN = "actual"
 
 
+def _has_table(connection, table: str) -> bool:
+    """Whether the registry carries this table at all.
+
+    The stub registries the unit tests build carry only the tables the case under
+    test needs, and a canonical registry predating a table has the same shape.
+    """
+    return (
+        connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone()
+        is not None
+    )
+
+
 def _copy_rows(src, dst, table: str, rows: list) -> int:
     """Insert rows into dst table with proper column quoting."""
     if not rows:
@@ -406,14 +420,8 @@ def _populate_sample_db(src, dst, dst_db) -> dict:
         # backtest_runs sample is. Filtering by leader_hash membership in the sample
         # is sufficient and correct: a row whose leader was not sampled would fail the
         # same JOIN downstream anyway, so it is dropped exactly like an FK would.
-        has_cohort_metrics = (
-            src.execute(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='cohort_metrics'"
-            ).fetchone()
-            is not None
-        )
         count = 0
-        if has_cohort_metrics:
+        if _has_table(src, "cohort_metrics"):
             for i in range(0, len(hash_list), batch_size):
                 batch = hash_list[i : i + batch_size]
                 placeholders = ",".join(["?"] * len(batch))
@@ -423,6 +431,46 @@ def _populate_sample_db(src, dst, dst_db) -> dict:
                 ).fetchall()
                 count += _copy_rows(src, dst, "cohort_metrics", rows)
         stats["cohort_metrics"] = count
+
+        # 3f. Copy backtest_paired_metrics for pairs both of whose sides survived.
+        # A challenger-versus-benchmark row is only readable when both backtests are
+        # in the fixture: challenger_hash carries an FK to backtest_runs and
+        # benchmark_hash is resolved the same way by every reader. The table got its
+        # schema and none of its rows, so a strategy-analysis notebook comparing a
+        # candidate against its benchmark found nothing and could not distinguish
+        # "not computed" from "not sampled".
+        count = 0
+        if _has_table(src, "backtest_paired_metrics"):
+            # benchmark_hash carries no FK, so the pair is filtered here rather than
+            # by SQLite: a row pointing at a benchmark the sample dropped reads as a
+            # comparison against a backtest that is not there.
+            benchmark_index = [
+                column[0]
+                for column in src.execute(
+                    "SELECT * FROM backtest_paired_metrics LIMIT 0"
+                ).description
+            ].index("benchmark_hash")
+            for i in range(0, len(hash_list), batch_size):
+                batch = hash_list[i : i + batch_size]
+                placeholders = ",".join(["?"] * len(batch))
+                rows = src.execute(
+                    "SELECT * FROM backtest_paired_metrics "
+                    f"WHERE challenger_hash IN ({placeholders})",
+                    batch,
+                ).fetchall()
+                rows = [row for row in rows if row[benchmark_index] in sampled_bt_hashes]
+                count += _copy_rows(src, dst, "backtest_paired_metrics", rows)
+        stats["backtest_paired_metrics"] = count
+
+    # 4. Copy causal_runs in full. Its rows are keyed by causal_hash and depend on no
+    # sampled backtest or prediction, so there is nothing to filter them by; the table
+    # had schema and no rows, and 15_causal_estimation reads it. One row per causal
+    # notebook run, so full is also small.
+    count = 0
+    if _has_table(src, "causal_runs"):
+        rows = src.execute("SELECT * FROM causal_runs").fetchall()
+        count = _copy_rows(src, dst, "causal_runs", rows)
+    stats["causal_runs"] = count
 
     dst.commit()
 
@@ -965,6 +1013,8 @@ def main() -> int:
             "backtest_metrics",
             "backtest_fold_metrics",
             "cohort_metrics",
+            "backtest_paired_metrics",
+            "causal_runs",
         ]:
             print(f"  {table:30s} {stats.get(table, 0):>6}")
         print(f"  {'backtest artifact dirs':30s} {stats.get('backtest_artifact_dirs', 0):>6}")

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -1,9 +1,13 @@
 """Tests for utils/data_quality.py.
 
 Pins:
-- apply_max_symbols: seed determinism + edge cases (no-op when max<=0 or >=N).
-  Called by every loader; non-determinism would break reproducibility of tests
-  and notebooks that depend on a sampled subset.
+- apply_max_symbols: the one entity-reduction rule (most-observed, ties by name)
+  and its edge cases. Called by every loader, and reached from the modelling side
+  by utils.modeling.reduce_to_top_entities, so a producer and a consumer reducing
+  the same panel to the same size get the same universe. When it was a seeded
+  random sample the two disagreed: on nasdaq100_microstructure's fixture the labels
+  covered {AAPL, AMD, CMCSA, CSCO, SIRI} and the temporal features
+  {AAPL, AMD, AMZN, FB, TSLA}.
 - check_ohlc_invariants: correct detection of OHLC violations, graceful
   handling of null values (TAQ no-trade bars), and missing-column tolerance.
 """
@@ -64,28 +68,32 @@ def test_apply_max_symbols_exceeds_universe_is_passthrough() -> None:
     assert out.equals(df)
 
 
-def test_apply_max_symbols_samples_requested_count() -> None:
+def test_apply_max_symbols_keeps_the_requested_count() -> None:
     df = _make_prices(["A", "B", "C", "D", "E"])
     out = apply_max_symbols(df, 3)
     assert out["symbol"].n_unique() == 3
 
 
-def test_apply_max_symbols_is_seed_deterministic() -> None:
-    """Same seed → same subset; critical for reproducible tests."""
-    df = _make_prices(["A", "B", "C", "D", "E", "F", "G", "H"])
+def test_apply_max_symbols_keeps_the_most_observed() -> None:
+    """The rule itself: history, not a draw."""
+    df = pl.concat(
+        [
+            _make_prices(["A"], n_rows=1),
+            _make_prices(["B"], n_rows=5),
+            _make_prices(["C"], n_rows=3),
+        ]
+    )
+    assert sorted(apply_max_symbols(df, 2)["symbol"].unique().to_list()) == ["B", "C"]
 
-    first = apply_max_symbols(df, 3, seed=42)["symbol"].unique().sort().to_list()
-    second = apply_max_symbols(df, 3, seed=42)["symbol"].unique().sort().to_list()
-    assert first == second
 
+def test_apply_max_symbols_breaks_a_tie_on_the_entity_name() -> None:
+    """Equal row counts are common - twelve nasdaq fixture symbols, five tied.
 
-def test_apply_max_symbols_different_seed_yields_different_sample() -> None:
-    df = _make_prices(["A", "B", "C", "D", "E", "F", "G", "H"])
-
-    s42 = set(apply_max_symbols(df, 3, seed=42)["symbol"].unique().to_list())
-    s7 = set(apply_max_symbols(df, 3, seed=7)["symbol"].unique().to_list())
-    # At least one sample differs — very high probability for k=3, n=8
-    assert s42 != s7
+    Without the tie break the answer comes out of frame order, so two callers
+    reducing the same panel to the same size can pick different symbols.
+    """
+    df = _make_prices(["D", "C", "B", "A"], n_rows=4)
+    assert sorted(apply_max_symbols(df, 2)["symbol"].unique().to_list()) == ["A", "B"]
 
 
 def test_apply_max_symbols_preserves_all_rows_per_symbol() -> None:
@@ -96,16 +104,45 @@ def test_apply_max_symbols_preserves_all_rows_per_symbol() -> None:
     assert per_symbol["len"].to_list() == [5, 5]
 
 
-def test_apply_max_symbols_sort_then_sample_is_order_invariant() -> None:
-    """Shuffling the input before sampling must yield the same subset: the
-    function sorts symbols before seeding the RNG so unstable loader order
-    (e.g., parquet partition order) can't perturb the selection."""
+def test_apply_max_symbols_is_invariant_to_input_order() -> None:
+    """Parquet partition order must not perturb the selection."""
     df_asc = _make_prices(["A", "B", "C", "D", "E"])
     df_desc = df_asc.sort("symbol", descending=True)
 
-    s1 = apply_max_symbols(df_asc, 2, seed=42)["symbol"].unique().sort().to_list()
-    s2 = apply_max_symbols(df_desc, 2, seed=42)["symbol"].unique().sort().to_list()
+    s1 = apply_max_symbols(df_asc, 2)["symbol"].unique().sort().to_list()
+    s2 = apply_max_symbols(df_desc, 2)["symbol"].unique().sort().to_list()
     assert s1 == s2
+
+
+def test_apply_max_symbols_reduces_a_lazyframe_the_same_way() -> None:
+    """Every loader passing include_microstructure=True reduces lazily."""
+    df = pl.concat(
+        [
+            _make_prices(["A"], n_rows=1),
+            _make_prices(["B"], n_rows=5),
+            _make_prices(["C"], n_rows=3),
+        ]
+    )
+    eager = apply_max_symbols(df, 2)["symbol"].unique().sort().to_list()
+    lazy = apply_max_symbols(df.lazy(), 2).collect()["symbol"].unique().sort().to_list()
+    assert eager == lazy == ["B", "C"]
+
+
+def test_the_loader_and_the_modelling_side_choose_the_same_universe() -> None:
+    """The coverage assertion the split was missing: same set, not same count.
+
+    A consumer symbol the producer never covered joins to null features and the
+    notebook runs clean on a wrong answer, which is why this is a set comparison.
+    """
+    from utils.modeling import reduce_to_top_entities
+
+    df = _make_prices(["A", "B", "C", "D", "E", "F"], n_rows=4)
+    # Give three symbols more history so the choice is not the whole universe.
+    df = pl.concat([df, _make_prices(["B", "D", "F"], n_rows=3)])
+
+    producer = set(apply_max_symbols(df, 3)["symbol"].unique().to_list())
+    consumer = set(reduce_to_top_entities(df, "symbol", 3)["symbol"].unique().to_list())
+    assert producer == consumer == {"B", "D", "F"}
 
 
 def test_apply_max_symbols_custom_symbol_col() -> None:

--- a/tests/test_env_matches_lock.py
+++ b/tests/test_env_matches_lock.py
@@ -1,0 +1,131 @@
+"""The detector that would have caught the 11-day stale image.
+
+`.github/scripts/check_env_matches_lock.py` runs inside `ml4t/ml4t:latest` and
+compares its installed distributions against `uv.lock`. This file exercises the
+comparison against synthetic inventories, because the check itself can only ever
+report on the environment it happens to run in - and a detector that is only
+observed passing is not known to be able to fail.
+
+The condition it exists for: the image built 2026-07-16 carried
+`ml4t-models==0.1.0a4` while the repository declared `>=0.1.0a6` from 2026-07-21,
+so for eleven days public CI measured a dependency set the repository did not
+declare, and the notebook that failed on it read as a numerical problem.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "check_env_matches_lock", REPO_ROOT / ".github" / "scripts" / "check_env_matches_lock.py"
+)
+assert _spec and _spec.loader
+check = importlib.util.module_from_spec(_spec)
+sys.modules["check_env_matches_lock"] = check
+_spec.loader.exec_module(check)
+
+
+# --- name normalization ------------------------------------------------------
+
+
+def test_names_compare_under_pep503_normalization() -> None:
+    """`ml4t_diagnostic`, `ML4T-Diagnostic` and `ml4t.diagnostic` are one distribution."""
+    assert (
+        check.canonical("ML4T_Diagnostic")
+        == check.canonical("ml4t.diagnostic")
+        == "ml4t-diagnostic"
+    )
+
+
+def test_normalization_makes_a_differently_spelled_name_comparable() -> None:
+    locked = {check.canonical("ML4T_Models"): "0.1.2"}
+    installed = {check.canonical("ml4t-models"): "0.1.0a4"}
+    assert check.drift(locked, installed) == [("ml4t-models", "0.1.2", "0.1.0a4")]
+
+
+# --- what counts as drift ----------------------------------------------------
+
+
+def test_an_environment_that_matches_the_lock_reports_nothing() -> None:
+    locked = {"polars": "1.20.0", "numpy": "2.3.1"}
+    assert check.drift(locked, dict(locked)) == []
+
+
+def test_a_version_below_the_locked_one_is_drift() -> None:
+    """The filed instance, restated: the image lagged the lock by one release."""
+    locked = {"ml4t-models": "0.1.0a6"}
+    installed = {"ml4t-models": "0.1.0a4"}
+    assert check.drift(locked, installed) == [("ml4t-models", "0.1.0a6", "0.1.0a4")]
+
+
+def test_a_version_above_the_locked_one_is_drift_too() -> None:
+    """LightGBM went 4.6.0 -> 4.7.0 under a floating pin and broke the build."""
+    locked = {"lightgbm": "4.6.0"}
+    installed = {"lightgbm": "4.7.0"}
+    assert check.drift(locked, installed) == [("lightgbm", "4.6.0", "4.7.0")]
+
+
+def test_a_distribution_the_lock_does_not_pin_is_not_drift() -> None:
+    assert check.drift({"polars": "1.20.0"}, {"polars": "1.20.0", "ipdb": "0.13.13"}) == []
+
+
+def test_a_locked_distribution_the_environment_omits_is_not_drift() -> None:
+    """The lock resolves extras and platforms an image is not meant to carry."""
+    assert check.drift({"polars": "1.20.0", "darts": "0.38.0"}, {"polars": "1.20.0"}) == []
+
+
+# --- the declared carve-out --------------------------------------------------
+
+
+def test_the_torch_stack_is_exempt_because_the_image_builds_it_from_the_cuda_index() -> None:
+    locked = {"torch": "2.10.0", "torchvision": "0.25.0", "triton": "3.2.0"}
+    installed = {"torch": "2.10.0+cu128", "torchvision": "0.25.0+cu128", "triton": "3.5.0"}
+    assert check.drift(locked, installed) == []
+
+
+def test_the_cuda_runtime_wheels_are_exempt_by_prefix() -> None:
+    locked = {"nvidia-cublas-cu12": "12.8.3.14"}
+    installed = {"nvidia-cublas-cu12": "12.9.0.0"}
+    assert check.drift(locked, installed) == []
+
+
+def test_lightgbm_is_not_exempt() -> None:
+    """It was carved out of the Dockerfile's constraint once, and 4.7 broke the build.
+
+    The Dockerfile now installs the lock's exact version; this is what holds it.
+    """
+    assert not check.is_declared_off_lock("lightgbm")
+
+
+def test_every_carve_out_records_why_it_is_one() -> None:
+    assert all(reason.strip() for reason in check.DECLARED_OFF_LOCK.values())
+
+
+# --- the lock is read, not assumed -------------------------------------------
+
+
+def test_the_repository_lock_parses_and_pins_the_ml4t_libraries() -> None:
+    locked = check.locked_versions(REPO_ROOT / "uv.lock")
+    assert locked["ml4t-diagnostic"]
+    assert locked["polars"]
+
+
+def test_every_declared_ml4t_floor_is_satisfied_by_the_lock() -> None:
+    """pyproject states a reason for each ml4t-* floor; the lock has to clear it."""
+    project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    locked = check.locked_versions(REPO_ROOT / "uv.lock")
+    floors = [
+        dep.split(">=")
+        for dep in project["project"]["dependencies"]
+        if dep.startswith("ml4t-") and ">=" in dep
+    ]
+    assert floors, "no ml4t-* floor found in pyproject dependencies"
+    for name, floor in floors:
+        got = locked[check.canonical(name)]
+        assert tuple(int(p) for p in got.split(".")[:3] if p.isdigit()) >= tuple(
+            int(p) for p in floor.split(".")[:3] if p.isdigit()
+        ), f"uv.lock resolves {name} {got}, below the declared floor {floor}"

--- a/tests/test_env_matches_lock.py
+++ b/tests/test_env_matches_lock.py
@@ -108,6 +108,46 @@ def test_every_carve_out_records_why_it_is_one() -> None:
     assert all(reason.strip() for reason in check.DECLARED_OFF_LOCK.values())
 
 
+# --- what pyproject overrides ------------------------------------------------
+
+
+def test_an_override_is_read_out_of_pyproject() -> None:
+    """The repository's own override, so the parsing is checked against real text."""
+    overridden = check.overridden_dependencies(REPO_ROOT / "pyproject.toml")
+    assert "protobuf" in overridden
+    assert "protobuf>=5.0" in overridden["protobuf"]
+
+
+def test_an_overridden_distribution_is_not_drift() -> None:
+    """uv asserts the version by fiat and pip has no equivalent.
+
+    protobuf is overridden to >=5.0 because 4.x has a C-extension metaclass bug on
+    Python 3.14; the lock then resolves 7.35.0 while opentelemetry-proto requires
+    <7.0, so a pip install into the image resolves 6.33.6 and is right to.
+    """
+    locked = {"protobuf": "7.35.0"}
+    installed = {"protobuf": "6.33.6"}
+    assert check.drift(locked, installed) == [("protobuf", "7.35.0", "6.33.6")]
+    assert check.drift(locked, installed, {"protobuf": "overridden to protobuf>=5.0"}) == []
+
+
+def test_an_override_specifier_is_parsed_down_to_the_name() -> None:
+    written = {
+        "tool": {"uv": {"override-dependencies": ["Some_Pkg[extra]>=1.2", "other!=3"]}},
+    }
+    import tempfile
+    import tomllib as _tomllib  # noqa: F401
+
+    path = Path(tempfile.mkdtemp()) / "pyproject.toml"
+    path.write_text('[tool.uv]\noverride-dependencies = ["Some_Pkg[extra]>=1.2", "other!=3"]\n')
+    assert set(check.overridden_dependencies(path)) == {"some-pkg", "other"}
+    assert written  # the literal above documents the shape being parsed
+
+
+def test_a_missing_pyproject_overrides_nothing() -> None:
+    assert check.overridden_dependencies(Path("/nonexistent/pyproject.toml")) == {}
+
+
 # --- the lock is read, not assumed -------------------------------------------
 
 

--- a/tests/test_env_matches_lock.py
+++ b/tests/test_env_matches_lock.py
@@ -114,21 +114,37 @@ def test_every_carve_out_records_why_it_is_one() -> None:
 def test_an_override_is_read_out_of_pyproject() -> None:
     """The repository's own override, so the parsing is checked against real text."""
     overridden = check.overridden_dependencies(REPO_ROOT / "pyproject.toml")
-    assert "protobuf" in overridden
-    assert "protobuf>=5.0" in overridden["protobuf"]
+    assert str(overridden["protobuf"]) == "protobuf>=5.0"
 
 
-def test_an_overridden_distribution_is_not_drift() -> None:
+def test_an_overridden_distribution_is_held_to_the_override_not_the_lock() -> None:
     """uv asserts the version by fiat and pip has no equivalent.
 
     protobuf is overridden to >=5.0 because 4.x has a C-extension metaclass bug on
     Python 3.14; the lock then resolves 7.35.0 while opentelemetry-proto requires
     <7.0, so a pip install into the image resolves 6.33.6 and is right to.
     """
+    override = {"protobuf": Requirement("protobuf>=5.0")}
     locked = {"protobuf": "7.35.0"}
-    installed = {"protobuf": "6.33.6"}
-    assert check.drift(locked, installed) == [("protobuf", "7.35.0", "6.33.6")]
-    assert check.drift(locked, installed, {"protobuf": "overridden to protobuf>=5.0"}) == []
+
+    assert check.drift(locked, {"protobuf": "6.33.6"}) == [("protobuf", "7.35.0", "6.33.6")]
+    assert check.drift(locked, {"protobuf": "6.33.6"}, override) == []
+
+
+def test_an_override_that_the_environment_violates_is_still_drift() -> None:
+    """Exempting an overridden name outright lets through what the override excludes.
+
+    protobuf 4.x is the version the override was written against: it has a C
+    extension metaclass bug on Python 3.14.
+    """
+    override = {"protobuf": Requirement("protobuf>=5.0")}
+    assert check.drift({"protobuf": "7.35.0"}, {"protobuf": "4.25.8"}, override) == [
+        ("protobuf", ">=5.0", "4.25.8")
+    ]
+
+
+def test_an_override_for_something_not_installed_reports_nothing() -> None:
+    assert check.drift({}, {}, {"protobuf": Requirement("protobuf>=5.0")}) == []
 
 
 def test_an_override_specifier_is_parsed_down_to_the_name(tmp_path: Path) -> None:

--- a/tests/test_env_matches_lock.py
+++ b/tests/test_env_matches_lock.py
@@ -131,17 +131,12 @@ def test_an_overridden_distribution_is_not_drift() -> None:
     assert check.drift(locked, installed, {"protobuf": "overridden to protobuf>=5.0"}) == []
 
 
-def test_an_override_specifier_is_parsed_down_to_the_name() -> None:
-    written = {
-        "tool": {"uv": {"override-dependencies": ["Some_Pkg[extra]>=1.2", "other!=3"]}},
-    }
-    import tempfile
-    import tomllib as _tomllib  # noqa: F401
-
-    path = Path(tempfile.mkdtemp()) / "pyproject.toml"
+def test_an_override_specifier_is_parsed_down_to_the_name(tmp_path: Path) -> None:
+    """An override carries extras and a specifier; the comparison needs the name."""
+    path = tmp_path / "pyproject.toml"
     path.write_text('[tool.uv]\noverride-dependencies = ["Some_Pkg[extra]>=1.2", "other!=3"]\n')
+
     assert set(check.overridden_dependencies(path)) == {"some-pkg", "other"}
-    assert written  # the literal above documents the shape being parsed
 
 
 def test_a_missing_pyproject_overrides_nothing() -> None:

--- a/tests/test_env_matches_lock.py
+++ b/tests/test_env_matches_lock.py
@@ -19,6 +19,9 @@ import sys
 import tomllib
 from pathlib import Path
 
+from packaging.requirements import Requirement
+from packaging.version import Version
+
 REPO_ROOT = Path(__file__).parent.parent
 _spec = importlib.util.spec_from_file_location(
     "check_env_matches_lock", REPO_ROOT / ".github" / "scripts" / "check_env_matches_lock.py"
@@ -115,17 +118,28 @@ def test_the_repository_lock_parses_and_pins_the_ml4t_libraries() -> None:
 
 
 def test_every_declared_ml4t_floor_is_satisfied_by_the_lock() -> None:
-    """pyproject states a reason for each ml4t-* floor; the lock has to clear it."""
+    """pyproject states a reason for each ml4t-* floor; the lock has to clear it.
+
+    Compared with `packaging`, not by splitting on dots: the versions that matter
+    here are prereleases, and the filed instance was 0.1.0a4 against a 0.1.0a6
+    floor - two versions a numeric-component comparison reads as equal.
+    """
     project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
     locked = check.locked_versions(REPO_ROOT / "uv.lock")
-    floors = [
-        dep.split(">=")
-        for dep in project["project"]["dependencies"]
-        if dep.startswith("ml4t-") and ">=" in dep
+    requirements = [
+        Requirement(dep) for dep in project["project"]["dependencies"] if dep.startswith("ml4t-")
     ]
-    assert floors, "no ml4t-* floor found in pyproject dependencies"
-    for name, floor in floors:
-        got = locked[check.canonical(name)]
-        assert tuple(int(p) for p in got.split(".")[:3] if p.isdigit()) >= tuple(
-            int(p) for p in floor.split(".")[:3] if p.isdigit()
-        ), f"uv.lock resolves {name} {got}, below the declared floor {floor}"
+    assert requirements, "no ml4t-* dependency found in pyproject"
+    for requirement in requirements:
+        got = locked[check.canonical(requirement.name)]
+        assert requirement.specifier.contains(Version(got), prereleases=True), (
+            f"uv.lock resolves {requirement.name} {got}, "
+            f"which does not satisfy {requirement.specifier}"
+        )
+
+
+def test_the_floor_comparison_can_fail_on_a_prerelease() -> None:
+    """The filed instance, restated against the comparison that has to catch it."""
+    assert not Requirement("ml4t-models>=0.1.0a6").specifier.contains(
+        Version("0.1.0a4"), prereleases=True
+    )

--- a/tests/test_fixture_manifest_matches_builders.py
+++ b/tests/test_fixture_manifest_matches_builders.py
@@ -79,12 +79,18 @@ def test_every_unbuilt_fixture_records_why_it_has_none() -> None:
         assert fixture.entities, f"{fixture.name} declares nothing a test can measure"
 
 
-def test_the_nasdaq_builder_and_its_budget_name_the_same_symbols() -> None:
-    """The builder's literals and the budget it writes cannot drift apart."""
-    from tests.create_test_data import NASDAQ100_MINUTE_SYMBOLS
+def test_every_reducing_builder_declares_something_measurable() -> None:
+    """A builder with no `entities` is checked against nothing on the data side.
 
-    budget = declared_subsets()["nasdaq100_minute_bars"]
-    assert budget["symbols"] == list(NASDAQ100_MINUTE_SYMBOLS)
+    institutional_holdings_13f is the exemption and states it: it subsamples on no
+    axis, so there is no count to compare.
+    """
+    unmeasured = {
+        dataset.name
+        for dataset in DATASETS
+        if not dataset.entities and dataset.budget.get("subsample") != "none"
+    }
+    assert not unmeasured, f"{sorted(unmeasured)} declare no entity count to check"
 
 
 # --- the manifest against the declarations -----------------------------------
@@ -123,6 +129,77 @@ def test_every_file_the_manifest_lists_is_on_disk() -> None:
     assert not missing, f"{len(missing)} manifest paths are not on disk, e.g. {missing[:5]}"
 
 
+def _distinct(path: Path, column: str) -> int:
+    source = path / "**" / "*.parquet" if path.is_dir() else path
+    return pl.scan_parquet(source).select(pl.col(column).n_unique()).collect().item()
+
+
+def _declared_files(root: Path) -> dict[str, list[str]]:
+    """{dataset name: the files on disk under the paths it declares}."""
+    declared = {dataset.name: dataset.owns for dataset in DATASETS}
+    declared.update({fixture.name: fixture.covers for fixture in UNBUILT_FIXTURES})
+    found = {}
+    for name, paths in declared.items():
+        files = []
+        for declared_path in paths:
+            path = root / declared_path
+            if path.is_file():
+                files.append(path.relative_to(root).as_posix())
+            elif path.is_dir():
+                files += [f.relative_to(root).as_posix() for f in path.rglob("*") if f.is_file()]
+        found[name] = sorted(files)
+    return found
+
+
+@pytest.mark.parametrize(
+    "name", sorted({d.name for d in DATASETS} | {f.name for f in UNBUILT_FIXTURES})
+)
+def test_every_file_a_dataset_owns_is_listed_in_the_manifest(name: str) -> None:
+    """The other direction, and the one a recursive glob makes dangerous.
+
+    load_nasdaq100_bars globs '**/*.parquet' under its hive root, so a part left
+    behind by an earlier generation is unioned into the panel rather than replaced.
+    Manifest-to-disk membership cannot see that; disk-to-manifest can.
+    """
+    root = _fixture_root()
+    if not root.is_dir():
+        pytest.skip(f"no fixture root at {root}")
+    listed = set(_manifest()["files"])
+    unlisted = [rel for rel in _declared_files(root)[name] if rel not in listed]
+    assert not unlisted, (
+        f"{name} carries files the manifest does not list: {unlisted[:5]}. Either they are "
+        "left over from an earlier generation, or the manifest needs --reconcile-manifest."
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "rel", "column", "count"),
+    [
+        (dataset.name, rel, column, count)
+        for dataset in DATASETS
+        for rel, (column, count) in dataset.entities.items()
+    ],
+)
+def test_a_built_fixture_carries_the_universe_its_builder_declares(
+    name: str, rel: str, column: str, count: int
+) -> None:
+    """The builder's own constants against the data, which is where drift shows.
+
+    Measured 2026-09-03: the manifest and the nasdaq100_minute_bars builder agreed
+    with each other on 6 symbols while the fixture carried 12, so comparing the two
+    proved nothing and the builder, run as it stood, would have narrowed the fixture
+    back and left the loader's glob reading two generations at once.
+    """
+    path = _fixture_root() / rel
+    if not path.exists():
+        pytest.skip(f"{name}: {rel} is not in this checkout")
+    observed = _distinct(path, column)
+    assert observed == count, (
+        f"{name}'s builder declares {count} distinct {column} in {rel} and the fixture "
+        f"carries {observed}. Regenerate the dataset, or correct the builder."
+    )
+
+
 @pytest.mark.parametrize(
     ("name", "rel", "column", "count"),
     [
@@ -142,9 +219,9 @@ def test_an_unbuilt_fixture_carries_the_universe_it_declares(
     daily panel.
     """
     path = _fixture_root() / rel
-    if not path.is_file():
+    if not path.exists():
         pytest.skip(f"{name}: {rel} is not in this checkout")
-    observed = pl.scan_parquet(path).select(pl.col(column).n_unique()).collect().item()
+    observed = _distinct(path, column)
     assert observed == count, (
         f"{name} declares {count} distinct {column} in {rel} and the fixture carries {observed}"
     )

--- a/tests/test_fixture_manifest_matches_builders.py
+++ b/tests/test_fixture_manifest_matches_builders.py
@@ -1,0 +1,150 @@
+"""data/manifest.json describes the fixture set, and nothing was checking that.
+
+`tests/create_test_data.py` writes each dataset's declared budget into the
+manifest at build time. Nothing compared the committed manifest against the
+builder afterwards, so a builder change that was not followed by a regeneration
+left the fixture silently describing data that is not on disk.
+
+It cost a case study a day. The manifest still said `sp500_options` kept 3 "most
+liquid" underlyings while the builder declared 30 named ones from #652 - a
+different subsampling scheme entirely, never regenerated. Downstream,
+`cs-sp500_options` failed five notebooks on main; every one was the stale
+fixture, and the failure text pointed at the notebook.
+
+Two halves, and the second is why this file is not one assertion:
+
+- the data-free half compares the manifest's `subsets` against the declarations,
+  which is the check that would have fired the day #652 landed;
+- the data-backed half compares the declarations against the fixture on disk,
+  which is what the first half cannot see. Measured 2026-09-03: the manifest and
+  the `nasdaq100_minute_bars` builder agreed with each other on 6 symbols while
+  the fixture carried 12, so manifest-equals-builder alone would have passed on a
+  fixture neither of them described.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tests.create_test_data import (  # noqa: E402
+    DATASETS,
+    SUPERSEDED_SUBSETS,
+    UNBUILT_FIXTURES,
+    declared_subsets,
+)
+
+
+def _fixture_root() -> Path:
+    return Path(os.environ.get("ML4T_DATA_PATH", ""))
+
+
+def _manifest() -> dict:
+    path = _fixture_root() / "manifest.json"
+    if not path.is_file():
+        pytest.skip(f"no fixture manifest at {path}")
+    return json.loads(path.read_text())
+
+
+# --- the declarations themselves, no data needed -----------------------------
+
+
+def test_every_fixture_is_declared_exactly_once() -> None:
+    """A dataset with a builder and a declaration of having none is a contradiction."""
+    registered = {dataset.name for dataset in DATASETS}
+    unbuilt = {fixture.name for fixture in UNBUILT_FIXTURES}
+    assert not registered & unbuilt
+    assert not (registered | unbuilt) & set(SUPERSEDED_SUBSETS)
+
+
+def test_every_superseded_entry_names_the_dataset_that_owns_it() -> None:
+    registered = {dataset.name for dataset in DATASETS}
+    for name, owner in SUPERSEDED_SUBSETS.items():
+        assert owner in registered, f"{name} is superseded by {owner}, which has no builder"
+
+
+def test_every_unbuilt_fixture_records_why_it_has_none() -> None:
+    """Without the reason the entry is a shrug, which is what it replaced."""
+    for fixture in UNBUILT_FIXTURES:
+        assert fixture.reason.strip(), f"{fixture.name} declares no reason"
+        assert fixture.entities, f"{fixture.name} declares nothing a test can measure"
+
+
+def test_the_nasdaq_builder_and_its_budget_name_the_same_symbols() -> None:
+    """The builder's literals and the budget it writes cannot drift apart."""
+    from tests.create_test_data import NASDAQ100_MINUTE_SYMBOLS
+
+    budget = declared_subsets()["nasdaq100_minute_bars"]
+    assert budget["symbols"] == list(NASDAQ100_MINUTE_SYMBOLS)
+
+
+# --- the manifest against the declarations -----------------------------------
+
+
+def test_the_manifest_subsets_are_exactly_the_declared_ones() -> None:
+    """Both directions: an undeclared entry and a missing one are the same defect."""
+    assert sorted(_manifest()["subsets"]) == sorted(declared_subsets())
+
+
+@pytest.mark.parametrize("name", sorted(declared_subsets()))
+def test_the_manifest_records_what_the_declaration_says(name: str) -> None:
+    assert _manifest()["subsets"][name] == declared_subsets()[name], (
+        f"data/manifest.json's {name} entry has drifted from tests/create_test_data.py. "
+        "Regenerate the dataset, or rerun with --reconcile-manifest if only the "
+        "declaration moved."
+    )
+
+
+def test_no_superseded_entry_came_back() -> None:
+    present = set(_manifest()["subsets"]) & set(SUPERSEDED_SUBSETS)
+    assert not present, f"{sorted(present)} describe fixtures another dataset already owns"
+
+
+# --- the declarations against the fixture on disk ----------------------------
+
+
+def test_every_file_the_manifest_lists_is_on_disk() -> None:
+    """133 of 176 entries pointed at the pre-reorganization layout before this ran.
+
+    A manifest listing files that are not there is the same wrong answer as a stale
+    budget: it is the only record of what the fixture set is supposed to contain.
+    """
+    root = _fixture_root()
+    missing = [rel for rel in _manifest()["files"] if not (root / rel).is_file()]
+    assert not missing, f"{len(missing)} manifest paths are not on disk, e.g. {missing[:5]}"
+
+
+@pytest.mark.parametrize(
+    ("name", "rel", "column", "count"),
+    [
+        (fixture.name, rel, column, count)
+        for fixture in UNBUILT_FIXTURES
+        for rel, (column, count) in fixture.entities.items()
+    ],
+)
+def test_an_unbuilt_fixture_carries_the_universe_it_declares(
+    name: str, rel: str, column: str, count: int
+) -> None:
+    """These cannot drift against a builder, so they are measured against the data.
+
+    Every one of them declared a budget the fixture did not satisfy before this -
+    "15 most liquid ETFs" over 56 symbols, "8 major/cross FX pairs" over 20, "50
+    most liquid US equities" over 56, "8 most liquid CME products" over a 30-product
+    daily panel.
+    """
+    path = _fixture_root() / rel
+    if not path.is_file():
+        pytest.skip(f"{name}: {rel} is not in this checkout")
+    observed = pl.scan_parquet(path).select(pl.col(column).n_unique()).collect().item()
+    assert observed == count, (
+        f"{name} declares {count} distinct {column} in {rel} and the fixture carries {observed}"
+    )

--- a/tests/test_fixture_manifest_matches_builders.py
+++ b/tests/test_fixture_manifest_matches_builders.py
@@ -25,7 +25,6 @@ Two halves, and the second is why this file is not one assertion:
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -44,15 +43,24 @@ from tests.create_test_data import (  # noqa: E402
 )
 
 
-def _fixture_root() -> Path:
-    return Path(os.environ.get("ML4T_DATA_PATH", ""))
+@pytest.fixture
+def fixture_root(test_data_dir: Path) -> Path:
+    """The test-data checkout, or a skip.
+
+    Resolved through conftest's ``test_data_dir`` rather than by reading
+    ML4T_DATA_PATH here: that variable is rewritten during a session by the same
+    fixture, and under a full-suite run it resolves to the production root, where
+    these declarations are a category error rather than a failure. The manifest is
+    what distinguishes the two - production has none.
+    """
+    if not (test_data_dir / "manifest.json").is_file():
+        pytest.skip(f"{test_data_dir} is not a test-data checkout (no manifest.json)")
+    return test_data_dir
 
 
-def _manifest() -> dict:
-    path = _fixture_root() / "manifest.json"
-    if not path.is_file():
-        pytest.skip(f"no fixture manifest at {path}")
-    return json.loads(path.read_text())
+@pytest.fixture
+def manifest(fixture_root: Path) -> dict:
+    return json.loads((fixture_root / "manifest.json").read_text())
 
 
 # --- the declarations themselves, no data needed -----------------------------
@@ -96,36 +104,35 @@ def test_every_reducing_builder_declares_something_measurable() -> None:
 # --- the manifest against the declarations -----------------------------------
 
 
-def test_the_manifest_subsets_are_exactly_the_declared_ones() -> None:
+def test_the_manifest_subsets_are_exactly_the_declared_ones(manifest: dict) -> None:
     """Both directions: an undeclared entry and a missing one are the same defect."""
-    assert sorted(_manifest()["subsets"]) == sorted(declared_subsets())
+    assert sorted(manifest["subsets"]) == sorted(declared_subsets())
 
 
 @pytest.mark.parametrize("name", sorted(declared_subsets()))
-def test_the_manifest_records_what_the_declaration_says(name: str) -> None:
-    assert _manifest()["subsets"][name] == declared_subsets()[name], (
+def test_the_manifest_records_what_the_declaration_says(name: str, manifest: dict) -> None:
+    assert manifest["subsets"][name] == declared_subsets()[name], (
         f"data/manifest.json's {name} entry has drifted from tests/create_test_data.py. "
         "Regenerate the dataset, or rerun with --reconcile-manifest if only the "
         "declaration moved."
     )
 
 
-def test_no_superseded_entry_came_back() -> None:
-    present = set(_manifest()["subsets"]) & set(SUPERSEDED_SUBSETS)
+def test_no_superseded_entry_came_back(manifest: dict) -> None:
+    present = set(manifest["subsets"]) & set(SUPERSEDED_SUBSETS)
     assert not present, f"{sorted(present)} describe fixtures another dataset already owns"
 
 
 # --- the declarations against the fixture on disk ----------------------------
 
 
-def test_every_file_the_manifest_lists_is_on_disk() -> None:
+def test_every_file_the_manifest_lists_is_on_disk(fixture_root: Path, manifest: dict) -> None:
     """133 of 176 entries pointed at the pre-reorganization layout before this ran.
 
     A manifest listing files that are not there is the same wrong answer as a stale
     budget: it is the only record of what the fixture set is supposed to contain.
     """
-    root = _fixture_root()
-    missing = [rel for rel in _manifest()["files"] if not (root / rel).is_file()]
+    missing = [rel for rel in manifest["files"] if not (fixture_root / rel).is_file()]
     assert not missing, f"{len(missing)} manifest paths are not on disk, e.g. {missing[:5]}"
 
 
@@ -154,18 +161,17 @@ def _declared_files(root: Path) -> dict[str, list[str]]:
 @pytest.mark.parametrize(
     "name", sorted({d.name for d in DATASETS} | {f.name for f in UNBUILT_FIXTURES})
 )
-def test_every_file_a_dataset_owns_is_listed_in_the_manifest(name: str) -> None:
+def test_every_file_a_dataset_owns_is_listed_in_the_manifest(
+    name: str, fixture_root: Path, manifest: dict
+) -> None:
     """The other direction, and the one a recursive glob makes dangerous.
 
     load_nasdaq100_bars globs '**/*.parquet' under its hive root, so a part left
     behind by an earlier generation is unioned into the panel rather than replaced.
     Manifest-to-disk membership cannot see that; disk-to-manifest can.
     """
-    root = _fixture_root()
-    if not root.is_dir():
-        pytest.skip(f"no fixture root at {root}")
-    listed = set(_manifest()["files"])
-    unlisted = [rel for rel in _declared_files(root)[name] if rel not in listed]
+    listed = set(manifest["files"])
+    unlisted = [rel for rel in _declared_files(fixture_root)[name] if rel not in listed]
     assert not unlisted, (
         f"{name} carries files the manifest does not list: {unlisted[:5]}. Either they are "
         "left over from an earlier generation, or the manifest needs --reconcile-manifest."
@@ -181,7 +187,7 @@ def test_every_file_a_dataset_owns_is_listed_in_the_manifest(name: str) -> None:
     ],
 )
 def test_a_built_fixture_carries_the_universe_its_builder_declares(
-    name: str, rel: str, column: str, count: int
+    name: str, rel: str, column: str, count: int, fixture_root: Path
 ) -> None:
     """The builder's own constants against the data, which is where drift shows.
 
@@ -190,7 +196,7 @@ def test_a_built_fixture_carries_the_universe_its_builder_declares(
     proved nothing and the builder, run as it stood, would have narrowed the fixture
     back and left the loader's glob reading two generations at once.
     """
-    path = _fixture_root() / rel
+    path = fixture_root / rel
     if not path.exists():
         pytest.skip(f"{name}: {rel} is not in this checkout")
     observed = _distinct(path, column)
@@ -209,7 +215,7 @@ def test_a_built_fixture_carries_the_universe_its_builder_declares(
     ],
 )
 def test_an_unbuilt_fixture_carries_the_universe_it_declares(
-    name: str, rel: str, column: str, count: int
+    name: str, rel: str, column: str, count: int, fixture_root: Path
 ) -> None:
     """These cannot drift against a builder, so they are measured against the data.
 
@@ -218,7 +224,7 @@ def test_an_unbuilt_fixture_carries_the_universe_it_declares(
     most liquid US equities" over 56, "8 most liquid CME products" over a 30-product
     daily panel.
     """
-    path = _fixture_root() / rel
+    path = fixture_root / rel
     if not path.exists():
         pytest.skip(f"{name}: {rel} is not in this checkout")
     observed = _distinct(path, column)

--- a/tests/test_fork_pull_request_gating.py
+++ b/tests/test_fork_pull_request_gating.py
@@ -1,0 +1,130 @@
+"""Every job that checks out the private test data survives a fork pull request.
+
+`secrets.TEST_DATA_DEPLOY_KEY` is not exposed to a `pull_request` from a fork, so
+`actions/checkout` falls back to the default token, which cannot see
+`ml4t/third-edition-test-data`. The checkout fails and the job fails with it, at a
+step that has nothing to do with the contribution. Measured on #595, a two-line
+packaging fix from an outside contributor: 26 red checks, none of them theirs.
+
+The fix is to decide once whether the run can reach the data and gate the
+data-dependent steps on that. 26 jobs share one workflow file, so what keeps this
+from coming back is not the six edits but this test: a data-dependent job added
+without the gate fails here.
+
+The gate is a step and not the job's `if:` deliberately. A job-level `if:` that
+evaluates false creates no check run at all, and a required context with no check
+run blocks the pull request forever - which is what #613 was fixed for.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).parent.parent / ".github" / "workflows"
+TEST_DATA_REPO = "ml4t/third-edition-test-data"
+REACH_OUTPUT = "steps.reach.outputs.have_key"
+
+
+def _workflow_files() -> list[Path]:
+    return sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
+
+
+def _triggers(workflow: dict) -> dict:
+    """The workflow's `on:` block. YAML 1.1 reads a bare ``on`` as the boolean True."""
+    triggers = workflow.get("on", workflow.get(True)) or {}
+    return triggers if isinstance(triggers, dict) else dict.fromkeys(triggers)
+
+
+def _jobs_that_check_out_test_data() -> list[tuple[str, str, dict]]:
+    """(workflow name, job name, job) for every job checking out the test data.
+
+    Only workflows a pull request can trigger. A workflow_dispatch- or
+    schedule-only workflow always runs from this repository, so the deploy key is
+    always there and a missing one is a real failure to report rather than a state
+    to skip past.
+    """
+    found = []
+    for path in _workflow_files():
+        workflow = yaml.safe_load(path.read_text()) or {}
+        if "pull_request" not in _triggers(workflow):
+            continue
+        for job_name, job in (workflow.get("jobs") or {}).items():
+            steps = job.get("steps") or []
+            if any(
+                str((step.get("with") or {}).get("repository", "")) == TEST_DATA_REPO
+                for step in steps
+            ):
+                found.append((path.name, job_name, job))
+    return found
+
+
+def test_at_least_one_job_checks_out_the_test_data() -> None:
+    """Guards the guard: a rename that stops matching would empty every test below."""
+    assert _jobs_that_check_out_test_data()
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job_name", "job"),
+    _jobs_that_check_out_test_data(),
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_the_reach_decision_is_the_first_step(workflow: str, job_name: str, job: dict) -> None:
+    """It has to precede the container's own setup, not just the checkout."""
+    first = (job.get("steps") or [])[0]
+    assert first.get("id") == "reach", (
+        f"{workflow}::{job_name} checks out {TEST_DATA_REPO} but its first step is "
+        f"{first.get('name') or first.get('uses')!r}, not the reach decision"
+    )
+    assert "TEST_DATA_DEPLOY_KEY" in str(first.get("run", "")), (
+        f"{workflow}::{job_name}'s reach step does not read TEST_DATA_DEPLOY_KEY"
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job_name", "job"),
+    _jobs_that_check_out_test_data(),
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_every_step_after_the_reach_decision_is_gated_on_it(
+    workflow: str, job_name: str, job: dict
+) -> None:
+    ungated = [
+        step.get("name") or step.get("uses")
+        for step in (job.get("steps") or [])[1:]
+        if REACH_OUTPUT not in str(step.get("if", ""))
+    ]
+    assert not ungated, (
+        f"{workflow}::{job_name} runs these steps without the test data being "
+        f"reachable: {ungated}. Gate them on {REACH_OUTPUT}."
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job_name", "job"),
+    _jobs_that_check_out_test_data(),
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_the_job_says_out_loud_that_it_asserted_nothing(
+    workflow: str, job_name: str, job: dict
+) -> None:
+    """A green job that ran nothing has to report that, or the merge is misinformed."""
+    reach = (job.get("steps") or [])[0]
+    assert "::notice::" in str(reach.get("run", "")), (
+        f"{workflow}::{job_name} skips its work on a fork pull request without saying so"
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job_name", "job"),
+    _jobs_that_check_out_test_data(),
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_the_gate_is_not_the_jobs_own_if(workflow: str, job_name: str, job: dict) -> None:
+    assert REACH_OUTPUT not in str(job.get("if", "")), (
+        f"{workflow}::{job_name} gates the job rather than its steps; a job-level `if:` "
+        "that evaluates false creates no check run, which a required context can never "
+        "satisfy (#613)"
+    )

--- a/tests/test_generate_intermediates.py
+++ b/tests/test_generate_intermediates.py
@@ -1,0 +1,98 @@
+"""What tests/generate_intermediates.py treats as a completed unit of work.
+
+Two ways this script used to report success it had not earned, both of which left
+a stale fixture looking freshly built:
+
+- a pipeline stage (01-05) marked ``skip`` in ``tests/overrides.yaml`` cascaded to
+  every later stage of that case study, and skips were not counted as failures, so
+  the run exited 0 having generated nothing for those stages;
+- a ``--case-studies`` value naming nothing never entered ``results``, so the
+  failure count stayed zero and a typo produced a green run.
+
+The generator and the timed CI job read the same ``skip`` key and want different
+answers from it: the job is protecting a time budget, generation is producing the
+artifact that job consumes. ``--ignore-skips`` is that second answer.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tests.generate_intermediates import (  # noqa: E402
+    CASE_STUDIES,
+    FAILED,
+    INCOMPLETE,
+    NOT_RUN,
+    OK,
+    SKIPPED,
+    exit_code,
+    resolve_case_studies,
+    seed_configs,
+)
+
+# --- requested names ---------------------------------------------------------
+
+
+def test_resolve_case_studies_returns_the_request_when_every_name_is_known() -> None:
+    assert resolve_case_studies(["etfs", "cme_futures"]) == ["etfs", "cme_futures"]
+
+
+def test_resolve_case_studies_rejects_a_name_that_matches_nothing() -> None:
+    with pytest.raises(ValueError, match="cme_future"):
+        resolve_case_studies(["etfs", "cme_future"])
+
+
+def test_resolve_case_studies_names_the_supported_list_in_the_error() -> None:
+    with pytest.raises(ValueError, match="us_equities_panel"):
+        resolve_case_studies(["typo"])
+
+
+# --- exit status -------------------------------------------------------------
+
+
+def test_a_run_where_everything_ran_exits_zero() -> None:
+    assert exit_code({"etfs::01_x": OK, "etfs::02_y": OK}) == 0
+
+
+def test_a_stage_skipped_above_the_pipeline_does_not_fail_the_run() -> None:
+    """Stage 17 is a holdout notebook: skipping it leaves nothing else unbuilt."""
+    assert exit_code({"etfs::01_x": OK, "etfs::17_holdout": SKIPPED}) == 0
+
+
+def test_a_failed_stage_exits_nonzero() -> None:
+    assert exit_code({"etfs::01_x": FAILED, "etfs::02_y": NOT_RUN}) == 1
+
+
+def test_an_incomplete_unit_exits_nonzero() -> None:
+    """The regression this file exists for: a cascading skip is not a success."""
+    assert exit_code({"cme::04_model_based_features": INCOMPLETE, "cme::05_eval": NOT_RUN}) == 1
+
+
+def test_stages_not_run_behind_an_incomplete_one_do_not_by_themselves_fail() -> None:
+    assert exit_code({"etfs::05_eval": NOT_RUN}) == 0
+
+
+# --- config seeding scope ----------------------------------------------------
+
+
+def test_seed_configs_writes_only_the_case_studies_it_was_given(tmp_path: Path) -> None:
+    """A scoped regeneration must not rewrite eight other case studies' configs."""
+    seed_configs(tmp_path, ["cme_futures"])
+
+    seeded = {p.name for p in tmp_path.iterdir() if p.is_dir()}
+    assert "cme_futures" in seeded
+    assert seeded & set(CASE_STUDIES) == {"cme_futures"}
+
+
+def test_seed_configs_defaults_to_every_case_study(tmp_path: Path) -> None:
+    seed_configs(tmp_path)
+
+    seeded = {p.name for p in tmp_path.iterdir() if p.is_dir()}
+    assert set(CASE_STUDIES) <= seeded

--- a/tests/test_reduced_universe_is_shared.py
+++ b/tests/test_reduced_universe_is_shared.py
@@ -1,0 +1,110 @@
+"""Every stage of a reduced case-study run covers the same symbols.
+
+`tests/overrides.yaml` injects `MAX_SYMBOLS: 5` into `nasdaq100_microstructure`
+stages 01-05 so the pipeline runs small under CI. The stages have to agree on
+which five, or the labels and financial features cover one set while the temporal
+features cover another, and a symbol only one side chose joins to null features -
+a wrong answer that runs clean rather than a failure.
+
+Measured on this fixture before the rules were unified: `02_labels` and
+`03_financial_features` reduced through the loader to a seeded random sample,
+{AAPL, AMD, CMCSA, CSCO, SIRI}, while `04_model_based_features` took the five
+most-observed, {AAPL, AMD, AMZN, FB, TSLA}. Three of five had no temporal
+features at all.
+
+The rules are one rule now (`utils.data_quality.top_entities`), which
+`tests/test_data_quality.py` pins without data. What needs the real fixture is the
+second half: `04` and `05` still select the most-observed symbols with their own
+inline expression and no tie break, so they agree with the shared rule only while
+no tie straddles the cut. On this fixture five symbols sit at exactly 136,140 bars
+and the sixth at 136,131, so the cut at five is clear - and this test is what says
+so out loud, and fails on the day a regenerated fixture moves it.
+
+Needs the test-data checkout, so it runs in test-unit-data.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import polars as pl
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+CASE_STUDY = "nasdaq100_microstructure"
+REDUCED_STAGES = ("02_labels", "03_financial_features", "04_model_based_features", "05_evaluation")
+
+
+def _injected_max_symbols(stage: str) -> int | None:
+    overrides = yaml.safe_load((REPO_ROOT / "tests" / "overrides.yaml").read_text()) or {}
+    entry = overrides.get(f"case_studies/{CASE_STUDY}/{stage}") or {}
+    value = (entry.get("parameters") or {}).get("MAX_SYMBOLS")
+    return int(value) if value else None
+
+
+@pytest.fixture(scope="module")
+def bar_counts() -> pl.DataFrame:
+    """Rows per symbol on the panel stages 02, 03 and 04 all read."""
+    data_path = Path(os.environ.get("ML4T_DATA_PATH", ""))
+    hive = data_path / "equities" / "market" / "nasdaq100" / "minute_bars"
+    if not hive.is_dir() or not list(hive.glob("year=*")):
+        pytest.skip(f"no nasdaq100 minute bars under {hive}")
+
+    setup = yaml.safe_load(
+        (REPO_ROOT / "case_studies" / CASE_STUDY / "config" / "setup.yaml").read_text()
+    )
+    universe = sorted(setup["universe"]["symbols"])
+    return (
+        pl.scan_parquet(hive / "**/*.parquet", hive_partitioning=True)
+        .filter(pl.col("symbol").is_in(universe))
+        .filter(pl.col("date").is_between(pl.date(2020, 1, 1), pl.date(2021, 12, 31)))
+        .group_by("symbol")
+        .len()
+        .collect()
+    )
+
+
+def test_the_overrides_still_reduce_these_stages() -> None:
+    """Guards the tests below: with no injection they would assert nothing."""
+    injected = {stage: _injected_max_symbols(stage) for stage in REDUCED_STAGES}
+    assert all(injected.values()), f"no MAX_SYMBOLS injected for {injected}"
+
+
+def test_every_reduced_stage_is_given_the_same_size() -> None:
+    """Equal counts are not sufficient, but unequal ones are already a split."""
+    sizes = {_injected_max_symbols(stage) for stage in REDUCED_STAGES}
+    assert len(sizes) == 1, f"stages 02-05 are reduced to different sizes: {sizes}"
+
+
+def test_the_loader_and_an_untied_top_by_count_select_the_same_symbols(
+    bar_counts: pl.DataFrame,
+) -> None:
+    """02 and 03 reduce through the loader; 04 has its own untied expression."""
+    max_symbols = _injected_max_symbols("04_model_based_features")
+
+    shared = sorted(
+        bar_counts.sort(["len", "symbol"], descending=[True, False])
+        .head(max_symbols)["symbol"]
+        .to_list()
+    )
+    untied = sorted(bar_counts.sort("len", descending=True).head(max_symbols)["symbol"].to_list())
+    assert shared == untied, (
+        "the shared reduction and the stage-04 expression choose different symbols; "
+        "stage 04 has to break its tie on the symbol name"
+    )
+
+
+def test_no_tie_straddles_the_cut(bar_counts: pl.DataFrame) -> None:
+    """What makes the untied expression safe, stated as the property it needs."""
+    max_symbols = _injected_max_symbols("04_model_based_features")
+    ordered = bar_counts.sort(["len", "symbol"], descending=[True, False])
+    assert ordered.height > max_symbols, "the fixture carries no more symbols than the cut"
+
+    last_kept = ordered["len"][max_symbols - 1]
+    first_dropped = ordered["len"][max_symbols]
+    assert last_kept > first_dropped, (
+        f"symbols tie across the cut at {max_symbols} ({last_kept} bars on both sides), so an "
+        "expression that does not break ties by name can pick either one"
+    )

--- a/tests/test_reduced_universe_is_shared.py
+++ b/tests/test_reduced_universe_is_shared.py
@@ -25,7 +25,6 @@ Needs the test-data checkout, so it runs in test-unit-data.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import polars as pl
@@ -45,10 +44,18 @@ def _injected_max_symbols(stage: str) -> int | None:
 
 
 @pytest.fixture(scope="module")
-def bar_counts() -> pl.DataFrame:
-    """Rows per symbol on the panel stages 02, 03 and 04 all read."""
-    data_path = Path(os.environ.get("ML4T_DATA_PATH", ""))
-    hive = data_path / "equities" / "market" / "nasdaq100" / "minute_bars"
+def bar_counts(test_data_dir: Path) -> pl.DataFrame:
+    """Rows per symbol on the panel stages 02, 03 and 04 all read.
+
+    Resolved through conftest's ``test_data_dir`` rather than by reading
+    ML4T_DATA_PATH here: that variable is rewritten during a session by the same
+    fixture, and this is a statement about the CI fixture. Against the production
+    panel - 123 symbols where the fixture has 12 - the cut lands somewhere else
+    entirely and the question is not the one being asked.
+    """
+    if not (test_data_dir / "manifest.json").is_file():
+        pytest.skip(f"{test_data_dir} is not a test-data checkout (no manifest.json)")
+    hive = test_data_dir / "equities" / "market" / "nasdaq100" / "minute_bars"
     if not hive.is_dir() or not list(hive.glob("year=*")):
         pytest.skip(f"no nasdaq100 minute bars under {hive}")
 

--- a/tests/test_sample_registry_for_tests.py
+++ b/tests/test_sample_registry_for_tests.py
@@ -6,12 +6,14 @@ its source, and a production registry.db is 43-180 MB and gitignored. A wrong
 from, which is the one failure in this path that cannot be undone by re-running it.
 """
 
+import sqlite3
 from pathlib import Path
 
 from tests.sample_registry_for_tests import (
     CASE_STUDY_IDS,
     CODE_CS_DIR,
     DEFAULT_INTERMEDIATES_DIR,
+    _populate_sample_db,
     rejected_output_root,
 )
 
@@ -56,3 +58,112 @@ def test_every_case_study_is_covered_by_the_check(tmp_path: Path) -> None:
     """The guard iterates CASE_STUDY_IDS; an empty list would make it vacuous."""
     assert len(CASE_STUDY_IDS) == 9
     assert rejected_output_root(tmp_path) is None
+
+
+# --- The tables a sampled registry gets rows for ------------------------------
+#
+# Step 1 copies every table's CREATE statement, so a table nothing copies rows for
+# still exists in the fixture - empty. `causal_runs` and `backtest_paired_metrics`
+# were in exactly that state across all nine shipped registries: a notebook reading
+# either found no rows and could not distinguish "not computed" from "not sampled",
+# and the fixture had quietly replaced a populated table with an empty one.
+
+
+def _source_registry(path: Path) -> sqlite3.Connection:
+    """A registry with two backtests, one paired comparison and one causal run."""
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE training_runs (training_hash TEXT PRIMARY KEY, label TEXT, family TEXT);
+        CREATE TABLE prediction_sets (
+            prediction_hash TEXT PRIMARY KEY, training_hash TEXT, split TEXT
+        );
+        CREATE TABLE backtest_runs (
+            backtest_hash TEXT PRIMARY KEY, prediction_hash TEXT, stage TEXT
+        );
+        CREATE TABLE backtest_metrics (backtest_hash TEXT PRIMARY KEY, sharpe REAL);
+        CREATE TABLE backtest_fold_metrics (backtest_hash TEXT, fold INTEGER);
+        CREATE TABLE backtest_paired_metrics (
+            challenger_hash TEXT NOT NULL, benchmark_hash TEXT NOT NULL,
+            sharpe_diff REAL, computed_at TEXT NOT NULL,
+            PRIMARY KEY (challenger_hash, benchmark_hash)
+        );
+        CREATE TABLE causal_runs (
+            causal_hash TEXT PRIMARY KEY, label TEXT NOT NULL,
+            dml_effect REAL, created_at TEXT NOT NULL
+        );
+        INSERT INTO training_runs VALUES ('t1', 'fwd_ret_5d', 'linear');
+        INSERT INTO prediction_sets VALUES ('p1', 't1', 'validation');
+        INSERT INTO backtest_runs VALUES ('bt_challenger', 'p1', 'signal');
+        INSERT INTO backtest_runs VALUES ('bt_benchmark', 'p1', 'signal');
+        INSERT INTO backtest_metrics VALUES ('bt_challenger', 1.4);
+        INSERT INTO backtest_metrics VALUES ('bt_benchmark', 0.9);
+        INSERT INTO backtest_paired_metrics
+            VALUES ('bt_challenger', 'bt_benchmark', 0.5, '2026-01-01');
+        INSERT INTO backtest_paired_metrics
+            VALUES ('bt_challenger', 'bt_absent', 0.7, '2026-01-01');
+        INSERT INTO causal_runs VALUES ('c1', 'fwd_ret_5d', 0.003, '2026-01-01');
+        """
+    )
+    connection.commit()
+    return connection
+
+
+def _sampled(tmp_path: Path) -> sqlite3.Connection:
+    src_path, dst_path = tmp_path / "src.db", tmp_path / "dst.db"
+    src = _source_registry(src_path)
+    dst = sqlite3.connect(dst_path)
+    _populate_sample_db(src, dst, dst_path)
+    src.close()
+    return dst
+
+
+def test_causal_runs_reaches_the_sampled_registry(tmp_path: Path) -> None:
+    """Keyed by causal_hash and filtered by nothing, so full is the only answer."""
+    dst = _sampled(tmp_path)
+    assert dst.execute("SELECT causal_hash FROM causal_runs").fetchall() == [("c1",)]
+
+
+def test_a_paired_comparison_reaches_it_when_both_sides_do(tmp_path: Path) -> None:
+    dst = _sampled(tmp_path)
+    pairs = dst.execute(
+        "SELECT challenger_hash, benchmark_hash FROM backtest_paired_metrics"
+    ).fetchall()
+    assert ("bt_challenger", "bt_benchmark") in pairs
+
+
+def test_a_pair_whose_benchmark_was_not_sampled_is_dropped(tmp_path: Path) -> None:
+    """benchmark_hash carries no foreign key, so nothing else would drop it, and a
+    comparison against a backtest the fixture does not have is not readable."""
+    dst = _sampled(tmp_path)
+    benchmarks = {
+        row[0] for row in dst.execute("SELECT benchmark_hash FROM backtest_paired_metrics")
+    }
+    assert "bt_absent" not in benchmarks
+
+
+def test_a_registry_without_these_tables_still_samples(tmp_path: Path) -> None:
+    """A stub or an older canonical registry has neither, and that is not an error."""
+    src_path, dst_path = tmp_path / "src.db", tmp_path / "dst.db"
+    src = sqlite3.connect(src_path)
+    src.executescript(
+        """
+        CREATE TABLE training_runs (training_hash TEXT PRIMARY KEY, label TEXT, family TEXT);
+        CREATE TABLE prediction_sets (
+            prediction_hash TEXT PRIMARY KEY, training_hash TEXT, split TEXT
+        );
+        CREATE TABLE backtest_runs (
+            backtest_hash TEXT PRIMARY KEY, prediction_hash TEXT, stage TEXT
+        );
+        CREATE TABLE backtest_metrics (backtest_hash TEXT PRIMARY KEY, sharpe REAL);
+        CREATE TABLE backtest_fold_metrics (backtest_hash TEXT, fold INTEGER);
+        INSERT INTO training_runs VALUES ('t1', 'fwd_ret_5d', 'linear');
+        """
+    )
+    src.commit()
+    dst = sqlite3.connect(dst_path)
+
+    stats = _populate_sample_db(src, dst, dst_path)
+
+    assert stats["causal_runs"] == 0
+    assert stats["status"] == "OK"

--- a/tests/test_seed_prediction_fixtures.py
+++ b/tests/test_seed_prediction_fixtures.py
@@ -31,17 +31,18 @@ def test_crypto_prediction_hashes_share_keys_and_targets(tmp_path):
             [("hash_a", "train_a", "validation"), ("hash_b", "train_a", "validation")],
         )
 
-    stale_dir = run_log / "predictions" / "hash_a"
-    stale_dir.mkdir(parents=True)
-    pl.DataFrame(
+    reference_dir = run_log / "predictions" / "hash_a"
+    reference_dir.mkdir(parents=True)
+    reference = pl.DataFrame(
         {
-            "symbol": ["STALE"],
-            "timestamp": [date(2000, 1, 1)],
-            "fold": [0],
-            "prediction": [0.0],
-            "actual": [1.0],
+            "symbol": ["ETHUSDT", "ETHUSDT", "BTCUSDT", "BTCUSDT"],
+            "timestamp": [date(2020, 1, 1), date(2020, 1, 2)] * 2,
+            "fold": [0, 0, 0, 0],
+            "prediction": [0.0, 0.1, 0.2, 0.3],
+            "actual": [1.0, 1.1, 1.2, 1.3],
         }
-    ).write_parquet(stale_dir / "predictions.parquet")
+    )
+    reference.write_parquet(reference_dir / "predictions.parquet")
 
     _backfill_all_prediction_parquets(cs_dir, "crypto_perps_funding")
 
@@ -55,7 +56,9 @@ def test_crypto_prediction_hashes_share_keys_and_targets(tmp_path):
         .equals(frames[1].select("timestamp", "symbol", "actual"))
     )
     assert not frames[0]["prediction"].equals(frames[1]["prediction"])
-    assert frames[0].height > 1
+    # The group is seeded onto the panel the fixture already carries, rather than the
+    # artifact being replaced by a fabricated one: hash_a comes back untouched.
+    assert frames[0].equals(reference)
 
 
 def test_a_seeded_hash_joins_the_copied_artifact_it_shares_a_label_with(tmp_path):
@@ -193,11 +196,12 @@ def test_an_underivable_window_still_respects_the_split_boundary(tmp_path):
 # --- Cohort-leader handling -------------------------------------------------
 #
 # A label's cohort leader is the frozen carrier a strategy-analysis/portfolio/cost/
-# risk notebook resolves by hash and checks against real historical values, so it is
-# the one prediction the synthetic rewrite must not touch. All three tests use
-# crypto_perps_funding because it is the only case study with rewrite_existing set;
-# everywhere else an existing artifact is already left alone and the exemption is
-# unobservable.
+# risk notebook resolves by hash and checks against real historical values. It is one
+# case of the general rule these tests pin: an artifact the fixture already carries is
+# the one its registry row describes, so the seeder never replaces it. These use
+# crypto_perps_funding because it was the one case study exempted from that rule, by a
+# line with no recorded rationale; a leader with no artifact at all is the remaining
+# case, and it is reported rather than silently synthesized.
 
 LEADER_PRED = "hash_leader"
 LEADER_BT = "bt_leader_signal"
@@ -264,25 +268,44 @@ def _write_carrier(run_log, prediction_hash, marker):
     return frame
 
 
-def test_the_real_carrier_artifact_survives_the_crypto_rewrite(tmp_path):
-    """crypto normalizes every prediction onto one key/target panel. The carrier is
-    exempt: a notebook pins it by hash and correlates its target against real raw
-    prices, which synthetic noise cannot pass."""
+def test_no_artifact_the_fixture_already_carries_is_replaced(tmp_path):
+    """The registry row describes the artifact on disk, and it has to keep doing so.
+
+    Replacing one leaves the row reporting the coverage and IC of a prediction set that
+    is no longer there, which is a contradiction the fixture itself creates: a notebook
+    obeying C9 - validate that the artifact you read is the one the registry describes -
+    then cannot pass under CI, and `16_strategy_simulation/08_signal_method_comparison`
+    had to weaken its check because of it.
+
+    Both artifacts are checked, the cohort leader and the ordinary one, because
+    crypto_perps_funding used to exempt itself from this for everything but the leader.
+    """
     cs_dir = tmp_path / "crypto_perps_funding"
     run_log = cs_dir / "run_log"
     _crypto_registry(run_log, _COHORT_DDL)
     leader_before = _write_carrier(run_log, LEADER_PRED, "REALCARRIER")
-    other_before = _write_carrier(run_log, "hash_other", "STALE")
+    other_before = _write_carrier(run_log, "hash_other", "ORDINARY")
 
     _backfill_all_prediction_parquets(cs_dir, "crypto_perps_funding")
 
     leader_after = pl.read_parquet(run_log / "predictions" / LEADER_PRED / "predictions.parquet")
     other_after = pl.read_parquet(run_log / "predictions" / "hash_other" / "predictions.parquet")
     assert leader_after.equals(leader_before), "the cohort leader's real artifact was overwritten"
-    assert not other_after.equals(other_before), (
-        "hash_other was left alone, so the rewrite this exemption carves out of did not run "
-        "and the assertion above passes for the wrong reason"
-    )
+    assert other_after.equals(other_before), "an ordinary shipped artifact was overwritten"
+
+
+def test_a_hash_with_no_artifact_is_still_seeded(tmp_path):
+    """The control on the test above: leaving artifacts alone is not doing nothing."""
+    cs_dir = tmp_path / "crypto_perps_funding"
+    run_log = cs_dir / "run_log"
+    _crypto_registry(run_log, _COHORT_DDL)
+    _write_carrier(run_log, LEADER_PRED, "REALCARRIER")
+
+    _backfill_all_prediction_parquets(cs_dir, "crypto_perps_funding")
+
+    seeded = run_log / "predictions" / "hash_other" / "predictions.parquet"
+    assert seeded.is_file(), "the hash with no artifact of its own was not seeded"
+    assert pl.read_parquet(seeded).height
 
 
 def test_a_leader_with_no_artifact_is_named_not_silently_synthesized(tmp_path):

--- a/tests/test_seeded_prediction_eval_target.py
+++ b/tests/test_seeded_prediction_eval_target.py
@@ -25,9 +25,9 @@ import pytest
 
 from tests.fixtures import seed_results
 
-# Two case studies, because the seeder has two paths. It rewrites every artifact of
-# crypto_perps_funding, so every set there is built on the fabricated grid; elsewhere
-# an artifact already on disk survives and supplies the panel the rest are seeded onto.
+# Two case studies, because the seeder has two paths. A group with no artifact of its
+# own is built on the fabricated grid, which is what the crypto fixtures below have;
+# a group with one supplies the panel the rest of it is seeded onto.
 REWRITTEN_CS = "crypto_perps_funding"
 REWRITTEN_CLS_LABEL = "fwd_dir_8h"
 CASE_STUDY = "sp500_equity_option_analytics"

--- a/utils/data_quality.py
+++ b/utils/data_quality.py
@@ -15,7 +15,6 @@ Usage:
 
 from __future__ import annotations
 
-import random
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -25,31 +24,65 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
+def top_entities(
+    data: pl.DataFrame | pl.LazyFrame,
+    max_entities: int,
+    entity_col: str = "symbol",
+) -> list:
+    """The ``max_entities`` entities with the most rows, ties broken by name.
+
+    **This is the one rule for reducing a panel's entity axis**, and every reduction
+    in the test and fixture path has to reach it, whether from a loader or from a
+    modelling helper. Two callers reducing the same panel to the same size have to
+    get the same universe or they are not measuring the same study: a symbol only
+    one side chose carries null features on the other, which runs clean and answers
+    wrongly.
+
+    Measured on nasdaq100_microstructure's CI fixture before the rules were unified:
+    ``02_labels`` and ``03_financial_features`` reduced through the loader to
+    {AAPL, AMD, CMCSA, CSCO, SIRI} - a seeded random sample - while
+    ``04_model_based_features`` took the five most-observed symbols,
+    {AAPL, AMD, AMZN, FB, TSLA}. Three of the five symbols the labels and financial
+    features covered therefore had no temporal features at all.
+
+    Row counts tie readily on these panels - five of the twelve fixture symbols sit
+    at exactly 136,140 bars - and a tie broken by frame order is not stable across
+    runs or across callers, so the entity name is the secondary key.
+
+    Production runs pass 0 and never reach this.
+    """
+    counts = (
+        data.lazy()
+        .group_by(entity_col)
+        .len()
+        .sort(["len", entity_col], descending=[True, False])
+        .head(max_entities)
+        .collect()
+    )
+    return counts[entity_col].to_list()
+
+
 def apply_max_symbols(
     data: pl.DataFrame | pl.LazyFrame,
     max_symbols: int,
     symbol_col: str = "symbol",
-    seed: int = 42,
 ) -> pl.DataFrame | pl.LazyFrame:
-    """Limit data to a random subset of symbols for fast-path testing.
+    """Limit data to the ``max_symbols`` most-observed symbols, for fast-path testing.
 
-    Selects a reproducible random sample of symbols using a fixed seed.
-    Returns data unchanged if max_symbols <= 0 or >= total symbols.
+    The loader-side entry point to :func:`top_entities`; ``utils.modeling`` reaches
+    the same rule from the modelling side. It used to be a seeded random sample of
+    the sorted symbol list, which disagreed with every consumer that reduced by
+    observation count and moved whenever the underlying symbol set changed.
+
+    Returns data unchanged if max_symbols <= 0.
     """
     if max_symbols <= 0:
         return data
 
-    if isinstance(data, pl.LazyFrame):
-        all_symbols = data.select(pl.col(symbol_col).unique()).collect()[symbol_col].to_list()
-    else:
-        all_symbols = data[symbol_col].unique().to_list()
-
-    if max_symbols >= len(all_symbols):
-        return data
-
-    rng = random.Random(seed)
-    selected = rng.sample(sorted(all_symbols), max_symbols)
-    return data.filter(pl.col(symbol_col).is_in(selected))
+    selected = top_entities(data, max_symbols, symbol_col)
+    # implode: is_in against a bare Series of the same dtype is deprecated in polars
+    # as ambiguous, and membership in the value set is what is meant.
+    return data.filter(pl.col(symbol_col).is_in(pl.Series(symbol_col, selected).implode()))
 
 
 def describe_coverage(

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -1064,25 +1064,22 @@ def reduce_to_top_entities(
 ) -> pl.DataFrame:
     """Keep the ``max_symbols`` entities with the most rows, ties broken by name.
 
-    Row counts tie readily on these panels, and a tie broken by frame order is
-    not stable across runs or across callers. The entity name is the secondary
-    key so that every caller reducing the same dataset to the same size gets the
-    same universe. Without it a reduced stage-04 run and the reduced model
-    notebooks downstream of it can choose different equal-history symbols, and
-    the ones only a single side chose carry null temporal features - a wrong
-    answer that runs clean rather than a failure.
+    The modelling-side entry point to :func:`utils.data_quality.top_entities`, which
+    is the one rule; the loaders reach the same one through ``apply_max_symbols``.
+    Two callers reducing the same dataset to the same size have to get the same
+    universe, or the ones only a single side chose carry null temporal features - a
+    wrong answer that runs clean rather than a failure.
 
     Production runs set ``max_symbols=0`` and never reach this.
     """
-    top = (
-        dataset.group_by(primary_entity)
-        .len()
-        .sort(["len", primary_entity], descending=[True, False])
-        .head(max_symbols)
-    )
+    from utils.data_quality import top_entities
+
+    selected = top_entities(dataset, max_symbols, primary_entity)
     # implode: is_in against a bare Series of the same dtype is deprecated in
     # polars as ambiguous, and membership in the value set is what is meant.
-    return dataset.filter(pl.col(primary_entity).is_in(top[primary_entity].implode()))
+    return dataset.filter(
+        pl.col(primary_entity).is_in(pl.Series(primary_entity, selected).implode())
+    )
 
 
 def _inclusive_end_of(boundary: str) -> pd.Timestamp:


### PR DESCRIPTION
Nine changes to the CI fixture path and the workflow that consumes it. Each one is a
defect that was measured before it was fixed and re-measured after; the measurements are
in the commit messages.

## A fork pull request no longer fails 26 jobs on a checkout it cannot authenticate

`secrets.TEST_DATA_DEPLOY_KEY` is not exposed to a `pull_request` from a fork, so
`actions/checkout` falls back to the default token, which cannot see the private test-data
repository. Five jobs - `test-chapters`, `test-case-studies`, `test-py312`, `test-neo4j`,
`test-benchmark`, two of them matrix jobs - checked it out unconditionally and failed
there. On #595, a two-line packaging fix from an outside contributor, that was 26 red
checks, none of them theirs.

Each job now decides once whether it can reach the data and gates every step on that,
which is the shape #613 landed for `test-unit-data`, and prints a notice saying the honest
thing: the job checked out no data, executed no notebook, and asserts nothing about the
change. `tests/test_fork_pull_request_gating.py` is what keeps it fixed - 26 jobs share
one workflow file, so a data-dependent job added without the gate fails there rather than
on someone's pull request.

## CI fails when the image's installed distributions do not match `uv.lock`

`ml4t/ml4t:latest` is built from the lock and drifts from it silently the moment the lock
moves. `.github/scripts/check_env_matches_lock.py` compares the two from inside the image,
with no network, as the first step of `test-unit-image` - everything after it is only
evidence about the commit if it passes. The torch stack's carve-out is declared in the
script with its reason rather than left implicit in a `grep` in the Dockerfile; `lightgbm`
is deliberately not exempt, because an undeclared carve-out is what the 4.7 nvlink build
failure cost.

## The fixture manifest is checked against its builders

`data/manifest.json` is the only record of what the fixture set contains and nothing
compared it against `tests/create_test_data.py`. `tests/test_fixture_manifest_matches_builders.py`
does, in two halves: the manifest against the declarations, and the declarations against
the data on disk. The second is the one that matters - the manifest and the
`nasdaq100_minute_bars` builder agreed with each other on six symbols while the fixture
carried twelve, so comparing the two proved nothing.

That builder is corrected here. Run as it stood it would have narrowed the fixture back to
six and, writing one `data.parquet` per year beside the `data-00`/`data-01` parts already
there, left `load_nasdaq100_bars`'s `**/*.parquet` glob reading two generations at once. It
now declares the twelve, writes each year as contiguous session blocks under GitHub's 100
MB blob limit through a staging directory, and raises rather than exceeding the limit.
Verified against production: the rebuilt fixture is identical to the shipped one.

The fixtures that have no builder are declared in `UNBUILT_FIXTURES` with the universe
measured on the fixture and the reason there is no spec, so the manifest describes the
whole set and every entry is checkable.

## One rule for reducing a panel's entity axis

`tests/overrides.yaml` injects `MAX_SYMBOLS: 5` into `nasdaq100_microstructure` stages
01-05, and the stages did not agree on which five. Measured on the shipped fixture:
`02_labels` and `03_financial_features` reduced through the loader's seeded random sample
to `{AAPL, AMD, CMCSA, CSCO, SIRI}` while `04_model_based_features` took the five
most-observed, `{AAPL, AMD, AMZN, FB, TSLA}`. Three of the five symbols the labels and
financial features covered had no temporal features at all.

`apply_max_symbols` and `reduce_to_top_entities` are now two entry points to one function,
`utils.data_quality.top_entities`: most-observed, ties broken by name. Re-measured: the
loader and stage 04 select the same five.

## `seed_results` no longer replaces a prediction artifact the fixture ships

An artifact the fixture carries is the one its registry row describes. One unexplained
line - `rewrite_existing = cs_id == "crypto_perps_funding"`, from a bulk release commit
with no isolated rationale - made crypto the exception, and its registry rows went on
describing artifacts that had been overwritten. Measured after removing it: of the 77
prediction artifacts the fixture ships, zero have a value changed by seeding.

## `generate_intermediates` names the runs that generated nothing

A pipeline stage marked `skip` cascaded to every later stage and the run exited 0, so a
default regeneration produced nothing for a case study's stages 04-08 and reported success.
A cascading skip is now `incomplete` and exits 1, `--ignore-skips` runs those stages
instead, and a `--case-studies` value naming nothing is rejected before anything is
written. `seed_configs` also ran over all nine case studies regardless of scope, so a
single-case-study regeneration rewrote 51 tracked files under eight others.

Each run now also records per-case-study output sizes and prints the change against the
last run's, so a regeneration that quadruples a git-stored fixture says so.

## The registry sampler copies `causal_runs` and `backtest_paired_metrics`

Step 1 copies every table's schema, so a table nothing copies rows for exists and is empty.
Measured across the nine shipped fixtures: `causal_runs` empty in every registry that has
it, `backtest_paired_metrics` empty in all nine. Both are copied now, the paired metrics
only for pairs both of whose sides survived sampling.

## Checks

`guards`, `lint`, `test-unit`, `test-unit-data`, `test-unit-image`.
