### PR TITLE
CI: retry the container git install instead of failing on one apt hiccup

### DIFF
--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -41,7 +41,15 @@ jobs:
 
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git openssh-client >/dev/null
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git openssh-client >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
 
@@ -109,7 +117,15 @@ jobs:
 
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git openssh-client >/dev/null
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git openssh-client >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
 
@@ -144,7 +160,15 @@ jobs:
 
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git openssh-client >/dev/null
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git openssh-client >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1016,7 +1016,15 @@ jobs:
       image: ml4t/ml4t:latest
     steps:
       - name: Install git (for checkout inside container)
-        run: apt-get update && apt-get install -y git
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update && apt-get install -y git && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
       - uses: actions/checkout@v6
       # The image is built from uv.lock and drifts from it silently the moment the
       # lock moves. It carried ml4t-models 0.1.0a4 for eleven days after the repo
@@ -1141,7 +1149,15 @@ jobs:
           fi
       - name: Install git (for checkout inside container)
         if: steps.reach.outputs.have_key
-        run: apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
         if: steps.reach.outputs.have_key
@@ -1239,7 +1255,15 @@ jobs:
           fi
       - name: Install git
         if: steps.reach.outputs.have_key
-        run: apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
         if: steps.reach.outputs.have_key
@@ -1326,7 +1350,15 @@ jobs:
           fi
       - name: Install git
         if: steps.reach.outputs.have_key
-        run: apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
         if: steps.reach.outputs.have_key
@@ -1413,7 +1445,15 @@ jobs:
           fi
       - name: Install git
         if: steps.reach.outputs.have_key
-        run: apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
         if: steps.reach.outputs.have_key
@@ -1547,7 +1587,14 @@ jobs:
       - name: Install git
         if: steps.reach.outputs.have_key
         run: |
-          apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null 2>&1 || true
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
         if: steps.reach.outputs.have_key

--- a/.github/workflows/weekly-external.yml
+++ b/.github/workflows/weekly-external.yml
@@ -48,7 +48,15 @@ jobs:
       issues: write
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
 
@@ -196,7 +204,15 @@ jobs:
       issues: write
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git >/dev/null
+        run: |
+          # A transient apt mirror failure used to kill the whole job.
+          for attempt in 1 2 3; do
+            apt-get update -qq && apt-get install -y -qq git >/dev/null && exit 0
+            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "::error::apt-get could not install git after three attempts"
+          exit 1
 
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Every job that runs inside the `ml4t` image installs git before checkout, and until now a single `apt-get update` failure against a Debian mirror ended the job at a step that has nothing to do with the change under test.

On 2026-09-05 that took out five case-study jobs across three unrelated pull requests inside one four-minute window:

| PR | job | failed step |
|---|---|---|
| #764 | `cs-fx_pairs` | `Install git` |
| #767 | `cs-cme_futures`, `cs-crypto_perps_funding`, `cs-fx_pairs` | `Install git` |
| #768 | `cs-us_firm_characteristics` | `Install git` |

All eight of those jobs are green on `main` at 1f245ced, and `Install git` was the only failed step in each. Each one costs a full notebook re-run to recover.

Eleven steps across `test.yml`, `full-test.yml` and `weekly-external.yml` now retry three times with a 15/30/45s backoff and fail loudly with an `::error::` annotation if all three fail, so a real breakage still stops the job and names itself.

`test-benchmark`'s copy ended in `|| true`, which swallowed the failure and let the job continue to a checkout that then failed for an unrelated-looking reason. The retry replaces it; the swallow is gone.