### PR TITLE
seoa: an empty population-scoped baseline read says what is wrong instead of dividing by zero

### DIFF
--- a/case_studies/sp500_equity_option_analytics/14_backtest.ipynb
+++ b/case_studies/sp500_equity_option_analytics/14_backtest.ipynb
@@ -2,16 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e6368524",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002307,
-     "end_time": "2026-09-02T01:48:15.488358+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:15.486051+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "b7a73206",
+   "metadata": {},
    "source": [
     "# S&P 500 Equity+Options: Backtest and Signal Evaluation\n",
     "\n",
@@ -41,23 +33,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "e511bede",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:15.492197Z",
-     "iopub.status.busy": "2026-09-02T01:48:15.492082Z",
-     "iopub.status.idle": "2026-09-02T01:48:17.694070Z",
-     "shell.execute_reply": "2026-09-02T01:48:17.693531Z"
-    },
-    "papermill": {
-     "duration": 2.204657,
-     "end_time": "2026-09-02T01:48:17.694584+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:15.489927+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "d270f57d",
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Ch16 backtest and signal evaluation for S&P 500 equity and option features.\"\"\"\n",
@@ -79,6 +57,7 @@
     "    open_sweep_attempt,\n",
     "    population_supersedes,\n",
     "    predictions_identity,\n",
+    "    published_population_names_at,\n",
     "    sweep_plan_name,\n",
     ")\n",
     "from case_studies.utils.backtest_explorer import BacktestExplorer\n",
@@ -111,22 +90,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "b36b32f0",
+   "execution_count": null,
+   "id": "3b034372",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:17.698395Z",
-     "iopub.status.busy": "2026-09-02T01:48:17.698317Z",
-     "iopub.status.idle": "2026-09-02T01:48:17.700283Z",
-     "shell.execute_reply": "2026-09-02T01:48:17.699900Z"
-    },
-    "papermill": {
-     "duration": 0.00445,
-     "end_time": "2026-09-02T01:48:17.700679+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:17.696229+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
@@ -146,23 +112,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "41e653ac",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:17.704020Z",
-     "iopub.status.busy": "2026-09-02T01:48:17.703881Z",
-     "iopub.status.idle": "2026-09-02T01:48:17.788510Z",
-     "shell.execute_reply": "2026-09-02T01:48:17.788023Z"
-    },
-    "papermill": {
-     "duration": 0.086981,
-     "end_time": "2026-09-02T01:48:17.789069+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:17.702088+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "2bfcdd82",
+   "metadata": {},
    "outputs": [],
    "source": [
     "set_global_seeds(SEED)"
@@ -170,16 +122,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "416b2133",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001373,
-     "end_time": "2026-09-02T01:48:17.792071+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:17.790698+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "cff8600f",
+   "metadata": {},
    "source": [
     "## 1. Setup & Plumbing Test\n",
     "\n",
@@ -192,16 +136,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25d63c93",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001423,
-     "end_time": "2026-09-02T01:48:17.794975+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:17.793552+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "15888567",
+   "metadata": {},
    "source": [
     "### What is asked for, and what it resolves to\n",
     "\n",
@@ -213,41 +149,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "df5111f0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:17.798263Z",
-     "iopub.status.busy": "2026-09-02T01:48:17.798181Z",
-     "iopub.status.idle": "2026-09-02T01:48:17.820754Z",
-     "shell.execute_reply": "2026-09-02T01:48:17.820376Z"
-    },
-    "papermill": {
-     "duration": 0.024801,
-     "end_time": "2026-09-02T01:48:17.821143+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:17.796342+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Protocol term sheet\n",
-      "  Case study:    sp500_equity_option_analytics\n",
-      "  Label:         fwd_ret_5d\n",
-      "  Calendar:      NYSE\n",
-      "  Cadence:       weekly_friday_close\n",
-      "  Commission:    3.9 bps\n",
-      "  Slippage:      2.6 bps\n",
-      "  Total cost:    6.5 bps/leg\n",
-      "  Long/short:    False\n",
-      "\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "60c90222",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "CASE_DIR = get_case_study_dir(CASE_STUDY_ID)\n",
     "bt_config = get_backtest_config(CASE_STUDY_ID)\n",
@@ -272,32 +177,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "462838b6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:17.824664Z",
-     "iopub.status.busy": "2026-09-02T01:48:17.824586Z",
-     "iopub.status.idle": "2026-09-02T01:48:18.606337Z",
-     "shell.execute_reply": "2026-09-02T01:48:18.606010Z"
-    },
-    "papermill": {
-     "duration": 0.784027,
-     "end_time": "2026-09-02T01:48:18.606794+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:17.822767+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Price support: 250,916 rows across 554 historical symbols; plumbing-test top-K=5\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "c82bb70e",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "prices = load_backtest_prices_for(\n",
     "    CASE_STUDY_ID, BACKTEST_LABEL, split=\"validation\", max_symbols=MAX_SYMBOLS\n",
@@ -321,32 +204,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "8bb8a980",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:18.610859Z",
-     "iopub.status.busy": "2026-09-02T01:48:18.610775Z",
-     "iopub.status.idle": "2026-09-02T01:48:18.997895Z",
-     "shell.execute_reply": "2026-09-02T01:48:18.997424Z"
-    },
-    "papermill": {
-     "duration": 0.389975,
-     "end_time": "2026-09-02T01:48:18.998421+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:18.608446+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Random signal Sharpe: 0.797  [PASS]\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "3824cc46",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "strategy_spec = build_backtest_spec(\n",
     "    CASE_STUDY_ID,\n",
@@ -389,16 +250,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "399a91ec",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00148,
-     "end_time": "2026-09-02T01:48:19.001564+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.000084+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "934900ae",
+   "metadata": {},
    "source": [
     "## 2. Parametric Sweep\n",
     "\n",
@@ -414,16 +267,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de7e1a77",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001373,
-     "end_time": "2026-09-02T01:48:19.004418+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.003045+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "a2813e57",
+   "metadata": {},
    "source": [
     "**A population is immutable and the registry keeps every generation, so a candidate set built\n",
     "straight from it counts retired members beside current ones.** Refitting a configuration under a\n",
@@ -448,32 +293,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "e0ee7cde",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:19.007907Z",
-     "iopub.status.busy": "2026-09-02T01:48:19.007798Z",
-     "iopub.status.idle": "2026-09-02T01:48:19.049519Z",
-     "shell.execute_reply": "2026-09-02T01:48:19.049131Z"
-    },
-    "papermill": {
-     "duration": 0.044119,
-     "end_time": "2026-09-02T01:48:19.049998+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.005879+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "947 prediction sets in the populations in force\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "ec8102b1",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# `Study.at` is the read-only form: one root, no activation. These notebooks only read the\n",
     "# populations - their backtests reach the registry by their own paths - and every other way in\n",
@@ -487,39 +310,20 @@
     "for _note in _population_notes:\n",
     "    print(_note)\n",
     "CURRENT_MEMBERS = _members\n",
+    "# Kept for the refusal below, which has to name what scoped the read. `_population_notes`\n",
+    "# reports gaps in coverage, not which populations are in force, and by the time the\n",
+    "# baseline read comes back empty the only thing that explains it is the names.\n",
+    "CURRENT_POPULATIONS = sorted(published_population_names_at(_study.root))\n",
     "if CURRENT_MEMBERS is not None:\n",
     "    print(f\"{len(CURRENT_MEMBERS):,} prediction sets in the populations in force\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "5fb8fde2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:19.053857Z",
-     "iopub.status.busy": "2026-09-02T01:48:19.053782Z",
-     "iopub.status.idle": "2026-09-02T01:48:19.070422Z",
-     "shell.execute_reply": "2026-09-02T01:48:19.070052Z"
-    },
-    "papermill": {
-     "duration": 0.019044,
-     "end_time": "2026-09-02T01:48:19.070727+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.051683+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Predictions to sweep: 289\n",
-      "  Fold-aggregate IC range: -0.0168 to 0.0156\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "30e0cda5",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "pred_index = load_prediction_index(\n",
     "    CASE_STUDY_ID,\n",
@@ -547,38 +351,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "6eb08634",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:19.074399Z",
-     "iopub.status.busy": "2026-09-02T01:48:19.074332Z",
-     "iopub.status.idle": "2026-09-02T01:48:19.086883Z",
-     "shell.execute_reply": "2026-09-02T01:48:19.086556Z"
-    },
-    "papermill": {
-     "duration": 0.014745,
-     "end_time": "2026-09-02T01:48:19.087116+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.072371+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Entry schemes (3):\n",
-      "  ew_top5: equal_weight_top_k (top_k=5)\n",
-      "  ew_top10: equal_weight_top_k (top_k=10)\n",
-      "  ew_top20: equal_weight_top_k (top_k=20)\n",
-      "\n",
-      "Total grid: 289 predictions × 3 schemes = 867 backtests\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "c8592a25",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "entry_schemes = get_entry_schemes_for(\n",
     "    CASE_STUDY_ID, BACKTEST_LABEL, n_assets, long_short=bt_config.long_short\n",
@@ -597,16 +373,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "653acc40",
+   "id": "f1986c4c",
    "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.001494,
-     "end_time": "2026-09-02T01:48:19.090242+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.088748+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
    "source": [
     "For each prediction set, content-addressed hashes identify concentration\n",
@@ -616,23 +385,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "7a8f7967",
+   "execution_count": null,
+   "id": "070f718d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:19.093828Z",
-     "iopub.status.busy": "2026-09-02T01:48:19.093708Z",
-     "iopub.status.idle": "2026-09-02T01:48:19.096397Z",
-     "shell.execute_reply": "2026-09-02T01:48:19.096106Z"
-    },
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.00487,
-     "end_time": "2026-09-02T01:48:19.096636+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.091766+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": [
@@ -686,16 +442,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6732958",
+   "id": "08a19b15",
    "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.001452,
-     "end_time": "2026-09-02T01:48:19.099654+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.098202+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
    "source": [
     "A single execution helper keeps the sweep cell focused on orchestration. It\n",
@@ -704,23 +453,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "5aba2561",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:19.103243Z",
-     "iopub.status.busy": "2026-09-02T01:48:19.103177Z",
-     "iopub.status.idle": "2026-09-02T01:48:19.105037Z",
-     "shell.execute_reply": "2026-09-02T01:48:19.104794Z"
-    },
-    "papermill": {
-     "duration": 0.004146,
-     "end_time": "2026-09-02T01:48:19.105358+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.101212+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "cc2b1d87",
+   "metadata": {},
    "outputs": [],
    "source": [
     "def _execute_one(pred_hash, spec, predictions, force_rebacktest):\n",
@@ -744,16 +479,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1af2fe35",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00149,
-     "end_time": "2026-09-02T01:48:19.108563+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.107073+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5e9d7253",
+   "metadata": {},
    "source": [
     "Progress counts include cached and newly executed combinations. A complete\n",
     "registry therefore finishes quickly without reading every prediction parquet."
@@ -761,16 +488,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b179936",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001523,
-     "end_time": "2026-09-02T01:48:19.111607+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.110084+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "e61c714c",
+   "metadata": {},
    "source": [
     "The grid is published as an official population *before* it executes, and checked with\n",
     "`require_complete` after. Recording it afterwards would say nothing: a sweep that stops\n",
@@ -787,32 +506,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "406bd48f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:19.115186Z",
-     "iopub.status.busy": "2026-09-02T01:48:19.115116Z",
-     "iopub.status.idle": "2026-09-02T01:48:20.741023Z",
-     "shell.execute_reply": "2026-09-02T01:48:20.740612Z"
-    },
-    "papermill": {
-     "duration": 1.628548,
-     "end_time": "2026-09-02T01:48:20.741696+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:19.113148+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Baseline plan sp500_equity_option_analytics-baseline-fwd_ret_5d-9fa26d693a25: 6c1ee0a4795f, 867 planned, attempt 2\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "c8060f71",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "planned_by_prediction = [\n",
     "    (pred_row[\"prediction_hash\"], _planned_backtests(pred_row))\n",
@@ -865,49 +562,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "be1a1008",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:20.745786Z",
-     "iopub.status.busy": "2026-09-02T01:48:20.745707Z",
-     "iopub.status.idle": "2026-09-02T01:48:34.348257Z",
-     "shell.execute_reply": "2026-09-02T01:48:34.347695Z"
-    },
-    "papermill": {
-     "duration": 13.605563,
-     "end_time": "2026-09-02T01:48:34.349060+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:20.743497+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Existing equal-weight baseline hashes in registry: 3,327\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Sweep complete: 0 run in 3s (0 failed, 867 already complete)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Baseline plan sp500_equity_option_analytics-baseline-fwd_ret_5d-9fa26d693a25 complete: 867 backtests\n",
-      "Sweep attested as sp500_equity_option_analytics-baseline-fwd_ret_5d-9fa26d693a25-g20568bc2ec73-swept-2\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "0a95c4da",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "t0 = time.time()\n",
     "completed = failed = skipped = 0\n",
@@ -977,16 +635,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f806f18",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001626,
-     "end_time": "2026-09-02T01:48:34.353594+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:34.351968+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "f4fcd0e4",
+   "metadata": {},
    "source": [
     "## 3. Signal Evaluation\n",
     "\n",
@@ -1003,32 +653,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "a04e28af",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:34.357442Z",
-     "iopub.status.busy": "2026-09-02T01:48:34.357365Z",
-     "iopub.status.idle": "2026-09-02T01:48:34.360018Z",
-     "shell.execute_reply": "2026-09-02T01:48:34.359612Z"
-    },
-    "papermill": {
-     "duration": 0.00514,
-     "end_time": "2026-09-02T01:48:34.360386+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:34.355246+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BacktestExplorer('sp500_equity_option_analytics', 4730 runs: allocation=1218, cost_sensitivity=85, holdout=2, risk_overlay=98, signal=3327)\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "152f9f01",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "explorer = BacktestExplorer(CASE_STUDY_ID)\n",
     "print(repr(explorer))"
@@ -1036,16 +664,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11316658",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001605,
-     "end_time": "2026-09-02T01:48:34.363679+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:34.362074+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "94102876",
+   "metadata": {},
    "source": [
     "### Eligible Leaders\n",
     "\n",
@@ -1058,75 +678,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "296667b6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:34.367497Z",
-     "iopub.status.busy": "2026-09-02T01:48:34.367429Z",
-     "iopub.status.idle": "2026-09-02T01:48:35.572671Z",
-     "shell.execute_reply": "2026-09-02T01:48:35.572272Z"
-    },
-    "papermill": {
-     "duration": 1.207693,
-     "end_time": "2026-09-02T01:48:35.573021+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:34.365328+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Eligible baselines: 2,841; median Sharpe: 0.437; positive: 96.3%\n",
-      "Leader coverage: 549 symbols across 497 validation dates\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (10, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>source</th><th>label</th><th>top_k</th><th>sharpe</th><th>daily_ic</th><th>cagr</th><th>max_drawdown</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;latent_factors/sae&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>10</td><td>1.298</td><td>0.0286</td><td>0.398</td><td>-0.331</td></tr><tr><td>&quot;tabular_dl/tabm_m&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>5</td><td>1.287</td><td>0.0183</td><td>0.68</td><td>-0.458</td></tr><tr><td>&quot;deep_learning/lstm_h64&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>5</td><td>1.264</td><td>-0.0028</td><td>0.597</td><td>-0.376</td></tr><tr><td>&quot;latent_factors/sae&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>20</td><td>1.224</td><td>0.0286</td><td>0.325</td><td>-0.322</td></tr><tr><td>&quot;latent_factors/sae&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>5</td><td>1.181</td><td>0.0286</td><td>0.377</td><td>-0.327</td></tr><tr><td>&quot;latent_factors/cae&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>5</td><td>1.161</td><td>0.0007</td><td>0.408</td><td>-0.342</td></tr><tr><td>&quot;deep_learning/lstm_h64&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>5</td><td>1.094</td><td>-0.0005</td><td>0.469</td><td>-0.396</td></tr><tr><td>&quot;deep_learning/lstm_h64&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>5</td><td>1.065</td><td>-0.0027</td><td>0.434</td><td>-0.366</td></tr><tr><td>&quot;latent_factors/cae&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>5</td><td>1.061</td><td>0.0028</td><td>0.333</td><td>-0.373</td></tr><tr><td>&quot;tabular_dl/tabm_m&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>5</td><td>1.049</td><td>0.0175</td><td>0.483</td><td>-0.511</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (10, 7)\n",
-       "┌────────────────────────┬─────────────────────┬───────┬────────┬──────────┬───────┬──────────────┐\n",
-       "│ source                 ┆ label               ┆ top_k ┆ sharpe ┆ daily_ic ┆ cagr  ┆ max_drawdown │\n",
-       "│ ---                    ┆ ---                 ┆ ---   ┆ ---    ┆ ---      ┆ ---   ┆ ---          │\n",
-       "│ str                    ┆ str                 ┆ i64   ┆ f64    ┆ f64      ┆ f64   ┆ f64          │\n",
-       "╞════════════════════════╪═════════════════════╪═══════╪════════╪══════════╪═══════╪══════════════╡\n",
-       "│ latent_factors/sae     ┆ fwd_ret_risk_adj_5d ┆ 10    ┆ 1.298  ┆ 0.0286   ┆ 0.398 ┆ -0.331       │\n",
-       "│ tabular_dl/tabm_m      ┆ fwd_ret_10d         ┆ 5     ┆ 1.287  ┆ 0.0183   ┆ 0.68  ┆ -0.458       │\n",
-       "│ deep_learning/lstm_h64 ┆ fwd_ret_10d         ┆ 5     ┆ 1.264  ┆ -0.0028  ┆ 0.597 ┆ -0.376       │\n",
-       "│ latent_factors/sae     ┆ fwd_ret_risk_adj_5d ┆ 20    ┆ 1.224  ┆ 0.0286   ┆ 0.325 ┆ -0.322       │\n",
-       "│ latent_factors/sae     ┆ fwd_ret_risk_adj_5d ┆ 5     ┆ 1.181  ┆ 0.0286   ┆ 0.377 ┆ -0.327       │\n",
-       "│ latent_factors/cae     ┆ fwd_ret_10d         ┆ 5     ┆ 1.161  ┆ 0.0007   ┆ 0.408 ┆ -0.342       │\n",
-       "│ deep_learning/lstm_h64 ┆ fwd_ret_10d         ┆ 5     ┆ 1.094  ┆ -0.0005  ┆ 0.469 ┆ -0.396       │\n",
-       "│ deep_learning/lstm_h64 ┆ fwd_ret_10d         ┆ 5     ┆ 1.065  ┆ -0.0027  ┆ 0.434 ┆ -0.366       │\n",
-       "│ latent_factors/cae     ┆ fwd_ret_10d         ┆ 5     ┆ 1.061  ┆ 0.0028   ┆ 0.333 ┆ -0.373       │\n",
-       "│ tabular_dl/tabm_m      ┆ fwd_ret_10d         ┆ 5     ┆ 1.049  ┆ 0.0175   ┆ 0.483 ┆ -0.511       │\n",
-       "└────────────────────────┴─────────────────────┴───────┴────────┴──────────┴───────┴──────────────┘"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "6cbb92d3",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "all_baselines = explorer.best(\n",
     "    stage=\"signal\",\n",
     "    top_n=9999,\n",
     "    prediction_hashes=sorted(CURRENT_MEMBERS) if CURRENT_MEMBERS is not None else None,\n",
     ")\n",
+    "\n",
+    "# An empty read here is a statement about the registry, not a result to summarise. The\n",
+    "# division below is the first thing to touch it, so without this the failure arrives as\n",
+    "# `ZeroDivisionError: division by zero` and reads like a defect in the analysis - which is\n",
+    "# how ml4t/agent-workspace#1086 presented. The population is in force and its members are\n",
+    "# registered; what none of them has is a backtest, and only the counts say so.\n",
+    "if CURRENT_MEMBERS is not None and all_baselines.is_empty():\n",
+    "    _signal_rows = explorer.specs(\"signal\").height\n",
+    "    raise RuntimeError(\n",
+    "        f\"The populations in force publish {len(CURRENT_MEMBERS):,} prediction sets and not \"\n",
+    "        f\"one of them carries a signal backtest, so there is no baseline to rank. \"\n",
+    "        f\"Populations: {', '.join(CURRENT_POPULATIONS) or '(none named)'}. \"\n",
+    "        f\"The registry holds {_signal_rows:,} signal backtest(s), all against prediction \"\n",
+    "        f\"sets outside the populations, so this is a population and a set of backtests \"\n",
+    "        f\"describing different generations rather than an empty registry. A fixture \"\n",
+    "        f\"generated through a stage earlier than the backtest stage produces exactly this: \"\n",
+    "        f\"the model notebooks declare the population and nothing goes on to backtest its \"\n",
+    "        f\"members (ml4t/agent-workspace#1086).\"\n",
+    "    )\n",
+    "\n",
     "search_context = {\n",
     "    \"total\": len(all_baselines),\n",
     "    \"median_sharpe\": all_baselines[\"sharpe\"].median(),\n",
@@ -1166,16 +747,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1c8c3ad",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001745,
-     "end_time": "2026-09-02T01:48:35.576699+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:35.574954+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "c6b961b1",
+   "metadata": {},
    "source": [
     "Downstream selection is label-specific and admits one checkpoint per distinct model\n",
     "configuration. The primary label carries its own lineage: whichever configuration leads the\n",
@@ -1185,61 +758,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "e0e3d13c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:35.580622Z",
-     "iopub.status.busy": "2026-09-02T01:48:35.580543Z",
-     "iopub.status.idle": "2026-09-02T01:48:35.931213Z",
-     "shell.execute_reply": "2026-09-02T01:48:35.930881Z"
-    },
-    "papermill": {
-     "duration": 0.353035,
-     "end_time": "2026-09-02T01:48:35.931482+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:35.578447+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (10, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>config_name</th><th>checkpoint_value</th><th>sharpe</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;lstm_h64&quot;</td><td>60</td><td>0.996</td></tr><tr><td>&quot;latent_factors&quot;</td><td>&quot;sae&quot;</td><td>10</td><td>0.939</td></tr><tr><td>&quot;latent_factors&quot;</td><td>&quot;ipca&quot;</td><td>0</td><td>0.918</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_s&quot;</td><td>100</td><td>0.896</td></tr><tr><td>&quot;gbm&quot;</td><td>&quot;leaves_7_huber&quot;</td><td>150</td><td>0.874</td></tr><tr><td>&quot;gbm&quot;</td><td>&quot;leaves_31_mae&quot;</td><td>300</td><td>0.866</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;nlinear&quot;</td><td>20</td><td>0.864</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;patchtst&quot;</td><td>5</td><td>0.786</td></tr><tr><td>&quot;latent_factors&quot;</td><td>&quot;cae&quot;</td><td>35</td><td>0.781</td></tr><tr><td>&quot;latent_factors&quot;</td><td>&quot;pca&quot;</td><td>0</td><td>0.772</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (10, 4)\n",
-       "┌────────────────┬────────────────┬──────────────────┬────────┐\n",
-       "│ family         ┆ config_name    ┆ checkpoint_value ┆ sharpe │\n",
-       "│ ---            ┆ ---            ┆ ---              ┆ ---    │\n",
-       "│ str            ┆ str            ┆ i64              ┆ f64    │\n",
-       "╞════════════════╪════════════════╪══════════════════╪════════╡\n",
-       "│ deep_learning  ┆ lstm_h64       ┆ 60               ┆ 0.996  │\n",
-       "│ latent_factors ┆ sae            ┆ 10               ┆ 0.939  │\n",
-       "│ latent_factors ┆ ipca           ┆ 0                ┆ 0.918  │\n",
-       "│ tabular_dl     ┆ tabm_s         ┆ 100              ┆ 0.896  │\n",
-       "│ gbm            ┆ leaves_7_huber ┆ 150              ┆ 0.874  │\n",
-       "│ gbm            ┆ leaves_31_mae  ┆ 300              ┆ 0.866  │\n",
-       "│ deep_learning  ┆ nlinear        ┆ 20               ┆ 0.864  │\n",
-       "│ deep_learning  ┆ patchtst       ┆ 5                ┆ 0.786  │\n",
-       "│ latent_factors ┆ cae            ┆ 35               ┆ 0.781  │\n",
-       "│ latent_factors ┆ pca            ┆ 0                ┆ 0.772  │\n",
-       "└────────────────┴────────────────┴──────────────────┴────────┘"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "e737f8f0",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "primary_advancing = resolve_best_predictions(\n",
     "    CASE_STUDY_ID,\n",
@@ -1259,16 +781,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b3dde89",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001783,
-     "end_time": "2026-09-02T01:48:35.935291+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:35.933508+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5b45fa5c",
+   "metadata": {},
    "source": [
     "### Family Dispersion and IC Translation\n",
     "\n",
@@ -1283,23 +797,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "9b861f94",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:35.939374Z",
-     "iopub.status.busy": "2026-09-02T01:48:35.939283Z",
-     "iopub.status.idle": "2026-09-02T01:48:35.942780Z",
-     "shell.execute_reply": "2026-09-02T01:48:35.942488Z"
-    },
-    "papermill": {
-     "duration": 0.006041,
-     "end_time": "2026-09-02T01:48:35.943127+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:35.937086+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "7e2c5560",
+   "metadata": {},
    "outputs": [],
    "source": [
     "families = (\n",
@@ -1324,35 +824,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "045aee71",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:35.947737Z",
-     "iopub.status.busy": "2026-09-02T01:48:35.947634Z",
-     "iopub.status.idle": "2026-09-02T01:48:36.031522Z",
-     "shell.execute_reply": "2026-09-02T01:48:36.031147Z"
-    },
-    "papermill": {
-     "duration": 0.086701,
-     "end_time": "2026-09-02T01:48:36.031854+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:35.945153+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFVCAYAAAAUvhB3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAWZ1JREFUeJzt3Xd0FNX/xvH3pocaIPQQei+hV+ldRAQpUkR6UxBFilTpvXcIvQgioiggoKBUQVqAEDqEXgKEkspm9/dHyEo2hfD9QTaa53UO55Cd2Xs/c3d28+TO7IwhPDzMjIiIiIhY2Nm6ABEREZGkRgFJRERExIoCkoiIiIgVBSQRERERKwpIyURoaBhFytZl8MjJAKz57ifcPLz4Y+9fNq4sktFoxM3Di55fDAPgpy2/kbPoOxw5dtJmNVmP2f/K//pN3Dy8GDNpzhuqLGkrXrEhTT7qZpO+o/brg4eP2aT/12GrfbxI2bo0at45UfsU+TdSQEoCildsiJuHV7R/3Xp//Ub7cHFxZtXiaXzWrf0bbfdtqV2jMmu8Z1CiWGGb1RDbmBUoVYvxU+fbrKaEWLrqO9w8vP5zfcXm3/B6xCUp7OOJqVOvAQpm8q/iYOsCJFKBfLkZPqiP5efsWTO/8T7KlCr+xtt8W1KlTME7lcrauoxoYxYREUHAg0c2rCZh7t578J/sy9q/5fWIS1LZxxOLLfcVkf+FZpCSiPTp0vJeg1qWf6W8igKwYdNWGn7YEc8i71CsfH1Wrv3B8pxGzTvTvls/JkxbQOEydahQsyl79h/Ge8V6SlRqSLHy9dm956Bl/bhmpv7Y+xduHl78sPlXy2OfDxhFwdK1iYiIiLaum4cXU2d706331+QqWpWGzTrgf/0m/YeMI0/x6tRs1IZrN25Z1j905AR1GrfDo2Al3v2wExcuXbUs+3PfISrVbkauolUZOHxitH6sDwH+tns/zdr2IE/x6hQoVYuJ0xdY1u35xTBqNWrDstUbKFe9CbmLVWPW/OX/9LP/EJVrf0i2/BWo1agNu/48EGMMFixZQ9Fy9fAsXIVWn3zGpcv+0cbM//pNMuQsjclkYuL0Bbh5eLH3wN/R2jCbzaxe/yMVazUle4GKNGzWgStXr8foK6qmWo3akL1ARWo1asOe/Ycty076nqVO43ZkzVeByrU/5LsftgCRgWDanCUUq9CAfF41GDRiEuHhz6O12/OLYZaxcfPwsvzF/iwomP5Dx1OwdG0Klq7NgGETeBYUbHnez9t+p1z1JqTLUdIyi9mg6ScABAY+4dN+w8ldrBqlqrxn2Qfj6gsgLCyMYaOnUahMHYpVaMCf+w5Zlp09f4kmH3XDo2Alqjf8iL+PRh5iijoU+cPmX2nerhe5i1UjLCycj7t+Sa1GbaLti696Pf4+epL6H3xCjkKV6dRrAM+fP0/wGELkrO7A4RMZMGwCeUvUoGr9lvj6XWD81PkUKlOHctWb4HPaD4DgkBCmzVlClbotyJa/AlXqtuDwUR8A1m7YjJuHFxs2bQVg0IhJZC9QkTt378fYx1/n/Ww0GvFesZ5ajdrgUbASpd9pzLadf8S6r/mc9qP2e23xLFyFrp99TUhoWIzl77XojEfBSlSu/SE//rIj1nYaNe/Mx12/ZPLMRRSv2JACpWpZ9k2Ifx8rXrEh+/86wv6/juDm4fWvnfWT5EUBKYkwGiMIfPzE8s9kMgFw8PAxypUqwZhhX5IhQzq++HoM/tdvWp63eetvnPI9S5+eHbl56w7NP+7F5q2/0atLO548fZag82eqVSmPR/as/PjLTiDyF/2O3/fwfsPa2Nvbx1h/7OS5ZMmcifatm3Hw8HHKVW9ChMlEx3bNOe7jy+wX4eTqtRs0bd0dOzs7xn3TH4PBQIce/TGbzVy/eZtWn/TGYIhc9vy5Md4ajxw/RZ5cnowa+gWFC+Zj/NT50c4zOebjy3ebttKrazvcM6Rj5IRZBDx4CECPPkPAYGDCqIEULVyAsPDwaG1fuuzPoBGTKF2yGCOH9CVFClccHKNPrmZ0T8/UcUMAaPZ+fVZ7T6dIoXzR1lm7YTOf9RtBvjy5GD9yAEULFyBzZvcY23Lm7AWat+tFypQpmDx2MK6urnzYrid+5y4C0H/IeO7cvc+EkQN4p3I5QkJCAZizcCWjJsyiUf2afN2vF2u/+4lFy7+N1nb3Tm2oXKEMAKu9pzN0wKcA9B0wipXf/kCvLu3o2bkty9d8z5eDRgORYaNTrwFkyZyR8d/0J306N6q/U4FhA/tgNpvp2vtrfvl1F317deTDJg3oM2AkJ06eibMvgL/+PsHDwED69OzAo0eBDB45BYDAx0/4oHV37t67z+hhX+LpkY02nT8nOCTE8tzPB4zCI3sW5s8YjbOzE1ev3eDGrTvR9pFXvR6Lln1Li6bvUql8aX7YvJ1ff9uT4DGMsnDpWkJCQundvT2nz5ynZqPWnLtwmV5d2nHpyjXGTZ4LgJ3Bjj/3HaLFBw0ZPqgP9+4H0L3PEMxmM62bN6ZS+VJ8M24GN27dYfnq7/nis85kyZwx1j4T+n62t7fnj71/UbdWVUYN/QKz2Uz3z4dGC70AT58F0bL9Z9y9F8CY4f3ImiUTj588tSy/ey+AJq26Efj4KRNHDyJvnpx06NE/2h9WL/t52+8c8/Hl854dMBgMDBg2wRJc49vHZk4cRjq3tBQumJfV3tP5sEmDWNsXSUp0iC2JOHL8FLmKVrX8fOnkH2RIn45p44cSEhLK8ZNnKO1VFJ9Tfhz38SVnjuwAZMqYgdXe0zEYDOzec5Adu/ayfvlsXF1d2L3nIL/9cQCTyYSdXdxZ2M7OjtbNGzN7wQqeBQVz6Yo/t+/ep8l79WJdv0mjOowa+gUREREsXfUdBfPnYdr4oZhMJhYuXcu5i1cAWL3+R4JDQpk95RsyZ3LHPUN62nT6nKv+N/hpy05Cw8KYM+UbSpcsxvvv1mHltz/E2h/AoC978Pz5c06c9KN8GS/+3HeIv4+epFL50pZ1flg9H1dXFx4FPmHUhFlcvnod9wzpSZ06FY6ODlQqX5r2rZvFaNvZxRlHRwdSpkzB++/WoWO7FjHWSeHqSs2qFQHInzc37zWoFWOduYtWkSeXJysWTok1WEZZtvp7nj83Mm38UPLnzUVpr6JUrNWMZau/Z9LoQaROlRIMBryKF+aTth9anrdo2bdUrVyOr/v1BGD/X0fY8uuuaOdIlSxeGI9skYdno2p8+CiQ73/axodNGvB5r44AnDjlx3ebtjJx1CBOnPTj+XMjwwb2pnwZL86ev8SR46epUrEMV65eZ+fuffT/vFtkLWZY+91P/LJ9F0P7fxajryhlShZj7tRRAPy2ex/7Dh4BIgPAnbv3mTdtFKVLFqNMqeJUq9+Kv4+eJFdODwAqlivF9AnDMBgMAPz+8xqeG5/j4uKc4Ndj+oRh1K31DiWKFWLHrr2WmcuEjOHL2zB7yjcArNv4Mw8fPWbZ/EkYDAa+/X6zZT93cXHmp3WLePDwEcd9zpAvby4OHjrGg4ePcM+Qniljh1CtQSs++Kgb7hnS8WnXj+PcN17n/bzaezpPnj7j+ElfihUpwM/bfuf8hcuULlnM0t7OXXu5ey+A5Qsm88GL9/Pq9T9aln+3aQuBj5+wZO4EateownsNarF1xx8sXPYtNatVirW+tUtmYDAYOH3mHMvXbOR+wEOcnBzj3cdqVa+Mq4sz6dOli/W9I5IUKSAlEUUK5mPi6EGWn9OkTgVE/hU7buo87Ax25H7xC+TJk2eW9Rzs7S2/SDJkSAeA44vZj/Tp0xEREfHKgATQtmUTJs9cxI7f93D56nUyZ3KnUvlSsa7r6BDZvr29PenSuVn6s7OzI106N8JfzND4+0fOdFWo2TTa8+8/eGg5DJcnt2e8dUX58ZcdDBw+kaCgYIoWLhA5Dk+fRVsnqg739JHjEBYWWceGVXMZM3EOFWs1o17tqowd1i9avx7ZsvDTusWMHD+TouXq80nbDxk2sDepUqZIUG1Rrvpfp1b1yvGGIwD/azdJ4epCvjw5ASiYPw8pXF3wv3YDgAUzxzBx2gLqfdCesqVKMHZ4P4oWLsDN23e5eftutCAd1Ub8dUW26/XSycClShThx192cPXaDYoVzo/BYOD7H7eRwtWV/X8dJU+uHJHPfVHT5JmLmDxzkeX5AQEP4+3T8aUZOPf06SyHsfyvRe4Tzdr2jLb+/YCHloDkVbywZZ8GcHJyxMnJ8ZXbGVv/L+8L4eHPX2sMX96GDOnT8+TJM0td6dOl48rVawCEhz+n3+CxfPv9z2TPlhknx8hanzx5hnuG9BQplI+ihfNz8vRZhg3sjaurS5x1J/T9bDAYGDNpDvMWryZt2tRkeLGd1u+Ja9fjf59FvR5exSP3jbRpUpMvT07Lvhhffe4Z0gMQFh7Ordt3I9uJYx9Lly5tnNssklQpICURadKkomrlctEe879+k4HDJzJ8UB/69urI/r+O0rhll7fSf66cHrxTqSxbt//B3fsBcR5eex05PSNnuVYtnoZb2jSWx4sUyk+mjJGHnnxO+1G9SgXM5rhvCRgaGkb3z4fQtmUTJo0exM3bd/Gq9G7C68iRncVzxjNsUG/ea9GZz776hq0bl0Zbp3KF0mz/cQV/7j/Eh217kTZNagZ/1SvaOnb2kSEzLCz6ORxRPHNkw+/cRSIiIuIdu5ye2S2zGgXy5ebchcsEh4SS0zMyILhnSM/ksYMZ+GUPPurQh4+79eP0oV/JliUT2bNliXYyf2whzu5F36GhYbi4OFuCx4lTZyzrHD8Z+f9cnh64uaWhfp1qLFr2LYuWfUvmTO4MGfCZZewAOn3cgqaN61ueH/UlAuu+XiWqvekThpIvTy7L40UK5YtxeOhVXvV6WHNyckzwGL6ODT9uZdW6TWz/cQUVypZk/NT50c6R27zlN06fOU/ZUsVZtmoD3Tu1+X/3ue/gEabO9mbx7PE0/6Ahazds5tMvh8dYL1OmF++zU36UKFoIINp7Leo9euKkH3VqVuHxk6dcvOxP3VrvvFY9r9rHIHJfSehrJZIU6BykJCzq3JMTJ8+wdsNmho+d/sbazpYlE4Dl0AdA21YfsGPXXg4f9Ynz8NrraNPifVxdXJg62xu/cxc57uPL6TPnSZUyBY0b1gZgzMQ5rN2wmW59BsfZznOjkefPjZy7cIXvNm2l78BRCa7B//pN6jRux9zFq/hj71+Ehz/H3j76br91xx+836orK9ZsxOekH0ajMcY6AJkzuuPi7Mwvv+7ih82/cvdeQLTlnT5uyaUr1+jUayDrN/7C5wNGcdX/Bu4Z0uHg4MBxH1+eBQXToW1zHB0d6Dd4LGs3bKbf4HE4OjrQsV1zAh8/oUHTT5g625sdu/bxLCjIUkuXDh/x97GTrN/4C/7Xb7L99z3RZlqiRP1Cmjh9AXv2HyZ9OjeaN2nIlu27mTlvGTPmLmXrjt20bPou6dKl5fKVa/y68096dG7LV593ZeKogTg7OQGQO1cOalWvxIZNW9m95yBX/K/z05adZMyYIda+XqVxw9pkypiBOQtXcuLkGXz9zrPv4BHLDEhsOn86kEbNO8f4wsCrXo/YJHQMX0fU+/S33fuZ772GZas3WJYFh4QwZPRUmn/QkPkzxnDnXgDjp877f/X3cp8HDx9jxZqNTJ3lHet6dWpUIYWrC7PmL2fNdz/xab/hPAp8bFne4oN3SZs2Nd+Mn8ma737is34jiIiIoHvH1q9Vz6v2MYBcntk56XuW1et/5PSZ8//jloskHgWkJKxQgbz06dGB3XsOMm/RKnp2bvvG2i5f1otiRQqyZOV3ll88779bG5PJhFvaNHEeXnsdeXJ78uO6hTg7OTFy/EwWr1jPw0eBmM1mihbOz/wZY7gX8IARY6dTpGA+CubPE2s7qVOlZNyIr/D1O8/kGYto3LA2Gd3TJ6iGrJkzUbNaJRYvX8eg4RPJlycn08YPjbZO2VLFyZI5I2Mmz2HanCW0+vA9Puse85wUV1cXJo4ayOMnTxkwbALHT/pGW97lk1aMHfEVJ0+fpd/gsVy/eYvnRiMpU6Sg1YeNOHDoGGfPXaRo4fx8v2oeT54+46vBYwkKDub7VfMoXDAfaVKn4oP36vHdD1vo9/VYUri64j17AgB9enzCN19/zr6/jjBg6HgOHjoW45BKZB0teadSWRYuXcv0uUsAmD5xGB9/1JQ5i1Yyz3s1n7RuxrQJkRfl9MyRjfx5c7Fy7UamzFxMhx79qVCzKSPHz8RgMLBkzkSaNq7P6vU/MmzMNG7cusPDR4Fx9hWfdOnSsnn9YnJ6ZmfSjIXMnLeMgAcPY/0mWZRnz4LY/9cRzrw4iT2hr0dsEjqGr+Oj5o2pU6MK8xavYtvOP6KdzzRj7jJu37nHoC96kD9vLnp1aceCJWs56Xv2/9Vn7RqVadmsEes3/sKqdZvo0+OTWNfLlDEDqxZPw2AwMGTkFJwcHalWpbxleZbMGdm8fjFpUqdiwNDxXLh0haXzJsZ6/tGrxLePAXzz9ed4emTj6xGT+GnLztffaJFEZggPD4v72IYkK8EhIRSv0JC2LZswaugXti5HEsnSVd8xfup8fA5uJYWrK0+ePqNxyy4YjRHs37nh1Q28ZQ8ePqJw2boc37eF7Nne/PXBRERio3OQBIDdew6yZOV3PDca6ftpR1uXI4noxs073A94yISpCyhcKB+nfM9GzoL1eTvnu72OR48e07RND9q1+kDhSEQSlWaQBJPJRIlK72IwGBg34ivL+UGSPAQGPqHfkLH89sd+wsOekytndtq2+oCendv+v0/U//8yGo1s+nkHzd6vb/NaRCR5UUASERERsaKTtEVERESsKCAlAU3b92XSrGXRHlu4YgOV6rd77bba9xzMMZ/I64/MWrSWIyde/c2ehNZ4/pL/G2nrbfrzwBF69R+TaP0dOeHLrEVrE62/hHh5DC5dvc7ISUnvvlcDv5nOlh173lh7o6csZN0PkfcSTMhrEh7+nAEjpvHgYSAQ//5dqX47nj4LemO1vilv6z25ZsMWtu/aH+86x3zO0L5n7JfmuH3nfpzvwV79x/DngSOxLnsTbt+5T91m3Sw/j5w0n0tx3A9R5FV0knYSkCZ1So6c8CU8/DlOTo6YTCb2HDhKOrc0r35yPPp0a/OGKpS4lC1ZlLIli9q6jDjlzZWDEQN6vnrF/5CEvCZOTo5MGvllIlX079K2RSNbl/DGJLd9X94sBaQkwGiMoHSJwhz4+wQ1qpTDx/c8+XJ7cvDvE5Z1TvtdZNq8lQQFh5A1szvD+/cgfbq03LkXwIQZS7gf8IjsWTMR+NKNKAd+M51qlcvQqF41Dv7tw8p1mwkKDgGDgW8G9CRPLg+O+Zxh9YYt5MiemSPHz4ABJo/80nIhyZdt2bGHqReuEPDgEc3eq0PbFo0wmUzMW7qeYz5nCAoOoUjBfAzt1w17eztGT1lIwXy52L3vb4oVykejelUZOWkBQcEhuKVNzchBn5L1pZu5+p69yMLl3xP45CnPnz9nQJ9OlCpeiNt37jNw5HSqVynHvr+O8fjJM8YO7U3hApHXTfp+807Wb/qVtGlSxRkqe/UfQ813yvPn/iNcv3mHnp1aEvAgkJ1/HiQs7DkThvcll2c2/K/fYo73t9wPeERQcAg9OrakdrUKbN+1n83b/mDOpMHcuRvAZwPHsWLeWI76nGH9pl+ZN3moZSyzZsnIkeOnyZzRnd5dW+O96gd8z13k3TpV6dX5IyByVmLHxoWkTpWS85f8GThyOptWzrBsa5WKpdhz4CjOTo583bcLq777mZO+FyhZvCAjBvSMcXHDuMbg5bZDQkOZuWAN5y/58/RZEDWqlOPTLh+91viYzWZWrNvMzt0HMZvNVCxbgp6dWuHo6ID3qo2EhoVz6/Y9/C5cIU9ODyaO6IuDgwNPngYxadZSLly+RpZMGQh4MXMDsPHnnazZsBVHR3sqlvWib492bPhpBydOnWXcsM+jbaf/9VtMmrWMB48ekyZ1Sob264anR9Zo6/x54IjlNXkWFMzoyQs5f9mf+/cfkiZNKiqV82LYV92p26wbK+eNJWuWjHHu39YS0v8v2/9kzfdbiIgwUa50Mfr1ao+dnR3HT51l+vxVYDaTL48nfx44wu+bvLl95z7tew1h5w+LYtT/4GEgMxeu5satuzx5GkTLD+rT8oP6Meqy3v51P/zK/CmR90d8t1Uv2rV8j3Yt3uPcxauMn+7N8rlj4tyW6fNXkTpVCrp8/CEXL19j3HRvHj56zN37D8ieNROtmjYgby4Pwp8bmbVwDYeOnQIzTBr5Jfb2dvQeNJ6Hjx7TvudgOrVtSo13ot8h4OBhH9Zv+pV79x9StVJp+nRri8FgYM2GLfy+5xAhoaFky5KRUV9/RsoUrvyx72/meH+Lvb0dBfPlYnj/Htjb27Ni3Wa2/bYPs9lMwzrv0LHNBzHGon3PwfTt0Y7SXkXo1X8MtatVYM+Bo1y4dI0P369D53aR92aM6/N14YoN/PrbPpycHGlcvwbtWr4X79jLf4sOsSUBoaFh1KtVmW2/7QNg2297qV+rMs+CIu9w/vRZEOOmLWb8sM9Zv2Qy1auUZcW6nwAYPXkhpb0Ks2bRBIb064p9HPdcy5YlIxNGfMHK+eOoVbU8S1b/c2PY034XeLduNVYtGIdn9qz8tHV3rG1kyezOgqnDWDzjG5au2cSlq9exs7Oj5jvl8J45kjWLJnL2wmUOHT1pec73m3cy6Zsv+LTLR/zwy+8UK5yP75ZOYeSgT8mcMfrFHt3Tp2Nov66snDeWDq0/YPZLh0kuX71B8cL5WDp7FNWrlOHbjdsAOHbSjzXfb2HB1GF4zxxJyWKF4hznC5f9mTF+IP0+/YSRkxbg6ZGV5XPGUKxQXr7fHHnhOre0afisS2uWzx3DsK+6M3XOCsxmM/VqVsbR0YHtu/Yzf9l39OzUKtbbRZz2u0CThjVZs3ACz4KCmL5gFcP7d2fxjJGs3rCFhy9dxTgul6/eoFTxwqyaP45MGTMwYsI8+nRry5pFE9h78BhnL1yJtn5Cx8DF2Zn36ldnyayRrJw/lp+27eLKi/vlJXR8tu/az76/juE96xtWzh/LzTv3WPP9FksbR0+cYUCfTny7aCLnL/lz1McPgFkLV5MmdSq+XTyRCSP64uL8z21J5i1dz7hhfVizaCKtP2yIwWAgvVtasmWNHtKNEREMGzeHL3p+zDrvSXRq25Q5i7+Ndyw3/vwbxggjG5dPY+H0Ebi6ODPsq+6xrhvb/v26/fv4nufXXftZNmcM3y6exLNnwew5eJQnT4MYMnoW/Xq1Z+X8cbRoUo/g4NB4a4fIezK2bd6IpbNHM2/yEOZ4f/vKw31lvYpw7sIVQkPDuHD5Gvlye3LkeOSh9qMnzlC+TPEEj+Uc72+pVbU8P66eyaedP6Jk8UK0aBJ5lf2HjwKpX7sKq+aPw9MjK5u37SZLJncGf9GFQgVys3L+uBjhCMDV1ZnZEwazcv449hw4yoHDJwAo7VWYRdOHs3bRRCIiTPz6e+TnoffqH/i080es855Mz46tcHBwYMfug/hfv8WaheNZs3ACh4+d5pzV+yI25y5eZeqY/syaMIhla34kNDQszs/Xx0+esXztTyydPZpV88dTv3aVV7Yv/y2aQUoCTGYzJYsVZOLMpTx89JiTvhcY0KeT5Z5Jp/0ucjfgAf1HTAUgIsJE7pzZCQ4Jxef0OaaN7Q9E3mgydaqUsfbhkS0Lh46e5K8jJ/E7f5nw5/9cuThLJncK5ssFQNHCebn60i/Nl5XxKhL5yytdWooWyseZc5fJmysH2bNmZuPPv3Hm3GWePQvmxq27luc0aVjTUlPtahWYMHMJS1Zvotl7tWPcQDdTxvQcP3WWdZu2c+GSf7R2XF1dKF+mOADFCufnh59/A+DA4RM0qFWFDOndIrcze9zXyqlSoRQO9vYUL5IfgGqVywBQvEgBDryYrUubJhV37t5n/tL1XL12i0ePnxAcHELKlCkY2KcT3fuNIl9uT2pXqxBrH1kyuVMgb+TNTwsXzEu6tKlJmTIFKVOmIEN6Nx48CCS9W/w37nR1daF86WIvtjUfKVO44v7ixqV5c+fgfsAjXtyv97XGwGAwkDFDOtZ8v4XzF68CcOPWHXLnzJ7g8dl78BjvN6yJq0vkDVc/bFyXhcs30KF1EwBKFC2AW9rUABTI60nAw0cvavRh4fTh2NnZ4erigvuLWqPamDp3BW0+fJdqlcsCUKdGRerUqBit/hs37+B//TajJkfe58xs5pX3f8uSKQMHDocQFh7Ow0eB8d5WJK79+3X633fwGP7XbtGt7zcAhIaFU6RgHk77XSCHRxa8ihUEwCOB13RydHTAxcWZJasjA5sBA3fvPYj2Pn/46DF9B08EIH/enAz7qjuFCuTm5JkLXLjkT72alVi5/meePzdy1MeXNh82SvBYZs6YgYeBTzAajTx6/CTa+CX0c8NayeKFsLe3I4WrC2VLFsX37CWqVCiFp0dWfv19Pz6+57lx667l/d+kYU2Wrf2RZ8Eh1K9ZGYC9B4/ie+4SnXpH3n8uOCSU23cDLDf5jkvUPp43dw4cHR159PgpV6/djPXzNU3qlNSvVZlvJs6jbfNGlHvxnpTkQwEpibCzs6NujYpMmbuCKhVK4vDSNV/MZjMe2TKzYu7YaM+JurlnQq4PM3rKApydnHi/YQ3eqVCKOd6x/+XtYO9AQq774OBgj6uzM/fuP+DTAeP4uFVjun3SHDs7AybTPy28XJtXsYIsnzuG7b/v55NPh/DNwF6ULvHP3b8Xrfiey/43+KhZQ95vUIOuL37JxNa3+UWVRmMELs5OCag4+vNj/Pyi5J+27mbbb3vp2LYpn7RuQu0PumB6EVRv3bmPq4szwcEhmM3mV97Dy8E+Zj8vj63RGP3eYrG3Ef0t+vK2v9xOQsbg/CV/ho6dTbf2zWlY+x0CHs6xbJt1HzF+jmOnMBgi/8VZ+4vnGSOMMcYjSq9Orbh95z4r1m9m2bc/4T3jG5ycHGOsF/VLfPncMTHCdVwqly/JktWb6PXVWBwdHRJ8TkrU/v26/ZsxU6dGRT7vHv0LFnsOHI31/n4AGAwYjRGx7lMH//Zh7pJ1dP+kOc3fr0uH80NjvGbp06Vl5fxx0R6rWLYEx0/6ce7iVb7o+TGHjp7i1JnznLt4leJF8nPz9r0EjeW7dasyespCDh05iUf2zPT/rEOs6yX0cyPG8xzscXVxJiQ0lC6fj+D9BjVo16IRmdzTWz7fWjSpR+1qFdjw0w5adenP0lmjMJvNtG7WMMbhxtt37ieoX4PB8GK/Nsf5+QrwzcBeXLp6ncUrN7L+x1+ZOrr//7CV8m+lQ2xJSMM6Vdm99zDv1q0a7fGihfJx994Ddu2NvBloUHAIjwKfkCplCnLn9LAcmrt15160cztetvevYzR/vy5FCubFLwFT0bG5fvMOEHkI6My5S5QsXpAz5y7j6upC4/rVSZnClavXbsX5/JO+5zFgoHGDGpQsVtDybbuXa2xUtxqlihfi/KWrCaqpZPGC7NpzmKCgYMxmM6fOXPifti3KvkPHqFm1PBXKFOfSlX8OsYSFhzN17gomjviCDOnd2PhiBut/5Z7eDZ/T5zBGRLDtt73/r7YSOgZHT/iSO2d26tSoSITJxN17D167r6qVSvPzr38QGhqGMSKCjT//xjsVS7+6xmKF+Hn7nwA8CnzCtZu3gchxPXXmAlmzZKR3l9ZcvXbT8s0yazk8suCWNhXrfvgVs9lMePhz7gU8BMAAmM2mGM/Ze/AYpb0Ks2zOaBZNH2GZHYtNbPt3FJPJHG//UapUKMXWnfu4diNy+27fDSAiwkThgnk4f9Gfq9ciZ1lefo3SpU3N8+fPOX/xKmHh4ezYdcCy7ODfPpQtWZSqlcrwKPAxT5/+c3jNgAGzKeY2A1Qs64Xv2UvcvfcAj2yZKe1VmB+37qJgvlw4OTkmaFsAft7+J90+ac6aRROYOOILy0xmfLJkdufe/YdERMRe2/WbdzCbzdwLeMifB45QsWwJrl2/TeDjp7RoUo/Mmdy58OLbeSaTiWMn/UjnlobOHzfDFGHiiv8N3qlYmu9+3G7ZV27dufdiUAyYYtkP4hPX5+vjJ0+5ePkaeXPloGfHlhw6ehqj0fhabcu/m2aQkpDsWTOxeuH4aNP6EHnYZ/LIfsxcuJolq37A2dmRTzu3pkzJIgzr353x073Z8ON28ubOQY7sWWJtu3PbZgwdN5tM7hmoWLbE/1TfuQtXWLNhC6GhYQz7qjvuGdJRtlRRtu7cS7vuX5M7Z3ZyeWaL8/kXLvszff4qgkNCyJghfYy/stu1aMT8ZetZt2kb1SuXjfsv7pdUr1yWU2cu0L7XEDK5p6d40QKvfE58mr9fj7ne3/L7nkOUL12MzC/uWr987U9ULOdFLs/s9O35MZ37DKdKhZL/cz9d23/IuOneeG7IQruW7/HH/v/9q88JHYOaVcuz/9AJ2vcaQoG8Ocmd0+O1+6pfqwp37j2gU+/hGAwGypcpRtvmr/7W0xe92jN6ygLadhuER/bM5MgWuZ+Ghobxwy+/M2Xucp48DaJdi/fIktmdPQeOsmvvoWgnpDvY2zNxxJdMmbucn7f/gZOTIx+3bEyd6hUpX6Y43qt+4MPGdaP1W6xwPibPXs7J0+dxcHQgW5aM1K5Wgbo1Yt6MNbb9G6B6lbKsXL+Z3l3bxNl/lFLFC9G7a2sGjpyOg70DadOkYsTAnmTMkI4BfTrSf8Q00qZJRYmi/4QvFxdnOrb9gN6DxpM3tyfvN6jBz9v/AKBR3apMmbuCTr2HU7xI/mgnhFetVJpV3/3CmCG9Y2xLvtw5uHr9JqVLFMZgMFDGqwjT5q2kT7e2rxzLl5UoWoDJs5ezcv3PODk6kDNHNlo1bRDva50tSyby5spBq85f0alt0xh/8N0PeES3L0by5OkzundoSf68OTEajVQuX5K23b8mp0dWsmfLhMkUGdx27z3MjAWrefYsmErlvChRrCD2dnbcf/CQXv3H4OzkREb39Iwd0pvMGdPjmT0rG37aYTlX6lXi+nzNliUji1du5Pa9AIKCgvmy58c4OOhXZnKiK2mLSJJjNBrp0W80C6eNSFBQjsvYaYupWLYEtatVICLCxOoNv7DnwFGWzBr5Bqt9fU+fBVHvw+4c3L7apnW8ykddBjBrwiAyuacnPPw5X4+eQZ6cOSzffhT5L1McFpEkZ8HyDXRu1+z/FY4gcnZt9Xc/s+Lbnwh/biR71owM+bLrG6ryv69B7Sp8PWom4eHPCX/+nJLFCtL+o8a2LkskUWgGSUSSnIScBC8i8jbpJG0RSXIUjkTE1hSQRERERKwoIImIiIhYUUCyIbPZjNFotFwxW0RERJIGBSQbioiIoGqjDoSEvPqeTCIiIpJ4FJCSgOcv3RdNREREbE8BKQlwdIx53ykRERGxHQWkJCC2G3OKiIiI7SggJQEhoToHSUREJClRQEoCTHHc9VpERERsQwFJRERExIoCkoiIiIgVBaQkwMnJydYliIiIyEsUkJIAR0cHW5cgIiIiL1FASgKCdSVtERGRJEUBKQkwm/QtNhERkaREx3aSgJxFq9q6BJFEF3jDx9YliIjESTNIIiIiIlYUkERERESsKCCJiIiIWFFAEhEREbGigCQiIiJiRQFJRERExIoCkoiIiIgVBSQRERERKwpIIiIiIlYUkERERESsKCCJiIiIWFFAEhEREbGigCQiIiJiRQFJRERExIoCkoiIiIgVBSQRERFJdCZjCPd8vDEZQ2xdSqzeWkCq3OBjPu4xmLbdBzF9/ipCQ8PeSj+1mnR+K+1aGzlpPgEPHiVKXyIiIv9lJmMI1/cMJfDydq7vGZokQ9JbC0guzk6sWjCOlfPG4eBgz9R5K99WV4lixICeuGdIZ+syRERE/tWiwlFYoD+YIwgL9E+SIcnhbXdgb29Hjw4tada+L0FBwaRMmYKlazaxY/dBnBwdGNKvGwXz5cL37EUmzlpGWFgY79WrzsetGuO9aiMPHj7m2o3b3L3/gI5tPqBRvWqv7PPajduMmbqIx0+eUqFMCb7o+TF37j1g2rwV3L33AEdHRyaM6EvGDOno1X8M9WtWYdOW3xkzpDcDR06ncf0abNmxB0dHB2aOH0jqVClp2r4vy2aPJiQklPEzluCRLTOHj52iZPFCDO3XDbPZzNS5K9l/+Dh37z0gc6YMfNalNbWrVXjbQywiIvKvEC0cYYp61BKSclQbg52Dqy1LtEiUc5AcHR3w9MjKzTv3OXT0FBevXGftoglMGNGXRSs28Py5kXHTvZkyqh9rFk3kqM8Z7r84nPXk6TNmjh/IwmnDmbVoLUHBr06Y46Yt5qvPOrDOezIhoWH4nr1E2jSp6N21DSvnj6NcqaJs3rbbsv4pvwssmzMaj2yZCQ4JJZ1bGlbOH0s6tzTsP3Q8Rvtnzl2iRZN6rF44gb0Hj3Hv/gNOnrnAKb/zbFg2lXHD+lCyWCGFIxERkRdiD0eWpUluJumtzyBFMZlM2NnZcejoKfzOXaLDp0MBcHV14drN29y5G8BXw6YAEBwSyr37DwEoUjAvDg4OZEjvhke2zFy/eYdC+XPH2U9QcAh+568wZspCAELDwqlczotihfPx9FkQMxasxuf0OfLmzmF5TtNGtTAYDJafK5QpjsFgoEDenDx89CRGH5kzZiB3zuwA5PLMxsPAJ6R3S0NY2HPCQsN4FBjzOVG+37yTjT/vBMBsNido7ERERP7tAnzXEPb4GjHDURQTYY+vEeC7hkxeXRKztFglSkAKCw/n2s07ZMuSEcxm2jRvRIsm9SzLL165jqdHVpbNGR3teQf/PhG9WAd7nJ2c4u/MbCZFChdWzBsbLfTs3nuY7zfvpGv7DyleJD8HDv/Ttp1d7BNp9vZ2rwwxUetkz5qJ1KlS0HvQeFKlTMnXfWM/ebz5+3Vp/n5dAIxGI1UbdYh/e0RERP4D3Iu2JeSBXxwzSAB2OKf1xL1o28QuLVZv/RCbMSKCud7rqFqxNClcXShXuhibt/1BUFAwJpOJewEP8cyehcDHTzjmcwaAu/ceWJ5/+24AZrOZy1dvEPDgER7ZMsfbX8qUKciWJRNbf9tractsNnPUx49qlcvgVawgF69ce+Pbee3GbVKnSsnS2aOZNWEQWbNkfON9iIiI/FvZObiSo9oYnN1yEjN+2OHsljNJnYP01maQQsPC+bjHYCIiIihXuih9e34MQMWyJTh74Qodew/HxcWZFk3q0bh+dUYP7s2UOcuJiDCRPVsmxg7pA8DVazfp9sVIgoNDGfZVdxwdo5ccEhpG8w5fWn6ePXEww/t3Z/x0b9Z+v5UM6dwYN6wPDWpXYdKspfx54AheRQu+8e3Nksmds+ev0KbrQJycHMnlmY1ObZvi6ZH1jfclIiLybxQVkqKfi5T0whGAITw8LMmeCOO9aiOuLi60bdHI1qW80s/b/+RZUDCtmzXEaDQyZOxsypYsGu1QorWoQ2x+vqcSsVKRpCHwho+tSxARG7GcsP34Gs5pPZNcOIJEPEn7v6544XxMmbuCbb/tIywsnFIlCtG4fnVblyUiIpLkRM0kBfiuwb1o2yQXjiCJzyD912kGSZIzzSCJSFKme7GJiIiIWFFAEhEREbGigCQiIiJiRQFJRERExIoCkoiIiIgVBSQRERERKwpIIiIiIlYUkERERESsKCCJiIiIWFFAEhEREbGigCQiIiJiRQFJRERExIoCkoiIiIgVB1sXIODvu5e0adPYugwRERF5QTNIIiIiIlYUkJIAR0dHW5cgIiIiL1FASgKcnBSQREREkhIFpCQgJDTU1iWIiIjISxSQkgBThMnWJYiIiMhLFJBERERErCggiYiIiFhRQEoCnJycbF2CiIiIvEQBKQlwdNT1OkVERJIS/WZOAtxzlbF1CSIE3vCxdQkiIkmGZpBERERErCggiYiIiFhRQBIRERGxooAkIiIiYkUBSURERMSKApKIiIiIFQUkERERESsKSCIiIiJWFJBERERErCggiYiIiFhRQBIRERGxooAkIiIiYkUBSURERMSKApKIiIiIFQUkEZFkzmQM4Z6PNyZjiK1LEUkyFJBERJIxkzGE63uGEnh5O9f3DFVIEnkh2QWkWk06x3hs5sLVXLx8zQbViIjYTlQ4Cgv0B3MEYYH+CkkiLyS7gBSbz7u3I18eT1uXISKSaKKFI0xRjyokibyggAT06j8Gv/OXAWjddQALln3HR10G0HfwRIwREQDs++s4bboOpFXnr/j1930AHD1xhp79RtOm60CGjZuDyRT5IfNxj8HMW7qezwaOw2w222ajRETiEHs4sixVSBIBHGxdQFJz7cZtKpQtQZf2H9Lh06H4+l0kZ45szF+2Hu9ZI3Gwt6dHv9HUqV6RLJndmTTyS1KlTEGPfqM5cfocpUsU5rL/dVp8UI9enVrFaP/7zTvZ+PNOAIUnEbGJAN81hD2+RsxwFMVE2ONrBPiuIZNXl8QsTSTJUECy4uzkRKnihQDIlzsHDx895umzYAIeBNLjy1EAPA0KJvDxU7JkcmfPgSMcPOLDvfsPuHM3AABHR0ca168ea/vN369L8/frAmA0GqnaqMPb3ygRkZe4F21LyAO/OGaQAOxwTuuJe9G2iV2aSJKhgBQPe3t7zIAZM2W8CjNu2OfRlk+bt5IIk4mPmjbE1cXZMiNkZzBgMBhsULGIyKvZObiSo9qYOA6z2eHslpMc1cZg5+BqqxJFbE7nICVA0UJ5OXHqHFev3QTg7r0HQOQ5SB80rEn2bJm44n/LliWKiLyWqJDk7JaTf34VKByJREl2M0ghoWE07/Cl5efZEwe/8jnp3dIy+MuuDBkzG3t7O4oXyU//3h1p1bQ+w8bPxSNbZjJlTP82yxYReeOizSQ9voZzWk+FI5EXDOHhYTpT2EaizkHy8z1l61JECLzhY+sSxEZMxhACfNfgXrStwpHIC8luBklERKKzc3DVt9VErOgcJBERERErCkgiIiIiVhSQRERERKwoIImIiIhYUUASERERsaKAJCIiImJFAUlERETEigKSiIiIiBUFJBERERErCkgiIiIiVhSQRERERKzEGZCOnzqbmHWIiIiIJBlx3qx2yeofuHf/IQ1qV6FhnapkzeyemHWJiIiI2IwhPDzMHNfC+w8e8dsfB9m19zCuLi40qleVWlUr4OgYZ66S12A0GqnaqAN7tyzHwUFjKiIiklTEew5Sxgzp+LBxXZq/X4/HT5/y45ZddOw9jFNnLiRWfclCaFi4rUsQERGRl8Q5bXHF/yY/bt3F3oPHqFa5DGOH9MEjW2auXrvJoFEzWec9KTHr/E+LMBptXYKIiIi8JM6A1H/EVFo0qceq+WNJmTKF5fFcntkpU7JIohQnIiIiYgtxnoNkMpmws4t+BO5ewEMyuadPlMKSg6hzkH79bh5p06axdTkiIiLyQowZpJkLV8e6oslk5sDhE2xYNvWtF5XcODo62roEEREReUmMgJTqpcNp0RkY/GXXt1xO8uTkpIAkIiKSlMQISJ3bNbNFHclaSGgoqVOlsnUZIiIi8kKMgLRj9wHq1azMktWbYn1C53ZN33pRyY0pwmTrEkREROQlMQJSwINAAJ4+C0rsWkRERESShHivpC1vV9S32Px8T9m6FPmPCbzhY+sSRET+1eK8DtLz50b2HzrO/QePMJv/yVAtP6ifKIWJiIiI2Eq8F4q8fTeAwgVy42BvH/mgwZBYdYmIiIjYTJwB6ebte3y7eKJuoioiIiLJTpw3qy1Tsgi37wYkZi0iIiIiSUKc00ON61enV/+x5PTIGu3xOZMGv/WiRERERGwpzoA0dupi6lSvQPEiBf45B0lEREQkGYgzIDk7O/F593aJWYuIiIhIkhDnOUjv1q3Kr7/vIygoONo/ERERkf+6OGeQlqz+gSdPo19N22CA/dtWvfWiRERERGwpzoD064YFiVmHiIiISJLxyoscBYeEYjb9czPVlClTvNWCRERERGwtzoC0a+9hpsxZzuMnTzGbIw+vZcqYgU0rZyRieSIiIiKJL86AtHD5d0wc8QWrN/zCNwN7cvHydQ4f001VRURE5L8vzm+xpUzhSvEi+cntmZ3TfhcpXiQ/fx87nZi1iYiIiNhEnDNI7unTcf3mHWpWLc+MBau5eu0WwaFhiVmbiIiIiE3EOYP0WdfWuKVNTcF8uWhQqwp/HzvNZ50/SszaREREJJkyGUO45+ONyRhik/5jzCCNmryA4f17cOrMBRrVqwZAk3dr0uTdmole3NS5K/A5fY4Hjx5jZzCQzi0Nlcp50bNTq1jX9161EVcXF9q2aJSg9o/5nGHN91uZOvqr167Ne9VGftq6mzRpUpEyhSs9O7WiVPFCAPTqP4beXdtQuECe125XREQkuTMZQ7i+Zyhhj68R8sCPHNXGYOfgmqg1xAhI5y/5c9L3PKu++4WC+XOD2Rxteb48nolWXL9PPwFeP/gklo+aNaRti0Zc8b9Jv2FTmDVhEB7ZMtu6LBERkX8tSzgK9AdMhAX6c33P0EQPSTEC0rt1qjJq8gLuBTxkwIhp0ZYZDLBxxfREKy4uRqORKXNXcP7iVZ4FhTDo806U9ioCgO/Zi3w2YBx37gXQsc0HNKpXjS079uB3/gpffRYZuGo16cyun5ZEa/P23QCmzVvB3XsPcHR0ZMKIvmTMkI5e/cdQv2YVNm35nTFDescagHLnzE6rpvX5cesuPuvS+u0PgIiIyH+QdTh68ahNQlKMgNSm+bu0af4uY6YsZOhX3ROliNfl4OBA03drUTB/bg4fPcWS1ZssAclgMDBj3AAeP3lGm26DqPFOuQS1mTZNKnp3bYOnR1YWLPuOzdt207ldMwBO+V1g2ZzRGAyGOJ+fP29Ojvn4/f83TkREJBmKPRxZliZ6SIrzW2xJNRxFSZMmNUtW/8CZc5e5cy/A8niRgnlxcHAgQ3o3PLJl5tqN2wlqL4WrC0+fBTFjwWp8Tp8jb+4clmVNG9WKNxwBmEwm7OziPOfd4vvNO9n4804AzFaHL0VERJKrAN81hD2+RsxwFMVE2ONrBPiuIZNXl7dez6t/oydBt+7c48uhk8ifJycDenfEFEfQcHCwx8XZGQBjhDHeNnfvPcy8JeupUaUs7Vq+Fy28JCT4nL1whRweWV65XvP36/Lt4kl8u3gSqxeMf+X6IiIiyYF70bY4p/Uk7mhih3NaT9yLtk2Uev6VAenshat4emSlWuUyXLsZfYbo9t0AzGYzl6/e4MHDQHJkz0w6tzRcuHQNo9HIzj8O/jMbZDBYgtBRHz+qVS6DV7GCXLxy7bXquXjlOhs376Tpu7Uim8WAyaTZIRERkYSyc3AlR7UxOLvlJGY8scPZLadtz0G6eDn2cGAym1n93c+M+vqzt17Uq5TxKsKmX36nU+9hVKlQGtcXs0QAQcEhdPtiJMEhoQz7qjsODg6UKVmEVd/9QqvO/fmwcV0yZUwPQJ6cHty8fZfLV2/QoHYVJs1ayp8HjuBVtGCC6lj3wza27txLihSufDOwF1mzZASgXKli/Lh1F0UL5X3zGy8iIvIfFRWSop+LlPjhCMAQHh4WbaqjWfsvYl/RANUql+Hz7u0SpbDkwGg0UrVRB/x8dY87ebMCb/jYugQRkf/Zy9dBck7raZPrIMUISJJ4FJDkbVFAEpF/O5MxhADfNbgXbZvo4QjiOQcpLDyc9Zt+Za73OgBCQ8O44n8z0QoTERGR5MvOwZVMXl1sEo4gnoA0duoiHgU+Yf+h4wCEhoUzceaSuFYXERER+c+IMyCdv3SNHh1b4uAYeR63W9rUBIeEJlphIiIiIrYSZ0BycnTgWVAwUd+IP+13MbFqEhEREbGpOK+k3aNjSz4bMI779x8xePRMDh87zaivP03M2kRERERsIs6AVLl8SXLmyMaho6fAbKZnp1bkyP7qK0WLiIiI/NvFGZAAsmfNRLP3aidWLSIiIiJJQoyAVLnBx8R1X1ZXFxd+27T4bdckIiIiYlMxAtKOjQsxm81Mm7eKVk3r45EtMwAnfc/rRG0RERFJFmJ8iy1VyhSkTpWSq9duUih/blKlTEGqlCmoXL4kfx8/bYsaRURERBJVnF/zjzCZOHXmguVn/+u3ePL0WaIUJSIiImJLcZ6k3bdHOwaOnE5Oj6zY2dlx4bI/A3p3SszaRERERGwizoBUukRh1i+ZzGm/ixiNRgoXyIN7hnSJWZuIiIiITcR5iA3AzmDAYDDg5OSEq4tzYtUkIiIiYlNxziD5nr3IoJEzLN9iu3nnHhOG96VIwbyJVlxy4e+7l7Rp09i6DBEREXkhzoA0a9FaJoz4gqKFIgOR79lLzFiwmkXTRyRaccmFvUO81+sUERGRRBbnIbag4BBLOAIoWigvwSGhiVJUcuPi7GTrEkREROQlcQakdGnT8OeBI5af9xw4ilva1IlSVHITGhZu6xJERETkJXEe2/nqs08Y8M10ZsxfBYCzszOTvvki0QpLTiKMRluXICIiIi+JMyDlzJGNtYsmcv3mbQByZM+KvX28X3oTERER+U+I9+xge3s7cnlmT6xaRERERJKEGAGpcoOPSZ8uDc+fRxAUFIzJbMZgALMZDAbYv22VLer8T3N0dLR1CSIiIvKSGAHpk9bvs/fgMfLlzkH9WlUoX7q4Dq29ZU5OCkgiIiJJiSE8PMxs/aDZbMbn9Dm2/baPU2cu8E7FUrxbt6oOt71hRqORqo06sGPjAlKnSmXrckREROSFWAPSyx4GPmbqnBX8sf9vVi+YQO6cCklvSlRA8vM9ZetS5D8g8IaPrUsQEfnPiPUkbaPRyIHDPmz9bS/+129Rp3pFPu3yEdmyZErs+kREREQSXYyANHnOco4c96V0icJ81LQBJYsXskVdIiIiIjYTIyAdPOxDmtQpOeV3gb+Pn8ZsjjwCF/Utto0rpid6kSIiIiKJKUZA+mGlApCIiIgkb/r+voiIiIgVBSQRERERKwpIIiIiIlYUkERERESsKCCJiIiIWFFAEhEREbGigCQiIiJiRQFJRERExIoCkoiIiIgVBSQRERERKwpIIiIicTAZQ7jn443JGGLrUiSRKSCJiIjEwmQM4fqeoQRe3s71PUMVkpKZGDerTc6CQ0KZs/hbTp25gMEAtapVoHjh/KzduJWpo7+ydXkiIpJIosJRWKA/YCIs0J/re4aSo9oY7BxcbV2eJALNIL1kzJSFZMuakZXzx7J0zmhyeWbDYLB1VSIikpisw9GLRy0hSTNJyYNmkF64cesuV67dZOzQPhgMBhzs7alRpRzHfM7w8NFjBo2awRX/m5QrVYx+n7bnzt0Axk33JnvWTPx9/DRN3q2Jo6MjP2/7g8yZMjBl1FfY2yt/ioj8m8QejixLNZOUjOg3+AtX/G9QMF8uDLFMGQWHhDCgT0fWLBzPab8LHPPxA+DshSt81Kwhi6aPYMGyDWRMn46VC8ZxL+Ahp/0uxNrP95t30rrrAFp3HUC7Hl+/1W0SEZHXE+C7hrDH14gZjqKYCHt8jQDfNYlZltiAZpBeEhWOTvtdZNKspTx5GkT3Di3wyJaF9G5pAShXqhhnL1whW5aMZHJPTy7PbABkSO9G2VJFcbC3J19uTx4+ehxrH83fr0vz9+sCYDQaqdqow9vfMBERSRD3om0JeeAXxwwSgB3OaT1xL9o2sUuTRKYZpBdy5sjGuQtXMZvNFCucj5Xzx5Eta0ZMpuhvEAcHe1xcnGI838HBPtr/zW+9YhERedPsHFzJUW0Mzm45ifkr0g5nt5w6vJZMKCC94OmRlWxZM/Hdj9sxm82EhoYRHBwKwMNHjwkNCycoKJjd+/6mjFcRG1crIiJvS+whSeEoudEhtpd8M7An0+atpG23QUSYIqhUriQZ0ruRJnVKBn4zjTv3AmjRpD65PLNz+859W5crIiJvSVRIur5nKGGPr+Gc1lPhKJkxhIeH6WiQjUSdg+Tne8rWpch/QOANH1uXIPKfYzKGEOC7BveibRWOkhnNIImIiMTBzsGVTF5dbF2G2IDOQRIRERGxooAkIiIiYkUBSURERMSKApKIiIiIFQUkERERESsKSCIiIiJWFJBERERErCggiYiIiFhRQBIRERGxooAkIiIiYkUBSURERMSKApKIiIiIFQUkERERESsOti5A4Nb5v0iRwtXWZYiIiMgLmkFKAp4/f27rEkREROQlCkgiIiIiVhSQRERERKwoICUB9g46FUxERCQpUUBKAlycnWxdgoiIiLxEASkJCA0Lt3UJIiIi8hIFpCQgwmi0dQkiIiLyEgUkERERESsKSCIiIiJWFJCSAEdHR1uXICIiIi/R98uTgGwFKtq6BElCAm/42LoEEZFkTzNIIiIiIlYUkERERESsKCCJiIiIWFFAEhEREbGigCQiIiJiRQFJRERExIoCkoiIiIgVBSQRERERKwpIIiIiIlYUkERERESsKCCJiIiIWFFAEhEREbGigCQiIiJiRQFJRERExIoCkoiIiCR5JmMI93y8MRlDEqW/txaQajXpnOB1e/Ufw+079/+nfrxXbWTLjj0xHh89ZSFN2/elfc/BtO85mGVrf3ytdo/5nGH0lIX/U00iIiLy5piMIVzfM5TAy9u5vmdoooSk//QMUu+ubVg5fxwr54+jY5sPbF2OiIhIonhbsy2V6rfjryMnLT/7nr1IpfrtXnuS4/DRU6xa/3OC1o0KR2GB/mCOICzQP1FCksNbbd3K73sOse6HbTx5GkTl8l583r0dsxat5dSZC3w5bDINar/DJx+9z9I1m9ix+yBOjg4M6deNgvly0bb7IBrXr8GWHXtwdHRg5viB/HXkJN/9uIMUri7s++s444d/Hm//T54GMWXOMvxv3MZojGD015+RJ5cHgY+fMn6GNzdu3cU9vRu9u7Vl1OSFBIeE0r7nYOZMGkLg4yeMn7GEJ0+fkT+PJwP6dCKFqwu9+o+hfs0qbNryO2OG9Ob7zTvZe/AoKVOmYHj/HuTLnSORRldEROSlQPH4GiEP/MhRbQx2Dq5vpO3sWTOxa+8hKpYtAcCuvYfJmjnja7dTvkxxypcp/sr1ooUjTFGPWkLSm9w2a4kakPLm8mD2xME42NvRotNXtGxSnz7d2rB732Gmje5P1iwZOXT0FBevXGftogncuRfA1LkrmDq6P8EhoaRzS8PK+WP5avhU9h86ToPa7/DXkZOULlGYRvWqvbL/lClc+bhlY/LnzclPW3ez9vstDP2qOzMXrqZEkQJMHPEFjwKfkM4tDV3bf8ixk34M+6o7AF8OnUT7Vu9TrXIZZi1ay8p1m+nRsSUAp/wusGzOaJ48fcaWHXvYtmE+T54+I2WKt/OiiYiIxMY6ULzpIOHpkZWz569gNBqxt7fn+Ek/cufMblm+cPkGDh09xZOnz+jeoQV1a1Ri8OiZNKxblXcqlKJHv9EM+rwzZ85dwu/8Fb767BNGT1lIrhzZ+PPAEUJCwxj8RRdWfLsZ37MX6VrHjiIZ7rDpiD3Ojna862Xk/lMD07c5Ma6lP6vm9iPAviy37z3i0pVrfPnpJxw4dIK/jvjQqF41unz84f+8rYl6iC1rloz8vucvxk7zJiw0nDv3H8RY59DRU/idu0SHT4cyaOQMngX9M4VWoUxxDAYDBfLm5OGjJ6/sb/bitZZzkAIfP8Xe3g4HBwfmLV3Pr7v2c+deZP+Hjpziw/frApDOLU2MdoKCQ7hy7SaVy3sBUK9mJQ4fO2VZ3rRRLQwGA2lSp6K0V2HGTFlIUFAIzk5OMdr6fvNOWncdQOuuA2jX4+tXboOIiEhCvGq25U0ckgoLC8erWEGO+vhx7uJV8uTKQVhYuGV5jXfKsWTWSKaPHcD8pd8B8GmX1niv2shfR06SO2f2aIEqyu27ASye8Q1eRQsyde5KvhnUi07vevDzwYcvbUuMLcYY/IDjxw4zclAvPu3cmtGTF9CqaQO8Z45k1fpfiIiI67mvlqgzSEPHzqZQ/tx0bteU4OAQzKZYCjebadO8ES2a1IuzHXt7O8xm8yv76921DbWqlrf8fNrvIlPmLKdnp1ZUrVia+cvWR3aJGYMhnoZe0ZedXWTONBgMTBzxBUdPnGHw6Fl0bteUGu+Ui7Zu8/fr0vxFGDMajVRt1OGV2yEiIhKf2MORZekbm0kyY6Z2tQps33WAtGlSUad6RVau32xZntE9HWu+38KZc5e5F/AQiDwsV8arKBNmLGHJrJGxtlu2VFEMBgMF8+XCzs6OFK4ulK3RhvU7vgHCY30O2OGQIgNepcqQMoUrBfPnImOG9OTyzAZAmjSpeBYURNo0qf+nbU3UGaRjJ/1o0aQ+aVKn4sbtu5bHM7untwxkudLF2LztD4KCgjGZTJbH45IpY/pXrhPF5/Q5ShYvRIUyxbly7abl8VLFC/HT1t1AZIqNiDBFtnv/IWazmZQpU5ArR3YO/u0DwM4/DlK2VLEY7T9+8hT/67coU7IIDWpX4fgpvwTVJSIi8v8R4LuGsMfXiG+2JezxNQJ81/y/+ypRtAAXLvvje/YSZUsWsTweFBTMp/3H4p7ejYF9OuLq4mxZdvP2XVxcnAkLfx5v2w4O9pb/OzmnxCFlJpzdcgIGrCeDnN1ykr5AMwyGyLkeB3v7aMsdHOxfNb8Rr7cWkEJCw2je4UvLv9t3A2jbvBHdvhjJpFlL8cia2bJuo/rVGTp2NotWfE/FsiWoVa08HXsPp8Nnwzh09FQ8vUDNd8qzacvvfDl08itnlapVLsNpvwt07TuShw8fWx7v2/NjDhw+Qdvug5g8exlPnwVRvHB+nj4Lon3PIdy6c4/h/buzZsMW2nYfxP2Ah3Ro3SRG+6Gh4cxe/C3tenzNjj8O0Oy9Oq85aiIiIq/PvWhbnNN6EvevdTuc03riXrTt/7svOzs7ihbKS/ZsmXBw+OdA1LWbd3B0dKR+rSo8fPSEsPDImZ8jJ3xxdnKiT7c2zF689rX6MmBHjmpjSJ8+HVfv22Myw+FLDhjsHSNnw+xjnsrypry1Q2wHt6+O8Vintk3p1LZpjMcb169O4/rVLT93bPNBjK/lb1o5w/L/l0+6KpA3J5vXzI7RZtTJ1S/LkT0L3jP/md7r0CYy5GRyT8+McQNjrL987phoPy+YNjzGOvMmD7X8P3OmDEwZ1S/GOiIiIm+TnYMrOaqNieMwmx3Objnf6De+OrVtiskUfVIiX25PPLJm4pNeQyjtVYTMGTNgMpmYt2Q9Iwf1wiNbZr77cTt/Hz/9Wn3ZObjSrMM3/NZ3IIO/M9C0ihtOd1K/tW+vRTGEh4f9Pyag5P8j6hwkP9/4Z8kkeQm84WPrEkTkXyrmuUhvPhzZiskYQoDvGtyLtk2UbflPXyhSREQkOYmaSXJ2ywkG+/9MOILIbcvk1SXRtiVRv8UmIiIib1dUSErM2Zb/IgUkERGR/5io2Rb53+kQm4iIiIgVBSQRERERKwpIIiIiIlZ0DpKIiMi/hJuH11tpV5cXiUkzSCIiIpIgleq3468jJy0/+569SKX67bh9536Cnn/+kj+9+kdehHnrzr1s3bn3rdT5JmgGSURERBIke9ZM7Np7iIplSwCwa+9hsmbO+D+19W7dqm+ytDdOAUlEREQSxNMjK2fPX8FoNGJvb8/xk37kzpndsnzfX8eZt2QdEaYIOrb5gAa13+He/QeMnLSAp8+CyJY1k2Vd71UbcXVxoW2LRvy+5xDrftjGk6dBVC7vxefdI2elxs9Ygke2zBw+doqSxQsxtF+3RNtWHWITERGRBAkLC8erWEGO+vhx7uJV8uTKQVhY5E1pAx8/Zf6y9XjPGsmq+eP57scdGI1GZixcQ413yrFy/jga1nkn1nbz5vJg9sTBrFk4nj/2H7Ecsjtz7hItmtRj9cIJ7D14jHv3HyTatmoGSURERBLEjJna1SqwfdcB0qZJRZ3qFVm5fjMAp/0uEvAgkB5fjgLgaVAwgY+fcvykHyMG9ACI83Bc1iwZ+e3Pvzhy/AxhoeHcuf+ALBkzkDljBssMVS7PbDwMfEKmjBkSYUsVkEREROQ1lChagDne3+Lq4kKXj5tZApIZM2W8CjNu2OfR1jcaIwgJCcPZySnONoeOnU2h/Lnp3K4pwcEhmE2mGOvY29thNpvf7MbEQ4fYREREJMHs7OwoWigv2bNlwsHhn3mWooXycuLUOa5euwnA3XuRh8OKFMzDvr+OAXD2/OVY2zx20o8WTeqTJnUqbty++5a3IGE0g5QEXD+7n9SpUtm6DBERSeKSyvWKOrVtiskUfTYnvVtaBn/ZlSFjZmNvb0fxIvnp37sjn3dvxzeT5vPDL79RtmTRWNtr27wR3b4YSb7cOfDImjkxNuGVDOHhYYk3XyXRGI1GqjbqwN4ty6OlcBEREbEtHWJLAsLDn9u6BBEREXmJAlIS8Py5ApKIiEhSooAkIiIiYkUBSURERMSKAlISYK8TtEVERJIUBaQkwMU57otniYiISOJTQEoCQl/cx0ZERESSBgWkJCDCaLR1CSIiIvISBSQRERERKzo72IaibrpnNEZg1CySiIiITdnb22MwGAAFJJuKiIgA4L02vW1ciYiIiLx86y8FJBtycnLC0yMLqxeMtyRW+Ue7Hl+zesF4W5eRJGls4qaxiZvGJm4am7glp7Gxt7e3/F8ByYbs7Oyws7PD0dHR1qUkSQaDQTfxjYPGJm4am7hpbOKmsYlbch0bnaQtIiIiYkUBycY+bFzX1iUkWRqbuGls4qaxiZvGJm4am7gl17ExhIeHmW1dhIiIiEhSohkkERERESsKSCIiIiJWFJBERERErCS/7+3ZyI9bd7Hhpx2kSpmC0V9/SqaMGSzLbty6yzcT5xESGsbHLd+jQe13bFhp4otvbNb98Cs7du8nKDiUz7p8RNVKZWxYqW3ENz5Rvhw6mXRuaRj2VXcbVGg78Y1NUHAI46d7c/X6LTJnzMCoQb1ImTKFDatNXPGNzRX/m4yYMJeg4BBqV69Ir06tbFhp4vv2h22s3bCFj5o1pG2LRtGWJffP4/jGJrl9HmsGKRE8fPSYVet/ZsnMkTR/vy5zl6yPtnzmwtV0bPMBi6YNZ+HyDTwLCrZRpYkvvrEJCg4hLDycxTNGMn7Y54yb7m25PUty8ap9B+DA4RPcD3hkg+ps61Vjs2T1JgoVyM3qBeP5tPNHpEjhaqNKE9+rxmbpmk20a/ke67wnc9rvAtdv3rFRpbZRunghypcpHuuy5Px5DHGPTXL8PFZASgSHjp6iQN5cuLg4U7J4IQ7+fcKyLCLCxF9HTlKyWEFSpkyBp0dWjvn42a7YRBbf2KRM4conH72Pvb0duXNmJyIigrDw57Yr1gbiGx8Ao9GI96qNtGv5nm0KtKFXjc1vfx7kw8Z1AMiTyyNZXa3+VWOTMoUrbmnT4OjoQK4c2XF46erByUHB/LnJmtk9xuPJ/fMY4h6b5Ph5rICUCB48DMTTIwsA7undiDCZCA0LB+Dx06e4pUltmfr39MhKwIPkMxsQ39i87NzFq3hky4yLs1Nil2hTrxqf7zf/Rs13ypMxg5uNKrSd+MYmJDQUO4Mda7/fRvueg5m3NObM23/Zq/abDm2aMHXucpav/QmT2UTWLBltVWqSktw/jxMquXweKyAlBgPRpiLNJjNRf8waMGB6aZnJbMZgl3z+0o1vbKIYIyKYuXAN3Tu0TOTikoB4xifw8VN2/nGQVk0b2Kg4G4tnbIKDQ3n0+AlexQrgPXMkfx05id/5yzYq1AZe8b7asmMvrZo2JCw8nAuXriW7w0hxSfafxwmQnD6PFZASQcYM6bj24hj//QePcHR0xNkpMnmnTZOKp8+CLB9Q12/cwT1DOpvVmtjiG5soM+avpoxXYSrEcc7Af1l847P/0HGeBQXTq/8YJs9ZzoHDJ1i1/mdblpuo4hsbt7RpcHRwoESRAjg5OVKyWEFu3r5ny3ITVXxjExoaxp6DR2j2Xm26d2hBiaL52XPgqC3LTTKS++dxQiSnz2MFpERQvnRxLlzyJzQ0jOMnz1K5fEnWbNjCjt0HsLOzo1I5L46fOsuzoGCu37xN6RKFbV1yoolvbAC+37yTBw8D6dS2qY0rtY34xqdRvWqsXzIZ75kj6f9ZByqXL8nHrRrbuuREE9/Y2NvbUcarCAf+PkFoWDg+vufIk9PD1iUnmld95ty+E8CNW3cxRkRw7cZtW5drc/o8jlty/jzWrUYSyc/b/2TdD9tInTIFo4f0ZtX6n8mSyZ02zd/l9p37DJ8wl+CQUD756H3q1axs63ITVVxjU71KWVp1+orcOT0shwc+btWYujUq2bbgRBbfvhPlmM8Ztuzcm+y+5h/v++puAKMmzef+g0c0qleNjm0+sHW5iSq+sdlz4CizF6/FZDJRqkRhBn3eKdncrf3+g0f0GzqZB48eY2cwkNMzG3lyeujzmPjHJjl+HisgiYiIiFjRITYRERERKwpIIiIiIlYUkERERESsKCCJiIiIWFFAEhEREbGigCQiIiJiRQFJRERExIoCkogkCR91GcDRE2eiPda5zwgOHT0V53Nu37lP3WbdLD+PnDSfS1evx7pu+56DOeZzJtZlL2vavq/l/w8eBjJgxDTC39Bdy2/cukvvgeNp1bk/7XsNYfnan4iIMMXYDhGxveRx6VQRSfJqVCnL/sMnKFOyCAD3Ah5y6849yngl/FYPIwb0fKM1ZUjvxqSRX76x9ibNWkblCiX5qGkDwp8/58ChE9jpZqgiSZICkogkCTXfKceIifPp060NAHsPHqVqpdI4ODjge/YiC5d/T+CTpzx//pwBfTpRqnihGG207zmYvj3aUdqrCHfuBTBhxhLuBzwie9ZMBD55allv6869bNryOyGhYaRM4cqYIb1J55aGj3t8TcCDR7TvOZjGDWrQoHYV6n3YnYPbVwNw6swFZi1aQ3BIKOnd0tLv00/I5ZmN23fuM3DkdKpXKce+v47x+Mkzxg7tTeECeaLVFxwSwpOnzwBwdnKiZtXylmUms4nla39iz8EjPHr8lLFDelOkYF78r99ijve33A94RFBwCD06tqR2tQoANGzZk+4dWvDjll182as9P23bTaqUKbh89QZ37z+gaKF8DOrbCWcnJ/yv32LSrGU8ePSYNKlTMrRfNzw9sr7ZF1HkP0SH2EQkSSiQLxfh4c+5efseAHsOHKVW1cgg4J4+HUP7dWXlvLF0aP0BsxetfWV7oycvpLRXYdYsmsCQfl2xt/vn465A3pzMmjCI1QvGk9szO+s3/YqDvT3TRvfHPUM6Vs4fR4sm9aK19+RpEINGzaBvj3asWTiBZu/VZtCoGUREmAC4fPUGxQvnY+nsUVSvUoZvN26LUdOXvdqzc/dBOvUezq+/78NkMlmWhYWGU6RgHpbMGkWNKmVZ98OvALilTcNnXVqzfO4Yhn3VnalzVmA2R94hKvDxU27cusuyOaMpUbQAAAEPHjFldD/WLprAjVt3+WX7nxgjIhg2bg5f9PyYdd6T6NS2KXMWf5vg10YkOVJAEpEkwWAwRB5mO3ScZ0HBXLxynbIvDrdlypieG7fvMWvRWn7Z/ic3bt2Nt63gkFB8Tp+jVdMGAKRNk5rUqVJalufwyML+v04wceZSTp+9+Mr2AE77XSBHtswULZQPgJpVyxMcEsL1m7cBcHV1oXyZ4hgMBooVzs+Dh4Ex2ihSMC9rF02k5Qf1WbnuZ7p/OZqQ0NB4n582TSpCQ8OYv3Q9azZs4dHjJwQHh1jabNfiPQyGfw7TFS9SAGcnJxwcHKhSviSn/S5x4+Yd/K/fZtTkBbTvOZi53ut49PgpIhI3HWITkSSj+jvlWLr6B9K7paVy+ZKWO8wvWvE9l/1v8FGzhrzfoAZd+34TbztRMzP29vYxlpnNZvoMmkCp4oVo9l5tihTKy76Dx/6neg0YgJjnEDk42GMm9vuAOzk50rDOO9StWYmWHb/i0JFTFMyXK87n/7R1N9t+20vHtk35pHUTan/QBZP5n7bt7eP+O9fBwR5XF2fMZnBxcWb53DHY2envYpGE0DtFRJKM4oXzce3GbX7dtZ9aL52fs/evYzSqW41SxQtx/tLVf55gMGAym2K0kyplCnLn9GDbb/sAuHXnHgEvZmSePA3itN8FWn/4Lnly5eDs+cuW56VLl5agoGBCw8JjtFmscH5u3L6L79lLAPyx/29cXV3IkT1LgrbtydMgZi9ey+MX50I9efKM4JAQsmXNFO/z9h06Rs2q5alQpjiXrsT+Db2X3bx9F5PJxLOgYLbu3Eul8l7k8MiCW9pUrPvhV8xmM+Hhz7kX8DBBdYskV5pBEpEkw87OjsrlS7Lzj7+YMPxzy+PtWjRi/rL1rNu0jeqVy1pmTTJnTI9n9qxs+GlHjHOGhvXvzvjp3mz4cTt5c+ewBJk0qVPyUbOGdPviG7JmzkixwvkIeBAIgIuzE/VrVaF1l/582LguTd6taWkvTeqUjB/Wl+nzVxIaFo5b2tRMGN433hmcl6VK6Ypn9qx8MWQyYWHhGCOM9Or8EQXy5uT2nftxPq/5+/WY6/0tv+85RPnSxcicMUO8/Vy7cZteX43hwaPHNKpbjXcqlMJgMDBxxJdMmbucn7f/gZOTIx+3bEyd6hUTVLtIcmQIDw+LfR5YRET+VUZPWUj+PDn5qFkDW5ci8q+nQ2wiIiIiVjSDJCIiImJFM0giIiIiVhSQRERERKwoIImIiIhY+T/yPdHtnH2XbAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 583.3x340 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "8784f114",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"], constrained_layout=True)\n",
     "ax.barh(y_pos, family_plot[\"sharpe_median\"], color=COLORS[\"blue\"], label=\"Median\")\n",
@@ -1380,16 +855,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "413bcf78",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002248,
-     "end_time": "2026-09-02T01:48:36.036269+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:36.034021+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "08141281",
+   "metadata": {},
    "source": [
     "The same evaluation surface shows why prediction and portfolio diagnostics\n",
     "cannot substitute for one another: similar IC values map to a wide Sharpe\n",
@@ -1398,35 +865,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "b24cd9fb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:36.040985Z",
-     "iopub.status.busy": "2026-09-02T01:48:36.040871Z",
-     "iopub.status.idle": "2026-09-02T01:48:36.153818Z",
-     "shell.execute_reply": "2026-09-02T01:48:36.153405Z"
-    },
-    "papermill": {
-     "duration": 0.116192,
-     "end_time": "2026-09-02T01:48:36.154501+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:36.038309+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFVCAYAAAAUvhB3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzsnXecFOX9x9+zvdzt7fXKHXf0JggIiCCKKPYu9u5PY0wxJjEmaowxamyJ3dh772JFREFBpPd6HNf73fY+5ffH3K5X4ZCjzzuvvE52Z2eemZ195vN8qxCNRhQ0NDQ0NDQ0NDQS6Pb1ADQ0NDQ0NDQ09jc0gaShoaGhoaGh0QlNIGloaGhoaGhodEITSBoaGhoaGhoandAE0h7AWTCaa3/7151uV11bT/HIo3nyudf2wqh2zveLluIsGM0rb3ywr4eyW6xet5GpM2eRP3gS9z70VK8/d+9DT+EsGE1NbcMeHN3u86/7H8dZMJqKqhoApp10AZdd+8d9PCqV/e2e1tDQ0PilHBQCadSkkzjxrMs7vPbh7K+YcdolFAw5kskzzuWxp19GkqR9NMLuycvJ4vXnH+aCc07d10PZr9hSuh1nwWi+X7T0F33+9rv+w5bS7dx1+02cfvKMDu9tL6/ioqtvpGjEFIaNm8HVN/yF8srqvhj2PuPJ/9zFP/76+309DEC7pzU0NA4eDPt6AHuCR558kTvueZiZM47mvrtuobyimk+/mMdlF55NiiN5Xw8vgU6nY/LEsft6GPsdDY3Nu/X58spqRg4bzFWXzurwuqIoXHDl72hpdfHXm65Hp9Px6lsfsnzlWvoXFuzWMfclI4YN2tdDSKDd0xoaGgcLB4UFqT21dQ3c+9BTnHj8NN568VEunnUGt/75Br788KUu4khRFF558wPGTT2NohFTuPZ3f8Pr8xOJRBl/9OlMPPYsYrEY9Q1N5AyYwG13PQSoFqtrbriFX990O/1HTGXyceew6KcV3Y6n1eXmjrv/y8RjzyJv0ERmnnk5W7eVA1BRVYOzYDT/uv9xQHXxDBx9DLO/+IYpJ8yicNhR3HLH/Yl9rVm/iRmnXULuwIlMPu4c3vngsy7H8weC/Pm2exky9jiGjD2Om2//N/5AsMPxXnztXS6++kYKh09hxmmXUF1b32U/28oqcBaM5uEnXki89tBjz5FZPA63x9th2x1dD1EUee7lt5l+ykUUDDmSsVNO44uvv+vw2X/c8zB//ccDFI2YwoOPPstps64B4LRZ1+AsGL1L5zhq0klUVtWyfNW6Dm4oAJfbw+atZUyeOI5fXX0x1155IQu+fJtzzjipw/6/+mY+U2d2vf5zv13I2Rf/ipJR0xh8+HTu++//Eu9d/4fbOf70S3nzvdkMH388/338eV5/5+OEy3LycefQf8RUbvrrv4hEokDP919nAsEgv7/5nxSNmMKUE2axcvX6Ltc/bkGNRmP89k//oP+IqQwdN4M//u1ufP5Awn365HOvMeO0SygcdhRX/OrPHb7LL77+jskzzqVw2FGcf8VvqW9oAkicx9Lla5g841zOveTXKIrCnfc+wqAxx1IyahrX3HALDY3NXe5pUK25Rx53NgVDjuS0WdewZv2mxHunnHs1l/7fTTzwyDOMmnQSgw+f3u19raGhobG3OegE0tLlawhHIlx1yXkIgpB4vf1/x/no0zn87s93Mu7wUfzr9j/yw6Kl/Ov+xzGbTTx499/YvLWMl15/n8efeQWbzcqffvd/ic++9/EXWC0W7rr9Jrw+P5ddexPBUKjLMSRJYtnKdVxx8bncfON1rF2/iT/dek+P429ucXHvQ09x9WXnMWRQCf97/nVWr9sIwJ9vvZf6hib+fefNTJl8BKFQuMvnb7z5n7zy5gf8+ppLuP7qi3np9fe46Za7Omzz1zse4LCRQ7n8wrNZtnItj/3v5S77GVBSxJETDuejz75OvPbV3AVMP/pInCmOLtv3dD30ej3ffb+Y46dP5Z+3/QFFUbju97clBA3A86+8w7oNm7nvzr9w/jmncs3l5wNw659v4LXn/rtL5/jIfbeTkZ7K4IHFvPbcf8nMSEt8LtWZwsjhQ/jk87lcfcNfWLJ8dbffwXMvvc1Vl3a9/stWrqWkfyH/vO0PDBsykHsfeoofl/wsjNdv3MKDjzzDzTdex1mnzUy8/shTL3LtlRdy9ukzeeHVd3nmpTeBnu+/zvzj7od5+Y33ufrSWVx92XlsaRPY3fHmu5/w6lsfcs3l5/Pray4hFA5jMhoT7z/8xAucd9bJXHvlhXz06RzufuAJAJYsX81FV91IQV4O9/zjz1RV1XJjp/vmoqt/z6yzTuaWm37Fd98v5r9PvMApM4/lL3+4DgUFs8nUZTzz5i/iyutvZvDAEu676xZaWt2ccf61NDa1JLaZ/cU3rFi9nt9ffwWCIHDz7f/e79zhGhoahx4HnYstHk+Sn5ez022fefFNSvoXcv8/bwEBtpaW8/7HX3D/XbdwzNRJnH36TB545BnC4Qh/v+V3HYTB6FHDeOieWwFoam7ln/9+lKUr1jDtqIkdjpGZkc5n7z1PbV0Dq9dtpF9BHkuXr0ZRei5g/uJT9zNkUAnJSUksXbGGraXljB45jOQkOwgCo0cN4/KLz+nyuVaXm/c+/oJzzjiR3//6SgBWrd3IOx9+zn3/vCWx3XVXXchf/vCrhHVn67bt3Y7jolln8Ns//YPt5VU4HOpYnvjPP7vddkfX47Xn/ovX52flmvWMHD6Y2V98w5atZYwdMxIAm83Ka8/9N2HhO2zEUAAmHXE4UycfsUvnOH3aZKxWK2mpKZx64vQOnxUEgdlvP8tt/3qIt977lPc//pKpk4/gsQf/0cHF9uL/Huj2+t9y06+IxWKsWrORCeNGM/+Hn1i6fA1HTlBdSsFQmGcevYdxh48CYOFPywH419//yEnHH0MsFuOt92bz+Zzv+O11l+/w/osjyzKvv/MxJ0yfyt9v+R0A27ZX8vjTr3T7PSQn2wHIzEjj8ovOwWIxd3j/j7+9huuuughQBdoXc77jgX/9ledefhub1cLjD92JyWQkGAzxl7/fRzQaS3z2N9delrjmS5evAcCZ4uCiWWck9unx+Toc7+kX38RgMPD4Q3eSnGQnMz2NWZf/hnc+/IzfXHsZAFmZ6bzx/MMIgsC6DZt56fX3aWpuJSc7s9tz1NDQ0NgbHHQWpH4FuQDU1TfudNvyimrKyivpP3Iq/UdM5dH/vURTS2vi/XPOOInGphYkSeLSC87q8Nn2Fqkhg0oAaG11dzmG1+fnoqtvZOTEE7nj7ocJBEMEQ+EdrpCNBlW3ZqSnAhCJqi6Z/z3yL06acTQnnHkZJ59zVRdXS3mFKg5HjxyWeO3ww4ar77ULRDa2WRQMBgOpTgeRSIzuOPPUE7DbrHz82dd8890iDAY9J59wTLfb9nQ9FEXhrvseY8jhx3Hd726lrLwqcV3iFBcV9Do2rLfn2BOpqSk88dA/Wbv4C35z3WX88OOyLhlgPV3/jz6dw8iJJ3LWRdexYOGSLucBqlDsTPzaGI1GBpQUJe6Tnd1/oFoUg6EwJcWFOz03gLNOm8njD93J48+8yujJJ/P0C290EOOdv6eWtrFUVNYQCIYYfPh0+o+Yys23/xtFUWh1ubs9tyPGHcYbLzzCnG++Z8SEmdzz4JOIothlPBWV1QwsKVTFPXD4aPW7qqj4+bsy6PWJcWWkqxa/+DXX0NDQ2FccdAJp3OGjMBgMvPT6ex0eDLFYVxFQVJhPYb88Pnn7WWa/8xyz33mOj996BlBjZ+558EkmjBtNIBjixdfe7fGYW7aWAVBc1K/Le0888yrzvlvEsvkfs+S7j7pYRHaFjPQ0Hrj7b2xYOodoNMqlnR7s/YtUK8iqtRsSr61co/73LwlCTk6yc8apx/P5nO+Yv/CnHt1rnWl/PX74cRkPPfYcjz5wBxuXfc2v/++SnX5ep1dvy3isTnt29xzjrp283Gz+dfsfOXLCWLZs3b5Dix5AOBzhut/fyikzj6V8/fc881jPbtKeCIXCVFTVJs5hR/dfnLTUFAwGQ8LNB+xwrIIgcMn5Z7Lyh9lce+WF/OXv93WbDagoClu3lVMcH0u/PJLsNj568+nEWGa/81xCJHbHySccw8K573H/P//C/Q8/zVvvf9plm6LCArZuq8DnDwCwcrX6XRUVHbhB8RoaGocGB52LrahfPjf++koefPRZLrnmD5w881iqa+p4+fX3+eitZxg8sDix7TWXX8A1v7mFZ196i+OnT6GyqpZJRxwOwIuvvcfGzaX89O2HPPjos9z9wBOcfvIM8nKzAdi8pYz7H36atFQnDz/1ImMOG85hI1XXUG52Jpu2ltHY1EIoFCYciTBn3vcEgiE+/eKbX3Rebo+XC674LcdPn0puThb+QAC9vqO+TUt1cu4ZJzH7y2945MkXURSFz+d8y6yzTiY1NQWvv2sAcHvycrIA+GHxMi654Ex0Oh0XzzqTU8+7mm3bK7nr9pt6/GxP12PutwsB+HHJCgKBII92E+/UmbjQefbltwgEgpx+yoyEhWFn57gjfvhxGWdddB0XnHMaE48YQ1V1HUtXrObEGdO6jVFrT0wUicVENm/dzjsffs67H/Y+kPjRp17G5fby+Vff4vX6uPwi1T26o/svjsFg4JSZx/Lpl/N48NFnsdmsvPrWRz0e6467/0tzq4upRx7B9jZrnV6vR5ZlAF56/X2sVgvLVqxlS+l2/n3nzQBcddks3v3oC/7z+POcfdpMGptbKOqXj8HQ/RTxzItv8v2ipZx4/LSEINbr9V22u/aKC/hq7gJuuOnvzJxxNE888yrOFAfnnXlyr6+fhoaGxr7goLMggRrc+9iD/6C6tp6bb7uXjz6dw6+vvZSBJUUdtjvnjBN57MF/sKV0O3+5/T4+n/Md/kCAllYXdz/wBBeceyqDBvTnzr/dCNAho6kgP4flq9Zx572PcPhhI3j56QfR6dTLeemFZ7O1tJxFPy3n+msuZsK40dz9wBMsX7UuEYC8qziSkzjz1BN454PP+ONf78ZmtfLcY//ust1/77udSy84i8efeYUnn3uNyy88m//8+/ZeHaOkuJBpUyby6RffJFLtJ08cS//CArw+X4/uNej5ehx3zGRmnX0Kb7//Ka++9SG/+9XlPe4jzlGTxnH5ReewaPFy7rj34UQ21e6e4+SJY3nwX39j05Zt3PL3+3j1zQ+49IKzeOyBf+z0s8lJdu6540+s37iFBx5+htNOOq5DAPiOKOyXx7/ue4zlK9dy7z9u5qTjpwE933+defDuv3LCcVN55MkX+fjTr7n2ygt6PNZZp59IVXUdf77tXubNX8Qdt/yuQ9r9oAH9efiJF/j0y3nc9JurE/fjpCMO540XHsbl9vDXfzzA2+9/2m1GXZzjj52CKEn87c4HeOPdT7j+mkuYdVZX0XPcMUfxwpP3sXlrGTffdi+pzhQ+fvsZsrMyenXtNDQ0NPYVQjQa2bFvQaMLoyadRH5uFl9+uHNryIGOLMtMOf48Bg8q4aX/PdDtNofS9dgVXn/nY2646e989ObTHDN10j4dy/eLlnLarGt49P47uOyis/fpWDQ0NDQOBA46F5tG37Fk+Wpef/tjNpdu5+VnHtrXw9HQ0NDQ0NhraAJJo0fuuOdhtpVVcP9dtzBoQP99PRwNDQ0NDY29huZi09DQ0NDQ0NDoxEEZpK2hoaGhoaGhsTscFAJp8bI1XPqrv3Hxtbdwze/vYP6iZft6SHuUuvomjj/72j16DEVReOH1D7n4ulu4/IZbWb+ptNvtPvt6ARdfdwuXXf+3Dp999+M5XPP7O5h11Z+497/PIbYVxlz400quu+mfnH/1n7nihtvYuKVsh+OYO38x/3fjnVxwzc387a5HCLRrUdL+eI88/RpnXXYj515xE19+80OXbW6/53HOuuzGxL8rqmr58x0PMfWUy9myraI3lyTBr//8r8Q99tW8hbz+7o5T/lta3dx8x38SVamPnHlJoi5Qe3b1e12xekOH674nuOvBp3nrgy8BWLZqPY8+88YePZ6GhobG/sIBH4MUjca49e5HeeL+Wxk6qJjmFhflVbX7elgHPEtXrmf+omW89Pi/2LKtgtvueYz3XvxPl9pLQwYWc9rMY/j86wWJ17w+P26Pj6ceVFPvr/79HXw59wdOnTkNq8XMA3f+EUeynTfe+5ynXniHR/99C90Ri4lsKS3nkXv/gsVs4uZ//Jc33v+C/7usY5uVpSvXs2jJKt567n58vgAXX/dXjp06IdEbbMGi5dTUNXT4jCM5iQvPPokNm3cs0HbGzOlH7XSb9DQn99/Zcw2pA4XxY0YwfsyIfT0MDQ0Njb3CAS+QREkiEonh9akr8oz01ET138/mLGD+wmUYjAYqq+tIttv4+59/RW5OJoFAkIeefIUNm8sQBLjh6guZMulwKqpqefy5N2lqdhEIhvjVlbM47mi1v9pJs67nuivO46PP5nHTry/j4y++pV9+DqvXbWZbeRWzzpxJqtPBR5/No6nZxZ23/JrRI4fQ0urmkadfo7q2Aa8vwKwzZzLrTLWZ6VmX3cg1l57NZ3MWUFZeza+vOp/TTzq2wzk+9+r7CILA2g1bSXWmcO1l5yArMi+98TELflyGy+Pj7lt/y/AhA1AUhZff+oSvv/0RRVGYNP4wrr/qfIzGn7/ql9/6hG/mL+5wjAHF/bjj5usT//72+yUcf8yRGI0GRgwdgNlkYtPW7YwYOqDD5wYW98Pr9fH5zz1tSXEkdxAxhw0fTH1bXaWxo4ejKAqNTS3U1DUk9vfdwqW8+vanPP/onYnPGY0Gfn31zzV/Dh81lLKKru1E7DYrKY5kTEYjGemp5OVkEi827fMHeOzZN/jL76/i7v88m/hMqtNBqnM4JpOxy/7irNtYyn+efIVAMERudgZ///OvSOtUjPKtD75ka1kFt//pOhoaW7jrwaepqW+kvqGZrIw0TjzuKC6ZdSonnHMdP371WuJzr7w1m5VrN+Lx+rnm0rO7FVq9OX4wFObu/zzL5tJyBAFuvelaBg8o6vE+DoXD/OPfT7GtvAqT0cjvf3UJE8eNoqKqlvsffZEWlwdHsp3b/ngthW1te+LMX7SMtz/8kicfuI0Vqzfw2ruf0S8/m2UrN4AAD9x5E3k5WcRiIk88/xY/LlV7Dl4y61ROP/EYyitruPP+/xEIhnCmJHPnLTeQm63VQ9LQ0Ng/OeAFks1q4a9/uJpb//UoY0cP46JzTmb0yCGJ9ytr6nn037eQlZHG48+9yePPvcndt/2Ox559k1HDB3H7n67D7fFx1W9v58gjRuNMcfCbay6kqF8ea9Zv4ZY7H2b61AkIgoDb46O6toEXH78LQRD4+ItvWbN+C/fe/nuqauq57Ne38ofrL+WZ/97BC69/yCtvz+ahkUNwJCdx8bmnMGRQMY1NLZx75R85acaURH+q+oZmnrj/Vn5YvIL7H32xi0ACeO+Tr3nhsbvIzc6grr6JSDjK8CElXH7h6Tz6zOu89cGX/POvN/DVvIX8sHgFzz36D4wGA7fe/Rivv/cZV1x4RmJfl19wOpdfcPoOr2tjcwuHHzY08e/szDQam1q6CKSdEYuJLF25lltuvCbx2uvvfsYTz7/FxHGj+MOv1YaljuQkCgt6bjCsKAo/Ll3NycdP7fLe8CElDB1UzG//ci8jhg7ghOmTsZhV69Gjz7zBrDNnkt9WJby3+PwB7vnPs/z37pvJzkrnw8++4eW3PuYP11/W42defPMjivrl8th9f+WbBT/x0WfzuP6q87t1p40YNoAbrrmA7RU1XPGb25g47rBfdPxgMMzF555C/8I83p/9Nf9++DleeOyuHu/jn5atpbqugXdffAivT63GLkoSt9/zOH//868YWFLI4mVrePzZN3dq9Vq3cSvXXXEev7/uEm7912N8/Pm3XH/V+bz+3meYTUbefFZtdnv5DbcxZeLhfPDpN4wcNpA/3nA5dQ3NZGf2rtCmhoaGxr7ggBdIAKccfzSTjxjDJ19+xy3/fJgTjj0y8SApKsglq63i8dQjx3HHvU8AsODH5azdsJUPP1Vbf8iygtvjJT3NSX1DE0+98DbllbW4PF6CwRB2uw2AS847tUNbigljR2GxmBlYUojFbGbqpLEIgsCoYYOYv0jt5m40GrBYzDz/2odsK69CQKChsSUhkKYeOQ5BEBg5bBDN3TS8BTju6EkdVttWq4UJ49Su8SOHDeKD2XMB+P7HFZx+0rFYLRYAzjnteJ5+6d0OAqk3CEJHV5qisNN2HN3x/GsfMGRgfw4f9bPYumTWqZxz+gxefP0jbrnzYR785x8Ze9gwxh7WtdFrnE+++I5oLNatpWVbeTXNrW6uuOgMPvpsHuWVtZx18nTWrN9CXX0Tf73xahoaW3Zp3Os2ltLQ3MKf71DrP0mSTHFR/g4/k5OZwbbyKmIxEZfbCzu4XOPamrYWF+WTlZFG6fbKDiKut8fPSHfSvzAPUO+j/zz5CrGYSIojqdv7+LCRgzEZjdz3yAtccPaJ9C/Mp7yyhoqqOv75wP8A9bu2WMw7vUY5WRkMGdgfUAVfeUUNoN6DPn+AH5euBiAai1Hf2MxxR0/k3488z/OvfcjZpx6XqDyvoaGhsT9yUAgkUF0ml19wOtOnTuD8q//MVRd3rRZs0Ot/nvgVuPOWXzOwpGOX9I8//5Yv5n7PlRefxeUXnsFxZ16D3K45aOcYnDiCIGAw/NyLymDQE/fz/Lh0NU88/xbXXX4u555+PFdsua3DPjt8pgd6Om78cwrdV2sQBPX/7emNi021GP3cWb6hqYXsrPQex9Ad73z0FWs2bOE//7q5y3tWi4XLLzyDGWf9H7GY2MEF2JnvfljKu5/M4fH7/tbtdXjh9Q85/8yZjB45hPFjRvDnOx7ii29+YOWaTbg8Xq79w51EYyItrW6u/+NdPPXQztuSKIpCQV42Lz9xd6/P9/hjj+STv3zH1b+7g1Sngz/dcEWvPmcw6LF2EiS/5PgGgx6j0Yher+vxPk5zpvDCY/9k8bI1/P3eJzj+mCOZMmksFouZl5741y8WLQa9IXEHKorCb//vQqYeOa7Ldi898S+++mYhl99wK//4y693KIo1NDQ09iUH/BJu45YyXnv3U2IxEYD6xmZSHEnY7VYAmlpcBENhZFnmvU++ZvIRowE4atLhPP/ah8RiIoqiUFvfCMAPP63g2KkTmDhuFNu2V/XJGH9cuprxY0Yw9chxuNwefL6uLpe+YuqRY5n95XeEwxFESeL92XOZMmlsh20uv+B0Xnnqng7/by+OAKZPncic734kFhNZv6kUURQZMrA/FVW1/PH2BxNZaT0x+6v5fDH3Bx74x00Jd1c4EuW/T72C1xdAURS+/3E5Rf3ydiiOFi9bw1Mvvs1//vVnnCnJ3W7jdCSzZv0WREkiEAxRWV2HzWrhn3+9gdef/jfPPXIn9/39RtLTnL0SRwAjhg6kobGFed8vASAQDKlWIUBAQJG7CtIvv1nIGScfy6v/u4dH/31LwrLTHVU19QAsWbGOYDDMgOJCEARkRd7p8dvj8wdwe3wAvPvRHCYfMRqdTtfjfVxWXo3L4+XII0Zz1qnH8eOy1fQryMGZksRbH3yJoihEozEam1vbzhWUtjH1limTDueVtz9NZBzGf1tr1m9BQOC0E49hzMghrFi9YZf2q6GhobE3OeAtSP0L8/hmwU9c/bu/E4nGsNus3HfHHzC0dRaPRKP87a5HqG9sYeig/lx9qWpZ+v11F/PwU69y8XW3YLGYmTh2FDdccwHnnn4CTzz3Jt8s+IkJY0eSnblrVpPuOOX4qTz4xMtc9du/M2r4oC7Br33JzOlHUd/YwlW//TuCIDBh3EguPveUXd7P2NHDOHbKEVzxm9swGPTc9bffoNPp8AeCVFTVIooSwWCY39x8N8FQmKYWF5dd/zfOO3MmwwYV8++Hn6OwIJfr/3w3KAoGg4HnH72TkqJ+3Pi3+/D6/KQ6HfzzrzcAqkvppTc/5u7bfpvIPnO5vdzyz4fJSHPy5zseSoiSR//9V7Ztr+LdT+Zw962/47orzuP+R1/g/Kv+hCzLTD96IjOmHbnD83voiZdZvW4zzS0ubr/nMfr3y+e+f/wh8X6KI4kH7vwjjzz9Gs+/+gFms5Ebrr6QcWOGM3nCGN54/3OOmXJEh30eNmIQN9/xX+Z8uwijwUBBXjann3gMw4aUdNguOcnGl98s5P5HXwTgntt/h8VsIjszjcL8XN79eA7nnXFCj8dvT2ZGGvc98gKV1XXkZKfztz/8H0CP97Hb6+P+R1/A1yZebv7tlRj0eu674yYefOIlZn/1HSaTkUtnncaMaZOYMG4Uz736Aeecdnyv751LZ52G3x/kyt/+HYvFzID+Bfz9z79ia1kF/33qVYKhEJnpafz+ukt6vU8NDQ2Nvc1BXUn7szkLWLBoeYcHn8b+iaIo/PaWe7nntt/jSLbvdHtZlrnh5nv47903JyxU+5rf/OUefn3V+QwfMgBRkvjPE6/g9fn5162/3ddD09DQ0NDYRQ54C5LGwcEb733OyTOm9kocgRpHNeuME/YbcQRwwrGT+e9TrxEOR4jGYgwqKeR31160r4eloaGhofELOKgtSBoHDoqi7FKW3K5ur6GhoaGhsSsc8EHaGgcHuyp2NHGkoaGhobEn0QSShoaGhoaGhkYnNIGkoaGhoaGhodGJA1ogKYqCKKp1jDQ0NDQ0NDQ0+ooDWiBJksTUU65A2knRQg0NDY1fQjQa47lX3ycaje3roWhoaOxlDmiBpKGhobEnicVibRX3NYGkoXGooQkkDQ0NjR4wGo1cfclZGI3GfT0UDQ2NvYxWKFJDQ0OjB0wmI9dces6+HoaGhsY+QLMgaWhoaPRAKBzmxr/dRygc3tdD0dDQ2MtoAklDQ0OjB2RJ5qfla5EleV8PRUNDYy+jCSQNDQ0NDQ0NjU5oMUgaGhoaGhoa+y1ut5cPPp5NfX0tOTl5nH3GaTidjj1+XE0gaWhoaPSAyWTirzdejclk2tdD0dA45FAUhXvuf4jli79jxiiR4ak6arfJXHXlm4ybdAx/u/mPe7QvpxCNRg7YMtSiKDL1lCv4/rOXMBg0raehoaGhoXGwcPd9DyLVf8sFU81d3nvr+wj6nGO59S9/2mPH12KQNDQ0NHogGApz0f/9hWBIy2LT+GWEwxFaWl2Ew5F9PZQDCrfby/LF33UrjgAumGpm+eLvcLu9e2wMmtlFQ0NDowcUWWZ7ZQ2KrGWxaew6pWUVzJu/KPHv6dMmM7CkaB+O6MDhg49nM2OUCPTs3p4xSuSDjz/lqssv2iNj0CxIGhoaGhoafUw4HGHe/EWkOlNIS3WS6kxh3vxFmiWpl9TX15KXumOJkpuqo76+do+NQRNIGhoaBzyaG0NjfyMQDAIkgojjf+Ova+yYnJw8al07ttzWuWRycvL22Bg0F5uGhsYBzZ50Y5gtZv57982YLd3HQWho9ITdZgPUTCxBEFAUpcPrGjvm7DNO46or32TGmJ63mbvWwAs3nbrHxqBZkDQ0NA5Y9rQbw6DXM2n8YRj0+j7Zn8ahg8ViZvq0ybjcHlpdblxuD9OnTcaiie1e4XQ6GDfpGN76vvvf8psLIoybdMwerYekWZA0NDQOWHbkxuiLB1EgEOT0S37HJ689it2urfw1do2BJUUU5OUQCAax22yaONpF/nbzH7nnfrjlVbUOUm6qjjqXzNy1BsZNOpa/3fzHPXp8TSBpaGgcsOwNN0YwqKX4a/xyLBazJox+IYIgcOtf/oTbfS0ffDybjfV15AzI44WbTtUqaWtoaGjsiLgbo3MMkvZA0tA4eHA6HVx0/rl73RKnCSQNDY0DGs2NoaFxcLOv6klpAklDQ+OAZ0+5MSwWC68//W8sFkuf71tDQ2PntE/EiLvR581fREFezh5fDGlZbBoaGho9oNMJZGemodPtuYaYGhoaPbMv60lpAklDQ0OjB4LBEDPOvpZgMLSvh6KhcUjSPhGj/d+9UU9KE0gaGhoaGhoa+yXxRIzGphaqqmtpbGrZa4kYmkDS0NDQ0NDQ2K9p86wl/u4NtCBtDQ0NjV0kHI5oWXMaGnuBeJB2Zkb6Xg/S1gSShoaGRg/YbFbmfvAMNps18dq+SjnW0DgU2dPV8neE5mLT0NDQ6AFZVmhoakWW1cDQPd37TUNDoyNakLaGhobGfkg4HObi624hHFbbjezLlGMNjUORfdn0V3OxaWhoaPSSvdH7TUNDoyP7qlq+JpA0NDQ0eonW+01DY9+wL5r+agJJQ0NDYwfYbB3bjGi93zQ0Dg00gaShoaHRA3a7jW8+fK7L6/tiNauhobF30YK0NTQ0NFAz1FpaXR0y0kRJYvGyNYiStA9HpqGhsS/QLEgaGhqHPD3VNoqEI/zh1vuZ+8EzGOxaILaGxqGEJpA0NDQOadrXNupcqVdDQ+PQRXOxaWhoHPB05x7rLVptIw0Nje7QLEgaGhoHNLvb+mNHtY1kRaG4MB9B17drSa2Xm4bG/o8mkDQ0NA5YduQe663w2Fltozeeva9Px6z1cjs40UTvwYcmkDQ0NA5Y+qqRZU+1jWIxkS/mfs9JM6ZiNO7+dNkXgk6jb+hLQXMoi96DWRhqAklDQ+OAJe4ei0ajRKIxzCZjh9d3he5qG0WjUe59+HmOO3pinwikfdmZXONn+lLQdBa90WiU2Z/P5cpLz8OZ4uirIe+XHOzCUBNIGhoaBywWi5mBJUW8/Mb7KIqAIChcftE5e0Rs9MVKWevltu/paytee9Fb39DEhk1b8QdC8Nq7nHbSjINKMLTnULCGagJJQ0PjgCUcjlBaVsHM445OWJBKyyqYPHFcn07SZdsr+XHpysS/p0+b3K1Lbmciqqd4J4CWVtdB6abY3+hrK157K+aGTVuxWi0oQHZmxkEnGNpzKFhDNYGkoaFxwBKfpE0mEyaTKf5in03SOr2OcWOGs+DHJWRlZCRWym+//ympTgcGgzqFxkVOb9wNneOdqmvreeXND3b6OY2+oa+teHHRO/vzufgDIRRgxLBB6v3Yh/fi/sahYA3d63WQ3vzgC0678De8/u5nXd6rrm3gmt/fwcXX3cKX3/ywt4emoaFxgNF+km7/t68maavFwp1/uR6jwZhYIYuiyJbSMiwWC2mpTlKdKXw1dwFzvllAqjMl8dq8+Yt6rMtksZhJT0sFSLgpevO53an3pKESFzQut4dWlxuX29Mha/GXMLCkiCsvPY/DRw9j6pHjycnKPCgFQ3vi17GxqYWq6loam1p2+zrub+x1C9LYUUMpLavs9r1Hnn6NKy86kzEjh3DJr/7KlEljSdLK+2toaPTAzlL0d5doNMY7H81BkeTESjkUjqAoAta2Y8QDc+P/3f7vzqwHu+KmONgDYvcmPWUt7g7OFAennTRD/Y4C6vd6sAmG7mi7ZRN/Dyb2ukAaMqiY3OyMLq9LksziZWv4x83XY7fbKCzIZcXqjRw9edzeHqKGhkY73B4vTc0tZGak75dZOXviYRcnFovxytuzeeah2xIxSLGYyNDBxQn3mqIomEwmBKH7bLodxSX11k1xKATE7m26y1rcXfbkvbi/Eb8nMzPSD9p7cr+JQfL4fDgdydjbLEaFBbk0t7i6bPfeJ1/z/uyvgZ/N6RoHBgdzvYyDlXnzF3XJEIvH2+xP7ImHXXtKigsZNLC4Q9xQe2vOzBlHU1lV0+Vadd6us9WntxawQyEg9mBhT9+L+wuHwj253wgkAQG5neCRFQVB19Vmd+7px3Pu6ccDaizA1FOu2FtD1NgNNPfAgYfb4+XlN94nIz0NnU6HLMu8/Mb7jB0zcr+0JO1p2j/4OlsKwpEIsz+fy/Sjj0RWwGwysnHzNjZt2bbTFXZvrA6HQkDsgcyhuPg7FO7J/UYgpTiS8PkD+ANBkuw2qqrrmTT+sH09LI0+QHMPHJg0NbegKAK6tj5kOp0ORRFoam45ZASS3mDgtBOnoTd0nSrjgqm0rILZX8xl5ZqNJNmtDB86iOSkzF2KS9qZ1WFPx1pp/HIO1cXfoXBP7nOB9Pq7n5GZkcoJx07myCNGs3LtJg4fNZSqmjrGHjZsXw9Pow84FEyxByOq5UNBluWEBUkQFDIz0vf10PqcniwAFrOJv/3h/3b4uXnzF5GdmYHdbsVqtbBh01bSUlMScUl9tcI+lOJbDhQO9cXfwX5P7lWB1NTi4o+3PUCLy4NOEPhx2WpKigoSD8wbr7uEv//7Cf734jtcf9X52G3WvTk8jT3EoWCKPdgIhyNIksSF557Om+990iGuxpniOKhcCjuyAIQjUf7z5Mvc9OvLsZhNXT7bvg7TiGGDWL9xK4FAiJraeiZPGo8ArFyzIdGmZHdX2L80vuVg+r72J7TF38Edc7VXBVJmeiqvPHVPj+/n5mTy7MP/2HsD0tgrHAqm2IOJ9Ru3MuebBZhMJoxGA9dfcwl6nY5+/fLIyco8qFwKbo+X2Z/PJS01JRE71N4CIIkis7+cz++vvRi6EUjtxX9OViZpzhQ2bN6K1x/g6RfeRBAUSooLOWXmsYwcNmSf3PMH0/e1v6Et/g5u9rmLTePQ4GA3xR4srN+4lfsf/h9WqxWdIJCamsK8BYuYdMRYbGs2cNSk8SxcvOygcCnEY4d+WLwMt8dLTlYWKY4k8tvu096cT2fxH4uJCIKO6po60tJSMOj11Nc38dPS1YwcNmRPn1IXenIBZaSnIknSIf1b7Aurmrb4O7jRBJLGXuNgNsUeDITDEebMW4DVaiU5yU5Li4tPPv+ajLQ01qzbyNjRI5gzbwEmo+mAdyn8LBycuN1ekpLstLS2kpRkY+Pmrej1+l7vq734X7NuM1/P+4FmVytJNhv9CvIw6A1Eo1FaXS7MZvNeFSXduYCamlt58bV3E1aOQ9Gi1JdWNW3xd/CiCSQNDQ1AfZjGxU9MFKmqqUOn02MwGEhxJLNhUymDB5UQjUYPeJdCXDgoikJuThbVtXU0t7oIhsJkpqdTWlbO+MMPw2g0cvUlZ2E0Gne4P4vFzLbtlTz6vxcoLasgGAqRbLcTDkcYUFxIfWMz7370BVaLBdh7oqSzCygajbKltIyZxx2NyWQ6oC2Av5Q9EVitLf4OTvZ6LzYNDY39E7vNhtFoYPjQgXi9PkRRRJZl8nKzEEWJcCRCwB9g2tRJPfax2t97hcXHF7cQmU1GbDYrZpOJnMxMxowaRmZmGkuWrSYcjiDLMmedMh1ZlrvdT/w8w+EIn8+Zh8frJy8vm+QkO16/n+raemrqmigtK2fT5m1Eo7Gd9lvrSzr3HWtobGbwwJJEY9/2FsBDhR0FVsP+fw9r7D00C5KGhgbQMZ7isJHDCIXCDBs6iM1btxEKVeByu3EkJbFsxRqOmjSenOyMDi6F/T0YuPP4BpYUUVpWQWZGOhs2l9K/Xz4xUWLk8MEYDAbWbdzMT8tW8fEX33HGSccw87hpic90Ps9UpwNFAQQBu9VK/6J+eLw+/P4A06dNZHtFDXablQ2btpKe5gS6uiX3VKZZexeQXq/nnQ8+O+AtgLvDjgKr9/d7uLdoWYt9gyaQNDQ0ErR/mB591AQeefIFCvJyKN1WwRFjRxONxUiy21i4eBmXXXh2B8vR/lwPprvxlZZVMOvsUwgGg2RlpJGcnITVYsZgMNDY1MKSZatJSU6muraRlOTkRHBzd+c56+xTsNts5GZl0uJyq50BJImCglyys7LYXlEDgKJAqM0y0V6U7OkHc3sX0KEeVNxTYDWwX9/DvWVvi7yDWYxpAklDQ6MD7R+mxf0L2Vq6HZPJRHNLK5IkE4nGgI4WkF9aD2ZXJtddnYjbb9/T+ILBIGazmRnHTmHh4mX4/CIAE8ePYcXqdV22b2puSfw7Fovh9wfweLwEg0Fmzjgat8fLxs2lSJLE+LGjsFrM2KwWRgwbxLoNWwiFQoRCYWbOOHqfiUstqLj7a9DSqvb+PJATEPb2vXSwWNx6QhNIGhoa3aLX69leXklmRhqtbg9Go5H6xkbiLRLbW0B+ST2YXZlc228bi4lMHD+GkcMH9zjpx7ePxUSi0SjTpk7qMr6m5lY++vRrDG1tRNq7DQFWrF6XOI/433gV8fqGRn5cspK6hiai0RjBcJiLZ53JH397Da0uF4oikJ7mTDSrNRmNHDZiCBPGj2bksCGEIxG2bttOZkY6kiQBe/fBrAUVd70Ge6qmUV9aWHa2r71ZuHJ/txr3BZpA0tDQ6BZJkhg8sITq2nrSU53U1TfidDpodXk47eQZHVty7GI9mF2ZXNtv29DYzPqNW/hp2WomHTGaE447uouoim8fjUbZsKkUWVFYtXYDF5x7OlXVtUC8XhEdGsl2dhtOnzaZr+f9wHFTJuDzBzl++hScKQ6OmjSeex96krr6RsxmMyXF/aivb+KruQu4+rJZ5OXmJMbS2VIB8OXc+bz30ecoioAki1x43hmAVmxwX7Mnahr1pYWlN/vam4UrD4Uq4ppA0tDQ6Ba7zUZmRhrFRQX4AyGisRihUJArLz2v22a1u+K62ZXJNb6tKIps2LQVu90GgoDFYulWVAWCQWIxkQ2bSjGZTUiihGQysWlLKVdech6SJBEOR/nsq3k9Hj8cjpDqdHDheachSRJ6vb7tcxFysjM4bOQwTCYjzhQHer0ej8eH2+2hrr4BhyO5w/m3b2r72ZfzePfjL9ALOnQ6AbPFzIOPPMOffnctDY1NiXM41OKC9hf60v3YlxaW3u5rbxauPBSqiGsCSUNDowPtzfjTp03m7fc/ZUtpGYoiMHRwMc0trm4FEvTedbMrk2v8tVA4QttmAFgtZlpdYapqaumXn5c4rt1mIxqN4vaqokVRFKKxGPl5OUiSRHpaKm6Pl0AgSJLdlqgHFP9s+5V6IBTio8++48xTjsFuVXtDHjVpPEl2KyaTCVlRaGpoorqmlsbmFjZt3cbQwQPJzEjr2NOt7QGn0wkY9Hr8/gAAjuRkIoYo6zZs4oZrLzvkq1vvD/SV+7EvLSy7sq+9FWN2KFQR1wSShoZGgs5m/KMmjSfV6WDalEmJDK++iDPYlck1vu1XcxcQDAVRUBg5fDAtrS6WrlgDgNFoSAgSi8XMtKmT+GD2V9htNgSdQHFRP7aXV6LX6xPnGAyF+eqbBQweWJIQNABfzV2A1WrB4/WxZt0mNm7axIDCHMaOGUl2VgYLFy9j2pRJlJVXsvDH5bS6PThTkklKTsKRnKzGbaWn8umX8zjvzJNJT3MmHnAOhwOlraaSIAiIkohOELDb7QnxBj3HmsRfj1u04n81UbX32Vk8UF9aWHZ1X3srxuxgD/jXBJKGxiGE2+OlqbmFzIz0Llag7sz48dYijuSkDtv2RZzBwJIiMtJTexxP520LLpvFxCNGs2TZahQFlqxYzfixh5GdldHF5VDUL48ZxxxFRVUNBoMBvV5PcVE/gsFg4hzTUp0UFxXQ0NTMrLNPwWI2s3DxMn5cshybzcq27ZVkZ2YgCDr0eoEVq9dxzJSJAKQ6k0lOTqKosACD0YAoiWwt3Y7H7cfldlFX34TX76e5uYXCfvkcNWk8ADarhaOPmsCHs+egAMFgiKMmjUOR5UTxyp5iTeKvNzW3sqW0jIz0NJpbWjsIvIMpg2h/pjfxQH1pYdnT1prdCSQ/mAP+NYGkoXGIMG/+Il5+430URUAQFC6/6JyE1QS6N+ObjCaCwSBenz9hQYKeV667MtHu6CHT3X4sFjPjDz+MkcOGUFWjBltnZ2V0GHNcuNltNnJzshg0oD+RaAyzyYg/EERROrooTCZTm1utnCXLVvPjkhXU1jeSn5uL0WCksakVSZIor6hFUmS+/f4nBpYU4fEE2Li5lMzMdFweD83NrYQjEbx+H0ajkeraerKzMmhqbmX40EEsXLws0eg3JzuLGdOnEA6FcKamUlVTh9Vq5Z0PPuuxGXC8/lKS3cbKNRtIdaawau0GRg4fQnVtPcVFBarl69QTSE9zdhvofrCu8vc28YVEkt2WuLd6agDclxaWPWWtOdhT9XcHTSBpaBwCuD1eXn7jfTLS09DpdMiyzMtvvM/YMSMTlpvuzPhujxdRklj7/U8IgsLggSWcf86p3U7OuzLR7ijoNJ4a39N+LBYz/fLzMBoNPbocOq+4Y7EY06dNTlSxbv+5WExkybLVWCwWkpKSKCk2s21bJaAgKwpDB5egMwjIMRAEqKtv4N2PPqO6pgGPx4fdZqVBkjEZTEQiEdLT0nB7vGRmphGLifgDIQBysjM4atJ43nz3Y1paWhElmeqaeo6cMJaS/v0wGAw9NgOO11+K16CKRmPEYiLhUJiYKLK9opotpWVEo1HsdluHa6Y9APuWQDBIU3Mrq9ZsQFHUe8JoMvLEM6/gTEnp4O6FvrWw9LW15lBI1d8dNIGkoXEI0NTcgqII6HRq+0WdToeiCFTX1HVY9cZFRSwmEggGkSSR4UMGMXhAf0LhCOFwmIK8nC7739WJtqeg01aXq8+ydQrycjhl5nQEQSEtNTXx3lGTxvPZV/OQRBG9wcCUSeNZt3ELBr2OYDCEzWqhpLiAgrxcNm4pxWQ0YbdZSU5Kora+nnUbtzCopD8Z6U7C4Sgul5cURxIl/fuRkpKMwaBn1ZqNNDY2IysKBoOeosIC9Ho9839YTHOrm+ysTGrrGtlWXoXPH2To4BJGjRiKyWjqthlwvP6S2WTE61Ndd41NzXg8Xmw2K9vLq8jNzSYnO7NDnBgcHNWh9yf0en3CxanT6WhubuXb739k8oSxmM1mhg8deMBc40MhVX930ASShsZ+TF+5RtR6PwqyLCcsSIGAn2++W4TV2rHDfCQS5fM58wgGw5SWbSctNZWc7EyMRiOiKHY7eba6XAQCQZKT7D9vFwjS6nJ1qAsUP6dwOEosJnYRAp1dYD1N2G6PF0WROf2UGRjbYoziafjxlPqe4ng+/mwOS1espr6hhezsDELhCF6vj/qGJsorq/F4fVgtVnJzsrnyknO56db7ufjcU/ni62/x+vyqu9FkxpmWQkFeNoFgiPy8HAwGAy63hzXrNhKNitTVNzFwQBE6vR5BUKt2RyJRYrEYFRU1bCotIxwO0+p2EwxFWL9xCyOHD+GE445m4eJlHcbuTHEkAtXDoQiRSJQku51YTERWVEtX26XqtgGt9gDsO9rXB5MkiW3llaQ6U7DZbJjNJjZsKmXEsMF79RqrDXbdXRYDO+NQSNXfHTSBpKGxB9kdgdOXrhFnioPLLzonEYMkyyLF/QvJy83uEuvy0adzVMuSLFFb38iPS1Zw6onTe4w/Ki2rYM43C1i5ZiN223aysjJobGwmEAxjNps6FHNsf04er1d1RWWkJc6vOxdY52POm7+IF159h5goYzTomDljGqFQOPF+5zieaDTK7M/ncuGs05nzzQK2V1QTDkfJzkwnFAyzZWtZorGsIzmZJLsNvV5PWXkl6alOIuEIP/y4BLfHh8VswpGUhNfvR1ZkjpowNlFlvLSsgrLtFaSnp5GbYyY/N5tAMMjkCYcTjkQJh2Ns3lrG4iUrCQRDxGIxbDYrAqolLy83m4njxzBi2CAGFBd2uW8GlhRhPfUEotEoJrOZ5SvXkGS34/X6QACLxUI4Eu32e9pbD8D29ztwUMY9ta8P1uLyIIkS5ZXVGAx6tQWNKOJ2exJB93ua0rIK3vngUzZt2d7BDd6bueJQSNXfHTSBpKGxh9gdgdPXsQFuj5d+Bbn887abiEaj6PV65n67sItlobqmji2lZYkK0yXFhWzaXEZ1TR0pbVaMzmnn8+YvwpniYMTwgWzeUsa8+YsYOngAE8YfRmZGeo/unlRnCk3NLZx64rGkparp7YFgMCFw2l+3+DHdHi9PPPMKgWAYnSAgyhKPPvUyN1x7KUl2W4fMO0EQqG9oYsOmrfgDIYJtfdAkSUKRFby+AE2trbjdXkRZon+/fPJys5EVmXXrN5ORnorNasVoMmG1WEhzpmAxm2hsaaXF5aappZU5336PTqcnJTkZi8VCJBqjurqWWEwiyW7DbrMhSjJNza18MPtLVq5ejyTLSJKErMhEIlEmjR+DwWhk+NABjBw+GOg51iQ9zYndbsNsMqrfm07AarMyeEAxq9auJ9gmvNpfs7jlKRqNYjKZOvSB60va3+9Nza0IAmSk/yx+D5a4p/aiQtdWqmHq5CNoaGrB09RCVXUtBXk5vPPBZ3ulUeycbxZQWV1HVqZ6ratr6vhq7gIKLpvVod9fT2L1YE/V3x00gaShsQfYXYHTl7EB7bPXZFnk3DNP5phuepMB2GzWhJsLwOlwUFyUz8kzj2FAcf9uq1y3D1iVJJnUFAcTxh5Gaqqzy/l0PieDwYDZbO4SmN2+L1r7Y1bX1NHQ1EpGeiqCICBEo/gCflxuN0l2WyLzLhqNEo1GWbVmPQpgNOrJz8vlm+9+IByJUtfQiMfrIxYTiSUnoRNUK47ZbG47RjOyrDBi2BB0Oj1Go5GUlGQqa+ow6HQYdHpsyclU1zSAAKFgmMzMdGRJJhgMo9MLLF2+miGDS/D6/AiCGj9kT7JjtVooK68kxeEgFArj8nixWi2MP/ywnX6XFouZgSVFvPzG+/gDQbZuK2fCuNHY7VZuvvFX3V4z9Vp3/NvXWW3t73dRFFm5Wr3uxUX9+qx21t6iN9emvag4ZuokFi5ehtOZwk9LV3L2aSfSryB3r8R7BdrctoIgJH5XoFpN43NFaVlFF4HcXUmCA+G72dtoAklDYw+wuwKnr2ID2meveX1+qqqbefCx56iorGHUiCGUllUktp0+bTJ5OdkMHVxMZXVd4rjDhgzsVhxB14BVs9lIWXklpjYLR3fj7nxOer2+i5js3Bctjs1mhZ/1mxrfg4DRaErs22g0cMzUSTz57Cv88NNyDAbVwlOQn8vAkv4sXbEaEAiFVBeggEBRvzy2bCunqrYBMRZFbzBgMOj5/selnHz8UWzaso1gMEQoGMJut5GalkIkHMViNiPLEmFBoKm5BavZTDAUxmw2YrAYSE9L5fSTZjD3ux/Q6fT4fP62rvECkUgUvU5HTW09/QryePG19/lxyQpmnd2ze8Tt8bJ67UamH30ksqLeVy63m1lnn9JtHam4cGnfc+7t9z8l1elIuOL6wsrR/n4PR6KAgCBAOBIl2WhMbNNXD+Ed1fPaHXbF6hsXFelpqQwoLqSqphajwdBj6Ym+oLN4s7fFPSmKkvg9gZIoXxEOR3j7/U+prqlD/eGomal//O01miDqBZpA0tDYA/SFwBk7eiQ/LVuF0fjzg2xXJ7V49posK9TU1mOxmInGYuh0AqVlFcw6+5QutVtmnX0qc75ZQCQSTcQQ9XTc9gGrcSaMG02ry5NISe/s7un8AIp3sxdFkXAkisWsip34Q7f9AyEvJ5tJ48ewYtU61RyiKBx15DgEoNXlTuwzIz0Vl9tLfm42STbVsvTDoiUMHzZItfDoBPR6PYoCsiJRVlFNLCYiijH0egN6nZ5YTGT1mo2UbisHBaxWS9v4zBj0esKRKEIkisVqRlYUopEIkiSTnu4kMyMdo0FPJBJt+x5aqaisJhAM4fH60OsNWK1mkmw2kpOTKCxQW6VUVtcx55sFFOTN6nLNS8sqmP3FXFau2UiS3crwoYPUmC1FDQDvTii0Fy6xWAyX28OqtRuYccwU0lKdfWblaH+/q9+fgqKAxWzq87inndXz+qXsjtW3N6UndpeexNsJxx2N2+PtEIMUd6PW1tV3cJkrisKW0rJukyc0uqIJJA2NPcDuBD+2nwgFAcaOGcHAkv5IkoTb492l1hLJyUlEYxFCoRC0LTAF1JYXkUikQ3uLOKr7YFavXDDtA1bbF2TsTnjF9925enY4HKGpuZWVq9cTX+UW5OdS39DMd98vTrgGjpw4luQkGxfNOoN++bn4AgGS7XZOOXF6lxiKrdu2YzAYKSkupLpGFW+NzS5q5i3E7fai0+kIR6LodKo7In6tBQQURSYSjiFKIiaDgYamFkoKC/D6/TiS7DS1tJKdlYnL7SEjPRWL2UzWgAwam5oxGYxkZKSh0+vIzc4kEAy3uUCguaWVQCCIyWTCaDTQLy+XVpcbWZYxmYwJN0kkEu1idYg/vLMzM7DbrRhNRhYs/InkJDsxUe4SDN/++wGob2jkxyUrqaqpo7G5BYNe3+bGzAR238rR+X4vyM9FEMDX1nOurwJ/e1PP65eyu1bf7n7zR00an9jv7pz/jsTbwJIibvrNNd1msSmK0MFl3tNrGt2jCSQNjT3ELwl+7G4i/Gru9yxxrsbl9rKltKzXrSXiQis/N4dFPy0nHImRkmzn2KOPxGa1EIlE0Ov1tLS6uoyvtzEJPRVk7Olh1d0quCAvRzUGkTAKIUki7338OfX1TYBAbX0DL7/xAYMH9kev13HBuaczYdxhXSptq+nOLpKTkxAEBUdSEsMGD8Dn87O1dDsGgwGbzUIkGgUUZEnGZDQhyRKSrCDFonEdiaTIyLKMIsu4PR5iomrpsphM9C/KR0EhEopgMhqQJYkpR44nEonQ3OrGoFddjclJSXz46VdEYyI2u53k5CQMej0en48Wl4toNEpqqrOtLpWCKIqIktglAyr+kDWZTGRlpbPg+yXUNTaRlZ7Gsccc2SEYvvP3OH7sYfz7oSdpbGrBbDKRkeqkpdXN2vWbSEtNAfrGytH5fo+Puy8Df3uq59XU3LLbAqkvrL7tr0F9Q3OXZINf6srcmXizWMzk52V3+Vx6mrOLy3zo4OJEtqjGjtEEkobGHmRXgx87T4SiKLKltIyjJo2juraejPQ0atpaS+zI/N++HUJWZjpDBpZQ39RMiiM5Ua9nYEkR73zwWeIzv3QCb1+Q0WazdahH1N2YOq+CTz3xWDLS0ygu6pdwsVXX1LFi1Xry83OIRGNUVNWgyAqO5CSsVgtvvfcJR044vMMxOgejzjh2CnO//QFFEWhoasJiNhMIhhBFEbPJSCgUwWA0kpaWQiwq0tTSgtxuvIqsYDIYiUZjhMJRorEokiRhMBjw+wNEwxEcjmTycrMJBsPM/34J0ViUYDCEgkJGejr5eTlsKyuntraB7OwMkuw2mltaiUaiBAIhUp0O6usaiEWj2Kw2dDqBYDDMi6++ywnHHc2IYYOAnx/S0WiUpsYWiovyCQZDDBsygKbGFsSBIqDWozKbzQlRUlpWwfwfFqMgEAxFsCpgNBqpbWjAZDLR0NjMaSfP2GOVnvs6zqW7el6CoCQKae4OfZXyHt++u5Yxv9SV+UvFm8Vi3iWXuUZHNIGksd9zKPWR6jwRhsKRNnN4+xXzzy0nejL/x7PLlixbxdaycixmMxkZ6Rw9eQLBUJDTT5nBJ5/N7fUE3rmLfPsHcPyB0tzSiqLQoa5Re8HV0ypYUQRiMZFQOJLo96YABqMeUZLweLzIsoJOJ6DQvdWgu2DUgvxc7rvrFpqbW/n0q2/5/Mt5KCj4vH68viCyLCNLIkaDSbUkmUyEwxF0Oh2CIKDTCUTaSiKYzEZMJgPBUJjcnExQICnJjt8fwGg0sL2iEn8ghNViVjPjRJG6+gZSnQ7sNivNrS6a3R5kWcZqMRONxjCbTeRkZTJi2ECqaxoYOXwQyUl2Nm7ZBsBPy1dx842/YuzoEYmH9+zP57JteyXVNXXExBg/LltFcWEBoTY35Ueffp0Ivo6XS8jOzCAl2U4kGkWWRfJyczAZjdhtFi6cdTo5WZm/8G7d+3Su5xWPQeqrQO2+Snnv6wrVuyPedsVlrtERTSBp7Nd0dsn0lP59sNDVZSUydHAxSXYrgPpQlyVi0SgxUepxBanX61mxai0erx+Px0/AEMIXCDBz+hQ1NsTnB3o3gXfuIh938bUvyCiKIitWr0eARF+xzoKrp1Ww2+PF4/Xy07LViSDTM089gcamZlasXo8kyni8XrIy0hGAaCyWsBrEKwg3NDWycfNWcrKzOgSjhoIhzGYTkXCE9LRUGppa1M8DyUl2FFmhuaUFpzOFon75bK+oxqjXgwBiTMRgUjPiUhzJNLW00tTcQigYpqGpBZfbTVZGBoFgGIvVgj8YpNXtRhB0P49haxljxowg2ZHMEWMPY8HCJfTLz2PDxi1kZqQiSSJbt1XgDwT4aelKfMEgJoORVrcHg8HA3fc/wT9v+wMjhg1iYEkRp5w4nRdffw+dXo9Zp8Pn9bFu42YmTTgcQaBDMG68HpTJZGLQoGI2btmGx+vH7fFSWJDHsCEDMRoOvEfA9GmTGTtm5B7JYoO+SXnfExWqu4vf6y1aGv8v48D7dWgcMnR2ydQ3NHL/w/9jwrgxXRpCHkx0XsXGawQV5OWwYtVaJBm+WbCYEUMHUF1b3+01cLncRGOSGngcr4GDQCgcTTxIYzFRbZvRZrWBrhN4e1fdyjUbEi6+grxsPvr0K+x2O2mpTnz+INFoFIPeoLrJoEurkZ6CWBcuXsagAcUUF/VL9HvLz8smLdXJwOIiRElCpxOorK5j5er16PQ6LrngTGpqG/j4szls2rKdcDhMWUU1FotFFWySREurhzff+xSjyciXc+czZFAJU448grXrNlFb38jI4YOJRWNU1zUQCoWwW80kJ9nU4HUZTGYTer2OcCSCQ0liwtjRvPb2R0SiUTweL6Io0djUzNDBJXi9foLBMLIooTeoFiydoENWFNytbgr75TNoQDFbSrfh8Xjx+vz4A0FESWJgSSFmkwlfIKRes0gUfzCIJMmEQ2GefO4VHrr7Nqpr63nimVdpbXUhSaoz0GQyodNDQV4uoVCog+Bt39etMD+PoYNK8AdDTJ44lsz0NPyBYJ/EHvXEnrT8OlMcfS6M+pI9UaE6vlCJxUSi0WgHF2x3HEqW9z2FJpA09ls6pyhv2FSK1WrFZrOSZLcdUMXnumNHE1h8xRcOR0h1Oph19ikEg0HCkQjVNfUYjXrq6pt4+/1Pu9Q0KS2r4INPvsLl9pBks1LSv5BAIIg/FMLj9XL26SfS3OLC4/Wy6KcVSLLIsMEDufj8MwE6BG3HvwN/IEQkEsFiNuPx+pm/cAnRaAxJlHANLqG+vpHyyhoEFLKy0mlsbMbjC6DT6zhl5vSEiGsv/vR6PU3NLcRiIoIgYDQaE33cmppbEnFJZeXVbC+vJj8vG7vNitlk5vuFS/h+0VJAIC8nC0mSqKisZt2GzWRnZ9Pa0kI4HGHtuk2IsoRO0LF46UocyUm43B5kRabV7UYWZcwmEzaLhf5F/WhqcaHX60myW0hOTsZus7Jq7VZ+83/jCYfDgEKkrZ2HTqdDkiQ2b92mxjWZTQTEELIootfrMJmMhCNR3F4/ObEYS5atxO8L0NDYTKrTgcvjRZZlKqtqOXHmMXjdPlav24jX60Ov12M1mzEYjaxas5Hyiiq+mf8jLa2tGAxGBJ2MoqjZb0aTkfKKStJSUztYLOL1oBYuXkZTcytujx8EhRWr1iXaUeyp305ftsnpC3ZFLPSVsOjLCtXxhUo0GmXDplJkRWHV2g3cfOOvuhVJ+9v1P1DRBJLGfknnhqbhSLStIaeAxWw64Jtu9mYC67zNiOGDqKyqITXViSRK6A36LjVN4hNpQV42/QvzaW5x4fZ66d8vn9ycLK698kIsZjOvvPkBjuQkkuxWojGR0rJytm4r7zbDLF7Dp7yqBoO+Hn8gwNjRIwEYNHQQn3/9HUMHDyAvJwtRFPlq7vck2a3k5WWzafM2/P5gBxFnsfxcOTsYCrN46QrGjRlJRno6ZpORWEzN4op/99u2l2M2m2hoaKKiogprW2mBNGcK/mCQ7MwM6hoacXt9hMNh9Ro5nVisFmrq6rFZrdjsVlxuN61uLzpBIBQKsa2skoz0dArys/H5/PgCAYr796OutpFQOEwwEESS1Ot82onH4fH7+OSLbzDo9fj8AQwGA8FQiGhMxGK1MDA3m9r6JppbWgEQdDoy09PJSk/D5wuQkpyM3mAkya7GAzlTHLS0tKLICuvXb0YQdOTmZOH3B1BQCEciWK0WfP4g5ZW1RKNRbDYrWZnp1NTWgwCxqMjggcWkpaYycfwYVqxe1+Weys/L5sXX3uWcM2Ym4trC4XCi/UtfEnd5fjV3AVmZ6TuMb9tTFo7ORSR7ypzs7th9LSz6yrUVCAYJhsKsWbcRhyM54RqdM28BA4oLuy0J0VcB4ocymkDS2O/orqGpM8VBKBRi9GHDCUeiB3TX6d5MYG6Pl9mfzyU7KwOTSS22t/DHFbS6PNTUNmDQ69U+XJaOrUHap4NPmnA4a9dtwuvzM3TIAM467UT1odzqIhYTWbt+M0ajEZvNhsfr5bmX3uKk46ehNxgwm4zMm7+IWWefgiCoFavzsrOoqKohGAixfsNW8vKy2FpWTnqak+FDB5Jks+Hx+dm2vYqBA/rjTHF0W5iuvrGJt9+bjclsZHt5NeFQhOdfeYeS4kJMRiP9i/oR/TSKz++nrr6BaDTGug2b8QfUc/P4Avh9foSSQmRZwev1snb9ZmIxEUmSESWFppZWLBYzzUD/fgVkZmWwcdNWJEnGaDRhMpqIRKO0tLQQCgZJTrIjSzLNLjeBgGrdMpqMyKEQbpeXDz/7iuOOmUJOdiZl26uwWq34AwEMegOhcITc7EySk5Io7m8hFo1ht1s5/LAR1DU0AZCdlc7YMSP5bv5iSl2tCDo9oWAIBYGoGMNkNBIMhjAZjeh0OkRJQgAam1owGA0898rb5OdmgwKDSvqrPeVkiYy0VI479iiMRgMjhw9m5PDBXR788aB6k0ktwBm30vX14iL+uw0Egqxau4Ejxo4mJzuz28XMnrJwdC4iefYZJ1FWVtHhd9RTJfHOv8t4k+MrLz2vxyrlv1Tg7Wol8PqGZn5aspKG5hZMRgOZGelYrRZMRlPiN9/qciXOOxYT8QeCWMwmjHugkvmhgiaQNPYrOk9S8YamZ556PCXFhbz13icdslfibqjuMqz2V3aW4dJTxeSGpmYqq+uQRAmdQUeqw4HdZsPeFsANHYNDc7IySZuSQkNTM1de8vMkb7fZqKtvULPbTGa1iWs4gihJvPLWh/TLzyXFkUx+Xg7VNXVYLRYmTzgcSVatGq+88QFDBhWTnJxELBZj7fotrFu/mXAkRmVVDS63h6qqWgBSHMkoikA4HKOl1cXS5Wt4+Y33qayuxevzMaikhObWVowGA01NrQhAQ1MzwWAQvU5PRkYa6WnODr3cAPzBEE3NLswmI8tXbcDl9pKakowkSiiKWvgx2W6nxeWmvrmZ1FQnFrMFUVbT9KORiHqdEPAHVfehoNchCDrEtnpHHq+P9DQner0OWZKZ//1irrzkPF587V3qG5oQ9DosRgOhtpYhdQ2NBIJhwpEwzpRkotEYoKhxSB4fa9ZuJCqKSJJCLBJKxFaZTEbcXh+trW5SHBF0OgGr0UwoFMZo1KutTVIcbCktw2g00Or2YraYcDqSmTJ5AmajKWHR685isScChjvT/nebnGTHWmpl/cYtpKc5u8S39YWFozuB0bmIZKvLzb8feor+hQWkOh2J39GW0jKmTZmEIzmpw7Hb/y7bNznmtXc57aQZHQTcjgTezoTTrlYCD4cjLFy8jAnjx/DuR5/R0hqmpq6eEcOG4PZ4qW9o5qNP57CltAxFEUhLdVBVXU9mZho6QWD40IGJ1iMau4YmkDT2K7oTD/EJtqq6lpnHHZ2o2FxaVkF2VmYixmJXiijuS3b0wOpcMVmn1zH32x9ITrKxYVMp4VAIvV6PIKs1cUaNGJJo1QHdB4eedtKMLqtUo8kECkiyjMvrI9lmIxAIkpeThcvtITMjjRWr1mI2m1i5egMGvUBJcRFJyUlkZ2UgKwr+NhdUepqTmChS39iI1Woh1ZmMKElsKS1jQHERaWkO3v/kcxB0fPDxF+TnZmMyGkERWLF6nVocURSxWS3EJJmkJBuiKGFz2KisqiEzPZ1Em6l2NDe3Mm3qRJDB7XFjsVppafUgAKKkxugk2axYTCYkRUaVQwLhUJhILNoWvK6gKDLhqKT2eVMUFFlGktRihKFQmJzMdDZuKSMQCOL1+fjLH35FfWMzTz37Kn5/kFDIQzgcRpEhNzcTg0Ftbrt6/QZMJhMer5+0FAcer5cRwwbj9XqQFTVDsbnNmtfY1IJOEPD5A1gtFlSjoIBOr8Y5lZZV4AsEuei800hOsiHLEA6HGT9uFKvXbGTF6nWsWL2u2/t+TwQMd6b979ZoNDJy+GCWLFtDfUMTdrutw/F2NwW+J4HRvoikKErU1TdiNhnR6wSsVgsbNm1l9KjhKIqAte047Y/dvtbUhk1bsVotKEB2ZkYHAbcjgde56XLn78Pt8fLCq++Q4nCoAfY6YaeVwOPXKyc7g6J+BTQ1tyBJElaLGVGS+PrbH6iuqSMzIx1RklizbiNZmRnIsgw6HUtXrOHmG3+1w2urBXR3jyaQNPYrehIPcTeSyWRKuApibi9z5i0gOzOjQ4bVzooo7k26m3jiD6zOHbYtFnNbI1MS7SjmfbcIj8+PzWLGZDKRlGxHQCAzI41wOILNaumyMtxZcGggGCQ3O5PTTz6exUtXJAobFhXmI0oSkUgUl9sDqA8afzDAps3b+Pb7xWRmZpCVkcawwQNwOlOIRaOEw1EmHjGG5SvX4ExxUFZeSXNzK5FojNq6eurqdYTDUbaVVVBVU0dDYzMmkwmfz48iK4TCYQQBom0xR6FQmO3l1VgsJqwWK9OPObLba2tPspGVkU5TcyvhSJSqympEWRU8drsdQacjPT2NkcMGUViYT01tPXX1jUQi0YTg0un0bf8tEY1EEdvEpiRJoChEdDq8QoCt27bj8Xqpb2hk2ap15GSlU1PXgE7QqVlFMdVapNdlY9DpCITCyJJ6D48aNhiDXo8/EGTFqnW0tnpAUMsMCIqCJIpIkoTFasVutxGORgiFIkQiapXuFIcDs9lIXaMfR3IyzpRkABoam1m0eDnpaWmJTMSe7vu+DBju9ruw2TpkRWZnZjDpiNGceerxHVpfxLeFX2bR2lGrkfZFJEVRRFYU9Ho9ow8bQVl5JYGAmqQwdHBxYtEVP3ZMFKmqqWX82MOY//1i/IEQCjBi2CB1vgkEEwKuO4EXi4ls2LSFb75bRH5eTsKdN2/+IjLSUxOW7eUr11BeWYsjSb0H8vNyuq0E3n7eiF+XUDiCM8VBTnYGHq+PaVMm0drqIuAPoDYHFpBECQQBm9XC+MMPw2g0EAyGyMnO6PGaagHdPaMJJI39ip5Wu/HS+O0n1bi4iBdN7G0Rxb3FziaeRPp9u7ZIiRYNgQDrN26hID8HXV0j2VnpbNlWzsDMIlpcbmIxiZgkMXnS+G7PcUfBofFjGAw6kuw2BJ0AsoLFbCY3N4tgMMTYMaP48acVlG7bTjgUwWa1YjYZSbbbcDocLF+1lvFjRxONRhlY0o/UlGQsZjOSLNPY3ILFbCEmSrS0eNAZBIr7F9LQ2IwsyegteswmIx5ZRhSlttYeAkJbR3JRFIlGI+0af+rR6UCWO56HUW9QV/ubt2IwGBCMBoySgihFyUpPw2RS+6KVlBSxfXsldpsVi8mIzWKhxeVGJwgosoxOEJAAvUGXEEgABqMBg9FAS6uLcDiCI9mmFmTcVs728mo1TiUSRafXo4SjIEBlTT1ZaankZGfi9QdAAafTQVl5FSmOZMLhCHm5WTQ2tVBUkEcsFsNqs9LS7CIqiiiBYNtDXsJoNBBtEx0ul5fiwgJ0unhxTYWq6lrKyitxpqRgMOgZPnQQJpOxx/t+T9bCmTd/EfN/WEwoHCMtNTmRJdddQ9TdsWjtqNXIoAHFiSKSoigTCAQ5btpkiosKyM/NSriam1tcHRYnDkcSf7n93z/HLZ1+Egiq5SgudODn301ngVff0Mi3C37im/k/UlunLtDife6amlt58bV3sdtsiKJIXUMTJqMBU1tD5qrqOjLamhvH6W7emD5tMp9+OQ+Xx02ylMTYMSOxWS0EzCYEnQ7VEqqgN+hBUTDo9SQn2TAYDMRisR7FpxbQvWM0gaSx1+itGben1W7nSfWE445m4eJlmE1qEKLadoC2TKieJ4W9wY4mHlAfKO2L+rWflKZPm8zrb31IIBDCkWwnPc2JxWzGbFLbXqSmpJCXm8mAkv6MGzNyl8dmsZg5atJ47n/4f1itVtJSU2hqaqWisobq2nq16CBQ3L+Amtp6AoEgPp8Pua1ZWmZmOkV5+QQCAZwpKfj9fpatWkd6mpP1m0rxef24JG/bdQgTE0WyM+vQ63TY7TZ8fj/hcJRINEZqagoBfwBJkpBlBb2gHiMQCLVVz9axaXMpgqAHpA7nISsytfVN+PwB7FYzwVAEWZYQRRmbzUxJcRGiKFG6rYJt2ysIhsIg6LDbrUSiERRFvVcCoTB6WUckEkvs29zWPNagVx/Ekizi9QexWizo9XrCoTApKcl4PD5C4QiyLGOzWgmFQlTWhHF5fAwePACfz0c0GiM/N4emlhZikkQ4HMZgMCAqakHPQChEijMZr89PNBojJor065eHIkkYDHqCwTAlJYUMKimkuaWVUChMU0srm0vL1EKgXh9ZmRmsXL2OIYMHdOjj9ktcJ7v6mWt/9zfe//hLtX65ojB86ECGDi4hIz21y7bxfScl2Zg8cRx2m4XcnOxejy1uJQqFw4nWGe1bjbQvIunzB1m2Yg2tLjfws6u5ucWVWJSEwmHmzV9I/6J+CYvUB598we9/fRXLVqyBtsSA9gKuvcCLxUQWL12FKIlEwhFC4QgbNquV0E+ccTRbSsuYedzRmEwmvD4/lVU1HDVpHIt+WoGCWvT0V1df1KEifHfzxlGTxmMyGhhYUkRFZQ0ejw+T0cgJxx0NqDXH4jFIY0ePaKtNtvNGwX1d8ftgo0eBVFVTz+PPvonH6+N///k7TS0u1m7YyvSpE/bm+DQOEnbVjNvdarc74WQ2mxLiIh6D5A8E+zzGYlfZ0cQTZ0eTkj3J3lbkUSApyUZldb3akkOMcdjIIYwYNni3eirlZGcwYdwYaIvJSUlOZntlNYUFuTQ2NnP5RedgNpn41/2P0tTcqvbxsqruhcrKWgwGA6edOJ3NpdtZuHg5kUiU5OQkHCkOwuEosiKTnJSEGIshSRINTc1EYlFC4QipKU50gkAsGiEUCiHJMrKioGsLhrZarCQnJ2E0GQkGg6QkJ2M2GQmG2ll3DDqGDxtEKBhCkkT8QZlgIJhoNLtuYynlFdXMPP4Y9QUFmpqasdvsGA0GjCYTFpOJ7KxMtm7bTiQS7XB9ojERnU7A41VFUzQqotNJNLa4yMrMIBpWMynDoTCSLCdiXaJhCYPRQCAQYMWqNRTk5tK/MJ+augaK+uXh8wYor6pBlhWaW1rVEgRWC7Isk56WSjgcQa/TkZbiQG/Q09rqRtDr2tqtqNaLYChIOBQmOysTs9nExi1lVFTVgCJgNBoSfdziv404O0pvj7Orv9O16zfz0adfo9fr1O80JrJ2wxZC4QiBYIgrLj4v8fn4vjdvLWPJ8tVkZaaTZLclYoh6I8ycKQ4OGzGU5155uy2iTOGay87v4J5qX0Ry+JCBHfYZFyDxxUldfQMNTa0U9itAp/vZIpWcZOOyC8/ucTzxuaiqphaP18c38xdis9lIT3PS3NLK9soayiuqGTywJBESYLWYURTVmlpU2I/mlhYMBgMnzpiW2G9P7rs58xZQkJdLVmYGw4cMoqGpmdNPmYHRYMBus3HDtZdStr0CBUFN+zebeyVy90YA/4FMjwLp7oee4cqLz+KJ598CwOlI5tW3Z2sCSWOX+SVm3J4my87CqXPhwf0li603E8+OgrSL+uVz4oxpfLvgRyqqa8nOSOek449m6OCBuNxuLpp1xm5VErbbbLg9XkrLKqioqsXl8ZDiSCYrM4NgKMz8HxZz/dWXcO2VF/On2+5Gp9cRiUaxmszEJJGigjxEUeSHH5eSnJRENOqioqoWqaIaUIhEo0SaWzAYjSiKQGqKg8x0JytXbSAUDqnxOXodep0eg9WgprwravVqm81CbUMjApCdlcHipSsRdDqSkqxIEphNBiRJ5vDDhrNixTpSU5zU1tbTOY7bHwzz+ZzvOHbqJIoK86isrsHn99PqciHJCl7Zh8fnJxgMdbk+iqIgS4ra1k19BVGUCYdCeNweCvvlkZWVjsfnJ+APkJqaQigcQZIldJKAwaRWsfb5/aSlpTJh/BjWbdzMvAU/Eo2KCIpacDIQDKHX68jOyiQ7PQ2DTkdjixufz0+yI4n0VCc2mxWLxZzIRmppdbN4ySpMJiMul4d+eTlUVNVis5pZv7GUWExk+ap1DBrYn+FDBiXusZ7S22HX6he1Z8XqdQjICDq9mkHY9i1IkkRjYwtfzV1AwWWzANVqajYZWbV2A2mpTkKhMP3yc3n5jfdxOlNUi00bPQkzt8fLmvWbOO6YKUQiEcxmM2vWb0qUAulM5/miswBxOBwggN/vB0HoYJHamUvSYjHTLz8Po1FPMBTG6/Gp+0YgPdXBrHNO5ftFSxO/c4PBwNDBxZSVV7Jl6zZkRcdhIwZ1qIbf3bwRdwXGx2wymQgGw7z57ifYbTaamltxuT00NrUmWvWcf86pvYoj2hsB/AcyPQokry/AxHGjEgLJaDR0WWVpaPSGXTXj9oW1aV+zs4mnp/fiQdqCIDBi2GAyMtL5Zv5CZkybTFamGmgZjUY7ZK79UuJtSCJR1UWkE4REMc54fZXBA4sZPmQgVquFaCSGyWzE7w+Snu7E7fWjKOAPBKmqqVfT4WUFR3IS/mAQs9mM0+HAkZyEIAjo9UZSUhwYDHpiMQl/IIAoSTiTHIiiRJLdRkqSHUlRaGl1q5/R6TGaDAQCP1veQiHQ6wSWLltNTUMLGWlOqmvruz3HUCjMhi2lhINhTEYjJf0L2V5ZhculugC7E0dxkpJs+PxBDHq9auESVDduOBrB5fGSlZVORmoq6Wlq4U4xJoIC6empRCJRjEY1/qOsQm0uiyCgE9pcdu3S8iRJxu12oygy+TnZgEI0JlJVVUf/ojyGDxuE1WLBZDJR39DEgoVLWLtxC0k2G4FQkDRnCqFwGDEmYjRG2VZeRZozhU2btjF4QHGi7lFP6e3xzKve1C/qjFpeQIdep0NETAS/DxrQHxBwuz20ulyYzernvf5gu4bD6rmLoswXc75l8MCSnQqzeAyS1WJOZKJ5vf4uQc490VmA2KwW8nOz+f7HZSB0b5HaERaLmeOOmcJ7H35JJCai1wk4nQ6sFiu5OVkcNWk8c75ZkEi6OHz0SJ558Q1aWt3odTo2bzV0qIbf3bwRDyWIjzkajSZcd4IgsGzFGkrLKhg9ahh6vZ7qmrqEMO19M9s9F8B/INOjQEpLTWFbeVXCV/vm+58nAmU1NHaFXTHjHkxBgzuaeHp6r/O1Sk1JVgOj2ybs3prAd+auCASDxGIisiSTlZmB11tOOBrF6/Vx+OgR6sNdFHG5PaQ4HWzYuFVVU4rC2NEjOPmE6Xz97Q9EIhG8Xj9JSXZisRiipKbLJyfZEXR6UhzJ5OVm4Q8GSXEkk52VgcvjJeQLEhNF0lKdOJLt+P0BXG4PwVAIs8mkNpJV1LpLpdsquoxfkhU2bd2O2+OhspsSAO2prW1AQMBut1FRVZMQRzvCajXjSE4mEFRdaAA6AJ2A0WDA6/XR2NhCi8uF3x/AZDIRjcVQFBmdri2zLRIlGA7zzvufAwpDBg9AEiVkWepStiASFQmFo9Q1NJGfl8PQwQOIxqK0tnr4vysu4Ku5CwgEAny74Ee2llVg1BsQxRixSIzWVjcoCsFwCCEcRqdTaGpqYUBJIaFwBKPRSCgc6Ta9vdXl6nX9ou4YNWII55x+Au99/BWKLKMoCgOKC3E4ktm2vZxgKMRHn37NtCmT1OtqNiG1lXUQBNDrdUiyqGYd9mIB1T5TLR4z1D4GaWd0FiDBUBhJlJhxbO8sUt1R1C+Pk2ceQ1l5FQJgNpso7JdPaVk5K1atb7s3ohw5cSzffPcDHo+P9FQnCtDqcrNx89YOhVR3FEoAarxR3HXn86uLDAQBUZTavjNVRO1KHNH+uMjcH+hRIN38uyu57Z7Hqaiq5aRZ15PiSOb+f/xhb45N4yBhV8y4B1vQ4I4mnu7e6+5aXX7ROZSWVXQbMNqeuCiqb2hm4eJlide7s8BVVNUy97uF2O02dILAsCEDqa6tZ9jQQZhNJgwGPb/70x1IkkJlVS05ORlkZqRj0OtJS3UyoLiQAcUXkZ7m5KlnX8XrD2IwGEhPdWI2m0h1OjnphGnk52ajyAoLFi3FZDTQryAPBRm/z4/dZiE1xUFdQyNGowG7zapW/RUg1enAqDeSkZHKhk1bu71+Or2u2/pIndHrdRj0ejweD/pedq8PhyI0Sa0IAsiyehAZ0Ck6rBYLkViMWCyG1+cjPTUVvUFPMBgioCgEA0FCwRCRmBq/pCgysixTUVHVlpnX9XiyLBH0B/D5/NhsNkLhMM4UB263j62l28nJzuT1tz5i3cYtRKMx+hXk4khOYnPpdlJSkpFkharqOnQCeHQCFrOZYDCE1+dHFEViMbHb9PZ4+Yze1C/qiScfvpvr/+8yvpw7n+qaeppbXGzeWkZhQR6TJhxOZkY6Cxcvo19BHq+//SEGg5Gt27bTv6gAl9vDFRedS2V1ba8WUM4URyJTrX0dpJ7ETHcLhbgAaXW5KCuvZunyNb/YIhUfZ25OFv0L8/H6gziSbPgDIZYsW90hEWP+D4uJxaRE2mp8bouJcodq+N3ROZTgnQ8+Q1EULGYTBn1b5ppB33btFK0wZB/R42xRWJDLi4/dRVVNPaDQLz8XfVtGh4bGrtJbM+7uBg0eDAXP2k/g4XAMs9nE2DEjdxhf1b7T95Llqzhi7GHkZGd1a4ELhyPM/2ExhQV5tLo9yIpCq9vNjGMmc+YpM2hudfP7P/+DSEREUWRESaK52cWJM44lLdWBzx8gEAySnpbKeWeeTGurm1aXm5raemRFwePx8evrTsfV6kZRICZK5GRnUFffxKatZTQ1tSArSlujVQNGo5GCvBxEScLt9hKORAgGw5hNMpu3ltHq7t7i4+3h9fYIAghKm8tQCSXup51+TqfD3LZCj6MAgk4gGouRn5tNTlY6FVU19CvIpbnFRVKmDbfHR2Z6Kh5fWeL4igKCoNaCkkQJk9HYVjepHW3lADw+P5FImKrqWlwuD+s3beHZl96mtr6BsaNHkFFXT8AfJOBX73Gzqa01SzSG2+MhGAwjAJFwBL1Oz+knzSAlJYmYKLJ+w1bWbtiMzWoBui+fEa9fdNLx0zCZzL32GowaMYRRI4YQDkcoLavgiznfUpCfm2hzEYuJLFy8FJvVSlG/PPrl55Ce5uTPN15HTlZmt271nn6/7TPVdtSqo/0+YzGRiePHMHL44C69ACura7BYTKSlOnfZIgXqomZgSVEH0XbWqTNpbG7psNAzGU2IokhudiatLg8KanzRiKEDOlznnkIM2i+o2i+iigoLcDiSO8QgxeuqxTkY5sV9QY8CKRYTmf3VfNZvKlXTgieMYfKEMXtxaBqHIrsTNHgwFTyrrq3n7fc/TaTuDh1czKyzTyU9rfvU6bibxB8IYrVa2bCplPS01G77MAWCQUxGEw5HMlmZ6YiiRCQSIS1Vrcfy8hsf4PEFsJgtCIJAOKAWcgyEglitZmIxMSFYLRYzp5w4na/mLsAfCLGtrIJRIwbT2NDMmMOGU1yUj81m49GnXqS6ph6P24tepyOprShiZVUtep2OhqYWhg0ZQFG/fBYvWcnAAf0RRZHyiqpEY87OxHYQh9W+blI4EkGUZRQU7G3WmZ3FUyqKTCgcVl1AkowgCAiAyWTEYjKRm52p9sIymROFJxNBtTERo9GIJEkoioJOEIhX7I7EZAx6PQaDHllWXUWgiq9Wtxu9oCMUjtDc4mJ7eRVjRo8gKyMdj9fHkmWrURSFmCjh8noRdAIGvWqRioox/P4AFpOZFEcy6WmpBEJhAFav3Zh4eCuKxDlnnMSJM6b1GA83dPAAvv52YeLfu/I7sljMJCfbcXt8pDpTsNvV2lFer5fyippEbJOiKDQ1tyC3fYc9LaB66lnWPlOtO9r/Jhoam1m/cQs/LVvNpCNGM23KJBYuXkaqM4W0VCfHTZvMN/MXUViQj8Gg26FFqqdjlZZVdKjyX1vfgKJ0XOgZjQZOnjqdWExk4+ZSxJjE0KEDuGjWmR0WL70JMehsUQoEQkQiUSwWY6Iw565YlDW6p0eBdO/Dz1Fd28DkCWMwGPQ88dxblG6v5LLzT9+b49M4SNgV8bIza1N3q6E9Fbu0L1Ze4XCEr+YuSLQPAKisrmPONwsoyOsaeNneLWkxq9kusqIQjkS7jSOx22wYjQaGDx3Ihk2lKIqadXbCcUdTWlbO8lVraWlxqfE0goCg0xOJRPl+4VIcyUmMGDawQ+YNqA1of/hxKQa9jqUrVPdQ/IGUl5vN6rUbqaltwBcIkGS3om/LikOB7OwM3C4vazdsJisjjfz8HFCgbHuVKlIMenQ6IeHq2hmC8PO2igIKCrFYtM2aJXYozNkTigKKrCTij/R6PTarBaPRwIAB/Tli7GFUVNeSmprCtu0VRGMSSXYrRYUFmAwG/IEAzS1qVfJ48cmC/Fw8Hi+SJKET1POX21W/lCQFRadgsViYdMQYmppdFBbkqUILBV8gwIhhg/C4ffgDQTIz0zCZzFRUViJKCgaDAYPJgNPpQK/Xk52VTiQS7dLa4sPZX3HM1EldXE7t3Te/9Hf06lsf8syLbyaqseflZFNUWEBebibBYDixnShJhCMxwuGfLWmdXc672rOsPfHfhCiKbNi0FbvdBoKAxWJhzrwFmIw/Z4WNHD4EpzOFoyaOZdDA4l3ODm3fIDqe0m8wGBg7eiQrVq9LbBef8wYUF7YlIShdqoy3H3c4EsXSVlCyuxCD9paw9sfIyzXvkkVZo2d6FEjrN5XyxjP3J9xqZ548nat/93dNIGnsMr9EvPQUu9OT0NoTsUu7apHqKzEVCAaJRqPE2weAej5qWnjX82nvljQajQwfOpBlK9YQDIaIxWJdLHDxQpFzvlnAkEElKIrMCdOPZkBxIU+/8AZ+fwC9XkcsJiMpCrIYRVH0mI1GkuxWHMlJiRYKgUCIT7+cx6bN2/D6/YRDYULlVaQ5HYwYPhR/IMDLr7+v1vyxqcIoGhUJh93IikIsFsPmtjJk8AAi0QgNjc0YDAbWb9xMY3MLkihjNBowGgyJCuk7Q1EU9HodiiwT11RWq4VYVCQYDGE2GxHarkM0GkuIoM7EX1etPRLhiFr76IRjp1DYL48PZn9FWmoKdpsVk8GA2+slMz2NllYXw4cO5ocflyb2pRbJVC1yzS0tiLKMyWRsi0dRC2KiKEiygj8QYOZx03jv48+RZRm9Xk9WRjqVVbUk2e04HQ4GlBSxpXQ7387/EVlRrVMGvZ5IOEo4HAEFiosGs2VbGaVllTgdyej0uh5bW8R/b+2zKNv/7XzfdXev1zc28cyLb5KW6gTUh3xjUzOnnTSDzAwnpdsq8Hh9BENh6uobSHWm8OXc7zjhuKO7/K521FKkNwJGtaoE26w4P79utZgJhdQSDO2tOzarhVEjhv6i321PYQEjhw9m5PDB3bYays/L7rKfcDhCY1ML6zZtJeDzYzKZAYWC/NxdSmjJSE/dJYuyRs/0KJCyMzNQFJm23A3sNitpzpS9NS6Ng4i+Ei87Elp9XfBsV0VdX7r37DZb20pUaRdMq2A2dx942dktaTaZuPnGX5GTndGtWCstq2Dh4mWJ7JoTph/NiGGDaGl1IcsyDkey2rpDURKBxpIosWb9Rg4fM5INm0rJysrg2ZfeJBqJsXL1BrZtr8Dr8SG0WXrcXj+rVq+ntq6B+oZGZEXBYjK1lQUIIAB6vQGLxYLZYmZL6XbMFhM61Gyc+sZmYjERoEP7j94iSR1FTygURq/To9frSEpKIhJxIUsyZoupg2UjjtGgR5LUApaiqB5frxdITXXw/eJlROZHaW11EwiodYxkRaEgN4dBA/tzZNpY5nwzn1Cbi0svCAg6gS1byxkzejgWs5mGpiZkSW2gq8gKJrNRjctqiwPKy8vmrNNm8t5Hn6PTGVAUmZnHHc1hI4ditZiJRqO899HnSLKsFppUFFxuD0aDgbycHNLTUpBEiTfe/QS/P4DYljHYXWuL9rRv2Bp3F7V/PX7/dHevV1XVoii0ZfHFkCSZYDjMT8tWkJmRTlFhPhnpTtas3czA4iIOGzWMzIz0Lo1gA8EgdfWNXVqKiKLM1tLtOxUy8fEFQ2GWr1pHKBQikwxGDh+MwWDAaDRwzNRJXdxOvbFUd8fOwgJ6s9/Ssgr+9/zrLF6ygoamFnQ6HUOHDCA3O6tHi2dP82pTc0vi3zuyKLcfR3x/WoxSR3oUSCX9C7jz/v8xavggAGrqGjCbTbzz0VcAzDpz5t4ZocYBT1+Jlx0JrfS01D4teLYrom5nbUV2deKxWMzMnHE0bo+3QwzSjipnd3ZLxo8bjnScjLsb68LFyxhQXIjdpqbBby+vQpaktsavqvVDURQCgSBr1m1kwrjRrFixlszMNERJoqaunsbmFkwmo+omkiNEo2pdoyS7FblNaHj9AcSY2Ob2Ar2gtiKpq28kGo1gsVjUlb2sxtl0RqcT1Ho7Utc0+Z2hKGrgtSSJ6ARBjS1SJBB/3sbU1soF1G2RO5ofQqEIHrcPl8uFw5GMPxjEHwxis1qRFZm6xkZuP+m3fDl3QVtyS1uQtpoK11Z8UsZus1CQm02r20sSdhqbmgkEQ+oDzWLCoNPzw6KlWK0Wjhg7mpHDBzHu8MNoblFT8ltdYWrrGkhLSyXgDxETYwlBkmQ3YTIZGDywmOUr12GzWhg+dBAbN2+lpq6elBRHh9YW3d17nQOOL7/onF65srOyMpCkeAq/gD8QQCcIZGVmYLGYaW5p5ZrLz8ditpCTnZmwZsTv1W3bKxM1g0RRJBDwI8up6HQ6Wl1uKqtrWPjTClau2dDjAqT9+NJSnRQXFbBh01YyM9MxGY243J4Orq6efpu7uuDpbRJKd/styMvhsy/nsWLVOlJSHAlLZUuLi9NPPA5JlndqORZFkVA4QiwmJsTvjizK7V1zzS2tKApkZqT16lwPJXoUSH5/ALPJyJbS8sRrGWlO9d+9ceJraLTRV9Vadya0CvJyOGXm9G59+7vKroi6nsTUuo2bWbFqfWK73kw88VVdQV4Of/ztNbS6XCiKoPZj28n5xN0k8Um4qbk10X4lMyON6dMmk+p0dDvWePxJdU09mRnpRKOxhLtFbksnjkkira0eyiursZjM1NY3osgK0ViMSCQCgMloIDnJTjAUbitqFyMrK4Pq6tpE0HAcSRTR6fRtlhZFbYprs+L1+bs9P1lWMBp1KN2Ip94Qi8UwmwwEAiEEQNAZsFjMarFCSUqIo/i23YmwQCjMqrVqrFQ0qooSSVIDcDPT08jOTMdmtTJoQBF1DY1IkoyiyImC3DqdjpzMDJpaXBiNBtXNGI0SDEcwGQ3IskKrx0M0GlXdYU6FbdurOGrSEQwsKcLr8/PFnG+xWs3U1DQQDKsVyCPRGDoB8nKyycnOZP2mUhDA5fbR1NxMeqqTqCgyecLYDq0t4sTvO71e3yXguLSsgskTx2GxdN/JHtR7/aelqxlY0p+lK1Zjs1rR6fQMKClEVhSCoTCDB5bgSE7Gbrd1KTdQUVXLI0++gNVqRScIDB86kOL+hdQ3qJakyuoajmsTE+1dSZ0zOzuPz2RSaxKdMnM6Foupi6urp3IZvySecWe1hHra76knHosvEIC2atvxhACdTkcgFMayE8tx52SO5hZXhwKVnS3KAK+8+QFJdhuBQJDtFdUY9HpK+vfDYDBoMUrt6FEgnXnKcYwcNnBvjkXjIKYvqrXuSGj1dQbbroi67sRULCZ2qYOys4mnL84hPgkn2W2sXLOBjPQ0amrVDuPz5i9i1tmnAKoLxR8IgSITE9WHTFVNLTabjYGOZHSCWh25qaUVq9WCTqdHL+sRBIFBxUVs2FJGks1KdW09LrcHSZIJRyJEIhGMBkPCLabTxzuNq5YoXVu1bQHVdabIMjqdgNlkRpRkENSYH7EHEdS+oewvIRIVkdoCkyRRJDlZzRCLE4936clCJYoiRoMBt8fXZinRYTToyExPI9XpJBAMYzIZcTgcZGdmUFvfCKgWs6QkG7V19fh8fgKhMIokEwyFiMZiJNmtZKan4/MHUBSF2V/O4+zTZlKQnwv8bGF55MkXiIkSm7dso6m5mWgshiDoMBj0ZGdnUZCfQzgSJRaLEQiGWLl6A6KkmsnS05wYjargKcjPSViR2t93gWCQYDBMWqozEXBMIJiwYPR0r3/21bfU1zeRZLcz6YjDsZjN9C8qoLAgLyG0/IEg6WnOLr+royaNZ868BVit1kSB0A2bShkxbDC//r9LaGlxsfCnFQmLrCAINDW38uJr7ybGE/+t9LSw6c0CI87uhgT05JprH4Dt9wdQUPusKYpAst0ObWNOSUmmvqEZg9GALMs7XEwW5OWQ6nQweeJ4dALY7bZES5m4C/2YqZMYMWxQ4jMtrS6amltZtWYD4UiEiqoacrKyCEeiJGsxSh3oUSD958mXeeGxu/r8gB99Po93P55Dkt3GXX+9gazMn33hdz34NCvXbCLJbgXg8ftvxZFs7/MxaOwb+qJa68CSIjLSUzuk/ro9XmZ/PpfsrAxMJlOfZWr0VtR1J6Ymjh+j9qnq5STbeXUZjUaZ/flcrrz0vF3KqolPwvGA5nhLh/i/JUliYEkRj/7vJWrrGkEQmDxxLNW1quVIlkWqahqx2izk5mbh9niJRmLYbQasyXYGDSimZEB/6hqbqayqVesoyTImkwlJljDodOj0etJTHISCYSor6whHI0Tb3C5AoiUJgNlsRA1GB0kSiUV3XGvNaDCg0wu7JZQsFgvRSBRRjtHcFq8RR+4hYLs9MVFsE4ACiiITjarByNlZGaxau4FlK1YjK2Axm7CYTYiSjMVkpCA3h6zMdKKSSPnytRgMhkQZAY/Hh8lkJicrA5fbg7WtonN8ftTr9Wr2lclEdW0l9Y0tapNcsxm9To/JZGDc6OEcNWk8eoOBxuZm3nnvM4xGAzabhVhMxONWm6qWV1RhMhm5/KJzmDxxXIf7Lslu46tvFlBcVJD4LcHPi4D4vf7V3AWJHmGHHzacp198I7EYsNutNDW3cPTkCazbuEW9Zu2SBTr/ruJlJ+KCJh4zE41GycvJJi8nm5VrNiTea99qo7vfe28WNjuKL9qdkIAdLXLifdPmzV9EXUMjgiCQnurkmKmTOOXE6VTV1PHdD0vwB/wk222MGzOK44+dssNFUiAYxOX2UlNbj6KoBUebW1o55cTjEi1l4i70+Hnq9Xq2lJaRkZ6GxWKmtq6R+oYG9DqtWW1nehRIZ5w0nSeff4tLZp2GXvezS81u/+UXrtXl4dW3Z/P60//m+8UreOL5t7nzll932OZvN13D+DEjfvExNA5uOk9AA0uKWL1uIyvXbCTJbmX40EHkZGcCfbMK6q2o6y4G6Kdlq/D6/Fgt5p22bWi/aq1vaGLDpq2qhee1dzntpBm9tiTZbTY1uFlRkCSprfAdmE1GYrEYer2eBYuW0tDQTCgcRifoWLJsNa87P+IvN/6KsWNG8eRzryIgEA5H2jJhAqSkOBg6uIQpk49Ar9NRmJ/L1tLtyJKMJMtYzCZ0sg6DQYesqO0WUNT5wqlPRpZl/P4ArW3WJkmSEun4er1ANCYiSTJR4u06uk/rV1Cbge4OOp2A2awWa5SV7gWRToCeqgrodTr1mprVmC6dTs1EMxr1/O+FN+iXm6NmqZlNOBxJDBpYgs/rw2Q04vMHKeyXi9GgR0Gtg2Q2GwkGQ4ixGK1uD/3yc/H7A/j9AWpq6znr9BORJAmT0YTb46WuroFoJKJm2SkiOrOOaDRGTX2jWoMJGDJwAFabBQSBWCyKJIqEImG8Hj82qxWn08HLb7xPcVEB0NElNXhgCQ2NzYm5vrPAiESiBENBaPueFX6uyB1HUQSKCgsYO2Zkr5pOdy47EQqFEjF34XCEsaNH8tOyVRiNhg6tNtqPPf5739nCpqc4oPbb/5KQgN645pqaW1i7frP6vgDJSUl89/1irr5sFrfd/BvSUl/FYjGTnpaGzWrpIm663IttYsfpTEGWZGIxmYamVgxt2efdLcwkSWLwwJJE/8KM9FRC4TAtrW7s9qjWrLYdPQqkp196F7fXx2vvftauGiws/OLVX3ywn5avZfCA/lgsZsaMGsoDj73YZRunI/kX71/j4KY7K8vLb7zP9KOPxG63YrVa2LBpK2mparbl3l4FtZ/0S8sq8Hi9/LRsdaK67fnnnNrjxJMIrA4EWLF6HcnJSdhRs0l3xRpWXVuPx+tl05btBAJBWlpaGTtmFC63l4njx+ByuVm7djO+QBC7zYpOpyMYDLJhw1beev8T3n7/U/Q6Pf5AEIvZhM1mIyMjrW3CV5tYT54wlg2bS1EU1V0Qz5BRiySqGWTx5rImt5HkJDsDBhSCIuD1B1BkBUFQhYoAauxPW6p1UrIdWZQIhEKEw5Euri5RFBHFrue9KwT8gYSbLZ4p1xVV9HTGoNcjCGA0mUAQMJoM6PQ6DAYDjiQ7/kAIg9FI6ZZt+AJ+JElmy9Yy1b2o01HYLxe31080FsNqtaDISqLGUnJyMg5HEk0tLRTl56PT6xIiIH5/6PV6BEEHgtpSAoFEvMrI4YM567TjSUtNxe31Eo2KxMQorS4Pclu7k9zcTOoaGnE4klEUgUBbBl/7rLXMjDROP2UGPp9f7WpvVtP/7TYb27ZXcv/D/+sQK7R67QYGlvSjtr4pIQyGDi5OuLV6EzsXFyQjhw3ukFnZXswIAowdM4KBJf0TrTa6s/DsyDrUnYh5+/1PSUqyIUuqJXTmjKN/UUjAzlxzrS4XZWWVKIpMOBIDQWBr6XZGDB2U+GxGelqiTEL7/bYPkm8/JkmSyEhPY9XaDapQlRSSkqyqu5ruezfabTYyM9IoLipIfOduj5czTz1+t2M3DzZ6FEifv/Nknx+spdVNYYHqR85IcyLJcodiWACPPfsGDU2tnHDskVx50ZmJmyzOe598zfuzvwZ+/vI1Dg06T0CRaAxFEZAVGDFsEOs3biUQCNHQ2MxpJ8/YZz/0+CQ8aEAxxUX9CIUjhMPhRAxFd8RXvs+++BZVtfWYzUamTD5CfUC2iwFpf4zu6tC8/taHZGSkMeOYIxElGZ/Pz/hxo1i9ZiMrVq+jbHsl2ysqCAaCiNEY9iS1gJ7L4+Xxp18lEAjhDwQJtP0/HIkwcfwYTCYjbrePVWs2sGbNBkrLK9sybiJqJ/keYoaisZhaNLHVQ3NLM7FYLOH2i0ZFtd2I0UAkElXTkPUGjCYDgtC7Pmu/BKmdaajzMXS6uLuv4xuCADablSS7DRBIcTgIBPw0NLUQi0nEdDGWr16P1WLBoNMRjUbUbKyYSJLdhs1mJRqNUba9GlCLOkoxCQWQlSgZaWkUFuTS1OrC7fbRL09m6pETEgL5sgvPZuL4Mfy0bDVDhwzEFwgQDkfQ6/XYbWodqYHF/TGbVUHixMHow4ay8MdlqqiSdSQnmUhKSkKKiUSjUQRBoSA/J5G1JooykixywvSpfPLZXKBjhpMoilRW16LTqf3o9HpdIlbo5BOms2T5KiKRKGazaYcZl93RnSDpTsysWLWekcOG/OJYxM5ziCiKrFi1FofDgcWs1h1ye7z88bfX7HJIQLz2krktG1JuW0D8LNxiNLW2Eo2JmNuEbygcprSsAr1er44vECTJbuvWvdnduWWkp9Lc0sqo4UOQJBm9Xkd1TT1en59QKEy0rQBsZ+td++sXi8U44bijE81yNX5mp50bg6EwSju//O642BA6ipr4SjLOZeefhs1mRZIkbvjz3YwZOYSxo4d32MW5px/PuacfD6g339RTrvjl49E4IGifYROLiQm3ldlkRBAUzCYjyUmZpDlTaGhq5spLdi1upzfH3pXA8vaTsNFoxGg0qmnLO3D5JdoVHD+NbxcswmqxUF/XSElhAYFAMDGBQvcTZWVVDQ8/8QJbysoxGvSUFPfnmCkTicViLFq8nP6F/RBFkVaXG7PFjCUSJRJVrQtZGWmqGQIBr89HKBzpMK5t26tIslnQ6/UMGzKAUDhCaMNmdHo9GRnphEMhWlxuZFlBJ0C0k1UmEo0RDAQxGk3oI9FEU01JUq1HauwD6HUQiUXwBwO9rpq9q8SDsHvC1FaQUicIiXYgoiQhtP0PBbKz0klxprBpsxu9Xo/RYMBgMBCNxjCbzHj9fmIxEUeynVgkhqQo6AQd6empKIqC2+MhFlUrezscSRiNRmw2K/2LCkhLTSEajmKxWEhPdXawQowcPpgBJf0or6hhwrjRrFu/BZvdwugRQxl7+Ki2hr8/l3iYMHY0RQX5fPblPOxJNjweHw31TZjMJjxeL1ddOguLWRUVY0YNZ+2GzQgYefG19zj7tJnkZGeyYvV6BKCkfz8qqmqZ/8NPGPRqXFPh/7P3nwFylemZP/w7oXKu6uoc1K1WK2cJCQECBIg8MOBhPEzyOO04rMMGh032f73e9frdXedZ2+sZm0mYYWBmyDBCIIFAoBxbarVanXNXDqfqpPfDqSo6KpBmxtPXF0RVdZ3nnDrnee7nvq/7upoakCSJYrHImlUdtC9tqXADp2edFuLczSegOB+peb6MzNUGVLOzr7P5Ral0lrGJGM1NDciyjGmadHX3EIvHrylgKD+Tg8OjPP7d5yqdn9u3rq+ozjscdqoiYVKpLAXVUpF32B0sbWuhu6eXo8fPkMsrvPzq/hmdp5c7t/vuunVGuUzTdTauX83WTet498hx7HY7Bw4exuGwzwgUP4ymmZ8GLBgg7X3jXf7XX/8TyVS6Ul6rjkb43tf//H0fLBoJcbqzG6DU5mqrRNIALU31lX/fsG0jvQMjcwKkRfx0YXowMDEZY2IqxsjoBDZZZOXyZXOc7u+/+/YPLTh6v11l74fkWV4MMpksmq7T1dNLMpGmv3+I7ds28Z2nn69wJcoTZVn75PvPvcKRYycpFIt4SzYi3d09JOKJCnHd5bS8zyRJZmlrC3lFYWJ8ioKqsv26jbicLn7w3MtzAgjDMBkcHCYaDRMJh8hkc/i8HgIBP/FEEtM0SKYzFaVqTZ+fPF0oFFA1HVW1SgszAiDzvf/omv6RBUdw5ayzqhuYgN1mZbZsNpl4IoUkSbjcTjqWtbJl03rWr13Jn/3NV1EuWV17ZX81QbA67WRZIpu3POxMQycUtEx+Q0E/A0PDFX5TMpXB6bCzvGMpPX0DXLzYh6ZrHDt5hvraGrZsWgtY2YmpWAIBq8vP7/Oyds0KCgWF9etW47DbZ3BHyly04ZEx1qxZztDQGH6fl2g0ws89+hDXb9tMMOBnKhZHVTUuXOwlHApSKIkJnjp7Ho/HYwUlJqQzOU6cOks6nSUYDDA6MUUqk2HpkmZ237Zzhq7O4NAwmZxCc2M9bpdzxnOjKAVOn+3izYOHMUvk/ltu2j6vqGn5HBbi8V1NQKWqGgNDwzQ11Fc+Pz17kkylqKmOzNiAWJ51V89zKwcvDruNqak4AZ8HE4GVK5aSzeZ5ec9+Gr/wCJFwkK2b1pLJZK1WfkEgGo1QX1dd6XgNh4I01tcwODzKJ+69ndrq9/iUs8+tPNbZ5bJ4IsWJU2dprK+7bAfth9E08y8dl+EgfYf/+Qe/zTeffI4//N1fobtngHePnvpAB7tu01r+/rHvoigFjp08x47rNvCtJ58nWhVi68Y1vHv0NLtvvZ5kKsOJM+e5c9cNH+h4i/jJxvRdk6Zp7HvzHUbGxmltbsYwDTRdY8e2zezYtnkGOfpyO9f3c+xr9aR6PyTP8mJwprOLuppqZElmdGScnOJmeGSMSDhY2TECjI1PcvbcBUwTxiYmrSyTKBGJhJicjJHJKQQCGuvXrWJgcIQznV1cf91GwMTr9XDHrpsoFBQSyQxfePST/PXfPobb7SYWT1bG5HDYK+rTAZ8fj9vN4NAIyzuW0rakiWQ6SCKeJBZPYLfZLDFEJKarL1YMXItFDMMiPhcKxYpCMoBuWm3/mCbaAsGRaK3TH7jsdrkASRJFHHYbsuzCMHQKRbVk9SGyoqONaFUVTqeV7TnbecHiD4liyey3WLFlWt6xlM7z3RQKKpIoEvVH0A2DgqqWVLxnBpFKoUhBKTCRyrKkuYFcvsDkVIw3Dx6irq6adauX852nnyebzXHi1HnsdhmXy0k46Keubhn33nlLJQAow+l0VEpyHo+L5sY6lpba4K/bsqGyifC43dZvUwrmZVmysmeShFBSchcATVUZm5ikKhIqtfs7SaWz/MIXfpalrc38j//zFaZiSYqqyoG3D2EYJtVVEW7Zub3y3AwOj/LKq/vZ89pbJFNJamuqAdi772123Xw9Nps8I5gaHB5lKhbjzLmLlQ3R1fD4yhuT0bFxDh09CTDju2d7z1mlw5E5/KmrRTaXY2IyxsVLffT0DZBKZ/B7PShKAQGLK1kWs330kQcxgXPnLiLbJFYub+eGbVsqHa/TGzQef/KZSoPGQqKQs2UTVFW95g7aRSyMBQMkj9vF2lXLaG1u4HRnN1s3ruFv/uFxfuFzD73vg4WCfn7u0Qf5hd/8A3weN3/0H/8133jiWQRBwO12cu5CD48/9QKJZJpPf/JOVq9Y+r6PtYiffEzfNaUzOUbHJrDb7bjdThwOOz2X+iup8A9bC+laTCPnw7WmsKcvaLphcKlvgOpoBJfLhc1mq3A9TFOoBFLlcneo6GNkdAyf14vb7aI6GqkI87W1NBHw+3j38EmmYgkaG+pKWY4CIPDQJ+4k6PcjiKKl8NxQS2/fIIZpudDb7Ta8HjctLY1gGgwOj9E/MERTYz3RqgidxW5MwySZTFknIoil3XGZhC2gG4al14OIWGrhttsklIJRUa+2WrsXvj42m42iqpU+X7zyD/g+oBsGJpa1iK7ryLKEbJMpqiqnznYhit3YbTIDg6PcsH0zDXU1jI1Nkkil0HUDWZbIZPM47HaWNDeW1KRzPHDfHWTTWdLZPEeOz7/J9Hjc9A4MklNyqJpO0OfF7/Wwbct6Tp05TygYwOFwEE8ksNvt1NZUI4oC3Rcvzch+TC9drVnVwfat63E6nZUMzPjEFErJr62cQdh9206OHD9laVjZbNy0YyuX+gYoqhrNjXWWPUwuR1HVWNmxFJ/XQ7Gokkyl6Ghv5Vd/+z/zgxcszpKu69hkiUAgQCqd4YevvcEjn7yPWNxSAS8UNcYmxgkGApYQqWnx1Ox2mWAgMEOB/omnnmNkdIKA34Oq6mi6dkUeXzlYUFWNQ0dPsmXTOmqqq+ZscKZnTx556D5eeXX/++ZPlTvJQsEAbpeTeDzJ4PAodocD09Cpr6+pBDjtbS387m99eYYALMDRE6cpFoucPXcBl8uJput4XK5K9mkhUchy+W52B+3RE6c/NNuln2YsGCBVhUMMDI1y603X8ed/+016+4fJTeMmvF/cf+fN3H/ne0qu/+ZXv1D592/+q8994O9fxL8czNgRYlZavG22sgrve6nwD5LxWejYE5Mxjp04Q7mjaSHTyIVwrSns8oKm6Qa6ZjA8OgZYFhi5EuEyEg5WAqkygW/jhjUEgwG6unsYn5iiqKrU1URZt3YFNpuNmmgV27eur3SpwEz7k8PHTtI/MITdbqe3fwiPx9Km8XrdyJKNZe1teD0ulrW1AAJrVnVwruui1RllGthsNpSC1XEmS9a1y2azM7JBDocNTdUscrJuKWiD+l5KSBBKGYv5r02hqOJ2ObHbbbgcNpLp7FVf12tBPl+olBnDoRCaplYI6EapqaR/cBj3SSehoJ+6umrsdltJMgGy+QKnz54nEg4RCgVJpNOcOnUOE4Glbc3U11WX7qmZaKyv5fCxk2TSWUwgHoszMjbBntfeRBQlwqEghmFQX1fD8Ng4yVSKQlFFyRf5wXM/xONx097WYpWbS9h18w5237aTvfveIp3RmJiMIQjw/Mt7K++XuTHL2ts4d74bVdWw2WxzlJdj8Th5pcDI6Dh5pYBpmqxc3s7I2DjPvfwakiQiCiK6rqNquiWoaZNIpTIkE0lMU+D8hR4OHTnB4PAYY2OTeH0+wkE/CELJ1uS9TEehUKCru2eG0Or0DdFCKAcLA0PDANRUVwGXz6JYf/PIZTvfLrfRmd42HwoG6O0fwiZbgXxTQx1228xl1ul0zDmHXTfv4NkX9pBMZZiYiiFJIsdOdpLL59i2dT1bNq6riELefOP2SsA7O+ib/n0flu3STzMWDJB+/Zc+Q8Dvo6mhlrt23cCBd47x67/wsx/n2BbxU47ZO8JQIIDTaa9M0NNT4deqfns15OsS/WKGzMX7wbWYXu6+bScv79mPpquEQ1awl8srM3Rh5ssM2G02fuaT9/DPTz7L0Mgomq5z4K0jpNdk8Pu8c7pUprcNv3v4RInjEqeuJoqqalRFgqTTWWqqo5zrukBTQz0XLvay84brCIWCyLJEb/8oAlikb6eDfE5BEAXSmfeClwqnyTSRbRbpWVfNUpBktb7LslRS1jYvq6Lt9VglwPdjXns5zG7oL3Ow3G4nicTcbFU2m6O3f5DRcStbkFcUDMPEbpPRdZ1kKoMsyxQKBQpFDUmWWLtmBQGfj85zXfOO4eiJ0yhKETARBBFRsBZel9PFqbPnaG1pxOmw4/V6aHc1s37tak6cOoPP66G2Joppmjz27afmiCd+4TMP8YXPPEQsHufJ77+Iz+udsbiWnd+XtbVQXxOlUNTIKzka6mtmcPnq62r57CMP8Mqr+y0JBwHu2b2Lw8dOljShnBQL722gC8WCVa4VBHbeuA1JFnn3yAmCAT+eqTjJVIp0Joei5Fm+bCk+r3tGpkNRivNqK10NN8jpdNDUUI/NJl82izL7uZzv2byarHS5bb6xvoaR8UkcdksbatuW9YSCAdKZ7BUzz+1tLdx803YOHjrG5GQMp9OB1+PB5XLx7uETrFm5nGwuZ8lJ+Lwz/nbhoG+RhP1BsWCA1NxYV/n3A/fcygP33PqxDOjHDe+ni2kR146FrvP0B/2Wm7az782D86bCr4UYfTWTXjaXoyoSprWlqVJiu5qJ7v0cazra21qo+vQDrOho43RnF6ZpaSPdvfvWil1AOZAqZwbAsmt4/Y2DFItFljRb4n+DwyOcPXeB67dt5vU3DpLPK6xZ1VHpisnmcqRSaQoFS7H43SMnEUWRgqYS8PvwerxEwgHa21tIJlK4XE7eeucILY0NXOodRFEUbA4baqnkVVBVtDkiRe+FHjZZplAsYrfbcDqdqJkMSsH6W1EUscky0WiYoeGxea9NIplCkqUPPUBaqLIXi8fJ5ZQ5r2u6TjabJxgIVLScyved0+VC1zXi8STBgB9REpmcinHk6CnSmSwnT5+b91iTk3FkWcRms6EWNUKhALm8wujYOIFggL7+QSIRSwpAVTUSiQSpdJaNG6wmlrLkRaGoYrfbZ2wQIuEQw6PjHD1+GrfLjSDAqhXLsNttTExOVWwnkqkMo+PjBAN+ZFmeI1Da3tZCobDdUvS2Wd1RjfV1lhyTaWJ32C3xTcMkEAggSxINdTVsXL+aickpIuEQqXQGTdMxTQFZFnE47CiKQiyerPCELKHEICs6Wj8QN2i6uCTMzKJczXN5tVnpskTHY99+Cl036BsYYtfNO6iOVl11eUtRChw+epJN69fw8t43MIFLfQPcd/dtyLI8o3x2taWzRRL2B8eCAdK5C5f456dfZDKWmDGD/PWf/oePYVg/Hviw/b0WMT+u9jovbW1e0IH7WiwGrmbSK086sizjs9neVx2/bIESDgUsdWm77Zr82BLJFGpRpaoqwr43DuKw2ytB0mzLFV3XS9wcwfJFUwqMjU+ypLmRQqHI+a6LvHP4BNu3rmdFx1K6e/qYmIxxrqubbFYpeTfJlo2GqpNOpZEkGROTsfEJJmNxVFXHXlrANUNncHgUWZbJK4VKYDQ7y1buSKuqipBOp0vXsZQ1EkRk2crOiaKAbuhksnnsdplica6Ao6pqyDZ5xuLwUWK6ee10yLKEy+Uknc6gGyahUJCpWBzDMCoq5rligeqoFTBc7Omjrraa8ak4Ab+PXC5XsX4BK3Csqa5CKRQwTMvctuy8/vwrr2Ni0rG0lZ///Ke4YfsW9r15kP6BYQaGhpEkkb6+IZYtXYJhaKjFIqpqn9HxVc4SulwuPCUbpzOdXaxZtRyfz1tRYo4nEng9HhKJFKFgcM69qiiFSlBU/g0Gh0d48N7b+P7zr1pFcBOaG+tZu2Y5dlmmvr6OXC5HOpNjYnIKESgUiwQCXrLZPOFQkEw2R9uSJm7deT1KocCFi5eIVkXeNzdoPnHJNSuXzziPq5kDrjYrXZHoKBn8JhIpjp86Q3VVZEbQdzmUj9XcVM+ytpYS565IwOeraCm9X4XvRbx/LBgg/cf/9pfcvGMLO3dsQZ5GAvxpwYfNaVnE/LjSdb6WIHU+n7bZuNpJ74NORt09fTz74h7eeOswyXSK2uooAb+PhlI2bKGy3/SuvWMnJkimMxZ3RBQ5fuosv/NbX56jMAxWBslut5NKp+np7UMpFJmcilFdFaHnUh8ut4tCqZPssW8/xa07dzA4PEp1tIpRcwITk3Q6RzqdRrbJJFUNj8eFWhJ6LGsbZTJpdF3F4XTiL6neR8JBhkfH0XWtVAaZqzOUzeXwltrGA34fI6MTuFwONE1HFASKqorP68XQdQx9AZ0iwQq4Po7g6HKlPpfTgaIUyeqW0azTYcPjcVMoFBAwKRSL2GwyU/E4Pq+HRCpD2f+tvq4GWZYYn5hC1TSqqyJgmmRyOcLhEOMTEyBYnXEOhx2P20U4HKRYVHniqWfZvnUT0aowp892sXJ5OxdLIoP7DrzDkuYm3jx4dI5y+1QsjizLrFnVwcnT59A0jULB6nayyTId7W1cvNSHUiyiGwaR0vFg5nORzeVQVY1MNockCuiGZVT73/+/3+XXv/wl3jl8nMGhUTralzAwNMrFnl4GBkd48nsv0j84TLQqwvkLF8nm8qTSGSLhIIl4GqfLzqmzXSAI/PN3nynxkUy++OjD/PznH5lDaL4cLicuWcbVzgFXm7Epf5/dbsdut+PzerDbbey+7cY53YXTxzl9ozd9Q7Z2zQpOnOokncmQSme4765dle+Y3YGn63qFcL+IDx8LBkgBv4/f+Fef/TjH8mOFD+rovIirw+WuMzBnsnt5z35c9+2e4c5dnmxGxyY5cPBw5bsX4gvA1aWp328dvzxJh4MBkukUXo+HeCJJtCpMV3fPgl1H06+FUiii6wZj4xOEO9pxuZwAvLJ3Pw31NXOuy4GDh7l+2yaeffFVhobHME3L8iORSqNqOtn+QVRdx9B10ukc8USCQqGA0+HA7/XR3FjHgbePsHb1ckTR0ty5eKkPv08nncmVynIKsiyTTGVwlbzTJFEilc4gCiJI83eYuVxOqsIhqqMRCkqB4bEJBBFERIJBL6lkGqfDgcfjIhwKcLGnH6ckUShYHmKGaSKKguVOXvhwO9hsklWyK4dcomiJe+oLlPGkkv2Hy+UinkjgdNjJ5RTcbgfZrI5NFpFkGVEQSKezpNJZTNMknc5gIpBMpdE0jcb6GgRB5KEH7uHpH7xAJpujrjZKJBRANwzWr13JiZOdBIN+q+ypFFAKGulstmQTYnGlNM1aICcmY2zZuI7VK9orPKKqSAhFKaAoRXJ5hUKhgKHrpYyd9btM588kXniVRCLJ+FSMdw4dpba2pnKvKkqBc109vP3uEUzTUm2vqY5ikyVuuWk7a1cvZ+3q5XT39PHynv2cOtOJzWZj44ZVuFwO3j1ygs0b11JbU8XzL+0lm82TzeXJ5xXC4RC6ofP1bz9FfV1Nhbf22LefIhgMcLjUqg9XzuJfzbw9ew4oFotkszky2RyxeKKyubraTdJ8c4rNJi8YHJWvUdnst2xtUj5WMplGURTa21rmELzB2rxN1526musyHxbpI1fGggHSzTds4fDxMz+1xrEfxNF5EVePy13n2ZPd2Pgkh46eoFgs4vG42XXzDoAKifvdI8fZumkdtTXVl+ULXEtm6Frq+OUJp1Aiqxom1NZEicWTFApFUukMHe1tlcV3vixQ+Vo4HXY0TcU0rS628vWx2+xMlBzoLSE8FaVQRFU17DaZqkjIMiAVBCYnY5w83YlpgsvtYuXyNoLBAGfOXeTEyXP0Dw9jl8epioSQZBFBEnG7XOgltWfTtMxURVGkWChYv49hdRPmcnmcTiemaVgcHMHSKpqeeRFFLJ6OYHUeCqKI3ekgEgmSTCRpa20ilkhiGDqabrKyYynhcJBYLEEymcYsGe1KCNZCbZqIkgTGhycmqZZ+C0EASZIByxvNWCBAaqirxelwEAj4cDudxBNJMrkcqXQOh92B2+XExCRWUha3xHBt5BSFqnCYglLA7/eiawbbt61DFExqa6MlMU8HNlmmvq4Gm83Gael85ZmwlJllnA4HarHIVCzO+e5LANhjMfKKwquvv0VNTYSJyRjBgJ9kySC3UNQ4dfYcwyMT+H1u6mpr2L51Q8UIddfNO/jmE99ncGiUXC6Hw+ngzLluxidjPPbtp1je3saps+c4fvIcSr5I78AAoWCAsfEJ7r1r1wxD1fa2FsbWreLNtw7hdstcuHCJhnpLKkBTtZJ7goggCjgcdmRJQi2qTE7EretumBSLBWRZRtMMXnzlNTra2646i38183Z5Dnh5z36GR8fp6x/A6XTy9LMvE41E8PncfPHRhytBx5U2SdcypyhKgSeeeo7BoRHK7QFla5NyBvz//dPj3HT9Vnw+75xOtfJ3fNDqxiJ95OowJ0Da/fAvA0KlpdVd2rmWfbRfeervPtYB/qiwWO/96FEOKKYTjMs7qunXuSyOdqazC5fLRW1NFFmWeeXV/ZimpfCeyeZwuVycPddNJBzCZrMBH1+Hx/RdoSiJZDI5WlsaCfh8RCNhUukMO2/YZgV3JV7IbEXs1984yC03ba9kwVqaG0mls+TyCkLJGNRmk4lWRQAYHRvn7LluDNNyP1+1sh1RlPB43Oi6QSqdJhQKEomE0FSVickYHrebUNBPvpAn5LeUlPP5AoIo0drcQCKZZjIWtwjRJRNWWdJQCho2Wcbn86JqGqZpWI73WJwSSZLxet04bDbGJ6ZKbfuQyeSoigRZu2o5Bw4eLi2ARVatbGd8MkYslkDVdASg62IfvtFxnG4nYxNTM8jYuqrhdDqw22WUvHZFy5BrhcPhJBLyEwmHSabSDJWsG2bD53MTCYeoiVZx4VIf+WKBVCZj6TgZOhNTMUTRUgqXJAm7zUb70hamJuO0LWlmy+a1uJwOBEHkUw/eY1nlOOwEA/6KEnImaz0TsXiCNw8eRtN06mqj3HPnLgYGh9n/1lm6e/vI5fPURq17IZdTCAeDTE0lcLtcjI9PousmU1NTiKJkqYJLIsvb21AUBSWvkEpnicXjNNbX4na5WL2yHbfLxeFjp0gmU9hkmX1vvMO3nvg+KzraOX/hIplszvL4Uq1mgFAggKqqledMUQqcOHWWQNBf8q2Dvv4BopEwhWKRdCaLYRh43G5EwbKY0Qyd7ds28M9PPkPn+e6KVpbNJr2n5s3VZfGvZd7WNI2eS304HHbOnrtAtCqCUlBoaqrjsW8/xaYNayqZpCvNEVc7p8Ti8TnyBdOtTbp7ejl9tmsOmX52qXP69bjW6sYifeTqMSdAeuwr//1HMY4fSyy2Sn50mG0houk6fq9nBsl3+mSXzebI5hSu27KuEvwUSuUWQRBwOuwlsUHLWX62LcFHifl2hR6Pi2DAT0N9LV3dPXS0t1EsFiuT9VQsDsxUxC5rnnzhMw9V7rmLl/orXUNlwmcw4OeG7VsqruqCILBl0zo6z3VXXNWnYnGGRsbwul2kkmnaljQhyRJ11VWcPH2efF5BN3TqamtZ2dHKoz/zCdau7OCP/vSvcNjtSKJIMBhA13WCQT8TE1ME/F78Pj8+n9siaEsS9XU1JDNZUolUKUiwlLp1TUM3Tex2u2VLEk+yYnk7wyOW5UVP7wCFouXL5nLaKRQ1xsfHUXw+lEJhXv6Pz+ulWCwieSXSH5IOkt0mY3fYcdjtlu6RrpHN5rDbbQiaaFmjlOBxu2huaMDpcnLyzHkmpqbIZPIYho4oWlIFolAOjkQkScRmk3G7nIzpGuOTk5zvuojDbqeluRGPx/KdvPnG94JiVVUru/nbbrmB3r5BNN3iIx0/eZbtWzdSFYmQyWQ5d6EHSZZBEPB43OTzeQzDZGIqhmmY9A0M43Y7sdvsVEcjpHNZhkfHK4R9E5iYmOJzP/sAHrcLp9NJ/+Awvf2DJXmJPDklh6KoiKLEZCxmKavLEg67g97+QfQSOX+6B1yZ73Sm84L1fBRUvvjZh+gbGGJ0dJzDR07gcruwyTZU1doUXbd5Pe8cOs7R46cruhorOlaiahrDo+ME/V5cLteMYy2EK83b5QDB5/MSDFoBXiqdoaoqAiYYuoFpCkxMTl2TbdHVBFLzSRWUX7scmX76OZf/XSwWK0H19NevhEX6yNVjToBUWx2pXDCwZPDfOXKShtpq2tuaP9bB/ThgsVXyw8H0ejdYZTGvx002m6OvfxBRkui44bo5KeXyZBeLx3E47JXsiWlaO2/TpFTzt7FqRTuHj56sdAAttHNciAPwfjHfrnBicopf/cUvEAh4K2TK6ZN12Vrk5OlO7HY7ss3qGCtrnkTClqDj0tZmHvnkfQiCSTgUquzS7XaZjevXEPD7cDrs2Gw2YvEE9+zexYF3DvPW20fwlVzBdUPn8PFTLF3SRDaXR9N1MtksgiDS3dOLrqt4PC62bl7HrTfv4MKFHjLZLLpuda1VRULYbXaiVWGGR8ZRCgq6bhAI+HC6nNjsNloa6qmtqaK3f5Cz57txuUveb4KIaZosX95GX/8QK5a10ds/ZJGXB1M4nQ4KRcuSo+yAnp2ntR4gl8tRX1tN3+DQ+/6tZsPhdCIKAoVCkZGxcZwOO3aHDYfDxsRUbMZno9VVuN0u0uks99x5Cy+8/DoOR4aJiRg2WSKXV6DEP6mpjpJKpVA1jdGxSSvzVtToGxwuZUgMvv2dH1QC+Ru2b5nhR5ZIpvjn7z5DS3MDoiiSy+V598gJ1q9ZQSqV4mJvH4IgMDFhLeK5XI77dt/Da2++QygcZGBwGFmWUFUdl1MikUzhcjg4d+EixaKlsRWJhDh5upPX36jF5bTU6Q8fO1mygrHsRsYn4vh8HhKJBKYB+WIBWbRc691uF0PDo3z2Zz85h99TE60iEgqSVwooisKypa0Mj4zh8Xpoa2thciqGki8gigLRqgjdFy/R0d7K2tUrSKfT+Hw+Tp7u5I0D7xCLpxAEuG7zen7lFz93VfPx5ebtcoDgKr3vcrkqdioIIEoigmBW5poPE5eTL5gvuMzmFLZt2bCgrMB0QvvVrlOL9JGrx5wA6etPPEtLUx233LAV0zT5zd//EyanrDT8r/3iz3Lv7p0/inEu4icYs+vdmzasrmivKIUCff1D1NZWoxSK+OYpjZWVZ8vaP6qqUSwW2X3bThwOe+W7RUHkl7/0KK0tDZVgYjYuxwF4v4HwQrvCMpyOuZO10+mgoa6Gx7/7LHaHDQG4ccfWiubJQh188B7n6tiJ02zdtA6f11OZ5Nas6qCutppioUheKdA3NIxQOlN/IEA0HOTEqU6rLd8EySahahq5XA63283AwBCNDXWIosiZzi4UpUgkHGL3bTfx4g/3EYmE0HWdJS2NZLN5vG4XyVSGZDqN02HnoU/cxdDf/hOaplFUVYJ+H1VVYVLJNBcu9pFKp0mnMthsNkRJQJIsNU6tRMZOJJMLEqSzuTwXewc+1NKaoWkIsoxSsAJ4URBBEErkWKEiEiqKAlOTMXr7+lGKKvbSrt0myZimRUew7FUk3C4XNVErWJYliU0bVnH81DnCIT+GYVBXV8P5C5e4bvN6wqEgxWKRF17ey8MP3l1ZpCYmp9A0g2JRRZblymZgIpbg7Plu3C434xOTuFwuYvEEWzavx263gtix8UmcDmepG1DA63ERT6SoqY5iGiAHZaKRcIlwn7bkBQydHzz7Mvl8iT9nmJY6umHQ3tpMLJ5EFAXcTofVmp/LI4oiHq9nzn09u8RVzpBFqyKEggH6+ocoKEXWr2nC6/Wiqiqnz15AlmVCwQAet4tsNmsRuzesob1NpFAoMl7ygvugkCQrwPN63KxeuYzTZ7toqK8jmUpTE42SSCT54qMPf2im19PhdDquKF8wO7hcs6pjxnfMlhVw2G109/SxY9vmqw4eF+kjV4c5AdJrb7zL//vzPwTgldfeIpPJ8eQ//m8SyTS/+u//eDFAWsQ1Yb5694G3j9B5/gI11VGcTgfDtnFGRseQxCt3lRUKRavkZLeE6nbdvIMvfOYhTnee593DJzjT2cWZzq4FSYdX4gC8H8y3K6yOhnhpz+uVDMHs8ShKgeHRMVYtX4rdbpXPxscmqY5E5nCUpnfwCQKVsW/ZtI5DR09y3eYNc0T2ADK5LC2N9ei6gaapqKrKxd4BHA47bpeTdDpLsVAkFktyqW+IFR1tdLS30TcwhMvlpKO9jUw2x8b1qznTeYGmxjqiEUtz6fDxU5iGyenOC9jtdjxuJ0vbWnjhldcsq4xECsPQyWdzuJwOcnmF8YlJCoUi+byCLBcoFjWUfGGGUONCrfVglcMEQaBQ/OABklQSMWxprqdvYIRUOgOUSOa6Tl4pIMuWUa9lgiJQKBaZiCVpaayzMiCKQjqToa62BqVQIJXKWKU1UWJwaBSbXeauO25laHgMJa9YnXgOJ8PDYyRTWQ4eOkFdTRV9A8P09g9x9MQZ1q5eziMP3Uc6k6N/cIipeBxREKirraa2ugpFKZDPKySTKbxeD5IooWkq8ak4n/vP/4Z8QcHn9dDTO4DDbqNQLNLcVE9TYz27dl7P3//TP5PLKoyo44RDQTBN+geGeP2Nd2ZoM4HVBWnJMnjxer34fF5GRkcYm5zCNKmoe8/mr0zP+pYzHNZva/katjY30nn+IoIgoGkaa1Z1YLfZ2LR+DUdPnAas0l91NFIpp7vdroqW0gcJXMqbjlxe4eVX99PR3sa61cv5xS8+QmNDHel0ZkGJkA8LC1mbTA9cpm8CZ2suDQwNW00ZJVkBALK5ayqRLdJHrg5zAiSlUKwojz7xvZf5ws/ejyiKhEOBilv1TxMWWyE/GOardxuGQUtzE7F4AoCqSIi8ojAVS+DxFC/bAfL6GwcJ+P0z7BIeeehejh4/MyPoWYh0eDkOwPvF7F2hKIlks7nLjqecTl+3diVnOi+gF4oz0ulljtL061ZuoS93r3k9HjauXzNDb6V8v27ZtJ4fvPiqJVwoQHNTA5lMlmVLW5mcjDEyNoEkiXjcbhobajlx6mxFhBLTRNMMy3qkrobammp6+we5eKkPu83O+PgUqWQawzTxeb0E/F6qImFGx8aJx5OAQLGoohsGqpahs6uHgcFRq+W8UCzJGMxcjCVJRF9I/wgrg+PxeCqBzAeFAHS0tzI0PMLwyHvK3QVVtbhEokgg4MfQdVKZHH6vm2AwQEtTAzabjKpn8ft8xJNpXC4X4aCfFcvayKSzVFVH6O8f4pP330ltTZRLfYPohsHg8CiSJDE5GSOTzTE0PIJpGAQDfjo62qitidI/OMLzL+1FlmVuu3kHb7x1CMM0Odd1kd/8lS+x88br+Luvfove/iHS6QzJtBWIDo+Ocb7rIm6XxSUKhwJ0X+zD6bS0pnbdvIM33j5ETXUV5y/0kFcsA9qdN1zHxYv9JVuUmRIKkiQRCPgQRJHVK9upr63hh6+/xcDgEA67nY721oqJ8uzFeXobuqZpXLzUTy6XxxIy1QgGvbS1NFNXG8Xv9xFPJFmzqoM1q6zvUjWNrv/8JxiGUSH2G4b2gcpe0zcd4VCQ1pZGxiYmeeiBu7DJMh63m9rq6Af6/msxp57vM/NtAh0OO+1tLZzpvMArr+5HEMVK9rjcsQvXXiJbpI9cGXMCpOqqME987yVS6SzpTJbbdm4DIJnK4HT8dF3MxVbID475CIUOh5362uqSZov1WiKZqpipLvTQnu48z7tHjs9rlwBXRzr8MCwM5sP0XaGiFHn+5b1XpcUyO53evrSFqVi8oj8znSdgWUjM7V6749YbZ5TkkukMU5NTrFq+tGI+KooiK5a3UxUOEQ4GePHVfThsNkzT4IZtW5BlmVwuZ5WJJAlZ1q1ONAFSqRR9A0MUiiqHj54kGPJjChCNhInFk4TDAQpFlfHSwh+PJzFMo2JgWigUKBatjliHw24JKgpWEGJJCZhWR1Op+2s2RMHyYYtEghQKBXL5D241YpoGx06dtXSBZpXsTMAmS3hclrimaWSoq6mmpakB3dAIBvw0NdSRzxeQJJG6Upt+tCpCOp1h/dqVvP3uUWqqq5BEgdGxcSLhIC6ng0xJb8dht1nZsIJOLJHE43YhyzKCUCSdzeJxuVizajmtS5rp6e2nq/sSQ8OjPPP8HlYsX8Z3f/AyU/FESYtKIJnO8Fd//w1WLW9n68a1HHjnCLfurCeby7F5w1pef+MgJiaFQsHSoyoUWbuqg1AgQDKVJp3JIYozNwmRcJD62mo8bjfXbd7IydOdlqeeJNPS3FhRUS93ZpahKAVe3rMfmyyBIOJxu+jrHyIUCiDLMqMTUwwOjfFi/HVEUZzDLSr/94uPPszf/P3XGZuIgQDbt2xgcir+vrM7szdrdrulYfX4k89Uxv9+5/jpa4WqamzbsqFi63O1UJQCU7EEr79xcIZa+d59b5FKZ/iLr3wNl8uFKAgsaWmqZI8Btm3ZcM1jXsSVMSdA+t3f/Hn+9C+/Ri6v8F9//9cqJYJvfOdZHrj7lo97fD8ylHcbXo+7sogvtkJeOxYiFDY3NUybUNQ5ZqqzcbkOj+nE7SuRDq+GA/BBzrWcxbnSeObjAazoWMp3nn6+8v+z3dnvvH0nhUJxTvfagYOHK+KRpzu72LvvALpuqRxfv20T61YvRZREbti2BZfLyetvHGRJKROyfs0qGupriCeSKIqKy+lkx3UbLTVoWcYwTc6e76a1pYmu7ktURcLohk4w4CcaCWOz2ZicijM+cRG7TUJRihSLxZKQoYkgmpgmyJKEJEnk8zl03WC6GLatZPIqiiICBpIkUVQ1JMkqcS1buoS1q1Zw7kJ3xbvtShkn4LJSAIIo4nI5SSZTGPMof3vcLjZvWEPfwBBT8SQmUF9fwx233sjj330GMS9hGAbbtmygf3AYXdfJZHOsXbOCaFWElcvbyecVRkbHyOUUK+uk6milMQuC5V4vlXSjygbMpmni83iQZcto1W6TGR+fJOD3VeQt+gaGkEQRh92Gpls6VIVCkVgszp7X3uR0ZxcOm8UV0nS9UqY6d94i35ezOO8ePcWv/tLnkCShpF+lVSQKRFHA63WztK0FVVXZvHENmzeuoSx61XXxEulMdoaJchmnO8+zd9/bJFJJMCEcDmIYJtdtWkdR1Tl3/iK11VFalzQhCsKC3KId2zZz6sx5RFHA7/fjdjk/0Bw8n0BkV3fPHIPfa/3+6ZmpsfFJznR2VWx9dt92dQ0g5QArm81x/NRZtm5aT21NtJQt1njxlddwuVwVvuHExBQb169hRUcr5y9c4uiJ0xw9cXpxE/8hY06A1FBXzV/8j9+b88Ev/uwnKroWPw3I5nIVInHZyf1yNhGLmB+XIxROb2e/0jW9XIdHMOC/JtLhQhyADwtXS4KcbRvwnaefn6GL1Hn+Ip/99AMzOuCmYnGu27wBt9s1o3ttYnKKZDrDK6/ufy8jYxqcOt3JA3fvYmh0vMLvuOWm7Wzbup53D59AlmXiiSTtbS28tOd13jl8AkkU2LB+NWtWW9pFsmTpH91/9+10nr9QWtDzZDJ58jmFWCyO1+O0shmSiF4KSkzTEpW0sg4itdVREs4Uk1Nxq/SHtZMv847sdjs10QixeAKXywqwamqqAPi5zz3M3n1vYRomPb0DFp/FKF7BdmThAEoQBGJTcdSiynxfkc8rnO28wIoVS7k0OMoD996By+Xglpu209RYz+Pf/QG9fUMoSpEVy9tZuXwpff2DCAjEE0keuHc3oijw7e98n7WrOjBNrKxl3urQ0zUdm93K7AmCjiAIjIxO0LqkkdtvvbHSfDCfvIVSKFBfX4Oua2Ry+UoHYDKZIpHKMDYxRbFQJJ6I8Yn7doNpkMnlyWZzVlAmiui6gKIomAbsvHEbff1Dll5SyWcuk80jiTKKovDzn3+kkrW5/+7b2bvvLdas7KCoFtm9a2elNPteBuQd4olExYomlUqTKUknKEUVQRQQRAGX04EkSSSSaS50X2Lt6hUAM5TlXS6nxZWahvc7B89+LrPZHB3tbRUez+W81i43V5QzU5qmcfbcBTweNwgCTufVBXTTAyyf14Or28WZzi4i4SCyLJeEcS09KFXT0DUdVbN8985fuHRV1IJFvD8sqKQ9G75Z3Qr/0iFJEl3dPVRFwpWd6GybiEVcGZfT3IiEFy6nLeRVtFCHx7WSDj/q+vvVeiaVx3E5XaQtG9dVPu9xu7HZZLwe94zsVLQqwuREjLxSwON2I2Bl5iZjCf7xW0/RUFfD0rYWmhrqOHDwMF/4zEOsWbl8RnA2NjHFwNAwyVSaoyfPsHvXTn7nt77MvjcPUhOtwm6343TaeefQcRx2O/5aL6IokFcUBFEkk8lgt9twGU7Uooqm6wgC+Pw+q51fLVITjeBwOFBVlYmJKRBEDN3AZrPsORxOB7XV1STTKUDA5bRsSrLZLAG/n+UdS3HY7UzEYgwNjVFU5zeUtW4zi149Xwilqhqqqi3Iq1Q1nUDQjyAI1FdHuNjTR1EtcrrzPGtWLqe+toa2JS24Sr/d8y/tZeP6NRTVIm2tzfzg+Vc4frKT3v4hQkEvyXSGYMAi3Pu8HtKZLJqiIyCwYe1qfv2XP8+pM1143K4ZzQfT5S1UVbXI45KE1+2krbWFE6c60U29Yhhsd9iw2eyIokBn10Vsr7yOy+kimUiRzedxOizu3pLmBkbGJykWFLZt3sDkRIxX9r6B3+9DliVuv+UGqqIRPv/pB1m5vL3yPDbW1867sZmeATly9BR+v7fk/WeQLxRYu2o5sXgSzTDI5/M01tegqhqxeILe/gFeee0AL/7wdSRJJloVBmYqy39Y7ejzbUou9/1XQ7Mof97KAr73usvpIBZXGBgaXtB2BGbOkTabjTWrOnj38ElGxybweNzsvm0nBw4epjoa4c23D2Ga1rN9+603kkymFvWMPkJcdYD00wZd1+lob2NwmqLudJuIRVwdPG43E5Mxjp04Q7mtvrGh7rKT3EKT0uyszOzU/o8b6dDpvHrPpLIu0pnOLmsHCjN0kebrdJn+ncGAn123XM/j3/0BmqZZuZlyGUeSGBga4WJvP+2tLTQ3NcwIUKdicXJ5hTffPkQ0EqYqEiaTzTIyOk59XTU3XX8d7xw+js0m47Db+f1/+6vklTyv7X+bXL6AyTChoI9MJlsyb7VTXRVmKp6ksa6GTRvXUlAUYokU61evoHdgAEmSePPtI9TVRJmMxREQLINWm8x4whI6XL1yGQ0NtaiqVmkDX7t6OVNTCU53nkfV5g+OABx2G16Ph2QqY3mtLZBpmv26JAkYuonTbiedyXL8VCc+jwe7w44kS7x7+AT1tdXIsozf5yWXy3H0xBnsdjtulwtMg288/hSGaTI8MsbouNWh6XDYaWqoJ5PJsKKjjUJRxeV04Pf52LB+NV3dl2htaayUfp59YQ9f+vynKvIWTzz1HF3dPSRTGQzdIBjwcersScIhP8l0FofdTi6fx0TAJtuwSRKKbjI2NoHf72NJSzPDI6NohoGiKMTiCWqjEQRJsmQCNq2jqiqCzSZhmBCbijE4OMpr+99mZHS8UupVVY2N61ZZQpelZ3h2BsTn8zA2OUljQz3Dw2NIgkgmm6OttYWe3j6WL1vKO4eP4Xa7SSXTtC5poq9/gO6ePupqqrnvrl3IssyBg4e5YfuWOf6KH/QZnz5PXC7Te7U0i/Iz+dxLe4knE2i6xvq1K5mKxTlU8pErd5ku9OyX70VBEKiJVrF96/o5nMw//fO/pW1JM7qus3bVCqamYhUduEU9o48GiwHSAiibOLa2NM6wAFi8+a4dglAyqilpygjCwp+9nAz+T1pr6rVI+judDrZt2cA7h0+gGwaaprFyRbslYDg6ht/vq5zzQtfh5hu2cdstN3Lw0DFMw6RYVFja1kw6ncXrdaOqOoZhcOrsOdSSAnLZzDSZSFq/jSgilAjhRbXIVx97opTChzWrltHS1FQxCm5vW8I/fvNJmpsaeOvgITBN1GKRmup6bLKMt1DE5XKhKApNTfVMxVO88fYhBoaGCfh9+LweCsUimm7gdjgoqirZfJFc3up26uq5xOjEBHfsugmXy8mm9Wt4+dX9JFNJNN3AZrNVXOdnQ9MNnC4X1dVRBodG5nS/CQIIgljKDmuV101TQBAhHA6wpLmRM2fPc7brIm2tzWzdvK7EDbJu4NGxcY6eOENv/xCFQoFMJovL5aTn0gB5pUAimaSgFK3zyuY4cuwUNdVVaJqOpmmEQjX0DwxTXRUhmU6xfesmAM6eu0Amm4dvPsn9d99OY30toaCfjvZW9rz2Fg6nnd6BIVYtb6dYVHE4kyhKgd6+AXRNszJ6gGGaqJpOIpmiv38AfzBAsVDAMAx8Pi9bNq3j5z77MLqu0zcwTOf5bvYfOEEskcTv83LXHTcTDPh57NtPcedtO4nFk7z97lEe/+6zNDfW0tbawmd+5hPUlsqg5QzIurUrGZ+M0dV9CbfTQUN9LZs2ruHpZ15k187rcbuc3HbLjYyMjDHmnLQsbSQZu93O6NgE6UyOcCgAQG1N1TWV4q8Vl5tTrpVmYbfJtLe10Nc/xORUnEu9/WzZtI6a6qorPvvzbf6mczJra6rmLa1Pl0aART2jDxsLBkjnL1zi8adfZDKWYHqO+q//9D98DMP60WP2TXs5ZeZFLIxsLkdVJExrSxNKoYjTYe3My2nl2RPTlWTwP+4s0QeRebhWSf81qzpY2tZU4rYUeOmV1xFFibcPHWX1CksAsrwLne86OJ0O/uO//zX+7mvf5sSpTmKJBH6fn2wuy8DQCEpeYXRsnMbGWr7x+NMsW9rK0PAYNpuMZhik01lkScIwTeprrfb0hvo6vB43o2Pj/N3XHp/RNdO+tIXWliaOHDtFKBQklc4g22TyuTySz43P5yMUDHDDts3s3f82Y+PjJFMZRNHinTgddianYpimST5neenZJBG/34eAQH1dDZgmI8NjVEcitC9t4cA7brxeL7IsUSgsnEHyuFw01tfQ3NiAIJhc6O5D13WMEhHa4v6IlmBmCYIAdpuE3eGkqKoMj47hcrlw2B2sX7cKt8tFPq8QCQcrVi92ux3TMJBlmUQyRVVVGFESGZ+cqpgWg4lhQqGolY4tUV9bS7FQxGG3oRSKDI+O8+bBQwR8PrxeDyZWOXnvvre4765bMU24eKkfh9OOy+nENAzGJ2Pk8wUy2Qy6plcaBATBMkoOBX047A5MU2cqniAY8LN9y3pSqTS37LweQzfQdZ3RsUn+7K//gYuXBkgmMyj5Apqqs/e1t3A73ZimQCab59SZc8TiCSRJZHwizuj4FH39g/z2r/+idZbTMiA3bN+EqupEq0J4PR6UQhHTFBibjJFMpglHQni9Hiam4u9df4SS46c5IxvyUT/zC33/1dIsyhuhaFWE6mgVq5Yv41LfABvXr6Gupto6tys8+1fa/C1UWp8ujfCTsGn8ScOCAdJ//OO/Yuf1m9m5YwvyTynv5ictY/HjiHLGTZZlfDZb5cEeHZuckzpvb2v5sZLBfz8yD9MDqvdzLjZZRpYlxicmKRY1JqbGEUSB/W+9y3137roiCbNQKDI6Nk7A7yOdyTI2PsHI6DiN9TX4PB6CQT9T8ThnznbzgxdeZVXHUtatWcm61SsYHBzlTOd5BFHkfDrNmlXL8XrcqKrK2XPduFwuMtkcvX0DvPr6WziddgrFIkG/H4dD5aYbruPIsdOASTqdxefzMDg8yrmubnr7Bksq004M02RyYop4IoWmWd1q5WsUF6AqHMI0DHL5PKIkEkukWdGxlFwuR9eFHrq6e1DyBYwFymaCYJnPXuzp5/TZ81Y2pgRRfI9zVG7vl0Sh8rqqGfh8NpwOJ7U1UQzdoG9olEOHjmOz21nR0crg8OiMHf2SlkZeff0tCqVM0XWbN9DT2z9HsqBQUCo6UNlslqKmsWnDakKBAILUzJmzF2ior0OUJFavXGaRh7M5TNMqu8mSVLmPBEHA5/MyODyKWtRwOe1UhUPEk2lEERw2Oz6vp9JRmEylCAX9KEqBtWtW4HY6yWQtHs4re/cjCiLZbB7d0CsyB5lcjs5zXaXKuIGqahiGQTKVprmxHlXTkGWZfW8eZPeunTOe53t27+LAwcMV3pVpmoxPTPD8iwPEEglEUaalsY6GumjFmDgcClhdkKpGPJGcsyGdvVl5v5uXRDLFxOTUFQUhr5ZmMZ98QDAQKF37q3/2LxcIXqnxY3Ft+miwYIDk93n4jX/12Y9zLD+W+HHjtfykYb4Hu8wrWKj09OMgg/9+HK/nC6iu5lzKE32hUKAqEqYqEqFYLDI4PIrDYcdus6GJIqfOnmfzhrUL7kIVpcAre/fjdDqZiiWoioRIpdJUR8OYWC3lRVVFQEC2WU7zdrvlZO73eUilU3Qsa8U0Lc5EIpGs6FcZpolhGPRc6sPldpFMpwiHGhkbnyQcCjI+MUk4GMDhsLSa7HY7y5e1WZYjmkY0GkHJKyX16az1naXWflkU0E0oFlX8Xjfj41MU1SK+UqbI7/Nyrusix06e4eDhE9aiI4qwAB9QlmQKxQKZTAYEccYCZRiWjEAw4EPTdQqKgm4YmIb5Xgu+aFG7x8enqIqEcDqd3HzjNgIB3wxxUouTZaM6Eqa1uQHDhFtu3IaiFIhWRRgYHJkxLk3TCQf92G12/H4Pg8NjeD1W80vQ76e1uZHlHa0sW9paaTsHS49o9207OX7qLOFggEt9AwgIJJOpUsZIIJtTKiK/61YtxzANLvUOUlMdIZPN43E7sck2znVdZCqWxOU6w889+jMlvz07hmlQVItQkhbQDAO7blJUVR595AF6+4fIZDNkczmCAR+SKKKaWPeQzT5vKWy6DVAuryAIAi6XiypRJBZPMjo+xV2338iK5e34vV4cDjs337h9hifdQs/WbAmMq21v37vvrTmSI2ULn9m4WprFfBshm03mlpu2f6j8qcUN+8ePBQOkG7dv4vDxM2zZsPrjHM8i/gVi9oM9X+lJVbVKt8ePw0RwreWxhQKqL3zmocrCMV832/SJX9M04okUrS2NJQ0gCVGwshuCYSBLkuVmL0kMDY/NMLAtj81us6PrOrlcnmwuT7FoWYysXNGI0+HA5/VwoacXh92GrmkYpoGiFBgZn2RsIsbWTWsrGjzpdI6h4VHcbsspfuWKZfT1DaGpGibgdrvJKQrdFy8xPhnDMEySyRRgiU2eO38RzdBoaWxEVTWS6TQul5OpqTiSLKFqKrJskYJ1XSenKYyMW2Uop8NBOmOV/NwlZejJKR0BKBbUyzZLGIaBqpa1mGZ+ThRFHHY70UiYnKIwmlfQNH1G91E8nmTNyg6aGutobqxlzcplFRHF8n2g6zrNjfV89RvfKXnJ6bS1WmVkVdNZu6pjToAE0N8/RLQmyk03Xodeul5OpxPTNFmzuoMH7t1tLapZ6/4rL6qrVy7jd37ry7zwyl4M00QSBbp7+kG0ZAUcdjt5RaGpsZ5oVZiammqGhsfJ5RWymRzhSBClUGBJcxP9g0MsaWrgm098j+rqKhLJFMlEmkwmS15RkESJpqZ6WpsbueH6LRWj2Y5lbSiFIiOjkwiCSENdDWtWL8dmk+cthU1/jkdGJzh6/AxVkSCqqllGu5NTPPLQ/bS3tVz2WZ/9bBWLxQov6lr0ixLJFI99+6kZJbPHvv0UmzasmTeTdLU0i4U2de1tLSxtbf5Q57HFDfvHiwUDpNcPHOZr3/o+bpez9IpVHX7lqb/7eEa2iH9RmO/BLu+4RsfG5+32+FFOBFdbHpue/YGF5Qzm62ZrrK+dE1QlkiniiRQtTQ1cuNhLc1MDqVSaqkiIXD7PiuXtfOX/fYNzXZcQBJOO9jY+/fB9lfKkzSazYvlSDh09gb3U7r16ZQej4xPccuM2LvUNYJNtdHZdxOFwsP/Au7idTpLpDF6vawa/wuNx8/CDdxPw+7jlpu388LU3iScTuF0u6mqiCKJlKZLL5lCLKn39Q5QJi9GqKhKpFOFQAJ/Pw3Wb17P/rXcQBUuQUFEKTEzFrQzTNIsLEQGHy0koFKAqFGRsYgqH3Y5SKOL3+xEEkO1W5kZVtXnLbJIoAgIIJpjl3kkLhmFQUx0ll8+TzeZxu5ykNK3y+8qSpe598VI/qXSaVDpL14UeggEvzU0NbFy/Gq/HQ9/AMP/vnx4nFk+iGwa10Sg2m8wdt95AXW0NuXyeF17ZN2dsBmCXbTTW1SCUrrGhGxXB0va2Fhrqa+YtAa1eucz6fxOKqsbg8BiBgM8q5Zmgaioel5NMLofSN0A2l2NJ8zLcrjQ2m42BoWH6B4dIpbMMjowBJt95+jnsNplMPkdrSxPjE5OlLkiBFR1t3H7LjRWj2TK/5uiJMzidDqoiYRx2+2UzI+XnXpIkBMF6lpxOi5BvYlJVFZoxN8xXNpu9WSkUVUxToFBUS+ryV9fePjE5hWm+V061lNyFy/q7Xe1mrb2thapIaM7vthjQ/GRjwQDpf/7Bb3+c41jETxGm77hUVePQ0ZNX1e3xoxpjGbMXgvmyP9N3udkSx2O+HfCzL+zhwfvuqPxtmcBeFQlz7527cDrt3H/P7Tz9zItcvDQApknrkmbePXKckdEJqqOWVszg0Agv79lP4xceqYz52Rf2sLR1CfF4kvq6aoLBAGtWdfDoI5/A5/Py13/7GCOj4/QODFFXHcXjcXPbLTvY+/pbJFPpitfbkuY6HHZLg8oq9b3XpVNbHaV/cBgBCIUCeL0evG43PX2DREIBEqmUZTOiqixta6apsY7bb7mR7ddtZGxigjcOHOb5l/YyMjYBWEGMzS5jGCaFQhEBsDscZS1JnA47U7E4Pq+XgaGROcaq06HpOja7Ha/XQyqVnaODNDk1RSgYoLGpDpso09PXX+pys8Q1vW43ToeDQlFl/5sHrZb90TH6h0YZGBph1807+M7TzxFPpggE/ORzebp6LjEwPIzL6eBnHryXG7ZvnndshmHg93uJxZM88tB9cxbfK/HexiYmOXLiNE67g8nJKaqqItTXVlNfV83Y+CQ2m43RsQmKRRW7zcaZzgvYZBlJlpAlmcmpGJqmY5MlNMPg1OnzXLd5He1tLciSTCxRw8DgMNGqCD6fj7xi8bfKQUgsnmRicorVK5dbNjXbt1xVaSsY8PPFRx/msW8/RTqdY2Jqius2r+eZ5/dUznGhc5+9WbFsWkwcdlvldbgyT9HqxrRKxeUMkiCYV/R3u5ogZ9GW6l8mFgyQ6mqsxarsWdXUUFt5SBaxiA+K8s5sYGgYgJrq91qF4cdD7Oxyu8f5SmqJZIrxiSkSyRRd3T10tLfxnaefZ1OpTG1lyyYqbdyqpjM2PlEx8SxrRJV94WqiVUSrIhVBwrxS4IevvoHP7532LJaCsdL1am9r4Uuf/xQIEAoGMU1rIYknUrhdbgxdp7mpgZamBlKZLOl0llQ2y+GjJ2lptuxH+vqGyBcLpNNZ/ulb3yUU9BNPpOhob61kEcYmJrnlpu389//1FURRIpezutKKqkowGMDv81EoFhBFkbrqKKZpMjkVY+++A7hdbpoaavnVX/o83/j2d+nq6YMSn6WoWp1m2ZxCNpulqaGOttZmYvFkyXtqPRcv9VEoqPNqG9lsMnabDafDTnNjPT19AyRT6RmfKaoqU7EYuVweQbTKu5IoIYoCNpsTn8+LLEn0DQxVjiEIAplMlvraaqqrwrzx1uEKLyuWSGLoBslkhouXBvnTP/9bPvmJOwn4LIHIMkRRpLoqwo5tG/nS5z+F0+GYQzqefU+9vGc/rvt2EwkHuXipn7/4ytcQRYmunkvWf7sv4XY5SaQybNm4hp5LfciSDdklMzIyjt1ho6NjKdlMhtGJKTLZHOFgEFEUqQmHSKRSIFoE7cmpOGPjk5hAc6ODxvoa3j18gqKqIcsZZEnkTGcXLpeLpobailbR0tbmBUnT01/bdfMOVq1cxlcfe6LSHVneEFVFQpfl/M3erHzx0YctDtKsUuTlMD1Im85Ber/ebmW8H77iIn4ysGCA1DcwzO/91z8nl7PIdW6Xkz/5g9+iubHu4xzfIv4Fw+l00NRQj80m/1h0rc2HhXaP83GUqiJhbr/lRn7wwisz+BHvHj6BaVqGvWfPXcDlcpbauMO8e/h4xcSzrLVy9nw3r772Jrlcngs9vWzfugm/zwuAbJNQ1enBgaVZNP16BQP+iiUEwPDIGIIAz7+8t5LpaqyvIRa3ymWaruN2uxgbn2DDutW0LWniyLHTeL0ehoZHqYqE6eruoW1JE7YSsdtus9N5/iJtS5qYnIqXupRiVIWsoEw3dBrqaygUVaZiCZLpQU6fOW+1wQsC0WiECxcvoRRV7HaH1Zqu6+i6Za7b0lRPJBzk5z73KW69aTsDQ8PkFIVDh09gGCZOp4N8ybbDuv6Wxpau6wh2O/X1tQSDfqSBuZu6QqGILktEImESiZSl4i0KmCYVpWq5dE++B+vfmWwOv9+P3W4jGg4RS6QoFFUreKqvwetxoWoaR46eorY2itvtIpXJYhoGpmkSiYS449adTE7F52QcQkH/jHtqbHySQ0dPUCxanoFl2YGw00lsKo7T7sDv99Ha0oDd7mD5sqW8/uZBlrUtIZvLYQKpVIax8XGaG+tZtmwJ5873YJgGdpsNQRCprYmyc8d1nDx1jlw+j6brVIWDiJJFbo8nUuTzCkePn0EtEfZ33XJ9xfak/CzMV0IG5j3HaFWkYltVPtcrGU7Pt1nZsW3zNfN7dt28g00b1lxVF9vV4lr5iov4ycGCAdL/+crX+Vdf/BS33LgVgNcPHOJ//fVj/OWfzPVpW8Qi3i9+XLrWrhULcZSsUpSdQlGtCOfJssym9Wt44613yWTzmEDHslZSmRwOh4Otm9Zjs8k4HXbOd1/iD//4z8jkcpgGlpu8SUVdeOXydjRN4/yFXnRDY2VHO3fePtdst7ygxOJxvv/cD2f4NSWSKYZHxgC41NtPIOCn83w3y5ctRRJFy6pCkkocDRAFS0AxrxSwlaQaLAd3F9dv28Sp0+cI+L0MDo0QiUSoq6mifekSaqIRxienuPuOm3nmxb1UVYXxeT2omsabbx8i6PNZ3BTTtMQNBQERgepImF07r2dJSyMDg1aGsVjUOHr0FH0Dg6iahtv9np3JdDjslk5QQ311ZeGczkEqQ0DA0A00TadQKOD1uPH7fRgVY12B8Ympyt+Wg9fly5fidjlZtaIdVdU413WRVCqDHPJjk2UuXupDKRSIRMJsXLeGNw8eoiocRNcNGhvquOuOm2lf2lLx3ZuecfjEvbeTzeYqWjflbE1tTZS8UqC3bwi324WqqoiiaP1GukG0KkI+X0AwDfxeL9lcjqlYAkmSCAR81NVUlwLVJF6fh2Qihc/nJRTws6SlkY72VnbdfD2arvH2u8eIVoXRVN3iX5XMXFevXEY6k+HV199CLRTJlXSrwNILml1C/t6zL2Gz2Wmoq5lxjo88dO+8z83VGE7P3qxcC79neiYrGPB/KIFRGT9O0iSL+HCxYIAUi6cqwRHALTds5Wvf/N7HMqhF/HThx6Fr7Vo1VRYK7BLJFO8eOY7dbnWTrV29HI/bzZpVHbQvbYFvPgkmXLhwCU3T6B8cskpJjfVWhunsBdKZLIGAHwGIJZL09g0yODRCIODnkYfuo1Ao8vzLryFgYnfYSSRS8/q8AWRz+dLibu1q8/k8k7EENkkilcpQXR2lsb6OcMjP5FQcURIr3A6Lo2ERiVd0tJLPKxVhxbI/VCgYIHLTdvJKgXQ6w9bNazl+spN4IsUPX3uTxvo6nnj6OVRNryweuqaj6wbjUzECfi+5vEJxwgooRUFA03VOnT1P65ImAGLxuFXKaWvh+OlOy8MrlpxxnpIoIcsSoWCAcChAIpG2PMu8Pmy2OKo2y25EMFEUBafTTiptae9ksjmqqyIkEilCIcs9vlgsVojgoVCQJU2NxBPv8YdGRsd4+53j/NlXvoqm6cSTKYJ+HwfePsS/+41fJhoNc/bcBex2O2tWdnDvnbsqHXjTMw4TkzEef/IZcnmFF155jUgkxORUnB3Xb65ka0RRoq21mZ5L/SjFApqqUR2NoBsGhmGZ3zbU1eLxONE0y+dtKpbgTOcFUpksd99+E5s2rObI0VOoRZ3Vq6zxRMJBEskUg0MjSKUyWijgJ5lKzTBzHRoZ51LfEP2Dw8iyzHWb1/Mrv/i5GedTLiHHE0kw4Ybrt1Rc6cHK8C1klXPD9i288up+7HZ7pVnjw5gLPmp+0I96k/dBxGwXcXksGCA5nQ46u3pY2dEGQGdXDw6H/WMb2CJ+uvCj7PZ4vxPo7MAO4Ktf/w411VEOHT2BIIhcuNjLf/h3v1Y5v927dvKnf/63uFwuJFnmtpt3cPzUWcvao1ikrbWJyUS84qXmdrnwVbu5585bWNq6BICvP/40rS2WBtGZzi6OHDvD9q3r2X3bzsp4Rscmef2Ng2RzOU6e7mT71o1MTMXZ/+Y7DA6NItkkbLKNopZAKSiscS5n5fJ2bti2haMnTtNYX1vhUWWyuXkJxdN1bgDuvWsX7W0trFrRwf/6y79H1wwOHTuJoRtksnl2334jsVgSTdMolFrORUlgcHgcURRxORx4PNZ3D42MMRVLoqpFFEVFVTV6+wepioRIptIl3tZ7KBvjOhwOq7SUybB8WSt2xzCrV3ZwurML0zQxDBOvx41SUEhncwiCiCSKRMJWGzxATsljz9nwuF143C4SqQx+n5f21haWNDdwy03b0XWdi5f6eeoHL3Di1Dk03WB0fIK6migut4twMEBPbx+/9sufZ3IyjsftpK62BoCpWAJV1SoZh2KxWMnUxOJJNF3nnUPHEUWRw0dOYpNkaqqrWNHRis/jYf2aldhsEsMj45jAWwePEgr6SaQytLQ04PN6yOeKxGIJ6uuipFJZJFHgtTcOcvpsFy6XE6VQpLammva2lor6tgn4fT48LhfV0QhfePQhnnl+j6V0ns/z5lvvEgz4WNLSiGkYDAwN4/W+J4g6vYRcVi2f7kqvqhqKUpzX8La7p48DBw9XLG5uuWn7BwpiykHD7OzWR8UP+lFt8hbJ4R8tFgyQfuOXH+Xf/8H/pqnB4hwNDo/xJ//lNz+2gS1iER8HPijBcnpgd/jYSd5+9ygjY+M4bHaqq6M4HDbOdXVz603bcTod83oqRasi7L7tRqJVEb71xA/o7R9kYiqOLFl8o+3XbWRp6xKcTstYFqzOt7PnLljGtoKA0+nkiaeeIxT0Y5qwd98BnE4nfp8P04RXXt3PVNzSy3E47LicDiamYqxY1kZOKbB+9QpsdhvtS1sIh4LklRyRSBibLM+Y8Kdfk8b6Wu69cxfFYgG73VEhl+dyOXr7hkikUvi9XkwsEchznT1s2rQGu03ivrtv4+vf+i6xeBLT1LHJNnxeLzU1VUxMxsjm8uw/8A7r167kpT2vMzA4zPDoGH6fl0goMCdAsq6JTjKZpLWlkS2b1vGZn7mPr33zuxw/eQaw1NztNhvRaIT+gWH8Pje6bmAYVtAiyxLDo2MYhkGhUMTjcTM5aVmhLGlpoK42yle//gTdPX3IsswPX3uDyakYQX8ATVOxyRI2m432thZrLKkMjz/5TCWAmC5umEylSCRTRKvCZLM5OtrbEASBU2fOkUymCQYDVFdFGBwa4eChY1x/3aZKkBqLxxEEuGHbFjLZPHtee5PhkTGqq6rIZXP4vG7uuetmzv91N30Dw5aFh6mTzVkl3UDAh81m47kX93DnbTeh6/q8dkA2Wa5kRiYmpognM3hcDs52dpFKZ7DZ7Hz1sSf49MP3V7onyyXktWtWAFRc6S2hSIsHBzMX8vmewenk72vF9KAhm8uRyymEQ9a9+VHyg34UNkiL5PCPFgsGSGtXLePx//ennO7sBmDNynZ8Xs/HNrBFLOLjwIdFsFSUAu8ePlHqorKCkInJSZoa67Hb7JXvm89TyWaTaWqox+l0sHL5UvbuextFUTAMk21b1vPZRx6ojKW82OaVAqZpZU4KhQJmySdqx7Yt5HJ5puIJXE4nNdVVeDwWUTgQ8FNfE2VsYpJ0OotpQv/QGG63i2w+z5YV7fzFV/6RM53nMUyRdauX8egjDxIJh+acb3kRmpiMVTJN0aowu27egSiI5PPW+BEEBNPEEEwQwTQN7HYXVeEQq1Z2WLylcIgTp89RKBZQNY1l7a0UCgr33HlrpdOpf3DYUoqWLf0jURTmWHmYQDKd4fyFHv7Vzz9KLl9AlmWGhkdLGQwVwzAYHh4lFPDhcDgQBAFd10mm04iihMftoioSQhBF0qk0Xp8XPZ1FMOHYybMUlAKiKGGTZHouDaAUCvi8PmqjVVzo6aVQkndYs3o5R4+dYueO6yoBx//96re4785b8Xg8hIIBJianuO+uW3G73Xzn6efJKwVUVavch5aKt4PmpnoevG83DfVWBsrhcFjBnt0O2TyDwyNk8wojY2MUigWOHD/DnbffxFQ8AaaJzWFDUQx03SAWj5PL5amrieL1eJiYnKKpod66fqVS4nQOTSQcorG+lv1vHuQbT3yfYkEhHk9id9gxzSyCILJ331ts2rAGp8tBXU2E9WtXVRoUtm9dz9133MyLP9w3gwc3fSH/MEnOs4MGr8fNy6/up7WlcYY6+b8EftAiOfyjx5wASSv56wD4vB6u37r+Yx/UIhbxceHDIlhmczlkWWb9mlX0D+zBMAzyBYXmpvqK0jBcnq+gKAW6e/p4+IE7yeZyGAboukZj/Xuu3uW/f3nPfsYnJognU9TVVvPmwSOMjk1y9PgpFKXIxFSMkN/y3iqqKpOTMctOoqiiqTqGaSDJInXVETxeN59++D7+8Zvf5YevvkE2lwcBhkaGMYHf/a0vV86xfB57972F1+Pm+MmzVEXCDA6P0trSyLee+L5lfaHkS8FPEEmWQTcJhwJ43W7Onb/IwXePIUkSS1oaGR4ZY+P61fQPDLJ+zUoaG2ooFrWKD1y5HLRzx3WMjU/gcDgYn4wxl3oNum6QSmf42699G1GAjevXlvR8iiSSKSRJRC2qFFUVWbaxfu0KXE4nPZf6CYUCTMbi2Gw2kqk04XDI4nAZJolUGgEBQRTI5fIliw6ZYlElNhWnsbGOutpqqsJh1q1ZyeTkFJmswg9fO8Dg0AiGaZJMW3IDN9+wjdqaKLIs43A4CAb8ld+0qBYpFIu0tTZbRGxRJBwMVLJzs+9ZTVVJpTMICEzG4mQyGTTNIJVK43a5SKYySLqBUfKdczocVEcjqJrG2MQEPp+30iVWbn83DI2fefCeGdf1zPlu6utq6Dx3AVXTUXWN+toaunt6eeXV/fynP/o/pU5Ck9UrT/KZn/kEqqqxbcsGHA47siwvuJB/mCTn+XzROtrbGBuftLKtLMwP+knj8iySwz96zAmQ/uMf/xX/8w9+mx13fZ7pskflLo4DL37j4xzfIhbxkeLDIliWJ6WG+hqu37aZ1/e/jappnDnbxY6f+9kFLRjmUwwuqwMrhSK5nDZnR9je1kLVpx9gZHSM8YkpJFmmUCiQSKRwLl9qWWcYMDA0iiiKqLpG25Jm2pY08/qbBytt3ktallBXU01NTTWTUzE6Oy+QndadlMsrnDlzgSMnTnHm7IXK8cu6ToWiiqbpFIuW9celviGef3kvdrvdyoQIAkMjY0RCIQzTwO1xcezkGUKhID7Di6IoHHj7EO3trURCAXweF40NNXz+Mxb3ZXRsnFNnzlNULbuUz376k1zq7SceTzI+Ocml3gGKheKcMKlYLDI8MoYoCTg6z1EoFjF0AyWvVD4rSRIIeQYGR1jS0khtbRSfz0tzcwNvvnWIVDpDPJEkEgkRT6TI5RVEQWBJc2Pp70V8Pi+6blAoqsRicaoiEX7v336Z5sY6/u9Xv00ymSQWT5LNZXE5XdhlG6lUmlNnzhEOBWbcN+1tLTR+4RG2bV3PD57/IRcu9pLPFVi9sp3dt83sUpx+z2ZyOUREkuk0kiRSKBbxuNyMjk/icjpwuVwYuk7OppDN5rCXLElMw2Dblg3YZLkSmN95204Ghka52NPL08+8wvDIGLtv20ko6EcQRDRNo6a6ikwmBwLohkk8nuTU2S7cbheSKKJrOqfPXiDg9zIVS3D0xGnePTJTRHX2Qv5hkpznCxqiVWEeeehedF1fMPj5SeTy/KjJ4T8NmBMg/e5v/DzAoqXIIn5q8GEQLKdndjrPdSFJIpFIFLfLydvvHmPHts1XbFEuT+6jY+OcPdeNUSLH3nLT9jllLr0k+Lh6ZYfl/6VqJFNpEokkg8OjVFeFKQR8VEerGBkbZ8vmdTTV11FfX8MLL7/Gzhuvw9BNLvb0MjBoqXGns1mrJFY6hmCCbuocePsorS2NlQWnrOuUzea42NuHzWajoBQZGR0nFk/h93kRBMjl8oRDAW6+aStvvn2EV/a8gSSKhEMBamqi1NfV8tY7xxgZm0QQBdrbWmjONTA1FWPZ0lb+4v9+zVK4FqzW/zffPsy//vIXMHQdSZb4wfM/JJuzMlXlcpskikiSFTDm8gUKisrk1BSpdHbG9dM0DROTVDpDoVgknc4STyQZn4wzOTlFdTSCx+0mX8izfu1KREnk5hu2YbPLPPvCHjChuZQ1SibSON1OVnUs5eCh48QSCS719tPYWMdkLIGJQDaXY92alaQyGRKpDGPjk9x/z+1z7olgIEBdTXWJuyVw7523VojU0+/P8j07MjrGvjffhcFhJEkklUoj22RsskxjY32lhGlOxfB6PNRUV6FrGqYJ0dI5Ts+69PUP4vf7kHJ5nE5npTXfNAwa6mpJpzO4PS4ymSxej4uxiYlpFiDF0r2p8fh3n+ORT95TKWuVRVRtNmvJmb2Qf1gk54WChsu19SeSKZ59YQ811VXX5O3244Afhw7gf8mYEyCVdzYv7z3Aw/ffMeO9bz35PJ/91L0fz8gWsYiPER8GwbK9rQXxjlt4+Yf7cDktnZ7h0XESyRSxeJz6utoZn5+96DmdDm7YvqXS5SYIAls2rZuXsOpxu1FVjbxSwOV04LDb8HrcXLd5vaV/4/eRy1mL+9vvHiXg8zE6NsGZzi7sdhtHj5+hWCgQjVZx3ZaVhIMBDh09idPhIJdXMDHxut10LF2Cx+2aUR4xTWhb0sS3vvN9aqujjI5N4HQ5OHf+IoqiIIkCbrcTURTJ5fIMDk9YrduyRF4p0D9oWYWMjU1g6Dp2jwsRuNDdS09PH8dPnAVBoKd3kGVLW/F5XIxNTLLvwDsEA142b1hLJpND1w1yuTx2m4yqGRbfxibjdjkxEVCLBSbyecx5SnFFVcMhCjgcNm68fgtnznYxNjFFLpvFZpNJJFIYJsRiMVLJDC1NDQyNjLJ6xTJuvnEbalFFttno6u7BMHTSqTTnui5y6OgJHA4nyWSK5cvaqKuJMjE5hWGY1NVEqa4Ks6x9CV/6/KfmLNpl/kzZ96xMVgZmuMLfsH1LxfHe7/dx3eZ15PM5REnCbreTTKbp7R+ktjrKLTdtp7YmSjab5/jJMyiFIoIgEK0KUfLfrQTmqXQWRSkgyhKFQgFZEtE0KxjffdtOjp86y/JlbYyMTrB8WRuyJPHJT9zJr/+bP0AtFBElEU3XMQyTvv5B9u57iw3rVlNbE62IqOqGtqBA45WewastgV1L0NDd08ezL+7h2MlOvB4Xq1Yso7YmCvzkcHkW/d4+OixI0n7mpddnBEiFYpGnnt2zGCAt4qcKV5qU53s/lkxRFQ4iiCKmYTA2EUNRZnqHLZTSL3e52Ww2BEy8Xg/pTHbOZD04PEoyleKdwycqprVffPRhOs9fRNd18kqBtWtWEK2KsHJ5O1PxBEeOncTn9XLrzuuxyTZe3/82O67biLu0QG5Yu4rmpqSlhyNKrF61jPvvvp19bxykWCxit9srxsLZkj3KujUruHXnDt586x1SyVTFdiOVzmIYBl5vAEwDASu4kiSRYrEsgGkpbqeSKTTNIJvLIkkSumGgajqppJUR83hcNNXXYbfZcDndPPbtp7h15w4uXLxEJptDttlxOkVUTUOWJHRdR1EUBFGioaaaTCZDNptjtjNJoaAST6S5eKkfBIFYLAFY1iOGYZAaHMZml8nmFJoa6zh89CSfvO8OvvCZh1AKBf7xm0+y47otfO+5l/B5PfQNDNHYUEcmk6OmJkrvwCA10Sqy2RyqppHOZFi5fBmfvP+ueQOEWDxONpvD5/VYv79gjeWVvftprK9DEAQGhob5oz/9S7Zv3YRNltmwbhVVkTD3330Hx0+doV8bxu1ycMeum1jS3EgimeLB++7ANAW+/9wrJJJpLnRfxO6wc/FSP6c7z7Nlo+XF9rVvPMm5C5dQlDztbS28/e4xGhvq8LjdrF65jN/5rS/zyt79CIKIaRrs3mUJSL70yuv84IVXQdfQdYNIOIiqafT2D6EUityz+xYmJmO8tOf1Cr91oRLWQs/btZbAriZoKAekNVGrkcHlcnL23IU55c9F/PRiToD00Bd+G0GAyakED3/xPcPaTDbPnbt2fKyDW8QifpS40qQ83/tW51iEXE6p2MjXVEdmaIhdrj3X43ZXRPum+7NNn6zLf79saSutLU3klQKKorBj22Z2bNvMtq3reffwCWRZJp5Isn3rRg4fO42AJcSICS6nHQPIK0XcbjejY+P09Pazcf0aIqEgHR2t1NdUs++Ng6TSGY6fOkvrkmYu9fazZdM6qsIhenr76e0bIBQM4HS5aGluwMQqvamqTnNTHS6nC90wmJyKE41GiMXiJT0cBcG0hCxtss1ydzctccpiUSOXy2FiKXYXVRUEgQ1rVuKwy5imQLGoks5kyecVJFHE0E1ssozDYaelyVKH7h8cplBSfZ5XTVuw+ErvHjrO0rZmRNEK4Gw2mXxeQTd0BE0sdbe50Q2TAwePsH3rpgqfpfy9umHlqQzDRJAENm9Yy7muC6xYtpTtWzeyZdM6WlsaCIdCC3JgXnl1P8dOduJxX2L1yg5qqqsqgakgCAwOjfDcS3vRdYPX9h3E5bLzzuETtDTXYxgmy5e1USyqbNuykcYGK1tZJoKX75++/gG8Xi+yTUYUJd49fIL2tiV09/Rxx603UCyqxOMJ4vEk4VBwBg919cplLG1tnhPAfOXP/hvNTY30Dw7Ref4iNdEIyZTFiertH6KvfxBBYMEutis9bx9VO/t0zt/qlcs403mBbDZfKX8CTMXii6Wrn2LMCZCe/vqfAfDoL/0u//u//fvK6+GQH4d9UShyET8duNKkvND7jzx0L5s3rKG3bxBN15FLnVrTu5Au157rcbsron1lf7HZHtHT/95ms2Gz2dA0jVg8jsPhYM3K5axZubwilPedp5+nsb6GS30DuF1ODh46htvlRNNU3njrXdqXLqkEPpNTcV7f/xZP/eAF8kqRlcvbaairYcPaVeTyeTauX0NdTTUAa1Z18PY7xxgeGSWTyXD9ts1ct3kjR0+cpqAU2HH9Zm6/5UZGx8b5q7//OrFYgmRJdDEY9JPPKSUVZgHTtLqsMMEwDcvyQ5ZxOh2YhgmmyZrVHXg8bgTBRC0WyecVgn4/uqlTX1tNJpvnpuu38Es/9xnC4QBf+X/f4EznBabiCQRRglm2JJIoYZSCt3Vrl+P1elGUIrJNJloVYWh4DK/HRTKTwzBNREHA4/HM6ObzeNxWGW0ihl6SXIiEAjTWVxMK+rj7jpsrGlELLbLTS2vXbVnH6bNdHDp6gus2b6golheLRU6eOYem6iRSKeLxBIIo0tRQhySJaJrKquXtrFi+tCIHMJ0M7XQ6aKir4fHvPovdYUMAbtyxFVmWKz5ohgk2mw1JltELBXJ5BVWd2SQwX2bG6XTwuZ99kKefeYmui70Uiirt7Uvwut2Mjk2w+/adHDl2+rLt6OVr4PW4KRRVHHZb5Xn7qNrZpxO6a6ujhIMBxiYm+dLnPsXkVJyvP/505bM/CaTtRXz4WLDE9o2//R9IkvhxjmURi/ixwZUm5YXe13WdRx66j1de3U+hYJmMzu5CKvOHUukMLqejUnYoE2bnE+2bvhjM16kzMRnj+8/9cE4JoywsWd4lnzx9jt7+IZYtbeHWndcTDga41DfAxvVrCPi8fO0bT5JIJMnnFQRRpPN8N81N9Vy42EvHsraK6apQit5EETxuF8va20ilMkSrwmzfuoHrtqxnzcrlOJ0OlrY2c/5CD4pS5MA7h8lmcuQVBVmWcDldOBw2CgWrvV1AQC2qGIaO2+Vh6ZJmCkUVQ9ewyTYy2RxffPRhDh87RTKdJV8oIAkCo+OTiKLETTdcR31dNU6no/I7rF7Zwf43D9I/ZJUl8zkFSbb4Orph+cD19w9TXV1NLB4nGPBTU13FxnWreP3Nd3A6HGSyWW6+YRtul7MScJTJwKuWL+Oc0E1NdRU9vf0EDB9797/N7bfeyA9fO1D53RdaZKffS7XVUfxeDwODI9x9xy20tTbhcNh59oU95PMKsXicqqoImUzWUvPu6aOpsQ5FAZ/Pz+j4OEMjY7hdzsoxywH98OgYq5YvrVh5jI9NUh2JVHzQRAFGx8fBhGQqjdPpYM/ro9x/z+3zamFNR3tbC7/8pc+QSqWtzkpJJpPNsbSthYb6Wo4cO33ZdvRsLsfEZIzjJ89WNgUNs1TqP+x29vkI3ffffTtOh2NRgHERwGUCpEQyxRPfe4nB4bGKFxHAn/yX3/o4xrWIRfxIcaVJ+XLvR8IhqiIPzHEML/MrRscm5/CHPv3wfTMmX1mW8ZWMYacfD+ZO7KqqLVjCmL1Ltm+QSacz3HLT9XjcVjt/MBCgWCxy5lw3I6NjyJJsZXCAdCZLKpXG5XJhGkYlo6GqGgcPHWPN6hU0NtRVMhH33XXrjDJSIpliYnKK7ddt4u13juL1uImEgjQ21HLiZCeTUzHsDjuGaaIbBpIk0dxUTzqdxeezxt7SVE/HsjY+9+kHKt+tGwbf+OensckigigCJgImXd2XGBwaqQQjjfWPkM3leODeO/jnp57h5R/uZ2IqjqqqqJqGJIo0NtSh6wY9vb3cctP1DA1bXXFrV6/g7t23cvrsOTweD26Xc0bAEQr6K+3jqqbx+JPPcNstN2CaJqIAe157kztv23nFzqjpv1HZPiabU3hpz+vsvm0n7W0tfOnznyKXt3hf8USCuKqhGzpOl5OuC71klRyXegcJhwNs27KRG6/fXAlQ4T2drnVrV3Km8wJ6oUg2p7Bty4aKDtOzL+xBEiW6unvwuN1MTsVpaWpg35sHWbW8/YrBQTDg5+c+9yleeXU/wyNj9A0M4XI6eeb5PTNUxGFuF5skWcetioQRRRGjJHwqSdJH2s4+H6G7vKlYFGBcxIIB0n/647+ipbmeweExHnnwTjovXCIcDHycY1vEIn5kuNKkfLn35+NSALy8Z/8Mb7S779hZ4Q+VxSCnywWU+Sd33r5zzsQ8fWJXlCLPv7x33gk9Eg7NDKY0y0C3nGEoK3lfv20Tf/Df/8wqZ0kCNklCkEAr6hVbj90lV/eG+hpe2/8Wum7Q1zdEf/8Qq1Ysw2634XC8V4LZu+8tvvaN76BqBjZZ5LOf/iTbtq7n+Zdf48SpTvoGh9F0nXwyjcftor6mmuqaKrZt3sCum69n/4FD6JqKbJO5Z/euShfgiz/cx3/9k7+kWFDJ5BQcdhldN6ivqyabzeH3eXl5z34av/BIZSy1NVX82i9/geu3bWLva2/TeeEiXRd6qKuJUlUV5lzXRdKZLPr+t1nS0khLUwM337iN5qZ6hsemePCeXYSC/gV/31DQj8ftxlsSI0xnsmiawVQ8ScDnQTfMOeWq2ffay3v2c+joCVwuF9dtWUe0KlIJqoIBPw/edydd3ZdoaqzHX9JgOnv+AgQDOG12/H4viUSK6miEo8fPsGbl8soxykFYTbSKSChYue/WrOqo3E8PPXAXe/e/zdIlzbjcLkRBIJO11LKvNjhob2vB672Lrz72BLffcgMejwfTNOnu6busFpGu63S0tzE4PFp5raO9rWKE+1G2s88uGy4KMC6ijAUDpGwuz+/95i/wp3/5j6zoaOOeO27i3/2X//1xjm0Ri/iR4kqT8nzvz8eleHnPfiZjMUZHJygUiwyPjnPw0HHuvfNW/D4vmjZ34dR0jVwuj3iZMnd5YlcUy2R1oQl99jgHh0d57qW9ZDNZPF4P991lLf5rVnZw5uwFFKWAiYle1KmuCrNpw2o+cc9uVq9cRndPH8+/vJcDBw8zPjGFx+MmGPBzprOLNauWV46ZSKb4m7//OtmcJbBomCb/8E+P8zd/9kcEA378fj837WhgfHKKdw4dRxBFHHZ7xVpk2dIl+LxeXtm7H7vNzoGDh3E47Hi9bv7hn/4ZTJOiapXecjmVgN8HwEs/3EfHsiVoms62resJBgJzLFHaWpvYvesG/uHrT1JdHeHEyU4SiTQIVnddz6UB+geHqa2tRhYlvvb4M3zh0/dfkXs2/TdIJJL0Dw5hGDrjk1PUVEexydK8mlbl38h1326KxSK1NVFsNlvlvfK9Mb2TzG6zk8vnqKuNksnk6B8eoaiq1NVWV37/2dyh2QH99NJvd08f33v2JXTDYGxikqpIGJfbRU11FNMwrjo4KLfNn7/Qy9Dw2Iy2eV3XFyzVedxuolVhWlsaK89NJpubkzn9ODI4iwKMiyhjwQDJ4XCgFIpsWr+SV/cfpObhexgaGf84x7aIRfzIcaVJefb783Ep/D4vff1DNDTU4nI5sdvtDI+Okc7kCAWt8lt5IVCUAk889dyMLrZMJse//de/uOA4pmcgsqWOrXvu3LWgMGX/wBBHjp1E03RkWWLd6uVURUIMj4yxdfM6zp3vpqhpaKrGv/7yF/n0w/cTDPgrY+vu6WMylgDg7PkLrFm5HEUpsm3LhsoxBodGGJuIWb5mpUBibCLGxYu9GLqBs+QnFgmHcDocRCIhVq1YhsvlpKu7B1XTOHDwcKW93TRNnnjqOVRN41L/ACOjE4iCQFHVME2TqXgC3TTwuDz09Y9QXR3hwMEj2GSZYMDPsZIlylDJEqV3YJif//yn+Oo3vsPYxCSyLOHzejAMGB4bY9P6NQT8PmyyRDabQSkUkCSJgaFhcnkFm81WMRsGa/EvL6q5vMI7R45zw7YtHDp6ApvNxtj4BPfeteuyJqyRcBCPx13hkc2XuSh3ksXicZRCkRdf2YfX42LfgXfx+7yV4EJV1TlBzUIBf/l37esfRCkUCIdC5PIF2lqbKxpI0z+70IZhdtu8zW7j6InT3HzDdXPOY6F7+L2ysfqRByWXO5dFAcZFwGUCpIfuu42hkTF2Xr+ZJ3/wCt944jk+89DdH+fYFrGInzjMx6Xo6R1AlsXK+00NdXR2XSSRTALmjIUgFo/T1d0zg0/U1d0zr9DkbEzG4pw7340kSZYQosM+hxScSKZ47NtPEQ6HMHQDURJ57NtP0drSSNuSZvoGhti4fjWJZArDMMnlFL7z9PPsunkHbpeDru4ewqEgo+N2HCXPsuUdS3E57JVyjaIULHuPcmdaGQKEw5YRbKGgINkklLyCz+tBFAQ0XSeXV+hobyOdzlh/UioXappGV3cPa1YvJ5vN47DbyOUtUUrdALfbRbGo4nGbSJJgtfAXLIuRQtHSoBJFEdOk8v9bN6+jpbmB3//DPyWTzlJUVaZiCQQE4vEEyWSKaFUYgM7OC5ztusjw6Divvn6A5sZ6An4fq1a0Y7fb8bjdJb2gDva89gayJDM+OUk0GiEaCVMoFggFAqiqumC56mozF4PDo5XPJFMpEskUS1tbKhmyTDa3YHAxX8A//Z5b2trMwOAIuqHT0lTPzzx4L6tXLgOuLHsxvW2+ujrCm28dolBQyecUfulLP3vFIKO9rYWqSGgOd++jwNXoKi0KMC5iwQDp7ttvrPz77/7PfyGVzuL3eT6WQS1iET+pmI9LsXrlMlRNY3IqXhJLlLjj1htnkI7LME0B05zZ1z/fa9OhKAVeeXU/I6PjNJS4TH39gzz9zEv88pc+M2OhmZicIp22slyWlgA4HU7OdfXQ09uPw26noBsV24uyqerefW9x+y03YprW+BsbahkcHEXVdXRNY3fJNqO88KiqRsDnZWx8wvJ2M022b9lQCrpyDI9N0HfoGG63G1mU2LZlI9U1VThsMiBUOqvKJau8UiCdznHmzHm8HjfJVArTNJFlGck00TUDSRJoaqijo721pAYODocdh93K8hiGgSAwI8PS2uKmva2FvfvfZmR4DAQBURSpqY7S1X2JUDDAqo6lHDl5hmgkzPj4JMuXtXGpdwC328Whoyf5nd/6MoPDo7zy6n4OHjqB02HDpJQ5HBiiproKWZIXzOxMx5UyF7NtMULBABOTUzx43x243e7L+o0thOn3l9ftobW5kalYgs9/5iHaljRX7rErdXaVz6tYLDIxPsXaVctJpTPsvGEb3T19c+x2ZuPj8kP7qHSVZh9jMfv0k485AdKxU+cu+wcb1674yAaziEX8pGMhLsUN27ew782DM1r/58sIRcJBVnS0cqlvEF3XkSSJFR2tM3SUZiOby1EoWUgIgkAimaLnUj/pTJZ//OaT3H/37ZWFxufzMjE1RTgUrGS4xiYmOHG6k5UrltFzqR/TNOjtG+LhB9fO4MI4HHZWdLTSPziCLMk0NdRSHY1UgjBFKfDcS3sRRZGg38s9d97K2+8cpWNZK6FAgNtvvZEDBw+zpLmRvv4hljQ3kM8XqKuJ8uq+t5BlERPYvnUjk1PxGdmUXF5BFAWCwQA+n4dQPsj4xBSapgICdknCbnMwNRUnXVtNsVjk3jt34XDYK4vffBkWRSng93mt7sNIuCSsaGdyKo7dbicWT/Af/92XLW2noiVmGQoGENtE1q1ejiCIhII+nnvpNZxOJx6PC4/bRTafJ5dXCAb8jI1PsHbVistmdqZjoczFQrYYZTHI8m9QzuSU740rLdLle+505wXGxicwTQgHA+TzhRnfA5fv7CpnwJ59YQ+ZbB4PsGnDGrweN7Fi8bJE748jaLmWc/kg+Ek0vl3E/JgTIP3Z//0GAKlUBkEU8HmtrNFULEFzQy3/93//5493hItYxMeAhXZ817oTXIhL0d7WMq8K8Xx/v33rRjrPd1c4Qtu3brzssT1uNw6H1UquahqDQyPYbDZ8Pi810aoZC42h66xbvYKz5y4giCIC0NrSzKHDp3A67ZZXFwayJHK2sxuXw0lNdRVgLaTzaTyVM1Qv7dnHUz94sWSTATdev5Ubtm9h92030tRQX1mYCkUVUZLwetwYusng8AhgddO5nC6OnzzDPzz2z/zev/kVvvCZhyqdetlsjr6BIdKZHPm8gt0uoyhFSyxTllG1IgVVpbG+ZkZpqJyRkUo2JNMJ9QNDw7icTjqWttE/OITb5aSoakSrwixf1spnPv0Af/9PT1IV9OH1WCKeRkmOIBwKksnmKtkX17TfyO/1sXHdSrL5PJ/51CewyfIHyiZcjS3G9IV5YjKGIEBVxCoRXm6RdjodPHDvbkvzqrEeu83GmtXLZ/ClrrazqyxJwDefpCb6nvnrfJ+djo86aJmOj7JL7eMM9Bbx0WNOgPT1r/wxAL/7h3/Gf/g3v0TA7wVgeHScf/jG07M/vohF/MRjoR3f+90JLlQmuRpOg6IU6O7p4+47bqlkoK5UnnA6Hey+bSeJZIoTp8+TzuZY0tTAujUrsNvtkM2RzeUqZaB0JkfbkmYaG+torK/jye89x/DIOJIkkc5kiEYitLU2IctSRdG5LDUwXVto+rklkime+sGLeNxuXE4Hpmny5lvvctfuW3G7ZmpHlUteRVVlbGKS8fFJxiYmCYeCGLpJOpdj35vvEAkH+eT9d1XsJqJVYYJ+H+e6LhIJB+kfGMI00wiCQFUkhGlYC97NN20nFPShKIXKNZ997aaXAk+cPodpmjQ21jIwMIqmqRiGwYP33YnP7ebFPQf4+//9n3j70DEa6mvpPH+BluYm4okUd96+s5Ldk2WZ1SuXcfpsF/l8HlXTuf/u26mtjl7xnrkSrsYWo7wwa5rGsRNnMIHWlqZKifRyi3RtTRXbt27C7XZVyOexeKISoFxLZ1cw4Of+u2+3PpvNXfazZXycrfUfZZfaxxnoLeKjx4IcpKHR8UpwBFBfW83F3oGPZVCLWMTHhYV2fFWR0AfaCV4uGLpcVmr6QmgvW/uUApzLHbe9rYV/8+u/yPDIOE898wINdbUzdu+SJM2xs+jtG0AWBRLJDHV11UyVOFKjExPcc9fNdCxtY3Rsggfv212xr1jo3CYmpxAEiaamOgaHLP5VMp1jdHSC51/eC1iLUHlhKlueFAtFYokkuqaTzWSZnJgiGAricjrw+/wzrvmum3fw9DMvYZgmSr5QMp810TSNfF4BQJYl/ubvv4nDLtPS3MSjn/pEJZM0/fpP/223bd3A8y+9RjqTQQDC4SCf/fSDrF65jGxpgW9rbWZZeyunOy0OVJnPVL4e5fOy22ysW718hpL4h4HL2WIEA/4Z4oZKoQhYRHWlUMSJ5Y93OaK/x+3GZpNLWbL5A5Rr6ey61i6w9xO0fBCez0fVpbaoofQvCwsGSFXhIN988jk+/eBdSJLICz98A0n84NYj339hL0/+4BW8Hjd/9Pu/RnU0UnlvcHiMP/yfXyGvFPj8I/dx1203XuabFrGID45yQKJpWsXaA6j4U33YO8Hunr45IpDTs1LTia7lDNL01y8Hp9NBW2sTn7z/rjm797LgXtnOIhIKMjo2wfq1K3l57wG8bjdOuwMTUAsqAa/vvcnd41rwmOVFyufzIggmfq+XlR1LyeXypFJp1q5eXtE22rvvLb7wmYd45KF7+cdvPsmjSz7Ba/veJpPLkc3myOTy6LqOpmvUVEfx+zwzbFbKdhaxWIJ9b75jzUemgCBIFApFQqEAdpsNt9PB0MgYg8Nj9PUP8vv/9ldnBEmzd/lV4RBVkRC33bwdWbYTDvkZGByu6EtNx9HjZ6ivq5kTNH/UbeHzBRD33317pbw5fWG27mET04RkMsW7F3rI5pRKSXS+LOjVBijX0tl1rV1g13INPwyez0fRpbaoofQvCwsGSL//W7/IH/2vv+Nv//FJBAFaWxr5z//2lz/QwWLxJN944lm+9Xd/whsHj/I3X32C/+/3frXy/l/83Tf50qMPsmHNcj735d/nxu2bKsq0i1jERwGP283EZIxjJ85Q1h1qbKib00V1LTtBRSkwMjpGNqfQ2FA7w2pktsZRIpmaoXFUDgQe+/ZTmKaAIJh88dGHP/BCM1tMUpZlPB43q1Yuo7a6ikw2hyAK+H1e8nKByUSSY6fO0tHeVmnzn70AzV6kbr/1Rva89iamKVBUC2zfurHy/E4PMMvX0emwMz4Vs7IXsg3D0Emls0TDITasX4Usy6iqhqIUK+WyYMDPJ+65nTfePkR9XQ1VkRBFVaVQKFJdHUESRE6eOYckSWi6TjQS4oVX9hIM+CulMEUpopb0k8odcrmcQndPP6IozfAB83m9/MLnPonNZiOdmSk9MDto/qjbwi8XQMxemC37FI1jJ8/Mq8w9n4bRdOuUH1X31dWWoX+ceT6LGkr/crBggFRTHeGv//Q/kFcUDN3A8yEEKu8cOUXH0iU4nQ42rF3B/++v/rHynq4bHDx8kj/8nV/B43HT3FjH0ROd7Nyx+Yrfm83mKuJqkizjdFhkU13TKp+x2WzY7bbK+ZRRNm7M5RVM473XHU4HsiRVUuxlOJ1ORFGo2C+U4Xa7MAwTRVFmvO7xuNF0ncK03aggirhdTlRVo1gsVl4XJRGX00mxqKKqauX1xXP66M5JKRRQiyomYGKgqzpqUUXXda7ftpm33zmCrhvoms7NN16HruvkFWXBcxocGuGv/+4xDh05CVj+aL/yi5/lztt3MjQyxtlzF4hGwlbHmSjQ1d3D4PAYdTVVlfF0XbzEnbftJJ3OYrPbONvZzfq1KwkGAnPOSSkUME0Tl9OF1bf/HiLhEJquV67N9Vs3su+td7HbbKQzOZa3L8HQdX7+c5/iG9/5PpgmoWCAB++7g0u9A9x843ZcTieyLPHKq29YVhsOa7LXDYO9+97C43GhFlWUQoHJyTh//Af/nnw+j81m47kX9qIoiiVtIM+caooFy5C2oa6Gs+cvIghQUx2lsb4Oj8eNx+Xm/IUeNFXje8+8BAjcfON1rF1jeb+VdYhy+QIjY2OYWOWx/qFRMLH85AyTwaFRREnC0E3ypdb/6uoIyVSKyVicSDBAXilgGAZut6sUlKmcPXeBQqGA0+Hgiz/7ADabjCCKFAtq5ZwM0ySbzVEoFGbcfx/18xQJhygW1RnHlGTZ0hGqCpNOpnF7XMTiCb7/3B4a62swMSkWixQLRSYmpqitra48Txcv9rLvzXcBE9kuc/stN+J0OK75nJRCgVw2j9vjqtx7yWSq8prL5fpQ5ohUOguAqqmWNQ6W5lUimaLWGf2xmfcW+p1+HOa993tOP85z+YdxTrPjnDkB0qW+IVpbGhZs9/8gbf5TsQTNjVYNvCocRDeMSlkjmU4T9PsqA2xurGNyKj7nO777zA956tkfAu8pzd71yHtZqPvvupn/8Nu/xP/5ymM8+9K+yuu/8LlP8ouff5jf/69/wTtHTlVe//3f+gU+cfet/OJv/AGX+ocqr//ZH/8O27es4xOf+w1yufd+gG/93Z9QEw1z+0Mzs2l7nv57xiZifPZf/V7lNbfbyavf+wcOHzvDb///27vPwCbLtYHj/8ymaaGL0kFb9ioUyt6ggOBgCQqKCLhQUI+4PaI4UEDkHFFRBEGUjchQFBR5UUQB2bsIFRmle480TTPeD2lzulva0FJ6/b4oSfo8930neZ4r97pmzHM83jSkEWs+f4/tO/cwZ8Eyx+M9uoSxYPbLrFj/HctWbZY6VUOdzGYzRkMmrz43hYhzF9jw7c9Yrcf4Ydd+WjZrzBcfv83G73bw0edrWb15R5l1umNwH+q76fhx52+kZmShVCiIvHiFhORUenQLZ86CZezee9gezCugS4e2uOn1vDhzPrEJyY7yDO7flS4d2/HZV1+SY8rFYjbz1YZtrF82Hz9fbwaOehSz2YwpJwejMZtHJ4wmx5TLlu27cdHpynyfQgCdVbUAADgrSURBVBr5c//oIazftI0PPr0IgKenF/36dOO5qRPYvnMv7y9cSXpaKiq1ms4d2jLqzoH8329/snzd944fIvfdPRRXFzXLV2/mXKT9OFarFRvw3FMPM/6xlzl77m+ysuy9LiPuuJVxd9/JPQ89j9FoIsdoJDMzgw6hzWnVvDF7DxwnOTUTG+Dj48N7g/qzduNW1n/3s6OXYPGKDezZvpoTp//iz8OnMeWayM21D0O2D21Bcmo6ly5ftfcMKZV4etQjwM+X2NgElp/+lqysLBQK6NOzK6OHDWbNN99zOToRgNTkJDINBpo1CebA4ZOkZ2QxcsJ01Go1TRs3YtlHb/HUi7MddTKbc2nbqim9unVi6JjH0GhcHG3vzO/Tt9t38d6HX6BUKlEqlcU+e1arFavVyvDbBzDzxal8umyd4/tktVoJbRFMk5BGrPx6K+cvXMZqsbBy40/MeO4xRtxxKw89+RrHTpxCqVKhUCiYcO8wdu3ey9otP2M0/u9GUl6d7pk03fFea7UaNq9ayLGTfzFj1n8dr23dqgXfrVlY5WvExHHDUSlg7cbt/H0xCpvNhtViwT8wgHtGDJHrntSp0nXa99OqQudQmEw5hX52vv3+Z8x88QkmTptBUQoFfPXJu8Uer6hVG74nPT2TaY/ch81mY9CoR9m+YREuWi0pqelMeOLf/LDuEwDeX/glLZoGc/ddg0o9ntlspt9dk/nx60+lB0nqVKk6GXNyWPv1Vvz8GmC12cg1mUhNzeD+scMr9Is3IzPT8QvZmJPLlyu/Zuevex2bqhpzTHh41Ofdmc/RoIE3Hy5cTlR0rKMHqUlII554dAIuefsNGXNy2LBlGz5eXphMJmw2m6M8nh4eXLh4mVXrthBxNpJzF/5Bq9XQslkT6rm74dfQl39NneTo5SnpfUrPzOSVme/h4+WJzQZWm5XEpBT+M+dV/Bs2dNRp7ddb8fSsh0qlRq1WkZCYzLgxdxXqQVq5djPHTp7BzdUVFJCZaaBDWFumTL4Pq82GzWrFmJNDRMR5jp48i4uLBlNOLgP6dqdZ0xCMOfYVe4eOnMBkysWUm8ugW3rTtlULso1Gvtmy3bHNCMC5yIt4etZDp9MRF5tARlYmEX9FkpFpcPQApadlEhjQkPiEJIKDAoiKiePuu4bg7qbn0FH7Rbp7l454edknOY+4fRB6N1fWfr0VoynHvv1B3vv27FMPExLUiJETnmHnpiUolEpsVitp6emsXLeFwAA/XHU6jEaj4z3Subg47fsUHRPHz7t+z/t+2HvQWrRo4vjs/XXub0fPj1KlYsigfvahtQLfp8tXYtiz7wC5ubnYrDjaPv/7dOVqLN9u/QmvvO0C1BoNaWnp3DF4AN4F9t4qq04Gg5HlKzfg5mYvl1arwZCdg9Vqw8uzniPATU3P4NGJ4+w7vVfxGnE5Kpqf/m83NovN0TZtWreQ657U6fr2IM188Qngf8v9ncnXx4tTEZEAJCSloNFocMlbqeNR352MzCwyswy4u+m5EhVLz64dKnTcgvmL8ulctJA34bYg17xfeUXlZzcv6dgVfVylUpT4uFqlQl3C4xqNGo2m+CinVmv/YBUldXJ+ndzc9Nw+ZEChuTS3DxlQKKlmaXW6HBVd6O/69OyKm7sbSiWOTRsVCgUuWrUjdcKE++9mx//9Zr8IKODOIQPx9vQoVN7Bt/QtsTz2HbP3EHnhIkkpyaSnZ6BUKohycaFzeHsuXr5CTk5OobIXfZ+iY+Psu2EX+L6oVGoyMrLwb2h/n3y8vYq1yZBB/YolGu3RNZw/Dx13fPfCO4ai1WjIMhgcr1WpVJw59zf+fg0cN8p9B4/SskVTfLy98PH2omP7tsXma6hUKpRKJVqtFoVCgclk4uLlKwxt2R+tVksDby8uXblK1NVYQoIacelKtD39iCEb77ycZi2bN6Ztm5aEBAdiNptRqVUoAHd3+6RxjVqNb94ikU7h7Vi0dCXu7u4oFArCO7bjyLHTNG0c7Khv/mfPmJODl6eH4zOq0+nQuhgd71/B97Koin6f8ufZFMxll99uYO8d2nfwKH4F2jV/EnzB47dt05ymTYJKnQ/j6+OF1kXraGebzUZurhmlSoVKpSr2+pLKbswxkpaRwZm/zjvyD3p7eeDj7YVKpXKMEhT8bFT1GmGf5zOuxHrJdU/q5Kw6lToHqSQbt/7MmOG3XcufFNK9cxhLvvoGozGHoyfO0rt7OKs3/IBvAy+G3NqbXt06cvTkWTqFteHK1Rg6d2hb6XMJUVGVmVRZ0kTRP/Yf4rZb+3IlKpq9fx4m12wh0N/PsRQ7/1w5OT2LZakvOAG6tPJkGQwYDAZi4xLQarX2m5hCQUpqOkZjTrkpSYC8HG82rFarYydthcLmmJR+LW3SPrQVPbt1RKfT4aqzJ59NSU0rNJG9ojswl7RaquCk46wsA61aNHNsfaBQKFAplbRs3oT4xGTHr8ImjYPo0aUjWdnZPDThXhKTUhzHCAkKwGaDjEz7HJaBA3o78pplZRmwWKz4eHvRsIE3Oq0WU64ZQ1bhX61QPUu5S1tdmd9u17LfTlkTn4u2c/4GkwW3ZihvdVhJ+QcvXr6KQqnkXOQ/FFz84Mw2klxp4norFiANGTMF+we6MJvNRnAj/yoFSF6e9Zk8fhSPPPMG9dz0zJrxNCvXb3V8uac/PoGZcz/hs+VfM/XhcbjpS19eLIQzXevFtrQblL9fAwbf2pdLl69itliK/UoyGnOKZakvaQVOSeVx0+vzJpPbu6/dXF3JzMxCqTSTnpFJu7Yty0xJAvZN/CaNH1NslVxJiUELlqGkPWfyN6jctXsvGZn2rvWiS5qrEkwUDNJUKhVfb/qh0HG0Wi2BAX6Etmlp39jz74vkmEyODRo9PeyTyu8aOhCFwoa3l71XK78eACvWbsLL0wODIZtLV6I5evwUarWGevXdCfTzo2+vrvx7+iP/25OK6lnKXdrqyvxyOzNIy2/n5JQUtnz/c6FEyRVZHVZS/sGWzZvYVwpi71HK71kSojYpFiB99ensEl+oUICfr0+Jz12L4UMHMHzoAMe/n5s20fH/Af6+fL7gzSqfQ4jrrbQbVK7ZzLpvvqNxSCPHr+mv1mykc3h7PD3qV2mnXZ3OfrP/8+BxUlJTUWvs84P0ehds2MpNSZJv4IDedA5vX+Gs6WXtOVNeT1NVg4mCQVrR4wwd3B+w7yDt6VGf8A6hhTZoLLhbtslkYsig/rRr29JxvPzNFc1mMxF/RaJSKTGZzOh0rmRnG9FoVPyx/xAPPzi2WLd8dSzlVigoNcBwdpCm07ng4uKCzQaZWQbHbtpQ/mezpPyDcfGJjl2/83vACu5pJURtUCxAyl9uLIQoXWk3qIyMTGw2BVarDZMpB7Vajc2mICExCU+P+lX+5d+ubUvefu1Zvtu2g6PHI6jnrqd1q+YEBfpXKGN6Pk+P+uUGRlCxPWfK632rSDBRkV2RSztO0VxrBcttMpk4czYSq83GsZNneGn6E45NI/PbPNuYQ67ZjEajRq/X4+/XAFCg17uSkWlgwuOvsOKzOcV6A6/nEE+WwUADH2+aNg4uNcBwdpAWG5fIgcPHcHV1RalQENqmBVqtttzPZtHvQm5uLkMG9eeP/YdQq9XU02hkR2lRK5U6B+n4qb/4aMkarsbEYc3ba0KtUrHt60+rrXBC3MhKukGlpqWTnpHO1ehYNGoVKBS46XWOOT7O+OXfrm3LvOGj7/H383X80s9NTefK1WiCGwU67cbtrNxSRYOJggFR/jygfOUlVi2pl6roMTqHtyM318yZs5Ho9a6Ocu/Y9ZsjAWv+e/HTzt9ITkklLi4RUJCYlIK7mx6VSoVWq+ZKdFyh1TbVIT+QKC/AcFaQlj/027VzB0dAefDICV6a/kSFjl/Sd8HFRSs7SotardQAad5Hy5l0/wi+/+k3nn9yIn9FXiQ1LaM6yybEDa/oDepqdBw5OSbi4hNAAfXc3Wgf2sqxPB6c88vfJ2+lVv4Ksti4eA4esW9OqdGoK5V6oSTXY0JywSG7bKOR+IRk2uX1VlRmV+SSerkOHDqOwWDAWqDcCoUCrUZbrBemwbiRxMTGodPpuBIVTVp6BgqFkuBG/gwe0Ievv/ul0nWtLGcNoVU0X1l+IBzg15AG3l4Yc0wYDNl5vWkVL3PBc8iO0qK2KzVA0mjUDLm1tz0wSs9kyK29eeql2YwdNbQ6yydErWE05rBj1280DgmiZfOmGLKzsdnsGdWL9rhU9Zd/wRtobq6Zg0dO0LVzB/waNnBq6gVnz3UpGMzExSdy7EQE5y9cJDExibB2bfD38wWurYeqpF4utVpN755dORVxDovFgsVioX271mg06mLBncViISS4Ee3atiIj04DZnEtmVjYPjB2Jp0e9StUzv65VCQ6qGmBcS76ygoGwRqNx7Che1SExWWkmarNSAySP+u4kJKXQt2dn1m3cTnpGJskpadVZNiFqlSyDAa3Gvp+MVqvBJW/eiMlkui5zL/JvoFeuRgPg19D+a99ZiXWLnscZPQEFl6+fPH0WnYvWvmeJWs2Zs+fxztuw8FraS6VSkZqWjs0G9eu5OXrVuoS35757RrBizUZUKhXHT5wpMa9dweEsby8PbDYbanUaPt6eqDVqPnj3JVyuY3BSVNHAqjLtXdF8ZQXPJUlWq09Vg2dRPUoNkKZMuhebzUansDYcOHySJV9+w6T7R1Zn2YSoVdz0ejQaNaFtWnDmbCQ2m43s7GyGDOpf6kWwqhdKnc6F4EaBaDTqCg2DVfZ8zuoJyC/TpSvRRF64hFarITc3l6SUVFRKFf9cvMKo4UMrfK7IC5f4etP3HD52irj4JPx8vekcHsa4McMAuBIVzfA7BjlWV5U0kb28XrKKblibryrJVJ2RpR4qNnespHNNvH90lSfTi7I56z0W11+xAOnAkVN06RhKuzbNHY89PvleHp98b7UWTIjapuCNtn3bVphyTQwZ2N+xaqooZ10oKzoMdiNcmHU6F/r07Mqc/3yaF8gpaNWyKWlpGSgVStzc3UrcPLMkqWnpbN76I/9ciqJp42BCggJJTcvA3V3v6PECe2oDxz5GWYYSe9ZK3Zwzy8CICf/iu1UfVThhd2UntjszS315c8eKnstkMrF1204eevDeYjum57sRPj+1nTPfY3H9FQuQlny1gejYBPr36sLAft3pEt4OlUpZE2UTotap6HCUsy+U5Z33Rrow+/s1oFf3zmQZDBw9fpqLF68SE59AWNtWqFUqvDw9yi1b5IVLbN2+kyPHThOfmESzJiGOjSGtFmuhzSDL6lmryHBWwcSZFVHZie3OWjEI5QfNBc8VG5fAydNnSU3PxGwxc/fw24sFPjfS56c2c+Z7LK6/YgHS0g/fIiEphT17D7Nm4zZmzV9M7+7hDOzfg64SLAlRrooMR12PC2VZ572RLsz5Q5FBgf78feESer0ehcJGUCN/zpw979gNvLSy5d+svT09cNFqUSlVRF2NyevhsTn27ikvSHBWj0hJQVZl5vM4e8VgWUFz/jFNJhP7Dx4lMSkFkzmX85EXWb/xe55/+tFCr7+RPj+1WXWkqRHOU+IcJF8fL0YPH8zo4YPJyjKw79AJvvluB2/M/YQfN3xW3WUU4qZT3RfKG+nCnB9AbN22k2yjCZ1OS2CAPyqVCpvNvnFjWWXLMhhISEzmanQsuRYzWQYDOSYzHnHxhIW2Yejg/835Ki1IKNgjYjabyTbm8NPO3wiaOPaabvilBVmVmdju7BWD+ccs6e/zz7X5ux+5ePkq7u56mjcNoX69epyLvEBySgqBAf6O199In5/a7Hq8x+L6KTNZbUxsAr//eZQ//jzKpagYBg3oWV3lEuKmVt0XyhvtwtyiWWMeevBeWLUBP98GJKemcerMObKzs8nONhYKcooqmBzVzU2Pr4830THxvPnKMzRpHFziRpJFH8vvEYmLT+TMWXsWekO2gR7dOtK1U4cCf6tj9eK56ErISF7SsNNPO3/DddgQfLw9KzWxvTr3DmrRrDFjRt3BkeOn8ffzzdv13VZi0uMb7fNTm8n+ULVHsQDpyIkI9h44xh9/HiU318yAPl15+IG7CQtt6ehWFUJUXXVfKG+0C7OnR32G3zGYXbv3otVo6NCudaFcaqUpKTlqx7C2+Pr6oNO5FBryAkodYsrNNXM64pxj8rUN+waTBc+vVCrw8/VGqSx+7Ss67BQXn8jBI8ft2zq46as06b663ptAfz/C2rXmclQMCoUJm81Gm1ZNS0x6fKN9fmoz2R+qdigWIL3/8XJu6duNN1+eRusWTWqgSELUHdV9oazKvjrX48ZYmZtuSclRM7Psf19wyCshMRmFAhr4eAOF5xjpdC706BrOn4eOO7LAtg9thVqtLjSvxmDIZvDoKezctKTYKraCw05msz3YcnV1dfTG1IZJzDqdC2NHD2PH//1GTo4JFxdtmdtSyI1d1CXFAqS1n8+riXIIIW5Q13t597XedIsO9+Tm5jJwQG+AQvOKjh4/jQ37TuYlBSztQ1vRs1tHdDodrjoX1Go1KalpFZ5XU7AcWVkGsgxGunft4MiNB7VjErM9SB0rPUNCFFHmHCQhRN12oy7vbtGsMQ18vEhITMK3gQ+eHvVJSk4B7ENexhwToEChAGOOiXp5QUtMbBxmi8XxN0MG9WfX7r0kpxgxmUxl9p6UVo6gQH+SU1JwcdE6khLXtknM0jMkRHESIAkhSnU9lnc7Y7iupF6toED7qiubzYbORQvYsNlA52JPgvvX+Qvs2XsAhUKFQmFj0vgxDBzQm5wcEzt2/YZWq63wJpUF6XQuBAb4O4KtgmWSoEOI2ksCJCFEqZy9vNsZw3Wl9WpNvH90oaG3oEYBKBSQkZmFIdvIpctXaRzSCKVSidVq5as1Gwlt25I/9h8iKDCgxJVoer0rOzctQa93LbdcN/skZkkzIuoaCZCEEKVy5vJuZw3XldWrVTRIyX88JjaBI8dOo1TaN7pVKpXYbAquXIkudIyiK9Fu6dsTtUZD4+BAVKryV/HerENVkmZE1EUSIAkhyuSsnhFnDdeV16tVNEjR6VxQqezDalar1dGDpFDYCA4O5OiJM6WuRNvxf3tYufFHdm1ZWuFcbDebG3UemhDXm+QNEUKUS6dzwcfbq0o3xIKBTcH/FkygmpScgjFvJ+2yyjJwQG/iE5K4EhVNfEJSub1anh71mTR+DIlJycTFJ5GYlMyk8WPwb+jLwAG9SUlNI+pqDMmp6bRu1QyNRpMXwNmDqrqsrMBWiJuZ9CAJIZyivDkqZQ3XVWYIJ3/f2oruXztwQG86h7cvtPIN7D1kOTkmtu3YhVaj4ty5C2hUavwaNgAUjmG5ukrSjIi6SgIkIUSVVTTAKWm47lqHcPJf79vA55qHfDw96uPpUd/RW5V/k/9j/yGahATj6urKqTPnOHjkON27hDOgb3c2//RbFVundpM0I6KukgBJCFEl1xrgFJ0jdK1zk6o6l6loMNc5vJ3jOP4NffHx8iQ2LoFRw4bQKNCP/9u8tPxGuMnd7Cv0hChJ3e47FkJUWVXnqJQ3N6mir1epVOXOYSoYzHl7eeLl6cGBQ8fJzTU7jqNWq3Fz0+Pj7YnZYmH/oROYLZYK1aW2K2semDPmoQlRm0gPkhCiSqo6R6UyQzidO7bn9/2HsFmtKJRKmoQ0YvX6b9Fo1I6/L2mIr6RgTq1W07lje44cP1Xs/FlZBp6dMY+dm5agvslXsclSfiEKkwBJCFElzpijUtEhnPybeEJiMmfPRVK/vjspKen89vsB/Br60K5tK/waNih1iK+0YK59aCvah7aqs0NIspRfiOIkQBJCVJkz5qiUt8li/k3c3U3P0RNn8PH24uSZv2jZrAlxCRcJCQnk5OmzuGjDyM01lzgnqbxgrq4GA9cjpYwQtZ0ESEIIp7jeu0jn38RzTLkAWCxWbOTtig0kJaUSHROLKdeM1Wrhln498fH2KnacawnmFEolTUMaobjJl/rLUn4hiru5v/VCiBtGRTeCLE3+zdpFqwFApVKiADRaDQ0beBN1NRqbzYZGo6Zr5w78sf9Qqeeq6IRjvauONZ+/h95VV6ky1xb5PWspqWkkp6SSkpomS/lFnSc9SEKI684ZE4ALDo8FBfpzLvIC4WGhJCYl07xpEzRqNWHt2hDcKACNRkNySmqVh4hyc81s37mHOwb3c0wAv1nJUn4hCru5v/FCiBrnzAnABW/iKpUKi8WCSqXCYDCw5fufC20eCVUfIjKZTMxZsIxB/Xvc9AES3LzJdoWojJv/Gy+EqFHOngBc0k3c06M+Qwb1d8puzwVTpggh6i4JkIRwovLykdVF1TUB2BlDREWHAnt16+TMIgohahEJkIRwEtlor2RV2SfpWgPOqgwRpaals3XbTvwaNkCr1WKz2fht3wG6hIeiVMl6FiHqGgmQhHAC2WivbJXp3anOgDPywiW2bt/J0RMRuLu5EtqmJf5+vmjUGt56eSquupt7FZsQojj5WSSEE1Q1H1ldcC25vErKmbZr995KbxFQkXP5+TbAzc0VV1cdZ86ex2QyYTZb+XrLDkx5ey8JIeoOCZCEcIJrTbgqyladAWf+MbVaLa1aNiUlNY209Ezi4hPp16sLK9ZvJTdXAiQh6hoJkIRwAtloz7mqM+DMP2ZsXDznz/+DWqXCarUwoF9PmjUNKfb6qm54KYSoHWQOkhBOIhvtOY8zEuBey7n69OzKvAWf4erqikqtpnfPLhw6coLGwYGFXisT8YWoOyRAEsKJZKM956nOgNPfrwHdu4Sj17uic9E6duI25uQy/PYBqNRqmYgvRB0jAZIQ4oZVXQGnm16PRqPG3U1faK8mHy8PXn32MQCSklMAyXgvRF0hc5CEEHVeaXPIUCiY/cHnGHNMMhFfiDpGepCEEIKSh/Sysgxs/XE3z0x5ADc3fbXNixJC1DwJkIQQIk95Q3oyEV+IukMCJCFErVedOfBkIr4QdYMESEKIWu16Lr3XaDQ8MuFuNBqNU44nhKg9JEASQtRa13vpvVar4dEHxzihpEKI2kZWsQkhaq3rnZIk22hk+qvvkW00OuV4QojaQwIkIUStdb2X3lstVv48fBKrxeqU4wkhao9qG2JLTcvg9dkLSU5J447b+jLh3mGFno+JTeC+x16icVAAAIMG9GTSfSOqq3hCiFqoOlOSCCHqlmoLkL5YvZkBfboy6s5bmfTka/Tv1YWQvGAoX2irZiz6z+vVVSQhxE1Alt4LIa6Hahti23vgGOFhbVCr1YS1bcm+g8eLvcbDo151FUcIcRPR6Vzw8fZyenCk1Wr59/RH0Gq1Tj2uEOLGV209SMkpaQQF+gEQEhRAYlJqsddEXrjMQ0+9jpubKy88OYkmIY2Kveab735m49afgf/NNxBCiOtBo1Ez4o5ba7oYQogacF0CpC/XfMu+Q4V7iLKNOZAX0FhtVhRKRaHnG/r68PqLT9C2ZVPWbd7OvI+X8+n7rxU79j0jbuOeEbcBYDab6XfX5OtRBSGEwJBt5NF/vcHSj95C76qr6eIIIarRdQmQJo8fyeTxIws9du9DzxMVHUeLZiFciYqlRbOQQs+rVEo6tmsFwMg7BrJ+80/Xo2hCCFFhNquVfy5fxWaVVWxC1DXVNgepT49OHD15FrPZzKmISHp160hKajrPvz4fs8XCz7/uIyk5FZvNxp59h2nTskl1FU0IIYQQopBqm4P00PhRvD57IVt+2MWwof0JCvQjJi6RS1eiMeeaaejrw2uzF5KUnIqPtyczX3i8uoomhBBCCFGIwmTKqbUznfPnIO354UvUasmaIoRwLrPFwqGjp+naqR1qlaqmiyOEqEYSVQghRCnUKhU9u3ao6WIIIWqApBoRQohSZGUZGHT3o2RlOSe3mxCi9pAASQghymAwSKJaIeoiCZCEEEIIIYqQAEkIIYQQoggJkIQQohQ6nY7Vi+ei08ku2kLUNRIgCSFEKZRKBX6+3iiLpEYSQtz8JEASQohSGAzZDB49BYMhu6aLIoSoZhIgCSGEEEIUIQGSEEIIIUQREiAJIYQQQhQhAZIQQpRCr3dl56Yl6PWuNV0UIUQ1kwBJCCFKYbXaiEtIxmqttTm9hRCVJAGSEEKUwmg08sDjr2A0SroRIeoaCZCEEEIIIYqQAEkIIYQQoggJkIQQogx6vaQZEaIuUtd0AYQQ4kbl5qbn/zYvreliCCFqgPQgCSFEKcwWC/sPncBssdR0UYQQ1UwCJCGEKEWOMYdnZ8wjx5hT00URQlQzGWITQghRK6SmprPp263Exkbj7x/I6JHD8fSsX9PFEjcp6UESQghxQ7PZbLz73nwefmg8xr9XEqr9BePfK3n4ofG8+958bLaqbeQZE5vAA1NeqXI5J059lZjYhCodY9qL7xBx7kKZr7l74vRKH3/W/MUcOX6mzNekpWcw5dm3eGz6mxivoff0yPEzzJq/uNJlKyo1LYO5Hy5z2vGulfQgCSFEKRRKJU1DGqFQym/JmjR73n+wxP7C3AddAC0AoY1hcDis2/MLs+fBjJdfqNEy3kz2HzpJSCN/Xnvh8Rotx4EjJ+nROazGzi8BkhBClELvqmPN5+/VdDHqtNTUdA7v/zUvOCruvn4uvLLyV1JTpzhtuO2L1ZvZ8cs+tBo1M56fQusWTdjw7Q627/ydjMwsRg8bxP1j7sRms7Fo+dfs/uMgQYH+pKZnOI7x3Y+/suabbSgU8OwTD9K9SxjTXnyHobf2YfMP/8c7M55m5pyFPDdtEu3btiixHCWdc+acT4iNS2Ti1FcZN/p2hg7sw4JFqzh49BT167nz9ivTCPD35f7HXmJA7678+sch/Bv6MH/WC2zY8hO/7DnA8VN/0atbR55/clKxc165GsuiL9ZjzMnh/Y+X8/jkscxfuJxLUTGYzRZm/fspmjUJIjUtgzkLlhIVHUcDb0+envIAb7+/GEO2kYlTX2XhvBmkpqUzZ8Ey0jMyadkshJf+9TB6V12xdvjmu5/Zs+8wbm56Zr74BC2aBgNw8Ohp/jVlPPEJSbzy9odkZhlo07IJb7w0jQsXr/DRkjWkpKXj7enB3Demo3fVcfpsJO99tJycnByGDRnAg+OGV/pzID+LhBCiFLm5Zr7b/gu5ueaaLkqdtenbrQwOK7v9B4eZ2fTt904535+HTxL5zxXWLJnL3Dems+SrDQB0CmvDkgVv8OXCWSxfs4Uck4m9B45x7ORZVi6aw1uvTEOV19N48fJVftjxG6s+m83nC97k85UbHcc/GXGe5QtnERToR3CjANzKSIRc0jnf/veTAKxYNJu7buvP9z/tRqvVsG7pPKY9Mo4V67cCcDkqhh5dO7Bq8RwSk1M5HRHJ/WPupE2rprz67KMlBkcAwY38eWziGAYP6MWLTz+Em96VB8cO56tP3mXsyKGs+eYHAD5cvIoOoa1YvXgub748jRZNg3ls4hj69erMikWzqV/Pjbff/4z7R9/B6sVz8fbyZMW674q1Qz13PT/s+I31X8xnweyXCG7kB4DVaiXLkE09dzd27v6T0NbNWb/sfaY9ch8qlRJvLw9mvvQEqz6bg5dnfX75/QC5uWZmf7CU+W8/z+ol73H4+BkSklIq+1GQHiQhhCiNyWRizoJlDOrfA43m5rtcGo05ZBkMuOn16HQl99DUtNjYaEK9yv4tH+ClJCI22inn+/PwSSL++pvJT74GgKurfaPQAL8GbPlhFydO/4XFYiUlNZ3Dx85w52390Go1aLUa6rm7Afaej6sxcTz89EwAsgzZjuPffddAFAoFAG+9Mq3sepVwTv+GDQq95sDhk5y/cJlDR09hs0FIkD8ALlotncLaANCiaTDJKWmVag+VSolarebTL9Zz8sx5RxD456GTvPzMIwB4ldBzl2XI5p/LV+ndvSMAQ27txbyPvuCJh8YWaof69dzp3LEt78xfzCMTRuPt6QHA+b8v0ap5YwB6du3AzLmfsG7Tdu6+axAA3l4eHDhyii/XbOGvyIuEBAVw+WoMsXGJvPD6fAAM2UbiE5Lx9fGqVN1vvm+8EEKIckVeuMSu3Xsd/x44oDctmjWuwRKVzN8/kOi/rYSWUbSYFCv+zQOdc0KbjfH33MW9I4cUeMjGky/NZtjQATw95QEuXo7GZrVhsVowGEpOZDzk1j78a8r4Yo8rKzifrbRzllBcnnl8An17dir1WCqVispOYz8VEcn8hV8y9eFx9OvZmUXL19vPi428OK+0CpR53Px2UCgUvPfGsxw+doZXZ33EIxPu5pa+3dh38AS9unUAoFmTIJYueJPN23bx4NRXWb5wFlt//JWTEZE8OHYYQYF+ZBmy8wLEAJYvnFXJ2hYpo1OOIoQQotYwGnPYtXsvXp4eeHt54uXpwa7de69pxVJ1GT1yODtPlv1bfudJNaNHDqv8SRQKrDYrAN06t+e77b+SlWXAarUSn5hMWnomsfGJjLprIDarleRUe29MaOsW7D1wDIvFSnxCEonJqQB07tiWnbv3kZiUgs1mIy4+qcTTvjVvERcvXy1cFBRYrbZSzwnQsIE38Qn2Y3br1I5vvttBbq6Z3FxzuT1Ffr4+xCcmV7hpjp/6i/CwNvToEsY/BcraKawN3277BYCYuEQsFisNfb2JT0jGZrPh5qanSXAj9h08DsDPv+6ja6f2xY6flp7BpSvRdAkP5fZBfTh6MgKAcxcu0TKvB+mvyIsolArGjRqKVqvhakw8h46d4faBfWjVvAmR/1wBIKSRP6lp6Y5VeqW1e0VJgCSEEKVQqpT06BKGUnVzXSqzDAYAx1BP/n/zH7+ReHrWp0vPW1i3p+Tgbe1vOXTpeUuVJmg3bOCNWqXmwJFT9OzagYH9u/PQ0zOZ/NTr/Hn4JB713RnUvweTps5gyYqNNAqwz5MZ1L87DX29eeDxV1i4dC0Bfr4ANG8SzKMPjuHJl2Yz6cnX2LZzT4nnvXg5mozMwm3erVN7tmzbVeo5AUbccStTnn2bjVt/ZsSdtxLcyJ8JT7zCY9Pf5Oz5f8qs69CBffj487XM+aBiKXT69+7CqYjzPDb9LZKT/xd8TZ/6IHsPHOOBx1/h/Y+Xk5GZRVjblmRkZjFx6gyiY+OZ+eLjrN7wAw88/goJiclMvn9kseMbjSY+/nwtE574Nzt+3cvoYYPJyMzCTe/q6GWKjoln6vOzGPvwC7Rr05yWzUIYdddAFi1fz3OvzcPdTQ+AVqth1qtP89GSNTz4xKt88NlKLBZrhepZEoXJlFO1DSRqkNlspt9dk9nzw5eo1TJaKIQQFWE05rBi7Sa8PD1QKBTYbDZSUtOYeP/oG3Iuks1mY/a8/3B4/68MDjMT4KUkJsXKzpNquvS8hVdfet4R5Inab9eeA1gsFm67pVeNlkOiCiGEKIXJlMuK9d8xcdwItFpNTRfHaXQ6FwYO6F1sDtKNGByBvYdrxssvkJo6hU3fbiUiNgb/5oF88dww2Um7Cl6Y+R/HUF2+B8cNr/HA5MDhk0x9eGyNlgGkB0kIIUqVlWVg8Ogp7Ny0BLe8bvybSW1YxSbqnp279zN4QM+aLob0IAkhRF2l07lIYCRuODdCcAQySVsIIYQQohgJkIQQohQqtZrhtw9AJUP4QtQ58q0XQohS6Fy0vPrsYzVdDCFEDZAeJCGEKIUxx8TsDz7HmGOq6aIIIaqZBEhCCFEKi9nM1h93YzFLsloh6hoJkIQQQgghiqjVc5BsecnwzPLrTghxHeRfW8xms1xnhKgDVCrV/1Lw1OaNIo1GI7eOfLSmiyGEEEKIm0DBjadrdYBktVoxmUyFIr4b1YQn/s2qz+bUdDFqLWm/ypO2qxppv8qTtqsaab/Kq2zbFYwnavUQm1KpRKfT1XQxKkShUEg6lCqQ9qs8abuqkfarPGm7qpH2qzxntJ1M0hZCCCGEKEICpGoyZvhtNV2EWk3ar/Kk7apG2q/ypO2qRtqv8pzRdrV6DpIQQgghxPUgPUhCCCGEEEVIgCSEEEIIUYQESEIIIYQQRcj6QSdKTcvg9dkLSU5J447b+jLh3mGFnrfZbHyxejO7fjtAQ19vZr36FHpXHSvWbeXXPw6SlpHJ+DF3cu/IITVUg5pVmfZzd9OzbtOP7PjlD7IMRp569D769epSQzWoOZVtu7Pn/+GDRSvJzDSwesncGip9zdqybRcbvt2Bu5ueWf9+koa+Po7noqLjePO9T8k25vDg2GHcPqhvqW1ZF11r2wF8umwdW7b9wivTH2Fgv+41VfQad61tFxufyHsffkF8QjJBjfx46+Vp6HQuNViDmnWt7Xfx8lX+++lK4hKS8PKox6wZT+Pr41XmOaQHyYm+WL2ZAX268tWn77B95+9cjoop9Py5yIvsPXCcFYtm06lDG1Z9/T0KhYK2rZuxfOEsln30Fp8t/5rc3LqZ0qAy7ZdlyCbHZOLzBW8x5/VnmP3BUkcKmrqkMm0H4OPtyT0j6u5KmeSUNFau38qyD9/inhG38cmy9YWe/3DxKh4aP4ol/53J4i83kJllKLUt65rKtB1A356dCW3drCaKfMOoTNsdOR7B04+NZ9XiOahUKr7f8VsNlb7mVfaz9+9nH2Xd0nmEtm7Olh92lXseCZCcaO+BY4SHtUGtVhPWtiX7Dh4v9PwfB47RsV0rVCol4e3bsPfgcRQKBT26hJGbaybywhUaBweg0dTNjr3KtJ+b3pVJ941ApVLStHEjLBYLOabcGqpBzalM2wH4+njRvk2LmijyDeHPwydp1bwJOp0L4WFt2HfwmOM5i8XK/kMnCG/fGjc3PSFBARw5HlFqW9Y1lWk7gA7tWuHj7Vkzhb5BVKbt7rytH82aBKFQKAgLbUlCYnLNVaCGVab9moQ0IsCvAQlJKcQlJNGqReNyzyMBkhMlp6QRFOgHQEhQAIlJqYWeT0pOJSQ4AIDGwQEkJqU4npv05AxefvMDXn/hiWor742mKu0H8FfkRYIC/dC5aKulvDeSqrZdXZWUnEpIkD8ADbw9sVitGHNMAKRlZOBZvx5uecNn9nZNkbbMU5m2E3ZVbbvDx87QoV2r6i30DaSy7ffzr/sYNeEZ9HpX+ldgKkbd7Kpwgi/XfMu+Q4V/OWYbcyBveMdqs6JQFskPp1BgteY9b7WhLPD8miXvEXHuAi+9+V8+X/Amnh71rm8Fapiz289ssfDh4tU8Pnns9S34DcDZbVenKSg0JGuz2shP66hAgbXAc1abzd6u0pZ2lWk7YVeFtvvz8EkyMrPo3T28ukp746lk+912Sy/69uzEh5+t5ovVm3lkwugyTyMBUiVNHj+SyeNHFnrs3oeeJyo6jhbNQrgSFUuLZiGFnvf19uLKVfvckMtXY2ng/b8JYgqFgtDWzWnWOIiIcxfo1a3j9a9EDXJ2+y1YtIouHdvSo0vY9S98DXN229Vlvj5enIqIBCAhKQWNRoOL1t4D6VHfnYzMLDKzDLi76bkSFUvPrh1IS8uUtqRybSfsKtt2l6Ni+Gjxaj6Y/dINn6D9eqrKZ89Vp2P08MG89+EX5QZIMsTmRH16dOLoybOYzWZORUTSq1tHUlLTef71+ZgtFvr0COf4qb+wWKwcPRFB7+7hXI2JZ/WGH7BYrCSnpnHizDmCG/nXdFVqRGXaD+Cb734mKTmVhx+4u2YrUIMq23Z1XffOYZz/+xJGYw5HT5yld/dwVm/4gR2/7EWpVNKrW0eOnjxLZpaBK1dj6NyhrbRlnsq0nbCrTNulpWcy452PefW5R2nYwLumq1CjKtN+K9dvJTo2HpvNxq+/H6Rx3jB5WSTViBOlpWfy+uyFJCWnMmxof+4fcycxcYk8/fJsVn02B53OheVrtrDz1/34+/nw9r+fQqvR8OkX6zh87AzpGVlMHDec0cMH13RVakRl2i81LYNxD79A08ZBji7WB8cN57ZbetVsZapZZdrOTe/K7A8+5+SZ80THJNA4OIDnn5pMxzo2t2HrT7tZt2k79dz0zJrxNCvXb8W/YQPG33MnMbEJzJz7CYZsI5PuG8GQW3sDlNiWddG1tl3EuQvM+WApsfFJuLm5Et6+NW+8NLWmq1EjrrXt3vnPEn7ff4QAP18sFgvu7no+ff+1mq5GjbnW9jt55jyfLF1LUkoafg19eOOlqeUu85cASQghhBCiCBliE0IIIYQoQgIkIYQQQogiJEASQgghhChCAiQhhBBCiCIkQBJCCCGEKEICJCGEEEKIIiRAEkIIIYQoQlKNCHGTunvidLQaNWq1GledCw/ccxe39O1WboqCt+YtYsLYYTRvEsy0F99h3N23M6B312oqdXExsQlMnDaDnzctuaa/mzj1VaY/MYHOHUMLPb7mm21s+n4nrjodDXw8efLR+2nRNNiZRa5Rs+YvpmWzxtw3+nYArsbE89Hi1UTFxKFWq+jdLZxHHhyNWqWq4ZIKcWOTAEmIm9isV5+mVfPGXI6K4eW3PsBssZS7y/jNvLPx8dPnWLd5O2s/n4eb3pWIcxfQam7ey2B6RhbTXniHF56eTL+enTFbLOw7cAyVUgYPhCjPzXtlEEI4hAQF8K8pD7Bw6Vpuu6UXScmpfLh4FVHRcaRnZDF21FDGjhoKlNzzEhUdx9QX3mHzig9Qq9VkG43c+9DzfP3Ff9C76gqda9qL79CxXWuOn/6L+IRk+vfqwtNTxqNQKLh4OZr5n3xJSmo6eldXnnn8Adq3bQHAyTPn+WjJagzZRrw9PXj+yUk0CQksVpdTEZH899MVZBmyCfBrwMwXn8Dby4PY+ETmLlhGQmIKjQIakpqeUexvDYZsTKZcjMYc3PSutG3VzPHcrPmLcXfTc+FiFHEJSbRr04JXpj+Mi1bLpSvRzPtoOUkpadSv58Zrz08hJCiAfQePs2Ldd2QZskGh4M2XptKsSRBHjp9hw7c/4+VZn7PnL/Dp/Ne5/7GXeGj8KL7/aTdJyam88NRkjhyP4Pc/j6B3deX9t57D28uD02cjWfzlN6SmZ5Cbm8tL/3qYTmFtiIlN4OW3PmBAn278vv8IaemZvPva04XqUNTGrT/Tq1tH+vXsDIBapaJfry7X8MkRou6SnxFC1BHt2rTgclQMZouF+vXceeCeu/ji41l8+v4MFi5dS0ZmVql/GxToR9uWTfn9z6MA7Nl3hJ5dOhQLjvJlG3P4eO6rrFg0m917D7Hv4HHMFgsvv/VfxgwbzOrFc5n+xAO88vYHZGRmkZ6RxStvL2D6ExNYvXguo4cN4pW3F2CxWAsdNyMzi9n//Zw5rz/D+mXvM6BPV75a9y0As95fTOeObVm9ZC4znn+sxF6SHl3CGHJrb8Y+8gLzF35FdGx8oecTk1KYP+t51iyZS1R0HN//tBuzxcLrsxfy7NQHWbd0Hg8/cDcLP18LQKC/L3PfeJYVi2YzsF93lq3a5DjWnn2H6dWtA198PAudiz3TeEJiCov/O5Oxo4Yy452P6N+7C6s+m4veVcf2nb8D0MDbi9eef4wVn77L5PtH8fGSNY5jXrgYRVjbFnzx8dsM6NOFtRu3l/qeAZz/+5IjABVCXBvpQRKijrDZrCgUChQoUGtU6HQuLFu1mb8vXkGBgrj4JOq5u5X69+Puvp1VG77nlj7d2PHLPsbfcyfJKWlMf/U9AFo2b8zrLzwOQKcObVCplOhddXQNb8epiEgC/HwxGk3c2q87YA/YGgX4cSoiEpvNRnCgH+3a2G/mt/brzgefreTK1RhctFpHGU5FRBKXmMSLb/wHAIvFStPGjTBkGzl+6i/+++6LAHjUr1diXZRKJc9Nm8joYYPZ8O1PTJw6gxeffoihA+1JaMNCWznO16d7OKci/qZLx1AuXYnh7fc/y2tH0OlcAAgK9OfPwyfYf+gEEecuYMrNdZyrcXBgsd6afr06o1AoCAttiYdHPcJCW+a1RXMSklIAaOjrzdGTZ1m3+SfO/32JqOg4x9+7uuro3iUMgPZtW7Jp685S3698kmxTiMqRAEmIOuLkmUiaBAeiUinZd/A4nyxbx+OT7uGeEbcx+dxrWG1l30o7d2zLh0tWE/nPFa5cjSW8fWuUSiUrFs0u8+/UahWueQFFUWVNF1egKPYKm81GUKAfX33ybqHHM7MMAKgqOPG4SUggLz79EK1bNmXl11sdAVJJ5c4PiL785B2URXqlZs3/DBetlhF33ELfHp1YuHSt4zmVqvQOerVaXeTfKmxGe/sv+eobLlyK4r7RdzDi9lt4bPqbpRxDha2c8Kd50xBOnjnH8KEDynydEKI4GWITog64eDmaj5asZvL4UQDsO3icruHt6NerCympaWRklDy8pkCBzWq/CSsUCsaOHMLb8xYx5NbexYKFgq5cjcVmsxGfmMzuvYfo0bUDwUH+6HRafv3jIACnz/7N1Zh42rdtQfu2LYmKieP02b8B+PWPg7i66ghu5A8KBVabfaitXZsWxMUnsWvPAQCyDNmkpKbj7qanaeMgxzBVdGw8icmpxcr1w47f2LPvMDabDavVSlx8EkGBfo7nr8bEYbVaycwysO3nPfTq3pHgIH88PdxZt+lHbDYbJlMu8YnJAOzZf4R7RtxGaOvmRJz/p6JvR5n27D/CXbf1p1NYG879fbFKx7pnxGD2HjjGnv1HALBarWzZtou09EwnlFSIm5v0IAlxE3t99seolCpcXXVMe3gct/TtBsBdt/Vj/idf8fDTMwkLbUlIUECJf9+7ezhrNm5z/N3gW3ox7+PlvDe4b5nnPXn6PI/9/iYZmVk8PnksrZo3BuC9N55j/sIv+XzFRvSuOubMnO4YCpvz+nQ+WLQCY44JT496zJ05HZVKiZ+vNyGNAtjw7Q7uHTmE9996ng8Xr2LZyk24uGh48pH76RIeyusvPs6cD5ayYctPNG8abA+uiujcMZRPl63jsy83kJNjolnjIF7810OO5y9HxTDthXdISknjrtv607dHJxQKhb3cn3zJ1p9+RavV8ODY4Qwe0JNHHhjNa7M/pmEDH3p27XDtb1AJJtx7F4uWr2fd5u0M6N21zJ6o8njUr8cn82aw4LNVLFq2Ho1WTe/u4bjpS547JoT4H4XJlCND1EKICvn+p90cOnaaN1+eVuprboS9kyqj6P5BQoi6TXqQhBDlMlssTJn+Jmq1mrkzp9d0cYQQ4rqTHiQhhBBCiCJkkrYQQgghRBESIAkhhBBCFCEBkhBCCCFEEf8PXX4PWaXpzOUAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 583.3x340 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "584eca4c",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"], constrained_layout=True)\n",
     "ax.scatter(\n",
@@ -1460,16 +902,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b0c0bf1",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00401,
-     "end_time": "2026-09-02T01:48:36.163064+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:36.159054+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "ba956d97",
+   "metadata": {},
    "source": [
     "### Selection-Adjusted Uncertainty\n",
     "\n",
@@ -1495,67 +929,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "7ab5c5d3",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:36.168606Z",
-     "iopub.status.busy": "2026-09-02T01:48:36.168514Z",
-     "iopub.status.idle": "2026-09-02T01:48:36.887402Z",
-     "shell.execute_reply": "2026-09-02T01:48:36.887090Z"
-    },
-    "papermill": {
-     "duration": 0.721812,
-     "end_time": "2026-09-02T01:48:36.887667+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:36.165855+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "selection adjustment not available at this stage: dsr_pvalue, k_variants, pbo are entirely null because cohort_metrics holds no rows for sp500_equity_option_analytics yet. The bootstrap interval below stands on its own; the search-adjusted reading arrives with 20_strategy_analysis.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (5, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>config_name</th><th>label</th><th>sharpe</th><th>ci_lo</th><th>ci_hi</th><th>dsr_pvalue</th><th>k_variants</th><th>pbo</th></tr><tr><td>str</td><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>null</td><td>f64</td></tr></thead><tbody><tr><td>&quot;latent_factors&quot;</td><td>&quot;sae&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>1.298</td><td>0.004</td><td>2.732</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;tabular_dl&quot;</td><td>&quot;tabm_m&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>1.287</td><td>-0.294</td><td>2.739</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;fwd_ret_10d&quot;</td><td>1.264</td><td>-0.172</td><td>2.639</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;gbm&quot;</td><td>&quot;leaves_15_huber&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>1.018</td><td>-0.435</td><td>2.545</td><td>null</td><td>null</td><td>null</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;ridge_a1000000.0&quot;</td><td>&quot;fwd_ret_risk_adj_5d&quot;</td><td>0.819</td><td>-0.728</td><td>2.293</td><td>null</td><td>null</td><td>null</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (5, 9)\n",
-       "┌──────────────┬──────────────┬──────────────┬────────┬───┬───────┬────────────┬────────────┬──────┐\n",
-       "│ family       ┆ config_name  ┆ label        ┆ sharpe ┆ … ┆ ci_hi ┆ dsr_pvalue ┆ k_variants ┆ pbo  │\n",
-       "│ ---          ┆ ---          ┆ ---          ┆ ---    ┆   ┆ ---   ┆ ---        ┆ ---        ┆ ---  │\n",
-       "│ str          ┆ str          ┆ str          ┆ f64    ┆   ┆ f64   ┆ f64        ┆ null       ┆ f64  │\n",
-       "╞══════════════╪══════════════╪══════════════╪════════╪═══╪═══════╪════════════╪════════════╪══════╡\n",
-       "│ latent_facto ┆ sae          ┆ fwd_ret_risk ┆ 1.298  ┆ … ┆ 2.732 ┆ null       ┆ null       ┆ null │\n",
-       "│ rs           ┆              ┆ _adj_5d      ┆        ┆   ┆       ┆            ┆            ┆      │\n",
-       "│ tabular_dl   ┆ tabm_m       ┆ fwd_ret_10d  ┆ 1.287  ┆ … ┆ 2.739 ┆ null       ┆ null       ┆ null │\n",
-       "│ deep_learnin ┆ lstm_h64     ┆ fwd_ret_10d  ┆ 1.264  ┆ … ┆ 2.639 ┆ null       ┆ null       ┆ null │\n",
-       "│ g            ┆              ┆              ┆        ┆   ┆       ┆            ┆            ┆      │\n",
-       "│ gbm          ┆ leaves_15_hu ┆ fwd_ret_risk ┆ 1.018  ┆ … ┆ 2.545 ┆ null       ┆ null       ┆ null │\n",
-       "│              ┆ ber          ┆ _adj_5d      ┆        ┆   ┆       ┆            ┆            ┆      │\n",
-       "│ linear       ┆ ridge_a10000 ┆ fwd_ret_risk ┆ 0.819  ┆ … ┆ 2.293 ┆ null       ┆ null       ┆ null │\n",
-       "│              ┆ 00.0         ┆ _adj_5d      ┆        ┆   ┆       ┆            ┆            ┆      │\n",
-       "└──────────────┴──────────────┴──────────────┴────────┴───┴───────┴────────────┴────────────┴──────┘"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "4c95c56e",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "family_leaders = selection_adjusted_leader_table(\n",
     "    CASE_STUDY_ID,\n",
@@ -1584,16 +961,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f28b12c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002191,
-     "end_time": "2026-09-02T01:48:36.892315+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:36.890124+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "f4392514",
+   "metadata": {},
    "source": [
     "The interval plot shows which family leaders clear zero on their own return path and which do\n",
     "not. It is a bootstrap reading only: the search adjustment that would narrow it is the one the\n",
@@ -1602,35 +971,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "93a2cf39",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:36.897264Z",
-     "iopub.status.busy": "2026-09-02T01:48:36.897183Z",
-     "iopub.status.idle": "2026-09-02T01:48:36.968630Z",
-     "shell.execute_reply": "2026-09-02T01:48:36.968267Z"
-    },
-    "papermill": {
-     "duration": 0.074605,
-     "end_time": "2026-09-02T01:48:36.969140+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:36.894535+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAGRCAYAAACex0zVAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaQVJREFUeJzt3XV0FFcbx/HvJptkk6DB3Z3grsUKFJeWoi1uheLu7lCkOKVF2yKluJdCixR3d3dLspHdff8I7EsMaBqyEH6fcziH7M7eee7M7Owz986dawgI8LchIiIiInZOjg5ARERE5H2jBElEREQkFCVIIiIiIqEoQRIREREJRQnSe867SGVqfNkq3Peu37xNupyl+H7OwjeWEy9lbjp0G/RW65wy80cy5y1LxtyfcPzk2X8T7mv9c+AoaXKUYNXaLQC07dyfeClzExQU9NZl7Pz7H+KlzM1Pi1dEWVwAFy9dJV7K3IwcPz1Ky31b8VLmplWH3g5Z94esSt3m5C1e9V9/zmz2J3uBCvQZPPYdRCWRFdn9KfIuKEGKZs3a9SBeytw8efoMgLUbtxMvZW5GjPvevkyuopWpXPvrN5aVPGliFs2dxJd1ou6Ecu3GLfoPnUDqlMkZ2r8rmTKkjbKyc3tnY9GcSZT7pFiUlSkfjy3b/yJeytxcuXbjP5dlMrmxYPYEvmnVJAoie39kzlvWYUn+vxWV+1PkXVCCFM1y58wGwOmzFwDYs+8QAPsOHAHg2XMfrl67Sa4Xy72Ok5MTxQrnwyt+vCiL78rV4JNV/c+rU79uNdzcXKOsbFdXF0oULUAsT48oK1M+Hnfu3Y/S8vLn9SZ5siRRWqYjWSwW7j945Ogw3lpU70+RqKYEKZrl9g5OfE6dPg/Ann8OkT1LRvYfPIrFYuHMi8Tp5XIA/v7+9B86gaz5y5OzcCV27NoLwJVrN4iXMjfDxky1L7thyw4++aw+yTMVpmTFLzh4+Lj9vSdPn9Gh2yDSe5emcJlaHDt5JkRsO//+h6qfNwega5/hVKnbHF8/PyZMnUvxCp+TPFNhilf43J7MQXDX0Pgpc2jVoTdpc5Skcu2vuXLtBt37jiC9d2nKVGnA1es37eVH1D02bMxU4qfKw+079+yv5S9ZjaZtu792e9psNn5asoL8JauRJkcJWnXsw9Nnz4HgJLRVh97kLFyJ1NmK07x9T54997F/dtlv68lTvAoZc3/CxGnz3rrckeOnkyVfObb+8Rd5i1elc6+hBAQE0qHbINLmKEnW/OXp2md4iHW9zf551d79hylfrREpsxTlszrNOHfhMgAPHz1m4PCJFC5Ti+SZClOx5lf2914eDyt+30DdRu1Il7MU/v4B9jJfbv9X/7Xr0h+Ax4+f0r7rANLlLEXe4lVD7CPvIpUZNGISvQeNJU2OEuz55xA2m43Z85eSr0Q1UmcrTv1m33L5yvVw63L5ynW+bNqR1NmKk69ENeb8+DM2W/Dj1xb9sop4KXOz9Y+/qFC9MamyFqN5+54EBgaGKGPk+Om07zIAgNxFP8O7SGX7exarhUnT5pG72GdkylOGX1astb934+YdGrXoTOpsxSlcphYbtuywv/dqt+bLOP45cJRi5etSt1G7MPXY8ddeylZpQIrMRShbpQF//rUPgFNnzhMvZW4mT58PwK8r1xEvZW57993Bw8eJlzI3azZss++D39ZsosaXrUiVtRi1G7bh8ZOnYdbXtnN/KlRvzJJlq8leoAITp84FYP3mPyhWvi6psxWn3tcduH3nHleu3SBBmnxYrVZGT5xBvJS52fn3P/Z6/bFzT4hj4OX+DW8db7tPILhLrHq9lvQZPJZMecqQt3hVfl+3xf7+ryvXUblOU1JnL0HOQhXt643s/hSJTkqQolmunFkBOHnmPL5+fhw+dpLqVSrw3MeXE6fPcfJMcOKU+5UWpD3/HObh48d0bPs1jx49ps/gceGWveOvvXz5dUc8PTwYPbQX+fPkJFXKZPb3V6/fSpw4sejQuglnzl0M0a0HkD1rRvp2bw9Ai6/q0a9He5wMTuzYtZfPa1ZmQK+O3L13n9Yd+9p/4ACGj51G0iSJaVK/Nrv3HaJg6RpYrFaaNqrLoSMnmPLih+N1GnxeHZvNZj+5nr94mQuXrlKzyqev/dxvazbRsftg8uf1Zlj/ruz6+x97wnj9xm18fP3o8W0r6taszPJVG5gxdxEABw4do8U3vUiRLClD+3fl0eMnb10uwL37D+nUaxhtmjegxVdfsuTX31mwdCUtvqpHuxaN8DObcXVx+Vf756XLV69Tq35rnJycGDGoOwaDga/bdMdms2GxWNh/6DhfN6xLj06tOXbiNN36jgjx+W97DCFliqRMnzQ0RAtg9qwZWThnIgvnTKR0icI4OTnRtOHn2Gw2WnbozZoN2+jUril1alSiY4/BHD560v7ZuT/9wvGTZxg9uCe5cmblx0XL6d5vJKVLFGJY/64cO36a2g3b4uvnFyIWXz8/ajVow/GTZxk2oCulihekW98RLFiyMkzM9epUpWihfCxftYENW/4M8X6dGpWoUaUCAJNG9ee70f3t7129dpO9B47QofVXODk50aP/KCwWC4GBgXzx1TccOnKCvt3bU7RQXr5q3Y1bt++G2eYvNWj+LV/U+oxeXdqEeP3k6XPUbdQOT08Pxg7vg7u7O3UateXUmfNkzZyBRAm97BcO+/YfxuTmZm8d3rv/CAaDgeKF89vL69RzKJ+WK0mVSmXZtmM3i35ZFW48J06dZdx3s+jRqTW1qlVk34EjNGjWiZTJkzJiUHeuXbtJp15DSZTQi/Ej+gJQu3pFFs6ZSPasGSOs5+vW8dKb9slLf/61jzt37zOoTyc8PNxp8U0vbt66A8DufQcpmDcXw/p3IUGC+HTuPYwr125Ean+KRDejowP42HjFj0fKFMk4deY8h46cJDAwiBpVyjNh6hz27T/CxctXcXNzJXPGtPbP5M+Tk2njhwCwZfsudu3eH27Z0+csIk7sWCz54TvixI5F4y9rhXi/ZtUKDB/QDQi+Yj53/lKI9xN4xadIwbwA5MqRlaKF8gGwauksHjx8xKEjJ8mYIS279x7kwcNHJEzgBUCNKuUZ0q8zFouFeQt+IUum9EwY2Q+r1crMeYs5E2o94UmfLjVFC+dj5ZpNtGpan41bd+LhbqJCuRKv/dysH5aQPm1qxgzpBQY4d/4yy1etZ8zQXpQvU5xynxTjzLmLuLubWLB0Jf8cOGqvv8Fg4IfpY0icKAG5c2ZlzYZtb1UugNVqZUjfTvYflDPnglv+EiX04qsGdTCZ3P71/nlp4c+/4etnZsq4QSRJnJCECbxo8KKFJl3aVKxdNpebt+5w5PgpUqVMzj8HjoRIWIsUzMvEUf0xGAwhyk3gFZ+qlcpy+OhJdu3ezzetmlAwfy4uXb7G5u276P5tK75qWAdssPiXVazZuI08ubID4OHhzsI5E4kbJ7Z9+yRJnJAJI/thMBgICAykW98RbNn+F9U/K29f5+Ztf3HpyjUmjupHk/q1aVSvJms3bmfGvMU0aVDbvtzEUf2pULYEuXJmZdO2nfZWsZcyZ0xnvx+uTOmipEmVwv5e4kQJWDx3EgaDgeMnzzB/0XLu3X/ImXMXOXHqLJPHDKR6lfKYzf4s/vV3Nm/fRZP6tQnPN62a8G27pmFe/2HhMgIDg5gwsh+ZMqQlX+4cFClbmx8WLmPM0F6UKl6IXbv3Y7PZ2HvgCJU/Lc3v67by3MeXfw4eIUe2zMSPH9deXv+eHWje5Atu37nH0mWrw3wXX/L1MzNr8gjy5/UGYMT47/FwNzF1/GBcXV3w9fWj54DRGJ2NlClZBIBMGdJRtVLZcMt7m3X8tfcA8OZ98lL8eHGZO200AG6urrT4phdbd/xN4y9rMWFkP/z8zBw6epJ8uXNw5NgpDh05Qc2qn/7r/Zk0SaK3rpNIVFCC5AC5c2bl6IkzHD1+Gq/48ciaOQO5cmTlyLFTPHj0mBxZM+HySuuDi8v/d1NCr/gEBIRt6ga4fOUaadOkJE7sWOG+72J8pZwE8blxK+Ir6ZcCAgLp2mc4S5atJkXyJPZWkadPn9sTpJflOjs7Ez9+PHu8Tk5OxI8fj4CAgPALD6VRvZp803Ugt27fZfO2XVQsXwoPd/fXfubylevcunOPtDlL2l9zdQ2O8dSZ87T4pjdnzl0kb67suBiNPH0WfHP81Ws3iR07FokSev3rcl96tZWvVrWK+PqZGT1xJhOmzqXLN81p1bR+iCTlTfvnpStXgu8DK1wmZAJ178FDEiSIT5tO/diweQcZ06fB18+Mr585xBV2bu9sYZKjl8xmf9p06kuGdKnp0y24G+ny1eCusbHfzWLsd7Psy96//9D+/3RpUtqTo5efKVG0oH09eV8kUi/vYbPX5UXZL7eVk5MTebyz8/eLH+GXXh4zCb3iA4ToGnwTo7OzPY6Xx6R/QIC9y69jj8F07DH4//V6zX06r3Zth6zHDTzcTWRMnwaALJnS4+FustevVLFCLF+1gTPnLnL85Fm6dWzJytWbOHDoGP8cPEaVimVC1vfFdyZhghf1jeA7HTqmK1dv4OPrR+a8IROgh48eR/j5txFevd92n7x6rGXJnD44nofB8cyct5gR47/HyeBEujQpgeBzx+tEtD9FopsSJAfI7Z2N9Zt3cOjIcQrmz4XBYCBfnpzs+ecQFouVQvlzRarc1ClTsOefQzx77kPsWJ5REuuvv61jwdKVbPztRwoXyMPI8dMZPXFGlJQdWo0qFejRbySr1m5mz75DzPxu+Bs/kyZ1ClxcXZg6brD9pGo0OgPQre9InJ2duHT8T2LH8gxxn0PixAl4+vQZV67eIG2alNhsb19ueAwGA43q1eTLOlX5bvp8eg4YTbYsGSlVvJB9mbfdP2lSB19NL5g9gXhx49hfz541E1Nm/Mi2P/5m/45VpE+Xmrad+7Pk19/fuJ1eGjHue86ev8ym3360t3K9vHpv1vjzEF0sKV5zA3Pa1Ck5fOwkNpsNg8HAoRfdcS9j/39dgn8UDx87Sb48ObFarRw+dtL++r/h5BR8R8DbJk8vY+nVpS3Fi/y/eyt92tT/et1pUqewt6JkzpiOM+cu4utnttejdInCQPB9bQaDgXKfFCNFsiTs3P0P167fpETRAv96neHGkSo5J06dZeGciTg7//94TJggPtf9/YHgexZfenlBc/feA4Bw74uLSmfPXQQgbZpUXLl2g54DRjOgV0c6tWvKX3sOUO2LFvZl/+3+FIluugfJAXJ7Z8NqtbJx204K5c8NQIG83pw6c55Ll6+GaJn4N5o1+Zynz57ToNm3LFm2ml4Dx9i7lCLLz88MBA/JnT5nET8s/PU/lfeq5EkTA9i7DGN5elCz2qdMmDoXJydDuN1r9s/s2Y/VaqXFV19y9dpNZs9fyqUr19ixay8+Pn4vYvfj/v2H/L5uC137DOfai5vFAfv9Dz0HjGLxr7/TrW/IZOx15YZn4PCJtO86gGW/refS5WsAIX7A4PX7J1mSRJw+d5G79x7Q4PPquJtMjJ8y50VX7AmOnzxLLE8P/PzMmP392bRtJ+OnzGHN+q1vvb337j/M1Fk/UbRQPm7fvc+aDdvYve8g6dKmomzpovy6ch3b/9zNpSvXWLV2M4kSJYiwrFZN63P33gO69B7GT4tXMGnaPNKnTU35MsVDLFe+TDHSpknJhKnz+GnJCjr3Gsa9+w9p06zBW8f9UtoXLRDfTf+BTVt3vnH5YoXzkz1LRuYvWsbufQc5f/Ey6zb9QdIkCf/1ur9uWBcXFyNd+wxn8a+/07XPCFxcjDRtVBcITqBSpkjGr7+tI3vWjHh6eJA/rze/rlwX5v6j/6JZky/w8Q0eOHHh4hV27zvIzVt3MBqNJEmUEJObG2s2bGPF7xu4c/c+mTKmA4KfbTZu8mx69B8VJXG86vGTp/QfOoGflqxgwLCJJE+amPJlitnPHYePnmTxr78zYPjEEJ/7t/tTJLopQXKAlwnQkyfPKJgvuLWoQF5vAgOD8PUz22/k/rcqlS/NzO+Gc/feA7r2HsahIyeIoKflrX1ZtxrlPynO97MXsH7zH1H63Jhqn5UnUUIvZv6wxP5awy9qcvfegwi719KnS03pEoVZs34rd+7ep06NSkwZN4iz5y/Rs/9o1m36g+c+wVfJQ/p1wcXVhYHDJ+Lq6kqlCqXt5XxatiSDen/L0eOnGTF2GtU+Kx+iVed15YanVvVKXLt+i+79RrJtx98M7NWRYoXzhVjmdfuncf3anDt/mb/3HiB9utT8tnQmbq6uDB75HbN//JmHjx5js9lo26IhhfLnZvjYaRw4fJwWX9V76+09f9FyrFYrf+3ZT6MWnWnUojPDxkzDYDAwd+poalWryMKff6P/sAlcv3n7td02XzWsw+ghPdm+cw99h4wjR/bMrFg0Pcw+8/TwYOWiGeTImpG+g8fx51/7GDO0F43rh3//1evUqvopVSuV5bfVmxg0YlK4o6pe5erqwi8LplG4QB6mz1nE8LHTuH//4Ru7eMKTI1smli34nqfPntOtz3B8fH1ZtuB7smUJvhHaYDBQukQhrly9QYEX9/IUzJeLK1dvhLn/6L8oUjAvi+dN4tHjJ/QeNJafl6+xj650dzcxekhPnjx9Ro/+ozh09AS5c2alVdP6XL5ynfWb/mD+9DERdr9GVtw4sblz7z59B48jaZJE/PzTVDw9PMiaOQMd23zN9j938/2sBbRt3jDE5/7t/hSJboaAAH/bmxcTiR4HDx+nbNWG/PLjVD4tV/LNHxARh6lStzmXLl/l5P7Njg5FJMrpHiR5LwQFBfHLynVMm7WAooXyUqHs60eviYiIvEvqYpP3wrkLl+nedwSuri7hDlEXERGJTupiExEREQlFLUgiIiIioShBcoBaTTpRr3k36rfsQY2GHZk4/SeCgoIiXda/sXbTn/QcFDzc9sHDx/QYOCHCB0++NHnWYvYfPgHA0HEzWbpiQ7jLtes+jB1/h/+Ub0d6Xcz/xf7DJ5g8a/EblytasVGEz5+JaP/NWbCcidMX/Jfw3qhWk06cvXAFgEW/rmXjtr/e6freJxVqt+LW7XuvXSai43nD1l00aduHjr1GYbFY/3MsG7f9xaJfg+cbe/X7+SGyWKwMHjOdhq17sWTF+ig7rl73HXopMtvuQ9/e8m7pJm0HGdqnA5kzpMFs9qdph/7sO3icYoXyRGsMCbziMWZwlzcu17HVv39mzcegQJ4cFMiTw9FhRImGn1dxdAgfjDUb/6RB3c+o9IZpcN5WxbLF37zQB+Leg4ds27mPLStmh5gBQORDpCPYgWw2G3fvPyQoyELK5MFPLb7/4BFjJv/A1Ru3cXV1oUeHpuTMlpE/dv3D1DlLcHZ2IkvGtAzo3oau/cdx+859mrTtQ9GCuWnb7P/PxPHx8WX89z9x8sxFDAZo37w+JYrkDbH+Z899+LROa3ZvXIjNZmPGD7+w6Y/dPH36HKvVRqoUSZg3dSh9h06mVLH8VPm0FBA80W7HXqO4deceObNlolenZri5uoYo+23Wf/zUeSZ8/xM+vn4kS5KQAd3b4BU/Lrfv3mfUpLncvfeQxIm8ePzkGR1bNSBf7uzUatKJ0QM7kzlDmhDxW61Wvp/3MwePnMTH14/sWTLSr2srnJ0jbiR98vQZNRp9y4ZfZ2Byc6XXkOBnsYwf2h2LxUqVL9vxy7zxODsZwq3Ljr/38/PKDXw/th/PfXwZOnYmZy9e4d69h8SJE4uiBXPTv1trAFat387O3Qe5duM2fbu0pHjhvHzbe1SE+w/g6vVbdBswnus375AyeRL6d2tF3Dix2f3PEX5a+js+vn5gMDCoR1vSp03J5as3GDxmBj6+fsSLG5vBvdqTLElC/tp7iBk//EpAYACZ0qehX9dWYeaKmzh9AbFjedCicR3mLFiO2T+Am7fucurcJdKnScnogZ0wGo0RHp+vKlujOQ0/r8Ke/Ud5/OQZLRrXoWLZYgCs2biDRcvWYrFYKZgvJ13bNcHJyYnKX7Sl9def89vabXRp14RcOTIDcOv2PXoOnkjxInn58+8DuLm60LtTCxb8spqjJ86RxzsLA3u0xWAwcO/BI8ZNmc/1W3cwGp1p1aQuxQsHH3PnL11j9HfzMJv9SZcmBYGvtNhGdByGZ/q8nzl55gI3b9/j1p37VK/0Cd/NXMj1m3d4+syHL2pW5IuawU8jr9WkE00b1GTNxh08ePiYbt98zcEjp9i19yAe7u6MHdwFr/hxWbpiA+cuXrEfKy+17TaMRp9Xsddh2PhZ5PXOav8eAqzbvJOVa7fiZ/bH08OdYX07kChBfGw2G0tXrOf3DX/gYjRSIE8OOrZuyNBxM8mSMS3bd/1DzqwZad/iS1Zv3MHSFevBBtkyp6NT28bE8vTg8LHTjJn8AxarhWRJEjGsbwf8/QPoN2Iq9x88wsPDRJ/OLcnyYt7IIIuFzn3HEBQURPOOAxjQvQ2rN+4gdiwPypUqQue+Y1i5IHiONT+zmdpNOrNs/gT8/MxvPKZeFVGdAe4/fEy/4VO4dPUGsT09GNijLcmSJnqr89GDh48jrJt8nNTF5iD9R0yhzlddqNe8OyWL5rdP6zBs/CxqVyvP0jljGNKrHWOm/ADAnIUraN/8S5bOGUvbpvUwGo18NzJ44tSfpo8I8+M6ZfYSvLNnYsns0Xw/th/jp81/bXfA8VPn+X3DHyyaOYrVS6bi6Wli5IBOGJ3DTq9hsVgZO6QLS2aP5vrNO6zesCPMMm9a/7PnPoyYMJuR/b/l57ljKV28AD8uDZ7RfOjYmeTLnY3Fs0czuFc7njx99sbt6eTkRJkSBZnz3WAWzRrN6XMX2fuGp4jHjRObjOlScfzUOSwWK3fvPeD2nQcEBQVx7uIVUqVISpzYnm+1LZev3kKQJYjl8ycwc+JA3E1uIX7w4seNw4zx/fm6fg3mLwmeGuR1+w+C500b2KMNS2aPxuTmyk8/rwYgedJEjBrYmZ+mj6BsyULMXbgCgBVrtpIzW0Z+mTeOwb3akySRFzdu3WXWT8uYNrYvS+eMJUWyxKxcty3MukI7cPgkPTo2Y8ms0Zy9cIUDR04BER+fr/Iz+5MhbSpmTxrEmEFdGDlpDo+fPOPIibNs2PYXP0wdxpLZY3j+3Jc/dwfPyfb4yTOu37zDD1OH2pOjly5evk5e72wsmD6CxIkSMHDU93Rs1ZBFs0axc/dBTp8Lnuh1yJgZ5M6ZhUUzRzG8b0dGTJzD9Zt3CLJY6D1kEl/U/JQFM0bQrnk9++S+rzsOw9O2WT2yZk7Ht20a0rRBTeLEjkXDulWYN2Uo34/ty9Q5S0J0Bd27/4iZEwbwRc2K9B0WfKGxcMYoPNxNrN+y67X7oF6tiqxatx0Inots74FjlClZKMQymTOkYfKoXiycMZJ0qVPw88rgruTNf+xm/ZZdzBg/gB+/Hx6ihXDZ75sZM6gz7Vt8yeFjp/lxySqmju7DwpkjcXc3MXV28INbFy1bS9WKpVk6Zyw9OjYllqcHm7b/jaeHO7/MG8f4Id1Imzq5vVyjszMThnbHw92dn6aPIGP6/0/pki5NCuLFjc2J08GTOv+97wgF8+YMTnDe4ph6mzoD+Pj68W2bRiyaOYqc2TMxZU5wXd7mO/y6usnHSS1IDjK0TwcypU/N7bsPmLNgOSMnzaFLuybsP3SCh4+e8P3cpcD/506qUbkMPyz+jee+flQsU+yN5f+5+wDHTp5j5ZrgqSisVhuPnzyNcPmEXvGwWm08e+aDwQD+/oH2uZJC886e2d5iVLxQHk6cvkDd6hXeav0JvOIBwQnZnfsP6D5wPBCcdKVLkwJfPzNHjp9hwvDuQHAS87bzyqVIloTlq7dw8sxFnj/35frNO2GW6TZgvH1eqnlTh1KkQC4OHD6Jp4c7qVMmIyjIwokzFzl28iyF8nm/9bZMmjgBf+/zwz8ggIePHod5TEGpYvkxGAzkzJbxre+Hypwxrb3uJYvm47e1wYlNyuRJ2XvgKHv2H+XU2YsEvHgCcblShRn13VzmLlxJ7arlcHJyYu/+o9y5+4BvegRPpRIQGPRWXbm5cmQmXtzgyWkzZ0jN/YeP8PUzR3h8hpY/T/DktenSpCBRgvicv3SVvfuPceXqTVp1GgSA2T+A7FnS2z/T6POq4T7ewd3dRKF8OQHImS0jnh7u9kleM6RLxb37j0iTysyhY6cZP7Tbi22UhIJ5c7DvwDHy5sqGf0AA5UsHz3afNHFC+xxlER2Hb8vFxYjJ5MbchSu5cPkaBgzcufsgxH4zGAx4Z89E3Lix8c6eCYAcWTNw7zWT5gKULJKfaXOWcvf+Q06cOk/hfDnxcDeFWCZVyqTs/PsgB46c5Pjp8/aW6D//PkCdahWIGyd4YuSX3zsIPpe8jG/X3kNUKFOU+PGC5/z7omZFWncZQq9OzfmsfElm/7QcJycnqlUKfgp9sUJ5WLPxT6bMXsIXNT8N03L8OpXLl2Drn3vImS0jW//cS9VPS/2rY+pNdQZIkzKZvTWpZNH8DBw5LXh7vMV3+L/UTWImJUgOZDAYSJYkIVUrlmbclPkA2LAxbWzfMEnB5zU+pVypwvy6ahP1WnRn3uQh9pNauGwwuFe7EFdxr5M0SUIyZ0jDgFHT8PH1o2PrhiR7izmrjEZn3EN117zN+m02GymTJ+HHaSHnQHt5cgw9j9lLBgzh3tB+994D2vcYQeN61Wj1VV2cnAxYrWGfYDFuSNcQfxcpkJspsxfj6eFOXu9sBFmCOHD4BCdOn6fJlzXeqi4QfHKdu3Al7boNx8XFyMAebcNdzmg0YuPfP1nD2dnZ3i02dNwM3FxdqV75E0oUzsvUF1fJuXNmYf60YWzc+hdfte/LoJ7tsGEjj3dWRg3o9K/XaY/Z2cjLkCM6Pl/7+RfHiA0b5T8pwretG0VQxzc3aBudQ56yjEbnENvz1QTLYDCAIfh4cX5lhvhXRXQcvq3d/xxh2tyltP6qLnWrV+Drs/2whp75mOD9HiZu8+uPA2dnJ2pXK8+6TTs5d/EKdUJdhNhsNjr2GkVe76zUrlqO7FkzsGv3QQCsNluE0wxF9N2C4G32cjuVKVmIgvlysnrDH9Rr3o2po/uSNnVyfpw+nD92/cM3PUbQsklde/fpm1T4pCgtOw2iZZO6nDp7kSG92hEQGPSvjqnX1Tk04yvfmbf5DqdJFfm6ScykLjYHCwoKYvP23eTIlgEPdxN5c2Vj9k/Bc2ZZLFZu3bmP1Wrl4NFTxI8Xh+aNa2O1WLl05ToQ3HIR3mic4kXyMnfhSgIDg7DZbNy8fTf4DQNYbWG72u7ce8Dd+w+YMb4/C2eMpFrF0mGWeenGrTtYrVae+/iybvNOe4uEAQO2F0lJhOt/IUfWjNy5+4BtO/cBwU3jjx4/JXYsT9KmSWHvfrh5+y73Hz62fy6BVzyOHD+D1WplzaY/7a+fPHMRd3cT1SqWxtPDnctX/z8xrQGwhVNngGyZ03P7zn0OHTtFvtzZyJcrO4ePneHKtVvkeNG68aa6AOzcfZB8ubPxw9ShzJo40N5S8CYR7T+A23fuExQUREBAIL+t22bfzjv3HKRu9Qpkz5KBUy+6lwCOnjiLAQPVKn1CnpxZOHjkJIXyefPPweMcO3kOgEePn+L7YhLR4P319qOwIjo+w3Ptxm0A9h08jo+vHxnSpaZ44bys27yLq9dvAXDrzv0oGQVmj807K8tWB095cePWXfYdPE6hfDlJlTIZ/v4B/HPoOABnzl/G/GLG+4iOQwh5PEdk9z9HKJAnByWL5ufR4yc8e/b61o83CvX9rFaxNNt27ePq9dvkyZklxKJPn/lw/NQ56tf5jPRpU3H67EX7e8UL5WHl2m089/EF/r8/QitROC+bt+/m8ZNn2Gw2fl21kZJFgucQPHj0FB7uJr6sXZlkSRJz4vR5Tp29iL9/cGtc2VKF2Xfw2FtXzSt+3OAEa8kqShbJh9Fo/FfHlNVqe22dAe49eISf2YzVamXZ75vt35m3OR/+l7pJzKQWJAfpP2IKLi4uBAYG4Z09E53aBF9VD+zRlnFT51O/ZU/cXF2o8mkpalQuw/ad+5g0YyHPn/tStGBucr04WdapVoFWXYZQrlRhexkA37ZuyKTpC2jYuhcmkxuF83nTvsWX5MyakR8W/caJ0xdInTKpffmECeITFGShXvPumNxc8YofF+/smWnWsGaY2AMDg2jXbRgPHj2hSoVSFC+cBwhuRVm8fB2flCgY4fpfihsnFmMHd+W7mQuZu2AFbm4utG9en/x5sjOgextGTpzDr6s2kTl96hDdCk0b1GDY+Fms37KLBnU/s3chFMibg3Wbd9KodW/SpUkR4v6BQvm9mbNgBXWqVcDV1SVEXZydnciVIzPHT52zN9VfunqD7FnS26/631QXCO76GTtlPkePn8XoYiR50kSUK1WYCp8Ufe1xENH+AzCZ3OjUZwx37z+kaMFc1KpSFoDmDWvTb8QUEidMQJECuezLn7t4hYnTF+Dr50eiBF5827oRCbziMbhXe8ZM/gEbNjzcTfT8thkZ0qaiZNF8LPhlDcP6dnhtjK8K7/isV6tSmOWWr97C6MnzMGBgZP9vMbm5ktc7Kx1a1qfn4IkYnY3EjROLgT3b2rtE/qsBPdowdvIPrNm4A6PRmT6dW9j36eBe7Zj4/QLc3FzJkTUjSRMHt46+7jh89XiOSJUKJRk37UeadRiAd/ZMpE6Z7D/V4dXvZ46sGYjl6UGGtClJmTxpmC7vOLE9+bJ2ZVp1HkSyJInImS0j9x88BuCzCiW5ffcBzTsOwGRywztbZrq2DzvRdB7vrHxVvwbtewwHG2TNnI4ubRtjsVg5eOQk381ciI+PHxnTp6ZsqULs/uco46b+iK+fH+4mEwO6tw5T5utULleSQaO/Z+bEgfbX3uaYKl28AD/9/DvftKgfYZ0B4seLQ5+hk7l15z5ZM6WleaPgSZHf5nx4596D/1Q3iXn0JG0BYP2WXRw/fZ7u33yNzWbj6ImztO8xgo3LZuDp4f7mAt6hJm370KlNI/Llzu7QOF5n+ITZFCmQi3KlCmOxWFn46xr+/PsAcycPdnRo0a5oxUZsWj7zX3XDSfgePnpC227DmD6+H17xwh9ZJyLvhlqQBAhuAdm0/W+atOuLJciCu7sbw/t1cHhy9KEoXawAC39ZzY9LVhEQGESKZIno26Wlo8OSD9j8xatYvfEPOrRsoORIxAHUgiQiIiISim7SFhEREQlFCZKIiIhIKEqQREREREJRghSNbDYbQUFB9mkORERE5P2kBCkaWSwWSlb5GovF4uhQJAoEBAQyZ8FyAgICHR2KiIhEMSVIIpEUGBj44um8SpBERGIaJUgikeRsNFKtUmmcjXqcmIhITKMzu0gkmdxc6dNZD4MUEYmJ1IIkEklm/wBGTJyN2T/A0aGIiEgUU4IkEkmWoCBWb9iBJSjI0aGIiEgUU4IkIiIiEooSJBEREZFQlCCJRJKLiwvNG9XCxcXF0aGIiEgU0yg2kUhydXWhReM6jg5DRETeAbUgiUSSn9lMpz6j8TObHR2KiIhEMSVIIpFktVjZe+AYVovV0aGIiEgUe2cJ0q3b92jYqtdrlzl45CRDx82M9DpqNekU7uvfz/uZRm168+ffB6KkPBGRD8Hzm3u5sr0H51bV58r2Hjy/udfRIYl8sGLkPUjLf9/Mhl9n4OISI6snIhLG85t7ublntP1v/0fnublnDMmL9CBW8sIOjEzkwxQtGcTTZz6Mm/oDV67fIijIwtDe3+DiYmTI2Jn4+plp0rYPU8f05fGTpwwbP4snT59ROH8uOrdtzLrNOzl74TK37zzg5JkLtGhchxqflaFlp8Hcf/CIJm378E2L+hTK7w3AgJHT8DP707zjACaP6s3mP3azfssunj33oXbVctSv8xkAi5etY83GHRiNznzbuhGr1m/n9p37NGnbh3q1K1GxbHEmz1zEgcMncXNzpWv7r8iRNQNrN/3Jleu3OHnmAsUL5SFDutSMmzofg8FAjcplaFD3s+jYpPIecHV15YfWZm5s/hqDo4ORj57NGt4DS23c3DMag5MuFiVmyFTzl2hbV7R8azw93Gn8RTUyZUjDqnXbWbxsLf26taZlkzocPHqK/t1aA9Bj4Hi6ffM1mdKnZsTEOZw4fQGAoyfOMXV0b65cv8WAkdOo8VkZhvRqR7sew/lp+ogQ6xrSuz279hy0v57XOyu1qpbD3+xPrSadqF2tPEdPnGXLjj3MnTIYJycngoIs5M+Tnc1/7LZ/bsWardy9/5CFM0dy4fJ1egycwC/zxgKwZuMOFs4YiVf8uHQbMJ42Tb+gVNF8PH7yLEzdl/2+meWrNwNgs9nezQYWh3BxMeLspNv4RERiomhJkJydnTAajXw/72eOnTwX7o+Kj68fp85eYtiLe5LM/gEUK5gbgBxZM+Lp6UHmjGl59Pjpv1p3siQJ+W3tNo6eOIPFYuXR46fs2X+UapVK424yAeDmGvZz+w8dp3ypIhgMBjKmS4W7uxtXr98G4JPiBfGKHxeACp8UZcHPq3EyGChdvECYcupWr0Dd6hUACAoKomSVr/9V/PL+8vUzM3BtOuZMHoyHu8nR4chH7sr2Hvg/Oh/mdVP8TKQuMzqcT4jI60TL5e/xU+cZPGY6+XNnp12zelht4Yz6sdnw8DDx4/fBrUK/zBtHmZKFQixidHb+V60wNpuN9j2CW4Q6tGpIimSJsVlt2Kw2DIbXd4rYbBBRv4nTKwlexbLFGDO4C3/tO0zvod+9dWzy4bNZrVy6egObVaPYxPESZKlD2JOWAa8selaXSGS8uwTJYLAnQkeOnyGPd1YK5/fm0tUb9kUSJ/Li7r2H2Gw2PD09SJ40Meu27ATgzt0Hr02G4seLg4+PLwEBgREu8+Tpc27fvU/NKmWxWa08fPwEgHy5s7N2007M/gEEBgZx9/7D4HgSenH33gMACubNwdYde7HZbFy4fA1fXz9SpUgaZh3HTp4joVc82jb7goNHTv7LjSQiEjViJS9M8iI9MMXPhMHZhCl+JpIX6Ums5IXe/GERCeOddbElTuiF0dnIvoPHKVUsP4PHTKdlp8EUL5THvox3tkw8e+5Dk7Z9GT2oEwO6t2bkxDksXraOBPHjMaJ/xwjLN5ncKFOiEA1a9eSbFvX5pETBMMvEjROLcqUK81XbvmTLkp4UyZIAULxwHk6dvchX7fri6WGieaPaJE7oRfXKZWjVeQiN61WlxmdluXjlBo1a98bNzYWhfTqEGRVns9n4+5/DjJs2n+fPfWnTtF7UbDwRkUiIlbywRqyJRBFDQIC/7hyOJi/vQdq5dj5Go0aVfOiCLBb2HzpBgbw5MDo7OzocERGJQvqVFokko7MzRQrkcnQYIiLyDmiMskgk+fj4Uq5WC3x8fB0dioiIRDElSCL/ga+vJqoVEYmJlCCJiIiIhKIESURERCQUJUgikWQymVg0cxQmk56iLSIS0yhBEokkJycDSRJ54eSkqWpFRGIaJUgikeTr60f52q3w9fVzdCgiIhLFlCCJiIiIhKIESURERCQUJUgiIiIioShBEokkDw93tqyYhYeHu6NDERGRKKYESSSSrFYbd+49xGrVfM8iIjGNEiSRSDKbzTRs3QuzWdONiIjENEqQREREREJRgiQiIiISihIkkf/Aw0PTjIiIxERGRwcg8qHy9PRg68o5jg5DRETeAbUgiURSkMXCnv1HCbJYHB2KiIhEMSVIIpHkb/anc98x+Jv9HR2KiIhEMSVIIiIiIqEoQRIREREJRQmSSCQZnJxIlzoFBid9jUREYhqNYhOJJA93E4tnj3Z0GCIi8g7o0lckkgIDg/h9/XYCA4McHYqIiEQxJUgikRQQEMDISXMJCAhwdCgiIhLFlCCJiIiIhKIESURERCQUJUgikeTk7ETh/N44OetrJCIS02gUm0gkuZtMTBrR09FhiIjIO6BLX5FICggIZM6C5QQEBDo6FBERiWJKkEQiKTAwkLkLVxIYqARJRCSmUYIkIiIiEooSJBEREZFQlCCJRJKz0Ui1SqVxNmqsg4hITKMzu0gkmdxc6dO5paPDEBGRd0AtSCKRZPYPYMTE2Zj9NdWIiEhMowRJJJIsQUGs3rADS5AmqxURiWmUIImIiIiEogRJREREJBQlSCKR5OLiQvNGtXBxcXF0KCIiEsU0ik0kklxdXWjRuI6jwxARkXdALUgikeRnNtOpz2j8zGZHhyIiIlFMCZJIJFktVvYeOIbVYnV0KCIiEsWUIImIiIiEogRJREREJBQlSCKR5OrqSu9OzXF1dXV0KCIiEsU0ik0kklxcjFSvXMbRYYiIyDugFiSRSPL1M9OgZU98/TSKTUQkplGCJBJJNquVS1dvYLNqFJuISEyjBElEREQkFCVIIiIiIqEoQRKJJDeTGxOH98DN5OboUEREJIppFJtIJBmdnSlSIJejwxARkXdALUgikeTj40u5Wi3w8fF1dCgiIhLFlCCJ/Ae+vhriLyISEylBEhEREQlFCZKIiIhIKEqQRCLJZDKxaOYoTCaTo0MREZEopgRJJJKcnAwkSeSFk5PB0aGIiEgUU4IkEkm+vn6Ur90KX18/R4ciIiJRTAmSiIiISChKkERERERCUYIkIiIiEooSJJFI8vBwZ8uKWXh4uDs6FBERiWLvfYLUrvswbt2+99plho6bybad+966zLWb/mTc1B//a2js+Hs/Q8fNjFQM8uGzWm3cufcQq9Xm6FDkI7dmwzbKVmlA8kyFKVulAWs2bHN0SCIfvPc+QRJ5X5nNZhq27oXZrOlGxHHWbNhGoxadOXjkBL5+Zg4eOUHjll2UJIn8R0ZHB/A6k2ct5tjJc3TpP5ZK5UpQq0o5xk39gSvXbxEUZGFo729InzYlAH/tPcTSFet5/OQZXdo1oUiBXMxZsBx3k4mGn1fh1u17dBswnkWzRoVYx7kLV5g8azGPnjzFK15cRg3shIe7icZt+lCtUmnWb9nF9+P64v7iYYAXL19n6LiZ2Gw2vOLHJX68ONG+XT5GidMXcHQIYdkgMCiIdDlLgR6FJA4SGBgU5jWbzUbjll1wcXmvT/EikXL34v5oWc97/e3p2KoB23ftY8LQ7iRLmgiLxUrjL6qRKUMaVq3bzuJla+nXrTUAcWPHot+EAZy7eJWegyaw4qdJb7UOr/hxGdCjDYkSxGfgqO/ZvmsfVSqU4rmvL0+fPWfelCEYDP//9Rs2fibNG9WmRJG8LF2xgXMXr7y2/GW/b2b56s1A8ElLRCQqRXRe0flG5L95rxOk0JydnTAajXw/72eOnTyHs9P/ewhzZs+EwWAgU/rU+AcE8uTp87cq0yt+XPYdPM78xb9x5vxlUqdMZn+vdtXyIZIjHx9f7j14TIkieQFIljThGxOkutUrULd6BQCCgoIoWeXrt62uvCK6rhj+DR8fX6o36sjvCyfj6enh6HDkI1W2SgMOHjkR5vX8eXKydc0iB0QkEjN8UPcgHT91nsFjppM/d3baNauH1WYNs4zBYMDFaMTNzQWAIIvltWUuXbGeVeu3U7ViaWpU/gTbK2U6OYXcPBarDT8/MxZL2PXKx8fT04OtK+coORKH6tKhRYgLOQg+D3bp0MJBEYnEDO99gpQkoRd37z8E4MjxM+Txzkrh/N5cunojxHI3b98FYO+BYyRO5IW7yUT8eHE4c+4SVquVLTv2/H9hA/ZEaP/hk1QqW5zMGdJy/tK118YSO5YHXvHjcvjYaQBOn730apFYrUqcPiZBFgt79h99YxIu8i5VrVSWBbMnkD9PTjw93MmfJycL50ykSsUyjg5N5IP23idIVSqWpt/wKcz6cRmliuXn+KlztOw0mIcPn4RY7vrNOzTr0J+Z83+lT+eWAJQpWYirN25Tv2VPEnjFs99Imy1TevYdPM6Tp8+oWaUs03/4mS79xhDrDS0BBoOB3p1bMHbqfFp2GoSv3/9HL+XNnY3VG/6IyqrLe87f7E/nvmPwN/s7OhT5yFWtVJataxZx4+wetq5ZpORIJAoYAgL8dSdfNHl5D9LOtfMxGj+o278kHD4+vpSv3YotK2apm01EJIZ571uQRERERKKbEiSRSDI4OZEudQoMTvoaiYjENOrnEYkkD3cTi2ePdnQYIiLyDujSVySSAgOD+H399nCfZCwiIh82JUgikRQQEMDISXMJCAhwdCgiIhLFlCCJiIiIhKIESURERCQUJUgikeTk7ETh/N44OetrJCIS02gUm0gkuZtMTBrR09FhiIjIO6BLX5FICggIZM6C5QQEBDo6FBERiWJKkEQiKTAwkLkLVxIYqARJRCSmUYIkIiIiEooSJBEREZFQlCCJRJKz0Ui1SqVxNmqsg4hITKMzu0gkmdxc6dO5paPDEBGRd0AtSCKRZPYPYMTE2Zj9NdWIiEhMowRJJJIsQUGs3rADS5AmqxURiWmUIImIiIiEogRJREREJBQlSCKR5OLiQvNGtXBxcXF0KCIiEsU0ik0kklxdXWjRuI6jwxARkXdALUgikeRnNtOpz2j8zGZHhyIiIlFMCZJIJFktVvYeOIbVYnV0KCIiEsWUIImIiIiEogRJREREJBQlSCKR5OrqSu9OzXF1dXV0KCIiEsU0ik0kklxcjFSvXMbRYYiIyDugFiSRSPL1M9OgZU98/TSKTUQkplGCJBJJNquVS1dvYLNqFJuISEyjBElEREQkFCVIIiIiIqEoQRKJJDeTGxOH98DN5OboUEREJIppFJtIJBmdnSlSIJejwxARkXdALUgikeTj40u5Wi3w8fF1dCgiIhLFIkyQOvUZHZ1xiHyQfH01xF9EJCaKMEGK5enBmfOXozEUERERkfdDhPcgxY8XhzZdhlIgb3acnZ3tr48a0Ck64hIRERFxmAgTpKyZ05E1c7rojEXkg2IymVg0cxQmk8nRoYiISBSLMEGqUqEUNpuNR0+e4hUvbnTGJPJBcHIykCSRF05OBkeHIiIiUSzCe5D+3neY2l91pnnHgQDcun2P7+f9HG2BibzvfH39KF+7Fb6+fo4ORUREoliECdK0OUv5YcpQYsfyBCBZ0kTsO3As2gITERERcZQIEySbzUa8uLHtfwcFBeFn1pBmERERifkivAcpW5b0rFq3HavVyoXL15i7YAW5cmSJzthEREREHCLCFqQu7Zpw6txFHj1+SoeeI4kVy4NOrRtGZ2wi7zUPD3e2rJiFh4e7o0MREZEoZggI8Lc5OoiPRVBQECWrfM3OtfMxGjUN3ofOYrFy5dpN0qRKjrOzZu0REYlJwvxKz1248rUfaN6o1jsLRuRDYjabadi6F1tWzMLT08PR4YiISBQKkyA9e+4DwMkzF/CKH5ekiRMCcO7CFZIlTRS90YmIiIg4QJgEqVObRgB802MEw/t2tHcd+JnN9Bs+JXqjExEREXGACG+cuPfgYYi/TW5u3Lx9750HJPIh8fDQNCMiIjFRhHcK58uVnd5DJvFFrYo4OzuzduMOUqdIFp2xibzXPD092LpyjqPDEBGRdyDCFqTObRuTJVNaps/7hUkzFuDp6UHfrq2iMzaR91qQxcKe/UcJslgcHYqIiEQxDfOPRhrmH7P4+PhSvnYrjWITEYmBIvyV9jObWb/lL67fvIPNZrW//m3rRtESmIiIiIijRNjF1n/ENP78ez+79hzE08Odm7fuYTDoYXgiIiIS80WY8dy6fY9JI3qSxzsLFcsWZ3Dv9ty4dSc6YxN5rxmcnEiXOgUGJ104iIjENBGe2U0mNywWK7lzZOHvfYdxMRq5ev1WdMYm8l7zcDexePZoPNw11F9EJKaJMEEqV6ow5y9eoUzJQqxat51qDb4hR9aM0RmbyHstMDCI39dvJzAwyNGhiIhIFHurUWxmsz9Xrt8iQ7pUGJ2doyOuGEmj2GIWjWITEYm5ImxB8g8I4OeVG5g6ZwkmkxupUybl2vXb0RmbiIiIiENEmCANHz+LR4+f8vfewwD4+wcy+ru50RWXiIiIiMNEmCCdvXCVNk2/wOgS3BUUL25sfP3M0RaYyPvOydmJwvm9cXLWKDYRkZgmwhthXF2MPPfxxWAI/vv4qfPRFZPIB8HdZGLSiJ6ODkNERN6BCC992zT9gm96jODevUf0GfodnfqMpk3TL6IzNpH3WkBAIHMWLCcgINDRoYiISBSLsAWpWKE8pE2dnD37j4HNRttm9UiVIml0xibyXgsMDGTuwpXUr10ZV1cXR4cjIiJR6LVjzZMnTUztquXsf+/cfYCSRfO/86BEREREHClMgtSkXV/7fUevsllt+AcERipB6jloIvVqVSRf7uyRCjIitZp04ocpQ4kXN3aUlgtw/8Ejps39mYE92kR52SIi/9WaDduYMGUOp89eIGvmDHTp0IKqlco6OiyRGCNMgtSpTaNwFzQYDGRKn/qdB/S+SJggvpIjeS1no5FqlUrjrId+SjRbs2EbjVp0tv998MgJGrfswoLZE5QkiUSRMGf2fLmyRUnBv67axC+/bSRJ4gQ8evTU/vquPYf4fu5SLFYLTRvUpFK5Ejx89IQhY2dw6859MqVPzcAebTl28iwLf12Li9HI5Ws3KZg3J13bN8EQXvNWBOUeOHySOQuW8+TpczKkS8XgXu1wcnKicZs+FC2Um5NnLtCncwtGTZpHyuRJ2HfwGHm8s9Kvaytu3b5HtwHjWTRrFGs3/cnZC5e5fecBJ89coEXjOtT4rAxPnj6n3/ApXL1+i7v3H5I+TUrGDulC8qSJo2QbStRJnL7AOyt70pSZ76xskfCEN72NzWajccsuuLgoYZcPx92L+x0dQoTeyTfp/KVr/LpqE/OmDMHV1YV23YYD8PjJM6b/8DNzJg/G6OxMm65DKV+6CJNmLKRO9QqUKJyXeYt+44+//iFB/LjcuHWH6eP6Eye2Jy2+HcTBI6fInydsN11E5SZNkpAxg7sQy9ODNl2Hcvj4GfLlysbFK9f4vOantGtWj1u373HyzAU6t21Mx9YNqdGwI3fvPQizjqMnzjF1dG+uXL/FgJHTqPFZGVau2Ur6tCmYPKoXk2YsIGP6NGGSo2W/b2b56s1A8AlMYhaLxYKzpt+RaBbRuUTnGJGo804SpENHT1GmREFix/IEIKFXPCD4WUr3HzymTZchADzz8eXxk2f8c+g4l67cYPaPywgIDKLmZ2VJED8uKZMnxSt+XAAK5s3JmfOXw02QIio3aeKE/Pn3fnbvP8Ldew+4fec+AC4uLlSrWNr++SSJEpAuTQoA0qZOzsPHT4kbO1aIdeTImhFPTw8yZ0zLo8fBLWJeXnG5cv0mgYFBPH3mE+62qFu9AnWrVwD+PxebRL93cZWiudjEUcpWacDBIyfCvJ4/T062rlnkgIhEYp4IE6S6X3fhswolqVy+JMmSJPxXhQZZLOE+dduGjfy5szGi/7dh3psxoT+eHu72vw8eORkyUKMzbm7hD6WOqNwJ3/+ExWrly1qVcTe52a+unAyGCLvqnJ2dXnsVZnR2tr9ftGBuflr6O0079CdbpnRULFMsws+JiESVLh1a0LhllxDnKoPBQJcOLRwYlUjMEuGDIqeO6YPR6EyPgRP4pucINmzdhdns/1aF5siSgX0Hj+EfEMCz5z5cuxE8yW2OrBk4fOwMl6/eAODO3eCurPy5s7N0xXoAHj5+gn9AQPD/Hz3B7B+Aj48v23f9Q75cIVuPDBiw2qwRlnvg8ElqVi5DiuSJuXTl5ltvlLe18+8D1PysLItmjqJft9Z6Fo6IRIuqlcqyYPYE8ufJiaeHO/nz5GThnIlUqVjG0aGJxBgRtiAlTZyQJvWq06Redc6cu8TwiXMYO3U+9WpW4qv61XFzdY2wUO/smShVtACN2/QhTapkJH3RAuUVLy59urSk77ApODs74Z09E907NKVz28YMnzCbhq16ETuWBwN7tAXA7O9Pz0ETuH33PnWrf2rvBnupcH5vVqzeQovGdcItt16tivQfOY2UyZOQOJFXVGyvEDJnTMu3vUexYdtfuJtMZM2UlvbNv8Rkcovydcn7x8XFheaNauHiosRYol/VSmU1Yk3kHTIEBPhH2J907sIVflu/nf2HjlPhk6JULl+SDVt3cersJcYN6fpOAzt45CSLlq1j/NBu73Q9/8XgMTP4snYlsmRMy9NnPjRq04uJw3uQIW2qcJd/eQ/SzrXzMWpouIiIyHsrwl/pZh0GEGSxUK9mRb5t1dDefdS8UW2+bNEj2gJ8n5Uqmo9xU3/EbPbHYrFQv85npE+T0tFhSTTxM5vpPeQ7Rg74FneTydHhiIhIFIqwBengkZMRPvn68ZNn7+Tp1TGdWpBiFo1iExGJucL8Sp+/eBWAOLFj2f8PYLXZWPjLaob0/kbJkYiIiMRoYRKkHoMmhrugwQClimmiWhEREYn5wiRIK34KP0ESkZBcXV3p3ak5rq8Z0SkiIh+mMAnSw8dP8IoXl9t374f7gaSJ/91DI0ViKhcXI9Ur67kzIiIxUZgEafR38xg9sDNN2vYBDMCr93Ab2LRcE3OKAPj6mWnRcSBzJg/Gw12j2EREYpIwCdKwPh0A2LR8VrQHI/IhsVmtXLp6A5vV6uhQREQkioVJkFxcQr7k4+sHr8z3o+HMIiIiEtNF+DCeX1dtYsb8XzCb/e35kcEAf61fEF2xiYiIiDhEhAnS/CWrGDekG97ZM2F0do7OmEQ+CG4mNyYO74Gb5t4TEYlxIkyQMmdIo+RI5DWMzs4UKZDL0WGIiMg7EGGC1KJxbYaOnUnh/N4hXv+sQsl3HpTIh8DHx5fqjTry+8LJujdPRCSGiTBB+nnlRg4dO81zH1+MxuBWJIPBoARJ5BW+vmZHhyAiIu9AhAnSyTMXWDZ/PG56SrCIiIh8ZJwiesM7e2YeP34WnbGIiIiIvBcibEFydnaiXfdhZMqQJsTrowZ0etcxiXwQTCYTi2aOwmTSU7RFRGKaCBOkvLmykjdX1uiMReSD4uRkIEkiL5ycDI4ORUREoliECVKVCqWiMw6RD46vrx/la7diy4pZGsUmIhLDRJggPXj4mJ9XbuD6zTtYX5lqRF1sIiIiEtNFeJN2v+FTePrch+s371CicF4SeMUjU/o0ES0uIiIiEmNEmCD5+PrR69vm5MyWiayZ09O1XRNOnD4fnbGJiIiIOESECZKbmxtm/wDy5c7G1j/34OPrx41bd6MzNpH3moeHO1tWzMLDw93RoYiISBSLMEGqXbUcN27doVTR/Bw8corKX7SjVNH80RmbyHvNarVx595DrFbbmxcWEZEPiiEgwP+tzu5Pn/kQJ7bnu44nRgsKCqJkla/ZuXY+RmOE98fLB8LHx1ej2EREYqgwLUhd+48L8ffBo6cAlByJiIjIRyNMgnTvwaMQf383c2G0BSMiIiLyPgiTIBlCPRTYptsrRCLk4aFpRkREYqIwN8L4+wdy/tI1e2YUEBDy74zpU0dvhCLvKU9PD7aunOPoMERE5B0ImyAFBNBj4IQQr73822CA5T9OjJ7IRN5zQRYL+w+doEDeHBidnR0djoiIRKEwCdLKnyY5IAyRD4+/2Z/OfcewZcUsjBrFJiISo0T4HCQRERGRj5USJBEREZFQlCCJRJLByYl0qVNgcNLXSEQkptHjnEUiycPdxOLZox0dhoiIvAO69BWJpMDAIH5fv53AwCBHhyIiIlFMCZJIJAUEBDBy0lwCAgIcHYqIiEQxJUgiIiIioShBEhEREQlFCZJIJDk5O1E4vzdOzvoaiYjENBrFJhJJ7iYTk0b0dHQYIiLyDujSVySSAgICmbNgOQEBgY4ORUREopgSJJFICgwMZO7ClQQGKkESEYlplCCJiIiIhKIESURERCQUJUgikeRsNFKtUmmcjRrrICIS0+jMLhJJJjdX+nRu6egwRETkHVALkkgkmf0DGDFxNmZ/TTUiIhLTKEESiSRLUBCrN+zAEqTJakVEYholSCIiIiKhKEESERERCUUJkkgkubi40LxRLVxcXBwdioiIRDGNYhOJJFdXF1o0ruPoMERE5B1QC5JIJPmZzXTqMxo/s9nRoYiISBRTgiQSSVaLlb0HjmG1WB0dioiIRDElSCIiIiKhKEESERERCUUJkkgkubq60rtTc1xdXR0dioiIRDGNYhOJJBcXI9Url3F0GCIi8g6oBUkkknz9zDRo2RNfP41iExGJaZQgiUSSzWrl0tUb2KwaxSYiEtMoQRIREREJRQmSiIiISChKkEQiyc3kxsThPXAzuTk6FBERiWIaxSYSSUZnZ4oUyOXoMERE5B1QC1I45ixYzqJf1zo6DHnP+fj4Uq5WC3x8fB0dijjImg3bKFulAckzFaZslQas2bDN0SGJSBRRgiTyH/j6aoj/x2rNhm00atGZg0dO4Otn5uCREzRu2UVJkkgMYQgI8Lc5OghHstlsjJ/2E3/tO8Sduw9IkjgB7m5upE2dnKfPfLh99z5NG9SkyqelWLvpT86cv8zN2/e4cOkqXdp/xd97D7Nn/xGqfFqKFo3rvHZdQUFBlKzyNTvXzsdo/Dh6NxOnL+DoEN4dGwQGBeFiNILB0cFIdAsMDMJmC3v6NBgMuLh8HN9vkdDuXtzv6BCizEf/LT568hzHTp3l1x/Gs2vPQXb8dYAUyRJx6coNJo3owZOnz2nQqheflCgIwLGT55g6pg+79x1h6NgZzJo4iBaNa1O7SWeaNqiFs3PIRrllv29m+erNAOGeTEXkwxTR91nfc5GY4aNPkLzixcHfPxB/sz+PHj+1v549SwaMRiMJvOKRMnkSrl6/BUCOrBnx9HAnS6a0JErgRdrUyQGIEycWz318iBsndojy61avQN3qFYD/tyB9TGLS1URoFouVK9dukiZV8jCJscR8Zas04OCRE2Fez58nJ1vXLHJARCISlT76s3qKZImJHcuDDr1Gsn3nP7RqErabzGh0xuQWcii30dk5zDK6cPy4ODkZSJLICycn9a99jLp0aIHBEHLfGwwGunRo4aCIRCQqffQJ0tXrt4gdy5N5U4YyeVQvkiVNBMCtO/ex2WxcvHydBw8fkypFEgdHKu8bX18/ytduha+vn6NDEQeoWqksC2ZPIH+enHh6uJM/T04WzplIlYqawFgkJvjou9iSJk7I6bOXaNCyJ66uLqRNnRyr1YazszOtOg/G189M/26tP5qbqkXk7VWtVJaqlco6OgwReQc++lFsqzfu4LmPL/VrVyYoKIi+w6dQIE8OPq/xaZSv62McxRaT+fj4Ur52K7asmIWnp4ejwxERkSj00f9Ke2fLyLhpP7J+yy78/QPImysr1SqWdnRYIiIi4kAffQtSdFILUsxis9nw9fXDw8M9zM26IiLyYfvob9IWiSyr1cadew+xWnWNISIS0yhBEokks9lMw9a9MJs13YiISEyjBElEREQkFCVIIiIiIqEoQRL5Dzw8TI4OQURE3gENpRKJJE9PD7aunOPoMERE5B1QC5JIJAVZLOzZf5Qgi8XRoYiISBRTgiQSSf5mfzr3HYO/2d/RoYiISBRTgiQiIiISihIkERERkVCUIIlEksHJiXSpU2Bw0tdIRCSm0Sg2kUjycDexePZoR4chIiLvgC59RSIpMDCI39dvJzAwyNGhiIhIFFOCJBJJAQEBjJw0l4CAAEeHIiIiUUwJkoiIiEgoSpBEREREQlGCJBJJTs5OFM7vjZOzvkYiIjGNRrGJRJK7ycSkET0dHYaIiLwDuvQViaSAgEDmLFhOQECgo0MREZEopgRJJJICAwOZu3AlgYFKkEREYholSCIiIiKhKEESERERCUUJkkgkORuNVKtUGmejxjqIiMQ0OrOLRJLJzZU+nVs6OgwREXkH1IIkEklm/wBGTJyN2V9TjYiIxDRKkEQiyRIUxOoNO7AEabJaEZGYRgmSiIiISChKkERERERCUYIkEkkuLi40b1QLFxcXR4ciIiJRTKPYRCLJ1dWFFo3rODoMERF5B9SCJBJJfmYznfqMxs9sdnQoIiISxZQgiUSS1WJl74FjWC1WR4ciIiJRTAmSiIiISChKkERERERCUYIkEkmurq707tQcV1dXR4ciIiJRTKPYRCLJxcVI9cplHB2GiIi8A2pBEokkXz8zDVr2xNdPo9hERGIaJUgikWSzWrl09QY2q0axiYjENEqQREREREJRgiQiIiISihIkkUhyM7kxcXgP3Exujg5FRESimEaxiUSS0dmZIgVyOToMERF5B9SCJBJJPj6+lKvVAh8fX0eHIiIiUUwJksh/4OurIf4iIjGREiQRERGRUJQgiYiIiISiBEkkkkwmE4tmjsJkMjk6FBERiWJKkEQiycnJQJJEXjg5GRwdioiIRDElSCKR5OvrR/narfD19XN0KCIiEsWUIImIiIiEogRJREREJBQlSCIiIiKhKEESiSQPD3e2rJiFh4e7o0MREZEopgRJJJKsVht37j3EarU5OhQREYliSpBEIslsNtOwdS/MZk03IiIS0yhBEhEREQlFCZKIiIhIKEqQRP4DDw9NMyIiEhMZHR2AyIfK09ODrSvnODoMERF5B9SCJBJJQRYLe/YfJchicXQoIiISxZQgiUSSv9mfzn3H4G/2d3QoIiISxZQgiYiIiISiBElEREQklI8mQbp1+x4NW/Xi/MWrfDdzoaPDkRjA4OREutQpMDh9NF+jD8aaDdsoW6UByTMVpmyVBqzZsM3RIYnIB+ajO7NnTJ+ab1s3cnQYEgN4uJtYPHs0Hu4a6v8+WbNhG41adObgkRP4+pk5eOQEjVt2UZIkIv/KRzfM/+CRkyxato7xQ7sxZ8FybDY4cfo85y5epU/nFhQvnBdfPzMjJ87h7IUrJEuSkCG9v8HD3Y1x037k7PnLPPfxo9e3zciXOztzFizH1dWFnbsP8UXNT6nwSVGH1Ctx+gIOWe/Hzmq14qQWpPdKYGBQmNdsNhuNW3bBxeWjO+XJR+buxf2ODiHG+OjPFqfPXWTs4K78ufsAS1dsoHjhvPy4ZBW5cmRmaJ9vWLd5J7+t20qTetWp9VlZsmRKx74Dx5i7cCX5cmcHYP2WXfwwZSgmk1uY8pf9vpnlqzcDwSdpiUFsYLFYcTI4gcHRwchLEX3P9P0TkX/jo0+Q8uXKjouLkcwZ0vDw8RMA9h08jr9/AKs3/IHFYqVwfm8A4sSJzdyFKzh55iK37963l/FZ+ZLhJkcAdatXoG71CgAEBQVRssrX76QeumqIfj4+vpSv3YotK2bh6enh6HDkhbJVGnDwyIkwr+fPk5OtaxY5ICIR+RB99AnSS0ZnZ3hxgWmz2Rja9xsypE1lf//m7bt07T+Otk3rUfXT0rTpNtT+nrpYRN4fXTq0oHHLLiFajAwGA106tHBgVCLyofl4ftkNBqw261stWjBvTpau2IDVasXH14+nz3w4fe4yqVMmo1Sx/Fy9cesdBysfAidnJwrn98bJ+eP5Gn0IqlYqy4LZE8ifJyeeHu7kz5OThXMmUqViGUeHJiIfkI+mBSlxQi+MzkaCLG9Okr5uUIPR382jQateeLib6N7ha/Lnzs7KNVtp1qE/xQvnw90t/C41+Xi4m0xMGtHT0WFIOKpWKkvVSmUdHYaIfMAMAQH+unMxmry8B2nn2vkYjR9NbhpjBQQE8tPPv9OkXnVcXV0cHY6IiEQh9Q2IRFJgYCBzF64kMDDQ0aGIiEgUU4IkIiIiEooSJBEREZFQlCCJRJKz0Ui1SqVx1v1kIiIxjs7sIpFkcnOlT+eWjg5DRETeAbUgiUSS2T+AERNnY/YPcHQoIiISxZQgiUSSJSiI1Rt2YAkKOzmqiIh82JQgiYiIiISie5Ci0cu5oYLU4hAjvNyPQUFB2qciIjGAs7MzBoMB0JO0o5XZbKZMDU2YKSIi8j56daYLJUjRyGq1EhAQECJD/dA1atObhTNGOjoMh1H9P976f8x1B9Vf9Y+Z9X/191ldbNHIyckJk8nk6DCilMFg+KjnlVP9P976f8x1B9Vf9Y/59ddN2iIiIiKhKEGS/6ROtQqODsGhVP+Pt/4fc91B9Vf9Y379dQ+SiIiISChqQRIREREJRQmSiIiISChKkERERERCidlj9CRKPX7yjP4jpvLw0RMqVyhBo8+rhnj/1u17fNmyB2lSJgOgXOkifPVldUeEGuV+W7eNX1dtIpanB0N7tydxogT2967fvMOg0d/jZ/an8RdVqVSuhAMjfTdeV/+h42Zy6OhpYnm6AzB1TF/ixPZ0VKjvxJIV61n861q+rF2Zhp9XCfHex7D/X1f/mL7/nz7zYdR3c7l2/TZx48RiSO/2eMWPa38/pu//N9U/Ju9/JUjy1uYtWknp4gWo+VkZvmrfj1JF85P6RTL0UvbM6Zk+vr+DInw3Hj56woKfV7No5ih27jnItLk/M7hXO/v7381cSNMGNcmTMwuN2vSmRJF8xPL0cGDEUetN9Qfo06UFBfLkcFCE714+76ycv3g13Pdi+v6H19cfYvb+P37qHJ/X+JS83lmZMnsxi5atpUPLBvb3Y/r+f1P9Iebuf3WxyVv7e99h8nhnxWg04p0tE7v/ORJmmbhxYzsgsndr74FjZM6QFpPJjTzeWdn9z2H7exaLlT37j5InZxY8PT1InTIZB4+cclyw78Dr6v9SvDgxb7+/KkumdCRLkjDM6x/D/oeI6/9STN7/xQrlIa93VgC8s2fi3v1H9vc+hv3/uvq/FFP3v1qQ5K09fPSElMmTAJA6ZTLuP3gcZpnzF6/S9Jv+eHq60639V6RNnSKao4x6Dx4+JnXKpAAk9IqHxWrF7B+Ayc2VJ8+eES9ObDxfXDEGb5ewJ5AP2evq/9KU2Yu5c+8hn5YpStMGNWPMVDpv8jHs/7fxsez/A4dPkitHZvvfH9v+D13/l2Lq/leCJOGav3gVu/eHbCHyM/uDLfixWVabFYNTyC9B4kQJ6N+9DdkypWPpyvWMmfID34/tF20xvzMGsNn+/7gwm9XGy++/AQPWV96z2mxhtssH7zX1B2hSrxoeHu5YLBbadx9OnpxZyJc7uwMCjX4fxf5/g49l/1+4fI1/Dp3gm5b17a99TPs/vPpDzN7/SpAkXF83qMHXDWqEeO3zpl25fvMOGdOn5tr122RMnzrE+87OTuR+cXVRo3JZfl65MdrifZcSJYjP8VPnAbj34BEuLi64uQa3nsSNE4tnz3147uNLLE8Prl2/TZECuRwZbpR7Xf0B0qRKbv9/8cJ5uXztVow5Qb7Jx7D/3+Rj2P+PHj9l4KjvGda3Q4hj/2PZ/xHVH2L2/tc9SPLWihfOy6FjpwkKCuL4qfMULZibR4+f0rX/OIIsFjb/sZsHDx9js9nYufsAWTOldXTIUaJQPm/OXbiC2ezPoaOnKVYoD4t+Xcum7X/j5ORE0YK5OXTsNM99fLl24xb5cmVzdMhR6nX1f/T4KRu3/Y3NZuPxk2ccOXGGLBnTOjrkd+5j2v/h+Zj2f0BAIH2GfkfLJnXImC4V8HHt/9fVP6bvf7UgyVtr2qAm/UdM5be126hasRQpkyfh1p37XLl2k6DAIBInSkC/EVN58PAxCbziMaBba0eHHCXix4vD1w1q0vzbgcT29GBo3w4s+Hm1vZ+9U+tGDBg1jRk//ELbZvXw9HB3cMRR63X19/AwcfrcRZYsX8fjJ8+oV6siObJmcHTIUereg0d07TeWB4+e4GQwsHv/EdKnSfnR7P/X1f9j2P8LflnDmfOX+XHJKuYuWAFA9iwZPpr9/7r6x/T9r7nYREREREJRF5uIiIhIKEqQREREREJRgiQiIiISihIkERERkVCUIImIiIiEogRJREREJBQlSCIiIiKhKEESEXGAbTv3ceL0eUeHIdFo+erN3Lx919FhyFtSgiTywvotuyhWqTGXr95wyPrXbvqTnoMmAvDg4WN6DJxAQEDgfy6356CJrN30538up1aTTpy9cAUInmpg47a/wl1u4vQFzFmw/I3ltes+jFu379n/HjxmOhcuX/vPcQKY/QMYNn4Wdb/uQuM2fRg+YTZPnj4DQtbDUSwWK0uWryNt6hRYLFbGTvmBul934ev2/dh/+IR9uXbdh1Hnq840aduHJm37sPXPvQDM+nEZtZt0pmv/cfZjJCAgkH7Dp2C1WsNdZ9GKjXj23CfM67du36NC7VaRrsvBIydp0rbPG5f7r+uJqMx23Ye9cbmh42Zy8MjJKF13aPsPn6B1lyE0btOHZh36s+WPPUDI73WGtKlY8POadxqHRB1NNSLywuY/dlO98ids2r6bVl/VdWgsCbziMWZwF4fG8DoNP68S5WUO7NE2yspaunw9z318+XnuOJycDPy5+wCuri5RVv5/tXPPAbyzZcLTw53fN/zB1eu3WTxrNLfu3KNV5yEsmz+e2LE8AejfrTV5vLPaP3v33gMOHT3FL/PGMuvHZfzx1z98WqYYv6zaSO1q5XFy0nVvdDty/AwjJ85h/NDupE2dnKfPfDh/MWwSnjtnFqbN/ZmHj57gFT+uAyKVf0MJkgjw+MkzLl+9Sac2jejafxwtm9TBYDBw8MhJFv66llQpkrD/0EkwwNjBXUieNDFrN/3JoWOnsdlsHDt5jnhxYzNuSDfixPZk6LiZZEqfhi9rVwKgSds+dGrTiHy5s7Nu805Wrt2Kn9kfTw93hvXtQKIE8UPE8+y5D5/Wac3ujQs5cuIs46fOB+DBoyckShCf+dOGceXaTcZM/oEHj54QJ7Yn/bq2InXKZDx95sOYyfM4d/EqSRMn4P7Dx2Hq26zDANo2+4KCeXMCMGzcTHJ7Z6VYwdx8N3Mh12/e4ekzH76oWZEvalYM8/mJ0xcQO5YHLRrXwT8ggEnTF3LgyEkSJohHYKCFwvmDyz1x+jwz5y/j8dNnBAYG0qNjM/J6Z2XouJkcO3mOLv3Hkj1LBvp3ax1iG9178IhxU+Zz/dYdjEZnWjWpS/HCeYHgFqAWjWuzdtOfXLx8nXbN6lG9cpkQ8fn6+fHcxxeLxYKzswulixUI8f7O3QeZPHMR5y9dpW3TetT4rAx+ZjPfzVjE2QtXePbch0+KF6R9iy+B4JacyuVL8vv67ZQvXYRYnh7s+Gs/RhcjV6/fIranBwO6tyFZ0kT4+Pgy/vufOHnmIgYDtG9enxJF8oZY/5HjZyiUzxuAM+cuUaRALlxdXUiTKjkZ0qVkz/6jVPikKADx4sYJ8dm79x+ROWMajEYj2bNm4Or1Wzx6/JTLV27Q6POq4Rzd//fT0tUcOnaKJ0+f06JxbSqWLR5mmctXbzJu2nwePX6Kh7s737ZuSM5sGQE4eeYCk2cu4rmvX/C8fH2+CRnbvQe07zGCYX07hDtpqcViYfLMRRw+fho/sz+d2zahUL7gY2X1xh0sXbEebJAtczo6tW1MLE8PbDYbPy79nc3bd2Oz2ShSIBdtm9XjwaPHdOg1koePntCkbR+aNaxF2tTJGTxmBj6+fsSLG5vBvdrz29qtbN+5jyPHz5AiWWK+G9krzP4sUiAXU+cs4d79R/j4+tGm6ReUK1UYgLI1mtPw8yrs2X+Ux0+e0aJxHSqWLRaiXnMWrKDVV5+TNnXwzPZxYnuGO6O9wWAgT84snDxzMcwxIe8fXWqIEHw/SP482UmVIik2m43T5y7Z3zt+6hyfVSjFghkjSJ0iGavWbbe/d+DISZo3qsXiWaMICrKwbefeN64rc4Y0TB7Vi4UzRpIudQp+XrnhtcvnzpGZn6aPYObEAcTy9KBr+68IsljoP2Iqnds2ZumcMTRrWIups5cAMHnmQuLEjsWS2aMZNbATJje3MGVWLl+CbX/uAyAwMIg9B45SpkRB4sSORcO6VZg3ZSjfj+3L1DlLwu2WedXCX9Zw78EjFs0cxeSRvfCK//8f9IRe8enXtSU/fT+cr+vXZMqsxUBwq0jCBPGZMLQ7/cOZ1HjImBnkzpmFRTNHMbxvR0ZMnMP1m3fs79++c59pY/rSt0tLZv8Utjuvfp3PMGCgbtMu/Lj0d3x8/UItYWPK6N707dLS3h1ocnOjasXSzJ08mJ+mD2fV+m1cuvL/7ta1G3cwbUxf6tUKTnqv3rhNpzaNWDhjJDmyZWTqnODtP2X2EryzZ2LJ7NF8P7Yf46fNx2IJ2e119fotUiRLDECqFMnYe+AYQRYLl6/e4M7dB9y+c9++7HczF/Jlix4MGTuDJ0+fkzxpIo6dPM+z5z7s2X+U1CmTMX/JbzT6ohrT5/1Mv+FT2HfgWLj7Kke2DMz5bjBjBnVhxMQ5PH7yLMT7QRYLPQdPoE7V8iyaOYpObRrSa8hEnj334dlzH3oMmkCzRrVZOGMkw/t1JIFXPPtnzWZ/eg35jm9a1o9wRvfAoCDKlirMvClD6dCyAUPGTifIYuHwsdP8uGQVU0f3YeHMkbi7m+zH88Ztf7Frz0HmTB7ET9OHc+P2XRYtW0vSxAnp07kFWTOn46fpI/ikREFWrNlKzmwZ+WXeOAb3ak+SRF60bVaPrJnT0adzC74b2Svc/Rkvbhy+aVGf+dOG0b9ba8ZP/RGbLXiaUj+zPxnSpmL2pEGMGdSFkZPCbrdzF6/gnT1juHUOLXmyRFy9fuutlhXHUoIkQnD3WrGCuTEYDBQrlIfN23fb30uaOCFZMqbFycmJHNky8OCVFpnM6dOQPGlijEYj2bKkD/FeRFKlTMpfew4z+rt5HD99PsQP/+tMnb2EMiUK4p09E9dv3ObKtVsMGTuDJm37MG3OUh69OGn/ve8I9etUxsnJCXeTiYSv/Ii9VL50EXbtPUSQxcK+g8fInSMLsTw9cHExYjK5MXfhSibNXIQBA3fuPnhtXH/tPcwXNSvi4mLEaDSSNHFC+3uJE3lx/dZdJs9azJqNO96qrr5+Zg4dO03d6hUASJk8CQXz5gjxo1+yaH4MBgM5s2UKt4Usfrw4TB7ViwHd23Dk+Bnqt+zB+UvXXvt5g8FAogTxWbRsLSMnzgHg+s3b9s98UatSiG66NCmTkTihl728E6cvAPDn7gMsW7WZr9r15dveo7BabTx+8jREfDdv3yNxogQA1KxSlkQJ4/N1+34sXbmBLJnSETt2cPda5zaN6dulJdPH9SMwMIhZP/6KV/y4VCpXnFadB2OxWEmZLAnOTs5cu3ELJycnBnRvw+wFy8O9Fyn/i1aNdGlSkDihF+cvXQ3x/rXrtzGbAyhTshAAObJmJEWyJBw/dZ7jp86TPGlie4uPV/y49hntbTYYPmE2cePEsrfWrVq33X7v1B+7/gGCk9CXrVEF8+bkuY8fd+4+YNfeQ1QoU5T48eJgMBj4omZF/tx9AAhu7ateuQzuJhNGo5E61Sqwc/fBMHUDKFeqMPsPn2DuwpWY3Fxf29346v6MGycWZrM/0+f9zKJf1/LoyVN8X0mq8+f5/3ZLlCB+mO32chu8jSSJEnDj1tt958Wx1MUmH7279x5w7OQ5njx5xg+Lf8PXz0xAYCDftKwfZlmjs5GIzoNGZ2f7VacBCLIEhVnGZrPRsdco8npnpXbVcmTPmoFdEZzsX7Vn/1GOnTrP3O8GvygHTCY35k8bFuZHIMgShNHZ+bXlxY8Xh6yZ0nLwyCm27dxHpXLBXS27/znCtLlLaf1VXepWr8DXZ/thfcOZP8hiwegc/g/RrB+XcfHKdb6sXZnqlT6hZadBb6zrSy9/fO3/f+Xvl4zGiOtpMBgokCcHBfLkYPCY6fy+fjtd2jWJ8PNnL1yh3/AptGpSl8rlSnD/4dQQdXeOoI4QvO9NphctdTYY3KsdGdOnjnD5+PHi8OTJM0yJE2Bycw3RitaswwBSJU8KQKYMaeyvf1q2GIt+Cb7B99WuzwEjp9G1fRN+W7edbJnT4+rqgle8uDx+8uy197kYjc64m8K2Lob2cqtbrdYQ++RVFy5fI1uWdFy9cYsjx8+QO2cWanxWhhqf/b/r89Ub8iF4exowhBuDwWCIcF0RHApA8D0+86cNY+PWv/iqfV8G9WxHvlzZwl321f25at121m/ZSdOGtfiqfg3K1WwR4XEf3nbLmC41x06etbcKvs6b9ou8P9SCJB+9LTv2UrpYfhbPHs1P00fw89xx2Gxw+PiZSJeZwCsex06ew2KxcvDoKW7cCh7a+/SZD8dPnaN+nc9InzYVp89e/P+HDGC1hb3qf/L0OWOn/MCA7m1wcQm+pkmVMinx4sZi6YoN2Gw2AgICuXv/IQB5cmZl9cYdADx6/JSrN8Jvzq9UrgTbdu7l2MlzFCmQGwhOkArkyUHJovl59PgJz579v3vNgAFbOK0Seb2zsGbTn1itVvzMZs69cnPqzj0HqVKhFHm9s3L2wuUQn0uaOCG37twjNA93E3m9s7Js9WYAbty6y76Dx+0tF29is9mY+eOv9hFx/gEB3H/wmJTJk7z2cwcOnyBdmhSU/6QIFqv1jS1n9x48wtfPjNVqZdnvmylWMHgbFi+Sl7kLVxIYGITNZgt3WHfqlMm4+aLuvn5m+8jJXXsO4e8fQB7vrJw5f5ldew5hs9nwM5vZ9udevLNnDlHO7n+OkDVTOuLGiU3ihF4cP3UOs38A127ctt/k/aprN4JbxPYdPI6vr5kM6VKDwWA/7lKlTIrJ5MoffwW3+Jw4fYEbt+6SM1tGcmbLyNXrtzh07DQAd+8/xM9sBoL3ZY8OTen+TVNGfTcX/4CAcLdZQGAgt+8Gdx+u2biDtKmTEz9eHEoUzsvm7bt5/OQZNpuNX1dtpGSRfACULJqP1Rv+wGz2J8hiYfnqLZR48V7SJAm5e++hvQvz6ImzGDBQrdIn5MmZxT5yLfhYux9ORMF27T1ImZKFKJzfmwuXwo6kfHW7+fj6BW+3VzRrWJNZPy7nyrWbAPj4+vHrqk32C6ZX3bpzj1QpkkYYi7w/1IIkH73Nf4Qctebs7ETlcsXZvH03FT4pEqkya3xWhu4DJlCveTc+KVGQAnlzAME3b35ZuzKtOg8iWZJE5MyWkfsPHgOQM2tGflj0GydOXyB1yv+fQH9csopHj58yZMx0AJycnJg/bRijB3Zh3LT5rN74B66uLjT+ohrlSxehc7smDB03g4atepEyRRJ7a0RoJYrkZdzU+ZQtWcieeFWpUJJx036kWYcBeGfPROqUyezLlyyajwW/rGFY3w4hymnWsDbDx8+ifsueJE+aiGRJEtnfa/R5Fab/8DNLV66ndLECIa7aa35Wlv4jp5EvV7YwN/sO6NGGsZN/YM3GHRiNzvTp3OKNCc5LBoOBQvm8mfj9Ah49eYrZ7E+JIvmoXbXcaz9XpmQh/tp7mCbt+pI5QxrSpUn52uX9AwLoM/Q7bt99QNZMaWneuDYA37ZuyKTpC2jYuhcmkxuF83nbb/Z+KWO61Jw+d4m83lm5c/cBo76ba7+xeNTATjg7O5E4oRfLft/MnAXLefT4KYXye9O8US17GUEWCyvWbGF4347B8ZcoyPotu6jfojsN6lax79OXYsfyYMPWvxgz+QcARvTviMnNlSSJvEidIhm/rtrE5zU+DT6ups5n9k/L8XA3MXJAJ3uyNbL/t0yetYiAwCDixY1Nz47NAIjl6Y7RaCRntozk9c7GD4t+o03TL8Jss6SJEzDrx2Wcv3gVD3cTg3u1C75x2TsrX9WvQfsew8EGWTOno0vbxgBULFuc23cf0KzDgOB9mz8nDesGj6JMnjQxGdKmol7zbjRrWAs/s5mJ0xfg6+dHogRefNu6EQBVKpRi0OjvWbd5J9+N6hUmrrrVP2XanCVs/XMvhfLlJMmL7s+Xlq/ewujJ8zBgYGT/bzG5uYZ4P1/u7HTv8DWDx8wgIDAQVxcX6tepHG4r2JlzlylTolCY1+X9YwgI8H/LnlMREYHgZ9v8+fcBRg/qHKnPP/fx5dveo5k9aaCG5b/nilZsxKblM8Ntkfu3bt2+x+jJ85g0omcURCbvmr6ZIiLRLJanB4Xze3Pw6ClHhyLRaPXGHTT+opqjw5C3pBYkEREHCAwMwmh0jvBmZIl5tM8/LEqQREREREJRF5uIiIhIKEqQREREREL5H5iQoxg1friYAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 583.3x400 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "10d6a5a9",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "leader_plot = family_leaders.sort(\"sharpe\")\n",
     "leader_labels = [family.replace(\"_\", \" \") for family in leader_plot[\"family\"]]\n",
@@ -1665,16 +1009,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf8adb22",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002315,
-     "end_time": "2026-09-02T01:48:36.974061+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:36.971746+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "2332fc04",
+   "metadata": {},
    "source": [
     "### Downstream Preview\n",
     "\n",
@@ -1688,55 +1024,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "db33df07",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-02T01:48:36.979492Z",
-     "iopub.status.busy": "2026-09-02T01:48:36.979405Z",
-     "iopub.status.idle": "2026-09-02T01:48:36.984959Z",
-     "shell.execute_reply": "2026-09-02T01:48:36.984580Z"
-    },
-    "papermill": {
-     "duration": 0.008841,
-     "end_time": "2026-09-02T01:48:36.985307+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:36.976466+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (4, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>pipeline_layer</th><th>sharpe</th><th>cagr</th><th>max_drawdown</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;equal-weight baseline&quot;</td><td>1.298</td><td>0.398</td><td>-0.331</td></tr><tr><td>&quot;allocation&quot;</td><td>1.3</td><td>0.399</td><td>-0.331</td></tr><tr><td>&quot;risk overlay&quot;</td><td>2.691</td><td>0.486</td><td>-0.065</td></tr><tr><td>&quot;cost sensitivity&quot;</td><td>3.095</td><td>0.577</td><td>-0.064</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (4, 4)\n",
-       "┌───────────────────────┬────────┬───────┬──────────────┐\n",
-       "│ pipeline_layer        ┆ sharpe ┆ cagr  ┆ max_drawdown │\n",
-       "│ ---                   ┆ ---    ┆ ---   ┆ ---          │\n",
-       "│ str                   ┆ f64    ┆ f64   ┆ f64          │\n",
-       "╞═══════════════════════╪════════╪═══════╪══════════════╡\n",
-       "│ equal-weight baseline ┆ 1.298  ┆ 0.398 ┆ -0.331       │\n",
-       "│ allocation            ┆ 1.3    ┆ 0.399 ┆ -0.331       │\n",
-       "│ risk overlay          ┆ 2.691  ┆ 0.486 ┆ -0.065       │\n",
-       "│ cost sensitivity      ┆ 3.095  ┆ 0.577 ┆ -0.064       │\n",
-       "└───────────────────────┴────────┴───────┴──────────────┘"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "6456ef56",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "stage_labels = {\n",
     "    \"signal\": \"equal-weight baseline\",\n",
@@ -1758,16 +1049,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "732fd008",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002269,
-     "end_time": "2026-09-02T01:48:36.989995+00:00",
-     "exception": false,
-     "start_time": "2026-09-02T01:48:36.987726+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "3f55a67c",
+   "metadata": {},
    "source": [
     "## Key Takeaways\n",
     "\n",
@@ -1809,37 +1092,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  },
-  "ml4t_provenance": {
-   "executed_at": "2026-09-02T01:48:43.507675+00:00",
-   "executor": "local-uv",
-   "parameters": {},
-   "production": true,
-   "source_py_blob": "298f3f5a5d57cf44bf300ee9526b782f80e9d56c"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 23.510176,
-   "end_time": "2026-09-02T01:48:38.408466+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/14_backtest.ipynb",
-   "output_path": "~/ml4t/public-s6-seoa-labels/case_studies/sp500_equity_option_analytics/.14_backtest.papermill.2543583.ipynb",
-   "parameters": {},
-   "start_time": "2026-09-02T01:48:14.898290+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_equity_option_analytics/14_backtest.py
+++ b/case_studies/sp500_equity_option_analytics/14_backtest.py
@@ -59,6 +59,7 @@ from case_studies.research import (
     open_sweep_attempt,
     population_supersedes,
     predictions_identity,
+    published_population_names_at,
     sweep_plan_name,
 )
 from case_studies.utils.backtest_explorer import BacktestExplorer
@@ -245,6 +246,10 @@ _members, _population_notes = prediction_members_in_force(_study)
 for _note in _population_notes:
     print(_note)
 CURRENT_MEMBERS = _members
+# Kept for the refusal below, which has to name what scoped the read. `_population_notes`
+# reports gaps in coverage, not which populations are in force, and by the time the
+# baseline read comes back empty the only thing that explains it is the names.
+CURRENT_POPULATIONS = sorted(published_population_names_at(_study.root))
 if CURRENT_MEMBERS is not None:
     print(f"{len(CURRENT_MEMBERS):,} prediction sets in the populations in force")
 
@@ -531,6 +536,26 @@ all_baselines = explorer.best(
     top_n=9999,
     prediction_hashes=sorted(CURRENT_MEMBERS) if CURRENT_MEMBERS is not None else None,
 )
+
+# An empty read here is a statement about the registry, not a result to summarise. The
+# division below is the first thing to touch it, so without this the failure arrives as
+# `ZeroDivisionError: division by zero` and reads like a defect in the analysis - which is
+# how ml4t/agent-workspace#1086 presented. The population is in force and its members are
+# registered; what none of them has is a backtest, and only the counts say so.
+if CURRENT_MEMBERS is not None and all_baselines.is_empty():
+    _signal_rows = explorer.specs("signal").height
+    raise RuntimeError(
+        f"The populations in force publish {len(CURRENT_MEMBERS):,} prediction sets and not "
+        f"one of them carries a signal backtest, so there is no baseline to rank. "
+        f"Populations: {', '.join(CURRENT_POPULATIONS) or '(none named)'}. "
+        f"The registry holds {_signal_rows:,} signal backtest(s), all against prediction "
+        f"sets outside the populations, so this is a population and a set of backtests "
+        f"describing different generations rather than an empty registry. A fixture "
+        f"generated through a stage earlier than the backtest stage produces exactly this: "
+        f"the model notebooks declare the population and nothing goes on to backtest its "
+        f"members (ml4t/agent-workspace#1086)."
+    )
+
 search_context = {
     "total": len(all_baselines),
     "median_sharpe": all_baselines["sharpe"].median(),

--- a/tests/test_seoa_baseline_read_refuses.py
+++ b/tests/test_seoa_baseline_read_refuses.py
@@ -1,0 +1,118 @@
+"""An empty population-scoped baseline read must say what is wrong, not divide by zero.
+
+`sp500_equity_option_analytics/14_backtest` scopes its baseline read by the prediction
+sets the registry's populations publish. When that read comes back empty the next thing
+to touch it is
+
+    100 * all_baselines.filter(pl.col("sharpe") > 0).height / len(all_baselines)
+
+so the run failed as `ZeroDivisionError: division by zero`, which reads like a defect in
+the analysis. It was not: the populations were in force with 30 registered members, none
+of which carried a signal backtest, because the fixture had been generated through stage
+08 and nothing backtests a population the model notebooks declare at stage 06 and 07
+(ml4t/agent-workspace#1086).
+
+The refusal is lifted out of the notebook and executed here, rather than restated, so this
+cannot pass against a notebook that no longer carries it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+NOTEBOOK = (
+    Path(__file__).parent.parent
+    / "case_studies"
+    / "sp500_equity_option_analytics"
+    / "14_backtest.py"
+)
+GUARD_TEST = "CURRENT_MEMBERS is not None and all_baselines.is_empty()"
+
+
+def _lift_guard(source: str) -> str:
+    """The notebook's own refusal block, as source, found by what it tests."""
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.If) and ast.unparse(node.test) == GUARD_TEST:
+            return ast.unparse(node)
+    raise AssertionError(
+        f"no top-level `if {GUARD_TEST}:` in {NOTEBOOK.name}; the baseline read is "
+        f"unguarded and an empty population-scoped read will divide by zero"
+    )
+
+
+class _Explorer:
+    """Only what the refusal uses: the count of signal rows in the registry."""
+
+    def __init__(self, signal_rows: int) -> None:
+        self._rows = signal_rows
+
+    def specs(self, stages):  # noqa: ARG002 - the guard passes "signal"
+        return pl.DataFrame(
+            {"backtest_hash": [f"b{i}" for i in range(self._rows)]},
+            schema={"backtest_hash": pl.Utf8},
+        )
+
+
+def _run_guard(*, members, baselines_height: int, signal_rows: int, populations):
+    namespace = {
+        "CURRENT_MEMBERS": members,
+        "CURRENT_POPULATIONS": populations,
+        "all_baselines": pl.DataFrame(
+            {"sharpe": [0.1] * baselines_height}, schema={"sharpe": pl.Float64}
+        ),
+        "explorer": _Explorer(signal_rows),
+        "pl": pl,
+    }
+    exec(_lift_guard(NOTEBOOK.read_text()), namespace)  # noqa: S102
+
+
+def test_the_notebook_carries_the_guard():
+    """Fails on the pre-fix notebook, where no such block exists."""
+    assert GUARD_TEST in _lift_guard(NOTEBOOK.read_text())
+
+
+def test_a_population_whose_members_have_no_backtest_is_refused():
+    with pytest.raises(RuntimeError) as excinfo:
+        _run_guard(
+            members=frozenset(f"m{i}" for i in range(30)),
+            baselines_height=0,
+            signal_rows=52,
+            populations=["seoa-gbm-validation-v1", "seoa-linear-validation-v1"],
+        )
+    message = str(excinfo.value)
+    # What the next reader needs: the scope, its size, and that the registry is not empty.
+    assert "30" in message, message
+    assert "52" in message, message
+    assert "seoa-gbm-validation-v1" in message, message
+    assert "seoa-linear-validation-v1" in message, message
+
+
+def test_the_refusal_does_not_degrade_to_a_pass():
+    """An empty scoped read must stop the notebook, not be summarised as a result."""
+    with pytest.raises(RuntimeError):
+        _run_guard(
+            members=frozenset({"m0"}),
+            baselines_height=0,
+            signal_rows=1,
+            populations=["p"],
+        )
+
+
+def test_a_populated_read_is_not_refused():
+    """The premise: the guard fires on emptiness, not on the population existing."""
+    _run_guard(
+        members=frozenset({"m0"}),
+        baselines_height=3,
+        signal_rows=52,
+        populations=["p"],
+    )
+
+
+def test_an_unscoped_read_is_not_refused():
+    """No populations means no filter, which is a fixture or a clean clone, not a fault."""
+    _run_guard(members=None, baselines_height=0, signal_rows=52, populations=[])


### PR DESCRIPTION
> **This PR does not turn `cs-sp500_equity_option_analytics` green, and it is not
> meant to.** That job is going red on its next run because of a test-data change
> (ml4t/agent-workspace#1086), whoever merges this. What this changes is what the failure
> says. Merging is a decision for whoever owns the fixture repair; the five required
> checks do not include the case-study job, so this *can* merge red and should not without
> that decision.

## The failure

`sp500_equity_option_analytics/14_backtest` scopes its baseline read by the prediction sets
the registry's populations publish. When that read is empty, the first thing to touch it is

```python
"pct_positive": 100 * all_baselines.filter(pl.col("sharpe") > 0).height / len(all_baselines)
```

so the run failed as `Cell 26 (ZeroDivisionError): division by zero` — which reads like a
defect in the analysis. It is not. The populations are in force, their members are
registered, and what none of them carries is a backtest.

## Why it is reachable now

test-data `4db8572f` ("Regenerate the intermediates fixture through stage 08") landed at
22:10:11Z; the last green seoa job ran 21:35:04Z–21:55:54Z against `63a9e4e5`. The workflow
checks the test-data repo out unpinned, so the next run takes the new one. Comparing the
two registries by extracting the old one from git, so the shared checkout is not moved:

| registry | populations | members | members with a signal backtest | signal-backtested hashes |
|---|---:|---:|---:|---:|
| `63a9e4e5` | 0 | 0 | 0 | 52 |
| `4db8572f` | 2 | 30 | **0** | 52 |

With no populations `CURRENT_MEMBERS` is `None` and the read is unscoped — which is why the
division had a denominator: it was summarising 52 backtests the fixture already shipped,
none of which this notebook's own sweep produced. With two populations it is scoped to 30
members created 2026-09-06, while every backtested prediction was created 2026-08-22 to
08-30.

Generating through stage 08 runs `06_linear` and `07_gbm`, which declare validation
populations over the predictions they have just written, and stops six stages before
anything backtests them. A generation cut at that stage always leaves a population its own
run cannot back.

## The change

The guard names the population, its member count, and the registry's own signal-backtest
count, so the next reader sees a fixture problem rather than an analysis problem:

```
before:  Cell 26 (ZeroDivisionError): division by zero

after:   Cell 26 (RuntimeError): The populations in force publish 30 prediction sets and not
         one of them carries a signal backtest, so there is no baseline to rank. Populations:
         sp500_equity_option_analytics-gbm-validation-v1,
         sp500_equity_option_analytics-linear-validation-v1. The registry holds 57 signal
         backtest(s), all against prediction sets outside the populations, so this is a
         population and a set of backtests describing different generations rather than an
         empty registry. A fixture generated through a stage earlier than the backtest stage
         produces exactly this...
```

It refuses rather than degrading to a pass. That is the same rule
`notebook_contracts.prediction_members_in_force` already applies one step earlier, where it
returns `None` rather than an empty set precisely so that "nothing to filter by" cannot
become "nothing is admissible... reported as an ordinary result".

The count comes from `BacktestExplorer.specs()`, added in #847 for the same reason: it is
schema-stable when the read returns nothing.

## Tests

`tests/test_seoa_baseline_read_refuses.py` lifts the guard out of the notebook by AST and
executes it against a controlled namespace, so it cannot pass against a notebook that no
longer carries it. On the pre-fix notebook the lift finds zero matching blocks and all five
fail with

```
AssertionError: no top-level `if CURRENT_MEMBERS is not None and all_baselines.is_empty():`
in 14_backtest.py; the baseline read is unguarded and an empty population-scoped read will
divide by zero
```

Two of the five cover the premise — a populated read and an unscoped read are both left
alone — so the guard cannot pass by refusing everything.

## Render

`14_backtest.ipynb` carried 16 output cells stamped `2026-09-02T01:48:43Z`. The code cells
changed, so the stamp is cleared and that render goes to the central re-run wave.

Refs ml4t/agent-workspace#1086, ml4t/agent-workspace#1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQJrdyGw6wuWkGh5EQuLM2
