### PR TITLE
temporal: add the canonical ARIMA filter

### DIFF
--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -31,6 +31,7 @@ from threadpoolctl import threadpool_limits
 from case_studies.utils.artifact_digest import write_artifact
 
 __all__ = [
+    "arima_one_step_forecast",
     "filtered_state_probs",
     "fit_hmm_kmeans_init",
     "fold_feature_geometry",
@@ -225,6 +226,62 @@ def garch11_conditional_volatility(
             variance[t] = min(max(driver[t] + beta * variance[t - 1], low), high)
 
     return np.sqrt(variance)
+
+
+def arima_one_step_forecast(fitted: Any, y_prefix: np.ndarray) -> np.ndarray:
+    """One-step-ahead forecasts across *y_prefix*, under parameters fitted on an earlier block.
+
+    The ARIMA counterpart of :func:`garch11_conditional_volatility`, and it exists for the
+    opposite reason. ``arch`` offers no way to filter a series under fixed parameters without
+    re-deriving its backcast and its variance bounds from whatever array it is handed, so that
+    recursion had to be written out above. ``statsmodels`` does offer one:
+    ``ARIMAResults.apply(endog, refit=False)`` re-runs the Kalman filter over new data with the
+    coefficients left where the fit put them. What is shared here is therefore the correct call
+    and the check that it stayed correct, not a reimplementation of the filter.
+
+    Two neighbouring calls are wrong in ways that no assertion over the output frame can see.
+    ``apply(endog)`` defaults to ``refit=True`` and re-estimates on the array it is given, which
+    in a walk-forward feature means every emitted value was fitted on the block it is emitted
+    over. ``forecast(h)`` continues past the end of the data instead of filtering across it, so
+    it returns *h* values for an *n*-row prefix and lines up with nothing.
+
+    The parameter comparison is not decoration. ``refit=False`` is a keyword whose name is the
+    only thing asserting the behaviour, and a default that changed upstream would otherwise
+    surface as a feature that quietly began reading its own emission window. Comparing the two
+    vectors element by element costs nothing next to the fit and fails loudly instead.
+
+    Parameters
+    ----------
+    fitted
+        A fitted ``ARIMAResults``, estimated on training rows only - inside the closure
+        :func:`walk_forward_feature` calls, it sees exactly those.
+    y_prefix
+        The series to filter across, shape ``(n,)`` or ``(n, 1)``, in time order and beginning
+        where the fitted series began.
+
+    Returns ``(n,)`` one-step-ahead predictions, one per row of *y_prefix*.
+
+    :raises ValueError: if *y_prefix* carries more than one column, or if the parameters moved.
+    """
+    y = np.asarray(y_prefix, dtype=float)
+    if y.ndim == 2:
+        if y.shape[1] != 1:
+            raise ValueError(
+                f"y_prefix carries {y.shape[1]} columns; an ARIMA filter reads one series. "
+                "Select the column before calling."
+            )
+        y = y[:, 0]
+    elif y.ndim != 1:
+        raise ValueError(f"y_prefix must be one- or two-dimensional, got shape {y.shape}")
+
+    extended = fitted.apply(y, refit=False)
+    drift = float(np.abs(np.asarray(fitted.params) - np.asarray(extended.params)).max())
+    if drift != 0.0:
+        raise ValueError(
+            f"apply(refit=False) re-estimated the model: parameters moved by {drift:.3e}. "
+            "Every value this emits would be fitted on the block it is emitted over."
+        )
+    return np.asarray(extended.predict(start=0, end=len(y) - 1), dtype=float)
 
 
 def sort_states_by_variance(model: GaussianHMM) -> np.ndarray:

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -24,6 +24,7 @@ from hmmlearn.hmm import GaussianHMM
 from threadpoolctl import threadpool_limits
 
 from case_studies.utils.temporal import (
+    arima_one_step_forecast,
     filtered_state_probs,
     fit_hmm_kmeans_init,
     garch11_conditional_volatility,
@@ -1053,3 +1054,118 @@ def test_a_series_too_short_to_compare_is_accepted() -> None:
         n_features=1,
     )
     assert np.isnan(out).all()
+
+
+# ---------------------------------------------------------------------------
+# The ARIMA filter
+# ---------------------------------------------------------------------------
+#
+# `arima_one_step_forecast` wraps the one statsmodels call that filters a series under
+# parameters fitted elsewhere. These check the property the shared layer exists for - no
+# emitted value depends on a row at or after the timestamp it is emitted for - rather than
+# the spelling of the call, and they pin the equivalence that lets a notebook adopt the
+# helper without its values moving.
+
+
+def _arma_series(n: int = 240, seed: int = 0) -> np.ndarray:
+    """An ARMA(1,1) series with enough structure for a (1, 0, 1) fit to converge."""
+    rng = np.random.default_rng(seed)
+    eps = rng.standard_normal(n)
+    y = np.zeros(n)
+    for t in range(1, n):
+        y[t] = 0.6 * y[t - 1] + eps[t] + 0.3 * eps[t - 1]
+    return y
+
+
+def _arma_fit(y: np.ndarray, order: tuple[int, int, int] = (1, 0, 1)):
+    from statsmodels.tsa.arima.model import ARIMA
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return ARIMA(y, order=order).fit()
+
+
+def test_the_arima_filter_returns_one_value_per_row_of_the_prefix() -> None:
+    y = _arma_series()
+    out = arima_one_step_forecast(_arma_fit(y[:120]), y[:200])
+    assert out.shape == (200,)
+    assert np.isfinite(out).all()
+
+
+def test_deleting_later_observations_does_not_move_an_earlier_arima_forecast() -> None:
+    """The causality property, measured rather than taken from the keyword's name."""
+    y = _arma_series()
+    fitted = _arma_fit(y[:120])
+    full = arima_one_step_forecast(fitted, y[:240])
+    prefix = arima_one_step_forecast(fitted, y[:180])
+    assert np.abs(full[:180] - prefix).max() < 1e-10
+
+
+def test_the_arima_filter_matches_the_call_the_notebooks_made_by_hand() -> None:
+    """Adopting the helper must not move a value, or the migration is a model change."""
+    y = _arma_series()
+    fitted = _arma_fit(y[:120])
+    by_hand = np.asarray(fitted.apply(y[:200], refit=False).predict(start=0, end=199), dtype=float)
+    assert np.array_equal(arima_one_step_forecast(fitted, y[:200]), by_hand)
+
+
+def test_a_column_vector_and_a_flat_series_are_read_the_same_way() -> None:
+    y = _arma_series()
+    fitted = _arma_fit(y[:120])
+    flat = arima_one_step_forecast(fitted, y[:200])
+    column = arima_one_step_forecast(fitted, y[:200].reshape(-1, 1))
+    assert np.array_equal(flat, column)
+
+
+def test_a_multi_column_prefix_is_refused() -> None:
+    y = _arma_series()
+    fitted = _arma_fit(y[:120])
+    with pytest.raises(ValueError, match="carries 2 columns"):
+        arima_one_step_forecast(fitted, np.column_stack([y[:200], y[:200]]))
+
+
+class _ReestimatingResult:
+    """A results object whose ``apply`` re-estimates, which is what ``refit=True`` does.
+
+    Constructed rather than provoked: statsmodels does not re-estimate under
+    ``refit=False`` today, and the guard exists for the day that default changes.
+    """
+
+    params = np.array([0.5, 0.2])
+
+    def apply(self, endog, refit=False):  # noqa: ARG002 - mirrors the statsmodels signature
+        other = _ReestimatingResult()
+        other.params = np.array([0.9, 0.2])
+        return other
+
+
+def test_a_filter_that_re_estimated_is_refused() -> None:
+    with pytest.raises(ValueError, match="re-estimated the model"):
+        arima_one_step_forecast(_ReestimatingResult(), np.zeros(10))
+
+
+def test_the_arima_filter_walks_forward_without_reading_its_future() -> None:
+    """End to end through the harness: every block's values come from an earlier fit."""
+    y = _arma_series(n=300)
+    values = walk_forward_feature(
+        y.reshape(-1, 1),
+        timestamps=np.arange(300),
+        burnin=120,
+        refit_every=60,
+        fit=lambda train: _arma_fit(train[:, 0]),
+        apply=lambda fitted, prefix: arima_one_step_forecast(fitted, prefix).reshape(-1, 1),
+        n_features=1,
+    )
+    assert np.isnan(values[:120, 0]).all()
+    assert np.isfinite(values[120:, 0]).all()
+
+    shorter = walk_forward_feature(
+        y[:240].reshape(-1, 1),
+        timestamps=np.arange(240),
+        burnin=120,
+        refit_every=60,
+        fit=lambda train: _arma_fit(train[:, 0]),
+        apply=lambda fitted, prefix: arima_one_step_forecast(fitted, prefix).reshape(-1, 1),
+        n_features=1,
+    )
+    assert np.allclose(values[:240, 0], shorter[:, 0], equal_nan=True)


### PR DESCRIPTION
Criterion 1 of the stage-04 standardization requires every emitted value to come from a `temporal.py` export and names "the ARIMA equivalent once it exists". This adds it.

`arima_one_step_forecast(fitted, y_prefix)` filters a series under parameters estimated elsewhere and returns one-step-ahead predictions, one per row. It is the counterpart of `garch11_conditional_volatility` and exists for the opposite reason: `arch` has no call that filters under fixed parameters without re-deriving its backcast and variance bounds from whatever array it is handed, so that recursion had to be written out. `statsmodels` does have one, `ARIMAResults.apply(endog, refit=False)`, so what is shared here is the correct call and the check that it stayed correct, not a reimplementation.

Two neighbouring calls are wrong in ways no assertion over the output frame can see, which is why this is worth an export rather than a convention:

- `apply(endog)` defaults to `refit=True` and re-estimates on the array it is given, so every emitted value would be fitted on the block it is emitted over.
- `forecast(h)` continues past the end of the data instead of filtering across it, returning h values for an n-row prefix.

The internal parameter comparison guards an upstream default: `refit=False` is a keyword whose name is currently the only thing asserting the behaviour.

**Additive only.** No existing signature changes and no caller is converted here. `fx_pairs` and `cme_futures` adopt it in their own PRs so each digest measurement has a single cause.

## Verification

79 passed in `tests/test_temporal.py`.

The causality test is negative-controlled rather than merely passing: deleting later observations moves an earlier forecast by `0.000e+00` under the real filter and by `1.530e-01` under a deliberately leaky one, so the test discriminates.

`test_the_arima_filter_matches_the_call_the_notebooks_made_by_hand` pins equivalence with the hand-written call `fx_pairs` makes today, which is what lets that notebook adopt the helper without its values moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015p4BJvMLmU1rJ1jZYgugAC