### PR TITLE
seoa: the holdout chain names the candidate-set generation the registry resolves

### DIFF
--- a/case_studies/sp500_equity_option_analytics/16_risk_management.ipynb
+++ b/case_studies/sp500_equity_option_analytics/16_risk_management.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "75e5173d",
+   "id": "2c4d99eb",
    "metadata": {
     "papermill": {
-     "duration": 0.0091,
-     "end_time": "2026-09-02T01:59:05.295670+00:00",
+     "duration": 0.00178,
+     "end_time": "2026-09-04T03:27:59.773187+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:05.286570+00:00",
+     "start_time": "2026-09-04T03:27:59.771407+00:00",
      "status": "completed"
     }
    },
@@ -44,19 +44,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "e7b6f36c",
+   "id": "ce96275e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:05.307850Z",
-     "iopub.status.busy": "2026-09-02T01:59:05.307692Z",
-     "iopub.status.idle": "2026-09-02T01:59:05.603222Z",
-     "shell.execute_reply": "2026-09-02T01:59:05.602853Z"
+     "iopub.execute_input": "2026-09-04T03:27:59.776898Z",
+     "iopub.status.busy": "2026-09-04T03:27:59.776782Z",
+     "iopub.status.idle": "2026-09-04T03:28:00.534452Z",
+     "shell.execute_reply": "2026-09-04T03:28:00.534019Z"
     },
     "papermill": {
-     "duration": 0.300714,
-     "end_time": "2026-09-02T01:59:05.603612+00:00",
+     "duration": 0.760546,
+     "end_time": "2026-09-04T03:28:00.535218+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:05.302898+00:00",
+     "start_time": "2026-09-04T03:27:59.774672+00:00",
      "status": "completed"
     }
    },
@@ -77,13 +77,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee4db08b",
+   "id": "9d9180bb",
    "metadata": {
     "papermill": {
-     "duration": 0.001389,
-     "end_time": "2026-09-02T01:59:05.606628+00:00",
+     "duration": 0.00137,
+     "end_time": "2026-09-04T03:28:00.539607+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:05.605239+00:00",
+     "start_time": "2026-09-04T03:28:00.538237+00:00",
      "status": "completed"
     }
    },
@@ -95,19 +95,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "6dc5775f",
+   "id": "c96386d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:05.609989Z",
-     "iopub.status.busy": "2026-09-02T01:59:05.609861Z",
-     "iopub.status.idle": "2026-09-02T01:59:07.506518Z",
-     "shell.execute_reply": "2026-09-02T01:59:07.506003Z"
+     "iopub.execute_input": "2026-09-04T03:28:00.543214Z",
+     "iopub.status.busy": "2026-09-04T03:28:00.543037Z",
+     "iopub.status.idle": "2026-09-04T03:28:03.049761Z",
+     "shell.execute_reply": "2026-09-04T03:28:03.049124Z"
     },
     "papermill": {
-     "duration": 1.899226,
-     "end_time": "2026-09-02T01:59:07.507214+00:00",
+     "duration": 2.509322,
+     "end_time": "2026-09-04T03:28:03.050309+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:05.607988+00:00",
+     "start_time": "2026-09-04T03:28:00.540987+00:00",
      "status": "completed"
     }
    },
@@ -167,19 +167,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5bcbde7d",
+   "id": "22dd6561",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:07.511418Z",
-     "iopub.status.busy": "2026-09-02T01:59:07.511331Z",
-     "iopub.status.idle": "2026-09-02T01:59:07.513109Z",
-     "shell.execute_reply": "2026-09-02T01:59:07.512754Z"
+     "iopub.execute_input": "2026-09-04T03:28:03.054918Z",
+     "iopub.status.busy": "2026-09-04T03:28:03.054727Z",
+     "iopub.status.idle": "2026-09-04T03:28:03.057389Z",
+     "shell.execute_reply": "2026-09-04T03:28:03.056715Z"
     },
     "papermill": {
-     "duration": 0.004531,
-     "end_time": "2026-09-02T01:59:07.513401+00:00",
+     "duration": 0.005439,
+     "end_time": "2026-09-04T03:28:03.057741+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:07.508870+00:00",
+     "start_time": "2026-09-04T03:28:03.052302+00:00",
      "status": "completed"
     },
     "tags": [
@@ -197,13 +197,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f312322",
+   "id": "123ddd2c",
    "metadata": {
     "papermill": {
-     "duration": 0.001305,
-     "end_time": "2026-09-02T01:59:07.516151+00:00",
+     "duration": 0.001673,
+     "end_time": "2026-09-04T03:28:03.061256+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:07.514846+00:00",
+     "start_time": "2026-09-04T03:28:03.059583+00:00",
      "status": "completed"
     }
    },
@@ -218,19 +218,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "85fbed83",
+   "id": "c6474472",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:07.519350Z",
-     "iopub.status.busy": "2026-09-02T01:59:07.519283Z",
-     "iopub.status.idle": "2026-09-02T01:59:07.541181Z",
-     "shell.execute_reply": "2026-09-02T01:59:07.540929Z"
+     "iopub.execute_input": "2026-09-04T03:28:03.065867Z",
+     "iopub.status.busy": "2026-09-04T03:28:03.065660Z",
+     "iopub.status.idle": "2026-09-04T03:28:03.096674Z",
+     "shell.execute_reply": "2026-09-04T03:28:03.095960Z"
     },
     "papermill": {
-     "duration": 0.024261,
-     "end_time": "2026-09-02T01:59:07.541783+00:00",
+     "duration": 0.034367,
+     "end_time": "2026-09-04T03:28:03.097382+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:07.517522+00:00",
+     "start_time": "2026-09-04T03:28:03.063015+00:00",
      "status": "completed"
     }
    },
@@ -261,13 +261,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8500df97",
+   "id": "8d6bcfb2",
    "metadata": {
     "papermill": {
-     "duration": 0.001379,
-     "end_time": "2026-09-02T01:59:07.544912+00:00",
+     "duration": 0.001846,
+     "end_time": "2026-09-04T03:28:03.101594+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:07.543533+00:00",
+     "start_time": "2026-09-04T03:28:03.099748+00:00",
      "status": "completed"
     }
    },
@@ -281,13 +281,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "186e7bec",
+   "id": "be6dc871",
    "metadata": {
     "papermill": {
-     "duration": 0.001375,
-     "end_time": "2026-09-02T01:59:07.547705+00:00",
+     "duration": 0.001762,
+     "end_time": "2026-09-04T03:28:03.105247+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:07.546330+00:00",
+     "start_time": "2026-09-04T03:28:03.103485+00:00",
      "status": "completed"
     }
    },
@@ -306,19 +306,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "84a2f05e",
+   "id": "88aab275",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:07.550984Z",
-     "iopub.status.busy": "2026-09-02T01:59:07.550913Z",
-     "iopub.status.idle": "2026-09-02T01:59:07.609494Z",
-     "shell.execute_reply": "2026-09-02T01:59:07.609215Z"
+     "iopub.execute_input": "2026-09-04T03:28:03.110179Z",
+     "iopub.status.busy": "2026-09-04T03:28:03.110035Z",
+     "iopub.status.idle": "2026-09-04T03:28:03.184156Z",
+     "shell.execute_reply": "2026-09-04T03:28:03.183554Z"
     },
     "papermill": {
-     "duration": 0.061102,
-     "end_time": "2026-09-02T01:59:07.610197+00:00",
+     "duration": 0.077496,
+     "end_time": "2026-09-04T03:28:03.184548+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:07.549095+00:00",
+     "start_time": "2026-09-04T03:28:03.107052+00:00",
      "status": "completed"
     }
    },
@@ -351,19 +351,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "64df8f95",
+   "id": "fdabc1e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:07.613745Z",
-     "iopub.status.busy": "2026-09-02T01:59:07.613670Z",
-     "iopub.status.idle": "2026-09-02T01:59:39.965834Z",
-     "shell.execute_reply": "2026-09-02T01:59:39.965504Z"
+     "iopub.execute_input": "2026-09-04T03:28:03.190646Z",
+     "iopub.status.busy": "2026-09-04T03:28:03.190390Z",
+     "iopub.status.idle": "2026-09-04T03:28:24.928898Z",
+     "shell.execute_reply": "2026-09-04T03:28:24.928170Z"
     },
     "papermill": {
-     "duration": 32.354722,
-     "end_time": "2026-09-02T01:59:39.966522+00:00",
+     "duration": 21.742402,
+     "end_time": "2026-09-04T03:28:24.929588+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:07.611800+00:00",
+     "start_time": "2026-09-04T03:28:03.187186+00:00",
      "status": "completed"
     }
    },
@@ -433,13 +433,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26ee5439",
+   "id": "c47e932d",
    "metadata": {
     "papermill": {
-     "duration": 0.001515,
-     "end_time": "2026-09-02T01:59:39.969761+00:00",
+     "duration": 0.001694,
+     "end_time": "2026-09-04T03:28:24.933066+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:39.968246+00:00",
+     "start_time": "2026-09-04T03:28:24.931372+00:00",
      "status": "completed"
     }
    },
@@ -451,19 +451,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "d61df294",
+   "id": "aaa1cb46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:39.973166Z",
-     "iopub.status.busy": "2026-09-02T01:59:39.973063Z",
-     "iopub.status.idle": "2026-09-02T01:59:39.991687Z",
-     "shell.execute_reply": "2026-09-02T01:59:39.991274Z"
+     "iopub.execute_input": "2026-09-04T03:28:24.937887Z",
+     "iopub.status.busy": "2026-09-04T03:28:24.937711Z",
+     "iopub.status.idle": "2026-09-04T03:28:24.963926Z",
+     "shell.execute_reply": "2026-09-04T03:28:24.963505Z"
     },
     "papermill": {
-     "duration": 0.02074,
-     "end_time": "2026-09-02T01:59:39.991929+00:00",
+     "duration": 0.029739,
+     "end_time": "2026-09-04T03:28:24.964700+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:39.971189+00:00",
+     "start_time": "2026-09-04T03:28:24.934961+00:00",
      "status": "completed"
     }
    },
@@ -518,13 +518,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a1d881d",
+   "id": "720634bf",
    "metadata": {
     "papermill": {
-     "duration": 0.001402,
-     "end_time": "2026-09-02T01:59:39.994964+00:00",
+     "duration": 0.002072,
+     "end_time": "2026-09-04T03:28:24.968780+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:39.993562+00:00",
+     "start_time": "2026-09-04T03:28:24.966708+00:00",
      "status": "completed"
     }
    },
@@ -537,19 +537,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "6e20f56e",
+   "id": "d68e3398",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:39.998629Z",
-     "iopub.status.busy": "2026-09-02T01:59:39.998532Z",
-     "iopub.status.idle": "2026-09-02T01:59:40.820638Z",
-     "shell.execute_reply": "2026-09-02T01:59:40.820212Z"
+     "iopub.execute_input": "2026-09-04T03:28:24.973247Z",
+     "iopub.status.busy": "2026-09-04T03:28:24.973110Z",
+     "iopub.status.idle": "2026-09-04T03:28:27.631913Z",
+     "shell.execute_reply": "2026-09-04T03:28:27.631385Z"
     },
     "papermill": {
-     "duration": 0.824627,
-     "end_time": "2026-09-02T01:59:40.821055+00:00",
+     "duration": 2.661579,
+     "end_time": "2026-09-04T03:28:27.632292+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:39.996428+00:00",
+     "start_time": "2026-09-04T03:28:24.970713+00:00",
      "status": "completed"
     }
    },
@@ -577,13 +577,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37692fa5",
+   "id": "22bd9bbb",
    "metadata": {
     "papermill": {
-     "duration": 0.001531,
-     "end_time": "2026-09-02T01:59:40.824453+00:00",
+     "duration": 0.00158,
+     "end_time": "2026-09-04T03:28:27.635666+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.822922+00:00",
+     "start_time": "2026-09-04T03:28:27.634086+00:00",
      "status": "completed"
     }
    },
@@ -599,19 +599,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "fd168a5d",
+   "id": "04f02ec1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:40.828127Z",
-     "iopub.status.busy": "2026-09-02T01:59:40.828029Z",
-     "iopub.status.idle": "2026-09-02T01:59:40.840472Z",
-     "shell.execute_reply": "2026-09-02T01:59:40.840087Z"
+     "iopub.execute_input": "2026-09-04T03:28:27.639485Z",
+     "iopub.status.busy": "2026-09-04T03:28:27.639376Z",
+     "iopub.status.idle": "2026-09-04T03:28:27.653450Z",
+     "shell.execute_reply": "2026-09-04T03:28:27.652800Z"
     },
     "papermill": {
-     "duration": 0.014887,
-     "end_time": "2026-09-02T01:59:40.840842+00:00",
+     "duration": 0.016592,
+     "end_time": "2026-09-04T03:28:27.653825+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.825955+00:00",
+     "start_time": "2026-09-04T03:28:27.637233+00:00",
      "status": "completed"
     }
    },
@@ -639,13 +639,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54596f66",
+   "id": "1ed5c8c7",
    "metadata": {
     "papermill": {
-     "duration": 0.001449,
-     "end_time": "2026-09-02T01:59:40.843951+00:00",
+     "duration": 0.001591,
+     "end_time": "2026-09-04T03:28:27.657322+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.842502+00:00",
+     "start_time": "2026-09-04T03:28:27.655731+00:00",
      "status": "completed"
     }
    },
@@ -657,19 +657,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "f1aec3ee",
+   "id": "5a5195e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:40.847606Z",
-     "iopub.status.busy": "2026-09-02T01:59:40.847530Z",
-     "iopub.status.idle": "2026-09-02T01:59:40.853460Z",
-     "shell.execute_reply": "2026-09-02T01:59:40.853080Z"
+     "iopub.execute_input": "2026-09-04T03:28:27.661412Z",
+     "iopub.status.busy": "2026-09-04T03:28:27.661287Z",
+     "iopub.status.idle": "2026-09-04T03:28:27.668932Z",
+     "shell.execute_reply": "2026-09-04T03:28:27.668192Z"
     },
     "papermill": {
-     "duration": 0.008304,
-     "end_time": "2026-09-02T01:59:40.853729+00:00",
+     "duration": 0.010501,
+     "end_time": "2026-09-04T03:28:27.669445+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.845425+00:00",
+     "start_time": "2026-09-04T03:28:27.658944+00:00",
      "status": "completed"
     }
    },
@@ -706,19 +706,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "2beed0ed",
+   "id": "229380a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:40.857342Z",
-     "iopub.status.busy": "2026-09-02T01:59:40.857274Z",
-     "iopub.status.idle": "2026-09-02T01:59:40.860610Z",
-     "shell.execute_reply": "2026-09-02T01:59:40.860346Z"
+     "iopub.execute_input": "2026-09-04T03:28:27.674996Z",
+     "iopub.status.busy": "2026-09-04T03:28:27.674797Z",
+     "iopub.status.idle": "2026-09-04T03:28:27.679839Z",
+     "shell.execute_reply": "2026-09-04T03:28:27.679247Z"
     },
     "papermill": {
-     "duration": 0.005822,
-     "end_time": "2026-09-02T01:59:40.861079+00:00",
+     "duration": 0.00831,
+     "end_time": "2026-09-04T03:28:27.680139+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.855257+00:00",
+     "start_time": "2026-09-04T03:28:27.671829+00:00",
      "status": "completed"
     }
    },
@@ -740,14 +740,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a36d3781",
+   "id": "f4d220a4",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00141,
-     "end_time": "2026-09-02T01:59:40.864015+00:00",
+     "duration": 0.001628,
+     "end_time": "2026-09-04T03:28:27.683640+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.862605+00:00",
+     "start_time": "2026-09-04T03:28:27.682012+00:00",
      "status": "completed"
     }
    },
@@ -762,19 +762,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "9855a11b",
+   "id": "65606be5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:40.867598Z",
-     "iopub.status.busy": "2026-09-02T01:59:40.867535Z",
-     "iopub.status.idle": "2026-09-02T01:59:40.870101Z",
-     "shell.execute_reply": "2026-09-02T01:59:40.869769Z"
+     "iopub.execute_input": "2026-09-04T03:28:27.688160Z",
+     "iopub.status.busy": "2026-09-04T03:28:27.687957Z",
+     "iopub.status.idle": "2026-09-04T03:28:27.693006Z",
+     "shell.execute_reply": "2026-09-04T03:28:27.692317Z"
     },
     "papermill": {
-     "duration": 0.004813,
-     "end_time": "2026-09-02T01:59:40.870336+00:00",
+     "duration": 0.008238,
+     "end_time": "2026-09-04T03:28:27.693554+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.865523+00:00",
+     "start_time": "2026-09-04T03:28:27.685316+00:00",
      "status": "completed"
     }
    },
@@ -819,13 +819,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e31b713",
+   "id": "61e3192f",
    "metadata": {
     "papermill": {
-     "duration": 0.001439,
-     "end_time": "2026-09-02T01:59:40.873293+00:00",
+     "duration": 0.001698,
+     "end_time": "2026-09-04T03:28:27.697743+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.871854+00:00",
+     "start_time": "2026-09-04T03:28:27.696045+00:00",
      "status": "completed"
     }
    },
@@ -848,19 +848,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "62142677",
+   "id": "36f9670f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:40.876774Z",
-     "iopub.status.busy": "2026-09-02T01:59:40.876714Z",
-     "iopub.status.idle": "2026-09-02T01:59:40.920073Z",
-     "shell.execute_reply": "2026-09-02T01:59:40.919609Z"
+     "iopub.execute_input": "2026-09-04T03:28:27.702690Z",
+     "iopub.status.busy": "2026-09-04T03:28:27.702495Z",
+     "iopub.status.idle": "2026-09-04T03:28:27.780242Z",
+     "shell.execute_reply": "2026-09-04T03:28:27.779495Z"
     },
     "papermill": {
-     "duration": 0.045564,
-     "end_time": "2026-09-02T01:59:40.920362+00:00",
+     "duration": 0.081211,
+     "end_time": "2026-09-04T03:28:27.780702+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.874798+00:00",
+     "start_time": "2026-09-04T03:28:27.699491+00:00",
      "status": "completed"
     }
    },
@@ -869,7 +869,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Risk plan sp500_equity_option_analytics-risk-fwd_ret_5d-9fa26d693a25: b8ad08c1f941, 14 planned, attempt 3\n"
+      "Risk plan sp500_equity_option_analytics-risk-fwd_ret_5d-9fa26d693a25: b8ad08c1f941, 14 planned, attempt 4\n"
      ]
     }
    ],
@@ -923,19 +923,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "e5895dc4",
+   "id": "1337607b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:40.925644Z",
-     "iopub.status.busy": "2026-09-02T01:59:40.925510Z",
-     "iopub.status.idle": "2026-09-02T01:59:40.929332Z",
-     "shell.execute_reply": "2026-09-02T01:59:40.928453Z"
+     "iopub.execute_input": "2026-09-04T03:28:27.788614Z",
+     "iopub.status.busy": "2026-09-04T03:28:27.788438Z",
+     "iopub.status.idle": "2026-09-04T03:28:27.791486Z",
+     "shell.execute_reply": "2026-09-04T03:28:27.791024Z"
     },
     "papermill": {
-     "duration": 0.007339,
-     "end_time": "2026-09-02T01:59:40.929857+00:00",
+     "duration": 0.008051,
+     "end_time": "2026-09-04T03:28:27.792198+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.922518+00:00",
+     "start_time": "2026-09-04T03:28:27.784147+00:00",
      "status": "completed"
     }
    },
@@ -957,19 +957,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "11779ee8",
+   "id": "9286924d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:40.937967Z",
-     "iopub.status.busy": "2026-09-02T01:59:40.937899Z",
-     "iopub.status.idle": "2026-09-02T01:59:41.381644Z",
-     "shell.execute_reply": "2026-09-02T01:59:41.381282Z"
+     "iopub.execute_input": "2026-09-04T03:28:27.796607Z",
+     "iopub.status.busy": "2026-09-04T03:28:27.796458Z",
+     "iopub.status.idle": "2026-09-04T03:28:27.974012Z",
+     "shell.execute_reply": "2026-09-04T03:28:27.973289Z"
     },
     "papermill": {
-     "duration": 0.44797,
-     "end_time": "2026-09-02T01:59:41.381988+00:00",
+     "duration": 0.180399,
+     "end_time": "2026-09-04T03:28:27.974508+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:40.934018+00:00",
+     "start_time": "2026-09-04T03:28:27.794109+00:00",
      "status": "completed"
     }
    },
@@ -986,7 +986,7 @@
      "output_type": "stream",
      "text": [
       "Risk plan sp500_equity_option_analytics-risk-fwd_ret_5d-9fa26d693a25 complete: 14 backtests\n",
-      "Sweep attested as sp500_equity_option_analytics-risk-fwd_ret_5d-9fa26d693a25-g28fbc9ec4c6c-swept-3\n"
+      "Sweep attested as sp500_equity_option_analytics-risk-fwd_ret_5d-9fa26d693a25-g28fbc9ec4c6c-swept-4\n"
      ]
     }
    ],
@@ -1004,13 +1004,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "585c567e",
+   "id": "a116c15b",
    "metadata": {
     "papermill": {
-     "duration": 0.00161,
-     "end_time": "2026-09-02T01:59:41.385432+00:00",
+     "duration": 0.00308,
+     "end_time": "2026-09-04T03:28:27.981042+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:41.383822+00:00",
+     "start_time": "2026-09-04T03:28:27.977962+00:00",
      "status": "completed"
     }
    },
@@ -1025,19 +1025,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "16229151",
+   "id": "7f13d802",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:41.389063Z",
-     "iopub.status.busy": "2026-09-02T01:59:41.388969Z",
-     "iopub.status.idle": "2026-09-02T01:59:41.472401Z",
-     "shell.execute_reply": "2026-09-02T01:59:41.472010Z"
+     "iopub.execute_input": "2026-09-04T03:28:27.986761Z",
+     "iopub.status.busy": "2026-09-04T03:28:27.986509Z",
+     "iopub.status.idle": "2026-09-04T03:28:28.914838Z",
+     "shell.execute_reply": "2026-09-04T03:28:28.914024Z"
     },
     "papermill": {
-     "duration": 0.086039,
-     "end_time": "2026-09-02T01:59:41.473048+00:00",
+     "duration": 0.931718,
+     "end_time": "2026-09-04T03:28:28.915647+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:41.387009+00:00",
+     "start_time": "2026-09-04T03:28:27.983929+00:00",
      "status": "completed"
     }
    },
@@ -1078,14 +1078,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9d9beb6",
+   "id": "642f7db4",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001611,
-     "end_time": "2026-09-02T01:59:41.476515+00:00",
+     "duration": 0.002761,
+     "end_time": "2026-09-04T03:28:28.922587+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:41.474904+00:00",
+     "start_time": "2026-09-04T03:28:28.919826+00:00",
      "status": "completed"
     }
    },
@@ -1097,19 +1097,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "7b7232fc",
+   "id": "4089c604",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:41.480182Z",
-     "iopub.status.busy": "2026-09-02T01:59:41.480097Z",
-     "iopub.status.idle": "2026-09-02T01:59:41.482811Z",
-     "shell.execute_reply": "2026-09-02T01:59:41.482556Z"
+     "iopub.execute_input": "2026-09-04T03:28:28.929375Z",
+     "iopub.status.busy": "2026-09-04T03:28:28.929078Z",
+     "iopub.status.idle": "2026-09-04T03:28:28.933912Z",
+     "shell.execute_reply": "2026-09-04T03:28:28.933323Z"
     },
     "papermill": {
-     "duration": 0.004931,
-     "end_time": "2026-09-02T01:59:41.483029+00:00",
+     "duration": 0.009319,
+     "end_time": "2026-09-04T03:28:28.934637+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:41.478098+00:00",
+     "start_time": "2026-09-04T03:28:28.925318+00:00",
      "status": "completed"
     }
    },
@@ -1165,19 +1165,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "c42a460e",
+   "id": "6a61e26d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:41.486594Z",
-     "iopub.status.busy": "2026-09-02T01:59:41.486530Z",
-     "iopub.status.idle": "2026-09-02T01:59:47.586766Z",
-     "shell.execute_reply": "2026-09-02T01:59:47.586347Z"
+     "iopub.execute_input": "2026-09-04T03:28:28.942786Z",
+     "iopub.status.busy": "2026-09-04T03:28:28.942616Z",
+     "iopub.status.idle": "2026-09-04T03:28:37.087204Z",
+     "shell.execute_reply": "2026-09-04T03:28:37.086818Z"
     },
     "papermill": {
-     "duration": 6.10268,
-     "end_time": "2026-09-02T01:59:47.587333+00:00",
+     "duration": 8.150335,
+     "end_time": "2026-09-04T03:28:37.087781+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:41.484653+00:00",
+     "start_time": "2026-09-04T03:28:28.937446+00:00",
      "status": "completed"
     }
    },
@@ -1192,13 +1192,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43afa3fb",
+   "id": "caab4a5d",
    "metadata": {
     "papermill": {
-     "duration": 0.001849,
-     "end_time": "2026-09-02T01:59:47.591051+00:00",
+     "duration": 0.00264,
+     "end_time": "2026-09-04T03:28:37.093275+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:47.589202+00:00",
+     "start_time": "2026-09-04T03:28:37.090635+00:00",
      "status": "completed"
     }
    },
@@ -1214,19 +1214,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "c7d5e3e1",
+   "id": "2ffb4453",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:47.595195Z",
-     "iopub.status.busy": "2026-09-02T01:59:47.595061Z",
-     "iopub.status.idle": "2026-09-02T01:59:47.703725Z",
-     "shell.execute_reply": "2026-09-02T01:59:47.703350Z"
+     "iopub.execute_input": "2026-09-04T03:28:37.100918Z",
+     "iopub.status.busy": "2026-09-04T03:28:37.100795Z",
+     "iopub.status.idle": "2026-09-04T03:28:37.253430Z",
+     "shell.execute_reply": "2026-09-04T03:28:37.252953Z"
     },
     "papermill": {
-     "duration": 0.111397,
-     "end_time": "2026-09-02T01:59:47.704076+00:00",
+     "duration": 0.157025,
+     "end_time": "2026-09-04T03:28:37.253728+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:47.592679+00:00",
+     "start_time": "2026-09-04T03:28:37.096703+00:00",
      "status": "completed"
     }
    },
@@ -1278,19 +1278,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "dcd55dbe",
+   "id": "d5c81a96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:47.708417Z",
-     "iopub.status.busy": "2026-09-02T01:59:47.708320Z",
-     "iopub.status.idle": "2026-09-02T01:59:47.818787Z",
-     "shell.execute_reply": "2026-09-02T01:59:47.818430Z"
+     "iopub.execute_input": "2026-09-04T03:28:37.258760Z",
+     "iopub.status.busy": "2026-09-04T03:28:37.258651Z",
+     "iopub.status.idle": "2026-09-04T03:28:37.424528Z",
+     "shell.execute_reply": "2026-09-04T03:28:37.423898Z"
     },
     "papermill": {
-     "duration": 0.113175,
-     "end_time": "2026-09-02T01:59:47.819183+00:00",
+     "duration": 0.168879,
+     "end_time": "2026-09-04T03:28:37.424899+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:47.706008+00:00",
+     "start_time": "2026-09-04T03:28:37.256020+00:00",
      "status": "completed"
     }
    },
@@ -1345,13 +1345,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47193829",
+   "id": "3ccb9174",
    "metadata": {
     "papermill": {
-     "duration": 0.001832,
-     "end_time": "2026-09-02T01:59:47.823077+00:00",
+     "duration": 0.003033,
+     "end_time": "2026-09-04T03:28:37.431328+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:47.821245+00:00",
+     "start_time": "2026-09-04T03:28:37.428295+00:00",
      "status": "completed"
     }
    },
@@ -1391,56 +1391,60 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "aed7f60d",
+   "id": "c4841e1e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:47.827243Z",
-     "iopub.status.busy": "2026-09-02T01:59:47.827168Z",
-     "iopub.status.idle": "2026-09-02T01:59:47.829128Z",
-     "shell.execute_reply": "2026-09-02T01:59:47.828859Z"
+     "iopub.execute_input": "2026-09-04T03:28:37.438644Z",
+     "iopub.status.busy": "2026-09-04T03:28:37.438465Z",
+     "iopub.status.idle": "2026-09-04T03:28:37.441877Z",
+     "shell.execute_reply": "2026-09-04T03:28:37.441394Z"
     },
     "papermill": {
-     "duration": 0.004407,
-     "end_time": "2026-09-02T01:59:47.829351+00:00",
+     "duration": 0.007959,
+     "end_time": "2026-09-04T03:28:37.442700+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:47.824944+00:00",
+     "start_time": "2026-09-04T03:28:37.434741+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "# A candidate set is immutable under its name, so a field that has grown has to name the\n",
-    "# generation it replaces. Keyed by the full set name because that is what the refusal prints.\n",
+    "# A candidate set is immutable under its name, so a field whose membership has moved has to name\n",
+    "# the generation it replaces. Keyed by the full set name because that is what the refusal prints.\n",
     "# Resolved through `candidate_set_supersedes` rather than passed straight to `create`: a\n",
     "# reader's clean clone has no generation to supersede, and `create` refuses a first version that\n",
-    "# claims to replace one. Two generations precede this one and both stay readable by hash, which\n",
-    "# is what keeps a holdout registered against either traceable to the field it actually saw:\n",
-    "# `328d2009685c` is the single-label field frozen on 2026-08-30, before the four variant labels\n",
-    "# had baseline, allocation or overlay rows; `aa6b3986124b` replaced it on 2026-09-01 under a\n",
-    "# per-stage count of advancing configurations, which admitted a label whose sweep had produced\n",
-    "# one row per configuration and stopped; `04cb35eec43f` replaced that one later the same day and\n",
-    "# held 3,710 members, 66 of them allocation backtests from a grid no current sweep plan declares.\n",
-    "# `37169a5be187` replaced it with the declared grids only and holds 3,644, and `774c32c6e79b`\n",
-    "# replaced that. Every one of those five was frozen over a field that was still being produced:\n",
-    "# the allocation and risk plans behind them were all written at 21:40 UTC on 2026-09-01, while\n",
-    "# the baseline sweeps that feed them published at 22:34-22:46 and three of the baselines they\n",
-    "# rank were registered at 22:42. This generation is the first frozen over sweeps that ran in\n",
-    "# stage order and recorded that they finished. Only the tip is declarable - `create` refuses\n",
-    "# anything else and names the tip - so this value moves on every generation.\n",
+    "# claims to replace one. Five generations precede this one and all five stay readable by hash,\n",
+    "# which is what keeps a holdout registered against any of them traceable to the field it saw:\n",
+    "# `328d2009685c` is the single-label field frozen on 2026-08-30 with 1,097 members, before the\n",
+    "# four variant labels had baseline, allocation or overlay rows; `aa6b3986124b` replaced it on\n",
+    "# 2026-09-01 with 3,680 under a per-stage count of advancing configurations, which admitted a\n",
+    "# label whose sweep had produced one row per configuration and stopped; `04cb35eec43f` replaced\n",
+    "# that one later the same day and held 3,710, 66 of them allocation backtests from a grid no\n",
+    "# current sweep plan declares; `37169a5be187` replaced it with the declared grids only and held\n",
+    "# 3,644; `774c32c6e79b` replaced that with 3,811. All five were frozen over a field that was\n",
+    "# still being produced: the allocation and risk plans behind them were written at 21:40 UTC on\n",
+    "# 2026-09-01, while the baseline sweeps that feed them published at 22:34-22:46 and three of the\n",
+    "# baselines they rank were registered at 22:42. `57cb9eb3133c` is the tip, frozen 2026-09-02\n",
+    "# over sweeps that ran in stage order and recorded that they finished. It holds 3,811 as well and\n",
+    "# differs from `774c32c6e79b` in 54 members: the `fwd_ret_10d` allocation backtests registered at\n",
+    "# 00:55 on 2026-09-01 gave way to the 54 the re-executed 15 registered at 00:30 on 2026-09-02, so\n",
+    "# every member now rides an attestation that carries its own grid. Only the tip is declarable -\n",
+    "# `create` refuses anything else and names the tip - so this value moves on every generation, and\n",
+    "# it is wrong whenever it names a generation the registry has already superseded.\n",
     "SUPERSEDES_CANDIDATE_SETS: dict[str, str] = {\n",
-    "    \"sp500_equity_option_analytics:holdout-candidates\": \"774c32c6e79b\",\n",
+    "    \"sp500_equity_option_analytics:holdout-candidates\": \"57cb9eb3133c\",\n",
     "}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "76197e0d",
+   "id": "5bb226ff",
    "metadata": {
     "papermill": {
-     "duration": 0.001781,
-     "end_time": "2026-09-02T01:59:47.833002+00:00",
+     "duration": 0.003696,
+     "end_time": "2026-09-04T03:28:37.450438+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:47.831221+00:00",
+     "start_time": "2026-09-04T03:28:37.446742+00:00",
      "status": "completed"
     }
    },
@@ -1453,19 +1457,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "ffbc890a",
+   "id": "ece74454",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T01:59:47.837139Z",
-     "iopub.status.busy": "2026-09-02T01:59:47.837067Z",
-     "iopub.status.idle": "2026-09-02T02:01:55.678782Z",
-     "shell.execute_reply": "2026-09-02T02:01:55.678443Z"
+     "iopub.execute_input": "2026-09-04T03:28:37.459069Z",
+     "iopub.status.busy": "2026-09-04T03:28:37.458888Z",
+     "iopub.status.idle": "2026-09-04T03:30:59.240863Z",
+     "shell.execute_reply": "2026-09-04T03:30:59.240328Z"
     },
     "papermill": {
-     "duration": 127.845862,
-     "end_time": "2026-09-02T02:01:55.680719+00:00",
+     "duration": 141.789981,
+     "end_time": "2026-09-04T03:30:59.244209+00:00",
      "exception": false,
-     "start_time": "2026-09-02T01:59:47.834857+00:00",
+     "start_time": "2026-09-04T03:28:37.454228+00:00",
      "status": "completed"
     }
    },
@@ -1607,13 +1611,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5ec0139",
+   "id": "11ba057f",
    "metadata": {
     "papermill": {
-     "duration": 0.001827,
-     "end_time": "2026-09-02T02:01:55.684554+00:00",
+     "duration": 0.001837,
+     "end_time": "2026-09-04T03:30:59.248041+00:00",
      "exception": false,
-     "start_time": "2026-09-02T02:01:55.682727+00:00",
+     "start_time": "2026-09-04T03:30:59.246204+00:00",
      "status": "completed"
     }
    },
@@ -1669,22 +1673,22 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-02T02:02:02.179253+00:00",
+   "executed_at": "2026-09-04T03:31:09.744882+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
-   "source_py_blob": "0a8e185df3620eb058795033cc12fd7325013d57"
+   "source_py_blob": "330cdae809b6f84b6ebf97b1eb193a2e368f0be8"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 172.463213,
-   "end_time": "2026-09-02T02:01:57.102250+00:00",
+   "duration": 183.27464,
+   "end_time": "2026-09-04T03:31:02.099706+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/16_risk_management.ipynb",
-   "output_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/.16_risk_management.papermill.2558753.ipynb",
+   "input_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/16_risk_management.ipynb",
+   "output_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/.16_risk_management.papermill.195209.ipynb",
    "parameters": {},
-   "start_time": "2026-09-02T01:59:04.639037+00:00",
+   "start_time": "2026-09-04T03:27:58.825066+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/16_risk_management.py
+++ b/case_studies/sp500_equity_option_analytics/16_risk_management.py
@@ -700,26 +700,30 @@ fig_tradeoff.show()
 # on every label - so the second label's run could not publish at all.
 
 # %%
-# A candidate set is immutable under its name, so a field that has grown has to name the
-# generation it replaces. Keyed by the full set name because that is what the refusal prints.
+# A candidate set is immutable under its name, so a field whose membership has moved has to name
+# the generation it replaces. Keyed by the full set name because that is what the refusal prints.
 # Resolved through `candidate_set_supersedes` rather than passed straight to `create`: a
 # reader's clean clone has no generation to supersede, and `create` refuses a first version that
-# claims to replace one. Two generations precede this one and both stay readable by hash, which
-# is what keeps a holdout registered against either traceable to the field it actually saw:
-# `328d2009685c` is the single-label field frozen on 2026-08-30, before the four variant labels
-# had baseline, allocation or overlay rows; `aa6b3986124b` replaced it on 2026-09-01 under a
-# per-stage count of advancing configurations, which admitted a label whose sweep had produced
-# one row per configuration and stopped; `04cb35eec43f` replaced that one later the same day and
-# held 3,710 members, 66 of them allocation backtests from a grid no current sweep plan declares.
-# `37169a5be187` replaced it with the declared grids only and holds 3,644, and `774c32c6e79b`
-# replaced that. Every one of those five was frozen over a field that was still being produced:
-# the allocation and risk plans behind them were all written at 21:40 UTC on 2026-09-01, while
-# the baseline sweeps that feed them published at 22:34-22:46 and three of the baselines they
-# rank were registered at 22:42. This generation is the first frozen over sweeps that ran in
-# stage order and recorded that they finished. Only the tip is declarable - `create` refuses
-# anything else and names the tip - so this value moves on every generation.
+# claims to replace one. Five generations precede this one and all five stay readable by hash,
+# which is what keeps a holdout registered against any of them traceable to the field it saw:
+# `328d2009685c` is the single-label field frozen on 2026-08-30 with 1,097 members, before the
+# four variant labels had baseline, allocation or overlay rows; `aa6b3986124b` replaced it on
+# 2026-09-01 with 3,680 under a per-stage count of advancing configurations, which admitted a
+# label whose sweep had produced one row per configuration and stopped; `04cb35eec43f` replaced
+# that one later the same day and held 3,710, 66 of them allocation backtests from a grid no
+# current sweep plan declares; `37169a5be187` replaced it with the declared grids only and held
+# 3,644; `774c32c6e79b` replaced that with 3,811. All five were frozen over a field that was
+# still being produced: the allocation and risk plans behind them were written at 21:40 UTC on
+# 2026-09-01, while the baseline sweeps that feed them published at 22:34-22:46 and three of the
+# baselines they rank were registered at 22:42. `57cb9eb3133c` is the tip, frozen 2026-09-02
+# over sweeps that ran in stage order and recorded that they finished. It holds 3,811 as well and
+# differs from `774c32c6e79b` in 54 members: the `fwd_ret_10d` allocation backtests registered at
+# 00:55 on 2026-09-01 gave way to the 54 the re-executed 15 registered at 00:30 on 2026-09-02, so
+# every member now rides an attestation that carries its own grid. Only the tip is declarable -
+# `create` refuses anything else and names the tip - so this value moves on every generation, and
+# it is wrong whenever it names a generation the registry has already superseded.
 SUPERSEDES_CANDIDATE_SETS: dict[str, str] = {
-    "sp500_equity_option_analytics:holdout-candidates": "774c32c6e79b",
+    "sp500_equity_option_analytics:holdout-candidates": "57cb9eb3133c",
 }
 
 # %% [markdown]

--- a/case_studies/sp500_equity_option_analytics/17_costs.ipynb
+++ b/case_studies/sp500_equity_option_analytics/17_costs.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5345ed72",
+   "id": "a512a0f4",
    "metadata": {
     "papermill": {
-     "duration": 0.002994,
-     "end_time": "2026-09-01T23:39:06.733476+00:00",
+     "duration": 0.001969,
+     "end_time": "2026-09-04T03:31:14.283336+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:39:06.730482+00:00",
+     "start_time": "2026-09-04T03:31:14.281367+00:00",
      "status": "completed"
     }
    },
@@ -39,19 +39,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "892eabb3",
+   "id": "bd4860e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:39:06.738022Z",
-     "iopub.status.busy": "2026-09-01T23:39:06.737874Z",
-     "iopub.status.idle": "2026-09-01T23:39:09.883391Z",
-     "shell.execute_reply": "2026-09-01T23:39:09.882682Z"
+     "iopub.execute_input": "2026-09-04T03:31:14.288565Z",
+     "iopub.status.busy": "2026-09-04T03:31:14.288341Z",
+     "iopub.status.idle": "2026-09-04T03:31:17.725353Z",
+     "shell.execute_reply": "2026-09-04T03:31:17.723127Z"
     },
     "papermill": {
-     "duration": 3.150071,
-     "end_time": "2026-09-01T23:39:09.885905+00:00",
+     "duration": 3.440808,
+     "end_time": "2026-09-04T03:31:17.726170+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:39:06.735834+00:00",
+     "start_time": "2026-09-04T03:31:14.285362+00:00",
      "status": "completed"
     }
    },
@@ -103,19 +103,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "b984a5d6",
+   "id": "ce6552b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:39:09.890586Z",
-     "iopub.status.busy": "2026-09-01T23:39:09.890426Z",
-     "iopub.status.idle": "2026-09-01T23:39:09.892845Z",
-     "shell.execute_reply": "2026-09-01T23:39:09.892366Z"
+     "iopub.execute_input": "2026-09-04T03:31:17.731341Z",
+     "iopub.status.busy": "2026-09-04T03:31:17.731078Z",
+     "iopub.status.idle": "2026-09-04T03:31:17.734215Z",
+     "shell.execute_reply": "2026-09-04T03:31:17.733617Z"
     },
     "papermill": {
-     "duration": 0.005294,
-     "end_time": "2026-09-01T23:39:09.893339+00:00",
+     "duration": 0.006096,
+     "end_time": "2026-09-04T03:31:17.734925+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:39:09.888045+00:00",
+     "start_time": "2026-09-04T03:31:17.728829+00:00",
      "status": "completed"
     },
     "tags": [
@@ -132,13 +132,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccc4b2f7",
+   "id": "b7b33b76",
    "metadata": {
     "papermill": {
-     "duration": 0.000969,
-     "end_time": "2026-09-01T23:39:09.895510+00:00",
+     "duration": 0.00232,
+     "end_time": "2026-09-04T03:31:17.739946+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:39:09.894541+00:00",
+     "start_time": "2026-09-04T03:31:17.737626+00:00",
      "status": "completed"
     }
    },
@@ -153,19 +153,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "2fd95825",
+   "id": "7ccdd54b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:39:09.898203Z",
-     "iopub.status.busy": "2026-09-01T23:39:09.898115Z",
-     "iopub.status.idle": "2026-09-01T23:39:09.989095Z",
-     "shell.execute_reply": "2026-09-01T23:39:09.988575Z"
+     "iopub.execute_input": "2026-09-04T03:31:17.746042Z",
+     "iopub.status.busy": "2026-09-04T03:31:17.745851Z",
+     "iopub.status.idle": "2026-09-04T03:31:17.863354Z",
+     "shell.execute_reply": "2026-09-04T03:31:17.862877Z"
     },
     "papermill": {
-     "duration": 0.092883,
-     "end_time": "2026-09-01T23:39:09.989484+00:00",
+     "duration": 0.121251,
+     "end_time": "2026-09-04T03:31:17.863899+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:39:09.896601+00:00",
+     "start_time": "2026-09-04T03:31:17.742648+00:00",
      "status": "completed"
     }
    },
@@ -219,13 +219,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3215f55",
+   "id": "0141d327",
    "metadata": {
     "papermill": {
-     "duration": 0.001637,
-     "end_time": "2026-09-01T23:39:09.993007+00:00",
+     "duration": 0.001207,
+     "end_time": "2026-09-04T03:31:17.867192+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:39:09.991370+00:00",
+     "start_time": "2026-09-04T03:31:17.865985+00:00",
      "status": "completed"
     }
    },
@@ -254,19 +254,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b9b66daa",
+   "id": "43f8d721",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:39:09.997028Z",
-     "iopub.status.busy": "2026-09-01T23:39:09.996784Z",
-     "iopub.status.idle": "2026-09-01T23:40:27.862528Z",
-     "shell.execute_reply": "2026-09-01T23:40:27.862203Z"
+     "iopub.execute_input": "2026-09-04T03:31:17.870591Z",
+     "iopub.status.busy": "2026-09-04T03:31:17.870477Z",
+     "iopub.status.idle": "2026-09-04T03:32:30.149962Z",
+     "shell.execute_reply": "2026-09-04T03:32:30.147106Z"
     },
     "papermill": {
-     "duration": 77.872013,
-     "end_time": "2026-09-01T23:40:27.866622+00:00",
+     "duration": 72.28585,
+     "end_time": "2026-09-04T03:32:30.154355+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:39:09.994609+00:00",
+     "start_time": "2026-09-04T03:31:17.868505+00:00",
      "status": "completed"
     }
    },
@@ -276,8 +276,8 @@
      "output_type": "stream",
      "text": [
       "Label carried by the selection: fwd_ret_risk_adj_5d\n",
-      "Selection read from the frozen candidate set 774c32c6e79b (3811 members)\n",
-      "frozen candidate set 774c32c6e79b with 3811 members selects latent_factors/sae with score_weighted allocation, top-10, risk overlay trailing_2pct, validation Sharpe 2.691\n"
+      "Selection read from the frozen candidate set 57cb9eb3133c (3811 members)\n",
+      "frozen candidate set 57cb9eb3133c with 3811 members selects latent_factors/sae with score_weighted allocation, top-10, risk overlay trailing_2pct, validation Sharpe 2.691\n"
      ]
     }
    ],
@@ -369,13 +369,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "172db136",
+   "id": "f4ba1c53",
    "metadata": {
     "papermill": {
-     "duration": 0.001178,
-     "end_time": "2026-09-01T23:40:27.869616+00:00",
+     "duration": 0.006426,
+     "end_time": "2026-09-04T03:32:30.169884+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:27.868438+00:00",
+     "start_time": "2026-09-04T03:32:30.163458+00:00",
      "status": "completed"
     }
    },
@@ -389,19 +389,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "01e9ff6a",
+   "id": "6f67600d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:27.873236Z",
-     "iopub.status.busy": "2026-09-01T23:40:27.873028Z",
-     "iopub.status.idle": "2026-09-01T23:40:28.972397Z",
-     "shell.execute_reply": "2026-09-01T23:40:28.971818Z"
+     "iopub.execute_input": "2026-09-04T03:32:30.194198Z",
+     "iopub.status.busy": "2026-09-04T03:32:30.193939Z",
+     "iopub.status.idle": "2026-09-04T03:32:33.722808Z",
+     "shell.execute_reply": "2026-09-04T03:32:33.722187Z"
     },
     "papermill": {
-     "duration": 1.102219,
-     "end_time": "2026-09-01T23:40:28.973040+00:00",
+     "duration": 3.550297,
+     "end_time": "2026-09-04T03:32:33.726229+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:27.870821+00:00",
+     "start_time": "2026-09-04T03:32:30.175932+00:00",
      "status": "completed"
     }
    },
@@ -429,13 +429,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02c6e540",
+   "id": "d72ff418",
    "metadata": {
     "papermill": {
-     "duration": 0.001559,
-     "end_time": "2026-09-01T23:40:28.976985+00:00",
+     "duration": 0.005578,
+     "end_time": "2026-09-04T03:32:33.734676+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:28.975426+00:00",
+     "start_time": "2026-09-04T03:32:33.729098+00:00",
      "status": "completed"
     }
    },
@@ -452,19 +452,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "ce88d94b",
+   "id": "f1639144",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:28.979764Z",
-     "iopub.status.busy": "2026-09-01T23:40:28.979664Z",
-     "iopub.status.idle": "2026-09-01T23:40:28.982319Z",
-     "shell.execute_reply": "2026-09-01T23:40:28.981901Z"
+     "iopub.execute_input": "2026-09-04T03:32:33.750876Z",
+     "iopub.status.busy": "2026-09-04T03:32:33.750705Z",
+     "iopub.status.idle": "2026-09-04T03:32:33.754242Z",
+     "shell.execute_reply": "2026-09-04T03:32:33.753713Z"
     },
     "papermill": {
-     "duration": 0.0045,
-     "end_time": "2026-09-01T23:40:28.982594+00:00",
+     "duration": 0.013806,
+     "end_time": "2026-09-04T03:32:33.755355+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:28.978094+00:00",
+     "start_time": "2026-09-04T03:32:33.741549+00:00",
      "status": "completed"
     }
    },
@@ -486,13 +486,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e0ec460",
+   "id": "3aaca421",
    "metadata": {
     "papermill": {
-     "duration": 0.001031,
-     "end_time": "2026-09-01T23:40:28.984758+00:00",
+     "duration": 0.005814,
+     "end_time": "2026-09-04T03:32:33.767335+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:28.983727+00:00",
+     "start_time": "2026-09-04T03:32:33.761521+00:00",
      "status": "completed"
     }
    },
@@ -504,19 +504,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "792fce46",
+   "id": "9d571c2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:28.987371Z",
-     "iopub.status.busy": "2026-09-01T23:40:28.987290Z",
-     "iopub.status.idle": "2026-09-01T23:40:28.993347Z",
-     "shell.execute_reply": "2026-09-01T23:40:28.992922Z"
+     "iopub.execute_input": "2026-09-04T03:32:33.779008Z",
+     "iopub.status.busy": "2026-09-04T03:32:33.778841Z",
+     "iopub.status.idle": "2026-09-04T03:32:33.799413Z",
+     "shell.execute_reply": "2026-09-04T03:32:33.799015Z"
     },
     "papermill": {
-     "duration": 0.007728,
-     "end_time": "2026-09-01T23:40:28.993589+00:00",
+     "duration": 0.030314,
+     "end_time": "2026-09-04T03:32:33.800309+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:28.985861+00:00",
+     "start_time": "2026-09-04T03:32:33.769995+00:00",
      "status": "completed"
     }
    },
@@ -546,13 +546,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08430485",
+   "id": "35db1082",
    "metadata": {
     "papermill": {
-     "duration": 0.001599,
-     "end_time": "2026-09-01T23:40:28.996631+00:00",
+     "duration": 0.005219,
+     "end_time": "2026-09-04T03:32:33.807897+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:28.995032+00:00",
+     "start_time": "2026-09-04T03:32:33.802678+00:00",
      "status": "completed"
     }
    },
@@ -564,19 +564,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "2f5f5498",
+   "id": "b9d30f28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:29.000145Z",
-     "iopub.status.busy": "2026-09-01T23:40:28.999989Z",
-     "iopub.status.idle": "2026-09-01T23:40:29.006762Z",
-     "shell.execute_reply": "2026-09-01T23:40:29.006190Z"
+     "iopub.execute_input": "2026-09-04T03:32:33.818431Z",
+     "iopub.status.busy": "2026-09-04T03:32:33.818264Z",
+     "iopub.status.idle": "2026-09-04T03:32:33.828167Z",
+     "shell.execute_reply": "2026-09-04T03:32:33.827180Z"
     },
     "papermill": {
-     "duration": 0.009337,
-     "end_time": "2026-09-01T23:40:29.007323+00:00",
+     "duration": 0.015384,
+     "end_time": "2026-09-04T03:32:33.828635+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:28.997986+00:00",
+     "start_time": "2026-09-04T03:32:33.813251+00:00",
      "status": "completed"
     }
    },
@@ -605,13 +605,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8f09a3d",
+   "id": "7098ea5a",
    "metadata": {
     "papermill": {
-     "duration": 0.001233,
-     "end_time": "2026-09-01T23:40:29.010657+00:00",
+     "duration": 0.002189,
+     "end_time": "2026-09-04T03:32:33.833265+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.009424+00:00",
+     "start_time": "2026-09-04T03:32:33.831076+00:00",
      "status": "completed"
     }
    },
@@ -623,19 +623,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "588979db",
+   "id": "cc222f87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:29.014503Z",
-     "iopub.status.busy": "2026-09-01T23:40:29.014310Z",
-     "iopub.status.idle": "2026-09-01T23:40:29.020560Z",
-     "shell.execute_reply": "2026-09-01T23:40:29.020105Z"
+     "iopub.execute_input": "2026-09-04T03:32:33.838957Z",
+     "iopub.status.busy": "2026-09-04T03:32:33.838822Z",
+     "iopub.status.idle": "2026-09-04T03:32:33.847631Z",
+     "shell.execute_reply": "2026-09-04T03:32:33.846566Z"
     },
     "papermill": {
-     "duration": 0.009507,
-     "end_time": "2026-09-01T23:40:29.021495+00:00",
+     "duration": 0.012573,
+     "end_time": "2026-09-04T03:32:33.848131+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.011988+00:00",
+     "start_time": "2026-09-04T03:32:33.835558+00:00",
      "status": "completed"
     }
    },
@@ -658,13 +658,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29e52bc1",
+   "id": "690f0289",
    "metadata": {
     "papermill": {
-     "duration": 0.0022,
-     "end_time": "2026-09-01T23:40:29.027299+00:00",
+     "duration": 0.002336,
+     "end_time": "2026-09-04T03:32:33.853231+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.025099+00:00",
+     "start_time": "2026-09-04T03:32:33.850895+00:00",
      "status": "completed"
     }
    },
@@ -676,19 +676,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "5e98edf7",
+   "id": "a6216c92",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:29.032434Z",
-     "iopub.status.busy": "2026-09-01T23:40:29.032319Z",
-     "iopub.status.idle": "2026-09-01T23:40:29.034453Z",
-     "shell.execute_reply": "2026-09-01T23:40:29.034045Z"
+     "iopub.execute_input": "2026-09-04T03:32:33.859291Z",
+     "iopub.status.busy": "2026-09-04T03:32:33.858935Z",
+     "iopub.status.idle": "2026-09-04T03:32:33.862441Z",
+     "shell.execute_reply": "2026-09-04T03:32:33.861663Z"
     },
     "papermill": {
-     "duration": 0.005404,
-     "end_time": "2026-09-01T23:40:29.034918+00:00",
+     "duration": 0.007018,
+     "end_time": "2026-09-04T03:32:33.862826+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.029514+00:00",
+     "start_time": "2026-09-04T03:32:33.855808+00:00",
      "status": "completed"
     }
    },
@@ -702,19 +702,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "495bb09c",
+   "id": "e15e6497",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:29.041708Z",
-     "iopub.status.busy": "2026-09-01T23:40:29.041507Z",
-     "iopub.status.idle": "2026-09-01T23:40:29.045402Z",
-     "shell.execute_reply": "2026-09-01T23:40:29.044954Z"
+     "iopub.execute_input": "2026-09-04T03:32:33.868611Z",
+     "iopub.status.busy": "2026-09-04T03:32:33.868310Z",
+     "iopub.status.idle": "2026-09-04T03:32:33.872744Z",
+     "shell.execute_reply": "2026-09-04T03:32:33.871899Z"
     },
     "papermill": {
-     "duration": 0.007847,
-     "end_time": "2026-09-01T23:40:29.045968+00:00",
+     "duration": 0.00773,
+     "end_time": "2026-09-04T03:32:33.873157+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.038121+00:00",
+     "start_time": "2026-09-04T03:32:33.865427+00:00",
      "status": "completed"
     }
    },
@@ -751,19 +751,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "93e7407f",
+   "id": "4f396db1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:29.053487Z",
-     "iopub.status.busy": "2026-09-01T23:40:29.053218Z",
-     "iopub.status.idle": "2026-09-01T23:40:29.056746Z",
-     "shell.execute_reply": "2026-09-01T23:40:29.056163Z"
+     "iopub.execute_input": "2026-09-04T03:32:33.879284Z",
+     "iopub.status.busy": "2026-09-04T03:32:33.879129Z",
+     "iopub.status.idle": "2026-09-04T03:32:33.883518Z",
+     "shell.execute_reply": "2026-09-04T03:32:33.882622Z"
     },
     "papermill": {
-     "duration": 0.007802,
-     "end_time": "2026-09-01T23:40:29.057260+00:00",
+     "duration": 0.00814,
+     "end_time": "2026-09-04T03:32:33.883926+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.049458+00:00",
+     "start_time": "2026-09-04T03:32:33.875786+00:00",
      "status": "completed"
     }
    },
@@ -784,13 +784,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80159182",
+   "id": "cd61d477",
    "metadata": {
     "papermill": {
-     "duration": 0.002528,
-     "end_time": "2026-09-01T23:40:29.062480+00:00",
+     "duration": 0.002853,
+     "end_time": "2026-09-04T03:32:33.889520+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.059952+00:00",
+     "start_time": "2026-09-04T03:32:33.886667+00:00",
      "status": "completed"
     }
    },
@@ -805,19 +805,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "3fe9a082",
+   "id": "7aff174b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:29.069579Z",
-     "iopub.status.busy": "2026-09-01T23:40:29.069366Z",
-     "iopub.status.idle": "2026-09-01T23:40:29.196242Z",
-     "shell.execute_reply": "2026-09-01T23:40:29.195783Z"
+     "iopub.execute_input": "2026-09-04T03:32:33.897041Z",
+     "iopub.status.busy": "2026-09-04T03:32:33.896864Z",
+     "iopub.status.idle": "2026-09-04T03:32:34.065352Z",
+     "shell.execute_reply": "2026-09-04T03:32:34.064331Z"
     },
     "papermill": {
-     "duration": 0.130859,
-     "end_time": "2026-09-01T23:40:29.196924+00:00",
+     "duration": 0.172398,
+     "end_time": "2026-09-04T03:32:34.065862+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.066065+00:00",
+     "start_time": "2026-09-04T03:32:33.893464+00:00",
      "status": "completed"
     }
    },
@@ -853,19 +853,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "d071bcb7",
+   "id": "e6c7b341",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:29.200717Z",
-     "iopub.status.busy": "2026-09-01T23:40:29.200621Z",
-     "iopub.status.idle": "2026-09-01T23:40:29.204128Z",
-     "shell.execute_reply": "2026-09-01T23:40:29.203713Z"
+     "iopub.execute_input": "2026-09-04T03:32:34.076139Z",
+     "iopub.status.busy": "2026-09-04T03:32:34.075962Z",
+     "iopub.status.idle": "2026-09-04T03:32:34.100299Z",
+     "shell.execute_reply": "2026-09-04T03:32:34.099444Z"
     },
     "papermill": {
-     "duration": 0.006329,
-     "end_time": "2026-09-01T23:40:29.204881+00:00",
+     "duration": 0.03168,
+     "end_time": "2026-09-04T03:32:34.100778+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.198552+00:00",
+     "start_time": "2026-09-04T03:32:34.069098+00:00",
      "status": "completed"
     }
    },
@@ -889,13 +889,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb614c33",
+   "id": "ed974340",
    "metadata": {
     "papermill": {
-     "duration": 0.002375,
-     "end_time": "2026-09-01T23:40:29.210277+00:00",
+     "duration": 0.002267,
+     "end_time": "2026-09-04T03:32:34.105817+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.207902+00:00",
+     "start_time": "2026-09-04T03:32:34.103550+00:00",
      "status": "completed"
     }
    },
@@ -913,19 +913,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "9cc504c9",
+   "id": "b3e172b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:29.219390Z",
-     "iopub.status.busy": "2026-09-01T23:40:29.218323Z",
-     "iopub.status.idle": "2026-09-01T23:40:29.428480Z",
-     "shell.execute_reply": "2026-09-01T23:40:29.428055Z"
+     "iopub.execute_input": "2026-09-04T03:32:34.111875Z",
+     "iopub.status.busy": "2026-09-04T03:32:34.111543Z",
+     "iopub.status.idle": "2026-09-04T03:32:34.919314Z",
+     "shell.execute_reply": "2026-09-04T03:32:34.918631Z"
     },
     "papermill": {
-     "duration": 0.215576,
-     "end_time": "2026-09-01T23:40:29.429703+00:00",
+     "duration": 0.811742,
+     "end_time": "2026-09-04T03:32:34.919959+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.214127+00:00",
+     "start_time": "2026-09-04T03:32:34.108217+00:00",
      "status": "completed"
     }
    },
@@ -1027,13 +1027,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c75feda",
+   "id": "352ee65a",
    "metadata": {
     "papermill": {
-     "duration": 0.003184,
-     "end_time": "2026-09-01T23:40:29.437916+00:00",
+     "duration": 0.011819,
+     "end_time": "2026-09-04T03:32:34.938976+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:29.434732+00:00",
+     "start_time": "2026-09-04T03:32:34.927157+00:00",
      "status": "completed"
     }
    },
@@ -1088,7 +1088,7 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-01T23:40:38.342736+00:00",
+   "executed_at": "2026-09-04T03:32:57.619968+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
@@ -1096,14 +1096,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 86.242611,
-   "end_time": "2026-09-01T23:40:32.159128+00:00",
+   "duration": 85.392233,
+   "end_time": "2026-09-04T03:32:38.561865+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/17_costs.ipynb",
-   "output_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/.17_costs.papermill.1488380.ipynb",
+   "input_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/17_costs.ipynb",
+   "output_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/.17_costs.papermill.211487.ipynb",
    "parameters": {},
-   "start_time": "2026-09-01T23:39:05.916517+00:00",
+   "start_time": "2026-09-04T03:31:13.169632+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/18_holdout_predictions.ipynb
+++ b/case_studies/sp500_equity_option_analytics/18_holdout_predictions.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "60480a08",
+   "id": "12180826",
    "metadata": {
     "papermill": {
-     "duration": 0.003034,
-     "end_time": "2026-09-01T23:40:41.930924+00:00",
+     "duration": 0.004879,
+     "end_time": "2026-09-04T03:33:04.565308+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:41.927890+00:00",
+     "start_time": "2026-09-04T03:33:04.560429+00:00",
      "status": "completed"
     }
    },
@@ -41,13 +41,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48f46f1b",
+   "id": "4b7b5ea5",
    "metadata": {
     "papermill": {
-     "duration": 0.003889,
-     "end_time": "2026-09-01T23:40:41.938530+00:00",
+     "duration": 0.00243,
+     "end_time": "2026-09-04T03:33:04.571937+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:41.934641+00:00",
+     "start_time": "2026-09-04T03:33:04.569507+00:00",
      "status": "completed"
     }
    },
@@ -79,19 +79,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "879714c6",
+   "id": "556733fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:41.943052Z",
-     "iopub.status.busy": "2026-09-01T23:40:41.942846Z",
-     "iopub.status.idle": "2026-09-01T23:40:44.751859Z",
-     "shell.execute_reply": "2026-09-01T23:40:44.751058Z"
+     "iopub.execute_input": "2026-09-04T03:33:04.581702Z",
+     "iopub.status.busy": "2026-09-04T03:33:04.581499Z",
+     "iopub.status.idle": "2026-09-04T03:33:08.401479Z",
+     "shell.execute_reply": "2026-09-04T03:33:08.398396Z"
     },
     "papermill": {
-     "duration": 2.81199,
-     "end_time": "2026-09-01T23:40:44.752355+00:00",
+     "duration": 3.828383,
+     "end_time": "2026-09-04T03:33:08.402305+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:41.940365+00:00",
+     "start_time": "2026-09-04T03:33:04.573922+00:00",
      "status": "completed"
     }
    },
@@ -124,19 +124,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a5764bd9",
+   "id": "1a7c4306",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:44.755657Z",
-     "iopub.status.busy": "2026-09-01T23:40:44.755550Z",
-     "iopub.status.idle": "2026-09-01T23:40:44.758321Z",
-     "shell.execute_reply": "2026-09-01T23:40:44.757537Z"
+     "iopub.execute_input": "2026-09-04T03:33:08.407819Z",
+     "iopub.status.busy": "2026-09-04T03:33:08.407618Z",
+     "iopub.status.idle": "2026-09-04T03:33:08.411723Z",
+     "shell.execute_reply": "2026-09-04T03:33:08.410859Z"
     },
     "papermill": {
-     "duration": 0.005067,
-     "end_time": "2026-09-01T23:40:44.758811+00:00",
+     "duration": 0.007517,
+     "end_time": "2026-09-04T03:33:08.412197+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:44.753744+00:00",
+     "start_time": "2026-09-04T03:33:08.404680+00:00",
      "status": "completed"
     },
     "tags": [
@@ -153,13 +153,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf6f9577",
+   "id": "56af999f",
    "metadata": {
     "papermill": {
-     "duration": 0.001114,
-     "end_time": "2026-09-01T23:40:44.761610+00:00",
+     "duration": 0.001963,
+     "end_time": "2026-09-04T03:33:08.416549+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:44.760496+00:00",
+     "start_time": "2026-09-04T03:33:08.414586+00:00",
      "status": "completed"
     }
    },
@@ -183,20 +183,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "7f48c7a3",
+   "id": "ab230c98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:44.765165Z",
-     "iopub.status.busy": "2026-09-01T23:40:44.764923Z",
-     "iopub.status.idle": "2026-09-01T23:40:44.832909Z",
-     "shell.execute_reply": "2026-09-01T23:40:44.832290Z"
+     "iopub.execute_input": "2026-09-04T03:33:08.422329Z",
+     "iopub.status.busy": "2026-09-04T03:33:08.421573Z",
+     "iopub.status.idle": "2026-09-04T03:33:08.522863Z",
+     "shell.execute_reply": "2026-09-04T03:33:08.522077Z"
     },
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.070492,
-     "end_time": "2026-09-01T23:40:44.833258+00:00",
+     "duration": 0.105336,
+     "end_time": "2026-09-04T03:33:08.523895+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:44.762766+00:00",
+     "start_time": "2026-09-04T03:33:08.418559+00:00",
      "status": "completed"
     }
    },
@@ -206,7 +206,7 @@
      "output_type": "stream",
      "text": [
       "Case study: sp500_equity_option_analytics\n",
-      "Registry: ~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/run_log/registry.db\n"
+      "Registry: ~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/run_log/registry.db\n"
      ]
     }
    ],
@@ -231,13 +231,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7edf95b4",
+   "id": "553fc4f5",
    "metadata": {
     "papermill": {
-     "duration": 0.001098,
-     "end_time": "2026-09-01T23:40:44.835784+00:00",
+     "duration": 0.002457,
+     "end_time": "2026-09-04T03:33:08.529870+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:44.834686+00:00",
+     "start_time": "2026-09-04T03:33:08.527413+00:00",
      "status": "completed"
     }
    },
@@ -260,19 +260,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9a8c5e30",
+   "id": "5b63ad3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:40:44.838712Z",
-     "iopub.status.busy": "2026-09-01T23:40:44.838560Z",
-     "iopub.status.idle": "2026-09-01T23:41:49.895260Z",
-     "shell.execute_reply": "2026-09-01T23:41:49.894755Z"
+     "iopub.execute_input": "2026-09-04T03:33:08.539095Z",
+     "iopub.status.busy": "2026-09-04T03:33:08.537779Z",
+     "iopub.status.idle": "2026-09-04T03:34:19.751081Z",
+     "shell.execute_reply": "2026-09-04T03:34:19.750404Z"
     },
     "papermill": {
-     "duration": 65.059365,
-     "end_time": "2026-09-01T23:41:49.896195+00:00",
+     "duration": 71.219145,
+     "end_time": "2026-09-04T03:34:19.752152+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:40:44.836830+00:00",
+     "start_time": "2026-09-04T03:33:08.533007+00:00",
      "status": "completed"
     }
    },
@@ -282,8 +282,8 @@
      "output_type": "stream",
      "text": [
       "Label carried by the selection: fwd_ret_risk_adj_5d\n",
-      "Selection read from the frozen candidate set 774c32c6e79b (3811 members)\n",
-      "frozen candidate set 774c32c6e79b with 3811 members selects latent_factors/sae with score_weighted allocation, top-10, risk overlay trailing_2pct\n"
+      "Selection read from the frozen candidate set 57cb9eb3133c (3811 members)\n",
+      "frozen candidate set 57cb9eb3133c with 3811 members selects latent_factors/sae with score_weighted allocation, top-10, risk overlay trailing_2pct\n"
      ]
     }
    ],
@@ -359,14 +359,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2627be82",
+   "id": "707f9547",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.000967,
-     "end_time": "2026-09-01T23:41:49.898625+00:00",
+     "duration": 0.001058,
+     "end_time": "2026-09-04T03:34:19.754489+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:49.897658+00:00",
+     "start_time": "2026-09-04T03:34:19.753431+00:00",
      "status": "completed"
     }
    },
@@ -383,19 +383,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "bde47fa8",
+   "id": "9d58f60b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:41:49.901355Z",
-     "iopub.status.busy": "2026-09-01T23:41:49.901252Z",
-     "iopub.status.idle": "2026-09-01T23:41:50.008939Z",
-     "shell.execute_reply": "2026-09-01T23:41:50.008431Z"
+     "iopub.execute_input": "2026-09-04T03:34:19.757601Z",
+     "iopub.status.busy": "2026-09-04T03:34:19.757466Z",
+     "iopub.status.idle": "2026-09-04T03:34:19.979104Z",
+     "shell.execute_reply": "2026-09-04T03:34:19.978399Z"
     },
     "papermill": {
-     "duration": 0.109809,
-     "end_time": "2026-09-01T23:41:50.009414+00:00",
+     "duration": 0.223914,
+     "end_time": "2026-09-04T03:34:19.979520+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:49.899605+00:00",
+     "start_time": "2026-09-04T03:34:19.755606+00:00",
      "status": "completed"
     }
    },
@@ -449,19 +449,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "7d2e9fa4",
+   "id": "763fd4a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:41:50.015385Z",
-     "iopub.status.busy": "2026-09-01T23:41:50.015178Z",
-     "iopub.status.idle": "2026-09-01T23:41:50.020959Z",
-     "shell.execute_reply": "2026-09-01T23:41:50.020542Z"
+     "iopub.execute_input": "2026-09-04T03:34:19.983176Z",
+     "iopub.status.busy": "2026-09-04T03:34:19.983006Z",
+     "iopub.status.idle": "2026-09-04T03:34:19.988400Z",
+     "shell.execute_reply": "2026-09-04T03:34:19.988010Z"
     },
     "papermill": {
-     "duration": 0.009631,
-     "end_time": "2026-09-01T23:41:50.021564+00:00",
+     "duration": 0.007932,
+     "end_time": "2026-09-04T03:34:19.988970+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:50.011933+00:00",
+     "start_time": "2026-09-04T03:34:19.981038+00:00",
      "status": "completed"
     }
    },
@@ -476,7 +476,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (9, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>field</th><th>value</th></tr><tr><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;candidate set&quot;</td><td>&quot;frozen candidate set 774c32c6e…</td></tr><tr><td>&quot;candidate count&quot;</td><td>&quot;3811&quot;</td></tr><tr><td>&quot;selected validation backtest&quot;</td><td>&quot;ec0cfd449843&quot;</td></tr><tr><td>&quot;family&quot;</td><td>&quot;latent_factors&quot;</td></tr><tr><td>&quot;configuration&quot;</td><td>&quot;sae&quot;</td></tr><tr><td>&quot;label&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td></tr><tr><td>&quot;validation training&quot;</td><td>&quot;9723af112f0b&quot;</td></tr><tr><td>&quot;validation prediction&quot;</td><td>&quot;5f57bc2dfb15&quot;</td></tr><tr><td>&quot;checkpoint&quot;</td><td>&quot;epoch=5&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (9, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>field</th><th>value</th></tr><tr><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;candidate set&quot;</td><td>&quot;frozen candidate set 57cb9eb31…</td></tr><tr><td>&quot;candidate count&quot;</td><td>&quot;3811&quot;</td></tr><tr><td>&quot;selected validation backtest&quot;</td><td>&quot;ec0cfd449843&quot;</td></tr><tr><td>&quot;family&quot;</td><td>&quot;latent_factors&quot;</td></tr><tr><td>&quot;configuration&quot;</td><td>&quot;sae&quot;</td></tr><tr><td>&quot;label&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td></tr><tr><td>&quot;validation training&quot;</td><td>&quot;9723af112f0b&quot;</td></tr><tr><td>&quot;validation prediction&quot;</td><td>&quot;5f57bc2dfb15&quot;</td></tr><tr><td>&quot;checkpoint&quot;</td><td>&quot;epoch=5&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (9, 2)\n",
@@ -485,7 +485,7 @@
        "│ ---                          ┆ ---                             │\n",
        "│ str                          ┆ str                             │\n",
        "╞══════════════════════════════╪═════════════════════════════════╡\n",
-       "│ candidate set                ┆ frozen candidate set 774c32c6e… │\n",
+       "│ candidate set                ┆ frozen candidate set 57cb9eb31… │\n",
        "│ candidate count              ┆ 3811                            │\n",
        "│ selected validation backtest ┆ ec0cfd449843                    │\n",
        "│ family                       ┆ latent_factors                  │\n",
@@ -533,13 +533,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ebd2d63",
+   "id": "e70af79f",
    "metadata": {
     "papermill": {
-     "duration": 0.00247,
-     "end_time": "2026-09-01T23:41:50.026428+00:00",
+     "duration": 0.002159,
+     "end_time": "2026-09-04T03:34:19.993603+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:50.023958+00:00",
+     "start_time": "2026-09-04T03:34:19.991444+00:00",
      "status": "completed"
     }
    },
@@ -572,19 +572,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "5c1f4706",
+   "id": "1dd740cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:41:50.033695Z",
-     "iopub.status.busy": "2026-09-01T23:41:50.033525Z",
-     "iopub.status.idle": "2026-09-01T23:41:55.386186Z",
-     "shell.execute_reply": "2026-09-01T23:41:55.385634Z"
+     "iopub.execute_input": "2026-09-04T03:34:19.998941Z",
+     "iopub.status.busy": "2026-09-04T03:34:19.998830Z",
+     "iopub.status.idle": "2026-09-04T03:34:26.283498Z",
+     "shell.execute_reply": "2026-09-04T03:34:26.282807Z"
     },
     "papermill": {
-     "duration": 5.357182,
-     "end_time": "2026-09-01T23:41:55.387048+00:00",
+     "duration": 6.288058,
+     "end_time": "2026-09-04T03:34:26.283888+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:50.029866+00:00",
+     "start_time": "2026-09-04T03:34:19.995830+00:00",
      "status": "completed"
     }
    },
@@ -659,13 +659,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4645c179",
+   "id": "8da1d8dc",
    "metadata": {
     "papermill": {
-     "duration": 0.002978,
-     "end_time": "2026-09-01T23:41:55.392596+00:00",
+     "duration": 0.001572,
+     "end_time": "2026-09-04T03:34:26.287128+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:55.389618+00:00",
+     "start_time": "2026-09-04T03:34:26.285556+00:00",
      "status": "completed"
     }
    },
@@ -688,19 +688,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "35ee1805",
+   "id": "407680b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:41:55.398776Z",
-     "iopub.status.busy": "2026-09-01T23:41:55.398633Z",
-     "iopub.status.idle": "2026-09-01T23:41:55.402938Z",
-     "shell.execute_reply": "2026-09-01T23:41:55.402382Z"
+     "iopub.execute_input": "2026-09-04T03:34:26.291942Z",
+     "iopub.status.busy": "2026-09-04T03:34:26.291755Z",
+     "iopub.status.idle": "2026-09-04T03:34:26.297250Z",
+     "shell.execute_reply": "2026-09-04T03:34:26.296588Z"
     },
     "papermill": {
-     "duration": 0.007939,
-     "end_time": "2026-09-01T23:41:55.403354+00:00",
+     "duration": 0.00908,
+     "end_time": "2026-09-04T03:34:26.297634+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:55.395415+00:00",
+     "start_time": "2026-09-04T03:34:26.288554+00:00",
      "status": "completed"
     }
    },
@@ -741,13 +741,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9db4b60a",
+   "id": "2b0af455",
    "metadata": {
     "papermill": {
-     "duration": 0.001158,
-     "end_time": "2026-09-01T23:41:55.406179+00:00",
+     "duration": 0.00249,
+     "end_time": "2026-09-04T03:34:26.302463+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:55.405021+00:00",
+     "start_time": "2026-09-04T03:34:26.299973+00:00",
      "status": "completed"
     }
    },
@@ -798,19 +798,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "68dc8ff3",
+   "id": "9d0179a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:41:55.409654Z",
-     "iopub.status.busy": "2026-09-01T23:41:55.409481Z",
-     "iopub.status.idle": "2026-09-01T23:41:55.414341Z",
-     "shell.execute_reply": "2026-09-01T23:41:55.413788Z"
+     "iopub.execute_input": "2026-09-04T03:34:26.309151Z",
+     "iopub.status.busy": "2026-09-04T03:34:26.308949Z",
+     "iopub.status.idle": "2026-09-04T03:34:26.313993Z",
+     "shell.execute_reply": "2026-09-04T03:34:26.313341Z"
     },
     "papermill": {
-     "duration": 0.007711,
-     "end_time": "2026-09-01T23:41:55.415121+00:00",
+     "duration": 0.009511,
+     "end_time": "2026-09-04T03:34:26.314523+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:55.407410+00:00",
+     "start_time": "2026-09-04T03:34:26.305012+00:00",
      "status": "completed"
     }
    },
@@ -849,19 +849,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "5889b441",
+   "id": "f4fb4746",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:41:55.419560Z",
-     "iopub.status.busy": "2026-09-01T23:41:55.419419Z",
-     "iopub.status.idle": "2026-09-01T23:42:23.948438Z",
-     "shell.execute_reply": "2026-09-01T23:42:23.947983Z"
+     "iopub.execute_input": "2026-09-04T03:34:26.319252Z",
+     "iopub.status.busy": "2026-09-04T03:34:26.319136Z",
+     "iopub.status.idle": "2026-09-04T03:35:19.509686Z",
+     "shell.execute_reply": "2026-09-04T03:35:19.508910Z"
     },
     "papermill": {
-     "duration": 28.531768,
-     "end_time": "2026-09-01T23:42:23.948950+00:00",
+     "duration": 53.197119,
+     "end_time": "2026-09-04T03:35:19.514101+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:41:55.417182+00:00",
+     "start_time": "2026-09-04T03:34:26.316982+00:00",
      "status": "completed"
     }
    },
@@ -942,13 +942,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4a0274b",
+   "id": "54a2cb97",
    "metadata": {
     "papermill": {
-     "duration": 0.012246,
-     "end_time": "2026-09-01T23:42:23.964206+00:00",
+     "duration": 0.003526,
+     "end_time": "2026-09-04T03:35:19.521541+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:23.951960+00:00",
+     "start_time": "2026-09-04T03:35:19.518015+00:00",
      "status": "completed"
     }
    },
@@ -966,19 +966,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "54bd7c34",
+   "id": "d3e11ab2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:42:23.968806Z",
-     "iopub.status.busy": "2026-09-01T23:42:23.968677Z",
-     "iopub.status.idle": "2026-09-01T23:42:23.976813Z",
-     "shell.execute_reply": "2026-09-01T23:42:23.976495Z"
+     "iopub.execute_input": "2026-09-04T03:35:19.530619Z",
+     "iopub.status.busy": "2026-09-04T03:35:19.530330Z",
+     "iopub.status.idle": "2026-09-04T03:35:19.548240Z",
+     "shell.execute_reply": "2026-09-04T03:35:19.547350Z"
     },
     "papermill": {
-     "duration": 0.011031,
-     "end_time": "2026-09-01T23:42:23.977250+00:00",
+     "duration": 0.023525,
+     "end_time": "2026-09-04T03:35:19.549094+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:23.966219+00:00",
+     "start_time": "2026-09-04T03:35:19.525569+00:00",
      "status": "completed"
     }
    },
@@ -1022,13 +1022,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c8dc23f",
+   "id": "6f0a19e5",
    "metadata": {
     "papermill": {
-     "duration": 0.001258,
-     "end_time": "2026-09-01T23:42:23.980047+00:00",
+     "duration": 0.00377,
+     "end_time": "2026-09-04T03:35:19.557983+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:23.978789+00:00",
+     "start_time": "2026-09-04T03:35:19.554213+00:00",
      "status": "completed"
     }
    },
@@ -1044,19 +1044,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "3a75bf15",
+   "id": "a304cd71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:42:23.983318Z",
-     "iopub.status.busy": "2026-09-01T23:42:23.983200Z",
-     "iopub.status.idle": "2026-09-01T23:42:23.987944Z",
-     "shell.execute_reply": "2026-09-01T23:42:23.987473Z"
+     "iopub.execute_input": "2026-09-04T03:35:19.567328Z",
+     "iopub.status.busy": "2026-09-04T03:35:19.566872Z",
+     "iopub.status.idle": "2026-09-04T03:35:19.575967Z",
+     "shell.execute_reply": "2026-09-04T03:35:19.575205Z"
     },
     "papermill": {
-     "duration": 0.006952,
-     "end_time": "2026-09-01T23:42:23.988311+00:00",
+     "duration": 0.014615,
+     "end_time": "2026-09-04T03:35:19.576461+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:23.981359+00:00",
+     "start_time": "2026-09-04T03:35:19.561846+00:00",
      "status": "completed"
     }
    },
@@ -1126,13 +1126,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fafd9bf",
+   "id": "640f526d",
    "metadata": {
     "papermill": {
-     "duration": 0.001839,
-     "end_time": "2026-09-01T23:42:23.993679+00:00",
+     "duration": 0.002152,
+     "end_time": "2026-09-04T03:35:19.581157+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:23.991840+00:00",
+     "start_time": "2026-09-04T03:35:19.579005+00:00",
      "status": "completed"
     }
    },
@@ -1182,7 +1182,7 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-01T23:42:31.926103+00:00",
+   "executed_at": "2026-09-04T03:35:31.012165+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
@@ -1190,14 +1190,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 105.266148,
-   "end_time": "2026-09-01T23:42:26.352637+00:00",
+   "duration": 139.305948,
+   "end_time": "2026-09-04T03:35:22.927014+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/18_holdout_predictions.ipynb",
-   "output_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/.18_holdout_predictions.papermill.1493377.ipynb",
+   "input_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/18_holdout_predictions.ipynb",
+   "output_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/.18_holdout_predictions.papermill.222773.ipynb",
    "parameters": {},
-   "start_time": "2026-09-01T23:40:41.086489+00:00",
+   "start_time": "2026-09-04T03:33:03.621066+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/19_holdout_backtest.ipynb
+++ b/case_studies/sp500_equity_option_analytics/19_holdout_backtest.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d97b47cc",
+   "id": "c8842d51",
    "metadata": {
     "papermill": {
-     "duration": 0.001452,
-     "end_time": "2026-09-01T23:42:34.693552+00:00",
+     "duration": 0.002512,
+     "end_time": "2026-09-04T03:35:34.639042+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:34.692100+00:00",
+     "start_time": "2026-09-04T03:35:34.636530+00:00",
      "status": "completed"
     }
    },
@@ -44,19 +44,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "c0a34516",
+   "id": "170994a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:42:34.696781Z",
-     "iopub.status.busy": "2026-09-01T23:42:34.696669Z",
-     "iopub.status.idle": "2026-09-01T23:42:37.400351Z",
-     "shell.execute_reply": "2026-09-01T23:42:37.399260Z"
+     "iopub.execute_input": "2026-09-04T03:35:34.644289Z",
+     "iopub.status.busy": "2026-09-04T03:35:34.644126Z",
+     "iopub.status.idle": "2026-09-04T03:35:37.960782Z",
+     "shell.execute_reply": "2026-09-04T03:35:37.960147Z"
     },
     "papermill": {
-     "duration": 2.706063,
-     "end_time": "2026-09-01T23:42:37.400987+00:00",
+     "duration": 3.320511,
+     "end_time": "2026-09-04T03:35:37.961811+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:34.694924+00:00",
+     "start_time": "2026-09-04T03:35:34.641300+00:00",
      "status": "completed"
     }
    },
@@ -102,19 +102,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f2556578",
+   "id": "e34cb7dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:42:37.405819Z",
-     "iopub.status.busy": "2026-09-01T23:42:37.405654Z",
-     "iopub.status.idle": "2026-09-01T23:42:37.408092Z",
-     "shell.execute_reply": "2026-09-01T23:42:37.407522Z"
+     "iopub.execute_input": "2026-09-04T03:35:37.967720Z",
+     "iopub.status.busy": "2026-09-04T03:35:37.967465Z",
+     "iopub.status.idle": "2026-09-04T03:35:37.970362Z",
+     "shell.execute_reply": "2026-09-04T03:35:37.969720Z"
     },
     "papermill": {
-     "duration": 0.005917,
-     "end_time": "2026-09-01T23:42:37.408654+00:00",
+     "duration": 0.006658,
+     "end_time": "2026-09-04T03:35:37.970866+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:37.402737+00:00",
+     "start_time": "2026-09-04T03:35:37.964208+00:00",
      "status": "completed"
     },
     "tags": [
@@ -130,13 +130,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4499f803",
+   "id": "a231c4e5",
    "metadata": {
     "papermill": {
-     "duration": 0.00119,
-     "end_time": "2026-09-01T23:42:37.412090+00:00",
+     "duration": 0.001781,
+     "end_time": "2026-09-04T03:35:37.974790+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:37.410900+00:00",
+     "start_time": "2026-09-04T03:35:37.973009+00:00",
      "status": "completed"
     }
    },
@@ -151,19 +151,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "ea4f9876",
+   "id": "a57ec2ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:42:37.414949Z",
-     "iopub.status.busy": "2026-09-01T23:42:37.414755Z",
-     "iopub.status.idle": "2026-09-01T23:42:37.436903Z",
-     "shell.execute_reply": "2026-09-01T23:42:37.436393Z"
+     "iopub.execute_input": "2026-09-04T03:35:37.979607Z",
+     "iopub.status.busy": "2026-09-04T03:35:37.979428Z",
+     "iopub.status.idle": "2026-09-04T03:35:38.002317Z",
+     "shell.execute_reply": "2026-09-04T03:35:38.001697Z"
     },
     "papermill": {
-     "duration": 0.024243,
-     "end_time": "2026-09-01T23:42:37.437358+00:00",
+     "duration": 0.02615,
+     "end_time": "2026-09-04T03:35:38.002801+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:37.413115+00:00",
+     "start_time": "2026-09-04T03:35:37.976651+00:00",
      "status": "completed"
     }
    },
@@ -191,19 +191,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "6d25a06f",
+   "id": "adb3781e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:42:37.441486Z",
-     "iopub.status.busy": "2026-09-01T23:42:37.441365Z",
-     "iopub.status.idle": "2026-09-01T23:42:37.477750Z",
-     "shell.execute_reply": "2026-09-01T23:42:37.477346Z"
+     "iopub.execute_input": "2026-09-04T03:35:38.008083Z",
+     "iopub.status.busy": "2026-09-04T03:35:38.007875Z",
+     "iopub.status.idle": "2026-09-04T03:35:38.089233Z",
+     "shell.execute_reply": "2026-09-04T03:35:38.088709Z"
     },
     "papermill": {
-     "duration": 0.039256,
-     "end_time": "2026-09-01T23:42:37.478196+00:00",
+     "duration": 0.085222,
+     "end_time": "2026-09-04T03:35:38.090278+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:37.438940+00:00",
+     "start_time": "2026-09-04T03:35:38.005056+00:00",
      "status": "completed"
     }
    },
@@ -217,13 +217,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd652cdb",
+   "id": "bf54dda9",
    "metadata": {
     "papermill": {
-     "duration": 0.001325,
-     "end_time": "2026-09-01T23:42:37.480788+00:00",
+     "duration": 0.00147,
+     "end_time": "2026-09-04T03:35:38.094068+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:37.479463+00:00",
+     "start_time": "2026-09-04T03:35:38.092598+00:00",
      "status": "completed"
     }
    },
@@ -244,19 +244,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "56ad000e",
+   "id": "7c3efe54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:42:37.483810Z",
-     "iopub.status.busy": "2026-09-01T23:42:37.483670Z",
-     "iopub.status.idle": "2026-09-01T23:43:25.393503Z",
-     "shell.execute_reply": "2026-09-01T23:43:25.393033Z"
+     "iopub.execute_input": "2026-09-04T03:35:38.097255Z",
+     "iopub.status.busy": "2026-09-04T03:35:38.097069Z",
+     "iopub.status.idle": "2026-09-04T03:36:37.830851Z",
+     "shell.execute_reply": "2026-09-04T03:36:37.830256Z"
     },
     "papermill": {
-     "duration": 47.912913,
-     "end_time": "2026-09-01T23:43:25.394823+00:00",
+     "duration": 59.737459,
+     "end_time": "2026-09-04T03:36:37.832623+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:42:37.481910+00:00",
+     "start_time": "2026-09-04T03:35:38.095164+00:00",
      "status": "completed"
     }
    },
@@ -266,8 +266,8 @@
      "output_type": "stream",
      "text": [
       "Label carried by the selection: fwd_ret_risk_adj_5d\n",
-      "Selection read from the frozen candidate set 774c32c6e79b (3811 members)\n",
-      "frozen candidate set 774c32c6e79b with 3811 members selects latent_factors/sae with score_weighted allocation, top-10, risk overlay trailing_2pct\n"
+      "Selection read from the frozen candidate set 57cb9eb3133c (3811 members)\n",
+      "frozen candidate set 57cb9eb3133c with 3811 members selects latent_factors/sae with score_weighted allocation, top-10, risk overlay trailing_2pct\n"
      ]
     }
    ],
@@ -342,13 +342,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61d42200",
+   "id": "24de9b46",
    "metadata": {
     "papermill": {
-     "duration": 0.001044,
-     "end_time": "2026-09-01T23:43:25.397192+00:00",
+     "duration": 0.001684,
+     "end_time": "2026-09-04T03:36:37.836157+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:25.396148+00:00",
+     "start_time": "2026-09-04T03:36:37.834473+00:00",
      "status": "completed"
     }
    },
@@ -374,19 +374,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "49358d98",
+   "id": "ba6c90d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:25.399938Z",
-     "iopub.status.busy": "2026-09-01T23:43:25.399821Z",
-     "iopub.status.idle": "2026-09-01T23:43:25.402520Z",
-     "shell.execute_reply": "2026-09-01T23:43:25.402192Z"
+     "iopub.execute_input": "2026-09-04T03:36:37.840636Z",
+     "iopub.status.busy": "2026-09-04T03:36:37.840480Z",
+     "iopub.status.idle": "2026-09-04T03:36:37.843796Z",
+     "shell.execute_reply": "2026-09-04T03:36:37.843309Z"
     },
     "papermill": {
-     "duration": 0.004658,
-     "end_time": "2026-09-01T23:43:25.402947+00:00",
+     "duration": 0.006374,
+     "end_time": "2026-09-04T03:36:37.844296+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:25.398289+00:00",
+     "start_time": "2026-09-04T03:36:37.837922+00:00",
      "status": "completed"
     }
    },
@@ -416,19 +416,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3d1d66a1",
+   "id": "a42aaa9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:25.405908Z",
-     "iopub.status.busy": "2026-09-01T23:43:25.405743Z",
-     "iopub.status.idle": "2026-09-01T23:43:30.199754Z",
-     "shell.execute_reply": "2026-09-01T23:43:30.198217Z"
+     "iopub.execute_input": "2026-09-04T03:36:37.849046Z",
+     "iopub.status.busy": "2026-09-04T03:36:37.848922Z",
+     "iopub.status.idle": "2026-09-04T03:36:43.731757Z",
+     "shell.execute_reply": "2026-09-04T03:36:43.731183Z"
     },
     "papermill": {
-     "duration": 4.796522,
-     "end_time": "2026-09-01T23:43:30.200595+00:00",
+     "duration": 5.885862,
+     "end_time": "2026-09-04T03:36:43.732248+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:25.404073+00:00",
+     "start_time": "2026-09-04T03:36:37.846386+00:00",
      "status": "completed"
     }
    },
@@ -495,13 +495,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24c8af4b",
+   "id": "c41033de",
    "metadata": {
     "papermill": {
-     "duration": 0.001621,
-     "end_time": "2026-09-01T23:43:30.203831+00:00",
+     "duration": 0.002007,
+     "end_time": "2026-09-04T03:36:43.736578+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.202210+00:00",
+     "start_time": "2026-09-04T03:36:43.734571+00:00",
      "status": "completed"
     }
    },
@@ -515,19 +515,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "2f115a9b",
+   "id": "231159af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:30.207107Z",
-     "iopub.status.busy": "2026-09-01T23:43:30.206907Z",
-     "iopub.status.idle": "2026-09-01T23:43:30.213120Z",
-     "shell.execute_reply": "2026-09-01T23:43:30.212561Z"
+     "iopub.execute_input": "2026-09-04T03:36:43.741607Z",
+     "iopub.status.busy": "2026-09-04T03:36:43.741480Z",
+     "iopub.status.idle": "2026-09-04T03:36:43.747563Z",
+     "shell.execute_reply": "2026-09-04T03:36:43.746903Z"
     },
     "papermill": {
-     "duration": 0.008581,
-     "end_time": "2026-09-01T23:43:30.213519+00:00",
+     "duration": 0.009369,
+     "end_time": "2026-09-04T03:36:43.748080+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.204938+00:00",
+     "start_time": "2026-09-04T03:36:43.738711+00:00",
      "status": "completed"
     }
    },
@@ -596,13 +596,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d762861",
+   "id": "4c8a2e48",
    "metadata": {
     "papermill": {
-     "duration": 0.001302,
-     "end_time": "2026-09-01T23:43:30.216376+00:00",
+     "duration": 0.002195,
+     "end_time": "2026-09-04T03:36:43.752776+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.215074+00:00",
+     "start_time": "2026-09-04T03:36:43.750581+00:00",
      "status": "completed"
     }
    },
@@ -623,19 +623,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "a3aa9582",
+   "id": "1c447431",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:30.219988Z",
-     "iopub.status.busy": "2026-09-01T23:43:30.219812Z",
-     "iopub.status.idle": "2026-09-01T23:43:30.492214Z",
-     "shell.execute_reply": "2026-09-01T23:43:30.491672Z"
+     "iopub.execute_input": "2026-09-04T03:36:43.756941Z",
+     "iopub.status.busy": "2026-09-04T03:36:43.756819Z",
+     "iopub.status.idle": "2026-09-04T03:36:44.042276Z",
+     "shell.execute_reply": "2026-09-04T03:36:44.041793Z"
     },
     "papermill": {
-     "duration": 0.275691,
-     "end_time": "2026-09-01T23:43:30.493268+00:00",
+     "duration": 0.287979,
+     "end_time": "2026-09-04T03:36:44.042883+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.217577+00:00",
+     "start_time": "2026-09-04T03:36:43.754904+00:00",
      "status": "completed"
     }
    },
@@ -670,19 +670,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "7e4bef43",
+   "id": "1971ccc2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:30.500009Z",
-     "iopub.status.busy": "2026-09-01T23:43:30.499873Z",
-     "iopub.status.idle": "2026-09-01T23:43:30.504554Z",
-     "shell.execute_reply": "2026-09-01T23:43:30.504174Z"
+     "iopub.execute_input": "2026-09-04T03:36:44.049101Z",
+     "iopub.status.busy": "2026-09-04T03:36:44.048883Z",
+     "iopub.status.idle": "2026-09-04T03:36:44.054803Z",
+     "shell.execute_reply": "2026-09-04T03:36:44.054230Z"
     },
     "papermill": {
-     "duration": 0.007278,
-     "end_time": "2026-09-01T23:43:30.504759+00:00",
+     "duration": 0.00972,
+     "end_time": "2026-09-04T03:36:44.055229+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.497481+00:00",
+     "start_time": "2026-09-04T03:36:44.045509+00:00",
      "status": "completed"
     }
    },
@@ -756,19 +756,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "e11cea00",
+   "id": "f156fd55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:30.507865Z",
-     "iopub.status.busy": "2026-09-01T23:43:30.507778Z",
-     "iopub.status.idle": "2026-09-01T23:43:30.510915Z",
-     "shell.execute_reply": "2026-09-01T23:43:30.510633Z"
+     "iopub.execute_input": "2026-09-04T03:36:44.060025Z",
+     "iopub.status.busy": "2026-09-04T03:36:44.059906Z",
+     "iopub.status.idle": "2026-09-04T03:36:44.064355Z",
+     "shell.execute_reply": "2026-09-04T03:36:44.063722Z"
     },
     "papermill": {
-     "duration": 0.00522,
-     "end_time": "2026-09-01T23:43:30.511299+00:00",
+     "duration": 0.006962,
+     "end_time": "2026-09-04T03:36:44.064805+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.506079+00:00",
+     "start_time": "2026-09-04T03:36:44.057843+00:00",
      "status": "completed"
     }
    },
@@ -820,13 +820,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d1ea59e",
+   "id": "b7a6e95d",
    "metadata": {
     "papermill": {
-     "duration": 0.001201,
-     "end_time": "2026-09-01T23:43:30.513826+00:00",
+     "duration": 0.001317,
+     "end_time": "2026-09-04T03:36:44.067682+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.512625+00:00",
+     "start_time": "2026-09-04T03:36:44.066365+00:00",
      "status": "completed"
     }
    },
@@ -849,19 +849,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "57f0a5ab",
+   "id": "949bb66d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:30.516942Z",
-     "iopub.status.busy": "2026-09-01T23:43:30.516847Z",
-     "iopub.status.idle": "2026-09-01T23:43:30.715565Z",
-     "shell.execute_reply": "2026-09-01T23:43:30.714942Z"
+     "iopub.execute_input": "2026-09-04T03:36:44.071202Z",
+     "iopub.status.busy": "2026-09-04T03:36:44.071050Z",
+     "iopub.status.idle": "2026-09-04T03:36:44.277376Z",
+     "shell.execute_reply": "2026-09-04T03:36:44.276769Z"
     },
     "papermill": {
-     "duration": 0.200654,
-     "end_time": "2026-09-01T23:43:30.715807+00:00",
+     "duration": 0.208751,
+     "end_time": "2026-09-04T03:36:44.277724+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.515153+00:00",
+     "start_time": "2026-09-04T03:36:44.068973+00:00",
      "status": "completed"
     }
    },
@@ -937,13 +937,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bfd26e57",
+   "id": "4ccfbf3b",
    "metadata": {
     "papermill": {
-     "duration": 0.00124,
-     "end_time": "2026-09-01T23:43:30.718514+00:00",
+     "duration": 0.001306,
+     "end_time": "2026-09-04T03:36:44.280575+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.717274+00:00",
+     "start_time": "2026-09-04T03:36:44.279269+00:00",
      "status": "completed"
     }
    },
@@ -972,19 +972,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "4ee937b9",
+   "id": "1590b164",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:30.721541Z",
-     "iopub.status.busy": "2026-09-01T23:43:30.721449Z",
-     "iopub.status.idle": "2026-09-01T23:43:30.725127Z",
-     "shell.execute_reply": "2026-09-01T23:43:30.724689Z"
+     "iopub.execute_input": "2026-09-04T03:36:44.283915Z",
+     "iopub.status.busy": "2026-09-04T03:36:44.283786Z",
+     "iopub.status.idle": "2026-09-04T03:36:44.287679Z",
+     "shell.execute_reply": "2026-09-04T03:36:44.287302Z"
     },
     "papermill": {
-     "duration": 0.005691,
-     "end_time": "2026-09-01T23:43:30.725439+00:00",
+     "duration": 0.0062,
+     "end_time": "2026-09-04T03:36:44.288124+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.719748+00:00",
+     "start_time": "2026-09-04T03:36:44.281924+00:00",
      "status": "completed"
     }
    },
@@ -1027,13 +1027,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b56f859",
+   "id": "f5ec5ed6",
    "metadata": {
     "papermill": {
-     "duration": 0.001318,
-     "end_time": "2026-09-01T23:43:30.728304+00:00",
+     "duration": 0.0023,
+     "end_time": "2026-09-04T03:36:44.292938+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.726986+00:00",
+     "start_time": "2026-09-04T03:36:44.290638+00:00",
      "status": "completed"
     }
    },
@@ -1047,19 +1047,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "34b370c7",
+   "id": "89311709",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:30.731724Z",
-     "iopub.status.busy": "2026-09-01T23:43:30.731589Z",
-     "iopub.status.idle": "2026-09-01T23:43:30.934106Z",
-     "shell.execute_reply": "2026-09-01T23:43:30.933795Z"
+     "iopub.execute_input": "2026-09-04T03:36:44.298232Z",
+     "iopub.status.busy": "2026-09-04T03:36:44.298137Z",
+     "iopub.status.idle": "2026-09-04T03:36:44.517149Z",
+     "shell.execute_reply": "2026-09-04T03:36:44.516575Z"
     },
     "papermill": {
-     "duration": 0.20481,
-     "end_time": "2026-09-01T23:43:30.934448+00:00",
+     "duration": 0.222336,
+     "end_time": "2026-09-04T03:36:44.517704+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.729638+00:00",
+     "start_time": "2026-09-04T03:36:44.295368+00:00",
      "status": "completed"
     }
    },
@@ -1107,13 +1107,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62220824",
+   "id": "d9e77fd4",
    "metadata": {
     "papermill": {
-     "duration": 0.001613,
-     "end_time": "2026-09-01T23:43:30.937716+00:00",
+     "duration": 0.001577,
+     "end_time": "2026-09-04T03:36:44.521366+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:30.936103+00:00",
+     "start_time": "2026-09-04T03:36:44.519789+00:00",
      "status": "completed"
     }
    },
@@ -1166,7 +1166,7 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-01T23:43:39.741850+00:00",
+   "executed_at": "2026-09-04T03:36:53.151689+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
@@ -1174,14 +1174,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 60.174104,
-   "end_time": "2026-09-01T23:43:34.202769+00:00",
+   "duration": 73.168912,
+   "end_time": "2026-09-04T03:36:47.129662+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/19_holdout_backtest.ipynb",
-   "output_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/.19_holdout_backtest.papermill.1504788.ipynb",
+   "input_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/19_holdout_backtest.ipynb",
+   "output_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/.19_holdout_backtest.papermill.238578.ipynb",
    "parameters": {},
-   "start_time": "2026-09-01T23:42:34.028665+00:00",
+   "start_time": "2026-09-04T03:35:33.960750+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/20_strategy_analysis.ipynb
+++ b/case_studies/sp500_equity_option_analytics/20_strategy_analysis.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "49bc6cce",
+   "id": "3d95150d",
    "metadata": {
     "papermill": {
-     "duration": 0.002317,
-     "end_time": "2026-09-01T23:43:42.478749+00:00",
+     "duration": 0.004163,
+     "end_time": "2026-09-04T03:36:56.139418+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:42.476432+00:00",
+     "start_time": "2026-09-04T03:36:56.135255+00:00",
      "status": "completed"
     }
    },
@@ -47,19 +47,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "94997aea",
+   "id": "c2adc58c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:42.483158Z",
-     "iopub.status.busy": "2026-09-01T23:43:42.482976Z",
-     "iopub.status.idle": "2026-09-01T23:43:42.832978Z",
-     "shell.execute_reply": "2026-09-01T23:43:42.832372Z"
+     "iopub.execute_input": "2026-09-04T03:36:56.147063Z",
+     "iopub.status.busy": "2026-09-04T03:36:56.146934Z",
+     "iopub.status.idle": "2026-09-04T03:36:56.591315Z",
+     "shell.execute_reply": "2026-09-04T03:36:56.590551Z"
     },
     "papermill": {
-     "duration": 0.352852,
-     "end_time": "2026-09-01T23:43:42.833419+00:00",
+     "duration": 0.448892,
+     "end_time": "2026-09-04T03:36:56.591865+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:42.480567+00:00",
+     "start_time": "2026-09-04T03:36:56.142973+00:00",
      "status": "completed"
     }
    },
@@ -79,13 +79,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5942935",
+   "id": "fe609eca",
    "metadata": {
     "papermill": {
-     "duration": 0.001608,
-     "end_time": "2026-09-01T23:43:42.836947+00:00",
+     "duration": 0.001794,
+     "end_time": "2026-09-04T03:36:56.596179+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:42.835339+00:00",
+     "start_time": "2026-09-04T03:36:56.594385+00:00",
      "status": "completed"
     }
    },
@@ -97,19 +97,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "3c6171d7",
+   "id": "8bf3f5d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:42.841021Z",
-     "iopub.status.busy": "2026-09-01T23:43:42.840824Z",
-     "iopub.status.idle": "2026-09-01T23:43:45.197416Z",
-     "shell.execute_reply": "2026-09-01T23:43:45.197019Z"
+     "iopub.execute_input": "2026-09-04T03:36:56.601150Z",
+     "iopub.status.busy": "2026-09-04T03:36:56.600946Z",
+     "iopub.status.idle": "2026-09-04T03:36:59.312841Z",
+     "shell.execute_reply": "2026-09-04T03:36:59.312236Z"
     },
     "papermill": {
-     "duration": 2.359717,
-     "end_time": "2026-09-01T23:43:45.198314+00:00",
+     "duration": 2.715455,
+     "end_time": "2026-09-04T03:36:59.313707+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:42.838597+00:00",
+     "start_time": "2026-09-04T03:36:56.598252+00:00",
      "status": "completed"
     }
    },
@@ -153,19 +153,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "16b4106a",
+   "id": "ca6531ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:45.204270Z",
-     "iopub.status.busy": "2026-09-01T23:43:45.204126Z",
-     "iopub.status.idle": "2026-09-01T23:43:45.206097Z",
-     "shell.execute_reply": "2026-09-01T23:43:45.205647Z"
+     "iopub.execute_input": "2026-09-04T03:36:59.320370Z",
+     "iopub.status.busy": "2026-09-04T03:36:59.320225Z",
+     "iopub.status.idle": "2026-09-04T03:36:59.322089Z",
+     "shell.execute_reply": "2026-09-04T03:36:59.321739Z"
     },
     "papermill": {
-     "duration": 0.00611,
-     "end_time": "2026-09-01T23:43:45.206385+00:00",
+     "duration": 0.005335,
+     "end_time": "2026-09-04T03:36:59.322630+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:45.200275+00:00",
+     "start_time": "2026-09-04T03:36:59.317295+00:00",
      "status": "completed"
     },
     "tags": [
@@ -181,19 +181,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "5a1fd7fc",
+   "id": "3bd44892",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:45.211156Z",
-     "iopub.status.busy": "2026-09-01T23:43:45.211064Z",
-     "iopub.status.idle": "2026-09-01T23:43:45.271570Z",
-     "shell.execute_reply": "2026-09-01T23:43:45.271174Z"
+     "iopub.execute_input": "2026-09-04T03:36:59.330640Z",
+     "iopub.status.busy": "2026-09-04T03:36:59.330507Z",
+     "iopub.status.idle": "2026-09-04T03:36:59.390164Z",
+     "shell.execute_reply": "2026-09-04T03:36:59.389594Z"
     },
     "papermill": {
-     "duration": 0.063463,
-     "end_time": "2026-09-01T23:43:45.272006+00:00",
+     "duration": 0.064305,
+     "end_time": "2026-09-04T03:36:59.390474+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:45.208543+00:00",
+     "start_time": "2026-09-04T03:36:59.326169+00:00",
      "status": "completed"
     }
    },
@@ -224,13 +224,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92aa7688",
+   "id": "4f3e5603",
    "metadata": {
     "papermill": {
-     "duration": 0.003054,
-     "end_time": "2026-09-01T23:43:45.278323+00:00",
+     "duration": 0.001911,
+     "end_time": "2026-09-04T03:36:59.394598+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:45.275269+00:00",
+     "start_time": "2026-09-04T03:36:59.392687+00:00",
      "status": "completed"
     }
    },
@@ -252,13 +252,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d27db7ac",
+   "id": "a8a7f7f5",
    "metadata": {
     "papermill": {
-     "duration": 0.00162,
-     "end_time": "2026-09-01T23:43:45.281706+00:00",
+     "duration": 0.002955,
+     "end_time": "2026-09-04T03:36:59.400002+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:45.280086+00:00",
+     "start_time": "2026-09-04T03:36:59.397047+00:00",
      "status": "completed"
     }
    },
@@ -276,19 +276,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "a6feb32f",
+   "id": "dfdf3cd0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:45.287557Z",
-     "iopub.status.busy": "2026-09-01T23:43:45.287214Z",
-     "iopub.status.idle": "2026-09-01T23:43:45.310439Z",
-     "shell.execute_reply": "2026-09-01T23:43:45.309910Z"
+     "iopub.execute_input": "2026-09-04T03:36:59.407010Z",
+     "iopub.status.busy": "2026-09-04T03:36:59.406824Z",
+     "iopub.status.idle": "2026-09-04T03:36:59.479779Z",
+     "shell.execute_reply": "2026-09-04T03:36:59.479218Z"
     },
     "papermill": {
-     "duration": 0.02846,
-     "end_time": "2026-09-01T23:43:45.311865+00:00",
+     "duration": 0.07724,
+     "end_time": "2026-09-04T03:36:59.480436+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:45.283405+00:00",
+     "start_time": "2026-09-04T03:36:59.403196+00:00",
      "status": "completed"
     }
    },
@@ -321,19 +321,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "6f960975",
+   "id": "cbf3b1c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:43:45.317795Z",
-     "iopub.status.busy": "2026-09-01T23:43:45.317652Z",
-     "iopub.status.idle": "2026-09-01T23:44:34.045011Z",
-     "shell.execute_reply": "2026-09-01T23:44:34.043327Z"
+     "iopub.execute_input": "2026-09-04T03:36:59.488220Z",
+     "iopub.status.busy": "2026-09-04T03:36:59.488046Z",
+     "iopub.status.idle": "2026-09-04T03:37:56.453112Z",
+     "shell.execute_reply": "2026-09-04T03:37:56.452609Z"
     },
     "papermill": {
-     "duration": 48.731114,
-     "end_time": "2026-09-01T23:44:34.046152+00:00",
+     "duration": 56.969422,
+     "end_time": "2026-09-04T03:37:56.453438+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:43:45.315038+00:00",
+     "start_time": "2026-09-04T03:36:59.484016+00:00",
      "status": "completed"
     }
    },
@@ -343,14 +343,14 @@
      "output_type": "stream",
      "text": [
       "Label carried by the selection: fwd_ret_risk_adj_5d\n",
-      "Selection read from the frozen candidate set 774c32c6e79b (3811 members)\n"
+      "Selection read from the frozen candidate set 57cb9eb3133c (3811 members)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "frozen candidate set 774c32c6e79b: 3811 members (2841 equal-weight baselines), selected ec0cfd449843 at validation Sharpe 2.691\n"
+      "frozen candidate set 57cb9eb3133c: 3811 members (2841 equal-weight baselines), selected ec0cfd449843 at validation Sharpe 2.691\n"
      ]
     }
    ],
@@ -453,13 +453,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d5baceb",
+   "id": "e129a79d",
    "metadata": {
     "papermill": {
-     "duration": 0.002233,
-     "end_time": "2026-09-01T23:44:34.051654+00:00",
+     "duration": 0.001758,
+     "end_time": "2026-09-04T03:37:56.457159+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.049421+00:00",
+     "start_time": "2026-09-04T03:37:56.455401+00:00",
      "status": "completed"
     }
    },
@@ -477,19 +477,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "cf661995",
+   "id": "17111249",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:34.055992Z",
-     "iopub.status.busy": "2026-09-01T23:44:34.055895Z",
-     "iopub.status.idle": "2026-09-01T23:44:34.691315Z",
-     "shell.execute_reply": "2026-09-01T23:44:34.690762Z"
+     "iopub.execute_input": "2026-09-04T03:37:56.461503Z",
+     "iopub.status.busy": "2026-09-04T03:37:56.461361Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.087883Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.087349Z"
     },
     "papermill": {
-     "duration": 0.638327,
-     "end_time": "2026-09-01T23:44:34.691780+00:00",
+     "duration": 0.629476,
+     "end_time": "2026-09-04T03:37:57.088378+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.053453+00:00",
+     "start_time": "2026-09-04T03:37:56.458902+00:00",
      "status": "completed"
     }
    },
@@ -561,19 +561,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "6f435723",
+   "id": "8b7d7a69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:34.697284Z",
-     "iopub.status.busy": "2026-09-01T23:44:34.697165Z",
-     "iopub.status.idle": "2026-09-01T23:44:34.719155Z",
-     "shell.execute_reply": "2026-09-01T23:44:34.718697Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.094836Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.094666Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.121415Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.121027Z"
     },
     "papermill": {
-     "duration": 0.02484,
-     "end_time": "2026-09-01T23:44:34.719422+00:00",
+     "duration": 0.029875,
+     "end_time": "2026-09-04T03:37:57.121947+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.694582+00:00",
+     "start_time": "2026-09-04T03:37:57.092072+00:00",
      "status": "completed"
     }
    },
@@ -726,13 +726,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6699be6a",
+   "id": "dce56863",
    "metadata": {
     "papermill": {
-     "duration": 0.001881,
-     "end_time": "2026-09-01T23:44:34.723474+00:00",
+     "duration": 0.001978,
+     "end_time": "2026-09-04T03:37:57.127202+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.721593+00:00",
+     "start_time": "2026-09-04T03:37:57.125224+00:00",
      "status": "completed"
     }
    },
@@ -744,19 +744,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "857a5d37",
+   "id": "3ce62558",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:34.730172Z",
-     "iopub.status.busy": "2026-09-01T23:44:34.730006Z",
-     "iopub.status.idle": "2026-09-01T23:44:34.856617Z",
-     "shell.execute_reply": "2026-09-01T23:44:34.854834Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.131815Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.131704Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.240708Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.240231Z"
     },
     "papermill": {
-     "duration": 0.132545,
-     "end_time": "2026-09-01T23:44:34.857873+00:00",
+     "duration": 0.112237,
+     "end_time": "2026-09-04T03:37:57.241351+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.725328+00:00",
+     "start_time": "2026-09-04T03:37:57.129114+00:00",
      "status": "completed"
     }
    },
@@ -828,13 +828,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43e89121",
+   "id": "8d0d0fd4",
    "metadata": {
     "papermill": {
-     "duration": 0.001846,
-     "end_time": "2026-09-01T23:44:34.862034+00:00",
+     "duration": 0.001884,
+     "end_time": "2026-09-04T03:37:57.245340+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.860188+00:00",
+     "start_time": "2026-09-04T03:37:57.243456+00:00",
      "status": "completed"
     }
    },
@@ -848,19 +848,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "88b2004d",
+   "id": "4f126c2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:34.866305Z",
-     "iopub.status.busy": "2026-09-01T23:44:34.866201Z",
-     "iopub.status.idle": "2026-09-01T23:44:34.868777Z",
-     "shell.execute_reply": "2026-09-01T23:44:34.868452Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.253054Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.252944Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.256343Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.255761Z"
     },
     "papermill": {
-     "duration": 0.005351,
-     "end_time": "2026-09-01T23:44:34.869167+00:00",
+     "duration": 0.00807,
+     "end_time": "2026-09-04T03:37:57.256910+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.863816+00:00",
+     "start_time": "2026-09-04T03:37:57.248840+00:00",
      "status": "completed"
     }
    },
@@ -890,13 +890,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d9d88a9",
+   "id": "149d1df1",
    "metadata": {
     "papermill": {
-     "duration": 0.001761,
-     "end_time": "2026-09-01T23:44:34.872799+00:00",
+     "duration": 0.003504,
+     "end_time": "2026-09-04T03:37:57.264245+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.871038+00:00",
+     "start_time": "2026-09-04T03:37:57.260741+00:00",
      "status": "completed"
     }
    },
@@ -909,19 +909,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "47977328",
+   "id": "956162dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:34.877936Z",
-     "iopub.status.busy": "2026-09-01T23:44:34.877803Z",
-     "iopub.status.idle": "2026-09-01T23:44:34.880591Z",
-     "shell.execute_reply": "2026-09-01T23:44:34.880278Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.272081Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.271905Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.275724Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.275157Z"
     },
     "papermill": {
-     "duration": 0.006216,
-     "end_time": "2026-09-01T23:44:34.880925+00:00",
+     "duration": 0.008164,
+     "end_time": "2026-09-04T03:37:57.276070+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.874709+00:00",
+     "start_time": "2026-09-04T03:37:57.267906+00:00",
      "status": "completed"
     }
    },
@@ -963,19 +963,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "ae706bb4",
+   "id": "89f9590b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:34.886522Z",
-     "iopub.status.busy": "2026-09-01T23:44:34.886401Z",
-     "iopub.status.idle": "2026-09-01T23:44:34.893481Z",
-     "shell.execute_reply": "2026-09-01T23:44:34.893084Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.280908Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.280816Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.289867Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.289259Z"
     },
     "papermill": {
-     "duration": 0.010477,
-     "end_time": "2026-09-01T23:44:34.893959+00:00",
+     "duration": 0.011872,
+     "end_time": "2026-09-04T03:37:57.290220+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.883482+00:00",
+     "start_time": "2026-09-04T03:37:57.278348+00:00",
      "status": "completed"
     }
    },
@@ -1070,13 +1070,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce1db3e4",
+   "id": "af07d7ce",
    "metadata": {
     "papermill": {
-     "duration": 0.00191,
-     "end_time": "2026-09-01T23:44:34.897903+00:00",
+     "duration": 0.00193,
+     "end_time": "2026-09-04T03:37:57.294463+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.895993+00:00",
+     "start_time": "2026-09-04T03:37:57.292533+00:00",
      "status": "completed"
     }
    },
@@ -1091,19 +1091,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "5af99bdc",
+   "id": "b7d56e17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:34.902525Z",
-     "iopub.status.busy": "2026-09-01T23:44:34.902418Z",
-     "iopub.status.idle": "2026-09-01T23:44:35.001954Z",
-     "shell.execute_reply": "2026-09-01T23:44:35.001590Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.299395Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.299298Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.437786Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.437244Z"
     },
     "papermill": {
-     "duration": 0.102647,
-     "end_time": "2026-09-01T23:44:35.002488+00:00",
+     "duration": 0.141869,
+     "end_time": "2026-09-04T03:37:57.438344+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:34.899841+00:00",
+     "start_time": "2026-09-04T03:37:57.296475+00:00",
      "status": "completed"
     }
    },
@@ -1169,13 +1169,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c5075da",
+   "id": "804b19ae",
    "metadata": {
     "papermill": {
-     "duration": 0.002146,
-     "end_time": "2026-09-01T23:44:35.007122+00:00",
+     "duration": 0.002122,
+     "end_time": "2026-09-04T03:37:57.442942+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.004976+00:00",
+     "start_time": "2026-09-04T03:37:57.440820+00:00",
      "status": "completed"
     }
    },
@@ -1193,19 +1193,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "7d68aa4c",
+   "id": "a45fb957",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:35.012471Z",
-     "iopub.status.busy": "2026-09-01T23:44:35.012347Z",
-     "iopub.status.idle": "2026-09-01T23:44:35.032404Z",
-     "shell.execute_reply": "2026-09-01T23:44:35.032013Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.448699Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.448289Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.468665Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.468157Z"
     },
     "papermill": {
-     "duration": 0.023529,
-     "end_time": "2026-09-01T23:44:35.032894+00:00",
+     "duration": 0.023987,
+     "end_time": "2026-09-04T03:37:57.469122+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.009365+00:00",
+     "start_time": "2026-09-04T03:37:57.445135+00:00",
      "status": "completed"
     }
    },
@@ -1230,13 +1230,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "576af2f5",
+   "id": "3a868494",
    "metadata": {
     "papermill": {
-     "duration": 0.002149,
-     "end_time": "2026-09-01T23:44:35.037608+00:00",
+     "duration": 0.002179,
+     "end_time": "2026-09-04T03:37:57.473687+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.035459+00:00",
+     "start_time": "2026-09-04T03:37:57.471508+00:00",
      "status": "completed"
     }
    },
@@ -1248,19 +1248,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "201b5c15",
+   "id": "1b6cc84b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:35.045159Z",
-     "iopub.status.busy": "2026-09-01T23:44:35.044787Z",
-     "iopub.status.idle": "2026-09-01T23:44:35.119009Z",
-     "shell.execute_reply": "2026-09-01T23:44:35.118652Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.478768Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.478651Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.570745Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.569942Z"
     },
     "papermill": {
-     "duration": 0.079845,
-     "end_time": "2026-09-01T23:44:35.119562+00:00",
+     "duration": 0.095472,
+     "end_time": "2026-09-04T03:37:57.571342+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.039717+00:00",
+     "start_time": "2026-09-04T03:37:57.475870+00:00",
      "status": "completed"
     }
    },
@@ -1285,19 +1285,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "0dac837f",
+   "id": "ab7cf79a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:35.127277Z",
-     "iopub.status.busy": "2026-09-01T23:44:35.127178Z",
-     "iopub.status.idle": "2026-09-01T23:44:35.133038Z",
-     "shell.execute_reply": "2026-09-01T23:44:35.132717Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.580521Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.580344Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.588920Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.588261Z"
     },
     "papermill": {
-     "duration": 0.00918,
-     "end_time": "2026-09-01T23:44:35.133488+00:00",
+     "duration": 0.013929,
+     "end_time": "2026-09-04T03:37:57.589554+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.124308+00:00",
+     "start_time": "2026-09-04T03:37:57.575625+00:00",
      "status": "completed"
     }
    },
@@ -1354,19 +1354,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "5b65aaa5",
+   "id": "bfc27a71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:35.138706Z",
-     "iopub.status.busy": "2026-09-01T23:44:35.138527Z",
-     "iopub.status.idle": "2026-09-01T23:44:35.231680Z",
-     "shell.execute_reply": "2026-09-01T23:44:35.231158Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.598910Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.598665Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.695461Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.694980Z"
     },
     "papermill": {
-     "duration": 0.096254,
-     "end_time": "2026-09-01T23:44:35.231976+00:00",
+     "duration": 0.102041,
+     "end_time": "2026-09-04T03:37:57.695852+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.135722+00:00",
+     "start_time": "2026-09-04T03:37:57.593811+00:00",
      "status": "completed"
     }
    },
@@ -1436,19 +1436,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "fdd936bf",
+   "id": "80292f0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:35.238739Z",
-     "iopub.status.busy": "2026-09-01T23:44:35.238601Z",
-     "iopub.status.idle": "2026-09-01T23:44:35.241096Z",
-     "shell.execute_reply": "2026-09-01T23:44:35.240767Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.702052Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.701881Z",
+     "iopub.status.idle": "2026-09-04T03:37:57.704527Z",
+     "shell.execute_reply": "2026-09-04T03:37:57.704195Z"
     },
     "papermill": {
-     "duration": 0.006137,
-     "end_time": "2026-09-01T23:44:35.241469+00:00",
+     "duration": 0.006373,
+     "end_time": "2026-09-04T03:37:57.704930+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.235332+00:00",
+     "start_time": "2026-09-04T03:37:57.698557+00:00",
      "status": "completed"
     }
    },
@@ -1475,13 +1475,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d11659ca",
+   "id": "0e1acbcc",
    "metadata": {
     "papermill": {
-     "duration": 0.002287,
-     "end_time": "2026-09-01T23:44:35.246242+00:00",
+     "duration": 0.002296,
+     "end_time": "2026-09-04T03:37:57.709864+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.243955+00:00",
+     "start_time": "2026-09-04T03:37:57.707568+00:00",
      "status": "completed"
     }
    },
@@ -1495,13 +1495,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fe2f63e",
+   "id": "ed0716e2",
    "metadata": {
     "papermill": {
-     "duration": 0.002114,
-     "end_time": "2026-09-01T23:44:35.250663+00:00",
+     "duration": 0.002348,
+     "end_time": "2026-09-04T03:37:57.714678+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.248549+00:00",
+     "start_time": "2026-09-04T03:37:57.712330+00:00",
      "status": "completed"
     }
    },
@@ -1517,19 +1517,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "f489fef8",
+   "id": "9f78a1a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:35.256113Z",
-     "iopub.status.busy": "2026-09-01T23:44:35.255960Z",
-     "iopub.status.idle": "2026-09-01T23:44:35.704661Z",
-     "shell.execute_reply": "2026-09-01T23:44:35.704204Z"
+     "iopub.execute_input": "2026-09-04T03:37:57.720518Z",
+     "iopub.status.busy": "2026-09-04T03:37:57.720402Z",
+     "iopub.status.idle": "2026-09-04T03:37:58.281328Z",
+     "shell.execute_reply": "2026-09-04T03:37:58.280677Z"
     },
     "papermill": {
-     "duration": 0.452408,
-     "end_time": "2026-09-01T23:44:35.705278+00:00",
+     "duration": 0.565034,
+     "end_time": "2026-09-04T03:37:58.282177+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.252870+00:00",
+     "start_time": "2026-09-04T03:37:57.717143+00:00",
      "status": "completed"
     }
    },
@@ -1570,13 +1570,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "064d9cb9",
+   "id": "1622313c",
    "metadata": {
     "papermill": {
-     "duration": 0.003062,
-     "end_time": "2026-09-01T23:44:35.712022+00:00",
+     "duration": 0.004054,
+     "end_time": "2026-09-04T03:37:58.291130+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.708960+00:00",
+     "start_time": "2026-09-04T03:37:58.287076+00:00",
      "status": "completed"
     }
    },
@@ -1588,19 +1588,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "c0492125",
+   "id": "e412ad1b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:35.717787Z",
-     "iopub.status.busy": "2026-09-01T23:44:35.717698Z",
-     "iopub.status.idle": "2026-09-01T23:44:36.069014Z",
-     "shell.execute_reply": "2026-09-01T23:44:36.067657Z"
+     "iopub.execute_input": "2026-09-04T03:37:58.299197Z",
+     "iopub.status.busy": "2026-09-04T03:37:58.298961Z",
+     "iopub.status.idle": "2026-09-04T03:37:58.732816Z",
+     "shell.execute_reply": "2026-09-04T03:37:58.731907Z"
     },
     "papermill": {
-     "duration": 0.356139,
-     "end_time": "2026-09-01T23:44:36.070884+00:00",
+     "duration": 0.438982,
+     "end_time": "2026-09-04T03:37:58.733543+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:35.714745+00:00",
+     "start_time": "2026-09-04T03:37:58.294561+00:00",
      "status": "completed"
     }
    },
@@ -1634,19 +1634,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "ac9b0295",
+   "id": "48521338",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:36.077504Z",
-     "iopub.status.busy": "2026-09-01T23:44:36.077271Z",
-     "iopub.status.idle": "2026-09-01T23:44:36.081583Z",
-     "shell.execute_reply": "2026-09-01T23:44:36.081317Z"
+     "iopub.execute_input": "2026-09-04T03:37:58.741302Z",
+     "iopub.status.busy": "2026-09-04T03:37:58.741075Z",
+     "iopub.status.idle": "2026-09-04T03:37:58.747052Z",
+     "shell.execute_reply": "2026-09-04T03:37:58.746325Z"
     },
     "papermill": {
-     "duration": 0.008226,
-     "end_time": "2026-09-01T23:44:36.081937+00:00",
+     "duration": 0.010108,
+     "end_time": "2026-09-04T03:37:58.747467+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:36.073711+00:00",
+     "start_time": "2026-09-04T03:37:58.737359+00:00",
      "status": "completed"
     }
    },
@@ -1714,13 +1714,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c05c0e5",
+   "id": "d858f077",
    "metadata": {
     "papermill": {
-     "duration": 0.002367,
-     "end_time": "2026-09-01T23:44:36.086741+00:00",
+     "duration": 0.002762,
+     "end_time": "2026-09-04T03:37:58.753729+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:36.084374+00:00",
+     "start_time": "2026-09-04T03:37:58.750967+00:00",
      "status": "completed"
     }
    },
@@ -1734,13 +1734,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95958f66",
+   "id": "00320c2d",
    "metadata": {
     "papermill": {
-     "duration": 0.00231,
-     "end_time": "2026-09-01T23:44:36.091331+00:00",
+     "duration": 0.00279,
+     "end_time": "2026-09-04T03:37:58.759520+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:36.089021+00:00",
+     "start_time": "2026-09-04T03:37:58.756730+00:00",
      "status": "completed"
     }
    },
@@ -1770,19 +1770,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "cdedf0df",
+   "id": "9eee4e4f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:36.098991Z",
-     "iopub.status.busy": "2026-09-01T23:44:36.098881Z",
-     "iopub.status.idle": "2026-09-01T23:44:36.101752Z",
-     "shell.execute_reply": "2026-09-01T23:44:36.101374Z"
+     "iopub.execute_input": "2026-09-04T03:37:58.766431Z",
+     "iopub.status.busy": "2026-09-04T03:37:58.766197Z",
+     "iopub.status.idle": "2026-09-04T03:37:58.770517Z",
+     "shell.execute_reply": "2026-09-04T03:37:58.769822Z"
     },
     "papermill": {
-     "duration": 0.008477,
-     "end_time": "2026-09-01T23:44:36.102125+00:00",
+     "duration": 0.00861,
+     "end_time": "2026-09-04T03:37:58.771053+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:36.093648+00:00",
+     "start_time": "2026-09-04T03:37:58.762443+00:00",
      "status": "completed"
     }
    },
@@ -1810,13 +1810,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0692e961",
+   "id": "baf30219",
    "metadata": {
     "papermill": {
-     "duration": 0.002436,
-     "end_time": "2026-09-01T23:44:36.107129+00:00",
+     "duration": 0.004941,
+     "end_time": "2026-09-04T03:37:58.781473+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:36.104693+00:00",
+     "start_time": "2026-09-04T03:37:58.776532+00:00",
      "status": "completed"
     }
    },
@@ -1847,19 +1847,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "80455d1b",
+   "id": "ef9429c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:36.113634Z",
-     "iopub.status.busy": "2026-09-01T23:44:36.113500Z",
-     "iopub.status.idle": "2026-09-01T23:44:40.508080Z",
-     "shell.execute_reply": "2026-09-01T23:44:40.507678Z"
+     "iopub.execute_input": "2026-09-04T03:37:58.788230Z",
+     "iopub.status.busy": "2026-09-04T03:37:58.788032Z",
+     "iopub.status.idle": "2026-09-04T03:38:03.784391Z",
+     "shell.execute_reply": "2026-09-04T03:38:03.783839Z"
     },
     "papermill": {
-     "duration": 4.398949,
-     "end_time": "2026-09-01T23:44:40.508541+00:00",
+     "duration": 5.000566,
+     "end_time": "2026-09-04T03:38:03.784881+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:36.109592+00:00",
+     "start_time": "2026-09-04T03:37:58.784315+00:00",
      "status": "completed"
     }
    },
@@ -2041,19 +2041,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "46c94217",
+   "id": "f72099c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:40.514613Z",
-     "iopub.status.busy": "2026-09-01T23:44:40.514493Z",
-     "iopub.status.idle": "2026-09-01T23:44:40.518397Z",
-     "shell.execute_reply": "2026-09-01T23:44:40.518040Z"
+     "iopub.execute_input": "2026-09-04T03:38:03.793840Z",
+     "iopub.status.busy": "2026-09-04T03:38:03.793697Z",
+     "iopub.status.idle": "2026-09-04T03:38:03.798185Z",
+     "shell.execute_reply": "2026-09-04T03:38:03.797506Z"
     },
     "papermill": {
-     "duration": 0.007678,
-     "end_time": "2026-09-01T23:44:40.518897+00:00",
+     "duration": 0.008396,
+     "end_time": "2026-09-04T03:38:03.798546+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:40.511219+00:00",
+     "start_time": "2026-09-04T03:38:03.790150+00:00",
      "status": "completed"
     }
    },
@@ -2115,13 +2115,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e994ae8",
+   "id": "d5daa4a6",
    "metadata": {
     "papermill": {
-     "duration": 0.002925,
-     "end_time": "2026-09-01T23:44:40.524500+00:00",
+     "duration": 0.002761,
+     "end_time": "2026-09-04T03:38:03.804394+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:40.521575+00:00",
+     "start_time": "2026-09-04T03:38:03.801633+00:00",
      "status": "completed"
     }
    },
@@ -2136,14 +2136,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c541a9a",
+   "id": "1cd67a0b",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002282,
-     "end_time": "2026-09-01T23:44:40.529395+00:00",
+     "duration": 0.002751,
+     "end_time": "2026-09-04T03:38:03.809979+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:40.527113+00:00",
+     "start_time": "2026-09-04T03:38:03.807228+00:00",
      "status": "completed"
     }
    },
@@ -2162,19 +2162,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "89c25993",
+   "id": "160da27f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-01T23:44:40.534713Z",
-     "iopub.status.busy": "2026-09-01T23:44:40.534605Z",
-     "iopub.status.idle": "2026-09-01T23:44:40.540781Z",
-     "shell.execute_reply": "2026-09-01T23:44:40.540452Z"
+     "iopub.execute_input": "2026-09-04T03:38:03.816905Z",
+     "iopub.status.busy": "2026-09-04T03:38:03.816713Z",
+     "iopub.status.idle": "2026-09-04T03:38:03.825925Z",
+     "shell.execute_reply": "2026-09-04T03:38:03.825319Z"
     },
     "papermill": {
-     "duration": 0.009378,
-     "end_time": "2026-09-01T23:44:40.541080+00:00",
+     "duration": 0.013583,
+     "end_time": "2026-09-04T03:38:03.826407+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:40.531702+00:00",
+     "start_time": "2026-09-04T03:38:03.812824+00:00",
      "status": "completed"
     }
    },
@@ -2290,13 +2290,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a8b3fe9",
+   "id": "d8e6f08c",
    "metadata": {
     "papermill": {
-     "duration": 0.00261,
-     "end_time": "2026-09-01T23:44:40.546576+00:00",
+     "duration": 0.004901,
+     "end_time": "2026-09-04T03:38:03.836663+00:00",
      "exception": false,
-     "start_time": "2026-09-01T23:44:40.543966+00:00",
+     "start_time": "2026-09-04T03:38:03.831762+00:00",
      "status": "completed"
     }
    },
@@ -2356,7 +2356,7 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-01T23:44:48.502981+00:00",
+   "executed_at": "2026-09-04T03:38:12.969733+00:00",
    "executor": "local-uv",
    "parameters": {},
    "production": true,
@@ -2364,14 +2364,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 61.16912,
-   "end_time": "2026-09-01T23:44:42.983448+00:00",
+   "duration": 71.170479,
+   "end_time": "2026-09-04T03:38:06.645235+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/20_strategy_analysis.ipynb",
-   "output_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/.20_strategy_analysis.papermill.1507822.ipynb",
+   "input_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/20_strategy_analysis.ipynb",
+   "output_path": "~/ml4t/public-seoa-candidate-sets/case_studies/sp500_equity_option_analytics/.20_strategy_analysis.papermill.244221.ipynb",
    "parameters": {},
-   "start_time": "2026-09-01T23:43:41.814328+00:00",
+   "start_time": "2026-09-04T03:36:55.474756+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
`16_risk_management` declared `774c32c6e79b` as the generation its freeze replaces. `57cb9eb3133c` superseded that on 2026-09-02 and is what `CandidateSet.one` returns. A freeze whose field is unchanged is idempotent, so nothing failed today; the next change to the field would have been refused, naming a generation the notebook does not declare. That refusal is what ml4t/agent-workspace#1008 reports, one generation on.

## What changed

- `SUPERSEDES_CANDIDATE_SETS` bumped to `57cb9eb3133c`, and the lineage comment corrected. It said "two generations precede this one" while listing five, and stopped at `774c32c6e79b`. `57cb9eb3133c` also holds 3,811 members and differs from `774c32c6e79b` in 54: the `fwd_ret_10d` allocation backtests registered at 00:55 on 2026-09-01 gave way to the 54 the re-executed `15` registered at 00:30 on 2026-09-02.
- `17` through `20` re-executed. They rendered `774c32c6e79b`; they now name the set the registry resolves.

## What did not change

The selection is `ec0cfd449843` before and after: `latent_factors/sae` on `fwd_ret_risk_adj_5d`, `score_weighted` top-10 under the `trailing_2pct` overlay, validation Sharpe 2.691. `18` and `19` reused the holdout training run and the holdout backtest by identity rather than registering new ones, so the holdout was not spent again. Apart from the set hash, the papermill paths and the sweep attempt counter, no value in the four re-executed notebooks moved.

## The underlying defect was repaired in #704

Measured against the registry rather than the source: 0 of 15 sweep plans unfinished, all five declared labels carry `signal`, `allocation` and `risk_overlay` rows, and rebuilding the field live reproduces the frozen head exactly at 3,811 members with nothing on either side of the diff. The field is built by `resolve_field_members` over `sweep_labels`, gated on `unfinished_sweep_plans`, and spans every declared label rather than `RISK_LABEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1EzmRdDAxsqksSBN9EsT3