### PR TITLE
Choose the ml4t image at the step, so a lock bump reaches the notebook jobs

### DIFF
--- a/.github/actions/resolve-ml4t-image/action.yml
+++ b/.github/actions/resolve-ml4t-image/action.yml
@@ -1,0 +1,60 @@
+name: Resolve the ml4t image to measure in
+description: >-
+  Load the candidate image this commit produced when there is one, and report the
+  reference to run against. Without this a job takes its environment from
+  ml4t/ml4t:latest, which is whatever was published last rather than what the
+  commit declares.
+
+inputs:
+  candidate-result:
+    description: >-
+      The result of the build-image-candidate job. A failure or cancellation is
+      fatal here: the commit changes what the image installs and no image was
+      produced to measure it in, so falling back to the published image would
+      measure the environment this commit replaces. A skip is normal and means
+      the commit does not move the image.
+    required: true
+
+outputs:
+  ref:
+    description: The image reference to run against.
+    value: ${{ steps.pick.outputs.ref }}
+  is-candidate:
+    description: Non-empty when the reference is an image built from this commit.
+    value: ${{ steps.pick.outputs.is_candidate }}
+
+runs:
+  using: composite
+  steps:
+    - name: The candidate image built
+      if: inputs.candidate-result == 'failure' || inputs.candidate-result == 'cancelled'
+      shell: bash
+      run: |
+        echo "::error::build-image-candidate ${{ inputs.candidate-result }}:"
+        echo "::error::this commit changes what the image installs, and no image was"
+        echo "::error::produced to measure it in. Measuring in ml4t/ml4t:latest would"
+        echo "::error::test the environment this commit replaces."
+        exit 1
+
+    - name: Load the candidate image
+      if: inputs.candidate-result == 'success'
+      uses: actions/download-artifact@v4
+      with:
+        name: ml4t-candidate-image
+        path: /tmp
+
+    - name: Which image this commit is measured in
+      id: pick
+      shell: bash
+      run: |
+        if [ -f /tmp/ml4t-candidate.tar ]; then
+          docker load -i /tmp/ml4t-candidate.tar
+          ref=ml4t/ml4t:candidate
+          echo "is_candidate=yes" >> "$GITHUB_OUTPUT"
+          echo "::notice::measuring in an image built from this commit"
+        else
+          ref=ml4t/ml4t:latest
+          docker pull "$ref"
+          echo "is_candidate=" >> "$GITHUB_OUTPUT"
+        fi
+        echo "ref=$ref" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1272,8 +1272,16 @@ jobs:
   test-chapters:
     name: ${{ matrix.name }}
     timeout-minutes: 60
-    needs: [lint, changes]
-    if: needs.changes.outputs.chapter_matrix != '[]'
+    needs: [lint, changes, build-image-candidate]
+    # `always()` is needed because build-image-candidate is skipped whenever the commit
+    # does not move what the image installs, and a skipped dependency skips its
+    # dependents. lint and changes are then checked explicitly, so this gate is exactly
+    # as strict as the `needs:` list it replaces.
+    if: >-
+      always()
+      && needs.lint.result == 'success'
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.chapter_matrix != '[]'
 
     strategy:
       fail-fast: false
@@ -1281,8 +1289,6 @@ jobs:
         include: ${{ fromJSON(needs.changes.outputs.chapter_matrix) }}
 
     runs-on: ubuntu-latest
-    container:
-      image: ml4t/ml4t:latest
 
     steps:
       # secrets.TEST_DATA_DEPLOY_KEY is not exposed to a pull_request from a fork,
@@ -1312,18 +1318,6 @@ jobs:
             echo "have_key=" >> "$GITHUB_OUTPUT"
             echo "::notice::No test-data deploy key in this context, which is a fork pull request. This job checked out no test data and executed no notebook, so it asserts nothing about this change; the notebooks run on the branch once it is merged."
           fi
-      - name: Install git (for checkout inside container)
-        if: steps.reach.outputs.have_key
-        run: |
-          # A transient apt mirror failure used to kill the whole job.
-          for attempt in 1 2 3; do
-            apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null && exit 0
-            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
-            sleep $((attempt * 15))
-          done
-          echo "::error::apt-get could not install git after three attempts"
-          exit 1
-
       - uses: actions/checkout@v6
         if: steps.reach.outputs.have_key
 
@@ -1336,23 +1330,30 @@ jobs:
           ssh-key: ${{ secrets.TEST_DATA_DEPLOY_KEY }}
           lfs: false
 
-      # This job executes notebooks inside the PUBLISHED image, which drifts from
-      # uv.lock the moment the lock moves and has no way to carry a candidate built
-      # from this commit: `container:` is resolved before any step runs. So when the
-      # lock has moved and the image has not, every notebook here runs against a
-      # dependency set the repository does not declare - and it does not fail in a way
-      # that says so. On #787, which moved ml4t-diagnostic to 0.1.4, it surfaced as
-      # thirteen fold-ordering errors inside cme_futures and a red ch26, none of which
-      # names the environment.
+      - name: Resolve the image this commit declares
+        id: image
+        if: steps.reach.outputs.have_key
+        uses: ./.github/actions/resolve-ml4t-image
+        with:
+          candidate-result: ${{ needs.build-image-candidate.result }}
+
+      # This job used to execute notebooks in whatever `ml4t/ml4t:latest` happened to
+      # hold, because a job-level `container:` is resolved before any step runs and so
+      # could not name an image this run produced. A commit that moved uv.lock was then
+      # measured in the environment it replaced: on #787, which moved ml4t-diagnostic to
+      # 0.1.4, that surfaced as thirteen fold-ordering errors inside cme_futures and a
+      # red ch26, none of which names the environment as the cause.
       #
-      # The guard cannot make the job pass; nothing can until the image is rebuilt from
-      # a landed lock. What it does is put the reason first, so the failure reads as
-      # "this image is not the environment this commit declares" rather than as a
-      # numerical defect in a notebook. That distinction cost four rounds of
-      # investigation the last time it was missing.
+      # The image is a step-level choice now, so a lock bump is measured in the image
+      # built from the same commit and this check is a guard against drift rather than a
+      # standing report of it.
       - name: The image's installed distributions match uv.lock
         if: steps.reach.outputs.have_key
-        run: python .github/scripts/check_env_matches_lock.py
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" -w "$GITHUB_WORKSPACE" \
+            "${{ steps.image.outputs.ref }}" \
+            python .github/scripts/check_env_matches_lock.py
       - name: Seed case study intermediates
         if: steps.reach.outputs.have_key
         run: |
@@ -1385,9 +1386,18 @@ jobs:
           FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
         run: |
           FILTER="${TEST_FILTER_INPUT:-$MATRIX_FILTER}"
-          python -m pytest tests/test_chapter_notebooks.py \
-            -v --tb=short \
-            -k "$FILTER"
+          mkdir -p "$ML4T_OUTPUT_DIR"
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            -v "$ML4T_OUTPUT_DIR:$ML4T_OUTPUT_DIR" \
+            -w "$GITHUB_WORKSPACE" \
+            -e PYTHONPATH -e ML4T_DATA_PATH -e ML4T_OUTPUT_DIR \
+            -e MPLBACKEND -e PLOTLY_RENDERER \
+            -e FRED_API_KEY \
+            "${{ steps.image.outputs.ref }}" \
+            python -m pytest tests/test_chapter_notebooks.py \
+              -v --tb=short \
+              -k "$FILTER"
 
   # ---------------------------------------------------------------------------
   # Case study pipeline tests — inside Docker (ml4t/ml4t:latest)
@@ -1395,8 +1405,16 @@ jobs:
   test-case-studies:
     name: cs-${{ matrix.case-study }}
     timeout-minutes: 90
-    needs: [lint, changes]
-    if: needs.changes.outputs.case_matrix != '[]'
+    needs: [lint, changes, build-image-candidate]
+    # `always()` is needed because build-image-candidate is skipped whenever the commit
+    # does not move what the image installs, and a skipped dependency skips its
+    # dependents. lint and changes are then checked explicitly, so this gate is exactly
+    # as strict as the `needs:` list it replaces.
+    if: >-
+      always()
+      && needs.lint.result == 'success'
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.case_matrix != '[]'
 
     strategy:
       fail-fast: false
@@ -1404,8 +1422,6 @@ jobs:
         include: ${{ fromJSON(needs.changes.outputs.case_matrix) }}
 
     runs-on: ubuntu-latest
-    container:
-      image: ml4t/ml4t:latest
 
     steps:
       # secrets.TEST_DATA_DEPLOY_KEY is not exposed to a pull_request from a fork,
@@ -1435,18 +1451,6 @@ jobs:
             echo "have_key=" >> "$GITHUB_OUTPUT"
             echo "::notice::No test-data deploy key in this context, which is a fork pull request. This job checked out no test data and executed no notebook, so it asserts nothing about this change; the notebooks run on the branch once it is merged."
           fi
-      - name: Install git
-        if: steps.reach.outputs.have_key
-        run: |
-          # A transient apt mirror failure used to kill the whole job.
-          for attempt in 1 2 3; do
-            apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null && exit 0
-            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
-            sleep $((attempt * 15))
-          done
-          echo "::error::apt-get could not install git after three attempts"
-          exit 1
-
       - uses: actions/checkout@v6
         if: steps.reach.outputs.have_key
 
@@ -1459,23 +1463,30 @@ jobs:
           ssh-key: ${{ secrets.TEST_DATA_DEPLOY_KEY }}
           lfs: false
 
-      # This job executes notebooks inside the PUBLISHED image, which drifts from
-      # uv.lock the moment the lock moves and has no way to carry a candidate built
-      # from this commit: `container:` is resolved before any step runs. So when the
-      # lock has moved and the image has not, every notebook here runs against a
-      # dependency set the repository does not declare - and it does not fail in a way
-      # that says so. On #787, which moved ml4t-diagnostic to 0.1.4, it surfaced as
-      # thirteen fold-ordering errors inside cme_futures and a red ch26, none of which
-      # names the environment.
+      - name: Resolve the image this commit declares
+        id: image
+        if: steps.reach.outputs.have_key
+        uses: ./.github/actions/resolve-ml4t-image
+        with:
+          candidate-result: ${{ needs.build-image-candidate.result }}
+
+      # This job used to execute notebooks in whatever `ml4t/ml4t:latest` happened to
+      # hold, because a job-level `container:` is resolved before any step runs and so
+      # could not name an image this run produced. A commit that moved uv.lock was then
+      # measured in the environment it replaced: on #787, which moved ml4t-diagnostic to
+      # 0.1.4, that surfaced as thirteen fold-ordering errors inside cme_futures and a
+      # red ch26, none of which names the environment as the cause.
       #
-      # The guard cannot make the job pass; nothing can until the image is rebuilt from
-      # a landed lock. What it does is put the reason first, so the failure reads as
-      # "this image is not the environment this commit declares" rather than as a
-      # numerical defect in a notebook. That distinction cost four rounds of
-      # investigation the last time it was missing.
+      # The image is a step-level choice now, so a lock bump is measured in the image
+      # built from the same commit and this check is a guard against drift rather than a
+      # standing report of it.
       - name: The image's installed distributions match uv.lock
         if: steps.reach.outputs.have_key
-        run: python .github/scripts/check_env_matches_lock.py
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" -w "$GITHUB_WORKSPACE" \
+            "${{ steps.image.outputs.ref }}" \
+            python .github/scripts/check_env_matches_lock.py
       - name: Seed case study intermediates
         if: steps.reach.outputs.have_key
         run: |
@@ -1484,14 +1495,6 @@ jobs:
             cp -r test-data/intermediates/* $ML4T_OUTPUT_DIR/
             echo "Seeded $(du -sh $ML4T_OUTPUT_DIR | cut -f1) of intermediates"
           fi
-
-      # ml4t/ml4t:latest only bakes in pytest + pytest-timeout (envs/ml4t/Dockerfile);
-      # pytest-rerunfailures lives in the dev extra, which this image doesn't install.
-      # Without it, overrides.yaml's `reruns:` key (tests/conftest.py) silently adds no
-      # retry marker, so a notebook marked flaky just fails outright here.
-      - name: Install pytest-rerunfailures
-        if: steps.reach.outputs.have_key
-        run: pip install --no-cache-dir "pytest-rerunfailures>=15.0"
 
       - name: Run pipeline (${{ matrix.case-study }})
         if: steps.reach.outputs.have_key
@@ -1502,9 +1505,26 @@ jobs:
           FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
         run: |
           FILTER="${TEST_FILTER_INPUT:-$MATRIX_CASE_STUDY}"
-          python -m pytest tests/test_case_studies.py \
-            -v --tb=short \
-            -k "$FILTER"
+          mkdir -p "$ML4T_OUTPUT_DIR"
+          # The image bakes in pytest + pytest-timeout only (envs/ml4t/Dockerfile);
+          # pytest-rerunfailures lives in the dev extra it does not install. Without it
+          # overrides.yaml's `reruns:` key (tests/conftest.py) adds no retry marker and a
+          # notebook marked flaky fails outright. It is installed inside the run
+          # container rather than in a step of its own, because a step now runs on the
+          # runner and would install it where the notebooks do not execute.
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            -v "$ML4T_OUTPUT_DIR:$ML4T_OUTPUT_DIR" \
+            -w "$GITHUB_WORKSPACE" \
+            -e PYTHONPATH -e ML4T_DATA_PATH -e ML4T_OUTPUT_DIR \
+            -e MPLBACKEND -e PLOTLY_RENDERER \
+            -e FRED_API_KEY -e "FILTER=$FILTER" \
+            "${{ steps.image.outputs.ref }}" \
+            bash -c '
+              set -e
+              pip install --no-cache-dir "pytest-rerunfailures>=15.0"
+              python -m pytest tests/test_case_studies.py -v --tb=short -k "$FILTER"
+            '
 
   # ---------------------------------------------------------------------------
   # Py312 Docker image (Python 3.12: gensim, signatory, esig, tfcausalimpact,
@@ -1589,16 +1609,27 @@ jobs:
   # ---------------------------------------------------------------------------
   test-neo4j:
     timeout-minutes: 30
-    needs: [lint, changes]
-    if: needs.changes.outputs.run_neo4j == 'true'
+    needs: [lint, changes, build-image-candidate]
+    # `always()` is needed because build-image-candidate is skipped whenever the commit
+    # does not move what the image installs, and a skipped dependency skips its
+    # dependents. lint and changes are then checked explicitly, so this gate is exactly
+    # as strict as the `needs:` list it replaces.
+    if: >-
+      always()
+      && needs.lint.result == 'success'
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.run_neo4j == 'true'
 
     runs-on: ubuntu-latest
-    container:
-      image: ml4t/ml4t:latest
-      env:
-        NEO4J_URI: bolt://neo4j:7687
-        NEO4J_USER: neo4j
-        NEO4J_PASSWORD: password
+
+    # `bolt://neo4j:7687` resolved only because the job container shared GitHub's
+    # per-job network with the service. The notebooks now run under `docker run
+    # --network host`, so they reach the service on the port it publishes to the
+    # runner and the name the service is registered under stops mattering.
+    env:
+      NEO4J_URI: bolt://localhost:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: password
 
     services:
       neo4j:
@@ -1642,18 +1673,6 @@ jobs:
             echo "have_key=" >> "$GITHUB_OUTPUT"
             echo "::notice::No test-data deploy key in this context, which is a fork pull request. This job checked out no test data and executed no notebook, so it asserts nothing about this change; the notebooks run on the branch once it is merged."
           fi
-      - name: Install git
-        if: steps.reach.outputs.have_key
-        run: |
-          # A transient apt mirror failure used to kill the whole job.
-          for attempt in 1 2 3; do
-            apt-get update -qq && apt-get install -y -qq git git-lfs openssh-client >/dev/null && exit 0
-            echo "apt-get failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
-            sleep $((attempt * 15))
-          done
-          echo "::error::apt-get could not install git after three attempts"
-          exit 1
-
       - uses: actions/checkout@v6
         if: steps.reach.outputs.have_key
 
@@ -1666,24 +1685,49 @@ jobs:
           ssh-key: ${{ secrets.TEST_DATA_DEPLOY_KEY }}
           lfs: false
 
-      # Same reason as the two notebook jobs above: this runs in the published image,
-      # which cannot carry a candidate built from this commit.
+      - name: Resolve the image this commit declares
+        id: image
+        if: steps.reach.outputs.have_key
+        uses: ./.github/actions/resolve-ml4t-image
+        with:
+          candidate-result: ${{ needs.build-image-candidate.result }}
+
+      # Same as the two notebook jobs above: the image is a step-level choice, so a
+      # commit that moves uv.lock is measured in the image built from that commit.
       - name: The image's installed distributions match uv.lock
         if: steps.reach.outputs.have_key
-        run: python .github/scripts/check_env_matches_lock.py
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" -w "$GITHUB_WORKSPACE" \
+            "${{ steps.image.outputs.ref }}" \
+            python .github/scripts/check_env_matches_lock.py
       - name: Run Ch23 Knowledge Graph notebooks (pipeline order)
         if: steps.reach.outputs.have_key
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
-          # Run in dependency order: upstream notebooks generate data for downstream
-          python -m pytest tests/test_docker_notebooks.py -v --tb=short \
-            -k "08_8k_event_extraction" && \
-          python -m pytest tests/test_docker_notebooks.py -v --tb=short \
-            -k "02_supply_chain_kg_construction" && \
-          python -m pytest tests/test_docker_notebooks.py -v --tb=short \
-            -k "07_dynamic_kg_temporal or 03_graph_rag_qa or 05_institutional_holdings_kg \
-                or 09_knowledge_graph_features"
+          mkdir -p "$ML4T_OUTPUT_DIR"
+          # --network host so the notebooks reach the neo4j service on the port it
+          # publishes to the runner. The job no longer shares GitHub's per-job network,
+          # which is what `bolt://neo4j:7687` depended on.
+          docker run --rm --network host \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            -v "$ML4T_OUTPUT_DIR:$ML4T_OUTPUT_DIR" \
+            -w "$GITHUB_WORKSPACE" \
+            -e PYTHONPATH -e ML4T_DATA_PATH -e ML4T_OUTPUT_DIR \
+            -e MPLBACKEND -e PLOTLY_RENDERER \
+            -e NEO4J_URI -e NEO4J_USER -e NEO4J_PASSWORD \
+            "${{ steps.image.outputs.ref }}" \
+            bash -c '
+              # Dependency order: upstream notebooks generate data for downstream ones.
+              python -m pytest tests/test_docker_notebooks.py -v --tb=short \
+                -k "08_8k_event_extraction" && \
+              python -m pytest tests/test_docker_notebooks.py -v --tb=short \
+                -k "02_supply_chain_kg_construction" && \
+              python -m pytest tests/test_docker_notebooks.py -v --tb=short \
+                -k "07_dynamic_kg_temporal or 03_graph_rag_qa or 05_institutional_holdings_kg \
+                    or 09_knowledge_graph_features"
+            '
 
   # ---------------------------------------------------------------------------
   # Benchmark Docker image (Ch02 storage benchmarks + database services)

--- a/tests/test_image_rebuild_triggers.py
+++ b/tests/test_image_rebuild_triggers.py
@@ -236,31 +236,69 @@ def test_a_broken_candidate_fails_the_required_check():
     assert "exit 1" in str(guard.get("run", "")), f"{guard.get('name')} does not fail the job"
 
 
-def _jobs_in_the_published_ml4t_image() -> dict[str, dict]:
-    """Jobs whose `container:` is `ml4t/ml4t:latest`, keyed by job name.
+# The jobs that execute in the ml4t image and must therefore check it against the
+# lock. Named rather than only discovered, because both ways of reaching that image
+# are structural: a job-level `container:`, or a step that resolves the image and
+# runs `docker run`. A restructuring that moved a job out of both forms would empty
+# a purely discovered set and leave the tests below asserting nothing, which is how
+# this test previously stopped covering the three notebook jobs.
+JOBS_THAT_RUN_IN_THE_ML4T_IMAGE = frozenset(
+    {"test-unit-image", "test-chapters", "test-case-studies", "test-neo4j"}
+)
 
-    Only that image. `ml4t-py312` and `ml4t-benchmark` install their own dependency
-    sets on top of a constraint derived from the root lock, so their installed
-    distributions legitimately differ from it and the guard below does not apply.
+
+def _jobs_in_the_published_ml4t_image() -> dict[str, dict]:
+    """Jobs that execute in `ml4t/ml4t`, keyed by job name.
+
+    Two shapes count. A job-level `container:` pins the published image before any
+    step runs. A step-level `docker run` against the reference the
+    `resolve-ml4t-image` action produces runs either the published image or a
+    candidate built from this commit, which is what lets a lock bump be measured in
+    the environment it declares.
+
+    Only the ml4t image. `ml4t-py312` and `ml4t-benchmark` install their own
+    dependency sets on top of a constraint derived from the root lock, so their
+    installed distributions legitimately differ from it and the guard below does not
+    apply.
     """
     workflow = yaml.safe_load(TEST_WORKFLOW.read_text(encoding="utf-8"))
     out = {}
     for name, spec in workflow["jobs"].items():
         container = spec.get("container")
         image = container.get("image") if isinstance(container, dict) else container
-        if image == "ml4t/ml4t:latest":
+        steps = spec.get("steps") or []
+        # Either shape of step-level resolution: the shared composite action, or the
+        # inline resolve test-unit-image carries. Both end in a `docker run` against
+        # `steps.image.outputs.ref`, which is what actually names the image.
+        resolves = any(
+            "resolve-ml4t-image" in str(step.get("uses", ""))
+            or "steps.image.outputs.ref" in str(step.get("run", ""))
+            for step in steps
+        )
+        if image == "ml4t/ml4t:latest" or resolves:
             out[name] = spec
     return out
 
 
-def test_every_job_in_the_published_image_checks_it_against_the_lock():
-    """A `container:` cannot carry an image built from the commit under test.
+def test_the_guarded_set_is_the_set_that_runs_in_the_image():
+    """The two tests below assert over a discovered set, so an empty one proves nothing.
 
-    GitHub resolves it before any step runs, so these jobs get the published image
-    whatever the lock says - and unlike `test-unit-image` they cannot be pointed at a
-    candidate without restructuring them to `docker run`. The guard cannot make them
-    pass on a lock-changing commit; nothing can until the image is rebuilt from a
-    landed lock. What it does is make the failure say which of the two is wrong.
+    Both filter that set and assert the filter caught nothing. If the discovery stops
+    matching - as it did when these jobs moved from `container:` to `docker run` - the
+    set empties, both tests pass, and the coverage they exist for is gone with no
+    failure anywhere. Pinning the expected membership is what makes that a red test
+    rather than a silent one.
+    """
+    assert set(_jobs_in_the_published_ml4t_image()) == JOBS_THAT_RUN_IN_THE_ML4T_IMAGE
+
+
+def test_every_job_in_the_published_image_checks_it_against_the_lock():
+    """Every job that runs in the ml4t image checks that image against the lock.
+
+    These jobs choose their image at the step, so a commit that moves the lock is
+    measured in an image built from that commit. The guard is what catches the case
+    that remains: an image that is not what the lock declares, whether because the
+    candidate was not built or because the published image has drifted.
 
     Without it the drift arrives as arithmetic. On the commit that moved
     ml4t-diagnostic to 0.1.4 it surfaced as thirteen fold-ordering errors inside


### PR DESCRIPTION
`test-chapters`, `test-case-studies` and `test-neo4j` took their environment from a job-level `container:`, which GitHub resolves before the first step runs. #782 built a candidate image from the commit under test and pointed `test-unit-image` at it; these three could not be pointed anywhere, so a PR that moved `uv.lock` ran its notebooks against the environment it replaced. On #787, the `ml4t-diagnostic` 0.1.4 adoption, that surfaced as thirteen fold-ordering errors inside `cme_futures` and a red `ch26`, none of which names the environment as the cause.

The three now run their notebooks through `docker run`, so the image is a step-level choice and the candidate is used when the commit produced one. That is the shape `test-unit-image` already used for the same reason; the resolution is factored into `.github/actions/resolve-ml4t-image` rather than copied a fourth time.

## What the container was doing that now needs doing explicitly

- **Checkout ran inside the container**, which is why each job `apt-get install`ed git first. Checkout runs on the runner now and those three steps are gone.
- **`pytest-rerunfailures` was installed into the job container.** As its own step it would now install on the runner, where the notebooks do not execute, and `overrides.yaml`'s `reruns:` key would silently add no retry marker. It moved inside the run container, under `set -e`: as a separate step a failed install failed the job, and two commands in one shell would not have. I checked that specific regression rather than assuming - without `set -e` a failing `pip` exits 0 and pytest still runs.
- **`test-neo4j` reached its service by hostname.** `bolt://neo4j:7687` resolved only because the job container shared GitHub's per-job network with the service. It runs under `--network host` and reaches the port the service publishes to the runner.
- **`build-image-candidate` is skipped whenever a commit does not move the image**, and a skipped dependency skips its dependents. The gate is `always()` with `lint` and `changes` asserted explicitly, which leaves it exactly as strict as the `needs:` list it replaces.

`test-py312` and `test-benchmark` keep their `container:`, per the issue: those images install their own dependency sets over a constraint derived from the root lock, so their installed set legitimately differs and the drift guard would report drift that is not drift.

## The second commit is a defect the first one introduced

RoboRev's pre-push review caught it. `tests/test_image_rebuild_triggers.py` selected the jobs to check with `container: ml4t/ml4t:latest`, and the three no longer have one. Both of its tests filter that set and assert the filter caught nothing, so **an empty set passed them**: the regression coverage was gone and nothing was red.

Discovery now matches either shape that puts a job in the image, which also brings `test-unit-image` into the guarded set for the first time. But discovery alone fails the same way silently, so the expected membership is pinned and asserted; a job leaving the set names itself in a failure instead of shrinking the coverage.

Worth recording that **my first control did not fail**. Deleting only the resolve step left the run steps still referencing the resolved ref, so the job stayed discoverable and the test passed - that version proved nothing. The control that matters reverts `test-neo4j` to naming the published image directly, and it fails reporting `test-neo4j` as missing.

## How to judge this one

**The five required checks are not the gate here.** They do not include the three jobs this changes, so a green required set would say nothing about the change. What makes it verifiable is that `.github/workflows/test.yml` is in the `shared` paths-filter, which fans the matrix out to every chapter and every case study - so this PR runs the full ch01-ch26 matrix and all eight `cs-*` jobs against the converted workflow. Those are the checks to read.

Two known-red jobs are inherited rather than caused here: `ch11-12` and `ch18-20` fail identically on `main`.

Verified locally: `actionlint` clean, the workflow parses, `test_image_rebuild_triggers.py` 11 passed, and the nested `bash -c` quoting produces the intended argv - including a multi-word `workflow_dispatch` filter, checked under `env -i` to prove `$FILTER` expands inside the container rather than on the runner.

Closes ml4t/agent-workspace#1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvQUuNRz572ohmUwscwmzp
