### PR TITLE
A universe reduction must not move the fold boundaries

### DIFF
--- a/tests/test_reduced_universe_keeps_the_fold_geometry.py
+++ b/tests/test_reduced_universe_keeps_the_fold_geometry.py
@@ -1,0 +1,136 @@
+"""A universe reduction must not move where the folds fall.
+
+``load_modeling_dataset`` derives the walk-forward geometry from the label frame, and
+``generate_cv_splits`` reads the unique timestamps of whatever frame it is handed. Since #780
+pushed the ``max_symbols`` reduction into the scans, that frame was the reduced one, so a preview
+got a different calendar from the canonical run it is supposed to be a subset of.
+
+Nothing downstream follows the shift. ``canonical_window`` always reads the whole label parquet,
+so ``load_backtest_prices_for`` windows prices on the canonical geometry while the preview's
+predictions carry sessions outside it, and ``Strategy._decision_weights`` refuses the decision
+artifact with "decision artifact contains keys outside the backtest price grid". Measured on
+cme_futures on 2026-09-06: the full 30-product universe puts fold 0's validation window at
+2019-01-03..2020-01-02, a five-product preview at 2018-12-31..2019-12-30, and `cs-cme_futures`
+failed at `13_backtest` on the two sessions between them.
+
+The reduction here is built so the dropped entity owns dates the kept ones do not, which is what
+makes the two timelines differ. ``top_entities`` keeps the entities with the most rows, so the
+short-history entity is the one that goes - and it is the one holding the tail of the calendar.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+import pytest
+import yaml
+
+CASE = "reduction_geometry_cs"
+
+
+def _seed(tmp_path: Path) -> None:
+    case_dir = tmp_path / CASE
+    (case_dir / "config").mkdir(parents=True)
+    (case_dir / "features").mkdir()
+    (case_dir / "labels").mkdir()
+    (case_dir / "config" / "setup.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "strategy_id": CASE,
+                "labels": {"primary": "fwd_ret_1d", "buffer": "1D"},
+                "evaluation": {
+                    "n_splits": 2,
+                    "train_size": "1Y",
+                    "val_size": "6M",
+                    "calendar": "NYSE",
+                    "periods_per_year": 252,
+                },
+            }
+        )
+    )
+
+    long_days = pl.date_range(date(2018, 1, 1), date(2021, 6, 30), interval="1d", eager=True)
+    tail_days = pl.date_range(date(2021, 7, 1), date(2021, 12, 31), interval="1d", eager=True)
+
+    rows: dict[str, list] = {"timestamp": [], "symbol": []}
+    # Four long-history entities, kept by the reduction, stopping mid-2021.
+    for symbol in ("AAA", "BBB", "CCC", "DDD"):
+        rows["timestamp"].extend(long_days.to_list())
+        rows["symbol"].extend([symbol] * len(long_days))
+    # One short-history entity, dropped by the reduction, owning the last six months.
+    rows["timestamp"].extend(tail_days.to_list())
+    rows["symbol"].extend(["ZZZ"] * len(tail_days))
+
+    frame = pl.DataFrame(rows)
+    frame.with_columns(pl.lit(0.01).alias("fwd_ret_1d")).write_parquet(
+        case_dir / "labels" / "fwd_ret_1d.parquet"
+    )
+    frame.with_columns(pl.lit(1.0).alias("feature")).write_parquet(
+        case_dir / "features" / "financial.parquet"
+    )
+
+
+@pytest.fixture
+def seeded_case_study(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    _seed(tmp_path)
+
+    import utils.modeling as modeling
+    from case_studies.utils import cv_window
+
+    monkeypatch.setattr(modeling, "load_feature_spec", lambda *_args: {})
+    monkeypatch.setattr(modeling, "load_label_spec", lambda *_args: {})
+    monkeypatch.setattr(
+        modeling,
+        "resolve_storage_path",
+        lambda _case_id, _spec, fallback: tmp_path / CASE / fallback,
+    )
+    cv_window._fold_splits.cache_clear()
+    cv_window._load_setup_yaml.cache_clear()
+    yield tmp_path
+    cv_window._fold_splits.cache_clear()
+    cv_window._load_setup_yaml.cache_clear()
+
+
+def _windows(splits: list[dict]) -> list[tuple]:
+    return [(s["fold"], s["val_start"], s["val_end"]) for s in splits]
+
+
+def test_the_dropped_entity_really_does_shorten_the_timeline(seeded_case_study: Path) -> None:
+    """Without this the test below could pass on a fixture where the reduction changes nothing."""
+    from utils.modeling import load_modeling_dataset
+
+    full = load_modeling_dataset(CASE, "fwd_ret_1d")
+    reduced = load_modeling_dataset(CASE, "fwd_ret_1d", max_symbols=4)
+
+    entity = full.entity_cols[0]
+    assert full.dataset[entity].n_unique() == 5
+    assert reduced.dataset[entity].n_unique() == 4
+    assert reduced.dataset["timestamp"].max() < full.dataset["timestamp"].max()
+
+
+def test_a_reduced_load_keeps_the_full_universe_fold_geometry(seeded_case_study: Path) -> None:
+    from utils.modeling import load_modeling_dataset
+
+    full = load_modeling_dataset(CASE, "fwd_ret_1d")
+    reduced = load_modeling_dataset(CASE, "fwd_ret_1d", max_symbols=4)
+
+    assert _windows(reduced.splits) == _windows(full.splits)
+
+
+def test_a_reduced_load_agrees_with_the_window_the_backtest_prices_on(
+    seeded_case_study: Path,
+) -> None:
+    """canonical_window reads the label parquet whole; a preview has to land on the same dates."""
+    from case_studies.utils.cv_window import canonical_window
+    from utils.modeling import load_modeling_dataset
+
+    reduced = load_modeling_dataset(CASE, "fwd_ret_1d", max_symbols=4)
+    window = canonical_window(CASE, "fwd_ret_1d")
+
+    assert window is not None
+    starts = [s["val_start"].date() for s in reduced.splits]
+    ends = [s["val_end"].date() for s in reduced.splits]
+    assert (min(starts), max(ends)) == window

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -895,6 +895,20 @@ def load_modeling_dataset(
     # against a frame made unique on its keys, and neither it nor the META_LEAK drop moves a row.
     #
     # Production runs pass ``max_symbols=0`` and no ``symbols``, so neither branch fires.
+    #
+    # Bound before the filter because the fold geometry below is derived from the label frame,
+    # and a reduced universe is a different timeline: ``generate_cv_splits`` reads the unique
+    # timestamps of whatever frame it is handed, so dropping 25 of cme_futures' 30 products
+    # removes four sessions and moves every fold boundary two sessions earlier. Measured
+    # 2026-09-06: the same call over the full universe puts fold 0's validation window at
+    # 2019-01-03..2020-01-02 and over a five-product preview at 2018-12-31..2019-12-30. Nothing
+    # downstream follows that shift - ``canonical_window`` always reads the whole label parquet -
+    # so the backtest loads prices for the canonical window, the preview's predictions carry two
+    # sessions that window does not, and ``Strategy._decision_weights`` refuses the decision
+    # artifact for keys outside the price grid. Before #780 the reduction ran after both frames
+    # were read whole, so this call already saw the full timeline; pushing it into the scans is
+    # what put a reduced frame here.
+    unreduced_labels_lazy = labels_lazy
     if entity_cols:
         primary_entity = entity_cols[0]
         keep: list | None = None
@@ -1003,7 +1017,7 @@ def load_modeling_dataset(
     # feature-joined frame lets warm-up nulls or feature availability shift the
     # calendar and makes model selection disagree with canonical_window().
     splits = generate_cv_splits(
-        labels,
+        unreduced_labels_lazy.select(date_col).unique().collect(),
         case_study_id=case_study_id,
         label_buffer=label_buffer,
         outcome_horizon=resolve_label_horizon(case_study_id, primary_label, setup),


### PR DESCRIPTION
`main` is red on `cs-cme_futures`: `13_backtest` raises `decision artifact contains keys outside the backtest price grid` at cell 11, and 14 through 19 cascade off it (ml4t/agent-workspace#1055).

## What it is

`load_modeling_dataset` derives the walk-forward geometry from the label frame, and `generate_cv_splits` reads the unique timestamps of whatever frame it is handed. #780 pushed the `max_symbols` reduction into the scans, so the frame reaching that call became the reduced one - and a reduced universe is a different calendar.

Measured on `cme_futures`, 2026-09-06, same function and same config, only the entity subset differing:

| universe | fold 0 validation window |
|---|---|
| all 30 products | 2019-01-03 .. 2020-01-02 |
| the 5 products CI's preview keeps | 2018-12-31 .. 2019-12-30 |

Dropping 25 of the 30 products removes four sessions from the timeline and moves every boundary two sessions earlier. Nothing downstream follows: `canonical_window` always reads the whole label parquet, so `load_backtest_prices_for` windows prices on the canonical geometry while the preview's predictions carry 2018-12-31 and 2019-01-02, which that window does not. Eight `(product, timestamp)` keys across five products, and `Strategy._decision_weights` refuses the decision artifact.

The comment three lines above the call already stated the rule this restores: fold identity belongs to the label contract, and deriving boundaries from a frame that feature availability or a reduction has narrowed makes model selection disagree with `canonical_window()`.

## Why it went red now

#780 landed before the last green run on `main` (b9235544). What is new is #808's adoption of `ml4t-diagnostic` 0.1.4, whose boundary rule follows the observed timeline where 0.1.2's did not. The canonical `cme_futures` predictions registered on 2026-08-30 carry fold windows that match `canonical_window` exactly, so the disagreement is not in the artifacts.

## Verification

End to end on the reductions CI uses - `06_linear` then `13_backtest`, both `EXECUTION_TIER=preview`, `folds: [0, 1]`, `max_symbols: 5`: exit 1 at cell 11 before, **exit 0 after**.

Production runs pass `max_symbols=0`, so the frame handed to `generate_cv_splits` is unchanged and no canonical fold geometry moves.

`tests/test_reduced_universe_keeps_the_fold_geometry.py` builds a case study whose dropped entity owns the tail of the calendar, so the full and reduced timelines really differ; two of its three tests fail with this change reverted.

136 passed across `test_reduced_universe_is_shared`, `test_cv_window_fold_splits`, `test_variant_fold_geometry`, `test_temporal_artifact_is_read_by_fold`, `test_modeling_input_lineage` and `test_smoke_configs`. One pre-existing failure, unchanged with this reverted: `test_corpus_temporal_fold_geometry_covers_resolved_validation_windows[us_equities_panel]`.

## Not this

`ch11-12` and `ch14-15` are also red on `main`, on `Fold-specific temporal artifact is not aligned with the canonical CV splits`, and clear with the fixture regeneration. `ch26` is red on neither: `01_drift_monitoring` and `05b_feast_live` both fail at cell 17 on an empty join, which is a third cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3GtYYaqpHTe5itLUYXomS