### PR TITLE
A causal request can name the notebook that submitted it

### DIFF
--- a/case_studies/research/causal.py
+++ b/case_studies/research/causal.py
@@ -279,6 +279,12 @@ class CausalRequest:
     execution_tier: ExecutionTier
     preview_reductions: dict[str, Any]
     supersedes: str | None = None
+    # The notebook that submitted this request, for `runtime_provenance["notebook_path"]`.
+    # Provenance only - `registry/specs.py:_V2_PROVENANCE_FIELDS` excludes it from the causal
+    # identity, so two notebooks submitting the same analysis still collide on one hash. It
+    # answers the separate question of which notebook produced a row, and `entry_point` cannot:
+    # that names the module (`case_studies.utils.causal`), which every causal notebook shares.
+    notebook: str | None = None
 
     @classmethod
     def from_request(cls, study: Study, request: dict[str, Any]) -> CausalRequest:
@@ -290,6 +296,7 @@ class CausalRequest:
             "execution_tier",
             "preview_reductions",
             "supersedes",
+            "notebook",
         }
         unknown = set(request) - supported
         if unknown:
@@ -316,6 +323,7 @@ class CausalRequest:
             execution_tier=tier,
             preview_reductions=reductions,
             supersedes=(str(request["supersedes"]) if request.get("supersedes") else None),
+            notebook=(str(request["notebook"]) if request.get("notebook") else None),
         )
 
     def as_dict(self) -> dict[str, Any]:
@@ -326,9 +334,13 @@ class CausalRequest:
             "overrides": dict(self.overrides),
             "execution_tier": self.execution_tier.value,
             "preview_reductions": dict(self.preview_reductions),
+            "notebook": self.notebook,
         }
         # `supersedes` is absent on purpose: this dict is what the resolver turns into
-        # the spec, and the spec is hashed.
+        # the spec, and the spec is hashed. `notebook` is present and safe for the same
+        # reason `supersedes` is not: the resolver reads every field by name and builds
+        # `computation` from a literal set of keys, so a request key it does not name
+        # cannot reach the hash. It lands in `provenance`, which the identity excludes.
 
     def resolve(self) -> ResolvedCausalRequest:
         module = get_adapter("causal", self.method)

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1771,7 +1771,14 @@ def run_resolved_causal_request(
         refutation_n_successful=int(refutation_n) if refutation_n is not None else None,
         refutation_placebo_json=_placebo_draws_json(refutation),
         spec_json=canonical_json(spec),
-        notebook="case_studies.utils.causal",
+        # `causal_runs.notebook` says which notebook produced the row, and this path used to
+        # write the module string - which `spec_json.provenance.entry_point` already carries,
+        # and which every causal notebook shares. `us_firm_characteristics` shows the result:
+        # three rows under `09_causal_dml` from `register_causal_run`'s direct callers and
+        # three under `case_studies.utils.causal` from this one, one notebook answering as two
+        # populations. NULL when the request names no notebook, because a wrong name is worse
+        # than none. A column, not part of the spec, so it cannot move `causal_hash`.
+        notebook=(spec.get("provenance") or {}).get("notebook_path"),
         started_at=results.get("started_at"),
         elapsed_s=results.get("elapsed_s"),
         case_dir=case_dir,

--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1112,14 +1112,22 @@ def _causal_runtime_identity() -> dict[str, str]:
     }
 
 
-def _causal_runtime_provenance(study: Study) -> dict[str, Any]:
-    return {
+def _causal_runtime_provenance(study: Study, *, notebook: str | None = None) -> dict[str, Any]:
+    record: dict[str, Any] = {
         "entry_point": "case_studies.utils.causal",
         "packages": _causal_runtime_identity(),
         "platform": platform.platform(),
         "python": platform.python_version(),
         "source_commit": study.manifest.get("baseline_source_commit", "unknown"),
     }
+    # `notebook_path` says which notebook produced a row; `entry_point` says which module ran.
+    # Different questions, and the module is legitimately shared - every causal notebook calls
+    # this one, so `entry_point` cannot name a notebook and should not try. Both sit in
+    # `registry/specs.py:_V2_PROVENANCE_FIELDS`, so neither reaches the causal identity. Absent
+    # when the caller names no notebook: a wrong notebook name would be worse than none.
+    if notebook:
+        record["notebook_path"] = notebook
+    return record
 
 
 def _whole_timestamp_tail(
@@ -1573,7 +1581,7 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     }
     if tier is ExecutionTier.PREVIEW:
         computation["preview_reductions"] = reductions
-    provenance = _causal_runtime_provenance(study)
+    provenance = _causal_runtime_provenance(study, notebook=request.get("notebook"))
     spec = ResolvedSpec.create(
         family="causal_dml",
         label=label_ref.name,

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -951,3 +951,48 @@ def test_naming_the_notebook_records_provenance_without_moving_the_identity(
     assert named.spec["provenance"]["notebook_path"] == "11_causal_dml"
     assert "notebook_path" not in unnamed.spec["provenance"]
     assert named.spec["provenance"]["entry_point"] == "case_studies.utils.causal"
+
+
+def test_the_registered_row_names_the_notebook_not_the_module(tmp_path, monkeypatch) -> None:
+    """`causal_runs.notebook` must answer which notebook ran, and the module is not an answer.
+
+    This path used to write the literal `"case_studies.utils.causal"` into that column, which
+    `spec_json.provenance.entry_point` already carries and which every `*_causal_dml` notebook
+    shares. The other writer, `register_causal_run`'s direct callers, writes the stem - so one
+    notebook appeared in the registry as two populations. `us_firm_characteristics` holds three
+    rows each way today.
+
+    A column, not part of the spec, so it cannot move `causal_hash` - pinned separately by
+    `test_naming_the_notebook_records_provenance_without_moving_the_identity`.
+    """
+    import sqlite3
+
+    from case_studies.utils import causal as causal_module
+
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
+    # The fit itself is not what is under test and the fixture panel is too short to run a
+    # canonical five-fold DML, so the analysis is canned the way the supersedes tests can it.
+    # What is under test is the value the registration writes into one column.
+    monkeypatch.setattr(
+        causal_module,
+        "run_dml_analysis",
+        lambda *a, **k: {
+            "dml_result": {"theta": 0.02, "se_hac": 0.01, "n_obs": 120},
+            "p_value_hac": 0.04,
+            "naive_effect": 0.03,
+            "confounding_bias_pct": 50.0,
+            "refutation": {"empirical_p": 0.1, "n_successful": 100},
+            "started_at": "2026-08-15T00:00:00+00:00",
+            "elapsed_s": 1.0,
+        },
+    )
+
+    result = study.causal(method="dml", label=label.name, notebook="09_causal_dml").run()
+
+    with sqlite3.connect(study.storage_root("canonical") / "run_log" / "registry.db") as db:
+        stored = db.execute(
+            "SELECT notebook FROM causal_runs WHERE causal_hash = ?", (result.hash,)
+        ).fetchone()
+
+    assert stored is not None, "the run registered no causal row"
+    assert stored[0] == "09_causal_dml"

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -924,3 +924,30 @@ def test_the_outcome_horizon_is_registered_and_is_not_the_buffer(tmp_path, monke
 
     assert refutation["label_buffer_steps"] == 3
     assert refutation["label_horizon_steps"] == 1
+
+
+def test_naming_the_notebook_records_provenance_without_moving_the_identity(
+    tmp_path, monkeypatch
+) -> None:
+    """`notebook=` answers which notebook wrote a row, and must not reprice the analysis.
+
+    `entry_point` in a causal spec names the module, `case_studies.utils.causal`, which every
+    `*_causal_dml` notebook shares - so it cannot say which one ran. `notebook_path` can, and
+    it is in `_V2_PROVENANCE_FIELDS`, so recording it moves no hash and forces no refit. That
+    is the whole reason this is safe to add to notebooks whose rows already exist, and it is
+    worth pinning rather than asserting: `computation` is hashed whole, so a request field
+    that leaked into it would reprice every causal row in the corpus.
+    """
+    study, label, _frame = _causal_fixture(tmp_path, monkeypatch)
+
+    unnamed = study.causal(method="dml", label=label.name).resolve()
+    named = study.causal(method="dml", label=label.name, notebook="11_causal_dml").resolve()
+
+    from case_studies.utils.registry.specs import training_hash_from_spec
+
+    assert named.spec["computation"] == unnamed.spec["computation"]
+    assert training_hash_from_spec(named.spec) == training_hash_from_spec(unnamed.spec)
+
+    assert named.spec["provenance"]["notebook_path"] == "11_causal_dml"
+    assert "notebook_path" not in unnamed.spec["provenance"]
+    assert named.spec["provenance"]["entry_point"] == "case_studies.utils.causal"


### PR DESCRIPTION
Nine `*_causal_dml` notebooks cannot record which notebook wrote a registry row, and the causal path fails harder than the model path: `CausalRequest.from_request` validates its field set, so `study.causal(..., notebook=...)` raises

```
ValueError: unsupported causal request fields: ['notebook']
```

A sweep that threads `notebook=` across call sites by pattern therefore breaks all nine. ml4t/agent-workspace#1059.

## The change

`CausalRequest` gains `notebook` the way `ModelRequest` already has it, and `_causal_runtime_provenance` records it as `notebook_path`, the way the four family runners that support it already do (`gbm.py:1820`, `linear.py:571`, `tabular_dl.py:441`, `latent_factors/adapter.py:515`).

`entry_point` in a causal spec names the module, `case_studies.utils.causal`. All nine notebooks share it, so it cannot answer which one ran.

## Nothing reprices, and that is pinned rather than asserted

`notebook_path` and `runtime_provenance` are both in `registry/specs.py:_V2_PROVENANCE_FIELDS`, and the identity projects `computation` alone. There is exactly one causal resolver; it reads every request field by name and builds `computation` from a literal set of keys, so a request key it does not name cannot reach the hash.

`test_naming_the_notebook_records_provenance_without_moving_the_identity` resolves the same analysis with and without the argument and compares both `computation` and `training_hash_from_spec`. Mutation-verified: adding `computation["notebook"] = request.get("notebook")` to the resolver fails it.

82 passed across `test_causal_adapter.py`, `test_causal_registry_registration.py`, `test_causal_rows_are_resolvable.py` and `test_causal_supersedes.py`.

## No call site is threaded here

Adding the argument to a notebook changes a code cell, which makes an executed notebook's provenance stamp stale and costs it a re-run. The nine get it as their chains reach them. This PR lands the capability only, so nothing goes stale and no run is forced.

The matching gap in `case_studies/utils/deep_learning.py` is deliberately not in this PR: its `resolve_model_request` never reads the boundary's notebook key either, but the failure mode is silence rather than an exception, and five chains are executing against that module now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Smmj8LBZc1vzgXHQDZsmX