### PR TITLE
Name the notebook on the four etfs model requests the chain has not reached

### DIFF
--- a/case_studies/etfs/10a_dl_nlinear.ipynb
+++ b/case_studies/etfs/10a_dl_nlinear.ipynb
@@ -345,6 +345,7 @@
     "    execution_tier=EXECUTION_TIER,\n",
     "    overrides={\"device\": device},\n",
     "    preview_reductions=PREVIEW_REDUCTIONS,\n",
+    "    notebook=\"10a_dl_nlinear\",\n",
     ")\n",
     "resolved = tuple(request.resolve() for request in requests)\n",
     "\n",

--- a/case_studies/etfs/10a_dl_nlinear.py
+++ b/case_studies/etfs/10a_dl_nlinear.py
@@ -241,6 +241,7 @@ requests = model_requests(
     execution_tier=EXECUTION_TIER,
     overrides={"device": device},
     preview_reductions=PREVIEW_REDUCTIONS,
+    notebook="10a_dl_nlinear",
 )
 resolved = tuple(request.resolve() for request in requests)
 

--- a/case_studies/etfs/11a_pca.ipynb
+++ b/case_studies/etfs/11a_pca.ipynb
@@ -324,6 +324,7 @@
     "    execution_tier=EXECUTION_TIER,\n",
     "    overrides=overrides,\n",
     "    preview_reductions=PREVIEW_REDUCTIONS,\n",
+    "    notebook=\"11a_pca\",\n",
     ")\n",
     "resolved = tuple(request.resolve() for request in requests)\n",
     "\n",

--- a/case_studies/etfs/11a_pca.py
+++ b/case_studies/etfs/11a_pca.py
@@ -200,6 +200,7 @@ requests = model_requests(
     execution_tier=EXECUTION_TIER,
     overrides=overrides,
     preview_reductions=PREVIEW_REDUCTIONS,
+    notebook="11a_pca",
 )
 resolved = tuple(request.resolve() for request in requests)
 

--- a/case_studies/etfs/11b_ipca.ipynb
+++ b/case_studies/etfs/11b_ipca.ipynb
@@ -329,6 +329,7 @@
     "    execution_tier=EXECUTION_TIER,\n",
     "    overrides=overrides,\n",
     "    preview_reductions=PREVIEW_REDUCTIONS,\n",
+    "    notebook=\"11b_ipca\",\n",
     ")\n",
     "resolved = tuple(request.resolve() for request in requests)\n",
     "\n",

--- a/case_studies/etfs/11b_ipca.py
+++ b/case_studies/etfs/11b_ipca.py
@@ -205,6 +205,7 @@ requests = model_requests(
     execution_tier=EXECUTION_TIER,
     overrides=overrides,
     preview_reductions=PREVIEW_REDUCTIONS,
+    notebook="11b_ipca",
 )
 resolved = tuple(request.resolve() for request in requests)
 

--- a/case_studies/etfs/11c_conditional_autoencoder.ipynb
+++ b/case_studies/etfs/11c_conditional_autoencoder.ipynb
@@ -304,6 +304,7 @@
     "    execution_tier=EXECUTION_TIER,\n",
     "    overrides={\"device\": device},\n",
     "    preview_reductions=PREVIEW_REDUCTIONS,\n",
+    "    notebook=\"11c_conditional_autoencoder\",\n",
     ")\n",
     "resolved = tuple(request.resolve() for request in requests)\n",
     "\n",

--- a/case_studies/etfs/11c_conditional_autoencoder.py
+++ b/case_studies/etfs/11c_conditional_autoencoder.py
@@ -201,6 +201,7 @@ requests = model_requests(
     execution_tier=EXECUTION_TIER,
     overrides={"device": device},
     preview_reductions=PREVIEW_REDUCTIONS,
+    notebook="11c_conditional_autoencoder",
 )
 resolved = tuple(request.resolve() for request in requests)
 


### PR DESCRIPTION
A registered training run should say which notebook produced it. `tests/test_model_registry.py::test_model_notebook` checks exactly that and is in `.github/ci/unit-test-quarantine.txt`, where the entry reads "nothing runs it".

The mechanism already exists end to end: `model_requests(..., notebook=)` reaches every family runner, and each writes `runtime_provenance["notebook_path"]` - `linear.py:189`, `gbm.py:1524`, `tabular_dl.py:141`, `deep_learning.py`, `latent_factors/adapter.py:162`. Only `us_firm_characteristics` passes it, so 54 of the 61 registering notebooks write rows that name nothing.

## Why only four notebooks

`notebook_path` is in `_V2_PROVENANCE_FIELDS`, so no training identity moves and nothing refits. But the argument goes in a code cell, and the provenance gate keys on the paired `.py` (`source_py_blob`), so threading it into an already-executed notebook makes that notebook's stamp stale and costs it a re-run.

Running the gate over all 54 gives 39 stamped and 15 unverified. These four carry no stamp and sit at jobs 7 to 10 of `prod-etfs-2`, which is on job 3, so they are threaded ahead of their own execution and cost nothing.

The other 50 are not free in the same way:

- **9 cannot be threaded at all.** `Study.causal` passes `**request` into `CausalRequest`, which has no notebook field, so every `*_causal_dml` notebook needs a library change before its call site can name anything.
- **10 belong to two active case studies** (`nasdaq100_microstructure`, `us_equities_panel`) and land with work those sessions are already doing.
- **The rest are stamped**, and are threaded as their chains reach them rather than by re-running a notebook to add a provenance field.

The check stays quarantined until a regenerated case study's `cs-<id>` passes it. Un-quarantining now would put a red check on `main` on landing day.

Verified: `notebook_provenance.py check` reports the four as unverified with 0 stale, and `uv run ruff check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Smmj8LBZc1vzgXHQDZsmX