### PR TITLE
Price 00_holdout_predictions for the work it started doing

### DIFF
--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -60,13 +60,17 @@ jobs:
             cp -r test-data/intermediates/* $ML4T_OUTPUT_DIR/
           fi
 
+      # No --timeout. A per-test wall clock here contradicts the per-cell budgets in
+      # tests/overrides.yaml, which is where a notebook's cost is declared and measured:
+      # twelve chapter entries already exceed 600s, up to 07_hpo_comparison's 2400s, and
+      # pytest would kill those runs before their own budget ever applied. The job's
+      # timeout-minutes above bounds a hang, and test.yml runs this same file the same way.
       - name: Run ALL chapter notebooks
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           python -m pytest tests/test_chapter_notebooks.py \
-            -v --tb=short \
-            --timeout=600
+            -v --tb=short
 
       - name: Upload test results
         if: always()
@@ -117,14 +121,16 @@ jobs:
           ssh-key: ${{ secrets.TEST_DATA_DEPLOY_KEY }}
           lfs: false
 
+      # No --timeout, for the reason the chapters job gives: twenty-four case-study entries
+      # in tests/overrides.yaml declare budgets above 600s, up to sp500_options'
+      # 04_model_based_features at 2760s.
       - name: Run pipeline (${{ matrix.case-study }})
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           python -m pytest tests/test_case_studies.py \
             -v --tb=short \
-            -k "${{ matrix.case-study }}" \
-            --timeout=600
+            -k "${{ matrix.case-study }}"
 
   # ---------------------------------------------------------------------------
   # Py312 notebooks (signatory, gensim, esig, tfcausalimpact, torch CUDA bug)

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -868,7 +868,23 @@
 19_risk_management/11_systematic_risk_sweep:
   timeout: 900
 20_strategy_synthesis/00_holdout_predictions:
-  skip_reason: Requires trained model registry (not available in CI test data)
+  # No `skip: true` ever stood above the skip_reason this replaces, so the notebook has
+  # always run; the reason was describing a state that had stopped being true. It also
+  # carried no timeout, so it inherited the 300s default while 01 and 03 next to it carry
+  # 600 - it had never been priced, only kept under the default by work it was not doing.
+  #
+  # It is doing that work now. Until #746 the seeded fixtures gave cme_futures' two cohort
+  # leaders a fabricated entity grid (the RuntimeWarning naming b099266d758c and
+  # fbeb779467d5 is in the last green run's log), the holdout retrain found nothing real to
+  # fit, and the cell finished in about 135s while stepping over the case study. Seeding
+  # those leaders from the case study's own label parquet makes the retrain run: measured
+  # here at 350s for cme_futures and 60s for sp500_equity_option_analytics against 426s for
+  # the whole loop, with every other case study in single figures. Measured at 590s in the
+  # ml4t image with the wider fixture panels of #749 on top.
+  #
+  # 1800s is three times the widest of those against a runner slower than either machine,
+  # the same ratio 11d_conditional_autoencoder's cap carries, and it absorbs #749.
+  timeout: 1800
 20_strategy_synthesis/01_aggregate_synthesis:
   parameters:
     # Isolated test registry has no nasdaq out-of-band cost-feasible carrier,
@@ -1030,7 +1046,6 @@
   long_running: true
   parameters:
     MAX_COMPANIES: 3
-  skip_reason: Needs GPU + Neo4j
   timeout: 1200
 24_autonomous_agents/01_react_reasoning:
   parameters:

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -182,6 +182,28 @@ def test_credential_gated_notebooks_declare_requires_env_not_skip(overrides: dic
     assert hard_skipped_despite_a_gate == set()
 
 
+def test_no_entry_declares_a_reason_for_a_skip_it_does_not_take(overrides: dict) -> None:
+    """``skip_reason`` without ``skip`` is text nothing reads.
+
+    Every one of its seven call sites reaches it only inside a branch already taken on
+    ``skip``, so a reason standing alone describes a notebook that runs anyway. That is
+    worse than silence: ``00_holdout_predictions`` carried "Requires trained model
+    registry (not available in CI test data)" while executing every case study in the
+    registry, and the entry looked accounted for until it timed out.
+
+    What routes a notebook away from a job belongs in the key that does the routing -
+    ``requires_env``, ``docker_env``, ``gpu``, ``tier`` - and each says what it needs
+    without a second copy in prose.
+    """
+    reason_without_skip = {
+        key
+        for key, value in overrides.items()
+        if isinstance(value, dict) and value.get("skip_reason") and not value.get("skip")
+    }
+
+    assert reason_without_skip == set()
+
+
 def _executable(tmp_path: Path) -> Path:
     interpreter = tmp_path / "python"
     interpreter.write_text("#!/bin/sh\n")


### PR DESCRIPTION
`ch18-20` went red on `main` at c6ed6255: `20_strategy_synthesis/00_holdout_predictions` hit a 300s cell timeout in the `generate_holdout` loop.

## What changed under it

Nothing got slower per unit of work. The notebook started doing work it had been skipping.

The last green run's log (ae2d6a11, job 100883565340) ends with `cme_futures: no predictions.parquet on disk for cohort-leader prediction(s) b099266d758c, fbeb779467d5; each gets synthetic scores on a fabricated entity grid`. In CI those two leaders had no prediction artifact, so they fell to the fabricated 60-date grid, the holdout retrain had nothing real to fit, and the cell finished in about 135s while stepping over the case study. #746 seeds those leaders from `cme_futures`' own label parquet, so the retrain runs.

This does not reproduce on a workstation that has the artifacts: there the exemption preserves them, the fabricated grid never applies, and `cme_futures` measures 350s with the change against 397s with `_label_artifact_panel` disabled - slightly cheaper, the opposite of the CI effect. The flip exists only where the artifacts are absent.

## The entry had never been priced

`tests/overrides.yaml:870` was two lines: the key, and a `skip_reason` reading "Requires trained model registry (not available in CI test data)". No `skip: true` ever stood above it, so the notebook had always run and the reason described a state that had stopped being true. No `timeout` either, so it inherited the 300s default while `01_aggregate_synthesis` and `03_signal_quality` beside it carry 600.

Measured on a contended workstation over the whole loop: **426s**, of which `cme_futures` is 350s and `sp500_equity_option_analytics` 60s, with every other case study in single figures. Measured at **590s** in `ml4t/ml4t:latest` with the wider fixture panels of #749 on top. `1800` is three times the widest of those against a runner slower than either machine - the ratio `11d_conditional_autoencoder`'s cap already carries - and it absorbs #749.

## Two dead skip reasons, and a test that refuses the pairing

All seven call sites read `skip_reason` only inside a branch already taken on `skip`, so a reason standing alone is text nothing reads. The second one, `23_knowledge_graphs/02_supply_chain_kg_construction`'s "Needs GPU + Neo4j", is already said by its own `docker_env` and `gpu` keys.

## full-test.yml capped notebooks below their own budgets

Both its steps passed `--timeout=600` to pytest, a per-test wall clock contradicting the per-cell budgets in `overrides.yaml`. Twelve chapter entries already exceed it (up to `07_hpo_comparison` at 2400s) and twenty-four case-study entries do (up to `sp500_options/04_model_based_features` at 2760s); all of them would be killed before their own budget applied. Removed rather than raised: `test.yml` runs both files with no `--timeout`, and each job's `timeout-minutes: 120` already bounds a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7W14G4noaTLHBm16arPmF