### PR TITLE
Record why a unit rebalance step cannot be normalized out of the backtest identity

### DIFF
--- a/case_studies/utils/backtest_loaders.py
+++ b/case_studies/utils/backtest_loaders.py
@@ -1282,9 +1282,13 @@ def resolve_rebalance_timestamps(
     - ``monthly_month_end`` → last available timestamp in each calendar month
     - ``weekly_friday_close`` / ``weekly_friday`` → last available timestamp
       in each ISO week (typically Friday, or Thursday if Friday is a holiday)
-    - ``daily_*`` → every available timestamp
-    - ``8_hour_*`` / ``15_min`` → every available timestamp (fixed-interval
-      cadences where the data is already at the correct granularity)
+    - ``daily_*`` and coarser cadences naming no interval → every available timestamp
+    - ``8_hour_*`` / ``15_minute`` and every other fixed-interval cadence → the slots
+      on the clock at that interval, constructed rather than assumed. This line used
+      to say "every available timestamp ... already at the correct granularity",
+      which is the precondition nasdaq100_microstructure did not meet and
+      ml4t/agent-workspace#187 was filed about; the branch below has constructed the
+      schedule since public ``83141459`` and the description had not followed it.
 
     Parameters
     ----------

--- a/case_studies/utils/registry/specs.py
+++ b/case_studies/utils/registry/specs.py
@@ -216,27 +216,6 @@ def _hashable_strategy_spec(strategy_spec: dict) -> dict:
             direction = str(signal.get("direction", "long_only")).strip().lower()
             if direction == "long_only":
                 signal.pop("direction", None)
-        rebalance = strategy.get("rebalance")
-        if isinstance(rebalance, dict) and "step" in rebalance:
-            # A step of 1 is the absence of a step. Both execution paths apply it as
-            # `gather_every(step)` over the resolved schedule, and `gather_every(1)` returns
-            # the schedule unchanged, so a spec carrying `step: 1` and a spec carrying no
-            # step describe the same set of traded decisions. Same normalization, and same
-            # reason, as `long_only` above: the parameter became explicit after rows had
-            # already been written without it, and only the explicit default is dropped.
-            #
-            # Every other value stays in the hash, which is the whole point of
-            # ml4t/agent-workspace#1005: a step that changes what is traded must change the
-            # identity, or a corrected run hashes to the rows it was meant to replace and is
-            # skipped. Popping the step unconditionally - or popping it whenever it equals
-            # whatever `setup.yaml` currently declares - would restore that defect in full,
-            # because the declaration is exactly what a correction moves.
-            try:
-                step = int(rebalance["step"])
-            except (TypeError, ValueError):
-                step = None
-            if step == 1:
-                rebalance.pop("step", None)
     backtest_config = spec.get("backtest_config")
     if isinstance(backtest_config, dict):
         metadata = backtest_config.get("metadata")

--- a/case_studies/utils/registry/specs.py
+++ b/case_studies/utils/registry/specs.py
@@ -216,6 +216,27 @@ def _hashable_strategy_spec(strategy_spec: dict) -> dict:
             direction = str(signal.get("direction", "long_only")).strip().lower()
             if direction == "long_only":
                 signal.pop("direction", None)
+        rebalance = strategy.get("rebalance")
+        if isinstance(rebalance, dict) and "step" in rebalance:
+            # A step of 1 is the absence of a step. Both execution paths apply it as
+            # `gather_every(step)` over the resolved schedule, and `gather_every(1)` returns
+            # the schedule unchanged, so a spec carrying `step: 1` and a spec carrying no
+            # step describe the same set of traded decisions. Same normalization, and same
+            # reason, as `long_only` above: the parameter became explicit after rows had
+            # already been written without it, and only the explicit default is dropped.
+            #
+            # Every other value stays in the hash, which is the whole point of
+            # ml4t/agent-workspace#1005: a step that changes what is traded must change the
+            # identity, or a corrected run hashes to the rows it was meant to replace and is
+            # skipped. Popping the step unconditionally - or popping it whenever it equals
+            # whatever `setup.yaml` currently declares - would restore that defect in full,
+            # because the declaration is exactly what a correction moves.
+            try:
+                step = int(rebalance["step"])
+            except (TypeError, ValueError):
+                step = None
+            if step == 1:
+                rebalance.pop("step", None)
     backtest_config = spec.get("backtest_config")
     if isinstance(backtest_config, dict):
         metadata = backtest_config.get("metadata")

--- a/tests/test_rebalance_step_identity.py
+++ b/tests/test_rebalance_step_identity.py
@@ -119,41 +119,54 @@ def _spec(step: int | None) -> dict:
     }
 
 
-class TestAUnitStepIsTheAbsenceOfAStep:
-    """`gather_every(1)` returns the schedule unchanged, so `step: 1` describes no thinning.
+class TestAUnitStepIsNotNormalizedAway:
+    """`step: 1` stays in the identity, and this records the measurement that says it must.
 
-    The step became an explicit hash input in public `83141459`, after 21,995 backtests had
-    been registered without it. Every one of those specs resolved to a different hash than the
-    next run would compute, so a sweep re-run in any completed case study raised `a changed
-    population named '<name>' must explicitly supersedes <hash>` and recomputed every member
-    (ml4t/agent-workspace#1028).
+    Public `83141459` made `strategy.rebalance.step` a hash input after 21,995 backtests had
+    been registered without it, so every one of those rows resolves to a different hash than
+    the next run computes and a sweep re-run in any completed case study stops on `a changed
+    population named '<name>' must explicitly supersedes <hash>` (ml4t/agent-workspace#1028).
 
-    Normalizing the explicit default is the same move `signal.direction == "long_only"`
-    already gets in `_hashable_strategy_spec`, and it recovers every row whose declared step is
-    1: measured 16,423 of 21,995 across the seven live registries, invalidating none, because
-    no registered spec anywhere carries `step: 1`.
+    The obvious repair is to drop `step: 1` before hashing, the way `signal.direction ==
+    "long_only"` is dropped just above: `gather_every(1)` returns the schedule unchanged, so
+    `step: 1` and no step describe the same traded decisions, and it recovers 16,423 of the
+    21,995 rows while invalidating none.
+
+    **It is unsound, and the reason is not obvious enough to leave unwritten.** A legacy spec
+    carries no step but did not execute at step 1 - it executed at whatever `setup.yaml`
+    declared when it ran, which for `cme_futures/fwd_ret_21d` is 3, for `sp500_options` 5 and
+    for `fx_pairs/fwd_ret_21d` 21. Drop the explicit default and a *future* spec at step 1
+    hashes to those rows, is served from the registry as already registered, and reports
+    step-3 numbers under a step-1 request. That is ml4t/agent-workspace#1005 exactly, arrived
+    at from the other side, and it is silent.
+
+    5,572 rows across `cme_futures`, `crypto_perps_funding`, `fx_pairs` and `sp500_options`
+    are in that ambiguous state. The sound repair is to record each legacy row's executed step
+    in its spec and rehash - which is what `preset_path` did - but 5,570 of those rows are
+    members of 848 official populations whose own identity is the hash of their member list,
+    so it cannot be done without rewriting that lineage. #1028 carries the disposition.
     """
 
-    def test_a_unit_step_hashes_as_though_it_were_absent(self) -> None:
+    def test_a_unit_step_is_part_of_the_identity(self) -> None:
+        """Not normalized away: a legacy spec with no step may have traded at any step."""
         from case_studies.utils.registry.specs import backtest_hash_from_parts
 
-        assert backtest_hash_from_parts("pred123", _spec(1)) == backtest_hash_from_parts(
+        assert backtest_hash_from_parts("pred123", _spec(1)) != backtest_hash_from_parts(
             "pred123", _spec(None)
         )
 
-    def test_a_non_unit_step_does_not(self) -> None:
+    def test_a_non_unit_step_is_too(self) -> None:
         from case_studies.utils.registry.specs import backtest_hash_from_parts
 
-        absent = backtest_hash_from_parts("pred123", _spec(None))
-        assert backtest_hash_from_parts("pred123", _spec(3)) != absent
+        assert backtest_hash_from_parts("pred123", _spec(3)) != backtest_hash_from_parts(
+            "pred123", _spec(None)
+        )
 
     def test_two_non_unit_steps_stay_distinct(self) -> None:
-        """The half of #1005 that must survive: a corrected step still moves the identity.
+        """The half of #1005 that any repair here has to preserve.
 
-        Normalizing the step against whatever `setup.yaml` currently declares - rather than
-        against 1 - would fail here, because the declaration is exactly what a correction
-        moves. That reading restores #1005 in full: the corrected run would hash to the rows
-        it was written to replace and be skipped as already registered.
+        A corrected step must move the identity, or the corrected run hashes to the rows it
+        was written to replace and is skipped as already registered.
         """
         from case_studies.utils.registry.specs import backtest_hash_from_parts
 
@@ -162,26 +175,4 @@ class TestAUnitStepIsTheAbsenceOfAStep:
         )
         assert backtest_hash_from_parts("pred123", _spec(3)) != backtest_hash_from_parts(
             "pred123", _spec(1)
-        )
-
-    def test_the_stored_spec_is_not_touched(self) -> None:
-        """Normalization is for the hash only; `spec_json` keeps what the run declared.
-
-        Same contract as `preset_path`, which is stripped from the hash and retained in the
-        stored spec so provenance survives.
-        """
-        from case_studies.utils.registry.specs import backtest_hash_from_parts
-
-        spec = _spec(1)
-        backtest_hash_from_parts("pred123", spec)
-        assert spec["strategy"]["rebalance"]["step"] == 1
-
-    def test_a_string_step_is_normalized_on_its_value(self) -> None:
-        """YAML and papermill both hand numbers over as strings often enough to matter."""
-        from case_studies.utils.registry.specs import backtest_hash_from_parts
-
-        spec = _spec(None)
-        spec["strategy"]["rebalance"]["step"] = "1"
-        assert backtest_hash_from_parts("pred123", spec) == backtest_hash_from_parts(
-            "pred123", _spec(None)
         )

--- a/tests/test_rebalance_step_identity.py
+++ b/tests/test_rebalance_step_identity.py
@@ -91,3 +91,97 @@ def test_execution_reads_the_recorded_step_not_the_editable_file() -> None:
 
     with pytest.raises(ValueError, match="must be >= 1"):
         resolved_rebalance_step({"step": 0}, "nasdaq100_microstructure", "fwd_ret_15m")
+
+
+# ---------------------------------------------------------------------------
+# A unit step is the absence of a step (ml4t/agent-workspace#1028)
+# ---------------------------------------------------------------------------
+
+
+def _spec(step: int | None) -> dict:
+    """A minimal strategy spec, with or without a declared step."""
+    rebalance = {
+        "mode": "engine",
+        "cadence": "weekly_friday_close",
+        "min_weight_change": 0.005,
+        "min_trade_value": 100.0,
+    }
+    if step is not None:
+        rebalance["step"] = step
+    return {
+        "version": 2,
+        "identity_version": 2,
+        "chapter": "16",
+        "strategy": {
+            "signal": {"method": "equal_weight_top_k", "top_k": 5},
+            "rebalance": rebalance,
+        },
+    }
+
+
+class TestAUnitStepIsTheAbsenceOfAStep:
+    """`gather_every(1)` returns the schedule unchanged, so `step: 1` describes no thinning.
+
+    The step became an explicit hash input in public `83141459`, after 21,995 backtests had
+    been registered without it. Every one of those specs resolved to a different hash than the
+    next run would compute, so a sweep re-run in any completed case study raised `a changed
+    population named '<name>' must explicitly supersedes <hash>` and recomputed every member
+    (ml4t/agent-workspace#1028).
+
+    Normalizing the explicit default is the same move `signal.direction == "long_only"`
+    already gets in `_hashable_strategy_spec`, and it recovers every row whose declared step is
+    1: measured 16,423 of 21,995 across the seven live registries, invalidating none, because
+    no registered spec anywhere carries `step: 1`.
+    """
+
+    def test_a_unit_step_hashes_as_though_it_were_absent(self) -> None:
+        from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+        assert backtest_hash_from_parts("pred123", _spec(1)) == backtest_hash_from_parts(
+            "pred123", _spec(None)
+        )
+
+    def test_a_non_unit_step_does_not(self) -> None:
+        from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+        absent = backtest_hash_from_parts("pred123", _spec(None))
+        assert backtest_hash_from_parts("pred123", _spec(3)) != absent
+
+    def test_two_non_unit_steps_stay_distinct(self) -> None:
+        """The half of #1005 that must survive: a corrected step still moves the identity.
+
+        Normalizing the step against whatever `setup.yaml` currently declares - rather than
+        against 1 - would fail here, because the declaration is exactly what a correction
+        moves. That reading restores #1005 in full: the corrected run would hash to the rows
+        it was written to replace and be skipped as already registered.
+        """
+        from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+        assert backtest_hash_from_parts("pred123", _spec(3)) != backtest_hash_from_parts(
+            "pred123", _spec(5)
+        )
+        assert backtest_hash_from_parts("pred123", _spec(3)) != backtest_hash_from_parts(
+            "pred123", _spec(1)
+        )
+
+    def test_the_stored_spec_is_not_touched(self) -> None:
+        """Normalization is for the hash only; `spec_json` keeps what the run declared.
+
+        Same contract as `preset_path`, which is stripped from the hash and retained in the
+        stored spec so provenance survives.
+        """
+        from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+        spec = _spec(1)
+        backtest_hash_from_parts("pred123", spec)
+        assert spec["strategy"]["rebalance"]["step"] == 1
+
+    def test_a_string_step_is_normalized_on_its_value(self) -> None:
+        """YAML and papermill both hand numbers over as strings often enough to matter."""
+        from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+        spec = _spec(None)
+        spec["strategy"]["rebalance"]["step"] = "1"
+        assert backtest_hash_from_parts("pred123", spec) == backtest_hash_from_parts(
+            "pred123", _spec(None)
+        )


### PR DESCRIPTION
Records why the obvious repair for ml4t/agent-workspace#1028 does not work, and corrects one
stale docstring. **No identity changes here** - the branch ends with `_hashable_strategy_spec`
exactly as it was.

## What was tried

Public `83141459` made `strategy.rebalance.step` a hash input after 21,995 backtests had been
registered without it, so every one now resolves to a different hash than the next run computes
and a sweep re-run in any completed case study stops on `a changed population named '<name>'
must explicitly supersedes <hash>`.

The obvious repair is to drop `step: 1` before hashing, the way `signal.direction == "long_only"`
is dropped immediately above it: both execution paths apply the step as `gather_every(step)`, and
`gather_every(1)` returns the schedule unchanged, so `step: 1` and no step describe the same
traded decisions.

Measured offline against all seven live registries - every stored `spec_json`, stamped with the
step the current declaration emits and rehashed, which simulates the re-run without executing one:

```
cme_futures                     rows= 1152  match=  582  moved=  570   steps={1:582, 3:570}
crypto_perps_funding            rows= 2852  match= 1920  moved=  932   steps={1:1920, 3:932}
etfs                            rows= 3313  match= 3313  moved=    0   steps={1:3313}
fx_pairs                        rows= 3875  match= 1470  moved= 2405   steps={1:1470, 21:1203, 5:1202}
sp500_equity_option_analytics   rows= 4730  match= 4730  moved=    0   steps={1:4730}
sp500_options                   rows= 2543  match=  878  moved= 1665   steps={5:2543}
us_firm_characteristics         rows= 3530  match= 3530  moved=    0   steps={1:3530}

FLEET match=16423 moved=5572 total=21995
```

16,423 recovered, none invalidated - no spec in any registry carries `step: 1`, so nothing that
currently matches would have moved.

## Why it is wrong anyway

The pre-push review caught it and it is right. **A legacy spec carries no step; it did not
execute at step 1.** It executed at whatever `setup.yaml` declared when it ran - 3 for
`cme_futures/fwd_ret_21d`, 5 for `sp500_options`, 21 for `fx_pairs/fwd_ret_21d`. Drop the
explicit default and a *future* spec at step 1 hashes to those rows, is served from the registry
as already registered, and reports step-3 numbers under a step-1 request.

That is ml4t/agent-workspace#1005 reached from the other side, and it is silent. The recovery and
the hazard are the same edit: the 5,572 rows that would still move are exactly the ambiguous
ones.

My tests missed it because they compared explicit 1 against explicit non-unit values and never
against legacy absence. `TestAUnitStepIsNotNormalizedAway` now pins the constraint and the
measurement so the next reader finds them rather than repeating the attempt.

## What the sound repair costs

Record each legacy row's executed step in its `spec_json` and rehash, which is what the
`preset_path` migration did without re-running anything - the stored spec reproduces the numbers
exactly, and the declarations have not moved since `2c8ca2de` (2026-06-29), so every affected row
provably ran at the step now declared.

It does not transfer, because `scripts/migrate_backtest_hash_portable.py`'s `_HASH_REFS` covers
`backtest_metrics`, `backtest_fold_metrics`, `backtest_paired_metrics` and
`cohort_metrics.leader_hash` - and not `official_population_members` or `candidate_set_members`.
Measured on the 5,572:

```
cme_futures           570 in  570 population members across 573 populations;  570 candidate members / 6 sets
crypto_perps_funding  932 in  931 population members across  46 populations;  920 candidate members / 4 sets
fx_pairs             2405 in 2404 population members across 224 populations; 2360 candidate members / 24 sets
sp500_options        1665 in 1665 population members across   5 populations; 1632 candidate members / 3 sets
```

5,570 of 5,572 are members of an official population, across 848 of them, and a population's
identity is the hash of its member list. Rehashing members rewrites the lineage those snapshots
exist to make immutable.

So the disposition is on #1028 and it is a scheduling decision, not a repair.

## Also here

`resolve_rebalance_timestamps`' docstring still described the intraday branch as returning every
available timestamp "already at the correct granularity" - the precondition
ml4t/agent-workspace#187 was filed about, and one the branch below it stopped relying on in
`83141459`. Prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015p4BJvMLmU1rJ1jZYgugAC
