### PR TITLE
The papermill progress log is per notebook and per process

### DIFF
--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -1157,6 +1157,33 @@ def injected_parameters(
     return resolved or None
 
 
+def _progress_log_path(py_path: Path) -> Path:
+    """Where this run writes its cell-level progress.
+
+    Keyed on the notebook's path relative to the repo root, plus the pid. The stem
+    alone is not unique: `04_model_based_features`, `12_backtest` and `05_evaluation`
+    are shared by all nine case studies and by chapter notebooks, and the file is
+    opened with mode "w" - so one pane truncated another's. Observed on 2026-08-05
+    while `cs-sp500_options` was executing its own `04_model_based_features`: the log
+    held `params={'GARCH_MIN_OBS': 50, 'MAX_SYMBOLS': 5, ...}`, which is the etfs
+    entry from `tests/overrides.yaml`, written by a different pane.
+
+    That matters because `work/2026-08-05-ci-green/PROTOCOL.md` names this file as the
+    way to see which cell a hanging notebook is on, "which is faster than waiting for
+    the traceback". Reporting another job's notebook is worse than reporting nothing:
+    it is wrong and plausible at the same time.
+
+    The pid separates two panes running the same notebook, which the path alone does
+    not. `ML4T_OUTPUT_DIR` would separate them too, but it is not always set and the
+    pid always is.
+    """
+    try:
+        slug = py_path.resolve().relative_to(REPO_ROOT).with_suffix("").as_posix()
+    except ValueError:
+        slug = py_path.stem
+    return Path(f"/tmp/ml4t-pm-{slug.replace('/', '_')}.{os.getpid()}.log")
+
+
 def run_notebook(
     py_path: Path,
     parameters: dict | None = None,
@@ -1290,10 +1317,10 @@ def run_notebook(
     for key in remove_vars:
         saved_env[key] = os.environ.pop(key, None)
 
-    # Cell-level progress — always log to /tmp/ml4t-pm-{name}.log for visibility.
-    # Since request_save_on_cell_execute=True, the executed notebook is updated
-    # after each cell. Monitor it with: watch -n5 'python -c "import json; ..."'
-    progress_log = Path(f"/tmp/ml4t-pm-{nb_name}.log")
+    # Cell-level progress — always logged for visibility. Since
+    # request_save_on_cell_execute=True, the executed notebook is updated after each
+    # cell. Monitor it with: watch -n5 'python -c "import json; ..."'
+    progress_log = _progress_log_path(py_path)
     n_cells = 0
     try:
         with open(progress_log, "w") as pf:

--- a/tests/test_papermill_progress_log.py
+++ b/tests/test_papermill_progress_log.py
@@ -1,0 +1,67 @@
+"""Two notebooks running at once must not write to the same progress log.
+
+`run_notebook` writes cell-level progress to a file that is opened with mode `"w"`,
+and it used to be keyed on the notebook's stem alone. `04_model_based_features`,
+`12_backtest` and `05_evaluation` are stems shared by all nine case studies and by
+chapter notebooks, so two panes running different notebooks truncated each other.
+
+Observed on 2026-08-05 while `cs-sp500_options` was executing its own
+`04_model_based_features`: the log held `params={'GARCH_MIN_OBS': 50, 'MAX_SYMBOLS':
+5, 'N_RESTARTS': 1}`, which is the **etfs** entry in `tests/overrides.yaml`, written
+by a different pane.
+
+The cost is not a lost log. `work/2026-08-05-ci-green/PROTOCOL.md` names this file as
+the way to see which cell a hanging notebook is on, "which is faster than waiting for
+the traceback" - so under concurrency an agent debugging a hang reads cell progress
+belonging to a different case study. Wrong and plausible at the same time is worse
+than absent.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from tests.pm_helpers import REPO_ROOT, _progress_log_path
+
+
+def test_the_same_stem_in_two_case_studies_gets_two_logs():
+    """The collision that was actually observed."""
+    etfs = _progress_log_path(REPO_ROOT / "case_studies/etfs/04_model_based_features.py")
+    options = _progress_log_path(
+        REPO_ROOT / "case_studies/sp500_options/04_model_based_features.py"
+    )
+
+    assert etfs != options
+
+
+def test_two_panes_running_the_same_notebook_get_two_logs():
+    """The path alone does not separate them; two panes run the same job all the time."""
+    path = REPO_ROOT / "case_studies/etfs/04_model_based_features.py"
+
+    assert str(os.getpid()) in _progress_log_path(path).name
+
+
+def test_the_log_still_matches_the_glob_the_tooling_uses():
+    """`grep -l FAIL /tmp/ml4t-pm-*.log` is in the runbooks and has to keep working."""
+    log = _progress_log_path(REPO_ROOT / "case_studies/etfs/04_model_based_features.py")
+
+    assert log.parent == Path("/tmp")
+    assert log.match("ml4t-pm-*.log")
+
+
+def test_the_name_says_which_notebook_it_is():
+    """A reader with several logs open has to be able to tell them apart by name."""
+    log = _progress_log_path(REPO_ROOT / "case_studies/sp500_options/04_model_based_features.py")
+
+    assert "case_studies_sp500_options_04_model_based_features" in log.name
+
+
+def test_a_notebook_outside_the_repo_still_gets_a_log(tmp_path: Path):
+    """`relative_to` raises for a path outside the repo, and losing the log to that
+    would take the diagnostics away exactly when someone is running something unusual.
+    """
+    log = _progress_log_path(tmp_path / "scratch_notebook.py")
+
+    assert "scratch_notebook" in log.name
+    assert log.match("ml4t-pm-*.log")


### PR DESCRIPTION
`run_notebook` writes cell-level progress to a file opened with mode `"w"`, keyed on the notebook's **stem alone**. `04_model_based_features`, `12_backtest` and `05_evaluation` are stems shared by all nine case studies and by chapter notebooks, so two panes running different notebooks truncated each other.

Observed 2026-08-05 while `cs-sp500_options` was executing its own `04_model_based_features`:

```
$ cat /tmp/ml4t-pm-04_model_based_features.log
START 04_model_based_features timeout=300s params={'GARCH_MIN_OBS': 50, 'MAX_SYMBOLS': 5, 'N_RESTARTS': 1}
```

Those are the **etfs** overrides from `tests/overrides.yaml`. Another pane had overwritten the file.

## Why it is worth fixing rather than tolerating

`work/2026-08-05-ci-green/PROTOCOL.md` names this file as the way to see which cell a hanging notebook is on, "which is faster than waiting for the traceback". Under concurrency it silently reports another job's notebook, so an agent debugging a hang reads cell progress belonging to a different case study. Wrong and plausible at the same time is worse than absent.

## The fix

The path is the notebook's repo-relative path slugged, plus the pid:

```
/tmp/ml4t-pm-case_studies_sp500_options_04_model_based_features.31337.log
```

The path separates the case studies; the pid separates two panes running the *same* job, which the path cannot. `ML4T_OUTPUT_DIR` would do the latter too but is not always set, and the pid always is. A notebook outside the repo falls back to its stem rather than losing its log — that is when someone is most likely running something unusual.

`/tmp/ml4t-pm-*.log` still matches, so `grep -l FAIL /tmp/ml4t-pm-*.log` in the runbooks keeps working, and a test holds that line.

`PROTOCOL.md` is updated in the same pass (`ml4t/agent-workspace@791c8567`), since it was the document naming the old path.

Closes ml4t/agent-workspace#285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQUuNRz572ohmUwscwmzp