### PR TITLE
The backtest engine and what it reports: five defects across ruin, feasibility, previews, risk triggers and concentration

### DIFF
--- a/case_studies/cme_futures/research_workflow.py
+++ b/case_studies/cme_futures/research_workflow.py
@@ -1103,14 +1103,40 @@ def rank_by_validation_sharpe(
     The same rule `CandidateSet._ranked_validation_hashes` applies, so a preview ranking and a
     canonical one differ in which rows they see and in nothing else. A member with no Sharpe is
     refused rather than sorted to an end, which is what a null would otherwise do silently.
+
+    Unless it is bankrupt. A null Sharpe used to mean exactly one thing - the run was not
+    measured - and refusing was the whole of the right answer. Since ml4t/agent-workspace#920
+    it means two, because a path whose equity reaches zero stops compounding and registers
+    `sharpe`, `sortino`, `calmar`, `omega`, `stability` and `tail_ratio` as null on purpose:
+    ranking a bankrupt path is the thing that issue exists to prevent. The `ruin` column is what
+    separates the two, so this reads it rather than testing the Sharpe alone:
+
+    * ``ruin = 1.0`` - bankrupt. It sorts last, ahead of nothing, and is never selected. It does
+      not disqualify the set, because a sweep that produced one bankrupt member and eleven
+      solvent ones has a perfectly good ranking of the eleven.
+    * null Sharpe, no ruin flag - not measured. Refused, as before.
+
+    Sorting last rather than dropping is what `strategy_analysis.rank_returns_on_common_support`
+    already does for the same condition, so a reader comparing the two sees one rule.
+
+    A registry written before #920 has no `ruin` column at all, which is not the same as no
+    bankrupt member; there the check falls back to the null test that was the whole rule then.
     """
     members = {result.hash: result for result in results}
     if not members:
         raise ValueError("ranking by validation Sharpe requires at least one result")
+    table = study.backtests.table(include_preview=True)
+    ruined = (
+        (pl.col("ruin") == 1.0).fill_null(False) if "ruin" in table.columns else pl.lit(False)  # noqa: FBT003
+    )
     rows = (
-        study.backtests.table(include_preview=True)
-        .filter(pl.col("backtest_hash").is_in(list(members)) & pl.col("sharpe").is_not_null())
-        .sort("sharpe", "backtest_hash", descending=[True, False])
+        table.filter(
+            pl.col("backtest_hash").is_in(list(members)) & (pl.col("sharpe").is_not_null() | ruined)
+        )
+        .with_columns(ruined.alias("_ruined"))
+        .sort(
+            "_ruined", "sharpe", "backtest_hash", descending=[False, True, False], nulls_last=True
+        )
     )
     if rows.height != len(members):
         raise ValueError("a result being ranked has no validation Sharpe recorded")

--- a/case_studies/research/catalog.py
+++ b/case_studies/research/catalog.py
@@ -111,6 +111,15 @@ _BACKTEST_METRIC_COLUMNS = (
     # the engine floors the drawdown at -1.0 (ml4t/agent-workspace#920).
     "ruin",
     "ruin_period",
+    # How often each declared risk control acted. NULL means no control of that
+    # kind was declared, which is what separates an overlay that never fired from
+    # one that was never installed (ml4t/agent-workspace#1051).
+    "risk_triggers",
+    "risk_triggers_stop_loss",
+    "risk_triggers_trailing_stop",
+    "risk_triggers_time_exit",
+    "risk_triggers_max_drawdown",
+    "risk_triggers_daily_loss",
 )
 BACKTEST_RESERVED_COLUMNS: dict[str, Any] = {
     "catalog_version": pl.Int64,

--- a/case_studies/research/catalog.py
+++ b/case_studies/research/catalog.py
@@ -106,6 +106,11 @@ _BACKTEST_METRIC_COLUMNS = (
     # Sharpe clears zero.
     "sharpe_ci95_lo",
     "sharpe_ci95_hi",
+    # Whether the path ended, and where. Without these a catalog reader can only
+    # infer a bankrupt run from `max_drawdown`, and cannot infer it at all once
+    # the engine floors the drawdown at -1.0 (ml4t/agent-workspace#920).
+    "ruin",
+    "ruin_period",
 )
 BACKTEST_RESERVED_COLUMNS: dict[str, Any] = {
     "catalog_version": pl.Int64,

--- a/case_studies/utils/backtest_explorer.py
+++ b/case_studies/utils/backtest_explorer.py
@@ -50,6 +50,10 @@ _BEST_SCHEMA: dict[str, pl.DataType] = {
     "config_name": pl.Utf8,
     "label": pl.Utf8,
     "signal_method": pl.Utf8,
+    # The entry-scheme sweep varies concentration and nothing else, so without
+    # this the ten-row top table reads as one strategy repeated at different
+    # Sharpes (ml4t/agent-workspace#910).
+    "top_k": pl.Int64,
     "universe_filter": pl.Utf8,
     "exit_at_max_days": pl.Int64,
     "sharpe": pl.Float64,
@@ -288,8 +292,8 @@ class BacktestExplorer:
         -------
         pl.DataFrame
             Columns: backtest_hash, prediction_hash, source, family,
-            config_name, label, signal_method, sharpe, cagr, max_drawdown,
-            total_return, volatility, ic_mean
+            config_name, label, signal_method, top_k, sharpe, cagr,
+            max_drawdown, total_return, volatility, ic_mean
         """
         filter_sql = ""
         filter_params: list[str] = []
@@ -386,8 +390,14 @@ class BacktestExplorer:
         exit_at_max_days = [
             strategy_view(sp).get("signal", {}).get("exit_at_max_days") for sp in parsed
         ]
+        # Every entry scheme in a baseline sweep is `equal_weight_top_k` and varies
+        # only `top_k`, so `signal_method` alone made nine of the ten rows read as
+        # the same strategy. `top_k` sits one key across from `method` in the spec
+        # this block already parses (ml4t/agent-workspace#910).
+        top_k = [strategy_view(sp).get("signal", {}).get("top_k") for sp in parsed]
         df = df.with_columns(
             pl.Series("signal_method", methods),
+            pl.Series("top_k", top_k, dtype=pl.Int64),
             pl.Series("universe_filter", universe_filters),
             pl.Series("exit_at_max_days", exit_at_max_days, dtype=pl.Int64),
         )
@@ -400,6 +410,7 @@ class BacktestExplorer:
             "config_name",
             "label",
             "signal_method",
+            "top_k",
             "universe_filter",
             "exit_at_max_days",
             "sharpe",
@@ -1747,19 +1758,40 @@ class BacktestExplorer:
     # concentration_curve: Sharpe vs top_k at allocation stage
     # -----------------------------------------------------------------
 
-    def concentration_curve(self, prediction_hash: str) -> pl.DataFrame:
-        """Sharpe vs top_k for a given prediction at allocation stage.
+    def concentration_curve(
+        self, prediction_hash: str, *, stage: str | tuple[str, ...] = "allocation"
+    ) -> pl.DataFrame:
+        """Sharpe vs top_k for a given prediction, at one or more stages.
 
         Shows how portfolio concentration affects performance — typically
         more actionable than allocator comparison alone.
+
+        Parameters
+        ----------
+        stage : str or tuple of str, default ``"allocation"``
+            Which backtest stages to read. The default is unchanged, but the
+            entry-scheme sweep that varies concentration lives at the **signal**
+            stage, and that is where the first three notebooks of the backtesting
+            sequence read. This method used to hardcode the allocation stage, so
+            asking it about a baseline sweep returned an empty frame with no
+            indication that the rows were one stage away (ml4t/agent-workspace#910).
 
         Returns
         -------
         pl.DataFrame
             Columns: top_k, allocator, sharpe, max_drawdown, cagr
+
+        Raises
+        ------
+        ValueError
+            When the prediction has backtests, but none at the requested stage.
+            An empty frame cannot say whether the sweep was never run or was run
+            somewhere else, and those need different responses.
         """
+        stages = (stage,) if isinstance(stage, str) else tuple(stage)
+        placeholders = ", ".join("?" for _ in stages)
         df = self._query(
-            """
+            f"""
             SELECT
                 b.spec_json,
                 bm.sharpe,
@@ -1768,13 +1800,14 @@ class BacktestExplorer:
             FROM backtest_runs b
             JOIN backtest_metrics bm ON bm.backtest_hash = b.backtest_hash
             WHERE b.prediction_hash = ?
-              AND b.stage = 'allocation'
+              AND b.stage IN ({placeholders})
               AND bm.sharpe IS NOT NULL
               AND (bm.num_trades IS NULL OR bm.num_trades > 0)
             """,
-            (prediction_hash,),
+            (prediction_hash, *stages),
         )
         if df.is_empty():
+            self._refuse_if_the_curve_is_at_another_stage(prediction_hash, stages)
             return df
 
         rows = []
@@ -1800,6 +1833,28 @@ class BacktestExplorer:
             )
 
         return pl.DataFrame(rows).sort("top_k")
+
+    def _refuse_if_the_curve_is_at_another_stage(
+        self, prediction_hash: str, stages: tuple[str, ...]
+    ) -> None:
+        """Raise when this prediction has backtests, but not at the stage asked for."""
+        elsewhere = self._query(
+            "SELECT stage, COUNT(*) AS n FROM backtest_runs "
+            "WHERE prediction_hash = ? GROUP BY stage ORDER BY n DESC",
+            (prediction_hash,),
+        )
+        if elsewhere.is_empty():
+            return
+        held = {row["stage"]: row["n"] for row in elsewhere.iter_rows(named=True)}
+        if set(held) & set(stages):
+            return
+        counted = ", ".join(f"{name}: {n}" for name, n in held.items())
+        raise ValueError(
+            f"no concentration curve at stage {list(stages)} for prediction "
+            f"{prediction_hash[:12]} in {self.case_study}, which has backtests at "
+            f"{counted}. The entry-scheme sweep that varies top_k runs at the signal "
+            "stage; pass stage='signal' to read it."
+        )
 
     # -----------------------------------------------------------------
     # repr

--- a/case_studies/utils/backtest_explorer.py
+++ b/case_studies/utils/backtest_explorer.py
@@ -1191,7 +1191,8 @@ class BacktestExplorer:
         -------
         pl.DataFrame
             Columns: risk_name, risk_type, sharpe, max_drawdown, num_trades,
-            allocator, prediction_hash, baseline_sharpe, sharpe_delta
+            risk_triggers, allocator, prediction_hash, baseline_sharpe,
+            sharpe_delta
 
         Each overlay's ``baseline_sharpe`` is the no-overlay Sharpe of the
         allocation it was applied to, matched on ``(prediction_hash,
@@ -1207,6 +1208,13 @@ class BacktestExplorer:
         elif prediction_hashes:
             pred_clause = " AND b.prediction_hash IN (SELECT value FROM json_each(?))"
             pred_params = (json.dumps(list(prediction_hashes)),)
+        # Absent from a registry written before the engine counted triggers, where
+        # the question this column answers simply cannot be answered.
+        triggers_select = (
+            "bm.risk_triggers"
+            if self._has_metric_column("risk_triggers")
+            else "NULL AS risk_triggers"
+        )
         df = self._query(
             f"""
             SELECT
@@ -1216,7 +1224,8 @@ class BacktestExplorer:
                 t.config_name,
                 bm.sharpe,
                 bm.max_drawdown,
-                bm.num_trades
+                bm.num_trades,
+                {triggers_select}
             FROM backtest_runs b
             JOIN prediction_sets p ON b.prediction_hash = p.prediction_hash
             JOIN training_runs t ON p.training_hash = t.training_hash
@@ -1236,12 +1245,13 @@ class BacktestExplorer:
             return df
 
         rows = []
-        for spec_str, pred_h, sharpe, max_dd, trades in zip(
+        for spec_str, pred_h, sharpe, max_dd, trades, triggers in zip(
             df["spec_json"].to_list(),
             df["prediction_hash"].to_list(),
             df["sharpe"].to_list(),
             df["max_drawdown"].to_list(),
             df["num_trades"].to_list(),
+            df["risk_triggers"].to_list(),
             strict=False,
         ):
             spec = _parse_spec(spec_str) or {}
@@ -1267,6 +1277,12 @@ class BacktestExplorer:
                     "sharpe": sharpe,
                     "max_drawdown": max_dd,
                     "num_trades": trades,
+                    # How many times the control acted. 0 is an overlay that was
+                    # installed and never fired; NULL is a run the engine did not
+                    # count, which is every row registered before
+                    # ml4t/agent-workspace#1051. Matching Sharpe and trade counts
+                    # never established either one on their own.
+                    "risk_triggers": triggers,
                     "prediction_hash": pred_h,
                     "allocator": strategy_view(spec)
                     .get("allocation", {})

--- a/case_studies/utils/backtest_explorer.py
+++ b/case_studies/utils/backtest_explorer.py
@@ -158,6 +158,20 @@ class BacktestExplorer:
         finally:
             db.close()
 
+    def _has_metric_column(self, column: str) -> bool:
+        """Whether ``backtest_metrics`` carries this column in this registry.
+
+        A registry written before a metric existed has no column for it, and
+        selecting one that is not there is a hard SQLite error rather than a NULL.
+        """
+        db = sqlite3.connect(str(self._db_path))
+        try:
+            return column in {
+                row[1] for row in db.execute("PRAGMA table_info(backtest_metrics)").fetchall()
+            }
+        finally:
+            db.close()
+
     def _backtest_dir(self, b_hash: str) -> Path:
         return self.case_dir / "run_log" / "backtest" / b_hash
 
@@ -582,11 +596,22 @@ class BacktestExplorer:
         Returns
         -------
         pl.DataFrame
-            Columns: allocator, n, avg_sharpe, best_sharpe, avg_max_dd
+            Columns: allocator, n, ruined, avg_sharpe, best_sharpe, avg_max_dd.
+            ``n`` counts the runs with a rankable Sharpe and every statistic is
+            taken over those; ``ruined`` counts the runs the engine stopped at zero
+            equity, which carry no Sharpe to rank.
         """
         if not stages:
             return pl.DataFrame()
         placeholders = ", ".join("?" for _ in stages)
+        # A run the engine stopped at ruin carries a null Sharpe by design
+        # (ml4t/agent-workspace#920). Dropping those in SQL, as this query used to,
+        # would take an allocator that went bankrupt in every run off the table
+        # entirely and report the survivors as the whole population. The rows are
+        # kept and counted under `ruined`; the Sharpe and drawdown statistics are
+        # taken over the solvent runs only, so `avg_max_dd` is a mean of drawdowns
+        # that were actually measured.
+        ruin_select = "bm.ruin" if self._has_metric_column("ruin") else "NULL AS ruin"
         coverage_params: tuple[str, ...] = ()
         coverage_sql = full_coverage_prediction_sql("p", "t", "pm")
         if prediction_hashes:
@@ -603,7 +628,8 @@ class BacktestExplorer:
                 t.family,
                 t.config_name,
                 bm.sharpe,
-                bm.max_drawdown
+                bm.max_drawdown,
+                {ruin_select}
             FROM backtest_runs b
             JOIN prediction_sets p ON b.prediction_hash = p.prediction_hash
             JOIN training_runs t ON p.training_hash = t.training_hash
@@ -613,7 +639,6 @@ class BacktestExplorer:
               AND p.split != 'holdout'
               {excluded_family_sql(self.case_study, "t.family")[0]}
               {coverage_sql}
-              AND bm.sharpe IS NOT NULL
               AND (bm.num_trades IS NULL OR bm.num_trades > 0)
         """
         params: tuple = (
@@ -657,15 +682,21 @@ class BacktestExplorer:
         if df.is_empty():
             return df
 
+        # A run whose drawdown passed -100% crossed zero equity, so it is bankrupt
+        # whether or not the engine that produced it recorded `ruin` - registries
+        # written before that column carry the evidence only in the drawdown.
+        ruined = (pl.col("ruin") == 1.0) | (pl.col("max_drawdown") <= -1.0)
+        rankable = pl.col("sharpe").is_not_null() & ~ruined.fill_null(False)
         return (
             df.group_by("allocator")
             .agg(
-                n=pl.len(),
-                avg_sharpe=pl.col("sharpe").mean(),
-                best_sharpe=pl.col("sharpe").max(),
-                avg_max_dd=pl.col("max_drawdown").mean(),
+                n=rankable.sum(),
+                ruined=ruined.fill_null(False).sum(),
+                avg_sharpe=pl.col("sharpe").filter(rankable).mean(),
+                best_sharpe=pl.col("sharpe").filter(rankable).max(),
+                avg_max_dd=pl.col("max_drawdown").filter(rankable).mean(),
             )
-            .sort("avg_sharpe", descending=True)
+            .sort("avg_sharpe", descending=True, nulls_last=True)
         )
 
     # -----------------------------------------------------------------

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1210,10 +1210,35 @@ def resolved_allow_short_selling(
     return allow_short
 
 
-def restrict_to_priced_universe(
+def _restore_ruin_nans(metrics: dict) -> dict:
+    """Put the NaNs back that SQLite turned into NULLs on the way in.
+
+    `compute_portfolio_metrics` reports a stopped path's ranking metrics as NaN
+    precisely so a notebook formatting `f"{sharpe:.3f}"` prints `nan` rather than
+    raising on a None. SQLite stores that NaN as NULL, so the skip-if-complete
+    branch - which reads the metrics back out of the registry rather than
+    recomputing them - handed the None straight to those same lines. A cached
+    bankrupt run therefore failed where a fresh one printed
+    (ml4t/agent-workspace#1051's neighbour, found by review job #18941).
+
+    Only where `ruin` says the NULL was written on purpose. Everywhere else a
+    NULL means the metric was never computed, and inventing a NaN for it would
+    claim a measurement that was not made.
+    """
+    if metrics.get("ruin") != 1.0:
+        return metrics
+    from case_studies.utils.registry.store import _BACKTEST_UNCERTAINTY_COLUMNS
+
+    for name in (*RUIN_UNRANKABLE_METRICS, *_BACKTEST_UNCERTAINTY_COLUMNS):
+        if name in metrics and metrics[name] is None:
+            metrics[name] = float("nan")
+    return metrics
+
+
+def refuse_predictions_the_panel_cannot_price(
     predictions: pl.DataFrame, prices: pl.DataFrame, *, case_study: str, label: str
-) -> pl.DataFrame:
-    """Drop predictions for symbols the price panel does not carry.
+) -> None:
+    """Stop a vectorized run whose price panel does not cover what it will trade.
 
     The vectorized path takes both the universe and the P&L from the predictions
     frame - ``gross_ret = weight * y_true`` - and uses ``prices`` only for the
@@ -1225,24 +1250,29 @@ def restrict_to_priced_universe(
     19 s, and the random-signal plumbing Sharpe read -0.149212 at 100, 300, 1000
     and 3,708 symbols alike (ml4t/agent-workspace#911).
 
-    Restricting the predictions to the priced universe makes the panel mean what
-    the parameter reads as - the set this run can trade - so a reduced panel is a
-    reduced run, and a preview costs what a preview should. It also closes the
-    trap the issue names: the path was pricing positions in names the panel does
-    not carry, which would begin to differ silently between preview and production
-    the moment the vectorized path started joining prices for returns.
+    Silently trading the predictions the panel does not carry is what made that
+    knob inert, and quietly narrowing the predictions to the panel instead is
+    worse: the traded universe would then decide the portfolio without entering
+    the backtest identity, and the caller hashes its specification before it ever
+    reaches this module - `us_firm_characteristics/11_backtest.py:273` computes
+    `backtest_hash_from_parts` and skips a matching run before calling
+    `run_backtest`. A reduced preview would be served the full-universe result.
 
-    This is not a production change. Measured 2026-09-07: every one of the 3,708
-    symbols `us_firm_characteristics` predicts for `fwd_ret_1m` and `fwd_class_1m`
-    is in its 9,861-symbol price panel, so at ``max_symbols=0`` the filter removes
-    nothing.
+    So the run stops. A preview at a reduced `MAX_SYMBOLS` no longer measures the
+    production sweep at the production cost per backtest while looking reduced -
+    it refuses, and says which knob does reduce this stage. `TOP_N_PREDICTIONS`
+    cuts the number of backtests, and each one it leaves is a full, honest run.
 
-    The caller stamps the resulting width into the spec when the filter does
-    remove something - see ``run_backtest``. A reduced run is a different backtest
-    and has to hash as one.
+    This fires on nothing that exists. Measured 2026-09-07 on the
+    us_firm_characteristics panel: every one of the 3,708 symbols it predicts for
+    `fwd_ret_1m` and `fwd_class_1m` is in its 9,861-symbol price panel, and
+    ``top_entities`` - the one rule every reduction in the repo reaches - selects
+    the identical symbol set from the price panel and from the label panel at 5,
+    12 and 200, which are the caps `tests/overrides.yaml` runs the backtest
+    notebooks at.
     """
-    if "symbol" not in prices.columns or prices.is_empty():
-        return predictions
+    if "symbol" not in prices.columns or prices.is_empty() or predictions.is_empty():
+        return
     priced = prices.select("symbol").unique()
     if priced["symbol"].dtype != predictions["symbol"].dtype:
         priced = _align_symbol_dtype(
@@ -1252,15 +1282,20 @@ def restrict_to_priced_universe(
             target_side="predictions",
             other_side="price panel",
         )
-    restricted = predictions.join(priced, on="symbol", how="semi")
-    if restricted.is_empty() and not predictions.is_empty():
-        raise ValueError(
-            f"{case_study}/{label}: none of the {predictions['symbol'].n_unique()} predicted "
-            f"symbols appears in the {priced.height}-symbol price panel, so this backtest "
-            "would have no universe. The panel and the fitting stages are drawn from "
-            "different symbol sets, or the panel was reduced past every predicted name."
-        )
-    return restricted
+    unpriced = predictions.join(priced, on="symbol", how="anti")
+    if unpriced.is_empty():
+        return
+    missing = sorted(unpriced["symbol"].unique().to_list())
+    raise ValueError(
+        f"{case_study}/{label}: the price panel carries {priced.height} symbols and the "
+        f"predictions carry {predictions['symbol'].n_unique()}, {len(missing)} of which it "
+        f"cannot price (first: {missing[:5]}). The vectorized path takes its universe and "
+        "its P&L from the predictions, so a narrower panel does not reduce this run - it "
+        "would trade every predicted name at the full cost per backtest while reading as a "
+        "reduction. Load the panel the predictions were fitted on. To reduce this stage, "
+        "cut TOP_N_PREDICTIONS, which lowers the number of backtests and leaves each one a "
+        "full run."
+    )
 
 
 def run_backtest(
@@ -1404,49 +1439,17 @@ def run_backtest(
         prediction_hash=prediction_hash,
     )
 
-    # Make the price panel the tradeable universe on the vectorized path, which
-    # otherwise ignores it entirely - see `restrict_to_priced_universe`. Only where
-    # the selection is made here: when the caller hands in `precomputed_weights` the
-    # selection already happened, and quietly dropping positions out of it would
-    # leave weights that no longer sum to what the allocator solved for. The
-    # sp500_options HTM path is excluded because its `prices` frame and its
-    # predictions are not indexed by the same kind of symbol.
-    if (
-        strategy.get("rebalance", {}).get("mode") == "vectorized"
-        and precomputed_weights is None
-        and not (case_study == "sp500_options" and label == "ret_to_expiry")
+    # A price panel that does not cover the predictions does not reduce a
+    # vectorized run, it just makes the parameter read as if it did - see
+    # `refuse_predictions_the_panel_cannot_price`. The sp500_options HTM path is
+    # excluded because its `prices` frame and its predictions are not indexed by
+    # the same kind of symbol.
+    if strategy.get("rebalance", {}).get("mode") == "vectorized" and not (
+        case_study == "sp500_options" and label == "ret_to_expiry"
     ):
-        _before = predictions["symbol"].n_unique() if predictions.height else 0
-        predictions = restrict_to_priced_universe(
+        refuse_predictions_the_panel_cannot_price(
             predictions, prices, case_study=case_study, label=label
         )
-        _after = predictions["symbol"].n_unique() if predictions.height else 0
-        if _after != _before:
-            # A reduced universe is a different portfolio, so it has to be a
-            # different identity. Without this the skip-if-complete check below,
-            # and the same check `11_backtest` runs before submitting a scheme,
-            # both hash prediction + strategy alone: a preview at reduced
-            # MAX_SYMBOLS would be served the full-universe result, or would
-            # register its own numbers under the full run's hash.
-            #
-            # Stamped only when the filter bites, so no registered backtest is
-            # re-keyed: production panels cover every predicted symbol, and there
-            # the key never appears.
-            if resolved_spec_only:
-                raise ValueError(
-                    f"{case_study}/{label}: the price panel covers {_after} of the "
-                    f"{_before} predicted symbols, so this run would trade a narrower "
-                    "universe than the resolved specification it was handed declares. A "
-                    "locked backtest cannot have its universe narrowed underneath its "
-                    "own hash. Load the full price panel."
-                )
-            # Copied, not stamped in place: `ensure_backtest_spec` returns the
-            # caller's own object for an already-canonical spec, and a sweep loop
-            # that reuses one would carry the stamp into the next backtest.
-            strategy_spec = deepcopy(strategy_spec)
-            strategy_spec["strategy"]["signal"]["universe_n_symbols"] = _after
-            strategy = strategy_view(strategy_spec)
-            signal_config = strategy["signal"]
 
     # Skip-if-complete: if the backtest_hash already has complete artifacts,
     # return the cached result instead of re-running (unless force_rebacktest).
@@ -1474,7 +1477,11 @@ def run_backtest(
                     if _metric_cols:
                         _q = f"SELECT {', '.join(_metric_cols)} FROM backtest_metrics WHERE backtest_hash = ?"
                         _row = _db.execute(_q, (_bt_status.backtest_hash,)).fetchone()
-                        cached_metrics = dict(zip(_metric_cols, _row, strict=True)) if _row else {}
+                        cached_metrics = (
+                            _restore_ruin_nans(dict(zip(_metric_cols, _row, strict=True)))
+                            if _row
+                            else {}
+                        )
                     else:
                         cached_metrics = {}
                 finally:

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1046,6 +1046,55 @@ def resolved_allow_short_selling(
     return allow_short
 
 
+def restrict_to_priced_universe(
+    predictions: pl.DataFrame, prices: pl.DataFrame, *, case_study: str, label: str
+) -> pl.DataFrame:
+    """Drop predictions for symbols the price panel does not carry.
+
+    The vectorized path takes both the universe and the P&L from the predictions
+    frame - ``gross_ret = weight * y_true`` - and uses ``prices`` only for the
+    rebalance calendar, which is the same set of decision dates whichever symbols
+    are in the panel. So ``load_backtest_prices_for(..., max_symbols=N)`` reduced
+    the price frame and nothing else. Measured on us_firm_characteristics/11_backtest,
+    2026-08-24: 8 predictions x 4 schemes at 300 symbols and at 3,708 gave
+    bit-identical Sharpe, CAGR and drawdown on all 32 backtests, in 21 s against
+    19 s, and the random-signal plumbing Sharpe read -0.149212 at 100, 300, 1000
+    and 3,708 symbols alike (ml4t/agent-workspace#911).
+
+    Restricting the predictions to the priced universe makes the panel mean what
+    the parameter reads as - the set this run can trade - so a reduced panel is a
+    reduced run, and a preview costs what a preview should. It also closes the
+    trap the issue names: the path was pricing positions in names the panel does
+    not carry, which would begin to differ silently between preview and production
+    the moment the vectorized path started joining prices for returns.
+
+    This is not a production change. Measured 2026-09-07: every one of the 3,708
+    symbols `us_firm_characteristics` predicts for `fwd_ret_1m` and `fwd_class_1m`
+    is in its 9,861-symbol price panel, so at ``max_symbols=0`` the filter removes
+    nothing.
+    """
+    if "symbol" not in prices.columns or prices.is_empty():
+        return predictions
+    priced = prices.select("symbol").unique()
+    if priced["symbol"].dtype != predictions["symbol"].dtype:
+        priced = _align_symbol_dtype(
+            predictions,
+            priced,
+            case_study=case_study,
+            target_side="predictions",
+            other_side="price panel",
+        )
+    restricted = predictions.join(priced, on="symbol", how="semi")
+    if restricted.is_empty() and not predictions.is_empty():
+        raise ValueError(
+            f"{case_study}/{label}: none of the {predictions['symbol'].n_unique()} predicted "
+            f"symbols appears in the {priced.height}-symbol price panel, so this backtest "
+            "would have no universe. The panel and the fitting stages are drawn from "
+            "different symbol sets, or the panel was reduced past every predicted name."
+        )
+    return restricted
+
+
 def run_backtest(
     case_study: str,
     prediction_hash: str,
@@ -1186,6 +1235,22 @@ def run_backtest(
         strategy.get("signal") or {},
         prediction_hash=prediction_hash,
     )
+
+    # Make the price panel the tradeable universe on the vectorized path, which
+    # otherwise ignores it entirely - see `restrict_to_priced_universe`. Only where
+    # the selection is made here: when the caller hands in `precomputed_weights` the
+    # selection already happened, and quietly dropping positions out of it would
+    # leave weights that no longer sum to what the allocator solved for. The
+    # sp500_options HTM path is excluded because its `prices` frame and its
+    # predictions are not indexed by the same kind of symbol.
+    if (
+        strategy.get("rebalance", {}).get("mode") == "vectorized"
+        and precomputed_weights is None
+        and not (case_study == "sp500_options" and label == "ret_to_expiry")
+    ):
+        predictions = restrict_to_priced_universe(
+            predictions, prices, case_study=case_study, label=label
+        )
 
     # Skip-if-complete: if the backtest_hash already has complete artifacts,
     # return the cached result instead of re-running (unless force_rebacktest).

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -2945,7 +2945,22 @@ def run_plumbing_test(
             calendar=calendar,
             contract_specs=contract_specs,
         )
-        return float(result.metrics["sharpe"])
+        sharpe = result.metrics["sharpe"]
+        if sharpe is None:
+            # The engine stops a path that loses its capital and registers no
+            # Sharpe for it, so there is no number to compare against the
+            # tolerance. The random signal is not the finding here: a
+            # configuration that bankrupts a no-edge book is what the plumbing
+            # test exists to surface, and it says so rather than raising a
+            # TypeError several frames away.
+            raise ValueError(
+                f"{case_study}/{label}: the random-signal plumbing run went bankrupt "
+                f"at period {result.metrics.get('ruin_period')} of "
+                f"{result.metrics.get('n_periods')}, so it has no Sharpe to test. A "
+                "no-edge signal that loses the whole account points at the sizing or "
+                "the short leg, not at the signal."
+            )
+        return float(sharpe)
 
     # Engine plumbing test
     from ml4t.backtest import DataFeed, Engine, RebalanceConfig, Strategy, TargetWeightExecutor

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -226,6 +226,108 @@ def calendar_periods_per_year(calendar: str) -> int:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Ruin: an account that loses its capital stops there
+# ---------------------------------------------------------------------------
+
+# What a bankrupt path reports, and why it reports that.
+#
+# A long-short book can lose more than it holds in a single period: the long leg
+# stops at -100%, but the short leg's loss is unbounded, and a squeeze on a
+# concentrated short costs more than the account holds. Compounding straight
+# through zero is not a larger version of that loss, it is a different quantity.
+# Once equity is negative, `(1 + r)` inverts the sign of every later period, so a
+# gain on the underlying reduces the balance and the series after that point is
+# not a return series. Measured on the `us_firm_characteristics` registry,
+# 2026-09-07: 46 registered runs hold a period return below -100%, and the worst
+# of them reports sharpe 1.547 and a positive cagr against a total return of
+# -202.3 (ml4t/agent-workspace#920).
+#
+# The engine models no creditor, so the largest loss it can express is the
+# capital: the period that would take equity through zero is truncated to
+# exactly -100%, and every later period is 0.0, because there is nothing left to
+# trade. That is the "floor equity at zero" option of the three the issue offers.
+# The other two need something the case studies do not declare - a margin rule
+# needs a maintenance requirement and a borrow rate, and halting the path without
+# flooring it leaves a shorter series that still compares against full-length
+# ones as though the difference were performance.
+#
+# Descriptive statistics of the stopped path are then true statements:
+# `total_return`, `max_drawdown` and `cagr` all read -1.0, and a mean drawdown
+# over a sweep is back inside [-1, 0] rather than the -8.15 a sweep of
+# twenty-four with five insolvent members reported. The risk-adjusted ratios are
+# not statements about the stopped path at all. A ratio of a mean to a dispersion
+# describes a process that continues; this one ended. So they are registered as
+# NULL - `BacktestExplorer.best()` already reads `sharpe IS NOT NULL` as "not
+# rankable", and SQL `AVG` and `ORDER BY ... DESC` both keep NULLs out of the way
+# on their own. Nothing downstream has to know about ruin to stop ranking it.
+#
+# `ruin` and `ruin_period` are registered as metrics, never as identity fields:
+# they say what happened in a run, not what was asked for.
+RUIN_UNRANKABLE_METRICS: tuple[str, ...] = (
+    "sharpe",
+    "sortino",
+    "calmar",
+    "omega",
+    "stability",
+    "tail_ratio",
+)
+
+
+def first_ruin_index(returns) -> int | None:
+    """Index of the first period whose loss takes cumulative equity to zero.
+
+    ``None`` when the path stays solvent. A period return below -100% is not by
+    itself ruin - prior gains can absorb it - so the test is on the equity curve
+    rather than on any single return.
+    """
+    arr = np.asarray(returns, dtype=float)
+    if arr.size == 0:
+        return None
+    equity = np.cumprod(1.0 + arr)
+    # Non-finite equity is a broken series rather than a bankrupt one, and
+    # silently reporting it as ruin would hide the breakage. It is excluded here
+    # and left to `_safe` downstream.
+    hit = np.flatnonzero(np.isfinite(equity) & (equity <= 0.0))
+    return int(hit[0]) if hit.size else None
+
+
+def apply_ruin_stop(returns) -> tuple[np.ndarray, int | None]:
+    """Stop a return series at the period that wipes the account out.
+
+    Returns ``(series, ruin_index)``. The ruin period is truncated to exactly
+    -1.0 and every later period is set to 0.0. A solvent series is returned
+    unchanged with ``None``. Idempotent: a stopped series reports the same index
+    and is not changed again, so a caller that applies this to both the return
+    frame and the array it computes metrics from cannot make the two disagree.
+    """
+    arr = np.asarray(returns, dtype=float)
+    index = first_ruin_index(arr)
+    if index is None:
+        return arr, None
+    stopped = arr.copy()
+    stopped[index] = -1.0
+    stopped[index + 1 :] = 0.0
+    return stopped, index
+
+
+def stop_returns_at_ruin(
+    daily_returns: pl.DataFrame, column: str = "daily_return"
+) -> tuple[pl.DataFrame, int | None]:
+    """`apply_ruin_stop` over a ``[timestamp, daily_return]`` frame.
+
+    The engine paths also emit an equity curve, a trade log and a fill log. Those
+    are the broker's raw record of what it did, including the trade that took the
+    account out, and they are deliberately left alone: the stop is a statement
+    about what the account had left to compound, not a claim that the fills did
+    not happen.
+    """
+    stopped, index = apply_ruin_stop(daily_returns[column].to_numpy())
+    if index is None:
+        return daily_returns, None
+    return daily_returns.with_columns(pl.Series(column, stopped)), index
+
+
 def compute_portfolio_metrics(
     returns: np.ndarray,
     *,
@@ -236,7 +338,7 @@ def compute_portfolio_metrics(
     uncertainty_n_boot: int = 1000,
     uncertainty_seed: int = 0,
     trim_leading_zeros: bool = False,
-) -> dict[str, float]:
+) -> dict[str, float | None]:
     """Compute portfolio metrics using ml4t-diagnostic.
 
     Replaces hand-rolled Sharpe/drawdown/etc. with the library's
@@ -267,9 +369,12 @@ def compute_portfolio_metrics(
 
     Returns
     -------
-    dict[str, float]
+    dict[str, float | None]
         Metric name → value. Keys match the existing backtest_metrics schema,
-        plus uncertainty columns when ``uncertainty=True``.
+        plus uncertainty columns when ``uncertainty=True``, plus ``ruin`` and
+        ``ruin_period``. A path stopped at ruin carries ``None`` for every
+        ranking metric and every uncertainty column - see
+        ``RUIN_UNRANKABLE_METRICS``.
     """
     from ml4t.diagnostic.evaluation import PortfolioAnalysis
 
@@ -277,6 +382,11 @@ def compute_portfolio_metrics(
         nonzero = np.flatnonzero(np.asarray(returns) != 0.0)
         if len(nonzero) > 0:
             returns = returns[nonzero[0] :]
+
+    # Stop the path at the period that takes equity through zero, before anything
+    # is measured off it. See RUIN_UNRANKABLE_METRICS above for what a stopped
+    # path reports and why.
+    returns, ruin_period = apply_ruin_stop(returns)
 
     if len(returns) < 2:
         return {
@@ -296,6 +406,8 @@ def compute_portfolio_metrics(
             "kurtosis": 0.0,
             "tail_ratio": 0.0,
             "n_periods": int(len(returns)),
+            "ruin": 0.0 if ruin_period is None else 1.0,
+            "ruin_period": None if ruin_period is None else float(ruin_period),
         }
 
     analysis = PortfolioAnalysis(returns=returns, periods_per_year=periods_per_year)
@@ -332,7 +444,19 @@ def compute_portfolio_metrics(
         "kurtosis": _safe(pm.kurtosis),
         "tail_ratio": _safe(pm.tail_ratio),
         "n_periods": int(len(returns)),
+        "ruin": 0.0 if ruin_period is None else 1.0,
+        "ruin_period": None if ruin_period is None else float(ruin_period),
     }
+
+    if ruin_period is not None:
+        # Every ratio that ranks one path against another, and every confidence
+        # band drawn around one, is undefined for a path that ended. NULL, not a
+        # number a selection step would sort on.
+        from case_studies.utils.registry.store import _BACKTEST_UNCERTAINTY_COLUMNS
+
+        out.update(dict.fromkeys(RUIN_UNRANKABLE_METRICS, None))
+        out.update(dict.fromkeys(_BACKTEST_UNCERTAINTY_COLUMNS, None))
+        return out
 
     if uncertainty and len(returns) >= 4:
         try:
@@ -1594,6 +1718,9 @@ def _run_engine(
             (pl.col("timestamp").dt.date() >= window[0])
             & (pl.col("timestamp").dt.date() <= window[1])
         )
+    # The persisted return path stops where the account does, so the parquet, the
+    # overall metrics and the per-fold metrics all describe the same series.
+    daily_df, _ = stop_returns_at_ruin(daily_df)
     returns_arr = daily_df["daily_return"].to_numpy()
 
     ppy = overall_periods_per_year(case_study, calendar, daily_df)
@@ -1859,6 +1986,9 @@ def _run_htm_daily_mtm(
     # HTM uses daily MTM on NYSE sessions → periods_per_year = 252. Operates on
     # the FINAL daily_returns (post-slice, post-risk-overlay) so the persisted
     # parquet and the registered metrics are derived from the same series.
+    # The persisted return path stops where the account does, so the parquet, the
+    # overall metrics and the per-fold metrics all describe the same series.
+    daily_returns, _ = stop_returns_at_ruin(daily_returns)
     returns_arr = daily_returns["daily_return"].to_numpy()
     metrics.update(
         compute_portfolio_metrics(
@@ -2101,6 +2231,10 @@ def _run_vectorized(
         pl.col("timestamp"),
         pl.col("net_ret").alias("daily_return"),
     )
+
+    # The persisted return path stops where the account does, so the parquet, the
+    # overall metrics and the per-fold metrics all describe the same series.
+    daily_returns, _ = stop_returns_at_ruin(daily_returns)
 
     # Portfolio metrics via ml4t-diagnostic
     returns_arr = daily_returns["daily_return"].to_numpy()

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1276,14 +1276,16 @@ def warn_if_the_panel_does_not_bound_the_universe(
     before it hashes - which is a notebook change. Until then the parameter is
     inert here and this says so at the moment it happens.
 
-    Said twice, on purpose. Every notebook that reaches this line installs a
-    blanket ``warnings.filterwarnings("ignore")`` at import. Twenty-two of the
-    notebooks that call ``run_backtest`` or ``run_plumbing_test`` do, across all
-    six case studies that run a backtest - from
-    ``us_firm_characteristics/11_backtest.py:62`` to
-    ``sp500_equity_option_analytics/17_costs.py:50`` - and 77 do corpus-wide,
-    measured 2026-09-07. So a diagnostic that only warns is a diagnostic no reader
-    of the executed notebook ever sees.
+    Said twice, on purpose. 22 of the 35 notebooks that call ``run_backtest`` or
+    ``run_plumbing_test`` install a blanket ``warnings.filterwarnings("ignore")``
+    at import, measured 2026-09-07 - every backtest, portfolio, risk and cost
+    stage in ``etfs``, ``nasdaq100_microstructure``,
+    ``sp500_equity_option_analytics`` and ``us_firm_characteristics``, plus four
+    holdout backtests. The 13 that do not are ``crypto_perps_funding``,
+    ``fx_pairs`` and ``us_equities_panel``. Corpus-wide 77 case-study notebooks
+    install it. So a diagnostic that only warns is one that four of the seven case
+    studies' readers never see, and which of the seven is not something this
+    function can know.
     The ``warnings`` call is what a library caller and the tests read; the print is
     what survives the filter and lands in the rendered cell. It is emitted once per
     (case study, label, panel width, prediction width) because a sweep calls

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1235,6 +1235,12 @@ def _restore_ruin_nans(metrics: dict) -> dict:
     return metrics
 
 
+# One entry per (case study, label, panel width, prediction width) already reported, so a
+# sweep of twelve backtests over one prediction set prints the diagnostic once rather than
+# twelve times. Process-scoped: a notebook is one process, which is the scope that matters.
+_UNPRICED_UNIVERSE_REPORTED: set[tuple[str, str, int, int]] = set()
+
+
 def warn_if_the_panel_does_not_bound_the_universe(
     predictions: pl.DataFrame, prices: pl.DataFrame, *, case_study: str, label: str
 ) -> None:
@@ -1269,6 +1275,16 @@ def warn_if_the_panel_does_not_bound_the_universe(
     What closes this is the caller declaring the universe it trades, in the spec,
     before it hashes - which is a notebook change. Until then the parameter is
     inert here and this says so at the moment it happens.
+
+    Said twice, on purpose. Every notebook that reaches this line installs a
+    blanket ``warnings.filterwarnings("ignore")`` at import - eleven of them, from
+    ``us_firm_characteristics/11_backtest.py:62`` to
+    ``nasdaq100_microstructure/15_portfolio_management.py:59`` - so a diagnostic
+    that only warns is a diagnostic no reader of the executed notebook ever sees.
+    The ``warnings`` call is what a library caller and the tests read; the print is
+    what survives the filter and lands in the rendered cell. It is emitted once per
+    (case study, label, panel width, prediction width) because a sweep calls
+    ``run_backtest`` once per scheme and would otherwise repeat it dozens of times.
     """
     if "symbol" not in prices.columns or prices.is_empty() or predictions.is_empty():
         return
@@ -1284,15 +1300,19 @@ def warn_if_the_panel_does_not_bound_the_universe(
     unpriced = predictions.join(priced, on="symbol", how="anti")
     if unpriced.is_empty():
         return
-    warnings.warn(
+    message = (
         f"{case_study}/{label}: the price panel carries {priced.height} symbols and the "
         f"predictions carry {predictions['symbol'].n_unique()}, {unpriced['symbol'].n_unique()} "
         "of which it cannot price. The vectorized path takes its universe and its P&L from "
         "the predictions, so this run trades every predicted name at the full cost per "
         "backtest and the narrower panel reduces nothing (ml4t/agent-workspace#911). "
-        "TOP_N_PREDICTIONS is the knob that reduces this stage.",
-        stacklevel=2,
+        "TOP_N_PREDICTIONS is the knob that reduces this stage."
     )
+    warnings.warn(message, stacklevel=2)
+    seen = (case_study, label, priced.height, int(predictions["symbol"].n_unique()))
+    if seen not in _UNPRICED_UNIVERSE_REPORTED:
+        _UNPRICED_UNIVERSE_REPORTED.add(seen)
+        print(f"  WARN warn_if_the_panel_does_not_bound_the_universe: {message}")
 
 
 def run_backtest(

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -500,6 +500,131 @@ class BacktestRunResult:
     execution_mode: str = "engine"
 
 
+# ---------------------------------------------------------------------------
+# Risk-control trigger counts
+# ---------------------------------------------------------------------------
+
+# The controls the engine knows how to build, and therefore the ones it can count.
+# The names are the `type` values a spec declares under `strategy.risk`.
+RISK_POSITION_RULE_TYPES = ("stop_loss", "trailing_stop", "time_exit")
+RISK_PORTFOLIO_LIMIT_TYPES = ("max_drawdown", "daily_loss")
+RISK_CONTROL_TYPES = RISK_POSITION_RULE_TYPES + RISK_PORTFOLIO_LIMIT_TYPES
+
+
+class RiskTriggerLog:
+    """How many times each declared risk control acted during one backtest.
+
+    A risk overlay that never fired was indistinguishable from one that was never
+    installed, and the two have opposite meanings (ml4t/agent-workspace#1051). The
+    registry carried `num_trades` and the performance metrics and nothing else, so
+    a reader comparing an overlay against the strategy it was laid on could
+    conclude "the control acted" from a difference and nothing at all from a
+    match: a stop can close a position the next rebalance would have closed
+    anyway, leaving the trade count where it was. `rules/notebook-standards.md`
+    C17 records the failure that hides behind that - 56 registered
+    `crypto_perps_funding/16_risk_management` results whose Sharpe, drawdown and
+    trade count matched the unprotected book in every digit, because the
+    configuration declared its controls in a shape the engine does not read and
+    nothing was installed.
+
+    So the counts distinguish three states, and the third is the one that was
+    missing:
+
+    * nothing declared - every count is ``None``, which is what "no overlay" means;
+    * declared and never fired - ``0``;
+    * declared and fired - the number of times.
+
+    A fourth state, declared but not installable on this execution path, is not
+    represented because it is refused instead: registering a row named for a
+    control the path cannot apply is the C17 failure itself.
+
+    Counts are per control *type*, not per declared control: two stops in one spec
+    share a key and their firings sum. Every sweep in the tree declares one
+    control per backtest, so the distinction has no reader today.
+    """
+
+    def __init__(self) -> None:
+        self._counts: dict[str, int] = {}
+
+    def declare(self, control: str) -> None:
+        """Record that this control was installed, before it has fired."""
+        self._counts.setdefault(control, 0)
+
+    def record(self, control: str, n: int = 1) -> None:
+        self._counts[control] = self._counts.get(control, 0) + n
+
+    def as_metrics(self) -> dict[str, float | None]:
+        """One registered column per control type, plus the total.
+
+        Every column is ``None`` when no control was declared, so a NULL reads as
+        "no overlay here" rather than as "not measured".
+        """
+        if not self._counts:
+            return {"risk_triggers": None} | {
+                f"risk_triggers_{name}": None for name in RISK_CONTROL_TYPES
+            }
+        return {"risk_triggers": float(sum(self._counts.values()))} | {
+            f"risk_triggers_{name}": (float(self._counts[name]) if name in self._counts else None)
+            for name in RISK_CONTROL_TYPES
+        }
+
+
+class _CountedPositionRule:
+    """Delegate to a position rule and count the exits it produces.
+
+    Structural, not inherited: ``ml4t.backtest.risk.PositionRule`` is a Protocol
+    and ``RuleChain`` is a plain dataclass over ``rules``, so a wrapper with
+    ``evaluate`` composes wherever the real rule does.
+
+    Only exits are counted - ``EXIT_FULL`` and ``EXIT_PARTIAL``. ``HOLD`` and
+    ``ADJUST_STOP`` are not firings: moving a stop level is the control working
+    without acting on the book, and counting it would report a rule that closed
+    nothing as the most active one in the sweep. No rule in ml4t-backtest 0.1.3
+    returns ``ADJUST_STOP``, so the exclusion is for rules added later.
+    """
+
+    def __init__(self, rule, control: str, log: RiskTriggerLog) -> None:
+        self._rule = rule
+        self._control = control
+        self._log = log
+        log.declare(control)
+
+    def evaluate(self, state):
+        from ml4t.backtest.risk import ActionType
+
+        action = self._rule.evaluate(state)
+        if action.action in (ActionType.EXIT_FULL, ActionType.EXIT_PARTIAL):
+            self._log.record(self._control)
+        return action
+
+
+def _counted_portfolio_limit(limit, control: str, log: RiskTriggerLog):
+    """Wrap a portfolio limit so each breach *episode* is counted once.
+
+    ``RiskManager.update`` re-checks every limit on every bar and returns whatever
+    is breached, so a halted book breaches again on each of the bars that follow.
+    Counting those would report one drawdown halt as several hundred firings. The
+    count moves on the rising edge only: not breached, then breached.
+    """
+    from ml4t.backtest.risk import PortfolioLimit
+
+    class _CountedPortfolioLimit(PortfolioLimit):
+        def __init__(self) -> None:
+            self._limit = limit
+            self._breached = False
+            log.declare(control)
+
+        def check(self, state):
+            result = self._limit.check(state)
+            breached = bool(result.breached)
+            if breached and not self._breached:
+                log.record(control)
+            self._breached = breached
+            return result
+
+    return _CountedPortfolioLimit()
+
+
 def _target_weights_by_timestamp(
     weights: pl.DataFrame,
 ) -> dict[date | datetime, dict[str, float]]:
@@ -1622,9 +1747,12 @@ def _run_engine(
     if transition_timestamps and config.execution_mode.value != "same_bar":
         raise ValueError("state-transition sequencing requires same-bar engine execution")
 
-    # Build risk components from spec (Ch19)
-    position_rules = _build_position_rules(risk_spec)
-    risk_manager = _build_risk_manager(risk_spec, initial_cash)
+    # Build risk components from spec (Ch19). The log counts what each installed
+    # control actually did, so a reader can tell an overlay that never fired from
+    # one that was never installed - see `RiskTriggerLog`.
+    trigger_log = RiskTriggerLog()
+    position_rules = _build_position_rules(risk_spec, trigger_log)
+    risk_manager = _build_risk_manager(risk_spec, initial_cash, trigger_log)
 
     # Rebalance thresholds are sourced from setup.yaml::backtest.rebalance and
     # always present in the canonical strategy.rebalance block (populated by
@@ -1791,6 +1919,7 @@ def _run_engine(
     ppy = overall_periods_per_year(case_study, calendar, daily_df)
     metrics = compute_portfolio_metrics(returns_arr, periods_per_year=ppy, trim_leading_zeros=False)
     metrics.update(funding_metrics)
+    metrics.update(trigger_log.as_metrics())
 
     # Engine-specific metrics (execution details not derivable from returns)
     m = engine_result.metrics
@@ -1953,6 +2082,9 @@ def _run_htm_daily_mtm(
     percentile = float(signal_config.get("percentile", 90.0))
     if risk_spec:
         raise ValueError("the specialized option path does not support risk overlays")
+    # Refused above, so every count is None: no control was installed here, and a
+    # NULL says that rather than leaving the columns unwritten (#1051).
+    trigger_log = RiskTriggerLog()
     required_accounting = {
         "n_roll",
         "delta_hedge",
@@ -2064,6 +2196,7 @@ def _run_htm_daily_mtm(
             uncertainty=True,
         )
     )
+    metrics.update(trigger_log.as_metrics())
 
     # Number of distinct rebalance events (= entry days with any new cohort).
     # `n_open.sum()` is the count of cohort-days, kept under a distinct key.
@@ -2288,8 +2421,9 @@ def _run_vectorized(
                 port_ret = port_ret_filtered
 
     # Apply portfolio-level risk overlays (post-hoc on return series)
+    trigger_log = RiskTriggerLog()
     if risk_spec:
-        port_ret = _apply_vectorized_risk(port_ret, risk_spec)
+        port_ret = _apply_vectorized_risk(port_ret, risk_spec, trigger_log)
 
     # Daily returns DataFrame
     daily_returns = port_ret.select(
@@ -2319,6 +2453,7 @@ def _run_vectorized(
     avg_turnover = cast(float, port_ret["turnover"].mean()) if n > 0 else 0.0
     metrics["avg_turnover"] = avg_turnover
     metrics["n_periods"] = n
+    metrics.update(trigger_log.as_metrics())
 
     return {
         "daily_returns": daily_returns,
@@ -2331,7 +2466,9 @@ def _run_vectorized(
 # ---------------------------------------------------------------------------
 
 
-def _apply_vectorized_risk(port_ret: pl.DataFrame, risk_spec: dict) -> pl.DataFrame:
+def _apply_vectorized_risk(
+    port_ret: pl.DataFrame, risk_spec: dict, log: RiskTriggerLog | None = None
+) -> pl.DataFrame:
     """Apply portfolio-level risk limits to a close-to-close return series.
 
     Used by the vectorized + HTM dispatch paths (us_firm_characteristics,
@@ -2355,6 +2492,22 @@ def _apply_vectorized_risk(port_ret: pl.DataFrame, risk_spec: dict) -> pl.DataFr
         engine path (which has proper ``DailyLossLimit`` halt-on-update
         semantics through ``ml4t.backtest.risk``).
     """
+    # A position rule declared here installs nothing on this path - the
+    # close-to-close series cannot express an intrabar stop - so the run would
+    # register under an identity named for a stop that never ran. That is
+    # `rules/notebook-standards.md` C17's shape, and ml4t/agent-workspace#1051 is
+    # about not letting it register silently, so it stops here instead.
+    position_rules = risk_spec.get("position_rules", [])
+    if position_rules:
+        declared = ", ".join(str(rc.get("name", rc.get("type"))) for rc in position_rules)
+        raise ValueError(
+            f"position rules ({declared}) cannot be applied on the vectorized path: an "
+            "intrabar stop needs position tracking that a close-to-close return series "
+            "does not carry. Registering the run anyway would name a result for a control "
+            "that never ran. Move the case study to the engine path, or sweep "
+            "portfolio-level limits here instead."
+        )
+
     limits = risk_spec.get("portfolio_limits", [])
     if not limits:
         return port_ret
@@ -2364,6 +2517,8 @@ def _apply_vectorized_risk(port_ret: pl.DataFrame, risk_spec: dict) -> pl.DataFr
         ltype = lc["type"]
         if ltype == "max_drawdown":
             dd_threshold = lc["threshold"]
+            if log is not None:
+                log.declare("max_drawdown")
         elif ltype == "daily_loss":
             raise ValueError(
                 "daily_loss portfolio limit is not supported on the "
@@ -2389,6 +2544,9 @@ def _apply_vectorized_risk(port_ret: pl.DataFrame, risk_spec: dict) -> pl.DataFr
             exit_eq = float(peak[i]) * (1.0 - abs(dd_threshold)) * (1.0 - breach_slippage)
             returns[i] = exit_eq / prior_eq - 1.0
             returns[i + 1 :] = 0.0
+            # At most once: the breaker exits the book and zeroes every later bar.
+            if log is not None:
+                log.record("max_drawdown")
 
     return port_ret.with_columns(pl.Series("net_ret", returns))
 
@@ -2637,11 +2795,16 @@ def _refuse_an_allocation_that_produced_no_target(
     )
 
 
-def _build_position_rules(risk_spec: dict):
+def _build_position_rules(risk_spec: dict, log: RiskTriggerLog | None = None):
     """Create ml4t-backtest PositionRule objects from risk spec.
 
     Supports: stop_loss, trailing_stop, time_exit.
     Returns a RuleChain (multiple rules) or single rule, or None.
+
+    An unrecognized ``type`` used to fall through the if-chain and contribute
+    nothing, so a spec naming one produced no rule, a distinct identity hash, and
+    a registered row named for a control that never ran - the shape
+    ``rules/notebook-standards.md`` C17 generalizes. It is refused instead.
     """
     rules_config = risk_spec.get("position_rules", [])
     if not rules_config:
@@ -2653,22 +2816,33 @@ def _build_position_rules(risk_spec: dict):
     for rc in rules_config:
         rtype = rc["type"]
         if rtype == "stop_loss":
-            rules.append(StopLoss(pct=rc["threshold"]))
+            rule = StopLoss(pct=rc["threshold"])
         elif rtype == "trailing_stop":
-            rules.append(TrailingStop(pct=rc["threshold"]))
+            rule = TrailingStop(pct=rc["threshold"])
         elif rtype == "time_exit":
-            rules.append(TimeExit(max_bars=rc["bars"]))
+            rule = TimeExit(max_bars=rc["bars"])
+        else:
+            raise ValueError(
+                f"unknown position rule type {rtype!r} in strategy.risk.position_rules; "
+                f"the engine builds {sorted(RISK_POSITION_RULE_TYPES)}. A type it does not "
+                "recognize installs nothing, and the run would register under a distinct "
+                f"identity named {rc.get('name', rtype)!r} for a control that never ran."
+            )
+        rules.append(_CountedPositionRule(rule, rtype, log) if log is not None else rule)
 
     if not rules:
         return None
     return RuleChain(rules) if len(rules) > 1 else rules[0]
 
 
-def _build_risk_manager(risk_spec: dict, initial_cash: float):
+def _build_risk_manager(risk_spec: dict, initial_cash: float, log: RiskTriggerLog | None = None):
     """Create RiskManager with portfolio-level limits from risk spec.
 
     Supports: max_drawdown, daily_loss.
     Returns initialized RiskManager, or None.
+
+    Refuses an unrecognized ``type`` for the reason given in
+    ``_build_position_rules``.
     """
     limits_config = risk_spec.get("portfolio_limits", [])
     if not limits_config:
@@ -2680,9 +2854,17 @@ def _build_risk_manager(risk_spec: dict, initial_cash: float):
     for lc in limits_config:
         ltype = lc["type"]
         if ltype == "max_drawdown":
-            limits.append(MaxDrawdownLimit(max_drawdown=lc["threshold"]))
+            limit = MaxDrawdownLimit(max_drawdown=lc["threshold"])
         elif ltype == "daily_loss":
-            limits.append(DailyLossLimit(max_daily_loss_pct=lc["threshold"]))
+            limit = DailyLossLimit(max_daily_loss_pct=lc["threshold"])
+        else:
+            raise ValueError(
+                f"unknown portfolio limit type {ltype!r} in strategy.risk.portfolio_limits; "
+                f"the engine builds {sorted(RISK_PORTFOLIO_LIMIT_TYPES)}. A type it does not "
+                "recognize installs nothing, and the run would register under a distinct "
+                f"identity named {lc.get('name', ltype)!r} for a control that never ran."
+            )
+        limits.append(_counted_portfolio_limit(limit, ltype, log) if log is not None else limit)
 
     if not limits:
         return None

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1277,10 +1277,13 @@ def warn_if_the_panel_does_not_bound_the_universe(
     inert here and this says so at the moment it happens.
 
     Said twice, on purpose. Every notebook that reaches this line installs a
-    blanket ``warnings.filterwarnings("ignore")`` at import - eleven of them, from
+    blanket ``warnings.filterwarnings("ignore")`` at import. Twenty-two of the
+    notebooks that call ``run_backtest`` or ``run_plumbing_test`` do, across all
+    six case studies that run a backtest - from
     ``us_firm_characteristics/11_backtest.py:62`` to
-    ``nasdaq100_microstructure/15_portfolio_management.py:59`` - so a diagnostic
-    that only warns is a diagnostic no reader of the executed notebook ever sees.
+    ``sp500_equity_option_analytics/17_costs.py:50`` - and 77 do corpus-wide,
+    measured 2026-09-07. So a diagnostic that only warns is a diagnostic no reader
+    of the executed notebook ever sees.
     The ``warnings`` call is what a library caller and the tests read; the print is
     what survives the filter and lands in the rendered cell. It is emitted once per
     (case study, label, panel width, prediction width) because a sweep calls

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -24,6 +24,7 @@ Usage::
 
 from __future__ import annotations
 
+import math
 import warnings
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -264,6 +265,19 @@ def calendar_periods_per_year(calendar: str) -> int:
 #
 # `ruin` and `ruin_period` are registered as metrics, never as identity fields:
 # they say what happened in a run, not what was asked for.
+#
+# The unrankable value is NaN and not None, which is a decision about the readers
+# rather than about the metric. SQLite stores a NaN as NULL, so the registry and
+# every SQL reader see exactly the intended "no value" - `ORDER BY sharpe DESC`
+# puts it last, `AVG` skips it, and the fifteen `sharpe IS NOT NULL` filters drop
+# it. A None would reach the notebooks that format a metric as `f"{sharpe:.3f}"`
+# as a TypeError several frames from the cause; NaN formats as `nan`, which is
+# what those lines should print.
+#
+# The cost is that polars sorts a NaN *first* on a descending sort, so anything
+# ranking these dicts in memory before they reach SQLite has to say what it
+# wants. `rank_returns_on_common_support` is the one place that does, and it
+# converts to null and passes `nulls_last=True`.
 RUIN_UNRANKABLE_METRICS: tuple[str, ...] = (
     "sharpe",
     "sortino",
@@ -328,6 +342,37 @@ def stop_returns_at_ruin(
     return daily_returns.with_columns(pl.Series(column, stopped)), index
 
 
+def _apply_ruin_semantics(
+    out: dict[str, float | None], ruin_period: int | None, *, uncertainty_columns: bool = True
+) -> dict[str, float | None]:
+    """Stamp `ruin`/`ruin_period` and, for a stopped path, what it actually reports.
+
+    The three descriptive metrics are stated here rather than read back from the
+    diagnostic library. A stopped path ends at exactly zero equity by
+    construction, so total return, CAGR and maximum drawdown are known to be
+    -1.0 - and the library does not always produce them. On a path that ruins in
+    its first period the drawdown series divides by a running maximum of zero and
+    comes back all-NaN, which `_safe` turns into 0.0; a single-period path takes
+    the short branch in the caller, where every value is 0.0. Both reported ruin
+    beside a drawdown of nothing.
+    """
+    out["ruin"] = 0.0 if ruin_period is None else 1.0
+    out["ruin_period"] = None if ruin_period is None else float(ruin_period)
+    if ruin_period is None:
+        return out
+    out["total_return"] = -1.0
+    out["max_drawdown"] = -1.0
+    out["cagr"] = -1.0
+    # Every ratio that ranks one path against another, and every confidence band
+    # drawn around one, is undefined for a path that ended.
+    out.update(dict.fromkeys(RUIN_UNRANKABLE_METRICS, float("nan")))
+    if uncertainty_columns:
+        from case_studies.utils.registry.store import _BACKTEST_UNCERTAINTY_COLUMNS
+
+        out.update(dict.fromkeys(_BACKTEST_UNCERTAINTY_COLUMNS, float("nan")))
+    return out
+
+
 def compute_portfolio_metrics(
     returns: np.ndarray,
     *,
@@ -389,26 +434,28 @@ def compute_portfolio_metrics(
     returns, ruin_period = apply_ruin_stop(returns)
 
     if len(returns) < 2:
-        return {
-            "sharpe": 0.0,
-            "sortino": 0.0,
-            "total_return": 0.0,
-            "max_drawdown": 0.0,
-            "cagr": 0.0,
-            "calmar": 0.0,
-            "volatility": 0.0,
-            "win_rate": 0.0,
-            "omega": 0.0,
-            "var_95": 0.0,
-            "cvar_95": 0.0,
-            "stability": 0.0,
-            "skewness": 0.0,
-            "kurtosis": 0.0,
-            "tail_ratio": 0.0,
-            "n_periods": int(len(returns)),
-            "ruin": 0.0 if ruin_period is None else 1.0,
-            "ruin_period": None if ruin_period is None else float(ruin_period),
-        }
+        return _apply_ruin_semantics(
+            {
+                "sharpe": 0.0,
+                "sortino": 0.0,
+                "total_return": 0.0,
+                "max_drawdown": 0.0,
+                "cagr": 0.0,
+                "calmar": 0.0,
+                "volatility": 0.0,
+                "win_rate": 0.0,
+                "omega": 0.0,
+                "var_95": 0.0,
+                "cvar_95": 0.0,
+                "stability": 0.0,
+                "skewness": 0.0,
+                "kurtosis": 0.0,
+                "tail_ratio": 0.0,
+                "n_periods": int(len(returns)),
+            },
+            ruin_period,
+            uncertainty_columns=False,
+        )
 
     analysis = PortfolioAnalysis(returns=returns, periods_per_year=periods_per_year)
     with warnings.catch_warnings():
@@ -444,18 +491,10 @@ def compute_portfolio_metrics(
         "kurtosis": _safe(pm.kurtosis),
         "tail_ratio": _safe(pm.tail_ratio),
         "n_periods": int(len(returns)),
-        "ruin": 0.0 if ruin_period is None else 1.0,
-        "ruin_period": None if ruin_period is None else float(ruin_period),
     }
 
+    out = _apply_ruin_semantics(out, ruin_period)
     if ruin_period is not None:
-        # Every ratio that ranks one path against another, and every confidence
-        # band drawn around one, is undefined for a path that ended. NULL, not a
-        # number a selection step would sort on.
-        from case_studies.utils.registry.store import _BACKTEST_UNCERTAINTY_COLUMNS
-
-        out.update(dict.fromkeys(RUIN_UNRANKABLE_METRICS, None))
-        out.update(dict.fromkeys(_BACKTEST_UNCERTAINTY_COLUMNS, None))
         return out
 
     if uncertainty and len(returns) >= 4:
@@ -1197,6 +1236,10 @@ def restrict_to_priced_universe(
     symbols `us_firm_characteristics` predicts for `fwd_ret_1m` and `fwd_class_1m`
     is in its 9,861-symbol price panel, so at ``max_symbols=0`` the filter removes
     nothing.
+
+    The caller stamps the resulting width into the spec when the filter does
+    remove something - see ``run_backtest``. A reduced run is a different backtest
+    and has to hash as one.
     """
     if "symbol" not in prices.columns or prices.is_empty():
         return predictions
@@ -1373,9 +1416,37 @@ def run_backtest(
         and precomputed_weights is None
         and not (case_study == "sp500_options" and label == "ret_to_expiry")
     ):
+        _before = predictions["symbol"].n_unique() if predictions.height else 0
         predictions = restrict_to_priced_universe(
             predictions, prices, case_study=case_study, label=label
         )
+        _after = predictions["symbol"].n_unique() if predictions.height else 0
+        if _after != _before:
+            # A reduced universe is a different portfolio, so it has to be a
+            # different identity. Without this the skip-if-complete check below,
+            # and the same check `11_backtest` runs before submitting a scheme,
+            # both hash prediction + strategy alone: a preview at reduced
+            # MAX_SYMBOLS would be served the full-universe result, or would
+            # register its own numbers under the full run's hash.
+            #
+            # Stamped only when the filter bites, so no registered backtest is
+            # re-keyed: production panels cover every predicted symbol, and there
+            # the key never appears.
+            if resolved_spec_only:
+                raise ValueError(
+                    f"{case_study}/{label}: the price panel covers {_after} of the "
+                    f"{_before} predicted symbols, so this run would trade a narrower "
+                    "universe than the resolved specification it was handed declares. A "
+                    "locked backtest cannot have its universe narrowed underneath its "
+                    "own hash. Load the full price panel."
+                )
+            # Copied, not stamped in place: `ensure_backtest_spec` returns the
+            # caller's own object for an already-canonical spec, and a sweep loop
+            # that reuses one would carry the stamp into the next backtest.
+            strategy_spec = deepcopy(strategy_spec)
+            strategy_spec["strategy"]["signal"]["universe_n_symbols"] = _after
+            strategy = strategy_view(strategy_spec)
+            signal_config = strategy["signal"]
 
     # Skip-if-complete: if the backtest_hash already has complete artifacts,
     # return the cached result instead of re-running (unless force_rebacktest).
@@ -2946,7 +3017,7 @@ def run_plumbing_test(
             contract_specs=contract_specs,
         )
         sharpe = result.metrics["sharpe"]
-        if sharpe is None:
+        if sharpe is None or math.isnan(sharpe):
             # The engine stops a path that loses its capital and registers no
             # Sharpe for it, so there is no number to compare against the
             # tolerance. The random signal is not the finding here: a

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1278,14 +1278,21 @@ def warn_if_the_panel_does_not_bound_the_universe(
 
     Said twice, on purpose. 22 of the 35 notebooks that call ``run_backtest`` or
     ``run_plumbing_test`` install a blanket ``warnings.filterwarnings("ignore")``
-    at import, measured 2026-09-07 - every backtest, portfolio, risk and cost
-    stage in ``etfs``, ``nasdaq100_microstructure``,
-    ``sp500_equity_option_analytics`` and ``us_firm_characteristics``, plus four
-    holdout backtests. The 13 that do not are ``crypto_perps_funding``,
-    ``fx_pairs`` and ``us_equities_panel``. Corpus-wide 77 case-study notebooks
-    install it. So a diagnostic that only warns is one that four of the seven case
-    studies' readers never see, and which of the seven is not something this
-    function can know.
+    at import, measured 2026-09-07 over ``case_studies/*/[0-9]*.py``::
+
+        cme_futures                    1 of 1    fx_pairs                0 of 5
+        etfs                           5 of 5    us_equities_panel       0 of 4
+        nasdaq100_microstructure       5 of 5    crypto_perps_funding    1 of 5
+        sp500_equity_option_analytics  5 of 5
+        us_firm_characteristics        5 of 5
+
+    Five case studies filter every backtest-calling notebook they have, two filter
+    none, and ``crypto_perps_funding`` filters only ``18_holdout_backtest.py``. So
+    a diagnostic that only warns is silent for the readers of five of the seven,
+    and which of the seven this is being read in is not something this function
+    can know. (76 of the 195 numbered case-study notebooks install it in total; a
+    recursive grep also finds an archived notebook and the line you are reading,
+    which is why that count comes back as 78 - ml4t/agent-workspace#1078.)
     The ``warnings`` call is what a library caller and the tests read; the print is
     what survives the filter and lands in the rendered cell. It is emitted once per
     (case study, label, panel width, prediction width) because a sweep calls

--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -1235,41 +1235,40 @@ def _restore_ruin_nans(metrics: dict) -> dict:
     return metrics
 
 
-def refuse_predictions_the_panel_cannot_price(
+def warn_if_the_panel_does_not_bound_the_universe(
     predictions: pl.DataFrame, prices: pl.DataFrame, *, case_study: str, label: str
 ) -> None:
-    """Stop a vectorized run whose price panel does not cover what it will trade.
+    """Say when a price panel is not the universe a vectorized run will trade.
 
-    The vectorized path takes both the universe and the P&L from the predictions
-    frame - ``gross_ret = weight * y_true`` - and uses ``prices`` only for the
-    rebalance calendar, which is the same set of decision dates whichever symbols
-    are in the panel. So ``load_backtest_prices_for(..., max_symbols=N)`` reduced
-    the price frame and nothing else. Measured on us_firm_characteristics/11_backtest,
-    2026-08-24: 8 predictions x 4 schemes at 300 symbols and at 3,708 gave
-    bit-identical Sharpe, CAGR and drawdown on all 32 backtests, in 21 s against
-    19 s, and the random-signal plumbing Sharpe read -0.149212 at 100, 300, 1000
-    and 3,708 symbols alike (ml4t/agent-workspace#911).
+    The vectorized path computes ``gross_ret = weight * y_true`` from the
+    predictions frame and reads ``prices`` only for the rebalance calendar, which
+    is the same set of decision dates whichever symbols are in the panel. So
+    ``load_backtest_prices_for(..., max_symbols=N)`` reduces the price frame and
+    nothing else, and a preview taken at a reduced ``MAX_SYMBOLS`` is the
+    production sweep with the production cost per backtest. Measured on
+    us_firm_characteristics/11_backtest, 2026-08-24: 8 predictions x 4 schemes at
+    300 symbols and at 3,708 gave bit-identical Sharpe, CAGR and drawdown across
+    all 32 backtests, in 21 s against 19 s (ml4t/agent-workspace#911).
 
-    Silently trading the predictions the panel does not carry is what made that
-    knob inert, and quietly narrowing the predictions to the panel instead is
-    worse: the traded universe would then decide the portfolio without entering
-    the backtest identity, and the caller hashes its specification before it ever
-    reaches this module - `us_firm_characteristics/11_backtest.py:273` computes
-    `backtest_hash_from_parts` and skips a matching run before calling
-    `run_backtest`. A reduced preview would be served the full-universe result.
+    This warns and does not act, which is a decision the engine cannot make on
+    its own. Both ways of acting were tried and both are wrong here:
 
-    So the run stops. A preview at a reduced `MAX_SYMBOLS` no longer measures the
-    production sweep at the production cost per backtest while looking reduced -
-    it refuses, and says which knob does reduce this stage. `TOP_N_PREDICTIONS`
-    cuts the number of backtests, and each one it leaves is a full, honest run.
+    * **Narrowing the predictions to the panel** makes the traded universe decide
+      the portfolio without entering the backtest identity. The caller hashes its
+      specification before this module sees the run -
+      ``us_firm_characteristics/11_backtest.py:273`` computes
+      ``backtest_hash_from_parts`` and skips a matching run - so a reduced preview
+      would be served the full-universe result. Stamping the universe inside
+      ``run_backtest`` is too late for that check, and a symbol count is not a
+      universe in any case: ``{A, B}`` and ``{A, C}`` are different portfolios.
+    * **Refusing the run** stops a preview that is legitimately configured this
+      way. Measured on CI 2026-09-07: the `us_firm_characteristics` fixture holds
+      a 5-symbol price panel against 20-symbol predictions, and refusing took
+      four notebooks down.
 
-    This fires on nothing that exists. Measured 2026-09-07 on the
-    us_firm_characteristics panel: every one of the 3,708 symbols it predicts for
-    `fwd_ret_1m` and `fwd_class_1m` is in its 9,861-symbol price panel, and
-    ``top_entities`` - the one rule every reduction in the repo reaches - selects
-    the identical symbol set from the price panel and from the label panel at 5,
-    12 and 200, which are the caps `tests/overrides.yaml` runs the backtest
-    notebooks at.
+    What closes this is the caller declaring the universe it trades, in the spec,
+    before it hashes - which is a notebook change. Until then the parameter is
+    inert here and this says so at the moment it happens.
     """
     if "symbol" not in prices.columns or prices.is_empty() or predictions.is_empty():
         return
@@ -1285,16 +1284,14 @@ def refuse_predictions_the_panel_cannot_price(
     unpriced = predictions.join(priced, on="symbol", how="anti")
     if unpriced.is_empty():
         return
-    missing = sorted(unpriced["symbol"].unique().to_list())
-    raise ValueError(
+    warnings.warn(
         f"{case_study}/{label}: the price panel carries {priced.height} symbols and the "
-        f"predictions carry {predictions['symbol'].n_unique()}, {len(missing)} of which it "
-        f"cannot price (first: {missing[:5]}). The vectorized path takes its universe and "
-        "its P&L from the predictions, so a narrower panel does not reduce this run - it "
-        "would trade every predicted name at the full cost per backtest while reading as a "
-        "reduction. Load the panel the predictions were fitted on. To reduce this stage, "
-        "cut TOP_N_PREDICTIONS, which lowers the number of backtests and leaves each one a "
-        "full run."
+        f"predictions carry {predictions['symbol'].n_unique()}, {unpriced['symbol'].n_unique()} "
+        "of which it cannot price. The vectorized path takes its universe and its P&L from "
+        "the predictions, so this run trades every predicted name at the full cost per "
+        "backtest and the narrower panel reduces nothing (ml4t/agent-workspace#911). "
+        "TOP_N_PREDICTIONS is the knob that reduces this stage.",
+        stacklevel=2,
     )
 
 
@@ -1441,13 +1438,13 @@ def run_backtest(
 
     # A price panel that does not cover the predictions does not reduce a
     # vectorized run, it just makes the parameter read as if it did - see
-    # `refuse_predictions_the_panel_cannot_price`. The sp500_options HTM path is
-    # excluded because its `prices` frame and its predictions are not indexed by
-    # the same kind of symbol.
+    # `warn_if_the_panel_does_not_bound_the_universe`. The sp500_options HTM path
+    # is excluded because its `prices` frame and its predictions are not indexed
+    # by the same kind of symbol.
     if strategy.get("rebalance", {}).get("mode") == "vectorized" and not (
         case_study == "sp500_options" and label == "ret_to_expiry"
     ):
-        refuse_predictions_the_panel_cannot_price(
+        warn_if_the_panel_does_not_bound_the_universe(
             predictions, prices, case_study=case_study, label=label
         )
 

--- a/case_studies/utils/registry/completeness.py
+++ b/case_studies/utils/registry/completeness.py
@@ -469,8 +469,19 @@ def backtest_run_status(
 
         has_metrics = False
         if require_metrics:
+            # A NULL sharpe means "no metric pass has run here" everywhere except one
+            # case: a path the engine stopped at ruin registers every ranking metric as
+            # NULL on purpose, so that nothing sorts a bankrupt account against a solvent
+            # one (ml4t/agent-workspace#920). Reading that as incomplete would re-run the
+            # backtest on every pass and never converge, so `ruin` is what separates
+            # them. `ruin` is absent from a registry written before that column existed,
+            # in which case a NULL sharpe still means unmeasured.
+            has_ruin = "ruin" in {
+                row[1] for row in db.execute("PRAGMA table_info(backtest_metrics)").fetchall()
+            }
+            measured = "sharpe IS NOT NULL OR ruin = 1.0" if has_ruin else "sharpe IS NOT NULL"
             m_row = db.execute(
-                "SELECT sharpe FROM backtest_metrics WHERE backtest_hash = ? AND sharpe IS NOT NULL",
+                f"SELECT sharpe FROM backtest_metrics WHERE backtest_hash = ? AND ({measured})",
                 (b_hash,),
             ).fetchone()
             has_metrics = m_row is not None

--- a/case_studies/utils/registry/metrics.py
+++ b/case_studies/utils/registry/metrics.py
@@ -579,6 +579,18 @@ def compute_backtest_fold_metrics(
     if ts_dtype != pl.Date:
         daily_returns = daily_returns.with_columns(pl.col("timestamp").cast(pl.Date))
 
+    # Where the account ended, read off the whole series before it is cut up.
+    # A fold that begins after ruin is all zeros, and a slice of zeros is
+    # indistinguishable from a fold in which the strategy simply did not trade:
+    # `compute_portfolio_metrics` on it reports `ruin=0`, a Sharpe of 0 and no
+    # drawdown, which is a clean row for a period in which the book did not exist
+    # (ml4t/agent-workspace#920). The fold that contains the ruin finds it for
+    # itself; the folds after it are told.
+    from case_studies.utils.backtest_runner import first_ruin_index
+
+    ruin_index = first_ruin_index(daily_returns["daily_return"].to_numpy())
+    ruin_date = None if ruin_index is None else daily_returns["timestamp"].to_list()[ruin_index]
+
     for split in splits:
         fold_id = split["fold"]
         val_start = str(split["val_start"])[:10]  # "YYYY-MM-DD"
@@ -599,6 +611,14 @@ def compute_backtest_fold_metrics(
 
         returns_arr = fold_returns["daily_return"].to_numpy()
         fold_metrics = compute_portfolio_metrics(returns_arr, periods_per_year=periods_per_year)
+        if ruin_date is not None and start_date > ruin_date:
+            from case_studies.utils.backtest_runner import _apply_ruin_semantics
+
+            # The account was already gone when this fold opened. Report the ruin
+            # rather than the zeros it leaves behind, and carry the whole path's
+            # index so the fold rows agree with the overall row about where it
+            # happened.
+            fold_metrics = _apply_ruin_semantics(fold_metrics, ruin_index)
 
         # Add fold metadata
         fold_metrics["n_days"] = len(fold_returns)

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -597,10 +597,16 @@ _BACKTEST_UNCERTAINTY_COLUMNS = (
     "bootstrap_n",
 )
 
+# Written on every run by `compute_portfolio_metrics`: whether the path lost its
+# capital, and the index of the period where it did (ml4t/agent-workspace#920).
+_BACKTEST_RUIN_COLUMNS = ("ruin", "ruin_period")
+
 _DECLARED_METRIC_COLUMNS: dict[str, tuple[str, ...]] = {
-    "backtest_metrics": _BACKTEST_UNCERTAINTY_COLUMNS,
+    "backtest_metrics": _BACKTEST_UNCERTAINTY_COLUMNS + _BACKTEST_RUIN_COLUMNS,
     # n_periods rides along: the fold table declares n_days, and the metric pass writes both.
-    "backtest_fold_metrics": _BACKTEST_UNCERTAINTY_COLUMNS + ("n_periods",),
+    "backtest_fold_metrics": _BACKTEST_UNCERTAINTY_COLUMNS
+    + _BACKTEST_RUIN_COLUMNS
+    + ("n_periods",),
     "prediction_metrics": tuple(
         f"{metric}_{suffix}"
         for metric in ("ic", "auc")

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -601,8 +601,21 @@ _BACKTEST_UNCERTAINTY_COLUMNS = (
 # capital, and the index of the period where it did (ml4t/agent-workspace#920).
 _BACKTEST_RUIN_COLUMNS = ("ruin", "ruin_period")
 
+# Written on every run by `RiskTriggerLog.as_metrics`: how often each declared risk
+# control acted, NULL where none of that kind was declared (ml4t/agent-workspace#1051).
+_BACKTEST_RISK_TRIGGER_COLUMNS = (
+    "risk_triggers",
+    "risk_triggers_stop_loss",
+    "risk_triggers_trailing_stop",
+    "risk_triggers_time_exit",
+    "risk_triggers_max_drawdown",
+    "risk_triggers_daily_loss",
+)
+
 _DECLARED_METRIC_COLUMNS: dict[str, tuple[str, ...]] = {
-    "backtest_metrics": _BACKTEST_UNCERTAINTY_COLUMNS + _BACKTEST_RUIN_COLUMNS,
+    "backtest_metrics": _BACKTEST_UNCERTAINTY_COLUMNS
+    + _BACKTEST_RUIN_COLUMNS
+    + _BACKTEST_RISK_TRIGGER_COLUMNS,
     # n_periods rides along: the fold table declares n_days, and the metric pass writes both.
     "backtest_fold_metrics": _BACKTEST_UNCERTAINTY_COLUMNS
     + _BACKTEST_RUIN_COLUMNS

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -20,6 +20,7 @@ Usage::
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timezone
@@ -72,6 +73,13 @@ UNIVERSE_RESTRICTIONS: dict[str, str] = {
 # information only. The corrected S&P 500 options carrier is the liquid-universe
 # cross-stage rank-1. Two alternative allocator rows tie its Sharpe exactly, so
 # the deterministic tie-break preserves the simpler equal-weight baseline spec.
+
+
+def _ruined(returns) -> bool:
+    """Whether this return path took its account through zero equity anywhere."""
+    from case_studies.utils.backtest_runner import first_ruin_index
+
+    return first_ruin_index(returns) is not None
 
 
 def rank_returns_on_common_support(
@@ -128,7 +136,19 @@ def rank_returns_on_common_support(
         # of a mean to a dispersion describes a process that continues
         # (ml4t/agent-workspace#920). The candidate stays on the frame so the
         # caller can see it was compared, and sorts below every solvent one.
+        #
+        # Ruin is read off the *whole* series, not off the common-support slice.
+        # The intersection can end before the period that wiped the account out,
+        # and a bankrupt book restricted to the months before it went bankrupt is
+        # not a rankable strategy - it would outrank a solvent candidate with a
+        # negative Sharpe on the strength of the window the comparison happened
+        # to choose.
+        #
+        # None rather than the NaN the metrics carry: polars sorts a NaN first on
+        # a descending sort, which is the one place that matters here.
         sharpe = metrics["sharpe"]
+        if _ruined(frame["daily_return"].to_numpy()) or (sharpe is not None and math.isnan(sharpe)):
+            sharpe = None
         rows.append(
             {
                 "backtest_hash": backtest_hash,

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -124,16 +124,21 @@ def rank_returns_on_common_support(
             uncertainty=False,
             trim_leading_zeros=False,
         )
+        # A path the engine stopped at ruin carries no Sharpe, by design: a ratio
+        # of a mean to a dispersion describes a process that continues
+        # (ml4t/agent-workspace#920). The candidate stays on the frame so the
+        # caller can see it was compared, and sorts below every solvent one.
+        sharpe = metrics["sharpe"]
         rows.append(
             {
                 "backtest_hash": backtest_hash,
-                "sharpe": float(metrics["sharpe"]),
+                "sharpe": None if sharpe is None else float(sharpe),
                 "n_periods": aligned.height,
                 "start": common[0],
                 "end": common[-1],
             }
         )
-    return pl.DataFrame(rows).sort("sharpe", descending=True)
+    return pl.DataFrame(rows).sort("sharpe", descending=True, nulls_last=True)
 
 
 def rank_backtests_on_common_support(

--- a/case_studies/utils/sweep_config.py
+++ b/case_studies/utils/sweep_config.py
@@ -381,31 +381,46 @@ def _periods_per_year_for(case_study: str) -> float:
     return float(ppy)
 
 
+# How many registered prediction sets the width resolver reads before it decides.
+# One is enough where they agree and cannot detect it where they do not.
+_RANKED_WIDTH_SAMPLE = 8
+
+
 def ranked_cross_section_width(
     case_study: str, label: str, *, split: str = "validation"
 ) -> int | None:
     """Distinct symbols in the predictions an entry-scheme sweep will rank.
 
-    ``None`` when nothing is registered yet for ``(label, split)``, or when the
-    artifact behind the first registered prediction set is missing - a case study
-    whose model stages have not run has no ranked cross-section, and inventing one
-    would refuse a sweep that has not been set up wrong.
+    ``None`` when nothing is registered yet for ``(label, split)``, when the
+    artifacts behind the registered sets are missing, or when the sampled sets do
+    not agree on a width. A case study whose model stages have not run has no
+    ranked cross-section, and inventing one would refuse a sweep that has not
+    been set up wrong.
 
-    One prediction set is read, not all of them: every prediction set for a label
-    is scored over the same feature panel, so they share a width. Measured
-    2026-09-07 over six registered sets per label in etfs, us_firm_characteristics,
-    sp500_equity_option_analytics and us_equities_panel: one width per label in
-    every case, 99 / 3,708 / 549 / 3,147 respectively.
+    The registry is sampled rather than asked about the population a particular
+    caller is sweeping, and those are different questions: `cme_futures/13_backtest`
+    selects official or preview candidates, and a width taken from an unrelated
+    set could remove a concentration that is feasible for the ones actually being
+    swept. So the resolver only speaks when the sample is unanimous - up to eight
+    registered sets, all reporting the same width - and otherwise returns ``None``
+    and leaves the caller's own number standing. A caller that knows its
+    population passes ``ranked_width`` and skips this entirely.
 
-    Distinct symbols over the window, which is the same count the callers take off
-    the price panel, so the comparison in ``get_entry_schemes_for`` is between two
-    measurements of the same kind. The number that literally bounds a ranking is
-    the per-date cross-section, which is smaller - 88 against 99 for etfs, 2,032
-    against 3,708 for us_firm_characteristics - and moving the rule onto it would
-    change which concentrations are feasible today. That is a separate decision
-    about the rule; this function is about which set the rule reads.
+    Unanimity is the common case, not a hope: measured 2026-09-07 over six
+    registered sets per label in etfs, us_firm_characteristics,
+    sp500_equity_option_analytics and us_equities_panel, every label had exactly
+    one width - 99, 3,708, 549 and 3,147 respectively.
+
+    Distinct symbols over the window, which is the same count the callers take
+    off the price panel, so the comparison in ``get_entry_schemes_for`` is between
+    two measurements of the same kind. The number that literally bounds a ranking
+    is the per-date cross-section, which is smaller - 88 against 99 for etfs,
+    2,032 against 3,708 for us_firm_characteristics - and moving the rule onto it
+    would change which concentrations are feasible today. That is a separate
+    decision about the rule; this function is about which set the rule reads.
     """
     import sqlite3
+    import warnings
 
     from case_studies.utils.registry.store import _case_dir, _registry_db_path, _run_log_dir
 
@@ -415,27 +430,42 @@ def ranked_cross_section_width(
         return None
     try:
         with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as db:
-            row = db.execute(
+            rows = db.execute(
                 """
                 SELECT p.prediction_hash
                 FROM prediction_sets p
                 JOIN training_runs t ON t.training_hash = p.training_hash
                 WHERE t.label = ? AND p.split = ?
+                LIMIT ?
                 """,
-                (label, split),
-            ).fetchone()
+                (label, split, _RANKED_WIDTH_SAMPLE),
+            ).fetchall()
     except sqlite3.Error:
         return None
-    if row is None:
-        return None
 
-    artifact = _run_log_dir(case_dir) / "predictions" / row[0] / "predictions.parquet"
-    if not artifact.is_file():
+    widths: set[int] = set()
+    for (prediction_hash,) in rows:
+        artifact = _run_log_dir(case_dir) / "predictions" / prediction_hash / "predictions.parquet"
+        if not artifact.is_file():
+            continue
+        try:
+            widths.add(
+                int(pl.scan_parquet(artifact).select(pl.col("symbol").n_unique()).collect().item())
+            )
+        except (pl.exceptions.PolarsError, OSError, ValueError):
+            return None
+    if not widths:
         return None
-    try:
-        return int(pl.scan_parquet(artifact).select(pl.col("symbol").n_unique()).collect().item())
-    except (pl.exceptions.PolarsError, OSError, ValueError):
+    if len(widths) > 1:
+        warnings.warn(
+            f"{case_study}/{label}: registered prediction sets disagree on the ranked "
+            f"cross-section ({sorted(widths)}), so the entry-scheme feasibility rule falls "
+            "back to the caller's price-panel width. Pass ranked_width= with the width of "
+            "the population actually being swept.",
+            stacklevel=2,
+        )
         return None
+    return widths.pop()
 
 
 def get_entry_schemes_for(

--- a/case_studies/utils/sweep_config.py
+++ b/case_studies/utils/sweep_config.py
@@ -381,11 +381,70 @@ def _periods_per_year_for(case_study: str) -> float:
     return float(ppy)
 
 
+def ranked_cross_section_width(
+    case_study: str, label: str, *, split: str = "validation"
+) -> int | None:
+    """Distinct symbols in the predictions an entry-scheme sweep will rank.
+
+    ``None`` when nothing is registered yet for ``(label, split)``, or when the
+    artifact behind the first registered prediction set is missing - a case study
+    whose model stages have not run has no ranked cross-section, and inventing one
+    would refuse a sweep that has not been set up wrong.
+
+    One prediction set is read, not all of them: every prediction set for a label
+    is scored over the same feature panel, so they share a width. Measured
+    2026-09-07 over six registered sets per label in etfs, us_firm_characteristics,
+    sp500_equity_option_analytics and us_equities_panel: one width per label in
+    every case, 99 / 3,708 / 549 / 3,147 respectively.
+
+    Distinct symbols over the window, which is the same count the callers take off
+    the price panel, so the comparison in ``get_entry_schemes_for`` is between two
+    measurements of the same kind. The number that literally bounds a ranking is
+    the per-date cross-section, which is smaller - 88 against 99 for etfs, 2,032
+    against 3,708 for us_firm_characteristics - and moving the rule onto it would
+    change which concentrations are feasible today. That is a separate decision
+    about the rule; this function is about which set the rule reads.
+    """
+    import sqlite3
+
+    from case_studies.utils.registry.store import _case_dir, _registry_db_path, _run_log_dir
+
+    case_dir = _case_dir(case_study)
+    db_path = _registry_db_path(case_dir)
+    if not db_path.is_file():
+        return None
+    try:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as db:
+            row = db.execute(
+                """
+                SELECT p.prediction_hash
+                FROM prediction_sets p
+                JOIN training_runs t ON t.training_hash = p.training_hash
+                WHERE t.label = ? AND p.split = ?
+                """,
+                (label, split),
+            ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+
+    artifact = _run_log_dir(case_dir) / "predictions" / row[0] / "predictions.parquet"
+    if not artifact.is_file():
+        return None
+    try:
+        return int(pl.scan_parquet(artifact).select(pl.col("symbol").n_unique()).collect().item())
+    except (pl.exceptions.PolarsError, OSError, ValueError):
+        return None
+
+
 def get_entry_schemes_for(
     case_study: str,
     label: str,
     n_assets: int,
     long_short: bool,
+    *,
+    ranked_width: int | None = None,
 ) -> list[dict]:
     """Synthesize Ch16 entry schemes for ``(case_study, label)`` from setup.yaml.
 
@@ -402,9 +461,27 @@ def get_entry_schemes_for(
     When the case study declares a ``backtest.sweep.signal_nasdaq100`` block
     (the nasdaq100 v4 slot-mechanism sweep), schemes from that block are
     appended — see ``get_signal_nasdaq100_schemes_for`` for the cross-product.
+
+    ``n_assets`` is the width of the price panel. What bounds a ranked selection
+    is the prediction cross-section, and the two are not the same number: every
+    caller measures ``n_assets`` off the panel it loaded, while the ranking runs
+    over whatever the fitting stages scored. ``ranked_width`` is that second
+    number, resolved from the registry when the caller does not supply it, and
+    the feasibility rule below applies to the narrower of the two.
+
+    They agree on `main` today, which is why nothing is currently wrong and why
+    the check could not fire on the condition it exists to catch
+    (ml4t/agent-workspace#1003). Any change that narrows the fitting stages
+    without narrowing the panel - a new preview tier, a per-notebook
+    ``max_symbols``, a family that scores a subset - reproduces
+    ml4t/agent-workspace#989: twelve backtests with a Sharpe, zero trades, and
+    four notebooks failing several stages downstream of the cause.
     """
     sweep = load_sweep(case_study)
     schemes: list[dict] = []
+    if ranked_width is None:
+        ranked_width = ranked_cross_section_width(case_study, label)
+    tradeable = n_assets if ranked_width is None else min(n_assets, ranked_width)
 
     top_k_by_label = sweep.get("top_k_grid") or {}
     pct_by_label = sweep.get("percentile_grid") or {}
@@ -430,17 +507,18 @@ def get_entry_schemes_for(
             f"pct={sorted(pct_by_label)}, qnt={sorted(qnt_by_label)}"
         )
 
-    for k in top_k_by_label.get(label, []):
-        k = int(k)
-        # k == n_assets holds the whole universe = equal-weight benchmark, not a
-        # prediction-based portfolio; exclude it to match get_top_k_values_for.
-        if k >= n_assets:
+    declared_top_k = [int(k) for k in top_k_by_label.get(label, [])]
+    top_k_schemes: list[dict] = []
+    for k in declared_top_k:
+        # k == tradeable holds the whole cross-section = equal-weight benchmark, not
+        # a prediction-based portfolio; exclude it to match get_top_k_values_for.
+        if k >= tradeable:
             continue
         # Long and short selections must be disjoint. Keep the declared grid and
         # exclude only members that the available cross-section cannot realize.
-        if long_short and 2 * k > n_assets:
+        if long_short and 2 * k > tradeable:
             continue
-        schemes.append(
+        top_k_schemes.append(
             {
                 "name": f"ew_top{k}",
                 "method": "equal_weight_top_k",
@@ -448,6 +526,23 @@ def get_entry_schemes_for(
                 "long_short": long_short,
             }
         )
+    # Raised here rather than left to the caller's empty-list guard, because only
+    # this scope holds both numbers. A caller that reports `n_assets` back is
+    # reporting the number the check did not use, which is how the original
+    # failure presented. The panel-too-narrow case (`tradeable == n_assets`) is
+    # left to that guard, which names the right number for it.
+    if declared_top_k and not top_k_schemes and tradeable < n_assets:
+        raise ValueError(
+            f"no concentration declared for {case_study}/{label} can be realized: "
+            f"backtest.sweep.top_k_grid declares {sorted(declared_top_k)}, and the "
+            f"predictions this sweep ranks carry {tradeable} symbols against a price "
+            f"panel of {n_assets}. Every k is at or above the ranked cross-section, so "
+            "each would hold all of it rather than select from it, and every backtest "
+            "in the sweep would record num_trades = 0 while still reporting a Sharpe. "
+            "Narrow the price panel and the fitting stages together, or declare a "
+            "smaller concentration."
+        )
+    schemes.extend(top_k_schemes)
 
     for p in pct_by_label.get(label, []):
         p = float(p)
@@ -674,6 +769,7 @@ def get_top_k_values_for(
     n_assets: int,
     *,
     long_short: bool | None = None,
+    ranked_width: int | None = None,
 ) -> list[int]:
     """Return the top-K grid for ``(case_study, label)`` used by Ch17.
 
@@ -705,6 +801,13 @@ def get_top_k_values_for(
     notices, and it blames the operator for not having run this stage. Raise
     here instead, where the cause - a universe cap smaller than the smallest
     declared k - is still visible.
+
+    ``ranked_width`` is the prediction cross-section, resolved from the registry
+    when not supplied, and the filter runs against the narrower of it and
+    ``n_assets`` for the reason given under ``get_entry_schemes_for``
+    (ml4t/agent-workspace#1003). The two functions are halves of one grid and
+    have to filter it the same way or a sweep and its plumbing test disagree
+    about which concentrations exist.
     """
     sweep = load_sweep(case_study)
     grid = (sweep.get("top_k_grid") or {}).get(label)
@@ -715,9 +818,12 @@ def get_top_k_values_for(
         )
     if long_short is None:
         long_short = get_declared_long_short(case_study)
-    ceiling = n_assets // 2 if long_short else n_assets
+    if ranked_width is None:
+        ranked_width = ranked_cross_section_width(case_study, label)
+    tradeable = n_assets if ranked_width is None else min(n_assets, ranked_width)
+    ceiling = tradeable // 2 if long_short else tradeable
     values = [
-        int(k) for k in grid if int(k) < n_assets and not (long_short and 2 * int(k) > n_assets)
+        int(k) for k in grid if int(k) < tradeable and not (long_short and 2 * int(k) > tradeable)
     ]
     if not values:
         smallest = min(int(k) for k in grid)
@@ -734,7 +840,8 @@ def get_top_k_values_for(
         side = f"long-short ceiling ({ceiling})" if long_short else "universe"
         raise ValueError(
             f"top_k_grid[{label!r}] = {list(grid)} is empty after filtering against "
-            f"n_assets={n_assets} for case_studies/{case_study}: every declared k holds "
+            f"{tradeable} tradeable names for case_studies/{case_study} (price panel "
+            f"{n_assets}, ranked cross-section {ranked_width}): every declared k holds "
             f"the whole {side}. A cross-sectional sweep here needs {needed}. Raise the "
             f"universe cap (MAX_SYMBOLS) if the panel has them, widen the panel if it "
             f"does not, or declare a smaller k."

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1236,6 +1236,8 @@ case_studies/cme_futures/05_evaluation:
 # this case study's arithmetic: top_k_grid [5, 10] and long-short, so the smallest declared
 # concentration needs 2 x 5 = 10 names to hold a long and a short leg that do not overlap.
 # This also clears the fold-4 feature-column loss the header of this file records at 5.
+# Ten is reachable here: `intermediates/cme_futures/features/financial.parquet` carries 30
+# products, measured 2026-09-07 on ml4t/third-edition-test-data 63a9e4e.
 case_studies/cme_futures/06_linear:
   # 120s is measured here, not copied. Slowest of 5 green `cs-cme_futures` runs of
   # .github/workflows/test.yml sampled 2026-09-04: 15.1s, 13% of the budget, against
@@ -1429,19 +1431,28 @@ case_studies/crypto_perps_funding/02_labels:
   timeout: 120
 case_studies/crypto_perps_funding/03_financial_features:
   timeout: 120
-# max_symbols is 6 rather than 5 for the reason case_studies/etfs/06_linear states:
-# top_k_grid [3, 5, 10] and long-short, so the smallest concentration needs 2 x 3 = 6 names.
-# 04 and 05 move together because 04 builds the temporal artifact the model stages read, and
-# a cap the artifact does not share is what ml4t/agent-workspace#988 measured diverging.
+# max_symbols stays 5 here, and unlike the other three case studies raising it would change
+# nothing: the whole crypto fixture is five perpetuals. `data/crypto/market/perps_1h.parquet`,
+# `premium_index_8h.parquet` and `funding_rate.parquet` each carry exactly the five symbols
+# `tests/create_test_data.py:CRYPTO_SYMBOLS` names, measured 2026-09-07 on
+# ml4t/third-edition-test-data 63a9e4e, and every seeded feature and fold artifact under
+# `intermediates/crypto_perps_funding` carries the same five. This case study declares
+# top_k_grid [3, 5, 10] and is long-short, so its smallest concentration needs 2 x 3 = 6 names
+# and no cap written here can produce a sixth. `cs-crypto_perps_funding` therefore fails at
+# 13_backtest with "no concentration declared ... can be realized", which is
+# ml4t/agent-workspace#989's cause stated rather than the twelve zero-trade backtests it used
+# to register silently. Widening it means widening the fixture, which regenerates
+# `intermediates/crypto_perps_funding` and is the coupling create_test_data.py's crypto header
+# records as ml4t/agent-workspace#970.
 case_studies/crypto_perps_funding/04_model_based_features:
   parameters:
     HMM_N_RESTARTS: 1
-    MAX_SYMBOLS: 6
+    MAX_SYMBOLS: 5
     MIN_TRAIN_BARS: 10
   timeout: 300
 case_studies/crypto_perps_funding/05_evaluation:
   parameters:
-    MAX_SYMBOLS: 6
+    MAX_SYMBOLS: 5
   timeout: 300
 case_studies/crypto_perps_funding/06_linear:
   # 120s is measured here, not copied. Slowest of 5 green `cs-crypto_perps_funding` runs of
@@ -1585,7 +1596,9 @@ case_studies/etfs/05_evaluation:
 # every scheme is dropped and the sweep registers nothing, which is the zero-trade state
 # ml4t/agent-workspace#989 recorded and #1003 makes loud. Six rather than something rounder
 # because cs-etfs is already the longest case-study job on main at 43m and the model cost
-# scales with the cross-section.
+# scales with the cross-section. Six is reachable: the fixture carries 56 funds
+# (`intermediates/etfs/features/financial.parquet`, measured 2026-09-07 on
+# ml4t/third-edition-test-data 63a9e4e), not the 24 the 02_labels entry above still says.
 case_studies/etfs/06_linear:
   # 120s is measured here, not copied. Slowest of 5 green `cs-etfs` runs of
   # .github/workflows/test.yml sampled 2026-09-04: 16.1s, 13% of the budget, against
@@ -2046,7 +2059,11 @@ case_studies/fx_pairs/19_strategy_analysis:
 # reason case_studies/etfs/06_linear states: top_k_grid [5, 10, 20] and long-short, so the
 # smallest declared concentration needs 2 x 5 = 10 names. The label and feature stages move
 # with the model stages because they bound what the model stages can see, and 14-16 already
-# load a 12-symbol price panel, which is wide enough to hold it.
+# load a 12-symbol price panel, which is wide enough to hold it. Ten is reachable through
+# `load_nasdaq100_bars`: `data/equities/market/nasdaq100/minute_bars` carries 12 symbols,
+# measured 2026-09-07 on ml4t/third-edition-test-data 63a9e4e. The seeded
+# `intermediates/nasdaq100_microstructure` features carry 5 because they were generated
+# under the cap this entry raises, not because the bars stop there.
 case_studies/nasdaq100_microstructure/01_feasibility_analysis:
   parameters:
     MAX_SYMBOLS: 10

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1232,6 +1232,10 @@ case_studies/cme_futures/05_evaluation:
   # zero-row subplot. The fixture carries all 30 products, which is what production
   # evaluates, and the reduction bought nothing: the panel is 38k rows either way.
   timeout: 600
+# max_symbols is 10 rather than 5 for the reason case_studies/etfs/06_linear states, with
+# this case study's arithmetic: top_k_grid [5, 10] and long-short, so the smallest declared
+# concentration needs 2 x 5 = 10 names to hold a long and a short leg that do not overlap.
+# This also clears the fold-4 feature-column loss the header of this file records at 5.
 case_studies/cme_futures/06_linear:
   # 120s is measured here, not copied. Slowest of 5 green `cs-cme_futures` runs of
   # .github/workflows/test.yml sampled 2026-09-04: 15.1s, 13% of the budget, against
@@ -1249,7 +1253,7 @@ case_studies/cme_futures/06_linear:
     # for the same reason as 07_gbm below: the reduction is what it was calibrated against.
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 10
   timeout: 120
 case_studies/cme_futures/07_gbm:
   parameters:
@@ -1275,7 +1279,7 @@ case_studies/cme_futures/07_gbm:
       checkpoint_interval: 10
       folds: [0, 1]
       max_iterations: 20
-      max_symbols: 5
+      max_symbols: 10
   # Measured the same way and at the same load: 172.9 s end to end. Kept at 180 s.
   timeout: 180
 case_studies/cme_futures/08_tabular_dl:
@@ -1425,15 +1429,19 @@ case_studies/crypto_perps_funding/02_labels:
   timeout: 120
 case_studies/crypto_perps_funding/03_financial_features:
   timeout: 120
+# max_symbols is 6 rather than 5 for the reason case_studies/etfs/06_linear states:
+# top_k_grid [3, 5, 10] and long-short, so the smallest concentration needs 2 x 3 = 6 names.
+# 04 and 05 move together because 04 builds the temporal artifact the model stages read, and
+# a cap the artifact does not share is what ml4t/agent-workspace#988 measured diverging.
 case_studies/crypto_perps_funding/04_model_based_features:
   parameters:
     HMM_N_RESTARTS: 1
-    MAX_SYMBOLS: 5
+    MAX_SYMBOLS: 6
     MIN_TRAIN_BARS: 10
   timeout: 300
 case_studies/crypto_perps_funding/05_evaluation:
   parameters:
-    MAX_SYMBOLS: 5
+    MAX_SYMBOLS: 6
   timeout: 300
 case_studies/crypto_perps_funding/06_linear:
   # 120s is measured here, not copied. Slowest of 5 green `cs-crypto_perps_funding` runs of
@@ -1569,6 +1577,15 @@ case_studies/etfs/05_evaluation:
   # Same reason as 04 above: this stage feeds the same predictions, so reducing it
   # re-narrows the cross-section that 04 was widened to preserve.
   timeout: 900
+# max_symbols is 6 rather than 5 across this case study's model stages, and the number is
+# derived rather than chosen. `get_entry_schemes_for` drops any declared `top_k` at or above
+# the universe the signal ranks, because holding k of k is the equal-weight benchmark rather
+# than a selection. etfs declares top_k_grid [5, 10, 20] and is long-only, so 6 is the
+# smallest cross-section at which the smallest declared concentration is realizable - at 5
+# every scheme is dropped and the sweep registers nothing, which is the zero-trade state
+# ml4t/agent-workspace#989 recorded and #1003 makes loud. Six rather than something rounder
+# because cs-etfs is already the longest case-study job on main at 43m and the model cost
+# scales with the cross-section.
 case_studies/etfs/06_linear:
   # 120s is measured here, not copied. Slowest of 5 green `cs-etfs` runs of
   # .github/workflows/test.yml sampled 2026-09-04: 16.1s, 13% of the budget, against
@@ -1587,7 +1604,7 @@ case_studies/etfs/06_linear:
   parameters:
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 6
   timeout: 120
 case_studies/etfs/07_gbm:
   # As 06_linear. The iteration and checkpoint axes are left at their declared values: a
@@ -1596,7 +1613,7 @@ case_studies/etfs/07_gbm:
   parameters:
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 6
   timeout: 180
 case_studies/etfs/08_tabular_dl:
   # DEVICE and POPULATION_NAME travel together. The runner refuses to substitute a CPU
@@ -1612,7 +1629,7 @@ case_studies/etfs/08_tabular_dl:
     POPULATION_NAME: etfs-tabular_dl-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 6
   timeout: 300
 case_studies/etfs/09_dl_lstm:
   # Converted onto the research boundary, so the notebook no longer binds BATCH_SIZE, LOOKBACK or
@@ -1631,7 +1648,7 @@ case_studies/etfs/09_dl_lstm:
     POPULATION_NAME: etfs-lstm-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 6
   timeout: 180
 case_studies/etfs/10_dl_tsmixer:
   # Converted onto the research boundary alongside 09_dl_lstm, so the same three names are gone:
@@ -1697,7 +1714,7 @@ case_studies/etfs/11a_pca:
     POPULATION_NAME: etfs-pca-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 6
   timeout: 300
 case_studies/etfs/11b_ipca:
   # max_symbols must match 04_model_based_features for the same reason as 11a,
@@ -1722,7 +1739,7 @@ case_studies/etfs/11b_ipca:
     POPULATION_NAME: etfs-ipca-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 6
       n_factors: 1
   # Budget raised from 300 on a CI measurement, not on another notebook's number.
   # Slowest of 5 green `cs-etfs` runs of .github/workflows/test.yml sampled 2026-09-04:
@@ -1759,7 +1776,7 @@ case_studies/etfs/11c_conditional_autoencoder:
     LABELS: ['fwd_ret_21d']
     POPULATION_NAME: etfs-cae-preview
     PREVIEW_REDUCTIONS:
-      max_symbols: 5
+      max_symbols: 6
   timeout: 900
 case_studies/etfs/11d_stochastic_discount_factor:
   # Still skipped, but not for the reason it used to claim. The old skip_reason said
@@ -1782,7 +1799,7 @@ case_studies/etfs/11e_supervised_autoencoder:
     LABELS: ['fwd_ret_21d']
     POPULATION_NAME: etfs-sae-preview
     PREVIEW_REDUCTIONS:
-      max_symbols: 5
+      max_symbols: 6
   timeout: 900
 case_studies/etfs/12_causal_dml:
   parameters:
@@ -2025,18 +2042,23 @@ case_studies/fx_pairs/19_strategy_analysis:
   skip_reason: "Reads back the holdout lineage 17 and 18 produce; with those skipped there is
     nothing for it to resolve."
   timeout: 300
+# max_symbols is 10 rather than 5 through this case study's data and model stages, for the
+# reason case_studies/etfs/06_linear states: top_k_grid [5, 10, 20] and long-short, so the
+# smallest declared concentration needs 2 x 5 = 10 names. The label and feature stages move
+# with the model stages because they bound what the model stages can see, and 14-16 already
+# load a 12-symbol price panel, which is wide enough to hold it.
 case_studies/nasdaq100_microstructure/01_feasibility_analysis:
   parameters:
-    MAX_SYMBOLS: 5
+    MAX_SYMBOLS: 10
   timeout: 120
 case_studies/nasdaq100_microstructure/02_labels:
   parameters:
-    MAX_SYMBOLS: 5
+    MAX_SYMBOLS: 10
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/nasdaq100_microstructure/03_financial_features:
   parameters:
-    MAX_SYMBOLS: 5
+    MAX_SYMBOLS: 10
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/nasdaq100_microstructure/04_model_based_features:
@@ -2047,12 +2069,12 @@ case_studies/nasdaq100_microstructure/04_model_based_features:
   # covered none of fold 0 and validate_temporal_fold_coverage failed at 0.0%.
   long_running: true
   parameters:
-    MAX_SYMBOLS: 5
+    MAX_SYMBOLS: 10
     START_DATE: '2000-01-01'
   timeout: 900
 case_studies/nasdaq100_microstructure/05_evaluation:
   parameters:
-    MAX_SYMBOLS: 5
+    MAX_SYMBOLS: 10
   timeout: 300
 case_studies/nasdaq100_microstructure/06_linear:
   parameters:
@@ -2062,7 +2084,7 @@ case_studies/nasdaq100_microstructure/06_linear:
     # cutting the cross-section does not touch it. `folds` is the reduction that does.
     PREVIEW_REDUCTIONS:
       folds: [0]
-      max_symbols: 5
+      max_symbols: 10
       train_sample_frac: 0.02
   # Measured after the preview branch stopped re-resolving: slowest cell 211s (the fit),
   # planning 121s, 342s end to end. Timeout is per cell, so this is ~2.8x the slowest.
@@ -2077,7 +2099,7 @@ case_studies/nasdaq100_microstructure/07_gbm:
       checkpoint_interval: 10
       folds: [0]
       max_iterations: 20
-      max_symbols: 5
+      max_symbols: 10
       train_sample_frac: 0.02
   # Measured the same way: slowest cell 362s, planning 147s, 515s end to end.
   tier: weekly
@@ -2099,7 +2121,7 @@ case_studies/nasdaq100_microstructure/08_dl_nlinear:
     POPULATION_NAME: nasdaq100_microstructure-nlinear-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 10
       max_train_sequences: 2000
   timeout: 600
 case_studies/nasdaq100_microstructure/09_dl_lstm:
@@ -2119,7 +2141,7 @@ case_studies/nasdaq100_microstructure/09_dl_lstm:
     POPULATION_NAME: nasdaq100_microstructure-lstm_h64-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 10
       max_train_sequences: 2000
   timeout: 600
 case_studies/nasdaq100_microstructure/10_dl_tcn:
@@ -2139,7 +2161,7 @@ case_studies/nasdaq100_microstructure/10_dl_tcn:
     POPULATION_NAME: nasdaq100_microstructure-tcn-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 10
       max_train_sequences: 2000
   timeout: 600
 case_studies/nasdaq100_microstructure/11_dl_patchtst:
@@ -2155,7 +2177,7 @@ case_studies/nasdaq100_microstructure/11_dl_patchtst:
     POPULATION_NAME: nasdaq100_microstructure-patchtst-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 5
+      max_symbols: 10
       max_train_sequences: 2000
       # The training cap bounded the fit and left the forward pass over validation
       # scaling with the panel, which is why this cell sat at its 600s budget while

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2055,27 +2055,34 @@ case_studies/fx_pairs/19_strategy_analysis:
   skip_reason: "Reads back the holdout lineage 17 and 18 produce; with those skipped there is
     nothing for it to resolve."
   timeout: 300
-# max_symbols is 10 rather than 5 through this case study's data and model stages, for the
-# reason case_studies/etfs/06_linear states: top_k_grid [5, 10, 20] and long-short, so the
-# smallest declared concentration needs 2 x 5 = 10 names. The label and feature stages move
-# with the model stages because they bound what the model stages can see, and 14-16 already
-# load a 12-symbol price panel, which is wide enough to hold it. Ten is reachable through
-# `load_nasdaq100_bars`: `data/equities/market/nasdaq100/minute_bars` carries 12 symbols,
-# measured 2026-09-07 on ml4t/third-edition-test-data 63a9e4e. The seeded
-# `intermediates/nasdaq100_microstructure` features carry 5 because they were generated
-# under the cap this entry raises, not because the bars stop there.
+# max_symbols stays 5 here. The arithmetic asks for 10 - top_k_grid [5, 10, 20] and
+# long-short, so the smallest declared concentration needs 2 x 5 = 10 disjoint names - and the
+# raw fixture could supply it: `data/equities/market/nasdaq100/minute_bars` carries 12 symbols,
+# all with quotes. What binds is one step further in. The model stages fit from the fold
+# artifacts, and `intermediates/nasdaq100_microstructure/folds/*/fold_*_meta.parquet` carries
+# 5 symbols on ml4t/third-edition-test-data 63a9e4e, measured 2026-09-07. `max_symbols` at a
+# model stage selects from the fold universe and cannot widen past it, so a cap of 10 over
+# 5-symbol folds still registers 5-symbol predictions - which is what CI measured on
+# 34157373964, where every stage ran and 14_backtest still refused at a ranked cross-section
+# of 5. Raising 01-05 without the folds also re-creates the ml4t/agent-workspace#988
+# divergence the 04 entry below warns about: features over 10 names, folds over 5.
+#
+# etfs and cme_futures are raised in this same file because their seeded folds are already
+# wide - 55-56 and 30 - so a model-stage cap selects from them. nasdaq and
+# crypto_perps_funding are the two whose folds were generated at 5, and both need the fixture
+# regenerated rather than an override (ml4t/agent-workspace#1077).
 case_studies/nasdaq100_microstructure/01_feasibility_analysis:
   parameters:
-    MAX_SYMBOLS: 10
+    MAX_SYMBOLS: 5
   timeout: 120
 case_studies/nasdaq100_microstructure/02_labels:
   parameters:
-    MAX_SYMBOLS: 10
+    MAX_SYMBOLS: 5
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/nasdaq100_microstructure/03_financial_features:
   parameters:
-    MAX_SYMBOLS: 10
+    MAX_SYMBOLS: 5
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/nasdaq100_microstructure/04_model_based_features:
@@ -2086,12 +2093,12 @@ case_studies/nasdaq100_microstructure/04_model_based_features:
   # covered none of fold 0 and validate_temporal_fold_coverage failed at 0.0%.
   long_running: true
   parameters:
-    MAX_SYMBOLS: 10
+    MAX_SYMBOLS: 5
     START_DATE: '2000-01-01'
   timeout: 900
 case_studies/nasdaq100_microstructure/05_evaluation:
   parameters:
-    MAX_SYMBOLS: 10
+    MAX_SYMBOLS: 5
   timeout: 300
 case_studies/nasdaq100_microstructure/06_linear:
   parameters:
@@ -2101,7 +2108,7 @@ case_studies/nasdaq100_microstructure/06_linear:
     # cutting the cross-section does not touch it. `folds` is the reduction that does.
     PREVIEW_REDUCTIONS:
       folds: [0]
-      max_symbols: 10
+      max_symbols: 5
       train_sample_frac: 0.02
   # Measured after the preview branch stopped re-resolving: slowest cell 211s (the fit),
   # planning 121s, 342s end to end. Timeout is per cell, so this is ~2.8x the slowest.
@@ -2116,7 +2123,7 @@ case_studies/nasdaq100_microstructure/07_gbm:
       checkpoint_interval: 10
       folds: [0]
       max_iterations: 20
-      max_symbols: 10
+      max_symbols: 5
       train_sample_frac: 0.02
   # Measured the same way: slowest cell 362s, planning 147s, 515s end to end.
   tier: weekly
@@ -2138,7 +2145,7 @@ case_studies/nasdaq100_microstructure/08_dl_nlinear:
     POPULATION_NAME: nasdaq100_microstructure-nlinear-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 10
+      max_symbols: 5
       max_train_sequences: 2000
   timeout: 600
 case_studies/nasdaq100_microstructure/09_dl_lstm:
@@ -2158,7 +2165,7 @@ case_studies/nasdaq100_microstructure/09_dl_lstm:
     POPULATION_NAME: nasdaq100_microstructure-lstm_h64-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 10
+      max_symbols: 5
       max_train_sequences: 2000
   timeout: 600
 case_studies/nasdaq100_microstructure/10_dl_tcn:
@@ -2178,7 +2185,7 @@ case_studies/nasdaq100_microstructure/10_dl_tcn:
     POPULATION_NAME: nasdaq100_microstructure-tcn-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 10
+      max_symbols: 5
       max_train_sequences: 2000
   timeout: 600
 case_studies/nasdaq100_microstructure/11_dl_patchtst:
@@ -2194,7 +2201,7 @@ case_studies/nasdaq100_microstructure/11_dl_patchtst:
     POPULATION_NAME: nasdaq100_microstructure-patchtst-preview
     PREVIEW_REDUCTIONS:
       folds: [0, 1]
-      max_symbols: 10
+      max_symbols: 5
       max_train_sequences: 2000
       # The training cap bounded the fit and left the forward pass over validation
       # scaling with the panel, which is why this cell sat at its 600s budget while

--- a/tests/test_backtest_ruin_stop.py
+++ b/tests/test_backtest_ruin_stop.py
@@ -9,6 +9,9 @@ zero and `(1 + r)` inverts the sign of every later period. The worst of them,
 
 from __future__ import annotations
 
+import math
+import sqlite3
+
 import numpy as np
 import polars as pl
 import pytest
@@ -28,9 +31,48 @@ def test_a_bankrupt_path_reports_no_sharpe() -> None:
     """The defect: a path whose equity crossed zero was still ranked."""
     out = _metrics(_RUINED)
     assert out["ruin"] == 1.0
-    assert out["sharpe"] is None
-    assert out["sortino"] is None
-    assert out["calmar"] is None
+    assert math.isnan(out["sharpe"])
+    assert math.isnan(out["sortino"])
+    assert math.isnan(out["calmar"])
+
+
+def test_the_unrankable_value_survives_the_round_trip_a_reader_makes() -> None:
+    """NaN, so that SQLite stores NULL and a notebook's `f"{x:.3f}"` still prints.
+
+    A None would reach `12_portfolio_management`'s progress line as a TypeError,
+    which its `except Exception` counts as a failed execution - a run that
+    registered successfully reported as a failure.
+    """
+    sharpe = _metrics(_RUINED)["sharpe"]
+    assert f"{sharpe:.3f}" == "nan"
+    db = sqlite3.connect(":memory:")
+    db.execute("CREATE TABLE m (sharpe REAL)")
+    db.execute("INSERT INTO m VALUES (?)", (sharpe,))
+    db.execute("INSERT INTO m VALUES (2.0)")
+    assert db.execute("SELECT COUNT(*) FROM m WHERE sharpe IS NOT NULL").fetchone()[0] == 1
+    assert db.execute("SELECT sharpe FROM m ORDER BY sharpe DESC").fetchall() == [(2.0,), (None,)]
+
+
+def test_a_path_that_ruins_in_its_first_period_still_reports_the_loss() -> None:
+    """The diagnostic library divides by a running maximum of zero and returns NaN.
+
+    `_safe` turned that into a drawdown of 0.0 beside `ruin=1`, which reads as a
+    bankruptcy that cost nothing.
+    """
+    out = compute_portfolio_metrics(np.array([-1.2, 0.1]), periods_per_year=12, uncertainty=False)
+    assert out["ruin"] == 1.0
+    assert out["max_drawdown"] == -1.0
+    assert out["total_return"] == -1.0
+    assert out["cagr"] == -1.0
+
+
+def test_a_single_period_wipeout_is_not_a_flat_series() -> None:
+    """The short branch reported zeros for every metric, ruin included."""
+    out = compute_portfolio_metrics(np.array([-1.2]), periods_per_year=12, uncertainty=False)
+    assert out["ruin"] == 1.0
+    assert out["total_return"] == -1.0
+    assert out["max_drawdown"] == -1.0
+    assert math.isnan(out["sharpe"])
 
 
 def test_a_bankrupt_path_reports_the_loss_it_actually_took() -> None:
@@ -47,7 +89,7 @@ def test_a_solvent_path_is_untouched() -> None:
     out = _metrics(_SOLVENT)
     assert out["ruin"] == 0.0
     assert out["ruin_period"] is None
-    assert isinstance(out["sharpe"], float)
+    assert not math.isnan(out["sharpe"])
     assert out["total_return"] > 0.0
 
 
@@ -129,6 +171,33 @@ def test_a_common_support_ranking_puts_a_bankrupt_candidate_last() -> None:
         periods_per_year=12,
     )
     assert ranking["backtest_hash"].to_list() == ["solvent", "ruined"]
+    assert ranking["sharpe"][1] is None
+
+
+def test_a_comparison_window_that_misses_the_ruin_does_not_make_it_rankable() -> None:
+    """The intersection can end before the period that wiped the account out.
+
+    A bankrupt book restricted to the months before it went bankrupt is not a
+    rankable strategy, and it would otherwise outrank a solvent candidate with a
+    negative Sharpe on the strength of the window the comparison happened to pick.
+    """
+    from case_studies.utils.strategy_analysis import rank_returns_on_common_support
+
+    early = pl.datetime_range(
+        pl.datetime(2009, 1, 1), pl.datetime(2009, 1, 1) + pl.duration(days=29), "1d", eager=True
+    )
+    full = pl.datetime_range(
+        pl.datetime(2009, 1, 1), pl.datetime(2009, 1, 1) + pl.duration(days=108), "1d", eager=True
+    )
+    ranking = rank_returns_on_common_support(
+        {
+            # Ruins at period 40, well past the 30-day intersection below.
+            "ruined": pl.DataFrame({"timestamp": full, "daily_return": _RUINED}),
+            "losing": pl.DataFrame({"timestamp": early, "daily_return": [-0.01] * 30}),
+        },
+        periods_per_year=12,
+    )
+    assert ranking["backtest_hash"].to_list() == ["losing", "ruined"]
     assert ranking["sharpe"][1] is None
 
 

--- a/tests/test_backtest_ruin_stop.py
+++ b/tests/test_backtest_ruin_stop.py
@@ -1,0 +1,109 @@
+"""An account that loses its capital stops there (ml4t/agent-workspace#920).
+
+Measured on the `us_firm_characteristics` registry, 2026-09-07: 46 registered
+backtests hold a period return below -100%, so their equity compounds through
+zero and `(1 + r)` inverts the sign of every later period. The worst of them,
+`e7708f4f376a`, reports sharpe 1.547 and cagr 0.687 against a total return of
+-202.3. The series below is that run's shape.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from case_studies.utils.backtest_runner import compute_portfolio_metrics
+
+# 109 monthly periods, one of them -103.42%, which is what e7708f4f376a held.
+_RUINED = np.array([0.03] * 40 + [-1.0342] + [0.03] * 68)
+_SOLVENT = np.array([0.03] * 40 + [-0.30] + [0.03] * 68)
+
+
+def _metrics(returns: np.ndarray) -> dict:
+    return compute_portfolio_metrics(returns, periods_per_year=12, uncertainty=False)
+
+
+def test_a_bankrupt_path_reports_no_sharpe() -> None:
+    """The defect: a path whose equity crossed zero was still ranked."""
+    out = _metrics(_RUINED)
+    assert out["ruin"] == 1.0
+    assert out["sharpe"] is None
+    assert out["sortino"] is None
+    assert out["calmar"] is None
+
+
+def test_a_bankrupt_path_reports_the_loss_it_actually_took() -> None:
+    """Total loss of capital, not the sign-flipped product of the raw series."""
+    out = _metrics(_RUINED)
+    assert out["total_return"] == -1.0
+    assert out["max_drawdown"] == -1.0
+    assert out["cagr"] == -1.0
+    assert out["ruin_period"] == 40.0
+
+
+def test_a_solvent_path_is_untouched() -> None:
+    """The control: the same shape with a survivable loss keeps every metric."""
+    out = _metrics(_SOLVENT)
+    assert out["ruin"] == 0.0
+    assert out["ruin_period"] is None
+    assert isinstance(out["sharpe"], float)
+    assert out["total_return"] > 0.0
+
+
+def test_the_stop_floors_equity_at_zero_and_holds_it_there() -> None:
+    from case_studies.utils.backtest_runner import apply_ruin_stop
+
+    stopped, index = apply_ruin_stop(_RUINED)
+    assert index == 40
+    assert stopped[39] == 0.03  # periods before ruin are untouched
+    assert stopped[40] == -1.0  # the engine models no creditor
+    assert (stopped[41:] == 0.0).all()  # no capital, no positions, no returns
+    assert float(np.cumprod(1.0 + stopped)[-1]) == 0.0
+
+
+def test_the_stop_is_idempotent() -> None:
+    from case_studies.utils.backtest_runner import apply_ruin_stop
+
+    once, first = apply_ruin_stop(_RUINED)
+    twice, second = apply_ruin_stop(once)
+    assert first == second == 40
+    assert (once == twice).all()
+
+
+def test_a_solvent_series_passes_through_the_stop_unchanged() -> None:
+    from case_studies.utils.backtest_runner import apply_ruin_stop
+
+    stopped, index = apply_ruin_stop(_SOLVENT)
+    assert index is None
+    assert (stopped == _SOLVENT).all()
+
+
+def test_the_registered_return_path_stops_where_the_account_does() -> None:
+    from case_studies.utils.backtest_runner import stop_returns_at_ruin
+
+    frame = pl.DataFrame(
+        {
+            "timestamp": pl.date_range(
+                pl.date(2009, 1, 1), pl.date(2009, 1, 1) + pl.duration(days=108), eager=True
+            ),
+            "daily_return": _RUINED,
+        }
+    )
+    stopped, index = stop_returns_at_ruin(frame)
+    assert index == 40
+    assert stopped.height == frame.height
+    assert stopped["timestamp"].to_list() == frame["timestamp"].to_list()
+    assert stopped["daily_return"].to_list()[40:] == [-1.0] + [0.0] * 68
+
+
+def test_a_loss_that_the_book_survives_is_not_ruin() -> None:
+    """A period return below -100% is not by itself ruin: prior gains absorb it."""
+    from case_studies.utils.backtest_runner import apply_ruin_stop
+
+    # Equity reaches 4.0 before a -120% period, which leaves it at -0.8: still ruin.
+    through_zero, index = apply_ruin_stop(np.array([1.0, 1.0, -1.2, 0.1]))
+    assert index == 2
+    # A -60% period from equity 4.0 leaves 1.6, which is a drawdown and not ruin.
+    survived, no_index = apply_ruin_stop(np.array([1.0, 1.0, -0.6, 0.1]))
+    assert no_index is None
+    assert (survived == np.array([1.0, 1.0, -0.6, 0.1])).all()

--- a/tests/test_backtest_ruin_stop.py
+++ b/tests/test_backtest_ruin_stop.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import numpy as np
 import polars as pl
+import pytest
 
 from case_studies.utils.backtest_runner import compute_portfolio_metrics
 
@@ -107,3 +108,60 @@ def test_a_loss_that_the_book_survives_is_not_ruin() -> None:
     survived, no_index = apply_ruin_stop(np.array([1.0, 1.0, -0.6, 0.1]))
     assert no_index is None
     assert (survived == np.array([1.0, 1.0, -0.6, 0.1])).all()
+
+
+def test_a_common_support_ranking_puts_a_bankrupt_candidate_last() -> None:
+    """A null Sharpe must not sort to the top of a descending polars sort.
+
+    SQL puts NULLs last on `ORDER BY ... DESC`; polars puts them first unless
+    told otherwise, so the ranking that reads these metrics has to say so.
+    """
+    from case_studies.utils.strategy_analysis import rank_returns_on_common_support
+
+    timestamps = pl.datetime_range(
+        pl.datetime(2009, 1, 1), pl.datetime(2009, 1, 1) + pl.duration(days=108), "1d", eager=True
+    )
+    ranking = rank_returns_on_common_support(
+        {
+            "ruined": pl.DataFrame({"timestamp": timestamps, "daily_return": _RUINED}),
+            "solvent": pl.DataFrame({"timestamp": timestamps, "daily_return": _SOLVENT}),
+        },
+        periods_per_year=12,
+    )
+    assert ranking["backtest_hash"].to_list() == ["solvent", "ruined"]
+    assert ranking["sharpe"][1] is None
+
+
+def test_the_plumbing_test_refuses_a_bankrupt_random_run(monkeypatch) -> None:
+    """No Sharpe to compare against the tolerance, so it says why."""
+    from types import SimpleNamespace
+
+    import case_studies.utils.backtest_runner as br
+
+    spec = {
+        "version": 2,
+        "strategy": {"rebalance": {"mode": "vectorized"}},
+        "backtest_config": {},
+    }
+    predictions = pl.DataFrame(
+        {
+            "timestamp": [pl.datetime(2024, 1, 1)] * 2,
+            "symbol": ["A", "B"],
+            "y_score": [0.8, 0.2],
+            "y_true": [0.1, -0.1],
+        }
+    )
+    monkeypatch.setattr(br, "get_backtest_config", lambda _: object())
+    monkeypatch.setattr(br, "ensure_backtest_spec", lambda *args, **kwargs: args[2])
+    monkeypatch.setattr(
+        br,
+        "run_backtest",
+        lambda *a, **k: SimpleNamespace(
+            metrics={"sharpe": None, "ruin": 1.0, "ruin_period": 40.0, "n_periods": 109}
+        ),
+    )
+
+    with pytest.raises(ValueError, match="went bankrupt at period 40.0 of 109"):
+        br.run_plumbing_test(
+            "demo", pl.DataFrame(), spec, predictions=predictions, label="fwd_ret_1m", seed=7
+        )

--- a/tests/test_backtest_ruin_stop.py
+++ b/tests/test_backtest_ruin_stop.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import math
 import sqlite3
+from datetime import datetime
+from types import SimpleNamespace
 
 import numpy as np
 import polars as pl
@@ -234,3 +236,98 @@ def test_the_plumbing_test_refuses_a_bankrupt_random_run(monkeypatch) -> None:
         br.run_plumbing_test(
             "demo", pl.DataFrame(), spec, predictions=predictions, label="fwd_ret_1m", seed=7
         )
+
+
+def test_a_bankrupt_run_served_from_the_cache_still_formats(monkeypatch, tmp_path) -> None:
+    """The skip-if-complete branch reads metrics back out of SQLite, where NaN is NULL.
+
+    So a cached bankrupt run handed `None` to the same `f"{sharpe:.3f}"` lines the
+    NaN exists to protect, and failed where a freshly computed one printed.
+    """
+    import case_studies.utils.backtest_runner as br
+    import case_studies.utils.conformal as conformal
+    import case_studies.utils.registry.store as store
+
+    case_dir = tmp_path / "cs"
+    run_log = case_dir / "run_log"
+    backtest_dir = run_log / "backtest" / "cachedhash"
+    backtest_dir.mkdir(parents=True)
+    pl.DataFrame({"timestamp": [datetime(2009, 1, 1)], "daily_return": [0.0]}).write_parquet(
+        backtest_dir / "daily_returns.parquet"
+    )
+    with sqlite3.connect(run_log / "registry.db") as db:
+        db.execute(
+            "CREATE TABLE backtest_metrics (backtest_hash TEXT PRIMARY KEY, computed_at TEXT, "
+            "sharpe REAL, total_return REAL, ruin REAL)"
+        )
+        # What the engine wrote: NaN in, NULL out.
+        db.execute(
+            "INSERT INTO backtest_metrics VALUES ('cachedhash', 'now', ?, -1.0, 1.0)",
+            (float("nan"),),
+        )
+    assert (
+        sqlite3.connect(run_log / "registry.db")
+        .execute("SELECT sharpe FROM backtest_metrics")
+        .fetchone()[0]
+        is None
+    )
+
+    monkeypatch.setattr(br, "get_backtest_config", lambda _: object())
+    monkeypatch.setattr(br, "ensure_backtest_spec", lambda *args, **kw: args[2])
+    monkeypatch.setattr(conformal, "ensure_conformal_calibration_identity", lambda spec: spec)
+    monkeypatch.setattr(br, "substitute_continuous_return_for_classification", lambda p, *_: p)
+    monkeypatch.setattr(store, "_case_dir", lambda _cs: case_dir)
+    monkeypatch.setattr(
+        br,
+        "_refuse_an_allocation_that_produced_no_target",
+        lambda *a, **k: None,
+        raising=False,
+    )
+
+    from case_studies.utils.registry import completeness
+
+    monkeypatch.setattr(
+        completeness,
+        "backtest_run_status",
+        lambda *a, **k: SimpleNamespace(
+            complete=True, backtest_hash="cachedhash", summary=lambda: "cached"
+        ),
+    )
+    import case_studies.utils.registry as registry
+
+    monkeypatch.setattr(
+        registry,
+        "backtest_run_status",
+        lambda *a, **k: SimpleNamespace(
+            complete=True, backtest_hash="cachedhash", summary=lambda: "cached"
+        ),
+    )
+    monkeypatch.setattr(registry, "backtest_dir", lambda _cs, h: backtest_dir)
+
+    spec = {
+        "version": 2,
+        "strategy": {
+            "signal": {"method": "equal_weight_top_k", "top_k": 1, "long_short": False},
+            "rebalance": {"mode": "vectorized", "cadence": "daily", "step": 1},
+        },
+        "backtest_config": {"cash": {"initial": 1.0}, "account": {}},
+    }
+    result = br.run_backtest(
+        "us_firm_characteristics",
+        "pred1",
+        spec,
+        prices=pl.DataFrame({"timestamp": [datetime(2024, 1, 1)], "symbol": ["A"], "close": [1.0]}),
+        predictions=pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1)],
+                "symbol": ["A"],
+                "y_score": [1.0],
+                "y_true": [0.1],
+            }
+        ),
+        register=True,
+    )
+    assert result.metrics["ruin"] == 1.0
+    assert math.isnan(result.metrics["sharpe"])
+    # The line `12_portfolio_management.py:245` runs on every sweep result.
+    assert f"Sharpe={result.metrics.get('sharpe', 0):.3f}" == "Sharpe=nan"

--- a/tests/test_best_reports_concentration.py
+++ b/tests/test_best_reports_concentration.py
@@ -1,0 +1,136 @@
+"""The top table names the concentration each row was run at.
+
+ml4t/agent-workspace#910. Every entry scheme in a baseline sweep uses the same
+method, `equal_weight_top_k`, and varies only `top_k`. `best()` returned
+`signal_method` and not `top_k`, so the ten-row table every case study's backtest
+notebook prints read as one strategy repeated at different Sharpes - it hid
+exactly what the sweep was run to measure. `concentration_curve()` looked like
+the answer and was not: it hardcoded the allocation stage, so at the signal
+stage, where the baseline sweep lives, it returned an empty frame.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from case_studies.utils.backtest_explorer import BacktestExplorer
+
+# (prediction_hash, stage, top_k, sharpe)
+ROWS = [
+    ("pred_a", "signal", 5, 1.80),
+    ("pred_a", "signal", 10, 1.68),
+    ("pred_a", "signal", 20, 1.64),
+    ("pred_b", "allocation", 5, 1.20),
+]
+
+
+def _build_registry(case_dir) -> None:
+    run_log = case_dir / "run_log"
+    run_log.mkdir(parents=True)
+    with sqlite3.connect(run_log / "registry.db") as db:
+        db.executescript(
+            """
+            CREATE TABLE training_runs (
+                training_hash TEXT PRIMARY KEY, family TEXT, config_name TEXT, label TEXT
+            );
+            CREATE TABLE prediction_sets (
+                prediction_hash TEXT PRIMARY KEY, training_hash TEXT, split TEXT,
+                checkpoint_value REAL
+            );
+            CREATE TABLE prediction_metrics (
+                prediction_hash TEXT PRIMARY KEY, ic_mean REAL, ic_mean_daily REAL,
+                ic_ci_lo REAL, ic_ci_hi REAL, ic_n_days REAL
+            );
+            CREATE TABLE fold_metrics (prediction_hash TEXT, ic REAL);
+            CREATE TABLE backtest_runs (
+                backtest_hash TEXT PRIMARY KEY, prediction_hash TEXT, spec_json TEXT, stage TEXT
+            );
+            CREATE TABLE backtest_metrics (
+                backtest_hash TEXT PRIMARY KEY, sharpe REAL, cagr REAL, max_drawdown REAL,
+                total_return REAL, volatility REAL, num_trades REAL
+            );
+            CREATE TABLE backtest_fold_metrics (
+                backtest_hash TEXT, fold_id INTEGER, sharpe REAL
+            );
+            """
+        )
+        for prediction_hash in {row[0] for row in ROWS}:
+            training_hash = f"train_{prediction_hash}"
+            db.execute(
+                "INSERT INTO training_runs VALUES (?, 'gbm', 'leaves_7_mae', 'fwd_ret_5d')",
+                (training_hash,),
+            )
+            db.execute(
+                "INSERT INTO prediction_sets VALUES (?, ?, 'validation', 0)",
+                (prediction_hash, training_hash),
+            )
+            db.execute(
+                "INSERT INTO prediction_metrics VALUES (?, 0.1, 0.1, 0.0, 0.2, 4.0)",
+                (prediction_hash,),
+            )
+        for prediction_hash, stage, top_k, sharpe in ROWS:
+            backtest_hash = f"bt_{prediction_hash}_{stage}_{top_k}"
+            spec = {
+                "version": 2,
+                "strategy": {
+                    "signal": {"method": "equal_weight_top_k", "top_k": top_k},
+                    "allocation": {"method": "equal_weight"},
+                },
+                "backtest_config": {},
+            }
+            db.execute(
+                "INSERT INTO backtest_runs VALUES (?, ?, ?, ?)",
+                (backtest_hash, prediction_hash, json.dumps(spec), stage),
+            )
+            db.execute(
+                "INSERT INTO backtest_metrics VALUES (?, ?, 0.1, -0.2, 0.2, 0.1, 100)",
+                (backtest_hash, sharpe),
+            )
+
+
+@pytest.fixture
+def explorer(tmp_path) -> BacktestExplorer:
+    case_dir = tmp_path / "cs"
+    _build_registry(case_dir)
+    return BacktestExplorer("us_firm_characteristics", case_dir=case_dir)
+
+
+def test_the_top_table_names_the_concentration(explorer) -> None:
+    """The defect: three rows of one method, and nothing saying which is which."""
+    best = explorer.best(stage="signal")
+    assert best["top_k"].to_list() == [5, 10, 20]
+    assert best["signal_method"].unique().to_list() == ["equal_weight_top_k"]
+
+
+def test_the_column_sits_beside_the_method_it_disambiguates(explorer) -> None:
+    columns = explorer.best(stage="signal").columns
+    assert columns.index("top_k") == columns.index("signal_method") + 1
+
+
+def test_the_concentration_curve_reads_the_stage_the_sweep_ran_at(explorer) -> None:
+    curve = explorer.concentration_curve("pred_a", stage="signal")
+    assert curve["top_k"].to_list() == [5, 10, 20]
+    assert curve["sharpe"].to_list() == [1.80, 1.68, 1.64]
+
+
+def test_the_default_stage_is_unchanged(explorer) -> None:
+    """The control: a caller reading the allocation stage still reads it."""
+    curve = explorer.concentration_curve("pred_b")
+    assert curve["top_k"].to_list() == [5]
+
+
+def test_asking_the_wrong_stage_says_where_the_rows_are(explorer) -> None:
+    """An empty frame cannot say whether the sweep was never run or run elsewhere."""
+    with pytest.raises(ValueError) as excinfo:
+        explorer.concentration_curve("pred_a")
+    message = str(excinfo.value)
+    assert "signal: 3" in message
+    assert "stage='signal'" in message
+
+
+def test_a_prediction_with_no_backtests_returns_empty(explorer) -> None:
+    """Nothing to point at, so nothing to raise about."""
+    assert explorer.concentration_curve("pred_missing", stage="signal").is_empty()

--- a/tests/test_compare_allocators_ruin.py
+++ b/tests/test_compare_allocators_ruin.py
@@ -1,0 +1,142 @@
+"""``compare_allocators`` counts the bankrupt runs instead of dropping them.
+
+ml4t/agent-workspace#920, item 2. Measured on `us_firm_characteristics`: five of
+twenty-four allocation runs had crossed zero equity, and the table averaged them in
+with the rest, reporting `avg_max_dd` of -5.74 and -8.15 where every solvent member
+was between -0.10 and -0.41. The engine now stops those paths and registers no
+Sharpe for them, so the fix has to keep them visible rather than let the null drop
+them out of the population.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from case_studies.utils.backtest_explorer import BacktestExplorer
+
+# (prediction_hash, allocator, sharpe, max_drawdown, ruin)
+ROWS = [
+    ("mvo_a", "mean_variance", 1.0, -0.20, 0.0),
+    ("mvo_b", "mean_variance", 0.5, -0.30, 0.0),
+    # Stopped at ruin by the engine: no Sharpe to rank, drawdown floored at -1.0.
+    ("mvo_ruined", "mean_variance", None, -1.00, 1.0),
+    # Every run of this allocator went bankrupt. It must still appear.
+    ("sw_ruined_1", "score_weighted", None, -1.00, 1.0),
+    ("sw_ruined_2", "score_weighted", None, -1.00, 1.0),
+]
+
+
+def _build_registry(case_dir) -> None:
+    run_log = case_dir / "run_log"
+    run_log.mkdir(parents=True)
+    with sqlite3.connect(run_log / "registry.db") as db:
+        db.executescript(
+            """
+            CREATE TABLE training_runs (
+                training_hash TEXT PRIMARY KEY,
+                family TEXT,
+                config_name TEXT,
+                label TEXT
+            );
+            CREATE TABLE prediction_sets (
+                prediction_hash TEXT PRIMARY KEY,
+                training_hash TEXT,
+                split TEXT,
+                checkpoint_value REAL
+            );
+            CREATE TABLE prediction_metrics (
+                prediction_hash TEXT PRIMARY KEY,
+                ic_mean REAL,
+                ic_mean_daily REAL,
+                ic_ci_lo REAL,
+                ic_ci_hi REAL,
+                ic_n_days REAL
+            );
+            CREATE TABLE fold_metrics (prediction_hash TEXT, ic REAL);
+            CREATE TABLE backtest_runs (
+                backtest_hash TEXT PRIMARY KEY,
+                prediction_hash TEXT,
+                spec_json TEXT,
+                stage TEXT
+            );
+            CREATE TABLE backtest_metrics (
+                backtest_hash TEXT PRIMARY KEY,
+                sharpe REAL,
+                cagr REAL,
+                max_drawdown REAL,
+                total_return REAL,
+                volatility REAL,
+                num_trades REAL,
+                ruin REAL
+            );
+            CREATE TABLE backtest_fold_metrics (
+                backtest_hash TEXT,
+                fold_id INTEGER,
+                sharpe REAL
+            );
+            """
+        )
+        for prediction_hash, allocator, sharpe, max_drawdown, ruin in ROWS:
+            training_hash = f"train_{prediction_hash}"
+            db.execute(
+                "INSERT INTO training_runs VALUES (?, 'gbm', ?, 'fwd_ret_5d')",
+                (training_hash, prediction_hash),
+            )
+            db.execute(
+                "INSERT INTO prediction_sets VALUES (?, ?, 'validation', 0)",
+                (prediction_hash, training_hash),
+            )
+            db.execute(
+                "INSERT INTO prediction_metrics VALUES (?, 0.1, 0.1, 0.0, 0.2, 4.0)",
+                (prediction_hash,),
+            )
+            db.execute(
+                "INSERT INTO backtest_runs VALUES (?, ?, ?, 'allocation')",
+                (
+                    f"bt_{prediction_hash}",
+                    prediction_hash,
+                    json.dumps({"allocation": {"method": allocator}}),
+                ),
+            )
+            db.execute(
+                "INSERT INTO backtest_metrics VALUES (?, ?, 0.1, ?, 0.2, 0.1, 1, ?)",
+                (f"bt_{prediction_hash}", sharpe, max_drawdown, ruin),
+            )
+
+
+def _compare(tmp_path):
+    case_dir = tmp_path / "cs"
+    _build_registry(case_dir)
+    explorer = BacktestExplorer("us_firm_characteristics", case_dir=case_dir)
+    return {row["allocator"]: row for row in explorer.compare_allocators().iter_rows(named=True)}
+
+
+def test_an_allocator_whose_every_run_went_bankrupt_stays_on_the_table(tmp_path) -> None:
+    rows = _compare(tmp_path)
+    assert set(rows) == {"mean_variance", "score_weighted"}
+    assert rows["score_weighted"]["n"] == 0
+    assert rows["score_weighted"]["ruined"] == 2
+    assert rows["score_weighted"]["avg_sharpe"] is None
+
+
+def test_the_reported_statistics_describe_the_solvent_runs(tmp_path) -> None:
+    rows = _compare(tmp_path)
+    mvo = rows["mean_variance"]
+    assert mvo["n"] == 2
+    assert mvo["ruined"] == 1
+    assert mvo["avg_sharpe"] == 0.75
+    # -0.20 and -0.30, not dragged toward -1.0 by the run that ended.
+    assert mvo["avg_max_dd"] == -0.25
+
+
+def test_a_registry_without_the_ruin_column_still_reads_the_drawdown(tmp_path) -> None:
+    """An older registry carries the evidence only in `max_drawdown`."""
+    case_dir = tmp_path / "cs"
+    _build_registry(case_dir)
+    with sqlite3.connect(case_dir / "run_log" / "registry.db") as db:
+        db.execute("ALTER TABLE backtest_metrics DROP COLUMN ruin")
+    explorer = BacktestExplorer("us_firm_characteristics", case_dir=case_dir)
+    rows = {r["allocator"]: r for r in explorer.compare_allocators().iter_rows(named=True)}
+    assert rows["mean_variance"]["ruined"] == 1
+    assert rows["score_weighted"]["ruined"] == 2

--- a/tests/test_entry_scheme_feasibility_cross_section.py
+++ b/tests/test_entry_scheme_feasibility_cross_section.py
@@ -123,3 +123,44 @@ def test_both_halves_of_the_grid_report_both_numbers(tmp_path, monkeypatch) -> N
         get_top_k_values_for(case_study, "fwd_ret_5d", 24, long_short=False)
     assert "price panel 24" in str(excinfo.value)
     assert "ranked cross-section 3" in str(excinfo.value)
+
+
+def test_disagreeing_prediction_sets_leave_the_callers_number_standing(
+    tmp_path, monkeypatch
+) -> None:
+    """The resolver samples the registry; the caller sweeps a chosen population.
+
+    Those are different questions. A width taken from an unrelated set could
+    remove a concentration that is feasible for the sets actually being swept, so
+    the resolver only speaks when its sample is unanimous.
+    """
+    from case_studies.utils.sweep_config import ranked_cross_section_width
+
+    case_study = _case_study(tmp_path, monkeypatch, n_prediction_symbols=6)
+    run_log = tmp_path / case_study / "run_log"
+    (run_log / "predictions" / "pred2").mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "timestamp": [1] * 40,
+            "symbol": [f"S{i}" for i in range(40)],
+            "y_score": [0.0] * 40,
+        }
+    ).write_parquet(run_log / "predictions" / "pred2" / "predictions.parquet")
+    with sqlite3.connect(run_log / "registry.db") as db:
+        db.execute("INSERT INTO training_runs VALUES ('t2', 'gbm', 'other', 'fwd_ret_5d')")
+        db.execute("INSERT INTO prediction_sets VALUES ('pred2', 't2', 'validation')")
+
+    with pytest.warns(UserWarning, match="disagree on the ranked cross-section"):
+        assert ranked_cross_section_width(case_study, "fwd_ret_5d") is None
+    with pytest.warns(UserWarning):
+        schemes = get_entry_schemes_for(case_study, "fwd_ret_5d", n_assets=24, long_short=False)
+    assert [s["top_k"] for s in schemes] == [3, 5, 10]
+
+
+def test_a_caller_that_knows_its_population_is_believed(tmp_path, monkeypatch) -> None:
+    """`ranked_width` skips the registry sample entirely."""
+    case_study = _case_study(tmp_path, monkeypatch, n_prediction_symbols=100)
+    schemes = get_entry_schemes_for(
+        case_study, "fwd_ret_5d", n_assets=24, long_short=False, ranked_width=6
+    )
+    assert [s["top_k"] for s in schemes] == [3, 5]

--- a/tests/test_entry_scheme_feasibility_cross_section.py
+++ b/tests/test_entry_scheme_feasibility_cross_section.py
@@ -1,0 +1,125 @@
+"""The entry-scheme guard measures against the set the signal ranks.
+
+ml4t/agent-workspace#1003. ``get_entry_schemes_for`` drops any declared ``top_k``
+at or above the traded universe, because holding k of k is the equal-weight
+benchmark rather than a ranked selection. That rule is right; it was applied to
+the price panel, which is not the set the ranking runs over. When the two differ
+the check passes and every backtest in the sweep records ``num_trades = 0`` -
+measured in ml4t/agent-workspace#989 as twelve backtests with a Sharpe and no
+trades, and four notebooks failing several stages downstream of the cause.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import polars as pl
+import pytest
+import yaml
+
+from case_studies.utils.sweep_config import get_entry_schemes_for, get_top_k_values_for
+
+SETUP = {
+    "backtest": {
+        "sweep": {
+            "top_k_grid": {"fwd_ret_5d": [3, 5, 10]},
+        }
+    }
+}
+
+
+def _case_study(tmp_path: Path, monkeypatch, *, n_prediction_symbols: int) -> str:
+    """A case study whose price panel is 24 wide and whose predictions are not."""
+    case_study = "fixture_cs"
+    case_dir = tmp_path / case_study
+    (case_dir / "config").mkdir(parents=True)
+    (case_dir / "config" / "setup.yaml").write_text(yaml.safe_dump(SETUP))
+
+    run_log = case_dir / "run_log"
+    (run_log / "predictions" / "pred1").mkdir(parents=True)
+    pl.DataFrame(
+        {
+            "timestamp": [1] * n_prediction_symbols,
+            "symbol": [f"S{i}" for i in range(n_prediction_symbols)],
+            "y_score": [0.0] * n_prediction_symbols,
+        }
+    ).write_parquet(run_log / "predictions" / "pred1" / "predictions.parquet")
+
+    with sqlite3.connect(run_log / "registry.db") as db:
+        db.executescript(
+            """
+            CREATE TABLE training_runs (
+                training_hash TEXT PRIMARY KEY, family TEXT, config_name TEXT, label TEXT
+            );
+            CREATE TABLE prediction_sets (
+                prediction_hash TEXT PRIMARY KEY, training_hash TEXT, split TEXT
+            );
+            """
+        )
+        db.execute("INSERT INTO training_runs VALUES ('t1', 'gbm', 'default', 'fwd_ret_5d')")
+        db.execute("INSERT INTO prediction_sets VALUES ('pred1', 't1', 'validation')")
+
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    return case_study
+
+
+def test_the_ranked_width_is_read_from_the_predictions(tmp_path, monkeypatch) -> None:
+    from case_studies.utils.sweep_config import ranked_cross_section_width
+
+    case_study = _case_study(tmp_path, monkeypatch, n_prediction_symbols=6)
+    assert ranked_cross_section_width(case_study, "fwd_ret_5d") == 6
+
+
+def test_a_concentration_wider_than_the_cross_section_is_dropped(tmp_path, monkeypatch) -> None:
+    """The defect: k=10 survived because the price panel was 24 wide."""
+    case_study = _case_study(tmp_path, monkeypatch, n_prediction_symbols=6)
+    schemes = get_entry_schemes_for(case_study, "fwd_ret_5d", n_assets=24, long_short=False)
+    assert [s["top_k"] for s in schemes] == [3, 5]
+
+
+def test_the_guard_fires_when_the_cross_section_leaves_no_scheme(tmp_path, monkeypatch) -> None:
+    """The failure #989 recorded: every backtest runs, none of them trades."""
+    case_study = _case_study(tmp_path, monkeypatch, n_prediction_symbols=3)
+    with pytest.raises(ValueError) as excinfo:
+        get_entry_schemes_for(case_study, "fwd_ret_5d", n_assets=24, long_short=False)
+    message = str(excinfo.value)
+    # Both numbers, so the message cannot read the same wrong one the check did.
+    assert "3 symbols" in message
+    assert "24" in message
+    assert "num_trades" in message
+
+
+def test_the_price_panel_still_bounds_the_grid(tmp_path, monkeypatch) -> None:
+    """The control: a narrow panel and a wide cross-section keeps the old rule."""
+    case_study = _case_study(tmp_path, monkeypatch, n_prediction_symbols=100)
+    schemes = get_entry_schemes_for(case_study, "fwd_ret_5d", n_assets=6, long_short=False)
+    assert [s["top_k"] for s in schemes] == [3, 5]
+
+
+def test_a_case_study_with_no_registered_predictions_keeps_the_panel(tmp_path, monkeypatch) -> None:
+    """Nothing to read yet, so the caller's number stands and nothing is dropped."""
+    case_study = "fixture_cs"
+    case_dir = tmp_path / case_study
+    (case_dir / "config").mkdir(parents=True)
+    (case_dir / "config" / "setup.yaml").write_text(yaml.safe_dump(SETUP))
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    from case_studies.utils.sweep_config import ranked_cross_section_width
+
+    assert ranked_cross_section_width(case_study, "fwd_ret_5d") is None
+    schemes = get_entry_schemes_for(case_study, "fwd_ret_5d", n_assets=24, long_short=False)
+    assert [s["top_k"] for s in schemes] == [3, 5, 10]
+
+
+def test_the_plumbing_test_grid_filters_against_the_same_width(tmp_path, monkeypatch) -> None:
+    """`get_top_k_values_for` is the other half of the same grid and must agree."""
+    case_study = _case_study(tmp_path, monkeypatch, n_prediction_symbols=6)
+    assert get_top_k_values_for(case_study, "fwd_ret_5d", 24, long_short=False) == [3, 5]
+
+
+def test_both_halves_of_the_grid_report_both_numbers(tmp_path, monkeypatch) -> None:
+    case_study = _case_study(tmp_path, monkeypatch, n_prediction_symbols=3)
+    with pytest.raises(ValueError) as excinfo:
+        get_top_k_values_for(case_study, "fwd_ret_5d", 24, long_short=False)
+    assert "price panel 24" in str(excinfo.value)
+    assert "ranked cross-section 3" in str(excinfo.value)

--- a/tests/test_fold_metrics_after_ruin.py
+++ b/tests/test_fold_metrics_after_ruin.py
@@ -1,0 +1,84 @@
+"""A fold that opens after the account is gone reports the ruin, not zeros.
+
+Second half of ml4t/agent-workspace#920. The engine stops a bankrupt path at
+-100% and zeroes every later period, so a fold sliced out of the tail is all
+zeros - and a slice of zeros is indistinguishable from a fold in which the
+strategy simply did not trade. `compute_portfolio_metrics` on it reported
+`ruin=0`, a Sharpe of 0 and no drawdown: a clean row for a period in which the
+book did not exist.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date
+
+import polars as pl
+import pytest
+
+from case_studies.utils.registry.metrics import compute_backtest_fold_metrics
+
+# Ruin lands on 2024-02-10, inside fold 1. Fold 2 opens after it.
+FOLDS = [
+    {"fold": 1, "val_start": date(2024, 2, 1), "val_end": date(2024, 2, 20)},
+    {"fold": 2, "val_start": date(2024, 2, 21), "val_end": date(2024, 3, 11)},
+]
+
+
+@pytest.fixture
+def stopped_returns() -> pl.DataFrame:
+    from case_studies.utils.backtest_runner import apply_ruin_stop
+
+    raw = [0.01] * 9 + [-1.2] + [0.01] * 30
+    stopped, index = apply_ruin_stop(raw)
+    assert index == 9
+    return pl.DataFrame(
+        {
+            "timestamp": pl.date_range(
+                date(2024, 2, 1), date(2024, 2, 1) + pl.duration(days=39), "1d", eager=True
+            ),
+            "daily_return": stopped,
+        }
+    )
+
+
+def _fold_metrics(monkeypatch, frame: pl.DataFrame) -> dict:
+    import case_studies.utils.registry.metrics as metrics_module
+
+    monkeypatch.setattr(metrics_module, "fold_boundaries", lambda *_a, **_k: FOLDS, raising=False)
+    import case_studies.utils.cv_window as cv_window
+
+    monkeypatch.setattr(cv_window, "fold_boundaries", lambda *_a, **_k: FOLDS)
+    return compute_backtest_fold_metrics(frame, "demo", label="fwd_ret_1d", periods_per_year=252)
+
+
+def test_the_fold_holding_the_ruin_finds_it_for_itself(monkeypatch, stopped_returns) -> None:
+    folds = _fold_metrics(monkeypatch, stopped_returns)
+    assert folds[1]["ruin"] == 1.0
+    assert folds[1]["max_drawdown"] == -1.0
+    assert math.isnan(folds[1]["sharpe"])
+
+
+def test_a_fold_after_the_ruin_is_told(monkeypatch, stopped_returns) -> None:
+    """The defect: all zeros read as a quiet fold with a Sharpe of nothing."""
+    folds = _fold_metrics(monkeypatch, stopped_returns)
+    assert folds[2]["ruin"] == 1.0
+    assert math.isnan(folds[2]["sharpe"])
+    # The whole path's index, so the fold rows and the overall row agree on where.
+    assert folds[2]["ruin_period"] == 9.0
+
+
+def test_a_solvent_path_leaves_every_fold_alone(monkeypatch) -> None:
+    """The control: no ruin anywhere, so no fold is marked."""
+    frame = pl.DataFrame(
+        {
+            "timestamp": pl.date_range(
+                date(2024, 2, 1), date(2024, 2, 1) + pl.duration(days=39), "1d", eager=True
+            ),
+            "daily_return": [0.01] * 40,
+        }
+    )
+    folds = _fold_metrics(monkeypatch, frame)
+    assert folds[1]["ruin"] == 0.0
+    assert folds[2]["ruin"] == 0.0
+    assert not math.isnan(folds[1]["sharpe"])

--- a/tests/test_max_symbols_reduces_a_vectorized_backtest.py
+++ b/tests/test_max_symbols_reduces_a_vectorized_backtest.py
@@ -178,3 +178,46 @@ def test_the_htm_option_path_keeps_its_own_universe(monkeypatch) -> None:
         register=False,
     )
     assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]
+
+
+def test_the_notebooks_blanket_warning_filter_does_not_hide_it(capsys) -> None:
+    """Eleven backtest notebooks ignore warnings at import; the reader still sees this.
+
+    `us_firm_characteristics/11_backtest.py:62` and ten siblings call
+    `warnings.filterwarnings("ignore")` before the first backtest runs, so a
+    diagnostic that only warns reaches nobody who reads the executed notebook.
+    This asserts the message survives that filter, which is the condition the
+    notebook actually runs under - `pytest.warns` in the tests above installs its
+    own filter and cannot see the difference.
+    """
+    import warnings as _warnings
+
+    from case_studies.utils.backtest_runner import warn_if_the_panel_does_not_bound_the_universe
+
+    with _warnings.catch_warnings():
+        _warnings.filterwarnings("ignore")
+        warn_if_the_panel_does_not_bound_the_universe(
+            _predictions(), _prices(["A", "B"]), case_study="filtered", label="fwd_ret_1m"
+        )
+    assert "cannot price" in capsys.readouterr().out
+
+
+def test_a_sweep_over_one_prediction_set_says_it_once(capsys) -> None:
+    """A twelve-scheme sweep calls `run_backtest` twelve times over one panel.
+
+    Each call sees the same panel and the same predictions, so twelve copies of
+    one diagnostic would bury the cell output it is printed into. The case study
+    name here is distinct from every other test in this file, so what is counted
+    is this loop and not a report some earlier test already made.
+    """
+    import warnings as _warnings
+
+    from case_studies.utils.backtest_runner import warn_if_the_panel_does_not_bound_the_universe
+
+    with _warnings.catch_warnings():
+        _warnings.filterwarnings("ignore")
+        for _ in range(12):
+            warn_if_the_panel_does_not_bound_the_universe(
+                _predictions(), _prices(["A", "B"]), case_study="swept", label="fwd_ret_1m"
+            )
+    assert capsys.readouterr().out.count("cannot price") == 1

--- a/tests/test_max_symbols_reduces_a_vectorized_backtest.py
+++ b/tests/test_max_symbols_reduces_a_vectorized_backtest.py
@@ -74,7 +74,7 @@ def _run(monkeypatch, prices, **kwargs) -> dict:
 
     monkeypatch.setattr(br, "_run_vectorized", fake_vectorized)
 
-    br.run_backtest(
+    result = br.run_backtest(
         "us_firm_characteristics",
         "pred1",
         SPEC,
@@ -83,6 +83,7 @@ def _run(monkeypatch, prices, **kwargs) -> dict:
         register=False,
         **kwargs,
     )
+    captured["strategy_spec"] = result.strategy_spec
     return captured
 
 
@@ -180,3 +181,55 @@ def test_the_htm_option_path_keeps_its_own_universe(monkeypatch) -> None:
         register=False,
     )
     assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]
+
+
+def test_a_reduced_universe_gets_its_own_identity(monkeypatch) -> None:
+    """A reduced run is a different portfolio, so it must hash as one.
+
+    Without this the skip-if-complete check inside `run_backtest`, and the same
+    check `11_backtest` runs before submitting a scheme, both hash prediction plus
+    strategy alone - and a preview at reduced MAX_SYMBOLS would be served the
+    full-universe result or register its numbers under the full run's hash.
+    """
+    from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+    reduced = _run(monkeypatch, _prices(["A", "C"]))["strategy_spec"]
+    full = _run(monkeypatch, _prices(["A", "B", "C", "D"]))["strategy_spec"]
+    assert reduced["strategy"]["signal"]["universe_n_symbols"] == 2
+    # Absent, not equal to the full width: stamping it unconditionally would
+    # re-key every backtest already registered.
+    assert "universe_n_symbols" not in full["strategy"]["signal"]
+    assert backtest_hash_from_parts("pred1", reduced) != backtest_hash_from_parts("pred1", full)
+
+
+def test_a_locked_specification_refuses_a_narrowed_universe(monkeypatch) -> None:
+    """The holdout producer hashed its spec already; it cannot be narrowed under it."""
+    import case_studies.utils.backtest_runner as br
+
+    spec = {
+        "version": 2,
+        "strategy": {
+            "signal": {"method": "equal_weight_top_k", "top_k": 2, "long_short": False},
+            "rebalance": {"mode": "vectorized", "cadence": "daily", "step": 1},
+        },
+        "backtest_config": {
+            "cash": {"initial": 100_000.0},
+            "commission": {"model": "percentage", "rate": 0.0},
+            "slippage": {"model": "percentage", "rate": 0.0},
+            "account": {"allow_short_selling": False},
+            "metadata": {"prediction_hash": "pred1"},
+        },
+    }
+    spec["strategy"]["rebalance"]["min_weight_change"] = 0.0
+    spec["strategy"]["rebalance"]["min_trade_value"] = 0.0
+    monkeypatch.setattr(br, "substitute_continuous_return_for_classification", lambda p, *_: p)
+    with pytest.raises(ValueError, match="covers 2 of the 4 predicted symbols"):
+        br.run_backtest(
+            "us_firm_characteristics",
+            "pred1",
+            spec,
+            prices=_prices(["A", "C"]),
+            predictions=_predictions(),
+            register=False,
+            resolved_spec_only=True,
+        )

--- a/tests/test_max_symbols_reduces_a_vectorized_backtest.py
+++ b/tests/test_max_symbols_reduces_a_vectorized_backtest.py
@@ -1,0 +1,182 @@
+"""MAX_SYMBOLS reduces the vectorized backtest, not just the price frame.
+
+ml4t/agent-workspace#911. The vectorized path computes `gross_ret = weight *
+y_true` from the predictions frame, and reads `prices` only for the rebalance
+calendar - the same set of decision dates whichever symbols are in the panel. So
+a preview taken at a reduced `MAX_SYMBOLS` was the production sweep with the
+production cost per backtest: measured on us_firm_characteristics/11_backtest,
+32 backtests at 300 symbols and at 3,708 agreed in every column to six decimals.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import polars as pl
+import pytest
+
+SPEC = {
+    "version": 2,
+    "strategy": {
+        "signal": {"method": "equal_weight_top_k", "top_k": 2, "long_short": False},
+        "rebalance": {"mode": "vectorized", "cadence": "daily", "step": 1},
+    },
+    "backtest_config": {
+        "cash": {"initial": 100_000.0},
+        "commission": {"model": "percentage", "rate": 0.0},
+        "slippage": {"model": "percentage", "rate": 0.0},
+        "account": {"allow_short_selling": False},
+    },
+}
+
+
+def _predictions() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "timestamp": [datetime(2024, 1, 1)] * 4,
+            "symbol": ["A", "B", "C", "D"],
+            "y_score": [0.9, 0.8, 0.7, 0.6],
+            "y_true": [0.1, 0.2, 0.3, 0.4],
+        }
+    )
+
+
+def _prices(symbols: list[str]) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "timestamp": [datetime(2024, 1, 1)] * len(symbols),
+            "symbol": symbols,
+            "close": [100.0] * len(symbols),
+        }
+    )
+
+
+def _run(monkeypatch, prices, **kwargs) -> dict:
+    """Call run_backtest and capture what the vectorized path was handed."""
+    import case_studies.utils.backtest_runner as br
+    import case_studies.utils.conformal as conformal
+
+    captured: dict = {}
+
+    monkeypatch.setattr(br, "get_backtest_config", lambda _: object())
+    monkeypatch.setattr(br, "ensure_backtest_spec", lambda *args, **kw: args[2])
+    monkeypatch.setattr(conformal, "ensure_conformal_calibration_identity", lambda spec: spec)
+    monkeypatch.setattr(br, "substitute_continuous_return_for_classification", lambda p, *_: p)
+
+    def fake_vectorized(**kw):
+        captured.update(kw)
+        return {
+            "daily_returns": pl.DataFrame(
+                {"timestamp": [datetime(2024, 1, 1)], "daily_return": [0.0]}
+            ),
+            "metrics": {"sharpe": 0.0},
+        }
+
+    monkeypatch.setattr(br, "_run_vectorized", fake_vectorized)
+
+    br.run_backtest(
+        "us_firm_characteristics",
+        "pred1",
+        SPEC,
+        prices=prices,
+        predictions=_predictions(),
+        register=False,
+        **kwargs,
+    )
+    return captured
+
+
+def test_a_reduced_price_panel_reduces_the_backtest(monkeypatch) -> None:
+    """The defect: the panel was reduced and the backtest ran over all four names.
+
+    B outranks C, so a top-2 over the full cross-section holds {A, B}. Over the
+    reduced panel it holds {A, C} - the selection is made inside the universe the
+    panel defines, which is what the parameter reads as and what a preview needs
+    it to mean.
+    """
+    captured = _run(monkeypatch, _prices(["A", "C"]))
+    assert captured["predictions"]["symbol"].to_list() == ["A", "C"]
+    assert sorted(captured["weights"]["symbol"].to_list()) == ["A", "C"]
+
+
+def test_the_full_panel_leaves_the_predictions_alone(monkeypatch) -> None:
+    """The control: nothing is dropped when the panel carries every predicted name."""
+    captured = _run(monkeypatch, _prices(["A", "B", "C", "D", "E"]))
+    assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]
+    assert sorted(captured["weights"]["symbol"].to_list()) == ["A", "B"]
+
+
+def test_a_precomputed_allocation_is_not_silently_narrowed(monkeypatch) -> None:
+    """The Ch19 risk sweep hands in weights an allocator solved for.
+
+    Dropping positions out of that would leave weights summing to something the
+    allocator never chose, so the reduction applies where the selection is made.
+    """
+    weights = pl.DataFrame(
+        {
+            "timestamp": [datetime(2024, 1, 1)] * 4,
+            "symbol": ["A", "B", "C", "D"],
+            "weight": [0.25, 0.25, 0.25, 0.25],
+        }
+    )
+    captured = _run(monkeypatch, _prices(["A", "C"]), precomputed_weights=weights)
+    assert captured["weights"]["symbol"].to_list() == ["A", "B", "C", "D"]
+    assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]
+
+
+def test_a_panel_that_prices_nothing_stops_the_run() -> None:
+    from case_studies.utils.backtest_runner import restrict_to_priced_universe
+
+    with pytest.raises(ValueError, match="would have no universe"):
+        restrict_to_priced_universe(
+            _predictions(), _prices(["X", "Y"]), case_study="demo", label="fwd_ret_1m"
+        )
+
+
+def test_an_empty_panel_is_left_to_the_engine() -> None:
+    """No panel is not a reduction to zero; the engine's own guards cover it."""
+    from case_studies.utils.backtest_runner import restrict_to_priced_universe
+
+    predictions = _predictions()
+    restricted = restrict_to_priced_universe(
+        predictions, pl.DataFrame(), case_study="demo", label="fwd_ret_1m"
+    )
+    assert restricted.equals(predictions)
+
+
+def test_the_htm_option_path_keeps_its_own_universe(monkeypatch) -> None:
+    """sp500_options/ret_to_expiry indexes prices and predictions differently."""
+    import case_studies.utils.backtest_runner as br
+    import case_studies.utils.conformal as conformal
+
+    captured: dict = {}
+    monkeypatch.setattr(br, "get_backtest_config", lambda _: object())
+    monkeypatch.setattr(br, "ensure_backtest_spec", lambda *args, **kw: args[2])
+    monkeypatch.setattr(conformal, "ensure_conformal_calibration_identity", lambda spec: spec)
+    monkeypatch.setattr(br, "substitute_continuous_return_for_classification", lambda p, *_: p)
+
+    def fake_htm(**kw):
+        captured.update(kw)
+        return {
+            "daily_returns": pl.DataFrame(
+                {"timestamp": [datetime(2024, 1, 1)], "daily_return": [0.0]}
+            ),
+            "metrics": {"sharpe": 0.0},
+        }
+
+    monkeypatch.setattr(br, "_run_htm_daily_mtm", fake_htm)
+    monkeypatch.setattr(
+        br,
+        "declared_rebalance_step",
+        lambda *_: None,
+    )
+    br.run_backtest(
+        "sp500_options",
+        "pred1",
+        SPEC,
+        prices=_prices(["X"]),
+        predictions=_predictions(),
+        label="ret_to_expiry",
+        register=False,
+    )
+    assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]

--- a/tests/test_max_symbols_reduces_a_vectorized_backtest.py
+++ b/tests/test_max_symbols_reduces_a_vectorized_backtest.py
@@ -1,11 +1,17 @@
-"""MAX_SYMBOLS reduces the vectorized backtest, not just the price frame.
+"""A price panel narrower than the predictions stops a vectorized run.
 
 ml4t/agent-workspace#911. The vectorized path computes `gross_ret = weight *
-y_true` from the predictions frame, and reads `prices` only for the rebalance
+y_true` from the predictions frame and reads `prices` only for the rebalance
 calendar - the same set of decision dates whichever symbols are in the panel. So
-a preview taken at a reduced `MAX_SYMBOLS` was the production sweep with the
+a preview taken at a reduced `MAX_SYMBOLS` was the production sweep at the
 production cost per backtest: measured on us_firm_characteristics/11_backtest,
 32 backtests at 300 symbols and at 3,708 agreed in every column to six decimals.
+
+Narrowing the predictions to the panel instead would make the traded universe
+decide the portfolio without entering the backtest identity, and the caller
+hashes its specification before this module sees it - `11_backtest.py:273`
+computes `backtest_hash_from_parts` and skips a matching run before calling
+`run_backtest`, so a reduced preview would be served the full-universe result.
 """
 
 from __future__ import annotations
@@ -74,7 +80,7 @@ def _run(monkeypatch, prices, **kwargs) -> dict:
 
     monkeypatch.setattr(br, "_run_vectorized", fake_vectorized)
 
-    result = br.run_backtest(
+    br.run_backtest(
         "us_firm_characteristics",
         "pred1",
         SPEC,
@@ -83,36 +89,29 @@ def _run(monkeypatch, prices, **kwargs) -> dict:
         register=False,
         **kwargs,
     )
-    captured["strategy_spec"] = result.strategy_spec
     return captured
 
 
-def test_a_reduced_price_panel_reduces_the_backtest(monkeypatch) -> None:
-    """The defect: the panel was reduced and the backtest ran over all four names.
-
-    B outranks C, so a top-2 over the full cross-section holds {A, B}. Over the
-    reduced panel it holds {A, C} - the selection is made inside the universe the
-    panel defines, which is what the parameter reads as and what a preview needs
-    it to mean.
-    """
-    captured = _run(monkeypatch, _prices(["A", "C"]))
-    assert captured["predictions"]["symbol"].to_list() == ["A", "C"]
-    assert sorted(captured["weights"]["symbol"].to_list()) == ["A", "C"]
+def test_a_panel_that_cannot_price_the_predictions_stops_the_run(monkeypatch) -> None:
+    """The defect: the panel was reduced and the sweep ran over all four names."""
+    with pytest.raises(ValueError) as excinfo:
+        _run(monkeypatch, _prices(["A", "C"]))
+    message = str(excinfo.value)
+    assert "2 of which it cannot price" in message
+    assert "['B', 'D']" in message
+    # Names the knob that does reduce this stage, so the reader is not left to guess.
+    assert "TOP_N_PREDICTIONS" in message
 
 
-def test_the_full_panel_leaves_the_predictions_alone(monkeypatch) -> None:
-    """The control: nothing is dropped when the panel carries every predicted name."""
+def test_a_covering_panel_runs(monkeypatch) -> None:
+    """The control: nothing is refused when the panel carries every predicted name."""
     captured = _run(monkeypatch, _prices(["A", "B", "C", "D", "E"]))
     assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]
     assert sorted(captured["weights"]["symbol"].to_list()) == ["A", "B"]
 
 
-def test_a_precomputed_allocation_is_not_silently_narrowed(monkeypatch) -> None:
-    """The Ch19 risk sweep hands in weights an allocator solved for.
-
-    Dropping positions out of that would leave weights summing to something the
-    allocator never chose, so the reduction applies where the selection is made.
-    """
+def test_a_precomputed_allocation_is_held_to_the_same_panel(monkeypatch) -> None:
+    """The Ch19 risk sweep reads y_true from the same predictions frame."""
     weights = pl.DataFrame(
         {
             "timestamp": [datetime(2024, 1, 1)] * 4,
@@ -120,29 +119,17 @@ def test_a_precomputed_allocation_is_not_silently_narrowed(monkeypatch) -> None:
             "weight": [0.25, 0.25, 0.25, 0.25],
         }
     )
-    captured = _run(monkeypatch, _prices(["A", "C"]), precomputed_weights=weights)
-    assert captured["weights"]["symbol"].to_list() == ["A", "B", "C", "D"]
-    assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]
-
-
-def test_a_panel_that_prices_nothing_stops_the_run() -> None:
-    from case_studies.utils.backtest_runner import restrict_to_priced_universe
-
-    with pytest.raises(ValueError, match="would have no universe"):
-        restrict_to_priced_universe(
-            _predictions(), _prices(["X", "Y"]), case_study="demo", label="fwd_ret_1m"
-        )
+    with pytest.raises(ValueError, match="cannot price"):
+        _run(monkeypatch, _prices(["A", "C"]), precomputed_weights=weights)
 
 
 def test_an_empty_panel_is_left_to_the_engine() -> None:
     """No panel is not a reduction to zero; the engine's own guards cover it."""
-    from case_studies.utils.backtest_runner import restrict_to_priced_universe
+    from case_studies.utils.backtest_runner import refuse_predictions_the_panel_cannot_price
 
-    predictions = _predictions()
-    restricted = restrict_to_priced_universe(
-        predictions, pl.DataFrame(), case_study="demo", label="fwd_ret_1m"
+    refuse_predictions_the_panel_cannot_price(
+        _predictions(), pl.DataFrame(), case_study="demo", label="fwd_ret_1m"
     )
-    assert restricted.equals(predictions)
 
 
 def test_the_htm_option_path_keeps_its_own_universe(monkeypatch) -> None:
@@ -166,11 +153,7 @@ def test_the_htm_option_path_keeps_its_own_universe(monkeypatch) -> None:
         }
 
     monkeypatch.setattr(br, "_run_htm_daily_mtm", fake_htm)
-    monkeypatch.setattr(
-        br,
-        "declared_rebalance_step",
-        lambda *_: None,
-    )
+    monkeypatch.setattr(br, "declared_rebalance_step", lambda *_: None)
     br.run_backtest(
         "sp500_options",
         "pred1",
@@ -181,55 +164,3 @@ def test_the_htm_option_path_keeps_its_own_universe(monkeypatch) -> None:
         register=False,
     )
     assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]
-
-
-def test_a_reduced_universe_gets_its_own_identity(monkeypatch) -> None:
-    """A reduced run is a different portfolio, so it must hash as one.
-
-    Without this the skip-if-complete check inside `run_backtest`, and the same
-    check `11_backtest` runs before submitting a scheme, both hash prediction plus
-    strategy alone - and a preview at reduced MAX_SYMBOLS would be served the
-    full-universe result or register its numbers under the full run's hash.
-    """
-    from case_studies.utils.registry.specs import backtest_hash_from_parts
-
-    reduced = _run(monkeypatch, _prices(["A", "C"]))["strategy_spec"]
-    full = _run(monkeypatch, _prices(["A", "B", "C", "D"]))["strategy_spec"]
-    assert reduced["strategy"]["signal"]["universe_n_symbols"] == 2
-    # Absent, not equal to the full width: stamping it unconditionally would
-    # re-key every backtest already registered.
-    assert "universe_n_symbols" not in full["strategy"]["signal"]
-    assert backtest_hash_from_parts("pred1", reduced) != backtest_hash_from_parts("pred1", full)
-
-
-def test_a_locked_specification_refuses_a_narrowed_universe(monkeypatch) -> None:
-    """The holdout producer hashed its spec already; it cannot be narrowed under it."""
-    import case_studies.utils.backtest_runner as br
-
-    spec = {
-        "version": 2,
-        "strategy": {
-            "signal": {"method": "equal_weight_top_k", "top_k": 2, "long_short": False},
-            "rebalance": {"mode": "vectorized", "cadence": "daily", "step": 1},
-        },
-        "backtest_config": {
-            "cash": {"initial": 100_000.0},
-            "commission": {"model": "percentage", "rate": 0.0},
-            "slippage": {"model": "percentage", "rate": 0.0},
-            "account": {"allow_short_selling": False},
-            "metadata": {"prediction_hash": "pred1"},
-        },
-    }
-    spec["strategy"]["rebalance"]["min_weight_change"] = 0.0
-    spec["strategy"]["rebalance"]["min_trade_value"] = 0.0
-    monkeypatch.setattr(br, "substitute_continuous_return_for_classification", lambda p, *_: p)
-    with pytest.raises(ValueError, match="covers 2 of the 4 predicted symbols"):
-        br.run_backtest(
-            "us_firm_characteristics",
-            "pred1",
-            spec,
-            prices=_prices(["A", "C"]),
-            predictions=_predictions(),
-            register=False,
-            resolved_spec_only=True,
-        )

--- a/tests/test_max_symbols_reduces_a_vectorized_backtest.py
+++ b/tests/test_max_symbols_reduces_a_vectorized_backtest.py
@@ -1,4 +1,4 @@
-"""A price panel narrower than the predictions stops a vectorized run.
+"""A price panel narrower than the predictions is reported, not acted on.
 
 ml4t/agent-workspace#911. The vectorized path computes `gross_ret = weight *
 y_true` from the predictions frame and reads `prices` only for the rebalance
@@ -7,11 +7,15 @@ a preview taken at a reduced `MAX_SYMBOLS` was the production sweep at the
 production cost per backtest: measured on us_firm_characteristics/11_backtest,
 32 backtests at 300 symbols and at 3,708 agreed in every column to six decimals.
 
-Narrowing the predictions to the panel instead would make the traded universe
-decide the portfolio without entering the backtest identity, and the caller
-hashes its specification before this module sees it - `11_backtest.py:273`
-computes `backtest_hash_from_parts` and skips a matching run before calling
-`run_backtest`, so a reduced preview would be served the full-universe result.
+Both ways of acting on it are wrong here, and each was tried. Narrowing the
+predictions to the panel makes the traded universe decide the portfolio without
+entering the backtest identity - the caller hashes its specification before this
+module sees the run, so a reduced preview would be served the full-universe
+result. Refusing the run stops a preview that is legitimately configured this
+way: the CI `us_firm_characteristics` fixture holds a 5-symbol panel against
+20-symbol predictions, and refusing took four notebooks down. What closes it is
+the caller declaring the universe it trades, before it hashes, which is a
+notebook change.
 """
 
 from __future__ import annotations
@@ -92,25 +96,31 @@ def _run(monkeypatch, prices, **kwargs) -> dict:
     return captured
 
 
-def test_a_panel_that_cannot_price_the_predictions_stops_the_run(monkeypatch) -> None:
+def test_a_panel_that_cannot_price_the_predictions_says_so(monkeypatch) -> None:
     """The defect: the panel was reduced and the sweep ran over all four names."""
-    with pytest.raises(ValueError) as excinfo:
-        _run(monkeypatch, _prices(["A", "C"]))
-    message = str(excinfo.value)
+    with pytest.warns(UserWarning) as record:
+        captured = _run(monkeypatch, _prices(["A", "C"]))
+    message = str(record[0].message)
     assert "2 of which it cannot price" in message
-    assert "['B', 'D']" in message
     # Names the knob that does reduce this stage, so the reader is not left to guess.
     assert "TOP_N_PREDICTIONS" in message
+    # And says it without changing the run: the identity the caller already hashed
+    # describes a sweep over all four names, and that is what it gets.
+    assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]
 
 
-def test_a_covering_panel_runs(monkeypatch) -> None:
-    """The control: nothing is refused when the panel carries every predicted name."""
-    captured = _run(monkeypatch, _prices(["A", "B", "C", "D", "E"]))
+def test_a_covering_panel_is_silent(monkeypatch) -> None:
+    """The control: nothing is reported when the panel carries every predicted name."""
+    import warnings as _warnings
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", UserWarning)
+        captured = _run(monkeypatch, _prices(["A", "B", "C", "D", "E"]))
     assert captured["predictions"]["symbol"].to_list() == ["A", "B", "C", "D"]
     assert sorted(captured["weights"]["symbol"].to_list()) == ["A", "B"]
 
 
-def test_a_precomputed_allocation_is_held_to_the_same_panel(monkeypatch) -> None:
+def test_a_precomputed_allocation_is_reported_on_too(monkeypatch) -> None:
     """The Ch19 risk sweep reads y_true from the same predictions frame."""
     weights = pl.DataFrame(
         {
@@ -119,17 +129,21 @@ def test_a_precomputed_allocation_is_held_to_the_same_panel(monkeypatch) -> None
             "weight": [0.25, 0.25, 0.25, 0.25],
         }
     )
-    with pytest.raises(ValueError, match="cannot price"):
+    with pytest.warns(UserWarning, match="cannot price"):
         _run(monkeypatch, _prices(["A", "C"]), precomputed_weights=weights)
 
 
-def test_an_empty_panel_is_left_to_the_engine() -> None:
+def test_an_empty_panel_says_nothing() -> None:
     """No panel is not a reduction to zero; the engine's own guards cover it."""
-    from case_studies.utils.backtest_runner import refuse_predictions_the_panel_cannot_price
+    import warnings as _warnings
 
-    refuse_predictions_the_panel_cannot_price(
-        _predictions(), pl.DataFrame(), case_study="demo", label="fwd_ret_1m"
-    )
+    from case_studies.utils.backtest_runner import warn_if_the_panel_does_not_bound_the_universe
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", UserWarning)
+        warn_if_the_panel_does_not_bound_the_universe(
+            _predictions(), pl.DataFrame(), case_study="demo", label="fwd_ret_1m"
+        )
 
 
 def test_the_htm_option_path_keeps_its_own_universe(monkeypatch) -> None:

--- a/tests/test_ranking_a_bankrupt_member.py
+++ b/tests/test_ranking_a_bankrupt_member.py
@@ -1,0 +1,98 @@
+"""A bankrupt backtest ranks last; an unmeasured one still refuses the ranking.
+
+ml4t/agent-workspace#1079. The ruin stop (#920) registers `sharpe` as null for a
+path whose equity reached zero, on purpose - a bankrupt path must not produce a
+rankable Sharpe. `rank_by_validation_sharpe` read a null Sharpe as "not measured"
+and refused the whole ranking, so a sweep with one bankrupt member and several
+solvent ones ranked nothing at all. Measured on CI run 34157373964, where
+cme_futures 14_portfolio_management, 15_risk_management, 16_costs and
+19_strategy_analysis all failed at that refusal once #1003 let the sweep register
+backtests that trade.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import polars as pl
+import pytest
+
+from case_studies.cme_futures.research_workflow import rank_by_validation_sharpe
+
+
+@dataclass(frozen=True)
+class _Result:
+    hash: str
+
+
+class _Backtests:
+    def __init__(self, table: pl.DataFrame) -> None:
+        self._table = table
+
+    def table(self, *, include_preview: bool = False) -> pl.DataFrame:
+        return self._table
+
+
+class _Study:
+    def __init__(self, table: pl.DataFrame) -> None:
+        self.backtests = _Backtests(table)
+
+
+def _table(rows: list[tuple[str, float | None, float | None]], *, with_ruin: bool = True):
+    data = {
+        "backtest_hash": [r[0] for r in rows],
+        "sharpe": [r[1] for r in rows],
+    }
+    if with_ruin:
+        data["ruin"] = [r[2] for r in rows]
+    return pl.DataFrame(data, schema_overrides={"sharpe": pl.Float64, "ruin": pl.Float64})
+
+
+def _rank(rows, hashes, *, with_ruin=True):
+    study = _Study(_table(rows, with_ruin=with_ruin))
+    return [r.hash for r in rank_by_validation_sharpe(study, [_Result(h) for h in hashes])]
+
+
+def test_a_bankrupt_member_ranks_last_instead_of_refusing_the_set() -> None:
+    """One ruined member and two solvent ones is a ranking of three, not an error."""
+    rows = [("solid", 1.2, 0.0), ("broke", None, 1.0), ("better", 2.0, 0.0)]
+    assert _rank(rows, ["solid", "broke", "better"]) == ["better", "solid", "broke"]
+
+
+def test_the_bankrupt_member_is_never_the_selection() -> None:
+    """`best_validation_sharpe` takes the head, so last is the whole protection."""
+    rows = [("broke", None, 1.0), ("thin", -0.4, 0.0)]
+    assert _rank(rows, ["broke", "thin"])[0] == "thin"
+
+
+def test_several_bankrupt_members_keep_a_deterministic_order() -> None:
+    """Ties among the unrankable break on identity, as they do among the rankable."""
+    rows = [("b", None, 1.0), ("a", None, 1.0), ("live", 0.1, 0.0)]
+    assert _rank(rows, ["b", "a", "live"]) == ["live", "a", "b"]
+
+
+def test_a_null_sharpe_without_the_ruin_flag_still_refuses() -> None:
+    """That is the other reason a Sharpe is null, and it is still a broken run."""
+    rows = [("measured", 0.5, 0.0), ("unmeasured", None, 0.0)]
+    with pytest.raises(ValueError, match="no validation Sharpe recorded"):
+        _rank(rows, ["measured", "unmeasured"])
+
+
+def test_a_null_ruin_flag_is_not_a_bankruptcy() -> None:
+    """Null in that column means the run predates the measurement, not that it survived."""
+    rows = [("measured", 0.5, None), ("unmeasured", None, None)]
+    with pytest.raises(ValueError, match="no validation Sharpe recorded"):
+        _rank(rows, ["measured", "unmeasured"])
+
+
+def test_a_registry_without_the_column_keeps_the_old_rule() -> None:
+    """Written before #920: no `ruin` column at all, so a null Sharpe means one thing."""
+    rows = [("measured", 0.5, None), ("unmeasured", None, None)]
+    with pytest.raises(ValueError, match="no validation Sharpe recorded"):
+        _rank(rows, ["measured", "unmeasured"], with_ruin=False)
+
+
+def test_an_all_solvent_ranking_is_unchanged() -> None:
+    """The common case has to sort exactly as it did before the ruin column existed."""
+    rows = [("mid", 1.0, 0.0), ("top", 3.0, 0.0), ("low", -1.0, 0.0)]
+    assert _rank(rows, ["mid", "top", "low"]) == ["top", "mid", "low"]

--- a/tests/test_risk_trigger_counts.py
+++ b/tests/test_risk_trigger_counts.py
@@ -1,0 +1,179 @@
+"""A risk overlay that never fired is distinguishable from one never installed.
+
+ml4t/agent-workspace#1051. The registry carried `num_trades` and the performance
+metrics and nothing else, so a reader comparing an overlay against the strategy
+it was laid on could conclude "the control acted" from a difference and nothing
+at all from a match. `rules/notebook-standards.md` C17 records the failure that
+hides behind that: 56 registered `crypto_perps_funding/16_risk_management`
+results whose Sharpe, drawdown and trade count matched the unprotected book in
+every digit, because the configuration declared its controls in a shape the
+engine does not read and nothing was installed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import numpy as np
+import polars as pl
+import pytest
+
+from case_studies.utils.backtest_runner import (
+    _apply_vectorized_risk,
+    _build_position_rules,
+    _build_risk_manager,
+)
+
+STOP_LOSS = {"position_rules": [{"name": "stop_loss_5pct", "type": "stop_loss", "threshold": 0.05}]}
+DRAWDOWN = {"portfolio_limits": [{"name": "dd_20", "type": "max_drawdown", "threshold": 0.20}]}
+
+
+def _position_state(unrealized_return: float, high_water_mark: float | None = None):
+    """A long position at a given unrealized return, as the broker would present it."""
+    from ml4t.backtest.risk.types import PositionState
+
+    entry = 100.0
+    price = entry * (1.0 + unrealized_return)
+    return PositionState(
+        asset="A",
+        side="long",
+        entry_price=entry,
+        current_price=price,
+        quantity=10.0,
+        initial_quantity=10.0,
+        unrealized_pnl=(price - entry) * 10.0,
+        unrealized_return=unrealized_return,
+        bars_held=3,
+        high_water_mark=entry if high_water_mark is None else high_water_mark,
+        low_water_mark=price,
+        bar_open=price,
+        bar_high=price,
+        bar_low=price,
+        entry_time=datetime(2024, 1, 1),
+        current_time=datetime(2024, 1, 5),
+    )
+
+
+def test_no_declared_control_registers_null_everywhere() -> None:
+    """A NULL says "no overlay here", never "not measured"."""
+    from case_studies.utils.backtest_runner import RiskTriggerLog
+
+    metrics = RiskTriggerLog().as_metrics()
+    assert metrics["risk_triggers"] is None
+    assert metrics["risk_triggers_stop_loss"] is None
+    assert metrics["risk_triggers_max_drawdown"] is None
+
+
+def test_a_control_that_never_fired_registers_zero() -> None:
+    from case_studies.utils.backtest_runner import RiskTriggerLog
+
+    log = RiskTriggerLog()
+    rule = _build_position_rules(STOP_LOSS, log)
+    rule.evaluate(_position_state(+0.02))  # comfortably above the stop
+    metrics = log.as_metrics()
+    assert metrics["risk_triggers"] == 0.0
+    assert metrics["risk_triggers_stop_loss"] == 0.0
+    # The control that was not declared stays NULL alongside it.
+    assert metrics["risk_triggers_trailing_stop"] is None
+
+
+def test_a_control_that_fired_registers_the_count() -> None:
+    from case_studies.utils.backtest_runner import RiskTriggerLog
+
+    log = RiskTriggerLog()
+    rule = _build_position_rules(STOP_LOSS, log)
+    rule.evaluate(_position_state(+0.02))
+    rule.evaluate(_position_state(-0.09))
+    rule.evaluate(_position_state(-0.12))
+    metrics = log.as_metrics()
+    assert metrics["risk_triggers"] == 2.0
+    assert metrics["risk_triggers_stop_loss"] == 2.0
+
+
+def test_the_wrapped_rule_returns_what_the_real_rule_returned() -> None:
+    """Counting must not change the exit the broker acts on."""
+    from ml4t.backtest.risk import ActionType, StopLoss
+
+    from case_studies.utils.backtest_runner import RiskTriggerLog
+
+    log = RiskTriggerLog()
+    counted = _build_position_rules(STOP_LOSS, log)
+    bare = StopLoss(pct=0.05)
+    for unrealized in (0.02, -0.09):
+        state = _position_state(unrealized)
+        expected, observed = bare.evaluate(state), counted.evaluate(state)
+        assert observed.action == expected.action
+        assert observed.fill_price == expected.fill_price
+    assert counted.evaluate(_position_state(-0.09)).action == ActionType.EXIT_FULL
+
+
+def test_a_portfolio_limit_counts_the_episode_not_the_bars() -> None:
+    """RiskManager re-checks every bar, so a halted book breaches on each one."""
+    from case_studies.utils.backtest_runner import RiskTriggerLog
+
+    log = RiskTriggerLog()
+    manager = _build_risk_manager(DRAWDOWN, 100_000.0, log)
+    manager.update(equity=100_000.0, positions={}, timestamp=datetime(2024, 1, 1))
+    for day in range(2, 8):
+        manager.update(equity=50_000.0, positions={}, timestamp=datetime(2024, 1, day))
+    assert log.as_metrics()["risk_triggers_max_drawdown"] == 1.0
+
+
+def test_an_unknown_control_type_is_refused_rather_than_ignored() -> None:
+    """C17's shape: a key the engine does not read, inside the identity hash."""
+    with pytest.raises(ValueError, match="unknown position rule type"):
+        _build_position_rules({"position_rules": [{"name": "tp", "type": "take_profit"}]})
+    with pytest.raises(ValueError, match="unknown portfolio limit type"):
+        _build_risk_manager({"portfolio_limits": [{"name": "var", "type": "var_95"}]}, 1.0)
+
+
+def _port_ret(returns: list[float]) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "timestamp": [datetime(2024, 1, 1 + i) for i in range(len(returns))],
+            "net_ret": returns,
+        }
+    )
+
+
+def test_the_vectorized_drawdown_breaker_reports_whether_it_fired() -> None:
+    from case_studies.utils.backtest_runner import RiskTriggerLog
+
+    fired = RiskTriggerLog()
+    _apply_vectorized_risk(_port_ret([0.05, -0.30, 0.02, 0.02]), DRAWDOWN, fired)
+    assert fired.as_metrics()["risk_triggers_max_drawdown"] == 1.0
+
+    quiet = RiskTriggerLog()
+    _apply_vectorized_risk(_port_ret([0.01, -0.02, 0.01, 0.01]), DRAWDOWN, quiet)
+    assert quiet.as_metrics()["risk_triggers_max_drawdown"] == 0.0
+
+
+def test_the_vectorized_path_refuses_a_position_rule_it_cannot_install() -> None:
+    """Registering it would name a result for a stop that never ran."""
+    from case_studies.utils.backtest_runner import RiskTriggerLog
+
+    with pytest.raises(ValueError, match="cannot be applied on the vectorized path"):
+        _apply_vectorized_risk(_port_ret([0.01, -0.02]), STOP_LOSS, RiskTriggerLog())
+
+
+def test_a_trailing_stop_counts_the_retracement_and_not_the_hold() -> None:
+    """The rule acts only when price retraces from its high water mark."""
+    from ml4t.backtest.risk import ActionType
+
+    from case_studies.utils.backtest_runner import RiskTriggerLog
+
+    log = RiskTriggerLog()
+    rule = _build_position_rules(
+        {"position_rules": [{"name": "trail_5pct", "type": "trailing_stop", "threshold": 0.05}]},
+        log,
+    )
+    # Rising into a new high water mark: nothing to exit.
+    for gain in np.linspace(0.0, 0.03, 4):
+        assert rule.evaluate(_position_state(float(gain))).action == ActionType.HOLD
+    assert log.as_metrics()["risk_triggers_trailing_stop"] == 0.0
+
+    # Back to the entry price from a high of 110, a 9% retrace on a 5% trail.
+    assert rule.evaluate(_position_state(0.0, high_water_mark=110.0)).action == (
+        ActionType.EXIT_FULL
+    )
+    assert log.as_metrics()["risk_triggers_trailing_stop"] == 1.0


### PR DESCRIPTION
Five defects in the backtest engine and what it reports. Source edits and unit
tests only; no notebook was executed and no artifact regenerated.

## What changes a published number

**The engine stops a path that loses its capital** (ml4t/agent-workspace#920).
A long-short book can lose more than it holds in one period, and equity
compounded straight through zero: once it is negative, `(1 + r)` inverts the
sign of every later period. Measured read-only on the `us_firm_characteristics`
registry, 2026-09-07 - **46 registered runs** with `max_drawdown < -1.0`, the
worst reporting **sharpe 1.547 and cagr +0.687 against a total return of
-202.3**.

The decision, made explicit in `RUIN_UNRANKABLE_METRICS`: the engine models no
creditor, so the largest loss it can express is the capital. The period that
would take equity through zero is truncated to exactly -100% and every later
period is 0.0. `total_return`, `max_drawdown` and `cagr` then read -1.0; every
risk-adjusted ratio and uncertainty band is registered NULL, because fifteen
call sites across the case studies already read `sharpe IS NOT NULL` as "not
rankable". `ruin` and `ruin_period` register as metrics, never identity.

Every registered run with `max_drawdown < -1.0` reports different metrics after
the scheduled re-run wave.

## What changes a check that could not fire

**The entry-scheme feasibility rule measures the ranked cross-section** (#1003),
not the price panel. `get_entry_schemes_for` and `get_top_k_values_for` - halves
of one grid - now filter against `min(price_panel, ranked_width)`, and the raise
happens where both numbers are in scope. Verified against every case study's
`top_k_grid` and one registered prediction set per label: no sweep on `main`
changes.

It changes four CI fixtures, which is the point. `n_assets` came from
`setup["universe"]["n_assets"]` - the declared production universe, 19 for crypto
against a 5-symbol fixture - so the rule was comparing a grid against a number no
preview run had. See "What CI now says" below.

## What changes what a preview measures

**A narrower price panel is reported, not acted on** (#911). The vectorized path
takes the universe and the P&L from the predictions and reads `prices` only for
the rebalance calendar, so a reduced panel reduced nothing: 32 backtests at 300
symbols and at 3,708 agreed in every column. Both ways of acting on it are wrong
and each was tried. Narrowing the predictions to the panel makes the traded
universe decide the portfolio without entering the backtest identity, since the
caller hashes its specification before this module sees the run. Refusing the run
stops a preview that is legitimately configured this way - the CI
`us_firm_characteristics` fixture holds a 5-symbol panel against 20-symbol
predictions, and refusing took four notebooks down. What closes #911 is the caller
declaring the universe it trades before it hashes, which is a notebook change.

The diagnostic is printed as well as warned, because 22 of the 35 notebooks that
call `run_backtest` install a blanket `warnings.filterwarnings("ignore")` at
import and a warning reaches nobody reading an executed notebook. Filed as
ml4t/agent-workspace#1078.

## What changes a table the reader sees

**A risk overlay that never fired is no longer silence** (#1051). Six metric
columns count what each installed control did, distinguishing "no overlay"
(NULL) from "installed, never fired" (0). Portfolio limits count breach
episodes, not bars. Two silent-nothing paths - an unrecognized control `type`,
and a position rule on the vectorized path - are refused, because registering
them is `notebook-standards.md` C17's failure itself. Neither can fire on
anything declared today.

**`BacktestExplorer` can show concentration** (#910). `best()` returns `top_k`
beside `signal_method`, `compare_allocators` keeps bankrupt rows behind a
`ruined` column and computes its statistics over the solvent ones, and
`concentration_curve` is stage-aware and names where the rows actually are when
it is asked at the wrong one.

## What #920 turned up downstream

A null validation Sharpe used to mean one thing - not measured - and refusing to
rank was right. The ruin stop gave it a second meaning, so
`rank_by_validation_sharpe` refused whole rankings containing a bankrupt member.
It now reads the `ruin` column: `ruin = 1.0` survives the filter, sorts last and
is never selected; a null Sharpe with no flag still refuses; a registry written
before #920 has no such column and keeps the old rule.

Four of that file's seven tests pass before and after, on purpose. They are the
cases that must **not** change - an unmeasured run, a null ruin flag, a registry
with no `ruin` column, and an all-solvent ranking - and a test that passes either
way is the only thing that says so. The three that fail pre-fix fail on the
height check's own message, not on a mis-ordering.

`CandidateSet._ranked_validation_hashes` conflates the same two meanings on the
canonical path and is not fixed here: `case_studies/research/comparison.py` is
being edited by #839. Tracked as ml4t/agent-workspace#1079 with `_leader_index`
in `utils/uncertainty.py`, which picks a leader the same way.

## What CI now says

`cs-etfs` and `cs-cme_futures` are green with sweeps that select rather than hold
the whole cross-section. `cs-nasdaq100_microstructure` and
`cs-crypto_perps_funding` are red, refusing an infeasible sweep. Both were green
on `main` by registering backtests that held everything and traded nothing, which
is #989 - the colour changed, not what CI verified.

`tests/overrides.yaml` raises `max_symbols` where that helps and says why where it
cannot. What bounds a preview is the seeded fold artifacts, measured on
ml4t/third-edition-test-data 63a9e4e: etfs 55-56, cme_futures 30,
nasdaq100_microstructure 5, crypto_perps_funding 5. A `top_k` needs width `k + 1`
long-only and `2k` long-short, so a 5-symbol fold universe drops every
concentration all four declare, and no override closes it. Fixing those two means
regenerating the fixture: ml4t/agent-workspace#1077.

`cs-us_firm_characteristics` is red identically on `main` (#1075), as are
`ch11-12`, `ch14-15` and `ch26`.

## Verification

Every fix carries a test written against the behaviour and run against the
pre-fix tree; each commit message holds the command and its failure output.

Two rounds of pre-push RoboRev review found ten further defects in this work -
two of them mine, in the ruin stop and the universe filter. Each is fixed with
its own test and named in the commit that fixes it.

CI-shaped sweep locally (`pytest tests/` minus `.github/ci/unit-test-quarantine.txt`):
**4587 passed, 113 skipped, 101 deselected**, no failures. `test-unit` has been
green on every push since.

No notebook `.py` was edited, so no provenance was cleared and no render was lost.

## Follow-ups outside this branch's boundary

- **#1077** - the nasdaq and crypto fixtures fit in 5-symbol folds.
- **#1078** - 22 of 35 backtest notebooks ignore warnings at import.
- **#1079** - the canonical ranking and the uncertainty leader still conflate the
  two meanings of a null Sharpe.
- `us_firm_characteristics/11_backtest.py` documents the old `MAX_SYMBOLS`
  behaviour in its parameters cell and is now wrong.
- `us_firm_characteristics/11_backtest.py` has no empty-entry-schemes guard, so a
  universe cap below the smallest declared `top_k` registers zero backtests
  silently - the failure `etfs/14_backtest` raises on.
- `us_firm_characteristics/11_backtest.py` joins `top_k` from
  `backtest_runs.spec_json` by hand; `best()` now returns the column.
- `crypto_perps_funding/15_risk_management.py` takes `float(row["sharpe"])` off
  `rank_returns_on_common_support` and would raise on a bankrupt overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HHT2sUgKgTC2GfpePdm4m
