### PR TITLE
A run registered off the research path records when it started

### DIFF
--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -321,6 +321,15 @@ def register_training_run(
     spec = _validate_spec(spec)
     t_hash = training_hash_from_spec(spec)
     spec_json_str = canonical_json(spec)
+    # Defaulted here rather than only in `ResultsCatalog.register_training`, because this
+    # function has five other callers and none of them supplied it. A NULL `started_at` is
+    # what leaves a row with no recoverable timing at all: `elapsed_s` is filled in later by
+    # `record_training_runtime` and stays NULL when a run does not reach it, and without a
+    # start there is nothing to fall back on. Measured on the current nasdaq registry,
+    # 2026-09-05: 13 of 13 linear rows carry NULL for both, registered across 3.1 seconds.
+    # "When the identity was registered" is within seconds of "when work on it began" on
+    # every path that registers before fitting, which is all of them.
+    started_at = started_at or _utc_now()
 
     if spec.get("identity_version") in SUPPORTED_IDENTITY_VERSIONS:
         identity_version = int(spec["identity_version"])

--- a/tests/test_training_start_time_is_recorded.py
+++ b/tests/test_training_start_time_is_recorded.py
@@ -96,3 +96,35 @@ def test_two_runs_of_one_spec_keep_one_identity_and_differ_in_start(tmp_path: Pa
     first = study.results.register_training(spec, started_at="2026-09-05T01:00:00+00:00")
     second = study.results.register_training(spec, started_at="2026-09-05T02:00:00+00:00")
     assert first.hash == second.hash
+
+
+def test_the_direct_registration_path_also_records_a_start(tmp_path: Path) -> None:
+    """The default belongs to `register_training_run`, not to `ResultsCatalog`.
+
+    `ResultsCatalog.register_training` supplied the default, and five other callers of
+    `register_training_run` did not: `gbm.py:1395`, `latent_factors/cv.py:1707`, and the
+    re-registration path inside `registration.py` itself. A row registered through any of
+    them carried NULL for `started_at`, and because `elapsed_s` is filled in later by
+    `record_training_runtime` and stays NULL when a run never reaches it, such a row holds no
+    recoverable timing at all - not a duration, not a start, nothing to difference.
+
+    Measured on `nasdaq100_microstructure`'s live registry, 2026-09-05: 13 of 13 `linear`
+    rows carry NULL for both, registered across 3.1 seconds of wall clock. That corpus is
+    what `reference/case-study-runtimes.md` prices the next run from.
+
+    Refs ml4t/agent-workspace#1026.
+    """
+    from case_studies.utils.registry.registration import register_training_run
+
+    study = _study(tmp_path)
+    spec = _training_spec()
+    before = datetime.now(UTC)
+    training_hash = register_training_run(
+        "etfs", spec=spec, case_dir=study.root, entry_point="tests"
+    )
+    after = datetime.now(UTC)
+
+    started_at, _elapsed_s = _row(study, training_hash)
+    assert started_at is not None, "a row registered off the research path holds no timing"
+    assert before <= datetime.fromisoformat(started_at) <= after
+    assert training_hash == training_hash_from_spec(spec), "defaulting a start moved the identity"


### PR DESCRIPTION
`ResultsCatalog.register_training` defaulted `started_at`; `register_training_run` itself did not, and it has five other callers - `gbm.py:1395`, `latent_factors/cv.py:1707`, and the re-registration path inside `registration.py` - none of which passed one.

A row from any of those holds no recoverable timing at all. `elapsed_s` is filled in afterwards by `record_training_runtime` and stays NULL when a run never reaches it, so with a NULL start there is no duration, no start, and nothing to difference.

## Measured

Live `nasdaq100_microstructure` registry, 2026-09-05:

| | |
|---|---|
| `linear` rows | 13 |
| with `elapsed_s` | 0 |
| with `started_at` | 0 |
| wall clock they span | 3.1 s |

That corpus is what `reference/case-study-runtimes.md` prices the next run from, and every case study is about to be re-run against those prices.

## The fix

Default in `register_training_run`, so it closes for every caller rather than one.

`started_at` is a table column and not part of `spec`, so this moves no training hash. The new test asserts that alongside the default, and fails without the change:

```
assert started_at is not None, "a row registered off the research path holds no timing"
E   AssertionError: assert None is not None
```

`tests/test_research_registry.py`, `tests/test_training_start_time_is_recorded.py` and `tests/test_research_models.py`: 109 passed.

Refs ml4t/agent-workspace#1026.