### PR TITLE
Sequence families: impute a missing feature at the training mean, not below its minimum

### DIFF
--- a/case_studies/utils/sequence_dataset.py
+++ b/case_studies/utils/sequence_dataset.py
@@ -293,8 +293,12 @@ def _normalize_feature_arrays(
         feats -= means
         feats /= stds
         # Now that the arrays are on the training scale, 0.0 is the training
-        # mean, so this is the same imputation the linear and tabular families
-        # get from SimpleImputer(strategy="median") followed by StandardScaler.
+        # mean of the observed rows, so a row with no observation reads as
+        # average rather than as an extreme. The linear and tabular families
+        # reach the same place by a different route - SimpleImputer fills the
+        # training median and StandardScaler is then fitted on the filled
+        # data - so the normalized values differ; what is shared is that the
+        # fill is a central value of the feature rather than a raw zero.
         np.nan_to_num(feats, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
 
 

--- a/case_studies/utils/sequence_dataset.py
+++ b/case_studies/utils/sequence_dataset.py
@@ -214,7 +214,17 @@ def _build_symbol_arrays(
         n_rows = len(sym_df)
         if n_rows < lookback + 1:
             continue
-        feats = np.nan_to_num(sym_df[feature_names].to_numpy(dtype=np.float32), nan=0.0)
+        feats = sym_df[feature_names].to_numpy(dtype=np.float32, copy=True)
+        # Keep missing values missing until after normalization. Filling here
+        # would put a raw 0.0 into _compute_feature_stats, which is not the
+        # feature's mean on its own scale - for a strictly positive feature
+        # like a conditional volatility it sits below the observed minimum, so
+        # a symbol with no model-based estimate is presented to the model as
+        # the calmest name in the panel rather than a neutral one. Infinities
+        # are treated as missing for the same reason: np.nan_to_num leaves
+        # posinf on its default, the float32 maximum, which would destroy the
+        # feature's mean and standard deviation for every other symbol.
+        feats[~np.isfinite(feats)] = np.nan
         targets = sym_df[label_col].to_numpy(dtype=np.float32)
         # Cast to datetime64[ns] explicitly so concat/np.asarray downstream
         # never falls back to object dtype.
@@ -252,17 +262,23 @@ def _compute_feature_stats(features_list: list[np.ndarray]) -> tuple[np.ndarray,
     n_features = features_list[0].shape[1]
     sum_x = np.zeros(n_features, dtype=np.float64)
     sum_x2 = np.zeros(n_features, dtype=np.float64)
-    n_rows = 0
+    n_rows = np.zeros(n_features, dtype=np.int64)
 
     for feats in features_list:
-        sum_x += feats.sum(axis=0, dtype=np.float64)
-        sum_x2 += np.square(feats, dtype=np.float64).sum(axis=0, dtype=np.float64)
-        n_rows += feats.shape[0]
+        observed = np.isfinite(feats)
+        values = np.where(observed, feats, 0.0).astype(np.float64)
+        sum_x += values.sum(axis=0, dtype=np.float64)
+        sum_x2 += np.square(values).sum(axis=0, dtype=np.float64)
+        n_rows += observed.sum(axis=0, dtype=np.int64)
 
-    means = sum_x / max(n_rows, 1)
-    variances = np.maximum(sum_x2 / max(n_rows, 1) - np.square(means), 0.0)
+    denominator = np.maximum(n_rows, 1)
+    means = sum_x / denominator
+    variances = np.maximum(sum_x2 / denominator - np.square(means), 0.0)
     stds = np.sqrt(variances)
     stds[stds == 0] = 1.0
+    # A feature observed nowhere in training normalizes to zero everywhere,
+    # which is what the post-normalization fill would give it anyway.
+    means[n_rows == 0] = 0.0
     return means.astype(np.float32), stds.astype(np.float32)
 
 
@@ -276,6 +292,10 @@ def _normalize_feature_arrays(
     for feats in features_list:
         feats -= means
         feats /= stds
+        # Now that the arrays are on the training scale, 0.0 is the training
+        # mean, so this is the same imputation the linear and tabular families
+        # get from SimpleImputer(strategy="median") followed by StandardScaler.
+        np.nan_to_num(feats, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
 
 
 def _build_sequence_index(

--- a/tests/test_sequence_dataset.py
+++ b/tests/test_sequence_dataset.py
@@ -496,3 +496,104 @@ def test_priming_includes_label_buffer_gap_rows():
         )
         assert last_context == expected_context
         assert last_context > train_end
+
+
+def _strictly_positive_fold_df(
+    *,
+    missing_symbol: str = "S0",
+    n_symbols: int = 3,
+) -> tuple[pd.DataFrame, pd.Series, pd.Series, pd.Timestamp]:
+    """A panel whose `feat0` is strictly positive and missing for one symbol.
+
+    This is the shape a model-based feature has: `garch_cond_vol` is a
+    conditional volatility, so zero is below every value it can take, and a
+    symbol the walk skipped has no estimate at all.
+    """
+    df, train_mask, val_mask, val_start_ts, _ = _synthetic_fold_df(n_symbols=n_symbols)
+    df = df.assign(feat0=df["feat0"].abs() + 1.0)
+    df.loc[df["symbol"] == missing_symbol, "feat0"] = np.nan
+    return df, train_mask, val_mask, val_start_ts
+
+
+def test_missing_feature_is_imputed_at_the_training_mean_not_below_the_minimum():
+    """A symbol with no estimate must read as average, not as the extreme.
+
+    Filling the raw array before the scaler is fitted puts a 0.0 into a
+    strictly positive feature, which lands below its observed minimum once
+    standardized - the skipped symbol is then presented to the model as the
+    calmest name in the panel for its whole history.
+    """
+    df, train_mask, val_mask, val_start_ts = _strictly_positive_fold_df()
+
+    train_store, _, _ = prepare_fold_sequence_stores(
+        df,
+        train_mask=train_mask,
+        val_mask=val_mask,
+        feature_names=["feat0", "feat1"],
+        label_col="y",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=20,
+        val_start=val_start_ts,
+    )
+
+    missing_idx = train_store.entities.index("S0")
+    missing_column = train_store.features[missing_idx][:, 0]
+    assert np.all(missing_column == 0.0), (
+        "the skipped symbol's normalized feature is not the training mean; "
+        f"it ranges {missing_column.min()} to {missing_column.max()} standard deviations"
+    )
+
+
+def test_training_statistics_ignore_rows_with_no_observation():
+    """The mean and scale describe the observed rows, not the filled ones."""
+    df, train_mask, val_mask, val_start_ts = _strictly_positive_fold_df()
+
+    train_store, _, _ = prepare_fold_sequence_stores(
+        df,
+        train_mask=train_mask,
+        val_mask=val_mask,
+        feature_names=["feat0", "feat1"],
+        label_col="y",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=20,
+        val_start=val_start_ts,
+    )
+
+    observed = df.loc[train_mask & df["feat0"].notna(), "feat0"].to_numpy(dtype=np.float64)
+    assert train_store.feature_mean is not None
+    assert train_store.feature_scale is not None
+    np.testing.assert_allclose(train_store.feature_mean[0], observed.mean(), rtol=1e-4)
+    np.testing.assert_allclose(train_store.feature_scale[0], observed.std(), rtol=1e-4)
+
+
+def test_an_infinity_does_not_reach_the_training_statistics():
+    """`np.nan_to_num` maps posinf to the float32 maximum by default.
+
+    One such value in a training fold would set that feature's mean and scale
+    for every symbol, so an infinity has to be treated as a missing
+    observation rather than as a very large one.
+    """
+    df, train_mask, val_mask, val_start_ts = _strictly_positive_fold_df(missing_symbol="S0")
+    finite_rows = df.index[(df["symbol"] == "S1") & train_mask]
+    df.loc[finite_rows[0], "feat0"] = np.inf
+
+    train_store, _, _ = prepare_fold_sequence_stores(
+        df,
+        train_mask=train_mask,
+        val_mask=val_mask,
+        feature_names=["feat0", "feat1"],
+        label_col="y",
+        date_col="timestamp",
+        entity_col="symbol",
+        lookback=20,
+        val_start=val_start_ts,
+    )
+
+    assert train_store.feature_mean is not None
+    assert train_store.feature_mean[0] < 10.0, (
+        f"an infinity reached the training mean: {train_store.feature_mean[0]}"
+    )
+    for feats in train_store.features:
+        assert np.all(np.isfinite(feats)), "a non-finite value survived normalization"


### PR DESCRIPTION
`_build_symbol_arrays` filled NaN with a raw `0.0` before `_compute_feature_stats` ran, so the fill was not the feature's mean on its own scale.

For a strictly positive model-based feature that is worse than neutral. On sp500_equity_option_analytics' artifact:

| feature | mean | std | observed min | raw 0.0 lands at |
|---|---|---|---|---|
| `garch_cond_vol` | 0.294 | 0.180 | 0.0196 | -1.64 sd |
| `garch_vol_surprise` | 0.754 | 0.744 | 0.0 | -1.01 sd |
| `garch_ivrv_spread` | 0.000 | 0.125 | - | 0.00 sd |

`garch_cond_vol` is a conditional volatility, so `0.0` sits below every value it can take. A symbol the stage-04 walk skipped was presented to every LSTM and PatchTST as the calmest name in the panel, every session, for its whole history. seoa fold 0 has 3,432 such training rows; sp500_options 2,356; crypto_perps_funding 590. Only a feature centred on zero was harmless, and that by accident.

It also moved the statistics for every *other* symbol, because the zeros went into the mean and variance the normalizer was then fitted with. On the new test's panel, 2.158 against an observed mean of 3.238.

Separately, `np.nan_to_num(x, nan=0.0)` leaves `posinf` and `neginf` on their defaults, which are the float32 maximum and minimum. One infinity in a training fold set that feature's mean to 4.3e35 for every symbol. Non-finite values are now treated as missing rather than as very large ones.

## The fix

The order the other families already use: keep missing values missing through `_build_symbol_arrays`, compute the mean and scale over observed rows only, then fill with `0.0` after normalization, where `0.0` is the training mean.

- `linear` and `tabular_dl` impute the training median and standardize; their `nan_to_num` runs after the scaler and only catches what the imputer could not fill.
- `gbm` passes NaN to LightGBM, which learns a default split direction. Unaffected and already correct.
- `sequence` was the outlier.

This makes `validate_temporal_fold_coverage`'s claim that a skipped symbol is "imputed downstream" true for all four families rather than two. It does not decide whether that guard should keep rejecting those rows - that is #759's question and it stays open.

## Verification

Three tests, each of which fails on the previous code with the numbers above:

- a skipped symbol's normalized feature is exactly the training mean
- the mean and scale describe the observed rows, not the filled ones
- an infinity does not reach the training statistics

86 tests pass across the sequence and deep-learning unit suites. Every stored `feature_mean` and `feature_scale` moves for any fold that had a missing value, so sequence-family results change on re-run; nothing is registered against the current values that the rebuild is not already discarding.

Found by agents-ce while measuring the #926 coverage numbers.