### PR TITLE
Skip a runner's transient notebooks so one run cannot fail another's sweep

### DIFF
--- a/.github/scripts/sanitize_notebook_paths.py
+++ b/.github/scripts/sanitize_notebook_paths.py
@@ -156,6 +156,16 @@ def _iter_notebooks() -> list[Path]:
             continue
         if p.name.startswith("_executed_"):
             continue
+        # `nb-run.sh` writes `.<stem>.build.<pid>.ipynb` and `.<stem>.papermill.<pid>.ipynb`
+        # beside the notebook it is running and deletes them on exit. They belong to that run,
+        # not to the working tree this script fixes, and a concurrent run in the same directory
+        # deletes one between this walk and the read below. On 2026-09-08 that raced four
+        # teaching notebooks at once: a healthy `12_kalshi_prediction_markets` run printed a
+        # `FileNotFoundError` naming `11_defi_tvl_evaluation`'s build file, the sweep died
+        # before sanitizing kalshi's own outputs, and the run still exited 0 with the notebook
+        # no longer matching its stamp.
+        if p.name.startswith("."):
+            continue
         if p in ignored:
             continue
         out.append(p)
@@ -322,7 +332,15 @@ def main() -> int:
     dirty: list[tuple[Path, int]] = []
     blocked: list[tuple[Path, str]] = []
     for nb in targets:
-        raw = nb.read_text(encoding="utf-8")
+        try:
+            raw = nb.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            # Only reachable for a path that existed during the walk and is gone now, which
+            # means another process owns it. Skipping one such file is right; failing the whole
+            # sweep leaves every notebook after it in the sort order unsanitized.
+            if args.notebooks:
+                raise
+            continue
         new, n, skipped = sanitize_notebook(raw)
         blocked += [(nb.relative_to(REPO_ROOT), s) for s in skipped]
         if n:

--- a/tests/test_notebook_output_hygiene.py
+++ b/tests/test_notebook_output_hygiene.py
@@ -457,3 +457,29 @@ def test_an_untracked_notebook_is_not_committed_content() -> None:
         assert relative not in _empty_tag_offenders()
     finally:
         shutil.rmtree(scratch, ignore_errors=True)
+
+
+def test_a_runners_transient_notebook_is_not_walked(tmp_path, monkeypatch) -> None:
+    """`nb-run.sh` writes `.<stem>.build.<pid>.ipynb` beside the notebook it runs and deletes it
+    on exit. The sweep must not pick one up: a concurrent run in the same directory deletes it
+    between the walk and the read, which on 2026-09-08 killed the sweep mid-way and left the
+    notebook it was actually running unsanitized while the run still exited 0."""
+    import sanitize_notebook_paths as snp
+
+    chapter = tmp_path / "08_financial_features"
+    chapter.mkdir()
+    real = chapter / "01_price_volume_features.ipynb"
+    real.write_text("{}", encoding="utf-8")
+    for transient in (
+        ".01_price_volume_features.build.1234.ipynb",
+        ".02_microstructure_features.papermill.5678.ipynb",
+    ):
+        (chapter / transient).write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(snp, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(snp, "_ignored_notebooks", lambda: set())
+
+    walked = snp._iter_notebooks()
+
+    assert real in walked
+    assert not [p for p in walked if p.name.startswith(".")]


### PR DESCRIPTION
`nb-run.sh` writes `.<stem>.build.<pid>.ipynb` and `.<stem>.papermill.<pid>.ipynb` beside the notebook it is executing and deletes them on exit. `sanitize_notebook_paths.py` walked them.

With four teaching notebooks running in one chapter directory on 2026-09-08, a healthy `12_kalshi_prediction_markets` run died on a `FileNotFoundError` naming `11_defi_tvl_evaluation`'s build file - deleted by its own run between this walk and the read. The sweep stopped before sanitizing kalshi's own outputs, the runner still exited 0, and the notebook that reached the working tree no longer matched its provenance stamp. Only the pre-commit provenance gate caught it.

Two changes:

- Transient dot-prefixed notebooks are skipped. They belong to the run that owns them, not to the working tree this script fixes.
- A file that vanishes mid-walk is skipped rather than ending the sweep, which used to leave every notebook after it in sort order unsanitized. An explicitly named notebook still raises, so `--check` on a specific path cannot pass by silently skipping it.

`tests/test_notebook_output_hygiene.py::test_a_runners_transient_notebook_is_not_walked` fails on `main` and passes here; the module's other 16 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu