### PR TITLE
Close nine CI-blocking infrastructure defects

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -154,8 +154,19 @@ tests/test_notebook_sync.py::test_stamped_notebooks_are_current_and_production
 tests/test_external_drift.py
 
 # ---------------------------------------------------------------------------
-# Needs a dataset. This job checks out no test-data and points ML4T_DATA_PATH
-# at the repo's own `data/`, which holds loaders and no market data.
+# Needs a dataset - run by test-unit-data, which checks out the test-data
+# repository. This job checks out no test-data and points ML4T_DATA_PATH at the
+# repo's own `data/`, which holds loaders and no market data.
+#
+# These sat here from 2026-08-24 to 2026-09-03 excluded from this job and named
+# by no other, so the three files ran in no CI job at all - the defect the
+# subtraction above exists to prevent, reappearing one level down because
+# test-unit-data enumerates its files by hand. Measured against the test-data
+# checkout: 35 passed, 0 skipped, up from 14.
+# test_the_data_job_runs_exactly_what_is_quarantined_for_it in
+# tests/test_quarantine_list.py is what keeps this section and that job in step,
+# the same way the modelling-environment section is kept in step with
+# test-unit-image.
 # ---------------------------------------------------------------------------
 tests/test_artifact_specs.py
 tests/test_backtest_presets.py

--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -116,14 +116,14 @@ tests/test_training_identity_migration.py
 # notebook, and its other ten tests are pure config assertions that finish in
 # 0.07s. Excluding the file threw those away, which is the same
 # exclude-more-than-you-meant defect the subtraction below exists to fix.
-# Ten, not nine: `test_registering_stage_maps_to_its_actual_entry_point` is
+# Eleven, not nine: `test_registering_stage_maps_to_its_actual_entry_point` is
 # parametrized over five stages, so counting `def test_` undercounts what the
-# deselect leaves behind. Measured 2026-08-27: 88 collected, 78 deselected.
+# deselect leaves behind. Measured 2026-09-03: 105 collected, 94 deselected.
 # ---------------------------------------------------------------------------
 tests/test_case_studies.py                       # cs-<case-study> (test-case-studies)
 tests/test_chapter_notebooks.py                  # chNN (test-chapters)
 tests/test_docker_notebooks.py                   # test-py312, test-neo4j, test-benchmark
-tests/test_model_registry.py::test_model_notebook  # nothing runs it; the file's other ten tests run here
+tests/test_model_registry.py::test_model_notebook  # nothing runs it; the file's other eleven tests run here
 
 # ---------------------------------------------------------------------------
 # Needs the reader's Docker image. It walks every declared third-party import

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -79,6 +79,13 @@ Notebooks WITHOUT a stamp are reported as "unverified" but do not fail unless
 as they are re-run through the canonical path, and the gate enforces only where
 provenance exists. Flip to ``--strict`` once the backfill is complete.
 
+**Where this gate runs.** In two places, asking two different questions. The pre-commit hook
+runs it over the *staged* files, so a notebook another session left dirty does not block an
+unrelated commit. CI runs it over the *change*: ``check --since <base>`` on a pull request,
+over the notebooks that pull request touches, and on a push to ``main`` against the previous
+tip. A stale render only reaches a reader through a merge, and until CI ran this the gate
+never covered a merge at all - it fired on every local commit and on nothing that publishes.
+
 Usage::
 
     uv run python .github/scripts/notebook_provenance.py stamp <nb.ipynb> --executor ml4t-gpu --production
@@ -87,6 +94,8 @@ Usage::
     uv run python .github/scripts/notebook_provenance.py clear <nb.ipynb>  # commit it unexecuted
     uv run python .github/scripts/notebook_provenance.py check          # gate (stamped-only)
     uv run python .github/scripts/notebook_provenance.py check --strict  # also fail on unverified
+    uv run python .github/scripts/notebook_provenance.py check --since origin/main  # this branch only
+    uv run python .github/scripts/notebook_provenance.py check --since <tip> --no-merge-base  # a push
 """
 
 from __future__ import annotations
@@ -318,6 +327,72 @@ def iter_notebooks() -> list[Path]:
             continue
         out.append(p)
     return sorted(out)
+
+
+def _changed_paths(ref: str, merge_base: bool, diff_filter: str | None = None) -> list[str]:
+    """Repo-relative paths changed relative to ``ref``, optionally by change type.
+
+    ``-z``, because the gate must not lose a notebook for having a space in its name.
+    Plain ``--name-only`` quotes such a path and ``.split()`` then tears it into
+    fragments that match no suffix, so the notebook drops out of scope and passes
+    unchecked - the one thing a gate must never do.
+
+    ``--no-renames`` for the same reason from the other side: rename detection reports
+    only the destination, so moving a ``.py`` would hide the source path whose notebook
+    is now stale, and a rename arrives here as a delete plus an add instead.
+    """
+    spec = f"{ref}...HEAD" if merge_base else f"{ref}..HEAD"
+    cmd = ["git", "diff", "--name-only", "-z", "--no-renames"]
+    if diff_filter:
+        cmd.append(f"--diff-filter={diff_filter}")
+    cmd.append(spec)
+    out = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=True).stdout
+    return [name for name in out.split("\0") if name]
+
+
+def notebooks_orphaned_since(ref: str, merge_base: bool = True) -> list[str]:
+    """Notebooks this change left with no source: the ``.py`` deleted, the ``.ipynb`` kept.
+
+    This is the strongest form of the staleness the gate exists to catch - a render whose
+    source is gone can never be re-derived - and :func:`check_all` cannot see it, because
+    its ``paired_py() is None`` branch cannot tell a notebook that was just orphaned from
+    one that was never paired. Tracked notebooks are deliberately unpaired, so the
+    distinction has to come from the diff rather than from the tree.
+    """
+    orphaned: list[str] = []
+    for name in _changed_paths(ref, merge_base, diff_filter="D"):
+        if not name.endswith(".py"):
+            continue
+        nb = (REPO_ROOT / name).with_suffix(".ipynb")
+        if nb.exists() and not (SKIP_PARTS & set(nb.parts)):
+            orphaned.append(f"{nb.relative_to(REPO_ROOT)} (deleted source: {name})")
+    return sorted(orphaned)
+
+
+def notebooks_changed_since(ref: str, merge_base: bool = True) -> list[Path]:
+    """Notebooks this change is answerable for, relative to ``ref``.
+
+    A change owns a notebook if it edited the notebook OR edited the paired ``.py``,
+    since changing the ``.py`` is exactly what makes the rendered notebook stale.
+    Notebooks nobody touched are somebody else's.
+
+    ``merge_base`` picks which question is being asked. For a pull request it is "what
+    does this branch add on top of the base", so the diff runs from the merge base
+    (``ref...HEAD``) and commits that landed on the base meanwhile are not this branch's
+    problem. For a push it is "what does the published tree become", so the diff must run
+    against the previous tip itself (``ref..HEAD``) - a force-push can revert a notebook
+    relative to that tip without the merge base ever seeing it.
+    """
+    owned: set[Path] = set()
+    for name in _changed_paths(ref, merge_base):
+        path = REPO_ROOT / name
+        if path.suffix == ".ipynb":
+            owned.add(path)
+        elif path.suffix == ".py":
+            nb = path.with_suffix(".ipynb")
+            if nb.exists():
+                owned.add(nb)
+    return sorted(p for p in owned if p.exists() and not (SKIP_PARTS & set(p.parts)))
 
 
 def paired_py(nb_path: Path) -> Path | None:
@@ -701,6 +776,25 @@ def stamp_reference(base_branch: str = "main") -> str:
     return "HEAD"
 
 
+def _fork_point(ref: str) -> str:
+    """Where HEAD forked from *ref*, for the de-stamp comparison under ``--since``.
+
+    ``stamp_reference`` answers this for the default base branch. A pull request names
+    its own base, so the same question has to be asked against that ref rather than
+    against ``origin/main``, or a PR onto a release branch compares its stamps to a
+    commit neither side descends from. Falls back to *ref* itself when the two share no
+    history, which is the honest answer for an unrelated ref.
+    """
+    merge_base = subprocess.run(
+        ["git", "merge-base", "HEAD", ref],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return merge_base.stdout.strip() if merge_base.returncode == 0 else ref
+
+
 def was_executed(nb: dict) -> bool:
     """True if any non-empty code cell in *nb* shows evidence of having been run.
 
@@ -1069,13 +1163,42 @@ def _cmd_clear(args: argparse.Namespace) -> int:
 
 def _cmd_check(args: argparse.Namespace) -> int:
     only = {str(Path(p)) for p in args.paths} or None
+    orphaned: list[str] = []
+    since_ref: str | None = None
+    if args.since:
+        if only is not None:
+            print("check: pass --since or paths, not both", file=sys.stderr)
+            return 2
+        merge_base = not args.no_merge_base
+        # Before the scope check returns early: an orphaned notebook is invisible to
+        # check_all by construction, and a change that deletes only a .py leaves nothing
+        # in scope to report it.
+        orphaned = notebooks_orphaned_since(args.since, merge_base=merge_base)
+        scope = notebooks_changed_since(args.since, merge_base=merge_base)
+        only = {str(nb.relative_to(REPO_ROOT)) for nb in scope}
+        since_ref = _fork_point(args.since) if merge_base else args.since
+        if not only and not orphaned:
+            print(f"notebook sync OK: no notebook is changed relative to {args.since}")
+            return 0
+        if scope:
+            print(f"checking {len(scope)} notebook(s) changed relative to {args.since}:")
+            for nb in scope:
+                print(f"  {nb.relative_to(REPO_ROOT)}")
+            print()
     stale, testmode, contradicted, unverified, alt_only, hollow = check_all(
         strict=args.strict, only=only
     )
-    lost = destamped(only=only)
-    fail = bool(stale or testmode or contradicted or lost or hollow) or (
+    lost = destamped(ref=since_ref, only=only)
+    fail = bool(stale or testmode or contradicted or lost or hollow or orphaned) or (
         args.strict and bool(unverified)
     )
+    if orphaned:
+        print(
+            "ORPHANED (the paired .py was deleted but the rendered .ipynb was kept — "
+            "restore the source or delete the notebook with it):"
+        )
+        for r in orphaned:
+            print(f"  {r}")
     if hollow:
         print(
             "HOLLOW (carries a provenance stamp over a notebook with no trace of a run — "
@@ -1182,6 +1305,21 @@ def main() -> int:
         nargs="*",
         help="restrict the scan to these files (the pre-commit gate passes the staged ones); "
         "with none given, the whole tree is scanned",
+    )
+    cp.add_argument(
+        "--since",
+        default=None,
+        metavar="REF",
+        help="check only notebooks this change touched relative to REF (e.g. origin/main), "
+        "counting a notebook as touched when its paired .py changed. This is the merge "
+        "gate: CI passes the PR base here",
+    )
+    cp.add_argument(
+        "--no-merge-base",
+        action="store_true",
+        help="diff REF..HEAD instead of REF...HEAD — use for a push, where the question is "
+        "what the published tree becomes relative to the previous tip, not what a branch "
+        "adds on top of a base",
     )
     cp.set_defaults(func=_cmd_check)
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -406,6 +406,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # notebook_provenance.py --since diffs against the base or the previous
+          # tip, and neither is in a shallow clone.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
@@ -437,6 +441,40 @@ jobs:
         run: |
           source .venv/bin/activate
           python -m pytest tests/test_notebook_output_hygiene.py -q
+      # A committed .ipynb must be its CURRENT .py, executed for real. The gate
+      # existed only as a pre-commit hook, so it fired on every local commit and
+      # on nothing that publishes - a stale render reaches a reader through a
+      # merge, and no merge was covered. Here it covers what this change touched:
+      # a notebook it edited, or one whose paired .py it edited. Scoped, so one
+      # stale notebook elsewhere is somebody else's and does not block this PR.
+      #
+      # It runs on push to main as well as on the PR. Branch protection means
+      # everything should arrive via a PR, but this workflow's own history is that
+      # exports used to land on main as pushes and nothing CI ran had seen them -
+      # a gate that only fires on the path we believe is the only path is how that
+      # happened. On a push the base is the previous tip, so the scope is exactly
+      # what the push introduced.
+      - name: Notebooks this change touched were executed from their current .py
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        run: |
+          source .venv/bin/activate
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # What does this branch add on top of the base: merge-base diff.
+            python .github/scripts/notebook_provenance.py check \
+              --since "origin/${{ github.base_ref }}"
+            exit $?
+          fi
+          # What does the published tree become: diff the previous tip directly,
+          # so a force-push that reverts a notebook relative to it is still seen.
+          base="${{ github.event.before }}"
+          if [[ "$base" =~ ^0+$ ]] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            # First push, or a force-push that dropped the old tip. There is no
+            # honest scope, so check everything rather than guess a narrower one.
+            echo "previous tip unavailable ($base) - checking every notebook"
+            python .github/scripts/notebook_provenance.py check
+            exit $?
+          fi
+          python .github/scripts/notebook_provenance.py check --since "$base" --no-merge-base
 
   # ---------------------------------------------------------------------------
   # Fast native unit tests — download-script logic (no Docker, no network,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -892,8 +892,13 @@ jobs:
         if: steps.reach.outputs.have_key
         run: |
           uv venv --python 3.14
+          # ml4t-backtest joined with tests/test_backtest_presets.py:
+          # ensure_backtest_spec resolves the engine's own BacktestConfig
+          # (case_studies/utils/backtest_loaders.py:169 imports ml4t.backtest), and
+          # without the package four of its tests raise rather than skip. Measured in a
+          # venv holding exactly this list: 4 failed without it, 37 passed with it.
           uv pip install pytest numpy pandas polars pyyaml python-dotenv plotly gymnasium requests \
-            scipy statsmodels scikit-learn matplotlib hmmlearn pyarrow \
+            scipy statsmodels scikit-learn matplotlib hmmlearn pyarrow ml4t-backtest \
             "ml4t-diagnostic>=0.1.2" jupytext==1.19.3
       # The precondition is the load-bearing half, the same shape as the
       # data-root anchoring step above. Every test in this job skips politely

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -936,9 +936,22 @@ jobs:
           # CI job, which is a real gap and is stated in that file's docstring.
           # The other three tests in the same file assert relations that hold on any
           # extract - they collect as six cases - and are what this job gates.
+          # The two deselects below are not quarantine entries: the quarantine file
+          # describes what test-unit does not run, and both of these are inside a
+          # file this job DOES run. They need the stage 01-05 artifacts of
+          # us_equities_panel and nasdaq100_microstructure, the two case studies
+          # whose rebuild has not produced them, so they fail on any checkout -
+          # here and on a workstation alike. Take them out when those two rebuild.
           .venv/bin/python -m pytest \
             tests/test_eoa_universe_roster.py \
             tests/test_fixture_registry_identity.py \
+            tests/test_artifact_specs.py \
+            tests/test_backtest_presets.py \
+            tests/test_etf_baseline_parity.py \
+            tests/test_sp500_options_research.py::test_official_population_is_snapshotted_before_option_execution \
+            tests/test_us_firm_research_workflow.py::test_open_study_writes_canonical_results_to_output_dir \
+            --deselect tests/test_artifact_specs.py::test_us_equities_pilot_helpers_preserve_current_outputs \
+            --deselect tests/test_artifact_specs.py::test_microstructure_pilot_helpers_preserve_current_outputs \
             -m "not production_extract" \
             -v --tb=short -rs --junitxml=unit-data.xml
       # A skip here is a failure: these tests run in this job and nowhere else,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,8 +59,13 @@ repos:
       # on every commit, so one notebook another session had left dirty blocked every
       # unrelated commit in that worktree - three worktrees were stuck that way in a
       # single day, and the cme_futures one could not commit anything for six days.
-      # Nothing unstaged can reach main, so the narrower scan gives up no protection,
-      # and CI still calls `check` with no arguments and scans everything.
+      # Nothing unstaged can reach main, so the narrower scan gives up no protection.
+      # This hook gates the commit; the merge is gated separately, by the `guards` job
+      # in .github/workflows/test.yml running
+      #   notebook_provenance.py check --since <base>
+      # over the notebooks the pull request touches, and against the previous tip on a
+      # push to main. A stale render only reaches a reader through a merge, and until
+      # that job existed no merge was covered at all.
       - id: notebook-sync
         name: notebook provenance sync gate
         language: system

--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -139,11 +139,10 @@ def open_study(
     """
     if execution_tier == "canonical":
         if workspace is None:
-            return Study.regenerate(CASE_STUDY, release_root=REPO_ROOT, entry_point=entry_point)
+            return Study.regenerate(CASE_STUDY, entry_point=entry_point)
         return Study.open(
             CASE_STUDY,
             workspace=Path(workspace).expanduser().resolve(),
-            release_root=REPO_ROOT,
             entry_point=entry_point,
         )
     if execution_tier != "preview":
@@ -155,7 +154,6 @@ def open_study(
         return Study.open(
             CASE_STUDY,
             workspace=workspace,
-            release_root=REPO_ROOT,
             entry_point=entry_point,
             execution_tier=ExecutionTier.PREVIEW,
         )

--- a/case_studies/crypto_perps_funding/research_workflow.py
+++ b/case_studies/crypto_perps_funding/research_workflow.py
@@ -25,7 +25,6 @@ from case_studies.research.contracts import ExecutionTier
 from case_studies.research.execution import ModelExecution
 from case_studies.research.models import ModelRequest
 from utils.modeling import load_configs
-from utils.paths import REPO_ROOT
 
 CASE_STUDY = "crypto_perps_funding"
 ALL_LABELS = ("fwd_ret_8h", "fwd_ret_24h", "fwd_dir_8h", "fwd_dir_8h_3c")
@@ -39,7 +38,7 @@ def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> S
     """Open canonical regeneration or an isolated reader preview."""
     if execution_tier == "canonical":
         if workspace is None:
-            return Study.regenerate(CASE_STUDY, release_root=REPO_ROOT)
+            return Study.regenerate(CASE_STUDY)
     elif execution_tier == "preview":
         workspace = workspace or os.environ.get("ML4T_OUTPUT_DIR")
         if workspace is None:
@@ -49,7 +48,6 @@ def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> S
     return Study.open(
         CASE_STUDY,
         workspace=Path(workspace).expanduser().resolve(),
-        release_root=REPO_ROOT,
     )
 
 

--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -29,6 +29,38 @@ if TYPE_CHECKING:
 _ACTIVE_OUTPUT_ROOT: Path | None = None
 
 
+def default_release_root() -> Path:
+    """The released tree a study reads when its caller names none.
+
+    ``REPO_ROOT`` for a reader and for production, and that is the whole answer for a
+    clean checkout, where ``case_studies/<case study>/run_log`` does not exist.
+
+    ``ML4T_RELEASE_ROOT`` overrides it, and the test harness is what sets it. In a
+    maintainer worktree that same path is a symlink into ``~/ml4t/artifacts``, so a
+    harness run resolving its canonical reads through ``REPO_ROOT`` overlays the
+    machine's published catalog onto an isolated workspace - measured on a freshly
+    seeded fx_pairs fixture as 749 catalog rows where the workspace held 23 - while a CI
+    runner, which has no such symlink, reads the seeded 23 and nothing else. Same code,
+    different rows, and the environment where the suite is actually exercised before a
+    push is the one that is not hermetic: a local pass is then not evidence of a CI pass
+    and a local failure is not evidence of a CI failure.
+
+    Pointing this at a checkout-shaped tree is what makes the two agree. It is not a
+    change to what "canonical" means - the released catalog is still overlaid onto a
+    workspace, which is the contract ``test_workspace_overlay_restarts_without_copying_release_run_log``
+    pins - only to which released tree an unqualified caller gets.
+    """
+    named = os.environ.get("ML4T_RELEASE_ROOT")
+    return Path(named).expanduser().resolve() if named else REPO_ROOT
+
+
+def _resolve_release_root(named: str | Path | None) -> Path:
+    """An explicit release root wins over the environment, which wins over REPO_ROOT."""
+    if named is None:
+        return default_release_root()
+    return Path(named).expanduser().resolve()
+
+
 def _release_manifest_digest(case_dir: Path) -> str:
     release_manifest = case_dir / "run_log" / ".release" / "SHA256SUMS"
     if release_manifest.exists():
@@ -196,12 +228,12 @@ class Study:
         case_study: str,
         workspace: str | Path | None = None,
         *,
-        release_root: str | Path = REPO_ROOT,
+        release_root: str | Path | None = None,
         entry_point: str | None = None,
         execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL,
     ) -> Study:
         execution_tier = ExecutionTier(execution_tier)
-        release_root = Path(release_root).expanduser().resolve()
+        release_root = _resolve_release_root(release_root)
         release_case_dir = release_root / "case_studies" / case_study
         if not release_case_dir.is_dir():
             raise FileNotFoundError(f"Unknown released case study: {release_case_dir}")
@@ -288,11 +320,11 @@ class Study:
         cls,
         case_study: str,
         *,
-        release_root: str | Path = REPO_ROOT,
+        release_root: str | Path | None = None,
         entry_point: str | None = None,
     ) -> Study:
         """Open the canonical generated-artifact links for maintainer regeneration."""
-        release_root = Path(release_root).expanduser().resolve()
+        release_root = _resolve_release_root(release_root)
         case_dir = release_root / "case_studies" / case_study
         if not case_dir.is_dir():
             raise FileNotFoundError(f"Unknown released case study: {case_dir}")
@@ -451,7 +483,7 @@ def open_study(
     *,
     execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL,
     workspace: str | Path | None = None,
-    release_root: str | Path = REPO_ROOT,
+    release_root: str | Path | None = None,
     entry_point: str | None = None,
 ) -> Study:
     """Open the study a notebook should execute against for its tier.
@@ -463,7 +495,7 @@ def open_study(
     ``workspace``, and must declare the reductions that make it cheap.
     """
     tier = ExecutionTier(execution_tier)
-    release_root = Path(release_root).expanduser().resolve()
+    release_root = _resolve_release_root(release_root)
     if tier is ExecutionTier.CANONICAL:
         if workspace is None:
             return Study.regenerate(case_study, release_root=release_root, entry_point=entry_point)

--- a/case_studies/sp500_equity_option_analytics/research_workflow.py
+++ b/case_studies/sp500_equity_option_analytics/research_workflow.py
@@ -51,13 +51,12 @@ def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> S
     """Open canonical regeneration or an isolated preview workspace."""
     tier = ExecutionTier(execution_tier)
     if tier is ExecutionTier.CANONICAL:
-        return Study.regenerate(CASE_STUDY, release_root=REPO_ROOT)
+        return Study.regenerate(CASE_STUDY)
     if workspace is None:
         raise ValueError("preview execution requires an explicit workspace")
     return Study.open(
         CASE_STUDY,
         workspace=Path(workspace).expanduser().resolve(),
-        release_root=REPO_ROOT,
     )
 
 

--- a/case_studies/sp500_options/research_workflow.py
+++ b/case_studies/sp500_options/research_workflow.py
@@ -108,7 +108,7 @@ def declared_dl_device(requested: str | None = None) -> str:
 def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> Study:
     """Open canonical regeneration or an isolated reader preview."""
     if execution_tier == "canonical":
-        return Study.regenerate(CASE_STUDY, release_root=REPO_ROOT)
+        return Study.regenerate(CASE_STUDY)
     if execution_tier != "preview":
         raise ValueError("execution_tier must be canonical or preview")
     if workspace is None:
@@ -141,7 +141,7 @@ def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> S
         )
         study.activate(execution_tier)
         return study
-    return Study.open(CASE_STUDY, workspace=workspace, release_root=REPO_ROOT)
+    return Study.open(CASE_STUDY, workspace=workspace)
 
 
 def model_request_catalog(

--- a/case_studies/us_firm_characteristics/research_workflow.py
+++ b/case_studies/us_firm_characteristics/research_workflow.py
@@ -47,7 +47,7 @@ def open_study(*, execution_tier: str, workspace: str | Path | None = None) -> S
     # in the same kernel would otherwise nest one preview root inside another.
     if resolved_root.name == PREVIEW_DIR_NAME:
         resolved_root = resolved_root.parent
-    study = Study.open(CASE_STUDY, workspace=resolved_root, release_root=REPO_ROOT)
+    study = Study.open(CASE_STUDY, workspace=resolved_root)
     study.activate(execution_tier)
     return study
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,6 +281,56 @@ def seed_case_study_intermediates(src: Path, dst: Path) -> None:
             shutil.copy2(item, dst / item.name)
 
 
+GENERATED_CASE_DIRS = ("features", "labels", "run_log")
+
+
+def _checkout_shaped_release_root(output_dir: Path) -> Path:
+    """A released tree shaped like a clean checkout, for the harness to read canonical from.
+
+    `open_study` resolves its canonical reads against a release root, and the default was
+    `REPO_ROOT`. In a maintainer worktree `case_studies/<cs>/run_log` there is a symlink
+    into `~/ml4t/artifacts`, so a harness run overlaid the machine's published catalog
+    onto its isolated workspace - measured on a freshly seeded fx_pairs fixture as 749
+    catalog rows where the workspace held 23 - while a CI runner, which has no such
+    symlink, read the seeded 23 and nothing else. The same code took different rows in
+    the two places, so a local pass was not evidence of a CI pass and a local failure was
+    not evidence of a CI failure. The reads that produced it are real: a backtest selected
+    two published predictions the fixture did not have, registered their identities, and
+    the next stage failed on a `predictions.parquet` the workspace has no copy of.
+
+    So the harness gives it a release root of its own, carrying what a checkout carries -
+    `config/` and the tracked top-level files - and, exactly like a checkout, no
+    `run_log`. Nothing else is read through the release root: the catalogs read
+    `<release case dir>/run_log`, `create_experiment` reads `config/`, and everything a
+    notebook loads goes through `get_case_study_dir()`, which follows ML4T_OUTPUT_DIR.
+
+    Symlinks rather than copies, so this costs nothing per session and cannot drift from
+    the tree it mirrors.
+    """
+    release = output_dir / ".release"
+    cases = release / "case_studies"
+    cases.mkdir(parents=True, exist_ok=True)
+    source_root = REPO_ROOT / "case_studies"
+    shared = cases / "config"
+    if not shared.exists() and (source_root / "config").is_dir():
+        shared.symlink_to(source_root / "config", target_is_directory=True)
+    for cs_id in CASE_STUDY_IDS:
+        source = source_root / cs_id
+        if not source.is_dir():
+            continue
+        target = cases / cs_id
+        target.mkdir(exist_ok=True)
+        for entry in source.iterdir():
+            if entry.name in GENERATED_CASE_DIRS or entry.name.startswith("."):
+                continue
+            if entry.is_dir() and entry.name != "config":
+                continue
+            link = target / entry.name
+            if not link.exists() and not link.is_symlink():
+                link.symlink_to(entry, target_is_directory=entry.is_dir())
+    return release
+
+
 @pytest.fixture(scope="session")
 def seeded_output_dir(tmp_path_factory):
     """Session-scoped output dir seeded with case study config files.
@@ -308,6 +358,11 @@ def seeded_output_dir(tmp_path_factory):
     global _SESSION_OUTPUT_DIR
     os.environ["ML4T_OUTPUT_DIR"] = str(output_dir)
     _SESSION_OUTPUT_DIR = str(output_dir)
+
+    # And a release root that is not REPO_ROOT, so a study opened here reads the same
+    # canonical rows a CI runner reads. See _checkout_shaped_release_root.
+    output_dir.mkdir(parents=True, exist_ok=True)
+    os.environ["ML4T_RELEASE_ROOT"] = str(_checkout_shaped_release_root(output_dir))
 
     cs_root = REPO_ROOT / "case_studies"
 

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1212,6 +1212,13 @@ case_studies/cme_futures/05_evaluation:
   # evaluates, and the reduction bought nothing: the panel is 38k rows either way.
   timeout: 600
 case_studies/cme_futures/06_linear:
+  # 120s is measured here, not copied. Slowest of 5 green `cs-cme_futures` runs of
+  # .github/workflows/test.yml sampled 2026-09-04: 15.1s, 13% of the budget, against
+  # 20.9s for the gbm sibling on its 180. The premise that the linear stage does more work
+  # than its gbm sibling holds for us_equities_panel, whose reduction leaves all three
+  # labels x 16 configurations; it does not hold here, where the preview reduction cuts the
+  # grid and the gbm run is the slower of the two in every case study measured. The tier is
+  # the one-third line the raised entries elsewhere in this file state.
   parameters:
     # Restored after #560, same removal as 07_gbm below. This one has been passing on its 120s
     # budget rather than failing, which is the reason to fix it now: it is mispriced in exactly
@@ -1389,6 +1396,13 @@ case_studies/crypto_perps_funding/05_evaluation:
     MAX_SYMBOLS: 5
   timeout: 300
 case_studies/crypto_perps_funding/06_linear:
+  # 120s is measured here, not copied. Slowest of 5 green `cs-crypto_perps_funding` runs of
+  # .github/workflows/test.yml sampled 2026-09-04: 19.8s, 17% of the budget, against
+  # 27.9s for the gbm sibling on its 180. The premise that the linear stage does more work
+  # than its gbm sibling holds for us_equities_panel, whose reduction leaves all three
+  # labels x 16 configurations; it does not hold here, where the preview reduction cuts the
+  # grid and the gbm run is the slower of the two in every case study measured. The tier is
+  # the one-third line the raised entries elsewhere in this file state.
   timeout: 120
 case_studies/crypto_perps_funding/07_gbm:
   timeout: 180
@@ -1496,6 +1510,13 @@ case_studies/etfs/05_evaluation:
   # re-narrows the cross-section that 04 was widened to preserve.
   timeout: 900
 case_studies/etfs/06_linear:
+  # 120s is measured here, not copied. Slowest of 5 green `cs-etfs` runs of
+  # .github/workflows/test.yml sampled 2026-09-04: 16.1s, 13% of the budget, against
+  # 22.9s for the gbm sibling on its 180. The premise that the linear stage does more work
+  # than its gbm sibling holds for us_equities_panel, whose reduction leaves all three
+  # labels x 16 configurations; it does not hold here, where the preview reduction cuts the
+  # grid and the gbm run is the slower of the two in every case study measured. The tier is
+  # the one-third line the raised entries elsewhere in this file state.
   # #560 moved this notebook onto the shared boundary and removed `MAX_FOLDS: 2` /
   # `MAX_SYMBOLS: 5` without replacing them, leaving a timeout that had been measured
   # against them. `_collect_preview_reductions` defaults `max_symbols: 5` when nothing is
@@ -1580,7 +1601,14 @@ case_studies/etfs/10_dl_tsmixer:
     POPULATION_NAME: etfs-tsmixer-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-  timeout: 180
+  # Budget raised from 180 on a CI measurement, not on another notebook's number.
+  # Slowest of 5 green `cs-etfs` runs of .github/workflows/test.yml sampled 2026-09-04:
+  # 103.1s, 57% of the old budget. A budget a green run already fills is one
+  # contention band away from a timeout that reads as a notebook defect. The line is a
+  # third, because the only measurement anyone has of that band is the
+  # us_equities_panel/06_linear timeout this rule comes from: a notebook that fit in 120s
+  # idle, did not fit in 120s loaded, and passed at 300.
+  timeout: 360
 case_studies/etfs/10a_dl_nlinear:
   # Without a block here the notebook runs as a preview that declares no reduction, which
   # `run_model_population` refuses outright, so an absent entry is a failed job rather than a
@@ -1636,7 +1664,14 @@ case_studies/etfs/11b_ipca:
       folds: [0, 1]
       max_symbols: 5
       n_factors: 1
-  timeout: 300
+  # Budget raised from 300 on a CI measurement, not on another notebook's number.
+  # Slowest of 5 green `cs-etfs` runs of .github/workflows/test.yml sampled 2026-09-04:
+  # 251.9s, 84% of the old budget. A budget a green run already fills is one
+  # contention band away from a timeout that reads as a notebook defect. The line is a
+  # third, because the only measurement anyone has of that band is the
+  # us_equities_panel/06_linear timeout this rule comes from: a notebook that fit in 120s
+  # idle, did not fit in 120s loaded, and passed at 300.
+  timeout: 780
 case_studies/etfs/11_latent_factors:
   gpu: true
   timeout: 900
@@ -1749,6 +1784,13 @@ case_studies/fx_pairs/05_evaluation:
     MAX_SYMBOLS: 5
   timeout: 300
 case_studies/fx_pairs/06_linear:
+  # 120s is measured here, not copied. Slowest of 5 green `cs-fx_pairs` runs of
+  # .github/workflows/test.yml sampled 2026-09-04: 17.2s, 14% of the budget, against
+  # 22.7s for the gbm sibling on its 180. The premise that the linear stage does more work
+  # than its gbm sibling holds for us_equities_panel, whose reduction leaves all three
+  # labels x 16 configurations; it does not hold here, where the preview reduction cuts the
+  # grid and the gbm run is the slower of the two in every case study measured. The tier is
+  # the one-third line the raised entries elsewhere in this file state.
   # Restores the reduction #560 removed. It dropped MAX_FOLDS: 2 / MAX_SYMBOLS: 5 when the
   # stage moved onto the shared boundary and left the timeout priced for them, so since
   # 2026-08-20 this has run all 8 folds over all 20 pairs on a budget measured against 2 and 5.
@@ -1780,7 +1822,14 @@ case_studies/fx_pairs/09_dl_tcn:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 5
     N_EPOCHS: 1
-  timeout: 180
+  # Budget raised from 180 on a CI measurement, not on another notebook's number.
+  # Slowest of 5 green `cs-fx_pairs` runs of .github/workflows/test.yml sampled 2026-09-04:
+  # 104.7s, 58% of the old budget. A budget a green run already fills is one
+  # contention band away from a timeout that reads as a notebook defect. The line is a
+  # third, because the only measurement anyone has of that band is the
+  # us_equities_panel/06_linear timeout this rule comes from: a notebook that fit in 120s
+  # idle, did not fit in 120s loaded, and passed at 300.
+  timeout: 360
 case_studies/fx_pairs/10_dl_nlinear:
   parameters:
     BATCH_SIZE: 256
@@ -2045,7 +2094,14 @@ case_studies/nasdaq100_microstructure/14_backtest:
     TOP_N_PREDICTIONS: 2
   # Doubled with the universe. The slot grid does not widen with the ceiling, so this run
   # prices twice the names over the same number of schemes.
-  timeout: 360
+  # Budget raised from 360 on a CI measurement, not on another notebook's number.
+  # Slowest of 6 green `cs-nasdaq100_microstructure` runs of .github/workflows/test.yml sampled 2026-09-04:
+  # 354.1s, 98% of the old budget. A budget a green run already fills is one
+  # contention band away from a timeout that reads as a notebook defect. The line is a
+  # third, because the only measurement anyone has of that band is the
+  # us_equities_panel/06_linear timeout this rule comes from: a notebook that fit in 120s
+  # idle, did not fit in 120s loaded, and passed at 300.
+  timeout: 1080
 case_studies/nasdaq100_microstructure/15_portfolio_management:
   parameters:
     # Same constraint as 14_backtest above, and the widened fixture relaxes it.
@@ -2088,6 +2144,13 @@ case_studies/sp500_equity_option_analytics/05_evaluation:
     MAX_SYMBOLS: 5
   timeout: 300
 case_studies/sp500_equity_option_analytics/06_linear:
+  # 120s is measured here, not copied. Slowest of 5 green `cs-sp500_equity_option_analytics` runs of
+  # .github/workflows/test.yml sampled 2026-09-04: 20.0s, 17% of the budget, against
+  # 31.9s for the gbm sibling on its 180. The premise that the linear stage does more work
+  # than its gbm sibling holds for us_equities_panel, whose reduction leaves all three
+  # labels x 16 configurations; it does not hold here, where the preview reduction cuts the
+  # grid and the gbm run is the slower of the two in every case study measured. The tier is
+  # the one-third line the raised entries elsewhere in this file state.
   timeout: 120
 case_studies/sp500_equity_option_analytics/07_gbm:
   timeout: 180
@@ -2361,12 +2424,26 @@ case_studies/sp500_options/04_model_based_features:
   parameters:
     SV_N_PARTICLES: 100
     SV_POOL_SIZE: 2
-  timeout: 1800
+  # Budget raised from 1800 on a CI measurement, not on another notebook's number.
+  # Slowest of 5 green `cs-sp500_options` runs of .github/workflows/test.yml sampled 2026-09-04:
+  # 903.5s, 50% of the old budget. A budget a green run already fills is one
+  # contention band away from a timeout that reads as a notebook defect. The line is a
+  # third, because the only measurement anyone has of that band is the
+  # us_equities_panel/06_linear timeout this rule comes from: a notebook that fit in 120s
+  # idle, did not fit in 120s loaded, and passed at 300.
+  timeout: 2760
 case_studies/sp500_options/05_evaluation:
   parameters:
     MAX_SYMBOLS: 5
   timeout: 300
 case_studies/sp500_options/06_linear:
+  # 120s is measured here, not copied. Slowest of 5 green `cs-sp500_options` runs of
+  # .github/workflows/test.yml sampled 2026-09-04: 22.8s, 19% of the budget, against
+  # 33.1s for the gbm sibling on its 180. The premise that the linear stage does more work
+  # than its gbm sibling holds for us_equities_panel, whose reduction leaves all three
+  # labels x 16 configurations; it does not hold here, where the preview reduction cuts the
+  # grid and the gbm run is the slower of the two in every case study measured. The tier is
+  # the one-third line the raised entries elsewhere in this file state.
   # The reductions these budgets were measured against, restored. #446 removed
   # NUM_BOOST_ROUND and #560 removed MAX_FOLDS and MAX_SYMBOLS from both entries, in each case
   # because the notebook could no longer receive that parameter - and left the timeouts, which
@@ -2789,6 +2866,13 @@ case_studies/us_firm_characteristics/04_evaluation:
     MAX_SYMBOLS: 5
   timeout: 300
 case_studies/us_firm_characteristics/05_linear:
+  # 120s is measured here, not copied. Slowest of 5 green `cs-us_firm_characteristics` runs of
+  # .github/workflows/test.yml sampled 2026-09-04: 13.9s, 12% of the budget, against
+  # 16.8s for the gbm sibling on its 180. The premise that the linear stage does more work
+  # than its gbm sibling holds for us_equities_panel, whose reduction leaves all three
+  # labels x 16 configurations; it does not hold here, where the preview reduction cuts the
+  # grid and the gbm run is the slower of the two in every case study measured. The tier is
+  # the one-third line the raised entries elsewhere in this file state.
   parameters:
     # Restored after #560 removed MAX_FOLDS/MAX_SYMBOLS and left the timeout that had
     # been measured against them, so this preview had been fitting the full declared

--- a/tests/test_holdout_boundary.py
+++ b/tests/test_holdout_boundary.py
@@ -187,10 +187,11 @@ LABEL_ENDPOINT_PURGED_NOTEBOOKS = [
 # one this test checks.
 # ``etfs/03_financial_features`` is deliberately absent. It was listed here while it
 # purged on a shifted label endpoint; public #447 replaced that mechanism with a seal
-# that rebuilds the whole panel with the holdout withheld and compares all 57 columns,
-# which is checked by executing the notebook rather than by reading its source. A
-# source pattern cannot see the stronger check, so listing it here only produces a
-# false red. See agent-workspace #141.
+# that rebuilds the whole panel with the holdout withheld and compares all 57 columns.
+# A source pattern for a shifted endpoint cannot see that, so listing it here only
+# produces a false red. The rebuild is checked instead by
+# ``RECONSTRUCTION_SEALED_NOTEBOOKS`` below, which is the list every stage-03 notebook
+# joins -- eight of the nine are on it now.
 # ``sp500_options/02_labels`` is deliberately absent, and for the opposite reason to
 # ``etfs/05``: its endpoint is not an approximation that needs the per-symbol form. The
 # hold-to-expiry label settles on the expiration written into the contract and the
@@ -995,3 +996,137 @@ def test_a_holdout_end_naming_an_instant_is_taken_literally() -> None:
     # An explicitly configured midnight is an instant, not a day. It parses to the
     # same Timestamp as the bare date, so the configured string is what decides.
     assert _inclusive_end_of("2021-12-31 00:00:00") == pd.Timestamp("2021-12-31")
+
+
+# The second seal mechanism. ``PER_SYMBOL_ENDPOINT_NOTEBOOKS`` above checks a purge on a
+# shifted label endpoint by reading it out of the source. Stage 03 does not purge: it
+# rebuilds the whole feature panel from the pre-holdout rows alone and requires every
+# emitted column to reproduce the values the full build produced on the rows the two
+# panels share (``case_studies/utils/feature_engineering.py::assert_values_agree``). That
+# catches a transform fitted across the sample -- a winsorization bound, a scaler, an
+# encoder -- for every column at once, rather than for the ones someone remembered to flag.
+#
+# The seal is stronger than a source pattern and it is checked by *executing* the notebook,
+# which is why nothing statically asserted it was still there: a future edit could delete it
+# and every static gate would stay green. That is the failure this file's docstring records
+# against the 2026-07-21 revert, so the seal gets a list of its own here. Eight of the nine
+# stage-03 notebooks carry it. ``us_equities_panel/03_financial_features`` is deliberately
+# absent and has its own test above
+# (``test_us_equities_panel_03_restricts_the_evaluation_on_the_label_endpoint``): it draws a
+# winsorization bound from development rows rather than rebuilding, so there is no second
+# build to compare against.
+RECONSTRUCTION_SEALED_NOTEBOOKS = [
+    "case_studies/cme_futures/03_financial_features.py",
+    "case_studies/crypto_perps_funding/03_financial_features.py",
+    "case_studies/etfs/03_financial_features.py",
+    "case_studies/fx_pairs/03_financial_features.py",
+    "case_studies/nasdaq100_microstructure/03_financial_features.py",
+    "case_studies/sp500_equity_option_analytics/03_financial_features.py",
+    "case_studies/sp500_options/03_financial_features.py",
+    "case_studies/us_firm_characteristics/03_financial_features.py",
+]
+
+
+def _module_level_bindings(tree: ast.Module) -> dict[str, ast.expr]:
+    """Every ``name = expr`` assigned once at module scope, by name."""
+    bindings: dict[str, ast.expr] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    bindings[target.id] = node.value
+    return bindings
+
+
+def _expanded_source(node: ast.expr, bindings: dict[str, ast.expr], source: str) -> str:
+    """The node's source with module-level names substituted, three levels deep.
+
+    A notebook may name the boundary filter (``_before``), the restricted frame
+    (``pre_holdout``) or both, so the boundary is not always spelled inside the
+    call itself. Following the binding is what lets one check cover all eight
+    rather than eight regexes.
+    """
+    text = ast.get_source_segment(source, node) or ""
+    for _ in range(3):
+        names = {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+        expansion = [
+            ast.get_source_segment(source, bindings[name]) or ""
+            for name in sorted(names)
+            if name in bindings
+        ]
+        if not expansion:
+            break
+        text = text + "\n" + "\n".join(expansion)
+        node = ast.parse("(" + ", ".join(f"({e})" for e in expansion) + ",)").body[0].value
+    return text
+
+
+@pytest.mark.parametrize("rel_path", RECONSTRUCTION_SEALED_NOTEBOOKS)
+def test_stage_03_is_sealed_by_reconstruction(rel_path: str) -> None:
+    """Stage 03 rebuilds the panel without the holdout and compares every column.
+
+    Four things have to hold together, and each of them alone is satisfiable by a
+    seal that checks nothing: the call is there, the second frame is *rebuilt*
+    rather than sliced out of the first, both frames stop at the boundary, and the
+    comparison covers the emitted feature columns rather than a hand-picked few.
+    """
+    path = REPO_ROOT / rel_path
+    source = path.read_text()
+    tree = ast.parse(source)
+    bindings = _module_level_bindings(tree)
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "assert_values_agree"
+    ]
+    assert calls, (
+        f"{rel_path}: no call to assert_values_agree. The holdout seal at this stage is a "
+        "rebuild of the panel from the pre-holdout rows compared against the full build; "
+        "deleting it leaves every other gate in this file green"
+    )
+    call = calls[0]
+    assert len(call.args) == 2, (
+        f"{rel_path}: assert_values_agree takes the full build and the withheld build as "
+        f"its two positional arguments; found {len(call.args)}"
+    )
+    full, withheld = call.args
+    keywords = {kw.arg: kw.value for kw in call.keywords}
+
+    # The withheld side must call a build function. Without this the seal is
+    # satisfiable by passing the same frame twice, which compares a panel to itself.
+    rebuilt = [
+        node
+        for node in ast.walk(withheld)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    ]
+    assert any(node.func.id.startswith("build") for node in rebuilt), (
+        f"{rel_path}: the second argument must rebuild the panel from the pre-holdout rows "
+        "(a build_* call); slicing the full build instead compares it against itself"
+    )
+
+    for label, side in (("full", full), ("withheld", withheld)):
+        expanded = _expanded_source(side, bindings, source)
+        assert "HOLDOUT_START" in expanded, (
+            f"{rel_path}: the {label} frame passed to assert_values_agree is not restricted "
+            "to the rows before HOLDOUT_START, so the comparison does not run on the rows "
+            "the two panels share"
+        )
+
+    assert "columns" in keywords, f"{rel_path}: assert_values_agree needs columns="
+    columns = keywords["columns"]
+    assert isinstance(columns, ast.Name), (
+        f"{rel_path}: columns= must be the notebook's emitted feature-column list, not a "
+        f"literal; a hand-written list seals only the columns someone typed out "
+        f"({ast.get_source_segment(source, columns)})"
+    )
+    assert columns.id in bindings, (
+        f"{rel_path}: columns={columns.id} is not assigned at module scope, so what the "
+        "seal covers cannot be read from the source"
+    )
+    assert "keys" in keywords, (
+        f"{rel_path}: assert_values_agree needs keys=, the panel key both builds are sorted "
+        "on before the values are compared"
+    )

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -379,6 +379,41 @@ def isolated_model_output(tmp_path_factory):
     return test_root
 
 
+def absent_read_only_inputs(case_study: str) -> list[str]:
+    """The read-only inputs ``isolated_model_output`` found nothing to symlink.
+
+    ``config/`` is tracked. ``features/`` and ``labels/`` are not: they are stage
+    01-05 output, and a maintainer worktree reaches them through
+    ``case_studies/<case study>/{features,labels}`` symlinks into
+    ``~/ml4t/artifacts``. A CI runner has none of those (they are gitignored) and
+    neither does a freshly created worktree, so the fixture links nothing and every
+    notebook fails on its first read with "Missing prerequisites".
+
+    That produced 94 failures naming the notebooks, none of which said anything
+    about a notebook, and a suite whose reds are all environmental is a suite nobody
+    reads. A missing input is a skip, and the skip names the exact directories so it
+    cannot be mistaken for the notebook working.
+    """
+    prod = PROD_CS_DIR / case_study
+    return sorted(subdir for subdir in ("features", "labels") if not (prod / subdir).exists())
+
+
+def test_absent_read_only_inputs_reports_only_what_is_missing(tmp_path, monkeypatch) -> None:
+    """Two-sided, because a skip that swallows a present input is worse than a red.
+
+    The failure this guards is a skip condition that is always true: it would turn
+    all 94 notebook executions green-by-absence and nothing would say so.
+    """
+    monkeypatch.setattr("tests.test_model_registry.PROD_CS_DIR", tmp_path)
+    case = tmp_path / "demo_case"
+    case.mkdir()
+    assert absent_read_only_inputs("demo_case") == ["features", "labels"]
+    (case / "features").mkdir()
+    assert absent_read_only_inputs("demo_case") == ["labels"]
+    (case / "labels").mkdir()
+    assert absent_read_only_inputs("demo_case") == []
+
+
 LOG_PATH = Path("/tmp/model_registry_test.log")
 
 
@@ -463,6 +498,13 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
 
     if overrides.get("skip"):
         pytest.skip(overrides.get("skip_reason", "marked skip in overrides"))
+
+    if absent := absent_read_only_inputs(case_study):
+        pytest.skip(
+            f"case_studies/{case_study}/ has no {', '.join(absent)} to read - stage 01-05 "
+            "output, which a maintainer worktree reaches through a symlink into "
+            "~/ml4t/artifacts and which no CI runner and no fresh worktree has"
+        )
 
     if overrides.get("gpu"):
         try:

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -748,3 +748,174 @@ def test_stamp_accepts_a_notebook_whose_cells_only_have_execution_counts(
     nb = tmp_path / "nb.ipynb"
     nb.write_text(json.dumps(_notebook([cell])), encoding="utf-8")
     assert stamp_notebook(nb, "local-uv", parameters={})["production"] is True
+
+
+# --- The merge gate's scope: what a change is answerable for ------------------
+#
+# `check --since <base>` is what CI runs, so these cover the diff parse the scope is
+# built from. They use a real git repo because the mechanism *is* a `git diff`
+# invocation - rename detection, -z quoting and --diff-filter are the behaviour under
+# test, and a mocked diff would only assert that the mock returns what it was told to.
+
+
+def _git(repo: Path, *args: str) -> str:
+    import subprocess
+
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout
+
+
+def _repo_with_a_paired_notebook(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "chapter").mkdir(parents=True)
+    _git(repo.parent, "init", "-q", str(repo))
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "chapter" / "demo.py").write_text("# %%\nX = 1\n")
+    (repo / "chapter" / "demo.ipynb").write_text(json.dumps({"cells": [], "metadata": {}}))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "paired notebook")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "checkout", "-qb", "topic")
+    return repo
+
+
+def test_deleting_the_source_and_keeping_the_notebook_is_reported(tmp_path, monkeypatch) -> None:
+    """check_all cannot see this by construction.
+
+    Its ``paired_py() is None`` branch cannot tell a notebook that was just orphaned
+    from one that was never paired, and tracked notebooks are deliberately unpaired,
+    so the distinction has to come from the diff.
+    """
+    repo = _repo_with_a_paired_notebook(tmp_path)
+    _git(repo, "rm", "-q", "chapter/demo.py")
+    _git(repo, "commit", "-qm", "drop the source, keep the render")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", repo)
+
+    orphaned = notebook_provenance.notebooks_orphaned_since("main")
+
+    assert len(orphaned) == 1
+    assert "chapter/demo.ipynb" in orphaned[0]
+    assert "chapter/demo.py" in orphaned[0]
+
+
+def test_moving_the_source_leaves_the_notebook_orphaned(tmp_path, monkeypatch) -> None:
+    """The case --no-renames exists for.
+
+    With rename detection on, git reports only the destination and the notebook
+    rendered from the old path goes unmentioned.
+    """
+    repo = _repo_with_a_paired_notebook(tmp_path)
+    _git(repo, "mv", "chapter/demo.py", "chapter/renamed.py")
+    _git(repo, "commit", "-qm", "move the source out from under the notebook")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", repo)
+
+    orphaned = notebook_provenance.notebooks_orphaned_since("main")
+
+    assert len(orphaned) == 1
+    assert "chapter/demo.ipynb" in orphaned[0]
+
+
+def test_deleting_both_halves_is_not_an_orphan(tmp_path, monkeypatch) -> None:
+    """Retiring a notebook properly must stay merge-able."""
+    repo = _repo_with_a_paired_notebook(tmp_path)
+    _git(repo, "rm", "-q", "chapter/demo.py", "chapter/demo.ipynb")
+    _git(repo, "commit", "-qm", "retire the notebook")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", repo)
+
+    assert notebook_provenance.notebooks_orphaned_since("main") == []
+
+
+def test_editing_a_paired_notebook_is_not_an_orphan(tmp_path, monkeypatch) -> None:
+    repo = _repo_with_a_paired_notebook(tmp_path)
+    (repo / "chapter" / "demo.py").write_text("# %%\nX = 2\n")
+    _git(repo, "commit", "-qam", "ordinary edit")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", repo)
+
+    assert notebook_provenance.notebooks_orphaned_since("main") == []
+
+
+def test_a_notebook_name_with_a_space_survives_the_diff_parse(tmp_path, monkeypatch) -> None:
+    """git quotes such a path under plain --name-only.
+
+    Splitting on whitespace then tears it into fragments matching no suffix - the
+    notebook leaves the gate's scope and passes unchecked, which is the one thing a
+    gate must never do.
+    """
+    repo = _repo_with_a_paired_notebook(tmp_path)
+    (repo / "chapter" / "my demo.py").write_text("# %%\nX = 1\n")
+    (repo / "chapter" / "my demo.ipynb").write_text(json.dumps({"cells": [], "metadata": {}}))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "a notebook with a space in its name")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", repo)
+
+    changed = [
+        str(p.relative_to(repo)) for p in notebook_provenance.notebooks_changed_since("main")
+    ]
+
+    assert "chapter/my demo.ipynb" in changed
+
+
+def test_editing_the_paired_py_puts_the_notebook_in_scope(tmp_path, monkeypatch) -> None:
+    """Changing the .py is exactly what makes the rendered notebook stale."""
+    repo = _repo_with_a_paired_notebook(tmp_path)
+    (repo / "chapter" / "demo.py").write_text("# %%\nX = 2\n")
+    _git(repo, "commit", "-qam", "edit the source only")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", repo)
+
+    changed = [
+        str(p.relative_to(repo)) for p in notebook_provenance.notebooks_changed_since("main")
+    ]
+
+    assert changed == ["chapter/demo.ipynb"]
+
+
+def test_a_notebook_nobody_touched_is_out_of_scope(tmp_path, monkeypatch) -> None:
+    """The whole point of scoping: one stale notebook elsewhere is somebody else's."""
+    repo = _repo_with_a_paired_notebook(tmp_path)
+    (repo / "unrelated.txt").write_text("hello\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "touch nothing paired")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", repo)
+
+    assert notebook_provenance.notebooks_changed_since("main") == []
+    assert notebook_provenance.notebooks_orphaned_since("main") == []
+
+
+def test_a_force_push_reverting_a_notebook_is_seen_only_against_the_previous_tip(
+    tmp_path, monkeypatch
+) -> None:
+    """The case ``--no-merge-base`` exists for.
+
+    A pull request asks what a branch adds on top of its base, so it diffs the merge
+    base. A push asks what the published tree *becomes*, and a force-push can revert a
+    notebook relative to the tip it replaces without the merge base ever seeing it: the
+    merge base of the new tip and the old one is their common ancestor, where the revert
+    has not happened yet.
+    """
+    repo = _repo_with_a_paired_notebook(tmp_path)
+    _git(repo, "checkout", "-q", "main")
+    fork = _git(repo, "rev-parse", "HEAD").strip()
+    (repo / "chapter" / "demo.py").write_text("# %%\nX = 2\n")
+    _git(repo, "commit", "-qam", "the edit that was published")
+    previous_tip = _git(repo, "rev-parse", "HEAD").strip()
+
+    # The force-push: main is rewound past the edit and re-grown, so the new tip does
+    # not descend from the old one and carries demo.py back at X = 1.
+    _git(repo, "reset", "-q", "--hard", fork)
+    (repo / "unrelated.txt").write_text("hello\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "rewrite main without the edit")
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", repo)
+
+    merge_base_scope = [
+        str(p.relative_to(repo)) for p in notebook_provenance.notebooks_changed_since(previous_tip)
+    ]
+    assert merge_base_scope == [], "the revert is invisible from the common ancestor"
+
+    against_the_tip = [
+        str(p.relative_to(repo))
+        for p in notebook_provenance.notebooks_changed_since(previous_tip, merge_base=False)
+    ]
+    assert against_the_tip == ["chapter/demo.ipynb"]

--- a/tests/test_quarantine_list.py
+++ b/tests/test_quarantine_list.py
@@ -119,8 +119,8 @@ def test_no_entry_is_both_ignored_and_deselected() -> None:
     )
 
 
-def _modelling_environment_block() -> list[str]:
-    """The entries under the "needs the modelling environment" heading.
+def _section(marker: str) -> list[str]:
+    """The entries under the heading containing *marker*.
 
     Sections in the quarantine file are separated by full-width `# ---` rules, so a
     heading owns every entry until the next one.
@@ -146,7 +146,7 @@ def _modelling_environment_block() -> list[str]:
         if not entry:
             continue
         if heading is not None:
-            mine = any("modelling environment" in h for h in heading)
+            mine = any(marker in h for h in heading)
             heading = None
         if mine:
             block.append(entry)
@@ -162,22 +162,69 @@ def test_the_image_job_runs_exactly_what_is_quarantined_for_it() -> None:
     removed from here it goes red in test-unit for want of torch. That is the same
     exclude-more-than-you-meant failure this whole file exists to catch.
     """
-    quarantined = set(_modelling_environment_block())
-    assert quarantined, "the modelling-environment section of the quarantine file is empty"
+    _assert_section_matches_job(
+        "modelling environment", "  test-unit-image:", "\n  test-chapters:", exclusive=True
+    )
+
+
+def test_the_data_job_runs_exactly_what_is_quarantined_for_it() -> None:
+    """The same decision, for the section that needs the test-data checkout.
+
+    It needed the check more than the image section did. From 2026-08-24 to
+    2026-09-03 this section excluded three files from `test-unit` and named no job
+    that ran them, and `test-unit-data` - which has the dataset they want - did not
+    list them, so they ran nowhere. That is the enumeration defect this whole
+    subtraction replaced, reappearing one level down because the job on the other
+    side of the exclusion still enumerates by hand.
+    """
+    _assert_section_matches_job(
+        "Needs a dataset", "  test-unit-data:", "\n  test-unit-image:", exclusive=False
+    )
+
+
+def _assert_section_matches_job(
+    marker: str, job_header: str, next_header: str, *, exclusive: bool
+) -> None:
+    """Every test a quarantine section excludes is named by the job that takes it.
+
+    Nothing makes "excluded here, run there" true except the two lists agreeing, and a
+    file dropped from the job is invisible from here: it silently runs nowhere. That is
+    the same exclude-more-than-you-meant failure this file exists to catch.
+
+    ``exclusive`` is the other direction, and the two sections differ on it. A
+    modelling-environment file cannot be collected in `test-unit` at all - it raises on
+    the import - so a file the image job runs and this list does not exclude is a red
+    `test-unit`, and the equality holds both ways. A data-dependent file collects fine
+    and *skips*, so `test-unit-data` legitimately runs files that stay in the sweep; the
+    two the job has always run are exactly that. Requiring equality there would demand
+    they be quarantined, which would give up the collection they still provide.
+
+    A `--deselect` in the job is deliberately not counted. The quarantine file says what
+    `test-unit` does not run; a test deselected inside a file the other job *does* run
+    is that job's own business and is justified in the workflow beside it.
+    """
+    quarantined = set(_section(marker))
+    assert quarantined, f"the {marker!r} section of the quarantine file is empty"
 
     workflow = (REPO_ROOT / ".github/workflows/test.yml").read_text()
-    _, _, after = workflow.partition("  test-unit-image:")
-    job, _, _ = after.partition("\n  test-chapters:")
-    assert job, "no test-unit-image job in .github/workflows/test.yml"
+    _, _, after = workflow.partition(job_header)
+    job, _, _ = after.partition(next_header)
+    assert job, f"no {job_header.strip()} job in .github/workflows/test.yml"
     in_job = {
         token
         for line in job.splitlines()
         for token in [line.strip().rstrip("\\").strip()]
-        if token.startswith("tests/") and token.endswith(".py")
+        if token.startswith("tests/") and ".py" in token
     }
 
-    assert quarantined == in_job, (
-        "the quarantine's modelling-environment section and the test-unit-image job "
-        f"disagree.\n  quarantined but not run by the job: {sorted(quarantined - in_job)}"
-        f"\n  run by the job but not quarantined: {sorted(in_job - quarantined)}"
+    assert not (quarantined - in_job), (
+        f"the quarantine's {marker!r} section excludes these from test-unit and the "
+        f"{job_header.strip()} job does not run them, so they run in no job at all: "
+        f"{sorted(quarantined - in_job)}"
     )
+    if exclusive:
+        assert not (in_job - quarantined), (
+            f"the {job_header.strip()} job runs these and the quarantine's {marker!r} "
+            f"section does not exclude them, so test-unit collects them too and goes "
+            f"red on the import: {sorted(in_job - quarantined)}"
+        )

--- a/tests/test_research_workspace.py
+++ b/tests/test_research_workspace.py
@@ -82,7 +82,12 @@ def test_crypto_preview_then_canonical_workspace_isolates_symlinked_inputs(
     (case_root / "config").mkdir()
     (case_root / "config" / "setup.yaml").write_text("evaluation: {}\n")
     (release / "case_studies" / "config").mkdir()
-    monkeypatch.setattr(research_workflow, "REPO_ROOT", release)
+    # The release root is named through the environment rather than by patching the
+    # module's REPO_ROOT: `research_workflow.open_study` no longer passes one, so that
+    # every caller reaches the same resolution - an explicit argument, else
+    # ML4T_RELEASE_ROOT, else REPO_ROOT - and the harness can point a run at a
+    # checkout-shaped tree instead of at the worktree's symlinks into ~/ml4t/artifacts.
+    monkeypatch.setenv("ML4T_RELEASE_ROOT", str(release))
 
     workspace = tmp_path / "workspace"
     preview_study = research_workflow.open_study(execution_tier="preview", workspace=workspace)
@@ -917,3 +922,98 @@ class TestTheSingleRootReadOnlyForm:
         case_dir = release / "case_studies" / "etfs"
 
         assert Study.at(case_dir).case_study == "etfs"
+
+
+def _publish_into_release_registry(release: Path, prediction_hash: str) -> None:
+    """One published prediction in a released registry, written as the registry stores it."""
+    case_dir = release / "case_studies" / "etfs"
+    _open_registry(case_dir).close()
+    # Closed, not merely committed. The registry runs in WAL mode and a released root is
+    # read with `immutable=1`, which tells SQLite to skip WAL recovery - so a row left in
+    # the log rather than checkpointed into the database file is invisible to the read
+    # under test, and the test would pass by not seeing what it is meant to see.
+    db = sqlite3.connect(case_dir / "run_log" / "registry.db")
+    try:
+        db.execute(
+            "INSERT INTO training_runs (training_hash, identity_version, execution_tier, family, "
+            "label, config_name, spec_json, started_at, created_at) "
+            "VALUES ('t-published', 2, 'canonical', 'linear', 'fwd_ret_1d', 'ridge', '{}', "
+            "'2026-09-01T00:00:00', '2026-09-01T00:00:00')"
+        )
+        db.execute(
+            "INSERT INTO prediction_sets (prediction_hash, training_hash, split, created_at) "
+            f"VALUES ('{prediction_hash}', 't-published', 'validation', '2026-09-01T00:00:00')"
+        )
+        db.commit()
+        db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        db.close()
+
+
+def test_the_release_root_defaults_to_the_repository(monkeypatch) -> None:
+    """Unset, nothing moves: a reader and a production run read the checkout they are in."""
+    monkeypatch.delenv("ML4T_RELEASE_ROOT", raising=False)
+    from case_studies.research.workspace import default_release_root
+    from utils.paths import REPO_ROOT as repo_root
+
+    assert default_release_root() == repo_root
+
+
+def test_the_environment_names_the_release_root_a_study_reads(tmp_path: Path, monkeypatch) -> None:
+    """The half of #912 that makes a harness run hermetic.
+
+    `open_study` resolved canonical reads through REPO_ROOT, whose
+    `case_studies/<cs>/run_log` is a symlink into the published registry in every
+    maintainer worktree and does not exist on any CI runner. The overlay itself is the
+    contract and is not in question; which released tree an unqualified caller gets is
+    what made a local run and a CI run read different rows.
+    """
+    release = _seed_release(tmp_path)
+    _publish_into_release_registry(release, "published-1")
+    monkeypatch.setenv("ML4T_RELEASE_ROOT", str(release))
+
+    study = Study.open("etfs", workspace=tmp_path / "workspace")
+
+    assert study.release_root == release
+    assert study.predictions.table()["prediction_hash"].to_list() == ["published-1"]
+
+
+def test_a_named_release_root_still_wins_over_the_environment(tmp_path: Path, monkeypatch) -> None:
+    """Otherwise the variable would silently redirect a caller that named its own root.
+
+    Every research_workflow that used to pass `release_root=REPO_ROOT` explicitly now
+    relies on the default, so the precedence has to be stated rather than assumed.
+    """
+    named = _seed_release(tmp_path)
+    _publish_into_release_registry(named, "from-the-argument")
+    other = _seed_release(tmp_path / "elsewhere")
+    _publish_into_release_registry(other, "from-the-environment")
+    monkeypatch.setenv("ML4T_RELEASE_ROOT", str(other))
+
+    study = Study.open("etfs", workspace=tmp_path / "workspace", release_root=named)
+
+    assert study.release_root == named
+    assert study.predictions.table()["prediction_hash"].to_list() == ["from-the-argument"]
+
+
+def test_a_checkout_shaped_release_root_carries_no_run_log(tmp_path: Path) -> None:
+    """What the harness builds, and the property that makes it hermetic.
+
+    It mirrors `config/` and the tracked top-level files and stops there. No `run_log`
+    is the point - that is the directory a maintainer worktree symlinks into
+    `~/ml4t/artifacts` and a CI checkout does not have at all - and no `features` or
+    `labels`, so `_release_manifest_digest` does not walk an artifact tree it is never
+    asked about.
+    """
+    from tests.conftest import _checkout_shaped_release_root
+
+    release = _checkout_shaped_release_root(tmp_path / "out")
+
+    case_dir = release / "case_studies" / "etfs"
+    assert (case_dir / "config").is_dir()
+    for generated in ("run_log", "features", "labels"):
+        assert not (case_dir / generated).exists(), (
+            f"{generated} must not be reachable through the harness release root, or the "
+            "harness reads the machine's published state again"
+        )
+    assert (release / "case_studies" / "config").is_dir()

--- a/tests/test_sp500_options_underlying_returns.py
+++ b/tests/test_sp500_options_underlying_returns.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
+from pathlib import Path
 
 import numpy as np
 import polars as pl
@@ -12,8 +13,10 @@ from case_studies.sp500_options._underlying_returns import (
     reconcile_underlying_log_returns,
     validate_reconciled_returns,
 )
-from data import load_sp500_daily_bars, load_sp500_options_straddles
-from data.exceptions import DataNotFoundError
+from data import load_sp500_daily_bars
+from data.equities import loader
+
+REPO_ROOT = Path(__file__).parent.parent
 
 TRUE_SPLITS = {
     "FAST": (64.28, 31.34, 2.668525, 5.337051),
@@ -152,12 +155,55 @@ def test_fails_loudly_on_invalid_input_or_boundary_return() -> None:
         validate_reconciled_returns(reconciled)
 
 
-def test_real_option_universe_nulls_all_identity_boundaries() -> None:
-    try:
-        symbols = load_sp500_options_straddles()["symbol"].unique().to_list()
-        bars = load_sp500_daily_bars(symbols=symbols)
-    except DataNotFoundError:
-        pytest.skip("Licensed S&P 500 data is unavailable")
+# Every security-identity change in the shipped bars, by the ticker and session it
+# falls on. The file is tracked (``data/equities/market/sp500/daily_bars.parquet``,
+# redistributed by AlgoSeek's permission), so this set is fixed by construction rather
+# than by whatever the machine running the test happens to hold.
+SHIPPED_IDENTITY_BOUNDARIES = {
+    ("AON", date(2020, 4, 2)),
+    ("APA", date(2021, 3, 2)),
+    ("ARNC", date(2020, 4, 6)),
+    ("DD", date(2019, 6, 3)),
+    ("DIS", date(2019, 6, 3)),
+    ("DLPH", date(2017, 12, 5)),
+    ("DOW", date(2019, 4, 2)),
+    ("FOX", date(2019, 3, 19)),
+    ("FOXA", date(2019, 3, 19)),
+    ("FTI", date(2017, 1, 17)),
+    ("IR", date(2020, 3, 2)),
+    ("STX", date(2021, 5, 19)),
+    ("ULTA", date(2017, 1, 30)),
+    ("XRX", date(2019, 8, 1)),
+    ("ZION", date(2018, 10, 1)),
+}
+
+
+def _shipped_daily_bars(monkeypatch: pytest.MonkeyPatch) -> pl.DataFrame:
+    """The repository's own S&P 500 daily bars, whatever ML4T_DATA_PATH points at.
+
+    ``_bundled`` prefers a copy under ``ML4T_DATA_PATH`` over the tracked one, and the
+    test-data fixture holds a reduced daily-bars file - 29 symbols against 638. So the
+    same assertion measured two different universes depending on the environment: 15
+    boundaries against the tracked file, 1 against the fixture, and a skip in
+    ``test-unit``, where the straddle dataset this test used to take its symbol list
+    from is absent. The invariant is a property of the bars this repository ships, so
+    it is those bars that get read.
+    """
+    monkeypatch.setattr(loader, "ML4T_DATA_PATH", REPO_ROOT / "data")
+    return load_sp500_daily_bars()
+
+
+def test_real_option_universe_nulls_all_identity_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every identity change in the shipped bars is nulled; no real shock is.
+
+    The straddle universe is not what this measures - it only ever supplied a symbol
+    filter, and filtering by it made the count a function of the machine. Naming the
+    boundaries rather than counting them says which reassignments are being caught, so
+    a bar file that gains or loses one reports which.
+    """
+    bars = _shipped_daily_bars(monkeypatch)
 
     reconciled = reconcile_underlying_log_returns(bars)
     boundaries = reconciled.filter(pl.col("identity_boundary"))
@@ -171,8 +217,8 @@ def test_real_option_universe_nulls_all_identity_boundaries() -> None:
         | ((pl.col("symbol") == "DXC") & (pl.col("timestamp") == pl.date(2019, 8, 9)))
     )
 
-    assert boundaries.height == 15
-    assert boundaries["clean_log_return"].null_count() == 15
+    assert set(boundaries.select(["symbol", "timestamp"]).rows()) == SHIPPED_IDENTITY_BOUNDARIES
+    assert boundaries["clean_log_return"].null_count() == boundaries.height
     assert known_splits["clean_log_return"].null_count() == 0
     assert known_splits["clean_log_return"].abs().max() < 0.04
     assert real_shocks["clean_log_return"].null_count() == 0

--- a/tests/test_superseded_members_registries.py
+++ b/tests/test_superseded_members_registries.py
@@ -1,61 +1,303 @@
-"""`superseded_members` against real registries, at four shapes a fixture does not reach.
+"""`superseded_members` against six lineage shapes a simple fixture does not reach.
 
 The unit suite in `test_population_supersedes.py` builds its own populations, and five
 successive forms of this function passed it while being wrong - three returning an empty
 set, one over-retiring, one under-retiring systematically. Every one was caught by a real
-registry or by review, none by the unit suite alone. These are the four registries the
-fleet measured on 2026-08-25, each chosen for a shape the others do not test:
+registry or by review, none by the unit suite alone. So the shapes those registries had
+are what this file is for, and each is kept here as a lineage it builds rather than as a
+number read off a machine:
 
-| case study | retired | what it catches |
-|---|---|---|
-| `etfs` | 364 | Transitive closure. `etfs-gbm-validation-v1` runs four generations, `linear` and `ipca` three each, so a form that finds the first edge and stops under-reports. Was 324 until 2026-08-28, when `09_dl_lstm` refit and `etfs-lstm-validation-v1` retired its 40 members in one edge (`1c04632dec9c` -> `9d09b33a058c`); the difference is that edge exactly. |
-| `us_firm_characteristics` | 135 | Four independent single-hop chains with uneven counts (30/3/30/72), so a form that stops at one chain misses the rest and an over-retiring form cannot coincidentally match. |
-| `sp500_equity_option_analytics` | 123 | A doubled catalog, visible directly: 915 prediction rows = 792 live + 123 retired, zero overlap. |
-| `crypto_perps_funding` | 400 | The edge outlives the rows. Its refit deleted generation A's `prediction_sets` rows and only the `official_population_members` record survives, so a form reading supersession out of `prediction_sets` returns empty here and correct on the other three. |
-| `cme_futures` | 656 | A live population lists retired members. Four dead names left by two renames are in force under their own names and hold 178 identities that `linear` and `gbm` have refit past, so the global reading - retired by someone, listed by nobody in force - un-retires all 178 and the per-name reading does not. |
-| `nasdaq100_microstructure` | 150 | A superseded generation that retires nothing. Its `linear-validation-v1` refit grew 16 members to 61 and re-listed all 16, so those 16 are superseded and still published; only `gbm-validation-v1` retires (150 of 150). A form comparing whole generations rather than members returns 166 - isolated to one edge here, where `etfs` shows the same defect only as a total. Added 2026-08-27. |
+| shape | measured on | retires | what it catches |
+|---|---|---:|---|
+| `transitive_closure` | `etfs` 2026-08-25 | 30 | Four generations under one name. A form that finds the first edge and stops under-reports. |
+| `independent_chains` | `us_firm_characteristics` 2026-08-25 | 135 | Four single-hop chains with uneven counts (30/3/30/72), so a form that stops at one chain misses the rest and an over-retiring form cannot coincidentally match. |
+| `doubled_catalog` | `sp500_equity_option_analytics` 2026-08-25 | 123 | A doubled catalog: 915 prediction rows = 792 live + 123 retired, zero overlap. |
+| `edge_outlives_rows` | `crypto_perps_funding` 2026-08-25 | 400 | The refit deleted generation A's `prediction_sets` rows and only the `official_population_members` record survives, so a form reading supersession out of `prediction_sets` returns empty here and correct on the others. |
+| `dead_name_in_force` | `cme_futures` 2026-08-25 | 656 | A live population lists retired members. Four dead names left by two renames are in force under their own names and hold 178 identities that `linear` and `gbm` have refit past, so the global reading - retired by someone, listed by nobody in force - un-retires all 178 and the per-name reading does not. |
+| `re_listed_generation` | `nasdaq100_microstructure` 2026-08-27 | 150 | A superseded generation that retires nothing. `linear-validation-v1` grew 16 members to 61 and re-listed all 16, so those 16 are superseded and still published; only `gbm-validation-v1` retires (150 of 150). A form comparing whole generations rather than members returns 166. |
 
-`crypto_perps_funding` is why this file exists rather than a single spot check: three of the
-others would let a wrong implementation look right, and its reading clean is not evidence the
-filter is unnecessary there - exposure is decided by whether a refit deleted or layered, never
-by the notebook.
+**Why the shapes are built rather than read.** These were six assertions against the
+canonical registries under `~/ml4t/artifacts`, which are shared, mutable and reset before
+every retrain, so each count went red the moment anyone retrained and every agent learned to
+read a red `test-unit` as environmental. That is the habit that lets a real failure through.
+It is not a hypothetical drift either: measured 2026-09-03, `cme_futures` and
+`crypto_perps_funding` hold **no supersedes edge at all** - their run logs were reset, every
+population is an unsuperseded tip, and `superseded_members` correctly returns nothing there.
+Two of the six shapes had ceased to exist in the registries the file was reading, so those
+assertions had stopped testing the function some time before anyone noticed. A shape that is
+built is fixed by construction, runs on a CI runner that has no `~/ml4t/artifacts`, and stays
+the shape it was measured as.
 
-`cme_futures` is here for the *other* decision in this function: that retirement is asked per
-name. Under the global reading - retired by someone, listed by nobody in force - `etfs`,
-`us_firm_characteristics` and `sp500_equity_option_analytics` all still read correctly, so
-without a registry that overlaps, half of what this function decides is untested. Its dead
-names are not a hypothetical stale snapshot; they are two renames' worth of leftovers, in
-force in the only sense the registry has, which is that nothing supersedes them. They list
-178 identities `linear` and `gbm` have refit past, and the global reading stops counting
-those as retired - so a sweep runs over two generations with nothing about the run looking
-wrong. `crypto_perps_funding` happens to overlap too, for an unrelated reason, which is why
-the assertion below is on the named cause rather than on a count.
-
-Skipped where the artifacts are not present, which is every CI runner: these read the
-canonical production registries under `~/ml4t/artifacts`, not the test fixture.
+**Why a built shape is not the fixture that let five wrong forms through.** That suite built
+*simple* populations - one name, one edge - and the wrong forms agree with the right one
+there. What separates them is structure, and structure is what is transcribed below.
+`test_every_wrong_form_is_separated_by_some_shape` holds the four wrong readings as
+executable functions and requires each to be caught, so the discriminating power is asserted
+rather than asserted-about: delete a shape and that test says which reading stops being
+covered.
 """
 
 from __future__ import annotations
 
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
 from case_studies.research.population import superseded_members, superseded_members_at
 
-ARTIFACTS = Path.home() / "ml4t" / "artifacts" / "case_studies"
 
-# Measured 2026-08-25, each by the pane that owns that case study.
-RETIRED_PREDICTIONS = {
-    "etfs": 364,
-    "us_firm_characteristics": 135,
-    "sp500_equity_option_analytics": 123,
-    "crypto_perps_funding": 400,
-    "cme_futures": 656,
-    # Added 2026-08-27.
-    "nasdaq100_microstructure": 150,
+@dataclass(frozen=True)
+class Generation:
+    """One published generation: what it is called, what it lists, what it replaced."""
+
+    name: str
+    population_hash: str
+    supersedes_hash: str | None
+    members: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Shape:
+    """A lineage, and the answer it must produce.
+
+    ``registered`` is what ``prediction_sets`` holds. It is not the union of the members:
+    a refit may delete the rows of the generation it replaced and keep only the membership
+    record, which is the whole of ``edge_outlives_rows``.
+    """
+
+    why: str
+    generations: tuple[Generation, ...]
+    retired: frozenset[str]
+    registered: frozenset[str]
+
+
+def _ids(prefix: str, count: int, *, start: int = 0) -> tuple[str, ...]:
+    """``count`` distinct twelve-character member hashes, stable across runs."""
+    return tuple(f"{prefix}{index:08d}" for index in range(start, start + count))
+
+
+def _chain(name: str, generations: list[tuple[str, tuple[str, ...]]]) -> list[Generation]:
+    """A single name's generations, each superseding the one before it."""
+    built: list[Generation] = []
+    previous: str | None = None
+    for population_hash, members in generations:
+        built.append(Generation(name, population_hash, previous, members))
+        previous = population_hash
+    return built
+
+
+def _shape_transitive_closure() -> Shape:
+    """`etfs`: one name, four generations, each replacing the last outright."""
+    a, b, c, d = (_ids("e", 10, start=index * 10) for index in range(4))
+    generations = _chain(
+        "etfs-gbm-validation-v1",
+        [("e0000000a", a), ("e0000000b", b), ("e0000000c", c), ("e0000000d", d)],
+    )
+    return Shape(
+        why="a form that follows one edge and stops reports 10 of the 30",
+        generations=tuple(generations),
+        retired=frozenset(a + b + c),
+        registered=frozenset(a + b + c + d),
+    )
+
+
+def _shape_independent_chains() -> Shape:
+    """`us_firm_characteristics`: four names, one edge each, uneven counts."""
+    generations: list[Generation] = []
+    retired: set[str] = set()
+    registered: set[str] = set()
+    for index, (family, count) in enumerate(
+        [("cae", 30), ("ipca", 3), ("sae", 30), ("tabular_dl", 72)]
+    ):
+        old = _ids(f"u{index}o", count)
+        new = _ids(f"u{index}n", count)
+        generations += _chain(
+            f"us_firm_characteristics-{family}-validation-v1",
+            [(f"u{index}0000000", old), (f"u{index}1000000", new)],
+        )
+        retired |= set(old)
+        registered |= set(old) | set(new)
+    return Shape(
+        why="a form that stops at the first chain reports at most 72 of the 135",
+        generations=tuple(generations),
+        retired=frozenset(retired),
+        registered=frozenset(registered),
+    )
+
+
+def _shape_doubled_catalog() -> Shape:
+    """`sp500_equity_option_analytics`: both generations complete and current."""
+    old = _ids("s0", 123)
+    new = _ids("s1", 792)
+    generations = _chain(
+        "sp500_equity_option_analytics-sdf-validation-v1",
+        [("s000000000", old), ("s100000000", new)],
+    )
+    return Shape(
+        why="915 catalog rows are 792 live plus 123 retired, and a sweep on the catalog "
+        "alone takes both",
+        generations=tuple(generations),
+        retired=frozenset(old),
+        registered=frozenset(old) | frozenset(new),
+    )
+
+
+def _shape_edge_outlives_rows() -> Shape:
+    """`crypto_perps_funding`: the refit deleted the rows and kept the edge."""
+    old = _ids("c0", 400)
+    new = _ids("c1", 400)
+    generations = _chain(
+        "crypto_perps_funding-gbm-validation-v1",
+        [("c000000000", old), ("c100000000", new)],
+    )
+    return Shape(
+        why="nothing of generation A is left in prediction_sets, so a form reading "
+        "supersession out of the rows returns nothing retired",
+        generations=tuple(generations),
+        retired=frozenset(old),
+        registered=frozenset(new),
+    )
+
+
+def _shape_dead_name_in_force() -> Shape:
+    """`cme_futures`: two renames left four names in force listing retired identities.
+
+    The dead names were never superseded - a rename does not supersede anything - so they
+    stand behind the members they listed on the day they were published, including the 178
+    that `linear` and `gbm` have since refit past.
+    """
+    linear_old, linear_new = _ids("m0o", 328), _ids("m0n", 328)
+    gbm_old, gbm_new = _ids("m1o", 328), _ids("m1n", 328)
+    generations = _chain(
+        "cme_futures-linear-validation-v1",
+        [("m000000000", linear_old), ("m010000000", linear_new)],
+    ) + _chain(
+        "cme_futures-gbm-validation-v1",
+        [("m100000000", gbm_old), ("m110000000", gbm_new)],
+    )
+    # The four leftovers, in force, between them listing 178 of the retired identities.
+    leftovers = [
+        ("cme_futures-linear-validation-v0", "m200000000", linear_old[:50]),
+        ("cme_futures-linear-preflight-v1", "m210000000", linear_old[50:89]),
+        ("cme_futures-gbm-validation-v0", "m300000000", gbm_old[:50]),
+        ("cme_futures-gbm-preflight-v1", "m310000000", gbm_old[50:89]),
+    ]
+    generations += [
+        Generation(name, population_hash, None, members)
+        for name, population_hash, members in leftovers
+    ]
+    return Shape(
+        why="the global reading un-retires the 178 identities a dead name still lists",
+        generations=tuple(generations),
+        retired=frozenset(linear_old + gbm_old),
+        registered=frozenset(linear_old + linear_new + gbm_old + gbm_new),
+    )
+
+
+def _shape_re_listed_generation() -> Shape:
+    """`nasdaq100_microstructure`: one edge retires everything, the other nothing."""
+    gbm_old = _ids("n0o", 150)
+    gbm_new = _ids("n0n", 500)
+    linear_old = _ids("n1o", 16)
+    linear_new = linear_old + _ids("n1n", 45)
+    generations = _chain(
+        "nasdaq100_microstructure-gbm-validation-v1",
+        [("n000000000", gbm_old), ("n010000000", gbm_new)],
+    ) + _chain(
+        "nasdaq100_microstructure-linear-validation-v1",
+        [("n100000000", linear_old), ("n110000000", linear_new)],
+    )
+    return Shape(
+        why="retiring superseded generations wholesale reports 166, which retires 16 "
+        "identities linear-validation-v1 still publishes",
+        generations=tuple(generations),
+        retired=frozenset(gbm_old),
+        registered=frozenset(gbm_old + gbm_new + linear_new),
+    )
+
+
+SHAPES: dict[str, Shape] = {
+    "transitive_closure": _shape_transitive_closure(),
+    "independent_chains": _shape_independent_chains(),
+    "doubled_catalog": _shape_doubled_catalog(),
+    "edge_outlives_rows": _shape_edge_outlives_rows(),
+    "dead_name_in_force": _shape_dead_name_in_force(),
+    "re_listed_generation": _shape_re_listed_generation(),
 }
+
+# The counts the registries were measured at, kept because the table in the docstring is
+# the record of what each shape is. A shape edited without its row being edited fails here
+# rather than quietly measuring something else.
+RETIRED_PREDICTIONS = {
+    "transitive_closure": 30,
+    "independent_chains": 135,
+    "doubled_catalog": 123,
+    "edge_outlives_rows": 400,
+    "dead_name_in_force": 656,
+    "re_listed_generation": 150,
+}
+
+
+def _write_registry(root: Path, shape: Shape) -> Path:
+    """Write `shape` into a registry at `root`, in the schema the readers query."""
+    run_log = root / "run_log"
+    run_log.mkdir(parents=True, exist_ok=True)
+    db_path = run_log / "registry.db"
+    with sqlite3.connect(db_path) as db:
+        db.executescript(
+            """
+            CREATE TABLE official_populations (
+                population_hash  TEXT PRIMARY KEY,
+                name             TEXT NOT NULL,
+                member_kind      TEXT NOT NULL,
+                snapshot_json    TEXT NOT NULL,
+                supersedes_hash  TEXT REFERENCES official_populations(population_hash),
+                created_at       TEXT NOT NULL
+            );
+            CREATE TABLE official_population_members (
+                population_hash TEXT NOT NULL REFERENCES official_populations(population_hash),
+                member_hash     TEXT NOT NULL,
+                ordinal         INTEGER NOT NULL,
+                PRIMARY KEY (population_hash, ordinal),
+                UNIQUE (population_hash, member_hash)
+            );
+            CREATE TABLE prediction_sets (
+                prediction_hash     TEXT PRIMARY KEY,
+                training_hash       TEXT NOT NULL,
+                checkpoint_value    INTEGER,
+                checkpoint_kind     TEXT,
+                split               TEXT NOT NULL,
+                created_at          TEXT NOT NULL
+            );
+            """
+        )
+        for generation in shape.generations:
+            db.execute(
+                "INSERT INTO official_populations VALUES (?, ?, 'prediction', '{}', ?, "
+                "'2026-08-25T00:00:00')",
+                (generation.population_hash, generation.name, generation.supersedes_hash),
+            )
+            db.executemany(
+                "INSERT INTO official_population_members VALUES (?, ?, ?)",
+                [
+                    (generation.population_hash, member, ordinal)
+                    for ordinal, member in enumerate(generation.members)
+                ],
+            )
+        db.executemany(
+            "INSERT INTO prediction_sets VALUES (?, 't', NULL, NULL, 'validation', "
+            "'2026-08-25T00:00:00')",
+            [(member,) for member in sorted(shape.registered)],
+        )
+    return root
+
+
+@pytest.fixture
+def registry(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
+    """The case directory for the shape named by the test's parameter."""
+    return _write_registry(tmp_path / request.param, SHAPES[request.param])
 
 
 class _SingleRootStudy:
@@ -75,155 +317,255 @@ class _SingleRootStudy:
         return self.root
 
 
-def _study(case_study: str) -> _SingleRootStudy:
-    root = ARTIFACTS / case_study
-    if not (root / "run_log" / "registry.db").exists():
-        pytest.skip(f"no production registry for {case_study} on this machine")
-    return _SingleRootStudy(root)
+# The four readings that are wrong, written out so a shape's claim to separate one is
+# executable rather than a comment. Each takes the lineage in the form `_lineage` returns.
 
 
-@pytest.mark.parametrize(("case_study", "expected"), sorted(RETIRED_PREDICTIONS.items()))
-def test_retired_prediction_count(case_study: str, expected: int) -> None:
-    assert len(superseded_members(_study(case_study), member_kind="prediction")) == expected
+def _by_name(
+    rows: list[tuple[str, str, str | None]],
+) -> dict[str, list[tuple[str, str | None]]]:
+    grouped: dict[str, list[tuple[str, str | None]]] = {}
+    for population_hash, name, supersedes in rows:
+        grouped.setdefault(name, []).append((population_hash, supersedes))
+    return grouped
+
+
+def _wrong_one_edge_only(rows, members) -> frozenset[str]:
+    """Retire only the generation the tip directly replaced."""
+    retired: set[str] = set()
+    for generations in _by_name(rows).values():
+        superseded = {s for _, s in generations if s is not None}
+        for population_hash, supersedes in generations:
+            if population_hash not in superseded and supersedes is not None:
+                retired |= members.get(supersedes, set())
+    return frozenset(retired)
+
+
+def _wrong_first_chain_only(rows, members) -> frozenset[str]:
+    """Answer for one name and stop."""
+    for name in sorted(_by_name(rows)):
+        answer = _wrong_whole_generation(
+            [row for row in rows if row[1] == name],
+            members,
+        )
+        if answer:
+            return answer
+    return frozenset()
+
+
+def _wrong_global(rows, members) -> frozenset[str]:
+    """Retired by someone, and listed by nobody in force - across all names at once."""
+    superseded = {row[2] for row in rows if row[2] is not None}
+    in_force = {row[0] for row in rows if row[0] not in superseded}
+    listed = set().union(*(members.get(h, set()) for h in in_force)) if in_force else set()
+    retired_somewhere = (
+        set().union(*(members.get(h, set()) for h in superseded)) if superseded else set()
+    )
+    return frozenset(retired_somewhere - listed)
+
+
+def _wrong_whole_generation(rows, members) -> frozenset[str]:
+    """Retire every member of a superseded generation, re-listed or not."""
+    superseded = {row[2] for row in rows if row[2] is not None}
+    return frozenset(
+        set().union(*(members.get(h, set()) for h in superseded)) if superseded else set()
+    )
+
+
+def _wrong_from_prediction_rows(rows, members, registered: frozenset[str]) -> frozenset[str]:
+    """Derive supersession from the rows rather than from the membership record."""
+    return frozenset(_wrong_whole_generation(rows, members) & registered)
+
+
+# Each wrong reading, and the one shape whose job is to separate it. Naming the shape is
+# what keeps a shape load-bearing: flatten `re_listed_generation` and the whole-generation
+# row fails, rather than another shape quietly covering for it.
+WRONG_FORMS = {
+    "one edge only": (_wrong_one_edge_only, "transitive_closure"),
+    "first chain only": (_wrong_first_chain_only, "independent_chains"),
+    "global reading": (_wrong_global, "dead_name_in_force"),
+    "whole generation": (_wrong_whole_generation, "re_listed_generation"),
+}
+
+
+def _lineage_of(shape: Shape) -> tuple[list[tuple[str, str, str | None]], dict[str, set[str]]]:
+    rows = [(g.population_hash, g.name, g.supersedes_hash) for g in shape.generations]
+    members = {g.population_hash: set(g.members) for g in shape.generations}
+    return rows, members
+
+
+@pytest.mark.parametrize("registry", sorted(SHAPES), indirect=True)
+def test_retired_prediction_count(registry: Path) -> None:
+    """The retired set is exactly the one the shape was measured to have.
+
+    Both the identities and the count: a count alone is satisfied by an over-retiring form
+    that happens to land on the same total, which is the coincidence
+    `independent_chains` exists to rule out.
+    """
+    shape = SHAPES[registry.name]
+    retired = superseded_members(_SingleRootStudy(registry), member_kind="prediction")
+    assert retired == shape.retired
+    assert len(retired) == RETIRED_PREDICTIONS[registry.name]
+
+
+@pytest.mark.parametrize("registry", sorted(SHAPES), indirect=True)
+def test_retired_members_were_registered_and_are_not_still_published(registry: Path) -> None:
+    """The invariant behind the counts, asserted on every shape.
+
+    Retirement is a claim about identities the registry knows, and nothing a name still
+    stands behind may be in it. `dead_name_in_force` is why the second half is stated
+    against the generations of the *publishing* name rather than against every population
+    in force: a population left over by a rename does list retired identities, and that is
+    the reading this function exists to refuse.
+    """
+    shape = SHAPES[registry.name]
+    rows, members = _lineage_of(shape)
+    retired = superseded_members(_SingleRootStudy(registry), member_kind="prediction")
+
+    every_member = set().union(*members.values())
+    assert retired <= every_member
+
+    for generations in _by_name(rows).values():
+        superseded = {s for _, s in generations if s is not None}
+        published = set().union(
+            *(members[h] for h, _ in generations if h not in superseded),
+            set(),
+        )
+        assert not (published & retired & set().union(*(members[h] for h in superseded), set())), (
+            "a name is listing identities it also retired, which no reading of the lineage allows"
+        )
+
+
+@pytest.mark.parametrize(
+    ("form", "wrong", "shape_name"), [(k, *v) for k, v in sorted(WRONG_FORMS.items())]
+)
+def test_a_named_shape_separates_each_wrong_form(form: str, wrong, shape_name: str) -> None:
+    """Each wrong reading is caught, by the shape that is here to catch it.
+
+    This is what a built lineage has to earn that a read one had for free. Flattening a
+    shape while editing it shows up here as the reading it was carrying, rather than as
+    six tests that still pass because another shape happens to cover it.
+    """
+    shape = SHAPES[shape_name]
+    assert wrong(*_lineage_of(shape)) != shape.retired, (
+        f"{shape_name} no longer distinguishes the {form!r} reading from the right one"
+    )
+
+
+def test_the_prediction_row_reading_is_separated_by_the_deleted_generation() -> None:
+    """`edge_outlives_rows` is the only shape where the rows and the record disagree.
+
+    A form deriving supersession from `prediction_sets` returns nothing retired there and
+    is right everywhere else, so it is the one wrong reading that needs a shape built
+    around a deletion rather than around a lineage.
+    """
+    shape = SHAPES["edge_outlives_rows"]
+    rows, members = _lineage_of(shape)
+    assert _wrong_from_prediction_rows(rows, members, shape.registered) == frozenset()
+    assert shape.retired
 
 
 def test_a_retired_generation_and_the_live_catalog_do_not_overlap() -> None:
     """What the doubling looks like from the catalog's side.
 
-    `sp500_equity_option_analytics` holds both generations as complete, current rows, so
-    the count a backtest would sweep is the sum. Asserting the disjointness rather than
-    the totals is what says the retired set is a clean second generation and not an
-    arbitrary subset.
+    `doubled_catalog` holds both generations as complete, current rows, so the count a
+    backtest would sweep is the sum. Asserting the disjointness rather than the totals is
+    what says the retired set is a clean second generation and not an arbitrary subset.
 
-    The disjointness has to be stated against the generations in force, not against the
-    catalog. `len(registered - retired) == len(registered) - len(retired)` follows from
+    `len(registered - retired) == len(registered) - len(retired)` follows from
     `retired <= registered` by counting alone: it holds for any subset whatsoever and
-    cannot fail, so it asserted nothing. What is worth checking is that nothing this name
-    still publishes is also something it retired - which `cme_futures` shows is not a
-    given, since a population left in force by a rename can list retired identities.
+    cannot fail, so it asserts nothing. What is worth checking is that nothing this name
+    still publishes is also something it retired.
     """
-    study = _study("sp500_equity_option_analytics")
-    retired = superseded_members(study, member_kind="prediction")
-    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
-        registered = {row[0] for row in db.execute("SELECT prediction_hash FROM prediction_sets")}
-        rows = db.execute(
-            "SELECT population_hash, supersedes_hash FROM official_populations "
-            "WHERE member_kind = 'prediction'"
-        ).fetchall()
-        members: dict[str, set[str]] = {}
-        for population_hash, member_hash in db.execute(
-            "SELECT population_hash, member_hash FROM official_population_members"
-        ):
-            members.setdefault(population_hash, set()).add(member_hash)
+    shape = SHAPES["doubled_catalog"]
+    rows, members = _lineage_of(shape)
+    retired = shape.retired
 
     assert retired
-    assert retired <= registered
-    superseded = {row[1] for row in rows if row[1] is not None}
+    assert retired <= shape.registered
+    assert len(shape.registered) == 915
+    superseded = {row[2] for row in rows if row[2] is not None}
     in_force = {row[0] for row in rows if row[0] not in superseded}
-    live = set().union(*(members.get(h, set()) for h in in_force))
-    assert live
+    live = set().union(*(members[h] for h in in_force))
+    assert len(live) == 792
     assert not (live & retired)
 
 
-def test_an_edge_outlives_the_rows_it_retired() -> None:
-    """`crypto_perps_funding` deleted the rows and kept the membership record.
+def test_an_edge_outlives_the_rows_it_retired(tmp_path: Path) -> None:
+    """`edge_outlives_rows`: the refit deleted the rows and kept the membership record.
 
     Nothing of generation A is left in `prediction_sets`; only
     `official_population_members` still lists it, which is what keeps the edge readable as
     history. A form that derives supersession from the prediction rows returns empty here
     and correct everywhere else, which is the failure this case exists to catch.
     """
-    study = _study("crypto_perps_funding")
-    retired = superseded_members(study, member_kind="prediction")
+    shape = SHAPES["edge_outlives_rows"]
+    root = _write_registry(tmp_path / "edge_outlives_rows", shape)
+    retired = superseded_members(_SingleRootStudy(root), member_kind="prediction")
     assert retired
-    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
+    with sqlite3.connect(root / "run_log" / "registry.db") as db:
         registered = {row[0] for row in db.execute("SELECT prediction_hash FROM prediction_sets")}
     assert not (retired & registered)
 
 
-def test_a_dead_name_still_in_force_does_not_un_retire_what_it_lists() -> None:
-    """`cme_futures` measures the per-name rule against a registry that defeats the global one.
+def test_a_dead_name_still_in_force_does_not_un_retire_what_it_lists(tmp_path: Path) -> None:
+    """`dead_name_in_force` measures the per-name rule against a lineage that defeats the global one.
 
-    Its `linear` and `gbm` populations were published three times under two earlier names
-    before the current one, and those earlier names were never superseded - a rename leaves
-    them in force, listing members their producer has since refit past. So the two readings
-    disagree here by construction, and the disagreement is exactly the overlap asserted
-    below: identities that are retired under the name that published them and listed by a
-    population nothing supersedes.
+    `linear` and `gbm` were published under earlier names before the current one, and those
+    earlier names were never superseded - a rename leaves them in force, listing members
+    their producer has since refit past. So the two readings disagree by construction, and
+    the disagreement is exactly the overlap asserted below: identities that are retired
+    under the name that published them and listed by a population nothing supersedes.
 
     The assertion is on the overlap being non-empty, not on its size, because the size is a
     property of how many configurations were fitted and would move under a re-run; that a
-    dead name lists retired members at all is the property this registry contributes.
+    dead name lists retired members at all is the property this shape contributes.
     """
-    study = _study("cme_futures")
-    retired = superseded_members(study, member_kind="prediction")
+    shape = SHAPES["dead_name_in_force"]
+    root = _write_registry(tmp_path / "dead_name_in_force", shape)
+    rows, members = _lineage_of(shape)
+    retired = superseded_members(_SingleRootStudy(root), member_kind="prediction")
     assert retired
 
-    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
-        rows = db.execute(
-            "SELECT population_hash, name, supersedes_hash FROM official_populations "
-            "WHERE member_kind = 'prediction'"
-        ).fetchall()
-        members: dict[str, set[str]] = {}
-        for population_hash, member_hash in db.execute(
-            "SELECT population_hash, member_hash FROM official_population_members"
-        ):
-            members.setdefault(population_hash, set()).add(member_hash)
-
     superseded = {row[2] for row in rows if row[2] is not None}
-    in_force = {h for h, _, _ in rows if h not in superseded}
-    listed_by_something_in_force = set().union(*(members.get(h, set()) for h in in_force))
+    in_force = {row[0] for row in rows if row[0] not in superseded}
+    listed_by_something_in_force = set().union(*(members[h] for h in in_force))
 
     # The global reading keeps only what nothing in force still lists. The per-name reading
     # is what `superseded_members` returns, and here the two differ.
-    global_reading = retired - listed_by_something_in_force
-    assert global_reading < retired, "no live population lists a retired identity"
+    assert _wrong_global(rows, members) < retired, "no live population lists a retired identity"
 
     un_retired = retired & listed_by_something_in_force
-    holders = {name for h, name, _ in rows if h in in_force and members.get(h, set()) & un_retired}
-    assert holders, "the overlap has no holder, so this registry no longer tests the rule"
+    assert len(un_retired) == 178
+    holders = {name for h, name, _ in rows if h in in_force and members[h] & un_retired}
+    assert holders, "the overlap has no holder, so this shape no longer tests the rule"
     assert all(
         name not in ("cme_futures-linear-validation-v1", "cme_futures-gbm-validation-v1")
         for name in holders
     ), "a name is listing identities it also retired, which no reading of the lineage allows"
 
 
-def test_a_superseded_generation_whose_members_are_all_re_listed_retires_none() -> None:
+def test_a_superseded_generation_whose_members_are_all_re_listed_retires_none(
+    tmp_path: Path,
+) -> None:
     """The case that separates member-wise comparison from whole-generation comparison.
 
-    `nasdaq100_microstructure` carries two supersedes edges. `gbm-validation-v1` replaced 150
-    members with a disjoint 500 and retires all 150. `linear-validation-v1` grew 16 members to
-    61 and kept every one of the 16, so its superseded generation retires nothing at all - the
-    name moved past that *snapshot*, not past those identities.
+    `re_listed_generation` carries two supersedes edges. `gbm-validation-v1` replaced 150
+    members with a disjoint 500 and retires all 150. `linear-validation-v1` grew 16 members
+    to 61 and kept every one of the 16, so its superseded generation retires nothing at all
+    - the name moved past that *snapshot*, not past those identities.
 
-    A form that retires a superseded generation wholesale returns 166 here. Measured
-    2026-08-27, `etfs` also moves under that form and the other three do not, so this is the
-    second of two registries that separate them - and the only one where the difference is a
-    single edge with a stated cause, rather than a total across four generations.
+    A form that retires a superseded generation wholesale returns 166 here.
     """
-    study = _study("nasdaq100_microstructure")
-    retired = superseded_members(study, member_kind="prediction")
+    shape = SHAPES["re_listed_generation"]
+    root = _write_registry(tmp_path / "re_listed_generation", shape)
+    rows, members = _lineage_of(shape)
+    retired = superseded_members(_SingleRootStudy(root), member_kind="prediction")
     assert len(retired) == 150
 
-    with sqlite3.connect(study.root / "run_log" / "registry.db") as db:
-        generations = db.execute(
-            "SELECT population_hash, name, supersedes_hash FROM official_populations "
-            "WHERE member_kind = 'prediction'"
-        ).fetchall()
-        members = {
-            population_hash: {
-                row[0]
-                for row in db.execute(
-                    "SELECT member_hash FROM official_population_members WHERE population_hash = ?",
-                    (population_hash,),
-                )
-            }
-            for population_hash, _, _ in generations
-        }
-
-    superseded = {row[2] for row in generations if row[2] is not None}
+    superseded = {row[2] for row in rows if row[2] is not None}
     assert len(superseded) == 2, "both names must have refit for this case to be the one described"
-    wholesale = set().union(*(members[population_hash] for population_hash in superseded))
+    wholesale = _wrong_whole_generation(rows, members)
     assert len(wholesale) == 166
     assert retired < wholesale, (
         "retiring superseded generations wholesale would retire 16 identities that "
@@ -231,7 +573,8 @@ def test_a_superseded_generation_whose_members_are_all_re_listed_retires_none() 
     )
 
 
-def test_superseded_members_at_answers_for_the_root_it_is_given() -> None:
+@pytest.mark.parametrize("registry", sorted(SHAPES), indirect=True)
+def test_superseded_members_at_answers_for_the_root_it_is_given(registry: Path) -> None:
     """The root-based form a notebook uses when it holds a directory and no study.
 
     `14_backtest` reads its catalog through `prediction_rows_at(CASE_DIR)` precisely so that
@@ -240,9 +583,8 @@ def test_superseded_members_at_answers_for_the_root_it_is_given() -> None:
     selected, so the retired set and the catalog it filters could describe different
     registries. Same reduction, same answer, one named root.
     """
-    study = _study("nasdaq100_microstructure")
-    assert superseded_members_at(study.root, member_kind="prediction") == superseded_members(
-        study, member_kind="prediction"
+    assert superseded_members_at(registry, member_kind="prediction") == superseded_members(
+        _SingleRootStudy(registry), member_kind="prediction"
     )
 
 


### PR DESCRIPTION
Nine CI-blocking infrastructure defects, closed. Each commit stands on its own measurement; the
short version is what each one changes about what CI actually checks.

## What was not being checked, and now is

**The provenance gate never gated a merge.** It ran from `.pre-commit-config.yaml` and nowhere else -
`grep -rn notebook_provenance .github/workflows/` returned nothing - so it fired on every local
commit and on nothing that publishes. `check --since REF` scopes the scan to the notebooks a change
touched and runs in `guards` on the pull request, and against the previous tip on a push to `main`.
Five ways the scope leaked come with it: a NUL-delimited diff (a notebook with a space in its name
silently left scope and passed unchecked), `--no-renames` (a moved `.py` hid the notebook it staled),
the previous-tip diff (a force-push can revert a notebook relative to a tip the merge base never
sees), and an orphan check for a change that deletes a `.py` and keeps its `.ipynb`, which
`check_all` cannot see by construction. Safe to turn on today: `check` over the whole tree reports
0 stale, 0 test-mode, 0 contradicted.

**Three test files ran in no CI job.** `test-unit` sweeps `tests/` minus a written-down quarantine,
but the jobs on the other side of an exclusion still enumerate by hand, and the "needs a dataset"
section named no job at all. `tests/test_artifact_specs.py`, `tests/test_backtest_presets.py` and
`tests/test_etf_baseline_parity.py` were excluded on 2026-08-24 and never picked up by
`test-unit-data`, which has the dataset. They run there now - 35 passed, 0 skipped, up from 14 - and
a new test keeps the section and the job in step, the way the modelling-environment section is
already kept in step with `test-unit-image`.

**The stage-03 holdout seal was checked only by executing the notebook.** Eight of the nine stage-03
notebooks rebuild the feature panel with the holdout withheld and require every emitted column to
reproduce the full build. Nothing asserted the source still contained that, so an edit could delete
it and every static gate stayed green - the failure `tests/test_holdout_boundary.py`'s own docstring
records against the 2026-07-21 revert. `RECONSTRUCTION_SEALED_NOTEBOOKS` is the second list that
file needed, checked through the AST and verified two-sided against four mutations.

## Three tests that were red for reasons that were not about the code

Each failed rather than skipped on an input that could not exercise it, which is the habit that lets
a real failure through.

- **`test_real_option_universe_nulls_all_identity_boundaries`** took its symbol list from a licensed
  dataset and asserted a count against whatever bars that selected. It *skipped* in `test-unit` and
  *failed* `1 == 15` against the test-data fixture, whose reduced `daily_bars.parquet` (29 symbols)
  shadows the tracked one (638). The invariant belongs to the bars this repository ships, so it
  reads those, and the fifteen boundaries are named rather than counted. 5 passed under both roots.
- **`tests/test_superseded_members_registries.py`** pinned six counts against the canonical
  registries under `~/ml4t/artifacts`. Two of its six shapes no longer exist there at all -
  `cme_futures` and `crypto_perps_funding` hold no supersedes edge since their run logs were reset -
  so two assertions had stopped testing the function before anyone noticed. Each shape is now a
  lineage the test builds, and the four wrong readings the file's history records are executable, each
  paired with the shape that separates it. 28 passed, from 7 failed / 5 passed.
- **`tests/test_model_registry.py::test_model_notebook`** failed 94 times on `Missing
  prerequisites`, because the fixture symlinks `case_studies/<cs>/{features,labels}` and those are
  stage 01-05 output that a maintainer worktree reaches through `~/ml4t/artifacts` and no runner or
  fresh worktree has. An absent input is a skip that names the directory. 11 passed, 94 skipped.

## Budgets, priced from what CI measures

41 `cs-*` job logs across 6 green runs, 121 notebooks timed. Every linear notebook runs in 13.9-22.8s
against 120s and its GBM sibling is slower in all seven case studies, so 120s is confirmed rather
than copied and each entry now records its own number. The budgets that were actually thin were
elsewhere: `nasdaq100_microstructure/14_backtest` finished 5.9 seconds inside its 360s cap on a
*green* run. Five entries raised, each with its measurement, on one stated line - the slowest green
run fits in a third of the budget.

## A harness run reads what CI reads

`open_study` resolved canonical reads through `REPO_ROOT`, whose `case_studies/<cs>/run_log` is a
symlink into `~/ml4t/artifacts` in every maintainer worktree and does not exist on any runner. So the
environment where the suite is exercised before a push was the one that was not hermetic: 749 catalog
rows locally where the workspace held 23, and a backtest selecting published predictions whose
parquet the workspace has no copy of. The released-catalog overlay is a contract and is unchanged;
what changes is which released tree an unqualified caller gets - an explicit argument, else
`ML4T_RELEASE_ROOT`, else `REPO_ROOT` - and the test harness now points it at a checkout-shaped tree
carrying `config/` and no `run_log`.

## Verification

`test-unit`'s exact command locally: **3830 passed, 60 skipped, 6 failed**. Five are
`test_awaiting_rebuild.py` declarations that have outlived their reason against this workstation's
registry and are green on any runner - filed separately, untouched here. The sixth was a real defect
in this branch, caught by the pre-push review before the run finished: stripping
`release_root=REPO_ROOT` from two direct `Study(...)` constructor calls dropped a required field,
which raises `TypeError` on the preview symlink path. Restored, and
`tests/test_sp500_options_research.py` and `tests/test_cme_futures_research.py` are green.

The eleven files this branch touches directly, plus the five research-contract tests that pin the
released-catalog overlay: **411 passed, 96 skipped**. `test-unit-data`'s seven files in a venv
holding exactly that job's install list: **37 passed, 0 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tJuX3jfWkXVUAQTkmjrYt
