### PR TITLE
Record when a training run started, report progress as it runs, and move L1 logistic off liblinear

### DIFF
--- a/case_studies/config/logistic/logistic_l1_C0.001.yaml
+++ b/case_studies/config/logistic/logistic_l1_C0.001.yaml
@@ -1,6 +1,37 @@
+# L1 logistic regression. The solver is `saga` rather than `liblinear`, and the tolerance
+# is set explicitly rather than left at scikit-learn's 1e-4 default.
+#
+# Two reasons, and the first one is not optional. These labels are three-class (-1, 0, 1),
+# and scikit-learn 1.8 makes multiclass `liblinear` a hard error; #740 already moved our
+# floor to 1.7. `OneVsRestClassifier(liblinear)` would reproduce the current objective
+# exactly - liblinear multiclass IS one-vs-rest - and would keep the problem below.
+#
+# The second is that `liblinear` does not finish. It is single-threaded coordinate descent
+# and scales about N^1.4 here. Measured on nasdaq100_microstructure's `fwd_dir_15m` panel:
+#
+#     rows      liblinear 1000/1e-4     saga 200/1e-2
+#     400,000     144.4s  converged      11.0s  converged
+#   1,200,000     716.9s  converged      44.8s  converged
+#
+# which extrapolates to roughly eight hours per configuration at the full 16.9M rows against
+# about twenty minutes. That is not a projection: `06_linear` ran 7h23m at 100% of one core
+# on 2026-09-05 and was killed with two of thirteen configurations still unfinished, both of
+# them these L1 ones.
+#
+# `tol: 0.01` is what makes saga converge. At 1e-3 it hits the iteration cap without
+# converging at either size; at 1e-2 it converges in 22 to 29 iterations, which is the same
+# count liblinear needs at 1e-4. On a 20% out-of-sample split at 1.2M rows the looser
+# tolerance costs nothing measurable and is slightly better: log loss 1.0275 against 1.0294,
+# accuracy 0.4183 against 0.4106.
+#
+# One property to know rather than to be surprised by: the two solvers reach different
+# points in coefficient space (correlation 0.77) while predicting almost identically. At
+# C >= 10 the penalty leaves 195 of 198 coefficients non-zero, so it is barely binding and
+# the solution is weakly identified - that is a property of the configuration, not of saga.
 model_class: LogisticRegression
 params:
   C: 0.001
-  max_iter: 1000
+  max_iter: 200
   penalty: l1
-  solver: liblinear
+  solver: saga
+  tol: 0.01

--- a/case_studies/config/logistic/logistic_l1_C0.001.yaml
+++ b/case_studies/config/logistic/logistic_l1_C0.001.yaml
@@ -18,20 +18,33 @@
 # on 2026-09-05 and was killed with two of thirteen configurations still unfinished, both of
 # them these L1 ones.
 #
-# `tol: 0.01` is what makes saga converge. At 1e-3 it hits the iteration cap without
-# converging at either size; at 1e-2 it converges in 22 to 29 iterations, which is the same
-# count liblinear needs at 1e-4. On a 20% out-of-sample split at 1.2M rows the looser
-# tolerance costs nothing measurable and is slightly better: log loss 1.0275 against 1.0294,
-# accuracy 0.4183 against 0.4106.
+# saga is also better out of sample at every C measured here: log loss 1.0273-1.0276 against
+# liblinear's 1.0293-1.0294, and accuracy 0.415-0.420 against 0.404-0.410.
 #
-# One property to know rather than to be surprised by: the two solvers reach different
-# points in coefficient space (correlation 0.77) while predicting almost identically. At
-# C >= 10 the penalty leaves 195 of 198 coefficients non-zero, so it is barely binding and
-# the solution is weakly identified - that is a property of the configuration, not of saga.
+# `tol: 0.001` here rather than the 0.01 the weakly-penalised configurations use, because
+# this is where the penalty binds and exact sparsity is the point of the sweep. At 1e-2 saga
+# leaves coefficients stranded NEAR zero instead of AT zero, which `coef_ != 0` then counts
+# as live. Measured on the same panel, exact zeros against coefficients below 1e-8, out of
+# 198:
+#
+#     C        liblinear 1e-4     saga 1e-2        saga 1e-3
+#     0.001      128 / 128         148 / 149        157 / 157
+#     0.01        40 /  40          24 /  52         87 /  87
+#     0.1          8 /   8           3 /   4         24 /  26
+#
+# The 24-against-52 at C=0.01 is the defect: twenty-eight coefficients below 1e-8 that are
+# not zero. At 1e-3 the two counts agree and saga is *more* sparse than liblinear at every C
+# here, so the tighter tolerance is not a concession - it is what makes the L1 solution an
+# L1 solution.
+#
+# Cost at 1.2M rows: 226s, 352s and 287s for C=0.001, 0.01 and 0.1 against liblinear's 30s,
+# 202s and 499s. **The full-panel cost of this arm is not established** - the 16.9M-row
+# extrapolation is uncertain because it rests on a single scaling estimate taken from the
+# tol=1e-2 timings. Watch it on the first run rather than assuming it is small.
 model_class: LogisticRegression
 params:
   C: 0.001
   max_iter: 200
   penalty: l1
   solver: saga
-  tol: 0.01
+  tol: 0.001

--- a/case_studies/config/logistic/logistic_l1_C0.01.yaml
+++ b/case_studies/config/logistic/logistic_l1_C0.01.yaml
@@ -1,6 +1,37 @@
+# L1 logistic regression. The solver is `saga` rather than `liblinear`, and the tolerance
+# is set explicitly rather than left at scikit-learn's 1e-4 default.
+#
+# Two reasons, and the first one is not optional. These labels are three-class (-1, 0, 1),
+# and scikit-learn 1.8 makes multiclass `liblinear` a hard error; #740 already moved our
+# floor to 1.7. `OneVsRestClassifier(liblinear)` would reproduce the current objective
+# exactly - liblinear multiclass IS one-vs-rest - and would keep the problem below.
+#
+# The second is that `liblinear` does not finish. It is single-threaded coordinate descent
+# and scales about N^1.4 here. Measured on nasdaq100_microstructure's `fwd_dir_15m` panel:
+#
+#     rows      liblinear 1000/1e-4     saga 200/1e-2
+#     400,000     144.4s  converged      11.0s  converged
+#   1,200,000     716.9s  converged      44.8s  converged
+#
+# which extrapolates to roughly eight hours per configuration at the full 16.9M rows against
+# about twenty minutes. That is not a projection: `06_linear` ran 7h23m at 100% of one core
+# on 2026-09-05 and was killed with two of thirteen configurations still unfinished, both of
+# them these L1 ones.
+#
+# `tol: 0.01` is what makes saga converge. At 1e-3 it hits the iteration cap without
+# converging at either size; at 1e-2 it converges in 22 to 29 iterations, which is the same
+# count liblinear needs at 1e-4. On a 20% out-of-sample split at 1.2M rows the looser
+# tolerance costs nothing measurable and is slightly better: log loss 1.0275 against 1.0294,
+# accuracy 0.4183 against 0.4106.
+#
+# One property to know rather than to be surprised by: the two solvers reach different
+# points in coefficient space (correlation 0.77) while predicting almost identically. At
+# C >= 10 the penalty leaves 195 of 198 coefficients non-zero, so it is barely binding and
+# the solution is weakly identified - that is a property of the configuration, not of saga.
 model_class: LogisticRegression
 params:
   C: 0.01
-  max_iter: 1000
+  max_iter: 200
   penalty: l1
-  solver: liblinear
+  solver: saga
+  tol: 0.01

--- a/case_studies/config/logistic/logistic_l1_C0.01.yaml
+++ b/case_studies/config/logistic/logistic_l1_C0.01.yaml
@@ -18,20 +18,33 @@
 # on 2026-09-05 and was killed with two of thirteen configurations still unfinished, both of
 # them these L1 ones.
 #
-# `tol: 0.01` is what makes saga converge. At 1e-3 it hits the iteration cap without
-# converging at either size; at 1e-2 it converges in 22 to 29 iterations, which is the same
-# count liblinear needs at 1e-4. On a 20% out-of-sample split at 1.2M rows the looser
-# tolerance costs nothing measurable and is slightly better: log loss 1.0275 against 1.0294,
-# accuracy 0.4183 against 0.4106.
+# saga is also better out of sample at every C measured here: log loss 1.0273-1.0276 against
+# liblinear's 1.0293-1.0294, and accuracy 0.415-0.420 against 0.404-0.410.
 #
-# One property to know rather than to be surprised by: the two solvers reach different
-# points in coefficient space (correlation 0.77) while predicting almost identically. At
-# C >= 10 the penalty leaves 195 of 198 coefficients non-zero, so it is barely binding and
-# the solution is weakly identified - that is a property of the configuration, not of saga.
+# `tol: 0.001` here rather than the 0.01 the weakly-penalised configurations use, because
+# this is where the penalty binds and exact sparsity is the point of the sweep. At 1e-2 saga
+# leaves coefficients stranded NEAR zero instead of AT zero, which `coef_ != 0` then counts
+# as live. Measured on the same panel, exact zeros against coefficients below 1e-8, out of
+# 198:
+#
+#     C        liblinear 1e-4     saga 1e-2        saga 1e-3
+#     0.001      128 / 128         148 / 149        157 / 157
+#     0.01        40 /  40          24 /  52         87 /  87
+#     0.1          8 /   8           3 /   4         24 /  26
+#
+# The 24-against-52 at C=0.01 is the defect: twenty-eight coefficients below 1e-8 that are
+# not zero. At 1e-3 the two counts agree and saga is *more* sparse than liblinear at every C
+# here, so the tighter tolerance is not a concession - it is what makes the L1 solution an
+# L1 solution.
+#
+# Cost at 1.2M rows: 226s, 352s and 287s for C=0.001, 0.01 and 0.1 against liblinear's 30s,
+# 202s and 499s. **The full-panel cost of this arm is not established** - the 16.9M-row
+# extrapolation is uncertain because it rests on a single scaling estimate taken from the
+# tol=1e-2 timings. Watch it on the first run rather than assuming it is small.
 model_class: LogisticRegression
 params:
   C: 0.01
   max_iter: 200
   penalty: l1
   solver: saga
-  tol: 0.01
+  tol: 0.001

--- a/case_studies/config/logistic/logistic_l1_C0.1.yaml
+++ b/case_studies/config/logistic/logistic_l1_C0.1.yaml
@@ -18,20 +18,33 @@
 # on 2026-09-05 and was killed with two of thirteen configurations still unfinished, both of
 # them these L1 ones.
 #
-# `tol: 0.01` is what makes saga converge. At 1e-3 it hits the iteration cap without
-# converging at either size; at 1e-2 it converges in 22 to 29 iterations, which is the same
-# count liblinear needs at 1e-4. On a 20% out-of-sample split at 1.2M rows the looser
-# tolerance costs nothing measurable and is slightly better: log loss 1.0275 against 1.0294,
-# accuracy 0.4183 against 0.4106.
+# saga is also better out of sample at every C measured here: log loss 1.0273-1.0276 against
+# liblinear's 1.0293-1.0294, and accuracy 0.415-0.420 against 0.404-0.410.
 #
-# One property to know rather than to be surprised by: the two solvers reach different
-# points in coefficient space (correlation 0.77) while predicting almost identically. At
-# C >= 10 the penalty leaves 195 of 198 coefficients non-zero, so it is barely binding and
-# the solution is weakly identified - that is a property of the configuration, not of saga.
+# `tol: 0.001` here rather than the 0.01 the weakly-penalised configurations use, because
+# this is where the penalty binds and exact sparsity is the point of the sweep. At 1e-2 saga
+# leaves coefficients stranded NEAR zero instead of AT zero, which `coef_ != 0` then counts
+# as live. Measured on the same panel, exact zeros against coefficients below 1e-8, out of
+# 198:
+#
+#     C        liblinear 1e-4     saga 1e-2        saga 1e-3
+#     0.001      128 / 128         148 / 149        157 / 157
+#     0.01        40 /  40          24 /  52         87 /  87
+#     0.1          8 /   8           3 /   4         24 /  26
+#
+# The 24-against-52 at C=0.01 is the defect: twenty-eight coefficients below 1e-8 that are
+# not zero. At 1e-3 the two counts agree and saga is *more* sparse than liblinear at every C
+# here, so the tighter tolerance is not a concession - it is what makes the L1 solution an
+# L1 solution.
+#
+# Cost at 1.2M rows: 226s, 352s and 287s for C=0.001, 0.01 and 0.1 against liblinear's 30s,
+# 202s and 499s. **The full-panel cost of this arm is not established** - the 16.9M-row
+# extrapolation is uncertain because it rests on a single scaling estimate taken from the
+# tol=1e-2 timings. Watch it on the first run rather than assuming it is small.
 model_class: LogisticRegression
 params:
   C: 0.1
   max_iter: 200
   penalty: l1
   solver: saga
-  tol: 0.01
+  tol: 0.001

--- a/case_studies/config/logistic/logistic_l1_C0.1.yaml
+++ b/case_studies/config/logistic/logistic_l1_C0.1.yaml
@@ -1,6 +1,37 @@
+# L1 logistic regression. The solver is `saga` rather than `liblinear`, and the tolerance
+# is set explicitly rather than left at scikit-learn's 1e-4 default.
+#
+# Two reasons, and the first one is not optional. These labels are three-class (-1, 0, 1),
+# and scikit-learn 1.8 makes multiclass `liblinear` a hard error; #740 already moved our
+# floor to 1.7. `OneVsRestClassifier(liblinear)` would reproduce the current objective
+# exactly - liblinear multiclass IS one-vs-rest - and would keep the problem below.
+#
+# The second is that `liblinear` does not finish. It is single-threaded coordinate descent
+# and scales about N^1.4 here. Measured on nasdaq100_microstructure's `fwd_dir_15m` panel:
+#
+#     rows      liblinear 1000/1e-4     saga 200/1e-2
+#     400,000     144.4s  converged      11.0s  converged
+#   1,200,000     716.9s  converged      44.8s  converged
+#
+# which extrapolates to roughly eight hours per configuration at the full 16.9M rows against
+# about twenty minutes. That is not a projection: `06_linear` ran 7h23m at 100% of one core
+# on 2026-09-05 and was killed with two of thirteen configurations still unfinished, both of
+# them these L1 ones.
+#
+# `tol: 0.01` is what makes saga converge. At 1e-3 it hits the iteration cap without
+# converging at either size; at 1e-2 it converges in 22 to 29 iterations, which is the same
+# count liblinear needs at 1e-4. On a 20% out-of-sample split at 1.2M rows the looser
+# tolerance costs nothing measurable and is slightly better: log loss 1.0275 against 1.0294,
+# accuracy 0.4183 against 0.4106.
+#
+# One property to know rather than to be surprised by: the two solvers reach different
+# points in coefficient space (correlation 0.77) while predicting almost identically. At
+# C >= 10 the penalty leaves 195 of 198 coefficients non-zero, so it is barely binding and
+# the solution is weakly identified - that is a property of the configuration, not of saga.
 model_class: LogisticRegression
 params:
   C: 0.1
-  max_iter: 1000
+  max_iter: 200
   penalty: l1
-  solver: liblinear
+  solver: saga
+  tol: 0.01

--- a/case_studies/config/logistic/logistic_l1_C1.0.yaml
+++ b/case_studies/config/logistic/logistic_l1_C1.0.yaml
@@ -1,6 +1,37 @@
+# L1 logistic regression. The solver is `saga` rather than `liblinear`, and the tolerance
+# is set explicitly rather than left at scikit-learn's 1e-4 default.
+#
+# Two reasons, and the first one is not optional. These labels are three-class (-1, 0, 1),
+# and scikit-learn 1.8 makes multiclass `liblinear` a hard error; #740 already moved our
+# floor to 1.7. `OneVsRestClassifier(liblinear)` would reproduce the current objective
+# exactly - liblinear multiclass IS one-vs-rest - and would keep the problem below.
+#
+# The second is that `liblinear` does not finish. It is single-threaded coordinate descent
+# and scales about N^1.4 here. Measured on nasdaq100_microstructure's `fwd_dir_15m` panel:
+#
+#     rows      liblinear 1000/1e-4     saga 200/1e-2
+#     400,000     144.4s  converged      11.0s  converged
+#   1,200,000     716.9s  converged      44.8s  converged
+#
+# which extrapolates to roughly eight hours per configuration at the full 16.9M rows against
+# about twenty minutes. That is not a projection: `06_linear` ran 7h23m at 100% of one core
+# on 2026-09-05 and was killed with two of thirteen configurations still unfinished, both of
+# them these L1 ones.
+#
+# `tol: 0.01` is what makes saga converge. At 1e-3 it hits the iteration cap without
+# converging at either size; at 1e-2 it converges in 22 to 29 iterations, which is the same
+# count liblinear needs at 1e-4. On a 20% out-of-sample split at 1.2M rows the looser
+# tolerance costs nothing measurable and is slightly better: log loss 1.0275 against 1.0294,
+# accuracy 0.4183 against 0.4106.
+#
+# One property to know rather than to be surprised by: the two solvers reach different
+# points in coefficient space (correlation 0.77) while predicting almost identically. At
+# C >= 10 the penalty leaves 195 of 198 coefficients non-zero, so it is barely binding and
+# the solution is weakly identified - that is a property of the configuration, not of saga.
 model_class: LogisticRegression
 params:
   C: 1.0
-  max_iter: 1000
+  max_iter: 200
   penalty: l1
-  solver: liblinear
+  solver: saga
+  tol: 0.01

--- a/case_studies/config/logistic/logistic_l1_C10.0.yaml
+++ b/case_studies/config/logistic/logistic_l1_C10.0.yaml
@@ -1,6 +1,37 @@
+# L1 logistic regression. The solver is `saga` rather than `liblinear`, and the tolerance
+# is set explicitly rather than left at scikit-learn's 1e-4 default.
+#
+# Two reasons, and the first one is not optional. These labels are three-class (-1, 0, 1),
+# and scikit-learn 1.8 makes multiclass `liblinear` a hard error; #740 already moved our
+# floor to 1.7. `OneVsRestClassifier(liblinear)` would reproduce the current objective
+# exactly - liblinear multiclass IS one-vs-rest - and would keep the problem below.
+#
+# The second is that `liblinear` does not finish. It is single-threaded coordinate descent
+# and scales about N^1.4 here. Measured on nasdaq100_microstructure's `fwd_dir_15m` panel:
+#
+#     rows      liblinear 1000/1e-4     saga 200/1e-2
+#     400,000     144.4s  converged      11.0s  converged
+#   1,200,000     716.9s  converged      44.8s  converged
+#
+# which extrapolates to roughly eight hours per configuration at the full 16.9M rows against
+# about twenty minutes. That is not a projection: `06_linear` ran 7h23m at 100% of one core
+# on 2026-09-05 and was killed with two of thirteen configurations still unfinished, both of
+# them these L1 ones.
+#
+# `tol: 0.01` is what makes saga converge. At 1e-3 it hits the iteration cap without
+# converging at either size; at 1e-2 it converges in 22 to 29 iterations, which is the same
+# count liblinear needs at 1e-4. On a 20% out-of-sample split at 1.2M rows the looser
+# tolerance costs nothing measurable and is slightly better: log loss 1.0275 against 1.0294,
+# accuracy 0.4183 against 0.4106.
+#
+# One property to know rather than to be surprised by: the two solvers reach different
+# points in coefficient space (correlation 0.77) while predicting almost identically. At
+# C >= 10 the penalty leaves 195 of 198 coefficients non-zero, so it is barely binding and
+# the solution is weakly identified - that is a property of the configuration, not of saga.
 model_class: LogisticRegression
 params:
   C: 10.0
-  max_iter: 1000
+  max_iter: 200
   penalty: l1
-  solver: liblinear
+  solver: saga
+  tol: 0.01

--- a/case_studies/config/logistic/logistic_l1_C100.0.yaml
+++ b/case_studies/config/logistic/logistic_l1_C100.0.yaml
@@ -1,6 +1,37 @@
+# L1 logistic regression. The solver is `saga` rather than `liblinear`, and the tolerance
+# is set explicitly rather than left at scikit-learn's 1e-4 default.
+#
+# Two reasons, and the first one is not optional. These labels are three-class (-1, 0, 1),
+# and scikit-learn 1.8 makes multiclass `liblinear` a hard error; #740 already moved our
+# floor to 1.7. `OneVsRestClassifier(liblinear)` would reproduce the current objective
+# exactly - liblinear multiclass IS one-vs-rest - and would keep the problem below.
+#
+# The second is that `liblinear` does not finish. It is single-threaded coordinate descent
+# and scales about N^1.4 here. Measured on nasdaq100_microstructure's `fwd_dir_15m` panel:
+#
+#     rows      liblinear 1000/1e-4     saga 200/1e-2
+#     400,000     144.4s  converged      11.0s  converged
+#   1,200,000     716.9s  converged      44.8s  converged
+#
+# which extrapolates to roughly eight hours per configuration at the full 16.9M rows against
+# about twenty minutes. That is not a projection: `06_linear` ran 7h23m at 100% of one core
+# on 2026-09-05 and was killed with two of thirteen configurations still unfinished, both of
+# them these L1 ones.
+#
+# `tol: 0.01` is what makes saga converge. At 1e-3 it hits the iteration cap without
+# converging at either size; at 1e-2 it converges in 22 to 29 iterations, which is the same
+# count liblinear needs at 1e-4. On a 20% out-of-sample split at 1.2M rows the looser
+# tolerance costs nothing measurable and is slightly better: log loss 1.0275 against 1.0294,
+# accuracy 0.4183 against 0.4106.
+#
+# One property to know rather than to be surprised by: the two solvers reach different
+# points in coefficient space (correlation 0.77) while predicting almost identically. At
+# C >= 10 the penalty leaves 195 of 198 coefficients non-zero, so it is barely binding and
+# the solution is weakly identified - that is a property of the configuration, not of saga.
 model_class: LogisticRegression
 params:
   C: 100.0
-  max_iter: 1000
+  max_iter: 200
   penalty: l1
-  solver: liblinear
+  solver: saga
+  tol: 0.01

--- a/case_studies/research/results.py
+++ b/case_studies/research/results.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 from contextlib import closing
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -561,7 +562,25 @@ class ResultsCatalog:
         *,
         execution_tier: str | ExecutionTier = ExecutionTier.CANONICAL,
         runtime_provenance: dict[str, Any] | None = None,
+        started_at: str | None = None,
     ) -> TrainingResult:
+        """Register a training identity. ``started_at`` records when work on it began.
+
+        A training run is registered before it is fitted, because the identity has to exist
+        before anything can be written under it, and ``elapsed_s`` is filled in afterwards by
+        :func:`record_training_cost`. Between those two moments - which for one nasdaq
+        configuration has now been more than seven hours - the row says nothing about
+        whether the fit is running, finished or wedged.
+
+        ``started_at`` closes that. With it, a row whose ``elapsed_s`` is still NULL is
+        legible: a wall clock says how long this configuration has been going, and how that
+        compares to its siblings. Without it the only recoverable timing is
+        ``created_at - started_at`` after the fact, which is what
+        ml4t/agent-workspace#1026 found the whole corpus reduced to.
+
+        Like ``entry_point``, it is a **table column and not part of ``spec``**, so recording
+        it moves no training hash. Nothing here may touch ``computation``.
+        """
         self.study.require_writable()
         tier = ExecutionTier(execution_tier)
         resolved = dict(spec)
@@ -593,6 +612,10 @@ class ResultsCatalog:
             # (`case_studies.utils.linear`); this one names the notebook.
             entry_point=self.study.entry_point,
             runtime_provenance=runtime_provenance,
+            # Defaulted here rather than at every call site: a caller that forgets it should
+            # still leave a legible row, and "when the identity was registered" is within
+            # seconds of "when work on it began" on every path that registers before fitting.
+            started_at=started_at or datetime.now(UTC).isoformat(),
         )
         result = Result.open(
             self.study,

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -10,7 +10,7 @@ import subprocess
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -1239,6 +1239,23 @@ def _fail_batch_candidate(candidate: _BatchCandidate, error: Exception) -> None:
         candidate.attempt = None
 
 
+def _progress(message: str) -> None:
+    """One timestamped line per unit of work, flushed.
+
+    Deliberately not a tqdm bar. This runner's output is read two ways and neither favours
+    one: papermill captures it into a notebook cell, and `nb-run.sh` tees it to a log that
+    someone greps hours later to ask whether the run is moving. A bar rewrites one line with
+    carriage returns, which a log file records as an unreadable single line and a captured
+    cell renders as the final frame only - so at 07:30 it says exactly as little as no output
+    at all.
+
+    Discrete lines carry the thing a bar cannot: when each unit finished. That is what makes
+    "no new line for four hours" a legible statement, which is the question this exists to
+    answer.
+    """
+    print(f"[{datetime.now(UTC).strftime('%H:%M:%S')}] {message}", flush=True)
+
+
 def _run_batch_candidate_fold(candidate: _BatchCandidate, fold: dict[str, Any]) -> None:
     if candidate.result is not None or candidate.error is not None:
         return
@@ -1262,6 +1279,11 @@ def _run_batch_candidate_fold(candidate: _BatchCandidate, fold: dict[str, Any]) 
         return
     candidate.frames.append(frame)
     candidate.fit_elapsed_s += elapsed
+    _progress(
+        f"  fold {fold_id} {'reused' if reused else 'fitted'} for "
+        f"{candidate.request.get('config_name', '?')} "
+        f"in {elapsed:6.1f}s (config total {candidate.fit_elapsed_s:7.1f}s)"
+    )
     (candidate.reused_folds if reused else candidate.fitted_folds).append(fold_id)
 
 
@@ -1370,6 +1392,10 @@ def _run_batch_group(
         candidate.result is None and candidate.error is None for candidate in candidates
     )
     if first_pass_needed:
+        _progress(
+            f"linear group {compatibility_key[:12]}: {len(candidates)} configurations x "
+            f"{len(fold_ids)} folds, fold-major"
+        )
         for split in base["splits"]:
             fold_id = int(split["fold"])
             fixed_pending = [
@@ -1388,6 +1414,11 @@ def _run_batch_group(
                     _fail_batch_candidate(candidate, exc)
                 break
             preparation_elapsed_s += time.perf_counter() - started
+            _progress(
+                f"fold {fold_id} of {len(fold_ids)} prepared in "
+                f"{time.perf_counter() - started:.1f}s; {len(fixed_pending)} configurations "
+                f"to fit on it"
+            )
             for candidate in dependent:
                 if candidate.error is not None:
                     continue

--- a/tests/test_logistic_solver_supports_multiclass.py
+++ b/tests/test_logistic_solver_supports_multiclass.py
@@ -28,10 +28,25 @@ import pytest
 import yaml
 
 PRESETS = Path(__file__).resolve().parents[1] / "case_studies" / "config" / "logistic"
-# `saga` needs a looser tolerance than coordinate descent to converge here: at 1e-3 it hits
-# the iteration cap at both sizes measured; at 1e-2 it converges in 22 to 29 iterations,
-# which is the count liblinear needs at 1e-4.
-REQUIRED_TOL = 0.01
+# The tolerance is split by where the penalty binds, and both halves are measured.
+#
+# Weakly penalised (C >= 1): saga needs a LOOSER tolerance than coordinate descent to
+# converge at all. At 1e-4 and 1e-3 it hits the iteration cap at every size tried; at 1e-2 it
+# converges in 22 to 29 iterations, the count liblinear needs at 1e-4.
+#
+# Strongly penalised (C <= 0.1): 1e-2 converges but leaves coefficients stranded NEAR zero
+# rather than AT zero, and `coef_ != 0` counts those as live. At C=0.01 that is 24 exact
+# zeros against 52 below 1e-8, where liblinear has 40 of each. At 1e-3 the two counts agree
+# and saga is more sparse than liblinear at every C measured. Sparsity is the entire point of
+# the small-C end of this sweep, so it gets the tighter tolerance.
+LOOSE_TOL = 0.01
+TIGHT_TOL = 0.001
+# Where the penalty starts binding hard enough for the stranding to matter.
+TIGHT_TOL_MAX_C = 0.1
+
+
+def _c_of(preset: Path) -> float:
+    return float(yaml.safe_load(preset.read_text())["params"]["C"])
 
 
 def _presets() -> list[Path]:
@@ -61,10 +76,12 @@ def test_no_l1_preset_pins_liblinear(preset: Path) -> None:
 def test_each_l1_preset_sets_the_tolerance_saga_needs(preset: Path) -> None:
     """Left at the 1e-4 default, saga does not converge within any iteration cap tried."""
     params = yaml.safe_load(preset.read_text())["params"]
-    assert params.get("tol") == REQUIRED_TOL, (
-        f"{preset.name} does not set tol={REQUIRED_TOL}. At the scikit-learn default of "
-        "1e-4, and at 1e-3, saga hit the iteration cap without converging at both 400k and "
-        "1.2M rows."
+    expected = TIGHT_TOL if _c_of(preset) <= TIGHT_TOL_MAX_C else LOOSE_TOL
+    assert params.get("tol") == expected, (
+        f"{preset.name} sets tol={params.get('tol')}, expected {expected}. At C<=0.1 the "
+        "penalty binds and 1e-2 strands coefficients near zero rather than at zero, which "
+        "blunts the sparsity the sweep exists to show; at C>=1 saga does not converge at "
+        "any tolerance tighter than 1e-2."
     )
     assert params.get("max_iter", 0) >= 200, (
         f"{preset.name} caps iterations below the 22-29 saga needed plus headroom"

--- a/tests/test_logistic_solver_supports_multiclass.py
+++ b/tests/test_logistic_solver_supports_multiclass.py
@@ -1,0 +1,71 @@
+"""No shared logistic preset may pin `liblinear`, because these labels are multiclass.
+
+Four case studies fit the `logistic_l1_*` presets, and their direction labels take three
+values (-1, 0, 1) rather than two. scikit-learn 1.8 makes multiclass `liblinear` a hard
+error, and #740 already moved this repo's floor to 1.7, so the deprecation is one release
+away from breaking every one of them.
+
+Speed is the second reason and it is the one that was actually costing time. `liblinear` is
+single-threaded coordinate descent scaling about N^1.4 on this data. Measured on
+nasdaq100_microstructure's `fwd_dir_15m` panel, L1 at C=100: 144.4 s at 400k rows and 716.9 s
+at 1.2M, against 11.0 s and 44.8 s for `saga` at `tol=1e-2`. That extrapolates to roughly
+eight hours per configuration at the full 16.9M rows against about twenty minutes - and
+`06_linear` did run 7h23m before being killed with exactly these two configurations
+unfinished.
+
+`OneVsRestClassifier(liblinear)` is the fix this test is written to refuse. It silences the
+deprecation while preserving the objective exactly, because liblinear multiclass already is
+one-vs-rest - so it keeps the eight hours.
+
+Refs ml4t/agent-workspace#1040.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+PRESETS = Path(__file__).resolve().parents[1] / "case_studies" / "config" / "logistic"
+# `saga` needs a looser tolerance than coordinate descent to converge here: at 1e-3 it hits
+# the iteration cap at both sizes measured; at 1e-2 it converges in 22 to 29 iterations,
+# which is the count liblinear needs at 1e-4.
+REQUIRED_TOL = 0.01
+
+
+def _presets() -> list[Path]:
+    return sorted(PRESETS.glob("logistic_l1_*.yaml"))
+
+
+def test_the_l1_presets_are_present() -> None:
+    """A guard over an empty glob passes without checking anything."""
+    assert len(_presets()) >= 6, f"expected the six shared L1 presets, found {_presets()}"
+
+
+@pytest.mark.parametrize("preset", _presets(), ids=lambda p: p.stem)
+def test_no_l1_preset_pins_liblinear(preset: Path) -> None:
+    params = yaml.safe_load(preset.read_text())["params"]
+    assert params["solver"] != "liblinear", (
+        f"{preset.name} pins liblinear, which scikit-learn 1.8 refuses for the three-class "
+        "direction labels these presets are fitted on, and which does not finish on a "
+        "16.9M-row panel. Use saga."
+    )
+    assert params["solver"] == "saga", (
+        f"{preset.name} uses {params['solver']!r}. saga is the solver scikit-learn "
+        "recommends for large-n L1 and the only one measured to converge here."
+    )
+
+
+@pytest.mark.parametrize("preset", _presets(), ids=lambda p: p.stem)
+def test_each_l1_preset_sets_the_tolerance_saga_needs(preset: Path) -> None:
+    """Left at the 1e-4 default, saga does not converge within any iteration cap tried."""
+    params = yaml.safe_load(preset.read_text())["params"]
+    assert params.get("tol") == REQUIRED_TOL, (
+        f"{preset.name} does not set tol={REQUIRED_TOL}. At the scikit-learn default of "
+        "1e-4, and at 1e-3, saga hit the iteration cap without converging at both 400k and "
+        "1.2M rows."
+    )
+    assert params.get("max_iter", 0) >= 200, (
+        f"{preset.name} caps iterations below the 22-29 saga needed plus headroom"
+    )

--- a/tests/test_training_start_time_is_recorded.py
+++ b/tests/test_training_start_time_is_recorded.py
@@ -1,0 +1,98 @@
+"""A registered training run records when work on it began.
+
+A training run is registered before it is fitted, because the identity has to exist before
+anything can be written under it, and `elapsed_s` is filled in afterwards by
+`record_training_cost`. Between those two moments the row said nothing at all: `started_at`
+was never passed by any caller on the research path, so a run in flight was indistinguishable
+from one that had wedged.
+
+That is not hypothetical. `nasdaq100_microstructure`'s `06_linear` ran 7h23m at 100% of one
+core, and the question "is it working?" could not be answered from the registry - it held
+thirteen rows with `started_at` and `elapsed_s` both NULL. The run had in fact completed 24
+of 26 fold-fits and was stuck on a `liblinear` L1 configuration; that was recoverable only by
+reading file modification times off the fold artifacts.
+
+`started_at` is a table column and not part of the spec, so recording it moves no training
+hash. That is the property this file pins, because an observability change that reprices the
+corpus is not an observability change.
+
+Refs ml4t/agent-workspace#990, #1026.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from datetime import UTC, datetime
+from pathlib import Path
+
+from case_studies.research import Study
+from case_studies.utils.registry.specs import training_hash_from_spec
+from tests.test_research_registry import _seed_release, _training_spec
+
+
+def _study(tmp_path: Path) -> Study:
+    return Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+
+
+def _row(study: Study, training_hash: str) -> tuple:
+    with closing(sqlite3.connect(study.root / "run_log" / "registry.db")) as db:
+        return db.execute(
+            "SELECT started_at, elapsed_s FROM training_runs WHERE training_hash = ?",
+            (training_hash,),
+        ).fetchone()
+
+
+def test_a_registered_run_records_a_start_time_without_being_asked(tmp_path: Path) -> None:
+    """Defaulted, so a caller that forgets still leaves a legible row."""
+    study = _study(tmp_path)
+    before = datetime.now(UTC)
+    training = study.results.register_training(_training_spec())
+    after = datetime.now(UTC)
+
+    started_at, elapsed_s = _row(study, training.hash)
+    assert started_at is not None, "the row cannot say whether the fit has begun"
+    assert before <= datetime.fromisoformat(started_at) <= after
+    # Still NULL: the fit has not finished, which is exactly the window `started_at` makes
+    # legible rather than a gap in it.
+    assert elapsed_s is None
+
+
+def test_an_explicit_start_time_is_kept(tmp_path: Path) -> None:
+    """A caller that captured the moment the fit began passes it rather than re-taking it."""
+    study = _study(tmp_path)
+    stamp = "2026-09-05T04:40:19.123456+00:00"
+    training = study.results.register_training(_training_spec(), started_at=stamp)
+    assert _row(study, training.hash)[0] == stamp
+
+
+def test_recording_a_start_time_moves_no_training_hash(tmp_path: Path) -> None:
+    """The whole constraint on this change, checked rather than argued.
+
+    `started_at` is a table column. If it ever reaches `spec_json`, every training identity
+    in the corpus moves and every stored result is orphaned - so this asserts both that the
+    hash matches the spec's own projection and that the stored spec does not carry the field.
+    """
+    study = _study(tmp_path)
+    spec = _training_spec()
+    expected = training_hash_from_spec(spec)
+
+    training = study.results.register_training(spec, started_at="2026-09-05T04:40:19+00:00")
+
+    assert training.hash == expected, "recording a start time changed the training identity"
+    with closing(sqlite3.connect(study.root / "run_log" / "registry.db")) as db:
+        spec_json = db.execute(
+            "SELECT spec_json FROM training_runs WHERE training_hash = ?", (training.hash,)
+        ).fetchone()[0]
+    assert "started_at" not in spec_json, "started_at leaked into the hashed spec"
+
+
+def test_two_runs_of_one_spec_keep_one_identity_and_differ_in_start(tmp_path: Path) -> None:
+    """Re-registering the same identity is not a new identity, whatever the clock says."""
+    study = _study(tmp_path)
+    spec = _training_spec()
+    first = study.results.register_training(spec, started_at="2026-09-05T01:00:00+00:00")
+    second = study.results.register_training(spec, started_at="2026-09-05T02:00:00+00:00")
+    assert first.hash == second.hash


### PR DESCRIPTION
## Why

`nasdaq100_microstructure`'s `06_linear` ran **7h23m at 100% of one core** and the registry could not say whether it was working. It was not: 24 of 26 fold-fits were done and nothing had been written for 4h35m. Recovering that took reading file modification times off fold artifacts, which is the whole complaint.

## What this changes

**`started_at` is recorded.** A training run is registered before it is fitted and `elapsed_s` is filled in afterwards, so between those moments the row said nothing. `register_training_run` has taken a `started_at` parameter all along, writing a dedicated column; no research-path caller passed it. `ResultsCatalog.register_training` now does, defaulted so a caller that forgets still leaves a legible row.

It is a **table column, not part of the spec**, so no training hash moves — asserted directly against `training_hash_from_spec` and against `spec_json`, because an observability change that reprices the corpus is not one.

**Progress is reported.** One timestamped, flushed line per fold preparation and per fold fit, with counts and elapsed:

```
[04:48:54] linear group 3f9a1c2b8e04: 13 configurations x 2 folds, fold-major
[04:48:54] fold 0 of 2 prepared in 12.4s; 13 configurations to fit on it
[04:49:50]   fold 0 fitted for logistic_l2_C0.001 in   55.9s (config total    55.9s)
```

Deliberately **not tqdm**. This output is read as a papermill-captured cell and as a tee'd log; a bar rewrites one line with carriage returns, which the log records unreadably and the cell renders as the final frame only. Discrete lines carry *when* each unit finished, which is what makes "no new line since 07:30" a statement someone can act on.

**L1 logistic moves off `liblinear`.** Two independent reasons:

1. These labels are **three-class** and scikit-learn 1.8 makes multiclass `liblinear` a hard error; #740 already moved the floor to 1.7.
2. It does not finish. Measured on the real `fwd_dir_15m` panel at C=100:

| rows | liblinear 1000/1e-4 | saga 200/1e-2 |
|---:|---|---|
| 400,000 | 144.4 s | 11.0 s |
| 1,200,000 | 716.9 s | 44.8 s |

About N^1.4, extrapolating to **~8 h per configuration** at 16.9M rows against ~20 min. The killed run had exactly these two configurations outstanding.

`OneVsRestClassifier(liblinear)` is explicitly not the fix and a test says so: liblinear multiclass already *is* one-vs-rest, so it silences the deprecation and keeps the eight hours.

## The tolerance is split, and that took a second measurement

`saga` needs a **looser** tolerance than coordinate descent to converge at C >= 1 (at 1e-4 and 1e-3 it hits the iteration cap at every size tried). But at small C, where the penalty binds and sparsity is the point of the sweep, 1e-2 leaves coefficients stranded near zero rather than at it. Exact zeros / coefficients below 1e-8, of 198:

| C | liblinear 1e-4 | saga 1e-2 | saga 1e-3 |
|---|---|---|---|
| 0.001 | 128 / 128 | 148 / 149 | 157 / 157 |
| 0.01 | 40 / 40 | **24 / 52** | 87 / 87 |
| 0.1 | 8 / 8 | **3 / 4** | 24 / 26 |

So `C <= 0.1` takes `tol=0.001` and `C >= 1` keeps `0.01`. At 1e-3 saga is *more* sparse than liblinear at every C measured.

**One thing not established:** the full-panel cost of the tightened small-C arm. It measures 226 s, 352 s and 287 s at 1.2M rows, but the 16.9M extrapolation rests on a scaling estimate taken from the `tol=1e-2` timings. The config comments say so rather than implying it is small — watch it on the first run.

## Verified

- **Features are standardized before the model** (`folds.py:807` fits `SimpleImputer + StandardScaler` per fold), which saga requires. Checked, not assumed.
- **Chapter 11's `03_logistic_classification` keeps `liblinear` legitimately** — its target is binary, so 1.8 does not refuse it and the speed argument does not apply.
- saga is better out of sample at every C measured: log loss 1.0273-1.0276 against 1.0293-1.0294.
- 84 tests pass across the registry, contract-execution, start-time and solver suites; `test_research_models.py` 75 pass.

## Filed from this work

ml4t/agent-workspace#1041 — `C=10` and `C=100` agree to six decimals in log loss, accuracy and sparsity under **both** solvers independently, so a saturated grid submits two configurations and produces one result while the effective-trials count treats it as two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015p4BJvMLmU1rJ1jZYgugAC