### PR TITLE
The fx_pairs vintage divergence is over, so the guard stops claiming it is current

### DIFF
--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -171,9 +171,11 @@ def _enforce_input_artifact_vintage(db, spec: dict) -> None:
     under - and it is silent, so the mixture is found later by comparing the registry to the
     disk by hand, if at all (ml4t/agent-workspace#987).
 
-    Measured on the fleet 2026-09-07: `fx_pairs` has 138 training runs pinning one
-    `model_based` sha and **zero** of them match the file on disk. That state is safe only
-    for as long as nobody runs a modelling notebook there, and nothing enforced it.
+    The state this catches is reachable and was reached. On 2026-09-07 `fx_pairs` held 138
+    training runs pinning one `model_based` sha while no file on disk carried it; a
+    re-derivation later the same day put those bytes back. Nothing reported either change,
+    and a fit registered in between would have joined that population under a vintage no
+    other member was fitted on.
 
     Refusing here is what makes it cheap: `register_training_run` runs before the fit on
     every path, so the run stops at the moment the change can still be undone rather than


### PR DESCRIPTION
`_enforce_input_artifact_vintage` carried a dated fleet measurement as its motivation: 138 `fx_pairs` training runs pinning one `model_based` sha, zero of them matching the file on disk. Re-measured today across all nine registries, that is no longer the state anywhere.

```
features/model_based.parquet  sha256 731864eed053db47...  size 4117253
138 runs pin sha256           731864eed053db47...  size 4117253
```

Every (label, artifact) pair in all nine registries pins exactly one vintage, and every pinned vintage resolves to a live file under its case study - matched by size and confirmed by sha256, not by a guessed path. No registry holds an `artifact_supersessions` table, so nothing was declared to get there: the artifact on disk hashes what the population was fitted on again. The fx_pairs stage-04 artifact was rewritten 2026-09-07 16:44 and reproduces the pinned bytes exactly.

A reader checking the docstring's claim today would find the opposite and conclude the guard was motivated by fiction, so the paragraph now states the episode in the past tense and says what it would have cost. The guard itself is unchanged.

Docstring only, no behaviour change: `pytest tests/test_input_artifact_vintage.py` -> 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXQMijYC3QFxNgJwxgUnZg