### PR TITLE
The GARCH helper takes gamma, so three more case studies can use it

### DIFF
--- a/case_studies/etfs/04_model_based_features.ipynb
+++ b/case_studies/etfs/04_model_based_features.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "170ab2d9",
+   "id": "32f9b139",
    "metadata": {
     "papermill": {
-     "duration": 0.013544,
-     "end_time": "2026-09-05T01:19:32.555122+00:00",
+     "duration": 0.013934,
+     "end_time": "2026-09-05T03:36:29.397026+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:32.541578+00:00",
+     "start_time": "2026-09-05T03:36:29.383092+00:00",
      "status": "completed"
     }
    },
@@ -70,9 +70,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "73138793",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "7ec366ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:29.407492Z",
+     "iopub.status.busy": "2026-09-05T03:36:29.407356Z",
+     "iopub.status.idle": "2026-09-05T03:36:32.786794Z",
+     "shell.execute_reply": "2026-09-05T03:36:32.786043Z"
+    },
+    "papermill": {
+     "duration": 3.383967,
+     "end_time": "2026-09-05T03:36:32.787241+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:29.403274+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"ETFs: model-based features from a walk-forward HMM, fractional differencing and GARCH.\"\"\"\n",
@@ -121,9 +135,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5db0d949",
+   "execution_count": 2,
+   "id": "3c06d3ad",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:32.792712Z",
+     "iopub.status.busy": "2026-09-05T03:36:32.792619Z",
+     "iopub.status.idle": "2026-09-05T03:36:32.794786Z",
+     "shell.execute_reply": "2026-09-05T03:36:32.794299Z"
+    },
+    "papermill": {
+     "duration": 0.005344,
+     "end_time": "2026-09-05T03:36:32.795062+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:32.789718+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -147,13 +174,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf5519cc",
+   "id": "81953541",
    "metadata": {
     "papermill": {
-     "duration": 0.002122,
-     "end_time": "2026-09-05T01:19:34.609451+00:00",
+     "duration": 0.002174,
+     "end_time": "2026-09-05T03:36:32.799493+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:34.607329+00:00",
+     "start_time": "2026-09-05T03:36:32.797319+00:00",
      "status": "completed"
     }
    },
@@ -167,10 +194,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d3ddf4cc",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "id": "8d514bdf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:32.804533Z",
+     "iopub.status.busy": "2026-09-05T03:36:32.804470Z",
+     "iopub.status.idle": "2026-09-05T03:36:32.850181Z",
+     "shell.execute_reply": "2026-09-05T03:36:32.849609Z"
+    },
+    "papermill": {
+     "duration": 0.048843,
+     "end_time": "2026-09-05T03:36:32.850562+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:32.801719+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Target: fwd_ret_21d, a return realized 21 trading sessions after the session it is attached to.\n",
+      "Regime model reads 21-session realized volatility, the shortest volatility window this case study declares.\n",
+      "Sessions before 2024-01-01 are available for development; 2024-01-01 to 2025-12-31 is the holdout and is read once, in the final notebook of the case study.\n",
+      "A validation session needs at least 20 ETFs quoting to be scored - the largest basket the strategy holds - and at least 63 such sessions before the coefficient across them is corrected for serial dependence.\n",
+      "Regime model: 756 sessions of burn-in, then refitted every 63 from 10 starting points, on the market series.\n",
+      "Volatility model: 504 sessions of burn-in per ETF, then refitted every 21.\n"
+     ]
+    }
+   ],
    "source": [
     "set_global_seeds(SEED)\n",
     "\n",
@@ -239,13 +293,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed27c278",
+   "id": "5743ba60",
    "metadata": {
     "papermill": {
-     "duration": 0.002228,
-     "end_time": "2026-09-05T01:19:34.667500+00:00",
+     "duration": 0.002472,
+     "end_time": "2026-09-05T03:36:32.855558+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:34.665272+00:00",
+     "start_time": "2026-09-05T03:36:32.853086+00:00",
      "status": "completed"
     }
    },
@@ -295,13 +349,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e25b317",
+   "id": "b4786f99",
    "metadata": {
     "papermill": {
-     "duration": 0.002168,
-     "end_time": "2026-09-05T01:19:34.671926+00:00",
+     "duration": 0.002198,
+     "end_time": "2026-09-05T03:36:32.860124+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:34.669758+00:00",
+     "start_time": "2026-09-05T03:36:32.857926+00:00",
      "status": "completed"
     }
    },
@@ -324,10 +378,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4162f22e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "fd8f9968",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:32.865509Z",
+     "iopub.status.busy": "2026-09-05T03:36:32.865414Z",
+     "iopub.status.idle": "2026-09-05T03:36:32.936132Z",
+     "shell.execute_reply": "2026-09-05T03:36:32.935655Z"
+    },
+    "papermill": {
+     "duration": 0.074193,
+     "end_time": "2026-09-05T03:36:32.936586+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:32.862393+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (9, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>category</th><th>ETFs</th><th>earliest start</th><th>latest start</th><th>shortest history</th></tr><tr><td>str</td><td>u32</td><td>date</td><td>date</td><td>u32</td></tr></thead><tbody><tr><td>&quot;international_developed&quot;</td><td>18</td><td>2006-01-03</td><td>2012-10-24</td><td>3315</td></tr><tr><td>&quot;fixed_income&quot;</td><td>15</td><td>2006-01-03</td><td>2013-06-04</td><td>3165</td></tr><tr><td>&quot;us_sectors&quot;</td><td>13</td><td>2006-01-03</td><td>2018-06-19</td><td>1895</td></tr><tr><td>&quot;emerging_markets&quot;</td><td>11</td><td>2006-01-03</td><td>2012-10-24</td><td>3315</td></tr><tr><td>&quot;specialty&quot;</td><td>10</td><td>2006-01-03</td><td>2006-06-22</td><td>4913</td></tr><tr><td>&quot;us_equity_style&quot;</td><td>10</td><td>2006-01-03</td><td>2013-07-18</td><td>3134</td></tr><tr><td>&quot;us_equity_broad&quot;</td><td>10</td><td>2006-01-03</td><td>2006-01-03</td><td>5031</td></tr><tr><td>&quot;commodities&quot;</td><td>9</td><td>2006-01-03</td><td>2010-01-08</td><td>4020</td></tr><tr><td>&quot;currency&quot;</td><td>4</td><td>2006-01-03</td><td>2007-03-01</td><td>4741</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (9, 5)\n",
+       "┌─────────────────────────┬──────┬────────────────┬──────────────┬──────────────────┐\n",
+       "│ category                ┆ ETFs ┆ earliest start ┆ latest start ┆ shortest history │\n",
+       "│ ---                     ┆ ---  ┆ ---            ┆ ---          ┆ ---              │\n",
+       "│ str                     ┆ u32  ┆ date           ┆ date         ┆ u32              │\n",
+       "╞═════════════════════════╪══════╪════════════════╪══════════════╪══════════════════╡\n",
+       "│ international_developed ┆ 18   ┆ 2006-01-03     ┆ 2012-10-24   ┆ 3315             │\n",
+       "│ fixed_income            ┆ 15   ┆ 2006-01-03     ┆ 2013-06-04   ┆ 3165             │\n",
+       "│ us_sectors              ┆ 13   ┆ 2006-01-03     ┆ 2018-06-19   ┆ 1895             │\n",
+       "│ emerging_markets        ┆ 11   ┆ 2006-01-03     ┆ 2012-10-24   ┆ 3315             │\n",
+       "│ specialty               ┆ 10   ┆ 2006-01-03     ┆ 2006-06-22   ┆ 4913             │\n",
+       "│ us_equity_style         ┆ 10   ┆ 2006-01-03     ┆ 2013-07-18   ┆ 3134             │\n",
+       "│ us_equity_broad         ┆ 10   ┆ 2006-01-03     ┆ 2006-01-03   ┆ 5031             │\n",
+       "│ commodities             ┆ 9    ┆ 2006-01-03     ┆ 2010-01-08   ┆ 4020             │\n",
+       "│ currency                ┆ 4    ┆ 2006-01-03     ┆ 2007-03-01   ┆ 4741             │\n",
+       "└─────────────────────────┴──────┴────────────────┴──────────────┴──────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100 ETFs, 470,662 rows, 5,031 sessions from 2006-01-03 to 2025-12-31.\n",
+      "Quoting on the first session: 59. On the last: 100.\n",
+      "ETFs with fewer than 504 sessions in the whole panel, which can therefore carry no conditional volatility at all: 0.\n"
+     ]
+    }
+   ],
    "source": [
     "prices = load_etfs()\n",
     "\n",
@@ -379,13 +491,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac6475b7",
+   "id": "b1234346",
    "metadata": {
     "papermill": {
-     "duration": 0.002638,
-     "end_time": "2026-09-05T01:19:34.763506+00:00",
+     "duration": 0.00364,
+     "end_time": "2026-09-05T03:36:32.944023+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:34.760868+00:00",
+     "start_time": "2026-09-05T03:36:32.940383+00:00",
      "status": "completed"
     }
    },
@@ -415,10 +527,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "23651ca1",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "3c7a5dc0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:32.949530Z",
+     "iopub.status.busy": "2026-09-05T03:36:32.949434Z",
+     "iopub.status.idle": "2026-09-05T03:36:33.172029Z",
+     "shell.execute_reply": "2026-09-05T03:36:33.171526Z"
+    },
+    "papermill": {
+     "duration": 0.225819,
+     "end_time": "2026-09-05T03:36:33.172505+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:32.946686+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 folds. Purge gap between training and validation: [22]\n",
+      "Earliest training session any configured label asks for: 2006-01-13.\n",
+      "Last validation session 2023-11-29 00:00:00, and its return resolves 22 sessions before the holdout opens.\n"
+     ]
+    }
+   ],
    "source": [
     "labels = pl.read_parquet(LABELS_DIR / f\"{PRIMARY_LABEL}.parquet\")\n",
     "\n",
@@ -464,13 +600,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34e7c449",
+   "id": "e34e0618",
    "metadata": {
     "papermill": {
-     "duration": 0.002419,
-     "end_time": "2026-09-05T01:19:35.054964+00:00",
+     "duration": 0.003854,
+     "end_time": "2026-09-05T03:36:33.180655+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:35.052545+00:00",
+     "start_time": "2026-09-05T03:36:33.176801+00:00",
      "status": "completed"
     }
    },
@@ -497,10 +633,65 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "942123ea",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "87c51934",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:33.186812Z",
+     "iopub.status.busy": "2026-09-05T03:36:33.186654Z",
+     "iopub.status.idle": "2026-09-05T03:36:33.612269Z",
+     "shell.execute_reply": "2026-09-05T03:36:33.611891Z"
+    },
+    "papermill": {
+     "duration": 0.42913,
+     "end_time": "2026-09-05T03:36:33.612716+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:33.183586+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regime burn-in ends 2009-02-04, 1,736 sessions before the earliest validation session 2015-12-28 any configured label is scored on.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (8, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>fold</th><th>train_start</th><th>training sessions</th><th>inside the burn-in</th></tr><tr><td>i64</td><td>date</td><td>i64</td><td>i64</td></tr></thead><tbody><tr><td>0</td><td>2013-01-17</td><td>2483</td><td>0</td></tr><tr><td>1</td><td>2012-01-17</td><td>2483</td><td>0</td></tr><tr><td>2</td><td>2011-01-14</td><td>2483</td><td>0</td></tr><tr><td>3</td><td>2010-01-15</td><td>2483</td><td>0</td></tr><tr><td>4</td><td>2009-01-15</td><td>2483</td><td>13</td></tr><tr><td>5</td><td>2008-01-16</td><td>2483</td><td>265</td></tr><tr><td>6</td><td>2007-01-17</td><td>2483</td><td>517</td></tr><tr><td>7</td><td>2006-01-13</td><td>2483</td><td>769</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (8, 4)\n",
+       "┌──────┬─────────────┬───────────────────┬────────────────────┐\n",
+       "│ fold ┆ train_start ┆ training sessions ┆ inside the burn-in │\n",
+       "│ ---  ┆ ---         ┆ ---               ┆ ---                │\n",
+       "│ i64  ┆ date        ┆ i64               ┆ i64                │\n",
+       "╞══════╪═════════════╪═══════════════════╪════════════════════╡\n",
+       "│ 0    ┆ 2013-01-17  ┆ 2483              ┆ 0                  │\n",
+       "│ 1    ┆ 2012-01-17  ┆ 2483              ┆ 0                  │\n",
+       "│ 2    ┆ 2011-01-14  ┆ 2483              ┆ 0                  │\n",
+       "│ 3    ┆ 2010-01-15  ┆ 2483              ┆ 0                  │\n",
+       "│ 4    ┆ 2009-01-15  ┆ 2483              ┆ 13                 │\n",
+       "│ 5    ┆ 2008-01-16  ┆ 2483              ┆ 265                │\n",
+       "│ 6    ┆ 2007-01-17  ┆ 2483              ┆ 517                │\n",
+       "│ 7    ┆ 2006-01-13  ┆ 2483              ┆ 769                │\n",
+       "└──────┴─────────────┴───────────────────┴────────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "market_sessions = (\n",
     "    prices.filter(pl.col(\"symbol\") == \"SPY\").select(\"timestamp\").unique().sort(\"timestamp\")\n",
@@ -540,13 +731,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc12a6b7",
+   "id": "94c33f96",
    "metadata": {
     "papermill": {
-     "duration": 0.002436,
-     "end_time": "2026-09-05T01:19:35.509288+00:00",
+     "duration": 0.002413,
+     "end_time": "2026-09-05T03:36:33.617809+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:35.506852+00:00",
+     "start_time": "2026-09-05T03:36:33.615396+00:00",
      "status": "completed"
     }
    },
@@ -557,10 +748,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a47b14ff",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "e3efc10b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:33.623234Z",
+     "iopub.status.busy": "2026-09-05T03:36:33.623147Z",
+     "iopub.status.idle": "2026-09-05T03:36:33.625987Z",
+     "shell.execute_reply": "2026-09-05T03:36:33.625680Z"
+    },
+    "papermill": {
+     "duration": 0.006234,
+     "end_time": "2026-09-05T03:36:33.626491+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:33.620257+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (8, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>fold</th><th>train_start</th><th>train_end</th><th>val_start</th><th>val_end</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;0&quot;</td><td>&quot;2013-01-17&quot;</td><td>&quot;2022-11-28&quot;</td><td>&quot;2022-12-29&quot;</td><td>&quot;2023-11-29&quot;</td></tr><tr><td>&quot;1&quot;</td><td>&quot;2012-01-17&quot;</td><td>&quot;2021-11-26&quot;</td><td>&quot;2021-12-29&quot;</td><td>&quot;2022-12-28&quot;</td></tr><tr><td>&quot;2&quot;</td><td>&quot;2011-01-14&quot;</td><td>&quot;2020-11-25&quot;</td><td>&quot;2020-12-29&quot;</td><td>&quot;2021-12-28&quot;</td></tr><tr><td>&quot;3&quot;</td><td>&quot;2010-01-15&quot;</td><td>&quot;2019-11-26&quot;</td><td>&quot;2019-12-30&quot;</td><td>&quot;2020-12-28&quot;</td></tr><tr><td>&quot;4&quot;</td><td>&quot;2009-01-15&quot;</td><td>&quot;2018-11-26&quot;</td><td>&quot;2018-12-28&quot;</td><td>&quot;2019-12-27&quot;</td></tr><tr><td>&quot;5&quot;</td><td>&quot;2008-01-16&quot;</td><td>&quot;2017-11-24&quot;</td><td>&quot;2017-12-27&quot;</td><td>&quot;2018-12-27&quot;</td></tr><tr><td>&quot;6&quot;</td><td>&quot;2007-01-17&quot;</td><td>&quot;2016-11-23&quot;</td><td>&quot;2016-12-27&quot;</td><td>&quot;2017-12-26&quot;</td></tr><tr><td>&quot;7&quot;</td><td>&quot;2006-01-13&quot;</td><td>&quot;2015-11-24&quot;</td><td>&quot;2015-12-28&quot;</td><td>&quot;2016-12-23&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (8, 5)\n",
+       "┌──────┬─────────────┬────────────┬────────────┬────────────┐\n",
+       "│ fold ┆ train_start ┆ train_end  ┆ val_start  ┆ val_end    │\n",
+       "│ ---  ┆ ---         ┆ ---        ┆ ---        ┆ ---        │\n",
+       "│ str  ┆ str         ┆ str        ┆ str        ┆ str        │\n",
+       "╞══════╪═════════════╪════════════╪════════════╪════════════╡\n",
+       "│ 0    ┆ 2013-01-17  ┆ 2022-11-28 ┆ 2022-12-29 ┆ 2023-11-29 │\n",
+       "│ 1    ┆ 2012-01-17  ┆ 2021-11-26 ┆ 2021-12-29 ┆ 2022-12-28 │\n",
+       "│ 2    ┆ 2011-01-14  ┆ 2020-11-25 ┆ 2020-12-29 ┆ 2021-12-28 │\n",
+       "│ 3    ┆ 2010-01-15  ┆ 2019-11-26 ┆ 2019-12-30 ┆ 2020-12-28 │\n",
+       "│ 4    ┆ 2009-01-15  ┆ 2018-11-26 ┆ 2018-12-28 ┆ 2019-12-27 │\n",
+       "│ 5    ┆ 2008-01-16  ┆ 2017-11-24 ┆ 2017-12-27 ┆ 2018-12-27 │\n",
+       "│ 6    ┆ 2007-01-17  ┆ 2016-11-23 ┆ 2016-12-27 ┆ 2017-12-26 │\n",
+       "│ 7    ┆ 2006-01-13  ┆ 2015-11-24 ┆ 2015-12-28 ┆ 2016-12-23 │\n",
+       "└──────┴─────────────┴────────────┴────────────┴────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(\n",
     "    pl.DataFrame(\n",
@@ -580,13 +819,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e37fa996",
+   "id": "12f1061c",
    "metadata": {
     "papermill": {
-     "duration": 0.00242,
-     "end_time": "2026-09-05T01:19:35.526589+00:00",
+     "duration": 0.002389,
+     "end_time": "2026-09-05T03:36:33.632847+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:35.524169+00:00",
+     "start_time": "2026-09-05T03:36:33.630458+00:00",
      "status": "completed"
     }
    },
@@ -600,13 +839,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3a0fa57",
+   "id": "d271c2e2",
    "metadata": {
     "papermill": {
-     "duration": 0.002339,
-     "end_time": "2026-09-05T01:19:35.531404+00:00",
+     "duration": 0.002364,
+     "end_time": "2026-09-05T03:36:33.637655+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:35.529065+00:00",
+     "start_time": "2026-09-05T03:36:33.635291+00:00",
      "status": "completed"
     }
    },
@@ -635,10 +874,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6305619f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "6dc40fe6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:33.643022Z",
+     "iopub.status.busy": "2026-09-05T03:36:33.642948Z",
+     "iopub.status.idle": "2026-09-05T03:36:33.648015Z",
+     "shell.execute_reply": "2026-09-05T03:36:33.647683Z"
+    },
+    "papermill": {
+     "duration": 0.008239,
+     "end_time": "2026-09-05T03:36:33.648318+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:33.640079+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Market proxy: SPY, 5,010 sessions from 2006-02-02 to 2025-12-31.\n",
+      "4,508 of them precede the holdout, so the last re-estimation is on those and the remaining 502 are filtered through frozen parameters.\n"
+     ]
+    }
+   ],
    "source": [
     "market = (\n",
     "    prices.filter(pl.col(\"symbol\") == \"SPY\")\n",
@@ -673,13 +935,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4db4f335",
+   "id": "62f3f3f4",
    "metadata": {
     "papermill": {
-     "duration": 0.002441,
-     "end_time": "2026-09-05T01:19:35.547122+00:00",
+     "duration": 0.002467,
+     "end_time": "2026-09-05T03:36:33.653405+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:35.544681+00:00",
+     "start_time": "2026-09-05T03:36:33.650938+00:00",
      "status": "completed"
     }
    },
@@ -725,10 +987,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c16d5bfa",
+   "execution_count": 9,
+   "id": "c58d4bd7",
    "metadata": {
-    "lines_to_next_cell": 2
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:33.658896Z",
+     "iopub.status.busy": "2026-09-05T03:36:33.658821Z",
+     "iopub.status.idle": "2026-09-05T03:36:33.661871Z",
+     "shell.execute_reply": "2026-09-05T03:36:33.661539Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006239,
+     "end_time": "2026-09-05T03:36:33.662118+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:33.655879+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -772,14 +1047,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d433fbdf",
+   "id": "5b2d9ed9",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002539,
-     "end_time": "2026-09-05T01:19:35.561685+00:00",
+     "duration": 0.002447,
+     "end_time": "2026-09-05T03:36:33.667090+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:35.559146+00:00",
+     "start_time": "2026-09-05T03:36:33.664643+00:00",
      "status": "completed"
     }
    },
@@ -794,9 +1069,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "677d5e04",
-   "metadata": {},
+   "execution_count": 10,
+   "id": "96f3b062",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:33.672687Z",
+     "iopub.status.busy": "2026-09-05T03:36:33.672603Z",
+     "iopub.status.idle": "2026-09-05T03:36:33.675222Z",
+     "shell.execute_reply": "2026-09-05T03:36:33.674887Z"
+    },
+    "papermill": {
+     "duration": 0.005893,
+     "end_time": "2026-09-05T03:36:33.675519+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:33.669626+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def regime_derived(prob_stress: np.ndarray) -> dict[str, np.ndarray]:\n",
@@ -828,10 +1117,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7568bd9f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 11,
+   "id": "661d119b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:33.681046Z",
+     "iopub.status.busy": "2026-09-05T03:36:33.680972Z",
+     "iopub.status.idle": "2026-09-05T03:36:55.175413Z",
+     "shell.execute_reply": "2026-09-05T03:36:55.175137Z"
+    },
+    "papermill": {
+     "duration": 21.498523,
+     "end_time": "2026-09-05T03:36:55.176583+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:33.678060+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regime model: 60 estimations over 68 blocks, 4,254 of 5,010 sessions carrying a value.\n",
+      "First value 2009-02-04, last re-estimation on 2023-11-08.\n"
+     ]
+    }
+   ],
    "source": [
     "regime_prob = walk_forward_feature(\n",
     "    MARKET_X,\n",
@@ -877,13 +1189,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b78ab2e1",
+   "id": "9681bcd4",
    "metadata": {
     "papermill": {
-     "duration": 0.004248,
-     "end_time": "2026-09-05T01:19:57.368130+00:00",
+     "duration": 0.003968,
+     "end_time": "2026-09-05T03:36:55.185467+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:57.363882+00:00",
+     "start_time": "2026-09-05T03:36:55.181499+00:00",
      "status": "completed"
     }
    },
@@ -895,10 +1207,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "562ec645",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 12,
+   "id": "9d6b44e5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:55.194008Z",
+     "iopub.status.busy": "2026-09-05T03:36:55.193905Z",
+     "iopub.status.idle": "2026-09-05T03:36:55.197942Z",
+     "shell.execute_reply": "2026-09-05T03:36:55.197692Z"
+    },
+    "papermill": {
+     "duration": 0.009195,
+     "end_time": "2026-09-05T03:36:55.198647+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:55.189452+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Every regime estimate ended before the first session it speaks for, and the 756 burn-in sessions carry no value.\n"
+     ]
+    }
+   ],
    "source": [
     "assert hmm_fit_df[\"fit_end\"].max() <= HMM_FREEZE_AFTER, (\n",
     "    f\"a regime model was estimated from {hmm_fit_df['fit_end'].max()} sessions, past the \"\n",
@@ -922,14 +1256,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25c3ccd9",
+   "id": "e8551da2",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004307,
-     "end_time": "2026-09-05T01:19:57.393115+00:00",
+     "duration": 0.004015,
+     "end_time": "2026-09-05T03:36:55.206789+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:57.388808+00:00",
+     "start_time": "2026-09-05T03:36:55.202774+00:00",
      "status": "completed"
     }
    },
@@ -952,10 +1286,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9b25376f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 13,
+   "id": "74909ad4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:55.216028Z",
+     "iopub.status.busy": "2026-09-05T03:36:55.215938Z",
+     "iopub.status.idle": "2026-09-05T03:36:55.353268Z",
+     "shell.execute_reply": "2026-09-05T03:36:55.352678Z"
+    },
+    "papermill": {
+     "duration": 0.142976,
+     "end_time": "2026-09-05T03:36:55.353764+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:55.210788+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation sessions drawn: 1,995 (2015-12-28 to 2023-11-29)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLEAAAH1CAYAAAAJTmyJAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3Xd4U+UXwPFvZ7rSPaGUsrcMRQRkiCgiQxBRVBQRFQQcgAIqCCiKiCwFEUGUn+IAFyoqiCCCoIJMZW8KdO+VdOT3R0Zv6aAtbe9tcz7P42Ob3NycJqfvTQ/nfV8Ho9FgQgghhBBCCCGEEEIIDXNUOwAhhBBCCCGEEEIIIa5GilhCCCGEEEIIIYQQQvOkiCWEEEIIIYQQQgghNE+KWEIIIYQQQgghhBBC86SIpZLc3Fx8w9vy5ITpqjz/i7Pm0fKG28jONqjy/JXl3ZWf0KB1d6IuRZfp+HMXLtL37keo06QTTz03s2qDK0HLG26j3z2jVHnu0ryzfDVN2/eicdue/Hv4uNrhFPLkhOn4hrclNzdX7VAAOH3mPL7hbZkzf1mZH7N95258w9vyv0+/rsLIyu+hxyfS8877K+Vcc+Yvwze8LRcvxVTK+crDN7wtTzz1AlD+19pozOGJp14gokVXbuo1mLy8PNZ+vYHWN/ahfqub2bz1j6oMXQghhBBCCFFGNbqIdebsBR4Y9Sz1W91Mi+t7M2rcFM6ejwIgKysb3/C2rFm7XuUotWn8Ew/z8YoFuLnp1A7lmgwb0p81HyyiblhImY6ft+h9dv29jxcmjeXh+++u4uiq18zXF9Hmpr4VeuyFi5eZ/uoCIsLr8Or0STRpFFm5wYlKs3nrH/iGt+XchYuVcr5ZLz7L0vmvlPtxtWmM/fq7n1n7zY/079uLGS88Q25uHs9MfgWdzpXXZzxP+7Yt1Q5RCCGEEEIIATirHUBFmUwmho18moTEJF6Y+CSOjo58/Pk3/LPvEJER4cTGJ6gdoqbVCQuhThkLP1rm7+dLl04dynz82fNRBAX689SYEVUYlTpi4iqe8+fOmwsi9w8dyP33DKiskEQViImLr9TzNWwQUaHH1aYx9qwl/595ciTNmjTkfNQlsrKz6X9HLx689y6VoxNCCCGEEEJY1dhOrKTkFI6dOE2XTtczZtSDPDHyfn7/+QuG3NWX7Tt307bznQCMm/iyrWthzvxlNOtwK7/+9gftu/ZnwtRXAfhrz356DxhOeLPO3DnkUU6cOguYp5g89dxMIlt1o/n1vZn04mukpWeUeHtp5wLYtuMvOt96N5GtujHl5bkl/mwH/ztK7wHDCWvciS63DmHt1xsAyMvLY8GSD2jd6Q4at+3J1BlvYjTmlPqYkm6/cnpWXHwCTzz9Ig1ad6fNTX15Y8F75OSYz22dmvPtD5u4a9gT1GvehbsfHENySioAySmpDH9sAvWad+G6zn15de47trisdv9zkAdHPUvz63sT2aobz730uu25y/u+KFmnL50+cx6ANjf15flpc3hh5jyadbiVNjf1ZduOvwDod88oduzaQ1x8Ir7hbdm+c3epr+mTE6Zz28CH+OzL72l5w20sXPIBa9auxze8Lbv/OUiX3vdwz/CxABw9foq7hj1BeLPO9Og7jN3/HLTFeODfI9za/0EiWnTl8fEvkFXKFM5vvt9I51vvJrxZZwbc+xgH/ztqu6/fPaNoecNttu+V72G/e0bx2brvuBB1qcRpqgf+PUL/oaMIb9aZLrcO4dsfNtne3/5DzdMbJ734WpGpjiW9v1GXopn4wmw63DyAuk1v4p7hY4mOiSuSM3cOeZTIVt0Y8+w0zl24yH0jxhPRoiuPjHne9lrPmb+Mes27sOrjtXS4eQBN2t3Ca/OWkp+fX+zrlJycyrhJL9OgdXfad+1fpmljZY23uBwH+PLbn2jXtR+N2/Zk4dJVJT5Pbm4uby/7iA43DyC8WWeGPjSOhMSkIsddmbvW3Ppt+58AbPvjL7rcOoQ6TTrRq98DbNm2kznzlzFu4ssAtO18p63zLisrm2mvzqdZh1tp1fF23np7he2163fPKEaNm8KipatodF1Pvvz2p0JxKPPq3IWL+Ia35cNP1vHgqGeJaHkzvQcMLzJdt6Qx1mrjr9vo1udeIlp0ZeqMN223lxan0nsfrKFVx9uJaNGV+0aM59TpcwBcvBTD8McmENGiK51uGczPm7eV+D5cqaTfrTnzl/HGAvO00E63DObJCdO5zvK6Ll72ke01LikmIYQQQgghRPWpsUUsP18fWrdsxnc/bmbUuCn8/c8B230tmzdm6sQnAXhi5P18snIhQYH+AMTFJ/Ls1NmMGfUAj40YxtnzUQy+fzSOjo68PvN5HBwceGTM85hMJj5b9x0ff/4Nj424j7GPDScrOxtXF5cSby/tXBcuXua+EU/h4GC+Lyen5LV9nn9pDtExcbwxazI3d+lIVlY2AEuW/49X3nibfn1u4YVJY/l07Xre/+izUh9T0u1K+fn5PPT4RDb9up2Xnh/HPXfdwRsLljF34fJCxz075VVuv7Ub/e7oxZZtu2zTiN55bzU/bvqNqZOe5IGhd5GRmYWLS+EmvyPHTuLl5cm0yePp2e0mVq7+gq/W/2y7vzzvy9Ws+OhzUtPSeGbsSBITk3hx1lsATJs8jhbNGuHn68MnKxfSsnnjUl9TgP+OHOetxe8z+dnRDB7Qx3b7A6Oe4d7BdzJ1ornQMej+0cTExvHq9IlEhNfhgVHPkJmVRVp6Bvc+PJ6Y2HhmvzyJsNBgUlLTio17y7adjHxyMk0bN2Tuq1NJSEzmrvueILYMHVbTJo+jaeMGBAb48cnKhYx+9IFC98fExnPXfU+QnJLG3Fen0qhhfR4Z8zxbf99Fy+aNeen5cQA8NuI+pk0eV+ixJb2/aWnpnDpznvGjH+LJx4ez+bc/eG3e0kKPnTB1NgP63kqnG9ry+Zff0/2O++jS6Xpu7tKRb3/YxE+bfrMdm5aewSeff8uE8Y/SpdP1zFv8Pt//tKXIz2oymXj8qRf44ectPDt2JEPuuoOnJ89i/8HDpb5GZYm3pBz/Z98hHhs/lbphobw6fRJJySklPs+8xSt4+bWF3Nz5Bl6dPpFmTRvi5+tTamzFGfP0S+DgwBuvTKFVi6YYjEaG3HUHd/UzF5wWvTGdxXPNxcppr85n+apPGfHAEMY89iBz5i/jh58LXrtNv27nq+9+ZtZLz9Lj5huv+twvzJjHda2bM+L+u9mz7xDvvLe60P2ljbEAKz/6gkcfGkqzJg1574M1HPj3SJniBDh1+hxTZ7xJh3atmfXSs3h4uOPs4kxOTg73jhjPvgP/8dLz4+h8Y3tGjH6Oy9GxV/15SvvdGnLXHdw90Py7Pf/1l3jmyUdY9Ib5db2r320snju9xJiEEEIIIYQQ1avGfgp3cHDg+y9WMG32fD7/8ge+Wv8z3bp05J23ZhIZEc5NHdsB0LZNC/rf0cv2uPz8fF556VlbQWL2vCVkZmXzzlszCQkOJDDAnwcefYaz56LQ6z0BCAr0Z8QDQ2zrR5V0+ydffFviudZv+IVsg4Elb82kQ7vWDLyzN//7rPjuEb2XJzg40LZNC0Y8OMR2+/sffka3Lh15YZL5j8c//tzDhp+3MP6Jh0t8TEm3Kx389yh/7t7PhHGP8tiI+wBz19j7H35mK24ATJ/yFKMevpfomDg+//J7Tpw8Y3sOBwcH6oaF0H9kL5ydi6bVww/czfBhgzh0+BiZmVl8+8Mmdu89yH1D+pf7fWkQWa/Yn8Pq+natbWv8bN66gx279gDQ+cYO+Pv5kZKSZsuJ0l5TgMysbN5/+3Wub9/GfP9f/wDmNcWeGTsSgP999jXRMXG8u+AVOrRrzfXt29C9z33s/ucgCYlJxMTG89F78xjU/3bAnCfFWf7hZzg7O7Nk/iz0Xp4EBfhz74jxrP1mgy2ekph/Nh+ysg2F8t1q7TcbSE5J5YOlb3Brz670v6MXP276jeUffsbnH77NTR3bA3Bdq+Z0vrHw9MyS3t8WzRqz/vP3OXsuigP/HiUo0J/dew8Ueuy0yeMZ9fC9dLqhLRt/3c4jDwzhmbEj2XfgP37cuJVjJ08XOv6dt2bRqkUTevfsyvoNv/Djpq3c1a93oWPOnovil607eP6ZJ8w5bYJP167nh41baHddyWsXlSXeknJ8zdr1ODg48OGyNwkOCqBt6+ZFii9gLrAtW/kJ3bp05O15M0qMpSz0ei9cXJzpfGOHQuu3Wdcru6VHZ+rXq0t2toGP1nzFvXf3Y+zjwwH4/sdf+eHnLQy80/za5eTksuaDRUSE1ynTc49+9H6mTBhDbm4uK1d/wYlTZwrdH+DvV+IYC/Dhe/No1qQhei8vdu89yImTZ2nWuOFV4wTQuelwcXHG09ODgXf2ZuTwoYB5TPrvyHHefnMGA/v1JjvbwKfrvuOXrTuuur7d1X63mjRqYH5Nu91EwwYRuLu72V7rXj26EHUputiYhBBCCCGEENWrxnZiAfj5+bB0/isc+vMnxo9+mB279vDwE5Ou+ri2rVvYvj53zjwFptMtg4ls1Y0HHn0GgLiERAYP6MOS+bNY8v7HtO1yJ8tXfYrJZCrx9tLOdT7qElC29WfeWzybvr27c/ugh7lzyKPsO/AfRmMOFy/HsH3nbiJbdSOyVTe+/m4jcfGJJT6mtNuVrIvht21T8Lq0b9uK1LR0EpOSbbe5WIoXgQF+ABgsU8HGPfEQM198hudeep0betzFV+sLT1cC2LFrDx26DaDPXSP47sfNAKRe0ZFU1vflapRdYIH+fkWmNlpd7TW1xaV4XYq7zbqe1N0PPklkq25072MuBMbFJ3L+Qtnf93Pno2jcMMJceATbYtLnzkVd9bFXP/fFQnH7eOtp3LA+585f/dwlvb+Xo2PpO2QkHboN4K2338dkMpGaml7osdacCbDkjIuLCwD+/r4ARd4bBwfz/8NCg/Hx0ZOYmFwkHmu+zlv8vvl9a92NS9GxxMeXnhvliffKHD9/4RJ6vVehbqPiJCQmkZqWTptWzUo9rizWfbyUpo0acFOvu7n/0Wds0w6vdPFSNHl5eXy27jtbHv/9zwHiFb8r/n4+ZS5gQcH75OzsjJ+vNwZD8b9DJT6+yOtoLFOcAOF1Qln/+QrOnL1Aq459mPLyXNIzMjlr+T14evIs21RuozGH+ISiUzWvdK2/WyXFJIQQQgghhKheNbYTCyA2LoHgoADqhIUwe/ok9u7/j737/8VkMuHoaK7PGQwlrz8EUD+iLgAfr1iAr4+37faWzZvg4ODA8PsGMWxIfxYv+4gpL8+lRbPGdO96Y7G3l3au4KBAwLwuUY+unUqdFhcY4M+8115kysQxDHvkaR56YhL//vUzdUKDqVsnlJenPm071svTo9THlHS7UmREOAD7Dx62dQvtO/Af3nov/P18S339wPwH71OjR/D4iGG89MpbjBo3lQ5tWxfqmHpywnRaNmvEX1u+QadzxTe8bannLO21rCyuri6lvqZlVb+eOdaFb0yjccNI2+0tmzdm46/bAThw6AjXtWoOUOJ7Xz8inM1b/yAtPQO9lyf7Dpinx9WvH26J15nEpBRyc3NxdjZP51NydHQqMd+tr+f+g0fofUtXUlLTOHn6HLf1uvmqP19J7++bi9/n3Lkojv6zmeCgAPrdM4ozZ4svtJRXdEwcKSlpRFp+9kI/i+X1fvShoYWmeF5th8pX5r5T4XiDgwNITU3j3PmLRNYPp6RfX38/Xzw93Pn38PGrntPV1Vwoio1PoGGDiCLvZ/16dVmxZA7Tpz5F/6GjGP/cTH78apVibDMCULdOKI6OjvS9rQdjRj1oe3yApVBYVco6xlqVJ84unTqw8dvVbPvjL4Y8OBYfb71tA4epE5+k603X245tGHn1AvHVfrfKoriYXnxubJkfL4QQQgghhLh2NbaItWPXHgY/MJphQwbQqWM7LkRdZvfeA9zRuwcODg62P9o/W/c9/n6+9L6l+D/WHxg6kKXvf8z8d1bywNCBZGcbcHFxoVuXjsx4bSHxiUl069yRM2cvAODk5FTi7aWda0DfW3ljwTJmz13CxYdi+P6nX4uNJzkllWGPPMVtvboRFhpMekYGTk7mPxYfe2QYr7zxNl989QM33dieo8dPcc9dfUt8TGnnUmrTqhmdbmjHR2u+IrxuGBcvRbP3wH889/TjOFhbY0pgMpkY/fSL+Pv70a5NCy5Fx+Lg4IDjFc+TlZXFhYvRfPXdz2zeuqPUc17tfalMJb2m5TGg763MnreEJcv/xyMP3oOLizNJyal069KR3j274uHuxtvLPsLR0ZGdf/1T4npKTzwyjI2bf2fcxJfp07s7S9//GF8fb4YOMi+g3aRRA7b+/ieTXnwdgF+ueB0j69dl51//8O7KT+jY/jo6Xn+d7b6hg+7krbdXMHPOYmLi4vn5l23k5eUxeuT9pf5spb2/WVnZJKek8vPmbZw5e4G//9lPUEDpnUpX89q8pfTveyuffP6tuYg8bBAAdUKDAfPvfY+bO9GrR2fWffMjvj7eRNYP5+C/R5nxgrlb76HHJ5KUnML6z9/HycnJdu5rifeufrfx6drvmPLyG9zV/3Y+LmEqsKOjIyMfGsqS5f9jwtRX6XRDO7bv2s1r058r+Bn+3MPwYYNs0wJnv7mErjfdwPsfFqzFdu7CRUaNncLggX3Qe3liNObYfnethb3Fyz7krjtv4/Zbu/Hw/YNZs3Y99cLr0LplUw4cPMwz4x4t46teMWUdY63c3HRlivPHTb/x3gdrGDLwDlJS08jNzcXJyZEuna6nZbPGfLTmSxwdHQgK9Of4ybPMnj4RgLCQII6eOE1sXEKR1/pqv1tXU1JMQgghhBBCiOpVYz+Fd+nUgbdmv8jR46eY+vJcPv7sax4aNph35s0EzF0MUyc+yYlTZ3lx5jxOlrCTVMMGEXz7+XJ0rq7MmrOYFau/IDEp2TxtcOAdXIi6zPPT5rBl205mTH2aLp06lHh7aedq1aIJyxbNJjY+gRmvLaRls8Y0a9KwSDzeei8G9b+dtV9vYNILr+Hh7s7Kd94A4OkxI5j5wjPs+HMPk6fNYddfe0lNSy/xMaWdS8nJyYlPVi6gd8+uzH5zCeu++ZHJz45m8rOjr/o+ODg48MC9d/HPvkNMfGE2R46d5J23Ztq6ZazmzX6B+IREXntzCS2aNS517aKrvS+VqaTXtDz8/Hz47osV1I+oy5uLlrP43Q+JT0jEaMwhOCiAj1cswMHBgZdmvYWriwvduxa/sPatPbuy6t25HDtxmsnT5uDn68P6L94nJNjcxffUmBG0b9uK9Rt+ISc3h1enTSz0+EnjH6Ntmxa89uYSVn/6VaH7QkOC+O6LFXjrvZg8bQ4nTp1h1btzuaV751J/ttLe38nPPkFkRDjTZy8gOjae++8ZWK7XrThBgf5Mf3U+Fy9H88HSN2xTTAfc2ZugQH+Wf/gZDg4OfLBkLoMH9OGTL75l+uwFRF2Ktk19Tc/IYMeuPRw+drLQua8l3tt7dWPmC89w8N+jvD5vKQPu7G2bmnal6ZOfYtJTj/HLlh1MmTGX9PRMsg0GGjaIoMfNnfjhp1+JiY2n7209GNT/dg4cOsKuv/fy0XvzbOcICwnmlu6dWfHR50x9eS6NG9ZnwZxpAAzufzv97+jFt99vYubri8jJyWHOzMk8OWo4P/z0K1NfnsvRE6dLXXy+MpR1jFUqS5w3tG9DaEgQs+ctYcGSD7hvSH/Gj34YV1cX1n68lE43tGPZyjW8Nm8p8fGJtimhD91/NydOnmXnX/8Uea2v9rt1NSXFJIQQQgghhKheDkajoXKrAkIIUU5z5i9j7sL32Lv9+zKtH1aa+IREWna8nX07NlC3TulTDIUQQgghhBBC1Bw1thNLCCGuFJ+QyKD7x/DQsMFSwBJCCCGEEEKIWqbGroklhBBX8tbreXbsSO4e2OfqBwshhBBCCCGEqFFkOqEQQgghhBBCCCGE0DyZTiiEEEIIIYQQQgghNE+KWEIIIYQQQgghhBBC86SIJYQQQgghhBBCCCE0r0YWsUwmE7m5uZhMspyXEEIIIYQQQgghhD2okbsT5uXl0a3fI2zf8BHOzjXyRyjWZ1/9yP1D7ixye37UxUp7DsfwupV2rsp2tZ9Ty7FXhZLyQdiniuZDRcYP5e/atYw/9vI7W5ljdFl9vvF3hvXpXu7H1aT3RPm6Vmbc1/p+afU1rOxrhhp5XZ0q8j5q4TUpS9zlzQXrz1Xaua/1WiKqz5XvlfV6Udb3Qwt5LqpORT8/lMW1fH6U8UKUR43sxKqtMjKz1A5BaIjkg1CSfBBKGdkGtUMQGiNjhLCSXBBKcr0QSpIPojZwMBoNNW5OXm5ubq3sxCqJdGKZaTl2IbRKOrGqXk36V+ua9J5IJ5a6alJeV0Rt7sQqL+nEql1Keq+kE0tUNenEEtVFOrE0ZOjISWqHIDRE8kEoST4IpfteeFPtEITGyBghrCQXhJJcL4SS5IOoDaSIpSHLF7ysdghCQyQfhJLkg1BaNvVJtUMQGiNjhLCSXBBKcr0QSpIPojaQIpaGHD52Wu0QhIZIPgglyQehdORslNohCI2RMUJYSS4IJbleCCXJB1EbSBFLQzZt3al2CEJDJB+EkuSDUPrlr/1qhyA0RsYIYSW5IJTkeiGUJB9EbSALu9cAsrC7mZZjF0KrZGH3qleTFsGtSe+JLOyurpqU1xUhC7sXkIXdaxdZ2F2oRRZ2F9VFOrE0ZOK0eWqHIDRE8kEoST4IpUmLVqkdgtAYGSOEleSCUJLrhVCSfBC1gRSxNOTh+waoHYLQEMkHoST5IJQeuvMWtUMQGiNjhLCSXBBKcr0QSpIPojaQIpaG+Pv5qB2C0BDJB6Ek+SCU/L291A5BaIyMEcJKckEoyfVCKEk+iNpAilgaMuONd9UOQWiI5INQknwQSjPf/0ztEITGyBghrCQXhJJcL4SS5IOoDWRh9xpAFnY303LsQmiVLOxe9WrSIrg16T2Rhd3VVZPyuiJkYfcCsrB77SILuwu1yMLuorpIJ5aGLFz2sdohCA2RfBBKkg9CadFn36kdgtAYGSOEleSCUJLrhVCSfBC1gRSxNKRxwwi1QxAaIvkglCQfhFLj8DC1QxAaI2OEsJJcEEpyvRBKkg+iNpAiloYM6NND7RCEhkg+CCXJB6HUv1tHtUMQGiNjhLCSXBBKcr0QSpIPojaQIpaG3Dr4MbVDEBoi+SCUJB+E0m3jXlY7BKExMkYIK8kFoSTXC6Ek+SBqA1nYvQaQhd3NtBy7EFolC7tXvZq0CG5Nek9kYXd11aS8rghZ2L2ALOxeu8jC7kItsrC7qC7SiaUhX3+/We0QhIZIPgglyQeh9M3WXWqHIDRGxghhJbkglOR6IZQkH0RtIEUsDYmOjVc7BKEhkg9CSfJBKEUnJKsdgtAYGSOEleSCsPr0h19Ys+FXPtuwmXZd+5GSmqZ2SEJl8vlB1AYynbAGkOmEZlqOXQitkumEVa8mTb2oSe+JTCdUV03K64qQ6YQFZDph7WJ9rzKzswnveTcAvt5eJKems+3nz2nbukWZHi9Eecl0QlFdpBNLQx4cPVXtEISGSD4IJckHofTQywvVDkFojIwRwkpyQQAcP3sBgAaNmpCcmg6AwWBUMyShAfL5QdQGUsTSkLdeeU7tEISGSD4IJckHoTTv6UfUDkFojIwRwkpyQQAcOXWO0EB/Gof64e3lCUB2tkHlqITa5PODqA2kiKUhUZei1Q5BaIjkg1CSfBBKUbEJaocgNEbGCGEluSAAjpw+R/OG9el54/U8N/J+dDpX6cQS8vlB1ApSxNKQL7/7Re0QhIZIPgglyQeh9NWWnWqHIDRGxghhJbkgAI5ailjn45IY/+Dd6HQ6sg3SiWXv5PODqA2kiKUhc2dMUDsEoSGSD0JJ8kEozRn/sNohCI2RMUJYSS4IMHditWhY33a9cNO5YjRKJ5a9k88PojaQIpaGvPDKYrVDEBoi+SCUJB+E0otLP1Y7BKExMkYIK8kFkZqewcWYOFo0rG+7Xpg7saSIZe/k84OoDaSIpSGD+/VSOwShIZIPQknyQSgN6tlJ7RCExsgYIawkF8TRM+cBaNYgwna9cNO5YjAYyM3NZf0PMuXUXsnnB1EbSBFLQyLqhakdgtAQyQehJPkglCJCg9QOQWiMjBHCSnJBHD19jvDQIPSeHrbrhbUT66M1XzFizHMkJCapHKVQg3x+ELWBFLE0ZOJL89QOQWiI5INQknwQSpMWrVI7BKExMkYIK8kFcSk2nnqhwUDB9cJN54oh28DeA/8CkJGZpVp8Qj3y+UHUBlLE0pBPV8xVOwShIZIPQknyQSiteXWS2iEIjZExQlhJLtiX5ORUWt/Yhx83/Ub3O+4DICYhiZAAf6DgemHtxEpJSQMgIyNTnYCFquTzQ/nk5eXx4SfrSE1LVzsUoSBFLA15d9UXaocgNETyQShJPgilZV/9pHYIQmNkjBBWkgu1S1JSCuMmvUxCYhL7Dx0hM6twB9VnX35P1KVonpwwjYP/HsVkMhETn0hIoLmIZb1e+PjoOXr8FDk5uQBkSieWXZLPD+Xz7JRXmTB1Nt/9uFntUEqVlZXN9z/9isFONm+QIpaGBFsuNkKA5IMoTPJBKAX7+agdgtAYGSOEleRCzXbxUgwvzprHz5u3AdCgTXfWfLGeRUs/pGffYcx/e6Xt2Pz8fF6Y+SaArcMqPTOL2MQkgv19gYLrxX1392fTr9ttRTCZTmif5PND2SUkJvHx599QNyyEfQf+UzucUo0cO5mHHp9ISKOOPP38LPLz89UOqUpJEUtD7hl4m9ohCA2RfBBKkg9CaUivLmqHIDRGxghhJblQsz02fgrvffAp//vsm0J/iL6zfDUAjo4Ff76dsuxCqJSSnkFqega+ei+g4HrRukUTsrKzOXz0JECRji5hH+TzQ+lMJhNJSSnk5eXx6tx3AGjTujnxCdrdCGH6qwv4+ZdtvPT8OAL8/fj8q+9JTa3d0x+liKUht939hNohCA2RfBBKkg9Cqc/4GWqHIDRGxghhJblQc+Xl5bH/4BFuu6UrO3buZvTTLwEwbfJ4XF1dAHB3d7Mdn5iUXOQcqWnppKRl4G0pYlmvF/Uj6uLv52t7jKyJZZ/k80Pp3l72EQ3adOfP3fv5aM1XANQJDdb09Ftrgbt3z66cOvgbMad24+vrrXJUVavKi1iXo+PoMWAkew8cJjkljaemzOHBJ6byybofbMd8++MWHhw9ldETXyE2LqGqQ9KsjV++p3YIQkMkH4SS5INQ+ult+RAqCpMxQlhJLtRcFy5eJis7m9tv7U5qWjpff7+RBXNeYtJTj3HywG9c3641aYoFpotb/yYlPYPUjAy8PT2AguuFs7Mzv6z/H3cP7APA73/sroafSGiNfH4o3afrvgNgy7adttuCAgNIz9Rm0TcnJwedzpU7butB2zYtAHBwcFA5qqpX5UWspR98Tr26oQCsWvMNPbrewOp3Z/PT5h2cj7pMYlIKH3/xPR8snsU9A29j6Qf2uxjlj79sVzsEoSGSD0JJ8kEo/bTzH7VDEBojY4SwklyouS5EXcbBwYHrWjUHwE3nyqMP3YuDgwPeei/C64aRlp5hO95axBr18L2222ISkjAYc/CxdGIprxeNGtZn1bvmNbRWf/pVlf88Qnvk80PpsrKzAVi4dJXtNi9PD812Yh389ygGg5Elb80sNNW4tqvSn3T/oaPk5+fTrHEkADv/3k+7Ns1xdnamTYsm7Np9gL/+OUTTRpG4uelo16Y5u3bvr8qQNO3E6XNqhyA0RPJBKEk+CKUT5y+rHYLQGBkjhJXkQs118VI0IcGBhIQEAhT5o1Tv5UlqWjqXLscAkG0w4O2tZ/7rL9mOOW+5z9vLEyj+erF29RJ0OtdqWfw5MSWVjKzsKn8eUTby+aF01t+5/Px8fH3MU/I8PNw1W8Ta+fdemjZuQGCAfW3o4VxVJ87Ly+fdVV8wa8pYVn7yNQCJSSmE1wkBICI8jPiEZHJycokIN3dqBfr7kpefT7bBiJvOtdD5vvzuF776/hfAvOBabTThyYfVDkFoiOSDUJJ8EErPPjBQ7RCExsgYIawkF2qui5djqBsWgr+fL1B0WpBe78Wfu/fR5qa+/LP9O4xGIzrLWlm2c0THmY+1TCcs7nrRILIeBoORS9GxhNcJrYKfpEDjPsNo1bgB2z9ZWqXPI8pGPj+Uzlqs6n9HL2a9+Cx79h0i32TSZBErPz+fNV98S59bu6sdSrWrsk6sDb/8zo0dWhMWGmS7zcHBASwFqHxTPg6ODuBQuChlyjdR3DTOewbexmcr3uSzFW/yyXtzqipsVT361MtqhyA0RPJBKEk+CKXHZr+jdghCY2SMEFaSCzXXxUvR1K0TiqeHOwAdO1xX6H69lyeH/jtGXl4eySlpZBuM6HS6QsdEJyQC4GG5vbjrRUR4HRwdHTlz9kJV/BhF/HfyTLU8j7g6+fxQsvz8fBISk/l6zTI+XrGARg3rc9+Q/ni4u5ORmUVaeganSul0zczKolmHW+l0y2Byc3OrPN5ftu7gzLkoxj3xUJU/l9ZUWRFr2x+72fHnPh57ZgY7/97PvCUfkZmVTdQlc4vrhahoggL8CArw4/zFaADiEpJwcXFB5+pa2qlrrZefH6N2CEJDJB+EkuSDUJo+6j61QxAaI2OEsJJcqLmiLpqLWA4ODuz/YwNrPlhU6H693tP2x7HBYMBgMNhmr3z72XL8/XyJiTcXsay3F3e90OlcqVsntNqKWEI75PNDyX74eQuOjg40b9qoUBekl6c7GZmZDH9sAtd3L7mTbf/BI8TExnPsxGk+/vwb2+1jnp3GO++trvR4N/26ne5dbiQ0JOjqB9cyVTadcP6rz9u+fvWt5fS7rRu/79rLvkNHiYyow79HTvLQfQPw9HDn/dVfkp1tYN/Bo3S5sV1VhaR5KYrdRoSQfBBKkg9CKSVdm7vkCPXIGCGsJBdqrqhL0XS/+UYAIuuHF7nf28vL9nW2wYDBkIOr5R//e3a7id49u/DXX3uBgiJWSdeLBvXDOXNOilj2Rj4/FG/Ltp08/MQkRj/6AHXCQgrdFxYaTE5OLtt2/AVAXl4eTk5ORc5x+ux5AMaMepDZby7l7oF34OOt5/MvvwfgqTEjKjXmyzFxNGwQUannrCmqdQn7kQ8MYvuuvYwYO43+fboTXicEP19vHnlgEKOemcE3P2xmrB1Xhz/69Fu1QxAaIvkglCQfhNLqH35VOwShMTJGCCvJhZopPz+fM2cv0KB+vRKP0es9bV8bso2FOrEAAgL8uRwXj5vO1dZJUtL1okH9epw5F1VJ0YuaQj4/FG/9hs0APPf0Y0Xua9akoW2KL5iLzcW5EHWZzp06MPOFZ8jOzmb7zt38e/h41QQMGLINRdYRtxdV1omlNP250bav335japH7B/TpwYA+PaojFE1b+NpktUMQGiL5IJQkH4TS/Amj1A5BaIyMEcJKcqFmiroUTVZ2Nk0bNyjxGP0VnVjZBiM6t4I1sZo3aYgxJxdf74LjSrpeNIysx1ff/VwJkZeNwZhDbl4enu5u1facoij5/FC83Lxc7r27H0GBAUXuc3Jywsm5oGxy6XIM4ya+zIypz9Dx+oJ16zIyM9F7euLmpiM0JIiY2HiGPzahymLONhhxc7PP36dq7cQSpZs59121QxAaIvkglCQfhNKsFZ+rHYLQGBkjhJXkQs2TmpbOo09OplGDCCIj6pZ4XKFOLIPRsjthQSdGi+aNAXBXLPZe0vUisn49zp6LKnXX98Mnz1zTrvAGY47t61eXfcRTsxdW+Fyicsjnh+IlJCYT4O9X4v2pqWkAeHvr2bBxKzt27eHYydOFjsnMzMLD0rEVHBzIb9v/rLqAgezsbLvtxJIilobc2r2T2iEIDZF8EEqSD0KpV8frrn6QsCsyRggryYWa5/Mvv+fCxcv8+NWHuLi4lHhcaHAQOp0r3novsg0GsrIN6BR/xLZoZi5iKf+wLel60SAynNS0dBKTkgvdfsfjk+jywJNcjkvg5uHj2GJZY6siEpJTbF//+uc/xFh2ThTqkc8PxUtMTCbA37fE+8eMepCWzRoTEhTA0vc/BiAtLaPQMekZmXh6motYIUGBfP9TwdRNF5fKnwB3ZSemPZEiloa0btFE7RCEhkg+CCXJB6HUupF9LuQpSiZjhLCSXKh5dv29l963dCUkOLDU4yLrh3Ns76+EhQaTmZnFuQsXqVc3zHa/3suTiLCQQkWskq4X1rW3rtyh8O9DRzh6+hwZWVkAJCanVuhnAth14D/b18fOnCctI6vC5xKVQz4/FC8+IanUItYbsyaz89evcHJytHUnpmcULmJlZmbh4W4uYil/LwHC64SRYunmqiwGgwF3KWIJtT3+7Ey1QxAaIvkglCQfhNITry1VOwShMTJGCCvJhZonMSmFkKDSC1hWvj7eODs7M+Xlufy4cWuRNbRaNKxfaDphSdcLvZcnrq4uJKcU/4d1Tm4eAI5OFf9z8ffd+2nRqL7t+7QM2RlPbfL5oXjxCYkEBvhf9bgPl83jhUlP0vnG9kU6sTKzsmwLwDdpFAnAj199yJL5szhz7gKtOt5OeiX+DmRnG9DppIglVPblRwvUDkFoiOSDUJJ8EErr3piidghCY2SMEFaSCzWL0ZjD/kOH8fXxLvNjlOtUNWvSsNB97Vs2xV9xrtKuF956L1LTii9iZWUbAHC07HJYEdt27+eOmwumt0oRS33y+cEsPz+ff/YdwmQykZ1tIDUtneCgoou6X6lFs8ZMmTCGkOCg4juxLEWswQP78MasyXS+sT397+jFuwtfJTc3jx27dlfaz5BtsN/dCaWIpSEffPKN2iEIDZF8EEqSD0Jp1Xeb1Q5BaIyMEcJKcqFmGXT/aFJS0spVxMrPz7N9be34sHrmoaGsfLWgUFHa9cJbryc1Nb3Y+zKzsgFwqGAR68LlGM5fjqGPpYhVNySItIzMa1ooXlw7+fxg7pjqe/dIbh0wnHmL3yfOslZbUBk6saz0Xp62TqzL0bHEJySSoShi6b08GTPqQRwcHPD18eaBoQOpExbC5ejYSvs5DLI7odACe62kiuJJPgglyQeh5OZa8sK/wj7JGCGsJBdqjozMTHb+9Q8ALuUY15WFpbDQ4EL36Vxd8PYq2MWwtOuFt7cXqWklFLGyzUWsnJzcMseldOL8RVycnWlrWWy+V6cO5OTmFtqxUFQ/+fwAR46e5K89+3l6zCN88L+1xMebi1iBgeUoYuk9bV2MLW64jfZd+5Ockobe07PEx/j5epN0DWvMKcUnJJKVLZ1YQgMeHNpP7RCEhkg+CCXJB6H0wB091A5BaIyMEcJKcqFmMJlMvL1ste37bEvRqCycnAp2Ortap1Rp1wvzdMKCIlZubkHBKsPSiZVlMJQ5LqXzl6IJDw1C5+rC86Me4N47egEypVBt8vkB0tIzcHR0pMfNN5KQmExsfAJuOh16r5ILUFcKDPAnITG50DkvRF2i4/Ul7/7o5+tDciUUseLiE2ja/lZyc3NlTSyhvv73j1M7BKEhkg9CSfJBKA2cOFvtEITGyBghrCQXaoZdf+9j7sL3uKX7TSye+zLDhgwo82OdnZ0AcxHqakq7XnjrvQrtmBYblwCAo6OjrROrop1TUdFx1LN0ib3w+HAiw827tUkRS1329vlhx649bN76R6HbUtPS0es9CQz0Jzc3l5OnzxEY6F+uqbOB/n62aYhW9cLr0MLSeVgcXx9vklOuvYiVlJxKfn4+Y0Y9SNs2La75fDWR89UPEdVl3Yfz1Q5BaIjkg1CSfBBKX8yZrHYIQmNkjBBWkgs1w66/9wKwcM50IuuHl+uxTo7mPoTDe3656rGlXS+unE4YHRMHgL+PnswscwdWRTqx/j50hAWrv+DO7jfZbtN7egCQesVi2KJ62dvnh/5DRwGQHHXAdlt6RiZ6Ly8C/P0AOHrsFEHlmEoI5qmHCQlJhW6749ZupRbC/Hy9iY6NL9fzFMe6Xt0Lk57Ey/J7ZW+kE0tDtu/aq3YIQkMkH4SS5INQ2rH/sNohCI2RMUJYSS5UvaEPjWP6q9e2C+S/h4/x8P13l7uABeDsbO5DKMsfsKVdL7z1+kJFrMuWIpaLszNJlg4tg9FY7vg279oDFJ7q6OVuXoC61yPPlPt8ovLY6+eHvLyCzRDS0tLRe3kQaCli/bl7X5l2JlQKDPAjPSOTs+ejbLd1V+zEWRy93qvIjoYVkZmZBYCHu30u6g5SxNKUvQeOqB2C0BDJB6Ek+SCU9h49pXYIQmNkjBBWkgtVJz8/n2cmv8IvW3fwzvLVbNm2s8LnOnbiDE2bNKjQY52cnMp8bGnXC72XZ6HdCa07p2UbjCRa1u7JNpS/iGXdgTA/v2AnQkfHgj87ZXF39djb54dWLZoCsH5DQddiWnoGei8v3Nx0NG/akFNnzjPu8YfKdV7rToZDHnzSdlvdsJBSH+PmpiM7u2JrzFnl5ubyyJjnAHBxsd9F+qWIpSFTnx2ldghCQyQfhJLkg1CaMmKI2iEIjZExQlhJLlSdzVv/YPWnXwEwcvg9PD35FdLSK9ZZcSHqEpER5e/CAhgz6gEi6tUp07GlXS+8vb1ISy86nTApNY21G7cAFSxiWYpX1mLWlU6eiyr2dlH17O3zg3X3vrcWryA/Px+A1NR02yLu40ePYOGcaXTvemO5zhsQYO7iOnXmvO22oKt0c7m7u9mmAhbno0++JCkphROnzpKTU3yh948//7GtXWfPpIilIU8+Z18L7YnSST4IJckHoTRu7ntqhyA0RsYIYSW5UHXeW7WGG69vy9+/fcvslyfh4ODA8lWflvs8BoORtPSMcq/DYzXwzt4c3PVTmY4t7Xrhc8V0wkvRMXh5uAOQbOnQqlARC0snlim/2PsvxsaV+5yictjb54f0jEwmjh/FyTPn+Hnz7wCcPnveVgQeft8gRjxY/sKecidDHx89UNCdVRIPd3eySihiZWcbmPDCbJZ9sIaOPe5i2co1xR535SL19kqKWBry7JjhaocgNETyQShJPgilZ4aVfRcrYR9kjBBWkgtVIzkllS3bdjHjhWdo2rgBnh4e9OremX8PHy/3ueItC0Jb1+SpSqVdL7y9vQpNJ4yOibNNVWwcUReAbKORi7HxHDl9rszPaZ1GqJxOCHBq4xfUCw3mkmJx6xRFEU1UPXv7/JCenkGTxg1o16YlDzz6DBcvxfDPvkM0a9Lwms6rXO/tf8vNm2m4uelKfUxpnVjnLlzEZDLxw8/mDkjlrqFWW3/fxdIVH1c05FpFilgaUlLLrbBPkg9CSfJBKOVLPogryBghrCQXqsbarzcAFJoC2LhhfU6Wo7hjFZ+YCBRMSapKpV0vvDw9ycjMtH0fHR3H0D49Cfb3Y+en7zFiUF+yDUbaDHyYmx8cW6bn++vgYf46aF48/Mpc9PPRU79OKBctRayYhEQa3HYvX/2yrbw/lqgge/r8YDKZLOtfeZKaZi4KLXp3FZdj4uh3R69rPv/slyex5oNF9Li5U6HdD0vi7qYrsRPrzLkLABw+egKADMvi7UqrP/2agXf2tm3sYM+kiKUh77xf/nZkUXtJPgglyQehtGTtBrVDEBojY4SwklyofAaDkcnT3wDAz8/bdnt43VAuXY4BCtaTKos//96H3ssTH2995QZajNKuFzqdKwaD0VZsuhQdS5f2bTj64xqcnZ3QubrYdicsa3H0rVWf8e+J00DxBZM6wQFcijEXsRIsi8fv3Huo7D+QuCb29Plh5197ycjMonWLpgT4m6f6xSckEhjgR726Ydd8/vFPPEy/PreU+Xh3dzeys0soYp0tvE5cRkZmkWOSklNo1CCCWS89S6cb2pUr1tpGilgasnTeS2qHIDRE8kEoST4IpSWTR6sdgtAYGSOEleRC5bEuBP2rYhdCD3d329cB/n4kJaewZ+9Bml/fm+Mnz1z1nJcuxzD7zSW88NzYQlOSqkpp1ws3nXn6k8FgJCsrm+SUVMIUi1O763RklXNNrLSMTJ55aCgzxo5k3nNFu7fqhgTx2Y+b8b/pTrIsO7VZ19ASVc+ePj8cO3GKyIi6RNYP54Ol5iL0qTPn8dZXffG4ONbphAmJSWRmFe60snZigfn3Mj2j6IYRSckp+Pp6M+7xh9j47eoqj1fLpIilIXMWrlQ7BKEhkg9CSfJBKL3x0ZdqhyA0RsYIYSW5UDn2HfiPBm26c/zkGX7Zsr3YYwID/DCZTEx71bwmztbfd131vJt/+wMvTw9Gj7y/UuMtSWnXCzd3cxErO9tg6yQLCywoYulcXUrdTa04qRmZ6D09eObhoTQsZgfFOkGBtq8zLV0pV66dJaqOPX1+iI6JJyQ4CIDQkCBu6tiOM2cv4O3tpUo87m5umEwmGl3Xk2cnv1LovkP/HaW+ZR26Th3bkZFRdDphUnIqfr4+1RKr1kkRS0M6tm+tdghCQyQfhJLkg1C6oWUTtUMQGiNjhLCSXLh2aekZPDjqWVJS0jh5+hy7S5juFmBZmP3P3fsB8+LvVxOfkETdOqG2BdSrWmnXC2snVrbBwGVLEStEsWOiu05HUjELTJcmzVLEKkndkCDb13GJyQC2jixR9ezp80NMbDyhIQVF0zatmpOWnoG3Xp0ilvJ5jTm5tq8Tk5L5a88BJo1/jOZNG9KhbSvSi5lOmJycIkUsCyliaUiXTu3UDkFoiOSDUJJ8EEpdrmuudghCY2SMEFaSC9fu9z/+Jik5lbphIZw6c47DR0/w3RcrSDi3t9BxAf6+eCkKNskpaRiNOXTscRdffvtTseeOi0+slgXdrUq7Xuh0roC5iBUdE0uAvx86VxfF/S4kpVRuEatOcEFRITbRvEtjZgnrBInKZ0+fHy5cvERYaLDt+7GPDcfR0VG1IlbTxg1sX+u9PG1f/7JlB3q9J/cPHcCfW77B38+30IYLAHl5eaoW4LRGilgact+o59UOQWiI5INQknwQSve/9JbaIQiNkTFCWEkuXLvftv9J507tiahXh59/+R2A69u3LtI95ezszLF9v9q+T05JZceu3Zw4dZYxz04jxrILn1KCZWHp6lLa9cLWiZVtIDEpBX8/nyL3l6cTy2QylaETq6CIZe3EyijnlEVRcfby+cFkMrF3/3+0a9PSdluDyHrcP3QAjRpEqBKTo6MjW35Yw4C+txZaE2vjr79zW8+bcXExF5C99V6kXPF7l20wdyt6uLtVX8AaJkUsDfn+03fUDkFoiOSDUJJ8EErr58vCzaIwGSOEleTCtdu24y963nwTQYEB/PHnHlq1aIKnR/GFGU8PD1Yvn49O50pySioxcQkEBfoT4O/Lz79sK3J8QmIyAX7VV8Qq7Xrh5madTmjEYDSisxS1bPe7upKbl1fm58rIysZkMuHtVXIRy9+nYHfHWEsRq7zrbomKs5fPD6fPnCc5JZUb2rcpdPuSt2Yx66UJKkUFHdq1JrxuGEeOnuTCxcsAnDkXReuWTW3H+Pn5kJiUUuhx2ZYpt25uUsQCKWJpyidrf1A7BKEhkg9CSfJBKK356Te1QxAaI2OEsJJcqLgTp86y/odfOH7yDD26dcLH27yLWasWTUt93F39evPs2EdJTkklNTWNwAA/Avx8ySpmmlxmVhaenu7FnKVqlHa9sHZiPfnsS/z5975CUwkBrmvWqFzPlWZZx6e0TizljozRcQkAZMqaWNXGXj4/7Nl3iAB/PyLrhxe6vTp2BL0aTw93Dh87SZtOdwCQlpZeaLF5fz9fUlPTyM0tWDfLum6cu1vhQrO9kiKWhuQoElUIyQehJPkglHJyy/4v48I+yBghrCQXKu7RsZMZMeY5wuuG0aZlM9sflkEB/ld5JISGBBITE09qWjreej06Nx0Gg7HIcVnZBjzcq6+IVdr1wsXFGYAjx07x/U+/4mpZI8uqZaNI2rcoWAjcZCp9F8GyFLEAls2YBMCvf/4DUGyxT1QNe/n8sGffIa5v11oTRasreXgU/P4PvO9xkpJT0XsVFLGsi7crN4ow2DqxpIgF4Kx2AKLAyAcGqR2C0BDJB6Ek+SCUHhlwq9ohCI2RMUJYSS6U3V979qPT6WjXpgXvrvyEQ/8dY+WSN+jUsV2hBaAD/H2veq66YaFcvBxNckoq3nov0jMybOvYKGVlZeNejevalHa9uPIPfFcXlyLHfPPO68xcuoqPvvmJ3Lw8XJydyco2kJuXR3JqGvXCQmzHlrWIdV/fW2lUry55+fkcPHaKpZ9+XZ4fSVwDe/n88Mef/zCo/21qh1Es67pWvXp0Zsu2XQDo9QULvVvXpktMSiHQUkDPkiJWIdKJpSFDRqg3P1doj+SDUJJ8EEpDp8xVOwShMTJGCCvJhbL578gJBt8/mp59h3Fd5768OHMeADd3voF6dcMA8NabpxOWZTfB8LqhGAxGTp05j4+3Hp2uoBMrPz+fA/8eAczrP1VnEetq14v+d/SyTSvUuboWud/by5OHBvYBwGDM4Y+9h6jbczA3DRtN28EjCx2bmp6Bk5Mj7rqr/6F9Q+vmdLquJb56L+kerEb28PnhfNQlDh89Qb8+vdQOpVg+lnXhRg4farvNOtYA+FruT1Us7p5t6VaUIpaZFLE05IO3X1E7BKEhkg9CSfJBKK2YNl7tEITGyBghrCQXymb2vCXk5ecDcP7CJdvtQYEFUwednMx/KoUGB131fOGWwteRYyfx9vbCzU1n68T6cdNv9LhjGOejLpGVlVWtO4xd7XrxycqF9L29BwCurkU7sQA8LItJZ2Rl2XYrvGxZz0opLSMTb0/Pck3hcnFxxpiTU+bjxbWpzZ8fUtPSWfXxWp5+fhYATRpFqhtQCQb3v53fN35Bl04dbLcpO7Hc3HQ4OTmRlp5huy3bUhB3K0OB2B5IEUtDDvx3TO0QhIZIPgglyQehdPDEWbVDEBojY4Swklwom9jYeDp2uK7I7U5OTravIyPMi0J369Lxqufz1nvh7a3n3PmLeOu9cNPpbDuKGY3mP0B/+HlLtU8nLMv1wsvT/Ae0Tle0EwsgxNKJFpuQhOGKglNKWrrt67TMzKtOJbySq4szxhzpxKoutfnzw9Ztu5j4wmv8tv1PoOSirNrc3HRc16p5oR1PgwMDbF87ODjg5eVRuIiVbUCnc8XRUco3IEUsTfltxx61QxAaIvkglCQfhNK2vf+qHYLQGBkjhJXkQtkkp6QyqP/tzHrxWdttyxbNLnTM7bd2I+nC/jJP4Qm3rA9lnk7oauvESkxKAeC33/+s9umEZbleWLtAXIuZTgjgo/fCTedKdHxikcXqL8bG277OyMwud5eZi7OzTCesRrX580NmDdsgwFo01ulcCQkOLHSf3suLX7bswDe8LSaTiazsbHTShWUjRSwNmTF5jNohCA2RfBBKkg9Cafpj96kdgtAYGSOEleRC8X797Q/2Hzxs+z4lNQ0/X2+eGTuStauXEBwUQK/unYs8rjxT46xTCr299bgp1sRKSEwyx7BtJyaTCQ+36tudsCzXC+t6PLoSOlccHBwICfDnUmwCBqMRb6+CqU+JyQU7qGUbjbiX0M1VElcXF+nEqka1+fNDRkYmTRs34OCfP7Hx29Vqh3NV1rElwM+3yH16Lw/WfrMBMO/emZ1twF3Ww7KRIpaGPPti7V9oT5Sd5INQknwQShMWrFQ7BKExMkYIK8mFohISkxj55GRu6fcAaekZmEwmUlLTbAso335rN47t/bVIN0R5hdcNBcxTC3U6V9t0wsSkFLp0up68vDyAau3EKsv1om2b5gDk55tKPKZpZD3+O3kaQ04O/j4Fi1AnpBQUsQxGY7GLw5fG1cWZ/Px822sjqlZt/vyQmZmFp6cHEeF16HRDO7XDKbPixgO9l5etCJ6enklGRiZe5ZyqW5tJEUtDHn1wsNohCA2RfBBKkg9C6dGBvdUOQWiMjBHCSnKhqLfeXklqWjomk4lP164nKzubnJxcfLwLijHl6bgqSUEnlhfnzkexYeNWZr6+iKiLl2nZvLHtuMj64df8XGVVluuFdW2w81GXSjymS7vW/LHvEAZDDr56L9vtCZapkgBGY06J3VwlcXF2Nj9W491YFy7H4H/TncQrft6aqDZ/fkjPyMTDvfq6HCtD/Yi6PDN2ZJHb9Ypux/T0DFJS0wqNV/ZOilgaokxWISQfhJLkg1Dy8qhZH9JE1ZMxQlhJLhSWmZXFdxt+4cnHhgNw7sJFDv57FAcHB+pH1K3U57IWg3x9vDFZmpoWvfshx0+eoWnjBtzS/SaAau2oKMv1IsDfvHD75ejYEo/p3L41R06d43JcQqF1r+KTC4o62cYc3MrdiWUueml9XazPf/oVgDMXL6scybWpzZ8fMjIz8fKsWT/fgZ0/8vD9dxe5fezjw21fp2WYi1jeUsSykSKWhry24H21QxAaIvkglCQfhNLrH65TOwShMTJGCCvJBbO8vDz+O3KCQcNGc/FyDC2bN+aJkfdz7vxF/t5zgJbNmxCk2BGsMnTr0pHfN35Bxw7X8f47r9tuP3HqLA0jI/jf+wv45/fvKvU5r6Ys1wtrF5pHKQWOds0b4+Gm47fd+2yFJ4Ck1DTb1wajsdw7wrm4aL8Ty5iTw+pvfwZgwYefqxzNtanNnx8yMjLxrCVT7m7t2ZWdm78EICMjSzqxruCsdgCiwMrFs9QOQWiI5INQknwQSiteGq92CEJjZIwQVpILZpu2bOf+kc/YvvfW6wkM8OPAoSPExScSFhJUJc97XSvz+lJX/sHp7+eD3suz2jvlynq9+H3jF4QEBYLRUOz9ri4udGzdgm179tMwvI7t9mRFESvbYCx/J5ZlOqEhJ8d22/wPP6d+nRDu6XNLuc5VVdZt3EpaRiYAG//4W+Vork1t/vyQmZlV46YTlqZl8ya46XTm6YQpUsRSkk4sDZm/VPu7KIjqI/kglCQfhNKCNevVDkFojIwRwkpywezS5VgCA/xs3/v66AkK9Cc+IZH4xCQCFPdVhSvX2FLrD9CyXi+ua9X8qgvbd+nQGgCdrqROrPKvieVq6cRqM/BhfvhtJ/n5+by2/H88MWNeuc5TlfYdPkGPju3UDqNS1ObPDylp6egV67XVBl5eHqTbphPWrp/tWkgRS0OaN22gdghCQyQfhJLkg1BqHll9iwKLmkHGCGEluWAWG5dAk8YN+HTVYgA8PdwJ8PcjPjGJhISkQgWu6uDr612tz2dVmdcLaweWzsWFxD9/ZNqYESSmKIpYOTm46crXieWimJr48NTZvLFyTeUEW4mysg14ebiz4tUpAJhMJe/iqHW18fPDkWMn+eB/a9m4+Xf8/XzUDqdSeXl5kp6eSXRsnLlTUgAynVBT+vTqqnYIQkMkH4SS5INQuv2mdmqHIDRGxghhJblgFp+QSFCAP56WhZ6dnJwICQ4kJSWNqEvRdL6xfbXG461Sh0hlXi/c3XQA6CxTBv28vQpNJzQYjLb7ysraiWX198HD1xhl5cs0ZOPv7U24ZQqqMSe33B1nWlFbPj9cjo7F09MDb70Xo8ZO4dyFiwD4+dayIpanJ2kZGVyOjqVOWLDa4WiGdGJpyJ33jlU7BKEhkg9CSfJBKPV/9lW1QxAaI2OEsJJcMIuJjSc4KIBunTuycskbtLuuJfXrmXcjPH7yTLXs9BWqWHdL2XFUnSrzeuGmMxexrLsT+nrrSUpNw/+mO9n0x99kG424lbO4c2XR68ppmFqQlW3A3U2H3rLwfXpmpsoRVVxt+fxwXee+RLToyouz5pGUnMKwewYAoCtnJ6DW6b08SEpKIT4hibDQELXD0QwpYmnIpq+Wqx2C0BDJB6Ek+SCUfn5nptohCI2RMUJYSS6YRV2KJrxOKI6OjtwzqC8ODg6EBAfi7uZGbm4unqXsxFdZjv6zmcO7N/H6zOer/LlKUpnXCw9LEcvN1omlJyk1HYAV677HYMwp9+6Enu5ubFy5gPBQc8HPycmp0uKtLNYilqetiJWlckQVV1s+P+RYdrN8d8UnJKek0bxpI8C8uHtt4unhwX9HTwBQLzxM5Wi0Q4pYGrJu/Sa1QxAaIvkglCQfhNK6X/9QOwShMTJGCCvJBbMLUZcJr1v4jz4HBwci65u7sTw9PaoljjphIYx9bHi1PFdxKvN64eZmLl45Opq7pfx9vMnPzwfgQnQsBmP5pxMCdGzd3FYYc9RgJ1ZmtgEPNx1eliJWRg0ulNSWzw8NIyN4fMR9AGRlZ9OkUSR9endn4J29VY6scnl5ebJn70H0Xp6E1wlVOxzNkCKWhiQkJqsdgtAQyQehJPkglJQL6QoBMkaIApILsH7DZhISk2jSOLLIfZH16wHgVU1FLLVV5vXC3dKJZS00+Sl2S0tITsFgzLEVo8rLwcH8Z6m1QKYlWdkGPNzc0FtyJiU9Q+WIKq62fH5ISU2jnmWjATCvOffFR+8QFlq71o3y8vQgLj6RZk0aanKqrVqkiKUhY0beq3YIQkMkH4SS5INQGn33HWqHIDRGxghhZe+5sGHjVkaNm8KMqU/TtnWLIvdHRph3Z6uuTiy1Veb1wlrEcnA0/wnpq1hXzJiTW+FOLDPzjn+ODtr78zTLYJ5O6Origq+3FzEJSWqHVGE16fNDj77DeHTsZJKTUwvdbjKZLEWsgk5LvUobJ1Q1Ly9PAFo0a6xyJNqivVHCjt3/+GS1QxAaIvkglCQfhNKD0+arHYLQGBkjhJW958KUl+cy9rHhTBg/qtj7IyMs0wk97KOIVZnXC+vuhNZOLC8Pd5wta1gZc3LINubgpqvYAvYmk6WIpbFOrNSMTM5EXcbD8rMH+/sRW4OLWOXNh27Dx/HAc7OqKJqSGQxGDhw6wtffbeTbHwpPkc7MyiI3N5fwOgVFrNraWRng7wtA82aN1A1EY6SIpSGLX5+idghCQyQfhJLkg1BaOLH4P86E/ZIxQljZcy4kJCYRdfEydw/sU+IxDSzTCT09q35hdy2ozOuFm866Jpb5T0gHBwf8fbwBMBhzMBiNuFZwF8aCIpa2/jzdte8QANdZOmFCA/2JSUik+0Pj2bBtp5qhVUh58+G/k2f4ecdfVRRNYas+Xsu4SS+Tl5dHYlIyAHovT5JTCndipVimRPr5edtuq62dWBGWKZMtmkoRS0lbo4SdO33uotohCA2RfBBKkg9C6cylGLVDEBojY4SwsudcOH7yDADNmjQs8ZhWLZpSL7wOAf5+1RWWqirzemHtRmpUr2AtIl/FuljZBmOF18Sy1LA0V8TKMhgJ8PWmaaS5+BkS4E9MQhL/njjNe5+vVzm68qtoPoTcPJDV3/5cydGY7T96ght7DmLiC6+x5ov1XIqOta3tF1k/nNS09ELHnzkXBYCPYjprdew2qoaGkREANC1lTLNH2hol7Nx3P/+mdghCQyQfhJLkg1D6/vfdaocgNEbGCGFlT7mQlZXNqHFT+GXLDgCiLkYTFOiPu7tbiY+pWyeEQ3/+hN6y1kxtV5nXCycnJw6uX83dt/Ww3eanKCQYjDnodBUsYtnWxNLWdMIr1/kKDvAjJj4RAFfXinWdqami+ZCTm8sn328E4Pc9+zEYcyotphXrvuf4yTO0bWNew27W64uZ+foiHB0dqV+vLr//8Tf97hmFb3hb+gwaQb97HgXAW1+Qe7V10fOO11/Hsb2/ys6EV5Ailoa8Pu1ptUMQGiL5IJQkH4TS7LHqbdcutEnGCGFlT7kwbtLLfLX+Z95ctByAx596gThLgUGYVfb1IjwkqFDBwDqdEMyFDrcKFna0Op0w64ruspAAf6ItOVbRrjM1XUs+5ObmkZqewaDxL/Lxd5XXldWkvnmzhQ/ffROAL9f/xObf/sBb74Wvjzd79h3ijz/3APDXnv22x1W0YFrThAQHqh2C5mhrlLBzU2YuVDsEoSGSD0JJ8kEoTX1ntdohCI2RMUJY2UsuHD95hq+/28jjI+4j6uJlMjIzAQgLCVI5Mm2p6uuFcjohUOHdCa3TCa3FLK0wGIzoFIvVhwb6cfbiZQBcXZ3VCqvCriUfcvPyGD1jHlCwyH9FmEwmPv5uI2kZ5t/ZjKxsunXpSMMGEXz1ybu88tIE23N4W/KrccP6FX4+UftU2W9ebHwi85eu5kJUNC6uzrz8/Bi2bv+b9T/9hp+PufVv5pSxNIwMZ/ufe1n+0TqcnZyYNukJGjeMqKqwNG3ooNvVDkFoiOSDUJJ8EEpDe3dVOwShMTJGCKvanguXLsewdfufpKamExwUwF39b2fl/9Zy4uRZALb9/IW6AWpMVV8vrNMJ/bz1JKWmoatgJ1Z+fj5gLpSU1cnzUdw5+nkOf/8Jzs5OFXreqzEYjbjrCgo2wQF+ZGRlA6Cr4CL2aipPPlxZUMzNy+MPy0L3eXn5FY5h8649PPP6Ynz1Xgy4pSvpmVl4Wab33tqzq+3cbm5u+Pn6AFC3TiidOrZjyoQx3H7Xw0THxAGwY9O6Igu/i9qvyopYDg4OPP7QEBo3jGDd+k2sWbeBOqFBPDHiHgb0KZhHnZOTy/wlq1m15BUuXY7jzXc+5P2FM6oqLE2rEyr/ciQKSD4IJckHoRQW6K92CEJjZIwQVjU1F9asXc/pM+eZPuWpUo/7av3PTJ+9wPZ9ZP1wTCYT7636FC9PD4JkfCykqq8X1iJWj47t+PbX7RXuxLoQHQtAXjmKWD9v/5v4pBQysrLwqeTd6Q6fOkuwvx9ZBmOhwlxIQMHrWdGfVU3lyYdsg7HQ92kZmbYCnvX/5WUymXh1mbkbbPOuPfy+Zz8ffLWBnt1ush3jYVmkXadzISTIPJXO3d2NpfNfAeCbT99j/6EjALRu2bRCcYiarcqmEwYF+NG4YQRJyalEXYqmaaNIoGjL6X9HT+Lro8ff14cWTRty7ORZ0tIzqiosTZsyc5HaIQgNkXwQSpIPQumFJf9TOwShMTJGCKuamgt//LmHtd/8eNXjEhKT6NypAx3atmL86IcJrxNK2zYt+PLbn2gQWa/WLvBcUVV9vfD30ePi7EzPG9sD4OxUsY6oQbd2A7CtN+XiXHKvhclkIiMrG+tbveWvvUxbvKJCz1uSmx8cS9O+95NtKLywe0hAwa6WFe06U1N58iE9MwuADpZC0aXYeEwmE00j65Fumb5bXrGJ5p0dw0OD+Pi7jew7cgKAk6fO2o6x7jSYn28iJMRSxFJMX2zRrDH33zOgQs8vaocqXRPrwH/HGXD/eM6cu8TQu8ytzWvWbeCBx6cwf+lqcvPyiE9MJiI8DAAnJ0fC64TYttRU+vK7X7j/8cnc//hkho95oSrDVs3H772udghCQyQfhJLkg1BaPetZtUMQGiNjhLCqSbmQkZnJ2fNRAMTFJXIh6hLxCcUvzH7sxGkuXoph0bsfEhwYwJYNnzJ7+iTAvF5Obm4uDerXq7bYa4qqvl74euvRubpwf7/ezJ88jvp1Qip0nlWvvcDIwXdy9PQ5AEIC/Uo89uvNv3PTsNEYc8w75D0x403e/eybCj3v1Sz+eB2m/IJpdcqOL9caOJ2wPPlgXbNqxKC+tttCA/2pFxpMRmbFOrGsj6sfZt5tb+n0ieY7FMVn6+6i+fn5hASbO0srczdEUfNVaRGrbaumbP1uFW1bN2XOwhX079ODac+NZsm8Fzl64gwbf/0DBweHQvNtTfmmYv8F5Z6Bt/HZijf5bMWbfPLenKoMWzVLVn6mdghCQyQfhJLkg1Bauu7q3QrCvsgYIaxqUi48/tSLtOvSD4DY+AQA9u7/r9Axubm5HDtxmm597qXVjeZ/FI+yLKxt5eVpXk+nYaQUsa5U1deL3p1vYNmMSbg4OzPy7n7XtLugi7MzmdkGoPQ1lxKSUrgYE8enP/xy1WPLKyUtnZS0dAJ8vXnmoaEAtnWggEJ/p+ZrbBH6sihPPlg7sQb07MKbzz0JQItGkXh6uJORlVWh57ee84H+twHQsF4dflw+j++/KOik81B0YoVaduZLTU2r0POJ2qnKdyd0cXHm3kF92Ln7AKHBgYTXCcHf14de3W7k3IVLBAb4cd5yIcrLy+didCyB/r5VHZYm1QkNVjsEoSGSD0JJ8kEo1QmSNV9EYTJGCKualAsHDh62fR0XZyliHShcxJozfxmdbhlMRHgdvvrkXQCyLIUOKy8vDwAaRtrn5lClqerrhd7Tg349ulTKuZyczH+aNmsQYStmFSfbaF6r6dSFS4Vuty4Ofy0emjKbBrfdS1JqOp3btQKKLja/aeUCAny9ycmped1B5ckH65RBLw8PmloKxM0bRODj5Ul8ckqFnt9a/Bra5xbid/6Ai7MzN7VtRQNFAdo2ndCUb1vjLkWKWEKhyopY32z4lWMnzmAymdi6YzdhIUGs/3EreXn5ZGRmsXvffzRr0oBWzRqSmpZBYlIK/x09ScumDfH09KiqsDTt7v63qh2C0BDJB6Ek+SCUBve86eoHCbsiY4Swqim5YDTmEGMpXHW9bSiXomNpGBnBvgP/Fjru738OADBt8nhu7dmV/70/n9XL3yp0jLUTq4F0YhVRk64XZ6LMjQ3jHriblLT0EhcPNxiNtGhUv8jt1i6fa5GTmwuYC2Ke7u4889BQZj01qtAxN7RuTo+O7cnJLboI/de/bOO6QSOuOY6qUp58SM/Mwl2nw9nZCQ838xS/Fo0iuaF1c3bu/bfI7oVlPaebzhVnZ6cSu/asv8/Z2QacLGuspaall/u5RO1VZUWs9m1a8O6qLxj22GS+3fArL018nKTkVB5/dgbDR0+lQf269Op2I87Ozjw//hGefuENFi77mOefGllVIWnerYMfUzsEoSGSD0JJ8kEo3TbuZbVDEBojY4Sw0moupKalM2rcFJJTUklOTuW2ux4i11Iw+O/IcQC6dOrA+ajC3TVx8Qk8MfJ+7upnnn408M7eNLFsGGVl7cSSIlZRNel64ehonqrXq1MHAC7GxBV7nMGQQ7B/0TWzklOvvdDhpljE3cNdx4xxI3nqwSFFjnNxdrIVvJReefcjoqKLj1sLypMPaRmZeFm6olo0iuTeO27hrl43c33LpsQlJROfVP5urPTMLDwta16VRKczvwfRive/aaMG5X4uUXuVvO3DNYqMqMPiOVML3dYwMpxHHriryLFdbmxHlxvbVVUoNcav36xUOwShIZIPQknyQSj9svQVtUMQGiNjhLDSai7s+nsvX63/mVYtmvL3PwfIyMjkx68+JCExiUfHTiYnJ5fmzRrx0y/buKnXYKZPeZoeN3fi2IkzLJgzvdRdB/Wenuh0rjVqKmV1qUnXi2UzniMjK5sgPx+cnBy5FBtvm8amlG00Fio2WaWkpwMVW1jeKi3TXLhJz8yydR8Vx9nZGWMxi42fvxxzTc9fEVPeWkZ4WHCxxbYrlTUfln76NRcux+LlaS5iebq78d7M5wGoX9e8KduZi5cJKucyQOmZWXh5lG3WlXWjhv/+3oSvr75czyNqtypfE0uU3Xc/bVU7BKEhkg9CSfJBKH33+99qhyA0RsYIYaXVXPj3sLnb6pU33ubnX7bRs9tNdOnUgQF9b6VRA/NaVk0bNSAhMYmjx0/z4Khnee+DNZhMJq5r3bzUc3ftfAOTnnrsmhYVr61q0vVC7+lBaKA/Tk5O+Hh5kVzCFDKD0YibW0ERq9dN1wOQXQk72KVnZlE3xLwjnoebrsTjiuvEqsj0usqw4svvmfHOB8SUsLOnUlnyITU9g+lvr+T9dd+hL6bg5OnuRkiAH2ejLhe5L6uEKaDKc+vLsHTQif1b2LrhUwDq1gnBs4yFL2EfZKTXkDPnL6odgtAQyQehJPkglM5eqv5/6RXaJmOEsNJqLsQnJBUqRnkp/pB9e95M1nywiGDLTmRWs99cUuTY4jRpFMnkZ0dXYrS1R029XvjoPUssYmUZzJ1Y1u68L+bPBCi2M6q80jIybdMZvb08SzzOxcmZ3CvWxLpkWeOtukXWDQXg2JnzVz22LPlw5PQ529fWTqyizxnGGcUuoQnJKfToO4y6zTpzOTq2xHNfio2nTnDAVWMICgzA19f7qscJ+yRFLA15ZvRwtUMQGiL5IJQkH4TS08MGqB2C0BgZI4SVVnMhOSWVFs0a275Xdq3ceH1b+vW5BX8/H9tt1l3JpkwYU31B1kI19Xrhq/cqtJj3qfMXbTljMBrRubry3/cfc/Dbj3BycsLJyRFjJewWmJ6ZRed2rUn880d89F4lHudcTCfWoWOngIJdFquL9VfpYkz8VY8tSz6kpmfYvrauiXWlBuFhnFUUsU5HXebAoSPk5+cTV0pHWFRMHOEhMu1XXBspYmnIiHEvqR2C0BDJB6Ek+SCURs5arHYIQmNkjBBWWs2Fw0dP4OtT0FmRl59f5Bhlx1VEeB0AOt/YvuqDq8Vq6vXC26ugEysnN5eO9z7Oup/NU2UNhhzcXF0JDfQn3LIOms7F5ZqLWCaTiYys7BILN0quLi7k5BXuxDqpUhek9eeOiim5A8qqLPmgXCC/pPWrIuuG2XaTBMhQ7AyZkZFZ4rnNnViBJd4vRFlIEUtDZr/4lNohCA2RfBBKkg9C6dUxD6odgtAYGSOElRZz4bsfN3Pg0JFC3Vd5eUWLWNZdyQD8fM1dWcrClyi/mnq98PX2IiXN3BGUbTACEB1vnq6XbTSic3UpdLyrqwuGa5xOmJltID8/v0xrNjk7O5FzRdEsPdNcvMnLy6/W9bGsHWFl6cQqSz6kpKfbplKW9Fo0qBvG2YvRtu8zs7PRe3ni6upCpqKgdaXU9Ex8SpmmKURZSBFLQ+ITk9UOQWiI5INQknwQSvHJqWqHIDRGxghhpbVc2PnXXha/+yEA585Hcd+Q/gA8PuK+Ise66QoW0na1FLSkiHVtaur1Qrmwu7WI5eTkBFimE+oK705YGZ1Y1iJUWTqxmkSEc/D46UJTCjOzDbaiT3FF2spmfV2MObk0CA/jYkzcVR9ztXwwmUxcuBxL08h6+Oi9SnwtIsPDiE1M4oJlN8bMrGw8PNzxcHcnPaPkIlZGVlaJ62wJUVYlFrGSklPZ+fd+Pvv6J95asppVa75h829/claji0XWBp+s/UHtEISGSD4IJckHobTm521qhyA0RsYIYaW1XFi45AOyDUbqhoUwYfwoli9+jeSoAzS07EioZC1SALRp2QwAH299tcVaG9XU64Wv3ouUdGsnlgEAZ0t+ZBvN0wmVXFycMeYUXqOqvKzFl6ttJABwe9eOZGRm8cfeQ7bbMjKzbB1MuVdMNaxsm3ftoU6PQbzy7ofk5uYSWTeMKEsRy2Qy8dmGzeQXM2X3avmw6Y+/eWfNV7jrXGnXvDGhlrXprtSgbhgAbQePZP/RE2RkGfBwd8fL04PMrMJFrCdefpPX3lsNmNcc83SXIpa4Ns5X3nA5Oo6P1/7AqbMXaNu6GXVCg+jaqR3JKWmci7rML7/twpiTw0P3DaDDdS3UiLnWmv/qc2qHIDRE8kEoST4IpXnPjFQ7BKExMkYIK63lQkxcPMOG9OepMSPK9bhnx44kLCRIdii7RjX1euGj9yQ5NQ0wF62goIhlMBSdTlgZnVhplk4sfRk6sXy99XTt0IYN23bS07JuW0ZWFj5enlyMiavyIpZ1J8K/Dx3BmJNLw/Awdlum7B46fppxry4gJNDfttOi1dXy4dDx0wC8NGYErZs0wNXZpdjjAhS/lwnJqWRkZeHh4U5urkuRNbG+3PQbAC+OftjciVWG11eI0hTpxNq1+wB9enVh+YKXGfvofQy6sxedO7alb++bGTV8MHNnTmDy04/yz/7DVf7LaW9enrNE7RCEhkg+CCXJB6E0Y/mnaocgNEbGCGGltVyIiY0npAILObu7u/HI8HtwcHCogqjsR029XvjqvWy75Nk6sZzN/RfZRmORTqzKWBPL2onl6e5WpuN7d76BHYpOrMwsAz56cydWXhX/nXwx1rz+1Zmoy+Tm5RFZN4z0zCxS0zNs0yIzilmbqrh82PPvUeIs05CPnD7HA/1v48Y2LfBwc8PZ2anI8UCh30ujMYfMrGy8PD04duI0z730erGPyTYYycvLx1OKWOIaFSli3T2gN21bNyt0286/9/PJuh/YtHUnRmMOYSGBPP7wEFs1XFSOO269We0QhIZIPgglyQeh1Kdzh6sfJOyKjBHCSku5kJeXR1x8YoWKWKJy1NTrhbe+YE2sLMvaT87O5j9dDcYc3NyKrolluOY1sbLwcNMVmtZampAAP1u3GEB6VhbentUznfBSbDxNI+txOc682H2DcPP0vosxccRaClLxSclFHndlPuTl5TH4qRe5adhoft7+F4dPnaVlo8gyxfDx3GkA7PnvKP+ePIOHR+nFv2WffwuUbc0xIUpz1YXdl69ex6EjJ4ioG8bJMxeYPHNBdcRll5o2qq92CEJDJB+EkuSDUGoaUUftEITGyBghrLSUCxeiLpOfn0/9enXVDsVu1dTrha/ei+TUdEwmk60Ty8mxYGH3omtiuZBzjWtiZWSVb70mH0WhDcyLm1s7saqiiKXc8TAlNZ32LZrYvg8NDMDJyZGYhCRbV1V0QlKRc1yZD6ejLpORlc31rZrxyrKPOHk+qsxFrH49utCyUSQLV6/luy078NbrWbnkDdzdii9mzbasi+Xhpiv2fiHKqtgi1snT521fR12MYdSDg+ne5XpGDR/MuajL1RacvRk3+TW1QxAaIvkglCQfhNL4N5erHYLQGBkjhJWWcuHUmXO4uDhTz9IlIqpfTb1e+Hh5kpuXxw+/7eSeZ6YDBYWhLIMRnWvld2JlG424XbHrYakx6r0wGHNsuwQmp6Xja9mIILeSdyd8ft5SBo1/Af+b7sSYk0NaZiZN6tez3a9zccHT3Z2MrGzOW3YMNFjiUroyHw4dP4WP3ou+3Tpx9PQ58vLyadW4QZnjshbtAIID/QkM8MNgNGIymUjNyCQqOtZ2/7133MKEEfdSNziozOcXojhFFnYH2LpjN+t/2soj99/FgD49ePK52QT6+3E+6jIPDLmzumO0G1988JbaIQgNkXwQSpIPQunz159XOwShMTJGCCut5EJsXAJDho+lSaPIMk/PEpWvpl4vfL29AFj55fe24pX1/wZj0YXdXV1dMFZwTayUtHTSMjIxGnOKnLc0PpadCFPS03HT+XM5LoGIsBAA8nIrtxPr+NkLbP/nIABxSSmkZWThq/fCy8Od9MwsnJ2d8PJwJyMri1PnLwIUW9S7Mh/+PXGaNk0a4uVh3pExwNebIH/fMsc19v7B9O3WmZffWYmbmxseHu7k5+djMOYw5OmX+Oe/Y7ZjmzWIYMKI+8r7owtRRLGdWI8/PIThQ/uz4n9f8e/RkyyeM5Xnxo/go6WzGXrX7dUdo91Y8b+v1A5BaIjkg1CSfBBKK7/dpHYIQmNkjBBWWsmF3XvNf3CvXl7+olpoiHRqVJaaer3w8fIq9H+A3Nxcy/TCoh1T19KJ1W/MZK4b9AiGnBxcXcpRxNKbY0tJyyA1I5O0jEzqhQabY63k6YSJKQVrb8UmJJKemYmXhzt1LOvNuVo6seKTUjh5PgowF/uudGU+XIiOJbJuKB7u5il+fpZOsrLq16MLjwzuC0BcQiIelumYmdnZ/HfyTKFjw4JkbTxROYrtxAIICQ5g6rOj+O/oSV6b/z5dbmzHnbd1q87Y7I6Xl4faIQgNkXwQSpIPQkkWRRVXkjFCWGklF/YfPEynG9rRsnmTqx+s8McvXxJQjk4QUbqaer2wTlP7YdtO2jVvzP6jJ8nNy8NoWffqyumELi7OFe7EOnzqLEC5O7H8fcwFn4TkFNtufeGh5gJs5RexUm1f3zryWQD0nh7UCQ7k+NkLuLg4o/d0Z/rbKwEIDfQvdrfGK/MhNT2T0MAAPCzrWLnpyr9elZeHO08Pv4dHRo+wvQ6ZWdlFNoFrWK9mrs8mtKfYItbhY6d4f/WXZGRm4+/nzZhH7uXU2Qu88Opi7hl4Gze0a1XdcdqF++/uq3YIQkMkH4SS5INQGna7/KOSKEzGCGGllVw4cOgIbdu0KPfjWrUoX9FLlK6mXi+UHVF1Q4IwmSAnN8/WXXTlwu46FxeMude2sHt5O7FcXVzw9vJk96EjdLuhLQD+Pt5A5RexklLTcNO52tbfAnMRq2fHdvz29z50Li6FCnAtGkUWW8S6Mh9S0zPQe3rgaSluOTledd+3Ys0c/yiO4XWJiY0HICMrG2fnwkWs9vK7LSpJsVk6+633mTj2YVYsmsED9/RjzqKV9O5xE7OmjuXIsdPVHaPd6Hvvk2qHIDRE8kEoST4IpX7PvKJ2CEJjZIwQVlrIBZPJxP5Dh2nfVv7hW2214Xrh6uKCk5MjeXl5tiJOZa6JZXU5LqFcnVhgLgLNXPohmVnmHRT1nuZOyLxKLGJZF4+fNmZEodt9vb0Y98DdfD5/JkH+voWKVg3Dw4p9Pa7Mh7SMTLy9PPC0dGLlm65tQXoPj4LphK7O5tdy3AN3c3Lj57g4lzgJTIhyKbaIlW8y2VoBoWA7T52rKw/dN6B6IrND6z95W+0QhIZIPgglyQeh9M1bL6odgtAYGSOElRZy4XJcArFxCbSrQCeWqFw1+Xrx+oQnAHPXlYuzM7m5ecxcugoAT3e3QsdWxu6EH33zE1HRcRV6bEZWFjpXF1snV2V2YuVYOsw6t2vFD8vmsnDq0+z96gNaNW6Ak5MTt3e9EaBQEcvdza3Y1+PKfEjNyMDb0xNPD/Prafmzv8I8LO9LXGIysYlJAHS6rqWtQ02IylBsEWv6c08wf+lqHn92Jp+u28CLEx6v7rjs0pbtf6kdgtAQyQehJPkglLbuOah2CEJjZIwQVlrIhQNHT+Lh7kbTxg3UDsXu1eTrhXWdJp3OBWcnJ3Ly8vj8x18B8PctXBS5ljWx/H28bR1USalpVzm6sJnjHwUgJiEJdzedbR2oSXOXVCiW4li7upwcnejSvg0jBt1BZN2wQk0nAE/cOxCAPl1vROfiXOzC7lfmQ1pGFnpPD9vPb7zGQqCTkxNuOh2ffFewgHxnWYpIVLIiRazLMfG0at6YRa9PYcWimcydOYEG9esWeeCl6NhqCdCeHPzvhNohCA2RfBBKkg9C6eDJc2qHIDRGxghhpYVcOHDsJK1bNsPpioWdRfWrydcL6zpNOldXnJ2dSM/ItN1nLXBZVXRNrLy8PFLS0/nfG9OA4nf0K82gXuY1pi7HJeCuKyhi7T96styxlBhjvnmKn7NT6etVPTSwD7E7vuez+TNxdXUpdk0sZT7k5eWRlpGJj97TtithmuI1rigPD3ecnM2x9u/ZhQBfn2s+pxBKRSam7vp7Pz9v+YPbb+nCjR1aExYShIuLMyaTibj4RI6eOMu3P27B39ebqRMeK7LrgKi4yU+PVDsEoSGSD0JJ8kEoPf/QYLVDEBojY4Sw0kIuXI5LICJcdiLTgpp8vbCu06RzMXdinb8cU+KxFV0TKzohiby8fOqGBAKQXc5z+Hp7AXApNh5PdzecrlJoqojcXHMnlmMZ/u62Lqauc3UttqtKmQ9xSSnk5+cTEuCPo2VB98oqYmVlm9cIS0opX2ebEGVR5Lfs7gG9WfT6FHJz81i2ai0jn5rOPY9MZNhjk5mz6AMOHT7Bc+NHMO250VLAqmRPTJildghCQyQfhJLkg1AaM+ddtUMQGiNjhLDSQi4kp6Xj6ytr4GhBTb5eeLjrAPNUQRdnZ85ejC7x2IquiXXZsptenWBzESs/v3wLm+s9PXBxdubQ8VO4u+lwcHDgsXv6065543LHUpKydmIp6VxcyC6mq0yZD9HxCQCEBQXYbiuue6u8PD3ciU9KAeCl0Q9f8/mEuFKxWwR4uLsx7O47GHb3HdUdj12b/PSjaocgNETyQShJPgilmvwv66JqyBghrLSQCylp6TSThZw1oSZfLzzdzdMJMZlwdnLi7MXLuOt0bFq5oMixFe3EysjKxsHBAXedrkIxOjg48OSwQbz9yZd0uq4lAC0bN2DLn3srdL7iKNfEKiudqwsGQ8mdWL/s3M2zc97Gw01nWw/r47nTCA8JvuZ4PTzciYuJo2lkPW6S9bBEFaj8fkdRYQZD+eZgi9pN8kEoST4IJYOx/Ot+iNpNxghhpYVcSEpNw8dHr3YYgpp9vagXai6o5OXn4+TsSEZWNm2bN6ZVk6IbBrg6O2PMLVy0MZlMpGdmlfocxpwcdK4uODg44O/jTf+eXcod50tjHuamtq3w1ZunFvrqvUhJTycuMblCC6W/8u6HfPDlD7bvK9KJ5enuTmZ2dpHbrflw5PQ58vPzmfbkCNsC8f16dKFtJXSQebibO7Gu3EFSiMoiRSwNee/DtWqHIDRE8kEoST4IpeVf/6x2CEJjZIwQVlrIheTUdHylE0sTavL1IjjAjy0fLeapB++xdUqFhwQVe6yumE6s7f8cIKLXEKJK2ZDMYMzB1cUFgJMbP7ct8F4eLs7OrFv0Km+/9CxgLmIlp6Vz+2MT+XTD5nKfb9H/1vH8WwXT/sqzJpaVt5cHqekZGHNy+EwRgzUfsg1GGoTXYcx9g8od39V4eriTZTAUWXxfiMoiRSwNeWfuC2qHIDRE8kEoST4IpcXPPa52CEJjZIwQVtWZC3l5efjfdCd7Dx8HYMpby7jx3se5EB1LSFBgtcUhSlbTrxftmjfBz0dPHUs+1S2hiOVazJpY1i6sWe9+aLvth992snD1F7bvDTk56CxFrGvh6e5GkL8vAMH+vuTl5XPuUjSxCUkVPmdiSipQsU4sHy8vMrMNfLx+I+NeXWBbYN2aDwajETeda4VjK02IZX0xTw8pYomqUexvQn5+Pht++Z0PPvmGA/8eK3TfY8/MqJbA7NHst5arHYLQEMkHoST5IJReW6V+p4XQFhkjhFV15sKo6XMB+Oc/898LB46d5OT5iwC0bNGk2uIQJast14vwUHPxqvROrMJTJ60dTF9t2kaqZde9Rf9by6vLVtuKS0ZjDq6u117EUgoO8Ld9nZKWXu7HN42sB8DmnXsAyK3Amljeek8AYpOSAcg0mHcLtOZDtsGIm2vVFLFenT6RkYPvpEfH9lVyfiGKLWK9+faHrP12I8kpqby+cCUz3niXnBzzoGDMqbnzqrWuayf5RRcFJB+EkuSDUOpyXQu1QxAaI2OEsKquXEjNyOS7LTsA89QlgMxsA0P73ELbZo2pGxZSLXGI0tWW60XrJg0BuKlt8QuFu7vpiqwBlZNb8HdrhqUry9rRdfD4KaDyOrGU/H30OFm6plLSM8r9eOsOidv27C/0fXk6sby9zEUsaxEt3VLEs+bD7n+PotNV7s9t5evjzfwp43ly2KAqOb8Qxf4m7Dt0lA8Wz2LSuBGsWT6HsJBAJrz0JplZ2VjWfRNV4Ib2snuDKCD5IJQkH4TSDS0rb+tuUTvIGCGsqisXvtuyAz9vPfXrhJKRaS4eZGRl0aV9G7auftu2WLRQV225XtzQujmJf/5Y7KLuAN6enqRnZtl28oPCzRfZlg0PrFMO/z1x2nxMFXRiOTo60r9nF65v1azcnVg//r6Lk+cv0qheHY6ePgcUdGKVZ00snyuKWOcuRfPn/v8YPf11tv9zgD3/HiU6LrFcsQmhFcUWsbz1njg4mO9ydnZmzMh76d7lesZPfo3cnLziHiIqwUNjXlQ7BKEhkg9CSfJBKI2YsVDtEITGyBghrKojF0wmE/9b/zN339Ydfx89l+PimbZ4BanpGXjJOjiaYi/XC2vnkXI3QmNOLnpPc5dglmU6XUaW+f6Dx6quEwvgw9de5JZOHUhJK18n1vDJrwLQpmkjTpyLAiAvr/ydWF4e7oQG+rP/6EkAhk2ayTebf8c3MNQ2TdG61pYQNU2xvwl9enXlo8++LXTbvYP6MLh/b85duFQdcdmlbz9ZrHYIQkMkH4SS5INQ+nqeFCxEYTJGCKtrzYX0jMxC3SzFOXXhInv+PcqjQ/rj5eHOV79s493PviEhORVPd/dren5RuezlemEtVqUqpu/l5ObYilvWTqz0jCwiwkI4dPwUH3z5A5//uLnSO7GUMaVZpvGVV7C/HxlZ2ZhMpgqtieXg4EC369ty7Mx5220rvvyekyeOsXzteoAiuzkKUVMUW8S6Z+Bt3DPw9iK3D+jTg4/efa3Kg7JXqz//Tu0QhIZIPgglyQeh9L8NW9UOQWiMjBHC6lpzofOtQ2jc9hb63TOK5OTUYo+JT0wBoFG9Oni6u3P2YrTtPg933TU9v6hc9nK9sK7LpiwaGXNybbdnKzqxOrdrxakLl/h68zaOnDpXJZ1YAB66out0lZXey8NWwLIWlcvTiQXQ7Ya2RW4LCAzC1fLzZhuNFYpNCLWV+Jtw8vR53lqymskzFjBl5kIWvPs/9h06SuMG9aozPiGEEEIIIUQ1SE5O5ULUJR55cAh//LmHf/Yf4v5Hn6Hrg08WOi4pNQ0vD3dcXVzwvGL6oHRiCTUUdGIVFLFyc3Nx1+lwcXYmy9qJlZlFm6aNAGzT9Yw5VdOR5OHuRma2oUKP9fHyAswdZFPmvweY19oqj+7XFxSxPp47zfb1ezOfA8AgnViihnIu7sZVa75h28493NajM9e1aoLJBLFxCSxc9jG3du/EiGEDqztOuyCvq1CSfBBKkg9C6eF+t6gdgtAYGSOEVUVzITkllQVLPgBgwvhRbNqyg38PH+enTb8VOTYxNRU/bz0AYZbd3qy8PKSIpSX2cr1wdXHBTedKakbBdEJjTi4uzs64u+nINhjINhhJSE6lWYMIAOKTzB2Fe/47ViUxebi7kZlV9k4sZTHN2kFmzMnhv5NnAMq9WUJEnRAeGdyXx4b0p2Vj84L4CfFx3Nm9c7nOI4TWFFvO3bL9bz5YPIvh9/bn9lu60KdXFx66bwArF81k09ad1R2j3Rg0/Bm1QxAaIvkglCQfhNLdz7+udghCY2SMEFYVzYXlqz7l7fc+okmjSLz1Xtzaowtff7/Rdv/F2HjbVK2klHT8fbwBmPLYg6x4ZbJt7aG6IUHX+BOIymRP1wtvT8/C0wlzc3F1ccZd50q2wcjan7eQl59Px9bNbfkLkF9FC5x7uJVvOqF1l08o6LoqTxGsOAumPGUrYAE0btIMgNVzXmLtwleu6dxCqKXYIparizOnzkYVuf30uSh0VbTwnYCP37Ofi4y4OskHoST5IJRWz5qgdghCY2SMEFYVzYWfN//OvYPvZP3n7wMwZNAdHDh0xHZ/m4EPc9/EGQDEJyXj72suAni6uzHk9p44O5kXnZZOLG2xp+uFt5dH4YXdc3JxcXHBTafjpUUrmPTmEl54fDjeXp4E+PoAMHLwnfy8Yn6VxOPh5obBmHPVjRKsrDsnAkSEBQNw7OyFSo3p9KkTAAy4pStN6odX6rmFqC7FFrEmjXuEqa8s4sHRU5nw0ptMeOlNHnh8CtNee4fJTz9a3THajT37/lM7BKEhkg9CSfJBKO05fFLtEITGyBghrCqSC5di49l34D/GjHqQOmEhAFzXqjkhwYWnCv5jmXYVFRNH+BUdV889OozmDetXMGpRVezpeuHt5VloTSxjTg6uzs746r2ITUxiyqgHee7R+wEICfADoEv71tzYpkWVxGPd5KCs62KlZZqLWEc2fEKLhpEAbN9zoFJj8vT0qtTzCaGGYotYrZo34quPFvDihMcYcEdP7up7C9Oee4K1q96ieZMGxT1EVII//tqndghCQyQfhJLkg1DaefDI1Q8SdkXGCGFVkVz4ZeceQkOCaHddS9ttDg4O9OrRpdBxJpMJgAvRsYSHFi5ijblvEDs/XVaBiEVVsqfrhd7Do9B0wpzcXFxcnBl8W3cAgi2FK4DIuqEAuLtV3W6aHm7mTQ+UUwrPRF1mzQ+bij3+TNQlPNx0BPr62GY/bdu9v9Li8fPW0yhSCs2i5itxiwNHR0daNW9Mr243cuzkWVo2a1TuHRFE+Ux7brTaIQgNkXwQSpIPQumlR+9VOwShMTJGCKuK5MK+I8e58fq2RT7r33Fr92KPvxwXX2RBd6FN9nS90Ht5FFnY3dXFmQhLd6FyHayG9eoA4K6ruiKWp7uliJVV0Ik1b9WnPDV7EamKYpvVvyfO0KJRJE5OTuhcXQE4ePxUpcVz/KdP2bx8TqWdTwi1lKkqtbMSK8CiZE9NkUFFFJB8EEqSD0LpmbdWqB2C0BgZI4RVRXLh8KmztG7ZtMjtd/W/jYVvTLN97+Rk/tMhLSMLH8tC7kLb7Ol64e3lSUpahm2hdmNODi7OzgQo1m+zat2kIQC5ZVyvqiL8LEWzhOQU222NI8zrUB227Dio9O+J07a4XF2cKz0eJycnJiz4oNLPK0R1K1MRy9I5LKrYmJH28y8l4uokH4SS5INQGn33HWqHIDRGxghhVZFciE9KJqSEzip/X1/b1y7OzphMJtIzM2UB9xrCnq4Xek8P1m3cSt2egwFIy8jE29PTNq1PqUfHdjwyuG+VrYcF5qKZh5uO+KSCIpajowMASSlpRY7/7+QZWlt2EnRwcLDdXie48roe7SkfRO1VpiLWtElPVHUcAtDpXNUOQWiI5INQknwQSjrXyv8XWlGzyRghrErLBZPJxP8++5ovv/2JWXMW225PTkvHVzHVSslVV7AzeZbBQGa2gby8fPSeHpUXtKgy9nS98LZ0BxqMOQAkJKfi56OnfYsmvDFxDN2ub2s71sXZmQVTnsJHX7ULnQf5+xGbmGT73hpbUmrhIlZaRiZnoi7Tqpj1p70rsevRnvJB1F4lFrEuRcey79BRMrOyadqoYAG4t5asrpbA7NGbb69SOwShIZIPQknyQSjN+/gbtUMQGiNjhLAqLRcOHT7G08/P4rHxU1m4dBUnT58lPz+flLQMfH2LL2K5KdYMysvL55YRTwHgJUWsGsGerhfeV+RkYkoqAb7eODo68sS9A3F2dqr2mAL9fIhLTLZ9n5OTa4mtcBHr6JnzALRsXLSI5VGJi8/bUz6I2qvYUuzX329m8ftrCK8TQmJSCk+OvJeBfW8B4NCR49UaoD15f+EMtUMQGiL5IJQkH4TSey+MVTsEoTEyRgir0nIhLi6h0PcJickEeLpjMpnwKaETS2cpYoUFBXA5LoGT5y8CSCdWDWFP1wtlTu7cd4jjZy/Y1qVSi4/ei9R0xWLzueYiVvIVnVjJqWm46VyLFOIAPnztBf46eLhS4rGnfBC1V7GdWF98u5EvP1rAmuVvsHLxLDZt3cV7H64FZH2sqvTm2x+qHYLQEMkHoST5IJTkX1LFlWSMEFal5UKa5Y/p7ZvMn+uzDQYuxycC4OujL/Yxnp7mta9CA/0L3a6XNbFqBHu6Xiin3X239Q/zbSoXWz3d3cjMzrZ9b7RMJ0y7YnfCbIPRtiPhleqFhXBPn1sqJR57ygdRexVbxPJwdyMowA+AumHBLHp9MhcuRjN38aoq2SlBmF3XqonaIQgNkXwQSpIPQum6xvWvfpCwKzJGCCtlLqxZu55pr863fZ+alk5k/XDatGyGm06HIdvIt5t/p25IEHXDQoo9X/16dQHzzmZWPW5oJwu71xD2dL1QFrHy8vJo36IJvTvfoGJE5iJWRpaiiJVrLmIZcnIKHWcwGnFzdaGq2VM+iNqr2CJW6xaN+WnzDtv3zs7OvPLCeHJycjhy/HS1BWdvenXrpHYIQkMkH4SS5INQuuWG69QOQWiMjBHCSpkL4ya+zJLl/8NgMALmTiy95Q99nZsrBqORhOQUOrRsiotL8X9AWxd893Qv2OHtmyWv4+hYpv2hhMrs6XrRtH647esL0bF0atuq0C5/aihSxLKsiWVUFLH2Hj7OEzPmldiJVZnsKR9E7VXs1Wf84/cTXqfwv8Y4OTny0qQnmDj24WoJzB7dNfxptUMQGiL5IJQkH4TS4OdeVzsEoTEyRggrZS40tSwSHdKoI3PmLyMtLQO9l3k3NjedDoPBSFpG5lXXt1o95yXemTah6oIWVcaerhfhocG2ry9Ex1JP8b1aPNzMRayHp86m+0PjbQu7W3cpBFi02jy9V3dFJ9bGlQv4YsGsSo3HnvJB1F7Fzg3UubrSMDKcLdv/JiYuAQccCA0OoNMNbRgy4LbqjtFu/LR2mdohCA2RfBBKkg9CacPil9UOQWiMjBHCSpkLSckptq/nv7OSJ0YOQ6+3dGLpXMk2GEjLyCKiTvFTCa0G3NK1aoIVVc7erhcrXpnMS4tWcOFyLBFh6hexPD3cyczKZsuf/wDQsF4doHAnlk5nLl5lGQyFHtuxdfNKj8fe8kHUTsV2Yu34cx9DH5nEhk3bOHfhEmfPX2T9T1u555FJ7Np9oLpjtBufff2T2iEIDZF8EEqSD0Lp803b1Q5BaIyMEcJKmQspqWm8+NxYwkKCCPD3Zedfe2nWuCEAzk7OHD1+ivTMTFnfqhazt+uFi7MzsYlJpGdmUS+09OJsdfB0dyNTMZ2wuE4sN8sOoMmp6VUej73lg6idiu3Een/1Oj545xXCQgIL3X45Oo4psxbSuWPbq544Nj6R+UtXcyEqGhdXZ15+fgwBfr5Mf30JiUkp9L3tZoYP7Q/Atz9uYd36TXh5evDqC+MIDgqohB+t5klPz7z6QcJuSD4IJckHoZSemaV2CEJjZIwQVtZcMBiMGI05dO96Ix07XMfgB8YQExvP+2+bpxOdPnueJcv/R7vmja86nVDUXPZ2vXBVrO2mhemEnu5uhd4DaweWshPLxdm8aUJ1vFf2lg+idiq2iGUygbfes8jt3npP8k2mMp3YwcGBxx8aQuOGEaxbv4k16zbg5elBj643MOjOWxgxbhrdO1+Pl6cHH3/xPWuWv8H2P/ey9IMvmDV17LX9VDXU4w8PUTsEoSGSD0JJ8kEoPTbodrVDEBojY4SwsuZCekYGAF6enrbF2Tvf2N62TpZVWkYm3mUsYnl5uNM0sl4lRiuqmr1dL5wtBSEvD3d8vb1UjgYahNfh3OVo2/fW4pWyEyu1Gv8Rwt7yQdROxU4nvGfgbQwfPZX5S1fz8Rff8/EX3zNvyUcMH/MCwwbfUaYTBwX40bhhBEnJqURdiqZpo0h2/r2fdm2a4+zsTJsWTdi1+wB//XOIpo0icXPT0a5Nc3bt3l+ZP1+Nct+o59QOQWiI5INQknwQSsNenKd2CEJjZIwQVtZcSEs3F7H0ek/CLB0pw4cNLnJ8TEISAb4+ZTr3yY2f89P7b1VSpKI62Nv1wtXF3KNRLyxY9Z0JATq2aY6jQ8Gf3AZjDnpPD1sxKy0jk6TUtGqLx97yQdROxXZi3XXnLXRo24LfduwmJi4RR0cHwkICWfLmS9QtxwJ5B/47zrjnZtOhbUuefmI4769eZ9v1MCI8jPiEZHJycokIDwUg0N+XvPx8sg1G3HSFtxj98rtf+Or7XwAwlbEbrKZZ+uZLaocgNETyQShJPgilJZNHqx2C0BgZI4SVNRes0wr1Xp74eOtZ//n7dL3p+iLHp2dm0TC8TpnOrZyqJWoGe7teuDqbc7ROUOBVjqweHm5utG/RhL8PHQEgMSWVsKAADMYc/j1xmu4PjcfPW19t8dhbPojaqdgiFkC9uqE8dN8AALbt3EOPLjeU++RtWzVl63er+N8X3zFn4QpzNdxSgMo35ePg6AAOhYtSpnwTxRXN7xl4G/cMNO+MmJubS7d+j5Q7Hq07fuocgQF+aochNELyQShJPgil4+cvEejrrXYYQkNkjBBWv/3xNy6OjgQHm9eY9fI0LxHS4+ZOhY5zdXXBaJnSFBkeVr1Bimpjb9cLF0snVkigv8qRFOjaoY2tiBWbmMz1rZoRFR3LhcuxACSlptE0sh739e1V5bHYWz6I2qnY6YRXWrXmmwo/gYuLM/cO6sPO3Qfw9/Mh6lIMABeiogkK8CMowI/zF83zhOMSknBxcUHn6lraKWutn3/doXYIQkMkH4SS5INQ2rhrr9ohCI2RMUJYLVj6ESPGPEdKahpuOh2ursV3T/299VsAQgP98XR3q8YIRXWyt+uFi7O5iFU3JEjlSAp0btfa9nVqegbhIUEYjDmFpjvOnfQkE0bcV+Wx2Fs+iNqpTEWsisze+2bDrxw7cQaTycTWHbupX68OXTu1Z9+ho+Tm5vLvkZN07tiWGzu04cSpc2RnG9h38ChdbmxX/ierJV55YbzaIQgNkXwQSpIPQmnW6AfUDkFojIwRAuDchYsc/u8wANt37qauZRmP4ri56QBoIF1YtZq9XS883M153b9HZ5UjKdDpupaFvq8bElRod0KA4GrqpLW3fBC1U5mKWPcM6F3uE7dv04J3V33BsMcm8+2GX5n81EhGPjCI7bv2MmLsNPr36U54nRD8fL155IFBjHpmBt/8sJmxo6q+Aq1Vk6bLQpmigOSDUJJ8EErPL/5Q7RCExsgYIQBuv+thwiPqA/D1+p+pV8paV+6W7qsGZVwPS9RM9na9aBwRzqmNX9CmaSO1Q7HRe3rwxsQxtu8j64SSlpFJvinfdluwv2+1xGJv+SBqp2LXxEpMTsHPx9vW4hgY4MenX/5Is8aRXN+uZXEPKSIyog6L50wtcvvbbxS9bUCfHgzo06M8cddKw+/tr3YIQkMkH4SS5INQevAOuWaKwmSMsE8nTp3lUnQMPbp2IjEpmZjYeJo09qbHzZ3YtuMvet9yc4mP9bAUscq6qLuomezxeuHnU30LpZdV326dmLrgPdx1OnrddD1ZBiN/HjB3TTo7OVXb4u72mA+i9im2E+u1+e9z+lwUAO9+8DlLVnzGpeg45i9dzUefrq/WAO1JYDVV4EXNIPkglCQfhJIsyiquJGOEfeo/dBR33fcEAN98v4ngoADW/W8Jvbqbp1LVK2WqoIuLCy4uzjKdsJaT64U2WIvGQf6+BPr50LF1c7799XfbbY6OZZogdc0kH0RtUOxvS1xCMo0i6wGwa/dBVr3zCs+NH8GKRTPY8Mvv1RqgPZn2+jtqhyA0RPJBKEk+CKXp761ROwShMTJG2KfU1HQAUlLT+OKrHxhyV19mzH2Xjte3BSh1OiHA6uXzueOKXQtF7SLXC23wcCsoYoG5MysqOg6AYP/q21lW8kHUBsUWsdx0rpw8fR6ABvXrkpmVDUBuXh5uOl31RWdnVi99Te0QhIZIPgglyQeh9OGMZ9QOQWiMjBG1nzEnhw8/WUfPO+9n+apPycvLw8PDHYDnp83h738OcFe/3qxe+hrtr2uJv58vLZs3LvWcd97eE3c3+Wxfm8n1QhvcdK44ODjYClY3WwrNUFDYqg6SD6I2KLaINXHswzz38nxmvPEuPt5ePD9jAa8tWMGDo6fy8LAB1R2j3Vi8/BO1QxAaIvkglCQfhNLbn3+vdghCY2SMqP12HzrKhKmz2X/wMMtXfcY/+/8lITGJ5YtfY+3XGwBo27oFi5d/gru7GycPbKVt6xYqRy3UJtcLbXBwcMDDTUegnw8A9RU7h1bXzoQg+SBqh2IXdm/epAGfrZzLlt//5nzUZZo3iSQ4KIBlb02nXt3Q6o7RbjSIqKt2CEJDJB+EkuSDUIpUfPgVAmSMsAcxCYl4671ITUunRbNGJCQm4eHuxn1D+vP9T7/iptPh7u5my4XqWmNHaJtcL7TDw83Ntguhv0/B2lTVtTMhSD6I2qHYIhaAu5sbXTu1p3HDCBwcHAgJ8senmnZNsFcD+96idghCQyQfhJLkg1Aa2P1GtUMQGiNjRO0Xm5hEeJ1Q7ritB//s/5fU1HS8LZ/NP16xwLaruOSCUJLrhXZ4eboTEugPYPt9BeimmFpY1SQfRG1Q7D/RXLwcy5OTXuWeRyby8pylTHvtHYaMmMj4ya9zKTq2umO0G7cOfkztEISGSD4IJckHoXTbuJfVDkFojIwRtZvJZGL2stXo9V4EBQbw5+59nDpzHm+9F1D4D2LJBaEk1wvtWD7zeYb2KSgyt2naEIBbOnWothgkH0Rt4GA0GkxX3jh64ivcO6gPPbt2xMnJXOfKzcvjt+27WffdJpYvUDf5c3Nz6dbvEbZv+Ahn5xKbyWqN/KiLlXYux3DtTje42s+p5diF0KqKjB/K37VrGX/s5Xe2MsfoqlaT3hPl61qZcV/r+1WTXsNrUZPyuiIq8j6q+Zr8d+IM3R4ax7zZLzDkrjvoe/dIjp04zQ3t27D5+2tbD836c5X2mlzrtURUn5Leq7K+H7X9d19LsrINGHNy8LEUo2u6a/n8KOOFKI9iO7HSMzK5tXsnWwELwNnJid49byI9I7PagrM3X//wq9ohCA2RfBBKkg9C6Zvf/lQ7BKExMkbUbsfOnifQz4fHHxmGv58vb732IgBRl6KLHCu5IJTkeqFd7m66ai9gST6I2qDYNqYO17Vg8owF9O19M8FB5nm7MXGJ/LR5O9e3bVmtAdoTmaoplCQfhJLkg1C6FJeodghCY2SMqN2SUtLw8y5YCLpbl444OjoSGOBf5FjJBaEk1wuhJPkgaoNipxPm5eWzYdM2tu7YTWxcIg6O5oXde3XrRN/eN6u+24lMJ6w4LbdqynRCISqfTCesejVp6kVNek9kOqG6alJeV0RNmU54KTaelV9+z469h3B0cGDTT5/b7svIzCQvL9+2LlZFyXTC2kWmEwq1yHRCUV2KrUY5OTkysO8tLHxtMsvmT2fZW9OY/+rz9Lu9u+oFrNrsoTEvqh2C0BDJB6Ek+SCURsxYpHYIQmNkjKg9/j1xmguXYwBoPfBhFv1vHXv+PYq/j3eh4zw9PIotYEkuCCW5XgglyQdRGxTbxpScksbi5Wv4fececnPzMGHCxcWZW26+kacefwAf79qx+JzWzJ35rNohCA2RfBBKkg9Cac74h9UOQWiMjBG1R/eHxhPs78fRH9cA0KheHbIMRvy89WV6vOSCUJLrhVCSfBC1QbFFrFlvLuP6di156on78ff1ASAhMZkff9nOzLnvsvC1ydUapL24FB1HndBgtcMQGiH5IJQkH4TS5fhE6gQVXQtH2C8ZI2qH3Nw8AGITkwDw9fZi+pOPUL9OKDqda5nOIbkglOR6IZQkH0RtUOzcwNj4RIYP7W8rYAEE+Pvy0H0DiI2XxeCqyrpvN6kdgtAQyQehJPkglNZt/kPtEITGyBhROxw/dwEw7wpuMplIz8jCy9ODts0b07xBRJnOIbkglOR6IZQkH0RtUGwnVqPIcBa8+z/uvK0bwYHW3QkT+PGX7TSKDK/WAO3J3JkT1A5BaIjkg1CSfBBKbzw1Qu0QhMbIGFE7HDx2CgBXF2cMxhxy8/Lw8nAv1zkkF4SSXC+EkuSDqA2K7cR6ccLjeHq6M3PuMu55ZCJDH53E7Lfex9dHz4sTn6juGO3Gi7PfVjsEoSGSD0JJ8kEoTXv3E7VDEBojY0TtcODYSfSeHmRmG0hMSQUodxFLckEoyfVCKEk+iNqg2E4sNzcdo0cMZfSIodUdj10beEdPtUMQGiL5IJQkH4TSgO4d1Q5BaIyMEbXDv8dP0/2GtmzYtovf/t4HgL6cRSzJBaEk1wuhJPkgaoNiO7Hy8/PZ8MvvfPDJNxz473ih+x57Zka1BGaPGtavq3YIQkMkH4SS5INQalAnRO0QhMbIGFE7xCYm0bJxAwDGz14IgLeXZ7nOIbkglOR6IZQkH0RtUGwR6823P2TttxtJTknl9QUrmPHGu+Tk5AJgtPxfVL5nXpyrdghCQyQfhJLkg1CasOADtUMQGiNjRNX64ectXLgcU6XPMe6VBZw4F0VEWMHOgjd3uA4fvVe5ziO5IJTkeiGUJB9EbVBsEWvfoaN8sHgWk8aNYM3yOYSFBDLhpTfJzMrGwaG6Q7Qfn614U+0QhIZIPgglyQehtGb2JLVDEBojY0TVGv7YBB6e+lqVPsdnP24GIMjPlzrBgQA8Mrhv+c8juSAU5HohlCQfRG1QbBHLW++Jg4P5LmdnZ8aMvJfuXa5n/OTXyM3Jq9YA7cl7H65VOwShIZIPQknyQSgt//pntUMQGiNjRNXLN+VX2bmNOTm2r709Pfl2yev06NiO/j27lPtckgtCSa4XQknyQdQGxRax+vTqykeffVvotnsH9WFw/96cu3CpOuKySwH+vmqHIDRE8kEoST4IJX8fvdohCI2RMaLq6Vxdq+zcG7btsn3t7eVB44hwvnnndVxdXMp9LskFoSTXC6Ek+SBqg2J3J7xn4G2kpKYXuX1Anx60aNqwyoOyV0Pvul3tEISGSD4IJckHoTT01q5qhyA0RsaIqpNj6ZJy11VdEevwqbO2r52cnK7pXJILQkmuF0JJ8kHUBsV2YgH4eBe/iGTjBvWqLBh7d/uQ0WqHIDRE8kEoST4IpTuemql2CEJjZIyoOqlp5n/YrUgn1pHT53h12UdXPe7gsVOMGtKPRS88TdPIa/usLbkglOR6IZQkH0RtUGIRS1S/H9e+q3YIQkMkH4SS5INQ+mHRdLVDEBojY0TVSUvLAMCtAp1YG3f8xbuffUN+fsnraZlMJg4cPUmHls14+K47cLjGXZQkF4SSXC+EkuSDqA2uWsRKSk7l6Ikz1RGL3du45Q+1QxAaIvkglCQfhNKmP/erHYLQGBkjqk5yahoAHm66cj/2xNkoDMYcYhKSSjwmOj6R2MQk2jZvXOEYlSQXhJJcL4SS5IOoDUotYv2wcRtPPjebl2a/DcDl6DhemfdetQRmj44el2KhKCD5IJQkH4TS0bNRaocgNEbGiKoTH58IVGw64fFzFwA4dym6xGMmzV0CQNP6lbNkh+SCUJLrhVCSfBC1QalFrI/X/sBHS2fj6ekBQFhoEKcl8avMpHEj1A5BaIjkg1CSfBBKEx+8S+0QhMbIGFE1vv/pVz74eC0Aubl55XqsyWTi5PmLAFy4HFvicSnp6fS8sT3Ozte2oLuV5IJQkuuFUJJ8ELVBqUUsR0eHQvP/MzKzyMrOrvKg7NVjz8xQOwShIZIPQknyQSg9/toStUMQGiNjRNX4+LNv+GnTbwAYc3PK9di4xGRS0tLx9vIstRMrNy+fru3bXEuYhUguCCW5XgglyQdRG5RaxLrphutY/tE6DAYjO/7cx8Rp87j5pg7VFZvdeWniE2qHIDRE8kEoST4IpRdHDlU7BKExMkZUjXMXLqL38gTAmJNbrseeOBeFg4MDvTvfwOZde8g2GIs9LjMrGw93t2uO1UpyQSjJ9UIoST6I2qDUIta4UcNwc9Oh9/Lgw0+/5aYbruPJkfdWV2x2Jy09Q+0QhIZIPgglyQehlJ6ZpXYIQmNkjKh8RmMO585f5N2Fr/LoQ0PJKW8R63wUEWEhvDT6YQ4eP8X6LduLPS4zOxsPt8orYkkuCCW5XgglyQdRG5RaxMrLz2fEsIGsXDyLD96exYhhA0nPkMSvKqvWfKN2CEJDJB+EkuSDUFr13Wa1QxAaI2NE5du6fRcA3bveiI+3HmNu+YpYF2PiiAgLpkF4GJ3atOTIqXMkp6axc9+hQsdlZmXj6V7+nQ9LIrkglOR6IZQkH0RtUGoR68VXF5OUnGr7/nJMPK8vWFHlQdmrRa9PUTsEoSGSD0JJ8kEoLZz4mNohCI2RMaLynTt/kcj6dfHx1uPi4kJOTvnWxIpNSCI4wA+AZg0iOHbmPI+9/Cb9nyz8XmVU8nRCyQWhJNcLoST5IGqDUotYcQnJ+Pl6276vGxZMTHxClQdlr2a9+Z7aIQgNkXwQSpIPQunVlV+oHYLQGBkjKl9cfCIB/v4AuLq6lHtNrJiEREICzI9v3jCCY2fPs+ffowCkZWQC5h0MM7Iqdzqh5IJQkuuFUJJ8ELVBqUUsZydHzpy7aPv+fNRl8vNMVR6Uvep58w1qhyA0RPJBKEk+CKUeHVqrHYLQGBkjKl9CYhJBgeYilJubjsxy7tB9ZSfW2YvRpFrWq7LuVphtMGIymSq1E0tyQSjJ9UIoST6I2sC5tDufGDGUcc+/Rqcb2gAO/LXnIC9MGFVNodmftq2aqR2C0BDJB6Ek+SCUrmsSqXYIQmNkjKh8cfGJhAYHAhASFEhMfFK5Hh+TkESIooildPZiNK2bNLQVxjwrsRNLckEoyfVCKEk+iNqg1E6sm264jvcXzaBNy6a0btGI5Qtfplvn66srNrsz6umX1Q5BaIjkg1CSfBBKj89eonYIQmNkjKh8/x4+TqOG9QEIDQkiLimZnDIu7p6fn09cYjLB/uYilr9PwfIcTerX48zFy4B5UXegUjuxJBeEklwvhJLkg6gNSu3EAgivE0J4nZDqiMXufbV6odohCA2RfBBKkg9Cad1cWbhZFCZjROWKuhTNmXMXuLlzRwDqhAZjMpmISUgiPCToqo9PTEkjNy+PEMt0RICP506jbbPGvLjofc5GmYtYGdkGADwqcXdCyQWhJNcLoST5IGqDUjuxdu0+wOiJr3DPIxMZMmKC7T9RNT789Fu1QxAaIvkglCQfhNJH3/+qdghCY2SMqFx/7NqDn68PLZs3BqBOmPkfdC/GxJXp8bGJ5qmHQX6+ttv69ehCeGgwkXXDOGtZE8vaieXp7l5ZoUsuiELkeiGUJB9EbVBqJ9brC1bw8LCBtG7RGGcnp+qKyW65/J+9uw6P4mqjAH427o4Egru7Q3F3/XBoKVYKhVLcikMp7lDcixW34k5xd0uwuHt2vz+SXW6IJ7s7k835PU+eJruzM+9kD/dub+7cMUlxYhxlIcwDiZgHEpmasE+m+NhGaNelqzdRq3olGBnF/r3X0tIC2Rwd4P7pC6qVLZni62v3+AkAYGdjneC5Arlz4sj5KwCEywkttDcTi1kgEfsLEjEPZAiSnYmVyzU7OrdtghJFC6JIoXyaL9KNnl1aSV0CyQjzQCLmgUQ9mteTugSSGbYR2nXp6k3UrhH/Ln95XLPj3ccv8PjihdDwcIycuyzROxZGREZpvjczTTigVKxAXrz7+AWBwSEIDQ+Hpbm5ZrBMG5gFErG/IBHzQIYg2R6zaYNaOPbvJYSEhMb7It1o3X2o1CWQjDAPJGIeSNR25EypSyCZYRuhPd+uh6WW1zUHZq7ejLJt++DavcfYsP8ozt+4m+D16kXbAUChUCR4vmLJYjA2MsKtR88QEhau1fWwAGaB4mN/QSLmgQxBsvON12zajcCgEACAQgGoVLH/vXxsi16Ky2p2rZsndQkkI8wDiZgHEu2Y+ZvUJZDMsI3Qjpev36Lyd23jrYellidnds33j16+AQA8e/sezb+rrnncPzAIy7btTfYYFuZmsLW2QmBIKELDw2Flob07EwLMAsXH/oJEzAMZgmRnYh3fvQpXjm/BleNbcPnY1/+Sbly5flfqEkhGmAcSMQ8kunL/qdQlkMywjciYkNBQvHj1FsNGTQMAuObIluASv7yuX+/Wfe3uIwDAZ2/feNuMXbAK2w+fSvF45mamiIyMQmhYBKwstTuIxSyQiP0FiZgHMgSJDmJFR0fruw4C8N+dh1KXQDLCPJCIeSDRzccvpC6BZIZtRMb8uXgtqtRti2v/3QEANGtcN8E2eXN9HcS6ei/29+3tFxBvmy/efqk6nqmJCSKjoxAaFg5rLQ9iMQskYn9BIuaBDEGilxNOmLkUc6eMQM1mvSBeys/LCXVr3IgfpS6BZIR5IBHzQKKxfTtJXQLJDNuIjDGOuwv3xlXzULNaRTg62CfYJo8wE8s/MBgVSxaFt59/vG3CIyNTdTwzUxNERkYhRAeXEzILJGJ/QSLmgQxBojOxxgz7AQBwcu9qnNjz9Uv9M+nGkFFcaI++Yh5IxDyQ6Oc/2BdTfNpoIyIiIhEVFZXyhgbm0tWb+HPJWlSrXB5tWjSCi7OTZlBLJK6JBQD1q1WElzCItfXQSVy//xgA0LJuDVzbmfS/UzNTU0RGRSMkNEzrC7uzvyAR+wsSMQ9kCBIdxHJyjP3rk0KhgI21FWysreDrF4ALV27BxCTZteApA4YO6C51CSQjzAOJmAcS/dylpdQlkMxkpI2IiIiEp5cPKtdti+YdvtdiVfL34PEz9PhxOADA28c32W2tLS3gZG+n+bl4gbzw8QvU/Dx/w07N99OH/Yii+fMkuS8zUxNERkcjNDxC6zOx2F+QiP0FiZgHMgTJLuw+adYyfPrijdCwcAwZNRP/HD2DaX+s1FdtWU5it2GmrIt5IBHzQCIj5oG+kd424r3HR+QoVAVFKzSAu8dH3LzzQMuVydvyNVtQomghAEBoaFiK2+eLWxercN7ccHawh7d/AJRKJQAgRhkDAFg7bTTy53ZNdj9mpuqF3cO1vrA7+wsSsb8gEfNAhiDZQayPn73gmsMFh0+cR/fOLbF6wWS8eP0+VTsODArB+BlL0GvQePw8ehZ8/QLw15a9aN19KHoPHo/eg8fj9VsPAMDFa7fRc9A49B0yES9TuX9DtGjVVqlLIBlhHkjEPJBo8c5DUpdAMpPeNuJu3OVvXTp8/eu8SqXSSk2ZwZu37qhXpwYAICQsPMXti+RzQ80KpXHyrwXI5ugApVIJv8AgAIBSqUKRfG5o8V2NFPdjZmoaNxMrHDaWlhk7iW+wvyAR+wsSMQ9kCJK9NtDYyAg79h3D4RPnsWbhFACAtVXqOtqHT16gc9smqFCmOJau3Y5te47A0sIcA/p0QuumX+/4EhUVjfnLNmH9smn4+MkLfyzdoDlWVrPyz4lSl0AywjyQiHkg0fIxg6QugWQmvW3E23ceKFOqGNYsmYWB33dDw9Y9ERgUDFst1ydXb997oEA+N0yf9Csqliud4vbzRg2BkZERrC0tEBG3fpi3XwDMzczw0dMbR1fPg6VFymtcmaoXdg8L1/qaWOwvSMT+gkTMAxmCZGdijRraF3fuPUH/Xh1hbWWJuw+foU6Niqnacc2q5VGhTHEAQJmSReAVd8thBzubeNs9evoSDva2cHKwR4miBfHs5VsEBYek51wyvTmL1kldAskI80Ai5oFEczftlboEkpn0thHXbt5FiWKFAQDZs7sAAHx9/bVVlqyFhIbii6c38udzw9CBfVCreqUUX2NrbQXruMv/XBzsYW1pgRrdBiFvg44AkOw6WKKIyEgs3rIbgcEhsNbyTCz2FyRif0Ei5oEMQbIzscqXKY7ycQNRAFChTHGUK1U0zQe5dfcxypYqCv+AQGzbfQQr1/+NSuVL4pdBPeHt64+8brHrBhgbG8EtVw74+PrD1sY63j72HDyFvYdOATDcae4Vy5WQugSSEeaBRMwDiSoWLyR1CSQzaW0j7j18guVrtuDk6YvYtXEJAMDZyQEA4O3jh3w5nLVdouy8ffcBAFAgX+oGnr5lbGyMyqWL4/x/dwEALo728RZ+T86VOw8BAHeevMBv33dL1/GTwv6CROwvSMQ8kCFI860GjYySnbyVwKu37vjvziP83L8b/PwD0axhbVhZWWDM7wtx4vRlWFiYxxuUUilViS5I2alNY3Rq0xgAEB0djTot+6a1dNlL7Sw3yhqYBxIxDySqXb6k1CWQzKS1jfhpxGQ8evIc2bM5o16d6gAAK0tLWFlawNvXF8gCg1gvX72FjbUVsrk4pXsf1cuV0gxiFcqTO82vV6lUqFZWu/+e2V+QiP0FiZgHMgRpG5FKIz//QEyZswIzJgyFuZkZcmZ3gVuuHHBysEeDOlXxzv0jXJwd8f7DJwBATIwSHz57wiXuL4FZTefvR0pdAskI80Ai5oFE/xv3h9QlkMwk1kb4BwTi8xevRLePilvPqWa1SjA2NtY87uTkCJ8scjnhjdv3ULF86Qzdza96uVKa71M7C0tUvGA+ONprdwUy9hckYn9BIuaBDEGKg1gRkZH44umDz57emq/UiIyMwvjpi9G/d0cULpAHEZGROHD0LGJilAgJDcN/dx6hWJECKFWsIAKDQuDrF4BHT1+iZNGCsLa2yvCJZUaHdyyXugSSEeaBRMwDiQ4u4MLNFF9ibcSoCbNRrmYL1GjYAa0694v3nLm5GYyNjTFn6uh4j7s4O8LHx0+ntcqBUqnEkRNnUT9uFlp6VSpVTPO9nU3aP7/WEAbBtIX9BYnYX5CIeSBDkOwg1rqt+9GwXX90HzAGvQePj/uakKodb/n7MJ69fItNOw6g9+Dx+GHoZPj5B6L/8CnoOXAsCuTLjQZ1qsLExASjfu6LYePmYOHKLRg19HutnFhmtG33EalLIBlhHkjEPJBo+/HzUpdAMpNYG3HmwlV0bNsMT569wqWrN+M95x8QhMV/TEbOHNniPe5iwDOxQsLCNd9funoT790/omun1hnap42VJXq1aQogdtH31Fo3YywAoF2jOhk6fmLYX5CI/QWJmAcyBMmuibX30ClsXD4DhQukfcHLfj3bo1/P9gke79u9bYLHalYtj5pVy6f5GIYmPCJS6hJIRpgHEjEPJAqPjJK6BJKZb9uIoOAQ+Pj64cfe/0OPLu3QstMPiIyMgpmZKQDA3z8ADolc/ubk5BC7JpaBiYiMQp76HbBrwVQ0rlkF23cfROP6teCaM3uG9129XClsOXgiTYNY7Rt9h/aNvsvwsRPD/oJE7C9IxDyQIUh2JlbRQvlQMF/aF6mk9Els0I+yLuaBRMwDiX5o00jqEkhmvm0jPn32BAC45syOnNldAABfvGKXhIiOjkZQcEiig1iGejnha4+PAIB3Hz8DAO4/fIrvalfTyr4tLcwBAHbW1ilsqR/sL0jE/oJEzAMZgmQHsb6rUQl/LNmAi1dvxfsi3ejU91epSyAZYR5IxDyQqPPYuVKXQDLzbRtx+twVKBQKZM/mDFfX2NlG7h6xN9IJCAwCADg62CfYj4uzk0FeTvj45RsAgImxMVbu/AePn76AWy5Xrezb0twMQNouJ9Ql9hckYn9BIuaBDEGylxOevnAdALBz33HNYwqFAnVqVNJtVVnU2kW/S10CyQjzQCLmgURrJgyRugSSGbGNePr8Fcb9HnsHKmNjY1hZWiJvnlx49uIVWnT8HlPGDgOARGdiOTs6wNvX8GZi7TlxDgDgGxCELQdPAIiddaYNkVHRAICCeXJpZX8Zxf6CROwvSMQ8kCFIdhBr4m8D4ZrDRV+1ZHkPn7zgACFpMA8kYh5I9PDVe9QpX1LqMkhG1G3Eleu30aJj7E1yLpzYpXm+RNFCGDF2BgDg5NlLAAAHB9sE+3E2wMsJA4KCceb6bRgZGcH9s6fmksIK5bTzb6h6uVJo27A2alUso5X9ZRT7CxKxvyAR80CGINnLCcdPX6yvOghfZ74RAcwDxcc8kOjMf/elLoFkRt1GDBg2HgDw58zxKFuquOb54kULab43MzWFqakJrCwtE+zH2ckBQcEhiDCgxX+PX7oOK0sLdGxcF7uOnQYANG1YJ9HzT49sTg7YMHM8TE2S/duw3rC/IBH7CxIxD2QIkh3Eql29IvYeOqWvWrK838f8JHUJJCPMA4mYBxJN6d9V6hJIRlQqFQrnz4XQsDC45coBAOjaqXW8bYoXK6z5/sPHz3Cwt4NCoUiwLxdnJwCAj3+ADitOn19mLcbDF6/T9Jq1uw9h8NT5aFGnOorkc9Pcuc8/IEgXJcoC+wsSsb8gEfNAhiDZQazL1+9g4YotaNS+P5p0HIgmHQegSceB+qotyxkx4Q+pSyAZYR5IxDyQaOTCdVKXQDLy6bMn5i7egB27D8Hj4xcsmTcFNt8sMl5CmIn14eOXRNfDAgAXp9h1onwDAnVXcDr4+Adgy8ETOP/f3TS9btKStQCA1vVroYCwZlXZUsW0WZ6ssL8gEfsLEjEPZAiSnfc8c+IwfdVBAPp2byd1CSQjzAOJmAcS9WnVUOoSSAYiI6MQFh6O+4+ewtvLE79NmAWVSoUihfIn2LZI4a+PhYWHo2TxIonu097eFsbGxvD2k9dMrP8ePAUAvIm7w2Jq1ShXGudv3kX9ahURFh6Oeb/9hA6N68JOGNQzNOwvSMT+gkTMAxmCZGdiueZwSfSLdMPe1kbqEkhGmAcSMQ8ksrexSnkjMngTpv2JfCVr4+DRfxETEwOVSgUAKFwwX4Jtra2scGDXGs1lhl07tUp0n0ZGRnBytJfd5YQ3HjwGALz5kLZBrPDISIzt3xPmZqZwsLNFv06t4GhvC1NTU12UKQvsL0jE/oJEzAMZgmQHsTr0HoGOfRJ+kW5Mm7dK6hJIRpgHEjEPJJq+blfKG5FBi4qKwt/7jwAAtv99EG558mLB7Ak4vn8jsrk4J/qaurWqwcnRHs5OjmhUr1aS+7a3s0VAUIhO6k6v6/cfI5ujA954fEzT63z8A+DiYK+jquSJ/QWJ2F+QiHkgQ5Ds5YRzpwyP9/Oxfy+hfJniiW9MGbZ+6TSpSyAZYR5IxDyQ6K+JQ6UugSR049Y9/PjzWAQEBGHZ/Kn4eeQUTBv3E1o1a5Dia7u0b4ma1SolOxPJ3NwcEVHyuTuhSqXC3Scv0atNU6zbdxhR0dEp3gnws7cvjl+6Dm//ADg7Zq1BLPYXJGJ/QSLmgQxBsjOxihTKF+9ryI/dsOXvw/qqLctZuHKz1CWQjDAPJGIeSLRo+0GpSyAJjZ08FyWLF8F/5w+gR5e2OLZvA56/9kjVa8uXLZniYJeFuRkiI+UziBUVHY2wiAgUL5gXMTFKBAYnP0vsl1mLMXz2Yvw6Zyn8A4Oz3Ews9hckYn9BIuaBDEGyf8YKCQnVfB8dE4O7D5/hfRoX1KTUK5LIGhaUdTEPJGIeSFQkr6vUJZBEwsLCcf/RM/w9+mfNAu41qlaEj1+Q1o5hZm6G8MhIre0vo8LCIwAANlaWAGI/kyYlIjIKWw6eiPdYVpuJxf6CROwvSMQ8kCFIdhCrcceBUCiAuHVC4eLsgCE/dtVHXVlSi8Z1pC6BZIR5IBHzQKLmNStJXQJJ5Pa9R4iOjkbF8qXjPa7NNsLC3AwRchrEioitxdY6dkHi6Bhlktveefw8wWPZstggFvsLErG/IBHzQIYg2csJrxzfgsvHtuDK8divg9uWok2zenoqLetp2mmQ1CWQjDAPJGIeSNR82FSpSyAJvH7zHi07/YCSxQrDwd4u3nPabCPMzc0RIaPLCcMj1DOxYgexYqKTnol15e7DeD872dvBIYvdrY/9BYnYX5CIeSBDkOwg1oz5axI8Nnn2cp0Vk9Wd2pfw901ZF/NAIuaBRCeW8UNoVvTX5l0oU6oYDu3+K8Fz2mwjzM3MZDWIFZqGywmvCoNYh1bMxdMj22BsbKzbAmWG/QWJ2F+QiHkgQ5DoINZnT298+uKNJ89e44unDz57euOzpzdu33+C2/cf67vGLGPPwVNSl0AywjyQiHkg0d4zV6QugfQsKDgE2/8+iP59usLZyTHB89psI8xltiZWeILLCRMfxIqOjsH1+4+xYMzP+Hf9ItSqWAYmJllrAAtgf0Hxsb8gEfNAhiDRNbGmz1sNAHD/+BmDf5uhedw1hwuGDeihn8qyIE9vX6lLIBlhHkjEPJDI0y9A6hJIz/5YGPvZrEPbZok+r802wsLcHKEp3AFQn75eTvh1JlZEZBTMzUxx7d4jPH/rjt5tm+Hxq7cIDg1D8++qI4ezk5QlS4r9BYnYX5CIeSBDkOgg1vJ5EwAAM/5cjYm/DdRrQVnZTz/8T+oSSEaYBxIxDyQa3LG51CWQDqlUKigUiniPPX3+Cj3+1xY2cbORvqXNNsLc3Ay+MpqJ5R8UDIVCATPT2I+tEZGRcP2uLbbMnYheY2L/2Nq7bTM8e/Me2RwdsvQAFsD+guJjf0Ei5oEMQbJrYk38bSCev3qH81duah6T091qDE33/mOkLoFkhHkgEfNAoh6T5ktdAulIaFgYHPOUx7FT5wAAHz99QXBIKD58+oJcrjmSfJ022whzc3mtidVz9HSoVCqYmMQOYvkHBgOAZgBL7cV7DxTKm1vv9ckN+wsSsb8gEfNAhiDZQayNOw5g0aotWLZ2BwDg02cvTJy5VC+FZUULZo6SugSSEeaBRMwDieYP/0HqEkhH7j98CgCY8UfsjXS+HzwarTr3w4tXb5ArZ/YkX6fNNsLC3ByRcYNYe0+ew9ZDJ7W274wwiVugPSCJSx1fvf+AwhzEYn9B8bC/IBHzQIYg2UGsY/9ewpLZY2FpaQEAcM2ZjdfZ69B7909Sl0AywjyQiHkg0fvPXlKXQDpy+twVKBQKPHryHK9ev8N79w+4e/8xoqKiUalCmSRfp802Ins2Z7z79BkA0H/yHxg2c5HW9p0e+XPnxKwRAzSDWP5BwfGez+kSe/ngy/ceKJzPTe/1yQ37CxKxvyAR80CGINlBLIVCAYXCCOplGXz9AhAezssJdWX/kTNSl0AywjyQiHkg0T/nrktdAumAUqnEjj2HMG3CCBQplB97Dx7HFy8fLJozCQvnTERet1xJvlabbUT1qhXw9sNnePr4aW2fGeEfFIxc2VxgbBz7sTUwbhCrTYPaGPl9V4TF3b3wjccnFEzmd5RVsL8gEfsLEjEPZAgSXdhdrXmj2pgxfw2Cg0Ox+8BJ7D5wEm2a1dNTaVnP7Mm/SF0CyQjzQCLmgUSzhvSSugTSks9fvDB7/kq8eeeOTm2b49NnT3Tp0BIBQUFYtmYLlEolalavhKKFCyS7H222EU6ODgCAkLBwre0zvWJiYhAQFAJHe1soFAoYGxvBPygYRkZG2DBzHE5fu4X5G3Zi0z/HERwahmxODlKXLDn2FyRif0Ei5oEMQbIzsfp0bYMaVcqiZLFCuPfwGX7o0Q49u7TSV21ZzpipC6UugWSEeSAR80Ciccs2S10CacnBo//i0LHTuPvgCYaNnopG9WshR3YXNG9UF4GBQXB2ckShAnlT3I822wjTuAXUo6KjtbbP9PIPCoZKpYKjnS2A2HWxAoJCYG1pAYVCAUtzcwDAiDlLAABO9naS1SoX7C9IxP6CRMwDGYJkZ2KtWL8LP/3wPzSpX1Nf9WRpndo0lroEkhHmgUTMA4k6NmC/bCjeuX9ApfKlUapEESxasQG9urYHABSJm3mVI7sLjOPWgkqONtsIU9PYj4cb9h/V2j7T66OnNwAgV3YXALGDWL6BgbCxsgQAWJibxdveyd5WvwXKEPsLErG/IBHzQIYg2UGsh09eICQ0DNZxHxRIt9xy5ZS6BJIR5oFEzAOJ3LI7S10CaYFKpcKDR89QtHABjPi5H7Jlc0bzxnUBAHa2NgAA1xzZUrUvbbYRpqamAIBDZy9rbZ/p9eGLN6wszDUzsYyNjXHp1n1UKlUMAGBm+vWjrEKhgEPc7y0rY39BIvYXJGIeyBAkezlh/dpV8cPQydix9yj+/ueE5ot047fJf0pdAskI80Ai5oFEo5ZslLoEygClUok6TbvAMU95XLh8A53aNYe9nS2G9O8Vb9bVvm0rsWrxjFTtU5tthPpywsDgEK3tM73uPn0Bt5zZoYi7y5CRkQI+/oFoXqcGACBGqdRs6+xgl6pZa4aO/QWJ2F+QiHkgQ5DsTKxnL96gTInCePXG/euD6lsVktZtWz1H6hJIRpgHEjEPJNoybYTUJVAG3Lh1Dw8ePUOpEkUx8IduqF6lQqLbNaib+ss+tNlGqC8nDA4N09o+0+PxyzdYvGU35o4crHnMPzD2zoTN6lQFAJQrVhjODnbw8Q9EqRQWv88q2F+QiP0FiZgHMgTJzsSa+NvAhF8jB+irtixnxbqdUpdAMsI8kIh5INHKPcekLoHSafGKDWjWvi8qlCuFy6d2o3e3DlrZrzbbCGNjYxgZJfsRUecio6LQ7bepqFK6BHq1aZrg+RzOTgBiLyHs0aoJAKB88SJ6rVGu2F+QiP0FiZgHMgTSfkKheHLGLVpKBDAPFB/zQKKczg5Sl0Dp8ODxM0ydswTly5bEwjmTtLpvbbcRpibSXpZ3/r+7cP/siVJFCmguJUyKpUXsHQrLFiukj9Jkj/0FidhfkIh5IEOQ7OWEpF8dWjeSugSSEeaBRMwDidrXryF1CZQOJ09fRKkSRXDu6A6t71vbbYSpiQkiIqO0us+0CA2PAAAM69kpxW3Vg1iciRWL/QWJ2F+QiHkgQ5DiTKznr97h/JWbmp8jIiN1WlBW1rD9j1KXQDLCPJCIeSBR4yGTpS6B0uHFq7fIlye3Tvat7TZCvbi7VPwDg1HAzRWu2RLeScvmm7tmW1mYw87GGvlz8658APsLio/9BYmYBzIEyX5C2bjjAG7cfgAvbz/UrVkZnz57YcHKzZg3daS+6stSTu//S+oSSEaYBxIxDyQ6tXya1CVQGt28fR879xxCvTrVdbJ/bbcR3w5iKZVKva6TFRAUBAdbm0SfK/TNQGCrerWQR7iDYVbH/oJE7C9IxDyQIUj208ixfy9hyeyxsLS0AAC45swGT29fvRSWFR06cV7qEkhGmAcSMQ8kOnzxP6lLoDQIDQtDoza9AADlShfXyTG03Uao71CoFhwWrtX9p8Q/KBj2iQxiHV01D38vjP8/YTldnNC0djV9lSZ77C9IxP6CRMwDGYJkZ2IpFAooFEZQ/2HL1y8A4eG8nFBXXr5+L3UJJCPMA4mYBxK99PgkdQmUBn9t3AUzM1OcP7YTxYoU1MkxtN1GfDupKTA4BHbWVlo9RnK8/AISnYlVvXwpvdWQWbG/IBH7CxIxD2QIkp2J1bxRbcyYvwbBwaHYfeAkBo2cjtZN6+qrtixnxOBeUpdAMsI8kIh5INHwbm2kLoFSKSYmBktWbcSUcb+gRLHCOrskT9ttRGhYRLyfA4NDtLr/5KhUKpy7cQfVypbU2zENCfsLErG/IBHzQIYg2U9Sfbq2QY0qZVGyWCHce/gMP/Roh55dWumrtizn+5+1e7ttytyYBxIxDyT6YdoSqUvIFKKjozFm8lz8uWQtIiKkmUn++NlLePv4oX2rJjo9jrbbiJCwMADArT3rAOhvEMvHPwDX7z3Ghy9eaFmvpl6OaWjYX5CI/QWJmAcyBMleTnjk5AXUq10FTerzQ4Q+TB37k9QlkIwwDyRiHkj0+4BuUpcgS17ePnjx6h3KlSkOaysrdO49BGcvXIOxsTECA4MxbeKIdO13++FT2PjPMQzo3BrHbt7DtIm/Ik9u12RfExAYhPWb/8bUOUtQoVwp5HLNka5jp5a224iIyCgAQA4XR1iYmyEoJFSr+09KkWax2a5YsijccmTTyzENDfsLErG/IBHzQIYg2ZlYdx48RdcfR2PSrGW4dO0OomNi9FVXluTrFyB1CSQjzAOJmAcS+QYGS12C7KhUKtRu0gUtOn6PxSs2AgDOXrgGAOj5v3Y4eOzfdO9784HjuPnwKQZMmYf9h07i+KnkF84+fe4y8pWsjalzlmiOr2u6aiMszc1hZ22t18sJAaAVZ2GlG/sLErG/IBHzQIYg2UGsiSMHYP/mhWjeqDbOXbqBHgPGYv7yTfqqLcvZvOuQ1CWQjDAPJGIeSLTl6FmpS5Cd12/e44unNzq3a4HT5y5DqVRqnmtYryY+ffaESqVK835VKhWevnmPhWOHYeD/2qJB3RqYOnsxxkyeG+8YopETZmm+X/rn7+jdrX3aTyiNtN1GGBvHfkRUKBSwtrJAcKju706448jXgca2Dero/HiGiv0FidhfkIh5IEOQ7OWEAGBiYoLqlcvC1NQEpqamOH3hOkYO6aOP2rKcBTNGSV0CyQjzQCLmgUTzh/8gdQmy4OPrh/bdB+GnH3viw6cvyJc3N1o1b4g+A0di3O/zAAD/nT+AsPBwREREwt8/EPZpPMbL9x8QGByCiiWLoE+7ZvhiYorZ81di9frt+OLpjbVLZ8HU1DTeawrkc4O9nS26d26DXl11P4AFaL+NmPzT91i8eTeA2NlY4RERKbwi44ZMXwAA6NC4Lgq4JX+5JiWN/QWJ2F+QiHkgQ5DsTKxbdx/jjyUb0L7XcOw5cApVK5bGP1sW66u2LGfy7OVSl0AywjyQiHkg0e9rdkhdgiw8fPIc9x8+xeARk7Bh6x60b9UEBfK7AQBWr98OIyMj5HXLBde4tZU+ffFM9b5VKhXaDx2Pav8bAADIH7cGlmvO7GjcoDYA4J/DJ1GoXH3cuvNA87rd+4/i5ev36NapNQb+0F0r55ka2m4jhvboiJcndgIALMzNEKalQSyPL17Y+M+xZLfp17GlVo6VVbG/IBH7CxIxD2QIkp2JtWL9LjRrWAsD+nSCg72tvmrKsriAPomYBxIxDyRqXK281CXIgrvHJ7jlygkHB3s8fPwMlSqUQYmihWBvb4uAgCCM/+0nmJubwdnUESYmJvji6Y3iNnlTtW+/wCCc/+8u1kwdhTqVy8HW2krzXK6c2TXfBwYG4c07D1SqUAYBgUHoP3QcAKBA/jzaPdkU6LKNsLKwQGi4dgaxxi9cjcPnrqBvu+aIjIrCr3OXwdc/EIvH/6LZxsLcTCvHyqrYX5CI/QWJmAcyBMkOYq1bMlVfdRCAksUKSl0CyQjzQCLmgUQl4mYbZXUvXr5BvrxumDl5JNZv2Y2mDb+Dqakpnt06jacvXqN8mRIAACMjI+TI5oxPX7yAgqkbxPLy9QcA1K5UDjmcneI9V6lCGVw+tQeTZszHg0fP4Ontg4iISHz4+BkAcO3MPhQtXEB7J5oKumwjLC3MEaalQSxrSwsAQGBIKLx8/LD98CkAwJPXbzXbONrxD6cZwf6CROwvSMQ8kCFI9HLCafNWAQA69B6Bjn0SfpFuDPx1mtQlkIwwDyRiHkg0eM5KqUuQnEqlwqFjZ9C4fi2UL1sSS+ZNgZlZ7NpUFhbmmgEstZw5suHzF69U79/HP/YOb84Odok+X6pEEezbtgrFixbC+N/noVGbnnj91h3m5mYoVqQgjIySXbFB63TZRliYm2ltTSx7WxsAwCdPbwSGxN7x0NjYCIHBoTAzNcGaqaM0l25S+rC/IBH7CxIxD2QIEp2J1bNzKwDA3CnD9VlLlrd7w3ypSyAZYR5IxDyQaNfs0VKXIInd+4+icoUyKJA/D+49eILXb9+jfZumqXptzhzZ8PHTl1Qfy9svAPa2NjA1Sf4eOC7OjgCAB4+eYdioqciVMwcUCkWqj6MtumwjrCzMtXY5ofqyTE9fP8TEKGFsbITsTo5w/+yJyKhoFC+YTyvHycrYX5Aoq/YXlDjmgQxBon8mLBg3zfDjFy8UKZQv3tert+56LTAr+WvLXqlLIBlhHkjEPJBo3YFTUpcgif5Dx6FC7VbYsHU39hw4hioVyyJfntypem2+vLnx3v0joqNjsGrXP4iJiUl2e2+/AGRzTPleho4OsduYmJjA188fuXPlSFU92qbLNkKblxNGRkYBAMLCIxAQHAJ7GxvY2VjjxbvYz5ffXrpJacf+gkRZtb+gxDEPZAiSneu+ftv+eD8rlUqs3/aPLuvJ0qytLKUugWSEeSAR80AiawtzqUtItaDgEDx4/Aw3b9/P0H6iomIHP0qVKIo/Fq7GP4dOokObZql+ff68bnj73gM3Hz7F+IVrcOHmPbjHzcyKiYlBYEgoAMAvIAiv3T/C2z8Azg4pD2LZ2lgDAPLlyQUAyJ0rZ5rOS1t02UZYmpsjPCJSK/tS3+UwNDwCAUHBsLOxgo2VJV6++wATY+MkL9+k1GN/QaLM1F+Q7jEPZAgSnSM/ZNRMKBQKeHz8gp9Hz9I8/sXLRzNLi7SvW8cWUpdAMsI8kIh5IFHXpt9JXUKq7D90AiPHz4Kvnz8AYO3S2ejcPn1Z/uzpDQD4sU8XjBg7AwBQ/7vqqX593jy58N79I4yMY/9+N3z2Erh/9sSVHatQs9sgAMD9A5uwbNterPn7ICqXLo6cqZgVZBe3CHmBfHnw6s17uEk0iKXLNsLSXHszsdSXJYZHRCIgOAR21tawtbbC09fvkMPFSe9riRki9hckyiz9BekH80CGINFPChN/G4gJv/aHk4M9fujZXvO1ZPZYzJ2SuoXdA4NCMH7GEvQaNB4/j54FX78A+AcEYeiY2egxYCy27j6s2fafo2fQY+BYDPx1Gjy9fLRzZplQi//9JHUJJCPMA4mYBxK1GjFd6hJS1KHHIHw/eDRqVK2geWzE2Onw9w9M1/4ePHoGExMTVChXWvNYkUL5U/1615zZER4RAY/PngAA97j/nrh4XbONl68fvP1iF3S/+fApnFNxOaF6JlahuLWcsmdzTnVN2qTLNsLSwhyPX73FwTOX0vzau09f4LX7RwCAb0Cg5m6EYeHh8AsIhJODHWytrfDZ2xc54tYXo4xhf0GizNBfkP4wD2QIEh3Ecs3hAtec2bBs7nhULFtC8+WaM1uqd/zwyQt0btsEW1bNQrEi+bFtzxGs37YfdWtVxqYVM3Ds30t47/EJvn4B2LLrENYtnopObRpj+bpdWju5zGbf5kVSl0AywjyQiHkg0d65Y6UuIUVnzl8FAAwb3FfzWHBIKDw+fk7X/k6evoDGDWqjUIG8AICihQvA2Ng41a93zZEdAPDy/Yd4j9999kLzfVh4BHz8A9CvY0vkyZkdubO7pHr/pUsWBQDYxt19T9902UZYWpjDy88ffcfPSnnjb8xavQXzN+4EANx69Ezz+JPX77Bo825YW1rAJu7yt1zZUv/7pqSxvyBRZugvSH+YBzIEyc7ZtrOzxr7Dp7FkzXYsXr1V85UaNauWR4UyxQEAZUoWgZe3H67cuIvyZYrDxMQEZUoUwdX/7uH6rQcoWih/3O2wi+Pqf3czfFKZ1fnLN6UugWSEeSAR80Ci87cfSl1CssLjLhmbPulXVK1ULt5zgUHB6drnpy9eyJ/XDbY21ti/fRXWrZibpte7ODvC2NgYL995xHv87PU7mu9DwyPg4x+I/LldcX7zUvzco2OK+/UPiJ1ZVqp4EQCxa29JQZdthKW5WbpfGxoejqev3wGIP4h17kbs7z0wOERzx8IyxQpmoEpSY39BIrn3F6RfzAMZgmQHsSbNWo4LV27i0rXbsLayxMdPXlAo0r5Wwa27j1G2VFH4+gXALe6uPXndXOHt4w8fX3/kdYtdP8LFyQExSmWii4fuOXgK3fqPRrf+o9Fz0Lg015AZ3H3wVOoSSEaYBxIxDyS6+/yN1CUksHXXP5g0fQEGj5iEURNnAwDatmwMhUKBB9eP47/zB2BtZYmAwPRdTvjF0xs542ZG1f+uBsqULJam1xsZGSFHNme8eOeBXMIMq8DgENzbvwEOdjaamVgujvZwsLOFRSoGb9q0aISC+fOiQrlSuHXhIGpWq5i2E9MSXbYRlhYW6X5tWHgEnr5+D6VSiVuPnmFA5zaoW7k8/AKDAAABQSGwjZuJVbZoIa3Um9WxvyCRHPsLkg7zQIYg2RGpT5+9sGjWGJQvUwxNG9TC1HFD8CHuTj6p9eqtO/678witm9WFQqEAVCoAgFKlhMJIASgAVdxjAKBSqqBQJNxPpzaNsWPtH9ix9g9sXTU7TTVkFmN++UHqEkhGmAcSMQ/Sefz0BQ4cltctqUf37iB1CQnMWbAKf23ahR27D+L6zbuYNmEE8uR2BQDkye2KIoXyw87WBoGBqZ+JFRkVhT0nzqJa/fZ4+eotcqTh8r7E5MyRDfeevUTuHNniDVDlcc0BS3NzbPznGD55+cAt7tLD1ChetBBuXzoEhUKhWRdLCrpsIyzTeTerer2H4s6TFwiLiMDbD59x+/FzVCpVDJYW5vCJWxtt3ughmu1zuKS8kD6ljP0FieTYX5B0mAcyBMkOYllYmCMmRolypYrhyo27MDUxwXuPT6neuZ9/IKbMWYEZE4bC3MwMTo728PgYOwjm7vEZ2Zwdkc3ZEe8/xK6P4eXjB1NTU5ibpX/aemY26NdpUpdAMsI8kIh5kM78pX+hz6DfsGzNZqhUKoyfOg95itfEydMXJatp8JyVkh1b5P7hE1p0/AGuhavB48Mn7N22Elv/WogzR7Zj2OC+sX+8Etjb28Lb1w/R0dGp2v8vsxZjwJR5ePbiNTq2bY56dVJ/N8LE5MwZOzj1XeVyWDnlt3jPWVmY4+z12wCAQnlzZ+g4UtBlG2GVzkGs+89fab4/fuk6/AKDULFkUXj7xy6ev2LySFQpXRzhkVEAABdHhwzXSuwvKD659BckD8wDGQKT5J5s+F01vHz9DvXrVMWPw6Zg086DqFm1fKp2HBkZhfHTF6N/744oXCAPAKBWtQq48+Ap8ufNhYdPXqLX/1rD2soSazbtQXh4BO7cf5rq/RuikUP6SF0CyQjzQCLmQToBAUHI7ZoDk6YvwLQ5SxATo0RMTAzOXryGJg3rSFLTrz3aSnLcb+07cByv375HWHg4AKBkscJwcLBLcntHB3tMmPonTvx7Ab+P+wVv3rmjY9vmiW57/OJ17D5xDnWrlMfgIT+gWaO6Ga5XfTli1TIlULZY7KVrpiaxH4XES+Yy413ydNlGpOayypSoBwjdcmbHrOEDEBwahnpxd64Mj4hdQ83FIeW7QVLK2F+QSC79BckD80CGINlBrO6dWmi+X790Gt55fEKhuAGplGz5+zCevXyLTTsOYN2WfQCA+TNGYfq81fjnyBm0avqdZn2svt3bod8vU2BrbYXpE4am91wyveiYGKlLIBlhHkjEPOjO77MWYcO2PXj36FK8x2/cuoecObLh0ZPn+HXojzh78RqOnjiLnRuX4PylG3gVt1i1FKJjlJIdW3Tlxm00aVAHm3fsw9Txw5MdwAKAnl3b4+qNO7hw+QZaduqHsPBwNGn4HUyMjWFpGX/dpSMXrqJVvZrYOGs8jNy0MzPK3s4WAOBoZwtL89jZReoBGksLc2R3csTjw1sSzCDLDHTZRqh/V+llZ2ON/x4+hY2VJczNTFG5dPF4z9etUgHr9h7RymAZsb+g+OTSX5A8MA9kCFK9SruFhTmKFc6PA0fPpGr7fj3b48yBdVi/dDo2r5yFzStnIZuzI5bMGYtta+agW8evA2Stm9bFttVzsGrBZGTLhH/91Jblf+2UugSSEeaBRMyD7qzfshsBAUFYsnIj/OPW6fHy9kGTtr1Rtnpz+Pj5o2XT+pg/czxWLpqBZo3qomjh/Hj+SrrFUVfsPirZsdWu3riNf89eRoc2TeH99haGDe6b4mvat24CIHbWk5FR7EBRqapNUa9FtwTbun/6gsJ5tHtZn1nccgVO9naapQvUl8rZWFmiQfWKMDJK+w1s5ECXbUR6LydUy+Zoj8DgEDjGDSJ+q1W9mvC9Jn2mDQX7CxLJob8g+WAeyBAkOhOrSccBABL+FVKlUiFP7pzo2LqxruvKkpb9MV7qEkhGmAcSMQ+6cf/RUwQGBcPB3g4r/tqKlX9txe1Lh3H95j0AsXe0K1+mJHK5xs4c7tapNQCgcMH8eO/+EXfvP0YZRzu9z9xZOmqAXo+XmJ9HTkGLJvVQt3a1VJ+/laUltq1bhAFDx8HJyREhoWEIDAxCYNyd6kTvPn5Bey1cQihSz/RxsreFmWnsR6BSRQoCAGYOHwB7G2utHk+fdNlGWAgzsVQqVZrz7mhvB7h/hIOdjbZLo0SwvyCRHPoLkg/mgQxBon9u3LRiFjatmJnga8uqWVi3ZKq+a8wyZi5YK3UJJCPMA4mYB91Yt+lvVK9SHm8eXsDNCwcREhaO/YdPYs6CVahSsSwWzp6I3t0T3smnVIkisLQwR70W3bBxv/7/qjl7w269H7N4pUYYNWEWAOCd+we8evMe40YOTvOARh43V4SEhsHd4yOshEsIY4RLoKKjo/Hhixfyuqb+LoGp8UPvLhjdrzvsbW2gUCiwcOwwrJ06GgBQvEBeuGZz1urx9EmXbYR4d8KYVF6KIt55Olvcgu0mxsZarYsSx/6CRFL0FyRfzAMZgkRnYrnmyNgtrCl9qlcuK3UJJCPMA4mYB+0LCg7Bnn+OYsm8KVAoFLCxtkLXjq3w+6xF8PTywfnjO1GudIlEX+vk6IB3jy+h35CxuP3kBb7Xc+3VShfT8xGBz1+8sGHbXsybOR7nL11H9mzOKFGscJr3k9ctl+b71UtmoVf/XwEAvn7+yOYSO4j06YsXomNikDduBpy22NvZYmz/npqf+7RrptX9S0mXbYR4OWFUdDRMTJIfjJq/YSdevHPX/Fy6aEEcu3gNA7twQWF9YH9BIin6C5Iv5oEMQbILu3foPQKJ/YF176aFuqonS6teqYzUJZCMMA8kYh6078z5q1AoFGjVrKHmsUE/dMejJy/w58zxSQ5gqZmYmMDezhahPr66LjWBaqWL6vV4gUHBAKCZOXXu4jXUS8NlhCIH+6+Lvzdr9B3+O38AVeq2xdad/2DEz/0AAO/dPwKIvZMdpY4u2whxJlZUTAwsU9j+8au32P/vBQBA2aKFYGdtBQDI4eKkqxJJwP6CRPruL0jemAcyBMmuXjp3ynDMmfz1q27NyvhlYM/kXkIZ0G3AGKlLIBlhHkjEPGjXmfNX0GfgSFhZWcJcuCNawQJ5cWTPOrRp0ShV+zE3N0N4RKSuykxSj0nz9Xas9x4fkbdELQCxN3kBgGs37qB2jSoZ3repqSkK5o+96/HUOUsQHh6hOaZrNmeYm5lm+BhZhS7bCFOTr3/zjIqKSnF7P2GNs7XTx0B9ZaH1N3egJN1gf0EiffYXJH/MAxmCZAexihTKF+9ryI/dsOXvw/qqLcs5uG2p1CWQjDAPJGIe0u/vfUdQsnJjPHn2EgBw/tJ1/PTrZABA985tMrRvSwsLhEfqfxDrnz8n6O1YvQeMRPa4taLs7Wwxfe5SfPzsiVIlimhl/8bGxti7dQWsLC3w974jAID37h+Qh7Ow0kSXbYQ44y4qOiaZLWMFBAWjQlw+rCwtNOudWVulNIeLtIH9BYn02V+Q/DEPZAiSHcQKCQnVfAUEBuHS9dt47/FJX7VlOZt3HZS6BJIR5oFEqcmDSqXC0+ev9FCNvEUIM6MiI6Ow4q+t+PjZE2s37oRSqUT/oePQsF5NfHpxHb+PH56hY0k1E2vL0bN6Oc7VG7dx9/5j7N6yHGN/HQxLSwvMX/oXAKBY0ULp3u/gH3uiS/sWmp8b1quFAd93w7I1m6FUKuHu8Ql5tLyou6HTV58RHR2d4jZ+gUHo1bYZdi+ajtzZXRCjjF0M3paDWHrBzw8k0ld/QZkD80CGINk1sRp3HAiFAppp4C7ODhjyY1d91JUlKWNUKW9EWQbzQKLU5OHB42f4run/cPrQVlSqkDXXRPn46QtKVmmi+R2MmjgbHz99QZcOLfHsxRs45a0AAJjw2xBYauHSJktLaWZiKZW6aR/evvOAW+6cMIm7fGzkuJkAgJLFCuPajTua2WwAYBO3zlF6zP59VILHenfrgEUrNuD5yzfwDwiEq51dIq+kpOirz4iMSs0gVjCc7e3QsHolAECMMm4mliUHsfSBnx9IpKv+gjIn5oEMQbKDWFeOb9FXHQSgb3fetYe+Yh5IlJo8fPz0BQDw59K/sGP9Yl2XJEsvXr8FABw8+i9KlyyGHXsOYt3yuYiKisLQ337XbOeqpUvVzM3NEJHKQSyVSpWuhdAT06dVA63sRy0sLBzevn6o3qADOrZrhmV/TgWA2BlsS2fD1NQUpUoUhbmZGaKionH97H6tHh8A8udzAwBUb9AB9b+rDuvszlo/hiHTV58RlYqZWKFh4fEuHYyOiZ2JZW3FNbH0gZ8fSKTt/oIyN+aBDEGylxMCgH9AEF6+ccfL1+81X6Qb7XsPl7oEkhHmgUSpyYOnpw9MTU1w7OQ5eHz8rPuiZEh9V7vXb91x/+FTREZGoXb1ymjTohFqVquk2U5bg0mWFuYIj4iESqXCuRt34OMfkOh27p++wLlGSzx+9VYrx+04eo5W9gPE3mmwZJUmKFOtGcIjIrB7/1EsX7sFr968g39AIKpULAsAqF2jMt4+uoh3jy+hWJGCWju+mpHR148kwcGhsLFK/0yvrEhffUZ0CmtixcTEICo6GhbCovyD/9cW4wb0hJkpF+rXB35+IJE2+wvK/JgHMgTJzsRasX4Xtu0+DGcnB5gYx26qUAB7Ny3US3FZzcZlM6QugWSEeSBRSnmIiIjEvkMnUKpEUdy9/zj2srBcOfVUnfTOXrgKS0sLvHr9DgBw684DNG7bCwDg6GgPANiwah5+HTsduVxzaO245uaxg1junzzRYdgEDO7aDjOHD0iw3UcvHwDAwTOXULJQ/gwfd8PkYRneBwA8fPwc7boNRK3qlVG1UlksXL4evw3rjx27D8HFyRHOTo7Ilze3ZnsTExPY29lq5diJ2bFhMb4fNBrBISGw4fpJaaLrPuPhwc0o3aa3Zn2rpIRHxt690MLcXPOYg50tRv3QXaf10Vf8/EAibfUXZBiYBzIEyc7EOvbvJezdtBAHty3Fvs0LsW/zQg5g6dCd+0+kLoFkhHkgUUp52LB1N85dvIZmjeoim4sTPn321FNl0ouMjEL77oPQrH1fXLzyH/p076i55Klj22aa7WysrbBm6ewML+YuUs/ECggOBgB4+yU+Eys4NAwAkpyppVauXV8s374vxePefvY6jZXGp1KpMO73eajdpDMAwMXZEVPG/QLf93dQqXxpPH/5Gldv3EHlimW0NmstNbK7OCM8IgKeXr4cxEojXfcZtnFroKnXt0qK+vJacSYW6Rc/P5Aoo/0FGRbmgQxBsoNYJYsVhL2djb5qyfIuXrstdQkkI8wDiZLLg1KpxF+bdmHULwMw9tdBsLCwwC+jpyIqKkqPFUpjw9bdaNW5n+bnN+888EPvzpg7bQyKFSmIv5bpdtq8ubk5wiIiNINUEUn8ztXPf/T0SXJfYeERcP/siX9OX0zxuJfuPk5HtV95+/hi5V9bsWD2BCycMxHTJo4AEHtJX9EiBREVFY39h05oLiXUF2cnRwCAj69fvDWVKGW67jOMjWM/MsbEJD8TKyzubp3mZmY6rYeSxs8PJMpof0GGhXkgQ5Ds5YT9e3XEqMkLUKFsiXiP9+vZXqdFZVWTfhsodQkkI8wDiZLLw7mL1/D2/Qf80Ct2Vs3In/th+NjpuHnnAarl0t6lc3IzYux0bNi6B6VLFsMvg/uiTYtGKFwoP+ztbFGudAl0aNMs5Z1kkLWVZbxBrMDgkES3Cw4NBQC4JzND7uajpwCAcsUKp3jcif26pLXUeD57egMA2rVqAidHh3jP5Ypb9D4wKBiV9XyXy9y5cqBs6eK4//ApZ2Klka77DGMjYwBI8XLCiLhBLAsL82S3I93h5wcSZbS/IMPCPJAhSHYm1rK/diA0LBx+/oEICg7RfJFu/DKOC+3RV8wDiZLLw4ate9CqWQPNHff69uwESwsLBAQG6as8rbpy/TYOHz+T7EwypVKJDVv3AABmThmJqRNGoFKFMjpdrykx1lZWiIlRai4jfP7WHTExCS+3Cg6JHeR68c49yYWxL91+AAAwMTFO8bjD5/+V3pIBAJNnLAAAODrYJ3jO2Pjr8SuUK5Wh46SVqakpju3bgJlTfkN1PR87s9N1n2Ect/C+MsU1sXg5odT4+YFEGe0vyLAwD2QIkp2J9emLN7avmauZQk661b93J6lLIBlhHkiUVB627voHh46dxurFM+M9bmNjhZCQ0DQdIyQsHFYSzp4ID4/AwF8m4MCRUwCAyhXKYNPq+cidyGyyG7fuab7PrcWF2tPKxiZ2naAh02MHhfwDg7Bw09/47Ydu8bYLDg2DazZnfPLywZsPn1Akn1uCfV2JG8QKj5vJkpwf2zVOd81hYeE4e+EagKTv0tiiaX0cPXFW74OCQOzA4JD+vaD0+KD3Y2dmuu4zjIxis9Jy0Gj4Xjua5HbhvJxQcvz8QKKM9BdkeJgHMgTJjk5VqVAab97zQ6S+WFlaSF0CyQjzQKKk8nD52i0AQKP6teI9bmNtjeDg1A9ixcTEoGSrnqjZfTDevvNIf6EZMGzU7zjx7wX8MX0sypUpgcioKJSq2gTvPT4m2HbvP8dQtnRx9O/bFfnzJhwQ0hfruMWu1ZZOHIG567bh8cs38R4PCA5B8YL5YGtthSev3ibYj5evPy7feQA7G2vNwtjJSc9g4/O37njx6i3eucf266cObEly2y1r5uPto5TX5iL50HWfYWSUuj9ofl3YnYNYUuHnBxJJ+ccpkh/mgQxBsp9IPn3xxJBRM9FnyIR4X6Qbsxetk7oEkhHmgUTf5uHJs5coU705bt99iL49OmoWxFazsbFCUEjSl39HRkWhdo+fNIMtgcGhCAoJxRuPjzh07LT2TyAVjpw4i3atm2DA991w/thO/DlzPABg/O/z4m2nUqnwz5FT+L5nJ8ybMQ4mJslOKtYpW2trzfdO9nZo3+g7FMmXB6evx19Y+dX7DyiUJxdKFMyHx6/e4rX7R80dFAGgXp+hAIDKpYtrFsZOztxNe9Nca7MBI1Glblt4evlAoVCgQrmSSW5rbGwMB3u7NB+DpCOXPiMsIhImxsapuiyWdEMuWSB5SE9/QYaLeSBDkOwn/x6dW+mrDgKwdtEUqUsgGWEeSPRtHq7/dxeeXt6IiIhElw4tE2xvY5385YTX7z/G41dv8eT1O5QsXAD+QcEAgCqlS+BB3ALj+hQYFIyQ0DD07/M/zWNVK5VDsSIFcfj4GTx/+QZFCxcAAHh6+cDL2xfVKpfXe53fUs/EalqrKlZPGw0AKF+8MB69iL2F9b5T5/HjpLlwzeaMRjUqISo6BlfuPMQf67Zj5vABGNy1HQCgSD43fPLyQZF8bnjr8SnF464ePyRNdXr7BcA/MPY9fvn6LZwcHSQd/CPt02efoVKpkrwU9d2HT7Aw5ywsKfHzA4nS2l+QYWMeyBAkOxOrYtkSiX6RbsxbtlHqEkhGmAcSfZuHZy/foE6NKjh3dAf69Up4p5mULif898pNAICnrz8AICA4doCjVsUyePD4mXaKToOdew4BAArkzxPv8T9mjAUAnD53RfOY+nK4fHlz66m6pJnFLV5tbWUJu7gBLXtbG83dCk9evgEACA2PQOv6tVGyUH5cun0fAPBGuEzSysICg7q2g5WFearWxJq/9Z801bl61z+wt7UBAOzaewTZXBxTeAVlNvrsM6ITuXmB2r9Xb6FhjUp6q4US4ucHEqW1vyDDxjyQIUh2EGvIqJn4efSsBF+kG6WLp3xbdco6mAcSfZuH5y9eo2iRAihftiQcHBJe9mVra42guIGpxPx7LXYQy8vXDwAQEBQCIyMj1KxQGk+evcKv42ZosfrkPX/5BpNnLMT0ib/CydEh3nN1a1VD9y5tcO2/O5rHXrx6i+zZnGFtZQU5KFW4APp3bq352dLcDKHhEQAAe5vYgaNJg/rAxdEebRvU1mz3SFg3KyQsDNaWFrAwN9Pc3S3ZYxbMm+r6nr91x8qd/2DKkO8BANdv3kXTht+l+vWUOeizz4iITPrOoUEhoSiaP/X5JO3j5wcSpaW/IMPHPJAhSHYQ63/tm6FLu6aaLwd7W7RuVldftWU5jetVl7oEkhHmgURiHo7/ex6nz19BwWT+R9HJ0QG+fgGJPhcQFIwnr96hoFuurzOxgoJhb2ONWhXKoEC+PFi/ZTcik/kf1bRQqVQ4e+Eqdu8/CpVKhRnzlsHBrRzOX7oOAJi/9C9UqVQWPw/snejra1arhBP/XoCfXwCu3riN0RNno2Y1+cz0uLh1OaqV/bq+lIX519lUPgGBaFa7Gr7v0AIAkN356wyoB89fQ6lUAoi9e6GtlSXMzcxSNROrUdVyqa5v17HTcHF0QPeWjXD2yHa8f3IZUyeMSPXrKXPQZ5+R3M0HgkJCYWNlqbdaKCF+fiBRWvoLMnzMAxmCZAexvqtZKd7X5FGDcPDYOT2VlvW07Pqz1CWQjDAPJFLnYdW6bejadxgAoFG9Wklu7+ToAJ+4ASq1Nx6f8NHTG95xg1tlihWEV9w2bz98gms2ZxgbG+P04a0AgDv3H2ml9oNHT6Njz5/Qf+g4/DJ6Gv5cvBYA8MNPY/D3viPYtfcwateonOQaO7WqVUJ4RAQKlPkOzTt8j5DQMNSqLp9BrG9ZWpjj2r1HOHbhGr54+6JUkQLxzk29XlBwaBhex11SGBwaDmtLS2RzdMCLd+64djf5333rX1M/U+79py+oU7kczExNUaFcKdjFXVZIhkWffca3M7Gio2Nw8MwlAEBwaChsOYglKX5+IFFa+gsyfMwDGYLU3S85zlv3j3j5xl1XtWR5J/askroEkhHmgUTqPCxfuxWjfhkAP/e7yJ/PLcntnZ0c4Ovnp/lZpVKhUqd+qNK5P9w/ewIAiubPCy9fP3h89sTvyzegcuniAGIHwEoWL4LL125ppfaTZy6gVbMGAIDNO/YBAPZsWQFfP39MmPYnAMDO1jbJ14vnOXH0z6haqRxaN2+oldp0wTJukGrFjv3w8vNH9m/uHPn0yDa8O70H9rY2uPfsFYC4ywmtLNGpaT2UK14Y+/49n+wxji1J/cLN7z95Iq9r9jSeBWU2+uwzxEGswVP/RN6GHdF3/Cz4+AfEziq0lselvlkVPz+QKC39BRk+5oEMQbKDWE06DkCTjgPRpONANGz3I/oNm4wu7Zrqq7YsZ9f+41KXQDLCPJBo1/7jCA4JhbvHRzSqXyvJWUtqLs6O8Pb5OoilXmg8LCICg37/E+ZmpsjnmgNefgHYdvgUTE1MMH5AL832pYoXwbQ5S3D59oMUa/P44oX3H78k+by7xycUKZQftjbWAIBNq+ejUf1aaFi3Jry8fQEAObI7J/l6hUKByWNjZ591atccJw9sRs4c2VKsSyrmZl/vzObl649sTg7xnrezsYattRXyumbHZy8fKJVKBAaHwMbKEqYmJsiXKydCQsOTPcbfpy4l+rhKpcKZ67ehUqmEGvyQw9kp/SdEmYI++wxx3bZdx85oLoH1Cwzi5YQywM8PJEqqv6CsiXkgQ5Ds/bU3rfi6iLtCATjY2/G2yTrkHxgkdQkkI8wDifwDg3DrzgMYGxujZPEiKW7v7OQIX78AKJVKGBkZaS4bXDN1FAZMmQcAyObkAC9fP5y4dB3DenWKt17TkIG9sfufo9hz8hxqVSyT7LHKtu2DXNld8PDg5kSfd/f4hA6tm+L9k8sAoBmA69W1Pf49dxlVK5VD+9bJ/4GkV9d28PL2Rb480t+RMCUxcetcRUVHwy8wCNm+Waxezc7aGgHBIbj56BlCwsI1M+FsrCzxRRiATIx/cEiijz95/Q6dfpmI42vnIzo6GtExMfANCIKjXdIz3cgw6LPPSGq9PG/fAISGR3AmlsT4+YFESfUXlDUxD2QIkp2J9dnTG472tnDN4YKc2V0QGBSMq//d01dtWc7APp2lLoFkhHkg0cA+nXHx6n+oVL60ZkZTcpycHBATE4PAuA8rXn7+AICWdWtqtsnu5IjIqGjcffoSTWpVjff68mVKoFfX9giJm8GVFPVlRR89vRETE5PgeaVSiQ+fPsMttysUCkW8GWTNm9SDs5MjKpYvneLMsmwuzpj9+6gUt5ODqKhoAICPf+zaY9/OxFKzt7VGYHAIrt19iBIF8yGnS+xsKWtLS4SEJT8Ta0D7xAf9POMGvw6cvojl2/fjp2kLEBgcwkGsLECffUZSd9BUX6psI5M7h2ZV/PxAoqT6C8qamAcyBMkOYi1ZvS3ez/Z2Nli3dZ9OC8rK/tdvlNQlkIwwDyT6X79RePj4OcrFzdZJibNj7KyqOX9tg0qlgrefP2ysLGFpYY4Ns8bjzMbF8QZXKpZIOLvL2tpKcxliUr7EXQ4IAB++eCd43tPLB5GRUcjj5prgOTMzU6xZMhN9undI1TllFuqBPfWdH7MnMYhlZxM7iHXz0TNUKlVM87i1pQWCQ0Lh4x+Ae09fJvrabhP+TPRx9cDZwbOX8drjIz56xr4nTvYcxDJ0+uwzkro74buPnwGAlxNKjJ8fSJRUf0FZE/NAhiDZQazIyChYWJhrfjY3M0NoCut0UPotnTtO6hJIRpiHrCsoOASHj5/R/KxUKjF9/BBcu3EHZcuUSNU+nOMGTtb8fRAv3nnAyy9AM2jVtkFtlC9eRPOz+q6E37KxsUJIWPKDWB5fPDXfv/34KcHzj548BwDkzpUz0dc3rFcLJYoVTul0MpUyRQsCAIJCQmFqYgL7JO4GqIACO4+explrt+IPYlnFzsQau2AV6vcdphmYEi35rX+i+/Ty80c2Rwd8+OKFZ2/ew9QkdtUAe87EMnj67DO+vTuh2ue4QW1eTigtfn4gUVL9BWVNzAMZgmQHsQrky411W/cjKioa0dHR2LzrIHLxDkc684p3fiQB85B1jRgzHT1/HIGm7fpg0fL1KF21Keq37IEc2V3QpX3LVO1D/APEg+ev4OXrl2BtJvUAR60Kia95ZWOV8kysQ+euoHzxwsiXKyd+mbUEExevxdCZi6BUKvH6zXv0HTQKbrldYZOF/qe2bpXyeH5sB5wd7ODiaJ/kJZBvPsQO+oWGR6BSya+DWDZWlvjg6YW9J2PvUOgbkHB9m5ceCQcMAeCLtx9KFs4PJ3s75M6RDc+ObsPckYORK1vSC+eTYdBnn5HUIJZPQOyAK2diSYufH0iUVH9BWRPzQIYg2UGsX3/qjQePn6NBu36o37Yfbtx6iNHDvtdXbVnOkZMXpC6BZIR5yJrcP3zCgaOnAADXb97F3/uO4ONnTzg4OGLR3EkwT8fNNXwDguDtG5Do2kwn/lqAReOHJfo6GxtrBH8z+9bbLwAzVm6CSqVCnZ5DsHrXAfTr1ArLJo6ArbUVVuzYj22HTuLk5f/w6/iZqFCuFK6dyXqXobs42mPBmKFoWbdGktssnTBc832xAnk132d3ckBAUIjmtQFBwQlee/TyrUT3+er9BxTKkxt39q3Hnb3r4WBni/6dW2eKtcQoY/TZZ0REJT6I5esfCBNjY94ESGL8/ECipPoLypqYBzIEyd6d0MnRHotmjUFYeOz/xFhaWOilqKxqxoShUpdAMsI8ZD0qlQqbt++Da87suHxqD1QqFexsbRAVFYV7D56gcsWy6dpveGQkPnh6IZuTY4LnqiSzxlbsmlihcKreArNGDMCg/7XDwk27sHLnP4iIisKjl28AAB0a1YWlhTkqlCiChy9eAwC6j5oKAFg0Z1KWmoUlal2/FlrXr5Xk84Xy5sbtvetw5c5DmJh8vZyzcc0qeHpkG1wc7ZGzTlsEJHInoemDeiR4TKVS4embd6hZsTQv58qC9NlnREQkXBPL2cEOvgFBsLG25KCpxPj5gUSJ9ReUdTEPZAiSnYmlZmlhwQEsPRg1Zb7UJZCMMA9Zi1KpxJCRkzFv8RoolSrY2ljDLm4tJVNTU+w6cCrd+/by9cepKzfRqEalNL3OxtoKQSGhAICTl/8DAHj6xt797tiFawCAJROGwzLu0kX15Ypj+/fU7CMbL2NLVv7crujeqnG8x4yMjJDNyQEKhQJ2NlaaO0yKRi/ZmOCxB89f4+X7D2hUo7KuyiUZ02efkdjC7vly5YRvQCAvJZQBfn4gUWL9BWVdzAMZglQNYpF+dOvQXOoSSEaYB8OnVCqhUqkAAL+MnoZDR08DAGysE/5PYEbycOnWPQBAg2ppH8RSr4l17sYdXLv7CN6+sWveZHeOndXVrHY1zfZhEREAgFZ1a6Bv+9h6s7twECsj7G1sEp2J1bVJnXg/33/2Cpdu34ejnS0K53XTV3kkI/rsMxK7nNDZwR4+/gGcBSgD/PxAom/7C8ramAcyBIkOYq1cvwuBQQk/NJNuZeeMBRIwD4avQu1W6PbDL/Dy9sG2vw9g7bLZuHjyb+zduirBtunJw4RRQwAAd5++RIUSRTQzplLLxto63s8tBo1CUGjszCwf/wD0bd8cLo72mue7t2yMn7q1R8nCBdCybk0AQO5cOdJcN33l7GiPL3F3fBNlF9Y3++Tlg3p9hmLi4rXImc1Jj9WRnOizz4iI+DqIldc1B5ZMGA4zUxNERkXDxoqDWFLj5wcSZU9kPUzKupgHMgSJDmJFRceg56CxWL1xNwez9Gj8jCVSl0AywjwYvnfvP+D4qfMoUr4BlEolalarhDIliyU68JOePIz6ZQBa1YsdTKpRvnSaX29jk/B/RtUzs95/+gJHO9t4z5UqUgAzfom9dXPD6pXw+sF55HLlIFZGFC+QF09ev0vw+MQVWzXfn74Wu0irmakJcnLmW5alzz5j3vrtePfxMwAgKjoapibGeO3xEQDwJu6/JB1+fiCR2F8QMQ9kCBIdxBo2oDu2rpoDc3Mz/PjLFKzZtAcXr97SfJFubF4xU+oSSEaYB8N2684DAMC2dYsAAJXKl9asgZWYjOahRvlSaX6NdSKXBX309AYARERGIVc2l2Rf7xS3RhalX8lC+fHk1dsEj2/8/RfN96ev3USXZvUxfVh/tKhTXY/VkZzos88IDY/AuAWrAagHsUwQFRUd+1xYeHIvJT3g5wcSif0FEfNAhiDJNbHsbK3Rqsl3qFm1PP45egY79x3Hzn3HsWv/CX3Wl6UsWbNd6hJIRpgHw7Zl534AwHe1quLkgc3YvWV5stunNw9ffGIXYi9dpGCaX2v7zeWEwNeZWAASLEhO2leqcAG8cv+IsPCIeI8v23VY8/3jl+9QqVRx9O/cGv06tdJ3iSQTUvUZUdExMDUxgUIR+5HSxCTZG1+THvDzA4nE/oKIeSBDkOgnDfcPn7Hl70O4cesh/te+KfZtWgiLNK6lQmmX1y2n1CWQjDAPhs3bxw8/9vkfbG2sUbVSuRS3T28eQuIGncS1q1JLPRPr1z7/Q8E8ubBix348fvUWA7q0wfftW6R5jS1Ku5KF80OpVOLZ2/coX7yI5vE8ObMBAFQqFdw/f0E+rj2W5em7z1AoFACAaPVMrOjYdbKUSqVe66CE+PmBROr+gghgHsgwJDoT66ffZqBA3tzY+dcf6NaxBQew9KRdiwZSl0AywjwYpqDgECxdtQm37z6EW67U/49GevOgnjllZmqa5teamZnCzNQEBfPkQvdWjVG5dHEAwKTBfVGsQN501UNp42Rvh5wuTnj88m28x9vWjb0r5EcvH4RHRMItZ3YJqiM5karPiIqOhomJMSIiYwexnOztJKmDvuLnBxKp+wsigHkgw5DoINbuDfPRqU0T+PoHaG7/TrrXqH1/qUsgGWEeMr+YmJh4bWhAYBDyFK+JSTMWIJdrDtSsXinV+0pvHkLCwlLeKBlThvyARjUqAwCqlCkORztbWFtaZGiflDYVSxbF9iOn4j3W5OfJAIAdh08hT87sKJovjxSlkYxI0WeoVCrN5YTqQazDK+fqvQ6Kj58fSKTuL4gA5oEMQ6KXE9579Bzjpy+GmZkpLMzNsHDmaOTPm1vftWU5/+5fK3UJJCPMQ+bl5e2DhcvXY8XarRg2qC8G/tAdd+4/QkRE7LpGl07uRumSRdO0z/TmIV+unPDxD0zXawFgcNd2mu+7NGuASqWKp3tflD6dmzXA0BkL4z12ctk0hEdEYu3uQxjepwtMTIwlqo7kQoo+IzpuoN7M1ASRUbGDWJwVKD1+fiDRyWXTpC6BZIR5IEOQ6Eys1Rv/xsKZo3Hs75UY8mM3rNm0R991ZUn/HD0jdQkkI8xD5nPqzCWEh0fg55FTcPTkOQDAklUbUapqE/T8cQT6DRmL0iWLpXkAC0h/HnYvnI7//tbO/9CYmpigOC8j1Lsczo4IDg3TDBIAwIHz1/HgxWt4+fmjW4uGElZHcqGPPuPm7r/QrHbspSgqlQp+AUEAAAc7W/zYqRWyOznqvAZKGT8/kOjA+etSl0AywjyQIUh0EMvPPxBlS8X+T1ajutXh/uGLXovKqt57fJa6BJIR5iFzOHDkX6zduBNv3rqjc+8hqFq/HU6euYTFcyfD++0tbF+/GA3r1gQANG1YB/u3r0zXcdKbB0d7WxTiTNpMTb3GkG/cgAEAuH/2QmhYOBQKBextbaQqjWREH31GwTy5kMPFSfOzT0DsLE8XB3tM/ul7PD26Tec1UMr4+YFE7p+9pC6BZIR5IEOQ6OWEtt98IDYyVuilmKxu2IDuUpdAMsI8ZA4Llv2Few+eaH62tbHB9vWLUDdutkKLJvUQFBSM0+evYNWimXBMx10CAeYhK9MMYvkHIGfcAELDKmXQ6ZeJUKlUmrvEUdamrzbC2Cj2758KhQI+fgFQKBRwtLPVy7EpddhfkOjn/7WSugSSEeaBDEGiM7Hee3xCnyETNF/v3OP/TLrR+yf+bukr5kG+3nt8xPnL19H1+2G49+AJhg3qq3nu8qndaN64Xrztu3RoiYsn/073ABbAPGRlDrY2UCgUmplYKpUKP05fik9ePhJXRnKirzZCHDP1CQiEg60N12STGfYXJOr7+2KpSyAZYR7IECQ6E2vBjFH6roMAzJo4TOoSSEaYB3mJiorC94NHo3zZkpjxxzIAQPMm9fDvwS2oXLEsChXIi0IF8yX6WoVCgTIli2Xo+MxD1mViYgx7W2vNpVvn/7uLV69eSVwVyY2+2ggjxde/fwaHhsLW2kovx6XUY39Bohk/9ZS6BJIR5oEMQaKDWBXLlkjwWFBwCKytLGFklOjkLdICTy8fuOXKIXUZJBPMg7w8ef4Kh4+fweHjZ2Bna4OdG5eiZrWKmuf79Oio0+MzD1mbs70d/AIC8dnbFx2GTUCJIgXx5MVrqcsiGdFXGyFevhodrYSJMWdhyQ37CxJ5+vrDLbuz1GWQTDAPZAgSHZG6ePUWbt97rPl50aqtaNZ5EFp1+xmPnr7UW3FZzY59x6QugWSEeZCXzdv3IW+eXHhx9wzuXD4cbwBLH5iHrM3R3g4+/oF49PINAKB86dISV0Ryo682QmEUO4ilUqkQExMDYw5iyQ77CxLtPHlR6hJIRpgHMgSJDmJt3nUY+ePuZnXv0XOcPHsFO/+ah6ljf8LClVv0WmBWMm/qSKlLIBlhHuTj9LnLWL9lN+bPnIBsLs5wluA28sxD1uZsbwffgEC8fOeBovnzYPmYQVKXRDKjrzbCSJiJFaNUwsSEM/Tlhv0Fif4Y1lfqEkhGmAcyBIl+8ggLD4dT3ALEO/ceQ9cOzZAnd05UqVAawSFhqd75jn3H0Lrbz9i2+wgA4K8te9G6+1D0HjwevQePx+u3HgCAi9duo+egceg7ZCJevn6f0XPKtCbOXCp1CSQjzIM8fPz0Bd8PHo1hg/qgcYPaktXBPGRtjva28AsMgk9AILI7OWLSqm1Sl0Qyo682Qr2sxPFL1xEVHQ1jI87Ekhv2FyRif0Ei5oEMQaJrYhkpFHj+6h0Cg4Jx694jjB3+AwAgOjoaZmamqd55xTLFEwxKDejTCa2b1tX8HBUVjfnLNmH9smn4+MkLfyzdgDULp6TnXDK9lk2+k7oEkhHmQTpv3rrD188flSqUwZoNO+Dk5IDJY6VdKJd5yNrsbKzh8dkTwaFhsLGyRItalbB8Iz+I0lf6aiMshM+BXr7+MDHmTCy5YX9Boha1KkldAskI80CGINFBrJ/6dcVPv81AZFQUxv7SD/Z2tgCAXftPoFrFMqneebEiBeCawyXeYw52NvF+fvT0JRzsbeHkYA97W1s8e/kWQcEhsLWxTuu5ZHqFCuSRugSSEeZB/wICgzBv8RosW70ZADB6+EAsWrEBy+ZPlfymFsxD1mZnY43A4FCEhIbB2soChd1csXDsMPgGBEhdGsmEvtqIX3p3wUdPH+w4+i9Cw8K5JpYMsb8gUWE3V6lLIBlhHsgQJPp/ZdUrl8Wxv1fixJ5VaNG4jubxSuVLol/P9hk64LbdR9C9/xjMX74J0TEx8Pb1R964f0zGxkZwy5UDPr7+CV635+ApdOs/Gt36j0bPQeMyVINcDR0zW+oSSEaYB/26cPkG8pWsjb/3HcHapbPxfc9OWPnXVuTKmR1d2reUujzmIYuzs7ZGYHBI3EwsKwz7cy36tGuGEX3+J3VpJBP6aiNsrCwxbkDsLdpDwsNhzLtWyw77CxIN+3Ot1CWQjDAPZAgSnYkFAKamJjA1jf908SIFMnSwVk3rolnD2rCyssCY3xfixOnLsLAwh0ql0myjUqri3b5ZrVObxujUpjGA2Msa67Tsm6Fa5GjXunlSl0Aywjzo17rNf6NmtUrYvm4RHBzs0Ll9C0yfFLs4blouo9YV5iFrs7OxQkDcIFau7C7YMXao1CWRzOizjTA3MwMAhIaFw8SEM7Hkhv0FiXbM/E3qEkhGmAcyBHr981nO7C5wy5UDTg72aFCnKt65f4SLsyPef/gEAIiJUeLDZ0+4ODnosyzZWL1pt9QlkIwwD+n3+YsX/rt1P9ltwsLCcf/RUwCxlxEe//c8hgzoBQcHO802NtZWsLG20mmtqcU8ZG2xlxOGIDg0FDZWlliz/4TUJZHM6LONMI8b2A8ND4cJLyeUHfYXJGJ/QSLmgQyB3gaxIiIjceDoWcTEKBESGob/7jxCsSIFUKpYQQQGhcDXLwCPnr5EyaIFYS2T/2nUN4e4tceIAOYhJSqVCnsPHMOFyzfQqnM/TJq+AH9t2gUHt3IoXqkRGrfthUPHTgMAnj5/leD1IyfMxHdN/4ezF65i0fL1sLSwQOP60t19MCXMQ9bmZG+LgOAQ+AcFw8bKEg5ZcN1ISp4+2wgz07hBrLAIydcLpITYX5CI/QWJmAcyBEleTphRXj5+GDlxHnz8AmCkUODKjbuoUqE0+g+fAj//QDT4rhoa1KkKhUKBUT/3xbBxc2BqYoJJvw3UVUmy97/2zaQugWSEeUje6XNX0G/IWACAlaUFHj5+Dv+AQADApDFDsWXnfuz55xh27T2Mw8fP4OaFAyhcML/m9Rcu3QAAtO8+CADQuV0LWVw2mBTmIWvLn8sVSqUSL999gI2VFbo0lu+AK0lDn22EWdxyE6Hh4XCyt0tha9I39hckYn9BIuaBDIHOBrGyOTti88pZCR7v271tgsdqVi2PmlXL66qUTKNpp0E4sWeV1GWQTDAPiVMqlRg/9U+cPncZ1SqXx84NS2BpaQETE2N8+PQFbrlywtjYGJGRUdi6cz8+fPoCAPji6YP7D5+ifp0aCA4NhcfHzzh5YDN6DxiJTu2a49ef+0l8ZsljHrK23DlcYGpigqjoaNhYW6L5sKk4tmSK1GWRjOizjTAyMoKZqQlCwsKR3clRL8ek1GN/QSL2FyRiHsgQ6GwQi9LuyM5lUpdAMpIV8xAdHY0lqzZhUL/usLK0THSb+4+eYdW6bejWuQ2+79kJjo72mufy5cmt+T6bixM+fPqC4kUL4tMXL3h5++CHn8bAyMgIbVo0goO9HSpXKIMnN08lejMJucmKeaCvjI2NkT93Trx45wFbK0scWjBR6pJIZvTdRpiZmiI0LBzGxrycUG7YX5CI/QWJmAcyBPzkISOnzl2TugSSkayWB6VSiX8On8K0OUtw9kLsuXv7+CIyMiredqvXb0eFcqWwcuF0VK1ULsn9OcfdIKJHl3ZwcXLEoycvNMdx9/iIOVNHw8jIKFMMYAFZLw+UUAE3VwCAtaUl/r1xT+JqSG703UaYm5kiNDwcxlzYXXbYX5CI/QWJmAcyBBzEkpGHT19KXQLJiCHnwT8gEGMmz8WWnfvx+YsX7t5/DKe8FfDjz7FrXI37/Q+UqNQIhcvVx9BRvyMkNBR37j0CAFy8fAN9u3dM8RhVK5XHD706o1+fLnBxdsLOvYcBAJtWz8e/h7aia6fWujtBHTDkPFDqFHDLBQCwsbLEo9fvJa6G5EbfbYS5mRlCwyJ4d0IZYn9BIvYXJGIeyBDwckIZGfVzX6lLIBkx5Dxs330QO/YcQmBgEAAgZ45sAGIXaJ88dhjOnL8KU1MTHDlxFrv2HsaxU+cRGBiE8mVLwuPjZ5QoXjjFY+TOlQMLZsdOme7dvQPmLlyFnv9rh7YtG+nuxHTIkPNAqVMoz9dBrJE920lbDMmOvtsIczNThEVEwISXE8oO+wsSsb8gEfNAhoCfPGSk//CpUpdAMmLIebj+3120a9kY0yf9ioE/dEfndi2wb9tKvHl4EYP69cDfm5ehY9uvd1cqFTdo9e79B/w+7hdUKFsyTcfr0aUt7l89hmXzM+/v1JDzQKmjmYllbYmBs5ZLXA3Jjb7bCDPT2Lu5GhtxJpbcsL8gEfsLEjEPZAg4E0tGxg2X993RSL8MLQ9BwSHoPeBXODs64tp/dzBscF8M6d8rye1bNm2A/n3+h+pVK6B966ZwylsBTRt9h+FDftBj1fJhaHmgtKtSujh+7NQKLg72GNMn5UtqKWvRdxuRw9kRz96858LuMsT+gkTsL0jEPJAh4CCWjISGhUtdAsmIIeQhMjIKJibGMDIywoXLN3D1+h10bNcMBfPnQb3a1ZN9rbm5GebNHK/5edu6RahVvZKuS5YtQ8gDZYydjTX++O0nAEBoeITE1ZDc6LuNKJQnNy7cvAcTE87Ekhv2FyRif0Ei5oEMAf98JiNrN++RugSSkcyYh6DgEGzffRCz56/Err2H0bB1D7TtOgBKpRIr1m5Fk4Z1sHz+NBzbtxGlShRJ075bNq0PB3s7HVUuf5kxD6Q7f/1zSuoSSGb03UYUzucGADA24kdJuWF/QSL2FyRiHsgQcCaWjCyePVbqEkhGdJUH9w+f4OLkCEtLC63tMzw8AmFh4Zgw/U/sPXAcERGR8Z5fvnYL7j14jIsn/tbaMbMatg8kWjTyR6lLIJnRdxtROG9uAICRgoNYcsP+gkTsL0jEPJAh4CcPGZn+52qpSyAZ0VUeylRrhn4/x/+A++atO/wDAtO8L6VSiXylaiNn4aooUOY7bP/7IEYM6Ye3jy5iythhmDx2GABg0vQFmDt9LArkz6OVc8iK2D6QaMY6DghTfPpuIwrliR3E+uTto9fjUsrYX5CI/QWJmAcyBJyJJSN1qleUugSSEV3m4eiJs3j24jWKFSkIAKhQuxVMTEzw8t7ZNF2y9+zFawQEBKFYkYLo26MTalStgLKli8PIyAgjfu6H5y/fYNqcJbAwN0f3zm10dTpZAtsHEtUun7Y7dJLh03cbkdc1BwDg7YfPej0upYz9BYnYX5CIeSBDwEEsGalQtoTUJZCM6CIP/v5fZ1s1aNkd/Xr/Dzv3HgIAREdHo3C5+jixfyMqVSiD0LAwPHj0DNUql09yf/+evYx8eXPj2pl9UCgUCZ53dIgdEMufL3eiz1PqsX0gUcViBaUugWRG322EekH3tx8+6fW4lDL2FyRif0Ei5oEMAS8nlJG+P0+UugSSEW3m4cate/htwizkL10HAHDrwkGULVMCS1ZtROGC+QEA547tRM7sLnj87CUAYNTE2Wjarg9mzFuGlX9tw/lL1/Ek7jkgdm2ttZt2onO7FkkOUKlndTWuX0dr55JVsX0g0ffTlkhdAsmMFG3E8N6dsWLySL0fl5LH/oJE7C9IxDyQIVBERkaopC4iraKjo1GnZV9cPLIRJiaGP5lM6fFBa/sycsuttX1pW0rnKefa5ezaf3fQrH1fAMDQgX1w49Y9HNy1Fq/fvseaDTswbeKvePHyDSqWL40mbXujYb2a6NO9I4pXaoTSJYvh4eNn8fZ37thOQKVCvRbdAADXz+7XXJaYmItX/kP1KuVhamqqs3OkpKWn/RD/rWWk/ckq/2a12UbrWmZ6T8Tfqzbrzuj7lZl+hxmRmXKdHul5H+XwO9FF/tTnldy+M9qXkP4k9V6l9v2QQ84pc8rI50e2F5QWnIklIxu3H5C6BJIRbeRhwbJ1aNa+L37o1Rl+7ncxfdKvOPHPJpibm6FEscJYOGcSbG2sUbF8aQDAy9fvMHv+Soyd8gfMzExx9sg2eDy7iukTf8XLe2dRqXxpLF21UTOAZWdnm+wAFgDUqVmFA1hawPaBRJsOn5G6BJIZthGkxiyQiP0FiZgHMgQcxJIRI2OuGURfZTQP/v6BmDZnCSqUK4U/po9N1ZpUv4//BS7Ojnj99j0a1K0JU1NT2FhbYeigPnBxdkLd2tWw98Bxzfbnj+7IUI2UemwfSGRkxDxQfGwjSI1ZIBH7CxIxD2QIDP9avEyk9/949zb6KqN5OHvxKmxtrHHyn02pvuy2d7cO6N2tQ5LPV6pQBsbGxjh/bCdy5nCBi7NThmqk1GP7QKJeLepLXQLJDNsIUmMWSMT+gkTMAxkCzsSSkTY9hkpdAslIRvIQExODvzb9rZlNpS3NGn2H62f3oXTJohzA0jO2DyRq99tMqUsgmWEbQWrMAonYX5CIeSBDwJlYMrJjzVypSyAZyUgelq7ahAePnuLC8V1arAgwNjbW3M2Q9IvtA4m2Tecd4Sg+thGkxiyQiP0FiZgHMgSciSUj1249kLoEkpH05kGpVGL1+u0YO3Iw8udz03JVJBW2DyS6/vC51CWQzLCNIDVmgUTsL0jEPJAh4CCWjFy7eV/qEkhGUpMHf/9APHj8TPNzWFg4nj5/hU9fvNC6eUNdlkd6xvaBRNcfPkt5I8pS2EaQGrNAIvYXJGIeyBAoIiMjVFIXkVbR0dGo07IvLh7ZmOoFqzMzpccHre3LyC231valbSmdp5xrl8rYKX9g1bpt2LlxCXLmyI4GLbsjd66cUKlUeHj9eMo7IIOXnvZD/LeWkfYnq/yb1WYbrWuZ6T0Rf6/arDuj71dm+h1mRGbKdXqk532Uw+9EF/lTn1dy+85oX0L6k9R7ldr3Qw45p8wpI58f2V5QWnAmloz8PHqW1CWQjKQmDx8+fo7dduQUHDh8Ejmzu6BZo++wdimzZGjYPpBo6Lw1UpdAMsM2gtSYBRKxvyAR80CGgINYMjLkx65Sl0Ayos7De4+PmLtwFR48foY/Fq3Gy9dvER0djZiYGDx9/grTJ/6KbC5OWLh8Pdq2aoJ5M8ahRtWKEldP2sb2gUQ/dW4hdQkkM2wjSI1ZIBH7CxIxD2QIDP9avEzExNhY6hJIz5RKJcZO+QOjfumP9+4fce/hE7RoUh/7Dp1A9SoVERIairLVmwMAZs9fCQCY9eeKePuoWrkcenVrD48Pn1GqRBG9nwPpB9sHEpkY829QFB/bCFJjFkjE/oJEzAMZAqZYRuYv3yR1CaRHIaGhOP7vBazZsANFyjdAk3Z98Ou4mSheqRHG/z4PM+avwc07sXcY2rhqHqaOH471K+Zi1aIZAABbG2s0qFsD5UqXgIO9HUqXLAqFQiHlKZEOsX0g0YJtB6QugWSGbQSpMQskYn9BIuaBDAEXds8EuLB7LDnXnh5zFqzCnAUrNT+XLF4ExYsWRP3vamDPP8fg4uwIP/8AREZG4fDudfFeGxERCYVCATMzU32XTZkMF3bXvcy0CG5mek+4sLu0MlOu04MLu3/Fhd0NCxd2J6lwYXfSF87EkpG5i9dLXQLp0YXLN9Dzf+0w/refsGz+VFw6+TfWr/gDvbq2R93a1XD5xn2cOX8Vi+dOTvBac3MzDmBlMWwfSPTH5n1Sl0AywzaC1JgFErG/IBHzQIbA8KcxZSLlyxSXugTSk1ev3+HK9VuYMelXVCxfOsHzI4b8gAtXbmH6+KEoVDCfBBWS3LB9IFH5ogWkLoFkhm0EqTELJGJ/QSLmgQwBB7FkpG6tylKXQHry+q07zM3NUKFcqUSfVygU2LlhESzMzfRcGckV2wcS1a2YcPCbsja2EaTGLJCI/QWJmAcyBLycUEY69B4udQmkJx8/fYFrzuzJLsTOPJCIeSBRxzFzpC6BZIZtBKkxCyRif0Ei5oEMAQexZOTorhVSl0A68uzFa5y7eE3zs/vHT3DNmT3Z1zAPJGIeSHR44SSpSyCZYRtBaswCidhfkIh5IEPAQSwZ2bH3qNQlkA48e/Ea7bsNRLtuA1GsYkO8ePUWu/cfRe3qyU/3Zx5IxDyQaOeJC1KXQDLDNtzvQRIAACUGSURBVILUmAUSsb8gEfNAhoCDWDISEhomdQmkZRERkej+wy/Iny8PRv0yAF88vVGlblvERMdgSP9eyb6WeSAR80CikPAIqUsgmWEbQWrMAonYX5CIeSBDwIXdZeTHXh2lLoG06MPHL+jS52f4BwTh9KFtcHCwQ9nSxTHolwlYvWQWHBzskn0980Ai5oFE/do2lroEkhm2EaTGLJCI/QWJmAcyBJyJJSOdvx8pdQkG4dNnT9y8fR+hYWEID4+Al7dPvOe/eHrj3MVrUKlUOqshJDQUpao2waMnzzF5zFDNgFXr5g3x4fk11KpeKcV9MA8kYh5I9L9xf0hdAskM2whSYxZIxP6CRMwDGQLOxJKR1QsmS11CpnXp6k2Eh0dg5p/Lcefeo3jPGRkZ4e6VIzh15hJCQ8Mw688VCAsPx/IF09CjS1vNdvcfPYWpiQlKFCucoVqCgkNw++5DAMDwn75H7+4d0rUf5oFEzAOJVo4dLHUJJDNsI0iNWSAR+wsSMQ9kCDgTS0YeP3stdQmyFxkZhWcvXiMmJgZKpRIBgUEIDApG6y4/olOvn3Dn3iN07dQaAFC+bEm0adEISqUSZas3x8jxMzFpxgJMHPMzmjeph7vfDHZ91/R/qNGwI3btPYz6Lbvj/qOnAACVSoW37zxSVd+nz57IU7wmOvQYjBLFCuH38cOhUCjSda7MA4mYBxI9eZu6NomyDrYRpMYskIj9BYmYBzIEnIklIyfPXkHt6hWkLkO2vLx9UKR8AwBA4YL54Onti8DAILjldoVKpcLTW//i4pX/0KldcyycPRGWlhYAgJV/bcOxU+fQuH5tnLt4DQO/74bHT18gIDAIHh8/wy1XTsTExGiOM/CXCQBiB7UUCgVsbawRFByCB9ePwy1XzmRrPHfpOgCgV9d2aN+6aYbOl3kgEfNAolPX76JWuRJSl0EywjaC1JgFErG/IBHzQIZAERkZobuFgXQkOjoadVr2xcUjG2FiYvjjcEqPD1rbl5Fbbq3tS9uSOs+YmBjU7D4YL4TZUH17dMSHj19Q77vqmDD1T5QuWQyXTv6d6mON+30eNm/fC6VSBfenl/HxsyfKVm8OIyMjKJVKAICTowN8/fw1rzmyZz1qVa+EyMgovPf4gMkzF2HBrAnImSObZptZf67AxSs3cGzfxrSdPJGOpKf9ENuJjLQ/cm5vtEmbbbSuZab3RPy9arPujL5fmel3mBGZKdfpkZ73UQ6/E13kT31eye07o30J6U9S71Vq3w855Jwyp4x8fmR7QWnBywll5NeJ86QuQZZW7TqAF+88MGbEIDy99S88X9/EormTsXvLcvT8Xzvkypkda5bMTNM+7WxtEBIahrDwcLjkr4RzF69BoVDgr2WzAQBdOrTE8f0b8dsv/XH3yhEAwN/7jiAwKBg5C1dF5e/a4uiJs1i0YkO8/b58/RYF8ufRynkzDyRiHkg0ctF6qUsgmWEbQWrMAonYX5CIeSBDYPjTmDKR3v9rLXUJsrT35DmUKVoQ40YmXIjQ3s4Wj2+eSvM+7e1t4/08bNRUFCqQFx3aNEPtGlWQPZszAGDiqJ8122/avhcfP32BUqnEqF8GoHSJovhhyBi0a9UYFcuVhpGRAqfPX8GcqWPScZYJMQ8kYh5I1KtFfalLIJlhG0FqzAKJ2F+QiHkgQ8BBLBlxcrSXugTZuf/sFR6/eostcydpdb92tjbxLh288u8e5MqZAwA0A1iiJzdPYcqMhdj29wE0bfQdJowaAgBosOsfNGvfF62bN8TYXwcjICAI9WpX00qNzAOJmAcSOdnZSF0CyQzbCFJjFkjE/oJEzAMZAl5OKCNT5qyQugRZ8Q0IRIuBv6FVvVqoV1W7C5Q2aVAHqxbNwNTxw7F8wTSULF4EDg52SW5vZWmJeTPH49rZ/Vgwa6Lm8W3rFmHmlN9w6epN3L73EDlzZINrzuxaqZF5IBHzQKLf1+yQugSSGbYRpMYskIj9BYmYBzIEXNg9EzC0hd2vXL+NMqWKwdbGOt7j357nrUfP0LjfCLw7vQe21layqD0xb995oHytlqhbuxosLS2wc8MSqUsi0uDC7rqXmRbBzUzvCRd2l1ZmynV6cGH3r7iwu2Hhwu4kFS7sTvrCmVgysnDlFqlL0LmHj5+jRcfv8cvoqfEeX7JyI4bPjj/489nbBzZWlrC1ttJniWmWL29uZHNxwvlL11GxXCmt7Tcr5IFSj3kg0aIdB6UugWSGbQSpMQskYn9BIuaBDIHhT2PKRAoXzCt1CTrjHxCI4WOm49zFawCAV2/ex3t+8syFAIBF44ZhztqtMDUxweU7D2Bmaqr3WtNKoVDgu1pVsffAcVQoq71BLEPOA6Ud80Ciwm6uUpdAMsM2gtSYBRKxvyAR80CGgINYMtK6aV2pS0jW0tWb4JYrJ9q3bprq11y9cRsDhk2AMiYGHz59gVtuV8yfNR5Df/sdYWHhsLS0iLd9WHgE/li3XfNz/WoVtVa/Lo0ZMQgqlQrVqpTX2j7lngfSL+aBRK3qVJG6BJIZthGkxiyQiP0FiZgHMgS8nFBGGrb/UeoSknT+0nVMmr4A3w8ejU3b9qJmw44ICAxK9jVRUVH4acRkONjbomL50li7dDb+O/cPGjeoA1tbG8xf9hcAYPOOfZrXePr6AQB+7tER1pYWWDN1lO5OSouKFi6A9Sv+gJ2t9u74Iec8kP4xDyRqPGSy1CWQzLCNIDVmgUTsL0jEPJAh4MLumYCUC7tHR0dj8459GDN5LmpWq4TQ0DD8d/s+AGDPlhVwdnJAhXKlsH33QWz/+wAO716nee2de49Qv2V3XD+7H8WKFIy3330Hj+OHn8bAydEBvn7+AAAneztsmzcZzQf8hg/n9kMFFawsvs7U4oJ/RGnHhd11LzMtgpuZ3hMu7C6tzJTr9ODC7l9xYXfDwoXdSSpc2J30ReczsXbsO4bW3X7Gtt1HAAD+AUEYOmY2egwYi627D2u2++foGfQYOBYDf50GTy8fXZclS/sO/St1CYiKikJERKTm56s37uDXcTPhmjM7tq9fhFMHt+DF3TPIn88NXb8fhtZdfoRSqcSsP1fg0tWbUKm+jonee/AEefPkSjCABQDtWzdFnZpV4OvnD1NTE6xePBOmJsbw9PGDnY01LC3M4w1gZUVyyAPJB/NAov1nr0pdAskM2whSYxZIxP6CRMwDGQKdD2JVLFMcVSuV0fy8ftt+1K1VGZtWzMCxfy/hvccn+PoFYMuuQ1i3eCo6tWmM5et26bos2Xn7zgO37z+WugxMm7MUpas1xYRpf+Lh4+d49uI1CuTLgxtn/4G1VexdArO5OCNfntyIjo5GcEgo3r3/AKu4ta1+HTcDNRp2gFKphPuHT8if1y3R4ygUChzYuQbXz+7H89tnYGNjjZCwcHj6+CGHs6PezlfOPnt6S10CyQjzQKLPPv5Sl0AywzaC1JgFErG/IBHzQIZA54NYxYoUgGsOF83PV27cRfkyxWFiYoIyJYrg6n/3cP3WAxQtlB8WFuYoX6Y4rv53V9dlyU6rzv2wbOW6lDfUoVNnLmHp6k3wDwjE8jVb0Kh1Tzx78RrFihaEhYV5vG3HjBiE/n27ws7WBnVbdMPb9x4AgA1b9+DJs1f4a9MuXLh8A265cyZ5PCMjIxQrUhCOjvawtrJEaHgEPvv4Ioezk07PM7P4qV9XqUsgGWEeSDS4U3OpSyCZYRtBaswCidhfkIh5IEOg94Xdff0C4JYrBwAgr5srvH384ePrj7xusYMdLk4OiFEqES5c0gYAew6eQrf+o9Gt/2j0HDRO32XrnI+vPwoUKoKg4BC9HTMgMAjrNv+NdZv/hkqlwj9HTgIApk/8FQAQHhGBew+eoGihAgleW7NaRcybMQ5VKpZFYGAQ/pwxHmNGDNI8P3rSHNy+9wilSxZLVS1WVpZQKpXw+OyJ7JyJBQDoMXCs1CWQjDAPJOo1eaHUJZDMsI0gNWaBROwvSMQ8kCHQ+6roCoUCiFs3SalSQmGkABSIt5aSSqmCQhH/dZ3aNEanNo0BfF3Y3ZCYm5vB/f1bvHj5BhXLl9bLMX8bPwvH/z2PoOAQVKlUFo+evMCkMUPRrFFdjJ3yBwDgxq176N29Q5L7WL5gGl69eY9a1SvB4+NnuObIhkdPX2Dtxp24f/UYcscNWKZEfVe/Ry/fok6lshk/OQPw57TfpC6BZIR5ING8YX2lLoFkhm0EqTELJGJ/QSLmgQyB3mdiOTnaw+PjFwCAu8dnZHN2RDZnR7z/8BkA4OXjB1NTU5ibmem7NEnt2LAYZmZmePHqrV6OFxUVhRNnLmLB7InIn88Nzdr1wf2HT1GyeGHkz+eGM4e3Yc2SWdi8Zj7at26S5H5y5siGWtUrAQDccuVE356dMG/GODy8cSLVA1gAUKRQftjb2uDhi9dcEyuOx8fPUpdAMsI8kMjDM2veAIWSxjaC1JgFErG/IBHzQIZA74NYtapVwJ0HTxEdHY2HT16iRpVyqFqxDF68eofw8Ajcuf8UNauW13dZkqtRtSJKFC+G4/+e1/mxPn76gqs37iA4OAQN69XE5jXzMXnsMGxYOQ+N6tUCAFQsXxpdOrREmxaNNAu6p4VbrqTXwkqMsbExaleMvQFADheuiQXEXkJLpMY8kGjvmStSl0AywzaC1JgFErG/IBHzQIZAERkZoUp5s/Tx8vHDyInz4OMXACOFAvny5sLMCcMwadYy+Pj6o1XT79CtYwsAwKET57Fz3zHYWlth+oShyJbMbBz15YQXj2yEiYner4jUmXMXr6FDj8G4c/kw8uXJrXlc6fFBa8f4aGSM0lWbAgDy5c2Ne1eOam3fGbV64SqMmb8SexfPQP1qFRM8b+SWO5FXEVFy0tN+iP/WMtL+ZJV/s9pso3UtM70n4u9Vm3Vn9P3KTL/DjMhMuU6P9LyPcvid6CJ/6vNKbt8Z7UtIf5J6r1L7fsgh55Q5ZeTzI9sLSgudzsTK5uyIzStn4cjO5Ti0YxmWzR0PezsbLJkzFtvWzNEMYAFA66Z1sW31HKxaMDnZASxDduLsNRQplB8VarVCYFCwTo7x3v0jAGD08IGY/ftonRwjvb6rXA4AkCu7SwpbZg3jpi2WugSSEeaBROOXb5G6BJIZthGkxiyQiP0FiZgHMgSGM43JALRv2RBVyhfHDz+Nwelzl9G+dVOt7fvKnQfYeugk/CIi4ezkiPG//aS1fWtLsQJ5cXHLchQrkFfqUmShfcsGUpdAMsI8kKhdvWpSl0AywzaC1JgFErG/IBHzQIaAg1gykjePK6pWKoP5S9fB44P2FuWMjIrCj5PmIio6Gj7+gShZvIjW9q1tpYoUkLoE2cibx1XqEkhGmAcS5c2ZTeoSSGbYRpAas0Ai9hckYh7IEOh9YXdK2q8T5gEA8ufNjffu2rse/cSlG/APCsbI77sCABrXr6W1fZPuqPNABDAPFN/IReulLoFkhm0EqTELJGJ/QSLmgQwBB7FkZPvauQCAHNld4Ontq7X97jl5Dq3q1kTN8rF3/xsxpJ/W9k26o84DEcA8UHzbpo+UugSSGbYRpMYskIj9BYmYBzIEHMSSkRXrdwEAHOztEBAYpLX9vv/4BWWKFULZYoXg73EPDg52Wts36Y46D0QA80Dxrdx7TOoSSGbYRpAas0Ai9hckYh7IEHAQS0ayuzgBiB3E8g8I1Np+/QKD4Ghnq7X9kX6o80AEMA8UX3ZHe6lLIJlhG0FqzAKJ2F+QiHkgQ8CF3WWkU5vGALQziBUTE4M1uw/h0NnLcYNYNtookfRInQcigHmg+Do2qCl1CSQzbCNIjVkgEfsLEjEPZAg4E0tGGncYAACwt7eDv3/GBrGGzVqMCYvW4Nq9RwgKCYWDLWdiZTbqPBABzAPF1/TnKVKXQDLDNoLUmAUSsb8gEfNAhoCDWDJyYs8qAICLsyMCAoOw98AxjJ40J8F2D1+8RrX/DUSXEZMRExOT4PmQsHAcOH0RAGBjZQkAcLDlTKzMRp0HIoB5oPiOLeGHUIqPbQSpMQskYn9BIuaBDAEHsWTk6KnYgaeC+fNApVKh35CxWLNhR4LtHr54gxfv3PHv1Zvw+WbG1r5T55GnfgeEhkcAAJZP+hXTh/2IYgXy6v4ESKvUeSACmAeK79iVW1KXQDLDNoLUmAUSsb8gEfNAhoCDWDLy4vU7AEDOHNlgY22leXzzgePxtvMPCkLOuEU7Nx04BpVKpXlu17EzAIDCeXMDAJrUqooh3TvAxMRYp7WT9qnzQAQwDxTfi/efpC6BZIZtBKkxCyRif0Ei5oEMAQexZGTE4N4AAIVCgc1r5mPA990AAMNnLwEAfPHxRVR0NPwCg1HAzRUAMHvNVrz98FmzDyd7W5QolA9HVs2D77WjMDcz1fNZkLao80AEMA8U3/DubaQugWSGbQSpMQskYn9BIuaBDAEHsWTkh6GTNd83qFsTndu1iPd8h2ET0GHoBMxbtx1O9naaxz19/TTff/byRbPa1ZDNyUHn9ZJuiXkgYh5I9OOMpVKXQDLDNoLUmAUSsb8gEfNAhoCDWDIyedSgeD9bxS3Krvbhizcu33kAALCztsbB5bGLvnv7+QMAwsIjcO/5SxTJl0f3xZLOfZsHytqYBxJN6vc/qUsgmWEbQWrMAonYX5CIeSBDwEEsGQkICo73c66c2QEAJsbG2Hb4JAKDQzTPWVtZoHalsijolgtefgEAgENnLyM6Ogat6tXUX9GkM9/mgbI25oFEAcGhUpdAMsM2gtSYBRKxvyAR80CGgINYMrJx+z/xfnZ0tMem1fMRHRODoTMWAQCsLMwBACP6xI6i53HNjkcvXse+/p9j6NKsAWy+mcFFmdO3eaCsjXkg0abDp6UugWSGbQSpMQskYn9BIuaBDIEiMjJClfJm8hIdHY06Lfvi4pGNMDExkbocnVKpVAh4/hIlWvRAWEQEzm5cgvy5c8Le1gYAsOXgCfy+bD0OrZiD2j2H4MKWZShdpGCS+zNyy62v0tNM6fEh2eflXDuRXKX07yox4r+19Lw+sf0Ysoz8jvQtM70n4u9Vm3Vn9P3KTL/DjMhMuU6P9LyPcvid6CJ/6vNKbt8Z7UtIf5J6r1L7fsgh55Q5ZeTzI9sLSgvOxJKR3+euSPCYQqGAnbUVlColAKBssUKaASwAaNuwDsIiItD1t99hY2WZ7AAWZS6J5YGyLuaBRFPX7pS6BJIZthGkxiyQiP0FiZgHMgSGPY0pk2n4XbUknzu88g/4BQZBoVDEe9zO2gpDunfA/A1skAxNcnmgrId5IFGDKmWlLoFkhm0EqTELJGJ/QSLmgQwBZ2LJSOkSRZJ8rlKpYmhUo3Kiz00Y2FtXJZGEkssDZT3MA4lKF8ordQkkM2wjSI1ZIBH7CxIxD2QIOIglI/2H/y51CSQjzAOJmAcSDZi5XOoSSGbYRpAas0Ai9hckYh7IEHBh90wgNQvjbT5wHEqVCn3bNU92OzkvmseF3Ym0jwu7615mWgQ3M70nXNhdWpkp1+nBhd2/4sLuhoULu5NUuLA76QtnYsnIuq370/3a3m2bpTiARZlLRvJAhod5INH6g/9KXQLJDNsIUmMWSMT+gkTMAxkCDmLJiIW5mdQlkIwwDyRiHkhkYWYqdQkkM2wjSI1ZIBH7CxIxD2QIOIglIz06t5S6BJIR5oFEzAOJujerK3UJJDNsI0iNWSAR+wsSMQ9kCDiIJSOtug2RugSSEeaBRMwDidr8OkPqEkhm2EaQGrNAIvYXJGIeyBBwEEtGdm+YL3UJJCPMA4mYBxLtmj1a6hJIZthGkBqzQCL2FyRiHsgQcBBLRi5evS11CSQjzAOJmAcSXbr7WOoSSGbYRpAas0Ai9hckYh7IEHAQS0Zu33sidQkkI8wDiZgHEt1++krqEkhm2EaQGrNAIvYXJGIeyBAoIiMjVFIXkVbR0dGo07IvLh7ZCBMTE6nL0Tmlxwet7cvILbfW9qVtKZ2nnGsnkqv0tB/iv7WMtD9Z5d+sNttoXctM74n4e9Vm3Rl9vzLT7zAjMlOu0yM976Mcfie6yJ/6vJLbd0b7EtKfpN6r1L4fcsg5ZU4Z+fzI9oLSgjOxZGTwb1xoj75iHkjEPJBoyNxVUpdAMsM2gtSYBRKxvyAR80CGgINYMjJ8UE+pSyAZYR5IxDyQ6JeuraUugWSGbQSpMQskYn9BIuaBDAEHsWREpcp0V3aSDjEPJGIeSKRkHugbbCNIjVkgEfsLEjEPZAg4iCUjS9dsl7oEkhHmgUTMA4mW/X1E6hJIZthGkBqzQCL2FyRiHsgQcGH3TIALu8eSc+1EcsWF3XUvMy2Cm5neEy7sLq3MlOv04MLuX3Fhd8PChd1JKlzYnfSFM7FkZPbCv6QugWSEeSAR80CiORv3SF0CyQzbCFJjFkjE/oJEzAMZAg5iyUiVCqWlLoFkhHkgEfNAosoli0hdAskM2whSYxZIxP6CRMwDGQIOYslIzWrlpS6BZIR5IBHzQKKaZYtLXQLJDNsIUmMWSMT+gkTMAxkCDmLJyP/6jZK6BJIR5oFEzAOJuk34U+oSSGbYRpAas0Ai9hckYh7IEHBh90yAC7vHknPtRHLFhd11LzMtgpuZ3hMu7C6tzJTr9ODC7l9xYXfDwoXdSSpc2J30JVOOAKlUseNu0dHREleiXdv2HEWPTi0SPK6MjtHaMYxk/DtL6TzlXLsuJJUHyprSm4f0tB/iv7WMtD9Z5d+sNtvo1Np+4jy6N62b5tdlpvdE/L1qs+6Mvl9y/R1qu8+QItf6lJ73UQ6/k9TUndYsqM8ruX1ntC8h/fn2vVL3F6l9P+SQc9Kd9H5+SI2MfH5ke0EpMTY2hkKhAJBJZ2KFh4ejftsfpS6DiIiIiIiIiIh0SLwKL1MOYimVSkRGRsYbjTMUPQeNw9ZVs6Uug2SCeSAR80Ai5oFEzAN9i5kgNWaBRMwDiTJLHsSxn0x5OaGRkREsLCykLkMnFApFlljni1KHeSAR80Ai5oFEzAN9i5kgNWaBRMwDiTJjHnh3QiIiIiIiIiIikj0OYslMx9aNpS6BZIR5IBHzQCLmgUTMA32LmSA1ZoFEzAOJMmMeMuWaWERERERERERElLVwJhYREREREREREckeB7GIiIiIiIiIiEj2OIhFRERERERERESyl7nupZiJBQaFYM7idXD3+Ax7OxtMGzcERkZGmDRrGXz9AtC8cW307NwKALBj3zFs330EXTs0R4/OLQEA0dHRWLhyC+4+fAZ7Oxv8PnowsmdzlvKUKAMymocfhk5GdHQ0AMDXPwAN6lTDrz/1lux8KGMymgdvHz9MmLkUXt5+KF+mGCaOHAAjI/6NIrPKaB6evXiD6fPXQKVSoVObxmjfsqGUp0MZlNo8JLadk6M9/AOCEs0OZU4ZzcOHT574c9lG3H/8HKf3/yX16VAGZTQPp85dxa79xxEQGIwenVuiXYsGUp8SZUBG83Dg6FkcOHYGfv6BaFy/JgZ/3wUKhULq06J0ymge1OYt3YA37z9gxbyJEp5NfFzYXU+u3LgLS0sLVChTHEvXbgcAREVFI6+bK9q1qI8+QyZi9qRfkNfNFc9evMHfB06iYD43zf+U7D5wEm/dP+K3IX3g/uEzXHNkg6kpxyAzq4zmQS0mRomhY2fh9zE/IbuLkxSnQlqQ0TysWLcT1tZW6NWlFabNW4UWjeqgaqUyUp4SZUBG8/DD0MkYMbgXihTMiz5DJmL+9N/gliuHlKdEGZDaPHh8/JJgu6H9u2PBis2JZocyp4zmISAwGK/evMdvk+fjzIF1Up4KaUFG8vDTD12xccc/6NWlNcLCw9Ghzwjs37wYdrbWUp4SZUBG24f/7jxEhTLFEaNUolOfX7F64WTkypldylOiDMhoHgDg5Rt3TP9zFaytLGU1iMU/1etJzarlUaFMcQBAmZJF4OXthys37qJ8meIwMTFBmRJFcPW/ewCAYkUKwDWHS7zXH/v3Erq2bwaFQoG8bq4cwMrkMpoHteNnLqFqhTIcwMrkMpoHKytLONrbwsjICIXy54GJibHez4G0J6N5+OzpjdIlCsPCwhy1q1fA5et39H4OpD2pzUNi2wFIMjuUOWU0D/Z2NqhYrqRk9ZN2ZSQPxsZG6NezA8zMTGFvZ4tcObLDPyBQytOhDMpo+1ClQmlAocCrN+6wtrZCNmf+/0VmltE8qFQqLF2zDT/0aC/ZOSSFg1gSuHX3McqWKgpfvwDNX8fzurnC28c/ydd89vTGjdsP0GfIBMxcsBbRMTF6qpZ0LT15UDt47BxaNf1OxxWSPqUnDx1bN8KeQ/9i7ea9ePH6PcqWLqanaknX0pMHBztbPHn+GiEhoXj28i08vX31VC3pWmrzoN4OQLr6Fsoc0pMHMlwZyYO3jx+CgkOQ25Wzdg1FevMwesoC9B/+O0b93JeTJgxIevJw4eot5HbNgaIF8+m73BRxEEvPXr11x393HqF1s7qx1xirYq/mVKqUUBglfc1xaFg4bKytsWHpdPj6BeDClVv6Kpl0KL15AAAvHz9ERUXDxdlRH6WSHqQ3D+cv30TdmpVhbWWJ1+884O3jp6+SSYfSm4dRw77HH0s2YNLs5ShcIC9srK30VTLpUGrzIG4HIM19C2UO6c0DGaaM5EGlUmHJmu34vns7GBvzfw0NQUbysGDGKOxY+wfmL9+Et+8/6L120r705CEyMgqbdx7CwL6dpCo7WWyp9MjPPxBT5qzAjAlDYW5mBidHe3h8/AIAcPf4jGzJDEY4O9qjfOliMDIyQuXyJfHxk6e+yiYdyUgeAODp89coXDCPPkolPchIHnbsO4Y+XVuje6cWaNOsHo6cvKivsklHMpKHCmWKY+PyGVgwYxSio2OQK2c2fZVNOpLaPHy7HYA09y0kfxnJAxmejOZh+56jMDU1QZvm9aQon7RMG+1DXjdXVKlYGrfvPdF7/aRd6c3DvUfPEBgUjJGT/sSYaYvw7OVbLFy5RcpTiYeDWHoSGRmF8dMXo3/vjihcIHbgoVa1Crjz4Cmio6Px8MlL1KhSLsnX165eEWcu3UB0TAxu3n2Mgvnd9FU66UBG8wAAnz194OzkoIdqSdcymofIyCg8evoKSqUSb97xr2aZXUbz8OqtO2JilPji6YMbtx+gTo1K+iqddCC1eUhsu6S2pcwro3kgw5LRPFy8dhsXrt7C6GHf8y50BiAjeQgKDsHqTbsRFRWNkJBQ/Hf7IfLlySXl6VAGZSQPVSqUxu4N8/HX4qmYO3k4ihXOjxGDe0l5OvHw7oR6sm7rfmzbfRj58+ZCdHTselbzZ4zC9Hmr4ePrj1ZNv0O3ji3g5eOHkRPnwccvAEYKBfLlzYVlc8cjIDAY0+atwnuPT6hSoTRGDe3LziYTy2geAGDjjgNQKBTo07WNlKdCWpDRPNx79Bx/LFmP8PAIFMqfB5NHD+IlZJlYRvOwdfdhHD99GUZGRvhlQA9UKs9FnDOz1OYhse3WLJyCiMgoTJq1LN62lHllNA+bdx3CpWu38fKNOwoXyIM+3dqi4XfVpDwlyoCM5qHF/35C9mzOMDMzBVQqNG9Um21EJpbRPOzcdxxnL99AQEAwmjeujQG9O/H/NzOxjObBwsIcAPDpsxemz18tq7sTchCLiIiIiIiIiIhkj5cTEhERERERERGR7HEQi4iIiIiIiIiIZI+DWEREREREREREJHscxCIiIiIiIiIiItnjIBYREREREREREckeB7GIiIiIiIiIiEj2OIhFRERERERERESyZyJ1AURERERZVfvew2FmagITExNYWpijR6eWqFe7ChQKRZKv+WvLXrjmyIaWTb7TY6VERERE0uMgFhEREZGEpo8fiqKF8uG9xyeMmboQ0TExaFyvhtRlEREREckOB7GIiIiIZCCvmyuGDeiBZX/tQMWyJbB49VZ4fPyCwKAQdGnXFF3aNcXuAyfx9z8nYWVpgV37j2P9sunw9w/EH0s24P2HzzAzM8Xood+jdInCUp8OERERkdZxEIuIiIhIJkoVL4z3Hp9gZ2uDHp1aoliRAvD08kGn70eieaPa6Ny2CZ6+eIOKZUtoLiecMX8NunZojuqVy+Lt+w+YPGcFNq+YKfGZEBEREWkfB7GIiIiIZEKlUkKhUMDIyAgWFuZYt3U/Xr11hwIKfPH0ga2NdbztQ8PCcfPOI/j6BWDFup0AgKDgEClKJyIiItI5DmIRERERycSDxy+RP08u3Lj9AMvX7cTAPp3QqU1j9H0+EUqVKtHXqKDC8nkTEgxwERERERkaI6kLICIiIiLg7fuPWLJmG/p2b4er/91D5fKlUKdGJfj5ByAo6OvsqpzZXfDpixcAwMrSAhXKlsDazXuhVCoRE6PEpy/eUp0CERERkU4pIiMjEv+zHhERERHpVPvew2FmagJjo/+3b/cqCcYBFIcPSH4sSlfgEDYEjW4iTiHo4qJTUzcQuDS1tL6j7npNQSBCiUR38Uo3EfQfnucOzvqD00in087jcp7JaJjD8SvVdp+6vuT+bpD3j2Nenp9ye9PP5+k769cq171uqrd16vqSarPL6fyTVvMqs4dxVovpf08DAPhzIhYAAAAAxXMnBAAAAKB4IhYAAAAAxROxAAAAACieiAUAAABA8UQsAAAAAIr3C4pJ/qSiP3PPAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "SPY cumulative return from 2016 to 2024 as a dark line rising steeply, with vertical pink bands marking the sessions the regime model calls stressed. The bands sit on the drawdowns - early 2016, early 2018, late 2018, the February 2020 crash and most of 2022 - and are absent from the steady climbs between."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "def in_validation_windows(column: str = \"timestamp\") -> pl.Expr:\n",
     "    \"\"\"True on a session inside any cross-validation fold's validation window.\"\"\"\n",
@@ -1028,13 +1398,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b58adb04",
+   "id": "fc6602ed",
    "metadata": {
     "papermill": {
-     "duration": 0.00295,
-     "end_time": "2026-09-05T01:19:57.555734+00:00",
+     "duration": 0.003713,
+     "end_time": "2026-09-05T03:36:55.363387+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:57.552784+00:00",
+     "start_time": "2026-09-05T03:36:55.359674+00:00",
      "status": "completed"
     }
    },
@@ -1069,10 +1439,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c18c347c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 14,
+   "id": "3daaaad1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:55.369688Z",
+     "iopub.status.busy": "2026-09-05T03:36:55.369543Z",
+     "iopub.status.idle": "2026-09-05T03:36:55.375921Z",
+     "shell.execute_reply": "2026-09-05T03:36:55.375067Z"
+    },
+    "papermill": {
+     "duration": 0.01052,
+     "end_time": "2026-09-05T03:36:55.376705+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:55.366185+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (10, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>symbol</th><th>differencing order d</th><th>asset class</th></tr><tr><td>str</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>&quot;SPY&quot;</td><td>0.4</td><td>&quot;US large-cap equities&quot;</td></tr><tr><td>&quot;QQQ&quot;</td><td>0.4</td><td>&quot;US technology equities&quot;</td></tr><tr><td>&quot;IWM&quot;</td><td>0.4</td><td>&quot;US small-cap equities&quot;</td></tr><tr><td>&quot;EFA&quot;</td><td>0.4</td><td>&quot;International developed equiti…</td></tr><tr><td>&quot;EEM&quot;</td><td>0.4</td><td>&quot;Emerging-market equities&quot;</td></tr><tr><td>&quot;TLT&quot;</td><td>0.5</td><td>&quot;Long-dated Treasuries&quot;</td></tr><tr><td>&quot;GLD&quot;</td><td>0.4</td><td>&quot;Gold&quot;</td></tr><tr><td>&quot;VNQ&quot;</td><td>0.4</td><td>&quot;US real estate&quot;</td></tr><tr><td>&quot;HYG&quot;</td><td>0.5</td><td>&quot;High-yield credit&quot;</td></tr><tr><td>&quot;LQD&quot;</td><td>0.5</td><td>&quot;Investment-grade credit&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (10, 3)\n",
+       "┌────────┬──────────────────────┬─────────────────────────────────┐\n",
+       "│ symbol ┆ differencing order d ┆ asset class                     │\n",
+       "│ ---    ┆ ---                  ┆ ---                             │\n",
+       "│ str    ┆ f64                  ┆ str                             │\n",
+       "╞════════╪══════════════════════╪═════════════════════════════════╡\n",
+       "│ SPY    ┆ 0.4                  ┆ US large-cap equities           │\n",
+       "│ QQQ    ┆ 0.4                  ┆ US technology equities          │\n",
+       "│ IWM    ┆ 0.4                  ┆ US small-cap equities           │\n",
+       "│ EFA    ┆ 0.4                  ┆ International developed equiti… │\n",
+       "│ EEM    ┆ 0.4                  ┆ Emerging-market equities        │\n",
+       "│ TLT    ┆ 0.5                  ┆ Long-dated Treasuries           │\n",
+       "│ GLD    ┆ 0.4                  ┆ Gold                            │\n",
+       "│ VNQ    ┆ 0.4                  ┆ US real estate                  │\n",
+       "│ HYG    ┆ 0.5                  ┆ High-yield credit               │\n",
+       "│ LQD    ┆ 0.5                  ┆ Investment-grade credit         │\n",
+       "└────────┴──────────────────────┴─────────────────────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "REFERENCE_ETFS = {\n",
     "    \"SPY\": (0.4, \"US large-cap equities\"),\n",
@@ -1099,10 +1519,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2a425bd6",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 15,
+   "id": "51d63a07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:55.386102Z",
+     "iopub.status.busy": "2026-09-05T03:36:55.385981Z",
+     "iopub.status.idle": "2026-09-05T03:36:56.035749Z",
+     "shell.execute_reply": "2026-09-05T03:36:56.035380Z"
+    },
+    "papermill": {
+     "duration": 0.654232,
+     "end_time": "2026-09-05T03:36:56.036191+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:55.381959+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fractionally differenced series: 10 over 5,031 sessions, each computed once over its own whole history.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (10, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>series</th><th>first value</th><th>sessions with a value</th></tr><tr><td>str</td><td>date</td><td>i64</td></tr></thead><tbody><tr><td>&quot;ffd_spy&quot;</td><td>2006-01-03</td><td>5031</td></tr><tr><td>&quot;ffd_qqq&quot;</td><td>2006-01-03</td><td>5031</td></tr><tr><td>&quot;ffd_iwm&quot;</td><td>2006-01-03</td><td>5031</td></tr><tr><td>&quot;ffd_efa&quot;</td><td>2006-01-03</td><td>5031</td></tr><tr><td>&quot;ffd_eem&quot;</td><td>2006-01-03</td><td>5031</td></tr><tr><td>&quot;ffd_tlt&quot;</td><td>2006-01-03</td><td>5031</td></tr><tr><td>&quot;ffd_gld&quot;</td><td>2006-01-03</td><td>5031</td></tr><tr><td>&quot;ffd_vnq&quot;</td><td>2006-01-03</td><td>5031</td></tr><tr><td>&quot;ffd_hyg&quot;</td><td>2007-04-11</td><td>4713</td></tr><tr><td>&quot;ffd_lqd&quot;</td><td>2006-01-03</td><td>5031</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (10, 3)\n",
+       "┌─────────┬─────────────┬───────────────────────┐\n",
+       "│ series  ┆ first value ┆ sessions with a value │\n",
+       "│ ---     ┆ ---         ┆ ---                   │\n",
+       "│ str     ┆ date        ┆ i64                   │\n",
+       "╞═════════╪═════════════╪═══════════════════════╡\n",
+       "│ ffd_spy ┆ 2006-01-03  ┆ 5031                  │\n",
+       "│ ffd_qqq ┆ 2006-01-03  ┆ 5031                  │\n",
+       "│ ffd_iwm ┆ 2006-01-03  ┆ 5031                  │\n",
+       "│ ffd_efa ┆ 2006-01-03  ┆ 5031                  │\n",
+       "│ ffd_eem ┆ 2006-01-03  ┆ 5031                  │\n",
+       "│ ffd_tlt ┆ 2006-01-03  ┆ 5031                  │\n",
+       "│ ffd_gld ┆ 2006-01-03  ┆ 5031                  │\n",
+       "│ ffd_vnq ┆ 2006-01-03  ┆ 5031                  │\n",
+       "│ ffd_hyg ┆ 2007-04-11  ┆ 4713                  │\n",
+       "│ ffd_lqd ┆ 2006-01-03  ┆ 5031                  │\n",
+       "└─────────┴─────────────┴───────────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ffd_features = None\n",
     "for symbol, (d, _) in REFERENCE_ETFS.items():\n",
@@ -1141,13 +1618,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00959d80",
+   "id": "4d23f5ca",
    "metadata": {
     "papermill": {
-     "duration": 0.003124,
-     "end_time": "2026-09-05T01:19:57.754518+00:00",
+     "duration": 0.003138,
+     "end_time": "2026-09-05T03:36:56.042638+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:57.751394+00:00",
+     "start_time": "2026-09-05T03:36:56.039500+00:00",
      "status": "completed"
     }
    },
@@ -1166,10 +1643,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ef7ab4e9",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 16,
+   "id": "e1ec88ee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:56.049613Z",
+     "iopub.status.busy": "2026-09-05T03:36:56.049496Z",
+     "iopub.status.idle": "2026-09-05T03:36:57.644155Z",
+     "shell.execute_reply": "2026-09-05T03:36:57.643807Z"
+    },
+    "papermill": {
+     "duration": 1.599129,
+     "end_time": "2026-09-05T03:36:57.644824+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:56.045695+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (10, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>symbol</th><th>d</th><th>log price p-value</th><th>differenced p-value</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;SPY&quot;</td><td>0.4</td><td>0.973684</td><td>3.2707e-18</td></tr><tr><td>&quot;QQQ&quot;</td><td>0.4</td><td>0.978578</td><td>8.1794e-18</td></tr><tr><td>&quot;IWM&quot;</td><td>0.4</td><td>0.841016</td><td>5.6438e-17</td></tr><tr><td>&quot;EFA&quot;</td><td>0.4</td><td>0.605045</td><td>2.5825e-15</td></tr><tr><td>&quot;EEM&quot;</td><td>0.4</td><td>0.096591</td><td>1.6033e-12</td></tr><tr><td>&quot;TLT&quot;</td><td>0.5</td><td>0.394199</td><td>1.7561e-18</td></tr><tr><td>&quot;GLD&quot;</td><td>0.4</td><td>0.180186</td><td>9.3831e-22</td></tr><tr><td>&quot;VNQ&quot;</td><td>0.4</td><td>0.734767</td><td>4.2320e-12</td></tr><tr><td>&quot;HYG&quot;</td><td>0.5</td><td>0.793152</td><td>2.0324e-19</td></tr><tr><td>&quot;LQD&quot;</td><td>0.5</td><td>0.578789</td><td>9.7852e-19</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (10, 4)\n",
+       "┌────────┬─────┬───────────────────┬─────────────────────┐\n",
+       "│ symbol ┆ d   ┆ log price p-value ┆ differenced p-value │\n",
+       "│ ---    ┆ --- ┆ ---               ┆ ---                 │\n",
+       "│ str    ┆ f64 ┆ f64               ┆ f64                 │\n",
+       "╞════════╪═════╪═══════════════════╪═════════════════════╡\n",
+       "│ SPY    ┆ 0.4 ┆ 0.973684          ┆ 3.2707e-18          │\n",
+       "│ QQQ    ┆ 0.4 ┆ 0.978578          ┆ 8.1794e-18          │\n",
+       "│ IWM    ┆ 0.4 ┆ 0.841016          ┆ 5.6438e-17          │\n",
+       "│ EFA    ┆ 0.4 ┆ 0.605045          ┆ 2.5825e-15          │\n",
+       "│ EEM    ┆ 0.4 ┆ 0.096591          ┆ 1.6033e-12          │\n",
+       "│ TLT    ┆ 0.5 ┆ 0.394199          ┆ 1.7561e-18          │\n",
+       "│ GLD    ┆ 0.4 ┆ 0.180186          ┆ 9.3831e-22          │\n",
+       "│ VNQ    ┆ 0.4 ┆ 0.734767          ┆ 4.2320e-12          │\n",
+       "│ HYG    ┆ 0.5 ┆ 0.793152          ┆ 2.0324e-19          │\n",
+       "│ LQD    ┆ 0.5 ┆ 0.578789          ┆ 9.7852e-19          │\n",
+       "└────────┴─────┴───────────────────┴─────────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Series whose log price is judged stationary at 5%: 0 of 10. After differencing: 10.\n"
+     ]
+    }
+   ],
    "source": [
     "adf_rows = []\n",
     "for symbol, (d, _) in REFERENCE_ETFS.items():\n",
@@ -1211,13 +1745,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "187f8909",
+   "id": "f1cd5766",
    "metadata": {
     "papermill": {
-     "duration": 0.00294,
-     "end_time": "2026-09-05T01:19:59.356534+00:00",
+     "duration": 0.005938,
+     "end_time": "2026-09-05T03:36:57.656928+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:59.353594+00:00",
+     "start_time": "2026-09-05T03:36:57.650990+00:00",
      "status": "completed"
     }
    },
@@ -1248,9 +1782,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ce131c12",
-   "metadata": {},
+   "execution_count": 17,
+   "id": "55605de4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:57.669694Z",
+     "iopub.status.busy": "2026-09-05T03:36:57.669535Z",
+     "iopub.status.idle": "2026-09-05T03:36:57.680369Z",
+     "shell.execute_reply": "2026-09-05T03:36:57.679872Z"
+    },
+    "papermill": {
+     "duration": 0.017908,
+     "end_time": "2026-09-05T03:36:57.680918+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:57.663010+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "all_symbols = sorted(prices[\"symbol\"].unique().to_list())\n",
@@ -1277,17 +1825,22 @@
     "            \"omega\": float(result.params.get(\"omega\", np.nan)),\n",
     "            \"alpha\": float(result.params.get(\"alpha[1]\", np.nan)),\n",
     "            \"beta\": float(result.params.get(\"beta[1]\", np.nan)),\n",
+    "            # The value that seeds the recursion, computed by `arch` from the ESTIMATION\n",
+    "            # window's residuals and nothing else. It has to be produced here, where only\n",
+    "            # training rows are in scope: the array `apply` receives runs to the end of the\n",
+    "            # block being emitted, so a seed derived there would read the block's own rows.\n",
+    "            \"backcast\": float(result.model.volatility.backcast(np.asarray(result.resid))),\n",
     "        }\n",
     "        fits.append({\"symbol\": symbol, \"fit_end\": int(len(X_train)), **coefficients})\n",
     "        return coefficients\n",
     "\n",
     "    def apply(coefficients: dict[str, float], X_prefix: np.ndarray) -> np.ndarray:\n",
     "        # `garch11_conditional_volatility` rather than the fitted result object's own\n",
-    "        # `conditional_volatility`: `arch` seeds its recursion from a backcast over whatever\n",
-    "        # sample it is handed, and the sample here runs to the end of the block being emitted,\n",
-    "        # so an emitted value would move when the block's later returns arrived. The shared\n",
-    "        # helper seeds from the coefficients' own implied long-run variance instead, which is\n",
-    "        # a function of the fit and of no observation in the array.\n",
+    "        # `conditional_volatility`: `arch` derives its residuals, its seeding backcast and its\n",
+    "        # variance bounds from whatever sample it is handed, and the sample here runs to the\n",
+    "        # end of the block being emitted, so an emitted value would move when the block's\n",
+    "        # later returns arrived. The helper takes every one of those from `fit`, where only\n",
+    "        # training rows are in scope.\n",
     "        #\n",
     "        # The recursion runs on percent returns; restore decimal and annualize.\n",
     "        sigma = garch11_conditional_volatility(X_prefix[:, 0], **coefficients)\n",
@@ -1310,13 +1863,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa86fb40",
+   "id": "40ad4ae1",
    "metadata": {
     "papermill": {
-     "duration": 0.005075,
-     "end_time": "2026-09-05T01:19:59.382313+00:00",
+     "duration": 0.004565,
+     "end_time": "2026-09-05T03:36:57.690334+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:19:59.377238+00:00",
+     "start_time": "2026-09-05T03:36:57.685769+00:00",
      "status": "completed"
     }
    },
@@ -1330,10 +1883,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2ff611db",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 18,
+   "id": "b4c76e2d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:36:57.700362Z",
+     "iopub.status.busy": "2026-09-05T03:36:57.700269Z",
+     "iopub.status.idle": "2026-09-05T03:37:15.151397Z",
+     "shell.execute_reply": "2026-09-05T03:37:15.151014Z"
+    },
+    "papermill": {
+     "duration": 17.456834,
+     "end_time": "2026-09-05T03:37:15.151876+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:36:57.695042+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  fitting 100 ETFs across 23 processes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conditional volatility: 420,162 values across 100 ETFs, from 17,659 estimations over 20,052 blocks.\n"
+     ]
+    }
+   ],
    "source": [
     "returns_panel = (\n",
     "    prices.filter(pl.col(\"symbol\").is_in(all_symbols))\n",
@@ -1400,13 +1982,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63d8f5a2",
+   "id": "c5e0d4c9",
    "metadata": {
     "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-09-05T01:20:16.630850+00:00",
+     "duration": 0.003021,
+     "end_time": "2026-09-05T03:37:15.158159+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:16.627851+00:00",
+     "start_time": "2026-09-05T03:37:15.155138+00:00",
      "status": "completed"
     }
    },
@@ -1417,10 +1999,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bfcbfd0a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 19,
+   "id": "0a41070e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:15.165110Z",
+     "iopub.status.busy": "2026-09-05T03:37:15.164997Z",
+     "iopub.status.idle": "2026-09-05T03:37:15.180345Z",
+     "shell.execute_reply": "2026-09-05T03:37:15.179972Z"
+    },
+    "papermill": {
+     "duration": 0.019479,
+     "end_time": "2026-09-05T03:37:15.180676+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:15.161197+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Every volatility estimate ended before the holdout, and every ETF's first value falls after its own 504-session burn-in.\n"
+     ]
+    }
+   ],
    "source": [
     "_freeze_by_symbol = {symbol: freeze for symbol, _, freeze in payloads}\n",
     "_first_value = garch_features.group_by(\"symbol\").agg(pl.col(\"timestamp\").min().alias(\"first_value\"))\n",
@@ -1447,13 +2051,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a16cca8f",
+   "id": "74c9a8a5",
    "metadata": {
     "papermill": {
-     "duration": 0.003047,
-     "end_time": "2026-09-05T01:20:16.666216+00:00",
+     "duration": 0.003108,
+     "end_time": "2026-09-05T03:37:15.187116+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:16.663169+00:00",
+     "start_time": "2026-09-05T03:37:15.184008+00:00",
      "status": "completed"
     }
    },
@@ -1476,10 +2080,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9591182c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 20,
+   "id": "4f2ec61f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:15.193868Z",
+     "iopub.status.busy": "2026-09-05T03:37:15.193766Z",
+     "iopub.status.idle": "2026-09-05T03:37:15.850817Z",
+     "shell.execute_reply": "2026-09-05T03:37:15.850182Z"
+    },
+    "papermill": {
+     "duration": 0.66114,
+     "end_time": "2026-09-05T03:37:15.851311+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:15.190171+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ACWI: deleting the 2,233 sessions after 2,236 moved none of the 1,732 values before it.\n"
+     ]
+    }
+   ],
    "source": [
     "_check_symbol, _check_returns, _check_freeze = payloads[0]\n",
     "_boundaries = refit_boundaries(len(_check_returns), GARCH_BURNIN_SESSIONS, GARCH_REFIT_SESSIONS)\n",
@@ -1500,13 +2126,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2968eefb",
+   "id": "626d03f5",
    "metadata": {
     "papermill": {
-     "duration": 0.003015,
-     "end_time": "2026-09-05T01:20:17.305857+00:00",
+     "duration": 0.003033,
+     "end_time": "2026-09-05T03:37:15.857732+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:17.302842+00:00",
+     "start_time": "2026-09-05T03:37:15.854699+00:00",
      "status": "completed"
     }
    },
@@ -1529,10 +2155,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7a3e5e07",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 21,
+   "id": "601e804d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:15.864371Z",
+     "iopub.status.busy": "2026-09-05T03:37:15.864295Z",
+     "iopub.status.idle": "2026-09-05T03:37:15.985324Z",
+     "shell.execute_reply": "2026-09-05T03:37:15.984917Z"
+    },
+    "papermill": {
+     "duration": 0.125137,
+     "end_time": "2026-09-05T03:37:15.985908+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:15.860771+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLEAAAKlCAYAAAA0KH7jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAhT5JREFUeJzs3Xd4FGWjxuFn0gk1CaH3Kk0I0qsiCIigRMQGWBApSlNBBLEQBBQQUKQriGBFFLEgRSmfSJWuCEjvabS0Jdk5fyA5RBIgBPJOyO++Lq/D7s7M+8zO7p7N870za7lcCbYAAAAAAAAAB/MwHQAAAAAAAAC4GkosAAAAAAAAOB4lFgAAAAAAAByPEgsAAAAAAACOR4kFAAAAAAAAx6PEusGq1WutVu2fMB3jqpavWqNaTdqp+G0NNPvT+Rne3oFDR5SvWHUNf2fiDUhnVuVaLdSmQ9ebOsaW7X+pccuOKlqhnkaOnXzV5fMVq65ne7+S6mOJiYnKV6y6evYfetXtzP50vvIVq65Vq9enO/NF6zduVckqjbTgh6U3bYzr0bP/UAWVrJnm401bP6Iuz7541e206dBVIQ3vu5HRrtvho8dVumoTTZoxx3SUm2L4OxOVr1h1HTh05KrLmvpsbdX+CVWr1zrTxwUAAABwOS/TAdJr3rc/adL0T/T37r0qXqyw2t3bQi/16SYfH2/T0bKUfoPCdO5cjN56/SU1aVjHdJxsZ2jYu9q1Z59GvjFAdWuFmI6TLtWrVdLcGeNV4/bKpqOky6R3w5TDz9d0jHQpUqiA5n44XrdVKGM6CgAAAAAYl6VKrEkz5mjwG6PV+p471fWJh7Vtx98aPWGadvy1S3M/HG86Xpay/8BhtW97j7o8Gmo6Sra0/+BhVa1UQU937mg6Srr5+HirUf1apmOkW5VK5U1HSDcPDw81qJv27DIAAAAAyE6yzOmEp8+c1cgxk9Sofi19+uF4Pd7xfo16c6AG9uuuH37+Vb+t2SjpwqlAnbu9oNETpqlavdaqENJMX87/IXk7p06d0XMvvqbSVZsopOF9aZ5Kd/jocT3Vc4BKV22iSnc017sTP5Qk2bat6bM+V81GbVWiUkM9+nRf7T9wONVtpHaK3aWnhc39coHyFauuZct/0533Pqqyt9+p198apz937ta9Dz6tEpUbacCrI2XbtqQLp0s1a/OYZs75SrWb3q/SVZvovcmzUh07PCJSz/YZrNJVm6havdYa9e4UnT9/PjmDJH2zcHHyvy+6+77H1aB5h+TbR46eUL5i1TXj4y8UFX1Kr781TnXvaq8i5euq5QNPaPc/+1Md/+K+LV+1RpK0avV65StWPfn5TkpK0rsTP1TVuq1UrvqdGvT6O3K5LuTbumOnmrftpMLl6qrB3Q+mOH6piY2L07sTP1TDFg+pSPm6atjiIa3buCXFcz7mvenq2X+oylRrqnrN2mvbn38nP75l+1+6+77HVaJSQ3V7/hXFxSekOs7IsZNVrvqdWvjTMjW6p6NKVGqoQa+/k/z4tb42qtVrrYOHjmrj5u3Jp1K5XOc1cuxkVa3bSqWrNtGzfQYrPCIyzX1e8b+1qn93qEpVaayXX3s7zeUSExP15sgJKlf9TtVs1FZLl/+W4vG4uHi9GjZWFWverSq179GY96bL7XYnr/ve5Fmq2aitilWsr4c6P6fIqOjLjmVGxljx21o1uPtBFSlfV83aPKZfVqxOse7QsHeVr1j15Oei/WPdla9YdW3/c5ck6aUhI1SqSuPk7dm2rU8+/0Z172qvUlUap3h//Pd0tL/+3qOHOj+nEpUb6fb6rTX3ywXJjyW5kzT+g49UvcG9Kl/jrsteg0lJSapY82498lSf5PvWrN+kfMWqa/GyVZKkn5YsV4PmHVSiUkM9/GRvHT8RLun/3xvrN25Vg+Yd1KFTL9m2rTdHTlD5GnepTLWmeua5QTpxMiLVz5BvFv6s+neHqljF+mrb8Rlt3bEz+bGrff5ddLX3zEUXj/W33y/WvQ8+rVJVGqtHv1d14NARPfzE8ypRqaGe7DEg+b17tXwxsbHqO3CYSlZppEb3dNSmLTtSjHetn8+XSu35lKSdu/7R/Y88q2IV66tp60e0fuPWa9r3/QcP64FHu6v4bQ3+fc2fSn4sreMEAAAAIHNkmRLrr7/36Oy5GHVs30aWZSXf37H9vZKktRs2J9+38Kdl+mPLDvXt+aQsy9LAoaOUlJQk27bVrfcr+n7RL+rX6yk9eH8r9Rn4pjZv/TPFWHFx8Wr/aHctX7VWA/o9qyce76CypUtKkj6e+7UGvDpSTRvV0fChL2rb9p0KfbynYuPirnvf+r4cpk4PP6CypUtowuRZevDxnrq/TXNVua2cps/6PEW+P7bs0Jff/Khe3Topf1CA3hz1niIio1Jsz+12q3O3F7R42SoNGfCcOtzfSqPenay3x02VJM2ZMU6S1KDuHcn/vuiBtvfoz527dejIMUnSz8tWyLIstW19t5KSkrRh03Y9+XgHDezXXdt27NRLQ0Zc1z5PnDpbw0a9pzYt79IrL/bSp18u0LRZn0mSBgwZqeMnwjXqzYFq1KC24uLir7gtD8tDK/63Vg890FqvDeqjk+ER6t5nSHL5J0kjxkxSYEBe9e7eRTt37dWIMZMk6cJrqsvzOnEyQsNfe1GFCxXQ6TNn0xwrIjJaI8dOVtcuD6li+TKa8uFcbdn+l6Rrf21MeHuo8gcFqEK50pozY5yC8wdq1LuT9c74qXo4tI0Gv9RLPy9bqS7dX0ouZy516MgxPfxEb1mWh0a8MUDnzyemmXfyjLka98FHuq9VM73Qu6v27D2Q4vFXw8Zq6kef6onHHlSPZx7XyLGT9f2iXyRJoydM12tvjVOj+rUUNvQFVaxQRgH58t7QMXr0GSJZlkYNe1lVKlVQgsuVYt2Lp7qu/2PbhdffH9vk5+urNes3Sbrwvm9Q7w55eFz4KHO73fr0q+/Uo+tjCs4fmOr7Q7pQ8t730DP6a9c/enNwX91/bwuVLlk8+fGDh45q7cYt6t39CXl4eCR/hlzk6empdvc218r/rVX8v6XnoiUrlDdvbt3ZuJ7Wbdyix57up2JFCmnEGwN06NBR9RsUliLDY137qmP7ezXohR5avmqNxn3wkdq0vEsv9+8uW7Z8fXwuy/3LitV6qudAVShXRm+HDVJk1Cnd//CzOhn+/4VnWp9/l7qW98yl+g8arrat71bdWtX1+byFatLqYTWoe4caNaitb79frJ8WL7+mfG+8NV4ff/q1unbuqK5dHtKuS0rwa/18Tsulz+ep02f0wKPddeJkuMKGvqASxYrosa59FRsXd8V9T0pK0uNd+2vT1h16/ZW+qn3H7Tp85HjyGNd6nAAAAADcHFnmdMKjx05IkgoUCEpxf4EC+SVJR47+/x8aBYKD9OmH42VZlrb/+bdmzf1a4RFRiouL15Jf/6cBfZ/VE48/KNnSp18u0Pc//5Li+j5Lfv2fdv+zX5PHD9ejHdqmGG/azM9UsEB+vTvyVVmWJdf583ppyAgt/fU3tbu3+XXt27iRr6pFs0bKHxSgdRu36KW+z6prl44qVCBYv6/bpL9371VI9SrJy8+fM1k5cvgp+tQZDRv1nvbuP6T8QYHJj2/dvlNr1m9W/+ee1jNPPCzpwsydaTM/05ABz+m+Vs0kScWKFEz+90Xt27bU0LB3tXjZKnXt0lGLlqxUg7p3qOC/z/MP8z7U0WMntGX7XyperIjWb9yS5h++VzJt5mdq3KC2XnmxpyTptzUb9MOiX/T8s12UO1dOybJUvVqlC8fpKvz8fLXg82mKjIrWpi1/qlzZUvp97R+KjIpOfl7ub9Ncb732kqQLMzd279knSVryyyqdOBmhWVNG64H77pEkzfni2yuON3PyO6pYvoxy58ql9X9s1e49+1W9aqVrfm00a9pAOXLkUGBAXt3Xqpncbremz/pctUKqaejLvSVJhw4f03tTZmnrjr9Vo1qlFON//e1Pik9I0MQxb6hmjapqd29zzf4s9Rkrn3z+jSpVLKtxo4bKsizFxsZp4NBRkqT4+ATNmvu1Ooa2Ua9unSRJC39cpu8X/aK2re/W5Blz1LhBbb03+vUrPh/XO0a7e5srd+5c8vb2Uv06NVM9tbVenRB5eXlp/cYtKlGsiM7FxKpt67v1+7o/9EiHttrx1249+lC7FOtc7f0hSV/M/0GRUdH6Yd5HaljvjsvGTeszpFDB4ORlQtu11PRZn2vV6vVq0ayRFi1doXvvuUs+Pt6a8fEX8s/hp4lj35SPj7diY+P08mtvp5ix9PyzXdS311OSlDxLKF/ePHqs4/3q/vRjkqTTZ1MWqlNnfiYvLy9NHPumcufKqeCgQHV84nl9+c0Pev7ZLtec/VreM5d6deDz6tqlo+rWqq6fl63Sk489qL69ntKmLTv048+/6u89e6+ar9cznTT3ywW6p1ljvTbowgy2f/Yd1MSpsyVdOMX5Wj6f03Lp8zn7s/k6fiJck94dppo1quqOkGpq0vJhrd+4VU0b1U1z3/cfOKwdf+3SsCH9kz87f1y8PHk2Vq6cOVM9TgAAAAAyR5aZiVW8aBFJ0rHjJ1Pcf/F2iWJFku/z8vRMnq118Q+yBJdL+w9eOLVr9IRpKlWlsUpVbayjx08qIiLlTI2Lp4BVq1zxshz7Dx5W9aqVkrcf8u8fVwcOXv3XtdLi7X2hSwwKDLhw2+vC7cDAfJKU4g/fS5fP/+/yCQkpZ69c3M/ql5QfIdWr6MzZc4qKPnXFLMWKFFLdWjX089KVio2L04rf1ur+NhcKmDNnz+mxrv1UtW4rvf7WeMXExik2Lv6yWR5X43Kd15FjJ7Rq9foLx6FKY83/7meF/3scpkwYrtbNm+ieB7ro3gefvuyUo9S21/ulN1SxZnO9OOSt5ON55sy55GUuPqeSlD8oQAn/PqcHDx2VJJUpXeKa81/cVv6gf5//f2cPXe9rIyr6lM6ei/nP8fp33VRORzx4+NozHzx0VKVLlUgxe/GiI0ePKykpSZ999V3ycVi3cYsiIqMUGRWtM2fPqVqVy98DN2oMSfrqkw9UoWxp1WsWqkef7qu9+w6mWD93rpy6o0ZVrf9jq9Zt3KzSJYurZvUqWrNukzZt2SG3233Z9bmu9v6QLnmPp7F/aX2GXKpurRoqUqiAfl62UvsPHNbOXXuT3ysHDh5RTGycKoQ0U6kqjTVw6CjZtp3i/Xfp8a59x+369KMJWrxslarUaakRYyYpMfHyGXYHDh5WuTIlLhS9Sv11ci3Zr+U9c6mLr/mgf1/z3t4Xfkjjv59RV8oXERmt2Lj4NF+31/r5nJZLn8+L77nQx3uqVJXGatLyQiEVHhF1xX2/2nvrWo8TAAAAgJsjy8zEqnRbOeXLm0dffP29nnjsweTThz776jtJF06Nu5qSxYtKkp7u/JDat22ZfH/RwgVTLFei+IVCbPuff6tq5QopHitVopg2b/tTtm3Lsixt+vdUl5Ilil42ns+/f+hdPJXmzNnU/0C80UqVKCZJ2rz1z+TZRZu27FCe3LkUGJDvquu3b3uP3hz5nn5Z8btcrvNq2/puSdIH0z7RL8tXa8OKBSpTuoR69h+a/Pz/13/3/ey5mP9/zMdbRQoVUNEihZJnZEhSrpz+ki784T36rcF6+YUeeuTJPur87IvavnZRmnm/+vZHffL5N/r5249Vt1YNjRw7WW+Pm3LV/ZT+fybflm1/6fYqt0nSdc0sk9L32rhUYEA+5c6VM8VpU5u2/LtuyWKXZw7+N/P2v9S0Yd0r5i1QIEhbt/2VnOnSZYsWKSQPDw+1btFUPbo+nnx/UGA+BQbkU07/HMnXnrqS6x1DuvCenD5xpIYO6q37Huqq5196Qz9+/VGK7TdpWEcfzv5S5cqUVM3qVRRSvYqOHDuhFb+tVb68eVS1Usr36LW4WHpv/3PXdV843cPDQw+0vUc/LV6hShXLKU/uXLqrcf1/96uIdvy1S3NmjJOnp2fyOheLz9Tce8+dat2iqb74+nv16PeqShQvosYNaqdYpmSJYlr66286ey5GuXPlvOLr5Eoy8p65kivlCwzIKy8vr+TTb6WU77Vr/Xy+phz/bmvcqFdVrkyp5Psr31buivue/N7a9lfyLNX/vr9SO06dHn4g3RkBAAAApF+WKbFy5fTX0Jd768XBb+nRp/qoXZsW2rLtL02b+Zk63N9ate+4/arbKF2quJo1ra+vvvlR+fLmUamSxbR1+069/krfFMs1v6uRihUtrMFvjtHpM2dlWZaiT53Wy/176NmnHlW/QWF64ZXhCrm9isZ/8JHKlCqh5nc1lCQVKVRAhw4f0/6Dh1WsSCHlzZtbP/z8q4oXK6wffv41eZbIzVStSkXVrVVDs+Z+rWJFC+vI0eP6Y8sOvdSnW6qzZf7r/jYt9MobozXq3SmqV7uGChcqIOnCtcLiExK0+JdViomN0/c/LUteJ39QgLy8vLRpyw6di4lV+XKlJUnvT/1YBw8f1ay5X6cY45knH9GwUe/pi6+/V706Idq56x91uL+1Tp0+o0ee7K0WzRqrcKECOhcTI09Pj+Rtzfn8W839cFyKP0wvXjNr6a+/6Y/NOzRzzlfX/Fw1v7Oh/HP46b3Js+Th4aHVazcq+tTpa17/Uld7baTFw8ND3Z58ROM++Ehhb7+vQgWD9fFnX6t+nRDd/u9MocIFg7Vz916dDI9U29Z3a9S7kzX87Yk60vmEFl5yHP7r/ntb6P2pH2vo8HcvXHNt0szkx/z8fNXl0faa++UCFS9WRFUrV9CWrX+q73NPy8PDQ091fkgTp85W/0Fhqlurhlb9vl5vDX3pho1x4NARde31stq3a6ncuXLK5TqffKwv1aRhHY2eME2/rlqjHk8/rpDqVWRZlr765scU18NKjw4PtNboCdPUo98Qvfj8M4o+dVq5c+dS1y7p+7XI0LYtNWn6HM2cM0+tWjSVr++F6yM93aWjvvr2J7078UOFtm2pkxGRKlm8qLy8Un//T5v5mVatXq9WLZpq1+4Lp+ZdWn5d9OyTj+jnpSv13AuvqWXzJvpg2ifKlzePHnrg3nTlzsh75kqulM/Ly0ttWt6l7xf9ojHvTZe/fw598vm3yete7fP50s/Wi0V9Wtq2vlvDR0/UxKmz9eTjHeTt7aXoU2fU+JJr7KW277VCqqlIoQL6+NOvVaxIIe3eu19bt+9UsaKFJV37cQIAAABwc2SZ0wklqWuXjpo1ZbQiIqM18NWRWvnbWg1+qZemTBh+TetblqUPJ76t9m1bas4X32ro8Hd1+Ojxy06xy5XTX99+NkV31Kiqt0Z/oA+mfyI/X1/Ztq0nHn9Qbw97Wb+uWqMhw8aoSuUKmj93svxz5JAkPfZQO506fUYLf1omLy8vvTNskCxL+uyrher+9GOqVfPqZVtGeXp6as6Md9X8zoYa/s5EffXNjxrYr7sG9ut+TesXLlRADereoe1//q3727RIvr/nM4+rzh3V9dboD7Rx8/bka8ZIUk5/fz38YButXvuHdv69R9Wr3qZnn3pU+w8c1k+Ll2vW5HdSFGh9ejyhN17pq/+t2aCBr47U72v/0Jmz55Qndy49cN89+nL+D3rxlbfknyOHZrx/4fpKcXHx2rVnn5b8kvLX7x7p0FbN72yoSdM/0U9LlidfG+haFAgO0ifT35VlWRry5hj5eHsnX0w8va722riSQS/01Et9uunzeQv11ugPdM9djTV72tjkgqbzo6HavWe/Vq/dqCqVymvy+OE6GRGp198ap8oVy6li+TKpbvflF3ro0Yfa6ZPPv9GMj79MMRtKkka+MVA9u3bS9z8t06DX3tbO3XuTS7yhA3vrxd7PaMkv/9PLr7+tc+diFZ9w+S83Xu8YhQsW0F1N6mv6rM816LW3Va5MSb078tXLtl+75u3y8/XVgYNHVCukmvLkzqXbKpTRgYNHLjuV8FoVKVxQCz6fpqKFC2rwm6M198sFypHDL93buSOkmkoUL6Ltf/6dPOtRkurVDtGnH41X9KnTeuWN0fri6++vOBOzxV2NlJiUpMFvjtanX32nns90Sv7RikvdfWdDfTTpbf29e68GvjpSAfnyasEX05KvWXetMvKeuZKr5Rvz1iu65+7GmjBpphZ8v0TPPvVI8rpX+3y+9LP1agIC8uq7L6arZImiemf8VE2YNFMRkRdOJbzSvvv5+Wruh+NVpHBBDR3+ro4cPa7Qdv8/K+xajxMAAACAm8NyuRKu79wpIJPZtq0mrR5Wnx5P6iH+cAQAAAAAIFvJUjOxkL0923uwJCVfowsAAAAAAGQfzMRClrHgh6Vq1rR+8i+fAQAAAACA7IMSCwAAAAAAAI7H6YQAAAAAAABwPEosAAAAAAAAOB4lFgAAAAAAABzPy3QAAAAAAACQvYVHRpuOgOsUHBSQaWMxEwsAAAAAAACOR4kFAAAAAACMSdqzR/6dO8nav890FDgcJRYAAAAAAAAcjxILAAAAAAAAjkeJBQAAAAAAAMejxAIAAAAAAIDjWS5Xgm06BAAAAAAAyJ5sl0uRe/6RHRAo+fiYjoN0Cg4KyLSxvDJtJAAAAAAAgP+wfHxkFyxkOgayAE4nBAAAAAAAxriPH5fP5EmyTp40HQUOR4kFAAAAAACMsc+dk9fq1VJsjOkocDhKLAAAAAAAADgeJRYAAAAAAAAcjxILAAAAAAAAjkeJBQAAAAAAjLECA3W+fXvZ+fKZjgKHs1yuBNt0CAAAAAAAkH2FR0abjoDrFBwUkGljMRMLAAAAAAAYY8fGymPrViku1nQUOBwlFgAAAAAAMMZ99Kj8Rr8j68QJ01HgcJRYAAAAAAAAcDxKLAAAAAAAADgeJRYAAAAAAAAcjxILAAAAAAAYY3l7y12ggOTlbToKHM5yuRJs0yEAAAAAAED2FR4ZbToCrlNwUECmjcVMLAAAAAAAADgeJRYAAAAAADDGvW+fcvTqKevgQdNR4HDZ/nTCqKhI0xGQAfOWbDUdAQAAALhuA1/sZzoCYFzVHN76uXxBtdkboe3xiabjIJ0i9m/MtLGYiQUAAAAAAADHo8QCAAAAAACA41FiAQAAAAAAwPEosQAAAAAAgDF7ExLVfl+k9iYkmY4Ch/MyHQAAAAAAAGRfsW5bf8SdNx0DWQAzsQAAAAAAgDGFvT01tGBuFfKiosCV8QoBAAAAAADGBHl56JmgnMpPiYWr4BUCAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxKLEAAAAAAIAxUYluzY6KUVSi23QUOJyX6QAAAAAAACD7Ono+SUOPnzUdA1kAM7EAAAAAAIAxfpalqn5e8rNMJ4HTUWIBAAAAAABjyvl56Ycy+VXOl5PFcGWUWAAAAAAAAHA8SiwAAAAAAAA4HiUWAAAAAAAAHI8SCwAAAAAAGGPb0tkkt9y26SRwOq6aBgAAAAAAjNkRf15V/z5pOgayAGZiAQAAAAAAwPEosQAAAAAAgDHlfb20pEyQyvt4mo4Ch6PEAgAAAAAAxvh6WKrg5y1fD8t0FDgcJRYAAAAAAAAcjxILAAAAAAAAjkeJBQAAAAAAAMejxAIAAAAAAMYcTEhU14PROuhKMh0FDudlOgAAAAAAAMi+zrhtLT2XYDoGsgBmYgEAAAAAAGOCvTzUKyingj2pKHBllsuVYJsOAQAAAAAAsqekPXsU36ev4sLCZJcqbToO0ik4KCDTxqLmBAAAAAAAgONl+xIrpOF9OnTkWPLtz+ct1IBXR6a5/NwvF2jAkBFX3ObIsZM198sFkqSEBJc6PdNfCQkurVq9Xg8/8bwk6deVv2v8Bx9JklatXq+e/YdmdFfS7bGu/bRq9fo0H+/Zf6gWfL/kpucIKF5Dje7pmPzf9j93qXO3F9Tono4qVaWxqtVrrUb3dNS0mZ/pwKEjKli2dorlI6Oib3pGAAAAAABgVra/sHuLZo208rd1erzj/ZKkZctX6+EH77th2/f19dGcGeMuu/+uJvV1V5P6N2ycrMw/h5/+t/jLFPd9Mv1dSReKtFZ3N9H997WQJB04dERlShW/bHkAAAAAAHBry/YzsVrcdaHEkiS32601GzarUf1aSkxM1MCho1T/7lA1a/OYNm7adtm62/78W/c/8qwaNO+gBx7trnMxsfp6wU+a+tGnGjlmkjp3e0GSVLRCvcvWvTija+++g+rZ71X9tHi5Gt3TUV/O/0E9+r2avNzzL76uX1f+nnx71er16vb8K3q610BVq9dac79coDdHTlBIw/vU+6U3kpf75PNvVP/uUNW/O1Rzvvg2+f6pH32qmo3aqt3D3bRv/8Hk+xctXaF6zdqrVpN2+uLr76/puWvToauGvzNRd9/3uBrc/aA2b/tLknQyPFIPPt5TtZver6d6DpDLdV6rVq9X34HD9FjXfhoa9u41bR8AAAAAcOuzcuZUYu06kn9O01HgcNl+Jlaj+rX08mtvy7Ztbd76p6pUKi8/P1999MmXOnrshFYv/Vp/7tyjR5/uo40rv0uxboH8QZoyfrgKFyqgbs+/ou9+XKrHHmqnpctXq1H9Wsmzu66kTOkSeuWlXvrf7xs0eVyYEhMTNXrCNMXGxcnXx0cbNm3V+LdTnmq4ZsNmLVkwW4ePHFOr0Kf0/VczNLBfd1Wq1UKDXuipM2fPasx707Xq5wuzle5s/ahq17xdiYlJmjbzM/3yw1z5+fqqTYenJUmRUdEaNvI9LV04V95eXmod+qRC27W8pucvKDBAy76fq+8X/aLBb4zWj19/pMFvjNYzTz6sVs2b6p3xU7Xwp6UqEJxfX87/Qb/++Kluq1A2xTZi4+LV6J6OkqS6tapr7Igh1zQ2AAAAACDr8yhcWK4+fUzHQBaQ7UusHDn8VLZ0Ce3+Z7+WrVitlnc3liQtX7VWoe1ayrIsValUXrn8/bVn74EU6xYIDtKvK3/XmPema8v2v1SubMkM5/Hy8lLb1nfr56UrVbBAsOrXqSkvr5SHqXLFsipUMFhBgfnk6+OterVDJEkVy5dReESk1m3corubNlCe3LkkSXff2UArf1snt9ut+9u0UL68eSRJBQsGS5LW/7FVx06Eq1X7JyVJp8+cVWTUqWvKW692DUnSnY3rqdcLr0mSfl21Rn/t+kdvjZ4kl8ulJzt1UIHg/GpY747LCiwp9dMJr2Tv/kPJpdf9bZprQN9nr3ldAAAAAICz2OfPy4qKlJ0nr+SV7WsKXAGvDl24LtavK3/Xyt/WafL44ZIk27ZlWdYV1/tg+idav3Gr+vV6SqVLFdfZszE3JE+nhx/Qa2+NU+mSxdW+bdozory9vVPc9vLykm3baWZPTErS2XOXZ7RtW40b1NbsaWOvO7O3l5f8fH2Sby/6ZpZy5/r/qaCrVq+Xp+eNOXuVa2IBAAAAwK3DfeCAcvTtq7iwMNmlSpuOAwfL9tfEki5cF+uHn39VbGycihUpJOnCzKL53/0s27b1587dOnMuRmVLl5RlWXLbtiRp1W/r1DG0jW6vept2/LU7eXtFixTU0WMnLhvHsiy53fZl9xcrUkhHj52Q/e92y5Quobi4eK3dsFkN692R7v1p3KC2li7/TWfPxejsuRgtW75ajRvUVq2Qavp15e+Kj0/QqdNntHffhZlltUKqafXajfp7915J0uGjx//NK7lt9xXHOnDoiCTps6++U6P6tSRJTRrW1gfTPpEkhUdEKj4+Id37AAAAAAAAcClKLEmlSxXX0WMn1LRR3eT7nngsVIUK5FeD5g/quRdf18xJ78jHx1sht1fWryvXKCr6lJ7s1EHDRr2nDp17KW+e3Mnrtru3uWZ+8pUe6vxccjElSZUqltW+A4f01997Uoxf+47bder0GTW6p6P2HzwsSWrZvImqV71Nnp6e6d6fyreV14vPP6N77u+se+7vrH7PPaXbKpRVnTuqq03Lu9SwRQf16PeqihctIkkKzh+kiWPf1JM9XlKjezpq3MQPJUmN6tfW7M/mS5LeGv2BFvyw9LKx5n37k5q0elhfffuThg99UZI06s2XtXHTNtW/O1Rdnn1RJ8Ijrpj34jWxLv536YXsAQAAAAAAJMlyuRIunxoEoxITE9Xxiec1fOiLqnxbedNxJEkb/tiqX1b+roH9uiff16ZDVw0f+oJCqlcxmAwAAAAAkJUl7dmj+D6cTphVBQcFZNpYzMRymAOHjqjOne1Vu2Z1xxRYtm1rxuwv9VSnDqajAAAAAACAbIqZWLgm13KhewAAAAAA0st2uxVxMkLy9JQ8mGuT1WTmTCx+nRDXhAILAAAAAHAzWB4ekre36RjIAqg4AQAAAACAMe7DR+T71nBZx46ZjgKHo8QCAAAAAADG2PFx8ty5U0qINx0FDkeJBQAAAAAAAMejxAIAAAAAAIDjUWIBAAAAAADA8SixAAAAAACAMR7BwUro2lV2UH7TUeBwlsuVYJsOAQAAAAAAsq/wyGjTEXCdgoMCMm0sZmIBAAAAAABj7NOn5bn8V+nsWdNR4HCUWAAAAAAAwBh3eLh8P/xQVmSE6ShwOEosAAAAAAAAOF62vyZWVFSk6QjANVn2USd1G3803etN71eE9W7Qelkh462+XmZnNDFmVnheWO/GrZcVMrLejR0rI+vyGmO9mzlWRtbltcl6GV2nag5v/Vy+oNrsjdD2+MR054FZEfs3ZtpYzMQCsojc/p6sZ3i9rJDxVl8vszOaGDMrPC+sd+PWywoZWe/GjpWRdXmNsd7NHCsj6/LaZL2bORZwKUosAAAAAABgTGySrd9jXIpxZ+sTxXANvEwHAAAAAAAA2ddeV6IeORBlOgayAGZiAQAAAAAAYyxJPtaF/wtcCSUWAAAAAAAwpkoOb+2uVEhV/DhZDFdGiQUAAAAAAADHo8QCAAAAAACA41FiAQAAAAAAwPEosQAAAAAAAOB4XDUNAAAAAAAY83f8edXddVKRiW7TUeBwlFgAAAAAAMCY87Z0nAIL14DTCQEAAAAAgDElfDw1qVg+Fff2NB0FDkeJBQAAAAAAjMnj6aE2efyU19MyHQUOR4kFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxKLEAAAAAAIAxJ84n6e0TZ3XiPL9QiCvzMh0AAAAAAABkX+GJbk2KjDEdA1kAM7EAAAAAAIAxeTwsNc/lqzwe/DohrowSCwAAAAAAGFPC10sflghQCR9P01HgcJRYAAAAAAAAcDxKLAAAAAAAADgeJRYAAAAAAAAcjxILAAAAAAAYk+C2tSv+vBLctukocDgv0wEAAAAAAED2tTshUS32RpqOgSyAmVgAAAAAAABwPEosAAAAAABgTBU/b22vWECVfTlZDFdGiQUAAAAAAIyxLCm3p4c8LNNJ4HTZvuYMDAwyHQG4JpUrV9Opw9+ne72Dy19hvRu0XlbIeKuvl9kZTYyZFZ4X1rtx62WFjKx3Y8fKyLq8xljvZo6VkXV5bbJeRtdJ2rNH8X36at7cybJLlU53HmQflsuVwOX/AQAAAACAERdLrLiwMEqsLCg4KCDTxuJ0QkkBxWuo0T0dVbVuK9374NPaf+BwurfxbJ/BOn4i/Caky5hG93TUgUNH0ny8TYeu2rRlRyYmAgAAAAAASD9KLEn+Ofz0v8VfauvvP+qB+1po2NvvpXsb094boUIFg29COgAAAAAAbl0exYpdmIVVuIjpKHA4SqxLeHh4qHGD2skzsTb8sVWNW3ZUrSbtNP6DjyRJ+w8c1t33Pa7b7miugOI11LDFQ0pIcKlavdaKjIrWgUNHdP8jz6rvwGGq3uBejZv4oT6Y/onqNWuvDp16KSkpSZK0aOkK1WvWXrWatNMXX6c8L3julws0cOgoPfxkb1Wt20o/LVmu/oPCVLVuK40cO1mSZNu2xrw3XfXvDlXDFg9p8bJVyfe/OXKCajVpp4efeF5RUdHJ25392XzVufMB1b2rvX5d+ftNfz4BAAAAALgay8/vwmmEvr6mo8DhKLEu4Xa79eX8H1S9WiW5XOfVZ8Cb+mLW+1rzy3ytWr1ex46f1LsTP1To/a3014Ylan3PnRrxxkvy9fVJsZ1NW//Uc8921uJvZ2vY2++rcMFg/W/xVzp67ITWbdyiyKhoDRv5npYunKvflszT1I8+1fnz51NsY93GLZoxcZSGDemnHv1eVc9nOmnZwjkaP+kjJSUladny1frx51+14qcv9PWcSeo78E1FRkVr8S+rtHrtH/ptyTxNe3+kPDw9JUl/796rT79coN+WfKXFC2ZrxJhJmfa8AgAAAACQFvfJk/KeNUtWRITpKHC4bP/rhJIUGxevRvd01KEjR3Vfq2Z6e9gg7dm7XwcPH1XHJ3pLks7FxOjosRMqUCBIUVGnFB+foDNnzqa6vaKFC6hCuQsXoytUIL+aNqorLy8vValUQSfDo3T6zFkdOxGuVu2flCSdPnNWkVGnUpyOWDukmnLnyqnqVSupSKH/315gvrw6feaslv9vjdrd21w+Pt4qVDBYt1erpA2btmnlb+v0aIe28vX1ka+vj/LlzSNJWvG/tdp34LDuavO4JOnsuXM35bkEAAAAACA97DNn5L1sqRLvbCrlz286DhyMEkv/f02saTM/0+49+5Qrp79sWypXtpSW//hZimU9PDz0dK+X9cPPv+ieZk3UpEGdK27by9v7kn97SbYt27bVuEFtzZ429qrZvLy9/nPbW/a/27As67LlExOTdDYm5rL7bdvWQ+3v1fChL151TAAAAAAAAKfhdMJLPNWpg1auXq8df+1WuTIlFREZrVWr10uSDh89Lkn69vvFem1Qb6355RsNe7V/qkXS1dQKqabVazfq7917U2w7Pe5sVE8Lf1qm8+fP68TJCG3Z9pdqhVRTrZBqWrxslZKSknTk6AmdOHnhFxMbN6it+QsW6fiJcNm2nTymZV04jRIAAAAAAMDJmIl1CW9vbw19ubcGvf62vvtiumZOekcvvTpCiYlJKl2ymD6eOka3V71N/QcN15j3ZihPnlxqUKemhgx4Ll3jBOcP0sSxb+rJHi/J09NLdWtV19gRQ9K1jeZ3NdSmrTvUuGVHeXp6afzbQxUUGKAH7muhZStWq/7dD6palYoqUezCrztUvq28Br3YU207PiM/P1+1u7e5BvR9Vnc2rqeZc+bpjpBq6RofAAAAAAAgM1kuV4JtOkRWcv8jz2r6+yNVIDhIh44cU/1mofpzwxLlyZ3LdDQAAAAAALIcd0SEznz6mRJbt5YdGGQ6DtIpOCgg08ZiJlY6tW19tx57uq9i4+JlWZbeHfkqBRYAAAAAANfJI39+nX+8k+kYyAKYiQUAAAAAAIyx4+IUtWWb3MWLS35+puMgnTJzJhYXdgcAAAAAAMa4jxyR37A3ZR0/ZjoKHI4SCwAAAAAAAI5HiQUAAAAAAADHo8QCAAAAAACA41FiAQAAAAAAYyxPT9m5c0senqajwOH4dUIAAAAAAGBUeGS06Qi4Tvw6IQAAAAAAAHAJSiwAAAAAAGCM+8AB+b34gqzDh01HgcNRYgEAAAAAAGPs8+flcfKklHjedBQ4HCUWAAAAAAAAHI8SCwAAAAAAAI5HiQUAAAAAAADHs1yuBNt0CAAAAAAAkD3ZsbGKWrte7vLlpBz+puMgnYKDAjJtLK9MGwkAAAAAAOA/LH9/uW+/3XQMZAGcTggAAAAAAIxxR0XJe/7X0qlo01HgcJRYAAAAAADAGDsqSt7ffCPr1CnTUeBwlFgAAAAAAABwPEosAAAAAAAAOB4lFgAAAAAAAByPEgsAAAAAABhj5cqlxAYNJP+cpqPA4SyXK8E2HQIAAAAAAGRf4ZH8MmFWFRwUkGljMRMLAAAAAAAYY7tcsk4cl1wu01HgcJRYAAAAAADAGPfBg8rx0kuyjh4xHQUOR4kFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxKLEAAAAAAADgeJbLlWCbDgEAAAAAALKv8Mho0xFwnYKDAjJtLGZiAQAAAAAAwPEosQAAAAAAgDHuw4fl++Ybso4dNR0FDkeJBQAAAAAAjLHj4+W5Z4+UkGA6ChyOEgsAAAAAAACOR4kFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAGM8ChZUQo8esvMHm44Ch7NcrgTbdAgAAAAAAJB9hUdGm46A6xQcFJBpYzETCwAAAAAAGGOfPi2vJUukM2dMR4HDeZkOAAAAAAAArmzX/FDTEW6YCqHzU9x2h4fLZ/bHSipfTnaePIZSIStgJhYAAAAAAAAcjxILAAAAAAAAjkeJBQAAAAAAAMejxAIAAAAAAMZYOXIoqVo1yS+H6ShwOC7sDgAAAAAAjPEoWlQJA182HQNZADOxAAAAAACAMXZSkhQXK7ndpqPA4SixAAAAAACAMe59++T/7LOyDh4wHQUOR4kFAAAAAAAAx0vzmlgNWnVWudLFk2+/NqCHypUpkeqyYWOmqmHdEDVrXCfF/StWb9DK1Rs19KXuyfclJbk1ZuIsbd2xS+XKlNCrLz4rb28uzQUAAAAAAIC0pdke+fn6aPbkETd8wFW/b9Tps+c0d9oovT3hI/24ZJXuv/euGz4OAAAAAAAAbh3pmgIVGXVKI8bN0PGTESpUIL+GvNBNgQF5Uyyzd/9hhY2ZKtu2FRiQVwH58qR4/Ld1mxVS7TZJUo1qt+mXVWspsQAAAAAAAHBF6Sqxxk+Zozo1q+rh9q301YLFmjB1rt4c1CvFMsPHTlXXTqFqVC9En89fpN17U16YLTLqlEo0rSdJKlm8sCIiT6U61rzvlujrhUuSbz/YtoU6tGuRnrgAAAAAAMDhPEqVUuwHkyR/f9NR4HBplljxCS516TlYklStcnkN6P2UNmzeoX49OkmSmjetp5lzv02xTkxMrMIjT6lRvRBJUuFC+S8rsSxLcv/7s5lut1seHlaq43doR2kFAAAAAMCtzvLykvLkufqCyPbSdU0s27ZlWamXTpKU5LYVFxevpCS3PD1T/+HD/IEBOnTkuOrXrq5DR44rf2DAdUYHAAAAAABZnfvYMflM/EDnH+8ku2BB03HgYKk3TWmoVaOKlq5YI0latnKtaoVUliRZujCrKncufwUG5NXmbTslSTt37btsGw3rhmjT1guPb9q6Uw3q1shAfAAAAAAAkJXZMTHy2rRJios1HQUOl64Sq3/PzlqzYase7z5Iq9dtVt/uF04tDKleSQsXLZdlWXql/zMaPXGWuvV7Q7Fx8Zdto1G9EAUG5NHjzw5Sgsul1nc3vDF7AgAAAAAAgFuW5XIl2KZDAAAAAACAtO2aH2o6wg1TIXR+ittJe/Yovk9fxYWFyS5V2lAqXK/goMy7TFS6ZmIBAAAAAAAAJlBiAQAAAAAAYzyCguR67DHZAYGmo8Dh0vx1QgAAAAAAgJvNCghQYut7TcdAFsBMLAAAAAAAYIx99qw8166VYmJMR4HDUWIBAAAAAABj3CdOyHfi+7LCT5qOAoejxAIAAAAAAIDjcU0sAAAAAAAcrkLofNMRAOOYiQUAAAAAAADHo8QCAAAAAADGWD4+cpcsKXn7mI4Ch7NcrgTbdAgAAAAAAJB9hUdGm46A6xQcFJBpYzETCwAAAAAAAI5HiQUAAAAAAIxJ+ucf5XjqSVn795uOAoejxAIAAAAAAObYtqzERElc7QhXRokFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxLJcrgZNOAQAAAACAEXZCgiJ37pJdoIDk42M6DtIpOCgg08byyrSRAAAAAAAA/sPy9ZVdrJjpGMgCOJ0QAAAAAAAY4z5xUj4zpsuKiDAdBQ5HiQUAAAAAAIyxz56R14oV0rmzpqPA4SixAAAAAAAA4HiUWAAAAAAAAHA8SiwAAAAAAAA4HiUWAAAAAAAwxsqXT+fvayvlyWs6ChzOcrkSbNMhAAAAAABA9hUeGW06Aq5TcFBApo3FTCwAAAAAAGCMHRsrj7/+lOLiTEeBw1FiAQAAAAAAY9xHj8pvxAhZJ46bjgKHo8QCAAAAAACA41FiAQAAAAAAwPEosQAAAAAAAOB4lFgAAAAAAMAYy9NL7oAAydPLdBQ4nOVyJdimQwAAAAAAkFG75oeajnDTVAidbzrCTRUeGW06Aq5TcFBApo3FTCwAAAAAAAA4HiUWAAAAAAAwxr1vv/z69JZ16JDpKHA4SiwAAAAAAGCMnZQoj+hoKSnRdBQ4HCUWAAAAAAAAHI8SCwAAAAAAAI5HiQUAAAAAAADHo8QCAAAAAADGeBQpovjBg2UXLGQ6ChwuzRKrQavO6tJzcPJ/e/YeTHMjYWOm6pdV6y67f8XqDQobMzXFfYlJSRo+dpruatdVf+3am4HoAAAAAAAgq7P8/eWuVFnKkcN0FDicV1oP+Pn6aPbkETd8QA/L0r3NG2nXnv03fNsAAAAAACBrcUdEyPvLeUps0UJ2YKDpOHCwNEus1ERGndKIcTN0/GSEChXIryEvdFNgQN4Uy+zdf1hhY6bKtm0FBuRVQL48KR738PBQzeqVlSuXf8bTAwAAAACALM0+dUre3y9UYt06EiUWriBd18QaP2WO6tSsqrlTR6lerds1Yercy5YZPnaqunYK1awPhqtOzWo3LCgAAAAAAACyrzRnYsUnuNSl52BJUrXK5TWg91PasHmH+vXoJElq3rSeZs79NsU6MTGxCo88pUb1QiRJhQvl1+69B64r2LzvlujrhUuSbz/YtoU6tGtxXdsCAAAAAABA1paua2LZti3LstLcWJLbVlxcvJKS3PL0zNgPH3ZoR2kFAAAAAACAC9LVNNWqUUVLV6yRJC1buVa1QipLkixJbrdbuXP5KzAgrzZv2ylJ2rlr341NCwAAAAAAbilW7jxKbNpUypXbdBQ4XLpKrP49O2vNhq16vPsgrV63WX27Xzi1MKR6JS1ctFyWZemV/s9o9MRZ6tbvDcXGxV+2jVW/b1SXnoO1c9c+vT5qkj6Y8fmN2RMAAAAAAJDleBQsINcz3WTnz286ChzOcrkSbNMhAAAAAADIqF3zQ01HuGkqhM43HeGmsRMSFLlzl+wCBSQfH9NxkE7BQQGZNlbGLlwFAAAAAACQAe5Dh5TjlUGyjh4xHQUOR4kFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxKLEAAAAAAIA5liXby0uSZToJHM7LdAAAAAAAAJB9eZYtq7iZs0zHQBbATCwAAAAAAAA4nuVyJdimQwAAAAAAgOzJffCgYkaOUkLPXrKLFjUdB+kUHBSQaWMxEwsAAAAAABhju1zyOHBAOu8yHQUOR4kFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxKLEAAAAAAIAxHgULKuH53rKDC5iOAofj1wkBAAAAAIBR4ZHRpiPgOvHrhAAAAAAAIFuwo6Pl9dOP0unTpqPA4SixAAAAAACAMe7ISPl8+qms6CjTUeBwlFgAAAAAAABwPEosAAAAAAAAOB4lFgAAAAAAAByPEgsAAAAAABhj5cypxJAQKYe/6ShwOMvlSrBNhwAAAAAAANlXeGS06Qi4TsFBAZk2FjOxAAAAAACAMXZionTmjJSYaDoKHI4SCwAAAAAAGOPev1/+z/WSdfiQ6ShwOEosAAAAAAAAOB4lFgAAAAAAAByPEgsAAAAAAACOR4kFAAAAAAAAx7NcrgTbdAgAAAAAAJA92UlJijh2XPL1kzyYa5PVBAcFZNpYXpk2EgAAAAAAwH9Ynp5SDn/TMZAFUHECAAAAAABj3EeOyPedt2UdP246ChyOEgsAAAAAABhjx8XJc9s2KT7OdBQ4HKcTAgAAAEA2sWt+qOkIN1WF0PmmIwC4iZiJBQAAAAAAAMejxAIAAAAAAIDjUWIBAAAAAABjPIKD5eryhOzAINNR4HBcEwsAAAAAABhj5c2rxBYtTMdAFsBMLAAAAAAAYIx99qw8f/ufdO6c6ShwOEosAAAAAABgjPvECflOmSIrItx0FDgcJRYAAAAAAAAcL81rYjVo1VnlShdPvv3agB4qV6ZEqsuGjZmqhnVD1KxxnRT3r1i9QStXb9TQl7on37dn70G9O3m2oqLPqHqVCnq579Py8KBLAwAAAAAAQNrSLLH8fH00e/KIGz7gpm079cbLvRQUkE/P9n9Tv6/fooZ1Q274OAAAAAAAALh1pOvXCSOjTmnEuBk6fjJChQrk15AXuikwIG+KZfbuP6ywMVNl27YCA/IqIF+eFI8/dP89yf+uWqmswiOjMxAfAAAAAABkZZafn5LKlZN8fU1HgcOl6zy+8VPmqE7Nqpo7dZTq1bpdE6bOvWyZ4WOnqmunUM36YLjq1KyW5rbcbrc2bd2papXLpz81AAAAAAC4JXgUK6aE19+QXbiI6ShwuDRnYsUnuNSl52BJUrXK5TWg91PasHmH+vXoJElq3rSeZs79NsU6MTGxCo88pUb1LpweWLhQfu3eeyDV7X+3aLlKlyymsqWKp/r4vO+W6OuFS5JvP9i2hTq0a3HtewYAAAAAAIBbRrquiWXbtizLSnNjSW5bcXHxSkpyy9Mz7UleW3bs0oIff9XEdwanuUyHdpRWAAAAAADc6pL27JF/n76KCwuTXaq06ThwsHSdTlirRhUtXbFGkrRs5VrVCqksSbJ04fTA3Ln8FRiQV5u37ZQk7dy177JtHD1+UiPHzdDwIb2V0z9HBuMDAAAAAAAgO0jXhd379+yst96drgU//aqCwUEa8kI3SVJI9UpauGi5mjetp1f6P6O3J3yk3Ln8Vbli2cu2MeLdGYqJjdPg4RNku22VKlFUw1557sbsDQAAAAAAAG5JlsuVYJsOAQAAAAC4+XbNDzUd4aaqEDrfdARch6Q9exTP6YRZVnBQQKaNla7TCQEAAAAAAAAT0nU6IQAAAAAAwI3kUaKE4saMkR0QaDoKHI4SCwAAAAAAGGP5+MguWMh0DGQBnE4IAAAAAACMcR8/Lp/Jk2SdPGk6ChyOEgsAAAAAABhjnzsnr9WrpdgY01HgcJRYAAAAAAAAcDxKLAAAAAAAADgeF3YHAAAAgGyiQuh80xEA4LoxEwsAAAAAABhjBQbqfPv2svPlMx0FDme5XAm26RAAAAAAACD7Co+MNh0B1yk4KCDTxmImFgAAAAAAMMaOjZXH1q1SXKzpKHA4SiwAAAAAAGCM++hR+Y1+R9aJE6ajwOEosQAAAAAAAOB4lFgAAAAAAABwPEosAAAAAAAAOB4lFgAAAAAAMMby9pa7QAHJy9t0FDic5XIl2KZDAAAAAACA7Cs8Mtp0BFyn4KCATBuLmVgAAAAAAABwPEosAAAAAABgjHvfPuXo1VPWwYOmo8DhKLEAAAAAAIAxdlKSrLNnJXeS6ShwOEosAAAAAAAAOB4lFgAAAAAAAByPEgsAAAAAAACOZ7lcCbbpEAAAAAAAIHuy4+IUtWWb3MWLS35+puMgnYKDAjJtLK9MGwkAAAAAAOA/rBw55C5f3nQMZAGcTggAAAAAAIxxR0TIe+4cWVGRpqPA4SixAAAAAACAMfapU/JetEg6c8Z0FDgcJRYAAAAAAAAcjxILAAAAAAAAjkeJBQAAAAAAAMejxAIAAAAAAMZYefLo/N3NpVy5TUeBw1kuV4JtOgQAAAAAOMWu+aGmI9w0FULnm44ApCo8Mtp0BFyn4KCATBuLmVgAAAAAAMAYOz5e1v59UkKC6ShwOEosAAAAAABgjPvwYeUYOlTWsaOmo8DhKLEAAAAAAADgeJRYAAAAAAAAcDxKLAAAAAAAADgeJRYAAAAAADDHsmT7+UkWFQWuzMt0AAAAAAAAkH15li2ruOkzTMdAFpBmidWgVWeVK108+fZrA3qoXJkSqS4bNmaqGtYNUbPGdVLcv2L1Bq1cvVFDX+qefN/WHbs06cPPFRF1SqVKFNWwV56Tfw6/jO4HAAAAAAAAbmFpllh+vj6aPXnEDR/Q29tLo17vr7x5cmnI8Pf0y8q1uq9l0xs+DgAAAAAAcD73wYPyCxuuhN59ZBctajoOHCxdpxNGRp3SiHEzdPxkhAoVyK8hL3RTYEDeFMvs3X9YYWOmyrZtBQbkVUC+PCker1ShjGzb1tHj4Tp15qzKpzG7CwAAAAAA3Ppsl0seR45I512mo8Dh0nXVtPFT5qhOzaqaO3WU6tW6XROmzr1smeFjp6prp1DN+mC46tSslup25nz5vTo8+YLuqF5FFcuXvr7kAAAAAAAAyDbSLLHiE1zq0nOwuvQcrNHvz5Qkbdi8Q82b1pMkNW9aT+v/2J5inZiYWIVHnlKjeiGSpMKF8qe67c4Pt9Wir6Zo5+69+mHxylSXmffdEj3abWDyf/O+W5L+vQMAAAAAAMAtIV3XxLJtW5ZlpbmxJLetuLh4JSW55el55UleefPk0n0tm2rJr7+rzT1NLnu8Q7sW6tCuxdXyAwAAAAAAIBtI1+mEtWpU0dIVayRJy1auVa2QypIkS5Lb7VbuXP4KDMirzdt2SpJ27tp32TamzvpKp06fVWJSklat3qiSxYtkcBcAAAAAAEBW5VGokBL695cdXMB0FDhcui7s3r9nZ7317nQt+OlXFQwO0pAXukmSQqpX0sJFy9W8aT290v8ZvT3hI+XO5a/KFcteto3KFcvopdfGKPrUGZUvW1L9O9x7Y/YEAAAAAABkOVauXEqqeYfpGMgCLJcrwTYdAgAAAACcYtf8UNMRbpoKofNNRwAu446K0ukFC5XYpImUL5/pOEin4KCATBsrXacTAgAAAAAA3Eh2VJR8vvpS1qlo01HgcJRYAAAAAAAAcDxKLAAAAAAAADgeJRYAAAAAAAAcjxILAAAAAAAYY+XMqcTadST/nKajwOG8TAcAAAAAAADZl0fhwnL16WM6BrIAZmIBAAAAAABj7PPnZUVFSomJpqPA4SyXK8E2HQIAAAAAAGRPSXv2KL5PX8WFhckuVdp0HKRTcFBApo3FTCwAAAAAAAA4HiUWAAAAAAAAHI8SCwAAAAAAAI5HiQUAAAAAAADH48LuAAAAAADAGNvtVsTJCMnTU/Jgrk1Wk5kXdvfKtJEAAAAAAAD+w/LwkLy9TcdAFkDFCQAAAAAAjHEfPiLft4bLOnbMdBQ4HCUWAAAAAAAwxo6Pk+fOnVJCvOkocDhKLAAAAAAAADgeJRYAAAAAAAAcjxILAAAAAAAAjkeJBQAAAAAAjPEIDlZC166yg/KbjgKHs1yuBNt0CAAAAAAAkH2FR0abjoDrFBwUkGljMRMLAAAAAAAYY58+Lc/lv0pnz5qOAoejxAIAAAAAAMa4w8Pl++GHsiIjTEeBw1FiAQAAAAAAwPEosQAAAAAAAOB4lFgAAAAAAABwPEosAAAAAABgjOWXQ0m33Sb5+pmOAoezXK4E23QIAAAAAACQfYVHRpuOgOsUHBSQaWMxEwsAAAAAABhju93S+fOS2206ChyOEgsAAAAAABjj3rtX/k8/JevgAdNR4HCUWAAAAAAAAHA8L9MBAAAAAGQtu+aHmo5w01QInW86AgAgDczEAgAAAAAAgONRYgEAAAAAAMDxOJ0QAAAAAAAY41GypOImTJCdJ6/pKHA4SiwAAAAAAGCM5e0tOzDIdAxkAZxOCAAAAAAAjHEfOyaf996TdfKk6ShwOEosAAAAAABgjB0TI6/166TYGNNR4HCUWAAAAAAAAHA8SiwAAAAAAAA4XpolVoNWndWl5+Dk//bsPZjmRsLGTNUvq9Zddv+K1RsUNmZqqussXbFG9Vt2uo7IAAAAAAAAyG7S/HVCP18fzZ484qYMGp/g0mdf/6SAfHluyvYBAAAAAEDWYAUGyvVQR9n5AkxHgcOlWWKlJjLqlEaMm6HjJyNUqEB+DXmhmwID8qZYZu/+wwobM1W2bSswIG+qRdWn835Qq7sb6tOvf8xYegAAAAAAkKV5BAYqsV070zGQBaTrmljjp8xRnZpVNXfqKNWrdbsmTJ172TLDx05V106hmvXBcNWpWe2yx09GRGn1us1qf9/dVxxr3ndL9Gi3gcn/zftuSXqiAgAAAACALMA+d06ef2yUYvh1QlxZmjOx4hNc6tJzsCSpWuXyGtD7KW3YvEP9ely4jlXzpvU0c+63KdaJiYlVeOQpNaoXIkkqXCi/du89kGKZyR99oZ5PPSwvT88rBuvQroU6tGuR7h0CAAAAAABZh/v4cfmOG6e4sDDZOUubjgMHS9c1sWzblmVZaW4syW0rLi5eSUlueXpePskrNi5em7ft1KEjxyVdOD2x54thmjx26PXmBwAAAAAAQDaQrmti1apRRUtXrFHHB1pq2cq1qhVSWZJkSXK73cqdy1+BAXm1edtO3VGjsnbu2pdiff8cfvrmkwnJt9t36UeBBQAAAAAAgKtKV4nVv2dnvfXudC346VcVDA7SkBe6SZJCqlfSwkXL1bxpPb3S/xm9PeEj5c7lr8oVy96U0AAAAAAAAMheLJcrwTYdAgAAAEDWsWt+qOkIN02F0PmmIwDZjvvgQcWEDVdC7z6yixY1HQfpFBwUkGljpWsmFgAAAAAAwI3kUaKE4ke9bToGsoDLr74OAAAAAAAAOAwlFgAAAAAAMCbpn3+Uo9szsg4cMB0FDkeJBQAAAAAAzLFtWfHxku02nQQOR4kFAAAAAAAAx6PEAgAAAAAAgOPx64QAAAAA0qVC6HzTEQAA2ZDlciXYpkMAAAAAAIDsyY6PV+SOP2UXLiL5+pqOg3QKDgrItLGYiQUAAAAAAIyx/PxklyptOgayAK6JBQAAAAAAjHGfPCnvWbNkRUSYjgKHo8QCAAAAAADG2GfOyHvZUuncWdNR4HCUWAAAAAAAAHA8SiwAAAAAAAA4HiUWAAAAAAAAHI8SCwAAAAAAGGPly6fzrVpJefKYjgKHs1yuBNt0CAAAAAAAkH2FR0abjoDrFBwUkGljMRMLAAAAAAAYY8fFyWP3bik+3nQUOBwlFgAAAAAAMMZ95Ij8hr0p6/gx01HgcJRYAAAAAAAAcDxKLAAAAAAAADgeJRYAAAAAAAAcjxILAAAAAAAYY3l6ys6dW/LwNB0FDme5XAm26RAAAAAAACD7Co+MNh0B1yk4KCDTxmImFgAAAAAAAByPEgsAAAAAABjjPnBAfi++IOvwYdNR4HCUWAAAAAAAwBj7/Hl5nDwpJZ43HQUOR4kFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxLJcrwTYdAgAAAAAAZE92bKyi1q6Xu3w5KYe/6ThIp+CggEwbyyvTRgIAAACyiV3zQ01HuKkqhM43HQHALcTy95f79ttNx0AWwOmEAAAAAADAGHdUlLznfy2dijYdBQ5HiQUAAAAAAIyxo6Lk/c03sk6dMh0FDkeJBQAAAAAAAMejxAIAAAAAAIDjUWIBAAAAAADA8SixAAAAAACAMVauXEps0EDyz2k6ChzOy3QAAAAAAACQfXkUKiRXz16mYyALYCYWAAAAAAAwxna5ZJ04LrlcpqPA4dKcidWgVWeVK108+fZrA3qoXJkSqS4bNmaqGtYNUbPGdVLcv2L1Bq1cvVFDX+qefN8fW/7UwDfGqUihYEnSw6Gt1KZFkwztBAAAAAAAyJrcBw8qx0svKS4sTHap0qbjwMHSLLH8fH00e/KImzJo4/p36PWBPW7KtgEAAAAAAHDrSdc1sSKjTmnEuBk6fjJChQrk15AXuikwIG+KZfbuP6ywMVNl27YCA/IqIF+ey7aTL2+ujKUGAAAAAABAtpKuEmv8lDmqU7OqHm7fSl8tWKwJU+fqzUEpL742fOxUde0Uqkb1QvT5/EXavffAZdtZ98d2de4xWIUL5teAPk8pOCjgsmXmfbdEXy9cknz7wbYt1KFdi/TEBQAAAAAAwC0izRIrPsGlLj0HS5KqVS6vAb2f0obNO9SvRydJUvOm9TRz7rcp1omJiVV45Ck1qhciSSpcKP9lJVbl28ppcP9nVLZ0CU2c/pmmzPwyxTWzLurQjtIKAAAAAAAAF6Trmli2bcuyrDQ3luS2FRcXr6Qktzw9U//hQz9fH1W5rZwkqW3LJho9cdZ1xAYAAAAAALcCz3LlFPvJHNMxkAWk3jSloVaNKlq6Yo0kadnKtaoVUlmSZElyu93KnctfgQF5tXnbTknSzl37LtvGwp9XKCYmVklJbv1v7SZVLM8vDwAAAAAAAODK0nVNrP49O+utd6drwU+/qmBwkIa80E2SFFK9khYuWq7mTevplf7P6O0JHyl3Ln9Vrlj2sm3kzZ1L/YaMVvSp0ypdsqheffHyUwkBAAAAAED24D58WL7vjJbr2WdlFy5iOg4czHK5EmzTIQAAAIBbya75oaYj3FQVQuebjgDgFpK0Z4/i+/RVXFiY7FKcrZXVpPZjfTdLuk4nBAAAAAAAAEygxAIAAAAAAIDjUWIBAAAAAADA8SixAAAAAACAMR4FCyqhRw/Z+YNNR4HDpevXCQEAAAAAAG4kK3duJTVsZDoGsgBmYgEAAAAAAGPs06fltWSJdOaM6ShwOEosAAAAAABgjDs8XD6zP5YVFWk6ChyO0wkBAACAG6xC6HzTEQAAuOUwEwsAAAAAAACOR4kFAAAAAAAAx6PEAgAAAAAAxlg5ciipWjXJL4fpKHA4y+VKsE2HAAAAAAAA2Vd4ZLTpCLhOwUEBmTYWM7EAAAAAAIAxdlKSFBcrud2mo8DhKLEAAAAAAIAx7n375P/ss7IOHjAdBQ5HiQUAAAAAAADHo8QCAAAAAACA41FiAQAAAAAAwPEosQAAAAAAAOB4lsuVYJsOAQAAAAAAsic7MVERh45I/v6Sl5fpOEin4KCATBuLVwcAAAAAADDG8vKS8uQxHQNZAKcTAgAAAAAAY9zHjsnn3bGyTpwwHQUOR4kFAAAAAACMsWNi5LVpkxQXazoKHI4SCwAAAAAAAI5HiQUAAAAAAADHo8QCAAAAAACA41FiAQAAAAAAYzyCguR67DHZAYGmo8DhLJcrwTYdAgAAAAAAZF/hkdGmI+A6BQcFZNpYzMQCAAAAAADG2GfPynPtWikmxnQUOBwlFgAAAAAAMMZ94oR8J74vK/yk6ShwOEosAAAAAAAAOB4lFgAAAAAAABzPy3QAAAAAZE+75oeajnDTVAidbzoCAAC3HGZiAQAAAAAAYywfH7lLlpS8fUxHgcMxEwsAAAAAABjjUaKE4oe/ZToGsgBmYgEAAAAAAMDxKLEAAAAAAIAxSf/8oxxPPSlr/37TUeBwlFgAAAAAAMAc25aVmCjJNp0EDkeJBQAAAAAAAMejxAIAAAAAAIDjpfnrhA1adVa50sWTb782oIfKlSmR6rJhY6aqYd0QNWtcJ8X9K1Zv0MrVGzX0pe4p7v/mh2Wat2CJvLw91bvbY6pVo0pG9gEAAAAAAAC3uDRLLD9fH82ePOKGD7hn3yEtXLRcH773plznExWfkHDDxwAAAAAAAFmDR/Hiihs5SnaBAqajwOHSLLFSExl1SiPGzdDxkxEqVCC/hrzQTYEBeVMss3f/YYWNmSrbthUYkFcB+fKkeHzRsv/p/tbN5OfnKz8/X+XJnTPjewEAAAAAALIky9dXdrFipmMgC0jXNbHGT5mjOjWrau7UUapX63ZNmDr3smWGj52qrp1CNeuD4apTs9pljx89Hq7I6FPq/sIw9Rk0SifDI68/PQAAAAAAyNLcJ07KZ8Z0WRERpqPA4dIsseITXOrSc7C69Bys0e/PlCRt2LxDzZvWkyQ1b1pP6//YnmKdmJhYhUeeUqN6IZKkwoXyX7bd2Ng4RUWf0QfvDFadmlU1+4vvUx1/3ndL9Gi3gcn/zftuyfXtIQAAAAAAcCz77Bl5rVghnTtrOgocLl3XxLJtW5ZlpbmxJLetuLh4JSW55emZej+WPyhAVW4rKy8vL9UOqaKpH89LdbkO7VqoQ7sW17IPAAAAAAAAuMWl63TCWjWqaOmKNZKkZSvXqlZIZUmSJcntdit3Ln8FBuTV5m07JUk7d+27bBuN69fUr6vWybZtrftju8qU4rxXAAAAAAAAXFm6Sqz+PTtrzYaterz7IK1et1l9u3eSJIVUr6SFi5bLsiy90v8ZjZ44S936vaHYuPjLttG4Xk0VLVJAj3Z7WWs3blOnh+67MXsCAAAAAACAW5blciXYpkMAAAAg+9k1P9R0hJumQuh80xEAIMtwR0TozJfzlNiihezAQNNxkE7BQQGZNlaa18QCAAAAAAC42Tzy59f5hx82HQNZQLpOJwQAAAAAALiR7NhYefz1pxQXZzoKHI4SCwAAAAAAGOM+elR+I0bIOnHcdBQ4HCUWAAAAAAAAHI8SCwAAAAAAAI5HiQUAAAAAAADHo8QCAAAAAADGWJ5ecgcESJ5epqPA4SyXK8E2HQIAAAAAAGRf4ZHRpiPgOgUHBWTaWMzEAgAAAAAAgONRYgEAAAAAAGPc+/bLr09vWYcOmY4Ch6PEAgAAAAAAxthJifKIjpaSEk1HgcNRYgEAAAAAAMDxKLEAAAAAAADgeJRYAAAAAAAAcDzL5UqwTYcAAAAAAADZkx0bq6g/NsldqrSUI4fpOEin4KCATBvLK9NGAgAAAAAA+A/L31/uSpVNx0AWwOmEAAAAAADAGHdEhLy/+EJWVJTpKHA4SiwAAAAAAGCMfeqUvL9fKJ05bToKHI4SCwAAAAAAAI5HiQUAAAAAAADHo8QCAAAAAACA41FiAQAAAAAAY6zceZTYtKmUK7fpKHA4y+VKsE2HAAAAAAAA2Vd4ZLTpCLhOwUEBmTYWM7EAAAAAAIAxdkKCrMOHJZfLdBQ4HCUWAAAAAAAwxn3okHK8MkjW0SOmo8DhKLEAAAAAAADgeJRYAAAAAAAAcDxKLAAAAAAAADgeJRYAAAAAADDHsmR7eUmyTCeBw1kuV4JtOgQAAAAAAMi+wiOjTUfAdQoOCsi0sZiJBQAAAAAAAMfzMh0AAAAAqds1P9R0hJumQuh80xEAAA7hPnhQfiNHKaFnL9lFi5qOAwdjJhYAAAAAADDGdrnkceCAdN5lOgocjhILAAAAAAAAjkeJBQAAAAAAAMejxAIAAAAAAIDjUWIBAAAAAABjPAoWVMLzvWUHFzAdBQ7HrxMCAAAAAABjrNy5lVS3rukYyAKYiQUAAAAAAIyxo6Pl9dOP0unTpqPA4dKcidWgVWeVK108+fZrA3qoXJkSqS4bNmaqGtYNUbPGdVLcv2L1Bq1cvVFDX+qefN/o92dq25+7JUlx8Qny9fXRnCkjM7QTAAAAAAAga3JHRsrn00+VVKmS7Lx5TceBg6VZYvn5+mj25BE3fMABvZ9K/ve4yZ+oVkiVGz4GAAAAAAAAbi3puiZWZNQpjRg3Q8dPRqhQgfwa8kI3BQakbEn37j+ssDFTZdu2AgPyKiBfnlS3dejIcR06clz9e3a+/vQAAAAAAADIFtJ1TazxU+aoTs2qmjt1lOrVul0Tps69bJnhY6eqa6dQzfpguOrUrJbmtr77abnua9k0/YkBAAAAAACQ7aQ5Eys+waUuPQdLkqpVLq8BvZ/Shs071K9HJ0lS86b1NHPutynWiYmJVXjkKTWqFyJJKlwov3bvPZDq9lf+vlFPPf5AmsHmfbdEXy9cknz7wbYt1KFdi2vaKQAAAAAAkDVYOXMqMSREyuFvOgocLl3XxLJtW5ZlpbmxJLetuLh4JSW55emZ9iSvs+diZNu2/HP4pblMh3aUVgAAAAAA3Oo8CheW64UXTcdAFpCu0wlr1aiipSvWSJKWrVyrWiGVJUmWJLfbrdy5/BUYkFebt+2UJO3ctS/V7ZyMiFJgGtfKAgAAAAAA2YedmCidOSMlJpqOAodLV4nVv2dnrdmwVY93H6TV6zarb/cLpxaGVK+khYuWy7IsvdL/GY2eOEvd+r2h2Lj4VLcTExMnPz/fjKcHAAAAAABZmnv/fvk/10vW4UOmo8DhLJcrwTYdAgAAAJfbNT/UdISbpkLofNMRAAAOkbRnj+L79FVcWJjsUqVNx0E6BQcFZNpY6ZqJBQAAAAAAAJhAiQUAAAAAAADHo8QCAAAAAACA43mZDgAAAAAAALIvj9KlFTttmuTrZzoKHI4SCwAAAAAAGGN5eko5/E3HQBbA6YQAAAAAAMAY95Ej8n3nbVnHj5uOAoejxAIAAAAAAMbYcXHy3LZNio8zHQUOx+mEAAAADlUhdL7pCAAAAI7BTCwAAAAAAAA4HiUWAAAAAAAAHI8SCwAAAAAAGOMRHCxXlydkBwaZjgKHs1yuBNt0CAAAAAAAkH2FR0abjoDrFBwUkGljMRMLAAAAAAAYY589K8/f/iedO2c6ChyOEgsAAAAAABjjPnFCvlOmyIoINx0FDkeJBQAAAAAAAMejxAIAAAAAAIDjUWIBAAAAAADA8SixAAAAAACAMZafn5LKlZN8fU1HgcNZLleCbToEAAAAAADIvsIjo01HwHUKDgrItLGYiQUAAAAAAADHo8QCAAAAAADGJO3ZI//OnWTt32c6ChyOEgsAAAAAAACOR4kFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxLJcrwTYdAgAAAAAAZE+2y6XIPf/IDgiUfHxMx0E6BQcFZNpYXpk2EgAAAAAAwH9YPj6yCxYyHQNZAKcTAgAAAAAAY9zHj8tn8iRZJ0+ajgKHo8QCAAAAAADG2OfOyWv1aik2xnQUOBwlFgAAAAAAAByPEgsAAAAAAACOlyUu7G7btpKSkkzHAAAAAAAAN1hSUpISbSkxKUl2In/7ZzWJiYk3dfuenp6yLEuSZLlcCfZNHe0GSExMVOM2T5qOAQAAAAAAgEy06odZ8vK6MAcrS5RYN3MmVqcer2jOlJE3Zdu4uTh2WRfHLuvi2GVdHLusi2OXdXHssi6OXdbFscu6OHZZ2808fpfOxMoSpxNalpXcumWlbePm4thlXRy7rItjl3Vx7LIujl3WxbHLujh2WRfHLuvi2GVtmXX8uLA7AAAAAAAAHC/bl1gPtm1hOgKuE8cu6+LYZV0cu6yLY5d1ceyyLo5d1sWxy7o4dlkXxy5ry6zjlyWuiQUAAAAAAIDsLdvPxAIAAAAAAIDzUWIBAAAAAADA8W7JS/+fORujURM+1KHDx5U3Ty4Ne+U5eXh4aOiIiYqKPq3WLRqp00P3SZK+/fEXfbVgsXLl9FfYK8+pQHCQEhMTNW7yJ9q8/W/lzZNLbwzsqQLBQYb3KnvI6LGLiIzWkLfeV3hEtGpUq6hXX3xWHh50tZkhPcfus/k/6dOvftAjoa31+ENtJEmnTp9NdVncfBk9dkuW/64vvlmk02fO6fGH2uiBe5uZ3J1sJaPH7qLR78/UvoNHNGn0qyZ2I1vK6LHju4pZGT1+fF8x51qPXWrLBQbk5fuKQRk9dnxfMSejx+4ivq9kvoweu5vxfeWWvCbW6nWblSOHn0Kq3ab3p38qSTp/PlElihXWA/fepSeee1Ujh/ZVrpz+6tbvDc2dOkqr1vyh/63ZpDcH9dJXCxZr/6Gjeum5J3ToyHEVLhgsb+9bsu9znIweu0kffq6cOf3VueN9GjZ6iu5t3lh17qhmeK+yh2s9diWKFdbfu/fpywWLVaZkseQv9O9Omp3qsrj5MnLskpLcmvXZt+rcsa3i4uMV+kR/fTN7gvLkzml4r7KHjL7vJGnPvkMKGzNFOf1z8KUwE2X02PFdxayMHj++r5hzrcfu8NETly3Xu9tjfF8xKCPHrtfTj/B9xaCMvu8kvq+YktFjdzO+r9yS/5NPgzo1FFLtNklStcrlFR4RrdXrNqtGtdvk5eWlapXK6/f1W7R24zZVKFtKfn6+qlHtNv2+frMk6ael/9Mj7VvJsiyVKFaYL4WZKKPHzt8/hwLy5paHh4fKliouLy9Pg3uTvVzrsZOkiuVLq3DB/CnWT2tZ3HwZOXaenh7q2ilUPj7eypsnt4oULKBTp88Y2Y/sKKPvO9u29f60uXr68faZnj27y+ix47uKWRk9fnxfMedaj11qy0l8XzEpI8eO7ytmZfR9x/cVczJ67G7G95VbssS61MbNf+r2KhUUFX1axYoUlCSVKFZYEZGnFBl1SiWKFZIk5Q/MpyS3W/EJLh0/GaF1f2zTE88N0VvvTldiUpLJXci2rufYPdi2ueYtXKrps7/W7r0HdXvViiZ3Idu60rFLS3qWxc1zPcfuoojIaJ09F6OihQve5JRIzfUcu5W/b1TRwgVVoUzJTEqJ1FzPseO7inNcz/Hj+4ozXOuxu7icxPcVp7ieY3cR31fMup5jx/cVZ7ieY3czvq/c0iXWP/sPaf2mHWrbqqksy5LsC2dOum23LA9Lsi60uhfZbluWJcXGxStXzpya+X6YoqJPa+XqjaZ2Idu63mO34rcNatqglnL659DeA4cVERltaheyraseuzSkZ1ncHNd77KQL78f3pn2qpx57QJ6et/T/a3Gk6zl2Ltd5zf58obo/2SEzo+I/rvd9x3cVZ7je48f3FfOu9dhdupzE9xUnuN5jJ/F9xbTrOXZ8X3GG633f3YzvK7fsOzf61Bm9PmqShg/pLV8fHwUG5NXhoyckSYcOH1dwUICCgwJ08MhxSVJ4ZLS8vb3l6+OjoIC8qlG1ojw8PFSrRmUdPXbS5K5kOxk5dp/N/0lPPNJWj3W4V+1a3akfFq8yuSvZzrUcu7SkZ1nceBk5dpL06bwf5e3tpXat78yEtLjU9R67LTv+1pmz5/Ti0DF6edh4/b1nv8ZN/iQzo2d7GXnf8V3FvIwcP76vmHWtx+6/y0l8XzEtI8dO4vuKSdd77Pi+Yl5G3nc34/vKLVliuVznNThsgrp1eVDlSheXJDWsG6JN23YqMTFR2//ao/q1q6tOzWra/c8BxccnaNPWnWpQp4YkqVG9mvrlf+uUmJSkDZv/VJlSxQzuTfaS0WPncp3Xjp3/yO12a9+BIwb3JPu51mOXlvQsixsro8du1Zo/tPL3jRrY56kL/8sMMk1Gjl3tkKr6auZYzZjwpt5+rZ8qliul/j07Z2b8bC2j7zu+q5iV0ePH9xVzrvXYpbZcWssic2T02PF9xZyMHDu+r5iV0ffdzfi+ckv+OuGHc77R3K++V6kSRZSYeOGcy7HDByhs9FRFRp3SfS2b6NEH75UkLfx5hT6f/5Ny5/RX2JDeCg4K0Okz5zRs9BQdPHxMtUOqakDvJ/mgyyQZPXZbduzSO+99pPj4BJUtVVyvDeyhXDn9Te5StnGtxy48MlovvjpakdGn5WFZKlmiiCa+PVinz5zT0BETLzvOuPkycuzGvPmi7n24lwoEB8nHx1uybbVu3ojjl0ky+r676NjxcIWNncqv/WSiG/GZyXcVczJ6/Pi+Ys61HrvUlps27nUluM7zfcWQjB47vq+Yk9Fj5+fnK4nvKybciM/MG/195ZYssQAAAAAAAHBruSVPJwQAAAAAAMCthRILAAAAAAAAjkeJBQAAAAAAAMejxAIAAAAAAIDjUWIBAAAAAADA8SixAAAAAAAA4HiUWAAAAAAAAHA8L9MBAAAAspv2XfrJx9tLXl5eyuHnq8c7tNGdjWrLsqw015nxydcqXDBYbe5pkolJAQAAnIMSCwAAwICwwb1VoWxJHTx8TC+/OU6JSUlqcWd907EAAAAcixILAADAoBLFCqvPs49r4ozPVPP2SpowdY4OHz2hM2dj1PGBlur4QEt9tWCxvvx2sfxz+OmLbxbpo4lhOnXqjN55b6YOHjkuHx9vDez9lKpWKmd6dwAAAG4aSiwAAADDqtxWTgcPH1Oe3Ln0eIc2qli+tE6GR6rDUy+qdfNGeuj+e7Rz9z7VvL1S8umEw8dO0yOhrVWv1u3af/CIXhs1SbMnvWV4TwAAAG4eSiwAAADDbNsty7Lk4eEhPz9ffTjnG/2z/5AsWTpxMlK5c+VMsXxsXLw2bNqhqOjTmvTh55Kks+diTEQHAADINJRYAAAAhm37c49KFS+idX9s0wcffq7uT3RQh3Yt9OSuV+W27VTXsWXrg9FDLiu4AAAAblUepgMAAABkZ/sPHtV70+bqycce0O/rt6hWjSpqXP8ORZ86rbNn/392VaEC+XXsRLgkyT+Hn0Jur6Tps7+W2+1WUpJbx05EmNoFAACATGG5XAmp/897AAAAuCnad+knH28veXp4KkcOP3XueJ/ubFRbf+/epzEffKykJLeqVS6vbX/u1qB+XVWhbEnt3X9YL742RgF582hM2ItKSnJrzMRZ2n/wqHx9vNXmniZ6uH0r07sGAABw01BiAQAAAAAAwPE4nRAAAAAAAACOR4kFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxKLEAAAAAAADgeJRYAAAAAAAAcDxKLAAAAAAAADgeJRYAAAAAAAAcjxILAAAAAAAAjkeJBQAAAAAAAMejxAIAAAAAAIDjUWIBAAAAAADA8SixAAAAAAAA4HiUWAAAAAAAAHA8SiwAAAAAAAA4HiUWAAAAAAAAHI8SCwAAAAAAAI5HiQUAAAAAAADHo8QCAAAAAACA41FiAQAAAAAAwPEosQAAAAAAAOB4lFgAAAAAAABwPEosAAAAAAAAOB4lFgAAAAAAAByPEgsAAAAAAACOR4kFAAAAAAAAx6PEAgAAAAAAgONRYgEAAAAAAMDxKLEAAAAAAADgeJRYAAAAAAAAcDxKLAAAAAAAADgeJRYAAAAAAAAcjxILAAAAAAAAjkeJBQAAAAAAAMejxAIAAAAAAIDjUWIBAAAAAADA8SixAAAAAAAA4HiUWAAAAAAAAHA8SiwAAAAAAAA4HiUWAAAAAAAAHI8SCwAAAAAAAI5HiQUAAAAAAADH8zId4EY7c+aM3O6kG75dDw9P5cmT56rLNWjVWeVKF9e5mDgFBebTkBe6qVSJIjc0i8t1Xq+N+kDDBj0nHx/vG7rtjDp2PFwvvTZWc6eNyvSx//u8tO/ST9/MHp/8+H9vX83Lb4zTw+1bqmb1yjc+LG6YBx7trsNHjt3w7RYrWljffjb1qstdfM9f9NqAHipXpsRV14uIjNYHH36h1wf2kJTy9XnseLjCxk7VpNGvSpI++WKhKpYrpTp3VLuOPclcl+7Hj0tWSZLubdE4Q9sMGzNVbVo0vub34orVG7Ry9UYNfan7VZf9YfFKHTsRrmc6P5ihjP8VNmaqGtYNUbPGddJcJj3PVa8Bw9W722OqVKHMDc0JAAAAZCW3XInldifJ7XYbG9/P10ezJ4+Qbdua990SffLlwmv6Qyo9fHy8Neq1fjd0m7cCnpfs6fCRY9qz94Cx8S++59Mrf1BAcoF1NZ0fbpvu7TtBRsur7ITnCgAAALi6W67EcoqEBJcOHTmuYkUKSpJmfPK1cvj56fGH2qSYrfTD4pU6cPiY/vz7HzWsU0MxsXGybWnHzj3avfegBvd/Rg3rhly2/Wb3d9UvCz7UH1v+1HeLlsu2pS3b/1abe5qoW5fUZxSktaxt2/r4s++0ZPnv8vDwUM+nO6pBnRrJ64394GNVrVReLZs1kG3beuSZgfrwvTe1duM2fT7/J505G6MGdaqrb/dOl403d96PGhv2kqQLsw5mvh+mfHlz67tFy/XpvB9lWVL/Hp1TzDCJjYvXyHEztOufAypcML+GvfK8YmJiNWLcDBUtXEDrN23X/ffeJW9vby38abkKFgjSmGEvydPTI/l5eW3kBzp+IkJdeg7Ww6Gt9O0PvyoiMlpdeg7W8888qqqVy182Rp7cOfXVgsX68tufVbBAkKKjz2T0ZYBs6o8tf2rBT8vldru1fecePdMpVAcOH9MvK9eqZvVKGty/W4rPgW793kx+fT7T+UG9N22uoqJPq0vPwXrj5V6aO++H5Fk9j3cfpLYt79QPi1fK29tLE0a+rNy5cuqHxSs189NvFRl1Wr6+3mrb8k4998wjqWZb/Ovvij51RsWKFlTPpx/W+MlztH7TduXJnUvDBvVS4ULBKdZJ7T3p6WFp0LAJOn4yQkUKBWvka/3U95W3U7zPtv65K/lzr9eA4bqzYW19v3il/P189dwzj2rax/N08PAxvf1Gf91WvrQ2bv5TMz75WqfPnFPZ0sX15qBe+uKbRfp11Tpt2f636teurhefeyLVz4+9+w8rbMxU2batwIC8CsiXcubssRMRenfSxzpxMlLe3t4a9Xo/HT56QpM++kKStHbjNk0f/0by8lHRpzVs9BQdOxGh8mVK6PWBPRUXn6AxE2fqwOFjSkxMUtgrz6tMqWI6dfqsRo6focNHTyh/YD69/cYLkqQt23fq6++W6NDR43r79f4pZlFdesz/+1wdOXZSo8Z/qOjTZ1S6RFENe+W55PXi4xPU48UwvdL/GVUsVyqjL1UAAAAgS+GaWDdYfIJLXXoOVptHn9OqNX+oXas7r7rO9z+v0LBBz+nRB++VJO3cvVej33xRL/Tqos/nL7rq+lt27NLz3R7VR+8P05wvv1dSUtoz0VJbds2GrVr5+0bN+mC4xr01QCPHf6hTp88mr3Nnw9r6be0mSdK+A0dUrEgB5crpr7Kliun9twdr7tSRWv7bBh07Hn7VrJK0/+AR/bB4peZMGaHp49/Q9E++TvH4x58t0O1VKuiLD0frnrsa6Nsfl/37vOzTI6GtNW3c65oy8ysFBwZo9pQROhkRpe1/7U6xjYt/9M2ePEJtWjTRsEG9lD8oQLMnj1CdO6qlOsaefYf01YLF+uj9YRob9pL8/HyvaX+QvV18z3fpOVij35+ZfP/WP3epb/fHNXzw8xo5/kM1rBuiOVNHafn/NuhkeGSKbVz6+mzS4A4N7v+MbqtQWrMnj1CZUsVSLBsbF6+AfHk0e/JbCsiXR7+t3aTEpCSNnzJHU999TfNmjVXuXDlTLbAuWvTLb+rxVEf17vaYvv95hXx8vPX5jHfUq+vDmv3FwsuWT+39su6P7fLx8dZXM8dqcP9u8s/hd9n77PLnKkEffzBc/v45NPuL7zTurQHq0K6F5n+/VJJUqGB+vfPmC5o7bZRORkRp8/a/9eiD9+q2CqU1uP8zevG5J9L8/Bg+dqq6dgrVrA+Gq07Ny8fOmyeXend7TLMnj1DtkCr67qdfFVLtNrVv00zt2zRLUWBJ0vgpc/Rguxb6fMY7Kl2ymJb/tl45/XOoc8e2+viDt9Tx/pb6dN4PkqQJU+fo9soVNHfqKL3xci/5+fpIkhJc5/X+26+o4wMt9c0Py9I85v99rsJGT1H7++7WnCkj9UKvLrIsK0Wu+1o2pcACAABAtsRMrBvs4qlFLtd5rf1jm/q/OlqzJ711xXXubFhbgQF5k2/XvL2yvL29VKFsSUWdOi3pwvVQzp2LVf3a1dXz6YdTrF+mZDEFBwVIkvLmzaVzMTHKmyd3qmOltuz6TTt0V6Pa8vb2Uv6gAFUsV0o7du5JngFWvVpFvfP+R0pMStJvazepacPakqTChYK1dMUabdj0pxLiXToeHqlCwUFXfY7Wb9qhI8dO6Oner0mSYmLjUjy+7o/tSkhwaeGi5UpKcqvuv3/gFcgfmHx9saDAfKoVUkVenp4qV7qEoqJPX3Xcq42xaetfuqtRbeXOlVOSlD8wX7q2iewprdMJy5QspvxBAcqXN7d8vL1UvUoFSVKpEkUUdeqM8ubOdd1j1r2jmizLuvAZEX1Gnh4eyp0rp86ei5Ft66qnVIdUu02lSxaVJK3buE279x7Uhk3bZdtSiWKFtGT57/rk3zLrnTdfSPX90qZFE838bIGmfTxPj4S2vqbctUOqJufOnSunvLy8VLFcKW3ZsUuSVKhAfq1cvUG/b9iik+GROn4i4rJtpPb5ERMTq/DIU2pU78JnVuFC+bX7P6eY+ufw09lzMRo/ZY62bP9bZS+5jllq1m/arn0Hjmj6x/PkOp+oB+5tJk9PD3l5eWnSR19o25+75elx4X8HWrthm17u21WSUswAq1Ozmjw8PFShbClt3vb3NT1HMbFxOnLspO5qVPuy7f2ycp1Wr9+sgX2euqZtAQAAALcaSqybxMfHW43r1dSEKXN05myMJCkxKfULznt4pD4hzsvTU7Iv/PviBZ6vxtPTU7Z9bRmTl7XtFP9Lf2o5alS9TVt37NLvG7borSF9JEmvvvW+bitfWl07tVdsbJzsVP5wTkpjn++5q6H6PPtYqo/Ztq2wIc+rbKn//yPzv7O8vLw8U/z7Gnf5imN8Nv8nxcbFp3NLwJV5eXn957an7Gt9k16Fp6eH7H/fvw3q1NCw0VPldruTC5W0XPqZY9tS3+6dkgugi1rcWf+SZS5/v0jSR+8P06Kl/9OTz72qie+8Iktpf45c6rL377/Px4Spc5TkduuR9q2Vw883zefpv58fZ87GKC4uXklJbnl6pv55+uuqdZr33RJ16/KgqlUur9XrNl8155R3hyqnf47k29v/2qMxE2ep59MPq3G9mpo888KpiLZsXeEjVF7/HqdrYtuSZaX6mbzy9w26o3oVLVm+Ri2bNbi27QEAAAC3EE4nvIl27PxHtm0rdy5/BeTLo79375Pb7dbSFWtMR0uhds2qWv7beiUmJioy6pT+3r1PVW4rl2KZOxvV1tLla+Tl6ZU8M+CPrX/poftbKk/uXDp87MSFBS1LbvtCmRWQL6/2Hjis+PgE/bH1L0VFXZgtVbN6JS1d8bsiIqNl27ZOnEx5alXtkKr6fP4iud1uxcTGJZeA6VUgf2DyaVsB+fIoJiZWLtf5NMeoUrGs1v2xTQkul86ei9GhI8eva1wgvf77+iwQHKTwiOh0/UjFmg1bNH38G/+eTlf1mterHVJF875brPPnE3X+fGKqsxpTe7/sO3BEcXHxanNPE5UuWVS7/jlw2X6k18bNf+qB1nepaJEC2nfgaPL9BYODdDIiSlLqnx+5c/krMCCvNm/bKUnauWvf5dve8peaNLhD1atW1J59B5Pv/7/27jws6moN4Ph3BJRF2VcRxRAFlUVQ3NcWK291bTMXsFRANBMUQkERN7TU3DIFzTW3FvNmppmZe2ooJIgoLokLCEooMCyy3D9GR7jshTei9/MXzJw575nzO795nnmf95wxL9V3ae4u7dm2Yw8AGZn3yC8o4Nf4C7g6OdDV3YmryTfVbTs5OfCf734CVGdvVbWl+5HK5kpPTxdTY0OO/HwagFupaernJo0byQTvoazfupO8vPxqYwghhBBCCNHQSBKrjj06H2e47xSWrNrErKnjUSgU9O/tQfLNVIZ6B2NibEgNCxb+sJspaQTPXFxp9Vdp3To708PDFS+/UPxDPiR44mgMDcpuR+zs2oEDR07Su7ub+rHhrw/CJ2AmHy5bSwsr1QH25qbGaGpocupMPLYtm+PkaM+Q0UEcOxmDY9vWANjZ2jDG8zXGvx/ByPHT+G7/kTKx3h72Cvn5BQzzmcKE4HncfJQgq6WXX+iPT8Asvtr1A9raTejfy4NhPsEcPPpLhTGc2tvTp3tnPMeGMGvBKiwtTP9QXPHPUvpMLC+/EE6djqt1H/+7Pq2tzLG2MmeodzBxCUnVdwC0aG7BkNGBePmFEBy+mOOnYmv0OfDyi/2xsbZkxNgpePuHk5hUPgFU0f2SeT+LSdMW8taYIBo1UtCts0u591FbQwYPZPq8FYTOWY65mbH68YEDerJ89VbmLV5T4eeHQqFgasAYFny8Hm//8AorKp9/uie79x1m/PtzKV262a2zMzFnExk1IYzcvMevC/Dz5FziZYb7TCFk1lIyMu7Rp4c78eeT8PafqU7KA/j7eXL8VCzDfaewYPk6srKrT7xXNVdhQWPZ9Pm3eI4N4ZNPt6sTXfrN9DA2MuCZvt3Z/PA8LiGEEEIIIf5JFAUF+XWzr6WeuH//PsXF1SduaqtRIw309fWrb1iPhMxZRligrxxQLhq0fw/15cbNlDrvt4W1FTu3RtZ5v0/C9ZuprPh0G/PD/CkuLmbbjr3En08iYvpE+RwQQgghhBBCNBgNLoklVPYfOoEyN69Gv44ohPh7y83LI+KjNVy/mUpBwQMszE2YPH4kiUlX5XNACCGEEEII0WBIEquBKqnmsHYhRMMnnwNCCCGEEEKIhkTOxGqg5IurEEI+B4QQQgghhBANiSSxhBBCCCGEEEIIIUS9J0ksIYQQQgghhBBCCFHvSRJLCCGEEEIIIYQQQtR7ksQSQgghhBBCCCGEEPWe5l89gLq2+2As2cq8Ou+3qa42g/q5Vtvux8MnidrwBZqamtjZ2jB5vBcG+s3qfDyPnPk1gaDwj7C2NAdAU1OTJRHBvPv+XACuJt+kpbUVGhqNeP+9UVy7fovlq7dgbmoMgJWFGR+EBzyRsX33wxEAXny2N7v3HSbldjpjPF8DYM2mr7CyMGPQc30oKHhA2PwVzJoynsaNtf503DO/JrD7hyNMD/QFYFzQHCZ4D8Ox7VN/uu+aGBc0h+mTfbGyNKu27WAvf77euASAU6fjuHDpNzyHvMTshZH07NqJAb09Khz/pu27aNfGFg93p2pjlO7rSanra1gbN47O5IEyvc771dI1o0WvGdW26/G8J21a26j/DwsaS5unWlbYtrJrceh4NIePn1av2dpas+krdLS1Gf7GoErXxrYde8nOyVHfgxUpvXYvXUlm9w+Hmeg74g+NqSZqGyMrOwevcaHqe0YIIYQQQgjxz9LgkljZyjzuZeX+JbHzCwr4cNk6tkTNx8TYkBPRZ/8vX+hdOzqwaHZgmcc2rowAVEmSFQtCMTRQJdKuXb/FM327E/juyCc+rhef7V2jdo0bazE/zP/JDuZvwMPdqUZJKQDPIS894dHUzl95DR8o03mQfesviQ2g3aSx+n6rD+pqbbR5quUTTWD9v2IIIYQQQgghGo4Gl8T6KxU+KCQvPx9lbh4mQLfOzurndn1/iG1f7QFg6Gsv8K+BfUlJTSdi8Rqsrcz5JSaeV17sj5aWFrv2HMTC3ISFswLR0GjE0RMxfPLpNoqKi3hn2L95/uledTvuoiJmfrCS8xevYGRowNxpE9SVWkCF8WcvjMTWpjmHjkeTm5dPSMAYNmz9hnMXLhM6yZseHq7q6pD2DnZ8snY7ACdPx/Hmvwfy+c596Opoc/REDPPCJjLgldEc+M+nnPk1gW/2HqSkBH6Nv8Cg5/rg7fUaBQUPmPnhShIuXCY17S421paETvbBpUPbMu/l+s1UZi2IRJmbh5dfCB9/GArAT0d/YdGKDdzPymFpRDBWlmYk30hhzqIo7t3Poqu7MwF+nigUCgBSUtNZ9MlGDA2aUVhYSHjwONZu/pp9P/1MYy1NQif70NauFUsjN3Pk59Po6ekSFjSW7344QlxCEpOmL+D5p3sx8q2XK53jj1dvJfX2Hbz8Qhjy6vNQAucvXq1RgrF0Rc9w3ym8NLAfu/cdRktLk6XzgmnWVK9M+2MnY9i2Yw+Z97KYNM6Lbp2dy1TvpKSmExi2iM1R89m97zDXbqSQcOEyPT1cyVHmUlIC5xIvkXQlmZCAMfTs2qncmKq7hv8kdzMyiVi8htS0O1iamxI6yRtjI4Myba78doPZCyMpKSnB2MgAI0N99XOFhYW8/vZkPl+7kMaNtThz9jw7d/9IWNBYFq7YwMVLv5Gdk8uUiaNwc2lfpt/SayMmLpEFy9aho6ONjnYTXJ3aAaqK0W079nA/K4ceHi5M9B3BsqgtZdauk2MbNn/5HYtmB6LMzeODpWu5dDUZ/WZNCQkYg421JWs2fVXl2pgQPA+/UW/Svp0dE6fOp4NDG3xGvs6OXfvJylGWiVFZX9k5SmYviORGym3sbFs8nqOiIpZFbuZ0bAJNmjRm8viRdHCw4/W3JxG1ZAbGhga8OSoQzyEv8dLAvqxYsw17u5Y817/Hk7jkQgghhBBCiP8DOROrDunp6fLumKGMfm8Gy6K2kHkvC1B9WV2/ZSdRi8OIWhzGhm3f8FvyTQASk67y1qsvELV4BqvWfYGZsREbV0WQdieD+PNJZN7LYuW67axZNpNNK+fx+c59FBYWlokbG5+Il18IXn4h7Pr+UK3HfelKMleu3eCLdYuYG/oupsaG6ueqip9y+w6rl4Tj0qEdi1ZsJHzKOALGerL1YbLukU5ODgweNIDBgwawekk4z/brTu/ubnh7vca8sInlxvPruYu86z2Utctn8dnn31JUVMxPR09RWFjEjo1LeM93OM/07VYugQVgY22Jt9dr9O7uxsaVEeg3UyVzdHW0Wb0knC5uHdl74BgAER+tJvDdt9m2ZgG5efmcS7xcpq+ff4ll4IAehAeP4+TpOC5dvc6WqPnMn+FP1IYvuJ+Vze59h9m+diFLIt7HxtqC93yGYWpixEezg9QJrMrmeNbU8YCqam7Qs31qfd0eUebmYWSoz8aVczEy1OfYyZhybQyaNSXyozDmhE7gg6WfUlJSUmWf335/iFlTxjP0tRcBSEy6woKZk5k0zottO/ZWO6aKruE/yZJVn+Hh1pHNkfPp1tmZpZGby7WZsyiS0SNeZf2KOXi4la3A09TUxM3FkZi4RECVhOzbswuampoMfnEAa5fPJnD8SD797OtKx1BQ8IBZC1YRPmUca5aGY1dqy6OdbQuWfxDC5sh5HDwWTUpqeqVrF2D9lp0YGeqzOXI+w18fxOyFkernqlobbi6OnD2XpL7+CRdU91jc+SRcnRzKjbmivtZt2Yl1cws2R85nxJuPq8y+2XOQtDsZfBY5j5BJ3kyP+JjCwkLcXByJS0giI/Mexob6nD13URUz4SKuHdtVOl9CCCGEEEKI+k8qserYG688Rw8PV9Zt2YmnXwhLI4I5/WsCXd2d0dPTBVQVWtGxCfT0cMXc1Bjbls0BMDE2pHOnDmhqaNCmdUsyfr9HVraSO3czGTtpFgBZOUoy72VhamKkjlnRdsKq7D/0M2fPXQDAb9QQOjk50FRPlyWrNjHizZdo1OhxbjP+/KUK4wN07tQBhUJBuza2NGrUCF0dbdrZ25Kx9d6fmEF4qlULzB6+PwODpmTn5GBsZEB2jpL8ggdkZt5HQ0OjVn12dXdSjdWuFUlXkslR5nL+4lXmPPwynpdfQI8uLmVeY2NtRZdOHQFVBdn5C5d5e/w0AHR0tNFv1hQ3F0fmLFQlI4wNy1balGZr07zSOa4Lj95fW7tWZPx+v9zzHdvbo1AosH+qJfkFD7h3P7vK/vr17FKmcsjNuT1aWpqq/jNV13dc0Byys5V07+KC36ghZV5f0TV8kmfD/ZXy8gvw8gsBwKm9PUET3iE69hz+Y1Xb5J7p2411m3eWeU1OjpL0u5n06qaqWrKyNCXpyrUybfr36sKxkzF0dXfil5hzjB7xKgD6+s349LMdJFy4QmranUrHlXwzFVNjI9ratVLFsDAjOyfnYTwz9h86QXRMAvl5BaSm363yDLdfYs6pKwS7dXFm1oKV5ChV27YrWhuPuDk7sn3n97i5OPKUbQviz1+isLCQi5eu4WjfmvjzSf/Tvnxfp2MT1AlfKwtTddvomHie6dMNhUJBm9Y26Og0IflGKm7OjurEVf/eHnx/4DgPHhSSla3E3Myk0vcohBBCCCGEqP8kifUEWFuZM22yD8siN7P3wDHMTIx4uEutSpqaGmX+LgFKKMHdxZGI6eUrlv6ois7EWrVoOoeORzMucA4z3vejo2MbqGH8MuPW0ICqi3xqRUNDg5IScHK05/fM+/j4h9Pcypyp/mP+VH+UlKCrq82GT+aqtxCWa1s60VRSwrDXB/HGK8+VafPBjABOxyYQMnsZo0cMpl+vLhX2pa3dpNI5rksaGo2qrLJSKBRoaWrSpInqrLbCoqIK21WWZCt9fT9ZMK2GY3o45w1URWdilZSUVLquAIqKS8jNzaOoqBgNjYrn2sPdicgNX3Lj1m0szUzQ1dHmVmoak6cvxO+dIfzrub6MDZxdeYyiIpS5FZ8POG3uchzsWzN6xGCUylxKiquulFOtqao/xCq69x3bPsWlK8nEJVykQ7s25ChzOXUmHkODZlWeF1i6r6KiYpS55X+so7IhdXJy5OvdB1AoFA8TgbH8EhOPY9vWVY5fCCGEEEIIUf/JdsI6dPHyNXbs2k9xcTGFRUWk3/0dS3NT3FwcORF9lhxlLjnKXE5En8X9f86xqUwHBzti4y6otx/eTrtb5+NOSU3nTkYm/Xp2oau7M3GlqiPqKr65mQlpdzJK/W9c5v/qxMQl0snZgY0rI5gf5o+BftMqYhmTlp5RZTJHT0+X5pbmfLdf9QuKt9PuVtm+i1tHvtlzkJwcJcXFxaTdyeDe/SyuXb+Fu2t7nn+6JzFx5wGwMC3/3iqbY3NTY9LSy8+pAih+mFhQoKC4+M9lgW6lpgGqijJzM2N0tLUxMtTnQtJViouL2X/oxJ/qX5TV2bWDek5/PHySzp1U9/uj69qsqS7GRgbEPtwumHjxark+mjRujK1Nc7Z/vZe+vTqr2iX9RssWVvTp4U7yzRR1W4VCUW79tmxhSfqd37mZkkZxcTEXLj2Ocebsed54ZSD6zZpyI+W2+vGK1i5Al04d2X/oZwBORp+llU1z9HR1qp2Hxo21sDAz4UT0WTq2b0NHR3t27j5Q4VbCynRwsOPIz2cA1Zlxj8fUgR8PnaSkpITLv11HqczFxtoSC3MTcvPyuXz1Om3tbOngaFfrmEIIIYQQQoj6SZJYdcjG2oLfrt/Ca1wob40OQk9Xh5ef74udrQ0j33oZH/+Z+PjPxHPIS7RuZV2jPo0NDQiZ5E3onOV4+YWwcfs35dqUPhPLyy+E+1k5tRq3Mi+PmR+sZJh3MJevJjNwwOODj2sSvya6dXYm5mwioyaEkZuXR/9eHny9+0cmTVtQ7flMoNqetvfHYwz3mcKoCWHM/Wg1GZn32LFrP1/8Z1+Ztk6O9mRl5+DlF6pO3lQkLMiXXXsOMtx3CnM/Wq3eHlXZ+Af08eCdCWG8/e50Tp6OIy+vgOWrtzJi7FT2HTzOq/96BoBBA/sybe5yojZ8qX59ZXP88gv98QmYxVe7figTr5OLI7v2HgRUCYSd3x2odo6qcuPWbUZNmE7k+i8ICfAGVFutkm+mMtQ7GBNjw+oKbUQtBPh5ciL6LMN9p3D8VKz6F/geXVeFQsHUgDEs+Hg93v7hFVYaAfTr1YVv9hykV1c3ANxd2qNU5jFqwnTOnktCp0kTAJzat2XPj0fL3Es62toETxzFxKnzGR80lyZNGqufG/76IHwCZvLhsrW0sLJQP17R2gV4e9gr3M3IZLjvFD77/FumB/rWeC7cXBxJupyMhZkJzu3tOXYqRn3AfE2MGjGY07HnGDk+lOiYeBprqSq4Xn6xPybGhozwncrcRVHMDpmAlpaquNjB3pa8/AK0tDRxbt/2YUxJYgkhhBBCCPF3pygoyG9QG312H4wlW1nxF8I/o6muNoP6udZ5v6JmojZ8Sds2rejXswt5+QWMC5zNqOGv4mBvy+qNXzE14I9tLxR/fzeOzuSBMr3O+9XSNaNFrxl13q8QQgghhBBCiD+mwSWxRMMUG5dI5PovyFHmUvCgkL493PEZ+QaLV25iyOCB2Fhb/tVDFEIIIYQQQgghxBMkSSzxt1bdAdpCCCGEEEIIIYRoGORMLPG3JgksIYQQQgghhBDin0GSWEIIIYQQQgghhBCi3pMklhBCCCGEEEIIIYSo9ySJJYQQQgghhBBCCCHqPUliCSGEEEIIIYQQQoh6T5JYQgghhBBCCCGEEKLekySWEEIIIYQQQgghhKj3JIklhBBCCCGEEEIIIeq9/wIBPplSxzB//AAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x676 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "A date axis from 2006 to 2026. Two bars at the top are the two fitted models: each begins with a pale burn-in segment carrying no values, then a long dark segment. The regime row is crossed by regularly spaced amber ticks marking the sessions it was re-estimated through, and none of them falls right of the holdout. Below, eight short amber bars step back one year at a time, marking the fold validation windows a later notebook selects rows by. A dashed line and a shaded column mark the holdout."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig_folds, ax = plt.subplots(figsize=(12, 0.42 * len(cv_splits) + 3.4))\n",
     "\n",
@@ -1634,13 +2289,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b03d8f2e",
+   "id": "abf179bb",
    "metadata": {
     "papermill": {
-     "duration": 0.003112,
-     "end_time": "2026-09-05T01:20:17.439464+00:00",
+     "duration": 0.00315,
+     "end_time": "2026-09-05T03:37:15.992545+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:17.436352+00:00",
+     "start_time": "2026-09-05T03:37:15.989395+00:00",
      "status": "completed"
     }
    },
@@ -1660,10 +2315,96 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "49cf4ab1",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 22,
+   "id": "a74d84af",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:15.999425Z",
+     "iopub.status.busy": "2026-09-05T03:37:15.999334Z",
+     "iopub.status.idle": "2026-09-05T03:37:16.017886Z",
+     "shell.execute_reply": "2026-09-05T03:37:16.017536Z"
+    },
+    "papermill": {
+     "duration": 0.022497,
+     "end_time": "2026-09-05T03:37:16.018220+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:15.995723+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (10, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>fit_end_session</th><th>sessions_fitted_on</th><th>mean_ret_stress</th><th>mean_vol_stress</th><th>mean_vol_calm</th><th>persist_stress</th><th>persist_calm</th></tr><tr><td>date</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>2021-08-09</td><td>3906</td><td>-0.037951</td><td>27.916864</td><td>10.629064</td><td>0.982368</td><td>0.992006</td></tr><tr><td>2021-11-05</td><td>3969</td><td>-0.037743</td><td>27.88776</td><td>10.628277</td><td>0.982307</td><td>0.992131</td></tr><tr><td>2022-02-07</td><td>4032</td><td>-0.03325</td><td>27.95267</td><td>10.717173</td><td>0.98223</td><td>0.991975</td></tr><tr><td>2022-05-09</td><td>4095</td><td>-0.038251</td><td>27.511328</td><td>10.665799</td><td>0.982771</td><td>0.991621</td></tr><tr><td>2022-08-09</td><td>4158</td><td>-0.032168</td><td>27.365755</td><td>10.618732</td><td>0.983161</td><td>0.991246</td></tr><tr><td>2022-11-07</td><td>4221</td><td>-0.034311</td><td>26.874655</td><td>10.510148</td><td>0.983156</td><td>0.990399</td></tr><tr><td>2023-02-08</td><td>4284</td><td>-0.026011</td><td>26.208298</td><td>10.354024</td><td>0.983879</td><td>0.989745</td></tr><tr><td>2023-05-10</td><td>4347</td><td>-0.031689</td><td>27.245674</td><td>10.811362</td><td>0.984168</td><td>0.991906</td></tr><tr><td>2023-08-10</td><td>4410</td><td>-0.029403</td><td>27.100984</td><td>10.767209</td><td>0.983868</td><td>0.991748</td></tr><tr><td>2023-11-08</td><td>4473</td><td>-0.029395</td><td>27.133921</td><td>10.80663</td><td>0.983986</td><td>0.992019</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (10, 7)\n",
+       "┌──────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┐\n",
+       "│ fit_end_sess ┆ sessions_fi ┆ mean_ret_st ┆ mean_vol_st ┆ mean_vol_ca ┆ persist_str ┆ persist_cal │\n",
+       "│ ion          ┆ tted_on     ┆ ress        ┆ ress        ┆ lm          ┆ ess         ┆ m           │\n",
+       "│ ---          ┆ ---         ┆ ---         ┆ ---         ┆ ---         ┆ ---         ┆ ---         │\n",
+       "│ date         ┆ i64         ┆ f64         ┆ f64         ┆ f64         ┆ f64         ┆ f64         │\n",
+       "╞══════════════╪═════════════╪═════════════╪═════════════╪═════════════╪═════════════╪═════════════╡\n",
+       "│ 2021-08-09   ┆ 3906        ┆ -0.037951   ┆ 27.916864   ┆ 10.629064   ┆ 0.982368    ┆ 0.992006    │\n",
+       "│ 2021-11-05   ┆ 3969        ┆ -0.037743   ┆ 27.88776    ┆ 10.628277   ┆ 0.982307    ┆ 0.992131    │\n",
+       "│ 2022-02-07   ┆ 4032        ┆ -0.03325    ┆ 27.95267    ┆ 10.717173   ┆ 0.98223     ┆ 0.991975    │\n",
+       "│ 2022-05-09   ┆ 4095        ┆ -0.038251   ┆ 27.511328   ┆ 10.665799   ┆ 0.982771    ┆ 0.991621    │\n",
+       "│ 2022-08-09   ┆ 4158        ┆ -0.032168   ┆ 27.365755   ┆ 10.618732   ┆ 0.983161    ┆ 0.991246    │\n",
+       "│ 2022-11-07   ┆ 4221        ┆ -0.034311   ┆ 26.874655   ┆ 10.510148   ┆ 0.983156    ┆ 0.990399    │\n",
+       "│ 2023-02-08   ┆ 4284        ┆ -0.026011   ┆ 26.208298   ┆ 10.354024   ┆ 0.983879    ┆ 0.989745    │\n",
+       "│ 2023-05-10   ┆ 4347        ┆ -0.031689   ┆ 27.245674   ┆ 10.811362   ┆ 0.984168    ┆ 0.991906    │\n",
+       "│ 2023-08-10   ┆ 4410        ┆ -0.029403   ┆ 27.100984   ┆ 10.767209   ┆ 0.983868    ┆ 0.991748    │\n",
+       "│ 2023-11-08   ┆ 4473        ┆ -0.029395   ┆ 27.133921   ┆ 10.80663    ┆ 0.983986    ┆ 0.992019    │\n",
+       "└──────────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (10, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>fit_end_session</th><th>alpha_median</th><th>beta_median</th><th>persistence_median</th><th>n_fits</th></tr><tr><td>date</td><td>f64</td><td>f64</td><td>f64</td><td>u32</td></tr></thead><tbody><tr><td>2023-12-12</td><td>0.080894</td><td>0.906042</td><td>0.989697</td><td>4</td></tr><tr><td>2023-12-13</td><td>0.076737</td><td>0.908423</td><td>0.986524</td><td>3</td></tr><tr><td>2023-12-14</td><td>0.145866</td><td>0.854134</td><td>1.0</td><td>3</td></tr><tr><td>2023-12-15</td><td>0.100409</td><td>0.887444</td><td>0.987853</td><td>1</td></tr><tr><td>2023-12-19</td><td>0.073588</td><td>0.917811</td><td>0.991399</td><td>1</td></tr><tr><td>2023-12-20</td><td>0.160971</td><td>0.810568</td><td>0.974926</td><td>4</td></tr><tr><td>2023-12-21</td><td>0.07252</td><td>0.922096</td><td>0.994616</td><td>1</td></tr><tr><td>2023-12-27</td><td>0.227604</td><td>0.772396</td><td>1.0</td><td>1</td></tr><tr><td>2023-12-28</td><td>0.161215</td><td>0.803806</td><td>0.973878</td><td>3</td></tr><tr><td>2023-12-29</td><td>0.088289</td><td>0.903596</td><td>0.992611</td><td>3</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (10, 5)\n",
+       "┌─────────────────┬──────────────┬─────────────┬────────────────────┬────────┐\n",
+       "│ fit_end_session ┆ alpha_median ┆ beta_median ┆ persistence_median ┆ n_fits │\n",
+       "│ ---             ┆ ---          ┆ ---         ┆ ---                ┆ ---    │\n",
+       "│ date            ┆ f64          ┆ f64         ┆ f64                ┆ u32    │\n",
+       "╞═════════════════╪══════════════╪═════════════╪════════════════════╪════════╡\n",
+       "│ 2023-12-12      ┆ 0.080894     ┆ 0.906042    ┆ 0.989697           ┆ 4      │\n",
+       "│ 2023-12-13      ┆ 0.076737     ┆ 0.908423    ┆ 0.986524           ┆ 3      │\n",
+       "│ 2023-12-14      ┆ 0.145866     ┆ 0.854134    ┆ 1.0                ┆ 3      │\n",
+       "│ 2023-12-15      ┆ 0.100409     ┆ 0.887444    ┆ 0.987853           ┆ 1      │\n",
+       "│ 2023-12-19      ┆ 0.073588     ┆ 0.917811    ┆ 0.991399           ┆ 1      │\n",
+       "│ 2023-12-20      ┆ 0.160971     ┆ 0.810568    ┆ 0.974926           ┆ 4      │\n",
+       "│ 2023-12-21      ┆ 0.07252      ┆ 0.922096    ┆ 0.994616           ┆ 1      │\n",
+       "│ 2023-12-27      ┆ 0.227604     ┆ 0.772396    ┆ 1.0                ┆ 1      │\n",
+       "│ 2023-12-28      ┆ 0.161215     ┆ 0.803806    ┆ 0.973878           ┆ 3      │\n",
+       "│ 2023-12-29      ┆ 0.088289     ┆ 0.903596    ┆ 0.992611           ┆ 3      │\n",
+       "└─────────────────┴──────────────┴─────────────┴────────────────────┴────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(\n",
     "    hmm_fit_df.select(\n",
@@ -1701,10 +2442,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "77ec857f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 23,
+   "id": "b40dce31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:16.025534Z",
+     "iopub.status.busy": "2026-09-05T03:37:16.025449Z",
+     "iopub.status.idle": "2026-09-05T03:37:16.183479Z",
+     "shell.execute_reply": "2026-09-05T03:37:16.183039Z"
+    },
+    "papermill": {
+     "duration": 0.162075,
+     "end_time": "2026-09-05T03:37:16.183768+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:16.021693+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLEAAAGRCAYAAACaKyHFAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA7k5JREFUeJzs3Xd4U9UbwPHvzW7SPWkpe++9EZQlyBBEBREnKuLGheD6uQcobsGFKKiogANEcYGDIXvvXejeM/v3R9o0oemClhZ4P8/TJzc3d5xz70168+ac9ygWi9mJEEIIIYQQQgghhBC1mKqmCyCEEEIIIYQQQgghRHkkiCWEEEIIIYQQQgghaj0JYgkhhBBCCCGEEEKIWk+CWEIIIYQQQgghhBCi1qt1QayFX39PcGwHFi1eVtNFKaGgwEynPiMYdtXNNV0UUYWGXXUznfqMoKDAXNNFKVOnPiNo13NYTRejSrTrOYxOfUZU2fZmvvkBwbEd+HvNhgotf+zESYJjO3DHvdOrrAwXkp2793PZ8AnENOtRoWNUkeNZ2XNUlqrclhBCCCGEEOL8ccZBrOFXTyI4tgPBsR0Ia9CZ1l0Hc98jz5CRmVXhbXz57Y8Ex3bg8JHjZ1qMc8pg0DNt6mTum3Jzucva7XbCGnTm+Vffqf6CiQobee1tDB1zk9e8+6bczLSpkzEY9NW23w69r5CAiSjVv+s2ERzbgVV/rzuj9av682bGMzPZsm0XY0ZdztDB/atkm0IIIYQQQghxtjRnu4FH7r+D3Lw81v63hc++XEJ+fgEfvvNShdY9FZ94trs/58ZfPbJCyyUlp2K326u5NKKyTsUnEhEe6jVv2OBLq3WfDoeD+ISkat2HOL+d7WdhVX/eHDp8jKjIcN6Z9QyKolTZdoUQQgghhBDibJx1d8JpUyfz4tOP8NsPnxMYGMCuPfvdr+Xk5vHI4y/SqssgWnYZxCOPv0hObh4AU6Y+yXOvvA1A50tGEhzbwWu7SSmpTLp7Gg3bXMJlwydw9Ficz/0Hx3bgkcdf5KnnZ9OyyyA69x3Jl9/+6LXMil9Xccnl11KvZW+uHH8Hhw4f81r/hZnv8uZ782jeaQDvfbSAjIwsbr3rURq06UvbHkN57OlX3eUOju3g1ZLn+2W/0v3S0dRt3pPLR9/EX//+x99rNtCq62AAZr31IcGxHVj49fcAZGRmcfdDT9Gk/aV06H0Fb7z7CQ6HA4CXXnuf4NgO7N57gGtuuJv6rfow+rrJpKalu/eXkZHFA9OepXXXwTTtcCkPTHuWvPx8wPVF+IbbH6RBm75063+le5/g6h407KqbiWnWg14Dr+Kj+Yvc+y1it9v5ZulPDL96kqvu3S/n7bnz3a//vWYDwbEd+PWPf7jjvhnUb9WHLdt24XQ6+eyLJfS4bAwN2vRl4m1TSUpOLXGuirocffblEmY8M5OGbS7hh59+K/cc+XImdQ2O7cChI8dZt2ErwbEdmDL1ScDVta114fkCVyvDoWNu4oeffqP3oKtp1WUQb8+dT0JiMtdPeoD6rfsy9voppKdnlnvcjp04SWj9TlgsVr5e+hPBsR146bX3AVf31MefnUWrLoNo1WUQTzz3GhaL1V2O3/78l94Dx9KwzSU8OP15LBZLqcfDarXy4qz3aN9rGE3aX8od904nOaX4HEyZ+iStuw5m4+btDBt7C/Vb9eGWKY+Qn19QYltms4WP5i9i8KgbqNeyN536jOCbpT/53G9Z7xW73c5b739K90tHU69lb8ZeP4Wjx73fx199+yO9B11No7b9mPnmB16vlXVNJKekus5Fqz4MufJG9uw76LXulKlPerXyPHzkuNc591mXMt6bZSl6X/zw02/c/+izNO1wKT0uG8PW7bvdy5R1fl567X1uL2ylN/q6yQTHduDYiZNe+yjrnJT1eVPE6XSy8ve/GXv9FJp2uJTmnQbw1POzsdlsJeoTHNuBk/GJJCalEFKvo7vL3radexhxzSTqtexN70FXs+SHn8s8LuWdo9Odzfm22+08+/JbtOwyyN1CODi2g7v7bUU/o4QQQgghhBC1W5XkxEpPz2TpjyvJzs6hX98egOtLw82TH+bD+Yvo07MrfXp24cP5i7jlzkdwOp0Mv/wy2rZuAcAdt1zHtKl3em3z6RfewGaz07dXV7Zs28VLr79f6v4/nL+IP/5ay5XDB5OTm8uUB55g6449APyxeg3X3XI/AFePHsaefQcZd/O9Xq0Wvlq8jHc++IzRI4bQr3d3XnztPZb88AsD+/dmyIC+/PrH3z67SSYmpXDbvY+RX2Dmxglj0em0/Pbnv9SvF8N114wCoFePzkybeift2rTA4XAw/uZ7WfL9Lwwe0Jcmjerzv5feLBEguHz0TYSHh9KhXStW/b2OOR9/AYDNZmPM9Xfy6cLFdO7YltEjhpCQlIJepyM/v4Arrr6Vv9ds4MorBhMSHMTdDz7F2v82u47xfTPYtmMP110zilYtmrL0x5UlWm4UmM088dxr+Bn03DB+DDqdjiefe5016zd7LffgjBfYuWsfN1w3hpbNmzB/4WLue/QZQkODGTVsEH+t2eD+Uu7LzDc/ZPkvf3LdNaPo2qldhc6RpzOta9E1FhtTh2lT72T45ZeVWsYt23fz8OMv0rdXV2x2O08+9zr9h43HYNDToW1Lfl+9hjmffFHucQsKDODOSdcD0LplM6ZNvZO+vboCcM9DTzPn4y/o0a0TXTu35/2PFvLm+/MA2L33ANfedA+JyamMv3oke/Yd5GQZrXWmPfUKr74xl5bNmjD88stY/MMvXDl+MlZrcVAsPjGZa268h5bNGtOoYT2W/riSb79fUWJbKanp/O/FN4iKDOfGCVeRl5/PnQ884TOQXNZ75YnnXuepF2bjbzJyw3VjyM7JxaAv7rJ59HgcL8x6j0t6d0Or1fDCzHfdQaeyrgmn08mEWx9g+S9/MnhAX5o3bcSPK34v9dhUREXfm2W5494ZnDh5iiEDL2HfgcNMf2am+7Wyzk/fXl3p09N1TYwbO4JpU+8kKDDAa9tlnZPSPm88OZ1O/vfSm+QVFDBu7Aii60Ty1pxP+fa7kud/2tQ7CfA3ERgYwLSpd1K/XgxHj8cxdPTN7DtwmAnXXgnArXdNY+mPv/g8FpU9R2d7vud88gWvv/MxjRvW55rRV6AoCp06tGHKba73XmU/o4QQQgghhBC101l3Jwxv2MU93alDGx5/5G4A/tu0jd9W/ctNE8by5qtPAWAyGvnsyyVs2LydEUMHsPyXP9m5ex933jqBxo3qe2136t238uS0e8nLzye2RW+279xTahmaNKrPH8sWotNp6d29Mzfd+TBffvMDHdu14oWZ71I3OorffliAXq9j6OD+jLvpXjZu2UGPrh0BV6ue35ctpGO7VgCcPJWATqdl1gszCA0Jxul0+uxSk5SSitVqY/TwwTz35IMA7mUnXDOKL7/5gT49ujD9oSkA/PrHP6zbsJXXXnycSTdeC8Blwyfw1eIfGTe2OMn1808+xE3Xj+XAoaN063+lu+4//PQbW7bt4q7bJ/Li0494leWLbxZz9Fgc33z2LoMH9MVut9OyyyC++nYZvbp35mR8Ai2bN2HWCzNQFMVnnUxGIxtWf09ggD8AfXp24bpb7ueP1Wvo3aOzezmnw8Ev339GgL8Jp9PJC7PepWundvz07ScoikL7ti155ImXiE9IIrpOZInjlpGRybo/llI3JgqAG25/sNxz5F3XH86ortMfmsIrs+cQW7eO+5yUxmy2sGLxPJo0boDRz8Ab781j4rjRPDntXvd52bp9V4WO25TbrmfOxwtp26qZe7979x/i2+9XcP+Um3nm8akA3DT5Yb769kceuf8O3vngMxwOB59/+Dq9e3TG6XTSsssgn2U9eSqReQu+5bJ+PVk0/20URaF+vRief/Udvl/+G1ePLm6N8sl7r3BZv178vupfxk68i+079sD4MV7bqxsTxe6Nv7rrUz82hmlPvcJf//5Hwwaxp+3b93slPiGJuZ98QecObVj5/WdoNCU/agL8Tfy5fCHhYaEY/QzMfvcTduzaR+NG9ct831qtNjZs3s7EcaN557VnAAgPC+GN9+aVeU7L8vuqNRV6b5Zl5LCBfPD2iyiKwu+r1rB9xx6cTien4pPKPT//rN3Iv+s2ct3VI7n0kp4ltl3WOblxwlU+P288qVQqfl76qXv9XXsO0Gfw1fyxek2JLtLTH5rC518uQa3RuLd1/6PPkl9QwHdfzaVH145k5+TSrsdQXpj5LmNGXl5if/+u21Spc3S25/vvNRvwMxj4dsG7GP38OJWQREFBAXfdNvGMPqOEEEIIIYQQtVOV5MSyWCxs37WXv9ds5PLRN/H7jwvYvnMvAAP693YvO7B/bz77cgk7du2je5cOpW0SgAb16gJg9PMjpk4kmZnZpS4bEOCPTqcFoFuX9gAcPXYCu93Ozj37MZstRDXp5rVO3Ml4d4CkS8e27gAWuBJ9r9+4la79ruS2m8Zx9x03lGgZAdCmZTPGjR3B23Pns23nHh59YLK7lY0v2wqDUQ/NeIGHZrzgnt+sSUPvutd31b1JYWAvM8tV963bXeuPHTW05LYLW55dc+PdJeoJ8OSj9zLjmZl0v3Q09991C9ddPRK1Wl1iO6mp6Tz/6jv8sXoNhwpbxcQneudzuvaq4QT4m1yvJSSRnJJGckoaIfU6nrbvBJ9fEC8f2M8dwCrvHFksVv5Zu9E9b8pt11dZXctTdB6KAqxF1+Tp5wUqdtw8Fb0/3nz/U958/1P3fL1eB8DuvQcxGf3o1b0TAIqioFb5bji5c88+nE4nA/r3dgcmB/bvzfOvvsOOXXvdQSzvOjQoUQdPR4/HMefjhfyzdiPHT5wqtT6lvVd27NqHw+HgyuGDfQawAPxNRsLDXPnJGnsc0/KuidS0DAAGX9bXPb+0fVRURd+bZWlQv677+DduVJ+16zcX1qXi56csFT0npcnLy+fN9+axYuUq9h86Wrh+coXW3b5rL/4mo/tzO8DfRI+uHfjl97/JzcsrsfzuvQeAip2jqjjfrZo34edfV7P6n/U0a9KQ/QcP06JZY1cdz+AzSgghhBBCCFE7nXUQa9rUye4vFM+98javvf0Rf/69DqfTWeo6Fckz40lRqaCC6xSVxWQy4nQ6cTqdxMbU4fpxo72Wa9empXtapfJukdSja0c2/7OMOR8vZO4nX/LJ51/z+7KF7gBA8Xoq5r75AjdNGMtrb33IiGsmcd+dN/PsE1N9lq3omIwbO4KG9YtbtERFhvlcXnVa0MLuKD1xc9G277jlOkKCg9zzmzdtCMBtN41j0GV9mP3OJzw4/Xk+/3Ipy775CK1W61726LE4Lhs+gYjwUMZfPZL6sTHccd8MHA7vc+lZrqLT3LplM0YOG+i1XP16MaXUq/h4l3eOFn//M6/MnuOeN+HaUVVS18o4PQB2+nmp6HHzVFSHoYP706FtcQDVUBjEslptqNXqCiXVLvu95vs1RVX6djds2s6IayfRumUzbr95PGq1mhn/m+lzW6W9V8q6Vn3xvqbKviZ+/fMf1zrq8ntD2yv4uVHZ92Z5VIp3fUpT1jXiqTLnxJeMjCyGjL4Rm9XGhHFX8ly3ToydeFeF1y+rDr5eshbm2qrIOaqK8/3A3bfy2ZdL3V0S1Wo190y+0at8lfmMEkIIIYQQQtROZx3E8pRXmCTaZPRz52T5Y/Uarhzu6gb126p/AWjf1hVAKvrCnpKWXqI7YWXYbMVfmH9fvQaAVi2aotFoaNWiKQcOHuGG68YQG1MHoNTugUVSUtMICw0pbFnVjSvG3sKyn//g7ttv8FrO4XCQkZlF7x6d6b3wfUaNu51PF37Ls09Mdef+SUlNcy/ftnVzAIICA9zddMr6cni6Nq1c6y9dtpIundoBrlYMarXave369WK4546iL2/F9UxJTaNh/VjefPUp6sZE8eKs99i976BXAOXn31aTkZnF4gXv0aVTO3frlLLEREcSGhJMRkYmd90+0d1irbxjXKS8czT9oSklukedTV31eh0pqelUpfKOm/ta8EjQX5QPTlEUHnvwTnfZi66Hxg3rsWvPfrbv2kv7Ni3Jy88nv8CMv3/Jt2zRtv5YvYZ77rgRRVFKvNcqY+myXzCbLXw9/20iwsPKzGVU2ntlxNABAPy44nfuvuMGNBqN+1otT3nXxKEjroTf/67b5A5KpGdkem2jqKXggUNHadakIVsKu36erujtV5H3ZkpqGqEhwSWCmOWpyPlxfxaWcm2Wd058fd54WvPfZo6fOMW8919lzMjLycgomeOvLO1at2Dr9t38t2kbPbp2JCs7h/Ubt9GkUX38TUb34BNFh6xxw3pA2eeoSFWc7++X/YrD4eDDt18iKSWVgf1707J5E+DsP6OEEEIIIYQQtcdZB7FemT0Xs9nCxi07WPvfZhrUr0uXTu0wGf0Y0L8X879YTG5uHk6cLP7+Zwb07+XuklIUlJnxv5kM6N+baVMnn1EZdu7ex5gJk2nauCELF31HYIA/t0y82rXth+9i3E33MmjkRK4adTmZWdkkJCTz7YL3fH6BKSgw03/oeGLrRtOlU1t3UvOmjRuUWPaTz7/h2ZffYuQVA9FqNPy3cRutWjZ1L6/X61i6bCUhwUGMGDqAIQMuoUvHtnww70uOx52iWeOGrP1vM9MfmsLAS/uUW8+xo4by2lsf8s7czzgRF09EeCh//rWWX76bz8Txo3nng8956vnZbN22m6iocFb9vZ6P330Zm83OgBETGDLgEmLrRvPD8l8x6PXuL4tFwkJDXMfsmVm0b9OCJT+uLLdMRYGmR554iQHDJ3DFkMuIT0hCp9fy3uvPlbs+VP4cnU1d27RsxuZtu3hoxgv07dXVZz6fyirvuIWHhRAZEca/6zbx+LOzGNCvFwMv7cOVwwfz/fJfGXntbXTu0Jbtu/Yyevhgbp54NbdMvJofV/zOdTffx8grBvHXP+tJz8jEvzA44yk2pg43Xz+WTxcuZtxN91InKoKFX39PqxZNGD1icInlK1qfu6a6goC+kn9D2e+VBvXqcl1hnqZhV91Cty7t+e3Pf5n1wgz69elebhnKuiYG9u9DbN1o5n7yBdk5OeTm5vPdMu9j3qGwe/ATz77GosXLWPvfZq8uaEWBjLUbtrB774Fy35sfzV/Ew4+/yIP3TOKpx+6r1PGsyPkp+ix89Y257DtwmCm3XU9oSLB7G+WdE1+fN0WBbtf6rm3NfOMD1m3Yyk8rV1WqDg/eM4lvlv7ExNumctWoofy9ZgMZmVnMemEGUPJ4VuQceTrb8330eBy5eXms27CF8LBQlv/yJ7v27Gfo4P6YjMaz/owSQgghhBBC1A5nPTrhzDc/4O258zl89DjXjB7Gd1/Mxd9kRFEU5s99jUk3Xsvfazfwz9qN3HrDNcyf+5o7MDHh2lGMGTmEvfsPsfTHX0hITDmjMrRu2YyoyAgWLV5Gy+ZN+GHRh+5cO5cP7McXn7xJnagIPl3wLev+20LP7p1KHfnOYNDz3hvPoSiuEa3S0jN47okHGTLgkhLLXnfNSK67ZhR/r9nA4u9/pnfPznz49osAhIQEMfP56RgNBj77cinbd+1FrVbz7efvceN1V7Ft+24++2oJwUGBhIeHVqieer2OZd98zJiRQ/hn7UaW//wHgwdcgp+fAZPRyIol8xg5bCB//r2ORYuX0axJQwx6PW1aNeP5Jx/i8NETzF+4mLCwED7/8HX3F+MiY0YO4bprRrFrz37Wb9rGe7OfJaYC+WJuu2kcb818Gr1Ox8efLWLX3v106diu3PWKVPYcnU1dZz4/nVYtmrBo8TJ+X7WmwmUsS3nHTa1W8/as/1EnKoIFi75j/cZtAMx543nunXwTx+NO8cnnX2O2WNwtEgf0783rLz2OVqdlyQ8/c8Xll3HVqNIDbq8+N52H77ud3fsO8uOK3xk9YjDff/XhGXWhvP3m8Vw+qB9r/9vM3v2HWDT/HZ/BxPLeK7NfeoIH7rqFxOQUFiz6nmZNGrrzjJWnrGtCp9OyeMF79OzWkR+W/0Z2dg5vvvKU1/pjRw1l7JVDSU5JJSk5hW8XvOeV+yg4KJDbbxpHWlo66zduLfe9GRYajJ/B4O7aVlnlnZ9Bl/Vh0o3XkpicwtdLl3Ps+Emv9cs7J74+bzx179KBB+66hbj4RFb9vY5pUyfTs1vHCpe/UcN6/Lz0U5o1acTCRd/hdLpaPY290pWf7/TjWZFz5Olsz/c1Y67AZrPz9ZLlvDJ7Ds+98jaT7n6MCbc+AJz9Z5QQQgghhBCidlAsFnPF+7PVQsGxHejZrSM/L51f00URQlzAZjwzk5279/PDog9ruijiNP2Hjadh/Vjmz50FuAYIGDrmJuITkjm66+8aLp0QQgghhBCiqlRpTiwhhLgQfb1kOZ99sYS5b71Y00URPqSmpnPo8DFuv2c6kZFh7NpzgD37DnHnpOtrumhCCCGEEEKIKiRBLCGEKMfGLTt445WnGH75ZTVdFOHDp3Nm8tQLb7Di11WAq/vjy888yu03j6/ZggkhhBBCCCGq1HnfnVAIIYQQQgghhBBCXPjOOrG7EEIIIYQQQgghhBDVTYJYQgghhBBCCCGEEKLWkyCWEEIIIYQQQgghhKj1JIglhBBCCCGEEEIIIWo9CWIJIYQQQgghhBBCiFpPglhCCCGEEEIIIYQQotaTIJYQQgghhBBCCCGEqPUkiFWGfQeOcOOUGVgs1pouynntmVfnsHT57zVdDCGEEEKIUm3etpvBV91xxuvfM+1F/l2/BYDlK//ixikz3K+dL/dCyanpTLh9Gsmp6TVdFCGEEMInxWIxO2u6EFXhrkeeZ8fuA2jUGpw4aVAvmlsmjObSPt1qumhn5KPPFwNw2w1jK7T8XY88z20Tr6Jzh9bVWaxq1evyiaz9ZUFNF0MIIYQQPuzed4gP5n/L/oPH0Bt0dOvUhrsnjScoMMC9zFsffMHXS39m8fzZREWGuedX5D7trzWb+PzrHzl6/BR1IsO5auRARl8xAEVRGHPjAzxw50T69+7qXv6jzxdz4NBxXvnf1Cqp3+Ztu5n2zBv8uuSDCi370YIlvDfzCZ+vL1/5F4uW/sxn77/o8/UxNz7Ae68+TnSdiLMqc01ZvvIvNm/fw5MPT67pogghhLjIaGq6AFXp7knXMf6qoWRmZbPmv2088cI7LJn/OpERYeWvLIQQQgghfNq4dRfTn32T+ydfzwuP34sTWPnnWtLSs9xBLIfDwV9rNjJmxEB+/2s9E66+wmsbZd2n/bDiTz78fAlPPHQHndu3Ij4xmeUr/8Jms6PVXlC3q0IIIYQ4CxfkXUFQYADDBvVl9vufcfREPJERYRw4dIzX3p3PoaNxtGjakBkP3kZMnUgAFnyzjEVLfiYlLQMAP4Oeh+6+iZbNGzFx8nR366C7Hnme4YP7sfrfjWzfvZ9e3TrwwJ0Tee3dz1i/aQctmjbkhSfuJcDfBMDvf63nw88Wk5GZxSW9uvDQXTdiMOi9yvrDij/5eMFSCswWunZszaP33cL7875m2c+rUVQKX3z7E89Mv5sendvx5ZIV/LZqHfGJybRq3pinH72T8LAQrrv9UY4eP8XUJ2aiVqn4fuFb+JuMfPvDr3y1ZAUFZgvDBvVlyi3jUKu9e5COufEBbho/ip9+/Zujx0/SqV0rZjx4m/uGtLQ6fPT5YixWG2azmV/+WMPHbz3L4aMneOuDL8jIzKZNyyY8et8txNSJZMZzb9K4YSy33TCWtPRMnp05hx17DhARFsqkiWNo26oZ193+KAADrpxEk0b1+PCN/5FfUMA7H33Fn3//h9HPwO03juXyAX3c5X747pv49odf2bX3IO1aN+P5x+/Fz2AA4L/NO5kzbxHH4xJo3DCWGVNvp2H9GOITkpn5zqfs3HOA2Jgopt0/iRZNG1b9RSiEEEJcIJxOJ6+9O587brqaEZf3d8+/asRAr+V27D5A/dhohg/px6tvfVIiiFXk9Ps0f38T7368iP9Nm0KPLu0AqB8bzZRbx1W6rNk5uQwffzdffvgqdaNd93m/rV7HV0tW8NGbz5Cdk8vbH37BP2u3oDfoGDtiENeNvaLE/RHA3gNHmLfwO3btO4iiqLhlwmiuGjGQn3//hxdnf4TdbmfAlZO4auQg7rntOm6550muHjWY4UP6ldiW573QgCsnkV9g5ro7phHgb+KpRybz3Ky5fPf5m6hUrnLMemc+fgY9d9823r2Nzdt288bchQzu35PvfvoDi9XGdVcNcx/n8u6bHrt/Eh99vgSjn57Xn3+U19//jF//XIvBoGPowL5MueVa8gvMDBx9G0vmzya6TgR/r91U4t5u5Z9r+XjBEpwOJ3/+/R93TRrP1aMGl3qvvXnbbt6f9zWjhw/gi29/IiU1g9tuuIprrhwCgNVqY94X37Hit78xm63079OVh++5GbVaVaF7aSGEEBeXCzInVlJyKl8u/gmbzU6zxvXJys7l/hmvcOUVA1jxzfsMurQnL87+CHAFO+Yt/I7ZLzzKN/NeIzoqgpnPPOTzBgRg/lc/cPuNY1k492X+WrOJKQ89z9hRg1ky/3VOJSSx7JfVAGzbuY+Zb8/j2el38/3Ct7Db7Xyx+CevbeXm5vHKW5/w+EN3sPyrdxg17DJMJiOP3T+Jywf24abxo/jj+4+5pGdn1Go1Op2Wmc8+yLKv3sWJk0+//AGALz98lTpR4cx+/hH++P5jAvxNrPxzLV9/9wtvvTydrz+eyf6Dx1j55xqfdfrjr/94ZtpdLJ4/m9z8fN6f93WF6rB02e9ERYSz7Mt3iKkTwYuzP+KGcSNZ8fV73Dh+lFf3giILv12Ooij8sPBt3nxxGvXr1iE6KpwvP3jFVZbvP+bDN/4HwJtzFpKSks43n8zijRenMWfe15yMT3Jv6+MFS3ngzol8M+819uw7wq+r1gFw8PBxHv3f60y8diQ/f/M+U24dR3hYMFarjYeenEX7Ns35adF73H7j1Tz10jvY7Y6yLyghhBDiIpaemcXR46cYfGmvMpf7bfU6LunVmRZNG5KRmUPcqUSfy51+n3b4aBw2u42eXdufdVkD/E306tqBVf9scM9b9c8GBvbvCcCLr39EVnYuX8+bxdsvT+fHX1aXmqsqNzef0cMHsHj+bJ586A5ef+8zUlLTGTqwL9Puu5UObVvwx/cfc89t11WqjH98/zEAX37wCj9+8TZdOrRGrVazdec+wBU0/HvtJgb171Fi3YOHj6NWq1kw9yVeevJ+PvxsMTt2HwDKv2967d35PPbArcx+4VHWbdzGn3//x4K5L/Hlh6/SvXNbFEUpsT9f93Y3X3clN40fxeUD+/DH9x9z9ajBZd5rg6sr6rET8Xzw+lNMnTKRdz78krz8AgA+/Oxb/lm3mbdfmcGSz2Zz2SXdUatVFbqXFkIIcfG5oIJY789bxKAxt3PlxPv5/a/1zH5xGiHBgaz65z/q1a3DsEF90ajVXDnsMvYdOIrZYuHQkeO0a92Mpo3rExsTRfcubdl74Eip+xgzYiDNmjQgLDSYVs0bc9kl3enQpjkmk5GO7Vpy7EQ8AEuX/86Y4QNp3qQBep2Oa0dfztoN2722pdPpCA4KZPfeQ9jsDnp0aYdGrfa5X7VaxXVXDSM4MIBDR44THhrMvoNHSy3nkmW/ccO1I6gbHYnJZGTM8AGs3bDN57JjRw0iuk4EAf4mJoy9gjX/ba1QHerHRnPd2GFoNBoURSEyIpR9B49SYLbQuX0rTEa/EvuKigjjVEIyiUmpREWG0aJZI59lMlssLPtlNffcfh0mk5HYmCj69uzMhi073cvcOH4kDerFEBQYQJtWTTge5zr23/30J5f17caAS7qj0Wjo1K4l/iYjW3bsJScvj5vGj0Kj0dCrWwc0Gg0n433fZAshhBAC4hNS0Go1BAX6A/Dv+i0MvuoOBo6+jZcKAxV2u4PVazbSv09XFEXh0j5d+W31Oq/tlHaflpCUQnhosM8giqf/vfw+g6+6w/33+aJlPpcbfGkvVv27EXDdT6zduI2Bl3QnPSOLVf9uYOqdN+BfeG9x6/WjWbrMdxCrS8fW9OrWgbT0LMxWK2qVikNH4yp17CpCpVIxYkg/Vv7h+rFx38GjaLUamvtoKW4y+jHh6ivwMxho26opvbt3YM1/Wyt03zR+zFCaNKyHSqUiPCyE/HwzBw8fx+hnoGvHNj7LVpF7O6DMe20AP4OBu24dh8lkpFe3jlisVhKTUnE4HCxe9hv33jGB2JgoDAY93Tu3BSp2Ly2EEOLic0F1J5xyyzjGXzWUp156B6OfHx3aNAfgZHwSu/cd8hpxxmKxkpWdS5eObfh4wVL27D+M0c/Aug3bGfJo71L3oVB8gxUYYMLzfiswwJ/MrOzCfSaz6t+NfPvDrwA4nA7qRIR7bUur1fDRG//j0y+/Z9ytD3Pt6Mu5buwwd1NyTw6HgznzvubXVWtp3qQharUKs9lcajlPxSfxxpwFvP3hl+71O7ZrUeryRYKDAsjMyqlQHU6/4Zz9wqMs+Ho5190+jSsG9eXWiWPQ63Re27961GACA0w8/sJbxNSJ5O5J42ncMLZEORKTUrE7HNxyz5Pufdhsdm69frR7Gc99Bwb4Y7XaXHVPSKJ94bn3OiYJSaSlZTJkbHESUovV6q6vEEIIIUqqExmG1WojKzuHoMAA+vToxK9LPnAn9wbYsmMPaWmZjLv1EQDsdjt1o6O4+bor3dsp7T6tTmQ4KWkZOJ3OMgNZ/3tsis/E7qfr07MjL73xEUkpaew7cITmjRsQGRHGrr2H0Go1REaEupeNjanDqYRkn/vbd/Aor7z5CVarja6dWqPX6ygo497rbFwxuB+33PMED951I3+t2cTAfj3KDeoBBAcHkpmVU6H7prCwYPd0i6YNeePFR/lk4VLe+2QRk2++hkt6di6x/Yrc20HZ99rgfc9WFAy12mxkZGWTl1dAw/p1fWyz/HtpIYQQF58LKohV5I6bruH6yY9x9ZVDaNqoHtF1IujQtgXvvDKjxLIBJiN1osJ56Y2PyczM5prRQ+jcvtVZlyE6Kpxe3dpz6/Vjyl6uTgTTp95GUkoa9057kfCwYC4f0AcFcDiKB478bfU6/vxnAws/eAWjn8E96k0RBQWHs3j5OlERXDViIMMG9a1UuY/HxRMbHVWpOhQJDQ7ivjsmcPN1VzLtf6/z5bcruHnClV7LqFQqhg7sy5DLerNo6c9Me2Y238x7jaJooMPhQKVSERkRhkqlsHDuy16jG1VEnchw4k4mlJgfHRVBnahwvpn3WoVuDIUQQggBoSFB1I2O5LfV6xg7crDPZX5btY57bp/A+KuGAq6WWcPH38XR4ydLBChOv09r1KAuKkXFuo3b6dWtw1mX189goE+PTvyzdjN7Dhxh0KWuroQxdSKwWm0kp6S5B/2JO5VITCkjBD710juMv2oYY4a7cn8Vte4CQAGn4+wG+Pa8b4uOCqdF04b8t3kna/7byowHb6/QNo6fiKdn1/ZndN/UoW0L3nzpMXbsPsA9017kq49mugNMRUq7t1MUxes+tax77ROFLeV9CQ4MwKDXc+JkAhFhIV6vVfY+VAghxMXhgupOWCQ2JopRQy/lnQ+/AODSPt04fCSOxT/+itVq48TJBHf+gA1bd6HX6fhg9tN8v/AtJl4zokrKMHr4AL5a8jObt+/BZreza+9BTpwWWDl8NI7vfvqD3Lx81CoVoGC2WAEIDQ1m556DFBSYsVhcrYVsNhs2m52T8Ums+O0fr22FhQaxadtuLBYrdruDMcMH8OFni9l/6BhWq43N23aTkprus6x/r91Mdk4u8QnJfPrlD4wY2r/CdSiSkprOF9/+RGZWDk6nE5VKhdlqKbHcV0t+5tDREzgcDjQaDZbC+gYF+qNWqdi4dTdmiwWDXsewQZfw8psfk5qWQU5uHn+v21yh/FUjLu/Hr6vX8deaTdhsNrbt2s/BIyfo1K4larWauZ9+Q0GBmcSkVDZu3VXu9oQQQoiLmaIoPHjXjcyZ9w0///4PuXn55OUXsGvvIQBsNht//rOB3t2LA1BqtYrunduV6FIIJe/TTEY/7rzlGl6c/RH/bdqB1WrjVEISz7w6h4SklDMq8+BLe/LX2k2s37Sdy/p2ByAkOJBL+3TjjTkLyM3N42R8EvO++I7RwwcArjQPVpvNfa+RkZmD2WzFbLGwfOVfpBYOAAQQFhLM4WMnSUvPdHeZ86TTaTFbrDidvgNdYaFBbNq6y2vdkZdfyjff/0J+gZlmjev7XC+/wMyqfzdgs9n4bfU6du45yOBLe1b6vmnVPxtYX3isNRo1drsDm83mtUxZ93ahIUHsO3CEnNw8LBZrmffaZVGpVIwc2p+3P/iC+MQUCgrM/Pz7P9js9krdhwohhLh4XJBBLIBbJoxmx+4DrN2wjeCgAN58aRq//7WeYddO4YEZr7hvvNq3bk7cqUSGj7+LAVdOcr+elp55Vvvv3L4V0+6/ldfemc/lYyfz6tvziE/0vhELCw1i195DjJ/0CBPueIyObVswbKCr5dSYKwaQnpHF6Bvu589/NjB0YB/qRkdx1Y0PMPPteQy5zDu56q3Xj2HZz6u59taHORmfyLBBfbn+mit4/Pm3GHrtncyd/63XzZcnRVG4/YFnuPW+p7ikZ2euGTW4wnUo4m8ykpKWwc33PMHVNz9IYIA/1189vMRy0XXCeW7mXC6/+k6+X/EnTz96JwBGPwO3ThzDjOfe5O5HXsDhcPDQ3TdSr24dbrr7ca655SFW/Po3Obl55R771i2a8Oz0u5k7/xuGXjOFOfO+BqcTnU7L7Bce4dDRE4y6/l7umPoM6zfuKPUGUwghhBAuvbt3ZOYzD/Ljz6sZc8MDTLh9Gjm5udw28So2bNlFgL+RenXreK3Tq1sHfl21zuf/Wc/7NICxIwdz/+TrmfPp1wy7dgrT/vcG7Vo1JSqicq2xi/To0p7d+w7TIDaG0JAg9/wZD96G0ejH1bc8xD2PvsAVg/ty1YhBADRv0oBG9evy3idfAXDf5AnM/+p7Jtw+jZS0DK9UBV07tqZDm+aMm/QI7338VYn9d2zXEnCy+MfffJZv8s3X8u7Hi7jhzhnue5tLendmz/4jDOjXvdQW4zqths3b9jDiunv4eMESXnn6AXerssrcN9WLrcOXi39i+Pi7mfbMbO6ffH2J81fWvd3Afj0JDDBx1Y0P8PX3v5R5r12euyaNp0PbFtz+wNNcfcuD7NxzCJvVVqn7UCGEEBcPxWIxX9Tf4D9ZuBSdTsvEa0bgdDpJS8/krkdeYPTwAVx31bCaLl61G3PjAzxw50SvHBNCCCGEEOLcslptjL15Km+++BiNGpTMEbV5226mPfMGvy75oAZKJ4QQQtQOF2ROrMo4fDSO4KBAklPTMRn92L3/MJlZ2bRt2bSmiyaEEEIIIS4CZouFeQu/o2Pblj4DWEIIIYRwueiDWHdNGserb81j/G2PoFJUNKxflycemky71s1qumhCCCGEEOICl5Obx5gbHqBJw1ienX53TRdHCCGEqNUu+u6EQgghhBBCCCGEEKL2u2ATuwshhBBCCCGEEEKIC4cEsYQQQgghhBBCCCFErSdBLCGEEEIIIYQQQghR6533QSyn04nNZsPplNReQgghhBBVSe6zhBBCCFGbnPdBLLvdziXDb8Zut9d0UYQQQgghLihynyWEEEKI2uS8D2IJIYQQQojaa/nKv5j1zvwa38a5tHrNRp6bNbfG9v/R54tZ+M3yat1HfEIydz3yvPv5c7Pm8sff/5VY7vNFP/Lfph3lbm/MjQ+QkZmNxWLlsWffwGKxVml5hRBCXBg0NV0AIYQQQgghxIXphnEjK7W8Tqfl5aceqJ7CCCGEOO9JEEsIIYQQQlSJ3Nw8Hnv2TRKSUoipE8FLhcGI5NQ0pj/7Jjv3HGDSDVcx+ooB2Ox23pq7kE1bd6PX63jo7pto07IJdruD9+ctYs36rej1Op58eLLXPj5esJSCAjN3TRrHm3MX8vfaTZhMRp565E6aNqrnXu76yY8x8vJLWb7yL7RaDW++NI0AfxO79h7klbfmYTabGTGkP8OH9GPKw8+z6OOZACz/9S+OnYjnrlvH8cnCpaz8cy06rYbHH7qDFk0bcsOdMxg5tD8rfvuH92Y9jp/BAMDho3E8N2suTqeT0JAgQoIDAUhLz+TZmXOIT0yhWeP6PP3oFLRaDV98+xPLflmNRqPm/skTadakAbPemcexuHhsNjvPTb8HJ05mvTOf92c9AcAnC5cSFhLMlVdcBoDNZmPWu/PZf/AoObn5PHb/rXTu0BqAXXsPcs+jL5KQlMItE0YzfEg/n8e8RdMGXH3zQ3z9ySx0Oi2bt+/hu+W/8+z0e/jh51V88e1PKApMvfMGundpB0BBgZl7H3uJtPRMbpwyg/9NuwuAbTv3sviHXzlxKoFXnp5Kq+aNeW7WXPr06MRlfbuVeb48DbhyEn98/zGbt+3mh59X4XTCtp37GD6kH7ffONZ9LE4/N0IIIS58EsQSQgghhBBV4r/NO9HptHwz7zUSk1Ix+rkCPEnJabzzynSOxcXz1EvvMvqKAfywYhVJKWksmPsSh47G8ejTr/P1JzP56bd/OH4ins/mvEh+fgEGvZ49+w8DsHXHXjZs3sE7r84gKzuH5Sv/YsU375OVnYPJ6OdVlrz8AkKCA/ns/Rd4+KnX+Hf9Fgb268mLsz9i9guPEhoSxMNPzmLooL6EhgRxPC6e+rHR/Lt+KxOvGc76TTs4eOQEX3zwMglJKbz27nxee+4RcvLyyMrO4ZO3n0VRFPf+nn9tLpMmXkXfnp34asnPHDh8DIA35ixg7KjB9O3RiU8WfseqfzcQHBTAb6vX8fHbz6BSqbDZ7Bj0em64diTNmjTg+5/+5Itvl/PEw5Ox2WwkJKVQJzKcf9dv5fXnH3bvU6PRMOaKAbRo1oj/Nu3g4wVL3UEsRVF448VHyczKYcIdj3Fp32788scan8e8c4dWbNmxlx5d2vHv+i3079ONo8dPsnzlXyyY8yIFZgtTH3/VHcQyGPTMmHobHy1Ywnszn3CXx2yx8vYr0/li8U8sXf47rZo3dr9W3vkqzbZd+/lg9tOoVSrG3PAAt14/ho1bd/k8N0IIIS58EsQSQgghhBBVon2b5sz78ns+mP8t468a5p7fpmVTTCYjzZs2JD0jC4CNW3YyqF9PFEWhaaN6+PnpOR6XwLqN27lq5CA0ajUB/ib3NrKyc3j65feY8eDtaDQaAgP86dyhFc/PcgWPQoODSpSnR5d2KIpC8yYNSEvP4vjJeBISU3j4yVmAK9CVlJzGZX278e/6LURHRXDs+ClaNW/M2x9+yZ59h7j5bleQxq8wIAdw1YhBXgGs3Nw8klMz6NuzEwDRdcLdQawNW3Zy5NhJPpz/LRarjdFXDGDvgSOMHNrf3YpLr3NtR6PR8N4ni9ix+wBqlSt17fAh/fht1ToGXdqTwAATQYEBXnUMDAzg4wVL2L3vMAlJKe75rVs0QaPREBYaTGxMFMfj4ks95kX179GlHRu27GLSxKtYvvIvTsYncuu9T7nqmJdf7vnv3rkdKpWK5k0asnXHPu9yVuB8+dK4QSwRYSEABAX5k5Oby/pNO0o9N0IIIS5sEsQSQgghhBBVIiw0mE/efpaff/uHm+9+gndene71ukatxul0AuB0AkrJbTgdTq8AUZHf/1rHrdeP4cvFP9G9c1sUReGVp6eyaetuZjz3FpMmjuHSvt18lkutVuF0OnE6oX5sNPPeec7r9fDQYJ6bNZemjevTtVNr1/6dTiZcPZxrrhxSYnsqlffYSHaHk/z8Aux2B2p1yXGT5rz+pFfLo7fmLixRx517DjLrnU+Zcus4LunZmffnLQJgcP+ePPjkLAwGPQP79fBa51RCEg89OYspt4xjxJD+3Pmwd72KaDRqDHp9qce8e5d2zJ3/LXGnEqkTEeZuQTfksj7cd8cEn9ssi6bweHuqzPkqjVqtdtWhjHMjhBDiwlatoxN+uWQFI6+7x+foKHGnErnt/qe5fvJj/Pz7PwA4nU4+XrCE6+94jKmPv0pObl51Fk8IIYQQ4rxVG++zjhw7SX5+AcOH9KNRg7rsP3Ss1GW7dWrD76vX43Q6OXT0BHl5+dSrW4fOHVrx/U9/YLc7yM3Ld7fcGtivJ5MmXoXJ6Me/67eSmZXNsROn6NKxNUMH9mHLjj3llq9+3TpkZGaxedtuABKTUgGIigzDZrPx+1/r6d/HFVjp1rktP6xYRW5uHg6Hg6SUtFK3G+BvJDQkiK079gKwd/8R92tdOrTmqyUrAEjLyMRssdC5Q2uWr/ybArMFq9VGUkoa23buo2O7lvTo0o4jx0+61zeZjMTGRPHDij/p17ur1373HjhK/dho+vXuwvGT8V6vxSem4HQ6OXw0jtS0DOrVjSr1mOt1OhrWi2HR0p/p39e1j84dWvHb6rWkpKbjdDrdx6pIZEQYySnpOByOco87UO75UlBwOCu2rcqcGyGEEBeWag1idW7X0t13/nRvzl3ALRNG88HrTzH302/Iyc1j/8GjrPlvG5+9/yKd2rdkwdfLqrN4QgghhBDnrdp4n5WRlc2DT8xi/G2PoFIp9OzaodRlR11xGWGhwUycPJ0XXvuA52bci1arYfQVAwgOCuT6yY/xwIxXiE9MBlzd0QDuvOVa3v9kEXn5Zt7+8Esm3jmdlavWcNWIQeWWT6fT8tyMe3nrgy+44c4ZzJ7zOXa7K3DSt2dn/l23hQ5tWgDQs2t7BvTrzi33PsXN9zzJ+k07St2uoihMn3obM9/5lNsf+B95+QXu16ZOuYFdew9x/R2PMePZN0lLy6RPj45079yWm+56nMkPPsOBQ8fo17sLO/cc4PYHniEtLdNr+5f17U5EeCiBASav+V06tCYvr4Bb732S7bsO4KfXu1/LzcvnjqnP8ORL7/Dkw5PRaDSlHnOAS/t244cVq+jbozMATRrW47YbxnL3oy9y091P8NNvf3vtu250JHWjI7nu9mns2H2g3GNfUGAp83z16NKOJT/+Vu52oHLnRgghxIVFsVjMzvIXO3Mffb4YP4OB668Z7p5ntzu4dNQt/Pz1+5hMRu6f/jJjRw7m4JHj5OTkcd/k69m+az+z3p3PZ++9UOb2bTYblwy/mb+Xf4pGI70jhRBCCHHxkPssl5zjO9CHxKCoNeQnHiagUSfyk46gKAq64GiyDm4goHEnzClx5CceRBccjS03HX1oLPlJh1FUagKb9yQ/4RD58fvRh9XDabfi37AT9oIc8hMPE9S8J4r67I6Bw2rGYbOQue9fDKGx6EJjSNv6M6EdLseSmUTeqX2EtL2MtG2/EtC4M06blZwTu5i7+hS9W0YxYMQYrNmppO/8g7DOV5CfcBC/6OY4LPlYs1Iw1WtNbtwetP6hqA0m8k7uxb9xF3KP70QfGoPaL5Cco1vwb9ABW14m1qwUjHVbkH1kC6bYVuB0Fq9zYif6kBhUWgN5J/fg36gzlox47OY8/KIau9ex5WZiL8jBGNPcdR6Co1E0Wvd5yD6yBb/IRqh0fuQc205Ao05Yc9OxZiRiqt+WvJP7UBsD0fgFuveTn3AAtSEAXVAk2Ue24N+gPdacNOz5WfjVaUb2kc2Y6rbC6bCTn3iIgEadyD2xC21QJCqNnvyEg/g36oQlIwF7XhZ+0c3IObIZY91WqLT64m1mp2IvyMYY4zoGflGuRPRFZc85uhVDREOvspvT4nA6nehDYsg5th3/hh2x52VizojHVK8tOYc3YazbEntBDtacdIx1W5JzZDN+0c1R6/zIPrIZ//rtsRVkY06NA8Cen4U+LBZLRiIqrQG1wZ/8pMMENOxEfsJBUFQYIhuSc3Qrxpjm6MPqkXN0G4bweuSd2ofGFIKpfjv3foquBxRc5zimOdasFKy5GQQ06YLTZiU/4QCKSo0tLxNT/XYoai358fvxb9QZc2ocTpsFfXh9co5uxb9hB6yZSditBfhFNSHnyBb8opvidNgxJx/H1KC9a16dpjhsZqyZSZjqtXGfW31INDnHdqAPq4tKoytxjbmuy634N2iPOf2U630bUtd1/MPrY8lIwFSvjdf7z+lwYC/IQWMMdM+zm3PJjdtDQKPO5CccRG0woQ+t674uVTo/ck+6Xs+L2402OAqtKcR1Thp0QKXVI6qHLT+LrH1r0YfV87guW6A2BpJ7fKfrMzvhIGpjkOt9f3gzhsiGWDOTUTTaUj9zfL1vLZnJWDITcFjNOK1mTPXbYs1KwWHJL/8zJ7iO6/MlthW2vCz3Z07R54fTYSM/8TD+DTuSe2wbhoiGoFKRH1/6Z469IBtbbgbGui1dn1OBkah0evLjD6LxD8WSkYDWFIJfTHOyD2/CVPj5Udo6ikqFLS8TY0xLcuN2odab0IfXpyDpKGqDv+v1/Gy0AWFYMhJQafWuz6vjOzDFtqIg5QSg4BfViILk46gNJlRaA/lJh/Gv3578xEOoNDpM9dtiTolDpdO713F9TiWgMfhjt+TjtFkwNWiPxi+grNNf5WrkbiQzO5vgwABMJiPgyk2QkppOaloGzZo0AKBBPdc8IYQQQghRcdVxn5Wbm+cOYqk1Ggx6HQVmC3abzb2MVqtFp9OSX1CAw17cLUyn06HVasjLL8Dp0fVMb9CjUavJPa1bo8FgQKVSyDstkbjR6IfD4aSgoMBrviongT1zJmNxKGhModhy02h6w0xOfvEwNgeE9LqOpDVfuZYF9GonVgfYnMXJodQKRHcfSfx/P2L3+Hk3pGlXbMmHyM1Mp96Y6aj0/uhDYwiMboxGoya/wFzhOiX8/iFH//jMe77KiRM4uOzd4plLZuKndmJ3Qq5Nxex9MTQ0mjGkpZAYUsDxFe9jdSocXPaO67iEN8CZfhSrAxrd/DYH5t0HgH+dxtiTDxHc+3ri//4CFIWIbleRvuFb6nQfxan1P+IAInuPJ2nNV4Q07ohiySE97iARfa4j6d8vQVEIjm2B+dQeIoY/yvEfZgIQM+gOUv+YS0CjTqQc2gpAs1ve4sC8+zConKj9w8jNSiOq7wQS//kCjTGYyBZdSdn2KyG9ryfxny8AaDHpHY5/ejc2B+jqtiE3bjd1h0whfuX76NVOQvtM5ORfCwluO5CMnb+jVqDxyPs4/ONb6KNbYs1OwZqdQqMR95Ow4g3MdgVNcDSWjHgajX+euEWPo1FB2KC7ifvlPYzRzfFv3IWMtV8Q0WkoJzf9AkDDq5/k6LfP4R8cjgJkZ6QQWXgMNH5BRLTsRtq2XwnqWXwthXYcSv6OFYT1Hk/c3678ZZG9x5G8ZhGh9VuQdWIvVqdC3cvv5uQv75Z57elUTiwOxeva0yhOtCow2xU8O1lqFScaFRTYFTxbIuhUTtQKOEMaUZBytPiaVDlRgAKHdzK0omvP7FBQ1DqcdourDi26knFgAxaHQljXUaRu/IGIriPJ2fIDNgfEjHmCY0teQB9WD3tOKlpbrvs86YLrYMlIQK1Au7s+YMd7d2B3QvPb3mf/R1PQajQERDUg4+QhwouuMSCm91jS13+LqcMVpGx2db2N6HUtmesXoVYg3+4qe+v7vkAXFIHBYODwgkdI2rOO0E5XENSiN0HNenBiwYPkHNtB2KApnFo5x3WN3fkhxz+cjN0JmjqtyDu1132eDGonoX2u5+RfXxDSbiANRj+GSq3Cz2DAYrFitVqLz1Mt+9wzmYzY7HbMBWb3PEWlwuhnwGq1YbFY3PNrQ532vHsb5jRXN2nPay+wWU+yDqwjoufV5Gz4BrsTIgbdxcmV77vqBBjUToI6XEHC5hX4N+hIzrGtqICWE59j/8InUAKicNpt2HLTqHvZzaT9Na/U91P9W95j30d3u45h3VZYTu2m4Yj7OfjjWziB2GH3E7fiTUIbtSP/+Hby7Qoxg27n1G8fuoLgucnYspIJ7DXB9flgDEKlM6LKOkWjia+w57PHAIgZcienVs4hvGFrso7vwuJQaHbr2xz45F4UIDA8mrzUU1g9PgvqXX4XKb+9iza6FVlxrq7pTW96nSOfPVilnxFF7yf3+avAZ4Snov9PlsL5fpGNaTnlw2q99oruZ4rUSEus9IwsJt45neVfuf5hz3znU5o2qsfBIydo0rAeV40YSHpGFjdMmc6yL98tsc1vf/iVxT/+CrjyOxw7EV/rfyEUQgghhKhq5+o+y9PIof2ZMfV2Xpz9IT/+vNo9f9LEMdx2w1gemPGKV/eu6Q9MYtSwy5hw+zSvXE+zX3iUnl3bM3DMbeTlFX9BWzj3ZaIiQhl01R1e+/1tyQckJqdx/eTH3POMRgPfPDOOnz54mXcPRLvn1wsz8VijHfybHMAXxyLc81sF5nFP8wSWnwzhp/gQ9/ze4Vnc0a8OH/yVwJqU4pYdV0SnM7xuOu/sr8OerOKb6PuvvYTWiT/w4oFmHDtVPCJgaXVaMOclEuaO5+EtjbzqNKvTEdItGl7YVc89z6By8Frno+zO9POqUx2DhZeG+PPrtpMVrtP1DVNYeCyKNcnF3RCviE5nRINc3t4d6lWnCQ2S6RORzXM7Y0ko0Lnn390sntZB+Ty8rQn51uKvDY+3OUGIznZWdaoXbuKxhqWfp5/T6vPj4eL7e9d5iuaDv+K9ztOVLdQMCThQ4jwV1emFfU04lV1c9qI6PbS5IQWO4uwqZ1Kn/ZYo3txefHzrGCw82TauUtfe9Q1TWHg0vELXXnnnqSrqdPp5ivaz8kSbE6XW6aeECJbHFbfE6B2exSOTr2Xm3K8rVKeJzbLpFZTM87vqEZ+vLbdOb0+5FPO6eRWqk59ey6x2+3y+n55sG8f63Lp8tqe4BVbn5jG8+/arfPT5Yj5esNQ9v7Z97v2+9CPWbdzO1Mdfdc9vVL8uX3z4Cj+s+JOX3vjYPb9Hl3a88eK0WlMnn9ee2sFrnXx/7pX2fnpqXCc+X7au1ryf1O2uYupnW4rrVMZn+YX2GVHd197aXxZ4la1GglgOh4NLR93KT4vew99k5L7HXuaa0UM4dPgEmdnZ3D95Itt27Wf2e5/x6bvPl7n986WZuxBCCCFEVTtX91k/f/1erW2JZT70L4e+etr9qzBAnUsmkrnmc2wOvH7pLqs1jCkojNzM1FJ/6XaqNDgdrvoW/dKtimpBs0nFgcDT62TLz2LnrLGEN+tKzqENZ/xLN7haJATHNCIn/nCpdQrrM5HEfxa666RTObGqdNgKfwFXGwJRzJno9HoKCiw4AK1/GNacVK9f7xWNAYfNdZyLfr3XNb+UzD2uLxvGmJbYE/Z4/Xpfp/9NJKye71UnldaIw5rnVSdVWGMKkl2J76P730jGP/O9zpN//XbkHd+BXu1ECYohL604iKpWILRpJ9IObvE6T4F1W2BN2OvVIiGyz3Wkr/kCjQrU0a3JiXMlktcGRqLkJHq1SAhqeQmZe//2apGg0vrhsOZ7nSeC62FOi/M6Tyr/CHIzCwOZigrF6cCgdrrr5F+/PTnHt5+zllhV3coCilvDlPZ+smuMWMzF71e1Ag2HTuboz3OxOyF22H3ErXjLq054XBt6gxGVNfes6tTxyV/Z+8IgnIA6qgV58fsBqH/lNJKXvexVJ5XOiNOSh0HtRPGPIC+zOBCtAnq9/K+0xKriOm19bnDx/Cq69up0HkzSlpU18n4yK3p368WiOkVccj0nVn9Rap2KWneW9346Hz8jOj39+zltiXVOoz4Lv1lORHgIQy7rTa9uHdiyYy+d2rXkxMl4OrdvRZ2IMF564yPsdgdbtu+hd/eO57J4QgghhBDnreq8zzKZjCV+LDTodaDXlVjWz2DwuQ2jn+/5p9+cljVfrVZKzDfjusn3UxffrhvUDjIBjQo0lPy9VqsC7Wnzrdkp6EoZ8kivdqI26LEXWL3mGzQKqb+9i9pgwli3Ffu+fJxW935O9r5/yU84SHDbAfipneQe3oByWhmLKPief3qdAMwpx8usk0HjLLGOTgXawnlqjQO7FRRFhb5wns5PhyXf89g5UWmcOJze2zFqwVK4jp9WIa/w+0vR/vw89l1UJ5UWHI7i7agV8DNoUQqXKyqDZ538dBrshfO1qpL1UVQadCrveVq1gtVjewBGvYbswvNp0Ko9tmnHqgCK4t62QWVz162oTqeXXQH0ageq08qjVnmeJ7t7flGdjPri+rj2X/LaA0rUqYjex7UBrvPki69rqbT5lbn2oIz3kxrUpy/vdLrr5KdTeW1Pr3aCIxfUReWw4TzLOtlObEFRCuukVXC6r1VViTqptSrshdEAtdPmmq9Sg8N1/iyZyZxa+R5R/W5w51sqUt7n3smVcyhIOkrj618Cqu9zD0CjVqPxMV+r1bgHbPCk07kCBKc7F5/lJd7HnP21l75tZY29nwyY3ddvkZR/FuKnLrlsUZ2y133h9Xpl/j9B7f6MKLomqvvaK1JtQazk1HQeemImqemZqBSFtRu30bhBLIri+o/3wOSJPPXyu8yZ9zVTbh2HyehHsyYNuKRXF26cMoM6UWE8O/2e6ireecVms5GTk0dOXh55efnk5eWTk1s4nZ9PbuE8jUZNn55dadakofs4CyGEEOLCI/dZYE47Se6JXT5fK2oxVZWc9pLbVOmMpPy31GvenrdvcE/nHKvaUfN8lcHrdZu57NeLWk943CeqNBVLZu30DGo5HCVed9isJeYpqpJRQUVV/C2uvPrgLLkfz/WLZ5a871UUj317TLvroajA6QpaOH2VXSlZdqfT95e/spzJOucbhzmvxDynx7lL+verMtd3Wsu+bivi0OePuKfzTu71KJyPa8zjunQWBq4URYWzMAh5bMnzZB/cQNb+9bR56GsKko9jqteazH1r8Ituhi7Q1QUsc98aNKYQbLnpxP85j8bjnydxtSvvnSU9Hm1AGIn/fIEpthUBTbphTjuFIbweQoizU21BrIiwED57/8VSX4+uE8GHb/yvxPxbJozmlgmjq6tY55TD4SAnN4+cnFyyc3LJzMomMzPb9Vj0l5lFZlY2Wdk5ZGfnkpObS3ZOHjm5ueTk5JKTk0eBuXIf7LF1oxnQrxcD+/emf98eBAcHlr+SEEIIIc4bcp8Fu167BoCQDkNKvOa0VX0Qy2EvGeiwF+SUuY41M7HKy1EWh9VS9gKFARXPAE2FR2TzCEoUffH3etnH8XH9jn/aHM8R5nyuUxz08Rn/qegPtaUtV1gPz6CFZ7egMtf3EVQrtzzOksfqYhD/24fuaUt6fBlLVi9f16rn9e/rdUuG631ry8tg77u3YE47SVT/G90BKm1AOFH9JhK3/A2v9eJWvOWezovfz5HXZrifq/0Csedn0XDcM4S2H0xlOJ1OFEXB6XRiTjuJPrSuNFgQFzVJIlWOl1+fw+p/1qEoKhRFQaVSUKmKpxUUFEUhL7+AnNxccnPz3IGr3NP6NJ8JtVpNUFAAASYTJpMRo9EPo58f/iY/13Thc5PRj8ysbP78ex1Hj8Xx2ZdL+OzLJahUKrp0bMtl/Xpx6SU98fc3FgfLsl2Bsuyi6dxcLBYrDocDu92Bw+HA4fSYtjtQqVU0qFeXZk0a0rxpI5o0bkCAv6n8igghhBBCVIOC5GMl5vkKOJ01X1+G1bXrVtp3UMhzAR8tsSoYxPLMgeP0EZjx1arKnp9VYp6i8ghi+WgB5RW58nHMK8zzS75HeZ0+joHDV0sgny2xfASxyuH00WpNnDsnfnytxDyv1ny+rjGP81w0op5nazJrdkqJABaAwyMv2JEvZni9VvReOLroaZx2GyHtBpF9aAMBjTqDSoU9PxttQJh3MZxOcDrY885NGMLrow+vT+Lqz6g77B6i+k4ovdJCXOBq13/eWujAoSOs/W9L+QueRlEUAvxN+JuM+PubCPA3ERQUQFBgIEGBAa6/oAD3dGCgP/4mE/7+RgJMJgICTPibTBgM+kpH2o8cPcHvq9fw++o1/P3vf2zYvJ0Nm7fz6htzK12PioiOiqBpk4Y0a9KQpk0aotfpvLo85ublubs85ublodfr6d65PT27d6JT+zYYDBX8BVAIIYQQogKqozuhL3lxu8/JfirKYSu7JZYTj650hRRNyXwkTh/5WDxbK/lqveIzEOSDoi4OIDh8tYDy3KbP+vi4Ly6nO6FXl76illgqtbuWvsqu+NqPr4BUOd0FfR0rUbOs2cWJ3B1WV8J0zwCwOTWuxDrOct5bAFkH1lVo/8e+fY5j3z4HgErnh8YUjCU9nma3vUtAo04AJPz1OYl/LaDJDTMpSDxMQeJh9/pJ/3yFOfUk2sAIoi+72ec+nHYbDrsVtc6vQmWqiJxj29EFRaELjqqybQpxJiSIVY6np9/PA3ffisPhwBUMd+B0Ot3PHU7Xc4PBQEBhwMrf34jRz6/Gmnk2aliP2xqO47abxmG1Wvlv03b+/Gst/67fBE4nAf7++Psb8fcIlhUFzwwGPSqVCpVKhVqtQqWoUFQKarUalUrBYrZy+OhxDhw+ysFDxzhw6CjxicnEJybz95oNFS7jipWrAFeSt84d2tCzWyd6du9Ejy4dCQkJqtA2rFYrubn55OQVtnzLdeUNy83Nd3fhzMrKdj1m57j/srNzyc3Lo0/PLjx0722EhgSfwVEWQgghRG1Vbq6lC1S5X7QLgzCeAZrsgz7u33wEZrxavPkI5qRt+alCZfRuieWrvB7dCX2cx4rfX3ss59mKzEdeMIevXGI+9uOzG2V5La2kJZYog8OSj8XiasF14KO7MdZtRViX4Zz65X0A4n//2L2sotHhtFmw5WW4c/FFX3YzloxEtIERpG37heS139D05jfY++5NWDIS6fi/PyveZbgMBclH2f/BnQB0fmENTofDZ847cfFR1CUTtlc3CWKVo35sTE0X4axotVr69OxCn55dqm0fqWnpHDh0lAOHjnL4yHEcDoe7q6O/yRXQM5mMmArnpWdksn7DVtZt2MKmrTtZt2Er6zZshffmAdCkUX30Oh1Wmw2bzY7Nbsdus2Gz213PbTYKzGYslrPrKrB1+24+/+o7Hr73Nu645TppESaEEEKcj3wEXCSIVcrrPrrSVZQ1M8k9bU49Uen1i3h2wXRYCkq87tVoqpyWWmVx+upC6LEDRfFMMF8yOKXSlmyh5rPVVTktrfJO7S3zdSE85Z3cQ97JPe7nuSd2uqcVtQanzeIVTM3ct5ZDnz1ERO9rSV7zNeDq+liU18ualUxewkECGnZEYwoudb8OmxWnw4Za54fdnIta750uJjeuuEzxf3xCwqpPaT11EfqQ6LOqrzj/qXRljyRYHSSIJc5aWGgIYaEh9OzWqcLrDB3UH4CCAjNbd+xm3X9bWLthC+s3bOXQkePlrq/RaAgOCizsrmnEZDS6AmUmIwFFj/7+BAb6E+BvIjAwwPUY4E9ggD8Oh4O35sznu2UreeqF2Xw4fxFPTbuXsVcORXWOf1VwOp1YrTbyCwrIzy+goMBMXn5+4WMBdrvd3TquKCebSvGYVqsICQ4iPCwEo1/VNRn2LF9uXj7pGZmkpWeQkZHlnk7PyCp8zCQ7OxeL1YrFYsFisWG1Wl3PzRbXo9WK3WbH7nBgLwxI2h0OHHY7drsDm91GWGgILZo1pkWzxrRs3piWzZvSsnljaS0nhBCiUsrNDXWByjqwvmIL+sj35P169fUm8MxH5LsLYtktsSpcNh9dCF2z7SW34yvfmY9RG33lAvPZikuIKuKwFOfZcgepPa7tQ589BOAOYAEkrf3GPb3r9Wu9thfVbyJqgz+mem3QmEI48cNM6g69l0OfP4wtN4MG1zzFsW+eBXAHxkwN2mOMbu7eRvzvHwGQsn4J/o0641enCbacNNK2/0bM4DtwWPKx52ejC61L3sm9GCIbVs3BELWSqgq7rFaUBLGqgNNuq3WJPc8XBoPe1ZWwWycewDWi48l41y8HGrUajUaNRq1BrSme1mjUVRJo+nTOTP7bNJEnn3ud9Ru3cvu903n3w8957okHuaR3twpvx+FwkJWdQ0ZmFhmZrhEnMzKyCp9nkZWd4xqBsnBEyqzsHDIzs93dG3Pz8rH7+AXwTJiMfoSFhRAeGkJEeChhYSFEhIXi5+dX2AXW6cpz4XQFp4r+rDYbWVk5p42cWTxtq4ZRnjwVdVdNSEwmITGZ1f9434RHhIfSolljmjRqQGhIECHBQQQHBxISHOTx53ru53fufw0QQghRg3x1+7pIW2L54tU6yx3MKSePUwXzW50Jr5ZYvgJA5eSY8pkTywevrn9eyeKLRyd0v+zjejGnlPxR1Z6fXWJeRXOBCXG2Kvq55jDnlvpa4l8LSszbN+c293RRAAuKA2O5x7aTe2x7ifWyj24l8e+FXvOs2Smkb1sJQP0x0zm+9CUMUU0qVG5xflJppSXWeSd1ywpO/DCLkHaDqD/mMRnu9CypVCrq1T13zVK7d+nAz0s/5ccVv/O/F99k6/bdjLz2NoYO7s99d96MzWYjJTWN5JQ0klPTSElxTaekppOckkZaegZZ2Tk4ziLfgZ/BgCHAH6OfAYNBj5+fH34GPX5+BvwMetQajSsA5XDgcDjdo0YWTdtsNtIzMklOSSctPYPcE6c4fuJUlR0jg17vDhyFhgQRXPjoeh5MSHAgocHBBASY0Ol06HU6tDotOq0GnU6LVqt1zdNqUKvVqNVqNIWParXKPdonuLqm7jtwhH0HDrF3/2H27j/EvgOHSUhMJjkljX/Wbiy3vEFBAdSrG0O92Gjqx7oe69WNoUE913RoSHCteJ86nU6ysnNIT3e1aktzP7qmM7Oyyc3Ncw2MkJtPbtEgCYUDJlisVkJDgokIDyUqMpyI8DAiI8KICA8lMiKMqIhwoiJdf+e6daEQQtQ0CWKVojCYY8tJq7Ei5J3c5572GQAqbwRAX0ncfS3nEbjyDGj56lJ5VgMBnMGIhUJcCPJO7CoxryiABXB86UsAFCQeOmdlEuee5MQ6jzidTuL/+JiEPz4BIHXTj+iCIokeOKmGSyYqS1EURl0xiKGD+jNvwTe8MnsuP/+6mp9/XV2h9U1GP4KDAgkKCiQ4KJDg4ECCgwJc00GBhaNPFo5CGeDq4hgUGEBQQAABASbUHqP0nC273V4Y0HIF2lLTXMG2ArMZRVHcfyqPaUVR0GjUxaNmBgYQVFTuAP9zmissLDSE3j1C6N2js9f8jIws9h08zLHjJ0nPyCQjM4v0wm6NGRmZpBe2fEtLzyAlNZ3MzH3s3L3P5z50Oq373BSdH9d0AEHBrnmhIcGEhQYTGlz4GBpMUGBAucEvz66hiUkpxCckcTI+kfiEJOITkjhV+BifkERKavpZt3BLTklj34HDZS6j02mJjYkuDOZFU79eDPViY6gfG0PdmChMRj+0Gi1anQadVotGo6kVQT4hhDgb2YcqPtiMOLc882mdSYuvCv+P8pEHq8R89ywZQVAIIc5ETXxvkCDWGXDYLBxf+jJpW39GUWuJumQCiX9/QfwfH6MPr0dohyE1XURxBnQ6LZNvncD4q0fy1vuf8s/ajYSEBBERFkpEeCjh4aFEhIUSHhbing4NCUanO/fR59Ko1WrCw0IJDwut6aJUqeDgQHp07UiPrh3LXbagwEzcqXhOxMVz/MQpTpyM53jcKU7EneJEXDwJSSkkJaeSlJxaqTKo1WpCQ1ytz1QqBbPZlf/LbLFgtrhyf5ktFu9hvMug1+uICIsgJCTYvd2ix5CQIIKDAgnwNxUPjFA4OILJ6Hqu0ahJTcsgOTmVpJRUkpPTSEpJJTEpheSUNJKSU4lPSCLuVDyHjx7n8NHyc80V0WpdAS2tVkvvnl149bnHiI2pU6njdT5xOp38vWYDySmpriCvSoXikXfONU/B32SiVYsmhIWG1HSRhRCeKvi5K2ofX90Jq+psev4/9pXY3XPfEsQSQojzhwSxKsmWl8XhL6aTc2QLar9Amkx8Gf+GHdGH1+fYt89xbMmL6EKi8a/frqaLKs5QUGAAT067t6aLIc6QwaCnaeOGNG3c0OfrRYnqMzOz3XnLMrOKpzMyskhPzyA1PYPUtMLufWmu6eTC7qS+aDQajH4GdDodBr2OyMhwoutEElMnkujCv7rRUe7pwAD/s/7lwmQ0ljuCqsPhICExmRMnCwN7HgG9U/GJFBQm3rdarVgsrkerzUZuXj6Qz0+//Mk/azfy0v8eYcI1oy6oVlp2u53vlq3ktbc/ZvfeAxVer05UBK1bNqV1y2buv5bNGssIp0LUkPz4/ZVfSaUud1Q5Uf08k1YX8dVFyVPGrlUl5vkMQnnM89XdxWHOK16/nFEdhRBC+JafcPCc71OxWMzn9c9XNpuNS4bfzN/LP0Wjqd6YnDk1joOfPYw55Tj6sFia3DgLQ3h99+unfp1Lwqr5aEzBtJjysQw5KsQFJi8/n9S0DAD0Oh06ndb9WJXdQmsDp9NJRkYW05+ZyVff/gjA0MH9eePlJ6kTFVHDpTs7VquVRUuW88a7n3Dw8DEAmjZuQJ+eXXE6i/POOZ145aNLy8hg996DJCQml9imWq2mQb26mEx+aDQatBoNGo1rIAqtRoNG65qn1WrceeJ0Oi06na4wf1zhc63WlcNMwavLr4KCorjyBtrsdgoKzBQUmDGbzeQXmDGbLRSYXfPAFcw1+hnw8zNg9PNz5djzM2A0uB5DgoMKc6i58qjVphalReJOJZCRkVVcD6MfRj8DWm3JshYUmAu7GRd3L3ZNZ9K1U7tKjZ4rvJ3L+6zK2vx470qvo2h0OG0WFLX2oh3BUAghhKhKnV9Yc073V7vuRmqxnOM7OPz5NGx5GZgatKfJ9S+jMQV7LRM98HYKUk6QsfMPDn32MC0mz0Vt8K+ZAgshqpzRzw9j3XM/jGxNUBSFkJAg5rzxPKOuGMQD057l519X02vDVmY+P52xVw4971plFRSYWbDoO958/1NOxLkGP2jTqjkP3TuJK4cPrnAgMjUtnV17DrB77wH34559ByvVZbO2CQ4KdAe1IiNCiSwcGKBokIDISNdjeFhItQcyjsed4oWZ7/L1kuU+u+cWtXr08zOgUhQyMrPJLygodXsP33e7BLFESSoVSEMsIYQQ4rwjQawKSN/xB0e/fRanzUJI+0E0uOpxVNqS3UYUlYqGVz/J/owE8uJ2c+SrJ2lyw0yvoYSFEOJ8c8WQS+nZrSOPPPESi7//mdvueYwfV/zOay/OqJL8a06ns0oDYna7nezsXDKyXF1FMzOz2bp9N+9++DmJSSkAdOnYlofvv52hg/pXet9hoSH069Odfn26u+c5HA7iE5Ixm83Y7HasVhtWmw27zfVotdqwFT5arK58ahaLtXC68LGwa6fD4cTp9PjDCU7crcQ0Gg0Ggx69XoefwVD4qEev12PQu/435RcUkJ9fQEGBmbz8fPLzC8jLLyC/oIC8PFeLQlcutVSSUtLc3Wn3HzxSZt0VRSE8LISoyAjatm5Ot87t6dKpHW1aNvXZQqoyMjKyeP2dj5k77wvMZgv+JiNtWjV3l99dh/wCsrJzyMrOAVyt04pGSg0Jdo2cWjTIRkhwEH16dTmrcokLk6Koqiz3khBCCCHOHelOWAan00ni3ws59ct7AET1v5GYQXeglDNcvTU7lb3v34Y1M5GIHmOpN+qhKi2XEELUlO+WreShGS+SmpZOeFgI0x+6i9CQIFcXPEdRV7zCR4cDp8NJVk4O6emZpKVnkJ7hGkUyLT2T9MJHs8VCYIA/wcHFo0V6PgYEmLDZ7IVBmQLyC8yuIE2B2fU8v4DsnDwyMrPIysp2Bzd86dOzK4/cfzv9+/Y471qSVaeCAjMpaenugQKKBghILBwIITE5haTC6eyc3BLr+xkMdGzfiq6d2tO1Uzu6dm5P3ZioCu/7w/lf8dpbH5GRmYVareaWiVfz6AOTiYwI87mOw+Egv6AAm81OgL/J1QVTVIsLrjthYTdCld6Ew1zyWhZCCCFE5Uh3wlqmIOkIqNTUv/JRwruOrNA62oAwmtw4k/1z7yR5/WL0EfWJ7HVNNZdUCCGq3+gRQ+jdowtTH3uO5b/8yUMzXjir7alUKnRarbslUFUI8DcRFBhAYGAAQUEBBAUGEBEWyoRrR9Gre+cq2ceFxmDQExtTp0KjUObm5XHyVCKbt+5k05YdbNiyg52797P2vy2s/W+Le7nQkGBaNG9Mi6aNaNGsCS2auR5joiNRFAWHw8G3363guVffcXfvHDlsIE89dh/NmjQsswwqlQqT0XhWdRYXt/J+kBRCCCFE7SQtscrhsFnJP7UPU/22lV43c++/HFowDYAGV01HH1oXh92G02bBabfisFlx2q047TbXo8MODgdOp7142mHH6XBA4Tyn0wkOu2uo4MLXcboSD2uMgUT2vQ6t/9l37xFCiLI4nU6+W7aS31b9i4KCSqVCrVahUqlQKQqKqnBapeBvMhESHERoSJC721doSDChIcEEBvqjUqkwmy1kZWeTkZlNZmaW6zHL9ZidnYNG68qDZDAYCh/1+BUmKTcY9AT6+7tbbdW21iIXg/z8Arbt3MOGzdvZtGUnGzdvJ+5Ugs9lA/xNNGvSkIICM7v3uUa06dG1I88+MZUeXTuew1KLiqitLbGsOWnseGlEpddT1BqcdhtqYxD2vMxqKJkQQghxcTnXLbEkiFXNktYsIm75m+dsfxpjMPWufISQtpeds30KIYQQp8vMyubAwSPsPXCY/QeOsO/gYfYdOMyx4yfdCdubNm7A09PvZ8TQAdK9s5aq6fssp8NBzrFtGOu2RK3zw2m3kZ94mL3v3lzhbXh1HVSpwWFHYwrGlptRLWUWQgghLibSnfACE9HrWgAy965BUWtQ1FpUGi2KuvBPo0Wl1oJag6JSu/4UFajUKCoVikoDKhWKokJRqV3zFQUU1+uer6Xv+J2MXas48uXjZHQYQr0RD6IxBtbwERBCCHExCgoMoGvn9nTt3N5rfn5+AQePHCMtPYPe3TufdUJ4cWHLPvQfBz99kKj+N2JOO0nGrlWVTtGgKB5dB4tGvFQqNhqpEEIIIWoXCWJVM0VRiOw9jsje46p9X8FtB5C+/VdO/Pga6dtWknN4M/XHPEZQi8onPhVCCCGqg5+fgXatW9R0McR5wpKRCIAtN4OMHb8DkHt8R+U24tnKz+konFU8L7zbaFI2fHdW5RRCCCHEuSFZLS8giqIQ2mEIre5bQGCL3lizUzj02cMcW/IS9gIZgUcIIYQQ5xe7Jb9wyiP7hapyrai8WmL52oZHQEvR6iu2TbW0IBRCCCFqggSxLkC6wAia3DCT+mNmoNIbSd30I3venkj2oY01XbQyOZ1Okv/7jt1vTOD49zPJObrVldReCCGEEBclh7kwiOURw/IZlCqLj3xrnqMTem5PpdZVbttnSWMKPqf7E0IIIc530p3wAqUoCuFdRxDQpAvHl7xI9uFNHPjkPtQG/8KEus7CG0InOJ04Cx9VOj+0AWGFf+ElpnXB0eiCo6q8vA6rmRM/zCJ183IACpKPkvLfUnTBUYS0H0JohyH41WlS5fsVQgghRO1lt+QVThVHsZRKtsTCV9DLM7Cl8miJpSnZwiqgaTeyD24off2zYKrXlsy9/1TJtoQQQoiLgQSxLnD6kGia3vImyeuXEP/bB9gLckoupCjuGzx7Xib2vEwKEg+Xus3gNpdSd+g96ENjqqSMlowEDn8xg7yTe1Eb/Ikd+SDWzCTStv5CQdIREv/6nMS/PscQ1YTQDoMJaT8YfUh0qdtzOuw4HXZ38lan01E4XRy4czqdqA3+MhqWEEIIUYs5zIVBLKdnd8LKtcTy9b9e8UrsXvy6ykcQi+ocx1vuQ4QQQohKkSDWRUBRqYjsdTURPa7CdSemgKL4vKlzWAqwZqdgzU4t/CuetuWkkntiNxm7VpG5bw1Rfa8jqt8NqPXGMy5b9uFNHPnySWx5GRiiGtP4+pcxhMUCENXvBvITD5G+9RfStv9GQeIhTq08xKmVc9AGRYLDgdNuw+mwuQJXhdNeN7plUOlNGKOb4RfTHGN0c/ximuMX0RBFXfG3hdPhwGm34rCZcdqsOGwWnDYLDrsVp9VSWB6Hq/WbO5DmLIyluZ4riso1cqVK49q3Su31XK03ofYLkICbEEKIi46jMCeW07MlVmXzUfkKennmwfJoqVXhbVfwXqN88r9dCCGEqAwJYl1ElAr8cqnSGdCHxaIvDCSdzpaXSfxvH5G84TsSVs0nddNyYobeRWj7IRXafhGn00nSv19x8pf3wGEnuN1AGoyZ7hUQUxQFY52mGIc2JWbIFHKObSN920rSd/6BNTPptMopKCoNKo2+OBBUGKxz3ah6BO1UKnA4sOakknN0KzlHtxZvRqPDL7IxfjHN0IfEYDfnYS/IwV6QjT0/B7s5x/VYkIOtIBun1VzhOp8NRa1FGxCKxr+we2fho6awq6dfnSbogutIoEsIIcQFpSixuzk1zj2v8j+e+WqJpfJ8Ujxd2a6KZ8nz3slUvy25x3ee0/0LIYQQ5xsJYolK0RiDqDfqIcJ7jCZu+ZtkH9rIsW+eJWXdYmKHT8VUr3W527Bb8jm+9CXSt/8Gioq6Q+8hsu91ZQZgFJWKgEadCGjUiXojH8JuyXO3VFJU6srnxwDs5jzyEw6Sd2o/+fH7yTu1n4Kkw+Sd2kveqb3lb0ClRqU3odLoUGl1KGodikaLSqND0ehcjypNyUBa4bT7prmw+6O7VZnd5jVtN+dizU7FkpHoHmrcF40xGGPdlhhjW2Gs2wpTbCu0AWGVPi6i5jmsZsxpJ7EX5OKw5GIvyMNuzsVhdj26pvNx2C04bdbC1oAWnHarq0Wg3YrTZkFjDCa001BC2lyGSmeo6WoJIUSZLBkJpO/4ncje49ytoh2FObFsOWlnvF2f9xeqUoJYPvlodVUdPxpVNmG9EEIIcRGSIJY4I35RTWh6y5tk7vmbuBVvkXtiF/vm3EZop2EEt+5PUf6pooTx7ucOGwmrP6cg8RBqYxCNxj9HYJOuldq3otag8Qs86zqo9Ub8G7THv0F79zyHzUpB0hHyEw5gyUxGbfBH7eePxhDgnlYXTqt0fues5ZPT4cCen4U1JxVrdhrW7BRsOa5HS2YSeaf2YUk7RdaBdWQdWOdeTxsYgbFuK/Th9VzdEg0mVz2KpvX+qA0mVFoDTqezuPtjUWDNYS8OsrmDJa5Hp70oWFL43GEv3KtHqzePgJ1CUUoyV44yVxdLh8fAAg50wdEENu2G2uB/To5rbWHNSSP3+A5yju0g9/h28k7uw2m3Vsm2sw9tIG7ZbEI6DCG860iMMS2qZLtCCFHVTiybTeaevzFENiKoRW+gOCeW0+kxWnFlu/L5CA555cSqsq6BZ8CrW6O0phZCCCHKI0EsccYURSG4dT8Cm/ckac0iEv6cT9qWFaRtWVHuusaYljSa8EKZCdprgkqjxRjTHGNM85ouihdFpUJjCkZjCsYvyvcojba8TPJO7iU3bg95J/eQd3Iv1qxkMrOSz3Fpz5JKjX/9tgQ270Vg81741Wla7o29LS+LguRjmNPiMEQ0wFi3Va3+MmBOjyf7wHpyju8k9/h2r24y4Oo+aoxpidoYiFpvRK03oTKYUOuMrqCjzohK7+dq7afWodJoUTQ6FLUGVWGLQEWjI//UflI2/kD2oQ2krF9CyvolGGNaEtZtFKHtB6M2mGroCNQuTruNnOM7cJjzUOmNqAuPb9GjSuvn7vLjdDhwWIq6Gee6uhoX5GIvyMFhs2CIbIgxujkqrb6Ga1W72S35mFNOYMvLxFY4oIgtLwt7flbxvPwsFI0OjTEIjTEItTEIjTEQjTG48Lnr/eGVj7Dwz+nx3BjTAlO9NjVdZVEOh81K9qGNrmlLAQl/fY4uONrdndCzMVRlQ06KSkX90dNQ6fxI+PNTCpKPYoxpTn7CAdf23D/C4EpFcE4ppUy7qI1B2PMyz11xhBBCiFpOgljirKk0Our0u4GwjsNI/PcrrNkphQEEz65zuHNU6UKiieo7Qb7kVTGNMYjAZj0IbNbDPc+SlewOZrm/dJtz3dMOc67r0ZrvyiOmqFzdNFVqUBc9V4NK5QqOqDWFXSW1KOrCP40WlVpbnEeklAT2OJ2gqIq7VBZNUzw6Zn78frIPbSTn6DZyjm5zJfEPCCeweU8Cm/fEL6ox5tSTFKQccwWtUo5TkHwMW26G17EwRDUmrMsIQjtejtYUcg6OfsXY8rOI//1jktcvAY8vTRpTMKb67fFv0A5T/fYY67ZApdGd9f4MYbGEtBuAOT2e1E3LSN20zNVd9vu9nPzpLYLbXoYhokFhK8MANH4BqA2BrhaHfgFoDAGVGujgfOKwmsk6sJ6M3avJ3PMP9oLsMpdX6fxAUbm6NpXXakOlxi+ysbt7r6luKwxRjX2PenaBczocmNNPUZBwiPyEg+Qnuh7NaSfPWeuXOpfeJEGs80Du8e3uJO62/CxO/fI++tC6xS2wPFtiVZbTSXi3KwHwb9iRtC0riOg5ltTNy10v221nVfaz4vmDi48fX3RBkeRLEEsIIYRwuzC/nYgaoQ0MJ3bYPTVdDOFBFxiBLjCipotRKQ6rmZxj28jav5bM/eswJx9zB2BKow0IRx9RH31wNNmHN1GQeJiTP73FyZ/fJbjVJYR1Hk5gsx41FpBxOuykbvyRU79+gC0vA0WtJbTzUPwbdcJUvx36sNhqbTmmD4kmZtDtRF92C1kH1pOy8Qcy962pUKtJjSkYfWhd9GGx6Aofi55rjMHucjudTpxWsytAas5xt04q/vNuteT553TYXa1tTMFoTCGuR8/n/iHogqLQ+AWc1XGwF+SSuX8NGbtWkbV/nfsLM4CpXht0wXWwm/NwWPKxW/JxuKddjzidqHR+hd1xC7sXF3bJVRv8QVGRn3iIvFP7yE84QH7CAVI3/QgUDhpRpynG6ObuY6gLq4s+JOasRnitTk6n09WN2ceItbacdK/uXV5Xr6KA04k5I4GCxMNex7mISm/CL7IhGv/Q4lZWfgEeLa6C0PgF4rBZPFpqFbbWysvElpeBLS8LhyUPRaMvzEVYlJPQ+7l/ww7Vf7DEWcvaX9wV3l6QA+Ae6Rdc16NbJQOgniMb6oIiqXPpTQBoTCHYctO9W19X9LPYVxkKr/3KKPHeKbGA5MkSQgghPEkQSwhRq6i0egKbdiewaXdir7gfc9opd0DLkpGAIbwe+vD6GCIaYAhvgCGivlcOLafDQc6RzaRsWkbGrlXuP21AOKGdhhLWeTiGiAbnrD45R7dyYtkb5MfvByCoZV/qXnEfhlJGAK1OilpDUMs+BLXsgzUrhcx9/2LLzcCWn104Aqfrz1aQUzydm4EtN4PcE7tKbE+lN6IxBeMoyMNuzqn21gxqQwC60Bj0IdHoQmLQh8a4HkOiUdQa7PmuUUPt+dmuAJm7XjmY00+RfWhjca4xlZqAxl0IbnMpQa36oQsqO9jrdDjA6ahQINRpt1GQfMyja+8e1yAScbvJi9tdYnmNfyj60BhXYCukLhpTkCtIVvRXFDQz+KPWG6ssGFsUpDKnnsScFlf46PqzZiZgzU47+9xsigpDREP86jTBENUEvzpNZTRV4VOmRxCrKA8WDgf2wsTuXi2xqujaaT31SyxppzBENOT4d69gatABe35WyQUrHJhyZ3+sOM+cWD5HUZT3iRBCCOFJglhCiFpNHxpDRM+xRPQcW6HlFZWKgCZdCWjSFVt+NunbfyN183Ly4naT+NcCEv9agDG2NWGdhhHSbiAaU3C1lNuSkcjJX951jcIJGCIaEjv8fq/unjVJGxju7l5TFrs51yO4EecOeFjSTmLJTMJS+GVTUWvRmIK9gy+nB2BKtF4KcOXlUqmx52Vizc3AlpvuanFTNJ2bgS0nDUtGItbsFPJP7SP/1L4zqrOi1hLYog8hbfoT1LJvpc69KydWxVpEKGoNfnWa4FenCXQdAYDDZqEg8TD5iYe8gkXmtJPYctKw5aSRe3xnhetRNDIrhaOzev6hUhe+XjiCa9F04XwUlWtQiLST7hYvpdVDGxSFNiCs8C/cPa3xD3WNvgp4JysqntYGhGGIbCRdx0W5LJnJFCQecj8vClwVjbQKeAeSKtsVtZTFNX6BaOq6Borp+MwqFLWWPW9NrNy2PSlK5RN2UXZ3QmmJJYQQQniTIJYQ4oKl8QsgoscYInqMIT/xEKmblpO29Rd3i5gTy98gqHkvQjsNI6hln7POQ+WwFJCfdITMff+S+PdCnFYzaoM/0QMmEdFz7HmZX0qtN5U62IHDasZuznUlnj/bQEUFBnlwWM2Y0+OxpJ10Paafwpx2Ckt6PE6nozCnlyufl7pw2jUvAI0pGP8GHWosmb1Ko3PlyKrbssRr9oIcd0DLkh5f2DKu9K6YTpvZZxe9M6ENinR1Dy380xVNh0Sj9gt0J7QXojplHVjv9byoJZbDnOue55l8vfLXf/mRpbI+/52+1vcRcFJUaq9yVkg5ObGkJZYQQgjh7fz7RiWEEGfAL6oJsVfcR93L7yLr4AbStq4gY/dfZO79h8y9/6A2BBDSbgAhHYagC66DSqtHpTWg0updrVs8OO02zGlx5CccJr+wdU1B4mHMaXHFLQQUhbCuo4gZMrlWJZevSq5jdO5a2ai0evwiG+IX2fCc7fNcUBv8Mca0wBjTolLrOR0O1xdmhx2n047TUfhnt7n+iqYdNnDPc83X+IehD4mWVlKiVsg64OpKqDb4F+bVcwWxvLooe7S+chR1MayoyrTcOougkaKoKt8Qy3sLJeaoamnOPCGEEKKmVFsQ67uf/uCb71fibzLy3PS7iYwIc7+2buN2Zr//OVqthsk3Xc0lvboA8O0Pv/Ll4p/QaDRMf2ASHduV/MVaCCHOhqLWENSiF0EtemEvyCV955+kbf3ZlUdrw/ekbPjexzra4oCWRoc1O6W4i4sHld6IX1Rj/KKaEN5tNMa6lQtKCFEZikpV2FLq4hv1UFw491lOu43sgxtAUQho0pWMXat8trTyHEigKMhVib2cZSkr6Ay6/nm2tPKcbnn3p9gLssk5tp3sgxvQBoRjzU6pkmIKIYQQ57NqCWKlpWfy+aIfWTj3Zf5et5l3P17EM4/dBYDD4eCl2R8xd/ZTGPR6br77CTq1b4VKpeKThUv59tPXSU5J46XZHzHn9aeqo3hCCAGA2mAivOsIwruOwJweT/q2lWTuX4u9IAeHtQCHxezqumUtKOzOlQ24AmGuJNVN3EErQ1RjSVYthDgnLqT7rNy43dgLsjHWbYmmsNWqzyCVR2uq6h5EouS+K7jcGX38Kz6ni7pwm+q1ReMXSFDLvuycOeZMdiCEEEJcUKoliLV+0w6aN2mIwaCnY7uWzHx7nvu1jMxsAgJM1IkMB6B1yyZs3raHnl3bExoShE6rITamDiaTNJ8WQpw7+pBo6lx6k3vo9dM57TYcNjMOqxmNX+B5md9KCHFhuJDus8ypJ1A0OgKb9cSWlwl4jE7owbMlVmXzTlUuD/w5/iGinJxYKq3ePbBJYLOeZB1YR1jn4aRuXn6uSiiEEELUKtXyLSw1LYP6sXUACA8Nxu5wUGC2YNDrCAz0JzUtg6SUNNQqFcfj4klKSUOn0zJm+ACmPPwCrZo34upRg0vd/rc//MriH38FXEOECyFEdVPUGtRqDWp9zSQGF0KIIhfSfVZY5+GEtB2Iw27h1Mq5ANgtuSUX9GyJ5ahsS6yK16HCrWmr7LiUMzqhh8YTX8aceoKC5OMSxKpGLe78kH1zbq/pYgghhChF9Qw7pHjf9DgdTvf/ZY1azSP33sJDT8zi9fc+o3mTBvib/MjNzWP9xh3cev1oDh+LY8/+w6Vu/upRg/nyw1f58sNXWTDnpWqpghBCCCFErXSB3WepdAY0foHuII7D7GP0QY+WWFUXQKpiZ1IsrxhW2bflKo0Ov6gmBDbthuIxmmKLyR9grNuK5re/hzbA1QIvsHmvEutH9hnvsTPXvjT+xbnUIvtOKLGOf6NOFarG+SJ2+AMl5hkiG7mnW977GaZ6bdAGRpzDUpVNpSvZalIXGlNyOa2hxLzQTle4pxuMfbxqCyaEEDWkWlpiRYSFsHPPQQCSU9PRarXodcX/bAdc0p0Bl3QH4KEnZxFdJ5LVazbRplVTenXrQNeObRg36REmXD0cg/7shrwXQgghhLiQXKj3WUphRMfuY/TBs+lOePZBLx/rV1H+Q+UMui+qDf50fPoPLOmnsBfkYKzbkpZ3fQxAq/s+Jz/xMHlxe8jav9Z7X17d4F118kosf6F1k1eUEudebfDRmtozeOhwXWdtH16M0+nAabdy4KN7Ce08jLhls0vdVdQl15P498IqKXbJ8vmaVXKm0+d1Wg3lEUKIGlYtLbG6d27HgUPHKCgws2X7Xnp378jCb5az8s81ABw8fByn08nBw8dJSEqhXaumqNUqtu/ah8ViJSUtg6zsnKq6PxBCCCGEuGBcsPdZhQVyWs0lX/MMRjgcJV8vS6WCWLUrJ1apq6lU6MNiMdb1HmFSYwwioFEnfAfePG77fRwTReUjiFVbW71VgKJSl5ynLjmaq2uU1yKFwT21BpVGh1pvouXdnxDZ65oS64V1Hemejuh1LY3GP09Ak65nX/CSJfQx60yuU18510q23hJCiNquWn5yCQkO5OYJo5l0/9MEmIw89/i9fL7oR/evPT/+sppN23Zj0Ot4ZtpdqFQqBvXvxdYd+xh/26Oo1SqmT73N61dFIYQQQghxAd9nlfG9/KxaYtVqnkGsqvtt2VcuM59BKs/XfbbEOr+CWGq/AOz5rpGEfR1Pn0EsxSPYVYGgXZ0Bt6LWmwjvOorUjT+654e0G4AlM4HsQxsrX/AqoKCcZ2dLCCHOTLW1Gx55eX9GXt7f/fzBu250T0+dckOJ5dVqFdPuv7W6iiOEEEIIccG46O6zvHKAVXZ0wkp8tfcVSKvO1kie3fmqtGmcryCWjyCZxz4jeowhdeP3hPcYy6lf3nNt5Qzqrg0Ix5qdUun1qoRHcRWVBicWr5d9BbE8j0FF6qsNCCei++gzLeEZOPPrT6nEwAFCCHG+qJ7E7kIIIYQQQlRKWU2xHL6naxMfxfeVgNtrlUoGUCrMZ0us4hZHxnptXI8xLWg84SUajnsGjTGIto8spU6/iWVup/xd1+T5KS5vSPtBgHfyel+BPM95uuCocveg0urPvHgVDCSp9CWTuZ+2oSrZn888WkIIUctdYBkchRBCCCHEeamCX/Cdlc2JddZf1H2s7yu44zOvdnl18ni9mvNPqfTFSc2bTHiJlA3fE9FzLBpTcBlrnUGZajCPlmcgsN6IqQS17ENg0+5s/d9lABjC67tfV+lNOMy56ELr0njiK9jyMtH6h5a67YbX/o/0nX8S0m5QGQUou3x1+t9Iwqr5FahJOdeNtKoSQlzEJIglhBBCCCFqXEVH6nM6bJXb8Fkmdve5elUFEby2U3XBH31orHvav2FHco5uJbh1fzTGQDSmELSB4UQPnFT+hjwqH9XvBhL/+rxS65x7xftWafUEt7oEgA5PrsRhs6D1D6XprW+hC4rEabeRvG4xMYNuR2MKLjOABRDaYQihHYZUukThPa4iZf2SUl9XtPoSgxl4dy2VgJUQoupE9hlP0r9fec2L6H0tyWu+rqESVZ4EsYQQQgghRM2r6Hf16uyu5jM4VcGgjK9VqzBZe2UEt7mUeiMfwr9xZwzhDXBY8lAb/CsdhPGsed3Lp6AxBnHy53dKLKdodDhtlsJ1ai6IZYxpSc6Rzaj9Arzmqw3+FHWmDPQYQbD+lY9UzY6V0x69XjqTLqPl5EqrcBBVAmBCXCwMkY0oSDoCgKl+O3KP7/C53Omj2gKodX7FT1RqcNjRmEKw5aa7ZmkNOKwFVV/oMyRBLCGEEEIIUQvU0u6EZ9OyqLxgg1I93QkVlYqInmPdz9UG/0qtH9zmUjJ2rSKwSVfyTuzymN+fkz+/Q1CrfmTu+ctjh571qLmcWCHtBhDR8ypM9dvVWBmqhNdlUX1BQRnRUIjzVGGgyYvnjyYen8ONJ7xE7sk9RA+4FZxOFLUWc+pJApv1wJKZQPK6JUT2nVBmV+falj9PglhCCCGEEOL8UdkgyVmnxKq+oExFu1Cea42uewGn3YotN4OEVfMJ7XwFAPrQunR46ldUOiP58QfY++7NACiK6px/xQlo2o3sgxtKzA9pO+Acl6Q6VP668Pkls3ZeXkKIsxQz6HZOrZzjNU/xCGJ5fhoEt+lPcJv+XstGD7gFAFO91u7PzJZ3zcPpsHHqtw/IPrgB/4YdyNi1CoCgFn3I2PkHIe0Hkb79t6qvUCVJEEsIIYQQQtS8akpWfda/IHuM6ldp52kCbkVRUDQ6dEGRdHxmNSqN1v2aujBBvDGmOSq9EYc5D++mQ1VfHpXOiMOS511Gta7EchpjUNXvvALKDEZWwzVQ8eCnx3Ln6bUohKggj7e4LjCCvNKX9MlYtwUAjcY9S9rWXwjtNMwdxGowZjpBLfsQ3LofmXvX4LDkEd5tNCkbvquSoleWBLGEEEIIIUQtUE1fsivRHcszOND0ljexF+Sg9Q9h/4d3UXfYvZxc8Xaldu25PV1oDJa0U95F84j4VGe3sbPhGcAqoajI1ZSgviyKuvhrTNNb3yJr3xqC21x6TvZdqqqqemW6oRbNOoOugbWti5AQ4iwoKprcMJP8hINE9Lwap8NOeLcrK70ZjTGIyN7XAtD2kSU47DbUBhNhnYYVzluMOe0Uhoj65BzbRlhhS91zSYJYQgghhBCi5tWGliIeRQhs2s093enZv1DUmuIglq+ylhMPUBQfLbq8AlfnYUChsKulz+TjValw8yq9CYc51zXLI4gV2KSrV8L2c66s+p/BoVHKS+wuhLi4eXwuhHa+grTNPxHWaRhBLfsQ1LIPAE0mvnLWu9EF1ykxT2MMcrd6bX3/wrPex5momSFThBBCCCGE8FDVX9UVTVF3s7MPDnkGTKAS3blqoIXSuVTckqe4nnUuvRl9RAMaXP1kte5bawqp1u2fEZ+XxRkk71dKfVI4q2LXnwTAhDj/qQ0BZb7eYPRjtLz7UyJ6XXOOSlTzJIglhBBCCCEuPEVf4KsjdnQmwQFfAQzPebW0O2FZAhp1BsC/UUf3PE1AKG0e+NLd9aS6RF1yPSHtB9Hs1reqdT81o7zgZ+Wvv9o6iIAQ4uwoag3GmOYXVdBauhMKIYQQQoiaV8U34GeSI+is2oOVs6rvnFfnX+DKU8NrniZt6wpCOw1j+/NDAfCLbHxO9q02+NNo3LPnZF/n3Bm8FyS/lRAXqpLvbf/67QBXrsWLkQSxhBBCCCFqQFZ2LifjEwkNDiIqMqymi1ML+PjirlKDw36W263El/uKBg8qEWRofsccFEVF4ppFWNJPYYxtTV7cblfJCnNKFT6peDlrCY0xkMje4wBo99iPmFPjMMY0Pzc7v6AbHVRV5coenfDMAr1CiJqmD6tHm4cXo/UPremi1AgJYgkhhBBCnCO79h7is0U/EHcqEZPRj8jwUDKysklLy8Tf38jYkYMYfGkvVKqLMOODjy/Zar0Re3526euUEeRSaQ04rAUo6jJG1ztjvhK7+w4H+DdoD0D9iPoYo5sR1nk4O14eWbiO1waqtojnmDYgDG3AuQzG1qIoVlldV88gL1p53YIq3G3oIupeJMSFymcrXkVBHxJ97gtTS0gQSwghhBDiHHjv46/IzMrh9huvpmmjeiVez8jM5rvlf3D/9FeY/eKjaNQ+RrO7yKj1pjKDWIpKjbOUIFaTm2Zx/LtXqT/60eoqnhen3Vbm6xq/QOr0v/H0tYqnzsOWWOeK2uCPw5yH2mAiqEUvrNmpqHR+NV2sCqmeXFTSqkqIi4e8s09XZhDL6XSSnplFaHDQuSqPEEIIIcQFacqt40ptQWG3OwgOCuDmCVdy03WjLqoErWVR6Y1lvq6o1KXe3ptiW9Pqnk8rt8OzGPXN6Sg7iOUppP0g0rf/Rkj7waRuWgaAX3Qzsg/+hzYgvMLbuVg0uWEmccteJ3bEgxijm9V0cSrHqyHWmXwZ9TU64ZkWRghxPtCYgrHlZrie+PjYUOtN57Q8tU2pQax/129h1rvzAVj62RvEJySz9Kc/uOvWceescEIIIYQQFwrPwMfCb5YzdGAfwkKDeejJWWzYspMH77qR0VcMuGgDWL7qXd6NuqKq2tZqFT/yJZfUh9fHnHysQms3vPYZ6o+ZjlrnR2Tf6zCENyC0wxC0pmCC2w6ocCkuBvVGPoQxuhnNb3+/potSvipLZVXehqpmR5IMXojaSaXVezwrfp+2eXgxDkv+aa9ffEpNuPDex4uY9/ZzBPi7bh6i60Tw36Yd56xgQgghhBAXqh9/WU1QoD//bd6JTqvl8/dfZMHXy2q6WDXMd06sMtdQ1VBmDB8xhJC2A6k/ZgZtHvy6/NUVBXVhd7jYYfcS3m0UKp2BqEuuv2jznAQ07uKebnrLGwS26EP7x38moufYGixV1apwyEhGJxTiouHfsGPJmYrvH2j0IdH4RZ2bEWBrs1L/8zudToKDAtzPbTYb+QUF56RQQgghhBAXMrPFQm5ePl98u5z7J0+kQb0YTKbzI8dPtfHxxb287oRUcUusivORk0hRCO864vSZ56g8FwCPYxXYtDuBTbvXYGHOUJXFkaroupHrT4haTxccVWKeV8tkyZdYQqktsVq1aMz3P/2Jw+Hg0NETPPXSu7RrfY6GzBVCCCGEuIANHdiHYdfeRUhwEI0a1OXgkRPUibzYcyH5aImlK6clVk19Sfe1X59lkSCCL8bY1j7mXqjHqvL1Kve6PpPr3sc61ZN0XghROT7ehx4/0Cia6hhh9/xWahDrwbtuZM+Bw6RnZHHfYy8T4G9i6pQbzmXZhBBCCCEuSJNvuoafv5nD04/eCUBEWAgP3Cn3WW6FX7hVhnKS11Z1EKuiid3ly/9ZUWkNJWeez4e0rOumGgKtFb3+5DoV4vykKMVhmnojHsQY05ImN71egyWqXUoNYuXm5vHY/ZNY/tW7LP/qXaZPvY2EpJRzWTYhhBBCiAvKQ0/Ock8HBpjYvH0PAEGB/kRHXeQtsTy+b6sKW2CV1xILpdRb2bMvRKUXk4DB2Tn/jp8hshGKWovGEFD+wlDxbkGega8KNvCTgJUQ56lyWvbqQmNoefcnBDXveQ4LVbuV+p//kf+VjPQ9O3NOtRZGCCGEEOJClpya7vX8zbkLaqgktY/nl3B1YQus8nJiVXV3Qv9GnQAw1m1VzpI+owjiNE1vfavCy56Po3K2uvdzOj79O4q6MM1wlQU3ZXRCIS4ePrr61li+x/NDicTuHy9YCkBaWqZ7GiA+IQmb1X7uSiaEEEIIcYE5/Xu65Gv14HFw1HoTVsofnbCqu2pFD7gVQ0QDglr0PoP9nn9BmOoW2KRrxReu8lZ11U9RqSijTYAPFW2JVfmy+AxIeV2ncn0Kcd44D4P651KJIFadqDCg6IOw+MOwU/tW3DVp/DkrmBBCCCHEhcZstnLwyAl39Mpi8X7etHH9mixeDSu+adeH1qUg6Qi6oJKjNpW2TlVQaXSEdRpWgSUrmJNIvohU3IVwrKooKC1dA4W4iPjsTVjcEkvrH3oOC3N+KBHEGj64HwAmox+X9ul2zgskhBBCCHGhMlssPPq0d8qGoueKAovnz66JYtU6DcY+jjk1DrVfYJnLeQaJWkz5iEPzH8aWl1HNpSu/LP6NO5NzeDMBjbvUSFlELVJFIwme0TYlFiZErecZtA5s3ous/WsJanUJ9cc8hiU9Hn1o3RosXe1UIohV5NI+3Th6/BRxpxJxOh3u+Zf0kn/GQgghhBBnYulnb9R0EWqvwvt4lc4PjTEIjTGIgtS4ctYp7splim1N7MgHObroqWosZOFuy0nE23jCi2TuW0NIm8uqvSznC2PdVuSd3FPTxTjnziyOVEVBLK9VJKIlRG3XaPxz5BzbTmCTrihqDcaY5jVdpFqp1CDWe58s4rvlf6AoCk0b1SMxOZXGDWIliCWEEEIIcYbe+2QRd906rqaLUUu5vmSrdH6nzSlrldOXqB1JxjR+gYR1HFrTxTivKOdhTqxKO5PRCX0lfa7wDsteUkGpJe8YIQS48kDKKITlK/W/xep/N/DDwrfo0aUdzz1+D+/NeoLg4AoOHyuEEEIIIUpYv2l7TReh1ipqKaL2CGJVusXJucqUL61aRE3ycf35zKMl16kQtZ+8Tyut1JZY/iYTBoOeFk0bsvX/7d13fFPV/8fxV9Ld0r3Ze5epKMgQEBARRFBQRERQEBBBEUSmiCgigspQ3IKoiLj44QD1q6KAyhBZIkt2KV2MQltK8/ujWlqb0NBmNXk/Hw8fNnec+7knN5eTT849Z9tuOrRpwV97DzoyNhERERG3kpmZXWgg9//y6IHdDf/2xCo4I6GLNu6LeZxQzCkmweiu9VfovErSE8t+zM5oKCKOpWmKr5jFJFatGpXZ8ec+Ol1/LSPHP8Oa/62nXLlipjkWEREREYuOnzjJY0/MMdtm1cDueYx+ZaAnltnkmpsmYWymuHGePOBxQiuVZHbC4hNSuj5FxD1YTGKNHtoff38/AJ6aMJKNW3fSsU0LhwUmIiIi4m6qVq7A4oUznB2GSyv0OKGLMt8RS0mC0lD9FVBsXVhXVyVJhomIuDqLP3msWvNj/t+1alThzl5dWfP9BocEJSIiIiIeJv9xwgIDu19hYsNxj0epJ5a1Ylr3wz+mGuWqNnJ2KO6jJAk/XZ4i4iYsJrE+/+r7Qq+zsy+wYuU3Vhf86RffcdfQ8Qx95EmSTqYUWrdh4x/0HTyW/g88ztr1m/KXb9u5h4EjJnH3AxN476MvrD6WiIiISFlgq5kJ3bOdZYMxsZw4sLvRT8NumFOx64PUH7UUg5evs0NxkgLXis0uTys/F0pcibiUgPjaRZYZvHycEEnZVuRxwl4DHsZggOSUdHrf83D+8rMZ5+nSoZVVhaamnWLJspUsXTSTtRs2s+CNZUwbPxyA3Nxcnpn7OovmTsHfz4+BIybRtFE9/Hx9eer5RTw/fSzxsdEcOnLcRqcoIiIi4hoSk5Itrnt9yQruu7t3sWW4azvLkN8Ty7/gQidFU5xLcVW/ayZpf6whstlNTozHDWhMrEuKue7NPs6KwUyOrJhyzO4jInZT4MPrG16e7LRjlKvWhNi2/TF4K5llrSJJrI8X5w0o2u/+x3j+qbH5yyPCQ/Dzte4XlF82baN2jar4+/vRJKEuz817K39d+qkzBAcHERcTBUD9ujXYvHUX3t5e1K1VnYrlYwGoVqVCyc9KRERExAV9supbet7UAYAHxz3N/FkT8tet3bDZqiSWu7ezCo+J5ao9sS79GVa/LWH12zrmuO7MZROWpVTgvEr0uKvZenHTuhLxIHWHv0HG4Z2E1L5WYwJeIYsDuy9+5Wm8vbwAyMnJITk1Pb9BVJyU1HQqV4wDICoijIu5uWRmZePv50tISDlSUtNJSk7Fy2jk0JHjJCWnAhAQ4Me4qXM4kZzCqKH9adaontnyP/p8DStWrgHApCkpRUREpIwo2Gw5fTbD4rrLcdd2lk9INAB+EQUSbFfcrle7sKxy269wJfgMGUrQK60kCTLHjSEnIv/lHRhKaJ2Wzg6jTLKYxFrw+vvc2asrUZHhDB41lb8PHWNA3+4M7t+r+FINhRs9plxT/o8I3l5ejB15L2MmzaZyxThq16hCuaAAkpJT2bv/EHOeGsfho4k8Pec1lr4602zxt/XoxG09OgF5CbY23QZaf8YiIiIiTlLwx9b//vBq9Q+xbtrOCm/UiYD4WvhHVclf5qqzq5UkySDF8ISeCFYntIqri5IknzygfkVcnKv+m1bWWExirf/tD0be348f122ifu0aLJw1kQHDJ1qVxIqODGf7rr0AnExJw8fHp9CjiB3atKBDmxYAjJk8m/i4GHJzTVSrUpGQ4CDq16lO+ukzpT03EREREZdy8PBx7hkxscjfJhMcPpJoVRnu2s4yGAwExFQrvNBYTLLov4kPh/Uc0xcRm3PXxKA9ZhK0tq48ITEoIh7HYhLrwoUL7Nl/iPdWfMGTj48gKCiQ4HJBVhXaolkCr77zEZmZWWz5409atWjC0uWriI4Kp3P7Vuzdf4ga1Sqx78BhEpOSSahXk4rxMby59BMyzp3n70NHiY2OtNlJioiIiLiCOQXGGy0ptbMu+W+PKI0yIe6h2CxWCYpUQkvE6fQxtAmLSax+t93EiLEzuK1HJ+Jioti+ay/Vq1a0qtDwsBAG9uvJ4FFTCQ4KZPrEkSxZtjJ/wLKVX//Apq078ffzZdpjwzEajURGhHHf3b0Y8vA0TLkmJj06xDZnKCIiIuIiLI1DdSU8qp1VzBfv2Lb9OfHju8S2vhMA74BgR0SlhIDYV3HXl9WXn65TEWer//Ayds7tC0D5zsPY+9YoKt78sJOjKtssJrF6d+9E7+6d8l/XrlGFUUP7W11w9y7t6N6lXf7rR4YPyP/74WF3m93nxo6tubFja6uPISIiIuKJPKWdVdz4IT7lwqk/amn+69B6rYm5ri8hta6xd2hiY54xO5d1XQULXvfmPgOWlhUpvZg6NbuPiNiU0cefit1Gk3PuNCE1r6bpkz9i8LKYhhErWF17vr4++Pr62DMWEREREZFLik1sFF5vMHpR8aZR9osn/0CekHCxrdC613HixyUEVWlkfgM3HRPLUck5zTQo4rpiWvXJ/1sJrNJzz38tRERERFzYnn0HuXAhB4A136/nqedf5eDhY06OyhUV91iVc5qymmHqypWr0ogGY5ZTa9A8s+v9Y6o6NiBnsNXkhDaixJeIA+ifC5u77L/8f+07yA/rNua/zsrOtntAIiIiIu7u6bmvc+ZsBieSUnj1nY+IDA9l+uxFzg7L9RTbEctJ3w7UE6tE/CIqYPQ2/2RHUMX61BjwPA0eXeHgqMqgElx/SryKOIc+e7ZnMYn19vuf8cIrS5j/2vsAHE88yaQZ5n85ERERERHrnTt/nojwUJZ/vpoH7u3DsEF9OXcu09lhuaBixvRRMsmNGAit0xK/8HhnB+ICbDM7oT4dIuKOLCaxvvzmJ156ZjwBAf4AxMdFk5Sc6rDARERERNxVZEQY46bOYcPGP2jf+mrOnc8kMNDf2WG5nGKTVM4aR0nJs1KJuroHAJFX9chfZjB6OSscG3LQ43klufx0yYo4h/69sDmLo4oZDAYMBmN+naemnSIzU48TioiIiJTWUxNG8vX/1vFgizsxGo0cOnKcu27r5uywXNDlG/9efoEOiuO/9KWkNCIadyaocgK+obH4R1fm7IHfCarc0Nlh2Yk9rhUry9SXZxFxQxaTWF1vaM1Tz7/K2bPnWP7ZapZ/tpoeN17vwNBERERE3JOfny939uoKwKEjx9n/9xE6tL3GyVG5IAvfwSvdMo6cMykElq/j2HjEZv59bDC2dT9iW/dzcjS2UkzSyFSCnlqlykMV8zguBg3tLmIHoXVbc+rPnwAwOu3HFvdlMYl1zx09WP2/deTk5LB1+24G3dWTGzu2dmRsIiIiIm5p8tPzGTvyXkJDyjFi7Azi46L56ZctPD3pIWeH5mIufQk3+viTeyFv3LDwhh3wDgxxVlAi1itJbyj1oBIp2wwGGjzyIRezMvDyDXB2NG7HYhILoHP7VnRu38pRsYiIiIh4hGOJJ4mPjeLDT7+m3+3duOPWG+kz6FFnh+V6CnyZ9woIzk9iGSzMcOcoBmeNxSVlmslG/Z5KNqFB0X1sFY+ILRi8fDBdvODsMGzEgF9kRWcH4bYsJrHW/7aVt9//jJTUdEwFur6ueGeuQwITERERcVdeRiPvf/wl//f1D7w6dyoAQYH6tfa/Ck5N7uVfjgunTwJg9HJuEkvEropNUmlMLHE/TaZ9T+J3b4LBwPFvX3d2OKWjz55dWUxizZjzKvfccQsN69XE28sdZgsRERERcQ1jRw7kvY++4P67exMUGMCWbX/SpmUzZ4flev7TEyt/sddlHyawP30/EbNcuGeTvlSLMxkMZseEC63bmoimN+IXWQmDwUB8x8GYTKb8JJZ3uQhyzqY6OtpSK1lvSbGWxRZAxfhYbr+lsyNjEREREfEITRLq0iShbv7rpgl1adygthMjcn1e/uWcHUIB+oIi1rrya6XYPUryBbkkg8qL2IjRJ4Dc7HMABFVpRMbBP4hpfScVOg8r8qNEwQRQUKUG+MdUI6hSA46tWUTmif1523j7UrHrSA6vfN5xJyEuo0gSKyMj7+Jq2+oqvvzmJ9r+51fBoCCNri8iIiJSGhnnzjP/tfdZu2ETBgy0admcB++/k8AAf2eH5loK9sTyC3JiIIVpTCwxzw6zE9oxYarZCcVhTLn5f9a8Zw7nju2mXJXGGIzF3UsNVOj8AAC+obEc+GAylXqMIaRmCwDXTWKpJ5ZdFUlideo9tEhvv39fGwzw85dLHBmfiIiIiNt54ZV3CfD345XnpwCw/LPVzFm4mEljhjg5MldTeHZCEbFeoUeazHyp1sDu7s8vsiJZKUecHQY+IVH5cXj5BRJcrellt//3McKA+Jr5ywLL16bBI8vsGqftKIllT0WSWOu+UpJKRERExJ52/bWfd195Jv/16Af6c/ewCU6MyDUV/BJu9PFzYiQizmIm0aReHmKlgLiaLpHEiu94H2cPbCHq6lus2r7usNdJ3/mj1dsX5Btenuy0Y1e8n03pM2pXFvvvLXp7eZFlLy1aatdgRERERDzFqdNn8/8+fSbDiZGUEa70pcCFQhFPVJILUBetR7LDfbMkvWK9/IKo3PMxAivULX5jwDcsjphWfUr044V3YGiRZQY7/AgSf0Nez+nyXYYVPZ7NjyYFWUxirfvt90Kvj59I5tsff7F3PCIiIiJur++tN3LfqKm8tngFry1ewf2jn+DOXl2dHZbrMebNkG30DcSUe9HJwRSkryhijrleUyUoplDioWgB1s98putULrFVIsfg7WuTchzKDhMbxLa+k2Yz1uEbFp+/LK7DIABirrvT5seTS4o8TthrwMMYDHlJq+u63p2/PDY6itt7arZCERERkdLq3qUdlcrH8vMvvwMw8ZH7adywjnODckEGg4EmU78Do5HDK+c4OxwRl1XcIO3WJ77EvdjjfS+DY6nZ8foPrX0tRt9AIhp3pnzH+4hrdw9Gbx+7HU/MJLE+XjwXgNETnuWFpx9zeEAiIiIi7m7hm8sYPqgvTRKse7TCkxl9/3l0xZV6YikhIGaZ6TVVcJnVvUEuPyC7OWYHadd1KiW4BsIbdyZt62o7BGN7TaZ9z+k9v5Kddowjq14AoGK3URx4fxJ+UZU5e2AzUPqZOAMrNeDc4R0AxLbtT865U/mPOnr5l6PxlDX5iWIlsOyvSBLrX0pgiYiIiNjH9l17yDh3nqDAAGeHUmaYcnOcHUI+9WoRq9njWrHR44Sl/WIv7s/LP5iLmWeK3c67XCQ5Z1McEFFhRm9fwuq1Jnnjyvxl5ao0ouG4T8FgYMuk6wAbzMRZIAFdocvwIqv1b4JjWUxiiYiIiIh9tG/dgkEjp9DzpvZ4eXnlL+/Ts4sTo3JtLjUmlr6wSImU4It0acbyKeYyLfUXeynzrE1SFccvskJ+Eiuk1rWc3rOh1GVeiXJVEgDwjSgPgMH4n6G/zXyOvIPCyclIs1imwcsb00XX+fFELlESS0RERMTBdu85QEK9muw7cNjZoZQZ+jIhrs9MUsgOA0prwHaxll2ulOIuaSck+f2jq9JgzEf4BEea38BMTDHX9eXY6lcKLSv4KKXRJ4CLF0uf4BPbu2wS6/DRRFJS0wtdp001doOIiIhIqUx6dKizQyhzXCuJpSSC2JGhmDGx1BNQrFXstVKSJKujkrVXxu+fXljW8g4IKbLM6O1LWMMOpG//jvCEjiT/9ikAEY06ce7ITsITOtoiVCkli0msmS+8wao1P1K5Qjxe3nnd3A0GeGfBDIcFJyIiIuKO5r32Hnfd3o2IsFAg74fD5Z+t5pHhA5wcmetyqccJRazloISTxrcS8y5//ZmKTT5Ze1UV2K6MJFn9oipRqfsY/KIqceKHJZzZv4nQuq0JrdOK89ffgyknOz+JFd3ydoIqJxAQX8u5QQtwmSTWz7/+zv+9P5/QkGBHxiMiIiLi9jb+voOR9/fLf12pQhzbdu5xYkSuz6WSWGXkS5q4gkvXSvEJg6L7mF1r5vrT+FZij7GorL9mXVN4486c2bcJv/A4Mv6ZXfASA9HX9gagXNUmZKUcxj+mOgaDgcD4WmQc2n5pS6ORoEr1HRi5XI7R0oo6NasS4O/vyFhEREREPMKF7BzOZpzLf52RcY5z5zOdGJHrM3r7OjuEApTEEnNc67owWDE7oTiH0efS92zvwDCblBlQvrZNynEn1fo8QcL4zzF4++Uvi772NvwiKxFUuWH+MqO3LwGxNQoliI2+mj3YVVnsidWoQS0en/4i1zRPKLRcs+aIiIiIlE73G9sxYtwMenfvhMFg4JP/+5YbO17n7LBcWsVuo8k5f5ryHe9zdijqiCUl5OjZCS8/tpZ6b3kAO4yJVXzvLNe6QRoMBiIad+Lsgc2EJXSkUvdHMJlMZns0FuQfW53YtncTqOSgy7GYxDp0+DjhocH8tffvSwv1L7aIiIhIqd3Z+yYiI8JYu34zubm59O5xA906tXV2WC7NL6I8dYa8UvyGIk7jakkhfXeTYtjhki0uOeQMkVf1ILBifQJiqgHWxWgwGKjQZZi9Q5MSsJjE0qw5IiIiIvbTuX0rOrdv5ewwpCQMFkfkELHMyoRB4e/XZnYqUZLAzD5lfLwjd1GaHnFGH39yL+Q9iu4XFldkvV94cTP2lWRg92JmJ3TBJNa/41yJeyiSxNq8dSfNGtfnizVrze5wU6c2dg9KRERExJ2lpKaz7JOvOHLsBLkFGv8zp4x2XlByBVzvS5q4KLtcKkUL1eyErssnJJoLp09a3sBMMjEgvjbnj/9VaFlsuwGc+GGxxWIim9/MhYw0Quu2xmAwkvr7V8S2u5vE79+2HFtwJFkpR4o9h+IUPIMKXUeSmfQ35TsP5cD7k0pdtsh/FUli/fzr7zRrXJ8f1m0ssrHBYFASS0RERKSUJs2YR5XK5Tly7AR9enZh154DRISFOjssEXEJxWS+bDW+lQv2mHFLJejxZjB6Xfk+Xt7Et783/3WFG0dY3LbOsDdI3fwF4Y068tdrw6/4WJfjH1mRBo8sA+CATUsWyVMkifXvdM/PTn3Y4cGIiIiIeIKMc+cZP2ows156i7q1q3NTpzY8OuV5Z4clIqViLilk+0SR1SUWlwtT7y2H8/IP5mLmGSu2LNGzp5flHRDChQt5PcKCKtYjqGI9AGrc/Rz+MVXZ8fzt1oVRgovGJyT6yncSscDimFgiIiIiYh9+fn5kZmXTrHE9vv1xA7G9b+Lo8SRnhyVWcsWBi8UVlGR8ITMKXl/mdjF3/Wl8K5dV/Gx+1inpfSe+432c2b+JqrdP5fDns4ltc1eh9aF1LzczbtHYjb7+5GafK7TMy8ff7N51H3yHzKQDmuFPbEpJLBEREREH63VzR44eP0Hbls1Z/tlqliz7P+7s1dXZYYm1lMQSBynNoN+FumLZ6hFEsYp/dFUyT/79zysbJTfN7lr8vvEdBhHfYRAANe6eVeJD1R6yiJyMVI6ufoWcs6mF1kVe1R2jfzkimnQptDwwvpYGVBebszi1yoqVa4os273nAAvfXEZGxjkzexT26RffcdfQ8Qx95EmSTqYUWrdh4x/0HTyW/g88ztr1mwqtO554knbd72Xz1p3WnoOIiIhImdL1htbUqFoJX18fFs2ZwhfLFjLivjus3l/tLJEyyFzCoUS9dMwkUZVYdTOOfz+r9J6IT0g05Tvel78ssHwdAPxjq1OuSgJh9dvhH1UZAN8CMx8avf2ocdczhDe43qExi2ey2BPr/RVfsnvv3xgwMHTg7USEh/LBJ19z+sxZ5r3+PuNHDbZYaGraKZYsW8nSRTNZu2EzC95YxrTxeQPG5ebm8szc11k0dwr+fn4MHDGJpo3qUS4oEIAFb3xApQpFpwcVERERcVchwUFWb6t2litQwkAcxFySy0zCqrjxrczmuPQIov1cSVLR2kdG7XzfiWzWjchm3QCoMWA2ORlphNRpRdJP7xN9Ta/87Sr3fIwT4eWJbnkbu+bdQ272OQLiatg1NpGCLPbEOpZ4ksoV4wkODuK5eW8DcOjIcWZOGc3v23ZfttBfNm2jdo2q+Pv70SShLut/+z1/XfqpMwQHBxEXE0VYaDD169Zg89ZdAPy+7U9yc3OpU7NqqU9MRERExB2pneUClMMSKxU7jpGNkhV6NNCFlSRZaO0+duqBF1qnFZHNuuETFE6FLsPxDbv044dPuQgqdhuFX0QFGo77hPqj38MvsqJd4hAxx2JPrNjoCPrffjM5Fy8ycMQkAC5cuICPjze+PpcfSislNZ3KFfMu9KiIMC7m5pKZlY2/ny8hIeVISU0nKTkVL6ORQ0eOk5ScysWLuSx8cxnTHhvO6+9+fNnyP/p8Tf7jjrYaKE9ERESkLFA7yxUoiyVWcuXH/Fw5NinKBd8v74BgvAOCnR2GeBiL2aiI8DCWLl9F2qnTZGVl8833G0hMSiE5JQ1fX5/Ll2oo3Ogx5ZryP3PeXl6MHXkvYybNpnLFOGrXqEK5oABWrfmRFs0aEh9X/PSbt/XoxG09OgGQk5NDm24Diz9TERERERexe88B3v/4S5JT0ws9SjJ/1oTid1Y7S6RMKllvqZInkovrBVbcI4hiK7Z6310viSXiDBaTWI8/fB/zX3uPuJgoJj06lP/7+gdGDunHyPHP0PWG1pctNDoynO279gJwMiUNHx8f/Hx989d3aNOCDm1aADBm8mzi42JY/MFnpKSeYsPGPzh6PImdu/fx1MSR1KhayRbnKSIiIuIyJs6YR9uWzWnb6iq8vbyuaF+1s5yvpFPdi1il2CcQzWxQbK9JzU7ouuw7O6GIu7GYxKpZrRIvPP1Y/uvGDWoD0L1Lu2ILbdEsgVff+YjMzCy2/PEnrVo0YenyVURHhdO5fSv27j9EjWqV2HfgMIlJySTUq8nz08fm7z999iK6dWqjhpWIiIi4pZDgIB4aeleJ9lU7yxUoiSUlYC7fUFwSwtochbnElpKtzlPqutd7J2KJxSTW2YxzfPfjLySnphe6tw7uf2uxhYaHhTCwX08Gj5pKcFAg0yeOZMmylfm/Gqz8+gc2bd2Jv58v0x4bjtFocXx5EREREbfT+tpmbPx9B1c1aXDF+6qd5QKUHBCnuvLZCcWJistTWjkDpYjksZjEGjN5Njk5F6lXuzre3lfWzR3yemwV7LX1yPAB+X8/POzuy+47+dGhV3w8ERERkbLi+5838ubSTwkM8P9niQkwsHrFIqv2VztLxE0Um6y4lODwCgzl4rlT+EaUN7NVMZmSEj2CaFuBFepy7uifDj2mIxh8/DBdyLK4vkSPbZpNbJk7uJJd4nksJrHST53mvVdn4eWlX+9EREREbOnZqQ87OwQRcVEGC4+SJYz7lNwLmaRs/sJGB3JsAsS7XGSRZWENrid9x/cOjcPhbJQstHRdiHgai0mshHq1OJmSSlxMlCPjEREREXF78bFqX5Vp6v0gJXLlyYyCj5oZffww+vjZ7Ppz/COIRY/mGx7v0Agcp7TvkR4xFLHEYhLLYDQyYuwMatWoUmj5zCmj7R2TiIiIiFvbun03L736HkePnyA3N+/LireXF198uNDJkYl19GVSrFSSxENJ9nGjWep8QmO4cCrJ2WHYUHHvjfu8dyKOYDGJ1SShDk0S6jgyFhERERGPMOult7jnzh7839c/MmbEAHbv/Zv0U2ecHZZYyaAeEVIS5hJN9kw+FbpOi16zJRqrqTTcKNFWHN0jROzHYhKrW6e2joxDRERExGP4+HjTuX2rvOTV6bN0bt+KB8c9TZ+eXZwdmoi4FCsTP2U2aVJW47Yhs2+x6kXEkiJJrPdXfMGdvW/iqdmLzN4MJ40Z4pDARERERNxVaEg5Tqak0fraZnyw4ktOnzlLatopZ4clInZlm3GOSjTAd5lNcrmB4vKQVr81eg9FwEwSKyI8DKDIWFgiIiIiYhtD7rkdk8lE04S6/LppG6++/RH33NnD2WGJtZQQEDOMvgFmlpbkWrm0T0BcTTIO/oFfZKUSx2WRBz3eZ09Gb18uXsj6z9KC77vqWcSWiiSxunRoBUDbls2Jj4t2eEAiIiIi7q5B3Rr5fw8deDtDB97uxGjkyimJJUVFNuvGmf2biGjUmf3vPW6TMiveNIrTf20gstlNNilPbM8/qjJBVRoTEFudgyueuvICrM1x6bYjAlxmTKyHHp9JbEwk3Tq1pX3rq/H393NkXCIiIiJuZ/X/1tG5fSveePcTs+sH97/VwRGJiK0YffyofueM0hdUIFnh5V+O+A73WlxvdUFmVzs4K2Ku55eb9Gqs2PVBgEtJLANU6T2JxB8WE3VVD45+Nf8ye5vLYplb5h51JVJaRksrlr/1PA8M7MOuv/Zzz4iJPD33NbZu3+3I2ERERETcSnJKOgBnzmaY/U/KBoPRYhNapJCCs9SZbPT4Xmjd1gCE1LmOuA6DAIi+pteVx+bwpMiVn3/8DffbIQ77CYivBUBQxfpENruJBg9/gE9IlN2O5x0UbreyRVyVxZ5YAA3r1aRhvZps3b6b5xcu5tdN2ykfH834UYOpXDHeUTGKiIiIuIV+t+U9EjT6gf5OjkREXILZxNblk0t+ERVoPGUNRt9ADAYD8e0Hkfzbp0VLKZBAM1eiyQXGaio+jVa2eh/VvGcOadu+IbL5zaUsybrzNvr603DcpxbGYxNxTxaTWKfPZPDFmrWs/Pp7KpaPZfTQu2jWuD4bf9/BpKfns3ihDbrKioiIiHiQL9asvez6mzq1cVAkImJPMdfdQcrmLwit25qjXy2wvGGxj9OZTzR5+QVdKsJoxD+6LEzKVbYSUiXhExxJTKu+hRfaeQB939AYu5Yv4mosJrHuGDyWzh1a8ezUh6lYPjZ/+VVNGhAXHemQ4ERERETcyQ/rNgJw7PhJ/Px8iIwIA+DwkUQqVYxTEquMiG3dj/OJe4lt3c/ZoYiLqnjTQ1ToOpKL58845HjB1ZtT7c6nCCxfhx3P/ztRRIGkkUuMPXXlyRyDmbiDqzfnzP5NtgjIIYrt8WZlkstcXYh4IotJrOVvzSYoKNDsulnTHrFbQCIiIiLu6tmpDwMwesKzzJwyOn/inLT008x66S1nhiZXwDs4kgaPfOjsMMTFGQwGvANDiL/hfnyCo/CPrkra1tXEXNeXpJ+XWVfIFfTiCW/YwXIs3r5Wl1NS5ao25uzfWwstC6ndktN/rQdKOCaYJyVuDIbLv9+eVBcil2ExiZWZlc07H3zOkWMnyC3wYZo5ZbQj4hIRERFxWydOphSa+Tk8LITDxxKdGJGI2Et8+0uzCzae+i1evgGXTWIVGsvKRsmnoEoNibr6FoKqNOLgR9NtUmZRJUiyKDFjoaeW88crE3FVFqdWmTRjHqfPZnDk2AlaX9OUyIgwalUvC89ai4iIiLi2mtUq89z8tzl6PInEpGReW7yC0OByzg5LROzM6z8DcAf+M5udb3j5Qsur3j6VuPaD8Au3zWRaBoOByj0fI7JpV5uUZ+EgxWxgm8SMKwxIf0Ws7oGmhJ6INSwmsTLOnWf8qME0rFeLurWrM2b4AHb8udeRsYmIiIi4pXEP3UtWZhb3j36Ce4ZPYu+BQ0weO9TZYYmVNDaNlFbMdXcAEH/DEBImrKL+6PcLrDUQ0aQL5W+4zznBlVhJPhfF7OMBn7Ww+u0ACE8o+Dio+5+3SElZfJzQz8+PzKxsmjWux7c/biC2900cPZ7kyNhERERE3FJwuSAmPaqkVdmlL5hSOhVveoj4DoPx8g8qfuMSMhi97FZ2iZSxDlSBlRpw7vAOu5XvExrDhVNJVO75GOEN2xNcswVpf3xjt+OJuAuLPbF63dyRo8dP0LZlczZv3UXXPsNp27K5I2MTERERcUuHjyby2BNzeeCRJwE4mZLGd2t/dXJUYjUP6B0i9vffBFalHo8CEG+jHlgGL2+q9nmC6v1n2aQ8l1HGkmGWHidsOOYjmkz7Hi/fAMLqtyvyqKmImGexJ1bXG1rn/71ozhROn8kgKFAfLBEREZHSmvH8q9x7160seD3vEaKwkGCWLFtJhzYtnByZiDhL9DW9iLq6JwajxX4GV8ZgIKJxZ9uU5UrcJIds8PK+slNR8lwEuExPrNETni30OiQ4iFETZto9IBERERF3d/pMBtc0T8j/UuLj401WVraToxIRZ7NZAgvwjzY/KVfMdX3z/n/tbTY7VokVm5gxs96JPbHKd37givcJqX0tAGEJHfGLqACA7z//F5ErV6Qn1pZtfwJwLPFk/t95r5M4ePi44yITERERcVMR4aHs+/tw/ve391d8QWREmFNjkiuhHhHiuhqM+Yhzx3YTXN38UDAVuj5E3PUDyTx5kBNrl9ruwMV8LMpVbcKZ/RsJa9iB9G3f2u64jlSC3lA+5SJoMu0HDF7eZKcnkvj928S1u8cOwYl4hiJJrFVf/wBASmo6ry9ekb88LjaKaY8Nc1xkIiIiIm5q3EP3Munp+Rw8fIyufYYRGhLMrCcednZYIuIG/CLK4xdR3uJ6g8GAd2CozY9rKCaL5eUXSNN/kjmbrUxiOXUmUAtjWZWE0dsHAL/weKrc+nix2wfEVufc0V02O76IOymSxPp3ppyoyHAeuLePwwMSERERcXeVK8bz1rzpHD6aCJioVCEeLy/bPUYkdqaOWOIG/CIrOvyYBi/v/P+bLuYQEFfD7HbeQWFczDpnoRQbPk9o9ILci1eww6UPf/nOD3Bs9SvEXT/QZuE0HPsJ5xP3knP+NCmbV9msXBF3YnFg91u7dcz/+/dtf7Jp6y5uvbkDEWG2z9qLiIiIeJq9+w+SlJIGJtM/ySxoo5mgy4TiepyIlAU+5SKo/8iHePn4s+3ZHqUvsJheU6YCyacGj3zI2YN/EJ5wA6bci5Cby8n1H3Hu2J8ExNagRv9nMZlMnFz/YenjuozACnU5d3iHhYAvnyyLazeAmJZ9MPr62ywe37BYfMNiSdnypZm1uu+IwGWSWFNnLmDa+BH4+fkydeZCGjesw9RnFjLv2eK7P4qIiIiIZdNmvcyP6zdRs1plvL28gLzHZpTEEhFH8o+sSG6OrSaVsD7J4hsWR0RYHACRTW4EILjG1Zz8ZQUxrfpc+cx9TmLLBJY1Ylr1xeDjx4kfFjv0uCKuxGISK+3UGWJjInnrvU8ZfHcvetx4PX0Hj3VkbCIiIiJu6fdtf7LyvfkEBjj2C5DYiKa6FzGjdI/5+YZGU+E/s/+ZbDgulTnR1/bmoIWeWIZ/fmBwFQaDgYrdRgEoiSUezeLgC0GB/sx9eTHffL+Brh1bc+FCDkGBamiJiIiIlFZC/dpkZmU5OwwpKSWxxK3Y6noue5+LkBpX02jS1xh9AwEw+gVRqcdYylVvRnyHwUW2d9RA815+QUWWOWMMMxFXZLEn1pSxw/hk1TeMGzUIHx9vtu3cw82d2zkyNhERERG3NKBvd0Y+9gz1alcvtHzSmCFOikhExM5s1avKlr2zDAa8A4ILLYq+5lair7kVgOr9nyUgriY7Zve23TGtEFr3OqKu6UVIrWvwj6rM2b+3ElqvrUNjEHFVFpNYVSuX5+FhA/JfJ9SvRUL9Wg4JSkRERMSdPfPCG1SuEE+1yhXw9natR1ZERIoTWKEe547usvtx7N7zqZiEWFi9NvY9vgUGoxeVezya/9o/uopT4hBxRRaTWCIiIiJiH1nZ2TwzZZSzwxARsV2iqNhi7Du+lbX8oquQdfJgifb1j6lm42hE5EoVGRPrmx82AHDq9FmHByMiIiLiCdq2bM6m33c6OwwpKY2JJWJGMZ8Lm+WwbJgMs/LRxIZjP6Z6/1mE1LoW76AwAuJq2i6GEvAOCgfANzTWqXGIOEORnliLl63khnbX8tDjz/DOghnOiElERETErf30yxYWL1tZYHZCE2Bg9YpFzgxLRETM8A2LwzcsDoCE8Stx9iD2te9fwIm171P+hvudGoeIMxRJYkVHhtNn0KOcTE7jnhETi+xgbWLr0y++Y/lnqykXFMj0x0cQEx2Zv27Dxj+Y+/ISfHy8GXrPbbRp2ZzTZzKY+eIbHD6SSGhIOZ58fAQR4aGlODURERER1/Ts1IdLtb/aWc5lKIOzsInYVtEeTI6auc/ZDEbnj2PoH12VKr0ed3YYIk5RJIk1fcKD7N77N0/PeY1RQ/uXqNDUtFMsWbaSpYtmsnbDZha8sYxp44cDkJubyzNzX2fR3Cn4+/kxcMQkmjaqx/Zde7j9ls40TajLvNfeY+lHqxh5f7/SnZ2IiIiIi9i5ex/VqlQgwN+f+Ngoi9tt3rqTZo3rW1yvdpYL8JAv6+IhzFzPBceN8gmN4cKpJGsKsnFgYLLlTIT/KJiENvoGAFChyzAOr3yeCp0fsPnxRMS2iiSxAgP8aZpQl/nPTiA2JtLcPsX6ZdM2ateoir+/H00S6vLcvLfy16WfOkNwcBBxMXmNt/p1a7B56y7atmqev01C/Vp89+OvJTq2iIiIiCs6kZTC3JffpVGDWrRolkD5uGhioyNJP32G44kn2fXXAb75YT3XXtWIRg3r4O1l/td+tbOcJ6bNXVxIT8QrIMTZoYg4TFi9tpzc8JEVWxaXcHKNgd0B6g5/i5zzp/HyDwIg+trehDfuhLc+2yIuz+LshJGRYSxe9jlr128GDLRt2Yw7b7vJYoOqoJTUdCpXzHtmOCoijIu5uWRmZePv50tISDlSUtNJSk7Fy2jk0JHjJCWnFtp/0+87adSgtsXyP/p8DStWrgHsk50XERERsbX2bVrQ7rqrWLthM79s/IODR45zPPEkEeGhVKoQR83qlXjx6ccICgq8bDlqZzlPxRtHODsEEcco+Nk328HK3ELH9FAs9W3JYCCwQp0ii5XAEikbLCaxXn5zGUePJzHkntswGAys+PwbFr6xjIeGWNH13FC40WPKNeX3UvX28mLsyHsZM2k2lSvGUbtGFcoFBeRvu+/vw/y2ZQcP3n+nxeJv69GJ23p0AiAnJ4c23QYWH5OIiIiIkxmNRtq1uop2ra4qeSFqZ4mITZUk+XTlmaSSJMXtMc6WwWjxK7CIlAEWP8EbNv7B4oVP4+VlBKBJQl0GjphkVaHRkeFs37UXgJMpafj4+ODn65u/vkObFnRo0wKAMZNnEx8XA0Ba+mmmzlzIUxNHFtpeRERERPKonSUidufS476VritW1T5TbBSHiDiD8XIrcy7mXPo75yKmXOtuGC2aJbBn30EyM7PY8seftGrRhKXLV7H6f+sA2Lv/ECaTib37D5GYlExCvZpkZ19gwvQXuX9Ab2pWq1SKUxIRERFxX2pniYhNFZuwstWjg67xeHJAbA1nhyAipWCxJ1an61vy4LhnuKXr9QB8/tX3dOnYyqpCw8NCGNivJ4NHTSU4KJDpE0eyZNnK/O6gK7/+gU1bd+Lv58u0x4ZjNBpZ8uFn7N77N++8/xlvLPkYgFfnTsXf36+UpygiIiLiPtTOEhGX5NK9t0TEXVhMYg288xbiYiL5acMWAHp3v4EuHa6zuuDuXdrRvUu7/NePDB+Q//fDw+4usv3g/rcyuP+tVpcvIiIiUlalpKaz7JOvOHLsBLkFxomZOWW0VfurnSUiIiKe6LKj2t3YsTU3dmztqFhEREREPMKkGfOoUrk8R46doE/PLuzac4CIsFBnhyUiHsgeg6ebpdlORcQGLjsmloiIiIjYXsa584wfNZiG9WpRt3Z1xgwfwI4/9zo7LBGRkrNDMqwkMxqKiHtTEktERETEwfz8/MjMyqZZ43p8++MGMs6d5+jxJGeHJSLi+pTYEvFoFpNYI8bO4MtvfiIzM8uR8YiIiIi4vV43d+To8RO0bdmczVt30bXPcNq2bO7ssERErOSYRJLDHnUUkTLD4phY9w/ozdffrePVxR9xVZMG3Ny5LY0b1nFkbCIiIiJuqesNl8YcXTRnCqfPZBAUGODEiERELLA6kVTMdjbrQVW0HKNfELlZGcXvatCDSCJlncVPcZOEujw2ahDL35xN+9ZX8/zCxdw28BH+7+sfHBmfiIiIiNsZPeHZQq9DgoMYNWGmk6IREXF95Ts/gH9sdULrtb3ifX1CY6h57ws0HPeJHSITEUe67OyEaemnWbXmR7769mfq1KxK1xta89W3P7N1x19MfOR+R8UoIiIi4ha2bPsTgGOJJ/P/znudxMHDx50VlojIFXL8Y35x7QYQ124AJzesuOJ9wxt1IqRmCztEJSKOZjGJNfGpl9jx5z6639iOl54ZT0R43rTPzRrVo+/gsQ4LUERERMRdrPqnR3tKajqvL770RSwuNoppjw1zVlgi4uFq3/8yBqMXuxcNKXEZxY1fZd+ZBjXYu4insJjEatWiCVPHDcPX1yd/WW5uLkajkWcmj3JIcCIiIiLuZNKjQwGIigzngXv7ODkaEZE85ao2trjO4IReV1esmBxWGTgDEbGSxTGx1ny/vlACC+Chx/PGaqhZvbJ9oxIRERFxY0MH3s6P6zax/LPVQF4PhZTUdOcGJSIezzeiPAD+kZWo99AS6j20xIalX3lvKXO9t+zbo0tEXF2Rnlgaq0FERETEvuYsXMyZsxns+usAt9/SmRMnU5jx/GvMe/ZxZ4cmIh6s1r0vcnLDCmLb9senXMSV7Wz1LIZ2oK5WIh6jSBJLYzWIiIiI2Nevm7fz/mvPMvDByQDExURx6sxZJ0clIp7OL6ICFW96qPBCWyWIStCBqrhxtkTE8xRJYmmsBhERERH78jIaycm5mN9x4fDRRHIu5Dg3KBERc6xOPjkq4WQmIDOLgqo0JuPgVvuHIyIOVWRMrJycvAaUElgiIiIi9nHX7d0YM3k2aemneenV9xjy8DTu6tPN2WGJiJSC+WzXv4PGh9Zp6chgRMRNFemJNXHGPJ6d+jCtbry70GPNJlPeY84/f2nLwf1EREREPE+3zm2pVCGOnzZsxmSCZyaPoklCXWeHJSJSCuZ7YtUaNI8LZ1PxDY1xbDQFv8s69MgiYk9FkliPPTQIgNUrFjk8GBERERFPUaVSeXJycvD396NmNc38LCIuymxuykxayML4VQYvbwcksMzNYmjnQ4qIUxRJYkWEhwJQLiiwyMa7/tpPvdrV7R+ViIiIiBv7+rt1PPPC68RGR+Bl9OJ8ZiZPTx6ldpaIiB1oeHgR91G0J9a0uWZngTDlmth/8AjL33reIYGJiIiIuKs3l37M2/OnU7VyBSBvtsLn5r3Fm/OmOzkyERFrFP2+aI+ZBE3mulOpi5WIRyuSxGrbqrnZDQ0YGHHfHXYPSERERMTdhQSXy09gAbRo1pCX31zmxIhERCxRPyYRcR1FkljdOrV1RhwiIiIibi8j4xwATRvVY+36TTRrVA+Aw8dO0KhBbWeGJiLicuzRu0tEyrYiSaz3V3zBnb1v4qnZi8wOzjdpzBCHBCYiIiLibjr1HorBYP5pmOByQTw87G7HByUiUqboEUMRT2ZmYPcwAGrVqOLoWERERETc2rqvljg7BBER+1CvKRFxgCJJrC4dWgHQ99YbHR6MiIiIiIiIlEHqDSUiDlAkifWvxKRk5r/2Pjt27yPAz4/rrmnKoP49CfD3d2R8IiIiIiIiIgBENL2JpHUfEnX1LRxb/QoAJnOPGIqIWzJaWjFt1ivEx0Yz7bHhTHp0CClp6cx66W0HhiYiIiLi3nJycpwdgoiIbTjocULvgGAaPrqCuHYD8pd5+ZVzyLFFxPksJrHOnM1gxH130KhBberXqcGkMUP4c89+R8YmIiIi4tYGj5rq7BBERC7P6uSU88bECqpUn/JdhlFjwGynxSAijmHxccJqlSuQmnaKiPBQALIv5BAfG+2wwERERETcnYaQERGxLKhKIwB8w+LMrq81eB7Hv3uTSjc/bHEbEXEvRZJYj02bi8FgIDkljQfHPU3lSvEAJKekER4W4vAARURERNzNiLEzMBgMHD1+ggfHPQ3A/FkTnByViIi1zGTg7fA4YbnKCdQd8TZ+ERXMrg+u3pzg6s1tflwRcV1FklhtW+kmICIiImJPkx4dCiYTYybPZuKYIc4OR0TkMqxLTtnrYcLA8rXtVLKIlEVFkljdOrV1RhwiIiIiHiM+NgoAbx/v/L9FRMoO541/JSKezeKYWCmp6Sz75CuOHDtBboEBG2ZOGe2IuERERETc3qC7ejo7BBEREZEyw+LshJNmzOP02QyOHDtB62uaEhkRRq3qVRwZm4iIiIhbu/66q50dgoiIbdhhTCwRkf+ymMTKOHee8aMG07BeLerWrs6Y4QPY8edeR8YmIiIiIiIiUiLxHe8Dg4GoFrc6OxQRsRGLjxP6+fmRmZVNs8b1+PbHDcT2vomjx5OsLvjTL75j+WerKRcUyPTHRxATHZm/bsPGP5j78hJ8fLwZes9ttGnZvNh9RERERCSP2lkiIsWL7zCIuOsHYjBa7LshImWMxSRWr5s7cvT4Cdq2bM7yz1azZNn/cWevrlYVmpp2iiXLVrJ00UzWbtjMgjeWMW38cAByc3N5Zu7rLJo7BX8/PwaOmETTRvXIzr5gcR8RERERd1KasUfVzhIR1+SajxMqgSXiXiwmsbre0Dr/70VzpnD6TAYhwUFWFfrLpm3UrlEVf38/miTU5bl5b+WvSz91huDgIOJi8mbiqV+3Bpu37iLj3HmL+4iIiIi4k0kz5lGlcnmOHDtBn55d2LXnABFhoVbtq3aWiDiUxroSERdiMYl14UIOK7/6nh279+Hv70fra5rS8urGVhWakppO5YpxAERFhHExN5fMrGz8/XwJCSlHSmo6ScmpeBmNHDpynKTkVDIzsyzuIyIiIuJO/h17dNZLb1G3dnVu6tSGR6c8b9W+ameJiEtSsktEHMBiEuuZF17nyLETtGrRBG9vL+a/9j579h9kQN8exZdqAFOBrvGmXFP+Pc3by4uxI+9lzKTZVK4YR+0aVSgXFEBmVpbFff7ro8/XsGLlmrztCuwjIiIiUhaUauxRtbNERETEQ1lMYm3ftZf3X5uFl1feM8Q9b+rA4IemWJXEio4MZ/uuvJkMT6ak4ePjg5/vpV/6OrRpQYc2LQAYM3k28XExGAyGy+5T0G09OnFbj04A5OTk0KbbQCtOVURERMQ1lGbsUbWzRMT5lOAWEeewOMpdfGwUJlNu/uugwACrx2po0SyBPfsOkpmZxZY//qRViyYsXb6K1f9bB8De/YcwmUzs3X+IxKRkEurVNLuPiIiIiDvqekNralSthK+vD4vmTOGLZQsZcd8dVu2rdpaIOJIeEhQRV1KkJ9aHn34NQGhIMNNmvUJC/VoAHD1+gqqVK1hVaHhYCAP79WTwqKkEBwUyfeJIlixbieGffusrv/6BTVt34u/ny7THhmM0Gs3uIyIiIuKOLl7MZdPWnaSkphd6ZO+mTm2K3VftLBGR4nkHBDs7BBGxA0N2dlahvqBPzV50ma0NTBozxN4xXZF/u7mvXfU23t4Wn44UERERcRljJs9mz/6D1KpeBW9vLwAMBgMzp4x2bmD/oXaWiBz9agEn1i4ttCywQj3OHd1VaFlEky6k/v51oWUhtVtS8x7rJq2wlYxD2zn+/TtUvmUsvqExDj22iNhfkdbIpEeHOiMOEREREY9x4OBRPnzzec0OKCJiY0GVG1JzwHPODkNE7OSyP6mt+X49a9dvAgy0bdmcG66/1kFhiYiIiLivhvVqkJ19QUksERERkStgMYm1eNnnrF2/me43Xo/BYGDZp1+TmJRM/z43OzI+EREREbfx4qJ3gbwxsUZPeJbGDWsXWj9qaH9nhCUiYgMaAl5E7M9iEmv1/9bz+gtP4O/vB8AN7a7h/tHTlMQSERERKaFyQYH5/69etaKToxERsSGDklgiYn8Wk1imXBO+vj75r319fDHlmixtLiIiIiLFGNy/l7NDEBG5MkpOiYgLsZjEatG8IROfmsdtPToBsOL/vqFF84YOC0xERETEXSUmJbPg9Q/Y/udeAvz8aHVNEwb3v5UAf39nhyYiUiJBlRqQuuVLgmtezZm9vzk7HBFxU0ZLK0YMvoPaNauw8M1lLHxzGbWrV2HE4DscGZuIiIiIW3ryuVeIi4li2mPDmfToEFLTTjHrpbedHZaISIl5+ZejybTvqTnwBWeHIiJuzGJPrJ82bOHefj25t19PB4YjIiIi4v7OnDnHiPsu/Tg4aUw17ho63okRiYhYYv3jhEZvzbgqIvZlsSfW4mUrHRmHiIiIiMeoXDGOlNT0/NfZ2ReIj412XkAiIldEYyWLiHNY7Il1Z++uTJ25kH69u+Ll5ZW/vGb1yg4JTERERMRd5eRcZORjz1C5UjwAySlpZGZlM/7JFwCYOWW084ITERERcVEWk1gvv/khAI/v3JO/zGCAFe/MtX9UIiIiIm6s7XXNnR2CiEgpaMZCEXEOi0msjxcrWSUiIiJiD906tS2yLCcnB29vi00zEREREY9ntqX09Xc/c+hIIk0S6nB104aOjklERETELX346ddml+fmmvhk1bcse+M5B0ckImIjBvXOEhH7K5LEevnNZWzaupPGDeswe/47DLzzFrre0NoZsYmIiIi4lb/2/m1+hcHAfXf3cmgsIiIiImVNkSTW6u/Xs+TlpykXFEifW7ow+Zn5SmKJiIiI2MCkR4c6OwQRkStTgh5W8Tfcz/FvXiO2bX87BCQinqxIEsvP15dyQYEAxMZEkpmZ5fCgRERERNyZyWRiw8Y/OHLsBCbTpanq+/Ts4sSoRERK41KyK779vcS27ofRx8+J8YiIOzI7JtbeA4fhnwZV9oWcQq9rVq/suOhERERE3NBTz7/Krt37OXvuHC2aNuTvw8eoWrmCs8MSEbEZJbBExB6KJLGysrMZN3VOoWX/vjYYYMU7mrVQREREpDR2/LmPpYtmMmPOq9w/4DYCAvyZPf8tZ4clIlJi3gHBzg5BRDxAkSTWJ4tfcEIYIiIiIp4jMMAfLy8j9evUYOPvO+jWuS37Dx51dlgiIles5sA5nNm/heCaLZwdioh4ALOPE4qIiIiI/TRvXJ+du/fR6fpruX/0NJZ/tpoK8THODktE5IqF1LqWkFrXOjsMEfEQSmKJiIiIONjwwX0x/DPj1/xZE9i5ex9XN2ng5KhERKxlKn4TERE7UBJLRERExMEMBaasj4mKICYqwonRiIiIiJQNRmcHICIiIiIiImWJofhNRETsQEksERERERERERFxeUpiiYiIiIiIiFkFH38WEXE2JbFERERERERERMTlKYklIiIiIiIiIiIuT0ksERERERERERFxeUpiiYiIiIiIiAUaE0tEXIeSWCIiIiIiIiIi4vKUxBIRERERERGzfIIjnR2CiEg+JbFERERERETErMirehBz3R3UHrrI2aGIiODt7ABERERERETENRm9fah400P/WWpySiwiIuqJJSIiIiIiIiIiLs9uPbE+/eI7ln+2mnJBgUx/fAQx0ZeepT5w8ChTZy4g49x5Ora7luGD+gLw0edreH/FF3h7e/P46ME0Sahrr/BEREREyiy1s0TEuTRjoYg4h116YqWmnWLJspW88eI0buvRiQVvLCu0/s2ln9C/z8188PpzbN+1h8NHEzl3PpM3l37CkleeYdYTD/PKWx/aIzQRERGRMk3tLBEREfFUdkli/bJpG7VrVMXf348mCXVZ/9vvhdYHBQYQFhqCj483VStVwNvLC28vLyLCQ/H18aZi+TiCggLtEZqIiIhImaZ2loiIiHgquzxOmJKaTuWKcQBERYRxMTeXzKxs/P18ARjY7xZGPT6Trh3bkGvKJT4uGoBbu3Vg2KMzqFe7Grf16GSx/I8+X8OKlWsAMJk0qKCIiIh4DrWzRMTZfCPKc+7oLmeHISIeyD5jYhkKN3pMuSYMBR6bXrV6LX1v7crJ5FT27DvE2YxzGIBfNm5j0F09WfrRKsJCg2l5dWOzxd/Wo1N+4ysnJ4c23Qba5TREREREXI7aWSLiJPUfXkZW8iHOHd9D+rZvnR2OiHgguySxoiPD2b5rLwAnU9Lw8fHBzzfv18HMzCx+XL+RdxbMyHudlcWP6zYB0KBeTVpe3ZirmjSg7+Cx9LutW/6viiIiIiKidpaIOI9/VCX8oypx7vgeZ4ciIh7KLmNitWiWwJ59B8nMzGLLH3/SqkUTli5fxer/rcNoNHI8MZkjx06Qc/Eih44cB8DLy8gfO3aTnX2B5NR0Tp85W+hXRRERERFRO0tEREQ8l116YoWHhTCwX08Gj5pKcFAg0yeOZMmylRgMBnx9fZg0ZggPT5xFbm4uTRvVo3P7lhgMRn7ftps77huHl5eRxx++L/9XRRERERHJo3aWiIiIeCpDdnZWmR6x89+xGtauehtvb/sM8SUiIiLiidTOEhFzjv/vbY5/8yoAzWasc3I0IuJJ7PI4oYiIiIiIiIiIiC0piSUiIiIiIiIiIi5PSSwREREREREREXF5SmKJiIiIiIiIiIjLUxJLRERERERERERcnpJYIiIiIiIiIiLi8pTEEhERERERERERl6cklov44OOvyMzMslv502cvslvZtrZz9z42bPzD2WGIiIiIiIiIiAtREsuBWt14N3c/MIGe/Ucx6vGZJCYlA3A+M5Mtf+zC39/P7H6rVv/I60tWOCTG4WOf4njiSYcc678ee2Ium7fupErFeD5Z9a1TYhARERERERER16QklgP5+/my5JWn+XjxXFpf24yFbywDYM33G2h33VVOjs51BAUFElwuiMNHE50dioiIiIiIiIi4CG9nB+CJjEYjzRvX5+vvfgZg1+79DOjbHYBfN29n9vy3MRgM3NK1PfXqVGfhm3nJrl82beO1F55g+Wer+fKbnzhzNoNeN3fkzt43MWjkZKZPGEmF+BgSk5KZOnMhi+ZMsRiDyWTixUVLWbt+E0FBgUwZ+wBfrFnLtp17eGTyc9zYsTUJ9Wqy+n/rSUs/TcUKsQwb1JcXXn6X37ZsJyS4HE+OH050dATTnn2ZXX/tJzwslBmTRoLJxPgnX+Rsxjnq1qrK1HHDycrO5pm5r/PXvoPEx0bx5OMPEhIcxPLPVvPhp18TGxNJWtrp/PgaN6zD7j1/U6lCnB3fCREREREREREpKzwmifX7tBswXbxgl7INXj40mfqN1dtfvJjL19/9TP06NQBITEomOiocgA8//ZoH7u1D25bNSD91hqjIcG7t1gGA++7uDUDThLrcenNHsjKzuHXAaHp1v4GbO7dj9f/WcW+/nqxdv5mOba+5bAynz5xl1eof+XL5y5w+c5agwAAeGtKP//30K3OmjyU+LprNW3fy1Xc/89a86VSrUoFPv/gOX18fPnh9Fr9v383iZSu55ab27D94hOVvPc/J5FSiIsL44OOvqF+nBmNGDODEyRS8vIy88/5nNGpQm+kTHuSLNWv59ItvadWiKcs/W82b857E19eH4Y/OyI8vNjqSXX/tv6L3QURERERERETclx4ndKDMrGwGDJvAPSMmcur0WYbccxsA2dkX8PbOyyd2ur4lS5at5KcNW4iMCDNbTnxsFJ+u+o5nX3qTixdzSUs/Taf2Lfnh542YTCbWrt9M+zYtLhtLSHA5mjWux1OzF5GRcR4/X1+z2zVNqEu1KhUA+HXTNtau38Q9wycyZ8FiTp85S9VK5SkXFMgLryzBYDRiNBq59qpG/L79Tz74+EvCQoLz9t28nU/+71sGDJvA0uWrSE8/w5Y/dtG+9dUElwvCz9eXqALnGxMVzomklCupXhERERERERFxYx7TE+tKekrZi7+fL4tffrrIcqPRSG5uLkajkS4dWtGscT1efecjvvruZ2ZOGV1oW5PJxIhxT3Nzl3aMHHIXfx86hinXRHC5IKpVqcCWbX+Sa8olOjL8srEYDAaenfowm37fyYTpLzG4/61c3/pqs7FdOjaMGtqf1tc2LbTNK89P5od1Gxn+6FNMHTeMhvVq8voLT/DJF99x97AJvDV/OiaTiekTH6RG1Ur5+73/8ZecO59pNr7TZzIIDS132XMQEREREREREc+hnlguICoynPRTZwDYtnMPURFhDBvUh81bdwIQEx1JUnIqAKdOnyUxKZme3Tpgys0lNf1Ufjndu7TjuXlvcf11RZNR/3Xq9BkOHj5G8yb1ubHjdWzZtguA2KiI/GP919VNG/DR56u5cCGHCxdySE07xfHEkySnpnP9dVdzTfNGbNu1h917/8ZgNNC3Zxd8fX04ejyJq5s25IOPvyI3N5eMc+c5fSaDBnVq8OvmbWRlZ3PmbEahgdwTk5KpGB9bsgoVEREREREREbfjMT2xXFnVyuXZe+AwV4eFsO6335m94G3Onj3HA/f2BeDaqxqxZNlKBo2cwoLnJtCx7TXcM2wi9epUp0KBRE/TRvU4fSaD9mZ6VP1XZmY28157n8SkZLy8jDw5fgQA3bq0Y9KMeXS/8XqualK/0D49bmrPgUNH6f/AeAL8/Rlyz23ExkQyd84SUtNOERpSjkH9e7J1226effENTp/JoFnjetSqXpmK5WN59sU36TdkPIEB/owdOZCE+rVo2/Iq7n5gAlUqxRMXG5V/rH0HDtOmZXNbVK+IiIiIiIiIuAFDdnaWydlBlEZOTg5tug1k7aq388eVKmsSk5J5bfEKJj86tFTlbN66k09Wfcf0CQ8WWTd99qJSl+8oFy/mMmbyc8ydMQ6DweDscERERDyWO7SzRMT2jv/vbY5/8yoAzWasc3I0IuJJ1BpxAXExUeTmmsjMzMLf369EZSx84wPW/baVZ6c+bOPoHG/rjt20vraZElgiIiIiIiIikk9JLBcx8ZH7SvUL5/DBdzB88B02jMh5mibUpVH9Ws4OQ0RERERERERciAZ2dxH27qJfVh4lhLyZE/XIgoiIiIiIiIgUpCSWiIiIiIiIiIi4PCWxRERERERERETE5SmJJSIiIiIiIiIiLk9JLBERERERERERcXlKYomIiIiIiIjVjN4+zg5BRDyUklgu4oOPvyIzM8tu5U+fvchuZf/Xp198R2r6KYcdT0REREREHCeqRU/KVWtKldsmOzsUEfEwSmI5UKsb7+buBybQs/8oRj0+k8SkZADOZ2ay5Y9d+Pv7md1v1eofeX3JCkeGWsjmrTsZM3m21dtXLB/L519+b7+ARERERETEabz8gqh93wIim3Z1digi4mGUxHIgfz9flrzyNB8vnkvra5ux8I1lAKz5fgPtrrvKydHZTrNG9fht83ZMJpOzQxERERERERERN+Ht7AAcpWKdlmRfuGCXsn19fDiye73V2xuNRpo3rs/X3/0MwK7d+xnQtzsAv27ezuz5b2MwGLila3vq1anOwjfzkl2/bNrGay88wfLPVvPlNz9x5mwGvW7uyJ29b2LQyMlMnzCSCvExJCYlM3XmQhbNmXLZOHbvOcDsBe+QmZlN8yb1Gf1Af7NlF7Rq9Y/s3vs3xxJPsu/AIR4ZcQ/rfvmdDRu30q1zW+67uzdGo5GY6EjS0k8TER56JVUpIiIiIiIiImKWxySxXMnFi7l8/d3P1K9TA4DEpGSio8IB+PDTr3ng3j60bdmM9FNniIoM59ZuHQC47+7eADRNqMutN3ckKzOLWweMplf3G7i5cztW/28d9/brydr1m+nY9prLxpCTk8Okp+czddwwGtarSVr6aYtl/9e2nXuYP2sC63/dyvTnXuHVuU9w39296DXgYe7tdyteXkbiYiI5ejxJSSwRERERERERsQmPSWJdSU8pe8nMymbAsAnkmkw0rFuTB++/E4Ds7At4e+e9FZ2ub8mSZSsxGgwWHzGMj43i01Xf8ceO3Vy8mEta+mk6tW/JyMeeYeCdt7B2/WYmjx162VgOHUkkLDSYhvVqAhAeFmKx7P9qULcmQYEB1KlVlejICKpWLg9ASEg5zmZkEBoSTHRkOCeSUkioX6tklSUiIiIiIiIiUoDHJLFcgb+fL4tffrrIcqPRSG5uLkajkS4dWtGscT1efecjvvruZ2ZOGV1oW5PJxIhxT3Nzl3aMHHIXfx86hinXRHC5IKpVqcCWbX+Sa8olOjL8srHkmkyAwaqyLfH28ir82tuLf4fBOn02g0oV4y4bg4iIiIiIiIiItTSwuwuIigwn/dQZIO9RvaiIMIYN6sPmrTsBiImOJCk5FYBTp8+SmJRMz24dMOXmkpp+Kr+c7l3a8dy8t7j+uquLPWblCnEkp6Sye88BAI4lJlku22C44kHaE5OSqRgfe0X7iIiIiIiIiIhYYreeWJ9+8R3LP1tNuaBApj8+gpjoyPx1Bw4eZerMBWScO0/HdtcyfFBfIC+B8/yCd7h4MZeuN7Sm3203WSrerVStXJ69Bw5zdVgI6377ndkL3ubs2XM8cG9evVx7VSOWLFvJoJFTWPDcBDq2vYZ7hk2kXp3qVCiQKGraqB6nz2TQvnXxSSxfXx+eGD+Cp194HZMJEurV5NEHB5otu3qVihw9foL9fx+x+pyOJ54kOjriCmtCRERErKF2loiIiHgiQ3Z21pV1sbFCatop7h/9BEsXzWTths38tGEL08YPz18/+en5tGnZjPatWzBqwkweH30fcTFR9H9gPM9PH0t8bDSHjhynWpUKxR4rJyeHNt0GsnbV2/njSpU1iUnJvLZ4BZMfvfw4VsXZvHUnn6z6jukTHiyybvrsRaUu31qHjhzng4+/YtxD9zrkeCIiIp5E7SwRERHxVHZ5nPCXTduoXaMq/v5+NEmoy/rffi+0PigwgLDQEHx8vKlaqQLeXl78tmU7dWtVp2L5WLy8jFY1rNxFXEwUubkmMjOzSlzGwjc+YM7LS3jg3j42jKxk1ny/nt49is5qKCIiIqWndpaIiIh4Krv8pJaSmk7lfwb1jooI42JuLplZ2fj7+QIwsN8tjHp8Jl07tiHXlEt8XDQ///o7AQF+jJs6hxPJKYwa2p9mjeqZLf+jz9ewYuUagCseq8lVTXzkvlL9wjl88B0MH3yHDSMquXvu6KFfa0VEROxE7SwRERHxVPbJNBgKN3pMuSYMBSbCW7V6LX1v7crJ5FT27DvE2YxznDt/nr37DzHnqXEcPprI03NeY+mrM80Wf1uPTtzWoxNwqZt7WWfvpI+jHiUE+5+LiIiIR1M7S0RERDyUXbIN0ZHhbN+1F4CTKWn4+Pjg55v362BmZhY/rt/IOwtm5L3OyuLHdZuIiginWpWKhAQHUb9OddJPn7FHaCIiIiJlmtpZIiIi4qnsMiZWi2YJ7Nl3kMzMLLb88SetWjRh6fJVrP7fOoxGI8cTkzly7AQ5Fy9y6MhxAK5pnsCWP3aRce48O3fvI7bALDsiIiIikkftLBEREfFUdumJFR4WwsB+PRk8airBQYFMnziSJctWYjAY8PX1YdKYITw8cRa5ubk0bVSPzu1b4u3tzX1392LIw9Mw5ZqY9OgQe4QmIiIiUqapnSUiIiKeypCdnVWmR+zU1M8iIiIi9qF2loiIiLgSuzxOKCIiIiIiIiIiYktKYomIiIiIiIiIiMtTEktERERERERERFxemR/cwGTKG9IrJyfHyZGIiIiIJ/Ly8sJgMDg7DLtQO0tEREScrWBbq8wnsS5evAhA+1vuc3IkIiIi4oncedBztbNERETE2Qq2tcr87IS5ublkZ2e77a+g/R94nHdfecbZYbgE1cUlqovCVB+XqC4uUV1coroozNb14a5tEHBMO8uTr09PPXedt2fReXsWnbdncdR5u1VPLKPRiL+/v7PDsBuDweC2v+5eKdXFJaqLwlQfl6guLlFdXKK6KEz1YT1HtLM8+f3w1HPXeXsWnbdn0Xl7FmectwZ2FxERERERERERl6cklovr3b2Ts0NwGaqLS1QXhak+LlFdXKK6uER1UZjqw7V48vvhqeeu8/YsOm/PovP2LM447zI/JpaIiIiIiIiIiLg/9cQSERERERERERGXpySWiIiIiIiIiIi4PCWxRERERERERETE5XneHJAu4PSZDGa++AaHjyQSGlKOJx8fgdFoZPLT80lNO0XXTq3pf/vNALz/8Ze8t3wVd/Tqyl23dwMg/dQZs9uWRaWtizXfr2fZJ19x6vRZ7rq9Gz1v6uDM0ym10tbHv56b9xYHDh1l4XOTnHEaNlHausjJyWHuy0v4fftuQkPK8cS4YcRERzrzlEqstHWRnJLGxBnzOJmcRpOEOkwaMwSjsWz+hmFtXZjbLiI81K3un1D6+nCne2hp6+Jf7nD/dBVXcu/69IvvWP7ZasoFBTL98RHEREeW2XuXp7bzPLVN56ltN09tp3lqm8xT21+e3M5y5XaV639i3ND2XXu4/ZbOLHnlaerUqsrSj1bx5tJPaHfdVbyz8Cm+/OYnDh05DkCzhLq0aJ5QaH9L25ZFpamLixdzOXTkOAufm8TrLz7BvNfe4/SZDGedik2U9toA2HvgMNv/3Ovo0G2utHXxyarvwGDg3VeeYfyowYSHhZo7TJlQ2rr48NOvadWiCR+9/Ty5ubls3LLDGadhE9bWhbntwL3un1C6+nC3e2hprw1wn/unq7D2PUlNO8WSZSt548Vp3NajEwveWAaU3XuXp7bzPLVN56ltN09tp3lqm8xT21+e3M5y5XaVklhO0KpFE5om1AUgoX4tTianse7X32mSUBdvb28S6tVi/W9bAahTqxrxsVGF9re0bVlUmrrw8jIyuH8vfH19CA0JpnxsDOmnTjvlPGyltNeGyWRi3qtLGXTXrQ6P3dZKWxdffvMTd9x6IwaDgcoV4/HxKbsdT0tbF4GBAYSHBmM0GqlRtRLe3l4OPwdbsbYuzG0H7nX/hNLVh7vdQ0t7bbjT/dNVWPue/LJpG7VrVMXf348mCXVZ/9vvQNm9d3lqO89T23Se2nbz1Haap7bJPLX95cntLFduVymJ5WSbft9Jowa1SU07RcXysQBUrhhPckq6xX2uZNuypCR18a/klDTOnM2gQnysnaN0nJLUx4/rN1EhPpba1as4KErHKEldJCYl8+vmbdwzYiIz5rxGzsWLDorWvkpSF72738BHK7/htcUr2LP/EI0a1nFQtPZlbV38ux247/0TSlYf/3K3e2hJ6sJd75+u4nLvSUpqOpUrxgEQFRHGxdxcMrOy3eLe5antPE9t03lq281T22me2ibz1PaXJ7ezXK1dpSSWE+37+zC/bdlB9xvbYTAYwGQCINeUi8FosLjflWxbVpS0LiAvy/vSq+9xb7+eeHm5xyVdkvrIzr7A4g9WMnTgbY4M1e5Kem2cO59JuaAg3po3ndS0U/y4bpOjQrabktbFDz9vpF2rqwgKDGD/wSMkp6Q5KmS7sbYuCm4H7nn/hJLXB7jfPbQkdeGu909XUex7Ysi7Dv9lyjVhMJT9e5entvM8tU3nqW03T22neWqbzFPbX57cznLFdlXZq0U3kZZ+mqkzF/LUxJH4+foSER7KkWMnADh8JJHoyHCL+17JtmVBaeoC4L2PvsDHx5seXa93QLT2V9L62LpjN6fPnGXM5Nk89uQL7N77N3NfXuLI0G2uNNdGZHgoTRrWwWg0clWT+hw7nuSosO2iNHXx/sdfcs8d3el32030uPF6Vq1e66iw7cLauvjvduB+908oXX2Ae91DS1oX7nj/dBXWvCfRkeEcOpoIwMmUNHx8fPDz9S3T9y5Pbed5apvOU9tuntpO89Q2mae2vzy5neWq7SolsZwgO/sCE6a/yP0DelOzWiUArrumKVu2/UlOTg7bd+2l5dWNLe5/Jdu6utLWxdoNm/lx/SbGPXRvXma4jCtNfVzdtCHL33qe11+cxrNTRlOnZlUeHna3I8O3qdJeG62vbcZ3P/1KzsWLbPx9J9WrVnRU6DZX2rrIzr7Ajj/3kZuby4GDRx0Vtl1YWxfmtrO0bVlW2vpwp3toaerC3e6frsLa96RFswT27DtIZmYWW/74k1YtmuTvXxbvXZ7azvPUNp2ntt08tZ3mqW0yT21/eXI7y5XbVYbs7CxT8ZuJLb3x7icsXf5/VK1cnpycvOe/n39qLNOfW0RKajo3d2nLnb1v4mRKGmMmPUdK2imMBgNVKpdn/rMTOHX6LJOfnl9o27KqNHUxe9oYbuo7nJjoSHx9fcBkousNrT22PuY/OyG/nOOJJ5n+/KIyM02zObb4nDz53CscOnKcq5s2ZOzIgWXuH49/lbYutu74i1kvvUlmZhY1qlZiyrgHKBcU6OSzKhlr68Lcdq/OnUpW9gW3uX9C6evDne6hpa0Lf38/wD3un67C2vcEYOXXP/DBx18SHBTI9IkjiY4ML7P3Lk9t53lqm85T226e2k7z1DaZp7a/PLmd5crtKiWxRERERERERETE5elxQhERERERERERcXlKYomIiIiIiIiIiMtTEktERERERERERFyeklgiIiIiIiIiIuLylMQSERERERERERGXpySWiIiIiIiIiIi4PCWxRERERERERETE5SmJJfIfGzb+wd0PTOCuIeO5b9RUfli30WZlv/Tqe2z8fYfNyrt1wOj8v48nnqRTryE2K9sVFTxfT1LwvLOzLzBu6hxSUtNtVv7wsU9xPPHkFe83YNgENm/dWWT5f9+nll36c+ZsRknDKxVnHltERIpSO8t1qZ2ldtaVUjtLnMHb2QGIuJLs7AtMnPESC2ZNpG6taiSnpPH34WM2K/+hIf1sVpZ4Jl9fH2ZNe8TZYYiIiFwxtbPE1amdJeL6lMQSKSDn4kWysi5w+kzeLwpRkeFERYYDcOFCDgve+ID1v23FZDLRv8/N9Ljxev4+dJRps14h49x5wkKDmTZ+BGGh5Xhi5svs+/swvj4+jHqgP9c0T+CxJ+bStlVzunVuy9mMc8x9eQl//nUAg9HAHbfeyM1d2gF5v9h0bHsNP67bxJ59h+jd4wYG9+9VKM67H3ic5JQ0BgybQPcbr6f1NU3JNeXy9nuf8eP6jaSdOsOMiSOpX6eGxdgLGj72KRo3qMPWHbtJOplK25bNGTmkHwaDgaXLV/Htj79wPjOT8nHRPPn4gwQFBvD6khUYDAa27dxDeFgo4x4ayIuvLOWvfQc5czaD66+7mhH33ZFffvvWLfjh540cPprIsEF9SE5JZ80P68nKusDMKaOpWrm8xVhHPT6TxBPJDBg2gZZXN2bYoL78/MsWXnlrOdkXsqlVvQqTxgzB39+PWweMZti9ffjg4y/p36c7RoOB+a+/j5eXkTo1qzJl7AN4e+fd/n5Yt5EPPv6Kl2dPIjc3l5v6Dqd/n5vpf/vN7N77N8/MfZ23FzzFwcPHmPXSW6SknSIkOIhJY4ZQuWI802cvok7Nqvzvp99oWLcmwwf35Z0PPufLb37CZDLR9YbW3NuvZ6G6Tk5JY9ZLb3HoaCK+vj6MG3kvDevV5PuffisS55jJs4ucd6deQ1i8cAbxcdHcOmA09/bryf99/QMpqek8+uBANm/dxU+/bCYwIIDnpj1CRHgoO/7cy6K3PyL99BkuXLjAuIcG0TShLtNnL2Lbzj08Mvk56tepweRHh7J9117mLFxMxrnzxMdGMWXsA0SEh5KYlMzMF97gZHIaFeJjSD99pshnyNz7BPDZl/9j7frNHD6ayMRH7ue6a5qyeetOln+2hvCwEP7cs5+FsyeTeCKZ2QveJi39NIEBAYwaehcN69XkeOJJBgyfyJqPX81/35Z98hULn5vE2YxzTH9uEX/tP8jJk6mEhJSj5dWNmfzoUIvHFhERx1M7S+0stbPUzhIpLT1OKFJAYIA/jz88mIlPvcRj0+aydfvu/HVLP1qFn68P77/2LIsXzmDp8lWkpp3i4//7lob1avLhm7OZNn4EsdER/LJxG0eOn2D5W8/z8vOTaVC3RpFjvfTqUgID/Hl30TPMm/k4b7//WaHj7d77N88/NZaXZo7nraWfkpmZlb/O28uLOdPHEhUZzuKXn+b2WzoDkJWZTf061XnjpSe5/rqr+ODjry4b+3+dz8xi3swJLH75aX5Yt5H1v20FoFnjerw6dwrvvfosFy/m8tW3P+Xv89Hna3hs1GCmjnsAfz8/bu7Sjjdemsbil2fw2ZffceDg0fxt9+w/yAvPPMaYEfcwbdYrVK4Yz9vzn6Jh3Rp89Pmay8b64jPjAVj88tMMG9SXo8eTeHXxRyx4biIfvP4cFeJj+OSL7/KP9dOGzbz2wjQ6tGnB6+9+zIjBd/DB688x7N6++Q0rgKsa12f3ngNkZmaxZ/8halarzMYteY8ibPp9Jy2aJ5Bz8SKTn57Pw8Pu5oPXZzHorluZ/9r7hepg1hMPM+K+O1j9v/UcPHyMpYueYemimfy6eTu79xwoVM9PPf8qvbrfwAevz+LJ8cOZNe8tALNx/ve8zTmZnMaiOVPo07MLE596ibatmvPuKzMJDPDny2/y3quoiHAmjbmfxQtnMPDOnsx79T0AJj86lKjIcOZMH8vkR4dy5mwGT895jWcmj2LZG8/R7rqreOeDzwCY/twimjWux9JXZzJxzP14GYv+E2Ip3vDQEF55fjID77yFt9//PH/52vWbaHl1I96cNx1vby8emzaH3jffwNJFMxn9wF2Mf3Jusd3UV6z8hpyLOax4ew6L5k4lwN8vv2F1uWOLiIhjqZ2ldpbaWWpniZSWemKJ/Ee3Tm1pdXUTPv/qe8Y/+QKd27fk4WEDWLt+M2fOZuQ3OLIvXCAxKZmOba9h5otv8Ma7n9Dr5o4YjUYaNayNr48Pz774Jnf0upGqlSsUOc5P67fw6gtTMRgMhIeF0On6lvy0YQuNG9YB4LprmuLt5UWNapXw8fEh7dQZ4v39Lht7QIA/LZonANCwXi0+XvkNgMXYI8JDC+3ftFFdvLyMBAb4c1WTBmzftZdWLZpQuWI8X337M1t3/MWRYyc4cuxE/j4d215LfGwUAAaDgejIcJZ+tIq/9v4NwJFjiVSrUqHQOSXUrwVA21bNAUioX5t1v/1+RbH+svEPTiSl8OC4Gf9sl0OrFk3y19/Z+ya8vPL+8b+la3veeu9Tzp47T5f2rQqVExQUSN3a1fhj5x727DtI5/YtWbxsJRcu5LBp6w769e7GkaOJHDx8nCefewUAkwn8C7wXt3RtT3C5oH/i38SO3fsYNHIKAOfOZ3L8RDJ1alXLf71xyw5S006x8I0PAPIbD5eL83LatGyGwWAgoX4tQkOD8+u3Qd0anExJAyAmOoIt2/7kg0++Zs++g4Xew4K279rLieQUxk59HoCLF3OpVqUC585nsnX7bubMGAtAaEhw/jlbo22r5hgMBhrWq5nf6AeoUqk8bVrmXQeHjySSmZlN+zYt/om/JhXiY9m+ay9VK5W3WHZcTCTrfj1PVnY2qWnpGAwGq44tIiKOp3aW2llqZ6mdJVIaSmKJmBEeFsI9d/SgQ5sW9B08lkF39cJkMjHy/jvz/yEo6O0FT/H1tz9zz4iJPPHYcJo1qseb855kw8Y/mPLMAjpd35K7+3a//EEN8J9/E/IWGwx4e3vl/Yt+Bby9vTCRt8/lYr/c/gH+fpzPzOS+UVPpceP19L+9GzFREZzNOJe/3b8NGIC/9h1k0ox5DBlwG107tiY5dT65ZuL29vYq+vqfzayN1YSJJgl1mTlltNn1Xl6XjnH7LZ3p2PYaln+2mr73jeXNl54kPCwkf/21VzViyx+72L33bx4edje/bNrGtp1/sXvv3yTUr8XR40n4+/vx9oKnMJr5VazgsUwmE3f26kqfnl0uG/uC5yYWaZwUF2dxCv7ymffaC1NmXsW++s5H7D94hDt6daXHjddz/+gnzMdmMlGxfCzvLJhRaPm/73nBcy0Jb2/v/Osyr7zLdwjO/0gYDOTkXMRkMhVpPLVq0YQ33v2E4Y/OwMfHm6njhll1bBERcQ61s9TOUjtL7SyRktLjhCIF7PprP+8u/z8uXMgBIDEpmdCQcgQFBdD62qYsXvZ/ZPzzj8yxxCQA/tjxFwYMdL/xepo0rMPmrTvZ//cR0k6dpuXVjbn15o6s37i1yLFat2zK8s++xmQykX7qDGv+t57rrm1mdazh4aFkZJwjMyu72G0txf5fh48mYjKZSEpO5Yd1G7nmqkYcOnyc9FNnuP2WzsTGRLFn30GLx9n0+w6qVanADddfy8XcXE4kpVh9PtbEGhcTmT+7S4tmCfy2eTvbdu4BIC39NOfOZxYpLzc3l81/7CI8LITBd/ci92IuBw4eKbTNtVc1Zsef+ziRlELF8rE0a1yPT7/4jjo1q+Lr60OlinGEhZbjg4+/wmQykZ19gaTkVAvxN+PDT7/On9Xmv3UdGOBP00b1eG3xCnJzc7l4MZfjJ5IvG2fB8y6ptRs2061TW5om1OWvfX8XWhcXE8XxE3nlN6hbkxNJKXy39lcAMs6dJy39NOWCAqlWpWJ+t/ljiUkkW5i5p6TxVqoYh7+/L9///BsAO/7cx9HjSTSsV5Pw0GAuXLjAX3v/Jis7m9Xfrbt0bus306xxPd6aP51X507N/4VURERci9pZamepnaV2lkhpqSeWSAFVK5fn2x9/YfBDU8jKvkBQYADPTn0Yby8v7u7TnbNnz3HvyCn4+/tRo2pFpox9gD37DzL35SWcO3+e6MgIRg3tz8Ejx5n10puc+aeBMG7kvUWO9dCQu5izcDH9hz6OwWhg4J230LhBbatj9ffzpUuH67jzvrH07t6Jjm2vsbitpdj/+0vLth17uP+nJzhzNoOhA/tQu0YVcnLyuo/fNfRxqlSMp0L5GHJzzf/K0r5NC37+5XcGDJ9I7RpVqFalotXnY02svbt3YsgjT9Kx7TWMfqA/08aPYNZLb2HCRGCAP4+NGkSNqpUKlZedfYH/rf2VF155l7Nnz9Hy6sY0+udRgn/VrFaJvw8fpVmjehgMBpo3rs+chYt5aMhdQN7YGM9OfYTZC95m5dff4+vrw919unNDu2uLxH9jx+s4mZLK8LFP4efrS3RUBDMmjizULX7quGHMnv82d97/GH6+PnTr3JZbura3GOd/z7sk+t/ejZffWsYHn3xJu1ZXFfplrudNHZj8zAKaNarH9AkP8ty0Mby46F3eWPIxfn4+jBh8J82b1Gfy2KE8M/d1ln/6NTWqVaJShTizxyppvPn1PP9tXlu8gsAAf56ZMjr/l9R77+rJyPHPUKNaZXrceD0rv/4egIb1avLcvLf5Y/tfePt4Uz4umo5tr6HT9S1LVFciImIfamepnaV2ltpZIqVlyM7OUp8/EWH42Kfoe+uNtGt1lbNDEbkiM+a8xrVXNaJj22u4eDGXd5f/Hz+u28QbL01zdmgiIiKA2llSdqmdJa5GPbFERKRMa9fqKt79cCXvvP8Z2RdyqBAfzcRH7nd2WCIiIiJlntpZ4mrUE0tERERERERERFyeBnYXERERERERERGXpySWiIiIiIiIiIi4PCWxRERERERERETE5f0/nDQ/+uKqu4gAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Two panels against the session each estimate was made through. On the left the probability of staying in each regime state, both close to one and drifting slowly over the sixty-odd re-estimations. On the right the median GARCH persistence across ETFs, also close to one, moving more sharply around the volatile stretches of the sample and staying below the dashed line at one, above which shocks would never decay."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig_stab, (ax_l, ax_r) = plt.subplots(1, 2, figsize=(12, 4))\n",
     "\n",
@@ -1773,14 +2543,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d2db30d",
+   "id": "9f33caf6",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003389,
-     "end_time": "2026-09-05T01:20:17.649916+00:00",
+     "duration": 0.003411,
+     "end_time": "2026-09-05T03:37:16.191034+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:17.646527+00:00",
+     "start_time": "2026-09-05T03:37:16.187623+00:00",
      "status": "completed"
     }
    },
@@ -1802,10 +2572,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "59353093",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 24,
+   "id": "5784d200",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:16.198448Z",
+     "iopub.status.busy": "2026-09-05T03:37:16.198358Z",
+     "iopub.status.idle": "2026-09-05T03:37:16.201554Z",
+     "shell.execute_reply": "2026-09-05T03:37:16.201071Z"
+    },
+    "papermill": {
+     "duration": 0.007309,
+     "end_time": "2026-09-05T03:37:16.201795+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:16.194486+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Widest regime persistence range across estimates: 0.0133\n",
+      "GARCH median persistence range across estimates:  0.1345\n",
+      "Expected run in the stressed state: 173 sessions at the most persistent estimate, 52 at the least.\n",
+      "Expected run in the calm state: 431 sessions at the most persistent estimate, 98 at the least.\n",
+      "GARCH variance-shock half-life: -62450858 sessions at the most persistent estimate, 5 at the least.\n"
+     ]
+    }
+   ],
    "source": [
     "def _range(series: pl.Series) -> float:\n",
     "    return float(series.max() - series.min())\n",
@@ -1835,13 +2631,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91ede0fe",
+   "id": "2ba879f8",
    "metadata": {
     "papermill": {
-     "duration": 0.003346,
-     "end_time": "2026-09-05T01:20:17.669075+00:00",
+     "duration": 0.00349,
+     "end_time": "2026-09-05T03:37:16.208922+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:17.665729+00:00",
+     "start_time": "2026-09-05T03:37:16.205432+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1863,13 +2659,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56039fba",
+   "id": "a844cf59",
    "metadata": {
     "papermill": {
-     "duration": 0.003752,
-     "end_time": "2026-09-05T01:20:17.676654+00:00",
+     "duration": 0.003394,
+     "end_time": "2026-09-05T03:37:16.215834+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:17.672902+00:00",
+     "start_time": "2026-09-05T03:37:16.212440+00:00",
      "status": "completed"
     }
    },
@@ -1899,9 +2695,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fef0d8ae",
-   "metadata": {},
+   "execution_count": 25,
+   "id": "4fd63d5f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:16.223683Z",
+     "iopub.status.busy": "2026-09-05T03:37:16.223515Z",
+     "iopub.status.idle": "2026-09-05T03:37:16.297655Z",
+     "shell.execute_reply": "2026-09-05T03:37:16.297301Z"
+    },
+    "papermill": {
+     "duration": 0.079139,
+     "end_time": "2026-09-05T03:37:16.298453+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:16.219314+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "skeleton = (\n",
@@ -1921,10 +2731,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "87ffae8e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 26,
+   "id": "d2e0db08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:16.306542Z",
+     "iopub.status.busy": "2026-09-05T03:37:16.306463Z",
+     "iopub.status.idle": "2026-09-05T03:37:16.329750Z",
+     "shell.execute_reply": "2026-09-05T03:37:16.329181Z"
+    },
+    "papermill": {
+     "duration": 0.027698,
+     "end_time": "2026-09-05T03:37:16.330048+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:16.302350+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "470,662 rows, 14 features, 100 ETFs, one row per session-symbol.\n",
+      "Panel runs 2006-01-03 to 2025-12-31; the price history ends 2025-12-31 and the holdout 2025-12-31, so 0 rows were cut for falling past it.\n"
+     ]
+    }
+   ],
    "source": [
     "assert model_based.select(KEY_COLS).is_duplicated().sum() == 0, (\n",
     "    \"the panel key repeats; a downstream join would multiply rows\"\n",
@@ -1966,13 +2799,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88707e28",
+   "id": "45aadcd1",
    "metadata": {
     "papermill": {
-     "duration": 0.003486,
-     "end_time": "2026-09-05T01:20:17.789213+00:00",
+     "duration": 0.00354,
+     "end_time": "2026-09-05T03:37:16.337464+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:17.785727+00:00",
+     "start_time": "2026-09-05T03:37:16.333924+00:00",
      "status": "completed"
     }
    },
@@ -1993,10 +2826,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "299686bf",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 27,
+   "id": "e4a78797",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:16.345128Z",
+     "iopub.status.busy": "2026-09-05T03:37:16.345023Z",
+     "iopub.status.idle": "2026-09-05T03:37:16.369285Z",
+     "shell.execute_reply": "2026-09-05T03:37:16.368885Z"
+    },
+    "papermill": {
+     "duration": 0.028646,
+     "end_time": "2026-09-05T03:37:16.369640+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:16.340994+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (14, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>feature</th><th>first value</th><th>rows with a value</th><th>coverage</th><th>mean (development)</th><th>std (development)</th></tr><tr><td>str</td><td>date</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;regime_prob_stress&quot;</td><td>2009-02-04</td><td>411285</td><td>0.873844</td><td>0.259508</td><td>0.427855</td></tr><tr><td>&quot;regime_transition&quot;</td><td>2009-02-04</td><td>411285</td><td>0.873844</td><td>0.01467</td><td>0.072386</td></tr><tr><td>&quot;regime_log_duration&quot;</td><td>2009-02-04</td><td>411285</td><td>0.873844</td><td>4.420407</td><td>1.410809</td></tr><tr><td>&quot;ffd_spy&quot;</td><td>2006-01-03</td><td>470662</td><td>1.0</td><td>0.226711</td><td>0.10167</td></tr><tr><td>&quot;ffd_qqq&quot;</td><td>2006-01-03</td><td>470662</td><td>1.0</td><td>0.207464</td><td>0.081344</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;ffd_gld&quot;</td><td>2006-01-03</td><td>470662</td><td>1.0</td><td>0.208191</td><td>0.092144</td></tr><tr><td>&quot;ffd_vnq&quot;</td><td>2006-01-03</td><td>470662</td><td>1.0</td><td>0.167808</td><td>0.079659</td></tr><tr><td>&quot;ffd_hyg&quot;</td><td>2007-04-11</td><td>449008</td><td>0.953992</td><td>0.0867</td><td>0.070732</td></tr><tr><td>&quot;ffd_lqd&quot;</td><td>2006-01-03</td><td>470662</td><td>1.0</td><td>0.093735</td><td>0.068206</td></tr><tr><td>&quot;garch_cond_vol&quot;</td><td>2008-01-07</td><td>420162</td><td>0.892704</td><td>0.194704</td><td>0.139848</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (14, 6)\n",
+       "┌─────────────────────┬─────────────┬─────────────┬──────────┬───────────────┬─────────────────────┐\n",
+       "│ feature             ┆ first value ┆ rows with a ┆ coverage ┆ mean          ┆ std (development)   │\n",
+       "│ ---                 ┆ ---         ┆ value       ┆ ---      ┆ (development) ┆ ---                 │\n",
+       "│ str                 ┆ date        ┆ ---         ┆ f64      ┆ ---           ┆ f64                 │\n",
+       "│                     ┆             ┆ i64         ┆          ┆ f64           ┆                     │\n",
+       "╞═════════════════════╪═════════════╪═════════════╪══════════╪═══════════════╪═════════════════════╡\n",
+       "│ regime_prob_stress  ┆ 2009-02-04  ┆ 411285      ┆ 0.873844 ┆ 0.259508      ┆ 0.427855            │\n",
+       "│ regime_transition   ┆ 2009-02-04  ┆ 411285      ┆ 0.873844 ┆ 0.01467       ┆ 0.072386            │\n",
+       "│ regime_log_duration ┆ 2009-02-04  ┆ 411285      ┆ 0.873844 ┆ 4.420407      ┆ 1.410809            │\n",
+       "│ ffd_spy             ┆ 2006-01-03  ┆ 470662      ┆ 1.0      ┆ 0.226711      ┆ 0.10167             │\n",
+       "│ ffd_qqq             ┆ 2006-01-03  ┆ 470662      ┆ 1.0      ┆ 0.207464      ┆ 0.081344            │\n",
+       "│ …                   ┆ …           ┆ …           ┆ …        ┆ …             ┆ …                   │\n",
+       "│ ffd_gld             ┆ 2006-01-03  ┆ 470662      ┆ 1.0      ┆ 0.208191      ┆ 0.092144            │\n",
+       "│ ffd_vnq             ┆ 2006-01-03  ┆ 470662      ┆ 1.0      ┆ 0.167808      ┆ 0.079659            │\n",
+       "│ ffd_hyg             ┆ 2007-04-11  ┆ 449008      ┆ 0.953992 ┆ 0.0867        ┆ 0.070732            │\n",
+       "│ ffd_lqd             ┆ 2006-01-03  ┆ 470662      ┆ 1.0      ┆ 0.093735      ┆ 0.068206            │\n",
+       "│ garch_cond_vol      ┆ 2008-01-07  ┆ 420162      ┆ 0.892704 ┆ 0.194704      ┆ 0.139848            │\n",
+       "└─────────────────────┴─────────────┴─────────────┴──────────┴───────────────┴─────────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Coverage over the sessions the folds validate on, which is what a model actually reads: regime_prob_stress 100.0%, regime_transition 100.0%, regime_log_duration 100.0%, ffd_spy 100.0%, ffd_qqq 100.0%, ffd_iwm 100.0%, ffd_efa 100.0%, ffd_eem 100.0%, ffd_tlt 100.0%, ffd_gld 100.0%, ffd_vnq 100.0%, ffd_hyg 100.0%, ffd_lqd 100.0%, garch_cond_vol 99.5%\n"
+     ]
+    }
+   ],
    "source": [
     "_dev = model_based.filter(pl.col(\"timestamp\") < pl.lit(HOLDOUT_START).cast(pl.Date))\n",
     "display(\n",
@@ -2025,13 +2917,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "767a5f92",
+   "id": "0d219b47",
    "metadata": {
     "papermill": {
-     "duration": 0.00353,
-     "end_time": "2026-09-05T01:20:17.829692+00:00",
+     "duration": 0.003552,
+     "end_time": "2026-09-05T03:37:16.378295+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:17.826162+00:00",
+     "start_time": "2026-09-05T03:37:16.374743+00:00",
      "status": "completed"
     }
    },
@@ -2046,10 +2938,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7e8ee0b4",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 28,
+   "id": "832a48be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:16.385868Z",
+     "iopub.status.busy": "2026-09-05T03:37:16.385783Z",
+     "iopub.status.idle": "2026-09-05T03:37:16.473694Z",
+     "shell.execute_reply": "2026-09-05T03:37:16.473229Z"
+    },
+    "papermill": {
+     "duration": 0.09257,
+     "end_time": "2026-09-05T03:37:16.474446+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:16.381876+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wrote case_studies/etfs/features/model_based.parquet\n",
+      "  digest 6630763a5692da3c, 470,662 rows\n"
+     ]
+    }
+   ],
    "source": [
     "record = write_model_based(\n",
     "    model_based,\n",
@@ -2083,13 +2998,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71fb0bda",
+   "id": "794c4610",
    "metadata": {
     "papermill": {
-     "duration": 0.003625,
-     "end_time": "2026-09-05T01:20:17.915201+00:00",
+     "duration": 0.003647,
+     "end_time": "2026-09-05T03:37:16.482339+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:17.911576+00:00",
+     "start_time": "2026-09-05T03:37:16.478692+00:00",
      "status": "completed"
     }
    },
@@ -2109,10 +3024,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8f4500ab",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 29,
+   "id": "fb9894f4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:16.489982Z",
+     "iopub.status.busy": "2026-09-05T03:37:16.489906Z",
+     "iopub.status.idle": "2026-09-05T03:37:16.508586Z",
+     "shell.execute_reply": "2026-09-05T03:37:16.508156Z"
+    },
+    "papermill": {
+     "duration": 0.02295,
+     "end_time": "2026-09-05T03:37:16.508843+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:16.485893+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "198,877 validation rows, of which 198,877 carry a resolved fwd_ret_21d; 0 do not, being the sessions whose forward window runs past the end of the price history or whose ETF was not yet quoting.\n",
+      "100 ETFs scored across 1,995 sessions.\n"
+     ]
+    }
+   ],
    "source": [
     "val_features = model_based.filter(in_validation_windows())\n",
     "\n",
@@ -2132,13 +3070,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd8a071c",
+   "id": "26d9af8e",
    "metadata": {
     "papermill": {
-     "duration": 0.00372,
-     "end_time": "2026-09-05T01:20:17.951943+00:00",
+     "duration": 0.003588,
+     "end_time": "2026-09-05T03:37:16.516347+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:17.948223+00:00",
+     "start_time": "2026-09-05T03:37:16.512759+00:00",
      "status": "completed"
     }
    },
@@ -2164,10 +3102,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7b3a9b4e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 30,
+   "id": "a6ab0b43",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:16.524056Z",
+     "iopub.status.busy": "2026-09-05T03:37:16.523970Z",
+     "iopub.status.idle": "2026-09-05T03:37:16.556400Z",
+     "shell.execute_reply": "2026-09-05T03:37:16.556039Z"
+    },
+    "papermill": {
+     "duration": 0.036776,
+     "end_time": "2026-09-05T03:37:16.556728+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:16.519952+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "garch_cond_vol: 1,995 sessions carry a cross-sectional coefficient\n"
+     ]
+    }
+   ],
    "source": [
     "DATE_LEVEL_COLS = [c for c in FEATURE_COLS if c not in GARCH_COLS]\n",
     "feature_stats = {}\n",
@@ -2203,9 +3163,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0a61043b",
-   "metadata": {},
+   "execution_count": 31,
+   "id": "81719ccf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:16.564959Z",
+     "iopub.status.busy": "2026-09-05T03:37:16.564870Z",
+     "iopub.status.idle": "2026-09-05T03:37:35.865853Z",
+     "shell.execute_reply": "2026-09-05T03:37:35.865250Z"
+    },
+    "papermill": {
+     "duration": 19.305591,
+     "end_time": "2026-09-05T03:37:35.866269+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:16.560678+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "panel_return = (\n",
@@ -2241,13 +3215,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f35f9bd6",
+   "id": "c2770711",
    "metadata": {
     "papermill": {
-     "duration": 0.003678,
-     "end_time": "2026-09-05T01:20:37.502034+00:00",
+     "duration": 0.003665,
+     "end_time": "2026-09-05T03:37:35.874025+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:37.498356+00:00",
+     "start_time": "2026-09-05T03:37:35.870360+00:00",
      "status": "completed"
     }
    },
@@ -2261,10 +3235,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "29b1def1",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 32,
+   "id": "a84dd5a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:35.882351Z",
+     "iopub.status.busy": "2026-09-05T03:37:35.882242Z",
+     "iopub.status.idle": "2026-09-05T03:37:35.887205Z",
+     "shell.execute_reply": "2026-09-05T03:37:35.886883Z"
+    },
+    "papermill": {
+     "duration": 0.009815,
+     "end_time": "2026-09-05T03:37:35.887553+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:35.877738+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (14, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>feature</th><th>kind</th><th>ic</th><th>t_stat</th><th>p_value</th><th>se</th><th>retained</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>bool</td></tr></thead><tbody><tr><td>&quot;ffd_tlt&quot;</td><td>&quot;time-series&quot;</td><td>0.189477</td><td>2.371211</td><td>0.002</td><td>0.079907</td><td>true</td></tr><tr><td>&quot;regime_prob_stress&quot;</td><td>&quot;time-series&quot;</td><td>0.171462</td><td>2.14165</td><td>0.023</td><td>0.080061</td><td>true</td></tr><tr><td>&quot;ffd_lqd&quot;</td><td>&quot;time-series&quot;</td><td>0.139792</td><td>1.735038</td><td>0.033</td><td>0.08057</td><td>false</td></tr><tr><td>&quot;ffd_gld&quot;</td><td>&quot;time-series&quot;</td><td>0.069414</td><td>0.836257</td><td>0.295</td><td>0.083005</td><td>false</td></tr><tr><td>&quot;garch_cond_vol&quot;</td><td>&quot;cross-sectional&quot;</td><td>0.068999</td><td>2.519155</td><td>0.011841</td><td>0.02739</td><td>true</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;ffd_qqq&quot;</td><td>&quot;time-series&quot;</td><td>-0.142454</td><td>-1.791099</td><td>0.041</td><td>0.079534</td><td>false</td></tr><tr><td>&quot;ffd_vnq&quot;</td><td>&quot;time-series&quot;</td><td>-0.17798</td><td>-2.442207</td><td>0.003</td><td>0.072877</td><td>true</td></tr><tr><td>&quot;ffd_efa&quot;</td><td>&quot;time-series&quot;</td><td>-0.182395</td><td>-2.464351</td><td>0.009</td><td>0.074014</td><td>true</td></tr><tr><td>&quot;ffd_iwm&quot;</td><td>&quot;time-series&quot;</td><td>-0.188124</td><td>-2.59276</td><td>0.007</td><td>0.072557</td><td>true</td></tr><tr><td>&quot;ffd_spy&quot;</td><td>&quot;time-series&quot;</td><td>-0.202813</td><td>-2.941841</td><td>0.001</td><td>0.068941</td><td>true</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (14, 7)\n",
+       "┌────────────────────┬─────────────────┬───────────┬───────────┬──────────┬──────────┬──────────┐\n",
+       "│ feature            ┆ kind            ┆ ic        ┆ t_stat    ┆ p_value  ┆ se       ┆ retained │\n",
+       "│ ---                ┆ ---             ┆ ---       ┆ ---       ┆ ---      ┆ ---      ┆ ---      │\n",
+       "│ str                ┆ str             ┆ f64       ┆ f64       ┆ f64      ┆ f64      ┆ bool     │\n",
+       "╞════════════════════╪═════════════════╪═══════════╪═══════════╪══════════╪══════════╪══════════╡\n",
+       "│ ffd_tlt            ┆ time-series     ┆ 0.189477  ┆ 2.371211  ┆ 0.002    ┆ 0.079907 ┆ true     │\n",
+       "│ regime_prob_stress ┆ time-series     ┆ 0.171462  ┆ 2.14165   ┆ 0.023    ┆ 0.080061 ┆ true     │\n",
+       "│ ffd_lqd            ┆ time-series     ┆ 0.139792  ┆ 1.735038  ┆ 0.033    ┆ 0.08057  ┆ false    │\n",
+       "│ ffd_gld            ┆ time-series     ┆ 0.069414  ┆ 0.836257  ┆ 0.295    ┆ 0.083005 ┆ false    │\n",
+       "│ garch_cond_vol     ┆ cross-sectional ┆ 0.068999  ┆ 2.519155  ┆ 0.011841 ┆ 0.02739  ┆ true     │\n",
+       "│ …                  ┆ …               ┆ …         ┆ …         ┆ …        ┆ …        ┆ …        │\n",
+       "│ ffd_qqq            ┆ time-series     ┆ -0.142454 ┆ -1.791099 ┆ 0.041    ┆ 0.079534 ┆ false    │\n",
+       "│ ffd_vnq            ┆ time-series     ┆ -0.17798  ┆ -2.442207 ┆ 0.003    ┆ 0.072877 ┆ true     │\n",
+       "│ ffd_efa            ┆ time-series     ┆ -0.182395 ┆ -2.464351 ┆ 0.009    ┆ 0.074014 ┆ true     │\n",
+       "│ ffd_iwm            ┆ time-series     ┆ -0.188124 ┆ -2.59276  ┆ 0.007    ┆ 0.072557 ┆ true     │\n",
+       "│ ffd_spy            ┆ time-series     ┆ -0.202813 ┆ -2.941841 ┆ 0.001    ┆ 0.068941 ┆ true     │\n",
+       "└────────────────────┴─────────────────┴───────────┴───────────┴──────────┴──────────┴──────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Retained by Benjamini-Hochberg at 5%: 7 of 14\n"
+     ]
+    }
+   ],
    "source": [
     "evaluation = pl.DataFrame(\n",
     "    [\n",
@@ -2294,13 +3326,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1fd07e4",
+   "id": "a35133bc",
    "metadata": {
     "papermill": {
-     "duration": 0.005596,
-     "end_time": "2026-09-05T01:20:37.525019+00:00",
+     "duration": 0.003739,
+     "end_time": "2026-09-05T03:37:35.895255+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:37.519423+00:00",
+     "start_time": "2026-09-05T03:37:35.891516+00:00",
      "status": "completed"
     }
    },
@@ -2312,10 +3344,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c75b980c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 33,
+   "id": "baad1296",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-05T03:37:35.903422Z",
+     "iopub.status.busy": "2026-09-05T03:37:35.903314Z",
+     "iopub.status.idle": "2026-09-05T03:37:35.979631Z",
+     "shell.execute_reply": "2026-09-05T03:37:35.979212Z"
+    },
+    "papermill": {
+     "duration": 0.080908,
+     "end_time": "2026-09-05T03:37:35.979921+00:00",
+     "exception": false,
+     "start_time": "2026-09-05T03:37:35.899013+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA4UAAAIxCAYAAAD6/B13AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAhCdJREFUeJzs3Xd4FNUexvF300gjCYTekd4JvasIIqIoTZTee5UqAtI70qQEUDqiFKWJgIIKiiC9hd47hPRNIdm9fyDxhvQQssB+P89znwdnzpz5nbNDbl7mzKwhIiLcLAAAAACAVbKxdAEAAAAAAMshFAIAAACAFSMUAgAAAIAVIxQCAAAAgBUjFAIAAACAFSMU4rkJCwtX8Qp1NWz01FTv++r1m6rfuJ1yFKqs3gNHJdq+VJX6eqdR2+hjPXKV0bgpX6V6XSkxcfp8eeQqo5u37lq6lBR5p1FblapSP9X6GzflK3nkKqOr12+mWp+vkgZNO8qr+nvPpe9/Dh1X3hI1tHHrL8+l/6f5+QWoedteylm4ihq16Jpo++c59mf19M8ks9msYaOnKl+JmipR8W3tO3A4SXN749Yd5S9ZS/MWr0yjygEAIBS+9EpVqS+PXGXkkauMshaoqCq1G2nZqvVJOvabFd/LI1eZVKtl1ISZMcKBo2M6rVj0pXp1aZNq53hi6syF2nfgiD4b0ENtPmmc6v0/L6GhYfLIVUarvt+YZud8+nPBiyOx6+GX3X+maUAuU6qYVi2eqbfeqJYm51u0bI22/7pHndo2V78eHWLsS+uxP6unfybtO3BE8xatVOUKZTRmeH+VL1sqSXObI1sWrfp6pj5u8uzh99yFy/LIVUZ7/vrnmfsCALza7CxdAJ5d4YL5NXJoH925e18/bN6hvkPGqGCBfKpepXyCx92955uqddy9H7u/8l6lUvUcT1y5dkOZM2VU725tn0v/z8u9B6k750kR1+eCF0Ni18Pd+w/SqJLHHBzsVaNqhTQ735VrNyRJQz/tLicnxxj70nrsz+rpn0mr126SJHVq+7Hq1q4hSUmaWxsbG1WrXC5Varp77+WaQwCA5XCn8BWQMYO73nuntjq1ba7xXwyUJB0+elKS5O8fqJ4DRip/yVryqv6elq/eIEnq3n+EJs9YIEnyyFVGDZp2TLC99Piu5KDhE/XZqKkqUu4tlapSX7/v3S/p8bKub9du0vUbt+SRq4y69x8R3XeX3p9F9/H7n/tVu0EL5SxcRbUbtNAffx6I3te9/wjVbtBCS1auVcXXP1D+krU0e/7SWONt0LSj9u47qPsPHkb/K7jZbNaipWtUrsb7ylOsuj7p0FdXrt5I8hzGV5fP2QvyyFUmuo61P/wkj1xlopfEHj56Uh65ymjLz7sUEfFIvQeOUr4SNVW0fB0NGDZeQcEh0efY89c/KlP1XUlSz09HxroLsv3X31Wz3kfKU6y6hn4xJXp7aGiYho+driLl3lKJim9r2uxFMplMscaw4OtVKlHxbeUpVl3N2/bSxUtX4/xcIiMjtXjZd6rdoIVyFamqcjXe17adv0X3k9DnLD3+5ffDT7oqd9Fqata6p3wf+kfvM4aG6suvvlb1us2Uo1BlVa/bTAcOHYve75GrjLy/Wa0uvT9T7qLVdP3mbYUYjeo7eIzylqihGm9/pCPHTsX7OZ05d1EffNxFuYpU1ev1P9Y/h45L+m9J8IZNP6tpqx7KX7KWwsMjVKpKfY2aMFOfjZqqvCVq6O9/jiR6rcR1THyenHfJyrVq2bGf8hSvoTrvt9KNW3ei2xw76aP3mnVUriJVVe2tJvpxy44kXQ8Tp89Xz09HSpLKVH03xt3eKFOUZs79RmWqvatCZd/U9xu2Ru+7eeuuWnXqrzzFqqvym4308y+/x6o7vmt1z1//yCNXmei/9w2adoxeifDkf9du3JIkbdv5m6rVafr4emvXW3fu3o91noTmunv/EVr9/ePglL1Q5Rh3S5/n2KXHf6+bte6pPMVrqHTV+tHnjoh4pInT56tk5XeUv2QtdekzTPf/L7jH1//TP5NWfb9RPf79GdisTU917z8i1tyazWat/O5HVandSDkLV1H9xu10+cr1WMvbzWazln+7QeVrvq+8JWqoS59hCgwKjp6ngmXe0OZtv6rG2zF/dqz6fqPe/6iTJOn9jzql6qoQAMCrh1D4CoiMjJJ/QKCOnzoj729WS5IKFcwns9mszr0/05afd6lfj/Zq8sE76jN4tI4eP62uHVqoWuXHdxJXLp6h4YN7Jtj+iUVL1ygwKEh9e7TXw4d+GjZ6miRp+OCeKlwwvzJ5ZtDKxTPUtUOLWHWePnNeTVv1kIuLs6aOHyYnJyc1adVdPmcvRLc5fOyUvv/hJ/Xo3EqZPDNo9KTZeuD7MEY/wwf3VLEiBZTBw10rF89Q8aIFtWzVeg0aPlGv16ikcSMG6MTJM2rcsruMoaGJzl9CdRUtXECZM2WMDjYHDh6VY7p0+vvA46Cw/+AxGQwGVa9cXt+u3aQVa35Qp7bN1aNTK4WGhcnB3j76PMWLFtTQT7tLkrq0/0QrF89Q5kwZo/cvXvqdOrRupiKFXtOCr1fp2Emfx+MdO13e36xW2xZN1K1TS02cPl9bft4VYwwXL13V0C+mqFzZkhr9eT85OzvJzt4uzs/F1tZWv+35W3Vr19SY4f1lNpvVte9wBYcYE/2co6Ki1LJjfx05fkpffNZXFcuX1o2b/wUgG4ONft+7X80+rK+RQ/vo3v0H6trnc5nN5ug246Z8pbDwCM2YNEK5cmTTqPEztWz1enVs/ZE6tmmmcxevxPk5+QcE6sNPuuruvfsaO+JT5cmVQy069o3xGfcdPEa5cmbT/JljlS6dgyTp6+Xf6+Tps5o8eohKlyyapGvl6WMS89kXU1W6ZFG1/aSxDh45oTkLlkl6fKfmg+Zd5B8QpMljh6rAa3nVrtsg7f5jX6LXQ5MP3tEHDepKkmZOGqFZk0dE77t2/Zb2Hzqm3l3bysbGRoNHTFJUVJQePXqkj9r20pFjp/T5oJ6qWslLbbsO1O0792LUm9i1+sTwwT21cvEMzZg0XAaDQW/XrqncObPrwKFjatGhn3LlyKYJowbp+vVb6jd0bKzjE5rrrh1aqGa1io/beU9XreqV0mTs9x/46r1mneRz7qJGD+urD96tq/x5c0uSJn05X1Nmeqt54wYaNrCHtv/6h9p0HSiTyZRg/0//TKpVvZK6tP9E0uO7oHH9PFy9dpN6DfhCBV/Lp4mjB6tEscLKmjVTrHY/btmhPoNGq7xXKY0bMUB7//onxvPQD3z9NHH6fHVsE/NnR63qldSpbXNJ0ueDHn+OAADEh+Wjr4CDR04oX4makiQnR0eNHfGp6r1VS1eu3tDO3Xs1qG8XtW3ZRDJLq7/fqC3bd2n4oF7KlSOrJOm9d2pLki5fuR5v+7Kli0uSypctqbnTx0iSftm9V3v3HZQkVa1UThkzuCs0LDy6v6ctWblOjx5F6suJw1WoQD6VK1NCVWo31pKV6zRl7NDodhtWzpeTk6P8/AM1ZtJsXbpyXZk8//tl+fG5MiggICj6XAuXfKusWTLpy4mPf3mNePRIAz+foF92/6mG79ZJcP4Sq6tW9Urau++gzGaz9h86pvpvv65NP/2q4BCj/jl8TCWKFVaGDO5Kn95FkpQ5U0a1bdFEjo7pYpzHM2MGValYVtLjZ7eenqclC6aqSKHXlN7VVf8cPq7zF66oSMHXtHTVen3UuIF6dG4lSdr806/a8vOuGONK55hO9vZ2cnFxVsN366h9q2aSpLy5c8b5uaxcPEOBQcE6cvyUShYvrM3bftW585dUrmzJBD/nI8dO6ZTPOY35vH/0L5w/7fgt+m6ho2M6bVyzUL4P/XTk2GkVLJBP+/Yflu9Dv+jPME/unPp67iTZ29vLZDJp1fcb9Xbtmho5tI8k6eLla/rKe3msz2nTT7/ozt37mvflGJUrW1LlvUqpVr3m+ufQceXLm0uSVKWil2ZMGiGDwRB9nLOzk1YuniF3t/RJvlaePiYxXTt8oiH9u0XfhT1/8bIk6fsftso/IFBfz52kt96orvfeqa2fdvwm7yXfas2S2QleD4UL5lehAvkkSW++XlV5c+eM3pcls6dWfz1TBoNBJ0+f1dJV63X/wUOdPX9Jp3zOafaUL9SwQR2FhYVr9dpN2rl7b4xnbxO7Vp+oWqmczGazWnXqr/TpXTVz8uO5XbzsOzk7Oeqr6aPl4GAvozFUQ0ZOVkTEIzk4/BcuE5vrXDmzS5Ia1HtDdnb//d/R8xz7dxu2yvehn7au+ybGEnuTyaRFS9eoglcpjRjSW5J0/cZtzV6wVMdPnVVAQGCC/T/9M6lMqWKSpCoVy6psqWKxnuubu3CFXsuXR8u8p8nW1jbO+X8yh6/ly6MpY4ZKBun8hStav3FbjJ+ZS+ZPifWzo+mH9VW6RNF/a/CKDuAAAMSFO4WvgOJFCmrz94tVsVxpZczgrk5tmstgMEQ/rzN11kLlK1FT+UrW1K079/TgwcM4+0lKe3v7/35xy5QxgyIiHiW5zqvXbsrZyVEFX8srSSpS6DU5Oznq6rWYyzyfnCNTxgySpPDwiET7vnLthsqULBYdBrz+DbFXryX+korE6qpVrZLu3nugs+cv6eTpc2r0fj1FRUXp0JET+ufwiejnhBq9X09fTR+trxauUJlq78r7m9Ux7pAlxv7fX4ozef477ogI3bx1R1FRUfp27abHn0mJmjpw6Fisu6e5cmTTxjWLdPnKdZWoWE9DRk6Ocefv/5nNZo2dPEdFvN5S1z6f69KV65IUvSRNiv9zfrJ08LX8eeLs+8myxCLl6mjA5+Ojr53AwP/6LlG0oOz/vSv1wNdPxtCwePv7f08+y8YtuytfiZqqVe9xKL3/f9dnmVLFYgRCScqfN1eMcJeUa+XpYxLzZDx2dnbK4OGm8PBHMfp8EhDc3dKr4Gt5Y13zyWVnaxtd/5OwHR4REb00s8/g0dFLQyMiHumBr1+M45NzrX6/Yau2bt+tyWOGKEf2rNHjCjGGqrBXbeUrUVODR0yS2WzWQz//GMc+y9/L5zX2J+1KlSgSY/tDP38FBYdEf1aS5FXm33qv3khy/0l15ep1FS9aMMFA+KTeS1euKV/Jx3//Zy9YqvtP/f2P62cHAADJwZ3CV4Cbm6tqVquozwf11IefdNX8r1fp014do/91vUPrZmr0fr3o9jn//cXO5t9fRsLCwuXomC7R9omxsbFVeHh4vPvz5smpHbv26PzFKypcML/Onr8kY2iY8ubJlbwBxyFfnlw6euK0zGazDAaDjvy75DVvnpyJHJl4Xa/XqCxJWvfjNhkMBr31RjXlzJ5Ve/b9o+s3bkWHQoPBoFbNP9THTd7TrPlLNWTkZBUrUjDGsjgbm8f/DpPQPP2/nDmyycbGRvXrvq5uHVtGb/fM6BGrbbXK5bT9x2X6/c/9atKyh9zd0mvYwB6xPpe9+w5q+pzFWjRnopp+WF+r126Kfn4rMVkyP17eduyET/Qdkf8PE2t//Ekr1vyg7T8uU+UKZTVx+vzoZ1fjkjGDu+zs7KKXyj7d3/97cn3OmDRcBV/LF729eNGC8QbguDzLtZJcT/o8etxHdd6sroDAIF24dDX6xSOJXQ//7U/aL/lPzjf00+4x7oK9li9m6I7vWn06UN+6fVeDR05SvTq1YrwNM2/uHDrlc04rF8+IEWqehJInnmWun9fY8+TKIUk6efpcjBe6ZMzgofSuLjGWyx859m+9eXPJ3T8gSf0nVZ7cOeRz9oKioqISDIZ58+SUvYO9vpo2OvrzsbNLOEg+YWObvDkEAFgv7hS+Ql6vUVlVK3lpxldf6/4DX+XPl1u1X6+qtT/8pN1/7NPlq9e1cetOZc7sKenxL2ySNHnGAv3x54FE2ycmX96cunffV/MWr4x+Acj/a9eyqezt7TRg2HitXrtJA4ZNkL29ndq3avrMY+/S/hPdu++rTz8bp+WrN2jm3G/0Wr48qvNmdUmPX/N+/cZtXbl2Q5k8M8jOzk5Hjp1ScIgx0bry5smpXDmza+2PP6l40YJycXZWea9SWvvDT9HPE0rSF+NnqOeAkVr34zZd/vfu29O/7D35xfXbtZv145YdiYYZR8d0avNJI+3YtUdbt+/W1es3tWnrTrk9dRfrpx2/qWHzzlq2ar2OHfdRZGSkbP/9hfDpzyU0NEyStO/AYS1btV7TZy9O8jxX8CqlHNmyaNnq9Vq2ar2Gj52u4yfPRO9/0vcvu//U/MWrtGTl2gT7s7OzU4N6b+rAwWOaNnuR5i1eqRVrfoyz7fv131KWzJ76ynu5jh4/rVM+57R330F5ZswQZ/v4JHatxGWO9zJVfrORLly6kqxzNfvwXbm7p9eoibO06vuN6jXgC0VFRanrv8+bJXY9PFkWO2v+Eu34dU+i56tWubyKFymopavWad+Bw7pw6Yp+2vGbsj31rFpSrlWz2aw+g0YrICBIdd+soa3bd2vLz7vk+9BPHdp8pBDj45cKXbx0VfsOHNat23djLAGVUjbXz3vsTT+sr/SuLurW73MtW7VeM+d+o6+Xfy8bGxt1bvexDh09qbGT52jR0jVa9u16Va3kpdIliiS5/6Tq0PojXbx8TR16DNF367eo7+Axcb4cq1Pbj3Xt+i0tWrpGl69e1+979yskJPFnpaX/fsYvWrZGG7fsTNbKBQCAdSEUvkIMBoM+G9BDQcEhmjzDWwaDQV9/NVmN3q+nld/9qBHjvtSNW3eil3h1avuRalStIO9vVmvG3K8TbZ+YAb06qUypYho/5SstWx37uxJLFCukdSvmKTAoWAOHjVeI0ah1K+apWJGCzzz2ti2baPKYIdq95299PmaaShQvrA2r5svZyUmS1KJZQ/kHBGrztl/l4uys5k0a6K/9h3Xm7IVE6zIYDHq9RiVdvXZTFf79io2K5Urr6rWb0c8TSlKjhu/o+o3bGjR8onb9/pe+GNon1qvl8+bOqaGfdtf5i1c0bNRUXbh0NdGxTRw1WN07ttKWbb9q6MjJOnP+kvz+vWvxRAWvUsqWNbPGTf1KX371tZo3eU+9uj7+fsinP5e33qimjxo30Hfrt2jFmh/UJxlf6+HomE6rvp6pHNmzasS4L3Xz1h01bvjfXeWPm76vOm9U17xFK7Rt529J+o7KaeM/09tv1dSseUu0cctOdWn/cZztMmRw16bvFilvnpyaMtNbs+Yt0QPfh8lawiwlfq3EJTQ0TOcuXNbOXX8m61zZsmbWpu8WyS29qwYPn6jzFy/rm3mT9WatqpISvx4avfe23nuntn7cvEOjJszUo0cJj9XBwV7fr5iryhXKav7iVRo/da4ePHgYY/mulLRr9dqNW/rlt8fjHfj5BLXq1F+tOvXX6TMXVKWil1Z/M1N+/gH6bNRUfbd+S4zlx0+kZK6f99hzZM+qjWsWKmf2rBo2eqpWfb8x+uswhn7aXQP7dNaadZs1fupcvf1mTS1fOF02NjZJ7j+pnrwt+vjJMxowbLyu37ylR5GRsdo1+eAdzZk2SucuXNaQEZP1047fFBwSEkePsVWvUl5tWzTRX38f0hcTZ8b5hlgAACTJEBERzj8dAkACzGazar3TXH26tVOzRu9auhwAAIBUxZ1CAEhEl97DJD1ewgoAAPCq4U4hACRi49ZfVPv1qkrv6mLpUgAAAFIdoRAAAAAArBjLRwEAAADAihEKAQAAAMCKEQpfUmazWZGRkXzvFAAAAIBnQih8SUVFRalmg3aKioqydCkAgJdcSIhRVeu1UkiI0dKlAAAsgFAIAAAAAFaMUAgAAAAAVoxQCAAAAABWjFAIAAAAAFaMUAgAAAAAVoxQCAAAAABWjFAIAAAAAFaMUAgAAAAAVoxQCAAAAABWjFAIAAAAAFaMUAgAAAAAVoxQCAAAAABWjFAIAAAAAFaMUAgAAAAAVoxQCAAAAABWjFAIAAAAAFaMUAgAAAAAVoxQCAAAAABWjFAIAAAAAFaMUAgAAAAAVszO0gUAAIAXw7Wbt+Xs5GjpMgDglePm6qoMGdwtXUa8CIUAAFg5f/9ASVL1Ok1lMpksXA0AvHpcXZx14u+fX9hgyPJRAACsXGBIiKVLAIBXWnCIUYHBwZYuI16EQgAAAACwYoRCAAAAALBihEIAAAAAsGKEQgAAAACwYoRCAAAAALBihEIAAAAAsGKEQgAAAACwYoRCAAAAALBihMJkWLtxh1p2HaoNW35Vh94jNGDEVJnN5hht6jbukmAfW3f8ocUr1kf/d6M2/eQfECRJGjvNW4ePnU79wgEAAAAgHoTCZFi7cYemjRmowKBgVa/speljB8lgMFi6LAAAAABIMTtLF/CymL1wtW7fva8mbfvL1cVZ6RzsZWNjo1bN3tOUOUt00ue8CuTLrUeRkfH2ceTEGc375jtJ0v5DJ7Ro5qjofd+u/0m79xzQsZNnVbViGQ3o2fZ5DwkAAAAACIVJ1adLC+3ee0BL5ozVuk075OToqJbNGmjdpp0yGkO1ynuSfP0CtOfvw/H24VWqqBo1qC1J6tS6SYx9nzR5V3v+PqxOrRqrXJnicR6/btNOrd+8U5JiLVsFAAAAgJQgFD6jQ0dP68MGtWVjY6PMnhnkYG//3M7VtGFdNW1YV5IUGRmpmg3aPbdzAQAAALAOPFP4jKKiomQ0hlq6DAAAAABIEULhMypetID27j8is9msS1duKCw8PMH2WTJ76t6Dh9H/bZBBJrNJkpT1qX0AAAAA8LwRCp9Rs4Z15R8QpNbdh+n7jduV2TNjgu2rVCitI8fPqEPvkQoNC1Pl8qW0YfMvkqR6tatrzqJvNXHG4rQoHQAAAABkiIgI540lL6EnzxTu2bpUdnY8GgoASDmfcxfVofcXOutzSiaTydLlAMAr6di+n5Q3d05LlxEn0sRz0q7n8Fj/x9q/Rxt5lSpqoYoAAAAAIDZC4XOydO44S5cAAAAAAInimUIAAAAAsGKEQgAAAACwYoRCAAAAALBihEIAAAAAsGKEQgAAAACwYoRCAACsnJuLi6VLAIBXmquLs9xcXS1dRrz4SgoAAKych4ebJOnPX9bJ2cnRwtUAwKvHzdVVGTK4W7qMeBEKAQCAJClPzuxycXG2dBkAgDTG8lEAAAAAsGKEQgAAAACwYiwfBQAAkqRrN2/zTCGAV86L/jzfi4BQCACAlfP3D5QkVa/TVCaTycLVAEDqcnVx1om/fyYYJoDlowAAWLnAkBBLlwAAz01wiFGBwcGWLuOFRigEAAAAACtGKAQAAAAAK0YoBAAAAAArRigEAAAAACtGKAQAAAAAK0YoBAAAAAArRigEAAAAACuWJqHwwqVrmuW9Mi1OlWyLV6zXqrVbn6mPHoPG6fad+6lUEQAAAACknTQJhQVfy6O+XVulxakAAAAAAMlgl5zGt+/c1/R5y+Xhnl6RkZHKkyu7duzeJwd7O30+oIuKFMynrTv+0JLVP8r3YYDSpbPX+/XeUNWKpbVq3U+aPnagFq9YryiTSSdOndedew807NPO+nHrLh057qPObZqoYf03FRkVpZnzV+qfIyfllt5VY4b2UPZsmeOsafGK9fJ9GKBrN27r7n1ftW/xoRq8XUtbd/yhqzdu6/TZi6peqaw+eLe2Js/6RhcuX5NbelcN699JuXNmkySdOnNBvQZP0J17D6KPj4vZbNYs71Xas++QXFycNXJQN/20c49OnD6vT0dM1Ttv1VCpYgW1Y/c++fkHKlfOrOreoXmssWTOnFGjJ8+Xz7lLyuDhrvHDe0tms4aOmaXgEKOKFsqnLwb3kK0tq3sBAAAAPF/JCoWStO+fo5o5YYhMJrM2btut1Qsn6c69B5o+d5kmj/pUMxes1JrFUyRJ3QaMVc9OH+vwsdMx+jh34apmThisb9dv07hpC7Vo5he6c++Bvpg0Tw3rv6kt23+Xg4O91iyeoqMnz2r5d5s1pG+HeGsKDArWrIlDFBAYrBZdhuqNGhUlSVu2/66VCyYqYwZ3zft6jTJ4uGmV9yTt/fuIxk7z1sIZX0iSDAaDZk4YHON4F2enOM+zdccf2rZ2vgKDguXi7KQ+XVpo994D+nLsIGXPllmHj53Wz7v+1JI5Y5U/b079+NOuWGP54N03denqDa1dMl33HzxUpoweWrPhZxUvUkADerbR3fu+BEIAAAAAaSLZoTB3zuyq6FVSsxeuls/Zi2rXc7gkycnJUbY2Nkrv6qKg4BCZzZLJZIqzj3Kli8nOzk5FCuZT/rw55ZnRQ+5urvLzD5QkHTh0QucvXdPBIydlNkt5cmVLsKbiRQrIzs5Onhk9lCtHVl2/eUeS9Eb1isqYwV2S9M+RUxrYq60kqUrF0hozdb5CjKFxHn/txm0VK/xarPO4pXdVuTLFNG6atzq2aqyMHu5x1uNVqqjy580Z71jy5c4hVxdnzVywQq0+el82NjaqUqG0Rk6aqzUbtqlRg7fi7Hfdpp1av3mnpMd3LQEAAADgWSU7FNra/HsHy2xWi6YN1OyDt2Psr1aprMZM9ZbJZNKQvh0TPrmd7f/92S466JjNUt+urVSjildyy5Odna3SOThIkmxs/rvb9rhvQ5KOd0yXLs59BoNBk7/or0NHT2vY2Nnq2KpR9F3J/xfzvHGPZcH0Efr9r4PqMXCcvhjcXSWLFdTimaP0w0+71Lr7MC35aqxcXZxjHNO0YV01bVhXkhQZGamaDdolOh4AAAAASEiK1yhWLFdSm7b9ppAQo0wmk+49eChJ+vvgMS2aOUpL545TpXIlU9a3Vwmt27RDjx5F6tGjSD30C0iw/e27D2Q2m3Xpyg098PVTrhxZ4+izpH75fZ8kaf/B48qbO0f0EtH/P973ob9y54x9vCQFBAbp6vVbKl+2uN55q7qOnPCRJGXNlDF6/EkZy+079/Xgob/eqF5RlcuX1gmf8zp74YoMNgY1/7CeHBzsdfP2vSTPFwAAAACkVLLvFD5RpUJpnTl/We17j5SjYzo1++BtvV/vdeXKkVXNOw6Us5OjsmfNrA/efVOO6RyS1XfDd9/U5Ws31arbUDk5OqpL26aqVqlsvO2vXLupLv1Hy2gM04iBXWVvH3tY7Vp8oMmzvlbLrkPl5uqiEQO7Ru8LMYY+Pj708fF2dnFPS1hYhOYs+lZ37j2Qra2NxgztKUlqUO91DR8/R++/84YqlC2e6FiyZvHUjC9X6KFfgNzdXNWh1Yc6duKsJs/6WoFBISpXppgKvZYnWXMGAAAAAClhiIgIT7WH067fvKO5X6/RpJH9ZDKZtGbDzzrpc14TRvRNrVPEsnjFejk5OqplswbP7RwvoifLR/dsXRpviAUAICl8zl1Uh95f6KzPqXjfBwAAL7Nj+35S3tw5LV3GCytV00QmTw/Z29mpXc/hioh4pKxZPDWgZ9tU6XvSrK91+szFGNvq16mRKn0/7aFfgPoNmxxr+/jhfaK/xgIAAAAAXgWpGgqdHB01dliv1Owy2tBEXlqTmjJmcNfy+RPS7HwAAAAAYCl8GR4AAAAAWDFCIQAAAABYMUIhAAAAAFgxQiEAAAAAWDFCIQAAAABYMUIhAAAAAFgxQiEAAFbOzcXF0iUAwHPj6uIsN1dXS5fxQkvV7ykEAAAvHw8PN0nSn7+sk7OTo4WrAYDU5ebqqgwZ3C1dxguNUAgAACRJeXJml4uLs6XLAACkMZaPAgAAAIAVIxQCAAAAgBVj+SgAAJAk3bnnK2enEEuXASANOTs7yd2Nl7BYO0IhAABWLiDocRBs1e0zC1cCIK2ld3XR2iXTCYZWjlAIAICVCw0NkySNGdpVuXJktXA1ANLKA19/DR49W0ZjKKHQyhEKAQCAJMkzg4eyZva0dBkAgDTGi2YAAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRChOwduMOtew6VBu2/KoOvUdowIipMpvNMdrUbdwlwT56DBonn3OXknzO3/86qLHTvFNULwAAAAAkF6EwAWs37tC0MQMVGBSs6pW9NH3sIBkMBkuXBQAAAACpxs7SBbyoZi9crdt376tJ2/5ydXFWOgd72djYqFWz9zRlzhKd9DmvAvly61FkZJL7PHrijKbOWSoHB3tlzeKpgvlzq1PrJrp05YbGTvOW2WxWxgzuyuDh9hxHBgAAAAD/IRTGo0+XFtq994CWzBmrdZt2yMnRUS2bNdC6TTtlNIZqlfck+foFaM/fh5PUX0TEI42eukCTv+ivQq/l0cwFK6P3jZvurY6tGqtGFS+t2fCzzl+6Gmcf6zbt1PrNOyUp1jJWAAAAAEgJQmEyHTp6Wh82qC0bGxtl9swgB3v7JB137eYdZcqYQYUL5JUkZc+aWcEhIQoJMeq+r79qVPF6vD1bpnhDYdOGddW0YV1JUmRkpGo2aPfsAwIAAABg1XimMJmioqJkNIam7LjQ2MdFmcwKDQ1TVJQpNcoDAAAAgGQhFCZT8aIFtHf/EZnNZl26ckNh4eEJtjfIIJPJrDy5sun+Az/dvH1PJpNJZy9cliSld3VWxgzuOnrijCTpzLnLz30MAAAAAPAEoTCZmjWsK/+AILXuPkzfb9yuzJ4ZE2xf0aukfvxpl5wcHTW4T3v1/WySeg2ZoLCwCEmSwWDQZ/07aepXS9W53ygZQ8PSYhgAAAAAIIlnChP0w/KZkqROrZtEb3Nxcdb0sQOT3Ee7Fh9E/7nO61VU5/UqkqQ1G35WcEiIJMmrVFGtWTwlFSoGAAAAgOQhFKaSdj2Hy2SK+Vxg/x5t5FWqqIUqAgAAAIDEEQpTydK545LV/uPG7zynSgAAAAAg6XimEAAAAACsGKEQAAAAAKwYoRAAAAAArBihEAAAAACsGC+aAQAAkiRfP385OaWzdBkA0sgDX39Ll4AXBKEQAAAr5+TkKEkaOcnbwpUASGvpXV3k7Oxk6TJgYYRCAACsnHt6F0nSygUT5fxvQARgHZydneTu5mrpMmBhhEIAACBJypbFUy4uzpYuAwCQxnjRDAAAAABYMUIhAAAAAFgxlo8CAABJ0p17vnJ2CrF0GUhDPE8GQCIUAgBg9QKCHgfBVt0+s3AlSGvpXV20dsl0giFg5QiFAABYudDQMEnSmKFdlStHVgtXg7TywNdfg0fPltEYSigErByhEAAASJI8M3goa2ZPS5cBAEhjvGgGAAAAAKwYoRAAAAAArBihEAAAAACsGKEQAAAAAKwYoRAAAAAArBihEAAAAACsGKEQAAAAAKwYoTABazfuUMuuQ7Vhy6/q0HuEBoyYKrPZHKNN3cZdkt3v7Tv31bLL0Dj3tek+TLfv3E9RvQAAAACQXITCBKzduEPTxgxUYFCwqlf20vSxg2QwGCxdFgAAAACkGjtLF/Cimr1wtW7fva8mbfvL1cVZ6RzsZWNjo1bN3tOUOUt00ue8CuTLrUeRkQn2s++fY5oxf4X8AwIVZTKpVtXy6tKmafR+s9ms+Uu+1+9//qNcObLJPzDoeQ8NAAAAAKIRCuPRp0sL7d57QEvmjNW6TTvk5Oiols0aaN2mnTIaQ7XKe5J8/QK05+/DCfbz5bzlGvd5b+XNnUMtOg/R4D7t5e//X/D768BRHT1xRivmT1TEo0dq3e2zePtat2mn1m/eKUmxlrECAAAAQEoQCpPp0NHT+rBBbdnY2CizZwY52Nsn2N4zg7v8A4KU2TNUYeHhMhhirtg9dPS03q1bUw4O9nJwsFd6V5d4+2rasK6aNqwrSYqMjFTNBu2eeTwAAAAArBuhMJmioqJkNIYmuX3NquU1d/G3MpnN6tetlRzTOcTszxQlozEstcsEAAAAgCQhFCZT8aIFtHf/Eb1Ro6IuX72psPDwBNvv3ntAMycOUUYP9/82GgwymU2P+ytSUJt//k3NG70j34d+evDQ/zlWDwAAAAAxEQqTqVnDuho5aZ5adx+mksUKKrNnxgTbF3otr9r3HCF3N1dl8sygum9U1dtvVpOdrZ0OHD6pt2pV0v5Dx9Wy61AVLpBH2bNmTqORAAAAAAChMEE/LJ8pSerUukn0NhcXZ00fOzBJxxtDw3Th8nX9sGKmDAaDftv7j5Z/t1n169TQigUTotuNHNQtVesGAAAAgKQiFKaSdj2Hy2QyxdjWv0cbFcifSx16j9SjR5Fyc3PV4D7tLVQhAAAAAMRGKEwlS+eOi3O7V6miaVwJAAAAACSdTeJNAAAAAACvKkIhAAAAAFgxQiEAAAAAWDFCIQAAAABYMV40AwAAJEm+fv5yckpn6TKQRh74+lu6BAAvCEIhAABWzsnJUZI0cpK3hStBWkvv6iJnZydLlwHAwgiFAABYOff0LpKklQsmyvnfgAjr4OzsJHc3V0uXAcDCCIUAAECSlC2Lp1xcnC1dBgAgjfGiGQAAAACwYoRCAAAAALBiLB8FAACSpGs3b/NMoZVxc3VVhgzuli4DgIURCgEAsHL+/oGSpOp1mspkMlm4GqQlVxdnnfj7Z4IhYOVYPgoAgJULDAmxdAmwkOAQowKDgy1dBgALIxQCAAAAgBUjFAIAAACAFSMUAgAAAIAVIxQCAAAAgBUjFAIAAACAFSMUAgAAAIAVIxQCAAAAgBUjFAIAAACAFXslQmHtDzpa7NxBwSFq1KZfqvU3dpq3du05kGr9AQAAAEBCXolQCAAAAABIGTtLnNRsNmv63OX688AR3b3nq6xZPPXe27V09MRZ+QUEKqOHuyZ90U/OTo5q3W2Y3n/ndW37Za/mTftcJ05f0FeLv5XZZFa9t6qpVbP3ZDKbtWj5eu3as19ZM3tq2tiBsrO1jfPcYWHhmj5vuU6fuSgXFydNGN5Hzs5OmjzrG124fE1u6V01rH8n5c6ZTYtXrJfZLJ06c0HnL13TsP6dVL2yl4JDjBo71Vs3bt9VgXy5Ehzr6nU/KeLRI7X75ANJUs9B4zWod3uld3XWhBmLdefeA2XLkkmff9pZGTO4p/pcAwAAAEBCLHKn8Pjp8zrhc05rl0zXhBF9VLZkUX34bm2NHNxNKxdMVAYPN+3e+3gJZbDRqMCgYH0zZ4wiIh5pwpeLNGF4Hy2fP14N6taSJD169EgVvEpoxYKJevDQX6d8LsR77mXfbVI6Bwet9J6oKaM+lWdGDy1d/aMyeLhplfcktWzaQGOneUe3P3P+kqaOHqBPe7TRmg0/S5KWrP5ROXNk1SrvSWr10fsJjvX16hX05/6jkh4vNQ0MClG+PDk0c8FKVSpXUqu8J6lKhdKa5b0q0Xlbt2mnPuk8WJ90HqxW3T5LtD0AAAAAJMYioTCjh5vCwx8pPCxcfv6Bj7dlcNelKzc0dc4Snb1wRXfu+ka3b/xeHRkMBp30uaDSJQopV46sMhgMyuDhJklK5+Agr1JFZWdrq4L5c+uhX0C8595/8LiafVBXBoNBHu7pZTAY9M+RU6r7RhVJUpWKpXXl2k2FGEMlSeVKF5e9vZ0KF8irh/6P+z109LQ+fPdNSVL2rJkSHGvO7FkUFRUpP/9A7T94QjWqekmSDh49pTqvPz5nnder6J/DJxOdt6YN6+rbRVP07aIpWrlgYqLtAQAAACAxFlk+mjN7FqV3dVbvoRPl6uKiz/p11JoN23TC54Jaf/SecuXIGh3KJMnG5nF2NZnNkgwJ9m1raytzAvtNJrMMhph9mJPQr52trZ50HBVlkjE0LMH2/69W1Qr665+jOnjklD5uXD/6nE/XAQAAAABpzSJ3Cq/duK30ri76Zs5YzZ40VNmzZdbBo6f1Tu3qKlwgny5cvh7ncSWKFNCRE2d0++4Dmc1m3bpzL9nnLlemuH7Y+qvMZrMe+gUoNCxMFb1K6pff90l6fCcxb+4ccnF2irePEkULaM++w5Ikn3OXEz3nGzUqaN+BY7p2444KF8grSapQtoR++f1vSdKvf+xXBa/ikh5HU5PJlOxxAQAAAEBKWOROYbYsmXTm3GW16DxEDg72ypcnhyqVK6n5S77T+s07lS9PzjiPy5jBXQN7tdWA4VNl72CnN6pXVPsWHybr3B1afqiJMxarZZeh8vBIr2H9O6tdiw80edbXatl1qNxcXTRiYNeE+2jVSCMnfKW9+w+rcrlScrC3T7B9vjw5deX6LVXyKhl9d7B/99Ya/+Uibdy2W1kze+rzTztLkrzKFNPmn3+LXloKAAAAAM+TISIiPKHVls/F5u2/KzjEqE8a11dkZKQ+Hz9HFcqWULMP3k7rUl5akZGRqtmgnfZsXSo7O4tkewDAK8Ln3EV16P2FzvqcYrWKFTq27yflzR33P8gDsA4WSROlihXUtLnLtO2XvQoPj5BX6aJ6v97rqXqOSbO+1ukzF2Nsq1+nhj5p8m6qnueJh34B6jdscqzt44f3Ue6c2Z7LOQEAAADgWVkkFObLk1NfTR72XM8xtG/H59r/0zJmcNfy+RPS9JwAAAAA8Kws8qIZAAAAAMCLgVAIAAAAAFaMUAgAAAAAVoxQCAAAAABWjFAIAAAAAFaMUAgAgJVzc3GxdAmwEFcXZ7m5ulq6DAAWxreeAwBg5Tw83CRJf/6yTs5OjhauBmnJzdVVGTK4W7oMABZGKAQAAJKkPDmzy8XF2dJlAADSGMtHAQAAAMCKEQoBAAAAwIoRCgEAAADAivFMIQAAzyAgMFhGY6ily3gmxtAwS5cAALAgQiEAACkUEBisZu0HKCg4xNKlpIqAoBBeNAMAVohQCABAChmNoQoKDtGUL/ook6eHpctJsRu37mrkJG+FcscQAKwSoRAAgGeUydNDWTN7WrqMFAsNDbd0CQAAC+JFMwAAAABgxQiFAAAAAGDFCIUAAAAAYMUIhQAAAABgxQiFAAAAAGDFCIUAAAAAYMVeqFB44dI1zfJe+Vz6vn3nvnoMGvdc+pakA4dOaMV3myVJh4+d1thp3tH7Znmv1IVL157buQEAAAAgpV6o7yks+Foe9e3aytJlpEil8qVUqXypOPe9rGMCAAAA8Op7LqHw9p37mj5vuTzc0ysyMlJ5cmXXjt375GBvp88HdFGRgvm0dccfWrL6R/k+DFC6dPZ6v94bqlqxtFat+0nTxw7U4hXrFWUy6cSp87pz74GGfdpZP27dpSPHfdS5TRM1rP+mIqOiNHP+Sv1z5KTc0rtqzNAeyp4tc6x6wsLC1XvoRD30C1Cb7sM0akgPrVq3VUUK5tPPv+5Vny4t5esXoDUbtikwKETVKpVR366tdPvOfU2c+bVy5ciqA4dPqGypoho+oItCQowaOmaW7tx7oBzZMmviyH7aveeAfM5dVvNG9TRmqreMoWFq032YvpryuYaOmaHenVuoWOHX9Of+I1qwZK1MJpPqvllV7T75QJL0SefBer1aBf3250Fly+KpaWMHys7W9nl8PAAAAAAQ7bndKdz3z1HNnDBEJpNZG7ft1uqFk3Tn3gNNn7tMk0d9qpkLVmrN4imSpG4Dxqpnp491+NjpGH2cu3BVMycM1rfrt2nctIVaNPML3bn3QF9MmqeG9d/Ulu2/y8HBXmsWT9HRk2e1/LvNGtK3Q6xaHB3TaVj/Tlq8coPmTR0evX3PvsNaOHOU7GxtdeXaTc2ZPEx2tjZq1mGgPvqgniTp9NmL6t+9tfp0bakPWvbRvfu+OnXmohwc7LV2yXTdvecrZyfH6D5z58ymzm2a6PBxH40Y2DVGHX7+gZowY7GWzh0nD7f06jFonIoXfk2VypfStRu3VblCaXVq00Tteg7XKZ8LKlOySIzj123aqfWbd0qSzGbzM3w6AAAAAPDYcwuFuXNmV0Wvkpq9cLV8zl5Uu56Pw5iTk6NsbWyU3tVFQcEhMpslk8kUZx/lSheTnZ2dihTMp/x5c8ozo4fc3Vzl5x8o6fFzfOcvXdPBIydlNkt5cmVLVo0f1H8z+m5c9myZ9cvvf+vgkdMKD4vQnfu+ypbZU1kzeyp/3pySpHx5cuihf6BKlyisJd9u1MJl6/Rx4/pJPt+pMxdVuEBeZfbMIEl6s0Yl7T98QpXKl1I6Bwd5lSoqSSqYP7ce+gXEOr5pw7pq2rCuJCkyMlI1G7RL1ngBAAAA4GnPLRTa2vz7DhuzWS2aNlCzD96Osb9apbIaM9VbJpNJQ/p2TLhIO9v/+7Nd9F0ys/nx83o1qnilqEYb2//eszN8/BwVLZRfHVs1ktEYKnMcQdXW1kZms1meGT30zZwx+vmXvWrXc7i+mvJZks5nllkGgyHRdra2tuI+IAAAAIC08NzfPlqxXElt2vabQkKMMplMuvfgoSTp74PHtGjmKC2dO06VypVMWd9eJbRu0w49ehSpR48i47y79kSWzJ66/8Av3ruSh4/7qNkH9eSW3lU3bt9N8LyXr95UaGiYGrxdS/nz5tS5i1efOldG3bv/MNYSzxJFC+jshSt64OunyMhI7d57QBW9UjZ2AAAAAEgNz/3to1UqlNaZ85fVvvdIOTqmU7MP3tb79V5XrhxZ1bzjQDk7OSp71sz64N035ZjOIVl9N3z3TV2+dlOtug2Vk6OjurRtqmqVysbZNmf2LMqZPYs+6TxEwwd0ibW/ZdMG6tJ/tArmz61c2bMmeF7/wCBNmLFYgUFBypMru6pUKKNff/87en+pYoUUFByiNt0/1+RR/aK3Z/Rw12f9Oqn/51NlMplU540qqlKhdLLGDAAAAACpyRAREZ7mKxWv37yjuV+v0aSR/WQymbRmw8866XNeE0b0TetSXlpPnincs3Wp7OxeqG8WAQCrcfvOfTVu21/fzB6prJk9LV1Oil25dks9h0zWygUTVSB/bkuXAwBIYxZJE5k8PWRvZ6d2PYcrIuKRsmbx1ICebVOl70mzvtbpMxdjbKtfp4Y+afJuqvQPAAAAAK8Si4RCJ0dHjR3W67n0PTSRl9YAAAAAAP7z3F80AwAAAAB4cREKAQAAAMCKEQoBAAAAwIoRCgEAAADAivFdBgAAPKMHvv6WLuGZ+Pr5W7oEAIAFEQoBAEghZ2cnpXd10eDRsy1dSqpwcnK0dAkAAAsgFAIAkELubq5au2S6jMZQS5fyTIyhYWrV7TO5p3exdCkAAAsgFAIA8Azc3Vzl7uZq6TKeSUiI0dIlAAAsiBfNAAAAAIAVIxQCAAAAgBUjFAIAAACAFeOZQgDASykgMPilf8HLi8IYGmbpEgAAFkQoBAC8dAICg9Ws/QAFBYdYupRXSkBQiFxcnC1dBgAgjREKAQAvHaMxVEHBIZryRR9l8vSwdDkvvRu37mrkJG+FcscQAKwSoRAA8NLK5OmhrJk9LV3GSy80NNzSJQAALIgXzQAAAACAFSMUAgAAAIAVIxQCAAAAgBUjFAIAAACAFSMUAgAAAIAVIxQCAAAAgBVL9VB44dI1zfJemdrdSpIWr1ivVWu3Ppe+g4JD1KhNv1Tpa+uOP7R4xfro/x49Zb4e+PqlSt8AAAAAkJpS/XsKC76WR327tkrtbl9qXwzubukSAAAAACBO8YbC23fua/q85fJwT6/IyEjlyZVdO3bvk4O9nT4f0EVFCubT1h1/aMnqH+X7MEDp0tnr/XpvqGrF0lq17idNHztQi1esV5TJpBOnzuvOvQca9mln/bh1l44c91HnNk3UsP6bioyK0sz5K/XPkZNyS++qMUN7KHu2zIkW7vvQXxNmLNadew+ULUsmff5pZ2XM4C6fc5c0bvpC+fkFKsQYqlIlCumrycPi7CM4xKixU7114/ZdFciXK3r71h1/yOfcZQ3s1VaSVPuDjtq18WsdPnZaO3bvk59/oHLlzKqmDd/Wl/OW6e49X9nb22vSF/1049ZdzfvmO0nS/kMntGjmKDVq009L5oyVh3t6bd7+u9as3yZJ+qRJfb1X73XdvnNfE2d+rVw5surA4RMqW6qohg/okvRPEQAAAABSKMHlo/v+Oap6taupfp2aunD5ulYvnKRJX/TTwmVrH4e5BSvl/eVIrVs6XeldXdSz08ex+jh34apmThisD+q/qXHTFqpv15aa9EU/Lf9usyRpy/bf5eBgrzWLp6hHx+bR2xMzc8FKVSpXUqu8J6lKhdKa5b1KkjT/m+/VuU0Tbfp2jl7Ll0tD+nSIt48lq39UzhxZtcp7klp99H6Szvvzrj/Vrf1H6t25hdzdXNW7cwstnz9BFb1KaNO23fIqVVSNGtRWowa1tWjmqBjHXrpyQ0tX/6iFM0Zq4YyRWrZmk65cuylJOn32opp98LZWek/Snn2Hde++b5LqAQAAAIBnkeDy0dw5s6uiV0nNXrhaPmcvql3P4ZIkJydH2drYKL2ri4KCQ2Q2SyaTKc4+ypUuJjs7OxUpmE/58+aUZ0YPubu5ys8/UJJ04NAJnb90TQePnJTZLOXJlS1JhR88ekr9uj1eplrn9SpasupHSZJnRnf5BwQpPCxcxtBQGQyGePs4dPS0xnzWU5KUPWumJJ3Xq1RR5c+bU5Lk7OSooOAQzVywUsdOnlWB/LkTPPbQsdOqXL60XFycJUlVKpTWwaOnVb1SWWXN7Bndb748OfTQP1BZMnvGOH7dpp1av3mnJMlsNiepXgAAAABISIKh0Nbm3xuJZrNaNG2gZh+8HWN/tUplNWaqt0wmk4b07Zjwiexs/+/PdtGhxmyW+nZtpRpVvJJVuNlsjjPw1axaXouWr9PaH3fowwZvKVeOrPH2ERVlkjE0LM59kVGRcW63sfnv5uruPQe0btNOdW7TRKWKF9JfB44mWncCGTWara1NnKGvacO6atqw7uP6IiNVs0G7xDsDAAAAgAQk6e2jFcuV1KZtvykkxCiTyaR7Dx5Kkv4+eEyLZo7S0rnjVKlcyRQVUNGrhNZt2qFHjyL16FGkHvoFxNvWYDBEh6UKZUvol9//liT9+sd+VfAqLkna9cd+DR/QVasWTtInjesneO4SRQtoz77DkiSfc5ejt2fwcNP5i9cUGRmpnb/ti/du46FjPqpVrbzKlCyiC5evRW/Pktkzeo7+X7kyxfT3weMKMYYqxBiqvw8eV/kyxROsEQAAAACepySFwioVSqt2rUpq33uk2vUaof2HTkiScuXIquYdB6pN92EaMmpGku6UPa3hu28qd85satVtqDr3G6Uz5y/H27ZU8cLa9utemc1m9e/eWn8fPK6WXYfqrwNHo994WrhgXg36YrpadxumXkMm6Nv1P8XbX4dWjXTo6Cm17fm5Dh45KQd7e0lS+bLF5eBgr+YdB+n+Az9lyZwxzuPfeau6tu74Qz0Hj5f+78ZelQqldeT4GXXoPVKhYf/diSyQL7faftxQXfqNVpd+o9W6+fvRS0YBAAAAwBIMERHhKXo47frNO5r79RpNGtlPJpNJazb8rJM+5zVhRN/UrjFZOvQeqXnThiudg718zl3SwBHT9dP38yxa0/PwZPnonq1LZWeX6t8sAgAvtNt37qtx2/76ZvZIZX3q+Wsk35Vrt9RzyGStXDAx0efjAQCvnhSniUyeHrK3s1O7nsMVEfFIWbN4akDPtqlS1KRZX+v0mYsxttWvU0OfNHk30WOrViyj7gPGKuLRI6VzcNDIwd2eqT8AAAAAeJWlOBQ6OTpq7LBeqVlLtKGJvLQmIZ3bNFHnNk1ibKtSofSzlgQAAAAAr6QkPVMIAAAAAHg1EQoBAAAAwIoRCgEAAADAihEKAQAAAMCK8V0GAICX1gNff0uX8Erw9fO3dAkAAAsiFAIAXjrOzk5K7+qiwaNnW7qUV4qTk6OlSwAAWAChEADw0nF3c9XaJdNlNIZaupRXgjE0TK26fSb39C6WLgUAYAGEQgDAS8ndzVXubq6WLuOVEBJitHQJAAAL4kUzAAAAAGDFCIUAAAAAYMUIhQAAAABgxXimEADwwggIDOblMRZgDA2zdAkAAAsiFAIAXggBgcFq1n6AgoJDLF2K1QoICpGLi7OlywAApDFCIQDghWA0hiooOERTvuijTJ4eli7Hqty4dVcjJ3krlDuGAGCVCIUAgBdKJk8PZc3saekyrEpoaLilSwAAWBAvmgEAAAAAK0YoBAAAAAArRigEAAAAACtGKAQAAAAAK0YoBAAAAAArRigEAAAAACtGKIzD2o071LLrUG3Y8qs69B6hASOmymw2x2hTt3GXBPvoMWicfM5dep5lAgAAAMAzIxTGYe3GHZo2ZqACg4JVvbKXpo8dJIPBYOmyAAAAACDV8eX1T5m9cLVu372vJm37y9XFWekc7GVjY6NWzd7TlDlLdNLnvArky61HkZGJ9rV77z+aPneZAoNCNGvCEF26ekO//rFfIwd1kySN/3KR6r5eRTlzZNXIiXN1776vfP0CVCBfbn09e7QcHOyf93ABAAAAWDnuFD6lT5cWyuSZQT99N08fffi2Pm5cX+1bfKiN23bLaAzVKu9J6tutVazlpHFxdnLUopmjVLFcSf28609VrlBap85cVFhYuKKiTDrlc0HlyhbX8jWbVOeNKtq0eo5qVimnvt1aEggBAAAApAnuFCbRoaOn9WGD2rKxsVFmzwxysE88tFUuX0oGg0FFCuTV+UvXZGdrqzeqV9De/UeUKaOHypQsIjtbW2XM6K6AgCCFRzxScIgx3v7Wbdqp9Zt3SlKSQikAAAAAJIZQmERRUVEyGkNTdKytra2eZLj36r2uuV+vUc7sWVTn9SqSpFpVy2vEhK/0x1+HVK1yWZUvUzzOfpo2rKumDetKkiIjI1WzQbsU1QMAAAAATxAKk6h40QLau/+I3qhRUZev3lRYeHiK+smdM5vCwsJ1/NR59ejwsSRp1x8H1K39R9EhEQAAAADSCqEwiZo1rKuRk+apdfdhKlmsoDJ7ZkxxX9Ure+nq9duytX38SGfhgnk1ZfYSLft2k1xdnFSmZBF1adtUNjY88gkAAADg+SIUxuGH5TMlSZ1aN4ne5uLirOljBya5j3lTh0f/ucHbtdTg7VqSpMioKP25/4h6d2kRvX/Ttt+0ZvEUZczgrjv3Hqhll6Fq/dF7cnFxfsaRAAAAAEDCCIXPqF3P4TKZTDG29e/RRl6lisZqe/vOffX5bJLq1a6mAvlyR29/o0YFDR71pcLCI2SQQYP7tCcQAgAAAEgThMJntHTuuCS3zZ4ts9YumR5re5P366rJ+3VTsywAAAAASBIeWgMAAAAAK0YoBAAAAAArRigEAAAAACtGKAQAAAAAK8aLZgAAL5QHvv6WLsHq+Pr5W7oEAIAFEQoBAC8EZ2cnpXd10eDRsy1ditVycnK0dAkAAAsgFAIAXgjubq5au2S6jMZQS5didYyhYWrV7TO5p3exdCkAAAsgFAIAXhjubq5yd3O1dBlWJyTEaOkSAAAWxItmAAAAAMCKEQoBAAAAwIoRCgEAAADAivFMIYBXXkBgMC8vARJgDA2zdAkAAAsiFAJ4pQUEBqtZ+wEKCg6xdCnACy8gKEQuLs6WLgMAkMYIhQBeaUZjqIKCQzTliz7K5Olh6XKAF9KNW3c1cpK3QrljCABWiVAIwCpk8vRQ1syeli4DeCGFhoZbugQAgAXxohkAAAAAsGKEQgAAAACwYoRCAAAAALBihEIAAAAAsGKEQgAAAACwYoRCAAAAALBihEIAAAAAsGKEwn+t3bhDLbsO1YYtv6pD7xEaMGKqzGZzjDZ1G3exUHUAAAAA8HwQCv+1duMOTRszUIFBwape2UvTxw6SwWCwdFkAAAAA8FzZWbqAF8Hshat1++59NWnbX64uzkrnYC8bGxu1avaepsxZopM+51UgX249ioxMsJ9rN25r3PSFCggMUuXypdW/e2tFmUyaOX+l/jlyUm7pXTVmaA9lz5ZZn3QerBqVy+n3vw6qcvlSKlmskFat2yp7OzvNmjhEri7OaTR6AAAAANaMUCipT5cW2r33gJbMGat1m3bIydFRLZs10LpNO2U0hmqV9yT5+gVoz9+HE+xnwpeLNLBXOxV6LY8mzFisU2cu6sLla3JwsNeaxVN09ORZLf9us4b07aBrN26rRl8vdWzdWA1b9FbWzJ5aNnecBoyYpr1/H9Y7b9WI1f+6TTu1fvNOSYq1tBUAAAAAUoJQmIBDR0/rwwa1ZWNjo8yeGeRgbx9v2xBjqHzOXda4ad6SpLDwCFWrWEYHDp3Q+UvXdPDISZnNUp5c2SRJ6RwcVKZkEUlSvjw5VL5scRkMBhUukFcP/QLjPEfThnXVtGFdSVJkZKRqNmiXiqMFAAAAYI0IhQmIioqS0RiatMZms5ydHbVs3vgYzyLu2L1Pfbu2Uo0qXvEeamdnG+PP3AUEAAAAkFZ40UwCihctoL37j8hsNuvSlRsKCw+Pt62Li7NyZMuin37ZI0m6e89XZrNZFb1KaN2mHXr0KFKPHkXqoV9AWpUPAAAAAIkiFCagWcO68g8IUuvuw/T9xu3K7JkxwfYjB3XV5m2/qWXXoRr/5SKFGEPV8N03lTtnNrXqNlSd+43SmfOX06h6AAAAAEicISIinLWKL6EnzxTu2bpUdnasAgbic/vOfTVu21/fzB6prJk9LV0O8EK6cu2Weg6ZrJULJqpA/tyWLgcAkMZIEynQrudwmUymGNv692gjr1JFLVQRAAAAAKQMoTAFls4dZ+kSAAAAACBV8EwhAAAAAFgxQiEAAAAAWDFCIQAAAABYMUIhAAAAAFgxXjQDwCo88PW3dAnAC8vXz9/SJQAALIhQCOCV5uzspPSuLho8eralSwFeeE5OjpYuAQBgAYRCAK80dzdXrV0yXUZjqKVLAV5YxtAwter2mdzTu1i6FACABRAKAbzy3N1c5e7maukygBdWSIjR0iUAACyIF80AAAAAgBUjFAIAAACAFWP5KGDlAgKDed4OsHLG0DBLlwAAsCBCIWDFAgKD1az9AAUFh1i6FAAvgICgELm4OFu6DABAGiMUAlbMaAxVUHCIpnzRR5k8PSxdDgALuXHrrkZO8lYodwwBwCoRCgEok6eHsmb2tHQZACwkNDTc0iUAACyIF80AAAAAgBUjFAIAAACAFSMUAgAAAIAVIxQCAAAAgBUjFAIAAACAFSMUAgAAAIAVIxQCAAAAgBUjFD5l7cYdatl1qDZs+VUdeo/QgBFTZTabY7Sp27iLhaoDAAAAgNRFKHzK2o07NG3MQAUGBat6ZS9NHztIBoPB0mUBAAAAwHNhZ+kCXiSzF67W7bv31aRtf7m6OCudg71sbGzUqtl7mjJniU76nFeBfLn1KDIywX4uX72psdO8FRkVpXy5s8ve3l4jBnbVvQcPNWbKAgUEBqtwwby6ffe+5k0drpAQo8ZOX6jrN+6oUIE8Onvhir5dNCWNRg0AAADAmhEK/0+fLi20e+8BLZkzVus27ZCTo6NaNmugdZt2ymgM1SrvSfL1C9Cevw8n2M/Yad7q0LKRalTx0poNP+v8pauSpFkLVur16hXU7IO39ftfB/XdDz9LkpZ8u1E5smXRpJH9dO7iVQ0ZPSPOftdt2qn1m3dKUqwlrQAAAACQEoTCJDh09LQ+bFBbNjY2yuyZQQ729vG2DQkx6r6vn2pU8ZIkZc+WKToUHj7uo5GDuz3enjVz9DEHj5zSmM96/rs9U7x9N21YV00b1pUkRUZGqmaDds80LgAAAADgmcIkiIqKktEYmrS2JrNCQ8MUFWWKtS8yMkqhoeFx9G+SMTTsmesEAAAAgOQiFCZB8aIFtHf/EZnNZl26ckNh4bGD3RPpXZ2VMYO7jp44I0k6c+7yf/0UeU17/116eubcpejtJYoW0J59j7f7/F97AAAAAHjeWD6aBM0a1tXISfPUuvswlSxWUJk9M8bb1mAwaGi/jpo86xu5pXdVrhxZZWPz+O2lfbu20qgp87Vhy68qXCBv9DEdWjXSiAlfae/+wypToshzHw8AAAAAPEEofMoPy2dKkjq1bhK9zcXFWdPHDkxyH+VKF9N3X0+VJP3+10H98dchSdJr+XJp+bzxkqRzF69q5oIVkqQsmTLK+8uRkqSg4JBEX2QDAAAAAKmFUPgM2vUcLpMp5rOD/Xu0kVepohaqCAAAAACSh1D4DJbOHZdom9erVdDr1SrE2l64QF7Nmzo81vb0ri7RdysBAAAA4HnjRTMAAAAAYMUIhQAAAABgxQiFAAAAAGDFCIUAAAAAYMV40QwAPfD1t3QJACzI18/f0iUAACyIUAhYMWdnJ6V3ddHg0bMtXQqAF4CTk6OlSwAAWAChELBi7m6uWrtkuozGUEuXAsCCjKFhatXtM7mnd7F0KQAACyAUAlbO3c1V7m6uli4DgAWFhBgtXQIAwIJ40QwAAAAAWDFCIQAAAABYMZaPwqpFGgMVFR5i6TIAwKLCjWGWLgEAYEGEQlitSGOgTk5tLFMEz9IAsG6hUQZJ+RUZGiS5OFu6HABAGmP5KKxWVHgIgRAA/k9UOD8TAcAaEQoBAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEK47B24w617DpUG7b8qg69R2jAiKkym80x2tRt3MVC1QEAAABA6iEUxmHtxh2aNmagAoOCVb2yl6aPHSSDwWDpsgAAAAAg1dlZuoAXzeyFq3X77n01adtfri7OSudgLxsbG7Vq9p6mzFmikz7nVSBfbj2KjIy3j917Dmj/oRMa2q+jJGncNG/VeaOqTvqcl9ksnTpzQecvXdOw/p1UvbKXQkKMGjt9oa7fuKNCBfLo7IUr+nbRlLQaMgAAAAArRih8Sp8uLbR77wEtmTNW6zbtkJOjo1o2a6B1m3bKaAzVKu9J8vUL0J6/D8fbR5WKpTXvm+9kNptlNpt1wue8hvTtqJM+53Xm/CVNHT1Af+w7pDUbflb1yl5a8u1G5ciWRZNG9tO5i1c1ZPSMOPtdt2mn1m/eKUmxlrMCAAAAQEoQCpPo0NHT+rBBbdnY2CizZwY52NvH29bJ0VEF8ufWuQtXFBkVpeJFCsje/vFUlytdXPb2dipcIK8e+gdIkg4eOaUxn/WUJGXPminefps2rKumDetKkiIjI1WzQbtUGh0AAAAAa0UoTKKoqCgZjaFJbv9mjYrau/+IIqOi9Hr1CrH229naSuYnfZtkDA1LrVIBAAAAIMl40UwSFS9aQHv3H5HZbNalKzcUFh6eYPtqlcrq4NHTOnr8jKqUL51g2xJFC2jPvsfLUX3OXU61mgEAAAAgMYTCJGrWsK78A4LUuvswfb9xuzJ7ZkywfXpXFzk7OSqDh5scHdMl2LZDq0Y6ePSU2vb8XHsTeFYRAAAAAFKbISIinDeWvECCgkPUpsfn+mH5zATbPXmmcM/WpbKzYxVwSoT73dapaU0sXQYAWFxolEEDj+TX1m/GKmPO/JYuBwCQxkgTz6hdz+EymUwxtvXv0UZepYpaqCIAAAAASDpC4TNaOndcqvaX3tUl0buEAAAAAJBaeKYQAAAAAKwYoRAAAAAArBihEAAAAACsGKEQAAAAAKwYoRAAAAAArBihEFbLNp2LbBycLV0GALwwbNPxMxEArBFfSQGrZefsppKDNigqPMTSpQCARYUYw6QOI2TnlN7SpQAALIBQCKtm5+wmO2c3S5cBABYV6WC0dAkAAAti+SgAAAAAWDFCIQAAAABYMZaP4pUWaQzkmUEASES4MczSJQAALIhQiFdWpDFQJ6c2limCZ2UAICGhUQZJ+RUZGiS58AZSALA2LB/FKysqPIRACADJEBXOz0wAsEaEQgAAAACwYoRCAAAAALBihEIAAAAAsGKEQgAAAACwYoRCAAAAALBihEIAAAAAsGKEQgAAAACwYoRCAAAAALBihEIAAAAAsGKEwkSs3bhDLbsO1YYtv6pD7xEaMGKqzGZzjDZ1G3dJUd+jpyxQmx6f69SZC6lRKgAAAAAkm52lC3jRrd24Q7MmDtX2XX+qemUvdWzVOFX6ve/rp2Mnz2rD8hmp0h8AAAAApAShMAGzF67W7bv31aRtf7m6OCudg71sbGzUqtl7mjJniU76nFeBfLn1KDIywX6u3bitcdMXKiAwSJXLl1b/7q01bOxs+T70V4feI/XNnDHyXrpW+w+dUGBQsLq2a6a6b1SN1c+6TTu1fvNOSYp1txIAAAAAUoJQmIA+XVpo994DWjJnrNZt2iEnR0e1bNZA6zbtlNEYqlXek+TrF6A9fx9OsJ8JXy7SwF7tVOi1PJowY7FOnbmoMUN7aODI6fpmzhhJ0hs1KqpL26a6ceuu+n42Oc5Q2LRhXTVtWFeSFBkZqZoN2qX6mAEAAABYF0JhChw6elofNqgtGxsbZfbMIAd7+3jbhhhD5XPussZN85YkhYVHqFrFMvLM4B6jXeZMGbRq3VadPntJ9x48fK71AwAAAMAThMIUiIqKktEYmrTGZrOcnR21bN54GQyG6M2379yP/nNIiFE9B41X248bakif9vrn8MnULhkAAAAA4sTbR1OgeNEC2rv/iMxmsy5duaGw8PB427q4OCtHtiz66Zc9kqS793xjPQ947eYd2dvbq17t6nroF6jwiIjnWj8AAAAAPEEoTIFmDevKPyBIrbsP0/cbtyuzZ8YE248c1FWbt/2mll2HavyXixTy1F3GgvnzKFf2LGrb43Nt3LZbWTN7Ps/yAQAAACCaISIinNdYvoSevGhmz9alsrNjFXBcwv1u69S0JpYuAwBeeKFRBg08kl9bvxmrjDnzW7ocAEAaI02konY9h8tkMsXY1r9HG3mVKmqhigAAAAAgYYTCVLR07jhLlwAAAAAAycIzhQAAAABgxQiFAAAAAGDFCIUAAAAAYMUIhQAAAABgxQiFeGXZpnORjYOzpcsAgJeGbTp+ZgKANeLto3hl2Tm7qeSgDYoKD7F0KQDwQgsxhkkdRsjOKb2lSwEAWAChEK80O2c32Tm7WboMAHihRToYLV0CAMCCWD4KAAAAAFaMUAgAAAAAVozlo3gpRRoDeVYQAFJJuDHM0iUAACyIUIiXTqQxUCenNpYpgmdgACA1hEYZJOVXZGiQ5MIbSAHA2rB8FC+dqPAQAiEAPAdR4fxsBQBrRCgEAAAAACtGKAQAAAAAK0YoBAAAAAArRigEAAAAACtGKAQAAAAAK0YoBAAAAAArRigEAAAAACtGKAQAAAAAK0YoBAAAAAArRij819qNO9Sy61Bt2PKrOvQeoQEjpspsNsdoU7dxlwT7mOW9UhcuXXueZQIAAABAqrKzdAEvirUbd2jWxKHavutPVa/spY6tGie7j75dWz2HygAAAADg+SEUSpq9cLVu372vJm37y9XFWekc7GVjY6NWzd7TlDlLdNLnvArky61HkZEJ9tNj0Dj17txCfx88Lnt7O7Vq9p6WfrtR+w8e1/zpI3Tl2k3NXLBSMycM0SedB6tG5XL6/a+Dqly+lEoWK6RV67bK3s5OsyYOkauLc6z+123aqfWbd0pSrLuYAAAAAJASLB+V1KdLC2XyzKCfvpunjz58Wx83rq/2LT7Uxm27ZTSGapX3JPXt1irJQaxc6WI6ceq8JOnM+cuSpIiIRzp++rzKliwqSbp247ZqVPHS8vkTtH3XX7r/4KGWzR0ndzdX7f37cJz9Nm1YV98umqJvF03RygUTU2HkAAAAAKwdoTABh46eVsP6b8rGxkaZPTPIwd4+SccVK/yazl26KpPJpJCQUBUqkFdnL1zRidPnVbZUEUlSOgcHlSlZRI7pHJQvTw6VL1tcBoNBhQvk1UO/wOc5LAAAAACIRihMQFRUlIzG0GQf5+Bgr1zZs+rPA0eVO2c2FS/ymo6dOqvzF6+qWJHXYrW3s7ON8WeWhgIAAABIK4TCBBQvWkB79x+R2WzWpSs3FBYenuRjy5Uppk3bdqtksYIqWayQjhw/IxdnJ6VzcHiOFQMAAABA8hAKE9CsYV35BwSpdfdh+n7jdmX2zJjkY8uVLqa/DhxVqeKFlDN7Fp27cEWlSxZ+jtUCAAAAQPIZIiLCWav4EoqMjFTNBu20Z+tS2dlZ10tkw/1u69S0JpYuAwBeGaFRBg08kl9bvxmrjDnzW7ocAEAas640kUra9Rwuk8kUY1v/Hm3kVaqohSoCAAAAgJQhFKbA0rnjLF0CAAAAAKQKnikEAAAAACtGKAQAAAAAK0YoBAAAAAArRigEAAAAACtGKMRLxzadi2wcnC1dBgC8cmzT8bMVAKwRbx/FS8fO2U0lB21QVHiIpUsBgFdCiDFM6jBCdk7pLV0KAMACCIV4Kdk5u8nO2c3SZQDAKyHSwWjpEgAAFsTyUQAAAACwYoRCAAAAALBihEIAAAAAsGI8U4hUE2kM5OUvAPASCjeGWboEAIAFEQqRKiKNgTo5tbFMEbysAABeNqFRBkn5FRkaJLnwtRQAYG1YPopUERUeQiAEgJdcVDg/xwHAGhEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKAQAAAMCKEQrjsXbjDrXsOlQbtvyqDr1HaMCIqTKbzTHa1G3cxULVAQAAAEDqIBTGY+3GHZo2ZqACg4JVvbKXpo8dJIPBYOmyAAAAACBV2Vm6gBfR7IWrdfvufTVp21+uLs5K52AvGxsbtWr2nqbMWaKTPudVIF9uPYqMTLCfVWu3av3mX+SYzkGf9myjCmVLqFGbfqpWsYxOnD4vD3c3jR3WUzt/+1t+/oHq3KaJJKnXkAka0qeDcufMlhbDBQAAAGDFCIVx6NOlhXbvPaAlc8Zq3aYdcnJ0VMtmDbRu004ZjaFa5T1Jvn4B2vP34QT7+Wb1D1q35EvZ2/83zfcf+Om9eq9rUO/2mjF/hb7/cYeaN3pH3QeOVafWjRUYFCKjMSzOQLhu006t37xTkmItZQUAAACAlCAUJsOho6f1YYPasrGxUWbPDHKwt0+w/Xtv19K46d7q3KapihbKL0lysLdTscKvSZKqVCit9Zt/kVt6FxXIl1unz17StRu39UaNCnH217RhXTVtWFeSFBkZqZoN2qXe4AAAAABYJZ4pTIaoqCgZjaFJbt+/ext1adNUM+av0Hc//Bxrv62trdI5PA6W77/zunb+tk97/z6st2pVSbWaAQAAACAhhMJkKF60gPbuPyKz2axLV24oLDw83rbhERE6e/6yihTKr+aN3tGho6clSZFRUbp331dms1lbtv+u8mVLSJLKlykun3OXFBRsVM7sWdJkPAAAAADA8tFkaNawrkZOmqfW3YepZLGCyuyZMd624eGPtGrdT7py7aYeRUbqs36dovd9tfhbXbh0XSWKFdT79V6XJNnY2KhE0YLyzOD+3McBAAAAAE8QCuPxw/KZkqROrZtEb3Nxcdb0sQOTdLxbeheN+axnrO12trYa81mvWNvDwiN09MQZTRs7IGUFAwAAAEAKEApTQbuew2UymWJs69+jjbxKFU3S8SdOn9eoyfPUpnlDZfTgTiEAAACAtEMoTAVL545LcttdG7+Ota1U8UJav2xGapYEAAAAAEnCi2YAAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKkSps07nIxsHZ0mUAAJ6BbTp+jgOANeIrKZAq7JzdVHLQBkWFh1i6FABAMoUYw6QOI2TnlN7SpQAALIBQiFRj5+wmO2c3S5cBAEimSAejpUsAAFgQy0cBAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKAQAAAMCKEQoBAAAAwIoRCgEAAADAihEKAQAAAMCK2Vm6AKSM2WyWJEVGRlq4EgDAy+7J/5dERkby/ysAYCVsbW1lMBgkSYaIiHCzhetBCoSFhenNDzpZugwAAAAAL6E9W5fKzu7xPUJC4UvKZDIpIiIiRsJ/EbXq9plWLpho6TKsAnOddpjrtMNcpx3mOu0w12mHuU47zHXaSa25/v8cwfLRl5SNjY0cHR0tXUaiDAZD9L9A4PlirtMOc512mOu0w1ynHeY67TDXaYe5TjvPY6550QwAAAAAWDFCIZ6rJu/XtXQJVoO5TjvMddphrtMOc512mOu0w1ynHeY67TyPueaZQgAAAACwYtwpBAAAAAArRigEAAAAACtGKAQAAAAAK8Z7Y/HM/AOCNGLCV3roF6D6dWuoVbP3Yuy/c++BJs/6RvfuP1SunFk1ekgPOTqm041bdzVq8jyFhoWr9Ufv6Z23alhoBC+PxOZakuZ9vUY//rRbQ/t1VO2alSRJY6d568jxM3J1cZIkfTXlc7mld0nT2l82KZ1rruvkS2yuzWazvln1g3b9cUBZMmfU2GG95OrizHWdTD/+tEtrN+54PHef9VSWzJ7R++K6buObdyQuuXN9+859fdx5sPLmyi5Jeuv1Kmr7cUNLlf9SSWiuz5y/rBnzVyg42KhVCydJiv/nCRKX3Lnmuk65hOZ6zYaftWP3nwoxhqlXp49Vs2r5VLmuuVOIZ/bNqh/0evUKWjZvnLb9slfXbtyOsf/wMR/17txCK70nytbWVlt2/CFJmuW9Uu1bfKiFX46U99K1Cg4xWqL8l0picy1JNaqUU/Eir8XaPuzTTlo+f4KWz5/AL85JkNK55rpOvsTm+tyFK/rrwDEtnz9BXqWLauX3W6L3cV0nzUO/AK34brO+njVaTRvW1dyvv4uxP67rNqF5R/xSMteSVLzwa9HXMr84J01ic+2Z0UNNG8Z8SyPXdcqkZK4lruuUSGiuQ4yhCo+I0KKZozVxRF9NmLFYZrM5Va5rQiGe2V8HjqpsqaKys7NTqWKFtO+fYzH2v1u3pl7Ll0sGg0GlihfS/QcPFRVl0t8Hj6tsySJycXFWnlzZdfiYj4VG8PJIbK4lqXSJwvLM6BFru4db+jSo8NWRkrnmuk6ZxOb6zwNHVaZEYdna2qhsyaL66//2c10nzf5DJ1S4QD45OqZT2VJFte+fo9H74rtuE5p3xC8lcy1J7u5cy8mV0FxLUmbPDCpZtGCMbVzXKZOSuZa4rlMiobl2cXZS248bytbWRvnz5lRUVJTCIx6lynVNKMQze+gXoFw5skqS8uTKrge+/vG2PXT0tEqXKKyAoCB5uKWXy7+3th8f55cW5b7UkjPXT5uzaLU+7jRY36z6QWYz30STmJTMNdd1yiQ2174P/ZUn9+PlR3lzx5xTruuk8X3orzy5skmSMmX0UJTJpLDwCEnxX7cJzTvil5K5lqQLl66pfa8R6jVkgq5cu2mZ4l8yCc11gsdwXSdbSuZa4rpOiaTO9dkLV5QrR1Y5pnNIleuaZwqRLEtXb9S+gzH/9SE0LFz695cxk9kkg40hzmP3HzqhoOAQVatUVv4BQTL93y9wJrM53uOs1bPM9dPaNH9fzs5OioqKUs9B41W2ZBGVK1M81Wt+WaXWXBtk4LpORIrm2mCQyfTvfpNZNv/u57pOBoNihGazySyD4cmueK7beOYdiUjBXGfJ7KkRg7qpWKH8WvPDNk2Zs0Tzpg5P68pfPgnMdfzHcF2nSArmmus6hZIw15FRUZrlvUpd23307zHPfl0TCpEs7Vp8oHYtPoixrVn7Abpx664KvpZH12/cUcHX8sQ67tqN25rtvUozJgyWwWCQu5urgoJDFBxilKuLs67fuKMqFUqn1TBeCimd67jkzZ0j+s/VK3vpyvXb/PL8f1JrrrmuE5eSuc6cMYOu33z8nOG1m3eUKWMGSVzXyZHZM4NO+lyQJN339ZO9vb3SOThIiv+6DQgIjnPekbCUzLWtrY3KlCgsSfqgfm1998N2i9X/MkloruM9Jp6fJ0hYSuaa6zplkjLXM+evVPkyxVS5fKnHx6TCdc3yUTyz6pW9dOTEGUVGRuqkzwVVrVhGfv6BGjBimiKjohQQGKzPx83RsE87KUumjJIkGxsbVa1YRkdOnFFwiFHXb95WudLFLDySF19icx0XP/9Abd/1l8xms/wDgnTs1FkVKZgvbQt/CaVkrrmuUyaxua5euayOnTyrqCiTjhz3UbVKZbmuk6lSuVI6f/GqwsLCdeT4GVWrVFar1m7Vjt1/xXvdxjXvSFxK5nrnb/vk+9BfZrNZe/YdUtFC+Sw9jJdCQnMdH67rlEnJXHNdp0xic71u0075PvRXh5aNoo9JjevaEBERzkMYeCYBgcEaMeEr+T7013v1aumTJu/q9t0H6j1kglYumKhpc5dp79+HlT1rZkVFRcnV1Vnzpg7X7Tv3NXLSXBlDw9T244Z6+81qlh7KCy+xub587aYmzlisO/d85eLipLIli2hov45asOR7HTl+Rv4BQWreqJ4+afKupYfywkvJXH8xuDvXdQokNteOjum0ZPWP+uW3v5Utq6fGfNZLdna2XNfJtHn771qzYZvSuzhr7Oe9teK7zcqWJZNaNH033uv26Xl3cXay8CheDsmd62OnzmnBku/l+9Bfnhk9NHJgV2XPltnSw3gpJDTXE2Ys0onT53Xr9n3lzZ1dA3q1U5kShbmuUyi5cy2J6zqF4pvr16tXUPMOA5U/b67oJaWtm7+vum9UfebrmlAIAAAAAFaM5aMAAAAAYMUIhQAAAABgxQiFAAAAAGDFCIUAAAAAYMUIhQAAAABgxQiFAAAAAGDFCIUAAAAAYMUIhQBgxRq16adzF68m2u7cxavq3G+0OvQeoSvXbqVBZTGNneatw8dOR//37IWrdfDoqTSvIzH37vuqx6BxatPjcx0+dloHDp1Q+14j1KnvF3rg66fBX3ypiIhH8R5/8cp1jZ4y/5lq6DFonG7fuf9MfaSW/7++Vq3dqu27/oyz3Yz5K7R4xfpE+3t6bKOnzNfFK9dTp9jnJKFxA8CLws7SBQAAXnx79h1W/rw5NKx/Z0uXIknq06WFpUuI08Gjp2VrY6vl88ZLksZNX6ha1cqrfYsPJUlTRn+a4PEF8uXWF4O7P+8yLaJlswap3ufLMFfPY9wAkNoIhQAASY/vxuXJlV3HT53TuQtXVK1SWX3Wv5N+2/uPNmz5RSaTSUMCZmjyqP46cfq8Zi9cJWNomDJ6uGtAz7bKlyeHbt+5r8/Hz1b1yl76Y98hTRrRT2One+vNGpX0+58Hdf3mHXXv8JEe+Ppr5+/7FB7+SJNG9lO+PDl09fotfbX4W91/4KcQY6i6tf9Ib9WqrPnffKfdew7o2Mmzypk9i2ZNHKoho2aoVrXyavB2LQWHGDVj/gqdOXdZBhuDPm70jt6r97qkx3eW3qpVWX/8dUjnL15Tk4Z11LFV4xjjNpvNWrNhmzb9/Jvs7exUoWwJ9enaMsF+r16/pSmzl8jXL0Bu6V00fEAXBQaFaOGydQoOMapD75GqX6eG/vjrkNKlc9ADXz91a/+R3m7SVfu2r5QknT57UbO9VynYGKr0Ls4aO6yXHvoHasjoGfph+UxJ0pbtv2vVuq2KijKpYrmSGtCjjWxsbFSvaTd1bdtUP+/6Uzdv39Ow/p1UvbKXxk7z1onT5/XpiKkqXqSARgzsGmOcy9Zs0s7d+2Q2m1WlQml179Bc9vZ2WrxivcLCI3Tr9j35nL+s1/Lm0uQv+snO7r9fEzr0HqnuHT5SRa+SkqRx07xVplRRVatYRrO8V+rGrbsKDArRRx/W00cf1ot1fc2Yv0LpXZ3VqXUThUdEaOb8lTp07LQyeXro0aMoVS7/uN9TZy7Ie+k6+QcG6dGjRxrcp4O8ShWNc2xtug9Tv26tVK5Mcd339dO0OUt14/Zd2dnZqkubpqpe2UvS4zuWnVo31tYdf+jSlRvq0aG5GtZ/M0Z9v+39R18t/la2tjYqUjCfRg7qJltbWy1bs0nbftkrs9ms+nVqqH2LD+X70F/DJ3ylB75+cnZ21LD+nVUwfx5Nnv21Dh45LXt7W7X75EPVr1MjxrgfPYrUvG/WaP/BEzIYDHq7djW1af6+DAZDvH//JMl72Vr9/MteOTjY6/16b6jVR++l7C85AMSDUAgAiHbs5FlNGN5HYeEReu+TXmrZrIHeqFFRFy5fU1CwUf27t1ZgUIiGjpmpKaP6q0TRgtq954CGjpmpVd6TJElnL1xR/To1tWzu+Oh+z1+6qpkTh+iv/Uc1ZPQMTf6iv5Z+NU7jpy/Uuk07NbBXW3m4u6lXp0+UN3cOHT91TkNHz1TtmpXUvUNznfA5r06tGqtcmeKxap69cJWcnRy10nui/AOC1LnfKOXOmU1lShaJrmf6uEG6cvWm2vUcrpZNG8jRMV308Tt/26dtv+zVgukj5ZbeRQ/9AhLst0Sxghox4SuNHNRNBV/Lo78PHtdXi77VlNGfqnObJvrjr0OaPKq/JOnM+csq9Fpefdz4HQUFh0SfMyg4RINHfamRg7qrUrmSeugXoAwebnroH/jfZ3HqnH7e9aeWfDVO9nZ2GjN1gf7Yd0hvVK+owKBgpUvnIO8vR2rtxh1a+u0mVa/spREDu+rwcR99OXaQsmfLHGOetu/6U3v/PqzFs0fJ3s5On4+fo1XrtqrdJx9Ikg4dPa0Z4wfLMZ2DmnUYqEPHfFS5fKno4+vXqaFdfxxQRa+SevQoUn8fOq5+3VsrnYODWjZtoCKF8uvefV81bT9A9evUUHpXl3ivs5Xfb9F9Xz+t8p4kg0H6fPyc6H2ZMmbQ8AGdlSWzp7bv+ktzFq7WN3PGJDg2SRozZYGqViyjyaP668atu+r66Rh5fzlSuXJklSTduftAc6d8rr1/H9aU2UtihcLFKzeoZ8eP9UaNirpz94Hs7Oy0fddfunr9llZ5T5TZLPX5bJKqVSyjw8d95OLspHlTP5fvQ3+lT++iC5eu6re9/+in7+Yp4lGkwsMjYo977RbdunNfy+eP16PISPUeMlHZsmRSvdrVHn/mcfz9c3dLr6WrN+qn7+bJxdlJAUHB8c4rAKQUzxQCAKJVKldKjo7p5OGeXnlyZtODh/6x2pz0Oa/cObKqRNGCkqQ3a1aSMTRU12/eliQ5pkunpg3rxjimemUv2dnaqlTxQpKkWtXKy2AwqFTxwrrv+1CS5O7mqrCwcM3/5jutWrtVfgGBMhpDE615774jat7oHRkMBmXwcFPdN6pq799HYp27QP7csre3l19AUIzj//jrkJq8X1fubq4yGAzyzOiRYL83bt7R1eu3NWbqArXpPkxzF6+J1WdiTvpcUI5sWVSp3OO7YxkzuMtgMDw1rsO6eu2WuvQbpfa9hsvn3CXdvecbvf/JHJYsVlC+cXxOT9uz77Aa1n9TTo6OsrOzU5P362rPvsPR+0uXKCwP9/RydEynwgXy6MFDvxjH13m9ivbuP6LIqCgdOHxCZUoUkauLs+zt7eTomE5fr/xBM71XySBDjDrj8uf+o/row3qyt7eTnZ2dsmXJFL0vS+aMunH7nmYvXK0t23/XjVt3Ex2bMTRMR06cib7ucuXIqopeJXTg0InoNjWrPpmvQnFe1x/Uf1NLVv+oLTv+iL4G9uw7pKMnz6pD75Hq2Gek7j94qNt3H6hapbK6fee+5iz6VpFRUUrn4KC8eXKqaKHXNHLSPF2+ekMZPNzi/AyaNqwrOzs7OTk6quE7b2jPvkPR++P6++eW3kX1alfTqMnzdPTEGWX6tzYASE3cKQQAxMnOzlYym5PU1iCDpMehxsbGJlbAidFnrHM8/vPGn3Zr2y971L5lI7X95AO99WEnmZJ4/qeKUVynNxgMcY7JZDbH2T6+fs1mydExnZbOHScbm5T926rJZIp3jp4wy6w6b1RR366tEmxnZ2cns5I/T4Z45kmS7Gzt9HSXGTzcVLRQPh0+5qNdew7onbeqS5L2/XNMc79eo65tm6ppw7pqd254op9bZFSU7GzjnruFy9bp0tUb+rhxfTV85w117jcqGWMyxPxzHAN8+hp8otkHb+utWpW1duMONe80SN/MHiOz2axPGtePcznssvnj9dvef9Rr8AR1btNU9WpX0+xJQ3X81DnN/XqN8ufNpUG92iVWcMJ/V8xmGQwGjRrSQxevXNei5ev13Y8/a/rYQQn3CwDJxJ1CAECylCxWSDdu39WpMxclSb/9+Y+cnByVO2e2Z+p37/7DerNmJVUuX0oXL8d8o2S2LJl0++6DOI+rUdVLazdul9lsln9AkHbu3qfqVcol+bzVK5XVD1t3KTjEKEm6fvNOgv3mzpVNHu6uWrPhZ5nNZkVEPNK9Bw+TNdaSxQrq2o3bOnLijCTp3oOHCg0Li1lXZS/9tHOvrt14fAf29t0HiooyJdr347mK/fbRmlXLafPPvyksLFyRUVFav/kX1UjGPEnSO2/V0K49+3Xi9HlVqVBG0uNQWKFsCdWsWl5+/gEKCvpvmaxBBplNsWv2KlVEW3b8IZPJpNCwMJ2/9N8bcPf8fVgN6taSV6miOnfxSpLG5uzkKK9SRbVu805J0s3b93Tg8MnoO7GJMZlMOnzcRxk83NSxdWOZoky6fPWGalQpp+9/3B59J/bWnXuSJJ9zlxQeHqE6r1dR7VqVdeDwCd2+c1+37txT6RKF1aZ5Q/114Gis89SsWk4bNv+qyKgohYaFafPPvyX6GQQEBunCpWsqkC+3urf/SPsPnVRkZGSSxgUAScWdQgBAsrild9HEEf00Y/5yhYVHyMM9vSaN7CfbeO78JFXThm9r7uJv9esf+1WpXEllzewZva9B3VoaNXmeftq5R7MmDY1xXJ8uLfXlvOVq1fUzGWwMavfJBypTonCSz/tu3Zq6c89XHfuMlKNjOpUqVlgDerZJsN/JX3yqaXOXavP23+TgYK/WH72vOq9XSfI53d3Sa+KIvpq9cJUiHkXKwz29hvTpEKONV6mi6t35Ew0ZPUN2tnZyd3PVF0O6K7NnhgT7/vDd2hoxca7KlS6mscN6RW+vV7u67tzzVYfeI2UwGFSpfEm1bJq8N2PWqOKlaV8tVe2alWRv//hXiAZ1a2ra3GXq0HukShUvpDy5ske3r1m1nFZ8v0XjPu8do58OLRtr/PSF+qTzEOXIllnZs/73jGCrZg00f8l3WvPDNr1erUKM6yq+sUnSyMHdNHX2Em3Z/rvs7Gw1rH+n6OcJExMR8Ui79xzQzAUrFRxsVNWKZVS6ZBHZ2tjovu9D9Rg0TukcHJQ5U0aN/7y3bt99oGlfLZMxNFROjo4aOairQoyhmrNotR76BSo8IkJ9u7aMdZ5Wzd7T3K/XqE23YdEvmnn7zaoJ1mY0hmnR8vW6fe+BQkKM+rR76xgvAAKA1GCIiAhPwdocAAAAAMCrgOWjAAAAAGDFCIUAAAAAYMUIhQAAAABgxQiFAPB/GrXpp+YdB6pN92Fq032YPh0+VZI0e+FqHTx6SpI0dpq31mz4WZK0dccfGjJqRrLOERQcoqr1Ev6agdTQqE2/JLVbtXartu/6M9XOO2P+Ci1esT7W9qr1WsX4AvfkGDvNW++36K2WXYfq/Ra9NXDkdD3w9Uv8wHgcPHpKsxeuTvHxT9u+60+tWrv1mdrFdS3FN5dJ1WPQOP3+18E49z3L55Eabt+5rx6DxsW5b+w0bzVs2Tv67+F3Pzz++/bD1l/VpG1/df10jPz//W5Is9mskRO/UlhYeKLnTGg+EqqzbuMu0f/dqE0/nbt4NYEjXixbd/zxTNeQlPBn9bTRU+br4pXriTdMojbdh+nwsdOp1h+AuPH6KgB4ythhvVW4QN4Y2/p0aWGhap6/ls2S9wZKS2nZtIE+bvyOoqJMmjhzsdb88LN6dfokRX1VKFtCFcqWSLXa6tWunqrtIHVv31z169SI/u/IyEit27hTq7wn6adf9mrjtt1q+3FD7dpzQFUqlJGjYzoLVosnvhjc3dIlAEgBQiEAJMGQUTNUq1p5NXi7VoLttmz/XavWbVVUlEkVy5XUgB5tZGNjo8PHfTRz/goZbAx6LW+uWMcFBoWo1+DxsbYP6NUuxtcr9Bg0TvXr1NSmbbtV5/UqavxeHc39eo32/XNMZrNZrT56Tw3feUN9P5ukO3cfqE33YapasYy6tmumed98p8PHTivEGKriRQpq+IAusrW10Yz5K5Te1VmdWjfR4hXrFRYeoVu378nn/GW9ljeXJn/RT3Z2dnrg66cps5fo2s07cnCw1+De7VWyWEGFR0Ro5vyVOnTstDJ5eujRoyhVLh/398MtX7NZR074KCAwWJ1aN1a92tXVfeA4tWrWQNUre0mSxk1fKK9SReOd64DAIAUFhahsySKSpEePIuOcg8PHTmvl2q3KnTOrDh45LRmkqaM/VY5sWfT7Xwf13Q8/a97U4fJ96K9Z3it149ZdBQaF6KMP60V/WXmjNv3UvsWH2rL9d/k+9NfAXu10+JiP9u4/LGcnJ00d/akyZnDXmg0/6/ylqxoxsKu27vhDR06ckdls1onT5+Xhnl7TxgyUW3qXGO2Sy2w2a9maTdq5e5/MZrOqVCit7h2ay97eTpGRkVq4bJ32/H1YdrZ2erduDX3S5F1J0onT5/XDll919sIVNXm/jjq1bpLg5yHFfx3X/6i7urZrph+37tKnPdro0aNIfTlvuQKDQ/TA1095c+dQt3bN9EaNitHnWLV2q379Y79Cw8KUI1tmjfmsl4KCQ9R76EQ99AtQm+7D1KFloxjHSJKHe/qnPvdg5cyeRY6O6VSiaAH9uHWXwiMi9Ovvf8f6yovvf9yuoyfOaMKIvrHmMb75OHH6vGYvXCVjaJgyerhrQM+2ypcnR4KfSXCIUTPmr9CZc5dlsDHo40bv6L16r+v3vw5qzYafNX/acJlMJr3bvIdaffSeWjV7T2cvXNHEGYu1dO5/d94+GzNLN2/fjdF3g7drqXmjd6L/O6G/m/HV8dvefzTvm+8kSX/8dUhTRn+qbFkyRff59OeZI1vmWH/HM3l6xPqsShUvFO/fmTbdh6lft1YqV6a4egwap7dqVdYffx3S+YvX1KRhHXVs1ViSdNLngr6ct1whxlBlz5pJIwd1U8YM7rpz74Emzfxa9x/4KWf2LPIPDErwMwCQOgiFAJBKjp06p593/aklX42TvZ2dxkxdoD/2HVK50sU1fNwcTRzZV2VKFpHPuUv6+deYyzXd0rto+fwJSTrP1u2/a+6Uz+XgYK+l325UOgd7fbtosiIiHqltz+GqUdlLsyYOVdV6rWL0+WaNiurRoblMZrNad/tM+w8dV7VKZWP1f+joac0YP1iO6RzUrMNAHTrmo8rlS2nc9IX6uHF9ValQWleu3dTISfO0fN54rfx+i+77+mmV9yQZDNLn4+fEW3uJYgXUs9PHunz1ptr1Gq7K5UureaN62vjTblWv7KXwiAjtP3RCn/ZoE+vYVeu2atO23bp87abKliqqN/8NEavWbY1zDiTppM95dW3XTH27ttLn4+Zo40+71b1D86fm3lUtmzZQkUL5de++r5q2H6D6dWoovauLJOn+Az95fzlS3/+4XZ+Pm61ZE4eqW/uP1G/YZG37ZW+cd1oPHTutuVOGKUumjOrSf4x27dmvD9+tnehne+jYabX5X3t3HhTFsQdw/DvsIqAIisgNiuCBiqgYgSgeUTSH6FMxPiIqiQdSxltINIrGM/HAJF7xeho8otF4PI/nEY9SlCRGjfEKggqIIigCgrjCsvv+WFhh2V0w0ViV9KeKKqbo6e35dffW9HRPEzlVe3w/O4f+wd0BzdLT+B/Ps/armZjK5Xwydymbd+wnPLQPm3cc4PqNVNYvm0MNU3mFG+lH+QUsmj2ZlNQ7hI+eRtiAXtpZNX31kZqeobcdd+nwGrl5+aTfzWT9stlIksTAYZMZMSSEbp38WLRsAzZ161Qa3LX18WJg357IZDImfLKAg0fj6R8cxNQJw1m7aScrFk7TG4tN3+1j6eotuLk6Mi4ijPq2dUm/m8nD3DwSzl7EzdWR7bsPE9I7iG27D3H5ahKdXm9Hzzdex6aONU6Odnrz1RePomIlH8/6ggUzJ9CimSfHT/3Mx7O+YPOqz4zW11erN1PTwpxNq+aTm5fPiPEzcXV2oJ1Pcz79fCUKxVNS0zPwdHfjlwtXCBvQi3O/XqW9r3eFfObHVB686mOobxoqR5eOr5F8Kw2gwsOAMrr1OX7q53r7uG5dFRcrjfaZ8hKTU1g8J0ob70Eh71CsVDIvdg1L5kZjb1ePXfuP8s3WPUyIHMLshavwa+fNkIG9yXuUT/ho/e1DEIQXSwwKBUEQdEyftxSzGjUAGBcRhm/r5tU6Lz7hPKlpdxk5fiYAiqdFNG/aiMvXknB1ccCndGaruv9Q25B3+75JjRqmAJxKOE9+wWMSzl4EoKi4mHtZD7Cpa13pPGdHe77f+wNXE29SUFBI+t3MSmkAWrVoop2laeLhxoOHORQ+UfDLhSs8zMljxbqtANr30U7/9Cuj3n9X+8/My89E6PL10cTSvYEzdrY2JN9KI9Dfl+Vrt5L14CFXriXj17YlNS3MK51btnw071EBh4+fYejoaWxbt8hgDMrK0tSzIaAZAKWk3qmUr6mpHHNzM9Zt2sWNlNtISGRmZWtvcAMD2iJJEt7NG2NtXRvv5o01+TXz4L6B9xqbNGqAk4NmUOLVtBHZD3MrpZkcs5is+9kA/GfZbG18Pp85QZtmycqN2t9PJZyn91tdsTDXxKZ/cBCrNmwnPLQPJ8+cI2JoCOZmmnZrU+dZ/Xfwa4NcJsPD3RVTU1Ny8vJxLB0U6quPn365pLcdlwkb0AtJkgCwr2/Lw5w8iouVPMp/TD2bOpWu083FkYNHT3PxynXS72YabHflDRkYjFwup46VJWs27mTh0vXEzoli2OB+jImej6uLAx8OD2Xdpl34t2tFYtItZk35kInTFuDfzpvuXfzp3sVfb9764nErNR1XJ3taNPMEoGtge5Z8vZHbdzK03wX6xCdcYPUXM5Akibp1rAjqEkD8jxfwadmUZk3c+e1qEkk3UunRNYC4bXspLlZy7uIV3uv/x5Zs6+ubVZWjKmX1aayP66qqz5SnL94paXfIfJBN1IzFAJSUqHBv4EzhEwUXLycSOzcKAGur2nrzFAThxRODQkEQBB363imsDjVqunfxZ1xExU1kTp45h0xmfF+v6i4fBSrkpVarGTMilMAAX6P5Z93PZnT0PAYPDGbk0BBMTCRUKnVVl4RcJofSZGrULF/4SaWbNGVJCfIqrk9v3nIZFuZmyGQm9AvuzoHDp0i6mUr/3kFGz7O2sqRfr+58+fUm8gseG4yB7uYUcpkcfVeccPYiy9dtJWJoCCG9gwi/Pg2VunJKuVyucyxDrahODGWo9eS3aNakKs81RpI0PwBqterZgcH0EnK5DPSUBZ7Vh6F2XKZ8+3s7qCNxW/eya/9RvJo04t/93qqQ9olCwfBxM+j9ZhfCBryDna0NBY8Lq7y2Bq7Plm326tmZSaUbPnXr5Ee3Tn4AxK6IIzy0N4nJKXg1aYRMZkJDN2fS72ZibVVbb77lVRUPCQkwHlM9J2mrwb9dKy78do3E5BQmRA7mp3OXuHT1OonJKdoHC2Wqs3xUV/m+aawcVanwfWKgj+uqbp+pUKRy8Var1bg42fPN8orfeWVtQyaTVa/wgiC8MGL3UUEQhOckUXoTXnqgKv29g18bDhyJJy09A4CMzAeUlKjwatqI68mppKRpZqkuXU2qlGfZ8lHdH90Boa6O/m2I27aPx6U3U3fvZWn/5mBXj4x79wG4mngTCwtzgnt2plZNC1LS7j7XNde0MKdNKy/WxH2PSqWipERFRqZmNq6Nd1P2HT6JSqXiiUJB0k3DOzPevnMPgJ/PX6awUIGHuxsAwT07cyz+Z9LS72nfFTRErVZz5MQZHOxtsbayNBqD6kg4e5F2rVsQGOBLTm4e+fmvbkdOYwID2rL34AkUiqcoS0r4fu8PdPRvC8Dr7VuzbddBioqKUavV2jhXRV99GGrH+uw7dJIpE4bz7ZoFxESNqjTDm3Y7g9y8fAb06YG9nS1J5XbtdLC3Jev+w0p538t6wIEjp1CpVBQVFXP42OlKg6gbKbcxMTGhgasTdrY2XL6WjFKpJDHpFrY2dat17eW19GpMekYmV36/AcCJ02exsDDH1dkBJEnbx0EzWFSrNMcdA9qwfc8h1Go1uXn5HDmeQIfSOvFv58OV32+QmZWNi5M9bX282H3gGE09G2pn+svMjxlXqe8bGxDqMlYOBztbbV81xlgf162rP9tnWjTzJDMrm2OnfgbgceETcnIfYVmrJu4NXPjfD/GApi8/0DPLLgjCiydmCgVBEJ5Te19v1m7cSf/gIFo282T95t1c+f0GbbybMWZEKB99ugS5TI61lSUzPoqkfr26RI99n+iZS6htWYv2vvqXR/4Rg98NpqCgkPfHxGBuboZHQxdiokYhSRL9g4MYOXEW3Tr5MXxwPw4cOUVYxBTcGzhXuYGGPjOiI1m0bAOhIz7CrIapdibjg0H9mLt4NaEjPsLJoT6O9vX1nl/bsiYHj55mwVfrAZg3fax2uaNlrZp4NHTBxckBExP9zys379jP/sMnUZYosbO1YcHMiUiSZDAG1fVOUCCLln/DB2Ni8G7eGDcXx+eMzF+j5xsduJeVzQdjYpAkifa+LRkUolmGOHhgMMvWfMvgyCmYm5vRtUN7wt/rYzQ/Q/VhrB3r8m7RmOiZsdja1MXMzJSGrk68P6gvzqXv83m4u/J6+9YMiphCAxdHnJ3stDPUTg52eDR0ZeCwyXwwqC9vBwUCmnc8k26msuO/h8nJfUSzxo2IGhte4XM3bNnDpNFDAc2Syp37jhISPokeXQOwt6vHyTPnOHbqJ2ZER2qXuhpjVbsW86ePZ8nKOBRPi6hjXZvPYsYjk5lgX98GN2dHtu85zIA+PQgMaMvG7/Yx55MxjB05iNgVcYRFTEEykQgP7aN9kOPp7krK7Tu0beWFJEn4+jQndkUcY0cOqrI8z8tYOQJe82HLjgMMiZxKTNQoPBu5GczHUB/Xras/22esrSxZ+Okkvly1iXUbd2JmZsroYaH4tm7O9KgI5i9Zy/bdh/Bwd9UMzAVBeOmkoqKnVa99EQRBEISX6GFOHpGT57By8bQK78O9LHsOHOfcxavMmjL6pX/W39UThYLBo6YSt3IeNS3MKXyiYNTEWfzr7TfoV7o5zquiVCoZNWk2q2JnVLl0WxAEQRAzhYIgCMIrtmHLHvYeOsGYEe/9JQPC2BVxHI8/y/RJI6tOLBhkbmZGB7/WfBg9l6JiJUplCR38WtOrZ+dXXTS+3rCdYWH9xIBQEAShmsRMoSAIgiAIfytqtbpay0YFQRAEDfEITRAEQRCEvxUxIBQEQXg+YlAoCIIgCIIgCILwDyYGhYIgCIIgCIIgCP9g/wfp//ODMWOnjAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 900x560 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Fourteen horizontal bars of information coefficient on validation sessions, sorted from the largest positive at the top to the largest negative at the bottom. Filled bars are retained by Benjamini-Hochberg at 5 percent and hollow ones are not, and the two do not follow the ordering: hollow bars sit above filled ones of the same size."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ordered = evaluation.sort(\"ic\")\n",
     "bar_fill = [\n",
@@ -2362,13 +3423,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98df8dc3",
+   "id": "ead0988f",
    "metadata": {
     "papermill": {
-     "duration": 0.003886,
-     "end_time": "2026-09-05T01:20:37.634283+00:00",
+     "duration": 0.004044,
+     "end_time": "2026-09-05T03:37:35.988329+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:37.630397+00:00",
+     "start_time": "2026-09-05T03:37:35.984285+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2390,13 +3451,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "076f438d",
+   "id": "98a04187",
    "metadata": {
     "papermill": {
-     "duration": 0.003882,
-     "end_time": "2026-09-05T01:20:37.642112+00:00",
+     "duration": 0.003898,
+     "end_time": "2026-09-05T03:37:35.996200+00:00",
      "exception": false,
-     "start_time": "2026-09-05T01:20:37.638230+00:00",
+     "start_time": "2026-09-05T03:37:35.992302+00:00",
      "status": "completed"
     }
    },
@@ -2478,6 +3539,25 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-05T03:37:42.515877+00:00",
+   "executor": "local-uv",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "747276d6b317e7bfa00d4b5247b7ce5a7bb74b91"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 69.193352,
+   "end_time": "2026-09-05T03:37:37.417282+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-gjr/case_studies/etfs/04_model_based_features.ipynb",
+   "output_path": "~/ml4t/public-gjr/case_studies/etfs/.04_model_based_features.papermill.3143817.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-05T03:36:28.223930+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/etfs/04_model_based_features.py
+++ b/case_studies/etfs/04_model_based_features.py
@@ -960,17 +960,22 @@ def garch_walk(payload: tuple[str, np.ndarray, int]) -> tuple[str, np.ndarray, l
             "omega": float(result.params.get("omega", np.nan)),
             "alpha": float(result.params.get("alpha[1]", np.nan)),
             "beta": float(result.params.get("beta[1]", np.nan)),
+            # The value that seeds the recursion, computed by `arch` from the ESTIMATION
+            # window's residuals and nothing else. It has to be produced here, where only
+            # training rows are in scope: the array `apply` receives runs to the end of the
+            # block being emitted, so a seed derived there would read the block's own rows.
+            "backcast": float(result.model.volatility.backcast(np.asarray(result.resid))),
         }
         fits.append({"symbol": symbol, "fit_end": int(len(X_train)), **coefficients})
         return coefficients
 
     def apply(coefficients: dict[str, float], X_prefix: np.ndarray) -> np.ndarray:
         # `garch11_conditional_volatility` rather than the fitted result object's own
-        # `conditional_volatility`: `arch` seeds its recursion from a backcast over whatever
-        # sample it is handed, and the sample here runs to the end of the block being emitted,
-        # so an emitted value would move when the block's later returns arrived. The shared
-        # helper seeds from the coefficients' own implied long-run variance instead, which is
-        # a function of the fit and of no observation in the array.
+        # `conditional_volatility`: `arch` derives its residuals, its seeding backcast and its
+        # variance bounds from whatever sample it is handed, and the sample here runs to the
+        # end of the block being emitted, so an emitted value would move when the block's
+        # later returns arrived. The helper takes every one of those from `fit`, where only
+        # training rows are in scope.
         #
         # The recursion runs on percent returns; restore decimal and annualize.
         sigma = garch11_conditional_volatility(X_prefix[:, 0], **coefficients)

--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -109,45 +109,92 @@ def garch11_conditional_volatility(
     omega: float,
     alpha: float,
     beta: float,
+    backcast: float,
+    gamma: float = 0.0,
+    bounds: tuple[float, float] | None = None,
 ) -> np.ndarray:
-    r"""GARCH(1,1) conditional standard deviation, computed so a value cannot move later.
+    r"""GARCH(1,1) or GJR-GARCH(1,1,1) conditional standard deviation, computed so a value
+    cannot move later.
 
-    :math:`\sigma^2_t = \omega + \alpha \epsilon_{t-1}^2 + \beta \sigma^2_{t-1}`, with
-    :math:`\epsilon_t = r_t - \mu`. Returns one value per input observation, in the units of
-    *returns*.
+    :math:`\sigma^2_t = \omega + (\alpha + \gamma \mathbb{1}[\epsilon_{t-1} < 0])
+    \epsilon_{t-1}^2 + \beta \sigma^2_{t-1}`, with :math:`\epsilon_t = r_t - \mu`. One value
+    per input observation, in the units of *returns*. ``gamma=0`` is the symmetric model; the
+    asymmetry term is what ``arch`` fits under ``o=1``, and three of the four case studies that
+    fit a volatility model here fit it.
 
     **Why this exists rather than ``arch_model(...).fix(params)``.** Under a walk-forward refit
     schedule the recursion is run over a prefix of the series that ends at the end of the block
     being emitted, and only the block's own rows are kept. That is causal only if a value at
     :math:`t` is a function of observations up to :math:`t` and of nothing else in the array it
-    was handed. ``arch``'s own result object does not satisfy that: it derives the residuals,
-    the backcast that seeds :math:`\sigma^2_0` and the variance bounds from the whole sample it
-    is given, so extending the sample moves earlier values. Measured on ``arch==8.0.0`` with SPY
-    returns and one fixed parameter vector: ``fix`` over 1,500 observations and over 2,000 differ
-    by up to 0.19% on the 1,500 they share, largest at the start and decaying to zero. Small, and
-    a dependence on the future all the same, in exactly the channel the schedule exists to close.
+    was handed. ``arch``'s own result object does not satisfy that: it derives the residuals, the
+    backcast that seeds :math:`\sigma^2_0` and the variance bounds from the whole sample it is
+    given, so extending the sample moves earlier values. Measured on ``arch==8.0.0`` with SPY
+    returns and one fixed parameter vector, ``fix`` over 1,500 observations and over 2,000 differ
+    by up to 0.19% on the 1,500 they share. ``sp500_equity_option_analytics`` measured the same
+    thing across 38 securities and found up to 0.9% of a security's own largest value.
 
-    The seed here is the long-run variance the *parameters* imply, :math:`\omega/(1-\alpha-\beta)`
-    - a function of coefficients estimated strictly before the block, and of no observation in
-    the array. A fit with :math:`\alpha+\beta \ge 1` has no long-run variance, so the
-    persistence is clamped just below one for the seed alone; its influence on any later value
-    decays as :math:`\beta^t` either way. On the SPY series above that decay is complete well
-    inside any burn-in a case study declares: against ``arch``'s own recursion the two agree to
-    within 1e-3 relative from observation 83, and to floating-point equality from 292.
+    **Every argument must come from before the block.** *backcast* seeds the recursion as
+    :math:`\omega + (\alpha + \gamma/2 + \beta) \cdot \mathrm{backcast}`, where the halved
+    :math:`\gamma` is the asymmetry's contribution under symmetric shocks; pass the mean squared
+    residual of the estimation window, or ``arch``'s own
+    ``result.model.volatility.backcast(training_residuals)``. *bounds*, when given, clips
+    :math:`\sigma^2` at every step as ``arch`` does internally; derive it from
+    ``result.model.volatility.variance_bounds`` over the training residuals. Neither is checked
+    here, because the array handed in reaches the end of the block and nothing computed from it
+    could tell a legitimate seed from one that read the block's own rows.
 
-    The recurrence is linear in :math:`\sigma^2` and evaluated with ``scipy.signal.lfilter``
-    rather than a Python loop: this runs once per block per entity, tens of thousands of times
-    per notebook, over series of thousands of observations.
+    **Why there is no parameter-implied seed.** :math:`\omega/(1-\alpha-\gamma/2-\beta)` is
+    the long-run variance the coefficients imply, is a function of no observation at all, and was
+    the seed here until it was measured. Fitting GJR-GARCH on 25 sampled
+    ``sp500_equity_option_analytics`` securities broke it twice, in ways a single guard does not
+    cover. Two fits came out integrated at persistence 1.0000, where the ratio is infinite, any
+    clamp makes it :math:`\omega \times 10^6`, and :math:`\beta=1` means the seed's influence
+    never decays - 56x errors at emitted rows. A third was numerically stationary at persistence
+    0.9953 but had :math:`\omega = 1.6 \times 10^{-8}`, so the implied seed was
+    :math:`3.4 \times 10^{-6}` against a data-supported 2.283, and the recursion reached negative
+    variance 495 observations in. The second case is invisible to any threshold on persistence.
+    A seed bounded by the estimation window cannot do either, whatever the optimizer returns.
+
+    Without *bounds* the recurrence is linear in :math:`\sigma^2` and is evaluated with
+    ``scipy.signal.lfilter`` rather than a Python loop: this runs once per block per entity, tens
+    of thousands of times per notebook, over series of thousands of observations. Clipping makes
+    it nonlinear, so *bounds* costs a Python loop.
+
+    :raises ValueError: if the recursion leaves the positive reals. ``arch`` will return
+        :math:`\alpha + \gamma < 0`, a negative shock coefficient on down days, without
+        complaint; the variance then falls through zero and ``sqrt`` yields ``nan``. A ``nan`` is
+        not a feature value and must not reach an artifact. Passing *bounds* prevents it.
     """
     resid = np.asarray(returns, dtype=float) - mu
     if resid.size == 0:
         return np.empty(0, dtype=float)
-    persistence = min(alpha + beta, 1.0 - 1e-6)
+
+    persistence = alpha + 0.5 * gamma + beta
     driver = np.empty(resid.size, dtype=float)
-    driver[0] = omega / (1.0 - persistence)
-    driver[1:] = omega + alpha * resid[:-1] ** 2
-    # y[0] = driver[0]; y[t] = driver[t] + beta * y[t-1] - the recursion above, in C.
-    return np.sqrt(lfilter([1.0], [1.0, -beta], driver))
+    driver[0] = omega + persistence * float(backcast)
+    driver[1:] = omega + (alpha + gamma * (resid[:-1] < 0.0)) * resid[:-1] ** 2
+
+    if bounds is None:
+        # y[0] = driver[0]; y[t] = driver[t] + beta * y[t-1] - the recursion above, in C. The
+        # sign indicator is already in the driver, so the recursion in sigma^2 is still linear
+        # with constant coefficients.
+        variance = lfilter([1.0], [1.0, -beta], driver)
+        if not np.all(np.isfinite(variance)) or np.any(variance <= 0.0):
+            first = int(np.argmax(~(np.isfinite(variance) & (variance > 0.0))))
+            raise ValueError(
+                f"the variance recursion left the positive reals at observation {first} of "
+                f"{variance.size}: alpha + gamma is {alpha + gamma:.6g}, so a negative return "
+                "reduces the variance rather than raising it. Pass bounds= to clip, or reject "
+                "the fit."
+            )
+    else:
+        low, high = float(bounds[0]), float(bounds[1])
+        variance = np.empty(resid.size, dtype=float)
+        variance[0] = min(max(driver[0], low), high)
+        for t in range(1, resid.size):
+            variance[t] = min(max(driver[t] + beta * variance[t - 1], low), high)
+
+    return np.sqrt(variance)
 
 
 def sort_states_by_variance(model: GaussianHMM) -> np.ndarray:

--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -126,12 +126,42 @@ def garch11_conditional_volatility(
     schedule the recursion is run over a prefix of the series that ends at the end of the block
     being emitted, and only the block's own rows are kept. That is causal only if a value at
     :math:`t` is a function of observations up to :math:`t` and of nothing else in the array it
-    was handed. ``arch``'s own result object does not satisfy that: it derives the residuals, the
-    backcast that seeds :math:`\sigma^2_0` and the variance bounds from the whole sample it is
-    given, so extending the sample moves earlier values. Measured on ``arch==8.0.0`` with SPY
-    returns and one fixed parameter vector, ``fix`` over 1,500 observations and over 2,000 differ
-    by up to 0.19% on the 1,500 they share. ``sp500_equity_option_analytics`` measured the same
-    thing across 38 securities and found up to 0.9% of a security's own largest value.
+    was handed. ``arch``'s result object is not, and the reason is one line of ``ARCHModel.fix``:
+
+    .. code-block:: python
+
+        resids = self.resids(self.starting_values())   # NOT the parameters you fixed
+        backcast = v.backcast(resids)
+        var_bounds = v.variance_bounds(resids)
+
+    The seed and the bounds are derived from residuals taken at the **estimated** mean of
+    whatever array was handed in, so under ``mean="Constant"`` extending the sample moves that
+    mean, moves the backcast, and moves every value the seed still reaches. Read against
+    ``arch==8.0.0``; measured here on 2,000 observations with a variance break, one fixed
+    parameter vector, prefix of 1,500 against the full sample:
+
+    ================================  ==========================================================
+    ``mean="Constant"``               sample mean 0.03496 -> 0.03007, backcast 0.57714 ->
+                                      0.57637. **128 of the 1,500 shared rows move**, by up to
+                                      0.064%, largest at the start and decaying to zero.
+    ``mean="Zero"``                   nothing is estimated, so the residuals are the returns and
+                                      the seed does not move: **bit-identical**.
+    ================================  ==========================================================
+
+    ``mean="Zero"`` is not therefore safe. ``variance_bounds`` clamps every row with two
+    whole-sample quantities - ``np.var(resids) / 1e8`` below and ``1e7 * (1 + max(resids**2))``
+    above - and those move whatever the mean specification is. They are six orders of magnitude
+    apart, so they change an emitted value only when the variance actually reaches one, which is
+    what a degenerate fit does. With :math:`\omega=10^{-8}, \alpha=0.02, \gamma=-0.30,
+    \beta=0.90` - a shape ``arch`` returns without complaint, where a down day *reduces* the
+    variance - the recursion sits on the lower clamp and **1,498 of the 1,500 shared rows move,
+    by up to 64%**, because a shock 500 observations later raised ``np.var(resids)`` and with it
+    the clamp under every earlier row.
+
+    So the dependence on the future is unconditional under an estimated mean, and under a zero
+    mean it opens exactly on the fits that were also being silently clipped. This function takes
+    the seed and the bounds from the caller instead, and raises on the degenerate case rather
+    than emitting a clipped number for it.
 
     **Every argument must come from before the block.** *backcast* seeds the recursion as
     :math:`\omega + (\alpha + \gamma/2 + \beta) \cdot \mathrm{backcast}`, where the halved

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -450,13 +450,20 @@ def test_the_gjr_recursion_does_not_move_when_later_returns_arrive() -> None:
 
 
 def test_arch_moves_earlier_values_when_the_sample_is_extended() -> None:
-    """The negative control: the property above is not vacuous.
+    """The negative control: the prefix-stability assertions above are not vacuous.
 
     A prefix-stability assertion passes trivially against any implementation that happens to
     process observations in order, so on its own it is evidence about nothing. This runs the
     identical assertion against `arch`'s own fixed-parameter result object - the thing the
-    helper replaces - and requires it to FAIL. If `arch` ever becomes prefix-stable this test
-    goes red, and the helper's reason for existing has to be re-established rather than assumed.
+    helper replaces - and requires it to FAIL.
+
+    The mechanism is one line of `ARCHModel.fix`: it takes `resids = self.resids(
+    self.starting_values())`, the residuals at the ESTIMATED mean of whatever array it was
+    handed, and seeds the backcast from those. Under `mean="Constant"` the estimated mean moves
+    when the sample is extended, so the seed moves with it.
+
+    If `arch` ever stops doing this the test goes red, and the helper's reason for existing has
+    to be re-established rather than assumed.
     """
     arch_model = pytest.importorskip("arch").arch_model
     returns = _garch_returns(n=2000)
@@ -477,16 +484,85 @@ def test_arch_moves_earlier_values_when_the_sample_is_extended() -> None:
     full = arch_path(returns)[:1500]
 
     assert not np.array_equal(short, full), (
-        "arch's fixed-parameter path is prefix-stable, which contradicts the measurement this "
-        "helper was written for. Re-derive the reason before deleting the helper."
+        "arch's fixed-parameter path is prefix-stable under an estimated mean, which "
+        "contradicts the measurement this helper was written for. Re-derive the reason before "
+        "deleting the helper."
     )
-    # The disagreement is real but small and decays: it is a seeding and bounds effect, not a
-    # different model. Pinning the shape keeps the negative control from passing for the wrong
-    # reason - a crash or an all-nan path would also satisfy `not array_equal`.
+    # Pin the shape, so a crash or an all-nan path cannot satisfy the assertion above. The
+    # disagreement is a seeding effect: largest at the start, decaying to nothing.
     relative = np.abs(short - full) / np.maximum(np.abs(full), 1e-12)
     assert np.isfinite(relative).all()
     assert relative.max() > 1e-6
     assert relative[0] > relative[-1]
+
+
+def test_the_arch_seed_is_taken_at_the_estimated_mean_not_the_fixed_one() -> None:
+    """Name the mechanism, so the control above cannot pass for an unrelated reason.
+
+    Without this, `fix` could start disagreeing with itself for some other cause and the
+    negative control would keep passing while the stated reason had become false.
+    """
+    volatility = pytest.importorskip("arch.univariate.volatility")
+    returns = _garch_returns(n=2000)
+    garch = volatility.GARCH(p=1, q=1)
+
+    at_sample_mean = (
+        garch.backcast(returns[:1500] - returns[:1500].mean()),
+        garch.backcast(returns - returns.mean()),
+    )
+    at_fixed_mu = (
+        garch.backcast(returns[:1500] - GARCH_PARAMS["mu"]),
+        garch.backcast(returns - GARCH_PARAMS["mu"]),
+    )
+
+    # Residuals at the parameter you fixed give the same seed either way: `backcast` is an
+    # EWMA over the first min(75, n) residuals, which a longer sample does not change.
+    assert at_fixed_mu[0] == at_fixed_mu[1]
+    # Residuals at the estimated mean do not, and that is the pair `fix` actually uses.
+    assert at_sample_mean[0] != at_sample_mean[1]
+
+
+def test_arch_is_prefix_stable_under_a_zero_mean_until_the_bounds_bind() -> None:
+    """The channel is narrower under `mean="Zero"`, and does not close.
+
+    crypto_perps_funding fits a zero-mean model, where nothing is estimated and the seed
+    therefore does not move. What still moves is `variance_bounds`, which clamps every row
+    with two WHOLE-SAMPLE quantities - `np.var(resids) / 1e8` below and
+    `1e7 * (1 + max(resids**2))` above. They sit six orders of magnitude apart, so they change
+    an emitted value only when the variance reaches one - which is what a degenerate fit does.
+    """
+    arch_model = pytest.importorskip("arch").arch_model
+    rng = np.random.default_rng(5)
+    # A quiet series, then a crash 500 observations past the cut. The crash is what moves
+    # np.var(resids), and with it the lower clamp under every row that came before it.
+    quiet = rng.normal(0.0, 0.5, 1500)
+    tail = rng.normal(0.0, 0.5, 500)
+    tail[250] = 400.0
+    returns = np.concatenate([quiet, tail])
+
+    def zero_mean_path(sample: np.ndarray, params: pd.Series) -> np.ndarray:
+        spec = arch_model(sample, mean="Zero", vol="GARCH", p=1, o=1, q=1, dist="Normal")
+        return np.asarray(spec.fix(params).conditional_volatility, dtype=float)
+
+    healthy = pd.Series({"omega": 0.02, "alpha[1]": 0.05, "gamma[1]": 0.08, "beta[1]": 0.88})
+    np.testing.assert_array_equal(
+        zero_mean_path(returns[:1500], healthy), zero_mean_path(returns, healthy)[:1500]
+    )
+
+    # alpha + gamma < 0: a down day REDUCES the variance, so the recursion is driven onto the
+    # lower clamp. arch returns this shape without complaint.
+    degenerate = pd.Series({"omega": 1e-8, "alpha[1]": 0.02, "gamma[1]": -0.30, "beta[1]": 0.90})
+    short = zero_mean_path(returns[:1500], degenerate)
+    full = zero_mean_path(returns, degenerate)[:1500]
+    relative = np.abs(short - full) / np.maximum(np.abs(full), 1e-30)
+    assert (relative > 1e-9).sum() > 1000
+    assert relative.max() > 0.1
+
+    # The helper does not clip that fit silently - it refuses it.
+    with pytest.raises(ValueError, match=r"alpha \+ gamma"):
+        garch11_conditional_volatility(
+            returns, mu=0.0, omega=1e-8, alpha=0.02, beta=0.90, gamma=-0.30, backcast=0.25
+        )
 
 
 def test_the_garch_recursion_reproduces_its_own_definition() -> None:

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import polars as pl
 import pytest
 from hmmlearn.hmm import GaussianHMM
@@ -421,7 +422,8 @@ def test_an_all_null_feature_is_still_refused_without_a_fold_column(tmp_path: Pa
 # there is a recursion here at all.
 # ---------------------------------------------------------------------------
 
-GARCH_PARAMS = dict(mu=0.05, omega=0.02, alpha=0.08, beta=0.90)
+GARCH_PARAMS = dict(mu=0.05, omega=0.02, alpha=0.08, beta=0.90, backcast=1.5)
+GJR_PARAMS = dict(mu=0.05, omega=0.02, alpha=0.04, beta=0.90, gamma=0.07, backcast=1.5)
 
 
 def _garch_returns(n: int = 800, seed: int = 3) -> np.ndarray:
@@ -438,6 +440,55 @@ def test_the_garch_recursion_does_not_move_when_later_returns_arrive() -> None:
     np.testing.assert_array_equal(short, full[:500])
 
 
+def test_the_gjr_recursion_does_not_move_when_later_returns_arrive() -> None:
+    # Same property with the asymmetry term on, because gamma enters through the sign of the
+    # PREVIOUS residual and a prefix ends one observation earlier.
+    returns = _garch_returns()
+    short = garch11_conditional_volatility(returns[:500], **GJR_PARAMS)
+    full = garch11_conditional_volatility(returns, **GJR_PARAMS)
+    np.testing.assert_array_equal(short, full[:500])
+
+
+def test_arch_moves_earlier_values_when_the_sample_is_extended() -> None:
+    """The negative control: the property above is not vacuous.
+
+    A prefix-stability assertion passes trivially against any implementation that happens to
+    process observations in order, so on its own it is evidence about nothing. This runs the
+    identical assertion against `arch`'s own fixed-parameter result object - the thing the
+    helper replaces - and requires it to FAIL. If `arch` ever becomes prefix-stable this test
+    goes red, and the helper's reason for existing has to be re-established rather than assumed.
+    """
+    arch_model = pytest.importorskip("arch").arch_model
+    returns = _garch_returns(n=2000)
+    params = pd.Series(
+        {
+            "mu": GARCH_PARAMS["mu"],
+            "omega": GARCH_PARAMS["omega"],
+            "alpha[1]": GARCH_PARAMS["alpha"],
+            "beta[1]": GARCH_PARAMS["beta"],
+        }
+    )
+
+    def arch_path(sample: np.ndarray) -> np.ndarray:
+        spec = arch_model(sample, mean="Constant", vol="GARCH", p=1, q=1, dist="Normal")
+        return np.asarray(spec.fix(params).conditional_volatility, dtype=float)
+
+    short = arch_path(returns[:1500])
+    full = arch_path(returns)[:1500]
+
+    assert not np.array_equal(short, full), (
+        "arch's fixed-parameter path is prefix-stable, which contradicts the measurement this "
+        "helper was written for. Re-derive the reason before deleting the helper."
+    )
+    # The disagreement is real but small and decays: it is a seeding and bounds effect, not a
+    # different model. Pinning the shape keeps the negative control from passing for the wrong
+    # reason - a crash or an all-nan path would also satisfy `not array_equal`.
+    relative = np.abs(short - full) / np.maximum(np.abs(full), 1e-12)
+    assert np.isfinite(relative).all()
+    assert relative.max() > 1e-6
+    assert relative[0] > relative[-1]
+
+
 def test_the_garch_recursion_reproduces_its_own_definition() -> None:
     returns = _garch_returns(n=60)
     got = garch11_conditional_volatility(returns, **GARCH_PARAMS)
@@ -445,18 +496,93 @@ def test_the_garch_recursion_reproduces_its_own_definition() -> None:
     alpha, beta = GARCH_PARAMS["alpha"], GARCH_PARAMS["beta"]
     resid = returns - mu
     want = np.empty(len(returns))
-    want[0] = omega / (1.0 - alpha - beta)
+    want[0] = omega + (alpha + beta) * GARCH_PARAMS["backcast"]
     for t in range(1, len(returns)):
         want[t] = omega + alpha * resid[t - 1] ** 2 + beta * want[t - 1]
     np.testing.assert_allclose(got, np.sqrt(want), rtol=1e-12)
 
 
-def test_the_garch_seed_survives_a_non_stationary_fit() -> None:
-    # alpha + beta >= 1 has no long-run variance, so the seed is clamped rather than infinite.
+def test_the_gjr_recursion_reproduces_its_own_definition() -> None:
+    returns = _garch_returns(n=60)
+    got = garch11_conditional_volatility(returns, **GJR_PARAMS)
+    mu, omega = GJR_PARAMS["mu"], GJR_PARAMS["omega"]
+    alpha, beta, gamma = GJR_PARAMS["alpha"], GJR_PARAMS["beta"], GJR_PARAMS["gamma"]
+    resid = returns - mu
+    want = np.empty(len(returns))
+    want[0] = omega + (alpha + 0.5 * gamma + beta) * GJR_PARAMS["backcast"]
+    for t in range(1, len(returns)):
+        shock = alpha + gamma * (resid[t - 1] < 0.0)
+        want[t] = omega + shock * resid[t - 1] ** 2 + beta * want[t - 1]
+    np.testing.assert_allclose(got, np.sqrt(want), rtol=1e-12)
+
+
+def test_a_zero_gamma_is_the_symmetric_model() -> None:
+    returns = _garch_returns(n=200)
+    np.testing.assert_array_equal(
+        garch11_conditional_volatility(returns, **GARCH_PARAMS),
+        garch11_conditional_volatility(returns, gamma=0.0, **GARCH_PARAMS),
+    )
+
+
+def test_the_asymmetry_raises_variance_only_after_a_negative_return() -> None:
+    # gamma has to attach to the sign of the residual it multiplies, not to the current row.
+    # A sign error here is invisible to every aggregate and to the definition test above if
+    # that test repeats the same mistake, so it is stated directly against constructed input.
+    returns = np.array([0.05, 0.05 - 1.0, 0.05 + 1.0, 0.05, 0.05])
+    sym = garch11_conditional_volatility(returns, **GARCH_PARAMS)
+    asym = garch11_conditional_volatility(returns, **{**GARCH_PARAMS, "gamma": 0.07})
+    # Row 2 follows the -1.0 residual and must be lifted; row 3 follows the +1.0 and must not.
+    assert asym[2] > sym[2]
+    assert asym[3] == pytest.approx(
+        sym[3] + GARCH_PARAMS["beta"] * (asym[2] ** 2 - sym[2] ** 2) / (asym[3] + sym[3]), rel=1e-6
+    )
+
+
+def test_a_degenerate_fit_raises_rather_than_emitting_nan() -> None:
+    """arch returns alpha + gamma < 0 without complaint, and sqrt of it is nan.
+
+    A nan is not a feature value. Measured on sp500_equity_option_analytics: 19% of first
+    blocks come back with a negative net shock coefficient, and the old path emitted them.
+    """
+    with pytest.raises(ValueError, match=r"alpha \+ gamma"):
+        garch11_conditional_volatility(
+            _garch_returns(n=400),
+            mu=0.0,
+            omega=1e-8,
+            alpha=0.02,
+            beta=0.90,
+            gamma=-0.30,
+            backcast=1.0,
+        )
+
+
+def test_bounds_clip_the_recursion_instead_of_raising() -> None:
     out = garch11_conditional_volatility(
-        _garch_returns(n=50), mu=0.0, omega=0.02, alpha=0.3, beta=0.75
+        _garch_returns(n=400),
+        mu=0.0,
+        omega=1e-8,
+        alpha=0.02,
+        beta=0.90,
+        gamma=-0.30,
+        backcast=1.0,
+        bounds=(1e-6, 1e4),
     )
     assert np.isfinite(out).all()
+    assert (out >= np.sqrt(1e-6) - 1e-12).all()
+
+
+def test_an_integrated_fit_no_longer_seeds_from_the_parameters() -> None:
+    """Persistence 1.0 has no long-run variance; the seed comes from the data instead.
+
+    Two of 25 sampled sp500_equity_option_analytics securities fitted to persistence 1.0000,
+    where omega/(1 - persistence) is infinite, any clamp makes it omega x 1e6, and beta = 1
+    means that seed never decays. The backcast bounds the seed whatever the optimizer returns.
+    """
+    out = garch11_conditional_volatility(
+        _garch_returns(n=300), mu=0.0, omega=0.02, alpha=0.10, beta=0.90, backcast=1.5
+    )
+    assert np.isfinite(out).all()
+    assert out[0] == pytest.approx(np.sqrt(0.02 + 1.0 * 1.5))
 
 
 def test_an_empty_return_series_gives_an_empty_recursion() -> None:

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -496,30 +496,52 @@ def test_arch_moves_earlier_values_when_the_sample_is_extended() -> None:
     assert relative[0] > relative[-1]
 
 
-def test_the_arch_seed_is_taken_at_the_estimated_mean_not_the_fixed_one() -> None:
+def test_the_arch_seed_is_taken_at_the_estimated_mean_not_the_fixed_one(monkeypatch) -> None:
     """Name the mechanism, so the control above cannot pass for an unrelated reason.
 
     Without this, `fix` could start disagreeing with itself for some other cause and the
-    negative control would keep passing while the stated reason had become false.
+    negative control would keep passing while the stated reason had become false. The
+    assertion has to be about what `fix` ITSELF hands to `backcast`, not about what an
+    independent recomputation would hand it, so this captures the array in flight.
     """
+    arch_model = pytest.importorskip("arch").arch_model
     volatility = pytest.importorskip("arch.univariate.volatility")
+
+    seen: list[np.ndarray] = []
+    original = volatility.GARCH.backcast
+
+    def spy(self, resids):
+        seen.append(np.asarray(resids, dtype=float).copy())
+        return original(self, resids)
+
+    monkeypatch.setattr(volatility.GARCH, "backcast", spy)
+
     returns = _garch_returns(n=2000)
+    params = pd.Series(
+        {
+            "mu": GARCH_PARAMS["mu"],
+            "omega": GARCH_PARAMS["omega"],
+            "alpha[1]": GARCH_PARAMS["alpha"],
+            "beta[1]": GARCH_PARAMS["beta"],
+        }
+    )
+    for sample in (returns[:1500], returns):
+        arch_model(sample, mean="Constant", vol="GARCH", p=1, q=1, dist="Normal").fix(params)
+
+    assert len(seen) == 2, "fix should seed the recursion exactly once per call"
+    short_resids, full_resids = seen
+
+    # What fix passed is the sample centred at its OWN estimated mean, not at the mu given.
+    np.testing.assert_allclose(short_resids, returns[:1500] - returns[:1500].mean(), rtol=1e-12)
+    np.testing.assert_allclose(full_resids, returns - returns.mean(), rtol=1e-12)
+    assert not np.allclose(short_resids, returns[:1500] - GARCH_PARAMS["mu"])
+
+    # And that is what makes the seed move: the same residuals taken at the fixed mu would not.
     garch = volatility.GARCH(p=1, q=1)
-
-    at_sample_mean = (
-        garch.backcast(returns[:1500] - returns[:1500].mean()),
-        garch.backcast(returns - returns.mean()),
+    assert original(garch, short_resids) != original(garch, full_resids[:1500])
+    assert original(garch, returns[:1500] - GARCH_PARAMS["mu"]) == original(
+        garch, returns - GARCH_PARAMS["mu"]
     )
-    at_fixed_mu = (
-        garch.backcast(returns[:1500] - GARCH_PARAMS["mu"]),
-        garch.backcast(returns - GARCH_PARAMS["mu"]),
-    )
-
-    # Residuals at the parameter you fixed give the same seed either way: `backcast` is an
-    # EWMA over the first min(75, n) residuals, which a longer sample does not change.
-    assert at_fixed_mu[0] == at_fixed_mu[1]
-    # Residuals at the estimated mean do not, and that is the pair `fix` actually uses.
-    assert at_sample_mean[0] != at_sample_mean[1]
 
 
 def test_arch_is_prefix_stable_under_a_zero_mean_until_the_bounds_bind() -> None:


### PR DESCRIPTION
`garch11_conditional_volatility` landed in #764 as symmetric GARCH(1,1). Three of the four case studies that fit a volatility model fit GJR instead - `sp500_equity_option_analytics`, `sp500_options` and `crypto_perps_funding` all pass `o=1` to `arch_model` - so the shared helper could serve exactly one of them and the other three each kept a private filter that is the same recursion written a fourth time. This adds the asymmetry term so those three consolidate onto it.

The sign indicator multiplies the **previous** residual, so it lives in the driver and the recursion in $\sigma^2$ stays linear with constant coefficients. `lfilter` still applies, and `gamma=0` is bit-identical to the symmetric path.

## `backcast` is required, and the parameter-implied seed is gone

Not guarded - removed. Fitting GJR on 25 sampled seoa securities broke $\omega/(1-\alpha-\gamma/2-\beta)$ twice, in two ways that one guard does not cover:

| fit | persistence | what happened |
|---|---|---|
| two of 25 | 1.0000 | ratio infinite; any clamp gives $\omega \times 10^6$; $\beta=1$ so the seed never decays. 56x errors at emitted rows. |
| one of 25 | 0.9953 | numerically stationary, but $\omega = 1.6\times10^{-8}$, so the implied seed was $3.4\times10^{-6}$ against a data-supported 2.283. Variance went negative at observation 495. |

The second is invisible to any threshold on persistence. A seed bounded by the estimation window cannot do either, whatever the optimizer returns.

**The seed comes from the caller's `fit`, never from inside `apply`.** The array `apply` receives runs to the end of the block being emitted, so anything derived from it would read the block's own rows - the one thing the refit schedule exists to prevent. Same for `bounds`.

## A degenerate fit raises instead of emitting nan

`arch` returns $\alpha + \gamma < 0$ without complaint; the variance falls through zero and `sqrt` yields `nan`. A `nan` is not a feature value and must not reach an artifact. 19% of seoa's first blocks come back that way. Pass `bounds` to clip instead of raising.

## Tests

The prefix-stability assertion already here passes trivially against anything that processes observations in order, so on its own it was evidence about nothing. It is now paired with a **negative control** that runs the identical assertion against `arch_model(...).fix(params).conditional_volatility` and requires it to FAIL, and pins the shape of the disagreement so a crash or an all-`nan` path cannot satisfy it. If `arch` ever becomes prefix-stable, that test goes red and the helper's reason for existing has to be re-established rather than assumed.

Added: GJR prefix stability, GJR against its own definition, `gamma=0` reducing to the symmetric model, the asymmetry attaching to the right residual's sign, the degenerate-fit raise, bounds clipping, and the integrated seed. A `<`/`>` inversion in the indicator fails two of them. 62 pass.

## etfs re-run

The one call site on `main`. `04_model_based_features` ran in 68s, exit 0, peak 1.6 GB.

| | |
|---|---|
| bit-identical emitted values | 414,063 of 420,162 |
| p99 relative move | 1.4e-14 |
| rows moving more than 1e-6 | 676 (0.16%), across 8 of 100 ETFs |
| where they sit | early in a series - median row 66, max row 209, which is the seed's $\beta^t$ decay |
| rows moving more than 10% | 63 |

Largest is XLV at 2008-07-08: 0.2079 → 0.1613 annualized, against a realized volatility near 0.10-0.12 over the surrounding months. The old seed was the further of the two from the data.