### PR TITLE
A fold-free model-based artifact now names the features it contributed

### DIFF
--- a/tests/test_fold_free_temporal_features.py
+++ b/tests/test_fold_free_temporal_features.py
@@ -1,0 +1,154 @@
+"""A fold-free model-based artifact has to report which features it contributed.
+
+`load_modeling_dataset` records `temporal_feature_names` on the per-fold branch and,
+before this, recorded nothing on the fold-free one. The columns were joined into the
+panel and fitted on regardless, so a stage that produces one value per key - which is
+what a walk-forward refit schedule produces - reported no model-based features at all
+while its features were in use. `nasdaq100_microstructure` has been on that branch the
+whole time.
+
+Every consumer of the list also requires `temporal_by_fold`, which stays None here, so
+recording the names changes no fold substitution. What it changes is that a notebook
+asking which columns came from stage 04 gets an answer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.utils.artifact_digest import write_artifact
+
+TEMPORAL_FEATURES = ["garch_cond_vol", "kalman_trend"]
+
+
+def _case_study(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, by_fold: bool):
+    """A minimal case study whose model-based artifact is fold-keyed or is not."""
+    import utils.modeling as modeling
+
+    case_dir = tmp_path / "cs"
+    (case_dir / "config").mkdir(parents=True)
+    (case_dir / "features").mkdir()
+    (case_dir / "labels").mkdir()
+    (case_dir / "config" / "setup.yaml").write_text("labels:\n  primary: primary\n  buffer: 1D\n")
+
+    days = pl.datetime_range(datetime(2020, 1, 1), datetime(2020, 3, 1), "1d", eager=True).dt.date()
+    keys = {"timestamp": days, "symbol": ["AAA"] * len(days)}
+    write_artifact(
+        pl.DataFrame({**keys, "primary": [0.1] * len(days)}),
+        case_dir / "labels" / "primary.parquet",
+        keys=["timestamp", "symbol"],
+        written_by="test",
+    )
+    write_artifact(
+        pl.DataFrame({**keys, "feature": [1.0] * len(days)}),
+        case_dir / "features" / "financial.parquet",
+        keys=["timestamp", "symbol"],
+        written_by="test",
+    )
+
+    splits_for_artifact = [
+        {
+            "fold": fold,
+            "train_start": days[0],
+            "train_end": days[20],
+            "val_start": days[25],
+            "val_end": days[-1],
+        }
+        for fold in (0, 1)
+    ]
+    temporal = pl.DataFrame({**keys, **{name: [0.5] * len(days) for name in TEMPORAL_FEATURES}})
+    temporal_keys = ["timestamp", "symbol"]
+    if by_fold:
+        temporal = pl.concat([temporal.with_columns(pl.lit(fold).alias("fold")) for fold in (0, 1)])
+        temporal_keys = ["fold", *temporal_keys]
+        # The fold branch resolves each fold's window through a per-case-study
+        # resolver, and this synthetic case study is not one of the registered
+        # ones. The names the branch reports do not depend on that resolution.
+        import case_studies.utils.cv_window as cv_window
+
+        monkeypatch.setattr(
+            cv_window,
+            "temporal_artifact_fold_boundaries",
+            lambda *_a, **_k: splits_for_artifact,
+        )
+    write_artifact(
+        temporal,
+        case_dir / "features" / "model_based.parquet",
+        keys=temporal_keys,
+        written_by="test",
+    )
+
+    splits = [
+        {
+            "fold": 0,
+            "train_start": days[0],
+            "train_end": days[20],
+            "val_start": days[25],
+            "val_end": days[-1],
+        }
+    ]
+    monkeypatch.setattr(modeling, "get_case_study_dir", lambda _case_id: case_dir)
+    monkeypatch.setattr(modeling, "load_feature_spec", lambda *_args: {})
+    monkeypatch.setattr(modeling, "load_label_spec", lambda *_args: {})
+    monkeypatch.setattr(
+        modeling, "resolve_storage_path", lambda _case_id, _spec, fallback: case_dir / fallback
+    )
+    monkeypatch.setattr(modeling, "resolve_label_buffer", lambda *_args: "1D")
+    monkeypatch.setattr(modeling, "resolve_label_horizon", lambda *_args: "1D")
+    monkeypatch.setattr(modeling, "generate_cv_splits", lambda *_a, **_k: splits)
+    monkeypatch.setattr(modeling, "make_wf_config", lambda *_args, **_kwargs: None)
+    return modeling
+
+
+def test_a_fold_free_artifact_names_the_features_it_contributed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    modeling = _case_study(tmp_path, monkeypatch, by_fold=False)
+
+    mds = modeling.load_modeling_dataset("cs", "primary")
+
+    assert mds.temporal_by_fold is None, (
+        "the artifact has no fold column, so there is nothing to substitute"
+    )
+    assert sorted(mds.temporal_feature_names) == sorted(TEMPORAL_FEATURES)
+
+
+def test_the_named_features_are_the_ones_in_the_panel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The list is only worth anything if it describes the frame that comes back."""
+    modeling = _case_study(tmp_path, monkeypatch, by_fold=False)
+
+    mds = modeling.load_modeling_dataset("cs", "primary")
+
+    assert set(mds.temporal_feature_names) <= set(mds.dataset.columns)
+    for name in mds.temporal_feature_names:
+        assert mds.dataset[name].null_count() == 0
+
+
+def test_neither_join_key_is_reported_as_a_feature(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    modeling = _case_study(tmp_path, monkeypatch, by_fold=False)
+
+    mds = modeling.load_modeling_dataset("cs", "primary")
+
+    assert "timestamp" not in mds.temporal_feature_names
+    assert "symbol" not in mds.temporal_feature_names
+
+
+def test_a_fold_keyed_artifact_still_reports_the_same_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The two branches disagreed about this; they no longer do."""
+    modeling = _case_study(tmp_path, monkeypatch, by_fold=True)
+
+    mds = modeling.load_modeling_dataset("cs", "primary")
+
+    assert mds.temporal_by_fold is not None
+    assert sorted(mds.temporal_feature_names) == sorted(TEMPORAL_FEATURES)
+    assert "fold" not in mds.temporal_feature_names

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -900,7 +900,17 @@ def load_modeling_dataset(
             # Kept lazy. Materialising it here is what made a run hold every fold at once.
             temporal_by_fold_pd = temporal
         else:
-            # Legacy: single feature set, join directly
+            # Fold-free: one value per key, joined straight on. A refit schedule produces this
+            # shape, and so does any stage that fits nothing per fold.
+            #
+            # The names are recorded here for the same reason the fold branch records them:
+            # they say which of the panel's columns came from the model-based artifact. They
+            # were not recorded before, so a fold-free artifact reported no model-based
+            # features at all while its columns sat in `dataset` regardless - the features
+            # were used, and nothing that asks which ones they are could answer. Every
+            # consumer of this list also requires `temporal_by_fold`, which stays None here,
+            # so filling it in changes no fold substitution.
+            _temporal_feature_names = [c for c in temporal_columns if c not in set(_temporal_keys)]
             temporal_dedup = temporal.unique(subset=_temporal_keys, keep="last").collect()
             dataset = features.join(temporal_dedup, on=_temporal_keys, how="left", suffix="_t")
             del temporal_dedup


### PR DESCRIPTION
Extracted from #762 so the four stage-04 conversions that need it do not wait on one case study's notebook.

`load_modeling_dataset` records `temporal_feature_names` on the per-fold branch and recorded nothing on the fold-free one, whose only comment was `# Legacy: single feature set, join directly`. It is not legacy: a walk-forward refit schedule produces one value per key with no fold column, and that is the shape every stage 04 is being converted to.

The features were not dropped - they were joined into the panel and fitted on exactly as before. What came back was an empty list, so anything asking which of the panel's columns came from stage 04 was told "none" while five of them sat in the frame. `nasdaq100_microstructure` has been on this branch the whole time.

It surfaces as a contract assertion in the converted `05_evaluation` notebooks, which is how it was found:

> the loader reports [], not the five this stage contracts to produce

Every consumer of the list also requires `temporal_by_fold`, which stays `None` on this branch - `folds.py:473,635`, `linear.py:552,656,817`, `deep_learning.py:886,1246`, `latent_factors/adapter.py:430,597` all gate on both - so recording the names substitutes nothing that was not substituted before. No result moves.

## Verification

Four tests against a synthetic case study, one fold-free and one fold-keyed:

- a fold-free artifact names its features (fails on the previous code with `[] == ['garch_cond_vol', 'kalman_trend']`)
- the names describe columns that are actually in the returned panel
- neither join key is reported as a feature
- the fold-keyed branch reports the same names, and does not report `fold`

54 pass across this file and the three neighbouring temporal/artifact suites.