### PR TITLE
A uv.lock bump rebuilds the images it stales, and stays mergeable

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,20 @@ name: Docker Publish
 on:
   push:
     tags: ["v3.*"]
+    # A lock bump stales every published image the moment it lands, and until
+    # 2026-09-05 nothing rebuilt them: this workflow ran on a `v3.*` tag or a manual
+    # dispatch and on nothing else. All three Dockerfiles derive their pinned
+    # constraint from the root `uv.lock`, so #740 moved five distributions
+    # (econml, causalml, scikit-learn, shap, statsforecast) and `ml4t/ml4t:latest`
+    # kept the old five. `test-unit-image` is required and correctly refused the
+    # mismatch, so `main` and every open pull request went red and nothing could
+    # merge until someone dispatched a rebuild by hand.
+    #
+    # No `paths:` filter here: a `paths:` under `push` applies to the tag trigger
+    # too, which would make a release tag whose commit touched none of these files
+    # build nothing at all. The `changes` job below does the filtering instead,
+    # which is also what test.yml does.
+    branches: [main]
   workflow_dispatch:
     inputs:
       images:
@@ -35,11 +49,50 @@ env:
 # ML4T MAIN — Multi-arch (amd64 + arm64 native runners)
 # ============================================================================
 jobs:
+  # Which images a push to `main` staled. A tag or a manual dispatch skips this and
+  # builds whatever it was asked for; only a branch push is filtered.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      ml4t: ${{ steps.filter.outputs.ml4t }}
+      py312: ${{ steps.filter.outputs.py312 }}
+      benchmark: ${{ steps.filter.outputs.benchmark }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            # The root lock and manifest are the resolve every image is built
+            # from, so they stale all three. Each image then adds its own
+            # Dockerfile and, where it has one, its own dependency manifest.
+            ml4t:
+              - 'uv.lock'
+              - 'pyproject.toml'
+              - 'envs/ml4t/Dockerfile'
+            py312:
+              - 'uv.lock'
+              - 'pyproject.toml'
+              - 'envs/py312/Dockerfile'
+              - 'envs/py312/pyproject.toml'
+              - 'envs/py312/bsts-pyproject.toml'
+            benchmark:
+              - 'uv.lock'
+              - 'pyproject.toml'
+              - 'envs/benchmark/Dockerfile'
+              - 'envs/benchmark/pyproject.toml'
+
   build-ml4t:
+    needs: changes
     if: >-
-      github.event_name != 'workflow_dispatch' ||
+      (github.event_name != 'workflow_dispatch' ||
       github.event.inputs.images == 'all' ||
-      github.event.inputs.images == 'ml4t'
+      github.event.inputs.images == 'ml4t') &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref_type == 'tag' ||
+      needs.changes.outputs.ml4t == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -183,10 +236,14 @@ jobs:
   # ============================================================================
   build-py312:
     runs-on: ubuntu-latest
+    needs: changes
     if: >-
-      github.event_name != 'workflow_dispatch' ||
+      (github.event_name != 'workflow_dispatch' ||
       github.event.inputs.images == 'all' ||
-      github.event.inputs.images == 'py312'
+      github.event.inputs.images == 'py312') &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref_type == 'tag' ||
+      needs.changes.outputs.py312 == 'true')
 
     steps:
       - name: Free disk space (signature stack + ML deps ~5GB)
@@ -247,10 +304,14 @@ jobs:
   # BENCHMARK — Multi-arch (amd64 + arm64 on NATIVE runners)
   # ============================================================================
   build-benchmark:
+    needs: changes
     if: >-
-      github.event_name != 'workflow_dispatch' ||
+      (github.event_name != 'workflow_dispatch' ||
       github.event.inputs.images == 'all' ||
-      github.event.inputs.images == 'benchmark'
+      github.event.inputs.images == 'benchmark') &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref_type == 'tag' ||
+      needs.changes.outputs.benchmark == 'true')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1122,14 +1122,13 @@ jobs:
 
   test-unit-image:
     needs: [changes, build-image-candidate]
-    # `always()` so this still runs when the candidate build was skipped, which is
-    # the common case; a candidate that failed or was cancelled must not fall
-    # through to measuring in `latest`, which is the drift this job exists to
-    # refuse.
-    if: >-
-      always() &&
-      needs.build-image-candidate.result != 'failure' &&
-      needs.build-image-candidate.result != 'cancelled'
+    # Plain `always()`, and the candidate's result is handled in a step rather than
+    # here. A `!= 'failure'` in this condition would SKIP the job when the
+    # candidate build broke, and GitHub counts a skipped required check as
+    # satisfied - so a lock bump whose image would not build would have become
+    # mergeable without the image tests running at all. Skipping is the one
+    # outcome this job must never have.
+    if: always()
     runs-on: ubuntu-latest
     # The 26 files measured on 2026-08-24 ran in 3m21s; the list now contains 36.
     # --timeout=900 bounds a hung test but not a hung
@@ -1137,6 +1136,19 @@ jobs:
     # GitHub's six-hour default.
     timeout-minutes: 30
     steps:
+      # `needs` cannot fail this job, because the condition above is unconditional
+      # by design. This step is what turns a broken candidate into a red required
+      # check instead of a green one.
+      - name: The candidate image built
+        if: >-
+          needs.build-image-candidate.result == 'failure' ||
+          needs.build-image-candidate.result == 'cancelled'
+        run: |
+          echo "::error::build-image-candidate ${{ needs.build-image-candidate.result }}:"
+          echo "::error::this commit changes what the image installs, and no image was"
+          echo "::error::produced to measure it in. Measuring in ml4t/ml4t:latest would"
+          echo "::error::test the environment this commit replaces."
+          exit 1
       - uses: actions/checkout@v6
       - name: Load the candidate image
         if: needs.build-image-candidate.result == 'success'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,13 @@ on:
         description: "pytest -k filter (e.g. 'us_equities_panel or nasdaq100' to run only those)"
         type: string
         default: ""
+      # The candidate path is exercised only by a commit that moves the resolve, so
+      # without this there is no way to run it deliberately - including to prove it
+      # works before a lock bump depends on it.
+      force_image_candidate:
+        description: "Build the ml4t image from this commit and measure test-unit-image in it"
+        type: boolean
+        default: false
 
 env:
   ML4T_DATA_PATH: ${{ github.workspace }}/test-data/data
@@ -76,6 +83,10 @@ jobs:
       run_py312: ${{ steps.build.outputs.run_py312 }}
       run_neo4j: ${{ steps.build.outputs.run_neo4j }}
       run_benchmark: ${{ steps.build.outputs.run_benchmark }}
+      # Whether this change moves what `ml4t/ml4t:latest` would install. Read
+      # straight off the filter rather than through `build`, because it gates a
+      # job rather than shaping a matrix.
+      image_inputs: ${{ steps.filter.outputs.image-inputs }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -123,6 +134,16 @@ jobs:
             # matrix; it gets its own filter, wired into run_py312 below.
             docker-notebooks:
               - 'tests/test_docker_notebooks.py'
+            # The resolve `envs/ml4t/Dockerfile` performs. When one of these moves,
+            # `ml4t/ml4t:latest` is by definition not the environment this commit
+            # declares, so test-unit-image builds a candidate from the commit
+            # instead of measuring in a published image that predates it. Keep in
+            # step with the `ml4t` filter in docker-publish.yml; a test asserts both
+            # cover what the Dockerfile reads.
+            image-inputs:
+              - 'uv.lock'
+              - 'pyproject.toml'
+              - 'envs/ml4t/Dockerfile'
             ch01:
               - '01_process_is_edge/**'
             ch02-03:
@@ -1052,27 +1073,93 @@ jobs:
   # tmp_path. Measured with ML4T_DATA_PATH at the repo's own data/ directory,
   # which holds loaders and no market data.
   # ---------------------------------------------------------------------------
+  # A commit that moves the resolve gets its own image, because no published one
+  # can be the environment it declares.
+  #
+  # test-unit-image is required, and its first step refuses to measure anything in
+  # an image whose installed distributions do not match uv.lock. Against
+  # `ml4t/ml4t:latest` that made every lock-changing pull request unmergeable: the
+  # image can only be rebuilt from a lock that has landed, and the lock could not
+  # land without the check that needed the rebuild. #740 escaped it only because
+  # its branch predated the guard and so ran a workflow that did not have it, and
+  # the mismatch surfaced on main instead, where it blocked every open PR until
+  # someone dispatched a rebuild by hand.
+  #
+  # So on those commits the image under test is built here, from this tree, and
+  # `latest` stays out of it. It costs a CUDA build (~22 min, warm registry cache)
+  # on the ~18 commits in 60 days that touch these paths, and nothing at all on the
+  # rest.
+  build-image-candidate:
+    needs: changes
+    if: needs.changes.outputs.image_inputs == 'true' || github.event.inputs.force_image_candidate == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Free disk space (CUDA base + ML deps)
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo docker image prune -af
+          df -h /
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      # Read-only: this never publishes. The tag is local to the tarball and the
+      # digest is whatever this tree builds, so nothing here can move `latest`.
+      - name: Build the image this commit declares
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: envs/ml4t/Dockerfile
+          platforms: linux/amd64
+          tags: ml4t/ml4t:candidate
+          outputs: type=docker,dest=/tmp/ml4t-candidate.tar
+          cache-from: type=registry,ref=ml4t/ml4t:buildcache-linux-amd64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ml4t-candidate-image
+          path: /tmp/ml4t-candidate.tar
+          if-no-files-found: error
+          retention-days: 1
+
   test-unit-image:
+    needs: [changes, build-image-candidate]
+    # `always()` so this still runs when the candidate build was skipped, which is
+    # the common case; a candidate that failed or was cancelled must not fall
+    # through to measuring in `latest`, which is the drift this job exists to
+    # refuse.
+    if: >-
+      always() &&
+      needs.build-image-candidate.result != 'failure' &&
+      needs.build-image-candidate.result != 'cancelled'
     runs-on: ubuntu-latest
     # The 26 files measured on 2026-08-24 ran in 3m21s; the list now contains 36.
     # --timeout=900 bounds a hung test but not a hung
     # import, collection or image pull, which would otherwise fall through to
     # GitHub's six-hour default.
     timeout-minutes: 30
-    container:
-      image: ml4t/ml4t:latest
     steps:
-      - name: Install git (for checkout inside container)
-        run: |
-          # A transient apt mirror failure used to kill the whole job.
-          for attempt in 1 2 3; do
-            apt-get update && apt-get install -y git && exit 0
-            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
-            sleep $((attempt * 15))
-          done
-          echo "::error::apt-get could not install git after three attempts"
-          exit 1
       - uses: actions/checkout@v6
+      - name: Load the candidate image
+        if: needs.build-image-candidate.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: ml4t-candidate-image
+          path: /tmp
+      # Not a `container:` on the job, because that is resolved before any step
+      # runs and so cannot name an image this run produced. Running the same two
+      # commands through `docker run` is what lets one required job measure either
+      # image, which keeps the check name stable for branch protection.
+      - name: Which image this commit is measured in
+        id: image
+        run: |
+          if [ -f /tmp/ml4t-candidate.tar ]; then
+            docker load -i /tmp/ml4t-candidate.tar
+            ref=ml4t/ml4t:candidate
+            echo "::notice::measuring in an image built from this commit"
+          else
+            ref=ml4t/ml4t:latest
+            docker pull "$ref"
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
       # The image is built from uv.lock and drifts from it silently the moment the
       # lock moves. It carried ml4t-models 0.1.0a4 for eleven days after the repo
       # declared >=0.1.0a6, so public CI measured a dependency set the repository
@@ -1084,23 +1171,28 @@ jobs:
       # if it passes: a green job in a drifted image is not evidence of green under
       # the declared lock.
       - name: The image's installed distributions match uv.lock
-        run: python .github/scripts/check_env_matches_lock.py
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" -w "$GITHUB_WORKSPACE" \
+            ${{ steps.image.outputs.ref }} \
+            python .github/scripts/check_env_matches_lock.py
       - name: Run modelling-environment unit tests
-        env:
-          PYTHONPATH: ${{ github.workspace }}
-          ML4T_PATH: ${{ github.workspace }}
-          ML4T_DATA_PATH: ${{ github.workspace }}/data
-          MPLBACKEND: Agg
         run: |
           # utils.config requires a .env to exist and validates ML4T_DATA_PATH at
           # import, the same as test-unit's steps.
           printf 'ML4T_PATH=%s\nML4T_DATA_PATH=%s/data\n' \
             "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" > .env
-          # Same reason as test-unit's sweep: the workflow-level ML4T_OUTPUT_DIR
-          # redirects every get_case_study_dir() call at a directory this job
-          # does not seed.
-          unset ML4T_OUTPUT_DIR
-          python -m pytest \
+          # ML4T_OUTPUT_DIR is deliberately not passed in: same reason as
+          # test-unit's sweep, the workflow-level value redirects every
+          # get_case_study_dir() call at a directory this job does not seed.
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" -w "$GITHUB_WORKSPACE" \
+            -e "PYTHONPATH=$GITHUB_WORKSPACE" \
+            -e "ML4T_PATH=$GITHUB_WORKSPACE" \
+            -e "ML4T_DATA_PATH=$GITHUB_WORKSPACE/data" \
+            -e MPLBACKEND=Agg \
+            ${{ steps.image.outputs.ref }} \
+            python -m pytest \
             tests/test_crypto_modeling_lineage.py \
             tests/test_common_sample_daily_ic.py \
             tests/test_cv_cached_results.py \

--- a/tests/test_image_rebuild_triggers.py
+++ b/tests/test_image_rebuild_triggers.py
@@ -19,11 +19,18 @@ builds run on a push to `main`. That list is the thing that goes stale next: a
 Dockerfile that starts reading a new dependency manifest, with nothing added to
 the filter, reintroduces the same outage in a form no one is looking for.
 
-So this derives the answer from the Dockerfiles rather than restating the
-workflow. Every path a Dockerfile copies out of the build context to decide what
-gets installed - a lock or a dependency manifest - must appear in that image's
-filter, along with the Dockerfile itself. It fails on the edit that adds the
-manifest, not on the release that discovers it.
+Rebuilding after merge is only half of it, and on its own it is the wrong half.
+A pull request that changes the lock cannot pass the guard either: the published
+image can only be built from a lock that has landed, and the lock cannot land
+without the check that needs the rebuild. So `test.yml` builds a candidate image
+from the commit under test whenever those same inputs move, and `test-unit-image`
+measures in that instead of in `latest`.
+
+Both halves read the same list, and this derives it from the Dockerfiles rather
+than restating either workflow. Every path a Dockerfile copies out of the build
+context to decide what gets installed - a lock or a dependency manifest - must
+appear in that image's filter, along with the Dockerfile itself. It fails on the
+edit that adds the manifest, not on the release that discovers it.
 """
 
 from __future__ import annotations
@@ -37,6 +44,7 @@ yaml = pytest.importorskip("yaml")
 
 REPO_ROOT = Path(__file__).parent.parent
 WORKFLOW = REPO_ROOT / ".github/workflows/docker-publish.yml"
+TEST_WORKFLOW = REPO_ROOT / ".github/workflows/test.yml"
 
 # Filter name in the `changes` job -> the Dockerfile it builds. The names are the
 # workflow's own outputs, so a renamed job output fails here rather than silently
@@ -74,8 +82,8 @@ def _context_dependency_paths(dockerfile: Path) -> set[str]:
     return found
 
 
-def _filters() -> dict[str, list[str]]:
-    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+def _filters(workflow_path: Path = WORKFLOW) -> dict[str, list[str]]:
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
     step = next(
         s
         for s in workflow["jobs"]["changes"]["steps"]
@@ -142,4 +150,65 @@ def test_the_tag_trigger_is_not_path_filtered():
         assert "github.ref_type == 'tag'" in str(spec.get("if", "")), (
             f"{job} does not exempt a tag push from the `changes` filter, so a "
             "release tag would build nothing"
+        )
+
+
+def test_a_lock_change_measures_test_unit_image_in_a_candidate():
+    """The pre-merge half, and the reason a lock bump is mergeable at all.
+
+    `test-unit-image` is required and refuses to measure in an image that does not
+    match `uv.lock`. Rebuilding after merge does not help a pull request that
+    changes the lock: the published image can only be built from a lock that has
+    landed, and the lock cannot land without the check that needs the rebuild. So
+    the same inputs that stale `ml4t/ml4t:latest` must also make this workflow
+    build a candidate from the commit under test.
+    """
+    required = _context_dependency_paths(REPO_ROOT / IMAGES["ml4t"]) | {IMAGES["ml4t"].as_posix()}
+    declared = set(_filters(TEST_WORKFLOW).get("image-inputs", []))
+    missing = sorted(required - declared)
+
+    assert not missing, (
+        f"a change to {missing} moves what the image installs, but test.yml would still "
+        "measure test-unit-image in the published `latest`. Add "
+        f"{'them' if len(missing) > 1 else 'it'} to the `image-inputs` filter, or that "
+        "pull request cannot pass a required check and cannot merge."
+    )
+
+
+def test_the_candidate_build_never_publishes():
+    """A pull request's image must not be able to move a published tag.
+
+    The candidate exists to be measured, not to ship: anyone can open a pull
+    request, and a build step that pushed would let one replace the image every
+    other job in the repository trusts.
+    """
+    workflow = yaml.safe_load(TEST_WORKFLOW.read_text(encoding="utf-8"))
+    build = workflow["jobs"]["build-image-candidate"]
+
+    for step in build["steps"]:
+        with_ = step.get("with") or {}
+        assert not with_.get("push"), f"{step.get('name')} pushes the candidate image"
+        assert "push=true" not in str(with_.get("outputs", "")), (
+            f"{step.get('name')} pushes the candidate image by digest"
+        )
+        assert not str(step.get("uses", "")).startswith("docker/login-action"), (
+            "the candidate build authenticates to a registry, so it can publish"
+        )
+
+
+def test_a_failed_candidate_does_not_fall_back_to_latest():
+    """The failure mode that would make the whole thing decorative.
+
+    `test-unit-image` runs under `always()` so a skipped candidate still lets it
+    measure in `latest`, which is correct for the commits that change nothing. A
+    candidate that failed is different: falling through to `latest` there would
+    green a lock bump against the environment it is replacing.
+    """
+    workflow = yaml.safe_load(TEST_WORKFLOW.read_text(encoding="utf-8"))
+    condition = str(workflow["jobs"]["test-unit-image"]["if"])
+
+    for result in ("failure", "cancelled"):
+        assert f"needs.build-image-candidate.result != '{result}'" in condition, (
+            f"test-unit-image runs after a {result} candidate build, and would measure "
+            "the lock bump in the image it is meant to replace"
         )

--- a/tests/test_image_rebuild_triggers.py
+++ b/tests/test_image_rebuild_triggers.py
@@ -196,19 +196,41 @@ def test_the_candidate_build_never_publishes():
         )
 
 
-def test_a_failed_candidate_does_not_fall_back_to_latest():
+def test_a_broken_candidate_fails_the_required_check():
     """The failure mode that would make the whole thing decorative.
 
-    `test-unit-image` runs under `always()` so a skipped candidate still lets it
-    measure in `latest`, which is correct for the commits that change nothing. A
-    candidate that failed is different: falling through to `latest` there would
-    green a lock bump against the environment it is replacing.
+    A skipped job counts as a satisfied required check. So excluding a failed
+    candidate in the job's own `if` - the obvious way to write "do not fall back
+    to `latest`" - would skip `test-unit-image` exactly when the image could not
+    be built, and a lock bump whose image is broken would become mergeable with
+    the image tests never having run.
+
+    The job therefore runs unconditionally and a step turns a broken candidate
+    into a red check. `build-image-candidate` itself is not in the required set,
+    so this step is the only thing standing between a failed build and a green
+    pull request.
     """
     workflow = yaml.safe_load(TEST_WORKFLOW.read_text(encoding="utf-8"))
-    condition = str(workflow["jobs"]["test-unit-image"]["if"])
+    job = workflow["jobs"]["test-unit-image"]
 
-    for result in ("failure", "cancelled"):
-        assert f"needs.build-image-candidate.result != '{result}'" in condition, (
-            f"test-unit-image runs after a {result} candidate build, and would measure "
-            "the lock bump in the image it is meant to replace"
-        )
+    assert str(job["if"]).strip() == "always()", (
+        "test-unit-image must run unconditionally: any other condition can skip it, "
+        "and a skipped required check is reported as satisfied"
+    )
+
+    guard = next(
+        (
+            step
+            for step in job["steps"]
+            if "needs.build-image-candidate.result == 'failure'" in str(step.get("if", ""))
+        ),
+        None,
+    )
+    assert guard is not None, (
+        "nothing fails test-unit-image when the candidate build fails, so a lock bump "
+        "whose image does not build would pass the check that exists to measure it"
+    )
+    assert "cancelled" in str(guard["if"]), (
+        "the guard ignores a cancelled candidate build, which leaves the same hole"
+    )
+    assert "exit 1" in str(guard.get("run", "")), f"{guard.get('name')} does not fail the job"

--- a/tests/test_image_rebuild_triggers.py
+++ b/tests/test_image_rebuild_triggers.py
@@ -1,0 +1,145 @@
+"""A file that decides what an image installs must also rebuild that image.
+
+`test-unit-image` is required and runs the repository's tests inside
+`ml4t/ml4t:latest`. Its first step, `.github/scripts/check_env_matches_lock.py`,
+refuses to measure anything in an environment that does not match `uv.lock` -
+correctly, because a green job in a drifted image is not evidence about the
+commit under test.
+
+Until 2026-09-05 nothing rebuilt the published images when the lock moved:
+`.github/workflows/docker-publish.yml` ran on a `v3.*` tag or a manual dispatch
+and on nothing else. A lock bump therefore staled `ml4t/ml4t:latest`, the guard
+refused it, and `main` plus every open pull request went red until someone
+dispatched a rebuild by hand. The gap was not in the guard, which did exactly
+what it exists to do; it was that a lock bump could not trigger the rebuild that
+would have kept the guard satisfiable.
+
+The trigger is now a `changes` job whose per-image path filters decide which
+builds run on a push to `main`. That list is the thing that goes stale next: a
+Dockerfile that starts reading a new dependency manifest, with nothing added to
+the filter, reintroduces the same outage in a form no one is looking for.
+
+So this derives the answer from the Dockerfiles rather than restating the
+workflow. Every path a Dockerfile copies out of the build context to decide what
+gets installed - a lock or a dependency manifest - must appear in that image's
+filter, along with the Dockerfile itself. It fails on the edit that adds the
+manifest, not on the release that discovers it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).parent.parent
+WORKFLOW = REPO_ROOT / ".github/workflows/docker-publish.yml"
+
+# Filter name in the `changes` job -> the Dockerfile it builds. The names are the
+# workflow's own outputs, so a renamed job output fails here rather than silently
+# leaving an image unfiltered.
+IMAGES = {
+    "ml4t": Path("envs/ml4t/Dockerfile"),
+    "py312": Path("envs/py312/Dockerfile"),
+    "benchmark": Path("envs/benchmark/Dockerfile"),
+}
+
+# What "decides what gets installed" means, concretely: a lock, or a manifest the
+# resolve reads. A kernel.json or a test script is copied into the image without
+# changing a single installed distribution, and rebuilding for one would mean a
+# multi-arch build on every unrelated edit.
+DEPENDENCY_SUFFIXES = (".lock", ".toml")
+
+
+def _context_dependency_paths(dockerfile: Path) -> set[str]:
+    """Repo-relative lock and manifest paths *dockerfile* copies from the build context.
+
+    `COPY --from=...` pulls from another stage or an external image rather than
+    from the repository, so those sources are not repo paths and cannot be
+    changed by a commit. Everything else on a `COPY` line except the final
+    destination is a context path.
+    """
+    found: set[str] = set()
+    for line in dockerfile.read_text(encoding="utf-8").splitlines():
+        if not re.match(r"^\s*COPY\b", line):
+            continue
+        parts = line.split()[1:]
+        if any(p.startswith("--from=") for p in parts):
+            continue
+        sources = [p for p in parts if not p.startswith("--")][:-1]
+        found.update(s for s in sources if s.endswith(DEPENDENCY_SUFFIXES))
+    return found
+
+
+def _filters() -> dict[str, list[str]]:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    step = next(
+        s
+        for s in workflow["jobs"]["changes"]["steps"]
+        if str(s.get("uses", "")).startswith("dorny/paths-filter")
+    )
+    return {name: list(paths) for name, paths in yaml.safe_load(step["with"]["filters"]).items()}
+
+
+@pytest.mark.parametrize("image", sorted(IMAGES))
+def test_every_dependency_input_rebuilds_its_image(image: str):
+    """The filter covers every lock and manifest the build actually reads."""
+    dockerfile = IMAGES[image]
+    filters = _filters()
+
+    assert image in filters, f"docker-publish.yml has no `{image}` path filter"
+    declared = set(filters[image])
+    required = _context_dependency_paths(REPO_ROOT / dockerfile) | {dockerfile.as_posix()}
+    missing = sorted(required - declared)
+
+    assert not missing, (
+        f"{dockerfile} reads {missing} to decide what it installs, but a change to "
+        f"{'them' if len(missing) > 1 else 'it'} does not rebuild `{image}`. Add "
+        f"{'them' if len(missing) > 1 else 'it'} to the `{image}` filter in "
+        "docker-publish.yml, or the image drifts from the lock and `test-unit-image` "
+        "goes red on main with no way to fix it but a manual dispatch."
+    )
+
+
+def test_a_push_to_main_can_trigger_a_build():
+    """The trigger the outage was missing.
+
+    Without a branch push in `on`, no lock bump reaches this workflow at all and
+    the per-image filters above have nothing to filter.
+    """
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    # PyYAML resolves the bare key `on` to the boolean True.
+    triggers = workflow.get("on") or workflow[True]
+
+    assert "main" in (triggers["push"].get("branches") or []), (
+        "docker-publish.yml does not run on a push to main, so nothing rebuilds the "
+        "published images when uv.lock moves"
+    )
+
+
+def test_the_tag_trigger_is_not_path_filtered():
+    """A release tag must build regardless of what its commit touched.
+
+    A `paths:` under `push` applies to the tag trigger as well as the branch one,
+    so filtering there would make `v3.x` build nothing whenever the tagged commit
+    happened not to touch a lock. The filtering belongs in the `changes` job,
+    which the build jobs consult only for a branch push.
+    """
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    triggers = workflow.get("on") or workflow[True]
+
+    assert "paths" not in triggers["push"], (
+        "a `paths:` filter under `push` also filters the `v3.*` tag trigger - "
+        "put the filtering in the `changes` job instead"
+    )
+
+    for job, spec in workflow["jobs"].items():
+        if not job.startswith("build-"):
+            continue
+        assert "github.ref_type == 'tag'" in str(spec.get("if", "")), (
+            f"{job} does not exempt a tag push from the `changes` filter, so a "
+            "release tag would build nothing"
+        )


### PR DESCRIPTION
`test-unit-image` is required and runs the suite inside `ml4t/ml4t:latest`. Its first step, `check_env_matches_lock.py`, refuses to measure anything in an image whose installed distributions do not match `uv.lock` — correctly, because a green job in a drifted image is not evidence about the commit under test.

Nothing kept that guard satisfiable. `docker-publish.yml` ran on a `v3.*` tag or a manual dispatch and on nothing else, and all three Dockerfiles derive their pinned constraint from the root `uv.lock`. So #740 moved five distributions and the published image kept the old five: `main` and every open PR went red until someone dispatched a rebuild by hand.

## Two halves, and the post-merge one alone is the wrong half

**After merge** — a push to `main` now reaches `docker-publish.yml`, and a `changes` job decides which images it staled. Not a `paths:` under `push`, which would filter the `v3.*` tag trigger too and make a release whose commit touched no lock build nothing; the build jobs exempt a tag and a manual dispatch explicitly.

**Before merge** — this is the half that matters more. With the guard in place, a PR that changes `uv.lock` could not pass a required check *at all*: the published image can only be built from a lock that has landed, and the lock cannot land without the check that needs the rebuild. #740 escaped only because its branch predated the guard and ran a workflow that did not carry it. The next lock bump would have been stuck before merge rather than after.

So a commit that moves the resolve now gets its own image. `build-image-candidate` builds `linux/amd64` from that tree into a tarball artifact — never pushing, never authenticating to a registry, so no pull request can move a tag anything else trusts — and `test-unit-image` loads it instead of pulling `latest`.

`test-unit-image` is no longer a job-level `container:`, because that is resolved before any step runs and so cannot name an image the same run produced. Both commands go through `docker run`, which keeps **one** required check measuring either image and so keeps the check name stable for branch protection.

## The two things RoboRev caught

1. Rebuilding only after merge left every lock-changing PR unmergeable. That is what the candidate build above is for.
2. Excluding a failed candidate in the job's `if` — the obvious way to write "do not fall back to `latest`" — **skips** `test-unit-image`, and GitHub counts a skipped required check as satisfied. A lock bump whose image would not build would have become mergeable with the image tests never running. The job now runs under a plain `always()` and a step turns a failed or cancelled candidate into a red check.

## Tests

`tests/test_image_rebuild_triggers.py` derives the required paths from the Dockerfiles rather than restating either workflow: every lock or manifest a build copies out of the context must appear in that image's filter, in both workflows. It fails on the commit that adds a manifest, not on the release that discovers it. Also asserts the candidate never publishes, and that a broken candidate reddens rather than skips.

Each assertion was verified to fail against the defect it describes (dropping `uv.lock` from the filter; softening the `exit 1`).

## Cost

18 commits in the last 60 days touch these paths. Everything else is unchanged: no candidate build, `latest` as before.

## Before merging

`force_image_candidate` was added to `workflow_dispatch` so the candidate path can be exercised deliberately — this PR touches no lock, so its own CI runs only the `latest` path. Worth one dispatched run on this branch before landing, since it changes a required check.

Closes ml4t/agent-workspace#1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQUuNRz572ohmUwscwmzp