### PR TITLE
The shared preset tree is seeded once and never refreshed

### DIFF
--- a/tests/generate_intermediates.py
+++ b/tests/generate_intermediates.py
@@ -111,10 +111,29 @@ def seed_configs(output_dir: Path, case_studies: Iterable[str] = CASE_STUDIES) -
 
     # Copy global model presets so load_configs() can find them.
     # load_configs() resolves presets at {case_dir.parent}/config/{model_type}/*.yaml
+    #
+    # Refreshed on every run, like the per-case-study configs above. Guarding this on
+    # `not dst.exists()` meant the copy ran once, on a tree that had no config/ yet, and
+    # never again - so a preset added or edited after the first generation never reached
+    # the fixture. sp500_options/06_linear failed the 2026-09-06 regeneration on
+    # `Preset not found: lasso_f0.5.yaml`, which has been in case_studies/config/lasso/
+    # since the initial release: the fixture held only the five `lasso_a*` presets that
+    # existed when its config/ was first written.
+    #
+    # Refreshing is not the ownership problem the per-case-study loop guards against.
+    # These presets are shared by all nine case studies rather than owned by the one the
+    # run was scoped to, so bringing them into line with source is what a scoped run
+    # should do, not a rewrite of state it does not own.
     global_config_src = cs_root / "config"
     global_config_dst = output_dir / "config"
-    if global_config_src.exists() and not global_config_dst.exists():
-        shutil.copytree(global_config_src, global_config_dst)
+    if global_config_src.exists():
+        if global_config_dst.exists():
+            shutil.rmtree(global_config_dst)
+        shutil.copytree(
+            global_config_src,
+            global_config_dst,
+            ignore=shutil.ignore_patterns("__pycache__"),
+        )
         _patch_presets_for_testing(global_config_dst)
 
     print(f"Seeded configs into {output_dir} for: {', '.join(case_studies)}")

--- a/tests/test_generate_intermediates.py
+++ b/tests/test_generate_intermediates.py
@@ -96,3 +96,36 @@ def test_seed_configs_defaults_to_every_case_study(tmp_path: Path) -> None:
 
     seeded = {p.name for p in tmp_path.iterdir() if p.is_dir()}
     assert set(CASE_STUDIES) <= seeded
+
+
+def test_seed_configs_refreshes_shared_presets_over_an_existing_tree(tmp_path: Path) -> None:
+    """Every preset a seeded case study names has to resolve after seeding.
+
+    The shared preset copy used to be guarded on ``not dst.exists()``, so it ran once
+    on a tree that had no ``config/`` and never again. A preset added or edited after
+    that first generation never reached the fixture, and the notebook that named it
+    failed with ``Preset not found`` against a file that had been in the repo since the
+    initial release - which is how sp500_options/06_linear went down on 2026-09-06.
+
+    Written against the contract rather than the copy: seed over a tree that already
+    holds a stale ``config/``, then require that every preset named by a seeded case
+    study's training menus exists. That fails on the old guard and cannot be satisfied
+    by any implementation that leaves a preset behind.
+    """
+    stale = tmp_path / "config" / "lasso"
+    stale.mkdir(parents=True)
+    (stale / "lasso_a0.1.yaml").write_text("stale: true\n")
+
+    seed_configs(tmp_path, ["sp500_options"])
+
+    named: set[str] = set()
+    for menu in (tmp_path / "sp500_options" / "config" / "training").glob("*.yaml"):
+        for line in menu.read_text().splitlines():
+            entry = line.strip()
+            if entry.startswith("- "):
+                named.add(entry[2:].strip().strip("\"'"))
+
+    assert named, "no presets named by sp500_options' training menus"
+    available = {p.stem for p in (tmp_path / "config").rglob("*.yaml")}
+    assert named <= available, f"presets named but not seeded: {sorted(named - available)}"
+    assert "stale" not in (stale / "lasso_a0.1.yaml").read_text()


### PR DESCRIPTION
`sp500_options/06_linear` failed the 2026-09-06 fixture regeneration on `Preset not found: lasso_f0.5.yaml`, against a file that has been in `case_studies/config/lasso/` since the initial release.

`seed_configs` copies the per-case-study configs with rmtree-then-copytree, but guarded the shared preset copy on `not global_config_dst.exists()`. That guard runs the copy exactly once, on a tree that has no `config/` yet, and never again - so every preset added or edited after a fixture's first generation stayed absent from it.

Measured against `origin/main`: `sp500_options`' training menus name **50** presets the seeding leaves unavailable, of which `lasso_f0.5` is the one that happened to fail first.

Refreshing is not the ownership problem the per-case-study loop guards against. These presets are shared by all nine case studies rather than owned by the one a run was scoped to, so bringing them into line with source is what a scoped run should do. `__pycache__` is excluded now that the copy runs every time.

The test asserts the contract rather than the copy: seed over a tree that already holds a stale `config/`, then require every preset named by a seeded case study's training menus to resolve. Verified to fail on `origin/main`, naming all 50.