### PR TITLE
nasdaq names the notebook behind a registry row, at the two call sites that record it

### DIFF
--- a/case_studies/nasdaq100_microstructure/06_linear.ipynb
+++ b/case_studies/nasdaq100_microstructure/06_linear.ipynb
@@ -273,6 +273,7 @@
     "    configs,\n",
     "    execution_tier=EXECUTION_TIER,\n",
     "    preview_reductions=PREVIEW_REDUCTIONS,\n",
+    "    notebook=\"06_linear\",\n",
     ")\n",
     "plan = plan_models(study, requests=requests)\n",
     "\n",

--- a/case_studies/nasdaq100_microstructure/06_linear.py
+++ b/case_studies/nasdaq100_microstructure/06_linear.py
@@ -209,6 +209,7 @@ requests = model_requests(
     configs,
     execution_tier=EXECUTION_TIER,
     preview_reductions=PREVIEW_REDUCTIONS,
+    notebook="06_linear",
 )
 plan = plan_models(study, requests=requests)
 

--- a/case_studies/nasdaq100_microstructure/07_gbm.ipynb
+++ b/case_studies/nasdaq100_microstructure/07_gbm.ipynb
@@ -287,6 +287,7 @@
     "    configs,\n",
     "    execution_tier=EXECUTION_TIER,\n",
     "    preview_reductions=PREVIEW_REDUCTIONS,\n",
+    "    notebook=\"07_gbm\",\n",
     ")\n",
     "plan = plan_models(study, requests=requests)\n",
     "\n",

--- a/case_studies/nasdaq100_microstructure/07_gbm.py
+++ b/case_studies/nasdaq100_microstructure/07_gbm.py
@@ -223,6 +223,7 @@ requests = model_requests(
     configs,
     execution_tier=EXECUTION_TIER,
     preview_reductions=PREVIEW_REDUCTIONS,
+    notebook="07_gbm",
 )
 plan = plan_models(study, requests=requests)
 


### PR DESCRIPTION
Nothing tied a `nasdaq100_microstructure` training row to the notebook that wrote
it. `entry_point` names the module, several notebooks share one, and
`notebook_path` is the field that answers "which notebook". The boundary has
carried the argument all along - `model_requests(..., notebook=...)` at
`research/configs.py:170` forwards it into `study.model` - and it was simply
absent at these call sites.

## Why now rather than after nasdaq executes

It is provenance, not identity. `registry/specs.py:_V2_PROVENANCE_FIELDS`
excludes `notebook_path`, so passing it moves no training hash and refits
nothing. But it is a code cell, and `notebook_provenance.py` compares the paired
`.py` blob against the stamp, so adding it to an already-executed notebook
invalidates that stamp and costs a re-execution. Both notebooks here report
UNVERIFIED with no outputs in the `.ipynb`, so the argument is free today and is
not free after the next production chain.

## The two sites threaded, and verified on rows rather than reads

A preview smoke of each, at the reduction its `tests/smoke.yaml` entry declares
(one fold, five symbols), then the registry read back out of the workspace:

| Notebook | Family | Read at | Rows | `notebook_path` |
|---|---|---|---|---|
| `06_linear` | linear | `utils/linear.py:571` | 16 | `06_linear` on all 16 |
| `07_gbm` | gbm | `utils/gbm.py:1820` | 15 | `07_gbm` on all 15 |

Both exited 0 at 6.4 GB peak. `entry_point` also carries the stem on these two
paths, which is the disposition `tests/test_model_registry.py` records as settled
on 2026-08-25: the migrated family runners write the stem there rather than the
module, so the check's two halves agree instead of covering for each other.

## The five sites left alone

Threading the argument at either would read as provenance in the diff and record
nothing in the registry.

**`08_dl_nlinear`, `09_dl_lstm`, `10_dl_tcn`, `11_dl_patchtst`.**
`config/training/fwd_ret_15m.yaml:39-43` files nlinear, lstm_h64, tcn and
patchtst under the `deep_learning` family, so all four resolve through
`utils/deep_learning.py`. Its `_sequence_runtime_provenance` (`:171-187`)
hardcodes `entry_point: "case_studies.utils.deep_learning"` and never reads the
`notebook` key that `ModelRequest` carries. The `notebook=` parameter that module
does have at `:1892` is a different, direct-call entry point, and it forwards as
`entry_point=notebook` at `:1915` - the other column.

**`12_causal_dml`.** `CausalRequest.from_request` validates against an explicit
`supported` set (`research/causal.py:285-296`) with no `notebook` field, so
passing it raises `ValueError` rather than being ignored.

## A finding this PR does not fix

The causal path is not merely missing the argument. `causal_runs` already has a
`notebook` column (`utils/registry/store.py:171`), and
`run_resolved_causal_request` fills it with `"case_studies.utils.causal"`
(`utils/causal.py:1766`) - the module in the column named for the notebook, which
is the `entry_point` defect one table over. It affects nine `*_causal_dml`
notebooks, and the consequence is already in the registry: `us_firm_characteristics`
`causal_runs` holds six rows for one notebook under two spellings, `09_causal_dml`
on the older direct-call path and `case_studies.utils.causal` on the modern
request-driven one. A query grouping on the column sees two populations that are
one. Tracked in ml4t/agent-workspace#1059.

Fixed at the write site while this PR was open: #824 (`d17f4341`) adds `notebook`
to `CausalRequest` and lands `spec.provenance.notebook_path` in the column instead
of the module string, so the two spellings will not recur. The existing
`us_firm_characteristics` rows keep theirs until that case study re-runs. The
`12_causal_dml` call site here is still untouched, because threading it is only
free before a notebook executes and nasdaq's causal stage is queued behind its own
production chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3GtYYaqpHTe5itLUYXomS
