### PR TITLE
The stages after the selection price one configuration, so they run once

### DIFF
--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2672,34 +2672,19 @@ case_studies/sp500_equity_option_analytics/15_portfolio_management:
         TOP_N_PREDICTIONS: 2
   timeout: 300
 case_studies/sp500_equity_option_analytics/17_costs:
-  # The same five labels as 14_backtest above, because this stage takes LABEL
-  # too and reads what the previous one registered for that label.
-  invocations:
-    - id: fwd_ret_5d
-      parameters:
-        LABEL: fwd_ret_5d
-        MAX_SYMBOLS: 5
-        TOP_N_COMBOS: 1
-    - id: fwd_dir_5d
-      parameters:
-        LABEL: fwd_dir_5d
-        MAX_SYMBOLS: 5
-        TOP_N_COMBOS: 1
-    - id: fwd_dir_10d
-      parameters:
-        LABEL: fwd_dir_10d
-        MAX_SYMBOLS: 5
-        TOP_N_COMBOS: 1
-    - id: fwd_ret_10d
-      parameters:
-        LABEL: fwd_ret_10d
-        MAX_SYMBOLS: 5
-        TOP_N_COMBOS: 1
-    - id: fwd_ret_risk_adj_5d
-      parameters:
-        LABEL: fwd_ret_risk_adj_5d
-        MAX_SYMBOLS: 5
-        TOP_N_COMBOS: 1
+  # One run, and no LABEL, unlike the three stages above it. This is the first stage
+  # after the selection: it opens the candidate set 16_risk_management froze, and prices
+  # the single configuration that set carries. That configuration is on one label, so the
+  # notebook treats an injected LABEL as a request and raises when it disagrees -
+  # "Costs price the configuration the selection names; running it under another label's
+  # contract would report a different strategy" (17_costs.py, the REQUESTED_LABEL guard).
+  #
+  # Fanning it out over the five labels 14/15/16 run is therefore four guaranteed
+  # failures and one pass, which is what #851 did and what CI run 34174124145 showed on
+  # main. The stages before the selection sweep every label; this one prices the winner.
+  parameters:
+    MAX_SYMBOLS: 5
+    TOP_N_COMBOS: 1
   timeout: 600
 case_studies/sp500_equity_option_analytics/16_risk_management:
   # The same five labels as 14_backtest above, because this stage takes LABEL
@@ -3599,21 +3584,18 @@ case_studies/us_firm_characteristics/12_portfolio_management:
         TOP_N_PREDICTIONS: 2
   timeout: 300
 case_studies/us_firm_characteristics/14_costs:
-  # The same three labels as 11_backtest above, because this stage takes LABEL
-  # too and reads what the previous one registered for that label.
-  invocations:
-    - id: fwd_ret_1m
-      parameters:
-        LABEL: fwd_ret_1m
-        MAX_SYMBOLS: 5
-    - id: fwd_class_1m
-      parameters:
-        LABEL: fwd_class_1m
-        MAX_SYMBOLS: 5
-    - id: fwd_ret_1m_win
-      parameters:
-        LABEL: fwd_ret_1m_win
-        MAX_SYMBOLS: 5
+  # One run, and no LABEL, unlike the three stages above it. Same reason as
+  # sp500_equity_option_analytics/17_costs: this stage sweeps the cost grid over the one
+  # configuration `resolve_solvent_carrier` carries forward. It reads the label off that
+  # carrier - `LABEL = carrier["label"]` at 14_costs.py:142, unconditional once the two
+  # differ - so an injected LABEL never reaches a decision.
+  #
+  # That makes a fan-out inert rather than red: #851 declared three and CI ran the same
+  # carrier three times, passing each. Two of the three were duplicates of the first, and
+  # a green tick on a run that could not have exercised its label is the coverage claim
+  # this file exists to keep honest.
+  parameters:
+    MAX_SYMBOLS: 5
   timeout: 600
 case_studies/us_firm_characteristics/13_risk_management:
   # The same three labels as 11_backtest above, because this stage takes LABEL

--- a/tests/test_invocation_fanout.py
+++ b/tests/test_invocation_fanout.py
@@ -7,13 +7,23 @@ chain ran the primary label and the rest were never exercised - while `17_costs`
 `us_firm_characteristics`) assert that every declared label carries rankable
 validation backtests. A claim tested on one label of five is not tested.
 
+Not every stage of such a chain takes the label as a free parameter. The stages after
+the selection run the one configuration the selection carried forward, and that
+configuration is on one label: `sp500_equity_option_analytics/17_costs` refuses a
+`LABEL` that disagrees with it, and `us_firm_characteristics/14_costs` overwrites the
+injected one with the carrier's. Fanning those out asks for five runs of a notebook
+that has one thing to do - four failures in the first case and two duplicates in the
+second. So the fan-out covers the stages before the selection and stops at it.
+
 These checks are about the declaration, not about a run: they hold the fan-out to the
-labels the case study declares, hold the stages of one chain to the same fan-out, and
-hold a `requires_stage` pair to fan-outs that line up. None of them needs a notebook.
+labels the case study declares, hold the stages of one chain to the same fan-out, hold
+a stage that resolves its own label to a single run, and hold a `requires_stage` pair
+to fan-outs that line up. Only the third opens a notebook.
 """
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -24,8 +34,50 @@ from tests.pm_helpers import OVERRIDES_PATH, invocations_for
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OVERRIDES: dict = yaml.safe_load(OVERRIDES_PATH.read_text()) or {}
 
-FANNED_OUT = sorted(
+DECLARED = sorted(
     key for key, entry in OVERRIDES.items() if isinstance(entry, dict) and entry.get("invocations")
+)
+
+
+def _resolves_its_own_label(key: str) -> bool:
+    """Does this notebook decide its own label, rather than run the one it is given?
+
+    Two shapes say so, and both are the notebook stating that the injected value is a
+    request rather than the answer. It binds `REQUESTED_LABEL`, keeping the parameter
+    apart from the label it resolves and comparing them; or it assigns `LABEL` from
+    something that is neither the parameter's own empty default nor the
+    `bt_config.primary_label` fallback every stage has.
+
+    Read off the notebook because that is where the contract lives. A stage moving
+    behind the selection is exactly the change that should force this file's hand, and
+    a list here would not notice it.
+    """
+    source = (REPO_ROOT / f"{key}.py").read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+        if "REQUESTED_LABEL" in names:
+            return True
+        if "LABEL" not in names:
+            continue
+        value = node.value
+        if isinstance(value, ast.Constant):
+            continue
+        if isinstance(value, ast.Attribute) and value.attr == "primary_label":
+            continue
+        return True
+    return False
+
+
+FANNED_OUT = [key for key in DECLARED if not _resolves_its_own_label(key)]
+RESOLVE_THEIR_OWN_LABEL = sorted(
+    key
+    for key, entry in OVERRIDES.items()
+    if isinstance(entry, dict)
+    and (REPO_ROOT / f"{key}.py").exists()
+    and _resolves_its_own_label(key)
 )
 
 
@@ -42,8 +94,36 @@ def _case_study(key: str) -> str:
 
 
 def test_some_notebook_declares_several_invocations() -> None:
-    """Without this the three checks below hold vacuously and would not say so."""
+    """Without this the checks below hold vacuously and would not say so."""
     assert FANNED_OUT, "no entry declares `invocations`; the checks below test nothing"
+
+
+def test_some_notebook_resolves_its_own_label() -> None:
+    """The same premise for the check that a self-resolving stage runs once."""
+    assert RESOLVE_THEIR_OWN_LABEL, (
+        "no notebook resolves its own label, so `_resolves_its_own_label` recognises "
+        "nothing and the check below cannot fail"
+    )
+
+
+@pytest.mark.parametrize("key", RESOLVE_THEIR_OWN_LABEL)
+def test_a_stage_that_resolves_its_own_label_runs_once(key: str) -> None:
+    """One selection carried forward is one configuration on one label.
+
+    `17_costs` raises on a `LABEL` that is not the selection's, so five invocations are
+    four failures; `14_costs` replaces the injected label with the carrier's, so three
+    are two duplicates of the first. Neither reaches a second label, and a fan-out that
+    cannot reach one is asserting coverage it does not have.
+    """
+    runs = invocations_for(OVERRIDES[key], key=key)
+    assert len(runs) == 1, (
+        f"{key} resolves its own label from the selection carried forward, so it has one "
+        f"run to make, but {len(runs)} are declared: {[run.id for run in runs]}"
+    )
+    assert "LABEL" not in runs[0].parameters, (
+        f"{key} is given LABEL={runs[0].parameters['LABEL']!r}, which it will refuse or "
+        f"overwrite; the selection names the label here"
+    )
 
 
 @pytest.mark.parametrize("key", FANNED_OUT)
@@ -59,7 +139,11 @@ def test_a_fanned_out_notebook_covers_every_label_its_case_study_declares(key: s
 
 
 def test_every_stage_of_one_chain_fans_out_the_same_way() -> None:
-    """15 reads what 14 registered for its label; a stage covering fewer breaks the chain."""
+    """15 reads what 14 registered for its label; a stage covering fewer breaks the chain.
+
+    Over the stages that take the label as a parameter. The ones that resolve it from the
+    selection are held to a single run instead, above.
+    """
     by_case_study: dict[str, dict[str, set[str]]] = {}
     for key in FANNED_OUT:
         ids = {run.id for run in invocations_for(OVERRIDES[key], key=key)}


### PR DESCRIPTION
#851 fanned four stages of each label-taking chain across every declared label. Three of the four take the label as a parameter. The fourth is the first stage after the selection, and it prices whatever the selection carried forward: one configuration, on one label. Fanning it out asks for runs it cannot make.

**`sp500_equity_option_analytics/17_costs` says so and raises.** From CI run 34174252466, and from main's own run 34174124145 before it:

> `LABEL='fwd_dir_10d'` was requested but the selection carried forward is `a45b8897af3c` on `'fwd_ret_risk_adj_5d'`. Costs price the configuration the selection names; running it under another label's contract would report a different strategy.

Four of its five runs fail that way. **main is red on this now.**

**`us_firm_characteristics/14_costs` does not raise, which is worse to find.** It reads `LABEL = carrier["label"]` at `14_costs.py:142` once the injected label disagrees, so all three runs swept the same carrier and all three passed. Two were duplicates of the first, and their green ticks reported coverage of two labels no run reached.

## The change

Both entries go back to a single `parameters` block with no `LABEL`. The stages before the selection still sweep every declared label; nothing else changes. Collection goes 223 -> 217.

`tests/test_invocation_fanout.py` grows the check. `_resolves_its_own_label` reads the notebook for the two shapes that say the label is not a free parameter (binding `REQUESTED_LABEL` and comparing it, or assigning `LABEL` from something that is neither the empty default nor the `bt_config.primary_label` fallback), and holds such a stage to one invocation carrying no `LABEL`. The two fan-out checks now range over the stages that do take it. A premise test asserts some notebook is recognised, so the new check cannot pass vacuously.

The detection reads the notebook rather than a list here, because a stage moving behind the selection is exactly the change that should force this file's hand, and a list would not notice it.

## Verification

Against the pre-fix `tests/overrides.yaml`:

```
$ uv run pytest tests/test_invocation_fanout.py -q
tests/test_invocation_fanout.py .......F...F.............
E   AssertionError: case_studies/sp500_equity_option_analytics/17_costs resolves its own
    label from the selection carried forward, so it has one run to make, but 5 are
    declared: ['fwd_ret_5d', 'fwd_dir_5d', 'fwd_dir_10d', 'fwd_ret_10d', 'fwd_ret_risk_adj_5d']
E   AssertionError: case_studies/us_firm_characteristics/14_costs resolves its own label
    from the selection carried forward, so it has one run to make, but 3 are declared:
    ['fwd_ret_1m', 'fwd_class_1m', 'fwd_ret_1m_win']
2 failed, 23 passed in 1.65s
```

After: 25 passed. 213 pass across `test_invocation_fanout`, `test_pm_helpers`, `test_smoke_configs`, `test_seoa_sweep_universe` and `test_ufc_sweep_grid_is_feasible`.

No notebook was executed and no fixture regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HHT2sUgKgTC2GfpePdm4m