### PR TITLE
The fixture registries describe the fixture, and the generation that writes them says what it left

### DIFF
--- a/tests/fixture_registry.py
+++ b/tests/fixture_registry.py
@@ -334,3 +334,170 @@ def restore_backed_prediction_rows(db_path: Path, captured: dict) -> dict[str, i
     finally:
         db.close()
     return restored
+
+
+#: The column carrying the realized outcome, in both conventions the fixture ships.
+TARGET_COLUMNS = ("actual", "y_true")
+ENTITY_COLUMNS = ("symbol", "product")
+
+
+def panel_signature(frame, entity: str) -> tuple:
+    """What makes two prediction artifacts the same cross-section.
+
+    Height, entities and timestamps - not the scores, which differ by construction, and
+    not the target, which is what a caller then checks agrees. Identifiers are
+    stringified because they are only ever compared for equality and a column carrying
+    nulls raises in ``sorted()``.
+    """
+    return (
+        frame.height,
+        tuple(sorted(map(str, frame[entity].unique().to_list()))),
+        tuple(map(str, frame["timestamp"].unique().sort().to_list())),
+    )
+
+
+def choose_reference_panel(by_signature: dict, hash_of=lambda entry: entry[0]) -> tuple:
+    """The panel a ``(split, label)`` group is seeded onto: most artifacts, then largest.
+
+    Ties break on the lowest hash so the choice comes out the same on every
+    regeneration. ``tests/fixtures/seed_results.py`` seeds its synthetic sets onto this
+    panel, which is what makes them joinable with the copied artifacts rather than only
+    with each other - so the rule has one implementation and both callers read it.
+
+    *by_signature* maps a :func:`panel_signature` to its entries; *hash_of* reads the
+    prediction hash out of one, because the two callers carry an entry as a tuple and as
+    a mapping. Returns the winning ``(signature, entries)`` pair.
+    """
+    return min(
+        by_signature.items(),
+        key=lambda item: (-len(item[1]), -item[0][0], hash_of(item[1][0])),
+    )
+
+
+def prediction_panels(case_dir: Path) -> dict:
+    """Per ``(split, label)``, the distinct cross-sections this fixture ships for it.
+
+    ``us_equities_panel`` ``(validation, fwd_ret_1d)`` ships two: four ``gbm`` artifacts
+    over 8 symbols storing the target as ``Float32``, and three ``linear`` ones over 56
+    storing it as ``Float64``. They share 5,212 of 16,744 keys and disagree on the
+    realized target by 2.6e-08 there, which is 260x the 1e-10 that
+    ``14_latent_factors/09_case_study_insights::paired_daily_ic`` rejects a pair at
+    (ml4t/agent-workspace#288). Which one a notebook lands on is decided by registry
+    metrics, so this returns the panels and what separates them rather than a verdict.
+
+    Returns ``{(split, label): {"panels": [...], "cross_panel_target_gap": float|None}}``
+    where each panel carries its hashes, entity count, target dtype and a frame.
+    """
+    import polars as pl
+
+    db_path = case_dir / "run_log" / "registry.db"
+    predictions = case_dir / "run_log" / "predictions"
+    if not db_path.is_file() or not predictions.is_dir():
+        return {}
+    db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = db.execute(
+            "SELECT ps.prediction_hash, ps.split, tr.label, tr.family FROM prediction_sets ps "
+            "JOIN training_runs tr ON tr.training_hash = ps.training_hash"
+        ).fetchall()
+    finally:
+        db.close()
+
+    groups: dict = {}
+    for prediction_hash, split, label, family in rows:
+        parquet = predictions / str(prediction_hash) / "predictions.parquet"
+        if parquet.is_file():
+            groups.setdefault((split, label), []).append((str(prediction_hash), family, parquet))
+
+    result: dict = {}
+    for key, members in sorted(groups.items(), key=lambda item: (str(item[0][0]), str(item[0][1]))):
+        by_signature: dict = {}
+        for prediction_hash, family, parquet in sorted(members):
+            frame = pl.read_parquet(parquet)
+            entity = next((name for name in ENTITY_COLUMNS if name in frame.columns), None)
+            target = next((name for name in TARGET_COLUMNS if name in frame.columns), None)
+            if entity is None or target is None or "timestamp" not in frame.columns:
+                continue
+            keyed = frame.select([entity, "timestamp", target]).rename(
+                {entity: "entity", target: "target"}
+            )
+            by_signature.setdefault(panel_signature(frame, entity), []).append(
+                {
+                    "prediction_hash": prediction_hash,
+                    "family": family,
+                    "entities": frame[entity].n_unique(),
+                    "target_dtype": str(frame.schema[target]),
+                    "frame": keyed,
+                }
+            )
+        if not by_signature:
+            continue
+        reference_signature, _ = choose_reference_panel(
+            by_signature, hash_of=lambda entry: entry["prediction_hash"]
+        )
+        panels = []
+        for signature, entries in by_signature.items():
+            panels.append(
+                {
+                    "hashes": [entry["prediction_hash"] for entry in entries],
+                    "families": sorted({entry["family"] for entry in entries}),
+                    "entities": entries[0]["entities"],
+                    "target_dtypes": sorted({entry["target_dtype"] for entry in entries}),
+                    "is_reference": signature == reference_signature,
+                    "entries": entries,
+                }
+            )
+        result[key] = {"panels": panels, "cross_panel_target_gap": _cross_panel_gap(panels)}
+    return result
+
+
+def _cross_panel_gap(panels: list) -> float | None:
+    """The largest target disagreement between two panels, over the keys they share."""
+    import itertools
+
+    import polars as pl
+
+    worst: float | None = None
+    for left, right in itertools.combinations(panels, 2):
+        a = left["entries"][0]["frame"].with_columns(
+            pl.col("timestamp").cast(pl.Datetime("us")).dt.replace_time_zone(None)
+        )
+        b = right["entries"][0]["frame"].with_columns(
+            pl.col("timestamp").cast(pl.Datetime("us")).dt.replace_time_zone(None)
+        )
+        joined = a.join(b, on=["entity", "timestamp"], how="inner")
+        if joined.is_empty():
+            continue
+        gap = float(
+            (joined["target"].cast(pl.Float64) - joined["target_right"].cast(pl.Float64))
+            .abs()
+            .max()
+        )
+        worst = gap if worst is None else max(worst, gap)
+    return worst
+
+
+def within_panel_target_gap(panel: dict) -> float:
+    """The largest target disagreement between artifacts of one cross-section.
+
+    Zero is the only acceptable value: these artifacts carry the same keys, so a
+    non-zero gap means two of them are scored against different outcomes while every
+    breadth and key check passes.
+    """
+    import polars as pl
+
+    entries = panel["entries"]
+    worst = 0.0
+    for other in entries[1:]:
+        joined = entries[0]["frame"].join(other["frame"], on=["entity", "timestamp"], how="inner")
+        if joined.is_empty():
+            continue
+        worst = max(
+            worst,
+            float(
+                (joined["target"].cast(pl.Float64) - joined["target_right"].cast(pl.Float64))
+                .abs()
+                .max()
+            ),
+        )
+    return worst

--- a/tests/fixture_registry.py
+++ b/tests/fixture_registry.py
@@ -1,0 +1,228 @@
+"""Keep a fixture's ``run_log`` describing what the fixture actually ships.
+
+The CI fixture registries were copied whole from production while the artifacts beside
+them were subsampled, so they pin files the fixture has never held. This module holds the
+operations that put a fixture registry back into agreement with its own tree; the callers
+are :mod:`tests.generate_intermediates`, which prunes before it registers, and
+``tests/reconcile_fixture_registry.py``, which reconciles a fixture already committed.
+
+Imported by ``generate_intermediates.py``, which runs standalone without pytest, so
+nothing here may import from ``conftest`` or from pytest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+
+#: The directories under a case study whose parquets a training run pins by whole-file
+#: sha256. ``utils.modeling`` builds ``input_data_spec.artifacts`` from exactly these:
+#: ``financial`` and ``model_based`` from ``features/``, ``label`` and ``eval_label``
+#: from ``labels/``.
+PINNED_ARTIFACT_DIRS = ("features", "labels")
+
+#: Every table that hangs off a training run, in the order they must be deleted so no
+#: statement removes a row another still needs to find its own. Each entry is
+#: ``(table, column, key)`` where *key* names which set of hashes the column is matched
+#: against: ``training``, ``prediction`` or ``backtest``.
+_CASCADE: tuple[tuple[str, str, str], ...] = (
+    ("backtest_paired_metrics", "challenger_hash", "backtest"),
+    ("backtest_paired_metrics", "benchmark_hash", "backtest"),
+    ("cohort_metrics", "leader_hash", "backtest"),
+    ("backtest_fold_metrics", "backtest_hash", "backtest"),
+    ("backtest_metrics", "backtest_hash", "backtest"),
+    ("backtest_runs", "backtest_hash", "backtest"),
+    ("fold_metrics", "prediction_hash", "prediction"),
+    ("prediction_metrics", "prediction_hash", "prediction"),
+    ("prediction_coverage", "prediction_hash", "prediction"),
+    ("official_population_members", "member_hash", "prediction"),
+    ("candidate_set_members", "member_hash", "prediction"),
+    ("holdout_staging", "holdout_prediction_hash", "prediction"),
+    ("holdout_evaluations", "holdout_prediction_hash", "prediction"),
+    ("prediction_sets", "prediction_hash", "prediction"),
+    ("candidate_fold_completions", "training_hash", "training"),
+    ("holdout_staging", "holdout_training_hash", "training"),
+    ("holdout_evaluations", "holdout_training_hash", "training"),
+    ("training_runs", "training_hash", "training"),
+)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def shipped_artifact_shas(case_dir: Path) -> dict[str, str]:
+    """Every sha256 the fixture ships under this case study, to the file carrying it.
+
+    Keyed by digest rather than by artifact name on purpose. A training run pins
+    ``label`` to ``labels/<its own label>.parquet`` and ``financial`` to
+    ``features/financial.parquet``, so resolving a pin by name means reproducing that
+    mapping here and going stale the day it changes. The question this module asks is
+    narrower and name-free: does the fixture hold the bytes this run was fitted on.
+    """
+    shas: dict[str, str] = {}
+    for subdir in PINNED_ARTIFACT_DIRS:
+        for parquet in sorted((case_dir / subdir).glob("*.parquet")):
+            shas[sha256_file(parquet)] = f"{subdir}/{parquet.name}"
+    return shas
+
+
+def pinned_input_shas(spec_json: str | dict | None) -> dict[str, str]:
+    """The ``{artifact name: sha256}`` a training run's spec pins, hex and unprefixed.
+
+    Mirrors ``case_studies/utils/registry/registration.py::_input_artifact_shas``, which
+    is what the vintage guard compares against, and tolerates the same spec shapes it
+    does: a spec that carries no ``computation.input_data_spec.artifacts`` block pins
+    nothing and is never stale.
+    """
+    spec = spec_json
+    if isinstance(spec, str):
+        try:
+            spec = json.loads(spec)
+        except (TypeError, ValueError):
+            return {}
+    if not isinstance(spec, dict):
+        return {}
+    computation = spec.get("computation")
+    if not isinstance(computation, dict):
+        return {}
+    input_data_spec = computation.get("input_data_spec")
+    if not isinstance(input_data_spec, dict):
+        return {}
+    artifacts = input_data_spec.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return {}
+    return {
+        str(name): str(record["sha256"]).removeprefix("sha256:")
+        for name, record in sorted(artifacts.items())
+        if isinstance(record, dict) and record.get("sha256")
+    }
+
+
+def stale_training_runs(db: sqlite3.Connection, case_dir: Path) -> dict[str, dict[str, str]]:
+    """Training runs fitted on input artifacts this fixture does not ship.
+
+    Returns ``{training_hash: {artifact name: pinned sha}}`` for the pins that are
+    absent, so a caller can say which file each row wanted rather than only how many
+    rows it dropped.
+    """
+    shipped = set(shipped_artifact_shas(case_dir))
+    stale: dict[str, dict[str, str]] = {}
+    for training_hash, spec_json in db.execute(
+        "SELECT training_hash, spec_json FROM training_runs"
+    ):
+        absent = {
+            name: sha for name, sha in pinned_input_shas(spec_json).items() if sha not in shipped
+        }
+        if absent:
+            stale[str(training_hash)] = absent
+    return stale
+
+
+def _existing_tables(db: sqlite3.Connection) -> set[str]:
+    return {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+
+
+def _in_batches(values: Iterable[str], size: int = 500):
+    batch: list[str] = []
+    for value in values:
+        batch.append(value)
+        if len(batch) == size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def delete_training_runs(db: sqlite3.Connection, training_hashes: set[str]) -> dict[str, int]:
+    """Remove these training runs and everything that hangs off them.
+
+    SQLite does not enforce the schema's foreign keys unless the connection asks it to,
+    so deleting ``training_runs`` alone leaves prediction sets, metrics and backtests
+    pointing at a row that is gone - which reads downstream as a corrupt registry rather
+    than a pruned one. The cascade is spelled out in :data:`_CASCADE` and applied leaf
+    first.
+    """
+    if not training_hashes:
+        return {}
+    tables = _existing_tables(db)
+    prediction_hashes: set[str] = set()
+    backtest_hashes: set[str] = set()
+    for batch in _in_batches(training_hashes):
+        marks = ",".join("?" * len(batch))
+        prediction_hashes.update(
+            str(row[0])
+            for row in db.execute(
+                f"SELECT prediction_hash FROM prediction_sets WHERE training_hash IN ({marks})",
+                batch,
+            )
+        )
+    if "backtest_runs" in tables:
+        for batch in _in_batches(prediction_hashes):
+            marks = ",".join("?" * len(batch))
+            backtest_hashes.update(
+                str(row[0])
+                for row in db.execute(
+                    f"SELECT backtest_hash FROM backtest_runs WHERE prediction_hash IN ({marks})",
+                    batch,
+                )
+            )
+    keys = {
+        "training": training_hashes,
+        "prediction": prediction_hashes,
+        "backtest": backtest_hashes,
+    }
+    deleted: dict[str, int] = {}
+    for table, column, key in _CASCADE:
+        if table not in tables:
+            continue
+        hashes = keys[key]
+        if not hashes:
+            continue
+        for batch in _in_batches(hashes):
+            marks = ",".join("?" * len(batch))
+            cursor = db.execute(f"DELETE FROM {table} WHERE {column} IN ({marks})", batch)
+            deleted[table] = deleted.get(table, 0) + cursor.rowcount
+    db.commit()
+    return {table: count for table, count in deleted.items() if count}
+
+
+def prune_stale_training_runs(case_dir: Path) -> dict:
+    """Drop this fixture's training runs that were fitted on artifacts it no longer has.
+
+    Called by the fixture generator immediately before its first registering stage. By
+    then stages 01-05 have rewritten ``features/`` and ``labels/``, so a row pinning an
+    older vintage is describing a population the fixture no longer holds - and the
+    vintage guard in ``register_training_run`` refuses to let the run about to start
+    join it (ml4t/agent-workspace#1082). Declaring an artifact supersession is the wrong
+    override: it would record that the fixture's reduced file deliberately replaces the
+    production one inside one continuing population, and the two were never in the same
+    population.
+
+    Returns a summary with the rows dropped per table and one example of what was
+    pinned, or ``{}`` when the case study has no registry yet.
+    """
+    db_path = case_dir / "run_log" / "registry.db"
+    if not db_path.is_file():
+        return {}
+    db = sqlite3.connect(str(db_path))
+    try:
+        stale = stale_training_runs(db, case_dir)
+        if not stale:
+            return {"training_runs_pruned": 0}
+        deleted = delete_training_runs(db, set(stale))
+    finally:
+        db.close()
+    example_hash = sorted(stale)[0]
+    return {
+        "training_runs_pruned": len(stale),
+        "deleted": deleted,
+        "example": {"training_hash": example_hash, "absent_pins": stale[example_hash]},
+    }

--- a/tests/fixture_registry.py
+++ b/tests/fixture_registry.py
@@ -501,3 +501,54 @@ def within_panel_target_gap(panel: dict) -> float:
             ),
         )
     return worst
+
+
+def unbacktested_populations(case_dir: Path) -> list[dict]:
+    """Populations in this fixture whose members carry no signal backtest.
+
+    A population scopes what `14_backtest` ranks: with one in force the notebook reads
+    `explorer.best(stage="signal", prediction_hashes=members)`, and with none it reads
+    unscoped. So a fixture that publishes a population and no backtests for its members
+    gives that read nothing, and before public #849 the first thing to touch the empty
+    frame was a division. That is how it arrived: a stage-08 regeneration created two
+    populations over 30 fresh prediction sets while every backtest in the fixture
+    referenced predictions from two weeks earlier, and the next CI run divided by zero
+    (ml4t/agent-workspace#1086).
+
+    Generation cannot avoid it - the model stages declare a population and the backtest
+    stages are numbers 14 and up, which `--through-stage 8` never reaches - so what a
+    generation owes is to say it left the fixture in that state rather than to let the
+    next CI run discover it.
+    """
+    db_path = case_dir / "run_log" / "registry.db"
+    if not db_path.is_file():
+        return []
+    db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        tables = _existing_tables(db)
+        if not {"official_populations", "official_population_members"} <= tables:
+            return []
+        rows = db.execute(
+            "SELECT p.population_hash, p.name, COUNT(m.member_hash) FROM official_populations p "
+            "LEFT JOIN official_population_members m ON m.population_hash = p.population_hash "
+            "GROUP BY p.population_hash, p.name"
+        ).fetchall()
+        unbacked = []
+        for population_hash, name, members in rows:
+            if not members:
+                continue
+            backtested = 0
+            if "backtest_runs" in tables:
+                backtested = db.execute(
+                    "SELECT COUNT(DISTINCT m.member_hash) FROM official_population_members m "
+                    "JOIN backtest_runs b ON b.prediction_hash = m.member_hash "
+                    "WHERE m.population_hash = ? AND b.stage = 'signal'",
+                    (population_hash,),
+                ).fetchone()[0]
+            if not backtested:
+                unbacked.append(
+                    {"name": name, "population_hash": population_hash, "members": members}
+                )
+        return unbacked
+    finally:
+        db.close()

--- a/tests/fixture_registry.py
+++ b/tests/fixture_registry.py
@@ -226,3 +226,111 @@ def prune_stale_training_runs(case_dir: Path) -> dict:
         "deleted": deleted,
         "example": {"training_hash": example_hash, "absent_pins": stale[example_hash]},
     }
+
+
+#: The tables a prediction set carries with it. Ordered parent first so a re-insert
+#: never writes a child before the row its foreign key names.
+_PREDICTION_TABLES: tuple[tuple[str, str], ...] = (
+    ("training_runs", "training_hash"),
+    ("prediction_sets", "prediction_hash"),
+    ("prediction_metrics", "prediction_hash"),
+    ("prediction_coverage", "prediction_hash"),
+    ("fold_metrics", "prediction_hash"),
+)
+
+
+def _table_columns(db: sqlite3.Connection, table: str) -> list[str]:
+    return [row[1] for row in db.execute(f"PRAGMA table_info({table})")]
+
+
+def capture_backed_prediction_rows(db_path: Path, case_dir: Path) -> dict:
+    """The registry rows describing prediction artifacts this fixture actually ships.
+
+    A re-sample rewrites the registry from production and leaves ``run_log/predictions/``
+    alone, so every artifact a generation wrote loses the row that named it: 6 directories
+    on etfs, 10 on fx_pairs, 39 on sp500_equity_option_analytics, all addressable by
+    nothing afterwards (ml4t/agent-workspace#1081). Captured before the rewrite and put
+    back after, these rows keep the fixture's own artifacts reachable.
+
+    Returns ``{table: (columns, rows)}``, empty when there is no registry yet.
+    """
+    if not db_path.is_file():
+        return {}
+    shipped = (
+        {entry.name for entry in (case_dir / "run_log" / "predictions").iterdir() if entry.is_dir()}
+        if (case_dir / "run_log" / "predictions").is_dir()
+        else set()
+    )
+    if not shipped:
+        return {}
+    db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        tables = _existing_tables(db)
+        if "prediction_sets" not in tables:
+            return {}
+        prediction_hashes: set[str] = set()
+        training_hashes: set[str] = set()
+        for batch in _in_batches(sorted(shipped)):
+            marks = ",".join("?" * len(batch))
+            for prediction_hash, training_hash in db.execute(
+                "SELECT prediction_hash, training_hash FROM prediction_sets "
+                f"WHERE prediction_hash IN ({marks})",
+                batch,
+            ):
+                prediction_hashes.add(str(prediction_hash))
+                training_hashes.add(str(training_hash))
+        if not prediction_hashes:
+            return {}
+        keys = {"training_hash": training_hashes, "prediction_hash": prediction_hashes}
+        captured: dict = {}
+        for table, column in _PREDICTION_TABLES:
+            if table not in tables:
+                continue
+            columns = _table_columns(db, table)
+            rows: list[tuple] = []
+            for batch in _in_batches(sorted(keys[column])):
+                marks = ",".join("?" * len(batch))
+                rows.extend(db.execute(f"SELECT * FROM {table} WHERE {column} IN ({marks})", batch))
+            if rows:
+                captured[table] = (columns, rows, column, sorted(keys[column]))
+        return captured
+    finally:
+        db.close()
+
+
+def restore_backed_prediction_rows(db_path: Path, captured: dict) -> dict[str, int]:
+    """Put captured rows back, replacing whatever the rebuilt registry holds for them.
+
+    Replace rather than ignore: where production also carries the hash, its metrics
+    describe the production artifact, and the file the fixture ships is the subsample.
+    The row that names a shipped artifact has to be the one measured against it.
+    """
+    if not captured or not db_path.is_file():
+        return {}
+    db = sqlite3.connect(str(db_path))
+    restored: dict[str, int] = {}
+    try:
+        tables = _existing_tables(db)
+        for table, _ in _PREDICTION_TABLES:
+            if table not in captured or table not in tables:
+                continue
+            columns, rows, key_column, keys = captured[table]
+            present = set(_table_columns(db, table))
+            shared = [name for name in columns if name in present]
+            if not shared:
+                continue
+            for batch in _in_batches(keys):
+                marks = ",".join("?" * len(batch))
+                db.execute(f"DELETE FROM {table} WHERE {key_column} IN ({marks})", batch)
+            index = {name: position for position, name in enumerate(columns)}
+            quoted = ",".join(f'"{name}"' for name in shared)
+            marks = ",".join("?" * len(shared))
+            db.executemany(
+                f"INSERT INTO {table} ({quoted}) VALUES ({marks})",
+                [tuple(row[index[name]] for name in shared) for row in rows],
+            )
+            restored[table] = len(rows)
+        db.commit()
+    finally:
+        db.close()
+    return restored

--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -21,6 +21,7 @@ import yaml
 
 from case_studies.utils.registry.specs import IDENTITY_VERSION
 from case_studies.utils.registry.store import _open_registry
+from tests.fixture_registry import choose_reference_panel, panel_signature
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 CS_ROOT = REPO_ROOT / "case_studies"
@@ -882,20 +883,11 @@ def _reference_panels(cs_dir: Path, hash_rows: list, survives, _pl) -> dict:
             entity = next((c for c in ENTITY_COLUMN_CANDIDATES if c in frame.columns), None)
             if entity is None or not {"timestamp", "actual"} <= set(frame.columns):
                 continue
-            # Only ever compared for equality, so stringifying the identifiers is
-            # enough and keeps a column carrying nulls from raising in sorted().
-            signature = (
-                frame.height,
-                tuple(sorted(map(str, frame[entity].unique().to_list()))),
-                tuple(map(str, frame["timestamp"].unique().sort().to_list())),
-            )
+            signature = panel_signature(frame, entity)
             by_signature.setdefault(signature, []).append((p_hash, frame, entity))
         if not by_signature:
             continue
-        _, entries = min(
-            by_signature.items(),
-            key=lambda item: (-len(item[1]), -item[0][0], item[1][0][0]),
-        )
+        _, entries = choose_reference_panel(by_signature)
         _, frame, entity = entries[0]
         panels[key] = _subsampled_panel(frame, entity, _pl)
     return panels

--- a/tests/generate_intermediates.py
+++ b/tests/generate_intermediates.py
@@ -45,11 +45,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 try:
-    from tests.fixture_registry import prune_stale_training_runs
+    from tests.fixture_registry import prune_stale_training_runs, unbacktested_populations
     from tests.pm_helpers import get_overrides, invocations_for, run_notebook
     from tests.preset_patches import _patch_presets_for_testing, _trim_label_configs
 except ModuleNotFoundError:
-    from fixture_registry import prune_stale_training_runs
+    from fixture_registry import prune_stale_training_runs, unbacktested_populations
     from pm_helpers import get_overrides, invocations_for, run_notebook
     from preset_patches import _patch_presets_for_testing, _trim_label_configs
 
@@ -281,6 +281,16 @@ def main():
     results = {}
     total_start = time.time()
 
+    # Which populations the fixture already carried, so the summary can name the ones
+    # this run added rather than every one it finds.
+    populations_before = {
+        cs: {
+            population["population_hash"]
+            for population in unbacktested_populations(output_dir / cs)
+        }
+        for cs in case_studies
+    }
+
     for cs in case_studies:
         cs_dir = REPO_ROOT / "case_studies" / cs
         if not cs_dir.exists():
@@ -396,6 +406,39 @@ def main():
 
     total_elapsed = time.time() - total_start
 
+    # A population whose members carry no backtest is what `14_backtest` reads as an
+    # empty ranking, and before public #849 what it read as `ZeroDivisionError`. The
+    # model stages declare the population and the backtest stages are numbers 14 and up,
+    # so `--through-stage 8` cannot avoid leaving one; what it can do is say so, rather
+    # than let the next CI run be the thing that reports it fifteen minutes after the
+    # fixture was committed (ml4t/agent-workspace#1086).
+    # Only the ones this run added. Eight of the nine committed fixtures already ship a
+    # population in that state, so listing all of them on every run would be noise; a
+    # run creating one is the event that landed test-data 4db8572f.
+    unbacked = {}
+    for cs in case_studies:
+        added = [
+            population
+            for population in unbacktested_populations(output_dir / cs)
+            if population["population_hash"] not in populations_before.get(cs, set())
+        ]
+        if added:
+            unbacked[cs] = added
+    if unbacked:
+        print(f"\n{'=' * 60}")
+        print("This run published a population with no backtested member")
+        print(f"{'=' * 60}")
+        print("  `14_backtest` scopes its baseline ranking to the members in force, so it")
+        print("  has nothing to rank against this fixture and refuses. The backtest stages")
+        print("  are numbers 14 and up, which this run did not reach. Either run them into")
+        print("  the fixture, or do not commit these populations.")
+        for cs, populations in sorted(unbacked.items()):
+            for population in populations:
+                print(
+                    f"  {cs}: {population['name']} "
+                    f"({population['members']} member(s), 0 backtested)"
+                )
+
     # Summary
     print(f"\n{'=' * 60}")
     print(f"Summary ({total_elapsed:.0f}s total)")
@@ -457,6 +500,10 @@ def main():
         "total_seconds": round(total_elapsed),
         "size_mb": round(total_bytes / 1e6, 1),
         "size_mb_by_case_study": sizes,
+        "populations_with_no_backtested_member": {
+            cs: [population["name"] for population in populations]
+            for cs, populations in sorted(unbacked.items())
+        },
     }
     with open(metadata_path, "w") as f:
         json.dump(metadata, f, indent=2)

--- a/tests/generate_intermediates.py
+++ b/tests/generate_intermediates.py
@@ -45,9 +45,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 try:
+    from tests.fixture_registry import prune_stale_training_runs
     from tests.pm_helpers import get_overrides, invocations_for, run_notebook
     from tests.preset_patches import _patch_presets_for_testing, _trim_label_configs
 except ModuleNotFoundError:
+    from fixture_registry import prune_stale_training_runs
     from pm_helpers import get_overrides, invocations_for, run_notebook
     from preset_patches import _patch_presets_for_testing, _trim_label_configs
 
@@ -160,6 +162,21 @@ def discover_stages(cs_dir: Path, through_stage: int, skip_dl: bool) -> list[Pat
         stages.append(notebook)
 
     return stages
+
+
+# The pipeline stages: the ones that build the artifacts a training run pins by
+# sha256. Everything after them registers runs fitted on those artifacts. The boundary
+# is read from the stem rather than from the stage number because it is not the same
+# number in every case study - `us_firm_characteristics` has no model-based stage and
+# starts registering at `05_linear`, where the other eight start at `06_linear`.
+PIPELINE_STAGE_STEMS = re.compile(
+    r"\d{2}_(feasibility_analysis|labels|financial_features|model_based_features|evaluation)$"
+)
+
+
+def registers_training_runs(notebook: Path) -> bool:
+    """Whether this stage registers training runs, rather than building their inputs."""
+    return PIPELINE_STAGE_STEMS.match(notebook.stem) is None
 
 
 # Outcomes a stage can end a generation run with. `incomplete` is the one this
@@ -285,6 +302,7 @@ def main():
         print(f"{'=' * 60}")
 
         cs_failed = False
+        pruned = False
         for notebook in stages:
             stage = notebook.stem
 
@@ -292,6 +310,31 @@ def main():
                 print(f"  {stage}: NOT RUN (an earlier stage did not complete)")
                 results[f"{cs}::{stage}"] = NOT_RUN
                 continue
+
+            # The last moment at which the fixture's own artifacts are final and nothing
+            # has been registered against them yet. Stages 01-05 have just rewritten
+            # `features/` and `labels/`, so any training run in the registry pinning an
+            # older vintage describes a population this fixture no longer holds - and the
+            # vintage guard refuses to let the stage about to run join it, which is what
+            # stopped `06_linear` for sp500_options and us_equities_panel on 2026-09-07
+            # (ml4t/agent-workspace#1082).
+            if not pruned and registers_training_runs(notebook):
+                pruned = True
+                summary = prune_stale_training_runs(output_dir / cs)
+                dropped = summary.get("training_runs_pruned", 0)
+                if dropped:
+                    example = summary["example"]
+                    pins = ", ".join(
+                        f"{name}={sha[:12]}" for name, sha in example["absent_pins"].items()
+                    )
+                    rows = ", ".join(
+                        f"{table} {count}" for table, count in sorted(summary["deleted"].items())
+                    )
+                    print(
+                        f"  pruned {dropped} training run(s) fitted on artifacts this fixture "
+                        f"no longer ships (e.g. {example['training_hash'][:12]} pinned {pins})"
+                    )
+                    print(f"    rows removed: {rows}")
 
             rel_path = notebook.relative_to(REPO_ROOT).with_suffix("")
             overrides = get_overrides(str(rel_path))

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1831,19 +1831,55 @@ case_studies/etfs/11c_conditional_autoencoder:
       max_symbols: 6
   timeout: 900
 case_studies/etfs/11d_stochastic_discount_factor:
-  # Still skipped, but not for the reason it used to claim. The old skip_reason said
-  # "TEMPORARY: DL training (SDF) 300s timeout under trimmed test-data"; the timeout is not
-  # what fails it. It is the only latent member that loads the initial-release macro panel
+  # Un-skipped. It is the only latent member that loads the initial-release macro panel
   # config/setup.yaml declares (modeling.latent_factors.macro_context.source:
-  # alfred_initial_release), and that fixture does not exist in the test-data repo:
-  # data/macro/ ships fred_macro{,_raw,_dictionary,_raw_dictionary,_metadata}.parquet and no
-  # fred_macro_initial_release.parquet. Not gitignored - never built. So this cannot be
-  # un-skipped by any parameter choice until that fixture is built; filed as ml4t/agent-workspace#1035.
+  # alfred_initial_release), and that fixture did not exist - data/macro/ shipped
+  # fred_macro{,_raw,_dictionary,_raw_dictionary,_metadata}.parquet and no
+  # fred_macro_initial_release.parquet, never built rather than gitignored. Built by
+  # `data/macro/download_alfred.py` and committed to the test-data repo
+  # (ml4t/agent-workspace#1035). The panel starts 2010-11-22, which is where ALFRED's
+  # VIXCLS vintages start; the etfs fixture reaches back to 2007, so the macro context
+  # covers the later part of that window and not the whole of it.
   #
-  # 11c and 11e above ARE un-skipped: they do not read the macro panel, and their own
-  # blocker (#926) is worked around by pinning them to the primary label.
-  skip: true
-  skip_reason: 'no fred_macro_initial_release.parquet in the test-data repo; SDF is the one latent member that reads the declared initial-release macro panel (ml4t/agent-workspace#1035)'
+  # Reading fred_macro.parquet instead would be a look-ahead: that file is the finalized
+  # revised series, and this member is declared against the point-in-time vintage.
+  #
+  # LABELS, POPULATION_NAME and DEVICE for the same reasons as 11c and 11e above:
+  # ml4t/agent-workspace#926 leaves features/model_based.parquet carrying one fold
+  # geometry, a narrowed run cannot publish the canonical population, and the family is
+  # declared on cuda where the library refuses to substitute a device. The three epoch
+  # budgets are stated because preset_patches.py patches `n_epochs`, which this model does
+  # not read - its budgets are n_epochs_unc, n_epochs_moment and n_epochs_cond, so an
+  # unreduced run trains 256 + 64 + 1024 epochs.
+  #
+  # A fold reduction is what the seoa entry does not need and this one does. The two
+  # fixtures are not the same length: seoa spans 2017-2021 and etfs spans 2007-2025, so at
+  # the same width and the same epoch budgets this notebook walks about four times as many
+  # sessions, and it timed out at 1800s with all eight folds where seoa measures 537s. Two
+  # folds brings the walk back to seoa's size without touching the width, which the SDF
+  # conditioning network needs.
+  #
+  # Stated as `folds` inside PREVIEW_REDUCTIONS rather than as MAX_FOLDS. The translation
+  # from MAX_FOLDS runs on the preview path only, so the name reaches the canonical path
+  # untranslated, where papermill drops it and logs "Passed unknown parameter" - which is
+  # what `unusable_parameters` reports and what a silently unreduced run looks like.
+  parameters:
+    DEVICE: cpu
+    LABELS: ['fwd_ret_21d']
+    POPULATION_NAME: etfs-sdf-preview
+    PREVIEW_REDUCTIONS:
+      folds: [0, 1]
+      max_symbols: 6
+      n_epochs_unc: 2
+      n_epochs_moment: 2
+      n_epochs_cond: 4
+  # Measured on this workstation at load 33-55 of 24 cores, which is where every number
+  # available for this notebook was taken: 1,167s with the two folds above, against a run
+  # that hit the 1800s cap with all eight. That is the loaded figure, not the idle one -
+  # the us_equities_panel/06_linear entry records the same shape, a notebook that fit in
+  # 120s idle, did not fit in 120s loaded, and passed at 300 - so the cap is the one-third
+  # line against the loaded measurement rather than against a quiet-machine guess.
+  timeout: 3600
 case_studies/etfs/11e_supervised_autoencoder:
   # Same restriction and the same reason as 11c above.
   parameters:

--- a/tests/reconcile_fixture_registry.py
+++ b/tests/reconcile_fixture_registry.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Bring a committed fixture registry back into agreement with the artifacts beside it.
+
+The nine registries under ``ml4t/third-edition-test-data`` ``intermediates/*/run_log/``
+were copied whole from production while the artifacts beside them were subsampled. Two
+consequences are repairable in place, without regenerating the fixture:
+
+* **Metrics that describe a different file.** A shipped ``predictions.parquet`` is a
+  subsample; its ``prediction_metrics`` row is production's. ``crypto_perps_funding``
+  ``f6bd7cd2d208`` registers 2104 IC days against a parquet holding 66, and
+  ``08_signal_method_comparison::validate_prediction_set`` rejects the pair - correctly.
+  Recomputing the row from the shipped parquet makes the fixture internally consistent
+  at whatever scale it ships (ml4t/agent-workspace#286).
+
+* **Artifact directories nothing can reach.** A ``run_log/predictions/<hash>/`` with no
+  ``prediction_sets`` row is addressable by nothing: every reader resolves a hash out of
+  the registry. These are what a re-sample leaves behind when it rewrites the registry
+  after a generation wrote artifacts (ml4t/agent-workspace#1081).
+
+What it deliberately does not do is invent rows for the 97.7% of registered predictions
+whose artifact the fixture has never held. Those rows are the replay surface the
+chapter notebooks and the ``research_preview: false`` case-study stages rank over, and
+seeding their artifacts is 88 MB per panel. ``--report`` prints how many there are so
+the gap is visible rather than silent.
+
+Usage::
+
+    uv run python tests/reconcile_fixture_registry.py --report
+    uv run python tests/reconcile_fixture_registry.py --apply
+    uv run python tests/reconcile_fixture_registry.py --apply --case-study etfs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+try:
+    from tests.fixture_registry import PINNED_ARTIFACT_DIRS
+except ModuleNotFoundError:  # standalone, as generate_intermediates.py also runs
+    from fixture_registry import PINNED_ARTIFACT_DIRS
+
+DEFAULT_INTERMEDIATES = Path.home() / "ml4t" / "test-data" / "intermediates"
+
+#: The column each role takes in a shipped artifact. Both conventions are in the tree:
+#: ``tests/conftest.py::_migrate_predictions_schema`` renames the legacy trio at seed
+#: time, so the fixture ships either and a reconciliation that knew only one would skip
+#: every legacy artifact silently.
+_COLUMNS = {
+    "score": ("prediction", "y_score"),
+    "target": ("actual", "y_true"),
+    "fold": ("fold", "fold_id"),
+    "date": ("timestamp", "date"),
+    "entity": ("symbol", "product"),
+}
+
+
+def _resolve(columns: list[str], role: str) -> str | None:
+    return next((name for name in _COLUMNS[role] if name in columns), None)
+
+
+def _spec_context(spec_json: str | None) -> dict:
+    """Task type, label buffer and eval column, read off the training run's own spec."""
+    try:
+        spec = json.loads(spec_json or "{}")
+    except (TypeError, ValueError):
+        return {}
+    computation = spec.get("computation") or {}
+    input_spec = computation.get("input_data_spec") or {}
+    task = computation.get("task") or {}
+    return {
+        "label": spec.get("label"),
+        "task_type": input_spec.get("task_type") or "regression",
+        "label_buffer": input_spec.get("label_buffer"),
+        "eval_label_col": input_spec.get("eval_label_col"),
+        "class_values": task.get("class_values"),
+    }
+
+
+def prediction_dirs(case_dir: Path) -> list[str]:
+    """Every ``run_log/predictions/<hash>/`` the fixture ships, parquet or not.
+
+    Empty ones count. ``sp500_equity_option_analytics`` ships 39 directories of which 30
+    hold no file at all - the residue of a regeneration whose registry rows a later
+    re-sample overwrote - and a check that only looked at directories holding a parquet
+    would call the tree clean while 30 dead directories sat in it.
+    """
+    root = case_dir / "run_log" / "predictions"
+    if not root.is_dir():
+        return []
+    return sorted(entry.name for entry in root.iterdir() if entry.is_dir())
+
+
+def shipped_predictions(case_dir: Path) -> dict[str, Path]:
+    """``{prediction_hash: parquet}`` for every prediction artifact this fixture ships."""
+    root = case_dir / "run_log" / "predictions"
+    return {
+        name: root / name / "predictions.parquet"
+        for name in prediction_dirs(case_dir)
+        if (root / name / "predictions.parquet").is_file()
+    }
+
+
+def recompute_metrics(parquet: Path, context: dict) -> tuple[dict, dict[int, dict]]:
+    """Headline and per-fold metrics as the *shipped* parquet determines them.
+
+    Calls the same ``compute_prediction_fold_metrics`` a registration calls, so the
+    reconciled row is produced by the code that writes a real one rather than by a second
+    implementation of the same statistics that could drift from it.
+    """
+    import polars as pl
+
+    from case_studies.utils.registry.metrics import compute_prediction_fold_metrics
+
+    frame = pl.read_parquet(parquet)
+    columns = frame.columns
+    score = _resolve(columns, "score")
+    target = _resolve(columns, "target")
+    fold = _resolve(columns, "fold")
+    date = _resolve(columns, "date")
+    entity = _resolve(columns, "entity")
+    if not (score and target and fold and date and entity):
+        raise ValueError(
+            f"{parquet} carries {columns}, which does not resolve a score, target, fold, "
+            f"date and entity column; its metrics cannot be recomputed from it."
+        )
+    eval_col = "eval_actual" if "eval_actual" in columns else None
+    task_type = str(context.get("task_type") or "regression")
+    if task_type == "classification" and eval_col is None:
+        # IC against a binary label collapses to 2*(AUC-0.5) and is not a rank
+        # correlation against returns, which is why compute_prediction_fold_metrics
+        # requires the continuous column. Without it in the artifact there is nothing to
+        # recompute honestly, so say so rather than register a different statistic under
+        # the same column name.
+        raise ValueError(
+            f"{parquet} is a classification prediction set with no 'eval_actual' column, "
+            f"so its IC cannot be recomputed from the shipped artifact."
+        )
+    return compute_prediction_fold_metrics(
+        frame,
+        y_true_col=target,
+        y_score_col=score,
+        fold_col=fold,
+        date_col=date,
+        entity_col=entity,
+        task_type=task_type,
+        class_values=context.get("class_values"),
+        eval_col=eval_col,
+        label=context.get("label"),
+        label_buffer=context.get("label_buffer"),
+    )
+
+
+def _write_metrics(
+    db: sqlite3.Connection, prediction_hash: str, headline: dict, folds: dict
+) -> None:
+    columns = {row[1] for row in db.execute("PRAGMA table_info(prediction_metrics)")}
+    payload = {
+        name: value
+        for name, value in headline.items()
+        if name in columns and name != "prediction_hash"
+    }
+    payload["computed_at"] = datetime.now(UTC).isoformat()
+    names = ["prediction_hash", *sorted(payload)]
+    marks = ",".join("?" * len(names))
+    quoted = ",".join(f'"{name}"' for name in names)
+    db.execute("DELETE FROM prediction_metrics WHERE prediction_hash = ?", (prediction_hash,))
+    db.execute(
+        f"INSERT INTO prediction_metrics ({quoted}) VALUES ({marks})",
+        [prediction_hash, *(payload[name] for name in sorted(payload))],
+    )
+    fold_columns = {row[1] for row in db.execute("PRAGMA table_info(fold_metrics)")}
+    db.execute("DELETE FROM fold_metrics WHERE prediction_hash = ?", (prediction_hash,))
+    for fold_id, metrics in sorted(folds.items()):
+        row = {name: value for name, value in metrics.items() if name in fold_columns}
+        row["prediction_hash"] = prediction_hash
+        row["fold_id"] = int(fold_id)
+        row["computed_at"] = payload["computed_at"]
+        names = sorted(row)
+        marks = ",".join("?" * len(names))
+        quoted = ",".join(f'"{name}"' for name in names)
+        db.execute(
+            f"INSERT INTO fold_metrics ({quoted}) VALUES ({marks})", [row[name] for name in names]
+        )
+
+
+def reconcile(case_dir: Path, *, apply: bool) -> dict:
+    """Report, and optionally repair, one case study's registry against its own tree."""
+    db_path = case_dir / "run_log" / "registry.db"
+    if not db_path.is_file():
+        return {"status": "no registry"}
+    shipped = shipped_predictions(case_dir)
+    # Counted before anything is removed. Reporting the tree after the deletions
+    # describes the repair rather than what was found, which is the one thing a
+    # --report run exists to say.
+    dirs = prediction_dirs(case_dir)
+    db = sqlite3.connect(str(db_path))
+    try:
+        registered = {row[0] for row in db.execute("SELECT prediction_hash FROM prediction_sets")}
+        orphans = sorted(set(dirs) - registered)
+        unbacked = len(registered - set(shipped))
+        recomputed, failed = [], {}
+        for prediction_hash in sorted(set(shipped) & registered):
+            row = db.execute(
+                "SELECT tr.spec_json FROM prediction_sets ps "
+                "JOIN training_runs tr ON tr.training_hash = ps.training_hash "
+                "WHERE ps.prediction_hash = ?",
+                (prediction_hash,),
+            ).fetchone()
+            context = _spec_context(row[0] if row else None)
+            try:
+                headline, folds = recompute_metrics(shipped[prediction_hash], context)
+            except (ValueError, KeyError) as exc:
+                failed[prediction_hash] = str(exc)
+                continue
+            recomputed.append(prediction_hash)
+            if apply:
+                _write_metrics(db, prediction_hash, headline, folds)
+        if apply:
+            db.commit()
+    finally:
+        db.close()
+    if apply:
+        for prediction_hash in orphans:
+            shutil.rmtree(case_dir / "run_log" / "predictions" / prediction_hash)
+    return {
+        "status": "ok",
+        "dirs": len(dirs),
+        "shipped": len(shipped),
+        "registered": len(registered),
+        "recomputed": len(recomputed),
+        "orphan_dirs": len(orphans),
+        "rows_without_a_shipped_artifact": unbacked,
+        "failed": failed,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--intermediates", type=Path, default=DEFAULT_INTERMEDIATES)
+    parser.add_argument("--case-study", action="append", dest="case_studies")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--report", action="store_true", help="measure and change nothing (default)")
+    mode.add_argument("--apply", action="store_true", help="write the reconciled rows")
+    args = parser.parse_args()
+
+    root = args.intermediates.expanduser().resolve()
+    if root.name != "intermediates":
+        parser.error(f"{root} is not a fixture intermediates root")
+    names = args.case_studies or sorted(
+        entry.name for entry in root.iterdir() if (entry / "run_log" / "registry.db").is_file()
+    )
+    failures = 0
+    for name in names:
+        stats = reconcile(root / name, apply=args.apply)
+        if stats["status"] != "ok":
+            print(f"{name:34s} {stats['status']}")
+            continue
+        print(
+            f"{name:34s} dirs {stats['dirs']:4d}  with a parquet {stats['shipped']:4d}  "
+            f"registered {stats['registered']:5d}  recomputed {stats['recomputed']:4d}  "
+            f"orphan dirs {stats['orphan_dirs']:3d}  "
+            f"rows with no shipped artifact {stats['rows_without_a_shipped_artifact']:5d}"
+        )
+        for prediction_hash, reason in stats["failed"].items():
+            failures += 1
+            print(f"    {prediction_hash}: {reason}")
+    if not args.apply:
+        print("\nNothing was written. Re-run with --apply.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/sample_registry_for_tests.py
+++ b/tests/sample_registry_for_tests.py
@@ -30,6 +30,14 @@ import sqlite3
 import sys
 from pathlib import Path
 
+try:
+    from tests.fixture_registry import (
+        capture_backed_prediction_rows,
+        restore_backed_prediction_rows,
+    )
+except ModuleNotFoundError:  # standalone, like generate_intermediates.py
+    from fixture_registry import capture_backed_prediction_rows, restore_backed_prediction_rows
+
 REPO_ROOT = Path(__file__).parent.parent
 CODE_CS_DIR = REPO_ROOT / "case_studies"
 
@@ -201,6 +209,13 @@ def sample_registry(cs_id: str, intermediates_dir: Path = DEFAULT_INTERMEDIATES_
     dst_dir.mkdir(parents=True, exist_ok=True)
     dst_db = dst_dir / "registry.db"
 
+    # The rows that name an artifact this fixture ships, read before the rewrite that
+    # would drop them. `run_log/predictions/` is deliberately not removed below - a
+    # generation writes those artifacts and nothing else does - so rebuilding the
+    # registry from production alone leaves each of them addressable by nothing: every
+    # reader resolves a prediction by hash out of the registry (ml4t/agent-workspace#1081).
+    backed = capture_backed_prediction_rows(dst_db, intermediates_dir / cs_id)
+
     # Remove old DB to start fresh. The artifact dirs go too: they are keyed by
     # backtest_hash, so a re-sample that changes hashes would otherwise leave the
     # previous generation's directories behind alongside the new ones.
@@ -217,6 +232,9 @@ def sample_registry(cs_id: str, intermediates_dir: Path = DEFAULT_INTERMEDIATES_
             dst.close()
     finally:
         src.close()
+
+    restored = restore_backed_prediction_rows(dst_db, backed)
+    stats["fixture_rows_restored"] = sum(restored.values())
 
     sampled = stats.pop("sampled_hashes", set())
     artifacts = _copy_backtest_artifacts(src_db.parent, dst_dir, sampled)
@@ -1018,6 +1036,7 @@ def main() -> int:
         ]:
             print(f"  {table:30s} {stats.get(table, 0):>6}")
         print(f"  {'backtest artifact dirs':30s} {stats.get('backtest_artifact_dirs', 0):>6}")
+        print(f"  {'fixture rows restored':30s} {stats.get('fixture_rows_restored', 0):>6}")
         print(f"  {'file size (KB)':30s} {stats['file_size_kb']:>6}")
         missing_dir = stats.get("backtest_artifacts_missing_dir", 0)
         missing_returns = stats.get("backtest_artifacts_missing_returns", 0)

--- a/tests/test_fixture_file_size_ceiling.py
+++ b/tests/test_fixture_file_size_ceiling.py
@@ -1,0 +1,87 @@
+"""No fixture file may come within the margin of GitHub's per-file limit.
+
+`intermediates/nasdaq100_microstructure/features/financial.parquet` reached 98.8 MB
+against a hard 100 MiB, and the way that surfaced was a rejected push in an unrelated
+lane: the fixture repo uses no Git LFS, so the limit is enforced by the remote at the
+moment someone tries to publish a regeneration (ml4t/agent-workspace#1019). Nothing in
+either repo measured it.
+
+The immediate cause there is fixed - `tests/overrides.yaml` set `MAX_SYMBOLS: 5` for
+nasdaq's 01, 02, 04, 05 and 07 and not for `03_financial_features`, whose notebook
+default applies no reduction, and the missing line takes that panel to 50.5 MB. What was
+not fixed is that nothing checks. This does.
+
+The ceiling is GitHub's limit less a margin, not the limit itself. A check that fired at
+100 MiB would fire for the first time on the commit that is already unpublishable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+#: GitHub rejects a push carrying a file at or above this size, on every repository,
+#: with no per-repository setting. `ml4t/third-edition-test-data` tracks its parquets
+#: directly rather than through Git LFS, so this applies to every one of them.
+GITHUB_FILE_LIMIT_BYTES = 100 * 1024 * 1024
+
+#: What is left for one regeneration's growth. The binding file today is
+#: `intermediates/etfs/features/financial.parquet` at 93,815,698 bytes - 89.5 MiB, 89.5%
+#: of the limit - so the margin has to be small enough to admit it and large enough that
+#: the failure arrives before the push does. Ten mebibytes is roughly one added feature
+#: block on a panel of this width.
+MARGIN_BYTES = 10 * 1024 * 1024
+
+CEILING_BYTES = GITHUB_FILE_LIMIT_BYTES - MARGIN_BYTES
+
+
+def test_no_fixture_file_is_within_the_margin_of_the_push_limit(intermediates_dir):
+    """Measured over the fixture as committed, not over what a generation would write.
+
+    A generation writes into whatever `--output` names, and the file that gets rejected
+    is the one in the repo, so the repo is what this reads.
+    """
+    if intermediates_dir is None:
+        pytest.skip("no test-data intermediates on this checkout")
+    oversized = sorted(
+        (path.stat().st_size, path)
+        for path in intermediates_dir.rglob("*")
+        if path.is_file() and path.stat().st_size > CEILING_BYTES
+    )
+    assert not oversized, (
+        "fixture file(s) within "
+        f"{MARGIN_BYTES / 1024 / 1024:.0f} MiB of GitHub's {GITHUB_FILE_LIMIT_BYTES / 1024 / 1024:.0f} MiB "
+        "per-file limit, so the next regeneration's push is rejected:\n  "
+        + "\n  ".join(
+            f"{path.relative_to(intermediates_dir)} {size / 1024 / 1024:.1f} MiB"
+            for size, path in oversized
+        )
+        + "\nThree ways out, and they are not equivalent: put `intermediates/**/*.parquet` "
+        "behind Git LFS (fixes the ceiling and stops history growth, and every consumer - "
+        "CI checkout, both workstations - then needs LFS); narrow this case study's fixture "
+        "window (cheapest, and `evaluation.n_splits` has to still resolve to the same fold "
+        "count); or cut its symbol count (cheapest of all, and it starves every reader the "
+        "fixture feeds). ml4t/agent-workspace#1019."
+    )
+
+
+def test_the_margin_leaves_room_for_the_file_that_is_closest_to_it(intermediates_dir):
+    """The ceiling is only a warning if something is measured against it.
+
+    A margin set so wide that no file approaches it would pass forever and check nothing,
+    which is the state this file exists to leave. Recorded so that a later change to
+    `MARGIN_BYTES` has to face what it makes true.
+    """
+    if intermediates_dir is None:
+        pytest.skip("no test-data intermediates on this checkout")
+    largest = max(
+        (path.stat().st_size for path in intermediates_dir.rglob("*") if path.is_file()),
+        default=0,
+    )
+    assert largest > CEILING_BYTES / 2, (
+        f"the largest fixture file is {largest / 1024 / 1024:.1f} MiB against a "
+        f"{CEILING_BYTES / 1024 / 1024:.0f} MiB ceiling. Nothing is near it, so the ceiling "
+        "is measuring nothing; either the fixture shrank a great deal or this file is "
+        "reading the wrong tree."
+    )

--- a/tests/test_fixture_population_backtests.py
+++ b/tests/test_fixture_population_backtests.py
@@ -1,0 +1,104 @@
+"""A fixture that publishes a population with no backtested member says so.
+
+`cs-sp500_equity_option_analytics` went red on a `ZeroDivisionError` fifteen minutes
+after its last green run, because a stage-08 regeneration of the fixture created two
+populations over 30 fresh prediction sets while every backtest in the fixture referenced
+predictions from two weeks earlier. `14_backtest` scopes its baseline ranking to the
+members in force, got an empty frame, and divided by its height
+(ml4t/agent-workspace#1086).
+
+Public #849 made the notebook refuse and say what is wrong. This is the other half:
+the generation that produces the state reports it, so the fixture is not committed with
+nobody having been told. It cannot avoid producing it - the model stages declare the
+population and the backtest stages are numbers 14 and up, which `--through-stage 8`
+never reaches - which is exactly why saying so is what it owes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from tests.fixture_registry import unbacktested_populations
+
+SCHEMA = """
+CREATE TABLE official_populations (population_hash TEXT PRIMARY KEY, name TEXT);
+CREATE TABLE official_population_members (population_hash TEXT, member_hash TEXT, ordinal INTEGER);
+CREATE TABLE backtest_runs (backtest_hash TEXT PRIMARY KEY, prediction_hash TEXT, stage TEXT);
+"""
+
+
+@pytest.fixture
+def case_dir(tmp_path):
+    (tmp_path / "run_log").mkdir()
+    db = sqlite3.connect(str(tmp_path / "run_log" / "registry.db"))
+    db.executescript(SCHEMA)
+    db.commit()
+    db.close()
+    return tmp_path
+
+
+def _connect(case_dir):
+    return sqlite3.connect(str(case_dir / "run_log" / "registry.db"))
+
+
+def test_a_population_whose_members_have_no_signal_backtest_is_reported(case_dir):
+    db = _connect(case_dir)
+    db.execute("INSERT INTO official_populations VALUES ('pop','seoa-gbm-preview')")
+    db.executemany(
+        "INSERT INTO official_population_members VALUES ('pop',?,?)",
+        [("p1", 0), ("p2", 1)],
+    )
+    db.commit()
+    db.close()
+    assert unbacktested_populations(case_dir) == [
+        {"name": "seoa-gbm-preview", "population_hash": "pop", "members": 2}
+    ]
+
+
+def test_a_population_with_one_backtested_member_is_not_reported(case_dir):
+    """One is enough: the ranking has a denominator, which is what the read needs."""
+    db = _connect(case_dir)
+    db.execute("INSERT INTO official_populations VALUES ('pop','seoa-gbm-preview')")
+    db.executemany(
+        "INSERT INTO official_population_members VALUES ('pop',?,?)", [("p1", 0), ("p2", 1)]
+    )
+    db.execute("INSERT INTO backtest_runs VALUES ('b','p1','signal')")
+    db.commit()
+    db.close()
+    assert unbacktested_populations(case_dir) == []
+
+
+def test_a_backtest_at_another_stage_does_not_count(case_dir):
+    """`14_backtest` reads `stage='signal'`. An allocation row is not one."""
+    db = _connect(case_dir)
+    db.execute("INSERT INTO official_populations VALUES ('pop','seoa-gbm-preview')")
+    db.execute("INSERT INTO official_population_members VALUES ('pop','p1',0)")
+    db.execute("INSERT INTO backtest_runs VALUES ('b','p1','allocation')")
+    db.commit()
+    db.close()
+    assert [p["name"] for p in unbacktested_populations(case_dir)] == ["seoa-gbm-preview"]
+
+
+def test_a_backtest_against_a_prediction_outside_the_population_does_not_count(case_dir):
+    """The exact shape #1086 arrived in: 52 backtests, none of them on a member."""
+    db = _connect(case_dir)
+    db.execute("INSERT INTO official_populations VALUES ('pop','seoa-gbm-preview')")
+    db.execute("INSERT INTO official_population_members VALUES ('pop','p_new',0)")
+    db.execute("INSERT INTO backtest_runs VALUES ('b','p_old','signal')")
+    db.commit()
+    db.close()
+    assert [p["members"] for p in unbacktested_populations(case_dir)] == [1]
+
+
+def test_a_population_with_no_members_is_not_reported(case_dir):
+    db = _connect(case_dir)
+    db.execute("INSERT INTO official_populations VALUES ('pop','empty')")
+    db.commit()
+    db.close()
+    assert unbacktested_populations(case_dir) == []
+
+
+def test_a_case_study_with_no_registry_reports_nothing(tmp_path):
+    assert unbacktested_populations(tmp_path) == []

--- a/tests/test_fixture_prediction_panels.py
+++ b/tests/test_fixture_prediction_panels.py
@@ -123,11 +123,20 @@ CREATE TABLE prediction_metrics (prediction_hash TEXT PRIMARY KEY, ic_mean_daily
 
 
 def _panelled_case(tmp_path, artifacts):
-    """A case study shipping *artifacts*: (hash, family, symbols, targets, ic)."""
+    """A case study shipping *artifacts*: (hash, family, symbols, targets, ic).
+
+    Under an intermediates root of its own, not directly under ``tmp_path``. The
+    fixture-wide checks take the root and walk every case study in it, and
+    ``tmp_path.parent`` is the session-wide temp directory pytest shares with every
+    other test - so passing that root made this test read whatever another test had
+    just written, which in CI was a deliberately truncated parquet from
+    ``test_fixture_registry_prune.py`` and a `ComputeError` here.
+    """
     import datetime
 
     import polars as pl
 
+    tmp_path = tmp_path / "intermediates" / "case_study"
     (tmp_path / "run_log").mkdir(parents=True)
     db = sqlite3.connect(str(tmp_path / "run_log" / "registry.db"))
     db.executescript(SCHEMA)

--- a/tests/test_fixture_prediction_panels.py
+++ b/tests/test_fixture_prediction_panels.py
@@ -1,0 +1,196 @@
+"""Two prediction artifacts of one (split, label) are scored against one outcome.
+
+`us_equities_panel` `(validation, fwd_ret_1d)` ships seven artifacts in two clusters:
+four `gbm` over 8 symbols storing the target as `Float32`, three `linear` over 56
+storing it as `Float64`. Over the 5,212 keys they share they disagree on the realized
+target by 2.6e-08 - 260 times the 1e-10 at which
+`14_latent_factors/09_case_study_insights::paired_daily_ic` rejects a pair
+(ml4t/agent-workspace#288).
+
+Two things have to hold for that to be harmless, and only one of them was ever written
+down. Within a cluster the artifacts must agree exactly, or two streams on the same keys
+are scored against different outcomes while every breadth and key check passes. And the
+artifact a notebook selects by metric rank has to sit on the cluster
+`tests/fixtures/seed_results.py` seeded its synthetic sets onto, or the supervised side
+and the latent side are comparing different cross-sections.
+
+The second currently holds by four gbm artifacts outranking three linear ones, which is
+a property of the metrics rather than of anything declared - #288's own point. It is
+checked here so that the day it stops holding arrives as this test rather than as
+`ch14-15` red with a message about neither.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tests.fixture_registry import (
+    choose_reference_panel,
+    panel_signature,
+    prediction_panels,
+    within_panel_target_gap,
+)
+
+
+def _case_studies(intermediates_dir: Path | None) -> list[Path]:
+    if intermediates_dir is None:
+        pytest.skip("no test-data intermediates on this checkout")
+    return sorted(
+        entry
+        for entry in intermediates_dir.iterdir()
+        if (entry / "run_log" / "registry.db").is_file()
+    )
+
+
+def test_artifacts_on_one_panel_agree_on_the_realized_target(intermediates_dir):
+    """Exactly, not nearly. They carry the same keys, so any gap is two outcomes."""
+    disagreements = []
+    for case_dir in _case_studies(intermediates_dir):
+        for (split, label), group in prediction_panels(case_dir).items():
+            for panel in group["panels"]:
+                if len(panel["entries"]) < 2:
+                    continue
+                gap = within_panel_target_gap(panel)
+                if gap:
+                    disagreements.append(
+                        f"{case_dir.name} ({split}, {label}) {panel['families']} "
+                        f"{panel['entities']} entities: {gap:.3e} across {panel['hashes']}"
+                    )
+    assert not disagreements, (
+        "artifacts on one cross-section disagree on the target:\n  " + "\n  ".join(disagreements)
+    )
+
+
+def test_the_top_ranked_artifact_sits_on_the_panel_the_seeder_aligns_to(intermediates_dir):
+    """Where a group ships two cross-sections, the selected one is the seeded one.
+
+    `09_case_study_insights` picks its supervised side by `ic_mean_daily` rank and joins
+    it against the seeded latent panel. `_reference_panels` seeds onto the cluster the
+    most artifacts share; if the rank leader is on the other cluster, the two sides are
+    joined across a 2.6e-08 target gap and the notebook refuses.
+    """
+    misaligned = []
+    for case_dir in _case_studies(intermediates_dir):
+        panels_by_group = prediction_panels(case_dir)
+        db = sqlite3.connect(f"file:{case_dir / 'run_log' / 'registry.db'}?mode=ro", uri=True)
+        try:
+            for (split, label), group in panels_by_group.items():
+                if len(group["panels"]) < 2:
+                    continue
+                ranked = None
+                best = None
+                for panel in group["panels"]:
+                    for entry in panel["entries"]:
+                        row = db.execute(
+                            "SELECT ic_mean_daily FROM prediction_metrics WHERE prediction_hash = ?",
+                            (entry["prediction_hash"],),
+                        ).fetchone()
+                        if row is None or row[0] is None:
+                            continue
+                        if best is None or float(row[0]) > best:
+                            best = float(row[0])
+                            ranked = panel
+                if ranked is None or ranked["is_reference"]:
+                    continue
+                reference = next(p for p in group["panels"] if p["is_reference"])
+                misaligned.append(
+                    f"{case_dir.name} ({split}, {label}): rank leader is on the "
+                    f"{ranked['entities']}-entity {ranked['families']} panel, the seeder aligns to "
+                    f"the {reference['entities']}-entity {reference['families']} one; the two "
+                    f"disagree on the target by {group['cross_panel_target_gap']:.3e}"
+                )
+        finally:
+            db.close()
+    assert not misaligned, (
+        "a notebook selecting by metric rank would join across two cross-sections:\n  "
+        + "\n  ".join(misaligned)
+    )
+
+
+# --- the mechanism, on a fixture built to break it -------------------------------
+#
+# Both checks above pass against the committed fixture, so on their own they do not
+# show they can fail. These build the two states they exist to catch.
+
+SCHEMA = """
+CREATE TABLE training_runs (training_hash TEXT PRIMARY KEY, family TEXT, label TEXT);
+CREATE TABLE prediction_sets (prediction_hash TEXT PRIMARY KEY, training_hash TEXT, split TEXT);
+CREATE TABLE prediction_metrics (prediction_hash TEXT PRIMARY KEY, ic_mean_daily REAL);
+"""
+
+
+def _panelled_case(tmp_path, artifacts):
+    """A case study shipping *artifacts*: (hash, family, symbols, targets, ic)."""
+    import datetime
+
+    import polars as pl
+
+    (tmp_path / "run_log").mkdir(parents=True)
+    db = sqlite3.connect(str(tmp_path / "run_log" / "registry.db"))
+    db.executescript(SCHEMA)
+    for prediction_hash, family, symbols, targets, ic in artifacts:
+        db.execute(
+            "INSERT INTO training_runs VALUES (?,?,?)",
+            (f"t_{prediction_hash}", family, "fwd_ret_1d"),
+        )
+        db.execute(
+            "INSERT INTO prediction_sets VALUES (?,?,?)",
+            (prediction_hash, f"t_{prediction_hash}", "validation"),
+        )
+        db.execute("INSERT INTO prediction_metrics VALUES (?,?)", (prediction_hash, ic))
+        directory = tmp_path / "run_log" / "predictions" / prediction_hash
+        directory.mkdir(parents=True)
+        pl.DataFrame(
+            {
+                "symbol": symbols,
+                "timestamp": [datetime.date(2020, 1, 1 + i) for i in range(len(symbols))],
+                "prediction": [0.1 * i for i in range(len(symbols))],
+                "actual": targets,
+            }
+        ).write_parquet(directory / "predictions.parquet")
+    db.commit()
+    db.close()
+    return tmp_path
+
+
+def test_the_within_panel_check_catches_two_outcomes_on_one_cross_section(tmp_path):
+    case_dir = _panelled_case(
+        tmp_path,
+        [
+            ("aaaa", "gbm", ["A", "B"], [1.0, 2.0], 0.3),
+            ("bbbb", "gbm", ["A", "B"], [1.0, 2.5], 0.2),
+        ],
+    )
+    panels = prediction_panels(case_dir)[("validation", "fwd_ret_1d")]["panels"]
+    assert len(panels) == 1
+    assert within_panel_target_gap(panels[0]) == pytest.approx(0.5)
+
+
+def test_the_alignment_check_catches_a_rank_leader_off_the_seeded_panel(tmp_path):
+    """Two artifacts on one panel, one on another, and the outlier ranks first."""
+    case_dir = _panelled_case(
+        tmp_path,
+        [
+            ("aaaa", "gbm", ["A", "B"], [1.0, 2.0], 0.1),
+            ("bbbb", "gbm", ["A", "B"], [1.0, 2.0], 0.2),
+            ("cccc", "linear", ["A", "B", "C"], [1.0, 2.0, 3.0], 0.9),
+        ],
+    )
+    with pytest.raises(AssertionError, match="join across two cross-sections"):
+        test_the_top_ranked_artifact_sits_on_the_panel_the_seeder_aligns_to(case_dir.parent)
+
+
+def test_the_seeder_and_the_check_read_one_panel_rule(tmp_path):
+    """`seed_results` must pick the same panel this file calls the reference one.
+
+    Two implementations of "most artifacts, then largest, then lowest hash" would drift,
+    and the drift is invisible: the seeded sets simply stop being joinable with the
+    copied ones.
+    """
+    from tests.fixtures import seed_results
+
+    assert seed_results.choose_reference_panel is choose_reference_panel
+    assert seed_results.panel_signature is panel_signature

--- a/tests/test_fixture_registry_prune.py
+++ b/tests/test_fixture_registry_prune.py
@@ -15,9 +15,11 @@ import polars as pl
 import pytest
 
 from tests.fixture_registry import (
+    capture_backed_prediction_rows,
     delete_training_runs,
     pinned_input_shas,
     prune_stale_training_runs,
+    restore_backed_prediction_rows,
     sha256_file,
     shipped_artifact_shas,
     stale_training_runs,
@@ -223,3 +225,84 @@ def test_pruning_is_idempotent(case_dir):
 )
 def test_the_prune_happens_before_the_first_stage_that_registers(tmp_path, stem, registers):
     assert registers_training_runs(tmp_path / f"{stem}.py") is registers
+
+
+def test_a_resample_keeps_the_rows_that_name_a_shipped_artifact(case_dir):
+    """A rebuild from production must not strand the artifacts a generation wrote.
+
+    `sample_registry_for_tests.py` unlinks the registry and rebuilds it from production
+    while leaving `run_log/predictions/` in place, so without this every artifact the
+    generator produced loses the only row that names it - 39 such directories on
+    `sp500_equity_option_analytics` (ml4t/agent-workspace#1081).
+    """
+    (case_dir / "run_log" / "predictions" / "p_local").mkdir(parents=True)
+    (case_dir / "run_log" / "predictions" / "p_local" / "predictions.parquet").write_bytes(b"")
+    db_path = case_dir / "run_log" / "registry.db"
+    db = _connect(case_dir)
+    db.execute("INSERT INTO training_runs VALUES ('t_local','fwd_ret_1d','{}')")
+    db.execute("INSERT INTO prediction_sets VALUES ('p_local','t_local','validation')")
+    db.execute("INSERT INTO prediction_metrics VALUES ('p_local', 0.5)")
+    db.commit()
+    db.close()
+
+    captured = capture_backed_prediction_rows(db_path, case_dir)
+
+    # The rebuild: the registry is replaced by one carrying production's rows only.
+    db_path.unlink()
+    db = _connect(case_dir)
+    db.executescript(SCHEMA)
+    db.execute("INSERT INTO training_runs VALUES ('t_prod','fwd_ret_1d','{}')")
+    db.execute("INSERT INTO prediction_sets VALUES ('p_prod','t_prod','validation')")
+    db.commit()
+    db.close()
+
+    restore_backed_prediction_rows(db_path, captured)
+
+    db = _connect(case_dir)
+    assert sorted(r[0] for r in db.execute("SELECT prediction_hash FROM prediction_sets")) == [
+        "p_local",
+        "p_prod",
+    ]
+    assert db.execute(
+        "SELECT ic_mean FROM prediction_metrics WHERE prediction_hash='p_local'"
+    ).fetchone() == (0.5,)
+    db.close()
+
+
+def test_a_restored_row_replaces_the_production_row_for_the_same_hash(case_dir):
+    """Where both registries carry the hash, the row measured on the shipped file wins.
+
+    Production's metrics describe the production artifact; the fixture ships a subsample.
+    Keeping production's row would leave the fixture claiming 2104 IC days for a parquet
+    holding 66 (ml4t/agent-workspace#286).
+    """
+    (case_dir / "run_log" / "predictions" / "p").mkdir(parents=True)
+    db_path = case_dir / "run_log" / "registry.db"
+    db = _connect(case_dir)
+    db.execute("INSERT INTO training_runs VALUES ('t','fwd_ret_1d','{}')")
+    db.execute("INSERT INTO prediction_sets VALUES ('p','t','validation')")
+    db.execute("INSERT INTO prediction_metrics VALUES ('p', 0.5)")
+    db.commit()
+    db.close()
+    captured = capture_backed_prediction_rows(db_path, case_dir)
+
+    db_path.unlink()
+    db = _connect(case_dir)
+    db.executescript(SCHEMA)
+    db.execute("INSERT INTO training_runs VALUES ('t','fwd_ret_1d','{}')")
+    db.execute("INSERT INTO prediction_sets VALUES ('p','t','validation')")
+    db.execute("INSERT INTO prediction_metrics VALUES ('p', 9.9)")
+    db.commit()
+    db.close()
+
+    restore_backed_prediction_rows(db_path, captured)
+    db = _connect(case_dir)
+    assert db.execute(
+        "SELECT ic_mean FROM prediction_metrics WHERE prediction_hash='p'"
+    ).fetchone() == (0.5,)
+    assert db.execute("SELECT COUNT(*) FROM prediction_sets").fetchone()[0] == 1
+    db.close()
+
+
+def test_capturing_from_a_fixture_with_no_prediction_directories_returns_nothing(case_dir):
+    assert capture_backed_prediction_rows(case_dir / "run_log" / "registry.db", case_dir) == {}

--- a/tests/test_fixture_registry_prune.py
+++ b/tests/test_fixture_registry_prune.py
@@ -1,0 +1,225 @@
+"""A fixture registry keeps only the training runs its own artifacts back.
+
+The nine CI fixture registries were copied whole from production while the artifacts
+beside them were subsampled, so every copied training run pins a file the fixture has
+never held. `register_training_run` refuses to add a run fitted on a different vintage
+of the same artifact, which is correct and which stopped the 2026-09-07 regeneration at
+`06_linear` for two case studies (ml4t/agent-workspace#1082). These tests pin the
+pruning that clears the stale rows before the generator registers anything.
+"""
+
+import json
+import sqlite3
+
+import polars as pl
+import pytest
+
+from tests.fixture_registry import (
+    delete_training_runs,
+    pinned_input_shas,
+    prune_stale_training_runs,
+    sha256_file,
+    shipped_artifact_shas,
+    stale_training_runs,
+)
+from tests.generate_intermediates import registers_training_runs
+
+SCHEMA = """
+CREATE TABLE training_runs (training_hash TEXT PRIMARY KEY, label TEXT, spec_json TEXT);
+CREATE TABLE prediction_sets (prediction_hash TEXT PRIMARY KEY, training_hash TEXT, split TEXT);
+CREATE TABLE prediction_metrics (prediction_hash TEXT PRIMARY KEY, ic_mean REAL);
+CREATE TABLE prediction_coverage (prediction_hash TEXT PRIMARY KEY, n_expected INTEGER);
+CREATE TABLE fold_metrics (prediction_hash TEXT, fold_id INTEGER, ic REAL);
+CREATE TABLE backtest_runs (backtest_hash TEXT PRIMARY KEY, prediction_hash TEXT, stage TEXT);
+CREATE TABLE backtest_metrics (backtest_hash TEXT PRIMARY KEY, sharpe REAL);
+CREATE TABLE backtest_fold_metrics (backtest_hash TEXT, fold_id INTEGER, sharpe REAL);
+CREATE TABLE cohort_metrics (cohort_type TEXT, stage TEXT, leader_hash TEXT);
+CREATE TABLE official_population_members (population_hash TEXT, member_hash TEXT, ordinal INTEGER);
+"""
+
+
+def _spec(**artifacts: str) -> str:
+    return json.dumps(
+        {
+            "computation": {
+                "input_data_spec": {
+                    "artifacts": {
+                        name: {"sha256": sha, "size": 1} for name, sha in artifacts.items()
+                    }
+                }
+            }
+        }
+    )
+
+
+@pytest.fixture
+def case_dir(tmp_path):
+    """A case study shipping one feature panel and one label, with a registry beside it."""
+    (tmp_path / "features").mkdir()
+    (tmp_path / "labels").mkdir()
+    (tmp_path / "run_log").mkdir()
+    pl.DataFrame({"symbol": ["A"], "x": [1.0]}).write_parquet(
+        tmp_path / "features/financial.parquet"
+    )
+    pl.DataFrame({"symbol": ["A"], "y": [1.0]}).write_parquet(
+        tmp_path / "labels/fwd_ret_1d.parquet"
+    )
+    db = sqlite3.connect(str(tmp_path / "run_log" / "registry.db"))
+    db.executescript(SCHEMA)
+    db.commit()
+    db.close()
+    return tmp_path
+
+
+def _connect(case_dir):
+    return sqlite3.connect(str(case_dir / "run_log" / "registry.db"))
+
+
+def test_shipped_shas_are_keyed_by_digest_not_by_artifact_name(case_dir):
+    shipped = shipped_artifact_shas(case_dir)
+    assert shipped == {
+        sha256_file(case_dir / "features/financial.parquet"): "features/financial.parquet",
+        sha256_file(case_dir / "labels/fwd_ret_1d.parquet"): "labels/fwd_ret_1d.parquet",
+    }
+
+
+def test_a_sha256_prefixed_pin_compares_against_the_bare_digest():
+    """`feature_artifacts` writes `sha256:<hex>` in one shape and bare hex in the other.
+
+    Reading the prefixed form without stripping it makes every such run look stale, which
+    would delete a population the fixture does hold.
+    """
+    assert pinned_input_shas(_spec(financial="sha256:" + "a" * 64)) == {"financial": "a" * 64}
+
+
+def test_a_run_fitted_on_a_shipped_artifact_is_not_stale(case_dir):
+    on_disk = sha256_file(case_dir / "features/financial.parquet")
+    db = _connect(case_dir)
+    db.execute(
+        "INSERT INTO training_runs VALUES (?,?,?)",
+        ("t_local", "fwd_ret_1d", _spec(financial=on_disk)),
+    )
+    db.commit()
+    assert stale_training_runs(db, case_dir) == {}
+    db.close()
+
+
+def test_a_run_pinning_an_artifact_the_fixture_lacks_is_stale_and_names_the_pin(case_dir):
+    db = _connect(case_dir)
+    db.execute(
+        "INSERT INTO training_runs VALUES (?,?,?)",
+        ("t_copied", "fwd_ret_1d", _spec(financial="b" * 64)),
+    )
+    db.commit()
+    assert stale_training_runs(db, case_dir) == {"t_copied": {"financial": "b" * 64}}
+    db.close()
+
+
+def test_a_run_pinning_nothing_is_never_stale(case_dir):
+    """A spec with no `input_data_spec.artifacts` block makes no claim to check."""
+    db = _connect(case_dir)
+    db.execute("INSERT INTO training_runs VALUES (?,?,?)", ("t_bare", "fwd_ret_1d", "{}"))
+    db.commit()
+    assert stale_training_runs(db, case_dir) == {}
+    db.close()
+
+
+def test_deleting_a_training_run_takes_its_whole_downstream_surface(case_dir):
+    """SQLite leaves the foreign keys unenforced, so the cascade has to be spelled out.
+
+    Deleting `training_runs` alone leaves prediction sets, metrics and backtests pointing
+    at a row that is gone, which reads downstream as a corrupt registry rather than a
+    pruned one.
+    """
+    db = _connect(case_dir)
+    db.execute("INSERT INTO training_runs VALUES ('t','fwd_ret_1d','{}')")
+    db.execute("INSERT INTO prediction_sets VALUES ('p','t','validation')")
+    db.execute("INSERT INTO prediction_metrics VALUES ('p', 0.1)")
+    db.execute("INSERT INTO prediction_coverage VALUES ('p', 10)")
+    db.execute("INSERT INTO fold_metrics VALUES ('p', 0, 0.1)")
+    db.execute("INSERT INTO backtest_runs VALUES ('b','p','signal')")
+    db.execute("INSERT INTO backtest_metrics VALUES ('b', 1.0)")
+    db.execute("INSERT INTO backtest_fold_metrics VALUES ('b', 0, 1.0)")
+    db.execute("INSERT INTO cohort_metrics VALUES ('stagelabel','signal','b')")
+    db.execute("INSERT INTO official_population_members VALUES ('pop','p',0)")
+    db.commit()
+
+    delete_training_runs(db, {"t"})
+
+    for table in (
+        "training_runs",
+        "prediction_sets",
+        "prediction_metrics",
+        "prediction_coverage",
+        "fold_metrics",
+        "backtest_runs",
+        "backtest_metrics",
+        "backtest_fold_metrics",
+        "cohort_metrics",
+        "official_population_members",
+    ):
+        assert db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0, table
+    db.close()
+
+
+def test_pruning_keeps_the_runs_the_fixture_backs_and_drops_only_the_rest(case_dir):
+    on_disk = sha256_file(case_dir / "features/financial.parquet")
+    db = _connect(case_dir)
+    db.execute(
+        "INSERT INTO training_runs VALUES (?,?,?)",
+        ("t_local", "fwd_ret_1d", _spec(financial=on_disk)),
+    )
+    db.execute(
+        "INSERT INTO training_runs VALUES (?,?,?)",
+        ("t_copied", "fwd_ret_1d", _spec(financial="b" * 64)),
+    )
+    db.execute("INSERT INTO prediction_sets VALUES ('p_local','t_local','validation')")
+    db.execute("INSERT INTO prediction_sets VALUES ('p_copied','t_copied','validation')")
+    db.commit()
+    db.close()
+
+    summary = prune_stale_training_runs(case_dir)
+    assert summary["training_runs_pruned"] == 1
+    assert summary["example"]["training_hash"] == "t_copied"
+
+    db = _connect(case_dir)
+    assert [r[0] for r in db.execute("SELECT training_hash FROM training_runs")] == ["t_local"]
+    assert [r[0] for r in db.execute("SELECT prediction_hash FROM prediction_sets")] == ["p_local"]
+    db.close()
+
+
+def test_pruning_a_case_study_with_no_registry_yet_is_a_no_op(tmp_path):
+    assert prune_stale_training_runs(tmp_path) == {}
+
+
+def test_pruning_is_idempotent(case_dir):
+    db = _connect(case_dir)
+    db.execute(
+        "INSERT INTO training_runs VALUES (?,?,?)",
+        ("t_copied", "fwd_ret_1d", _spec(financial="b" * 64)),
+    )
+    db.commit()
+    db.close()
+    assert prune_stale_training_runs(case_dir)["training_runs_pruned"] == 1
+    assert prune_stale_training_runs(case_dir)["training_runs_pruned"] == 0
+
+
+@pytest.mark.parametrize(
+    ("stem", "registers"),
+    [
+        ("01_feasibility_analysis", False),
+        ("02_labels", False),
+        ("03_financial_features", False),
+        ("04_model_based_features", False),
+        ("05_evaluation", False),
+        ("06_linear", True),
+        ("07_gbm", True),
+        # us_firm_characteristics has no model-based stage, so its first registering
+        # stage is 05, not 06. A boundary read from the stage number would prune after
+        # that notebook had already registered against the copied rows.
+        ("05_linear", True),
+        ("04_evaluation", False),
+    ],
+)
+def test_the_prune_happens_before_the_first_stage_that_registers(tmp_path, stem, registers):
+    assert registers_training_runs(tmp_path / f"{stem}.py") is registers

--- a/tests/test_fixture_registry_self_consistency.py
+++ b/tests/test_fixture_registry_self_consistency.py
@@ -1,0 +1,177 @@
+"""The shipped fixture registry describes the artifacts shipped beside it.
+
+The nine registries under ``intermediates/*/run_log/`` were copied whole from production
+while the artifacts beside them were subsampled, which produced two states a reader
+cannot tell apart from a pipeline failure:
+
+* a ``prediction_metrics`` row measuring a file 32x larger than the ``predictions.parquet``
+  it sits beside, so ``16_strategy_simulation/08_signal_method_comparison`` rejects the
+  pair it is given (ml4t/agent-workspace#286), and
+* a ``run_log/predictions/<hash>/`` no registry row names, left behind when a re-sample
+  rewrote the registry after a generation had written the artifact
+  (ml4t/agent-workspace#1081).
+
+Both are properties of the committed fixture rather than of any code path, so this module
+reads the fixture itself. ``tests/reconcile_fixture_registry.py`` is what repairs a
+fixture these fail against.
+
+What is deliberately not asserted: that every registered prediction set ships an
+artifact. 97.7% of them do not, and seeding them is 88 MB per panel. Those rows are the
+replay surface the chapter notebooks rank over, and a row with no artifact is only a
+defect once a reader reaches it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.utils.notebook_contracts import defined_ic
+from tests.reconcile_fixture_registry import (
+    _resolve,
+    _spec_context,
+    prediction_dirs,
+    shipped_predictions,
+)
+
+#: The tolerance `08_signal_method_comparison::validate_prediction_set` uses when it
+#: checks a loaded parquet against its registered coverage and mean rank IC. Matched
+#: here so a fixture that passes this file is one that notebook accepts.
+REL_TOL = 1e-12
+
+
+def _case_studies(intermediates_dir: Path | None) -> list[Path]:
+    if intermediates_dir is None:
+        pytest.skip("no test-data intermediates on this checkout")
+    return sorted(
+        entry
+        for entry in intermediates_dir.iterdir()
+        if (entry / "run_log" / "registry.db").is_file()
+    )
+
+
+def _registered(case_dir: Path) -> set[str]:
+    db = sqlite3.connect(f"file:{case_dir / 'run_log' / 'registry.db'}?mode=ro", uri=True)
+    try:
+        return {str(row[0]) for row in db.execute("SELECT prediction_hash FROM prediction_sets")}
+    finally:
+        db.close()
+
+
+def test_no_prediction_directory_is_unreachable(intermediates_dir):
+    """A directory no ``prediction_sets`` row names is addressable by nothing.
+
+    Every reader resolves a prediction by hash out of the registry, so an unnamed
+    directory is not a spare artifact - it is bytes in the fixture that no code path can
+    ever open, and its presence makes the tree look richer than it is.
+    """
+    unreachable = {}
+    for case_dir in _case_studies(intermediates_dir):
+        registered = _registered(case_dir)
+        orphans = sorted(set(prediction_dirs(case_dir)) - registered)
+        if orphans:
+            unreachable[case_dir.name] = orphans
+    assert not unreachable, (
+        "prediction directories with no registry row: "
+        + "; ".join(
+            f"{name} {len(hashes)} ({hashes[0]}...)" for name, hashes in unreachable.items()
+        )
+        + ". Run tests/reconcile_fixture_registry.py --apply."
+    )
+
+
+def _daily_ic(parquet: Path, context: dict) -> tuple[int, float] | None:
+    """The IC coverage and mean the shipped artifact itself produces.
+
+    Only the daily block, not the whole metrics row: this is the pair the consuming
+    notebook validates, and computing it needs no bootstrap, which keeps the check
+    inside a unit job's budget.
+    """
+    from ml4t.diagnostic.metrics import cross_sectional_ic_series
+
+    frame = pl.read_parquet(parquet)
+    columns = frame.columns
+    score = _resolve(columns, "score")
+    target = _resolve(columns, "target")
+    date = _resolve(columns, "date")
+    entity = _resolve(columns, "entity")
+    if not (score and target and date):
+        return None
+    # Classification sets score IC against the continuous return the binary label was
+    # derived from, exactly as `compute_prediction_fold_metrics` does. Against the binary
+    # column the statistic is 2*(AUC-0.5), not a rank correlation, so comparing one to a
+    # registered value computed the other way would report a disagreement that is not one.
+    if str(context.get("task_type") or "regression") == "classification":
+        if "eval_actual" not in columns:
+            return None
+        target = "eval_actual"
+    series = cross_sectional_ic_series(
+        frame,
+        frame,
+        pred_col=score,
+        ret_col=target,
+        date_col=date,
+        entity_col=entity,
+        method="spearman",
+        min_obs=5,
+    )
+    defined = defined_ic(series) if isinstance(series, pl.DataFrame) else None
+    if defined is None or defined.height == 0:
+        return None
+    return defined.height, float(defined["ic"].mean())
+
+
+def test_a_shipped_prediction_artifact_reproduces_its_registered_ic(intermediates_dir):
+    """Registered daily-IC coverage and mean come from the parquet shipped beside them.
+
+    This is the check `08_signal_method_comparison` makes on whichever set it selects; a
+    fixture that fails here fails that notebook, and the notebook is right.
+    """
+    disagreements: list[str] = []
+    for case_dir in _case_studies(intermediates_dir):
+        db = sqlite3.connect(f"file:{case_dir / 'run_log' / 'registry.db'}?mode=ro", uri=True)
+        try:
+            columns = {row[1] for row in db.execute("PRAGMA table_info(prediction_metrics)")}
+            if not {"ic_n_days", "ic_mean_daily"} <= columns:
+                continue
+            for prediction_hash, parquet in shipped_predictions(case_dir).items():
+                row = db.execute(
+                    "SELECT tr.spec_json, pm.ic_n_days, pm.ic_mean_daily "
+                    "FROM prediction_sets ps "
+                    "JOIN training_runs tr ON tr.training_hash = ps.training_hash "
+                    "LEFT JOIN prediction_metrics pm ON pm.prediction_hash = ps.prediction_hash "
+                    "WHERE ps.prediction_hash = ?",
+                    (prediction_hash,),
+                ).fetchone()
+                if row is None:
+                    continue  # covered by the unreachable-directory test above
+                spec_json, n_days, mean_daily = row
+                measured = _daily_ic(parquet, _spec_context(spec_json))
+                if measured is None:
+                    continue
+                if n_days is None or mean_daily is None:
+                    disagreements.append(
+                        f"{case_dir.name} {prediction_hash}: no registered daily IC, "
+                        f"artifact gives {measured[0]} days"
+                    )
+                    continue
+                same_days = int(n_days) == measured[0]
+                same_ic = abs(float(mean_daily) - measured[1]) <= REL_TOL * max(
+                    1.0, abs(measured[1])
+                )
+                if not (same_days and same_ic):
+                    disagreements.append(
+                        f"{case_dir.name} {prediction_hash}: registered "
+                        f"{int(n_days)} days / {float(mean_daily):.6f}, artifact gives "
+                        f"{measured[0]} days / {measured[1]:.6f}"
+                    )
+        finally:
+            db.close()
+    assert not disagreements, (
+        f"{len(disagreements)} shipped prediction artifact(s) disagree with their registered "
+        "metrics. Run tests/reconcile_fixture_registry.py --apply.\n  "
+        + "\n  ".join(disagreements[:20])
+    )


### PR DESCRIPTION
The nine CI fixture registries were copied whole from production while the artifacts
beside them were subsampled. Seven of the eight issues in wave W3 are consequences of
that one act, which is why they land together.

## What each commit does

**Generation drops the training runs its own artifacts no longer back** (#1082). Stages
01-05 rewrite `features/` and `labels/`, so every copied training run pins a vintage the
fixture no longer holds and `_enforce_input_artifact_vintage` refuses the next
registration - correctly, since the two files were never in one population. The
generator prunes those rows immediately before its first registering stage. Measured:
the same command that stopped `sp500_options` at `06_linear` now runs all six stages,
pruning 97 of 106 training runs and leaving 28 prediction directories with 28 rows
naming them.

**A shipped prediction artifact and its registered metrics describe one file** (#286).
`tests/reconcile_fixture_registry.py` recomputes `prediction_metrics` from the parquet
the fixture ships, via the same `compute_prediction_fold_metrics` a registration calls.
46 rows moved; 5,940 did not.

**A re-sample keeps the rows that name an artifact the fixture ships** (#1081).
`sample_registry_for_tests.py` rebuilt the registry from production while leaving
`run_log/predictions/` alone, stranding 79 directories that no row named. It now carries
those rows across the rebuild. The 6,541 registered predictions whose artifact was never
in the fixture stay: 16 case-study notebook entries at `research_preview: false` and the
ch12/ch14-17/ch20/ch26 jobs rank over them, and seeding their artifacts is 88 MB a panel.

**Which cross-section a prediction group is compared on is checked** (#288).
`us_equities_panel (validation, fwd_ret_1d)` ships two clusters that disagree on the
realized target by 2.5703e-08 over their shared keys, 260x the tolerance
`paired_daily_ic` rejects at. Which one a notebook lands on was decided by registry
metrics; it is now asserted, and the panel rule has one implementation instead of two.

**A generation says when it leaves a population with nothing to rank** (#1086). The
state that made `14_backtest` divide by zero is reported by the run that creates it,
rather than by CI fifteen minutes after the fixture is committed.

**A fixture file that would be rejected at push time fails a test instead** (#1019).
GitHub's 100 MiB limit less a 10 MiB margin. The binding file is now
`intermediates/etfs/features/financial.parquet` at 89.5 MiB.

**The etfs SDF member runs** (#1035). `fred_macro_initial_release.parquet` did not exist
in the test-data repo and `case_studies/etfs/config/setup.yaml` declares this member
against it; substituting the finalized series would be a look-ahead. Built and committed
to test-data, and `11d` is un-skipped.

## Test-data

`ml4t/third-edition-test-data` `2a6833f6..1ea74a26`, already on `main`: the reconciled
registries, the 79 unreachable directories removed, and the ALFRED panel.

## Verification

`14_latent_factors/09_case_study_insights` and
`16_strategy_simulation/08_signal_method_comparison` - the two notebooks #286 and #288
name - pass against the reconciled fixture. Both fixture-wide checks fail against the
fixture as it stood before `b5a58114` (79 unreachable directories, 13 artifacts
disagreeing with their registered IC) and pass after; the 18 `crypto_perps_funding` rows
that already agreed are the control and did not move.
