### PR TITLE
seoa: the sweep realizes the declared grid, and its feasibility check is not optional

### DIFF
--- a/case_studies/sp500_equity_option_analytics/14_backtest.ipynb
+++ b/case_studies/sp500_equity_option_analytics/14_backtest.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b7a73206",
+   "id": "9f059553",
    "metadata": {},
    "source": [
     "# S&P 500 Equity+Options: Backtest and Signal Evaluation\n",
@@ -34,7 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d270f57d",
+   "id": "fb72420d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b034372",
+   "id": "4ecff6af",
    "metadata": {
     "tags": [
      "parameters"
@@ -113,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2bfcdd82",
+   "id": "97cbaefb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cff8600f",
+   "id": "7dba6810",
    "metadata": {},
    "source": [
     "## 1. Setup & Plumbing Test\n",
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15888567",
+   "id": "0f4d9383",
    "metadata": {},
    "source": [
     "### What is asked for, and what it resolves to\n",
@@ -150,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60c90222",
+   "id": "a98d1d38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c82bb70e",
+   "id": "2a4c3132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,16 +186,14 @@
     "    CASE_STUDY_ID, BACKTEST_LABEL, split=\"validation\", max_symbols=MAX_SYMBOLS\n",
     ")\n",
     "n_assets = prices[\"symbol\"].n_unique()\n",
-    "if TOP_K:\n",
-    "    PLUMBING_TOP_K = TOP_K\n",
-    "else:\n",
-    "    _feasible_top_k = get_top_k_values_for(CASE_STUDY_ID, BACKTEST_LABEL, n_assets)\n",
-    "    if not _feasible_top_k:\n",
-    "        raise ValueError(\n",
-    "            f\"top_k_grid for {BACKTEST_LABEL!r} in {CASE_STUDY_ID} has no value < \"\n",
-    "            f\"n_assets={n_assets}; declare a feasible k in setup.yaml\"\n",
-    "        )\n",
-    "    PLUMBING_TOP_K = _feasible_top_k[0]\n",
+    "# Called unconditionally, because the call is the feasibility check: it raises when no\n",
+    "# declared k fits `n_assets`. It used to sit in the `else` of `if TOP_K:`, so a papermill\n",
+    "# TOP_K skipped the check as well as the default it was there to supply. At MAX_SYMBOLS: 3\n",
+    "# with TOP_K: 1 that is what let this notebook run a `6 predictions x 0 schemes` sweep,\n",
+    "# register nothing, and report an analysis of rows the fixture already held\n",
+    "# (ml4t/agent-workspace#1084).\n",
+    "_feasible_top_k = get_top_k_values_for(CASE_STUDY_ID, BACKTEST_LABEL, n_assets)\n",
+    "PLUMBING_TOP_K = TOP_K if TOP_K else _feasible_top_k[0]\n",
     "print(\n",
     "    f\"Price support: {len(prices):,} rows across {n_assets} historical symbols; \"\n",
     "    f\"plumbing-test top-K={PLUMBING_TOP_K}\"\n",
@@ -205,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3824cc46",
+   "id": "e026ce3e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "934900ae",
+   "id": "0adc159e",
    "metadata": {},
    "source": [
     "## 2. Parametric Sweep\n",
@@ -267,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2813e57",
+   "id": "aaa5c67d",
    "metadata": {},
    "source": [
     "**A population is immutable and the registry keeps every generation, so a candidate set built\n",
@@ -294,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec8102b1",
+   "id": "8cbadc64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30e0cda5",
+   "id": "c07041ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8592a25",
+   "id": "b20db301",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1986c4c",
+   "id": "37b3c71a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -386,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "070f718d",
+   "id": "aea8357b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -442,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08a19b15",
+   "id": "e1d497c0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -454,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc2b1d87",
+   "id": "e3f8c65a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +477,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e9d7253",
+   "id": "c2f7c869",
    "metadata": {},
    "source": [
     "Progress counts include cached and newly executed combinations. A complete\n",
@@ -488,7 +486,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e61c714c",
+   "id": "e7d2510f",
    "metadata": {},
    "source": [
     "The grid is published as an official population *before* it executes, and checked with\n",
@@ -507,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8060f71",
+   "id": "c5704258",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a95c4da",
+   "id": "45e72fc9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4fcd0e4",
+   "id": "e1d6c17d",
    "metadata": {},
    "source": [
     "## 3. Signal Evaluation\n",
@@ -654,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "152f9f01",
+   "id": "3ec00ea9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -664,7 +662,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94102876",
+   "id": "b7f4a48f",
    "metadata": {},
    "source": [
     "### Eligible Leaders\n",
@@ -679,7 +677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cbb92d3",
+   "id": "a74a3735",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -747,7 +745,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6b961b1",
+   "id": "27fa4393",
    "metadata": {},
    "source": [
     "Downstream selection is label-specific and admits one checkpoint per distinct model\n",
@@ -759,7 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e737f8f0",
+   "id": "92e27068",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,7 +779,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b45fa5c",
+   "id": "b08524e1",
    "metadata": {},
    "source": [
     "### Family Dispersion and IC Translation\n",
@@ -798,7 +796,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e2c5560",
+   "id": "3c5a6647",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -825,7 +823,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8784f114",
+   "id": "9c586975",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -855,7 +853,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08141281",
+   "id": "aaded73e",
    "metadata": {},
    "source": [
     "The same evaluation surface shows why prediction and portfolio diagnostics\n",
@@ -866,7 +864,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "584eca4c",
+   "id": "a60f5636",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -902,7 +900,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba956d97",
+   "id": "89d6097f",
    "metadata": {},
    "source": [
     "### Selection-Adjusted Uncertainty\n",
@@ -930,7 +928,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c95c56e",
+   "id": "6607946e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -961,7 +959,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4392514",
+   "id": "f8747629",
    "metadata": {},
    "source": [
     "The interval plot shows which family leaders clear zero on their own return path and which do\n",
@@ -972,7 +970,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10d6a5a9",
+   "id": "f68a7cf8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1009,7 +1007,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2332fc04",
+   "id": "022a1112",
    "metadata": {},
    "source": [
     "### Downstream Preview\n",
@@ -1025,7 +1023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6456ef56",
+   "id": "e5d413b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1049,7 +1047,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f55a67c",
+   "id": "0c7efeec",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",

--- a/case_studies/sp500_equity_option_analytics/14_backtest.py
+++ b/case_studies/sp500_equity_option_analytics/14_backtest.py
@@ -146,16 +146,14 @@ prices = load_backtest_prices_for(
     CASE_STUDY_ID, BACKTEST_LABEL, split="validation", max_symbols=MAX_SYMBOLS
 )
 n_assets = prices["symbol"].n_unique()
-if TOP_K:
-    PLUMBING_TOP_K = TOP_K
-else:
-    _feasible_top_k = get_top_k_values_for(CASE_STUDY_ID, BACKTEST_LABEL, n_assets)
-    if not _feasible_top_k:
-        raise ValueError(
-            f"top_k_grid for {BACKTEST_LABEL!r} in {CASE_STUDY_ID} has no value < "
-            f"n_assets={n_assets}; declare a feasible k in setup.yaml"
-        )
-    PLUMBING_TOP_K = _feasible_top_k[0]
+# Called unconditionally, because the call is the feasibility check: it raises when no
+# declared k fits `n_assets`. It used to sit in the `else` of `if TOP_K:`, so a papermill
+# TOP_K skipped the check as well as the default it was there to supply. At MAX_SYMBOLS: 3
+# with TOP_K: 1 that is what let this notebook run a `6 predictions x 0 schemes` sweep,
+# register nothing, and report an analysis of rows the fixture already held
+# (ml4t/agent-workspace#1084).
+_feasible_top_k = get_top_k_values_for(CASE_STUDY_ID, BACKTEST_LABEL, n_assets)
+PLUMBING_TOP_K = TOP_K if TOP_K else _feasible_top_k[0]
 print(
     f"Price support: {len(prices):,} rows across {n_assets} historical symbols; "
     f"plumbing-test top-K={PLUMBING_TOP_K}"

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2531,7 +2531,13 @@ case_studies/sp500_equity_option_analytics/13_model_analysis:
   timeout: 300
 case_studies/sp500_equity_option_analytics/14_backtest:
   parameters:
-    MAX_SYMBOLS: 3
+    # backtest.sweep.top_k_grid declares [5, 10, 20] for every label here, and the case
+    # study is long-only, so a scheme survives when k < n_assets. Three symbols realized
+    # none of them and the sweep ran a `6 predictions x 0 schemes` grid; six realizes only
+    # ew_top5. Twenty-one realizes all three, which is what the fixture declares, and the
+    # seeded predictions carry 27 symbols so the panel has the names
+    # (ml4t/agent-workspace#1084).
+    MAX_SYMBOLS: 21
     TOP_K: 1
   timeout: 600
 case_studies/sp500_equity_option_analytics/15_portfolio_management:

--- a/tests/test_seoa_sweep_universe.py
+++ b/tests/test_seoa_sweep_universe.py
@@ -1,0 +1,115 @@
+"""The seoa CI universe must realize the grid the case study declares, and the check that
+says so must not sit behind a papermill parameter.
+
+`cs-sp500_equity_option_analytics` was green while `14_backtest` swept nothing. Two
+parameters did it between them. `MAX_SYMBOLS: 3` left no declared `k` realizable, so
+`get_entry_schemes_for` returned `[]` and the sweep ran a `6 predictions x 0 schemes`
+grid. `TOP_K: 1` took the `if TOP_K:` branch, which is where the feasibility check lived,
+so nothing said so. The analysis downstream then summarised 52 backtests the fixture
+already shipped, and the job's green tick was one of the seven conditions the case study
+was declared complete against (ml4t/agent-workspace#1084).
+
+Both halves are pinned, because either alone leaves the failure reachable: a universe that
+realizes the grid, and a check that no parameter can route around.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import yaml
+
+from case_studies.utils.sweep_config import get_entry_schemes_for, get_top_k_values_for, load_sweep
+
+CASE_STUDY = "sp500_equity_option_analytics"
+REPO_ROOT = Path(__file__).parent.parent
+NOTEBOOK = REPO_ROOT / "case_studies" / CASE_STUDY / "14_backtest.py"
+SWEEPING_NOTEBOOK = f"case_studies/{CASE_STUDY}/14_backtest"
+# seoa declares no `backtest.long_short`, and `get_backtest_config` resolves it to False.
+LONG_SHORT = False
+
+
+def _max_symbols() -> int:
+    overrides = yaml.safe_load((REPO_ROOT / "tests" / "overrides.yaml").read_text())
+    return overrides[SWEEPING_NOTEBOOK]["parameters"]["MAX_SYMBOLS"]
+
+
+def _declared_labels() -> list[str]:
+    return sorted(load_sweep(CASE_STUDY).get("top_k_grid") or {})
+
+
+def test_the_ci_universe_realizes_every_declared_concentration():
+    """Not just one. A universe admitting `ew_top5` alone still runs a third of the grid.
+
+    Fails at `MAX_SYMBOLS: 3` (no scheme at all) and at 6 (one of three).
+    """
+    max_symbols = _max_symbols()
+    grid = load_sweep(CASE_STUDY)["top_k_grid"]
+    shortfalls = {}
+    for label in _declared_labels():
+        declared = [int(k) for k in grid[label]]
+        realized = get_top_k_values_for(CASE_STUDY, label, max_symbols)
+        missing = sorted(set(declared) - set(int(k) for k in realized))
+        if missing:
+            shortfalls[label] = missing
+    assert not shortfalls, (
+        f"MAX_SYMBOLS={max_symbols} cannot realize every declared k: {shortfalls}. "
+        f"The fixture would assert a grid it does not run."
+    )
+
+
+def test_every_declared_label_admits_an_entry_scheme():
+    max_symbols = _max_symbols()
+    starved = [
+        label
+        for label in _declared_labels()
+        if not get_entry_schemes_for(CASE_STUDY, label, max_symbols, long_short=LONG_SHORT)
+    ]
+    assert not starved, f"MAX_SYMBOLS={max_symbols} leaves no entry scheme for {starved}"
+
+
+def test_a_universe_below_the_smallest_declared_k_realizes_nothing():
+    """The premise: the filter is what empties the grid, so the test above can fail."""
+    label = _declared_labels()[0]
+    smallest = min(int(k) for k in load_sweep(CASE_STUDY)["top_k_grid"][label])
+    assert get_entry_schemes_for(CASE_STUDY, label, smallest, long_short=LONG_SHORT) == []
+    assert get_entry_schemes_for(CASE_STUDY, label, smallest + 1, long_short=LONG_SHORT) != []
+
+
+def test_the_feasibility_check_is_not_behind_a_parameter():
+    """`get_top_k_values_for` raises on an unrealizable grid, so calling it IS the check.
+
+    It used to sit in the `else` of `if TOP_K:`, which meant supplying TOP_K skipped the
+    check as well as the default it was there to provide. Fails on the pre-fix notebook.
+    """
+    tree = ast.parse(NOTEBOOK.read_text())
+
+    calls_under_parameter_branch = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        names = {n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)}
+        if "TOP_K" not in names:
+            continue
+        for inner in ast.walk(node):
+            if (
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Name)
+                and inner.func.id == "get_top_k_values_for"
+            ):
+                calls_under_parameter_branch.append(node.lineno)
+
+    assert not calls_under_parameter_branch, (
+        f"{NOTEBOOK.name} calls get_top_k_values_for inside a branch on TOP_K "
+        f"(line {calls_under_parameter_branch}). Supplying TOP_K then skips the "
+        f"feasibility check, which is how ml4t/agent-workspace#1084 stayed silent."
+    )
+
+    called_somewhere = any(
+        isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "get_top_k_values_for"
+        for n in ast.walk(tree)
+    )
+    assert called_somewhere, f"{NOTEBOOK.name} never calls get_top_k_values_for at all"


### PR DESCRIPTION
> **This does not turn `cs-sp500_equity_option_analytics` green.** Four notebooks still
> fail, none of them on this change, for the reason set out at the bottom. What it does is
> make the sweep run the grid the case study declares, and make the check that would have
> said so unskippable.

## Two parameters, both chosen to make CI fast

`MAX_SYMBOLS: 3` against a declared `top_k_grid` of `[5, 10, 20]`. seoa is long-only, so a
scheme survives when `k < n_assets`:

```
MAX_SYMBOLS=  3: declared [5, 10, 20] -> ValueError (nothing realizable)
MAX_SYMBOLS=  6: declared [5, 10, 20] realized [5]         missing [10, 20]
MAX_SYMBOLS= 21: declared [5, 10, 20] realized [5, 10, 20] missing []
```

`TOP_K: 1` hid it. `get_top_k_values_for` raises on an unrealizable grid, so *calling it is
the feasibility check* — and it sat in the `else` of `if TOP_K:`, so supplying `TOP_K`
skipped the check as well as the default it was there to provide. The sweep then ran a
`6 predictions x 0 schemes` grid, registered nothing, and the analysis downstream reported
on 52 backtests the fixture already shipped.

**Six would not have been the answer.** It admits `ew_top5` and leaves `k=10` and `k=20`
declared but never run — a smaller version of the same defect. 21 realizes all three, and
the seeded predictions carry 27 symbols, so the panel has the names.

## Measured

Whole chain, `-k sp500_equity_option_analytics -p no:randomly`:

| stage | `MAX_SYMBOLS: 3` | `MAX_SYMBOLS: 21` |
|---|---|---|
| `14_backtest` | 5.4s **FAIL** | 15.5s **OK** |
| `15_portfolio_management` | 4.2s FAIL | 12.6s **OK** |
| `16_risk_management` | 4.3s FAIL | 9.0s **OK** |
| whole chain | 745.9s — 7 failed, 16 passed | **739.9s — 4 failed, 19 passed** |

About ten seconds more in the sweeping notebook, three notebooks that failed now passing,
and no slowdown anywhere else — `11d_stochastic_discount_factor` is 321s of the chain and
is untouched. `14_backtest`'s timeout is 600s and it now uses 15.5s. The sweep proper is 3s
of that, six backtests at 2.0 bt/s.

## What still fails, and why it is not this

- `11_latent_factors`, `13_model_analysis` — a declared population disagreeing with the
  registered prediction sets. Present at `MAX_SYMBOLS: 3` as well.
- `17_costs`, `20_strategy_analysis` — they require *every* declared label to carry rankable
  validation backtests, and the chain backtests one. This change removes `fwd_ret_5d` from
  that list (5 labels to 4) and cannot remove the rest.

All four are the same shape as the defect fixed here: they were passing by reading
backtests baked into the fixture by an earlier generation, and they stop once
ml4t/agent-workspace#1086's populations scope the reads to members that generation never
backtested. That is a fixture-generation property, not a notebook one.

## Tests

`tests/test_seoa_sweep_universe.py`. On the pre-fix tree:

```
test_the_ci_universe_realizes_every_declared_concentration
    MAX_SYMBOLS=3 cannot realize every declared k: {'fwd_ret_5d': [5, 10, 20], ...}

test_the_feasibility_check_is_not_behind_a_parameter
    14_backtest.py calls get_top_k_values_for inside a branch on TOP_K (line 149)
```

The second is the one worth keeping whatever the universe becomes: a parameter that routes
around a feasibility check will route around it again under a different number, and next
time nobody will be looking. A third test pins the premise — that the filter, not the
absence of a grid, is what empties it — so the first cannot pass for the wrong reason.

Refs ml4t/agent-workspace#1084, ml4t/agent-workspace#1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQJrdyGw6wuWkGh5EQuLM2
