### PR TITLE
The provenance stamp covers the outputs and the library, not just the .py

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -59,11 +59,19 @@ superseded result to reach ``main`` with every check green.
 
 ``outputs_digest`` answers "are these the outputs that run produced". A notebook
 whose ``.py`` is untouched passed the staleness check carrying outputs from any
-earlier run, which is what ``nbconvert --execute --inplace`` under ``nohup ... &``
-produces: it exits 0 without rewriting the notebook, so the stamp goes on the
-previous run's figures. Computed over the parsed structure with every
-``execution_count`` removed, so re-running to the same values, reformatting the
-JSON, or folding in a prose edit do not move it.
+earlier run. Computed over the parsed structure with every ``execution_count`` and
+every figure ``alt`` removed, so re-running to the same values, reformatting the
+JSON, folding in a prose edit and correcting alt text do not move it - the last
+because ``alt_text_only_drift`` already forgives that edit, on the proven grounds
+that re-executing cannot change the image.
+
+The digest is written from whatever is on disk at stamp time, so it cannot by
+itself catch a run that never wrote the file - ``nbconvert --execute --inplace``
+under ``nohup ... &`` exits 0 and does exactly that, and the resulting stamp agrees
+with itself forever. ``unwritten_run`` catches it at the only moment the state is
+still visible: the ``.py`` moved and the outputs are byte-identical to what the
+previous stamp recorded. ``--allow-unchanged-outputs`` answers it for a notebook
+genuinely deterministic enough that the change altered nothing it prints.
 
 ``library_digest`` answers "did this run use the code that is here now". The
 numbers in a case study are computed in ``case_studies/utils/*.py``, which
@@ -477,7 +485,7 @@ def outputs_digest(nb: dict) -> str:
     carries no output, so folding a prose edit into an executed notebook must not
     invalidate the record of the run.
     """
-    payload = [_without_execution_counts(c.get("outputs") or []) for c in _code_cells(nb)]
+    payload = [_normalized_outputs(c.get("outputs") or []) for c in _code_cells(nb)]
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
     ).hexdigest()
@@ -487,11 +495,24 @@ def _code_cells(nb: dict) -> list[dict]:
     return [c for c in nb.get("cells", []) if c.get("cell_type") == "code"]
 
 
-def _without_execution_counts(value: object) -> object:
+# Dropped before hashing. `execution_count` is the kernel's counter, renumbered by
+# every run and cleared by the metadata strippers, and it names no value the
+# notebook reports. `alt` is figure alt text, which `alt_text_only_drift` already
+# forgives in the `.py` on the proven grounds that re-executing cannot change the
+# image - and the workflow it forgives requires the matching output metadata to be
+# corrected too. Hashing the alt would make that documented correction read as a
+# changed result and price four rewritten sentences at a 90-minute re-run, which is
+# the cost the exception exists to remove.
+VOLATILE_OUTPUT_KEYS = frozenset({"execution_count", "alt"})
+
+
+def _normalized_outputs(value: object) -> object:
     if isinstance(value, dict):
-        return {k: _without_execution_counts(v) for k, v in value.items() if k != "execution_count"}
+        return {
+            k: _normalized_outputs(v) for k, v in value.items() if k not in VOLATILE_OUTPUT_KEYS
+        }
     if isinstance(value, list):
-        return [_without_execution_counts(v) for v in value]
+        return [_normalized_outputs(v) for v in value]
     return value
 
 
@@ -505,7 +526,11 @@ def _module_candidates(module: str, from_dir: Path) -> list[Path]:
     reason a chapter's ``async_utils`` is importable at all.
     """
     parts = module.split(".")
-    roots = [REPO_ROOT] if len(parts) > 1 else [from_dir, REPO_ROOT]
+    # Both roots for a dotted name too. `17_portfolio_construction/deepm/` is a real
+    # package inside a chapter directory, so `import deepm.model` resolves against
+    # the chapter, not the repo root - and searching only the root left the code
+    # that computes that chapter's allocations out of the digest entirely.
+    roots = [from_dir, REPO_ROOT]
     out: list[Path] = []
     for root in roots:
         base = root.joinpath(*parts)
@@ -865,12 +890,50 @@ def contradicts_injected_cell(nb: dict, parameters: dict[str, object]) -> str | 
     )
 
 
+def unwritten_run(nb: dict, py: Path) -> str | None:
+    """Why this stamp would record a run that never rewrote the notebook, or None.
+
+    The digests are computed from whatever is in the file at stamp time, so a run
+    that exited without writing leaves the previous run's outputs to be recorded as
+    the new ones - and every later check agrees with itself. That is the failure
+    that motivates the outputs digest, and only this refusal catches it, because
+    afterwards there is nothing left to disagree.
+
+    The signal is a source change with no corresponding output change: the previous
+    stamp says the notebook was executed from a different ``.py``, and the outputs
+    are byte-identical to what that older run produced. ``nbconvert --execute
+    --inplace`` under ``nohup ... &`` exits 0 and leaves exactly that state.
+
+    Silent when there is no previous stamp to compare against, and when the ``.py``
+    has not moved - re-running unchanged source to the same values is a normal
+    thing to do and says nothing about whether the file was written.
+    """
+    previous = nb.get("metadata", {}).get(STAMP_KEY) or {}
+    recorded = previous.get("outputs_digest")
+    if recorded is None:
+        return None
+    if previous.get("source_py_blob") == git_blob(py):
+        return None
+    if recorded != outputs_digest(nb):
+        return None
+    return (
+        "the .py has changed since the last stamp, but the outputs are exactly the "
+        "ones the previous run produced. A run that changed the source and changed "
+        "no output almost always means the execution never wrote this file - "
+        "`nbconvert --execute --inplace` in the background exits 0 and does that. "
+        "Re-execute and check the outputs moved. If this notebook really is "
+        "deterministic enough that the change altered nothing it prints, pass "
+        "--allow-unchanged-outputs to say so."
+    )
+
+
 def stamp_notebook(
     nb_path: Path,
     executor: str,
     notes: str | None = None,
     *,
     parameters: dict[str, object],
+    allow_unchanged_outputs: bool = False,
 ) -> dict:
     """Record how this notebook was executed.
 
@@ -898,6 +961,8 @@ def stamp_notebook(
             "output or an execution count, so nothing in it was executed. A stamp on this "
             "would claim a run that left no trace. Execute it, or leave it cleared."
         )
+    if not allow_unchanged_outputs and (reason := unwritten_run(nb, py)):
+        raise SystemExit(f"refusing to stamp {nb_path.relative_to(REPO_ROOT)}: {reason}")
     stamp = {
         "source_py_blob": git_blob(py),
         # What the run produced, and the repository code that produced it. Neither is
@@ -1355,7 +1420,11 @@ def _cmd_stamp(args: argparse.Namespace) -> int:
         if not isinstance(parameters, dict):
             raise SystemExit("--parameters must be a JSON object of override name to value")
     s = stamp_notebook(
-        Path(args.notebook).resolve(), args.executor, args.notes, parameters=parameters
+        Path(args.notebook).resolve(),
+        args.executor,
+        args.notes,
+        parameters=parameters,
+        allow_unchanged_outputs=args.allow_unchanged_outputs,
     )
     print(
         f"stamped {args.notebook}: source_py_blob={s['source_py_blob'][:12]} "
@@ -1543,6 +1612,14 @@ def main() -> int:
     sp.add_argument("notebook")
     sp.add_argument("--executor", required=True, help="environment label, e.g. ml4t-gpu / local-uv")
     sp.add_argument("--notes", default=None)
+    sp.add_argument(
+        "--allow-unchanged-outputs",
+        action="store_true",
+        help=(
+            "stamp even though the .py moved and the outputs did not - for a notebook "
+            "genuinely deterministic enough that the change altered nothing it prints"
+        ),
+    )
     # The executor states the parameters; the tool does not infer them from
     # notebook metadata written by a different process. See the module docstring.
     params = sp.add_mutually_exclusive_group(required=True)

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -10,6 +10,8 @@ caught mechanically instead of by review.
 The stamp lives in ``nb.metadata["ml4t_provenance"]``::
 
     source_py_blob : git blob hash of the paired .py at execution time
+    outputs_digest : digest over the outputs the run left in the notebook
+    library_digest : digest over the repository code the paired .py imports
     executed_at    : ISO-8601 timestamp
     executor       : environment label (e.g. "ml4t-gpu", "local-uv")
     production     : bool — True iff overrides preserve the full production surface
@@ -48,10 +50,42 @@ refuses to write a stamp that contradicts it. Stamping also rewrites
 ``metadata.papermill.parameters`` to the declared set, so the fossil cannot
 outlive the stamp and disagree with it later.
 
+What the three digests each answer, because they are easy to confuse
+--------------------------------------------------------------------
+
+``source_py_blob`` answers "has the paired ``.py`` changed since somebody stamped
+this". For a long time that was the whole gate, and it left two ways for a
+superseded result to reach ``main`` with every check green.
+
+``outputs_digest`` answers "are these the outputs that run produced". A notebook
+whose ``.py`` is untouched passed the staleness check carrying outputs from any
+earlier run, which is what ``nbconvert --execute --inplace`` under ``nohup ... &``
+produces: it exits 0 without rewriting the notebook, so the stamp goes on the
+previous run's figures. Computed over the parsed structure with every
+``execution_count`` removed, so re-running to the same values, reformatting the
+JSON, or folding in a prose edit do not move it.
+
+``library_digest`` answers "did this run use the code that is here now". The
+numbers in a case study are computed in ``case_studies/utils/*.py``, which
+``source_py_blob`` never covered: #606 changed ``causal.py`` under all nine case
+studies at once and the committed stamps went on claiming runs whose outputs
+described code no longer in the tree. It digests the repository files the paired
+``.py`` imports transitively, keyed by path as well as content.
+
 Gate (``check``): for every tracked ``.ipynb`` that HAS a stamp,
 
 * ``source_py_blob`` must equal ``git hash-object`` of the current paired ``.py``
   (else the ``.py`` changed since the notebook was executed — STALE),
+* ``outputs_digest``, where the stamp records one, must match the notebook's
+  current outputs (else the stored results are not the ones the stamped run
+  produced — OUTPUTS CHANGED),
+* ``library_digest``, where the stamp records one, is compared and *reported*
+  rather than failed (LIBRARY DRIFT). Failing it would block at least five
+  notebooks across three case studies on the day it lands, and that is a separate
+  decision from being able to see the drift at all,
+* a stamp carrying neither digest predates them both and is counted, not failed:
+  every stamp written before they existed lacks them, and none of those notebooks
+  has the defect the fields exist to catch,
 * ``production`` must be True (else a TEST-mode run was committed),
 * some code cell must show it ran - an output or an execution count (else the stamp
   is over a render nothing produced — HOLLOW), and
@@ -102,6 +136,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import hashlib
 import json
 import re
 import subprocess
@@ -109,6 +144,7 @@ import sys
 from datetime import UTC, datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
+from typing import NamedTuple
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKIP_PARTS = {"_reference", ".venv", ".git", ".ipynb_checkpoints"}
@@ -420,6 +456,143 @@ def git_blob(path: Path) -> str:
     ).stdout.strip()
 
 
+def outputs_digest(nb: dict) -> str:
+    """A digest over the outputs this notebook stores, in cell order.
+
+    ``source_py_blob`` answers "has the ``.py`` changed since somebody stamped
+    this", which is not the same question as "did these outputs come from that
+    run". A notebook whose ``.py`` is untouched passes the stale check carrying
+    outputs from any earlier run - including a superseded one - and that is a real
+    path a stale result took to ``main``: ``nbconvert --execute --inplace`` under
+    ``nohup ... &`` exits 0 without rewriting the notebook, so the agent stamps a
+    file that still holds the previous run's outputs.
+
+    Computed over the parsed structure rather than the file's bytes, so
+    reformatting, a re-indent or a different ``json.dumps`` cannot move it. Every
+    ``execution_count`` is dropped: the kernel renumbers those on each run and
+    ``strip_papermill_cell_metadata`` and friends may clear them, and neither
+    changes a single value the notebook reports.
+
+    Markdown cells are excluded for the same reason ``sync-prose`` exists: prose
+    carries no output, so folding a prose edit into an executed notebook must not
+    invalidate the record of the run.
+    """
+    payload = [_without_execution_counts(c.get("outputs") or []) for c in _code_cells(nb)]
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+
+
+def _code_cells(nb: dict) -> list[dict]:
+    return [c for c in nb.get("cells", []) if c.get("cell_type") == "code"]
+
+
+def _without_execution_counts(value: object) -> object:
+    if isinstance(value, dict):
+        return {k: _without_execution_counts(v) for k, v in value.items() if k != "execution_count"}
+    if isinstance(value, list):
+        return [_without_execution_counts(v) for v in value]
+    return value
+
+
+def _module_candidates(module: str, from_dir: Path) -> list[Path]:
+    """Where a repo-local ``module`` could live, most specific first.
+
+    Two roots, because the repository has two import mechanisms. Dotted names
+    resolve from the repo root (``case_studies.utils.causal``). A bare name also
+    resolves from the importing file's own directory, because ``sitecustomize``
+    appends every ``NN_*`` chapter directory to ``sys.path`` - which is the only
+    reason a chapter's ``async_utils`` is importable at all.
+    """
+    parts = module.split(".")
+    roots = [REPO_ROOT] if len(parts) > 1 else [from_dir, REPO_ROOT]
+    out: list[Path] = []
+    for root in roots:
+        base = root.joinpath(*parts)
+        out += [base.with_suffix(".py"), base / "__init__.py"]
+    return out
+
+
+def _imported_modules(tree: ast.AST, py: Path) -> set[str]:
+    """Module names *py* imports, with relative imports resolved to dotted names."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                # `from . import x` inside case_studies/utils/ is case_studies.utils.x
+                package = py.resolve().parent
+                for _ in range(node.level - 1):
+                    package = package.parent
+                try:
+                    prefix = ".".join(package.relative_to(REPO_ROOT).parts)
+                except ValueError:
+                    continue
+                base = f"{prefix}.{node.module}" if node.module else prefix
+            else:
+                base = node.module or ""
+            if not base:
+                continue
+            names.add(base)
+            # `from case_studies.utils import causal` names the module in the alias,
+            # not in `node.module`, and that alias is the file that changed.
+            names.update(f"{base}.{a.name}" for a in node.names if a.name != "*")
+    return names
+
+
+def repo_local_sources(py: Path) -> list[Path]:
+    """Every repository file *py* imports, transitively, sorted repo-relative.
+
+    The numbers in a case-study notebook are computed in ``case_studies/utils/*.py``,
+    which ``source_py_blob`` does not cover. #606 changed ``causal.py`` under all
+    nine case studies at once, and the committed stamps went on claiming runs whose
+    outputs described code no longer in the tree - ``analysis_rows`` 88695 -> 88633
+    among them. Nothing in the repository could answer "did this run use the code
+    that is here now", and that absence was the finding.
+
+    Best effort by construction: a module reached through ``importlib``, a plugin
+    registry or a string name is invisible to ``ast``. It covers the import graph,
+    which is where the case-study helpers are.
+    """
+    seen: set[Path] = set()
+    queue = [py.resolve()]
+    while queue:
+        current = queue.pop()
+        if current in seen or not current.is_file():
+            continue
+        seen.add(current)
+        try:
+            tree = ast.parse(current.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+        for module in _imported_modules(tree, current):
+            for candidate in _module_candidates(module, current.parent):
+                if candidate.is_file():
+                    queue.append(candidate.resolve())
+                    break
+    return sorted(p for p in seen - {py.resolve()} if _within_repo(p))
+
+
+def _within_repo(path: Path) -> bool:
+    try:
+        path.relative_to(REPO_ROOT)
+    except ValueError:
+        return False
+    return SKIP_PARTS.isdisjoint(path.parts)
+
+
+def library_digest(py: Path) -> str:
+    """A digest over the repository code *py* imports, transitively.
+
+    Keyed by path as well as content, so moving a module is drift too. An empty
+    import graph still has a digest, which keeps "no repo-local imports" distinct
+    from "not recorded".
+    """
+    lines = [f"{p.relative_to(REPO_ROOT).as_posix()}:{git_blob(p)}" for p in repo_local_sources(py)]
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
 ALT_FUNCS = frozenset({"show_with_alt", "show_plotly_with_alt"})
 
 
@@ -727,6 +900,13 @@ def stamp_notebook(
         )
     stamp = {
         "source_py_blob": git_blob(py),
+        # What the run produced, and the repository code that produced it. Neither is
+        # covered by source_py_blob, and each was a way a superseded result reached
+        # main with every check green: outputs from an earlier run under an untouched
+        # .py, and outputs computed by a case_studies/utils module that has since
+        # moved. See outputs_digest and library_digest.
+        "outputs_digest": outputs_digest(nb),
+        "library_digest": library_digest(py),
         "executed_at": datetime.now(UTC).isoformat(),
         "executor": executor,
         "production": production_parameters(parameters),
@@ -878,15 +1058,44 @@ def destamped(ref: str | None = None, only: set[str] | None = None) -> list[str]
     )
 
 
+class CheckResult(NamedTuple):
+    """The gate's verdicts, one list of repo-relative notebooks each.
+
+    A ``NamedTuple`` rather than a dataclass because callers iterate it - "no
+    category may name a notebook outside ``only``" is asserted by looping over the
+    result - and unpack it positionally.
+    """
+
+    stale: list[str]
+    testmode: list[str]
+    contradicted: list[str]
+    unverified: list[str]
+    alt_only: list[str]
+    hollow: list[str]
+    outputs_changed: list[str]
+    library_drift: list[str]
+    # Stamped before the two digests existed, so neither can be checked. Reported as
+    # a count rather than failed: every stamp predating them lacks both, and failing
+    # those would turn every branch red at once for a defect none of them has.
+    undigested: list[str]
+
+
 def check_all(
     strict: bool = False,
     only: set[str] | None = None,
-) -> tuple[list[str], list[str], list[str], list[str], list[str], list[str]]:
-    """Return (stale, testmode, contradicted, unverified, alt_only, hollow) rows.
+) -> CheckResult:
+    """Return the gate's verdicts over the tracked notebooks.
 
-    ``stale``, ``testmode``, ``contradicted`` and ``hollow`` fail. ``alt_only`` is reported so that forgiving a drift is
-    never silent: a notebook in that list has a ``.py`` that no longer matches its
-    stamp, and the reason it is allowed is printed rather than assumed.
+    ``stale``, ``testmode``, ``contradicted``, ``hollow`` and ``outputs_changed``
+    fail. ``alt_only``, ``library_drift`` and ``undigested`` are reported so that
+    forgiving a drift is never silent: a notebook in one of those lists has
+    something that no longer matches its stamp, and the reason it is allowed is
+    printed rather than assumed.
+
+    ``library_drift`` is deliberately not a failure yet. On the measurement in
+    ml4t/agent-workspace#917 it would immediately block at least five notebooks
+    across three case studies, and turning it into a hard failure is a separate
+    decision from being able to see it at all.
 
     ``only`` restricts the scan to the notebooks whose ``.ipynb`` or paired ``.py``
     is in that set of repo-relative paths. The pre-commit gate passes the staged
@@ -901,6 +1110,9 @@ def check_all(
     unverified: list[str] = []
     alt_only: list[str] = []
     hollow: list[str] = []
+    outputs_changed: list[str] = []
+    library_drift: list[str] = []
+    undigested: list[str] = []
     for nb_path in iter_notebooks():
         rel = str(nb_path.relative_to(REPO_ROOT))
         py = paired_py(nb_path)
@@ -929,7 +1141,26 @@ def check_all(
             contradicted.append(f"{rel} ({conflict})")
         if not was_executed(nb):
             hollow.append(rel)
-    return stale, testmode, contradicted, unverified, alt_only, hollow
+        stamped_outputs = stamp.get("outputs_digest")
+        stamped_library = stamp.get("library_digest")
+        if stamped_outputs is None and stamped_library is None:
+            undigested.append(rel)
+        else:
+            if stamped_outputs is not None and stamped_outputs != outputs_digest(nb):
+                outputs_changed.append(rel)
+            if stamped_library is not None and stamped_library != library_digest(py):
+                library_drift.append(rel)
+    return CheckResult(
+        stale,
+        testmode,
+        contradicted,
+        unverified,
+        alt_only,
+        hollow,
+        outputs_changed,
+        library_drift,
+        undigested,
+    )
 
 
 def code_cells_only(comparable: list[tuple] | None) -> list[tuple] | None:
@@ -1193,13 +1424,13 @@ def _cmd_check(args: argparse.Namespace) -> int:
             for nb in scope:
                 print(f"  {nb.relative_to(REPO_ROOT)}")
             print()
-    stale, testmode, contradicted, unverified, alt_only, hollow = check_all(
-        strict=args.strict, only=only
-    )
+    result = check_all(strict=args.strict, only=only)
+    stale, testmode, contradicted, unverified, alt_only, hollow = result[:6]
+    outputs_changed, library_drift, undigested = result[6:]
     lost = destamped(ref=since_ref, only=only)
-    fail = bool(stale or testmode or contradicted or lost or hollow or orphaned) or (
-        args.strict and bool(unverified)
-    )
+    fail = bool(
+        stale or testmode or contradicted or lost or hollow or orphaned or outputs_changed
+    ) or (args.strict and bool(unverified))
     if orphaned:
         print(
             "ORPHANED (the paired .py was deleted but the rendered .ipynb was kept — "
@@ -1260,12 +1491,28 @@ def _cmd_check(args: argparse.Namespace) -> int:
         )
         for r in contradicted:
             print(f"  {r}")
+    if outputs_changed:
+        print(
+            "OUTPUTS CHANGED (the stored outputs are not the ones the stamped run "
+            "produced — the notebook was edited, or a run exited without rewriting it; "
+            "re-execute and re-stamp, or clear it):"
+        )
+        for r in outputs_changed:
+            print(f"  {r}")
     if alt_only:
         print(
             "ALT-TEXT ONLY (the .py drifted from its stamp only in figure alt text the "
             "outputs already carry, so re-executing could not change them — allowed):"
         )
         for r in alt_only:
+            print(f"  {r}")
+    if library_drift:
+        print(
+            "LIBRARY DRIFT (repository code this notebook imports has moved since it "
+            "was executed, so its outputs may describe code no longer in the tree — "
+            "advisory, re-run when the numbers matter):"
+        )
+        for r in library_drift:
             print(f"  {r}")
     if unverified:
         verb = "UNVERIFIED (no provenance stamp"
@@ -1279,6 +1526,8 @@ def _cmd_check(args: argparse.Namespace) -> int:
         print(
             f"notebook sync OK: {len(stale)} stale, {len(testmode)} test-mode, "
             f"{len(contradicted)} contradicted, {len(alt_only)} alt-text-only, "
+            f"{len(outputs_changed)} outputs-changed, {len(library_drift)} library-drift "
+            f"(advisory), {len(undigested)} stamped before the digests existed, "
             f"{len(unverified)} unverified (advisory)"
         )
     return 1 if fail else 0

--- a/tests/test_notebook_provenance_digests.py
+++ b/tests/test_notebook_provenance_digests.py
@@ -1,0 +1,346 @@
+"""The stamp records what the run produced, and the code that produced it.
+
+`source_py_blob` answers one question: has the paired `.py` changed since somebody
+stamped this notebook. Two things a reader sees are outside it.
+
+**The outputs.** A notebook whose `.py` is untouched passes the staleness check
+carrying outputs from any earlier run. That is a path a superseded result actually
+took: `nbconvert --execute --inplace` under `nohup ... &` exits 0 without rewriting
+the notebook, so the stamp goes on a file still holding the previous run's figures,
+and every check in the repository passes it.
+
+**The library.** The numbers in a case study are computed in `case_studies/utils/*.py`,
+which the stamp never covered. #606 changed `causal.py` under all nine case studies at
+once; `cme_futures` found by hand that its committed outputs described code no longer in
+the tree - `analysis_rows` 88695 -> 88633 on `fwd_ret_5d`, and every `request_hash` with
+it. Nothing in the repository could answer "did this run use the code that is here now".
+
+Both are recorded at stamp time and recomputed by `check`. The outputs digest fails the
+gate, because a mismatch means the notebook is not the run it claims. The library digest
+is reported and does not fail: on the measurement in #917 it would block at least five
+notebooks across three case studies on the day it landed, and turning it into a failure
+is a separate decision from being able to see it.
+
+A stamp written before either field existed has neither, and is counted rather than
+failed - 423 of them at the time this landed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / ".github" / "scripts"))
+
+import notebook_provenance  # noqa: E402
+from notebook_provenance import (  # noqa: E402
+    check_all,
+    library_digest,
+    outputs_digest,
+    repo_local_sources,
+    stamp_notebook,
+)
+
+
+def _code_cell(source: str, outputs: list[dict], execution_count: int | None = 1) -> dict:
+    return {
+        "cell_type": "code",
+        "metadata": {},
+        "source": source,
+        "outputs": outputs,
+        "execution_count": execution_count,
+    }
+
+
+def _stream(text: str) -> dict:
+    return {"output_type": "stream", "name": "stdout", "text": [text]}
+
+
+def _notebook(cells: list[dict]) -> dict:
+    return {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+# -----------------------------------------------------------------------------
+# outputs_digest
+# -----------------------------------------------------------------------------
+
+
+def test_a_changed_output_changes_the_digest():
+    """The whole point: the stored result is part of what the stamp covers."""
+    before = _notebook([_code_cell("print(sharpe)", [_stream("0.81\n")])])
+    after = _notebook([_code_cell("print(sharpe)", [_stream("0.42\n")])])
+
+    assert outputs_digest(before) != outputs_digest(after)
+
+
+def test_re_running_the_same_cells_renumbers_without_moving_the_digest():
+    """`execution_count` is the kernel's counter, not a result.
+
+    A notebook re-executed to the same values must keep its digest, or every
+    re-run would read as a changed result and the class would be noise.
+    """
+    outputs = [_stream("0.81\n")]
+    first = _notebook([_code_cell("print(sharpe)", outputs, execution_count=1)])
+    second = _notebook([_code_cell("print(sharpe)", outputs, execution_count=7)])
+
+    assert outputs_digest(first) == outputs_digest(second)
+
+
+def test_an_execution_count_inside_an_output_is_ignored_too():
+    """`execute_result` carries its own counter, nested one level down."""
+    result = {"output_type": "execute_result", "data": {"text/plain": ["3"]}}
+    first = _notebook([_code_cell("1 + 2", [{**result, "execution_count": 1}])])
+    second = _notebook([_code_cell("1 + 2", [{**result, "execution_count": 9}])])
+
+    assert outputs_digest(first) == outputs_digest(second)
+
+
+def test_editing_prose_does_not_change_the_digest():
+    """`sync-prose` exists so a markdown edit costs no re-run; this keeps it true."""
+    code = _code_cell("print(sharpe)", [_stream("0.81\n")])
+    before = _notebook([{"cell_type": "markdown", "metadata": {}, "source": "## A"}, code])
+    after = _notebook([{"cell_type": "markdown", "metadata": {}, "source": "## B"}, code])
+
+    assert outputs_digest(before) == outputs_digest(after)
+
+
+def test_the_digest_is_over_the_parsed_notebook_not_its_bytes(tmp_path: Path):
+    """Reformatting the JSON must not read as a changed result."""
+    nb = _notebook([_code_cell("print(sharpe)", [_stream("0.81\n")])])
+    compact = json.loads(json.dumps(nb, separators=(",", ":")))
+    spaced = json.loads(json.dumps(nb, indent=4))
+
+    assert outputs_digest(compact) == outputs_digest(spaced)
+
+
+# -----------------------------------------------------------------------------
+# library_digest
+# -----------------------------------------------------------------------------
+
+
+def test_a_case_study_notebook_reaches_the_helpers_that_compute_its_numbers():
+    """The concrete case #917 was filed from.
+
+    `case_studies/utils/causal.py` is where a causal notebook's numbers come from,
+    and it is exactly what `source_py_blob` does not cover.
+    """
+    py = REPO_ROOT / "case_studies/etfs/12_causal_dml.py"
+    if not py.exists():
+        pytest.skip("the etfs causal notebook is not in this tree")
+
+    reached = {p.relative_to(REPO_ROOT).as_posix() for p in repo_local_sources(py)}
+
+    assert "case_studies/utils/causal.py" in reached
+
+
+def test_the_import_graph_is_transitive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A module the notebook imports indirectly still counts.
+
+    A one-level scan would miss `causal.py` entirely for any notebook that reaches
+    it through `case_studies/research/`, which is how most of them do.
+    """
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    (tmp_path / "leaf.py").write_text("VALUE = 1\n")
+    (tmp_path / "middle.py").write_text("import leaf\n")
+    entry = tmp_path / "entry.py"
+    entry.write_text("import middle\n")
+
+    reached = {p.name for p in repo_local_sources(entry)}
+
+    assert reached == {"middle.py", "leaf.py"}
+
+
+def test_a_module_imported_by_name_from_a_package_is_reached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """`from case_studies.utils import causal` names the module in the alias.
+
+    `node.module` is the package there, so resolving only that finds
+    `__init__.py` and stops - one short of the file that actually changed.
+    """
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "causal.py").write_text("EFFECT = 1\n")
+    entry = tmp_path / "entry.py"
+    entry.write_text("from pkg import causal\n")
+
+    reached = {p.relative_to(tmp_path).as_posix() for p in repo_local_sources(entry)}
+
+    assert "pkg/causal.py" in reached
+
+
+def test_an_installed_package_is_not_repo_code(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Third-party versions are uv.lock's business, and check_env_matches_lock's."""
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    entry = tmp_path / "entry.py"
+    entry.write_text("import json\nimport numpy as np\nfrom pathlib import Path\n")
+
+    assert repo_local_sources(entry) == []
+
+
+def test_moving_a_module_is_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The digest is keyed by path as well as content.
+
+    Two files with identical bytes at different paths are not the same import
+    graph, and a rename that changes what a notebook resolves must show.
+    """
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    (tmp_path / "helper.py").write_text("VALUE = 1\n")
+    entry = tmp_path / "entry.py"
+    entry.write_text("import helper\n")
+    before = library_digest(entry)
+
+    (tmp_path / "helper.py").rename(tmp_path / "renamed.py")
+    entry.write_text("import renamed\n")
+
+    assert library_digest(entry) != before
+
+
+def test_a_notebook_with_no_repo_imports_still_has_a_digest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """ "No repo-local imports" and "not recorded" must not look the same."""
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    entry = tmp_path / "entry.py"
+    entry.write_text("import json\n")
+
+    assert library_digest(entry)
+
+
+# -----------------------------------------------------------------------------
+# The gate
+# -----------------------------------------------------------------------------
+
+
+def _seed_stamped_pair(root: Path, source: str = "print(1)\n") -> tuple[Path, Path]:
+    py = root / "nb.py"
+    py.write_text(f"# %%\n{source}")
+    nb_path = root / "nb.ipynb"
+    nb_path.write_text(json.dumps(_notebook([_code_cell(source, [_stream("1\n")])])))
+    stamp_notebook(nb_path, executor="test", parameters={})
+    return py, nb_path
+
+
+def test_replacing_the_outputs_fails_the_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A stamped notebook holding outputs no run of it produced.
+
+    This is the `--execute --inplace` failure: the stamp claims a run, the `.py`
+    is untouched so the staleness check passes, and the figures are the previous
+    run's.
+    """
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(notebook_provenance, "iter_notebooks", lambda: [tmp_path / "nb.ipynb"])
+    _, nb_path = _seed_stamped_pair(tmp_path)
+    assert check_all().outputs_changed == []
+
+    nb = json.loads(nb_path.read_text())
+    nb["cells"][0]["outputs"] = [_stream("999\n")]
+    nb_path.write_text(json.dumps(nb))
+
+    result = check_all()
+    assert result.outputs_changed == ["nb.ipynb"]
+    assert result.stale == [], "the .py is untouched, which is the whole problem"
+
+
+def test_moving_an_imported_module_is_reported_but_does_not_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Library drift is named and printed, not enforced - #917's own sequencing."""
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(notebook_provenance, "iter_notebooks", lambda: [tmp_path / "nb.ipynb"])
+    (tmp_path / "helper.py").write_text("EFFECT = 1\n")
+    _seed_stamped_pair(tmp_path, source="import helper\nprint(helper.EFFECT)\n")
+    assert check_all().library_drift == []
+
+    (tmp_path / "helper.py").write_text("EFFECT = 2\n")
+
+    result = check_all()
+    assert result.library_drift == ["nb.ipynb"]
+    assert result.outputs_changed == [], "the stored outputs are untouched"
+    assert result.stale == [], "and so is the .py"
+
+
+def test_a_stamp_predating_the_digests_is_counted_not_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Every stamp written before this change lacks both fields.
+
+    Failing them would turn every branch red at once for a defect none of them
+    has. Counting them keeps the backfill visible instead.
+    """
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(notebook_provenance, "iter_notebooks", lambda: [tmp_path / "nb.ipynb"])
+    _, nb_path = _seed_stamped_pair(tmp_path)
+
+    nb = json.loads(nb_path.read_text())
+    stamp = nb["metadata"][notebook_provenance.STAMP_KEY]
+    del stamp["outputs_digest"]
+    del stamp["library_digest"]
+    nb["cells"][0]["outputs"] = [_stream("anything at all\n")]
+    nb_path.write_text(json.dumps(nb))
+
+    result = check_all()
+    assert result.undigested == ["nb.ipynb"]
+    assert result.outputs_changed == []
+    assert result.library_drift == []
+
+
+def test_stamping_records_both_digests(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    _, nb_path = _seed_stamped_pair(tmp_path)
+
+    stamp = json.loads(nb_path.read_text())["metadata"][notebook_provenance.STAMP_KEY]
+
+    assert stamp["outputs_digest"] and stamp["library_digest"]
+
+
+def test_folding_prose_in_keeps_the_outputs_digest_valid(tmp_path: Path, monkeypatch):
+    """`sync-prose` must stay free, which is the whole reason it exists.
+
+    It rewrites `source_py_blob` and keeps the executed outputs. If the outputs
+    digest did not survive that, every prose fold would be reported as a changed
+    result and the cheapest correction in the repository would cost a re-run
+    again - the exact cost sync-prose was built to remove.
+    """
+    import subprocess
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(notebook_provenance, "iter_notebooks", lambda: [tmp_path / "nb.ipynb"])
+
+    py = tmp_path / "nb.py"
+    py.write_text("# %% [markdown]\n# A paragraph.\n\n# %%\nprint(1)\n")
+    subprocess.run(
+        [sys.executable, "-m", "jupytext", "--to", "ipynb", "--output", "nb.ipynb", "nb.py"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    nb_path = tmp_path / "nb.ipynb"
+    nb = json.loads(nb_path.read_text())
+    for cell in nb["cells"]:
+        if cell["cell_type"] == "code":
+            cell["execution_count"] = 1
+            cell["outputs"] = [_stream("1\n")]
+    nb_path.write_text(json.dumps(nb, indent=1) + "\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    stamp_notebook(nb_path, executor="test", parameters={})
+    assert check_all().outputs_changed == []
+
+    py.write_text(
+        "# %% [markdown]\n# A rewritten paragraph, and a second sentence.\n\n# %%\nprint(1)\n"
+    )
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    notebook_provenance.sync_prose(nb_path)
+
+    result = check_all()
+    assert result.outputs_changed == []
+    assert result.stale == [], "sync-prose re-points the blob, so nothing is stale"

--- a/tests/test_notebook_provenance_digests.py
+++ b/tests/test_notebook_provenance_digests.py
@@ -344,3 +344,117 @@ def test_folding_prose_in_keeps_the_outputs_digest_valid(tmp_path: Path, monkeyp
     result = check_all()
     assert result.outputs_changed == []
     assert result.stale == [], "sync-prose re-points the blob, so nothing is stale"
+
+
+# -----------------------------------------------------------------------------
+# The failure the digest exists for, which only the stamp can catch
+# -----------------------------------------------------------------------------
+
+
+def test_stamping_a_run_that_never_wrote_the_notebook_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """`--execute --inplace` under `nohup ... &` exits 0 without rewriting the file.
+
+    The digests are computed from whatever is on disk at stamp time, so once such a
+    stamp is written every later check agrees with itself and nothing is left to
+    disagree. This refusal is the only place the state is still visible: the source
+    moved and the outputs are exactly the previous run's.
+    """
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    py, nb_path = _seed_stamped_pair(tmp_path)
+
+    py.write_text("# %%\nprint(2)\n")
+    with pytest.raises(SystemExit) as exc:
+        stamp_notebook(nb_path, executor="test", parameters={})
+
+    assert "never wrote this file" in str(exc.value)
+
+
+def test_a_deterministic_notebook_can_say_so(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The refusal is a heuristic, so it has to be answerable.
+
+    A source change that genuinely alters nothing the notebook prints is possible;
+    the escape hatch makes that a statement someone made rather than a silence.
+    """
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    py, nb_path = _seed_stamped_pair(tmp_path)
+    py.write_text("# %%\nprint(2)\n")
+
+    stamp = stamp_notebook(nb_path, executor="test", parameters={}, allow_unchanged_outputs=True)
+
+    assert stamp["source_py_blob"] == notebook_provenance.git_blob(py)
+
+
+def test_re_stamping_unchanged_source_is_not_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Re-running the same `.py` to the same values says nothing about the write.
+
+    Firing here would make every ordinary re-stamp of a deterministic notebook an
+    error, which is how a check earns being ignored.
+    """
+    monkeypatch.setattr(notebook_provenance, "REPO_ROOT", tmp_path)
+    _, nb_path = _seed_stamped_pair(tmp_path)
+
+    assert stamp_notebook(nb_path, executor="test", parameters={})["outputs_digest"]
+
+
+# -----------------------------------------------------------------------------
+# The two exceptions the digest must not break
+# -----------------------------------------------------------------------------
+
+
+def test_correcting_figure_alt_text_does_not_read_as_a_changed_result():
+    """`alt_text_only_drift` forgives an alt-only `.py` edit, and that workflow
+    requires the matching output metadata to be corrected too - it accepts the drift
+    only when "every alt in the notebook's output metadata already equals the literal
+    in its own cell". Hashing the alt would fail exactly the correction the exception
+    was built to make free: `nasdaq100_microstructure/04` is 90 minutes and 43 GB to
+    restate four sentences.
+    """
+
+    def figure(alt: str) -> dict:
+        return {
+            "output_type": "display_data",
+            "data": {"image/png": "AAAA"},
+            "metadata": {"image/png": {"alt": alt}},
+        }
+
+    before = _notebook([_code_cell("show_with_alt(fig, alt)", [figure("A blue line.")])])
+    after = _notebook([_code_cell("show_with_alt(fig, alt)", [figure("A rising blue line.")])])
+
+    assert outputs_digest(before) == outputs_digest(after)
+
+
+def test_the_image_behind_the_alt_text_is_still_hashed():
+    """Blanking the alt must not blank the figure it describes."""
+
+    def figure(png: str) -> dict:
+        return {
+            "output_type": "display_data",
+            "data": {"image/png": png},
+            "metadata": {"image/png": {"alt": "A blue line."}},
+        }
+
+    before = _notebook([_code_cell("show_with_alt(fig, alt)", [figure("AAAA")])])
+    after = _notebook([_code_cell("show_with_alt(fig, alt)", [figure("BBBB")])])
+
+    assert outputs_digest(before) != outputs_digest(after)
+
+
+def test_a_package_inside_a_chapter_directory_is_reached():
+    """`17_portfolio_construction/deepm/` is a real package, imported dotted.
+
+    Resolving dotted names from the repo root alone left the code that computes
+    that chapter's allocations out of the digest, so a change to it produced no
+    drift report at all.
+    """
+    py = REPO_ROOT / "17_portfolio_construction/13_deepm_regime_robust.py"
+    if not py.exists():
+        pytest.skip("the deepm notebook is not in this tree")
+
+    reached = {p.relative_to(REPO_ROOT).as_posix() for p in repo_local_sources(py)}
+
+    assert "17_portfolio_construction/deepm/model.py" in reached
+    assert "17_portfolio_construction/deepm/train.py" in reached

--- a/tests/test_notebook_sync.py
+++ b/tests/test_notebook_sync.py
@@ -260,7 +260,13 @@ def test_stamp_records_declared_overrides_as_test_mode(tmp_path, monkeypatch) ->
 
 
 def test_stamped_notebooks_are_current_and_production() -> None:
-    stale, testmode, contradicted, _unverified, _alt_only, hollow = check_all(strict=False)
+    result = check_all(strict=False)
+    stale, testmode, contradicted, hollow = (
+        result.stale,
+        result.testmode,
+        result.contradicted,
+        result.hollow,
+    )
     assert not stale and not testmode and not contradicted and not hollow, (
         "Committed notebooks are out of sync with their source .py:\n"
         + (


### PR DESCRIPTION
`source_py_blob` answers one question — has the paired `.py` changed since somebody stamped this notebook. Two things a reader sees were outside it, and each was a way a superseded result reached `main` with every check green.

## The outputs (#241)

A notebook whose `.py` is untouched passed the staleness check carrying outputs from **any** earlier run. `outputs_digest` is computed over the parsed cells, so reformatting cannot move it, with `execution_count` and figure `alt` dropped — the first because the kernel renumbers it, the second because the alt-text exception depends on it (below).

## The library (#917)

A case study's numbers are computed in `case_studies/utils/*.py`, which the stamp never covered. #606 changed `causal.py` under all nine at once and the committed stamps went on claiming runs whose outputs described code no longer in the tree — `analysis_rows` 88695 → 88633 on `fwd_ret_5d`, and every `request_hash` with it.

`library_digest` resolves the paired `.py`'s repo-local imports transitively and digests those blobs, keyed by path as well as content so a move is drift too. It reaches `case_studies/utils/causal.py` from `case_studies/etfs/12_causal_dml.py` through 81 files.

**Outputs drift fails. Library drift is reported and does not** — making it fail would block at least five notebooks across three case studies on the day it lands, and #917 asks for the measurement first and that decision separately.

## Migration

A stamp carrying neither field predates them both and is **counted, not failed** — 423 notebooks in this tree, none of which has the defect the fields exist to catch. `check` prints the count, so the backfill is visible rather than silent. The gate is green on the tree today.

## What RoboRev caught, and it was right three times

1. **The digest alone could not catch the failure it was built for.** It is written from whatever is on disk at stamp time, so a run that exited without writing gets the *previous* outputs recorded as the new ones — and every later check then agrees with itself. `unwritten_run` catches it at the only moment the state is still visible: the previous stamp names a different `.py` and the outputs are byte-identical to what that run produced. `--allow-unchanged-outputs` answers it for a genuinely deterministic notebook.
2. **It broke the alt-text exception.** `alt_text_only_drift` accepts an alt-only `.py` edit only when the output metadata already carries the corrected alt — so that workflow edits both files, and hashing the alt priced four rewritten sentences at a 90-minute re-run again. `alt` is now dropped; the image behind it is still hashed, and a test holds that line.
3. **It missed packages inside a chapter directory.** `17_portfolio_construction/deepm/` is a real package imported as `deepm.model`, so the code computing that chapter's allocations was outside the digest entirely. Nine modules are covered now.

## Tests

`tests/test_notebook_provenance_digests.py`, 22 tests. The gate-level ones seed a stamped pair and assert the right class fires: replaced outputs are `outputs_changed` while `stale` stays empty (the `.py` is untouched — that is the whole problem); a moved imported module is `library_drift` with the outputs untouched; a stamp with the fields deleted is `undigested` and fails nothing. `sync_prose` is exercised end to end, because a prose fold costing a re-run again would undo what sync-prose is for.

`check_all` returns a `CheckResult` NamedTuple rather than a six-tuple, which keeps positional unpacking and iteration working while nine categories stay readable.

Closes ml4t/agent-workspace#241
Closes ml4t/agent-workspace#917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQUuNRz572ohmUwscwmzp