### PR TITLE
Let a preview run resolve its workspace, and let a notebook refuse a parameter it cannot take

### DIFF
--- a/case_studies/research/workspace.py
+++ b/case_studies/research/workspace.py
@@ -485,6 +485,26 @@ class Study:
         return CausalRequest.from_request(self, request)
 
 
+def _resolve_preview_workspace(workspace: str | Path) -> Path:
+    """Place a relative preview workspace outside the checkout.
+
+    A preview writes a registry, a `config` symlink and a `.preview/` tree under whatever it is
+    given. Notebooks run from the repo root, so resolving a bare name against the caller's cwd
+    puts all of that in the repo root: five absolute symlinks and a 268K registry reached a
+    branch that way on 2026-09-06. An absolute path is the caller's own choice and is taken as
+    given; a relative one is resolved against a root that is not the repository, so no
+    `.gitignore` rule has to be load-bearing for it.
+    """
+    path = Path(workspace).expanduser()
+    if path.is_absolute():
+        return path.resolve()
+    declared = os.environ.get("ML4T_PREVIEW_ROOT")
+    base = (
+        Path(declared).expanduser() if declared else Path.home() / "ml4t" / "artifacts" / "preview"
+    )
+    return (base / path).resolve()
+
+
 def open_study(
     case_study: str,
     *,
@@ -515,7 +535,7 @@ def open_study(
 
     if workspace is None:
         raise ValueError("preview execution requires an explicit workspace")
-    workspace = Path(workspace).expanduser().resolve()
+    workspace = _resolve_preview_workspace(workspace)
     case_dir = release_root / "case_studies" / case_study
     generated = tuple(case_dir / name for name in ("features", "labels", "run_log"))
     linked = all(path.is_symlink() for path in generated)

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1641,15 +1641,16 @@ case_studies/etfs/01_feasibility_analysis:
   timeout: 120
 case_studies/etfs/02_labels:
   parameters:
-    # No MAX_SYMBOLS: the CI fixture is already only 24 ETFs, and stage 03 needs at least
-    # 10 non-null labels per date to accumulate an IC series at all. Reducing here starves
-    # it. The fixture is the reduction; MIN_SYMBOLS_FOR_DISPERSION keeps its production 10.
+    # No MAX_SYMBOLS: the fixture is itself the reduction, and stage 03 needs at least 10
+    # non-null labels per date to accumulate an IC series at all, so reducing here starves
+    # it. MIN_SYMBOLS_FOR_DISPERSION keeps its production 10. The fixture carries 56 ETFs
+    # (ml4t/third-edition-test-data 2a6833f6), not the 24 this comment claimed.
     START_DATE: '2000-01-01'
   timeout: 120
 case_studies/etfs/03_financial_features:
   timeout: 300
 case_studies/etfs/04_model_based_features:
-  # No MAX_SYMBOLS, for the reason 02_labels gives: the CI fixture is already only 24
+  # No MAX_SYMBOLS, for the reason 02_labels gives: the CI fixture is already only 56
   # ETFs, so it IS the reduction. Cutting to 5 on top of it made every downstream
   # backtest degenerate rather than fast. etfs declares top_k_grid [5, 10, 20] against a
   # 24-fund price panel, so all three schemes pass the feasibility filter - but the
@@ -1735,9 +1736,13 @@ case_studies/etfs/09_dl_lstm:
   # DEVICE and POPULATION_NAME travel together, as in 08_tabular_dl: the device is inside the
   # training identity, so a CPU run declares a different member set and must name its own
   # population rather than publish into the canonical one.
-  # max_symbols is 5 to match 04_model_based_features for the reason 11a_pca states below: the
-  # boundary validates the fold-specific temporal artifact against the CV splits, and the 6 the
-  # pre-conversion block carried put fold 0 validation at 93.5%, under the 95% floor.
+  # max_symbols is 6 for the reason the case-study header above derives: at 5 every declared
+  # entry scheme is dropped and the sweep registers nothing. The block used to say 5 "to match
+  # 04_model_based_features" and to blame a 93.5% fold 0 coverage on the 6 - both wrong.
+  # 04 declares no max_symbols at all, so there is nothing to match, and 11a_pca records that
+  # the 93.5% came from running the FULL fixture universe against an artifact built at 5, not
+  # from any value of this cap. The boundary still validates the temporal artifact against the
+  # CV splits, and 6 clears the 95% MIN_TEMPORAL_DATE_COVERAGE floor on green cs-etfs runs.
   parameters:
     DEVICE: cpu
     POPULATION_NAME: etfs-lstm-preview
@@ -1756,7 +1761,7 @@ case_studies/etfs/10_dl_tsmixer:
   # No max_symbols, and that is the fix for ml4t/agent-workspace#988. This block carried
   # `max_symbols: 5` "to match 04_model_based_features" - a justification that stopped holding
   # when 04's own cap was removed, so the reduction went on cutting the cross-section to five
-  # while the temporal artifact it fits against covered the fixture's twenty-four. Darts TSMixer
+  # while the temporal artifact it fits against covered the whole fixture. Darts TSMixer
   # diverged on the mismatch: the registration guard refused predictions at a per-fold dispersion
   # ratio of 286 (score std 10.588 against a target std of 0.037), and #988 measured that
   # restoring the pre-conversion LOOKBACK of 22 made it four times worse at 1285. Neither the
@@ -1765,9 +1770,9 @@ case_studies/etfs/10_dl_tsmixer:
   # takes the chain green: measured 2026-08-31 in the container, stages 01-10, 10 passed in
   # 288.70s, with this notebook inside its 180s cap.
   #
-  # 09_dl_lstm, 11a_pca and 11b_ipca keep max_symbols: 5 and pass with it. Their blocks state the
-  # same "must match 04" rule, which is no longer true of any of them; it is left in place there
-  # because what those three need is a coverage floor they currently clear, not agreement with 04.
+  # 09_dl_lstm, 11a_pca and 11b_ipca declare max_symbols: 6 and pass with it. Their blocks used to
+  # state the same "must match 04" rule; 04 declares no cap, so it was corrected in place rather
+  # than left standing. What those three need is a coverage floor they currently clear.
   parameters:
     DEVICE: cpu
     POPULATION_NAME: etfs-tsmixer-preview
@@ -1798,11 +1803,13 @@ case_studies/etfs/10a_dl_nlinear:
       folds: [0, 1]
   timeout: 180
 case_studies/etfs/11a_pca:
-  # max_symbols must match 04_model_based_features, which builds the temporal
-  # artifact these notebooks validate against. With no reduction they ran on the
-  # full fixture universe while the artifact covered 5 symbols, so the CV splits
-  # spanned dates the artifact never saw and fold 0 validation came out at 93.5%,
-  # just under the 95% floor in MIN_TEMPORAL_DATE_COVERAGE.
+  # max_symbols has to clear the MIN_TEMPORAL_DATE_COVERAGE floor against the temporal
+  # artifact 04_model_based_features builds. With no reduction at all these notebooks ran
+  # on the full fixture universe while the artifact covered 5 symbols, so the CV splits
+  # spanned dates the artifact never saw and fold 0 validation came out at 93.5%, just
+  # under the 95% floor. This used to read "must match 04_model_based_features"; 04
+  # declares no max_symbols, so there is nothing to match, and the value is the 6 the
+  # case-study header derives.
   # A reduced run declares a different member set than the canonical population,
   # so it names its own.
   parameters:
@@ -1812,10 +1819,12 @@ case_studies/etfs/11a_pca:
       max_symbols: 6
   timeout: 300
 case_studies/etfs/11b_ipca:
-  # max_symbols must match 04_model_based_features for the same reason as 11a,
-  # which leaves IPCA five funds to fit a 71-characteristic Gamma on. At the
-  # production n_factors=5 that is 355 parameters against five assets a date and
-  # the ALS does not identify. Measured on this fixture at the declared
+  # max_symbols clears the coverage floor for the same reason as 11a, and at 6 leaves
+  # IPCA six funds to fit a 71-characteristic Gamma on. At the production n_factors=5
+  # that is 355 parameters against a handful of assets a date and the ALS does not
+  # identify. The per-fold K measurements below were taken when this block declared 5;
+  # they are what chose n_factors=1 and have not been re-measured at 6. Measured at the
+  # declared
   # max_iter=100, per fold: K=5 fails on both folds (110.0s, 113.6s), K=3 fails
   # on both (55.7s, 57.0s), K=2 converges on fold 0 in 21.8s and fails on fold 1
   # at 42.0s, K=1 converges on both in 0.6s and 0.8s. The times are the tell -

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -1162,6 +1162,93 @@ def _collect_preview_reductions(parameters: dict) -> dict:
     return resolved
 
 
+def _is_canonical_tier_test(node: ast.expr) -> bool:
+    """Is this the `EXECUTION_TIER == "canonical"` comparison itself?"""
+    return (
+        isinstance(node, ast.Compare)
+        and isinstance(node.left, ast.Name)
+        and node.left.id == "EXECUTION_TIER"
+        and len(node.ops) == 1
+        and isinstance(node.ops[0], ast.Eq)
+        and isinstance(node.comparators[0], ast.Constant)
+        and node.comparators[0].value == "canonical"
+    )
+
+
+def _refused_by_guard(test: ast.expr) -> frozenset[str]:
+    """Names a guard refuses, or nothing if the guard is a requirement rather than a refusal.
+
+    A refusal reads `if A or B or C: raise` - every operand a bare name, so the guard fires when
+    any of them is truthy, which is to say when the caller supplied one. A requirement reads
+    `if not X or len(X) != len(set(X)): raise`, and fires when the caller did NOT supply one.
+    They sit side by side in the same canonical branch (`16_backtest.py` has both), and reading
+    the second as a refusal would strip `PREDICTION_SET_NAMES` - a parameter the canonical run
+    needs. Any `not`, comparison or call in an operand marks the guard as the second kind.
+    """
+    operands = (
+        test.values if isinstance(test, ast.BoolOp) and isinstance(test.op, ast.Or) else [test]
+    )
+    names: set[str] = set()
+    for operand in operands:
+        if not isinstance(operand, ast.Name):
+            return frozenset()
+        names.add(operand.id)
+    return frozenset(names)
+
+
+def canonically_refused_parameters(py_path: Path) -> frozenset[str]:
+    """Parameters this notebook's own canonical branch raises on, read from its source.
+
+    Preview-only-ness is a property of the notebook, not of the name. The `PREVIEW_` prefix
+    covers most of it by convention, but `MAX_SYMBOLS` carries no prefix and is a preview-only
+    reduction for `us_equities_panel` 16 through 19 while being a legitimate canonical parameter
+    elsewhere - so it can be neither stripped globally nor left in. The notebook already answers
+    the question in the only place that can: `if EXECUTION_TIER == "canonical": if ... raise`.
+    This reads that answer instead of restating it in a list here, which is the same reason the
+    prefix replaced the fourteen-name list it grew out of.
+
+    Both guard shapes in the fleet are handled - the nested `if EXECUTION_TIER == "canonical":`
+    with the refusal inside it, and the flattened `if EXECUTION_TIER == "canonical" and (...)`.
+    The result is intersected with what the parameters cell declares, so a local aggregate like
+    `preview_filters` drops out; the `PREVIEW_`-prefixed names behind it are stripped by prefix
+    anyway, and the aggregate is not a parameter anyone can pass.
+    """
+    source = py_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(py_path))
+    cells = _percent_cell_bounds(source)
+    tagged = [cell for cell in cells if PARAMETERS_CELL_MARKER in cell[0]]
+    if not tagged:
+        return frozenset()
+    declared = {
+        name for name, line in _top_level_bindings(tree) if tagged[-1][1] <= line <= tagged[-1][2]
+    }
+
+    refused: set[str] = set()
+
+    def walk(node: ast.AST, in_canonical: bool) -> None:
+        if isinstance(node, ast.If):
+            here, inner = in_canonical, node.test
+            if isinstance(node.test, ast.BoolOp) and isinstance(node.test.op, ast.And):
+                rest = [v for v in node.test.values if not _is_canonical_tier_test(v)]
+                if len(rest) < len(node.test.values):
+                    here = True
+                inner = rest[0] if len(rest) == 1 else None
+            elif _is_canonical_tier_test(node.test):
+                here, inner = True, None
+            if here and inner is not None and any(isinstance(s, ast.Raise) for s in node.body):
+                refused.update(_refused_by_guard(inner))
+            for statement in node.body:
+                walk(statement, here)
+            for statement in node.orelse:
+                walk(statement, in_canonical)
+            return
+        for child in ast.iter_child_nodes(node):
+            walk(child, in_canonical)
+
+    walk(tree, False)
+    return frozenset(refused & declared)
+
+
 def injected_parameters(
     py_path: Path,
     parameters: dict | None,
@@ -1193,27 +1280,30 @@ def injected_parameters(
     ``generate_intermediates.py``'s default ``--through-stage 8``. A higher stage bound, or
     the same guard added to an earlier notebook, reaches it.
 
-    **The prefix narrows the gap; it does not close it.** Preview-only-ness is a property of
-    the notebook, not of the name. ``MAX_SYMBOLS`` carries no prefix and is a preview-only
-    reduction for ``us_equities_panel`` 16 through 19, whose canonical branch refuses it
-    (``16_backtest.py:99``) while ``tests/overrides.yaml`` declares it for all four - so a
-    canonical run of those still fails on its first cell. It cannot be added to the strip
-    either: elsewhere it is a legitimate canonical parameter, which
-    ``test_injected_parameters_keeps_everything_else_on_a_canonical_run`` pins. Deciding this
-    properly means reading which names a notebook's own canonical branch refuses, or marking
-    the entry in the override file; both are design changes that belong with whoever owns the
-    preview contract.
+    **The prefix narrows the gap and the notebook closes it.** Preview-only-ness is a property
+    of the notebook, not of the name. ``MAX_SYMBOLS`` carries no prefix and is a preview-only
+    reduction for ``us_equities_panel`` 16 through 19, whose canonical branch refuses it, while
+    being a legitimate canonical parameter for 57 other entries - which
+    ``test_injected_parameters_keeps_everything_else_on_a_canonical_run`` pins. So it can be
+    neither stripped by name nor left in, and no list here can decide it. Only the notebook can,
+    and it already does: ``canonically_refused_parameters`` reads the refusal out of the
+    notebook's own ``EXECUTION_TIER == "canonical"`` guard. Naming the four here instead would
+    have gone stale the same way the fourteen ``PREVIEW_`` names did.
 
-    What is here covers every ``PREVIEW_``-prefixed name, plus ``DEVICE_SCOPED_NAMES`` - and
-    those only for an entry that declares ``DEVICE``, which is what confines them to the
-    entries where the population name exists to carry the device. ``MAX_SYMBOLS`` stays out
-    for the reason above: it is a legitimate canonical parameter elsewhere.
+    What is here covers every ``PREVIEW_``-prefixed name, whatever the notebook's own guard
+    refuses, and ``DEVICE_SCOPED_NAMES`` - the last only for an entry that declares ``DEVICE``,
+    which is what confines them to the entries where the population name exists to carry the
+    device. The device pair stays separate rather than folding into the guard read: no notebook
+    refuses ``DEVICE`` or ``POPULATION_NAME``, because a canonical run of a CPU-fitted population
+    is wrong for a reason the notebook expresses by refusing to publish, not by raising.
     """
     if research_preview:
         return research_preview_parameters(py_path, parameters, output_dir)
     resolved = dict(parameters or {})
     for name in [key for key in resolved if key.startswith("PREVIEW_")]:
         resolved.pop(name)
+    for name in canonically_refused_parameters(py_path):
+        resolved.pop(name, None)
     if "DEVICE" in resolved:
         for name in DEVICE_SCOPED_NAMES:
             resolved.pop(name, None)

--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -16,6 +16,7 @@ from tests.pm_helpers import (
     TIER_ON_DEMAND,
     TIER_PER_COMMIT,
     TIER_WEEKLY,
+    canonically_refused_parameters,
     check_kernel_routing,
     collect_chapter_notebooks,
     current_test_tier,
@@ -1589,6 +1590,76 @@ def test_injected_parameters_keeps_everything_else_on_a_canonical_run() -> None:
         )
         == parameters
     )
+
+
+def test_canonical_run_drops_a_parameter_the_notebook_itself_refuses() -> None:
+    """MAX_SYMBOLS carries no PREVIEW_ prefix and is preview-only for these four notebooks.
+
+    Their canonical branch raises on it, so passing it through was a guaranteed failure on the
+    notebook's first cell. It cannot be added to the prefix strip either - the entry above pins
+    it as a legitimate canonical parameter elsewhere - so the only place that can answer is the
+    notebook, and this reads its answer.
+    """
+    for stem in ("16_backtest", "17_portfolio_management", "18_risk_management", "19_costs"):
+        py_path = REPO_ROOT / f"case_studies/us_equities_panel/{stem}.py"
+        assert "MAX_SYMBOLS" in canonically_refused_parameters(py_path), stem
+        resolved = injected_parameters(py_path, {"MAX_SYMBOLS": 5}, None, research_preview=False)
+        # An empty injection is returned as None - papermill is handed nothing rather than an
+        # empty mapping - so the contract here is that the notebook receives no parameter at all.
+        assert not resolved, f"{stem} still receives a parameter it raises on"
+
+
+def test_a_requirement_guard_is_not_read_as_a_refusal() -> None:
+    """`16_backtest` refuses MAX_SYMBOLS and requires PREDICTION_SET_NAMES in the same branch.
+
+    Both are `if ...: raise` inside `if EXECUTION_TIER == "canonical":`. Reading the second as a
+    refusal would strip the names the canonical run needs, so the two shapes have to be told
+    apart: a refusal is a bare disjunction of names, a requirement negates or compares them.
+    """
+    refused = canonically_refused_parameters(
+        REPO_ROOT / "case_studies/us_equities_panel/16_backtest.py"
+    )
+    assert "MAX_SYMBOLS" in refused
+    assert "PREDICTION_SET_NAMES" not in refused
+
+
+def test_the_flattened_and_guard_shape_is_read_too() -> None:
+    """Two shapes express the same refusal and both are in the fleet.
+
+    `cme_futures/13_backtest` nests the refusal inside `if EXECUTION_TIER == "canonical":`;
+    `sp500_options/13_portfolio_management` flattens it into a single `and`. Reading only the
+    nested one would leave the flattened notebooks unprotected.
+    """
+    assert canonically_refused_parameters(
+        REPO_ROOT / "case_studies/sp500_options/13_portfolio_management.py"
+    ) == {"PREVIEW_LABELS", "PREVIEW_MAX_BASELINE_CONFIGS"}
+    assert canonically_refused_parameters(
+        REPO_ROOT / "case_studies/cme_futures/13_backtest.py"
+    ) == {"PREVIEW_LABELS", "PREVIEW_MAX_PREDICTIONS"}
+
+
+def test_no_override_entry_declares_a_parameter_its_notebook_refuses_canonically() -> None:
+    """The fleet-wide statement, so a new entry cannot reintroduce this silently.
+
+    A name in this position does not fail loudly on the preview path - it reduces, correctly -
+    and fails on the canonical path only when a run reaches that notebook. `us_equities_panel`
+    16 through 19 sit above `generate_intermediates.py`'s default `--through-stage 8`, which is
+    why four of them sat here unnoticed.
+    """
+    entries = yaml.safe_load((REPO_ROOT / "tests/overrides.yaml").read_text())
+    leaked = {}
+    for key, entry in entries.items():
+        if not isinstance(entry, dict):
+            continue
+        declared = set(entry.get("parameters") or {})
+        py_path = REPO_ROOT / f"{key}.py"
+        if not declared or not py_path.exists():
+            continue
+        resolved = injected_parameters(py_path, entry["parameters"], None, research_preview=False)
+        refused = canonically_refused_parameters(py_path) & set(resolved or {})
+        if refused:
+            leaked[key] = sorted(refused)
+    assert not leaked, f"canonical injection carries names the notebook raises on: {leaked}"
 
 
 def test_injected_parameters_keeps_preview_reductions_under_the_preview_tier(

--- a/tests/test_research_workspace.py
+++ b/tests/test_research_workspace.py
@@ -1108,3 +1108,53 @@ def test_a_bare_label_read_keeps_the_tier_the_study_was_opened_at(
     # And naming the tier explicitly reaches the same artifact, so the default is a default
     # rather than a second behaviour.
     assert study.labels.get("fwd_ret_21d", execution_tier="preview").path == resolved
+
+
+def test_relative_preview_workspace_lands_outside_the_repository(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A bare workspace name used to resolve against the caller's cwd, which is the repo root.
+
+    Notebooks run from the repo root, so `WORKSPACE=smoke-1045` put a `config` symlink, a
+    `.preview/` tree and a 268K registry there, and `git status` offered all of it
+    (ml4t/agent-workspace#1053). A relative name now resolves against a declared preview root
+    instead, so nothing in `.gitignore` is load-bearing for it.
+    """
+    from utils.paths import REPO_ROOT as repo_root
+
+    release = _seed_release(tmp_path)
+    preview_root = tmp_path / "preview-root"
+    monkeypatch.setenv("ML4T_PREVIEW_ROOT", str(preview_root))
+    monkeypatch.chdir(repo_root)
+
+    study = open_study(
+        "etfs",
+        execution_tier=ExecutionTier.PREVIEW,
+        workspace="smoke-1045",
+        release_root=release,
+    )
+
+    assert study.output_root == (preview_root / "smoke-1045").resolve()
+    assert not (repo_root / "smoke-1045").exists(), (
+        "a relative workspace must not create anything in the checkout"
+    )
+
+
+def test_absolute_preview_workspace_is_taken_as_given(tmp_path: Path, monkeypatch) -> None:
+    """The drivers pass absolute paths (`smoke-chain.sh` defaults to the artifact store).
+
+    Redirecting those under the preview root would move every existing smoke workspace, so an
+    absolute path stays exactly where the caller put it.
+    """
+    release = _seed_release(tmp_path)
+    monkeypatch.setenv("ML4T_PREVIEW_ROOT", str(tmp_path / "unused-root"))
+    declared = tmp_path / "explicit" / "ws"
+
+    study = open_study(
+        "etfs",
+        execution_tier=ExecutionTier.PREVIEW,
+        workspace=declared,
+        release_root=release,
+    )
+
+    assert study.output_root == declared.resolve()


### PR DESCRIPTION
Three fixes to the preview path, none of which changes what a canonical run computes.

## A relative preview workspace landed in the repo root

`open_study` resolved a relative preview workspace against the checkout, so every lane staged
symlinks and a registry into its own repo root and then had to clean them up. It now resolves
outside the checkout. (ml4t/agent-workspace#1053)

## The etfs override comments described a reduction nothing declares

Comment-only. The entries said `max_symbols` was set where it was not; the comments now say what
the entries do.

## A notebook can now say which parameters its canonical branch refuses

`tests/overrides.yaml` has two consumers that inject differently. `injected_parameters(research_preview=True)`
folds `MAX_FOLDS` / `MAX_SYMBOLS` / `TRAIN_SAMPLE_FRAC` into `PREVIEW_REDUCTIONS`;
`research_preview=False` strips the `PREVIEW_`-prefixed names and passes everything else through
untranslated. So a name that is preview-only for one notebook and legitimate for another reached
the canonical path of the notebooks that refuse it, and four entries failed there.
(ml4t/agent-workspace#1057)

The fix reads the refusal from the notebook rather than from a list. `canonically_refused_parameters`
parses the source and returns the names the notebook's own `EXECUTION_TIER == "canonical"` guard
raises on, and `injected_parameters` drops those on the canonical path. Preview-only-ness is a
property of the notebook, not of the name, so this stays right as notebooks change.

Two guard shapes exist - nested, and flattened into `and` - and a refusal has to be told from a
requirement by shape: `16_backtest` has both in one branch, and reading the second as a refusal
would strip `PREDICTION_SET_NAMES`.

## Verification

- `tests/test_pm_helpers.py` 108 passed; with `tests/test_smoke_configs.py` 184 passed.
- Falsifiability: with the strip monkeypatched off, the fleet test fails on exactly the four
  entries it is meant to fix.
- `ruff check` and `ruff format` clean; `ty` at 15 diagnostics, matching baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu