### PR TITLE
uep names the notebook behind a registry row, at the five call sites that record it

### DIFF
--- a/case_studies/us_equities_panel/06_linear.ipynb
+++ b/case_studies/us_equities_panel/06_linear.ipynb
@@ -287,6 +287,7 @@
     "    configs,\n",
     "    execution_tier=EXECUTION_TIER,\n",
     "    preview_reductions=PREVIEW_REDUCTIONS,\n",
+    "    notebook=\"06_linear\",\n",
     ")\n",
     "plan = plan_models(study, requests=requests)\n",
     "\n",

--- a/case_studies/us_equities_panel/06_linear.py
+++ b/case_studies/us_equities_panel/06_linear.py
@@ -223,6 +223,7 @@ requests = model_requests(
     configs,
     execution_tier=EXECUTION_TIER,
     preview_reductions=PREVIEW_REDUCTIONS,
+    notebook="06_linear",
 )
 plan = plan_models(study, requests=requests)
 

--- a/case_studies/us_equities_panel/07_gbm.ipynb
+++ b/case_studies/us_equities_panel/07_gbm.ipynb
@@ -291,6 +291,7 @@
     "    configs,\n",
     "    execution_tier=EXECUTION_TIER,\n",
     "    preview_reductions=PREVIEW_REDUCTIONS,\n",
+    "    notebook=\"07_gbm\",\n",
     ")\n",
     "plan = plan_models(study, requests=requests)\n",
     "\n",

--- a/case_studies/us_equities_panel/07_gbm.py
+++ b/case_studies/us_equities_panel/07_gbm.py
@@ -227,6 +227,7 @@ requests = model_requests(
     configs,
     execution_tier=EXECUTION_TIER,
     preview_reductions=PREVIEW_REDUCTIONS,
+    notebook="07_gbm",
 )
 plan = plan_models(study, requests=requests)
 

--- a/case_studies/us_equities_panel/08_tabular_dl.ipynb
+++ b/case_studies/us_equities_panel/08_tabular_dl.ipynb
@@ -260,6 +260,7 @@
     "            overrides=overrides,\n",
     "            execution_tier=EXECUTION_TIER,\n",
     "            preview_reductions=preview_reductions,\n",
+    "            notebook=\"08_tabular_dl\",\n",
     "        )\n",
     "    )\n",
     "requests = tuple(requests)\n",

--- a/case_studies/us_equities_panel/08_tabular_dl.py
+++ b/case_studies/us_equities_panel/08_tabular_dl.py
@@ -220,6 +220,7 @@ for config_name in selected_names:
             overrides=overrides,
             execution_tier=EXECUTION_TIER,
             preview_reductions=preview_reductions,
+            notebook="08_tabular_dl",
         )
     )
 requests = tuple(requests)

--- a/case_studies/us_equities_panel/13a_pca.ipynb
+++ b/case_studies/us_equities_panel/13a_pca.ipynb
@@ -536,6 +536,7 @@
     "        overrides=dict(OVERRIDES),\n",
     "        execution_tier=EXECUTION_TIER,\n",
     "        preview_reductions=preview_reductions,\n",
+    "        notebook=\"13a_pca\",\n",
     "    )\n",
     "    for label in selected_labels\n",
     ")\n",

--- a/case_studies/us_equities_panel/13a_pca.py
+++ b/case_studies/us_equities_panel/13a_pca.py
@@ -187,6 +187,7 @@ requests = tuple(
         overrides=dict(OVERRIDES),
         execution_tier=EXECUTION_TIER,
         preview_reductions=preview_reductions,
+        notebook="13a_pca",
     )
     for label in selected_labels
 )

--- a/case_studies/us_equities_panel/13b_ipca.ipynb
+++ b/case_studies/us_equities_panel/13b_ipca.ipynb
@@ -545,6 +545,7 @@
     "        overrides=dict(OVERRIDES),\n",
     "        execution_tier=EXECUTION_TIER,\n",
     "        preview_reductions=preview_reductions,\n",
+    "        notebook=\"13b_ipca\",\n",
     "    )\n",
     "    for label in selected_labels\n",
     ")\n",

--- a/case_studies/us_equities_panel/13b_ipca.py
+++ b/case_studies/us_equities_panel/13b_ipca.py
@@ -196,6 +196,7 @@ requests = tuple(
         overrides=dict(OVERRIDES),
         execution_tier=EXECUTION_TIER,
         preview_reductions=preview_reductions,
+        notebook="13b_ipca",
     )
     for label in selected_labels
 )


### PR DESCRIPTION
Nothing tied a `us_equities_panel` registry row to the notebook that wrote it.
`entry_point` cannot answer that question - it names the module, and several
notebooks share one - and `notebook_path` exists to answer it. The boundary has
carried the argument all along; it was simply absent at uep's call sites.

## Why now rather than later

It is provenance, not identity. Both fields sit in
`registry/specs.py:_V2_PROVENANCE_FIELDS`, so passing the name moves no hash and
refits nothing. But it is a code cell, and `notebook_provenance.py` compares the
paired `.py` blob against the stamp, so adding it to an already-executed notebook
invalidates that stamp and costs a re-execution. uep has not executed stages 06+,
so the argument is free today and is not free after.

## The five sites threaded

Each verified by finding the read in the family that serves it, not by assuming
the boundary forwards it:

| Notebook | Call | Read at |
|---|---|---|
| `06_linear` | `model_requests` | `utils/linear.py:571` |
| `07_gbm` | `model_requests` | `utils/gbm.py:1820` |
| `08_tabular_dl` | `study.model` | `utils/tabular_dl.py:441` |
| `13a_pca` | `study.model` | `utils/latent_factors/adapter.py:515` |
| `13b_ipca` | `study.model` | `utils/latent_factors/adapter.py:515` |

## The four sites left alone, and why

**`09_dl_nlinear`, `10_dl_lstm`, `11_dl_tsmixer`.** `study.model` accepts
`notebook` into `ModelRequest` (`research/models.py:284`) and carries it in
`as_dict()` (`:338`), but `deep_learning` contains zero occurrences of
`request.get("notebook")` - its `resolve_model_request` never reads the key, so
nothing is recorded. The `notebook=` parameter that module does have at `:1892` is
a different entry point, the one `12_dl_weekly` uses, and it forwards as
`entry_point=notebook` at `:1915` - the other column, and the wrong answer to
this question. Threading it here would read as provenance in the diff and record
none in the registry.

**`14_causal_dml`.** `CausalRequest.from_request` validates against an explicit
`supported` set that excludes `notebook`. Constructing one confirms it does not
merely ignore the field:

```
ValueError: unsupported causal request fields: ['notebook']
```

Both gaps are in the shared boundary rather than in uep, so they belong to
whoever closes the fleet-wide disposition, not here. Until they land there is
nothing these four notebooks can usefully pass.

## Verification

Behavioural, not by reading:

```
linear      entry_point=case_studies.utils.linear
            notebook_path with argument -> 'stem_linear'
            notebook_path without       -> None
tabular_dl  entry_point=case_studies.utils.tabular_dl
            notebook_path with argument -> 'stem_tabular_dl'
            notebook_path without       -> None
```

`entry_point` is unchanged in both cases, so the two columns keep answering
different questions.

ruff and ruff-format clean; jupytext pairs synced; the provenance sync gate and
the verified-notebook gate both pass. No notebook was executed.

`20_strategy_analysis.ipynb` reports a `ruff format` diff, and it does so on
`origin/main` too - reproduced against main's own blob. Pre-existing and not
touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SP3KUnd2D1Hjc4p8beVzN
