### PR TITLE
The SV sampler's chain workers, and what #942's thirteen entries actually declare

### DIFF
--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -17,7 +17,9 @@ and asserting the results are identical.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Mapping, Sequence
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -33,6 +35,7 @@ from case_studies.utils.artifact_digest import write_artifact
 __all__ = [
     "HmmFit",
     "arima_one_step_forecast",
+    "chain_worker_pool",
     "filtered_state_probs",
     "fit_hmm_kmeans_init",
     "fit_hmm_restarts",
@@ -49,6 +52,44 @@ __all__ = [
 # Guards the log of a zero transition or start probability. Small enough not to move a
 # fitted probability, large enough that log() stays finite.
 _LOG_FLOOR = 1e-300
+
+
+@contextmanager
+def chain_worker_pool(n_threads: int):
+    """Size the BLAS and OpenMP pools of sampler chain workers, leaving this process alone.
+
+    ``pm.sample(cores=...)`` runs each chain in its own process, started through
+    multiprocessing's forkserver. Those children are fresh interpreters: they import numpy
+    and scipy themselves, so they size their pools from these variables at import. Setting
+    the variables is the only thing that reaches them - ``threadpoolctl`` reconfigures pools
+    already loaded in the calling interpreter, and the workers are not in it. Measured on an
+    sp500_options SV fit, peak threads across the process tree: 113 with nothing set, 115
+    with ``threadpool_limits`` around the sampler, 41 with this.
+
+    The forkserver starts at the first parallel sample, which is why the variables have to be
+    set before it and why restoring them afterwards is safe: by then it exists, and later
+    samples reuse it. This process's own pools are untouched, so whatever else the notebook
+    fits keeps the threading it had.
+
+    The pool size does not change the draws. Same data and seed at 2,000 draws, 2,000 tune
+    and 4 chains, every variant above returns a ``sigma_eta`` array equal bit for bit, so this
+    is a runtime setting and stays out of any identity. Contrast ``DML_THREAD_LIMIT`` in
+    ``case_studies/utils/causal.py``, which is recorded in the resolved specification because
+    there the reduction order does move the estimate.
+    """
+    if n_threads < 1:
+        raise ValueError("chain_worker_pool needs at least one thread per worker")
+    names = ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS")
+    previous = {name: os.environ.get(name) for name in names}
+    os.environ.update(dict.fromkeys(names, str(n_threads)))
+    try:
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def filtered_state_probs(model: GaussianHMM, X: np.ndarray) -> np.ndarray:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2468,8 +2468,28 @@ case_studies/sp500_equity_option_analytics/06_linear:
   # labels x 16 configurations; it does not hold here, where the preview reduction cuts the
   # grid and the gbm run is the slower of the two in every case study measured. The tier is
   # the one-third line the raised entries elsewhere in this file state.
+  #
+  # The reduction is stated rather than left to the max_symbols: 5 that
+  # `_collect_preview_reductions` applies when an entry declares none, for the reason
+  # 08_tabular_dl gives below: a preview that reduces by default reduces invisibly, and the
+  # next reader of this entry cannot tell a deliberate universe cut from an absent one.
+  # Stating it changes nothing about what runs.
+  #
+  # Only the universe is cut, matching 08_tabular_dl. #560 removed a `MAX_FOLDS: 2` here and
+  # ml4t/agent-workspace#942 reads its absence as this preview running every fold on a budget
+  # priced for two. Measured on run 34271885198, the whole stage takes 26s of its 180s, so the
+  # fold axis is not what this budget is short of and a fold cut is not restored blind.
+  parameters:
+    PREVIEW_REDUCTIONS:
+      max_symbols: 5
   timeout: 120
 case_studies/sp500_equity_option_analytics/07_gbm:
+  # As 06_linear: the universe cut is stated rather than defaulted, and no fold reduction is
+  # invented for a case study whose sibling entries declare none. 26s of 180s on run
+  # 34271885198.
+  parameters:
+    PREVIEW_REDUCTIONS:
+      max_symbols: 5
   timeout: 180
 case_studies/sp500_equity_option_analytics/08_tabular_dl:
   # DEVICE and POPULATION_NAME travel together. The runner refuses to substitute a CPU

--- a/tests/test_chain_worker_pool.py
+++ b/tests/test_chain_worker_pool.py
@@ -1,0 +1,57 @@
+"""`chain_worker_pool` must configure sampler workers without changing this process.
+
+The helper exists because `threadpoolctl` cannot reach a `pm.sample(cores=...)` chain
+worker: those are fresh interpreters started through multiprocessing's forkserver, and
+they size their pools from the environment when they import numpy. Measured on an
+sp500_options SV fit, peak threads across the process tree were 113 with nothing set,
+115 with `threadpool_limits` wrapped around the sampler, and 41 with this.
+
+What the cases below hold is the part that fails silently. If the variables leak past the
+block, every later fit in the notebook runs single-threaded too - the GARCH walk that
+`04_model_based_features` spends most of its time in - and nothing reports it.
+"""
+
+import os
+
+import pytest
+
+from case_studies.utils.temporal import chain_worker_pool
+
+POOL_VARS = ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS")
+
+
+def test_every_pool_variable_is_set_inside_the_block() -> None:
+    with chain_worker_pool(1):
+        assert [os.environ[name] for name in POOL_VARS] == ["1", "1", "1"]
+
+
+def test_a_variable_absent_before_is_absent_again_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in POOL_VARS:
+        monkeypatch.delenv(name, raising=False)
+    with chain_worker_pool(2):
+        assert os.environ["OMP_NUM_THREADS"] == "2"
+    assert [name for name in POOL_VARS if name in os.environ] == []
+
+
+def test_a_value_set_before_is_restored_exactly(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMP_NUM_THREADS", "6")
+    monkeypatch.setenv("OPENBLAS_NUM_THREADS", "6")
+    monkeypatch.delenv("MKL_NUM_THREADS", raising=False)
+    with chain_worker_pool(1):
+        pass
+    assert os.environ["OMP_NUM_THREADS"] == "6"
+    assert os.environ["OPENBLAS_NUM_THREADS"] == "6"
+    assert "MKL_NUM_THREADS" not in os.environ
+
+
+def test_the_block_restores_even_when_the_sampler_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMP_NUM_THREADS", "6")
+    with pytest.raises(RuntimeError, match="sampler failed"), chain_worker_pool(1):
+        raise RuntimeError("sampler failed")
+    assert os.environ["OMP_NUM_THREADS"] == "6"
+
+
+@pytest.mark.parametrize("n_threads", [0, -1])
+def test_a_pool_smaller_than_one_thread_is_refused(n_threads: int) -> None:
+    with pytest.raises(ValueError, match="at least one thread"), chain_worker_pool(n_threads):
+        pass


### PR DESCRIPTION
Two issues, both of which turned on a premise that did not survive being measured.

## ml4t/agent-workspace#1062: the SV sampler's chain workers

`sp500_options/04` runs `pm.sample(chains=4, cores=4)` with no thread limit, and each chain worker sizes its BLAS and OpenMP pools from the host: 453 threads across the process tree for a model whose largest array is a 252-element vector and whose operations are elementwise.

**The fix the issue proposes does not work.** Wrapping the sampler in `threadpool_limits` leaves the thread count exactly where it was. `threadpoolctl` reconfigures pools already loaded in the calling interpreter, and the chain workers are not in it: `cores=` starts them through multiprocessing's forkserver, so they are fresh interpreters that import numpy themselves and take their pool sizes from the environment. Peak threads across the process tree, 8-core allocation, sampling the real SV model:

| how the limit is set | threads | draws |
|---|---|---|
| nothing | 113 | `c0cc5777a1bd` |
| `threadpool_limits` around `pm.sample` | 115 | `c0cc5777a1bd` |
| `chain_worker_pool` | 41 | `c0cc5777a1bd` |

This is the same fact `case_studies/utils/causal.py` records from the other side. There the environment variable is useless because sklearn had already loaded in-process; here it is the only thing that reaches the workers, because they load *after* it is set. Worth stating explicitly, because the two notes read as contradicting each other and the next person will apply one to the other's situation.

`chain_worker_pool` sets the three pool variables and restores them. The forkserver starts at the first parallel sample, which is what the variables have to precede; by the time the block exits it exists and later samples reuse it, so restoring is safe and everything outside the sampler keeps the threading it had - including the GARCH walk this notebook spends most of its time in.

**The pool size is a runtime field, measured rather than assumed.** Same data and seed at production settings of 2,000 draws, 2,000 tune and 4 chains, every variant above returns a `sigma_eta` array equal bit for bit. It therefore has to stay out of the identity: were it folded in, every existing sp500_options row would re-key for a thread count. That is the opposite of `DML_THREAD_LIMIT`, which *is* written into the resolved specification because there the reduction order does move the estimate.

`mp_ctx="fork"` also fixes the thread count and is slightly faster, but Python 3.14 warns once per chain that forking a multi-threaded process may deadlock the child, so it is not the route taken.

**The call site is not in this PR.** Changing a code cell obliges re-executing the notebook, which rewrites `features/model_based.parquet`, which moves the feature artifact sha256 and re-keys the training identity of everything fitted against it. `sp500_options` is mid-DL-wave, so that re-run waits for the chain to drain; the diff is ready and goes in behind it. The helper is tested on its own in the meantime.

## ml4t/agent-workspace#942: the preview reductions

The issue reports thirteen entries left running the full config set on a budget measured for a fraction of it. Checked against the file rather than the issue's table, that is no longer the shape of it:

- **Eleven of the thirteen already declare `PREVIEW_REDUCTIONS`**, restored piecemeal by the case-study PRs that reworked each stage (#598 for `us_firm_characteristics`, #611 for `cme_futures`, others since).
- **`us_equities_panel` 06 and 07 declare none** and are absent from the issue's list, because the case study is DEFERRED at `.github/workflows/test.yml:376` and never enrolls.
- **The remaining two are not unreduced either.** An entry declaring no reductions still gets `max_symbols: 5`, applied by `_collect_preview_reductions` at `tests/pm_helpers.py:1159` on the grounds that a preview reducing nothing is a canonical run wearing the wrong tier.

So the axis #560 actually left uncovered is folds, not symbols. Whether the two `seoa` entries want a fold cut is a question the measurement answers: on run `34271885198`, `06_linear` took 20s of its 120s budget and `07_gbm` 26s of its 180s. Neither is short of budget on the fold axis, and no sibling `seoa` entry reduces folds - `08_tabular_dl` declares `max_symbols` alone and argues for stating it. So the universe cut is written out and no fold reduction is restored blind. `_collect_preview_reductions` resolves the declared and undeclared forms to the same mapping, so behaviour is unchanged.

## Verification

`tests/test_chain_worker_pool.py` is six cases over the helper, mutation-checked: removing the restore path fails three of them. What they hold is the part that fails silently - if the variables leak past the block, every later fit in the notebook runs single-threaded and nothing reports it.

Local: `test_chain_worker_pool` 6 passed, `test_temporal` + `test_quarantine_list` 157 passed, `test_pm_helpers` + `test_smoke_configs` 180 passed, ruff clean.
