### PR TITLE
CI's hand-built venvs take their versions from uv.lock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -424,7 +424,22 @@ jobs:
         # stays a ~1-minute gate.
         run: |
           uv venv --python 3.14
-          uv pip install jupytext==1.19.3 pytest nbformat
+          # Pin every one of these to uv.lock. The list is a set of NAMES, and
+          # letting uv resolve their versions freely makes an external release
+          # decide what a required check measures. ml4t-diagnostic 0.1.4 shipped on
+          # 2026-09-05 with WalkForwardCV returning folds oldest-first;
+          # `"ml4t-diagnostic>=0.1.2"` picked it up on the next run and turned
+          # test-unit red on `main` and on every branch cut from it, with no commit
+          # in the repository having changed. The lock said 0.1.2 the whole time.
+          #
+          # Same derivation as envs/ml4t/Dockerfile: export the lock as a
+          # fully-pinned requirements file and hand it to uv as a constraint, so
+          # this stays a fast minimal venv and still cannot drift off what the
+          # repository declares.
+          uv export --frozen --extra live --extra dev --no-emit-project --no-hashes \
+            --format requirements-txt \
+            | grep -iE '^[a-z0-9._-]+==' > /tmp/locked-constraints.txt
+          uv pip install --constraint /tmp/locked-constraints.txt jupytext pytest nbformat
       - name: Notebook pairs open in JupyterLab (#372 regression gate)
         run: |
           source .venv/bin/activate
@@ -546,9 +561,25 @@ jobs:
         # inspection: the helper-level tests never reach the conversion and passed.
         run: |
           uv venv --python 3.14
-          uv pip install pytest pytest-timeout numpy pandas polars pyyaml python-dotenv plotly gymnasium requests \
+          # Pin every one of these to uv.lock. The list is a set of NAMES, and
+          # letting uv resolve their versions freely makes an external release
+          # decide what a required check measures. ml4t-diagnostic 0.1.4 shipped on
+          # 2026-09-05 with WalkForwardCV returning folds oldest-first;
+          # `"ml4t-diagnostic>=0.1.2"` picked it up on the next run and turned
+          # test-unit red on `main` and on every branch cut from it, with no commit
+          # in the repository having changed. The lock said 0.1.2 the whole time.
+          #
+          # Same derivation as envs/ml4t/Dockerfile: export the lock as a
+          # fully-pinned requirements file and hand it to uv as a constraint, so
+          # this stays a fast minimal venv and still cannot drift off what the
+          # repository declares.
+          uv export --frozen --extra live --extra dev --no-emit-project --no-hashes \
+            --format requirements-txt \
+            | grep -iE '^[a-z0-9._-]+==' > /tmp/locked-constraints.txt
+          uv pip install --constraint /tmp/locked-constraints.txt \
+            pytest pytest-timeout numpy pandas polars pyyaml python-dotenv plotly gymnasium requests \
             scipy statsmodels scikit-learn matplotlib hmmlearn pyarrow nest-asyncio \
-            "ml4t-diagnostic>=0.1.2" jupytext==1.19.3 papermill==2.7.0 ml4t-backtest ml4t-data ml4t-engineer databento
+            ml4t-diagnostic jupytext papermill ml4t-backtest ml4t-data ml4t-engineer databento
       - name: Run download-logic unit tests
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -900,9 +931,25 @@ jobs:
           # (case_studies/utils/backtest_loaders.py:169 imports ml4t.backtest), and
           # without the package four of its tests raise rather than skip. Measured in a
           # venv holding exactly this list: 4 failed without it, 37 passed with it.
-          uv pip install pytest numpy pandas polars pyyaml python-dotenv plotly gymnasium requests \
+          # Pin every one of these to uv.lock. The list is a set of NAMES, and
+          # letting uv resolve their versions freely makes an external release
+          # decide what a required check measures. ml4t-diagnostic 0.1.4 shipped on
+          # 2026-09-05 with WalkForwardCV returning folds oldest-first;
+          # `"ml4t-diagnostic>=0.1.2"` picked it up on the next run and turned
+          # test-unit red on `main` and on every branch cut from it, with no commit
+          # in the repository having changed. The lock said 0.1.2 the whole time.
+          #
+          # Same derivation as envs/ml4t/Dockerfile: export the lock as a
+          # fully-pinned requirements file and hand it to uv as a constraint, so
+          # this stays a fast minimal venv and still cannot drift off what the
+          # repository declares.
+          uv export --frozen --extra live --extra dev --no-emit-project --no-hashes \
+            --format requirements-txt \
+            | grep -iE '^[a-z0-9._-]+==' > /tmp/locked-constraints.txt
+          uv pip install --constraint /tmp/locked-constraints.txt \
+            pytest numpy pandas polars pyyaml python-dotenv plotly gymnasium requests \
             scipy statsmodels scikit-learn matplotlib hmmlearn pyarrow ml4t-backtest \
-            "ml4t-diagnostic>=0.1.2" jupytext==1.19.3
+            ml4t-diagnostic jupytext
       # The precondition is the load-bearing half, the same shape as the
       # data-root anchoring step above. Every test in this job skips politely
       # when the data is absent, so a checkout that silently produced an empty

--- a/tests/test_ci_venvs_follow_the_lock.py
+++ b/tests/test_ci_venvs_follow_the_lock.py
@@ -1,0 +1,129 @@
+"""A CI job's environment is decided by `uv.lock`, not by whatever released today.
+
+Three jobs in `.github/workflows/test.yml` build a small venv with `uv pip install`
+rather than syncing the project, deliberately: `guards` and `test-unit` are fast
+gates and a full sync would cost more than the checks they run. That is a
+reasonable trade as long as the *list* is names and the *versions* still come from
+the lock.
+
+They did not. `test-unit` installed `"ml4t-diagnostic>=0.1.2"`, and on 2026-09-05
+`ml4t-diagnostic` 0.1.4 shipped with `WalkForwardCV` returning folds oldest-first.
+The next run picked it up, `generate_cv_splits` raised on every case study's
+configuration, and `test-unit` - a required check - went red on `main` and on every
+branch cut from it with no commit in the repository having changed. `uv.lock` said
+0.1.2 throughout, and the job that was measuring the repository was not measuring
+the environment the repository declares.
+
+That is the same shape as `check_env_matches_lock.py`, which exists because the
+Docker image drifted off the lock the same way. The fix is the same one
+`envs/ml4t/Dockerfile` already uses: export the lock as a fully-pinned requirements
+file and hand it to `uv` as a constraint.
+
+So this asserts the contract rather than the text. Every `uv pip install` in the
+workflow constrains against the lock; no package it names carries a version, because
+naming one is how the two sources of truth start to disagree; and every package it
+names is actually in the lock, because a constraint file that does not mention a
+package does not constrain it and the pin would be silently absent.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+WORKFLOW = REPO_ROOT / ".github/workflows/test.yml"
+LOCK = REPO_ROOT / "uv.lock"
+
+# uv itself, and the project. `uv` is the installer rather than a dependency, and
+# `ml4t` is this repository, which the lock does not pin a version of.
+NOT_LOCKED = frozenset({"uv", "ml4t"})
+
+
+def _install_commands() -> list[str]:
+    """Each `uv pip install` invocation in the workflow, line continuations joined."""
+    text = WORKFLOW.read_text(encoding="utf-8").replace("\\\n", " ")
+    return [line.strip() for line in text.splitlines() if "uv pip install" in line]
+
+
+def _named_packages(command: str) -> list[str]:
+    """The package arguments of an install command, options and their values removed."""
+    tokens = command.split("uv pip install", 1)[1].split()
+    packages: list[str] = []
+    skip = False
+    for token in tokens:
+        if skip:
+            skip = False
+            continue
+        if token.startswith("-"):
+            skip = "=" not in token
+            continue
+        packages.append(token.strip("\"'"))
+    return packages
+
+
+def _locked_names() -> set[str]:
+    lock = tomllib.loads(LOCK.read_text(encoding="utf-8"))
+    return {p["name"].lower().replace("_", "-") for p in lock["package"]}
+
+
+def test_the_workflow_still_builds_venvs_by_hand():
+    """The premise. If these jobs ever sync the project instead, delete this file."""
+    assert _install_commands(), (
+        "no `uv pip install` left in test.yml - if the fast gates now sync the "
+        "project, this whole contract is moot and the file should go"
+    )
+
+
+def test_every_hand_built_venv_is_constrained_by_the_lock():
+    for command in _install_commands():
+        assert "--constraint" in command, (
+            "an unconstrained `uv pip install` resolves to whatever released today, "
+            "so an external publish decides what a required check measures:\n"
+            f"  {command.strip()}"
+        )
+
+
+def test_no_installed_package_carries_a_version():
+    """A version in the workflow is a second source of truth, and it loses.
+
+    `jupytext==1.19.3` sat beside `"ml4t-diagnostic>=0.1.2"` and both were wrong to
+    be there: one duplicated the lock and would silently go stale against it, the
+    other was a floor that let anything newer in.
+    """
+    offenders = [
+        pkg
+        for command in _install_commands()
+        for pkg in _named_packages(command)
+        if re.search(r"[=<>~!]", pkg)
+    ]
+
+    assert not offenders, (
+        f"{offenders} pin or bound a version in the workflow; uv.lock decides these. "
+        "Name the package and let the constraint file pin it."
+    )
+
+
+def test_every_installed_package_is_in_the_lock():
+    """A constraint file only constrains what it mentions.
+
+    Installing a package the lock has never heard of reintroduces the defect for
+    that one package, silently, in a job that now looks pinned.
+    """
+    locked = _locked_names()
+    missing = sorted(
+        {
+            pkg.lower().replace("_", "-")
+            for command in _install_commands()
+            for pkg in _named_packages(command)
+        }
+        - locked
+        - NOT_LOCKED
+    )
+
+    assert not missing, (
+        f"{missing} are installed in CI but absent from uv.lock, so the constraint "
+        "file cannot pin them and they resolve freely. Add them to the project's "
+        "dependencies, or drop them."
+    )


### PR DESCRIPTION
**`test-unit` is red on `main` and on every branch cut from it, and no commit in this repository caused it.**

`ml4t-diagnostic` 0.1.4 shipped on 2026-09-05 with `WalkForwardCV` returning folds oldest-first. `test-unit` installed `"ml4t-diagnostic>=0.1.2"`, picked it up on the next run, and `generate_cv_splits` now raises on every case study's configuration:

```
RuntimeError: generate_cv_splits produced folds that are not ordered newest first:
val_starts ['2015-12-30', '2016-12-29', ... ]
```

`uv.lock` said `0.1.2` the whole time. Confirmed from the job log: `+ ml4t-diagnostic==0.1.4`. Locally, on the lock, the same tests pass.

## The defect this PR fixes

Three jobs build a small venv with `uv pip install` rather than syncing the project. That is a reasonable trade for a fast gate — as long as the list is *names* and the versions still come from the lock. It was the versions that were wrong: a floor for one package, hand-copied pins (`jupytext==1.19.3`, `papermill==2.7.0`) for others, and free resolution for everything else. **An external publish decided what a required check measured**, on a schedule nobody in this repository set.

That is the same shape as `check_env_matches_lock.py`, which exists because the Docker image drifted off the lock the same way.

## The fix

Each step exports `uv.lock` as a fully-pinned requirements file and passes it as `--constraint` — the derivation `envs/ml4t/Dockerfile` already uses, for the same reason. The venvs stay minimal and stay on the lock. Verified locally: the export pins 537 packages including `ml4t-diagnostic==0.1.2`, `pytest==9.0.3`, `jupytext==1.19.3`, `papermill==2.7.0`.

## Scope: this is the timing fix, not the version decision

**Adopting 0.1.4 is already decided and is in flight separately**, on `infra/fold-numbering`. Oldest-first numbering was measured as a defect, fixed as `ml4t/diagnostic#53`, and released as 0.1.4 specifically so this repository could adopt it; the fold id sits inside `computation.cv.folds`, so it blocks the stage-04 regeneration program. That PR moves `uv.lock`, both Dockerfiles and both pyprojects to 0.1.4, flips `_assert_newest_first` to `_assert_chronological`, and sweeps the positional fold sites.

The two compose rather than compete: **this** PR makes the hand-built venvs follow the lock, **that** one moves the lock, and `test-unit` then installs 0.1.4 against a guard that expects it. What was wrong was never the version — it was that CI reached 0.1.4 before the repository did, through a floor rather than through the lock.

## Tests

`tests/test_ci_venvs_follow_the_lock.py` asserts the contract rather than the text: every `uv pip install` constrains against the lock, no package it names carries a version, and every package it names is actually **in** the lock — because a constraint file does not constrain what it never mentions, and a pinned-looking job with one unlocked package is the same defect wearing a disguise.

Verified it fails by restoring the `>=0.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQUuNRz572ohmUwscwmzp
