### PR TITLE
etfs 11c and 11e run in CI; 11d's skip says what actually blocks it

### DIFF
--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1691,14 +1691,54 @@ case_studies/etfs/11_latent_factors:
   gpu: true
   timeout: 900
 case_studies/etfs/11c_conditional_autoencoder:
-  skip: true
-  skip_reason: 'TEMPORARY: DL training (CAE) 300s timeout under trimmed test-data'
+  # Un-skipped when 11e moved onto the research boundary (ml4t/agent-workspace#991).
+  # The skip_reason these three carried - "TEMPORARY: DL training 300s timeout under
+  # trimmed test-data" - was never what failed them, and a TEMPORARY skip whose stated
+  # cost is runtime never gets revisited because the notebook getting faster cannot help.
+  # What fails them is ml4t/agent-workspace#926: features/model_based.parquet carries ONE
+  # fold geometry, the primary label's, and a variant label's fold-0 validation window
+  # runs 16 sessions past the artifact's last fold-0 date. validate_temporal_alignment
+  # then measures 231/247 = 93.5% against a 0.95 floor and raises.
+  #
+  # LABELS pins each run to the primary label, whose geometry IS the artifact's, so the
+  # notebook is exercised here instead of not at all. It is a scheduling restriction and
+  # not a fix: when #926 lands and the artifact carries per-label geometry, delete the
+  # LABELS line and these fit both declared labels in CI. POPULATION_NAME travels with it
+  # because a narrowed run declares a different member set and cannot publish the
+  # canonical population. DEVICE is cpu because config/setup.yaml declares this family on
+  # cuda and the library refuses to substitute; the device is inside the training identity,
+  # so the CPU fit publishes under its own name. n_epochs stays out - preset_patches.py
+  # already reduces these presets and declaring it here would replace that patch.
+  parameters:
+    DEVICE: cpu
+    LABELS: ['fwd_ret_21d']
+    POPULATION_NAME: etfs-cae-preview
+    PREVIEW_REDUCTIONS:
+      max_symbols: 5
+  timeout: 900
 case_studies/etfs/11d_stochastic_discount_factor:
+  # Still skipped, but not for the reason it used to claim. The old skip_reason said
+  # "TEMPORARY: DL training (SDF) 300s timeout under trimmed test-data"; the timeout is not
+  # what fails it. It is the only latent member that loads the initial-release macro panel
+  # config/setup.yaml declares (modeling.latent_factors.macro_context.source:
+  # alfred_initial_release), and that fixture does not exist in the test-data repo:
+  # data/macro/ ships fred_macro{,_raw,_dictionary,_raw_dictionary,_metadata}.parquet and no
+  # fred_macro_initial_release.parquet. Not gitignored - never built. So this cannot be
+  # un-skipped by any parameter choice until that fixture is built; filed as ml4t/agent-workspace#1035.
+  #
+  # 11c and 11e above ARE un-skipped: they do not read the macro panel, and their own
+  # blocker (#926) is worked around by pinning them to the primary label.
   skip: true
-  skip_reason: 'TEMPORARY: DL training (SDF) 300s timeout under trimmed test-data'
+  skip_reason: 'no fred_macro_initial_release.parquet in the test-data repo; SDF is the one latent member that reads the declared initial-release macro panel (ml4t/agent-workspace#1035)'
 case_studies/etfs/11e_supervised_autoencoder:
-  skip: true
-  skip_reason: 'TEMPORARY: DL training (SAE) 300s timeout under trimmed test-data'
+  # Same restriction and the same reason as 11c above.
+  parameters:
+    DEVICE: cpu
+    LABELS: ['fwd_ret_21d']
+    POPULATION_NAME: etfs-sae-preview
+    PREVIEW_REDUCTIONS:
+      max_symbols: 5
+  timeout: 900
 case_studies/etfs/12_causal_dml:
   parameters:
     CV_FOLDS: 2


### PR DESCRIPTION
Three etfs latent-factor notebooks carried

    skip_reason: 'TEMPORARY: DL training (CAE|SDF|SAE) 300s timeout under trimmed test-data'

and the timeout was never what failed any of them. That is what made the skips permanent
rather than temporary: a skip whose stated cost is runtime gets revisited when the notebook
gets faster, and none of these three was ever going to get faster into a green run.

**`11c` and `11e` are un-skipped and pass.** `11e` at 4m22s against its 900s cap. `cs-etfs`
now exercises two notebooks it did not run at all.

## What actually failed 11c and 11e

ml4t/agent-workspace#926: `features/model_based.parquet` carries **one** fold geometry, the
primary label's, and a variant label's windows run past it. Measured on the etfs fixture
artifact, `fwd_ret_5d` windows against the artifact's fold-k dates:

| fold | missing left | missing right | artifact ends | 21d val_end | 5d val_end |
|---|---|---|---|---|---|
| 0 | 0 | **16** | 2023-11-29 | 2023-11-29 | 2023-12-21 |
| 1-7 | 0 | 0 | | both agree | |

`validate_temporal_alignment` measures 231/247 = 93.5% against a 0.95 floor and raises. Fold 0
only, because it is the one fold whose `val_end` is not clamped by the holdout boundary at
2024-01-01. The 16 sessions are the difference between a 5-day and a 21-day label buffer.

This is the same defect #926 found at the left edge, where the artifact begins at the primary's
`train_start` and the variant's is earlier in every fold. One artifact geometry, two ends.

**Worth noting against #926's scope table**, which lists etfs as the case study where this is
"not live - `fwd_ret_5d` is shorter, so stale not leaking": that is right about leakage and
incomplete about consequence. `validate_temporal_alignment` is a coverage guard, not a leakage
guard, so the shorter variant that cannot leak is exactly the one that trips it.

It surfaced now because #991 (public #753) moved `11e` onto the research boundary, where it
fits both declared labels. The legacy runner fitted the primary only.

## The restriction, and when it comes off

`LABELS: ['fwd_ret_21d']` pins each run to the label whose geometry **is** the artifact's.
**This is a scheduling restriction and not a fix.** When #926 lands and the artifact carries
per-label geometry, delete the `LABELS` line and both notebooks fit their full declared menu
in CI. Until then `cs-etfs` exercises one label of two for these two, which is two more
notebooks than before and none of the coverage it had.

`POPULATION_NAME` travels with `LABELS` because a narrowed run declares a different member set
and cannot publish the canonical population. `DEVICE: cpu` because `config/setup.yaml` declares
this family on cuda and the library refuses to substitute a CPU for a requested card, and the
device is inside the training identity. `n_epochs` is deliberately absent: `preset_patches.py`
already reduces these presets and declaring it here would replace that patch with the full
schedule.

## 11d stays skipped, for a reason that is now true

It is the one latent member that loads the initial-release macro panel `config/setup.yaml`
declares (`modeling.latent_factors.macro_context.source: alfred_initial_release`), and that
fixture does not exist:

```
$ git ls-files data/macro/          # ml4t/third-edition-test-data
data/macro/fred_macro.parquet
data/macro/fred_macro_dictionary.parquet
data/macro/fred_macro_metadata.parquet
data/macro/fred_macro_raw.parquet
data/macro/fred_macro_raw_dictionary.parquet
$ git check-ignore -v data/macro/fred_macro_initial_release.parquet
(nothing - not ignored, never built)
```

No parameter choice reaches a green run, and substituting `fred_macro.parquet` would be a
look-ahead: `alfred_initial_release` is the point-in-time vintage and that file is the
finalized revised series. Filed with the measurement as ml4t/agent-workspace#1035, and the
`skip_reason` and comment now name it instead of a timeout.

## Verification

```
$ pytest tests/test_case_studies.py -k "etfs and (11c or 11d or 11e)"
1 failed, 2 passed          # the failure is 11d, on the missing macro fixture above
$ pytest tests/test_case_studies.py -k "etfs and 11e"
1 passed in 262.73s
```

Closes ml4t/agent-workspace#1031. Refs #926, #1035.
