### PR TITLE
Fourteen infrastructure defects: silent zero returns, forked identities, and a fixture that fabricated its carriers

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -45,7 +45,8 @@
 # `test_holdout_expected_keys` loads `20_strategy_synthesis/holdout.py`, whose
 # module scope reaches lightgbm and torch through the family training paths it
 # dispatches to. It tests two pure functions and needs none of that, but the
-# module cannot be imported without it.
+# module cannot be imported without it. `test_holdout_force_regenerates` loads
+# the same module for the same reason and is behind the same boundary.
 # ---------------------------------------------------------------------------
 # The three files the etfs deep-learning and latent-factor pass added are behind
 # the same boundary. `test_common_sample_daily_ic` tests one pure polars
@@ -70,6 +71,7 @@ tests/test_gbm_holdout_rekey.py
 tests/test_gbm_identity.py
 tests/test_gbm_runtime.py
 tests/test_holdout_expected_keys.py
+tests/test_holdout_force_regenerates.py
 tests/test_insight_chapter.py
 tests/test_latent_epoch_ic_over_dates.py
 tests/test_latent_factors_identity.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1009,6 +1009,7 @@ jobs:
             tests/test_tabular_dl.py \
             tests/test_tabular_dl_adapter.py \
             tests/test_holdout_expected_keys.py \
+            tests/test_holdout_force_regenerates.py \
             tests/test_tabular_dl_identity.py \
             tests/test_tabular_dl_runtime.py \
             tests/test_training_identity_migration.py \

--- a/20_strategy_synthesis/holdout.py
+++ b/20_strategy_synthesis/holdout.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import contextlib
 import gc
 import json
+import shutil
 import sqlite3
 import time
 from datetime import date as dt_date
@@ -628,10 +629,19 @@ def _referencing_columns(
 
 
 def delete_holdout_predictions(cs_id: str) -> int:
-    """Delete all existing holdout predictions and their backtests.
+    """Delete all existing holdout predictions and their backtests, rows and artifacts.
 
     Deletion order respects FK constraints: child tables first, then parents. Which tables
     those are is read from the schema - see :func:`_referencing_columns`.
+
+    The artifact directories go with the rows. A prediction artifact is immutable per hash:
+    `register_prediction_set` refuses a hash whose `predictions.parquet` is already on disk
+    with a different digest, and the row it would have compared against is gone. Leaving the
+    directories behind therefore turns a regenerated holdout that lands on the same hash and
+    different content into an "immutable prediction artifact conflict" with nothing left in
+    the registry to explain it - which is exactly the state `force=True` exists to clear.
+    The directories are removed after the transaction commits, so a failed delete leaves both
+    halves intact rather than the rows behind their files.
     """
     case_dir = get_case_study_dir(cs_id)
     db_path = case_dir / "run_log" / "registry.db"
@@ -646,12 +656,15 @@ def delete_holdout_predictions(cs_id: str) -> int:
         "SELECT prediction_hash FROM prediction_sets WHERE split = 'holdout'"
     ).fetchall()
     deleted = 0
+    stale_dirs: list[Path] = []
     try:
         for (ph,) in rows:
+            stale_dirs.append(case_dir / "run_log" / "predictions" / ph)
             bts = db.execute(
                 "SELECT backtest_hash FROM backtest_runs WHERE prediction_hash=?", (ph,)
             ).fetchall()
             for (bh,) in bts:
+                stale_dirs.append(case_dir / "run_log" / "backtest" / bh)
                 for table, column in backtest_children:
                     if table == "backtest_runs":
                         continue
@@ -672,6 +685,9 @@ def delete_holdout_predictions(cs_id: str) -> int:
         raise
     finally:
         db.close()
+
+    for stale in stale_dirs:
+        shutil.rmtree(stale, ignore_errors=True)
     return deleted
 
 

--- a/20_strategy_synthesis/holdout.py
+++ b/20_strategy_synthesis/holdout.py
@@ -1122,13 +1122,20 @@ def generate_holdout(
         if verbose:
             print(msg, flush=True)
 
-    if has_holdout_predictions(cs_id):
-        if force:
-            n = delete_holdout_predictions(cs_id)
-            _log(f"  Deleted {n} existing holdout prediction(s)")
-        else:
-            _log("  Holdout predictions exist - loading from registry")
-            return load_existing_holdout(cs_id)
+    # `force` deletes unconditionally. Gating the delete on `has_holdout_predictions`
+    # skipped it exactly when it was needed: that check looks for a holdout tied to one of
+    # the *current* validation top-N, and its own docstring says it returns False when a
+    # holdout exists but no top-N candidate matches it - which is the definition of stale.
+    # So a holdout whose training fell out of the top-N after a sweep reshuffle survived
+    # `force=True`, and the new holdout was written beside it, two holdouts for one case
+    # study. Measured on nasdaq100_microstructure: bf76fac27013 (training b8add3b63794)
+    # coexisted with 6f95e10992fe and had to be deleted by hand.
+    if force:
+        n = delete_holdout_predictions(cs_id)
+        _log(f"  Deleted {n} existing holdout prediction(s)")
+    elif has_holdout_predictions(cs_id):
+        _log("  Holdout predictions exist - loading from registry")
+        return load_existing_holdout(cs_id)
 
     label_filter = LABEL_RESTRICTIONS.get(cs_id)
     candidates = select_best_models(

--- a/20_strategy_synthesis/holdout.py
+++ b/20_strategy_synthesis/holdout.py
@@ -601,10 +601,37 @@ def has_holdout_predictions(cs_id: str, *, top_n: int = 5) -> bool:
     return count > 0
 
 
+def _referencing_columns(
+    db: sqlite3.Connection, parent_table: str, parent_column: str
+) -> list[tuple[str, str]]:
+    """Every ``(table, column)`` the schema declares as a foreign key into one column.
+
+    Read from the schema rather than listed here. The hand-written list this replaces named
+    `fold_metrics`, `prediction_metrics`, `backtest_metrics`, `backtest_fold_metrics` and
+    `backtest_paired_metrics`, and omitted `prediction_coverage` and `cohort_metrics`, both
+    of which have been foreign keys into these tables since. Every registered holdout hits
+    that: `DELETE FROM prediction_sets` under `PRAGMA foreign_keys=ON` raises
+    `sqlite3.IntegrityError: FOREIGN KEY constraint failed` while its coverage row stands.
+    Reproduced on a copy of cme_futures' production registry, holdout 18d48c3b9cc2. A list
+    that has to be maintained by hand will be wrong again; the schema cannot be.
+    """
+    tables = [
+        row[0]
+        for row in db.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    ]
+    references = []
+    for table in tables:
+        for row in db.execute(f"PRAGMA foreign_key_list('{table}')").fetchall():
+            if row[2] == parent_table and row[4] == parent_column:
+                references.append((table, row[3]))
+    return sorted(references)
+
+
 def delete_holdout_predictions(cs_id: str) -> int:
     """Delete all existing holdout predictions and their backtests.
 
-    Deletion order respects FK constraints: child tables first, then parents.
+    Deletion order respects FK constraints: child tables first, then parents. Which tables
+    those are is read from the schema - see :func:`_referencing_columns`.
     """
     case_dir = get_case_study_dir(cs_id)
     db_path = case_dir / "run_log" / "registry.db"
@@ -613,32 +640,38 @@ def delete_holdout_predictions(cs_id: str) -> int:
 
     db = sqlite3.connect(str(db_path))
     db.execute("PRAGMA foreign_keys=ON")
+    prediction_children = _referencing_columns(db, "prediction_sets", "prediction_hash")
+    backtest_children = _referencing_columns(db, "backtest_runs", "backtest_hash")
     rows = db.execute(
         "SELECT prediction_hash FROM prediction_sets WHERE split = 'holdout'"
     ).fetchall()
     deleted = 0
-    for (ph,) in rows:
-        bts = db.execute(
-            "SELECT backtest_hash FROM backtest_runs WHERE prediction_hash=?", (ph,)
-        ).fetchall()
-        for (bh,) in bts:
-            # Child tables first. backtest_paired_metrics has FK on
-            # challenger_hash; we also clean rows where the holdout backtest
-            # is referenced as benchmark_hash (no FK but logically stale).
-            db.execute(
-                "DELETE FROM backtest_paired_metrics WHERE challenger_hash=? OR benchmark_hash=?",
-                (bh, bh),
-            )
-            db.execute("DELETE FROM backtest_fold_metrics WHERE backtest_hash=?", (bh,))
-            db.execute("DELETE FROM backtest_metrics WHERE backtest_hash=?", (bh,))
-            db.execute("DELETE FROM backtest_runs WHERE backtest_hash=?", (bh,))
-        # Child tables of prediction_sets
-        db.execute("DELETE FROM fold_metrics WHERE prediction_hash=?", (ph,))
-        db.execute("DELETE FROM prediction_metrics WHERE prediction_hash=?", (ph,))
-        db.execute("DELETE FROM prediction_sets WHERE prediction_hash=?", (ph,))
-        deleted += 1
-    db.commit()
-    db.close()
+    try:
+        for (ph,) in rows:
+            bts = db.execute(
+                "SELECT backtest_hash FROM backtest_runs WHERE prediction_hash=?", (ph,)
+            ).fetchall()
+            for (bh,) in bts:
+                for table, column in backtest_children:
+                    if table == "backtest_runs":
+                        continue
+                    db.execute(f"DELETE FROM {table} WHERE {column}=?", (bh,))
+                # No foreign key declares it, but a paired metric benchmarked against a
+                # deleted holdout backtest is as stale as one challenging it.
+                db.execute("DELETE FROM backtest_paired_metrics WHERE benchmark_hash=?", (bh,))
+                db.execute("DELETE FROM backtest_runs WHERE backtest_hash=?", (bh,))
+            for table, column in prediction_children:
+                if table == "backtest_runs":
+                    continue
+                db.execute(f"DELETE FROM {table} WHERE {column}=?", (ph,))
+            db.execute("DELETE FROM prediction_sets WHERE prediction_hash=?", (ph,))
+            deleted += 1
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
     return deleted
 
 

--- a/22_rag_financial_research/07_institutional_holdings_graph.ipynb
+++ b/22_rag_financial_research/07_institutional_holdings_graph.ipynb
@@ -3,7 +3,15 @@
   {
    "cell_type": "markdown",
    "id": "273a5c5c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003398,
+     "end_time": "2026-09-04T01:46:27.137901+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:27.134503+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# Institutional Holdings Graph: Point-in-Time 13F Features\n",
     "\n",
@@ -47,7 +55,15 @@
   {
    "cell_type": "markdown",
    "id": "f8336e6b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002532,
+     "end_time": "2026-09-04T01:46:27.143512+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:27.140980+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 1. Setup and Imports\n",
     "\n",
@@ -62,10 +78,17 @@
    "id": "40454066",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:28.614850Z",
-     "iopub.status.busy": "2026-07-26T19:39:28.614481Z",
-     "iopub.status.idle": "2026-07-26T19:39:30.178702Z",
-     "shell.execute_reply": "2026-07-26T19:39:30.178376Z"
+     "iopub.execute_input": "2026-09-04T01:46:27.148944Z",
+     "iopub.status.busy": "2026-09-04T01:46:27.148831Z",
+     "iopub.status.idle": "2026-09-04T01:46:28.726819Z",
+     "shell.execute_reply": "2026-09-04T01:46:28.726318Z"
+    },
+    "papermill": {
+     "duration": 1.581541,
+     "end_time": "2026-09-04T01:46:28.727463+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:27.145922+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -93,10 +116,17 @@
    "id": "f3caa3c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:30.180446Z",
-     "iopub.status.busy": "2026-07-26T19:39:30.180304Z",
-     "iopub.status.idle": "2026-07-26T19:39:30.182269Z",
-     "shell.execute_reply": "2026-07-26T19:39:30.181983Z"
+     "iopub.execute_input": "2026-09-04T01:46:28.732494Z",
+     "iopub.status.busy": "2026-09-04T01:46:28.732346Z",
+     "iopub.status.idle": "2026-09-04T01:46:28.734375Z",
+     "shell.execute_reply": "2026-09-04T01:46:28.734064Z"
+    },
+    "papermill": {
+     "duration": 0.005007,
+     "end_time": "2026-09-04T01:46:28.734737+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.729730+00:00",
+     "status": "completed"
     },
     "tags": [
      "parameters"
@@ -130,10 +160,17 @@
    "id": "9071b4c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:30.183219Z",
-     "iopub.status.busy": "2026-07-26T19:39:30.183161Z",
-     "iopub.status.idle": "2026-07-26T19:39:30.185077Z",
-     "shell.execute_reply": "2026-07-26T19:39:30.184820Z"
+     "iopub.execute_input": "2026-09-04T01:46:28.739310Z",
+     "iopub.status.busy": "2026-09-04T01:46:28.739243Z",
+     "iopub.status.idle": "2026-09-04T01:46:28.741288Z",
+     "shell.execute_reply": "2026-09-04T01:46:28.741048Z"
+    },
+    "papermill": {
+     "duration": 0.004843,
+     "end_time": "2026-09-04T01:46:28.741594+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.736751+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -160,7 +197,15 @@
   {
    "cell_type": "markdown",
    "id": "30fa67a7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001953,
+     "end_time": "2026-09-04T01:46:28.745552+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.743599+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Part 1: Load Holdings Data\n",
     "\n",
@@ -184,10 +229,17 @@
    "id": "ad796397",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:30.186024Z",
-     "iopub.status.busy": "2026-07-26T19:39:30.185963Z",
-     "iopub.status.idle": "2026-07-26T19:39:30.214193Z",
-     "shell.execute_reply": "2026-07-26T19:39:30.213862Z"
+     "iopub.execute_input": "2026-09-04T01:46:28.750465Z",
+     "iopub.status.busy": "2026-09-04T01:46:28.750386Z",
+     "iopub.status.idle": "2026-09-04T01:46:28.829025Z",
+     "shell.execute_reply": "2026-09-04T01:46:28.828185Z"
+    },
+    "papermill": {
+     "duration": 0.082437,
+     "end_time": "2026-09-04T01:46:28.829941+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.747504+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -214,6 +266,14 @@
     "# Filter to the CIKs listed in ALL_INSTITUTIONS. The artifact may contain a\n",
     "# wider or narrower set; rows outside this universe are dropped.\n",
     "holdings_df = holdings_df.filter(pl.col(\"cik\").is_in(SELECTED_CIKS))\n",
+    "# Whether a manager filed for a quarter, and when that quarter became public, are\n",
+    "# questions about what was *disclosed* - not about what enters the graph. The producer\n",
+    "# counts any disclosed row as evidence a manager filed, so both are answered from the\n",
+    "# selected holdings before the option filter below. A manager that discloses options only\n",
+    "# has filed; reading coverage off the filtered frame would make this notebook step back\n",
+    "# from, or reject, a quarter the producer used, and the parity assertion at the end would\n",
+    "# then compare two different quarters.\n",
+    "disclosed_df = holdings_df\n",
     "option_rows = holdings_df.filter(\n",
     "    pl.col(\"put_call\").fill_null(\"\").cast(pl.Utf8).str.strip_chars() != \"\"\n",
     ").height\n",
@@ -240,10 +300,17 @@
    "id": "164d1c51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:30.215588Z",
-     "iopub.status.busy": "2026-07-26T19:39:30.215510Z",
-     "iopub.status.idle": "2026-07-26T19:39:30.219482Z",
-     "shell.execute_reply": "2026-07-26T19:39:30.218970Z"
+     "iopub.execute_input": "2026-09-04T01:46:28.840600Z",
+     "iopub.status.busy": "2026-09-04T01:46:28.840500Z",
+     "iopub.status.idle": "2026-09-04T01:46:28.845369Z",
+     "shell.execute_reply": "2026-09-04T01:46:28.844822Z"
+    },
+    "papermill": {
+     "duration": 0.009356,
+     "end_time": "2026-09-04T01:46:28.845728+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.836372+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -251,15 +318,25 @@
     "# A reporting quarter becomes available only after the last included manager\n",
     "# files. Duplicate CIK/CUSIP rows in an information table are summed rather than\n",
     "# selected positionally.\n",
-    "quarter_availability = holdings_df.group_by(\"report_period\").agg(\n",
-    "    pl.col(\"filing_date\").max().alias(\"timestamp\")\n",
+    "quarter_availability = (\n",
+    "    disclosed_df.with_columns(pl.col(\"report_date\").alias(\"report_period\"))\n",
+    "    .group_by(\"report_period\")\n",
+    "    .agg(pl.col(\"filing_date\").max().alias(\"timestamp\"))\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "6c18da5f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002114,
+     "end_time": "2026-09-04T01:46:28.850743+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.848629+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "Canonicalize each CUSIP's issuer label by the largest disclosed value in that\n",
     "reporting period, with a lexical tie-break. This keeps graph labels stable."
@@ -271,10 +348,17 @@
    "id": "1ff7b21b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:30.220545Z",
-     "iopub.status.busy": "2026-07-26T19:39:30.220409Z",
-     "iopub.status.idle": "2026-07-26T19:39:30.310643Z",
-     "shell.execute_reply": "2026-07-26T19:39:30.310294Z"
+     "iopub.execute_input": "2026-09-04T01:46:28.855604Z",
+     "iopub.status.busy": "2026-09-04T01:46:28.855433Z",
+     "iopub.status.idle": "2026-09-04T01:46:28.953817Z",
+     "shell.execute_reply": "2026-09-04T01:46:28.953283Z"
+    },
+    "papermill": {
+     "duration": 0.101565,
+     "end_time": "2026-09-04T01:46:28.954296+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.852731+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -315,9 +399,10 @@
     "# quarter holds the early filers only, and their peers' absence would read as a\n",
     "# mass exit rather than as missing coverage. The downloader applies the same rule,\n",
     "# so this is also what keeps the reconstruction below equal to its artifacts.\n",
-    "covered_ciks = holdings_df[\"cik\"].n_unique()\n",
+    "covered_ciks = disclosed_df[\"cik\"].n_unique()\n",
     "complete_periods = (\n",
-    "    positions_df.group_by(\"report_period\")\n",
+    "    disclosed_df.with_columns(pl.col(\"report_date\").alias(\"report_period\"))\n",
+    "    .group_by(\"report_period\")\n",
     "    .agg(pl.col(\"cik\").n_unique().alias(\"n_ciks\"))\n",
     "    .filter(pl.col(\"n_ciks\") == covered_ciks)[\"report_period\"]\n",
     "    .to_list()\n",
@@ -358,7 +443,15 @@
   {
    "cell_type": "markdown",
    "id": "745cfcf3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002164,
+     "end_time": "2026-09-04T01:46:28.959718+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.957554+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "**Interpretation**: The filtered panel exposes the core constraints of 13F\n",
     "data: sparse quarterly snapshots, filing lags, and heterogeneous institution\n",
@@ -369,7 +462,15 @@
   {
    "cell_type": "markdown",
    "id": "48679528",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001996,
+     "end_time": "2026-09-04T01:46:28.963753+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.961757+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Part 2: Bipartite Graph Construction\n",
     "\n",
@@ -383,10 +484,17 @@
    "id": "60c2a2bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:30.312300Z",
-     "iopub.status.busy": "2026-07-26T19:39:30.312189Z",
-     "iopub.status.idle": "2026-07-26T19:39:30.316737Z",
-     "shell.execute_reply": "2026-07-26T19:39:30.316352Z"
+     "iopub.execute_input": "2026-09-04T01:46:28.968612Z",
+     "iopub.status.busy": "2026-09-04T01:46:28.968493Z",
+     "iopub.status.idle": "2026-09-04T01:46:28.972414Z",
+     "shell.execute_reply": "2026-09-04T01:46:28.971989Z"
+    },
+    "papermill": {
+     "duration": 0.007028,
+     "end_time": "2026-09-04T01:46:28.972804+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.965776+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -429,7 +537,14 @@
    "cell_type": "markdown",
    "id": "7801b7fa",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.002268,
+     "end_time": "2026-09-04T01:46:28.977368+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.975100+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## Part 3: Co-Ownership Analysis\n",
@@ -450,12 +565,19 @@
    "id": "228a0af0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:30.318042Z",
-     "iopub.status.busy": "2026-07-26T19:39:30.317951Z",
-     "iopub.status.idle": "2026-07-26T19:39:30.320389Z",
-     "shell.execute_reply": "2026-07-26T19:39:30.320121Z"
+     "iopub.execute_input": "2026-09-04T01:46:28.982332Z",
+     "iopub.status.busy": "2026-09-04T01:46:28.982163Z",
+     "iopub.status.idle": "2026-09-04T01:46:28.985769Z",
+     "shell.execute_reply": "2026-09-04T01:46:28.985470Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006841,
+     "end_time": "2026-09-04T01:46:28.986290+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.979449+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -479,7 +601,14 @@
    "cell_type": "markdown",
    "id": "c7dc0b4f",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.00244,
+     "end_time": "2026-09-04T01:46:28.991939+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.989499+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### Stock co-ownership similarity\n",
@@ -494,10 +623,17 @@
    "id": "3937abd9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:30.321385Z",
-     "iopub.status.busy": "2026-07-26T19:39:30.321318Z",
-     "iopub.status.idle": "2026-07-26T19:39:30.323098Z",
-     "shell.execute_reply": "2026-07-26T19:39:30.322862Z"
+     "iopub.execute_input": "2026-09-04T01:46:28.996535Z",
+     "iopub.status.busy": "2026-09-04T01:46:28.996464Z",
+     "iopub.status.idle": "2026-09-04T01:46:28.998396Z",
+     "shell.execute_reply": "2026-09-04T01:46:28.998090Z"
+    },
+    "papermill": {
+     "duration": 0.00488,
+     "end_time": "2026-09-04T01:46:28.998874+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:28.993994+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -518,10 +654,17 @@
    "id": "1d4d8ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:30.324172Z",
-     "iopub.status.busy": "2026-07-26T19:39:30.324102Z",
-     "iopub.status.idle": "2026-07-26T19:39:31.194338Z",
-     "shell.execute_reply": "2026-07-26T19:39:31.193978Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.003429Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.003363Z",
+     "iopub.status.idle": "2026-09-04T01:46:29.729667Z",
+     "shell.execute_reply": "2026-09-04T01:46:29.729245Z"
+    },
+    "papermill": {
+     "duration": 0.728976,
+     "end_time": "2026-09-04T01:46:29.729924+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.000948+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -586,7 +729,15 @@
   {
    "cell_type": "markdown",
    "id": "0cf37619",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002223,
+     "end_time": "2026-09-04T01:46:29.734580+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.732357+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "**Interpretation**: The highest-similarity pair identifies securities with the\n",
     "most similar disclosed owner weights. It does not measure return comovement."
@@ -595,7 +746,15 @@
   {
    "cell_type": "markdown",
    "id": "1beddfd6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002025,
+     "end_time": "2026-09-04T01:46:29.738869+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.736844+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Part 4: Institutional Ownership Change\n",
     "\n",
@@ -609,7 +768,14 @@
    "cell_type": "markdown",
    "id": "b34b78cb",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.00207,
+     "end_time": "2026-09-04T01:46:29.742967+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.740897+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### Select comparable quarter snapshots\n",
@@ -623,10 +789,17 @@
    "id": "40e814a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:31.195460Z",
-     "iopub.status.busy": "2026-07-26T19:39:31.195384Z",
-     "iopub.status.idle": "2026-07-26T19:39:31.197309Z",
-     "shell.execute_reply": "2026-07-26T19:39:31.197020Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.747889Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.747787Z",
+     "iopub.status.idle": "2026-09-04T01:46:29.750082Z",
+     "shell.execute_reply": "2026-09-04T01:46:29.749598Z"
+    },
+    "papermill": {
+     "duration": 0.005328,
+     "end_time": "2026-09-04T01:46:29.750360+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.745032+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -646,10 +819,17 @@
    "id": "5e49b24e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:31.198418Z",
-     "iopub.status.busy": "2026-07-26T19:39:31.198357Z",
-     "iopub.status.idle": "2026-07-26T19:39:31.207643Z",
-     "shell.execute_reply": "2026-07-26T19:39:31.207263Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.755211Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.755118Z",
+     "iopub.status.idle": "2026-09-04T01:46:29.767481Z",
+     "shell.execute_reply": "2026-09-04T01:46:29.766960Z"
+    },
+    "papermill": {
+     "duration": 0.015428,
+     "end_time": "2026-09-04T01:46:29.767905+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.752477+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -695,7 +875,15 @@
   {
    "cell_type": "markdown",
    "id": "74e716a1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002139,
+     "end_time": "2026-09-04T01:46:29.772442+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.770303+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Inspect ownership-change leaders and exits\n",
     "\n",
@@ -712,10 +900,17 @@
    "id": "e1a495a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:31.209081Z",
-     "iopub.status.busy": "2026-07-26T19:39:31.209005Z",
-     "iopub.status.idle": "2026-07-26T19:39:31.214949Z",
-     "shell.execute_reply": "2026-07-26T19:39:31.214483Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.777479Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.777328Z",
+     "iopub.status.idle": "2026-09-04T01:46:29.785952Z",
+     "shell.execute_reply": "2026-09-04T01:46:29.785338Z"
+    },
+    "papermill": {
+     "duration": 0.011748,
+     "end_time": "2026-09-04T01:46:29.786297+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.774549+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -813,7 +1008,15 @@
   {
    "cell_type": "markdown",
    "id": "ccfd31a4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002178,
+     "end_time": "2026-09-04T01:46:29.790843+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.788665+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "**Interpretation**: The table measures disclosed quarter-over-quarter changes\n",
     "across managers. Persistence and predictive value require a separate\n",
@@ -823,7 +1026,15 @@
   {
    "cell_type": "markdown",
    "id": "f23bed6b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002107,
+     "end_time": "2026-09-04T01:46:29.795117+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.793010+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Part 5: Crowding Descriptors\n",
     "\n",
@@ -837,10 +1048,17 @@
    "id": "7738bc8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:31.215919Z",
-     "iopub.status.busy": "2026-07-26T19:39:31.215849Z",
-     "iopub.status.idle": "2026-07-26T19:39:31.230429Z",
-     "shell.execute_reply": "2026-07-26T19:39:31.229450Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.800454Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.800299Z",
+     "iopub.status.idle": "2026-09-04T01:46:29.811306Z",
+     "shell.execute_reply": "2026-09-04T01:46:29.810852Z"
+    },
+    "papermill": {
+     "duration": 0.01443,
+     "end_time": "2026-09-04T01:46:29.811735+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.797305+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -866,10 +1084,17 @@
    "id": "dd2aaa02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:31.232368Z",
-     "iopub.status.busy": "2026-07-26T19:39:31.232198Z",
-     "iopub.status.idle": "2026-07-26T19:39:31.245842Z",
-     "shell.execute_reply": "2026-07-26T19:39:31.245432Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.817189Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.817086Z",
+     "iopub.status.idle": "2026-09-04T01:46:29.823367Z",
+     "shell.execute_reply": "2026-09-04T01:46:29.823025Z"
+    },
+    "papermill": {
+     "duration": 0.009451,
+     "end_time": "2026-09-04T01:46:29.823642+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.814191+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -985,7 +1210,15 @@
   {
    "cell_type": "markdown",
    "id": "725a1471",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002251,
+     "end_time": "2026-09-04T01:46:29.828279+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.826028+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "**Interpretation**: High values identify names disclosed by many included\n",
     "managers with dispersed ownership weights. Whether that structure predicts\n",
@@ -996,7 +1229,14 @@
    "cell_type": "markdown",
    "id": "00c1868d",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.002183,
+     "end_time": "2026-09-04T01:46:29.832687+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.830504+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## Part 6: Institution Similarity Network\n",
@@ -1013,10 +1253,17 @@
    "id": "e00f4c7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:31.247343Z",
-     "iopub.status.busy": "2026-07-26T19:39:31.247254Z",
-     "iopub.status.idle": "2026-07-26T19:39:31.250991Z",
-     "shell.execute_reply": "2026-07-26T19:39:31.250370Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.838088Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.837986Z",
+     "iopub.status.idle": "2026-09-04T01:46:29.840951Z",
+     "shell.execute_reply": "2026-09-04T01:46:29.840585Z"
+    },
+    "papermill": {
+     "duration": 0.006212,
+     "end_time": "2026-09-04T01:46:29.841211+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.834999+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -1055,7 +1302,14 @@
    "cell_type": "markdown",
    "id": "992f418e",
    "metadata": {
-    "lines_to_next_cell": 0
+    "lines_to_next_cell": 0,
+    "papermill": {
+     "duration": 0.002228,
+     "end_time": "2026-09-04T01:46:29.845827+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.843599+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### Pairwise Institution Similarity\n",
@@ -1071,10 +1325,17 @@
    "id": "dbfaed6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:31.252500Z",
-     "iopub.status.busy": "2026-07-26T19:39:31.252379Z",
-     "iopub.status.idle": "2026-07-26T19:39:31.256635Z",
-     "shell.execute_reply": "2026-07-26T19:39:31.256076Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.850985Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.850897Z",
+     "iopub.status.idle": "2026-09-04T01:46:29.853541Z",
+     "shell.execute_reply": "2026-09-04T01:46:29.853207Z"
+    },
+    "papermill": {
+     "duration": 0.005772,
+     "end_time": "2026-09-04T01:46:29.853833+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.848061+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -1114,10 +1375,17 @@
    "id": "6d739254",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:31.257917Z",
-     "iopub.status.busy": "2026-07-26T19:39:31.257785Z",
-     "iopub.status.idle": "2026-07-26T19:39:31.294143Z",
-     "shell.execute_reply": "2026-07-26T19:39:31.293845Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.859179Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.859079Z",
+     "iopub.status.idle": "2026-09-04T01:46:29.902710Z",
+     "shell.execute_reply": "2026-09-04T01:46:29.901402Z"
+    },
+    "papermill": {
+     "duration": 0.047385,
+     "end_time": "2026-09-04T01:46:29.903583+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.856198+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1219,7 +1487,15 @@
   {
    "cell_type": "markdown",
    "id": "00ef6e02",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003815,
+     "end_time": "2026-09-04T01:46:29.913262+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.909447+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "**Interpretation**: Institution-level similarity turns the 13F panel into a\n",
     "map of strategy overlap. Highly similar managers share more portfolio weight,\n",
@@ -1229,7 +1505,15 @@
   {
    "cell_type": "markdown",
    "id": "82368d67",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002296,
+     "end_time": "2026-09-04T01:46:29.918393+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.916097+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Part 7: Visualization\n",
     "\n",
@@ -1243,10 +1527,17 @@
    "id": "df83725f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:31.295233Z",
-     "iopub.status.busy": "2026-07-26T19:39:31.295161Z",
-     "iopub.status.idle": "2026-07-26T19:39:32.613967Z",
-     "shell.execute_reply": "2026-07-26T19:39:32.612686Z"
+     "iopub.execute_input": "2026-09-04T01:46:29.923790Z",
+     "iopub.status.busy": "2026-09-04T01:46:29.923687Z",
+     "iopub.status.idle": "2026-09-04T01:46:31.291017Z",
+     "shell.execute_reply": "2026-09-04T01:46:31.290464Z"
+    },
+    "papermill": {
+     "duration": 1.370836,
+     "end_time": "2026-09-04T01:46:31.291538+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:29.920702+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1297,10 +1588,10 @@
           "colorway": [
            "#0a1628",
            "#D4A84B",
-           "#1a2d4a",
            "#C87533",
            "#10b981",
-           "#ef4444"
+           "#ef4444",
+           "#94a3b8"
           ],
           "font": {
            "color": "#334155",
@@ -1422,7 +1713,15 @@
   {
    "cell_type": "markdown",
    "id": "ca8ae157",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004805,
+     "end_time": "2026-09-04T01:46:31.301955+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:31.297150+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "**Interpretation**: The bar chart separates breadth from scale. Institutions\n",
     "with fewer holdings but similar total value are expressing higher conviction\n",
@@ -1435,10 +1734,17 @@
    "id": "1f7d65a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:32.617090Z",
-     "iopub.status.busy": "2026-07-26T19:39:32.616855Z",
-     "iopub.status.idle": "2026-07-26T19:39:32.626670Z",
-     "shell.execute_reply": "2026-07-26T19:39:32.625623Z"
+     "iopub.execute_input": "2026-09-04T01:46:31.308340Z",
+     "iopub.status.busy": "2026-09-04T01:46:31.308237Z",
+     "iopub.status.idle": "2026-09-04T01:46:31.312392Z",
+     "shell.execute_reply": "2026-09-04T01:46:31.312017Z"
+    },
+    "papermill": {
+     "duration": 0.007976,
+     "end_time": "2026-09-04T01:46:31.312669+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:31.304693+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -1470,7 +1776,15 @@
   {
    "cell_type": "markdown",
    "id": "ece20945",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002581,
+     "end_time": "2026-09-04T01:46:31.317961+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:31.315380+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "Use a horizontal bar chart for the deterministic breadth-first selection.\n",
     "The CUSIP suffix makes every categorical label unique."
@@ -1482,10 +1796,17 @@
    "id": "da05b82b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:32.629798Z",
-     "iopub.status.busy": "2026-07-26T19:39:32.629536Z",
-     "iopub.status.idle": "2026-07-26T19:39:33.990478Z",
-     "shell.execute_reply": "2026-07-26T19:39:33.989544Z"
+     "iopub.execute_input": "2026-09-04T01:46:31.323794Z",
+     "iopub.status.busy": "2026-09-04T01:46:31.323687Z",
+     "iopub.status.idle": "2026-09-04T01:46:32.800363Z",
+     "shell.execute_reply": "2026-09-04T01:46:32.798536Z"
+    },
+    "papermill": {
+     "duration": 1.482221,
+     "end_time": "2026-09-04T01:46:32.802803+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:31.320582+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1545,10 +1866,10 @@
           "colorway": [
            "#0a1628",
            "#D4A84B",
-           "#1a2d4a",
            "#C87533",
            "#10b981",
-           "#ef4444"
+           "#ef4444",
+           "#94a3b8"
           ],
           "font": {
            "color": "#334155",
@@ -1657,7 +1978,15 @@
   {
    "cell_type": "markdown",
    "id": "55a09323",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003524,
+     "end_time": "2026-09-04T01:46:32.815369+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:32.811845+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "**Interpretation**: Widely held stocks are not automatically attractive\n",
     "signals. Ownership breadth is a graph descriptor, not evidence of future returns."
@@ -1669,10 +1998,17 @@
    "id": "d3a9e25a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:33.994709Z",
-     "iopub.status.busy": "2026-07-26T19:39:33.993971Z",
-     "iopub.status.idle": "2026-07-26T19:39:35.299218Z",
-     "shell.execute_reply": "2026-07-26T19:39:35.297550Z"
+     "iopub.execute_input": "2026-09-04T01:46:32.822060Z",
+     "iopub.status.busy": "2026-09-04T01:46:32.821864Z",
+     "iopub.status.idle": "2026-09-04T01:46:34.179362Z",
+     "shell.execute_reply": "2026-09-04T01:46:34.178720Z"
+    },
+    "papermill": {
+     "duration": 1.361628,
+     "end_time": "2026-09-04T01:46:34.179945+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:32.818317+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1790,10 +2126,10 @@
           "colorway": [
            "#0a1628",
            "#D4A84B",
-           "#1a2d4a",
            "#C87533",
            "#10b981",
-           "#ef4444"
+           "#ef4444",
+           "#94a3b8"
           ],
           "font": {
            "color": "#334155",
@@ -1914,7 +2250,15 @@
   {
    "cell_type": "markdown",
    "id": "1b3c1cc7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00659,
+     "end_time": "2026-09-04T01:46:34.196083+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.189493+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "**Interpretation**: The upper-right quadrant highlights names where both the\n",
     "dollar value and percentage ownership are rising. Those are the strongest\n",
@@ -1924,7 +2268,15 @@
   {
    "cell_type": "markdown",
    "id": "f3c13b8e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003171,
+     "end_time": "2026-09-04T01:46:34.204268+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.201097+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Part 8: Feature Engineering for ML Models\n",
     "\n",
@@ -1937,10 +2289,17 @@
    "id": "307d167c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:35.304010Z",
-     "iopub.status.busy": "2026-07-26T19:39:35.303631Z",
-     "iopub.status.idle": "2026-07-26T19:39:35.343826Z",
-     "shell.execute_reply": "2026-07-26T19:39:35.342954Z"
+     "iopub.execute_input": "2026-09-04T01:46:34.211738Z",
+     "iopub.status.busy": "2026-09-04T01:46:34.211565Z",
+     "iopub.status.idle": "2026-09-04T01:46:34.229176Z",
+     "shell.execute_reply": "2026-09-04T01:46:34.228711Z"
+    },
+    "papermill": {
+     "duration": 0.022052,
+     "end_time": "2026-09-04T01:46:34.229586+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.207534+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2032,7 +2391,14 @@
    "cell_type": "markdown",
    "id": "3f7363e8",
    "metadata": {
-    "lines_to_next_cell": 0
+    "lines_to_next_cell": 0,
+    "papermill": {
+     "duration": 0.003259,
+     "end_time": "2026-09-04T01:46:34.236348+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.233089+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "**Interpretation**: The feature summary describes quarter-end ownership\n",
@@ -2045,10 +2411,17 @@
    "id": "3fe05aa4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:35.345796Z",
-     "iopub.status.busy": "2026-07-26T19:39:35.345608Z",
-     "iopub.status.idle": "2026-07-26T19:39:35.359303Z",
-     "shell.execute_reply": "2026-07-26T19:39:35.357928Z"
+     "iopub.execute_input": "2026-09-04T01:46:34.243486Z",
+     "iopub.status.busy": "2026-09-04T01:46:34.243395Z",
+     "iopub.status.idle": "2026-09-04T01:46:34.249001Z",
+     "shell.execute_reply": "2026-09-04T01:46:34.248562Z"
+    },
+    "papermill": {
+     "duration": 0.009839,
+     "end_time": "2026-09-04T01:46:34.249426+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.239587+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2125,6 +2498,16 @@
     "            .sort(\"cusip\")\n",
     "        )\n",
     "        print(\"Added momentum features\")\n",
+    "    else:\n",
+    "        # With one complete quarter there is nothing to compare against, and the producer\n",
+    "        # emits both columns anyway - 0.0 and null - so an artifact built with\n",
+    "        # `--num-filings 1` has the same schema as any other. Skipping them here left the\n",
+    "        # parity assertion below comparing a frame two columns short.\n",
+    "        stock_features = stock_features.with_columns(\n",
+    "            pl.lit(0.0, dtype=pl.Float64).alias(\"inst_value_change_usd\"),\n",
+    "            pl.lit(None, dtype=pl.Float64).alias(\"inst_pct_change\"),\n",
+    "        ).sort(\"cusip\")\n",
+    "        print(\"Single complete quarter: momentum columns emitted as 0.0 / null\")\n",
     "\n",
     "    display(stock_features.head(10))"
    ]
@@ -2132,7 +2515,15 @@
   {
    "cell_type": "markdown",
    "id": "4ab0f305",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003605,
+     "end_time": "2026-09-04T01:46:34.256547+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.252942+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Canonical artifact parity\n",
     "\n",
@@ -2146,10 +2537,17 @@
    "id": "c486ac8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:35.363308Z",
-     "iopub.status.busy": "2026-07-26T19:39:35.362910Z",
-     "iopub.status.idle": "2026-07-26T19:39:35.394603Z",
-     "shell.execute_reply": "2026-07-26T19:39:35.393458Z"
+     "iopub.execute_input": "2026-09-04T01:46:34.264070Z",
+     "iopub.status.busy": "2026-09-04T01:46:34.263978Z",
+     "iopub.status.idle": "2026-09-04T01:46:34.282594Z",
+     "shell.execute_reply": "2026-09-04T01:46:34.281939Z"
+    },
+    "papermill": {
+     "duration": 0.022972,
+     "end_time": "2026-09-04T01:46:34.283085+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.260113+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2192,7 +2590,15 @@
   {
    "cell_type": "markdown",
    "id": "36981252",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006088,
+     "end_time": "2026-09-04T01:46:34.298542+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.292454+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "**Interpretation**: The feature table is the real bridge to modeling.\n",
     "Breadth, concentration, and ownership-change variables can be merged with\n",
@@ -2205,7 +2611,15 @@
   {
    "cell_type": "markdown",
    "id": "86ab5710",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003397,
+     "end_time": "2026-09-04T01:46:34.305599+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.302202+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Part 9: Artifacts on Disk\n",
     "\n",
@@ -2223,10 +2637,17 @@
    "id": "1b1fef33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:35.398559Z",
-     "iopub.status.busy": "2026-07-26T19:39:35.398260Z",
-     "iopub.status.idle": "2026-07-26T19:39:35.403698Z",
-     "shell.execute_reply": "2026-07-26T19:39:35.402407Z"
+     "iopub.execute_input": "2026-09-04T01:46:34.313103Z",
+     "iopub.status.busy": "2026-09-04T01:46:34.313003Z",
+     "iopub.status.idle": "2026-09-04T01:46:34.315013Z",
+     "shell.execute_reply": "2026-09-04T01:46:34.314737Z"
+    },
+    "papermill": {
+     "duration": 0.006408,
+     "end_time": "2026-09-04T01:46:34.315369+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.308961+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2263,7 +2684,15 @@
   {
    "cell_type": "markdown",
    "id": "913de717",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003294,
+     "end_time": "2026-09-04T01:46:34.322016+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.318722+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Results Interpretation\n",
     "\n",
@@ -2284,7 +2713,15 @@
   {
    "cell_type": "markdown",
    "id": "c0b949fc",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003413,
+     "end_time": "2026-09-04T01:46:34.328727+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.325314+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Summary: What We Can Do With 13F Data\n",
     "\n",
@@ -2306,10 +2743,17 @@
    "id": "da8a8ec1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-26T19:39:35.407747Z",
-     "iopub.status.busy": "2026-07-26T19:39:35.407394Z",
-     "iopub.status.idle": "2026-07-26T19:39:35.420615Z",
-     "shell.execute_reply": "2026-07-26T19:39:35.419959Z"
+     "iopub.execute_input": "2026-09-04T01:46:34.336243Z",
+     "iopub.status.busy": "2026-09-04T01:46:34.336164Z",
+     "iopub.status.idle": "2026-09-04T01:46:34.341217Z",
+     "shell.execute_reply": "2026-09-04T01:46:34.340947Z"
+    },
+    "papermill": {
+     "duration": 0.009638,
+     "end_time": "2026-09-04T01:46:34.341675+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.332037+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2341,7 +2785,15 @@
   {
    "cell_type": "markdown",
    "id": "89a063ba",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003341,
+     "end_time": "2026-09-04T01:46:34.348651+00:00",
+     "exception": false,
+     "start_time": "2026-09-04T01:46:34.345310+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key Takeaways\n",
     "\n",
@@ -2399,12 +2851,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "965876c9e85e54e50845400387eb3ee48609f7e3",
-   "executed_at": "2026-07-26T19:39:53.994174+00:00",
+   "source_py_blob": "abd1b4b2d30429dc86827892542f4dfe2fa8d468",
+   "executed_at": "2026-09-04T01:46:59.187705+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {},
-   "notes": "Re-executed after aligning the ownership-breadth denominator with the canonical producer"
+   "notes": "Re-executed for the 13F consumer edge cases: coverage and availability taken from the unfiltered disclosures, momentum columns emitted on the no-comparison path"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 8.885589,
+   "end_time": "2026-09-04T01:46:35.368109+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "22_rag_financial_research/07_institutional_holdings_graph.ipynb",
+   "output_path": "22_rag_financial_research/07_institutional_holdings_graph.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-04T01:46:26.482520+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/22_rag_financial_research/07_institutional_holdings_graph.ipynb
+++ b/22_rag_financial_research/07_institutional_holdings_graph.ipynb
@@ -5,10 +5,10 @@
    "id": "273a5c5c",
    "metadata": {
     "papermill": {
-     "duration": 0.003398,
-     "end_time": "2026-09-04T01:46:27.137901+00:00",
+     "duration": 0.003624,
+     "end_time": "2026-09-04T01:54:09.075272+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:27.134503+00:00",
+     "start_time": "2026-09-04T01:54:09.071648+00:00",
      "status": "completed"
     }
    },
@@ -57,10 +57,10 @@
    "id": "f8336e6b",
    "metadata": {
     "papermill": {
-     "duration": 0.002532,
-     "end_time": "2026-09-04T01:46:27.143512+00:00",
+     "duration": 0.002659,
+     "end_time": "2026-09-04T01:54:09.081647+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:27.140980+00:00",
+     "start_time": "2026-09-04T01:54:09.078988+00:00",
      "status": "completed"
     }
    },
@@ -78,16 +78,16 @@
    "id": "40454066",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:27.148944Z",
-     "iopub.status.busy": "2026-09-04T01:46:27.148831Z",
-     "iopub.status.idle": "2026-09-04T01:46:28.726819Z",
-     "shell.execute_reply": "2026-09-04T01:46:28.726318Z"
+     "iopub.execute_input": "2026-09-04T01:54:09.086588Z",
+     "iopub.status.busy": "2026-09-04T01:54:09.086472Z",
+     "iopub.status.idle": "2026-09-04T01:54:10.605814Z",
+     "shell.execute_reply": "2026-09-04T01:54:10.605448Z"
     },
     "papermill": {
-     "duration": 1.581541,
-     "end_time": "2026-09-04T01:46:28.727463+00:00",
+     "duration": 1.522775,
+     "end_time": "2026-09-04T01:54:10.606525+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:27.145922+00:00",
+     "start_time": "2026-09-04T01:54:09.083750+00:00",
      "status": "completed"
     }
    },
@@ -116,16 +116,16 @@
    "id": "f3caa3c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:28.732494Z",
-     "iopub.status.busy": "2026-09-04T01:46:28.732346Z",
-     "iopub.status.idle": "2026-09-04T01:46:28.734375Z",
-     "shell.execute_reply": "2026-09-04T01:46:28.734064Z"
+     "iopub.execute_input": "2026-09-04T01:54:10.611515Z",
+     "iopub.status.busy": "2026-09-04T01:54:10.611366Z",
+     "iopub.status.idle": "2026-09-04T01:54:10.613330Z",
+     "shell.execute_reply": "2026-09-04T01:54:10.613106Z"
     },
     "papermill": {
-     "duration": 0.005007,
-     "end_time": "2026-09-04T01:46:28.734737+00:00",
+     "duration": 0.004967,
+     "end_time": "2026-09-04T01:54:10.613786+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.729730+00:00",
+     "start_time": "2026-09-04T01:54:10.608819+00:00",
      "status": "completed"
     },
     "tags": [
@@ -160,16 +160,16 @@
    "id": "9071b4c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:28.739310Z",
-     "iopub.status.busy": "2026-09-04T01:46:28.739243Z",
-     "iopub.status.idle": "2026-09-04T01:46:28.741288Z",
-     "shell.execute_reply": "2026-09-04T01:46:28.741048Z"
+     "iopub.execute_input": "2026-09-04T01:54:10.618204Z",
+     "iopub.status.busy": "2026-09-04T01:54:10.618119Z",
+     "iopub.status.idle": "2026-09-04T01:54:10.620190Z",
+     "shell.execute_reply": "2026-09-04T01:54:10.619929Z"
     },
     "papermill": {
-     "duration": 0.004843,
-     "end_time": "2026-09-04T01:46:28.741594+00:00",
+     "duration": 0.0048,
+     "end_time": "2026-09-04T01:54:10.620592+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.736751+00:00",
+     "start_time": "2026-09-04T01:54:10.615792+00:00",
      "status": "completed"
     }
    },
@@ -199,10 +199,10 @@
    "id": "30fa67a7",
    "metadata": {
     "papermill": {
-     "duration": 0.001953,
-     "end_time": "2026-09-04T01:46:28.745552+00:00",
+     "duration": 0.002043,
+     "end_time": "2026-09-04T01:54:10.624915+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.743599+00:00",
+     "start_time": "2026-09-04T01:54:10.622872+00:00",
      "status": "completed"
     }
    },
@@ -229,16 +229,16 @@
    "id": "ad796397",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:28.750465Z",
-     "iopub.status.busy": "2026-09-04T01:46:28.750386Z",
-     "iopub.status.idle": "2026-09-04T01:46:28.829025Z",
-     "shell.execute_reply": "2026-09-04T01:46:28.828185Z"
+     "iopub.execute_input": "2026-09-04T01:54:10.629777Z",
+     "iopub.status.busy": "2026-09-04T01:54:10.629671Z",
+     "iopub.status.idle": "2026-09-04T01:54:10.674212Z",
+     "shell.execute_reply": "2026-09-04T01:54:10.673834Z"
     },
     "papermill": {
-     "duration": 0.082437,
-     "end_time": "2026-09-04T01:46:28.829941+00:00",
+     "duration": 0.047572,
+     "end_time": "2026-09-04T01:54:10.674500+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.747504+00:00",
+     "start_time": "2026-09-04T01:54:10.626928+00:00",
      "status": "completed"
     }
    },
@@ -300,16 +300,16 @@
    "id": "164d1c51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:28.840600Z",
-     "iopub.status.busy": "2026-09-04T01:46:28.840500Z",
-     "iopub.status.idle": "2026-09-04T01:46:28.845369Z",
-     "shell.execute_reply": "2026-09-04T01:46:28.844822Z"
+     "iopub.execute_input": "2026-09-04T01:54:10.679420Z",
+     "iopub.status.busy": "2026-09-04T01:54:10.679339Z",
+     "iopub.status.idle": "2026-09-04T01:54:10.683016Z",
+     "shell.execute_reply": "2026-09-04T01:54:10.682743Z"
     },
     "papermill": {
-     "duration": 0.009356,
-     "end_time": "2026-09-04T01:46:28.845728+00:00",
+     "duration": 0.006694,
+     "end_time": "2026-09-04T01:54:10.683439+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.836372+00:00",
+     "start_time": "2026-09-04T01:54:10.676745+00:00",
      "status": "completed"
     }
    },
@@ -330,10 +330,10 @@
    "id": "6c18da5f",
    "metadata": {
     "papermill": {
-     "duration": 0.002114,
-     "end_time": "2026-09-04T01:46:28.850743+00:00",
+     "duration": 0.002136,
+     "end_time": "2026-09-04T01:54:10.687719+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.848629+00:00",
+     "start_time": "2026-09-04T01:54:10.685583+00:00",
      "status": "completed"
     }
    },
@@ -348,16 +348,16 @@
    "id": "1ff7b21b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:28.855604Z",
-     "iopub.status.busy": "2026-09-04T01:46:28.855433Z",
-     "iopub.status.idle": "2026-09-04T01:46:28.953817Z",
-     "shell.execute_reply": "2026-09-04T01:46:28.953283Z"
+     "iopub.execute_input": "2026-09-04T01:54:10.692661Z",
+     "iopub.status.busy": "2026-09-04T01:54:10.692562Z",
+     "iopub.status.idle": "2026-09-04T01:54:10.751412Z",
+     "shell.execute_reply": "2026-09-04T01:54:10.750994Z"
     },
     "papermill": {
-     "duration": 0.101565,
-     "end_time": "2026-09-04T01:46:28.954296+00:00",
+     "duration": 0.062151,
+     "end_time": "2026-09-04T01:54:10.752067+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.852731+00:00",
+     "start_time": "2026-09-04T01:54:10.689916+00:00",
      "status": "completed"
     }
    },
@@ -421,6 +421,14 @@
     "        f\"{', '.join(str(p) for p in partial_periods)}\"\n",
     "    )\n",
     "positions_df = positions_df.filter(pl.col(\"report_period\").is_in(complete_periods))\n",
+    "# Every complete quarter, before NUM_QUARTERS narrows what this notebook displays. The\n",
+    "# ownership-change table is part of the canonical feature set and the producer computes it\n",
+    "# over the artifact's own last two complete quarters, so it has to be built from this frame\n",
+    "# rather than from the displayed one: with NUM_QUARTERS=1 over a multi-quarter artifact the\n",
+    "# truncated frame has nothing to compare, and emitting zero change there would contradict a\n",
+    "# producer that compared two quarters. A one-quarter *artifact* is the different case the\n",
+    "# no-comparison branch below handles.\n",
+    "complete_positions_df = positions_df\n",
     "\n",
     "if NUM_QUARTERS > 0:\n",
     "    recent_periods = (\n",
@@ -445,10 +453,10 @@
    "id": "745cfcf3",
    "metadata": {
     "papermill": {
-     "duration": 0.002164,
-     "end_time": "2026-09-04T01:46:28.959718+00:00",
+     "duration": 0.003253,
+     "end_time": "2026-09-04T01:54:10.758737+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.957554+00:00",
+     "start_time": "2026-09-04T01:54:10.755484+00:00",
      "status": "completed"
     }
    },
@@ -464,10 +472,10 @@
    "id": "48679528",
    "metadata": {
     "papermill": {
-     "duration": 0.001996,
-     "end_time": "2026-09-04T01:46:28.963753+00:00",
+     "duration": 0.002711,
+     "end_time": "2026-09-04T01:54:10.764574+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.961757+00:00",
+     "start_time": "2026-09-04T01:54:10.761863+00:00",
      "status": "completed"
     }
    },
@@ -484,16 +492,16 @@
    "id": "60c2a2bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:28.968612Z",
-     "iopub.status.busy": "2026-09-04T01:46:28.968493Z",
-     "iopub.status.idle": "2026-09-04T01:46:28.972414Z",
-     "shell.execute_reply": "2026-09-04T01:46:28.971989Z"
+     "iopub.execute_input": "2026-09-04T01:54:10.769376Z",
+     "iopub.status.busy": "2026-09-04T01:54:10.769283Z",
+     "iopub.status.idle": "2026-09-04T01:54:10.773533Z",
+     "shell.execute_reply": "2026-09-04T01:54:10.773240Z"
     },
     "papermill": {
-     "duration": 0.007028,
-     "end_time": "2026-09-04T01:46:28.972804+00:00",
+     "duration": 0.007263,
+     "end_time": "2026-09-04T01:54:10.773992+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.965776+00:00",
+     "start_time": "2026-09-04T01:54:10.766729+00:00",
      "status": "completed"
     }
    },
@@ -539,10 +547,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002268,
-     "end_time": "2026-09-04T01:46:28.977368+00:00",
+     "duration": 0.002061,
+     "end_time": "2026-09-04T01:54:10.778235+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.975100+00:00",
+     "start_time": "2026-09-04T01:54:10.776174+00:00",
      "status": "completed"
     }
    },
@@ -565,17 +573,17 @@
    "id": "228a0af0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:28.982332Z",
-     "iopub.status.busy": "2026-09-04T01:46:28.982163Z",
-     "iopub.status.idle": "2026-09-04T01:46:28.985769Z",
-     "shell.execute_reply": "2026-09-04T01:46:28.985470Z"
+     "iopub.execute_input": "2026-09-04T01:54:10.782864Z",
+     "iopub.status.busy": "2026-09-04T01:54:10.782788Z",
+     "iopub.status.idle": "2026-09-04T01:54:10.785222Z",
+     "shell.execute_reply": "2026-09-04T01:54:10.784942Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006841,
-     "end_time": "2026-09-04T01:46:28.986290+00:00",
+     "duration": 0.005226,
+     "end_time": "2026-09-04T01:54:10.785519+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.979449+00:00",
+     "start_time": "2026-09-04T01:54:10.780293+00:00",
      "status": "completed"
     }
    },
@@ -603,10 +611,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00244,
-     "end_time": "2026-09-04T01:46:28.991939+00:00",
+     "duration": 0.002047,
+     "end_time": "2026-09-04T01:54:10.789656+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.989499+00:00",
+     "start_time": "2026-09-04T01:54:10.787609+00:00",
      "status": "completed"
     }
    },
@@ -623,16 +631,16 @@
    "id": "3937abd9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:28.996535Z",
-     "iopub.status.busy": "2026-09-04T01:46:28.996464Z",
-     "iopub.status.idle": "2026-09-04T01:46:28.998396Z",
-     "shell.execute_reply": "2026-09-04T01:46:28.998090Z"
+     "iopub.execute_input": "2026-09-04T01:54:10.794489Z",
+     "iopub.status.busy": "2026-09-04T01:54:10.794401Z",
+     "iopub.status.idle": "2026-09-04T01:54:10.796433Z",
+     "shell.execute_reply": "2026-09-04T01:54:10.796188Z"
     },
     "papermill": {
-     "duration": 0.00488,
-     "end_time": "2026-09-04T01:46:28.998874+00:00",
+     "duration": 0.005246,
+     "end_time": "2026-09-04T01:54:10.796928+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:28.993994+00:00",
+     "start_time": "2026-09-04T01:54:10.791682+00:00",
      "status": "completed"
     }
    },
@@ -654,16 +662,16 @@
    "id": "1d4d8ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.003429Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.003363Z",
-     "iopub.status.idle": "2026-09-04T01:46:29.729667Z",
-     "shell.execute_reply": "2026-09-04T01:46:29.729245Z"
+     "iopub.execute_input": "2026-09-04T01:54:10.801900Z",
+     "iopub.status.busy": "2026-09-04T01:54:10.801831Z",
+     "iopub.status.idle": "2026-09-04T01:54:11.547658Z",
+     "shell.execute_reply": "2026-09-04T01:54:11.547320Z"
     },
     "papermill": {
-     "duration": 0.728976,
-     "end_time": "2026-09-04T01:46:29.729924+00:00",
+     "duration": 0.748711,
+     "end_time": "2026-09-04T01:54:11.548062+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.000948+00:00",
+     "start_time": "2026-09-04T01:54:10.799351+00:00",
      "status": "completed"
     }
    },
@@ -731,10 +739,10 @@
    "id": "0cf37619",
    "metadata": {
     "papermill": {
-     "duration": 0.002223,
-     "end_time": "2026-09-04T01:46:29.734580+00:00",
+     "duration": 0.002122,
+     "end_time": "2026-09-04T01:54:11.552577+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.732357+00:00",
+     "start_time": "2026-09-04T01:54:11.550455+00:00",
      "status": "completed"
     }
    },
@@ -748,10 +756,10 @@
    "id": "1beddfd6",
    "metadata": {
     "papermill": {
-     "duration": 0.002025,
-     "end_time": "2026-09-04T01:46:29.738869+00:00",
+     "duration": 0.002104,
+     "end_time": "2026-09-04T01:54:11.556833+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.736844+00:00",
+     "start_time": "2026-09-04T01:54:11.554729+00:00",
      "status": "completed"
     }
    },
@@ -770,10 +778,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00207,
-     "end_time": "2026-09-04T01:46:29.742967+00:00",
+     "duration": 0.00205,
+     "end_time": "2026-09-04T01:54:11.560992+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.740897+00:00",
+     "start_time": "2026-09-04T01:54:11.558942+00:00",
      "status": "completed"
     }
    },
@@ -789,16 +797,16 @@
    "id": "40e814a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.747889Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.747787Z",
-     "iopub.status.idle": "2026-09-04T01:46:29.750082Z",
-     "shell.execute_reply": "2026-09-04T01:46:29.749598Z"
+     "iopub.execute_input": "2026-09-04T01:54:11.565785Z",
+     "iopub.status.busy": "2026-09-04T01:54:11.565684Z",
+     "iopub.status.idle": "2026-09-04T01:54:11.567652Z",
+     "shell.execute_reply": "2026-09-04T01:54:11.567374Z"
     },
     "papermill": {
-     "duration": 0.005328,
-     "end_time": "2026-09-04T01:46:29.750360+00:00",
+     "duration": 0.005061,
+     "end_time": "2026-09-04T01:54:11.568123+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.745032+00:00",
+     "start_time": "2026-09-04T01:54:11.563062+00:00",
      "status": "completed"
     }
    },
@@ -819,23 +827,23 @@
    "id": "5e49b24e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.755211Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.755118Z",
-     "iopub.status.idle": "2026-09-04T01:46:29.767481Z",
-     "shell.execute_reply": "2026-09-04T01:46:29.766960Z"
+     "iopub.execute_input": "2026-09-04T01:54:11.573045Z",
+     "iopub.status.busy": "2026-09-04T01:54:11.572949Z",
+     "iopub.status.idle": "2026-09-04T01:54:11.581160Z",
+     "shell.execute_reply": "2026-09-04T01:54:11.580770Z"
     },
     "papermill": {
-     "duration": 0.015428,
-     "end_time": "2026-09-04T01:46:29.767905+00:00",
+     "duration": 0.011674,
+     "end_time": "2026-09-04T01:54:11.581883+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.752477+00:00",
+     "start_time": "2026-09-04T01:54:11.570209+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "if len(positions_df) > 0 and positions_df[\"report_period\"].n_unique() > 1:\n",
-    "    stock_quarter = positions_df.group_by([\"cusip\", \"report_period\"]).agg(\n",
+    "if len(complete_positions_df) > 0 and complete_positions_df[\"report_period\"].n_unique() > 1:\n",
+    "    stock_quarter = complete_positions_df.group_by([\"cusip\", \"report_period\"]).agg(\n",
     "        pl.col(\"issuer\").first().alias(\"issuer_name\"),\n",
     "        pl.col(\"reported_value_usd\").sum().alias(\"quarter_value_usd\"),\n",
     "        pl.col(\"cik\").n_unique().alias(\"n_institutions\"),\n",
@@ -843,7 +851,7 @@
     "    )\n",
     "    comparison_periods = stock_quarter[\"report_period\"].unique().sort(descending=True).head(2)\n",
     "    current_period, prior_period = comparison_periods.to_list()\n",
-    "    current_availability = positions_df.filter(pl.col(\"report_period\") == current_period)[\n",
+    "    current_availability = complete_positions_df.filter(pl.col(\"report_period\") == current_period)[\n",
     "        \"timestamp\"\n",
     "    ].max()\n",
     "    prior = select_stock_quarter(stock_quarter, prior_period, \"q1\")\n",
@@ -877,10 +885,10 @@
    "id": "74e716a1",
    "metadata": {
     "papermill": {
-     "duration": 0.002139,
-     "end_time": "2026-09-04T01:46:29.772442+00:00",
+     "duration": 0.003976,
+     "end_time": "2026-09-04T01:54:11.590107+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.770303+00:00",
+     "start_time": "2026-09-04T01:54:11.586131+00:00",
      "status": "completed"
     }
    },
@@ -900,16 +908,16 @@
    "id": "e1a495a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.777479Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.777328Z",
-     "iopub.status.idle": "2026-09-04T01:46:29.785952Z",
-     "shell.execute_reply": "2026-09-04T01:46:29.785338Z"
+     "iopub.execute_input": "2026-09-04T01:54:11.597072Z",
+     "iopub.status.busy": "2026-09-04T01:54:11.596971Z",
+     "iopub.status.idle": "2026-09-04T01:54:11.605441Z",
+     "shell.execute_reply": "2026-09-04T01:54:11.605066Z"
     },
     "papermill": {
-     "duration": 0.011748,
-     "end_time": "2026-09-04T01:46:29.786297+00:00",
+     "duration": 0.011565,
+     "end_time": "2026-09-04T01:54:11.605709+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.774549+00:00",
+     "start_time": "2026-09-04T01:54:11.594144+00:00",
      "status": "completed"
     }
    },
@@ -1010,10 +1018,10 @@
    "id": "ccfd31a4",
    "metadata": {
     "papermill": {
-     "duration": 0.002178,
-     "end_time": "2026-09-04T01:46:29.790843+00:00",
+     "duration": 0.002305,
+     "end_time": "2026-09-04T01:54:11.610759+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.788665+00:00",
+     "start_time": "2026-09-04T01:54:11.608454+00:00",
      "status": "completed"
     }
    },
@@ -1028,10 +1036,10 @@
    "id": "f23bed6b",
    "metadata": {
     "papermill": {
-     "duration": 0.002107,
-     "end_time": "2026-09-04T01:46:29.795117+00:00",
+     "duration": 0.002108,
+     "end_time": "2026-09-04T01:54:11.615023+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.793010+00:00",
+     "start_time": "2026-09-04T01:54:11.612915+00:00",
      "status": "completed"
     }
    },
@@ -1048,16 +1056,16 @@
    "id": "7738bc8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.800454Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.800299Z",
-     "iopub.status.idle": "2026-09-04T01:46:29.811306Z",
-     "shell.execute_reply": "2026-09-04T01:46:29.810852Z"
+     "iopub.execute_input": "2026-09-04T01:54:11.619968Z",
+     "iopub.status.busy": "2026-09-04T01:54:11.619876Z",
+     "iopub.status.idle": "2026-09-04T01:54:11.630635Z",
+     "shell.execute_reply": "2026-09-04T01:54:11.630303Z"
     },
     "papermill": {
-     "duration": 0.01443,
-     "end_time": "2026-09-04T01:46:29.811735+00:00",
+     "duration": 0.013933,
+     "end_time": "2026-09-04T01:54:11.631118+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.797305+00:00",
+     "start_time": "2026-09-04T01:54:11.617185+00:00",
      "status": "completed"
     }
    },
@@ -1084,16 +1092,16 @@
    "id": "dd2aaa02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.817189Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.817086Z",
-     "iopub.status.idle": "2026-09-04T01:46:29.823367Z",
-     "shell.execute_reply": "2026-09-04T01:46:29.823025Z"
+     "iopub.execute_input": "2026-09-04T01:54:11.637806Z",
+     "iopub.status.busy": "2026-09-04T01:54:11.637651Z",
+     "iopub.status.idle": "2026-09-04T01:54:11.649338Z",
+     "shell.execute_reply": "2026-09-04T01:54:11.648971Z"
     },
     "papermill": {
-     "duration": 0.009451,
-     "end_time": "2026-09-04T01:46:29.823642+00:00",
+     "duration": 0.015998,
+     "end_time": "2026-09-04T01:54:11.649730+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.814191+00:00",
+     "start_time": "2026-09-04T01:54:11.633732+00:00",
      "status": "completed"
     }
    },
@@ -1212,10 +1220,10 @@
    "id": "725a1471",
    "metadata": {
     "papermill": {
-     "duration": 0.002251,
-     "end_time": "2026-09-04T01:46:29.828279+00:00",
+     "duration": 0.002554,
+     "end_time": "2026-09-04T01:54:11.655159+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.826028+00:00",
+     "start_time": "2026-09-04T01:54:11.652605+00:00",
      "status": "completed"
     }
    },
@@ -1231,10 +1239,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002183,
-     "end_time": "2026-09-04T01:46:29.832687+00:00",
+     "duration": 0.002185,
+     "end_time": "2026-09-04T01:54:11.659638+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.830504+00:00",
+     "start_time": "2026-09-04T01:54:11.657453+00:00",
      "status": "completed"
     }
    },
@@ -1253,16 +1261,16 @@
    "id": "e00f4c7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.838088Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.837986Z",
-     "iopub.status.idle": "2026-09-04T01:46:29.840951Z",
-     "shell.execute_reply": "2026-09-04T01:46:29.840585Z"
+     "iopub.execute_input": "2026-09-04T01:54:11.665096Z",
+     "iopub.status.busy": "2026-09-04T01:54:11.664910Z",
+     "iopub.status.idle": "2026-09-04T01:54:11.668888Z",
+     "shell.execute_reply": "2026-09-04T01:54:11.668417Z"
     },
     "papermill": {
-     "duration": 0.006212,
-     "end_time": "2026-09-04T01:46:29.841211+00:00",
+     "duration": 0.00732,
+     "end_time": "2026-09-04T01:54:11.669156+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.834999+00:00",
+     "start_time": "2026-09-04T01:54:11.661836+00:00",
      "status": "completed"
     }
    },
@@ -1304,10 +1312,10 @@
    "metadata": {
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.002228,
-     "end_time": "2026-09-04T01:46:29.845827+00:00",
+     "duration": 0.002536,
+     "end_time": "2026-09-04T01:54:11.674340+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.843599+00:00",
+     "start_time": "2026-09-04T01:54:11.671804+00:00",
      "status": "completed"
     }
    },
@@ -1325,16 +1333,16 @@
    "id": "dbfaed6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.850985Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.850897Z",
-     "iopub.status.idle": "2026-09-04T01:46:29.853541Z",
-     "shell.execute_reply": "2026-09-04T01:46:29.853207Z"
+     "iopub.execute_input": "2026-09-04T01:54:11.679917Z",
+     "iopub.status.busy": "2026-09-04T01:54:11.679752Z",
+     "iopub.status.idle": "2026-09-04T01:54:11.683256Z",
+     "shell.execute_reply": "2026-09-04T01:54:11.682824Z"
     },
     "papermill": {
-     "duration": 0.005772,
-     "end_time": "2026-09-04T01:46:29.853833+00:00",
+     "duration": 0.006868,
+     "end_time": "2026-09-04T01:54:11.683513+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.848061+00:00",
+     "start_time": "2026-09-04T01:54:11.676645+00:00",
      "status": "completed"
     }
    },
@@ -1375,16 +1383,16 @@
    "id": "6d739254",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.859179Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.859079Z",
-     "iopub.status.idle": "2026-09-04T01:46:29.902710Z",
-     "shell.execute_reply": "2026-09-04T01:46:29.901402Z"
+     "iopub.execute_input": "2026-09-04T01:54:11.689241Z",
+     "iopub.status.busy": "2026-09-04T01:54:11.689075Z",
+     "iopub.status.idle": "2026-09-04T01:54:11.729325Z",
+     "shell.execute_reply": "2026-09-04T01:54:11.728806Z"
     },
     "papermill": {
-     "duration": 0.047385,
-     "end_time": "2026-09-04T01:46:29.903583+00:00",
+     "duration": 0.043855,
+     "end_time": "2026-09-04T01:54:11.729744+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.856198+00:00",
+     "start_time": "2026-09-04T01:54:11.685889+00:00",
      "status": "completed"
     }
    },
@@ -1489,10 +1497,10 @@
    "id": "00ef6e02",
    "metadata": {
     "papermill": {
-     "duration": 0.003815,
-     "end_time": "2026-09-04T01:46:29.913262+00:00",
+     "duration": 0.002714,
+     "end_time": "2026-09-04T01:54:11.736374+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.909447+00:00",
+     "start_time": "2026-09-04T01:54:11.733660+00:00",
      "status": "completed"
     }
    },
@@ -1507,10 +1515,10 @@
    "id": "82368d67",
    "metadata": {
     "papermill": {
-     "duration": 0.002296,
-     "end_time": "2026-09-04T01:46:29.918393+00:00",
+     "duration": 0.002318,
+     "end_time": "2026-09-04T01:54:11.741151+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.916097+00:00",
+     "start_time": "2026-09-04T01:54:11.738833+00:00",
      "status": "completed"
     }
    },
@@ -1527,16 +1535,16 @@
    "id": "df83725f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:29.923790Z",
-     "iopub.status.busy": "2026-09-04T01:46:29.923687Z",
-     "iopub.status.idle": "2026-09-04T01:46:31.291017Z",
-     "shell.execute_reply": "2026-09-04T01:46:31.290464Z"
+     "iopub.execute_input": "2026-09-04T01:54:11.746364Z",
+     "iopub.status.busy": "2026-09-04T01:54:11.746272Z",
+     "iopub.status.idle": "2026-09-04T01:54:13.162066Z",
+     "shell.execute_reply": "2026-09-04T01:54:13.158730Z"
     },
     "papermill": {
-     "duration": 1.370836,
-     "end_time": "2026-09-04T01:46:31.291538+00:00",
+     "duration": 1.420541,
+     "end_time": "2026-09-04T01:54:13.164033+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:29.920702+00:00",
+     "start_time": "2026-09-04T01:54:11.743492+00:00",
      "status": "completed"
     }
    },
@@ -1715,10 +1723,10 @@
    "id": "ca8ae157",
    "metadata": {
     "papermill": {
-     "duration": 0.004805,
-     "end_time": "2026-09-04T01:46:31.301955+00:00",
+     "duration": 0.006926,
+     "end_time": "2026-09-04T01:54:13.183270+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:31.297150+00:00",
+     "start_time": "2026-09-04T01:54:13.176344+00:00",
      "status": "completed"
     }
    },
@@ -1734,16 +1742,16 @@
    "id": "1f7d65a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:31.308340Z",
-     "iopub.status.busy": "2026-09-04T01:46:31.308237Z",
-     "iopub.status.idle": "2026-09-04T01:46:31.312392Z",
-     "shell.execute_reply": "2026-09-04T01:46:31.312017Z"
+     "iopub.execute_input": "2026-09-04T01:54:13.189888Z",
+     "iopub.status.busy": "2026-09-04T01:54:13.189686Z",
+     "iopub.status.idle": "2026-09-04T01:54:13.196609Z",
+     "shell.execute_reply": "2026-09-04T01:54:13.195845Z"
     },
     "papermill": {
-     "duration": 0.007976,
-     "end_time": "2026-09-04T01:46:31.312669+00:00",
+     "duration": 0.010989,
+     "end_time": "2026-09-04T01:54:13.197080+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:31.304693+00:00",
+     "start_time": "2026-09-04T01:54:13.186091+00:00",
      "status": "completed"
     }
    },
@@ -1778,10 +1786,10 @@
    "id": "ece20945",
    "metadata": {
     "papermill": {
-     "duration": 0.002581,
-     "end_time": "2026-09-04T01:46:31.317961+00:00",
+     "duration": 0.002704,
+     "end_time": "2026-09-04T01:54:13.203464+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:31.315380+00:00",
+     "start_time": "2026-09-04T01:54:13.200760+00:00",
      "status": "completed"
     }
    },
@@ -1796,16 +1804,16 @@
    "id": "da05b82b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:31.323794Z",
-     "iopub.status.busy": "2026-09-04T01:46:31.323687Z",
-     "iopub.status.idle": "2026-09-04T01:46:32.800363Z",
-     "shell.execute_reply": "2026-09-04T01:46:32.798536Z"
+     "iopub.execute_input": "2026-09-04T01:54:13.209991Z",
+     "iopub.status.busy": "2026-09-04T01:54:13.209821Z",
+     "iopub.status.idle": "2026-09-04T01:54:14.703723Z",
+     "shell.execute_reply": "2026-09-04T01:54:14.701829Z"
     },
     "papermill": {
-     "duration": 1.482221,
-     "end_time": "2026-09-04T01:46:32.802803+00:00",
+     "duration": 1.499404,
+     "end_time": "2026-09-04T01:54:14.705589+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:31.320582+00:00",
+     "start_time": "2026-09-04T01:54:13.206185+00:00",
      "status": "completed"
     }
    },
@@ -1980,10 +1988,10 @@
    "id": "55a09323",
    "metadata": {
     "papermill": {
-     "duration": 0.003524,
-     "end_time": "2026-09-04T01:46:32.815369+00:00",
+     "duration": 0.00359,
+     "end_time": "2026-09-04T01:54:14.719077+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:32.811845+00:00",
+     "start_time": "2026-09-04T01:54:14.715487+00:00",
      "status": "completed"
     }
    },
@@ -1998,16 +2006,16 @@
    "id": "d3a9e25a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:32.822060Z",
-     "iopub.status.busy": "2026-09-04T01:46:32.821864Z",
-     "iopub.status.idle": "2026-09-04T01:46:34.179362Z",
-     "shell.execute_reply": "2026-09-04T01:46:34.178720Z"
+     "iopub.execute_input": "2026-09-04T01:54:14.726187Z",
+     "iopub.status.busy": "2026-09-04T01:54:14.725978Z",
+     "iopub.status.idle": "2026-09-04T01:54:16.047019Z",
+     "shell.execute_reply": "2026-09-04T01:54:16.046651Z"
     },
     "papermill": {
-     "duration": 1.361628,
-     "end_time": "2026-09-04T01:46:34.179945+00:00",
+     "duration": 1.325263,
+     "end_time": "2026-09-04T01:54:16.047414+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:32.818317+00:00",
+     "start_time": "2026-09-04T01:54:14.722151+00:00",
      "status": "completed"
     }
    },
@@ -2252,10 +2260,10 @@
    "id": "1b3c1cc7",
    "metadata": {
     "papermill": {
-     "duration": 0.00659,
-     "end_time": "2026-09-04T01:46:34.196083+00:00",
+     "duration": 0.003335,
+     "end_time": "2026-09-04T01:54:16.054313+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.189493+00:00",
+     "start_time": "2026-09-04T01:54:16.050978+00:00",
      "status": "completed"
     }
    },
@@ -2270,10 +2278,10 @@
    "id": "f3c13b8e",
    "metadata": {
     "papermill": {
-     "duration": 0.003171,
-     "end_time": "2026-09-04T01:46:34.204268+00:00",
+     "duration": 0.003584,
+     "end_time": "2026-09-04T01:54:16.061245+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.201097+00:00",
+     "start_time": "2026-09-04T01:54:16.057661+00:00",
      "status": "completed"
     }
    },
@@ -2289,16 +2297,16 @@
    "id": "307d167c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:34.211738Z",
-     "iopub.status.busy": "2026-09-04T01:46:34.211565Z",
-     "iopub.status.idle": "2026-09-04T01:46:34.229176Z",
-     "shell.execute_reply": "2026-09-04T01:46:34.228711Z"
+     "iopub.execute_input": "2026-09-04T01:54:16.068915Z",
+     "iopub.status.busy": "2026-09-04T01:54:16.068806Z",
+     "iopub.status.idle": "2026-09-04T01:54:16.082783Z",
+     "shell.execute_reply": "2026-09-04T01:54:16.082392Z"
     },
     "papermill": {
-     "duration": 0.022052,
-     "end_time": "2026-09-04T01:46:34.229586+00:00",
+     "duration": 0.018829,
+     "end_time": "2026-09-04T01:54:16.083432+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.207534+00:00",
+     "start_time": "2026-09-04T01:54:16.064603+00:00",
      "status": "completed"
     }
    },
@@ -2393,10 +2401,10 @@
    "metadata": {
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.003259,
-     "end_time": "2026-09-04T01:46:34.236348+00:00",
+     "duration": 0.00671,
+     "end_time": "2026-09-04T01:54:16.096959+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.233089+00:00",
+     "start_time": "2026-09-04T01:54:16.090249+00:00",
      "status": "completed"
     }
    },
@@ -2411,16 +2419,16 @@
    "id": "3fe05aa4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:34.243486Z",
-     "iopub.status.busy": "2026-09-04T01:46:34.243395Z",
-     "iopub.status.idle": "2026-09-04T01:46:34.249001Z",
-     "shell.execute_reply": "2026-09-04T01:46:34.248562Z"
+     "iopub.execute_input": "2026-09-04T01:54:16.105686Z",
+     "iopub.status.busy": "2026-09-04T01:54:16.105573Z",
+     "iopub.status.idle": "2026-09-04T01:54:16.112493Z",
+     "shell.execute_reply": "2026-09-04T01:54:16.112187Z"
     },
     "papermill": {
-     "duration": 0.009839,
-     "end_time": "2026-09-04T01:46:34.249426+00:00",
+     "duration": 0.011514,
+     "end_time": "2026-09-04T01:54:16.113088+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.239587+00:00",
+     "start_time": "2026-09-04T01:54:16.101574+00:00",
      "status": "completed"
     }
    },
@@ -2517,10 +2525,10 @@
    "id": "4ab0f305",
    "metadata": {
     "papermill": {
-     "duration": 0.003605,
-     "end_time": "2026-09-04T01:46:34.256547+00:00",
+     "duration": 0.003494,
+     "end_time": "2026-09-04T01:54:16.123793+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.252942+00:00",
+     "start_time": "2026-09-04T01:54:16.120299+00:00",
      "status": "completed"
     }
    },
@@ -2537,16 +2545,16 @@
    "id": "c486ac8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:34.264070Z",
-     "iopub.status.busy": "2026-09-04T01:46:34.263978Z",
-     "iopub.status.idle": "2026-09-04T01:46:34.282594Z",
-     "shell.execute_reply": "2026-09-04T01:46:34.281939Z"
+     "iopub.execute_input": "2026-09-04T01:54:16.131562Z",
+     "iopub.status.busy": "2026-09-04T01:54:16.131449Z",
+     "iopub.status.idle": "2026-09-04T01:54:16.142982Z",
+     "shell.execute_reply": "2026-09-04T01:54:16.142561Z"
     },
     "papermill": {
-     "duration": 0.022972,
-     "end_time": "2026-09-04T01:46:34.283085+00:00",
+     "duration": 0.016383,
+     "end_time": "2026-09-04T01:54:16.143638+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.260113+00:00",
+     "start_time": "2026-09-04T01:54:16.127255+00:00",
      "status": "completed"
     }
    },
@@ -2592,10 +2600,10 @@
    "id": "36981252",
    "metadata": {
     "papermill": {
-     "duration": 0.006088,
-     "end_time": "2026-09-04T01:46:34.298542+00:00",
+     "duration": 0.003555,
+     "end_time": "2026-09-04T01:54:16.151174+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.292454+00:00",
+     "start_time": "2026-09-04T01:54:16.147619+00:00",
      "status": "completed"
     }
    },
@@ -2613,10 +2621,10 @@
    "id": "86ab5710",
    "metadata": {
     "papermill": {
-     "duration": 0.003397,
-     "end_time": "2026-09-04T01:46:34.305599+00:00",
+     "duration": 0.003376,
+     "end_time": "2026-09-04T01:54:16.157882+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.302202+00:00",
+     "start_time": "2026-09-04T01:54:16.154506+00:00",
      "status": "completed"
     }
    },
@@ -2637,16 +2645,16 @@
    "id": "1b1fef33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:34.313103Z",
-     "iopub.status.busy": "2026-09-04T01:46:34.313003Z",
-     "iopub.status.idle": "2026-09-04T01:46:34.315013Z",
-     "shell.execute_reply": "2026-09-04T01:46:34.314737Z"
+     "iopub.execute_input": "2026-09-04T01:54:16.165566Z",
+     "iopub.status.busy": "2026-09-04T01:54:16.165460Z",
+     "iopub.status.idle": "2026-09-04T01:54:16.167461Z",
+     "shell.execute_reply": "2026-09-04T01:54:16.167181Z"
     },
     "papermill": {
-     "duration": 0.006408,
-     "end_time": "2026-09-04T01:46:34.315369+00:00",
+     "duration": 0.006548,
+     "end_time": "2026-09-04T01:54:16.167879+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.308961+00:00",
+     "start_time": "2026-09-04T01:54:16.161331+00:00",
      "status": "completed"
     }
    },
@@ -2686,10 +2694,10 @@
    "id": "913de717",
    "metadata": {
     "papermill": {
-     "duration": 0.003294,
-     "end_time": "2026-09-04T01:46:34.322016+00:00",
+     "duration": 0.003311,
+     "end_time": "2026-09-04T01:54:16.174623+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.318722+00:00",
+     "start_time": "2026-09-04T01:54:16.171312+00:00",
      "status": "completed"
     }
    },
@@ -2715,10 +2723,10 @@
    "id": "c0b949fc",
    "metadata": {
     "papermill": {
-     "duration": 0.003413,
-     "end_time": "2026-09-04T01:46:34.328727+00:00",
+     "duration": 0.003338,
+     "end_time": "2026-09-04T01:54:16.181407+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.325314+00:00",
+     "start_time": "2026-09-04T01:54:16.178069+00:00",
      "status": "completed"
     }
    },
@@ -2743,16 +2751,16 @@
    "id": "da8a8ec1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-04T01:46:34.336243Z",
-     "iopub.status.busy": "2026-09-04T01:46:34.336164Z",
-     "iopub.status.idle": "2026-09-04T01:46:34.341217Z",
-     "shell.execute_reply": "2026-09-04T01:46:34.340947Z"
+     "iopub.execute_input": "2026-09-04T01:54:16.188858Z",
+     "iopub.status.busy": "2026-09-04T01:54:16.188745Z",
+     "iopub.status.idle": "2026-09-04T01:54:16.193685Z",
+     "shell.execute_reply": "2026-09-04T01:54:16.193188Z"
     },
     "papermill": {
-     "duration": 0.009638,
-     "end_time": "2026-09-04T01:46:34.341675+00:00",
+     "duration": 0.009461,
+     "end_time": "2026-09-04T01:54:16.194216+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.332037+00:00",
+     "start_time": "2026-09-04T01:54:16.184755+00:00",
      "status": "completed"
     }
    },
@@ -2787,10 +2795,10 @@
    "id": "89a063ba",
    "metadata": {
     "papermill": {
-     "duration": 0.003341,
-     "end_time": "2026-09-04T01:46:34.348651+00:00",
+     "duration": 0.004913,
+     "end_time": "2026-09-04T01:54:16.203077+00:00",
      "exception": false,
-     "start_time": "2026-09-04T01:46:34.345310+00:00",
+     "start_time": "2026-09-04T01:54:16.198164+00:00",
      "status": "completed"
     }
    },
@@ -2851,23 +2859,23 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "abd1b4b2d30429dc86827892542f4dfe2fa8d468",
-   "executed_at": "2026-09-04T01:46:59.187705+00:00",
+   "source_py_blob": "e620694c0abc92cf99bde41ef04bb9c7e8f527d3",
+   "executed_at": "2026-09-04T01:54:28.065883+00:00",
    "executor": "local-uv",
    "production": true,
    "parameters": {},
-   "notes": "Re-executed for the 13F consumer edge cases: coverage and availability taken from the unfiltered disclosures, momentum columns emitted on the no-comparison path"
+   "notes": "Re-executed for the 13F consumer edge cases: coverage and availability from the unfiltered disclosures, momentum from the untruncated complete-quarter panel, momentum columns on the no-comparison path"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 8.885589,
-   "end_time": "2026-09-04T01:46:35.368109+00:00",
+   "duration": 8.709632,
+   "end_time": "2026-09-04T01:54:17.124683+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "22_rag_financial_research/07_institutional_holdings_graph.ipynb",
    "output_path": "22_rag_financial_research/07_institutional_holdings_graph.ipynb",
    "parameters": {},
-   "start_time": "2026-09-04T01:46:26.482520+00:00",
+   "start_time": "2026-09-04T01:54:08.415051+00:00",
    "version": "2.7.0"
   }
  },

--- a/22_rag_financial_research/07_institutional_holdings_graph.py
+++ b/22_rag_financial_research/07_institutional_holdings_graph.py
@@ -228,6 +228,14 @@ if partial_periods:
         f"{', '.join(str(p) for p in partial_periods)}"
     )
 positions_df = positions_df.filter(pl.col("report_period").is_in(complete_periods))
+# Every complete quarter, before NUM_QUARTERS narrows what this notebook displays. The
+# ownership-change table is part of the canonical feature set and the producer computes it
+# over the artifact's own last two complete quarters, so it has to be built from this frame
+# rather than from the displayed one: with NUM_QUARTERS=1 over a multi-quarter artifact the
+# truncated frame has nothing to compare, and emitting zero change there would contradict a
+# producer that compared two quarters. A one-quarter *artifact* is the different case the
+# no-comparison branch below handles.
+complete_positions_df = positions_df
 
 if NUM_QUARTERS > 0:
     recent_periods = (
@@ -392,8 +400,8 @@ def select_stock_quarter(df: pl.DataFrame, period, suffix: str) -> pl.DataFrame:
 
 
 # %%
-if len(positions_df) > 0 and positions_df["report_period"].n_unique() > 1:
-    stock_quarter = positions_df.group_by(["cusip", "report_period"]).agg(
+if len(complete_positions_df) > 0 and complete_positions_df["report_period"].n_unique() > 1:
+    stock_quarter = complete_positions_df.group_by(["cusip", "report_period"]).agg(
         pl.col("issuer").first().alias("issuer_name"),
         pl.col("reported_value_usd").sum().alias("quarter_value_usd"),
         pl.col("cik").n_unique().alias("n_institutions"),
@@ -401,7 +409,7 @@ if len(positions_df) > 0 and positions_df["report_period"].n_unique() > 1:
     )
     comparison_periods = stock_quarter["report_period"].unique().sort(descending=True).head(2)
     current_period, prior_period = comparison_periods.to_list()
-    current_availability = positions_df.filter(pl.col("report_period") == current_period)[
+    current_availability = complete_positions_df.filter(pl.col("report_period") == current_period)[
         "timestamp"
     ].max()
     prior = select_stock_quarter(stock_quarter, prior_period, "q1")

--- a/22_rag_financial_research/07_institutional_holdings_graph.py
+++ b/22_rag_financial_research/07_institutional_holdings_graph.py
@@ -137,6 +137,14 @@ if holdings_df.schema["report_date"] != pl.Date:
 # Filter to the CIKs listed in ALL_INSTITUTIONS. The artifact may contain a
 # wider or narrower set; rows outside this universe are dropped.
 holdings_df = holdings_df.filter(pl.col("cik").is_in(SELECTED_CIKS))
+# Whether a manager filed for a quarter, and when that quarter became public, are
+# questions about what was *disclosed* - not about what enters the graph. The producer
+# counts any disclosed row as evidence a manager filed, so both are answered from the
+# selected holdings before the option filter below. A manager that discloses options only
+# has filed; reading coverage off the filtered frame would make this notebook step back
+# from, or reject, a quarter the producer used, and the parity assertion at the end would
+# then compare two different quarters.
+disclosed_df = holdings_df
 option_rows = holdings_df.filter(
     pl.col("put_call").fill_null("").cast(pl.Utf8).str.strip_chars() != ""
 ).height
@@ -160,8 +168,10 @@ holdings_df = holdings_df.with_columns(
 # A reporting quarter becomes available only after the last included manager
 # files. Duplicate CIK/CUSIP rows in an information table are summed rather than
 # selected positionally.
-quarter_availability = holdings_df.group_by("report_period").agg(
-    pl.col("filing_date").max().alias("timestamp")
+quarter_availability = (
+    disclosed_df.with_columns(pl.col("report_date").alias("report_period"))
+    .group_by("report_period")
+    .agg(pl.col("filing_date").max().alias("timestamp"))
 )
 
 # %% [markdown]
@@ -196,9 +206,10 @@ positions_df = (
 # quarter holds the early filers only, and their peers' absence would read as a
 # mass exit rather than as missing coverage. The downloader applies the same rule,
 # so this is also what keeps the reconstruction below equal to its artifacts.
-covered_ciks = holdings_df["cik"].n_unique()
+covered_ciks = disclosed_df["cik"].n_unique()
 complete_periods = (
-    positions_df.group_by("report_period")
+    disclosed_df.with_columns(pl.col("report_date").alias("report_period"))
+    .group_by("report_period")
     .agg(pl.col("cik").n_unique().alias("n_ciks"))
     .filter(pl.col("n_ciks") == covered_ciks)["report_period"]
     .to_list()
@@ -849,6 +860,16 @@ if len(latest_holdings) > 0:
             .sort("cusip")
         )
         print("Added momentum features")
+    else:
+        # With one complete quarter there is nothing to compare against, and the producer
+        # emits both columns anyway - 0.0 and null - so an artifact built with
+        # `--num-filings 1` has the same schema as any other. Skipping them here left the
+        # parity assertion below comparing a frame two columns short.
+        stock_features = stock_features.with_columns(
+            pl.lit(0.0, dtype=pl.Float64).alias("inst_value_change_usd"),
+            pl.lit(None, dtype=pl.Float64).alias("inst_pct_change"),
+        ).sort("cusip")
+        print("Single complete quarter: momentum columns emitted as 0.0 / null")
 
     display(stock_features.head(10))
 

--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -27,6 +27,7 @@ from case_studies.research import (
     StateTransitionPolicy,
     Study,
     plan_backtests,
+    require_resolved_requests_cover_the_catalog,
     run_backtests,
     run_models,
 )
@@ -300,6 +301,7 @@ def run_official_model_catalog(
         resolved = resolve_model_requests(study, request_catalog, execution_tier="canonical")
     if any(request.spec["execution_tier"] != "canonical" for request in resolved):
         raise ValueError("official model populations require canonical requests")
+    require_resolved_requests_cover_the_catalog(request_catalog, resolved)
     expected = expected_prediction_hashes(resolved)
     population = OfficialPopulation.create(
         study,

--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -28,6 +28,7 @@ from .execution import (
     PlannedBacktest,
     expected_prediction_hashes,
     plan_backtests,
+    require_resolved_requests_cover_the_catalog,
     run_backtests,
     run_model_population,
     run_models,
@@ -170,6 +171,7 @@ __all__ = [
     "superseded_members_at",
     "run_models",
     "run_official_model_subset",
+    "require_resolved_requests_cover_the_catalog",
     "run_official_models",
     "snapshot_official_models",
 ]

--- a/case_studies/research/execution.py
+++ b/case_studies/research/execution.py
@@ -466,6 +466,43 @@ def expected_prediction_hashes(
     return prediction_hashes_from_specs(request.spec for request in resolved_requests)
 
 
+def require_resolved_requests_cover_the_catalog(
+    request_catalog: pl.DataFrame,
+    resolved: Iterable[ResolvedModelRequest],
+) -> None:
+    """Refuse a snapshot built from a resolved set that is not the declared catalog.
+
+    Supplying ``resolved_requests`` beside a ``request_catalog`` is how a caller avoids
+    resolving twice - resolving a data-dependent penalty prepares every fold, so a large
+    panel cannot afford to do it once for the plan and again for the run. It is not a way
+    to narrow what the population contains, and nothing else distinguishes the two uses:
+    the population is declared from the resolved set, so a partial one snapshots under the
+    catalog's name and reports complete.
+
+    ``require_complete`` cannot catch that. It measures the population against the members
+    it just declared, which a partial set satisfies exactly. A population is the definition
+    of a comparison - selection is best validation backtest Sharpe across it - so every
+    configuration the resolved set omitted is not merely unreported, it is removed from the
+    competition, and the winner is chosen from the survivors. The result is internally
+    consistent, complete, correctly hashed, and the answer to a smaller question than its
+    name claims.
+
+    Both ``family``/``label``/``config_name`` triples are compared, not counts: a catalog of
+    the same size drawn from different labels is a different comparison.
+    """
+    declared = set(request_catalog.select("family", "label", "config_name").unique().iter_rows())
+    submitted = {
+        (request.family, request.spec["label"], request.spec.get("config_name"))
+        for request in resolved
+    }
+    if submitted != declared:
+        missing = sorted(declared - submitted)
+        extra = sorted(submitted - declared)
+        raise ValueError(
+            f"resolved requests do not match the declared catalog: missing={missing}, extra={extra}"
+        )
+
+
 def snapshot_official_models(
     study: Study,
     resolved_requests: Iterable[ResolvedModelRequest],
@@ -566,6 +603,12 @@ def run_official_models(
     A notebook that already built a :class:`ModelPlan` to show what it is about to fit passes the
     plan itself. Passing its requests instead would plan a second time, and planning a large panel
     is not free: resolving a data-dependent penalty prepares every fold to do it.
+
+    Both paths declare the population from ``requests`` and from nothing else, so neither can tell
+    a complete submission from a partial one - there is no second statement here of what the name
+    is supposed to contain. A caller that holds one, because it loaded a declared catalog and
+    passes a separately resolved set beside it, checks the two against each other with
+    :func:`require_resolved_requests_cover_the_catalog` before the snapshot is written.
     """
     if isinstance(requests, ModelPlan):
         if requests.study != study:

--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -46,7 +46,7 @@ def widest_label_buffer(case_study: str, setup: Mapping[str, Any]) -> tuple[str,
     :func:`utils.artifact_specs.resolve_label_buffer`, so a label carrying its own spec
     artifact still wins over the setup block.
     """
-    from utils.artifact_specs import resolve_label_buffer
+    from utils.artifact_specs import resolve_label_buffer, resolve_label_buffer_unit
     from utils.cv_splits import normalize_label_buffer
 
     labels = setup.get("labels") or {}
@@ -56,13 +56,31 @@ def widest_label_buffer(case_study: str, setup: Mapping[str, Any]) -> tuple[str,
         raise ValueError(f"{case_study} declares no labels, so no holdout buffer can be derived")
 
     widest: tuple[pd.Timedelta, str, str] | None = None
+    units: dict[str, str] = {}
     for name in names:
         buffer = resolve_label_buffer(case_study, name, setup)
         if not buffer:
             continue
+        units[name] = resolve_label_buffer_unit(case_study, name, setup)
         span = pd.Timedelta(normalize_label_buffer(buffer))
         if widest is None or span > widest[0]:
             widest = (span, str(buffer), name)
+    # "Widest" is decided by comparing the declared durations as timedeltas, which only
+    # answers the question when every label counts the same thing. 21 sessions and 21
+    # calendar days are not the same span, and reading both as timedeltas ranks them
+    # equal, so a mixed declaration would seal the holdout on whichever label happened to
+    # sort first. Refuse rather than pick: no case study declares a mix today, and the
+    # fix when one does is to compare on a common axis, not to keep guessing.
+    if len(set(units.values())) > 1:
+        by_unit = {
+            unit: sorted(n for n, u in units.items() if u == unit) for unit in set(units.values())
+        }
+        raise ValueError(
+            f"{case_study} declares buffers in more than one unit ({by_unit}), and the "
+            "widest buffer is chosen by comparing them as durations, which a session "
+            "count and a calendar span cannot be compared as. Declare one unit for the "
+            "case study, or give the holdout seal an explicit buffer."
+        )
     if widest is None:
         raise ValueError(
             f"{case_study} declares labels {names} and a buffer for none of them, so the gap "

--- a/case_studies/research/labels.py
+++ b/case_studies/research/labels.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import uuid
@@ -122,13 +121,18 @@ class LabelCatalog:
         if not path.is_file():
             raise FileNotFoundError(f"label artifact is missing: {path}")
         resolved_metadata_path = sidecar_path(path)
+        digest = value_digest(pl.read_parquet(path))
         if resolved_metadata_path.exists():
             metadata = json.loads(resolved_metadata_path.read_text())
-            digest = value_digest(pl.read_parquet(path))
             if metadata.get("digest") != digest:
                 raise ValueError(f"label artifact digest does not match its sidecar: {path}")
-        else:
-            digest = hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+        # The sidecar-less branch used to digest the file's bytes, so the same label values
+        # under a different parquet codec or row-group size produced a different label
+        # identity - and an artifact with a sidecar and one without disagreed about the
+        # same data. Every production label carries a sidecar; the CI fixtures, written
+        # before sidecars existed, do not, so that branch was the difference between what
+        # CI computes and what production computes. `value_digest` digests the values and
+        # answers the same either way.
         return LabelRef(definition=definition, path=path, digest=digest)
 
     def publish(self, definition: LabelDefinition, frame: pl.DataFrame) -> LabelRef:

--- a/case_studies/sp500_options/research_workflow.py
+++ b/case_studies/sp500_options/research_workflow.py
@@ -25,6 +25,7 @@ from case_studies.research import (
     Result,
     Study,
     plan_backtests,
+    require_resolved_requests_cover_the_catalog,
     run_models,
 )
 from case_studies.research.execution import ModelExecution
@@ -226,30 +227,6 @@ def expected_prediction_hashes(
     return tuple(hashes)
 
 
-def _require_resolved_requests_cover_the_catalog(
-    request_catalog: pl.DataFrame,
-    resolved: tuple[ResolvedModelRequest, ...],
-) -> None:
-    """Refuse a snapshot built from a resolved set that is not the declared catalog.
-
-    Supplying ``resolved_requests`` is how a caller avoids resolving twice, not a way to narrow
-    what the population contains. Without this check, a stale or partial set snapshots under the
-    catalog's name and reports complete, and every configuration it omitted silently leaves the
-    comparison the population exists to define.
-    """
-    declared = set(request_catalog.select("family", "label", "config_name").unique().iter_rows())
-    submitted = {
-        (request.family, request.spec["label"], request.spec.get("config_name"))
-        for request in resolved
-    }
-    if submitted != declared:
-        missing = sorted(declared - submitted)
-        extra = sorted(submitted - declared)
-        raise ValueError(
-            f"resolved requests do not match the declared catalog: missing={missing}, extra={extra}"
-        )
-
-
 def run_official_model_catalog(
     study: Study,
     request_catalog: pl.DataFrame,
@@ -300,7 +277,7 @@ def snapshot_official_model_catalog(
         resolved = resolve_model_requests(study, request_catalog, execution_tier="canonical")
     if any(request.spec["execution_tier"] != "canonical" for request in resolved):
         raise ValueError("official model populations require canonical requests")
-    _require_resolved_requests_cover_the_catalog(request_catalog, resolved)
+    require_resolved_requests_cover_the_catalog(request_catalog, resolved)
     expected = expected_prediction_hashes(resolved)
     return OfficialPopulation.create(
         study,

--- a/case_studies/utils/artifact_digest.py
+++ b/case_studies/utils/artifact_digest.py
@@ -29,6 +29,29 @@ from .registry.specs import canonical_json, compute_hash
 
 DIGEST_LENGTH = 16
 
+# The parquet encoding every identity-defining artifact is written under.
+#
+# Registry training identity digests these files' *bytes* - `utils/modeling.py`'s
+# `_sha256_file` feeds `computation.feature_artifacts` and
+# `computation.input_data_spec.artifacts`, both inside the hashed `computation` block. Two
+# files holding identical data therefore hash differently if they were written with a
+# different compression codec or row-group size, so a polars upgrade that moves a default
+# would fork the `training_hash` of every run reading that artifact: cached runs stop
+# matching, the sweep refits everything, and no number has moved to say why.
+#
+# These are polars 1.41.1's own defaults, written out. Verified byte-identical to writing
+# with none of them passed, so stating them moves nothing today and pins the encoding
+# against a future default change. `tests/test_artifact_digest_encoding.py` records the
+# bytes a fixed frame produces under them, so a change arrives as a red test rather than as
+# a registry that has quietly grown two identities for one piece of work.
+_PARQUET_WRITE_SETTINGS: dict[str, Any] = {
+    "compression": "zstd",
+    "compression_level": None,
+    "statistics": True,
+    "row_group_size": None,
+    "data_page_size": None,
+}
+
 
 def value_digest(df: pl.DataFrame, columns: Sequence[str] | None = None) -> str:
     """Return the content digest of *df* over *columns* (default: all).
@@ -170,7 +193,7 @@ def write_artifact(
     # this pair exists to make impossible.
     serialized = json.dumps(record, indent=2, sort_keys=True) + "\n"
     path.parent.mkdir(parents=True, exist_ok=True)
-    df.write_parquet(path)
+    df.write_parquet(path, **_PARQUET_WRITE_SETTINGS)
     sidecar_path(path).write_text(serialized)
     return record
 

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1944,12 +1944,44 @@ def _run_vectorized(
     if weights_thinned["timestamp"].dtype != thinned_sel["timestamp"].dtype:
         thinned_sel = thinned_sel.cast({"timestamp": weights_thinned["timestamp"].dtype})
 
-    # Join weights with forward returns
+    # Join weights with forward returns.
+    #
+    # Left, not inner, and then a refusal. An inner join discarded a selected position whose
+    # outcome row is missing, and three things followed. Weights are never renormalized after
+    # the join, so `gross_ret` summed the survivors' contributions against the original
+    # weights - the dropped name was marked at exactly zero return, which is an assertion
+    # about a position nobody could price rather than an exclusion. `n_positions` counted the
+    # survivors, so the one diagnostic that would show the loss reported the reduced count as
+    # though it were intended. And turnover is computed from `weights_thinned` below, which
+    # still holds the dropped name, so the position paid its cost and returned nothing.
+    #
+    # Renormalizing instead would be a filter applied to a chosen position using data from
+    # after the choice: "the selection step is unbiased" and "the realized result is
+    # unbiased" are different claims, and that fails the second while passing the first. So
+    # the run stops. A zero weight is exempt because it is not a position: its outcome
+    # cannot change any number here.
     bt = weights_thinned.join(
         thinned_sel,
         on=["timestamp", "symbol"],
-        how="inner",
+        how="left",
     )
+    unpriceable = bt.filter(
+        (pl.col("weight") != 0.0) & (pl.col("y_true").is_null() | ~pl.col("y_true").is_finite())
+    )
+    if not unpriceable.is_empty():
+        sample = unpriceable.sort("timestamp", "symbol").head(5)
+        named = ", ".join(
+            f"{row['symbol']}@{row['timestamp']}" for row in sample.iter_rows(named=True)
+        )
+        raise ValueError(
+            f"{case_study}/{label}: {unpriceable.height} of {bt.height} selected positions have "
+            f"no usable outcome, across {unpriceable['timestamp'].n_unique()} rebalance dates "
+            f"(first: {named}). Marking them at zero return asserts a result for a position "
+            "nobody could price, and they would still pay turnover. Supply the missing outcome "
+            "rows, or exclude these names before the weights are computed so the selection and "
+            "the realized result are drawn from the same set."
+        )
+    bt = bt.filter(pl.col("y_true").is_not_null())
 
     # Portfolio returns per period
     port_ret = (

--- a/case_studies/utils/coverage.py
+++ b/case_studies/utils/coverage.py
@@ -42,7 +42,7 @@ from pathlib import Path
 
 import polars as pl
 
-from case_studies.utils.notebook_contracts import _ENTITY_ALIASES, _first_present
+from case_studies.utils.notebook_contracts import _first_present
 
 __all__ = [
     "CoverageError",
@@ -442,7 +442,9 @@ def _coverage(
                     )
                 )
 
-    # (2) Every session inside a declared fold carries at least one row.
+    # (2) Every session inside a declared fold carries at least one row. On the prediction
+    #     path `check_prediction_coverage` has already dropped rows with no score, so a row
+    #     there is a prediction; a backtest input frame is not required to carry one.
     expected_total = 0
     for fold, sessions in expected.items():
         expected_total += len(sessions)
@@ -534,6 +536,30 @@ def _sessions_between(
     return axis.filter(keep).to_list()
 
 
+def _scored_rows(frame: pl.DataFrame, *, case_study: str, label: str, split: str) -> pl.DataFrame:
+    """Restrict a prediction frame to the rows that actually carry a score.
+
+    ``_coverage`` counts a session as observed when a row exists for it. On the
+    prediction path that is not what the module promises: a frame with no score column
+    at all, or one whose scores are all null, described a complete set of decisions
+    that were never made.
+    """
+    score_col = _first_present(frame.columns, _SCORE_ALIASES)
+    if score_col is None:
+        raise CoverageError(
+            f"{case_study}/{label}/{split} predictions: no prediction column among "
+            f"{_SCORE_ALIASES} in columns {sorted(frame.columns)}. A frame with no score "
+            "is not a prediction set, and a check that cannot run must not read as a pass."
+        )
+    scored = frame.filter(pl.col(score_col).is_not_null())
+    if scored.is_empty():
+        raise CoverageError(
+            f"{case_study}/{label}/{split} predictions: every value in {score_col!r} is "
+            f"null across {frame.height} rows; the frame carries sessions but no predictions."
+        )
+    return scored
+
+
 def check_prediction_coverage(
     predictions: pl.DataFrame,
     case_study: str,
@@ -550,9 +576,18 @@ def check_prediction_coverage(
     Call this where the predictions are produced, before anything downstream reads
     them. ``raise_on_gap=False`` returns the report for a notebook that wants to
     display it before failing.
+
+    Condition (2) is read here as the module docstring states it - a session carries a
+    **prediction**, not merely a row. The score column is required and rows with a null
+    score are dropped before the geometry is measured, so a frame carrying a timestamp
+    for every declared session and no usable score reports the gap rather than
+    ``complete``. The requirement sits here and not in ``_coverage`` because
+    ``check_backtest_input_coverage`` shares that helper and a backtest input frame is
+    not required to carry a score column.
     """
+    scored = _scored_rows(predictions, case_study=case_study, label=label, split=split)
     report = _coverage(
-        predictions,
+        scored,
         case_study=case_study,
         label=label,
         split=split,

--- a/case_studies/utils/coverage.py
+++ b/case_studies/utils/coverage.py
@@ -42,7 +42,7 @@ from pathlib import Path
 
 import polars as pl
 
-from case_studies.utils.notebook_contracts import _first_present
+from case_studies.utils.notebook_contracts import _first_present, _is_finite
 
 __all__ = [
     "CoverageError",
@@ -543,6 +543,11 @@ def _scored_rows(frame: pl.DataFrame, *, case_study: str, label: str, split: str
     prediction path that is not what the module promises: a frame with no score column
     at all, or one whose scores are all null, described a complete set of decisions
     that were never made.
+
+    Null is not the whole of it. NaN and infinity are non-null and rank against nothing,
+    so a session holding only those is as empty of decisions as one holding only nulls -
+    ``_is_finite`` is the same reading the IC series already applies, and on a non-float
+    column being non-null is the whole of the condition.
     """
     score_col = _first_present(frame.columns, _SCORE_ALIASES)
     if score_col is None:
@@ -551,11 +556,11 @@ def _scored_rows(frame: pl.DataFrame, *, case_study: str, label: str, split: str
             f"{_SCORE_ALIASES} in columns {sorted(frame.columns)}. A frame with no score "
             "is not a prediction set, and a check that cannot run must not read as a pass."
         )
-    scored = frame.filter(pl.col(score_col).is_not_null())
+    scored = frame.filter(_is_finite(frame.schema[score_col], score_col))
     if scored.is_empty():
         raise CoverageError(
-            f"{case_study}/{label}/{split} predictions: every value in {score_col!r} is "
-            f"null across {frame.height} rows; the frame carries sessions but no predictions."
+            f"{case_study}/{label}/{split} predictions: no finite value in {score_col!r} across "
+            f"{frame.height} rows; the frame carries sessions but no predictions."
         )
     return scored
 

--- a/case_studies/utils/cv_window.py
+++ b/case_studies/utils/cv_window.py
@@ -116,6 +116,7 @@ def _derive_modeling_splits(case_study: str, label: str) -> list[dict] | None:
     from utils.artifact_specs import (
         load_label_spec,
         resolve_label_buffer,
+        resolve_label_buffer_unit,
         resolve_label_horizon,
         resolve_storage_path,
     )
@@ -170,6 +171,10 @@ def _derive_modeling_splits(case_study: str, label: str) -> list[dict] | None:
         label_buffer=label_buffer,
         outcome_horizon=resolve_label_horizon(case_study, label, setup),
         date_col=date_col,
+        # The declared boundaries have to be derived the same way the fitted ones are, or
+        # `utils/modeling.py` and this resolver disagree about what the buffer counts and
+        # the register describes folds no model was fitted on.
+        buffer_unit=resolve_label_buffer_unit(case_study, label, setup),
     )
     return splits or None
 
@@ -232,6 +237,7 @@ def temporal_artifact_fold_boundaries(
         load_feature_spec,
         load_label_spec,
         resolve_label_buffer,
+        resolve_label_buffer_unit,
         resolve_label_horizon,
     )
     from utils.cv_splits import generate_cv_splits
@@ -280,6 +286,7 @@ def temporal_artifact_fold_boundaries(
         "case_study_id": case_study,
         "label_buffer": label_buffer,
         "date_col": date_col,
+        "buffer_unit": resolve_label_buffer_unit(case_study, primary_label, setup),
     }
     if include_outcome_horizon:
         split_kwargs["outcome_horizon"] = resolve_label_horizon(case_study, primary_label, setup)

--- a/case_studies/utils/latent_factors/adapter.py
+++ b/case_studies/utils/latent_factors/adapter.py
@@ -725,6 +725,16 @@ def _valid_model_dir(model_dir: Path, context: LatentFactorContext) -> bool:
 
 
 def _normalize_prediction_frame(frame: pl.DataFrame) -> pl.DataFrame:
+    """One representation for both sides of the persisted-vs-reconstructed comparison.
+
+    The zone is part of that. `register_prediction_set` writes a naive decision-time column
+    as UTC-aware, while a frame rebuilt from the fitted state carries whatever the context
+    holds, so comparing them as they arrive reports two identical checkpoints as
+    disagreeing. Both sides come through here, so normalizing once is enough.
+    """
+    from case_studies.utils.registry.store import _timestamps_as_utc
+
+    frame = _timestamps_as_utc(frame)
     rename = {
         old: new
         for old, new in {

--- a/case_studies/utils/registry/queries.py
+++ b/case_studies/utils/registry/queries.py
@@ -26,6 +26,7 @@ from .store import (
     _registry_db_path,
     _run_log_dir,
     _stage_filter_clause,
+    _timestamps_as_utc,
     _training_dir,
 )
 
@@ -646,7 +647,10 @@ def read_predictions(
         renames["fold"] = "fold_id"
     if renames:
         df = df.rename(renames)
-    return df
+    # A naive decision-time column means the same instants as a UTC-aware one and is
+    # localized rather than converted, so the artifacts a case study wrote before
+    # `_timestamps_as_utc` reached the writer still join against the ones it wrote after.
+    return _timestamps_as_utc(df)
 
 
 # ---------------------------------------------------------------------------

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -30,6 +30,7 @@ from .store import (
     _prediction_dir,
     _save_json,
     _save_parquet,
+    _timestamps_as_utc,
     _training_dir,
     _upsert_wide_metrics,
     _utc_now,
@@ -893,7 +894,7 @@ def register_prediction_set(
 
         from case_studies.utils.artifact_digest import value_digest
 
-        normalized_predictions = (
+        normalized_predictions = _timestamps_as_utc(
             predictions if isinstance(predictions, pl.DataFrame) else pl.from_pandas(predictions)
         )
         prediction_artifact_digest = value_digest(normalized_predictions)
@@ -943,7 +944,7 @@ def register_prediction_set(
                     if orphaned_digest != prediction_artifact_digest:
                         raise ValueError(f"immutable prediction artifact conflict for {p_hash}")
                 else:
-                    _save_parquet(temporary, predictions)
+                    _save_parquet(temporary, normalized_predictions)
                 try:
                     db.execute(
                         """
@@ -983,7 +984,7 @@ def register_prediction_set(
         # Save predictions
         if predictions is not None:
             pred_dir = _prediction_dir(case_dir, p_hash)
-            _save_parquet(pred_dir / "predictions.parquet", predictions)
+            _save_parquet(pred_dir / "predictions.parquet", _timestamps_as_utc(predictions))
 
         # Insert into DB
         db = _open_registry(case_dir)

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -852,6 +852,11 @@ def register_prediction_set(
                 or _sampling_reduced(parent_spec_json)
             ),
         )
+    # Before coverage, not after. `schema_json` records the dtypes of the frame handed in
+    # and the immutability check compares one checkpoint's against another's, so
+    # normalizing later would store a naive schema beside a UTC-aware parquet and make two
+    # equivalent checkpoints disagree on nothing but the zone.
+    predictions = _timestamps_as_utc(predictions)
     coverage = None
     if identity_version in SUPPORTED_IDENTITY_VERSIONS:
         if predictions is None or expected_keys is None:
@@ -894,7 +899,7 @@ def register_prediction_set(
 
         from case_studies.utils.artifact_digest import value_digest
 
-        normalized_predictions = _timestamps_as_utc(
+        normalized_predictions = (
             predictions if isinstance(predictions, pl.DataFrame) else pl.from_pandas(predictions)
         )
         prediction_artifact_digest = value_digest(normalized_predictions)
@@ -984,7 +989,7 @@ def register_prediction_set(
         # Save predictions
         if predictions is not None:
             pred_dir = _prediction_dir(case_dir, p_hash)
-            _save_parquet(pred_dir / "predictions.parquet", _timestamps_as_utc(predictions))
+            _save_parquet(pred_dir / "predictions.parquet", predictions)
 
         # Insert into DB
         db = _open_registry(case_dir)

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -1004,6 +1004,46 @@ def _save_json(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data, indent=2, default=str))
 
 
+_PREDICTION_TIME_COLUMNS = ("timestamp", "date", "datetime", "ts")
+
+
+def _timestamps_as_utc(predictions):
+    """Give a naive decision-time column an explicit UTC zone before it is written.
+
+    `gbm`, `linear` and `tabular_dl` write `Datetime(_, 'UTC')`; `deep_learning` reaches
+    this through `flush_fold_predictions`, whose dates come from a numpy `datetime64`
+    array and are therefore naive. Measured on crypto_perps_funding: 578 artifacts UTC-
+    aware and 100 naive, same label, same folds, same 19 symbols, same 2,189 decision
+    times, identical instants. A tz-aware value never equals a naive one, so an exact join
+    on (timestamp, symbol) between the two families returned nothing, and any code
+    assuming one dtype across a case study's artifacts dropped rows instead of failing.
+
+    Naive is read as UTC here, which is what it already meant: every producer derives
+    these timestamps from the label artifact's own axis, and the naive values are the same
+    instants the aware ones carry. This relabels; it never converts a wall time.
+
+    `value_digest` ignores the zone (it is time-unit sensitive and zone-insensitive), so
+    an artifact rewritten through here keeps its digest and no immutable-artifact check
+    moves. The time unit is deliberately left alone for the same reason.
+    """
+    try:
+        import polars as pl
+    except ImportError:  # pragma: no cover
+        return predictions
+    if not isinstance(predictions, pl.DataFrame):
+        return predictions
+    naive = [
+        column
+        for column in _PREDICTION_TIME_COLUMNS
+        if column in predictions.columns
+        and isinstance(predictions.schema[column], pl.Datetime)
+        and predictions.schema[column].time_zone is None
+    ]
+    if not naive:
+        return predictions
+    return predictions.with_columns(pl.col(column).dt.replace_time_zone("UTC") for column in naive)
+
+
 def _save_parquet(path: Path, frame) -> None:
     """Write a DataFrame to parquet, handling pl.Object columns safely.
 

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -1026,22 +1026,48 @@ def _timestamps_as_utc(predictions):
     an artifact rewritten through here keeps its digest and no immutable-artifact check
     moves. The time unit is deliberately left alone for the same reason.
     """
+    if predictions is None:
+        return predictions
     try:
         import polars as pl
     except ImportError:  # pragma: no cover
         return predictions
-    if not isinstance(predictions, pl.DataFrame):
+
+    if isinstance(predictions, pl.DataFrame):
+        naive = [
+            column
+            for column in _PREDICTION_TIME_COLUMNS
+            if column in predictions.columns
+            and isinstance(predictions.schema[column], pl.Datetime)
+            and predictions.schema[column].time_zone is None
+        ]
+        if not naive:
+            return predictions
+        return predictions.with_columns(
+            pl.col(column).dt.replace_time_zone("UTC") for column in naive
+        )
+
+    # pandas is handled in place rather than converted. Both the legacy registration branch
+    # and the pandas side of the versioned one hand the caller's own frame to the writer,
+    # and `pl.from_pandas` on an arbitrary frame is a wider change than this needs. A naive
+    # pandas column localizes to UTC the same way; an already-aware one is left alone.
+    import pandas as pd
+
+    if not isinstance(predictions, pd.DataFrame):
         return predictions
     naive = [
         column
         for column in _PREDICTION_TIME_COLUMNS
         if column in predictions.columns
-        and isinstance(predictions.schema[column], pl.Datetime)
-        and predictions.schema[column].time_zone is None
+        and pd.api.types.is_datetime64_any_dtype(predictions[column])
+        and getattr(predictions[column].dtype, "tz", None) is None
     ]
     if not naive:
         return predictions
-    return predictions.with_columns(pl.col(column).dt.replace_time_zone("UTC") for column in naive)
+    localized = predictions.copy()
+    for column in naive:
+        localized[column] = localized[column].dt.tz_localize("UTC")
+    return localized
 
 
 def _save_parquet(path: Path, frame) -> None:

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -261,6 +261,9 @@ def is_refit_of(holdout_spec_json: str | None, validation_spec_json: str | None)
 def resolve_holdout_self_backtest(
     case_study: str,
     val_backtest_hash: str,
+    *,
+    labels: Sequence[str] | None = None,
+    admitted: frozenset[str] | None = None,
 ) -> HoldoutSelfBacktest:
     """Find the holdout replay of a validation run's strategy, or say why there is none.
 
@@ -268,10 +271,18 @@ def resolve_holdout_self_backtest(
     goes through :func:`_refuse_a_selection_disagreement` first, so a caller that selected
     a different carrier than the holdout notebooks ran is told that rather than being told
     the holdout has not been produced.
+
+    ``labels`` and ``admitted`` are the caller's own selection scope, and they are carried
+    into that diagnosis rather than dropped. A carrier chosen from a preview's label subset
+    or from a frozen candidate set is a correct answer within its scope, and comparing it
+    against an unrestricted resolution would reject it for disagreeing with a question it
+    was never asked.
     """
     found = _resolve_holdout_self_backtest(case_study, val_backtest_hash)
     if found.backtest_hash is None:
-        _refuse_a_selection_disagreement(case_study, val_backtest_hash)
+        _refuse_a_selection_disagreement(
+            case_study, val_backtest_hash, labels=labels, admitted=admitted
+        )
     return found
 
 
@@ -428,7 +439,13 @@ def _resolve_holdout_self_backtest(
     return HoldoutSelfBacktest(matched[0])
 
 
-def _refuse_a_selection_disagreement(case_study: str, val_backtest_hash: str) -> None:
+def _refuse_a_selection_disagreement(
+    case_study: str,
+    val_backtest_hash: str,
+    *,
+    labels: Sequence[str] | None = None,
+    admitted: frozenset[str] | None = None,
+) -> None:
     """Raise when a *different* carrier has the holdout the caller could not find.
 
     A strategy-analysis notebook that ranks its pool's Sharpe column directly can select a
@@ -475,7 +492,7 @@ def _refuse_a_selection_disagreement(case_study: str, val_backtest_hash: str) ->
         return
 
     try:
-        canonical = resolve_canonical_rank1_lineage(case_study)
+        canonical = resolve_canonical_rank1_lineage(case_study, admitted=admitted, labels=labels)
     except Exception:  # noqa: BLE001 - this diagnoses; it must never replace the real answer
         return
     canonical_hash = canonical.get("val_backtest_hash")
@@ -499,13 +516,18 @@ def _refuse_a_selection_disagreement(case_study: str, val_backtest_hash: str) ->
 def select_holdout_self_backtest(
     case_study: str,
     val_backtest_hash: str,
+    *,
+    labels: Sequence[str] | None = None,
+    admitted: frozenset[str] | None = None,
 ) -> str | None:
     """The holdout replay's hash, or ``None`` when there is not exactly one.
 
     Kept for callers that only need the hash. A notebook that has to tell its reader
     what is missing wants ``resolve_holdout_self_backtest``, which carries the reason.
     """
-    return resolve_holdout_self_backtest(case_study, val_backtest_hash).backtest_hash
+    return resolve_holdout_self_backtest(
+        case_study, val_backtest_hash, labels=labels, admitted=admitted
+    ).backtest_hash
 
 
 def resolve_canonical_rank1_lineage(
@@ -740,7 +762,13 @@ def resolve_canonical_rank1_lineage(
     # Match holdout by strategy spec to the val rank-1 backtest, so an
     # experimental side-channel allocator (e.g., conformal_weighted) on
     # the same holdout pred set does not displace the canonical lineage.
-    ho_bh = select_holdout_self_backtest(case_study, val_bh)
+    # The raw lookup, not the diagnosing wrapper. `_refuse_a_selection_disagreement` asks
+    # this function for the canonical carrier, so going through the wrapper here would
+    # re-enter it: every call would resolve the whole ranking again, one level deeper,
+    # until the recursion limit - and the diagnosis would swallow the RecursionError after
+    # hundreds of registry reads. There is nothing to diagnose on this path anyway: this
+    # function IS the canonical selection, so it can never disagree with itself.
+    ho_bh = _resolve_holdout_self_backtest(case_study, val_bh).backtest_hash
     ho_ph: str | None = None
     ho_sharpe: float | None = None
     if ho_bh is not None:

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -20,6 +20,7 @@ Usage::
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timezone
 from pathlib import Path
@@ -261,7 +262,27 @@ def resolve_holdout_self_backtest(
     case_study: str,
     val_backtest_hash: str,
 ) -> HoldoutSelfBacktest:
+    """Find the holdout replay of a validation run's strategy, or say why there is none.
+
+    A thin wrapper over :func:`_resolve_holdout_self_backtest`: every "not found" answer
+    goes through :func:`_refuse_a_selection_disagreement` first, so a caller that selected
+    a different carrier than the holdout notebooks ran is told that rather than being told
+    the holdout has not been produced.
+    """
+    found = _resolve_holdout_self_backtest(case_study, val_backtest_hash)
+    if found.backtest_hash is None:
+        _refuse_a_selection_disagreement(case_study, val_backtest_hash)
+    return found
+
+
+def _resolve_holdout_self_backtest(
+    case_study: str,
+    val_backtest_hash: str,
+) -> HoldoutSelfBacktest:
     """Find the holdout backtest that replays a validation run's strategy, or say why not.
+
+    The lookup itself. Callers go through :func:`resolve_holdout_self_backtest`, which adds
+    the selection-disagreement diagnosis to every "not found" answer.
 
     This is the canonical ``val_rank1_self`` lineage anchor for the section 6 holdout
     closure: the holdout backtest produced by replaying the validation rank-1 strategy on
@@ -407,6 +428,74 @@ def resolve_holdout_self_backtest(
     return HoldoutSelfBacktest(matched[0])
 
 
+def _refuse_a_selection_disagreement(case_study: str, val_backtest_hash: str) -> None:
+    """Raise when a *different* carrier has the holdout the caller could not find.
+
+    A strategy-analysis notebook that ranks its pool's Sharpe column directly can select a
+    different configuration than `resolve_solvent_carrier` does - a Sharpe computed over a
+    configuration's own available history is not comparable across configurations that
+    priced different spans, so the raw ranking rewards whichever candidate had the most
+    forgiving window. Measured on cme_futures (992 signal / 120 allocation / 28 risk_overlay
+    backtests, rebuilt 2026-08-30): the raw column answered latent_factors/sdf on
+    fwd_ret_21d at 1.274, the resolver gbm/leaves_31_mse on fwd_ret_5d at 1.236 raw and
+    1.294 once compared over the 1,270 sessions they all price.
+
+    The failure that followed was silent and read as the wrong thing. `17_holdout_predictions`
+    and `18_holdout_backtest` resolve through `resolve_solvent_carrier`, so the notebook then
+    asked for the holdout replay of a configuration those notebooks never ran, got None, and
+    printed "not produced yet" while the holdout sat in the registry. A reader concluded the
+    holdout had not been run.
+
+    Only that exact shape raises: a *registered* hash other than the canonical one was asked
+    about, and the canonical carrier has a replay. A case study whose holdout stage genuinely
+    has not run reports "not produced yet" as before, which is a normal state for anyone
+    working the notebooks in order. An unregistered hash keeps its own answer, which is more
+    useful than this one - a hash the run log has never seen is a stale constant rather than
+    a carrier chosen from a pool. And a resolver that cannot answer - an empty registry, a
+    case study with no rank-1 - leaves the original answer standing rather than turning a
+    missing holdout into a resolver error.
+    """
+    import sqlite3
+
+    from utils.paths import get_case_study_dir
+
+    # Only a hash that is actually registered can be a *selection*. When the caller names a
+    # backtest the run log has never seen, `_resolve_holdout_self_backtest` already says
+    # exactly that, and it is the more useful answer - a stale hardcoded hash, not a
+    # carrier chosen from a pool.
+    try:
+        db_path = get_case_study_dir(case_study) / "run_log" / "registry.db"
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as db:
+            registered = db.execute(
+                "SELECT 1 FROM backtest_runs WHERE backtest_hash = ?", (val_backtest_hash,)
+            ).fetchone()
+    except sqlite3.Error:
+        return
+    if registered is None:
+        return
+
+    try:
+        canonical = resolve_canonical_rank1_lineage(case_study)
+    except Exception:  # noqa: BLE001 - this diagnoses; it must never replace the real answer
+        return
+    canonical_hash = canonical.get("val_backtest_hash")
+    if not canonical_hash or canonical_hash == val_backtest_hash:
+        return
+    if canonical.get("holdout_backtest_hash") is None:
+        return
+    raise RuntimeError(
+        f"{case_study}: no holdout replays validation backtest {val_backtest_hash}, but "
+        f"{canonical['holdout_backtest_hash']} replays {canonical_hash} - "
+        f"{canonical.get('family')}/{canonical.get('config_name')} on "
+        f"{canonical.get('label')}, which is what `resolve_solvent_carrier` selects and what "
+        "the holdout notebooks ran. This is a selection disagreement, not a missing holdout: "
+        "the caller ranked its own pool and chose a different carrier. Resolve the carrier "
+        "through `resolve_solvent_carrier`, which re-ranks candidates on exact common "
+        "timestamp support and applies LABEL_RESTRICTIONS, UNIVERSE_RESTRICTIONS and "
+        "CARRIER_PINS."
+    )
+
+
 def select_holdout_self_backtest(
     case_study: str,
     val_backtest_hash: str,
@@ -420,7 +509,10 @@ def select_holdout_self_backtest(
 
 
 def resolve_canonical_rank1_lineage(
-    case_study: str, *, admitted: frozenset[str] | None = None
+    case_study: str,
+    *,
+    admitted: frozenset[str] | None = None,
+    labels: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     """Resolve the canonical val rank-1 + matching holdout for a case study.
 
@@ -458,7 +550,12 @@ def resolve_canonical_rank1_lineage(
     from utils.paths import get_case_study_dir
 
     db_path = get_case_study_dir(case_study) / "run_log" / "registry.db"
-    label_filter = LABEL_RESTRICTIONS.get(case_study)
+    # `labels` overrides the module-level restriction rather than adding to it. A preview
+    # run narrows its pool with PREVIEW_LABELS and the resolver knew nothing about that, so
+    # it could resolve a carrier on a label the pool excludes - the carrier is then not in
+    # the pool, and the notebook reports it missing. The default is the declared
+    # restriction, which is what every canonical run wants.
+    label_filter = tuple(labels) if labels is not None else LABEL_RESTRICTIONS.get(case_study)
     universe_pin = UNIVERSE_RESTRICTIONS.get(case_study)
     carrier_pin = CARRIER_PINS.get(case_study)
 
@@ -691,7 +788,11 @@ exists - including a Sharpe high enough to top a ranking.
 
 
 def resolve_solvent_carrier(
-    case_study: str, *, require_solvent: bool = True, admitted: frozenset[str] | None = None
+    case_study: str,
+    *,
+    require_solvent: bool = True,
+    admitted: frozenset[str] | None = None,
+    labels: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     """The configuration downstream notebooks run, with its spec and drawdown.
 
@@ -715,6 +816,13 @@ def resolve_solvent_carrier(
     function exists to close. Selecting past a bankrupt rank-1 is a decision for
     whoever owns the sweep, taken by fixing the sweep or pinning a carrier.
 
+    ``labels`` narrows the candidate pool the same way ``LABEL_RESTRICTIONS`` does and
+    replaces it. A notebook run under preview restricts its own pool with ``PREVIEW_LABELS``
+    while this resolver read only the module-level restriction, so it could resolve a
+    carrier on a label the pool excludes - and the carrier is then simply not found in the
+    pool, which reads as a missing result rather than as two different questions. Pass the
+    same restriction to both.
+
     Returns ``resolve_canonical_rank1_lineage``'s dict with ``spec_json`` and
     ``max_drawdown`` for the validation rank-1 added.
     """
@@ -722,7 +830,7 @@ def resolve_solvent_carrier(
 
     from utils.paths import get_case_study_dir
 
-    lineage = resolve_canonical_rank1_lineage(case_study, admitted=admitted)
+    lineage = resolve_canonical_rank1_lineage(case_study, admitted=admitted, labels=labels)
     backtest_hash = lineage["val_backtest_hash"]
 
     db_path = get_case_study_dir(case_study) / "run_log" / "registry.db"

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -3032,15 +3032,27 @@ def run_tabm_cv(
                 )
                 checkpoint_metrics[int(epoch)]["n_invalid"] = _n_invalid_scores(epoch_predictions)
         elif fold_checkpoint_ics:
-            checkpoint_metrics = {
-                int(epoch): {
-                    "ic_mean": float(np.nanmean(values)),
-                    "ic_std": float(np.nanstd(values)) if len(values) > 1 else 0.0,
-                    "ic_n_days": 0,
-                    "n_invalid": 0,
-                }
-                for epoch, values in fold_checkpoint_ics.items()
-            }
+            # This used to fall back to `np.nanmean(fold_checkpoint_ics[epoch])`, the mean of
+            # the per-fold ICs. That violates the standing rule that IC is computed per
+            # decision time and then averaged: folds holding unequal numbers of decision times
+            # get equal weight, so a three-day fold counts as much as a thirty-day one and
+            # `best_epoch` can land on a different checkpoint than the primary path chooses.
+            # It reported a different epoch than the registry would, under the same name.
+            #
+            # It is also unreachable on the path it was written for. `incr_dir` is None exactly
+            # when `save_dir` is None, and both fold loops append the fold's frame to
+            # `state["prediction_frames"]` in that case, so `cfg_all_preds` is populated and
+            # the decision-time path runs. What is left is a config that reported itself
+            # available while its flushed predictions did not come back off disk, and there is
+            # no checkpoint metric to compute there - only per-fold ICs that would answer a
+            # different question. A check that cannot run must not read as a pass.
+            raise RuntimeError(
+                f"{artifact_name}: {len(fold_checkpoint_ics)} checkpoints have per-fold ICs but "
+                f"no predictions to score. Checkpoint selection is best mean IC across decision "
+                f"times, which cannot be computed from fold ICs, and averaging those instead "
+                f"would weight a short fold like a long one. Incremental predictions were "
+                f"expected under {incr_dir!s} and none were read back."
+            )
 
         if checkpoint_metrics:
             positive_days = [

--- a/data/equities/positioning/13f_download.py
+++ b/data/equities/positioning/13f_download.py
@@ -256,7 +256,15 @@ def build_features_and_matrix(
     latest_rows = equity.filter(pl.col("report_date") == latest_report_date)
     if latest_rows.is_empty():
         raise ValueError("The latest 13F report date has no positive long-equity positions.")
-    latest_timestamp = latest_rows["filing_date"].max()
+    # Availability is taken over every disclosure for the selected quarter, not only the
+    # long-equity ones the graph is built from. A manager that files later with options
+    # only makes the quarter complete - `_complete_report_dates` counts any disclosed row
+    # as evidence it filed - without advancing a timestamp read off `latest_rows`, so the
+    # graph would claim to have been available before that filing was public. That is
+    # lookahead: the quarter was not usable until the last of its filings landed.
+    latest_timestamp = holdings_df.filter(pl.col("report_date") == latest_report_date)[
+        "filing_date"
+    ].max()
     issuer_names = (
         latest_rows.group_by(["cusip", "issuer"])
         .agg(pl.col("value_thousands").sum().alias("issuer_value"))

--- a/envs/ml4t/Dockerfile
+++ b/envs/ml4t/Dockerfile
@@ -181,6 +181,44 @@ RUN /opt/ml4t/bin/pip install --no-cache-dir \
 # Force protobuf 5+ which uses the pure-Python descriptor pool.
 RUN /opt/ml4t/bin/pip install --no-cache-dir "protobuf>=5.0"
 
+# Chrome, so `fig.show()` emits the PNG in the reader's own run.
+#
+# kaleido 1.x renders through a Chrome it does not bundle, and `utils/__init__` asks for
+# the `+png` renderer half only when one is resolvable. With no Chrome here the reader
+# still gets an interactive figure, but every notebook re-executed in the image loses the
+# `image/png` that GitHub's notebook viewer needs - so the reader's run and the committed
+# artifact stopped telling the same story, and `tests/test_notebook_output_hygiene.py`
+# would catch the artifact rather than the cause.
+#
+# Chrome for Testing publishes a linux64 build only, so this is an amd64 step. On arm64
+# the renderer falls back to `plotly_mimetype`, which is still interactive in Jupyter.
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      set -e && \
+      apt-get update && apt-get install -y --no-install-recommends \
+        fonts-liberation libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 \
+        libatspi2.0-0t64 libcairo2 libcups2t64 libdbus-1-3 libdrm2 libexpat1 \
+        libgbm1 libglib2.0-0t64 libnspr4 libnss3 libpango-1.0-0 libx11-6 \
+        libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 \
+        libxrandr2 && \
+      rm -rf /var/lib/apt/lists/* && \
+      /opt/ml4t/bin/kaleido_get_chrome --path /opt/chrome && \
+      ln -s "$(find /opt/chrome -type f -name chrome -perm -u+x | head -1)" \
+        /usr/local/bin/google-chrome && \
+      chmod -R a+rX /opt/chrome && \
+      /opt/ml4t/bin/python -c "import plotly.express as px; \
+assert len(px.line(x=[1, 2], y=[1, 2]).to_image(format='png')) > 1000; \
+print('kaleido PNG export: OK')"; \
+    fi
+
+# Chrome needs a writable HOME, and the container runs as the host's UID:GID
+# (docker-compose.yml). A host UID with no /etc/passwd entry gets HOME=/, where Chrome
+# exits immediately - which would turn today's silent loss of the PNG into a raised
+# BrowserFailedError for exactly those readers. Naming a writable HOME for every UID is
+# what makes installing Chrome above safe rather than a regression. Jupyter needs the
+# same thing for its runtime directory.
+RUN chmod 1777 /home/ml4t
+ENV HOME=/home/ml4t
+
 WORKDIR /app
 ENV PATH="/opt/ml4t/bin:$PATH"
 ENV PYTHONPATH="/app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,11 @@ dependencies = [
     # kaleido>=1.0: 0.2.1 bundled its own Chromium but drives the deprecated
     # plotly.io.kaleido.scope.* API, which plotly 6.x emits DeprecationWarnings for
     # (support removed after Sept 2025). 1.x drives a system/self-provisioned Chrome
-    # (kaleido_get_chrome) and is warning-clean. Static PNG export is used only at
-    # figure-production time; reader-runtime kaleido calls (nb 21) already try/except.
+    # (kaleido_get_chrome) and is warning-clean. The default renderer is
+    # `plotly_mimetype+png`, so every `fig.show()` is a kaleido call and PNG export is a
+    # reader-runtime path, not only a figure-production one. Two things carry that:
+    # `utils/__init__` drops the `+png` half where no Chrome is resolvable, and
+    # `envs/ml4t/Dockerfile` installs Chrome for Testing so the image does resolve one.
     "kaleido>=1.3",
     # ===================
     # Machine Learning

--- a/scripts/prove_sp500_options_interface.py
+++ b/scripts/prove_sp500_options_interface.py
@@ -47,6 +47,11 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _boundary(moment) -> str:
+    """One rendering for a reduction boundary, whatever zone the artifact carries."""
+    return str(moment.replace(tzinfo=None) if getattr(moment, "tzinfo", None) else moment)
+
+
 def _seed_real_preview_prediction(
     study: Study,
     *,
@@ -112,8 +117,13 @@ def _seed_real_preview_prediction(
         "folds": [fold],
         "max_symbols": max_symbols,
         "max_sessions": max_sessions,
-        "date_start": str(preview.get_column("timestamp").min()),
-        "date_end": str(preview.get_column("timestamp").max()),
+        # Rendered without the zone. These boundaries go into `preview_reductions`, which
+        # is part of the spec the identity is computed over, so rendering them off the
+        # artifact's own dtype would give one reduction two identities depending on
+        # whether the prediction it reduces was written before or after decision times
+        # were stored UTC-aware. The instants are the same either way.
+        "date_start": _boundary(preview.get_column("timestamp").min()),
+        "date_end": _boundary(preview.get_column("timestamp").max()),
     }
     spec = ResolvedSpec.create(
         family="options_interface_fixture",

--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -1049,6 +1049,8 @@ def _label_artifact_panel(cs_dir: Path, label: str, window, n_folds: int, _pl):
     Returns None when the artifact is absent, carries no usable key, or holds nothing
     inside the split window - the fabricated grid still covers those.
     """
+    from datetime import timedelta
+
     path = cs_dir / "labels" / f"{label}.parquet"
     if not path.is_file():
         return None
@@ -1067,6 +1069,22 @@ def _label_artifact_panel(cs_dir: Path, label: str, window, n_folds: int, _pl):
     frame = frame.filter((as_date >= start) & (as_date <= end)).drop_nulls([label])
     if frame.is_empty():
         return None
+
+    # Daily or coarser only. `_subsampled_panel` keeps a contiguous run at native spacing
+    # for a sub-daily panel - it has to, because a stride hands an 8H label decisions ten
+    # days apart and `13_backtest` rejects them against its horizon. On a minute-bar label
+    # that run is sixty consecutive minutes: measured on nasdaq100_microstructure, every
+    # seeded set collapsed to 2021-06-15 14:44 through 15:43, one hour of a one-year
+    # window, and every configuration in the sweep then scored the same Sharpe -
+    # `14_backtest` failed at `hist(..., bins=30)` with "Too many bins for data range".
+    # The fabricated grid spans the window instead, which is what an intraday case study
+    # is better served by until this can subsample a sub-daily label without breaking its
+    # spacing.
+    stamps = frame.get_column("timestamp").unique().sort()
+    if stamps.len() > 1:
+        gaps = stamps.diff().drop_nulls()
+        if gaps.len() and gaps.min() < timedelta(days=1):
+            return None
     # `actual` is the label's own realized value, so nothing is redrawn: this is the
     # target the pinning notebook expects to find, not a stand-in for it.
     frame = frame.select(

--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -1029,6 +1029,73 @@ def _subsampled_panel(frame, entity: str, _pl):
     return panel.select(columns)
 
 
+def _label_artifact_panel(cs_dir: Path, label: str, window, n_folds: int, _pl):
+    """A key/target panel taken from the fixture's own label artifact.
+
+    The last resort before the fabricated grid, and the one that matters for a cohort
+    leader. `sample_registry_for_tests` samples registry rows and copies no prediction
+    artifacts, so a label whose group has no artifact on disk had nothing to take a panel
+    from and fell to `_weekday_grid` over placeholder symbols with a random `actual`. A
+    replay notebook that pins the leader by hash then failed a >0.99 correlation gate
+    against real prices several stages downstream, nowhere near here.
+
+    The label artifact is the right source and it is already in the fixture: its
+    (entity, timestamp) keys are the ones every notebook joins on, and its label column is
+    the realized value those notebooks check - computed by stage 02 from the fixture's own
+    prices, so the gate is satisfied by construction. That is what the comment on the
+    missing-leader warning asks for, and it is not a copy of the production artifact,
+    which would be stale the moment anything upstream is regenerated.
+
+    Returns None when the artifact is absent, carries no usable key, or holds nothing
+    inside the split window - the fabricated grid still covers those.
+    """
+    path = cs_dir / "labels" / f"{label}.parquet"
+    if not path.is_file():
+        return None
+    try:
+        frame = _pl.read_parquet(path)
+    except Exception:  # noqa: BLE001 - an unreadable label is not ours to fix here
+        return None
+    entity = next((c for c in ENTITY_COLUMN_CANDIDATES if c in frame.columns), None)
+    if entity is None or "timestamp" not in frame.columns or label not in frame.columns:
+        return None
+
+    start, end = window
+    as_date = _pl.col("timestamp")
+    if frame.schema["timestamp"] != _pl.Date:
+        as_date = as_date.cast(_pl.Date)
+    frame = frame.filter((as_date >= start) & (as_date <= end)).drop_nulls([label])
+    if frame.is_empty():
+        return None
+    # `actual` is the label's own realized value, so nothing is redrawn: this is the
+    # target the pinning notebook expects to find, not a stand-in for it.
+    frame = frame.select(
+        _pl.col(entity),
+        _pl.col("timestamp"),
+        _pl.col(label).alias("actual"),
+    ).sort("timestamp", entity)
+    panel = _subsampled_panel(frame, entity, _pl)
+    # `_subsampled_panel` defaults a frame with no fold column to two folds. The registry
+    # row says how many the run declared, and an artifact carrying fewer fails the same
+    # check a wrong fold count does, so the assignment is redone here on the dates that
+    # survived - contiguous blocks, one per fold, floored with the last absorbing the
+    # remainder, exactly as the fabricated grid does it.
+    kept = panel["timestamp"].unique()
+    block = max(1, kept.len() // max(1, n_folds))
+    # Ranked rather than mapped through a dict: a Python datetime round-trips as
+    # microsecond-precision and `replace_strict` refuses to match it against a
+    # millisecond column, which is what every intraday case study stores.
+    return panel.with_columns(
+        _pl.col("timestamp")
+        .rank("dense")
+        .sub(1)
+        .floordiv(block)
+        .clip(upper_bound=n_folds - 1)
+        .cast(_pl.Int64)
+        .alias("fold")
+    )
+
+
 def _normalize_prediction_timestamp_zone(cs_dir: Path) -> None:
     """Put one case study's prediction artifacts in the timezone its labels use.
 
@@ -1483,33 +1550,6 @@ def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
         for p_hash in cohort_leader_hashes
         if not (cs_dir / "run_log" / "predictions" / p_hash / "predictions.parquet").is_file()
     )
-    if missing_leaders:
-        # The exemption above can only preserve an artifact that exists. A leader with
-        # none still falls through to the synthetic write, and the notebook that pins
-        # its hash then fails a >0.99 correlation gate against real prices several
-        # stages downstream, nowhere near this function. The gap is reported by hash
-        # at regeneration time rather than left to surface there. Not fatal: seven of
-        # the nine fixtures are missing at least one leader artifact today, so raising
-        # would stop every regeneration on a pre-existing gap this function did not
-        # introduce.
-        #
-        # Do NOT close the gap by copying the production artifact in. A copied fixture
-        # is stale the moment anything upstream is regenerated, and every case study is
-        # being retrained end to end. What the correlation gate needs is a panel whose
-        # entities and timestamps are the ones the fixture's own labels carry, and whose
-        # historical target is derived from the same synthetic series the scores come
-        # from, so the check is satisfied by construction. That is what the branch below
-        # already does wherever a reference panel exists; a leader with no artifact of
-        # its own is the case that still falls back to a fabricated grid.
-        warnings.warn(
-            f"{cs_id}: no predictions.parquet on disk for cohort-leader prediction(s) "
-            f"{', '.join(missing_leaders)}; each gets synthetic scores on a fabricated "
-            "entity grid that a replay notebook's historical-target check will reject. "
-            "Generate the artifact against the fixture's own labels, deriving its "
-            "target from the series the scores come from; never copy the production one.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
 
     def _survives(p_hash: str) -> bool:
         """True when the loop below leaves this artifact exactly as it is."""
@@ -1528,6 +1568,21 @@ def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
     # one that survives, and otherwise using one that will be rewritten onto its
     # own keys. Only a group with no artifact at all keeps the fabricated grid.
     reference_panels = _reference_panels(cs_dir, hash_rows, _survives, _pl)
+    label_panels: dict = {}
+    fabricated_leaders: list = []
+
+    def _label_panel(split, label, n_folds):
+        """The fixture's own label artifact as a panel, computed once per key.
+
+        Keyed on the fold count as well, the way `_template_for` is: two runs of one
+        label can declare different fold counts and each artifact has to carry its own.
+        """
+        key = (split, label, n_folds)
+        if key not in label_panels:
+            label_panels[key] = _label_artifact_panel(
+                cs_dir, label, _window_for(split, label), n_folds, _pl
+            )
+        return label_panels[key]
 
     for p_hash, split, label in hash_rows:
         pred_dir = cs_dir / "run_log" / "predictions" / p_hash
@@ -1550,6 +1605,12 @@ def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
             # a direction label's target is a class, not a return.
             reference = _intraday_split_skeleton(reference_panels, split, _pl)
             borrowed = reference is not None
+        if reference is None:
+            # Nothing in this group and nothing to borrow: build the panel from the
+            # fixture's own label artifact rather than fabricating one. `borrowed` stays
+            # False - the target here IS this label's realized value, so it must not be
+            # redrawn below.
+            reference = _label_panel(split, label, declared_folds.get(p_hash, 2))
         if reference is not None:
             template, n = reference, reference.height
         else:
@@ -1585,6 +1646,39 @@ def _backfill_all_prediction_parquets(cs_dir: Path, cs_id: str) -> None:
             # seeded onto may be a classification artifact that does.
             frame = frame.drop("eval_actual")
         frame.write_parquet(str(pred_file))
+        if p_hash in missing_leaders and reference is None:
+            fabricated_leaders.append(p_hash)
+
+    if fabricated_leaders:
+        # The exemption above can only preserve an artifact that exists, so a cohort
+        # leader with none falls through to this loop. Where it lands on a real panel -
+        # another artifact of its group, a borrowed intraday skeleton, or the fixture's
+        # own label artifact - it carries the keys and the realized target a replay
+        # notebook pins it for, and there is nothing to report. This is what is left:
+        # a leader seeded onto a fabricated entity grid with a drawn target, whose
+        # >0.99 correlation gate against real prices fails several stages downstream,
+        # nowhere near this function.
+        #
+        # Reported rather than raised: a fixture that genuinely has no label artifact for
+        # the group cannot be fixed from here, and raising would stop every regeneration
+        # on a gap this function did not introduce.
+        #
+        # Do NOT close it by copying the production artifact in. A copied fixture is
+        # stale the moment anything upstream is regenerated, and every case study is
+        # being retrained end to end. What the gate needs is a panel whose entities and
+        # timestamps are the fixture's own and whose target is the one its labels carry,
+        # which is what `_label_artifact_panel` builds.
+        warnings.warn(
+            f"{cs_id}: cohort-leader prediction(s) "
+            f"{', '.join(sorted(fabricated_leaders))} have no artifact on disk and no "
+            "panel to seed onto - not from their own group, not borrowed, and not from "
+            "the fixture's own label artifact - so each gets synthetic scores on a "
+            "fabricated entity grid that a replay notebook's historical-target check "
+            "will reject. Add the label artifact this case study is missing; never copy "
+            "the production prediction.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 def _seed_causal_json(results_dir: Path, cs_id: str, label: str) -> None:

--- a/tests/test_13f_provenance.py
+++ b/tests/test_13f_provenance.py
@@ -359,17 +359,30 @@ def test_availability_is_the_last_filing_when_every_manager_holds_equity() -> No
     assert features["timestamp"].unique().to_list() == [date(2024, 11, 10)]
 
 
-def _thirteen_f_artifact_present() -> bool:
+def _multi_quarter_13f_artifact() -> bool:
+    """Two quarters at least: one is the case this test is not about.
+
+    The defect is a *display* horizon narrowing a multi-quarter artifact. A valid artifact
+    built with `--num-filings 1` takes the notebook's single-quarter branch correctly and
+    would fail the "Added momentum features" assertion for the right reason, so the skip
+    has to read the artifact rather than only look for it.
+    """
     from utils.config import ML4T_DATA_PATH
 
-    return (
+    path = (
         Path(ML4T_DATA_PATH) / "equities" / "positioning" / "13f" / "institutional_holdings.parquet"
-    ).is_file()
+    )
+    if not path.is_file():
+        return False
+    try:
+        return pl.read_parquet(path, columns=["report_date"])["report_date"].n_unique() > 1
+    except Exception:  # noqa: BLE001 - an unreadable artifact is a skip, not a failure
+        return False
 
 
 @pytest.mark.skipif(
-    not _thirteen_f_artifact_present(),
-    reason="needs the production 13F artifact; CI checks out no such data",
+    not _multi_quarter_13f_artifact(),
+    reason="needs a multi-quarter production 13F artifact; CI checks out no such data",
 )
 def test_a_narrowed_display_horizon_still_matches_the_producer(tmp_path) -> None:
     """`NUM_QUARTERS` narrows what the notebook shows, not what the producer compared.

--- a/tests/test_13f_provenance.py
+++ b/tests/test_13f_provenance.py
@@ -315,3 +315,43 @@ def test_holdings_loader_parses_both_sec_dates(tmp_path, monkeypatch) -> None:
     assert result.schema["report_date"] == pl.Date
     assert result.schema["filing_date"] == pl.Date
     assert result["put_call"].to_list() == [None]
+
+
+def test_availability_waits_for_the_last_filing_of_the_quarter() -> None:
+    """A late options-only filing completes the quarter and must move the timestamp.
+
+    `_complete_report_dates` counts any disclosed row as evidence a manager filed, so an
+    options-only filing makes the newest quarter complete. Reading `timestamp` off the
+    long-equity rows alone left the graph claiming to have been available before that
+    filing was public, which is lookahead: the quarter was not usable until the last of
+    its filings landed.
+    """
+    holdings = _two_manager_holdings(date(2024, 9, 30)).with_columns(
+        pl.when(pl.col("accession_no") == "c")
+        .then(pl.lit("PUT"))
+        .otherwise(pl.col("put_call"))
+        .alias("put_call"),
+        pl.when(pl.col("accession_no") == "c")
+        .then(pl.lit(date(2024, 11, 14)))
+        .otherwise(pl.col("filing_date"))
+        .alias("filing_date"),
+    )
+
+    features, _edges, _matrix, _stocks = downloader.build_features_and_matrix(
+        holdings, expected_ciks=["1", "2"]
+    )
+
+    # Manager 1's long-equity filing landed 2024-11-10; manager 2's options-only filing,
+    # which is what made the quarter complete, landed 2024-11-14.
+    assert features["timestamp"].unique().to_list() == [date(2024, 11, 14)]
+
+
+def test_availability_is_the_last_filing_when_every_manager_holds_equity() -> None:
+    """The ordinary case is unchanged: all rows are long equity, so both readings agree."""
+    holdings = _two_manager_holdings(date(2024, 9, 30))
+
+    features, _edges, _matrix, _stocks = downloader.build_features_and_matrix(
+        holdings, expected_ciks=["1", "2"]
+    )
+
+    assert features["timestamp"].unique().to_list() == [date(2024, 11, 10)]

--- a/tests/test_13f_provenance.py
+++ b/tests/test_13f_provenance.py
@@ -1,6 +1,8 @@
 import importlib
+import json
 import xml.etree.ElementTree as ET
 from datetime import date
+from pathlib import Path
 
 import numpy as np
 import polars as pl
@@ -355,3 +357,53 @@ def test_availability_is_the_last_filing_when_every_manager_holds_equity() -> No
     )
 
     assert features["timestamp"].unique().to_list() == [date(2024, 11, 10)]
+
+
+def _thirteen_f_artifact_present() -> bool:
+    from utils.config import ML4T_DATA_PATH
+
+    return (
+        Path(ML4T_DATA_PATH) / "equities" / "positioning" / "13f" / "institutional_holdings.parquet"
+    ).is_file()
+
+
+@pytest.mark.skipif(
+    not _thirteen_f_artifact_present(),
+    reason="needs the production 13F artifact; CI checks out no such data",
+)
+def test_a_narrowed_display_horizon_still_matches_the_producer(tmp_path) -> None:
+    """`NUM_QUARTERS` narrows what the notebook shows, not what the producer compared.
+
+    Truncating `positions_df` before the ownership-change table was built left
+    `NUM_QUARTERS=1` over a multi-quarter artifact with nothing to compare, so the
+    no-comparison branch emitted 0.0 and null while the producer - which never sees this
+    parameter - compared the artifact's last two complete quarters, and the notebook's own
+    parity assertion failed. Momentum is built from every complete quarter now.
+
+    Executed rather than reimplemented: the assertion under test is the notebook's own, and
+    a test that recomputed the comparison here would be checking a second implementation.
+    """
+    import papermill
+
+    notebook = Path(__file__).resolve().parents[1] / "22_rag_financial_research"
+    notebook = notebook / "07_institutional_holdings_graph.ipynb"
+    executed = tmp_path / "num_quarters_1.ipynb"
+
+    papermill.execute_notebook(
+        str(notebook),
+        str(executed),
+        parameters={"NUM_QUARTERS": 1},
+        cwd=str(Path(__file__).resolve().parents[1]),
+        progress_bar=False,
+    )
+
+    printed = "\n".join(
+        "".join(output.get("text", []))
+        for cell in json.loads(executed.read_text())["cells"]
+        for output in cell.get("outputs", [])
+    )
+    assert "artifact parity: PASS" in printed
+    # The momentum table came from the untruncated panel: one displayed quarter cannot
+    # produce a comparison, so this line is what distinguishes the fix from the defect.
+    assert "Added momentum features" in printed
+    assert "across 1 reporting quarters" in printed

--- a/tests/test_artifact_digest_encoding.py
+++ b/tests/test_artifact_digest_encoding.py
@@ -87,3 +87,26 @@ def test_the_settings_map_names_only_parameters_the_writer_accepts() -> None:
 
     accepted = set(inspect.signature(pl.DataFrame.write_parquet).parameters)
     assert set(_PARQUET_WRITE_SETTINGS) <= accepted
+
+
+def test_the_chunk_layout_a_frame_arrives_in_does_not_move_the_bytes(tmp_path: Path) -> None:
+    """`row_group_size` is left at the library's own default, so this is measured not assumed.
+
+    Setting a concrete value would change what the writer emits today and re-key every
+    training run that reads one of these artifacts - the exact harm the pin exists to
+    prevent - so the question is whether the default is layout-sensitive. It is not: a
+    frame assembled from three chunks writes the same bytes as its rechunked self. Recorded
+    here so that if a future polars makes the layout matter, it arrives as a failing test
+    rather than as two identities for one piece of work.
+    """
+    frame = _frame()
+    chunked = pl.concat([frame[:100], frame[100:200], frame[200:]], rechunk=False)
+    assert chunked.n_chunks() > 1 and frame.rechunk().n_chunks() == 1
+
+    single = tmp_path / "single.parquet"
+    multi = tmp_path / "multi.parquet"
+    write_artifact(frame.rechunk(), single, keys=("symbol", "timestamp"), written_by="test")
+    write_artifact(chunked, multi, keys=("symbol", "timestamp"), written_by="test")
+
+    assert single.read_bytes() == multi.read_bytes()
+    assert hashlib.sha256(multi.read_bytes()).hexdigest() == PINNED_SHA256

--- a/tests/test_artifact_digest_encoding.py
+++ b/tests/test_artifact_digest_encoding.py
@@ -1,0 +1,89 @@
+"""The parquet encoding identity-defining artifacts are written under, pinned to its bytes.
+
+Registry training identity digests these files' *bytes*: `utils/modeling.py::_sha256_file`
+feeds `computation.feature_artifacts` and `computation.input_data_spec.artifacts`, both
+inside the hashed `computation` block. Two files holding identical data hash differently
+if they were written with a different compression codec or row-group size, so a polars
+upgrade that moves a default would fork the `training_hash` of every run reading that
+artifact - cached runs stop matching, the sweep refits everything, and no number has moved
+to say why.
+
+Repeated writes with the same settings are byte-stable, so this only bites on a settings
+change or a library upgrade. That is what these tests catch, on the day it happens rather
+than on the day a registry is found holding two identities for one piece of work.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import polars as pl
+
+from case_studies.utils.artifact_digest import _PARQUET_WRITE_SETTINGS, value_digest, write_artifact
+
+# Recorded 2026-09-03 against polars 1.41.1. A change here means the encoding moved: check
+# whether `_PARQUET_WRITE_SETTINGS` still names what the writer does, and if the bytes
+# genuinely changed, every feature and label artifact re-written afterwards takes a new
+# `training_hash`. Do not re-record it without deciding that.
+PINNED_SHA256 = "29e7559707131249e0856c536f1152d9933e08329e532b2b886eb75ee260185a"
+
+
+def _frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": ["AAA", "BBB", "CCC"] * 100,
+            "timestamp": list(range(300)),
+            "value": [i / 7 for i in range(300)],
+        }
+    )
+
+
+def _written(tmp_path: Path, name: str = "artifact.parquet") -> Path:
+    path = tmp_path / name
+    write_artifact(_frame(), path, keys=("symbol", "timestamp"), written_by="test")
+    return path
+
+
+def test_the_bytes_a_fixed_frame_produces_are_the_recorded_ones(tmp_path: Path) -> None:
+    assert hashlib.sha256(_written(tmp_path).read_bytes()).hexdigest() == PINNED_SHA256
+
+
+def test_the_settings_are_stated_rather_than_inherited(tmp_path: Path) -> None:
+    """Stating polars' own defaults moves nothing today and pins them against a change."""
+    library_default = tmp_path / "default.parquet"
+    _frame().write_parquet(library_default)
+
+    assert _written(tmp_path).read_bytes() == library_default.read_bytes()
+
+
+def test_the_encoding_is_what_the_byte_digest_is_sensitive_to(tmp_path: Path) -> None:
+    """The failure this pins: same values, different codec, different file digest.
+
+    `value_digest` answers the same for all three, which is why it is the right identity
+    for a new identity version - and why the byte digest needs the encoding pinned until
+    one exists.
+    """
+    frame = _frame()
+    paths = {}
+    for name, kwargs in {
+        "default": {},
+        "lz4": {"compression": "lz4"},
+        "row_groups": {"row_group_size": 50},
+    }.items():
+        path = tmp_path / f"{name}.parquet"
+        frame.write_parquet(path, **kwargs)
+        paths[name] = path
+
+    digests = {name: hashlib.sha256(path.read_bytes()).hexdigest() for name, path in paths.items()}
+    assert len(set(digests.values())) == 3
+
+    values = {name: value_digest(pl.read_parquet(path)) for name, path in paths.items()}
+    assert len(set(values.values())) == 1
+
+
+def test_the_settings_map_names_only_parameters_the_writer_accepts() -> None:
+    import inspect
+
+    accepted = set(inspect.signature(pl.DataFrame.write_parquet).parameters)
+    assert set(_PARQUET_WRITE_SETTINGS) <= accepted

--- a/tests/test_backtest_runner_helpers.py
+++ b/tests/test_backtest_runner_helpers.py
@@ -446,3 +446,55 @@ def test_the_continuous_return_label_is_read_from_the_isolated_output_root(
     )
 
     assert out["y_true"].to_list() == [0.011, 0.031]
+
+
+def _vectorized_with_missing_outcome(missing_weight: float) -> dict:
+    """One rebalance date, two selected names, one of which has no forward return."""
+    from case_studies.utils.backtest_runner import _run_vectorized
+
+    dates = [datetime(2024, 1, i) for i in (2, 3, 4)]
+    weights = pl.DataFrame(
+        {
+            "timestamp": dates * 2,
+            "symbol": ["AAA"] * 3 + ["BBB"] * 3,
+            "weight": [0.5, 0.5, 0.5] + [missing_weight, 0.5, 0.5],
+        }
+    )
+    # BBB has no outcome row on the first date - the position the engine cannot price.
+    outcomes = pl.DataFrame(
+        {
+            "timestamp": dates + dates[1:],
+            "symbol": ["AAA"] * 3 + ["BBB"] * 2,
+            "y_true": [0.01, 0.02, -0.01, 0.03, 0.0],
+        }
+    ).with_columns(y_pred=pl.col("y_true"))
+    return _run_vectorized(
+        weights=weights,
+        predictions=outcomes,
+        prices=pl.DataFrame(
+            {"timestamp": dates * 2, "symbol": ["AAA"] * 3 + ["BBB"] * 3, "close": 100.0}
+        ),
+        cost_spec={"model": "percentage", "commission_bps": 0.0, "slippage_bps": 0.0},
+        cadence="daily",
+        label="fwd_ret_1d",
+        case_study="us_firm_characteristics",
+        initial_cash=1e6,
+        prediction_hash=None,
+        rebalance_step=1,
+    )
+
+
+def test_a_selected_position_with_no_outcome_row_stops_the_run() -> None:
+    """The inner join marked it at exactly zero return while it still paid turnover.
+
+    That is an assertion about a position nobody could price, not an exclusion, and
+    `n_positions` reported the reduced count as though it were intended.
+    """
+    with pytest.raises(ValueError, match="no usable outcome"):
+        _vectorized_with_missing_outcome(0.5)
+
+
+def test_a_zero_weight_needs_no_outcome() -> None:
+    """A zero weight is not a position: its outcome cannot move any number here."""
+    out = _vectorized_with_missing_outcome(0.0)
+    assert out["daily_returns"].height == 3

--- a/tests/test_cme_futures_research.py
+++ b/tests/test_cme_futures_research.py
@@ -800,6 +800,27 @@ def test_selection_catalog_rejects_a_candidate_the_catalog_does_not_describe(
         research_workflow.selection_catalog(study, members)
 
 
+def _pca_catalog() -> pl.DataFrame:
+    """The one declared configuration the wrapper tests below execute."""
+    return pl.DataFrame(
+        {"family": ["latent_factors"], "label": ["fwd_ret_5d"], "config_name": ["pca"]}
+    )
+
+
+def _pca_request():
+    return cast(
+        "object",
+        SimpleNamespace(
+            family="latent_factors",
+            spec={
+                "execution_tier": "canonical",
+                "label": "fwd_ret_5d",
+                "config_name": "pca",
+            },
+        ),
+    )
+
+
 def test_official_model_catalog_forwards_the_population_it_supersedes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -818,7 +839,14 @@ def test_official_model_catalog_forwards_the_population_it_supersedes(
     resolved = (
         cast(
             "object",
-            SimpleNamespace(spec={"execution_tier": "canonical"}),
+            SimpleNamespace(
+                family="latent_factors",
+                spec={
+                    "execution_tier": "canonical",
+                    "label": "fwd_ret_5d",
+                    "config_name": "pca",
+                },
+            ),
         ),
     )
     monkeypatch.setattr(research_workflow, "OfficialPopulation", SimpleNamespace(create=_create))
@@ -833,7 +861,7 @@ def test_official_model_catalog_forwards_the_population_it_supersedes(
 
     research_workflow.run_official_model_catalog(
         cast("object", SimpleNamespace()),
-        pl.DataFrame(),
+        _pca_catalog(),
         population_name="cme_futures-pca-validation-v1",
         resolved_requests=resolved,
         supersedes="2d252634bffb",
@@ -864,12 +892,44 @@ def test_official_model_catalog_defaults_to_superseding_nothing(
 
     research_workflow.run_official_model_catalog(
         cast("object", SimpleNamespace()),
-        pl.DataFrame(),
+        _pca_catalog(),
         population_name="cme_futures-pca-validation-v1",
-        resolved_requests=(SimpleNamespace(spec={"execution_tier": "canonical"}),),
+        resolved_requests=(_pca_request(),),
     )
 
     assert seen["supersedes"] is None
+
+
+def test_a_partial_resolved_set_cannot_snapshot_the_catalog_population(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`resolved_requests` avoids resolving twice; it does not narrow the population.
+
+    `require_complete` cannot catch a partial set: it measures the population against the
+    members it just declared. So a resolved set covering half the catalog snapshotted under
+    the catalog's name, reported complete, and removed every omitted configuration from the
+    comparison the population exists to define.
+    """
+    monkeypatch.setattr(
+        research_workflow,
+        "OfficialPopulation",
+        SimpleNamespace(create=lambda *a, **k: pytest.fail("a partial set reached the snapshot")),
+    )
+    catalog = pl.DataFrame(
+        {
+            "family": ["latent_factors", "latent_factors"],
+            "label": ["fwd_ret_5d", "fwd_ret_21d"],
+            "config_name": ["pca", "pca"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="do not match the declared catalog"):
+        research_workflow.run_official_model_catalog(
+            cast("object", SimpleNamespace()),
+            catalog,
+            population_name="cme_futures-pca-validation-v1",
+            resolved_requests=(_pca_request(),),
+        )
 
 
 def _multifold_frames(n_days: int = 60) -> tuple[pl.DataFrame, pl.DataFrame]:

--- a/tests/test_coverage_gate.py
+++ b/tests/test_coverage_gate.py
@@ -121,6 +121,33 @@ def test_all_null_predictions_do_not_read_as_coverage(case_dir):
     assert "no predictions" in str(excinfo.value)
 
 
+def test_non_finite_predictions_do_not_read_as_coverage(case_dir):
+    """NaN and infinity are non-null and rank against nothing; they are not decisions."""
+    for value in (float("nan"), float("inf"), float("-inf")):
+        frame = _frame().with_columns(pl.lit(value, dtype=pl.Float64).alias("prediction"))
+        with pytest.raises(CoverageError) as excinfo:
+            check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+        assert "no finite value" in str(excinfo.value)
+
+
+def test_a_session_whose_predictions_are_all_nan_counts_as_missing(case_dir):
+    frame = _frame().with_columns(
+        pl.when(pl.col("timestamp").dt.day() == 8)
+        .then(float("nan"))
+        .otherwise(pl.col("prediction"))
+        .alias("prediction")
+    )
+    with pytest.raises(CoverageError) as excinfo:
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+    assert "1 of 5 declared sessions absent" in str(excinfo.value)
+
+
+def test_an_integer_score_column_needs_only_to_be_non_null(case_dir):
+    """`is_finite` is undefined off a float column, so the condition there is non-null."""
+    frame = _frame().with_columns(pl.col("prediction").cast(pl.Int64).alias("prediction"))
+    assert check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir).complete
+
+
 def test_a_session_whose_predictions_are_all_null_counts_as_missing(case_dir):
     frame = _frame().with_columns(
         pl.when(pl.col("timestamp").dt.day() == 8)

--- a/tests/test_coverage_gate.py
+++ b/tests/test_coverage_gate.py
@@ -98,6 +98,41 @@ def test_a_dropped_fold_is_caught(case_dir):
     assert "5 of 5 declared sessions absent" in message
 
 
+def test_a_frame_with_no_prediction_column_is_not_a_prediction_set(case_dir):
+    """`check_prediction_coverage` read a row as a prediction, so a bare session axis passed."""
+    frame = _frame().drop("prediction")
+    with pytest.raises(CoverageError) as excinfo:
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+    assert "no prediction column" in str(excinfo.value)
+
+
+def test_a_backtest_input_frame_still_needs_no_score_column(case_dir):
+    """The requirement sits on the prediction entry point; `_coverage` is shared."""
+    report = check_backtest_input_coverage(
+        _frame().drop("prediction"), "cs", LABEL, case_dir=case_dir
+    )
+    assert report.complete
+
+
+def test_all_null_predictions_do_not_read_as_coverage(case_dir):
+    frame = _frame().with_columns(pl.lit(None, dtype=pl.Float64).alias("prediction"))
+    with pytest.raises(CoverageError) as excinfo:
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+    assert "no predictions" in str(excinfo.value)
+
+
+def test_a_session_whose_predictions_are_all_null_counts_as_missing(case_dir):
+    frame = _frame().with_columns(
+        pl.when(pl.col("timestamp").dt.day() == 8)
+        .then(None)
+        .otherwise(pl.col("prediction"))
+        .alias("prediction")
+    )
+    with pytest.raises(CoverageError) as excinfo:
+        check_prediction_coverage(frame, "cs", LABEL, case_dir=case_dir)
+    assert "1 of 5 declared sessions absent" in str(excinfo.value)
+
+
 def test_a_single_missing_interior_session_is_caught(case_dir):
     survivors = [ts for ts in SESSIONS if ts.day != 8]
     with pytest.raises(CoverageError) as excinfo:

--- a/tests/test_holdout_force_regenerates.py
+++ b/tests/test_holdout_force_regenerates.py
@@ -1,0 +1,74 @@
+"""`generate_holdout(force=True)` deletes the existing holdout, stale or not.
+
+The delete used to be gated on `has_holdout_predictions`, which asks whether a holdout is
+tied to one of the *current* validation top-N. Its own docstring says it returns False
+when a holdout exists but no top-N candidate matches it - a holdout whose training fell
+out of the top-N after a sweep reshuffle. So the delete was skipped exactly when the
+existing holdout was most stale, the new one was written beside it, and the case study
+carried two holdouts against the one-holdout-per-case-study rule.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "strategy_synthesis_holdout_force",
+    Path(__file__).resolve().parents[1] / "20_strategy_synthesis" / "holdout.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_HOLDOUT = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _HOLDOUT
+_SPEC.loader.exec_module(_HOLDOUT)
+
+
+class _ReachedSelection(Exception):
+    """Raised in place of the retrain, which is what this test is not exercising."""
+
+
+@pytest.fixture
+def calls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    seen: list[str] = []
+
+    def _delete(cs_id: str) -> int:
+        seen.append("delete")
+        return 1
+
+    def _select(*args, **kwargs):
+        raise _ReachedSelection
+
+    monkeypatch.setattr(_HOLDOUT, "delete_holdout_predictions", _delete)
+    monkeypatch.setattr(_HOLDOUT, "select_best_models", _select)
+    monkeypatch.setattr(_HOLDOUT, "load_existing_holdout", lambda cs_id: seen.append("load") or {})
+    return seen
+
+
+def test_force_deletes_a_holdout_no_top_n_candidate_matches(calls, monkeypatch) -> None:
+    """The stale case: `has_holdout_predictions` is False and a holdout is still on disk."""
+    monkeypatch.setattr(_HOLDOUT, "has_holdout_predictions", lambda cs_id: False)
+
+    with pytest.raises(_ReachedSelection):
+        _HOLDOUT.generate_holdout("nasdaq100_microstructure", force=True, verbose=False)
+
+    assert calls == ["delete"]
+
+
+def test_force_deletes_a_holdout_the_top_n_still_matches(calls, monkeypatch) -> None:
+    monkeypatch.setattr(_HOLDOUT, "has_holdout_predictions", lambda cs_id: True)
+
+    with pytest.raises(_ReachedSelection):
+        _HOLDOUT.generate_holdout("nasdaq100_microstructure", force=True, verbose=False)
+
+    assert calls == ["delete"]
+
+
+def test_without_force_a_matching_holdout_is_still_loaded(calls, monkeypatch) -> None:
+    monkeypatch.setattr(_HOLDOUT, "has_holdout_predictions", lambda cs_id: True)
+
+    _HOLDOUT.generate_holdout("nasdaq100_microstructure", force=False, verbose=False)
+
+    assert calls == ["load"]

--- a/tests/test_holdout_force_regenerates.py
+++ b/tests/test_holdout_force_regenerates.py
@@ -167,3 +167,28 @@ def test_deleting_a_holdout_clears_every_row_the_schema_points_at(tmp_path, monk
     # Both the challenger row and the benchmark row referencing the holdout backtest.
     assert counts["backtest_paired_metrics"] == 0
     assert counts["cohort_metrics"] == 0
+
+
+def test_deleting_a_holdout_removes_its_artifact_directories(tmp_path, monkeypatch) -> None:
+    """A prediction artifact is immutable per hash, so a stale file blocks its own replacement.
+
+    `register_prediction_set` refuses a hash whose `predictions.parquet` is on disk with a
+    different digest. Leaving the directory behind after deleting the row turns a
+    regenerated holdout into an "immutable prediction artifact conflict" with nothing in
+    the registry left to explain it - the state `force=True` exists to clear.
+    """
+    case_dir = _registry_with_a_holdout(tmp_path)
+    run_log = case_dir / "run_log"
+    stale_pred = run_log / "predictions" / "p_hold"
+    stale_bt = run_log / "backtest" / "b_hold"
+    kept_pred = run_log / "predictions" / "p_val"
+    for directory in (stale_pred, stale_bt, kept_pred):
+        directory.mkdir(parents=True)
+        (directory / "predictions.parquet").write_bytes(b"stale")
+    monkeypatch.setattr(_HOLDOUT, "get_case_study_dir", lambda cs_id, **kwargs: case_dir)
+
+    assert _HOLDOUT.delete_holdout_predictions("cs") == 1
+
+    assert not stale_pred.exists()
+    assert not stale_bt.exists()
+    assert kept_pred.exists()

--- a/tests/test_holdout_force_regenerates.py
+++ b/tests/test_holdout_force_regenerates.py
@@ -72,3 +72,98 @@ def test_without_force_a_matching_holdout_is_still_loaded(calls, monkeypatch) ->
     _HOLDOUT.generate_holdout("nasdaq100_microstructure", force=False, verbose=False)
 
     assert calls == ["load"]
+
+
+def _registry_with_a_holdout(tmp_path):
+    """The parent/child shape the delete has to walk, with the two FKs it used to miss."""
+    import sqlite3
+
+    case_dir = tmp_path / "cs"
+    (case_dir / "run_log").mkdir(parents=True)
+    db = sqlite3.connect(case_dir / "run_log" / "registry.db")
+    db.executescript(
+        """
+        CREATE TABLE prediction_sets (prediction_hash TEXT PRIMARY KEY, split TEXT);
+        CREATE TABLE prediction_coverage (
+            prediction_hash TEXT PRIMARY KEY
+                REFERENCES prediction_sets(prediction_hash));
+        CREATE TABLE prediction_metrics (
+            prediction_hash TEXT REFERENCES prediction_sets(prediction_hash));
+        CREATE TABLE fold_metrics (
+            prediction_hash TEXT REFERENCES prediction_sets(prediction_hash));
+        CREATE TABLE backtest_runs (
+            backtest_hash TEXT PRIMARY KEY,
+            prediction_hash TEXT REFERENCES prediction_sets(prediction_hash));
+        CREATE TABLE backtest_metrics (
+            backtest_hash TEXT REFERENCES backtest_runs(backtest_hash));
+        CREATE TABLE backtest_fold_metrics (
+            backtest_hash TEXT REFERENCES backtest_runs(backtest_hash));
+        CREATE TABLE backtest_paired_metrics (
+            challenger_hash TEXT REFERENCES backtest_runs(backtest_hash),
+            benchmark_hash TEXT);
+        CREATE TABLE cohort_metrics (
+            leader_hash TEXT REFERENCES backtest_runs(backtest_hash));
+
+        INSERT INTO prediction_sets VALUES ('p_hold', 'holdout');
+        INSERT INTO prediction_sets VALUES ('p_val', 'validation');
+        INSERT INTO prediction_coverage VALUES ('p_hold');
+        INSERT INTO prediction_coverage VALUES ('p_val');
+        INSERT INTO prediction_metrics VALUES ('p_hold');
+        INSERT INTO fold_metrics VALUES ('p_hold');
+        INSERT INTO backtest_runs VALUES ('b_hold', 'p_hold');
+        INSERT INTO backtest_metrics VALUES ('b_hold');
+        INSERT INTO backtest_fold_metrics VALUES ('b_hold');
+        INSERT INTO backtest_paired_metrics VALUES ('b_hold', 'other');
+        INSERT INTO backtest_paired_metrics VALUES ('other', 'b_hold');
+        INSERT INTO cohort_metrics VALUES ('b_hold');
+        """
+    )
+    db.commit()
+    db.close()
+    return case_dir
+
+
+def test_deleting_a_holdout_clears_every_row_the_schema_points_at(tmp_path, monkeypatch) -> None:
+    """`prediction_coverage` and `cohort_metrics` were missing from the hand-written list.
+
+    Both are declared foreign keys into the rows being deleted, so with
+    `PRAGMA foreign_keys=ON` every registered holdout raised
+    `sqlite3.IntegrityError: FOREIGN KEY constraint failed`. Reproduced on a copy of
+    cme_futures' production registry (holdout 18d48c3b9cc2) before the fix.
+    """
+    import sqlite3
+
+    case_dir = _registry_with_a_holdout(tmp_path)
+    monkeypatch.setattr(_HOLDOUT, "get_case_study_dir", lambda cs_id, **kwargs: case_dir)
+
+    assert _HOLDOUT.delete_holdout_predictions("cs") == 1
+
+    db = sqlite3.connect(case_dir / "run_log" / "registry.db")
+    counts = {
+        table: db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        for table in (
+            "prediction_sets",
+            "prediction_coverage",
+            "prediction_metrics",
+            "fold_metrics",
+            "backtest_runs",
+            "backtest_metrics",
+            "backtest_fold_metrics",
+            "backtest_paired_metrics",
+            "cohort_metrics",
+        )
+    }
+    assert db.execute("PRAGMA foreign_key_check").fetchall() == []
+    db.close()
+
+    # The validation prediction and its coverage row are untouched.
+    assert counts["prediction_sets"] == 1
+    assert counts["prediction_coverage"] == 1
+    assert counts["prediction_metrics"] == 0
+    assert counts["fold_metrics"] == 0
+    assert counts["backtest_runs"] == 0
+    assert counts["backtest_metrics"] == 0
+    assert counts["backtest_fold_metrics"] == 0
+    # Both the challenger row and the benchmark row referencing the holdout backtest.
+    assert counts["backtest_paired_metrics"] == 0
+    assert counts["cohort_metrics"] == 0

--- a/tests/test_label_buffer_unit.py
+++ b/tests/test_label_buffer_unit.py
@@ -1,0 +1,88 @@
+"""A label buffer is a duration, and the duration alone does not say what it counts.
+
+`21D` on a daily equity panel means 21 sessions; subtracting 21 calendar days from the
+holdout boundary leaks about six sessions into it. `sp500_options` declares `35D` for
+`ret_to_expiry`, a genuine calendar horizon to option expiry; counting 35 sessions there
+trims about seven weeks where five is correct. Both readings were live and neither was
+declared, so every consumer guessed independently and each guess was wrong for one class
+of label.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.artifact_specs import DEFAULT_LABEL_BUFFER_UNIT, resolve_label_buffer_unit
+from utils.cv_splits import _horizon_for_config, _purge_holdout_touching_validation
+
+
+def test_the_default_is_sessions_because_that_is_what_a_D_buffer_already_meant() -> None:
+    assert DEFAULT_LABEL_BUFFER_UNIT == "sessions"
+    assert resolve_label_buffer_unit("etfs", "fwd_ret_21d", {"labels": {}}) == "sessions"
+
+
+def test_setup_declares_the_unit_for_the_primary_label() -> None:
+    setup = {"labels": {"primary": "ret_to_expiry", "buffer": "35D", "buffer_unit": "calendar"}}
+
+    assert resolve_label_buffer_unit("sp500_options", "ret_to_expiry", setup) == "calendar"
+
+
+def test_setup_declares_the_unit_per_variant() -> None:
+    setup = {
+        "labels": {
+            "primary": "fwd_ret_5d",
+            "variants": ["ret_to_expiry"],
+            "variant_buffer_units": {"ret_to_expiry": "calendar"},
+        }
+    }
+
+    assert resolve_label_buffer_unit("sp500_options", "fwd_ret_5d", setup) == "sessions"
+    assert resolve_label_buffer_unit("sp500_options", "ret_to_expiry", setup) == "calendar"
+
+
+def test_an_unknown_unit_is_refused_rather_than_read_as_the_default() -> None:
+    setup = {"labels": {"primary": "ret_to_expiry", "buffer": "35D", "buffer_unit": "days"}}
+
+    with pytest.raises(ValueError, match="buffer_unit is 'days'"):
+        resolve_label_buffer_unit("sp500_options", "ret_to_expiry", setup)
+
+
+def test_a_session_buffer_is_counted_and_a_calendar_one_is_not() -> None:
+    """The int is what makes the splitter count sessions; the string is a duration."""
+    assert _horizon_for_config("35D", calendar_id="NYSE", buffer_unit="sessions") == 35
+    assert _horizon_for_config("35D", calendar_id="NYSE", buffer_unit="calendar") == "35D"
+
+
+def test_without_a_calendar_there_are_no_sessions_to_count() -> None:
+    assert _horizon_for_config("8h", calendar_id=None, buffer_unit="sessions") == "8h"
+    assert _horizon_for_config("1D", calendar_id=None, buffer_unit="sessions") == "1D"
+
+
+def test_the_purge_reads_the_same_declaration_as_the_fold_geometry() -> None:
+    """A calendar horizon purged as sessions removes decisions the label never reaches."""
+    import numpy as np
+    import pandas as pd
+
+    sessions = pd.bdate_range("2020-11-02", "2021-01-29")
+    val_idx = np.arange(len(sessions))
+    boundary = "2021-01-01"
+
+    as_sessions = _purge_holdout_touching_validation(
+        val_idx,
+        sessions,
+        holdout_start=boundary,
+        outcome_horizon="35D",
+        calendar_id="NYSE",
+        buffer_unit="sessions",
+    )
+    as_calendar = _purge_holdout_touching_validation(
+        val_idx,
+        sessions,
+        holdout_start=boundary,
+        outcome_horizon="35D",
+        calendar_id="NYSE",
+        buffer_unit="calendar",
+    )
+
+    assert len(as_sessions) < len(as_calendar)
+    assert sessions[as_calendar[-1]] < pd.Timestamp(boundary) - pd.Timedelta("35D")

--- a/tests/test_label_digest_without_a_sidecar.py
+++ b/tests/test_label_digest_without_a_sidecar.py
@@ -1,0 +1,82 @@
+"""A label's identity is its values, with or without a digest sidecar beside it.
+
+`LabelCatalog.get` digested the artifact's *bytes* when no sidecar was present and its
+*values* when one was. Every production label carries a sidecar; the CI fixtures, written
+before sidecars existed, do not - so the two answered differently for the same data, and
+the sidecar-less answer additionally forked whenever a parquet default moved. A whole-file
+digest of a container is not an identity of its contents.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.research.labels import LabelCatalog
+from case_studies.research.workspace import Study
+from case_studies.utils.artifact_digest import value_digest
+
+LABEL = "fwd_ret_21d"
+
+
+def _case_dir(tmp_path: Path) -> Path:
+    case_dir = tmp_path / "release" / "case_studies" / "etfs"
+    (case_dir / "run_log").mkdir(parents=True)
+    (case_dir / "run_log" / "registry.db").write_bytes(b"")
+    (case_dir / "config").mkdir()
+    (case_dir / "config" / "setup.yaml").write_text(
+        "labels:\n"
+        f"  primary: {LABEL}\n"
+        "  buffer: 2D\n"
+        f"  horizons: {{{LABEL}: 2D}}\n"
+        "evaluation:\n"
+        "  n_splits: 2\n"
+        "  train_size: 4D\n"
+        "  val_size: 2D\n"
+        "  holdout_start: '2024-01-11'\n"
+        "  holdout_end: '2024-01-12'\n"
+        "  calendar: crypto\n"
+    )
+    (case_dir / "labels").mkdir()
+    return case_dir
+
+
+def _frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": ["AAA", "BBB"] * 50,
+            "timestamp": list(range(100)),
+            LABEL: [i / 7 for i in range(100)],
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_output_redirect(monkeypatch):
+    monkeypatch.delenv("ML4T_OUTPUT_DIR", raising=False)
+    yield
+    os.environ.pop("ML4T_OUTPUT_DIR", None)
+
+
+def _digest_for(case_dir: Path, **write_kwargs) -> str:
+    _frame().write_parquet(case_dir / "labels" / f"{LABEL}.parquet", **write_kwargs)
+    study = Study.at(case_dir, case_study="etfs")
+    return LabelCatalog(study).get(LABEL).digest
+
+
+def test_the_same_values_under_two_codecs_have_one_identity(tmp_path: Path) -> None:
+    """Repeated writes are byte-stable, so only a settings change or an upgrade bites."""
+    default = _digest_for(_case_dir(tmp_path / "a"))
+    lz4 = _digest_for(_case_dir(tmp_path / "b"), compression="lz4")
+    row_groups = _digest_for(_case_dir(tmp_path / "c"), row_group_size=10)
+
+    assert default == lz4 == row_groups
+
+
+def test_the_identity_is_the_value_digest_the_sidecar_would_have_carried(
+    tmp_path: Path,
+) -> None:
+    assert _digest_for(_case_dir(tmp_path)) == value_digest(_frame())

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -44,6 +44,32 @@ def test_display_path_preserves_unrelated_and_relative_paths(tmp_path, monkeypat
     assert display_path("relative/artifact.txt") == "relative/artifact.txt"
 
 
+def test_display_path_stays_relative_through_a_symlinked_subdirectory(
+    tmp_path, monkeypatch
+) -> None:
+    """A `--case-study` worktree reaches run_log/ through a symlink into the artifact store.
+
+    Resolving before relativizing followed that link out of the repository and
+    printed the absolute store path into the committed notebook output.
+    """
+    import utils.paths as paths
+
+    fake_repo = tmp_path / "public-cs"
+    (fake_repo / "case_studies" / "etfs").mkdir(parents=True)
+    store = tmp_path / "artifacts" / "case_studies" / "etfs" / "run_log"
+    store.mkdir(parents=True)
+    (store / "registry.db").touch()
+    (fake_repo / "case_studies" / "etfs" / "run_log").symlink_to(store)
+
+    monkeypatch.setattr(paths, "REPO_ROOT", fake_repo.resolve())
+    monkeypatch.setattr(paths, "_REPO_ROOT_AS_WRITTEN", fake_repo)
+
+    assert (
+        paths.display_path(fake_repo / "case_studies" / "etfs" / "run_log" / "registry.db")
+        == "case_studies/etfs/run_log/registry.db"
+    )
+
+
 def test_chapters_registry_covers_1_through_27() -> None:
     """The book ships 27 chapters; the registry must enumerate all of them."""
     assert set(CHAPTERS.keys()) == set(range(1, 28))

--- a/tests/test_prediction_timestamp_zone.py
+++ b/tests/test_prediction_timestamp_zone.py
@@ -63,3 +63,48 @@ def test_a_frame_with_no_time_column_passes_through() -> None:
     frame = pl.DataFrame({"symbol": ["BTC"], "y_score": [0.1]})
 
     assert _timestamps_as_utc(frame).equals(frame)
+
+
+def test_a_pandas_frame_is_localized_in_place_rather_than_skipped() -> None:
+    """The legacy branch and the pandas side of the versioned one never convert.
+
+    Normalizing only Polars frames left those paths writing naive timestamps and recording
+    a naive `schema_json`, which is the mismatch this exists to remove.
+    """
+    import pandas as pd
+
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-01 08:00", "2024-01-01 16:00"]),
+            "symbol": ["BTC", "ETH"],
+            "prediction": [0.1, 0.2],
+        }
+    )
+
+    localized = _timestamps_as_utc(frame)
+
+    assert str(localized["timestamp"].dtype) == "datetime64[ns, UTC]"
+    assert pl.from_pandas(localized).schema["timestamp"].time_zone == "UTC"
+    # In place, not converted: the caller's frame type survives.
+    assert isinstance(localized, pd.DataFrame)
+    # And the instants are unchanged.
+    assert localized["timestamp"].dt.tz_localize(None).tolist() == frame["timestamp"].tolist()
+
+
+def test_an_already_aware_pandas_frame_is_left_alone() -> None:
+    import pandas as pd
+
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-01 08:00"]).tz_localize("UTC"),
+            "symbol": ["BTC"],
+            "prediction": [0.1],
+        }
+    )
+
+    assert _timestamps_as_utc(frame) is frame
+
+
+def test_none_passes_through() -> None:
+    """`register_prediction_set` accepts predictions=None on the legacy path."""
+    assert _timestamps_as_utc(None) is None

--- a/tests/test_prediction_timestamp_zone.py
+++ b/tests/test_prediction_timestamp_zone.py
@@ -83,7 +83,9 @@ def test_a_pandas_frame_is_localized_in_place_rather_than_skipped() -> None:
 
     localized = _timestamps_as_utc(frame)
 
-    assert str(localized["timestamp"].dtype) == "datetime64[ns, UTC]"
+    # The unit is pandas' own and differs across versions; the zone is what this pins.
+    assert localized["timestamp"].dt.tz is not None
+    assert str(localized["timestamp"].dtype).endswith(", UTC]")
     assert pl.from_pandas(localized).schema["timestamp"].time_zone == "UTC"
     # In place, not converted: the caller's frame type survives.
     assert isinstance(localized, pd.DataFrame)

--- a/tests/test_prediction_timestamp_zone.py
+++ b/tests/test_prediction_timestamp_zone.py
@@ -1,0 +1,65 @@
+"""Every family's prediction artifact carries the same timestamp dtype.
+
+`gbm`, `linear` and `tabular_dl` wrote `Datetime(_, 'UTC')`; `deep_learning` reaches the
+registry through `flush_fold_predictions`, whose dates come from a numpy `datetime64`
+array and are therefore naive. Measured on crypto_perps_funding (2026-08-28): 578
+artifacts UTC-aware and 100 naive - same label, same split, same folds, same 19 symbols,
+same 2,189 decision times, identical instants. A tz-aware value never equals a naive one,
+so an exact join on (timestamp, symbol) between the two families returned nothing, and
+code assuming one dtype across a case study's artifacts dropped rows instead of failing.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import polars as pl
+
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.registry.store import _timestamps_as_utc
+
+
+def _frame(zone: str | None) -> pl.DataFrame:
+    stamps = [dt.datetime(2024, 1, 1, 8), dt.datetime(2024, 1, 1, 16)]
+    frame = pl.DataFrame({"timestamp": stamps, "symbol": ["BTC", "ETH"], "y_score": [0.1, 0.2]})
+    if zone is None:
+        return frame
+    return frame.with_columns(pl.col("timestamp").dt.replace_time_zone(zone))
+
+
+def test_a_naive_decision_time_is_localized_not_converted() -> None:
+    localized = _timestamps_as_utc(_frame(None))
+
+    assert localized.schema["timestamp"].time_zone == "UTC"
+    assert localized["timestamp"].dt.replace_time_zone(None).to_list() == (
+        _frame(None)["timestamp"].to_list()
+    )
+
+
+def test_the_two_families_join_after_normalization() -> None:
+    naive = _timestamps_as_utc(_frame(None))
+    aware = _timestamps_as_utc(_frame("UTC").rename({"y_score": "y_score_other"}))
+
+    assert naive.join(aware, on=["timestamp", "symbol"], how="inner").height == 2
+
+
+def test_normalizing_does_not_move_the_artifact_digest() -> None:
+    """value_digest is zone-insensitive, so a rewritten artifact keeps its identity.
+
+    That is what lets this sit on the writer without any immutable-artifact check
+    firing on a prediction set that already exists on disk.
+    """
+    assert value_digest(_frame(None)) == value_digest(_timestamps_as_utc(_frame(None)))
+
+
+def test_an_already_aware_frame_and_its_time_unit_are_left_alone() -> None:
+    """The unit is deliberately untouched: value_digest *is* time-unit sensitive."""
+    aware_ms = _frame("UTC").with_columns(pl.col("timestamp").dt.cast_time_unit("ms"))
+
+    assert _timestamps_as_utc(aware_ms).schema == aware_ms.schema
+
+
+def test_a_frame_with_no_time_column_passes_through() -> None:
+    frame = pl.DataFrame({"symbol": ["BTC"], "y_score": [0.1]})
+
+    assert _timestamps_as_utc(frame).equals(frame)

--- a/tests/test_seed_prediction_fixtures.py
+++ b/tests/test_seed_prediction_fixtures.py
@@ -2,7 +2,7 @@
 
 import sqlite3
 import warnings
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 import polars as pl
 import pytest
@@ -380,3 +380,40 @@ def test_a_registry_without_cohort_metrics_still_seeds(tmp_path):
 
     for prediction_hash in (LEADER_PRED, "hash_other"):
         assert (run_log / "predictions" / prediction_hash / "predictions.parquet").is_file()
+
+
+def test_a_sub_daily_label_keeps_the_fabricated_grid(tmp_path):
+    """`_subsampled_panel` keeps a contiguous run at native spacing below a day.
+
+    It has to: a stride hands an 8H label decisions ten days apart and 13_backtest rejects
+    them against its horizon. On a minute-bar label that run is sixty consecutive minutes.
+    Measured on nasdaq100_microstructure, every seeded set collapsed to one hour of a
+    one-year window, every configuration in the sweep scored the same Sharpe, and
+    14_backtest failed at `hist(..., bins=30)` with "Too many bins for data range". The
+    fabricated grid spans the window, which is what an intraday case study is better
+    served by, so the label panel declines below a day.
+    """
+    cs_dir = tmp_path / "crypto_perps_funding"
+    run_log = cs_dir / "run_log"
+    _crypto_registry(run_log, _COHORT_DDL)
+    labels_dir = cs_dir / "labels"
+    labels_dir.mkdir(parents=True)
+    minutes = [datetime(2022, 3, 1) + timedelta(minutes=i) for i in range(600)]
+    pl.DataFrame(
+        {
+            "symbol": ["BTC", "ETH"] * 600,
+            "timestamp": [m for m in minutes for _ in (0, 1)],
+            "funding_next_8h": [i / 1000 for i in range(1200)],
+        }
+    ).write_parquet(labels_dir / "funding_next_8h.parquet")
+
+    with pytest.warns(RuntimeWarning, match=LEADER_PRED):
+        _backfill_all_prediction_parquets(cs_dir, "crypto_perps_funding")
+
+    leader = pl.read_parquet(run_log / "predictions" / LEADER_PRED / "predictions.parquet")
+    # The fabricated weekday grid, not the label's ten hours: the warning above already
+    # says the label panel declined, and the spacing is what the notebook depends on.
+    stamps = leader["timestamp"].unique().sort()
+    assert stamps.len() > 1
+    assert stamps.diff().drop_nulls().min() >= timedelta(days=1)
+    assert stamps.max() - stamps.min() > timedelta(days=30)

--- a/tests/test_seed_prediction_fixtures.py
+++ b/tests/test_seed_prediction_fixtures.py
@@ -1,7 +1,8 @@
 """Regression tests for coherent case-study prediction fixtures."""
 
 import sqlite3
-from datetime import date
+import warnings
+from datetime import date, timedelta
 
 import polars as pl
 import pytest
@@ -285,14 +286,72 @@ def test_the_real_carrier_artifact_survives_the_crypto_rewrite(tmp_path):
     )
 
 
-def test_a_leader_with_no_artifact_is_named_not_silently_synthesized(tmp_path):
-    """Nothing here can reconstruct the artifact, so the gap is reported by hash at
-    regeneration time rather than left to surface as a correlation failure several
-    notebooks downstream."""
+def test_a_leader_with_no_artifact_takes_its_group_panel(tmp_path):
+    """A leader with no artifact is seeded onto a real panel where its group has one.
+
+    That panel carries the entities, timestamps and realized target the pinning notebook
+    checks, so there is nothing to report.
+    """
     cs_dir = tmp_path / "crypto_perps_funding"
     run_log = cs_dir / "run_log"
     _crypto_registry(run_log, _COHORT_DDL)
-    _write_carrier(run_log, "hash_other", "STALE")
+    _write_carrier(run_log, "hash_other", "REALPANEL")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _backfill_all_prediction_parquets(cs_dir, "crypto_perps_funding")
+
+    assert not [w for w in caught if "cohort-leader" in str(w.message)]
+    leader = pl.read_parquet(run_log / "predictions" / LEADER_PRED / "predictions.parquet")
+    assert leader["symbol"].unique().to_list() == ["REALPANEL"]
+
+
+def test_a_leader_with_no_artifact_takes_the_fixture_label_panel(tmp_path):
+    """With nothing in the group, the fixture's own label artifact is the panel.
+
+    `sample_registry_for_tests` copies no prediction artifacts, so this is the ordinary
+    case in seven of the nine fixtures: the group is empty and the label parquet is the
+    only real source of keys and of the realized value the pinning notebook checks.
+    """
+    cs_dir = tmp_path / "crypto_perps_funding"
+    run_log = cs_dir / "run_log"
+    _crypto_registry(run_log, _COHORT_DDL)
+    labels_dir = cs_dir / "labels"
+    labels_dir.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "symbol": ["BTC", "ETH"] * 30,
+            # Inside the default validation window (holdout_start 2024-01-01).
+            "timestamp": [date(2022, 3, 1) + timedelta(days=i) for i in range(30) for _ in (0, 1)],
+            "funding_next_8h": [i / 1000 for i in range(60)],
+        }
+    ).write_parquet(labels_dir / "funding_next_8h.parquet")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _backfill_all_prediction_parquets(cs_dir, "crypto_perps_funding")
+
+    assert not [w for w in caught if "cohort-leader" in str(w.message)]
+    leader = pl.read_parquet(run_log / "predictions" / LEADER_PRED / "predictions.parquet")
+    assert sorted(leader["symbol"].unique().to_list()) == ["BTC", "ETH"]
+    # The realized value is the label's own, not a drawn one.
+    truth = pl.read_parquet(labels_dir / "funding_next_8h.parquet")
+    joined = leader.join(
+        truth.rename({"funding_next_8h": "truth"}), on=["symbol", "timestamp"], how="inner"
+    )
+    assert joined.height == leader.height
+    assert (joined["actual"] - joined["truth"]).abs().max() == 0.0
+
+
+def test_a_leader_with_no_panel_at_all_is_named(tmp_path):
+    """Nothing left to seed onto: no group artifact, no label parquet. Report it by hash.
+
+    The gap surfaces here at regeneration time rather than as a correlation failure
+    several notebooks downstream.
+    """
+    cs_dir = tmp_path / "crypto_perps_funding"
+    run_log = cs_dir / "run_log"
+    _crypto_registry(run_log, _COHORT_DDL)
 
     with pytest.warns(RuntimeWarning, match=LEADER_PRED):
         _backfill_all_prediction_parquets(cs_dir, "crypto_perps_funding")

--- a/tests/test_strategy_analysis_selection_disagreement.py
+++ b/tests/test_strategy_analysis_selection_disagreement.py
@@ -1,0 +1,164 @@
+"""Ranking a raw Sharpe column selects a different carrier, and used to say so as silence.
+
+A Sharpe computed over a configuration's own available history is not comparable across
+configurations that priced different spans, so ranking the pool's column directly rewards
+whichever candidate had the most forgiving window. Measured on cme_futures (992 signal /
+120 allocation / 28 risk_overlay backtests, rebuilt 2026-08-30): the raw column answered
+latent_factors/sdf on fwd_ret_21d at 1.274, `resolve_solvent_carrier` gbm/leaves_31_mse on
+fwd_ret_5d at 1.236 raw and 1.294 over the 1,270 sessions the candidates all price.
+
+`17_holdout_predictions` and `18_holdout_backtest` run the resolver's answer, so a notebook
+that selected its own then asked for the holdout replay of a configuration nothing ran, got
+None, and printed "not produced yet" while the holdout sat in the registry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import case_studies.utils.strategy_analysis as sa
+
+CANONICAL = {
+    "val_backtest_hash": "619a5cd773b4",
+    "holdout_backtest_hash": "aa11bb22cc33",
+    "family": "gbm",
+    "config_name": "leaves_31_mse",
+    "label": "fwd_ret_5d",
+}
+
+
+def _canonical(**overrides):
+    def _resolve(case_study, **kwargs):
+        return {**CANONICAL, **overrides}
+
+    return _resolve
+
+
+@pytest.fixture
+def registry(tmp_path, monkeypatch):
+    """A run log holding the hash the caller asks about.
+
+    The diagnosis only fires on a *registered* hash: one the run log has never seen is a
+    stale constant, not a carrier chosen from a pool, and `_resolve_holdout_self_backtest`
+    already says so more usefully.
+    """
+    import sqlite3
+
+    case_dir = tmp_path / "cs"
+    (case_dir / "run_log").mkdir(parents=True)
+    db = sqlite3.connect(case_dir / "run_log" / "registry.db")
+    db.execute("CREATE TABLE backtest_runs (backtest_hash TEXT PRIMARY KEY)")
+    db.executemany(
+        "INSERT INTO backtest_runs VALUES (?)",
+        [("cbd72d8408d3",), (CANONICAL["val_backtest_hash"],)],
+    )
+    db.commit()
+    db.close()
+    monkeypatch.setattr(sa, "get_case_study_dir", lambda cs, **kw: case_dir, raising=False)
+    import utils.paths
+
+    monkeypatch.setattr(utils.paths, "get_case_study_dir", lambda cs, **kw: case_dir)
+    return case_dir
+
+
+def test_a_carrier_the_holdout_notebooks_never_ran_is_named_as_such(registry, monkeypatch) -> None:
+    monkeypatch.setattr(sa, "resolve_canonical_rank1_lineage", _canonical())
+    monkeypatch.setattr(
+        sa,
+        "_resolve_holdout_self_backtest",
+        lambda cs, h: sa.HoldoutSelfBacktest(None, "no holdout backtest is registered"),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sa.resolve_holdout_self_backtest("cme_futures", "cbd72d8408d3")
+
+    message = str(excinfo.value)
+    assert "selection disagreement" in message
+    assert "cbd72d8408d3" in message and "619a5cd773b4" in message
+    assert "gbm/leaves_31_mse on fwd_ret_5d" in message
+
+
+def test_a_holdout_that_genuinely_has_not_run_still_reports_that(monkeypatch) -> None:
+    """The normal state for anyone working the notebooks in order must not raise."""
+    monkeypatch.setattr(
+        sa, "resolve_canonical_rank1_lineage", _canonical(holdout_backtest_hash=None)
+    )
+    monkeypatch.setattr(
+        sa,
+        "_resolve_holdout_self_backtest",
+        lambda cs, h: sa.HoldoutSelfBacktest(None, "the holdout has not been evaluated"),
+    )
+
+    answer = sa.resolve_holdout_self_backtest("cme_futures", "cbd72d8408d3")
+
+    assert answer.backtest_hash is None
+    assert "not been evaluated" in answer.reason
+
+
+def test_the_canonical_carrier_asking_for_its_own_replay_never_raises(monkeypatch) -> None:
+    monkeypatch.setattr(sa, "resolve_canonical_rank1_lineage", _canonical())
+    monkeypatch.setattr(
+        sa,
+        "_resolve_holdout_self_backtest",
+        lambda cs, h: sa.HoldoutSelfBacktest(None, "none of them replays that run's strategy"),
+    )
+
+    answer = sa.resolve_holdout_self_backtest("cme_futures", CANONICAL["val_backtest_hash"])
+
+    assert answer.backtest_hash is None
+
+
+def test_a_resolver_that_cannot_answer_leaves_the_original_answer_standing(monkeypatch) -> None:
+    """An empty registry must not turn a missing holdout into a resolver error."""
+
+    def _raise(case_study, **kwargs):
+        raise RuntimeError("no validation rank-1 candidate")
+
+    monkeypatch.setattr(sa, "resolve_canonical_rank1_lineage", _raise)
+    monkeypatch.setattr(
+        sa,
+        "_resolve_holdout_self_backtest",
+        lambda cs, h: sa.HoldoutSelfBacktest(None, "the holdout has not been evaluated"),
+    )
+
+    assert sa.resolve_holdout_self_backtest("cme_futures", "cbd72d8408d3").backtest_hash is None
+
+
+def test_a_found_replay_is_returned_without_consulting_the_resolver(monkeypatch) -> None:
+    def _fail(case_study, **kwargs):
+        raise AssertionError("the diagnosis ran on a successful lookup")
+
+    monkeypatch.setattr(sa, "resolve_canonical_rank1_lineage", _fail)
+    monkeypatch.setattr(
+        sa, "_resolve_holdout_self_backtest", lambda cs, h: sa.HoldoutSelfBacktest("aa11bb22cc33")
+    )
+
+    assert sa.resolve_holdout_self_backtest("cme_futures", "x").backtest_hash == "aa11bb22cc33"
+
+
+def test_select_holdout_self_backtest_raises_through_the_same_path(registry, monkeypatch) -> None:
+    """The six notebooks that print "not produced yet" call this one, not the resolver."""
+    monkeypatch.setattr(sa, "resolve_canonical_rank1_lineage", _canonical())
+    monkeypatch.setattr(
+        sa,
+        "_resolve_holdout_self_backtest",
+        lambda cs, h: sa.HoldoutSelfBacktest(None, "no holdout backtest is registered"),
+    )
+
+    with pytest.raises(RuntimeError, match="selection disagreement"):
+        sa.select_holdout_self_backtest("cme_futures", "cbd72d8408d3")
+
+
+def test_a_hash_the_run_log_has_never_seen_keeps_its_own_answer(registry, monkeypatch) -> None:
+    """A stale hardcoded hash is not a selection, and the specific answer is more useful."""
+    monkeypatch.setattr(sa, "resolve_canonical_rank1_lineage", _canonical())
+    monkeypatch.setattr(
+        sa,
+        "_resolve_holdout_self_backtest",
+        lambda cs, h: sa.HoldoutSelfBacktest(None, "is not registered in the run log"),
+    )
+
+    answer = sa.resolve_holdout_self_backtest("cme_futures", "never_registered")
+
+    assert answer.backtest_hash is None
+    assert "not registered" in answer.reason

--- a/tests/test_strategy_analysis_selection_disagreement.py
+++ b/tests/test_strategy_analysis_selection_disagreement.py
@@ -162,3 +162,65 @@ def test_a_hash_the_run_log_has_never_seen_keeps_its_own_answer(registry, monkey
 
     assert answer.backtest_hash is None
     assert "not registered" in answer.reason
+
+
+def test_the_canonical_resolver_does_not_re_enter_the_diagnosis(monkeypatch, tmp_path) -> None:
+    """Unmocked, on a registry with no holdout - the shape that used to recurse.
+
+    `resolve_canonical_rank1_lineage` looks the holdout up for its own rank-1, and the
+    diagnosis asks that resolver for the canonical carrier. Going through the diagnosing
+    wrapper there re-entered it: each call resolved the whole ranking again one level
+    deeper until the recursion limit, and the diagnosis swallowed the RecursionError after
+    hundreds of registry reads. The resolver takes the raw lookup now - it IS the canonical
+    selection, so it can never disagree with itself.
+    """
+    import sqlite3
+
+    case_dir = tmp_path / "cs"
+    (case_dir / "run_log").mkdir(parents=True)
+    db = sqlite3.connect(case_dir / "run_log" / "registry.db")
+    db.executescript(
+        """
+        CREATE TABLE training_runs (
+            training_hash TEXT PRIMARY KEY, family TEXT, config_name TEXT, label TEXT,
+            spec_json TEXT);
+        CREATE TABLE prediction_sets (
+            prediction_hash TEXT PRIMARY KEY, training_hash TEXT, split TEXT,
+            checkpoint_value INTEGER, checkpoint_kind TEXT);
+        CREATE TABLE backtest_runs (
+            backtest_hash TEXT PRIMARY KEY, prediction_hash TEXT, stage TEXT,
+            spec_json TEXT);
+        CREATE TABLE backtest_metrics (backtest_hash TEXT PRIMARY KEY, sharpe REAL);
+        CREATE TABLE fold_metrics (
+            prediction_hash TEXT, fold INTEGER, ic REAL, n_days INTEGER);
+        CREATE TABLE prediction_metrics (prediction_hash TEXT PRIMARY KEY, ic_mean REAL);
+        CREATE TABLE prediction_coverage (prediction_hash TEXT PRIMARY KEY, status TEXT);
+
+        INSERT INTO training_runs VALUES ('t1', 'gbm', 'leaves_31_mse', 'fwd_ret_5d', '{}');
+        INSERT INTO prediction_sets VALUES ('p1', 't1', 'validation', 100, 'iteration');
+        INSERT INTO backtest_runs VALUES ('b1', 'p1', 'signal', '{"strategy": {"a": 1}}');
+        INSERT INTO backtest_metrics VALUES ('b1', 1.2);
+        """
+    )
+    db.commit()
+    db.close()
+    monkeypatch.setattr(sa, "get_case_study_dir", lambda cs, **kw: case_dir, raising=False)
+    import utils.paths
+
+    monkeypatch.setattr(utils.paths, "get_case_study_dir", lambda cs, **kw: case_dir)
+
+    calls = {"n": 0}
+    real = sa.resolve_canonical_rank1_lineage
+
+    def _counted(case_study, **kwargs):
+        calls["n"] += 1
+        assert calls["n"] < 5, "the canonical resolver re-entered the diagnosis"
+        return real(case_study, **kwargs)
+
+    monkeypatch.setattr(sa, "resolve_canonical_rank1_lineage", _counted)
+
+    lineage = _counted("cs")
+
+    assert lineage["val_backtest_hash"] == "b1"
+    assert lineage["holdout_backtest_hash"] is None
+    assert calls["n"] == 1

--- a/tests/test_tabular_dl.py
+++ b/tests/test_tabular_dl.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 import torch
 
 from case_studies.utils.deep_model_state import restore_deep_model
@@ -81,3 +82,73 @@ def test_run_tabm_cv_returns_fold_metrics_after_training(tmp_path):
 
     np.testing.assert_allclose(actual, expected, rtol=1e-7, atol=1e-8)
     assert metadata["checkpoint_value"] == 1
+
+
+def test_save_dir_none_selects_through_the_decision_time_path():
+    """Without incremental saves the epoch is still chosen on mean IC per decision time.
+
+    `run_tabm_cv` used to fall back to the mean of the per-fold ICs whenever
+    `cfg_all_preds` was empty, which `save_dir=None` was believed to produce. Folds with
+    unequal numbers of decision times then carried equal weight, so a `save_dir=None` run
+    could report a different best epoch than the registered one. The folds here are
+    deliberately lopsided - 3 decision times against 30 - so the two readings differ, and
+    the reported IC has to be the decision-time one.
+    """
+    n_days, n_symbols = 120, 20
+    timestamps = pd.date_range("2020-01-01", periods=n_days, freq="D")
+    rng = np.random.default_rng(7)
+    dataset = pd.DataFrame(
+        {
+            "timestamp": np.repeat(timestamps, n_symbols),
+            "symbol": np.tile([f"S{i}" for i in range(n_symbols)], n_days),
+            "feature": rng.normal(size=n_days * n_symbols),
+        }
+    )
+    dataset["target"] = dataset["feature"] * 0.3 + rng.normal(scale=0.5, size=len(dataset))
+    splits = [
+        {
+            "fold": 0,
+            "train_start": timestamps[0],
+            "train_end": timestamps[39],
+            "val_start": timestamps[40],
+            "val_end": timestamps[42],
+        },
+        {
+            "fold": 1,
+            "train_start": timestamps[0],
+            "train_end": timestamps[79],
+            "val_start": timestamps[80],
+            "val_end": timestamps[109],
+        },
+    ]
+    configs = [
+        {
+            "config_name": "tabm_test",
+            "params": {"hidden_dim": 4, "n_members": 2, "dropout": 0.0},
+            "n_epochs": 2,
+            "batch_size": 32,
+            "checkpoint_interval": 1,
+        }
+    ]
+
+    result = run_tabm_cv(
+        dataset,
+        splits,
+        configs=configs,
+        n_features=1,
+        feature_names=["feature"],
+        label_col="target",
+        date_col="timestamp",
+        device="cpu",
+        save_dir=None,
+    )
+
+    # Predictions are retained in memory, which is what makes the decision-time path run.
+    assert result["all_predictions"].height == 2 * (3 + 30) * n_symbols
+
+    fold_ics = result["fold_metrics"].sort("fold_id")["ic_mean"].to_list()
+    assert len(fold_ics) == 2
+    reported = result["best_ic"]
+    pooled = (3 * fold_ics[0] + 30 * fold_ics[1]) / 33
+    assert reported == pytest.approx(pooled, abs=5e-3)
+    assert reported != pytest.approx(float(np.mean(fold_ics)), abs=5e-3)

--- a/tests/test_tabular_dl.py
+++ b/tests/test_tabular_dl.py
@@ -1,5 +1,9 @@
+import tempfile
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 import torch
 
@@ -152,3 +156,63 @@ def test_save_dir_none_selects_through_the_decision_time_path():
     pooled = (3 * fold_ics[0] + 30 * fold_ics[1]) / 33
     assert reported == pytest.approx(pooled, abs=5e-3)
     assert reported != pytest.approx(float(np.mean(fold_ics)), abs=5e-3)
+
+
+def test_a_config_with_fold_ics_and_no_predictions_refuses_rather_than_averaging(monkeypatch):
+    """The reachable remnant of the removed fallback: flushed predictions that never came back.
+
+    `run_tabm_cv` used to build `checkpoint_metrics` from the mean of the per-fold ICs there,
+    which weights a three-day fold like a thirty-day one and reports a different best epoch
+    than the registry's. There is no checkpoint metric to compute from fold ICs, so the run
+    stops instead.
+    """
+    import case_studies.utils.tabular_dl as tabular_dl
+
+    # The incremental predictions are written and read back through this one function;
+    # returning nothing is what a config whose flush produced no readable file looks like.
+    monkeypatch.setattr(
+        tabular_dl, "_load_incremental_preds_for_config", lambda incr_dir, key: pl.DataFrame()
+    )
+
+    n_days, n_symbols = 120, 20
+    timestamps = pd.date_range("2020-01-01", periods=n_days, freq="D")
+    rng = np.random.default_rng(3)
+    dataset = pd.DataFrame(
+        {
+            "timestamp": np.repeat(timestamps, n_symbols),
+            "symbol": np.tile([f"S{i}" for i in range(n_symbols)], n_days),
+            "feature": rng.normal(size=n_days * n_symbols),
+        }
+    )
+    dataset["target"] = dataset["feature"] * 0.3 + rng.normal(scale=0.5, size=len(dataset))
+    splits = [
+        {
+            "fold": 0,
+            "train_start": timestamps[0],
+            "train_end": timestamps[79],
+            "val_start": timestamps[80],
+            "val_end": timestamps[109],
+        }
+    ]
+    configs = [
+        {
+            "config_name": "tabm_test",
+            "params": {"hidden_dim": 4, "n_members": 2, "dropout": 0.0},
+            "n_epochs": 2,
+            "batch_size": 32,
+            "checkpoint_interval": 1,
+        }
+    ]
+
+    with pytest.raises(RuntimeError, match="no predictions to score"):
+        run_tabm_cv(
+            dataset,
+            splits,
+            configs=configs,
+            n_features=1,
+            feature_names=["feature"],
+            label_col="target",
+            date_col="timestamp",
+            device="cpu",
+            save_dir=Path(tempfile.mkdtemp()),
+        )

--- a/utils/artifact_specs.py
+++ b/utils/artifact_specs.py
@@ -122,6 +122,58 @@ def resolve_label_buffer(
     return None
 
 
+LABEL_BUFFER_UNITS = ("sessions", "calendar")
+DEFAULT_LABEL_BUFFER_UNIT = "sessions"
+
+
+def resolve_label_buffer_unit(
+    case_study_id: str,
+    label: str,
+    setup: Mapping[str, Any] | None = None,
+) -> str:
+    """Say whether a label's buffer counts sessions or calendar time.
+
+    A buffer is written as a duration - ``21D``, ``35D``, ``8H`` - and the duration alone
+    does not say which of the two it means. Both readings are live. On a session-gridded
+    daily panel ``21D`` means 21 sessions, and subtracting 21 calendar days from the
+    holdout boundary leaks about six sessions into it. ``sp500_options`` declares
+    ``35D`` for ``ret_to_expiry``, which is a genuine calendar horizon to option expiry,
+    and reading it as 35 sessions trims about seven weeks where five is correct - data
+    loss rather than leakage, but still a frame that ends earlier than it needs to.
+
+    Without a declaration each consumer guesses, and the guess is made independently in
+    every consumer and is wrong for one class of label wherever it is made. This is the
+    declaration; ``sessions`` is the default because it is the reading every ``D`` buffer
+    already gets wherever a calendar is configured.
+
+    Declared the same way and in the same order as the buffer itself
+    (:func:`resolve_label_buffer`): on the label spec under ``definition.buffer_unit``, or
+    in ``setup.yaml`` under ``labels.buffer_unit`` for the primary and
+    ``labels.variant_buffer_units[<label>]`` for a variant.
+    """
+    label_spec = load_label_spec(case_study_id, label)
+    declared: Any = None
+    if label_spec is not None:
+        declared = (label_spec.get("definition", {}) or {}).get("buffer_unit")
+
+    if declared is None:
+        labels = (setup or {}).get("labels", {})
+        if labels.get("primary") == label:
+            declared = labels.get("buffer_unit")
+        if declared is None:
+            declared = (labels.get("variant_buffer_units") or {}).get(label)
+
+    if declared is None:
+        return DEFAULT_LABEL_BUFFER_UNIT
+    unit = str(declared)
+    if unit not in LABEL_BUFFER_UNITS:
+        raise ValueError(
+            f"{case_study_id}/{label}: buffer_unit is {unit!r}, "
+            f"not one of {list(LABEL_BUFFER_UNITS)}"
+        )
+    return unit
+
+
 def resolve_label_horizon(
     case_study_id: str,
     label: str,
@@ -163,10 +215,13 @@ def resolve_market_runtime(case_study_id: str) -> dict[str, Any]:
 
 
 __all__ = [
+    "DEFAULT_LABEL_BUFFER_UNIT",
+    "LABEL_BUFFER_UNITS",
     "load_feature_spec",
     "load_label_spec",
     "load_market_data_spec",
     "resolve_label_buffer",
+    "resolve_label_buffer_unit",
     "resolve_label_horizon",
     "resolve_market_runtime",
     "resolve_market_semantics",

--- a/utils/cv_splits.py
+++ b/utils/cv_splits.py
@@ -38,7 +38,11 @@ import pandas as pd
 import polars as pl
 import yaml
 
-from utils.artifact_specs import resolve_market_semantics
+from utils.artifact_specs import (
+    DEFAULT_LABEL_BUFFER_UNIT,
+    LABEL_BUFFER_UNITS,
+    resolve_market_semantics,
+)
 from utils.paths import get_case_study_dir
 
 if TYPE_CHECKING:
@@ -92,6 +96,32 @@ def normalize_label_buffer(s: str) -> str:
     return s
 
 
+def _horizon_for_config(
+    normalized_buffer: str,
+    *,
+    calendar_id: str | None,
+    buffer_unit: str,
+) -> int | str:
+    """Turn a normalized buffer into what the splitter should count.
+
+    A ``D`` buffer is passed as an ``int`` so the library counts **sessions**, which is
+    right for a session-gridded panel: "21D" as ``pd.Timedelta("21 days")`` is about 15
+    sessions, and under-buffering the holdout boundary leaks. It is wrong for a
+    calendar-anchored horizon such as ``sp500_options``' 35 days to option expiry, where
+    counting 35 sessions over-trims by about two weeks.
+
+    The duration cannot say which it is, so the label declares it -
+    ``utils.artifact_specs.resolve_label_buffer_unit``. Without a calendar there are no
+    sessions to count and the duration is the only reading available.
+    """
+    if buffer_unit not in LABEL_BUFFER_UNITS:
+        raise ValueError(f"buffer_unit is {buffer_unit!r}, not one of {list(LABEL_BUFFER_UNITS)}")
+    if buffer_unit != "sessions" or calendar_id is None:
+        return normalized_buffer
+    d_match = re.match(r"^(\d+)D$", normalized_buffer)
+    return int(d_match.group(1)) if d_match else normalized_buffer
+
+
 def _purge_holdout_touching_validation(
     val_idx: np.ndarray,
     timestamps: pd.DatetimeIndex,
@@ -99,8 +129,15 @@ def _purge_holdout_touching_validation(
     holdout_start: str | None,
     outcome_horizon: str,
     calendar_id: str | None,
+    buffer_unit: str = DEFAULT_LABEL_BUFFER_UNIT,
 ) -> np.ndarray:
-    """Exclude validation signals whose label endpoint reaches the holdout."""
+    """Exclude validation signals whose label endpoint reaches the holdout.
+
+    ``buffer_unit`` decides how ``outcome_horizon`` is read, the same way it decides it
+    for the fold geometry: sessions counted back from the boundary's position, or a
+    calendar duration subtracted from the boundary itself. A calendar-anchored horizon
+    read as sessions purges further than the label reaches.
+    """
     if not holdout_start or outcome_horizon in {"", "0D", "0H"}:
         return val_idx
 
@@ -115,7 +152,7 @@ def _purge_holdout_touching_validation(
         boundary = boundary.tz_localize(None)
 
     trading_day_match = re.fullmatch(r"(\d+)D", outcome_horizon)
-    if calendar_id is not None and trading_day_match:
+    if calendar_id is not None and trading_day_match and buffer_unit == "sessions":
         horizon = int(trading_day_match.group(1))
         holdout_pos = int(timestamps.searchsorted(boundary, side="left"))
         return val_idx[val_idx < holdout_pos - horizon]
@@ -172,6 +209,8 @@ def make_walk_forward_config(
     case_study_id: str,
     label_horizon: str = "0D",
     date_col: str = "timestamp",
+    *,
+    buffer_unit: str = DEFAULT_LABEL_BUFFER_UNIT,
 ) -> WalkForwardConfig:
     """Create a WalkForwardConfig from a case study's setup.yaml.
 
@@ -197,13 +236,9 @@ def make_walk_forward_config(
 
     eval_config = load_evaluation_config(case_study_id)
     calendar_id = _map_calendar_id(eval_config.get("calendar"))
-
-    # For D-unit buffers with a calendar, pass as int (trading days)
-    normalized_horizon: int | str = normalize_label_buffer(label_horizon)
-    if calendar_id is not None and isinstance(normalized_horizon, str):
-        d_match = re.match(r"^(\d+)D$", normalized_horizon)
-        if d_match:
-            normalized_horizon = int(d_match.group(1))
+    normalized_horizon = _horizon_for_config(
+        normalize_label_buffer(label_horizon), calendar_id=calendar_id, buffer_unit=buffer_unit
+    )
 
     return WalkForwardConfig(
         n_splits=eval_config["n_splits"],
@@ -222,12 +257,15 @@ def make_wf_config(
     case_study_id: str,
     label_horizon: str = "0D",
     date_col: str = "timestamp",
+    *,
+    buffer_unit: str = DEFAULT_LABEL_BUFFER_UNIT,
 ) -> WalkForwardConfig:
     """Backward-compatible alias for make_walk_forward_config."""
     return make_walk_forward_config(
         case_study_id=case_study_id,
         label_horizon=label_horizon,
         date_col=date_col,
+        buffer_unit=buffer_unit,
     )
 
 
@@ -239,6 +277,7 @@ def generate_cv_splits(
     outcome_horizon: str | None = None,
     date_col: str = "timestamp",
     *,
+    buffer_unit: str = DEFAULT_LABEL_BUFFER_UNIT,
     cv_config: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Generate walk-forward date splits from evaluation config.
@@ -332,11 +371,9 @@ def generate_cv_splits(
     # library interprets it as trading days (not calendar days). This fixes
     # the under-buffering where "21D" → pd.Timedelta("21 days") → ~15 trading
     # days instead of the intended 21 trading days.
-    label_horizon: int | str = label_buffer
-    if calendar_id is not None:
-        d_match = re.match(r"^(\d+)D$", label_buffer)
-        if d_match:
-            label_horizon = int(d_match.group(1))
+    label_horizon = _horizon_for_config(
+        label_buffer, calendar_id=calendar_id, buffer_unit=buffer_unit
+    )
 
     # Build WalkForwardConfig (library Pydantic model)
     config = LibWalkForwardConfig(
@@ -388,6 +425,7 @@ def generate_cv_splits(
             holdout_start=eval_config.get("holdout_start"),
             outcome_horizon=outcome_horizon,
             calendar_id=calendar_id,
+            buffer_unit=buffer_unit,
         )
         if len(val_idx) == 0:
             raise ValueError(

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -42,6 +42,7 @@ from utils.artifact_specs import (
     load_feature_spec,
     load_label_spec,
     resolve_label_buffer,
+    resolve_label_buffer_unit,
     resolve_label_horizon,
     resolve_market_semantics,
     resolve_storage_path,
@@ -910,6 +911,10 @@ def load_modeling_dataset(
     # CV splits — read buffer from setup.yaml (explicit, handles non-standard labels)
     setup = yaml.safe_load((case_dir / "config" / "setup.yaml").read_text())
     label_buffer = resolve_label_buffer(case_study_id, primary_label, setup)
+    # Whether that duration counts sessions or calendar time is the label's to declare,
+    # not each consumer's to guess: `35D` to option expiry is calendar, `21D` on a daily
+    # equity panel is 21 sessions, and the duration alone cannot tell them apart.
+    buffer_unit = resolve_label_buffer_unit(case_study_id, primary_label, setup)
     if not label_buffer:
         raise ValueError(
             f"No explicit label buffer found for '{primary_label}' in "
@@ -925,6 +930,7 @@ def load_modeling_dataset(
         label_buffer=label_buffer,
         outcome_horizon=resolve_label_horizon(case_study_id, primary_label, setup),
         date_col=date_col,
+        buffer_unit=buffer_unit,
     )
     temporal_artifact_splits: list[dict[str, Any]] = []
     if temporal_by_fold_pd is not None:
@@ -968,7 +974,12 @@ def load_modeling_dataset(
     if wf_horizon and wf_horizon.endswith("M") and wf_horizon[:-1].isdigit():
         wf_horizon = f"{int(wf_horizon[:-1]) * 30}D"
     try:
-        cv_config = make_wf_config(case_study_id, label_horizon=wf_horizon, date_col=date_col)
+        cv_config = make_wf_config(
+            case_study_id,
+            label_horizon=wf_horizon,
+            date_col=date_col,
+            buffer_unit=buffer_unit,
+        )
     except Exception as exc:
         warnings.warn(f"WalkForwardConfig creation failed for {case_study_id}: {exc}", stacklevel=2)
         cv_config = None

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -282,7 +282,24 @@ class ModelingDataset:
 
 
 def _sha256_file(path: Path) -> str:
-    """Return a stable digest for an identity-defining input artifact."""
+    """Digest an identity-defining input artifact's bytes.
+
+    Stable across repeated writes, not across encodings. Two parquet files holding
+    identical data hash differently if they were written with a different compression
+    codec or row-group size, and this digest is inside `computation.feature_artifacts` and
+    `computation.input_data_spec.artifacts`, which are inside the hashed `computation`
+    block - so a codec change forks the `training_hash` of every run reading that artifact.
+
+    Two things hold that shut. `artifact_digest._PARQUET_WRITE_SETTINGS` states the
+    encoding these artifacts are written under rather than inheriting a library default,
+    and `tests/test_artifact_digest_encoding.py` records the bytes a fixed frame produces
+    under it, so a change arrives as a failing test rather than as a registry that has
+    grown two identities for one piece of work.
+
+    `artifact_digest.value_digest` digests column *values* and is what a new identity
+    version should use here; changing it now would re-key all 1,305 registered training
+    runs across the nine live registries, which is a re-derivation rather than a fix.
+    """
     digest = hashlib.sha256()
     with path.open("rb") as src:
         for chunk in iter(lambda: src.read(1024 * 1024), b""):

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -39,6 +39,13 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 
+# The same root without following symlinks. A `--case-study` worktree wires its
+# heavy state (`run_log/`, `features/`, `labels/`) in by symlink, so a path that
+# lives inside the repo through one of those links resolves to the canonical
+# artifact store outside it. Relativizing has to be tried against the path as
+# written before anything is resolved.
+_REPO_ROOT_AS_WRITTEN = Path(os.path.abspath(Path(__file__).parent.parent))
+
 # =============================================================================
 # Chapter Registry (Single Source of Truth)
 # =============================================================================
@@ -125,24 +132,36 @@ def display_path(path: Path | str) -> str:
 
     Use in `print(...)` statements inside notebooks so the committed cell
     output never bakes in machine-specific absolute paths (e.g. `/home/<user>/...`).
-    """
-    p = Path(path).resolve()
-    try:
-        return str(p.relative_to(REPO_ROOT))
-    except ValueError:
-        pass
 
-    if p.is_absolute():
-        for variable in ("ML4T_CHAPTER_OUTPUT_DIR", "ML4T_OUTPUT_DIR", "ML4T_DATA_PATH"):
-            configured_root = os.environ.get(variable)
-            if not configured_root:
-                continue
+    A path inside the repository stays relative even when it is reached through a
+    symlink, which is the normal state of a `new-worktree.sh --case-study`
+    worktree: `run_log/`, `features/` and `labels/` are links into
+    `~/ml4t/artifacts/`, so resolving first would relativize against the wrong
+    root and print the absolute store path.
+    """
+    as_written = Path(os.path.abspath(path))
+    resolved = as_written.resolve()
+
+    for candidate in (as_written, resolved):
+        for root in (_REPO_ROOT_AS_WRITTEN, REPO_ROOT):
             try:
-                relative = p.relative_to(Path(configured_root).expanduser().resolve())
+                return str(candidate.relative_to(root))
             except ValueError:
                 continue
-            return str(Path(f"<{variable}>") / relative)
-    return str(p)
+
+    for variable in ("ML4T_CHAPTER_OUTPUT_DIR", "ML4T_OUTPUT_DIR", "ML4T_DATA_PATH"):
+        configured_root = os.environ.get(variable)
+        if not configured_root:
+            continue
+        configured = Path(configured_root).expanduser()
+        for candidate in (as_written, resolved):
+            for root in (Path(os.path.abspath(configured)), configured.resolve()):
+                try:
+                    relative = candidate.relative_to(root)
+                except ValueError:
+                    continue
+                return str(Path(f"<{variable}>") / relative)
+    return str(resolved)
 
 
 def get_chapter_dir(chapter: int | str) -> Path:


### PR DESCRIPTION
Fourteen infrastructure defects, each fixed with the measurement that shows it was real and
a test that fails without the fix. Nothing here changes a published number; four changes
stop a run that would have produced a wrong one silently.

## Correctness in the shared engines

**The backtest engine marked an unpriceable position at exactly zero return.**
`_run_vectorized` inner-joined weights to outcomes, so a selected position whose outcome
row was missing was discarded while its original weight still sat in the sum - an assertion
about a position nobody could price, not an exclusion. `n_positions` counted the survivors
and turnover still charged the dropped name. The join is left now and a non-zero weight
with no usable outcome stops the run. Renormalizing instead was rejected: it applies a
filter to a chosen position using data from after the choice. Measured over the two case
studies named as the exposure - sp500_options 618 prediction sets / 65,274,796 rows,
us_firm_characteristics 827 / 207,725,536 - both have zero null outcomes and zero duplicate
keys, so the join is lossless on today's data and no published number moves.

**TabM checkpoint selection could report a different epoch than the registry.** The
fallback averaged per-fold ICs, which weights a three-day fold like a thirty-day one. On
lopsided folds (fold ICs +0.4675 and +0.3849 over 3 and 30 decision times) the decision-time
answer is +0.3924 and the fold mean +0.4262. The path it was written for no longer reaches
it - `save_dir=None` keeps predictions in memory - so what remains raises.

**`check_prediction_coverage` never checked for a prediction.** A frame carrying a
timestamp for every declared session and nothing else reported complete. It now requires a
score column and counts only finite scores, so a session whose predictions are all null or
NaN reports as missing. The requirement sits on the prediction entry point;
`check_backtest_input_coverage` shares the helper and still accepts a frame with no score.

**A partial resolved model set could snapshot under the catalog's name and report
complete.** `require_complete()` measures the population against the members it just
declared, so eight of sixteen configurations published as sixteen. sp500_options carried
the check privately; it is now `research.require_resolved_requests_cover_the_catalog` and
cme_futures' wrapper - the one four notebooks take - calls it.

**`generate_holdout(force=True)` did not delete a stale holdout.** The delete was gated on
a check that returns False exactly when the holdout is stale, so two holdouts coexisted.
It deletes unconditionally now, walks the child tables from the schema rather than a
hand-written list (`prediction_coverage` and `cohort_metrics` were missing, and every
registered holdout raised `FOREIGN KEY constraint failed` - reproduced on a copy of
cme_futures' registry), commits as one transaction, and removes the artifact directories
that would otherwise block the regenerated holdout as an immutable-artifact conflict.

## Values that did not say what they meant

**Prediction timestamps.** `deep_learning` wrote naive timestamps while every other family
wrote UTC-aware - 578 aware and 100 naive on crypto_perps_funding, identical instants - so
an exact join between the two families returned nothing. Naive is localized to UTC on the
writer and on the reader, so the artifacts already on disk join today. `value_digest` is
zone-insensitive, so no digest and no immutable-artifact check moves.

**Label buffers.** A buffer is a duration and nothing said whether it counted sessions or
calendar time. `resolve_label_buffer_unit` declares it, one resolver turns it into what the
splitter counts, and the holdout purge and both fold-boundary resolvers read the same
declaration. The default is `sessions`, which is what a `D` buffer already meant wherever a
calendar is configured, so no fold boundary moves.

**Registry training identity digests parquet bytes.** The encoding is now stated rather
than inherited, byte-identical to polars 1.41.1's defaults, and a recorded sha256 turns a
future default change into a failing test. The label path, where a sidecar-less artifact
was digested by bytes and one with a sidecar by values, now digests values either way.

**`display_path` resolved symlinks before relativizing**, so every `--case-study` worktree
baked an absolute store path into its committed notebook output - the opposite of what its
docstring promises.

## Reader-facing

**`ml4t/ml4t:latest` had no Chrome**, so kaleido could not render and every notebook
re-executed in the image lost the `image/png` GitHub needs. Chrome for Testing is installed
on amd64 and the build asserts PNG export. The second half is what makes that safe: the
container runs as the host UID, and a UID with no passwd entry got `HOME=/`, where Chrome
exits immediately - so a writable HOME is named for every UID. Verified against the
published image as root and as uid 1000, 1234 and 4242.

**13F producer and consumer.** Availability was taken over long-equity rows only, so a
manager filing options only completed the quarter without advancing the timestamp - the
graph claimed to have been available before that filing was public. The notebook derived
quarter coverage from a frame past the same filters, and skipped the two momentum columns
on the single-quarter path the producer always emits. All three fixed; the notebook was
re-executed against production data and its parity assertion prints PASS from that run.

## CI fixtures

**Cohort-leader predictions were synthesized on a fabricated grid.** In seven of nine
fixtures the leader had no artifact and neither did its group, so a replay notebook pinning
it failed a correlation gate against real prices several stages downstream. The panel now
comes from the fixture's own label artifact - real keys, and the realized value stage 02
computed from the fixture's own prices. Verified over all nine: zero warnings, and each of
the twelve leaders joins its label parquet on every row with max|actual - label| = 0.

**Three stale sp500_options label files** were removed from `ml4t/third-edition-test-data`
after confirming nothing in this repository reads them.

**`resolve_solvent_carrier` disagreements are named, not silent.** A notebook ranking its
pool's raw Sharpe can select a different carrier than the holdout notebooks ran, and the
result read as "holdout not produced yet" while the holdout sat in the registry. That
answer is now refused with both hashes and the configuration named. Six notebooks still
rank raw Sharpe; changing them is executable source and is tracked separately.

## Verification

Every change carries a test that fails without it - 39 files, +2,755/-313, the new tests in
thirteen files. RoboRev reviewed four times across the branch and every finding it raised
is either fixed here or answered with a measurement in the commit that addresses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7W14G4noaTLHBm16arPmF
