### PR TITLE
Reader onboarding: the install gate, the EDGAR wall, the macOS and Linux paths, and a parity check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,9 +49,14 @@ GID=1000
 # API Keys (Optional - only needed for downloading data)
 # ============================================================================
 
-# SEC EDGAR - required for Ch04 NB02 (SEC filing explorer) and NB14 (text
-# extraction). The SEC mandates a real User-Agent (your name + email) on every
-# EDGAR request and blocks placeholder addresses; the notebook raises if unset.
+# SEC EDGAR - free, no account, no sign-up: put your own name and email on the
+# line below. The SEC mandates a real User-Agent on every EDGAR request and
+# blocks placeholder addresses, so anything that calls EDGAR live refuses to run
+# while this is empty: Ch04 NB02 (SEC filing explorer) and NB14 (text
+# extraction), Ch22 NB01 (SEC filing pipeline), and the two download scripts
+# data/equities/positioning/form4_download.py and
+# data/equities/fundamentals/filings_download.py. Every other SEC-derived
+# notebook reads a committed snapshot and needs nothing here.
 # Format: "Jane Doe jane@example.org"
 EDGAR_IDENTITY=
 

--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,10 @@
 # Copy this to .env to get started:
 #   cp .env.example .env
 # The defaults work as-is for the early chapters — you do NOT need to edit
-# anything to run your first notebooks. Come back and set the optional values
-# below (data path, API keys) only when a specific chapter asks for one.
+# anything to run your first notebooks. Come back and fill in a line below only
+# when a chapter asks for it. Two of them are free and need no account:
+# EDGAR_IDENTITY (your own name and email, for the SEC) and UID/GID (only if
+# `id -u` or `id -g` prints something other than 1000). The rest are API keys.
 
 # ============================================================================
 # Path Configuration

--- a/04_fundamental_alternative_data/02_sec_filing_explorer.ipynb
+++ b/04_fundamental_alternative_data/02_sec_filing_explorer.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "85476b85",
+   "id": "e42eaa59",
    "metadata": {
     "papermill": {
-     "duration": 0.006588,
-     "end_time": "2026-05-16T23:42:13.240730+00:00",
+     "duration": 0.009872,
+     "end_time": "2026-09-08T22:55:21.580381+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:13.234142+00:00",
+     "start_time": "2026-09-08T22:55:21.570509+00:00",
      "status": "completed"
     }
    },
@@ -60,19 +60,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "41c04c68",
+   "id": "14f61715",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:14.565341Z",
-     "iopub.status.busy": "2026-07-13T21:37:14.564983Z",
-     "iopub.status.idle": "2026-07-13T21:37:14.644975Z",
-     "shell.execute_reply": "2026-07-13T21:37:14.644556Z"
+     "iopub.execute_input": "2026-09-08T22:55:21.599762Z",
+     "iopub.status.busy": "2026-09-08T22:55:21.599586Z",
+     "iopub.status.idle": "2026-09-08T22:55:21.880464Z",
+     "shell.execute_reply": "2026-09-08T22:55:21.879998Z"
     },
     "papermill": {
-     "duration": 0.050783,
-     "end_time": "2026-05-16T23:42:13.294203+00:00",
+     "duration": 0.291421,
+     "end_time": "2026-09-08T22:55:21.881405+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:13.243420+00:00",
+     "start_time": "2026-09-08T22:55:21.589984+00:00",
      "status": "completed"
     }
    },
@@ -93,20 +93,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d94393da",
+   "id": "2f8a1b8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:14.646194Z",
-     "iopub.status.busy": "2026-07-13T21:37:14.646124Z",
-     "iopub.status.idle": "2026-07-13T21:37:14.647657Z",
-     "shell.execute_reply": "2026-07-13T21:37:14.647348Z"
+     "iopub.execute_input": "2026-09-08T22:55:21.893271Z",
+     "iopub.status.busy": "2026-09-08T22:55:21.893083Z",
+     "iopub.status.idle": "2026-09-08T22:55:21.899492Z",
+     "shell.execute_reply": "2026-09-08T22:55:21.898756Z"
     },
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.004206,
-     "end_time": "2026-05-16T23:42:13.299977+00:00",
+     "duration": 0.013114,
+     "end_time": "2026-09-08T22:55:21.900840+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:13.295771+00:00",
+     "start_time": "2026-09-08T22:55:21.887726+00:00",
      "status": "completed"
     },
     "tags": [
@@ -121,19 +121,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "cd2a25f8",
+   "id": "ae63fed8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:14.648487Z",
-     "iopub.status.busy": "2026-07-13T21:37:14.648427Z",
-     "iopub.status.idle": "2026-07-13T21:37:17.756144Z",
-     "shell.execute_reply": "2026-07-13T21:37:17.755518Z"
+     "iopub.execute_input": "2026-09-08T22:55:21.915818Z",
+     "iopub.status.busy": "2026-09-08T22:55:21.915647Z",
+     "iopub.status.idle": "2026-09-08T22:55:31.097291Z",
+     "shell.execute_reply": "2026-09-08T22:55:31.096707Z"
     },
     "papermill": {
-     "duration": 0.478095,
-     "end_time": "2026-05-16T23:42:13.779507+00:00",
+     "duration": 9.195251,
+     "end_time": "2026-09-08T22:55:31.103939+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:13.301412+00:00",
+     "start_time": "2026-09-08T22:55:21.908688+00:00",
      "status": "completed"
     }
    },
@@ -154,15 +154,22 @@
     "from utils.style import COLORS\n",
     "\n",
     "# SEC requires a real User-Agent (name + email) for every request and blocks\n",
-    "# placeholder addresses. Set `EDGAR_IDENTITY` in your environment, e.g.\n",
-    "# `export EDGAR_IDENTITY=\"Jane Doe jane@example.org\"`.\n",
+    "# placeholder addresses. It is not an API key: put your own name and email on\n",
+    "# the `EDGAR_IDENTITY` line of `.env` in the repository root, e.g.\n",
+    "# `EDGAR_IDENTITY=Jane Doe jane@example.org`.\n",
     "edgar_identity = os.environ.get(\"EDGAR_IDENTITY\")\n",
     "if not edgar_identity:\n",
     "    raise RuntimeError(\n",
-    "        \"EDGAR_IDENTITY environment variable is not set. The SEC requires a \"\n",
-    "        \"real User-Agent (name + email) for every EDGAR request and blocks \"\n",
-    "        \"placeholder addresses. Set it before running this notebook, e.g. \"\n",
-    "        '`export EDGAR_IDENTITY=\"Jane Doe jane@example.org\"`.'\n",
+    "        \"EDGAR_IDENTITY is not set. The SEC requires a real User-Agent - your \"\n",
+    "        \"name and email - on every EDGAR request, and blocks placeholder \"\n",
+    "        \"addresses. It is not an API key and there is nothing to sign up for.\\n\"\n",
+    "        \"Put your own name and email on the EDGAR_IDENTITY line of the .env \"\n",
+    "        \"file in the repository root:\\n\"\n",
+    "        \"    EDGAR_IDENTITY=Jane Doe jane@example.org\\n\"\n",
+    "        \".env is read once, when the process starts, so then restart this \"\n",
+    "        \"notebook's kernel (Kernel -> Restart Kernel). On the Docker path, stop \"\n",
+    "        \"Jupyter Lab and run `docker compose up ml4t` again - `docker compose \"\n",
+    "        \"restart` keeps the environment the container was created with.\"\n",
     "    )\n",
     "set_identity(edgar_identity)\n",
     "\n",
@@ -171,13 +178,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6598ead",
+   "id": "972ac8f8",
    "metadata": {
     "papermill": {
-     "duration": 0.001407,
-     "end_time": "2026-05-16T23:42:13.782466+00:00",
+     "duration": 0.003505,
+     "end_time": "2026-09-08T22:55:31.118184+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:13.781059+00:00",
+     "start_time": "2026-09-08T22:55:31.114679+00:00",
      "status": "completed"
     }
    },
@@ -194,19 +201,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "1211237d",
+   "id": "7efd7211",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:17.757409Z",
-     "iopub.status.busy": "2026-07-13T21:37:17.757186Z",
-     "iopub.status.idle": "2026-07-13T21:37:17.954150Z",
-     "shell.execute_reply": "2026-07-13T21:37:17.953712Z"
+     "iopub.execute_input": "2026-09-08T22:55:31.126761Z",
+     "iopub.status.busy": "2026-09-08T22:55:31.126233Z",
+     "iopub.status.idle": "2026-09-08T22:55:31.534314Z",
+     "shell.execute_reply": "2026-09-08T22:55:31.532867Z"
     },
     "papermill": {
-     "duration": 0.178838,
-     "end_time": "2026-05-16T23:42:13.962652+00:00",
+     "duration": 0.420923,
+     "end_time": "2026-09-08T22:55:31.542673+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:13.783814+00:00",
+     "start_time": "2026-09-08T22:55:31.121750+00:00",
      "status": "completed"
     }
    },
@@ -235,19 +242,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "a7976055",
+   "id": "472b2052",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:17.955162Z",
-     "iopub.status.busy": "2026-07-13T21:37:17.955083Z",
-     "iopub.status.idle": "2026-07-13T21:37:18.281789Z",
-     "shell.execute_reply": "2026-07-13T21:37:18.280369Z"
+     "iopub.execute_input": "2026-09-08T22:55:31.558789Z",
+     "iopub.status.busy": "2026-09-08T22:55:31.558361Z",
+     "iopub.status.idle": "2026-09-08T22:55:31.650691Z",
+     "shell.execute_reply": "2026-09-08T22:55:31.648916Z"
     },
     "papermill": {
-     "duration": 0.266149,
-     "end_time": "2026-05-16T23:42:14.232040+00:00",
+     "duration": 0.102443,
+     "end_time": "2026-09-08T22:55:31.651385+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:13.965891+00:00",
+     "start_time": "2026-09-08T22:55:31.548942+00:00",
      "status": "completed"
     }
    },
@@ -256,13 +263,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Tesla by CIK: Tesla, Inc.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Tesla by CIK: Tesla, Inc.\n",
       "Tesla padded: Tesla, Inc.\n"
      ]
     }
@@ -280,19 +281,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "ce599316",
+   "id": "300a33e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:18.284754Z",
-     "iopub.status.busy": "2026-07-13T21:37:18.284503Z",
-     "iopub.status.idle": "2026-07-13T21:37:18.421366Z",
-     "shell.execute_reply": "2026-07-13T21:37:18.420066Z"
+     "iopub.execute_input": "2026-09-08T22:55:31.679042Z",
+     "iopub.status.busy": "2026-09-08T22:55:31.678846Z",
+     "iopub.status.idle": "2026-09-08T22:55:31.914511Z",
+     "shell.execute_reply": "2026-09-08T22:55:31.913847Z"
     },
     "papermill": {
-     "duration": 0.082688,
-     "end_time": "2026-05-16T23:42:14.317984+00:00",
+     "duration": 0.25564,
+     "end_time": "2026-09-08T22:55:31.919770+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.235296+00:00",
+     "start_time": "2026-09-08T22:55:31.664130+00:00",
      "status": "completed"
     }
    },
@@ -331,13 +332,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a913d48f",
+   "id": "927b0919",
    "metadata": {
     "papermill": {
-     "duration": 0.002877,
-     "end_time": "2026-05-16T23:42:14.323953+00:00",
+     "duration": 0.012127,
+     "end_time": "2026-09-08T22:55:31.947714+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.321076+00:00",
+     "start_time": "2026-09-08T22:55:31.935587+00:00",
      "status": "completed"
     }
    },
@@ -352,19 +353,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c0cb8276",
+   "id": "45646ade",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:18.424170Z",
-     "iopub.status.busy": "2026-07-13T21:37:18.423792Z",
-     "iopub.status.idle": "2026-07-13T21:37:18.541645Z",
-     "shell.execute_reply": "2026-07-13T21:37:18.539831Z"
+     "iopub.execute_input": "2026-09-08T22:55:31.981297Z",
+     "iopub.status.busy": "2026-09-08T22:55:31.978464Z",
+     "iopub.status.idle": "2026-09-08T22:55:32.022461Z",
+     "shell.execute_reply": "2026-09-08T22:55:32.022016Z"
     },
     "papermill": {
-     "duration": 0.121548,
-     "end_time": "2026-05-16T23:42:14.447010+00:00",
+     "duration": 0.067025,
+     "end_time": "2026-09-08T22:55:32.027003+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.325462+00:00",
+     "start_time": "2026-09-08T22:55:31.959978+00:00",
      "status": "completed"
     }
    },
@@ -373,7 +374,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total Apple filings: 2236\n"
+      "Total Apple filings: 2246\n"
      ]
     }
    ],
@@ -386,19 +387,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "9ee9baa2",
+   "id": "dfd776f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:18.545704Z",
-     "iopub.status.busy": "2026-07-13T21:37:18.545409Z",
-     "iopub.status.idle": "2026-07-13T21:37:18.554407Z",
-     "shell.execute_reply": "2026-07-13T21:37:18.553345Z"
+     "iopub.execute_input": "2026-09-08T22:55:32.044462Z",
+     "iopub.status.busy": "2026-09-08T22:55:32.044210Z",
+     "iopub.status.idle": "2026-09-08T22:55:32.056846Z",
+     "shell.execute_reply": "2026-09-08T22:55:32.054980Z"
     },
     "papermill": {
-     "duration": 0.005285,
-     "end_time": "2026-05-16T23:42:14.453966+00:00",
+     "duration": 0.020595,
+     "end_time": "2026-09-08T22:55:32.057752+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.448681+00:00",
+     "start_time": "2026-09-08T22:55:32.037157+00:00",
      "status": "completed"
     }
    },
@@ -408,8 +409,8 @@
      "output_type": "stream",
      "text": [
       "10-K filings: 32\n",
-      "10-Q filings: 99\n",
-      "8-K filings: 234\n"
+      "10-Q filings: 100\n",
+      "8-K filings: 236\n"
      ]
     }
    ],
@@ -427,19 +428,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "cc4634b5",
+   "id": "50221ee7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:18.556633Z",
-     "iopub.status.busy": "2026-07-13T21:37:18.556432Z",
-     "iopub.status.idle": "2026-07-13T21:37:18.561826Z",
-     "shell.execute_reply": "2026-07-13T21:37:18.561128Z"
+     "iopub.execute_input": "2026-09-08T22:55:32.086053Z",
+     "iopub.status.busy": "2026-09-08T22:55:32.085788Z",
+     "iopub.status.idle": "2026-09-08T22:55:32.105094Z",
+     "shell.execute_reply": "2026-09-08T22:55:32.100421Z"
     },
     "papermill": {
-     "duration": 0.004745,
-     "end_time": "2026-05-16T23:42:14.460429+00:00",
+     "duration": 0.036455,
+     "end_time": "2026-09-08T22:55:32.106130+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.455684+00:00",
+     "start_time": "2026-09-08T22:55:32.069675+00:00",
      "status": "completed"
     }
    },
@@ -468,19 +469,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "867b779c",
+   "id": "d22943f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:18.565775Z",
-     "iopub.status.busy": "2026-07-13T21:37:18.565224Z",
-     "iopub.status.idle": "2026-07-13T21:37:18.571670Z",
-     "shell.execute_reply": "2026-07-13T21:37:18.571054Z"
+     "iopub.execute_input": "2026-09-08T22:55:32.119733Z",
+     "iopub.status.busy": "2026-09-08T22:55:32.119459Z",
+     "iopub.status.idle": "2026-09-08T22:55:32.126229Z",
+     "shell.execute_reply": "2026-09-08T22:55:32.125153Z"
     },
     "papermill": {
-     "duration": 0.004474,
-     "end_time": "2026-05-16T23:42:14.466467+00:00",
+     "duration": 0.013478,
+     "end_time": "2026-09-08T22:55:32.126950+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.461993+00:00",
+     "start_time": "2026-09-08T22:55:32.113472+00:00",
      "status": "completed"
     }
    },
@@ -489,7 +490,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Insider filings (Forms 3, 4, 5): 1381\n"
+      "Insider filings (Forms 3, 4, 5): 1387\n"
      ]
     }
    ],
@@ -501,13 +502,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a01cf47",
+   "id": "05c0994a",
    "metadata": {
     "papermill": {
-     "duration": 0.001569,
-     "end_time": "2026-05-16T23:42:14.469613+00:00",
+     "duration": 0.003959,
+     "end_time": "2026-09-08T22:55:32.135548+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.468044+00:00",
+     "start_time": "2026-09-08T22:55:32.131589+00:00",
      "status": "completed"
     }
    },
@@ -522,19 +523,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "33c55a0e",
+   "id": "1c349792",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:18.573082Z",
-     "iopub.status.busy": "2026-07-13T21:37:18.572953Z",
-     "iopub.status.idle": "2026-07-13T21:37:18.923514Z",
-     "shell.execute_reply": "2026-07-13T21:37:18.923193Z"
+     "iopub.execute_input": "2026-09-08T22:55:32.145781Z",
+     "iopub.status.busy": "2026-09-08T22:55:32.145579Z",
+     "iopub.status.idle": "2026-09-08T22:55:33.009053Z",
+     "shell.execute_reply": "2026-09-08T22:55:33.008284Z"
     },
     "papermill": {
-     "duration": 0.319959,
-     "end_time": "2026-05-16T23:42:14.791146+00:00",
+     "duration": 0.873756,
+     "end_time": "2026-09-08T22:55:33.012975+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.471187+00:00",
+     "start_time": "2026-09-08T22:55:32.139219+00:00",
      "status": "completed"
     }
    },
@@ -581,13 +582,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31597389",
+   "id": "41f0fc66",
    "metadata": {
     "papermill": {
-     "duration": 0.001653,
-     "end_time": "2026-05-16T23:42:14.795509+00:00",
+     "duration": 0.009101,
+     "end_time": "2026-09-08T22:55:33.032368+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.793856+00:00",
+     "start_time": "2026-09-08T22:55:33.023267+00:00",
      "status": "completed"
     }
    },
@@ -598,19 +599,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "5c293611",
+   "id": "ef6539c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:18.924475Z",
-     "iopub.status.busy": "2026-07-13T21:37:18.924326Z",
-     "iopub.status.idle": "2026-07-13T21:37:18.970034Z",
-     "shell.execute_reply": "2026-07-13T21:37:18.969740Z"
+     "iopub.execute_input": "2026-09-08T22:55:33.047039Z",
+     "iopub.status.busy": "2026-09-08T22:55:33.046477Z",
+     "iopub.status.idle": "2026-09-08T22:55:33.168519Z",
+     "shell.execute_reply": "2026-09-08T22:55:33.167277Z"
     },
     "papermill": {
-     "duration": 0.049862,
-     "end_time": "2026-05-16T23:42:14.846991+00:00",
+     "duration": 0.134507,
+     "end_time": "2026-09-08T22:55:33.173630+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.797129+00:00",
+     "start_time": "2026-09-08T22:55:33.039123+00:00",
      "status": "completed"
     }
    },
@@ -675,19 +676,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "669710ce",
+   "id": "fde329d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:18.970928Z",
-     "iopub.status.busy": "2026-07-13T21:37:18.970855Z",
-     "iopub.status.idle": "2026-07-13T21:37:19.010281Z",
-     "shell.execute_reply": "2026-07-13T21:37:19.010014Z"
+     "iopub.execute_input": "2026-09-08T22:55:33.218439Z",
+     "iopub.status.busy": "2026-09-08T22:55:33.218044Z",
+     "iopub.status.idle": "2026-09-08T22:55:33.402682Z",
+     "shell.execute_reply": "2026-09-08T22:55:33.402180Z"
     },
     "papermill": {
-     "duration": 0.037751,
-     "end_time": "2026-05-16T23:42:14.886715+00:00",
+     "duration": 0.208864,
+     "end_time": "2026-09-08T22:55:33.404008+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.848964+00:00",
+     "start_time": "2026-09-08T22:55:33.195144+00:00",
      "status": "completed"
     }
    },
@@ -890,13 +891,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bb398e9",
+   "id": "fb96fc77",
    "metadata": {
     "papermill": {
-     "duration": 0.001844,
-     "end_time": "2026-05-16T23:42:14.890550+00:00",
+     "duration": 0.011495,
+     "end_time": "2026-09-08T22:55:33.424474+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.888706+00:00",
+     "start_time": "2026-09-08T22:55:33.412979+00:00",
      "status": "completed"
     }
    },
@@ -907,19 +908,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "214520a5",
+   "id": "6915ae22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:19.011275Z",
-     "iopub.status.busy": "2026-07-13T21:37:19.011205Z",
-     "iopub.status.idle": "2026-07-13T21:37:19.029387Z",
-     "shell.execute_reply": "2026-07-13T21:37:19.029107Z"
+     "iopub.execute_input": "2026-09-08T22:55:33.440428Z",
+     "iopub.status.busy": "2026-09-08T22:55:33.440229Z",
+     "iopub.status.idle": "2026-09-08T22:55:33.535754Z",
+     "shell.execute_reply": "2026-09-08T22:55:33.535159Z"
     },
     "papermill": {
-     "duration": 0.020734,
-     "end_time": "2026-05-16T23:42:14.913068+00:00",
+     "duration": 0.108785,
+     "end_time": "2026-09-08T22:55:33.540084+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.892334+00:00",
+     "start_time": "2026-09-08T22:55:33.431299+00:00",
      "status": "completed"
     }
    },
@@ -1002,19 +1003,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "80dd60cd",
+   "id": "54b15c1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:19.030254Z",
-     "iopub.status.busy": "2026-07-13T21:37:19.030178Z",
-     "iopub.status.idle": "2026-07-13T21:37:19.090210Z",
-     "shell.execute_reply": "2026-07-13T21:37:19.089792Z"
+     "iopub.execute_input": "2026-09-08T22:55:33.553518Z",
+     "iopub.status.busy": "2026-09-08T22:55:33.553326Z",
+     "iopub.status.idle": "2026-09-08T22:55:33.799021Z",
+     "shell.execute_reply": "2026-09-08T22:55:33.798583Z"
     },
     "papermill": {
-     "duration": 0.050628,
-     "end_time": "2026-05-16T23:42:14.965664+00:00",
+     "duration": 0.251714,
+     "end_time": "2026-09-08T22:55:33.799565+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.915036+00:00",
+     "start_time": "2026-09-08T22:55:33.547851+00:00",
      "status": "completed"
     }
    },
@@ -1034,13 +1035,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b828c0e0",
+   "id": "bd00780a",
    "metadata": {
     "papermill": {
-     "duration": 0.001959,
-     "end_time": "2026-05-16T23:42:14.969794+00:00",
+     "duration": 0.013941,
+     "end_time": "2026-09-08T22:55:33.825397+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.967835+00:00",
+     "start_time": "2026-09-08T22:55:33.811456+00:00",
      "status": "completed"
     }
    },
@@ -1051,19 +1052,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "2ee3d20c",
+   "id": "09e189d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:19.091215Z",
-     "iopub.status.busy": "2026-07-13T21:37:19.091142Z",
-     "iopub.status.idle": "2026-07-13T21:37:19.111358Z",
-     "shell.execute_reply": "2026-07-13T21:37:19.110894Z"
+     "iopub.execute_input": "2026-09-08T22:55:33.848491Z",
+     "iopub.status.busy": "2026-09-08T22:55:33.847477Z",
+     "iopub.status.idle": "2026-09-08T22:55:33.925202Z",
+     "shell.execute_reply": "2026-09-08T22:55:33.923837Z"
     },
     "papermill": {
-     "duration": 0.023882,
-     "end_time": "2026-05-16T23:42:14.995817+00:00",
+     "duration": 0.086201,
+     "end_time": "2026-09-08T22:55:33.925768+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.971935+00:00",
+     "start_time": "2026-09-08T22:55:33.839567+00:00",
      "status": "completed"
     }
    },
@@ -1147,13 +1148,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce61bd6d",
+   "id": "c3e2b84d",
    "metadata": {
     "papermill": {
-     "duration": 0.002035,
-     "end_time": "2026-05-16T23:42:15.000143+00:00",
+     "duration": 0.004773,
+     "end_time": "2026-09-08T22:55:33.936873+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:14.998108+00:00",
+     "start_time": "2026-09-08T22:55:33.932100+00:00",
      "status": "completed"
     }
    },
@@ -1166,19 +1167,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "09be83e1",
+   "id": "2765f559",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:19.112288Z",
-     "iopub.status.busy": "2026-07-13T21:37:19.112217Z",
-     "iopub.status.idle": "2026-07-13T21:37:19.150839Z",
-     "shell.execute_reply": "2026-07-13T21:37:19.150449Z"
+     "iopub.execute_input": "2026-09-08T22:55:33.948846Z",
+     "iopub.status.busy": "2026-09-08T22:55:33.947826Z",
+     "iopub.status.idle": "2026-09-08T22:55:34.066061Z",
+     "shell.execute_reply": "2026-09-08T22:55:34.065014Z"
     },
     "papermill": {
-     "duration": 0.0353,
-     "end_time": "2026-05-16T23:42:15.037490+00:00",
+     "duration": 0.124877,
+     "end_time": "2026-09-08T22:55:34.066627+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:15.002190+00:00",
+     "start_time": "2026-09-08T22:55:33.941750+00:00",
      "status": "completed"
     }
    },
@@ -1243,13 +1244,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07190fbc",
+   "id": "34d4d1d4",
    "metadata": {
     "papermill": {
-     "duration": 0.002106,
-     "end_time": "2026-05-16T23:42:15.041837+00:00",
+     "duration": 0.004991,
+     "end_time": "2026-09-08T22:55:34.076984+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:15.039731+00:00",
+     "start_time": "2026-09-08T22:55:34.071993+00:00",
      "status": "completed"
     }
    },
@@ -1264,19 +1265,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "c2adad97",
+   "id": "427c6707",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:19.152027Z",
-     "iopub.status.busy": "2026-07-13T21:37:19.151938Z",
-     "iopub.status.idle": "2026-07-13T21:37:19.398691Z",
-     "shell.execute_reply": "2026-07-13T21:37:19.397534Z"
+     "iopub.execute_input": "2026-09-08T22:55:34.098855Z",
+     "iopub.status.busy": "2026-09-08T22:55:34.098609Z",
+     "iopub.status.idle": "2026-09-08T22:55:34.165192Z",
+     "shell.execute_reply": "2026-09-08T22:55:34.162986Z"
     },
     "papermill": {
-     "duration": 0.369655,
-     "end_time": "2026-05-16T23:42:15.413733+00:00",
+     "duration": 0.083566,
+     "end_time": "2026-09-08T22:55:34.166610+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:15.044078+00:00",
+     "start_time": "2026-09-08T22:55:34.083044+00:00",
      "status": "completed"
     }
    },
@@ -1299,19 +1300,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "c0524b2c",
+   "id": "b891e9bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:19.401217Z",
-     "iopub.status.busy": "2026-07-13T21:37:19.400748Z",
-     "iopub.status.idle": "2026-07-13T21:37:21.737024Z",
-     "shell.execute_reply": "2026-07-13T21:37:21.735945Z"
+     "iopub.execute_input": "2026-09-08T22:55:34.182776Z",
+     "iopub.status.busy": "2026-09-08T22:55:34.182578Z",
+     "iopub.status.idle": "2026-09-08T22:55:36.478004Z",
+     "shell.execute_reply": "2026-09-08T22:55:36.477347Z"
     },
     "papermill": {
-     "duration": 2.839631,
-     "end_time": "2026-05-16T23:42:18.255664+00:00",
+     "duration": 2.304234,
+     "end_time": "2026-09-08T22:55:36.479123+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:15.416033+00:00",
+     "start_time": "2026-09-08T22:55:34.174889+00:00",
      "status": "completed"
     }
    },
@@ -1389,19 +1390,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "217bc878",
+   "id": "759b0bb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:21.740329Z",
-     "iopub.status.busy": "2026-07-13T21:37:21.739982Z",
-     "iopub.status.idle": "2026-07-13T21:37:22.162113Z",
-     "shell.execute_reply": "2026-07-13T21:37:22.161638Z"
+     "iopub.execute_input": "2026-09-08T22:55:36.493691Z",
+     "iopub.status.busy": "2026-09-08T22:55:36.493455Z",
+     "iopub.status.idle": "2026-09-08T22:55:36.799796Z",
+     "shell.execute_reply": "2026-09-08T22:55:36.798783Z"
     },
     "papermill": {
-     "duration": 0.483541,
-     "end_time": "2026-05-16T23:42:18.742731+00:00",
+     "duration": 0.313698,
+     "end_time": "2026-09-08T22:55:36.800374+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:18.259190+00:00",
+     "start_time": "2026-09-08T22:55:36.486676+00:00",
      "status": "completed"
     }
    },
@@ -1511,13 +1512,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d97fe51d",
+   "id": "a82966d3",
    "metadata": {
     "papermill": {
-     "duration": 0.002221,
-     "end_time": "2026-05-16T23:42:18.747407+00:00",
+     "duration": 0.016001,
+     "end_time": "2026-09-08T22:55:36.822341+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:18.745186+00:00",
+     "start_time": "2026-09-08T22:55:36.806340+00:00",
      "status": "completed"
     }
    },
@@ -1537,13 +1538,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9a8740c",
+   "id": "ace33728",
    "metadata": {
     "papermill": {
-     "duration": 0.002513,
-     "end_time": "2026-05-16T23:42:18.752095+00:00",
+     "duration": 0.017734,
+     "end_time": "2026-09-08T22:55:36.857016+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:18.749582+00:00",
+     "start_time": "2026-09-08T22:55:36.839282+00:00",
      "status": "completed"
     }
    },
@@ -1558,19 +1559,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "4a61a8d7",
+   "id": "2a6c50be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:22.163343Z",
-     "iopub.status.busy": "2026-07-13T21:37:22.163258Z",
-     "iopub.status.idle": "2026-07-13T21:37:22.558273Z",
-     "shell.execute_reply": "2026-07-13T21:37:22.555920Z"
+     "iopub.execute_input": "2026-09-08T22:55:36.882118Z",
+     "iopub.status.busy": "2026-09-08T22:55:36.881867Z",
+     "iopub.status.idle": "2026-09-08T22:55:36.976601Z",
+     "shell.execute_reply": "2026-09-08T22:55:36.972333Z"
     },
     "papermill": {
-     "duration": 0.250328,
-     "end_time": "2026-05-16T23:42:19.004672+00:00",
+     "duration": 0.108153,
+     "end_time": "2026-09-08T22:55:36.977735+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:18.754344+00:00",
+     "start_time": "2026-09-08T22:55:36.869582+00:00",
      "status": "completed"
     }
    },
@@ -1579,7 +1580,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Berkshire 13F-HR filings: 210\n"
+      "Berkshire 13F-HR filings: 211\n"
      ]
     }
    ],
@@ -1593,19 +1594,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "c88212bc",
+   "id": "b64bf42f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:22.563373Z",
-     "iopub.status.busy": "2026-07-13T21:37:22.562843Z",
-     "iopub.status.idle": "2026-07-13T21:37:22.643253Z",
-     "shell.execute_reply": "2026-07-13T21:37:22.640779Z"
+     "iopub.execute_input": "2026-09-08T22:55:36.992772Z",
+     "iopub.status.busy": "2026-09-08T22:55:36.992236Z",
+     "iopub.status.idle": "2026-09-08T22:55:37.305859Z",
+     "shell.execute_reply": "2026-09-08T22:55:37.305221Z"
     },
     "papermill": {
-     "duration": 0.156878,
-     "end_time": "2026-05-16T23:42:19.165750+00:00",
+     "duration": 0.326142,
+     "end_time": "2026-09-08T22:55:37.310297+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:19.008872+00:00",
+     "start_time": "2026-09-08T22:55:36.984155+00:00",
      "status": "completed"
     }
    },
@@ -1615,9 +1616,9 @@
      "output_type": "stream",
      "text": [
       "=== Berkshire Hathaway Holdings ===\n",
-      "Report Period: 2026-03-31\n",
-      "Total Value: $263,095,703,570\n",
-      "Number of Holdings: 90\n"
+      "Report Period: 2026-06-30\n",
+      "Total Value: $299,253,556,246\n",
+      "Number of Holdings: 89\n"
      ]
     }
    ],
@@ -1635,19 +1636,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "388a668f",
+   "id": "d45923d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:22.647239Z",
-     "iopub.status.busy": "2026-07-13T21:37:22.646720Z",
-     "iopub.status.idle": "2026-07-13T21:37:22.689672Z",
-     "shell.execute_reply": "2026-07-13T21:37:22.689281Z"
+     "iopub.execute_input": "2026-09-08T22:55:37.336192Z",
+     "iopub.status.busy": "2026-09-08T22:55:37.335968Z",
+     "iopub.status.idle": "2026-09-08T22:55:37.444242Z",
+     "shell.execute_reply": "2026-09-08T22:55:37.443822Z"
     },
     "papermill": {
-     "duration": 0.046233,
-     "end_time": "2026-05-16T23:42:19.217066+00:00",
+     "duration": 0.122675,
+     "end_time": "2026-09-08T22:55:37.445331+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:19.170833+00:00",
+     "start_time": "2026-09-08T22:55:37.322656+00:00",
      "status": "completed"
     }
    },
@@ -1684,141 +1685,141 @@
        "      <th>0</th>\n",
        "      <td>APPLE INC</td>\n",
        "      <td>COM</td>\n",
-       "      <td>57843260493</td>\n",
+       "      <td>65950296923</td>\n",
        "      <td>227917808</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>AMERICAN EXPRESS CO</td>\n",
        "      <td>COM</td>\n",
-       "      <td>45859204536</td>\n",
+       "      <td>51282319275</td>\n",
        "      <td>151610700</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>COCA COLA CO</td>\n",
        "      <td>COM</td>\n",
-       "      <td>30420000000</td>\n",
+       "      <td>32508000000</td>\n",
        "      <td>400000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>BANK AMERICA CORP</td>\n",
-       "      <td>COM</td>\n",
-       "      <td>25039178044</td>\n",
-       "      <td>513624165</td>\n",
+       "      <td>ALPHABET INC</td>\n",
+       "      <td>CAP STK CL A</td>\n",
+       "      <td>28157599351</td>\n",
+       "      <td>78791167</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>CHEVRON CORPORATION</td>\n",
+       "      <td>BANK OF AMER CORP</td>\n",
        "      <td>COM</td>\n",
-       "      <td>17457364606</td>\n",
-       "      <td>84375856</td>\n",
+       "      <td>27543790975</td>\n",
+       "      <td>483394015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>OCCIDENTAL PETE CORP</td>\n",
+       "      <td>CHEVRON CORPORATION</td>\n",
        "      <td>COM</td>\n",
-       "      <td>17221193015</td>\n",
-       "      <td>264941431</td>\n",
+       "      <td>13986141890</td>\n",
+       "      <td>84375856</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>ALPHABET INC</td>\n",
-       "      <td>CAP STK CL A</td>\n",
-       "      <td>15600071913</td>\n",
-       "      <td>54249798</td>\n",
+       "      <td>OCCIDENTAL PETE CORP</td>\n",
+       "      <td>COM</td>\n",
+       "      <td>12868205304</td>\n",
+       "      <td>264941431</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>CHUBB LTD SWITZ</td>\n",
+       "      <td>CHUBB LIMITED</td>\n",
        "      <td>COM</td>\n",
-       "      <td>11162836215</td>\n",
+       "      <td>11670066615</td>\n",
        "      <td>34249183</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>MOODYS CORP</td>\n",
        "      <td>COM</td>\n",
-       "      <td>10762190653</td>\n",
+       "      <td>11173435852</td>\n",
        "      <td>24669778</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>KRAFT HEINZ CO</td>\n",
-       "      <td>COM</td>\n",
-       "      <td>7323527057</td>\n",
-       "      <td>325634818</td>\n",
+       "      <td>ALPHABET INC</td>\n",
+       "      <td>CAP STK CL C</td>\n",
+       "      <td>9606489032</td>\n",
+       "      <td>27188433</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
-       "      <td>DAVITA INC</td>\n",
+       "      <td>KRAFT HEINZ CO</td>\n",
        "      <td>COM</td>\n",
-       "      <td>4626158909</td>\n",
-       "      <td>30100585</td>\n",
+       "      <td>7691494401</td>\n",
+       "      <td>325634818</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
-       "      <td>KROGER CO</td>\n",
+       "      <td>DAVITA INC</td>\n",
        "      <td>COM</td>\n",
-       "      <td>3618000000</td>\n",
-       "      <td>50000000</td>\n",
+       "      <td>6425268898</td>\n",
+       "      <td>28880209</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
-       "      <td>SIRIUSXM HOLDINGS INC</td>\n",
-       "      <td>COMMON STOCK</td>\n",
-       "      <td>2880548260</td>\n",
-       "      <td>124807117</td>\n",
+       "      <td>DELTA AIR LINES INC</td>\n",
+       "      <td>COM NEW</td>\n",
+       "      <td>5368591200</td>\n",
+       "      <td>57320000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
-       "      <td>DELTA AIR LINES INC</td>\n",
-       "      <td>COM NEW</td>\n",
-       "      <td>2646532635</td>\n",
-       "      <td>39809456</td>\n",
+       "      <td>SIRIUSXM HOLDINGS INC</td>\n",
+       "      <td>COMMON STOCK</td>\n",
+       "      <td>3686802237</td>\n",
+       "      <td>124807117</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
        "      <td>VERISIGN INC</td>\n",
        "      <td>COM</td>\n",
-       "      <td>2232726597</td>\n",
+       "      <td>2261494212</td>\n",
        "      <td>8989880</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>15</th>\n",
-       "      <td>CAPITAL ONE FINL CORP</td>\n",
+       "      <td>KROGER CO</td>\n",
        "      <td>COM</td>\n",
-       "      <td>1304374500</td>\n",
-       "      <td>7150000</td>\n",
+       "      <td>2165670000</td>\n",
+       "      <td>39000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
-       "      <td>NEW YORK TIMES CO MTN BE</td>\n",
-       "      <td>CL A</td>\n",
-       "      <td>1268219376</td>\n",
-       "      <td>15146535</td>\n",
+       "      <td>ALLY FINL INC</td>\n",
+       "      <td>COM</td>\n",
+       "      <td>1240650000</td>\n",
+       "      <td>27000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>17</th>\n",
-       "      <td>ALLY FINL INC</td>\n",
-       "      <td>COM</td>\n",
-       "      <td>1137670000</td>\n",
-       "      <td>29000000</td>\n",
+       "      <td>LENNAR CORP</td>\n",
+       "      <td>CL A</td>\n",
+       "      <td>1186481443</td>\n",
+       "      <td>13111741</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>18</th>\n",
-       "      <td>ALPHABET INC</td>\n",
-       "      <td>CAP STK CL C</td>\n",
-       "      <td>1028454775</td>\n",
-       "      <td>3585215</td>\n",
+       "      <td>LIBERTY LIVE HOLDINGS INC</td>\n",
+       "      <td>COM SHS SER C</td>\n",
+       "      <td>1118425787</td>\n",
+       "      <td>10587143</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
-       "      <td>LIBERTY LIVE HOLDINGS INC</td>\n",
-       "      <td>COM SHS SER C</td>\n",
-       "      <td>996356028</td>\n",
-       "      <td>10587143</td>\n",
+       "      <td>NEW YORK TIMES CO MTN BE</td>\n",
+       "      <td>CL A</td>\n",
+       "      <td>1098686000</td>\n",
+       "      <td>15700000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1826,26 +1827,26 @@
       ],
       "text/plain": [
        "                       Issuer          Class        Value  SharesPrnAmount\n",
-       "0                   APPLE INC            COM  57843260493        227917808\n",
-       "1         AMERICAN EXPRESS CO            COM  45859204536        151610700\n",
-       "2                COCA COLA CO            COM  30420000000        400000000\n",
-       "3           BANK AMERICA CORP            COM  25039178044        513624165\n",
-       "4         CHEVRON CORPORATION            COM  17457364606         84375856\n",
-       "5        OCCIDENTAL PETE CORP            COM  17221193015        264941431\n",
-       "6                ALPHABET INC   CAP STK CL A  15600071913         54249798\n",
-       "7             CHUBB LTD SWITZ            COM  11162836215         34249183\n",
-       "8                 MOODYS CORP            COM  10762190653         24669778\n",
-       "9              KRAFT HEINZ CO            COM   7323527057        325634818\n",
-       "10                 DAVITA INC            COM   4626158909         30100585\n",
-       "11                  KROGER CO            COM   3618000000         50000000\n",
-       "12      SIRIUSXM HOLDINGS INC   COMMON STOCK   2880548260        124807117\n",
-       "13        DELTA AIR LINES INC        COM NEW   2646532635         39809456\n",
-       "14               VERISIGN INC            COM   2232726597          8989880\n",
-       "15      CAPITAL ONE FINL CORP            COM   1304374500          7150000\n",
-       "16   NEW YORK TIMES CO MTN BE           CL A   1268219376         15146535\n",
-       "17              ALLY FINL INC            COM   1137670000         29000000\n",
-       "18               ALPHABET INC   CAP STK CL C   1028454775          3585215\n",
-       "19  LIBERTY LIVE HOLDINGS INC  COM SHS SER C    996356028         10587143"
+       "0                   APPLE INC            COM  65950296923        227917808\n",
+       "1         AMERICAN EXPRESS CO            COM  51282319275        151610700\n",
+       "2                COCA COLA CO            COM  32508000000        400000000\n",
+       "3                ALPHABET INC   CAP STK CL A  28157599351         78791167\n",
+       "4           BANK OF AMER CORP            COM  27543790975        483394015\n",
+       "5         CHEVRON CORPORATION            COM  13986141890         84375856\n",
+       "6        OCCIDENTAL PETE CORP            COM  12868205304        264941431\n",
+       "7               CHUBB LIMITED            COM  11670066615         34249183\n",
+       "8                 MOODYS CORP            COM  11173435852         24669778\n",
+       "9                ALPHABET INC   CAP STK CL C   9606489032         27188433\n",
+       "10             KRAFT HEINZ CO            COM   7691494401        325634818\n",
+       "11                 DAVITA INC            COM   6425268898         28880209\n",
+       "12        DELTA AIR LINES INC        COM NEW   5368591200         57320000\n",
+       "13      SIRIUSXM HOLDINGS INC   COMMON STOCK   3686802237        124807117\n",
+       "14               VERISIGN INC            COM   2261494212          8989880\n",
+       "15                  KROGER CO            COM   2165670000         39000000\n",
+       "16              ALLY FINL INC            COM   1240650000         27000000\n",
+       "17                LENNAR CORP           CL A   1186481443         13111741\n",
+       "18  LIBERTY LIVE HOLDINGS INC  COM SHS SER C   1118425787         10587143\n",
+       "19   NEW YORK TIMES CO MTN BE           CL A   1098686000         15700000"
       ]
      },
      "execution_count": 23,
@@ -1862,8 +1863,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e67cca8a",
-   "metadata": {},
+   "id": "33545de1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023622,
+     "end_time": "2026-09-08T22:55:37.474311+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:55:37.450689+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### 5.1 Portfolio Concentration\n",
     "\n",
@@ -1875,19 +1884,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "d3bb3ac3",
+   "id": "59a1c1ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:22.690628Z",
-     "iopub.status.busy": "2026-07-13T21:37:22.690555Z",
-     "iopub.status.idle": "2026-07-13T21:37:24.036246Z",
-     "shell.execute_reply": "2026-07-13T21:37:24.034517Z"
+     "iopub.execute_input": "2026-09-08T22:55:37.502401Z",
+     "iopub.status.busy": "2026-09-08T22:55:37.501675Z",
+     "iopub.status.idle": "2026-09-08T22:55:41.476513Z",
+     "shell.execute_reply": "2026-09-08T22:55:41.474487Z"
     },
     "papermill": {
-     "duration": 0.010021,
-     "end_time": "2026-05-16T23:42:19.229622+00:00",
+     "duration": 3.99459,
+     "end_time": "2026-09-08T22:55:41.477120+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:19.219601+00:00",
+     "start_time": "2026-09-08T22:55:37.482530+00:00",
      "status": "completed"
     }
    },
@@ -1918,39 +1927,39 @@
          "orientation": "h",
          "text": [
           "22.0%",
-          "17.4%",
-          "11.6%",
-          "9.5%",
-          "6.6%",
-          "6.5%",
-          "6.3%",
-          "4.2%",
-          "4.1%",
-          "2.8%"
+          "17.1%",
+          "12.6%",
+          "10.9%",
+          "9.2%",
+          "4.7%",
+          "4.3%",
+          "3.9%",
+          "3.7%",
+          "2.6%"
          ],
          "textposition": "outside",
          "type": "bar",
          "x": [
-          21.985634774005366,
-          17.430617039247302,
-          11.562332484804855,
-          9.51713680772366,
-          6.635366662821706,
-          6.545600244064069,
-          6.320333803389444,
-          4.242880466510538,
-          4.090599164853552,
-          2.783598119477265
+          22.038266729497398,
+          17.136745146261056,
+          12.619428439458948,
+          10.86302879999092,
+          9.204164963158451,
+          4.673676084404744,
+          4.300101046559244,
+          3.8997252902841617,
+          3.7337687786122515,
+          2.570226565554076
          ],
          "y": [
           "Apple Inc",
           "American Express Co",
+          "Alphabet Inc",
           "Coca Cola Co",
-          "Bank America Corp",
+          "Bank Of Amer Corp",
           "Chevron Corporation",
           "Occidental Pete Corp",
-          "Alphabet Inc",
-          "Chubb Ltd Switz",
+          "Chubb Limited",
           "Moodys Corp",
           "Kraft Heinz Co"
          ]
@@ -1969,10 +1978,10 @@
           "colorway": [
            "#0a1628",
            "#D4A84B",
-           "#1a2d4a",
            "#C87533",
            "#10b981",
-           "#ef4444"
+           "#ef4444",
+           "#94a3b8"
           ],
           "font": {
            "color": "#334155",
@@ -2035,12 +2044,12 @@
          }
         },
         "title": {
-         "text": "Berkshire's Top Three Positions Dominate Its 13F Portfolio<br><sup>As of 2026-03-31: top 3 = 51%, top 4 = 60% of reported value</sup>"
+         "text": "Berkshire's Top Three Positions Dominate Its 13F Portfolio<br><sup>As of 2026-06-30: top 3 = 52%, top 4 = 63% of reported value</sup>"
         },
         "xaxis": {
          "range": [
           0,
-          24.623910946886014
+          24.682858737037087
          ],
          "title": {
           "text": "Share of Reported 13F Value (%)"
@@ -2054,7 +2063,7 @@
         }
        }
       },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAGuCAYAAAByTNVOAAAQAElEQVR4AeydBWAUORfH/1vDOVwOd3d3hw+7ww53ijsUp1hpixSXIsXdHQ53O9zd3d1L+eal3WWrbEtl2/4LyWSSl+Tll5ndN28ysxZfv375wUAGPAZ4DPAY4DHAY4DHAI8BHgMR9RiwAP9IgARIgAQAEAIJkAAJkEBEJUCDN6LOLMdFAiRAAiRAAiRAAkEhEAHr0OCNgJPKIZEACZAACZAACZAACfwkQIP3JwumSIAETCdASRIgARIgARIINwRo8IabqaKiJEACJEACJEAC5keAGoUHAjR4w8MsUUcSIAESIAESIAESIIEgE6DBG2R0rEgCphOgJAmQAAmQAAmQQNgRoMEbduzZMwmQAAmQAAlENgIcLwmECQEavGGCnZ2SAAmQAAmQAAmQAAmEFgEavKFFmv2YToCSJEACJEACJEACJBCMBGjwBiNMNkUCJEACJEACwUmAbZEACQQPARq8wcORrZAACZAACZAACZAACZgpARq8ZjoxpqtFSRIgARIgARIgARIggYAI0OANiA7LSIAESIAEwg8BakoCJEAC/hCgwesPGGaTAAmQAAmQAAmQAAlEDAKRzeCNGLPGUZAACZAACZAACZAACZhMgAavyagoSAIkQAIRiQDHQgIkQAKRhwAN3sgz1xwpCZAACZAACZAACURKAgEavJGSCAdNAiRAAiRAAiRAAiQQoQjQ4I1Q08nBkAAJhBABNksCJEACJBCOCdDgDceTR9VJgARIgARIgARIIHQJhM/eaPCGz3mj1iRAAiRAAiRAAiRAAiYSoMFrIiiKkQAJmE6AkiRAAiRAAiRgTgRo8JrTbFAXkwgc/u8k4iTPhc+fv5gk71OoTuMOcBg50We2t/10OUth3aYd3vK4A5jCLiJxMuU4mDZrMUpWqheRhh2ksZBDkLCFm0o79hxE9bq2SJK+IBrZdjNJ72Zt7dBvyCiDbLO2PdF38EjDfiRJcJhmQoAGr5lMRERS487dB8ogFaNUgnxAVqrRDAuWrgk3wyxcMA/ix4vz2/pmK1gJe/YfCXQ7Ff5uCmHnXyhavnag2wyowmDHcQH2J3o8fvosoCbCpKyz3RCD3gnT5Efpyg3gPGYqPn78FCz6+DwOUmYphk3/7vbWdtIkiZA7Z1ZveaG9s3jFesgcSYifKi/kuCtXvTFGjZ8R5AvDwI4hJDicOnNBjev1m7eBVceXvJ6RvmDy9PkoU7WhfjfI2/5DR6P8X02QOF0BFCpTw1c7onv9Fp0hx2fcFLlRpFxtDHEajzdv3xlk9brJ/BmHMZNmGWR8JvKVqK7YiHyKzEVRpXZLLF21wadYoPfFmB0wzMVXvSGO45E/Tw7cPr8fi9zG+yo3JSNzxnRIkyqFKaKUIYFgJ0CDN9iRskE9gRFD+2DDcjcsmDkW/6tQCt37DsfCZWv1xWa9lQ/04kXyh46OfvQy2qGvYif8powdpiTGOg8w5E0aPUTlBVfUrFFtQ9vSZ7y4cdCySV3veXHiBFd3wdpOnlzZlJ6LZ49H0cJ54TLRDSPHTQuWPkw5Dv6uWh4TRw8Olv5+txGZuzWLp2FQn84oXbygOt9KVPoHL1+9/t2mf1nfnDj8UtlgFHj16i3+rlIBNapV9LPVz1++IFvmDFi5YApkbtq2aIAduw+ibdf+vuRl/ozDPzUq+5IxzmhSv6Y69iePGYaECeKhXdeB+HfHPmORYEvfvf8QhfLnQdSoUYLcZr+eHdC25e9fZARZAVaM1ARo8Ebq6Q/ZwWfLkgElihZAhTLF0b1jS4gBeejISW+dbtu1H/+r2RypshZH/pJ/YcTYafj+/btBJkHqfJi3eBVqNWyP1NlKaIbMdEOZPvHly1fUa9ZJtSPeFMkfPWEmKtZoqrwu4gFp0b63ZBvC9+8e6N5vOLLkr4AchStj2IiJcHd3N5T7vJXtnx6/0t/QoFfiV3p5iUE8hsJOQp6c2VR2jqyZFE/Jk4waDdoqbnmLV8NAhzH49OmzZKsgSw+69XFAw1ZdkSF3GTVG8SoZj1EJekVpU6c0tC3tW1tZIWWKP73l2dhYQ/5+xS6orL5r8z5p2nwUr/APkmUsorxv6zfvkC4DDH/EjqX0lOPMaXAvtGj8DzZv8/TCfv36DcNHTUKBUn9BvGDV/rHFoaMnDO29//ARwkk85nKcSL8Tp80zlBsfB+JRe/vuvbqdK7JZC3gaOD5v5f+qT2lcGMkdj3+adIB4jWXMy1ZtlCIVfqWXEvIjkrkrWawg6tWuBvs+XXBk5yp8/PRFu6082iD9K/30S4a27z6A0lUaQBh06D4Iz56/xOlzF9GkdQ91Loon8MHDx4Z2fXKQY9B++JgAzzMxztp06Q9hmSlPOUj6+YtXqk25U6T3wMq5L8ylXAqDeqxIXQniUZVzRu9BlrbnLlwpRTD1HFXCWuQ63gGd2zWFnEParq//SRIlVHNRqnghlC5RGM0b10HbVg2xdcd+/Pjxw5u8zJ9xkHPQm4CPneTJkqpjXy425k13QdbM6bFl2x4l9eTZc8VTPuMyaJ8B8hl4/8EjVSaReI8r12oB8XQXLP03xPssd0zkDsaUGQsgTCRs2rpHpeXYF0+15C1fvUmawIlT5xDQ55ASMop8LmnwS0djHY2qMkkCv02ABu9vI2QDphC4duMOzl+8gmJF8hnE9x44ii52Q7UvgNo4sX8DXMc54L/jZzDUeYJBRhIjx01HiyZ1cPnEDrS3bSRZhvDu/QfU0YyGb9++K+9JnD9iY9e+Q5g5dwkcBvbArXP7sG/rMhTMl8tQRxJLNePC/Zs7RmmeVPGiiJGzat2/UuRv8KmHKfpLv6KTNGqKXiL3qyBGxl/12kC+SIXb5DFDsUS7pW03wMlb1UXL12njzo1je9dh/Eh7LNO+pMT76U0oCDumsAsKq1Hjp2P9lh0YOrA7Lh7fhj7d2kGMdDGKAqOmhfapprcjBjuN046FZRipzfOZw5sht1T/rt8WcjxKmxOmzsbtu/fhNnkkHlw9jCVzJiBZ0kRS5CsI69ixYqrbua/vn8HFY9t8yUjGr/oUGQkz5yxFO9vGEL0a1v0b7boNxO0796UIgdFLVfAnih49Glo3r4/NWz0vAETMVP3GT5mD+rWrY5h2Hh09fgode9hjwNAx6sJ1mDZH5y5c1S4mpkiT/oZFy9ajQN6cOLh9BeQOxewFK2B8nr1+8wY1qlbEgW3LsWz+JESxsUHTNj2VIZgqZTLs3rRYtX37wn4I8xkTPY/x3z1WGv7zF4bb94TcHZB2JTTXDNHgOkeV0v5E8pm1fdcBVKlUGjqdzh+poGXrdDrFTgzpek074/KVG1i9aBq2r1uAh4+eoFajdvj27ZuhcbmAOXH6PJbPm4I7Fw9gkssQVP1fGXRs00TxFi5VNT1lGy1aVCydO0nl161VFaZ+Dhk685EwVUcf1bhLAkEmoH01BLkuK5JAgATkAQfxBkgQD1v1KuXRSPti11caN2U2Wmu39+RLNUH8uCigGaX97dpDvhT1MrJt+E91VK9cTt1Kix0rpuFL4tXrN6iueewSxI+HZfMmQj6QRf7R42eQW/JibMoXfs5smX0ZyjmzZVIf7tLuoL5dUL50Ufx34qxU9zf41MMU/ee4joJ4a6VRU/QSuV+F+UtWI2aM6Bg3YiCEW9FC+TQPUmeIgSteOH19WW/XrUMLiMFdrlRRdGzdBHMXrdQXB3lrCrvAshIv/fipc7SLlO4QXcVr+78KJdGsUR3Nw2+6zpeuXMfy1ZtRtlQR5fF2m7ccdl3aoGzJouqYGDG0F/7UDNpZ85eq8cucpEmdQnnGYkSPDvGO1v67sioLSiRe9l/1qW+3ZdN/1FjjxvkDHVo3RqIE8XHyzHlVHJx6pUuTEmJk3b330CQmSgEtGqydF+00T6Scs53bNcM2zUhzGmIHuSXdtEEttNXO3ROnAz5nypcpBjEu5XwUD3y50sVw7OQ5rXXP/3Lui+En5blzZFVG8dHjp3H56k1PAT/i4DpW/Ggawl10Ceizw696puS17NBHeUrlTsMDzficMsZzqZJxXfmsNA7i6TcuDyi9Ys1mXLh0DWVKFoFcjIsxO9FlMLJkSofUqZJj4ughuHr9tnb3Y6+3ZuRiWMrlYs5bwS92TP0c8q+ZwOjoXxvMJ4HAELAIjDBlSSAwBPRreNcumY5xzgNx9NgpdbtQ38aVazchb0sw/oCXhz/kQ/7R46d6MeTOkc2QloR4BmT7d/3WyJghDWZPHQlra2vJUkG+WJ89f4EyVRpqHqhJ6kEOuR2nCr2iLJnSe6U8N+JNev7ipeeOP7FPPUzVX9+cKXrpZQPa3rh1FyWKFTAY+CIrbcv25u27slEhR7aMaquPcuXIgsdPnuF3H+gyhV1gWd3SPJtiyMjyFuPjQR6mu3Xb0+upH4fPrTwUqK8jDwTl0C5mundspXluHyhvlhhd+jpWVlbKILipMZS8mn9VwvzFq9WSGLmVvWXbXuUhk7KghNt3f92nvt0/kybWJ9U2caIEatmA7AS3XtKmhMDolzVLBqmiQqoUydRW1qKqhBZJ3pOnL7SU//+T+RhjwgRxtTH+rHPv/kN06+MAWc4kc5gwTX61pOneg4f+Nvo7x4q/jXoVyHn0q88OL9FAb3p1bY1Vi1y1CzBbjcFL9Ozv6a02bmjDcje1Jle/jfaL9bLOY6YqI1rYyR0CuRCpWb0i5HMgSeKEyK1dROjbz5QhDSTcuHVHn6Xtp4VcXBoyApEw9XPIvyZN1dG/+swngcASoMEbWGKUN5mAfg2vrFtr0eQftGneAGMmzTSsldXpdBjj1F/dIpNbZsZBnvjWdxQ1WhR9Um11Op3a1qlRFfsO/qe8FirDK0qUMD72b12OhnX/woePn+A8xhWlK9fH02c/v2itrCy9pD03Op206X09nWfJz9gvPUzRX9+CKXrpZX+1tbT0rr+lj/EEVP+r0S3NgOT8KzOFXWBZ6XTCHzi8cxWMjwNJH9m12j9VVL7clhYD4d81c3Hz3F5lMBgfP2LkKkGvyMrSyisF5WHdtWkRimhe8us3b6sHiWTds0EgiImA+tQ3aSFrL/Q7Xlv9Uoxymkc+uPS6fvMOxHudInlSr14AU/SzMjrGdDrP+TGup9N53j43NOpHwsLCs573Is/zTC5c5Ra7GMGLZk3AkxvH8PLuKXXx+u2ru/cqRns6nWebQTlWjJrxMxmc56jPDuRCUeZ1YO/OmDnJCavWbcGlKze8iRmv35W0z/Pcm7C2o39obdfGRbh36aDmxR2s5Xr+N3YCeOYAPtuLFjWqvihIW5/tWQbic0g6NEVHkWMggeAgYBEcjbANsyVgVop9/PQZ8u7cT17vz82qeVl37TscZB27tm+O5totb/H0Xrl2y1s74j1ro91ydR7SG4d3rMLd+49w3OhWqjfhIO4ERf/g0EtuUZ89f9mb1qdOX1T7aVOnVFuJZI2lbPXhzLlLSJwwAWSJgz4vtLa/WtmaNwAAEABJREFUYpUuTQrlsd6551CgVRIPlRgHhQvkUcsW9A2kTplMfcGfPe/JRp8vywbSarf59fu5smeBLP2YPsERc6ePhnh53xi9MkovJ1sxEDx+eEjSz2Bqn35W9pEZGL18VDXsftQu+GSJULNGtdRSoODUz9BJEBNyF0fWUjes+7fmaUyDKFFscOHyNeWV1zcZJUoUlfTw+Mk83W8cK6oxryhqVBv88PA0vr2y1CY4zlHVkAmRGP0miPkron9oLW/u7IgePZpBTj4H5OEvYazPfP7iFcQrmy5NKn2Wn9soNlFgil7ptHPIlM8hPzvRMn9HR606/5NAoAnQ4A00MlYwlYCsJ9t/6Bgk/Lt9H2bNXwZZbxorZgzVRM8utpAngp3HTFUP68iXmqzrkgeelIAJUd8e7VCnRmUYG73ygxHyBLwsjZAm9h08przKaVInl91gC4HVP7j0Eq+OrMeUN0vIl5g86OcwaqJaHy2vJtIPUNbwTXCdC3lzxc69hzBl5gKIp11fHprbX7ESz6GstR07eRbkCfqXr16r9aYr125Rr9YKiq6yprtNi/rKw3/wyHFIm6PGz8C5C1fQunl91aQ8jb515351G12e/N934D8k0W4F+7eeMV3aVGqdpKrsR2RKn35U85U1ZcYCBEYvfQNyrunDhi071ZtLokaxhrwOSmSCSz9p63eDLOFI9mcS7NxzUDV18fJ1tbzB2GsoXukomiF8/uJVJSNR0I8Vqf0zpNEuDu/ef6jOD31uUM7RM+cvqc84MTA/ff6q0jIHskRH2pV5lGNa8jZv3aPeCCNvTJBnFjJnTCsiwR5kLbosYeraeyjEGSAPQ/boNxypUvyJyhVKBdhfWu1zUjzP8nkckKCpn0P+tfE7OvrXJvNJICACNHgDosOy3yIgv6gjD67VbNgOw0ZOQOWKpdU7efWNFimYV91+lofFylZrhCz5KmDMJDd8/fpFL+LnVu990G+H2/fEX1XKKaNX1qfFjBkdYjAkz1RErW9r120ARg/vC7ml6GeDQcwMrP7BpZd4dTaucMPxU+cgryST8ZUrXRQujt7f69myyT+acXcZqbOVUIZE/drV0LNzqyCO9veqmcKqR6eWGNS3s3poMUehyihRqa4ydmMYea4Cq8XQ/t1Ro1oFbfzDkKtIFbUEZt3S6Ujn5eX6rnkOO/UcBPmxBgmbtu7Sbjc7K2+oX311bttMO7bmq+NKXqXll8yv+vSrjs+8wOqlry/nm7wmStZzykOAf1WtgP1bV0B/kSlywaGftPO7QQzbRW7j1C8aFilXG/VbdEHvbm1hPN+id/eOLfFXvdaKuf61ZMFxrJQpURg5s2eGnB+yBlZeSxaUc3TgsDEQ7nKRfffeA5WW/edezwREjxYVrjMXqvyWHXtjz4GjqFerKha6jYVfy1p+l6vUl3aXzpmImDFjokaDNqjwdxN1TK9c4Aobr9cLipxfoVG9Grhz9z7ipcyjmIvB7JecqZ9DftWVvN/RUeozkEBgCdDgNSLGZPAQkAfAZO2lPjy/fQKHdqxSrwHy+etlcit6zeJpau3llVM7sX7ZTMj7Q/WaSN3ypYvpd9VWjCdpO6rRAx2jHPqp15aJISPr5GTdp8hIuH1hv+bRa6DqSrRy4VRvfUiePGA3b/oYSapw4+xeyLst1Y4W+aWHlo1f6S8y+vArvfRyPrdZM6dX61rFI6Qvk3WrwurupYM4eWAjHAb2VEsC9OWyjap5xtwmj1B1zx3ZgsH9uqr1kVL2qyBz0a1DC19iprALKiudTgdZorJj/QL1irDj+9ZDHnisWb2SLz30GfIaJZHR7/vcype7rJk8tnc97l0+BLlQkLsMerku7Zrh2undipEcKyInc6ov93kcVK5YSrUjsvrXksmbDPZtXaavogyKgPoUQb8YSRvSlpT/Si+RMQ7yJgTRScKLOydx4b+t2LlhoXpAyvg8kTq/YuLX+SXr8KVtqa8P8voqOf70+6K7jEG/b8qxkjtnVnXRK+txzx7ejErlSkDalLb17fTt0d4wP/rXkul0gT9W9Iz07YrBJceOjEuCvJYsKOeorB+X+j6DeK+lLzme9m9brsbw+Pp/kPW2ci7K8iIpl+BTN8n7VZDX5PXp3tZfMblTIQ/0Xjq+XR3j86a7qHdr6yvIxe+W1XP0u4at/BKafKboxyMPuknho2tH8b/yJSVpCL/6HJI+ZVmZvsI87TNWPmv1+7/SUS/HLQkEBwEavMFBkW2QAAmQQMQiwNGQAAmQQIQiQIM3Qk0nB0MCJEACJEACJEACJOCTQNANXp8tcZ8ESMBsCPh1O9lslKMiJEACJEACJBDKBGjwhjJwdhc+CCxZuR4JUufDq9dvgkXhhcvWokaDthgzaZa39uTp7ap1WiFD7jLobe+sXtumF3B1WwR5mE9+jOH4ybMqW17U373fcGTKU06VHTh8XOVL9PXrN9WGtCUv8JcnziXfZ5CnxSvWaKrqy4M6+nJ5IEge3smcrzy69BoK/VPm+nLZSh85CldWD7MULV8bk6fPl2wV5JeX5OEjaUNl/CKSp/J37Tv0CynTigPSy7QWfEudvXBZjVPGI8FugLNBqN+QUcict7yaU8mUIA9RyhzKA1ajxs+QLBWGj5qEI8dOqXRAUXDy0Pcjbw5ImqEQjOdZXxaUrdu8pYYfiRjo8HPNu1/Hqrz3uknrHoqRvOpN31/DVl3h32vf9DI+t9KWvNlAHoB9+OiJz+IQ35c3vsxbvCrQ/cgPp/h3Hpra2PMXryDnq6nylCMBEvCbAA1ev7kwN5ITkFc6yQMZazdsCxYS46fMxqqFU329JUFeE7R6kat68ExetzRl5kLV36Ur1yHGxeaVszFqeF906GGv8uVBG/kBD3mobKzzAHSyGwz5MpZCeaXX9Rt3sX3dAty9eAAF8+WUbG/B3d1da2sQJo0eio3L3TBu6mzIK85EaGCvTnh17zT2bFmifrBj2eqNku0tyI9O/Lt6jnoAZ9aUUViwdDWu37yjZOQhndlTR8G/V3opIaPo8tXr2Lv/qFFO0JMB6RX0VqEeXNQ/vOPi2M/QVMF8uTFpzBDDviTkHacfP36GPEx44PAxyM8Mi8F5/8ETyDuCRSagEJw89P0MdpqA8vLQp06fE/TtvoP/YfKMBZAHBeU4adG4jmrMv2P13x178b8KpSBvC5g2e5GSXaOdT2VLFgn0r3tt3rYb2bNmgjzgKu/JVY2FYvT+wwcsXLYuFHtkVyQQbgmYreI0eM12aqhYWBF4pXl1z124CqdBPbFu8w6DGvJe4WZt7ZS3Rbx78l5XQ6FXYubcJcpzWqZqQ8xesFzlitfv/sPHqN24g/pRA5XpFRUrnF+9cF9ev1SqeGH1GjEp2r77IGpWrwh5wj5ntszq9UKXrtyAGJVZMqUTEcjPhsovQ92+e1/tL121AY6DeyJ1quTqjQ3GvzamBLRIfnwiRbKkkCev5UX11SuXw449B7QSqCe4dTod4seNA0tLCz9fPm9hYaF0kArSt6WlJTy8Xt4vT7jrdZPyX4UJU+cqvuL53r3vsPIo9+zvhHLVG6NqnVY4/N9JyN/y1ZvQtE1P1GrYHj69ylIuISC9pDy4g8xNgnhxvTUrb8V49/69eqfvt2/uGkNLiKe3d/c23uT82/HJQ7z5DVp2QaUazSDbB9oxJHW79XVA197DUO0fW5Su0gDCTvJ9BnmndcrkSZE2dQrgh8/SwO8vXbkRnds2hbzFQafTQd6IIq34d6xGjRIF7959wJt37xAtahSIF37JinVo0fgfqeZn8GvMJ06dg6vbQixbtR7N2/XyVk+YCINmbXuqV5d9+vQJQ5zGo3TlBqjwd1P8u2Ofkg/oGPLrnPXZ7rjJs3D12k3IsTpp2nz1Xm+/+pHOxmkXt8Uq1EHdph1x647nuSn5+rB99wF06D5Ivwu5COgzaIR2Hnmo475kpXpKd3l3tEHIKyEXwfK6Oa9dyOfM6zdv1a6c/3LuSJ7LRDeVx4gESOAnAYufSaZIgASEwMZ/d6FGtfKQ14DdufsAT549l2z1pSs/WLBt7Xwc2rkSMWN4/oCGKtSiy1dvYsacJcoLJd5c+WK8ev025JVp8pJ9eQWSvNZKE/X1X26Hz9JuF5cqVlCVPXn6TDNAk6m0RKlSJMPDx95v5R49fhpPnj5HpvRp1BfwC+3Wp/SZNkcpyK1kvd5SXx8eP3mOlMn/1O+qF9Eb3yKW94fKcggxVuTF8gZBo4R4ieUWf7qcpdClfXNkTJ/aqNR3UowNWS5hKPFKdO3QHH9XKa9ePVZG8/otWr4Wz1+8hLyWbNiAbmjf3V4ZjyJ+WzMcFs0ah10bF2PNxm0QrpJvHEzRq37zzt6WKcg4JIghYdyWPr1H80AnTlcAtRu1hyw50Of7tZX3kubNnUPpLb9sduHSVcSOHVMzOH/++p1f9fR5PnkMHTERpYoVxta181C0YH4MGzlJL6q2G5bPxMKZY9FroLMyllSmV/Tt2zeI4dW7W1uvHL83geEhx9/xk+fVcpryfzWBGKLSqn/Hao1qFTVm1yDvqR3YpzNmzl2qGbt11YWA1PMr+DXmfHlyqHpNG9TG3GmjfVWTH6UY0r+b8qyv1jzIbzUje/v6+Vg2dyIcR002/LCEX8eQf+esdGLcbvdOrZAxQ1p1rHZu1xTLtIswv/q5cOkalq7cgH/XzMPE0UNw9NhpacpbEA/3gSPHDb8oJ3eTqv2vnHpP7viRgyCvdpsx0RG97Ud4qxfQjtxlmb1ghbqLtH3dfFy6ch27gmm5UED9sowEwhMBi/CkLHUlgdAgsH7TdtSq/j/VVd1aVaBf1pAvd3ZMnj5PrcMVw1HeZ6qEvKJjJ8/gL82Ak5+6jRc3DuQ9vpLnVRzgZtT4GcqL26xRbYOcTvfzPrRO9zMtAo8eP1XrbOW9pNbW1pKFd+8/IH/e7DhzeDPEczzMeaLK9xmJN1Sfp9N5b3fDcjf1zk5pU9bk6uWMt7L0Qm7zn9i/Xvty3wj5pSnjcp/pUiUKoXvHVj6zfe0fO3EOTRrUVF/8YuSIB/ne/UdKrliRfJBfCROPd8miBXDi9FmVbxyZotfSuZPUcgzR3zjYNvP85TXj9tKlSYlzR/+FvMe0qOaJb9qmh3Gxn2n5uWuZk/q1q2PMZDf07GwL4ShrfvUeaz8r+pEpPyzSrGEtVdKyaR3IL+qpHS0qV7qo4iRGdnzN03z/wWMt9+f/KTMXolXTuorZz1zfqcDw8PDwgLW1Ff7buxYOA7vD+CJGp/t5HOl0nmk5PyaOHqx+yCNp4kSQC7SSxQsor/dQ5wm4d/+hL4UCGrMvYa+MnNkzQ94dK7uHj56E/HT0P007oWWHPnj+8hWuaJ5ZKfPrGJLz079z1rhdqW8c/OtH+q5RrYL6oY8kiROiko/31kobcldEfvRi+66DatnLidPnULxIfjWfFy9fQ/tu9ujedzgePX5mMNalXkBB2Iy+X1UAABAASURBVD5//hLiAa/TpKO60Dh99hL4Z/4EqGHoEaDBG3qs2VM4ICDLGXZrXj25LSiev5HjpmP95p1K8xZN/lHe2iSJE0CMn9ua11EVGEVidOl3xTgQz61+37/ttl37cf3mbYhXR2+MJk6UUPN2vjJUeaF9cf+ZJLHaF+9d934OmOwyBIXy51Z50q8sYahcobT6sq1QthguXb2hygqVqQkJ8sCc6P7i5UuVL9HzF6/hc01kwgTxUKFMcRw8ckJEVF19fZXhFaVLkwo5s2XCyVPnvXL83sgL9k1d6mBlaWloxNrKWrsT/0Pt++T4wzNblfmMAtIrMB7NGNGjq/XIcvEiL+n/+s0dL16+9tmdn/vitStRpABkKYs8JDikXzf0H+rip6x/mTJmKytPHlFsbLyJ+Ry/yBoL7NxzEE1a91De7AmucyHLIKbNWmwsotKB4ZE4UQLIz8HKBV2Rgnnh/v073rx9h8QBHKuqEy1ymTgDPbvYYuHStUikHV+1a1T25bHWxNQyGv/GLOV+BWM2wmFg706QuykS5GJFf45ImXF9PUM5d/T5xuescbv6cv1W2vKrH8m3sPCcM5E1blv29aF6lXLa58oOqHXOmlGs0+lw6swFzFu0Cj20iyRZ15/8zyT48OGjvoraWllaefPmf3f/rvKlX1lmI2OWID/k0UPzSqtCRiRAAooADV6FgREJeBIQb27LJnVg7P17/OQp5OEj+XJPmeJPNKr7N+SBNrkd6lnLMy6QN5f2JbZTGQGyvnf95h0omC+3Z6E/8aGjJ+Cm3eqdOnYYjL8cxeDcvG0P3N3dIcsq5Fa/GI3y5oQOPQapW7yy5MK4WTF29W9tOKR5urJnyaiKj+5eAwlitOXOmRXycNUjzUMsayr/3b4XFcuWUHInTp1TWzGo/925FzmyZVb7UldCz86tIGsbpa4UyBj3HToG8YTJvn9BllZcuuJpfBvLRNcMyreaV1qfVyBfDixctlYZPfLl/+z5z+UXW3fsV8amrFfctHUX8ufJqa+mtqbqFRiP5tt371XbEh07cQayDjV+vDiyG2AQfvMXr0JL7QLpu2YUygVElCg2iBkjOuTv/KWrWLdphyS9BV888uZU3mERmjV/ueHiRvaXrd6gDJ/TZy9Cjo3kyZJItiGIp15/DHdt3xzjR9ijXauGhnJ9IjA8KpUriYPa8SrG1ZVrtxBVG5MYv/4dq/o+bty6g/fvPyJX9iz4/t0DCeLH04ze+Jr+vq9aCgQwZn17AW2LF82v3YWZD/2DnPJ2EznOpY5fx1ABE8/ZmDFi4K1m3Es7EvzrJ692F0jOaZGRJTb6tOwbB/Hw7j14VK3frV65vCq6fvOO9rmSBRnSpcKtO/dw8cp1lW8cpUz5J+56ecblc+HqjVuquEjBPFi1fqt24XxH7cvnlV8X5KqQEQlEUgI0eCPpxHPYfhOQh9SqVirrrbBqpTJYu3G7WiuZIXcZzbvbE2LElCtdxJtc5oxpNSOnDuTVSfKAWtuWDZExfWpvMj53HEZOxrZdB5AwTX7ljZOHYkRGjNta1SuhYo1maNdtICaOGizZ2H/4GFas2Yx6zTopefFCiwdRCgf27oiVazerh5x27D6IQX27SLa3YKl5UMc6D0Szdnb4X63maN6oNpInS6pkHEZNVm2KLje0L99WTX0/XPT5yxf8Vc9Wycla4aKF8kKWH0gDDiMnqnwxFEWvvoNHSrZ6E8O4KbNU2jiS27gfP35SD/fIg1eN6tbAH7FjQ9aHDnQYiwnamEVfqZND8yTXadIBlWu1gKzl9Mk1IL2kflDC4uXr1XiSZSyCMZPcMHeai6EZ0UPuAuzZf0TJGBuwspayacPa2u1/a2XkXb9xG1Vqt4Q8lCgNHD12CucuXJKkt1Bcu61tzGOwNn87NE9tJe0Y2HPgCOz7dDLIJ4wfH2WrNkK3vg5wcewf4LpYQ6XfTNT6q5Iy+uXBKLsBjpg+0Um16N+xqgq1SO6S9OvZXktBPYjpMmkm6jTuAP1yDVXgFQU0Zi+RADeylKRQ/lyQtejygKP98HEGeb+OIVPP2ZjaxUq1/5VBI9tukHXy/vUjF5nyM8wyvqZteyKGVs+ggFFCjmu50JTX1RUrnE+VyPKHPQf+g3wGTHSdB7k4VQVGkdw1kHXCIjNp+nyk1+6ySLHc1RB2HbWL4bLVGqk2Pn3+LEURK3A0JPAbBGjw/gY8Vo14BOR2YKnihbwNbNjAHujUtilkbea107sxf8YYOA3upQwab4LaTuvmDbBr4yLs3rRYM37rajme/88c2uyZ8BFv8XrFl94bJ/3rRdrbNlJtiYzeqCxfuhj0svptiaIFVBW59b5s3mT1kNO86S6aJy2uyvcZyW3pbWvnq7abe71aSmSkb32b4iGUW/qSbxzki/XY3vUGHYSDvty+TxdDvrQzYmgfVVS3VlXFTu0YRWJETJ/giOXzp0AeWhMv6Bin/ti5YSE2rZwFuW2uFxevlzCVW7UyF/p8/TYgvfQygd2KR1TG8eDqYSydOwli2OnbkDmRMn2Q9dr6MrnQqV65nNrV6XRqfJtXzYaddktfMk+fveTt2JA8CT55pEj+J5bMnqjmU7byhg6RkyC3xOX1cXs2L1HsJM+/MHRAdxjPs39yv8q3sLBQx70c33J8yFtC9HX8Olb1ZXLe6JfNyLIb0VkezJLjUC+j3/o3ZpkLv+ZdmMhc6OvrdDr069lBnX+HdqyClNnYWKti/46h1n6csz7blQbk+F7kNh7y0JpO538/3Tu2hPzwy+JZE9SxbHxsSDv6MGHUIFw9tUut3ZU8eZ2fHPtyHkqZPLwpeiSIHxdyvoqMtbU15KE0kZHX5B3YvgJx/ogtRdrFRCV1rMj8HN+3Xjte06t8RiRAAp4EaPB6cmAcMQhwFCRg9gTkPbZ6A9DslaWCJEACJBBBCNDgjSATyWGQQEQlIB5i8a5F1PEFdlyyHlc8/YGtF5nlI+cxFJlnnGMnAd8EaPD6ZsIcEiABEiABEiABEiCBCESABm8EmszADoXyJEACJEACJEACJBAZCNDgjQyzzDGSAAmQAAkERIBlJEACEZwADd4IPsEcHgmQAAmQAAmQAAlEdgI0eE09AihHAiRAAiRAAiRAAiQQLgnQ4A2X00alSYAESCDsCLBnEiABEghvBGjwhrcZo74kQAIkQAIkQAIkQAKBIhBCBm+gdKAwCZAACZAACZAACZAACYQYARq8IYaWDZMACZAAAEIgARIgARIIcwI0eMN8CqgACZAACZAACZAACUR8AmE5Qhq8YUmffZMACZAACZAACZAACYQ4ARq8IY6YHZAACZhOgJIkQAIkQAIkEPwEaPAGP1O2SAIkQAIkQAIkQAK/R4C1g5UADd5gxcnGSIAESIAESIAESIAEzI0ADV5zmxHqQwKmE6AkCZAACZAACZCACQRo8JoAiSIkQAIkQAIkQALmTIC6kUDABGjwBsyHpSRAAiRAAiRAAiRAAuGcAA3ecD6BVN90ApQkARIgARIgARKInARo8EbOeeeoSYAESIAEIi8BjpwEIh0BGryRbso5YBIgARIgARIgARKIXARo8Eau+TZ9tKEguWjRYixZshTW1jYMZsTg69evnA8zmg85PwAdfvwA58XM5uXr12+wsrLmvJjRvOh0cq784JyEwZzAzP8szFw/qkcCJEACJEACYUqAnZMACYR/AjR4w/8ccgQkQAIkQAIkQAIkQAIBEKDBGwAc04soGVQC+aIsx4Vl1RjMiMHtjfU5H2Y0H3J+XF1dE9fW1OK8mNm83N5YDxeXV+e8mNG8XFlVUztXapv1nLy4uj6oX5ms9xsEaPD+BjxWJQESIAES8EGAuyRAAiRghgRo8JrhpFAlEiABEiABEiABEiCB4CMQFgZv8GnPlkiABEiABEiABEiABEjgFwRo8P4CEItJgARIIOQIsGUSIAESIIHQIECDNzQosw8SIAESIAESIAESIAH/CYRwCQ3eEAbM5kmABEiABEiABEiABMKWAA3esOXP3kmABEwnQEkSIAESIAESCBIBGrxBwmaelRq37YcBwyf+lnJv371HvVZ2gWqjTfehOHvhaqDqUJgESIAESIAESADYsecwOvdxQvEqTdCoTW8sWPbzPb3+l/kmd//hE7TuNhhN2/dT24ePnyqhj58+o++wcbDtMggOo6fB/ft3lf/q9Vu07DwQ7u7uaj+iRxYRfYCRZXy37jzA129fcfLMJcjBHVnGzXGSAAmQAAmQQHgmEC/uH3Ac2AX7Ns5Dn662mDFvJS5dvamGFFCZEjCKBgyfgHIlC2O+q7O2LYRBTpNV6YEjJxH3j9hwmzgMHz5+xJnzV1T+mClz0aVNY1hZWan9iB7R4I0gM7xt9yFULl8SBfPlwN6Dxw2jch7nhqGjpqFTbyflud2uXUlK4dZdB9Gt/yiV38C2Fya7LZFsX0HkmrTvj8bt+mGc63x89/DwJWOcUbdlT0ycsQjtejiga7+RePb8pSp++eoNBjhOUu1UrN3Wm45KgFGwE2CDJEACJEAC5k8gb66siB0rJiwsLJAzW0akSpEUDx55emcDKjMe2aMnz3D95l3UrFZOZdesVh7nL1/H85evYWNjjXfvP+DHjx94/+EjokaxwX8nzyGKjQ1y58is5CNDRIM3gszyjr1HNIO3GP5Xrhi27znkbVRfv33DxBF9MX3cYEydvUwd8CLw4NETjBzSHQumOePajbs4euKcZBvCnXuPMHfJekxw6oP5Ux3x5as7Nvy7x1DuXyJNqmSYNtYedWtWwsIVG5XYpJlL1BXmQq2v1fPHIVvmdCqfEQmQAAmQAAmEMAGzav7HDw94eHz3M4g39u79R8ibM5Ov8oDKHmrf54kSxoO1laWqJ9skieLjwcNHKFE4j2ZQx0C/YeOVQZ0uTXJMnrkYnds0ULL+6RLYfLOC7IcyNHj9gBLesi5cvoH4ceMgSaIEKJw/J67dvIc3b98bhlGsUG515RgndixkSJtSXQVKYa7smRAjejR1O0Pqnb90XbIN4cz5y9rtj0/oP3wiOvRyVLdBLl72vM1iEPIjUbxQXpUrJ9vtu49U+uSZi7BtUlOlY8aIjgTx44J/JEACJEACJBDZCLi7f8fXr199hXMXrmD4mGlwHtQV0aNF9VYeUJm05e61DlfS+iBcv31zxzfN6dWlTUMM6dMOTetVx7TZy1FPc0jJHViXyXMxdso83Lx9z1t/+jYCs5X+zDnQ4DXn2TFRN1nOcEY7UYpUaoyi/2uC5y9eYee+Iz9ra7cxfu5A3daQfR/ZhnwpU0GnQ4kieTFtjL0KS2aORP8etqoooMjS0vOw0sEC370Wx0P7M+t1Qpp+/E8CJEACJEACIU3A2toaUaNG8xZevn6HkRPnYtKIAShWKJ/JZfp2UqZIhtdv3iFKlKiqro1NFLx4+QZpUqdQ+3q5R09e4NbdB6hasTRGTpijbUuhQpliGD18o6cuAAAQAElEQVRprjc5vXxgtiHN7Xfb97RMfrcV1g8zAj80q3X7nsOQZQKHty6EhLHDe2HH3qMGnTZu2w95KvP2vUc4d+Ea0mteXik8fOy0WmP76fNnbN6xHzmyppdsQ8ifOyv2HDiGG7fuqTx5ovOGdhWodgIZ5cmZBXMWrTHUknVEhh0mSIAESIAEzIYAFQldAvK92nvIWDjZd0WGdKm8dR5QmTwbo78zmzRxQvyZJCF27vV0du3QtpnSp1Z3f40bHDHeDX27eTquPH54IHHC+EiYIC5+GAtF0DQN3nA+sSfOXEQi7YCVg10/FHlwTYxUWawueXJAN23fH32HjkWPjk0RK2YMyUbGdKnRw94FzTsORKF8ObSQU+Xroz+TJELPjs3gOHYm5MG1ph0G4PXrt/riQG1lrdDjpy9UO2X/tsXRE2fBPxIgARIgARKI7AQmzViEy1dvok7z7shftq4KqzZsV1gCKjt++oJaAqEEtWjkkJ5YunoLmrTrixXrtmJY/05a7s//K9dvQ5GCuaG3F5o3qIG2PYaqV6I1q//3T8EImqLBG84nNn/ubJg72cHbKCwtLLB15TQkiBdH5cuyhMUzRmKp22hUKF1E5UmUIlkSLHB1wrJZLuhk20CyIE+Kyr7a0aKyJQpi9qRhSm7D4knIp/UHaAVG/2eMG6wWwkvW8tljVBuSTps6GSaP6i9JdZUpr12R/natc4O8OkUVMCIBEiABEiCBSExgvFNfHN+13FuoXb2CIhJQWcUyRbXvdRclJ1HyPxOrV48tmDYCM8cP1Ty+iSTbEOr8VRFi5OozShbNj1XzxqtQrFAefXaE3dLgjbBTy4GRAAmQAAmEOAF2QAIkEC4I0OANF9MUdCX7dbeFeGl9tlCpbDH07NjUZzb3SYAESIAESIAESCDCEbCIcCMyvwFRIxIgARIgARIgARIggTAkQIM3DOGzaxIgARKIXAQ4WhIgARIIGwI0eMOGO3slARIgARIgARIgARIIJQJmZ/CG0rjZDQmQAAmQAAmQAAmQQCQhQIM3kkw0h0kCJBDuCFBhEiABEiCBYCJAgzeYQLKZoBF46J4VCbM1YDAjBnEy1uZ8mNF8yPkRP0s9xMtcl/NiZvMSJ2MdzomZzUl4OFeix88UtC/MSF3r9wdPg/f3GbKF3yDw6Ht2JMreiMGMGMTJ+A/nw4zmQ86P+FnqQ4KkGczn80LOlYTZGvJ8MaPzJUHW+tq5Us+s5yQaDd7fsBqCXpUGb9DZsSYJkIAZEaAqJEACJEACJOAfARq8/pFhPgmQAAmQAAmQAAmEPwLU2A8CNHj9gMIsEiABEiABEiABEiCBiEOABm/EmUuOhARMJ0BJEiABEiABEohEBGjwRqLJNsehJrU8j6fnFzGYEYPXV1dwPsxoPuT8eHFpKSRImsF8Pi/kXHl2YXG4Pl+eX1phjl8NoaoTO4scBGjwRo55NttR/ml1Ec8uLGEwIwavr67ifJjRfMj58eLSMry8vJzzYmbz8vrqyvA/J5dWmu33AxUjgeAkQIM3OGmyrQhKgMMiARIgARIgARIIzwRo8Ibn2aPuJEACJEACJBCaBNgXCYRTAjR4w+nEUW0SIAESIAESIAESIAHTCNDgNY0TpUwnQEkSIAESIAESIAESMCsCNHjNajqoDAmQAAmQQMQhwJGQAAmYCwEavOYyE9SDBEiABEiABEiABEggRAhEaIN31/7/UKRSY9y9/zhE4Emj0ofzODdJBin8qtKR42fUGGQc+rB118FfVQuT8tdv3mLISFc0btsPHXs5YsDwibh150GY6MJOSYAESIAEgkbAbcEq1GraFfnL1sWZ81cMjTx/8UrlSb4+FCpfH5+/fDXI+Ey8//AR/6vTBu16DDUU7dh7BLZdBqm8I8fPGvJdZy/Flh37DftMkEBwEojQBu9O7aTKmC4V/t0ZcidQnhyZ0aB2leCcE19tFcybA4e3LjSESmWL+ZIxhwy7QWPxR+yYWDjdGVNGD0CPjk3xSjOCzUE36kACJGD2BKigmRBIlSIpRg3piWRJE3nTKEH8uDi+a7khdGnTGCWK5EPUKDbe5Ix3Rox3Q+6cWQCdDvq/6XOXw2V4L/Tp2gpzFq1W2bfu3Me5i9dQuXwJtc+IBIKbQIQ1eL98/YoTZy7CcWBnbNt92MBNvKM97Ueja7+RqNm0GxYu34TFq7agVZfB6KB5Jd++e69kX7x6DfFQNm7XD7ZdB+PC5RsqX+p36z8KnXo7oe+w8Th17jKWrNqsyl6+eoMBjpMgdSrWbou9B4+r/LY9hqFB697K86nPk4K6LXti4oxF2lWug9Ln2fOXkm1SuHT1pmrP/ft3fP32Df+06Ikbt+9BrsDrtbJTujVtP0Bt9WOS/sa5zkenPs7YfeAYpI12PR3QpH1/2Nm7QMYsnc9euAbt7Ybj70ZdMGbKfMlS8sKsQes+aNimj8ozjs5euIonz16gc+sGhuz4ceMgr3zQaTmrN+xA8072is3M+Su1HP4nARIgARIwRwIVShdF+rQpf6namk07UKNqOX/l9h8+ocpKFc0P/Pih0hLZWFvh/fsPePf+I2xsPI3lkRNno3+P1lLMQAIhQiB8GbyBQLBz31EUK5gHyf9Mgjh/xMbFK54GqzTx+MkLZQjPmTQMi1Zs1K5OrTFr4lDNOMuMNRt3iQgmzViC3Jr3duE0Z9jbtdNu1U9V+RI9ePQEI4d0x4hB3WTXECbNXIK4Wl9SZ/X8cciWOZ0q69OlFZbMHIVxjr0w2W0JPn3+rPIlSpMqGaaNtUfdmpWwUNNF8nyG/06e87as4cq1W8iSMS3KlSqMOYvXYvqc5ahQujDSpU6hqsoSjtZNamO+qyPSpUmhGfSeBrkUpkiWBJNH9kPJovkwdJQrurZthAWuTqhQpggmTFuEx0+e4+B/p+HqMhDrFk1Ek3rVpBoma2MbMbirNo6RmODUR+UZR3fvP0K2TGlhZWVlnK3SN28/wKxFazDWwQ4zxw+GLAM5fOyMKmNEAiRAAiQQ/gic1pw9Hz9+RrFCefxUXpYyTNG+7/p2s/VVPtCuHcZNnY/Zmne3V+cWWLtpJwrkya6+r30JM4MEgomARTC1Y3bNbN99BJXKFVV6VSpbVPPyHlJpiXJky4iYMaIrQzh+/DjqRJP8LJnS4fa9h5KEnMzb9xyGeECdtVsyz1++ht4DmzdXVsSIHk3JGUcnNY+ybZOaKkval9s/snP73gPNuJwGe+cp2hXtBzx4+FSyVSheKK/aJkkUH7fvPlJpn5HPJQ2ZMqRRIs0b/IUjx87iyPFzaNnIs18pSP5nYmXoSlqurM9f+mnsly5eULLx6PFTzSP7EhOmax5mzcu7SvPAXr52E/HjxcGXL18xZdYSLF+7FbFjxVTyObJmgMukeZi3ZD08jK7UVaE+Mrplpc+S7ZkLl1G6eAHEi/sHokWNiioVSkI8wlLGQAIkEDQCrEUCwUXg8+dP8Cv80D7rv3794mfZyvVbUbViSe374rOf5cNdpqFT6/qwstTh27ev8PDwMMilSZlUOZ1GDOoKS0tg/ZbdqFezona3dBOGu7hixdotBlm/9Aoo78uXL/BP54DqsczvYyAwXILreAypdixCquGwbPfN2/cQr6jcgpcHvcZqV5KyrEFOXtHL2sgLaWlhAWvt9gq0P0sLHdzd3bWU5/9RQ3tg2hh7FXavm4WECeKpAhtra7X1K/Lp4ZRlA0tWbUGTutXVutb0aVLi46fPhqqWlp5ToIMFvn//jsD8PX76HOJtdv/uDmMjVD9OQ1vah5Y+beM1VkCHpIkTqLHJGGeMG4zls8coFnOnDkfRArlx/eY9DHaeDPkb0qc96tX6H35o/2Q5x2fNKJZ8fUiZPKnmRb8Jd3/GYG2lfap5CVtpn3DSjtcuNyRAAiRAAmFIwNraRvvs9x10Op1mkFr5Kvvm7oE9B4+jbo1Kvsr0be09dByy/K94lWYYNno6Tp69hDrNe/qSnzxzKTq3aYRzF6/jkHZ3sU9XW+w+cBxntX19W4HZynewpaW1r34C0wZlfR8LpjBB2P2Z1LOntWWSaPgRkofVxKtr/KDXn0kSQTywpo6iQN7smDZnBfTG4/HTF35ZNU/OLJizaI1BTm7p3NE8xhnTp0La1MnwVjPELxgtrTAIBjExeMRUtGlaB8UL58UUt6WGVh48eqp5fT2XDKxctx3ZsngurTAIaIk/kySEGPdbvd748O2bu/K6KmNcM5BlLG1b1MF5r7XL795/QMZ0qdC8wd/aFbsFHj99obXy839OzWueSLsgGDLC1bAWWNYEy4dcrmyZsffQCcgaZ1nOsXnHfsjDfj9rM0UCJEACJBBWBCw1J4RfQfTxK3/rzoPImTUjkiROCONycfC8ffdB5R3eutjwcJtD/87InzsbNi6dqsr0dY6duoBYMWNAvm90Oh0SJ4yvGarWkLujFtq+Xi7wWwtv/QS+viXr+3NMBMRSjhdzDhbmrFxQddu+9wjKeN2617dRtmQhbNtzRL/7y21H2/rabZGvaNKuP6o37Iw1G3f+sk7nNg2UISgPgZX92xZHT5xVxuiFS9fRtscwjHNdgKwZ0yKwf+KtFk+1PixbsxVrNu3UPiiio1b18mjfsh6Oax8c+tfHpEyeBEtXb0UD2154+/49GtWp6qtLC82z7TiwCzZvP4BmHQbgL22MYtw+1rzGZf5qBRnD2CnzYdepuarbsE1f1GzSDfIgX4XSRZE6RVKVbxy5DOsBK82Ta9tlCOShN6kva5rTasZ+k3+qoYe9C1p3G4qSRfKiUL6cxlWZJoGQJcDWSYAETCbQ32G8ev2YOE9adbFHwfL1vdVdu2UX/q5S1lue7MhzISfPXpTkL4PcJZw2Zxm6tG2sZGXpniwptO06CE+fv0Q+zUBWBYxIIJgIREiDVx64KqEZVcaMGtaujH7dWqFS2WLo2bGpoWjeVEckSZRA7RfOnwsO/TupdJzYsTCoVzv1iq0NiydBjEMp8Fm/bImC6Nfdc1G+vJVA5OQhsF3r3FCuZGG1VnjulOGYPnYQhvXrqJY1iDdU2lo+e4xhjawYhZNH9Zdsb0F0MvZUS7pezUqoWbUcxjj0UrKyRGDRjBHIlT2T2re2ssZ4p95Y4jYa8mCdfh2ucX8imCFtKkxw7gNhsGWFK4RR2lTJsX/zPMgYZCxlihcQUQiDNQvGKw4tG/9cL6wKvSJ5OFCWPoiczIHUT5MqmSoVw3zuZAfIA32tNa+0ymREAiRAAiRgdgSc7LsZvLPyGrL/dvy8gyjKLpw2Qn2XSto4rJgzVn3vGedJWl41Nm3sYEkagrzKbO4UR/UdKZnihHGbMAwSpo0ZBJ3u52vMpJwh+AhE1pYsIuvAOW4SIAESIAESIAESIIHIQYAGbwSbZ1n7tHC6cwQbFYcTugTYGwmQAAmQAAlELAI0eCPWfHI0JEACJEACJEACwUWA7UQYAjR4I8xUciAku2tWKgAAEABJREFUQAIkQAIkQAIkQAJ+EaDB6xcV5pGA6QQoSQIkQAIkQAIkYOYEaPCa+QRRPRIgARIgARIIHwSoJQmYLwEavOY7N9SMBEiABEiABEiABEggGAjQ4A0GiGzCdAKUJAESIAESIAESIIHQJkCDN7SJsz9vBE58qYts9TYymBGD1NWWcj7MaD7k/MhYaw0y1FzNeTGzeUldbRmy1t0Q1Hkxi3pZai3z9pnMHRKIqARo8EbUmeW4SIAESIAESIAESIAEFAEavAqDmUZUiwRIgARIgARIgARI4LcJ0OD9bYRsgARIgARIIKQJsH0SIAES+B0CNHh/hx7rkgAJkAAJkAAJkAAJmD2BCGTwmj1rKkgCJEACJEACJEACJBAGBGjwhgF0dvmTQL4oy3FhWTUGM2Jwe2N9zocZzYecH1dX18S1NbVMn5dg1v/mDrufJy1TJEACJBAOCdDgDYeTRpVJgARIgARIgARIgAR+TUAvQYNXT4JbEiABEiABEiABEiCBCEmABm+EnFYOigRIwHQClCQBEiABEojoBGjwRvQZ5vhIgARIgARIgARIwBQCEViGBm8EnlwOjQRIgARIgARIgARIAKDBy6OABEggMAQoSwIkQAIkQALhjgAN3nA3ZVSYBEiABEiABEgg7AlQg/BEgAZvGM3W9Zt30bmPM1p0skd7u+FwmTwP7z98DDFtAtvfrv3/wXn8rEDp8/rNWwwZ6YrGbfuhYy9HDBg+EbfuPAhUGxQmARIwfwLfvrmj37DxqFi7NYpUauhN4YDKvAl67SxasRE1m3RB/rJ1VXtSX4qmzlqKVl3s0bWfMx49eSZZKrTvOQz3Hz5WaUYkQAIkYCoBGrymkgpGuVev36JdTwfUrFYOcyY7wNVlIKpWLIHXb94FYy8/mwqt/uwGjcUfsWNi4XRnTBk9AD06NsUrzQj+qUnkS3HEJBBRCRQvnBdjh/fxc3gBlRlX2Lx9H+YvXQ+7Ti1wZPsSzBg3BJaWFpDPrL0Hj2HWRAdIW+u37FbV1m7ehXy5siL5n0nUPiMSIAESMJUADV5TSQWj3NrNu1EoXw6ULVHQ0GqWjGm1D/HEEO/GqIlz0KR9f+X9FU+rXmjb7kMqr0Hr3prnY7DKlvKq9TtC8gY5T/HTSxzU/lQHWmRKH2cvXMWTZy/QuXUDrYbn//hx4yBvziwBjslTkjEJkEB4ImBtbaVdpJdEgvhxfKkdUJlP4aWrt6B10zooVigPrCwtkTplMlhYWCij1/37d3z99g3v3n9AlCg2ygheu2kHmjeq6bMZ7ocPAtSSBMKUAA3eMMB/78Ej5MyWyc+e1/+7G3cfPMbcKcMxuHd7jBg/C2/evsede48wznUhHPp3wpKZo2Dfq52qnzFdKqyePw6LZ4xEyuRJsET7AlEFRlFQ+jOqDlP6uHv/EbJlSgsrKyvjqirt35hUISMSIIFwQcDD4zv8CqK8X/mSF1CZlN9/+AQXrlxHhVq2qFa/A2YvXKX6iBkjGprUq4ZBTpMhy7Hq1qgEl8lz0KVtI1jooGSkfliHHz88zEaXsGbB/v0+PyITFznfzTnQ4A2j2dFpH9p+dX363BXUrFIWlhYWmrfjT2TPkg5Xrt/CmfOXUaZ4AeUFlnqpUySVDWxsrNUtwW79R+HAkVO4cfOuyvcZBbY/4/qm9gF/OvFvTMZ9qDQjEiABsyTg4eGBr1+/+grfNA+sKBzYMr28tOv+zR0LpjlhnGMvbN9zBNt3H1b9/K9sMQzp0w6DerXF8VPnEDWKNVImS4IpbkswauIsHD52Wsnp2wqL7XfxQvvBJSx0YZ+ex6fcJXV3dw/zYyMyzod8FphzoMEbBrOTIllSnLt4zd+erbTbhfpC8Zj++AH80CJra0t9tmE7csIsJE2cUPP8dkRXzfvx6fNXQ5k+EZT+9HVla0ofKZMnxcUrNyG3IaWOz+DXmHzKcJ8ESMA8Ccgyg6hRo8FniBIlqlLYZ77sB1Qm5RISJYyHUsUKIEmiRMiQLg3y5MyC67fveetHZ2GJ2YvWoXuH5li+djtix46FTq0bY/iYmbCytvEmK22GZrCysg6x/kNzHBGpryhRomiOoCicFz/O15CeZ/VhYMaRhRnrFmFVq1GljOadOKN5ZjdA1qjJQC9dvQm5vZc7RyZs2LIb3zWPyu27D3Hh8g1kyZgGuXNkwe4Dx5WMyH/4+Ek2uPfgMYoXyYvYsWLiwNFTKs9nFJT+jNswpY+c2TIiUYJ4GDLCFS9evVbVZXvy7CVNd7/HpIQYkQAJRCoC2/ccMoy3UtniOHL8jPq8k7fUnD53GdkypTOUS2LG3BVoWKcqYsaIDo8fHupzRtJRo9jgh4fmDRAhBhIgARL4BQEavL8AFBLFcePExrQx9jh26jwatu6DTr2dsGnbfsT5Ixb++l8ZJEoYH807DsTQUa6w69RcGbOpUiRFx1b10N9honpAzbbrEKVa8wZ/o1XnwZAlDXIbR2X6iILSn3ETpvQh8i7DesDKyhK2XYaoV62NnTIfcf+IDf/GJHUYSIAEwieB//3TVq27lVvI8kqxdj2GGgbiX9nrN2/V68zkQTQRblrvL+gsLNDA1g5tug3BX5VLo3Txnw/zXr91Fzdu3UPFMkVFHLWrV8CshavRqE1vlWdtbaXyGZEACZDArwjQ4P0VoRAqT582JSaN7IeVc8di8qj+mmHbTHkw5AO8d5cWWODqpF5ZVqZ4AYMGlcoWw3xXR/XQ2pKZI1V+lQolsWreWIx36o3u7ZtigrPfrwkKbH/yBol+3VoFqo84mnE7pE97rFkwXr1qzXFgF6RJlQwBjUl1wIgESCDcEfh3xXQc37XcEKaNHWwYg39l8hkhdWLFjKFk5bNhQI82WD57LBbPHIX6taqofH2UPk1KjHfuq99Vy7dWzh2HRTNGoX3L+oZ8MEUCJEACvyBAg/cXgFhMAiRAAiRAAiRAAiQQvglEFoM3fM8StScBEiABEiABEiABEggyARq8QUbHiiRAAiQQHglQZxIgARKIfARo8Ea+OeeISYAESIAESIAESCBSEfDT4I1UBDhYEiABEiABEiABEiCBCE2ABm+Enl4OjgRI4DcJsDoJkAAJkEAEIECDNwJMIodAAiRAAiRAAiRAAiFLIHy3ToM3fM9fuNf+oXtWJMzWgMGMGMTJWJvzYUbzIedH/Cz1EC9z3TCbl7hpK4b7zxoOgARIIHIToMEbuec/zEf/6Ht2JMreiMGMGMTJ+E+Q54NzGTLHcvws9SEhrPjS4A3zj0oqQAIk8JsEaPD+JkBWJwESIAESIAESIAEfBLhrZgRo8JrZhFAdEiABEiABEiABEiCB4CVAgzd4ebI1EjCdACVJgARIgARIgARChQAN3lDBzE5IgARIgARIgAT8I8B8EghpAjR4Q5ow2w+QwMZt++E4ejKDGTEYPWEG5yMU5+PO3QcBniMsJAESIAES+H0CNHh/nyFb+A0Cm7YfgJPLFBMCZUKL0+gJMzkfoXhM3rlHg/c3PkJYlQRIgARMIkCD1yRMFCIBEiABEiABMyFANUiABAJNgAZvoJGxAgmQAAmQAAmQAAmQQHgiQIM3PM2W6bpSkgRIgARIgARIgARIwIsADV4vENyQAAmQAAlERAIcEwmQAAkANHh5FJAACZAACZAACZAACURoAjR4AUToGebgSIAESIAESIAESCCSE4jUBu+R42dQoVYbtOvpgMbt+mHwiKl4/uJVkA4Jqde4bT+T6u7a/x+KVGqMu/cfmyQfFCHpw3mcW1Cq+qqzc+9RtOhkD9uuQ9DebjgWr9zsS4YZJEACwUPg3oPH6NzHCfVt7dCgdS+cu3jVz4bfvnuP/GXregvnL11Xstdv3UXHXsO1c3YQlqzarPIk+u/kOTiMniZJ/wLzSYAESCBCEojUBq/MaNZM6TBtjD3mThkOa2srLF+7VbJDNOzcewQZ06XCvzv3h1g/eXJkRoPaVX67fbkoGDN1Hgb36QC3CUPg6jIQiRLG++122QAJkIDfBOzsR6NimaJY6uYCh/6d0WfIWHz99s1P4RjRo+H4ruWGkD1LeiW3Qvscq1mtPGaOH4qFyzfgu4eHamPqrCXo1r6JkmFEAiRAApGJQOAN3ghKx0Kng06nQ7y4cdQIxUNatX5HzcPSG4Ocp+D9h48qf+uug7Czd0GXviM078lgLFvj20C+c++R8hhfvXFH1TGOvnz9ihNnLsJxYGds233YUCTt9tS+6Lr2G4maTbtpX1KbsHjVFrTqMhgdejlCvDki/OLVawwYPlG1b9t1MC5cviHZkPrd+o9Cp95O6DtsPE6du2zw7Lx89QYDHCepOhVrt8Xeg8dVnbY9hqnxiWdan6cKjKIlq/5Fq8Y1kTpFUkNu+VKFVfrx0+cQnZt3HKh5kxxx49Y9lS+e5WGaF6lTH2fMnL/Sm24NbHthstsSJceIBEjAOwH3799x4/Y9lC5eQBWkT5MS0TWj9ujxs2rf1MjGxlp9Zn34+AlWVpbQaRXd5q9CvZqVEStmDG2P/0mABEggchGI9Aav3OKT5QXFKjdVtw6rVSqpjgDxwK6ePw6LZ4xEyuRJsGT1FpUv0aMnz+Fk30XzeA7Fzn1H8PrtO0AzlqF9q1y7eQf9HMZj+IAuyosLH3879x1FsYJ5kPzPJIjzR2xcvHLDIPH4yQtlCM+ZNAyLVmxE1CjWmDVxKPLmzIw1G3cpuUkzliC35r1dOM0Z9nbtMGTkVJUv0YNHTzBySHeMGNRNdg1h0swliKv1JXVkTNkyp1Nlfbq0wpKZozDOsZcyQj99/qzyjSO5vZorWybjLEN60ozFyJIxHcQ7Xrl8cTiPn2Uo+/L1GyY690HrpnVUnl63BZre127cxdET51Q+IxIIzwSCW3crS0ukTZ0cB4+eUk3fvH0fcu48efZC7fuMPn3+guKVG6Nagw6YNGMRvn1zVyKtmtTGgcMn1PIFu04tcPf+I/VZU7l8CVXOiARIgAQiG4FIb/AWzJsDh7cuxM61bqhQuihcZy9Xx4B4SOYvXQ/xmh44cgo3bt5V+RLlyp4JMWNElyTix/sD92Qt7o8fePb8FXoPGYdRQ3p484gqQa9o++4jqFSuqNqrVLao5uU9pNIS5ciWUbUrhnD8+HFQIE92yUaWTOlw+95DlT6teW637zms1h07j3fD85evtX5fqrK8ubJCbnGqHaPopOZRtm1SU+WI3gnix1Xp2/ceYOioabDXPNjv3n/Ag4dPVb7PSKfTLHmfmdr+2YvXUOfvCloKqFqxJG7ffQB3d88v3FJF88HC4ufhJcxENysrKxTOnxP6tYaqMiMSiMQEvn79gs+fPxnC8P6dsH7LLhSu2BD2ThO1C+eU+KF9vviUk9NLLmC3rpqOnh2aYt/h45g2Z6lqJ6qNlXbR3QlD+7bXPkeywmnsDNh1aor9h49p6emY4rYYL16+VLLGfTP9cx5MYeHu/o0MjY5dU5iFtG4FknYAABAASURBVMyXL1/g81wJ6T7ZvjpvzP5T/KdFYvaqhqyC0aNFhRhp4vGVnkZOmIWkiRPCoX9HdG3bCJ8+f5VsFSw1L4xKaJGFzsLTyNOMwnhx/0CKP5PgyPEzWonv/2/evoe0L8sWxKs8dup8zeA9rL7MRNpaMwZlK8HSwkKtKYb2Z2mh8+xDS8v/UUN7qHXHsvZ497pZSJggnmTDxtpabf2KrIzalvJLV29iyaotaFK3OqaMHgC5dfrxk28Pb4pkSXDWn4dmpB29zjqdDjqdFjS9Jd9nf9r3tWQbgnyBG3aYIIFITMDKylo7120MIV2aVJg0cgAOblmAeVOd8ObtB+0uU1JYWloZZKytbRAtajTtMyqRdicoKkoWLYAm9f5SS5ykzDhs2LoPhfPnQuJECTFi/Gx0at0INjY2WLFuu7f2jOsw/XM+AmJhYWFJhtamsQqIY3CWWWnfdZaW3s+p4Gyfbfk/3+b+MW5h7gqGpn5Hjp9D/LhxVJdyK794kbyIHSsmDnjdXlQFAUSWlhYYPawHtu46jH93HvAlKQ+riVdXPMr68GeSRBAPrC9hfzIK5M2ueXFWGIzk46cv+CP5MztPziyYs2iNIUPWI9/RPMYZ06fSbp8mw1vNEL9gtLTCIKglGtT+H2bMW4XdB45pe57/d+w9ohI5s2bAqg07VHrb7kNInTIZLC38PqQOHzutPNGfPn/G5h37kSNrelWPUSQiwKH6ScBCO2cstYtoffj0+Qsk/er1W81AddOMU2vNS5td5d17+AT3tSDlsj5XthLkobb9h08gt3auy74+yHKrLdr51qxhDUg/UaLYqM809eCpdoGql+PWUvENLAdhGtg6lA8a68BxswjSfAauj9AYR/jqw88PODPKtDAjXcJEFVlD266nA+q1ssPiVZvQuU0DpUfzBn+jVefBakmD/ja9KvhFFEXznMia2AXLNmLvoRPepLdrhmKZ4gW95ZUtWQjb9ngakN4K/NnpaFtfu13zFU3a9Uf1hp2xZuNOfyR/ZsuYHj99gSbt+6Ps37Y4euIsihfOiwuXrkMeXBvnugBZM6aFX3/iGbLr2EwzmNeiQes+6qG4p888l1B0btMQZ85fhjy0tm7zbvTt1tKvJlRexnSp0cPeRckWypcDhfLlVPmMSIAEvBNYuGKjetVYzSZd8ezFK+XtFcNKpJau2ozla/+VJA79d1rJyavJGrbujXRpUhrWzCsBLXKZNBc9OjSDpYUF5LOpVLECaNy2j3pGoFa18poE/5MACYQFAfYZ+gQitcErxtz21TPU8oBls1ywedlUZMvs6XmsUqEkVs0bi/FOvdG9fVNMcO6jZqdS2WLo2bGpSkvkOLALxIOaIF4cyENhkifrZBfNGKGWSMi+PsgrvUpoXmP9vmwb1q6Mft1awWe786Y6IkmiBCKibkc69O+k0nFix8KgXu2wcLozNiyeBOlfCnzWL1uiIPp1t5Ui5bUWuQWuTti1zg3lShZWa4XnThmO6WMHYVi/jmpZQ85sGZW8z6hcqUKY7+qIJTNHYvKo/mhYp4oSEf3GOPSCtCPLItKlTqHypV/pX+14RbI0YoHWv3DuZOt5UeFVxA0JkIARgXbN66rXjO3fPF/73OmHxAnjG0r7drNFr86eF5b/K1dcyclrydYsmAipZ2lhYZCVhPOgbsieJYMkVejatrH22TESy2ePRSKvpVCqgBEJkAAJRHAC3j8dI/hgOTwSCD8EqCkJkAAJkAAJkEBwEaDBG1wk2Y6/BHx6n/0VZAEJkAAJkAAJ+CTAfRIIBgI0eIMBIpsgARIgARIgARIgARIwXwI0eM13bqiZ6QQoSQIkQAIkQAIkQAL+EqDB6y8aFpAACZAACZBAeCNAfUmABPwiQIPXLyrMIwESIAESIAESIAESiDAEaPBGmKk0fSCUJAESIAESIAESIIHIRIAGb2SabY6VBEiABEjAmADTJEACkYQADd5IMtHmOkzX0f3w4cklBjNi8PTmMc5HKM5HyWIFzfX0pF4kQAIkEGEI0OD91VSynARIgARIgARIgARIIFwToMEbrqePypMACZBA6BFgTyRAAiQQXgnQ4A2vM0e9SYAESIAESIAESIAETCIQzAavSX1SiARIgARIgARIgARIgARCjQAN3lBDzY5IgAQiFQEOlgRIgARIwGwI0OA1m6mInIq07+WMGImzMJgRg0RpC4T5fPxV1zZynhAcNQmQAAlEQALmMCQavOYwC9SBBEiABEiABEiABEggxAjQ4A0xtGyYBEjAdAKUJAESIAESIIGQI0CDN+TYsmUSIAESIAESIAESCBwBSocIARq8IYKVjZIACZAACZAACZAACZgLARq85jIT1IMETCdASRIgARIgARIggUAQoMEbCFgUJQESIAESIAESMCcC1IUETCNAg9c0TpQiARIgARIgARIgARIIpwQivMH7+s1bDBnpisZt+6FjL0cMGD4Rt+48wPMXr1SeOc6bfzqbg643bt/D/sMnDars2v8fnMe5GfbNMUGdIgaBJ89eoGs/Z5So0hQFy9fHwuUb/B3YohUbUbNJF+QvWxcVa7fGt2/uSnbqrKVo1cVetfPoyTOVJ1H7nsNw/+FjSTKQAAmQAAlEQAIR3uC1GzQWf8SOiYXTnTFl9AD06NgUrzQj2Jzn0px1louFw8fOGPDlyZEZDWpXMewzQQIhQeC7hwc62DkgUcL4WLNgAg5uWYhSxQr42dXm7fswf+l62HVqgSPbl2DGuCGwtLTAq9dvsffgMcya6IDihfNi/Zbdqv7azbuQL1dWJP8zidpnRAIRmACHRgKRlkCENnjPXrgK8Qp1bt3AMMHx48ZB3pxZ1L77d3cMcJykPL0Oo6dDvlSl4NLVm2jX0wFN2veHnb0LXrx6jfcfPuKvRl3w48cPEcHnL19RuW4HuLu7Kw/nsNHT0KmPM2bOX4lTZy+hdbehaNZhAOydJuPd+w+qjnhCnca6KU+zlImcKjCKfqXz6g070LyTPRq366f6kqrira7Xyg79HSagg+bFfvz0Oeq27IkxU+YrPVp1GYxrN++IKKSsp/1oNO84UOlx49Y9lS+6GY/hzr1H+KdFTzRq0xftejjg5u0HSm72ojWah/cEhM+OvUdw6txlLFm1WZX51/bWXQcVxy59R8C262AsW7NVyTMiAVMJHP7vND5++ow+XVshQfy4sLa2QopkfhuoS1dvQeumdVCsUB5YWVoidcpksLCwUEav+/fv+Prtmzono0SxUUbw2k3aOdWopqmqUI4ESIAESCAcEojQBu/d+4+QLVNaWFlZ+Tk1Dx8/g23jWlgwzQlfvn7D/kMnldE7dJQrurZthAWuTqhQpggmTFuEmDGiI2PalPjv5HnVlniKihbMbWhb6k907oMW2hfnIOcpaN+yLuZNddS+ZC2xYNnPW6/ftS/ciSP7YarLQIyftlC1ZRwFpLMYnbM0g3Osgx1mjh8MWU6g97bevf8Ytk1rY6rmxU6SKIFqMlWKJEpODP7Rk+aqvEkzFiNLxnSYO2U4KpcvDufxs1S+RGoM2hjEWIgbJxZcNR0XzRiBVk1qwmXKXBFBS218JYrkw7Qx9ihfqrDK00cBtf3oyXM42XeB24Sh2LnvCF6/faevxi0J+EHgBzw8vhvC3fsPkVjz7srSg+JVmqBTbwfcunPPUG4se//hE1y4ch0VatmiWv0OmL1wlZKLGSMamtSrhkHaRej1m3dRt0YluEyegy7auW6hg5Ixbofpn/zJwm8WP3548LgxOk95nPh9nEQWLn58kJtVVoQ2eBVpnfZNphK+oz+TJESaVMmg0+mQM1sG3L73AI8eP9W8wi8xYfoi5cVcpXlUL1+7qSqXL10YO/ceVentew6jQulCKi1RqaL5lBfpwcOniBUrhsGLXLdGRZy9cE1EVChSMBcsLSwQI3o0vH7jj9Gn6aOEfURnLlxG6eIFEC/uH4gWNSqqVCiptX1VSaVMngRpUyVXaX0khqmkc+fIjLua8f9D806fvXgNdf6uINmoWrEkbt99oLzUkqEfg6SjRo2CHdpYew8Zi1kL1+DOvYeSHWAIqO1c2TOpiwZpIH68P3BPM9AlzUACfhHw8PiBr1+/GoVvuHr9Nlo3qYV1CyegaME86Kfd0fAu4ynv4eEB92/u6kJ2nGMvbN9zBNt3H1Zt/a9sMQzp0w6DerXF8VPnEDWKNVJqnuIpbkswauIsHD52Wsn51W5Y5smdJAlhqUNk7PtXYxYHxq9kWO55XoYWB1mvz3MldJnr59avz3JzyovQBm/K5Elx8cpNyG1Mv6BbWf70/FpoLh539++amA5JEydQHkzxYs4YNxjLZ4/R8qEZmwXVF+Lbd+9x4fJNFMibQ+VLZOxFtjbyKEv+D/wQERXk1qpKaJGHZoBqG2//f6WztZWlQV5u1+rbtrayNuTrE2Lg6tM66PRJWFt5jlun00Gn04KF52EguuqFlq/ZhnsPH6NH+6bKa/zp0xd9UYBb/9q21G4t6yta6Czg7u75EJE+j1sSMCYg50nUqNGgD7K+NnmyxCiYLxfix4uHapVKQ7y0NjZRDDJ62UQJ46n1vUkSJUKGdGmQJ2cWXL99z5uczsISsxetQ/cOzbF87XbEjh0LnVo3xvAxM2FlbeNNVt9uWG5ttHFKCEsd2Hc0X8eFlfa5Sy6+uYQlkyhRooDnStjMifFnuDmmLcxRqeDSKWe2jEiUIB6GjHBV63ClXVmPe/LsJUn6GcTrK8bY1l0HVblcLZ694OlFjRrFBtmzpsfIiXNQtkRBWFr4xpfsz0R4++4Dzly4ouqvWLcNuXNkUmlTooB0zpUtM/YeOoGXr97g0+fP2LxjP+ShMf/aXbNppyratvsQUmgeYJ1Oh5xZM0C81lIg+bK+0dLC9zjEI5w3RxYk0Yz/w8fOwv27p4EqnuU3msEv9X0GU9v2WY/7JPArAsUK58G79x/VHQmR3Xf4BDKmSw0xjGV/+55DslGhUtniOHL8jFqeJGvvT5+7jGyZ0qkyfTRj7go0rFNV3XXw0G5Ly+eELFuSc/yH5l3Wy3FLAiRAAiQQMQj4tnQixrgMo3AZ1gNWmlfUtssQtLcbjrFT5iPuH7EN5T4T8gXqOLALNm8/oB46+6thZ5y/fMMgJutWd+07ivKlChnyjBPidZXbpZNnLlX1P3/+giZ1qxuL/DLtn85pUydDk3+qoYe9i3oYrWSRvCiUL6e/7b3/8AkNWvdRD4n16txcyXVu0xBnzl+GPLS2bvNu9O3WUuX7jGTZg+ucZeohuJNnL+KP2LGUSN5cmfFDu2Xctd9I7Nh7ROXpI1Pb1stzSwKmEpALLWf7bpAHMxu16Y3t2kXcqKE9VPXXb96i37DxmkHs+XBo03p/QaddxDWwtUObbkPwV+XSKF28oJKV6Pqtu5CHNSuWKSq7qF29AmYtXA1pV/Ksra1UPqNAEqA4CZAACZgxgQhv8MbRjNt9gTDKAAAQAElEQVQhfdpjzYLx6iEsMWbTpEqmnvSWV5Xp56bOXxVh26SW2s2QNhUmOPdRD51tWeGKhrUrq3yJypUsjMNbF6rbpLIvoV93W+XxlbQEuYUqD5XNm+oIh/6dlBdJ8n3KbVg8SbJ9Bf90FsFa1ctj7mQHLJzmrJ5Elzx5at14LJInoW2zOlgycyRmTRwKGZPkyQNtYxx6Ye6U4eo1belSp5Bs+NQtY7pUWDl3rFrO0Ll1Q+h1FcPDyb6r4iPGf1nN0y11pRH/2q5Uthh6dmwqIirIHAgjtcOIBEwkIGvRF88chUUzRmnHXz/Da8TkfDm+azlixYyhWhKDdUCPNlg+eyxEvn6tKipfH6VPkxLjnfvqd5E0cULtWB+n2m3fsr4hnwkSIAESIIGIQ8AiFIfCrkiABEiABEiABEiABEgg1AnQ4A115KHToTxoFztWzNDpjL2QAAkEkgDFSYAESIAEQpMADd7QpM2+SIAESIAESIAESIAEfhIIpRQN3lACzW5IgARIgARIgARIgATChgAN3rDhzl5JgARMJ0BJEiABEiABEvgtAjR4fwsfK5MACZAACZAACZBAaBFgP0ElQIM3qORYjwRIgARIgARIgARIIFwQoMEbLqYp4ipZtUJx9LfryBCMDH6XZ6+urcN8Pur/Uz3iHvQcGQmQAAmQQKgToMEb6sjZoTGBahVLYECvTgxmxKBX1zZhPh8N//kb/CMBEiCB3yTA6iRgIECD14CCCRIgARIgARIgARIggYhIgAZvRJxVjsl0ApQkARIgARIgARKI8ARo8Eb4KeYASYAESIAESODXBChBAhGZAA3eiDy7HBsJkAAJkAAJkAAJkABo8PIgCASB4BfduG0/HEdPZjAjBqMnzAiz+Rg/dXbwH2RskQRIgARIINIToMEb6Q+BsAWwafsBOLlMYTAjBqMnzAyz+Zg4dU7YHpDsnQRMJUA5EiCBcEWABm+4mi4qSwIkQAIkQAIkQAIkEFgCNHgDS8x0eUqSAAmQAAmQAAmQAAmYAQEavGYwCVSBBEiABCI2AY6OBEiABMKWAA3esOXP3kmABEiABEiABEiABEKYgNkYvCE8TjZPAiRAAiRAAiRAAiQQSQnQ4I2kE89hkwAJmC0BKkYCJEACJBDMBCK0wXvxyg206+GAVl0Go3G7fli0YhN+/PgRaIS79v8H53Fuftar3rCzn/mmZC5fuxWfPn/+pejYqfOwdddBX3Ktuw1Fk/b90bzjQHTrPxIPHz/1JWOcYWp/xnUkvXPvUbToZA/brkPQ3m44Fq/cLNkMJBAqBL58/aqdfzPxvzptkL9sXdgNcvGz3537jqhykZFQvEoTg9yOvUdg22WQ9nkwFEeOnzXku85eii079hv2mSABEiABEjAnAsGnS4Q1eJ+/fI2u/UaiRaMamDVxKKaOHoDN2/dj5frtgaaXJ0dmNKhdJdD1flVhzaad+Pz566/EAizv1ak55k4ZjhJF8mLUxIDfYRqU/o4cP4MxmsE9uE8HuE0YAleXgUiUMF6AOrGQBIKTwKgJs3Hl+m1MGNEfx3ctR7sWdf1tvnjhvEpG5A5sXmCQmz53OVyG90Kfrq0wZ9FqlX/rzn2cu3gNlcuXUPuMSIAESIAEIi6BCGvwrt20C4Xz50ShfDnU7MWOFROd2zTAinVb1b54eqfOWorGbfuhRuOumOy2ROVfvnYLHXs5Ks9pxdpt8fzFK5w6dxlLVnl6Ne8/fKK8nLZdB2Ok9kWsKmmRh4eHaqNhmz5o2l6M631aLlT9+ra9MMBxEtp0H4rhY2bguya7ads+PH7yHL0Gj0X3AaOVrOvsZRCPcb1WdnBbsErlmRoVypcTN27dU+LiDRbPr3i1x7nO97c/v+RUA0bRklX/olXjmkidIqkht3ypwir9+Olz9LQfDfEwCzN9/+INHzZ6Gjr1ccbM+SuVd7pb/1Ho1NsJDTQWetaqEUYkEACBDx8/Yd2WXRiiXXBlSp9aSaZPk1Jt9ZEpWxtrK7x//wHv3n+EjY2NqjJy4mz079FapRmRAAmQAAlEbAIR1uAVwzR7lgzeZi9X9kx4+OiZWtawcdteHD99ETMnDMaaBeNRvVJpZRj2d5iIOn9XxAJXJ8yf6ohYsWJ4a0OMtSIFcmnezqFI/mdifPrkuSRho2bAPnv+Snlbp7oMwPJ123H77kNV9+HjZ7BtXAszxg1GnD9iYf+hk6hasSSSJE6A0UN7YJxjLyVXqWxxbFg8CfOmOuH8pRs4cfqCyjclOq7Jpk2dAnfuPcLcJesxwamP0v/LV3ds+HePr/78k/PZ170Hj5ErWyaf2Wp/0ozFyJIxnRpz5fLF4Tx+lsqX6MvXb5jo3Aetm9aRXTx49AQjh3THgmnOuHbjLo6eOKfyGZFAQAQePnqKWDFjYNbC1ShZtSkatO6FA0dP+lvlhHZOFyxfX8lt3LrHIDfQrh3GTZ2P2Zp3t1fnFlir3V0pkCe7dg4nMcgwQQIkQALhnADVD4BAhDV4Zcw6ncQ/g05ngR/arsePHzh+6iIa1qmCaFGjQqfTIZXmwXz0+CmiRLFGmeIFNCkogzSKlzdIZWjRhcs3ULt6eS0F1P6rgtpKJF+0V2/cQZe+I2A3aAxevnqDy9duShGSJU2ENKmSqXSiBPFw+94DlfYZffn6BeKR7TFwtDIQr9+671PE137bHsNQompz7DlwDL06N8eZ85chXrH+wyeig+apPnP+Ci5e9tQDRn9nTJSTKjqdD5CSqYWz2u3gOn97MhAD/vbdB3B3d9dKgFJF88HC4ufhJRcbMaJHg5WVlfK8n790XckxIgGfBD5//gR9+KSl32me2cwZUqsL0+7tGsNeu1vy4NEjg4xeNnvmdFi3aAK2LJ+KOto5Okrz4B44clzJpUmZFI4DO2PEoK6wtATWb9mNejUranduNmG4iytWrN2i5PRtmdv2q/bZIMHc9Irs+ri7fzPr4yYyzs+XL1/Ac+XnZ2hoHgM+P8vNbf+nRWJumv2mPuJ9FePUuJnT5y5pxmdCWFp4DtvK0sq4WPP8Qhlk3jJ97mjGchQba5VrZWWpjGXZ0el0yos7bYw9JKxfNBH/K1dcirT+LNVWIgsLnWYUfpekt/DtmzvsnSajXMnCyuNbqWwxfPTyHnsT9LEzfewg7N80F+M1j66MWVNIrecVHSQsmTlSu21r66OWtqvpK+t+RUaCf3IpkiXB2YtXtQp+/7fWDFgp0el0WtdasLCQXV8cNWwqXx/JkhJ9mttQJBAOurK2toE+JEuaWGn8v/IltLsjfyBf7uxInDC+difjiUFGL5sgfjz8ETu2kqtRtTzKliykLvb05frt5JlL0blNI5y7eB2H/juNPl1tsfvAce04v+6rTX2dsN5aap9VEsJaD/b/89gUFhYWlmZ7zIh+kTGIU8XS0przYvQ5GlrHgfqwNuPI0zoxYwWDqlqNqmVx8Ogpw61z8RLJF13dGpVUk/lyZ8XSNVsMb0kQr+ifmidWlijsO+x5y1S8lV+/fVPy+ihblvQ4+N8ZtXv0+DnNSBafMSBrhReu2AjpRwpv3L6H12/eStLfIN7lN2/fq3KRtba2Rs5sGWGjbQ8f8+xDFQYiyq+NS7y9+vW0r16/hegiTRj3F5CcyOpDg9r/w4x5qzSD4Jg+C/LEu+zkzJoBqzbskCS27T6E1CmTwdLC70Pq8LHTePb8peK9ecd+5MiaXtVjRAI+CVhqLlh9iB8vrnZu5cRh7XyQPFli81Q7jjKmTw3Zv3T1Jt6++6DScoEoeRLkodXT5y4jT66sqkzyJBw7dUEtkciTM4u6QBPjWc67BPHjwkK7aBMZBktvzMjDfx4W2ucd+fjPJ+zYWJh0DIedfubI7Pd18vlZbm77FuamUHDpkyBeHEwc0RdzFq2FPGAmr9MSj2vt6p634KtVLInsmvEqryyr0bgrps5aBksLCzj076Td5tysHjwrV6M13rx5502lTrYNsOHf3erBNjHcokSxgfzJGtaihXKjfc/hkIfUxFvr4eFpDEu5X0GWVEyauUg9tJYwQTxkzZROvT6t16AxUN5avyr9Iu/PJInQs2MzOI6dqR68a9phAF5rRq9UM+4vIDmR1YfC+XPBTmtPODZo3Uc9ePb02UtV3LlNQ7WEQh5aW7d5N/p2a6ny/YoypkuNHvYuEFm5OJCH7PySYx4J+CQgD6xt3rYPDVv3xpCRUzBicHfI+S1yQ0e54uTZi5LExBmL1GvJCldoADv70Wjfsj5kna4q1KLPX75i2pxl6NK2sbYHFMybA7fvPdQ+HwZBjOh8ubOpfEYkQAIkQAIRj0CENXhlqsSAnDbWXj1gtnCaMxrXraq8OlImV+ZivC6eMRJrF05Q618lP0vGtOrVW/NdHbF34xyIIVq2REH06+65LEAMUZdhdpgyegAcB3TGpqVTpJoKrZvUxsLpzljqNhrSbry4f0A8R5KnBLSozl8VYduklpYC5G0HYxx6qSUMkmFv1waip4uDHYb27YAWDf+WbPTo0AyyxEHtGEUzxw9WHmGjLJUUfWdPGqYevJOH4PRf5D77809ONWIUlStVCMJDlj1MHtVfrX2W4iSJEkD0nztluOKRLnUKyVaspG214xXJ0ogFrk5YNssFwt0r28w3VM8cCMg5ONXFHotnjsLcKU7KUNXrtWLOWLUMSPYH9GijXkl2ZPsSLJg2wtc5E1W7OJ07xRExY0SH/MlngNuEYdrnwzBMGzPI8NkgZQwkQAIkQAIRi0CENngj1lRxNCRAAiRAAiQQRgTYLQmEcwI0eMP5BIYH9cU73bNj0/CgKnUkARIgARIgARKIgARo8EbASQ2jIbFbEiABEiABEiABEjBLAjR4zXJaqBQJkAAJkED4JUDNSYAEzI0ADV5zmxHqQwIkQAIkQAIkQAIkEKwEaPAGK07TG6MkCZAACZAACZAACZBA6BCgwRs6nNkLCZAACZCA3wSYSwIkQAIhToAGb4gjZgckQAIkQAIkQAIkQAJhSSB8GLxhSYh9hygB19H98OHJJQYzYvD05rEwm4+b5/eH6PHGxkmABEiABCInARq8kXPeOWoSIIFwSoBqkwAJkAAJBJ4ADd7AM2MNEiABEiABEiABEiCBsCUQqN5p8AYKF4VJgARIgARIgARIgATCGwEavOFtxqgvCZCA6QQoSQIkQAIkQAIaARq8GgT+JwESIAESIAESIIGITCCyj40Gb2Q/AsJ4/O17OSNG4iwMZsQgUdoCoTYfK9duDuMjkN2TAAmQAAlEBgI0eCPDLHOMJGASAQqRAAmQAAmQQMQkQIM3Ys4rR0UCJEACJEACJBBUAqwX4QjQ4I1wU8oBkQAJkAAJkAAJkAAJGBOgwWtMg2kSMJ0AJUmABEiABEiABMIJARq84WSiqCYJkAAJkAAJmCcBakUC5k+ABq/5zxE1JAESIAESIAESIAES+A0CNHh/Ax6rmk6AkiRAAiRAAiRAbWOitwAAEABJREFUAiQQVgRo8IYVeR/9vnn7HsUqN8XK9dsMJW/fvUe9VnaGff8SdVv2hMj6V+4z33mcG3bt/89ntr/7nz5/xvK1W/0tb9N9KM5euOpvOQtIIDAEFq3YiJpNuiB/2bqoWLs1vn1z91X9/sPHKF+jlZL53z9tMdBxIuQcEsHrt+6iY6/hsO06CEtWbZYsFf47eQ4Oo6epNCMSCEMC7JoESCAMCNDgDQPofnW5fc8hpE+TAjv2HvWrOEzzPn/+ijWbdoapDuw8chDYvH0f5i9dD7tOLXBk+xLMGDcElpa+P6bixY2DpbNccHzXcsye5AD3798xe9FqBWmFdnFWs1p5zBw/FAuXb8B3Dw98/fYNU2ctQbf2TZQMIxIgARIggchFwPc3SeQav9mMdseeo+jZsRkePX6G5y9f+9Jr666D6NZ/FDr1dkID216Y7LbEm8zcJes0j9ZgtOvpgGfPX6oy8eJWrd8RDVr3xiDnKXj/4aPKl2j/4ZOqLfEgb99zWLJUkH6atO+Pxu36YZzrfGUsuC1cjcdPnqu2XWcvU3L+ReJtnjhjEdr1cEDXfiMNurx89QYDHCepdivWbou9B4/71wTzIzGBpau3oHXTOihWKA+sLC2ROmUyWFj4/piKHi0qEsSPq0jJVgftn06n9m1srNWx/uHjJ1hZWWolgNv8VahXszJixYyhZBiRAAmQAAlELgIWkWu45jnax5ox+fzlK+TMlhGVyhbFlh0H/FT0waMnGDmkOxZMc8a1G3dx9MQ5g1yaVMngNmEoKpYugoXaLWEpyJguFVbPH4fFM0YiZfIkWKIZE5IvQdoa79wHI4f0xMgJs5WBcOfeI8xdsh4TnPpg/lRHfPnqjg3/7oFt41pIkjgBpo2xR/uW9aR6gEF0mTbWHnVrVjLoMmnmEsT9IzYWarqLTtkypwuwDRZGDgI/fnjAw+O7Idx/+AQXrlxHhVq2qFa/A2YvXGUoM5aT9KfPn9SShqKVGsFDa6dDy7qQ/BaNauDA4eNwGO2KHh2a4fbd+7iotSnnlpQz/OQdHliYs44+j19z1pW68bgP6WPA3L+1aPCawQxt0zysFUoXUZpU/19pbN/90+OqMr2iXNkzIUb0aJrXygqF8+fE+UvXvUqAogVzq7TI3L77SKXF0yW3h8UzfODIKdy4eVflS1StUilPD1qKpJqhnQE3bt/DmfOXIV6x/sMnokMvR23/Ci5evinigQrFC+VV8kkSxdeMDU9dTp65CNsmNVV+zBjRDd458C9SE3B3d8fXr18NwcPDA+7f3LWLOieMc+yF7XuOqPPBWEafFn/ugc3zsGreWIjHd8L0Raqd6FGjYPiAzhjatwMK5cuOEeNnwa5TMxw8elJLu0HuUrx6/UbJ6tsy961wkmDuekY2/b5//x6ujqPIMD+y5p/nys/P1NCcc3P/MosABq+5I/61fju0L/W5S9ahSKXGqNvSDtdu3sHd+499Vfzxw3vWD6MMaysrVajTWUA+hGVn5IRZSJo4IRz6d0TXto3w6fNXyVbByvLn1FtpdT2+ewDaLeESRfIqT654c5fMHIn+PWwR2D/9mksdfuoC7U/60Tb8TwIGAtbWNogaNZohJEoYD6WKFUCSRImQIV0a5MmZBde1izFjGZ/pVCmSa3dGiqk7Hj7LNm0/oF0M5sGfSZNoxu5sdG3XVOsrKlau36Fto4WbYGMTBRJ8jo/7YTuHVlbW4eYYiizHSpQoPFfCaq4NH+xmmrAwU70ijVpi2MobFg5vXQh9aFK3GrbuPuiLweFjp9Wa2E+fP2Pzjv3IkTW9LxnjjHsPHqO4ZsDGjhUTB46eMi7Cxm371YM+t+89wrkL15A+bUrkz50Vew4cw41b95Tsq9dvlec3evSoePfuo8oLaiSGy5xFawzVjdcTGzKZiPQEKpUtjiPHz6i143KMnD53GdkyeS5/uX3vIe5oQSDJHYlX2vEpaXkgbYd2l0SWBMm+Prx49Rqbtu1Fk/p/QS4Oo0SxUXdIEsSPAx/Xjvoq4X/LEZAACZAACfhJgAavn1hCL3PrrgMoW7Kgtw7LlSqMrTt9G7wZ06VGD3sXNO84ULtVm0MLOb3V87nTvMHfaNV5MGRJg9ziMS5PnDA+mrbvj75Dx6JHx6bqYZ4/kySCPDjnOHYm5MG1ph0G4LVmVESxsUHViiXUQ2hyO9i4HVPTnds0wOOnL1S7Zf+2xdETZ8E/EvBJoGm9v6CzsEADWzu06TYEf1UujdLFCyqxpas2Y/naf1X69Zt3SiZ/2booWqmRdlfkLtq38L6+3GXSXMgaXksLC8gxLJ7jxm37QF57VqtaedUOIxIgARIggYhJwOeoaPD6JBLK+/JEepc2jbz1mil9aqycOxbimV02y8VQliJZEixwdYLkdbJtYMhfPnuMkpWMtKmTYfKo/pJElQol1frG8U690b19U0xw7qPy+3W3xeDe7dTDbEvdRqOC1/phKSxboiBmTxqm+tmweBLy5c4m2ephNanv10NrM8YNht675p8u8ePGgePALqrdXevcUK5kYdUuIxIwJmBtbYUBPdpg+eyxWDxzFOrXqmIo7tvNFr06t1T7+XJlxb8rZ6jXksmryeZNdULCBPFUmT5yHtQN2bNk0O+ia9vGWDh9pGo7kQ9ZgxATJEACJEACEZIADd4IOa0cFAmQwK8JUIIESIAESCCyEKDBG05mulLZYujZsWk40ZZqkgAJkAAJkAAJhBsCkUBRi0gwRg6RBEiABEiABEiABEggEhOgwRuJJ59DJ4FAEKAoCZAACZAACYRbAjR4w+3UUXESIAESIAESIIHQJ8AewyMBGrzhcdaoMwmQAAmQAAmQAAmQgMkEaPCajIqCJGA6AUqSAAmQAAmQAAmYDwEavOYzF5FSk6oViqO/XUcGM2LQq2vrUJuPrJl/vic3Up4AHDQJRHwCHCEJmAUBGrxmMQ2RV4lqFUtgQK9ODGbEoFfXNqE2HzR4wT8SIAESIIFQIECDNxQgs4tfEGAxCZAACZAACZAACYQgARq8IQiXTZMACZAACZBAYAhQlgRIIGQI0OANGa5slQRIgARIgARIgARIwEwI0OA1k4kwXQ1KkgAJkAAJkAAJkAAJBIYADd7A0KJssBPYuG0/HEdPZghmBi9evg72uWKDJGB2BKgQCZAACZhIgAaviaAoFjIENm0/ACeXKQzBzODlKxq8IXPEslUSIAESIIHwSCCiG7zhcU6oMwmQAAmQAAmQAAmQQDASoMEbjDDZFAmQAAmYLwFqRgIkQAKRlwAN3sg79xw5CZAACZAACZAACUQKAt4M3kgxYg6SBEiABEiABEiABEggUhGgwRupppuDJQESMJEAxUiABEiABCIQARq8EWgyORQSIAESIAESIAESCF4CEaM1Gry/MY+v37zFkJGuaNy2Hzr2csSA4RNx684DPH/xSuUFpumtuw5izJT5vqqY2pbr7GWYs3idt/qfPn/G8rVbveUZ78xftgGLV242zlLpG7fuoVv/UWjQug/+9087OI9zU/m/it6+e4+6LXsqsRu372H/4ZMqzch8CJy/dA0FytXDjHkr/FTq4pUbcNLmu1yNlqjRuAuGj5mOL1+/Ktnrt+5qx/lw2HYdhCWrNqs8if47eQ4Oo6dJkoEESIAESIAEzJIADd7fmBa7QWPxR+yYWDjdGVNGD0CPjk3xSjOCf6PJYK36+fNXrNm0M9BtTnZbimxZ0mHxjBHYvGwqypYsaFIb0aNHw6Be7ZSsGP6Hj51RaUbmQeDbN3dlmBbKlxM6nc5PpWysrdGkbjXsXDsbk0b2x7Ubd7B8zb9KdoV28VSzWnnMHD8UC5dvwHcPD3z99g1TZy1Bt/ZNlAwjEiABEiABEjBHAjR4gzgrZy9cxZNnL9C5dQNDC/HjxkHenFnUvvt3dwxwnKQ8vQ6jpyvjQAqq1OsgGxWkDbtBLiot0b0Hj9GptxMa2PbCZLclkqXCN/dv6DtsPJq2H6C24klVBb+I3BauxuMnz9GupwPEAyzi4tX9p0VP1c+Va7cky1d49foNCuXNoYwiCwsLiIEkQuL1vaoZQJJu0r4/Zi5YJUlMn7sCqzfuwMePnzDMy9M3e9EazcN7QvW9Y+8RNR7RQ8Lfjbr46c1WjTEKMQKTZi5Cg9pVkCRRfPz48cPPftKnTYkUyZKoMtnmyp4JDx8/U/s2NtZ4/+EjPmjzbGVlCTGZ3eavQr2alRErZgwlw4gESIAEIjkBDt9MCdDgDeLE3L3/CNkypYWVlZWfLYiRYNu4FhZMc9JuCX/D/kMn/ZQzzpTbyYN7t8PsyQ44ePQUjp44p4rv3n+M6pVKY76rI6JFjYrFRreTlYA/kfSfJHECTBtjj/Yt6+HmnftYtX47Zk4YAudBXXHxyk0/azapWx32TpPRtd9ItSRCb2DnzJYRp89dVkZPFBsbnLtwTdUXwz13dk9DX2VoUctGNVGiSD7Vd/lShdHJtoFKj9D61el0qFKhuCbF/6FFQJYyyFKVGlXLmdzls+cvsWnbXpQsmk/VadWkNg4cPqG8xHadWkDOATlmK5cvocoZkQAJkAAJkIC5EqDB+zszoxlu/lX/M0lCpEmVDDqdDjmzZcDtew/8EzXkFy2YGwkTxFNGbZUKJXHh8g1VljhhfBQrlFul//m7Ai5evqnSgY3OnL+CMiUKIE7sWMojV65UIT+bkHwx1CuVLYJtuw/BtutguLu7a97rzDhz4SrEwC1SIJfy9Ll//64Mn7Spk/nZlnGmeBX7D5+Ets3/QZaMaY2LIlc6FEb75ctnfP78SYV3797BedxMDOhhq/a/a3Pmrt010Jf73ErZ8xcv0KGXAxr/UxV5cmRS9aLaWGH4gE4Y2rc9CuTJCqexM2DXqSn2Hz6mpadjittivHj5Usn6bJP7nnMRVA5fv36BhKDWZ73f4+8fPzlX/Ctjfsgw/xXXL194rvyKUUiVh8JX2291QYM3iPhSJk8K8ZCKwedXE1aWVoZsCwudZjB+V/uWlpbw8PBQaTE8VMIrkjKvJKyM5OT2sSFf8yjr6+vzArP11od2W9q/urFjxdS8sCUxc/wQfP/+A+cvXUf2rBlw/uI1zei9gtzZMyqjdd3mXciWOZ1/zXjLd1uwCmlSJkPl8vTuegMTAjtWVtawtrZR4drNe7hy/Tb+atQFxas0w4atezF70VoMHzNTlevl9Fv37x4YoF2YtGhYE03r1/BTZsPWfSicPxcSJ0qIEeNno1PrRrDRvP4r1m33U17fNreecxJYDpba54mEwNajfNB4m8rNwsKSx7v17zE2lbWpclbad6Sl5c/PP1PrUe735zEEvsqCtUkavEHEKbf3E2ne2CEjXPHi1WvVimxPnr2k0v5F4vm99+CJKj568pza6qPDx05DbiN/+vwZm3fsR46s6VXRg0dPceS45wNgKzWDQh4oUwW/iKJHj4p37z4apHJkyYATpy8qg1u8rY+orpkAABAASURBVMdOXjCUGScOHzsDecBJ8u7ce4SXr98gfrw4ygiXJRK79/+njN9cmtG7ZNUW5MyeWUS9BVl68ebde0Pe6XOXcfTEefVgnyGTiRAjYKldMOlD3lxZcXzXckOoUaUs2jT7R/PWdoHI3Hv4BPe1IGlZnzvQcQrq/F1RXfBIns/w+u07bNmxH80a1oCFhQWiRLGBXCAlShgP2i0N1abPOty3JBejYzKiHA9y/EeUsUSscVjwfAuD8w1m/mdh5vqZtXouw3pAvK+2XYagvd1wjJ0yH3H/iB2gznVrVERP+9GQB8Devf9pjEqljOlSo4e9C5p3HIhC+XJoIadkI2XyJFi6eqt6mO3t+/doVKeqyvcZyaumilRqDH2QD7CqFUuotbjy0Jo8kFS2RCF07uOMHgNd/H1w6fip86jTvAead7JHk3b90Kz+X4YHmWR5hhg3soY3V/ZMEGNcbnn71CVvrsz4oXmyZR2wPLQ2YfoifPz0CR17OaoH2Zat2eqzij/7zA5pAktXbcbytZ5vYli/ZTeOafPfb9h45C9bV4X+DuO9qeAyaS56dGgGSwsLyHFQqlgBNG7bB4tWbEStauW9yXKHBEiABEiABMyBAA3e35iFOJpxO6RPe6xZMB6uLgPhOLAL0qRKhgTx40JeVaZvus5fFWHbpJbaLVeyMFbOHYvxTr3Rq1NzuAyzU/mVyhZTeQtcnbBslgvkIS8pkLZkX+SXuI3GiEHdlDdNyoyDPJR2eOtCGAdZFiH5E5z7qIfWRL5p/erqFWrjHHth9qRhaFinimR7C53bNMK6RRMxd7ID9m+eh+YN/jaUd2zVAG4Thqp98XBLf/r1uGIIL589RpWJh9fJviuk7/KlCmOO1tbiGSPVg2vyEF29mpWUHKPQJzDQrp3y8Op77tvNFr06t1S7jetWx94Nsw3eYPEMO9l3U2X6yFk7BrNnyaDfRde2jbXjfSSWzx4LOSYMBUyQAAkELwG2RgIkEGQCNHiDjI4VSYAESIAESIAESIAEwgMBGrzhYZZM15GSJEACJEACJEACJEACPgjQ4PUBhLskQAIkQAIRgQDHQAIkQAI/CdDg/cmCKRIgARIgARIgARIggQhIIFIbvBFwPjkkEiABEiABEiABEiABHwRo8PoAwl0SIAESiIQEOGQSIAESiNAEaPBG6Onl4EiABEiABEiABEiABEw3eMmKBEiABEiABEiABEiABMIhARq84XDSIpLKrqP74cOTSwzBzCBDutQR6TAxu7FQIRIgARIggfBFgAZv+JovaksCJEACJEACJEAC5kIg3OhBgzfcTBUVJQESIAESIAESIAESCAoBGrxBocY6JEACphOgJAmQAAmQAAmEMQEavGE8AeyeBEiABEiABEggchDgKMOOAA3esGPPnkmABEiABEiABEiABEKBAA3eUIDMLvwn0L6XM2IkzsJgYBB0Fm/evvMfNEtIgARIgARIIBIToMEbiSefQycBEiABEiABsyVAxUggGAnQ4A1GmGyKBEiABEiABEiABEjA/AjQ4DW/OaFGphOgJAmQAAmQAAmQAAn8kgAN3l8iogAJkAAJkAAJmDsB6kcCJBAQARq8AdFhGQmQAAmQAAmQAAmQQLgnQIM33E+h6QOgJAmQAAmQAAmQAAlERgI0eCPjrHPMJEACJBC5CXD0JEACkYwADd4wmnD3799RpFJjDB01zaCBu7s7yv5tiwHDJxryfifRfcBoXLl263eaUHV37j2KFp3sYdt1CNrbDcfilZtVPqPwQWDu4rXIX7YuTp656KfCN2/fR6few1G8ShN07DXcm8yOvUdg22UQ2vUYiiPHzxrKXGcvxZYd+w37TJAACZAACZCAOROgwevf7IRwvk6nQ4zo0XD+0jWIoSvd7T10EkkSx5ek2YQjx89gzNR5GNynA9wmDIGry0AkShjPbPSjIgETuHv/EXbsPYzkfyaGTqfzU9jS0gJ1a/wPXdo08lU+fe5yuAzvhT5dW2HOotWq/Nad+zh38Roqly+h9hmRAAmQAAmQgLkToMEbhjOk0+lQtGBuHPzvjNJip2aYlCtZWKUlevz0OXraj0bzjgM1z5sjbty6J9n49s0doybOQZP2/ZXnddf+/1T+l69fMXjEVDRu1w89Bo7C+w8fVf7RE+dgN8hFpSUSI7b3kLH48PETHFxmoG2PYahYuy227T4kxd7CklX/olXjmkidIqkhv3wpTx390895nBuGjZ6GTn2cMXP+SmzddRDd+o9Cp95OaGDbC5PdlhjaYiLkCHh4eGjHwxQM69dZGbs/fvzws7NUKf5EyaL5ET1aVF/lNtZWeP/+A969/wgbGxtVPnLibPTv0VqlGUUOAhwlCZAACYR3AjR4w3gGK5Ypgl37juLzl6+4fe8h0qZObtBo0ozFyJIxHeZOGa5504rDefwsVbb+3924++Cxyh/cuz1GaPlv3r7Hus278fbdB8yf6gjbJrWV91gqFMybHbfuPMTLV29kFxu27kPViqWw58AxxI0TC9PHDsLm5VORP3c2VW4c3dP6yZUtk3GWIe2ffiLw5es3THTug9ZN68guHjx6gpFDumPBNGdcu3EXYoSrAkbBRsDD4zuMw5zFq1G6WH6kTul5sWJc5lf6xw8PTZcfkK2+XAzbcZqHf/aiVejZsSnWbNyuHSdZ8WeShN760stz630OyCNi8zA+VzjXEXuuOb+/nl/tC8Ss/weTwWvWYzRr5bJlTo+r129pRu8RlC1RUDM2fnrhzmq3jev8XUHpX7ViSdy++wCy/OH0uSuoWaUsLC0sNGPmT2TPkg5XtDbkNnONqmVhoeVnzZQOEqSyTqfTDOZi2Lz9gOap+6BuR5conAcZ06fCof9OY8a8Fdh/+CTixf1DxH0Fnc7vW+H+6ScNlCqaT+khaQm5smdSSzisrKxQOH9OzRi/LtkMwUjgq+bh14cbt+5qc3sGdWtUhOT90Ly7cuxI2r8g5R4eP/D9+3dVR+TSaRdgjgO7YMSgbrC2tsSGf/eifq3/Ydmaf+E0dgZWrd9mkBV5hq8hwkPmRgL5hgzfoHI1PleC2gbrBe+cyh1QnivBy9TUYzQYv85CpCkavCGC9deNigEiQSSLF8mr3eZfioplismut2CtGYiSodPp1G1pnWbMyr6VdqtZthLEiNTsGUnCytJSbSWysvqZ/rtyGWzYuhv/7jyISmWLKGM0Q9pUmDFuMDJrXuTla7di6ep/pZq3kCJZEpy9eNVbnvGOv/p56a2X1ev3c/+nYa/P4/b3CESNGg36sO/wKZw5fwUlqjZH8SrNcP/hE8gSk393HTbI6GX1W2trG3VcWFlZ+ykzxW0ZurVviguXb+LwsTPo36Mt9hw8gQtXbvkpr2830m2N5iG4xm5jEwUSgqs9tvPzXPkdFv6dK7/TJuv+3txEicJzJayOod/7Bgv52jR4Q57xL3v4639l0LB2VaRMnsSbbM6sGbBqww6Vt233IaROmUx5dXPnyIQNW3bju4cHbt99iAuXbyBLxjTIockfO3VOyb9+8xZXrt1WaYkSJoiHJIkSYt6S9aheqYxkQZZBxIwRHSU1g7tWtXJ+el0b1P6f5gFehd0Hjqk6EsmT+7L1Tz8p8xkOHzuNZ89f4tPnz9i8Y7+ma3qfItwPRgKtGtfC8V3LDUEuXGaMG4Ia2p0B6UYelnz1+q0kTQryhgY5VnJmy6juQiTSjie5kxA/Xhz80I5DkxqhEAmQAAmQQKQiYE6DpcFrBrMhxkjjulV9adK5TUPNS3dZPbQm63P7dmupZMRATpQwvsofOsoVdp2aI3asmPi7Shm8ev0OXfqOwNBR0+HzjQ+VyxdD8mSJDYb17gP/KQ9gh16O2Kt56lo0+lu1bxwVzp8Ldh2bYc6itWjQug/kwbOnz14qEf/0U4U+oozpUqOHvQvkAbxC+XKgUL6cPiS4G5oE5Lg5efai6vLOvYfqtWVDRk7F0RNnUap6S+0iZ4Uqk0jWl0+bswxd2jaWXRTMmwOy3ty26yA81S5i8vmx9lsJMiIBEiABEiABMyFAgzeMJkKWHuxYM9NX72VLFISsmZSCJIkSYIxDL/Vw2pTRA5AudQrJhrW1FXp3aYEFrk6YM9kBZYoXUPlRbGwwtG8HTBzRF+Mce2Gp22hkypBGlUl05fptiCdX0hLE27d/01xM1doePqCToX0pMw7lShXCfFdHLJk5EpNH9UfDOlVUsX/69etuq9YjKyGvSIz6BZq+y2a5oJNtA69cbkKLwJoFE5E3V1ZDdyvmjIX+jSDylgZjb/DeDbPRptk/BtmoUWwwd4ojxMMrmeLZdZswDBKmjRmkltpIftACa5EACZAACZBAyBOgwRvyjM2ih679RuLUuSsoX6qwWehDJUiABEiABEiABIwIMBmiBGjwhihe82l8gnMfzNW8weKdC22tKpUtpl5pFdr9sj8SIAESIAESIAESEAIWEjGQAAmECwJUkgRIgARIgARIIAgEaPAGARqrkAAJkAAJkAAJhCUB9k0CgSNAgzdwvChNAiRAAiRAAiRAAiQQzgjQ4A1nE0Z1TSdASRIgARIgARIgARIQAjR4hQIDCZAACZAACURcAhwZCUR6AjR4I/0hELYAqlYojv52HRmCgcEfsWOF7WSydxIgARIgARIwUwI0eM10YkJdrTDqsFrFEhjQqxNDMDAA/0iABEiABEiABPwkQIPXTyzMJAESIAESiKwEOG4SIIGIR4AGb8SbU46IBEiABEiABEiABEjAiAANXiMYpicpSQIkQAIkQAIkQAIkEF4I0OANLzNFPUmABEjAHAlQJxIgARIIBwRo8IaDSYrIKm7cth+OoydH2LBn/5GIPH0cGwmQAAmQAAmECwKhYfCGCxBUMmwIbNp+AE4uUyJs2HuABm/YHFnslQRIgARIgAR+EqDB+5MFUyRAAiQQwgTYPAmQAAmQQFgQoMEbFtTZJwmQAAmQAAmQAAlEZgKhPHYavKEMnN2RAAmQAAmQAAmQAAmELgEavKHLm72RAAmYToCSJEACJEACJBAsBGjwBgtGNkICJEACJEACJEACIUWA7f4uARq8v0uQ9UmABEiABEiABEiABMyaAA3eEJ4e19nLMGfxOtWL+/fv6NJ3BCZMX6j2TY0uXL6h6nXu44z9h0/ixu17flY9cvwMuvYb6a2s+4DROHj0tLc8nzuN2/bD8xevfGYHev/1m7cYMtIV0l7HXo4YMHwibt15EOh2InKFHXsOo3MfJxSv0gSN2vTGgmXr/R3unoPH0LLzQDRo3Qututhj666DSvbjp8/oO2wcbLsMgsPoaZDjSgpevX6r5N3d3WWXgQRIgARIgARIwIsADV4vECG98fDwwEDNAEyRLAm6tm0cqO5Wrt+OejX/h0kj++HwsTPBbkT2626LP2LHCpROfgnbDRqrtRMTC6c7Y8roAejRsSlevXnrl2ikzYsX9w84DuyCfRvnoU//dArRAAAQAElEQVRXW8yYtxKXrt70xUOOlyEjpqBNs7pYMnM0WjWujcHOk5Vxe+DIScT9IzbcJg7Dh48fceb8FVV/zJS56NKmMaysrNQ+IxIgARKIpAQ4bBLwRYAGry8kwZyhA3RacHCZgVixYqJX5+aQP/Go1mtlh/4OE9BB84Y+fvocbXsM07x5vZWHdO/B4yKGtZt34Yhm5IqneOioqZqH9wRmLViFdj0dcOfeIyVjaiSGldRr0r4/7Oxd8OLVa1XVeZwb3rx9p9J1W/bExBmL0K6Hg/IWP3v+UuWL51jqSij7ty127f9P5eujsxeu4smzF+jcuoE+C/HjxkHenFnU/uoNO9C8kz0at+uHmfNXqrzIGOXNlRWxtePAwsICObNlRKoUSfHg0VN/UVhYaAePVirbxIniw8rSEjY21nj3/gN+/PiB9x8+ImoUG/x38hyi2Nggd47M4B8JkAAJkAAJkIB3AjR4vfMI/r0fwNpNu5Qnrr/mSTXu4O79x7BtWhtTNW9okkQJ0KdLK82bNwrjHHthstsSfPr8GTWqlEXeXFnQtV0jDO7dASWK5EOrJrUxbYy9MpaM25O0GD5FKjWGPsgyB8n/rnmYh45y1bzLjbDA1QkVyhTBhGmLpMhXSJMqGaaNtUfdmpWwcMVGVT7BuY/qs13zfxA/3h8okCebytdHd+8/QrZMaf30Lt68/QCzFq3BWAc7zBw/WBnL4qnW1w2TrRl0eui/0xBu+XNn9aWNGMTtW9ZHl77OyF+2LnoPHoOhfTspuVJF8ytPulws5cqeGRnSpcLkmYu1Y6SxKmdEAiRAAiRAAiTgnYCF913uhQSBP5MmwrmL1315ZFMmT4K0qZIburx97wGGjpoGe+cpyoP34KH/nj9DJR+Jgnlz4PDWhYZQOH8uJfHo8VPNA/sSE6YvgnhpV2ke18vXfN9KF+HihfLKBkk0j+Ltuz+9yLJGd9jo6Rg5uAdixYyhZLxF4sr2luG5c+bCZZQuXgByOz9a1KioUqEkxCPsWRqxY1lP+/nzJ/gMZ85dxLDRU+E8qKvmobX2Vf7h4wfs3HsYo4d2x9aV0+A4sDMGOE7A8xcv8OXLZ4gnfXDvtmhStyqmahdH9bSLkydPn2HUxFlwmTQb12/e9tWmTx3823d3/xbkuv61yXzfx0BgmHz9+gUSAlOHsr/H3BR+EeVcMWWs4UXmyxeeK2E1VzDzPxq8IT1B2h3pgnmza57Vhug+YBSeei0RkG6traxlo4IsN1iyaotmwFRX61/Tp0mJj58+q7LgiXRImjiB8tKKd3jGuMFYPnuMn01bWnoeFjpY4Pv375A/uX3ef/gkdGxVH2lTJ5MsbyFl8qS4eOWmWmPqrcBrx9rK0isFdVv+B34Y9iNywtLSEtbWNt7CsxevMXLiXIx37IvC+XN7K9PL3tS84g8fP0PRgnkR548/1FaQPXj03Jv8fe2i6Oad+/hfuRIYOWGOti2OsiULa4bvHG9y+nZN2VpY+NbZlHqU8T7PwcnD0tIKlloIzjbZ1u/PF8+V32cY3MehPMNgaWkd5M+/4NYnMrVn7t/lFuauYETR73/liqPRP1XQqbcj3r5772tYd+49RMb0qZQx+fbte1y4csOXjGREixYFUi7pwIQ/kySEeBu3ej3p/+2beyC8rIDbglXIkjENypUqBL/+ZD1qogTxMGSEq2FtsKwRPnn2EnJly4y9h07g5as3apnG5h37kSdH5FhrqtPpYKkZvfpwW5vnfg4T4GTfFZkzpvVW9kab90tXb6m8xIkSaN7cV7h2867al3y5AEqXJoXa17c3etIc9OveWuV5/PDAn0kSIYl2YSMLx/Uygd1aWFio9gJbj/KW5GZ0rEeG44Hnirke8/wMC4vzD2b+Z2Hm+oV/9TRH5g8tyEDq/FURFUoXUQ+Dff32TbIMoXjhvLhw6bp6cG2c6wJk1YwhQ6FRokr5Ejh8/Ix60O1OIB5akw9meTvA5u0H0KzDAPzVsDPOX/bbqDbqTiU/fPyE2YvW4rymnyyHkHBKM2RVoVHkMqwHrDRPrm2XIWhvNxxjp8xXbxMQj3CTf6qhh70LWncbipJF8qJQvpxGNSNPctKMRbh89SbqNO+u1ubmL1sXqzZsh/wdP30Bw8dMkyTk4qGjbQO06DQA9VvZYZzrPIwd3hsxY0RX5RKtXL8NRQrm1jz3CWUXzRvU0I6foeq1Z83q/63yGJEACQQzATZHAiQQLgnQ4A3haWvfsh5aNPxpfLRuWgdzJjsoT5y8vkvfvRgyc6cMx/SxgzCsX0e1rEG8plIuhmqBPNkliXSah2/00J7qQTd5wl9lekWyXlceLvPaVRt5AK5YodwqnSFtKkj5vKmO2LLCFQ1rV1b5okeC+HFVWpY5yFsEZEcM1cmj+iNG9GhqTbDoJsshJOTxevuCyOlDnD9iY0if9lizYDxcXQZC9E6TKpkqrlW9POZq4144zRnCQGVGwmi8U18c37XcW6hdvYIiUbFMUSx1c1FpiZrU+0vjvhhLZ7lg1kQH+GQuF1Bi5IqshJJF82PVvPEqFCuUR7IYSIAESIAESIAENAI0eDUIwfyfzZEACZAACZAACZAACZgRARq8ZjQZVIUESIAEIhYBjoYESIAEzIMADV7zmAdqQQIkQAIkQAIkQAIkEEIEwtzgDaFxsVkSIAESIAESIAESIAESUARo8CoMjEiABEggzAlQARIgARIggRAiQIM3hMCyWRIgARIgARIgARIggaAQCP46NHiDnylbJAESIAESIAESIAESMCMCNHjNaDKoCgmQgOkEKEkCJEACJEACphKgwWsqKcqFCAHX0f3w4cmlCBsG9+sWItzYKAmQAAmQAAl4EeDGBAI0eE2ARBESIAESIAESIAESIIHwS4AGb/idO2pOAqYToCQJkAAJkAAJRGICNHgj8eSH9dAbNWqIBg3q49u3rwxmxMDGxobzYUbzIecH8AM6HTgvZjYvNjbWcHf/xnkxo3n58UPOFV2AcyLnFEPwf++GtU3xq/5p8P6KEMtJgARIgARIgARIgATCNQEavOF6+qh8yBBgqyRAAiRAAiRAAhGJAA3eiDSb4Wgsy9duReN2/dC0/QDsO3wyHGkecVXtO3QcilRqbAgXLt+IuIM145G9ev0WdvYuKPN3K4yaOMebpmfOX0HzTvZo0r4/3Bas8lbGnZAlsHbzLjSw7aXOD5kjfW/L1mxVefpzZ/6yDfqiiLE141GcOnsJfYeNR/marWHbdQj2Hjph0JbnigEFE14EaPB6geAm9AjcufcI85duwPSxgzBqSHc4jpmBz1++hp4C7MlfAlNHD8DhrQtVyJY5nb9yLAhZAlUqlkTrJrW9dSJrEwc5T0Hvzs0xZ7IDdu3/D/KF702IOyFGIHHC+BjWvxMSxI/rq49WjWupc0bOnab1qvsqZ0bIEIgeLSrsOjXH1lXT0az+X+q7RHriuSIUGHwSoMHrkwj3A0sg0PIHjpxEqWL5ESN6NCRJnACZM6TBsZPnwT8SIAEgbpzYKFuiIKJFi+INx5XrtxE9ejRkzZQOVpaWqFimKPZr55I3Ie6EGIEiBXIhQ9pUIdY+Gw48gUzad0eCeHFgaWGB4oXz4Nu3b/j0+TN4rgSeZWSoQYM3MsyymY3x2YuX+DNJQoNWyf9MjKfPXxj2mQg7Aj3tx6DyP+3hMnme9uXhHnaKsGdfBJ48e4lkRudNimSJ8eQpzxtfoMIgY/HKzWoJSu8hY7XPspdhoAG7XLNxJ9JrFyTRokYFzxUeD34RoMHrFxXmhTgBnXZFru9Ep9Ppk9yGIYEeHZth1zo3jBzSHZev3cKC5RvBP/MioLMwPlf48W0Os1OhdGFsWzUNC1ydECtmTAx3mWEOakUqHc5euIpF2kXHoF5tDePmuWJAwYQXAX5ieoEIrQ37ARLGj4fXr98YULx89RqJEsQ37DMRNgQSJYinOs6ZLSOa1K2GS1f50JoCYiZR4oTx8Or1O4M2ct4kTsTzxgAkjBLx4v4BKysryJ2q7u0ba+fNzTDSJHJ2++z5S0x2W4LJo/ohRbIkCgLPFYWBkQ8CNHh9AOFuyBMoXjivWnv45etXvHz1Bhev3ESh/DlCvmP2ECCB9x8+qnJ3d3c1P1ky8qE1BcRMokzpU+P5i1e49+Axvnt4YOfeo5BzyUzUC4oaEaKO/ryRwezadxRZMqaVJEMoEJDzYYDjJPTv3hpJE/9cJsdzJRTgh8MuaPCGw0kL7yqnSpEUNauWQ6sug9Gt/yh079AUNtbW4X1Y4V7/2s16qNcryfaP2DHRtD6fNg+LSXX//l3Ng7ySbM2mnSp95dot6HQ6DO3bAfZOk9G840Dky5MVeXNmCQsVI2WfrrOXqbkQI6tKvQ6wG+SiOAx3ma7yy9WwxdET52Bv1wb8Cx0CK9Ztw7mL19CgdW81B/JquMdPn/NcCR384a4X8zZ4wx1OKmwqgbo1KmHhNGfMd3VEqaL5TK1GuRAksHXlNPVqpXWLJqJz64bqTQAh2B2b9oeAvIFBXm9lHORpdBHPlT0T5k4ZjgWuTvD52jIpZwg5Au1b1lPnh35eXIbZqc5GDO6u8neudYPjwC5I6LU0SBUyClECPudE5iZJogSqT54rCgMjIwI0eI1gMEkCJEAC5kqAepEACZAACQSdAA3eoLNjTRIgARIgARIgARIggdAlEKTeaPAGCRsrkQAJkAAJkAAJkAAJhBcCNHjDy0xRTxIgAdMJUJIESIAESIAEjAjQ4DWCwSQJkAAJkAAJkAAJRCQCHIsnARq8nhwYkwAJkAAJkAAJkAAJRFACNHgj6MRyWCRgOgFKkgAJkAAJkEDEJkCDN2LPL0dHAiRAAiRAAiRgKgHKRVgCNHgj7NRyYCRAAiRAAiRAAiRAAkKABq9QYCAB0wlQkgRIgARIgARIIJwRoMEbziaM6pIACZAACZCAeRCgFiQQfgjQ4A0/c0VNSYAESIAESIAESIAEgkCABm8QoLGK6QQoSQIkQAIkQAIkQAJhTYAGb1jPAPsnARIgARKIDAQ4RhIggTAkQIM3DOGzaxIgARIgARIgARIggZAnQIM35Bmb3gMlSYAESIAESIAESIAEgp0ADd5gR8oGSYAESIAEfpcA65MACZBAcBKgwRucNNkWCZAACZAACZAACZCA2REIxwav2bGkQiRAAiRAAiRAAiRAAmZIgAavGU4KVSIBEiCBQBGgMAmQAAmQQIAEaPAGiIeFJEACJEACJEACJEAC4YWAf3rS4PWPDPNJgARIgARIgARIgAQiBAEavBFiGjkIEiAB0wlQkgRIgARIILIRoMEb2Wac4yUBEvBG4MTpC+jabyTq2/ZCtfqdYNt1CF6/fadk2vV0wLFT51U6rKP7Dx/DbpAL2tsNx3FNZ2N9lq3Ziv/90w6ibwNtHH2HjsOjJ8+MRUI0LX2t27wrSH0I3069nfysu/vAMW0+BqNY5aaYs3idN5kJkF+eoAAADLNJREFU0xeiuJZfompztO42FNt2HzKUy/iLVGoMfShfs7WhTJ+QOV+5fpt+V21//PiBmk27+eKrCr0i0WOy2xKvveDZvP/wEY3b9sO3b+74+OkzBjhOQrseDnAa6wb3799VJ69ev0Wb7kPh7u6u9iVa/+8euM5ZJkkGEggagUhUiwZvJJpsDpUESMA3AUfNqCiUPycWzxiJjUsno2Orer6FzCBn8/b9yJopPVxdBiJ/7my+NMqdPROmjbHHPFcniJE0Z5F3A9FXhWDMePzkOTZu2x+MLXo29UfsmOhk2wAVShfxzDCK//m7IvZsmI0da2agddNacB7nhnfvPxgkurVrgsNbF6qwY81MQ74+Ua1SSWzefkC/q7b6Cwm/+CqBEIoWrtiI/5UrDmtrKxz67zTi/hEb08ba48PHjzh74arqdfy0hdqxWR9WVlZqX6IqFUpg++4jePP2vewykAAJBECABm8AcFhEAiSACI/g6bMXKFE4DywsPD8O8+TMgjixYxnGvffgCXTs5YjazXpgxbqfHsGlq/9F5bod0LBNH3TrPxL3Hjw21BHP4tRZS9Gl7wgsWbVFlYnXUbx4Tdr3x5Yd3g0tfUUx2BxcZqBxu37K4yfeRCkTT95GzaDcvH0fxIv74eMnyfYz2Fhbo0CeHHj6/KWhfPnarZB+JfR3mIAXr16rshnzVqDvsPEQD2uD1n0gZXrvtn+6SEXRYdTEOaqew+jpmKKN9ebte0o38UqKzH8nz6Ftj2Fo1mGA2l68ckOyVRAP6T8teqKDxnXPweMqz68orzYXuXNkhqWlpa/iP5MkUsZfFBsb/BErJnQ6C3h4/PAl519GmeIF1LzcuvPAILJx6z5Uq1gKL1+9Ubxkbuu1ssPC5ZsMMsaJMVPmQ7zr+jzX2csMnuhPnz9DyoVrozZ9IWP28PDQi3rbiuFdvnQhlWetzZ+wF2+zzHPUKDbqLoOMM5d2UaOEvCIrjUth7WJt666DXjnckAAJ+EfA8xPev1LmkwAJkEAEJ9C5TSN01G6pi3E6f9kGyNIB4yF/124pTxzZD7MmDcX8pesNhmTBvDmwYfFE5RmuWLYonMfPMq6G5H8mxsQRfdGgdmUMHjEVJYvlx8Lpzpik5c1dshZXrt/2Ji87M+at0ryU7zF/qiMmjOiDtZt24sCRU/jrf6VRtkQB1KpWXnlxY0SPJuJ+BrnlfeLMBVSpUFyVH9Q8hlt3HcIkbQwLNO+vGJCjJsxWZRLdufcQIwZ3w5KZI5E0cQLMXrhasuGfLqpQiz59/qLGZ9+rrfI8pk2dQunWv4etMqiHj5mJXp2aY542lh4dmqLfsAnK87xz3xHsO3QccyY7YLxTb1y/eVdrLWj/J81crJYtiAE+aWRfiEdY39L4aQtUmVx8iPdXn6/fiqdU5m3D1j0qS5YSiF7V/1cK0aJFgdPALmpu3SYMxa79R3Hy7CUlZ2rktmA15NiRuZw7ZTiePH2B5Wu3+aouF0oWOh2SJEqgykoWyauNIwbsnaYgR9aMSJ82JVxnL0en1vVVuc8oZ7YMOHUucLr5bIP7phKgXHgmQIM3PM8edScBEvhtAvVqVoIYgnKL++SZi2jUph+uXLtlaLe4ZoBYWlgor68Ydbfu3FdlFpYWcNOMw679RmL9lj246sOArVSumJJ7++49Ll29qWTEMOurGX4fPnw23KpWQl6R9N+wdhVYaP3FjxsHlSsUhxivXsUBbvYeOqEMPFnTKh7KkkXzK/kjx87i9Zt36Dt0vPLAylrXsxevqzKJCubNjpgxoksSZUsW1oynKyr9K13KlSyk9FTCPqIz56/is2YQu0yZp/oc57pA3Xa/e/8RTp29gur/K6P6FG907erlfdQ2fbdz64bYu3EOxg7vhSEjXb2tWzZe0tCvu62fjVavVApbth/QPMMe2L77EHJmy4RECeIhapQoOHXuMoaOmoZeg8dC1s9evvrzmPCzMR+ZR4+fw/lL19G5r7MK127e0ebck62x6INHT5AgflxDlk6nQ48OzTB8QCe0alwTszTDuWGdKtocvseE6QsxacYi5ZnWV0iaOKF2kfZUv8stCZCAPwRo8PoDhtkkEBQCrBM+CYhnsGKZoprHsQ/EwN284+d6VBvrn2smxRB1d/e8Ld1jwChkTJcaQ/q0x6gh3SEeT+PRyy1o2Zfb8eJNnDp6gPKAyjpbWSssa1Cl3Dj8wA/tNv3P2/dWllaQW9vGMv6lSxXNp9arikdVHn6S5Qoiq9P9QNUKJQx9i8dyy/KpUhRg+JUuUaJY+1tfp9MhU/rUhj5lzLLeNm2q5NoItTFaGo3RaE2qvw0GUGBjbQ1ZhhI3TmxcuPxz2UQAVQxFmTOkQfx4cXDw6Gls2r4fctEjhRu37cWufUfRpG51TB7VH8UL54V4gKXMOFha6vDdaJmCeNcN5TqgZ8emBgZL3UbDyb6roVifsLGxgbd6+gJte+vOA1y/dRflSxWG09iZai1zqWIFMMLobsLnL18hDDRx/icBEgiAAA3eAOCwiARIIOIT2LX/P4PR8ur1W9zSPLgJ48cPcOCfPn/GqzdvNUMoD8TQ2rH3iL/ysvxADKuJmmdOv4bzxq17eP7ila86+XJlU2t+xciVdbayNlPW4/oSDCAjY7pU6N2lJVas247HT5+jaMHcWLN5F25q45JqX79983Z7fs+B42qZhvS5bM2/yJszs4ghMLrEjBkdb9+9U/Ukyp09k1qysXPvUdlV4fCxM2or7csyC+lPMsTYlG1gwwmjN1VcvXEHN2/fR9ZMaQPbjOZtLo15S9fjzr1HkHW90sBtzdCU5QRpUyfTjNHvOHzstGT7CimTJcU9zWstBcL1v1MXJKlCMY379HkrIetxJUPm069lLBnSpsSDR357aF0mz4Vdp+ZSHR4/PJT3OUH8ONpFg8pSkSzBkTlXO+YVURsSMCsCNHjNajqoDAmQQGgT+HfnAdRs0g22XQfjr4adkSpFUvxTo0KAakSLGhWN6lRFA9s+6pVmL16+DlB+aN/2moH7Bk3a9Yc8rGXvPNlgZBtXbNOsNqJqbTftMABd+45ElQolUaxQbmMRk9LZMqdD2RIFMX/pBhTOn0vdGh82ejqadxyIqvU64tyFa4Z2smhGYk97FzRo3Vsz7tzRolFNVRYYXdKmToHc2TOjx8BRmifSTV0EyLrg1Rt3oHkne8gr09Zs2qnaLVeysOb9TQVZCiLyz4werlMCRpHUkTW48rDejHkr1JKNU2c916uu/3ev2pfytj2GoXXTOpAH2Yyqm5SsXL6YWsJSoXQRzbvu6c2vWa085LiQV4MNGTlV8+Sn8rOt8qULaxcPF6HkRkxFymRJDHLCMXOG1Kqscbt+aN5hIF69fmMo1ydixYyBHFnTQ4x2fZ5shZ28PUSWLMh+E83b3KmPk8Z4NBr/U1WyVDh59jIqlS2q0oxIgAT8J2DhfxFLSCCECbB5EjADAqOG9MD6RRMht/r3b54HZ/tu0C9HkFvxBfJkN2g5zrGXwQC1bVILq+aNxQTnPsrYOrhlvkFOXodl2NESYojJmsxFM0ZgxZwx6mGoxAnjayXe/4vxY2/XRq0pXjjdGS0a/m0Q6NauCWQtpyHDKCHrkEcM7m6UAwzt20Hz9LZQeTWqlMXcyQ6Qh6e2r56BZg3+UvkSpU2VTPWnv+Wuf0NFQLr45GJpYQFZJzt2eG/IQ2vSbt6cWTBl9ABIv/+umAbhLPkSZO2tPNAn8rKVZQOS7zPUrFpOLdMQnvogyxdETsanz9u9bhaEgeRLEBbG+5LnX4gdKyZk3u06NTOIyAOHMk/yarARg7qppQgy3yIgcyKvSpO01F02y0W9QszJviscB3YxzFnUKDbo0qYRZM4XTnPGhiWT1cWH1PMZGtSugg2aAW+cLw8oNq1X3ZBVokheyBxJEK+9FMgdiRcvXiN3jsyyy0ACJBAAARq8AcBhEQmQAAmQAAmENAG5qEqZPImfXv+A+r599wG6d2gSkAjLSIAEvAjQ4PUCwQ0JkAAJRDYCbZr9AwmRbdzmOF55iNHSInBfyeLtzpQ+tTkOhzqRgNkRCNzZZXbqRyaFOFYSIAESIAESIAESIIGgEKDBGxRqrEMCJEACJBB2BNgzCZAACQSSAA3eQAKjOAmQAAmQAAmQAAmQQPgiEFEN3vA1C9SWBEiABEiABEiABEggxAjQ4A0xtGyYBEiABMyBAHUgARIgARKgwctjgARIgARIgARIgARIIEITUAZvhB4hB0cCJEACJEACJEACJBCpCdDgjdTTz8GTAAn4IMBdEiABEiCBCEiABm8EnFQOiQRIgARIgARIgAR+j0DEqv1/AAAA///IHFPTAAAABklEQVQDAG8Ih9FeIjFNAAAAAElFTkSuQmCC"
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAGuCAYAAAByTNVOAAAQAElEQVR4AeydBWAUyRKG/43hHO4Oh7u7uxxwuFtwDy7Bk+AOwd3dXR9+uLu7u4UkvKlOdtkomxDZJH+ge3qqq+3rmd2amp5ZCxeX7z8ZyIDHAI8BHgM8BngM8BjgMcBjILweAxbgHwmQAAmQAABCIAESIAESCK8EaPCG15nluEiABEiABEiABEggMATCYRkavOFwUjkkEiABEiABEiABEiCBXwRo8P5iwRQJkIDpBKhJAiRAAiRAAmGGAA3eMDNV7CgJkAAJkAAJkID5EWCPwgIBGrxhYZbYRxIgARIgARIgARIggUAToMEbaHQsSAKmE6AmCZAACZAACZBA6BGgwRt67NkyCZAACZAACUQ0AhwvCYQKARq8oYKdjZIACZAACZAACZAACYQUARq8IUWa7ZhOgJokQAIkQAIkQAIkEIQEaPAGIUxWRQIkQAIkQAJBSYB1kQAJBA0BGrxBw5G1kAAJkAAJkAAJkAAJmCkBGrxmOjGmd4uaJEACJEACJEACJEAC/hGgwesfHeaRAAmQAAmEHQLsKQmQAAn4QYAGrx9gKCYBEiABEiABEiABEggfBCKawRs+Zo2jIAESIAESIAESIAESMJkADV6TUVGRBEiABMITAY6FBEiABCIOARq8EWeuOVISIAESIAESIAESiJAE/DV4IyQRDpoESIAESIAESIAESCBcEaDBG66mk4MhARIIJgKslgRIgARIIAwToMEbhiePXScBEiABEiABEiCBkCUQNlujwRs25429JgESIAESIAESIAESMJEADV4TQVGNBEjAdALUJAESIAESIAFzIkCD15xmg30xicCx/84gVrIc+Pbtu0n63pVqN+6A4aMmexd72U+bvQQ2bt3jRcYdwBR24YmTKcfBjLnLULxCvfA07ECNhRwChS3MFNpz4Aiq1bVFonT50ci2m0n9bta2J/oNGW3Qbda2B/oOHmXYjyAJDtNMCNDgNZOJCE/duP/gsTJIxSiVIB+QFWo0w+IV68PMMAvmz4W4cWL9cX+z5K+AA4eOB7iectWbQtj5FQqXrRXgOv0rMNhhgr/tST+evXjpXxWhkte55xBDv+OnzouSlRrAadx0fPnyNUj64/04SJGpCLbu2O+l7sSJEiBn9sxeZCG9s2z1JsgcSYibMjfkuCtTrTFGT5wV6AvDgI4hODicPX9Zjevd+w8B7Y4PfT0jfcbUmYtQqkpD/W6gt/2HjkHZf5ogYdp8KFCqho96pO/1W3SGHJ+xk+dEoTK1MMRxIt5/+GjQ1fdN5s84jJsy16DjPZGnWDXFRvSTZyyMyrVaYsXazd7VArwvxuyAYWN9lBviMBF5c2XDvUuHsHTORB/5pggypk+L1CmTm6JKHRIIcgI0eIMcKSvUExg5tA82r5qDxbPHo2K5EujedwSWrNygzzbrrXygFy2UN2T66EsrY4b3VeyE37Txw5TGeKcBBtmUMUOULKiiZo1qGeqWNuPEjoWWTep6lcWKFVTNBWk9uXJkUf1cNm8iChfMjbGT52DUhBlB0oYpx0H1KmUxeczgIGnvTyuRuVu/bAYG9emMkkXzq/OtWIU6ePP23Z9W/dvy5sTht50NQoW3bz+geuVyqFG1vK+1fvv+HVky/o01i6dB5qZtiwbYs/8I2nbt70Nf5s841KlRyYeOsaBJ/Zrq2J86bhjix4uDdl0HYsee/xmrBFn6waMnKJA3FyJHjhToOvv16IC2Lf/8IiPQHWDBCE2ABm+Env7gHXyWTH+jWOF8KFeqKLp3bAkxII8eP+Ol0V37DqFizeZImbko8hb/ByPHz4Cbm5tBJ16qPFi4bC3+bdgeqbIU0wyZmYY8feL7dxfUa9ZJ1SPeFJGPmTQb5Ws0VV4X8YC0aN9bxIbg5uaO7v1GIFPecshWsBKGjZwMV1dXQ773W9l+9eN3/TdU6Jn4Xb881SAeQ2EnIVf2LEqcLXMGxVNkIqjRoK3ilrtoVQwcPg5fv34TsQqy9KBbn+Fo2Kor/s5ZSo1RvErGY1SKnlGaVCkMdUv91lZWSJE8iReZjY015O937ALLyk2b9ykzFqFouTpImr6Q8r5t2rZHmvQ3/BUzhuqnHGeOg3uhReM62LbLwwvr4vIDI0ZPQb4S/0C8YFXr2OLoidOG+j59/gLhJB5zOU6k3ckzFhryjY8D8ah9+PhJ3c4V3cz5PAwc77fyf9emVC6M5I5HnSYdIF5jGfPKtVskS4Xf9Usp+RLJ3BUvkh/1alWFfZ8uOL53Lb58/a7dVh5j0P5d//RLhnbvP4ySlRtAGHToPggvX73BuYtX0KS1nToXxRP4+MkzQ73eOcgxaD9inL/nmRhnbbr0h7DMkKsMJP3q9VtVp9wp0ntg5dwX5pIvmYE9VqSsBPGoyjmj9yBL3QuWrJEsmHqOKmUtcp44HJ3bNYWcQ9quj/+JEsRXc1GiaAGULFYQzRvXRttWDbFzzyH8/PnTi77Mn3GQc9CLgredZEkTq2NfLjYWzhyLzBnTYfuuA0rr+ctXiqd8xv2tfQbIZ+Cjx09VnkTiPa70bwuIpzt/yeoQ77PcMZE7GNNmLYYwkbB15wGVlmNfPNUiW7Vuq1SB02cvwr/PIaVkFHlf0uBbH437aFSUSRL4YwI0eP8YISswhcDN2/dx6cp1FCmUx6B+8PAJdOk5VPsCqIXThzbDecJw/HfqPIY6TTLoSGLUhJlo0aQ2rp3eg/a2jURkCB8/fUZtzWj48cNNeU9i/RUT+/53FLMXLMfwgXa4e/F/+N/OlcifJ4ehjCRWaMaF6w9XjNY8qeJFESNn7cYdkuVn8N4PU/ov7UqfpFJT+iV6vwtiZPxTrw3ki1S4TR03FMu1W9o9Bzh6Kbp01UZt3Dlx8uBGTBxlj5Xal5R4P70oBWLHFHaBYTV64kxs2r4HQwd2x5VTu9CnWzuIkS5GUUC6aaF9quntiMGOE7RjYSVGafN8/tg2yC3V6vXbQo5HqXPS9Hm49+AR5kwdhcc3jmH5/ElImjiBZPkIwjpmjOjqdu67R+dx5eQuHzoi+F2boiNh9vwVaGfbGNKvhnWro123gbh3/5FkISD9UgX8iKJGjYLWzetj206PCwBRM7V/E6fNR/1a1TBMO49OnDqLjnb2GDB0nLpwHabN0cXLN7SLiWlSpZ9h6cpNyJc7O47sXg25QzFv8WoYn2fv3r9HjSrlcXjXKqxcNAWRbGzQtE0PZQimTJEU+7cuU3Xfu3wIwnzWZI9j/E+PlYZ1/sEI+x6QuwNSr4TmmiEaVOeo6rQfkXxm7d53GJUrlIROp/NDK3BinU6n2IkhXa9pZ1y7fhvrls7A7o2L8eTpc/zbqB1+/PhhqFwuYE6fu4RVC6fh/pXDmDJ2CKpULIWObZoo3sKlitZP2UaJEhkrFkxR8rr/VoGpn0OGxrwlTO2jt2LcJYFAE9C+GgJdlgVJwF8C8oCDeAMkiIetWuWyaKR9sesLTZg2D62123vypRovbmzk04zS/j3bQ74U9TqybVinGqpVKqNupcWMEd3wJfH23XtU0zx28eLGwcqFkyEfyKL/9NlLyC15MTblCz97low+DOXsWTKoD3epd1DfLihbsjD+O31BivsZvPfDlP7Pdx4N8dZKpab0S/R+FxYtX4fo0aJiwsiBEG6FC+TRPEidIQaueOH05WW9XbcOLSAGd5kShdGxdRMsWLpGnx3orSnsAspKvPQTp8/XLlK6Q/oqXtuK5YqjWaPamoff9D5fvX4Lq9ZtQ+kShZTHe87CVejZpQ1KFy+sjomRQ3shiWbQzl20Qo1f5iR1quTKMxYtalSId7RW9UoqLzCReNl/16a+3pZN66ixxo71Fzq0bowE8eLizPlLKjso+5U2dQqIkfXg4ROTmKgOaNFg7bxop3ki5Zzt3K4ZdmlGmuOQnpBb0k0b/Iu22rl7+pz/50zZUkUgxqWcj+KBL1OyCE6euajV7vFfzn0x/CQ/Z7bMyig+ceocrt2446HgSxxUx4ovVUO4S1/8++zwrZwpspYd+ihPqdxpeKwZn9PGeSxVMi4rn5XGQTz9xvn+pVev34bLV2+iVPFCkItxMWYnjx2MTBnSIlXKZJg8Zghu3Lqn3f046KUauRiWfLmY85Lxmx1TP4f8qiYgffSrDspJICAELAKiTF0SCAgB/RreDctnYoLTQJw4eVbdLtTXcf3mHcjbEow/4OXhD/mQf/rshV4NObNlMaQlIZ4B2Vav3xrp/06NedNHwdraWkQqyBfry1evUapyQ80DNUU9yCG341SmZ5QpQzrPlMdGvEmvXr/x2PEj9t4PU/uvr86Uful1/dvevvsAxYrkMxj4oit1y/bOvQeyUSFblvRqq49yZMuEZ89f4k8f6DKFXUBZ3dU8m2LIyPIW4+NBHqa7e8/D66kfh/etPBSoLyMPBGXTLma6d2yleW4fK2+WGF36MlZWVsoguKMxFFnNfypg0bJ1akmM3Mrevuug8pBJXmDCvQe/b1Nfb5LECfVJtU2YIJ5aNiA7Qd0vqVNCQPqXOdPfUkSFlMmTqq2sRVUJLRLZ8xevtZTf/5N6G2P8eLG1Mf4q8/DRE3TrMxyynEnmMH7qvGpJ08PHT/ys9E+OFT8r9cyQ8+h3nx2eqgHe9OraGmuXOmsXYLYagzfo0d/DW21c0eZVc9SaXP02ym/WyzqNm66MaGEndwjkQqRmtfKQz4FECeMjp3YRoa8/w9+pIeH23ft6kbafBnJxaRAEIGHq55BfVZraR7/KU04CASVAgzegxKhvMgH9Gl5Zt9aiSR20ad4A46bMNqyV1el0GOfYX90ik1tmxkGe+NY3FDlKJH1SbXU6ndrWrlEF/zvyn/JaKIFnlCB+XBzauQoN6/6Dz1++wmmcM0pWqo8XL3990VpZWXpqe2x0OqnT63o6j5xfsW/9MKX/+hpM6Zde93dbS0uv/bf0Nh7/yrsY3dL0T8+vPFPYBZSVTif8gWN718L4OJD08X3r/OqKksttaTEQdqxfgDsXDyqDwfj4ESNXKXpGVpZWnikoD+u+rUtRSPOS37pzTz1IJOueDQqBTPjXpr5KC1l7od/x3OqXYpTRPPJB1a9bd+5DvNfJkyX2bAUwpX9WRseYTucxP8bldDqP2+eGSn1JWFh4lPOa5XGeyYWr3GIXI3jp3El4fvsk3jw4qy5ef7i4ei1itKfTedQZmGPFqBpfk0F5jnpvQC4UZV4H9u6M2VMcsXbjdly9ftuLmvH6XUl7P8+9KGs7+ofW9m1ZiodXj2he3MGa1OO/sRPAQwJ4ry9K5Mj6rEBtvddnGYDPIWnQlD6KHgMJBAUBi6CohHWYLQGz6tiXr98g78796vn+3Myal3Xf/44Fuo9d2zdHc+2Wt3h6r9+866Ue8Z610W65Og3pjWN71uLBo6c4ZXQr1YtyIHcC0/+g6Jfcor5w6ZqXXp89d0Xtp0mVQm0lkjWWstWH8xevImH8eJAlDnpZSG1/CRHdNAAAEABJREFUxypt6uTKY733wNEAd0k8VGIcFMyXSy1b0FeQKkVS9QV/4ZIHG71clg2k0W7z6/dzZM0EWfoxc5IDFswcA/Hyvjd6ZZReT7ZiILj/dJekr8HUNn0t7E0YkH55K2rY/aJd8MkSoWaN/lVLgYKyf4ZGApmQuziylrph3eqapzE1IkWyweVrN5VXXl9lpEiRVNLd/RfztH9wrKjKPKPIkW3w093D+PYUqU1QnKOqIhMiMfpNUPNTRf/QWu6cWRE1ahSDnnwOyMNfwlgvfPX6LcQrmzZ1Sr3I120km0gwpV9ptXPIlM8hXxvRhH/SR604/5NAgAnQ4A0wMhYwlYCsJzt09CQk7Nj9P8xdtBKy3jRG9Giqih5dbCFPBDuNm64e1pEvNVnXJQ88KQUTor527VC7RiUYG73ygxHyBLwsjZAq/nfkpPIqp06VTHaDLAS0/0HVL/HqyHpMebOEfInJg37DR09W66Pl1UT6AcoavknOCyBvrth78CimzV4M8bTr80Ny+ztW4jmUtbbjp86FPEH/5u07td50zYbt6tVagemrrOlu06K+8vAfOX4KUufoibNw8fJ1tG5eX1UpT6Pv3HtI3UaXJ///d/g/JNJuBfu1njFtmpRqnaQq7EtkSpu+FPMhmjZrMQLSL30Fcq7pw+bte9WbSyJHsoa8Dkp0gqp/UtefBlnCkTRJIuw9cERVdeXaLbW8wdhrKF7pSJohfOnKDaUjUeCPFSn9K6TWLg4fPHqizg+9NDDn6PlLV9VnnBiYX7+5qLTMgSzRkXplHuWYFtm2nQfUG2HkjQnyzELG9GlEJciDrEWXJUxdew+FOAPkYUi7fiOQMnkSVCpXwt/20mifk+J5ls9j/xRN/Rzyq44/6aNfdVJOAv4RoMHrHx3m/REB+UUdeXCtZsN2GDZqEiqVL6neyauvtFD+3Or2szwsVrpqI2TKUw7jpsyBi8t3vYqvW733Qb8dYd8D/1Quo4xeWZ8WPXpUiMGQLEMhtb6tXbcBGDOiL+SWoq8VBlIY0P4HVb/Eq7Nl9RycOnsR8koyGV+ZkoUx1sHrez1bNqmjGXfXkCpLMWVI1K9VFT06twrkaP+smCms7Dq1xKC+ndVDi9kKVEKxCnWVsRvNyHMV0F4M7d8dNaqW08Y/DDkKVVZLYDaumIm0nl4uN81z2KnHIMiPNUjYunOfdrvZSXlDfWurc9tm2rG1SB1X8iot33R+16ZvZbzLAtovfXk53+Q1UbKeUx4C/KdKORzauRr6i0zRC4r+ST1/GsSwXTpngvpFw0JlaqF+iy7o3a0tjOdb+t29Y0v8U6+1Yq5/LVlQHCulihVE9qwZIeeHrIGV15IF5hwdOGwchLtcZD94+FilZf+V5zMBUaNEhvPsJUresmNvHDh8AvX+rYIlc8bDt2Utf8pVyku9K+ZPRvTo0VGjQRuUq95EHdNrFjvDxvP1gqLnW2hUrwbuP3iEOClyKeZiMPumZ+rnkG9lRfYnfZTyDCQQUAI0eI2IMRk0BOQBMFl7qQ+v7p3G0T1r1WuAvP96mdyKXr9shlp7ef3sXmxaORvy/lB9T6Rs2ZJF9LtqK8aT1B3Z6IGO0cP7qdeWiSEj6+Rk3afoSLh3+ZDm0Wugykq0Zsl0L22ITB6wWzhznCRVuH3hIOTdlmpHi3zrhybG7/ovOvrwu37p9bxvM2dMp9a1ikdInyfrVoXVg6tHcObwFgwf2EMtCdDnyzay5hmbM3WkKnvx+HYM7tdVrY+UvN8FmYtuHVr4UDOFXWBZ6XQ6yBKVPZsWq1eEnfrfJsgDjzWrVfDRD71AXqMkOvp971v5cpc1kycPbsLDa0chFwpyl0Gv16VdM9w8t18xkmNF9GRO9fnej4NK5UuoekRX/1oyeZPB/3au1BdRBoV/bYqib4ykDqlL8n/XL9ExDvImBOmThNf3z+Dyfzuxd/MS9YCU8XkiZX7HxLfzS9bhS91SXh/k9VVy/On3pe8yBv2+KcdKzuyZ1UWvrMe9cGwbKpQpBqlT6tbX09euvWF+9K8l0+kCfqzoGenrFYNLjh0ZlwR5LVlgzlFZPy7lvQfxXktbcjwd2rVKjeHZrf8g623lXJTlRZIvwXvfRPa7IK/J69O9rZ9qcqdCHui9emq3OsYXzhyr3q2tLyAXv9vXzdfvGrbyS2jymaIfjzzoJplPb55AxbLFJWkIv/sckjZlWZm+wELtM1Y+a/X7v+ujXo9bEggKAjR4g4Ii6yABEiCB8EWAoyEBEiCBcEWABm+4mk4OhgRIgARIgARIgARIwDuBwBu83mviPgmQgNkQ8O12stl0jh0hARIgARIggRAmQIM3hIGzubBBYPmaTYiXKg/evnsfJB1esnIDajRoi3FT5nqpT57erlK7Ff7OWQq97Z3Ua9v0Cs5zlkIe5pMfYzh15oISy4v6u/cbgQy5yqi8w8dOKblELi4/VB1Sl7zAX544F7n3IE+Ll6/RVJWXB3X0+aaUF51sBSuph1kKl62FqTMX6Yurny6VMVao0Uy9VF/eemDI9CUhT+Xv+99RX3ICLvKvXwGvzaPEhcvX1DjlgSYJPQc4qQzf5kAy5CFKmUN5wGr0xFkiUmHE6Ck4fvKsSvsXBSUPfTvy5oDEfxeA8Tzr8wKznbNwheFHIgYO91jzfvL0eciDX/LQX+VaLbFr3yFVtbz3uklrO3Xcy6velFCLGrbqCr9e+6Zl+/pf6pI3G8gDsE+ePvdVJziF8saXhcvWBrgJ+eEUv85DUyt79fot5Hw1VZ96JEACvhOgwes7F0ojOAF5pZM8kLFh864gITFx2jysXTLdx1sS5DVB65Y6qwfP5HVL02YvUe1dvX4LYlxsWzMPo0f0RQc7eyWXB23kBzzkobLxTgPQqedgyJexZMorvW7dfoDdGxfjwZXDyJ8nu4i9BFdXV62uQZgyZii2rJqDCdPnQV5xJkqmlJcfndixbr56AGfutNFYvGIdbt25L8UxcPh41KxWHjs3LMTrN2+xZsN2JfcrunbjFg4eOuFXdoDk/vUrQBV5U5YHF/UP74x16Kdy/ZoDecfply/fIA8THj52EvIzw2JwPnr8HPKOYFXYnygoeeibGew4CWXloU+dXhL47f+O/Iepsxarn+R++/AcWjSurSr7O11qnD+2Dc9unUC/Hu2hvzDYsecgKpYrAXlbwIx5S5Xueu18Kl28UIB/3Wvbrv3ImjkD5AFXeU+uqiwEo0+fP2PJyo0h2CKbIoEwS8BsO06D12ynhh0LLQJvNa/uxcs34DioBzZu22PohrxXuFnbnsrbkjF3WfVeV0OmZ2L2guXKc1qqSkPMW7xKScXr9+jJM9Rq3EH9qIESekZFCuZVL9yX1y+VKFpQvUZMsnbvP6KMR3nCPnuWjOr1Qlev34Y8+Z0pQ1pRgfxsqPwy1L0Hj9T+irWb4TC4B1KlTKbe2GD8a2NKQYvkxyeSJ00MefJaXlRfrVIZ7DlwWMsBTCkvxp70QQpI2/JqKXfPl/fv2X8YtWtUkizUrVkFu7V9teNHNGn6AsVXvML7/3cM8t7SHv0dUaZaY1Sp3QrH/jsD+Vu1biuatumBfxu2h3evsuRL8K9fkh+UQcbv2xzIWzE+fvqk3un744er+tEL8fT27t7GpOa98xBPcoOWXSAec9k+1o4hqahb3+Ho2nsYqtaxRcnKDSDsRO49yDutUyRLjDSpkgM/vecGfH/Fmi3o3LYp5C0OOp0O8kYUqUV+yER+/MPa2hqxY/8FLUvEiBwpEj5+/Iz3Hz8iSuRIEC/88tUbNUO5jsr3LfJtzKfPXoTznCVYuXYTmrfr5aWYMBEGzdr2UK8u+/r1K4Y4TkTJSg1QrnpT7NjzP6Xv3zHk2znrvd4JU+fixs07kGN1yoxF6r3evrUjjU3QLm6LlKuNuk074u59j3NT5Pog50WH7oP0u5CLgD6DRsLd3V0d98Ur1FN9l3dHG5Q8E3IRLK+b89yFfM68e/9B7cr5K+eOyMZOnqNkjEiABH4RsPiVZIoESEAIbNmxDzWqloW8Buz+g8d4/vKViNWXbuvm9bFrwyIc3bsG0aN5/ICGytSiazfuYNb85coLJd5c+WK8cese5JVp8pJ9eQWSvNZKU/XxX26Hz9VuF5cokl/lPX/xEimSJ1VpiVJq6SfPnkvSEE6cOofnL14hg+ZhE8/ta+3Wp7SZJlsJyK1kfb8NBbTEs+evkCJZEi3l8T9l8iRqKYKp5aWU6Mot/rTZS6BL++ZIny6Venl/rFh/IVrUqKICeTXdk6cvVFqMDf37U5XAM+raoTmqVy4L4VJK8/otXbUBr16/gbyWbNiAbmjf3V4Zj6J+TzMcls6dgH1blmH9ll0QriI3Dr71yzhf0vWbd/ayTEHGIUEMCcn3Hg5oHuiEafOhVqP2kCUH3vON50DeS5o7ZzbVb/lls8tXbyBmzOiawfnr1++8lzfe985j6MjJKFGkoPKYF86fF8NGTTFWx+ZVs7Fk9nj0GuikjCXjzB8/fkAMr97d2hqLfaQDwkOOv1NnLqnlNGX/aQIxRPUVHjh0XHGtVLM5ls+brMQ1qpbXmN2EvKd2YJ/OmL1ghWbs1lUXAkrBl8i3MefJlU2Va9qgFhbMGOOjlPwoxZD+3ZRnfZ3mQf6gGdm7Ny3CygWT4TB6qjo2pZBvx5Bf56zoG9fbvVMrpP87jTpWO7dripXaRZhv7Vy+ehMr1mzGjvULMXnMEJw4eU6q8hLEw334+CnDL8rJ3aSqFctoFwo6TBw1CPJqt1mTHdDbfqSXcv7tyF2WeYtXq7tIuzcuwtXrt7AviJYL+dcu80ggLBGwCEudZV9JICQIbNq6G/9Wq6iaqvtvZeiXNeTJmRVTZy5U63DFcJT3mSolz+jkmfP4RzPgxNsVJ3YsyO1wkXlm+7sZPXGW8uI2a1TLoKfT/boPrdP9SovC02cv0KXXUMh7ScWzJrKPnz4jb+6s6vayeI6HOU0WsY8g3lC9UKf7Va+p5WXphdzmP31ok/blvgXyS1NSn4XFr7p0ul/pEsUKoHvHVqLibzh5+iKaNKipvvjFyBEP8sNHT1WZIoXyQH4lTDzexQvnw+lzF5TcOPKrX8Y6KxZMUcsxpP/GwbZZfWM1lU6bOgUuntgBeY9pYc0T37SNnZLrI9/mQH7uWuakfq1qGDd1Dnp0tsWi5evQb8hog8daX/53W/lhkWYN/1VqLZvWhvyintrRojIlCytOYmTHjRMbjx4/06S//k+bvQStmtZVzH5JfaYCwkM8kNbWVvjv4AYMH9gdxhcx8p7eV/dOQ5bndLCzV2vR5fyYPGaw+iGPxAkTQC4OihfNBznWhzpNwsNHT3x0yL8x+1D2FGTPmhHy7ljZPXbiDOSno+s07YSWHfrg1Zu3uK55ZiXPt2NIzk+/zlnjeqW8cfCrHWm7RtVy6oc+EiWMjwre3lsrdchdEfnRi937jqhlL6fPXUTRQpATzLEAABAASURBVHnVfF65dhPtu9mje98RePrspcFYl3L+BWH76tUbiAe8dpOO6kLj3IWr4J/5E2APQ44ADd6QY82WwgABWc6wX/PqyW1B8fyNmjATm7btVT1v0aSO8tYmShgPYvzc07yOKsMoEqNLvyvGgXhu9ft+bXftO4Rbd+5pxquD4ZeXEiaIr3k73xqKyJrYJIkSqn3x3nXvNxxTxw5Bgbw5lUzalSUMlcqVVF+25UoXwdUbt1VegVI1IUEemJO+v37zRsklevX6HWRNpKnlpYw+pE2dEtmzZMCZs5cgt7U/fvxk8Mi+fPVaqzeBUpUX7OuXACiBP5GVpaUh19rKWrsT/1Pte+f400Os8rxHxv3ynhcQj6Z4q2PGiA65eJGX9Lv8cMXrN+9Ulb7NgcrwjMRrV6xQPshSFnlIcEi/bug/dKxnrmkbGbOVlQePSDY2Xgp5H7/oGivsPXAE4uWXY3iS8wLIMogZc5cZq6h0QHgkTBAP8nOwckFXKH9uuLq54f2Hj6oeieQYkrsisr2n3RkRmT6MnTwLPbrYYsmKDUgQLw5q1ajkw2MtujIOv8Ys+b4FYzZSfmDvTpC7BhLkYkV/jkiecXk9Q+mvXm58zhrXq8/Xb6Uu39oRuYWFx5yJrnHdsq8P1SqX0T5X9kCtc9aMYp1Oh7PnL2Ph0rWw0y6S5MIhWZJE+Pz5i76I2lpZWnnx5ru5uim5tFuzWnnDuOWHPOw0r7TKZEQCJKAI0OBVGBiRgAcB8ea2bFIbxt6/Z89faB60p+rLPUXyJGhUtzrkgTa5HepRyiPOlzuH9iW2V+m9eftOS+9B/jweBqmHhs/46InTmKPd6p0+fhiMvxzLlSqKbbsOwNXVFbKsQm71i9Eo61w72A1St3jFuDCuUYxd/VsbjmqerqyZ0qvsE/vXQ4IYbTmzZ4Y8XPVU8xDLmsoduw+ifOliSs+U8rK2UcpKARnj/46ehHjCZF/WIO/Y7bFmUi4SypYqImLI0oqr1z2MbyXwjKJGjYoPmlfacxf58mTDkpUbIF/e8uX/8tWv5Rc79xxSxqasV9y6cx/y5squL6a2/vVLKXhGAfFoftAMeM9ikDcRyDrUuHFiqbXGfs2B6IsxvGjZWrTULpDcNKMwvmbgRYpkg+jRokL+Ll29gY1b90jSS/DBI3d25R0WpbmLVhkubmR/5brNyvA5d+EK5NhIljSRiA1h86o5hmO4a/vmmDjSHu1aNTTk6xMB4VGhTHEc0Y5XmZ/rN+8isjYmMX7lNr48oCd1yrIPOT5Sp0wmuyrcvnsfnz59QY6smbQLInfEixtHM3rjav33edWSz58xq8p+ExUtnFe7C7MI+gc55e0mcpxLMd+OoXwmnrPRo0XDByPj3q92cmt3geSclvZkiY0+LfvGQTy8B4+cUOt3q1Uqq7Ju3bmvfa5kwt9pU+Lu/Ye4cv2WkhtHKVIkwQNPz7h8Lty4fVdlF8qfC2s37dQunO+rfXlY0rcLcpXJiAQiKAEavBF04jls3wnIQ2pVKpT2klmlQils2LJbrZX8O2cpzbvbA2LElClZyItexvRpNCOnNuTVSfKAWtuWDZE+XSovOt53ho+ail37DiN+6rxqDaQ8FCM6Ytz+W60CytdohnbdBmLy6MEixqFjJ7F6/TbUa9ZJ6YsHTzyIkjmwd0es2bBNPeS0Z/8RDOrbRcRegqXmQR3vNBDN2vVExX+bo3mjWkiWNLHSMaX8t+/f8U89W9W2rBUuXCA3ZPmBVDDC3g6zF65Q7et0OtSuXknE6k0ME6bNVWnjSG7jfvnyVT3cIw9eNapbA3/FjAlZHypvfJikjVn6K2WyaZ7k2k06oNK/LSBrOb1z9a9fUj4wYdmqTWqcSdMXwrgpc7BgxlhVjX9zIAqylrJpw1qwtrZWRt6t2/cgr+uSCwLJP3HyLC5evipJL6GodlvbmMdgbf72aJ5aeWjtwOHjsO/TyaAfP25clK7SCN36DsdYh/7+ros1FPrDxL//VIAY/fJgVM8BDpg52VHVKIZVprzlFKsKNZpiUJ/O6kFMlalFcpdE3t6gJdWDmGOnzEbtxh2gX64hcn3wb8x6Hf+2spSkQN4cqFbXVj3gaD9igkHdt2PI1HM2unaxUrViKTSy7QZZJ+9XO3KRKcs7ZHxN2/ZANK2coQNGCTmu5UJTXldXpGAelSPLHw4c/g/yGTDZeSHk4lRlGEVy10AuMERnysxFSKfdZZFsuash7DpqF8OlqzZSdXz99k2ywlfgaEjgDwjQ4P0DeCwa/gjIbdASRQt4GdiwgXbo1LYpZG3mzXP7sWjWODgO7qUMGi+K2k7r5g2wb8tS7N+6TDN+62oSj//nj27zSHiLt3u+4kvvUZb29SrtbRupukRHb1SWLVkEel39tljhfKqI3HpfuXCqeshp4cyxmicttpJ7j+S29K4Ni1TdzT1fLSU6ppSXL9aTBzcZ+iAcpKwEWRoh/d+5YaFmhPUzeKzr/ltFsRMd4yBGxMxJDli1aBrkoTXxgo5z7I+9m5dg65q5kNvmen3xeglTuVUrc6GX67f+9UuvE9CteESF8eMbx7BiwRTIRYjU4d8cSL5c6FSrVEaSal2mjG/b2nnoqd3SF+G5C1e9HBsik+CdR/JkSdQDYMJz+bzJ6g0doidBbokf2L4cB7YtV+xE5lcYOqA7jOfZL73fyS0sLNRxL8e3eJDlLSFSpopmCN67fEgdEw+vHUW9WlVFbAhy3sixIQJZdiN9lgez5DgUmXHwa8wyF77Nu7wxQ84PfR06nQ79enRQ59/RPWsheTY21irbr2OotS/nrPd6pQL7Pl2wdM5EyENrOp3f7XTv2BLywy/L5k5Sx7Ks5Zfy3sOk0YNw4+w+dYxIniyfkWNfziHJk4c3pR/x4sZWD8qKjlxEyUNpoiOvyTu8e7VaTiR5NbULZDlWZH5O/W+TdrymEzEDCZCAJwEavJ4guAkXBDgIEjB7AlPGDoHeADT7zrKDJEACJBBOCNDgDScTyWGQQHglIB5i8a6F1/EFdFyyHle8zAEtF5H1I+YxFJFnnGMnAZ8EaPD6ZEIJCZAACZAACZAACZBAOCJAgzccTWZAh0J9EiABEiABEiABEogIBGjwRoRZ5hhJgARIgAT8I8A8EiCBcE6ABm84n2AOjwRIgARIgARIgAQiOgEavKYeAdQjARIgARIgARIgARIIkwRo8IbJaWOnSYAESCD0CLBlEiABEghrBGjwhrUZY39JgARIgARIgARIgAQCRCCYDN4A9YHKJEACJEACJEACJEACJBBsBGjwBhtaVkwCJEACAAiBBEiABEgg1AnQ4A31KWAHSIAESIAESIAESCD8EwjNEdLgDU36bJsESIAESIAESIAESCDYCdDgDXbEbIAESMB0AtQkARIgARIggaAnQIM36JmyRhIgARIgARIgARL4MwIsHaQEaPAGKU5WRgIkQAIkQAIkQAIkYG4EaPCa24ywPyRgOgFqkgAJkAAJkAAJmECABq8JkKhCAiRAAiRAAiRgzgTYNxLwnwANXv/5MJcESIAESIAESIAESCCME6DBG8YnkN03nQA1SYAESIAESIAEIiYBGrwRc945ahIgARIggYhLgCMngQhHgAZvhJtyDpgESIAESIAESIAEIhYBGrwRa75NH20IaC5dugzLl6+AtbUNg5kwsLS0hJubG+fDTOZDf264uLjAysqa82JG8+Lu7g6dTsc5MaM50eks4O7+k3MSSnMSAmbDHzVBg/eP8LEwCZAACZBAeCfA8ZEACYR9AjR4w/4ccgQkQAIkQAIkQAIkQAL+EKDB6w8c07OoGVgCeSKtwuWVVRnMhMHV1dVxe2MdzoeZzIf+3Li3pT6urKrGeTGjebm1oTaur63JOTGjObm+tgZubahl9nPy+samwH5lstwfEKDB+wfwWJQESIAESMAbAe6SAAmQgBkSoMFrhpPCLpEACZAACZAACZAACQQdgdAweIOu96yJBEiABEiABEiABEiABH5DgAbvbwAxmwRIgASCjwBrJgESIAESCAkCNHhDgjLbIAESIAESIAESIAES8JtAMOfQ4A1mwKyeBEiABEiABEiABEggdAnQ4A1d/mydBEjAdALUJAESIAESIIFAEaDBGyhs5lmocdt+GDBi8h917sPHT6jXqmeA6mjTfSguXL4RoDJUJgESIAESIAESAPYcOIbOfRxRtHITNGrTG4tX/npPr995Psk9evIcrbsNRtP2/dT2ybMXSunL12/oO2wCbLsMwvAxM+Dq5qbkb999QMvOA+Hq6qr2w3tkEd4HGFHGd/f+Y7j8cMGZ81chB3dEGTfHSQIkQAIkQAJhmUCc2H/BYWAX/G/LQvTpaotZC9fg6o07akj+5SkFo2jAiEkoU7wgFjk7adsCGOQ4VeUePn4Gsf+KiTmTh+Hzly84f+m6ko+btgBd2jSGlZWV2g/vEQ3ecDLDu/YfRaWyxZE/TzYcPHLKMCqnCXMwdPQMdOrtqDy3u7UrScncue8IuvUfreQNbHth6pzlIvYRRK9J+/5o3K4fJjgvgpu7uw8dY0Hdlj0wedZStLMbjq79RuHlqzcq+83b9xjgMEXVU75WWy99VAqMgpwAKyQBEiABEjB/ArlzZEbMGNFhYWGB7FnSI2XyxHj81MM761+e8ciePn+JW3ceoGbVMkpcs2pZXLp2C6/evIONjTU+fvqMnz9/4tPnL4gcyQb/nbmISDY2yJkto9KPCBEN3nAyy3sOHtcM3iKoWKYIdh846mVULj9+YPLIvpg5YTCmz1upDnhRePz0OUYN6Y7FM5xw8/YDnDh9UcSGcP/hUyxYvgmTHPtg0XQHfHdxxeYdBwz5fiVSp0yKGePtUbdmBSxZvUWpTZm9XF1hLtHaWrdoArJkTKvkjEiABEiABEggmAmYVfU/f7rD3d3N1yDe2AePniJ39gw+8v3Le6J9nyeIHwfWVpaqnGwTJYiLx0+eoljBXJpBHQ39hk1UBnXa1MkwdfYydG7TQOn61ZeAys0Ksi+docHrC5SwJrp87Tbixo6FRAnioWDe7Lh55yHef/hkGEaRAjnVlWOsmDHwd5oU6ipQMnNkzYBoUaOo2xlS7tLVWyI2hPOXrmm3P76i/4jJ6NDLQd0GuXLN4zaLQcmXRNECuZVUTrZ7D56q9JnzV2DbpKZKR48WFfHixgb/SIAESIAESCCiEXB1dYOLi4uPcPHydYwYNwNOg7oiapTIXvL9y5O6XD3X4UpaH4Trjx+u+KE5vbq0aYghfdqhab1qmDFvFeppDim5Azt26gKMn7YQd+499NKevo6AbKU9cw40eM15dkzsmyxnOK+dKIUqNEbhik3w6vVb7P3f8V+ltdsYv3agbmvIvjexQS55Kuh0KFYoN2aMs1dh+exR6G9nq7L8iywtPQ4rHSzg5rk4HtqfWa8T0vrH/yRAAiRAAiQQ3ASsra0ROXIUL+HNu48YNXkpidv9AAAQAElEQVQBpowcgCIF8picp68nRfKkePf+IyJFiqzK2thEwus375E6VXK1r9d7+vw17j54jCrlS2LUpPnatgTKlSqCMVMWeNHT6wdkG9zc/rR+D8vkT2th+VAj8FOzWncfOAZZJnBs5xJIGD+iF/YcPGHo05ZdhyBPZd57+BQXL99EOs3LK5nHTp5Ta2y/fvuGbXsOIVvmdCI2hLw5M+PA4ZO4ffehkskTnbe1q0C1E8AoV/ZMmL90vaGUrCMy7DBBAiRAAiRgNgTYkZAlIN+rvYeMh6N9V/ydNqWXxv3Lk2dj9HdmEyeMjySJ4mPvQQ9n1x5tmyFdKnX317jCkRPnoG83D8eV+093JIwfF/HjxcZPY6VwmqbBG8Yn9vT5K0igHbBysOuHIg+uiZEqi9VFJgd00/b90XfoeNh1bIoY0aOJGOnTpoKd/Vg07zgQBfJk00J2JddHSRIlQI+OzeAwfjbkwbWmHQbg3bsP+uwAbWWt0LMXr1U9pavb4sTpC+AfCZAACZAACUR0AlNmLcW1G3dQu3l35C1dV4W1m3crLP7lnTp3WS2BUIpaNGpID6xYtx1N2vXF6o07Max/J0366/+aTbtQKH9O6O2F5g1qoK3dUPVKtGb1q/9SDKcpGrxhfGLz5syCBVOHexmFpYUFdq6ZgXhxYim5LEtYNmsUVswZg3IlCymZRMmTJsJiZ0esnDsWnWwbiAjypKjsqx0tKl0sP+ZNGab0Ni+bgjxae4CWYfR/1oTBaiG8iFbNG6fqkHSaVEkxdXR/SaqrTHntirS3b+McyKtTVAYjEiABEiABEojABCY69sWpfau8hFrVyiki/uWVL1VY+14fq/QkSpYkoXr12OIZIzF74lDN45tAxIZQ+5/yECNXLyheOC/WLpyoQpECufTicLulwRtup5YDIwESIAESCHYCbIAESCBMEKDBGyamKfCd7NfdFuKl9V5DhdJF0KNjU+9i7pMACZAACZAACZBAuCNgEe5GZH4DYo9IgARIgARIgARIgARCkQAN3lCEz6ZJgARIIGIR4GhJgARIIHQI0OANHe5slQRIgARIgARIgARIIIQImJ3BG0LjZjMkQAIkQAIkQAIkQAIRhAAN3ggy0RwmCZBAmCPADpMACZAACQQRARq8QQSS1QSOwBPXzIifpQGDmTCIl7k+Ymeow/kwk/nQnxux0tfinJjZnMTJWAdxM9XjvJjRvMh8xMlY1+znJGrcDIH7wozQpf588DR4/5wha/gDAk/dsiJB1kYMZsJADCz5wuCcmNcxGSu9XIQ05HliJueJnB9xMtaDXCBKmsE8zpd4mRtA5sXc5yMKDd4/sBoCX5QGb+DZsSQJkIAZEWBXSIAESIAESMAvAjR4/SJDOQmQAAmQAAmQAAmEPQLssS8EaPD6AoUiEiABEiABEiABEiCB8EOABm/4mUuOhARMJ0BNEiABEiABEohABGjwRqDJNsehJra8hBeXljKYCYOXl5fjzbVVnA8zmQ/9ufHuxmq8vLyM82JG8/Lm2kq8urIizMyJm8snc/wKMIs+sRMRgwAN3ogxz2Y7yiRWV7Qv8uUMmqH50gyCfIG/vS7GFefEHOZD34d3N9byHDGD80M/H7J9c201Xl9dGWbmxc3lo9l+D7BjJBASBGjwhgRlthHGCbD7JEACJEACJEACYZkADd6wPHvsOwmQAAmQAAmEJAG2RQJhlAAN3jA6cew2CZAACZAACZAACZCAaQRo8JrGiVqmE6AmCZAACZAACZAACZgVARq8ZjUd7AwJkAAJkED4IcCRkAAJmAsBGrzmMhPsBwmQAAmQAAmQAAmQQLAQCNcG775D/6FQhcZ48OhZsMCTSqUNpwlzJBmo8LtCx0+dV2OQcejDzn1HflcsVPLfvf+AIaOc0bhtP3Ts5YABIybj7v3HodIXNkoCJEACJOA3gX2HTqB5x/7IX7Y+5i5Z50WxZpMuyFu6rpcg30VelLSdHz9c0W/YRJSv1Vr7nmqoSX79v3X3gfY9MAK2XQdh+dpthoz/zlzE8DEzDPtMkEBIEQjXBu/eg8eRPm1K7Nh7KNh45sqWEQ1qVQ62+qXi/Lmz4djOJYZQoXQREZtd6DloPP6KGR1LZjph2pgBsOvYFG81I9jsOsoOkQAJmCMB9ikECfwVMwa6tm0C375P1i+ejFP7VqmwyNlJfa7L95Bv3StaMDfGj+jjI2v1hp2oWbUsZk8ciiWrNsPN3R0uP35g+tzl6Na+iQ99CkgguAmEW4P3u4sLTp+/AoeBnbFr/zEDR/GO9rAfg679RqFm027aibgVy9ZuR6sug9FB80p++PhJ6b5++w7ioWzcrp92hToYl6/dVnIp363/aHTq7Yi+2pXt2YvXDFevb96+xwCHKZAy5Wu1xcEjp1SZtnbD0KB1b+X51Msko27LHpg8ayna2Q1X/Xn56o2ITQpXb9xR9bm6uakPkToteuD2vYd49fot6rXqqfrWtP0AtdWPSdqb4LwInfo4Yf/hk5A62vUYjibt+6On/VjImKXxeUvWo33PEajeqAvGTVskIqUvzBq07oOGbXx+uF24fAPPX75G59YNlL5EcWPHQu7smSSJdZv3oHkne8Vm9qI1SsaIBEiABEggdAjkyZEZubTPZ0tLS387sH7rXlSrWAoWFj7NBWtrK1QpXxzx4sbyUYeNjTU+ff6Cz1++wsrKEjpNY86itahXsxJiRI+m7fE/CYQsAZ9HcMi2H7DWAqC9938nUCR/LiRLkgix/oqJK9c9DFap4tnz18oQnj9lGJau3oLIkawxd/JQzTjLiPVb9okKpsxajpya93bJDCfY92yn3aqfruQSPX76HKOGdMfIQd1k1xCmzF6O2FpbUmbdognIkjGtyuvTpRWWzx6NCQ69MHXOcnz99k3JJUqdMilmjLdH3ZoVsETri8i8B7kFpF/OINvrN+8iU/o0KFOiIOYv24CZ81ehXMmCSJsquSoqSzhaN6mFRc4OSJs6uWbQ/7qdlDxpIkwd1Q/FC+fB0NHO2hV+Iyx2dkS5UoUwacZSPHv+Ckf+OwfnsQOxcelkNKlXVdU5VRvbyMFdtXGMwiTHPkpmHD149BRZMqTRPtisjMUqfefeY8xduh7jh/fUrvYHQ5aBHDt5XuUxIgESIAESME8C4pHdte8Iav9TPsAdbKV9Bx0+dlotX+jZqQXkO0K+hyuVLRbguliABIKCgEVQVGKOdezefxwVyhRWXatQurDm5T2q0hJly5Ie0aNFVYZwXO3KNF+urCJGpgxpce/hE5U+p3ludx84BvGAOk2cg1dv3kHvgc2tXRlHixpF6RlHZzSPsm2Tmkok9ceLG1ul7z18rBmXM2DvNA0fP33G4ycvlFyiogVyywaJEsTFvQdPVdp7JLeSjJc0ZPg7tVJp3uAfHD95AcdPXUTLRh7tSkayJAmVoSvpEoXz4tLVX8Z+yaL5RYynz15oHtk3mDRT8zBrXt61mgf22s07iBsnFr5/d8E07bbTKu2WVMwY0ZV+tsx/Y+yUhVi4fBPcf/5UMh+RTq7hfUhx/vI1lCyaD3Fi/4UokSOjcrniEI+wT01KSIAETCVAPRIICIHv37/h27evPoKbdpfQ1fWHD7nobt6+D2k1R0q8ODF9zRcdCVK39EXS+hDZxgojBnTC0L7tkS9XZjiOn4WenZri0LGTWnomps1Zhtdv3vhbr74uU7fSDxeX70Fap6ltU++rHAJmHSzMuneB7Nz7D58gXlG5BS8e0fHTF2kG7zH89DTUrK1+eSEtLSxgbe2xb2mhg6urK/R/o4faYcY4exX2b5yL+PHiqCwba2u19S2yMqpb8mXZwPK129GkbjW1rjVd6hT48vWbZKlgaekxBTpYQD54EIC/Zy9eQbzNrm6uXoxQ/TgNVXmOW/ZtPMcK7QZT4oTx1NhkjLMmDMaqeeMUiwXTR6Bwvpy4dechBjtNhfwN6dMe9f6tiJ/aP1nO8U0zikWuDymSJda86Hfgqn146mXGW2vtlpZ+30q7hSb16Pe5JQESIAESCF4CVlbW2ue7jY9goX0HWlhY+pBbW9tg257DqF65tK95kq8PUrf0Xr/vfbt55/9QMG8OJEwQHyMnzkOn1o1gY2OD1Rt3/7Zu73X5ty/9kOCfDvN8HgNBxUSOgVAKJjXrYW2ZpBp2lORhNfHqGntFkyRKAPHAmjqKfLmzYsb81QYj+dS5y78tKuuh5i9db9CT9Uv3NY9x+nQpkSZVUnzQDPHLRksrDIqBTAweOR1tmtaGPDQwbc4KQy2Pn77QvL4eSwbWaB8oWTJ5LK0wKGiJJIniQ4z7ndrtKm0X8rSteF2VMa4ZyDKWti1q45Ln2mXxTKdPmxLNG1SHlaUFnr14LcUMIbvmNU+gXRAMGekM/Vpg2Z65cBU5smTEwaOnIWucZTnHtj2HIA/7GQozQQIkQAIkEKwELDVHg29Bp9Op9bne8x4+fqY5PR6gYtmiMM57+OQ5HmnBWCZpaH+y9R7effiI7dpnfrOGNVQ7kSLZQO4cJoivOZC0tr3r/+m+hWbA/2kdLG/pZc5N5aEdAmb938KsexfIzu0+eBylPG/d66soXbwAdh04rt/97bajbX24uLigSbv+qNawM9Zv2fvbMp3bNFCGoDwEVrq6LU6cvqCM0ctXb6Gt3TBMcF6MzOnTIKB/4q0WT7U+rFy/E/IgQYzoUfFvtbJo37IeTp29jPOXrquqUyRLhBXrdqKBbS98+PQJjWpXUXLjSD4UHAZ2wbbdh9GswwD8o41RjNtnmte41D+tIGMYP22RdguquSrWsE1f1GzSDfIgX7mShZEqeWIlN47GDrODlebJte0yBPLQm5SXNc1pNGO/SZ2qsLMfi9bdhqJ4odwokCe7cVGmSSB4CbB2EiABLwTWbt6tXju2ZecBOM9bodLGTiH5jqlQuggiaZ5Y44Ir1m7Dqg07DKKKddqiav0OymkirzJrZzfUkCeJsVMWwK5DM1haWKi6ShTJh8Zt+0Cen/m3allRYSCBECEQLg1eeeCqmGZUGRNsWKsS+nVrBTmBe3RsashaON0BiRLEU/tyy2V4/04qHStmDAzq1Q5LZjph87IpEONQMryXL10sP/p1t5UsyFsJRE8eAtu3cQ7KFC+o1govmDYCM8cPwrB+HdWyBvGGSgFZQiBXupIWo3Dq6P6S9BKkT8aeaknXq1kBNauUwbjhvZSulXblvnTWSOTImkHtW2u3riY69sbyOWMgD9bp2zBuTxT/TpMSk5z6QBhsX+0MYZQmZTIc2rYQMgYZS6mi+URVMVi/eKLi0LJxTSXzHsnDgbL0QfRkDqR86pRJlZoY5gumDoc80Nda80orISMSIAESIIFQIVCrWjn12jH968dkK8+n6DvTvX1T9Ldro981bPt2s0Wvzi0N+ztWz/RSz4zxgw15knAa1A1ZM/0tSRW6tm2MJTNHYdW88ZC7gkrIKEQJRNTGwqXB/0N0+AAAEABJREFUG1Enk+MmARIgARIgARIgARLwSYAGr08mYVoib4YQr3SYHgQ7H8oE2DwJkAAJkAAJhC8CNHjD13xyNCRAAiRAAiRAAkFFgPWEGwI0eMPNVHIgJEACJEACJEACJEACvhGgwesbFcpIwHQC1CQBEiABEiABEjBzAjR4zXyC2D0SIAESIAESCBsE2EsSMF8CNHjNd27YMxIgARIgARIgARIggSAgQIM3CCCyCtMJUJMESIAESIAESIAEQpoADd6QJs72vBA4/b0ustTbwmAmDDLV2Yi01VdzPsxkPvTnRqqqK5C57mbOixnNS7oaa5Ch1vo/mZMQLWsTPbGXz17ukEBEI0CDN6LNOMdLAiRAAiRAAiRAAhGMAA1ec55w9o0ESIAESIAESIAESOCPCdDg/WOErIAESIAESCC4CbB+EiABEvgTAjR4/4Qey5IACZAACZAACZAACZg9gXBk8Jo9a3aQBEiABEiABEiABEggFAjQ4A0F6GzyF4E8kVbh8sqqDGbC4Orq6ri9sQ7nw0zmQ39u3NtSH1dWVTN9Xsys//pxGG8fn5jw64OAKRIgARIIZgI0eIMZMKsnARIgARIgARIgARIIHQL6Vmnw6klwSwIkQAIkQAIkQAIkEC4J0OANl9PKQZEACZhOgJokQAIkQALhnQAN3vA+wxwfCZAACZAACZAACZhCIBzr0OANx5PLoZEACZAACZAACZAACQA0eHkUkAAJBIQAdUmABEiABEggzBGgwRvmpowdJgESIAESIAESCH0C7EFYIkCD10xm6/2HTyhSqSnWbNpl6NGHj59Qr1VPw75fibote0B0/cr3LneaMAf7Dv3nXezn/tdv37Bqw04/89t0H4oLl2/4mc8MEiABEvgdgR8/XNFv2ESUr9UahSo09KJ+5fptDB45FWVqtESNxl0wYtxMfHdx8aJjvLN09RbUbNIFeUvXVfVJ3ZI/fe4KtOpij679nPD0+UsRqdC+xzA8evJMpRmRAAmETwI0eM1kXncfOIp0qZNjz8ETZtKjX9349s0F67fu/SVgymQCVCQBEjCdQNGCuTF+RB8fBWysrdGqcS3s3TAPU0b1x83b97Fq/Q4feiLYtvt/WLRiE3p2aoHju5dj1oQhsLS0wNt3H3DwyEnMnTwc0s6m7ftFHRu27UOeHJmRLEkitc+IBEggfBKgwWsm87rnwAn06NgMT5+9xKs373z0aue+I+jWfzQ69XZEA9temDpnuRedBcs3wrbrYLTrMRwvX71ReeLFrVK/Ixq07o1BTtPw6fMXJZfo0LEzqi7xIO8+cExEKkg7Tdr3R+N2/TDBeRHc3N0xZ8k6PHv+StXtPG+l0vMrEm/z5FlL0c5uuOZFGWXoy5u37zHAYYqqt3ytttoXzym/qqCcBEggAhKwtrZClfLFES9uLB+jT5cmBVIkS6zkyZMmQo6sGfBE+6xUAm/RinXb0bppbRQpkAtWlpZIlSIpLCwslNHr6uYGlx8/8PHTZ0SKZKOM4A1b96B5o5reauFuMBBglSQQqgRo8IYqfo/Gn2nG5Ks3b5E9S3pUKF0Y2/cc9sjwFj9++hyjhnTH4hlOmofjAU6cvmjQSJ0yKeZMGoryJQthiXY7TzLSp02JdYsmYNmsUdqXRSIs174IRC5B6pro1AejhvTAqEnzlDF8/+FTLFi+CZMc+2DRdAftlqErNu84ANvG/yJRwniYMc4e7VvWk+L+BunLjPH2qFuzgqEvU2YvR+y/YmKJ1nfpU5aMaf2tg5kkQALhm8DPnz/h7u7ma5CR+5X3/MVLbN11UPPS5vK17KMnz3H5+i2U+9cWVet3wLwla5Ve9GhR0KReVQxynIpbdx6gbo0KGDt1Prq0bQQLHZSOX236LncPRBnfx+t7/dQll7B1DMh5a86BBq8ZzM4uzcNarmQh1ZNqFUti9/5fHlcl9IzEqxEtahRYWVmhYN7suHT1lmcOUDh/TpUWnXsPnqq0jY21urUnnuHDx8/itvYhrzK0qGqFEh7ej+SJNUP7b9y+9xDnL13D5y9f0X/EZHTo5aDtX8eVa3c07YD9L1ogtyqQKEFc6Pty5vwV2Dbx8KJEjxZV8+LEho8/CkiABCIMAXft7pGLiwu8hx+aB1YgeJfL/pu379CpjyMa16mCPDky+SgrOlKv6w9XzTHgiAkOvbD7wHH1mSp5FUsXwZA+7TCoV1ucOnsRkSNZI4XmMZ6m3TEbPXkujp0852udUtZ7cHV1hawN9i7nvs85DSkmcuzIvIRUe2zH61zLeWvOgQavGczOHu0DWZYkFKrQGHVb9sTNO/fx4JHPByg0h4iX3oqHRC+w1oxgSet0FnDTbttJetSkuUicMD6G9++IrpoX4+s3FxGrYGX5a+rFgHZ3cwd0OhQrlFt5csWbu3z2KPS3s0VA/2S9nJTR4VdfoP1JO9qG/0mABEgAlpaWiBw5io8QKVJkRcd7noWlFQY6TFVreVs0quWjnF4/Qfw4KFEkHxIlSIC/06ZGruyZcEu7oNfny1ZnYYl5Szeie4fmWLVhN2LGjIFOrRtjxLjZsLK28bNuKasPNjY2iBQpkkm6+jIB2VI3SoDZRtKOHRsbzkloHTvqxDXjyMKM+xYhuiaGrbxh4djOJdCHJnWrYuf+Iz7GL94HWZ8rb03YtucQsmVO50PHWPDw8TMU1QzYmDGi4/CJs8ZZ2LLrEGQ9272HT3Hx8k3IGrm8OTPjwOGTuH33odKVhzzE8xs1amR8/PhFyQIbyZfO/KXrDcWN1xMbhEyQAAmQgC8EPnz8BLsBo1Hrn3KoWKaoD43dB44aZBVKF8XxU+fV8wfyOXPu4jVkyeB1CdWsBavRsHYVyN0m95/uSBAvjkpHjmSDn+4/DXUxQQIkEH4I0OAN5bncue8wShfP76UXZUoUxM69Pg3e9GlTwc5+LJp3HIgCebKhQJ7sXsp532neoDpadR4MWdIgt3mM8xPGj4um7fuj79DxsOvYFDGiR0OSRAkgD845jJ8NeXCtaYcBePfuAyJpnowq5Yuph9B+99CacRvG6c5tGuDZi9eq3tLVbXHi9AXwjwRIgASMCVSs01atu5WlAnlL10U7u6EqW96oIEasvLZM5BL6D5+o8t69/6BeZyYPoomgab1/oLOwQAPbnmjTbQj+qVQSJYvmlywVbt19oC7qy5cqrPZrVSuHuUvWoVGb3hCZtbWVkjMiARIIXwRo8IbyfMrTxF3aNPLSiwzpUmHNgvEQz+zKuWMNefJ08mJnR4isk20Dg3zVvHFKVwRpUiXF1NH9JYnK5Ypj7cLxmOjYG93bN8Ukpz5K3q+7LQb3bqceZlsxZwzKea4flszSxfJj3pRhkHY2L5uCPDmziFg9rCblfXtobdaEwZAH7kTRr77EjR0LDgO7qHr3bZyDMsULijoDCZAACRgI7Fg9E6f2rTKEGeMHq7zGdasZZPp8R/tuKi/WXzFxSisjF+0iEIN1gF0brJo3Hstmj0b9fyuL2BDSpU6BiU59Dfuy7GvNgglYOmu09jlX3yBnggRIIHwRoMEbvuaToyEBEiABEiABEiABEvBGIKIYvN6GHfZ2K5Qugh4dm4a9jrPHJEACJEACJEACJBDKBCxCuX02TwIkQAIkEKIE2BgJkAAJRDwCNHgj3pxzxCRAAiRAAiRAAiQQoQj4avBGKAIcLAmQAAmQAAmQAAmQQLgmQIM3XE8vB0cCJPCHBFicBEiABEggHBCgwRsOJpFDIAESIAESIAESIIHgJRC2a6fBG7bnL8z3/olrZsTP0oDBTBjEy1wfsTPU4XyYyXzoz41Y6WuFuzmJmYzv4g7zH+AcAAmEIQI0eMPQZIXHrj51y4oEWRsxmAkDMbDiZKwb6PngXAbPsRwrvVyENAxX8xIjaaHw+JHGMZEACZgpARq8Zjox7BYJkAAJkAAJkECYJcCOmxkBGrxmNiHsDgmQAAmQAAmQAAmQQNASoMEbtDxZGwmYToCaJEACJEACJEACIUKABm+IYGYjJEACJEACJEACfhGgnASCmwAN3uAmzPr9JbBl1yE4jJnKYCYMHMdOx6gJMzkfZjIf+nNjzKRZcBw77Y/nxd+TkZkkQAIkEI4J0OANx5MbFoa2dfdh9UUuX+b+h2nU0wye4GbkNG46Rk+cSdYhwDogczlm0uwgmZNPn7+EhY8F9pEESIAEgpwADd4gR8oKSYAESIAESCAYCbBqEiCBABOgwRtgZCxAAiRAAiRAAiRAAiQQlgjQ4A1Ls2V6X6lJAiRAAiRAAiRAAiTgSYAGrycIbkiABEiABMIjAY6JBEiABAAavDwKSIAESIAESIAESIAEwjUBGrwAwvUMc3AkQAIkQAIkQAIkEMEJ0OANpQPg1p0H6NzHCS062aN9zxEYO3UhgvOVQQFtb9+h/+A0cW6A6Lx7/wFDRjmjcdt+6NjLAQNGTMbd+48DVAeVSYAEQo7AnMVr8W/Trshbui7OX7ouDRvCoyfP0brbYDRt309tnzx7YcgzTnz5+g3Dx8xA/VY9UatZN6zZuMuQvefgcdh2GYR2dkNx/NQFg9x53gps33PIsM8ECZAACQQ3ARq8wU3Yl/rfvvuAdj2Go2bVMpg/dTicxw5ElfLF8O79R1+0/1wUUu31HDQef8WMjiUznTBtzADYdWyKt5oR/OcjYA0kQALBQSBl8sQYPaQHkiZO4KP6ASMmoUzxgljk7KRtC2CQ41QfOiKYMmspdBY6LJk1CgumOWDNpl24euOOZGHmglUYO6IX+nRthflL1ynZ3fuPcPHKTVQqW0ztMyIBEiCBkCAQcIM3JHoVztvYsG0/CuTJhtLF8htGmil9GiRLkhA/frhi9OT5aNK+v/L+iqdVr7Rr/1Ela9C6N1p1GazEkl+lfkeIbJDTNF+9xIFtTzWgRaa0ceHyDTx/+RqdWzfQSnj8jxs7FnJnz+TvmDw0GZMACYQGgXIlCyNdmhQ+mn76/CXkrpBclEtmzaplcenaLbx68052vYTrt+6icP6csLK0RIzo0ZAjawbs2HtY6dhYW+HTp8/4+OkLbGxslGzU5Hnob9dapRmRAAmQQEgRoMEbUqSN2nn4+CmyZ8lgJPmV3LRjPx48foYF00ZgcO/2GDlxLt5/+IT7D59igvMSDO/fCctnj4Z9r3aqUPq0KbFu0QQs07wrKZIlwvJ125XcOApMe8blTWnjwaOnyJIhDaysrIyLqrRfY1KZjEggDBMIr11/9vwVEsSPg0ieRqpsEyWIi6e+LGtIny4Vjp88D3d3d8iyrPOXrkPKC5uBPdthwvRFmKd5d3t1boENW/ciX66s2sV9IslmIAESIIEQI0CDN8RQe21Ip/O6r987d/E6alYuDUsLC6RKkQRZM6WFeFDOX7qGUkXzaV8UCZVqKu1WpCRsbKyxaMUmdOs/GoePn8XtOw9E7CMEtD3jCkxtA3404teYjNtgmgRIIPgJfPv2Fb6FnwczgacAABAASURBVD9/wsXluyFP0tIbY13Z//79l44+r3WTf/FNk5eu3hK1m3VFksTxNdWfkPzUKRLDYWBnjBzUFZoDGJu270e9muWxfO1WjBjrjNUbtis90Q1rwcXFBb7xCGvjCE/9/f79m5fjODyNLQyMRTvvzfs/Dd5QmJ/kSROrNWx+NW2l3QbU54nHVPsugnwhWVtb6sWG7ahJc5E4YXzN89sRXds2wtdvLoY8fSIw7enLytaUNlIkS4wr1+/A1c1NivgIvo3JhxIFJEACwUrA2toGvgWdTqcZpFaGvKRJEqlnCqysrJXM0tIKr9+8R4rkSdS+cR2x/vpLuxvVAXs3zMXWlTMQI1o0pPRFb+rsFejcppH22XcLR/87hz5dbbH/8ClcuHLLR53G9Ztr2kq7myXBXPsXEftlpR2vEiLi2M1hzDDzPxq8oTBBNSqXwjHtFuCiFZvh8uOH6oE85CFPRefMlgGbNS+Im3Z78N6DJ7h87TYypU+NnNkyqS8H0ZECn798lQ0ePn6GooVyI2aM6Dh84qySeY8C055xHaa0kT1LeiSIFwdDRjrj9dt3qrhsz1y4qvXd9zEpJUYRhwBHGuoELDU3q29BOmYsT6YZvEkSxceBwych8v3aNkO6VNo5Hlfty+fVh4+fVfrrt+9q++27C1Zv3Im9/zuO2tUrKJmUlXDy7GW1vjdX9kzajSAdEsaPqxm51ogXNzYslLFt6UVfyph7sNDuwpl7HyNi/zgvoXcuyeeIOQcLc+5ceO1b7FgxMWOcPU6evYSGrfugU29HbN11CLH+ioF/KpZCAu3LoHnHgRg62hk9OzVXxmzK5InRsVU99B8+WT2gZtt1iMLTvEF1tOo8WC1pcHV1VTLvUWDaM67DlDZEf+wwO1hZWcK2yxD1qrXx0xYh9l8x4deYpAwDCZBA6BHoP3yieiXZ46cv0KqLPfKXrW/ozKghPbBi3XY0addXGbLD+ncy5Mln05kLV9T+tRt3VB1larTC9j2HMW2MPeTiV2VqkRjCM+avRJe2jbU9IH/ubLj38Alsuw7Ci1dvkCdnFiVnRAIRiQDHGvIEaPCGPHPVojwZPWVUP6xZMB5TR/fXDNtmiB4tqub1sELvLi2w2NlRvbJM1u2qAlpUoXQRLHJ2UA+tLZ89SpMAlcsVx9qF4zHRsTe6t2+KSU59lNx7FND25A0S/bq1UtWY2kYszbgd0qc91i+eqF615jCwC1KnTOrvmFQDjEiABEKFgKN9N5zat8oQ/tuzwtCPZEkSYs7kYVg8YyRmTxyKJIkSGPJWzx8PeWWZCPLmyqrKH9+1DAunO0Le0iByfYgcyQYLpjmozzeRiQduzqRhkDBj3CDl8RU5AwmQAAkEJwEavMFJl3WTQKAJsCAJkAAJkAAJkEBQEaDBG1QkWQ8JkAAJkAAJkEDQE2CNJBAEBGjwBgFEVkECJEACJEACJEACJGC+BGjwmu/csGemE6AmCZAACZAACZAACfhJgAavn2iYQQIkQAIkQAJhjQD7SwIk4BsBGry+UaGMBEiABEiABEiABEgg3BCgwRtuptL0gVCTBEiABEiABEiABCISARq8EWm2OVYSIAESIAFjAkyTAAlEEAI0eCPIRJvrMJ3H9MPn51cZzITBx6eX8Pr+Gc6HmcyH/tx4ceckPj278sfzIj9uY66fBewXCZAACQQnARq8v6PLfBIgARIgARIgARIggTBNgAZvmJ4+dp4ESIAEQo4AWyIBEiCBsEqABm9YnTn2mwRIgARIgARIgARIwCQCQWzwmtQmlUiABEiABEiABEiABEggxAjQ4A0x1GyIBEggQhHgYEmABEiABMyGAA1es5mKiNmR9r2cEC1hJgYzYRAjcVbETZmb8xHE8zFp+vyIeYJz1CRAAiQAwBwg0OA1h1lgH0iABEiABEiABEiABIKNAA3eYEPLikmABEwnQE0SIAESIAESCD4CNHiDjy1rJgESIAESIAESIIGAEaB2sBCgwRssWFkpCZAACZAACZAACZCAuRCgwWsuM8F+kIDpBKhJAiRAAiRAAiQQAAI0eAMAi6okQAIkQAIkQALmRIB9IQHTCNDgNY0TtUiABEiABEiABEiABMIogQht8DrPW4l/m3ZHux7D0bBNH0yZvQyubm6Bmsqd+45g3LRFvy175fpttLMbjlZdBqNxu35Yunorfv78aSg3ZdZSSH+27zlskBknGrfthwEjJhuLgj299+AJtOhkD9uuQ9C+5wgsW7Mt2NsMygZYFwmYG4EvX79h+JgZqN+qJ2o164Y1G3f52sV3Hz5i7NQFaNK+P8rWbIUeA0fj3sMnSlfq6DtsAmy7DFJ16T+73r77gJadB8LV1VXpMSIBEiABEgAsIjqEahVLYsY4eziPtcd/Zy7hpBaCi8mrN+/Qtd8otGhUA3MnD8X0MQOwbfchrNm0WzX55NkLnL14XfWnUtmiSmYc3b3/GC4/XHDm/FXIl51xXnClj586j3HTF2Jwnw6YM2mIxmkgEsSPE1zNsV4SiBAE5MJWZ6HDklmjsGCag/YZsAtXb9zxdeyliuXHYmdHrF04CXHjxMLE6R4X1oePn0Hsv2JizuRh+PzlC85fuq7Kj5u2AF3aNIaVlZXaZ0QCRgSYJIEISyDCG7z6mbe09EARL24sJdp36D9Uqd8RDVr3xiCnafj0+YuSO02YA8fxc9CxlwOadRiAsxeuKrlxdPDoaYg39MPHT8ZibNi6DwXzZkeBPNmUPGaM6OjcpgFWb9wJN3d39B8xBQ8ePVUe3tv3Hiod42jX/qOoVLY48ufJhoNHThmy6rbsgQnOi9G840DlCbp15wG69B0JkW/accCgJ15o8RSJZ3mC8yLVpmSKnux36uOE/YdPisgQlq/dgVaNayJV8sQGWdkSBVX62YtX6GE/RrUrPG7f9eizMBqmea+kvtmL1kDa7dZ/NDr1dkQD216YOme5Ks+IBCIqgeu37qJw/pywsrREjOjRkCNrBuzY6/OuTqyYMZAnR2aF6a+Y0VGkYG48ff5S7dvYWOPjp8/qDpF8PkWOZKNdtF9EJBsb5MyWUekwIgESIAES8CDgYeV5pCNkPGvhahSq0Bjl/m2DlMmS4O80KRWH9GlTYt2iCVimeWBSJEuE5eu2K7lEbm5umDyqH6aPHYiJM5aICDqdTgs/lXG3fO02TB7ZF2LQqkzP6NGT58ia6W/PPY+NfNE9efoSFlr5QT3bIV2aFMrDmzZVcg8Fo3jPweOawVsEFcsUwe4DR41yoPU7heYpGoH8ubNi2JiZcBjYWfPIDsW8JeshtzrvP3yKBcs3YZJjHyya7oDvLq7YbGQMJ0+aCFO1MZUqms9LvQ8fP0OOLBm8yPQ7U2YtQ6b0aVW74pF2mjhXn6XV/wOTnfqgddPaSvb46XOMGtIdi2c44ebtBzhx+qKSMyKBiEDg5093uLu7GcLf2ufLsf/OwdX1Bz58/Ki8s880Q9ZYxzgt5X9ouotXbEJRzeiVvGIFc2mfMdHQb9hEZM+SHmlTJ8PU2csgF9GSz+Bm4B08LLzOafC0EdxjYP2ct6A7Bsz9szzCG7xtmtXBsZ1LsHXFNM1I+469/zuu5sxG854s0r5cxDN5+PhZ3Na8pipDiwrlzwFLCwtEixoF795/1CRQXpYjJ85r3trdmKgZlVGjRFZy75Fm13oR6XQW+KlJ3I3W8Wq7Pv5fvnYbcWPHQqIE8ZSX+Oadh3j/4ZcHWfokhcSgTp0yqfIaicEtt0BfvHytfaFe0257ftW8yJPRQfNOn9duf1659usWasmi+aW4r0Gn0/kqv3DlJmpXL6fyqpQvjnsPHmtf4B7rBksUzgMLjZHK1CIx7IWX3GYVL/elq7c0Kf+TQMQgIBfJLi4u0Ic2TWtpnzcuKFuzNeq2sEOSxPEVCH2+962UH6zdaYoZIyqaN/hH1fPjxw90adMQQ/q0Q9N61TBj3irUq1kBL1+9Uet+x09biDvanSLvdXH/1zz8joV/+bJG+scPVzUX/ukxL2h4m8JRzgmZF1N0qRP086I+xMw4ivAGr35u4sT+C3lzZsXxUx6ex1GT5iJxwvgY3r8jurZthK/fXPSqXgw5vaGq0+mQIV1K5a25ffeBQdc4kSxJQojhaiw7d/EqkmpfdpYW/k+FLGc4f/m68kYXrtgEr16/NRjnUp+153o9MTLFqBSZBNn/8cMN0PpXrFBu5T2WNcvLZ49Cfztb6P9srH1f7yee3wtXbujVfGz17ep0Oq0JLXiOw7gPUsi7Pf/Tu0CUGEggnBKwsrJG5MhRDCFunDgY1q8zDmxegB1rZiNm9OhIlSKpId9YV9Jzl2yAfEaNG9EHMWLE8KH39Plr3NUuOKuUL4lRk+ajSvkSKFeqCMZMWeBDV+pjiPLHXGxsbBApUqQ/rodz8edzoWcYKVJk2NhwTvQ8Qnpr7h/f/ltZ5t77IOyf3PY/c/4y4sXxWMMrt/KLagaieEkPnzjrR0texbL+d9zwXhg62hm3PdezGmvUqFIaR7S69LfzZf3d1NkrULdGBWM1H2kxDncfOKaWWIg3WsL4Eb2w5+AJH7p+CfLmzIwDh08a+iVPct/WvD9+6evlDWpVxKyFa72s7d1z0MMLnj3z31i7eY9SFYNcvrAtLXw/pI6dPKc8T1+/fcO2PYeQLXM6VY4RCUREArLmVsb9+ctXrFi3TTuXj6HWP+VFhDdv30N/B0TW9ssDbqLfs1MLdVGplLxFIyfOQd9uHhew7j/dkTB+XMSPF1vdPfKmyl0SIAESiJAEfLdOIhAKWcfarsdwVG/UBc9fvUWDWpXU6Js3qI5WnQdDljTILRIlNCESj6iTfTf0GToBYjQbFxFjWtb2zl+6AbZdB6tXfFUsUxS1qnksCzDWNU6fPn8FCbQvMPE46+Xy4JoY1fLmB73Mv22SRAnQo2MzOIyfrR5sa9phAN69++BfEZVXMG8O9NTKSZ8btO6jHjx78fKNyuus3U49f+ka5GG5jdv2a1+4LZXctyh92lSwsx+rdOWhvQJ5svumRhkJRAgC127cQd7SdVGmRivIKwinjbFHgnhx1NhPnbuMEeNmqPTNW/ewcMVGbNpxEPnK1FNlKtZpq/L00ZpNu1Aof051R0pkzRvUQFu7oejcxxHN6lcXUcgEtkICJEACZkwgQhu87VvWU15TucUva3gXTB0O8ehC+6tcrjjWLhyPiY690b19U0xy6qNJgX7dbVG6WH6VlmjzsimyQflShWHXoZlKp02dHGsWjIcYv0pgFGXOkBYzxturB8qWzHBC47pVDF6bNKmSqiUHRuoqmTdnFkjf1I5nZGlhgZ1rZiiP9Kp54wz9lrWz9j3beGoBsycORkrPNyxIv+dNGaZecST9zqPVK4rG5WXfeyhTogAWOTtAlkFMHd0fDWtXViqynlg82gumjcC0MQOgf9DOOyNRFhaLnR2xcu5YdLJtICIGEoiwBPLmyopT+1aRmxYbAAAQAElEQVTh+K5lWDjdUb2lQQ9DPktWzBmrdjOmT6P0Dm6eh5N7V6r0jtUzVZ4+qq15hsXI1e8XL5xX++yaqEKRArn0Ym5JgARIIEITCEmDN0KD5uBJgARIgARIgARIgARChwAN3tDhHqFarVC6CHp0bBqhxszBkoD/BJhLAiRAAiQQkgQsQrIxtkUCJEACJEACJEACJEACBgIhlKDBG0Kg2QwJkAAJkAAJkAAJkEDoEKDBGzrc2SoJkIDpBKhJAiRAAiRAAn9EgAbvH+FjYRIgARIgARIgARIIKQJsJ7AEaPAGlhzLkQAJkAAJkAAJkAAJhAkCNHjDxDSF305WKVcU/Xt2ZAhCBn/Cs1+PDujdrS3nI4jno2A+vg83/H6KcWQkQAJhgQAN3rAwS+G4j1XLF8OAXp0YzIRB/54d0Kd7W85HEM9HgXw5wT8SIIEQJ8AGScBAgAavAQUTJEACJEACJEACJEAC4ZEADd7wOKsck+kEqEkCJEACJEACJBDuCdDgDfdTzAGSAAmQAAmQwO8JUIMEwjMBGrzheXY5NhIgARIgARIgARIgAdDg5UEQAAJBr7pl1yE4jJnKEMIM1m3aEfSTyRpJgARIgARIwEwJ0OA104mJKN3auvswHMdOYwhhBjR4I8oZxnEGGwFWTAIkEKYI0OANU9PFzpIACZAACZAACZAACQSUAA3egBIzXZ+aJEACJEACJEACJEACZkCABq8ZTAK7QAIkQALhmwBHRwIkQAKhS4AGb+jyZ+skQAIkQAIkQAIkQALBTMBsDN5gHierJwESIAESIAESIAESiKAEaPBG0InnsEmABMyWADtGAiRAAiQQxATCvcH77v0HDBnljMZt+6FjLwcMGDEZd+8/xqvXb5UsiHkGSXV+9TlIKv/DSm7fe4hDx84Yatl36D84TZhj2Gci7BOwGzgG+cvW93MgNZt0Qd7Sdb2E46fOK/3pc1egVRd7dO3nhKfPXyqZRO17DMOjJ88kyUACJEACJEACJhIIOrVwb/D2HDQef8WMjiUznTBtzADYdWyKt5oRHHQIg74mc+6zXCwcO+lh3MjIc2XLiAa1KkuSIRwQ2LRjP6JFiwqdP2NZv3gyTu1bpcIiZyd1fuXPnQ1v333AwSMnMXfycBQtmBubtu9XtWzYtg95cmRGsiSJ1D4jEiABEiABEghpAuHa4L1w+Qaev3yNzq0bGLjGjR0LubNnUvuubq4Y4DBFeXqHj5kJN3d3Jb964w7a9RiOJu37o6f9WLx++w6fPn/BP4264OfPn0rn23cXVKrbAa6ursrDOWzMDHTq44TZi9bg7IWraN1tKJp1GAB7x6n4+OmzKiOeUMfxc5SnWfJET2UYRb/r87rNe9C8kz0at+un2pKi4q2u16on+g+fhA6aF/vZi1eo27IHxk1bpPrRqstg3LxzX1QheT3sx6B5x4GqH7fvPlRy6ZvxGO4/fIo6LXqgUZu+aGc3HHfuPVZ685au1zy8pyF89hw8jrMXr2H52m0qz6+6d+47ojh26TsStl0HY+X6nUqfkXkRePHqjZqbDi3rmtyx9Vv3olrFUrCwsIClpQVc3dzg8uOHOuYjRbJRRvCGrdox26imyXUGVJH6JEACJEACJPA7AuHa4H3w6CmyZEgDKysrXzk8efYSto3/xeIZjvju8gOHjp5RRu/Q0c7o2rYRFjs7olypQpg0Yymia16v9GlS4L8zl1Rd4skqnD+noW4pP9mpD1poX+yDnKahvWY0LJzuoBkBlli8crMqI5GbZhBMHtUP08cOxMQZS0TkJfjXZzE652oG5/jhPTF74mDIcgK9t/XBo2ewbVoL0zUvdqIE8VSdKZMnUnpi8I+ZskDJpsxahkzp02LBtBGoVLYonCbOVXKJ9GNo3bQ2YseKAWetj0tnjUSrJjUxdtoCUUFLbXzFCuXBjHH2KFuioJLpI//qfvr8FRztu2DOpKHY+7/jePfho74Yt2ZCYJDTVPTvbgtr7Xz5aUKfxLDdpV3M1P6nvNKOGSM6mtb/B4O1418upOr/W1m76FqAbu2bwsrSUukwIgESIAESCDYCrNgfAuHa4FXj1vl9czZJovhInTIpdDodsmf5G/cePsbTZy80r/AbTJq5VHkx12oe1Ws376iqypYsiL0HT6j07gPHUK5kAZWWqEThPMrL9fjJC8SIEc3gRa5bozwuXL4pKioUyp8DlhYWiBY1Ct6998Po0/qjlL1F5y9fQ8mi+RAn9l+IEjkyKpcrrtV9Q2mlSJYIaVImU2l9JIappHNmywgxpMU7feHKTdSuXk7EqFK+OO49eAzxUotAPwZJR44cCXu0sfYeMh5zl6zH/YdPROxv8K/uHFkzqIsGqSBunL/wUDPQJc0QOgTkwuvbt6/Qh1XrtyHj36mQLnUy7Xj4oTqlz/Nru3n7PqRNlRzx4sQ01FNBu0Ac3Lst7Hu2wX+nzyGSjRWSJY6PKbOWYOTEWThy4rRB1696Kf81L3oWrq4/yM3oeNVzCc2ti4sLvn//znkxo3n5/v0bXFy+c05CaU7UF4cZR+Ha4E2RLDGuXL8Duc3q2xxYWf7y/FpY6ODq6qap6ZA4YTzlwRQv5qwJg7Fq3jhNDs3YzI9jJ8/hw8dPuHztDvLlzqbkEllpXjHZShAPmWwliPwnfvnLLCx+IXf3XB4hevrwuz5bW1nqVZXXTF+3tZW1Qa5PiIGrT+ug0yeVB092dDoddDotePZJ+ipyCavW78LDJ89gp3nnxGv89et3Ef82WFt5MNXptHoleNZtaeThs9Bpt75dXX9bFxWCgYBnlXIcWlvbQB8OHDmNJau2oFiVFqjdohfc3d1RtHIz7eLvrUFHr6vfbttzGNUrl/Y131075Oct3YgubZtgpXYsRY8eTbvr0QAjxs2GzsLS1zL6ern9NS96FhZkZnbHjHxeStDPEbc+j9uQZmKlfQ9KCOl22Z7H3Ht+vZjt5pf1ZbZdDHzHsmdJjwTx4mDISGe1DldqkvW4Zy5claSvQby+rpoxtlO7VSsKP364GryokSPZIGvmdBg1eT5KF8uvPLWiYxySJkmgGcSfcf7ydSVevXEXcmbLoNKmRP71OUeWjDh49DTevH2Pr9++YdueQ8ileW/9qlfWV0rerv1HkVzzAOt0OmTP/DfEa62Xp0qR1NdxiEc4d7ZMSKQZ/8dOXoCrm4eBKp7l95rBL+W9B1Pr9l6O+yFPQKfTwVK7CNGH6WPt1UNo/+1Zjg2LJ8JCu1CRB9NSJk+i9PYdOqG2ev2Hj5/h1p0HqFi2qBe5Pn/u4nVoWLsK/ooZQ7vc+wlZZiNpOYfkgkevx62lr/y8c5H58C7jvmnsgosT5yR0+fs1rwGZF7/qoDxwcwsz/7Mw8/79cffGDrODleYVte0yBO17jsD4aYsQ+6+YftYrJ4vDwC7Ytvuweujsn4adcenabYO+rFvd978TKFuigEFmnJC1ioN6tcXU2StU+W/fvqNJ3WrGKr9N+9XnNKmSokmdqrCzH4vW3YaieKHcKJAnu5/1ffr8FQ1a99E8bDvRq3Nzpde5TUOcv3QN8tDaxm370bdbSyX3HsmyB+f5K9VDcGcuXFGGi+jkzpERPzXvX9d+o7Dn4HERGYKpdRsKMBEmCLx7/wH9hk1UD6LpOywXUxVKF0EkGxu9yLC9dfcBZA1v+VKFlaxWtXKYu2QdGrXpDZFZW1spOSMSIAESIAESCCkC4d7gjaUZt0P6tMd6zWslD2GJMZs6ZVLEixtbvapMD7r2P+Vh2+Rftft3mpSY5NQHC6c7YPtqZzSsVUnJJSpTvCCO7VyCXJ5vehBZv+62yuMraQmSJw+VSfnh/TsZ1q5619u8bIqo+wh+9VkU/61WFgumDseSGU6Qh8tE5n0sIpPQtlltLJ89CnMnD4WMSWTiaRs3vBcWTBuhXtOWNlVyEcN739KnTYk1C8arh+A6t24IfV/Fw+to31XxEeO/tObplrJSiV91i2HUo2NTUVFB5kAYqR2zjiJm5+R4+m/PCsPg5XgUb2+M6NEMsu7tm6K/XRvDvnEiXeoUmOjU1yBKnDC+dixNwNJZo9G+ZX2DnAkSIAESIAESCCkC4d7gDSmQbIcESIAESIAEwi0BDowEwjgBGrxhfAL96r48aBczRnS/siknARIgARIgARIggQhDgAZvhJnqYB8oGyABEiABEiABEiABsyRAg9csp4WdIgESIAESCLsE2HMSIAFzI0CD19xmhP0hARIgARIgARIgARIIUgI0eIMUp+mVUZMESIAESIAESIAESCBkCNDgDRnObIUESIAESMB3ApSSAAmQQLAToMEb7IjZAAmQAAmQAAmQAAmQQGgSCBsGb2gSYtvBSsB5TD98fn6VIYQZLJkzMVjnlZWTAAmQAAmQgDkRoMFrTrPBvpAACZDAbwgwmwRIgARIIOAEaPAGnBlLkAAJkAAJkAAJkAAJhC6BALVOgzdAuKhMAiRAAiRAAiRAAiQQ1gjQ4A1rM8b+kgAJmE6AmiRAAiRAAiSgEaDBq0HgfxIgARIgARIgARIIzwQi+tho8Eb0IyCUx9++lxOiJczEEAwMHj95Fsqzy+ZJgARIgARIwDwI0OA1j3lgL0jADAiwCyRAAiRAAiQQPgnQ4A2f88pRkQAJkAAJkAAJBJYAy4U7AjR4w92UckAkQAIkQAIkQAIkQALGBGjwGtNgmgRMJ0BNEiABEiABEiCBMEKABm8YmSh2kwRIgARIgATMkwB7RQLmT4AGr/nPEXtIAiRAAiRAAiRAAiTwBwRo8P4BPBY1nQA1SYAESIAESIAESCC0CIRrg/fK9dtoZzccrboMRuN2/bB09Vb8/PkzwKz3HfoPThPm+FquWsPOvspNEa7asBNfv337rer46Quxc98RH3qtuw1Fk/b90bzjQHTrPwpPnr3woWMsMLU94zKS3nvwBFp0sodt1yFo33MElq3ZJmKGMEpgwbINyFu6Ls6cv+LrCPb+7wSKVm6idOq0sMPU2csMensOHodtl0HaeTUUx09dMMid563A9j2HDPtMkAAJ+EmAGSRAAqFAINwavK/evEPXfqPQolENzJ08FNPHDMC23YewZtPuAGPOlS0jGtSqHOByvyuwfutefPvm8js1f/N7dWqOBdNGoFih3Bg9eb6/uoFp7/ip8xinGdyD+3TAnElD4Dx2IBLEj+NvO8w0XwIPHj3FnoPHkCxJQuh0Ol87miNrBuxYPRP/7VkBh4FdsO/QCfzv6CmlO3PBKowd0Qt9urbC/KXrlOzu/Ue4eOUmKpUtpvYZkQAJkAAJkIC5EQi3Bu+GrftQMG92FMiTTTGPGSM6OrdpgNUbd6p98fROn7sCjdv2Q43GXTF1znIlv3bzLjr2clCe0/K12uLV67c4e/Ealq/18Go+evJceTltuw7GqEnzVBmJ3N3dVR0N2/RB0/ZiXP9PxKp8fdteGOAwBW26D8WIcbPgpulu3fU/2rmG8QAAEABJREFUPHv+Cr0Gj0f3AWOUrvO8lRCPcb1WPTFn8VolMzUqkCc7bt99qNTFGyyeX/FqT3Be5Gd7vumpCoyi5Wt3oFXjmkiVPLFBWrZEQZV+9uIVetiPgXiYhZm+ffGGDxszA536OGH2ojXKO92t/2h06u2IBhoLPWtVCaMQIyDH6OCR0zCsX2dl7Mo54Fvj8eLEQvRoUWFhYYF4cWIrFUlLwsbaCp8+fcbHT19gY2MjIoyaPA/97VqrNCMSIAESIAESMEcC4dbgFcM0a6a/vTAXz9WTpy/VsoYtuw7i1LkrmD1pMNYvnohqFUoqw7D/8MmoXb08Fjs7YtF0B8SIEc1LHWKsFcqXQ/N2DoV4yb5+9ViSsEUzYF++equ8rdPHDsCqjbtx78ETVfbJs5ewbfwvZk0YjFh/xcCho2dQpXxxJEoYD2OG2mGCQy+lV6F0UWxeNgULpzvi0tXbOH3uspKbEp3SdNOkSo77D59iwfJNmOTYR/X/u4srNu844KM9v/S8t/Xw8TPkyJLBu1jtT5m1DJnSp1VjrlS2KJwmzlVyib67/MBkpz5o3bS27OLx0+cYNaQ7Fs9wws3bD3Di9EUlZxR8BNzd3WAc5i9bh5JF8iJVCo+LF+M84/TPn+7KoyvLHsrXao36/1ZE4fw5VF1i2E7QPP7zlq5Fj45NsX7LbuTNmRlJEsVX+cb1MO2V/5/wkDn5k/Jhuaz59t2dx7y3zxjznaugOxc5Rr9ZBt+3WdDUHG4NXsHj/Y6tTmeBn1qG+8+fOHX2ChrWrowokSNDp9MhpebBfPrsBSJFskapovk0LSiDNJKnF0sJtOjytduoVa2slgJq/VNObSU6rRnPN27fR5e+I9Fz0Di8efse127ekSwkTZwAqVMmVekE8eLg3sPHKu09+u7yHeKRtRs4RhmIt+4+8q7iY7+t3TAUq9IcBw6fRK/OzXH+0jV8/vIV/UdMRgfNU33+0nVcuebRDxj9nTdRT4rodL7f+r6g3cauXd2DgRjw9x48hqurqxRBicJ5oPcKikAuNqJFjQIrKyvleb909ZaIGYKRgIt20eHi4gIJt+8+wNH/zqNujfJq/6d2DshcSZ5x+PHjh5rD/Lmz4H9b5qsLvx17jmDH3iOqXNpUydQyh5GDusHa2lK7mDqoDOKV63fAcfwsrN20S+kZ18m0xxz8CQc3Nzdy9TyW/4RjUJaV8+fHD1fOixnNi/7zKyjnmXWZ/vkVjF9nQVJ1ODB4fecg3lcxTo1zz128qhmf8WFp4TFsK0sr42zN8wtlkHkRet/RDIVINtZKamVlqYxl2dHpdMqLO2OcPSRsWjoZFcsUlSytPUu1lcjCQqcZFG6S9BLkg9PecSrKFC+oPL4VShfBF0/vsRdFbzszxw/Coa0LMFHz6MqYtQ6p9bzSBwnLZ4/Sbjfbeiul7Wr9lXW/oiPBL73kSRPhwpUbWgHf/1trBqzk6HQ6rWktWFjIrg+OGjYl10dicOnT3AYPgcjaxVzkyFEg4X/HzmoXQ9fVxVHRys0gd0BkycmOfcdUvuhIiBQpsmbI2ihZ1KjRkClDOuTWPLjntQsnyTcO0+asRLf2TXFZu6A6dvK8dpy1xYEjp3H5+l1V3liXaY95CCwHKytrMvU8lgPLMKjL2WjOkEiRInFezGhe5PPLxoZzEtTHuqn1Bc83WdDVahF0VZlXTTWqlMaRE2cNt84/fvqMqbNXaB6uCqqjebQv8RXrtxvekiBe0SSaJ1aWKPzv2BmlI1fwLprHS+14RlkypcMRzVMmuydOXdSMZPEZQ60VXrJ6C6Qdybt97yHevf8gST+DeJfff/ik8kXX2toa2bOkh422FQNCZQQwktvL4u297bme9+27D5C+SDXG7fmnJ7r60KBWRcxauBb7NQ+yXiZP6ks6e+a/sXbzHkli1/6j2q3ypJpx7/shdezkObx89Ubx3rbnELJlTqfKMQoZAq0a/4tT+1YZglzIzJowBDUql1YduHT1JuRYkR3xvsuxL2m5U3FcM2aze1vWIm9okHW+2bXjVS5e5M6FePTjxomFn+7uUpQhNAiwTRIgARIgAV8J+G6d+KoatoTxtC/eySP7Yv7SDZAHzOR1WuJxrVXN4xZ81fLFkVUzXuWVZTUad8X0uSuVsTa8fyf1gJo8eFamRmu8f//Ry8A72TbQbuPuVw+2ieEWKZIN5E/WsBYukBPte4yAPKQm3lp3dw9jWPJ9C7KkYsrspeqhtfjx4iBzhrTq9Wm9Bo1T64N9K/M7WZJECdCjYzM4jJ+tHrxr2mEA3mlGr5Qzbs8/PdHVh4J5c6CnVp9wbNC6j3rw7MXLNyq7c5uGmtfwGuShtY3b9qNvt5ZK7luUPm0q2NmPVbryIKE8ZOebHmWhQ2DoaGecuXBFNX7l+h2UqNpcvZZM1vCmSpEUlcsVU3kSffvughnzV6JL28ayi/y5s+HewyfaeTYIL7SLmjw5syg5IxIgARIgARIILQLe2w23Bq8MVAzIGePt1QNmS2Y4oXHdKuq2u+SJN0qM12WzRmHDkklq/avIM6VPo169tcjZAQe3zIcYoqWL5Ue/7h7LAmTZwNhhPTFtzAA4DOiMrSumSTEVWjephSUznbBizhhIvXFi/4V4cWMrmVLQotr/lIdtk3+1FCBvOxg3vJdawiAC+55tIP0cO7wnhvbtgBYNq4sYdh2aQZY4qB2jaPbEwcojbCRSSenvvCnD1PpLeQhOb4B4b88vPVWJUVSmRAEID1n2MHV0f7X2WbITJYgH6f+CaSMUj7SpkotYsZK61Y5nJB7Fxc6OWDl3LIS7p5ibUCKwfvFk5M6R2dD66vnj1XIaEcg63yM7lhi8wSMGdDGcN5IfWbvIWzDNQb3JQfblXJozaZh2ng3DjHGDvOhKPgMJkAAJkAAJhDaBcG3whjZctk8CJGDOBNg3EiABEiCBiEKABm9EmelQHKd4p3t0bBqKPWDTJEACJEACJEACfhKIABk0eCPAJHOIJEACJEACJEACJBCRCdDgjcizz7GTgOkEqEkCJEACJEACYZYADd4wO3XsOAmQAAmQAAmQQMgTYIthkQAN3rA4a+wzCZAACZAACZAACZCAyQRo8JqMiookYDoBapIACZAACZAACZgPARq85jMXEbInVcoVRf+eHRmCgUGMGNEj5DHFQZMACZgVAXaGBMyCAA1es5iGiNuJquWLYUCvTgzBwCAmDV7wjwRIgARIgASEAA1eocAQugTYOgmQAAmQAAmQAAkEIwEavMEIl1WTAAmQAAmQQEAIUJcESCB4CNDgDR6urJUESIAESIAESIAESMBMCNDgNZOJML0b1CQBEiABEiABEiABEggIARq8AaFF3SAnsGXXITiMmcoQCAZBPhmskATCGgH2lwRIgARMJECD10RQVAseAlt3H4bj2GkMgWAQPDPCWkmABEiABEgg/BEI7wZv+JsxjogESIAESIAESIAESCBABGjwBggXlUmABEggrBJgv0mABEgg4hKgwRtx554jJwESIAESIAESIIEIQcCLwRshRsxBkgAJkAAJkAAJkAAJRCgCNHgj1HRzsCRAAiYSoBoJkAAJkEA4IkCDNxxNJodCAiRAAiRAAiRAAkFLIHzURoM3GOfR1c0NcxavReN2/dCux3B07TcKR06cUy3WbdkDHz5+UmlTop37jmDctEW+qppS1/FT51X73ito3LYfXr1+613s5/6+Q//BacIclX/o2BncvvdQpQMSdR8wBtdv3g1IEeqaQKBFp4HIW7ouildpis59HHHl+m1fS335+g3Dx8xA/VY9UatZN6zZuMugt+fgCXTo6YB2dkNx/NQFg9x53gps33PIsM8ECZAACZAACYQlAjR4g3G2Zi9cgxOnL2Hm+EGYMc4eY4bZQYzgYGwywFX3626Lv2LGMLlcrmwZ0aBWZaV/7OR53L3/WKUZhT6BwX064NS+Vdi8fDry5soCxwmzfe3UlFlLobPQYcmsUVgwzQFrNu3C1Rt3lO7sRWvgOKgL+nRthflL1ynZ3fuPcPHKTVQqW0zt+xZRRgIkQAIkQALmTIAGbzDNjru7O5av247+mkEZLWoU1YqNtTVKFM6j0hItWL4Rtl0HQ7y/L1+9EREGjJiMk2cvqbRElet1kI0KDx8/Q6fejmhg2wtT5yxXMn00e9E6tO42FK26DMbNO/f14t9uxVv7/sNH5eWtr9Ur7Uv9sj1z4Sra9xwB8SBf8/TInr14DcvXblNtHDp2GnMXr1X9v//wKV6/faf6Lx5tGdflax4exu8uLhg8crrydNsNHI1Pn7/8tl9UCDiBVMmTqEJ/xYwOaysrWOh0at97dP3WXRTOnxNWlpaIET0acmTNgB17Dys1G2srfNbm5+OnL7CxsVGyUZPnob9da5VmRAIkQAIk4C8BZpopARq8wTQxz1++RpTIkZE6ZVI/W5C8OZOGonzJQliyeoufevoMuUU9uHc7zJs6HEdOnNW8xxf1WZpxYoXZEwfj36plMHbqQoM8IIknz16iddPaWDxzJF69eafdwj6MqaP7o283W8yYv8pLVX+nSYlihfKgVZNaynudMnliTJm1HDk1D/CSGU6w79kOQ0ZNV2U2btuPDx8/Y9F0B9hq+peu3lRyRkFPoGn7fmpZg3htJzr29bWB9OlS4bjmnZeLMrn4OH/pOp49f6V0xbCdOns55mne3V6dW2DD1r3IlysrkiVJpPIZkQAJkAAJkEBYJGARFjsdVvrsh4PN0H3xssmOeNjuPXgqSX+D6MePF0cZ0pXLFYfegyqFalYpIxtULlcM9x48wc+fP9V+QKIkieIjVYokyvOXIV1KZM2YFpYWFsiaKR3uP/p9/85p3t/dB44pj6/TxDnKaBbPtdwOr1GlNCy0ujJnSAsJAelXuNMNogF9+/YV3sOsCYOwY7Uz6tWsgC59HfDly2cfOq2b/Itv37+jdPWWqN2sK5Ikjq/16CekrjQpk2BYvw4YOagrNAcwNm3fr9VVXvPqb8WIsc5YvWG70hNdBp/8g4uJq+sPcvfleA8u3qbU66LdufqunUem6FInZM6V79+/wcXlO8+VUDpXtC8Ss/5PgzeYpidh/Lj4+vU77mm3+v1qQm47S55OZwE3NzdJQoxCd/dfxqqbm7uSS2QpFogktCC3o93df+VZWVlqUkCn0/l5Kxu/+bOytDJoSD+srT32Je3q6tE/g4IfidFD7ZTHV9Ys7984F2Kgi6r0V7YSrDz7KmmGwBOwtraBbyF2rFiap78crt28hy9fXXzoxPrrLwzu3QF7N8zF1pUzECNaNKRMnkTpWVlZa4aulUpPnb0Cnds0wsUrt3D0v3Po09UW+w+fwgVt37d2KbNR3IKDg4WFZbDVHRz9jQh1WllZQUJEGGtwjjEo67bSPr8kBGWdrMv0z7XAf5uFTEkavMHE2ULzZtb/tyIGO01V612lGZcfP3Dw6GlJ+hmSJkmAJ5xISmkAABAASURBVM9eqPwTpy8aDGERHDt5DuIx/frtG7btOYRsmdOJWIX12q1nSezafxTJkyVShq/sB2eIEiUSPnz49aaJfLmzYsb81Qbv8qlzl1Xz2TL/jZNnPZZfvHv/Adc1Q0xlMPojApbaBZA+fPz0GXcfPNaMVUt10STHR7IkCREvbmwlk4fSZFmJ6H/99l3Jvn13weqNO7H3f8dRu3oFJZN8OXZPnr2s1vfmyp5JHUtyAWdtba3qk7XBosdgaWAW3CxkToK7DdYfsPnknASMV0gdX5yX0JuXP/pCC4HCFiHQRoRtonWz2ihWKDf6D5+sHibrM2SiWi7gH5BKZYph2Zpt6NDLAecuXoONjbVBPX3aVLCzH4vmHQeiQJ5sWshuyPv0+SsatO6Dlet3olfn5ga5ceK/MxdRqEJjQ5BXlRnnBzRduWwxHDt1XvVVHlrraFtfu53kgibt+qNaw85Yv2WvqrJ65VJ4++6jdot9JIaOnolECeMquWkRtUwh4K7dFbB3nKLW7+YrUw+zFqzGwB5tDUWHjnbGmQtX1P61G3eUXpkardQ67Wlj7JEgXhyVJ5EYwjPmr0SXto1lF/lzZ9PuVDyBbddBePHqDfLkzKLkjEiABEiABEggrBCgwRuMMyW38eUhrdXzx2Hu5KGY4NALRQrkVC2umjcOMWNEV+k0qZKqh8NkRx7+Ev3pYwagbfM62LZyuohRoXQRTHTsjcXOjlg5dyw62TZQcomkrl6dmmP57FGqHXmgTOTGoWDeHDi2c4mXILIlM52U1048gZLWl+nWrglknbDsyzg2L5siSZQulh/yKjPZSZs6OcYM7QHpq/Q7VswYGNSrHaQe0XcY2EXUEMnGBkP7dsDkkX0VgxVzxiDD36lVHqOgIRAn9l/a/I9RryWTV5NtXemMvLmyGipfPX88yhQvqPZFLjrHdy3DwumO6i0NKsMzihzJBgumOSB6tKhKIh6TOZOGQcKMcYOUx1dlMCIBEghZAmyNBEgg0ARo8AYaHQuSAAmQAAmQAAmQAAmEBQI0eMPCLJneR2qSAAmQAAmQAAmQAAl4I0CD1xsQ7pIACZAACYQHAhwDCZAACfwiQIP3FwumSIAESIAESIAESIAEwiGBCG3whsP55JBIgARIgARIgARIgAS8EaDB6w0Id0mABEggAhLgkEmABEggXBOgwRuup5eDIwESIAESIAESIAESMN3gJSsSIAESIAESIAESIAESCIMEaPCGwUkLT112HtMPn59fZQgEg/B0HIS1sbC/JEACJEACYYsADd6wNV/sLQmQAAmQAAmQAAmYC4Ew0w8avGFmqthREiABEiABEiABEiCBwBCgwRsYaixDAiRgOgFqkgAJkAAJkEAoE6DBG8oTwOZJgARIgARIgAQiBgGOMvQI0OANPfZsmQRIgARIgARIgARIIAQI0OANAchswm8C7Xs5IVrCTAwGBn6zaNO5n98gmUMCJEACJEACJOAnARq8fqJhBgmQAAmQAAmQQKgRYMMkEIQEaPAGIUxWRQIkQAIkQAIkQAIkYH4EaPCa35ywR6YToCYJkAAJkAAJkAAJ/JYADd7fIqICCZAACZAACZg7AfaPBEjAPwI0eP2jwzwSIAESIAESIAESIIEwT4AGb5ifQtMHQE0SIAESIAESIAESiIgEaPBGxFnnmEmABEggYhPg6EmABCIYARq8oTThrm5uKFShMYaOnmHogaurK0pXt8WAEZMNsj9JdB8wBtdv3v2TKlTZvQdPoEUne9h2HYL2PUdg2ZptSs4odAk8evIMZWu0Qt7SdVGxTlsMdJiM9x8++dqpmk26KD3R1Yfjp84r3elzV6BVF3t07eeEp89fKplE7XsMg7QhaQYSIAESIAESCMsEaPD6NXvBLNfpdIgWNQouXb0JMXSluYNHzyBRwriSNJsgRtG46QsxuE8HzJk0BM5jByJB/Dhm07+I3JE4sWNhxdyxOLVvFeZNGQ65iJq3dJ2vSNYvnqz0RHeRsxP+ihkd+XNnw9t3H3DwyEnMnTwcRQvmxuYdB1X5Ddv2IU+OzEiWJJHaZ0QCJEACJEACYZkADd5QnD2dTofC+XPiyH8enra9B4+hTPGChh49e/EKPezHoHnHgejYywG37z5UeT9+uGL05Plo0r6/8rzuO/Sfkn93ccHgkdPRuF0/2A0cjU+fvyj5idMX0XPQWJWWSIzY3kPG4/OXrxg+dhba2g1D+VptsWv/Ucn2Epav3YFWjWsiVfLEBnnZEh599Kt/ThPmYNiYGejUxwmzF63Bzn1H0K3/aHTq7YgGtr0wdc5yQ11MBJ5A1CiRES9ubFWBbHXQ/mnHlBL4E63fuhfVKpaChYUFLC0tIIayy48f+PjpMyJFslZG8Iate9C8UU1/amFWRCLAsZIACZBAWCdgEdYHENb7X75UIez73wl8++6Cew+fIE2qZIYhTZm1DJnSp8WCaSNQqWxROE2cq/I27diPB4+fKfng3u0xUpPLreyN2/bjw8fPWDTdAbZNainvsRTInzsr7t5/gjdv38suNu/8H6qUL4EDh08idqwYmDl+ELatmo68ObOofOPoodZOjiwZjEWGtF/9E4XvLj8w2akPWjetLbt4/PQ5Rg3pjsUznHDz9gOIEa4yGJlM4OfPn3B3d/MSvn77qpYqFK7QCO4/3dGhZV141zHe//b9G3ZpFyD/Vi2j9KJHi4Im9apikONU3LrzAHWql8fkWUvRpW0jWOigdIzLM+2Vf0jx+KnNbUi1xXZMnWN3nh/ePo947Jh67IRPPZO/zEJJMYgM3lDqfThoNkvGdLhx665m9B5H6WL58VMzavTDunDlJmpXL6d2q5QvjnsPHkOWP5y7eB01K5eGpYUFUqVIgqyZ0uK6VsdFTb9GldLKc5c5Q1pIkMI6nU4zmItg2+7DyosnesUK5kL6dClx9L9zmLVwNQ4dO4M4sf8SdR9Bp9MsHx9SwK/+iWqJwnlUPyQtIUfWDGoJh5WVFQrmza4Z47dEzBAAAu7u7nDRvPjGQWbm8LaFWLtwPMTjO2nmUh86xvpbdx5E2lTJkSBebINexdJFMKRPOwzq1Ranz11G5Eg2SJE0EaZpnvjRk+fi2MlzBl3juph2CTEubm5uIdYW59W0eZXPYrnbRl6m8QoJTj+0O1UyLyHRFtvwOe8B+DoLFVUavKGCHcqw1Ru3RQvl1m7zr0D5UkV89MZaMxBFqNPpoNNpQTNyZd/K2ko2KogRqbeTrSwtlUwiK6tf6eqVSmme3f3YsfcIKpQupIzRv9OkxKwJg5FR8yKv2rATK9btkGJeQnLN8Llw5YYXmfGOn/3z7LdeV9+/X/s/9UluTSRgqc1t5MhR4FtImTyZNq9FlOfct3y9bNuew6hZtayvdegsLDF/2SZ0tG2AVRt2I2bMGOjUujFGjJsNK2sbX8vo6+XWaF78mKM/YWRlZU3+wcD1T+bExsYGkSJF4ryY0bxEihQZNjackz85rv+krIlfZaGmZhFqLbNhA4F/KpZCw1pVkCJZIoNMEtkz/421m/dIErK+NlWKpMqrmzNbBmzevh9umsfv3oMnuHztNjKlT41smv7JsxeV/rv3H3D95j2Vlih+vDhIlCA+Fi7fhGoVSolIPdEfPVpUFNcM7n+1W9yXrvr0ujaoVVHzAK/F/sMnVRmJ9hw8Lhv41T+V6S0SL+HLV2/w9ds3bNtzSOtrOm8a3A0ogdv3Hqr1tlJO1uDuOXAM2bOkl10Vdh84qrb6SO4QyLKF8qUL60VetrMWrEaDWpUgx4Qsj0igHTOSFo/vT3deoHiBxR0SIAESIIHfEjAnBRq8ZjAb4kVtXLeKj550btMQ5y9dUw+tyfrcvt1aKh0xkBPEj6vkQ0c7o2en5ogZIzqqVy6lGUAf0aXvSAwdPRPe3/hQqWwRJEua0GBY7z/8H4pVaY4OvRxw8MhptGhUXdVvHBXMmwM9OzbD/KUb0KB1H/Xg2YuXb5SKX/1Tmd6i9GlTwc5+LOQBvAJ5sqFAnuzeNLgbUALv3n9EA9uehjW8N+88QPsW9VQ177QLnn7DJqolLEqgRfKwWoXSRRBJ80xpu17+37r7QD0UWa5kISWvVa0c5i5Zh0Ztemt3HgrD2vrXHQWlwIgESIAESIAEwhABGryhNFmy9GDP+tk+Wi9dLD8cBnZR8kQJ4mHc8F7q4bRpYwaotZeSIcZH7y4tsNjZEfOnDkepovlErAyZoX07YPLIvpjg0Asr5oxBhr9TqzyJrt+6B/HkSlpCjcqlcWjrAkzX6h4xoJOhfskzDmVKFMAiZwcsnz0KU0f3R8PalVW2X/3r191WrUdWSp6RGPWLtf6unDsWnbRb5p5ibv6AgLw2bMeaWYbXjS2c7gjx5EuVsf6KqeQxokeTXRW6t2+K/nZtVNp7lC51Ckx06msQJ04YH2sWTMDSWaPRvmV9gzzoE6yRBEiABEiABIKfAA3e4GdsFi107TcKZy9eR1nPV4qZRafYCRIgARIgARIgAQ8CjIOVAA3eYMVrPpVPcuqDBZo32MLzobeQ7JncRu/RsWlINsm2SIAESIAESIAESMBAgAavAQUTJGD2BNhBEiABEiABEiCBQBCgwRsIaCxCAiRAAiRAAiQQmgTYNgkEjAAN3oDxojYJkAAJkAAJkAAJkEAYI0CDN4xNGLtrOgFqkgAJkAAJkAAJkIAQoMErFBhIgARIgARIIPwS4MhIIMIToMEb4Q+B0AVQpVxR9O/ZkcEEBtUqlQndyWLrJEACJEACJBBGCdDgDaMTF+TdDqUKq5YvhgG9OjGYwKBa5bLgHwmQAAmQAAmQQMAJ0OANODOWIAESIAESCMcEODQSIIHwR4AGb/ibU46IBEiABEiABEiABEjAiAANXiMYpiepSQIkQAIkQAIkQAIkEFYI0OANKzPFfpIACZCAORJgn0iABEggDBCgwRsGJik8d3HLrkNwGDM13IRv376H5+ni2EiABEiABEggTBIICYM3TIJhp0OGwNbdh+E4dlq4CV+/fQsZcGyFBEiABEiABEjAZAI0eE1GRUUSIAES+FMCLE8CJEACJBAaBGjwhgZ1tkkCJEACJEACJEACEZlACI+dBm8IA2dzJEACJEACJEACJEACIUuABm/I8mZrJEACphOgJgmQAAmQAAkECQEavEGCkZWQAAmQAAmQAAmQQHARYL1/SoAG758SZHkSIAESIAESIAESIAGzJkCDN5inx3neSsxftlG14urmhi59R2LSzCVq39To8rXbqlznPk44dOwMbt976GvR46fOo2u/UV7yug8YgyMnznmRed9p3LYfXr1+610c4P137z9gyChnSH0dezlgwIjJuHv/cYDrCS8F3n34iLFTF6BWs24oU6MlegwcjXsPn/g5vFNnL6Fp+34oWL4hilZugvOXrivdPQePw7bLILSzG4rjpy4omUTO81Zg+55DklSBEQmQAAmQAAmQgO8EaPBT4emOAAAQAElEQVT6ziXIpe7u7hioGYDJkyZC17aNA1T/mk27Ua9mRUwZ1Q/HTp4PciOyX3db/BUzRoD65Jtyz0HjtXqiY8lMJ0wbMwB2HZvi7fsPvqlGGFmpYvmxduFErFs0GXHjxMLE6Yt8Hfuz56/QbcAo/FOxFPZumIuNS6cgZYokSnfmglUYO6IX+nRthflL1ynZ3fuPcPHKTVQqW0ztMyIBEiABEjAQYIIEfBCgwesDSRALdIBOC8PHzkKMGNHRq3NzyJ94VOu16on+wyehg+YNffbiFdraDUOD1r2Vh/TgkVOihg3b9uG4ZuQ6z1uJoaOnax7e05i7eC3a9RiO+w+fKh1To6s37qhyTdr3R0/7sXj99p0q6jRhDt5r3kjZqduyBybPWop2dsOVt/jlqzciVmlpU0Lp6rbYd+g/JddHFy7fwPOXr9G5dQO9CHFjx0Lu7JnU/rrNe9C8kz0at+uH2YvWKFl4j2JpFxF5cmRWw/wrZnQUKZgbT5+/VPveoxXrt6Ooll+7enlEixpFsZPy0P5srK3w6dNnfPz0BTY2NpoEGDV5HvrbtVZpRiRAAiRAAiRAAv4ToMHrP58/z/0JbNi6D5+/fEF/zZNqXOGDR89g27QWpmve0EQJ4qFPl1ZYPns0Jjj0wtQ5yyG/2lWjcmnkzpEJXds1wuDeHVCsUB60alILM8bZI2XyxMbVqfR/Zy6iUIXGhiDLHCTDTfMwDx3trHmXG2GxsyPKlSqESTOWSpaPkDplUswYb4+6NStgyeotKn+SUx/VZrvmdTRP5V/IlyuLkuujB4+eIkuGNLCystKLDNs79x5j7tL1GD+8J2ZPHKyMZfFUGxRCIxHCbQr/xSs2qfnzrelHj5/Bzc0NdVvaoWS15uri5vOXr0p1YM92mKB5hudp3t1enVtox9NejX9WJEuSSOUzIgESIAESIAES8J+Ahf/ZzA0KAkkSJ9BuP9/y4ZFNkSwR0qRMZmji3sPHmqEzA/ZO0zRv3mc8fvLCkGdqIn/ubDi2c4khFMybQxV9+uyF5oF9g0kzNe+t5h1eq3lcr928o/K8R0UL5FaiRAni4t6DX15kWaM7bMxMjBpshxjRoykdL5G4sr0IPHbOX76GkkXzIU7svxAlcmRULlcc4hH2yA1f8bdvX+FbGDhiEmLGiIpm9av5mu/q5oqHmtHrMKAzVswdDVdXN0ydvUTppk6RGA4DO2PkoK6wtAQ2bd+PejXLY/narRgx1hmrN2xXer61G1DZ9+/f8OOHS5DVF9D2qe/78ePq+oNz4se5FVrHjIuLC75//x4u5iW0GAZ1u9+1zy8XF85JUHM1tT5z/zanwRvcM6QD8ufOqnlWG6L7gNF44blEQJq1trKWjQqy3GD52u1oUreaWv+aLnUKfPn6TeUFTaRD4oTxlJdWvMOzJgzGqnnjfK3a0tLjsNDBQnkdof39/PkT/UdMQcdW9ZEmVVJN4vV/imSJceX6Hbi6uXnN8NyzttIsNc+0lWa1/cRPz73wtbG2toH3MGvhWsSOFROjh/ZE1KhRfeSLfkLNw58jawaNbQrEjxsXxQvnwY3bD3zoTp29Ap3bNFIXUEf/O4c+XW2x//ApXLhyy4eu1BvQYKUdk5aWVkFSV0Dbpr7PY0fPxMLCknPiy7ml5xMaWysrK3VHKzTaZpu+nytW2ueXBPLxnU9wczH3b3MPy8bcexkO+lexTFE0qlMZnXo74MPHTz5GdP/hE6RPl1IzeJLiw4dPuHz9tg8dEUSJEknlSzogIUmi+HB1dcXOfUdUsR8/XAPgZQXmLF6LTOlTo0yJAvDtL3uW9EgQLw6GjHQ2rA2WNcJnLlxFjiwZcfDoabx5+14t09i25xByZcvoWzVhXmapGfP6IIu3p89dgU+fv6B3l1bqy1GfJ1u5yPnw8TMkXblscVy8fFPj8x1S7sSpCxrvtCpP8iWcPHtZedZzZc+kqeiQMH5czQiyRry4sWGheddFJyiChYWFl3aDok7WYflHTDknf8YvOI4/zon5zYnMM+cl9OYFZv5nYeb9C/vd0xyZmnNUjaP2P+VRrmQh9QCYy48fSqaP5IGly1dvqQfXJjgvRub0afRZXraVyxbDsVPn1YNu9wPw0Jp8CDgM7IJtuw+jWYcB+KdhZ1y65rtR7aVBbUfWks5bugGXtP7JQ2sSzmqGrJbl5f/YYXaaUWcJ2y5D0L7nCIyftgix/4qpjPgmdarCzn4sWncbiuKFcqNAnuxeyobHnZu37mHhio1Yt2UP8pauq0LFOm0NQ5U11WcuXFH74t39p1IptOg0EI3b9oFOMzo72tZXeRJ9++6CGfNXoovnGz7y584GecWZbddB6q5Bnpxe11RLGQYSIIFgIMAqSYAEwiQBGrzBPG3tW9ZDi4bVDa20blob86cOR5JECdTru/QZ0aNFxYJpIzBz/CAM69dRLWsQr6nki6GaL1dWSSJt6uQYM7SHetDN+0Nrsl5XHi5Tip6RPABXpEBOtfd3mpSQ/IXTHbB9tTMa1qqk5PIaMfESyo4sc4gZI7oklaE6dXR/9dYAWRcsfZPlEBLEy6iUjKJYmnE7pE97rF88Ec5jB0L6nTplUqXxb7WyWKCNe8kMJwgDJQznUUbtouXUvlUwDjtWzzSMevX88ShTvKBhv/6/lSCy5bPHYIBdG7XeWZ8ZOZINFkxzgBwnIpMLmDmThkHCjHGDlMdX5AwkQAIkQAIkQAI+CdDg9cnkTyUsTwIkQAIkQAIkQAIkYEYEaPCa0WSwKyRAAiQQvghwNCRAAiRgHgRo8JrHPLAXJEACJEACJEACJEACwUQg1A3eYBoXqyUBEiABEiABEiABEiABRYAGr8LAiARIgARCnQA7QAIkQAIkEEwEaPAGE1hWSwIkQAIkQAIkQAIkEBgCQV+GBm/QM2WNJEACJEACJEACJEACZkSABq8ZTQa7QgIkYDoBapIACZAACZCAqQRo8JpKinrBQsB5TD98fn413ITYsf4KFk6slARIgARIgAT8IECxCQRo8JoAiSokQAIkQAIkQAIkQAJhlwAN3rA7d+w5CZhOgJokQAIkQAIkEIEJ0OCNwJMf2kNv1KghGjSojx8/XBjMhIGbmxssLS05H2YyH/pzw8bGBq6uPzgvZjQvFhYW+PnzJ+fEjObk5093WFjofjsn+vOK26D97g1tm+J37dPg/R0h5pMACZAACZAACZAACYRpAjR4w/T0sfPBQ4C1kgAJkAAJkAAJhCcCNHjD02yGobGs2rATjdv1Q9P2A/C/Y2fCUM/Db1cr1G6HQhUaq1CqeqvwO1AzH9mGbfvQwLaXmoe37z4Yeuvq5gaH8bPRvONAtOk+FI+ePDPkMRG8BM5fvq6YF6nUFHsOHof+79adB2qe9OdN9wFj9FnhZ2umIzl74Sr6DpuIsjVbw7brEBw8etrQ01ev36JTb0e07DwI/YdPwtdv3wx5TERcAjR4I+7ch9rI7z98ikUrNmPm+EEYPaQ7HMbNwrfvLqHWHzbsQcDS0gLHdi5RYf/GuR5CxiFOIGH8uBjWvxPixY3tpe3NOw7gzdt3WDBtBGr/Uw4jJ87zks+d4CMQOVIktG1WGyWL5PXRSJ4cmdU5I+fOBIdePvIpCB4CUaNERs9OzbFz7Uw0q/+P+h7RtzRp5lIUzJsD86YMQ8yYMbB09TZ9FrcRmAAN3gg8+UE09ABXc/j4GZTQvjiiRY2CRAnjIePfqXHyzCXwjwRIACiULwf+TpPSB4ojx8+icrliSl66eAFcvn4bn798VfuMgpdAhnSpkCdnFlhY8CszeEmbXnsG7XsjXpxYsLSwQNGCufDjxw+DJ/fIiXOoUt7jXKminTOHT5w1vWJqhlsCPHvD7dSa78Bevn6DJIniGzqYLElCvHj12rDPROgQcHd3R6l/WqK+djt9y86DodMJtuongZfabdqkiROqfCtLSyRKEA8vXr5R+4xCj4BceBSt1BRyW/3C5Ruh15EI3PL6LXuRTrtIjBI5sroI1OmA2LFiKiLJkybEy1c8TxSMCB7R4I3gB0BoDV+nXZXr29bptE8n/Q63oUZgsbMjdq+fjdZN62D6vJWQdYuh1hk27CsBne7XuWJhlPZVmcJgJ5AkcQJsWjoZ21c7Q7zuPQeNw5evXC8a7OCNGrhw+QaWrtmGQb3aGqTGnnidjmaOAUwET/BICOEDgM0B8ePGwbt37w0oZF1ignhxDftMhA6B+PHiQDyHZYrnR7mShXD52p3Q6Qhb9ZVA/Lix8eat0Xnz7gMSxI/jqy6FIUNA1pHGiB4NEhrWqqS87g8f82HCkKEP5bmdOmc5po7uh+RJE6lmZamcm5s7XH78UPuv376DfLapHUYRmgAN3gg9/aEz+KIFc+PQ8TP47uKivsCvXL+DAnmzhU5n2KoiIGtB3dzdVfrdh484fe4KsmRMo/YZmQeBwgVyYs/BE6ozJ05fRJqUSSFf7koQNqMw3+tPn78YxiBvbHj7/oPB8DJkMBEsBORNDAMcpqB/99ZInPDXEjlprHB+7Vw5cEyS2LX/KIpq547aYRShCdDgjdDTHzqDT5k8MWpWKYNWXQajW//R6N6hKWysrUOnM2xVEXikeaWKV2muXrHUsacDGmjeqhxZMqg8RiFLwHneSjUP8oVeuV4H9Bw0VnXgn0qlYGGhU68lm7tkHfp05avjFJgQiI6fOq/mZM/B47B3nKpehSXNbtt9SMmLaefOuOmL4DiwC8TrK3kMwUtg9cZduHjlJhq07q3mQF4N9+zFK9Vot3aNsHnn/9RryR48fIpGdaooOaOITcDCrIfPzoVbAnVrVMCSGU5Y5OyAEoXzhNtxhpWByRPPR7YvUq9XWjprJKqULx5Wuh7u+tm+ZT01D/KaKwljh/VUY5TlJgPsWqvXks2aMBgpknncwlWZjIKVgLziSuZCH/asn63ak88xkR3augDOYwciW+a/lZxR8BPwfp7IPMiDnNJyvLix1XzIa8kc7btCHmYTOUPEJkCDN2LPP0dPAiQQRgiwmyRAAiRAAoEnQIM38OxYkgRIgARIgARIgARIIGQJBKo1GryBwsZCJEACJEACJEACJEACYYUADd6wMlPsJwmQgOkEqEkCJEACJEACRgRo8BrBYJIESIAESIAESIAEwhMBjsWDAA1eDw6MSYAESIAESIAESIAEwikBGrzhdGI5LBIwnQA1SYAESIAESCB8E6DBG77nl6MjARIgARIgARIwlQD1wi0BGrzhdmo5MBIgARIgARIgARIgASFAg1coMJCA6QSoSQIkQAIkQAIkEMYI0OANYxPG7pIACZAACZCAeRBgL0gg7BCgwRt25oo9JQESIAESIAESIAESCAQBGryBgMYiphOgJgmQAAmQAAmQAAmENgEavKE9A2yfBEiABEggIhDgGEmABEKRAA3eUITPpkmABEiABEiABEiABIKfAA3e4GdsegvUJAESIAESIAESIAESOPkcLQAADclJREFUCHICNHiDHCkrJAESIAES+FMCLE8CJEACQUmABm9Q0mRdJEACJEACJEACJEACZkcgDBu8ZseSHSIBEiABEiABEiABEjBDAjR4zXBS2CUSIAESCBABKpMACZAACfhLgAavv3iYSQIkQAIkQAIkQAIkEFYI+NVPGrx+kaGcBEiABEiABEiABEggXBCgwRsuppGDIAESMJ0ANUmABEiABCIaARq8EW3GOV4SIAEvBE6fu4yu/Uahvm0vVK3fCbZdh+Ddh49Kp12P4Th59pJKh3b06Mkz9Bw0Fu17jsAprc/G/Vm5ficq1mkH6W8DbRx9h07A0+cvjVWCNS1tbdy2L1BtCN9OvR19Lbv/8EltPgajSKWmmL9soxedSTOXoKgmL1alOVp3G4pd+48a8mX8hSo0hj6UrdnakKdPyJyv2bRLv6u2P3/+RM2m3XzwVZmekfRj6pzlnntBs/n0+Qsat+2HHz9c8eXrNwxwmIJ2dsPhOH4OXN3cVCNv331Am+5D4erqqvYl2rTjAJznr5QkAwkEjkAEKkWDNwJNNodKAiTgk4CDZlQUyJsdy2aNwpYVU9GxVT2fSmYg2bb7EDJnSAfnsQORN2cWHz3KmTUDZoyzx0JnR4iRNH+pVwPRR4EgFDx7/gpbdh0Kwho9qvorZnR0sm2AciULeQiM4jrVy+PA5nnYs34WWjf9F04T5uDjp88GjW7tmuDYziUq7Fk/2yDXJ6pWKI5tuw/rd9VWfyHhG1+lEEzRktVbULFMUVhbW+Hof+cQ+6+YmDHeHp+/fMGFyzdUqxNnLNGOzfqwsrJS+xJVLlcMu/cfx/sPn2SXgQRIwB8CNHj9gcMsEiABhHsEL16+RrGCuWBh4fFxmCt7JsSKGcMw7oNHTqNjLwfUamaH1Rt/eQRXrNuBSnU7oGGbPujWfxQePn5mKCOexelzV6BL35FYvna7yhOvo3jxmrTvj+17vBpa+oJisA0fOwuN2/VTHj/xJkqeePK2aAbltt3/g3hxP3/5KmJfg421NfLlyoYXr94Y8ldt2AlpV0L/4ZPw+u07lTdr4Wr0HTYR4mFt0LoPJE/v3farL1JQ+jB68nxVbviYmZimjfXOvYeqb+KVFJ3/zlxEW7thaNZhgNpeuX5bxCqIh7ROix7ooHE9cOSUkvkW5dbmIme2jLC0tPSRnSRRAmX8RbKxwV8xokOns4C7+08fen4JShXNp+bl7v3HBpUtO/+HquVL4M3b94qXzG29Vj2xZNVWg45xYty0RRDvul7mPG+lwRP99ds3SL5wbdSmL2TM7u7uelUvWzG8y5YsoGTW2vwJe/E2yzxHjmSj7jLIOHNoFzVKyTOy0rgU1C7Wdu474inhhgRIwC8CHp/wfuVSTgIkQALhnEDnNo3QUbulLsbpopWbIUsHjIfspt1SnjyqH+ZOGYpFKzYZDMn8ubNh87LJyjNcvnRhOE2ca1wMyZIkxOSRfdGgViUMHjkdxYvkxZKZTpiiyRYs34Drt+550ZedWQvXal7KT1g03QGTRvbBhq17cfj4WfxTsSRKF8uHf6uWVV7caFGjiLqvQW55nz5/GZXLFVX5RzSP4c59RzFFG8NizfsrBuToSfNUnkT3Hz7ByMHdsHz2KCROGA/zlqwTMfzqi8rUoq/fvqvx2fdqqzyPaVIlV33rb2erDOoR42ajV6fmWKiNxa5DU/QbNkl5nvf+7zj+d/QU5k8djomOvXHrzgOttsD9nzJ7mVq2IAb4lFF9IR5hfU0TZyxWeXLxId5fvVy/FU+pzNvmnQeUSJYSSL+qVSyBKFEiwXFgFzW3cyYNxb5DJ3DmwlWlZ2o0Z/E6yLEjc7lg2gg8f/Eaqzbs8lFcLpQsdDokShBP5RUvlFsbRzTYO05DtszpkS5NCjjPW4VOreurfO9R9ix/4+zFgPXNex3cN5UA9cIyARq8YXn22HcSIIE/JlCvZgWIISi3uM+cv4JGbfrh+s27hnqLagaIpYWF8vqKUXf3/iOVZ2FpgTmacdi13yhs2n4AN7wZsBXKFFF6Hz5+wtUbd5SOGGZ9NcPv8+dvhlvVSskzkvYb1qoMC629uLFjoVK5ohDj1TPb383Bo6eVgSdrWsVDWbxwXqV//OQFvHv/EX2HTlQeWFnreuHKLZUnUf7cWRE9WlRJonTxgprxdF2lf9eXMsULqH4qZW/R+Us38E0ziMdOW6janOC8WN12f/DoKc5euI5qFUupNsUbXataWW+lTd/t3LohDm6Zj/EjemHIKGcv65aNlzT0627ra6XVKpTA9t2HNc+wO3bvP4rsWTIgQbw4iBwpEs5evIaho2eg1+DxkPWz1278OiZ8rcyb8MSpi7h09RY693VS4ead+9qce7A1Vn389DnixY1tEOl0Oth1aIYRAzqhVeOamKsZzg1rV9bm8BMmzVyCKbOWKs+0vkDihPG1i7QX+l1uSYAE/CBAg9cPMBSTQGAIsEzYJCCewfKlCmsexz4QA3fbnl/rUW2sf62ZFEPU1dXjtrTdgNFInzYVhvRpj9FDukM8nsajl1vQsi+348WbOH3MAOUBlXW2slZY1qBKvnH4iZ/abfpft++tLK0gt7aNdfxKlyicR61XFY+qPPwkyxVEV6f7iSrlihnaFo/l9lXTJcvf8Lu+RIpk7Wd5nU6HDOlSGdqUMct62zQpk2kj1MZoaTRGozWpflboT4aNtTVkGUrsWDFx+dqvZRP+FDFkZfw7NeLGiYUjJ85h6+5DkIseydyy6yD2/e8EmtSthqmj+6NowdwQD7DkGQdLSx3cjJYpiHfdkK8DenRsamCwYs4YONp3NWTrEzY2NvBSTp+hbe/ef4xbdx+gbImCcBw/W61lLlEkH0Ya3U349t0FwkBT538SIAF/CNDg9QcOs0iABMI/gX2H/jMYLW/ffcBdzYMbP25cfwf+9ds3vH3/QTOEckEMrT0Hj/upL8sPxLCarHnm9Gs4b999iFev3/ookydHFrXmV4xcWWcrazNlPa4PRX8E6dOmRO8uLbF64248e/EKhfPnxPpt+3BHG5cUc/nxw8vt+QOHT6llGtLmyvU7kDt7RlFDQPoSPXpUfPj4UZWTKGfWDGrJxt6DJ2RXhWMnz6ut1C/LLKQ9EYixKduAhtNGb6q4cfs+7tx7hMwZ0gS0Gs3bXBILV2zC/YdPIet6pYJ7mqEpywnSpEqqGaNuOHbynIh9hBRJE+Oh5rWWDOH639nLklShiMZ95sI1kPW4IpD59G0Zy99pUuDxU989tGOnLkDPTs2lONx/uivvc7y4sbSLBiVSkSzBkTlXO+YVsTckYFYEaPCa1XSwMyRAAiFNYMfew6jZpBtsuw7GPw07I2XyxKhTo5y/3YgSOTIa1a6CBrZ91CvNXr9556/+0L7tNQP3PZq06w95WMveaarByDYu2KZZLUTW6m7aYQC69h2FyuWKo0iBnMYqJqWzZEyL0sXyY9GKzSiYN4e6NT5szEw07zgQVep1xMXLNw31ZNKMxB72Y9GgdW/NuHNFi0Y1VV5A+pImVXLkzJoRdgNHa57IOeoiQNYFr9uyB8072UNembZ+615Vb5niBTXvb0rIUhDRf2n0cJ1SMIqkjKzBlYf1Zi1crZZsnL3gsV51046Dal/y29oNQ+umtSEPshkVNylZqWwRtYSlXMlCmnfdw5tfs2pZyHEhrwYbMmq65slP6WtdZUsW1C4erkDpjZyOFEkTGfSEY8a/U6m8xu36oXmHgXj77r0hX5+IET0asmVOBzHa9TLZCjt5e4gsWZD9Jpq3uVMfR43xGDSuU0VEKpy5cA0VShdWaUYkQAJ+E7DwO4s5JBDMBFg9CZgBgdFD7LBp6WTIrf5D2xbCyb4b9MsR5FZ8vlxZDb2c4NDLYIDaNvkXaxeOxySnPsrYOrJ9kUFPXodl2NESYojJmsyls0Zi9fxx6mGohPHjajle/4vxY9+zjVpTvGSmE1o0rG5Q6NauCWQtp0FglJB1yCMHdzeSAEP7dtA8vS2UrEbl0lgwdTjk4and62ahWYN/lFyiNCmTqvb0t9z1b6jwry/euVhaWEDWyY4f0Rvy0JrUmzt7JkwbMwDS7o7VMyCcRS5B1t7KA32iL1tZNiBy76FmlTJqmYbw1AdZviB6Mj69bP/GuRAGIpcgLIz3ReZXiBkjOmTee3ZqZlCRBw5lnuTVYCMHdVNLEWS+RUHmRF6VJmkpu3LuWPUKMUf7rnAY2MUwZ5Ej2aBLm0aQOV8ywwmbl09VFx9SzntoUKsyNmsGvLFcHlBsWq+aQVSsUG7IHEkQr71kyB2J16/fIWe2jLLLQAIk4A8BGrz+wGEWCZAACZAACQQ3AbmoSpEska9ef//avvfgMbp3aOKfCvNIgAQ8CdDg9QTBDQmQAAlENAJtmtWBhIg2bnMcrzzEaGkRsK9k8XZnSJfKHIfDPpGA2REI2Nlldt2PSB3iWEmABEiABEiABEiABAJDgAZvYKixDAmQAAmQQOgRYMskQAIkEEACNHgDCIzqJEACJEACJEACJEACYYtAeDV4w9YssLckQAIkQAIkQAIkQALBRoAGb7ChZcUkQAIkYA4E2AcSIAESIAEavDwGSIAESIAESIAESIAEwjUBZfCG6xFycCRAAiRAAiRAAiRAAhGaAA3eCD39HDwJkIA3AtwlARIgARIIhwRo8IbDSeWQSIAESIAESIAESODPCISv0v8HAAD//0zyy/4AAAAGSURBVAMAng//wgbv5CoAAAAASUVORK5CYII="
      },
      "metadata": {},
      "output_type": "display_data"
@@ -2108,13 +2117,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c6e655b",
+   "id": "c0ba597a",
    "metadata": {
     "papermill": {
-     "duration": 0.002314,
-     "end_time": "2026-05-16T23:42:19.234349+00:00",
+     "duration": 0.009536,
+     "end_time": "2026-09-08T22:55:41.499659+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:19.232035+00:00",
+     "start_time": "2026-09-08T22:55:41.490123+00:00",
      "status": "completed"
     }
    },
@@ -2128,19 +2137,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "a0035810",
+   "id": "61e8556d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:24.040276Z",
-     "iopub.status.busy": "2026-07-13T21:37:24.039905Z",
-     "iopub.status.idle": "2026-07-13T21:37:26.328485Z",
-     "shell.execute_reply": "2026-07-13T21:37:26.328137Z"
+     "iopub.execute_input": "2026-09-08T22:55:41.525877Z",
+     "iopub.status.busy": "2026-09-08T22:55:41.525678Z",
+     "iopub.status.idle": "2026-09-08T22:55:47.040685Z",
+     "shell.execute_reply": "2026-09-08T22:55:47.039262Z"
     },
     "papermill": {
-     "duration": 1.985352,
-     "end_time": "2026-05-16T23:42:21.222011+00:00",
+     "duration": 5.531115,
+     "end_time": "2026-09-08T22:55:47.041396+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:19.236659+00:00",
+     "start_time": "2026-09-08T22:55:41.510281+00:00",
      "status": "completed"
     }
    },
@@ -2149,7 +2158,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Recent 10-K filings available: 6529\n"
+      "Recent 10-K filings available: 6780\n"
      ]
     }
    ],
@@ -2162,19 +2171,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "453963c4",
+   "id": "03a8a9d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:26.329868Z",
-     "iopub.status.busy": "2026-07-13T21:37:26.329785Z",
-     "iopub.status.idle": "2026-07-13T21:37:26.403043Z",
-     "shell.execute_reply": "2026-07-13T21:37:26.402641Z"
+     "iopub.execute_input": "2026-09-08T22:55:47.077698Z",
+     "iopub.status.busy": "2026-09-08T22:55:47.077312Z",
+     "iopub.status.idle": "2026-09-08T22:55:48.592774Z",
+     "shell.execute_reply": "2026-09-08T22:55:48.588751Z"
     },
     "papermill": {
-     "duration": 0.46601,
-     "end_time": "2026-05-16T23:42:21.690683+00:00",
+     "duration": 1.528606,
+     "end_time": "2026-09-08T22:55:48.593219+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:21.224673+00:00",
+     "start_time": "2026-09-08T22:55:47.064613+00:00",
      "status": "completed"
     }
    },
@@ -2183,12 +2192,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10-K filings in last week: 10\n",
-      "2026-07-10 | ADM TRONICS UNLIMITED, INC.\n",
-      "2026-07-10 | DeltaSoft Corp\n",
-      "2026-07-10 | Radiant Strategies Corp\n",
-      "2026-07-10 | Sports Entertainment Gaming Global Corp\n",
-      "2026-07-09 | Barnes & Noble Education, Inc.\n"
+      "10-K filings in last week: 21\n",
+      "2026-09-04 | Blue Chip Capital Group Inc.\n",
+      "2026-09-04 | Elite Performance Holding Corp\n",
+      "2026-09-04 | PREAXIA HEALTH CARE PAYMENT SYSTEMS INC.\n",
+      "2026-09-04 | TWIN DISC INC\n",
+      "2026-09-03 | BRADY CORP\n"
      ]
     }
    ],
@@ -2207,13 +2216,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1cc405d",
+   "id": "8dba999a",
    "metadata": {
     "papermill": {
-     "duration": 0.002446,
-     "end_time": "2026-05-16T23:42:21.695798+00:00",
+     "duration": 0.003994,
+     "end_time": "2026-09-08T22:55:48.601806+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:21.693352+00:00",
+     "start_time": "2026-09-08T22:55:48.597812+00:00",
      "status": "completed"
     }
    },
@@ -2227,19 +2236,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "88ab1ede",
+   "id": "48f4f07f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:26.404436Z",
-     "iopub.status.busy": "2026-07-13T21:37:26.404351Z",
-     "iopub.status.idle": "2026-07-13T21:37:26.406647Z",
-     "shell.execute_reply": "2026-07-13T21:37:26.406301Z"
+     "iopub.execute_input": "2026-09-08T22:55:48.614164Z",
+     "iopub.status.busy": "2026-09-08T22:55:48.614029Z",
+     "iopub.status.idle": "2026-09-08T22:55:48.620717Z",
+     "shell.execute_reply": "2026-09-08T22:55:48.620187Z"
     },
     "papermill": {
-     "duration": 0.006217,
-     "end_time": "2026-05-16T23:42:21.704402+00:00",
+     "duration": 0.012602,
+     "end_time": "2026-09-08T22:55:48.621494+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:21.698185+00:00",
+     "start_time": "2026-09-08T22:55:48.608892+00:00",
      "status": "completed"
     }
    },
@@ -2271,19 +2280,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "56528843",
+   "id": "fc10b36a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:26.407556Z",
-     "iopub.status.busy": "2026-07-13T21:37:26.407438Z",
-     "iopub.status.idle": "2026-07-13T21:37:27.209223Z",
-     "shell.execute_reply": "2026-07-13T21:37:27.208914Z"
+     "iopub.execute_input": "2026-09-08T22:55:48.638083Z",
+     "iopub.status.busy": "2026-09-08T22:55:48.637950Z",
+     "iopub.status.idle": "2026-09-08T22:55:51.874643Z",
+     "shell.execute_reply": "2026-09-08T22:55:51.874374Z"
     },
     "papermill": {
-     "duration": 0.932235,
-     "end_time": "2026-05-16T23:42:22.639136+00:00",
+     "duration": 3.245637,
+     "end_time": "2026-09-08T22:55:51.878330+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:21.706901+00:00",
+     "start_time": "2026-09-08T22:55:48.632693+00:00",
      "status": "completed"
     }
    },
@@ -2354,19 +2363,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "1ec6a74f",
+   "id": "bcefc89a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T21:37:27.210306Z",
-     "iopub.status.busy": "2026-07-13T21:37:27.210230Z",
-     "iopub.status.idle": "2026-07-13T21:37:27.211994Z",
-     "shell.execute_reply": "2026-07-13T21:37:27.211769Z"
+     "iopub.execute_input": "2026-09-08T22:55:51.911433Z",
+     "iopub.status.busy": "2026-09-08T22:55:51.907715Z",
+     "iopub.status.idle": "2026-09-08T22:55:51.921850Z",
+     "shell.execute_reply": "2026-09-08T22:55:51.914903Z"
     },
     "papermill": {
-     "duration": 0.005601,
-     "end_time": "2026-05-16T23:42:22.647404+00:00",
+     "duration": 0.036641,
+     "end_time": "2026-09-08T22:55:51.922269+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:22.641803+00:00",
+     "start_time": "2026-09-08T22:55:51.885628+00:00",
      "status": "completed"
     }
    },
@@ -2401,13 +2410,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "258c22c4",
+   "id": "bb10b56b",
    "metadata": {
     "papermill": {
-     "duration": 0.002433,
-     "end_time": "2026-05-16T23:42:22.652399+00:00",
+     "duration": 0.007032,
+     "end_time": "2026-09-08T22:55:51.937031+00:00",
      "exception": false,
-     "start_time": "2026-05-16T23:42:22.649966+00:00",
+     "start_time": "2026-09-08T22:55:51.929999+00:00",
      "status": "completed"
     }
    },
@@ -2445,22 +2454,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-07-13T21:37:28.861958+00:00",
-   "executor": "nbconvert",
+   "executed_at": "2026-09-08T22:56:12.306665+00:00",
+   "executor": "local-uv",
+   "library_digest": "2b3316d44172a3281c167ab9f63af735dc4b11ee77739ed59f373aa69640b4ed",
+   "outputs_digest": "bd64e451fee6df47af24e12878368dd1201a1bf33c324fd3034e5bbede196bc8",
    "parameters": {},
    "production": true,
-   "source_py_blob": "ce6b639da841cdb0970dd192bc38656a474940e0"
+   "source_py_blob": "d3b21c3e1c3e03e48b1d1f5b7a865cf6a19bbd2d"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.574106,
-   "end_time": "2026-05-16T23:42:23.172310+00:00",
+   "duration": 35.320063,
+   "end_time": "2026-09-08T22:55:54.959003+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "04_fundamental_alternative_data/02_sec_filing_explorer.ipynb",
-   "output_path": "04_fundamental_alternative_data/02_sec_filing_explorer.ipynb",
+   "input_path": "~/ml4t/public-onboarding/04_fundamental_alternative_data/.02_sec_filing_explorer.build.1551299.ipynb",
+   "output_path": "~/ml4t/public-onboarding/04_fundamental_alternative_data/.02_sec_filing_explorer.papermill.1551299.ipynb",
    "parameters": {},
-   "start_time": "2026-05-16T23:42:12.598204+00:00",
+   "start_time": "2026-09-08T22:55:19.638940+00:00",
    "version": "2.7.0"
   }
  },

--- a/04_fundamental_alternative_data/02_sec_filing_explorer.py
+++ b/04_fundamental_alternative_data/02_sec_filing_explorer.py
@@ -79,15 +79,22 @@ from edgar import Company, find, get_filings, set_identity
 from utils.style import COLORS
 
 # SEC requires a real User-Agent (name + email) for every request and blocks
-# placeholder addresses. Set `EDGAR_IDENTITY` in your environment, e.g.
-# `export EDGAR_IDENTITY="Jane Doe jane@example.org"`.
+# placeholder addresses. It is not an API key: put your own name and email on
+# the `EDGAR_IDENTITY` line of `.env` in the repository root, e.g.
+# `EDGAR_IDENTITY=Jane Doe jane@example.org`.
 edgar_identity = os.environ.get("EDGAR_IDENTITY")
 if not edgar_identity:
     raise RuntimeError(
-        "EDGAR_IDENTITY environment variable is not set. The SEC requires a "
-        "real User-Agent (name + email) for every EDGAR request and blocks "
-        "placeholder addresses. Set it before running this notebook, e.g. "
-        '`export EDGAR_IDENTITY="Jane Doe jane@example.org"`.'
+        "EDGAR_IDENTITY is not set. The SEC requires a real User-Agent - your "
+        "name and email - on every EDGAR request, and blocks placeholder "
+        "addresses. It is not an API key and there is nothing to sign up for.\n"
+        "Put your own name and email on the EDGAR_IDENTITY line of the .env "
+        "file in the repository root:\n"
+        "    EDGAR_IDENTITY=Jane Doe jane@example.org\n"
+        ".env is read once, when the process starts, so then restart this "
+        "notebook's kernel (Kernel -> Restart Kernel). On the Docker path, stop "
+        "Jupyter Lab and run `docker compose up ml4t` again - `docker compose "
+        "restart` keeps the environment the container was created with."
     )
 set_identity(edgar_identity)
 

--- a/04_fundamental_alternative_data/14_text_data_extraction.ipynb
+++ b/04_fundamental_alternative_data/14_text_data_extraction.ipynb
@@ -2,8 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "adaf08d3",
+   "id": "278bd1be",
    "metadata": {
+    "papermill": {
+     "duration": 0.002378,
+     "end_time": "2026-09-08T22:57:54.540378+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:57:54.538000+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "# Text Data Extraction: Structuring Unstructured Financial Documents\n",
@@ -45,13 +52,20 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "959cc2b5",
+   "id": "7a5cd484",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:06.443864Z",
-     "iopub.status.busy": "2026-07-13T22:39:06.443745Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.920991Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.920395Z"
+     "iopub.execute_input": "2026-09-08T22:57:54.553987Z",
+     "iopub.status.busy": "2026-09-08T22:57:54.553857Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.504497Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.503961Z"
+    },
+    "papermill": {
+     "duration": 9.959802,
+     "end_time": "2026-09-08T22:58:04.508511+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:57:54.548709+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -81,13 +95,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "7b2a7030",
+   "id": "be0e85b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.922430Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.922248Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.924282Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.923868Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.526200Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.525888Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.537121Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.536760Z"
+    },
+    "papermill": {
+     "duration": 0.040078,
+     "end_time": "2026-09-08T22:58:04.550858+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.510780+00:00",
+     "status": "completed"
     },
     "tags": [
      "parameters"
@@ -102,8 +123,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0daaf10f",
+   "id": "86a8d1dc",
    "metadata": {
+    "papermill": {
+     "duration": 0.009548,
+     "end_time": "2026-09-08T22:58:04.568958+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.559410+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 1. SEC Filing Structure\n",
@@ -126,15 +154,22 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b317fde4",
+   "id": "c967fa43",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.925569Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.925499Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.928849Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.928347Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.583798Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.583637Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.597763Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.597173Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.029914,
+     "end_time": "2026-09-08T22:58:04.600713+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.570799+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -234,9 +269,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6b9fe4a",
+   "id": "4aa47594",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.012234,
+     "end_time": "2026-09-08T22:58:04.615054+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.602820+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 2. Text Cleaning Functions\n",
@@ -247,13 +289,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7da03d4e",
+   "id": "2dbde3d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.929859Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.929769Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.932116Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.931689Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.643076Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.642468Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.655469Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.655163Z"
+    },
+    "papermill": {
+     "duration": 0.031805,
+     "end_time": "2026-09-08T22:58:04.659544+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.627739+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -283,13 +332,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "cc7ac3e0",
+   "id": "803bf47a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.933025Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.932937Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.935682Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.935261Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.672083Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.671874Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.680126Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.679565Z"
+    },
+    "papermill": {
+     "duration": 0.018564,
+     "end_time": "2026-09-08T22:58:04.680464+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.661900+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -332,13 +388,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "d33bc058",
+   "id": "832b45e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.936674Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.936610Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.939688Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.939325Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.686911Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.686686Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.696264Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.695537Z"
+    },
+    "papermill": {
+     "duration": 0.014222,
+     "end_time": "2026-09-08T22:58:04.696630+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.682408+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -408,9 +471,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1c3e33b",
+   "id": "cb164527",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006588,
+     "end_time": "2026-09-08T22:58:04.705336+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.698748+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 3. Section Extraction"
@@ -419,13 +489,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "69aba95d",
+   "id": "c332faa2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.940492Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.940428Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.945345Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.945028Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.715261Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.714271Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.730343Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.729923Z"
+    },
+    "papermill": {
+     "duration": 0.021617,
+     "end_time": "2026-09-08T22:58:04.730986+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.709369+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -620,9 +697,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "438d5831",
+   "id": "a2a22cd9",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.00399,
+     "end_time": "2026-09-08T22:58:04.737001+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.733011+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 4. Building a Text Dataset"
@@ -631,13 +715,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "0b5c7317",
+   "id": "1612a31d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.946225Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.946156Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.952261Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.951892Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.746362Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.746242Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.762093Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.761841Z"
+    },
+    "papermill": {
+     "duration": 0.020939,
+     "end_time": "2026-09-08T22:58:04.762869+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.741930+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -792,9 +883,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4039d22",
+   "id": "4f6ed4f2",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.004956,
+     "end_time": "2026-09-08T22:58:04.770062+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.765106+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 5. Text Statistics and Quality Checks"
@@ -803,15 +901,22 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "947f2307",
+   "id": "e712b36a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.953251Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.953175Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.955580Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.955276Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.780307Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.780164Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.786383Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.785815Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.011498,
+     "end_time": "2026-09-08T22:58:04.786673+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.775175+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -846,9 +951,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e495ed4c",
+   "id": "00f1b7f9",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.005108,
+     "end_time": "2026-09-08T22:58:04.793980+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.788872+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### Quality Check Extraction\n",
@@ -858,13 +970,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a7534900",
+   "id": "a10541ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.956566Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.956430Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.966147Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.965690Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.804614Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.804440Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.829207Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.828744Z"
+    },
+    "papermill": {
+     "duration": 0.032881,
+     "end_time": "2026-09-08T22:58:04.829793+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.796912+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -948,13 +1067,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "b0e04cb7",
+   "id": "69bcc07e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.967210Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.967084Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.970504Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.970058Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.839165Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.839018Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.846721Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.846408Z"
+    },
+    "papermill": {
+     "duration": 0.012959,
+     "end_time": "2026-09-08T22:58:04.847215+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.834256+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -985,9 +1111,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "978f5052",
+   "id": "42b8f7e1",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.010121,
+     "end_time": "2026-09-08T22:58:04.861217+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.851096+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 6. Change Analysis Over Time\n",
@@ -998,13 +1131,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "2bdd5191",
+   "id": "6c1a497e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.971664Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.971552Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.974290Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.973898Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.888812Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.888676Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.892707Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.892379Z"
+    },
+    "papermill": {
+     "duration": 0.020837,
+     "end_time": "2026-09-08T22:58:04.894377+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.873540+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -1039,13 +1179,20 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "9af7bb68",
+   "id": "c897f909",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.975417Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.975297Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.978392Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.977940Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.909645Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.909420Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.922927Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.922552Z"
+    },
+    "papermill": {
+     "duration": 0.026405,
+     "end_time": "2026-09-08T22:58:04.925516+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.899111+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -1077,13 +1224,20 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "428d5bf0",
+   "id": "4bc26c4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.979521Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.979397Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.982505Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.982189Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.941383Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.941093Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.951498Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.951167Z"
+    },
+    "papermill": {
+     "duration": 0.018765,
+     "end_time": "2026-09-08T22:58:04.952366+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.933601+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1146,9 +1300,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6cc7776",
+   "id": "663b5bc0",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.010668,
+     "end_time": "2026-09-08T22:58:04.969489+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.958821+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 7. Saving the Dataset"
@@ -1157,13 +1318,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "d783f693",
+   "id": "00760f7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.983790Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.983677Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.986119Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.985856Z"
+     "iopub.execute_input": "2026-09-08T22:58:04.987729Z",
+     "iopub.status.busy": "2026-09-08T22:58:04.987592Z",
+     "iopub.status.idle": "2026-09-08T22:58:04.990481Z",
+     "shell.execute_reply": "2026-09-08T22:58:04.990015Z"
+    },
+    "papermill": {
+     "duration": 0.016816,
+     "end_time": "2026-09-08T22:58:04.993852+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:04.977036+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -1197,13 +1365,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "6046edd1",
+   "id": "7b071c27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.987142Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.987082Z",
-     "iopub.status.idle": "2026-07-13T22:39:09.988580Z",
-     "shell.execute_reply": "2026-07-13T22:39:09.988334Z"
+     "iopub.execute_input": "2026-09-08T22:58:05.019543Z",
+     "iopub.status.busy": "2026-09-08T22:58:05.019399Z",
+     "iopub.status.idle": "2026-09-08T22:58:05.024532Z",
+     "shell.execute_reply": "2026-09-08T22:58:05.024154Z"
+    },
+    "papermill": {
+     "duration": 0.022396,
+     "end_time": "2026-09-08T22:58:05.024981+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:05.002585+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1226,8 +1401,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94c660be",
+   "id": "da02abdb",
    "metadata": {
+    "papermill": {
+     "duration": 0.011005,
+     "end_time": "2026-09-08T22:58:05.043238+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:05.032233+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 8. End-to-End Run Against a Live EDGAR Filing\n",
@@ -1240,11 +1422,13 @@
     "what the synthetic example produced earlier in the notebook.\n",
     "\n",
     "The SEC requires a real User-Agent identity for every request and\n",
-    "blocks placeholder addresses. Set `EDGAR_IDENTITY` in your environment\n",
-    "to `\"Your Name your.email@domain.com\"` before running this section:\n",
+    "blocks placeholder addresses. It is not an API key and there is nothing\n",
+    "to sign up for: put your own name and email on the `EDGAR_IDENTITY` line\n",
+    "of the `.env` file in the repository root, then restart this notebook's\n",
+    "kernel so it is read.\n",
     "\n",
-    "```bash\n",
-    "export EDGAR_IDENTITY=\"Jane Doe jane@example.org\"\n",
+    "```\n",
+    "EDGAR_IDENTITY=Jane Doe jane@example.org\n",
     "```\n",
     "\n",
     "The fetch is read-only, rate-limited by edgartools, and typically\n",
@@ -1254,13 +1438,20 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "a51a61c0",
+   "id": "4121cbb3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:09.989331Z",
-     "iopub.status.busy": "2026-07-13T22:39:09.989272Z",
-     "iopub.status.idle": "2026-07-13T22:39:10.267728Z",
-     "shell.execute_reply": "2026-07-13T22:39:10.267384Z"
+     "iopub.execute_input": "2026-09-08T22:58:05.050595Z",
+     "iopub.status.busy": "2026-09-08T22:58:05.050460Z",
+     "iopub.status.idle": "2026-09-08T22:58:05.236548Z",
+     "shell.execute_reply": "2026-09-08T22:58:05.235445Z"
+    },
+    "papermill": {
+     "duration": 0.192682,
+     "end_time": "2026-09-08T22:58:05.238211+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:05.045529+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1276,10 +1467,16 @@
     "edgar_identity = os.environ.get(\"EDGAR_IDENTITY\")\n",
     "if not edgar_identity:\n",
     "    raise RuntimeError(\n",
-    "        \"EDGAR_IDENTITY environment variable is not set. The SEC requires a \"\n",
-    "        \"real User-Agent (name + email) for every EDGAR request and blocks \"\n",
-    "        \"placeholder addresses. Set it before running this section, e.g. \"\n",
-    "        '`export EDGAR_IDENTITY=\"Jane Doe jane@example.org\"`.'\n",
+    "        \"EDGAR_IDENTITY is not set. The SEC requires a real User-Agent - your \"\n",
+    "        \"name and email - on every EDGAR request, and blocks placeholder \"\n",
+    "        \"addresses. It is not an API key and there is nothing to sign up for.\\n\"\n",
+    "        \"Put your own name and email on the EDGAR_IDENTITY line of the .env \"\n",
+    "        \"file in the repository root:\\n\"\n",
+    "        \"    EDGAR_IDENTITY=Jane Doe jane@example.org\\n\"\n",
+    "        \".env is read once, when the process starts, so then restart this \"\n",
+    "        \"notebook's kernel (Kernel -> Restart Kernel). On the Docker path, stop \"\n",
+    "        \"Jupyter Lab and run `docker compose up ml4t` again - `docker compose \"\n",
+    "        \"restart` keeps the environment the container was created with.\"\n",
     "    )\n",
     "set_identity(edgar_identity)\n",
     "\n",
@@ -1292,8 +1489,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55712373",
+   "id": "8b08dd8d",
    "metadata": {
+    "papermill": {
+     "duration": 0.007359,
+     "end_time": "2026-09-08T22:58:05.258321+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:05.250962+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "Fetch the filing text and run the section extractor with the\n",
@@ -1305,13 +1509,20 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "67ce88e7",
+   "id": "558c8e89",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:10.268884Z",
-     "iopub.status.busy": "2026-07-13T22:39:10.268809Z",
-     "iopub.status.idle": "2026-07-13T22:39:11.243312Z",
-     "shell.execute_reply": "2026-07-13T22:39:11.242790Z"
+     "iopub.execute_input": "2026-09-08T22:58:05.282360Z",
+     "iopub.status.busy": "2026-09-08T22:58:05.281924Z",
+     "iopub.status.idle": "2026-09-08T22:58:07.007394Z",
+     "shell.execute_reply": "2026-09-08T22:58:07.003611Z"
+    },
+    "papermill": {
+     "duration": 1.742525,
+     "end_time": "2026-09-08T22:58:07.007973+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:05.265448+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1383,8 +1594,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47ad6360",
+   "id": "1edd04a2",
    "metadata": {
+    "papermill": {
+     "duration": 0.010505,
+     "end_time": "2026-09-08T22:58:07.030319+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:07.019814+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "A successful run shows non-zero word counts on each row - the same\n",
@@ -1403,13 +1621,20 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "40df5312",
+   "id": "000c0e0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T22:39:11.244446Z",
-     "iopub.status.busy": "2026-07-13T22:39:11.244346Z",
-     "iopub.status.idle": "2026-07-13T22:39:12.572175Z",
-     "shell.execute_reply": "2026-07-13T22:39:12.571806Z"
+     "iopub.execute_input": "2026-09-08T22:58:07.041755Z",
+     "iopub.status.busy": "2026-09-08T22:58:07.041564Z",
+     "iopub.status.idle": "2026-09-08T22:58:10.092334Z",
+     "shell.execute_reply": "2026-09-08T22:58:10.092039Z"
+    },
+    "papermill": {
+     "duration": 3.055529,
+     "end_time": "2026-09-08T22:58:10.092821+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:07.037292+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1462,10 +1687,10 @@
           "colorway": [
            "#0a1628",
            "#D4A84B",
-           "#1a2d4a",
            "#C87533",
            "#10b981",
-           "#ef4444"
+           "#ef4444",
+           "#94a3b8"
           ],
           "font": {
            "color": "#334155",
@@ -1597,8 +1822,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64d4ba3e",
+   "id": "034a0248",
    "metadata": {
+    "papermill": {
+     "duration": 0.002852,
+     "end_time": "2026-09-08T22:58:10.098768+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:10.095916+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## 9. Key Takeaways\n",
@@ -1649,6 +1881,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "tags,-all"
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -1667,22 +1902,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-07-13T22:39:14.391091+00:00",
-   "executor": "nbconvert",
+   "executed_at": "2026-09-08T22:58:26.011866+00:00",
+   "executor": "local-uv",
+   "library_digest": "2b3316d44172a3281c167ab9f63af735dc4b11ee77739ed59f373aa69640b4ed",
+   "outputs_digest": "716596e41fb94bb617c95c0c7139ecc3a44c5af31e7414e01522069b27ee0b1e",
    "parameters": {},
    "production": true,
-   "source_py_blob": "a8c5ff4488982f7906dfd417868da7e1b56088f9"
+   "source_py_blob": "d03c4139e96f7788dda315b7b06c39de53e7be22"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.284106,
-   "end_time": "2026-05-16T23:42:32.483343+00:00",
+   "duration": 20.334825,
+   "end_time": "2026-09-08T22:58:13.826689+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "04_fundamental_alternative_data/14_text_data_extraction.ipynb",
-   "output_path": "04_fundamental_alternative_data/14_text_data_extraction.ipynb",
+   "input_path": "~/ml4t/public-onboarding/04_fundamental_alternative_data/.14_text_data_extraction.build.1580678.ipynb",
+   "output_path": "~/ml4t/public-onboarding/04_fundamental_alternative_data/.14_text_data_extraction.papermill.1580678.ipynb",
    "parameters": {},
-   "start_time": "2026-05-16T23:42:29.199237+00:00",
+   "start_time": "2026-09-08T22:57:53.491864+00:00",
    "version": "2.7.0"
   }
  },

--- a/04_fundamental_alternative_data/14_text_data_extraction.py
+++ b/04_fundamental_alternative_data/14_text_data_extraction.py
@@ -1,11 +1,12 @@
 # ---
 # jupyter:
 #   jupytext:
+#     cell_metadata_filter: tags,-all
 #     text_representation:
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.18.1
+#       jupytext_version: 1.19.3
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -800,11 +801,13 @@ print("  save_text_dataset(text_dataset, 'data/sec_text_data.parquet')")
 # what the synthetic example produced earlier in the notebook.
 #
 # The SEC requires a real User-Agent identity for every request and
-# blocks placeholder addresses. Set `EDGAR_IDENTITY` in your environment
-# to `"Your Name your.email@domain.com"` before running this section:
+# blocks placeholder addresses. It is not an API key and there is nothing
+# to sign up for: put your own name and email on the `EDGAR_IDENTITY` line
+# of the `.env` file in the repository root, then restart this notebook's
+# kernel so it is read.
 #
-# ```bash
-# export EDGAR_IDENTITY="Jane Doe jane@example.org"
+# ```
+# EDGAR_IDENTITY=Jane Doe jane@example.org
 # ```
 #
 # The fetch is read-only, rate-limited by edgartools, and typically
@@ -814,10 +817,16 @@ print("  save_text_dataset(text_dataset, 'data/sec_text_data.parquet')")
 edgar_identity = os.environ.get("EDGAR_IDENTITY")
 if not edgar_identity:
     raise RuntimeError(
-        "EDGAR_IDENTITY environment variable is not set. The SEC requires a "
-        "real User-Agent (name + email) for every EDGAR request and blocks "
-        "placeholder addresses. Set it before running this section, e.g. "
-        '`export EDGAR_IDENTITY="Jane Doe jane@example.org"`.'
+        "EDGAR_IDENTITY is not set. The SEC requires a real User-Agent - your "
+        "name and email - on every EDGAR request, and blocks placeholder "
+        "addresses. It is not an API key and there is nothing to sign up for.\n"
+        "Put your own name and email on the EDGAR_IDENTITY line of the .env "
+        "file in the repository root:\n"
+        "    EDGAR_IDENTITY=Jane Doe jane@example.org\n"
+        ".env is read once, when the process starts, so then restart this "
+        "notebook's kernel (Kernel -> Restart Kernel). On the Docker path, stop "
+        "Jupyter Lab and run `docker compose up ml4t` again - `docker compose "
+        "restart` keeps the environment the container was created with."
     )
 set_identity(edgar_identity)
 

--- a/04_fundamental_alternative_data/README.md
+++ b/04_fundamental_alternative_data/README.md
@@ -69,10 +69,16 @@ Some Chapter 4 notebooks hit external APIs and need credentials or
 identification headers:
 
 - `EDGAR_IDENTITY` — SEC EDGAR mandates a `User-Agent` of the form
-  `"<Name> <email>"` (e.g. `"ML4T Research stefan@applied-ai.com"`).
-  Required by `02_sec_filing_explorer`, `03_sec_form4_insider_transactions`,
-  `04_sec_xbrl_fundamentals`, `10_institutional_holdings_13f`, and
-  `14_text_data_extraction`.
+  `"<Name> <email>"` and blocks placeholder addresses. It is free, needs no
+  account and no sign-up: put your own name and email on the `EDGAR_IDENTITY=`
+  line of the `.env` file in the repository root, before you start Jupyter.
+
+  Two notebooks in this chapter call EDGAR live and refuse to run without it:
+  `02_sec_filing_explorer` and `14_text_data_extraction`. The `form4_download.py`
+  script behind `03_sec_form4_insider_transactions` needs it too, at download
+  time. Everything else here — including `03` once its filings are on disk, plus
+  `04_sec_xbrl_fundamentals` and `10_institutional_holdings_13f` — reads
+  committed snapshots through the `data` loaders and never contacts the SEC.
 - `FRED_API_KEY` — only needed for live FRED downloads; the in-repo
   parquet snapshots used by `06_fred_macro_eda` and
   `07_macro_data_alignment` do not require it at notebook-execution time.

--- a/22_rag_financial_research/01_sec_filing_pipeline.ipynb
+++ b/22_rag_financial_research/01_sec_filing_pipeline.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a2b1d9e2",
+   "id": "31aaf694",
    "metadata": {
     "papermill": {
-     "duration": 0.006498,
-     "end_time": "2026-06-13T04:31:08.397954+00:00",
+     "duration": 0.001997,
+     "end_time": "2026-09-08T22:58:38.045082+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:08.391456+00:00",
+     "start_time": "2026-09-08T22:58:38.043085+00:00",
      "status": "completed"
     }
    },
@@ -39,13 +39,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9b152fa",
+   "id": "d23f5969",
    "metadata": {
     "papermill": {
-     "duration": 0.003596,
-     "end_time": "2026-06-13T04:31:08.403180+00:00",
+     "duration": 0.002017,
+     "end_time": "2026-09-08T22:58:38.050810+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:08.399584+00:00",
+     "start_time": "2026-09-08T22:58:38.048793+00:00",
      "status": "completed"
     }
    },
@@ -61,19 +61,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "bb6d9132",
+   "id": "e51e18f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:34.648626Z",
-     "iopub.status.busy": "2026-07-23T02:40:34.648398Z",
-     "iopub.status.idle": "2026-07-23T02:40:39.435931Z",
-     "shell.execute_reply": "2026-07-23T02:40:39.435287Z"
+     "iopub.execute_input": "2026-09-08T22:58:38.054782Z",
+     "iopub.status.busy": "2026-09-08T22:58:38.054512Z",
+     "iopub.status.idle": "2026-09-08T22:58:45.704414Z",
+     "shell.execute_reply": "2026-09-08T22:58:45.703999Z"
     },
     "papermill": {
-     "duration": 2.610712,
-     "end_time": "2026-06-13T04:31:11.017174+00:00",
+     "duration": 7.652774,
+     "end_time": "2026-09-08T22:58:45.705219+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:08.406462+00:00",
+     "start_time": "2026-09-08T22:58:38.052445+00:00",
      "status": "completed"
     }
    },
@@ -100,19 +100,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "490a4dd9",
+   "id": "51b4dd89",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:39.438259Z",
-     "iopub.status.busy": "2026-07-23T02:40:39.437921Z",
-     "iopub.status.idle": "2026-07-23T02:40:39.440810Z",
-     "shell.execute_reply": "2026-07-23T02:40:39.440060Z"
+     "iopub.execute_input": "2026-09-08T22:58:45.709067Z",
+     "iopub.status.busy": "2026-09-08T22:58:45.708816Z",
+     "iopub.status.idle": "2026-09-08T22:58:45.713092Z",
+     "shell.execute_reply": "2026-09-08T22:58:45.712665Z"
     },
     "papermill": {
-     "duration": 0.003532,
-     "end_time": "2026-06-13T04:31:11.021899+00:00",
+     "duration": 0.007352,
+     "end_time": "2026-09-08T22:58:45.714212+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:11.018367+00:00",
+     "start_time": "2026-09-08T22:58:45.706860+00:00",
      "status": "completed"
     },
     "tags": [
@@ -128,19 +128,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "7eced3ee",
+   "id": "20a967a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:39.443303Z",
-     "iopub.status.busy": "2026-07-23T02:40:39.443129Z",
-     "iopub.status.idle": "2026-07-23T02:40:39.447079Z",
-     "shell.execute_reply": "2026-07-23T02:40:39.446087Z"
+     "iopub.execute_input": "2026-09-08T22:58:45.720191Z",
+     "iopub.status.busy": "2026-09-08T22:58:45.720076Z",
+     "iopub.status.idle": "2026-09-08T22:58:45.726778Z",
+     "shell.execute_reply": "2026-09-08T22:58:45.726347Z"
     },
     "papermill": {
-     "duration": 0.004174,
-     "end_time": "2026-06-13T04:31:11.027126+00:00",
+     "duration": 0.010333,
+     "end_time": "2026-09-08T22:58:45.727370+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:11.022952+00:00",
+     "start_time": "2026-09-08T22:58:45.717037+00:00",
      "status": "completed"
     }
    },
@@ -166,19 +166,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a6519245",
+   "id": "3ad60445",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:39.449058Z",
-     "iopub.status.busy": "2026-07-23T02:40:39.448915Z",
-     "iopub.status.idle": "2026-07-23T02:40:39.452664Z",
-     "shell.execute_reply": "2026-07-23T02:40:39.451870Z"
+     "iopub.execute_input": "2026-09-08T22:58:45.735324Z",
+     "iopub.status.busy": "2026-09-08T22:58:45.735181Z",
+     "iopub.status.idle": "2026-09-08T22:58:45.741139Z",
+     "shell.execute_reply": "2026-09-08T22:58:45.740887Z"
     },
     "papermill": {
-     "duration": 0.004329,
-     "end_time": "2026-06-13T04:31:11.032481+00:00",
+     "duration": 0.01479,
+     "end_time": "2026-09-08T22:58:45.743978+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:11.028152+00:00",
+     "start_time": "2026-09-08T22:58:45.729188+00:00",
      "status": "completed"
     }
    },
@@ -189,7 +189,7 @@
      "text": [
       "Symbols: ['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'AMZN']\n",
       "Years: [2023, 2024]\n",
-      "Filing storage: /data/equities/fundamentals/10k/sp100/reference/all_10k_filings.parquet\n"
+      "Filing storage: ~/Dropbox/ml4t/data/equities/fundamentals/10k/sp100/reference/all_10k_filings.parquet\n"
      ]
     }
    ],
@@ -201,13 +201,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0f4cc13",
+   "id": "9e4b4007",
    "metadata": {
     "papermill": {
-     "duration": 0.000972,
-     "end_time": "2026-06-13T04:31:11.034497+00:00",
+     "duration": 0.005501,
+     "end_time": "2026-09-08T22:58:45.751088+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:11.033525+00:00",
+     "start_time": "2026-09-08T22:58:45.745587+00:00",
      "status": "completed"
     }
    },
@@ -227,19 +227,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "0b340b6a",
+   "id": "9aaa4fb3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:39.454872Z",
-     "iopub.status.busy": "2026-07-23T02:40:39.454675Z",
-     "iopub.status.idle": "2026-07-23T02:40:39.457993Z",
-     "shell.execute_reply": "2026-07-23T02:40:39.457343Z"
+     "iopub.execute_input": "2026-09-08T22:58:45.762490Z",
+     "iopub.status.busy": "2026-09-08T22:58:45.762360Z",
+     "iopub.status.idle": "2026-09-08T22:58:45.766308Z",
+     "shell.execute_reply": "2026-09-08T22:58:45.765813Z"
     },
     "papermill": {
-     "duration": 0.004092,
-     "end_time": "2026-06-13T04:31:11.039612+00:00",
+     "duration": 0.014154,
+     "end_time": "2026-09-08T22:58:45.766789+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:11.035520+00:00",
+     "start_time": "2026-09-08T22:58:45.752635+00:00",
      "status": "completed"
     }
    },
@@ -256,8 +256,16 @@
     "edgar_identity = os.environ.get(\"EDGAR_IDENTITY\")\n",
     "if not edgar_identity:\n",
     "    raise RuntimeError(\n",
-    "        \"EDGAR_IDENTITY is not set. Provide a real name and email address, \"\n",
-    "        'for example: EDGAR_IDENTITY=\"Jane Doe jane@example.org\".'\n",
+    "        \"EDGAR_IDENTITY is not set. The SEC requires a real User-Agent - your \"\n",
+    "        \"name and email - on every EDGAR request, and blocks placeholder \"\n",
+    "        \"addresses. It is not an API key and there is nothing to sign up for.\\n\"\n",
+    "        \"Put your own name and email on the EDGAR_IDENTITY line of the .env \"\n",
+    "        \"file in the repository root:\\n\"\n",
+    "        \"    EDGAR_IDENTITY=Jane Doe jane@example.org\\n\"\n",
+    "        \".env is read once, when the process starts, so then restart this \"\n",
+    "        \"notebook's kernel (Kernel -> Restart Kernel). On the Docker path, stop \"\n",
+    "        \"Jupyter Lab and run `docker compose up ml4t` again - `docker compose \"\n",
+    "        \"restart` keeps the environment the container was created with.\"\n",
     "    )\n",
     "set_identity(edgar_identity)\n",
     "print(\"edgartools configured with a non-placeholder SEC identity\")"
@@ -265,14 +273,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10c86f62",
+   "id": "6a50e63c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001011,
-     "end_time": "2026-06-13T04:31:11.041746+00:00",
+     "duration": 0.001433,
+     "end_time": "2026-09-08T22:58:45.769863+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:11.040735+00:00",
+     "start_time": "2026-09-08T22:58:45.768430+00:00",
      "status": "completed"
     }
    },
@@ -286,19 +294,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "267bae3e",
+   "id": "18d82525",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:39.459892Z",
-     "iopub.status.busy": "2026-07-23T02:40:39.459668Z",
-     "iopub.status.idle": "2026-07-23T02:40:39.464786Z",
-     "shell.execute_reply": "2026-07-23T02:40:39.463924Z"
+     "iopub.execute_input": "2026-09-08T22:58:45.783122Z",
+     "iopub.status.busy": "2026-09-08T22:58:45.782756Z",
+     "iopub.status.idle": "2026-09-08T22:58:45.790487Z",
+     "shell.execute_reply": "2026-09-08T22:58:45.789820Z"
     },
     "papermill": {
-     "duration": 0.005299,
-     "end_time": "2026-06-13T04:31:11.048068+00:00",
+     "duration": 0.012624,
+     "end_time": "2026-09-08T22:58:45.790901+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:11.042769+00:00",
+     "start_time": "2026-09-08T22:58:45.778277+00:00",
      "status": "completed"
     }
    },
@@ -331,13 +339,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9ffddb5",
+   "id": "9b662216",
    "metadata": {
     "papermill": {
-     "duration": 0.00098,
-     "end_time": "2026-06-13T04:31:11.050102+00:00",
+     "duration": 0.002173,
+     "end_time": "2026-09-08T22:58:45.798047+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:11.049122+00:00",
+     "start_time": "2026-09-08T22:58:45.795874+00:00",
      "status": "completed"
     }
    },
@@ -353,19 +361,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3084c79a",
+   "id": "a89acdf8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:39.466545Z",
-     "iopub.status.busy": "2026-07-23T02:40:39.466352Z",
-     "iopub.status.idle": "2026-07-23T02:40:42.749911Z",
-     "shell.execute_reply": "2026-07-23T02:40:42.749562Z"
+     "iopub.execute_input": "2026-09-08T22:58:45.801960Z",
+     "iopub.status.busy": "2026-09-08T22:58:45.801830Z",
+     "iopub.status.idle": "2026-09-08T22:58:49.697375Z",
+     "shell.execute_reply": "2026-09-08T22:58:49.694337Z"
     },
     "papermill": {
-     "duration": 2.344933,
-     "end_time": "2026-06-13T04:31:13.396064+00:00",
+     "duration": 3.902157,
+     "end_time": "2026-09-08T22:58:49.701718+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:11.051131+00:00",
+     "start_time": "2026-09-08T22:58:45.799561+00:00",
      "status": "completed"
     }
    },
@@ -374,13 +382,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== edgartools 10-K lookup ===\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "=== edgartools 10-K lookup ===\n",
       "\n",
       "AAPL: Apple Inc. (CIK: 320193)\n"
      ]
@@ -389,14 +391,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  10-K: 2024-11-01 (Accession: 0000320193-24-000123)\n",
-      "  10-K: 2023-11-03 (Accession: 0000320193-23-000106)\n"
+      "  10-K: 2024-11-01 (Accession: 0000320193-24-000123)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  10-K: 2023-11-03 (Accession: 0000320193-23-000106)\n",
       "\n",
       "MSFT: MICROSOFT CORP (CIK: 789019)\n"
      ]
@@ -405,16 +407,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  10-K: 2024-07-30 (Accession: 0000950170-24-087843)\n",
-      "  10-K: 2023-07-27 (Accession: 0000950170-23-035122)\n"
+      "  10-K: 2024-07-30 (Accession: 0000950170-24-087843)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  10-K: 2023-07-27 (Accession: 0000950170-23-035122)\n",
       "\n",
-      "NVDA: NVIDIA CORP (CIK: 1045810)\n",
+      "NVDA: NVIDIA CORP (CIK: 1045810)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  10-K: 2024-02-21 (Accession: 0001045810-24-000029)\n"
      ]
     },
@@ -422,13 +430,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  10-K: 2023-02-24 (Accession: 0001045810-23-000017)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  10-K: 2023-02-24 (Accession: 0001045810-23-000017)\n",
       "\n",
       "GOOGL: Alphabet Inc. (CIK: 1652044)\n"
      ]
@@ -437,14 +439,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  10-K: 2024-01-31 (Accession: 0001652044-24-000022)\n",
-      "  10-K: 2023-02-03 (Accession: 0001652044-23-000016)\n"
+      "  10-K: 2024-01-31 (Accession: 0001652044-24-000022)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  10-K: 2023-02-03 (Accession: 0001652044-23-000016)\n",
       "\n",
       "AMZN: AMAZON COM INC (CIK: 1018724)\n"
      ]
@@ -454,9 +456,15 @@
      "output_type": "stream",
      "text": [
       "  10-K: 2024-02-02 (Accession: 0001018724-24-000008)\n",
-      "  10-K: 2023-02-03 (Accession: 0001018724-23-000004)\n",
+      "  10-K: 2023-02-03 (Accession: 0001018724-23-000004)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "Lookup completed in 3.28s\n"
+      "Lookup completed in 3.89s\n"
      ]
     }
    ],
@@ -474,13 +482,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5677e80d",
+   "id": "f9beda26",
    "metadata": {
     "papermill": {
-     "duration": 0.006739,
-     "end_time": "2026-06-13T04:31:13.410614+00:00",
+     "duration": 0.00254,
+     "end_time": "2026-09-08T22:58:49.715984+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.403875+00:00",
+     "start_time": "2026-09-08T22:58:49.713444+00:00",
      "status": "completed"
     }
    },
@@ -495,19 +503,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4f8de307",
+   "id": "66a7a205",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:42.750955Z",
-     "iopub.status.busy": "2026-07-23T02:40:42.750835Z",
-     "iopub.status.idle": "2026-07-23T02:40:42.755519Z",
-     "shell.execute_reply": "2026-07-23T02:40:42.755261Z"
+     "iopub.execute_input": "2026-09-08T22:58:49.735350Z",
+     "iopub.status.busy": "2026-09-08T22:58:49.735061Z",
+     "iopub.status.idle": "2026-09-08T22:58:49.744822Z",
+     "shell.execute_reply": "2026-09-08T22:58:49.744527Z"
     },
     "papermill": {
-     "duration": 0.026974,
-     "end_time": "2026-06-13T04:31:13.443470+00:00",
+     "duration": 0.022328,
+     "end_time": "2026-09-08T22:58:49.750459+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.416496+00:00",
+     "start_time": "2026-09-08T22:58:49.728131+00:00",
      "status": "completed"
     }
    },
@@ -569,13 +577,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd63de70",
+   "id": "8772aed6",
    "metadata": {
     "papermill": {
-     "duration": 0.005249,
-     "end_time": "2026-06-13T04:31:13.456405+00:00",
+     "duration": 0.009551,
+     "end_time": "2026-09-08T22:58:49.767753+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.451156+00:00",
+     "start_time": "2026-09-08T22:58:49.758202+00:00",
      "status": "completed"
     }
    },
@@ -588,13 +596,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3172112f",
+   "id": "bc9f3c4e",
    "metadata": {
     "papermill": {
-     "duration": 0.004675,
-     "end_time": "2026-06-13T04:31:13.464702+00:00",
+     "duration": 0.006168,
+     "end_time": "2026-09-08T22:58:49.780209+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.460027+00:00",
+     "start_time": "2026-09-08T22:58:49.774041+00:00",
      "status": "completed"
     }
    },
@@ -614,19 +622,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "b22df6ed",
+   "id": "7a2dc244",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:42.756312Z",
-     "iopub.status.busy": "2026-07-23T02:40:42.756241Z",
-     "iopub.status.idle": "2026-07-23T02:40:42.761904Z",
-     "shell.execute_reply": "2026-07-23T02:40:42.761493Z"
+     "iopub.execute_input": "2026-09-08T22:58:49.793279Z",
+     "iopub.status.busy": "2026-09-08T22:58:49.793135Z",
+     "iopub.status.idle": "2026-09-08T22:58:49.808729Z",
+     "shell.execute_reply": "2026-09-08T22:58:49.808440Z"
     },
     "papermill": {
-     "duration": 0.009769,
-     "end_time": "2026-06-13T04:31:13.479542+00:00",
+     "duration": 0.027322,
+     "end_time": "2026-09-08T22:58:49.813081+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.469773+00:00",
+     "start_time": "2026-09-08T22:58:49.785759+00:00",
      "status": "completed"
     }
    },
@@ -662,19 +670,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "8ee1b322",
+   "id": "d25d77b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:42.763008Z",
-     "iopub.status.busy": "2026-07-23T02:40:42.762883Z",
-     "iopub.status.idle": "2026-07-23T02:40:42.767353Z",
-     "shell.execute_reply": "2026-07-23T02:40:42.766865Z"
+     "iopub.execute_input": "2026-09-08T22:58:49.832631Z",
+     "iopub.status.busy": "2026-09-08T22:58:49.832432Z",
+     "iopub.status.idle": "2026-09-08T22:58:49.848452Z",
+     "shell.execute_reply": "2026-09-08T22:58:49.847432Z"
     },
     "papermill": {
-     "duration": 0.009168,
-     "end_time": "2026-06-13T04:31:13.491975+00:00",
+     "duration": 0.024688,
+     "end_time": "2026-09-08T22:58:49.849025+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.482807+00:00",
+     "start_time": "2026-09-08T22:58:49.824337+00:00",
      "status": "completed"
     }
    },
@@ -729,13 +737,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "86db7c86",
+   "id": "0914b6fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:42.768480Z",
-     "iopub.status.busy": "2026-07-23T02:40:42.768350Z",
-     "iopub.status.idle": "2026-07-23T02:40:42.771001Z",
-     "shell.execute_reply": "2026-07-23T02:40:42.770606Z"
+     "iopub.execute_input": "2026-09-08T22:58:49.869490Z",
+     "iopub.status.busy": "2026-09-08T22:58:49.869280Z",
+     "iopub.status.idle": "2026-09-08T22:58:49.880985Z",
+     "shell.execute_reply": "2026-09-08T22:58:49.879931Z"
+    },
+    "papermill": {
+     "duration": 0.023067,
+     "end_time": "2026-09-08T22:58:49.881553+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:49.858486+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -749,13 +764,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd645200",
+   "id": "4b59d806",
    "metadata": {
     "papermill": {
-     "duration": 0.001624,
-     "end_time": "2026-06-13T04:31:13.494998+00:00",
+     "duration": 0.00338,
+     "end_time": "2026-09-08T22:58:49.897563+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.493374+00:00",
+     "start_time": "2026-09-08T22:58:49.894183+00:00",
      "status": "completed"
     }
    },
@@ -767,13 +782,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "909081e8",
+   "id": "46a1e660",
    "metadata": {
     "papermill": {
-     "duration": 0.002433,
-     "end_time": "2026-06-13T04:31:13.499414+00:00",
+     "duration": 0.00291,
+     "end_time": "2026-09-08T22:58:49.903751+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.496981+00:00",
+     "start_time": "2026-09-08T22:58:49.900841+00:00",
      "status": "completed"
     }
    },
@@ -788,19 +803,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "69bd6647",
+   "id": "6961ef56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:42.771925Z",
-     "iopub.status.busy": "2026-07-23T02:40:42.771812Z",
-     "iopub.status.idle": "2026-07-23T02:40:42.848276Z",
-     "shell.execute_reply": "2026-07-23T02:40:42.847782Z"
+     "iopub.execute_input": "2026-09-08T22:58:49.911562Z",
+     "iopub.status.busy": "2026-09-08T22:58:49.911350Z",
+     "iopub.status.idle": "2026-09-08T22:58:49.997506Z",
+     "shell.execute_reply": "2026-09-08T22:58:49.996754Z"
     },
     "papermill": {
-     "duration": 0.005733,
-     "end_time": "2026-06-13T04:31:13.507805+00:00",
+     "duration": 0.091022,
+     "end_time": "2026-09-08T22:58:49.998416+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.502072+00:00",
+     "start_time": "2026-09-08T22:58:49.907394+00:00",
      "status": "completed"
     }
    },
@@ -849,13 +864,20 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "5a7de071",
+   "id": "0ec91d41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:42.849558Z",
-     "iopub.status.busy": "2026-07-23T02:40:42.849466Z",
-     "iopub.status.idle": "2026-07-23T02:40:44.196977Z",
-     "shell.execute_reply": "2026-07-23T02:40:44.196467Z"
+     "iopub.execute_input": "2026-09-08T22:58:50.014328Z",
+     "iopub.status.busy": "2026-09-08T22:58:50.013425Z",
+     "iopub.status.idle": "2026-09-08T22:58:53.128573Z",
+     "shell.execute_reply": "2026-09-08T22:58:53.126792Z"
+    },
+    "papermill": {
+     "duration": 3.122241,
+     "end_time": "2026-09-08T22:58:53.129225+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:58:50.006984+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -958,10 +980,10 @@
           "colorway": [
            "#0a1628",
            "#D4A84B",
-           "#1a2d4a",
            "#C87533",
            "#10b981",
-           "#ef4444"
+           "#ef4444",
+           "#94a3b8"
           ],
           "font": {
            "color": "#334155",
@@ -1067,7 +1089,7 @@
         }
        }
       },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAGkCAYAAADT1/YoAAAgAElEQVR4XuydBZQUx9qGX9zdXUOwBA8QNBBCCMHdCe7u7u6uwd1dg3uCJBAIGiw4BNcF/vMVf8/dHWZ3urpnlt3N2+fcc8lOVXXV09XdT1d/VR3q9etX78GNBEiABEiABEiABEiABEIogVAU3hB6ZNksEiABEiABEiABEiABRYDCy45AAiRAAiRAAiRAAiQQoglQeEP04WXjSIAESIAESIAESIAEKLzsAyRAAiRAAiRAAiRAAiGaAIU3RB9eNo4ESIAESIAESIAESIDCyz5AAiRAAiRAAiRAAiQQoglQeEP04WXjSIAESIAESIAESIAEKLzsAyRAAiRAAiRAAiRAAiGaAIU3RB9eNo4ESIAESIAESIAESIDCyz5AAiRAAiRAAiRAAiQQoglQeEP04WXjSIAESIAESIAESIAEKLzsAyRAAiRAAiRAAiRAAiGaAIU3RB9eNo4ESIAESIAESIAESIDCyz5AAiRAAiRAAiRAAiQQoglQeEP04WXjSIAESIAESIAESIAEKLzsAyRAAiRAAiRAAiRAAiGaAIU3RB9eNo4ESIAESIAESIAESIDCyz5AAiRAAiRAAiRAAiQQoglQeEP04WXjSIAESIAESIAESIAEKLzsAyRAAiRAAiRAAiRAAiGaAIU3RB9eNo4ESIAESIAESIAESIDCyz5AAiRAAiRAAiRAAiQQoglQeEP04WXjSIAESIAESIAESIAEKLzsAyRAAiRAAiRAAiRAAiGaAIU3RB9eNo4ESIAESIAESIAESIDCyz5AAiRAAiRAAiRAAiQQoglQeEP04WXjSIAESIAESIAESIAEKLzsAyRAAiRAAiRAAiRAAiGaAIU3RB9eNo4ESIAESIAESIAESIDCyz5AAiRAAiRAAiRAAiQQoglQeEP04WXjSIAESIAESIAESIAEKLzsAyRAAiRAAiRAAiRAAiGaAIU3RB9eNo4ESIAESIAESIAESIDCyz5AAiRAAiRAAiRAAiQQoglQeEP04WXjSIAESIAESIAESIAEKLzsAyRAAiRAAiRAAiRAAiGaAIU3RB9eNo4ESIAESIAESIAESIDCyz5AAiRAAiRAAiRAAiQQoglQeEP04dVrXPIM+TBueB+U/bGYXkam9kNg0vT5mLtoJQ7tWKn+PmzMNGz5ZQ9+WTf/P0XKmUNwb/y7d+/QqmNfrNv0Cx49foKdGxaiS+9h+KZgHnRp11Q1z/kc4jkVPI56w5ZdETFCBIwf0SfQK2ymX7mr1B9//oWCxavgwu+7EDdOLJfJL/59BTkKlMafR7YgSeKE7ork7/4QqF6/NRInTIgRA7uSUTAjQOH10gG7cvUfZPn6B5elz54yIkhKZbuuA1Grallky5LJS1SCb7FV6rRAqpTJMKRvZ7eN+GX3ARw8fBQ9OrX0qPDq1MFtJW0kGDdlDpauWI9925YFWMqnEN7E6fJg2thB+LFEEX/rdu7CZYyfMhu79x/B7Tt3kThhAlQu/wPat2yI8OHD+Ztv/aYdaN6+FzavmoNECeMhWtQoGDFuBjJ8ngalf/jWpfAG1XOqc68h2L5zP/65eRuRIkZE9iyZ0LNzS2T9MuNH7c9VqDT6dG2Lr/NkR7N2PXHijzO4d/9fxIkdE0ULfY1eXVshQby4NnqUtayePB90hff473/im5LVcfnPvYgZI7q1Bvx/LjP9yt0OKLzuCHnud13h9WRf8Vwr/pslUXi9dNwN4R07rNdHApkiWRLEiB7NK3t+8+YNwoXz/6btlZ0GUqGfsm1mbq7v37/H27dvETZsWD9EPDXCa6YOgXEogrvwyui7yF6pEkWRPFli/H7yDHoNHI26NSoE+EAj7V6xehN2b17sL+bgMqI7euLPSJ0yOZIkio+Hj59g0rT5OHriJI7vX4/YsWI62icPBwW/r4xLf+zG8xcvMWPOEmTPmglxYsXE1es30H/oeCRMEB8bV/wcGF3Pzz48eT58SuE106/cwQ2Kwuvf9dBdW4L67xTeoH6E/K8fhddLx84Q3nVLZ6DA17k+2ovcSL4qXAb7ty1HpgyfOX6fPX85+g0dj7PHtitxPXv+b/QeOAp7D/yGiBHDI3/enBjUu6PjlZQhUz989w1mzl2C23fuYczQnug7eCzO/LbNj/zWbdJRCdm86aNcttr3zfr58xfqde3m7bvx8NFjJIgfD3VrVET7lvVV3m0792HA0Ak4e+ESIoQPj8/TpcaM8UOUQHTpPRR/X76GJXMmOPbz87ylGD9lrrqhyiYXw/FT52LWvGW4ces2UiZPihaNa6NW1XKOPLGTZ1Nt3bBlB46d+BMtm9R2vDr23QApS0YTZR9Xr99UI0+Vy/2Afj3aqWSHfzuBngNG4cQfpxE9WlSU/bE4+vdoi0iRIqrfDYYVy5TApBnz8fjxExTKnxvysBIrZgw0bdMTi5av9cPs8M7VePDvvyhR/ifMmToSg0ZMxOWr17F83iSc/POsy5CGahV/xMjxM/Hvw0f49pt8GDOkl+P1Y/5ilVC5wo9o1aSOYz8/Ne2EqFEiq9es/tXh889Sue0jAR0rVx1h6OipWLl2E65cu4E4sWNB+lafbq0QJXJkLFi6Bs3b9fKTbdTg7qhXq/JHRbka4d3yy14MHjkJZ85eQPx4cVHux2Lo1qE5IkaMoPIHtG/5PaB++UWeErh2/YajHvHjxcG54ztMneG9BozCirVb1OteV1vtRu2xduN2l791adfEVEjDwSPHVH+R86Lv4DG4dv0mPkubCuOH9/FzDdi+az+69x2Ov69cR+aMn6Nt83qo1bCd41X0hUtX0KXXUBw5+jve+PhAHqD7dm+L4kULmGqrq0SXLl9F9vylsH7ZTHWNMbYxk2bh8G/HsejncS7LloeHNp374+7fvyFMmDAu08h5LH14zfqt2HPgVyRNnBBjhvZCyuRJ0LpTPxw4cgypUiTFxJH9/AwOBHTt8+98SJokAWRUff+ho7h77z6SJ02EhnWrodFP1Rx1e/nyFTr1HIKVazcjQoTw6kFH+rqMdBshDXKsRUTPnruorqFf5fwSQ/p0RsoUSeHq7V25UsUxa/Iw1Uf8y2enX7m7XroS3l17D6Fzr6H4+8o11Y/aNPsJ0o+NkAbdfuSubUb/dr4eSn9yd613ZuPumn7z1h11n/ll1wG8e/8eBfPlchwfKcuoi9x/u/YehvOXLiNH1i8wc+IQqHbLPerKdeTLnR2TRg9AvLixVRXKVG2ENKlS4MnTp9i7/1e8ev0atauVQ++urRE6dGiVxll4Hz95qh6YN2zegefPXyJzxnTo36MdvsqZJcC+4u6YWj6ZmdFfAhReL3UOd8Iruy38QzUUzp8bfbq1cdTihwr1kOHztBg5qBtu372HfN9WROXyJVGranmVZvjYaTh/4W/s3LhQjSSKrA0bMxU1KpdB/57tECpUKIQOHQrps3+LiaP6OV61Pvj3IdLn+Bbzpo/298boW3gHDp+AdZt2YMqYARBxuPbPTfxz4xbKl/4eT589R9oshdVNvmKZ7/Hi5WscPfEH8ufJiaRJEpkSXpGepSs3YnDfTkj/WWr8fuovtOrYB2OH9XaEe8iNUvYtN5I8ubLh2fMXSgCdN6nrlJkLMaBXe3Wzvn//IU6cPK1ucsIwR/5SKFOyGFo0roPrN26qm+x3RQqoBwPZhKFw/almBfTp2kZd5MpVb4Jc2bNg+IAuKo2r0STjoip1mzZuEJIkToDXr99g1vzlHwnv2EmzkPerbErCnz9/jpYd+yJF8sRYPGu8Kt+d8PpXB3d95OWr1wEeK1fdX0b/cmX/EsmSJFLHXV5/f507p4OF1RFeuQFXr98Gg3p3QMF8X6mHs47dByPPV9kd8XDu9h1Qv5S2mAlpcNVmaeOhIycCHL0dNWEm1m7Yjl2bFjmKKF62jukYXqO/yMOUnFdyk+3QYzCO/HYCB7avUGXKOZa9QCnUr11Z/e/Cpavo2nsoLl2+5hCV78vVRaKE8dWDQoTw4fDX+YvqvPg6dw5VRrZ8P6Jo4XymYwzlgXbU+BmYu2gVju1b52eEt1iZ2uqG7/tB1Gi8PFy06tRP9fkNy2f6eyWV81jq271jc2TJnAFjJ8/Cnn1HkDZNSiWbcr0bOnoK/jp3AfIgKdcwd/1arn2uzklpy7RZi/FdkfzqYfXY76fU+T5+RF+UKfkh7KRrn2FYtXYrJo7uh2RJEmP42KnYtHUXRFoN4V26coN6wEv/eWo1sj1i7HRcvHQFe7YsUeLj32tqd/lcQTLTr9xdL52F99btu8iW/0dUr1QGTRvUwNlzl9C591Bc/+em6X7kXFd3bfPvejhm0s9ur/U613QRxW9L14LEPg/v3wVhw4VF974jce/+AxzYvlw9eBl1yZHtC/To2FyFnbTs0AdRo0bB23fv0LNTC0SOFFGF6Mi1zbgXiPDuO/gbJo7qiyrlf8TFv68qCW5av4YakJHNWXhLVqyvBn26tm+COHFiYc2G7ep+cuiXlWoAyL++4u6YeklN/tPFUni9dPgDiuE1nrBlBExGFE8e2qQu8nIxypz7e2xdPVc9HQ4ZNQUSD7ptzVxHLV+9eo1kGb7G+qUzVRqRNZGp8yd2IHLkSI50bbr0x82btx2jrFN/XggZrTl1eLO/IzG+hbdx6+4f5G3ysI8IyYiB3FQP7ViF9OlSf/S7uxHeFy9eIvWXhTB/xmgVA2hs0t4jv/2OlQsnqz/JjVKkulObRv4eJRnxk7L6dW/rZxTnf2VOxoKla3F83zpHqMHq9dtQr1knnD+xU40GC8PJM+bj3PFfHCPiMlouzI7sWqOKCkh4N60Umc3uqKOrSWtyATz961bHSIK087uytfHbnrVImzqFZeF110fixYsd4LEy0/1lxLFRy264dHK3Sm5VeEtVbqBEuleXVo7dys2lQs2muHn+sGMExXednPcdUL+UfFaE99SZc/i2VE1106taoZS/SMyISUCT1oyb8K6Nixyxsn+du4Q8Rcrh7PFfVBysCP3q9VtVv5NrgmzSF9t3G+QQlUxfFUe7FvVQv3YVl3Wt07g9cmbLot6IBLTNmLMYnXoOVeIgk5gW/jxGCamxiXRmzPkd/jq63dFv5Td5U7Rmwzb1lkb6veQTufRvk/O4U5vGkJFw2USUZTReHvRl1FG2M2cvIm/R8o42uuvXcu0zG9Igb7tEXOZOGwm59qTMXACjh/RE9Uql1b5lxDdz7uIoUaywv5PW5DqTNP3X2Ld1GTKmT+uvxDgzcM7nipG7fmXmeuksvCJTS1ZuwLG96xzn1YSpc9Gj/0jT/cjdtcG5bUb/9n09NFN3V8wCuqbvPfAr5FpiXDslv4z4Sp+aPXm4it836uL7jYW8pZM3AzJ5WERYNjkHJk6b73jzKHIr9z1pg7FNm7UI8iAub0xl8y28+w/9pgZHLv6xW8X0G9uPlRrgm4J51RtRV8JrhYu748Hf3ROg8LpnZClFQDG8GdKlUWIlN5QMOYph3dLpyJcnpzqp5i5c6Tj5qtVrhU1bP0iG8zZ17EBUqfCjkrW1G7Z9NIFIXt8X+bGGkqyECeKhwHeVUfzbAo6JVK7K9H2zPnD4KCrXbqFGLWW0qNg3+dUJLJvc6Go1aqdeJxUplBeF8uVG6ZLfImH8eOp3d8L7+6kzKPR9VZftSpUimaP9cqOcO3VkgBOQZCS3cIlq/sp3ncYdlOD/PGmoY3+37txVI+BbVs9B7pxZFcONW3dCRMTYRIrbdO6nJqXIFpDwOk9ccSW8K9ZsVKNXxiahJfFT58K8aaPwQ/HCloXXXR9RbwcCOFauDoL0uRHjp+Pc+Ut48vSZI8k/5w6qUS+rwpss/dd+yvO9b+Mh0N2+A+qXUp6u8MrrzR8r1UelciXQv0f7AM91d2Iimc0Ir8FR0svkL3lbIhMAM2dIB5HViBEjQs5vY5NzWd4GGYwmTpunQnSk7xYukEfFIouE6W7y1ufW7Xtq4t7UWQtx7vzf2L5uvmOEd87CFVi0bB02r5rtp2h5MP/30WNcvHRVhaekS5vK3zApySjn8YIZY1Diu0KqHInFj5cqp3qwLVLwwwOvhPmkylxQjZ5n/SIj3PVrufb5J7zyYL9gySoV3iQDBLLJRFxZVUNCafIWreBHluT3SrWaqVhkY4RX0vUdMha/HTupjpGxSTiKhI74N2rnLp+rY+SuX5m5XjoLr/QjucfMmDDEscujx0+iaKmalvuRu7YZkun7emim7s5M3F3TRVKHj5muHhJ9bzK5skqF0ujQqoFDeK/9dcAhojv2HED56k1V+I0xz0VWXGnapgeunz2oihLhTZc2teNtlvzNaNfVM/tVSJxv4ZVzsXu/ES5PPXkrIv3JVV+xwkX3/Gb6jwlQeL3UK8yENMiu5QSU1x4yuvT1txXUzatr+2aqVlXrtkT48OHVyIR/W0ATokRyy5UuruJFZckaiZ8VofRvc75Zyw1x24592LX3MNZt2o6ihb9W8arGJhfQbTv3qyW35Ga5ZvFU5Mz+Jbr1Ha5e//mO4Z0+exEmTV+g6mDcwOU1bkA3arlRLpkzXsm2f5tRln+jzSK88vpTYreMzRBeYyTdFUMRXgmxkIucbAEJ760LRxwxqJLWrPDKTX/+9NFKeOX4VCz3g58YXrlpRY8WzXETdlUHM31E6uTfsXLmKrHl0g+H9uuE0j8UUyPgh349Dgm1MW5kVoU3Sbq86N21lcuReKmHmX1LuoD6pY7wyqhiuWqNUam8e9mV/boTE0ljRnh99xdDeOVV+ZeZ0qsYS4ktD0h4ZT/ylmXL9r3YtfegOgcH9+noL1czlzgfHx+k+bKwGolt3qiWo8/ny5vLT590Lsu4mctEPt+jw77TOZ/Hsq+4KXPA9/wGCUVImamAklKRUzP92tX5MG/xKvQeOAYzJg5GzmxfKkGRuPB1G7erhwpDeP84uEldd41NJCZOrFjqXJMHehktLKJG6BogcaL46qFZHlCNEURXEmMmn6tj4a5fmbleuhLeKJGjYNLofo5dGml8L0tmth+ZaZshhr77t5m6OzNxd00X4R0xdgb+OuY3pl6Et2rFMmpU1VVddu45qEZjH17/3bFLWSGjUetuuHHukPqbCK+sxjNmyIdwN9l27zus/u5KeGVeyphJM9UIr3+bq75ihYuZ85hpAiZA4fVSDzErvItXrEOXXsOwetFUNYrj+zWNjJ7IrOjj+zeoC7erLSDhlQuDxLZ+U/BrnD1/EWuXTA+wtQHNMJeJT5VqNXec9M4FychB7pxZ1CQzuYBv2LLTz7qzEiO59Zd9SniNMIQOrRqpp3H/NjPCayakYdHyderVnjGpxlVIg/M6uc7CW7NhWyRKkMDlk78Z4XUX0lChRlN8kelzP/Hc+YpVRPYsmR3C66oOZvpIQMfK+bclK9ajz/9PeDR+kz4ko/aG8Mp/y+jfwV8+xJ36tzmLv0izTBJatXCKyyxm9u2c0blfijRJHLgRr+lf3WSEpXz1JqhdrbyakGJmcycmUoZd4TUT0uBc1z6DxmDH7oMqvtTqJq/1RXjbt2qAdi3q49nz50j9RSEVEymTePzb5GFIYool7CpXjiwuk1kRXjP92tX5IHGaL1+9wvTxgx11kXSXL19XwiuvklNkyo+5U0fh+2IFVRqROZmwpyZXjeij4qglbOTo3rWOtkvYi8TZywOqvDI3/ltERx4KZTOTzxUgd/3KzPXSVUiDeiDyFW9uvNL3bx3egPqRmba5kkwzdXdm4u6aboQ0SLy5rDQimxHSMGfKCJT8/htbwiuTHY2YeilbHphmzV+mQntk8z3Cu2f/EZSu0tDxttDV8XXVV6xwsXpuM9//CFB4vdQbAgppSJQgviMmTiaAfZb1G6RJmRzhI4THjvULHDWSkAe5yKZPlwbdOjSD5JOVAGSy18De7VXcXEDCK4vjy0Q1H5+3mDSqHyqVc70usLFD3zdrWU0gXdqUava4xBKOmTgLW3fsVSESMjImM3bl1Z6ES5w9fwn1mnVGry4t1UoOx06cUpMKtq6eo0Z85TV09XptVH2NVRqGjJqMsZNno0/X1ihSKB9evnqpJu+8efMWTepXV1UyI7ySrv/QcWqiysDeHdRN6+HDx2qySoM6VR2T1mRCSvNGtdWkNfl4gPOkNXfCK6+tDhw+pkZ4okSJjFgxo6tZ8jLr3ozwGpPWZGLhs2cfJq3JDHJjFFxGTWWVCRl1loXjpT2yT4kzNF6zuqrDvQf/BthHbt66G+Cxcu7+MhohE5VEYGSk7c8z51GlbksVX24Ir4Qd1G/RWcW5JUmUUE2YMlZZ8F2es/DKpDUZYZHY0zo1yiNihIg4/dd57D/0K4b176pe/bnbd0D9UvqphMpkz5YZnds2Rvhw4fxMwDLqJrJbunJDNXGuo1N8uIyy+re5ExPJZ1d4nSetSeyprMggk9bk3Euc6MMqBOVKfadWNpDQgrZdBqgVD4zX1/LgkDRJQhUm5WqTMA7pawW/zo14cWOpsAYJaZD+vH/bMiV5cn4PHD4Rh3euchQhr38lb5Yv0iNalCg4f+mKmjArE+dktRnn5fiMjFaE18y1z9X5MHH6fMyevwzb1s5XIrpq3VY0atUNn6dN5Qj7koe3g4ePY8WCySqNrCAgsicTf+Vck5CLz7IWQee2TdSEL3mjIG+KJN5cQpBEeCUEQx4QJozsq95ASf+PGCG823xWhFfyuLteOguvCKBMWhsxsBtqVin7YcJxjSZqRRdDeN31I991NcPElfCaqbsrJgFd0yW9DLDIJpPWQocJ7e+kNd/XZrMjvPI2rF6tSqhbsyJO/nkOLdr3Qsc2jR1vOnwLrzwslarcUC3RN7BXe3yR8XM1eU7uJ3L+SciRq74i8b7ujqmX1OQ/XSyF10uHP6BJazJT3/fyU/Wbd8GKNZswtF9nNK73QfaMTZYLkkkXu/cdwYuXL9XM+cIF8mJAz3bqIutujVeZ5LNl+x71dOpKSnzvy/fNWiY4yBJUItjhwoZVQf79erRVJ7S0rWOPQThx8gz+ffhYvfKrVrG0kgxjoo3IzoRpc9XNI3eurMic4XPIjdgQXtmvjEBPn71E3cyjR4uils5p2aQOvi2cT0t45aIjwihP4df/uaUeJqqUL+kYLZVlyXr0H4XfT55W8VzlSn3vclky319Ccx7hvXrtBoSlxJfJKJHvZcnMCK9cAGWpNInTlgughIeMHdrb8eAjI2wdewxWscQSw1mhdHFcufaPn5AGV3WQZckC6iNqJQQ3x8r5FJC4tInT56k/iziJCMhMd0N45ZV0kzY91Fq2aoa/xrJkIr0yYiIcw4QOjbSpU6pYdBEL2dztO6B+KfklTq9zzyH4+8o/iB0rhstlyURc+w1xvcyW79edzlwCQ3hlnzJq/WFZsn/UqH+TetWVtBmjidIPDx45jlu376j1vL8tnF89ABvr52bNVxLff1vQ3zWFJaRHVsf49dgfuP/goXrA+irHl+jQupE6v2WTfSRJlMDPBEN5cB00YjL+PHMOz1+8UB/s+K5ofvXBDllNxb/NivBKWe6ufa7OBxH/dl0HqIdzCQeTSZLyYCChWcaHUuT8lXNNpD664pdPnZPyFs14uBQ5kmUZZdAgRvSoKtRDHlJ9f9REXmdPnDYXwtNYlsxMPiv9yt310tWyZHIuyJJccowTxI+rQl7kPDaE110/cq6nu7b5J7zu6u6q37i7povQy5JrMo/kPd6j4Ne5VH+XZeNksxPSIIM8z569UMvWyVvBWtXKqtV7jDeEzqs0yKCVvJmR1Rnu3L2vzoWvcmRBj04t1IRk2Vz1FStc/D3J+IMpAhReU5iCbyKZzZo+XVo/r+KDb2tYcxL47xFYuGwtuvUZjr9P7XE8UPpHQdYElbCOLatm+xti4I6gTKhMm+UbLJ830TGb3V0e/k4CIYGAxOpm+zKjn9CykNAutuEDAQpvCO0J8hpORuDkKV5GIyU8gRsJkEDQJzB7wXIlmvHixFaf8W3btT/Kly6Ogb06uK385m171JuT5fMnuU3rXwIZpZq9YAU6tm7oVrAt74QZSSAIEqDwBsGD4sEqUXg9CDMoFZUhZzEVKypxaMas66BUP9aFBEjANQH5MMKKNZtVuFCyJAlRsWwJdGzdKMR+Mpz9gASCCgEKb1A5Et6pB4XXO1xZKgmQAAmQAAmQAAmQQBAhQOENIgeC1SABEiABEiABEiABEvAOAQqvd7iyVBIgARIgARIgARIggSBCgMIbRA4Eq0ECJEACJEACJEACJOAdAhRe73BlqSRAAiRAAiRAAiRAAkGEAIU3iBwIVoMESIAESIAESIAESMA7BCi83uHKUkmABEiABEiABEiABIIIAQpvEDkQrAYJkAAJkAAJkAAJkIB3CFB4vcOVpZIACZAACZAACZAACQQRAhTeIHIgWA0SIAESIAESIAESIAHvEKDweocrSyUBEiABEiABEiABEggiBCi8QeRAsBokQAIkQAIkQAIkQALeIUDh9Q5XlkoCJEACJEACJEACJBBECFB4g8iBYDVIgARIgARIgARIgAS8Q4DC6x2uLJUESIAESIAESIAESCCIEKDwBpEDwWqQAAmQAAmQAAmQAAl4hwCF1ztcWSoJkAAJkAAJkAAJkEAQIUDhDSIHgtUgARIgARIgARIgARLwDgEKr3e4slQSIAESIAESIAESIIEgQoDCG0QOBKtBAiRAAiRAAiRAAiTgHQIUXu9wZakkQAIkQAIkQAIkQAJBhACFN4gcCFaDBEiABEiABEiABEjAOwQovN7hylJJgARIgARIgARIgASCCAEKbxA5EKwGCZAACZAACZAACZCAdwhQeL3DlaWSAAmQAAmQAAmQAAkEEQIU3iByIFgNEiABEiABEiABEiAB7xCg8HqHK0slARIgARIgARIgARIIIgQovEHkQLAaJEACJEACJEACJEAC3iFA4fUOV5ZKAiRAAiRAAiRAAsRCYhIAACAASURBVCQQRAhQeIPIgbBSjbv3HmDe0nU4ffZvnL94Ba/fvMGKOaOQOGH8j4rz8fHBrIWrsX7LHvz76DFSJU+CBrUqoEDe7G53ffHyNdRs3BUdW9ZF+R+/daR/9PgpWncdgn9u3sGYQZ2QKX1al2W9f/8e46cvxJYdB/Dg30comDc72jWvg7I1W2NA91YoWvArla9l58GIED4cRvTvoP7791Nn0aR9f/w8vh8ypEvttp6BleD5i5coWrbBRzw8uf+fF6xWx3bnmpmeLJZlkcAnJbBszVaMmjQXoUKFwqp5Y5AgXhw/9dl/+AQ69Bqh/jZhWDfkyJJRq77rtuxCxAgRUKxwXq187hLnK1EbzepVQY1KJd0l9fO7t+qjVYlPnNjqdfzdu3f4ecEq5Mn5JTJn+OwTt4K7DwkEKLzB+CjKhaRr/7HImC41Xr56jaO/n/ZXeIdPmI21G3fipxrl8Fnq5Ni4fQ927z+KsYM7I1e2zAFScCW8/z58jJZdBuPe/X8xdnAXfJ42pb9l7Nr3G7r2H4OubRsgbapkiB4tCiJFiojmHQeibdNayJ3jS5fCe/bCZfQdNhkDurdE6hRJg8yRCgzhXb1xB9Zu2qVknxsJhBQChvBGjhQRdaqWQe2qpfw0rfvA8Tj06++Qc8yK8DZu1w8xo0fF0D7tPIrMqvB6qz4ebZyXC7MqvD5v36LAD3XQunFNVC3/vZdryeL/CwQovMH4KMsTcOjQoVULFq/cjLFT57sUXhmBrfRTe/xUoywa1qqg0r999w51mnZH2HBhMXtCfy3hFckV2X385BnGDemCNCmTBZh/1sI1mL90HX5ZPSPAdM4jvEH10ASG8AbVtrurl7xlCB8unLtk/P0/SsAQ3h++LYDT5y5h0fShDhJPnz1HySrN8W3hvNi4bQ+FN4T0EQpvCDmQIaAZFN4QcBDdCe/S1VswevI8LP15BJIlSeho8dwl6zD55yVYPX/sR68WfWPxPcKbL3c2tOw8CC9fvcG4IV2RMlmiAAmWq90Gt27f8zeNbkhD3RY9kTRRAuTImgELl2/E3Xv/IkWyRGjVqDpyZM3k2I88DMycv1KNkj55+hyZ0qdBu+a1Ubtpdz+vJm/evouJM5bg+MkzSuBjxYyODJ+lRK9OTRElciSX9TaEV0anb9+5h02/7Mfz5y+R9Yv0aN+8toOx7Ct+vFgY0e9DiIaxGTcA+Xu+3Fld7sNVSMOajTuwdPVW3Lh1B2HDhkXCBHFRo+IP+L5oflWGu7as3bQTg8fMVA8eMsJmbDPmrcCSVVuwbeU0x9/kgWjB0g3YsG03bty6p0bNin2TF43rVkKE8OFVun2HjqNj75EqBEXqduz3M6ofLZg2JIScVWyGpwkYwjt+aFcVwjRrQn+k/yyV2o30zwkzFqNLm/roPmDcR8K7e/9vKsznwqVrCBs2DHLn+AItG1ZX54FstZp2w4VLV/1U+btvvkbfLs0g17DZC9fg1JkLuP/vQ8SPGxt5c2VF47oVETVKZL/XjQWr1NswuR5k+Dw1Oraoi9rN/F43zJTnifr4x19YLFyxEecuXkHoUKGQIlli1K1eVoWLGZtc91eu345/btxB9OhRUTBvDjSrXwXRokZRSYzrmFyzJNRs7abdePbiBb7OlUW9jZMHkJET5+DoiTOIESMqqpUvgcplizvKHz9tATbvOIBu7RpiyqyluHLtBmLHjKHSVK/4w0fXO+fQtICO55Onz/BdhcYfNb9rm/ooXeIb9Xd3/cFon4wQ3757T4XUvX79Bl9kTIdOreoiUYJ4fsp3V54ktnsN9vT5xPL0CFB49XgF2dQBjfAOHfszNmzbg93rZqnYOWPbf+QEOvQcgdEDOyJPziz+ts0Q3lqVf8Qve47g3ft3GD+kK5ImTuCWx+2795WYrt+yG/OmDHKklwtswzZ9tWN4RXj/uXEbWTKnQ9N6VZSUTpm1DHsOHFWj2yKssonEiTTWqVoaObNmxNmLV7FKLv4376B5/aqOWLyfWvTEmzc+qFezHOLGjol7Dx7i8NGTaFqvMmJGj+ayfcaFNF7c2Pg8bQoV1ywXaKnHe7zHkpnD1SinhCUMHz9b1Sth/A83Zdn6DJ2s4pPl78YIvfOOnIXXiG2sU600cmf/Am98fPD3lRsIEyYUKpb+TmV31xYd4e09ZBJ27jsCOeZZMn+Oq9dvYurs5ciVLRMG9Wyt9mcIb5xYMVGvZlkVayehNUEp/MRtB2WCQCVgCK88ZHfrPw6ZM6RB26a1VR0kXl/mFshDtTxI+Q5pMPquCKz87+XLV5gxfyVevXqtrityHZA5DZ36jEb0aFHRufVPqkx5sIsZIzrk/Pnj9Fmk/yw1YkSPipu37mLukrXqt6mjejkYzJi3Uj0o16xcUoVanf7rkjqPb9255+e6YaY8T9TH1cFZuW47JEStUL6cikXkSBFw9vwVRIoUwSGk0+cuV9e/8qW+RYE82XDl2i1Mnb0MqVIkwdTRvRA2TBiH8Ir4ff5ZCnxfJD/kei2DIF9/lRVXrt3ENwW+UuFqu/b/ig1b92Di8O7I/mUGVS0R3qVrtiFJonjo0b4RUiZPgh17j6hrXtumNR3zPVyN8Lo7npEiRlAP9pV+6oB6Ncqi5HcF1T7leMkxdZdf+oNxnZYHmkpliqHU94XVwESfYZPVXJEZY/s68JopzxPX4EA92bizjwhQeENIpwhIeGW05MSps9iweKKf1p48fR6N2vZVIyBy4fRvM4RXfhdBWzBtqNuRXd9luRpBlAurlUlrIry379zHyrmjECnih1HKx0+eonjFJujWrgFKFS+sRiZKV2+FUt8XUjHCxmaMdLdoUE0Jr0zkK1CyriOf2a5gXEhlZHnhtKEOab105TpqNOqiRnlFQl+8fKnqUblccUcoiUz0K129JepUK6Mu5P5tzsIrN6tN2/ep0XhXm5m2mBVeo18Y7TD2Jzcz6UtzJw/EZ6lTOIRX2tGwdkWz+JjuP0zAt/DKQ6r083WLxuPO3fuoUKcdpozqiSdPnvsRXpHbUtVb4qvsmTGwRysHPbmGVP6pA5rVr4oq5T6MPOrEzMroaJ1m3TF/ymCkSZVMXTfK1GilroWdW9dz7Md4E2ZcN/w7fM7l2a2Pq/3ItUeuHzmyZPA3Tlkevn+s2gJFCuZG705NHMVs23UQvQZPxIDuLVC0YB6HEMqEsOljejvSjZo0B8vWbFPXTmNEV974lK3RCgXy5kCnVh8eJkR4F67Y9NGAiQivjJauXjBWibWz8Jo9nv7F8JrNb1ynv/4qC0b27+hon9StS78xWDZrpBq0MVueJ67B/+FTP0g0ncIbJA6D/Uq4E97fT53D+sUT/OzIWXjlgi8rKhibTCyTC5YhvDLi8evxU2qS27C+bU3HanpaeGPHjIZRAzr5aYsIrzzFy8oTf/x5Tt34Jo/oocIMjE1GXErXaAXfNy4JO3jy7Jl6XZcja0a38chSlnEhldHWJnUr+6mHCG/a1MnVQ4RscvPYtf+ompEeJnRoLFqxCRNnLFLiGjdOLH8PvLPw7j5wFF36jkaJb/OjSIHcyPrF535exUpB7tpiVniny+j4/FUqxMH3616Jzy1cqh7aNaulhN4Y4Z00vDuy/f+oj/2ezBJCMgHfwhshQniUqtoCg3u1wbkLl7Fx+14snz3K0a+MEd6jJ/5Ei86DMaxPu49WlZEH9nhxYjlE2D/hlQdCGY3cumO/emCWV/eyydsdI6zKuG5MGNrVT3iUhGRJaJbv64aZ8gISXrP5nfvCkWMn0brrUBUm5V841OGjf6BNt2EfiahIq5y/pUsUVmEaxnVMwpTqVivj2NWqDb9g2LhZDiE0fpBJxjLyaqyiI8K7aOVm7NkwW90njM24VhkhdM7Ca/Z4+ie8ZvMb7ZMHInlTZWwX/76Gmk26Ot4gmC3PE9fgkHxuB4e2UXiDw1EyUceAhHfI2J+xadte7Fr3c4AhDQV/rKtuAMZm3HB8x/DKqGr/EVPVxXZwz9YqltTd5mnhlRheGaXwvZWs2hwlixVQoz3GSOSiGcP9jETLBT9/idp+blx37j3AzHkrse/wcRXHJrF9VcqXQPUKJfxtlnEhbdOklmNkyUgscYkSPyyv/mS7fPUGqjXshCG92qhXkNUadETKFEkwuGebALG5iuGVEV65Gf3510VIYErunF+gdeNaSJ70Q1y2u7aYFV652cl+woX7+NhK/5CHivo1yznEZNH0YUiZPLG7bsDfSQC+hVfivTv1GYVwYcPi/KUramRV+pbxIGVcf7bvPoSegyaoa42viCxF08fnrXrFLmkDEswxU+Zh9YadKgwqc4a06rW4vBmSMAoZBZU4eP+uG4Z4+RZeM+XZrY+r7mKwmDNpINKlSeGyRxkjucabGN+J5IE/S6Z06N+thUN4nZeblNCFASOnYeuKqY54XylDJPrt27eQ+GvZRHjXbt7tJ/Zf/m4IrhH+4Cy8Zo+nf8JrNr9/k4uNa/KoAR2RN1cWmC1P2mb3GsxLwKclQOH9tPw9tveAhNe/SWvzlq7HpJmLHZPWZITD9wivvOaTET7nZckMcSpS4Cv069ZCjVwGtAW28OqM8Pqut7RTYo2F5YBuLVG0UG6XzTIupLKkUtOfqvhJ4zzCKz+26DQI4cKFU3GB8m9Zs9hYis0/bgGtwysj8b8dP42JMxcpCfA9090oz1VbNv+yD32HTfnoRiare8j6zMakNXl1N3/ZBsye2B9hQv9v5MYoO2aMqCqWzhATCq/HTuMQX5Cz8Ipk9hg4Xl13ls0agaSJE34kvMaopoipxOA6bxEjhHdMXPNvhLdEpaYqxEkeiI3tzLlLqNeyl0N4jeuGvN73ve6rPAjLA7Vv4TVTXkDCaza/c1vlDVurLkMwvG975M+TzWV/cTfCW6bEN+jQoo5HhFdCGmSt8IgRIzjqYgikfyO8Zo+nf8JrNr9Z4TVbnm/YVq/BIf4ED+INpPAG8QNktnoBCe/1G7dRuZ4E/5dDg1rlVZEyCikzj+VV1OyJAwLcjat1eI0bl4zKyI3Iv8lXUnBgC6/ZGF5XjZYbb6FSP6FWlVKOuFvndMaFVEZWF04f5hB+g5Nz7KtM9Os5aDy+zJhOzRCXG4HvyYOu6mHmwxOzF63BtDnLsWf9LJcj7c5tOXHyLzTtMMDPzHjZt0x2kz5iCK8xIuMutpvCa/bsZDqDgLPwSphM36GTETdOTMfkNecRXjnfJLa2aKE86OIrttYVVQl9kGuaPFQam5wHRcrUx0/Vy/lZ93fCjEVYsGyDQ3iNGN7qFUuqNxjGZjwoGsJrtjzJb6c+rton8wJKVWuJbF+mV9LrajNieOWBvVdHFzG8//8w758Q6ozwivAacyeMusio/Zmzl7BqvusYXp3jKesfN65Tyc9xM5vfrPCaLc8Va91rMK8En5YAhffT8re1d7nw7tj7qyrjwJETau1Kic2KESM64saJgSyZPneULys1rN+6R13I06ZKjk3b92Lnvl9VnJe70Ub/vrQmNwu5acgM2u7tGvorcYEtvIZkizTWrVZafa3J9yoNLRpWVyELsoyXrEYgX2USeRUJFTldt3kXJC7Vd/yv7wNlXEgl/CFt6mQoV/LDKg0inxJrYKzSYOSRkYpytdqoj3Q4x5P51wGchVdGYX183iHrF+nU0j8379zDtNnLkTxpIrUWspm2SNxg5Xod1USNLm3qqfYuWrERm7bvV9XwvSyZjATv3HsEFcsUU/0oTJjQanm5fYePKTGR5e0ovLZO3/9kZmfhdQXBWXglzdrNuzB49Aw12eqb/LkQLVpktaLK0eOnVWiPMelWYualP/fs2ATx4sRUKzYkSRQfnfuMwsXL1zGsT3skTBBHvcaWNxkyemuENHy4bqxU54SIoix7JmsFy37lgdD3CK/Z8uzWxxUfWWpMJobJCO/3RfOpybvnL15Vo6zG5D3HKg0/fouvc2fF1Ws3MX3uCperNNgJaVi5YQeiR42CahV+QMrkibBz76/qWMnEtnIli6rqu1ylweTxlC98SmhVi4bVVBhKogRx1dslM/3BrPCa7V+euAb/J0/6INRoCm8QOhi6VTFe+bjKl++rrI7JBfK7yM7M+auwYdteyFfSJOZS4uUKfZ3D7W79E17JKGImF1dZmksunK62TyG8MoIt+5W1JUVGZT1NWY5MJrnIGpOlv/+wmsPYqQtw8vQ5NZFFwgNk2Z6alUv5Wc/SuU3O6/Bu3C7r8L5Qoy7tm9fxs9axkVd96W7TLqxdMM6xdFpA4J2F95fdh7Fq4w5cunxNrSssS6jJ8k0Na1dQyyyZbYscyxET5uCv83+rcJVSxT8s9yOzsn0Lr/BbvnaburHIkmSyzJqsdyr9qnbV0moZKAqv21OHCZwIWBVeKebgr7+rEVkJRZDY3fjxYiPbFxlQvVJJR6y+TEwdOGo6fv/znJp9b6zDK29WRk2ciyPHTqm3W7KsoayU0qTd/2J4ZR/G+t1rNu7C46dP1eBAy4bV1Eit708Lmy3Pbn3860AyWDF/6Xq17rCsSSxLgv1UvayfMAdZW3vVBvfr8NoRXlmHd1ifthg1aZ6Kw44VIzqqlPve1Dq8Zo7n8T/OYNTkebh85R/I/c73Orzu8usIr5n+5alrMC8Kn44AhffTseeeA5mAMctWQjgC+hSyp6slk+Wq1OuADOlSq8ki3EiABEgguBMwPjzhvNxlcG8X6x9yCVB4Q+6x/U+37NSZ8zhy9BQypk+N8OHD4+z5y5izeI1aP9aYZextQM+ev4AsgfPLnkPqC2nOXxry9v5ZPgmQAAl4iwCF11tkWa63CFB4vUWW5X5SAiKaIybOUcIp4QaxY8dUn9Zs8lOlj9av9VZFjdg1iTmTdS6N+Dpv7Y/lkgAJkEBgEaDwBhZp7sdTBCi8niLJckiABEiABEiABEiABIIkAQpvkDwsrBQJkAAJkAAJkAAJkICnCFB4PUWS5ZAACZAACZAACZAACQRJAhRem4clXLjwNktwnf3Fi+eIECFigB908MqObRT65s1rldtbTGxUzd+sspaxsI4cOYo3ivdamS9fvlCcw/j6hr3Xduahgn183qhln8KH/99XmTxUtPpSl5TPzfMEwoYN5/ZDKZ7fa8AlBsdrTWAz8r2/58+fIVKkyEHuOH5KJv7t++1bH7WMp9x/g9pm9PugVq/gUh8Kr80j5S25o/DaPDAms1N4TYLyQDIKrwcgfoIiKLyfALqHd0nhNQ+UwmueVXBLSeG1ecQovP8DGBxHXSi8Nk8AjewUXg1YQSgphTcIHQyLVaHwmgdH4TXPKrilpPDaPGIUXgqvzS5kKTtDGvxiY0iDpW5kKhOF1xSmIJ2Iwmv+8FB4zbMKbikpvDaPGIWXwmuzC1nKTuGl8FrqOBYyeVN4N27bg7mL1+LSletoVq8q6lYv66jhi5cv0XfoJJz66wLChQ2Lds3qoEDeD59Cf/zkMQaMmIbT5y599NukmYtx4e+reP36Dfp0boa4cWKpPC07D0Ln1vWQNHFCCxSCRpYxk+filz2HcfP2XcyaMABfZEznqNiu/b9i7JR5eOPjg8wZPkOfTs0QMeKHePktO/ZiyqxlH/0mnw0fPHo6wocPh9w5vkT1iiVV+t+On8KWnQfQvV2joNFwC7U4e+Eyho6dgXMXLiPrFxkwYVh3P6VMm7MMazfvVH8rW6IIGtSuqP4twjt19jJs3L73o9+E8ZKVm9TfJX2OLBnVv6fMXoqUyRLj+6L5LdTUfBbG8Jpn5SolhdceP69N0GIMr80DYzI7QxpMgvJAMoY0eADiJyjCm8IrYho6VGjMW7oWKZIm9iO8k39ejJu376Ff1xa4dPk6GrXtgzULxiNK5EiYOGMBbt6+jwHdW/n5zcfnLZp3GoD5U4Zg7aaduHP3vhKTNZt24MGDR/ipRrlPQNBzuzxx8i8kTBAXTdr1Rf9uLR3C+/TZc5Sp0QLTx/RD6pRJ0WvwBCRNnACN6lSC8du00X2RJlUyP78NH/+zEl15kKhQpw2WzhqlJpY269AfowZ0QvRoUT1X+UAu6e69B7h99z4uXLqK7bsP+RHeI8dOYti4nzF38mBVq9pNu6Jr24ZKYA/9dgLDx8/GvClDPvqtWsOOmD6mLx49for+I6ZgysheuHz1H4yZMg9jBnXxegspvPYQU3jt8aPw+uLHGF6bnUkjO0d4/cJiSING59FM6k3hNarSf/gUJEuS0I/wlq3Z0o/Uteg0AKW+/wbFi+SD/Na7UxNk+zKTKsL4LX+e7KjRqDNWzh2DxSs34d379yhZrCA69x2FScN7IGzYsJqtD5rJndnISPnGbXsdUvfHn+fQd9gkrJgzBvLbus27MGlET7VKg+/f5GtpyZImwg/FCqBKvfZYOXcspsxagtQpkynOIWFzZiNtcu5vsxasUqPm3do1Qr9hk5E4YTzHiK/v3+o276Yesp49f6k4yUOBvDno0qaBesDw9kbhtUeYwmuPH4WXwmuzB1nLTuGl8FrrOfq5PoXwygNM3uI1sH7RREdIwsBR05RU1K5SWv22au5oJEr4QTKM3+pULYP1W3Zh94HfED1qVLRrXgdDx85ExdLf4ctM/3v9r08haOVwFt6Z81fi1p17jhCEe/f/RZkaLbF/83zIb9dv3EKvjk2V8Pr+7cG/jzB68ly8ePkKPxYvhORJEmHCjIVK5ELK5kp4ZQS7dIlvHCEIm3/Zpx4Mxg3phqbt+6kHAHm4ks33b6fOXMCcxasRJnRoNPmpCmTE/eHjJ6hb7X+hON7kRuG1R5fCa48fhZfCa7MHWctO4aXwWus5+rmCivAOGDlVjQK7El7jNxFe39uh3/7Arn1H0Kx+VYyaNFe93pc4y28L5dEHEYRyuBNeeZ1ftmYrl8Lr+zffTZKHjJadB6Jr20b4868L2LbrAKJGiYz2zeuq/w+umyeF1zcDeVjo0m+0enMwdc4yXL12E6lSJFEi7K2NwmuPLIXXHj8KL4XXZg+ylp3CS+G11nP0c30K4ZVaSkxq/26tHCOzvkMa5LfenZoiexa/IQ2+X8O/fPUaLToOwJjBXbBw+QbEjxdHhTdUbdABS2aOCNbhDc7Cu2HrHmzavgcThvVQB9h32IL8tn7LTkwa0eujkAbfvWHl+u14+vQ5qlYogeoNO2HxzBFYvf4XPH76FPVqlNfvOEEkhyvh7Td8MpIlTuiI6fYdtiChIIkTxEPDOpVUC3z/5rtJPQaOQ5Vy3+P1Gx+s3vCLCr8RAa5W/gdkyfy5V1pP4bWHlcJrjx+Fl8JrswdZy07hpfBa6zn6uT6V8E6cuQi379z/36S1Nr2xesF4Ndo4fvp83L7z4H+T1nz9ZrRwwvSFSJ8utRrNHTt1PjJ9ngbfFs6LinXbYv7UoYgYwTtfydQnrJ/DWXifPH2mQhhmjP3fpLUkieKjcd3KMH6TyVbGpDXjN2PP9/99iG79xmDiiJ5qdYufmnfHkp9Hqtf5MrGwRYPq+pUMIjlcCa+M/I+YMAtzJg1StazTrJuKw82ZNRMOHDmOkRPnOCa0+f7NaNLBX09gz4Gj6Ny6PvYdPoZ9h46hS+sGKrSmaMHcyJMzi1daT+G1h5XCa48fhZfCa7MHWctO4aXwWus5+rm8KbwiVCKjT548VZ/Jjhw5Ekb064BM6dPi+YuX6DNkIk6dOa+WzWrTtDYK58ulGvDosSxLNhV//nXxo9/kd5G0KT8vwYj+HVX6f27ewYARU9SobvYvMwTb1RpkVYUde4/g/oOHagWFiBHDY/2iSaqNO/cewdip85SwynJlfbo0Q6SIHz6Pu3n7HkyZvczlb/K7jFZWLf8DMmdIq9LPmLscf5w+hzdvfNC7UzO1MkRw227cuoP6rXrh5ctXePnqFWLGiI46VUurdsomS4mt3bhD/bvMD0XUw4FssiyZ/LZhy56PfpM/+H5zIA9f8hni7gPG4e3btwgbNgwG9GiNsF765DuF114vpPDa40fhpfDa7EHWslN4KbzWeo5+Lm8Kr35tPuQIjivCWG2rJ/LxwxPmKfLDE+ZZBbeUFF6bR4wfnvgfwOB4E+I6vDZPAI3sXIdXA1YgJ5WZ+z0HT8Rf5y6h5HeF0KFFHUcNKLyBfDC8sDsKr3moFF7zrIJbSgqvzSNG4aXw2uxClrJzhJcjvJY6jj+ZZPWCi5ev4dyFK7hy7SaF15Nwg0BZFF7zB4HCa55VcEtJ4bV5xDwtvLImosRivXr9GvHjxkb7FnWRNXN6m7X0bnZZ93L+svV4+PCx+pSlLA1U7sdvvbtTm6UbX8qR5XdklDf9Z6nUouPCPChvRv94/eY14sUJfv0jQoQIqFvN8/2DH57wTK+Vr5Odu3iVwusZnEGmFAqv+UNB4TXPKrilpPDaPGKeFl6ZUSqfeQwbJhT2HjyuPn+4deV0hA4d2mZNvZddZqmmSp4U8ePGxNXrt9CgdW9MG90Hn6VJ4b2d2iz54aPHOPbHGRTIkx2vXr3E5FnLcOfeAwzv28Fmyd7NbvSPcGFDY8+BY8GqfySIFwtXrt1Ag9Z9PN4/KLye6XcUXs9wDGqlUHjNHxEKr3lWwS0lhdfmEfO08BrVefHiOd74vEORMvWwZ8NcRI70YbZtUN6MGN46zXqohd7lM59BfTNieI8cP42Z81Y4vp8e1OstIQ2vXvugaNn6waZ/GDG8dZv39Hj/oPB6pse6Et53797j/ft3Lnfw3uc5Xj687Jmda5Ty7t1blTp06DAauTyTNGLMlAgV1tqHGF4/+QdvXz3yTEU0SvHxeY2wYQN/GbbQYcMjQswPKz9Y2V7cO20lm6080tffvXuHMGEC/zPU4aMmQJiIcfytv6xkws06AQqvdXYqpzeFd/6yjfj91FnH99FtVtXr2UV4j/9xBj0HTcSKuWOCxdd5RJSePXuKzn3HIle2zKhbPXA+EWn3YIjwzl2yXi0wP2FYOhymbwAAIABJREFUd7vFBUp+Ed6jJ/5Er8GTPN4/KLyeOYSuhPeDVL53uYPnd//E1d3Bo/95hhCQvNAgRI6X0VJxN46MweOruyzlDY6ZIkRPilTfTbBU9Xc+L3FudVVLeYNrpvhZ6iP2Z6X8rb6IODfrBCi81tl5VXjXbvoFcxevw9QxfRAnVkybtQyc7GcvXEL7HiPUF2eyfZkhcHZqcy8iSgNHTcHDh08xtG979Y304LCt27wDcxatDWb942+07zHcK/2DwuuZXqsb0vD87in8vaOLZ3YeTEpJVWQoIsf78IU33e36oZF4dGWnbrZgm16EN22JKZbqL8J7ZkVFS3mDa6aE2RoiTjq/n8f23Rauw2vvyFJ47fHzygjvlh37MXX2Ukwc3gOJEsSzWcPAyS4zvNt0HYJu7Rogb65sgbNTD+xFYqSv37iFkf07IVy4wH+FZaUJRv+Qkd3ECeNbKSLQ8xj9o2vbBvj6K8/3DwqvvUP69t07lKvVRi3S/8bHB9GiRsGYgZ2ROmUSBLQsGYVXjzuF1zwvCu/HrCi85vuPq5QUXnv8PC688uWh6XOXY9SADkiWJHGQnqxmoPMtu/JpRm+Fedg8VB9lHzp2Jm7fvY/eHRsjRowYni7eK+X9r390RNLECdXXqYL6ZvSP7u0bqq9chQ8fweNVpvB6HKmjQAqvX7Yc4TXf1zjCa56VpOQIrx4v3dQUXl1iTuk9LXfflP5JLZMly3uFChVK7W3muH5BeiSvQ68ROHjkBKJHj+qg07pxTXxfNL9Nut7Lfv7iFVRr2BGxY8VQDxXCOm7smEF+0prRPyJFEmlk/zB6CIXXe+cKhZfCa7V3UXj1yFF49Xjppqbw6hLzsvAaxcsqDREiRAwWI7xGnfmlNZudSSM7PzzhFxaFV6PzaCal8FJ4NbuMIzmFV48chVePl25qCq8uMQqvv8QovDY7k0Z2Ci+FV6O72EpK4aXwWu1AFF49chRePV66qSm8Joj9evwUxk9bhEePn6jJHG2b1UKOLB+WpfF0SANHeE0cEA8mMdbhjRw5igdL9X5RFF4Kr/d72Yc9UHgpvFb7GoVXjxyFV4+XbmoKrwlip86cR4zo0ZAsSUK1Lm63AeOwYfFECq8TO47wmuhMHkpC4aXweqgruS2GwkvhddtJ/ElA4dUjR+HV46WbmsKrSczn7VsUK9cQW1ZMRfhw4TjC64sfhVezM9lITuGl8NroPlpZKbwUXq0O4ysxhVePHIVXj5duagqvJrGN2/di646DGDOok8rprc8PitDI8k2ygkBw2eRLWrLJDTK4bBLSIKwjRbL2qdBP1c5Xr14qzsFhWTKDkY+Pj/pErTfCgOQ4Gp+b/VTHJKTul8JL4bXatym8euQovHq8dFNTeDWInb1wGT0Hjce4wV2RMEFcldPH58M33Y1t5drNmLNwpUaprpPKJwRlqSxjaTKrBaZMngRjh/UOMPuDfx/hp6Ydre7CkU+kQza7dZYyxg7rhZTJkwZYpx79R+Lkn2dt11tYe+LBonyp4qhTo0KA9dm+az/GT5lju84ijrIsmV3WsWLGwOwpw93Wp0zVRm7TuEvgyf7Rv2c7fJkpvWOXcvxCh/6wTBs3zxKg8PrlyXV4zfcvCq95VpKSwqvHSzc1hdckMfkaV/ueHz6bmy5NCkcu59GqURNmoGf/kSZL9X6yLzJ+jkM7Vwe4o5u37iBtlkLer4zGHqTOUveAth8q1MXufYc1SvVu0rbN62NArw4B7mTOwhVo1raHdyuiUXrCBPFw8Y89AeZ4/foNYiX7UqNU7yfdsHwWChfI49gRlyXzHnMKL4XXau+i8OqRo/Dq8dJNTeE1Qezeg4do2XkQOrSo61idwchG4TUB0EISCq8FaBayUHgtQPuPZaHwUnitdnkKrx45Cq8eL93UFF4TxORTv/OWrkfMGNEdqX8e3099mYvCawKghSQUXgvQLGSh8FqA9h/LQuGl8Frt8hRePXIUXj1euqkpvLrEnNJTeG0C9Cc7hdc7XJ1LpfAGDufgvBcKL4XXav+l8OqRo/Dq8dJNTeHVJUbhtUnMXHYKrzlOdlNReO0SDPn5KbwUXqu9nMKrR47Cq8dLNzWFV5cYhdcmMXPZKbzmONlNReG1SzDk56fwUnit9nIKrx45Cq8eL93UFF5dYhRem8TMZafwmuNkNxWF1y7BkJ+fwkvhtdrLKbx65Ci8erx0U1N4dYlReG0SM5edwmuOk91UFF67BEN+fgovhddqL6fw6pGj8Orx0k1N4dUlRuG1ScxcdgqvOU52U1F47RIM+fkpvBReq72cwqtHjsKrx0s3NYVXlxiF1yYxc9kpvOY42U1F4bVLMOTnp/BSeK32cgqvHjkKrx4v3dQUXl1iFF6bxMxlp/Ca42Q3FYXXLsGQn5/CS+G12sspvHrkKLx6vHRTU3h1iVF4bRIzl53Ca46T3VQUXrsEQ35+Ci+F12ovp/DqkaPw6vHSTU3h1SVG4bVJzFx2Cq85TnZTUXjtEgz5+Sm8FF6rvZzCq0eOwqvHSzc1hVeXGIXXJjFz2Sm85jjZTUXhtUsw5Oen8FJ4rfZyCq8eOQqvHi/d1BReXWIUXpvEzGWn8JrjZDcVhdcuwZCfn8JL4bXayym8euQovHq8dFNTeHWJUXhtEjOXncJrjpPdVBReuwRDfn4KL4XXai+n8OqRo/Dq8dJNTeHVJUbhtUnMXHYKrzlOdlNReO0SDPn5KbwUXqu9nMKrR47Cq8dLNzWFV5cYhdcmMXPZKbzmONlNReG1SzDk56fwUnit9nIKrx45Cq8eL93UFF5dYhRem8TMZafwmuNkNxWF1y7BkJ+fwkvhtdrLKbx65Ci8erx0U1N4dYlReG0SM5edwmuOk91UFF67BEN+fgovhddqL6fw6pGj8Orx0k1N4dUlRuG1ScxcdgqvOU52U1F47RL0bP7379/j6bPniBAhPMKHC+fZwi2WRuGl8FrsOqDw6pGj8Orx0k1N4dUlRuG1ScxcdgqvOU52U1F47RL0TP69B49h7eadOHriDN74+MDHxwcpkyVC4fxfofyPRREvbmzP7MhCKRReCq+FbqOyUHj1yFF49Xjppqbw6hKj8NokZi47hdccJ7upKLx2CdrP36zjQMSLEwvfffM1MmdIixjRo+Ltu3e4fPUfHP7tJLbuPICfqpdFoXw57e/MQgkUXgqvhW5D4bUAjcJrAZpGFgqvBixXScOFC+/nz6MmzEDP/iNtluq57F9k/BwijwFtN2/dQdoshTy3Uw+UROH1AEQTRVB4TUDycpLrN24jaeIE/u5F5PfO3ftIlCCel2viungKL4XXasfjCK8eOQqvHi/d1BReXWJO6Sm8NgH6k53C6x2uzqVSeAOHs9m9vH7zBrfv3EeyJAnNZvF6OgovhddqJ6Pw6pGj8Orx0k1N4dUlRuG1ScxcdgqvOU52U1F47RL0XP4jx05i8OiZCBcuDJb+PBInT5/HklVbMKB7C8/txEJJFF4Kr4Vuo7JQePXIUXj1eOmmpvDqEqPw2iRmLjuF1xwnu6kovHYJei7/Ty16YkjvNug7bAomDe+uCq7WoCMWzRjuuZ1YKInCS+G10G0ovBagUXgtQNPIQuHVgOUqKUMabAL0JzuF1ztcnUul8AYOZzN7qdu8B2ZPHACZxOYQ3oadsGj6MDPZvZaGwkvhtdq5OMKrR47Cq8dLNzWFV5eYU3oKr02AFF7vADRZKoXXJKhASNakXX8M7NkSPQdNVMK7/8gJzFu8DlNG9bS199t376PnoAm4d/8h0qRKin5dmyNSxIh+ynz37h2GjZ+NEyfPQP5dpGBuNKlbWaWh8FJ4rXZACq8eOQqvHi/d1BReXWIUXpvEzGXnCK85TnZTUXjtEvRc/t9PncWwcbPw4OFjpEiWSC1LNqJfe2TO8JmtnUiIRKb0qVGx9HcYO3U+YkSPhrrVyvgpc8/BY1i2egvGDu6s1gGu2bgrBvZohXRpUlB4neinKjIUkeNlsnRMrh8aiUdXdlrKGxwzUXj1jhqFV4+XbmoKry4xCq9NYuayU3jNcbKbisJrl6Bn8svSY6f/uohkSRPijz/P4/27d8iSOR1ixohuewfFyjfC6vljESVyJFz8+xr6j5yG2RP6+ylXPnyxYNkGjB/aFa9ev0b9Vr0wbkhXJIgXh8JL4bXcBym8eugovHq8dFNTeHWJUXhtEjOXncJrjpPdVBReuwQ9l79j75EY3re95woE8PzFS5Sp0QrbVk5T5T55+gzVGnTG+sUT/OxHwhgGjZ4BEd83b3zQsHYFVKtQQqUJHTqMv3V6fvcUru7+MMHuv7IlLzTI8gjvjSOj8fjqrv8KKrVKQ6rvJlpq7zuflzi3uoqlvME1U/ws9RH7s9L+Vv/du7fBtWlBot4UXpuHgTG8NgH6k53C6x2uzqVSeAOHs5m9DBo1A3WqlUaSRPHNJDeV5tnzFyhbs7VDeB89fooajbp8JLxnz/+N6fNWqDCGFy9foWm7fhjQoxXSpEyGd+/e4/379y739/L+afyzr5epuoSUREny90fEOBksNef20XF4en2PpbzBMVP4aEmQrMhYS1UX4f17Q01LeYNrpjiZ6yJmmh/9rX6YMKGDa9OCRL0pvDYPA4XXJkAKr3cAmiyVwmsSVCAkq9uiJy5dvoa0qZIjYsQIjj0aKzZYrYLvkIYLl65iwKjpH4U0TJy5CDGiRUfNyiXVbgaPmYnMGdKgVPHCDGlwAs8YXvM9kSEN5llJSoY06PHSTU3h1SXmlJ7CaxMghdc7AE2WSuE1CSoQkh39/bTLveTIktHW3vsMnYxM6dOgUpnvMGbKPESPFg31apTF02fP8edfF5A7x5dYvnYr9h/+HcP7tcPr129Qv1VvdGlTD1kyfU7hpfBa7n8UXj10FF49XrqpKby6xCi8NomZy86QBnOc7Kai8NolGPTz37pzDz0GTsCdew+QLnVy9OvWApEjRcS5i1fQa/AELJ4xXE1Uk5AKEeBQoULhu2/yomHtiqpxXJbM7zHmCK/5Pk/hNc+KI7x6rKykpvBaoeYrD0d4bQLkCK93AJoslcJrElQgJHv85CkWLN+Ai5eu4dXrN449ysoJn3Kj8FJ4rfY/Cq8eOY7w6vHSTU3h1SXGEV6bxMxl5wivOU52U1F47RL0XP4ufUcjQ7o02L7nkBpd3b7rIOLFjYWWDat7bicWSqLwUngtdBuVhcKrR47Cq8dLNzWFV5cYhdcmMXPZKbzmONlNReG1S9Bz+eVjD/OnDoZ8cc34uprE3/bp3NRzO7FQEoWXwmuh21B4LUCj8FqAppGFwqsBy1VShjTYBOhPdgqvd7g6l0rhDRzOZvYiqzTIByGatO+PYX3aInq0qGjbfThGD+xoJrvX0lB4KbxWOxdHePXIUXj1eOmmpvDqEuMIr01i5rJTeM1xspuKwmuXoOfy9xo8Ee2a1cKOvUewZNVmxIkdC/HixELfLs08txMLJVF4KbwWug1HeC1Ao/BagKaRhcKrAYsjvDZhaWSn8GrAspGUwmsDnheznjl3CY+fPEPObJkQJvSnXWyewkvhtdrVOcKrR47Cq8dLNzWFV5cYR3htEjOXncJrjpPdVBReuwQ9n9/Hxwdv371zFBwhfHjP70SjRAovhVeju/hJSuHVI0fh1eOlm5rCq0uMwmuTmLnsFF5znOymovDaJei5/Lv3/4YxU+bj34ePESp0KEfBO9fM9NxOLJRE4aXwWug2KguFV48chVePl25qCq8uMQqvTWLmslN4zXGym4rCa5eg5/JXrNsOA3u0wudpU3quUA+UROGl8FrtRhRePXIUXj1euqkpvLrEKLw2iZnLTuE1x8luKgqvXYKey9+gdR/MGNvHcwV6qCQKL4XXalei8OqRo/Dq8dJNTeHVJUbhtUnMXHYKrzlOdlNReO0S9Fz+uUvWIVrUyPihWAF86rhd362i8FJ4rfZyCq8eOQqvHi/d1P954e09ZBKOHD2JWLGiY+G0oS75Xbx8DT+16ImYMaKr33NlzYSeHRurf3MdXt0uZy49hdccJ7upKLx2CdrPn7d4zQALObhlvv2d2CiBwkvhtdp9KLx65Ci8erx0U//nhffYH2cQMUJ4DBg5LUDhHTN5Plx9057Cq9vlzKWn8JrjZDcVhdcuwZCfn8JL4bXayym8euQovHq8dFP/54VXgF375xY69x1N4dXtPV5MT+H1IlxfRVN4A4ezmb08+PcRokeLgrBhw+Ls+b9x8cp1FCmQWz2Qf8qNwkvhtdr/KLx65Ci8erx0U1N4TQpvw9Z9ETNGNMSNExPN6lVB1i/SK9Yc4dXtcubSU3jNcbKbisJrl6Dn8sunhaeO6olHj5+ifqveyJguFSJFioQ+nZt6bicWSqLwUngtdBuVhcKrR47Cq8dLNzWF14Twvnj5Ei9fvkasmNHx6/FT6DN0MpbNGonIkSLi/Xu/yMdOnoU+g8boHgevpc+cIR32bl0WYPk3b91BxlzFvFYHKwVLnaXuAW1lqjbEnv1HrBTvlTytmtRF3+5tAyx73uJVaNUx6MzEF+E989v2AOv8+vUbJEiT0yvMrBa6etE0FMqf20/2UP9butZqsZ80nwjv7An9sWbjDtx/8Aj1apZDzcZdMX/q4E9aLwovhddqB6Tw6pGj8Orx0k0dLIRXFmLf9Mt+HDvxJ27fe4CIESLgs9TJUTh/TuTKlhmhbN7p3IU0OEOVG1O3tg2QLk0KCq9ujzOZnsJrEpTNZCFFeD9cA5yePm2yCezsNRp1wZxJA9Bz8ARULVcCWTJ/jmoNO2PRdNeTaQOrfhReCq/Vvkbh1SNH4dXjpZs6yAvv5FlLsGvfr8ifJzsyZ/gMcWLFwOs3b/D3lX9w+Ogf+PfhE3RuXU/Jp9XNlfDK356/eKkWgb95+y5ix4qhlgo6ffYi2vcYgWWzRyJqlMgMabAK3U0+hjR4CaxTsQxpCBzOZvYyc/4qrFi3DUkSJcCUUT1x994DdB8wHjPH9TWT3WtpKLwUXqudi8KrR47Cq8dLN3WQF95N2/eheJGvETp0aJdtu3HrDm7duY/sX2bQbbtK36XfGJw6fQEPHz1G7Ngx0aBWeZT+vjAWr9yMK9duKJnesmM/psxapr5vHy1KZDSrXxX5cmdV+RnDawm720wUXreIPJKAwusRjB4r5Omz5ypUSq538sD9/PkLxI0Ty2PlWymIwkvhtdJvJA+FV48chVePl27qIC+8RoNOnj6PLzJ+5qd9J07+5Zg8pttwT6Wn8HqKpN9yKLze4epcKoU3cDgHtJfLV28gZfLE/ibx8fHBrTv3kDRxwk9SWQovhddqx6Pw6pGj8Orx0k0dbIS3WceBmDS8u5/21WraDfMmD9Jts0fTU3g9itNRGIXXO1wpvIHDVWcvrbsORdQokVC0UB5kSp9GhW29ev1GvWE6fPQUduw9jMZ1KiF/nmw6xXosLYWXwmu1M1F49chRePV46aYO8sJ7/cZtSNjCuGkL0apRdUf7njx9gelzl2HxjOG6bfZoegqvR3FSeL2D099SOcIbyMD92Z3MR1i7aReO/fGXCq8KGyYMUqVIisL5c6FcySJqhZhPtVF4KbxW+x6FV48chVePl27qIC+8G7fvxaZt+/DX+b+R/rNUjvZFjRoJpYoXxtdffYil/VQbhdc75DnC6x2uzqVSeAOHs85eJIQhTJgwtlef0dlnQGkpvBReq32JwqtHjsKrx0s3dZAXXqNB23cfwreF8ui2z+vpKbzeQUzh9Q5XCm/gcA1Je6HwUnit9mcKrx45Cq8eL93UwUZ4pWFGeMPbt+8c7cybK4tumz2ansLrUZyOwii83uFK4Q0criFpLxReCq/V/kzh1SNH4dXjpZs62Ajv1NnLsG3XQSRPmhChQ/1vibIR/Tvottmj6Sm8HsVJ4fUOTn9LZUhDIAMPhruj8FJ4rXZbCq8eOQqvHi/d1MFGeBu17YvJI3sijD/r8eo23FPpKbyeIum3HI7weocrR3gDh2tI2guFl8JrtT9TePXIUXj1eOmmDjbC22vwRPTr2ly3fV5PT+H1DmIKr3e4UngDh6uVvcxauAaVyhRTH57oOWgC/jp/Ge2a1XZ85MZKmZ7IQ+Gl8FrtRxRePXIUXj1euqmDjfCOm7YA7969g8Tshg0b1tHOHFky6rbZo+kpvB7F6SiMwusdrhTewOFqZS91mnXHnEkDceTYSSxdtQWN6lbCwJHT1N8+5UbhpfBa7X8UXj1yFF49Xrqpg43wyocnXG3OH6PQBWA3PYXXLkHX+Sm83uFK4Q0crlb2UrdFT8ye0B8yXyF50kQo8W1+BIWP61B4KbxW+rPkofDqkaPw6vHSTR1shFe3YYGVnsLrHdIUXu9wpfAGDlcre5F5CkUL5sHytVvVfIWYMaKhZuMun/zjOhReCq+V/kzh1adG4dVnppMj2AjvqTPnXbYrc4bPdNrr8bQUXo8jVQVSeL3DlcIbOFyt7OXKtZtYs2kHsn6RAQXzZof89+4Dv6F2lVJWivNYHgovhddqZ+IIrx45Cq8eL93UwUZ4G7fr52jbmzc+uHT5unrtN3fyp41vo/Dqdjlz6Sm85jjZTcVlyewSDPn5KbwUXqu9nMKrR47Cq8dLN3WwEV7nht28fRcLl29C++a1ddvs0fQUXo/idBRG4fUOV47wBg5Xnb207Dw4wOTjh3bVKc7jaSm8FF6rnYrCq0eOwqvHSzd1sBVeaWi3/mMxqGdr3TZ7ND2F16M4KbzewelvqRzhDWTgLnZ39PfT6q/7Dx/H1Ws3UbJ4IYQNEwZ7Dh5FxAgRPvlDPYWXwmv1LKHw6pGj8Orx0k0dbIT34uVr/2vbe+DSletYtmYrpo3urdtmj6an8HoUJ4XXOzgpvIHM1crumncciHFDu/r5uE7fYVPQu1MTK8V5LA+Fl8JrtTNRePXIUXj1eOmmDjbCK8vzGFuYMGGQNFEC1K9ZDqlSJNFts0fTU3g9ipPC6x2cFN5A5mpld1Xqd8CcSYMQMUJ4lV3WHW/VdSgm2AxpuH33vvqQxb37D5EmVVL1AZ9IESN+VMUz5y5hyJiZePDvI0SLFgXzpwxG6NChQeGl8Frpz5KHwqtHjsKrx0s3dbARXt2GBVZ6Cq93SDOG1ztcnUtlSEPgcDazl8k/L8HhoyfxXZF8CBc2DPYePIaM6VOjSd3KZrL7m0ZGiTOlT42Kpb/D2KnzESN6NNStVsZP+tdv3qBK/Y7o0b4R5GM+MkciYfy4CBUqFIXXiWyqIkMROV4mS8fk+qGReHRlp6W8wTEThVfvqFF49Xjppg5Wwrv/yAkcO/En3gPIlS2z+urap94ovN45AhRe73Cl8AYOV6t72b3/N/x24jRChXqPnNm+UMuT2d2KlW+E1fPHIkrkSLj49zX0HzlNfeDC9/bLnkPYtvMghvRu+9HuOMLrFwmF13yPpPCaZyUpKbx6vHRTBxvhnbNoLTbv2I9ihfKoNm7bdQA/fFcItSr/qNtmj6an8HoUp6MwCq93uFJ4A4er7l583r7F6Enz0LFlXd2sAaZ//uIlytRohW0rp6l0T54+Q7UGnbF+8QQ/+X5esBpXrt3A3fv/4uGjx/i+aH7H+r8UXgqv1U5J4dUjR+HV46WbOtgIb7WGnTF9TG9EjRLZceGWLxMtmj5Mt80eTU/h9ShOCq93cPpbKkMaAhl4ALvr0ne0yxFWOzV89vwFytZs7RDeR4+fokajLh8J74x5K7B+yx7MHN8XEcKHR5N2/dG2aU3kyJpJxRK/ffvOZTVe3j+Nmwf62KlisMub6Ou+iBgng6V63z0+AU+v77GUNzhmCh8tCZIUHm2p6u98XuLKpk+77KilitvIFDtTHcRIXdLfEsKFC2ujdGYNNsJbvVFnLJg6RMWUyfb+/XtUb9gJi2YM/6RHkcLrHfwc4fUOV+dSKbyBw9nMXiS+9sXL1yiQN7tj4prkk5haO5vvkIYLl65iwKjpH4U0rN20E0d/P4O+XZqpXY2btgDx4sRGtQolEDp0GMd117kez++ewpVd/5tQbKeewSVvisKDLcfw/nN4FB5f3RVcmmq7njLCm7r4JEvliPCeXWUvft3Sjj9hpgRZGyD2Z6X9rcHbtz6fsHbBf9fBRnj7DJ2M8OHCocwPhZXsrt64U4089Or4aZfsofB65ySg8HqHK4U3cLha2Uuzjq6/GjlpeHcrxTnyyLUzU/o0qFTmO4yZMg/Ro0VDvRpl8fTZc/z51wXkzvEl7t3/Fy06D8KMsX0RPnw4NcLbuG4l5M7xBSetOdFnDK/57siQBvOsJCVDGvR46aYONsIrF+eZ81fi12N/AqGAr7JnRv2a5dVEjE+5UXi9Q5/C6x2uFN7A4RqU9nLrzj30GDgBd+49QLrUydGvWwtEjhQR5y5eQa/BE7D4/9+Srdm4A/OXbYC8RCtaMI8SXtkYw+v3aFJ4zfduCq95VhRePVZWUgcb4bXSuMDIQ+H1DmUKr3e4UngDh6uVvUi87ayFq9UqDXj/Xj3U161eVsnpp9wovBReq/2PwqtHjiO8erx0Uwcb4e0+cDw6tqiDmDGiqzbK4uhjpsxXi6h/yo3C6x36FF7vcKXwBg5XK3vpN3yKeC7KlCissq/asANhw4ZFzw6NrBTnsTwUXgqv1c5E4dUjR+HV46WbOtgIb83GXTF/6mA/7ZOJbAunDdVts0fTU3g9itNRGIXXO1wpvIHD1cpenCfmyhyFGo06f/KJuRReCq+V/ix5KLx65Ci8erx0Uwcb4ZWbwdxJA9WIh2zyZaDaTbs54s90G+6p9BReT5H0Ww6F1ztcKbyBw9XKXmTpxZnj+jpCGCTEocH/tXce4FVUWxv+EopIEwEBRQVBAaV7LWChqGAXRAHpvYdeAoHQQgu9hN47goBKE1EpFsCKihVBqvQeIEIS7rM3N+cmIeew15RDTvjmef5aeuh+AAAgAElEQVTn55q19t7zzj5z3rNnzUzHfjf90YsUXgqvlflM4ZVTo/DKmUkyAkZ4x0yeh5OnzqFW9ap6/xavWIs8uXOhc5sGkv11PJbC6zhS3SCF1x2uFF7/cLXSi3r5w8YvvkaVSuWhXif58cav9L8b1fH+mCIr/UhzKLwUXumcSYjnCq+MHIVXxksaHTDC++/ly/qGji+370AQgvBMuTJoVKeafkj6zdwovO7Qp/C6w5XC6x+uVnvZsvV7fPvDz/q5t4+VKaGfyXuzNwovhdfqHKTwyshReGW8pNEBI7zSHfNXPIXXHdIUXne4Unj9wzUt9ULhpfBanc8UXhk5Cq+MlzQ61Quvejbkqy9WRPp06VLct30HDuPYiZN4vGwJ6b47Ek/hdQTjdY1QeN3hSuH1D1crvaTWJ9FQeCm8VuazyqHwyshReGW8pNGpXnhnLliJjz79AuUeK43ixQrhzhx34PLlK1Ci+/X3P+t/d+/QGIUL3ifdd0fiKbyOYKTwuoPxhq3y1cI3ROS3gNT6JBoKL4XX6oeAwisjR+GV8ZJGp3rhVTt07nw0Nmzaiu9//A3HT57WdbuFH7gXlZ95AqVLFJXus6PxFF5HcXoa4wqvO1y5wusfrlZ6Sa1PoqHwUnitzGeu8MqpUXjlzCQZASG8kh3ydyyF1x3iFF53uFJ4/cPVSi+p9Uk0FF4Kr5X5TOGVU6PwyplJMii8ElopxFJ4bQL0kk7hdYcrhdc/XK30klqfREPhpfBamc8UXjk1Cq+cmSSDwiuhReG1Scs8ncJrzspOJGt47dC7NXIpvBReqzOdNbwychReGS9pNIVXSixZPFd4bQLkCq87AA1bpfAagvJD2KHDxzAyai5Onz2HOVER+O3PPfhux2+oX+tVP/TuvQsKL4XX6gSk8MrIUXhlvKTRASm8MTH/4szZ88iXN7d0fx2Pp/A6jlQ3yBVed7gmb5XC6x/OJr106DkMb1erikXvrcGUUeGIjY1Fgza9sXh6pEm6azEUXgqv1clF4ZWRo/DKeEmjA0Z4ew4Ygz7dWiE4OBgNWoch5t9/Ubv6S2j4zuvSfXY0nsLrKE5PYxRed7hSeP3D1Uovjdr2xtxJg9G2+2BMGtFbN1GnRSiF1wpMF3MeeC4Sme8qbqmHg9tG4ey+jZZyAzGJwis7ahReGS9pdMAIb+OQcH2Z79Mt27Dj5z8R0uIdNA3pi4XThkn32dF4Cq+jOCm87uD02ipXeP0M3Ed3TULCMW1MP3QMi9TCq0ocQvuPwYKpQ2/qILnCyxVeqxOQwisjR+GV8ZJGB4zwNmgThvmTh2DEhDl48rFSqFD+UaT0oHYpALvxFF67BFPO5wqvO1y5wusfrlZ6eX/tZ9jy1bc4+M9RVKlUHh9+tBmtG9fEq1UrWGnOsRwKL4XX6mSi8MrIUXhlvKTRASO8vQeNR1xcHP7cvR8Lpw1FfPxVtOo88KavflB4pVPOLJ7Ca8bJbhRXeO0SdC4/Lj4eO376DV9s/0Gf354pV/amvTI98V5ReCm8Vmc5hVdGjsIr4yWNDhjhjfn3Mr75ficeKnS/vlnt6PGT2Lv/EJ78TynpPjsaT+F1FKenMQqvO1y5wusfrtJeYuPi0KlXJKKGh0lTXY+n8FJ4rU4yCq+MHIVXxksaHTDCK90xJ+NPnDyN8KET8fufe/Bq1YroFtLI0zyF10nS/2+LwusOVwqvf7ha6SUsYhz6hbbRr05PTRuFl8JrdT5SeGXkKLwyXtLogBHep19ueN2+Zc2SGSUfeRBd2jbEPfnySPfdOD76wkXs3nsAf/61D/sOHKbwGpOzHkjhtc5OksmSBgktd2P7Dp2IPfsOotxjpZDptv9Lb/MGb7nb8Q1ap/BSeK1OQAqvjByFV8ZLGh0wwrto+ToEAXj9pYp6Hz9YuxEXY2KQ/+48WP/pVxg3NFS67+L4D9dt1DXEXOEVoxMnUHjFyCwlUHgtYXMlacb85Sm2S+F1BbflRvlYMnN0FF5zViqSwivjJY0OGOFt3TVCP4w98dawTW/MmzwYCc+vlO68NJ7CKyVmPZ7Ca52dJJPCK6F1a8ZyhTfpcafwmn8OKLzmrCi8MlZWogNGeOs0744xQ0KRL8+1t6sdPnocnXsPx5IZI5DwjF4rACQ5KQnvlStXkjQxYepcDBw2QdKsq7HFiz2ETesW++zjyNHjKFnuZVfHIW1849rFKPHwQz7TatRrjc+/+lbatGvxIS0bol+vDj7bX7j0A3QKjXBtDNKG8+bJjZ3bP/KZdvnyFeQvWl7atKvxyxdMRoWnH/f0kS5dOv1SGm7OE6DwUnitzioKr4wcV3hlvKTRASO8GzZtxZjJ81GqeBHg6lX89OsudG3XEE89UQbzlqxCq8Y1pfsujk9JeNOlS5+knTETZ6LvoNHitt1KKPlIUXz16QqfzR8+cgxFylZ2awiW2lVjVmP3tb1Wsyk2f7HdUvtuJHVq2xQR4V19Nj1v8Qq065L0SoUbYzFtU63w7tqx6YbCm6tAGdMm/RK3aulMVHq2XJK+4uJi/dL3rdYJhZfCa3XOU3hl5Ci8Ml7S6IARXrVj6mkJSnSDgoJQ8uEHkTvXndL9tRXPkgZb+ETJLGkQ4bIczJIGy+humUQKL4XX6mSn8MrIUXhlvKTRASW8audiY2OhHtCesPnjET6qvzcbdEJMzL+4EhuLbFmzYOzgUBQqmB98LJl0ypnFU3jNONmNovDaJehs/i+//4UDh47gpeefwZmz56CeP55QxuVsT+atUXgpvOazJWkkhVdGjsIr4yWNDhjh3fzltxg7ZYH+EkCQel7DtW3jBzOl++xoPIXXUZyexii87nBN3iqF1z+cTXpZvHwdPt2yXf+wXjB1KPYfPIJh42Zi0ojeJumuxVB4KbxWJxeFV0aOwivjJY0OGOFVN6YN7t1eP4YsNW0UXneOBoXXHa4UXv9wtdJL/Va9MDsqAh3DIj2SW6dFKBZPj7TSnGM5FF4Kr9XJROGVkaPwynhJowNGeMOHRCEiLES6f67HU3jdQUzhdYcrhdc/XK300iQkXAtv2+6DtfBevXoVdVr00E+iuZkbhZfCa3X+UXhl5Ci8Ml7S6IAR3rmLP0TBAvnx1OOlkSFD0icjSHfayXgKr5M0/98WhdcdrhRe/3C10kuP/qNR961XMG3ecowd0gMzF6zAwUNHMbiP70fdWelLkkPhpfBK5kviWAqvjByFV8ZLGh0wwlv+xfop7tvW9Quk++xoPIXXUZyexii87nCl8PqHq5Vejhw7gQHDp2Dnr7t0evFiD2JgWDvkyZ3TSnOO5VB4KbxWJxOFV0aOwivjJY0OGOGV7pi/4im87pCm8LrDlcLrH65WelFPZMh0W0ZEX7ioyxnU02AS/puV9pzKofBSeK3OJQqvjByFV8ZLGp3qhfffy5eRMUMGXE72RrOEHfXHY8l8QaXwSqecWTyF14yT3Sg+pcEuQefyE2p3E7fYoE0Y5k8e4lwnFlqi8FJ4LUwbnULhlZGj8Mp4SaNTvfBWeK0xJo8MR5tuKb+OdcvqOdJ9djSewusoTk9jFF53uCZvlcLrH86+eomPj0f81atoHzoUEyJ7eUKjoy+gVZeBeHfmyJs6SAovhdfqBKTwyshReGW8pNGpXnilO+TveAqvO8QpvO5wpfD6h6ukl5kLVmLWwpVQ4hscHOxJzZolM2q/+RKa1qsuac7xWAovhdfqpKLwyshReGW8pNEUXimxZPEUXpsAvaRTeN3hSuH1D1crvUye9S7aNK1tJdVnztHjJ6Ee63ji5BkUfuBeDOzVDrdnypRijnp9u3r279tvVEGrxjV1DIWXwmt1UlJ4ZeQovDJe0uhUL7zNO/bzuU8zxg2Q7rOj8RReR3F6GqPwusOVwusfrlZ7cePVwurJD8WLFcLbb1TFuKkLcEf2bGhcp1qKQ+w7dKJ+dfv9+fNReL0cxAeei0Tmu4pbOsQHt43C2X0bLeUGYhKFV3bUKLwyXtLoVC+8O3+79ogeb1uJhx+S7rOj8RReR3FSeN3B6bVV1vD6GbiP7tx6tXCVGi3x/oJxyJL5duz++wAiRk3DnKjr74nY/t1P+HzrD/oxaJdiYii8FF7bHw4KrwwhhVfGSxqd6oVXukP+jqfwukOcK7zucE3eKoXXP5xNenHj1cIXL8WgWr0O2LBimh7C+egLqNM8FKuXRCUZknoaTkiPoRgV0RXvr9mYRHiBIAQFpbwHl078gv2b+5jsXpqJub/iYNye+xFL+3P4m7E4t3+zpdxATFLCW7DKBEtDj4+Nwa4P6ljKDdSkPKWb4s4HX/c6fPW4Qm7WCaR64VUlDWFdWmDI6Okp7iVLGnwf/JKPFIWSR1/b4SPH8GDpitZnkQuZFF4XoKbQJIXXP5xNenHj1cIXLl5C9fodPcJ79lw06rXseZ3wTp+/HPny5MLrL1bCvCWrkghvfPxVn8J78PO+JruXZmLufTbCsvAe+XY8zh+4dYQ3Y7b8KPDCeEvHXgnv7lX1LOUGatJdpZogR+HXvA4/yNsvz0DdYT+PO9ULryppKFTwPuzZeyBFNCxpoPD6+TPjtbvO7ZphUN9uPoczd9FytO2celbEKLypZfYAbr1aOHFJw1979mPQ6OnXlTR07j0Ce/cfUou5iI6+qKHUq/mqrvXlTWtJ5whreM0/MyxpMGelIlnSIOMljU71wqvuGF48PVLv15Q5S9G6cS3pProaz5IGd/ByhdcdrslbpfD6h7NJL269Wrh/5GQUL1YYNatVxdgp85E9Wzb9qDP1Rjd1k9yT/ymVZHjJV3gpvBRek/mbUgyFV0aOwivjJY1O9cL7Rr0O+HDhtUsibzbshJXzxkr30dV4Cq87eCm87nCl8PqHq51eEr9a2E47CblKpPsMjsKxE6dQpND9GBgWgsy3Z8Kfu/eh79AoLJkxgsIrAM0VXnNYFF5zViqSwivjJY2m8EqJJYun8NoE6CWdwusOVwqvf7hKetn6zY8+w8s/XlrSnOOxXOFNipTCaz7FKLzmrCi8MlZWolO98Kr6s5aN3tb7NmP+CjRvUCPJfqrLdDdzo/C6Q5/C6w5XCq9/uEp66RQ23Gf42CE9JM05HkvhpfBanVQUXhk5rvDKeEmjU73whkWM87lPQ8I7SvfZ0XgKr6M4PY1ReN3hSuH1D9e01AuFl8JrdT5TeGXkKLwyXtLoVC+80h3ydzyF1x3iFF53uFJ4/cPVai9fbt+B7378Rac/VqY4nnqijNWmHMuj8FJ4rU4mCq+MHIVXxksaTeGVEksWT+G1CdBLOoXXHa4UXv9wtdKLegrNz7/swjPlHkVsXBzWf/YlKj71H7RoeK2k62ZtFF4Kr9W5R+GVkaPwynhJoym8UmIUXpvEzNIpvGac7EbxsWR2CTqXH9JjCMYP64ng4GDdqHpLWqO2vbFs9ijnOrHQEoWXwmth2ugUCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5egc/n9hk3CgJ5tPQ3GxcejeYd+mB0V4VwnFlqi8FJ4LUwbCq8FaBReC9AEKRReAayUQlnSYBOgl3QKrztck7dK4fUPZ5Neho+fDSW5z6qShtg4rP54EwrcezeeerKsTv9P6UdMmnE8hsJL4bU6qbjCKyNH4ZXxkkZTeKXEksVTeG0CpPC6A9CwVQqvISg/hLXtPthnL5NG9PbDKK7vgsJL4bU68Si8MnIUXhkvaTSFV0qMwmuTmFk6V3jNONmNovDaJZj28ym8FF6rs5zCKyNH4ZXxkkZTeKXEKLw2iZmlU3jNONmNovDaJehs/qHDx3Do8FHExcV7Guab1pxlbLc1vmnNnCCF15yViqTwynhJoym8UmIUXpvEzNIpvGac7EZReO0SdC5/8qx3sXbD53igwL2eJzWo1vmmNecYO9EShdecIoXXnBWFV8bKSjSF1wq1RDms4bUJ0Es6hdcdrslbpfD6h7NJLzUadsaiacOQKdNtJuF+i2FJQ1LUFF7zqUfhNWdF4ZWxshJN4bVCjcJrk9qN0ym8N2bkRASF1wmKzrTRsvMARA0PQ8YMGZxp0KFWKLwUXqtTicIrI8eSBhkvaTSFV0osWTxXeG0C5AqvOwANW6XwGoLyQ9gvv+/G7IUr8eRjpXBbxv9L7xsvV/ZD7967oPBSeK1OQAqvjByFV8ZLGk3hlRKj8NokZpbOFV4zTnajKLx2CTqXr148sWffQRQpXBDp/ve2NdV6WJfmznVioSUKL4XXwrTRKRReGTkKr4yXNJrCKyVG4bVJzCydwmvGyW4UhdcuQefy327cBUtmjkD6dOmca9SBlii8FF6r04jCKyNH4ZXxkkZTeKXEKLw2iZmlU3jNONmNovDaJehcfqew4RjUOwRZs2R2rlEHWqLwUnitTiMKr4wchVfGSxpN4ZUSo/DaJGaWTuE142Q3isJrl6Bz+QOGT8Eff/2NZ54si4yJanibN3jLuU4stEThpfBamDY6hcIrI0fhlfGSRlN4pcQovDaJmaVTeM042Y2i8Nol6Fz+jPnLU2yMwuscYyda4mPJzClSeM1ZqUgKr4yXNJrCKyVG4bVJzCydwmvGyW4UhdcuwbSfzxVervBaneUUXhk5Cq+MlzSawislRuG1ScwsncJrxsluFIXXLkHn8i9cvITZi97Htzt+Ba5exROPlkDjutWR+fZMznVioSUKL4XXwrTRKRReGTkKr4yXNJrCKyVG4bVJzCydwmvGyW4UhdcuQefyB46YojwX1V6upBtdueYzpE+fHuHdWjrXiYWWKLwUXgvThsJrARqF1wI0QQqFVwArpVC+eMImQC/pFF53uCZvlcLrH84mvdRtGYqFU4chKChIh8fHx6Ney1AsnjHCJN21GAovhdfq5OIKr4wchVfGSxpN4ZUSSxZP4bUJkMLrDkDDVim8hqD8EFanRShmjh/gKWFQJQ7NO/bD4unD/dC79y4ovBReqxOQwisjR+GV8ZJGU3ilxCi8NomZpXOF14yT3SgKr12CzuXPWvg+Nn7xNapUKg9cBT7e+JX+d6M6bzjXiYWWKLwUXgvTRqdQeGXkKLwyXtJoCq+UGIXXJjGzdAqvGSe7URReuwSdzd+y9Xt8+8PPuqzhsTIl8Gz5R53twEJrFF4Kr4VpQ+G1AI3CawGaIIXCK4CVUihLGmwC9JJO4XWHa/JWKbz+4eyrl9jYWFyK+RfZsmZJEnY++gJuz3SbvnHtZm4UXgqv1fnHFV4ZOQqvjJc0+pYX3u92/ILhE2bjypU4VH2uPFo3rnUdw917D6BJSDhy3JFd/+3xMsUR3r2V/jeFVzrlzOIpvGac7EZReO0StJ8/ceZiZMuaFQ1rv56ksVkLViIuPg4tGr5tvxMbLVB4KbxWpw+FV0aOwivjJY2+pYX36tWrqNmkKyL7dUaB++9By04D0Kl1fZQqXiQJRyW8YycvwITIXtfxpfBKp5xZPIXXjJPdKAqvXYL282s17Yp5k4ci020ZkzQWfeGi/qG9bPYo+53YaIHCS+G1On0ovDJyFF4ZL2n0LS28f/y1F8PGzsTsqAjNben763H02Am0b1mPwiudSQ7HU3gdBuqlOQqvfzj76uXNhp2wct7YFEPeqNcBHy4cf1MHSeGl8FqdgBReGTkKr4yXNPqWFt4vtv2AVR9tRGT/Lprb5i+/xSebtyEiLOQ64W3RcQBy3JENuXPlQNumtVGmZDEdky5d0vq6MRNnou+g0dLj4Fp8yUeK4qtPV/hs//CRYyhStrJrY7DSsBqzGruv7bWaTbH5i+1Wmnclp1PbpogI7+qz7XmLV6Bdl3BX+rfSqBLeXTs2+Uy9fPkKchUoY6V513JWLZ2JSs+W87SvrtbEx8e51p+bDddo2BmzJqjzy7WSqYTtxKkz+qrTinlj3Oz+hm1TeJMieuC5SGS+q/gNuaUUcHDbKJzdt9FSbiAmUXhlR43CK+Mljb6lhffzrd9j9fpNHuHd+MU3+GzL9uuE91JMDGJiLuPOHNnxzQ870T9ysr7MqF75qW44SbyNnzIXA4fd3BWZxOMp8fBD2LRuic95ceTocZR48iXp3HE1ftO6xSjxcNLSkuQdvlm3NT7/6htXxyFpvH2rhujXq6PPlAXvfoBOoQMlzboamzdPbvzy9XqffSjhvafI/+XS1QEZNr5i4WRUePoJT3RwcDDU/wXiNmXOUvy1Zz/6dG3pkd5Tp89i4IipKF6sEGt4U9lBpfCaHxAKrzkrFUnhlfGSRt/SwqtKGoaOnYk5NyhpSA61cUg4wjo3R5HCBXjTmnTGGcazpMEQlM0wljTYBOhA+pUrsVCvFd7y1XfIf08e/XrhQ4ePovIzT+jXCvMpDQ5AdrAJCq85TAqvOSsKr4yVlehbWnjVqztrNumGyH6dUFDdtNZ5IDq2qofSJYriwKEjuHgpBkUfLIjDR48j55134LaMGfHrH7vRtc9ILJszClmzZKbwWpl1BjkUXgNIDoRQeB2A6FAT+w8ewZ+790K9WfihQgVx/735HGrZXjMsaUjKj8JrPp8ovOasKLwyVlaib2nhVcBUicLw8bOhLtu++NxTaNvsHc1xyYqPsO/APwjt2BTrP/sSU2YvQ1x8PLJlyaxjnn7yWk0jn9JgZdrdOIfCe2NGTkRQeJ2gmLbboPBSeK3OcAqvjBxLGmS8pNG3vPBKgSWPp/DaJZhyPoXXHa7JW6Xw+ofzzezl6PGTCB8ShRMnz6DwA/diYK92uD1TpiRDUj/8J0xbjLPnzusXYHRu2wD/Kf2IjqHwUnitzl8Kr4wchVfGSxpN4ZUSSxZP4bUJ0Es6hdcdrhRe/3BNTb0MGD5F3/z29htVMW7qAtyRPRsa16mWZIg7f9ul//t9+fPhx51/IGzQeKxZMpHCm8KBZEmD+eym8JqzUpEUXhkvaTSFV0qMwmuTmFk6hdeMk90orvDaJZj686vUaIn3F4xDlsy3Y/ffBxAxaprnRt2URh8bF4cqb7bA+uVTkTFDBq7wJoNE4TWf8xRec1YUXhkrK9EUXivUEuVwhdcmQK7wugPQsFUKryGoAA1TN95Wq9cBG1ZM03twPvoC6jQPxeolUV73aO0nn+Pjz7Zi7JAeOoYlDUlRUXjNPwwUXnNWFF4ZKyvRFF4r1Ci8NqndOJ0rvDdm5EQEhdcJiqm3jQsXL6F6/Y4e4T17Lhr1Wvb0KrzqUY3hQyZg/NBeyJc3t94x9axx9USblLaYk7/hyNYBqReACyPLV74/MuW69uIh6Xb8h4m4cOhzaVrAxmfMdg/uqWjtRUzxsTHY/1HjgN13KwPPWbwhsj/witfUjBmTvn7cSh+3cg6F1+bR5wqvTYBe0im87nBN3iqF1z+cb2YviUsa1AsuBo2enmJJw8F/jqBr+EhEhLXXzxhP2NQKr7ft4vGd2Lux183cPb/3XbDyMMtvWju0ffQt96a1wi9NtnSMlPD+vqKmpdxATcpbpjlyFUlaX594X2JjrwTqrqWKcVN4bR4GCq9NgBRedwAatkrhNQQVwGHqzZDFixVGzWpVMXbKfGTPlg1N61VH9IWL+OX3v/Dkf0pBvca4fegQdAtp7Hk6Q2LhDVIPB05hU8L792c9A5iOfOgsaTBnxpIGc1YqkjetyXhJoym8UmLJ4im8NgFSeN0BaNgqhdcQVACHHTl2An0GR+HYiVMoUuh+DAwL0a9F/3P3PvQdGoUlM0Zg+rz3MH/pas+rjdXuzpowELlz5mANb7JjT+E1/zBQeM1ZUXhlrKxEU3itUEuUQ+G1CZDC6w5Aw1YpvIagbuEw3rSW9OBTeM0/DBRec1YUXhkrK9EUXivUKLw2qd04nTW8N2bkRASF1wmKabsNCi+F1+oMp/DKyLGkQcZLGk3hlRJLFs8VXpsAucLrDkDDVim8hqBu4TAKL4XX6vSn8MrIUXhlvKTRFF4pMQqvTWJm6VzhNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rTdrRk8AAB0ESURBVM5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeGVEqPw2iRmlk7hNeNkN4rCa5dg2s+n8FJ4rc5yCq+MHIVXxksaTeE1JLZ4+Tos++BjpEsXjDZNa+O5Z5/QmRkyZEzSwuioGQiPGGXYqvthJR8pCiWPvrbDR47hwdIV3R+MoAcKrwCWjVAKrw14aSzV2zmOwkvhtTrVKbwychReGS9pNIXXgNjBf46gc+8RmDNxEKIvXETLTgPw7swRyJTpNgqvAT8rIRReK9TkORReObO0mOHrHEfhpfBanfMUXhk5Cq+MlzSawmtATK18nDh1Gu1b1NXRvSLG4tUqFfFMubIUXgN+VkIovFaoyXMovHJmaTHD1zmOwkvhtTrnKbwychReGS9pNIXXgNiEaQtxV+5ceKfGSzp6zOT5KHj/PXjz1eexZMm7SVpYv3ErVq7ZaNCqf0LuvTsP+nRt7rOzM2fPo2fEBP8MyLCX3l2a4b578vqMHjNlIf74a59hi+6HVa1UDjVee85nR19s34EFy9a6PxjDHu7InhWRfTv4jI6NjUNIz0jDFv0T1qlVXRR7qKCns1y5cqFKlRf803ka7MXXOW79+o9x+vTpFPc6a9AxFMmQes53/jg0f155DtFX77LUVYF025ArXeo5Z1naCUFSzNVs+PXKK4KM/4cGIxZlMi63lBuoSQfjyuJYXBGvw3/nndqBumupYtwUXoPDMH7aQuRJJLyjJ83FAwXu1cK7YMFCgxYYQgIk4CYBJbwvv3ztByk3OQFf57g1a9Z6FV55T8wgARKwSqB+/XpWU5kHgMJrMA305b6Tp9C+5bXJ1nPgWLxW9VpJAzcSIAESCHQCPMcF+hHk+EmABG5EgMJ7I0IADhxSN60Nx9xJg3E++gJadR7ouWnNIJ0hJEACJJCqCfAcl6oPDwdHAiTgAAEKryHERe+txdL31yM4OBjtmr2D5ys+aZiZNGzTF9/qm94WTx+u64ATbyn97evvf0Zo/zHInetOxMXFo/Kzj+ub52Lj4vBctWbYsnqOpXGYJKm+O/aKRHi3lnilSgWdsuPn39Gm2yB0b98YNV57Adu+/RFRM5bgypUruHr1KmpVfxFvv1EVKrdb31HIcUd2nZc9axbcnS+3rrmNjY3F+fMXcOedd+i/hTR/B1UrP2UyJJ8xismzrzRCnbdeRof/rcYvXLYGl2JiULbUw5g8aylmjOvvaUPFv1G3PeZNGozlqz7ByjWfIlvWLLh8+QoeKVYIrRrVSnKMfB07yeDj4+Mxe9EHWPPxFgQHByHTbbfhuQpPomm96rqZ02fOYeTEudj56y79v8s/UQadWtXTTwUx+fuuPfswYdpi7N57ANmzZUH+fHnQukktPFjofkydswy3Z8qEhu+8LhlyirFqnK/XCUHXkEa6vEdtCcdAzRc1b9QW8+9lvFKrLZ56ogwG9Q7BkNEzsO27nzxtXrkSizNnz2HjBzMxd8mHUKuNK+aNQc7/zY/K1Zrpv3Fzl4AT57hWXQbiyNETyJAhvf4s9ercHEUKF/A68Mhxs1DusVKo+PRjSWLUwkKLTv2xZMYIbP7yW2z79ieEdmwqBqA+/+nSpfPcf5FSA19+vQN357kLhQrmF7fvK0GdAxe9tw5jh/RwtN2UGtuz9xAOHzuOp58oo/+s7jMp8fCDqFKpvK2+Y2L+xZoNW/DW61V0O4mPi62GLSar81fCeTooCGje4C3Rd4cVLm/U64APF463OGLvaW616/hA01CDFF4/H8zeg8bj5KmzeKzsI/rDmnhL6W+JT5oXLl5C0/bh6N6+CcqULOYX4R0/dRHy5smJURHd9VBHRM3Bjzv/QI3Xnkf1V57DK7XbYvLIcDxQID/+vXwZB/85isIF79PC6+1k/+fufRgyZgbmREU4Sl/J1gvVW+DOHNkxO2qglu0E4W1a70282aATJo/qg3vy5dH9bv3mRyx8by2iInslEUElpO+v/Qwz5q/AoumRyJE9m473dewkO6JkVzHs37ONbls96m7ukg/Qrlkd3Uz70KFa0JvUrYa4+HiMmDAHuHpVy8ON/q6+kOq16oUubRqi0jPXJEL1dfT4Sf3F4KTwLl+1ARs2bkNwumBMGtFb96WOwUtvt0a+vLkxe0KEFp9PN2/H7MXvo+B9+bXwJt8GDJ+CXDnvQEjzOnp86z75AlUql/PwoPBKZtfNjVXC275FHZR4+CH9Gfro0y8xZVS410GZCO/Zc9E4Hx2Ne+/JJ945E+EdGTVXf96er3Dt2epObf4U3k+3fI0ffvoN3UIa6eEfOnwMWTJn8iw4WN0n9UO0bffBWDTt2k2r6nz01+59KPrQA1abtJWX+Py1Z99B/YjQVYsn6B/xN9rU2NWPMSkXt8TUrXZvxOFW/juF149H/+KlGNRu1h1RkWEIHTBar14kbN7+lvykOXDEFJQqXgSvvVjRL8K7/MMNOH32PEYM6IqsWTOjcbs+KFuyKArenx8vv/CMXrlbtTgKWbNkTkLyZgnvyzXboE6Nl3E59gpaN67lEV7142Lc1AW4M8cdaFj72upmxIipKF2iCN54uXKKIti93yg8+Z+SesXa17GTTCG1Cl6lRkssmDoU+fLkvi71911/I3xIlC6ZUVcT1Kb6rlavg/5vx06c8vl3JYt7D/yD3l1apDgsJ4W3dZcItG9ZF/0jJ2HiiN7IkzunFl51DN54uRLKlCiGZ8s/irCIcSjyYEH8tefAdcKrxqte6DJtTF+kT59eHwf1/1d9tEmXEKmnSFB4JTPs5sYmFl4lXa27DNTnh1ffaYc1Sybqwe38bRfmv7sKkf27QAmv2vYdPIxTp8+gVeNaqPzM40lWEhOv8Cr5HT5+FvYdOAwEAR1b1cPjZUsk2Wl1heDDdZ8hd66cyJUzB4o99IBe4VU/vBa+twbqqSPq6kH/0NZ68aFT7+H6/KV+KPfq1EzPueHj5+DQ4aO4CqBt01p44tGSYrCJz4FqP9UPw+joi7pErmHtNzw/SJWUr16/CXnuyq3HkDDe3X8f0Cu16gdx1qxZENa5mf6xvvaTz7Fo2VqkT58Od2TPhnFDQ1G/VS+cPR+N+/Ln06uxP/3yh2eF9+dfd2H0pHlQV1LUebtX52bIkvl2zd7bmBJ2Vt2gveqjzXi4aGGULl4Edd9+xbPyvmHTVmz8/GtcirmMvQcOoVa1F/WLmT5ct0mPbcSALrgrd06cO6+OmX2eakzJz19qEWPskFB91TAlVnofg4Nx+sxZPFS4oL6SlLDy7Y2LWhzoN2yS5lWmRBFs2Lw9xRVe9SNj4bLViIuL0zexh3VpjnPnLyCkx2B91ULJ9ZXYWAwJ74jbMmbUiw4m7YonGhOMCVB4jVHZD/zo0y/w3Y+/aRlp0WkAurVr6Pml7O1viU+a6hJy84790bd7KxR/+EG/CW/pEsX0r2L1zNYvt3+PoKBgFLjvbl3SoE6IGzZtxxOPlkD5x0uhSuWnkC44WK/wdu87GjlzXitbqFKxHNo2e0f/280VXiVb6nJ4g9ZhWio/WLtRlzQo4f31j90YNnYW5k0ejMtXrqBavY54d+ZwZM+WNUXhVSu86gu2a7uG8HXsJDNDnQSbtO+LdUsnpZimvsy+3PYDBvdJ+qiwJiHh6NCyLg4fO+Hz72s2fI6HizzguQSZvBOnhPfIsRN6JXrZ7FGYPPtd3JE9O+q+9bJHeCdE9tKlCT06NEGHnsP0j4wNm7YlEd79B4+gXY/BmDyyD+793yPo1PjUl7ha0UNQEFo0eIvCK5lgNzk2sfAqkVOlCGou+BLeYydO6h/UJ0+dQcvOA/XnVl1lSamkYfDo6bg7T240rf+mjlFXvVTpRMK2d/8/6DlwDGZNiFDTB01DwlHtlee18KrPspJZta1evxkHDx/VP4qTr/AOHTsTTz9ZFhXKP6oFqU3XCCycFun5AWqKOLnwxqurNJ2a6ZIltWq6eHok/t53CH0GT8DM8QP0fG/esZ++IbpW9apo2XkABvVur38Yf7fjF112peTp7cZd9EuQlKSr/VfymnyFN+HSvSqVqt20G4b27YiHChXA2Cnz9Wpoq8Y1tfCmNKbE+5d8hTdxSYMS3mlz38Ps/12pq9mkGxrUfl2fB+a9uwqXL1/W512neCYXXvXDSb0Q6oOF49Gh59AUWal9vBTzL/qHttG7ZcKl79CJKFuqmC7TWrV+E9RVzg0rpiU57P8cOYZBo6brcpWMGTJg+vzl+mpd5Wef0FcS1feK+nGivh9LPlJEl5aYtGs6txhnjQCF1xo3S1ldw0egVvWX9KqhqgdWv/gSXmbh7W+JxTFD+nR4+YUK+lK3v2p41Qpv57YNdd1l3jy58NqLFfDZlq89wqtAqBWLb77fidUfb8Hd+e7C4N7tb1pJgxJedXJSEnZbhoy47baMHuFVY63ZpCtGDOyGffsPYfXHm/UXbfITacLBVSexc+cuaOH1dewkk0ELb0g41i2brNM+2bwNM+YvR3T0JUQND8Ovf/yFL7fvuE54G4eE6zpedaL19Xd1DNTzadWqtNrUKqx6aYoqgenTtaVjJQ0Llq5B9MULWhj+2rMfSkTUF1/CCq86Bg3b9EaN15/H6TPnUahA/iTCq1ZPlNDUq/lqkjrDBOFVVw8ate2t5ef1uu1ZwyuZZDcxVgnvoX+OIUPG9Lj37rzo2q6RroP3Jbwliz+EV154Vo+654AxqPP2KyhU4N4UhVfJxNxJg/SP1JS2D9dtxL4D/3ieqDNlzlLkyJ5dC69aMVXnhfPRF3Wdfp7cd+pV5uTC+2bDTloyg5QxAzh56jQmjeyDXHfmEJFNLryPlSnuufejev2OeH/BOKjxHvjniKd8Z/q895Ata1ZUeOpRNGrbBw/9r/5ZXRkKDgrSV1LUVT71mXquwuOoUP4xLfHehFf9+O09aIK+WqI2Vd8/auI8XWaiZDClMUmE94efftc/atWmPq+D+7TXpSfbv/sJH3+2FeHdW8Epngnn6fc+3KCvNirhb9Wopq699sZK7aOS14R7RBKE1xcXdTVt8YzhyHx7Jr3Kq+bux8unJjn26v6LGQtW4O68157H/O+/l/FYmUdQs/qLeiFA/ZhRmyr7unAhRt8zYdKuaIIxWEyAwitGZi3hzLnzqFa3w7UbcYKA+Lh4fUJdOX+svhTl7W/f/LAzxVpYfwqv+lJQN6qdPXceC6cOw9gpC5IIbwIRdentxbdbY8uaOXpF4mbU8CYIr1qZaBLSF69WVTfbXfXUS0+buwzBwemgVoLUl0rCiTCllc9ufUei/OOl8XzFcl6PT8KXoums8JQ0TBmq61wTNiW06iYv9UWsShqWzhrpWVFSqzjqC1KVNKgfSb7+nlJJwxfbfsDaDVv06pBTK7zqy+3UmXP60qXaTpw4rVfB7rn7Ll3SoIRXycbK1Z/pGwX37D2YRHjVF48q1UheepEgvEpQomYsRvasWXX9L29aM51hNzcu8Qpv4pGoesX354/Vc1rVmi5Zsc5T0qBKtNQPHLXdSHjV50BdofElvKqUok3Taw/oVz8ms2bJooVXXVVT5QmqXletDs6Yv1Kv0F0nvA06Yfq4/sidUya4ycknF97EN+cl1G9+sPYzvdKcUL+fILyqFEj9yE5c9pbQvjqH7PztL2z9ZgfWffol5k8egu3f7UxSw2sidsnrp1OqKb3RCq8aR+c2DfTQ1Dkssl8n5L0rl17wWPPx5xjQs61e8XSCZ4LwJr/pVh1vb6yS76MJFyWmS2eP1GUIqu731dpt8dGyKUkOr7pC8Mvvu6+7kfLEqTP6iU7qmKhtxepPcOZstL4h2aTdm/vpTfu9U3j9dIzVnaXqCQU9E91prCSyVaO38ff+Q17/pi69pySO/hZe9SV14WKMfvawOmmokgZ1J/72b3/SdZrqi0w9sSFy/GysnDf2pq/wqsOqanY3fv6NXpVOuEFQ3c2s6qejL1zCinmjPTc7JBZBxVatvCTctKbq1LwdO7VyKt1mLViJn37dhX49WuuaPXWM1QqFuqFL3fAX0mMIypQsCnWjnbpsq+rfruKqRw59/V1dcqzbIhRd2jVCpacf0z+qVDnGlq++c0x49x44jND+o/DuzJGeXVer4emCgtGwzhse4VWr0erGQFVTqOowE0oa1Ap11IxF+qa2hCdPJDSUWHhPnj6jS3jUpW43n0YiPX6M907Am/Cq/96rU3O92qukTl0VSKjhlZQ0qCtN+fLk0iUNSkYuXLiYRH7VD9mIkVMxbWw/ta6AVl0i8HyFJ7Xw1mneHRNH9NGLDhNnLsau3Qe08E6e9S7uzZ8Xr79YSe+YugR/e6aM6Niqvv78/PbnHjxcpJD4sJsIrzofhQ9JuaShXstQtG5SWz/BQp2T/t53UJclHPzniOcGPnUVZWBYCI4cPYb1n23V5xS1+bp0r1YuWza6VtKQkoQn3lF1I/I7zXrohRm1JS9pMBFep3h6E151jvTGypvwplTqkcBFlR68UKm8Lmn56usduu42eUlDQn365FHhuhxLcVELQpkyZfIqvCbtiicZE0QEKLwiXNaDVc1Wg1qv6RXDhE2VNagTtLrJyNvf1J323oRXPYJL3RSQsKmbBurXetX6IJNlqhO2KmlQX0yJtwThVaun6oal33ftRfp06XQtXcfW9VC6eNFUIbwnTp5GjUaddf1o4idi1G/d67onBijRSrhUFnslVtdIq8v16gva17FLuJwnga6+qGctXIm1H3+uV/uzZcmiv5TVDSHqqQZK9EZPnIeffvlTN6se59WpTX2PnN/o73/8tRcTpi/G7j37kSNHNv1YshYN39L14mo/1U1imTPf7hmy+jJTddemm1o1UyvRCTXZKk8JTPjQKMyfMtQjvInbSyy8qk5RzfvEY1Cxk0aE6VUhVcOb8BpvVQO37IMN2Lp+genwGHcTCXgT3m93/IJJM99F/rvz6CdyHD5y3CO8mTJlxK9/7NH1skrwTG5a27P3gL5S07ltA31ZPvGmaseVqCixVY9yVDcpJdy09u77HyH/3XmRM0c27N57SAuvulFUlQmkT5dey2OuO7Pry/5/7Nqja1wfLlLYUwMqQWsivKq9+UtXX7tpLXcufeNnmVJFtXwrGR45cY6+4Uqt6qp7JtRjHzuFDcfxE6f0UMo9XkqXxamrJapWXn0u69V8RfNMfHPWqIlz9VN0ChW8D2Gdm3tuWruR8Ko+ho6ZgZ9/26Xv02hWv0aSm9ZMhFfJoBM81Vi8XaHyxsqb8KqaWnXTWkpc1FU0tc/qKoJ6QtFHn36FVYsmXHfoN3/1nf7xpm5aU4++UyvdBe67x6vwmrYrmWOMlRGg8Mp4MZoESIAESIAEHCOgnnWrrnSoKz0dQoeha0hDvZLLjQRIwFkCFF5nebI1EiABEiABEjAmoFYT/9i9Tz/VQN1T0LhONeNcBpIACZgToPCas2IkCZAACZAACZAACZBAABKg8AbgQeOQSYAESIAESIAESIAEzAlQeM1ZMZIESIAESIAESIAESCAACVB4A/CgccgkQAIkQAIkQAIkQALmBCi85qwYSQIkQAIkQAIkQAIkEIAEKLwBeNA4ZBIgARIgARIgARIgAXMCFF5zVowkARIgARIgARIgARIIQAIU3gA8aBwyCZAACZAACZAACZCAOQEKrzkrRpIACZAACZAACZAACQQgAQpvAB40DpkESIAESIAESIAESMCcAIXXnBUjSYAESIAESIAESIAEApAAhTcADxqHTAIkQAIkQAIkQAIkYE6AwmvOipEkQAIkQAIkQAIkQAIBSIDCG4AHjUMmARIgARIgARIgARIwJ0DhNWfFSBIgARIgARIgARIggQAkQOENwIPGIZMACZAACZAACZAACZgToPCas2IkCZAACZAACZAACZBAABKg8AbgQeOQSYAESIAESIAESIAEzAlQeM1ZMZIESIAESIAESIAESCAACVB4A/CgccgkQAIkQAIkQAIkQALmBCi85qwYSQIkQAIkQAIkQAIkEIAEKLwBeNA4ZBIgARIgARIgARIgAXMCFF5zVowkARIgARIgARIgARIIQAIU3gA8aBwyCZAACZAACZAACZCAOQEKrzkrRpIACZAACZAACZAACQQgAQpvAB40DpkESIAESIAESIAESMCcAIXXnBUjSYAESIAESIAESIAEApAAhTcADxqHTAIkQAIkQAIkQAIkYE6AwmvOipEkQAIkQAIkQAIkQAIBSIDCG4AHjUMmARIgARIgARIgARIwJ0DhNWfFSBIgARIgARIgARIggQAkQOENwIPGIZMACZAACZAACZAACZgToPCas2IkCZAACZAACZAACZBAABKg8AbgQeOQSYAESIAESIAESIAEzAlQeM1ZMZIESIAESIAESIAESCAACVB4A/CgccgkQAIkQAIkQAIkQALmBCi85qwYSQIkQAIkQAIkQAIkEIAEKLwBeNA4ZBIgARIgARIgARIgAXMCFF5zVowkARIgARIgARIgARIIQAIU3gA8aBwyCZAACZAACZAACZCAOQEKrzkrRpIACZAACZAACZAACQQgAQpvAB40DpkESIAESIAESIAESMCcAIXXnBUjSYAESIAESIAESIAEApAAhTcADxqHTAIkQAIkQAIkQAIkYE6AwmvOipEkQAIkQAIkQAIkQAIBSIDCG4AHjUMmARIgARIgARIgARIwJ0DhNWfFSBIgARIgARIgARIggQAkQOENwIPGIZMACZAACZAACZAACZgToPCas2IkCZAACZAACZAACZBAABKg8AbgQeOQSYAESIAESIAESIAEzAlQeM1ZMZIESIAESIAESIAESCAACVB4A/CgccgkQAIkQAIkQAIkQALmBCi85qwYSQIkQAIkQAIkQAIkEIAEKLwBeNA4ZBIgARIgARIgARIgAXMCFF5zVowkARIgARIgARIgARIIQAIU3gA8aBwyCZAACZAACZAACZCAOQEKrzkrRpIACZAACZAACZAACQQgAQpvAB40DpkESIAESIAESIAESMCcAIXXnBUjSYAESIAESIAESIAEApAAhTcADxqHTAIkQAIkQAIkQAIkYE6AwmvOipEkQAIkQAIkQAIkQAIBSIDCG4AHjUMmARIgARIgARIgARIwJ0DhNWfFSBIgARIgARIgARIggQAkQOENwIPGIZMACZAACZAACZAACZgToPCas2IkCZAACZAACZAACZBAABKg8AbgQeOQSYAESIAESIAESIAEzAlQeM1ZMZIESIAESIAESIAESCAACfwX8/dbsK6LzDgAAAAASUVORK5CYII="
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAGkCAYAAADT1/YoAAAQAElEQVR4AeydBYAUNxuG3z2Bw91KKVaghVIoUNxdirtT3N3d3d2LluI/7u4UpxQoWtyt6MHBP1+OWXbv9vb2fOWFy0wm+uVJJvNNksm6eXu/+0RDBmwDbANsA2wDbANsA2wDbAPO2gbcwH8kQAIkQAIACIEESIAESMBZCVDhddaaZblIgARIgARIgARIIDgEnDAOFV4nrFQWiQRIgARIgARIgARI4AsBKrxfWNBGAiRgOwGGJAESIAESIAGHIUCF12GqioKSAAmQAAmQAAnYHwFK5AgEqPA6Qi1RRhIgARIgARIgARIggWAToMIbbHSMSAK2E2BIEiABEiABEiCBiCNAhTfi2DNnEiABEiABEnA1AiwvCUQIASq8EYKdmZIACZAACZAACZAACYQXASq84UWa+dhOgCFJgARIgARIgARIIBQJUOENRZhMigRIgARIgARCkwDTIgESCB0CVHhDhyNTIQESIAESIAESIAESsFMCVHjttGJsF4shSYAESIAESIAESIAErBGgwmuNDv1IgARIgAQchwAlJQESIIEACFDhDQAMnUmABEiABEiABEiABJyDgKspvM5RaywFCZAACZAACZAACZCAzQSo8NqMigFJgARIwJkIsCwkQAIk4DoEqPC6Tl2zpCRAAiRAAiRAAiTgkgSsKrwuSYSFJgESIAESIAESIAEScCoCVHidqjpZGBIggTAiwGRJgARIgAQcmAAVXgeuPIpOAiRAAiRAAiRAAuFLwDFzo8LrmPVGqUmABEiABEiABEiABGwkQIXXRlAMRgIkYDsBhiQBEiABEiABeyJAhdeeaoOykAAJkAAJkAAJOBMBlsVOCFDhtZOKoBgkQAIkQAIkQAIkQAJhQ4AKb9hwZaokYDsBhiQBEiABEiABEghTAlR4wxQvEycBEiABEiABErCVAMORQFgRoMIbVmSZLgmQAAmQAAmQAAmQgF0QoMJrF9VAIWwnwJAkQAIkQAIkQAIkEDQCVHiDxouhSYAESIAESMA+CFAKEiABmwlQ4bUZFQOSAAmQAAmQAAmQAAk4IgEqvI5Ya7bLzJAkQAIkQAIkQAIk4PIEqPC6fBMgABIgARJwBQIsIwmQgCsToMLryrXPspMACZAACZAACZCACxCgwmtSybSSAAmQAAmQAAmQAAk4HwEqvM5XpywRCZAACYSUAOOTAAmQgFMRoMLrVNXJwpAACZAACZAACZAACfglEHyF129KvCYBEiABEiABEiABEiABOyRAhdcOKyWiREr9YwGs2bA9orJ3mnynz/kd+UtUN5ZnzKQ5KFXpV+O1q1iEQ4GSNZymuO/fv0ebzv2R/ufiiP11Jpw8fQ5lqzXGiHEzoBfy20wFze4h3lM6Gfs+t2jfB+27D4oQIW1pV4EJdvbvi6pNPn7yLMCgV679q8LcvnMvwDD0CJxA/Wad0aP/yMADMoTdEaDCG0ZV8u+N26pzkQejX2OvSmXO7D8hXtzYYUTEsZOt3bg9eg0cbVMhkiROiMw/prcpbFACBUWGoKQb1LCTZyxAoTK1ghotXMJ/830ebNi8y2pecm8OHD4RRcrWQdK0uVD4l9oYP/U3iOJhLeJ6Ld0NW3Zh44q5eHbrNH7KlAE/pE+LZF8nCTCavd5T0pZTZSwA6Zt+zFUaovBduvKvxXLkLloZq9ZuxrPnL1Dj1zZIkDIb4iTLjFxFKqP/0PF4/uI/i/HC2jEi7wd52RF2wiSk5QxOuwppnowffgRCs62En9QhysluI1PhDeOqGT6gG9Ytm21mcufIEsa5Bi/5xbPHI2+ubMGLzFhGAuXLFMXEUf2M17TYF4F9h/7E3xcvoXK5kpg1aRiyZs6IIaOmQEbirUkqI2OpUn6DFMm/NgYb1r8ralUtZ7z2a7HXeyqKV2RMHTdI9Us9O7fAi5f/aaPVjfDiv5dmRbh46RquXr+JooXy4u27d8jwXRqsWDgFq3+fjma/1sT2XQfQrF1Pszi8CBqB4LSroOXA0CRAAkKACq9QCEOT4fs0yJf7ZzOTIH5cXPv3JmSE4Nz5S2a5L1iyCmkyFzKONl345yrqNOmA77IUVe4yEmM6qiAP6VLadLmMumUvWF6NvPy+fK0K73fEqmnbnmjQvItZfqYXptOvL1+9RvtugyCjOyKnjIRNnD7fGHztxu2oVKsFkqfPq8pRsHRN3Ll7X/nL6JGMvqiLz4d5i1YgR6EKn68AHx8fTJq+AHmLVVWjbDJiKGkaA2iW+CmyYv7vK1U+KTLkM5s61ryNfx8/foRMn8tInchZrHw9zPxtidH/+MmzqFCzmZI1S95f0HvQGLx589borzOUOD8XKAcZ+WrcujvuPXiowsg0towaTpm5UJVVeIgicOjoCXW9efteSPkTf5sd+w7+qWQxXdKgEtEOEj9rvrKQsjRs2Q33Hz7SXH3/pPxSh75XvkepL32aNSAZJGRgbUS4BlRXEt+vmTVvCarUaankzJa/HIaMmowPHz6oYNK2hJ8+aiEspG6Vpw2HrTv3oWTFBqouJO3hY6ertqBHtZa3hPnr/D+QKUV9WUGG7CWwe99h8YKwFYVN2p7IJWGUh59DneoV8Mdvk9CySR2ULlEQowZ3R/NGNbFs1Xo/Ib9cSn1JuY+dOKPqXNLXjemShi8xfG2m95TeXnbuPahGyJN9lxuyJELap29o3+P23QdUe/o6XS4ULVcXMiMkeYliJCGsMRB/W0zvrm1Qsmh+1S/VqFwWg3p3xL37D/GXNjVuGn/Ttt0omDcHYsaIjsQJE6BPt7YooF0XzJcTDepUQbNGtbBl+z58+vQJAf2T+3jhH6vVfSz9hbStE6f+wqPHT9Ghx2Ck+6kI5J49eOS4WRLW2nVA94P0W4NHTkLxCvUgfOW+lNFp04QlTPvug5D2p8LImLMUeg4YZeqt7HJPy/0nbUjkE7vIK54yQyD3q9jlXpa6EX+5thZP/P0aW9uVjw39pd+09Xamt6O//jZ/1gS1HQVWNr19SzjhrveHwZE9sD5d+k5h/n22Yuq5+GuLrrh1+64Rgd6nT5u9GNLPSD0PGzNV9TWr121FmSqNVLxufYfD2/u9MZ60zfbac69Wo3bKX+LJLIbe/xkDmliePnuOzr2GQZ4t0uakrxW2EsRaWwkOF0mTJvgEqPAGn12IYqZMngw5smXG6nWbzdJZtXYLKpYtDk9PTzx4+BjlqzdBph/SY93yOdi6ZgFixYqOavVbQzoEPeKps3/juPYAWTZ/Cv79e78auXr/4T2k49HDyLTjmg3bUNPKaJQeVs4Tps7F9Ru3MHvyCNz+5xCW/DYBSZMkFC/89/IVGrXqjhpVfsHpQxtx6sAGNKhVGQaDQfnbchg5fgbWbtqOAb074O9jW9GtfXNIx2Iqs6QjysSvdavgwvHtaNG4tjj5MyPGTceEab+hbfMGOH98G0YO7IY3b9+pcKIklKveVD2sj+9bh8ljBmCJ9kLQuddQ5a8fhKEo7MsXTMX//pihRrWGj5muvCeN7o8yJQuhVdO6kKlsMenSpFR+chgzaTZGD+6BWxcOqmlucfNrZP3cyTPn8L8lM7B+xRylXDRt09NvsACvA5IhsDYSnLp68d9rdGrbGGcOb8JITRk8cPgE5GEhwslo5uA+nVQ5hYOYBpriI36BmT37j6Bt5wGaolQZUhfTtBHGo8dOY8CwCcao1vKWQN36jMDXSRNjy+p5uPbXXogsUaJ4iZdKUxQzGVUVuf7+c6tyt+Xg4e6B6NGiBRh07tQR6N+zPX7OmsnYBiQPeZkNMFIAHgt+X40xQ3ri6O7/IVnSr9C8fS+jwnjpyr+oXr8NShUrqPj36doaE6fPM0vJGgMJKC+W3fuNEKtNRh68q9dtQ/JvkiK9NoJrGmmL9jJXsmgBUyejXdrWtp371UuDwWD93p88Y77GLqM289EfHzTlrWGrbmjTpR8SJYivtbEe8PTwQMuOfY39WmDtOqD7wdvbG5Eje2HcsD6qb2rVpK6m0I7Gdu0lQhe814DRWKe9sM+bPgo71i3C/QePsXPPQd1bnZ89f44KZYpj/9ZlWLpgEiJHioR6TTupehJOuzb8rsJdP7dPtYeZE337E2vxVAQ/B1vb1Ugb+0s9eRlQqV6/LbJk+kG1o24dmqHvkLG6tzoH1o5UIJODrWXz2x8GVXbJ0lqfLi9X1eu1wYWLV7Bq8XRsW7NQDbZUqt3cOFAkaUifK+2zS7umaFC7CibPWIjm7Xtj6cp1aFy/umZqYN7ilVjq50V38bI1yJ41M/7cswbjR/TR/Ddg9MTZkqRFU7dJJ+2Z+FLNFp06uBG/lCqkvdw1hzx7rLUVnUtgz0CLmdIxWATcghWLkWwmICM4MgJgauRGkAQqlSuBFWu+KLziLkpB5fKlxBtzFy7Hjz+kQ5d2TZAmdXKIkjxMm0I9p72pywibCvT5IDemTLXKAz9y5EioWrE0/tBu7M/eWL56AxJqD5dihfLoTlbPd+89RMoUybQH4LeIFjUq8ufJDl2ux9rIjIwey/KH2LFiQvIVpUfWrlpN9LPnu3feas3kIE3ZLVIgN2LFjIGSxfKjvtYpzf99xedQvqdaVcuibKki8NKmYKVsvq5fjvLmLesve3ZuiQq/FFMjUT9lyoB2LRqoQDJiHj1aVIwb3hvx48VB7hxZtVGqNpBO7eGjJyqMHOLEjgVRaKQsP2b4DrWrlcPR46fEK1DTvWNzZMvyIzy0h7bkZSmCjDyOGdoLyb7+Cj98nxZD+naC1PV5rdO2FN5Wt8DaSHDqqlObRsiVPYtiWTh/bsjDcvGytbaKFGC4cVPmook2DV5DG1GUuhDlUabTpQx6pMDyvnvvPjJnTK84xtHqTF4Oc2gvjnr84JxllkVkaB7AC1Vw0rQWp2fnVsiS+QfI/dKmeT2IkisjVhLn92X/Q/p030KYx40TW42mNqhdWbyMJjAGP/34g+orjBECsMye/wekX4qXPAvE/tvUkZD7WQ8uI75Hj5/W7s0CupM6y6ikxJPRrNvarM6UMQOVu7VDjSrl0KNTS8hyn5GDeuD6v7eQP3cOyL0jbkP7dVZu8tIp6Uh92Nr3SXjdCDPpLzNoM2til35QlJ0/VqxTQWR0V/qEHp1aqL4gYYJ4Sql59fq18tcP0kZl9F/SkPY2dlgvHDl2CjLqrIexdA5uPEtp6W5B6S/1OIu0EXWZSRw+oAukDMUK5UWtquV1b3UOrB2pQCYHW8smdar3h/IiI/2zLX29nlVgfbr0mzJAMXF0P3yfLjWkz544qj/+uXwdG7fu0ZPBhw8+aqCmeuVfIP2KDFrs3X8UC2eNVYNKco8VK5wXx0/+ZYwjlmw/ZUT7lr+qe0GeT/LSNG/xCvHyZ/YeOKo+Xp2iDaRk1eLJNzAN61bT7u8MWKkNXvmL8NkhOHX6OSpPISBAhTcE8GyJamkNb/x4cVXUimVLaNMw96BP5a1au1UptvoDXL2h7jqgHkrygBEjq/oRvQAAEABJREFUH4tI53xNe2CoRLRDujSplNKoWY1/dWtUwuZte6FPwy1ZsR41KpeBm5ttVV5RU8YX/L5KG21qjVETZmGT1pHIm7VkIB1MnpzZ1DSkTAfO0qbAZepG/GwxIrvc8CUrNoCUSTf9hozDteu3zJLInDGD2bXfi8tXb0DSkjdyv35yfeXaDeTL8zP0UUBxk85fzlev35CTMsmSmn94FD9ePDXCrjwDOWTRFOxAguDblMnN6ihjhnRqRPza9ZuBRLXuHVgbCU5dHf7zJGppU3rfZS2q6qd8jaYQ5ef16zfWhQnE9+Klqxg0YqJKU69zmbIXJeTuvQcqdmB5V6lQCjLl2KpjX21Ufx5kalxFDObhwOFjallBo3rVNIUg4LW4wUzeYrSvv0pkdE8QP56y6y9f12/c1l5yv1Nu+kHaim6Xc2AMpk8YjGYNa0lQq6Z08UJYu3QWBvbuiK+SJFJrcWXUVo+0edsebaQrExInSqA7qbMolCsXT0NnbRZA5O7U03d0U3kGcPheU+J1r5TJkyqrKCvKoh1kJEw7GfurwNq1hA3ILFmxVk1ZyweM0s6Gj52Gm7d8p7tv3LyjRmkL5M1ljB4jejR/3y7cvHVHtTOZDpc0EqTMpqbDb96+Y4xnyRLceJbS0t2C0l9+iXMbMvsgM4W6W+H8OXWrOgfWjlQgk4OtZTPtD4Mje2B9uvTb0iYzay++unjp0qSEGGk3ulvqVMkhgz/6dQptBiOtFs6UyTfaAMSjJ18GPiRsxgxp5WQ0mTJ+H2D/d+Xqv5DncfwUWc36NXn2ykudMRE/luBw8ZMEL4NBwDbtJxgJM4ovARlpkI7H1Og3oYwuFC2YGzKdKKFXrduMSuV8R3fl2mAwQEZVZerUr5HOSsKIieLlJSczI/mK4iwjmbKeSNYJ1qle0SyMtQt5s925YTFyaSOil69eVw9DUYL0OCsXTUWfbq3hFTkyRJnOUbgi9h86prwNBoM6mx4++HwwXhoMvv6HdqyE33Id3rnKGE4sXlEiyylQYzD4pmkpoLu7u5mzu4f5tXhaehHQFXzxt2Ys8bcWXveTEWE9D4PBv/wyQqGHDehsMATeRqzVld905YFRtW4rVK9UFltWz8fjf09g48q5Kpj3+/fqHNyDwWDAmKE9/dW5tAEZ7bQlbxkdnTttJL5JlhQHNWVVdlqYNH1BsESS0XWZjmzVtB76dm8brDSCEykkbU3yCy0GouTKzE3b5vWxYfkc7QXvidk65s3b96BE0fySpZkR5VX6B1kHPGvSUKxcswnC0iyQnwsPk3vOYPBt66b3pcHg62Z6P9jS9/nJRpuuXq/W+vft3kYtGZG2JXL6bbseHm5mUU37BJFBpscTxI+DxXMm4P6VP/HkxkmIovTe+0s/ZpaAdhHceFpUq38Ggy8bW/pL04Q8/PR70t+Y+gelHQWlbKb9ocEQPNlFToPBN67YjeazReris9V4Mm1P4ui3/AaDAX7DGAwG9QIEG/75bUMSxWAwaDOn8Sz2aTIrIGEsGYPBt2xBrVNLadHNdgLmd73t8RgylAhIp/6/9Vsg06qyTKG6NgqrJ50uTWrICJTpB1a6ny3nOjUqYOGSVfh92RoUyp9LrdGzJZ4eJtMP36O9NrUzY8IQzJsxSo3yylpg8ffyiqyNGJdVisLO9YvVl+7ygBS/+NoI9pMnz8VqNBf+uWa0p06ZTI247th90OgWXMu3qb5Rb/FHj5+ymETqlN/gzF8XzPxOnvpbXadK8Y0623KIHCmyzR2jpfQuX/vXbPums+cuqvVmsmxEwieMHxdPnz0Tq9Gcv3jZaBeLJRlsaSPW6krSNTUnTp2D1J9MM8uomzwgRFbTMF5ekfDpY8AfKZmGNbWn10b5du49ZOpkZrclb4lQokg+yHTk0vmT1Sjjau3+EXcx8rD9+OmjWK2aS1f+hSg1fbq2VtOdVgOHo6eMQvltr375izjWGIh/UI0oNBJHP8sSnN37j6i1xOIemNHjBRbOVn9b2rWl++HwsVPIo72ky8t+4s8j02fPfbn/v0n2lZpZOfPXRaMosob55GnfPkEcZbZB2ketauUho4YyQHHuwiV1v4q/mMjai76cTb+lsCWexAmqCU5/KaPoZ/z0e6fPnveXta3tKLhlC47sgfXp0m/LB2oik14gmcm8os3mpdZm0nS34J7PnvvHLKpwk7Xmpst99ADp0qbSXhQfQ57dupvfs6W2EhwuftPlddAJUOENOrMgxRBFVr7cNzVys+qJyDoxUWg79hgMWTcp63R1v4Z1qyhrk7Y9cEbrtKVzFSVI9hDVFU8VIIBDxV+K48nT5/ht0QrUrFI2gFCWnafMXIgtO/apaTx5IMjap8TaA0TW0YoMYybNgV4Ombq5ok3tpPy8XVP2rD9Cpqb1TuDvC5exYctOY0Yy0tC5bVOMnTwH8tX/k6fPIAxW/G8TFi39nzGcLRZJS5TyIaOm4H/rt0Ee1JLvhGnzVPS6NSpCpjGFmXSK8pHUoJETUVt7mCXQlEwVyIZDqhRfq1EsqQMbgvsLYjAY0LHHEMi0oIy49+g/CjK6lv67b1XYbFkyKfmfPvN9UVi6cj2u3zBf3mFJhsDaSGB1pTI3OWT4Pi3u3LsP2chenGV3iokmu3OIW0rtReGGNuVruluIuAdm5EM4SU8+gJM2IyxlPd6IcTNUVFvylp0STpzyXXMn0+9/njiLlMmTqfhykGlMuefEHpA5deZvlK3aCHlyZsW3qVOonTX0+zOgOOHlXqtaBUj7kN0r5L6QNYJyL5rmHxgD2W1k6859plHM7DIlLOuppcw79hxU92GpSr9qI5geRgV3+679SJUiGUTh0yNLfyD3q8TbuGU35J6Sr+NlLfZ32oNfDxca58DateSRysI9mTF9WvUBr7B7//69KpspC1ljX69mJQwdPUXdz2/fvkOfwWO1l03f+07STZQwPpJ+lRg7dh+QS0j/1b7bILPRQdl7OXLkSPjr7y/KkS3xVIJBPEgfF9T+snb1Crhw6aoa7f7w4QNkd5Fpcxab5RxYOzINHNyyBUd2iWOtT5d+M1PG79Gu6wBcvHQN0pd01J6fybWXmVLFzNebm5bBVrusD5bnh/Rvcn9MmbUQv9atajG6PLNltqNVp77YufcgpD3J7j6TZyxQz0CJZKmtSBmDWqeSFk3ICFDhDRm/QGPL19Ly4Zqp+d/6bcZ48kHYLyWLqA8iKpYtbnQXS5zYsdS0ctQoUVC3SUekyJBPKU3yJisfA0gYa0bWrVYsWwKRPD3Vh1/Wwvr18/n4Ea21m1g+aBEjCuusScPU6IjIs2f/YfyQoyRkfVvW/OUgU5/ycYikIx+G9evRDk01RV38B4+ahBaN64iX0XRs3VAbHW6jPszLmKMU8pWoppTdaFGjGMPYaunavhnkw4LRE2aqrWRkXej9z1uKfZ00CdYvn41jJ8+qbWOat++FIgVzY/SQnrYmr8LJA+RfTQGN+81PqszS0SoPGw+y3uwH7WGcs3BllKncEIm1l4dZk4cZYzdrWBP58mRH9oIVkCj1z/jn8lX8UrKw0V8slmQIrI0EVleSrqkRBVw+QmrZvg9yFKqIMZNnY2Cv9qZBUChfTrXOVNqj1K+t25Llyp4F65bNxtHjZyBbyH2ftRjGTJoNb+93Kn1b8r7/4BFKV2mo6kA+mhKl2VS+Ns3qY8rMBcpftpRSCfs5yMilPJTkBcv0vhS7n6Dhfikfpy5fOAWbt+3R2nJhdOg+CG2a11dyxIoVU50DYzBr3hL1QaQKbOEgbWL/wT9RrnoTVKvXGvLVevrv0mD1khlK0ZMom7fv1ZRfc+UhahQvTJu1CMKpYauuEI7VK5XBotljbf42QNK2xcSxoe+zdD9IH1SmREEU+aUOshesqBTSDq0amWU5pF9n5NLaYsWazZCzSCX1Ul+udFFjGJnVWDx7nNoOTn5co8avbSF9jGnfJOt+O7RqqBjKPSBbZNkSz5hJEC1B7S9TaS+lyxdMxubte5Bd61Oat++tZkVMsw2sHZmGDUnZgiq75NvVSp8uS4L++G0iokePjgo1m6JY+brqubRi4TREiuQp0UNkGmrKrcwKSP8mLzo1Pn/0FlCi82eOQfHC+dCz/2ik/rEgav7aDnsPHNHkiwb5Z6mtiHtwuEg8muAToMIbfHZWY8p0sKwfs2RaN6tnFlc+MpFwTX+taeYuF5KObHlz+uBG3Dh/AJtW/Yb5M0Yj6mfFsFObRspNwloyoqRVq/SLWkJgyd/U7cqZPeoranGTdX2XTu2CyCXmzz1rIeuQxU9kko9dxF2MrPOcMLKv2QhI+5a/QuKI/+9zJkDSO7Lry+itwWCAPJy2r12otj07tnctZMsuUdAlDzGPrh9H0YJ5xGrVSGcsTPdvWw5ZbyfyDO3XxRhHdm0QeYXfif3rMah3JzMelhjKlL7w0BORUUSJK+URIyNfubSHpti9vMzXGTdvVAt7tyzVo6opc6m3Dq0aqrLK1nGyJZJMk+mBpFMcP7wPhLmUQfY7lRcMcdPDWJJB/KQ+Amoj4idlFznFCBu/dSVpmJoqFUph39ZlOLJrNWS5iiy7kbj6lJ48cKSuxE2M7NBhGl+3C4c9m//QL9VZ2tDq36fj6tk9uHhyB0Q2Kavy1A6B5S1M7l0+amyXEl9G47So6q9U8QK4eeGg8g9oWzJpmyK3JaMSCeAg8batMV8vLAq8LK/Qo1w+vdt4D4mbtCFpS2K31F5ktwqRQ3YGkTBipM3v3rQEUleyfZu83Mp6WxmdFH9rDOQDwMtXb6CapohKWEtGXrbko7OnN0+pPOS+nDpuIDKmT6eCe3u/x/ZdB+B3OzKpO2kXIq/UgbQNebE1bccqAT8Hv/exjG5JGpKeHlTalrjJvaq7SdsNqF1LGEv3g7RNaU8nD6yHmLlTR2jKalPs+ryNmMQTjrKrzYUT2yFbKo4Y2B2ybMv0XpNfSpS6lTWWZw5thEz9S/8hX/pLGmK6d2yh2pnILXKKmy3xJJypsaVdGQzW+0upO5FDdgnQ05a9kqXc0m9J/1qpXEklr36/WGtHehqm58DKZql9S3yDwbrsEsavCaxPlzYsdXv+2DbVZ8ozUZar6OlY6tNllxDpt/Qwch7StzNkG0Ox68ZLG7mfPXm4YnX28Cb00wZvTNcMS17D+nfVg0Pak+zwI9+f3P7nkGpryxZMUbvx6IEstRWDIehc9PR4Dh4BKrzB4+YQsWT973ZtWs7vtka68DyTAAnYH4HJ2nSofGQqyqssAek3dDwa1q1mk6Dy4WiJovkg6+9timAh0JNnz9C8UW211Z4FbzqRAAmQgEMSoMLrkNUWuNCZcpdGu64DIRu0y44NgcdgCBIgAXsg8PjJU5Ss9Kv6NbqBIyaifq3KaN/Sd1/pwOQrWTS/+hW5wMJZ85dfVOvavqmaJrYWzsn8WBwSIAEnJ0CF10krWJZAyDSWfLTlpEVksUjAKTivqsAAABAASURBVAnIFOrDa8c+LzdYrX6cQZYBOGVhWSgSsCMCK9R2m23tSCKKEpoEqPDaSpPhSIAESIAESIAESIAEHJIAFV6HrDYKTQIkQAIRR4A5kwAJkICjEaDC62g1RnlJgARIgARIgARIgASCRCCMFN4gycDAJEACJEACJEACJEACJBBmBKjwhhlaJkwCJEACAAiBBEiABEggwglQ4Y3wKqAAJEACJEACJEACJOD8BCKyhFR4I5I+8yYBEiABEiABEiABEghzAlR4wxwxMyABErCdAEOSAAmQAAmQQOgToMIb+kyZIgmQAAmQAAmQAAmEjABjhyoBKryhipOJkQAJkAAJkAAJkAAJ2BsBKrz2ViOUhwRsJ8CQJEACJEACJEACNhCgwmsDJAYhARIgARIgARKwZwKUjQSsE6DCa50PfUmABEiABEiABEiABBycABVeB69Aim87AYYkARIgARIgARJwTQJUeF2z3llqEiABEiAB1yXAkpOAyxGgwutyVc4CkwAJkAAJkAAJkIBrEaDC61r1bXtpGZIESIAESIAESIAEnIQAFV4nqUgWgwRIgARIIGwIMFUSIAHHJ0CF1/HrkCUgARIgARIgARIgARKwQoAKrxU4tnsxJAmQAAmQAAmQAAmQgL0SoMJrrzVDuUiABEjAEQlQZhIgARKwQwJUeO2wUigSCZAACZAACZAACZBA6BGICIU39KRnSiRAAiRAAiRAAiRAAiQQCAEqvIEAojcJkAAJhB0BpkwCJEACJBAeBKjwhgdl5kECJEACJEACJEACJBAwgTD2ocIbxoCZPAmQAAmQAAmQAAmQQMQSoMIbsfyZOwmQgO0EGJIESIAESIAEgkWACm+wsDESCZAACZAACZAACUQUAeYbVAJUeINKzI7C373/EP2GT0WdZj2Qr3R95CpRB7fu3A9QwjUbd6JZx4EoUaU5egwaj4uXrgUY1tTj8tUbKu0Va7eaOuPFfy9Ru2l3FKvUFH9fvGLmZ3rxwccHoybNQ43GXVQ6nfuOxr0Hj5R9+57DxqCtuw1Dx94jjdcnz5xXYc5dCDhtY+BwtLx6/UbJ5ZdHaIowe+EqFCrfKDSTZFokEOEElq7eou4d6avuP3zsT559h04Y/f88+Zc//8AcpI/bsvNAYMGC7J+nVD0sWLouyPHCSp4gCxKBEU6dvaDq1NozwpJ4Hz9+xMz5y3Hm3D+WvOlGAkEmQIU3yMjsJ8L9B49x5u9/kDBBHGTMkNaqYBNnLsbwCXPx808/oHv7RvDx+YjG7QcgOA8Vyejx02do1mEAHj15hulj+yB9utTibNFs3XUQq9ZvR4nCeTF+aDc0b1ANkTw9kemHdIgdK4bFOOIYPXpUSJioUbzk0qVMkkTx8WN663UaGBD6k4C9EvDyiozN2/0rpps1ZVX8giv3+q37sG33oeBGD/V49iZPqBcwDBP8+OkTfvt9Df46fzkMc2HSrkSACq8D13bmjN9h9YLxGDu4K/Lm+CnAkjx78R+WaSMr1SoUR+O6lVAo788Y2rstEiWIi0XLNgQYLyCPB4+eoEm7AXj56g1mjOuH1CmSBRRUud+5+xBRvLzwa63yyJE1I75N9Q3ixomF6WP6IFvmDCqMpUOaVMlVmJTJk1rydmq3MsXzY8Kwbk5dRhbO9QgYDL5lLpA7Gzbt2Od78fkoMyf7tRFe8RMng+FzYLmgIYGQEWBsEgAVXhdoBDv3HIGPNj1Uumg+Y2k9PDxQJH8OHD1xFs+evzC6B2a5decemmojwxJu5vh+SJEsiVgDNBXrtsecRavw5u1bNa0lU5mmxnRJg99ELC1pqN+yF3oNnoiFy9aj6q+dULBsQzRo1VsbBbjkNzpmLViBCnXaoVTVFhg0eiYeaoq636nJJ0+fY+TE31C5fkdjWpO00XB5+PpL0ILD8jVb8WvrPpDlB227D1d56MFqNulqtkRDd9en+PYcPK47+TtbWtKwa/+faN5pkMqrXO226DloAkzTCKwsqzfsUHXgt2wybVi0YhMzGaS+ho6djYr12qPAL79CyiIj9aaBJG+pSznLcpSSVZurcKZhaCcBSwRKFsmNf2/excXL143eO/cdgZu7G/LlsvzyfujP08Z7rVS1lug+cDyev3hpjC9Lu/46fwkHjpxS7VzaZp+hk5X/+X+uYuzU+ajTvIdqz3K/j5o8T3tpf638TQ+W+g1Tf7Hbkl5oySP5+TUyM9e4XT+1nEz6N2Eh5TYNt3bTLtRs3EX1a9IPj9Bm+N6//2AMIv2AMFqxdiukb2jUtp/qK+W+l+VqsmRO+s2yNVurfkDCGCNrlvHTF6J09ZaQfqlui57I/0sD1Y/KshXNO9A/a/Up+csyPUlk0qzfjfVpKoO1+BJPL9/vKzZi4KjpKFurDQqXb4xOfUapmUkJY2oCS0/CSllD0gdLGjQRR4AKb8SxD7ecb9/1Xdeb9tsUZnmmTe17ffO2r7+Zp8mFweA70nLrzn00aT9QG62NhFkT+iFJogQmoSxbB3RviRKF80CmKScO7w7dDOzRynIEG1xPnr2AcxcuY3jf9lg6d5Qaqe7QaxRev3lrjD130Wo1HZYvV1a1hCN+3Fho1XUIZF2YMZBm6aEpjZJerSqlMKJ/e7RsVB0enh54/+HLg0ELZvFv8fKN2H/4JOpUK4Om9argxq27aNllCD74+Kjw1SqUwOFjZ/Ho8VN1rR9Wrd+hRrjz5fxJdwr0fOT4GaXgpvs2Bfp2aY4+nZuioDZS/+zZc2PckJTFmIhmkZcjGcEXBaRMsfzor9Vhxu/TqvXiO7SXJy2I2d/oSb9pL0/ZsWzuaCWbmScvSMACgZTJv0ba1Mmxafs+o++WHQdROF8OeHh4KrdP2pS2smiHHXsPay+PoxAzRnR0b9cQjepUwMVL19Gi8yDjPd2jQ2Ok+CYpfvg+jbGf+bV2BS028PDxMzx+8hzlSxWC9D0F82TF3gPHtDY9Bab//PYb8eLEVPe0337DlvRCQx5T2XT7zn1HIS/XsWPFQNtmtdC5TX3EiRXT7KV/1brtGDZ+DjKmT4d+3VrglxIFIIML3QeO05Mxnpes3Iw9B46jZuVSqFK+OOS+HzNlATr0GolYMaOhQ8t6anmVDAz4XYf7QnvhGDN5Pto3q40Nf0xBlXLFIIrw2s27jelbsgRWn1GjRsH4oV1V1IplihjrU5/JDCy+ivj5sGj5eiRNkgjzpgzClFE9Ic+xgSOnf/b1PdmSXnj2wb5S8RjaBKjwhjZRO0xPOucY0aPBYDCYSRc7VnR1/eDhE3UO6KA/eOTN/fmL/zBmcBfEixM7oOBm7j9mSIuvEseHu5ubWj8sa4jFZEyfxixcUC7k4SOKdOqUyTRlNx7kwfLy1WvsPXhMJSP231duRJ2qZdCpVT0UyJMNLRpWR60qZWD674Om1MoHETUqlkDlssWQI+uPyJ4lI1r8Wh2xY8YwDWrRLkxl2UGR/DnVw2Lq6F64e+8h1m/Zo8LLsoQoXpGxXBtBUQ7aQWTbfeBPVCxTGG4aE83Jpr8Tp88jYfy46NCirlqSIgyLF8qN8qULq/ghLYtK5PNh5dptuHL9plbPnY1LYHp2bAyZIZi5YPnnUF9OhfNn18pTRCkj36dN9cWDNhKwQqBEkbzYsvMQpH+RbwKOn/4bpYrm8RdDRiXHTV0EWf4k95u8QFcpV1wpLze0UWJR5CRShu9SI3q0qEpJk/tDTCpNsRa//LmyYEjvtqiqKXTSH7RpWhvD+rbDwaOntRfVexJEjfb67TdaNqqh7m0VwORgS3ohlcckO6NVWIyfvghy748e2BllSxTUXjZzopv2EtCsQVUV7u07b8zUZrekT5P7VpawNapTEf27tVTllZkzFfDzIXq0KBDlsmiBnNqLREXtpaAgZDanRqVSaKtxKpwvuxa3hepr/X4QKC/HXdo0QNbMGSD9oSjNpbWZRHlxEL/PWZidpAyB1aeHu7tKUyJ+/VUi47MjgdYH2hJf4unmuzQpVLnkmSX9U9N6VSEj5DLjJ2FsTS88+2CRiyb0CVDhDX2mdpmiwWCu7IqQBj8K138vX8HUSBhTI52aPJx6D5msliiY+oWnPd23KRE5UiRjlrG10Q0Z+ZE3d3EUZU2ms/L4WdecJ3tm8TYaDw8PpEyeFPOWrFVfYN+64/vgMwYIxJI7RyazEF8lTojkyb6CdIziEcnTE2WK59MU4L3GUaj/bdiFDx98UOGzoirhbDFptTLL2mnZlWP3/mNqiYppvJCWxTQtGclInSIZMmVIZ+qMwvlzKOVAf1DonnlzZtGtPJOAVQL6oK30IyUL51Y7vUh727BlH+LHi4OsmdL7i3/52g2IQlzxlyJmfnK/pdVmPI6d/NvM3dKFKIGihOnLj2Qqv8nnpVkyMyNx9H4j18/m97XffkTC2pKehAvIBDe+sJD7TxTegNK+ovGSpR75NCXfNEzu7JnUwMORE2dNnZE/dzaz66+SJFTXObP+qM5yMBgMSJI4AW7feSCXZiaPn5mq3Fq/KztwWAorEaUMIanPoMaXUW7JVzfJPy/Du6nNWIqbremlDcc+WOSiCX0CVHhDn6ndpRg/XmylyPoV7Nnz/5RTgvhx1PmXGq1RvHIzozl26pxyNxh8leVCebOhT5dmOP/PVXToOQrvvL2Vf3gfZETCb57u7m6aEv5OOT969EydY/kZpY0X1/+o9LTRfSAPuDkLV6Fawy5o33MkNmzdq+IHdogVI4a/IHHixDJbH1a5bHHI2tpd+/5UYdds2ol82gMivvZwVw42Hopoo6jD+3XA1X9vqS3lKtRuiylzlqh1kHoSISmLnoac7z94Ann4i1JgamQ7OfG/fdf8oWeJq4SjIQFrBOTDVZlR2bT9ADZu36vNIOT1Nwsl8e/efyQnyNp90/YodllLe+f+Q+Vv7TBu2kJtpmWbNjuSHTIiOX5oNwzu1VpFefGfbz/46PFzdR0njnk/Yal925KeSiyAQ3Dj6yzia316AEnj3v3HyitO7JjqrB8MBgPian3g3Xu+PHV3Wbag2+Xsqb2oyzlqVC85GY28wIuibnTQLDKiLqOxmtX4J8vH5OLhI185xG5q9DIEtz6DGj9G9Cim2Wsza+7q+s0b3+eFremFZx+sBOQh1AlQ4Q11pPaXoEzlyIjKP1f+NRPu4mXffXh1hXfiiO6YNrq30XyXJqVZeLmQ6SpZQ3f63EV06jMG+npV8bMXEz++7wNLll+YyvT4ia8ibOoWK2Z0dG37K/as/w3L5o7SptHSY/CYmZA1XabhLNkfPXnqz/nBw0dIYKLMymhCNm26b82mXThy/KxaP6YvQ/AXORCHArmzYuG0oUrW3p2b4U9tZEs+VtGjBVaWyJF9R8VlSYgeR87vtClQOesmSeL4aicNfb2133OqFF/rQX3Pnwy+Zx5JIIgEShXNg517j6gXt5JF8lqMnfTziKNMr/tti3LdpnENi/FMHSWPimUKoV4XcpjUAAAQAElEQVSNsppinQ+yW0zihAlMg2gjzLHU9evXr9VZP8gyJN2un83S06bwLaWnh7V0Dm78JIniq+RkO0hlsXDQ+7+Hj8z7pw8fPkD6QL2/txA1yE7CRp4tphEfPfF9cUgQP56ps9Ee0voMaXyjIJ8tQUkvpH3w5yx5iiACbhGUL7MNRwK5P0/lm45cSucnHyDJlH7ihL6dqExhy1ZnupG3dxFT79D0syhsHVvWw3FtBLjHwPH+ptclTkQamY6Xj+QOHj1lJsYBP9dmntrF118lVut+ZXnApas3NBfrf3sPmu+yIKOv8gHgTz9+ZxaxUtmimnL6F2TnBVmPJiPKZgGCeCEjLfKAzZ8rK67fuG1cLmGajKWy6B37rc9TeXr4C5eu61Z1lvZy89Y99WGdrIP0a2T5iArIAwmEkICsp5V1/rIuV/oiS8ml1l6wpI+6cOka/LZFuU5n8mIeTRuVfP/ex18y8mLu5WU+Yrlz72GzcKlTJFMf1/pdIvHnib/MwsmFLelJuJDII/H9mm9TfqMp5nGwbVfAew2nSJZU7XMuH7eZxt994JjqK75Pm9LUOcT2vYdOmKUh/W6iBPGQ9KuEZu76RWob61NGjsW8836vR1VnW+OrwDYcgpNecPtgG8RhkDAkQIU3DOF+TjrMTqKAyuJ7MboSI7sXyPWlq/8a85UHiSipy/63RSldsrWKfNF/595DtG1ay+I0ojFyABb5+KNNk1pql4K+QyerD08CCBruzqKo1636CxYv3wD5Wlh4iHK/aNl6JYt0omIRZvVa9MKcRatx9MRZpZTKl8g+Pj7IkSWjBLFqXr58jdGT56t4El/W14pC+0uJAmbxZFRApm9lyyT5kM1gCPqIqOTTd9gUSDlUefYehWw7JFPCbm5uauQ4sLLID1nIiLOkJVtCSfnHTVsAvxu7y/piGd1v0m4AZIu2PdqDUh5iE2YsgmxdZFY4XpBACAjIWvwpo3qhf7cWAaYiL6CyDEE+TmveaRBWrtum7lf5FbP2PUdAznpk6etkJwFRwuQ+kZdQ8cv+Uwas27wbDx89UR+n/bFqM1Zt2CleRqP3G7JNnwwOyHcAks6YKfONYXSLLelJ2JDII/H9Gk9PD7RvXhvy8Zhs1yVllNko2XJsxjzfD0plpkc+0t28Yz+kz5cwUo7x0xZpM1gZ1EduftMN7rWXNmskuzJI+pKPbAG2cdteNKxTUa0XtpRuUOpTPkzee/CYqm9JX+ovKPEt5e/Xzdb0pN8MaR/sN29ehy8BKrzhyztUc5OvYGV7GjGrN+xQafcfMU1tWTN1zjJ1rR+6tmmASr8UxfotezBAC3Pr9j21PU/ObOYfaOjhbTnXqlIajepUgowkDB0325Yo4Ramodbh1q9ZDvKhivCZMucPyJfZIkDCBHHlhJgxoiFRwriQ/Rd7DZ6EvsOm4v7DR+oHH3768XsE9q9W1TJ49PgJ2vUYgW4DxkN2dpiqPbx1hVqPLwppwTw/Q86yLZLuHpTzd2lS4OHjp5gxfxm69B2rlWsVSmrTwUN6t1HJ2FIWg8GAkf07IVIkT9Rt0QO1mnaDj88nVK9YQqWhHwwGAyaN6IFKZYtg3+ET6K290PQYOAHycU/lckX1YDyTQDAIBC+KzDrMHNcX+ATMXrBK3XOLtBdaWV6TNXMGY6INa1dUu7KMmTxP9YO/Lf6f8uvS5lfIx661mnZHsUpNlcI4ekBH5Wd60PuNWQtWQvamHj9toeon5d41DWdzeiGUxzRP3S67wowd3EV9HNut/3jIjgfX/r2tPsDVw9SoVFLt3LB6/XbVX4ybukBxGafF08OExjlKFC+0b14XoybOVbxXrtuursuVLGg1eVvrs1/XFpCPknsOmqjS33/kpErX1vgqsA0HW9ILjT7YBlEYJAwJUOENQ7hhnbQoVoe2LIIlM25IF7PspcPu0qYB/rdoAnavm4sls0dBtqExCxTAhfwymuRRpVxxfyHkl9vEr1fHJv78dIem9ati++pZ+qU6yxSlxDOVYbKmZI0d3FX5y0GUTgkj2/vItZj5U4eo7YXEbmo2Lp0KGXE2dWtSr4oqr6SxasE4NZ0n/qm1qUs5y9T8qAGdMHtCf2xbNROblk1Vv1r3808/iHeAJlrUKIp53Wq/QD4kO7h5IXatmaOUxATx4/qLJy8mR46fQeF82RHHz4ck/gJ/dhCukubnS7WPpqyvXjZ3jKq/xTOHo3mDamobJglja1m++TqxWqO9d/08iOncuj5k6yW/9SMjSa0b14Tkt2/DPLVueMygLmr9o+QnRkauhW2qFK73S3hSfpqgE5CXK2kzcv8HFFtvV37vwwzffYvpY/tg0/Jp6v5b/tsYbYaqNmRWRU9Ltsbq3akp1iyeqMIM6un7YVr8eHHUR2pyn0v+v00epEY7xV66WH49ujr77TdkFuXApgWoV72s8peDremFhjySn18jy6KkDDvXzMb6PyYrLsUL5TYLJkqn9PPS369eOF59rCf3tR5I78f89usST7hIn6KHlbNsCTd5ZE+xmhmpr3VLJiveK+eP9fcCLUvkJL306VKbxbOlPmWEXJ5l0j9JGhXLFDGmEVj8gMon/ZWklSdHZmNaYgksPZm5C40+WPKiiRgCdqfwRgwG5upsBGR/Xdk3WKbBxMi+khOmL4KMaEsnGh7llS3eJO9xUxdCdjZoULN8eGTLPEiABEiABEiABPwQoMLrBwgvnYNAVG2qTda4ynKGjr1GYZY2RZkvV1YM6hn8X3gLKpnLV2+oaTjZUF9GnWQ9WlDTYHiXJsDCkwAJkAAJhBIBKryhBJLJ2BcBWYYh0/4ydbVv43zI9Kf86pp8mBJekupLMpbMGgH5WC288mU+JEACJBDWBGTtriwlC+t8mD4J+BII+ZEKb8gZMgUSIAESIAESIAESIAE7JkCF144rh6KRAAnYToAhSYAESIAESCAgAlR4AyJjo7unZySEhZEfhnB39wiTtMNCXklTRyZ2RzEeHp54//69Q3EWtrJXsJubu0PJbTAY1H7NIn9oG6lHvf3xHLoEhG1o11dI09NLGNJ0XCW+9HH2WI/2yN/NzU3t6GOPsunt3oYzg1ggQIXXAhQ6kQAJkAAJkAAJkAAJOA8BKrzOU5csCQnYToAhSYAESIAESMCFCFDhdaHKZlFJgARIgARIgATMCfDKNQhQ4XWNemYpSYAESMDuCOzcdwQNWvVE9qI1MGfRKjP53rx9i95DJqJ2066o06wbDv15yugvfv2GT7XoN3XOH2jUtg/a9RiGu/cfGuO06DQQt+7cM147omX2wpWoVK8dshWuhtN/XTQrwq0799GkfT/Ua9FDne/ce2D0lx++adqhvz+/12/eovvAcWjcti8GjZqODz4+Ks7TZy/QsE1vyLckysEBD1ev30LrroORt3RdtOoy2F8JpL3VaNQZYn5bvNrMf96Stcrdr9/2PYcVq+YdB+DwsTPGONPm/oFN2/cZr2mxTwJu9ikWpSIBeyJAWUiABMKCQKyYMdCuWV2UKJzHX/Iz56/AO29vLJ45Ev26tkT3AePw6vUbFW7OotXwfu/fTxS1PQf+xJyJg5A3ZxbIj89IhP9t3ImsmdLj668Sy6XDmuTJkmBk/05ImiShvzL0GjwBRfLnxIJpw7RzDvQdOtkYZuCoGSicL4c/v/2HTyBOrJiYPXGgxva1UYkeM2Ue2jatAw8PD2MajmZxd3dDtQoltXLU9if6/iMnsGrdNvw2ZTDmTh6MFWu34sjxMyrcgaMntXaz06LfjHnLMHpwF3Rr1wi/LfZ9Qbv27y2c/fsSShXNp+LzYL8EqPDab91QMhIgARJwagKihMoPtLi7u/sr5/bdh1BdU1jEI03q5EiTKjn2HToul9i59yiqlC2m7KZ+7pqSI6OU3u/fQ37aO3LkSHiqjVb+b8N2NKhdUYV35EOxgrkhP6rjtwwyki2/7FjxlyLKq+IvRfHXhct49OSZGuWW0U5LfpEieSpOnz59wstXr+Gl8Tp64iwiR4qEzBm/U2n5OziIQ/JkXyF/7myIGsXLn8Tbdh1E2VKFEMXLS/mXKV4A27T2JgG37z6M0sXzW/SL5OmBly9facxeI5LGSMKPmDgXPTs2ESuNnROgwmvnFUTxSIAESMDVCIgC9uDhY4jSopc92deJcffeQ7W1nfh983US3Qu6X8wY0VGvRjn0GzYFV67dRI1KpTFGG61s36IePCwo1cYEHNxy7/4jJEwQVymqUhRRWBMnjKfxegDxSxA/jkW/AppCGCtmdPQcNAGZfvgO8vIwedbvaNe8jiTjtOb+wyf4JumX0f5vtJHze5+Xv4jf10kSGctu6te7c3OMm7oAc7XR3S5tfsX/NuzAzz/9AEefOTAW1sktVHidvIIjoHjMkgRIgARCTMBgMMDg9uUR5Wb4YjcYAvYrX6owhvVtjyG92+HU2fNqBO/blN9A1lmOmjQXf578K8Sy2WMCBoPBTCyD4cu1wfDFLoEMBt9rg8GALm0aKl5N6lXBzHnLUadaWTx7/h/GTp2P8dMW4OZtx173LOW1ZNzM2pYvDz1cQH7fp02FMYO7YvzQ7ogWLQrWb9mD+jXLqyURw8bNUgqwngbP9kfgSw9if7JRIhIgARIgARckYDAYkCB+XDx+8sxY+kdPniJJ4gQwGHz9njx97s/P6KBZZP3v9N+WoW2zOljwx1pEjRoFLRrWQN9hkyHLHrQg4fAXPlkkThRfLd2QkXHJ8ePHj3j0+Bm+SpIQ4icKrCU/CasbWYt66eq/KF4oNwaOnKbWVRfKlwODR0/XgzjNOZE2Gm7WtjRWSRInVOUTvydPTdqdiZ8K8PkwZvI81baOnzqHvQePqXW923YfwvHTf38OwZO9EaDCa281QnlIgARIgARQpEBOrN6wXZGQNarnzl9WH6KJQ6F8P2PNpl1ihV8/5agdZLSyVpUyiB4tKj5++oiEmgItdlmn+unjJy2E8/wlSZQAX2kvAzv2HFaFkt0E0n2bAvHixIb4yfIGS34q8OfD8PGz0b19Y3UlvBIliKe9dMSBc5FSxYOshd64bS9krbeYzTv2o6jW3sRXzlt2HrToJ/5iDh87o9rVjxnSqiU2CbW2JaPC8eLGxiftZUPC0NgfASq8EVwnzJ4ESIAEXJXAynXb1BZb67fsVksOZLutE59HyJo1qKqm1ms16YoufUdjUK82SskQVo3rVgrQT/wvX7uh1vAW10Yr5bpy2WJq2zPZ4kzcPD0dc/eBnoPGK16yzZhsvSbbuUn5xIzo3wl/rNqEus27Y/maLRjYs7U4KzOwRyssXb3Zop8EkF0KcmXPrJRjuW5QswKadRyANt2Gon6N8uLkcObfm3cUq/4jpqodGKRtzZy/XJVDdvAonD+n2u6uQctemgKcCzmy/qj88uT4CQXy/GzRTwK8feeN6b8thcwcyHX2LBlxXcurcbu+ePDoCbJmziDONHZIgAqvHVYKnkKQ6AAAEABJREFURSIBEiABVyAgiuixncvw2ahzlkzpVdHlC/rhfTvg91kjsWjGCOT6ObNyl4P4DdEUYEt+4i9rdscP6y5WZWSUc8W8cZAtzlo0rKHcHPEwtE97xUjndXT7H8ZifP1VIrW92MLpwzFr/ABtxDeh0U+2MZs1YQAs+UmgKuWKQ5RcsYuR3Q1Wzh8PMaIAipujmeTJvjJjJcya1q9qLEajOpWwbO5Y1b5+rW2+g0eDmuUC9JMZgnlThhhfvmRkd/aEgRAzfUxfteTGmAktdkWACq9dVQeFIQESIIHwJ/D02Qt07jMahco3wsiJv4W/AMyRBEiABMKYgGMpvGEMg8mTAAmQgKsSkL1Hm9St7KrFZ7lJgAScnAAVXjur4Hm//w/1W/ZEscrNID+FqW+0bmdimokjG8TLWi8ZHarfshcWLl1r5m+PF89e/IfRk+ehSoMOKFurDTr1HqnWYdmjrKYy6e2jaKWmDtc+CpZriAatejtE+zBlbq/20JQrTuyYKJwvO6JEiRyayTItEiABErAbAlR47aYqfAWRX9GZM3Eg1i+ZhJJF86H3kImQLWZ8fe3zGDdOLAzp3RY7Vs9C59YNID8Jev6fq/YprIlUhbQHvKzrWzR9GOTr2vFTF5j42qdVbx8b/pjscO1j5/9mo1Or+g7TPuyzBVAqEiABEiABPwRsuqTCaxOm8AskX496eHioX8UpUTgPXr1+o37GMPwkCHpO8pGJ/MKRLN7PmD4NkidLAvmKOOgphV+M2DFjIOvnj2Pkl4by5MyitjcKPwmClxPbR/C4MVbwCbx79w5v376xaF7/9whPbx0Ld/Pi7kmIiYi8pcwB8QjM/cXDS+HOShi9vH8mQvJ9dvesxXYTGCfdX2QPb/Ps9gmtbZ2KEF4vn96yyiv4dzFjCgEqvELBTs3sBSuQMX1aiEJmpyL6E+vQn6dx49ZdZMuc3p+fvTr4fPyIhX+sRb5cWe1VRItyzVm40gHbx5mIaR8WCdLRFgKenp4IyPi8uo07B/qHu7l3aBDERETePq/uBMgjIE66+/PLa8KdlTB6eHQI7h4cEO55Pzo1Jdis3A0+4S6vsLp3aCAeHBkcIXm/uf+nVV623K8MEzABKrwBs4lQn7WbdmPPwWPqJx8jVJAgZH7x0jUMHTdb/fRi7FgxgxAzYoMOHTsLsWPFQLMG1SJWkCDkvnbTLodrHxf+uYZh4x2vfQShWpwyqMzcuLt7wN2icXfKMlsrlLu7O9wtsgiI0Rd3g8H8J2yt5eMsfsFlJfGchYGt5bB+r4Xe3tG2yuNs4dycrUDOUJ79h09Afiln7qRBSJwwvkMU6c69BxgydjbGDe6Cn3/6wSFkFiEnz/odMWNEw6iBnbU3a8foUKR9bNt9GLLW25Hax9BxszB2UGeHah/SRlzBfPDxQa4SddSWZKs37FB2eYF1hbKzjCRAAq5BgAqvndXzjr2HMW/J/zCif3vEiB7NzqSzLM6V6zfRtf9YyK/5yEdVlkPZl6ssY5g0czH+e/kK7ZrVcZjNwvX2MXJAhzBsH6FbV47YPkKXgP2n5qGNWh7asgimJl2alPYvOCUkARIgARsJUOG1EVR4BRs4chpOnb2A4pWbQ342Un4OUX4iMbzyD04+ojhe+OcqajbpqkaGRGb5ydDgpBVecS5dvo75f6zBqvXbkf+XX9VPUJas2iy8sg92Pnr7KFapGXIUq6nkdpT2UaNxV+QuWVfJbO/tI9gVxIgkQALORYClcRoCVHjtrCr3rJ+vfg5x34Z5kJ+NlJ9DlJ9ItDMxzcQZP7S7klkfHRKZK5ctZhbG3i6+S5tKyfznjqXYu/43Zd+8fIa9ielPHr197N84H0e2LVFyO0r7OLx1MQ5uXqhktvf24Q88HUiABEiABByaABVeh64+Cm8HBCgCCZAACZAACZCAnROgwmtDBZ08cx7dB45H0YpN0Lhdf+w5eNyGWAxCAiRAAiRAAq5EgGUlAfslQIXXhrqJGsVL/YLYlpUzUL9GOQwZM9OGWAxCAiRAAiRAAiRAAiRgDwSo8NpQC/K1cvy4seHu5oa8OX/C+/fv8ebtWxtiMohfArwmARIgARIgARIggfAmQIU3iMRXr9+Bb1MlRxQvLxXz48ePCBvzKYzSDSt5HTfdT5/IOmzacPi2CXVD8kACjkOAkpIACYQjASq8QYB95tw/WLxiI/p2+bJ91bt372Bqlixfg5IV64fYlK/RFKUr/xridFq072Umn6msuv3O3fshzkfK/EvVxhAj9pCai5euBCp3l95DQyx3qUoNUL5GsxCnI+WdOff3QGVev3lHqORVPpTaR81f2wYqs7QTKV9ITZkqjVC2WpNQKf/R46fM5JZZlyDcygxKAiRAAiTgYgSo8NpY4Q8fPcHk2UsweWQPJEua2BgrSpQoMDX3Hz7GgcPHQmwOHT2BA6GQzumz583kM5VVt7u7u4dYXinzwSPHIUbsITUffD4GKvf5i5dDRe7QYn3rzr1AZX767EWoyHzwyIlQYX3s5JlAZXZ39wglmUOvfbx9620md+TIkY33JC0kQAIkQAIk4JcAFV6/RCxcP3r8FL2GTELPDk2QJFECCyHoRAIkQAIkEJYEmDYJkAAJhIQAFV4b6C1fsxVn/75k/CWxXCXq4N6DRzbEZBASIAESIAESIAESIIGIJuBECm/YoWzRsDr0XxHTz4kTxg+7DJkyCZAACZAACZAACZBAqBGgwhtqKJkQCZAACdgJAYpBAiRAAiRgRoAKrxkOXpAACZAACZAACZAACTgLAb0cVHh1EjyTAAmQAAmQAAmQAAk4JQEqvE5ZrSwUCZCA7QQYkgRIgARIwNkJUOF19hpm+UiABEiABEiABEjAFgJOHIYKrxNXLotGAiRAAiRAAiRAAiQAUOFlKyABEggKAYYlARIgARIgAYcjQIXX4aqMApMACZAACZAACUQ8AUrgSASo8DpSbVFWEiABEiABEiABEiCBIBOgwhtkZIxAArYTYEgSIAESIAESIIGIJ0CFN+LrgBKQAAmQAAmQgLMTYPlIIEIJUOGNUPzMnARIgARIgARIgARIIKwJUOENa8JM33YCDEkCJEACJEACJEACYUCACm8YQGWSJEACJEACJBASAoxLAiQQugSo8IYuT6ZGAiRAAiRAAiRAAiRgZwSo8NpZhdguDkOSAAmQAAmQAAmQAAnYQoAKry2UGIYESIAESMB+CVAyEiABEgiEABXeQADRmwRIgATCksDHjx+xcdtetO42DJXqdUC+Mg1Qokpz1G7aHUPHzsbN2/fCMnumTQIkQAIuQcBVFF6XqEwWkgRIwPEINGzbD3+e/Bt1q/2CCcO6Yef/ZmPJrBHo27U50qVJjq79x2HHniOOVzBKTAIkQAJ2RIAKrx1VBkUhARJwPQLd2v6KfppymyNrRiRLmhienh6IGycW0n2bApXLFsOCqUPwddJEoQiGSZEACZCA6xGgwut6dc4SkwAJ2BGB79OmMkrzztsb5/+5arwWiyjAovyKnYYESIAESCB4BCwqvMFLirFIgARIgASCS+Dg0VOoULsd+g2fopK4cOka2vccoew8kAAJkAAJhIwAFd6Q8WNsEiAB5yYQbqWbPHsJZk3oj7hxYqs8v0uTEg8fPVV2HkiABEiABEJGgApvyPgxNgmQAAmECgFPDw98/ZX5Wt1P+BQqaTMREiABEgg5AcdOgQqvY9cfpScBEnASArJW98nT58bSnDhz3jjaa3QMhuXR46do3XUoGrbpi56DJuDN27f+Uvn06RNGT56vtkKr26InZi9cCXHzF5AOJEACJOCgBKjwOmjFUWwSsEcClCn4BDq3boCBo6bj8tUbaN5xEIaPn422TWsFP8HPMSfMWIyc2TJh7qSBiBkzBhYv3/jZ58vpwJFTKt/ZE/tjwtBu2LT9AC5evv4lAG0kQAIk4OAEqPA6eAVSfBIgAccn8MHHB+/ff8DYwV3Qv1tLVK1QDEtmj0La1MlDXDhRZssUz6fSKVMsH/YfOanspgefjx/VpZubG9zcDHB3NyBh/LjgPxIggWATYEQ7I0CF184qhOKQAAm4HgEPd3fMWrBSUzbdkDfnTyiSPyfc3ULePb96/QYGAxAndkwFNVnSRHj46Imymx5y/5wJHz99RMGyDVGqWktUKFMUshewhJFfgvPRFPKAjIRxJRMQB1vcXXGZiC1cAgrjSu1Kysp7TSiEnQl5jxp2sjFlEnBuAiwdCZgQiBzZExcvXTNxCR2rjNrqKRkMlrv86zdvI17cWFj/x2Qsmzsam7fvx5XrN1W09+/fa6PPlo0oKiqQCx2kzNaYWPMThcaFUKl14NZ4BObnSqykrIG1LQlDE3wClnu/4KfHmCRAAiRAAsEgcPvuAzRo3Qc1G3dB806DjCYYSRmjRIsaBT4+H+GtKa3i+PjpMySI73+pgii4GdKlQbw4sdWvvX2fNiXOXbgiURA5cmR4eXlZNJEiRVJhXOkgZQ6IR2Du7tpIviuxMhgMFtuNJU6W3FyJlZTV09PTKi8JQxN8AlR4g8+OMUmABEgg1Ah0aFEXE4d3R8dW9dGoTkWjCWkGubNnxvbdh1QyW3cdRN4cmZVdljv8df6SsseLGwenzp7Hhw8f4Ot+OVTWD6vEeSABEiABOyBAhdcOKoEi2EKAYUjAuQn8/NMPsGRCWur2zWtj3Za9aluyGzfvonbVMirJW7fvYdDoGcpevnQhPHvxEhXqtEeLToNRqWwRyA9fKE8eSIAESMAJCLg5QRlYBBIgARJweALvvL0xf8layM8Jh9aSBoESP14cTBvdW21LNrRPO0Tx8hJnpEuTEkvnjFZ2Wfowe0J/tYZ3wbQhqFy2mHLnwU4JUCwSIIEgE6DCG2RkjEACJEACoU9g4MjpePj4KR49foaKZQojetQo2ihritDPiCmSAAmQgAsSoMLrnJXOUpEACTgYgavXb6Jz6/qIFi0KShTOg9GDOuPWnfsOVgqKSwIkQAL2SYAKr33WC6UiARJwMQLRokVVJf7wwQev3/j+/O/79z7KjYeQEGBcEiABEgCo8LIVkAAJkIAdEIgeLRqevfgPebJnxq+te2umDxInjAf+IwESIAESCDkBKrwAQo6RKZAACZBAyAiMH9oVsWPGQMM6FdGzQxO0bFQdXds1DFmijE0CJEACJKAIUOFVGHggARIgAfshkOmHdGqLMne3cO+i7QcCJSEBEiCBUCTA3jQUYTIpEiABEggugf2HT6JJ+wHIV7o+cpWoYzTBTY/xSIAESIAEvhAIusL7JS5tJEACJEACoURg7NQFaNagCnaumYNDWxYZTSglz2RIgARIwKUJUOF16epn4UmABEJCIDTjxowRDdkyZ4Cnp0doJsu0SIAESIAENAJUeDUI/CMBEiCBiCaQ7acMmLdkjdqpIaJlYf4kQAIkEEQCdh/c5RXe0ZPno0yNVqjZpGuAlXX56g3jejpZW9eh13XCKJ0AABAASURBVKgAw9KDBEiABIJCQPoUMYuXb8CMectRqmoLs/4mKGkxLAmQAAmQgGUCLq/w/pghDQb1bG2Zjolr1kzpjWvqxg3pYuJDKwmQgE0EGMgiAdP1upbsFiPRkQRIgARIIEgEXF7hLV4oN+LFiR0kaAxMAiRAAmFJ4PrNu1i1fju8378Py2yYNgmQQAQRYLbhT8DlFV5bkZ+7eAV5S9VD43b9cebcP7ZGYzgSIAESsIlAg9Z98PLVa9y6cx8deo7AwSOnMGTMLJviMhAJkAAJkIB1AlR4rfNRvl8lSYi1iydi0/JpKJw/Bzr3HYPXb94qP29vb5gaHx8f5W4vh0+fPpnJZyqrqd1e5NXleK+NbJnKZ8kuZdPD28NZ6t6SnKZuHz58sFHU8AtmKl9A9vCTxrac/LYPubYtph2H0u7V6NGi4vCx0yhbsiBGD+qMf65ct2OBKRoJkAAJOA4Bh1B479x7gDmLVmPgqOlo2304ug8YB/nYbPOO/fgQDgpm1CheiBE9mjK1KpdC4oTxcfP2PcepZUpKAk5OwGAwOHwJP378hLfvvHH89N/I8F1qVR43g0N00UpWHkggzAgwYRIIBQJ235uOm7YA7XqMwPsP75EpQ1rUqFQSRQrkhIy67jt0AvVa9MT5f66GAgrzJO49eITrN+4oR5lmVBbtIDs2PH3+AsmSJtaugEiRIpkZd3d35W4vB4PBYCafX3n1a3uRV5fD09MzULkNBvtScqTudZ4BnT087G+P1YBkNXXX68Vezn7bhz1yDSqrAnmyoXbT7rh15wGyZvoe9x8+hpdX5KAmw/AkQAIkQAIWCLhZcLMrp0QJ4mPpnFFo3qAaypcujNzZM6NYwVyQkdYhvdtiaJ/2uPfgcbBllp/yrNG4C0S5la2Bfl+xUaW1c+9RLFm1Sdk3btuntgnKV6YBxkxdgKFavjLqqzx5sAcClIEEHJ5AozoVsXL+WCycNhSiwEeO5IlenZo4fLlYABIgARKwBwJ2r/DWqlIabm5uuHjpmj9e5y5cQYpkSVAo78/+/Gx1mDW+n3G7MdkSSPKTuHLu0b6RWFGtQgkVZt+GeZg2ujcypk+j3HkgARIggZASCGiGKnasmEiV/Gs8evwUf1+8EtJsGN9lCLCgJEAClgjYvcKrCz1u+iLdajwPGzfbaKeFBEiABByRwIiJv2HQqBk4ceY83r//YCzC3fsP1bcL1Rp2gdiNHrSQAAmQAAkEmYDdK7yyRc+fJ//Cy5evIWfd7Dl4HO+8vYNcYEYAyIAESMB+CMydOABZMn2PWQtWonCFxmr5lCyvatFpMO4/eIx5UwajSP6c9iMwJSEBEiABByRg9wqvjHrIDg33HjxSox1iF7N7/5/o3ampAyKnyCRAAiTwhYAs2SpTPL9aLiXLpmRplZj/LZqAnh0b45uvfT+Q/RKDtlAkwKRIgARchIDdK7zlShbE9DF90LZZbXUWu5h+XZsj0w/pXKSaWEwSIAESIAESIAESIIHgErB7hVcvmCi+skfl6b8uQl/WIGfdP8zOTJgESIAESIAESIAESMChCTiMwjt30WpUrNseU+b8Yba0waHpU3gSIAEScCACFJUESIAEHJWAwyi8h46dwcalUzBzXD+zpQ2OCp5ykwAJkAAJkAAJkAAJhA+BUFZ4w07oOLFjwGCwr1/WCrvSMmUSIAFXI7B2827Irzp+8PFR25SVrdkaB46ecjUMLC8JkAAJhAkBh1F4vSJHRu8hk7F7/zGu4Q2TpsBESYAEQpVAEBNbtnoLokeLiiPHzmqK7yuMGtgJ0+YuDWIqDE4CJEACJGCJgMMovA8ePcGjJ0/xx+pNXMNrqSbpRgIk4NAEIkeOpOQ/ceZv5M+dDd+lSclZLUWEBxIgAUcnYA/yO4zCK1uRWTL2AJEykAAJkEBICXh6emDVuu3Ye/C4+iEKWdrw4cOXX14LafqMTwIkQAKuTMBhFF7ZgsySceXKY9lJwHkIsCTd2zVSs1jNG1RDkkQJ8O/NO8iXMwvBkAAJkAAJhAIBh1F45dfVdDNp5hK07T4ck2ctCQUETIIESIAEIp5Aim++QtP6VVGkQA4lTOoUydCyUQ1l54EESMCFCLCoYULAYRRe0+UMC6YNwaIZw5Ay+ddhAoWJkgAJkEB4EWjeaRCsmfCSg/mQAAmQgDMTcBiF128lyOjHs+f/+XXmNQm4AgGW0YkINKpTEWK+SZoEsma3YJ6fUbpYPsjONPHjxnGikrIoJEACJBBxBBxG4fW7fnfzjv24//BRxJFjziRAAiQQCgR+/ukHiLl4+RpmjOuHGpVKolzJghg/tCvevnsbCjkwCRJwZgIsGwnYRsBhFF59/a5+3rrrIAb3amNbKRmKBEiABOycwNt37/xJ6O0d8l0aHj1+itZdh6Jhm77oOWgC3ry1rESfu3AZDVr3Qd5S9VC6ekv4fPzoTx46kAAJkICjEnAYhdd0Da/Yxw7uClnW4KjgKXf4EWBOJOAIBLJn+REtOg3CirVbsWn7fnTuOxopkycNsegTZixGzmyZMHfSQMSMGQOLl2/0l+ar12/QodcolCtRANv/NxvTRveBG3/Z0h8nOpAACTguAYdReD99+oQLl66ph4E8EC5evg5xc1z0lJwESIAEvhDo2LIuKpQpjJNnLmD/4RMoWiAn2jevg5D+O3DkFMoUz6eSKVMsH/YfOanspoc9B4/h+7SpUKlsUXhFjoTkyZLwRy9MATmPnSUhAZcl4DAK74iJv6Fl5yHqYSAPhBadBmP05PkuW3EsOAmQgPMQkB+ZkP6sdNF8GNK7rTIli+QNsdIpI7cyUBsndkwFK1nSRHj46Imymx7u3H2oLms27qKWMyxYuk5d80ACJEACzkLAYRTeYyf/wrLfRqsHgTwQls0dhcPHzjhLPdhPOSgJCZBAuBPwcHfH9Ru3wyRfN7cv3bzB8MVumtmnTx9x9/4DDO/XEQumDsGeA8dw/NQ5FeTdu7d4/fq1RfM2gPXAKqKTHqTMAfEIzN3Hx8dJqVgu1idtZjYwJtb8LafqvK7e3t4W7zOdkfOWPHxKZrn3C5+8g5RLpEieiB83tjFO/Hhx4OnpbrymhQRIgAQcmYD0abJud9vuQzDdlSYkZYoWNQp8fD7C+/17lczjp8+QIH5cZTc9xIsbG9+nTa2WMogcGdN/i4tXbqggnp6R4OXlZdFEihRJhXHWg6VySZkD4hGYu+nLh6W0nc3NYDBYbDeBcdL9nY1HYOXx9PS0yiuw+PS3TsDNurf9+MaLExtT5/xhfBBMmrkYiRLEtx8BKQkJkAAJhIDA/YeP8fLVG6xctx36bjRyDkGSKmru7JmxXVOi5UJ2t8mbI7NYIcsd/jp/SdnlJ4z/uXJdy/813mmjTGf/vozv0qRQfqKkWTMqkAsdrLEIzM9gMLgQKd+iBsbEmr9vCq5zNBgMIA+E2T+HUXgHdG+JR0+eod/wqco8e/4S/bo2DzMwtiXMUCRAAiQQOgRk9xlLJqSpt29eG+u27FXbkt24eRe1q5ZRSd66fQ+DRs9Qdhn1rVvtFzRpPwCN2/VHkQI5keXH75UfDyRAAiTgDATcHKUQcePEQt8uzbFx6VRl+nRpBnFzFPkpJwmQAAlYIyDrHcNiJxpZojBtdG+1LdnQPu0QxctLiZEuTUosnTNa2eVQulh+LJk1AgunDUWtyqXEKWiGoUmABEjAjgk4jMI7atI8PHv+wohS1qKNmbLAeE0LCZAACTgyAe5E48i1R9lJgATsnUB4KrwhYnHq7AXEjuW7tY4kJGt6j508K1YaEiABEnB4AtyJxuGrkAUgARKwYwIOo/C+fvPW7CcxX756rV172zFaikYCJEACARHw786daPwzoQsJkAAJhBYBh1F4c2T7ET0HTTLu0tB7yGTkzZkltDgwHRIgARKIUAIya8WdaCK0Cpg5CZBARBAIpzwdRuHt2qYBCuX7GROmL1amaIEc6NiybjhhYjYkQAIkELYEuBNN2PJl6iRAAq5NwGEUXtmbrlzJglg0Y5gyv5QooParc+3qY+lJwCUIuEQhZdcZ7kTjElXNQpIACUQAAbtXeH9fsRGyXU9AbHbsPYodew8H5E13EiABEnAIAtyJxiGqiUKSQAQTYPbBJWD3Cu/9h49QrWFnzF64EgePnjKu4V2/ZQ9adxuGGfOWIkmiBMEtP+ORAAmQgF0Q4E40dlENFIIESMBJCdi9wtuhRT1MGNZNjfL+sWqz8Sc3/zx5Dr8Uz4ffZ41E+nSpnbR6WCwSCDoBxnBMAtyJxjHrjVKTAAk4BgG7V3gF41eJE6JJvSqYOLw79J/elA88ShbJCw93dwlCQwIkQAIOTYA70Th09VF4+yRAqUjASMAhFF6jtLSQAAmQgJMS6MqdaJy0ZlksEiABeyBAhdceaoEyRBwB5kwCdkKAO9HYSUVQDBIgAackQIXXKauVhSIBEnA0Arfu3EPb7sNR9ddOSvSLl65h+rxlys4DCYQHAeZBAs5MwCEVXp+PH3H95l1nrheWjQRIwMUIDBg5A6WL5YX84poUPe23KbD/0Emx0pAACZAACYSQgMMovMMnzMXLV6/x4r+XqNWkK9p0HYIFS9eFsPiMHjQCDE0CJBBWBLy9vSEf4sLgm4PBYMDHTx99L3gkARIgARIIEQGHUXj/vnAF0aNFxaE/TyPXz5nwx5xR2LRtb4gKz8gkQAIkYC8EPn0CPnz4YBTn0eOn8PTwMF7TYmcEKA4JkIBDEXAYhdfN3VfUE6fP48cM6RAtahS482HgUI2NwpIACQRMoHrFEug7bAruP3iMGfOWo0mHAahXvVzAEehDAiRAAiRgMwFfLdLm4BEX8OskidBryCQcOX4WP/+UQS1vgDYiEnESBZozA5AACZCAzQTKFM+P1k1qonC+n/Hiv1eYMLQ7ihTIYXN8BiQBEiABEgiYgMMovD07NkaF0oUwdXQvxIgeDc+ev0D9mhz9CLhq6UMCJOAoBD74+KB5p0GQH9lp07Q2urRpgG++Tuwo4tsgJ4OQAAmQQMQScBiFN2oUL21k9wf1QBBkX3+VGMUK5hJrmJunz16gc5/RKFS+EUZO/C3M82MGJEACrkVAfjHSw8MDb96+da2Cs7QkQAIkEE4E7EbhDay8uUrUgV9Tsmpz9B4yGQ8ePQkseoj9S2vTjU3qVg5xOkyABEiABCwREKW3aoPOGDFhLmbOX240lsLSjQRIgARIIGgEHEbhrVWlNOpUK4PfZ45QRuwF8vyM9N+lxoAR04JW6iCGjhM7Jgrny44oUSIHMSaDkwAJkIBtBNKnS4lypQogTuwYtkVgKBIgARIgAZsJOIzCe+zkObRqVBMpkydVRuznzl9Grcql8Py/lzYXmAFJgARIwB4JNK1fFZaMPcpKmUiABEggfAiEXi4Oo/C+8/bGsxf/GUsu62q933ur64jcq/L161cwNe8/y6QEs4PDx48fzeQzlVW3v3mRLuCvAAAQAElEQVTz2g4kNRfhzZs3gcr98aOPeaQIvnr//n2gMnt7v4tgKc2z//TpU6AySzsxjxXxV2/fvjWT+907rn2N+FqhBCRAAiRgvwQcRuGtW60sajbqin7DpypTq0k31K1eFq/fvEW6NCkjjLCXVxSYGg8PzwiTxVLGbm5uZvKZyqrbI0f2shQ1Qt0iR44cqNxubu4RKqPfzD08PAKV2dMzEuzpn8FgCFRmaSf2JLPIEilSJKPcIl+kSFxuJFxoSIAESIAELBNws+xsf66yR+WcSQOQMf23ysydPBBlSxSE7N7QvV3DCBPYTVMoTY3B8Pl3QSNMIv8Zm8oXkN1/rIh1CUhOU/eIldB/7gaDAabyWbIbDGwfCIV/ftkaDPbHNRSKySRIgARIICgEGNYKAYdReKUMskdllXLFISZJogTiFC5G9siUHSJkS7LVG3ao3SIuXroWLnkzExIgAdchcObcP1j2vy2qwI8eP8X1G3eUnQcSIAESIIGQEXAYhXf/4ZNo0n4A8pWurxROUUDFhKz4tsWW7YIObVkEUxORyyhsk5qhSMACATrZLYH5S9Zi2Pg5WLNxl5JR1lcPGTtL2XkgARIgARIIGQGHUXjnLFqFzq3rY/f638wUz5AVn7FJgARIwD4IbN6xDwumDkGMGNGUQAnix8Wr16+VnQcSIIHQJ8AUXYuAwyi8iRLGQ7pvU8DdzWFEBv+RAAmQgK0EInt5wdPTwyy4AQaza16QAAmQAAkEj4DDaI/x4sbGqvXb8fIVRzyCV9WMFXQCjEEC4UcgTqyY+PviFZWhLGeYs2g1vk31jbrmgQRIgARIIGQEHEbhXbVuO0ZNmodilZqG+xrekCFmbBIgARIInEC/bs21l/odOHfhCvKXaYCbt++hQ4s6gUdkCBIIDwLMgwQcnIDDKLymH4yZ2h2cP8UnARIgAUUgdswY6N2pKTYunYLViyagf7cWiK2N+ipPHkiABEiABEJEwGEU3hCVkpHDgwDzIAESCAGB5p0GqdgxokdD/Lixlb1Osx7qzAMJkAAJkEDICNi9witbj539+5LZMgZx003Iis/YJEACJGCfBF69fgP5SXX7lI5SWSdAXxIgAXsjYPcKryxfyJg+jdlWZOKmG3sDSnlIgARIICgEZs5frl7oT/91UZ31l/k6zXug0i9Fg5IUw5IACZAACQRAwO4V3gDkdnhnFoAESIAEhEDT+lXVC738gqT+Ii/n1QvGo2blUhIkREZ+sa1116Fo2KYveg6agDdv3waY3tNnL1C4fGNMm7s0wDD0IAESIAFHJGD3Cm+jtv1gzTgidMpMAiRAAn4JdGpVD2Hx08ITZixGzmyZMHfSQMSMGQOLl2/0m7XxesyUBciS6TuE8/a/4D8SIAESCGsCdq/wtm9eB9ZMWANi+iRAAiQQHgTC6qeFDxw5hTLF86kilCmWD/uPnFR2vwdZUhElSmRk+C4N8MmvL69JgARIwLEJ2L3CK+t3M6ZPg4DOjo2f0pMACZCAL4HNO/ZhwdQhiBEjmnJIED8uXr0O2Q/tvHr9BgYDECd2TJVmsqSJ8PDRE2U3PXz48AGTZi1BmyY1TZ2VXfw+fHgPS8bH54MK40oHKbMlFra4ffr00ZVQqbLawiWgMCoBFzp8/Ohj8T7T+bgQijApqt0rvLJVz5XrNyFnSyZMqDBREiABEghnArb+tHBQxXJz+9LNGwxf7KbpyDKHSmWLIGaM6KbOyv7x40dYMyqQCx2ssQjM75OLjZx/0gocGBNr/i7UrFRRA+OlAvEQbAKWe79gJxf6ERvVqYhECeJBzpZM6OfIFEmABEgg/AmExU8LR4saBT4+H+H9/r0q0OOnzyAjx+rC5CDLHAaNmqF2iZBdIxYsXYfx0xeqEJEiRUKkSJEtGk/PSCqMKx2kzJEC4BGYu+nLhyswMxgMFttNYJx0f1dgZFpGd3cPq7xMw9KuCATp4Bak0BEQeKDWCUePFhU///QDLl25oc5i100EiMQsSYAESCDUCfTr1hyr1u/AuQtXkL9MA9y8fQ8dWtQJcT65s2fG9t2HVDpbdx1E3hyZlV2WO/x1/pKyzxrfT+0UIbtDyK4R9aqXRfvmdZUfDyRAAiTgDATsXuE1hbx8zVbTS9pJgARIwDoBB/KNHTMGendqio1Lp2D1ogno360FYsfyXXsbkmK0b14b67bsVduS3bh5F7WrllHJ3dIU6kGjZyg7DyRAAiTg7ATcnL2ALB8JkAAJ2DOBA0dPwdSc+fsSLl6+bnQLqezx48XBtNG91bZkQ/u0QxQvL5VkujQpsXTOaGU3PfxaqzxaNKxu6kQ7CZCAExBw9SLYvcL76tUbyJoyMf+9fGW0y7UYV69Alp8ESMCxCSxbvQXWjGOXjtKTAAmQgH0QsHuFN+23yXHizAVlvk31jTrr13K2D4yUggScgQDLEBEEJgzrBmsmImRiniRAAiTgbATsXuGdPqYPrBlnqxCWhwRIwHUJXLx8HSvWblXm0tV/XRcES04CEU2A+TsdAbtXeJ2OOAtEAiRAAhYIjJmyAOOmLsTN2/dx6epNDBo1E+Om+W4NZiE4nUiABEiABIJAgApvEGAxKAmYEKCVBEKVwI1bdzF9bB90aFEXPdo3wtxJA3Dw6KlQzYOJkQAJkICrEqDC66o1z3KTAAnYFQEPD//dcSRPT7uSkcKQgGUCdCUB+yfgv4e1f5kpIQmQAAk4HQEvLy907jMam7bvx7L/bUHzToPxY4a0+PPkX8o4XYFZIBIgARIIRwJUeMMRtitnxbKTAAlYJ/D4yTO8fP0Gazbtws59R+Hh4Y5rN25jzqLVyliPTV8SIAESIAFrBKjwWqNDPxIgARIIJwLWdqMRv3ASg9mEPQHmQAIkEAEEqPBGAHRmSQIkQAKWCLx9543Tf11USxi4lMESIbqRAAmQQPAIUOENHrewjcXUSYAEXI7ApFm/o1ytNpCzvoxBzi4HggUmARIggTAgQIU3DKAySRIgARIIKoFtuw9j9cLxmD1hgNmP7QQ1HWcLz/KQAAmQQGgQoMIbGhSZBgmQAAmEkEDcOLEQxStyCFNhdBIgARIgAUsEnEDhtVQsupEACZCAYxFoXKcSug0Yh5nzl5sZxyoFpSUBEiAB+yRAhdc+64VSkQAJuBiBrbsO4sI/1/D6zdvgl5wxSYAESIAELBKgwmsRCx1JgARIIHwJnDxzHsvnjUX75nXRtH5VowlfKZgbCZAACTgHAb+loMLrlwivSYAESCACCHydNDG8vb0jIGdmSQIkQALOT4AKr/PXMUtIAiRgkYB9OcaKGR01m3TDqMnzuIbXvqqG0pAACTgBASq8TlCJLAIJkIDjE0iVPCnKlyqIWDGiOX5hWAISIAHHIuAC0lLhdYFKZhFJgATsn4Dpul1Tu/1LTglJgARIwP4JUOG1/zqihCRgDwQoQxgTePrsBRYv34Begycq8/vKTRC3MM6WyZMACZCASxCgwusS1cxCkgAJ2DuBfsOnYveBY8iS6Xtldu49ggEjp9u72JSPBFyQAIvsiASo8DpirVFmEiABpyNw78FDTB/bB5XLFlNm+pjeuHXnntOVkwUiARIggYggQIU3IqgzT6cnwAKSQFAJuLn5747d3AxBTYbhSYAESIAELBDw38NaCEQnEiABEiCBsCWQOeP3aNl5sHFLshadh+DnnzKGbaZMnQTCngBzIAG7IECF1y6qgUKQAAm4OoGubRqgbIkC+PfmXWUqlC6ETq3quToWlp8ESIAEQoUAFd5QwchEQkSAkUmABCBLGn7RFN4hvdtCTJni+ZUb0ZAACZAACYScgMsrvKf/uogGrfugbouemL1wpUWil6/eQK4SdYymQ69RFsPRkQRIgASCSmD05Pn4fcVGf9EWLluPqXP+8OdOB+cmwNKRAAmEDQGXVng/ffqEvsOmQKYSf5s8CDv3HcXJM+ctks6aKT0ObVmkzLghXSyGoSMJkAAJBJXAwaOnUK1CcX/RalYqiX2HjvtzpwMJkAAJkEDQCbi0wnvx8nVEjRoF6dOlhoe7O4oXyo19h08EnWK4xmBmJEACzkTA3d0NHh4e8PtP3N55f/DrzGsSIAESIIFgEHBphff+wydImjiBEVuypIlw/8Fj47Wp5dzFK8hbqh4at+uPM+f+MXp9/PgRpkZGjY2edmIxlS8gu52IahQjIDlN3Y2B7cQidW8qnyW7hLETcY1iWJLTr5sxsJ1Y/Mon13YiWpDFiBwpEt68fesv3stXrxHFK7I/dzqYEKCVBEiABGwk4NIKrzAymO1zaRnHV0kSYu3iidi0fBoK58+Bzn3H4PUb3wfUu3dvYWo+fLCvEZlPnz6ayWcqq2739n4nKOzKiEy6fAGd7U3J8fH5ECjr9+/f2xXnT58+BSqz8LcroTVh3r/3NpNbrjVnh/yrUKYQegyciIePnhjlv//wMXoPmYQKZQob3WghARIgARIIPgHLGl7w07O3mFblSZQgLp4++88Y5snTZ0iUMJ7xWrdEjeKFGNGjKVOrcikkThgfN2/7/gJSlChRYWo8PT31aHZxNhjczOQzlVW3e3lFsQtZTYUQmXT5Ajq7udlX8/Xw8AyUdSRtNM+0nBFtNxgMgcos/CNaTr/5R47sZSa3XPsN4yjXVcoVR/p0KVGlQSfUatoN1Rp2QvWGXTS3VKhSrpijFINykgAJkIBdE7AvjSGcUaX7NgUePX6qlFefjx+xY88R5M2ZRUlx78EjXL9xR9llalFZtIPs2PD0+QskS5pYu+IfCZAACYScQNP6VbH+j8moqb1Q/1qrorKLm8FgCHnixhRoIQESIAHXJeDSCq/BYMCA7i3RZ+hkNGjVG1l/So8sP36vWsPOvUexZNUmZd+4bZ/akixfmQYYM3UBhvZuCxn1VZ48kAAJkEAoEJBZpLIlCqJU0byIHi1qKKTIJEiABEiABHQCZgqv7uhK50w/pMO8KYOxcNpQNKlb2Vj0WlVKo0f7Ruq6WoUSajuyfRvmYdro3siYPo1y54EESIAE7J2AzGK17joUDdv0Rc9BEyx+ICfbMXYfOB5FKzaBfJi75yC3Q7P3eqV8JEACQSPg8gpv0HAxNAmQgIsQcJpiTpixGDmzZcLcSQMRM2YMLF6+0V/ZZMaqc+sG2LJyBurXKIchY2b6C0MHEiABEnBkAlR4Hbn2KDsJkAAJBELgwJFTKFM8nwpVplg+7D9yUtlND+nSpET8uLHh7uaGvDl/wvv37y2OBJvGoZ0ESMBVCDhHOanwOkc9shQkQAIk4I/Aq9dvYDAAcWLHVH6y17jp9mfK0c9h9fod+DZVckTx8vLjw0sSIAEScFwCVHgdt+4oOQnYDQEKYr8ETLfvMxisd/nyozqLV2xE3y7NjAV68+Y1Xr16adG8efPGGM5VLFLmgHgE5m5v+7SHdZ19+vTRYrsJjJPuH9by2Vv6sv+8XnZLZ3uT19Hksd77OVppKC8JkAAJo0B3RQAAEABJREFUkICRQLSoUeDj8xHe798rt8dPnyFB/LjK7vcgI7+TZy/B5JE9zLZdlH2Yo0aNBkvGywVHgaXMlljY4uZh4Sek/daDM13LC5YtXAIK46Asgi22p2cki/eZzifYCTOiIkCFV2HggQRIgASck0Du7JmxffchVbituw4ib47Myi7LHf46f0nZZSeHXkMmoWeHJkiSKIFyMz0YDAYYDJaNaThXsBsMljkYDIG7uwIfv2U0GALnYjBYDuM3LWe/NhgsczAYfN2dvfxhXT4qvGFNmOmTgF8CvCaBcCTQvnltrNuyV21LduPmXdSuWkblfuv2PQwaPUPZl6/ZirN/X0LNJl3VnuO5StSB/PiO8uSBBEiABJyAgJsTlIFFIAESIAESCIBA/Hhx1P7hsi3Z0D7tjB+jyc4MS+eMVrFaNKyu9ho/tGWR8Sw/oa48eSCBMCTApEkgvAhQ4Q0v0syHBEiABEiABEiABEggQghQ4Y0Q7MzUdgIMSQIkQAIkQAIkQAIhI0CFN2T8GJsESIAESIAEwocAcyEBEgg2ASq8wUbHiCRAAiRAAiRAAiRAAo5AgAqvI9SS7TIyJAmQAAmQAAmQAAmQgB8CVHj9AOElCZAACZCAMxBgGUiABEjgCwEqvF9Y0EYCJEACJEACJEACJOCEBFxa4XXC+mSRSIAESIAESIAESIAE/BCgwusHCC9JgARIwAUJsMgkQAIk4NQEqPA6dfWycCRAAiRAAiRAAiRAArYrvGRFAiRAAiRAAiRAAiRAAg5IgAqvA1YaRSYBEohYAsydBEiABEjAsQhQ4XWs+qK0JEACJEACJEACJGAvBBxGDiq8DlNVFJQESIAESIAESIAESCA4BKjwBoca45AACdhOgCFJgARIgARIIIIJUOGN4Apg9iRAAiRAAiRAAq5BgKWMOAJUeCOOPXMmARIgARIgARIgARIIBwJUeMMBMrMgAdsJMCQJkAAJkAAJkEBoE6DCG9pEmR4JkAAJkAAJkEDICTAFEghFAlR4QxEmkyIBEiABEiABEiABErA/AlR47a9OKJHtBBiSBEiABEiABEiABAIlQIU3UEQMQAIkQAIkQAL2ToDykQAJWCNAhdcaHfqRAAmQAAmQAAmQAAk4PAEqvA5fhbYXgCFJgARIgARIgARIwBUJUOF1xVpnmUmABEjAtQmw9CRAAi5GgAqvi1U4i0sCJEACJEACJEACrkaACm9ANU53EiABEiABEiABEiABpyBAhdcpqpGFIAESIIGwI8CUSYAESMDRCVDhdfQapPwkQAIkQAIkQAIkQAJWCYSSwms1D3qSAAmQAAmQAAmQAAmQQIQRoMIbYeiZMQmQgFMSYKFIgARIgATsjgAVXrurEgpEAiRAAiRAAiRAAo5PwJ5KQIXXnmqDspAACZAACZAACZAACYQ6ASq8oY6UCZIACdhOgCFJgARIgARIIOwJUOENe8bMgQRIgARIgARIgASsE6BvmBKgwhumeJk4CZAACZAACZAACZBARBOgwmtjDSz73xbUad4D9Vr0wt5DJ2yMxWAkEKoEmBgJhBkB9nFhhpYJkwAJ2AEBKrw2VMK/N+9iwR/rMGNsX4zs3wFDxszE23feNsRkEBIgARKwfwLs4+y/jiihXwK8JoGgEaDCawOv/YdPoECebIgWNQoSJ4qP79KkxJ8n/gL/kQAJkIAzEGAf5wy1yDKQAAlYI0CF1xqdz34PHz/BV4kTfL4Cvv4qER48eqyuFy5cCFNz4oR9LXd4+vSpmXymsur2FStWqLLY02HdunWByn3v3j2rIoe357lz5wKV+eDBg+EtltX83rx5E6jMixcvtppGRHhu27bNTO6NGzdGhBhOk6e1Pm79+vVmrPV+Q85btmxxGga2FkTKLGUPjrl69aqt2ThFuOfPnwfYdgLjt2TJEqdgEJRCHDt2zCqvoKTFsP4JUOH1z8Sii8HtCyqDwWAM4+PzAaamaP6fMWVEV7sxPdo3MJPPVFbdHiN6FLuRV2f3VaJ4gcrdtkl1u5K7fKn8gcqcK9sPdiXz0F4tA5XZYPhkVzJLG0mT6mt/chtvSlqCRcDWPk7vN+T8/ENc/PmmskuZ5x/i+Gt7wsIWc9U7W0SxipB8z74tHmxW730QITJHZHu+653KKq9g3diMZCTwRYszOtHil0CCeHHx7Nlzo/OTp8+QMH48dV27dm3QkAHbQMS2gVKlSqn7kYfgEbDWx5UpU4Z9HPt5tgE7aAPBu7sZSydAhVcnYeWcN2cW7Dt8Au+8vfHk6XP8ffEqcmTLaCWGA3pRZBIgAZclwD7OZaueBScBlyFAhdeGqk6eLAkqlimCRm37oX3PkejQsh4ieXraENN/kJ37jiJXiTq4ccv/+lNLfoePnUaxSk3RvNMg1GzSDUtWblKJfvDxQf5fGih7WB0kb5F13ZbdxixOnb2g5F+xdqtyE5mbtB+Aui16omTV5vjfxp3KXY8r8cWUqNIcDdv0VXHl2tSs3rBDxQnpQZhIuuOmLTQmtWDpOsycvxzHTp1T9Wf00Cw+Hz+ieOVmePTkGabNXYpK9TqgZZch+LV1H/QbPhUPHj3RQn35k7JK+pbq7kuowG2S79xFqyHb3EmbaqDlt3DZemNEkaf7wPFo0Kq34jps3Gy8fPXaZv8r126iXY8RqN+yl8qj1+CJEDdJQMr52+9rxBpi8/zFS+QpVQ96W5AE9ToYMHK6XCrz4cMHFC7fGCKHOHTuO9piO5CdT0S+gmUb4umzFxJUmULlG6kzD2FHILT6OL0vkLbbvucI3Ln3wKrQ0rblvvIb6MV/L1G9UWflLP4STl0E8SD3/+8rrK/v3nfoBK5cv2mWcmhcSB8o92FopBVYGiK/lEMPN2bKAmzZeUC/DPb5zdu3WPa/Lcb4Ui/VGnYyXoe3RfoH6aebdRyo+rejJ84GSYTgcClbq02Q8rA1cFila2v+rhiOCq+NtV6tQgksmj4MC6YNQYHcWW2M5T/Yjj2HkTZ1cmzesc+fZ0B+6dOlxvQxfTBzXF+s2bQT5y5c9hc3LBwMBgNSfJMUO/YcMSa/XbOnTJ4UBoMBHzWFcdDoGWjWoAoWThuKVQvGI1Xyr41hs2fJiENbFimzZcV0zJ00UNnnTR6kGOh+8jJhjBRCi1fkSJCO/9nzLwqTJJk1U3rcvf8Q9+4/kktlDh87g29TfYP4cWOr67IlC2LqqF74TZNPytFUU+RlVF95aocdVupO87b5b+a85Th8/Iyq0zkTB2Bwz9a4ceuuMX7nPqOROmUyzJsyGAumDoH3+w8YOnaWTf4yAyEPg3KlCmG+FlfSKJQvO86ev2SMH1qWbbsP4ltNTmkTepoGg0HtZvKXlp8ouuK+5+AJJE7kuwRIrkcP7KzagV7/1SoUR8M6FSF1J/7xtPpYvGKDWGnCkUC1UOrjurRuoNpuvlxZMHLibyEuwU8Zv0PNyqVDnE5ACRz68zSu/Xs7IG+HcBf5pRy6sFXKFUO2nzLol8E+v33rDdMBiahRo6Bvl+bBTi80Iko/LVuEihz9hk1VM6+2phtaXGzNj+HsiwAV3mDVR/AiifJ0/PTfGNK7DbbuOmSWiDU/PWCM6NHwXZpUuHj5uu4U5uevv0qIZ8//UyOMnz59wp8nz+KnH79X+cqInFgy/5BOTogaxQs/Zkir7BFxMBgM8PDwQHlN2ftj9WYzEQwGA4oVzIXNJqMe23cfRtECOczC6Rf1a5ZDgvhxtVES310VbKkfPa61s7wkLFm1CT3aN0b0aFFV0K+/SoReHZso+8kz5xXvhrUrqmuDwYCOLevi4NHTePT4KQLzX7NpN3JkzYgi+bOr+B7u7loZc6JC6cLqOjQP23cfQadW9XH33kM1Sq6nbTAYkDt7ZhzQZBa3HXsOafLkFKs/Iy8n5/+5hkafywsD8EuJAur+ePX6jb/wdHAcAjmy/micWShdvaVR8DPn/oGM8usO0gZadx2qRnS37TbvFyXMSW1WaclK31FaeaHrNWSSmrmQ2Zk9B45JEDMjo7pVf+0ESfPipWtGPxkpLlOjlTZT1hV9h01Rfdqlq/9qL8jHMWfhSjWLJvsRP376TM1GyAxM43b9tAGGK8Y0gmuREeqhY2ejlTaDJDMvch/rac1fshZK3m7DVL76iPT5f64qmWT2TF6CRS6Js2v/n2oGR2b8ajXtJk6Yu3i1KkdzbSZwu/ZivmLtNhw7eU75SV5NtJd3ybfP0Mn47+Ur5W5NJhVAO8xetEoNEki6Mrr6WrsnB46arvlA6xsPoFOfUUqWivXaY9GyDfhdm4GUWSuZKZPRYAkocsvsTmjylHRlUMDLKzLu3n+MgFhJGUXe1hrbWQtWaLNRgXO5dec+WnQeDKn7ERPmSlYWjYygS91IucZNWwCZuZM+ukbjLpA22rSDNpgxZqZylwRsTVfC0oQNASq8YcPVYqo79h5Bnuw/4euvEiN2rJj4++IVYzhrfnogmda+cOmqNqr2je4ULufC+XJoo7yHNWX3L2T5MT3cDG4Q5VcU3EplCkM6XbnBpaMVhU4XSqabZAmAmEGjZ+rOYX6uUr6Y1hkfhF+FqXih3BDOIoCMPh44cjJARUzCZMn0Hf694TvyI/ECqjsJa6u5//Axonh5IaU2Sm4pzk2ts/0uTQq4u325NeVFR6ac/715B4H6376rvXT4voBYSj+03GSk/NGTp1peaVGicG5s2r7fLOnihXJhp9be5aXouiZ3qhRfm/nLhTwcJs5cjKG928LNpLyRtVH6ciULQldyJCyNHRMIQLRjp84hVYpkAfh+cb599z7GD+uGEf07QRQM6ee++JrbJs1agjha3ymzbasWjEOG71KbBbj67y2s1JS9WRP6Y1jfdlof+2UbsLTazJrE+X3mCHzzdWLIi2eaVMmRL1dWNKpbWc24yH02aeYSZNZGlSWPPp2bo/+IqWZ5BPfCx8cHE0f0wNTRvTF++iKVjCjcsgxMZr+G9WmrKW6+CrooTwNGTkO7ZrXV7Fkx7X6aMN13e8DJGoPh/dphyawRmDDUV+GVF2Qph8wEFi3w5eVSlhiJct+iYTU14+OuvQAvXLpO5S0HSzKJu24a16kE2Xte0m3RsLrubDzf05RNGcD5bdJALF6+Xpul8YTMWmX58TusXr9ThQsrnlev38abt2+RMEEcBMRKBHjn/R4TtfbVpF4VuVTGGpfJs5cg18+ZMHvCAO1ZnQhv3rxVcUwP/968i3nai4rwl1m4d94fsG7zbhXkjjYAINxmjuunPedjYJ82wyUetqQr4WjCjoBb2CXNlP0S2LbrMEoUya2cRUnYust39FAcrPnpimPd5j1RrlRhpWRInPAyorxs33NEU3qPaKOFOcyybdO0NsZrnW66b1Ngypw/MGTMl6l30yUNfTo3NYsXlhfyAyGliuTBijXbzLKRh6N0XtJZ7T98Cj98nxqxYkY3C2N64e725fawVj+mcWyxmyp3K9ZuNXtpLl8AABAASURBVK5nvXz1hm90bYTU1xLAMRB/NzeDMaKMrMkLR/cB44xuoWHZqo3EyYi5pCVTjNv8zFhk+O5b/HP5mqb0HkbhfNkhL0gSVjfyYtRz8ER0bl0f8ePF0Z2N55qVS2Ht5j38RUMjEcexyJKafGUaYLc2EtmlTeDfGciIvsxEpEiWROvb0lhdT3tCmyFrXLci5J/MkPhtO6f/uohC+X5G7JgxIC+KRQp86a8iRfLEgj/WQr7D2H/4JK7o95skZmLkOwUZaW7eaRCGjZ+tZi8e+lnPbxLcZmuu7JnUi6z0TzJrJhH/On8ZBfJkVbKKvIXzZxdn3L33APcfPsGEGYshcqxctx0y2CGeGdOnwehJ8yEjwx+1WTdxC8jcvvMAMWJE0wYqfGflqlUojjPnLhmDW5LJ6GmDJaM2oyf1IAM48eLFxs8//aBifZ8uNeRFVy5Cm6d8kyF9Wr8RUzCgeys8efIsQFaSvyxBNO1zxc0al3MXrqBy2aISDJXLFVNnv4fTf11QAyrSh8lo9mmt3f19wfflKmmShMYBjYTaLOH1m76DJrak6zcfXocugS9P9NBN1zQ12jUC8oGPKK7yEYPcrGOnLlDTtqIIWPPTokJXHFcvHI9amiIgbuFhRDYx8obv/f49pHPOkim9v6y/SpwQ9aqXhayrEkVI4vgLFA4Okq8YyapGpVJYtX47PnzwgcFgECdlREnbtvsgtmnT7MUK+r58KA8Lh6vXbyF5sq8QWP1YiBqgU+KE8fFWG5WQaT4JVKVccbWeNa02+iTXyb5KpJasiEIo12JkCvJfbURBZAnUP2kSs/WIG5dOxfB+HSSZUDXbdx/GvCVrlLJerWFnyEiVfMwn/MVIZnlzZcHk2X+geKE8cmlmZi1YqUbnZNrbzOOTdqU9xEUpKKmNHMtonebCPwciIP3Avg3z1IuwLNcR0WVkUW/TMqoobrrxcP/yGJIlSR99PupeFs8SxqLHZ0fJ67MVHh7uulUbPZ6DJIkSYFDPVmrk9M1bb6OfX8vIAR3ViK+MbO5aM0ctb/IbJqjXbm5fyqkrqnKvWJbXoMka3yiDjBYumztGZdm/WwtUr1QSn7T/smxDZlGURwAHTw8Po4+wk3i6gyWZdD9bzqZpu7u5wdPTNy937aX7w4cP0P+FJs+m9auqPlO+G5HlW0DArKD9kzJrJ39/prJLGCMXrf+JrL0cSQQPrf0YDF+eH+KmjOaWT+vfpH2IkdH2nh0bKy93ty9tzk1x8FHu2ls/Ak3XNySPYUTgyx0YRhkwWV8C8sGTjOrqH+rIWRRFGbGw5ucbO+KPMmUmxmD4cvO/8/bGkeNnjMJJWeLGjgmD4UsYo2c4W2LGiA4Z3dm4ba/Wz4gW5StA8UK5tReNgzhx6m9tZCWbr6OF4469h3Hxyr8oWTSvNrJ9GAHVnYWoVp0MBgOqVSiBTr1HayM2vtOXoggIS4ko66NjabLLmjy5lgeifFmcJ0dmNRIamH+F0oWwTRt9na9Nt+kPwnfv3klSoWZEsZX1edKGdVO32i/YsuuAWR7lShbSXtDKqOljUw9ZU3jgyCm0alzT1NmfXT5UkunewBQgfxHt2sE1hfsqcQLcvH1fFf6Iny/r12/dB5livq691J3VRh/lQ1IV0MJB2v9vi1cbffwuf8j4fRoc1+5tuafk3vnzxDlj2Ju370FewqRv2H/kpNE9SpTIePHipfH65yw/YPpvy439xrFTX9IwBgolyw+avCdOn1d5ibz6ulvhJQrjlp2+99T79x+0kdl/VK7yAiwvyA1qloe8LNx78Fgtk3r+35cyqIDaIelXCfHiv1c4fe6idgUsX7MVmTPavuQpalQv/PffaxU3uIew5mmNVUAyW+OS4ftvjd8fHDl2VtWN33SyZU4PmcHQd795+uyF1ZkJiW9LuhKOJuwIUOENO7ZmKW/bcxiF8mY3cyucPwe2aiNl1vzMIvi5kE5QRot1Ix8V+AkSapfyJi0KpN8EFy7bANmmRsz46YvQrV1Dv0Ei7LputbJqqstUAFk7G8kzErJk+l59ZGfqJ2uwZHpKtiXbe/CEGl2R7eeCWz+maZvamzaoivy5sqLvsMmo3bQ7qv7aGUUL5EKqz+tcRw/qjMvXbkK2K6vXspcaFejRobExCWv+cbQXDhlxOHHmvPo4p3L9jtigKRS/1vadBpZE9ClBvd2IsiHutpotO/ej8OepVz1OkQI5sWWH78NZd0uWNDHqVCujXxrPsvRFRoTzla6vRoh1Oa5ev20MIxYpi4wAy+yCXNM4LoFq2lS6fOAkywn+e2muQCVKEA/1WvRE9wFj0bFVPcjUfkAlbdO0JkTBk4+FCpdvDNMXbmj/RFkunC8H2nQbho7aS6UokZqz+hMFsVGbfmpJgyiTylE7lC6aD4eOnVZbEspMSqvGNeCtvczLEjLZOmr1+h1aqLD5E8W1YJ6flbzyIZ/sGBM9elS1pn1I77bYuG0/5GOzcrXa4C9tql2kqKX1GRXrtod8CFZMm6WSpSBZMn2HTx8/qg/ItmvPGgknxsPdHX27NMPkWX+odN6+fQfpF8XPFhM5UiSUKZ5PpRvc50tY83Rzc0NArAIqozUurbUX8XWbd6kPDDdu3wf5psBvOjJYJR/sDhk7S20dKf30M03p9RvO9NqWdE3Du4Q9nAtJhTecgE8b3RsyBWKanSxP6NG+Eaz55cyWCROGdTONpuxyw+qja/rZ0kcFKnAwD5K3bCHlN3on7aEkU/HSGU4e0QMy1SZm8/Lp6ut8CS9xLcktfunSpMT8qUPEGqpGmGxfPcuYpihMMrUqU2BGR82yaMYw1UFqVuOfsJMPWvRtyQZ0bwl5EEsAa/Uj/kE17m5uahsuYbZ45nCsnD8WjetWUg85SUseesP7tse8yYPUBys9NGVX1smJn5jA/OXrZWG/esF4lbbYZY21xJVy6u1FPws38bPVyMcfbZvWNgsu6a+YN1YbcXKHaR3ogQrny25kLh+D6HmbnlOlSAqRr1aV0no0tcZXwhgdaLFrArPG94OlnVqK5M8JaR/jh3aFbFum9yvStvt1bQ75kOyP2aPUTipSQBmFXTpntFjVGnAJJxfx4sRW7Uims3eumQ1JV9xNTb0aZTFlVC+MG9JFbYWot6fSxfKr+0Fk6NCinrFflftl1IBOaktC+WhN1v/KllfST6z7fZLKzzR9W+2mfaDIL/eAHlfS1e3yke3kkT0xuFcbPHv+Ej98l0Z5yQd1cu9KX7lp+TRttqSUcpe4srxNlDzZzk8c5UPYoX3aqTIV1V4+pY8uUTiPeKlddaReJJ1BPVsbd4exJpOK+Pkg96TIIWepF+m3xEvSl3zELkbSlyVbYpeyS15iDy2ekpbI8Gut8mI1MwGx8ltGkVfklsgyW2CJiyzDkfYpbWiIVicb/pgiwf0Zqc+5kwaqPlrqJGvmDGoWTtqNHliek9K3y7Wt6UpYmrAhQIU3bLgyVRIggZATYAok4PQEug0Yr2bJ5Id5Cub9WZvpSer0ZWYBSSAiCFDhjQjqzJMESIAESIAENAL6LNmSWSNRo1JJzYV/JGCJAN1CSoAKb0gJMj4JkAAJkAAJkAAJkIBdE6DCa9fVQ+FIwHYCDEkCJEACJEACJGCZABVey1zoSgIkQAIkQAIk4JgEKDUJ+CNAhdcfEjqQAAmQAAmQAAmQAAk4EwEqvM5UmyyL7QQYkgRIgARIgARIwGUIUOF1mapmQUmABEiABEjAPwG6kIArEKDC6wq1zDKSAAmQAAmQAAmQgAsToMLrwpVve9EZkgRIgARIgARIgAQclwAVXsetO0pOAiRAAiQQ3gSYHwmQgEMSoMLrkNVGoUmABEiABEiABEiABGwlQIXXVlK2h2NIEiABEiABEiABEiABOyJAhdeOKoOikAAJkIBzEWBpSIAESMA+CFDhtY96oBQkQAIkQAIkQAIkQAJhRCDCFd4wKheTJQESIAESIAESIAESIAFFgAqvwsADCZAACUQ4AQpAAiRAAiQQRgSo8IYRWCZLAiRAAiRAAiRAAiQQHAKhH4cKb+gzZYokQAIkQAIkQAIkQAJ2RIAKrx1VBkUhARKwnQBDkgAJkAAJkICtBKjw2kqK4UiABEiABEiABEjA/ghQIhsIUOG1ARKDkAAJkAAJkAAJkAAJOC4BKryOW3eUnARsJ8CQJEACJEACJODCBKjwunDls+gkQAIkQAIk4GoEWF7XJECF1zXrnaUmARIgARIgARIgAZchQIXXZaqaBbWdAEOSAAmQAAmQAAk4EwEqvM5UmywLCZAACZAACYQmAaZFAk5CgAqvk1Qki0ECJEACJEACJEACJGCZABVey1zoajsBhiQBEiABEiABEiABuyZAhdeuq4fCkQAJkAAJOA4BSkoCJGCvBKjw2mvNUC4SIAESIAESIAESIIFQIUCFN1Qw2p4IQ5IACZAACZAACZAACYQvASq84cubuZEACZAACfgS4JEESIAEwo0AFd5wQ82MSIAESIAESIAESIAEIoKAfSu8EUGEeZIACZAACZAACZAACTgVASq8TlWdLAwJkICzEmC5SIAESIAEgk+ACm/w2TEmCZAACZAACZAACZBA+BIIVm5UeIOFjZFIgARIgARIgARIgAQchQAVXkepKcpJAiRgOwGGJAESIAESIAETAlR4TWDQSgIkQAIkQAIkQALORIBl8SVAhdeXA48kQAIkQAIkQAIkQAJOSoAKr5NWLItFArYTYEgSIAESIAEScG4CVHidu35ZOhIgARIgARIgAVsJMJzTEqDC67RVy4KRAAmQAAmQAAmQAAkIASq8QoGGBGwnwJAkQAIkQAIkQAIORoAKr4NVGMUlARIgARIgAfsgQClIwHEIUOF1nLqipCRAAiRAAiRAAiRAAsEgQIU3GNAYxXYCDEkCJEACJEACJEACEU2ACm9E1wDzJwESIAEScAUCLCMJkEAEEqDCG4HwmTUJkAAJkAAJkAAJkEDYE6DCG/aMbc+BIUmABEiABEiABEiABEKdABXeUEfKBEmABEiABEJKgPFJgARIIDQJUOENTZpMiwRIgARIgARIgARIwO4IOLDCa3csKRAJkAAJkAAJkAAJkIAdEqDCa4eVQpFIgARIIEgEGJgESIAESMAqASq8VvHQkwRIgARIgARIgARIwFEIBCQnFd6AyNCdBEiABEiABEiABEjAKQhQ4XWKamQhSIAEbCfAkCRAAiRAAq5GgAqvq9U4y0sCJEACJEACJEACQsCFDBVeF6psFpUESIAESIAESIAEXJEAFV5XrHWWmQRsJ8CQJEACJEACJODwBKjwOnwVsgAkQAIkQAIkQAJhT4A5ODIBKryOXHuUnQRIgARIgARIgARIIFACVHgDRcQAJGA7AYYkARIgARIgARKwPwJUeO2vTigRCZAACZAACTg6AcpPAnZFgAqvXVUHhSEBEiABEiABEiABEghtAlR4Q5so07OdAEOlDrUfAAAAK0lEQVSSAAmQAAmQAAmQQDgQoMIbDpCZBQmQAAmQAAlYI0A/EiCBsCXwfwAAAP//Huwo+AAAAAZJREFUAwCkOw+FRh+ELQAAAABJRU5ErkJggg=="
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1088,13 +1110,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffe9619a",
+   "id": "416aa1cd",
    "metadata": {
     "papermill": {
-     "duration": 0.001418,
-     "end_time": "2026-06-13T04:31:13.510956+00:00",
+     "duration": 0.00906,
+     "end_time": "2026-09-08T22:58:53.145267+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.509538+00:00",
+     "start_time": "2026-09-08T22:58:53.136207+00:00",
      "status": "completed"
     }
    },
@@ -1126,13 +1148,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd970cc8",
+   "id": "7ec717c0",
    "metadata": {
     "papermill": {
-     "duration": 0.001289,
-     "end_time": "2026-06-13T04:31:13.513538+00:00",
+     "duration": 0.006763,
+     "end_time": "2026-09-08T22:58:53.160764+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.512249+00:00",
+     "start_time": "2026-09-08T22:58:53.154001+00:00",
      "status": "completed"
     }
    },
@@ -1143,19 +1165,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "b9e82787",
+   "id": "57a5cd00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T02:40:44.198694Z",
-     "iopub.status.busy": "2026-07-23T02:40:44.198578Z",
-     "iopub.status.idle": "2026-07-23T02:40:44.201778Z",
-     "shell.execute_reply": "2026-07-23T02:40:44.201210Z"
+     "iopub.execute_input": "2026-09-08T22:58:53.179101Z",
+     "iopub.status.busy": "2026-09-08T22:58:53.178922Z",
+     "iopub.status.idle": "2026-09-08T22:58:53.190837Z",
+     "shell.execute_reply": "2026-09-08T22:58:53.190128Z"
     },
     "papermill": {
-     "duration": 0.003945,
-     "end_time": "2026-06-13T04:31:13.518780+00:00",
+     "duration": 0.024443,
+     "end_time": "2026-09-08T22:58:53.195264+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.514835+00:00",
+     "start_time": "2026-09-08T22:58:53.170821+00:00",
      "status": "completed"
     }
    },
@@ -1168,7 +1190,7 @@
       "Symbols processed:           5\n",
       "Total 10-K filings found:    10\n",
       "Average filings per symbol:  2.0\n",
-      "Filing storage:              /data/equities/fundamentals/10k/sp100/reference/all_10k_filings.parquet\n"
+      "Filing storage:              ~/Dropbox/ml4t/data/equities/fundamentals/10k/sp100/reference/all_10k_filings.parquet\n"
      ]
     }
    ],
@@ -1183,13 +1205,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef008944",
+   "id": "452f6442",
    "metadata": {
     "papermill": {
-     "duration": 0.001307,
-     "end_time": "2026-06-13T04:31:13.521528+00:00",
+     "duration": 0.009275,
+     "end_time": "2026-09-08T22:58:53.217718+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.520221+00:00",
+     "start_time": "2026-09-08T22:58:53.208443+00:00",
      "status": "completed"
     }
    },
@@ -1200,13 +1222,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58bf954f",
+   "id": "943a6e54",
    "metadata": {
     "papermill": {
-     "duration": 0.001286,
-     "end_time": "2026-06-13T04:31:13.524107+00:00",
+     "duration": 0.009119,
+     "end_time": "2026-09-08T22:58:53.232241+00:00",
      "exception": false,
-     "start_time": "2026-06-13T04:31:13.522821+00:00",
+     "start_time": "2026-09-08T22:58:53.223122+00:00",
      "status": "completed"
     }
    },
@@ -1249,26 +1271,27 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.6"
+   "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "286157eebde8c8e0f367611ae7ea67a4e122d571",
-   "executed_at": "2026-07-23T02:41:02.640179+00:00",
-   "executor": "ml4t",
-   "production": true,
+   "executed_at": "2026-09-08T22:59:08.899328+00:00",
+   "executor": "local-uv",
+   "library_digest": "cbd996b33f5e922bb7e90ca746f4793a3cdc06ff5295ae1927fe548de024dd06",
+   "outputs_digest": "51ebf7592d1d92c34e3874985fbc6779471573d40e0805c0a251e7031124669e",
    "parameters": {},
-   "notes": "Docker image ml4t/ml4t:latest; live SEC metadata; output isolated; provider period string normalized to Date"
+   "production": true,
+   "source_py_blob": "cc6be298b527619fa8001b654a3ee861f39492e6"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.594559,
-   "end_time": "2026-06-13T04:31:14.339857+00:00",
+   "duration": 19.341311,
+   "end_time": "2026-09-08T22:58:56.060942+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "22_rag_financial_research/01_sec_filing_pipeline.ipynb",
-   "output_path": "22_rag_financial_research/01_sec_filing_pipeline.ipynb",
+   "input_path": "~/ml4t/public-onboarding/22_rag_financial_research/.01_sec_filing_pipeline.build.1584660.ipynb",
+   "output_path": "~/ml4t/public-onboarding/22_rag_financial_research/.01_sec_filing_pipeline.papermill.1584660.ipynb",
    "parameters": {},
-   "start_time": "2026-06-13T04:31:07.745298+00:00",
+   "start_time": "2026-09-08T22:58:36.719631+00:00",
    "version": "2.7.0"
   }
  },

--- a/22_rag_financial_research/01_sec_filing_pipeline.py
+++ b/22_rag_financial_research/01_sec_filing_pipeline.py
@@ -105,8 +105,16 @@ print(f"Filing storage: {SP100_10K_PARQUET}")
 edgar_identity = os.environ.get("EDGAR_IDENTITY")
 if not edgar_identity:
     raise RuntimeError(
-        "EDGAR_IDENTITY is not set. Provide a real name and email address, "
-        'for example: EDGAR_IDENTITY="Jane Doe jane@example.org".'
+        "EDGAR_IDENTITY is not set. The SEC requires a real User-Agent - your "
+        "name and email - on every EDGAR request, and blocks placeholder "
+        "addresses. It is not an API key and there is nothing to sign up for.\n"
+        "Put your own name and email on the EDGAR_IDENTITY line of the .env "
+        "file in the repository root:\n"
+        "    EDGAR_IDENTITY=Jane Doe jane@example.org\n"
+        ".env is read once, when the process starts, so then restart this "
+        "notebook's kernel (Kernel -> Restart Kernel). On the Docker path, stop "
+        "Jupyter Lab and run `docker compose up ml4t` again - `docker compose "
+        "restart` keeps the environment the container was created with."
     )
 set_identity(edgar_identity)
 print("edgartools configured with a non-placeholder SEC identity")

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ repository root**. New to the command line? Start with
 ```bash
 git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
 cd machine-learning-for-trading
-cp .env.example .env
+cp .env.example .env   # the defaults work as-is; nothing in it needs editing to start
 ```
 
 Then pick one environment. **Option A, Docker**, carries every dependency and needs no compiler:
@@ -321,21 +321,33 @@ uv run python scripts/download_artifacts.py
 
 ### 3. Run notebooks
 
-Notebooks are paired [Jupytext](https://jupytext.readthedocs.io/) files, a `.py` source and a
-generated `.ipynb`. `uv sync` already installed Jupyter Lab.
+First confirm the install, with the one command that answers it. It prints a
+PASS or FAIL line per component and exits non-zero on any required failure:
 
 ```bash
-uv run python 01_process_is_edge/factor_regimes.py                # smoke test
-ML4T_DATA_PATH="${ML4T_DATA_PATH:-$PWD/data}" uv run jupyter lab  # local: open the URL it prints
-docker compose up -d ml4t                                         # Docker: same address
+uv run python scripts/verify_installation.py                     # Option B
+docker compose run --rm ml4t python scripts/verify_installation.py   # Option A
 ```
 
-Start Jupyter from the repository root. The `ML4T_DATA_PATH` prefix gives the loaders an absolute
-path, because Jupyter runs each notebook with its chapter folder as the working directory and the
-loaders would otherwise search inside that folder and report the datasets as missing. It keeps a
-value you have already exported and defaults to this repository's `data/`. See
-**[running notebooks](docs/running-notebooks.md)** for case-study pipelines, Papermill parameters,
-and the experiment workflow.
+Notebooks are paired [Jupytext](https://jupytext.readthedocs.io/) files, a `.py` source and a
+generated `.ipynb`. `uv sync` already installed Jupyter Lab. Start it from the repository root,
+on **one** of the two paths:
+
+```bash
+# Option B, local uv. Open the tokenized URL it prints, in full.
+ML4T_DATA_PATH="${ML4T_DATA_PATH:-$PWD/data}" uv run jupyter lab
+
+# Option A, Docker. Then open http://localhost:8888 in your browser — no token.
+docker compose up ml4t
+```
+
+The `ML4T_DATA_PATH` prefix on the local path gives the loaders an absolute path, because Jupyter
+runs each notebook with its chapter folder as the working directory and the loaders would otherwise
+search inside that folder and report the datasets as missing. It keeps a value you have already
+exported and defaults to this repository's `data/`. The Docker path needs no prefix: the compose
+file sets the variable inside the container. See
+**[running notebooks](docs/running-notebooks.md)** for the first-notebook walkthrough, case-study
+pipelines, Papermill parameters, and the experiment workflow.
 
 ### Docker images
 

--- a/data/README.md
+++ b/data/README.md
@@ -323,8 +323,9 @@ every chapter.
 
 On the local `uv` path, `.env` reaches a notebook because importing `utils`
 loads it; a value you change there takes effect at the next kernel restart. On
-the Docker path Compose reads `.env` when the container starts, so change it
-before `docker compose up ml4t`, or restart the container afterwards.
+the Docker path Compose reads `.env` when it *creates* the container, so stop
+Jupyter Lab and run `docker compose up ml4t` again. `docker compose restart`
+does not pick up the new value.
 
 ---
 

--- a/data/README.md
+++ b/data/README.md
@@ -269,6 +269,23 @@ When data is missing, loaders raise `DataNotFoundError` with download instructio
 
 ## API Keys
 
+None of these are needed to start. `cp .env.example .env` and the free datasets
+in the table above download as they are; come back here when a chapter asks for
+a source that needs one.
+
+### No sign-up at all
+
+| Provider | Variable          | What to put there            |
+| -------- | ----------------- | ---------------------------- |
+| SEC      | `EDGAR_IDENTITY`  | Your own name and email      |
+
+The SEC mandates a real `User-Agent` on every EDGAR request and blocks
+placeholder addresses, so this is not a key and there is nothing to register
+for - `EDGAR_IDENTITY=Jane Doe jane@example.org` in `.env` is the whole step.
+Ch04 NB02 and NB14, Ch22 NB01, and the `form4_download.py` and
+`filings_download.py` scripts refuse to run while it is empty. Every other
+SEC-derived dataset here is a committed snapshot and needs nothing.
+
 ### Free API Keys
 
 | Provider         | Variable         | Sign Up                                           |
@@ -285,10 +302,11 @@ When data is missing, loaders raise `DataNotFoundError` with download instructio
 
 ### Configuration
 
-Create `.env` in repository root:
+Fill in the lines you need in the `.env` you copied from `.env.example`:
 
 ```bash
-ML4T_DATA_PATH=/path/to/your/data
+# No sign-up - your own name and email
+EDGAR_IDENTITY=Jane Doe jane@example.org
 
 # Free API keys
 FRED_API_KEY=your-fred-key
@@ -298,6 +316,15 @@ OANDA_API_KEY=your-oanda-key
 # Paid
 DATABENTO_API_KEY=db-your-key
 ```
+
+Leave `ML4T_DATA_PATH` commented out unless you keep the datasets on a separate
+drive. The default is this repository's own `data/` folder and it is correct for
+every chapter.
+
+On the local `uv` path, `.env` reaches a notebook because importing `utils`
+loads it; a value you change there takes effect at the next kernel restart. On
+the Docker path Compose reads `.env` when the container starts, so change it
+before `docker compose up ml4t`, or restart the container afterwards.
 
 ---
 

--- a/data/equities/fundamentals/filings_download.py
+++ b/data/equities/fundamentals/filings_download.py
@@ -44,11 +44,13 @@ Loader: ``data.load_sec_filings(form_type, universe, ...)``.
 
 import argparse
 import json
+import os
 import re
 import sys
 import time
 from pathlib import Path
 
+# Importing utils loads .env into os.environ, which is where EDGAR_IDENTITY lives.
 from utils.downloading import atomic_write_parquet, print_section, resolve_data_dir
 
 # ---------------------------------------------------------------------------
@@ -479,14 +481,27 @@ def main():
         print("[DRY RUN] No files created")
         return
 
-    # Init edgartools
+    # Init edgartools. The SEC requires a real User-Agent on every request and
+    # attributes the traffic to whoever it names, so this is the reader's own
+    # identity rather than a hardcoded one.
     try:
         from edgar import set_identity
-
-        set_identity("ML4T Book stefan@ml4trading.io")
     except ImportError:
-        print("ERROR: edgartools not installed. Run: pip install edgartools")
+        print("ERROR: edgartools not installed. Run: uv sync")
         sys.exit(1)
+
+    identity = os.environ.get("EDGAR_IDENTITY", "").strip()
+    if not identity:
+        print(
+            "ERROR: EDGAR_IDENTITY is not set. The SEC requires a real User-Agent\n"
+            "(your name and email) on every EDGAR request and blocks placeholder\n"
+            "addresses. It is free and needs no account: put your own name and\n"
+            "email on the EDGAR_IDENTITY= line of .env in the repository root,\n"
+            "        EDGAR_IDENTITY=Jane Doe jane@example.org\n"
+            "or export it in this shell before re-running."
+        )
+        sys.exit(1)
+    set_identity(identity)
 
     # Resume
     if args.resume:

--- a/data/equities/positioning/form4_download.py
+++ b/data/equities/positioning/form4_download.py
@@ -29,16 +29,20 @@ Output:
     script skips filings already on disk.
 
 Requirements:
-    - edgartools: pip install edgartools
+    - edgartools (installed by `uv sync`)
+    - EDGAR_IDENTITY: your own name and email, on that line of `.env` in the
+      repository root. The SEC requires a real User-Agent on every request.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
 from pathlib import Path
 
+# Importing utils loads .env into os.environ, which is where EDGAR_IDENTITY lives.
 from utils.downloading import print_section, resolve_data_dir
 
 
@@ -161,13 +165,27 @@ def main() -> int:
     print(f"Output:   {output_dir}")
     print()
 
+    # The SEC requires a real User-Agent on every request and attributes the
+    # traffic to whoever it names, so this is the reader's own identity rather
+    # than a hardcoded one.
     try:
         from edgar import set_identity
-
-        set_identity("ML4T Book stefan@ml4trading.io")
     except ImportError:
-        print("ERROR: edgartools not installed. Run: pip install edgartools")
+        print("ERROR: edgartools not installed. Run: uv sync")
         return 1
+
+    identity = os.environ.get("EDGAR_IDENTITY", "").strip()
+    if not identity:
+        print(
+            "ERROR: EDGAR_IDENTITY is not set. The SEC requires a real User-Agent\n"
+            "(your name and email) on every EDGAR request and blocks placeholder\n"
+            "addresses. It is free and needs no account: put your own name and\n"
+            "email on the EDGAR_IDENTITY= line of .env in the repository root,\n"
+            "        EDGAR_IDENTITY=Jane Doe jane@example.org\n"
+            "or export it in this shell before re-running."
+        )
+        return 1
+    set_identity(identity)
 
     t0 = time.time()
     total_written = 0

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -201,18 +201,37 @@ missing piece; see [Troubleshooting](#troubleshooting) below.
 
 ### Ubuntu / Linux
 
-```bash
-# Install Docker
-curl -fsSL https://get.docker.com | sudo sh
-sudo usermod -aG docker $USER
-# Log out and back in for group membership
+Three steps, and the middle one is not a command. Do them in order.
 
-# Verify
-docker run --rm hello-world
-docker compose version
-```
+1. **Install Docker Engine and add yourself to the `docker` group.** Both lines
+   need `sudo`, so you will be asked for your password:
+   ```bash
+   curl -fsSL https://get.docker.com | sudo sh
+   sudo usermod -aG docker $USER
+   ```
 
-If Docker Compose is missing: `sudo apt install docker-compose-plugin`
+2. **Log out of your desktop session and log back in.** This is a required step,
+   not a suggestion, and nothing prompts you for it. Group membership is read
+   when a session starts, so the shell you just typed in still does not have it;
+   `newgrp docker` fixes only that one shell. Skipping this is the most common
+   Linux install failure, and it does not read like one — every later `docker`
+   command fails with `permission denied while trying to connect to the docker
+   API`, which names the socket rather than the group you have not picked up yet.
+
+3. **Verify, in a terminal opened after logging back in:**
+   ```bash
+   docker run --rm hello-world
+   docker compose version
+   ```
+   `hello-world` must print "Hello from Docker!" and `docker compose version`
+   must print a version rather than an error before you continue. If
+   `docker compose` is not found at all, install the plugin:
+   `sudo apt install docker-compose-plugin`.
+
+**Docker Desktop for Linux is a different product** and you do not need it. The
+`get.docker.com` script above installs Docker Engine, which is what the compose
+file uses. If you already run Docker Desktop, keep it — the commands are the
+same.
 
 ### Windows 11 (WSL2)
 
@@ -325,30 +344,80 @@ real hardware before every release. Two things still want Docker on that machine
 [Py312 Image](#py312-image-specific-notebooks), and Chapter 2's storage benchmarks, which compare
 databases that run as containers. Everything else is `uv`.
 
-```bash
-xcode-select --install                        # compiler, if you do not have it already
-brew install libomp                           # OpenMP runtime; LightGBM will not import without it.
-                                              # Needs Homebrew - see the prerequisites section above
-curl -LsSf https://astral.sh/uv/install.sh | sh
-source $HOME/.local/bin/env                   # puts uv on PATH in this shell
-git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
-cd machine-learning-for-trading
-cp .env.example .env
-uv sync
-```
+Everything below is typed into **Terminal** (Applications → Utilities →
+Terminal). Two of the steps are not commands that finish when the prompt comes
+back, so run them in order rather than pasting the block at once.
+
+1. **Install the Xcode command-line tools**, if `xcode-select -p` does not
+   already print a path:
+   ```bash
+   xcode-select --install
+   ```
+   This **opens a dialog window** and returns to the prompt immediately, while
+   the download continues in the background. Click *Install*, accept the
+   licence, and **wait for the dialog to say it is done** — several minutes.
+   Running the next steps before it finishes leaves you with no compiler and a
+   `uv sync` that stops on `error: command 'c++' failed`. When
+   `xcode-select -p` prints `/Library/Developer/CommandLineTools`, continue.
+
+2. **Install Homebrew**, if `brew --version` does not already print one. A fresh
+   macOS does not ship it, and `brew install` below needs it:
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   eval "$(/opt/homebrew/bin/brew shellenv)"   # /usr/local/bin/brew on Intel
+   ```
+   The installer asks for your password and then **prints PATH instructions
+   rather than applying them**; the `eval` line is what it asks you to run, and
+   it puts `brew` on `PATH` in this shell only.
+
+3. **Install the OpenMP runtime.** macOS does not ship it and the Xcode tools do
+   not install it, so without it the environment builds cleanly and Chapter 12
+   stops at its first import with
+   `Library not loaded: @rpath/libomp.dylib`:
+   ```bash
+   brew install libomp
+   ```
+
+4. **Install `uv`, clone, and build the environment:**
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   source $HOME/.local/bin/env    # the installer's own line; puts uv on PATH here and now
+   git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
+   cd machine-learning-for-trading
+   cp .env.example .env           # defaults work as-is; nothing in it needs editing to start
+   uv sync                        # ~300 packages, about 11 GB; twelve compile from source
+   ```
+
+5. **Verify**, with the one command that gives a PASS or a FAIL:
+   ```bash
+   uv run python scripts/verify_installation.py
+   ```
 
 **Intel Macs: Docker is the only local option.** PyTorch publishes no macOS x86_64 wheel, so the
 `uv` path cannot be made to work on that hardware. The `ml4t` image is amd64 and runs, so:
 
-1. Install Docker Desktop from [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/),
-   choosing the **Intel chip** download. Give it 4+ CPUs, 8+ GB memory and 64+ GB disk in
-   Settings → Resources, and note that the image plus data wants about 17 GB of that disk.
-2. Clone and pull:
+1. **Download and install Docker Desktop.** This is a Mac application you
+   download in your web browser — not a command. Open
+   [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/),
+   choose the **Intel chip** download, and run the installer. Give it 4+ CPUs,
+   8+ GB memory and 64+ GB disk in Settings → Resources; the image plus data
+   wants about 17 GB of that disk.
+2. **Start Docker Desktop and wait for it**, then check in Terminal that the
+   engine is up before going on. `docker version` must print a **Server**
+   section, not just a Client one:
+   ```bash
+   docker version
+   ```
+3. **Clone and pull:**
    ```bash
    git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
    cd machine-learning-for-trading
-   cp .env.example .env
+   cp .env.example .env           # defaults work as-is; nothing in it needs editing to start
    docker compose pull ml4t
+   ```
+4. **Verify:**
+   ```bash
+   docker compose run --rm ml4t python scripts/verify_installation.py
    ```
 
 If that machine is tight on memory or disk, a Linux box or a cloud instance is the more
@@ -577,6 +646,11 @@ docker compose exec ml4t plotly_get_chrome -y
 
 Docker is recommended because it guarantees a consistent environment. But if you prefer a local Python setup — for faster iteration, IDE integration, or GPU access without container overhead — [uv](https://docs.astral.sh/uv/) handles everything from Python installation through dependency resolution.
 
+**On Windows this section is the Ubuntu terminal, not PowerShell.** WSL2 *is* the
+Linux path, so every command below is typed there. Installing `uv` into Windows
+Python is unsupported and the dependency set does not resolve on it — see
+[Platform Support](#platform-support).
+
 ### What uv Does
 
 `uv` is a fast Python package manager written in Rust. It replaces `pip`, `venv`, `pip-tools`, and `pyenv` in a single tool. When you run `uv sync`, it:
@@ -595,7 +669,6 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # The installer puts uv in ~/.local/bin, which your current shell does not know about
 # yet. Load it now rather than opening a new terminal:
 source $HOME/.local/bin/env        # sh, bash, zsh;  env.fish for fish
-# Windows PowerShell: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 
 # Clone and enter the repository (about 0.9 GB of history)
 git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
@@ -611,8 +684,8 @@ cp .env.example .env
 # API keys are optional and only needed for specific datasets later —
 # see data/README.md when a chapter asks for one.
 
-# Verify
-uv run python -c "import polars, torch, lightgbm; print('Ready')"
+# Verify — the one PASS/FAIL gate, same script on both paths
+uv run python scripts/verify_installation.py
 
 # Start Jupyter Lab, from the repo root, and open the URL it prints
 ML4T_DATA_PATH="${ML4T_DATA_PATH:-$PWD/data}" uv run jupyter lab

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -153,21 +153,32 @@ Rosetta. Nothing else in the book needs this.
 git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
 cd machine-learning-for-trading
 
-# 2. Copy environment template
+# 2. Copy the environment template. The defaults work as they are — nothing in
+#    it needs editing to start.
 cp .env.example .env
 
 # 3. Pull the pre-built image from Docker Hub
 docker compose pull ml4t
 
-# 4. Start Jupyter Lab
-docker compose up ml4t
-# Open http://localhost:8888
+# 4. Confirm the install: one PASS/FAIL line per component, exit 0 if ready
+docker compose run --rm ml4t python scripts/verify_installation.py
 
-# 5. Or run a notebook directly
-docker compose run --rm ml4t python 01_process_is_edge/factor_regimes.py
+# 5. Start Jupyter Lab. It keeps running in this terminal; leave it running.
+docker compose up ml4t
 ```
 
+Then open **http://localhost:8888** in your web browser. That is a browser
+address, not a command to type — and on Windows, open it in your normal Windows
+browser even though step 5 ran inside Ubuntu.
+
 **That's it.** No build step needed — Docker pulls the pre-built image (~12 GB on x86, ~3 GB on ARM64).
+
+To run a single notebook instead of opening Jupyter, name its `.py` — this one
+downloads the factor data it needs and takes a few minutes:
+
+```bash
+docker compose run --rm ml4t python 01_process_is_edge/factor_regimes.py
+```
 
 To build locally instead (if you prefer or need to modify the environment):
 
@@ -179,8 +190,9 @@ docker compose build ml4t    # ~45 min on x86, ~15 min on ARM64
 
 ## Verify Your Installation
 
-Before opening any notebook, run the one command that confirms every required
-library imports and the runtime is wired up correctly:
+This is step 4 of the Quick Start above, and the same command on either path. It
+is the one thing to run before opening a notebook: it confirms that every
+required library imports and that the runtime is wired up correctly.
 
 ```bash
 # Docker (recommended)

--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -575,9 +575,11 @@ they are empty, and neither is mentioned anywhere in the install path.
 
 A `.env` edit reaches a notebook at the next kernel restart on the local path
 (**Kernel → Restart Kernel**, because `.env` is read once when the kernel
-starts). On the Docker path Compose reads `.env` when the container starts, so
-edit it before `docker compose up ml4t`, or `docker compose restart ml4t`
-afterwards.
+starts). On the Docker path Compose reads `.env` when it creates the container,
+so stop Jupyter Lab (`Ctrl-C` in the terminal running it) and run
+`docker compose up ml4t` again. **`docker compose restart` is not enough** —
+verified: it restarts the existing container with the environment it was created
+with, and the old value is still there.
 
 Some datasets do require an API key (also set in `.env`):
 - **OANDA** (FX pairs): Free API key from [oanda.com](https://www.oanda.com/)

--- a/docs/running-notebooks.md
+++ b/docs/running-notebooks.md
@@ -6,6 +6,13 @@ This guide explains how to execute notebooks, work with case studies, and experi
 
 ## Two Ways to Run
 
+Every command in this guide is typed at a terminal prompt **from the repository
+root** — the folder `git clone` created — on macOS or Linux in Terminal, on
+Windows in the WSL2 Ubuntu terminal, never in PowerShell. The one exception is
+marked: opening a Jupyter address is something you do in a web browser.
+[Before You Begin](installation.md#before-you-begin) covers opening a terminal
+on each platform.
+
 ### Option A: Docker (Recommended)
 
 Docker provides a consistent environment across all platforms with pre-built images on Docker Hub. After [installation](installation.md):
@@ -14,16 +21,20 @@ Docker provides a consistent environment across all platforms with pre-built ima
 # Pull the image (one time, ~12 GB on x86, ~3 GB on ARM64)
 docker compose pull ml4t
 
-# Start Jupyter Lab
+# Start Jupyter Lab. It keeps running and prints its log here; leave it running.
 docker compose up ml4t
-# Open http://localhost:8888
 
-# Run a notebook directly
+# Run a notebook directly, without Jupyter
 docker compose run --rm ml4t python 11_ml_pipeline/01_ols_inference.py
 
 # Run with GPU (deep learning chapters)
 docker compose --profile gpu run --rm ml4t-gpu python 13_dl_time_series/01_core_architectures.py
 ```
+
+With `docker compose up ml4t` running, open **http://localhost:8888** in your web
+browser — that is a browser address, not something to type at the terminal. On
+Windows, open it in your normal Windows browser even though the command ran
+inside Ubuntu; WSL2 forwards `localhost` for you.
 
 Docker covers **all** notebooks across all 27 chapters and 9 case studies, though a small
 subset requires a non-default profile such as `py312`, `benchmark`, or `rapids`.
@@ -46,16 +57,21 @@ subset requires a non-default profile such as `py312`, `benchmark`, or `rapids`.
 ```bash
 # Install uv (if not already installed)
 curl -LsSf https://astral.sh/uv/install.sh | sh
+# The installer puts uv in ~/.local/bin, which this shell does not know about
+# yet. Load it now, or `uv sync` below fails with "uv: command not found":
+source $HOME/.local/bin/env        # sh, bash, zsh;  env.fish for fish
 
 # Clone the repository
 git clone https://github.com/stefan-jansen/machine-learning-for-trading.git
 cd machine-learning-for-trading
 
-# Set up environment
+# Copy the environment template. The defaults work as they are — nothing in it
+# needs editing to start. Come back to it when a chapter asks for an API key.
 cp .env.example .env
-# Edit .env to add API keys (see data/README.md)
 
-# Install all dependencies
+# Install all dependencies. Twelve of them compile from source, so a C/C++
+# compiler and the Python headers must already be installed — see
+# docs/installation.md, "What you need before either path".
 uv sync
 
 # Run a notebook
@@ -113,6 +129,12 @@ Ubuntu terminal and open the address in your normal Windows browser.
 You do **not** need a separate terminal window for the Docker workflow — the
 Jupyter Lab terminal tile is where the commands below run.
 
+**Most notebooks need downloaded data, and opening one does not download it.** A
+notebook whose dataset is missing stops with a `DataNotFoundError` naming the
+download command for that dataset. Get the free datasets out of the way first —
+the bulk command is in [Data Requirements](#data-requirements) below, and it is
+the same command whether you run it in the Jupyter Lab terminal or in your own.
+
 ---
 
 ## Notebook Format
@@ -139,6 +161,21 @@ docker compose run --rm ml4t python 11_ml_pipeline/01_ols_inference.py
 to the working directory, so running from a chapter folder reports the datasets as missing even when
 they are downloaded. Setting `ML4T_DATA_PATH` to an absolute path removes the constraint, which is
 why the Jupyter Lab command above sets it.
+
+**A `.py` run on a desktop opens figure windows and waits for you to close them.**
+Matplotlib picks an interactive backend whenever a display is available, and
+`plt.show()` then blocks until the window is closed — so the command appears to
+hang, with no message, part-way through. Close each window to continue, or run it
+the way [Headless Execution](#headless-execution) below does and get no windows
+at all:
+
+```bash
+MPLBACKEND=Agg PLOTLY_RENDERER=json uv run python 01_process_is_edge/factor_regimes.py
+```
+
+This does not affect Jupyter Lab, where figures render in the notebook, or the
+Docker path, which has no display and picks the non-interactive backend by
+itself.
 
 ---
 
@@ -519,7 +556,30 @@ python data/etfs/market/download.py
 python data/download_all.py --free-only
 ```
 
-Some datasets require API keys (set in `.env`):
+### Two `.env` lines you will meet before any API key
+
+Neither is a key and neither costs anything, but both stop a notebook dead when
+they are empty, and neither is mentioned anywhere in the install path.
+
+- **`EDGAR_IDENTITY`** — your own name and email, e.g.
+  `EDGAR_IDENTITY=Jane Doe jane@example.org`. The SEC mandates a real
+  `User-Agent` on every EDGAR request and blocks placeholder addresses, so there
+  is nothing to register for. Three notebooks call EDGAR live and refuse to run
+  without it — Ch04 `02_sec_filing_explorer` and `14_text_data_extraction`, and
+  Ch22 `01_sec_filing_pipeline` — as do the `form4_download.py` and
+  `filings_download.py` scripts. Every other SEC-derived notebook reads a
+  committed snapshot and needs nothing.
+- **`ML4T_DATA_PATH`** — leave it commented out. The default is this
+  repository's own `data/` folder and it is correct for every chapter. Set it
+  only if you keep the datasets on a separate drive.
+
+A `.env` edit reaches a notebook at the next kernel restart on the local path
+(**Kernel → Restart Kernel**, because `.env` is read once when the kernel
+starts). On the Docker path Compose reads `.env` when the container starts, so
+edit it before `docker compose up ml4t`, or `docker compose restart ml4t`
+afterwards.
+
+Some datasets do require an API key (also set in `.env`):
 - **OANDA** (FX pairs): Free API key from [oanda.com](https://www.oanda.com/)
 - **NASDAQ Data Link** (US equities): Free API key from [data.nasdaq.com](https://data.nasdaq.com/)
 - **Databento** (CME futures): $125 free signup credit from [databento.com](https://databento.com/)
@@ -560,16 +620,20 @@ Every notebook has a **parameters cell** (`# %% tags=["parameters"]`) with produ
 
 ```bash
 # Run with reduced parameters (output goes to /dev/null)
-uv run papermill notebook.ipynb /dev/null \
+uv run papermill 11_ml_pipeline/01_ols_inference.ipynb /dev/null \
     --cwd . -k python3 \
     -p MAX_SYMBOLS 15 \
     -p N_EPOCHS 2
 
 # Or save the executed notebook
-uv run papermill notebook.ipynb output.ipynb \
+uv run papermill 11_ml_pipeline/01_ols_inference.ipynb /tmp/executed.ipynb \
     --cwd . -k python3 \
     -p MAX_SYMBOLS 15
 ```
+
+`--cwd .` sets the directory the notebook executes in. Keep it, and run the
+command from the repository root: the data loaders resolve `data/` against the
+working directory, so anywhere else reports the datasets as missing.
 
 ### Running via pytest (Recommended)
 
@@ -626,10 +690,11 @@ When the environment variable `ML4T_OUTPUT_DIR` is set (which `pytest` does auto
 
 ## Headless Execution
 
-For running notebooks without a display (e.g., on a server or in CI):
+For running notebooks without a display (e.g., on a server or in CI), set both
+renderer variables and run the `.py` from the repository root:
 
 ```bash
-MPLBACKEND=Agg PLOTLY_RENDERER=json uv run python notebook.py
+MPLBACKEND=Agg PLOTLY_RENDERER=json uv run python 11_ml_pipeline/01_ols_inference.py
 ```
 
 ---
@@ -647,6 +712,22 @@ cd 11_ml_pipeline && python 01_ols_inference.py
 # Right
 uv run python 11_ml_pipeline/01_ols_inference.py
 ```
+
+### "EDGAR_IDENTITY environment variable is not set"
+
+Put your own name and email on the `EDGAR_IDENTITY=` line of `.env` in the
+repository root. It is not an API key and there is nothing to sign up for — the
+SEC just requires a real `User-Agent` and blocks placeholder addresses. See
+[Two `.env` lines you will meet before any API key](#two-env-lines-you-will-meet-before-any-api-key)
+for which notebooks need it and when the change takes effect.
+
+### "DataNotFoundError" naming a dataset
+
+The dataset has not been downloaded. The exception carries the exact download
+command; run it from the repository root, in the Jupyter Lab terminal on the
+Docker path (**File → New → Terminal**, no `uv run` prefix) or in your own shell
+on the local path. [Data Requirements](#data-requirements) above has the bulk
+command for the free datasets.
 
 ### Missing prerequisite files
 

--- a/envs/README.md
+++ b/envs/README.md
@@ -18,13 +18,13 @@ Covers all 27 chapters and 9 case studies. Includes PyTorch with CUDA 12.8 suppo
 ```bash
 docker compose pull ml4t
 docker compose up ml4t                    # Jupyter Lab at http://localhost:8888
-docker compose run --rm ml4t python nb.py # Run a notebook directly
+docker compose run --rm ml4t python 11_ml_pipeline/01_ols_inference.py   # one notebook, no Jupyter
 ```
 
 GPU passthrough (same image, NVIDIA runtime required):
 
 ```bash
-docker compose --profile gpu run --rm ml4t-gpu python notebook.py
+docker compose --profile gpu run --rm ml4t-gpu python 13_dl_time_series/01_core_architectures.py
 ```
 
 ### py312 (Python 3.12 Dependencies)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,8 +230,15 @@ mlops = [
     "mlflow>=2.16",
 ]
 # Live Trading (Ch25)
+# ib_async, not ib_insync. Both ship a top-level `eventkit` package to the same
+# site-packages path, and ib_insync's copy runs `main_event_loop = get_event_loop()`
+# at import time, which raises on Python 3.14. Installing both makes `import
+# ib_async` - and therefore `import ml4t.live` and every Ch25 notebook - fail with
+# "There is no current event loop in thread 'MainThread'". ib_insync is
+# unmaintained and nothing here imports it; ib_async is its maintained successor
+# and the name the notebooks and ml4t-live use.
 live = [
-    "ib_insync>=0.9",
+    "ib_async>=2.0",
     "python-okx>=0.3",
     "alpaca-py>=0.33",
 ]

--- a/scripts/verify_installation.py
+++ b/scripts/verify_installation.py
@@ -632,7 +632,7 @@ def check_optional():
     check_import(cat, "clickhouse_connect", "clickhouse-connect (db-benchmark extra)")
     check_import(cat, "influxdb_client", "influxdb-client (db-benchmark extra)")
     # Live trading
-    check_import(cat, "ib_async", "ib_insync/ib_async (live extra)")
+    check_import(cat, "ib_async", "ib_async (live extra)")
     check_import(cat, "alpaca", "alpaca-py (live extra)")
     # Feast / MLOps
     check_import(cat, "feast", "feast (mlops extra)")

--- a/tests/test_docs_match_compose.py
+++ b/tests/test_docs_match_compose.py
@@ -1,0 +1,249 @@
+"""Every service, profile, port and notebook path the docs tell a reader to type must exist.
+
+There is no sync tooling between `docs/`, `README.md` and `docker-compose.yml`,
+and the install doc has silently drifted before. A mirroring script is the wrong
+shape for that: it would keep two copies of the same prose equal without either
+one being right. What a reader actually hits is a command that no longer names
+anything - a renamed service, a profile that moved, a port the compose file
+stopped publishing, a notebook path that was reorganised. Those are checkable
+against the repository, so check them.
+
+Scope is deliberately narrow: the commands a reader is told to run, from the
+files an onboarding reader reads. It parses `docker compose` invocations out of
+fenced code blocks and resolves each name against the compose file and the
+working tree. It runs no Docker, opens no socket, and takes milliseconds.
+
+What it does not check: prose. A sentence claiming the image is 12 GB is not
+verifiable here, and pretending otherwise is how a check becomes noise.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+
+# The files an onboarding reader is sent to, in the order they meet them.
+DOC_FILES = (
+    "README.md",
+    "docs/installation.md",
+    "docs/running-notebooks.md",
+    "envs/README.md",
+)
+
+# `docker compose` subcommands whose first non-flag argument is a service name.
+_SERVICE_SUBCOMMANDS = {"pull", "up", "run", "build", "exec", "restart", "stop", "start", "logs"}
+
+# Flags that swallow the token after them, so it is never a service name.
+_FLAGS_WITH_VALUE = {
+    "-e",
+    "--env",
+    "-p",
+    "--publish",
+    "-w",
+    "--workdir",
+    "-u",
+    "--user",
+    "--file",
+    "-f",
+    "--project-name",
+    "-P",
+    "--scale",
+    "--entrypoint",
+}
+
+# Every fence, tagged or not. Matching only the shell tags would mis-pair: an
+# untagged or ```powershell fence would not register as an opener, and its
+# closing ``` would then open a "block" of ordinary prose.
+_FENCE = re.compile(r"^```([^\n]*)\n(.*?)^```", re.DOTALL | re.MULTILINE)
+_SHELL_TAGS = {"", "bash", "sh", "shell", "console"}
+
+
+def _load_compose() -> dict:
+    return yaml.safe_load(COMPOSE_FILE.read_text())
+
+
+def _compose_services() -> dict[str, dict]:
+    return _load_compose()["services"]
+
+
+def _compose_profiles() -> set[str]:
+    return {p for svc in _compose_services().values() for p in svc.get("profiles", [])}
+
+
+def _published_host_ports() -> set[str]:
+    """Host-side ports the compose file publishes, as strings."""
+    ports: set[str] = set()
+    for svc in _compose_services().values():
+        for entry in svc.get("ports", []):
+            if isinstance(entry, dict):
+                ports.add(str(entry["published"]))
+                continue
+            text = str(entry).split("/")[0]
+            if text.startswith("["):  # bracketed IPv6 host IP
+                text = text[text.index("]") + 1 :].lstrip(":")
+            parts = text.split(":")
+            # HOST_IP:HOST_PORT:CONTAINER  |  HOST_PORT:CONTAINER  |  CONTAINER
+            if len(parts) == 3:
+                ports.add(parts[1])
+            elif len(parts) == 2:
+                ports.add(parts[0])
+    return ports
+
+
+def _shell_lines(doc: Path) -> list[str]:
+    """Every logical command line inside a fenced shell block, continuations joined."""
+    lines: list[str] = []
+    for tag, block in _FENCE.findall(doc.read_text()):
+        if tag.strip().lower() not in _SHELL_TAGS:
+            continue
+        joined = block.replace("\\\n", " ")
+        for raw in joined.splitlines():
+            line = raw.split("#", 1)[0].strip()
+            if line:
+                lines.append(line)
+    return lines
+
+
+def _compose_invocations() -> list[tuple[str, str]]:
+    """``(doc path, command line)`` for every documented `docker compose ...` call."""
+    found = []
+    for name in DOC_FILES:
+        doc = REPO_ROOT / name
+        for line in _shell_lines(doc):
+            if "docker compose" in line:
+                found.append((name, line[line.index("docker compose") :]))
+    return found
+
+
+def _parse(command: str) -> tuple[list[str], str | None, str | None]:
+    """``(profiles, subcommand, service)`` for one `docker compose` line."""
+    tokens = command.split()[2:]  # drop "docker compose"
+    profiles: list[str] = []
+    subcommand: str | None = None
+    service: str | None = None
+
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--profile" and index + 1 < len(tokens):
+            profiles.append(tokens[index + 1])
+            index += 2
+            continue
+        if token.startswith("--profile="):
+            profiles.append(token.split("=", 1)[1])
+            index += 1
+            continue
+        if subcommand is None:
+            if not token.startswith("-"):
+                subcommand = token
+            index += 1
+            continue
+        if token in _FLAGS_WITH_VALUE:
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        service = token
+        break
+    return profiles, subcommand, service
+
+
+def test_documented_services_exist():
+    services = _compose_services()
+    unknown = []
+    for doc, command in _compose_invocations():
+        profiles, subcommand, service = _parse(command)
+        if subcommand not in _SERVICE_SUBCOMMANDS or service is None:
+            continue
+        if service not in services:
+            unknown.append(f"{doc}: `{command}` names service {service!r}")
+
+    assert not unknown, "docker-compose.yml has no such service:\n  " + "\n  ".join(unknown)
+
+
+def test_documented_profiles_exist():
+    declared = _compose_profiles()
+    unknown = []
+    for doc, command in _compose_invocations():
+        profiles, _, _ = _parse(command)
+        unknown += [
+            f"{doc}: `{command}` names profile {p!r}" for p in profiles if p not in declared
+        ]
+
+    assert not unknown, "no service declares that profile:\n  " + "\n  ".join(unknown)
+
+
+def test_documented_profile_matches_the_service_it_targets():
+    """A `--profile` that does not cover the named service is a stale doc.
+
+    Compose still runs it - naming a service explicitly activates its profiles -
+    so this drift is invisible to a reader who follows the instruction and to
+    anyone who tests it. It surfaces the day they adapt the command.
+    """
+    services = _compose_services()
+    mismatched = []
+    for doc, command in _compose_invocations():
+        profiles, subcommand, service = _parse(command)
+        if not profiles or subcommand not in _SERVICE_SUBCOMMANDS or service not in services:
+            continue
+        declared = set(services[service].get("profiles", []))
+        if declared and not declared & set(profiles):
+            mismatched.append(
+                f"{doc}: `{command}` passes {profiles} but {service!r} declares {sorted(declared)}"
+            )
+
+    assert not mismatched, "profile does not cover the service:\n  " + "\n  ".join(mismatched)
+
+
+def test_no_bare_docker_compose_up():
+    """`docker compose up` with no service named starts every profile-less service.
+
+    Naming a profiled service explicitly activates its profile, so a command that
+    names one is fine without `--profile`. A bare `up` is the case that behaves
+    differently from what the surrounding prose describes.
+    """
+    services = _compose_services()
+    bare_up = []
+    for doc, command in _compose_invocations():
+        profiles, subcommand, service = _parse(command)
+        if subcommand == "up" and service is None and not profiles:
+            bare_up.append(f"{doc}: `{command}`")
+
+    assert not bare_up, (
+        "`docker compose up` with no service starts every profile-less service at once; "
+        "name the service:\n  " + "\n  ".join(bare_up)
+    )
+
+
+def test_documented_localhost_ports_are_published():
+    published = _published_host_ports()
+    unpublished = []
+    for name in DOC_FILES:
+        doc = REPO_ROOT / name
+        for port in set(re.findall(r"localhost:(\d{2,5})", doc.read_text())):
+            if port not in published:
+                unpublished.append(f"{name}: localhost:{port}")
+
+    assert not unpublished, "docker-compose.yml publishes no such host port:\n  " + "\n  ".join(
+        sorted(unpublished)
+    )
+
+
+@pytest.mark.parametrize("doc", DOC_FILES)
+def test_documented_notebook_paths_exist(doc: str):
+    """Every `python <chapter>/<stem>.py` a doc tells a reader to run must be a real file."""
+    pattern = re.compile(r"\bpython3?\s+((?:case_studies/)?[\w.]+/[\w/]+\.py)\b")
+    missing = []
+    for line in _shell_lines(REPO_ROOT / doc):
+        for path in pattern.findall(line):
+            if not (REPO_ROOT / path).exists():
+                missing.append(f"{doc}: `{path}`")
+
+    assert not missing, "no such file in the repository:\n  " + "\n  ".join(missing)

--- a/tests/test_ib_client_is_ib_async.py
+++ b/tests/test_ib_client_is_ib_async.py
@@ -1,0 +1,63 @@
+"""The Interactive Brokers client is ib_async, and ib_insync must not be installed beside it.
+
+Both distributions install a top-level ``eventkit`` package to the same
+``site-packages/eventkit/`` path. ib_async ships a copy with the module-level
+``main_event_loop = get_event_loop()`` removed; the standalone ``eventkit`` that
+``ib_insync`` depends on still runs it at import time, and on Python 3.14
+``asyncio.get_event_loop()`` raises when no loop is running. Whichever
+distribution unpacks last wins, so an environment holding both is a coin flip.
+
+The published ``ml4t/ml4t:latest`` image lost that flip. It builds with
+``--extra live``, which pulled ``ib_insync``, so ``import ml4t.live`` - and
+therefore every Ch25 notebook, and the documented onboarding gate
+``docker compose run --rm ml4t python scripts/verify_installation.py`` - failed
+with ``RuntimeError: There is no current event loop in thread 'MainThread'``.
+The local ``uv sync`` path installs no extras, got ib_async's copy, and passed,
+which is why the break reached a published image unnoticed.
+
+Nothing in this repository imports ``ib_insync``; the notebooks and ``ml4t-live``
+use ``ib_async``, its maintained successor.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ib_async_imports():
+    """The failure a reader sees: importing the IB client raises at module scope."""
+    pytest.importorskip("ib_async", reason="live extra not installed")
+
+    import ib_async
+
+    assert hasattr(ib_async, "IB")
+
+
+def test_live_extra_declares_ib_async_not_ib_insync():
+    live = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())["project"][
+        "optional-dependencies"
+    ]["live"]
+    names = [spec.split(">")[0].split("=")[0].split("[")[0].strip().lower() for spec in live]
+
+    assert "ib_insync" not in names and "ib-insync" not in names, (
+        f"the live extra must not depend on ib_insync; found {live}"
+    )
+    assert "ib_async" in names or "ib-async" in names, (
+        f"the live extra must depend on ib_async; found {live}"
+    )
+
+
+def test_lock_resolves_neither_ib_insync_nor_standalone_eventkit():
+    """Static half, so a reintroduction fails its own PR rather than the next image build."""
+    lock = (REPO_ROOT / "uv.lock").read_text()
+
+    for package in ("ib-insync", "eventkit"):
+        assert f'name = "{package}"' not in lock, (
+            f"uv.lock resolves {package}, which overwrites ib_async's eventkit and breaks "
+            "`import ib_async` on Python 3.14 (see this module's docstring)"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1883,18 +1883,6 @@ wheels = [
 ]
 
 [[package]]
-name = "eventkit"
-version = "1.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/16/1e/0fac4e45d71ace143a2673ec642701c3cd16f833a0e77a57fa6a40472696/eventkit-1.0.3.tar.gz", hash = "sha256:99497f6f3c638a50ff7616f2f8cd887b18bbff3765dc1bd8681554db1467c933", size = 28320, upload-time = "2023-12-11T11:41:35.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d9/7497d650b69b420e1a913329a843e16c715dac883750679240ef00a921e2/eventkit-1.0.3-py3-none-any.whl", hash = "sha256:0e199527a89aff9d195b9671ad45d2cc9f79ecda0900de8ecfb4c864d67ad6a2", size = 31837, upload-time = "2023-12-11T11:41:33.358Z" },
-]
-
-[[package]]
 name = "exchange-calendars"
 version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2752,19 +2740,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/30/4d/dfc1da8224c3ffcdcd668da7283c4e5f14239a07f83ea66af99700296fc3/ib_async-2.1.0.tar.gz", hash = "sha256:6a03a87d6c06acacb0217a5bea60a8a168ecd5b5a7e86e1c73678d5b48cbc796", size = 87678, upload-time = "2025-12-08T01:42:32.004Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/e7/8f33801788c66f15e9250957ff7f53a8000843f79af1a3ed7a96def0e96b/ib_async-2.1.0-py3-none-any.whl", hash = "sha256:f6d8b991bdbd6dd38e700c61b3dced06ebe0f14be4e5263e2ef10ba10b88d434", size = 88876, upload-time = "2025-12-08T01:42:30.883Z" },
-]
-
-[[package]]
-name = "ib-insync"
-version = "0.9.86"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "eventkit" },
-    { name = "nest-asyncio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/bb/733d5c81c8c2f54e90898afc7ff3a99f4d53619e6917c848833f9cc1ab56/ib_insync-0.9.86.tar.gz", hash = "sha256:73af602ca2463f260999970c5bd937b1c4325e383686eff301743a4de08d381e", size = 69859, upload-time = "2023-07-02T12:43:31.968Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/f3/28ea87be30570f4d6b8fd24380d12fa74e59467ee003755e76aeb29082b8/ib_insync-0.9.86-py3-none-any.whl", hash = "sha256:a61fbe56ff405d93d211dad8238d7300de76dd6399eafc04c320470edec9a4a4", size = 72980, upload-time = "2023-07-02T12:43:29.928Z" },
 ]
 
 [[package]]
@@ -4278,7 +4253,7 @@ dev = [
 ]
 live = [
     { name = "alpaca-py" },
-    { name = "ib-insync" },
+    { name = "ib-async" },
     { name = "python-okx" },
 ]
 mlops = [
@@ -4331,7 +4306,7 @@ requires-dist = [
     { name = "granite-tsfm", specifier = ">=0.3" },
     { name = "gymnasium", specifier = ">=1.2" },
     { name = "hmmlearn", specifier = ">=0.3" },
-    { name = "ib-insync", marker = "extra == 'live'", specifier = ">=0.9" },
+    { name = "ib-async", marker = "extra == 'live'", specifier = ">=2.0" },
     { name = "iex-parser", specifier = ">=1.7" },
     { name = "influxdb-client", marker = "extra == 'db-benchmark'", specifier = ">=1.45" },
     { name = "ipython", specifier = ">=8.22" },


### PR DESCRIPTION
Five things a reader hits between `git clone` and a running notebook, and the check that keeps two of them from coming back.

## The onboarding gate failed on the Docker path

`docker compose run --rm ml4t python scripts/verify_installation.py` is the one PASS/FAIL command the install doc names. In `ml4t/ml4t:latest` it exits 1 with a red FAIL on a correct install, and Chapter 25 is broken in the same image for the same reason - every notebook that imports `ml4t.live` raises before its first cell.

`ib_insync` and `ib_async` both install a top-level `eventkit` package to the same site-packages path. ib_async ships a copy with the module-level `main_event_loop = get_event_loop()` removed; the standalone `eventkit` that ib_insync depends on still runs it at import, and on Python 3.14 `asyncio.get_event_loop()` raises when no loop is running. Whichever unpacks last wins. The image builds with `--extra live`, which pulled ib_insync and lost the flip; a local `uv sync` installs no extras, gets ib_async's copy, and passes - which is why this reached a published image unnoticed.

Reproduced on Python 3.14.3 with the same package versions: a venv holding `ib_async==2.1.0` and `ib_insync==0.9.86` raises on `import ib_async`; the same venv with ib_async alone imports clean. Nothing here imports ib_insync, it has been unmaintained since 2023, and ml4t-live and all of Ch25 use ib_async. The `live` extra now declares `ib_async>=2.0`, and `uv lock` drops both ib-insync and the standalone eventkit.

## EDGAR_IDENTITY was the second ML4T_DATA_PATH wall

A reader following `docs/installation.md` never saw it before a notebook stopped on it. `.env` copied from `.env.example` carries an empty `EDGAR_IDENTITY=`, and `04_fundamental_alternative_data/02_sec_filing_explorer` raises before its first figure.

Surfacing it is the fix, not a cached fallback. Measured what the siblings do differently: 03, 04 and 10 never contact the SEC - they read committed snapshots through the `data` loaders, and 04 and 10 exit 0 with the variable empty. NB02 is a live tour of edgartools, so there is no cached path to degrade to. Three notebooks genuinely need it, and they are the three `tests/overrides.yaml` already marks `requires_env`.

The chapter README claimed five and named the wrong ones. `data/README.md` omitted the variable entirely and led its `.env` example with `ML4T_DATA_PATH=/path/to/your/data`, reintroducing the exact wall two readers hit. Both SEC downloaders sent every reader's traffic under the maintainer's address - `set_identity("ML4T Book stefan@ml4trading.io")`, hardcoded - so a reader's bulk download was rate-limited against the maintainer. All fixed; the downloaders now read the variable and refuse with the same message.

## The macOS and Linux install paths, against the five failure patterns

The Windows path had two passes; these had none.

- **Linux, silent ordering.** Four commands in one block with `# Log out and back in` as a comment in the middle, and the next two lines cannot succeed until you have. Now three numbered steps, the log-out promoted, the tell named, a verify gate before Docker is used.
- **macOS, a GUI action inside a terminal block.** `xcode-select --install` opens a dialog and returns immediately while the download runs; the next line was `brew install libomp`, and `brew` is not on a fresh macOS either. Five numbered steps now, each with its own check.
- **Two verification commands, one of them wrong.** The uv section still ran `import polars, torch, lightgbm; print('Ready')` under `# Verify`, competing with `verify_installation.py`. Same in the README, whose step 3 opened with `factor_regimes.py  # smoke test`.
- **Windows told to use PowerShell**, in the section that forbids it: `# Windows PowerShell: powershell -c "irm .../install.ps1 | iex"`, two screens below the note that Windows Python does not resolve.
- **running-notebooks.md** still said `# Edit .env to add API keys` - the optional-as-mandatory wording the other files were rewritten to kill - and dropped `source $HOME/.local/bin/env` after the uv installer, so `uv sync` on the next line fails with `uv: command not found`.

That README smoke-test line was worse than redundant. With a display attached it never returns: `plt.show()` at `factor_regimes.py:353` enters the Tk main loop and waits for a window to be closed. `timeout 600` killed it at exit 124; the same run under `MPLBACKEND=Agg` exits 0. 81 notebooks call `plt.show()` and the repo `matplotlibrc` sets no backend, so the one-line fix touches every notebook's rendering path and is filed rather than done. `running-notebooks.md` now names the behaviour and the headless form.

## The error message at the point of use

The three EDGAR failures said `export EDGAR_IDENTITY=...`, which does not reach a running Jupyter kernel and is not where the repository documents the value. One wording now, naming `.env`, saying it needs no sign-up, and naming the restart per path. `docker compose restart` is not that restart - measured with a one-service probe: change the `env_file` value, restart, and the old one is still there; `up -d` recreates and picks it up. Three files said `restart`; all three now say to stop Jupyter Lab and run `docker compose up ml4t` again.

## Doc/compose parity (issue item 5)

A mirroring script would hold two copies of the same prose equal without either being right. What a reader trips over is a command that no longer names anything, and that resolves against the repository. `tests/test_docs_match_compose.py` parses `docker compose` invocations out of the fenced shell blocks in the four onboarding docs and asserts every service, profile, `localhost:<port>` and `python <chapter>/<notebook>.py` exists - 50 invocations and 61 notebook paths as the docs stand, in 0.15s, no Docker. Each of the five resolvable checks was mutation-tested against a copy of the tree with its own defect planted.

## Verified

- `verify_installation.py`: uv path PASS 149/154 exit 0; Docker path FAIL pre-fix, and the lock change triggers a candidate image build so `test-unit-image` measures the fix in the image rather than in `latest`.
- Both SEC downloaders, guard and happy path, with the variable empty and set.
- The three EDGAR notebooks re-executed against live EDGAR through `nb-run.sh`: exit 0, no error outputs, provenance stamped, `sanitize_notebook_paths.py` clean, cell-by-cell diff showing only the edited cells changed.
- Every internal anchor in the six touched docs resolves to a heading that exists.

## Left out

The published `ml4t/ml4t:latest` still carries the broken `eventkit`. Merging this triggers the rebuild; until it lands, a reader who pulls today still gets the Chapter 25 failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRbvPEVfdF9eSebTiX8vgM
