### PR TITLE
Three defects in the registry-identity fixes, one of them fleet-wide

### DIFF
--- a/case_studies/sp500_options/11_model_analysis.ipynb
+++ b/case_studies/sp500_options/11_model_analysis.ipynb
@@ -2,16 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b0403a8b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001007,
-     "end_time": "2026-09-04T05:53:12.898337+00:00",
-     "exception": false,
-     "start_time": "2026-09-04T05:53:12.897330+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "7dad8d41",
+   "metadata": {},
    "source": [
     "# S&P 500 Options: Model Analysis\n",
     "\n",
@@ -40,7 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6e4093e",
+   "id": "11453291",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +46,10 @@
     "    official_prediction_catalog,\n",
     "    open_study,\n",
     ")\n",
-    "from case_studies.utils.registry.completeness import require_comparable_key_digests\n",
+    "from case_studies.utils.registry.completeness import (\n",
+    "    key_digest_value,\n",
+    "    require_comparable_key_digests,\n",
+    ")\n",
     "\n",
     "MODEL_POPULATIONS = (\n",
     "    \"sp500-options-linear-validation-v1\",\n",
@@ -67,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bdc78947",
+   "id": "0b2fc95a",
    "metadata": {
     "tags": [
      "parameters"
@@ -81,16 +76,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71a6f53d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000657,
-     "end_time": "2026-09-04T05:53:14.957529+00:00",
-     "exception": false,
-     "start_time": "2026-09-04T05:53:14.956872+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "01254982",
+   "metadata": {},
    "source": [
     "## Complete population and its eligibility groups\n",
     "\n",
@@ -107,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "872e407a",
+   "id": "42f4b07f",
    "metadata": {
     "tags": [
      "results"
@@ -144,16 +131,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8000e114",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001333,
-     "end_time": "2026-09-04T05:53:17.528779+00:00",
-     "exception": false,
-     "start_time": "2026-09-04T05:53:17.527446+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "81bfba89",
+   "metadata": {},
    "source": [
     "Eligibility is grouped, not assumed identical. A sequence model needs a lookback window before it\n",
     "can score a symbol, so it is eligible on strictly fewer rows than a cross-sectional model reading\n",
@@ -173,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffd9f99d",
+   "id": "0f08e072",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +167,16 @@
     "require_comparable_key_digests(\n",
     "    coverage.get_column(\"expected_key_digest\"), what=\"this notebook's model populations\"\n",
     ")\n",
-    "for digest, group in coverage.group_by(\"expected_key_digest\"):\n",
+    "# Grouped on the digest value rather than the stored string. A row written before the rendering\n",
+    "# was stamped and a row written after it carry the same key set as `<value>` and `k2:<value>`,\n",
+    "# and grouping the strings would split one contract in two for no reason a reader could see -\n",
+    "# the same mis-grouping the check above refuses, arriving through the prefix instead.\n",
+    "coverage = coverage.with_columns(\n",
+    "    pl.col(\"expected_key_digest\")\n",
+    "    .map_elements(key_digest_value, return_dtype=pl.String)\n",
+    "    .alias(\"eligibility\")\n",
+    ")\n",
+    "for digest, group in coverage.group_by(\"eligibility\"):\n",
     "    if group.select(\"n_expected\", \"n_actual\", \"n_folds\").n_unique() != 1:\n",
     "        raise RuntimeError(\n",
     "            f\"predictions sharing eligibility {digest[0]} disagree on coverage dimensions\"\n",
@@ -197,7 +185,7 @@
     "        raise RuntimeError(f\"eligibility {digest[0]} has predictions short of their declaration\")\n",
     "\n",
     "population_audit = (\n",
-    "    coverage.group_by(\"expected_key_digest\")\n",
+    "    coverage.group_by(\"eligibility\")\n",
     "    .agg(\n",
     "        pl.col(\"family\").unique().sort().str.join(\", \").alias(\"families\"),\n",
     "        pl.len().alias(\"predictions\"),\n",
@@ -214,16 +202,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a49f410d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000691,
-     "end_time": "2026-09-04T05:53:17.539249+00:00",
-     "exception": false,
-     "start_time": "2026-09-04T05:53:17.538558+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "c49be3ca",
+   "metadata": {},
    "source": [
     "## Predictive diagnostics\n",
     "\n",
@@ -265,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb96ccbd",
+   "id": "2c0aff84",
    "metadata": {
     "tags": [
      "results"
@@ -315,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9eda851f",
+   "id": "bdd4ed14",
    "metadata": {
     "tags": [
      "results"
@@ -339,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61f756c5",
+   "id": "20c4cc72",
    "metadata": {
     "tags": [
      "results"
@@ -373,16 +353,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60a91038",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001794,
-     "end_time": "2026-09-04T05:53:19.384011+00:00",
-     "exception": false,
-     "start_time": "2026-09-04T05:53:19.382217+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "0bb6f915",
+   "metadata": {},
    "source": [
     "## Causal DML artifact\n",
     "\n",
@@ -412,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3ce99e3",
+   "id": "ddda4bb8",
    "metadata": {
     "tags": [
      "results"
@@ -440,16 +412,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ecc6480",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003335,
-     "end_time": "2026-09-04T05:53:19.400157+00:00",
-     "exception": false,
-     "start_time": "2026-09-04T05:53:19.396822+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "ac10edae",
+   "metadata": {},
    "source": [
     "Predictive diagnostics and the causal estimate are now available for reader inspection. Neither\n",
     "table changes the complete prediction population or selects a strategy.\n",
@@ -477,18 +441,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_options/11_model_analysis.py
+++ b/case_studies/sp500_options/11_model_analysis.py
@@ -48,7 +48,10 @@ from case_studies.sp500_options.research_workflow import (
     official_prediction_catalog,
     open_study,
 )
-from case_studies.utils.registry.completeness import require_comparable_key_digests
+from case_studies.utils.registry.completeness import (
+    key_digest_value,
+    require_comparable_key_digests,
+)
 
 MODEL_POPULATIONS = (
     "sp500-options-linear-validation-v1",
@@ -127,7 +130,16 @@ coverage = coverage.join(
 require_comparable_key_digests(
     coverage.get_column("expected_key_digest"), what="this notebook's model populations"
 )
-for digest, group in coverage.group_by("expected_key_digest"):
+# Grouped on the digest value rather than the stored string. A row written before the rendering
+# was stamped and a row written after it carry the same key set as `<value>` and `k2:<value>`,
+# and grouping the strings would split one contract in two for no reason a reader could see -
+# the same mis-grouping the check above refuses, arriving through the prefix instead.
+coverage = coverage.with_columns(
+    pl.col("expected_key_digest")
+    .map_elements(key_digest_value, return_dtype=pl.String)
+    .alias("eligibility")
+)
+for digest, group in coverage.group_by("eligibility"):
     if group.select("n_expected", "n_actual", "n_folds").n_unique() != 1:
         raise RuntimeError(
             f"predictions sharing eligibility {digest[0]} disagree on coverage dimensions"
@@ -136,7 +148,7 @@ for digest, group in coverage.group_by("expected_key_digest"):
         raise RuntimeError(f"eligibility {digest[0]} has predictions short of their declaration")
 
 population_audit = (
-    coverage.group_by("expected_key_digest")
+    coverage.group_by("eligibility")
     .agg(
         pl.col("family").unique().sort().str.join(", ").alias("families"),
         pl.len().alias("predictions"),

--- a/case_studies/utils/registry/completeness.py
+++ b/case_studies/utils/registry/completeness.py
@@ -104,6 +104,16 @@ class PredictionCoverage:
         }
 
 
+# The rendering `_canonical_key_column` implements, stamped onto every digest it produces.
+# `k1` is the rendering it implemented before it normalized temporal columns, under which a
+# `Date` rendered `2016-01-29` and a `Datetime("ms")` of the same instant rendered
+# `2016-01-29 00:00:00.000`, so the same key set digested two ways. Bump `KEY_DIGEST_RENDERING`
+# whenever `_canonical_key_column` changes what it emits, and keep the older rendering
+# reachable from `_canonical_key_column` so a digest that predates the stamp stays identifiable.
+KEY_DIGEST_RENDERING = "k2"
+LEGACY_KEY_DIGEST_RENDERING = "k1"
+
+
 def _prediction_key_columns(frame) -> tuple[str, ...]:
     columns = set(frame.columns)
     entities = [name for name in ("symbol", "product") if name in columns]
@@ -117,7 +127,12 @@ def _prediction_key_columns(frame) -> tuple[str, ...]:
     )
 
 
-def _canonical_key_frame(frame, key_columns: tuple[str, ...] | None = None):
+def _canonical_key_frame(
+    frame,
+    key_columns: tuple[str, ...] | None = None,
+    *,
+    rendering: str = KEY_DIGEST_RENDERING,
+):
     import polars as pl
 
     if not isinstance(frame, pl.DataFrame):
@@ -132,10 +147,12 @@ def _canonical_key_frame(frame, key_columns: tuple[str, ...] | None = None):
         raise ValueError(
             f"prediction coverage requires columns {sorted(required)}; missing {missing}"
         )
-    return frame.select(*(_canonical_key_column(frame, name) for name in key_columns))
+    return frame.select(
+        *(_canonical_key_column(frame, name, rendering=rendering) for name in key_columns)
+    )
 
 
-def _canonical_key_column(frame, name: str):
+def _canonical_key_column(frame, name: str, *, rendering: str = KEY_DIGEST_RENDERING):
     """One key column rendered so two frames from different paths can be joined on it.
 
     Casting a temporal column straight to String renders whatever dtype it happens to carry:
@@ -147,39 +164,62 @@ def _canonical_key_column(frame, name: str):
 
     Every temporal dtype is therefore normalized to microsecond UTC first, so the rendering
     is decided by this function rather than by which loader produced the frame.
+
+    *rendering* selects which version of that decision to apply. `k1` is what this function
+    did before it normalized, kept only so a stored digest that names no rendering can be
+    identified by recomputing it both ways rather than assumed to be one of them.
     """
     import polars as pl
 
     if name == "fold_id":
         return pl.col(name).cast(pl.Int64)
+    if rendering == LEGACY_KEY_DIGEST_RENDERING:
+        return pl.col(name).cast(pl.String)
     dtype = frame.schema[name]
     if dtype == pl.Date or isinstance(dtype, pl.Datetime):
         return pl.col(name).cast(pl.Datetime("us")).cast(pl.String).alias(name)
     return pl.col(name).cast(pl.String)
 
 
-# The rendering `_canonical_key_column` implements, stamped onto every digest it produces.
-# A digest carrying no prefix was written before this existed, under the rendering that cast
-# each key column straight to String - so a `Date` rendered `2016-01-29` and a `Datetime("ms")`
-# of the same instant rendered `2016-01-29 00:00:00.000`, and the same key set digested two
-# ways. Bump this whenever `_canonical_key_column` changes what it emits.
-KEY_DIGEST_RENDERING = "k2"
-_LEGACY_KEY_DIGEST_RENDERING = "k1"
+def key_digest_value(digest: str) -> str:
+    """*digest* without its rendering prefix: the part two digests are equal on."""
+    _, sep, value = str(digest).partition(":")
+    return value if sep else str(digest)
 
 
-def key_digest_rendering(digest: str) -> str:
-    """Which rendering produced *digest*.
+def key_digest_rendering(digest: str, *, expected_keys=None) -> str | None:
+    """Which rendering produced *digest*, or ``None`` where that cannot be established.
 
-    An unprefixed digest is `k1`: the straight-cast rendering every coverage row written
-    before `_canonical_key_column` normalized temporal columns carries. Measured across the
-    fleet 2026-09-07, 166 of 4,469 rows are still `k1` and all of them are
-    `us_equities_panel`'s - the residue no current sweep touches.
+    A digest carrying no prefix was written before the prefix existed, and that is all it
+    says: measured across the fleet 2026-09-07, 4,303 of the 4,469 stored digests reproduce
+    under the current rendering and 166 - all `us_equities_panel`'s - under `k1`, and every
+    one of them is stored bare. Reading a bare digest as `k1` would therefore have declared
+    a rendering change on 4,303 rows where there was none, and refuse the next checkpoint
+    registered against any of them.
+
+    Pass *expected_keys* to settle it by measurement instead: the key frame is digested
+    under each known rendering and the one that reproduces *digest* is the one that produced
+    it. Where neither does, the frames hold different keys, which is a different question,
+    and this returns ``None`` rather than guessing.
     """
-    prefix, sep, _ = digest.partition(":")
-    return prefix if sep else _LEGACY_KEY_DIGEST_RENDERING
+    prefix, sep, _ = str(digest).partition(":")
+    if sep:
+        return prefix
+    if expected_keys is None:
+        return None
+    for rendering in (KEY_DIGEST_RENDERING, LEGACY_KEY_DIGEST_RENDERING):
+        if key_digest_value(coverage_key_digest(expected_keys, rendering=rendering)) == str(digest):
+            return rendering
+    return None
 
 
-def require_comparable_key_digests(digests, *, what: str) -> None:
+def coverage_key_digest(expected_keys, *, rendering: str = KEY_DIGEST_RENDERING) -> str:
+    """The coverage key digest *expected_keys* takes under *rendering*."""
+    frame = _canonical_key_frame(expected_keys, rendering=rendering)
+    return _key_digest(frame, tuple(frame.columns), rendering=rendering)
+
+
+def require_comparable_key_digests(digests, *, what: str, expected_keys=None) -> None:
     """Refuse to treat digests from different renderings as comparable.
 
     Two digests taken under different renderings are unequal whatever their key sets, and
@@ -194,8 +234,20 @@ def require_comparable_key_digests(digests, *, what: str) -> None:
     in cme_futures, and nothing raised - the guard at the consumer only rejects a group whose
     members disagree on `n_expected`, `n_actual` or `n_folds`, and the split halves agree on
     all three.
+
+    Only renderings that can be established are compared. A digest that names none and that
+    *expected_keys* cannot identify makes no claim, and refusing on it would refuse the
+    whole fleet as written today.
     """
-    renderings = sorted({key_digest_rendering(str(digest)) for digest in digests if digest})
+    renderings = sorted(
+        {
+            rendering
+            for digest in digests
+            if digest
+            for rendering in (key_digest_rendering(str(digest), expected_keys=expected_keys),)
+            if rendering is not None
+        }
+    )
     if len(renderings) > 1:
         raise ValueError(
             f"{what} spans coverage-key renderings {renderings}, so its digests cannot be "
@@ -205,10 +257,10 @@ def require_comparable_key_digests(digests, *, what: str) -> None:
         )
 
 
-def _key_digest(frame, key_columns: tuple[str, ...]) -> str:
+def _key_digest(frame, key_columns: tuple[str, ...], rendering: str = KEY_DIGEST_RENDERING) -> str:
     from case_studies.utils.artifact_digest import value_digest
 
-    return f"{KEY_DIGEST_RENDERING}:{value_digest(frame, key_columns)}"
+    return f"{rendering}:{value_digest(frame, key_columns)}"
 
 
 def evaluate_prediction_coverage(expected_keys, predictions) -> PredictionCoverage:

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -1156,10 +1156,13 @@ def register_prediction_set(
             # consumer grouping a training run's checkpoints by eligibility splits one
             # contract into two and nothing says why (ml4t/agent-workspace#1065). Refusing
             # here is what makes the next rendering change arrive as an error naming its
-            # cause rather than as a quiet mis-grouping in a notebook.
+            # cause rather than as a quiet mis-grouping in a notebook. The stored digest
+            # is handed the keys it was taken over, so a row written before the rendering
+            # was stamped is identified by recomputing it rather than assumed to be old.
             require_comparable_key_digests(
                 (existing_coverage[1], coverage.expected_key_digest),
                 what=f"training run {training_hash} at split {split!r}",
+                expected_keys=expected_keys,
             )
 
     p_hash = prediction_hash_from_parts(

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -272,14 +272,19 @@ def declare_artifact_supersession(
 def _resolved_prediction_label(
     case_study: str, training_hash: str, label: str | None, case_dir: Path
 ) -> str | None:
-    """The label a prediction set was produced under: the caller's, else its parent run's.
+    """The label a prediction set was produced under: its parent run's, checked against the caller's.
 
     `training_runs.label` is authoritative and always present, so a caller that does not pass
     one is not an error - it is the common case, and every family reaches this through
-    `publish_predictions`, whose `label` is optional.
+    `publish_predictions`, whose `label` is optional. No family runner passes one.
+
+    A caller that passes a label the parent run disagrees with is refused rather than
+    believed. Letting the argument win would stamp the artifact with a label its own
+    training run was not fitted under, and the coverage guard reading that column would
+    then accept the wrong declaration and refuse the right one - which is the mistake this
+    column exists to catch, made one layer up.
     """
-    if label:
-        return label
+    registered = None
     try:
         db = _open_registry(case_dir)
         try:
@@ -289,8 +294,64 @@ def _resolved_prediction_label(
         finally:
             db.close()
     except sqlite3.Error:
+        registered = None
+    else:
+        registered = row[0] if row and row[0] else None
+    if label and registered and label != registered:
+        raise ValueError(
+            f"predictions of training run {training_hash} are being published as {label!r}, "
+            f"but that run is registered against label {registered!r} in {case_study}. One of "
+            f"the two is wrong, and stamping the artifact with either would record a "
+            f"declaration the other contradicts."
+        )
+    return label or registered
+
+
+def _prediction_frame_label(predictions) -> str | None:
+    """The single label *predictions* states, or ``None`` where it states none."""
+    from case_studies.utils.artifact_digest import PREDICTION_LABEL_COLUMN
+
+    if predictions is None or PREDICTION_LABEL_COLUMN not in getattr(predictions, "columns", ()):
         return None
-    return row[0] if row and row[0] else None
+    import polars as pl
+
+    frame = predictions if isinstance(predictions, pl.DataFrame) else pl.from_pandas(predictions)
+    present = sorted(
+        str(value) for value in frame.get_column(PREDICTION_LABEL_COLUMN).unique().drop_nulls()
+    )
+    if len(present) > 1:
+        raise ValueError(f"prediction frame carries labels {present}, which is more than one")
+    return present[0] if present else None
+
+
+def _without_prediction_label(predictions, label: str | None):
+    """*predictions* as its content is measured: without the label it was produced under.
+
+    The label is a constant the registry already holds on the parent training run, so it is
+    data about the frame rather than part of it - which is why `artifact_digest` excludes it
+    and why every digest recorded before the column existed stays valid. `schema_json` has
+    to agree: recording a schema without the column while writing a parquet that has it
+    makes the published artifact fail its own immutability check when it is read back and
+    re-registered, which is what a resumed or replayed registration does.
+
+    A frame that states a label the publication contradicts is refused here rather than
+    silently stripped, because the two are then telling different stories about what was
+    fitted.
+    """
+    from case_studies.utils.artifact_digest import PREDICTION_LABEL_COLUMN
+
+    stated = _prediction_frame_label(predictions)
+    if stated is None:
+        return predictions
+    if label and stated != label:
+        raise ValueError(
+            f"prediction frame carries label(s) ['{stated}'] and is being published as {label!r}"
+        )
+    import polars as pl
+
+    if isinstance(predictions, pl.DataFrame):
+        return predictions.drop(PREDICTION_LABEL_COLUMN)
+    return predictions.drop(columns=[PREDICTION_LABEL_COLUMN])
 
 
 def _with_prediction_label(predictions, label: str | None):
@@ -304,11 +365,11 @@ def _with_prediction_label(predictions, label: str | None):
     frame whose own `label` disagrees since that was found; the column it reads was never
     written.
 
-    Written here because this is the one path every family publishes through. A frame that
-    already carries the column keeps it, and a disagreement is refused rather than
-    overwritten: the caller and the parent training run are then telling two different
-    stories about what was fitted, and quietly picking one is how the mistake this closes
-    got made in the first place.
+    Written here because this is the one path every family publishes through, and last,
+    because everything that measures the frame - coverage, `schema_json`, the artifact
+    digest - measures it without this column. :func:`_without_prediction_label` has already
+    taken any column the caller supplied off, and refused it if it disagreed with the label
+    being published under.
     """
     import polars as pl
 
@@ -1120,6 +1181,13 @@ def register_prediction_set(
     # normalizing later would store a naive schema beside a UTC-aware parquet and make two
     # equivalent checkpoints disagree on nothing but the zone.
     predictions = _timestamps_as_utc(predictions)
+    # Resolved and removed before anything measures the frame, so coverage, `schema_json`
+    # and the artifact digest all describe the same thing: the predictions, without the
+    # label they were produced under. The column goes back on at the write below.
+    resolved_label = _resolved_prediction_label(
+        case_study, training_hash, label, case_dir
+    ) or _prediction_frame_label(predictions)
+    predictions = _without_prediction_label(predictions, resolved_label)
     coverage = None
     if identity_version in SUPPORTED_IDENTITY_VERSIONS:
         if predictions is None or expected_keys is None:
@@ -1187,11 +1255,9 @@ def register_prediction_set(
         # is data about the frame rather than part of its content identity - and excluding
         # it is what keeps every `artifact_digest` already recorded in the fleet valid
         # (ml4t/agent-workspace#887). Coverage and `schema_json` above are computed on the
-        # frame as handed in, so neither moves either.
-        published_predictions = _with_prediction_label(
-            normalized_predictions,
-            _resolved_prediction_label(case_study, training_hash, label, case_dir),
-        )
+        # frame with the column removed, for the same reason and so that the artifact
+        # written here passes its own immutability check when it is read back.
+        published_predictions = _with_prediction_label(normalized_predictions, resolved_label)
         prediction_artifact_digest = published_prediction_digest(normalized_predictions)
         pred_dir = _prediction_dir(case_dir, p_hash)
         pred_path = pred_dir / "predictions.parquet"

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -136,15 +136,30 @@ def _registered_artifact_shas(db, *, label: str) -> dict[str, set[str]]:
 
 
 def _declared_artifact_supersessions(db, *, artifact_name: str, sha256: str) -> set[str]:
-    """The shas *sha256* is declared to replace for *artifact_name*."""
-    return {
-        row[0]
-        for row in db.execute(
-            "SELECT supersedes_sha256 FROM artifact_supersessions "
-            "WHERE artifact_name = ? AND sha256 = ?",
-            (artifact_name, sha256),
-        )
-    }
+    """Every sha *sha256* is declared to replace for *artifact_name*, following the chain back.
+
+    Ancestry, not one edge. A second deliberate regeneration produces a chain - C replaces
+    B, which already replaced A - and the population still holds runs fitted on A, because
+    a declaration retires a vintage for future runs and does not delete the runs that used
+    it. Reading one edge would demand that C also declare it supersedes A, which
+    :func:`declare_artifact_supersession` refuses: A already names B as its successor, and a
+    sha has one. So the chain would be unregisterable and the error would name the
+    declaration that cannot be made.
+    """
+    predecessors: dict[str, set[str]] = {}
+    for successor, superseded in db.execute(
+        "SELECT sha256, supersedes_sha256 FROM artifact_supersessions WHERE artifact_name = ?",
+        (artifact_name,),
+    ):
+        predecessors.setdefault(str(successor), set()).add(str(superseded))
+    retired: set[str] = set()
+    frontier = [sha256]
+    while frontier:
+        for predecessor in predecessors.get(frontier.pop(), ()):
+            if predecessor not in retired:
+                retired.add(predecessor)
+                frontier.append(predecessor)
+    return retired
 
 
 def _enforce_input_artifact_vintage(db, spec: dict) -> None:

--- a/tests/test_coverage_key_rendering.py
+++ b/tests/test_coverage_key_rendering.py
@@ -32,8 +32,11 @@ import pytest
 
 from case_studies.utils.registry.completeness import (
     KEY_DIGEST_RENDERING,
+    LEGACY_KEY_DIGEST_RENDERING,
+    coverage_key_digest,
     evaluate_prediction_coverage,
     key_digest_rendering,
+    key_digest_value,
     require_comparable_key_digests,
 )
 from case_studies.utils.registry.registration import (
@@ -68,9 +71,30 @@ def test_a_digest_names_the_rendering_that_produced_it() -> None:
     assert key_digest_rendering(coverage.expected_key_digest) == KEY_DIGEST_RENDERING
 
 
-def test_an_unprefixed_digest_is_the_legacy_rendering() -> None:
-    """Every coverage row written before this existed carries a bare digest and means `k1`."""
-    assert key_digest_rendering("0adbebe7d4b67c11") == "k1"
+def test_an_unprefixed_digest_names_no_rendering_on_its_own() -> None:
+    """A bare digest says only that it predates the stamp, and every stored row is bare.
+
+    Measured across the fleet 2026-09-07: 4,303 of the 4,469 stored digests reproduce under
+    the current rendering and 166 - all `us_equities_panel`'s - under `k1`, and all 4,469 are
+    stored without a prefix. Reading bare as `k1` declared a rendering change on the 4,303
+    where there was none, which refused the next checkpoint registered against any of them.
+    """
+    assert key_digest_rendering("0adbebe7d4b67c11") is None
+
+
+def test_a_bare_digest_is_identified_by_recomputing_it() -> None:
+    """The measurement that replaces the assumption: digest the keys both ways and see."""
+    keys = _keys(pl.Date)
+    current = key_digest_value(coverage_key_digest(keys))
+    legacy = key_digest_value(coverage_key_digest(keys, rendering=LEGACY_KEY_DIGEST_RENDERING))
+    assert current != legacy, "the two renderings must actually differ on this fixture"
+    assert key_digest_rendering(current, expected_keys=keys) == KEY_DIGEST_RENDERING
+    assert key_digest_rendering(legacy, expected_keys=keys) == LEGACY_KEY_DIGEST_RENDERING
+
+
+def test_a_bare_digest_of_other_keys_stays_unidentified() -> None:
+    """Neither rendering reproduces it, so it holds different keys - a different question."""
+    assert key_digest_rendering("0adbebe7d4b67c11", expected_keys=_keys(pl.Date)) is None
 
 
 def test_the_same_keys_digest_alike_across_temporal_dtypes() -> None:
@@ -93,7 +117,29 @@ class TestComparingAcrossRenderingsIsAnError:
     def test_a_mix_is_refused(self) -> None:
         """The silent inequality this converts into an error."""
         with pytest.raises(ValueError, match=r"spans coverage-key renderings \['k1', 'k2'\]"):
-            require_comparable_key_digests(["k2:aaaa", "0adbebe7d4b67c11"], what="a population")
+            require_comparable_key_digests(["k2:aaaa", "k1:bbbb"], what="a population")
+
+    def test_a_bare_digest_alone_makes_no_claim(self) -> None:
+        """Without the keys there is nothing to measure, and guessing refuses the fleet."""
+        require_comparable_key_digests(["k2:aaaa", "0adbebe7d4b67c11"], what="a population")
+
+    def test_a_bare_digest_is_refused_once_the_keys_identify_it(self) -> None:
+        """With the keys in hand the same pair is a genuine rendering change, and says so."""
+        keys = _keys(pl.Date)
+        legacy = key_digest_value(coverage_key_digest(keys, rendering=LEGACY_KEY_DIGEST_RENDERING))
+        with pytest.raises(ValueError, match=r"spans coverage-key renderings \['k1', 'k2'\]"):
+            require_comparable_key_digests(
+                [coverage_key_digest(keys), legacy], what="a population", expected_keys=keys
+            )
+
+    def test_a_bare_digest_of_the_current_rendering_compares_fine(self) -> None:
+        """The regression: 4,303 fleet rows are this, and none of them is a rendering change."""
+        keys = _keys(pl.Date)
+        require_comparable_key_digests(
+            [coverage_key_digest(keys), key_digest_value(coverage_key_digest(keys))],
+            what="a population",
+            expected_keys=keys,
+        )
 
     def test_nulls_and_blanks_are_not_a_rendering(self) -> None:
         """A row with no digest is a different complaint, and one this must not raise for."""
@@ -136,19 +182,70 @@ def test_a_rendering_change_within_a_training_run_is_refused(tmp_path: Path) -> 
     publish(1)
     publish(2)  # a second checkpoint under the same rendering is ordinary
 
-    # Now rewrite the first checkpoint's stored digest as a legacy one, which is exactly the
-    # state a rendering change leaves behind, and register a third checkpoint.
+    # Now rewrite the stored digests as the previous rendering of these same keys, which is
+    # exactly what a rendering change leaves behind, and register a third checkpoint.
+    _rewrite_stored_digests(
+        tmp_path,
+        training_hash,
+        key_digest_value(
+            coverage_key_digest(_keys(pl.Date), rendering=LEGACY_KEY_DIGEST_RENDERING)
+        ),
+    )
+    with pytest.raises(ValueError, match="spans coverage-key renderings"):
+        publish(3)
+
+
+def test_a_checkpoint_joins_siblings_written_before_the_stamp(tmp_path: Path) -> None:
+    """The regression this guard caused, as the fleet meets it.
+
+    Every one of the 4,469 coverage rows in the nine registries was written before the
+    rendering was stamped, so every one is bare - and 4,303 of them under the rendering in
+    force today. Reading bare as a changed rendering refused the next checkpoint registered
+    against any of them, which is every re-run and every resumed sweep.
+    """
+    training_hash = register_training_run(
+        CASE_STUDY,
+        {
+            "identity_version": 2,
+            "execution_tier": "canonical",
+            "family": "linear",
+            "label": LABEL,
+            "seed": 42,
+            "config_name": "ridge_default",
+            "computation": {"model": {"class": "Ridge"}},
+        },
+        case_dir=tmp_path,
+    )
+
+    def publish(checkpoint: int) -> str:
+        return register_prediction_set(
+            CASE_STUDY,
+            training_hash,
+            checkpoint_kind="epoch",
+            checkpoint_value=checkpoint,
+            split="validation",
+            predictions=_predictions(pl.Date),
+            expected_keys=_keys(pl.Date),
+            case_dir=tmp_path,
+        )
+
+    first = publish(1)
+    _rewrite_stored_digests(
+        tmp_path, training_hash, key_digest_value(coverage_key_digest(_keys(pl.Date)))
+    )
+    assert publish(2) != first
+    assert publish(1) == first, "and re-registering the same checkpoint is still idempotent"
+
+
+def _rewrite_stored_digests(case_dir: Path, training_hash: str, digest: str) -> None:
     import sqlite3
     from contextlib import closing
 
-    with closing(sqlite3.connect(tmp_path / "run_log" / "registry.db")) as db:
+    with closing(sqlite3.connect(case_dir / "run_log" / "registry.db")) as db:
         db.execute(
-            "UPDATE prediction_coverage SET expected_key_digest = 'deadbeefdeadbeef' "
+            "UPDATE prediction_coverage SET expected_key_digest = ? "
             "WHERE prediction_hash IN (SELECT prediction_hash FROM prediction_sets "
             "WHERE training_hash = ?)",
-            (training_hash,),
+            (digest, training_hash),
         )
         db.commit()
-
-    with pytest.raises(ValueError, match="spans coverage-key renderings"):
-        publish(3)

--- a/tests/test_input_artifact_vintage.py
+++ b/tests/test_input_artifact_vintage.py
@@ -155,6 +155,56 @@ def test_a_declaration_does_not_wave_through_a_third_vintage(tmp_path: Path) -> 
         )
 
 
+def test_a_second_regeneration_registers_on_a_declared_chain(tmp_path: Path) -> None:
+    """A regeneration of a regeneration, which is the same operation done twice.
+
+    Declaring that C replaces B is the whole of what an author can say: A already names B as
+    its successor, and `declare_artifact_supersession` refuses a second successor for one
+    sha, so C -> A cannot be declared. But the population still holds the run fitted on A - a
+    declaration retires a vintage for later runs, it does not delete the runs that used it -
+    so reading one edge demanded a declaration that cannot be made, and the error named it.
+    """
+    register_training_run("etfs", _spec(model_based=SHA_A), case_dir=tmp_path)
+    declare_artifact_supersession(
+        "etfs", "model_based", sha256=SHA_B, supersedes_sha256=SHA_A, case_dir=tmp_path
+    )
+    register_training_run(
+        "etfs", _spec(model_based=SHA_B, config_name="ridge_wide"), case_dir=tmp_path
+    )
+
+    sha_c = "c" * 64
+    declare_artifact_supersession(
+        "etfs", "model_based", sha256=sha_c, supersedes_sha256=SHA_B, case_dir=tmp_path
+    )
+    register_training_run(
+        "etfs", _spec(model_based=sha_c, config_name="ridge_deep"), case_dir=tmp_path
+    )
+    assert _registered(tmp_path) == 3
+
+
+def test_a_chain_does_not_retire_a_vintage_outside_it(tmp_path: Path) -> None:
+    """The control: ancestry is followed, not assumed. A sha nobody declared stays refused."""
+    register_training_run("etfs", _spec(model_based=SHA_A), case_dir=tmp_path)
+    declare_artifact_supersession(
+        "etfs", "model_based", sha256=SHA_B, supersedes_sha256=SHA_A, case_dir=tmp_path
+    )
+    register_training_run(
+        "etfs", _spec(model_based=SHA_B, config_name="ridge_wide"), case_dir=tmp_path
+    )
+    # `d` replaces `c`, which no run was ever fitted on, so it retires nothing in this
+    # population and the run reading it is still joining two vintages.
+    register_training_run(
+        "etfs", _spec(model_based="c" * 64, label="fwd_ret_5d"), case_dir=tmp_path
+    )
+    declare_artifact_supersession(
+        "etfs", "model_based", sha256="d" * 64, supersedes_sha256="c" * 64, case_dir=tmp_path
+    )
+    with pytest.raises(ValueError, match="model_based"):
+        register_training_run(
+            "etfs", _spec(model_based="d" * 64, config_name="ridge_deep"), case_dir=tmp_path
+        )
+
+
 def test_another_label_is_compared_against_its_own_runs(tmp_path: Path) -> None:
     """The comparison is per label, because `label` names a different file for each one.
 

--- a/tests/test_published_prediction_label.py
+++ b/tests/test_published_prediction_label.py
@@ -191,3 +191,49 @@ def test_the_coverage_guard_now_has_evidence_to_refuse_on(tmp_path: Path) -> Non
         split="validation",
         source="predictions",
     )
+
+
+def test_a_caller_label_the_training_run_contradicts_is_refused(tmp_path: Path) -> None:
+    """The parent run is authoritative, so an argument disagreeing with it is a mistake.
+
+    Believing the argument would stamp the artifact with a label its own training run was
+    not fitted under, and `_reject_label_mismatch` would then accept the wrong declaration
+    and refuse the right one - the mistake the column exists to catch, made one layer up.
+    No family runner passes `label` at all; every one of them reaches this through
+    `publish_predictions`, which leaves it None.
+    """
+    with pytest.raises(ValueError, match="is registered against label 'fwd_ret_21d'"):
+        _publish(tmp_path, _training(tmp_path), label=OTHER_LABEL)
+
+
+def test_a_caller_label_agreeing_with_the_training_run_is_fine(tmp_path: Path) -> None:
+    """The control: passing the right label is not an error, it is redundant."""
+    p_hash = _publish(tmp_path, _training(tmp_path, label=OTHER_LABEL), label=OTHER_LABEL)
+    assert _frame(tmp_path, p_hash).get_column("label").unique().to_list() == [OTHER_LABEL]
+
+
+def test_the_published_artifact_re_registers_as_it_was_read(tmp_path: Path) -> None:
+    """A replayed registration hands back the frame it wrote, label column and all.
+
+    `schema_json` is recorded from the frame handed in and compared against the next
+    checkpoint's, so recording a schema without the label while writing a parquet that has
+    it made the published artifact fail against itself: reading it back and registering it
+    again raised "prediction schema differs from an existing checkpoint" on identical
+    content. Both are now taken without the column, the same way its digest is.
+    """
+    training_hash = _training(tmp_path)
+    first = _publish(tmp_path, training_hash, label=LABEL)
+    published = _frame(tmp_path, first)
+    assert "label" in published.columns
+    assert _publish(tmp_path, training_hash, predictions=published) == first
+    assert _recorded_digest(tmp_path, first) == value_digest(_predictions())
+
+
+def test_a_read_back_artifact_published_under_another_run_is_still_refused(
+    tmp_path: Path,
+) -> None:
+    """The control: the label travels with the frame and still has to agree."""
+    published = _frame(tmp_path, _publish(tmp_path, _training(tmp_path), label=LABEL))
+    other = _training(tmp_path, label=OTHER_LABEL, config="ridge_other")
+    with pytest.raises(ValueError, match="is being published as"):
+        _publish(tmp_path, other, predictions=published)


### PR DESCRIPTION
Three defects review found in #837, one of which blocks every registry in the fleet.

## A bare coverage digest was read as the legacy rendering, refusing 4,469 rows

`0865eb6c` stamped each coverage digest with the rendering that produced it and read an
unprefixed digest as `k1`, the straight-cast rendering that predates the stamp. Every one
of the 4,469 `prediction_coverage` rows across the nine registries is stored bare, because
the prefix only exists as of that commit - and 4,303 of them reproduce under the rendering
in force today. So the guard declared a rendering change on rows whose rendering had not
changed, and refused the next checkpoint registered against any of them: every re-run,
every resumed sweep, every idempotent re-registration.

| registry | coverage rows | stored without a prefix |
|---|---|---|
| cme_futures | 497 | 497 |
| crypto_perps_funding | 678 | 678 |
| etfs | 560 | 560 |
| fx_pairs | 787 | 787 |
| sp500_equity_option_analytics | 948 | 948 |
| sp500_options | 263 | 263 |
| us_equities_panel | 166 | 166 |
| us_firm_characteristics | 570 | 570 |
| **total** | **4,469** | **4,469** |

`key_digest_rendering` now returns `None` for a digest that names no rendering, and takes
the key frame the digest was computed over: the frame is digested under each known
rendering and the one that reproduces the digest is the one that produced it.
`register_prediction_set` passes the expected keys it already holds. The 166 genuinely
legacy rows, all `us_equities_panel`'s, are still refused - on a recomputation rather than
on the absence of a prefix. `sp500_options/11_model_analysis` groups on the digest value
rather than the stored string, so a population holding `<value>` beside `k2:<value>`
reports one eligibility contract rather than two.

## The caller's label beat the training run's, and the schema disagreed with the artifact

Two in `a73e7efe`. `_resolved_prediction_label` preferred the caller's argument, so
publishing a `fwd_ret_21d` run's predictions with `label="fwd_ret_5d"` stamped the
artifact `fwd_ret_5d` silently and `_reject_label_mismatch` - the guard the column exists
to feed - then accepted the wrong declaration and refused the right one. And `schema_json`
was recorded from the frame as handed in, without the column, while the parquet was
written with it: reading that artifact back and registering it again failed on identical
content with "prediction schema differs from an existing checkpoint".

The registered label is authoritative now and a caller that contradicts it is refused (no
family runner passes `label` at all), and the column comes off the frame before anything
measures it, so coverage, `schema_json` and the artifact digest all describe the same
thing.

## A second declared regeneration could not be registered

`c437f58c` read one supersession edge. After A is superseded by B and B by C, the
population still holds runs fitted on A, so registering C demanded that C also declare it
supersedes A - which `declare_artifact_supersession` refuses, because A already names B as
its successor. The error named a declaration that cannot be made. Ancestry is followed
transitively now; a vintage outside the chain is still refused, which is the control.

## Verification

Each fix has a test that fails against the merged behaviour with a behavioural error, not
an import error - the guard call or the resolver was reverted, the helpers left importable:

    tests/test_coverage_key_rendering.py       6 failed, 7 passed
    tests/test_published_prediction_label.py   2 failed, 9 passed
    tests/test_input_artifact_vintage.py       1 failed, 10 passed

After: `1267 passed, 102 skipped` across the 1,370 tests in every registry, research,
coverage, prediction, holdout, label and temporal module. The one failure in that sweep is
`test_import_coverage.py::test_every_expected_import_resolves_in_current_image`, which
fails on `No module named 'okx'` - this worktree's venv, not the change. No case study was
run, no artifact regenerated, no registry written, no key added to `computation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXQMijYC3QFxNgJwxgUnZg
