### PR TITLE
us_firm_characteristics: the sweep has something to sweep, and its reader survives finding nothing

### DIFF
--- a/case_studies/us_firm_characteristics/11_backtest.ipynb
+++ b/case_studies/us_firm_characteristics/11_backtest.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "44e833e6",
+   "id": "3392037f",
    "metadata": {},
    "source": [
     "# US Firm Characteristics: Backtest and Equal-Weight Baseline\n",
@@ -41,13 +41,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8539ed0",
+   "id": "d163f789",
    "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Ch16 backtest and equal-weight baseline for US Firm Characteristics.\"\"\"\n",
     "\n",
-    "import sqlite3\n",
     "import time\n",
     "import warnings\n",
     "from collections import Counter\n",
@@ -81,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d3b93ab",
+   "id": "e0a5d58b",
    "metadata": {
     "tags": [
      "parameters"
@@ -118,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "180c8c43",
+   "id": "5334a681",
    "metadata": {},
    "source": [
     "The study is opened before anything resolves a path or reads the registry. Under the preview\n",
@@ -131,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a28ef1cd",
+   "id": "75466c09",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d30e686",
+   "id": "dfa1563d",
    "metadata": {},
    "source": [
     "## 1. Setup & Plumbing Test\n",
@@ -164,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "292d7a05",
+   "id": "e6ec9dfa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6539dc0",
+   "id": "5b40b1d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "978b026b",
+   "id": "3aa50ce8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9cd9bd1",
+   "id": "95e917b8",
    "metadata": {},
    "source": [
     "## 2. Parametric Sweep\n",
@@ -283,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe7d601f",
+   "id": "e48531ce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea26cdc5",
+   "id": "62a590fb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,13 +318,29 @@
     "total_backtests = n_predictions * n_schemes\n",
     "print(\n",
     "    f\"\\nTotal grid: {n_predictions} predictions x {n_schemes} schemes = {total_backtests} backtests\"\n",
-    ")"
+    ")\n",
+    "\n",
+    "# A grid with no schemes is a configuration error, not a result, and it is silent at the\n",
+    "# point it happens: `get_entry_schemes_for` drops each declared k that the cross-section\n",
+    "# cannot realize and returns the empty list, so the sweep below completes in zero seconds\n",
+    "# reporting zero failures, and every section after it reads a registry this run never wrote\n",
+    "# to. Refuse here, where the numbers that explain it are still in hand, rather than several\n",
+    "# cells later on whatever the first empty read happens to raise\n",
+    "# (ml4t/agent-workspace#1075).\n",
+    "if n_schemes == 0:\n",
+    "    raise RuntimeError(\n",
+    "        f\"No entry scheme in backtest.sweep.top_k_grid[{LABEL!r}] is feasible on \"\n",
+    "        f\"{n_assets} assets. A scheme needs k < n_assets, because k == n_assets is the \"\n",
+    "        f\"whole universe and that is the equal-weight benchmark rather than a \"\n",
+    "        f\"prediction-based portfolio; long-short additionally needs 2k <= n_assets so the \"\n",
+    "        f\"two legs stay disjoint. Widen the universe (MAX_SYMBOLS) or declare a smaller k.\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52dd7c8a",
+   "id": "ff95e286",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +480,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0964cc9d",
+   "id": "5454477b",
    "metadata": {},
    "source": [
     "## 3. Equal-Weight Baseline Evaluation\n",
@@ -489,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3deae08",
+   "id": "ad47ae09",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +516,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fe41b19",
+   "id": "4fafb81e",
    "metadata": {},
    "source": [
     "### The upper tail of the surface\n",
@@ -523,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a62988a",
+   "id": "389da496",
    "metadata": {
     "tags": [
      "results"
@@ -577,22 +592,16 @@
     "# this sweep, so on its own the table cannot tell a five-name portfolio from a fifty-\n",
     "# name one - the dimension the sweep exists to vary. The concentration is in the same\n",
     "# spec, one key across, and is joined back here.\n",
-    "with sqlite3.connect(str(CASE_DIR / \"run_log\" / \"registry.db\")) as conn:\n",
-    "    concentration = (\n",
-    "        pl.DataFrame(\n",
-    "            conn.execute(\n",
-    "                \"SELECT backtest_hash, spec_json FROM backtest_runs WHERE stage = 'signal'\"\n",
-    "            ).fetchall(),\n",
-    "            schema=[\"backtest_hash\", \"spec_json\"],\n",
-    "            orient=\"row\",\n",
-    "        )\n",
-    "        .with_columns(\n",
-    "            names_per_side=pl.col(\"spec_json\")\n",
-    "            .str.json_path_match(\"$.strategy.signal.top_k\")\n",
-    "            .cast(pl.Int64)\n",
-    "        )\n",
-    "        .drop(\"spec_json\")\n",
+    "concentration = (\n",
+    "    explorer.specs(\"signal\")\n",
+    "    .drop(\"stage\")\n",
+    "    .with_columns(\n",
+    "        names_per_side=pl.col(\"spec_json\")\n",
+    "        .str.json_path_match(\"$.strategy.signal.top_k\")\n",
+    "        .cast(pl.Int64)\n",
     "    )\n",
+    "    .drop(\"spec_json\")\n",
+    ")\n",
     "\n",
     "top = top.join(concentration, on=\"backtest_hash\", how=\"left\")\n",
     "print(top.select(\"source\", \"names_per_side\", \"sharpe\", \"cagr\", \"max_drawdown\"))\n",
@@ -618,7 +627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bba1481",
+   "id": "4e6f57a1",
    "metadata": {},
    "source": [
     "### By model family\n",
@@ -646,7 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac1be721",
+   "id": "a3467331",
    "metadata": {
     "tags": [
      "results"
@@ -666,7 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06d7975e",
+   "id": "440f895a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,7 +740,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afef882e",
+   "id": "c9fa758f",
    "metadata": {},
    "source": [
     "### Deflated Sharpe Ratio\n",
@@ -762,7 +771,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2386a485",
+   "id": "9127fced",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -773,7 +782,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5d6e3d9",
+   "id": "1eb8cc2d",
    "metadata": {},
    "source": [
     "### Sharpe Progression Preview\n",
@@ -788,7 +797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff148a9f",
+   "id": "ee38e560",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -802,7 +811,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4507df03",
+   "id": "70fb0546",
    "metadata": {},
    "source": [
     "## What this notebook establishes, and what it does not\n",

--- a/case_studies/us_firm_characteristics/11_backtest.py
+++ b/case_studies/us_firm_characteristics/11_backtest.py
@@ -49,7 +49,6 @@
 # %%
 """Ch16 backtest and equal-weight baseline for US Firm Characteristics."""
 
-import sqlite3
 import time
 import warnings
 from collections import Counter
@@ -254,6 +253,22 @@ total_backtests = n_predictions * n_schemes
 print(
     f"\nTotal grid: {n_predictions} predictions x {n_schemes} schemes = {total_backtests} backtests"
 )
+
+# A grid with no schemes is a configuration error, not a result, and it is silent at the
+# point it happens: `get_entry_schemes_for` drops each declared k that the cross-section
+# cannot realize and returns the empty list, so the sweep below completes in zero seconds
+# reporting zero failures, and every section after it reads a registry this run never wrote
+# to. Refuse here, where the numbers that explain it are still in hand, rather than several
+# cells later on whatever the first empty read happens to raise
+# (ml4t/agent-workspace#1075).
+if n_schemes == 0:
+    raise RuntimeError(
+        f"No entry scheme in backtest.sweep.top_k_grid[{LABEL!r}] is feasible on "
+        f"{n_assets} assets. A scheme needs k < n_assets, because k == n_assets is the "
+        f"whole universe and that is the equal-weight benchmark rather than a "
+        f"prediction-based portfolio; long-short additionally needs 2k <= n_assets so the "
+        f"two legs stay disjoint. Widen the universe (MAX_SYMBOLS) or declare a smaller k."
+    )
 
 # %%
 results = []
@@ -476,22 +491,16 @@ top = (
 # this sweep, so on its own the table cannot tell a five-name portfolio from a fifty-
 # name one - the dimension the sweep exists to vary. The concentration is in the same
 # spec, one key across, and is joined back here.
-with sqlite3.connect(str(CASE_DIR / "run_log" / "registry.db")) as conn:
-    concentration = (
-        pl.DataFrame(
-            conn.execute(
-                "SELECT backtest_hash, spec_json FROM backtest_runs WHERE stage = 'signal'"
-            ).fetchall(),
-            schema=["backtest_hash", "spec_json"],
-            orient="row",
-        )
-        .with_columns(
-            names_per_side=pl.col("spec_json")
-            .str.json_path_match("$.strategy.signal.top_k")
-            .cast(pl.Int64)
-        )
-        .drop("spec_json")
+concentration = (
+    explorer.specs("signal")
+    .drop("stage")
+    .with_columns(
+        names_per_side=pl.col("spec_json")
+        .str.json_path_match("$.strategy.signal.top_k")
+        .cast(pl.Int64)
     )
+    .drop("spec_json")
+)
 
 top = top.join(concentration, on="backtest_hash", how="left")
 print(top.select("source", "names_per_side", "sharpe", "cagr", "max_drawdown"))

--- a/case_studies/us_firm_characteristics/12_portfolio_management.ipynb
+++ b/case_studies/us_firm_characteristics/12_portfolio_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "42c5d385",
+   "id": "139bb81e",
    "metadata": {},
    "source": [
     "# US Firm Characteristics: Allocator Sweep\n",
@@ -40,13 +40,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "806614fa",
+   "id": "3a6cf691",
    "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"US Firm Characteristics: Portfolio: Allocator Sweep.\"\"\"\n",
     "\n",
-    "import sqlite3\n",
     "import time\n",
     "import warnings\n",
     "from collections import Counter\n",
@@ -79,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a498c71",
+   "id": "20f03322",
    "metadata": {
     "tags": [
      "parameters"
@@ -101,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75b07edc",
+   "id": "7f647a16",
    "metadata": {},
    "source": [
     "The study is opened before anything resolves a path or reads the registry. Under the preview\n",
@@ -114,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9df84334",
+   "id": "c9636405",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3800abb4",
+   "id": "b572f74b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dada9d98",
+   "id": "b58e708f",
    "metadata": {},
    "source": [
     "## 1. Which predictions advance\n",
@@ -157,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f42a9309",
+   "id": "eae90ae8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7deceb20",
+   "id": "5eda6b5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2118a59",
+   "id": "b08decac",
    "metadata": {},
    "source": [
     "## 2. Allocation Sweep\n",
@@ -246,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a43c8d6c",
+   "id": "2e7d7cde",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f053d44",
+   "id": "d371ded6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b425cb5",
+   "id": "3467bd90",
    "metadata": {},
    "source": [
     "## 3. Allocation Analysis\n",
@@ -368,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27f780df",
+   "id": "ad15a857",
    "metadata": {},
    "source": [
     "Every query below is restricted to this label and to the ten predictions section 1\n",
@@ -387,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e834594",
+   "id": "9f308da0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,29 +394,21 @@
     "\n",
     "explorer = BacktestExplorer(CASE_STUDY_ID)\n",
     "\n",
-    "with sqlite3.connect(str(CASE_DIR / \"run_log\" / \"registry.db\")) as conn:\n",
-    "    grid = (\n",
-    "        pl.DataFrame(\n",
-    "            conn.execute(\n",
-    "                \"SELECT backtest_hash, stage, spec_json FROM backtest_runs \"\n",
-    "                \"WHERE stage IN ('signal', 'allocation')\"\n",
-    "            ).fetchall(),\n",
-    "            schema=[\"backtest_hash\", \"stage\", \"spec_json\"],\n",
-    "            orient=\"row\",\n",
-    "        )\n",
-    "        .with_columns(\n",
-    "            allocator=pl.col(\"spec_json\").str.json_path_match(\"$.strategy.allocation.method\"),\n",
-    "            names_per_side=pl.col(\"spec_json\")\n",
-    "            .str.json_path_match(\"$.strategy.signal.top_k\")\n",
-    "            .cast(pl.Int64),\n",
-    "        )\n",
-    "        .drop(\"spec_json\")\n",
-    "    )"
+    "grid = (\n",
+    "    explorer.specs([\"signal\", \"allocation\"])\n",
+    "    .with_columns(\n",
+    "        allocator=pl.col(\"spec_json\").str.json_path_match(\"$.strategy.allocation.method\"),\n",
+    "        names_per_side=pl.col(\"spec_json\")\n",
+    "        .str.json_path_match(\"$.strategy.signal.top_k\")\n",
+    "        .cast(pl.Int64),\n",
+    "    )\n",
+    "    .drop(\"spec_json\")\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5810b9ab",
+   "id": "4fdf8335",
    "metadata": {},
    "source": [
     "Two frames carry every table below. The baseline is restricted to the concentrations\n",
@@ -432,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3fecb3a6",
+   "id": "01b98d5c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62f6487f",
+   "id": "a594a437",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44f844da",
+   "id": "61e9dfda",
    "metadata": {},
    "source": [
     "### How many paths went bankrupt\n",
@@ -485,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "405be42e",
+   "id": "4eb02955",
    "metadata": {
     "tags": [
      "results"
@@ -504,7 +495,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75bd8926",
+   "id": "4ab1c644",
    "metadata": {},
    "source": [
     "### By allocator\n",
@@ -542,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb81932a",
+   "id": "f1c686c0",
    "metadata": {
     "tags": [
      "results"
@@ -571,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd07c919",
+   "id": "ee44d850",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -622,7 +613,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecc1dfbd",
+   "id": "5fe93737",
    "metadata": {},
    "source": [
     "### The upper tail of the allocation grid\n",
@@ -647,7 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de0e18cf",
+   "id": "9c4ef294",
    "metadata": {
     "tags": [
      "results"
@@ -670,7 +661,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20cac7bb",
+   "id": "0d766ef9",
    "metadata": {},
    "source": [
     "## What this notebook establishes, and what it does not\n",

--- a/case_studies/us_firm_characteristics/12_portfolio_management.py
+++ b/case_studies/us_firm_characteristics/12_portfolio_management.py
@@ -48,7 +48,6 @@
 # %%
 """US Firm Characteristics: Portfolio: Allocator Sweep."""
 
-import sqlite3
 import time
 import warnings
 from collections import Counter
@@ -312,24 +311,16 @@ from case_studies.utils.backtest_explorer import BacktestExplorer
 
 explorer = BacktestExplorer(CASE_STUDY_ID)
 
-with sqlite3.connect(str(CASE_DIR / "run_log" / "registry.db")) as conn:
-    grid = (
-        pl.DataFrame(
-            conn.execute(
-                "SELECT backtest_hash, stage, spec_json FROM backtest_runs "
-                "WHERE stage IN ('signal', 'allocation')"
-            ).fetchall(),
-            schema=["backtest_hash", "stage", "spec_json"],
-            orient="row",
-        )
-        .with_columns(
-            allocator=pl.col("spec_json").str.json_path_match("$.strategy.allocation.method"),
-            names_per_side=pl.col("spec_json")
-            .str.json_path_match("$.strategy.signal.top_k")
-            .cast(pl.Int64),
-        )
-        .drop("spec_json")
+grid = (
+    explorer.specs(["signal", "allocation"])
+    .with_columns(
+        allocator=pl.col("spec_json").str.json_path_match("$.strategy.allocation.method"),
+        names_per_side=pl.col("spec_json")
+        .str.json_path_match("$.strategy.signal.top_k")
+        .cast(pl.Int64),
     )
+    .drop("spec_json")
+)
 
 # %% [markdown]
 # Two frames carry every table below. The baseline is restricted to the concentrations

--- a/case_studies/utils/backtest_explorer.py
+++ b/case_studies/utils/backtest_explorer.py
@@ -64,6 +64,18 @@ _BEST_SCHEMA: dict[str, pl.DataType] = {
     "ic_n_days": pl.Float64,
 }
 
+# Canonical schema for BacktestExplorer.specs() output. Declared rather than inferred:
+# polars types an empty column as Null, and `.str.json_path_match` on a Null series raises
+# SchemaError instead of returning an empty result. A notebook whose registry holds no rows
+# for the stage it asks about would then fail on the dtype, several cells after the fact,
+# reporting a schema problem for what is actually an empty sweep
+# (ml4t/agent-workspace#1075).
+_SPEC_SCHEMA: dict[str, pl.DataType] = {
+    "backtest_hash": pl.Utf8,
+    "stage": pl.Utf8,
+    "spec_json": pl.Utf8,
+}
+
 # ---------------------------------------------------------------------------
 # Result containers
 # ---------------------------------------------------------------------------
@@ -182,6 +194,33 @@ class BacktestExplorer:
         if df.is_empty():
             return {}
         return dict(zip(df["stage"].to_list(), df["n"].to_list(), strict=False))
+
+    def specs(self, stages: str | Iterable[str]) -> pl.DataFrame:
+        """Every backtest hash and its spec JSON for ``stages``, schema-stable when empty.
+
+        ``best()`` reports the metrics and the model that produced a run, not the strategy
+        dimensions a sweep varies - the entry scheme's ``top_k``, the allocator. Those live
+        in the spec, so a notebook that varies them reads them back here and joins on
+        ``backtest_hash`` rather than opening ``registry.db`` itself.
+
+        The columns of ``_SPEC_SCHEMA`` are returned whether or not any row matched, so a
+        caller's ``json_path_match`` sees String and yields an empty frame rather than
+        raising on a Null column.
+        """
+        wanted = [stages] if isinstance(stages, str) else list(stages)
+        if not wanted:
+            return pl.DataFrame(schema=_SPEC_SCHEMA)
+        placeholders = ", ".join("?" * len(wanted))
+        df = self._query(
+            "SELECT backtest_hash, stage, spec_json FROM backtest_runs "
+            f"WHERE stage IN ({placeholders})",
+            tuple(wanted),
+        )
+        if df.is_empty():
+            return pl.DataFrame(schema=_SPEC_SCHEMA)
+        return df.select(
+            [pl.col(name).cast(dtype).alias(name) for name, dtype in _SPEC_SCHEMA.items()]
+        )
 
     # -----------------------------------------------------------------
     # best: top backtests at a stage

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -3278,9 +3278,18 @@ case_studies/us_firm_characteristics/10_model_analysis:
   timeout: 300
 case_studies/us_firm_characteristics/11_backtest:
   parameters:
-    MAX_SYMBOLS: 5
+    # The sweep's entry schemes come from backtest.sweep.top_k_grid, which for every
+    # us_firm_characteristics label is [5, 10, 20, 50]. `get_entry_schemes_for` drops a
+    # scheme when k >= n_assets (that is the whole universe, i.e. the equal-weight
+    # benchmark) and, long-short, when 2k > n_assets, because the two legs must be
+    # disjoint. So the smallest declared scheme needs ten symbols, and at MAX_SYMBOLS: 5
+    # every member of the grid was filtered out: the sweep ran a 19 x 0 grid, registered
+    # nothing, and section 3 read an empty registry (ml4t/agent-workspace#1075). Twelve
+    # admits ew_top5 and matches 12_portfolio_management, so the two notebooks sweep the
+    # same universe.
+    MAX_SYMBOLS: 12
     TOP_K: 2
-  timeout: 120
+  timeout: 300
 case_studies/us_firm_characteristics/12_portfolio_management:
   parameters:
     # top_k_grid starts at 5, so a cap of 5 empties the grid and the sweep registers

--- a/tests/test_ufc_sweep_grid_is_feasible.py
+++ b/tests/test_ufc_sweep_grid_is_feasible.py
@@ -1,0 +1,183 @@
+"""The us_firm_characteristics sweep must have something to sweep, and its reader must
+survive finding nothing.
+
+`cs-us_firm_characteristics` was red on `main` from #828 until #1075. Four notebooks
+failed, and the reported errors named a polars dtype and two missing upstream results,
+none of which was the defect. The sweep in `11_backtest` had been running a
+`19 predictions x 0 schemes` grid: `get_entry_schemes_for` drops every declared `k` that
+the cross-section cannot realize, the CI universe was five symbols, and every member of
+`backtest.sweep.top_k_grid` needs at least ten. The sweep therefore registered nothing,
+in zero seconds, reporting zero failures, and each later section read a registry that run
+had never written to.
+
+Two things are pinned here, because either one alone leaves the failure reachable.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import polars as pl
+import pytest
+import yaml
+
+from case_studies.utils.backtest_explorer import BacktestExplorer
+from case_studies.utils.registry.store import _open_registry
+from case_studies.utils.sweep_config import get_entry_schemes_for, load_sweep
+
+CASE_STUDY = "us_firm_characteristics"
+REPO_ROOT = Path(__file__).parent.parent
+SWEEPING_NOTEBOOK = f"case_studies/{CASE_STUDY}/11_backtest"
+
+
+def _overrides() -> dict:
+    return yaml.safe_load((REPO_ROOT / "tests" / "overrides.yaml").read_text())
+
+
+def _declared_labels() -> list[str]:
+    return sorted(load_sweep(CASE_STUDY).get("top_k_grid") or {})
+
+
+# ---------------------------------------------------------------------------
+# 1. The configured universe must admit a scheme.
+# ---------------------------------------------------------------------------
+
+
+def test_the_ci_universe_admits_an_entry_scheme_for_every_declared_label():
+    """The parameters CI runs the sweep under must leave at least one scheme standing.
+
+    This is the assertion that fails on the pre-#1075 tree: `MAX_SYMBOLS: 5` against a
+    `top_k_grid` of [5, 10, 20, 50] yields zero schemes for every label.
+    """
+    max_symbols = _overrides()[SWEEPING_NOTEBOOK]["parameters"]["MAX_SYMBOLS"]
+    labels = _declared_labels()
+    assert labels, "no top_k_grid declared; this test is guarding nothing"
+    empty = {
+        label: get_entry_schemes_for(CASE_STUDY, label, max_symbols, long_short=True)
+        for label in labels
+    }
+    starved = sorted(label for label, schemes in empty.items() if not schemes)
+    assert not starved, (
+        f"MAX_SYMBOLS={max_symbols} leaves no feasible entry scheme for {starved}. "
+        f"The sweep would register nothing and every section after it would read an "
+        f"empty registry."
+    )
+
+
+def test_a_universe_below_the_smallest_declared_k_is_what_empties_the_grid():
+    """The premise of the test above: the filter, not the grid, is what can empty it.
+
+    Without this, raising MAX_SYMBOLS could look like a fix for a grid that was simply
+    never declared, and the first test would pass for the wrong reason.
+    """
+    label = _declared_labels()[0]
+    smallest_k = min(int(k) for k in load_sweep(CASE_STUDY)["top_k_grid"][label])
+    # Long-short needs two disjoint legs, so the universe must hold 2k names.
+    assert get_entry_schemes_for(CASE_STUDY, label, 2 * smallest_k - 1, long_short=True) == []
+    assert get_entry_schemes_for(CASE_STUDY, label, 2 * smallest_k, long_short=True) != []
+
+
+# ---------------------------------------------------------------------------
+# 2. Reading a registry that holds nothing must not fail on a dtype.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def empty_case_dir(tmp_path: Path) -> Path:
+    """A real registry, migrated by the real opener, holding no backtest runs."""
+    case_dir = tmp_path / CASE_STUDY
+    (case_dir / "run_log").mkdir(parents=True)
+    conn = _open_registry(case_dir)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM backtest_runs").fetchone()[0] == 0
+    finally:
+        conn.close()
+    return case_dir
+
+
+def test_the_positional_read_the_notebooks_used_raises_on_an_empty_registry():
+    """Why `specs()` exists. polars types an empty column as Null, and json_path_match
+    demands String, so the old hand-rolled read raised several cells after the sweep."""
+    rows: list[tuple[str, str]] = []
+    frame = pl.DataFrame(rows, schema=["backtest_hash", "spec_json"], orient="row")
+    assert frame["spec_json"].dtype == pl.Null
+    with pytest.raises(Exception, match="dtype"):
+        frame.with_columns(pl.col("spec_json").str.json_path_match("$.strategy.signal.top_k"))
+
+
+def test_specs_returns_string_columns_when_no_run_matches(empty_case_dir: Path):
+    specs = BacktestExplorer(CASE_STUDY, case_dir=empty_case_dir).specs("signal")
+    assert specs.is_empty()
+    assert specs.schema["backtest_hash"] == pl.Utf8
+    assert specs.schema["stage"] == pl.Utf8
+    assert specs.schema["spec_json"] == pl.Utf8
+
+
+def test_the_notebooks_json_extraction_survives_an_empty_specs_read(empty_case_dir: Path):
+    """The two expressions `11_backtest` and `12_portfolio_management` apply, on nothing."""
+    specs = BacktestExplorer(CASE_STUDY, case_dir=empty_case_dir).specs(["signal", "allocation"])
+    out = specs.with_columns(
+        allocator=pl.col("spec_json").str.json_path_match("$.strategy.allocation.method"),
+        names_per_side=pl.col("spec_json")
+        .str.json_path_match("$.strategy.signal.top_k")
+        .cast(pl.Int64),
+    ).drop("spec_json")
+    assert out.is_empty()
+    assert out.schema["names_per_side"] == pl.Int64
+
+
+def test_specs_reads_back_the_spec_of_a_registered_run(empty_case_dir: Path):
+    """The populated path, so the empty-frame tests cannot pass by returning empty always."""
+    conn = sqlite3.connect(str(empty_case_dir / "run_log" / "registry.db"))
+    try:
+        conn.execute(
+            "INSERT INTO backtest_runs "
+            "(backtest_hash, prediction_hash, stage, spec_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                "abc123",
+                "pred1",
+                "signal",
+                '{"strategy": {"signal": {"top_k": 7}}}',
+                "2026-09-07T00:00:00Z",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    specs = BacktestExplorer(CASE_STUDY, case_dir=empty_case_dir).specs("signal")
+    assert specs.height == 1
+    assert specs["backtest_hash"][0] == "abc123"
+    names = specs.with_columns(
+        names_per_side=pl.col("spec_json")
+        .str.json_path_match("$.strategy.signal.top_k")
+        .cast(pl.Int64)
+    )["names_per_side"][0]
+    assert names == 7
+
+
+def test_specs_does_not_return_a_stage_it_was_not_asked_for(empty_case_dir: Path):
+    conn = sqlite3.connect(str(empty_case_dir / "run_log" / "registry.db"))
+    try:
+        conn.executemany(
+            "INSERT INTO backtest_runs "
+            "(backtest_hash, prediction_hash, stage, spec_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                ("s1", "p1", "signal", "{}", "2026-09-07T00:00:00Z"),
+                ("a1", "p1", "allocation", "{}", "2026-09-07T00:00:00Z"),
+                ("h1", "p1", "holdout", "{}", "2026-09-07T00:00:00Z"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    explorer = BacktestExplorer(CASE_STUDY, case_dir=empty_case_dir)
+    assert sorted(explorer.specs("signal")["backtest_hash"].to_list()) == ["s1"]
+    assert sorted(explorer.specs(["signal", "allocation"])["stage"].to_list()) == [
+        "allocation",
+        "signal",
+    ]


### PR DESCRIPTION
`cs-us_firm_characteristics` has been red since #828. Four notebooks failed and none of
the reported errors named the defect.

| notebook | reported |
|---|---|
| `11_backtest` cell 17 | `SchemaError: expected String, got null for spec_json` |
| `12_portfolio_management` cell 15 | `SchemaError` (same) |
| `13_risk_management` cell 10 | `RuntimeError: No baseline or allocation results found` |
| `14_costs` cell 8 | `RuntimeError: No validation rank-1 candidate` |

## Cause

One number. `get_entry_schemes_for` drops each declared `k` the cross-section cannot
realize: `k >= n_assets` is the whole universe, i.e. the equal-weight benchmark rather
than a prediction-based portfolio, and long-short needs `2k <= n_assets` so the two legs
stay disjoint. us_firm_characteristics declares `top_k_grid [5, 10, 20, 50]` for every
label, so its smallest scheme needs ten symbols. `tests/overrides.yaml` ran the sweep at
`MAX_SYMBOLS: 5`.

```
n_assets=  5 -> 0 schemes
n_assets=  9 -> 0 schemes
n_assets= 10 -> 1 scheme  ['ew_top5']
n_assets= 20 -> 2 schemes ['ew_top5', 'ew_top10']
```

So the sweep ran a `19 x 0` grid. Quoted from the executed notebook, not reconstructed:

```
Entry schemes (0):

Total grid: 19 predictions x 0 schemes = 0 backtests
Existing equal-weight baseline hashes in registry: 0

Sweep complete: 0 backtests in 0s (0 failed, 0 skipped)
```

It registered nothing, in zero seconds, reporting zero failures, and every section after
it read a registry the run had never written to. After a full in-order run the preview
registry held 57 prediction sets and **0** backtest runs. The two `SchemaError`s are that
empty registry meeting a positional-schema read; 13 and 14 are 11 and 12 having written
nothing.

## Changes

Three, and the failure is reachable again without any one of them.

- **`tests/overrides.yaml`** — `MAX_SYMBOLS` 5 to 12, which admits `ew_top5` and matches
  `12_portfolio_management` so both notebooks sweep the same universe. Timeout 120 to
  300, because the sweep now runs 19 backtests rather than none.
- **`BacktestExplorer.specs()`** — a schema-stable spec read, replacing the hand-rolled
  `sqlite3` in both notebooks. polars types an empty column as `Null` and
  `json_path_match` demands `String`, which is why an empty registry surfaced several
  cells later as a dtype error. `_SPEC_SCHEMA` is declared for the same reason
  `_BEST_SCHEMA` is.
- **`11_backtest`** refuses when the grid comes back empty, naming `n_assets` and both
  feasibility conditions, instead of sweeping nothing and leaving the next reader to
  report whatever it happens to hit.

## Verification

The full in-order chain is the instrument that reproduces CI — a focused run of
`11_backtest` alone fails earlier, at cell 8, on preview predictions a full run has:

```
ML4T_DATA_PATH=~/ml4t/test-data/data \
  uv run pytest tests/test_case_studies.py -k us_firm_characteristics -q -p no:randomly

before:   4 failed, 14 passed, 3 skipped
after:   18 passed, 3 skipped
```

Green for a reason rather than green: the preview registry went from 0 backtest runs to
signal 19, allocation 4, cost_sensitivity 11, backtest_metrics 34.

`tests/test_ufc_sweep_grid_is_feasible.py` (7 tests) pins both halves. Against the
pre-fix overrides it fails:

```
FAILED test_the_ci_universe_admits_an_entry_scheme_for_every_declared_label
AssertionError: MAX_SYMBOLS=5 leaves no feasible entry scheme for
['fwd_class_1m', 'fwd_ret_1m', 'fwd_ret_1m_win'].
```

Full CI-equivalent unit suite: 4617 passed, 113 skipped. Seven `sp500_eoa` failures in
that run are an artifact of pointing `ML4T_DATA_PATH` at the small fixture locally; they
pass without it and are independent of these files.

No render is affected — both `.ipynb` are already output-free and unstamped on `main`,
and `notebook_provenance check` reports sync OK.

## Related

`sp500_equity_option_analytics` has the identical defect at `MAX_SYMBOLS: 3` against a
grid of `[5, 10, 20]` — zero schemes for both labels, either polarity — and its job is
green because its readers tolerate the empty frame where ufc's raised. Filed as
ml4t/agent-workspace#1084 rather than changed here: a first real sweep there has an
unmeasured cost. For the same reason `get_entry_schemes_for` does not start raising on an
emptied grid — that would turn a passing job red the moment this one is fixed — so the
guard lives in the notebook.

Closes ml4t/agent-workspace#1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQJrdyGw6wuWkGh5EQuLM2
