### PR TITLE
Sequence families: move SEQUENCE_PREPARATION_VERSION to 2 for the corrected fill

### DIFF
--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -83,7 +83,14 @@ _SEQUENCE_PREVIEW_FIELDS = {
 }
 
 SEQUENCE_RUNNER_VERSION = 1
-SEQUENCE_PREPARATION_VERSION = 1
+# 2: #767 (174154ad) changed what a sequence family is fitted on. `np.nan_to_num(..., nan=0.0)`
+# used to run in `_build_symbol_arrays` BEFORE `_compute_feature_stats`, so a missing feature
+# became a raw zero, entered the mean and the standard deviation, and was then standardized like
+# a real observation - on seoa's `garch_cond_vol` landing at -1.64 sd, below anything observed,
+# and skewing every other symbol's normalization on the way. It is now imputed at the training
+# mean. That is a different design matrix, not a rename, so a version-1 run and a run under the
+# corrected fill must not share a training identity.
+SEQUENCE_PREPARATION_VERSION = 2
 SEQUENCE_STATE_VERSION = 1
 SEQUENCE_BACKEND_VERSIONS = {"darts": 1, "pytorch": 1}
 SEQUENCE_ARCHITECTURE_VERSIONS = {
@@ -1965,6 +1972,12 @@ def sequence_identity_params(
 
     params = dict(identity_params or {})
     params["device"] = torch.device(str(device).lower().replace("gpu", "cuda")).type
+    # The preparation version belongs on every sequence identity, not only on the ones assembled
+    # through the runner's own spec. `us_equities_panel/12_dl_weekly.py` registers through this
+    # function directly, so without it that notebook keeps a version-1 identity for a fit whose
+    # design matrix changed under #767 - and it is the notebook Table 13.5 cites, so the stale
+    # identity would be read as a result.
+    params["sequence_preparation"] = SEQUENCE_PREPARATION_VERSION
     if input_data_spec is not None:
         if uses_darts_backend([config]):
             if case_study is None:

--- a/tests/test_model_source_identity_versions.py
+++ b/tests/test_model_source_identity_versions.py
@@ -15,7 +15,10 @@ from case_studies.utils.latent_factors import adapter as latent_adapter
 from case_studies.utils.registry import training_hash_from_spec
 
 PINNED_SEQUENCE_RUNNER = 1
-PINNED_SEQUENCE_PREPARATION = 1
+# 2 since #767 (174154ad) corrected where the sequence path fills a missing feature. The pin
+# moves with the version deliberately: it exists to make a bump a decision someone writes down,
+# not to prevent one.
+PINNED_SEQUENCE_PREPARATION = 2
 PINNED_SEQUENCE_STATE = 1
 PINNED_TABM_RUNNER = 1
 PINNED_TABM_STATE = 1
@@ -53,7 +56,7 @@ def test_sequence_identity_is_declared_and_architecture_scoped() -> None:
 
     assert nlinear == {
         "sequence_runner": 1,
-        "sequence_preparation": 1,
+        "sequence_preparation": 2,
         "sequence_state": 1,
         "backend": "pytorch/v1",
         "architecture": "nlinear/v1",


### PR DESCRIPTION
#767 (`174154ad`) changed what a sequence family is fitted on and did not move the version that says so.

`np.nan_to_num(..., nan=0.0)` ran in `_build_symbol_arrays` **before** `_compute_feature_stats`, so a missing feature became a raw zero, entered the mean and the standard deviation, and was then standardized like a real observation. On `sp500_equity_option_analytics`'s `garch_cond_vol` that lands at **-1.64 sd**, below anything ever observed — presenting a skipped symbol as the calmest stock in the panel — and because the zeros were present when the statistics were computed they skewed every other symbol's normalization too. It is now imputed at the training mean.

That is a different design matrix, not a rename. A registered version-1 run and a run under the corrected fill would otherwise share a `training_hash` while having been fitted on different data, and the already-complete check would skip the refit.

## Three edits

- `SEQUENCE_PREPARATION_VERSION` 1 → 2, with the reason recorded at the constant.
- `sequence_identity_params` now carries the field, not only `_sequence_source_identity`. `us_equities_panel/12_dl_weekly.py` registers through that function directly rather than through the runner's own spec, so without it that notebook keeps a version-1 identity for a fit whose data changed — and it is the notebook Table 13.5 cites, so a stale identity there is read as a result.
- `PINNED_SEQUENCE_PREPARATION` 1 → 2, plus the hardcoded expectation in the same test.

## Cost

Low now, and it would not stay low. The stage-06-and-later registries were reset and the deep-learning stages have not been re-run, so nothing registered is invalidated by this bump.

## Provenance

Salvaged from #759, which is closed unmerged. The ruling on that PR's contract was to impute rather than trim, so its drop, its `FOLD_PREPARATION_VERSION` and `TABM_RUNNER_VERSION` bumps, and its fold-cache key pin do not travel. This hunk is the only part that was about the fill rather than the drop.

Tests: `test_model_source_identity_versions`, `test_sequence_identity_roundtrip`, `test_dl_force_retrain_identity`, `test_latent_input_identity` — 28 passed.