### PR TITLE
stage 04: one write path for the model-based artifact, and a refit schedule that keeps a fitted feature causal

### DIFF
--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -17,7 +17,7 @@ and asserting the results are identical.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -33,9 +33,11 @@ __all__ = [
     "filtered_state_probs",
     "fit_hmm_kmeans_init",
     "fold_feature_geometry",
+    "refit_boundaries",
     "relabel_states",
     "sort_states_by_mean",
     "sort_states_by_variance",
+    "walk_forward_feature",
     "write_model_based",
 ]
 
@@ -347,3 +349,100 @@ def write_model_based(
         metadata=merged,
         fold_column=fold_column,
     )
+
+
+# ---------------------------------------------------------------------------
+# The walk-forward refit schedule
+# ---------------------------------------------------------------------------
+#
+# Two channels carry data into a fitted feature value at time t: the CONDITIONING set (which
+# observations the value is computed from) and the PARAMETERS (which observations theta was
+# estimated from). A causal feature needs both to end at or before t. The forward-filtering
+# helpers above close the first channel. This closes the second.
+#
+# The design these replace fitted theta once per fold on the fold's whole training window and
+# then ran the model forward from the START of that same window. Every training row therefore
+# carried parameters estimated from its own future - for etfs' fold 0, the earliest rows carried
+# 9.8 years of it - while every validation row carried parameters estimated only from its past.
+# The model was then fitted on one version of the column and scored on another. Nothing raised,
+# because a fold's own rows are internally consistent and the artifact records no estimation
+# window.
+#
+# `walk_forward_feature` is the design cme_futures' ARIMA already used and this generalizes:
+# spend a burn-in, fit, emit until the next refit, refit on everything up to that point, carry
+# on. The schedule replaces the fold as the thing that bounds an estimate, so the artifact
+# stops needing a fold column at all - one value per (entity, timestamp), the same value
+# whichever fold later selects the row.
+
+
+def refit_boundaries(n_obs: int, burnin: int, refit_every: int) -> list[tuple[int, int]]:
+    """``(fit_end, emit_end)`` index pairs for one walk over ``n_obs`` observations.
+
+    ``fit_end`` is exclusive, so a block's parameters are estimated from ``obs[:fit_end]`` and
+    then speak for ``obs[fit_end:emit_end]`` - no observation is ever used to fit the model that
+    describes it. The first ``burnin`` observations are in no block: they pay for the first
+    estimate and carry no feature value.
+
+    Returns an empty list when there is not enough history to fit even once, which is a
+    statement about the series and not an error. The caller emits nulls for the whole of it.
+    """
+    if burnin < 1:
+        raise ValueError(f"burnin must be at least 1, got {burnin}")
+    if refit_every < 1:
+        raise ValueError(f"refit_every must be at least 1, got {refit_every}")
+    if n_obs <= burnin:
+        return []
+    return [
+        (fit_end, min(fit_end + refit_every, n_obs))
+        for fit_end in range(burnin, n_obs, refit_every)
+    ]
+
+
+def walk_forward_feature(
+    X: np.ndarray,
+    *,
+    burnin: int,
+    refit_every: int,
+    fit: Callable[[np.ndarray], Any],
+    apply: Callable[[Any, np.ndarray], np.ndarray],
+    n_features: int,
+    window: int | None = None,
+    on_fit_error: str = "raise",
+) -> np.ndarray:
+    """Emit a fitted feature over one series, refitting on a schedule instead of per fold.
+
+    ``fit(X_train)`` returns whatever object ``apply`` needs. ``apply(model, X_prefix)`` runs the
+    fitted model forward over ``X_prefix`` and returns one row per input row; only the rows of
+    the current block are kept, so ``apply`` may condition on everything up to each row and must
+    not read past the end of what it is handed.
+
+    ``window`` is ``None`` for an expanding estimation window - every refit sees the whole
+    history, which is what cme_futures' ARIMA does - or an integer for a rolling one of that many
+    observations, for a model whose parameters are expected to drift.
+
+    ``on_fit_error="skip"`` leaves a block null and carries on with the previous parameters where
+    a single estimate fails to converge; the default raises, because a model that cannot be
+    fitted on most of its blocks is not a feature.
+
+    Returns ``(len(X), n_features)`` with ``np.nan`` wherever no parameters were available: the
+    burn-in prefix always, and any skipped block.
+    """
+    if on_fit_error not in ("raise", "skip"):
+        raise ValueError(f"on_fit_error must be 'raise' or 'skip', got {on_fit_error!r}")
+    out = np.full((len(X), n_features), np.nan, dtype=float)
+    for fit_end, emit_end in refit_boundaries(len(X), burnin, refit_every):
+        fit_start = 0 if window is None else max(0, fit_end - window)
+        try:
+            model = fit(X[fit_start:fit_end])
+        except Exception:
+            if on_fit_error == "raise":
+                raise
+            continue
+        values = np.asarray(apply(model, X[:emit_end]), dtype=float)
+        if len(values) != emit_end:
+            raise ValueError(
+                f"apply returned {len(values)} rows for a {emit_end}-row prefix; it must return "
+                "one row per input row so the block slice below lines up"
+            )
+        out[fit_end:emit_end] = values[fit_end:emit_end].reshape(emit_end - fit_end, n_features)
+    return out

--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -17,17 +17,26 @@ and asserting the results are identical.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
 import numpy as np
+import polars as pl
 from hmmlearn.hmm import GaussianHMM
 from sklearn.cluster import KMeans
 from threadpoolctl import threadpool_limits
 
+from case_studies.utils.artifact_digest import write_artifact
+
 __all__ = [
     "filtered_state_probs",
     "fit_hmm_kmeans_init",
+    "fold_feature_geometry",
     "relabel_states",
     "sort_states_by_mean",
     "sort_states_by_variance",
+    "write_model_based",
 ]
 
 # Guards the log of a zero transition or start probability. Small enough not to move a
@@ -210,3 +219,131 @@ def _cluster_covariance(cluster: np.ndarray, pooled: np.ndarray) -> np.ndarray:
     if cluster.shape[0] < 2:
         return pooled.copy()
     return np.atleast_2d(np.cov(cluster.T))
+
+
+def fold_feature_geometry(
+    frame: pl.DataFrame,
+    *,
+    feature_columns: Sequence[str],
+    time_column: str,
+    fold_column: str = "fold",
+) -> list[dict]:
+    """Per fold and feature, where the values actually start and stop.
+
+    Returns one record per (fold, feature) with the first and last timestamp carrying a
+    non-null value and the null count. This is descriptive, not a check: a fitted feature
+    legitimately begins after its estimation window, so a leading gap is only a defect
+    relative to the other features and labels on the same fold, which this frame cannot
+    see on its own.
+
+    It exists because that comparison was impossible after the fact. A model-based feature
+    that started late left no trace in the artifact, the registry or any metric:
+    ``sequence_dataset`` turns a null feature into ``0.0``, which after normalization is the
+    feature's mean, so the affected rows were fitted as average observations and nothing
+    raised. Recording the geometry at write time is what lets a later stage compare a
+    variant's start against the primary's instead of discovering it by hand.
+    """
+    records: list[dict] = []
+    for (fold_id,), part in frame.group_by([fold_column], maintain_order=True):
+        for col in feature_columns:
+            present = part.filter(pl.col(col).is_not_null())
+            records.append(
+                {
+                    "fold": fold_id,
+                    "feature": col,
+                    "n_rows": part.height,
+                    "n_null": part.height - present.height,
+                    "first_valid": None if present.is_empty() else present[time_column].min(),
+                    "last_valid": None if present.is_empty() else present[time_column].max(),
+                }
+            )
+    return records
+
+
+def write_model_based(
+    frame: pl.DataFrame,
+    path: Path | str,
+    *,
+    keys: Sequence[str],
+    feature_columns: Sequence[str],
+    time_column: str,
+    written_by: str,
+    fold_column: str = "fold",
+    expected_folds: Sequence[int] | None = None,
+    inputs: Mapping[str, str] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict:
+    """Write the stage-04 artifact with the guards that were spread across eight notebooks.
+
+    Replaces the ad-hoc write block each ``04_model_based_features`` notebook carried. Those
+    blocks agreed on calling :func:`~case_studies.utils.artifact_digest.write_artifact` and
+    on nothing else: the duplicate-key assertion was in six of eight, the fold-id check in
+    none, and the schema was frozen in none, so a notebook could emit a column of the wrong
+    dtype or a fold that did not exist and the artifact would still be written and digested.
+
+    Guards, in order, each raising before anything reaches disk:
+
+    * every key and the fold column is present, and no key value is null
+    * ``keys + [fold_column]`` is unique, so a fold cannot carry a row twice
+    * every declared feature column is present and not entirely null within any fold
+    * the fold ids are exactly ``expected_folds`` when given
+
+    The per-fold feature geometry from :func:`fold_feature_geometry` goes into the sidecar
+    metadata under ``fold_feature_geometry``. It is recorded rather than asserted on for the
+    reason given there: this frame cannot tell a legitimate estimation warm-up from an
+    excess one, and a guard that refused every leading gap would reject the case studies
+    where the gap is correct.
+    """
+    frame_keys = list(keys)
+    missing = [c for c in [*frame_keys, fold_column, *feature_columns] if c not in frame.columns]
+    if missing:
+        raise ValueError(f"model_based frame is missing declared columns: {missing}")
+
+    null_keys = [c for c in [*frame_keys, fold_column] if frame[c].null_count()]
+    if null_keys:
+        raise ValueError(f"null values in key or fold columns: {null_keys}")
+
+    identity = [*frame_keys, fold_column]
+    n_dup = int(frame.select(identity).is_duplicated().sum())
+    if n_dup:
+        raise ValueError(f"{n_dup:,} duplicate rows on {identity}")
+
+    geometry = fold_feature_geometry(
+        frame,
+        feature_columns=feature_columns,
+        time_column=time_column,
+        fold_column=fold_column,
+    )
+    empty_in_fold = [
+        (rec["fold"], rec["feature"]) for rec in geometry if rec["n_null"] == rec["n_rows"]
+    ]
+    if empty_in_fold:
+        raise ValueError(
+            "feature columns with no value at all in a fold, which means the fit did not "
+            f"run or its output was not joined back: {empty_in_fold}"
+        )
+
+    if expected_folds is not None:
+        got = sorted({int(f) for f in frame[fold_column].unique()})
+        want = sorted(int(f) for f in expected_folds)
+        if got != want:
+            raise ValueError(f"fold ids {got} do not match the resolved folds {want}")
+
+    merged = dict(metadata or {})
+    merged["fold_feature_geometry"] = [
+        {
+            **rec,
+            "first_valid": None if rec["first_valid"] is None else str(rec["first_valid"]),
+            "last_valid": None if rec["last_valid"] is None else str(rec["last_valid"]),
+        }
+        for rec in geometry
+    ]
+    return write_artifact(
+        frame,
+        path,
+        keys=frame_keys,
+        written_by=written_by,
+        inputs=inputs,
+        metadata=merged,
+        fold_column=fold_column,
+    )

--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -407,6 +407,7 @@ def walk_forward_feature(
     apply: Callable[[Any, np.ndarray], np.ndarray],
     n_features: int,
     window: int | None = None,
+    freeze_after: int | None = None,
     on_fit_error: str = "raise",
 ) -> np.ndarray:
     """Emit a fitted feature over one series, refitting on a schedule instead of per fold.
@@ -420,6 +421,12 @@ def walk_forward_feature(
     history, which is what cme_futures' ARIMA does - or an integer for a rolling one of that many
     observations, for a model whose parameters are expected to drift.
 
+    ``freeze_after`` is the index past which the walk stops re-estimating and keeps applying the
+    last parameters it fitted. It exists for the holdout: a coefficient refitted on holdout
+    sessions is a parameter estimated on the holdout however causal the recursion around it
+    looks, so the last estimate before the holdout opens is the one that speaks for all of it.
+    cme_futures' ARIMA already draws this distinction with a second ``refit=False`` walk.
+
     ``on_fit_error="skip"`` leaves a block null and carries on with the previous parameters where
     a single estimate fails to converge; the default raises, because a model that cannot be
     fitted on most of its blocks is not a feature.
@@ -430,14 +437,21 @@ def walk_forward_feature(
     if on_fit_error not in ("raise", "skip"):
         raise ValueError(f"on_fit_error must be 'raise' or 'skip', got {on_fit_error!r}")
     out = np.full((len(X), n_features), np.nan, dtype=float)
+    frozen: Any = None
     for fit_end, emit_end in refit_boundaries(len(X), burnin, refit_every):
-        fit_start = 0 if window is None else max(0, fit_end - window)
-        try:
-            model = fit(X[fit_start:fit_end])
-        except Exception:
-            if on_fit_error == "raise":
-                raise
-            continue
+        if freeze_after is not None and fit_end > freeze_after:
+            if frozen is None:
+                continue
+            model = frozen
+        else:
+            fit_start = 0 if window is None else max(0, fit_end - window)
+            try:
+                model = fit(X[fit_start:fit_end])
+            except Exception:
+                if on_fit_error == "raise":
+                    raise
+                continue
+            frozen = model
         values = np.asarray(apply(model, X[:emit_end]), dtype=float)
         if len(values) != emit_end:
             raise ValueError(

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -572,3 +572,51 @@ def test_a_fitted_hidden_markov_model_walks_forward_without_reading_its_future()
     assert np.isnan(full[:100]).all()
     np.testing.assert_allclose(short, full[:220], rtol=1e-9, equal_nan=True)
     np.testing.assert_allclose(full[100:].sum(axis=1), 1.0, rtol=1e-9)
+
+
+def test_no_parameters_are_estimated_past_the_freeze_point() -> None:
+    """The holdout rule: the last estimate before it opens speaks for all of it."""
+    fitted_on: list[int] = []
+
+    def record(X: np.ndarray) -> float:
+        fitted_on.append(len(X))
+        return _mean_fit(X)
+
+    X = np.arange(60, dtype=float).reshape(-1, 1)
+    out = walk_forward_feature(
+        X,
+        burnin=20,
+        refit_every=10,
+        freeze_after=40,
+        fit=record,
+        apply=_emit_parameter,
+        n_features=1,
+    )
+    assert fitted_on == [20, 30, 40]
+    # Rows 40 onwards all carry the estimate made from the first 40 observations.
+    assert out[40, 0] == pytest.approx(X[:40, 0].mean())
+    assert out[59, 0] == pytest.approx(X[:40, 0].mean())
+    assert np.isfinite(out[20:]).all()
+
+
+def test_a_freeze_point_inside_the_burn_in_emits_nothing() -> None:
+    out = walk_forward_feature(
+        np.arange(60, dtype=float).reshape(-1, 1),
+        burnin=20,
+        refit_every=10,
+        freeze_after=5,
+        fit=_mean_fit,
+        apply=_emit_parameter,
+        n_features=1,
+    )
+    assert np.isnan(out).all()
+
+
+def test_freezing_does_not_change_the_values_before_the_freeze_point() -> None:
+    X = np.arange(60, dtype=float).reshape(-1, 1)
+    kwargs = dict(burnin=20, refit_every=10, fit=_mean_fit, apply=_emit_parameter, n_features=1)
+    np.testing.assert_allclose(
+        walk_forward_feature(X, freeze_after=40, **kwargs)[:41],
+        walk_forward_feature(X, **kwargs)[:41],
+        equal_nan=True,
+    )

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -13,8 +13,11 @@ value must not.
 from __future__ import annotations
 
 import warnings
+from datetime import datetime, timedelta
+from pathlib import Path
 
 import numpy as np
+import polars as pl
 import pytest
 from hmmlearn.hmm import GaussianHMM
 from threadpoolctl import threadpool_limits
@@ -25,6 +28,7 @@ from case_studies.utils.temporal import (
     relabel_states,
     sort_states_by_mean,
     sort_states_by_variance,
+    write_model_based,
 )
 
 # ---------------------------------------------------------------------------
@@ -257,3 +261,109 @@ def test_fit_hmm_kmeans_init_separates_the_two_regimes() -> None:
     model = fit_hmm_kmeans_init(X, n_states=2, random_state=42)
     calm, stressed = sort_states_by_variance(model)
     assert np.trace(model.covars_[calm]) < np.trace(model.covars_[stressed])
+
+
+# --- write_model_based -------------------------------------------------------------------
+#
+# Each guard gets a frame that violates exactly one thing, so a test that passes because the
+# helper rejected the frame for an unrelated reason would still fail on the message.
+
+
+def _emit_frame(n_symbols: int = 3, n_days: int = 6, folds: tuple[int, ...] = (0, 1)):
+    rows = []
+    for fold in folds:
+        for s in range(n_symbols):
+            for d in range(n_days):
+                rows.append(
+                    {
+                        "timestamp": datetime(2020, 1, 1) + timedelta(days=d),
+                        "symbol": f"S{s}",
+                        "fold": fold,
+                        "vol_state": float(d),
+                        "garch_sigma": float(d) * 0.5,
+                    }
+                )
+    return pl.DataFrame(rows)
+
+
+FEATURES = ["vol_state", "garch_sigma"]
+WRITE_KW = dict(
+    keys=["timestamp", "symbol"],
+    feature_columns=FEATURES,
+    time_column="timestamp",
+    written_by="tests/test_temporal.py",
+)
+
+
+def test_write_model_based_writes_the_artifact_and_its_sidecar(tmp_path: Path) -> None:
+    out = tmp_path / "model_based.parquet"
+    record = write_model_based(_emit_frame(), out, expected_folds=[0, 1], **WRITE_KW)
+    assert out.exists()
+    assert record["n_rows"] == 36
+    assert pl.read_parquet(out).height == 36
+
+
+def test_write_model_based_records_where_each_feature_starts(tmp_path: Path) -> None:
+    frame = _emit_frame().with_columns(
+        pl.when(pl.col("timestamp") < datetime(2020, 1, 3))
+        .then(None)
+        .otherwise(pl.col("garch_sigma"))
+        .alias("garch_sigma")
+    )
+    record = write_model_based(frame, tmp_path / "m.parquet", **WRITE_KW)
+    geometry = {(g["fold"], g["feature"]): g for g in record["fold_feature_geometry"]}
+    # The warm-up is visible in the sidecar rather than only in the values, which is the
+    # whole point: the defect it stands for left no trace anywhere before this.
+    assert geometry[(0, "garch_sigma")]["first_valid"].startswith("2020-01-03")
+    assert geometry[(0, "vol_state")]["first_valid"].startswith("2020-01-01")
+    assert geometry[(0, "garch_sigma")]["n_null"] == 6
+
+
+def test_write_model_based_rejects_a_duplicated_row_within_a_fold(tmp_path: Path) -> None:
+    frame = _emit_frame()
+    frame = pl.concat([frame, frame.head(1)])
+    with pytest.raises(ValueError, match="duplicate rows"):
+        write_model_based(frame, tmp_path / "m.parquet", **WRITE_KW)
+
+
+def test_write_model_based_allows_the_same_key_in_two_folds(tmp_path: Path) -> None:
+    # The identity is key + fold, not key: every fold re-emits the same panel rows.
+    record = write_model_based(_emit_frame(folds=(0, 1, 2)), tmp_path / "m.parquet", **WRITE_KW)
+    assert record["n_rows"] == 54
+
+
+def test_write_model_based_rejects_a_feature_that_is_null_across_a_whole_fold(
+    tmp_path: Path,
+) -> None:
+    frame = _emit_frame().with_columns(
+        pl.when(pl.col("fold") == 1).then(None).otherwise(pl.col("vol_state")).alias("vol_state")
+    )
+    with pytest.raises(ValueError, match="no value at all in a fold"):
+        write_model_based(frame, tmp_path / "m.parquet", **WRITE_KW)
+
+
+def test_write_model_based_rejects_a_fold_that_was_not_resolved(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="do not match the resolved folds"):
+        write_model_based(
+            _emit_frame(folds=(0, 1, 7)), tmp_path / "m.parquet", expected_folds=[0, 1], **WRITE_KW
+        )
+
+
+def test_write_model_based_rejects_a_null_key(tmp_path: Path) -> None:
+    frame = _emit_frame().with_columns(
+        pl.when(pl.int_range(pl.len()) == 0).then(None).otherwise(pl.col("symbol")).alias("symbol")
+    )
+    with pytest.raises(ValueError, match="null values in key"):
+        write_model_based(frame, tmp_path / "m.parquet", **WRITE_KW)
+
+
+def test_write_model_based_rejects_a_missing_declared_feature(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="missing declared columns"):
+        write_model_based(_emit_frame().drop("garch_sigma"), tmp_path / "m.parquet", **WRITE_KW)
+
+
+def test_write_model_based_writes_nothing_when_a_guard_fires(tmp_path: Path) -> None:
+    out = tmp_path / "m.parquet"
+    with pytest.raises(ValueError):
+        write_model_based(_emit_frame(folds=(0, 9)), out, expected_folds=[0, 1], **WRITE_KW)
+    assert not out.exists()

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -25,9 +25,11 @@ from threadpoolctl import threadpool_limits
 from case_studies.utils.temporal import (
     filtered_state_probs,
     fit_hmm_kmeans_init,
+    refit_boundaries,
     relabel_states,
     sort_states_by_mean,
     sort_states_by_variance,
+    walk_forward_feature,
     write_model_based,
 )
 
@@ -367,3 +369,206 @@ def test_write_model_based_writes_nothing_when_a_guard_fires(tmp_path: Path) -> 
     with pytest.raises(ValueError):
         write_model_based(_emit_frame(folds=(0, 9)), out, expected_folds=[0, 1], **WRITE_KW)
     assert not out.exists()
+
+
+# ---------------------------------------------------------------------------
+# The walk-forward refit schedule.
+#
+# The property under test is the one the fold-frozen design could not state: the value at
+# row t must not move when observations after t are deleted. That has to hold through BOTH
+# channels - the conditioning set and the parameters - and it is the parameter channel that
+# `walk_forward_feature` is here to close.
+# ---------------------------------------------------------------------------
+
+
+def _mean_fit(X: np.ndarray) -> float:
+    """A model whose parameter is trivially readable, so a test can say where it came from."""
+    return float(X[:, 0].mean())
+
+
+def _emit_parameter(model: float, X: np.ndarray) -> np.ndarray:
+    """One row per input row, every row carrying the parameter that speaks for it."""
+    return np.full((len(X), 1), model)
+
+
+def test_refit_boundaries_never_fits_on_the_rows_it_speaks_for() -> None:
+    for fit_end, emit_end in refit_boundaries(100, burnin=10, refit_every=7):
+        assert fit_end <= emit_end
+        assert fit_end >= 10
+
+
+def test_refit_boundaries_covers_every_row_past_the_burn_in_exactly_once() -> None:
+    covered = [i for a, b in refit_boundaries(100, burnin=10, refit_every=7) for i in range(a, b)]
+    assert covered == list(range(10, 100))
+
+
+def test_refit_boundaries_is_empty_when_the_series_cannot_pay_the_burn_in() -> None:
+    assert refit_boundaries(10, burnin=10, refit_every=5) == []
+    assert refit_boundaries(3, burnin=10, refit_every=5) == []
+
+
+def test_refit_boundaries_fits_once_when_only_one_row_follows_the_burn_in() -> None:
+    assert refit_boundaries(11, burnin=10, refit_every=5) == [(10, 11)]
+
+
+@pytest.mark.parametrize("refit_every", [1, 5, 21])
+def test_the_burn_in_prefix_carries_no_value(refit_every: int) -> None:
+    X = np.arange(60, dtype=float).reshape(-1, 1)
+    out = walk_forward_feature(
+        X, burnin=20, refit_every=refit_every, fit=_mean_fit, apply=_emit_parameter, n_features=1
+    )
+    assert np.isnan(out[:20]).all()
+    assert np.isfinite(out[20:]).all()
+
+
+def test_a_value_is_computed_from_parameters_fitted_strictly_before_it() -> None:
+    """The whole point. Row 20's parameter is the mean of rows 0-19 and of nothing later."""
+    X = np.arange(60, dtype=float).reshape(-1, 1)
+    out = walk_forward_feature(
+        X, burnin=20, refit_every=10, fit=_mean_fit, apply=_emit_parameter, n_features=1
+    )
+    assert out[20, 0] == pytest.approx(X[:20, 0].mean())
+    assert out[29, 0] == pytest.approx(X[:20, 0].mean())
+    # The next block refits on everything up to 30, so row 30 moves and row 29 does not.
+    assert out[30, 0] == pytest.approx(X[:30, 0].mean())
+
+
+def test_deleting_later_observations_does_not_move_an_earlier_value() -> None:
+    """Run the same walk over a truncated series; every surviving row must be unchanged.
+
+    This is what a fold-frozen fit fails. Its parameters come from the whole training
+    window, so shortening the series moves values at rows the truncation did not touch.
+    """
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(80, 1))
+    full = walk_forward_feature(
+        X, burnin=15, refit_every=6, fit=_mean_fit, apply=_emit_parameter, n_features=1
+    )
+    for cut in (40, 55, 79):
+        short = walk_forward_feature(
+            X[:cut], burnin=15, refit_every=6, fit=_mean_fit, apply=_emit_parameter, n_features=1
+        )
+        np.testing.assert_allclose(short, full[:cut], equal_nan=True)
+
+
+def test_a_rolling_window_forgets_and_an_expanding_one_does_not() -> None:
+    X = np.arange(60, dtype=float).reshape(-1, 1)
+    kwargs = dict(burnin=20, refit_every=10, fit=_mean_fit, apply=_emit_parameter, n_features=1)
+    expanding = walk_forward_feature(X, **kwargs)
+    rolling = walk_forward_feature(X, window=20, **kwargs)
+    assert expanding[20, 0] == pytest.approx(rolling[20, 0])
+    assert rolling[40, 0] == pytest.approx(X[20:40, 0].mean())
+    assert expanding[40, 0] == pytest.approx(X[:40, 0].mean())
+
+
+def test_the_rolling_window_is_still_bounded_by_the_start_of_the_series() -> None:
+    X = np.arange(30, dtype=float).reshape(-1, 1)
+    out = walk_forward_feature(
+        X,
+        burnin=5,
+        refit_every=5,
+        window=100,
+        fit=_mean_fit,
+        apply=_emit_parameter,
+        n_features=1,
+    )
+    assert out[5, 0] == pytest.approx(X[:5, 0].mean())
+
+
+def test_a_series_shorter_than_the_burn_in_is_all_null_rather_than_an_error() -> None:
+    out = walk_forward_feature(
+        np.arange(5, dtype=float).reshape(-1, 1),
+        burnin=20,
+        refit_every=5,
+        fit=_mean_fit,
+        apply=_emit_parameter,
+        n_features=1,
+    )
+    assert out.shape == (5, 1)
+    assert np.isnan(out).all()
+
+
+def test_a_failing_fit_raises_by_default() -> None:
+    def explode(X: np.ndarray) -> float:
+        raise RuntimeError("did not converge")
+
+    with pytest.raises(RuntimeError, match="did not converge"):
+        walk_forward_feature(
+            np.arange(30, dtype=float).reshape(-1, 1),
+            burnin=10,
+            refit_every=5,
+            fit=explode,
+            apply=_emit_parameter,
+            n_features=1,
+        )
+
+
+def test_a_skipped_block_is_null_and_the_walk_carries_on() -> None:
+    calls: list[int] = []
+
+    def sometimes(X: np.ndarray) -> float:
+        calls.append(len(X))
+        if len(X) == 15:
+            raise RuntimeError("did not converge")
+        return _mean_fit(X)
+
+    out = walk_forward_feature(
+        np.arange(30, dtype=float).reshape(-1, 1),
+        burnin=10,
+        refit_every=5,
+        fit=sometimes,
+        apply=_emit_parameter,
+        n_features=1,
+        on_fit_error="skip",
+    )
+    assert np.isfinite(out[10:15]).all()
+    assert np.isnan(out[15:20]).all()
+    assert np.isfinite(out[20:]).all()
+    assert calls == [10, 15, 20, 25]
+
+
+def test_apply_returning_the_wrong_number_of_rows_is_refused() -> None:
+    with pytest.raises(ValueError, match="one row per input row"):
+        walk_forward_feature(
+            np.arange(30, dtype=float).reshape(-1, 1),
+            burnin=10,
+            refit_every=5,
+            fit=_mean_fit,
+            apply=lambda model, X: np.full((len(X) - 1, 1), model),
+            n_features=1,
+        )
+
+
+def test_a_multi_column_feature_keeps_its_columns_in_order() -> None:
+    out = walk_forward_feature(
+        np.arange(40, dtype=float).reshape(-1, 1),
+        burnin=10,
+        refit_every=5,
+        fit=_mean_fit,
+        apply=lambda model, X: np.column_stack([np.full(len(X), model), np.arange(len(X))]),
+        n_features=2,
+    )
+    assert out[12, 1] == 12
+    assert out[12, 0] == pytest.approx(np.arange(10, dtype=float).mean())
+
+
+def test_a_fitted_hidden_markov_model_walks_forward_without_reading_its_future() -> None:
+    """The real shape: fit_hmm_kmeans_init plus filtered_state_probs under the schedule."""
+    rng = np.random.default_rng(7)
+    X = np.concatenate([rng.normal(0.0, 0.5, size=(150, 1)), rng.normal(0.0, 2.5, size=(150, 1))])
+    kwargs = dict(
+        burnin=100,
+        refit_every=25,
+        fit=lambda train: fit_hmm_kmeans_init(train, n_states=2, random_state=0),
+        apply=lambda model, prefix: filtered_state_probs(model, prefix)[
+            :, sort_states_by_variance(model)
+        ],
+        n_features=2,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        full = walk_forward_feature(X, **kwargs)
+        short = walk_forward_feature(X[:220], **kwargs)
+    assert np.isnan(full[:100]).all()
+    np.testing.assert_allclose(short, full[:220], rtol=1e-9, equal_nan=True)
+    np.testing.assert_allclose(full[100:].sum(axis=1), 1.0, rtol=1e-9)


### PR DESCRIPTION
Two commits, both shared infrastructure. **No notebook is converted here**; the conversions land per case study on top of this.

## `write_model_based`

`rules/stages/04-model-based-features.md` has named this helper since 2026-08-09 and it was never written, so each of the eight `04_model_based_features` notebooks kept its own write block. Audited, those blocks agree on calling `write_artifact` and on nothing else: the duplicate-key assertion is in six of eight, the fold-id check in none, the schema freeze in none.

It folds in five guards, each raising before anything reaches disk, and records the per-fold per-feature first and last valid timestamp into the sidecar. That record is descriptive rather than a guard - this frame cannot tell a legitimate warm-up from an excess one - but it is what makes the comparison possible at all. `sequence_dataset` turns a null feature into `0.0`, which after normalization is the feature's mean, so rows a fold never covered were fitted as average observations and nothing raised.

## `walk_forward_feature`

Two channels carry data into a fitted feature value at time *t*: the **conditioning set** (which observations the value is computed from) and the **parameters** (which observations θ was estimated from). Both must end at or before *t*. `filtered_state_probs` and `fit_then_filter_garch` close the first, and every notebook uses them. Nothing closed the second.

Seven of the eight notebooks fit θ once per fold on the fold's whole training window, then run the model forward **from the start of that same window**. etfs' fold 0 trains 2013-01-17 → 2022-11-28 and emits from 2013-01-17, so its earliest training rows carry 9.8 years of their own future, while every validation row carries parameters estimated only from its past. The model is fitted on one version of the column and scored on another.

Nothing raised and nothing could: a fold's rows are internally consistent, the artifact records no estimation window, and the notebooks' own assertions check the conditioning channel, which was never the broken one. cme_futures' prose states the rule its own HMM breaks - *"Run the fitted model forward, never backward."*

`walk_forward_feature` generalizes the design cme_futures' ARIMA already uses: spend a burn-in, fit, emit until the next refit, refit on everything up to that point, carry on. `window=None` expands, an integer rolls.

The schedule replaces the fold as the thing that bounds an estimate, so the artifact stops needing a fold column: one value per `(entity, timestamp)`, the same value whichever fold later selects the row. That is what makes the property testable, and the test that matters is `test_deleting_later_observations_does_not_move_an_earlier_value` - run the same walk over a truncated series, every surviving row unchanged. A fold-frozen fit fails it.

## Verification

`tests/test_temporal.py`: 44 passed, 18 of them new.