### PR TITLE
One set decides which case studies are vectorized, not two and a docstring

### DIFF
--- a/case_studies/utils/backtest_presets.py
+++ b/case_studies/utils/backtest_presets.py
@@ -7,8 +7,8 @@ from typing import Any
 import polars as pl
 import yaml
 
+from case_studies.utils.backtest_loaders import VECTORIZED_CASE_STUDIES, declared_rebalance_step
 from case_studies.utils.backtest_loaders import BacktestConfig as CaseStudyBacktestConfig
-from case_studies.utils.backtest_loaders import declared_rebalance_step
 from utils.paths import get_case_study_dir
 
 try:
@@ -461,11 +461,16 @@ def build_backtest_spec(
     strategy_spec: dict[str, Any] = {
         "signal": resolved_signal,
         "execution": {
+            # `VECTORIZED_CASE_STUDIES` rather than a second copy of the same set. The
+            # membership was written out here as well, and the two are read by different
+            # things: this one decides the dispatch in `backtest_runner`, and the constant
+            # decides `IS_VECTORIZED` in four risk-management notebooks. Adding a case study
+            # to one and not the other gives a notebook the wrong branch with nothing raising.
             "mode": (
                 execution_mode
                 if execution_mode is not None
                 else "vectorized"
-                if case_study in {"us_firm_characteristics", "sp500_options"}
+                if case_study in VECTORIZED_CASE_STUDIES
                 else "engine"
             ),
             "engine_preset": "realistic",

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1906,7 +1906,10 @@ def _run_vectorized(
 ) -> dict:
     """Run vectorized backtest (weight × forward return - costs).
 
-    Used for us_firm_characteristics, sp500_options, nasdaq100_microstructure.
+    Used for the case studies in `VECTORIZED_CASE_STUDIES`: us_firm_characteristics and
+    sp500_options. This line named nasdaq100_microstructure until 2026-09-06 and nothing
+    dispatched it here - no config declares `execution.mode`, so the preset's default decides,
+    and nasdaq is not in the set.
 
     Cost dispatch supports two models:
       * percentage — fractional drag = turnover × (commission_bps + slippage_bps) / 1e4


### PR DESCRIPTION
Three statements of the same membership, already drifted apart, found while resolving a docstring that two sessions had chased.

| where | what it decides | held |
|---|---|---|
| `backtest_presets.py:468` | `execution.mode`, which `backtest_runner` dispatches on | the set, written out inline |
| `backtest_loaders.py:82` | `IS_VECTORIZED` in four risk-management notebooks | `VECTORIZED_CASE_STUDIES` |
| `_run_vectorized`'s docstring | nothing | **three** case studies |

Nothing connected the first two, so adding a case study to one and not the other gives a risk-management notebook the wrong branch with nothing raising. The preset now imports the constant.

**The docstring was the drift that had already happened.** It named `us_firm_characteristics`, `sp500_options` and `nasdaq100_microstructure`, and nothing dispatches nasdaq to that function: no config declares `execution.mode`, so the preset's default decides, and nasdaq is not in the set. Corrected with the date and the reason, because that sentence sent two sessions looking for a dispatch that does not exist - the third docstring in one day asserting something the code beside it does not.

**No behaviour change.** The constant and the inline literal held the same two members, so this changes which line is read and not which branch is taken.

Verified: the import resolves, `VECTORIZED_CASE_STUDIES` is `{sp500_options, us_firm_characteristics}` at runtime, and no second copy of the membership remains in `backtest_presets`. The behavioural gate is CI - this is a two-line change in shared code and `test-unit` exercises both modules.