### PR TITLE
Say which of the image and the lock is wrong, in the jobs that cannot carry a candidate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1322,6 +1322,22 @@ jobs:
           ssh-key: ${{ secrets.TEST_DATA_DEPLOY_KEY }}
           lfs: false
 
+      # This job executes notebooks inside the PUBLISHED image, which drifts from
+      # uv.lock the moment the lock moves and has no way to carry a candidate built
+      # from this commit: `container:` is resolved before any step runs. So when the
+      # lock has moved and the image has not, every notebook here runs against a
+      # dependency set the repository does not declare - and it does not fail in a way
+      # that says so. On #787, which moved ml4t-diagnostic to 0.1.4, it surfaced as
+      # thirteen fold-ordering errors inside cme_futures and a red ch26, none of which
+      # names the environment.
+      #
+      # The guard cannot make the job pass; nothing can until the image is rebuilt from
+      # a landed lock. What it does is put the reason first, so the failure reads as
+      # "this image is not the environment this commit declares" rather than as a
+      # numerical defect in a notebook. That distinction cost four rounds of
+      # investigation the last time it was missing.
+      - name: The image's installed distributions match uv.lock
+        run: python .github/scripts/check_env_matches_lock.py
       - name: Seed case study intermediates
         if: steps.reach.outputs.have_key
         run: |
@@ -1428,6 +1444,22 @@ jobs:
           ssh-key: ${{ secrets.TEST_DATA_DEPLOY_KEY }}
           lfs: false
 
+      # This job executes notebooks inside the PUBLISHED image, which drifts from
+      # uv.lock the moment the lock moves and has no way to carry a candidate built
+      # from this commit: `container:` is resolved before any step runs. So when the
+      # lock has moved and the image has not, every notebook here runs against a
+      # dependency set the repository does not declare - and it does not fail in a way
+      # that says so. On #787, which moved ml4t-diagnostic to 0.1.4, it surfaced as
+      # thirteen fold-ordering errors inside cme_futures and a red ch26, none of which
+      # names the environment.
+      #
+      # The guard cannot make the job pass; nothing can until the image is rebuilt from
+      # a landed lock. What it does is put the reason first, so the failure reads as
+      # "this image is not the environment this commit declares" rather than as a
+      # numerical defect in a notebook. That distinction cost four rounds of
+      # investigation the last time it was missing.
+      - name: The image's installed distributions match uv.lock
+        run: python .github/scripts/check_env_matches_lock.py
       - name: Seed case study intermediates
         if: steps.reach.outputs.have_key
         run: |
@@ -1618,6 +1650,10 @@ jobs:
           ssh-key: ${{ secrets.TEST_DATA_DEPLOY_KEY }}
           lfs: false
 
+      # Same reason as the two notebook jobs above: this runs in the published image,
+      # which cannot carry a candidate built from this commit.
+      - name: The image's installed distributions match uv.lock
+        run: python .github/scripts/check_env_matches_lock.py
       - name: Run Ch23 Knowledge Graph notebooks (pipeline order)
         if: steps.reach.outputs.have_key
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1337,6 +1337,7 @@ jobs:
       # numerical defect in a notebook. That distinction cost four rounds of
       # investigation the last time it was missing.
       - name: The image's installed distributions match uv.lock
+        if: steps.reach.outputs.have_key
         run: python .github/scripts/check_env_matches_lock.py
       - name: Seed case study intermediates
         if: steps.reach.outputs.have_key
@@ -1459,6 +1460,7 @@ jobs:
       # numerical defect in a notebook. That distinction cost four rounds of
       # investigation the last time it was missing.
       - name: The image's installed distributions match uv.lock
+        if: steps.reach.outputs.have_key
         run: python .github/scripts/check_env_matches_lock.py
       - name: Seed case study intermediates
         if: steps.reach.outputs.have_key
@@ -1653,6 +1655,7 @@ jobs:
       # Same reason as the two notebook jobs above: this runs in the published image,
       # which cannot carry a candidate built from this commit.
       - name: The image's installed distributions match uv.lock
+        if: steps.reach.outputs.have_key
         run: python .github/scripts/check_env_matches_lock.py
       - name: Run Ch23 Knowledge Graph notebooks (pipeline order)
         if: steps.reach.outputs.have_key

--- a/tests/test_image_rebuild_triggers.py
+++ b/tests/test_image_rebuild_triggers.py
@@ -234,3 +234,65 @@ def test_a_broken_candidate_fails_the_required_check():
         "the guard ignores a cancelled candidate build, which leaves the same hole"
     )
     assert "exit 1" in str(guard.get("run", "")), f"{guard.get('name')} does not fail the job"
+
+
+def _jobs_in_the_published_ml4t_image() -> dict[str, dict]:
+    """Jobs whose `container:` is `ml4t/ml4t:latest`, keyed by job name.
+
+    Only that image. `ml4t-py312` and `ml4t-benchmark` install their own dependency
+    sets on top of a constraint derived from the root lock, so their installed
+    distributions legitimately differ from it and the guard below does not apply.
+    """
+    workflow = yaml.safe_load(TEST_WORKFLOW.read_text(encoding="utf-8"))
+    out = {}
+    for name, spec in workflow["jobs"].items():
+        container = spec.get("container")
+        image = container.get("image") if isinstance(container, dict) else container
+        if image == "ml4t/ml4t:latest":
+            out[name] = spec
+    return out
+
+
+def test_every_job_in_the_published_image_checks_it_against_the_lock():
+    """A `container:` cannot carry an image built from the commit under test.
+
+    GitHub resolves it before any step runs, so these jobs get the published image
+    whatever the lock says - and unlike `test-unit-image` they cannot be pointed at a
+    candidate without restructuring them to `docker run`. The guard cannot make them
+    pass on a lock-changing commit; nothing can until the image is rebuilt from a
+    landed lock. What it does is make the failure say which of the two is wrong.
+
+    Without it the drift arrives as arithmetic. On the commit that moved
+    ml4t-diagnostic to 0.1.4 it surfaced as thirteen fold-ordering errors inside
+    `cs-cme_futures` and a red `ch26`, none of which names the environment - the same
+    shape that cost four rounds of investigation aimed at a notebook the last time an
+    image drifted off the lock.
+
+    This is the check that was missing when `test-unit-image` was pointed at a
+    candidate and these three jobs were not.
+    """
+    unguarded = sorted(
+        name
+        for name, spec in _jobs_in_the_published_ml4t_image().items()
+        if not any(
+            "check_env_matches_lock.py" in str(step.get("run", "")) for step in spec["steps"]
+        )
+    )
+
+    assert not unguarded, (
+        f"{unguarded} execute inside ml4t/ml4t:latest without first checking it against "
+        "uv.lock, so a lock bump reaches them as a numerical failure in a notebook "
+        "rather than as a statement about the environment"
+    )
+
+
+def test_the_guard_runs_before_anything_it_would_explain():
+    """A guard after the work it qualifies explains a failure that already happened."""
+    for name, spec in _jobs_in_the_published_ml4t_image().items():
+        steps = [str(step.get("run", "")) for step in spec["steps"]]
+        guard = next(i for i, s in enumerate(steps) if "check_env_matches_lock.py" in s)
+        work = [i for i, step in enumerate(spec["steps"]) if "pytest" in str(step.get("run", ""))]
+
+        assert not work or guard < min(work), (
+            f"{name} runs its tests before checking the image against the lock"
+        )


### PR DESCRIPTION
#782 pointed `test-unit-image` at an image built from the commit under test, and **left three jobs that could not be**. `test-chapters`, `test-case-studies` and `test-neo4j` execute notebooks inside `ml4t/ml4t:latest` through a job-level `container:`, which GitHub resolves before any step runs — so they get the published image whatever the lock says, and unlike `test-unit-image` they cannot be pointed at a candidate without restructuring them to `docker run`.

That was a gap in my own change, and nothing noticed until agents-48 hit it rebasing the fold-numbering branch.

## The cost, concretely

On the commit that moves `ml4t-diagnostic` to 0.1.4 it surfaces as **thirteen fold-ordering errors inside `cs-cme_futures`**, a red `cs-crypto_perps_funding`, and a red `ch26` — none of which names the environment. It reads as arithmetic. The last time an image drifted off the lock, that exact shape cost four rounds of investigation aimed at the notebook.

## What this does and does not do

It **cannot make these jobs pass**. Nothing can until the image is rebuilt from a landed lock, and the order is unchanged: merge the lock bump, the image rebuilds (that is #782's other half), re-run. What it does is run `check_env_matches_lock.py` first, so the failure says *the image is not the environment this commit declares* instead of pointing at a notebook.

Deliberately **not** applied to `test-py312` and `test-benchmark`: those images install their own dependency sets on top of a constraint derived from the root lock, so their installed distributions legitimately differ from it and the guard would report drift that is not drift.

## The test is the point

Every job whose container is `ml4t/ml4t:latest` must run the guard, and must run it **before** its tests — a guard after the work it qualifies explains a failure that already happened. That is the check that was missing when #782 pointed one job at a candidate and left three behind.

Verified it fails by removing the guard from `test-neo4j`.

## The full fix, not attempted here

Converting the three to `docker run` so they can load the candidate is the complete answer, and it is a large change to the jobs every chapter and case study depends on — the test-data checkout happens inside the container, `test-neo4j` has service containers, and getting it wrong breaks every notebook job for five active lanes. Worth its own issue and its own quiet moment, not the end of a long session.

Refs ml4t/agent-workspace#1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQUuNRz572ohmUwscwmzp