### PR TITLE
Chapter 1: the two regime notebooks say what they measured, and on which panel

### DIFF
--- a/01_process_is_edge/README.md
+++ b/01_process_is_edge/README.md
@@ -12,26 +12,26 @@ The chapter establishes the chapter's central claim: in trading, durable perform
 
 ## Sections
 
-### 1.1 Why Process Discipline Matters
+### 1.1 Why process discipline matters
 
 This section establishes the chapter's central claim: in trading, durable performance depends less on picking a sophisticated model than on maintaining a disciplined research process that can survive changing markets, noisy signals, and real-world frictions. It gives readers a usable vocabulary for market change, shows why recent shocks exposed fragile assumptions, and reframes ML for trading as an adaptation problem rather than a model-selection contest.
 
-### 1.2 Introducing the ML4T Workflow
+### 1.2 Introducing the ML4T workflow
 
 This section presents the book's core framework: a research-to-production workflow built on point-in-time-correct data infrastructure, explicit scoping rules, iterative feature and model development, realistic strategy design, deployment discipline, and ongoing monitoring. The key value for readers is that it turns trading research into a managed lifecycle with auditable artifacts, clear handoffs, and an explicit boundary between exploration and confirmation.
 
-### 1.3 Causal Inference and Generative AI in the Workflow
+### 1.3 Causal inference and generative AI in the workflow
 
 This section places two modern method families inside the workflow rather than treating them as standalone trends. Causal inference is framed as a way to sharpen mechanisms, assumptions, and diagnosis; generative AI is framed as a way to expand research and unstructured-data processing while also creating new risks such as leakage, hallucination, and workflow bloat. Readers should care because the section makes clear that new tools increase the value of discipline rather than replacing it.
 
-### 1.4 Market Regimes: Change Is the Constant
+### 1.4 Keeping up with changing market regimes
 
 This section turns non-stationarity into something operational. It shows how regime concepts can support explanation, robustness checks, and live monitoring, while insisting that regimes are primarily a risk lens rather than a reliable timing signal. The factor and macro examples make the idea concrete: regime methods are useful when they help identify adverse environments and connect them to predefined risk actions.
 
 - [`factor_regimes`](factor_regimes.ipynb) — Demonstrates unsupervised learning for market regime detection using Gaussian Mixture Models (GMM) on factor returns from the AQR Century of Factor Premia dataset.
 - [`macro_regimes`](macro_regimes.ipynb) — Demonstrates unsupervised learning for market regime detection using macroeconomic indicators from FRED, validated against S&P 500 volatility and drawdowns.
 
-### 1.5 In the Real World: Independent vs. Institutional
+### 1.5 Independent versus institutional workflows in the real world
 
 This section translates the workflow into real operating contexts. It explains how institutions benefit from built-in friction and review, while independent researchers must create their own governance through documentation, checkpoints, and explicit stop criteria. The practical payoff is strong: it helps readers see where solo practitioners are vulnerable, where they can still compete, and how reusable infrastructure compounds research quality over time.
 

--- a/01_process_is_edge/factor_regimes.ipynb
+++ b/01_process_is_edge/factor_regimes.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "45ee9eb0",
+   "id": "c85dd30c",
    "metadata": {
     "papermill": {
-     "duration": 0.003734,
-     "end_time": "2026-09-08T23:58:55.728951+00:00",
+     "duration": 0.004692,
+     "end_time": "2026-09-09T00:01:03.360343+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:58:55.725217+00:00",
+     "start_time": "2026-09-09T00:01:03.355651+00:00",
      "status": "completed"
     }
    },
@@ -73,13 +73,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cc38958",
+   "id": "3e42b3e1",
    "metadata": {
     "papermill": {
-     "duration": 0.001935,
-     "end_time": "2026-09-08T23:58:55.733052+00:00",
+     "duration": 0.002266,
+     "end_time": "2026-09-09T00:01:03.365128+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:58:55.731117+00:00",
+     "start_time": "2026-09-09T00:01:03.362862+00:00",
      "status": "completed"
     }
    },
@@ -95,19 +95,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "e37c0758",
+   "id": "aa851939",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:58:55.738107Z",
-     "iopub.status.busy": "2026-09-08T23:58:55.737936Z",
-     "iopub.status.idle": "2026-09-08T23:59:00.095382Z",
-     "shell.execute_reply": "2026-09-08T23:59:00.094695Z"
+     "iopub.execute_input": "2026-09-09T00:01:03.369873Z",
+     "iopub.status.busy": "2026-09-09T00:01:03.369659Z",
+     "iopub.status.idle": "2026-09-09T00:01:07.062378Z",
+     "shell.execute_reply": "2026-09-09T00:01:07.061798Z"
     },
     "papermill": {
-     "duration": 4.360836,
-     "end_time": "2026-09-08T23:59:00.095918+00:00",
+     "duration": 3.695825,
+     "end_time": "2026-09-09T00:01:07.062823+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:58:55.735082+00:00",
+     "start_time": "2026-09-09T00:01:03.366998+00:00",
      "status": "completed"
     }
    },
@@ -149,19 +149,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ae1335f7",
+   "id": "9d3b0c5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:00.106220Z",
-     "iopub.status.busy": "2026-09-08T23:59:00.105992Z",
-     "iopub.status.idle": "2026-09-08T23:59:00.108838Z",
-     "shell.execute_reply": "2026-09-08T23:59:00.108139Z"
+     "iopub.execute_input": "2026-09-09T00:01:07.077272Z",
+     "iopub.status.busy": "2026-09-09T00:01:07.077146Z",
+     "iopub.status.idle": "2026-09-09T00:01:07.079212Z",
+     "shell.execute_reply": "2026-09-09T00:01:07.078775Z"
     },
     "papermill": {
-     "duration": 0.008032,
-     "end_time": "2026-09-08T23:59:00.109366+00:00",
+     "duration": 0.014607,
+     "end_time": "2026-09-09T00:01:07.079545+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.101334+00:00",
+     "start_time": "2026-09-09T00:01:07.064938+00:00",
      "status": "completed"
     },
     "tags": [
@@ -176,13 +176,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5b5c475",
+   "id": "3ec6b234",
    "metadata": {
     "papermill": {
-     "duration": 0.003838,
-     "end_time": "2026-09-08T23:59:00.117479+00:00",
+     "duration": 0.001776,
+     "end_time": "2026-09-09T00:01:07.083341+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.113641+00:00",
+     "start_time": "2026-09-09T00:01:07.081565+00:00",
      "status": "completed"
     }
    },
@@ -210,19 +210,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e2600c9e",
+   "id": "dae5e9c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:00.126967Z",
-     "iopub.status.busy": "2026-09-08T23:59:00.126768Z",
-     "iopub.status.idle": "2026-09-08T23:59:00.187298Z",
-     "shell.execute_reply": "2026-09-08T23:59:00.186744Z"
+     "iopub.execute_input": "2026-09-09T00:01:07.087573Z",
+     "iopub.status.busy": "2026-09-09T00:01:07.087481Z",
+     "iopub.status.idle": "2026-09-09T00:01:07.129367Z",
+     "shell.execute_reply": "2026-09-09T00:01:07.128682Z"
     },
     "papermill": {
-     "duration": 0.066301,
-     "end_time": "2026-09-08T23:59:00.187993+00:00",
+     "duration": 0.044575,
+     "end_time": "2026-09-09T00:01:07.129762+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.121692+00:00",
+     "start_time": "2026-09-09T00:01:07.085187+00:00",
      "status": "completed"
     }
    },
@@ -240,13 +240,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6e5e25a",
+   "id": "626a9d0e",
    "metadata": {
     "papermill": {
-     "duration": 0.001988,
-     "end_time": "2026-09-08T23:59:00.192899+00:00",
+     "duration": 0.001846,
+     "end_time": "2026-09-09T00:01:07.133690+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.190911+00:00",
+     "start_time": "2026-09-09T00:01:07.131844+00:00",
      "status": "completed"
     }
    },
@@ -261,19 +261,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "01629e90",
+   "id": "ad82720d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:00.197346Z",
-     "iopub.status.busy": "2026-09-08T23:59:00.197244Z",
-     "iopub.status.idle": "2026-09-08T23:59:00.229558Z",
-     "shell.execute_reply": "2026-09-08T23:59:00.229150Z"
+     "iopub.execute_input": "2026-09-09T00:01:07.138105Z",
+     "iopub.status.busy": "2026-09-09T00:01:07.138009Z",
+     "iopub.status.idle": "2026-09-09T00:01:07.169795Z",
+     "shell.execute_reply": "2026-09-09T00:01:07.169157Z"
     },
     "papermill": {
-     "duration": 0.035219,
-     "end_time": "2026-09-08T23:59:00.230029+00:00",
+     "duration": 0.034696,
+     "end_time": "2026-09-09T00:01:07.170246+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.194810+00:00",
+     "start_time": "2026-09-09T00:01:07.135550+00:00",
      "status": "completed"
     }
    },
@@ -299,13 +299,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6c003d8",
+   "id": "9b97e0d7",
    "metadata": {
     "papermill": {
-     "duration": 0.002053,
-     "end_time": "2026-09-08T23:59:00.234427+00:00",
+     "duration": 0.00197,
+     "end_time": "2026-09-09T00:01:07.174409+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.232374+00:00",
+     "start_time": "2026-09-09T00:01:07.172439+00:00",
      "status": "completed"
     }
    },
@@ -330,19 +330,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "b5f5e8db",
+   "id": "cebee7dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:00.239550Z",
-     "iopub.status.busy": "2026-09-08T23:59:00.239421Z",
-     "iopub.status.idle": "2026-09-08T23:59:00.241941Z",
-     "shell.execute_reply": "2026-09-08T23:59:00.241517Z"
+     "iopub.execute_input": "2026-09-09T00:01:07.179054Z",
+     "iopub.status.busy": "2026-09-09T00:01:07.178895Z",
+     "iopub.status.idle": "2026-09-09T00:01:07.182280Z",
+     "shell.execute_reply": "2026-09-09T00:01:07.181750Z"
     },
     "papermill": {
-     "duration": 0.005736,
-     "end_time": "2026-09-08T23:59:00.242281+00:00",
+     "duration": 0.006244,
+     "end_time": "2026-09-09T00:01:07.182577+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.236545+00:00",
+     "start_time": "2026-09-09T00:01:07.176333+00:00",
      "status": "completed"
     }
    },
@@ -361,6 +361,13 @@
     "]\n",
     "EQUITY_COLUMN = \"Equity indices Market\"\n",
     "\n",
+    "missing = [c for c in FACTOR_COLUMNS if c not in aqr_raw.columns]\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"The AQR file is missing {missing}. Re-fetch it with \"\n",
+    "        \"`uv run python data/factors/aqr_download.py`.\"\n",
+    "    )\n",
+    "\n",
     "# Short names for the figures and tables below; the full AQR column names do not fit on an\n",
     "# axis.\n",
     "SHORT_NAMES = {\n",
@@ -378,13 +385,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a16c2d62",
+   "id": "9d4472df",
    "metadata": {
     "papermill": {
-     "duration": 0.002034,
-     "end_time": "2026-09-08T23:59:00.246582+00:00",
+     "duration": 0.001837,
+     "end_time": "2026-09-09T00:01:07.186360+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.244548+00:00",
+     "start_time": "2026-09-09T00:01:07.184523+00:00",
      "status": "completed"
     }
    },
@@ -402,19 +409,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "0abe1a6f",
+   "id": "c1d0e7aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:00.251246Z",
-     "iopub.status.busy": "2026-09-08T23:59:00.251153Z",
-     "iopub.status.idle": "2026-09-08T23:59:00.273458Z",
-     "shell.execute_reply": "2026-09-08T23:59:00.272787Z"
+     "iopub.execute_input": "2026-09-09T00:01:07.191095Z",
+     "iopub.status.busy": "2026-09-09T00:01:07.190931Z",
+     "iopub.status.idle": "2026-09-09T00:01:07.228181Z",
+     "shell.execute_reply": "2026-09-09T00:01:07.227727Z"
     },
     "papermill": {
-     "duration": 0.025171,
-     "end_time": "2026-09-08T23:59:00.273850+00:00",
+     "duration": 0.04019,
+     "end_time": "2026-09-09T00:01:07.228467+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.248679+00:00",
+     "start_time": "2026-09-09T00:01:07.188277+00:00",
      "status": "completed"
     }
    },
@@ -424,14 +431,14 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_5a7f7\">\n",
+       "<table id=\"T_848b8\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_5a7f7_level0_col0\" class=\"col_heading level0 col0\" >First month</th>\n",
-       "      <th id=\"T_5a7f7_level0_col1\" class=\"col_heading level0 col1\" >Months quoted</th>\n",
-       "      <th id=\"T_5a7f7_level0_col2\" class=\"col_heading level0 col2\" >Mean (% / month)</th>\n",
-       "      <th id=\"T_5a7f7_level0_col3\" class=\"col_heading level0 col3\" >Std (% / month)</th>\n",
+       "      <th id=\"T_848b8_level0_col0\" class=\"col_heading level0 col0\" >First month</th>\n",
+       "      <th id=\"T_848b8_level0_col1\" class=\"col_heading level0 col1\" >Months quoted</th>\n",
+       "      <th id=\"T_848b8_level0_col2\" class=\"col_heading level0 col2\" >Mean (% / month)</th>\n",
+       "      <th id=\"T_848b8_level0_col3\" class=\"col_heading level0 col3\" >Std (% / month)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Series</th>\n",
@@ -443,73 +450,73 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_5a7f7_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
-       "      <td id=\"T_5a7f7_row0_col0\" class=\"data row0 col0\" >1926-07</td>\n",
-       "      <td id=\"T_5a7f7_row0_col1\" class=\"data row0 col1\" >1182</td>\n",
-       "      <td id=\"T_5a7f7_row0_col2\" class=\"data row0 col2\" >0.21</td>\n",
-       "      <td id=\"T_5a7f7_row0_col3\" class=\"data row0 col3\" >1.40</td>\n",
+       "      <th id=\"T_848b8_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
+       "      <td id=\"T_848b8_row0_col0\" class=\"data row0 col0\" >1926-07</td>\n",
+       "      <td id=\"T_848b8_row0_col1\" class=\"data row0 col1\" >1182</td>\n",
+       "      <td id=\"T_848b8_row0_col2\" class=\"data row0 col2\" >0.21</td>\n",
+       "      <td id=\"T_848b8_row0_col3\" class=\"data row0 col3\" >1.40</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_5a7f7_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
-       "      <td id=\"T_5a7f7_row1_col0\" class=\"data row1 col0\" >1926-07</td>\n",
-       "      <td id=\"T_5a7f7_row1_col1\" class=\"data row1 col1\" >1182</td>\n",
-       "      <td id=\"T_5a7f7_row1_col2\" class=\"data row1 col2\" >0.30</td>\n",
-       "      <td id=\"T_5a7f7_row1_col3\" class=\"data row1 col3\" >1.64</td>\n",
+       "      <th id=\"T_848b8_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
+       "      <td id=\"T_848b8_row1_col0\" class=\"data row1 col0\" >1926-07</td>\n",
+       "      <td id=\"T_848b8_row1_col1\" class=\"data row1 col1\" >1182</td>\n",
+       "      <td id=\"T_848b8_row1_col2\" class=\"data row1 col2\" >0.30</td>\n",
+       "      <td id=\"T_848b8_row1_col3\" class=\"data row1 col3\" >1.64</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_5a7f7_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
-       "      <td id=\"T_5a7f7_row2_col0\" class=\"data row2 col0\" >1926-07</td>\n",
-       "      <td id=\"T_5a7f7_row2_col1\" class=\"data row2 col1\" >1182</td>\n",
-       "      <td id=\"T_5a7f7_row2_col2\" class=\"data row2 col2\" >0.21</td>\n",
-       "      <td id=\"T_5a7f7_row2_col3\" class=\"data row2 col3\" >1.29</td>\n",
+       "      <th id=\"T_848b8_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
+       "      <td id=\"T_848b8_row2_col0\" class=\"data row2 col0\" >1926-07</td>\n",
+       "      <td id=\"T_848b8_row2_col1\" class=\"data row2 col1\" >1182</td>\n",
+       "      <td id=\"T_848b8_row2_col2\" class=\"data row2 col2\" >0.21</td>\n",
+       "      <td id=\"T_848b8_row2_col3\" class=\"data row2 col3\" >1.29</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_5a7f7_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
-       "      <td id=\"T_5a7f7_row3_col0\" class=\"data row3 col0\" >1926-07</td>\n",
-       "      <td id=\"T_5a7f7_row3_col1\" class=\"data row3 col1\" >1182</td>\n",
-       "      <td id=\"T_5a7f7_row3_col2\" class=\"data row3 col2\" >0.25</td>\n",
-       "      <td id=\"T_5a7f7_row3_col3\" class=\"data row3 col3\" >1.29</td>\n",
+       "      <th id=\"T_848b8_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
+       "      <td id=\"T_848b8_row3_col0\" class=\"data row3 col0\" >1926-07</td>\n",
+       "      <td id=\"T_848b8_row3_col1\" class=\"data row3 col1\" >1182</td>\n",
+       "      <td id=\"T_848b8_row3_col2\" class=\"data row3 col2\" >0.25</td>\n",
+       "      <td id=\"T_848b8_row3_col3\" class=\"data row3 col3\" >1.29</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_5a7f7_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
-       "      <td id=\"T_5a7f7_row4_col0\" class=\"data row4 col0\" >1926-07</td>\n",
-       "      <td id=\"T_5a7f7_row4_col1\" class=\"data row4 col1\" >1182</td>\n",
-       "      <td id=\"T_5a7f7_row4_col2\" class=\"data row4 col2\" >0.34</td>\n",
-       "      <td id=\"T_5a7f7_row4_col3\" class=\"data row4 col3\" >4.28</td>\n",
+       "      <th id=\"T_848b8_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
+       "      <td id=\"T_848b8_row4_col0\" class=\"data row4 col0\" >1926-07</td>\n",
+       "      <td id=\"T_848b8_row4_col1\" class=\"data row4 col1\" >1182</td>\n",
+       "      <td id=\"T_848b8_row4_col2\" class=\"data row4 col2\" >0.34</td>\n",
+       "      <td id=\"T_848b8_row4_col3\" class=\"data row4 col3\" >4.28</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_5a7f7_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
-       "      <td id=\"T_5a7f7_row5_col0\" class=\"data row5 col0\" >1927-01</td>\n",
-       "      <td id=\"T_5a7f7_row5_col1\" class=\"data row5 col1\" >1176</td>\n",
-       "      <td id=\"T_5a7f7_row5_col2\" class=\"data row5 col2\" >0.67</td>\n",
-       "      <td id=\"T_5a7f7_row5_col3\" class=\"data row5 col3\" >4.52</td>\n",
+       "      <th id=\"T_848b8_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
+       "      <td id=\"T_848b8_row5_col0\" class=\"data row5 col0\" >1927-01</td>\n",
+       "      <td id=\"T_848b8_row5_col1\" class=\"data row5 col1\" >1176</td>\n",
+       "      <td id=\"T_848b8_row5_col2\" class=\"data row5 col2\" >0.67</td>\n",
+       "      <td id=\"T_848b8_row5_col3\" class=\"data row5 col3\" >4.52</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_5a7f7_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
-       "      <td id=\"T_5a7f7_row6_col0\" class=\"data row6 col0\" >1926-07</td>\n",
-       "      <td id=\"T_5a7f7_row6_col1\" class=\"data row6 col1\" >1182</td>\n",
-       "      <td id=\"T_5a7f7_row6_col2\" class=\"data row6 col2\" >0.65</td>\n",
-       "      <td id=\"T_5a7f7_row6_col3\" class=\"data row6 col3\" >3.44</td>\n",
+       "      <th id=\"T_848b8_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
+       "      <td id=\"T_848b8_row6_col0\" class=\"data row6 col0\" >1926-07</td>\n",
+       "      <td id=\"T_848b8_row6_col1\" class=\"data row6 col1\" >1182</td>\n",
+       "      <td id=\"T_848b8_row6_col2\" class=\"data row6 col2\" >0.65</td>\n",
+       "      <td id=\"T_848b8_row6_col3\" class=\"data row6 col3\" >3.44</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_5a7f7_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
-       "      <td id=\"T_5a7f7_row7_col0\" class=\"data row7 col0\" >1926-07</td>\n",
-       "      <td id=\"T_5a7f7_row7_col1\" class=\"data row7 col1\" >1182</td>\n",
-       "      <td id=\"T_5a7f7_row7_col2\" class=\"data row7 col2\" >0.14</td>\n",
-       "      <td id=\"T_5a7f7_row7_col3\" class=\"data row7 col3\" >1.04</td>\n",
+       "      <th id=\"T_848b8_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
+       "      <td id=\"T_848b8_row7_col0\" class=\"data row7 col0\" >1926-07</td>\n",
+       "      <td id=\"T_848b8_row7_col1\" class=\"data row7 col1\" >1182</td>\n",
+       "      <td id=\"T_848b8_row7_col2\" class=\"data row7 col2\" >0.14</td>\n",
+       "      <td id=\"T_848b8_row7_col3\" class=\"data row7 col3\" >1.04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_5a7f7_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
-       "      <td id=\"T_5a7f7_row8_col0\" class=\"data row8 col0\" >1926-07</td>\n",
-       "      <td id=\"T_5a7f7_row8_col1\" class=\"data row8 col1\" >1182</td>\n",
-       "      <td id=\"T_5a7f7_row8_col2\" class=\"data row8 col2\" >0.41</td>\n",
-       "      <td id=\"T_5a7f7_row8_col3\" class=\"data row8 col3\" >4.59</td>\n",
+       "      <th id=\"T_848b8_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
+       "      <td id=\"T_848b8_row8_col0\" class=\"data row8 col0\" >1926-07</td>\n",
+       "      <td id=\"T_848b8_row8_col1\" class=\"data row8 col1\" >1182</td>\n",
+       "      <td id=\"T_848b8_row8_col2\" class=\"data row8 col2\" >0.41</td>\n",
+       "      <td id=\"T_848b8_row8_col3\" class=\"data row8 col3\" >4.59</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7213f4439a90>"
+       "<pandas.io.formats.style.Styler at 0x79a2b223da90>"
       ]
      },
      "execution_count": 6,
@@ -536,13 +543,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3389eb9a",
+   "id": "c57b274f",
    "metadata": {
     "papermill": {
-     "duration": 0.002653,
-     "end_time": "2026-09-08T23:59:00.279378+00:00",
+     "duration": 0.001961,
+     "end_time": "2026-09-09T00:01:07.232609+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.276725+00:00",
+     "start_time": "2026-09-09T00:01:07.230648+00:00",
      "status": "completed"
     }
    },
@@ -565,19 +572,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "6f2d1caf",
+   "id": "a48d6cc7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:00.285355Z",
-     "iopub.status.busy": "2026-09-08T23:59:00.285206Z",
-     "iopub.status.idle": "2026-09-08T23:59:00.302124Z",
-     "shell.execute_reply": "2026-09-08T23:59:00.301566Z"
+     "iopub.execute_input": "2026-09-09T00:01:07.237265Z",
+     "iopub.status.busy": "2026-09-09T00:01:07.237180Z",
+     "iopub.status.idle": "2026-09-09T00:01:07.243621Z",
+     "shell.execute_reply": "2026-09-09T00:01:07.243186Z"
     },
     "papermill": {
-     "duration": 0.020679,
-     "end_time": "2026-09-08T23:59:00.302673+00:00",
+     "duration": 0.009318,
+     "end_time": "2026-09-09T00:01:07.243889+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.281994+00:00",
+     "start_time": "2026-09-09T00:01:07.234571+00:00",
      "status": "completed"
     }
    },
@@ -591,13 +598,6 @@
     }
    ],
    "source": [
-    "missing = [c for c in FACTOR_COLUMNS if c not in aqr_raw.columns]\n",
-    "if missing:\n",
-    "    raise ValueError(\n",
-    "        f\"The AQR file is missing {missing}. Re-fetch it with \"\n",
-    "        \"`uv run python data/factors/aqr_download.py`.\"\n",
-    "    )\n",
-    "\n",
     "factors_pl = aqr_raw.select([\"timestamp\", *FACTOR_COLUMNS]).sort(\"timestamp\").drop_nulls()\n",
     "\n",
     "factors_df = factors_pl.select(FACTOR_COLUMNS).to_pandas()\n",
@@ -612,14 +612,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "056b8c47",
+   "id": "79fca424",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004066,
-     "end_time": "2026-09-08T23:59:00.311141+00:00",
+     "duration": 0.002014,
+     "end_time": "2026-09-09T00:01:07.248077+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.307075+00:00",
+     "start_time": "2026-09-09T00:01:07.246063+00:00",
      "status": "completed"
     }
    },
@@ -659,19 +659,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "d0fcde7e",
+   "id": "bc8201c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:00.320576Z",
-     "iopub.status.busy": "2026-09-08T23:59:00.320437Z",
-     "iopub.status.idle": "2026-09-08T23:59:00.323576Z",
-     "shell.execute_reply": "2026-09-08T23:59:00.323038Z"
+     "iopub.execute_input": "2026-09-09T00:01:07.252600Z",
+     "iopub.status.busy": "2026-09-09T00:01:07.252526Z",
+     "iopub.status.idle": "2026-09-09T00:01:07.255217Z",
+     "shell.execute_reply": "2026-09-09T00:01:07.254573Z"
     },
     "papermill": {
-     "duration": 0.008837,
-     "end_time": "2026-09-08T23:59:00.324180+00:00",
+     "duration": 0.005531,
+     "end_time": "2026-09-09T00:01:07.255608+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.315343+00:00",
+     "start_time": "2026-09-09T00:01:07.250077+00:00",
      "status": "completed"
     }
    },
@@ -692,19 +692,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "632cbae6",
+   "id": "5ec6cd94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:00.333345Z",
-     "iopub.status.busy": "2026-09-08T23:59:00.333183Z",
-     "iopub.status.idle": "2026-09-08T23:59:00.336695Z",
-     "shell.execute_reply": "2026-09-08T23:59:00.336233Z"
+     "iopub.execute_input": "2026-09-09T00:01:07.261339Z",
+     "iopub.status.busy": "2026-09-09T00:01:07.261206Z",
+     "iopub.status.idle": "2026-09-09T00:01:07.264534Z",
+     "shell.execute_reply": "2026-09-09T00:01:07.264050Z"
     },
     "papermill": {
-     "duration": 0.00867,
-     "end_time": "2026-09-08T23:59:00.337225+00:00",
+     "duration": 0.006305,
+     "end_time": "2026-09-09T00:01:07.264840+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.328555+00:00",
+     "start_time": "2026-09-09T00:01:07.258535+00:00",
      "status": "completed"
     }
    },
@@ -741,19 +741,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "b0343845",
+   "id": "90562314",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:00.345890Z",
-     "iopub.status.busy": "2026-09-08T23:59:00.345690Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.548930Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.548266Z"
+     "iopub.execute_input": "2026-09-09T00:01:07.269475Z",
+     "iopub.status.busy": "2026-09-09T00:01:07.269402Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.517304Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.516854Z"
     },
     "papermill": {
-     "duration": 2.209419,
-     "end_time": "2026-09-08T23:59:02.549385+00:00",
+     "duration": 1.250879,
+     "end_time": "2026-09-09T00:01:08.517773+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:00.339966+00:00",
+     "start_time": "2026-09-09T00:01:07.266894+00:00",
      "status": "completed"
     }
    },
@@ -763,16 +763,16 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_03bea\">\n",
+       "<table id=\"T_f49db\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_03bea_level0_col0\" class=\"col_heading level0 col0\" >BIC</th>\n",
-       "      <th id=\"T_03bea_level0_col1\" class=\"col_heading level0 col1\" >AIC</th>\n",
-       "      <th id=\"T_03bea_level0_col2\" class=\"col_heading level0 col2\" >Silhouette (mixture)</th>\n",
-       "      <th id=\"T_03bea_level0_col3\" class=\"col_heading level0 col3\" >Silhouette (k-means)</th>\n",
-       "      <th id=\"T_03bea_level0_col4\" class=\"col_heading level0 col4\" >Switches</th>\n",
-       "      <th id=\"T_03bea_level0_col5\" class=\"col_heading level0 col5\" >Smallest cluster (months)</th>\n",
+       "      <th id=\"T_f49db_level0_col0\" class=\"col_heading level0 col0\" >BIC</th>\n",
+       "      <th id=\"T_f49db_level0_col1\" class=\"col_heading level0 col1\" >AIC</th>\n",
+       "      <th id=\"T_f49db_level0_col2\" class=\"col_heading level0 col2\" >Silhouette (mixture)</th>\n",
+       "      <th id=\"T_f49db_level0_col3\" class=\"col_heading level0 col3\" >Silhouette (k-means)</th>\n",
+       "      <th id=\"T_f49db_level0_col4\" class=\"col_heading level0 col4\" >Switches</th>\n",
+       "      <th id=\"T_f49db_level0_col5\" class=\"col_heading level0 col5\" >Smallest cluster (months)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Clusters</th>\n",
@@ -786,55 +786,55 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_03bea_level0_row0\" class=\"row_heading level0 row0\" >2</th>\n",
-       "      <td id=\"T_03bea_row0_col0\" class=\"data row0 col0\" >26,170</td>\n",
-       "      <td id=\"T_03bea_row0_col1\" class=\"data row0 col1\" >25,617</td>\n",
-       "      <td id=\"T_03bea_row0_col2\" class=\"data row0 col2\" >0.270</td>\n",
-       "      <td id=\"T_03bea_row0_col3\" class=\"data row0 col3\" >0.234</td>\n",
-       "      <td id=\"T_03bea_row0_col4\" class=\"data row0 col4\" >267</td>\n",
-       "      <td id=\"T_03bea_row0_col5\" class=\"data row0 col5\" >276</td>\n",
+       "      <th id=\"T_f49db_level0_row0\" class=\"row_heading level0 row0\" >2</th>\n",
+       "      <td id=\"T_f49db_row0_col0\" class=\"data row0 col0\" >26,170</td>\n",
+       "      <td id=\"T_f49db_row0_col1\" class=\"data row0 col1\" >25,617</td>\n",
+       "      <td id=\"T_f49db_row0_col2\" class=\"data row0 col2\" >0.270</td>\n",
+       "      <td id=\"T_f49db_row0_col3\" class=\"data row0 col3\" >0.234</td>\n",
+       "      <td id=\"T_f49db_row0_col4\" class=\"data row0 col4\" >267</td>\n",
+       "      <td id=\"T_f49db_row0_col5\" class=\"data row0 col5\" >276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_03bea_level0_row1\" class=\"row_heading level0 row1\" >3</th>\n",
-       "      <td id=\"T_03bea_row1_col0\" class=\"data row1 col0\" >26,173</td>\n",
-       "      <td id=\"T_03bea_row1_col1\" class=\"data row1 col1\" >25,342</td>\n",
-       "      <td id=\"T_03bea_row1_col2\" class=\"data row1 col2\" >0.115</td>\n",
-       "      <td id=\"T_03bea_row1_col3\" class=\"data row1 col3\" >0.113</td>\n",
-       "      <td id=\"T_03bea_row1_col4\" class=\"data row1 col4\" >448</td>\n",
-       "      <td id=\"T_03bea_row1_col5\" class=\"data row1 col5\" >56</td>\n",
+       "      <th id=\"T_f49db_level0_row1\" class=\"row_heading level0 row1\" >3</th>\n",
+       "      <td id=\"T_f49db_row1_col0\" class=\"data row1 col0\" >26,173</td>\n",
+       "      <td id=\"T_f49db_row1_col1\" class=\"data row1 col1\" >25,342</td>\n",
+       "      <td id=\"T_f49db_row1_col2\" class=\"data row1 col2\" >0.115</td>\n",
+       "      <td id=\"T_f49db_row1_col3\" class=\"data row1 col3\" >0.113</td>\n",
+       "      <td id=\"T_f49db_row1_col4\" class=\"data row1 col4\" >448</td>\n",
+       "      <td id=\"T_f49db_row1_col5\" class=\"data row1 col5\" >56</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_03bea_level0_row2\" class=\"row_heading level0 row2\" >4</th>\n",
-       "      <td id=\"T_03bea_row2_col0\" class=\"data row2 col0\" >26,259</td>\n",
-       "      <td id=\"T_03bea_row2_col1\" class=\"data row2 col1\" >25,149</td>\n",
-       "      <td id=\"T_03bea_row2_col2\" class=\"data row2 col2\" >-0.024</td>\n",
-       "      <td id=\"T_03bea_row2_col3\" class=\"data row2 col3\" >0.096</td>\n",
-       "      <td id=\"T_03bea_row2_col4\" class=\"data row2 col4\" >577</td>\n",
-       "      <td id=\"T_03bea_row2_col5\" class=\"data row2 col5\" >3</td>\n",
+       "      <th id=\"T_f49db_level0_row2\" class=\"row_heading level0 row2\" >4</th>\n",
+       "      <td id=\"T_f49db_row2_col0\" class=\"data row2 col0\" >26,259</td>\n",
+       "      <td id=\"T_f49db_row2_col1\" class=\"data row2 col1\" >25,149</td>\n",
+       "      <td id=\"T_f49db_row2_col2\" class=\"data row2 col2\" >-0.024</td>\n",
+       "      <td id=\"T_f49db_row2_col3\" class=\"data row2 col3\" >0.096</td>\n",
+       "      <td id=\"T_f49db_row2_col4\" class=\"data row2 col4\" >577</td>\n",
+       "      <td id=\"T_f49db_row2_col5\" class=\"data row2 col5\" >3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_03bea_level0_row3\" class=\"row_heading level0 row3\" >5</th>\n",
-       "      <td id=\"T_03bea_row3_col0\" class=\"data row3 col0\" >26,388</td>\n",
-       "      <td id=\"T_03bea_row3_col1\" class=\"data row3 col1\" >24,998</td>\n",
-       "      <td id=\"T_03bea_row3_col2\" class=\"data row3 col2\" >0.006</td>\n",
-       "      <td id=\"T_03bea_row3_col3\" class=\"data row3 col3\" >0.087</td>\n",
-       "      <td id=\"T_03bea_row3_col4\" class=\"data row3 col4\" >600</td>\n",
-       "      <td id=\"T_03bea_row3_col5\" class=\"data row3 col5\" >8</td>\n",
+       "      <th id=\"T_f49db_level0_row3\" class=\"row_heading level0 row3\" >5</th>\n",
+       "      <td id=\"T_f49db_row3_col0\" class=\"data row3 col0\" >26,388</td>\n",
+       "      <td id=\"T_f49db_row3_col1\" class=\"data row3 col1\" >24,998</td>\n",
+       "      <td id=\"T_f49db_row3_col2\" class=\"data row3 col2\" >0.006</td>\n",
+       "      <td id=\"T_f49db_row3_col3\" class=\"data row3 col3\" >0.087</td>\n",
+       "      <td id=\"T_f49db_row3_col4\" class=\"data row3 col4\" >600</td>\n",
+       "      <td id=\"T_f49db_row3_col5\" class=\"data row3 col5\" >8</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_03bea_level0_row4\" class=\"row_heading level0 row4\" >6</th>\n",
-       "      <td id=\"T_03bea_row4_col0\" class=\"data row4 col0\" >26,598</td>\n",
-       "      <td id=\"T_03bea_row4_col1\" class=\"data row4 col1\" >24,930</td>\n",
-       "      <td id=\"T_03bea_row4_col2\" class=\"data row4 col2\" >0.003</td>\n",
-       "      <td id=\"T_03bea_row4_col3\" class=\"data row4 col3\" >0.077</td>\n",
-       "      <td id=\"T_03bea_row4_col4\" class=\"data row4 col4\" >654</td>\n",
-       "      <td id=\"T_03bea_row4_col5\" class=\"data row4 col5\" >3</td>\n",
+       "      <th id=\"T_f49db_level0_row4\" class=\"row_heading level0 row4\" >6</th>\n",
+       "      <td id=\"T_f49db_row4_col0\" class=\"data row4 col0\" >26,598</td>\n",
+       "      <td id=\"T_f49db_row4_col1\" class=\"data row4 col1\" >24,930</td>\n",
+       "      <td id=\"T_f49db_row4_col2\" class=\"data row4 col2\" >0.003</td>\n",
+       "      <td id=\"T_f49db_row4_col3\" class=\"data row4 col3\" >0.077</td>\n",
+       "      <td id=\"T_f49db_row4_col4\" class=\"data row4 col4\" >654</td>\n",
+       "      <td id=\"T_f49db_row4_col5\" class=\"data row4 col5\" >3</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7213e99311d0>"
+       "<pandas.io.formats.style.Styler at 0x79a2b0d45310>"
       ]
      },
      "execution_count": 10,
@@ -883,14 +883,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03222599",
+   "id": "c66c764a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002334,
-     "end_time": "2026-09-08T23:59:02.554258+00:00",
+     "duration": 0.003924,
+     "end_time": "2026-09-09T00:01:08.526155+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.551924+00:00",
+     "start_time": "2026-09-09T00:01:08.522231+00:00",
      "status": "completed"
     }
    },
@@ -906,19 +906,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "ba8b231b",
+   "id": "2244f84f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.560109Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.559934Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.563155Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.562575Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.534872Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.534760Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.537118Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.536684Z"
     },
     "papermill": {
-     "duration": 0.006814,
-     "end_time": "2026-09-08T23:59:02.563499+00:00",
+     "duration": 0.00745,
+     "end_time": "2026-09-09T00:01:08.537600+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.556685+00:00",
+     "start_time": "2026-09-09T00:01:08.530150+00:00",
      "status": "completed"
     }
    },
@@ -937,19 +937,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "651105ce",
+   "id": "e2a8a361",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.569064Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.568927Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.727703Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.727186Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.546961Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.546809Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.692211Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.691729Z"
     },
     "papermill": {
-     "duration": 0.162591,
-     "end_time": "2026-09-08T23:59:02.728553+00:00",
+     "duration": 0.150851,
+     "end_time": "2026-09-09T00:01:08.692826+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.565962+00:00",
+     "start_time": "2026-09-09T00:01:08.541975+00:00",
      "status": "completed"
     }
    },
@@ -997,19 +997,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "705c2649",
+   "id": "f6ca9692",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.740591Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.740473Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.744047Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.743519Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.702346Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.702189Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.705729Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.705287Z"
     },
     "papermill": {
-     "duration": 0.010303,
-     "end_time": "2026-09-08T23:59:02.744498+00:00",
+     "duration": 0.008835,
+     "end_time": "2026-09-09T00:01:08.706162+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.734195+00:00",
+     "start_time": "2026-09-09T00:01:08.697327+00:00",
      "status": "completed"
     }
    },
@@ -1042,13 +1042,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3a65282",
+   "id": "4f9b327c",
    "metadata": {
     "papermill": {
-     "duration": 0.004722,
-     "end_time": "2026-09-08T23:59:02.754199+00:00",
+     "duration": 0.003197,
+     "end_time": "2026-09-09T00:01:08.713811+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.749477+00:00",
+     "start_time": "2026-09-09T00:01:08.710614+00:00",
      "status": "completed"
     }
    },
@@ -1069,19 +1069,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "54a7388e",
+   "id": "dc95c1ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.764316Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.764194Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.766401Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.765815Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.719211Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.719046Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.721228Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.720761Z"
     },
     "papermill": {
-     "duration": 0.007989,
-     "end_time": "2026-09-08T23:59:02.766874+00:00",
+     "duration": 0.005449,
+     "end_time": "2026-09-09T00:01:08.721536+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.758885+00:00",
+     "start_time": "2026-09-09T00:01:08.716087+00:00",
      "status": "completed"
     }
    },
@@ -1092,14 +1092,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb516de4",
+   "id": "fa1688be",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004278,
-     "end_time": "2026-09-08T23:59:02.775742+00:00",
+     "duration": 0.002255,
+     "end_time": "2026-09-09T00:01:08.726124+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.771464+00:00",
+     "start_time": "2026-09-09T00:01:08.723869+00:00",
      "status": "completed"
     }
    },
@@ -1116,19 +1116,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "c4549e5b",
+   "id": "bcafe5f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.785609Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.785338Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.790233Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.788171Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.731858Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.731688Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.734519Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.734159Z"
     },
     "papermill": {
-     "duration": 0.010909,
-     "end_time": "2026-09-08T23:59:02.790965+00:00",
+     "duration": 0.006362,
+     "end_time": "2026-09-09T00:01:08.734906+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.780056+00:00",
+     "start_time": "2026-09-09T00:01:08.728544+00:00",
      "status": "completed"
     }
    },
@@ -1146,19 +1146,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "ee95faeb",
+   "id": "611f6461",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.797907Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.797787Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.800953Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.800405Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.740403Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.740297Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.743271Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.742577Z"
     },
     "papermill": {
-     "duration": 0.007102,
-     "end_time": "2026-09-08T23:59:02.801274+00:00",
+     "duration": 0.006324,
+     "end_time": "2026-09-09T00:01:08.743591+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.794172+00:00",
+     "start_time": "2026-09-09T00:01:08.737267+00:00",
      "status": "completed"
     }
    },
@@ -1185,19 +1185,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "7395dec2",
+   "id": "f5c6dea3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.807259Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.807117Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.948481Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.947767Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.749608Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.749497Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.862496Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.861929Z"
     },
     "papermill": {
-     "duration": 0.145038,
-     "end_time": "2026-09-08T23:59:02.948959+00:00",
+     "duration": 0.116658,
+     "end_time": "2026-09-09T00:01:08.862941+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.803921+00:00",
+     "start_time": "2026-09-09T00:01:08.746283+00:00",
      "status": "completed"
     }
    },
@@ -1251,13 +1251,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6198ebb",
+   "id": "91c01257",
    "metadata": {
     "papermill": {
-     "duration": 0.004958,
-     "end_time": "2026-09-08T23:59:02.958969+00:00",
+     "duration": 0.002643,
+     "end_time": "2026-09-09T00:01:08.870669+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.954011+00:00",
+     "start_time": "2026-09-09T00:01:08.868026+00:00",
      "status": "completed"
     }
    },
@@ -1273,13 +1273,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1f9ccf1",
+   "id": "8306dcc1",
    "metadata": {
     "papermill": {
-     "duration": 0.002987,
-     "end_time": "2026-09-08T23:59:02.965088+00:00",
+     "duration": 0.002365,
+     "end_time": "2026-09-09T00:01:08.875482+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.962101+00:00",
+     "start_time": "2026-09-09T00:01:08.873117+00:00",
      "status": "completed"
     }
    },
@@ -1302,19 +1302,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "e6cd75b6",
+   "id": "caf1bedd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.971651Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.971528Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.976099Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.975381Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.881289Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.881118Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.884156Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.883822Z"
     },
     "papermill": {
-     "duration": 0.008751,
-     "end_time": "2026-09-08T23:59:02.976666+00:00",
+     "duration": 0.006636,
+     "end_time": "2026-09-09T00:01:08.884509+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.967915+00:00",
+     "start_time": "2026-09-09T00:01:08.877873+00:00",
      "status": "completed"
     }
    },
@@ -1336,13 +1336,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8aedf42",
+   "id": "39e25eb2",
    "metadata": {
     "papermill": {
-     "duration": 0.002819,
-     "end_time": "2026-09-08T23:59:02.982581+00:00",
+     "duration": 0.002365,
+     "end_time": "2026-09-09T00:01:08.889411+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.979762+00:00",
+     "start_time": "2026-09-09T00:01:08.887046+00:00",
      "status": "completed"
     }
    },
@@ -1360,19 +1360,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "89dba545",
+   "id": "c183606b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.988700Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.988570Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.990796Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.990422Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.895271Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.895162Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.897128Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.896775Z"
     },
     "papermill": {
-     "duration": 0.005854,
-     "end_time": "2026-09-08T23:59:02.991117+00:00",
+     "duration": 0.005389,
+     "end_time": "2026-09-09T00:01:08.897364+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.985263+00:00",
+     "start_time": "2026-09-09T00:01:08.891975+00:00",
      "status": "completed"
     }
    },
@@ -1392,19 +1392,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "29416e7e",
+   "id": "10ddbaaa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:02.997066Z",
-     "iopub.status.busy": "2026-09-08T23:59:02.996956Z",
-     "iopub.status.idle": "2026-09-08T23:59:02.999704Z",
-     "shell.execute_reply": "2026-09-08T23:59:02.999321Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.902942Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.902858Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.905333Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.904976Z"
     },
     "papermill": {
-     "duration": 0.006224,
-     "end_time": "2026-09-08T23:59:03.000055+00:00",
+     "duration": 0.005838,
+     "end_time": "2026-09-09T00:01:08.905605+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:02.993831+00:00",
+     "start_time": "2026-09-09T00:01:08.899767+00:00",
      "status": "completed"
     }
    },
@@ -1430,19 +1430,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "df3cd222",
+   "id": "fef6c61a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.006376Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.006261Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.009489Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.008904Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.911596Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.911455Z",
+     "iopub.status.idle": "2026-09-09T00:01:08.914824Z",
+     "shell.execute_reply": "2026-09-09T00:01:08.914349Z"
     },
     "papermill": {
-     "duration": 0.00707,
-     "end_time": "2026-09-08T23:59:03.009877+00:00",
+     "duration": 0.006831,
+     "end_time": "2026-09-09T00:01:08.915128+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.002807+00:00",
+     "start_time": "2026-09-09T00:01:08.908297+00:00",
      "status": "completed"
     }
    },
@@ -1470,19 +1470,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "8b0e2505",
+   "id": "4e4a0cf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.016460Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.016350Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.225281Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.224668Z"
+     "iopub.execute_input": "2026-09-09T00:01:08.920976Z",
+     "iopub.status.busy": "2026-09-09T00:01:08.920842Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.114294Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.113855Z"
     },
     "papermill": {
-     "duration": 0.212934,
-     "end_time": "2026-09-08T23:59:03.225775+00:00",
+     "duration": 0.197021,
+     "end_time": "2026-09-09T00:01:09.114822+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.012841+00:00",
+     "start_time": "2026-09-09T00:01:08.917801+00:00",
      "status": "completed"
     }
    },
@@ -1539,13 +1539,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bccdc34",
+   "id": "091f58b9",
    "metadata": {
     "papermill": {
-     "duration": 0.003057,
-     "end_time": "2026-09-08T23:59:03.232070+00:00",
+     "duration": 0.004943,
+     "end_time": "2026-09-09T00:01:09.125010+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.229013+00:00",
+     "start_time": "2026-09-09T00:01:09.120067+00:00",
      "status": "completed"
     }
    },
@@ -1563,19 +1563,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "e99086b7",
+   "id": "236a853d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.239847Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.239716Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.245867Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.245489Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.135767Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.135667Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.141598Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.141156Z"
     },
     "papermill": {
-     "duration": 0.011453,
-     "end_time": "2026-09-08T23:59:03.246600+00:00",
+     "duration": 0.012186,
+     "end_time": "2026-09-09T00:01:09.142167+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.235147+00:00",
+     "start_time": "2026-09-09T00:01:09.129981+00:00",
      "status": "completed"
     }
    },
@@ -1585,13 +1585,13 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_29ed4\">\n",
+       "<table id=\"T_6b50b\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_29ed4_level0_col0\" class=\"col_heading level0 col0\" >Mean (%)</th>\n",
-       "      <th id=\"T_29ed4_level0_col1\" class=\"col_heading level0 col1\" >Median (%)</th>\n",
-       "      <th id=\"T_29ed4_level0_col2\" class=\"col_heading level0 col2\" >Max (%)</th>\n",
+       "      <th id=\"T_6b50b_level0_col0\" class=\"col_heading level0 col0\" >Mean (%)</th>\n",
+       "      <th id=\"T_6b50b_level0_col1\" class=\"col_heading level0 col1\" >Median (%)</th>\n",
+       "      <th id=\"T_6b50b_level0_col2\" class=\"col_heading level0 col2\" >Max (%)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Regime</th>\n",
@@ -1602,22 +1602,22 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_29ed4_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
-       "      <td id=\"T_29ed4_row0_col0\" class=\"data row0 col0\" >9.8</td>\n",
-       "      <td id=\"T_29ed4_row0_col1\" class=\"data row0 col1\" >8.7</td>\n",
-       "      <td id=\"T_29ed4_row0_col2\" class=\"data row0 col2\" >29.7</td>\n",
+       "      <th id=\"T_6b50b_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
+       "      <td id=\"T_6b50b_row0_col0\" class=\"data row0 col0\" >9.8</td>\n",
+       "      <td id=\"T_6b50b_row0_col1\" class=\"data row0 col1\" >8.7</td>\n",
+       "      <td id=\"T_6b50b_row0_col2\" class=\"data row0 col2\" >29.7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_29ed4_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
-       "      <td id=\"T_29ed4_row1_col0\" class=\"data row1 col0\" >12.7</td>\n",
-       "      <td id=\"T_29ed4_row1_col1\" class=\"data row1 col1\" >10.9</td>\n",
-       "      <td id=\"T_29ed4_row1_col2\" class=\"data row1 col2\" >31.8</td>\n",
+       "      <th id=\"T_6b50b_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
+       "      <td id=\"T_6b50b_row1_col0\" class=\"data row1 col0\" >12.7</td>\n",
+       "      <td id=\"T_6b50b_row1_col1\" class=\"data row1 col1\" >10.9</td>\n",
+       "      <td id=\"T_6b50b_row1_col2\" class=\"data row1 col2\" >31.8</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x72139c745810>"
+       "<pandas.io.formats.style.Styler at 0x79a294139950>"
       ]
      },
      "execution_count": 23,
@@ -1642,19 +1642,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "445aa4f2",
+   "id": "f7cae97f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.254283Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.254147Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.385265Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.384910Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.153529Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.153375Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.255152Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.254685Z"
     },
     "papermill": {
-     "duration": 0.135953,
-     "end_time": "2026-09-08T23:59:03.385871+00:00",
+     "duration": 0.108155,
+     "end_time": "2026-09-09T00:01:09.255870+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.249918+00:00",
+     "start_time": "2026-09-09T00:01:09.147715+00:00",
      "status": "completed"
     }
    },
@@ -1716,13 +1716,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa0da915",
+   "id": "e07764e7",
    "metadata": {
     "papermill": {
-     "duration": 0.003368,
-     "end_time": "2026-09-08T23:59:03.394592+00:00",
+     "duration": 0.005446,
+     "end_time": "2026-09-09T00:01:09.267459+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.391224+00:00",
+     "start_time": "2026-09-09T00:01:09.262013+00:00",
      "status": "completed"
     }
    },
@@ -1738,19 +1738,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "07ea1937",
+   "id": "0fcdecac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.401822Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.401678Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.405766Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.405307Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.280118Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.279945Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.284420Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.283978Z"
     },
     "papermill": {
-     "duration": 0.008198,
-     "end_time": "2026-09-08T23:59:03.406150+00:00",
+     "duration": 0.011406,
+     "end_time": "2026-09-09T00:01:09.284827+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.397952+00:00",
+     "start_time": "2026-09-09T00:01:09.273421+00:00",
      "status": "completed"
     }
    },
@@ -1773,13 +1773,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35cbc18d",
+   "id": "0b49b7ee",
    "metadata": {
     "papermill": {
-     "duration": 0.003884,
-     "end_time": "2026-09-08T23:59:03.414708+00:00",
+     "duration": 0.004595,
+     "end_time": "2026-09-09T00:01:09.295395+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.410824+00:00",
+     "start_time": "2026-09-09T00:01:09.290800+00:00",
      "status": "completed"
     }
    },
@@ -1800,19 +1800,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "6b6d2950",
+   "id": "c1dba5df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.423666Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.423481Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.428666Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.428165Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.301853Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.301698Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.306631Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.306060Z"
     },
     "papermill": {
-     "duration": 0.010406,
-     "end_time": "2026-09-08T23:59:03.429015+00:00",
+     "duration": 0.00878,
+     "end_time": "2026-09-09T00:01:09.306976+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.418609+00:00",
+     "start_time": "2026-09-09T00:01:09.298196+00:00",
      "status": "completed"
     }
    },
@@ -1826,19 +1826,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "fe08037f",
+   "id": "0314baf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.436427Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.436297Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.515820Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.515247Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.313548Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.313400Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.386896Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.386577Z"
     },
     "papermill": {
-     "duration": 0.084329,
-     "end_time": "2026-09-08T23:59:03.516717+00:00",
+     "duration": 0.077345,
+     "end_time": "2026-09-09T00:01:09.387302+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.432388+00:00",
+     "start_time": "2026-09-09T00:01:09.309957+00:00",
      "status": "completed"
     }
    },
@@ -1900,19 +1900,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "e69487b7",
+   "id": "e4ad734a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.525171Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.524996Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.533716Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.529522Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.394127Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.394042Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.397762Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.397351Z"
     },
     "papermill": {
-     "duration": 0.013956,
-     "end_time": "2026-09-08T23:59:03.534253+00:00",
+     "duration": 0.007451,
+     "end_time": "2026-09-09T00:01:09.398014+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.520297+00:00",
+     "start_time": "2026-09-09T00:01:09.390563+00:00",
      "status": "completed"
     }
    },
@@ -1922,65 +1922,65 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_ae135\">\n",
+       "<table id=\"T_bd7ae\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >regime</th>\n",
-       "      <th id=\"T_ae135_level0_col0\" class=\"col_heading level0 col0\" >Risk-on</th>\n",
-       "      <th id=\"T_ae135_level0_col1\" class=\"col_heading level0 col1\" >Risk-off</th>\n",
+       "      <th id=\"T_bd7ae_level0_col0\" class=\"col_heading level0 col0\" >Risk-on</th>\n",
+       "      <th id=\"T_bd7ae_level0_col1\" class=\"col_heading level0 col1\" >Risk-off</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_ae135_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
-       "      <td id=\"T_ae135_row0_col0\" class=\"data row0 col0\" >+1.6</td>\n",
-       "      <td id=\"T_ae135_row0_col1\" class=\"data row0 col1\" >+5.3</td>\n",
+       "      <th id=\"T_bd7ae_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
+       "      <td id=\"T_bd7ae_row0_col0\" class=\"data row0 col0\" >+1.6</td>\n",
+       "      <td id=\"T_bd7ae_row0_col1\" class=\"data row0 col1\" >+5.3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ae135_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
-       "      <td id=\"T_ae135_row1_col0\" class=\"data row1 col0\" >+4.5</td>\n",
-       "      <td id=\"T_ae135_row1_col1\" class=\"data row1 col1\" >+0.4</td>\n",
+       "      <th id=\"T_bd7ae_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
+       "      <td id=\"T_bd7ae_row1_col0\" class=\"data row1 col0\" >+4.5</td>\n",
+       "      <td id=\"T_bd7ae_row1_col1\" class=\"data row1 col1\" >+0.4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ae135_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
-       "      <td id=\"T_ae135_row2_col0\" class=\"data row2 col0\" >+3.5</td>\n",
-       "      <td id=\"T_ae135_row2_col1\" class=\"data row2 col1\" >-0.6</td>\n",
+       "      <th id=\"T_bd7ae_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
+       "      <td id=\"T_bd7ae_row2_col0\" class=\"data row2 col0\" >+3.5</td>\n",
+       "      <td id=\"T_bd7ae_row2_col1\" class=\"data row2 col1\" >-0.6</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ae135_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
-       "      <td id=\"T_ae135_row3_col0\" class=\"data row3 col0\" >+4.2</td>\n",
-       "      <td id=\"T_ae135_row3_col1\" class=\"data row3 col1\" >-0.5</td>\n",
+       "      <th id=\"T_bd7ae_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
+       "      <td id=\"T_bd7ae_row3_col0\" class=\"data row3 col0\" >+4.2</td>\n",
+       "      <td id=\"T_bd7ae_row3_col1\" class=\"data row3 col1\" >-0.5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ae135_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
-       "      <td id=\"T_ae135_row4_col0\" class=\"data row4 col0\" >-1.0</td>\n",
-       "      <td id=\"T_ae135_row4_col1\" class=\"data row4 col1\" >+20.6</td>\n",
+       "      <th id=\"T_bd7ae_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
+       "      <td id=\"T_bd7ae_row4_col0\" class=\"data row4 col0\" >-1.0</td>\n",
+       "      <td id=\"T_bd7ae_row4_col1\" class=\"data row4 col1\" >+20.6</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ae135_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
-       "      <td id=\"T_ae135_row5_col0\" class=\"data row5 col0\" >+10.7</td>\n",
-       "      <td id=\"T_ae135_row5_col1\" class=\"data row5 col1\" >-0.7</td>\n",
+       "      <th id=\"T_bd7ae_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
+       "      <td id=\"T_bd7ae_row5_col0\" class=\"data row5 col0\" >+10.7</td>\n",
+       "      <td id=\"T_bd7ae_row5_col1\" class=\"data row5 col1\" >-0.7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ae135_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
-       "      <td id=\"T_ae135_row6_col0\" class=\"data row6 col0\" >+9.5</td>\n",
-       "      <td id=\"T_ae135_row6_col1\" class=\"data row6 col1\" >+2.2</td>\n",
+       "      <th id=\"T_bd7ae_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
+       "      <td id=\"T_bd7ae_row6_col0\" class=\"data row6 col0\" >+9.5</td>\n",
+       "      <td id=\"T_bd7ae_row6_col1\" class=\"data row6 col1\" >+2.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ae135_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
-       "      <td id=\"T_ae135_row7_col0\" class=\"data row7 col0\" >+0.8</td>\n",
-       "      <td id=\"T_ae135_row7_col1\" class=\"data row7 col1\" >+4.2</td>\n",
+       "      <th id=\"T_bd7ae_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
+       "      <td id=\"T_bd7ae_row7_col0\" class=\"data row7 col0\" >+0.8</td>\n",
+       "      <td id=\"T_bd7ae_row7_col1\" class=\"data row7 col1\" >+4.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ae135_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
-       "      <td id=\"T_ae135_row8_col0\" class=\"data row8 col0\" >+4.0</td>\n",
-       "      <td id=\"T_ae135_row8_col1\" class=\"data row8 col1\" >+8.5</td>\n",
+       "      <th id=\"T_bd7ae_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
+       "      <td id=\"T_bd7ae_row8_col0\" class=\"data row8 col0\" >+4.0</td>\n",
+       "      <td id=\"T_bd7ae_row8_col1\" class=\"data row8 col1\" >+8.5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x72139c681950>"
+       "<pandas.io.formats.style.Styler at 0x79a29407da90>"
       ]
      },
      "execution_count": 28,
@@ -1994,13 +1994,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d872c363",
+   "id": "a5774000",
    "metadata": {
     "papermill": {
-     "duration": 0.006263,
-     "end_time": "2026-09-08T23:59:03.546033+00:00",
+     "duration": 0.002912,
+     "end_time": "2026-09-09T00:01:09.404038+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.539770+00:00",
+     "start_time": "2026-09-09T00:01:09.401126+00:00",
      "status": "completed"
     }
    },
@@ -2017,14 +2017,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df1c6f5d",
+   "id": "67a5005d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.0058,
-     "end_time": "2026-09-08T23:59:03.557694+00:00",
+     "duration": 0.003598,
+     "end_time": "2026-09-09T00:01:09.411036+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.551894+00:00",
+     "start_time": "2026-09-09T00:01:09.407438+00:00",
      "status": "completed"
     }
    },
@@ -2048,19 +2048,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "23283eab",
+   "id": "ff70b6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.569426Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.569282Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.571443Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.571107Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.421495Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.421286Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.423603Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.423150Z"
     },
     "papermill": {
-     "duration": 0.008979,
-     "end_time": "2026-09-08T23:59:03.571903+00:00",
+     "duration": 0.007883,
+     "end_time": "2026-09-09T00:01:09.424040+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.562924+00:00",
+     "start_time": "2026-09-09T00:01:09.416157+00:00",
      "status": "completed"
     }
    },
@@ -2075,19 +2075,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "e652af6f",
+   "id": "3352f5bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.579894Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.579788Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.586626Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.585836Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.437417Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.437309Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.443655Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.443232Z"
     },
     "papermill": {
-     "duration": 0.011476,
-     "end_time": "2026-09-08T23:59:03.587110+00:00",
+     "duration": 0.013643,
+     "end_time": "2026-09-09T00:01:09.444143+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.575634+00:00",
+     "start_time": "2026-09-09T00:01:09.430500+00:00",
      "status": "completed"
     }
    },
@@ -2097,16 +2097,16 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_04ef8\">\n",
+       "<table id=\"T_1c574\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_04ef8_level0_col0\" class=\"col_heading level0 col0\" >Months</th>\n",
-       "      <th id=\"T_04ef8_level0_col1\" class=\"col_heading level0 col1\" >Share of sample</th>\n",
-       "      <th id=\"T_04ef8_level0_col2\" class=\"col_heading level0 col2\" >Return, annualized</th>\n",
-       "      <th id=\"T_04ef8_level0_col3\" class=\"col_heading level0 col3\" >Volatility, annualized</th>\n",
-       "      <th id=\"T_04ef8_level0_col4\" class=\"col_heading level0 col4\" >Sharpe ratio</th>\n",
-       "      <th id=\"T_04ef8_level0_col5\" class=\"col_heading level0 col5\" >Max drawdown</th>\n",
+       "      <th id=\"T_1c574_level0_col0\" class=\"col_heading level0 col0\" >Months</th>\n",
+       "      <th id=\"T_1c574_level0_col1\" class=\"col_heading level0 col1\" >Share of sample</th>\n",
+       "      <th id=\"T_1c574_level0_col2\" class=\"col_heading level0 col2\" >Return, annualized</th>\n",
+       "      <th id=\"T_1c574_level0_col3\" class=\"col_heading level0 col3\" >Volatility, annualized</th>\n",
+       "      <th id=\"T_1c574_level0_col4\" class=\"col_heading level0 col4\" >Sharpe ratio</th>\n",
+       "      <th id=\"T_1c574_level0_col5\" class=\"col_heading level0 col5\" >Max drawdown</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Regime</th>\n",
@@ -2120,28 +2120,28 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_04ef8_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
-       "      <td id=\"T_04ef8_row0_col0\" class=\"data row0 col0\" >900</td>\n",
-       "      <td id=\"T_04ef8_row0_col1\" class=\"data row0 col1\" >76.5%</td>\n",
-       "      <td id=\"T_04ef8_row0_col2\" class=\"data row0 col2\" >+9.5%</td>\n",
-       "      <td id=\"T_04ef8_row0_col3\" class=\"data row0 col3\" >8.6%</td>\n",
-       "      <td id=\"T_04ef8_row0_col4\" class=\"data row0 col4\" >1.11</td>\n",
-       "      <td id=\"T_04ef8_row0_col5\" class=\"data row0 col5\" >-22.9%</td>\n",
+       "      <th id=\"T_1c574_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
+       "      <td id=\"T_1c574_row0_col0\" class=\"data row0 col0\" >900</td>\n",
+       "      <td id=\"T_1c574_row0_col1\" class=\"data row0 col1\" >76.5%</td>\n",
+       "      <td id=\"T_1c574_row0_col2\" class=\"data row0 col2\" >+9.5%</td>\n",
+       "      <td id=\"T_1c574_row0_col3\" class=\"data row0 col3\" >8.6%</td>\n",
+       "      <td id=\"T_1c574_row0_col4\" class=\"data row0 col4\" >1.11</td>\n",
+       "      <td id=\"T_1c574_row0_col5\" class=\"data row0 col5\" >-22.9%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_04ef8_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
-       "      <td id=\"T_04ef8_row1_col0\" class=\"data row1 col0\" >276</td>\n",
-       "      <td id=\"T_04ef8_row1_col1\" class=\"data row1 col1\" >23.5%</td>\n",
-       "      <td id=\"T_04ef8_row1_col2\" class=\"data row1 col2\" >+2.2%</td>\n",
-       "      <td id=\"T_04ef8_row1_col3\" class=\"data row1 col3\" >19.1%</td>\n",
-       "      <td id=\"T_04ef8_row1_col4\" class=\"data row1 col4\" >0.12</td>\n",
-       "      <td id=\"T_04ef8_row1_col5\" class=\"data row1 col5\" >-76.9%</td>\n",
+       "      <th id=\"T_1c574_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
+       "      <td id=\"T_1c574_row1_col0\" class=\"data row1 col0\" >276</td>\n",
+       "      <td id=\"T_1c574_row1_col1\" class=\"data row1 col1\" >23.5%</td>\n",
+       "      <td id=\"T_1c574_row1_col2\" class=\"data row1 col2\" >+2.2%</td>\n",
+       "      <td id=\"T_1c574_row1_col3\" class=\"data row1 col3\" >19.1%</td>\n",
+       "      <td id=\"T_1c574_row1_col4\" class=\"data row1 col4\" >0.12</td>\n",
+       "      <td id=\"T_1c574_row1_col5\" class=\"data row1 col5\" >-76.9%</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x72139c52a210>"
+       "<pandas.io.formats.style.Styler at 0x79a25f52a350>"
       ]
      },
      "execution_count": 30,
@@ -2180,19 +2180,19 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "c0c848db",
+   "id": "c4107539",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.596342Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.596210Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.599445Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.599028Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.452913Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.452818Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.456201Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.455613Z"
     },
     "papermill": {
-     "duration": 0.00833,
-     "end_time": "2026-09-08T23:59:03.599919+00:00",
+     "duration": 0.007585,
+     "end_time": "2026-09-09T00:01:09.456527+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.591589+00:00",
+     "start_time": "2026-09-09T00:01:09.448942+00:00",
      "status": "completed"
     }
    },
@@ -2230,13 +2230,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e196745",
+   "id": "5f93e852",
    "metadata": {
     "papermill": {
-     "duration": 0.004043,
-     "end_time": "2026-09-08T23:59:03.608458+00:00",
+     "duration": 0.003386,
+     "end_time": "2026-09-09T00:01:09.463550+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.604415+00:00",
+     "start_time": "2026-09-09T00:01:09.460164+00:00",
      "status": "completed"
     }
    },
@@ -2252,13 +2252,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "368f5d66",
+   "id": "a150ad9d",
    "metadata": {
     "papermill": {
-     "duration": 0.003384,
-     "end_time": "2026-09-08T23:59:03.615523+00:00",
+     "duration": 0.003055,
+     "end_time": "2026-09-09T00:01:09.469851+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.612139+00:00",
+     "start_time": "2026-09-09T00:01:09.466796+00:00",
      "status": "completed"
     }
    },
@@ -2274,19 +2274,19 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "e95ecf3d",
+   "id": "50b73dc7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.623300Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.623173Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.627814Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.627363Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.476981Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.476809Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.483073Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.482520Z"
     },
     "papermill": {
-     "duration": 0.009114,
-     "end_time": "2026-09-08T23:59:03.628176+00:00",
+     "duration": 0.010665,
+     "end_time": "2026-09-09T00:01:09.483512+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.619062+00:00",
+     "start_time": "2026-09-09T00:01:09.472847+00:00",
      "status": "completed"
     }
    },
@@ -2327,13 +2327,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b77e73f",
+   "id": "58799ac8",
    "metadata": {
     "papermill": {
-     "duration": 0.003371,
-     "end_time": "2026-09-08T23:59:03.635129+00:00",
+     "duration": 0.003147,
+     "end_time": "2026-09-09T00:01:09.490024+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.631758+00:00",
+     "start_time": "2026-09-09T00:01:09.486877+00:00",
      "status": "completed"
     }
    },
@@ -2358,13 +2358,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bb5a30e",
+   "id": "84b99ae2",
    "metadata": {
     "papermill": {
-     "duration": 0.005385,
-     "end_time": "2026-09-08T23:59:03.644250+00:00",
+     "duration": 0.003227,
+     "end_time": "2026-09-09T00:01:09.496793+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.638865+00:00",
+     "start_time": "2026-09-09T00:01:09.493566+00:00",
      "status": "completed"
     }
    },
@@ -2379,19 +2379,19 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "044423ba",
+   "id": "4f78c6c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.655529Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.655368Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.665850Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.665279Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.503974Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.503814Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.513194Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.512627Z"
     },
     "papermill": {
-     "duration": 0.015973,
-     "end_time": "2026-09-08T23:59:03.666184+00:00",
+     "duration": 0.013665,
+     "end_time": "2026-09-09T00:01:09.513615+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.650211+00:00",
+     "start_time": "2026-09-09T00:01:09.499950+00:00",
      "status": "completed"
     }
    },
@@ -2401,13 +2401,13 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_69a8d\">\n",
+       "<table id=\"T_84552\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_69a8d_level0_col0\" class=\"col_heading level0 col0\" >Mean length (months)</th>\n",
-       "      <th id=\"T_69a8d_level0_col1\" class=\"col_heading level0 col1\" >Longest (months)</th>\n",
-       "      <th id=\"T_69a8d_level0_col2\" class=\"col_heading level0 col2\" >Episodes</th>\n",
+       "      <th id=\"T_84552_level0_col0\" class=\"col_heading level0 col0\" >Mean length (months)</th>\n",
+       "      <th id=\"T_84552_level0_col1\" class=\"col_heading level0 col1\" >Longest (months)</th>\n",
+       "      <th id=\"T_84552_level0_col2\" class=\"col_heading level0 col2\" >Episodes</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Regime</th>\n",
@@ -2418,22 +2418,22 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_69a8d_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
-       "      <td id=\"T_69a8d_row0_col0\" class=\"data row0 col0\" >6.7</td>\n",
-       "      <td id=\"T_69a8d_row0_col1\" class=\"data row0 col1\" >110</td>\n",
-       "      <td id=\"T_69a8d_row0_col2\" class=\"data row0 col2\" >134</td>\n",
+       "      <th id=\"T_84552_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
+       "      <td id=\"T_84552_row0_col0\" class=\"data row0 col0\" >6.7</td>\n",
+       "      <td id=\"T_84552_row0_col1\" class=\"data row0 col1\" >110</td>\n",
+       "      <td id=\"T_84552_row0_col2\" class=\"data row0 col2\" >134</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_69a8d_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
-       "      <td id=\"T_69a8d_row1_col0\" class=\"data row1 col0\" >2.1</td>\n",
-       "      <td id=\"T_69a8d_row1_col1\" class=\"data row1 col1\" >14</td>\n",
-       "      <td id=\"T_69a8d_row1_col2\" class=\"data row1 col2\" >134</td>\n",
+       "      <th id=\"T_84552_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
+       "      <td id=\"T_84552_row1_col0\" class=\"data row1 col0\" >2.1</td>\n",
+       "      <td id=\"T_84552_row1_col1\" class=\"data row1 col1\" >14</td>\n",
+       "      <td id=\"T_84552_row1_col2\" class=\"data row1 col2\" >134</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x72139c52a710>"
+       "<pandas.io.formats.style.Styler at 0x79a25f52a850>"
       ]
      },
      "execution_count": 33,
@@ -2466,19 +2466,19 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "7effafcd",
+   "id": "bc5406a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:59:03.675175Z",
-     "iopub.status.busy": "2026-09-08T23:59:03.675006Z",
-     "iopub.status.idle": "2026-09-08T23:59:03.678621Z",
-     "shell.execute_reply": "2026-09-08T23:59:03.678026Z"
+     "iopub.execute_input": "2026-09-09T00:01:09.520983Z",
+     "iopub.status.busy": "2026-09-09T00:01:09.520846Z",
+     "iopub.status.idle": "2026-09-09T00:01:09.524182Z",
+     "shell.execute_reply": "2026-09-09T00:01:09.523680Z"
     },
     "papermill": {
-     "duration": 0.008925,
-     "end_time": "2026-09-08T23:59:03.678979+00:00",
+     "duration": 0.00755,
+     "end_time": "2026-09-09T00:01:09.524571+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.670054+00:00",
+     "start_time": "2026-09-09T00:01:09.517021+00:00",
      "status": "completed"
     }
    },
@@ -2510,13 +2510,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e8eaa05",
+   "id": "615a4f6b",
    "metadata": {
     "papermill": {
-     "duration": 0.003702,
-     "end_time": "2026-09-08T23:59:03.686530+00:00",
+     "duration": 0.003127,
+     "end_time": "2026-09-09T00:01:09.530960+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.682828+00:00",
+     "start_time": "2026-09-09T00:01:09.527833+00:00",
      "status": "completed"
     }
    },
@@ -2537,13 +2537,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10d4304f",
+   "id": "dd0b6562",
    "metadata": {
     "papermill": {
-     "duration": 0.003988,
-     "end_time": "2026-09-08T23:59:03.694430+00:00",
+     "duration": 0.003102,
+     "end_time": "2026-09-09T00:01:09.537287+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:59:03.690442+00:00",
+     "start_time": "2026-09-09T00:01:09.534185+00:00",
      "status": "completed"
     }
    },
@@ -2601,24 +2601,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-08T23:59:12.451578+00:00",
+   "executed_at": "2026-09-09T00:01:17.067444+00:00",
    "executor": "local-uv",
    "library_digest": "5c6cff9e7067767cd11d73fec3dd7f1c5b8a9af5570ee2ea53c7dfce7b154c8e",
-   "outputs_digest": "2df849f783db13254bb6e6f93d8e88e453be44ae443f55374b24cab456f75d6a",
+   "outputs_digest": "6f6b4fe34cfacdfbd21ac3df400095fbf56cada8e9dbb0f1403a9f1689557b39",
    "parameters": {},
    "production": true,
-   "source_py_blob": "43cef12adfc02b251c6d2bd026baa9621284b016"
+   "source_py_blob": "af95af13ebe9d1904ddba66146519231db87ffbc"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 11.135133,
-   "end_time": "2026-09-08T23:59:06.212022+00:00",
+   "duration": 9.132075,
+   "end_time": "2026-09-09T00:01:11.842795+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.build.2404169.ipynb",
-   "output_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.papermill.2404169.ipynb",
+   "input_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.build.2425616.ipynb",
+   "output_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.papermill.2425616.ipynb",
    "parameters": {},
-   "start_time": "2026-09-08T23:58:55.076889+00:00",
+   "start_time": "2026-09-09T00:01:02.710720+00:00",
    "version": "2.7.0"
   }
  },

--- a/01_process_is_edge/factor_regimes.ipynb
+++ b/01_process_is_edge/factor_regimes.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "db620c71",
+   "id": "45ee9eb0",
    "metadata": {
     "papermill": {
-     "duration": 0.012001,
-     "end_time": "2026-09-08T23:43:31.984305+00:00",
+     "duration": 0.003734,
+     "end_time": "2026-09-08T23:58:55.728951+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:31.972304+00:00",
+     "start_time": "2026-09-08T23:58:55.725217+00:00",
      "status": "completed"
     }
    },
@@ -73,13 +73,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c86b0a64",
+   "id": "5cc38958",
    "metadata": {
     "papermill": {
-     "duration": 0.004157,
-     "end_time": "2026-09-08T23:43:31.992974+00:00",
+     "duration": 0.001935,
+     "end_time": "2026-09-08T23:58:55.733052+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:31.988817+00:00",
+     "start_time": "2026-09-08T23:58:55.731117+00:00",
      "status": "completed"
     }
    },
@@ -95,19 +95,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "60ea80a3",
+   "id": "e37c0758",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:32.001887Z",
-     "iopub.status.busy": "2026-09-08T23:43:32.001750Z",
-     "iopub.status.idle": "2026-09-08T23:43:44.823896Z",
-     "shell.execute_reply": "2026-09-08T23:43:44.823426Z"
+     "iopub.execute_input": "2026-09-08T23:58:55.738107Z",
+     "iopub.status.busy": "2026-09-08T23:58:55.737936Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.095382Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.094695Z"
     },
     "papermill": {
-     "duration": 12.832898,
-     "end_time": "2026-09-08T23:43:44.829833+00:00",
+     "duration": 4.360836,
+     "end_time": "2026-09-08T23:59:00.095918+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:31.996935+00:00",
+     "start_time": "2026-09-08T23:58:55.735082+00:00",
      "status": "completed"
     }
    },
@@ -149,19 +149,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "3718e1cb",
+   "id": "ae1335f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:44.849990Z",
-     "iopub.status.busy": "2026-09-08T23:43:44.849672Z",
-     "iopub.status.idle": "2026-09-08T23:43:44.855265Z",
-     "shell.execute_reply": "2026-09-08T23:43:44.854485Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.106220Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.105992Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.108838Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.108139Z"
     },
     "papermill": {
-     "duration": 0.017832,
-     "end_time": "2026-09-08T23:43:44.857536+00:00",
+     "duration": 0.008032,
+     "end_time": "2026-09-08T23:59:00.109366+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:44.839704+00:00",
+     "start_time": "2026-09-08T23:59:00.101334+00:00",
      "status": "completed"
     },
     "tags": [
@@ -176,13 +176,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c109fc9",
+   "id": "f5b5c475",
    "metadata": {
     "papermill": {
-     "duration": 0.002431,
-     "end_time": "2026-09-08T23:43:44.866060+00:00",
+     "duration": 0.003838,
+     "end_time": "2026-09-08T23:59:00.117479+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:44.863629+00:00",
+     "start_time": "2026-09-08T23:59:00.113641+00:00",
      "status": "completed"
     }
    },
@@ -210,19 +210,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b7bd8687",
+   "id": "e2600c9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:44.880970Z",
-     "iopub.status.busy": "2026-09-08T23:43:44.880650Z",
-     "iopub.status.idle": "2026-09-08T23:43:44.906585Z",
-     "shell.execute_reply": "2026-09-08T23:43:44.904886Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.126967Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.126768Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.187298Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.186744Z"
     },
     "papermill": {
-     "duration": 0.031674,
-     "end_time": "2026-09-08T23:43:44.907010+00:00",
+     "duration": 0.066301,
+     "end_time": "2026-09-08T23:59:00.187993+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:44.875336+00:00",
+     "start_time": "2026-09-08T23:59:00.121692+00:00",
      "status": "completed"
     }
    },
@@ -240,13 +240,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a36ecf1",
+   "id": "c6e5e25a",
    "metadata": {
     "papermill": {
-     "duration": 0.002497,
-     "end_time": "2026-09-08T23:43:44.912344+00:00",
+     "duration": 0.001988,
+     "end_time": "2026-09-08T23:59:00.192899+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:44.909847+00:00",
+     "start_time": "2026-09-08T23:59:00.190911+00:00",
      "status": "completed"
     }
    },
@@ -261,19 +261,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "55cb0fa4",
+   "id": "01629e90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:44.919915Z",
-     "iopub.status.busy": "2026-09-08T23:43:44.919798Z",
-     "iopub.status.idle": "2026-09-08T23:43:45.030309Z",
-     "shell.execute_reply": "2026-09-08T23:43:45.029464Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.197346Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.197244Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.229558Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.229150Z"
     },
     "papermill": {
-     "duration": 0.115222,
-     "end_time": "2026-09-08T23:43:45.030749+00:00",
+     "duration": 0.035219,
+     "end_time": "2026-09-08T23:59:00.230029+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:44.915527+00:00",
+     "start_time": "2026-09-08T23:59:00.194810+00:00",
      "status": "completed"
     }
    },
@@ -299,13 +299,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f93d179e",
+   "id": "a6c003d8",
    "metadata": {
     "papermill": {
-     "duration": 0.00484,
-     "end_time": "2026-09-08T23:43:45.042707+00:00",
+     "duration": 0.002053,
+     "end_time": "2026-09-08T23:59:00.234427+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.037867+00:00",
+     "start_time": "2026-09-08T23:59:00.232374+00:00",
      "status": "completed"
     }
    },
@@ -330,19 +330,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "2957af9d",
+   "id": "b5f5e8db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:45.067223Z",
-     "iopub.status.busy": "2026-09-08T23:43:45.067072Z",
-     "iopub.status.idle": "2026-09-08T23:43:45.075675Z",
-     "shell.execute_reply": "2026-09-08T23:43:45.074994Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.239550Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.239421Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.241941Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.241517Z"
     },
     "papermill": {
-     "duration": 0.02487,
-     "end_time": "2026-09-08T23:43:45.076090+00:00",
+     "duration": 0.005736,
+     "end_time": "2026-09-08T23:59:00.242281+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.051220+00:00",
+     "start_time": "2026-09-08T23:59:00.236545+00:00",
      "status": "completed"
     }
    },
@@ -378,13 +378,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08d93b4c",
+   "id": "a16c2d62",
    "metadata": {
     "papermill": {
-     "duration": 0.002743,
-     "end_time": "2026-09-08T23:43:45.087495+00:00",
+     "duration": 0.002034,
+     "end_time": "2026-09-08T23:59:00.246582+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.084752+00:00",
+     "start_time": "2026-09-08T23:59:00.244548+00:00",
      "status": "completed"
     }
    },
@@ -402,19 +402,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "aad7d75f",
+   "id": "0abe1a6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:45.106740Z",
-     "iopub.status.busy": "2026-09-08T23:43:45.106249Z",
-     "iopub.status.idle": "2026-09-08T23:43:45.228251Z",
-     "shell.execute_reply": "2026-09-08T23:43:45.227860Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.251246Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.251153Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.273458Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.272787Z"
     },
     "papermill": {
-     "duration": 0.1344,
-     "end_time": "2026-09-08T23:43:45.231764+00:00",
+     "duration": 0.025171,
+     "end_time": "2026-09-08T23:59:00.273850+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.097364+00:00",
+     "start_time": "2026-09-08T23:59:00.248679+00:00",
      "status": "completed"
     }
    },
@@ -424,14 +424,14 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_9bb58\">\n",
+       "<table id=\"T_5a7f7\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_9bb58_level0_col0\" class=\"col_heading level0 col0\" >First month</th>\n",
-       "      <th id=\"T_9bb58_level0_col1\" class=\"col_heading level0 col1\" >Months quoted</th>\n",
-       "      <th id=\"T_9bb58_level0_col2\" class=\"col_heading level0 col2\" >Mean (% / month)</th>\n",
-       "      <th id=\"T_9bb58_level0_col3\" class=\"col_heading level0 col3\" >Std (% / month)</th>\n",
+       "      <th id=\"T_5a7f7_level0_col0\" class=\"col_heading level0 col0\" >First month</th>\n",
+       "      <th id=\"T_5a7f7_level0_col1\" class=\"col_heading level0 col1\" >Months quoted</th>\n",
+       "      <th id=\"T_5a7f7_level0_col2\" class=\"col_heading level0 col2\" >Mean (% / month)</th>\n",
+       "      <th id=\"T_5a7f7_level0_col3\" class=\"col_heading level0 col3\" >Std (% / month)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Series</th>\n",
@@ -443,73 +443,73 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_9bb58_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
-       "      <td id=\"T_9bb58_row0_col0\" class=\"data row0 col0\" >1926-07</td>\n",
-       "      <td id=\"T_9bb58_row0_col1\" class=\"data row0 col1\" >1182</td>\n",
-       "      <td id=\"T_9bb58_row0_col2\" class=\"data row0 col2\" >0.21</td>\n",
-       "      <td id=\"T_9bb58_row0_col3\" class=\"data row0 col3\" >1.40</td>\n",
+       "      <th id=\"T_5a7f7_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
+       "      <td id=\"T_5a7f7_row0_col0\" class=\"data row0 col0\" >1926-07</td>\n",
+       "      <td id=\"T_5a7f7_row0_col1\" class=\"data row0 col1\" >1182</td>\n",
+       "      <td id=\"T_5a7f7_row0_col2\" class=\"data row0 col2\" >0.21</td>\n",
+       "      <td id=\"T_5a7f7_row0_col3\" class=\"data row0 col3\" >1.40</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9bb58_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
-       "      <td id=\"T_9bb58_row1_col0\" class=\"data row1 col0\" >1926-07</td>\n",
-       "      <td id=\"T_9bb58_row1_col1\" class=\"data row1 col1\" >1182</td>\n",
-       "      <td id=\"T_9bb58_row1_col2\" class=\"data row1 col2\" >0.30</td>\n",
-       "      <td id=\"T_9bb58_row1_col3\" class=\"data row1 col3\" >1.64</td>\n",
+       "      <th id=\"T_5a7f7_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
+       "      <td id=\"T_5a7f7_row1_col0\" class=\"data row1 col0\" >1926-07</td>\n",
+       "      <td id=\"T_5a7f7_row1_col1\" class=\"data row1 col1\" >1182</td>\n",
+       "      <td id=\"T_5a7f7_row1_col2\" class=\"data row1 col2\" >0.30</td>\n",
+       "      <td id=\"T_5a7f7_row1_col3\" class=\"data row1 col3\" >1.64</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9bb58_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
-       "      <td id=\"T_9bb58_row2_col0\" class=\"data row2 col0\" >1926-07</td>\n",
-       "      <td id=\"T_9bb58_row2_col1\" class=\"data row2 col1\" >1182</td>\n",
-       "      <td id=\"T_9bb58_row2_col2\" class=\"data row2 col2\" >0.21</td>\n",
-       "      <td id=\"T_9bb58_row2_col3\" class=\"data row2 col3\" >1.29</td>\n",
+       "      <th id=\"T_5a7f7_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
+       "      <td id=\"T_5a7f7_row2_col0\" class=\"data row2 col0\" >1926-07</td>\n",
+       "      <td id=\"T_5a7f7_row2_col1\" class=\"data row2 col1\" >1182</td>\n",
+       "      <td id=\"T_5a7f7_row2_col2\" class=\"data row2 col2\" >0.21</td>\n",
+       "      <td id=\"T_5a7f7_row2_col3\" class=\"data row2 col3\" >1.29</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9bb58_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
-       "      <td id=\"T_9bb58_row3_col0\" class=\"data row3 col0\" >1926-07</td>\n",
-       "      <td id=\"T_9bb58_row3_col1\" class=\"data row3 col1\" >1182</td>\n",
-       "      <td id=\"T_9bb58_row3_col2\" class=\"data row3 col2\" >0.25</td>\n",
-       "      <td id=\"T_9bb58_row3_col3\" class=\"data row3 col3\" >1.29</td>\n",
+       "      <th id=\"T_5a7f7_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
+       "      <td id=\"T_5a7f7_row3_col0\" class=\"data row3 col0\" >1926-07</td>\n",
+       "      <td id=\"T_5a7f7_row3_col1\" class=\"data row3 col1\" >1182</td>\n",
+       "      <td id=\"T_5a7f7_row3_col2\" class=\"data row3 col2\" >0.25</td>\n",
+       "      <td id=\"T_5a7f7_row3_col3\" class=\"data row3 col3\" >1.29</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9bb58_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
-       "      <td id=\"T_9bb58_row4_col0\" class=\"data row4 col0\" >1926-07</td>\n",
-       "      <td id=\"T_9bb58_row4_col1\" class=\"data row4 col1\" >1182</td>\n",
-       "      <td id=\"T_9bb58_row4_col2\" class=\"data row4 col2\" >0.34</td>\n",
-       "      <td id=\"T_9bb58_row4_col3\" class=\"data row4 col3\" >4.28</td>\n",
+       "      <th id=\"T_5a7f7_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
+       "      <td id=\"T_5a7f7_row4_col0\" class=\"data row4 col0\" >1926-07</td>\n",
+       "      <td id=\"T_5a7f7_row4_col1\" class=\"data row4 col1\" >1182</td>\n",
+       "      <td id=\"T_5a7f7_row4_col2\" class=\"data row4 col2\" >0.34</td>\n",
+       "      <td id=\"T_5a7f7_row4_col3\" class=\"data row4 col3\" >4.28</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9bb58_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
-       "      <td id=\"T_9bb58_row5_col0\" class=\"data row5 col0\" >1927-01</td>\n",
-       "      <td id=\"T_9bb58_row5_col1\" class=\"data row5 col1\" >1176</td>\n",
-       "      <td id=\"T_9bb58_row5_col2\" class=\"data row5 col2\" >0.67</td>\n",
-       "      <td id=\"T_9bb58_row5_col3\" class=\"data row5 col3\" >4.52</td>\n",
+       "      <th id=\"T_5a7f7_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
+       "      <td id=\"T_5a7f7_row5_col0\" class=\"data row5 col0\" >1927-01</td>\n",
+       "      <td id=\"T_5a7f7_row5_col1\" class=\"data row5 col1\" >1176</td>\n",
+       "      <td id=\"T_5a7f7_row5_col2\" class=\"data row5 col2\" >0.67</td>\n",
+       "      <td id=\"T_5a7f7_row5_col3\" class=\"data row5 col3\" >4.52</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9bb58_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
-       "      <td id=\"T_9bb58_row6_col0\" class=\"data row6 col0\" >1926-07</td>\n",
-       "      <td id=\"T_9bb58_row6_col1\" class=\"data row6 col1\" >1182</td>\n",
-       "      <td id=\"T_9bb58_row6_col2\" class=\"data row6 col2\" >0.65</td>\n",
-       "      <td id=\"T_9bb58_row6_col3\" class=\"data row6 col3\" >3.44</td>\n",
+       "      <th id=\"T_5a7f7_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
+       "      <td id=\"T_5a7f7_row6_col0\" class=\"data row6 col0\" >1926-07</td>\n",
+       "      <td id=\"T_5a7f7_row6_col1\" class=\"data row6 col1\" >1182</td>\n",
+       "      <td id=\"T_5a7f7_row6_col2\" class=\"data row6 col2\" >0.65</td>\n",
+       "      <td id=\"T_5a7f7_row6_col3\" class=\"data row6 col3\" >3.44</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9bb58_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
-       "      <td id=\"T_9bb58_row7_col0\" class=\"data row7 col0\" >1926-07</td>\n",
-       "      <td id=\"T_9bb58_row7_col1\" class=\"data row7 col1\" >1182</td>\n",
-       "      <td id=\"T_9bb58_row7_col2\" class=\"data row7 col2\" >0.14</td>\n",
-       "      <td id=\"T_9bb58_row7_col3\" class=\"data row7 col3\" >1.04</td>\n",
+       "      <th id=\"T_5a7f7_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
+       "      <td id=\"T_5a7f7_row7_col0\" class=\"data row7 col0\" >1926-07</td>\n",
+       "      <td id=\"T_5a7f7_row7_col1\" class=\"data row7 col1\" >1182</td>\n",
+       "      <td id=\"T_5a7f7_row7_col2\" class=\"data row7 col2\" >0.14</td>\n",
+       "      <td id=\"T_5a7f7_row7_col3\" class=\"data row7 col3\" >1.04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9bb58_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
-       "      <td id=\"T_9bb58_row8_col0\" class=\"data row8 col0\" >1926-07</td>\n",
-       "      <td id=\"T_9bb58_row8_col1\" class=\"data row8 col1\" >1182</td>\n",
-       "      <td id=\"T_9bb58_row8_col2\" class=\"data row8 col2\" >0.41</td>\n",
-       "      <td id=\"T_9bb58_row8_col3\" class=\"data row8 col3\" >4.59</td>\n",
+       "      <th id=\"T_5a7f7_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
+       "      <td id=\"T_5a7f7_row8_col0\" class=\"data row8 col0\" >1926-07</td>\n",
+       "      <td id=\"T_5a7f7_row8_col1\" class=\"data row8 col1\" >1182</td>\n",
+       "      <td id=\"T_5a7f7_row8_col2\" class=\"data row8 col2\" >0.41</td>\n",
+       "      <td id=\"T_5a7f7_row8_col3\" class=\"data row8 col3\" >4.59</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7d287172da90>"
+       "<pandas.io.formats.style.Styler at 0x7213f4439a90>"
       ]
      },
      "execution_count": 6,
@@ -536,13 +536,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39a4ad5c",
+   "id": "3389eb9a",
    "metadata": {
     "papermill": {
-     "duration": 0.006438,
-     "end_time": "2026-09-08T23:43:45.244893+00:00",
+     "duration": 0.002653,
+     "end_time": "2026-09-08T23:59:00.279378+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.238455+00:00",
+     "start_time": "2026-09-08T23:59:00.276725+00:00",
      "status": "completed"
     }
    },
@@ -565,19 +565,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "135d87ff",
+   "id": "6f2d1caf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:45.258346Z",
-     "iopub.status.busy": "2026-09-08T23:43:45.258213Z",
-     "iopub.status.idle": "2026-09-08T23:43:45.291083Z",
-     "shell.execute_reply": "2026-09-08T23:43:45.289222Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.285355Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.285206Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.302124Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.301566Z"
     },
     "papermill": {
-     "duration": 0.040919,
-     "end_time": "2026-09-08T23:43:45.291869+00:00",
+     "duration": 0.020679,
+     "end_time": "2026-09-08T23:59:00.302673+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.250950+00:00",
+     "start_time": "2026-09-08T23:59:00.281994+00:00",
      "status": "completed"
     }
    },
@@ -591,6 +591,13 @@
     }
    ],
    "source": [
+    "missing = [c for c in FACTOR_COLUMNS if c not in aqr_raw.columns]\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"The AQR file is missing {missing}. Re-fetch it with \"\n",
+    "        \"`uv run python data/factors/aqr_download.py`.\"\n",
+    "    )\n",
+    "\n",
     "factors_pl = aqr_raw.select([\"timestamp\", *FACTOR_COLUMNS]).sort(\"timestamp\").drop_nulls()\n",
     "\n",
     "factors_df = factors_pl.select(FACTOR_COLUMNS).to_pandas()\n",
@@ -605,14 +612,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc0eacb2",
+   "id": "056b8c47",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006164,
-     "end_time": "2026-09-08T23:43:45.304538+00:00",
+     "duration": 0.004066,
+     "end_time": "2026-09-08T23:59:00.311141+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.298374+00:00",
+     "start_time": "2026-09-08T23:59:00.307075+00:00",
      "status": "completed"
     }
    },
@@ -652,19 +659,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "aef3b604",
+   "id": "d0fcde7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:45.320092Z",
-     "iopub.status.busy": "2026-09-08T23:43:45.319964Z",
-     "iopub.status.idle": "2026-09-08T23:43:45.324986Z",
-     "shell.execute_reply": "2026-09-08T23:43:45.324543Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.320576Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.320437Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.323576Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.323038Z"
     },
     "papermill": {
-     "duration": 0.014495,
-     "end_time": "2026-09-08T23:43:45.327851+00:00",
+     "duration": 0.008837,
+     "end_time": "2026-09-08T23:59:00.324180+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.313356+00:00",
+     "start_time": "2026-09-08T23:59:00.315343+00:00",
      "status": "completed"
     }
    },
@@ -685,19 +692,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "7bedcd52",
+   "id": "632cbae6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:45.356404Z",
-     "iopub.status.busy": "2026-09-08T23:43:45.356208Z",
-     "iopub.status.idle": "2026-09-08T23:43:45.364436Z",
-     "shell.execute_reply": "2026-09-08T23:43:45.363938Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.333345Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.333183Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.336695Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.336233Z"
     },
     "papermill": {
-     "duration": 0.027312,
-     "end_time": "2026-09-08T23:43:45.364965+00:00",
+     "duration": 0.00867,
+     "end_time": "2026-09-08T23:59:00.337225+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.337653+00:00",
+     "start_time": "2026-09-08T23:59:00.328555+00:00",
      "status": "completed"
     }
    },
@@ -734,19 +741,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "0cded4ba",
+   "id": "b0343845",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:45.394676Z",
-     "iopub.status.busy": "2026-09-08T23:43:45.394520Z",
-     "iopub.status.idle": "2026-09-08T23:45:11.883223Z",
-     "shell.execute_reply": "2026-09-08T23:45:11.882079Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.345890Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.345690Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.548930Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.548266Z"
     },
     "papermill": {
-     "duration": 86.499425,
-     "end_time": "2026-09-08T23:45:11.883730+00:00",
+     "duration": 2.209419,
+     "end_time": "2026-09-08T23:59:02.549385+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:45.384305+00:00",
+     "start_time": "2026-09-08T23:59:00.339966+00:00",
      "status": "completed"
     }
    },
@@ -756,16 +763,16 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_a9750\">\n",
+       "<table id=\"T_03bea\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_a9750_level0_col0\" class=\"col_heading level0 col0\" >BIC</th>\n",
-       "      <th id=\"T_a9750_level0_col1\" class=\"col_heading level0 col1\" >AIC</th>\n",
-       "      <th id=\"T_a9750_level0_col2\" class=\"col_heading level0 col2\" >Silhouette (mixture)</th>\n",
-       "      <th id=\"T_a9750_level0_col3\" class=\"col_heading level0 col3\" >Silhouette (k-means)</th>\n",
-       "      <th id=\"T_a9750_level0_col4\" class=\"col_heading level0 col4\" >Switches</th>\n",
-       "      <th id=\"T_a9750_level0_col5\" class=\"col_heading level0 col5\" >Smallest cluster (months)</th>\n",
+       "      <th id=\"T_03bea_level0_col0\" class=\"col_heading level0 col0\" >BIC</th>\n",
+       "      <th id=\"T_03bea_level0_col1\" class=\"col_heading level0 col1\" >AIC</th>\n",
+       "      <th id=\"T_03bea_level0_col2\" class=\"col_heading level0 col2\" >Silhouette (mixture)</th>\n",
+       "      <th id=\"T_03bea_level0_col3\" class=\"col_heading level0 col3\" >Silhouette (k-means)</th>\n",
+       "      <th id=\"T_03bea_level0_col4\" class=\"col_heading level0 col4\" >Switches</th>\n",
+       "      <th id=\"T_03bea_level0_col5\" class=\"col_heading level0 col5\" >Smallest cluster (months)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Clusters</th>\n",
@@ -779,55 +786,55 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_a9750_level0_row0\" class=\"row_heading level0 row0\" >2</th>\n",
-       "      <td id=\"T_a9750_row0_col0\" class=\"data row0 col0\" >26,170</td>\n",
-       "      <td id=\"T_a9750_row0_col1\" class=\"data row0 col1\" >25,617</td>\n",
-       "      <td id=\"T_a9750_row0_col2\" class=\"data row0 col2\" >0.270</td>\n",
-       "      <td id=\"T_a9750_row0_col3\" class=\"data row0 col3\" >0.234</td>\n",
-       "      <td id=\"T_a9750_row0_col4\" class=\"data row0 col4\" >267</td>\n",
-       "      <td id=\"T_a9750_row0_col5\" class=\"data row0 col5\" >276</td>\n",
+       "      <th id=\"T_03bea_level0_row0\" class=\"row_heading level0 row0\" >2</th>\n",
+       "      <td id=\"T_03bea_row0_col0\" class=\"data row0 col0\" >26,170</td>\n",
+       "      <td id=\"T_03bea_row0_col1\" class=\"data row0 col1\" >25,617</td>\n",
+       "      <td id=\"T_03bea_row0_col2\" class=\"data row0 col2\" >0.270</td>\n",
+       "      <td id=\"T_03bea_row0_col3\" class=\"data row0 col3\" >0.234</td>\n",
+       "      <td id=\"T_03bea_row0_col4\" class=\"data row0 col4\" >267</td>\n",
+       "      <td id=\"T_03bea_row0_col5\" class=\"data row0 col5\" >276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_a9750_level0_row1\" class=\"row_heading level0 row1\" >3</th>\n",
-       "      <td id=\"T_a9750_row1_col0\" class=\"data row1 col0\" >26,173</td>\n",
-       "      <td id=\"T_a9750_row1_col1\" class=\"data row1 col1\" >25,342</td>\n",
-       "      <td id=\"T_a9750_row1_col2\" class=\"data row1 col2\" >0.115</td>\n",
-       "      <td id=\"T_a9750_row1_col3\" class=\"data row1 col3\" >0.113</td>\n",
-       "      <td id=\"T_a9750_row1_col4\" class=\"data row1 col4\" >448</td>\n",
-       "      <td id=\"T_a9750_row1_col5\" class=\"data row1 col5\" >56</td>\n",
+       "      <th id=\"T_03bea_level0_row1\" class=\"row_heading level0 row1\" >3</th>\n",
+       "      <td id=\"T_03bea_row1_col0\" class=\"data row1 col0\" >26,173</td>\n",
+       "      <td id=\"T_03bea_row1_col1\" class=\"data row1 col1\" >25,342</td>\n",
+       "      <td id=\"T_03bea_row1_col2\" class=\"data row1 col2\" >0.115</td>\n",
+       "      <td id=\"T_03bea_row1_col3\" class=\"data row1 col3\" >0.113</td>\n",
+       "      <td id=\"T_03bea_row1_col4\" class=\"data row1 col4\" >448</td>\n",
+       "      <td id=\"T_03bea_row1_col5\" class=\"data row1 col5\" >56</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_a9750_level0_row2\" class=\"row_heading level0 row2\" >4</th>\n",
-       "      <td id=\"T_a9750_row2_col0\" class=\"data row2 col0\" >26,259</td>\n",
-       "      <td id=\"T_a9750_row2_col1\" class=\"data row2 col1\" >25,149</td>\n",
-       "      <td id=\"T_a9750_row2_col2\" class=\"data row2 col2\" >-0.024</td>\n",
-       "      <td id=\"T_a9750_row2_col3\" class=\"data row2 col3\" >0.096</td>\n",
-       "      <td id=\"T_a9750_row2_col4\" class=\"data row2 col4\" >577</td>\n",
-       "      <td id=\"T_a9750_row2_col5\" class=\"data row2 col5\" >3</td>\n",
+       "      <th id=\"T_03bea_level0_row2\" class=\"row_heading level0 row2\" >4</th>\n",
+       "      <td id=\"T_03bea_row2_col0\" class=\"data row2 col0\" >26,259</td>\n",
+       "      <td id=\"T_03bea_row2_col1\" class=\"data row2 col1\" >25,149</td>\n",
+       "      <td id=\"T_03bea_row2_col2\" class=\"data row2 col2\" >-0.024</td>\n",
+       "      <td id=\"T_03bea_row2_col3\" class=\"data row2 col3\" >0.096</td>\n",
+       "      <td id=\"T_03bea_row2_col4\" class=\"data row2 col4\" >577</td>\n",
+       "      <td id=\"T_03bea_row2_col5\" class=\"data row2 col5\" >3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_a9750_level0_row3\" class=\"row_heading level0 row3\" >5</th>\n",
-       "      <td id=\"T_a9750_row3_col0\" class=\"data row3 col0\" >26,388</td>\n",
-       "      <td id=\"T_a9750_row3_col1\" class=\"data row3 col1\" >24,998</td>\n",
-       "      <td id=\"T_a9750_row3_col2\" class=\"data row3 col2\" >0.006</td>\n",
-       "      <td id=\"T_a9750_row3_col3\" class=\"data row3 col3\" >0.087</td>\n",
-       "      <td id=\"T_a9750_row3_col4\" class=\"data row3 col4\" >600</td>\n",
-       "      <td id=\"T_a9750_row3_col5\" class=\"data row3 col5\" >8</td>\n",
+       "      <th id=\"T_03bea_level0_row3\" class=\"row_heading level0 row3\" >5</th>\n",
+       "      <td id=\"T_03bea_row3_col0\" class=\"data row3 col0\" >26,388</td>\n",
+       "      <td id=\"T_03bea_row3_col1\" class=\"data row3 col1\" >24,998</td>\n",
+       "      <td id=\"T_03bea_row3_col2\" class=\"data row3 col2\" >0.006</td>\n",
+       "      <td id=\"T_03bea_row3_col3\" class=\"data row3 col3\" >0.087</td>\n",
+       "      <td id=\"T_03bea_row3_col4\" class=\"data row3 col4\" >600</td>\n",
+       "      <td id=\"T_03bea_row3_col5\" class=\"data row3 col5\" >8</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_a9750_level0_row4\" class=\"row_heading level0 row4\" >6</th>\n",
-       "      <td id=\"T_a9750_row4_col0\" class=\"data row4 col0\" >26,598</td>\n",
-       "      <td id=\"T_a9750_row4_col1\" class=\"data row4 col1\" >24,930</td>\n",
-       "      <td id=\"T_a9750_row4_col2\" class=\"data row4 col2\" >0.003</td>\n",
-       "      <td id=\"T_a9750_row4_col3\" class=\"data row4 col3\" >0.077</td>\n",
-       "      <td id=\"T_a9750_row4_col4\" class=\"data row4 col4\" >654</td>\n",
-       "      <td id=\"T_a9750_row4_col5\" class=\"data row4 col5\" >3</td>\n",
+       "      <th id=\"T_03bea_level0_row4\" class=\"row_heading level0 row4\" >6</th>\n",
+       "      <td id=\"T_03bea_row4_col0\" class=\"data row4 col0\" >26,598</td>\n",
+       "      <td id=\"T_03bea_row4_col1\" class=\"data row4 col1\" >24,930</td>\n",
+       "      <td id=\"T_03bea_row4_col2\" class=\"data row4 col2\" >0.003</td>\n",
+       "      <td id=\"T_03bea_row4_col3\" class=\"data row4 col3\" >0.077</td>\n",
+       "      <td id=\"T_03bea_row4_col4\" class=\"data row4 col4\" >654</td>\n",
+       "      <td id=\"T_03bea_row4_col5\" class=\"data row4 col5\" >3</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7d28700fd450>"
+       "<pandas.io.formats.style.Styler at 0x7213e99311d0>"
       ]
      },
      "execution_count": 10,
@@ -876,14 +883,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5da82fef",
+   "id": "03222599",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007651,
-     "end_time": "2026-09-08T23:45:11.900893+00:00",
+     "duration": 0.002334,
+     "end_time": "2026-09-08T23:59:02.554258+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:11.893242+00:00",
+     "start_time": "2026-09-08T23:59:02.551924+00:00",
      "status": "completed"
     }
    },
@@ -899,19 +906,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "0bd9804a",
+   "id": "ba8b231b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:11.913027Z",
-     "iopub.status.busy": "2026-09-08T23:45:11.912843Z",
-     "iopub.status.idle": "2026-09-08T23:45:11.916240Z",
-     "shell.execute_reply": "2026-09-08T23:45:11.915644Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.560109Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.559934Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.563155Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.562575Z"
     },
     "papermill": {
-     "duration": 0.01144,
-     "end_time": "2026-09-08T23:45:11.917516+00:00",
+     "duration": 0.006814,
+     "end_time": "2026-09-08T23:59:02.563499+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:11.906076+00:00",
+     "start_time": "2026-09-08T23:59:02.556685+00:00",
      "status": "completed"
     }
    },
@@ -930,19 +937,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "55a84e1c",
+   "id": "651105ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:11.928560Z",
-     "iopub.status.busy": "2026-09-08T23:45:11.928033Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.236912Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.235970Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.569064Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.568927Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.727703Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.727186Z"
     },
     "papermill": {
-     "duration": 0.3151,
-     "end_time": "2026-09-08T23:45:12.237444+00:00",
+     "duration": 0.162591,
+     "end_time": "2026-09-08T23:59:02.728553+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:11.922344+00:00",
+     "start_time": "2026-09-08T23:59:02.565962+00:00",
      "status": "completed"
     }
    },
@@ -990,19 +997,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "12dc2c30",
+   "id": "705c2649",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.256905Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.256736Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.267109Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.266581Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.740591Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.740473Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.744047Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.743519Z"
     },
     "papermill": {
-     "duration": 0.023309,
-     "end_time": "2026-09-08T23:45:12.267939+00:00",
+     "duration": 0.010303,
+     "end_time": "2026-09-08T23:59:02.744498+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.244630+00:00",
+     "start_time": "2026-09-08T23:59:02.734195+00:00",
      "status": "completed"
     }
    },
@@ -1035,13 +1042,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d0d721b",
+   "id": "c3a65282",
    "metadata": {
     "papermill": {
-     "duration": 0.008466,
-     "end_time": "2026-09-08T23:45:12.288508+00:00",
+     "duration": 0.004722,
+     "end_time": "2026-09-08T23:59:02.754199+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.280042+00:00",
+     "start_time": "2026-09-08T23:59:02.749477+00:00",
      "status": "completed"
     }
    },
@@ -1062,19 +1069,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "b82e6ed3",
+   "id": "54a7388e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.310910Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.310729Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.316894Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.316280Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.764316Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.764194Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.766401Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.765815Z"
     },
     "papermill": {
-     "duration": 0.018432,
-     "end_time": "2026-09-08T23:45:12.317726+00:00",
+     "duration": 0.007989,
+     "end_time": "2026-09-08T23:59:02.766874+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.299294+00:00",
+     "start_time": "2026-09-08T23:59:02.758885+00:00",
      "status": "completed"
     }
    },
@@ -1085,14 +1092,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5cc3d01",
+   "id": "eb516de4",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.015111,
-     "end_time": "2026-09-08T23:45:12.340789+00:00",
+     "duration": 0.004278,
+     "end_time": "2026-09-08T23:59:02.775742+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.325678+00:00",
+     "start_time": "2026-09-08T23:59:02.771464+00:00",
      "status": "completed"
     }
    },
@@ -1109,19 +1116,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "52e05cc4",
+   "id": "c4549e5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.367270Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.367082Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.371235Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.370417Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.785609Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.785338Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.790233Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.788171Z"
     },
     "papermill": {
-     "duration": 0.016881,
-     "end_time": "2026-09-08T23:45:12.371703+00:00",
+     "duration": 0.010909,
+     "end_time": "2026-09-08T23:59:02.790965+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.354822+00:00",
+     "start_time": "2026-09-08T23:59:02.780056+00:00",
      "status": "completed"
     }
    },
@@ -1139,19 +1146,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "859f03db",
+   "id": "ee95faeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.391017Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.390852Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.399469Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.398588Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.797907Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.797787Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.800953Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.800405Z"
     },
     "papermill": {
-     "duration": 0.017468,
-     "end_time": "2026-09-08T23:45:12.399984+00:00",
+     "duration": 0.007102,
+     "end_time": "2026-09-08T23:59:02.801274+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.382516+00:00",
+     "start_time": "2026-09-08T23:59:02.794172+00:00",
      "status": "completed"
     }
    },
@@ -1178,19 +1185,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "2763b7a0",
+   "id": "7395dec2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.420158Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.419981Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.741391Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.737307Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.807259Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.807117Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.948481Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.947767Z"
     },
     "papermill": {
-     "duration": 0.335205,
-     "end_time": "2026-09-08T23:45:12.742207+00:00",
+     "duration": 0.145038,
+     "end_time": "2026-09-08T23:59:02.948959+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.407002+00:00",
+     "start_time": "2026-09-08T23:59:02.803921+00:00",
      "status": "completed"
     }
    },
@@ -1244,13 +1251,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fbb9b3d",
+   "id": "c6198ebb",
    "metadata": {
     "papermill": {
-     "duration": 0.008012,
-     "end_time": "2026-09-08T23:45:12.762487+00:00",
+     "duration": 0.004958,
+     "end_time": "2026-09-08T23:59:02.958969+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.754475+00:00",
+     "start_time": "2026-09-08T23:59:02.954011+00:00",
      "status": "completed"
     }
    },
@@ -1266,13 +1273,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cdaa9c4d",
+   "id": "d1f9ccf1",
    "metadata": {
     "papermill": {
-     "duration": 0.008598,
-     "end_time": "2026-09-08T23:45:12.782176+00:00",
+     "duration": 0.002987,
+     "end_time": "2026-09-08T23:59:02.965088+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.773578+00:00",
+     "start_time": "2026-09-08T23:59:02.962101+00:00",
      "status": "completed"
     }
    },
@@ -1295,19 +1302,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "26e6a8e1",
+   "id": "e6cd75b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.802810Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.802639Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.807842Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.807160Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.971651Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.971528Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.976099Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.975381Z"
     },
     "papermill": {
-     "duration": 0.016985,
-     "end_time": "2026-09-08T23:45:12.810348+00:00",
+     "duration": 0.008751,
+     "end_time": "2026-09-08T23:59:02.976666+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.793363+00:00",
+     "start_time": "2026-09-08T23:59:02.967915+00:00",
      "status": "completed"
     }
    },
@@ -1329,13 +1336,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5330021a",
+   "id": "d8aedf42",
    "metadata": {
     "papermill": {
-     "duration": 0.005551,
-     "end_time": "2026-09-08T23:45:12.822070+00:00",
+     "duration": 0.002819,
+     "end_time": "2026-09-08T23:59:02.982581+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.816519+00:00",
+     "start_time": "2026-09-08T23:59:02.979762+00:00",
      "status": "completed"
     }
    },
@@ -1353,19 +1360,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "4ce19466",
+   "id": "89dba545",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.833585Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.833419Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.837673Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.836730Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.988700Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.988570Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.990796Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.990422Z"
     },
     "papermill": {
-     "duration": 0.010725,
-     "end_time": "2026-09-08T23:45:12.838184+00:00",
+     "duration": 0.005854,
+     "end_time": "2026-09-08T23:59:02.991117+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.827459+00:00",
+     "start_time": "2026-09-08T23:59:02.985263+00:00",
      "status": "completed"
     }
    },
@@ -1385,19 +1392,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "3c5388d5",
+   "id": "29416e7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.849775Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.849606Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.857840Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.856763Z"
+     "iopub.execute_input": "2026-09-08T23:59:02.997066Z",
+     "iopub.status.busy": "2026-09-08T23:59:02.996956Z",
+     "iopub.status.idle": "2026-09-08T23:59:02.999704Z",
+     "shell.execute_reply": "2026-09-08T23:59:02.999321Z"
     },
     "papermill": {
-     "duration": 0.015134,
-     "end_time": "2026-09-08T23:45:12.858774+00:00",
+     "duration": 0.006224,
+     "end_time": "2026-09-08T23:59:03.000055+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.843640+00:00",
+     "start_time": "2026-09-08T23:59:02.993831+00:00",
      "status": "completed"
     }
    },
@@ -1423,19 +1430,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "501c4bb6",
+   "id": "df3cd222",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.880550Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.880359Z",
-     "iopub.status.idle": "2026-09-08T23:45:12.885186Z",
-     "shell.execute_reply": "2026-09-08T23:45:12.884284Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.006376Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.006261Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.009489Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.008904Z"
     },
     "papermill": {
-     "duration": 0.018081,
-     "end_time": "2026-09-08T23:45:12.885714+00:00",
+     "duration": 0.00707,
+     "end_time": "2026-09-08T23:59:03.009877+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.867633+00:00",
+     "start_time": "2026-09-08T23:59:03.002807+00:00",
      "status": "completed"
     }
    },
@@ -1463,19 +1470,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "8d161458",
+   "id": "8b0e2505",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:12.897945Z",
-     "iopub.status.busy": "2026-09-08T23:45:12.897767Z",
-     "iopub.status.idle": "2026-09-08T23:45:13.423561Z",
-     "shell.execute_reply": "2026-09-08T23:45:13.421155Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.016460Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.016350Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.225281Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.224668Z"
     },
     "papermill": {
-     "duration": 0.532327,
-     "end_time": "2026-09-08T23:45:13.423995+00:00",
+     "duration": 0.212934,
+     "end_time": "2026-09-08T23:59:03.225775+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:12.891668+00:00",
+     "start_time": "2026-09-08T23:59:03.012841+00:00",
      "status": "completed"
     }
    },
@@ -1532,13 +1539,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f59e667",
+   "id": "9bccdc34",
    "metadata": {
     "papermill": {
-     "duration": 0.009483,
-     "end_time": "2026-09-08T23:45:13.440285+00:00",
+     "duration": 0.003057,
+     "end_time": "2026-09-08T23:59:03.232070+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:13.430802+00:00",
+     "start_time": "2026-09-08T23:59:03.229013+00:00",
      "status": "completed"
     }
    },
@@ -1556,19 +1563,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "e98a9b68",
+   "id": "e99086b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:13.454551Z",
-     "iopub.status.busy": "2026-09-08T23:45:13.454375Z",
-     "iopub.status.idle": "2026-09-08T23:45:13.469055Z",
-     "shell.execute_reply": "2026-09-08T23:45:13.468659Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.239847Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.239716Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.245867Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.245489Z"
     },
     "papermill": {
-     "duration": 0.025719,
-     "end_time": "2026-09-08T23:45:13.469594+00:00",
+     "duration": 0.011453,
+     "end_time": "2026-09-08T23:59:03.246600+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:13.443875+00:00",
+     "start_time": "2026-09-08T23:59:03.235147+00:00",
      "status": "completed"
     }
    },
@@ -1578,13 +1585,13 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_1f898\">\n",
+       "<table id=\"T_29ed4\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_1f898_level0_col0\" class=\"col_heading level0 col0\" >Mean (%)</th>\n",
-       "      <th id=\"T_1f898_level0_col1\" class=\"col_heading level0 col1\" >Median (%)</th>\n",
-       "      <th id=\"T_1f898_level0_col2\" class=\"col_heading level0 col2\" >Max (%)</th>\n",
+       "      <th id=\"T_29ed4_level0_col0\" class=\"col_heading level0 col0\" >Mean (%)</th>\n",
+       "      <th id=\"T_29ed4_level0_col1\" class=\"col_heading level0 col1\" >Median (%)</th>\n",
+       "      <th id=\"T_29ed4_level0_col2\" class=\"col_heading level0 col2\" >Max (%)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Regime</th>\n",
@@ -1595,22 +1602,22 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_1f898_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
-       "      <td id=\"T_1f898_row0_col0\" class=\"data row0 col0\" >9.8</td>\n",
-       "      <td id=\"T_1f898_row0_col1\" class=\"data row0 col1\" >8.7</td>\n",
-       "      <td id=\"T_1f898_row0_col2\" class=\"data row0 col2\" >29.7</td>\n",
+       "      <th id=\"T_29ed4_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
+       "      <td id=\"T_29ed4_row0_col0\" class=\"data row0 col0\" >9.8</td>\n",
+       "      <td id=\"T_29ed4_row0_col1\" class=\"data row0 col1\" >8.7</td>\n",
+       "      <td id=\"T_29ed4_row0_col2\" class=\"data row0 col2\" >29.7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_1f898_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
-       "      <td id=\"T_1f898_row1_col0\" class=\"data row1 col0\" >12.7</td>\n",
-       "      <td id=\"T_1f898_row1_col1\" class=\"data row1 col1\" >10.9</td>\n",
-       "      <td id=\"T_1f898_row1_col2\" class=\"data row1 col2\" >31.8</td>\n",
+       "      <th id=\"T_29ed4_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
+       "      <td id=\"T_29ed4_row1_col0\" class=\"data row1 col0\" >12.7</td>\n",
+       "      <td id=\"T_29ed4_row1_col1\" class=\"data row1 col1\" >10.9</td>\n",
+       "      <td id=\"T_29ed4_row1_col2\" class=\"data row1 col2\" >31.8</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7d282c715950>"
+       "<pandas.io.formats.style.Styler at 0x72139c745810>"
       ]
      },
      "execution_count": 23,
@@ -1635,19 +1642,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "8bd850b9",
+   "id": "445aa4f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:13.484966Z",
-     "iopub.status.busy": "2026-09-08T23:45:13.484801Z",
-     "iopub.status.idle": "2026-09-08T23:45:13.806404Z",
-     "shell.execute_reply": "2026-09-08T23:45:13.805887Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.254283Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.254147Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.385265Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.384910Z"
     },
     "papermill": {
-     "duration": 0.32957,
-     "end_time": "2026-09-08T23:45:13.806923+00:00",
+     "duration": 0.135953,
+     "end_time": "2026-09-08T23:59:03.385871+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:13.477353+00:00",
+     "start_time": "2026-09-08T23:59:03.249918+00:00",
      "status": "completed"
     }
    },
@@ -1709,13 +1716,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "577fd3ea",
+   "id": "fa0da915",
    "metadata": {
     "papermill": {
-     "duration": 0.009864,
-     "end_time": "2026-09-08T23:45:13.823752+00:00",
+     "duration": 0.003368,
+     "end_time": "2026-09-08T23:59:03.394592+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:13.813888+00:00",
+     "start_time": "2026-09-08T23:59:03.391224+00:00",
      "status": "completed"
     }
    },
@@ -1731,19 +1738,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "5c9ad29c",
+   "id": "07ea1937",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:13.851669Z",
-     "iopub.status.busy": "2026-09-08T23:45:13.851486Z",
-     "iopub.status.idle": "2026-09-08T23:45:13.858095Z",
-     "shell.execute_reply": "2026-09-08T23:45:13.857715Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.401822Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.401678Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.405766Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.405307Z"
     },
     "papermill": {
-     "duration": 0.030135,
-     "end_time": "2026-09-08T23:45:13.863844+00:00",
+     "duration": 0.008198,
+     "end_time": "2026-09-08T23:59:03.406150+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:13.833709+00:00",
+     "start_time": "2026-09-08T23:59:03.397952+00:00",
      "status": "completed"
     }
    },
@@ -1766,13 +1773,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d53405ee",
+   "id": "35cbc18d",
    "metadata": {
     "papermill": {
-     "duration": 0.012707,
-     "end_time": "2026-09-08T23:45:13.883753+00:00",
+     "duration": 0.003884,
+     "end_time": "2026-09-08T23:59:03.414708+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:13.871046+00:00",
+     "start_time": "2026-09-08T23:59:03.410824+00:00",
      "status": "completed"
     }
    },
@@ -1793,19 +1800,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "e96aed80",
+   "id": "6b6d2950",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:13.904809Z",
-     "iopub.status.busy": "2026-09-08T23:45:13.904645Z",
-     "iopub.status.idle": "2026-09-08T23:45:13.914815Z",
-     "shell.execute_reply": "2026-09-08T23:45:13.914426Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.423666Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.423481Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.428666Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.428165Z"
     },
     "papermill": {
-     "duration": 0.023332,
-     "end_time": "2026-09-08T23:45:13.916853+00:00",
+     "duration": 0.010406,
+     "end_time": "2026-09-08T23:59:03.429015+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:13.893521+00:00",
+     "start_time": "2026-09-08T23:59:03.418609+00:00",
      "status": "completed"
     }
    },
@@ -1819,19 +1826,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "39acc4bc",
+   "id": "fe08037f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:13.932053Z",
-     "iopub.status.busy": "2026-09-08T23:45:13.931785Z",
-     "iopub.status.idle": "2026-09-08T23:45:14.265371Z",
-     "shell.execute_reply": "2026-09-08T23:45:14.264848Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.436427Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.436297Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.515820Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.515247Z"
     },
     "papermill": {
-     "duration": 0.347734,
-     "end_time": "2026-09-08T23:45:14.268625+00:00",
+     "duration": 0.084329,
+     "end_time": "2026-09-08T23:59:03.516717+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:13.920891+00:00",
+     "start_time": "2026-09-08T23:59:03.432388+00:00",
      "status": "completed"
     }
    },
@@ -1893,19 +1900,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "b11ae1ec",
+   "id": "e69487b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:14.295517Z",
-     "iopub.status.busy": "2026-09-08T23:45:14.295332Z",
-     "iopub.status.idle": "2026-09-08T23:45:14.301082Z",
-     "shell.execute_reply": "2026-09-08T23:45:14.300710Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.525171Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.524996Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.533716Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.529522Z"
     },
     "papermill": {
-     "duration": 0.02774,
-     "end_time": "2026-09-08T23:45:14.301718+00:00",
+     "duration": 0.013956,
+     "end_time": "2026-09-08T23:59:03.534253+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.273978+00:00",
+     "start_time": "2026-09-08T23:59:03.520297+00:00",
      "status": "completed"
     }
    },
@@ -1915,65 +1922,65 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_aaf2a\">\n",
+       "<table id=\"T_ae135\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >regime</th>\n",
-       "      <th id=\"T_aaf2a_level0_col0\" class=\"col_heading level0 col0\" >Risk-on</th>\n",
-       "      <th id=\"T_aaf2a_level0_col1\" class=\"col_heading level0 col1\" >Risk-off</th>\n",
+       "      <th id=\"T_ae135_level0_col0\" class=\"col_heading level0 col0\" >Risk-on</th>\n",
+       "      <th id=\"T_ae135_level0_col1\" class=\"col_heading level0 col1\" >Risk-off</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_aaf2a_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
-       "      <td id=\"T_aaf2a_row0_col0\" class=\"data row0 col0\" >+1.6</td>\n",
-       "      <td id=\"T_aaf2a_row0_col1\" class=\"data row0 col1\" >+5.3</td>\n",
+       "      <th id=\"T_ae135_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
+       "      <td id=\"T_ae135_row0_col0\" class=\"data row0 col0\" >+1.6</td>\n",
+       "      <td id=\"T_ae135_row0_col1\" class=\"data row0 col1\" >+5.3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_aaf2a_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
-       "      <td id=\"T_aaf2a_row1_col0\" class=\"data row1 col0\" >+4.5</td>\n",
-       "      <td id=\"T_aaf2a_row1_col1\" class=\"data row1 col1\" >+0.4</td>\n",
+       "      <th id=\"T_ae135_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
+       "      <td id=\"T_ae135_row1_col0\" class=\"data row1 col0\" >+4.5</td>\n",
+       "      <td id=\"T_ae135_row1_col1\" class=\"data row1 col1\" >+0.4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_aaf2a_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
-       "      <td id=\"T_aaf2a_row2_col0\" class=\"data row2 col0\" >+3.5</td>\n",
-       "      <td id=\"T_aaf2a_row2_col1\" class=\"data row2 col1\" >-0.6</td>\n",
+       "      <th id=\"T_ae135_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
+       "      <td id=\"T_ae135_row2_col0\" class=\"data row2 col0\" >+3.5</td>\n",
+       "      <td id=\"T_ae135_row2_col1\" class=\"data row2 col1\" >-0.6</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_aaf2a_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
-       "      <td id=\"T_aaf2a_row3_col0\" class=\"data row3 col0\" >+4.2</td>\n",
-       "      <td id=\"T_aaf2a_row3_col1\" class=\"data row3 col1\" >-0.5</td>\n",
+       "      <th id=\"T_ae135_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
+       "      <td id=\"T_ae135_row3_col0\" class=\"data row3 col0\" >+4.2</td>\n",
+       "      <td id=\"T_ae135_row3_col1\" class=\"data row3 col1\" >-0.5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_aaf2a_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
-       "      <td id=\"T_aaf2a_row4_col0\" class=\"data row4 col0\" >-1.0</td>\n",
-       "      <td id=\"T_aaf2a_row4_col1\" class=\"data row4 col1\" >+20.6</td>\n",
+       "      <th id=\"T_ae135_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
+       "      <td id=\"T_ae135_row4_col0\" class=\"data row4 col0\" >-1.0</td>\n",
+       "      <td id=\"T_ae135_row4_col1\" class=\"data row4 col1\" >+20.6</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_aaf2a_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
-       "      <td id=\"T_aaf2a_row5_col0\" class=\"data row5 col0\" >+10.7</td>\n",
-       "      <td id=\"T_aaf2a_row5_col1\" class=\"data row5 col1\" >-0.7</td>\n",
+       "      <th id=\"T_ae135_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
+       "      <td id=\"T_ae135_row5_col0\" class=\"data row5 col0\" >+10.7</td>\n",
+       "      <td id=\"T_ae135_row5_col1\" class=\"data row5 col1\" >-0.7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_aaf2a_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
-       "      <td id=\"T_aaf2a_row6_col0\" class=\"data row6 col0\" >+9.5</td>\n",
-       "      <td id=\"T_aaf2a_row6_col1\" class=\"data row6 col1\" >+2.2</td>\n",
+       "      <th id=\"T_ae135_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
+       "      <td id=\"T_ae135_row6_col0\" class=\"data row6 col0\" >+9.5</td>\n",
+       "      <td id=\"T_ae135_row6_col1\" class=\"data row6 col1\" >+2.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_aaf2a_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
-       "      <td id=\"T_aaf2a_row7_col0\" class=\"data row7 col0\" >+0.8</td>\n",
-       "      <td id=\"T_aaf2a_row7_col1\" class=\"data row7 col1\" >+4.2</td>\n",
+       "      <th id=\"T_ae135_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
+       "      <td id=\"T_ae135_row7_col0\" class=\"data row7 col0\" >+0.8</td>\n",
+       "      <td id=\"T_ae135_row7_col1\" class=\"data row7 col1\" >+4.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_aaf2a_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
-       "      <td id=\"T_aaf2a_row8_col0\" class=\"data row8 col0\" >+4.0</td>\n",
-       "      <td id=\"T_aaf2a_row8_col1\" class=\"data row8 col1\" >+8.5</td>\n",
+       "      <th id=\"T_ae135_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
+       "      <td id=\"T_ae135_row8_col0\" class=\"data row8 col0\" >+4.0</td>\n",
+       "      <td id=\"T_ae135_row8_col1\" class=\"data row8 col1\" >+8.5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7d282c65da90>"
+       "<pandas.io.formats.style.Styler at 0x72139c681950>"
       ]
      },
      "execution_count": 28,
@@ -1987,13 +1994,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfebe786",
+   "id": "d872c363",
    "metadata": {
     "papermill": {
-     "duration": 0.004357,
-     "end_time": "2026-09-08T23:45:14.313691+00:00",
+     "duration": 0.006263,
+     "end_time": "2026-09-08T23:59:03.546033+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.309334+00:00",
+     "start_time": "2026-09-08T23:59:03.539770+00:00",
      "status": "completed"
     }
    },
@@ -2010,14 +2017,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b349c02e",
+   "id": "df1c6f5d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004665,
-     "end_time": "2026-09-08T23:45:14.322953+00:00",
+     "duration": 0.0058,
+     "end_time": "2026-09-08T23:59:03.557694+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.318288+00:00",
+     "start_time": "2026-09-08T23:59:03.551894+00:00",
      "status": "completed"
     }
    },
@@ -2041,19 +2048,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "cfc9dccc",
+   "id": "23283eab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:14.332717Z",
-     "iopub.status.busy": "2026-09-08T23:45:14.332594Z",
-     "iopub.status.idle": "2026-09-08T23:45:14.335094Z",
-     "shell.execute_reply": "2026-09-08T23:45:14.334529Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.569426Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.569282Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.571443Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.571107Z"
     },
     "papermill": {
-     "duration": 0.007875,
-     "end_time": "2026-09-08T23:45:14.335377+00:00",
+     "duration": 0.008979,
+     "end_time": "2026-09-08T23:59:03.571903+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.327502+00:00",
+     "start_time": "2026-09-08T23:59:03.562924+00:00",
      "status": "completed"
     }
    },
@@ -2068,19 +2075,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "0203777e",
+   "id": "e652af6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:14.345916Z",
-     "iopub.status.busy": "2026-09-08T23:45:14.345792Z",
-     "iopub.status.idle": "2026-09-08T23:45:14.354377Z",
-     "shell.execute_reply": "2026-09-08T23:45:14.353795Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.579894Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.579788Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.586626Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.585836Z"
     },
     "papermill": {
-     "duration": 0.014216,
-     "end_time": "2026-09-08T23:45:14.354674+00:00",
+     "duration": 0.011476,
+     "end_time": "2026-09-08T23:59:03.587110+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.340458+00:00",
+     "start_time": "2026-09-08T23:59:03.575634+00:00",
      "status": "completed"
     }
    },
@@ -2090,16 +2097,16 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_c9fba\">\n",
+       "<table id=\"T_04ef8\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_c9fba_level0_col0\" class=\"col_heading level0 col0\" >Months</th>\n",
-       "      <th id=\"T_c9fba_level0_col1\" class=\"col_heading level0 col1\" >Share of sample</th>\n",
-       "      <th id=\"T_c9fba_level0_col2\" class=\"col_heading level0 col2\" >Return, annualized</th>\n",
-       "      <th id=\"T_c9fba_level0_col3\" class=\"col_heading level0 col3\" >Volatility, annualized</th>\n",
-       "      <th id=\"T_c9fba_level0_col4\" class=\"col_heading level0 col4\" >Sharpe ratio</th>\n",
-       "      <th id=\"T_c9fba_level0_col5\" class=\"col_heading level0 col5\" >Max drawdown</th>\n",
+       "      <th id=\"T_04ef8_level0_col0\" class=\"col_heading level0 col0\" >Months</th>\n",
+       "      <th id=\"T_04ef8_level0_col1\" class=\"col_heading level0 col1\" >Share of sample</th>\n",
+       "      <th id=\"T_04ef8_level0_col2\" class=\"col_heading level0 col2\" >Return, annualized</th>\n",
+       "      <th id=\"T_04ef8_level0_col3\" class=\"col_heading level0 col3\" >Volatility, annualized</th>\n",
+       "      <th id=\"T_04ef8_level0_col4\" class=\"col_heading level0 col4\" >Sharpe ratio</th>\n",
+       "      <th id=\"T_04ef8_level0_col5\" class=\"col_heading level0 col5\" >Max drawdown</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Regime</th>\n",
@@ -2113,28 +2120,28 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_c9fba_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
-       "      <td id=\"T_c9fba_row0_col0\" class=\"data row0 col0\" >900</td>\n",
-       "      <td id=\"T_c9fba_row0_col1\" class=\"data row0 col1\" >76.5%</td>\n",
-       "      <td id=\"T_c9fba_row0_col2\" class=\"data row0 col2\" >+9.5%</td>\n",
-       "      <td id=\"T_c9fba_row0_col3\" class=\"data row0 col3\" >8.6%</td>\n",
-       "      <td id=\"T_c9fba_row0_col4\" class=\"data row0 col4\" >1.11</td>\n",
-       "      <td id=\"T_c9fba_row0_col5\" class=\"data row0 col5\" >-22.9%</td>\n",
+       "      <th id=\"T_04ef8_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
+       "      <td id=\"T_04ef8_row0_col0\" class=\"data row0 col0\" >900</td>\n",
+       "      <td id=\"T_04ef8_row0_col1\" class=\"data row0 col1\" >76.5%</td>\n",
+       "      <td id=\"T_04ef8_row0_col2\" class=\"data row0 col2\" >+9.5%</td>\n",
+       "      <td id=\"T_04ef8_row0_col3\" class=\"data row0 col3\" >8.6%</td>\n",
+       "      <td id=\"T_04ef8_row0_col4\" class=\"data row0 col4\" >1.11</td>\n",
+       "      <td id=\"T_04ef8_row0_col5\" class=\"data row0 col5\" >-22.9%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_c9fba_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
-       "      <td id=\"T_c9fba_row1_col0\" class=\"data row1 col0\" >276</td>\n",
-       "      <td id=\"T_c9fba_row1_col1\" class=\"data row1 col1\" >23.5%</td>\n",
-       "      <td id=\"T_c9fba_row1_col2\" class=\"data row1 col2\" >+2.2%</td>\n",
-       "      <td id=\"T_c9fba_row1_col3\" class=\"data row1 col3\" >19.1%</td>\n",
-       "      <td id=\"T_c9fba_row1_col4\" class=\"data row1 col4\" >0.12</td>\n",
-       "      <td id=\"T_c9fba_row1_col5\" class=\"data row1 col5\" >-76.9%</td>\n",
+       "      <th id=\"T_04ef8_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
+       "      <td id=\"T_04ef8_row1_col0\" class=\"data row1 col0\" >276</td>\n",
+       "      <td id=\"T_04ef8_row1_col1\" class=\"data row1 col1\" >23.5%</td>\n",
+       "      <td id=\"T_04ef8_row1_col2\" class=\"data row1 col2\" >+2.2%</td>\n",
+       "      <td id=\"T_04ef8_row1_col3\" class=\"data row1 col3\" >19.1%</td>\n",
+       "      <td id=\"T_04ef8_row1_col4\" class=\"data row1 col4\" >0.12</td>\n",
+       "      <td id=\"T_04ef8_row1_col5\" class=\"data row1 col5\" >-76.9%</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7d282c506350>"
+       "<pandas.io.formats.style.Styler at 0x72139c52a210>"
       ]
      },
      "execution_count": 30,
@@ -2173,19 +2180,19 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "5be89c4f",
+   "id": "c0c848db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:14.365252Z",
-     "iopub.status.busy": "2026-09-08T23:45:14.364963Z",
-     "iopub.status.idle": "2026-09-08T23:45:14.370346Z",
-     "shell.execute_reply": "2026-09-08T23:45:14.368910Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.596342Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.596210Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.599445Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.599028Z"
     },
     "papermill": {
-     "duration": 0.011062,
-     "end_time": "2026-09-08T23:45:14.370714+00:00",
+     "duration": 0.00833,
+     "end_time": "2026-09-08T23:59:03.599919+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.359652+00:00",
+     "start_time": "2026-09-08T23:59:03.591589+00:00",
      "status": "completed"
     }
    },
@@ -2223,13 +2230,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc295b16",
+   "id": "3e196745",
    "metadata": {
     "papermill": {
-     "duration": 0.00843,
-     "end_time": "2026-09-08T23:45:14.387968+00:00",
+     "duration": 0.004043,
+     "end_time": "2026-09-08T23:59:03.608458+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.379538+00:00",
+     "start_time": "2026-09-08T23:59:03.604415+00:00",
      "status": "completed"
     }
    },
@@ -2245,13 +2252,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2724f018",
+   "id": "368f5d66",
    "metadata": {
     "papermill": {
-     "duration": 0.007325,
-     "end_time": "2026-09-08T23:45:14.405855+00:00",
+     "duration": 0.003384,
+     "end_time": "2026-09-08T23:59:03.615523+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.398530+00:00",
+     "start_time": "2026-09-08T23:59:03.612139+00:00",
      "status": "completed"
     }
    },
@@ -2267,19 +2274,19 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "07594b81",
+   "id": "e95ecf3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:14.424828Z",
-     "iopub.status.busy": "2026-09-08T23:45:14.424694Z",
-     "iopub.status.idle": "2026-09-08T23:45:14.438158Z",
-     "shell.execute_reply": "2026-09-08T23:45:14.437836Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.623300Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.623173Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.627814Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.627363Z"
     },
     "papermill": {
-     "duration": 0.025501,
-     "end_time": "2026-09-08T23:45:14.438885+00:00",
+     "duration": 0.009114,
+     "end_time": "2026-09-08T23:59:03.628176+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.413384+00:00",
+     "start_time": "2026-09-08T23:59:03.619062+00:00",
      "status": "completed"
     }
    },
@@ -2320,13 +2327,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1821fa96",
+   "id": "4b77e73f",
    "metadata": {
     "papermill": {
-     "duration": 0.01288,
-     "end_time": "2026-09-08T23:45:14.458821+00:00",
+     "duration": 0.003371,
+     "end_time": "2026-09-08T23:59:03.635129+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.445941+00:00",
+     "start_time": "2026-09-08T23:59:03.631758+00:00",
      "status": "completed"
     }
    },
@@ -2351,13 +2358,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24184602",
+   "id": "7bb5a30e",
    "metadata": {
     "papermill": {
-     "duration": 0.00633,
-     "end_time": "2026-09-08T23:45:14.476395+00:00",
+     "duration": 0.005385,
+     "end_time": "2026-09-08T23:59:03.644250+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.470065+00:00",
+     "start_time": "2026-09-08T23:59:03.638865+00:00",
      "status": "completed"
     }
    },
@@ -2372,19 +2379,19 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "d9b0b783",
+   "id": "044423ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:14.492809Z",
-     "iopub.status.busy": "2026-09-08T23:45:14.492685Z",
-     "iopub.status.idle": "2026-09-08T23:45:14.509486Z",
-     "shell.execute_reply": "2026-09-08T23:45:14.509150Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.655529Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.655368Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.665850Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.665279Z"
     },
     "papermill": {
-     "duration": 0.027868,
-     "end_time": "2026-09-08T23:45:14.510652+00:00",
+     "duration": 0.015973,
+     "end_time": "2026-09-08T23:59:03.666184+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.482784+00:00",
+     "start_time": "2026-09-08T23:59:03.650211+00:00",
      "status": "completed"
     }
    },
@@ -2394,13 +2401,13 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_889ea\">\n",
+       "<table id=\"T_69a8d\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_889ea_level0_col0\" class=\"col_heading level0 col0\" >Mean length (months)</th>\n",
-       "      <th id=\"T_889ea_level0_col1\" class=\"col_heading level0 col1\" >Longest (months)</th>\n",
-       "      <th id=\"T_889ea_level0_col2\" class=\"col_heading level0 col2\" >Episodes</th>\n",
+       "      <th id=\"T_69a8d_level0_col0\" class=\"col_heading level0 col0\" >Mean length (months)</th>\n",
+       "      <th id=\"T_69a8d_level0_col1\" class=\"col_heading level0 col1\" >Longest (months)</th>\n",
+       "      <th id=\"T_69a8d_level0_col2\" class=\"col_heading level0 col2\" >Episodes</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Regime</th>\n",
@@ -2411,22 +2418,22 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_889ea_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
-       "      <td id=\"T_889ea_row0_col0\" class=\"data row0 col0\" >6.7</td>\n",
-       "      <td id=\"T_889ea_row0_col1\" class=\"data row0 col1\" >110</td>\n",
-       "      <td id=\"T_889ea_row0_col2\" class=\"data row0 col2\" >134</td>\n",
+       "      <th id=\"T_69a8d_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
+       "      <td id=\"T_69a8d_row0_col0\" class=\"data row0 col0\" >6.7</td>\n",
+       "      <td id=\"T_69a8d_row0_col1\" class=\"data row0 col1\" >110</td>\n",
+       "      <td id=\"T_69a8d_row0_col2\" class=\"data row0 col2\" >134</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_889ea_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
-       "      <td id=\"T_889ea_row1_col0\" class=\"data row1 col0\" >2.1</td>\n",
-       "      <td id=\"T_889ea_row1_col1\" class=\"data row1 col1\" >14</td>\n",
-       "      <td id=\"T_889ea_row1_col2\" class=\"data row1 col2\" >134</td>\n",
+       "      <th id=\"T_69a8d_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
+       "      <td id=\"T_69a8d_row1_col0\" class=\"data row1 col0\" >2.1</td>\n",
+       "      <td id=\"T_69a8d_row1_col1\" class=\"data row1 col1\" >14</td>\n",
+       "      <td id=\"T_69a8d_row1_col2\" class=\"data row1 col2\" >134</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7d282c506850>"
+       "<pandas.io.formats.style.Styler at 0x72139c52a710>"
       ]
      },
      "execution_count": 33,
@@ -2459,19 +2466,19 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "194aba79",
+   "id": "7effafcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:45:14.525406Z",
-     "iopub.status.busy": "2026-09-08T23:45:14.525241Z",
-     "iopub.status.idle": "2026-09-08T23:45:14.529518Z",
-     "shell.execute_reply": "2026-09-08T23:45:14.528882Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.675175Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.675006Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.678621Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.678026Z"
     },
     "papermill": {
-     "duration": 0.012874,
-     "end_time": "2026-09-08T23:45:14.530943+00:00",
+     "duration": 0.008925,
+     "end_time": "2026-09-08T23:59:03.678979+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.518069+00:00",
+     "start_time": "2026-09-08T23:59:03.670054+00:00",
      "status": "completed"
     }
    },
@@ -2503,13 +2510,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b9781b5",
+   "id": "3e8eaa05",
    "metadata": {
     "papermill": {
-     "duration": 0.0066,
-     "end_time": "2026-09-08T23:45:14.544250+00:00",
+     "duration": 0.003702,
+     "end_time": "2026-09-08T23:59:03.686530+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.537650+00:00",
+     "start_time": "2026-09-08T23:59:03.682828+00:00",
      "status": "completed"
     }
    },
@@ -2530,13 +2537,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f2db3c1",
+   "id": "10d4304f",
    "metadata": {
     "papermill": {
-     "duration": 0.007547,
-     "end_time": "2026-09-08T23:45:14.561018+00:00",
+     "duration": 0.003988,
+     "end_time": "2026-09-08T23:59:03.694430+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:45:14.553471+00:00",
+     "start_time": "2026-09-08T23:59:03.690442+00:00",
      "status": "completed"
     }
    },
@@ -2594,25 +2601,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-08T23:45:30.304140+00:00",
+   "executed_at": "2026-09-08T23:59:12.451578+00:00",
    "executor": "local-uv",
    "library_digest": "5c6cff9e7067767cd11d73fec3dd7f1c5b8a9af5570ee2ea53c7dfce7b154c8e",
-   "outputs_digest": "3dfcb307002f7d1b930ea9ad13d24a6eb6faa8d3c825e7856b0db1ffe9362ed8",
+   "outputs_digest": "2df849f783db13254bb6e6f93d8e88e453be44ae443f55374b24cab456f75d6a",
    "parameters": {},
    "production": true,
-   "source_py_blob": "9ac295e42f617269561a199f1c86308c9ec610a3",
-   "notes": "prose synced from the .py at 2026-09-08T23:49:16.213393+00:00 without re-executing; every code cell is identical to blob 31c4c45f24af"
+   "source_py_blob": "43cef12adfc02b251c6d2bd026baa9621284b016"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 106.612052,
-   "end_time": "2026-09-08T23:45:17.325938+00:00",
+   "duration": 11.135133,
+   "end_time": "2026-09-08T23:59:06.212022+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.build.2193386.ipynb",
-   "output_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.papermill.2193386.ipynb",
+   "input_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.build.2404169.ipynb",
+   "output_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.papermill.2404169.ipynb",
    "parameters": {},
-   "start_time": "2026-09-08T23:43:30.713886+00:00",
+   "start_time": "2026-09-08T23:58:55.076889+00:00",
    "version": "2.7.0"
   }
  },

--- a/01_process_is_edge/factor_regimes.ipynb
+++ b/01_process_is_edge/factor_regimes.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c8fc813e",
+   "id": "0d594e87",
    "metadata": {},
    "source": [
     "# Factor-based regime detection\n",
@@ -48,7 +48,8 @@
     "\n",
     "- Monthly return series and standardization (subtracting a mean, dividing by a standard\n",
     "  deviation) so that series with different scales contribute comparably to a distance.\n",
-    "- The AQR Century of Factor Premia parquet under `data/aqr_factors/`. Download it with\n",
+    "- The AQR Century of Factor Premia dataset, which `AQRFactorProvider` reads from\n",
+    "  `data/factors/aqr` under `ML4T_DATA_PATH`. Fetch it with\n",
     "  `uv run python data/factors/aqr_download.py` if it is missing.\n",
     "\n",
     "## What this notebook establishes, and what it does not\n",
@@ -64,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e6725a2",
+   "id": "9397f172",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -78,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e44b4376",
+   "id": "444f3f5b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b6c331e",
+   "id": "01f13bd4",
    "metadata": {
     "tags": [
      "parameters"
@@ -132,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06adc491",
+   "id": "45ed9112",
    "metadata": {},
    "source": [
     "### Settings, and what each one decides\n",
@@ -158,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9a7ca4a",
+   "id": "e7164a2b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +175,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "990059a1",
+   "id": "408b798c",
    "metadata": {},
    "source": [
     "## Load the factor panel\n",
@@ -187,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "870703c1",
+   "id": "839b5910",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e2b080",
+   "id": "90f96dd6",
    "metadata": {},
    "source": [
     "### The nine series used here\n",
@@ -225,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8be45b3",
+   "id": "2d9496a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71024149",
+   "id": "9af3887f",
    "metadata": {},
    "source": [
     "### What is actually in the panel\n",
@@ -275,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc71c7e2",
+   "id": "4bf8ff2b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3be5b23",
+   "id": "8d683b0d",
    "metadata": {},
    "source": [
     "## Prepare the panel for clustering\n",
@@ -318,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f97754e2",
+   "id": "d44a9055",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccfb8f8f",
+   "id": "20df3f57",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -376,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98f487d3",
+   "id": "3e78bd47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af52b160",
+   "id": "35ef3ead",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9482314",
+   "id": "fd8e66f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be63baec",
+   "id": "60d28595",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -490,7 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58b84ec9",
+   "id": "cd992f1f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75f7fb1c",
+   "id": "c36f8c20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00628471",
+   "id": "575cec26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,7 +557,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e17c321a",
+   "id": "f28aa7b9",
    "metadata": {},
    "source": [
     "When the criteria disagree, the choice is made on what the model is for. AIC targets\n",
@@ -575,7 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14ad0dd0",
+   "id": "f882b37d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +585,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a615a98a",
+   "id": "bd083a69",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -601,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6313658a",
+   "id": "593d2a26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b84129e",
+   "id": "baca3c3c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -642,7 +643,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec3a7a60",
+   "id": "15eb7058",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,7 +680,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98935308",
+   "id": "05e2a5fe",
    "metadata": {},
    "source": [
     "No band settles down as clusters are added. An added cluster does not carve out an era the\n",
@@ -693,7 +694,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6880e28b",
+   "id": "6054702d",
    "metadata": {},
    "source": [
     "## The two-cluster model: risk-on and risk-off\n",
@@ -714,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a4b81c4",
+   "id": "d3864953",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -734,7 +735,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a0fcd17",
+   "id": "2d6af75b",
    "metadata": {},
    "source": [
     "### The timeline against dated events\n",
@@ -750,7 +751,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed065fc6",
+   "id": "6795b94e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -768,7 +769,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae888074",
+   "id": "1f8325da",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -792,22 +793,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39b3df59",
+   "id": "bdfb68cc",
    "metadata": {},
    "outputs": [],
    "source": [
     "def plot_by_regime(ax: Axes, values: np.ndarray, in_risk_on: np.ndarray) -> None:\n",
-    "    \"\"\"Draw one line whose every segment takes the colour of the month it starts in.\n",
+    "    \"\"\"Draw one line whose every segment takes the colour of the month it ends in.\n",
     "\n",
-    "    Colouring by masking each regime into its own line would drop the segment that spans a\n",
-    "    transition, and would draw nothing at all for a one-month episode, which is most of\n",
-    "    them here.\n",
+    "    The segment from month t-1 to month t is the move month t produced, so month t's regime\n",
+    "    is the one that colours it. Masking each regime into its own line instead would drop\n",
+    "    every segment that spans a transition, and would draw nothing at all for a one-month\n",
+    "    episode, which is most of them here.\n",
     "    \"\"\"\n",
     "    y = np.asarray(values, dtype=float)\n",
     "    points = np.column_stack([np.arange(len(y)), y]).reshape(-1, 1, 2)\n",
     "    segments = np.concatenate([points[:-1], points[1:]], axis=1)\n",
     "    drawable = np.isfinite(segments[:, :, 1]).all(axis=1)\n",
-    "    colours = np.where(in_risk_on[:-1], COLORS[\"recede\"], COLORS[\"blue\"])\n",
+    "    colours = np.where(in_risk_on[1:], COLORS[\"recede\"], COLORS[\"blue\"])\n",
     "    ax.add_collection(LineCollection(segments[drawable], colors=colours[drawable], linewidths=1.2))\n",
     "    finite = y[np.isfinite(y)]\n",
     "    ax.set_xlim(0, len(y) - 1)\n",
@@ -817,7 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "061eb86d",
+   "id": "f3ae3d8e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -857,7 +859,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13ed31d7",
+   "id": "7cf05cc1",
    "metadata": {},
    "source": [
     "## Volatility inside each regime\n",
@@ -873,7 +875,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6769ae37",
+   "id": "fc4b8703",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -893,7 +895,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114548eb",
+   "id": "b47b5dfa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -938,7 +940,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6df30909",
+   "id": "b8d2d047",
    "metadata": {},
    "source": [
     "### Figure 1.5 inputs\n",
@@ -952,7 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35ba202a",
+   "id": "173e864c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -973,7 +975,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6821add",
+   "id": "ce1085ae",
    "metadata": {},
    "source": [
     "## What each factor earned in each regime\n",
@@ -992,7 +994,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5dc0bb27",
+   "id": "fa204a48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1004,7 +1006,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a4a4452",
+   "id": "8a9b6e65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1049,7 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a40ec4a",
+   "id": "73505c2e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1058,7 +1060,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb6240b5",
+   "id": "40ad308f",
    "metadata": {},
    "source": [
     "The two strategies a calm market reads as safe income - carry, which collects a yield\n",
@@ -1073,7 +1075,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86508232",
+   "id": "739e4c7d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1097,7 +1099,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8bb7f0b",
+   "id": "ba714c80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1110,7 +1112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "655d862e",
+   "id": "4347fcc0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1144,7 +1146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f61bd812",
+   "id": "3a59be42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1167,7 +1169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df7acaa4",
+   "id": "86115a2d",
    "metadata": {},
    "source": [
     "The two ratios answer different questions and a reader should expect them to differ. The\n",
@@ -1181,7 +1183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2139d015",
+   "id": "3933271c",
    "metadata": {},
    "source": [
     "### What the restricted drawdown actually measures\n",
@@ -1195,7 +1197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db49641d",
+   "id": "9fad275c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1219,7 +1221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6292ceaa",
+   "id": "b00006a1",
    "metadata": {},
    "source": [
     "Nobody lived through the first of those two numbers. The risk-off months are selected by\n",
@@ -1242,7 +1244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb7531df",
+   "id": "769f9f87",
    "metadata": {},
    "source": [
     "## How long the regimes last\n",
@@ -1255,7 +1257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79b070a1",
+   "id": "e11958d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1283,7 +1285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca5634cf",
+   "id": "3df7b386",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1300,7 +1302,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3fc0ebe",
+   "id": "87982249",
    "metadata": {},
    "source": [
     "That is the finding that decides what this model is for. A label that changes several\n",
@@ -1319,7 +1321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "483abfab",
+   "id": "23458fe4",
    "metadata": {},
    "source": [
     "## Key takeaways\n",

--- a/01_process_is_edge/factor_regimes.ipynb
+++ b/01_process_is_edge/factor_regimes.ipynb
@@ -2,198 +2,169 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fa26090a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001996,
-     "end_time": "2026-07-11T19:31:13.755494+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:13.753498+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "eb2a2f0d",
+   "metadata": {},
    "source": [
-    "# Factor-Based Regime Detection\n",
+    "# Factor-based regime detection\n",
     "\n",
     "**Chapter 1 · §1.4 Market Regimes: Change Is the Constant**\n",
     "\n",
     "**Docker image**: `ml4t`\n",
     "\n",
-    "## Purpose\n",
+    "Markets do not behave the same way in every year. The same value strategy that earns a\n",
+    "steady premium through a long expansion can lose money for a decade, and the same\n",
+    "momentum strategy can give back years of gains in a single quarter. A **regime** is a\n",
+    "stretch of time over which the joint behaviour of returns is stable enough to be treated\n",
+    "as one environment: the averages, the volatilities and the correlations hold roughly\n",
+    "still inside it and shift when it ends.\n",
     "\n",
-    "Demonstrates unsupervised learning for market regime detection using Gaussian Mixture Models (GMM)\n",
-    "on factor returns from the AQR Century of Factor Premia dataset.\n",
+    "Nobody publishes a regime label. This notebook estimates one from the data with a\n",
+    "**Gaussian mixture model** (GMM), which treats each month's vector of factor returns as\n",
+    "a draw from one of a small number of multivariate normal distributions and infers both\n",
+    "the distributions and which one each month most likely came from. The inputs are monthly\n",
+    "returns to nine factor strategies from AQR's Century of Factor Premia dataset, which\n",
+    "starts in 1927.\n",
     "\n",
-    "## Learning Objectives\n",
+    "## Learning objectives\n",
     "\n",
-    "- Apply GMM clustering to factor return time series.\n",
-    "- Evaluate cluster count with BIC, AIC, and silhouette scores.\n",
-    "- Visualize regime timelines with historical event annotations.\n",
-    "- Compare factor performance across regimes.\n",
+    "By the end of this notebook you will be able to:\n",
     "\n",
-    "## Book Reference\n",
+    "- Fit a Gaussian mixture model to a panel of monthly factor returns and read off the\n",
+    "  cluster it assigns to each month.\n",
+    "- Choose how many clusters to keep by comparing three criteria that measure different\n",
+    "  things, and say what each one rewards.\n",
+    "- Read a regime timeline against dated market events and judge whether the clusters\n",
+    "  correspond to periods a reader would recognise.\n",
+    "- Measure what each factor earned inside each cluster, and say what that implies about\n",
+    "  which factors diversify each other when conditions deteriorate.\n",
+    "- Explain why a label fitted on the whole sample cannot be used as a trading signal.\n",
     "\n",
-    "Section 1.4 of Chapter 1, \"Market Regimes: Change Is the Constant\" — style-regime view that\n",
-    "precedes the macro-regime view in `macro_regimes.py`.\n",
+    "## Book reference\n",
+    "\n",
+    "Chapter 1, Section 1.4, \"Market Regimes: Change Is the Constant\". `macro_regimes` is the\n",
+    "companion notebook and estimates regimes from macroeconomic indicators instead.\n",
     "\n",
     "## Prerequisites\n",
     "\n",
-    "- Familiarity with monthly return series and StandardScaler-style preprocessing.\n",
-    "- Conceptual exposure to mixture models and information criteria.\n",
-    "- AQR Century of Factor Premia parquet at `data/aqr_factors/` (download via\n",
-    "  `uv run python data/factors/aqr_download.py` if missing).\n",
+    "- Monthly return series and standardization (subtracting a mean, dividing by a standard\n",
+    "  deviation) so that series with different scales contribute comparably to a distance.\n",
+    "- The AQR Century of Factor Premia parquet under `data/aqr_factors/`. Download it with\n",
+    "  `uv run python data/factors/aqr_download.py` if it is missing.\n",
     "\n",
-    "## Background\n",
+    "## What this notebook establishes, and what it does not\n",
     "\n",
-    "Inspired by [Two Sigma's 2021 paper](https://www.twosigma.com/articles/a-machine-learning-approach-to-regime-modeling/)\n",
-    "which uses GMM on an 18-factor \"Factor Lens\" to identify four market regimes. We work with\n",
-    "AQR's longer history (1927+) over Value, Momentum, Carry, and Defensive across multiple asset\n",
-    "classes. There is no objectively \"correct\" number of regimes; we sweep 2–6 clusters to show\n",
-    "how granularity shapes the regime map.\n",
-    "\n",
-    "### Scope: descriptive, not predictive\n",
-    "\n",
-    "This notebook fits the GMM and the StandardScaler on the **entire factor-return history**\n",
-    "and then assigns regime labels back over that same history. The result is an *ex-post*\n",
-    "characterization of how the factor space partitions, useful for narrative and for\n",
-    "visualizing where macro events fall within the partitioning. It is **not** a regime\n",
-    "classifier that can be used for prediction: using these labels as features in a trading\n",
-    "strategy would constitute look-ahead because the partition itself was estimated with\n",
-    "future data. Lookahead-safe label construction (walk-forward fitting, point-in-time\n",
-    "information sets, embargoed cross-validation) is introduced from Chapter 6 onward, and\n",
-    "the case-study chapters (Ch16-20) demonstrate how predictive regime features are\n",
-    "constructed and evaluated."
+    "The model is fitted on the whole history and the labels are assigned back over that same\n",
+    "history. What comes out is a description of how the factor space partitions, and a way\n",
+    "of seeing where dated events fall inside that partition. Every month's label is informed\n",
+    "by every other month, including later ones, so the labels describe the sample rather than\n",
+    "forecast it. Building regime labels a strategy could have acted on requires walk-forward\n",
+    "fitting on information available at each date; Chapter 6 onward introduces that machinery\n",
+    "and the case-study chapters apply it."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e9d9b6c0",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001469,
-     "end_time": "2026-07-11T19:31:13.758636+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:13.757167+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "f9f5352c",
+   "metadata": {},
    "source": [
-    "## Imports"
+    "## Setup\n",
+    "\n",
+    "The AQR provider logs its download and cache decisions through `structlog`, which writes\n",
+    "to the notebook rather than through the standard library's logging module. Raising its\n",
+    "threshold to `WARNING` keeps the data-loading cells readable while leaving anything that\n",
+    "reports a problem visible."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "3935fe80",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:13.762478Z",
-     "iopub.status.busy": "2026-07-11T19:31:13.762364Z",
-     "iopub.status.idle": "2026-07-11T19:31:16.932089Z",
-     "shell.execute_reply": "2026-07-11T19:31:16.931612Z"
-    },
-    "papermill": {
-     "duration": 3.172444,
-     "end_time": "2026-07-11T19:31:16.932591+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:13.760147+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "31e7eac3",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"Factor-Based Regime Detection — unsupervised regime detection using GMM on AQR factor returns.\"\"\"\n",
+    "\"\"\"Factor-based regime detection - Gaussian mixture regimes over AQR factor returns.\"\"\"\n",
     "\n",
     "from __future__ import annotations\n",
     "\n",
-    "import warnings\n",
+    "import logging\n",
     "from collections.abc import Iterable\n",
     "from dataclasses import dataclass\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import polars as pl\n",
+    "import structlog\n",
+    "from IPython.display import Markdown, display\n",
     "from matplotlib.axes import Axes\n",
     "from matplotlib.colors import ListedColormap\n",
     "from ml4t.data.providers import AQRFactorProvider\n",
+    "from ml4t.diagnostic.metrics import sharpe_ratio\n",
     "from sklearn.cluster import KMeans\n",
     "from sklearn.metrics import silhouette_score\n",
     "from sklearn.mixture import GaussianMixture\n",
     "from sklearn.preprocessing import StandardScaler\n",
     "\n",
+    "import utils.style as style\n",
     "from utils.paths import get_output_dir\n",
-    "from utils.reproducibility import set_global_seeds"
+    "from utils.reproducibility import set_global_seeds\n",
+    "\n",
+    "structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.WARNING))\n",
+    "\n",
+    "COLORS = style.COLORS"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "85611d08",
+   "execution_count": null,
+   "id": "628c36ce",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:16.936484Z",
-     "iopub.status.busy": "2026-07-11T19:31:16.936400Z",
-     "iopub.status.idle": "2026-07-11T19:31:16.938034Z",
-     "shell.execute_reply": "2026-07-11T19:31:16.937680Z"
-    },
-    "papermill": {
-     "duration": 0.004089,
-     "end_time": "2026-07-11T19:31:16.938386+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:16.934297+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
    },
    "outputs": [],
    "source": [
-    "# Production defaults (Papermill overrides for testing)\n",
+    "# Production defaults (Papermill overrides these when the test suite runs the notebook)\n",
     "SEED = 42"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "af2a04d5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001534,
-     "end_time": "2026-07-11T19:31:16.941494+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:16.939960+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "dc0a5e40",
+   "metadata": {},
    "source": [
-    "## Configuration"
+    "### Settings, and what each one decides\n",
+    "\n",
+    "`SEED` fixes the initialization of every estimator below. A Gaussian mixture is fitted by\n",
+    "expectation-maximization from a random start, so two runs from different starts can land\n",
+    "on different local optima and swap which cluster is numbered 0; fixing the seed is what\n",
+    "makes the figures in this notebook reproduce.\n",
+    "\n",
+    "`N_REGIMES_GRID` is the set of cluster counts to fit and compare. Two is the smallest\n",
+    "number that partitions anything. Six is where the search stops: the point of the sweep is\n",
+    "to show how the criteria move as clusters are added, and by six they have already\n",
+    "separated.\n",
+    "\n",
+    "`MONTHS_PER_YEAR` annualizes monthly statistics. Multiply a mean monthly return by it and\n",
+    "a monthly standard deviation by its square root.\n",
+    "\n",
+    "`ROLLING_VOL_MONTHS` is the width of the moving window used to draw a volatility series.\n",
+    "Twelve months is short enough to move inside a regime and long enough that a single month\n",
+    "does not dominate the estimate."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "e4640660",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:16.944976Z",
-     "iopub.status.busy": "2026-07-11T19:31:16.944902Z",
-     "iopub.status.idle": "2026-07-11T19:31:16.985451Z",
-     "shell.execute_reply": "2026-07-11T19:31:16.984933Z"
-    },
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.042845,
-     "end_time": "2026-07-11T19:31:16.985874+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:16.943029+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "811bfe08",
+   "metadata": {},
    "outputs": [],
    "source": [
+    "N_REGIMES_GRID = [2, 3, 4, 5, 6]\n",
+    "MONTHS_PER_YEAR = 12\n",
+    "ROLLING_VOL_MONTHS = 12\n",
+    "\n",
     "OUTPUT_DIR = get_output_dir(1, \"factor_regimes\")\n",
     "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
     "\n",
@@ -202,49 +173,213 @@
   },
   {
    "cell_type": "markdown",
-   "id": "877190e0",
-   "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.001569,
-     "end_time": "2026-07-11T19:31:16.989162+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:16.987593+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "28ab4491",
+   "metadata": {},
    "source": [
-    "## Helper Functions\n",
+    "## Load the factor panel\n",
     "\n",
-    "A small container for GMM fit diagnostics, and a grid-search function\n",
-    "that fits multiple cluster counts and reports BIC, AIC, and silhouette."
+    "The AQR Century of Factor Premia dataset holds monthly returns to long-short factor\n",
+    "strategies built inside several asset classes, plus the returns to holding each asset\n",
+    "class outright. The provider returns one row per month and one column per strategy."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "79338cf4",
+   "execution_count": null,
+   "id": "702ee31e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aqr_raw = AQRFactorProvider().fetch(\"century_premia\")\n",
+    "\n",
+    "date_range = aqr_raw.select(\n",
+    "    pl.col(\"timestamp\").min().alias(\"first\"), pl.col(\"timestamp\").max().alias(\"last\")\n",
+    ")\n",
+    "print(f\"AQR Century of Factor Premia: {aqr_raw.height} months, {aqr_raw.width - 1} series\")\n",
+    "print(f\"Covering {date_range['first'][0]:%Y-%m} to {date_range['last'][0]:%Y-%m}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80237ea1",
+   "metadata": {},
+   "source": [
+    "### The nine series used here\n",
+    "\n",
+    "Four of them are cross-asset long-short strategies, applied across equity indices, bonds,\n",
+    "currencies and commodities at once:\n",
+    "\n",
+    "- **Value** buys what is cheap relative to a fundamental anchor and sells what is\n",
+    "  expensive.\n",
+    "- **Momentum** buys what has risen over the past year and sells what has fallen.\n",
+    "- **Carry** buys what pays a high yield and sells what pays a low one.\n",
+    "- **Defensive** buys low-risk assets and sells high-risk ones.\n",
+    "\n",
+    "Two apply the value and momentum definitions inside the US stock market alone. The last\n",
+    "three are the returns to simply holding each asset class - equity indices, fixed income,\n",
+    "commodities - rather than a long-short strategy, and they are what places a month in a\n",
+    "risk environment rather than a style environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "217eec89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FACTOR_COLUMNS = [\n",
+    "    \"All asset classes Value\",\n",
+    "    \"All asset classes Momentum\",\n",
+    "    \"All asset classes Carry\",\n",
+    "    \"All asset classes Defensive\",\n",
+    "    \"US Stock Selection Value\",\n",
+    "    \"US Stock Selection Momentum\",\n",
+    "    \"Equity indices Market\",\n",
+    "    \"Fixed income Market\",\n",
+    "    \"Commodities Market\",\n",
+    "]\n",
+    "EQUITY_COLUMN = \"Equity indices Market\"\n",
+    "\n",
+    "# Short names for the figures and tables below; the full AQR column names do not fit on an\n",
+    "# axis.\n",
+    "SHORT_NAMES = {\n",
+    "    \"All asset classes Value\": \"Value\",\n",
+    "    \"All asset classes Momentum\": \"Momentum\",\n",
+    "    \"All asset classes Carry\": \"Carry\",\n",
+    "    \"All asset classes Defensive\": \"Defensive\",\n",
+    "    \"US Stock Selection Value\": \"US Value\",\n",
+    "    \"US Stock Selection Momentum\": \"US Momentum\",\n",
+    "    \"Equity indices Market\": \"Equity\",\n",
+    "    \"Fixed income Market\": \"Bonds\",\n",
+    "    \"Commodities Market\": \"Commodities\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfb9ccc4",
+   "metadata": {},
+   "source": [
+    "### What is actually in the panel\n",
+    "\n",
+    "Clustering treats every month as a point in nine dimensions, so a month is usable only\n",
+    "when all nine series are quoted. The table below reports, for each series, the month it\n",
+    "starts, how many observations it has, and its mean and standard deviation over the raw\n",
+    "file. Read it before anything computed from the panel: it says which series shortens the\n",
+    "usable history and how far apart the series are in scale, which is why they are\n",
+    "standardized before the distance is taken."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90757261",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coverage = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"Series\": SHORT_NAMES[column],\n",
+    "            \"First month\": aqr_raw.filter(pl.col(column).is_not_null())[\"timestamp\"].min(),\n",
+    "            \"Months quoted\": aqr_raw.select(pl.col(column).is_not_null().sum()).item(),\n",
+    "            \"Mean (% / month)\": aqr_raw.select(pl.col(column).mean()).item() * 100,\n",
+    "            \"Std (% / month)\": aqr_raw.select(pl.col(column).std()).item() * 100,\n",
+    "        }\n",
+    "        for column in FACTOR_COLUMNS\n",
+    "    ]\n",
+    ").set_index(\"Series\")\n",
+    "coverage[\"First month\"] = pd.to_datetime(coverage[\"First month\"]).dt.strftime(\"%Y-%m\")\n",
+    "coverage.style.format({\"Mean (% / month)\": \"{:.2f}\", \"Std (% / month)\": \"{:.2f}\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0cd6662",
+   "metadata": {},
+   "source": [
+    "## Prepare the panel for clustering\n",
+    "\n",
+    "Months in which any of the nine series is unquoted are dropped rather than filled. A\n",
+    "forward fill would repeat the previous month's return, and repeating a return is not a\n",
+    "missing observation recovered - it is an invented one, and a mixture model would treat it\n",
+    "as evidence for a cluster.\n",
+    "\n",
+    "The nine series are then standardized to zero mean and unit variance. Without that step\n",
+    "the equity market series, whose monthly standard deviation is several times a long-short\n",
+    "strategy's, would dominate every distance and the clustering would be a partition of\n",
+    "equity returns alone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2cc95a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "factors_pl = aqr_raw.select([\"timestamp\", *FACTOR_COLUMNS]).sort(\"timestamp\").drop_nulls()\n",
+    "\n",
+    "factors_df = factors_pl.select(FACTOR_COLUMNS).to_pandas()\n",
+    "factors_df.index = pd.DatetimeIndex(factors_pl[\"timestamp\"].to_pandas())\n",
+    "\n",
+    "factors_scaled = StandardScaler().fit_transform(factors_df)\n",
+    "\n",
+    "start_year = factors_df.index.min().year\n",
+    "end_year = factors_df.index.max().year\n",
+    "print(f\"Complete months: {len(factors_df)} ({start_year} to {end_year})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a30ebe0c",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:16.992761Z",
-     "iopub.status.busy": "2026-07-11T19:31:16.992676Z",
-     "iopub.status.idle": "2026-07-11T19:31:16.995306Z",
-     "shell.execute_reply": "2026-07-11T19:31:16.994866Z"
-    },
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.004879,
-     "end_time": "2026-07-11T19:31:16.995584+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:16.990705+00:00",
-     "status": "completed"
-    }
+    "lines_to_next_cell": 2
    },
+   "source": [
+    "## Fit a grid of mixture models\n",
+    "\n",
+    "There is no test that returns the true number of regimes, so the count is a modelling\n",
+    "choice made by comparing candidates. The helper below fits one mixture per candidate\n",
+    "count and records three quantities for each.\n",
+    "\n",
+    "**BIC**, the Bayesian information criterion, is the fitted log-likelihood penalised by the\n",
+    "number of free parameters times the log of the sample size. **AIC**, the Akaike\n",
+    "information criterion, applies the same idea with a constant penalty of two per parameter.\n",
+    "Both are better when lower, and BIC's penalty grows with the sample, so on a long panel it\n",
+    "is far more reluctant than AIC to buy an extra cluster. A full-covariance mixture spends\n",
+    "parameters quickly - each additional cluster costs a mean vector and a covariance matrix\n",
+    "over nine dimensions - which is what the two criteria are pricing differently.\n",
+    "\n",
+    "The **silhouette score** measures something else entirely. For each month it compares the\n",
+    "average distance to the other months in its own cluster against the average distance to\n",
+    "the months of the nearest other cluster, and reports the normalized difference; the score\n",
+    "is the average over months. It runs from -1 to 1, it is better when higher, and a negative\n",
+    "value means the typical month sits closer to a different cluster than to its own. It is a\n",
+    "geometric statement about separation and knows nothing about likelihood.\n",
+    "\n",
+    "K-means is fitted alongside for the same counts. It partitions on distance to a centroid\n",
+    "with no covariance and no probabilities, so putting its silhouette beside the mixture's\n",
+    "says how much of the separation is coming from the shape the mixture is allowed to fit.\n",
+    "\n",
+    "The last two columns count things none of the three criteria look at: how often consecutive\n",
+    "months carry different labels, and how many months the emptiest cluster holds. A criterion\n",
+    "can only say how well a partition fits. Whether the partition holds still long enough to be\n",
+    "called a regime, and whether every cluster in it has enough months to say anything about,\n",
+    "are separate questions, and these two counts are the cheapest way to ask them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c095783",
+   "metadata": {},
    "outputs": [],
    "source": [
     "@dataclass(frozen=True)\n",
     "class GmmFitResult:\n",
-    "    \"\"\"Results from fitting a Gaussian Mixture Model.\"\"\"\n",
+    "    \"\"\"One fitted mixture and the three quantities used to compare it against the others.\"\"\"\n",
     "\n",
     "    model: GaussianMixture\n",
     "    labels: np.ndarray\n",
@@ -255,42 +390,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "86449db4",
-   "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.001525,
-     "end_time": "2026-07-11T19:31:16.998679+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:16.997154+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Grid Search for Optimal Cluster Count\n",
-    "Fit GMM across multiple cluster counts and evaluate with BIC, AIC, and silhouette."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "9ef36914",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:17.002232Z",
-     "iopub.status.busy": "2026-07-11T19:31:17.002163Z",
-     "iopub.status.idle": "2026-07-11T19:31:17.004809Z",
-     "shell.execute_reply": "2026-07-11T19:31:17.004385Z"
-    },
-    "papermill": {
-     "duration": 0.004796,
-     "end_time": "2026-07-11T19:31:17.005047+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.000251+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "c766f988",
+   "metadata": {},
    "outputs": [],
    "source": [
     "def fit_gmm_grid(\n",
@@ -298,12 +401,7 @@
     "    n_components_list: Iterable[int],\n",
     "    random_state: int = SEED,\n",
     ") -> dict[int, GmmFitResult]:\n",
-    "    \"\"\"\n",
-    "    Fit a grid of GaussianMixture models and report diagnostics.\n",
-    "\n",
-    "    BIC and AIC are more appropriate for mixture models than silhouette,\n",
-    "    but silhouette can still be helpful as a coarse separation check.\n",
-    "    \"\"\"\n",
+    "    \"\"\"Fit one full-covariance mixture per requested cluster count.\"\"\"\n",
     "    results: dict[int, GmmFitResult] = {}\n",
     "    for n in n_components_list:\n",
     "        model = GaussianMixture(\n",
@@ -315,1326 +413,523 @@
     "        )\n",
     "        model.fit(x)\n",
     "        labels = model.predict(x)\n",
-    "        probs = model.predict_proba(x)\n",
-    "        bic = float(model.bic(x))\n",
-    "        aic = float(model.aic(x))\n",
-    "        sil = float(silhouette_score(x, labels)) if n >= 2 else float(\"nan\")\n",
     "        results[n] = GmmFitResult(\n",
     "            model=model,\n",
     "            labels=labels,\n",
-    "            probabilities=probs,\n",
-    "            bic=bic,\n",
-    "            aic=aic,\n",
-    "            silhouette=sil,\n",
+    "            probabilities=model.predict_proba(x),\n",
+    "            bic=float(model.bic(x)),\n",
+    "            aic=float(model.aic(x)),\n",
+    "            silhouette=float(silhouette_score(x, labels)),\n",
     "        )\n",
     "    return results"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "f2f3d112",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001523,
-     "end_time": "2026-07-11T19:31:17.008134+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.006611+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Load Factor Data"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "bcb68966",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:17.011806Z",
-     "iopub.status.busy": "2026-07-11T19:31:17.011738Z",
-     "iopub.status.idle": "2026-07-11T19:31:17.048363Z",
-     "shell.execute_reply": "2026-07-11T19:31:17.047830Z"
-    },
-    "papermill": {
-     "duration": 0.038963,
-     "end_time": "2026-07-11T19:31:17.048657+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.009694+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2m2026-07-11 15:31:17\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mRate limiter initialized      \u001b[0m \u001b[36mmax_calls\u001b[0m=\u001b[35m60\u001b[0m \u001b[36mperiod\u001b[0m=\u001b[35m60.0\u001b[0m \u001b[36mprovider\u001b[0m=\u001b[35maqr\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2m2026-07-11 15:31:17\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mHTTP session initialized      \u001b[0m \u001b[36mmax_connections\u001b[0m=\u001b[35m10\u001b[0m \u001b[36mtimeout\u001b[0m=\u001b[35m30.0\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2m2026-07-11 15:31:17\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mInitialized AQR factor provider\u001b[0m \u001b[36mdata_path\u001b[0m=\u001b[35mdata/factors/aqr\u001b[0m \u001b[36mname\u001b[0m=\u001b[35mAQRFactorProvider\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2m2026-07-11 15:31:17\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mFetched AQR data              \u001b[0m \u001b[36mcolumns\u001b[0m=\u001b[35m44\u001b[0m \u001b[36mdataset\u001b[0m=\u001b[35mcentury_premia\u001b[0m \u001b[36mname\u001b[0m=\u001b[35mAQRFactorProvider\u001b[0m \u001b[36mregion\u001b[0m=\u001b[35mNone\u001b[0m \u001b[36mrows\u001b[0m=\u001b[35m1182\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2m2026-07-11 15:31:17\u001b[0m [\u001b[32m\u001b[1mdebug    \u001b[0m] \u001b[1mHTTP session closed           \u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "AQR Century of Factor Premia: 1182 months, 44 factors\n",
-      "Date range: 1926-07-01 00:00:00 to 2024-12-01 00:00:00\n"
-     ]
-    }
-   ],
-   "source": [
-    "aqr_raw_pl = AQRFactorProvider().fetch(\"century_premia\")\n",
-    "\n",
-    "print(f\"AQR Century of Factor Premia: {aqr_raw_pl.height} months, {aqr_raw_pl.width - 1} factors\")\n",
-    "date_range = aqr_raw_pl.select(\n",
-    "    pl.col(\"timestamp\").min().alias(\"min\"), pl.col(\"timestamp\").max().alias(\"max\")\n",
-    ")\n",
-    "print(f\"Date range: {date_range['min'][0]} to {date_range['max'][0]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8b1a3248",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001688,
-     "end_time": "2026-07-11T19:31:17.052202+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.050514+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Understanding the Data\n",
-    "\n",
-    "The AQR \"Century of Factor Premia\" dataset contains monthly returns for various factor\n",
-    "strategies across asset classes. Key columns we use:\n",
-    "\n",
-    "| Factor | Description |\n",
-    "|--------|-------------|\n",
-    "| **Equity indices Market** | Global developed equity market return (value-weighted) |\n",
-    "| **All asset classes Value** | Cross-asset value factor (long cheap, short expensive) |\n",
-    "| **All asset classes Momentum** | Cross-asset momentum (long top-quantile past returns, short bottom-quantile) |\n",
-    "| **All asset classes Carry** | Cross-asset carry (long high yield, short low yield) |\n",
-    "| **All asset classes Defensive** | Cross-asset low-risk anomaly |\n",
-    "\n",
-    "The \"Equity indices Market\" is what you'd earn investing in a global equity index -\n",
-    "essentially the aggregate return from holding developed market stocks."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "73d062b9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001786,
-     "end_time": "2026-07-11T19:31:17.055658+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.053872+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Select Factors"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "e956d052",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:17.059666Z",
-     "iopub.status.busy": "2026-07-11T19:31:17.059528Z",
-     "iopub.status.idle": "2026-07-11T19:31:17.064043Z",
-     "shell.execute_reply": "2026-07-11T19:31:17.063624Z"
-    },
-    "papermill": {
-     "duration": 0.006977,
-     "end_time": "2026-07-11T19:31:17.064296+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.057319+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Selected 9 factors for regime detection:\n",
-      "  All asset classes Value: 0.0% missing\n",
-      "  All asset classes Momentum: 0.0% missing\n",
-      "  All asset classes Carry: 0.0% missing\n",
-      "  All asset classes Defensive: 0.0% missing\n",
-      "  US Stock Selection Value: 0.0% missing\n",
-      "  US Stock Selection Momentum: 0.5% missing\n",
-      "  Equity indices Market: 0.0% missing\n",
-      "  Fixed income Market: 0.0% missing\n",
-      "  Commodities Market: 0.0% missing\n"
-     ]
-    }
-   ],
-   "source": [
-    "factor_cols = [\n",
-    "    \"All asset classes Value\",\n",
-    "    \"All asset classes Momentum\",\n",
-    "    \"All asset classes Carry\",\n",
-    "    \"All asset classes Defensive\",\n",
-    "    \"US Stock Selection Value\",\n",
-    "    \"US Stock Selection Momentum\",\n",
-    "    \"Equity indices Market\",\n",
-    "    \"Fixed income Market\",\n",
-    "    \"Commodities Market\",\n",
-    "]\n",
-    "\n",
-    "available_cols = [c for c in factor_cols if c in aqr_raw_pl.columns]\n",
-    "print(f\"Selected {len(available_cols)} factors for regime detection:\")\n",
-    "for col in available_cols:\n",
-    "    na_count = aqr_raw_pl.select(pl.col(col).is_null().sum()).item()\n",
-    "    na_pct = na_count / aqr_raw_pl.height * 100\n",
-    "    print(f\"  {col}: {na_pct:.1f}% missing\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "33def6d3",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001659,
-     "end_time": "2026-07-11T19:31:17.067649+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.065990+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Prepare Data for Clustering"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "51b08b27",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:17.071638Z",
-     "iopub.status.busy": "2026-07-11T19:31:17.071523Z",
-     "iopub.status.idle": "2026-07-11T19:31:17.078309Z",
-     "shell.execute_reply": "2026-07-11T19:31:17.078060Z"
-    },
-    "papermill": {
-     "duration": 0.009487,
-     "end_time": "2026-07-11T19:31:17.078850+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.069363+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Factor data: 1176 months (1927 to 2024)\n"
-     ]
-    }
-   ],
-   "source": [
-    "factors_pl = (\n",
-    "    aqr_raw_pl.select([\"timestamp\"] + available_cols)\n",
-    "    .sort(\"timestamp\")\n",
-    "    .fill_null(strategy=\"forward\")\n",
-    "    .drop_nulls()\n",
-    ")\n",
-    "\n",
-    "factors_df = factors_pl.select(available_cols).to_pandas()\n",
-    "factors_df.index = factors_pl[\"timestamp\"].to_pandas()\n",
-    "\n",
-    "scaler = StandardScaler()\n",
-    "factors_scaled = scaler.fit_transform(factors_df)\n",
-    "\n",
-    "print(\n",
-    "    f\"Factor data: {len(factors_df)} months ({factors_df.index.min().year} to {factors_df.index.max().year})\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6abfd770",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001851,
-     "end_time": "2026-07-11T19:31:17.083632+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.081781+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Regime Detection with GMM"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "49c02cec",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:17.088774Z",
-     "iopub.status.busy": "2026-07-11T19:31:17.088706Z",
-     "iopub.status.idle": "2026-07-11T19:31:18.879271Z",
-     "shell.execute_reply": "2026-07-11T19:31:18.878809Z"
-    },
-    "papermill": {
-     "duration": 1.799247,
-     "end_time": "2026-07-11T19:31:18.885014+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:17.085767+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<style type=\"text/css\">\n",
-       "</style>\n",
-       "<table id=\"T_354ac\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_354ac_level0_col0\" class=\"col_heading level0 col0\" >BIC</th>\n",
-       "      <th id=\"T_354ac_level0_col1\" class=\"col_heading level0 col1\" >AIC</th>\n",
-       "      <th id=\"T_354ac_level0_col2\" class=\"col_heading level0 col2\" >Silhouette (GMM)</th>\n",
-       "      <th id=\"T_354ac_level0_col3\" class=\"col_heading level0 col3\" >Silhouette (K-Means)</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th class=\"index_name level0\" >n</th>\n",
-       "      <th class=\"blank col0\" >&nbsp;</th>\n",
-       "      <th class=\"blank col1\" >&nbsp;</th>\n",
-       "      <th class=\"blank col2\" >&nbsp;</th>\n",
-       "      <th class=\"blank col3\" >&nbsp;</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th id=\"T_354ac_level0_row0\" class=\"row_heading level0 row0\" >2</th>\n",
-       "      <td id=\"T_354ac_row0_col0\" class=\"data row0 col0\" >26169.8</td>\n",
-       "      <td id=\"T_354ac_row0_col1\" class=\"data row0 col1\" >25617.2</td>\n",
-       "      <td id=\"T_354ac_row0_col2\" class=\"data row0 col2\" >0.270</td>\n",
-       "      <td id=\"T_354ac_row0_col3\" class=\"data row0 col3\" >0.234</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th id=\"T_354ac_level0_row1\" class=\"row_heading level0 row1\" >3</th>\n",
-       "      <td id=\"T_354ac_row1_col0\" class=\"data row1 col0\" >26173.1</td>\n",
-       "      <td id=\"T_354ac_row1_col1\" class=\"data row1 col1\" >25341.7</td>\n",
-       "      <td id=\"T_354ac_row1_col2\" class=\"data row1 col2\" >0.115</td>\n",
-       "      <td id=\"T_354ac_row1_col3\" class=\"data row1 col3\" >0.113</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th id=\"T_354ac_level0_row2\" class=\"row_heading level0 row2\" >4</th>\n",
-       "      <td id=\"T_354ac_row2_col0\" class=\"data row2 col0\" >26258.9</td>\n",
-       "      <td id=\"T_354ac_row2_col1\" class=\"data row2 col1\" >25148.6</td>\n",
-       "      <td id=\"T_354ac_row2_col2\" class=\"data row2 col2\" >-0.024</td>\n",
-       "      <td id=\"T_354ac_row2_col3\" class=\"data row2 col3\" >0.096</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th id=\"T_354ac_level0_row3\" class=\"row_heading level0 row3\" >5</th>\n",
-       "      <td id=\"T_354ac_row3_col0\" class=\"data row3 col0\" >26387.6</td>\n",
-       "      <td id=\"T_354ac_row3_col1\" class=\"data row3 col1\" >24998.4</td>\n",
-       "      <td id=\"T_354ac_row3_col2\" class=\"data row3 col2\" >0.006</td>\n",
-       "      <td id=\"T_354ac_row3_col3\" class=\"data row3 col3\" >0.087</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th id=\"T_354ac_level0_row4\" class=\"row_heading level0 row4\" >6</th>\n",
-       "      <td id=\"T_354ac_row4_col0\" class=\"data row4 col0\" >26597.8</td>\n",
-       "      <td id=\"T_354ac_row4_col1\" class=\"data row4 col1\" >24929.8</td>\n",
-       "      <td id=\"T_354ac_row4_col2\" class=\"data row4 col2\" >0.003</td>\n",
-       "      <td id=\"T_354ac_row4_col3\" class=\"data row4 col3\" >0.077</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7747c4194d70>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "n_regimes_list = [2, 3, 4, 5, 6]\n",
-    "\n",
-    "# Fit GMM grid\n",
-    "gmm_grid = fit_gmm_grid(factors_scaled, n_regimes_list)\n",
-    "\n",
-    "# Also fit K-Means for comparison\n",
-    "kmeans_results = {}\n",
-    "for n in n_regimes_list:\n",
-    "    kmeans = KMeans(n_clusters=n, random_state=SEED, n_init=10)\n",
-    "    labels = kmeans.fit_predict(factors_scaled)\n",
-    "    kmeans_results[n] = (kmeans, labels)\n",
-    "\n",
-    "# Report model selection criteria as a DataFrame (lower BIC/AIC is better; higher silhouette is better).\n",
-    "selection_df = pd.DataFrame(\n",
-    "    {\n",
-    "        \"n\": n_regimes_list,\n",
-    "        \"BIC\": [gmm_grid[n].bic for n in n_regimes_list],\n",
-    "        \"AIC\": [gmm_grid[n].aic for n in n_regimes_list],\n",
-    "        \"Silhouette (GMM)\": [gmm_grid[n].silhouette for n in n_regimes_list],\n",
-    "        \"Silhouette (K-Means)\": [\n",
-    "            silhouette_score(factors_scaled, kmeans_results[n][1]) for n in n_regimes_list\n",
-    "        ],\n",
-    "    }\n",
-    ").set_index(\"n\")\n",
-    "selection_df.style.format(\n",
-    "    {\n",
-    "        \"BIC\": \"{:.1f}\",\n",
-    "        \"AIC\": \"{:.1f}\",\n",
-    "        \"Silhouette (GMM)\": \"{:.3f}\",\n",
-    "        \"Silhouette (K-Means)\": \"{:.3f}\",\n",
-    "    }\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "44986c23",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003556,
-     "end_time": "2026-07-11T19:31:18.893807+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:18.890251+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "**Interpretation**: BIC is minimised at K=2 (26,170) and silhouette is maximised\n",
-    "at K=2 (0.27); AIC keeps falling out to K=6 (24,930). BIC penalises model complexity\n",
-    "more heavily than AIC, making it the standard choice when the goal is interpretability\n",
-    "rather than maximum likelihood. We proceed with K=2 — a Risk-On / Risk-Off split that\n",
-    "both BIC and silhouette select on this 1927-2024 panel.\n",
-    "\n",
-    "The silhouette scores turn negative for K≥4 (−0.02 at K=4, near-zero for K=5 and K=6),\n",
-    "indicating that higher cluster counts produce overlapping, poorly separated regimes."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "671e4130",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003496,
-     "end_time": "2026-07-11T19:31:18.900692+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:18.897196+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Model Selection Visualization\n",
-    "\n",
-    "The charts below show BIC, AIC, and silhouette scores for different cluster counts.\n",
-    "Note the y-axis is scaled to highlight differences between models."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "4b58df87",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:18.913157Z",
-     "iopub.status.busy": "2026-07-11T19:31:18.912866Z",
-     "iopub.status.idle": "2026-07-11T19:31:18.915219Z",
-     "shell.execute_reply": "2026-07-11T19:31:18.914788Z"
-    },
-    "papermill": {
-     "duration": 0.006954,
-     "end_time": "2026-07-11T19:31:18.915600+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:18.908646+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "f205aeb8",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "metrics = {\n",
-    "    \"BIC\": [gmm_grid[n].bic for n in n_regimes_list],\n",
-    "    \"AIC\": [gmm_grid[n].aic for n in n_regimes_list],\n",
-    "    \"Silhouette\": [gmm_grid[n].silhouette for n in n_regimes_list],\n",
+    "gmm_grid = fit_gmm_grid(factors_scaled, N_REGIMES_GRID)\n",
+    "\n",
+    "kmeans_labels = {\n",
+    "    n: KMeans(n_clusters=n, random_state=SEED, n_init=10).fit_predict(factors_scaled)\n",
+    "    for n in N_REGIMES_GRID\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def switch_count(labels: np.ndarray) -> int:\n",
+    "    \"\"\"How many times consecutive months carry different labels.\"\"\"\n",
+    "    return int(np.sum(np.diff(labels) != 0))\n",
+    "\n",
+    "\n",
+    "selection = pd.DataFrame(\n",
+    "    {\n",
+    "        \"Clusters\": N_REGIMES_GRID,\n",
+    "        \"BIC\": [gmm_grid[n].bic for n in N_REGIMES_GRID],\n",
+    "        \"AIC\": [gmm_grid[n].aic for n in N_REGIMES_GRID],\n",
+    "        \"Silhouette (mixture)\": [gmm_grid[n].silhouette for n in N_REGIMES_GRID],\n",
+    "        \"Silhouette (k-means)\": [\n",
+    "            silhouette_score(factors_scaled, kmeans_labels[n]) for n in N_REGIMES_GRID\n",
+    "        ],\n",
+    "        \"Switches\": [switch_count(gmm_grid[n].labels) for n in N_REGIMES_GRID],\n",
+    "        \"Smallest cluster (months)\": [\n",
+    "            int(np.bincount(gmm_grid[n].labels).min()) for n in N_REGIMES_GRID\n",
+    "        ],\n",
+    "    }\n",
+    ").set_index(\"Clusters\")\n",
+    "selection.style.format(\n",
+    "    {\n",
+    "        \"BIC\": \"{:,.0f}\",\n",
+    "        \"AIC\": \"{:,.0f}\",\n",
+    "        \"Silhouette (mixture)\": \"{:.3f}\",\n",
+    "        \"Silhouette (k-means)\": \"{:.3f}\",\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82c4cd25",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "### Reading the three criteria against each other\n",
+    "\n",
+    "The bars below carry the same three columns. Both information criteria are drawn on a\n",
+    "zoomed vertical axis, because the differences between candidate models are small relative\n",
+    "to their level and would be invisible on a scale that started at zero; the silhouette\n",
+    "panel is drawn on its natural scale, which includes zero."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "170301c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_selection_criterion(ax: Axes, values: list[float], label: str, best: str) -> None:\n",
+    "    \"\"\"Draw one criterion as bars, highlighting the count it favours.\"\"\"\n",
+    "    bars = ax.bar(N_REGIMES_GRID, values, color=COLORS[\"recede\"])\n",
+    "    chosen = int(np.argmin(values)) if best == \"min\" else int(np.argmax(values))\n",
+    "    bars[chosen].set_color(COLORS[\"amber\"])\n",
+    "    ax.set_xlabel(\"Clusters\")\n",
+    "    ax.set_ylabel(label)\n",
+    "    ax.set_xticks(N_REGIMES_GRID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "879c7290",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=style.FIGSIZE[\"triple_h_tall\"])\n",
+    "\n",
+    "plot_selection_criterion(axes[0], selection[\"BIC\"].tolist(), \"BIC (lower is better)\", \"min\")\n",
+    "plot_selection_criterion(axes[1], selection[\"AIC\"].tolist(), \"AIC (lower is better)\", \"min\")\n",
+    "plot_selection_criterion(\n",
+    "    axes[2], selection[\"Silhouette (mixture)\"].tolist(), \"Silhouette (higher is better)\", \"max\"\n",
+    ")\n",
+    "for ax, values in ((axes[0], selection[\"BIC\"]), (axes[1], selection[\"AIC\"])):\n",
+    "    span = values.max() - values.min()\n",
+    "    ax.set_ylim(values.min() - 0.15 * span, values.max() + 0.15 * span)\n",
+    "\n",
+    "style.add_message_title(\n",
+    "    axes[0],\n",
+    "    \"BIC, AIC and silhouette do not pick the same number of regimes\",\n",
+    "    subtitle=\"Highlighted bar is the count each criterion favours; note the zoomed axes on BIC and AIC\",\n",
+    ")\n",
+    "style.show_with_alt(\n",
+    "    fig,\n",
+    "    \"Three bar charts over cluster counts two to six. BIC rises with the count, AIC falls \"\n",
+    "    \"with it, and the silhouette score falls sharply after the smallest count and hovers \"\n",
+    "    \"near zero at the larger ones.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94cef716",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bic_choice = int(selection[\"BIC\"].idxmin())\n",
+    "aic_choice = int(selection[\"AIC\"].idxmin())\n",
+    "silhouette_choice = int(selection[\"Silhouette (mixture)\"].idxmax())\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"BIC is lowest at **{bic_choice} clusters** and the silhouette score is highest at \"\n",
+    "        f\"**{silhouette_choice}**, while AIC keeps falling out to **{aic_choice}**, the \"\n",
+    "        \"largest count fitted.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "799f40c8",
+   "metadata": {},
+   "source": [
+    "When the criteria disagree, the choice is made on what the model is for. AIC targets\n",
+    "predictive likelihood and keeps buying clusters as long as they raise it, and the last two\n",
+    "columns say what it is buying at the larger counts: a partition that changes label more\n",
+    "often, containing at least one cluster with too few months to describe. A sliver of the\n",
+    "sample with its own covariance improves the fit and is not a regime anyone can name.\n",
+    "\n",
+    "BIC's sample-scaled penalty and the silhouette's separation test both ask for clusters\n",
+    "distinct enough to survive being described, which is what a regime has to be if it is going\n",
+    "to appear in a risk report. The rest of this notebook works with the two-cluster model on\n",
+    "that basis, and the timelines in the next section show what the larger counts do with the\n",
+    "clusters they add."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eaa7a46c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_REGIMES_SELECTED = 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a70719db",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## What each cluster count partitions\n",
+    "\n",
+    "Each band below is one fitted model. A month is shaded in the row of the cluster it was\n",
+    "assigned to, so a solid horizontal stretch is a period the model held in one regime and a\n",
+    "speckled stretch is one it switched through repeatedly. Comparing the bands shows what the\n",
+    "extra clusters buy: whether an added cluster carves out a recognisable era, or whether it\n",
+    "scatters across the whole century."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9aa30b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def decade_ticks(dates: pd.DatetimeIndex) -> tuple[list[int], list[str]]:\n",
+    "    \"\"\"Positions and labels for the first month of each decade in a monthly index.\"\"\"\n",
+    "    years = dates.year.tolist()\n",
+    "    ticks = [\n",
+    "        j for j, year in enumerate(years) if year % 10 == 0 and (j == 0 or years[j - 1] != year)\n",
+    "    ]\n",
+    "    return ticks, [str(years[j]) for j in ticks]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd30d574",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def draw_swimlanes(ax: Axes, rows: np.ndarray, n_rows: int, cmap: ListedColormap) -> None:\n",
+    "    \"\"\"Shade each month in the row given by *rows*, one row per regime.\"\"\"\n",
+    "    matrix = np.zeros((n_rows, len(rows)))\n",
+    "    matrix[rows, np.arange(len(rows))] = 1\n",
+    "    ax.imshow(\n",
+    "        matrix,\n",
+    "        aspect=\"auto\",\n",
+    "        cmap=cmap,\n",
+    "        vmin=0,\n",
+    "        vmax=1,\n",
+    "        extent=(0, len(rows), -0.5, n_rows - 0.5),\n",
+    "        interpolation=\"nearest\",\n",
+    "        origin=\"lower\",\n",
+    "    )\n",
+    "    for boundary in range(1, n_rows):\n",
+    "        ax.axhline(y=boundary - 0.5, color=COLORS[\"bg_light\"], linewidth=1.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17aa1a31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lane_cmap = ListedColormap([COLORS[\"bg_light\"], COLORS[\"blue\"]])\n",
+    "ticks, tick_labels = decade_ticks(factors_df.index)\n",
+    "\n",
+    "fig, axes = plt.subplots(\n",
+    "    len(N_REGIMES_GRID),\n",
+    "    1,\n",
+    "    figsize=(style.PAGE_WIDTH, 1.0 * len(N_REGIMES_GRID) + 1.0),\n",
+    "    sharex=True,\n",
+    ")\n",
+    "for ax, n in zip(axes, N_REGIMES_GRID):\n",
+    "    draw_swimlanes(ax, gmm_grid[n].labels, n, lane_cmap)\n",
+    "    ax.set_yticks([])\n",
+    "    ax.set_ylabel(f\"K = {n}\", rotation=0, ha=\"right\", va=\"center\")\n",
+    "\n",
+    "axes[-1].set_xticks(ticks)\n",
+    "axes[-1].set_xticklabels(tick_labels)\n",
+    "axes[-1].set_xlabel(\"Year\")\n",
+    "style.add_message_title(\n",
+    "    axes[0],\n",
+    "    \"Adding clusters makes the timeline switch more often, not cleaner\",\n",
+    "    subtitle=\"One panel per fitted model; a month is shaded in the row of the cluster it was assigned\",\n",
+    ")\n",
+    "style.show_with_alt(\n",
+    "    fig,\n",
+    "    \"Five stacked panels, one per cluster count. The two-cluster panel shows one row \"\n",
+    "    \"occupied most of the time and the other taking short scattered stretches. Each panel \"\n",
+    "    \"below it is more finely speckled than the one above, with no row holding a long \"\n",
+    "    \"uninterrupted stretch by the largest count.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b1f4d82",
+   "metadata": {},
+   "source": [
+    "No band settles down as clusters are added. An added cluster does not carve out an era the\n",
+    "earlier models had merged; it takes months from across the whole century, so each panel is\n",
+    "more finely speckled than the one above it. A mixture has no notion of time and nothing in\n",
+    "it prefers a month to keep its neighbour's label, so there is no mechanism by which more\n",
+    "clusters could produce longer stretches. That absence is the reason the last section of\n",
+    "this notebook points at a hidden Markov model, which supplies exactly the mechanism this\n",
+    "one lacks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "508ee49f",
+   "metadata": {},
+   "source": [
+    "## The two-cluster model: risk-on and risk-off\n",
+    "\n",
+    "The mixture returns cluster numbers, not names, and the numbering carries no meaning - a\n",
+    "different seed can swap it. To describe the two clusters they have to be identified by\n",
+    "something outside the model, and the natural choice is the series that says what the\n",
+    "market as a whole was doing: the average return to holding equity indices inside each\n",
+    "cluster. **Risk-on** and **risk-off** are the market's ordinary terms for the environments\n",
+    "that result, meaning periods when investors were adding exposure to risky assets and\n",
+    "periods when they were shedding it.\n",
+    "\n",
+    "Naming the clusters this way uses the whole sample, exactly as fitting them did. It is a\n",
+    "description of what the partition turned out to be, not a rule that could have been\n",
+    "applied in 1929."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89e5491d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labels_2 = gmm_grid[N_REGIMES_SELECTED].labels\n",
+    "equity_returns = factors_df[EQUITY_COLUMN]\n",
+    "\n",
+    "mean_equity_by_cluster = equity_returns.groupby(labels_2).mean()\n",
+    "risk_on_cluster = int(mean_equity_by_cluster.idxmax())\n",
+    "risk_off_cluster = int(mean_equity_by_cluster.idxmin())\n",
+    "\n",
+    "regime_name = pd.Series(\n",
+    "    np.where(labels_2 == risk_on_cluster, \"Risk-on\", \"Risk-off\"),\n",
+    "    index=factors_df.index,\n",
+    "    name=\"regime\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a5b4506",
+   "metadata": {},
+   "source": [
+    "### The timeline against dated events\n",
+    "\n",
+    "The upper panel is the same swim-lane band as above, restricted to the two-cluster model,\n",
+    "with seven dated episodes marked. The lower panel is the cumulative product of the equity\n",
+    "index returns on a logarithmic scale, drawn in the colour of the regime each month was\n",
+    "assigned to. A logarithmic scale is what makes the 1930s comparable to the 2010s: equal\n",
+    "vertical distances are equal percentage moves, so a fall of a given percentage takes up the\n",
+    "same space on the axis wherever in the century it happens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f9e1740",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HISTORICAL_EVENTS = {\n",
+    "    1929: (\"Great Crash\", \"top\"),\n",
+    "    1937: (\"Recession\", \"bottom\"),\n",
+    "    1973: (\"Oil crisis\", \"top\"),\n",
+    "    1987: (\"Black Monday\", \"bottom\"),\n",
+    "    2000: (\"Dot-com peak\", \"top\"),\n",
+    "    2008: (\"Global financial crisis\", \"bottom\"),\n",
+    "    2020: (\"COVID-19\", \"top\"),\n",
     "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "6b7e020d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:18.920609Z",
-     "iopub.status.busy": "2026-07-11T19:31:18.920539Z",
-     "iopub.status.idle": "2026-07-11T19:31:19.049070Z",
-     "shell.execute_reply": "2026-07-11T19:31:19.048544Z"
-    },
-    "papermill": {
-     "duration": 0.131203,
-     "end_time": "2026-07-11T19:31:19.049442+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:18.918239+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABJsAAAGsCAYAAAB6sKavAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA5OZJREFUeJzs3XdYFFfbBvB76UhVkaIoYMXeg4hSFEGs2EtiQWOJGINdE3vDXmIssQBGUSyxa1BUsGIPGgvEhhgVEKOiiIJwvj/8dl7XXXBXVzB6/65rL92ZM2eeGWbP7j475xyZEEKAiIiIiIiIiIhIC3QKOwAiIiIiIiIiIvp8MNlERERERERERERaw2QTERERERERERFpDZNNRERERERERESkNUw2ERERERERERGR1jDZREREREREREREWsNkExERERERERERaQ2TTUREREREREREpDVMNhERERERERERkdYw2URE9BFNmjQJMpkMMTEx711HYmIiZDIZevfurbW4PpRMJoOnp2dhhwHg0zw/pJnevXtDJpMhMTGxwOrP67rx9PSETCb7KHEQEWlbeno6fvjhBzg5OUFfXx8ymQxxcXGFHRYREZNNRF+6uLg4DBw4EFWqVIG5uTkMDAxga2uLZs2aYd68eXjw4IHSNjKZDDKZDIaGhnj48KHKeh89egRjY2Op7JtiYmKk5fXq1csztj/++EMqp25i42PW/V+SlJSEQYMGoUKFCjAyMoKpqSmcnJzQsmVLzJo1CxkZGYUdokYcHR3h6OhY2GF8MHnS482Hnp4ebG1t0bZtWxw9elRpG/k1PXDgQJV1Pn/+HIsWLYKXlxdKlCgBfX19FCtWDI0aNcLMmTNVvob/6169eoVffvkFrq6usLCwgIGBAezs7ODi4oKhQ4fizz//LOwQC438epk0aZLK9R87safK7du3oaurC5lMhjlz5hTYfr9EYWFhkMlkmDlzptK67OxsdO3aFTKZDN7e3nj27JlW9nnt2jXMmDED7u7uKFmyJAwMDFC6dGn07NkT8fHxWtnH2/r06QOZTIbixYvj5cuXeZaTJ4+Tk5NVrj937hz69u2LChUqwMTEBMbGxihXrhx69OiBqKgotWJ583OH/GFkZISyZcuiX79+H/21NmrUKPz888+oVq0axowZg4kTJ8LW1vaj7vN95ff3uHLlCuzt7aGjo4MlS5Zofd+pqakYOnSo9LmoePHicHV1xbJly7S+LyJ6Ta+wAyCiwpGbm4tRo0Zh3rx50NXVhbu7O3x8fGBiYoLU1FTExsZixIgRmDhxIhISElCqVCmF7fX09JCVlYXw8HAMGTJEqf7w8HC8ePECenp6ePXqlcoY9PT0cO7cOVy8eBE1atRQWr969ep8t8/Px6z7U3fhwgV4enri8ePHcHNzg5+fH0xNTZGUlISjR49i79696NChA8qXL1/YoWpFqVKlcPXqVVhYWBR2KGrr27cv7O3tAQCZmZm4evUq9u7di927d2Pbtm1o06aNWvVcuHABbdu2xe3bt+Hg4IA2bdrAxsYG6enpOHnyJMaOHYvg4GDcu3cPJiYmH/OQCkxOTg78/Pxw4MABlCxZEp06dYKNjQ0eP36M8+fP4+eff4aJiQlq164tbRMcHIwxY8YotWNUMEJCQpCbmwuZTIaQkBCMHDmysEP64jx//hzt27fHvn370L59e6xfvx6GhoZaqXv8+PHYuHEjqlWrhrZt28Lc3Bx//fUX1q5diy1btiAyMhLu7u5a2RcAPH36FJs2bYJMJsO///6L7du3o0uXLhrVkZubixEjRmDBggXQ09NDkyZN0KZNG+jr6+PmzZvYs2cP1q1bhylTpmD8+PFq1Vm3bl20atUKAPD48WPExMRg1apV+P3333Hq1ClUqFBB42NVx+7du1GxYkXs2rXro9RfEE6fPo0WLVogPT0d69atQ/fu3bVaf1xcHHx8fPDo0SO0bNkSHTt2xLNnz3D16lXs2rUL3333nVb3R0SvMdlE9IX66aefMG/ePNSpUwcbN25UmXg4f/48Ro8ejczMTKV15cqVgxACoaGhKpNNISEhqFSpEgAgISFBZQy+vr74448/EBISgoULFyqsS0tLw65du9CiRQvs3LlT4+P7mHV/6oYNG4bHjx/jt99+Q48ePZTWx8bGwsrKqhAi+zj09fXh7Oxc2GFo5Ntvv0WDBg0Ulm3evBmdO3fG3Llz1Uo2/fPPP/Dx8UFaWhrmzZuHH374Abq6ugpl/vzzTwwePBjZ2dlajb8wrV+/HgcOHEDz5s2xc+dO6OvrK6xPTk7GvXv3FJbZ2dnBzs6uIMOk/5ebm4uwsDBYWVmhVatWCAsLw4kTJ9CwYcPCDu2L8fjxY7Rs2RInTpxA37598euvvyq1FR+iefPmGD16tEKCFwAiIiLQrVs3fPfdd7h8+bLW9rdx40ZkZGRg2LBhWLhwIVavXq1xsmncuHFYsGABatWqhS1btqBcuXIK6zMzM/HLL7/kefe2KvXq1VO4o1AIgV69emHt2rWYPn06wsLCNIpRXffu3dNqMq+gHTx4EP7+/sjNzcWOHTvg5+en1frT09PRtm1bAK/vZHv7B8jP8UdHok8Fu9ERfYH+/vtvzJkzByVKlEBkZGSed7jUqVMHUVFReXZfCggIQFxcHM6fP6+w/MKFC/jzzz8REBCQbxz29vZo1qwZwsPDkZWVpbBu3bp1yMrKQp8+fdQ/MC3WnZaWhqCgIDg5OcHQ0BDW1tbo3LkzLl26pLL8nTt30K1bNxQrVgympqbw8PDAkSNH8o3xyJEjaN26NaysrGBoaIgKFSpg3LhxeP78ueYH/IbY2FhYWlqqTDQBgKurKywtLZWWX7x4EV27doWdnR0MDAzg4OCA77//XqMP21lZWZg/fz7q1KkDExMTmJmZoXHjxnkm9bKysrBgwQLUr18fZmZmMDU1RZUqVTBs2DA8evRIGlfn9u3buH37tkI3BfmH+vzGbLp9+zb69u2LUqVKwcDAAPb29ujbty+SkpKUyspv78/OzsakSZPg6OgIQ0NDVKxYEUuXLlX7HLyv5s2bA3h97anjp59+QmpqKn788UcMGzZM5ZfH2rVr4/DhwzA3N39nfdHR0ejTpw8qVaoEU1NTmJqaol69elixYoXK8vIuqCkpKejVqxesrKxgbGyMBg0a5DlG2eXLl9GqVSuYmZnBwsICLVq0yPM1lZfY2FgAwIABA5QSTQBga2uLOnXqKCx7n65jmlwHGRkZmDhxIpydnWFkZIRixYqhZcuWOH78uFLZ/GLJb4w3ddqLSZMmwcvLCwAwefJkhddLYmIiHB0dsWbNGgCAk5NTnl2Jb926hW+//RZlypSBoaEh7Ozs0Lt3b9y+fVvNs/c/UVFRSEpKQteuXdG3b18Ar+8szcvz588xatQolC5dGkZGRqhWrRpWrlyZZ/dAefx3795Fz549YWtrCx0dHYVzqGlbq622+fjx42jZsiWKFSsGIyMjODs7Y+LEiSrreZ/Xkzru378Pd3d3nDhxAiNHjsSqVau0mmgCXl/TbyeaAKBr166oWLEirly5otSupaWlIT4+Xu327k3yO5NHjRoFLy8vHDx4UKNr8/r165g9ezaKFy+OyMhIpUQTABgbG2PkyJGYPHmyxvHJyWQyBAYGAgDOnDkDQPH96urVq2jXrh2KFy+u1Cbs2LEDTZs2RdGiRaXXwdy5c5GTkyOVkbclQggcPnw4z9ezOnUB/+uCGRYWhl27dsHNzQ1mZmYKnwF///13eHh4wNraGkZGRihZsiS8vb3x+++/v9c52rp1K1q2bAk9PT3s379f64kmAFi6dCmSkpIwc+ZMlXe66+nx3guij4WvLqIv0Jo1a5CTk4MBAwagRIkS7yyf1xtxr169MG7cOISGhip8uVu9ejV0dXXRs2dPhIaG5lt3nz59sG/fPuzatQsdOnSQloeEhKBq1apwcXFR86i0V/eDBw/g6uqKGzduwNPTE127dsWtW7ewZcsW7NmzB/v27UOjRo2k8vfv34erqyvu3r0LX19f1KlTB1evXkWzZs2kL35vW7ZsGQIDA2FpaYnWrVvD2toaZ8+exfTp0xEdHY3o6GgYGBi813EXL15curujZMmSam2zc+dOdO7cGTo6Omjbti1Kly6NK1eu4JdffsG+fftw6tQpFC1aNN86Xr58iebNmyMmJga1atVC3759kZ2djT179qBt27ZYvHgxBg8eLJXPzMxEs2bNcPz4cVSoUAEBAQEwNDTEtWvX8Ouvv6Jnz55wdHTExIkTpbvTgoKCpO3fNdbW33//jUaNGuHBgwdo3bo1qlatikuXLiEkJAS7du3CsWPHULFiRaXtunXrhtOnT8PPzw+6urrYtGkTAgMDoa+vj379+imUlY9HJoTINxZ17N+/HwCUEiWqPH/+HBERETA2NsaIESPyLavuB+lZs2bh+vXraNCgAdq1a4fHjx8jMjISAwYMQEJCAubNm6e0zePHj9GoUSNYWFigR48eSE1NxcaNG+Hr64tz586hWrVqUtlLly7Bzc0Nz549Q/v27VGhQgWcPn0abm5uqFmzploxAq+vb+D13/djUvc6ePHiBZo0aYLTp0+jTp06CAoKQkpKCjZu3Ih9+/Zhw4YN6NSp0wfFom574enpicTERKxZswYeHh4KrxFLS0sEBQUhLCwMFy5cwA8//CAlnd/8Mnnq1Cn4+voiIyMDrVq1QoUKFZCYmIjw8HD88ccfiI2NRdmyZdWOXZ5Y6tmzJ+rXr4+yZcti06ZNWLRoEUxNTRXK5uTkoFWrVoiOjkb16tXRvXt3/Pvvvxg+fHi+r/eHDx/C1dUVxYoVQ9euXfHixQspwappW6uttnnz5s3o1q0bDA0N0aVLF1hbW2P//v2YMmUK9u3bh5iYGBgZGSlso8nrSR03b95Es2bNcPPmTcyaNQujRo3SaHttkCeE326HfvnlF0yePBkTJ07Mc3wxVa5cuYKTJ0+iRYsWsLGxQc+ePXHw4EGEhoaqXU9YWJj0GcjGxibfstrqavj22JXytrZ69ero3bs3Hj58KF1XY8eOxcyZM1GqVCm0b98eFhYWOHr0KEaOHIlTp05h8+bNAAB/f384Ojpi8uTJcHBwkH5wefP1rG5db9q8eTP279+PVq1aYdCgQUhPTwfw+rUxaNAg2NnZSUmy5ORknD59Gtu2bVP4nKWO1atXS59D9+3bpzIRpA0bN26ETCZDhw4dkJCQgP379yMzMxPOzs5o3rz5e3/WIiI1CCL64nh5eQkA4uDBg++1PQBRqVIlIYQQrVq1EsWKFRMvXrwQQgjx4sULUaxYMdG6dWshhBCVKlUSbzc10dHRAoAYMGCAePnypShevLho0aKFtP706dMCgJg3b564f/++ACA8PDzUik0bdQcEBAgAYuzYsQrL9+zZIwCI8uXLi5ycHGl5r169BAAxbdo0hfK//vqrACAAiOjoaGn55cuXhZ6enqhZs6ZIS0tT2CY4OFgAEHPnzpWW3bp1SwAQvXr1UuscDBs2TAAQTk5OYtasWeLEiRMiIyMjz/JpaWnC3NxclCpVSiQmJiqs27BhgwAgBg8erLBc1Xn78ccfBQAxfvx4kZubKy1PT08X9erVEwYGBuLu3bvS8uHDhwsAokePHuLVq1cKdT1+/Fg8ffpUeu7g4CAcHBxUxp/X+ZFf57/++qvC8iVLlggAokmTJgrLPTw8BADh4uIinjx5Ii2Pj48Xenp60jX/9nnQ5K1Ufq307dtXTJw4UUycOFGMGjVKtG3bVujr64s6deqI27dvK2zz5jUtFxMTIwCIRo0aqb3vd7l586bSsuzsbNGsWTOhq6urFJf82AcNGqTweli1apVSvEL87/yuW7dOYfnYsWOlum7duvXOOM+dOyf09PSEgYGBGDBggNi5c6e4d+9evtvIz/ub9ed13Wh6HUyePFkAEF9//bXCdX/+/HlhYGAgLC0tRXp6er6xyE2cOPGD2wv59TJx4kS1z4VcVlaWcHR0FGZmZuL8+fMK644ePSp0dXVFq1atVNarSlpamjAwMBDOzs7SsgkTJggAYtWqVUrl5deOn5+fQptw+fJlYWRkpPK45NdOQECAUjui6bnTtHxenjx5IiwsLIShoaG4cOGCtDwnJ0d06dJFABBTpkxReRzqvp7yEhoaKl2PdnZ2QldXV6xcuTLfbaKjo6X2SJ1HaGioWrGcOnVKABD169dXWie/1vO6TvMif3/bsGGDEEKIp0+fChMTE1GmTBmF8yYnfz3fv39fWubp6SkAiAMHDmi077yoaqOFECI3N1d6vQUEBAgh/tfuABATJkxQqmv//v0CgPD19RXPnj1TqGvgwIECgNiyZYvCNnl9RtK0Lvm1o6OjI6KiopTqq1OnjjAwMBApKSlK695+veRF/vcYMWKE9Dnl+vXr+W6zYMECja7PP//8U9r25cuXQldXV1hbW4upU6cKHR0d6fwDEGXLlhUXL15UK3Yi0hyTTURfoMqVKwsA4urVq0rrVH3ofPOLjxCKyaatW7cKACIiIkIIIURERIQAILZt2yaEeHeySQghhgwZInR1daVExMCBA4W+vr5ITU39oGTT+9T98uVLYWRkJIoXL64yQdOsWTMBQBw5ckShvLW1tcjMzFQom5OTIypUqKD05XHIkCEKdby9TYkSJUTdunWlZZommzIzM0Xv3r0VPlTp6uqKOnXqiKlTp4pHjx4plJ8/f74AIH777TeV9dWpU0dYWVkpLHv7vOXk5IiiRYuKcuXKKXzhltu5c6cAIBYvXiyEeJ3EMDMzExYWFuLff/995zFpmmy6ffu2ACCqVKmiFE9OTo5wdnYWAERSUpK0XP4h+NChQ0r7kK97M2kghBBXr15V+TrKi/yLh6qHlZWVmDNnjsjOzlbYRtUXGfnrrGvXrmrv+339/vvvAoAICwtTWA5AmJiYKCQFhXj9t9XT0xN16tSRlsn/HjVq1FCq/+nTp8LS0lLtZJMQQoSHhwsrKyuF82dvby969+4tzp49q1T+fZJN6l4HZcuWFfr6+uLOnTtK5fv166f02tI02aRpe/EhySZ5e/52IkSuffv2QkdHRyEJl58FCxYIAGL69OnSsuvXrwsAwtXVVam8PAnwdqJLCCH69++fZ7LJwMBAPHjwQGkbTc+dpuXz8ttvvwkA4rvvvlNad/v2baGnpyfKli2rdBzqvp7yI08YyB9jxox55zby607dhzrvx48fPxbOzs5CR0dH6TPE+8rKyhIlSpQQ5ubmCu+333zzjQAg9u3bp7SNqmSTvP2Pj4/XSlzy11zdunWlz01BQUGiVq1aAoAoVqyYlFCRtzu2trbi5cuXSnW1adNGAFBK7gvx+pzKZDLRoUMHheV5/U00rUt+7bRr107lcdapU0eYmJio9Z6dF/nfQ57Uunz58ju3cXBw0Oj6fDMZKv+cp6urK/T19cXcuXNFSkqK+Oeff8T48eOFTCYTDg4OSp/fiEg72I2OiBTExMSoHKMgry4MrVq1grW1NUJCQtClSxeEhITA2tpampFFHX369MHPP/+MNWvWYOjQoYiIiECrVq1QokSJPKcr/lh1x8fH48WLF/Dy8kKRIkWU1nt5eSEqKgpxcXFo3LgxEhISpG40b3eJ0NHRgZubG65du6aw/OTJkwCAffv24eDBg0r70NfX/6Dpoo2MjBAaGoqpU6di7969OH36NE6fPo3z58/j/Pnz+PXXX3H48GGpK4w8nlOnTuHGjRtK9b148QJpaWlIS0vLc2DxhIQEPHr0CCVLllR5/Tx48AAApOOKj4/H06dP4e3t/c7uee8jLi4OAODh4aHUfUFHRwfu7u6Ij49HXFwcSpcurbC+bt26SvXJZ457/PgxzMzMpOXvOzB5bGysNEB4VlYWEhMTsWjRIowcORKxsbHvPf7Fh3j69Cnmzp2L7du348aNG8jIyFBY//ag2wBQsWJFpa5Qenp60uxwchcuXAAAhe6ncqampqhVq5ZG49J0794d7du3R1RUFI4dO4Zz587hxIkTCAsLw2+//YYlS5Zg4MCBatenijrXQXp6Om7evInKlStL697k5eWFlStXIi4uLs8x1N7lY7cXqvaVkJCgsktScnIycnNz8ffff6NevXrvrG/16tWQyWT45ptvpGXlypVDw4YNceLECVy9ehWVK1eW1l24cEFpJkE5Nze3PMcPc3JyUtk2aXrutHWu//zzTwCq3zfLlCmDsmXL4u+//8bTp08V2hN1X0/q8PT0xPHjx7Fw4UJ4eXnBx8cnz7KTJk3SqCvbu2RmZqJdu3aIj4/H9OnT39nlWV07duzAgwcP0LdvX4X32549e2LdunVYvXp1vsf5sZ07dw7nzp0DABgYGKBUqVLo168ffvrpJzg4OCiUrVmzpsruWydPnoSJiQlCQkJU7sPY2Fjt1/v71vXVV1+pLN+1a1eMGjUK1apVQ/fu3eHl5YVGjRqpNSbg25o1a4aoqCj07NkTUVFR+X4O0GSsvbfl5uYCeN1Fd/DgwRg+fLi0bsqUKUhISMCmTZuwZcsWhXaKiLSDySaiL5CNjQ2uXr2Ke/fuKX1ZfvNDp3wmmfzo6+vjm2++wcKFC3HixAkcOHAAQ4cO1WjAxZo1a6JOnToIDQ1FmTJl8Pjx4/ceGPxD65aPTZDXOA7yGa3k5Z48eQIAsLa2VlleVT3//vsvAGD69OlqHsX7sbe3R//+/dG/f38AwI0bN9CnTx8cOXIEQ4cOxY4dOxTiWbJkSb71ZWRk5Jlsktdx+fLlfGcdkicw5OftY01Fr+nf8U2qPjjLr+e3B1TVBgMDA1SsWBFLlizBhQsXsHXrVhw/fhxubm55bmNrawsAuHv3rlZiyMrKgqenJ86fP4/atWujR48eKF68OPT09KQxgF6+fKm0XV5fMvT09BTO1fu8Tt7FyMgIrVu3RuvWrQG8TorOnTsX48ePxw8//AB/f3/pPL0Pda6DD7nO1FVQ7cWb+woPD8+33NuJSFVOnTqFS5cuwcvLC2XKlFFY17NnT5w4cQIhISGYM2eOtDw9PV0p+SuX3zWS1zpNz522zrU618Xff/+N9PR0hWSTuq8ndfj6+mLo0KHo1KkT2rRpg23btn2UwZff9uLFC7Rt2xbR0dEYO3YsfvzxR63V/eb4X29q2rQpSpUqhR07duDff/9FsWLF8q3H1tYW8fHxuHv3rjRrrjYMGDAAy5cvV6tsftfsq1ev8h2YXJ3X34fUlVdsI0aMQPHixbFs2TLMmzcPc+fOhZ6eHlq2bIkFCxbAyclJrbgAIDQ0FKNHj0Z4eDiaNm2KAwcOvPPv9j4sLCyk/6ua5bVNmzbYtGkTzp49y2QT0UfAZBPRF6hhw4aIiYlBdHQ0mjRp8sH19e3bF/Pnz0fnzp2Rm5srzTikaR2BgYEYPXo0SpYsqdUPxZrULf+wn5KSonK9/G4oeTn5B5nU1FSV5VXVI9/27S8aH1u5cuUQFhaGsmXL4tChQ0rx/PXXXxoPQPt2HR06dMCWLVveWV4+MLG2kiV5xaPu3/FT4eLiguPHj+PMmTP5Jpvq168PAwMDnD17Funp6R98HDt27MD58+fRt29frFq1SmFdRESENIPZ+3qf14mmjIyMMG7cOERFReHIkSM4fvy4xgPWaup9rjMdndcTAauabluelFO1j4JoL+T72rVrl0Z3p6oiTwxER0cr3V0o99tvv2HGjBnSINLm5ubSXZBvy+8ayat+Tc+dts71p9L+tGnTBlu3bkWHDh3Qrl07/P7772jZsqVSuZiYGI3uLHR0dFQ5+2dmZibatm2LqKgojBo1CjNmzPiA6BXduXNHmkTBw8Mjz3Lr1q3DkCFD8q3Lzc0NMTExOHjwoFY+A72P/K5ZmUz2XrP0aauuvGKTyWTo06cP+vTpg4cPH+Lo0aPYsGEDNm3ahGvXruHixYtqz3Soq6uL3377Tfq3SZMmOHDggMoftBYuXKjRnX3+/v6oVasWAMDExASlSpXC3bt3Vc7CK1+WmZmpdv1EpD4mm4i+QL169cLMmTOxYsUK/PDDD3neraKuKlWqwMXFBadOnUKDBg0UukWoq3v37hg+fDju3r2LMWPGaHVqZk3qlk9dfubMGTx//lypK538A7n8g0zFihVhZGSEs2fP4sWLFwq39ufm5uLEiRNK+3BxccH58+dx8uRJNGvW7MMPUANvd9GQx7N161bExsa+d7KpcuXKMDc3x9mzZ5Gdna1ySvo3VapUCebm5jhz5gwePXr0zq50urq6yMrKUjse+d/nyJEjEEIofHgWQuDIkSMK5T4Vjx49AvC/W//zUqRIEXTt2hW//fYb5s2bl+8v169evYKOjo6U5FBF3n2ybdu2SuuOHj2qTuj5ks82d+zYMaV1z549k7o9aoOqa/xjMTc3R9myZXH9+nXcvXtX6U69t9sLANK1fvfuXZQvX16hvLz71Zs0bS/k7Vted8Lkt14+Q2dsbOwHJZsyMjIQERGBIkWK5Hl37JkzZ3Dx4kXs3r0b7dq1A/D6OomJiUFcXJzSa1NVW/oump47bbXN8m6AMTEx6Ny5s8K6O3fu4MaNGyhbtmyB/NjQsmVLbNu2De3bt0f79u2xefNmpTs88uo+nxcPDw+lZNObiaYRI0Zg1qxZ2ghfEhYWhtzcXDRq1Ejl3UivXr3CmjVrsHr16ncmm3r37i19BgoKCsp3Vt6XL19qbUY6dbi4uOCPP/7AtWvXUKFChU+mrrcVL14c/v7+8Pf3R1paGg4dOoTr169rdKeYjo4OQkNDoauri9DQUDRp0gQHDx5U+nssXLgQt2/fVrteR0dHhfajSZMmWLt2La5cuaI02+uVK1ekbYhI+/L+5ElEn62KFSti1KhRSE1NhZ+fH65fv66ynCa/JIWEhGDbtm3Sr9masrS0xL59+7Bt2zYMHTr0verQRt0GBgbo1q0b0tLSEBwcrLAuMjIS+/btQ/ny5aW7TgwNDdG5c2ekpqYqTQ2/atUqldOzDxo0CHp6evj++++RlJSktP7x48cqv3Sqa8qUKbhz547SciEEZs6cCUBx7JyAgACYmZnhp59+UtkF7vnz59JYJnnR09PDd999h9u3b2PEiBHIzs5WKnPp0iXpzhY9PT0MGDAAT548wQ8//KD0xffJkyd49uyZ9LxYsWJIS0vDixcv8o1DrkyZMvDy8sLly5eVxqtYsWIFrl69iiZNmuTZZUdd8fHxWhsvJzExEVu3bgUAuLu7v7P89OnTUaJECUyfPh0///yzygTVxYsX4enp+c5uXPLxRN5OBh0+fBgrV65U9xDyVKZMGbi7u+PixYtKXbRmzJihUVsTERGBQ4cOQQihtO7kyZOIjo6Gnp6eNCbWx9arVy9kZ2dj7NixCjFdvHgRYWFhsLCwgL+/v7S8fv36AF5/eX7Tli1bcPjwYaX6NW0v5F1RVLUB71rftm1blClTBvPnz5cSsm/Kzs5WmTB82+bNm/H06VN07NgRq1atUvmQd5978z3j66+/BgCMGzdO4XqOj49/r7vrND132mqb27ZtCwsLC4SGhiq0qUIIjB49Gq9evVJ5Z9DH4ufnhx07dkBHRwcdO3bE9u3bFdZPmjQJ4vWkQWo93r4LSt51LioqCsOGDVPoGpmXSZMmQSaTqTVWlBACoaGhkMlkWLNmjcrrKSwsDK6urrh48SLOnj2bb33ly5fHqFGjkJaWBj8/P9y6dUupzIsXLzB//nytjmWlDnmiTH730NuSk5Nx9erVAq8LeJ2UfLvdzc7Olrqfvj1upTp0dHSwevVqfPvtt/jrr7/g5eWldAdsYmKiRtfn268t+fh9M2fOVHivSU5OxqJFi6Cjo/PR74Il+lLxziaiL9T06dORlZWF+fPnw9nZGe7u7qhZsyaKFCmC1NRUXLx4EadPn5YG732XKlWqoEqVKh8UkzpfsAui7lmzZuHw4cOYNm0aTpw4ARcXFyQmJmLz5s0oUqQIQkNDFe4SmTlzJg4ePIhx48bh2LFjqF27Nq5evYq9e/fCx8dHuvVfrlq1ali6dCm+++47VKpUCS1atEC5cuXw9OlT3Lx5E4cPH0bv3r3VHvvhbfIPyPXq1UPdunVRrFgxPHz4ENHR0fj7779RvHhxhcRYiRIlsGHDBnTq1Ak1a9ZE8+bN4ezsjJcvXyIxMRGHDx9Gw4YNERkZme9+J0+ejPPnz+Pnn3/Gnj174O7uDmtra9y9exd//fUXLly4gNjYWGncnilTpuDkyZNYu3YtTp48CT8/PxgaGuLmzZuIjIzEsWPHpGuvSZMmOHv2LPz8/NC4cWMYGBjA3d0937/rsmXL0KhRI/Tr1w+7du1ClSpVcPnyZezcuRMlSpTAsmXL3uv8vkl+F5+qxEd+Vq1aJZ3P7OxsJCYmYvv27Xj+/Dn69++v1uDL9vb22L9/P/z9/fHDDz9gwYIFaNq0KWxsbJCeno7Tp0/jzJkzMDc3f+edZq1bt4ajoyNmz56NS5cuoVq1akhISJDuOlGna+S7LFmyBG5ubujZsye2b9+OChUqSDE2btxY7TuoTp48iUWLFqFUqVJwd3dHmTJlkJWVhatXr2L//v3Izc3FzJkzP9p4YG8bNWoU9uzZg7Vr1+Lq1ato2rQpUlNTsXHjRrx69QorV65UuIOlbdu2UpfWO3fuSO3FoUOH0KJFC+zdu1ehfk3bC2dnZ5QsWRIREREwNDSEvb09ZDIZvv/+e1hYWKBJkyaYO3cu+vfvjw4dOsDExAQODg7o0aMHDA0NsWXLFvj5+cHDwwNNmjRB9erVIZPJcPv2bRw9ehTFixd/Z4JVnkAKCAjIs4y3tzfs7e0RGRmJe/fuoWTJkggICMDatWuxZ88e1K5dG35+fvj3338RERGBZs2aYdeuXfneofc2Tc+dttpmc3NzrFy5Et26dYOLiwu6dOmCEiVK4MCBAzh37hy++uorjBw5Uu3j0AYfHx/s2rULbdq0QefOnbFhwwatfcEeOHAgoqKiYGtrCzMzM5UJmt69eyvcPSJPJqozvuOhQ4dw69YteHh4SBNbqBIQEIDY2FisXr36nW3otGnT8OLFCyxYsACVKlVCkyZNUK1aNejr6+PWrVs4cOAAHj58iGnTpr0zPm1q3rw5xo8fj6lTp6J8+fJo3rw5HBwc8PDhQ1y/fh1Hjx7FtGnT1LqDXJt1Aa+7p5mbm6NBgwZwcHBAdnY2oqKicOXKFXTs2FFpEHR1yWQyrFixArq6uvj111/h6emJQ4cOfdCYe29q2LAhhg0bhvnz56NGjRpo3bo1srOzsWPHDqSmpmLGjBmoWLGiVvZFRG8pgBnviOgTdv78edG/f3/h7OwsTE1Nhb6+vrCxsRFNmjQRc+bMESkpKUrbABCVKlVSq/5KlSqJt5saVVO550U+ba06Uy1rs+4HDx6IIUOGCAcHB6Gvry+srKxEx44dxV9//aWyrtu3b4suXboIS0tLUaRIEdG4cWNx+PBhlVOZy50+fVp07dpVlCxZUtpHnTp1xJgxY8TVq1elcnlN0Z6XI0eOiDFjxghXV1epblNTU1GjRg0xYsQIce/ePZXbxcfHi759+woHBwdhYGAgihYtKqpXry6GDBkiTp8+rVA2r/P26tUr8euvvwo3Nzdhbm4uDA0NRZkyZUTz5s3FsmXLxLNnzxTKv3jxQsydO1fUqlVLGBsbC1NTU1GlShUxfPhw8ejRI6nc06dPRb9+/YSdnZ3Q1dVVmAI9v/OTmJgoAgIChJ2dndDT0xN2dnYiICBAJCYmKpWVT8msSl7TxeP/p1pWl7yeNx8ymUwULVpUeHp6irVr1ypt865rOiMjQyxcuFB4eHgIKysroaenJywtLYWrq6uYPn26SEtLUyu2mzdvig4dOogSJUqIIkWKiPr164uIiAhp/6qmnM/rdeng4CAcHByUlv/111+iRYsWwtTUVJiZmQk/Pz/x119/5Xl+VUlKShKLFy8WrVu3FuXLlxcmJibCwMBAlClTRnTq1EkcPHhQaRtV9ed13bzPdfDs2TMxfvx4UbFiRWFgYCAsLS2Fn5+fOHr0qMp6bt26Jfz9/YWZmZkwMTERTZs2FWfOnNFKeyGEECdPnhQeHh7CzMxMus7ejHn27NmiQoUKQl9fX+Xf8Z9//hE//PCDqFChgjA0NBTm5uaicuXK4ttvv1V5ft8UHx8vAAgnJyeRm5ubb9mffvpJABDTp09XOJfDhw8XJUuWFIaGhqJKlSpixYoVYsuWLQKAWLBggUId6rw/aHLu3qd8Xo4cOSL8/PyEpaWlMDAwEBUrVhTjx49XagffdRx5vZ5UkU9fHxwcrHL9oUOHRJEiRYSenp7YuHGjuoeSrzens8/r8fY13a5dO6GjoyMSEhLeWX+3bt2UprRX5cmTJ8LY2FhYWFiI58+fK8R2//59lducOXNG9OnTR5QvX14YGxsLQ0ND4ejoKLp37y6ioqLUOn5NPneo+34eFRUlWrduLUqUKCH09fWFra2tcHV1FVOnThVJSUkKZd/1GlC3Lvm1k9d5Xrp0qWjTpo1wcHAQRkZGonjx4uKrr74Sy5YtE1lZWe88diHy/3vk5uaKQYMGSZ8x8/qs8r5CQ0NFvXr1RJEiRYSJiYlo1KiR2Lp1q1b3QUSKZEJo+HMsEREREVEBGjduHKZPn469e/cWyKxq9HFZW1vD09MTmzZtKuxQiIjoI2GyiYiIiIg+Cffv34ednZ3CsitXrqBBgwbQ1dXFvXv3YGxsXEjRkTZcvXoVVapUwfnz56XB1ImI6PPDMZuIiIiI6JPw3XffITExEV999RWKFi2KGzduYNeuXcjOzsbq1auZaPoMVK5cWeNx7oiI6L+HdzYRERER0SchPDwcy5cvx9WrV/HkyROYmpqifv36GD58OHx9fQs7PCIiIlITk01ERERERERERKQ16s8fS0RERERERERE9A5MNhERERERERERkdYw2URERERERERERFrDZBMREREREREREWkNk01ERERERERERKQ1TDYREREREREREZHWMNlERERERERERERaw2QTERERERERERFpDZNNRERERERERESkNUw2ERERERERERGR1jDZREREREREREREWsNkExERERERERERaQ2TTUREREREREREpDVMNhERERERERERkdYw2USfPJlMhkmTJhV2GBpLSUlBx44dUbx4cchkMixcuLCwQ9Ka3r17w9HRsbDD+CCenp7w9PQssP1NmjQJMpmswPZHpC2JiYmQyWSYO3euVuoLCwuDTCZDYmKitMzR0RGtWrXSSv0fy5w5c1C2bFno6uqiVq1ahR2O1sTExEAmkyEmJqawQ3lvqq6pj0n+mggLCyuQ/RHR+3F0dETv3r2l56raO09PT1SrVq3ggyP6AjDZ9JmSf/B682FtbQ0vLy/88ccfhR3ef4I8OZCWlvZe2w8dOhT79u3D2LFjsXbtWjRv3lzLEX5c9+7dw6RJkxAXF1fYoShJT0/H5MmTUbNmTZiamsLY2BjVqlXD6NGjce/evfeq81M+XqKPaenSpZDJZHBxcSnsUD6aD02Y7d+/H6NGjYKbmxtCQ0MxY8YMLUf48S1duvSTTY5s27YNfn5+sLKygoGBAUqWLInOnTvj0KFD713np3y8RPRh/vrrL3Ts2BEODg4wMjJCqVKl0KxZMyxevLiwQ/sorly5gkmTJqlMqH+sti43Nxe//fYbXFxcUKxYMZiZmaFixYro2bMnTp48qfX90edJr7ADoI9rypQpcHJyghACKSkpCAsLQ4sWLbBr165P/ldkuczMTOjp/fcu1UOHDqFt27YYMWJEYYfyXu7du4fJkyfD0dFR6Vf8lStXIjc3t1DiunnzJry9vZGUlIROnTqhf//+MDAwwMWLF7F69Wps27YNf//99zvr2b9/v8Lz/I5XG8aNG4cxY8ZovV6iDxUeHg5HR0ecPn0a169fR/ny5T/q/nr06IGuXbvC0NDwo+5Hmw4dOgQdHR2sXr0aBgYGhR3Oe1m6dCmsrKwUfuUHAHd3d2RmZhbKcQkh0KdPH4SFhaF27doYNmwYbG1tcf/+fWzbtg1NmzbF8ePH0bBhw3zrUXVN5XW82uDg4IDMzEzo6+trvW4iyt+JEyfg5eWFMmXKoF+/frC1tcWdO3dw8uRJLFq0CN9//71UNiEhATo6//17K65cuYLJkyfD09NTqWfBx2rrhgwZgiVLlqBt27b4+uuvoaenh4SEBPzxxx8oW7YsGjRooNX90efpv/cNnjTi5+eHevXqSc/79u0LGxsbbNiw4T+TbDIyMirsEN5LamoqLC0ttVbfixcvYGBg8Em8aRbWB+xXr16hffv2SElJQUxMDBo1aqSwfvr06Zg1a1a+dTx//hxFihQpsC9WGRkZMDExgZ6e3n8yaUqft1u3buHEiRPYunUrBgwYgPDwcEycOPGj7lNXVxe6urofdR/alpqaCmNjY621G0IIvHjxAsbGxlqp70Po6OgU2vvsvHnzEBYWhqCgIMyfP1+hq/FPP/2EtWvX5ttuytvXgrqmXr16hdzcXBgYGPxnP5sQ/ddNnz4dFhYWOHPmjNLn7NTUVIXn/6UfNT4lKSkpWLp0Kfr164cVK1YorFu4cCEePHhQYLG82e7Sf0/hf2ulAmVpaQljY2OlD29z585Fw4YNUbx4cRgbG6Nu3brYsmWLQhkPDw/UrFlTZb2VKlWCr6+v9Dw3NxcLFy5E1apVYWRkBBsbGwwYMACPHj1S2O7s2bPw9fWFlZUVjI2N4eTkhD59+iiUeXvMptu3b2PQoEGoVKkSjI2NUbx4cXTq1Enp1lJ5V8Ljx49j2LBhKFGiBExMTNCuXbv3biTl/bqvXLkCLy8vFClSBKVKlcLs2bOV9iuEwJIlS6RujHI3b95Ep06dUKxYMRQpUgQNGjTAnj17FPYj71MeERGBcePGoVSpUihSpAjS09PRu3dvmJqaIikpCa1atYKpqSlKlSqFJUuWAHh9a3GTJk1gYmICBwcHrF+/XqHuf//9FyNGjED16tVhamoKc3Nz+Pn54cKFCwr7r1+/PgAgICBAOgb5bbqqxmzKyMjA8OHDUbp0aRgaGqJSpUqYO3cuhBAK5WQyGQYPHozt27ejWrVqMDQ0RNWqVREZGfnO8//777/jwoUL+Omnn5QSTQBgbm6O6dOnS8/lf69z587B3d0dRYoUwY8//iitk4/Z9K7jBYBTp06hefPmsLCwQJEiReDh4YHjx48r7F/e9fLKlSvo3r07ihYtKsWpasymV69eYerUqShXrhwMDQ3h6OiIH3/8ES9fvlQoJx/P5tixY/jqq69gZGSEsmXL4rfffnvnOSPKT3h4OIoWLYqWLVuiY8eOCA8PV2s7IYR0V+HWrVsBABcvXkTv3r1RtmxZGBkZwdbWFn369MHDhw8VtlV3fJ01a9ZAT08PI0eOlJap8zpUl7rvETKZDKGhocjIyFBqGzR9De/btw/16tWDsbExfv31V6mt37RpEyZPnoxSpUrBzMwMHTt2xJMnT/Dy5UsEBQXB2toapqamCAgIUKo7NDQUTZo0gbW1NQwNDVGlShUsW7ZMaf+XL1/G4cOHpWN4s/1TNWbT5s2bUbduXRgbG8PKygrffPMN7t69q1BG/n509+5d+Pv7w9TUFCVKlMCIESOQk5OT7/nPzMxEcHAwnJ2dMXfuXJVj2vXo0QNfffWVwt/r8OHDGDRoEKytrWFvb6+wTn5N5Xe8APD48WMEBQVJ71fly5fHrFmzFO7YfbPr5cKFC6W/8ZUrV/Ics+nQoUNo3LgxTExMYGlpibZt2+Lq1asKZeTvBdevX0fv3r1haWkJCwsLBAQE4Pnz5/meMyICbty4gapVq6r8Qdfa2lrh+dtjNuUnv8/2cqmpqdIP90ZGRqhZsybWrFmjUCavNjWvdiM+Ph4dO3ZEsWLFYGRkhHr16mHnzp3S+rCwMHTq1AkA4OXlJbVpMTExWmnrVLl16xaEEHBzc1NaJx+a5U2PHz/G0KFD4ejoCENDQ9jb26Nnz54KQ5Goc+7ya3fVOVf06eHP7J+5J0+eIC0tDUIIpKamYvHixXj27Bm++eYbhXKLFi1CmzZt8PXXXyMrKwsRERHo1KkTdu/ejZYtWwJ4/aGvX79+uHTpksJAemfOnMHff/+NcePGScsGDBiAsLAwBAQEYMiQIbh16xZ++eUX/Pnnnzh+/Dj09fWRmpoKHx8flChRAmPGjIGlpSUSExOlLy55OXPmDE6cOIGuXbvC3t4eiYmJWLZsGTw9PXHlyhUUKVJEofz333+PokWLYuLEiUhMTMTChQsxePBgbNy48b3O6aNHj9C8eXO0b98enTt3xpYtWzB69GhUr14dfn5+cHd3x9q1a9GjRw80a9YMPXv2lLZNSUlBw4YN8fz5cwwZMgTFixfHmjVr0KZNG2zZsgXt2rVT2NfUqVNhYGCAESNG4OXLl1JWPycnR9rX7NmzER4ejsGDB8PExAQ//fQTvv76a7Rv3x7Lly9Hz5494erqCicnJwCvk13bt29Hp06d4OTkhJSUFPz666/w8PDAlStXULJkSVSuXBlTpkzBhAkT0L9/fzRu3BgA8uzKIIRAmzZtEB0djb59+6JWrVrYt28fRo4cibt372LBggUK5Y8dO4atW7di0KBBMDMzw88//4wOHTogKSkJxYsXz/Pcy99QevToofbf6+HDh/Dz80PXrl3xzTffwMbGRqnMu4730KFD8PPzQ926dTFx4kTo6OhIX/COHj0qfRmS69SpEypUqIAZM2YoJdve9O2332LNmjXo2LEjhg8fjlOnTiE4OBhXr17Ftm3bFMpev34dHTt2RN++fdGrVy+EhISgd+/eqFu3LqpWrar2+SB6U3h4ONq3bw8DAwN069YNy5Ytw5kzZ6Tkqyo5OTno06cPNm7ciG3btknvEVFRUbh58yYCAgJga2uLy5cvY8WKFbh8+TJOnjyp0QD5K1aswMCBA/Hjjz9i2rRpADR/HarrXe8Ra9euxYoVK3D69GmsWrUKwP/aBk1ewwkJCejWrRsGDBiAfv36oVKlStK64OBgGBsbY8yYMbh+/ToWL14MfX196Ojo4NGjR5g0aRJOnjyJsLAwODk5YcKECdK2y5YtQ9WqVdGmTRvo6elh165dGDRoEHJzcxEYGAjg9S/R33//PUxNTfHTTz8BgMq2UE7+/l2/fn0EBwcjJSUFixYtwvHjx/Hnn38qfMnLycmBr68vXFxcMHfuXBw4cADz5s1DuXLl8N133+W5j2PHjuHff/9FUFCQRnclDRo0CCVKlMCECROQkZGhskx+x/v8+XN4eHjg7t27GDBgAMqUKYMTJ05g7NixuH//vtJkHqGhoXjx4gX69+8PQ0NDFCtWTOUXtQMHDsDPzw9ly5bFpEmTkJmZicWLF8PNzQ3nz59X+oGmc+fOcHJyQnBwMM6fP49Vq1bB2tr6nXfnEn3pHBwcEBsbq/R95EO867M98DpB7unpievXr2Pw4MFwcnLC5s2b0bt3bzx+/Bg//PCDxvu9fPky3NzcUKpUKYwZMwYmJibYtGkT/P398fvvv6Ndu3Zwd3fHkCFD8PPPP+PHH39E5cqVAbz+7KrNtu5NDg4OAF7/6NCpUyel71ZvevbsGRo3boyrV6+iT58+qFOnDtLS0rBz5078888/sLKy0vjcqWp31TlX9AkS9FkKDQ0VAJQehoaGIiwsTKn88+fPFZ5nZWWJatWqiSZNmkjLHj9+LIyMjMTo0aMVyg4ZMkSYmJiIZ8+eCSGEOHr0qAAgwsPDFcpFRkYqLN+2bZsAIM6cOZPvsQAQEydOzDNWIYSIjY0VAMRvv/2mdA68vb1Fbm6utHzo0KFCV1dXPH78ON/9Tpw4UQAQDx48kJZ5eHgo7efly5fC1tZWdOjQQSnuwMBAhWVBQUECgDh69Ki07OnTp8LJyUk4OjqKnJwcIYQQ0dHRAoAoW7as0vH26tVLABAzZsyQlj169EgYGxsLmUwmIiIipOXx8fFK5+/FixfSfuRu3bolDA0NxZQpU6RlZ86cEQBEaGio0rnp1auXcHBwkJ5v375dABDTpk1TKNexY0chk8nE9evXFc6LgYGBwrILFy4IAGLx4sVK+3pT7dq1hYWFRb5l3iT/ey1fvlzlOg8PD+l5Xsebm5srKlSoIHx9fRWuo+fPnwsnJyfRrFkzaZn8munWrZvS/uTr5OLi4gQA8e233yqUGzFihAAgDh06JC1zcHAQAMSRI0ekZampqcLQ0FAMHz783SeCSIWzZ88KACIqKkoI8fpat7e3Fz/88INCuVu3bgkAYs6cOSI7O1t06dJFGBsbi3379imUU9U2b9iwQenalbfNt27dkpY5ODiIli1bCiGEWLRokZDJZGLq1KnSek1eh6q8eQxvx6HOe0SvXr2EiYmJQp3v8xqOjIxUKCtv66tVqyaysrKk5d26dRMymUz4+fkplHd1dVVoe+Xn4G2+vr6ibNmyCsuqVq2q0Oa9HUN0dLQQ4vX7v7W1tahWrZrIzMyUyu3evVsAEBMmTJCWyd+P3nzvEOJ1W123bl2lfb1p0aJFAoDYtm1bvuXk5H+vRo0aiVevXqlc9+Y1ldfxTp06VZiYmIi///5bYfmYMWOErq6uSEpKEkL875oxNzcXqampCmXl6958v6hVq5awtrYWDx8+lJZduHBB6OjoiJ49e0rL5O8Fffr0UaizXbt2onjx4mqdC6Iv2f79+4Wurq7Q1dUVrq6uYtSoUWLfvn0Kbaicg4OD6NWrl/T87fZOCPU/2y9cuFAAEOvWrZOWZWVlCVdXV2FqairS09Pz3IcQqtuNpk2biurVq4sXL15Iy3Jzc0XDhg1FhQoVpGWbN29WWacQH97W5aVnz54CgChatKho166dmDt3rrh69apSuQkTJggAYuvWrUrr5O+t6p67/Npddc8VfVrYje4zt2TJEkRFRSEqKgrr1q2Dl5cXvv32W6W7h94cN+LRo0d48uQJGjdujPPnz0vLLSws0LZtW2zYsEG6WyMnJwcbN26Ev78/TExMALzOgltYWKBZs2ZIS0uTHnXr1oWpqSmio6MBQPpldPfu3cjOzlb7mN6MNTs7Gw8fPkT58uVhaWmpEK9c//79FX5Rb9y4MXJycnD79m219/kmU1NThTvDDAwM8NVXX+HmzZvv3Hbv3r346quvFLqAmZqaon///khMTJRuE5Xr1atXnmN6fPvtt9L/LS0tUalSJZiYmKBz587S8kqVKsHS0lIhNkNDQ2ncp5ycHDx8+BCmpqaoVKmSyvOnjr1790JXVxdDhgxRWD58+HAIIZRmQPT29ka5cuWk5zVq1IC5ufk7z2F6ejrMzMw0is3Q0BABAQEabfOmuLg4XLt2Dd27d8fDhw+l6zkjIwNNmzbFkSNHlH7lHjhw4Dvr3bt3LwBg2LBhCsuHDx8OAEpdK6tUqSLdcQUAJUqUQKVKldS67ohUCQ8Ph42NDby8vAC8vjW+S5cuiIiIUNkFKisrS7rjde/evfDx8VFY/2Zb9eLFC6SlpUkDiKrbtsyePRs//PADZs2apXC37Pu8DtX1vu8Rmr6GnZycFLqbv6lnz54KY+G5uLhIg2e/ycXFBXfu3MGrV6+kZW+ed/ndzB4eHrh58yaePHmS7zGocvbsWaSmpmLQoEEK4xK1bNkSzs7OSscFKLd5jRs3Vqs9B6Bxm96vX78PGp9p8+bNaNy4MYoWLarwGcXb2xs5OTk4cuSIQvkOHTqgRIkS+dZ5//59xMXFoXfv3ihWrJi0vEaNGmjWrJl0rbxJ1Tl7+PChdF6ISLVmzZohNjYWbdq0wYULFzB79mz4+vqiVKlS792lSp3P9nv37oWtrS26desmLdPX18eQIUPw7NkzHD58WKN9/vvvvzh06BA6d+6Mp0+fSm3Rw4cP4evri2vXril1XdaEpm3d20JDQ/HLL7/AyckJ27Ztw4gRI1C5cmU0bdpUIa7ff/8dNWvWVHlnkfy9VdNz93a7+7HPFX087Eb3mfvqq68UBgjv1q0bateujcGDB6NVq1ZSt6zdu3dj2rRpiIuLUxgP4u1uDz179sTGjRtx9OhRuLu748CBA0hJSVHo1nTt2jU8efJEqT+vnHzwPg8PD3To0AGTJ0/GggUL4OnpCX9/f3Tv3j3fAf3k4zyEhobi7t27Ct2UVH2wLlOmjMLzokWLAoDS+FHqsre3VzovRYsWxcWLF9+57e3bt1VOLy6/Jfb27dsKtwTLu769zcjISOnDr4WFhcrYLCwsFI41NzcXixYtwtKlS3Hr1i2FL5X5dWHLz+3bt1GyZEmlLw1vHteb3v6bAK/P4bv+JuokpN5WqlSpDxpU8Nq1awBeJ/7y8uTJE+m6AvL+u73p9u3b0NHRUZr5y9bWFpaWllo7Z0Sq5OTkICIiAl5eXrh165a03MXFBfPmzcPBgweVkknBwcF49uwZ/vjjD4UxIeT+/fdfTJ48GREREUqDtKqT9Dh8+DD27NmD0aNHK4zTBLzf61Bd7/seoelrOL924e0YLCwsAAClS5dWWp6bm4snT55I7fXx48cxceJExMbGKo358+TJE6kudcnjfrObn5yzszOOHTumsEzV+5G67TkAPH36VKP41Glf83Pt2jVcvHgxzwTS29euuu05oPqcVa5cGfv27ZMGM5fL77qTnxsiUq1+/frYunUrsrKycOHCBWzbtg0LFixAx44dERcXhypVqmhUnzqf7W/fvo0KFSooTdST12fdd7l+/TqEEBg/fjzGjx+vskxqaipKlSqlUb1ymrZ1b9PR0UFgYCACAwPx8OFDHD9+HMuXL8cff/yBrl274ujRowBej6HVoUOHfOvS9Ny93e5+7HNFHw+TTV8YHR0deHl5YdGiRbh27RqqVq2Ko0ePok2bNnB3d8fSpUthZ2cHfX19hIaGKg0u7evrCxsbG6xbtw7u7u5Yt24dbG1t4e3tLZXJzc2FtbV1ngPNyhs9mUyGLVu24OTJk9i1axf27duHPn36YN68eTh58iRMTU1Vbv/9998jNDQUQUFBcHV1hYWFBWQyGbp27aryl+28fgF9M0mlCW3Xl5+87mrKKwZ1YpsxYwbGjx+PPn36YOrUqShWrBh0dHQQFBT03ncGaOp9z6GzszP+/PNP3LlzR+lLWF4+dLYn+TmZM2cOatWqpbLM29eqJvtUdxybgrzu6PN36NAh3L9/HxEREYiIiFBaHx4erpRs8vX1RWRkJGbPng1PT0+l2bg6d+6MEydOYOTIkahVqxZMTU2Rm5uL5s2bq9W2VK1aFY8fP8batWsxYMAAhQ+b7/M6VNeHvrbUfQ3n1y68b5t+48YNNG3aFM7Ozpg/fz5Kly4NAwMD7N27FwsWLCiQNv197zJydnYG8HpSC39/f7W300ab3qxZM4waNUrl+ooVK2p1f3lhm0704QwMDFC/fn3Ur18fFStWREBAADZv3qzxrKrafD3m9Z7w9h3D8vZ5xIgRed71+vaPGZrQtK3LT/HixdGmTRu0adMGnp6eOHz4MG7fvi2N7aRtb7e7H/tc0cfDZNMXSH77/bNnzwC8vv3RyMgI+/btU7ijKDQ0VGlbXV1ddO/eHWFhYZg1axa2b9+udEt7uXLlcODAAbi5uan1Ia1BgwZo0KABpk+fjvXr1+Prr79GRESEQjexN23ZsgW9evXCvHnzpGUvXrzA48eP1Tr+wuTg4ICEhASl5fHx8dL6j23Lli3w8vLC6tWrFZY/fvwYVlZW0nNNBvN1cHDAgQMH8PTpU4W7m7R9XK1bt8aGDRuwbt06jB07Vit1yuV1vPLufubm5gpJ1Q/l4OCA3NxcXLt2TfplB3g9iPzjx48L5FqgL1d4eDisra2lWSzftHXrVmzbtg3Lly9XaMMbNGiAgQMHolWrVujUqRO2bdsmzWz66NEjHDx4EJMnT1YYvFp+R5I6rKyssGXLFjRq1AhNmzbFsWPHULJkSQAf73X4IT6F1/CuXbvw8uVL7Ny5U+FOGXl39Tep26bL405ISECTJk0U1iUkJGjtuBo1aoSiRYtiw4YN+PHHHz+oa5wq+bXpz54903p7DiDP93crKyuFu5qISPvkPTnu37//Uep3cHDAxYsXkZubq3CHztufdeV3Kb79veTtu3fKli0L4HV3sne1R/m13wXZ1gGvz/Phw4dx//59ODg4oFy5crh06VK+26h77vKiybmiTwvHbPrCZGdnY//+/TAwMJA+HOvq6kImkylk3BMTE7F9+3aVdfTo0QOPHj3CgAEDVM5s17lzZ+Tk5GDq1KlK27569UpqfB89eqT0i4H8F+u3p3Z+k66urtJ2ixcvfuc0y5+CFi1a4PTp04iNjZWWZWRkYMWKFXB0dNT4tt/3oer8bd68Wamvs/yDsTpJvBYtWiAnJwe//PKLwvIFCxZAJpNJM3l8qI4dO6J69eqYPn26wjmUe/r0qTQbh6byOt66deuiXLlymDt3rpSgfdObU6RrokWLFgCgNBvI/PnzAUCa4YtI2zIzM7F161a0atUKHTt2VHoMHjwYT58+VTn2hbe3NyIiIhAZGYkePXpIvzbKEwVvty35zXajir29PQ4cOIDMzEw0a9YMDx8+BPDxXocf4lN4Das670+ePFH5Y5GJiYla7Xm9evVgbW2N5cuXK7wX//HHH7h69arWjqtIkSIYPXo0rl69itGjR6u8g2DdunU4ffr0e9Wf1/F27twZsbGx2Ldvn9K6x48fK4yHpS47OzvUqlULa9asUdjnpUuXsH//fulaIaIPFx0drbK9kI+Npqo7qza0aNECycnJCrNZv3r1CosXL4apqSk8PDwAvE6c6OrqKo2JtHTpUoXn1tbW8PT0xK+//qoyQfbm+1p+n8k/RluXnJysNI4s8HrsxoMHDyp0Ie/QoYPUlfFt8r+TuucuL5qcK/q08M6mz9wff/whZY1TU1Oxfv16XLt2DWPGjJHGBGjZsiXmz5+P5s2bo3v37khNTcWSJUtQvnx5leMQ1a5dG9WqVcPmzZtRuXJl1KlTR2G9h4cHBgwYgODgYMTFxcHHxwf6+vq4du0aNm/ejEWLFqFjx45Ys2YNli5dinbt2qFcuXJ4+vQpVq5cCXNz83w/mLVq1Qpr166FhYUFqlSpgtjYWBw4cOC9xxsqSGPGjMGGDRvg5+eHIUOGoFixYlizZg1u3bqF33//Xakv88fQqlUrTJkyBQEBAWjYsCH++usvhIeHS78ayJUrVw6WlpZYvnw5zMzMYGJiAhcXF5XjV7Ru3RpeXl746aefkJiYiJo1a2L//v3YsWMHgoKCFAYD/xD6+vrYunUrvL294e7ujs6dO8PNzQ36+vq4fPky1q9fj6JFi2L69Oka153f8a5atQp+fn6oWrUqAgICUKpUKdy9exfR0dEwNzfHrl27NN5fzZo10atXL6xYsQKPHz+Gh4cHTp8+jTVr1sDf318atJlI23bu3ImnT5+iTZs2Ktc3aNAAJUqUQHh4OLp06aK03t/fH6GhoejZsyfMzc3x66+/wtzcHO7u7pg9ezays7NRqlQp7N+/X2E8KHWVL18e+/fvh6enJ3x9fXHo0CGYm5t/lNfhh/gUXsM+Pj4wMDBA69atpR+AVq5cCWtra6UP5HXr1sWyZcswbdo0lC9fHtbW1kp3LgGv29lZs2YhICAAHh4e6NatG1JSUrBo0SI4Ojpi6NChWot/5MiRuHz5MubNm4fo6Gh07NgRtra2SE5Oxvbt23H69GmcOHHiverO63hHjhyJnTt3olWrVujduzfq1q2LjIwM/PXXX9iyZQsSExMV7vJV15w5c+Dn5wdXV1f07dsXmZmZWLx4MSwsLDBp0qT3OgYiUvb999/j+fPnaNeuHZydnZGVlYUTJ05g48aNcHR0/KBJYfLTv39//Prrr+jduzfOnTsHR0dHbNmyBcePH8fChQulO/stLCzQqVMnLF68GDKZDOXKlcPu3btVjpG0ZMkSNGrUCNWrV0e/fv1QtmxZpKSkIDY2Fv/88w8uXLgA4PWP8bq6upg1axaePHkCQ0NDNGnSBNbW1h+lrfvnn3/w1VdfoUmTJmjatClsbW2RmpqKDRs24MKFCwgKCpK2HTlyJLZs2YJOnTqhT58+qFu3Lv7991/s3LkTy5cvR82aNdU+d/lR91zRJ6YAZ76jAiSfBvjNh5GRkahVq5ZYtmyZwjTPQgixevVqUaFCBWFoaCicnZ1FaGio0lTtb5o9e7YAIGbMmJFnDCtWrBB169YVxsbGwszMTFSvXl2MGjVK3Lt3TwghxPnz50W3bt1EmTJlhKGhobC2thatWrUSZ8+eVagHgJg4caL0/NGjRyIgIEBYWVkJU1NT4evrK+Lj45WmN5WfgzNnzijUl9eUpG+TH/+DBw+kZR4eHqJq1apKZXv16qU0HTUAERgYqFT2xo0bomPHjsLS0lIYGRmJr776SuzevVtljJs3b1a5r7en4M4vtjenFBdCiBcvXojhw4cLOzs7YWxsLNzc3ERsbKzw8PBQmjp1x44dokqVKkJPT09hulZVx/v06VMxdOhQUbJkSaGvry8qVKgg5syZo3St5XVe3v775efRo0diwoQJonr16qJIkSLCyMhIVKtWTYwdO1bcv3//nedEvk7d4xVCiD///FO0b99eFC9eXBgaGgoHBwfRuXNncfDgQamMqmvm7XVvys7OFpMnTxZOTk5CX19flC5dWowdO1ZhWlf5uXnzb5jfMRC9S+vWrYWRkZHIyMjIs0zv3r2Fvr6+SEtLk6YinjNnjkKZpUuXCgBixIgRQggh/vnnH9GuXTthaWkpLCwsRKdOncS9e/eU2nBV09SrusZPnTolzMzMhLu7u3j+/LkQQr3XoSqqjkGT94i82t0PfQ3n1dbnFZuqNmbnzp2iRo0awsjISDg6OopZs2aJkJAQpXOcnJwsWrZsKczMzAQAqe3I6z1x48aNonbt2sLQ0FAUK1ZMfP311+Kff/5RKJPXecnv84MqW7ZsET4+PqJYsWJCT09P2NnZiS5duoiYmJh3npM316lzvEK8fr8aO3asKF++vDAwMBBWVlaiYcOGYu7cudL06Xld92+ue/M9QgghDhw4INzc3ISxsbEwNzcXrVu3FleuXFF5bt5+n1B1DESk7I8//hB9+vQRzs7OwtTUVBgYGIjy5cuL77//XqSkpCiUffuzpar2TpPP9ikpKdJ3EAMDA1G9enWldkAIIR48eCA6dOggihQpIooWLSoGDBggLl26pLLduHHjhujZs6ewtbUV+vr6olSpUqJVq1Ziy5YtCuVWrlwpypYtK3R1dRWO4UPbOlXS09PFokWLhK+vr7C3txf6+vrCzMxMuLq6ipUrVyp9tn/48KEYPHiwKFWqlDAwMBD29vaiV69eIi0tTaNzl1+7q8m5ok+HTAiOREiaW7RoEYYOHYrExESVs2QRERERERER0ZeJySbSmBACNWvWRPHixVUOQkpEREREREREXy6O2URqy8jIwM6dOxEdHY2//voLO3bsKOyQiIiIiIiIiOgTwzubSG2JiYlwcnKCpaUlBg0a9F6DMBMRERERERHR543JJiIiIiIiIiIi0pqPP886ERERERERERF9MZhsIiIiIiIiIiIireEA4VqUm5uLe/fuwczMDDKZrLDDISIqEEIIPH36FCVLloSOzpf3GwbbfiL6ErHtZ9tPRF8eTdp+Jpu06N69eyhdunRhh0FEVCju3LkDe3v7wg6jwLHtJ6IvGdt+IqIvjzptP5NNWmRmZgbg9Yk3Nzcv5GiIiApGeno6SpcuLbWBXxq2/UT0JWLbz7afiL48mrT9TDZpkfwWWnNzc77pENEX50vtRsC2n4i+ZGz72fYT0ZdHnbb/y+tgTUREREREREREHw2TTUREREREREREpDVMNhERERERERERkdYw2URERERERERERFrDZBMREREREREREWkNk01ERERERERERKQ1TDYREREREREREZHWMNlERERERERERERaw2QTERERERERERFpDZNNRERERERERESkNXqFHQAREREREdGXJCsjFTkv0ws7jPema2gOAxPrwg6DiD5hTDYREREREREVkKyMVFzfOwAiN7uwQ3lvMh19lG/xKxNORJQndqMjIiIiIiIqIDkv0//TiSYAELnZ/+k7s4jo42OyiYiIiIiIiIiItIbJJiIiIiIiIiIi0homm4iIiIiIiIiISGuYbCIiIiIiIiIiIq0p9GRTcHAw6tevDzMzM1hbW8Pf3x8JCQlK5WJjY9GkSROYmJjA3Nwc7u7uyMzMVCizZ88euLi4wNjYGEWLFoW/v7/C+qSkJLRs2RJFihSBtbU1Ro4ciVevXimUiYmJQZ06dWBoaIjy5csjLCxM24dMRERERERERPTZKvRk0+HDhxEYGIiTJ08iKioK2dnZ8PHxQUZGhlQmNjYWzZs3h4+PD06fPo0zZ85g8ODB0NH5X/i///47evTogYCAAFy4cAHHjx9H9+7dpfU5OTlo2bIlsrKycOLECaxZswZhYWGYMGGCVObWrVto2bIlvLy8EBcXh6CgIHz77bfYt29fwZwMIiIiIiIiIqL/OJkQQhR2EG968OABrK2tcfjwYbi7uwMAGjRogGbNmmHq1Kkqt3n16hUcHR0xefJk9O3bV2WZP/74A61atcK9e/dgY2MDAFi+fDlGjx6NBw8ewMDAAKNHj8aePXtw6dIlabuuXbvi8ePHiIyMfGfs6enpsLCwwJMnT2Bubq7poRMR/Sd96W3fl378RPRl+tLbvg85/sx/r+NmVNDHCawAlW22EMbFyhd2GERUgDRp+wr9zqa3PXnyBABQrFgxAEBqaipOnToFa2trNGzYEDY2NvDw8MCxY8ekbc6fP4+7d+9CR0cHtWvXhp2dHfz8/BSSRrGxsahevbqUaAIAX19fpKen4/Lly1IZb29vhXh8fX0RGxurMtaXL18iPT1d4UFERERERERE9CXTK+wA3pSbm4ugoCC4ubmhWrVqAICbN28CACZNmoS5c+eiVq1a+O2339C0aVNcunQJFSpUUCgzf/58ODo6Yt68efD09MTff/+NYsWKITk5WSHRBEB6npycLP2rqkx6ejoyMzNhbGyssC44OBiTJ0/W/okgov+spKQkpKWlFXYY783KygplypQp7DC+KLxmiIiIiOhz80klmwIDA3Hp0iWFu5Zyc3MBAAMGDEBAQAAAoHbt2jh48CBCQkIQHBwslfnpp5/QoUMHAEBoaCjs7e2xefNmDBgw4KPEO3bsWAwbNkx6np6ejtKlS3+UfRHRpy8pKQmVnCvjRebzwg7lvRkZF0FC/FUmDwoIrxkiIiIi+hx9MsmmwYMHY/fu3Thy5Ajs7e2l5XZ2dgCAKlWqKJSvXLkykpKS8ixjaGiIsmXLSmVsbW1x+vRphTpSUlKkdfJ/5cveLGNubq50V5N8H4aGhpofLBF9ltLS0vAi8zmqdxgOkxL/vcRzxoM7+Ov3eUhLS2PioIDwmiEiIiKiz1GhJ5uEEPj++++xbds2xMTEwMnJSWG9o6MjSpYsiYSEBIXlf//9N/z8/AAAdevWhaGhIRISEtCoUSMAQHZ2NhITE+Hg4AAAcHV1xfTp05Gamgpra2sAQFRUFMzNzaUklaurK/bu3auwn6ioKLi6umr/wInos2VSojTMS3LATFIfrxkiIiIi+pwU+gDhgYGBWLduHdavXw8zMzMkJycjOTkZmZmZAACZTIaRI0fi559/xpYtW3D9+nWMHz8e8fHx0sxz5ubmGDhwICZOnIj9+/cjISEB3333HQCgU6dOAAAfHx9UqVIFPXr0wIULF7Bv3z6MGzcOgYGB0t1JAwcOxM2bNzFq1CjEx8dj6dKl2LRpE4YOHVoIZ4aI6PMVHByM+vXrw8zMDNbW1vD391f6UcHT0xMymUzhMXDgQKW6wsLCUKNGDRgZGcHa2hqBgYEK6y9evIjGjRvDyMgIpUuXxuzZs5Xq2Lx5M5ydnWFkZITq1asr/fBARERERETqK/Rk07Jly/DkyRN4enrCzs5OemzcuFEqExQUhLFjx2Lo0KGoWbMmDh48iKioKJQrV04qM2fOHHTt2hU9evRA/fr1cfv2bRw6dAhFixYFAOjq6mL37t3Q1dWFq6srvvnmG/Ts2RNTpkyR6nBycsKePXsQFRWFmjVrYt68eVi1ahV8fX0L7oQQEX0BDh8+jMDAQJw8eRJRUVHIzs6Gj48PMjIyFMr169cP9+/flx5vJ4rmz5+Pn376CWPGjMHly5dx4MABhTY7PT0dPj4+cHBwwLlz5zBnzhxMmjQJK1askMqcOHEC3bp1Q9++ffHnn3/C398f/v7+CjOaEhFR4VqyZAkcHR1hZGQEFxcXpeEx3rRy5Uo0btwYRYsWRdGiReHt7a1Uvnfv3ko/aDRv3vxjHwYR0Rfjk+hGp44xY8ZgzJgxea7X19fH3LlzMXfu3DzLODg4vPPXak9PT/z5559qxURERO8nMjJS4XlYWBisra1x7tw5uLu7S8uLFCkijav3tkePHmHcuHHYtWsXmjZtKi2vUaOG9P/w8HBkZWUhJCQEBgYGqFq1KuLi4jB//nz0798fALBo0SI0b94cI0eOBABMnToVUVFR+OWXX7B8+XKtHTMREb2fjRs3YtiwYVi+fDlcXFywcOFC+Pr6IiEhQRoe400xMTHo1q0bGjZsCCMjI8yaNQs+Pj64fPkySpUqJZVr3rw5QkNDpecci5WISHsK/c4mIiKiJ0+eAACKFSumsDw8PBxWVlaoVq0axo4di+fP/zdrW1RUFHJzc3H37l1UrlwZ9vb26Ny5M+7cuSOViY2Nhbu7OwwMDKRl8i8ojx49ksp4e3sr7NfX1xexsbEqY3358iXS09MVHkRE9PHMnz8f/fr1Q0BAAKpUqYLly5ejSJEiCAkJUVk+PDwcgwYNQq1ateDs7IxVq1YhNzcXBw8eVChnaGgIW1tb6SHvEUFERB+OySYiIipUubm5CAoKgpubG6pVqyYt7969O9atW4fo6GiMHTsWa9euxTfffCOtv3nzJnJzczFjxgwsXLgQW7Zswb///otmzZohKysLAJCcnAwbGxuF/cmfJycn51tGvv5twcHBsLCwkB6lS//3ZpEjIvqvyMrKwrlz5xR+FNDR0YG3t3eePwq87fnz58jOzlb6QSMmJgbW1taoVKkSvvvuOzx8+DDPOvhDAxGRZgq9Gx0REX3ZAgMDcenSJRw7dkxhubybGwBUr14ddnZ2aNq0KW7cuIFy5cohNzcX2dnZ+Pnnn+Hj4wMA2LBhA2xtbREdHf3RxtsbO3Yshg0bJj1PT09nwomI6CNJS0tDTk6Oyh8F4uPj1apj9OjRKFmypELCqnnz5mjfvj2cnJxw48YN/Pjjj/Dz80NsbCx0dXWV6ggODsbkyZM/7GCIiL4gTDYREVGhGTx4MHbv3o0jR47A3t4+37IuLi4AgOvXr6NcuXKws7MDAFSpUkUqU6JECVhZWSEpKQkAYGtri5SUFIV65M/lY0HlVSavsaIMDQ05rgcR0X/EzJkzERERgZiYGBgZGUnLu3btKv2/evXqqFGjBsqVK4eYmBiFcQDl+EMDEZFm2I2OiIgKnBACgwcPxrZt23Do0CE4OTm9c5u4uDgAkJJMbm5uAICEhASpzL///ou0tDQ4ODgAAFxdXXHkyBFkZ2dLZaKiolCpUiVpbA5XV1elcTyioqLg6ur6/gdIRERaYWVlBV1dXY1+FJCbO3cuZs6cif379ytMHqFK2bJlYWVlhevXr6tcb2hoCHNzc4UHERHljckmIiIqcIGBgVi3bh3Wr18PMzMzJCcnIzk5GZmZmQCAGzduYOrUqTh37hwSExOxc+dO9OzZE+7u7tIXhooVK6Jt27b44YcfcOLECVy6dAm9evWCs7MzvLy8ALwe98nAwAB9+/bF5cuXsXHjRixatEjh1+kffvgBkZGRmDdvHuLj4zFp0iScPXsWgwcPLvgTQ0RECgwMDFC3bl2FHwXkg33n96PA7NmzMXXqVERGRqJevXrv3M8///yDhw8fSj9oEBHRh2GyiYiICtyyZcvw5MkTeHp6ws7OTnps3LgRwOsvFwcOHICPjw+cnZ0xfPhwdOjQAbt27VKo57fffoOLiwtatmwJDw8P6OvrIzIyEvr6+gAACwsL7N+/H7du3ULdunUxfPhwTJgwQWE8qIYNG2L9+vVYsWIFatasiS1btmD79u0Kg5UTEVHhGTZsGFauXIk1a9bg6tWr+O6775CRkYGAgAAAQM+ePTF27Fip/KxZszB+/HiEhITA0dFR+kHj2bNnAIBnz55h5MiROHnyJBITE3Hw4EG0bdsW5cuX/2jj/RERfWk4ZhMRERU4IUS+60uXLo3Dhw+/sx5zc3OsXr0aq1evzrNMjRo1cPTo0Xzr6dSpEzp16vTO/RERUcHr0qULHjx4gAkTJiA5ORm1atVCZGSkNGh4UlISdHT+9xv6smXLkJWVhY4dOyrUM3HiREyaNAm6urq4ePEi1qxZg8ePH6NkyZLw8fHB1KlTOSYfEZGWMNlERERERESftMGDB+fZvTkmJkbheWJiYr51GRsbY9++fVqKjIiIVGE3OiIiIiIiIiIi0homm4iIiIiIiIiISGuYbCIiIiIiIiIiIq1hsomIiIiIiIiIiLSGySYiIiIiIiIiItIaJpuIiIiIiIiIiEhrmGwiIiIiIiIiIiKtYbKJiIiIiIiIiIi0hskmIiIiIiIiIiLSGr3CDoCIiIiIiD4fDx8+xOnTp3H//n1kZmaiePHiqFSpEmrVqgWZTFbY4RERUQFgsomIiIiIiD7IkydPsGbNGqxZswZxcXEQQiisl8lkMDU1Rbt27dCvXz+4ubkVUqRERFQQ2I2OiIiIiIje24wZM+Dk5IRFixahWbNm2LZtG27duoWnT58iKysLqampOHXqFGbNmoVHjx6hadOm8Pb2xpUrVwo7dCIi+kh4ZxMREREREb23mJgYbN26FZ6enirXW1lZwcrKCvXq1cPAgQPx6NEj/PLLL4iJiUGVKlUKNlgiIioQTDYREREREdF7279/v0blixYtivHjx3+kaIiI6FPAbnRERERERPTBXrx4gZo1a2qcfCIios8Pk01ERERERPTBjIyMcPfuXejo8CsGEdGXju8ERERERESkFe3bt8emTZsKOwwiIipkHLOJiIiIiIi0ws3NDT/++CNatWqFFi1awMbGBjKZTKFM+/btCyk6IiIqKEw2ERERERGRVgQEBAAA7t+/j7179yqtl8lkyMnJKeiwiIiogDHZREREREREWnHr1q3CDoGIiD4BTDYREREREZFWODg4FHYIRET0CeAA4UREREREpFWRkZGYOnUq+vfvj6SkJADAkSNHcO/evUKOjIiICgLvbCIiIiIiIq148OAB/P39cfLkSZQuXRp37tzBwIEDUaZMGYSEhMDExARLliwp7DCJiOgj451NRERERESkFUFBQXjw4AEuXbqE69evQwghrfP29sbBgwcLMToiIioovLOJiIiIiIi0Ys+ePVi5ciUqV66sNOtc6dKl8c8//xRSZEREVJB4ZxMRERW44OBg1K9fH2ZmZrC2toa/vz8SEhIUynh6ekImkyk8Bg4cqFDm7fUymQwREREKZWJiYlCnTh0YGhqifPnyCAsLU4pnyZIlcHR0hJGREVxcXHD69GmtHzMR0Zfg1atXMDExUbnu0aNHMDAwKOCIiIioMDDZREREBe7w4cMIDAzEyZMnERUVhezsbPj4+CAjI0OhXL9+/XD//n3pMXv2bKW6QkNDFcr4+/tL627duoWWLVvCy8sLcXFxCAoKwrfffot9+/ZJZTZu3Ihhw4Zh4sSJOH/+PGrWrAlfX1+kpqZ+tOMnIvpcubi4ICQkROW6iIgIuLm5FXBERERUGNiNjoiIClxkZKTC87CwMFhbW+PcuXNwd3eXlhcpUgS2trb51mVpaZlnmeXLl8PJyQnz5s0DAFSuXBnHjh3DggUL4OvrCwCYP38++vXrh4CAAGmbPXv2ICQkBGPGjHnvYyQi+hJNmzYNXl5ecHd3R8eOHSGTybB9+3YEBwdjz549OHbsWGGHSEREBYB3NhERUaF78uQJAKBYsWIKy8PDw2FlZYVq1aph7NixeP78udK2gYGBsLKywldffYWQkBCFwWhjY2Ph7e2tUN7X1xexsbEAgKysLJw7d06hjI6ODry9vaUyb3v58iXS09MVHkRE9Jqrqyuio6Mhk8kwfPhwCCEwffp03L9/HwcPHkSdOnUKO0QiIioAvLOJiIgKVW5uLoKCguDm5oZq1apJy7t37w4HBweULFkSFy9exOjRo5GQkICtW7dKZaZMmYImTZqgSJEi2L9/PwYNGoRnz55hyJAhAIDk5GTY2Ngo7M/Gxgbp6enIzMzEo0ePkJOTo7JMfHy8yniDg4MxefJkbR0+EdFnx9XVFYcPH5baWUtLSxQpUqSwwyIiogLEZBMRERWqwMBAXLp0SalrRf/+/aX/V69eHXZ2dmjatClu3LiBcuXKAQDGjx8vlalduzYyMjIwZ84cKdn0MYwdOxbDhg2Tnqenp6N06dIfbX9ERP8lffr0wfjx4+Hk5ARjY2MYGxtL627fvo3JkyfnOaYTERF9PtiNjoiICs3gwYOxe/duREdHw97ePt+yLi4uAIDr16/nW+aff/7By5cvAQC2trZISUlRKJOSkgJzc3MYGxvDysoKurq6KsvkNQ6UoaEhzM3NFR5ERPRaWFgYHjx4oHJdWloa1qxZU8ARERFRYWCyiYiICpwQAoMHD8a2bdtw6NAhODk5vXObuLg4AICdnV2+ZYoWLQpDQ0MAr7tyHDx4UKFMVFQUXF1dAQAGBgaoW7euQpnc3FwcPHhQKkNERJqRyWQql1+7dg3Fixcv4GiIiKgwsBsdEREVuMDAQKxfvx47duyAmZkZkpOTAQAWFhYwNjbGjRs3sH79erRo0QLFixfHxYsXMXToULi7u6NGjRoAgF27diElJQUNGjSAkZERoqKiMGPGDIwYMULaz8CBA/HLL79g1KhR6NOnDw4dOoRNmzZhz549Uplhw4ahV69eqFevHr766issXLgQGRkZ0ux0RESUv2XLlmHZsmUAXieaunfvrtB9DgBevHiBxMREdOrUqTBCJCKiAsZkExERFTj5lxJPT0+F5aGhoejduzcMDAxw4MABKfFTunRpdOjQAePGjZPK6uvrY8mSJRg6dCiEEChfvjzmz5+Pfv36SWWcnJywZ88eDB06FIsWLYK9vT1WrVoFX19fqUyXLl3w4MEDTJgwAcnJyahVqxYiIyOVBg0nIiLVSpYsibp16wIALl26hEqVKqFEiRIKZQwMDFC5cmX07du3MEIkIqICxmQTEREVOCFEvutLly6Nw4cP51umefPmaN68+Tv35enpiT///DPfMoMHD8bgwYPfWRcRESlr27Yt2rZtKz2fMGGCWt2jiYjo88Uxm4iIiIiISCvyGq8JeD0bXZ8+fd6r3iVLlsDR0RFGRkZwcXHB6dOn8yy7cuVKNG7cGEWLFkXRokXh7e2tVF4IgQkTJsDOzg7Gxsbw9vbGtWvX3is2IiJSxmQTERERERFpxZo1a7Q+G93GjRsxbNgwTJw4EefPn0fNmjXh6+uL1NRUleVjYmLQrVs3REdHIzY2FqVLl4aPjw/u3r0rlZk9ezZ+/vlnLF++HKdOnYKJiQl8fX3x4sULjeMjIiJlTDYREREREZFWCCG0PhudfDy+gIAAVKlSBcuXL0eRIkUQEhKisnx4eDgGDRqEWrVqwdnZGatWrZJmGpXHuHDhQowbNw5t27ZFjRo18Ntvv+HevXvYvn27xvEREZGyDxqzKScnBy9evICJiYm24iEiIiIiov+QjzkbXVZWFs6dO4exY8dKy3R0dODt7Y3Y2Fi16nj+/Dmys7NRrFgxAMCtW7eQnJwMb29vqYyFhQVcXFwQGxuLrl27ahQjEREp0+jOpocPH2Lx4sVo06YNbGxsYGBgAHNzcxgbG6NmzZoYPHjwOwd0fVtwcDDq168PMzMzWFtbw9/fHwkJCUrlYmNj0aRJE5iYmMDc3Bzu7u7IzMyU1js6OkImkyk8Zs6cqVDHxYsX0bhxYxgZGaF06dKYPXu20n42b94MZ2dnGBkZoXr16ti7d69Gx0NE9DnKycnBrl27MGTIELi4uKBMmTIoUaIEnJ2d0a1bNwBAYmJi4QZJRESFQj4bXd26dSGEQKVKlaTn8oeXlxdmz56N5cuXa1R3WloacnJylGYItbGxQXJyslp1jB49GiVLlpSSS/LtNKnz5cuXSE9PV3gQEVHe1LqzKSkpCRMmTEBERASKFSuGBg0aYNCgQbCysoKhoSEeP36MxMREnD17Fr/++iucnJwwceJEfP311++s+/DhwwgMDET9+vXx6tUr/Pjjj/Dx8cGVK1ekO6ZiY2PRvHlzjB07FosXL4aenh4uXLgAHR3FXNmUKVMUprw2MzOT/p+eng4fHx94e3tj+fLl+Ouvv9CnTx9YWlqif//+AIATJ06gW7duCA4ORqtWrbB+/Xr4+/vj/PnzqFatmjqniojos/Ls2TPMmzcPy5Ytw6NHj1C1alXUrFkT7u7uUvt//fp1AECdOnXg6emJyZMnw83NrZAjJyKigvIpz0Y3c+ZMREREICYmBkZGRu9dT3BwMCZPnqzFyIiIPm9qJZuqVKmCTp06ISoqCo0aNcp3lokHDx5g06ZNmDJlCu7cuYMxY8bkW3dkZKTC87CwMFhbW+PcuXNwd3cHAAwdOhRDhgxRqKtSpUpKdZmZmcHW1lblfsLDw5GVlYWQkBAYGBigatWqiIuLw/z586Vk06JFi9C8eXOMHDkSADB16lRERUXhl19+0fhXGCKiz4GTkxOqVauGOXPmwN/fXyGJL5eeng4LCwscOnQIu3btQuvWrTFt2jQMGjSoECImIqLCFBoaKv1fCIH79+/D2toaenrvN3qHlZUVdHV1kZKSorA8JSUlz8/9cnPnzsXMmTNx4MAB1KhRQ1ou3y4lJQV2dnYKddaqVUtlXWPHjsWwYcOk5+np6ShdurSmh0NE9MVQqxvd5cuXERoaisaNG+ebaAKAEiVKIDAwEPHx8ejRo4fGAT158gQApD7VqampOHXqFKytrdGwYUPY2NjAw8MDx44dU9p25syZKF68OGrXro05c+bg1atX0rrY2Fi4u7vDwMBAWubr64uEhAQ8evRIKvNm3215mbz6g/N2WiL63O3YsQPR0dHo0aOHykTTm2rVqoU5c+bg9u3b8PDwKKAIiYjoU7Nv3z40aNBAGrri4sWLAID+/fsjPDxco7oMDAxQt25daXBvANJg366urnluN3v2bEydOhWRkZGoV6+ewjonJyfY2toq1Jmeno5Tp07lWaehoSHMzc0VHkRElDe1kk0ODg4AXg/sN3/+fFy6dOmd28hkMpQqVUqjYHJzcxEUFAQ3Nzep29rNmzcBAJMmTUK/fv0QGRmJOnXqoGnTprh27Zq07ZAhQxAREYHo6GgMGDAAM2bMwKhRo6T1ycnJKvtly9flVyavvtvBwcGwsLCQHvx1g4g+Nw0bNgTweoDWrVu3Sm1yfszMzFC1atWPHRoREX2CNmzYgBYtWsDJyQlLly6FEEJaV65cOYU7n9Q1bNgwrFy5EmvWrMHVq1fx3XffISMjAwEBAQCAnj17KgwgPmvWLIwfPx4hISFwdHREcnIykpOT8ezZMwCvv6cEBQVh2rRp2LlzJ/766y/07NkTJUuWhL+//4edACIiAqDhbHRGRkYYN24c6tat+1GCCQwMxKVLlxTuWsrNzQUADBgwQHpDqV27Ng4ePIiQkBAEBwcDgMJtrTVq1ICBgQEGDBiA4OBgGBoafpR4eTstEX0pDAwM0L17d0RGRqJs2bKFHQ4REX2ipk6diqCgIMybNw85OTkK46lWrVoVCxYs0LjOLl264MGDB5gwYQKSk5NRq1YtREZGSj8SJyUlKYzlumzZMmRlZaFjx44K9UycOBGTJk0CAIwaNQoZGRno378/Hj9+jEaNGiEyMvKDxnUiIqL/0bjzdK1atXDlyhWtd5EYPHgwdu/ejSNHjsDe3l5aLu9HXaVKFYXylStXRlJSUp71ubi44NWrV0hMTESlSpVga2ursq838L9+23mVyas/uKGh4UdLZBERfWqcnZ3zbXeJiIhu3ryJFi1aqFxnYmIiDZmhqcGDB2Pw4MEq18XExCg8V2d2VJlMhilTpmDKlCnvFQ8REeVPrW50b1q0aBEWLFiALVu24Pnz5x8cgBACgwcPxrZt23Do0CGlmSscHR1RsmRJJCQkKCz/+++/pe59qsTFxUFHRwfW1tYAAFdXVxw5cgTZ2dlSmaioKFSqVAlFixaVyrzZd1teJr/+4EREX4rg4GBMmzYNZ8+eLexQiIjoE2Vra4v4+HiV6y5evJjv53ciIvp8aHxnU5MmTZCVlYUuXboAAIoUKaIwaLhMJtPoF4vAwECsX78eO3bsgJmZmTQ+koWFBYyNjSGTyTBy5EhMnDgRNWvWRK1atbBmzRrEx8djy5YtAF4P7H3q1Cl4eXnBzMwMsbGxGDp0KL755hspkdS9e3dMnjwZffv2xejRo3Hp0iUpcSb3ww8/wMPDA/PmzUPLli0RERGBs2fPYsWKFZqeJiKiz86oUaPw8OFDuLi4oHjx4rCxsYFMJpO6O7u5ueGvv/4q5CiJiKgwde/eHZMmTYKzszM8PT0BvP5+cOnSJcyePRvfffdd4QZIREQFQuNk0/Dhw985I50mli1bBgDSm5FcaGgoevfuDQAICgrCixcvMHToUPz777+oWbMmoqKiUK5cOQCvu7NFRERg0qRJePnyJZycnDB06FCF8ZQsLCywf/9+BAYGom7durCyssKECRPQv39/qUzDhg2xfv16jBs3Dj/++CMqVKiA7du3S4OVExF9yerWras0ow8AZGdn4/Lly6hZs2YhREVERJ+SSZMm4fLly2jWrBmKFy8OAPDz88ODBw/QqlUrjBkzppAjJCKigqBxskk+qJ62vDlDRX7GjBmT55tTnTp1cPLkyXfWUaNGDRw9ejTfMp06dUKnTp3UiomI6EsSFhamcnl6ejrCw8OxdOnSgg2IiIg+OQYGBtixYweio6MRFRWFtLQ0FCtWDN7e3vD29i7s8IiIqIBonGx60507d3Dnzh3UrFkTJiYm2oqJiIg+cUII3L9/XxoXj4iI6E1eXl7w8vIq7DCIiKiQaDxAOACsWLECpUqVgoODAxo3biwN3t2uXTssWrRIqwESEdGnY9++fWjQoAGMjIxQunRpXLx4UVq3adOmQoyMiIg+JVFRUZg2bRoCAwMxbdo0HDhwoLBDIiKiAqRxsmnhwoX4/vvv0bNnT+zfv1+hG5ynpyc2b96s1QCJiOjTsGHDBrRo0QJOTk5YunSpUjfodevWFVJkRET0qUhOToabmxt8fX2xcOFCREdHY+HChfDx8UHDhg2lyYCIiOjzpnGyafHixRg/fjyCg4OVbo2tVKmSdJcTERF9XqZOnYqgoCBs2LBBmsDhTVevXi34oIiI6JMycOBA3Lx5EwcPHkRaWhquXLmCtLQ0HDhwAImJiZyNjojoC6Fxsunu3bto2LChynX6+vp49uzZBwdFRESfnps3b6JFixZ5rk9PTy/AaIiI6FMUFRWF2bNnK/0o3aRJE8ycORP79+8vpMiIiKggaZxscnBwwOnTp1WuO3XqFCpWrPjBQRER0afH1tYW8fHxea4vXbp0AUZDRESfoqJFi6Jo0aJ5rrO0tCzYgIiIqFBonGzq168fpk2bhtWrV0u/YmdnZ2PPnj2YM2cOBgwYoPUgiYio8HXv3h2TJk3CwYMHpWUymQxXrlwBAHTp0qWwQiMiok9EUFAQZs6cqdTb4enTp5g1axZ++OGHQoqMiIgKkp6mG4wYMQJJSUno37+/lFhyc3MDAAwaNAiDBg3SboRERPRJmDRpEi5fvoxmzZqhePHiAAA/Pz88ePAAADB06NDCDI+IiArJkCFDFJ4nJibC3t4eXl5esLa2RmpqKqKjo2FmZoZ//vmnkKIkIqKCpHGyCQB+/vlnBAUF4cCBA0hLS0OxYsXQtGlTVKhQQdvxERHRJ8LAwAA7duxAdHQ0oqKipPbf1dUV/v7+0NN7r7cUIiL6j9u1a5fCc319fRQtWhRxcXHSMnnXut27d+Pnn38uyPCIiKgQaPzN4MiRI6hTpw7Kli2L/v37K6zLyMjAuXPn4O7urrUAiYjo05CUlAQ7Ozt4eXkpDPwq71J9584dVK1atbDCIyKiQnLr1q3CDoGIiD4xGo/Z5OXlJY3P8bb4+HilmSeIiOjz4OTkhD///DPP9TVq1CjAaIiIiIiI6FOlcbJJCJHnuoyMDBgbG39QQERE9GnKr/0HAENDQ7XrCg4ORv369WFmZgZra2v4+/sjISFBoYynpydkMpnCY+DAgSrre/jwIezt7SGTyfD48WOFdTExMahTpw4MDQ1Rvnx5hIWFKW2/ZMkSODo6wsjICC4uLnnOukpERERERO+mVje6kydP4sSJE9Lz9evX49ixYwplXrx4gR07dqBy5crajZCIiApNfHy8wt2sMTExSoO7Pnr0CADg6Oiodr2HDx9GYGAg6tevj1evXuHHH3+Ej48Prly5AhMTE6lcv379MGXKFOl5kSJFVNbXt29f1KhRA3fv3lVYfuvWLbRs2RIDBw5EeHg4Dh48iG+//RZ2dnbw9fUFAGzcuBHDhg3D8uXL4eLigoULF8LX1xcJCQmwtrZW+5iIiIiIiOg1tZJN+/btw+TJkwG8nuZa1aB++vr6qFy5MpYsWaLdCImIqNBs3LhRof0fM2ZMnmUnTJigdr2RkZEKz8PCwmBtba007l+RIkVga2ubb13Lli3D48ePMWHCBPzxxx8K65YvXw4nJyfMmzcPAFC5cmUcO3YMCxYskJJN8+fPR79+/RAQECBts2fPHoSEhOR7vEREREREpJpa3egmTpyI3Nxc5ObmQgiBkydPSs/lj5cvXyIuLg5ubm4fO2YiIiogQUFBuHXrFm7evAkhBLZu3Ypbt24pPOLj4wEALVq0eO/9PHnyBABQrFgxheXh4eGwsrJCtWrVMHbsWDx//lxh/ZUrVzBlyhT89ttv0NFRfkuLjY2Ft7e3wjJfX1/ExsYCALKysnDu3DmFMjo6OvD29pbKvO3ly5dIT09XeBARERER0f9oPBtddHQ0qlSponIdZ6MjIvq8WFhYwMLCAsDrLmklS5aEvr6+QpkPnY0uNzcXQUFBcHNzQ7Vq1aTl3bt3h4ODA0qWLImLFy9i9OjRSEhIwNatWwG8Tvp069YNc+bMQZkyZXDz5k2lupOTk2FjY6OwzMbGBunp6cjMzMSjR4+Qk5Ojsow8ifa24OBg6W4vIiJST1ZWFgwMDAo7DCIiKiAaDxDepEkTzkZHRPQFKlu27EeZjS4wMBCXLl1CRESEwvL+/fvD19cX1atXx9dff43ffvsN27Ztw40bNwAAY8eOReXKlfHNN9+8137f19ixY/HkyRPpcefOnQLdPxHRp2zt2rVYvHix9PzSpUuoUKECihQpAk9PT6SmphZidEREVFA4Gx0REalFm7PRyQ0ePBi7d+9GdHQ07O3t8y3r4uICALh+/ToA4NChQ9i8eTP09PSgp6eHpk2bAgCsrKwwceJEAICtrS1SUlIU6klJSYG5uTmMjY1hZWUFXV1dlWXyGivK0NAQ5ubmCg8iInptzpw5Ct2av//+exgYGGDhwoW4f/8+fvzxx0KMjoiICgpnoyMiojx9rNnohBD4/vvvsW3bNsTExMDJyemd28TFxQEA7OzsAAC///47MjMzpfVnzpxBnz59cPToUZQrVw4A4Orqir179yrUExUVBVdXVwCAgYEB6tati4MHD8Lf3x/A6259Bw8exODBg9U+HiIiei0xMVEaciMtLQ1Hjx7F7t270bx5c5QoUQIjRowo5AiJiKggaH02uqVLl2o3QiIiKjQfaza6wMBArF+/Hjt27ICZmRmSk5MBvB4jytjYGDdu3MD69evRokULFC9eHBcvXsTQoUPh7u4uddeTJ5Tk0tLSALyecc7S0hIAMHDgQPzyyy8YNWoU+vTpg0OHDmHTpk3Ys2ePtN2wYcPQq1cv1KtXD1999RUWLlyIjIwMaXY6IiJSn46ODrKysgC8HutVX19fGmbDzs4ODx8+LMzwiIiogKiVbJo4caLUJUFHRwcnT57EV1999VEDIyKiwhcUFITevXtDCIGyZcti69atqF27tkKZly9folKlShrNRrds2TIAgKenp8Ly0NBQ9O7dGwYGBjhw4ICU+CldujQ6dOiAcePGaRS/k5MT9uzZg6FDh2LRokWwt7fHqlWr4OvrK5Xp0qULHjx4gAkTJiA5ORm1atVCZGSk0qDhRET0bjVr1sTSpUthb2+Pn3/+GU2aNJG6WSclJcHa2rqQIyQiooKg8Wx0ubm5HyMOIiL6BL09G52dnZ3SbELy2eg08a7xn0qXLo3Dhw9rVKenp6fKej09PfMd2Bx4PXYUu80REX24GTNmoFWrVqhRowbMzMxw4MABad22bdv4gzUR0RdC42QTAGRnZ2P16tU4c+YM7ty5gyVLlqBChQrYuHEjatSowXGbiIg+Qw4ODgCAyMhIqf0fN26c1GXt/v37HCybiOgL5+bmhqSkJPz9998oV66c9B4BAH379kX58uULLzgiIiowGiebbt68CW9vb6SlpaF27do4duwYnj59CgA4cuQIIiMjERoaqvVAiYiocD148AD+/v44efIkSpcujTt37mDgwIHSF4m5c+di5cqVhRskEREVOjMzM9StW1dpuSbdrYmI6L9N42TTkCFDUKJECZw+fRqWlpYK3Sk8PDwwduxYrQZIRESfhqCgIDx48ACXLl1ChQoVlLrTadrtjYiIPg/z58/H119/DRsbG8yfPz/fsjKZDEOHDi2gyIiIqLBonGyKiYnBhg0bYGVlhZycHIV1tra2uH//vtaCIyKiT8eePXuwcuVKVK5cWan9B4B79+4VQlRERFTYRowYgUaNGsHGxgYjRozItyyTTUREXwaNk016enp5DuyakpICU1PTDw6KiIg+Pa9evYKJiUme6/X19QswGiIi+lS8OYEQJxMiIiIA0NF0Aw8PD8ybNw/Z2dnSMplMBiEEVqxYgaZNm2o1QCIi+jS4uLggJCQkz/UNGjQowGiIiIiIiOhTpfGdTbNmzULDhg1RpUoVtGnTBjKZDEuWLMGlS5dw7do1nD59+mPESUREhWzatGnw8vKCu7s7OnbsCJlMhu3bt+PixYsAwDH7iIiIiIgIwHvc2eTs7Ixz586hYcOG2LBhA3R1dbF7926UL18ep0+fRrly5T5GnEREVMhcXV0RHR0NmUyG4cOHQwiB6dOnIyUlBQBQq1atwg2QiIiIiIg+CRrf2QQATk5OWLNmjbZjISKiT5yrqysOHz6MzMxMPHr0CJaWlnj16hUsLCwKOzQiIiIiIvpEaHxn05v++ecfnDlzBnfv3tVWPERE9B9gZGQEfX19GBsbF3YoRERERET0iXmvZNOKFStQpkwZODg4wMXFBWXKlEHp0qXx66+/ajs+IiL6hOzfvx9ubm4wNjaGra0tjI2N4ePjU9hhERHRJ+DFixdo06YNjhw5UtihEBFRIdM42RQcHIyBAwfCy8sL27dvx8mTJ7F9+3Z4eXlh0KBBCA4O/hhxEhFRIQsNDYWfnx/09fUxZ84cbNiwAXPmzIGe3use2WvXri3kCImIqDAZGRnh8OHDyMnJ0XrdS5YsgaOjI4yMjODi4pLvpESXL19Ghw4d4OjoCJlMhoULFyqVmTRpEmQymcLD2dlZ63ETEX2pNB6zafHixRg5ciRmzZqlsLx169awsbHB4sWLOSMREdFnaMqUKejduzdWr16tsLxXr16wsLDA7NmzERgYWEjRERHRp8DHxwf79++Hl5eX1urcuHEjhg0bhuXLl8PFxQULFy6Er68vEhISYG1trVT++fPnKFu2LDp16oShQ4fmWW/VqlVx4MAB6bn8xxMiIvpwGreo6enp8Pb2VrnOx8cHy5cv/+CgiIjo05OamoquXbvmuT4tLa0AoyEiok9RQEAABgwYgKdPn6JFixawsbGBTCZTKFOnTh2N6pw/fz769euHgIAAAMDy5cuxZ88ehISEYMyYMUrl69evj/r16wOAyvVyenp6sLW11SgWIiJSj8bJJl9fXxw4cADNmjVTWhcVFYWmTZtqJTAiIvq0NGjQAOfPn1fZ/gNA3bp1Czgi+i9KSkr6zycmraysUKZMmcIOg+iT1KpVKwDA0qVLsXTpUoVEkxACMplMo252WVlZOHfunELPCR0dHXh7eyM2NvaDYr127RpKliwJIyMjuLq6Ijg4OM/X9suXL/Hy5UvpeXp6+gftm4joc6dWsun8+fPS/7/99lsMGDAAqamp8Pf3h7W1NVJTU7Ft2zYcOnSIg4QTEX1G/v33X+n/M2bMQLdu3fDixQuF9j8iIgLA6/EviPKTlJSESs6V8SLzeWGH8kGMjIsgIf4qE05EKkRHR2u1vrS0NOTk5MDGxkZhuY2NDeLj49+7XhcXF4SFhaFSpUq4f/8+Jk+ejMaNG+PSpUswMzNTKh8cHIzJkye/9/6IiL40aiWb6tWrp/SrxJo1a7BmzRrIZDIIIaR1rVq1+iiDAhIRUcGzsrJSav8nT56MKVOmKCwDgGbNmrH9p3ylpaXhReZzVO8wHCYlShd2OO8l48Ed/PX7PKSlpTHZRKSCh4dHYYegFj8/P+n/NWrUgIuLCxwcHLBp0yb07dtXqfzYsWMxbNgw6Xl6ejpKl/5vtmNERAVBrWSTtn+hICKi/4aQkBClsTbelpmZie+++w5LliwpoKjov86kRGmYlyxf2GEQ0Ud09epVnD17Fnfu3EGfPn1ga2uL69evw8bGRuWdQ3mxsrKCrq4uUlJSFJanpKRodbwlS0tLVKxYEdevX1e53tDQEIaGhlrbHxHR506tZNN/5RcKIiLSrt69e7+zTHp6Or777jt079794wdERESftOfPn+Pbb7/Fxo0boaOjg9zcXDRv3hy2trYYO3YsnJycMHv2bLXrMzAwQN26dXHw4EH4+/sDAHJzc3Hw4EEMHjxYa3E/e/YMN27cQI8ePbRWJxHRl0ynsAMgIiIiIqLPw4gRI3Do0CH88ccfSE9PVxhuo0WLFoiMjNS4zmHDhmHlypVYs2YNrl69iu+++w4ZGRnS7HQ9e/ZUGEA8KysLcXFxiIuLQ1ZWFu7evYu4uDiFu5ZGjBiBw4cPIzExESdOnEC7du2gq6uLbt26fcDRExGRnMaz0REREREREamyZcsWzJkzBz4+Pkrj+Dk6OiIxMVHjOrt06YIHDx5gwoQJSE5ORq1atRAZGSkNGp6UlAQdnf/9hn7v3j3Url1bej537lzMnTsXHh4eiImJAQD8888/6NatGx4+fIgSJUqgUaNGOHnyJEqUKKH5QRMRkRImm4iIiIiISCuePXsGOzs7lesyMjLeu97Bgwfn2W1OnkCSc3R0VLijShX5TKpERPRxsBsdERERERFpRY0aNfD777+rXLdnzx7Uq1evgCMiIqLCwDubiIiIiIhIK8aPH4+2bdvi+fPn6NSpE2QyGU6fPo0NGzYgJCQEe/fuLewQiYioAGicbLp9+zbS09NRvXp1AMDLly8xd+5cXL16Fd7e3mrNXERERP89T58+xcuXL2FlZSUtCw8PR1xcXOEFRUREn5SWLVsiIiICI0eORHh4OABg0KBBsLe3R3h4OJo2bVrIERIRUUHQuBtdv379sHbtWun56NGjMXnyZMTHx6N///5YunSpVgMkIqJPwzfffIPx48dLz6dMmYIePXogJCQEALB169bCCo2IiD4hHTt2xK1btxAfH49jx47hypUrSEpKQseOHQs7NCIiKiAaJ5vi4uLQuHFjAMCrV6+wZs0azJo1C2fPnsWkSZOwbNkyrQdJRESF78yZM/Dx8QEACCGwZMkS/Pjjj7h16xYA4Oeffy7M8IiI6BNTsWJFNGzYEM7OzoUdChERFTCNk01Pnz6FhYUFAODUqVNIT09H165dAQCNGjXCzZs3NaovODgY9evXh5mZGaytreHv74+EhASlcrGxsWjSpMn/tXfvcTnf///AH1dxXR1USmdSOaxIB3JKU6EVmmnDHOc4xgqVUTnWmGaENqaZbzOzxoc5zFlyngyRxGQZnwwXmlZzquj9+8Ov92fXKrpSvavrcb/drtun6/V+Xa/r+co+z+p5vV+vF/T19WFoaAgvLy88fvy4VL+CggK4ublBJpOVWtqRnp6O7t27Q0dHBzY2Nvjss89KvX7Tpk1wdHSEjo4OnJ2dua6ciOj/u3//vriELjU1FTk5ORg7dqx4PSsrq8JjVST3+/j4QCaTqTwmTpwoXv/zzz/Ru3dvWFtbQ6FQwMbGBsHBwcjPz1cZ5/Dhw+jQoQMUCgVatWqFtWvXlopn5cqVsLOzg46ODrp06YJTp05VeC5ERKQqMzMTCxcuxIcffoixY8eqPMaNGyd1eEREVAPULjY1a9YMJ0+eBPB8yUTbtm3F401zc3Ohp6en1nhHjhxBUFAQTp48iaSkJBQVFcHPz0/laNSUlBT07t0bfn5+OHXqFE6fPo3g4GBoaZUOf8aMGbC2ti7Vnp+fDz8/P9ja2iI1NRWLFy9GVFQUVq9eLfY5ceIEhg4dinHjxuHcuXMIDAxEYGAgMjIy1JoTEVF9ZGFhgUuXLgF4fqKQnZ0dWrRoIV7X1tau8FgVyf3A86Xbt2/fFh///JBAS0sL/fv3x08//YQrV65g7dq1OHDggEpB6tq1awgICECPHj2QlpaGkJAQvP/++9i3b5/YZ+PGjQgLC8O8efNw9uxZuLq6wt/fH3fv3lX7e0REpOm+++47ODk5YeHChThy5AjOnTtX6kFERPWf2huEjxs3DrNnz8amTZtw7tw5LFu2TLx28uRJtGnTRq3x9u7dq/J87dq1MDc3R2pqKry8vAAAoaGhmDJlCiIiIsR+Dg4Opcbas2cP9u/fjx9//BF79uxRufb999+jsLAQCQkJkMvlcHJyQlpaGpYuXYoJEyYAAOLi4tC7d29Mnz4dADB//nwkJSVhxYoViI+PV2teRET1zbvvvosZM2bgwIED2L17N8LDw1Wut2zZssJjVST3A4Cenh4sLS3LHMPY2BiTJk0Sn9va2uLDDz/E4sWLxbb4+HjY29sjNjYWANCmTRscP34cy5Ytg7+/PwBg6dKlGD9+PMaMGSO+ZteuXUhISFD5uUNERC83f/58DBw4EAkJCWp/CE1ERPWH2nc2RUREYM2aNejatSu+/vprBAcHi9dyc3Px/vvvv1JAeXl5AAATExMAwN27d/HLL7/A3Nwc3bp1g4WFBby9vXH8+HGV1925c0fcvLysH2wpKSnw8vKCXC4X2/z9/ZGZmYnc3Fyxj6+vr8rr/P39kZKSUmasBQUFyM/PV3kQEdVXMTExmDZtGp48eYKPPvoIkZGRKtfffvvtSo/979xf4vvvv4epqSnatWuHyMhIPHr0qNwxbt26hS1btsDb21tse1leLywsRGpqqkofLS0t+Pr6MvcTEVXCrVu3MH78eBaaiIg0nNp3NgHAyJEjMXLkyFLtr3r3T3FxMUJCQuDp6Yl27doBgLgHVFRUFJYsWQI3NzesW7cOvXr1QkZGBlq3bg1BEDB69GhMnDgRHTt2xPXr10uNrVQqYW9vr9JmYWEhXjM2NoZSqRTb/tlHqVSWGW9MTAyio6Nfac5ERHVFgwYNMHfu3HKvT548uVLjlpX7AWDYsGGwtbWFtbU10tPTER4ejszMzFKn3g0dOhTbt2/H48eP0a9fP6xZs0a8Vl5ez8/Px+PHj5Gbm4tnz56V2efy5ctlxsvcT0RUPi8vL2RkZKBXr15Sh0JERBKqULHp/v37aNy4MbS0tHD//v2X9v/3J9MVFRQUhIyMDJW7loqLiwEAH3zwgbjEoX379khOTkZCQgJiYmLwxRdf4O+//y71KXt1i4yMRFhYmPg8Pz8fNjY2NRoDEVFdV1buByAucQYAZ2dnWFlZoVevXrh69arKkr1ly5Zh3rx5uHLlipiXv/zyy2qLl7mfiEjVP/8+WLhwIUaMGAEdHR288cYbaNy4can+lf1bgYiI6o4KFZvMzMyQkpKCzp07w9TUFDKZ7IX9nz17pnYgwcHB2LlzJ44ePYpmzZqJ7SWbj7dt21alf5s2bZCdnQ0AOHjwIFJSUqBQKFT6dOzYEcOHD8e3334LS0tL3LlzR+V6yfOS/UDK61PefiEKhaLUexIR1SeGhoY4dOgQ3N3dYWBg8ML836xZM7WXlJWX+8vSpUsXAM9PvftnscnS0hKWlpZwdHSEiYkJunfvjjlz5sDKyqrcvG5oaAhdXV1oa2tDW1ubuZ+I6BX8++8DQRAwadKkcn9mVOZvBSIiqlsqVGxKSEgQf7FPSEh4abFJHYIgYPLkydi6dSsOHz5caqmbnZ0drK2tSx2JfeXKFfTp0wcA8Pnnn2PBggXitVu3bsHf3x8bN24U/zjx8PDArFmzUFRUhIYNGwIAkpKS4ODgAGNjY7FPcnIyQkJCxLGSkpLg4eFRZfMlIqpLpk2bJhb9p02bVmb+LygoQExMjMoefi/zstxflrS0NAD/+xCiLCV3wxYUFAB4ntd3796t0uefeV0ul8Pd3R3JyckIDAwUx0hOTlZrPkREmqyq/z4gIqK6r0LFplGjRolfjx49ukoDCAoKQmJiIrZv3w4DAwNxfyQjIyPo6upCJpNh+vTpmDdvHlxdXeHm5oZvv/0Wly9fxubNmwEAzZs3VxmzUaNGAJ6fjFTySfmwYcMQHR2NcePGITw8HBkZGYiLi1M5TW/q1Knw9vZGbGwsAgICsGHDBpw5cwarV6+u0jkTEdUV8+bNE7+Oiooqs09+fj5iYmLUOrntZbn/6tWrSExMRN++fdGkSROkp6cjNDQUXl5ecHFxAQDs3r0bd+7cQadOndCoUSNcvHgR06dPh6enJ+zs7AAAEydOxIoVKzBjxgyMHTsWBw8exH/+8x/s2rVLjCUsLAyjRo1Cx44d0blzZyxfvhwPHz4Ul24TEdGLVfXfB0REVPdVaoPwqrRq1SoAgI+Pj0r7N998I/7gCgkJwZMnTxAaGor79+/D1dUVSUlJah2zbWRkhP379yMoKAju7u4wNTXF3LlzVfYE6datGxITEzF79mzMnDkTrVu3xrZt21Q2rCUiolf3stwvl8tx4MABsfBjY2ODAQMGYPbs2WJfXV1dfP311wgNDUVBQQFsbGzwzjvvqBS97O3tsWvXLoSGhiIuLg7NmjXDmjVr4O/vL/YZPHgw7t27h7lz50KpVMLNzQ179+4ttWk4ERERERFVjOTFJkEQKtQvIiKiwp+a29nZlTmui4sLjh079sLXDho0CIMGDarQ+xDRi2VnZyMnJ0fqMCrN1NS01J2TVDVelvttbGxw5MiRF/bp0aMHTpw48dL38vHxwblz517YJzg4mMvmiIiqgL29fblL6rS0tGBkZAQ3NzcEBQWhQ4cONRwdERHVFMmLTURUP2VnZ8PBsQ2ePH4kdSiVpqOrh8zLv7LgREREVEH9+/fH1q1bkZ+fj169esHc3Bx3795FcnIyDA0N4erqiqNHj+K7777D7t274evrK3XIRERUDVhsIqJqkZOTgyePH8F5wDTom9W9Y+Ef3ruBCz/GIicnh8UmIiKiCrKzs4OtrS327NkDfX19sf3Bgwfo27cvHB0d8dVXX6Fv376YN28ei01ERPWUWsWmwsJC7Ny5E25ubmjRokV1xURE9Yi+mQ0MrVtJHQa9oqdPnyI9PR02NjYwMzOTOhwiIqqlli1bhpUrV6oUmoDnB/hMnz4dkyZNwowZMzBp0iSMHDlSoiiJiKi6aanTWS6XY9iwYcjOzq6ueIiIqBbS0tJC165dcf78ealDISKiWiwnJwf5+fllXsvLy0Nubi4AwMTEpCbDIiKiGqZWsQkAHB0dWWwiItIwWlpaaNGihfhHAhERUVl69OiBiIiIUgc4HD9+HJGRkejZsycAIDMzE3Z2dhJESERENUHtYlNMTAwWLFiAM2fOVEc8RERUS82cORPz58/HrVu3pA6FiIhqqa+++gpmZmbo3r07mjRpAkdHRzRp0gTe3t6wsLDAV199BeD5hxjh4eESR0tERNVF7Q3CZ8yYgT///BNdunRBkyZNYGFhoXK8qUwm4zILIqJ6aNOmTbh37x5atGgBFxcXMf8/ffoUADB06FDs2rVL4iiJiEhKTZs2RWpqKnbv3o0zZ87g9u3bsLKyQqdOndCnTx+x3/jx4yWMkoiIqpvaxSZ3d3d07NixOmIhIqJa7MGDB3B0dFR5DgDPnj0DAPz999+SxEVERLVP37590bdvX6nDICIiiahdbFq7dm01hEFERLXdoUOHymzPz8+HkZERdu7cWcMRERFRbXD//n00btwYWlpauH///kv7c3NwIqL6T+1i0z8JgoDbt2/D3NwcDRq80lBERERERFQHmZmZISUlBZ07d4apqanKFhtlKbkjloiI6q9KVYj27duHefPm4dy5c3j69ClOnz6NDh06YMKECfD29sbw4cOrOk4iIqoFLl68iPnz5+P06dP4448/kJKSglatWgEAkpKSMGDAAIkjJCKimpaQkICWLVuKX7+s2ESaJzs7Gzk5OVKHUWmmpqZo3ry51GEQ1SlqF5t++OEHjBgxAu+++y7Gjx+vsrlfy5Yt8c0337DYRERUDyUlJSEgIADu7u4YPnw4FixYoHJ9zZo1LDYREWmgUaNGiV+PHj1aukCoVsrOzoaDYxs8efxI6lAqTUdXD5mXf2XBiUgNaheb5s+fj5CQEMTGxuLZs2cqxSYnJycsW7asSgMkIqLaITIyEkOGDMG6devw9OnTUsWm9PR0iSIjIiKi2ionJwdPHj+C84Bp0DezkToctT28dwMXfoxFTk4Oi01EalC72PT777+Xe7KEvr4+8vLyXjkoIiKqfTIyMhATEwMAZS6R+PPPP2s6JCIiqmUeP36M+fPnY/Pmzfjjjz9QUFBQqg/3bNJM+mY2MLRuJXUYRFRD1C42WVpa4vLly+jVq1epa+np6bC1ta2SwIiIqHYxMTHBrVu3yr1uYWFRg9EQEVFtFBQUhMTERAwdOhRt27aFXC6XOiQiIpKA2sWmYcOGISoqCo6OjvDx8QHw/BPujIwMfPbZZ5g0aVJVx0hERLVAYGAg5s2bh65du4qbgstkMty5cwcA8NZbb0kZHhER1QI7duzAkiVLEBwcLHUoREQkIbWLTVFRUbh48SLeeOMNNGnSBADQp08f3Lt3D2+++SYiIiKqPEgiIpJeTEwMTp8+DRcXFzg7OwMAxo4di99//x3A8z2diIhIs2lra+O1116TOgwiIpKY2sUmuVyO7du349ChQ0hKSkJOTg5MTEzg6+sLX1/f6oiRiIhqASMjI5w4cQLr169HUlISTExMYGJigrFjx2LKlClo1KiR1CESEZHEJk2ahO+++w5+fn5Sh0JERBJSu9hUokePHujRo0dVxkJERLVcw4YNMWbMGIwZM0Zsy8/Px5QpUySMioiIpLR06VLxa319fRw7dgzdunWDr68vGjdurNJXJpMhNDS0hiMkIqKapnaxqV+/fvD29kb37t3RsWNHaGtrV0dcRERUy0yePFnM/9wMnIiISnz00Uel2rKzs3Hy5MlS7Sw2ERFpBrWLTY0aNcLy5csxY8YM6Ovro2vXrujevTu8vLzg4eEBhUJRHXESEZHEzpw5g9WrV+Pp06do1aoVvLy80L17d7Rv317q0IiISELFxcVSh0BERLWMlrov+OGHH/DHH3/gypUriIuLQ7NmzfDtt9+iV69eMDIyQvfu3asjTiIiklhKSgr++usv7Nu3D4MHD0ZWVhYmTpwINzc3AMCECROkDZCIiOqtlStXws7ODjo6OujSpQtOnTpVbt+LFy9iwIABsLOzg0wmw/Lly195TCIiUo/axaYSrVq1wtixYzF79mzMnDkT3t7eKCwsxIkTJ6oyPiIiqkV0dXXh6+uLjz/+GHv27MHmzZvh6ekJANi0aZPE0RERkRQuXbqk9muKiorE00xfZuPGjQgLC8O8efNw9uxZuLq6wt/fH3fv3i2z/6NHj9CiRQt8+umnsLS0rJIxiYhIPWoXm3799Vd89dVXGDZsGJo1awYHBwd8/vnncHJywsaNG3Hr1q3qiJOIiCT24MED7Nu3DzNnzoSnpycaN26MESNGQF9fHwBw4MABiSMkIiIpdO3aFf3798dPP/2EwsLCF/a9evUqFixYAHt7e2zbtq1C4y9duhTjx4/HmDFj0LZtW8THx0NPTw8JCQll9u/UqRMWL16MIUOGlLvFh7pjEhGRetTes8nJyQm6uroYNWoUVq1ahddffx3GxsbVERsREdUixsbGkMvl6NOnD4YMGYKVK1fC1dUVf//9N4yMjODu7i51iEREJIGsrCx88sknGD58OGQyGTp06AAXFxeYmZlBoVDgr7/+wrVr15CamoqrV6+iQ4cO+PLLL/HWW2+9dOzCwkKkpqYiMjJSbNPS0oKvry9SUlIqFW9lxiwoKEBBQYH4PD8/v1LvTUSkKdQuNgUEBODnn3/G//3f/yE9PR0pKSnw9vaGp6cnGjVqVB0xEhFRLeDo6IhLly7h1KlT0NHRgUKhgK6uLqysrKQOjYiIJGRubo64uDgsXLgQmzZtQnJyMvbv34/bt2/jyZMnMDExgYODAwYNGoSBAweqdbBETk4Onj17VuoUVAsLC1y+fLlS8VZmzJiYGERHR1fq/YiINJHay+h27NiBP//8E6dOncLgwYPx22+/YdSoUTAxMUGnTp3KPPqUiIjqvgsXLuDevXv44osvYGFhga+//hrt2rVD69atAQCrV6+u8FgxMTHo1KkTDAwMYG5ujsDAQGRmZqr08fHxgUwmU3lMnDhRvH7+/HkMHToUNjY20NXVRZs2bRAXF1fqvQ4fPowOHTpAoVCgVatWWLt2bak+3CSWiOjV6evrY/To0fjuu+9w+fJl5OXloaCgALdv38bhw4fxySef1NkTTCMjI5GXlyc+bty4IXVIRES1WqU2CJfJZHB1dcXkyZPx+eefY/ny5fD09ERqaiqWLVtW1TESEVEtYWJigv79+yM2NhYpKSnYvXs3HBwcAADh4eEVHufIkSMICgrCyZMnkZSUhKKiIvj5+eHhw4cq/caPH4/bt2+Lj88++0y8lpqaCnNzc6xfvx4XL17ErFmzEBkZiRUrVoh9rl27hoCAAPTo0QNpaWkICQnB+++/j3379ol9uEksEVHtZWpqCm1tbdy5c0el/c6dO+Vu/l0dYyoUChgaGqo8iIiofGovo7t27RqOHj0qPn7//Xc0bNgQ7du3x/Tp0+Ht7V0dcRIRkcQKCgpw8uRJMf+fPHkSjx49grm5OQCoFIJeZu/evSrP165dC3Nzc6SmpsLLy0ts19PTK/cX/7Fjx6o8b9GiBVJSUrBlyxYEBwcDAOLj42Fvb4/Y2FgAQJs2bXD8+HEsW7YM/v7+AFQ3iS15za5du5CQkICIiIgKz4mIiKqeXC6Hu7s7kpOTERgYCAAoLi5GcnKymOtrw5hERKRK7WJTy5YtoaOjg86dO2Po0KHw9vaGh4cH9PT0qiM+IiKqJYyMjFBUVAQbGxt4eXlh+fLl8PLygoWFBYyMjDB+/PhKj52Xlwfg+Z1T//T9999j/fr1sLS0RL9+/TBnzpwX/rzJy8tTGSMlJQW+vr4qffz9/RESEgKAm8QSEdUFYWFhGDVqFDp27IjOnTtj+fLlePjwofghwciRI9G0aVPExMQAeJ7bL126JH598+ZNpKWloVGjRmjVqlWFxiQiolejdrHp6NGj6Ny5M+RyeXXEQ0REtdSaNWvg5eWF5s2bq7S/arGluLgYISEh8PT0RLt27cT2YcOGwdbWFtbW1khPT0d4eDgyMzOxZcuWMsc5ceIENm7ciF27doltSqWyzA1g8/Pz8fjxY+Tm5nKTWCKiWm7w4MG4d+8e5s6dC6VSCTc3N+zdu1fM3dnZ2dDS+t/uILdu3VLZG2rJkiVYsmQJvL29cfjw4QqNSUREr0btYtPrr78ufv348WP89ddfaNy4MXR1das0MCIiql1GjBhRLeMGBQUhIyMDx48fV2mfMGGC+LWzszOsrKzQq1cvXL16FS1btlTpm5GRgf79+2PevHnw8/OrljhLREZGIiwsTHyen58PGxuban1PIiJNFxwcXO4St5ICUgk7OzsIgvBKYxIR0aup1AbhO3fuFE8RatasGQwMDNCpUyfs3r27quMjIqJa5Ny5cxg0aBCsrKygUChgZWWFUaNGVXq84OBg7Ny5E4cOHUKzZs1e2LdLly4AgKysLJX2S5cuoVevXpgwYQJmz56tcs3S0rLMDWANDQ2hq6vLTWKJiIiIiKqB2sWmbdu2oX///pDL5Vi6dCkSExMRGxsLhUKBt956C9u3b6+OOImISGLHjh2Dh4cHTp8+jaFDh+Ljjz/G0KFDcfbsWQAod4+jsgiCgODgYGzduhUHDx6Evb39S1+TlpYGALCyshLbLl68iB49emDUqFH45JNPSr3Gw8MDycnJKm1JSUnw8PAAoLpJbImSTWJL+hARkXouXryIIUOGoGXLllAoFOLPiVmzZmHPnj0SR0dERDVB7WV00dHRGDp0KNavX6/SPnXqVIwYMQJRUVHo379/lQVIRES1Q0REBHx8fLBz5040aPC/Hx9z5syBiYkJoqKixBPeXiYoKAiJiYnYvn07DAwMoFQqATzfhFxXVxdXr15FYmIi+vbtiyZNmiA9PR2hoaHw8vKCi4sLgOdL53r27Al/f3+EhYWJY2hra8PMzAwAMHHiRKxYsQIzZszA2LFjcfDgQfznP/9R2deJm8QSEVWdpKQkBAQEwN3dHcOHD8eCBQvEaw0bNsSXX36JPn36SBghERHVBLXvbLp8+TJGjhxZ5rX33nuv3A1ViYiobjt37hymTJmiUmgCnhd3AOD8+fMVHmvVqlXIy8uDj48PrKysxMfGjRsBPL/j6MCBA/Dz84OjoyOmTZuGAQMGYMeOHeIYmzdvxr1797B+/XqVMTp16iT2sbe3x65du5CUlARXV1fExsZizZo1KkWxwYMHY8mSJZg7dy7c3NyQlpbGTWKJiCopMjISQ4YMQUpKCubOnatyrX379jh37pxEkRERUU1S+84mExMTZGZmlrkBa2ZmZqljq4mIqH7Q19fH3bt3y72up6dX4bFetnGrjY0Njhw58sI+UVFRiIqKeul7+fj4vPSPG24SS0RUNTIyMhATEwMAkMlkKtcaN26MnJwcKcIiIqIapvadTYMHD8bMmTOxZs0a/PXXXwCAvLw8rFmzBrNnz8aQIUOqOkYiIqoF+vXrh/DwcBw4cECl/dChQwDAZRFERAQTExPcunWrzGtXrlxR2XePiIjqL7XvbIqJicF///tfTJgwAR988AEaNmyIoqIiCIKAd955BwsXLqyOOImISGKxsbG4ePEi/P39YWhoCHNzc9y9exf5+fkAoLIvBxERaabAwEDMmzcPXbt2RatWrQA8v8NJqVRiyZIlGDBggMQREhFRTVC72KRQKPDjjz/iwoULOHbsGHJzc2FiYoLXX38dzs7O1REjERHVAsbGxkhJScHOnTtx/PhxMf936NABQ4YMgbGxsdQhEhGRxGJiYnD69Gm4uLiIfxuMHTsWv//+OxwcHCq0/JmIiOo+tYtNJZydnVlcIiLSMFpaWnjrrbfw1ltviW0ldzYREREZGRnhxIkTWL9+PZKSkmBiYgITExMEBQVh5MiRkMvlUodIREQ1oELFprNnz6o1aIcOHSoVDBER1S73799/aZ+SYtP9+/dhaGhY3SEREVEt17BhQ4wZMwZjxoyROhQiIpJIhYpNHTt2LHWaRFkEQYBMJsOzZ89eOTAiIpKeqalphfI/ALRs2ZL5n4hIw2lrayMlJQWdO3cudS01NRWdO3fmzwoiIg1QoWJTyUlDRESkWRISEl5abHr8+DEmTZqElStX1lBURERUWwmCUO61p0+fQltbuwajISIiqVSo2OTt7V3dcRARUS00evTol/bJz8/HpEmTMGzYsOoPiIiIah2lUolbt26JzzMzM9GggeqfGU+ePEFCQgJsbW1rOjwiIpJAhYpNT58+LfUDozpfR0REREREdcNXX32F6OhoyGQyyGSyMj+oEAQB2tra+PLLL2s+QCIiqnEVqgTZ29tj2rRpeO+999CkSZOX9j9+/DiWL18ONzc3zJ49+5WDJCIiaXTp0gWRkZF46623oKWl9dL+N27cQFxcHKytrREWFlYDERIRkdRGjx4NHx8fCIKAnj17YuXKlWjbtq1KH7lcjtdee61Cf0sQEVHdV6FiU3x8PGbPno0ZM2bA29sbnp6ecHFxgZmZGRQKBf766y9cu3YNqamp2LdvH+7du4dJkyZh4sSJ1R0/ERFVo5EjR+LDDz/EhAkT0L9//zLzf0ZGBgCgd+/eOH36NN566y1MmjRJ4siJiKim2NraisvjDh06BHd3dzRq1EjiqIiISEoVKjYFBAQgICAAhw4dwrp16/B///d/uHnzJgBAJpNBEATI5XK4u7sjJCQE7733HkxNTas1cCIiqn5BQUEYO3YsNmzYgHXr1mHdunV4+vSpSp+SzWBdXV3x1VdfwdnZWYpQiWqt7Oxs5OTkSB1GpZmamqJ58+ZSh0F1RM+ePXkaHRERVazYVKJHjx7o0aMHgOcbAd6+fRtPnjyBiYkJ7OzsoFAo1A4gJiYGW7ZsweXLl6Grq4tu3bph0aJFcHBwUOmXkpKCWbNm4ZdffoG2tjbc3Nywb98+6OrqAgDeeustpKWl4e7duzA2Noavry8WLVoEa2trcYz09HQEBQXh9OnTMDMzw+TJkzFjxgyV99m0aRPmzJmD69evo3Xr1li0aBH69u2r9ryIiOoLXV1djBkzBmPGjMGTJ0+Qlpamkv+tra3h4uKCRYsWwdDQUOpwiWqV7OxsODi2wZPHj6QOpdJ0dPWQeflXFpyoQngaHRERAWoWm/7J0tISlpaWrxzAkSNHEBQUhE6dOuHp06eYOXMm/Pz8cOnSJejr6wN4Xmjq3bs3IiMj8cUXX6BBgwY4f/68yv4hPXr0wMyZM2FlZYWbN2/io48+wsCBA3HixAkAz09L8vPzg6+vL+Lj43HhwgWMHTsWjRs3xoQJEwAAJ06cwNChQxETE4M333wTiYmJCAwMxNmzZ9GuXbtXnisRUV2no6ODrl27qrTl5+dLFA1R7ZeTk4Mnjx/BecA06JvZSB2O2h7eu4ELP8YiJyeHxSYqF0+jIyKif5P8qLi9e/eqPF+7di3Mzc2RmpoKLy8vAEBoaCimTJmCiIgIsd+/73wKDQ0Vv7a1tUVERAQCAwNRVFSEhg0b4vvvv0dhYSESEhIgl8vh5OSEtLQ0LF26VCw2xcXFoXfv3pg+fToAYP78+UhKSsKKFSsQHx9fLfMnIiKi+k/fzAaG1q2kDoOoWvA0OiIi+jfJi03/lpeXBwAwMTEBANy9exe//PILhg8fjm7duuHq1atwdHTEJ598gtdff73MMe7fv4/vv/8e3bp1Q8OGDQE8vzvKy8sLcrlc7Ofv749FixYhNzcXxsbGSElJKXV6kr+/P7Zt21bm+xQUFKCgoEB8zk/3iYiIiEjT8DQ6IiL6t1pVbCouLkZISAg8PT3FZWu///47ACAqKgpLliyBm5sb1q1bh169eiEjIwOtW7cWXx8eHo4VK1bg0aNH6Nq1K3bu3CleUyqVsLe3V3k/CwsL8ZqxsTGUSqXY9s8+SqWyzHhjYmIQHR396hMnIiIiIqqj/n0aXYcOHWBgYCBxVEREJCWtl3epOUFBQcjIyMCGDRvEtuLiYgDABx98gDFjxqB9+/ZYtmwZHBwckJCQoPL66dOn49y5c9i/fz+0tbUxcuTIF25S+KoiIyORl5cnPm7cuFFt70VEREREVNt5e3vDwMAAv/76K7777jssXLhQ/OA2KysLf//9t8QREhFRTag1dzYFBwdj586dOHr0KJo1aya2W1lZAUCpW3HbtGmD7OxslTZTU1OYmpritddeQ5s2bWBjY4OTJ0/Cw8MDlpaWuHPnjkr/kuclG52X16e8jdAVCkWlTuAjIiIiIqqPHj16hPfffx8bN26ElpYWiouL0bt3b1haWiIyMhL29vb47LPPpA6TiIiqWYXubPrtt9/g7u6O3bt3l9tnz549cHd3F5e9VZQgCAgODsbWrVtx8ODBUkvd7OzsYG1tjczMTJX2K1euvPA0i5I7okr2VPLw8MDRo0dRVFQk9klKSoKDgwOMjY3FPsnJySrjJCUlwcPDQ605ERHVF7dv38aAAQOwb9++cvscOHAAAHDv3r2aCouIiGqpjz76CAcPHsSePXuQn5+vssqgb9++pQ4HIiKi+qlCxabY2Fg0atQIffv2LbdPnz59YGhoiCVLlqgVQFBQENavX4/ExEQYGBhAqVRCqVTi8ePHAACZTIbp06fj888/x+bNm5GVlYU5c+bg8uXLGDduHADgl19+wYoVK5CWlob//ve/OHjwIIYOHYqWLVuKhaJhw4ZBLpdj3LhxuHjxIjZu3Ii4uDiVDcGnTp2KvXv3IjY2FpcvX0ZUVBTOnDmD4OBgteZERFRfxMbG4vfff4efn1+5fXr16gUAWLFiRU2FRUREtdTmzZuxaNEi+Pn5qRzMAzz/EPn69evSBEZERDWqQsWm/fv3Y+zYsS/tN3bs2Bd++l2WVatWIS8vDz4+PrCyshIfGzduFPuEhIQgMjISoaGhcHV1RXJyMpKSktCyZUsAgJ6eHrZs2YJevXrBwcEB48aNg4uLC44cOSIuczMyMsL+/ftx7do1uLu7Y9q0aZg7dy4mTJggvk+3bt2QmJiI1atXw9XVFZs3b8a2bdvEzcqJiDTNzp07MXHiRMhksnL7lFx70d2vRESkGR48eCBug/FvDx8+rOFoiIhIKhXas+nmzZtiYedF7O3tcfPmTbUCqOgG3hEREYiIiCjzmrOzMw4ePPjSMVxcXHDs2LEX9hk0aBAGDRpUoZiIiOq769evl9ozrzz/3kePiIg0j4uLC3788ccy74jdtWsXOnbsKEFURERU0ypUbGrUqFGF9uLIycmBvr7+KwdFRES1g46ODvLz8yvUlwcmEBHRnDlz0L9/fzx69AiDBg2CTCbDqVOn8MMPPyAhIYF3wRIRaYgKLaPr2LGjyrK28mzYsIGfVhAR1SMuLi746aefKtTXycmpmqMhIqLaLiAgABs2bMDx48cRGBgIQRDw4YcfYuPGjfj+++/Fff6IiKh+q9CdTUFBQQgMDESbNm0we/ZsaGtrq1wvLi7GggULsGnTJmzbtq064iQiIgmMGzcO77//Prp164ZRo0aV2eeHH34AAIwcObImQyMiolpq4MCBGDhwIK5cuYKcnByYmJjA0dFR6rCIiKgGVejOprfeegszZsxAdHQ0bGxs8N5772HWrFmYPXs2Ro4cCRsbG0RHR2P69Ono169fdcdMREQ1ZNSoURg4cCDGjBmDTp06Yc6cOfj666+xZs0azJ07F126dMGHH34IABg6dGiFx42JiUGnTp1gYGAAc3NzBAYGIjMzU6WPj48PZDKZymPixIkqfaZMmQJ3d3coFAq4ubmV+V7p6eno3r07dHR0YGNjg88++6xUn02bNsHR0RE6OjpwdnbmMg8ioirw2muvoVu3biw0ERFpoArd2QQAn376Kby8vBAbG4vNmzejoKAAwPP9PDw9PbFmzRr06dOn2gIlIiJp/PDDD+jevTuWLl2KTz75ROVay5YtsXjxYkybNk2tMY8cOYKgoCB06tQJT58+xcyZM+Hn54dLly6p7P03fvx4fPzxx+JzPT29UmONHTsWv/zyC9LT00tdy8/Ph5+fH3x9fREfH48LFy5g7NixaNy4sXga6YkTJzB06FDExMTgzTffRGJiIgIDA3H27FmeRkpEpKZ/5uyyyGQyzJkzp4aiISIiqVS42AQAffv2Rd++ffHs2TP8+eefAIAmTZqUWlZHRET1y4cffogPP/wQN2/eFE8dbdq0KZo2bYr8/Hy1i0179+5Veb527VqYm5sjNTUVXl5eYruenh4sLS3LHefzzz8HANy7d6/MYtP333+PwsJCJCQkQC6Xw8nJCWlpaVi6dKlYbIqLi0Pv3r0xffp0AMD8+fORlJSEFStWID4+Xq15ERFpumXLlpVqe/DgAZ49ewZdXV0oFAoWm4iINECFltH9m7a2NszNzWFubs5CExGRBmnatCk6d+6Mzp07o2nTplU2bl5eHgDAxMREpf3777+Hqakp2rVrh8jISDx69EitcVNSUuDl5QW5XC62+fv7IzMzE7m5uWIfX19fldf5+/sjJSWlMlMhItJoubm5pR6PHz/Gnj170KpVKxw+fFjqEImIqAZU6M6mpUuXVnhAmUyG0NDQSgdERES1x5YtW17ap6QA9NNPP2HEiBFqv0dxcTFCQkLg6empsmxt2LBhsLW1hbW1NdLT0xEeHo7MzMwKxVRCqVTC3t5epc3CwkK8ZmxsDKVSKbb9s49SqSxzzIKCAnEpOfB8qR4REZWvQYMG8Pf3x82bNzFp0iT8/PPPUodERETVrELFpo8++qjCA7LYRERUfwwcOLDCfUeNGlWpYlNQUBAyMjJw/PhxlfaSZW4A4OzsDCsrK/Tq1QtXr15Fy5Yt1X6fqhITE4Po6GjJ3p+IqK5q1qwZ0tLSKvXalStXYvHixVAqlXB1dcUXX3yBzp07l9t/06ZNmDNnDq5fv47WrVtj0aJF6Nu3r3h99OjR+Pbbb1Ve4+/vX2qZNxERVU6Fik3FxcXVHQcREdVC165de2mfv//+G87Ozjh//rza4wcHB2Pnzp04evQomjVr9sK+Xbp0AQBkZWVVuNhkaWmJO3fuqLSVPC/ZC6q8PuXtFRUZGYmwsDDxeX5+PmxsbCoUDxGRprp27RoWLVpUqQ8LNm7ciLCwMMTHx6NLly5Yvny5uCTa3Ny8VP+KHvzQu3dvfPPNN+JzhUJRuckREVEpam0QTkREmsXW1valfUqWkanzwYQgCJg8eTK2bt2Kw4cPl1rqVpaST8OtrKwq/D4eHh6YNWsWioqK0LBhQwBAUlISHBwcYGxsLPZJTk5GSEiI+LqkpCR4eHiUOaZCoeAfJERE5TAwMIBMJlNpKyoqQmFhIfT09NRaCl1i6dKlGD9+PMaMGQMAiI+Px65du5CQkICIiIhS/St68INCoXjhIRRERFR5r1xsunTpEi5evAhTU1N4eXlxw3AiIg2Sk5MjLkNo3749nj17VqHXBQUFITExEdu3b4eBgYG4P5KRkRF0dXVx9epVJCYmom/fvmjSpAnS09MRGhoKLy8vuLi4iONkZWXhwYMHUCqVePz4sViQatu2LeRyOYYNG4bo6GiMGzcO4eHhyMjIQFxcnMppSVOnToW3tzdiY2MREBCADRs24MyZM1i9enUVfZeIiDTHtGnTShWbdHR00KxZM/Tp06fUQRAvU1hYiNTUVERGRoptWlpa8PX1Lfcgh5SUFJU7UIHnS+S2bdum0nb48GGYm5vD2NgYPXv2xIIFC9CkSZMyx+R+fURE6qlQsUkQBCxevBhbtmxBUVERBg0ahPDwcLz//vtYu3at2M/JyQkHDx6EqalpdcVLREQSe/ToEbZu3YrExEQcOHAARUVFAJ7vZVRRq1atAgD4+PiotH/zzTcYPXo05HI5Dhw4gOXLl+Phw4ewsbHBgAEDMHv2bJX+77//Po4cOSI+b9++PYDnyzXs7OxgZGSE/fv3IygoCO7u7jA1NcXcuXNV9oPq1q0bEhMTMXv2bMycOROtW7fGtm3bVJZaEBFRxURFRVXpeDk5OXj27FmZBzlcvny5zNdU5OCH3r1745133oG9vT2uXr2KmTNnok+fPkhJSSnzw3Pu10dEpJ4KFZuWLFmCyMhI9O/fHwYGBliwYAHS09OxZ88eLFmyBG3atMGFCxfwySef4OOPP8bnn39e3XETEVENevbsGfbu3YvExET89NNPePToESwtLfH06VMkJCRgzJgxmDhxYoXHEwThhddtbGxUikjlqcgR2i4uLjh27NgL+wwaNAiDBg166VhERFQxubm5OHXqFO7fvw8TExN07txZXL5cGwwZMkT82tnZGS4uLmjZsiUOHz6MXr16lerP/fqIiNRToWLTN998gzlz5oifVAwYMABvv/024uLiEBwcDOD5pwMNGjTAypUrWWwiIqonfv75ZyQmJmLTpk3IyclBkyZNMGLECAwbNgzt2rVDkyZNSn16TEREmksQBISHh+OLL75QWXamUCgwZcoULFq0SK3xTE1Noa2trdZBDuoe/AAALVq0gKmpKbKyssosNnG/PiIi9WhVpNO1a9fQo0cP8XnPnj0hCALc3d1V+nXs2BE3btyo2giJiEgy3bt3R3x8PFxcXLBz507cvn0bq1atQvfu3aGlVaEfIUREpEEWLlyIZcuWISwsDGlpabh9+zbS0tIQFhaGpUuXqrXkGgDkcjnc3d2RnJwsthUXFyM5ObncgxxKDn74pxcd/AAAf/zxB/7880+1DqEgIqLyVejOpoKCAujq6orPS77+d3VfLpfj6dOnVRgeERFJydnZGRcuXMCRI0egra2NnJwcvP322zAwMJA6NCIiqoXWrFmDOXPmYO7cuWKbhYUFXFxcoFAosHr1apXNvisiLCwMo0aNQseOHdG5c2dxP7+S0+lGjhyJpk2bioWslx388ODBA0RHR2PAgAGwtLTE1atXMWPGDLRq1Qr+/v5V9J0gItJsFT6N7t+nSpTXRkTly87ORk5OjtRhVJqpqSmaN28udRhUg86fP49Lly5h/fr12LBhA0aPHo1JkyYhICAAb775Jn8OEBGRitu3b6Nbt25lXvPw8MDChQvVHnPw4MG4d+8e5s6dC6VSCTc3N+zdu1dcxp2dna1yt+3LDn7Q1tZGeno6vv32W/z111+wtraGn58f5s+fz6VyRERVpMLFph49epRaMvHvZRTFxcVVFxlRPZOdnQ0HxzZ48viR1KFUmo6uHjIv/8qCk4Zp27YtFi5ciIULF4p7OG3evBmbN2+GTCYTT5YjIiKys7PDrl274OvrW+ra7t27YWdnV6lxg4ODxb1i/62swyJedPCDrq4u9u3bV6k4iIioYipUbJo3b151x0FU7+Xk5ODJ40dwHjAN+mZ17/SSh/du4MKPscjJyWGxSYN5enrC09MTn3/+Ofbt24cffvgB27dvB/D81Lfr169LGyAREUkqNDQUkyZNwr179zBw4EBYWFjg7t272LRpE3744Qd+QEFEpCFYbCKqYfpmNjC0biV1GESvRFtbG3379kXfvn3FE37atm0rdVhERCSxDz74AIWFhZg/fz4SExMhk8kgCALMzMwQFxeHCRMmSB0iERHVgAovoyMiIipLyaERGzZskDgSIiKqDSZPnoygoCBcvnwZubm5MDExgYODA08xJSLSICw2ERERERFRldLS0uIdr0REGozFJiIiIiIiqjKZmZn48ccf8ccff+DJkycq12QyGf7v//5PosiIiKimsNhERERERERV4rvvvsOYMWOgo6MDW1tbyOVylesymUyiyIiIqCax2ERERERERFVi/vz5GDhwIBISEqCnpyd1OEREJBHu0kdERERERFXi1q1bGD9+PAtNREQajsUmIiIiIiKqEl5eXsjIyJA6DCIikhiX0RERERERUaXdv39f/HrhwoUYMWIEdHR08MYbb6Bx48al+puYmNRgdEREJAUWm4iIiIiIqNJMTU1VNv4WBAGTJk0qdzPwZ8+e1VRoREQkERabiIiIiIio0hISEnjKHBERqWCxiYiIiIiIKm306NFSh0BERLUMNwgnIiIiIiIiIqIqwzubiIiIiIio0pydnSu8jE4mk+H8+fPVHBEREUmNxSYiIiIiIqo0d3d37tlEREQqWGwiIiIiIqJKW7t2rdQhEBFRLcM9m4iIiIiIiIiIqMrwziYiIiIiIqq0KVOm4KOPPkLz5s0xZcqUF/aVyWSIi4urociIiEgqLDYREREREVGl7dixA+PGjUPz5s2xY8eOF/ZlsYmISDOw2ERERERERJV27dq1Mr8mIiLNxT2biIiIiIiIiIioyrDYRERENS4mJgadOnWCgYEBzM3NERgYiMzMTJU+Pj4+kMlkKo+JEyeq9MnOzkZAQAD09PRgbm6O6dOn4+nTpyp9Dh8+jA4dOkChUKBVq1Zlnpq0cuVK2NnZQUdHB126dMGpU6eqfM5ERPVVTk4O0tPTS7Wnp6dj4MCBcHJyQq9evV66xI6IiOoPFpuIiKjGHTlyBEFBQTh58iSSkpJQVFQEPz8/PHz4UKXf+PHjcfv2bfHx2WefideePXuGgIAAFBYW4sSJE/j222+xdu1azJ07V+xz7do1BAQEoEePHkhLS0NISAjef/997Nu3T+yzceNGhIWFYd68eTh79ixcXV3h7++Pu3fvVv83goioHoiMjMTo0aNV2v773/+ie/fu2L59O3R1dZGRkYG3334bR48elSZIIiKqUSw2ERFRjdu7dy9Gjx4NJycnuLq6Yu3atcjOzkZqaqpKPz09PVhaWooPQ0ND8dr+/ftx6dIlrF+/Hm5ubujTpw/mz5+PlStXorCwEAAQHx8Pe3t7xMbGok2bNggODsbAgQOxbNkycZylS5di/PjxGDNmDNq2bYv4+Hjo6ekhISGhZr4ZRER13M8//4zhw4ertC1btgwPHjzArl27cObMGVy/fh1du3bFokWLJIqSiIhqEjcIJyIiyeXl5QEATExMVNq///57rF+/HpaWlujXrx/mzJkDPT09AEBKSgqcnZ1hYWEh9vf398ekSZNw8eJFtG/fHikpKfD19VUZ09/fHyEhIQCAwsJCpKamIjIyUryupaUFX19fpKSklBlrQUEBCgoKxOf5+fmVnzhRPZSdnY2cnBypw6g0U1NTNG/eXOow6pSbN2+iXbt2Km07duyAm5sb/Pz8AAC6uroIDg7G9OnTpQiRiIhqGItNREQkqeLiYoSEhMDT01Plj5Vhw4bB1tYW1tbWSE9PR3h4ODIzM7FlyxYAgFKpVCk0ARCfK5XKF/bJz8/H48ePkZubi2fPnpXZ5/Lly2XGGxMTg+jo6FebNFE9lZ2dDQfHNnjy+JHUoVSajq4eMi//yoKTGkr21Stx584dXLt2TSzsl2jWrFmdLkQSEVHFsdhERESSCgoKQkZGBo4fP67SPmHCBPFrZ2dnWFlZoVevXrh69SpatmxZ02GKIiMjERYWJj7Pz8+HjY2NZPEQ1SY5OTl48vgRnAdMg75Z3fv/xcN7N3Dhx1jk5OSw2KQGBwcHHDhwQLyLaefOnZDJZOLzErdv34aZmZkUIRIRUQ1jsYmIiCQTHByMnTt34ujRo2jWrNkL+3bp0gUAkJWVhZYtW8LS0rLUqXF37twBAFhaWor/W9L2zz6GhobQ1dWFtrY2tLW1y+xTMsa/KRQKKBSKik+SSAPpm9nA0LqV1GFQDZkyZQpGjhyJ3NxcWFpaYtWqVWjVqlWpZcz79u2Ds7OzRFESEVFN4gbhRERU4wRBQHBwMLZu3YqDBw/C3t7+pa9JS0sDAFhZWQEAPDw8cOHCBZVT45KSkmBoaIi2bduKfZKTk1XGSUpKgoeHBwBALpfD3d1dpU9xcTGSk5PFPkRE9GLDhw9HTEwM9u7di2XLlsHJyQlbtmxBgwb/+1z77t272LFjB/r16ydhpEREVFMkLzbFxMSgU6dOMDAwgLm5OQIDA5GZmVmqX0pKCnr27Al9fX0YGhrCy8sLjx8/BgBcv34d48aNg729PXR1ddGyZUvMmzdPPI2oRHp6Orp37w4dHR3Y2NioHKFdYtOmTXB0dISOjg6cnZ2xe/fu6pk4EZEGCwoKwvr165GYmAgDAwMolUoolUoxr1+9ehXz589Hamoqrl+/jp9++gkjR46El5cXXFxcAAB+fn5o27Yt3nvvPZw/fx779u3D7NmzERQUJN55NHHiRPz++++YMWMGLl++jC+//BL/+c9/EBoaKsYSFhaGr7/+Gt9++y1+/fVXTJo0CQ8fPsSYMWNq/htDRFRHzZgxAzdu3MCDBw9w5MgRODk5qVw3NzfHnTt3MHHiRIkiJCKimiR5senIkSMICgrCyZMnkZSUhKKiIvj5+eHhw4din5SUFPTu3Rt+fn44deoUTp8+jeDgYGhpPQ//8uXLKC4uxldffYWLFy9i2bJliI+Px8yZM8Ux8vPz4efnB1tbW6SmpmLx4sWIiorC6tWrxT4nTpzA0KFDMW7cOJw7dw6BgYEIDAxERkZGzX1DiIg0wKpVq5CXlwcfHx9YWVmJj40bNwJ4fsdRyf4fjo6OmDZtGgYMGIAdO3aIY2hra2Pnzp3Q1taGh4cHRowYgZEjR+Ljjz8W+9jb22PXrl1ISkqCq6srYmNjsWbNGvj7+4t9Bg8ejCVLlmDu3Llwc3NDWloa9u7dW2rTcCIiIiIiqhjJ92zau3evyvO1a9fC3Nwcqamp8PLyAgCEhoZiypQpiIiIEPs5ODiIX/fu3Ru9e/cWn7do0QKZmZlYtWoVlixZAuD58dmFhYVISEiAXC6Hk5MT0tLSsHTpUnET2ri4OPTu3Vs8knX+/PlISkrCihUrEB8fXz3fACIiDSQIwguv29jY4MiRIy8dx9bW9qV3oPr4+ODcuXMv7BMcHIzg4OCXvh8REREREb2c5Hc2/VteXh4AwMTEBMDz9d2//PILzM3N0a1bN1hYWMDb27vUqUVljVMyBvD87igvLy/I5XKxzd/fH5mZmcjNzRX7/HsjQ39/f6SkpJT5HgUFBcjPz1d5EBERERERERFpMsnvbPqn4uJihISEwNPTE+3atQMA/P777wCAqKgoLFmyBG5ubli3bh169eqFjIwMtG7dutQ4WVlZ+OKLL8S7mgBAqVSW2oC2ZImEUqmEsbExlEplqWUTFhYWUCqVZcYbExOD6Ojoyk+YiIiIiIiIqI7Lzs5GTk6O1GFUmqmpKZo3by51GPVKrSo2BQUFISMjQ+WupeLiYgDABx98IG7W2r59eyQnJyMhIQExMTEqY9y8eRO9e/fGoEGDMH78+GqNNzIyEmFhYeLz/Px82NjYVOt7EhEREREREdUW2dnZcHBsgyePH0kdSqXp6Ooh8/KvLDhVoVpTbAoODsbOnTtx9OhRNGvWTGwvOeK65BjrEm3atEF2drZK261bt9CjRw9069ZNZeNvALC0tMSdO3dU2kqeW1pavrBPyfV/UygU4olHRERERERERJomJycHTx4/gvOAadA3q3s3Xzy8dwMXfoxFTk4Oi01VSPJikyAImDx5MrZu3YrDhw+XWupmZ2cHa2trZGZmqrRfuXIFffr0EZ/fvHkTPXr0gLu7O7755hvxpLoSHh4emDVrFoqKitCwYUMAQFJSEhwcHGBsbCz2SU5ORkhIiPi6pKQkeHh4VOWUiYiIiIhIDStXrsTixYuhVCrh6uqKL774Ap07dy63/6ZNmzBnzhxcv34drVu3xqJFi9C3b1/xuiAImDdvHr7++mv89ddf8PT0xKpVq8rcooOIKkbfzAaG1q2kDqNG1PVlg0D1Lx2UvNgUFBSExMREbN++HQYGBuL+SEZGRtDV1YVMJsP06dMxb948uLq6ws3NDd9++y0uX76MzZs3A3heaPLx8YGtrS2WLFmCe/fuieOX3JU0bNgwREdHY9y4cQgPD0dGRgbi4uKwbNkyse/UqVPh7e2N2NhYBAQEYMOGDThz5kypu6SIiIiIiKhmbNy4EWFhYYiPj0eXLl2wfPly8aAfc3PzUv1PnDiBoUOHIiYmBm+++SYSExMRGBiIs2fPivvCfvbZZ/j888/x7bffwt7eHnPmzIG/vz8uXboEHR2dmp4iEdUh9WHZIFD9SwclLzatWrUKwPOjqf/pm2++wejRowEAISEhePLkCUJDQ3H//n24uroiKSkJLVu2BPD87qOsrCxkZWWpLMED/ne8tpGREfbv34+goCC4u7vD1NQUc+fOxYQJE8S+3bp1Q2JiImbPno2ZM2eidevW2LZtm/hDiYiIiIiIatbSpUsxfvx4cf/W+Ph47Nq1CwkJCYiIiCjVPy4uDr1798b06dMBAPPnz0dSUhJWrFiB+Ph4CIKA5cuXY/bs2ejfvz8AYN26dbCwsMC2bdswZMiQmpscEdU5dX3ZIFAzSwclLzaVFINeJiIioswfJgAwevRosTD1Ii4uLjh27NgL+wwaNAiDBg2qUExERERERFR9CgsLkZqaisjISLFNS0sLvr6+SElJKfM1KSkpKof4AIC/vz+2bdsGALh27RqUSiV8fX3F60ZGRujSpQtSUlLKLDYVFBSgoKBAfJ6fn/8q09JID+/dkDqESqls3HV9mVVlllhp2r8xvZjkxSYiIiIiIqKy5OTk4NmzZ7CwsFBpt7CwwOXLl8t8jVKpLLN/yXYdJf/7oj7/FhMTg+jo6ErN4d+0FYaQaTWEUFxUJeNJQabVENoKwwr1NTU1hY6uHi78GFvNUVUfHV09mJqaVrh/fVhmpc4SK037N64P8wXU/+9aXSw2ERERERERvUBkZKTK3VL5+fmwsanc8hm5vjla9f0Kzwrq7t1R2gpDyPVL75dVlubNmyPz8q8adZdPXV9mpe4SK037N64P8wU0YINwIiIiIiKispiamkJbWxt37txRab9z5454ENC/WVpavrB/yf/euXMHVlZWKn3c3NzKHFOhUEChUFR2GqXI9c2BChZr6oPmzZtr5JHymnQ6m6b9G2vafCtDS+oAiIiIiIiIyiKXy+Hu7o7k5GSxrbi4GMnJyfDw8CjzNR4eHir9gecHCpX0t7e3h6WlpUqf/Px8/PLLL+WOSURE6uGdTUREREREVGuFhYVh1KhR6NixIzp37ozly5fj4cOH4ul0I0eORNOmTRETEwMAmDp1Kry9vREbG4uAgABs2LABZ86cwerVqwEAMpkMISEhWLBgAVq3bg17e3vMmTMH1tbWCAwMlGqaRET1CotNRERERERUaw0ePBj37t3D3LlzoVQq4ebmhr1794obfGdnZ0NL638LNrp164bExETMnj0bM2fOROvWrbFt2za0a9dO7DNjxgw8fPgQEyZMwF9//YXXX38de/fuhY6OTo3Pj4ioPmKxiYiIiIiIarXg4GAEBweXee3w4cOl2gYNGoRBgwaVO55MJsPHH3+Mjz/+uKpCJCKif+CeTUREREREREREVGV4ZxNJJjs7m8dFEhEREREREdUzLDaRJLKzs+Hg2AZPHj+SOpRXoqOrh8zLv7LgRERERERERPT/sdhUixQ+vItnBflSh1Fp2gpDyPXNK9Q3JycHTx4/gvOAadA3s6nmyKrHw3s3cOHHWOTk5LDYREREpKHq+u9vgHq/wxEREVUEi021ROHDu8ja/QGE4iKpQ6k0mVZDtOr7lVq/rOib2cDQulU1RkVERERUPerD729A5X6HIyIiehFuEF5LPCvIr/O/qAjFRXX+kz0iIiKiiqoPv78B/B2OiIiqHotNRERERERERERUZVhsIiIiIiIiIiKiKsNiExERERERERERVRkWm4iIiIiIiIiIqMqw2ERERERERERERFWGxSYiIqpxMTEx6NSpEwwMDGBubo7AwEBkZmaW2VcQBPTp0wcymQzbtm1TuZacnIxu3brBwMAAlpaWCA8Px9OnT1X6pKeno3v37tDR0YGNjQ0+++yzUu+xadMmODo6QkdHB87Ozti9e3eVzZWIiIiISNOw2ERERDXuyJEjCAoKwsmTJ5GUlISioiL4+fnh4cOHpfouX74cMpmsVPv58+fRt29f9O7dG+fOncPGjRvx008/ISIiQuyTn58PPz8/2NraIjU1FYsXL0ZUVBRWr14t9jlx4gSGDh2KcePG4dy5cwgMDERgYCAyMjKqZ/JERERERPVcA6kDICIizbN3716V52vXroW5uTlSU1Ph5eUltqelpSE2NhZnzpyBlZWVyms2btwIFxcXzJ07FwDQqlUrfPbZZ3j33Xcxb948GBgY4Pvvv0dhYSESEhIgl8vh5OSEtLQ0LF26FBMmTAAAxMXFoXfv3pg+fToAYP78+UhKSsKKFSsQHx9fnd8GIiIiIqJ6iXc2ERGR5PLy8gAAJiYmYtujR48wbNgwrFy5EpaWlqVeU1BQAB0dHZU2XV1dPHnyBKmpqQCAlJQUeHl5QS6Xi338/f2RmZmJ3NxcsY+vr6/KOP7+/khJSSkz1oKCAuTn56s8iIiIiIjof3hnExERSaq4uBghISHw9PREu3btxPbQ0FB069YN/fv3L/N1/v7+WL58OX744Qe8++67UCqV+PjjjwEAt2/fBgAolUrY29urvM7CwkK8ZmxsDKVSKbb9s49SqSzzfWNiYhAdHV25yRIREZHGeHjvhtQhVEpdjZtqFxabiIhIUkFBQcjIyMDx48fFtp9++gkHDx7EuXPnyn2dn58fFi9ejIkTJ+K9996DQqHAnDlzcOzYMWhpVd+Nu5GRkQgLCxOf5+fnw8bGptrej4iIiOoWU1NT6Ojq4cKPsVKHUmk6unowNTWVOgyqw1hsIiIiyQQHB2Pnzp04evQomjVrJrYfPHgQV69eRePGjVX6DxgwAN27d8fhw4cBAGFhYQgNDcXt27dhbGyM69evIzIyEi1atAAAWFpa4s6dOypjlDwvWZpXXp+ylu4BgEKhgEKhqPSciYiIqH5r3rw5Mi//ipycHKlDqTRTU1M0b95c6jCoDmOxiYiIapwgCJg8eTK2bt2Kw4cPl1rqFhERgffff1+lzdnZGcuWLUO/fv1U2mUyGaytrQEAP/zwA2xsbNChQwcAgIeHB2bNmoWioiI0bNgQAJCUlAQHBwcYGxuLfZKTkxESEiKOmZSUBA8PjyqdMxEREWmO5s2bs1hDGo3FJiIiqnFBQUFITEzE9u3bYWBgIO6PZGRkBF1dXVhaWpZ5Z1Hz5s1VClOLFy9G7969oaWlhS1btuDTTz/Ff/7zH2hrawMAhg0bhujoaIwbNw7h4eHIyMhAXFwcli1bJo4xdepUeHt7IzY2FgEBAdiwYQPOnDmD1atXV/N3gYiIiIiofuJpdEREVONWrVqFvLw8+Pj4wMrKSnxs3LhRrXH27NmD7t27o2PHjti1axe2b9+OwMBA8bqRkRH279+Pa9euwd3dHdOmTcPcuXMxYcIEsU+3bt2QmJiI1atXw9XVFZs3b8a2bdtUNisnIiIiIqKK451NRERU4wRBqJLXHDx48KWvc3FxwbFjx17YZ9CgQRg0aJDaMRERERERUWm8s4mIiIiIiIiIiKoMi01ERERERERERFRlWGwiIiIiIiIiIqIqw2ITERERERERERFVGRabiIiIiIiIiIioyrDYREREREREREREVYbFJiIiIiIiIiIiqjINpA6gPhEEAQCQn5+v9msf5/+NB4+KqjqkGpef/zeKGrx8/g8ePAAAPC18gqdPHlV3WNXiaeETAM/nUpF/87o+Z8735TRxzsD/cl5JDtQ0r5L7Ne2/mbo+X0Dz5sz5vlh9+f0NqPjvcP/rz9wPVC73ExHVVerkfpmgqT8hqsEff/wBGxsbqcMgIpLEjRs30KxZM6nDqHHM/USkyZj7iYg0T0VyP4tNVai4uBi3bt2CgYEBZDKZ1OGoyM/Ph42NDW7cuAFDQ0Opw6l2mjZfQPPmrGnzBWrvnAVBwN9//w1ra2toaWne6mzm/tpD0+YLaN6cNW2+QO2dM3M/c39toWnzBTRvzpo2X6D2zlmd3M9ldFVIS0ur1n+yY2hoWKv+Y61umjZfQPPmrGnzBWrnnI2MjKQOQTLM/bWPps0X0Lw5a9p8gdo5Z+Z+5v7aRNPmC2jenDVtvkDtnHNFc7/mfQxBRERERERERETVhsUmIiIiIiIiIiKqMiw2aQiFQoF58+ZBoVBIHUqN0LT5Apo3Z02bL6CZc6ZXo2n/zWjafAHNm7OmzRfQzDnTq9G0/2Y0bb6A5s1Z0+YL1I85c4NwIiIiIiIiIiKqMryziYiIiIiIiIiIqgyLTUREREREREREVGVYbCIiIiIiIiIioirDYhMREREREREREVUZFpvquZiYGHTq1AkGBgYwNzdHYGAgMjMzpQ6r2qxatQouLi4wNDSEoaEhPDw8sGfPHqnDqjGffvopZDIZQkJCpA6l2kRFRUEmk6k8HB0dpQ6rWt28eRMjRoxAkyZNoKurC2dnZ5w5c0bqsKgWY+5n7q9vmPuZ++nFNC3vA8z9zP31U33K/Sw21XNHjhxBUFAQTp48iaSkJBQVFcHPzw8PHz6UOrRq0axZM3z66adITU3FmTNn0LNnT/Tv3x8XL16UOrRqd/r0aXz11VdwcXGROpRq5+TkhNu3b4uP48ePSx1StcnNzYWnpycaNmyIPXv24NKlS4iNjYWxsbHUoVEtxtzP3F8fMfcz91P5NC3vA8z9zP31T33L/Q2kDoCq1969e1Wer127Fubm5khNTYWXl5dEUVWffv36qTz/5JNPsGrVKpw8eRJOTk4SRVX9Hjx4gOHDh+Prr7/GggULpA6n2jVo0ACWlpZSh1EjFi1aBBsbG3zzzTdim729vYQRUV3A3M/cXx8x9zP3U/k0Le8DzP3M/fVPfcv9vLNJw+Tl5QEATExMJI6k+j179gwbNmzAw4cP4eHhIXU41SooKAgBAQHw9fWVOpQa8dtvv8Ha2hotWrTA8OHDkZ2dLXVI1eann35Cx44dMWjQIJibm6N9+/b4+uuvpQ6L6hjm/vqJuZ+5n6g8mpT3Aeb++oy5v+7mft7ZpEGKi4sREhICT09PtGvXTupwqs2FCxfg4eGBJ0+eoFGjRti6dSvatm0rdVjVZsOGDTh79ixOnz4tdSg1okuXLli7di0cHBxw+/ZtREdHo3v37sjIyICBgYHU4VW533//HatWrUJYWBhmzpyJ06dPY8qUKZDL5Rg1apTU4VEdwNxfPzH3M/cTlUdT8j7A3F/fMffX8dwvkMaYOHGiYGtrK9y4cUPqUKpVQUGB8NtvvwlnzpwRIiIiBFNTU+HixYtSh1UtsrOzBXNzc+H8+fNim7e3tzB16lTpgqphubm5gqGhobBmzRqpQ6kWDRs2FDw8PFTaJk+eLHTt2lWiiKiuYe6vf5j7mfuJXkRT8r4gMPcz99cv9S33cxmdhggODsbOnTtx6NAhNGvWTOpwqpVcLkerVq3g7u6OmJgYuLq6Ii4uTuqwqkVqairu3r2LDh06oEGDBmjQoAGOHDmCzz//HA0aNMCzZ8+kDrHaNW7cGK+99hqysrKkDqVaWFlZlfqErk2bNvX6FmKqOsz9zP31FXM/Udk0Ke8DzP3M/fVLfcv9XEZXzwmCgMmTJ2Pr1q04fPhwnd5grLKKi4tRUFAgdRjVolevXrhw4YJK25gxY+Do6Ijw8HBoa2tLFFnNefDgAa5evYr33ntP6lCqhaenZ6mji69cuQJbW1uJIqK6gLmfub++Y+4nUsW8/xxzf/3G3F+3sNhUzwUFBSExMRHbt2+HgYEBlEolAMDIyAi6uroSR1f1IiMj0adPHzRv3hx///03EhMTcfjwYezbt0/q0KqFgYFBqbX4+vr6aNKkSb1do//RRx+hX79+sLW1xa1btzBv3jxoa2tj6NChUodWLUJDQ9GtWzcsXLgQ7777Lk6dOoXVq1dj9erVUodGtRhzP3N/fcPcz9xPL6ZpeR9g7geY++ubepf7JV7GR9UMQJmPb775RurQqsXYsWMFW1tbQS6XC2ZmZkKvXr2E/fv3Sx1Wjarva7cHDx4sWFlZCXK5XGjatKkwePBgISsrS+qwqtWOHTuEdu3aCQqFQnB0dBRWr14tdUhUyzH3M/fXN8z9zP30YpqW9wWBuV8QmPvro/qU+2WCIAg1XeAiIiIiIiIiIqL6iRuEExERERERERFRlWGxiYiIiIiIiIiIqgyLTUREREREREREVGVYbCIiIiIiIiIioirDYhMREREREREREVUZFpuIiIiIiIiIiKjKsNhERERERERERERVhsUmqjOioqIgk8ng5eVV6lpISAjs7OxqNB4fHx+8+eabNfqe6igsLMSYMWNgZmYGmUyG5cuXv7D/Tz/9BD8/P5iYmEAul8Pe3h4ffPABrly5IvaRyWRYsmRJlcb5119/ISoqCpcuXarScYmofmDuVw9zPxHVB8z96mHup9qIxSaqc44dO4bDhw9LHUatt27dOnz33XdYvnw5UlJSMGTIkHL7RkREoH///jAyMsLXX3+NAwcOYO7cubh06RIGDx5crXH+9ddfiI6O5g8dInoh5v6KYe4novqEub9imPupNmogdQBE6tDX14eTkxPmz58PHx8fqcOpVo8fP4aurm6lX3/58mVYW1tj+PDhL+y3e/duLFq0CHPmzMHHH38stnt5eWHMmDHYuXNnpWOQgiAIKCwshEKhkDoUIqoizP0Vx9zP3E9UXzD3VxxzP3N/bcQ7m6jOmTNnDg4ePIgTJ06U22ft2rWQyWTIyclRaXdzc8Po0aPF56NHj0a7du1w4MABuLi4QFdXF97e3rh+/Tru37+Pd999F4aGhmjZsiU2btxY5nutW7cOLVu2hK6uLnx8fJCZmalyXRAELFmyBK+99hoUCgVatGiBZcuWqfSJiopCo0aNcOrUKXh4eEBHRwcrV64sd37//e9/MXDgQBgZGUFfXx/+/v64cOGCeN3Ozg6xsbG4ceMGZDIZZDIZrl+/XuZYsbGxsLCwwJw5c8q8/qJbhu3s7BAcHKzStm3btlLv9+mnn6JVq1bQ0dGBmZkZfH19ce3aNVy/fh329vYAgEGDBpWKtaCgADNnzoStrS0UCgXatGmDxMRElfcr+TfcvXs3XF1doVAosGPHDhQVFWH69Olo3rw5FAoFrKys0K9fP+Tl5ZU7HyKqvZj7mfv/ibmfSDMw9zP3/xNzf93CO5uoznnzzTfRvn17REdHY9++fa88nlKpxLRp0zBr1iw0bNgQU6ZMwfDhw6GnpwcvLy+MHz8eX3/9NUaMGIGuXbvC1tZWfO3Zs2dx9epVfPrppwCA2bNnw9/fH5mZmWKFferUqVizZg1mzZqFLl264MSJEwgPD4euri4mTpwojlVYWIhhw4YhNDQUCxcuRJMmTcqM9++//4aPjw+0tLQQHx8PHR0dfPLJJ/Dy8kJ6ejpsbGywdetWLFq0CEeOHMHWrVsBAFZWVqXGevr0KX7++WcMGDAADRs2fOXvZVnWrVsnfnri4eGBvLw8HDt2DPn5+XB0dMSWLVvwzjvvYOHChejRo4dKrO+++y6OHz+OefPmoU2bNti9ezdGjBgBY2Nj9OnTR3yPW7duYcqUKZg9ezaaN2+O5s2bIyYmBvHx8Vi0aBGcnJyQk5OD/fv3o6CgoFrmSUTVi7mfuZ+5n0jzMPcz9zP312ECUR0xb948QV9fXxAEQfjxxx8FAMIvv/wiCIIgTJ06VbC1tRX7fvPNNwIA4d69eypjuLq6CqNGjRKfjxo1SpDJZEJGRobY9sUXXwgAhPDwcLEtNzdX0NbWFpYvXy62eXt7C1paWsKVK1fEtt9++03Q0tIS4uPjBUEQhKysLEEmkwlfffWVShzh4eGCpaWl8OzZM3FuAIQNGza89PsQFxcnyGQy4dKlS2Lbn3/+Kejr6wthYWFi27+/J2VRKpUCACEiIuKl7ysIggBAWLx4sfjc1tZWCAoKUumzdetWAYBw7do1QRAEISgoSOjQoUO5Y167dk0AIGzatEml/eDBgwIAYd++fSrtgwcPFjp16iQ+HzVqlABAOHnypEq/gIAA4Z133qnQvIio9mLuf465n7mfSJMw9z/H3M/cX5dxGR3VSW+//TbatWunsta4sqytreHk5CQ+f+211wAAvr6+Ylvjxo1hbm6OGzduqLy2Xbt2aN26tfi8VatWcHV1xS+//AIAOHDgAABgwIABePr0qfjw9fWFUqksNV5AQMBL4z127BjatWuHNm3aiG0mJiZ44403cPz48YpOW4VMJqvU6yqiQ4cOOHfuHMLCwnD8+HEUFRVV6HX79++HiYkJevbsqfK9e+ONN3Du3Dk8e/ZM7NukSRN06dKl1Pvu3r0bUVFROH36NIqLi6t0XkRU85j7mfuZ+4k0D3M/cz9zf93EYhPVSTKZDLNmzcKuXbtw9uzZVxqrcePGKs/lcnm57U+ePFFpMzc3LzWehYUFbt++DQDIycmBIAgwNTVFw4YNxccbb7wBACo/dPT09NCoUaOXxpubmwsLC4sy3/f+/fsvff0/NWnSBDo6OsjOzlbrdeoYPXo0li1bhn379qF79+4wMzPD1KlT8fjx4xe+LicnB/fv31f5vjVs2BDvv/8+nj59Kn6PAZT5/Zg1axbCw8Px7bffonPnzrC0tER0dDQEQajyORJRzWDuZ+5n7ifSPMz9zP3M/XUT92yiOuvdd99FVFQU5s+fr7KeGgB0dHQAPF8P/U+5ublVGsPdu3dLtd25cwdubm4Ann/yIJPJcPz4cfGH2T85ODiIX1f0UwYTE5NSmxGWvK+JiUkFI3+uQYMG8PT0RHJyMp4+fYoGDdRLCTo6Oi/9HmtpaWHq1KmYOnUqbt68iQ0bNiAiIgKmpqblbk4IPJ+nmZkZdu/eXeb1f/7AL+t7p1AoEBUVhaioKGRlZSEhIQFRUVFo0aIF3nvvPXWmSUS1CHN/6fdl7v8f5n6i+om5v/T7Mvf/D3N/7cQ7m6jO0tLSwqxZs7B9+3akp6erXGvWrBkA4NdffxXbfv3111K3r76qjIwMZGVlic+zsrJw/vx58dbOXr16AQD+/PNPdOzYsdTDwMBA7fd8/fXXceHCBZUfPLm5uThw4ABef/11tccLCwuDUqnEJ598Uub18pI+8Pz7/M/vMfD8NtjyNG3aFNOmTYOLi4v4upIfxv/+9MjX1xf37t2DXC4v83tX1g/x8rRq1QoLFy6EiYlJqXiJqG5h7mfuryjmfqL6g7mfub+imPtrD97ZRHXasGHDEB0djUOHDql8ytGlSxfY2NggNDQUMTExyM/Px6efflruSQ+VZWFhgX79+olryOfMmYOmTZuKx6y+9tprCAoKwnvvvYfp06ejS5cuKCoqwpUrV3Do0CFs27ZN7fccM2YMli1bhoCAACxYsEA8laJBgwYICQlRe7y+fftixowZiIqKwqVLlzBkyBCYmpri2rVrSEhIQF5eHvr27VvmawcOHIhJkyYhOjoa3bp1w+7du5GSkqLS54MPPoCxsTG6du0KY2Nj/Pzzzzh//jw+/PBDAIClpSUaN26MH374Afb29lAoFHBxccEbb7yBfv36oXfv3pgxYwZcXFzw8OFDXLx4EVlZWVizZs0L5xUYGAh3d3e0b98e+vr62LFjB3Jzc9GzZ0+1v0dEVLsw9zP3l4e5n6j+Yu5n7i8Pc38tJeXu5ETq+OepFP+0Zs0aAUCpExjOnDkjdOrUSdDV1RWcnZ2FAwcOlHkqhZOTk8rrDh06JAAQTp8+rdL+7xMYvL29hYCAACEhIUGws7MTFAqF4OXlpXJahCAIQnFxsfDFF18I7dq1E+RyuWBiYiJ4eHgIS5cufencynP9+nXhnXfeEQwMDAQ9PT3hjTfeENLT01X6VORUin/atm2b4OvrKzRu3Fho2LChYGdnJ3zwwQfCb7/9JvbBv06lKCoqEj766CPBwsJCMDIyEj744AMhMTFR5VSKtWvXCp6enoKJiYmgo6MjtG3bVvj8889V3nvr1q1CmzZtBIVCofLagoICITo6WmjdurUgl8sFMzMzoUePHsK6devE15b1bygIgvDZZ58JHTt2FIyMjAR9fX2hQ4cOQmJiYoW/H0RUOzD3/w9zP3M/kaZg7v8f5n7m/rpKJgjcNYuIiIiIiIiIiKoG92wiIiIiIiIiIqIqw2ITERERERERERFVGRabiIiIiIiIiIioyrDYREREREREREREVYbFJiIiIiIiIiIiqjIsNhERERERERERUZVhsYmIiIiIiIiIiKoMi01ERERERERERFRlWGwiIiIiIiIiIqIqw2ITERERERERERFVGRabiIiIiIiIiIioyrDYREREREREREREVeb/ATQreeBA3RlBAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1400x400 with 3 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "09caa091",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "fig, axes = plt.subplots(1, 3, figsize=(14, 4))\n",
-    "\n",
-    "# BIC (lower is better) - zoomed y-axis\n",
-    "ax = axes[0]\n",
-    "bars = ax.bar(n_regimes_list, metrics[\"BIC\"], color=\"steelblue\", edgecolor=\"black\")\n",
-    "best_idx = np.argmin(metrics[\"BIC\"])\n",
-    "bars[best_idx].set_color(\"#D4A84B\")\n",
-    "ax.set_xlabel(\"Number of Clusters\", fontsize=11)\n",
-    "ax.set_ylabel(\"BIC (lower is better)\", fontsize=11)\n",
-    "ax.set_title(\"Bayesian Information Criterion\", fontsize=12)\n",
-    "ax.set_xticks(n_regimes_list)\n",
-    "# Zoom y-axis to show differences more clearly\n",
-    "bic_min, bic_max = min(metrics[\"BIC\"]), max(metrics[\"BIC\"])\n",
-    "bic_range = bic_max - bic_min\n",
-    "ax.set_ylim(bic_min - 0.1 * bic_range, bic_max + 0.1 * bic_range)\n",
-    "\n",
-    "# AIC (lower is better) - zoomed y-axis\n",
-    "ax = axes[1]\n",
-    "bars = ax.bar(n_regimes_list, metrics[\"AIC\"], color=\"steelblue\", edgecolor=\"black\")\n",
-    "best_idx = np.argmin(metrics[\"AIC\"])\n",
-    "bars[best_idx].set_color(\"#D4A84B\")\n",
-    "ax.set_xlabel(\"Number of Clusters\", fontsize=11)\n",
-    "ax.set_ylabel(\"AIC (lower is better)\", fontsize=11)\n",
-    "ax.set_title(\"Akaike Information Criterion\", fontsize=12)\n",
-    "ax.set_xticks(n_regimes_list)\n",
-    "# Zoom y-axis to show differences more clearly\n",
-    "aic_min, aic_max = min(metrics[\"AIC\"]), max(metrics[\"AIC\"])\n",
-    "aic_range = aic_max - aic_min\n",
-    "ax.set_ylim(aic_min - 0.1 * aic_range, aic_max + 0.1 * aic_range)\n",
-    "\n",
-    "# Silhouette (higher is better)\n",
-    "ax = axes[2]\n",
-    "bars = ax.bar(n_regimes_list, metrics[\"Silhouette\"], color=\"steelblue\", edgecolor=\"black\")\n",
-    "best_idx = np.argmax(metrics[\"Silhouette\"])\n",
-    "bars[best_idx].set_color(\"#D4A84B\")\n",
-    "ax.set_xlabel(\"Number of Clusters\", fontsize=11)\n",
-    "ax.set_ylabel(\"Silhouette (higher is better)\", fontsize=11)\n",
-    "ax.set_title(\"Silhouette Score\", fontsize=12)\n",
-    "ax.set_xticks(n_regimes_list)\n",
-    "\n",
-    "fig.suptitle(\n",
-    "    \"GMM Model Selection: BIC and Silhouette Agree on K=2; AIC Prefers K=6\",\n",
-    "    fontsize=14,\n",
-    "    y=1.02,\n",
+    "def mark_events(ax: Axes, years: list[int]) -> None:\n",
+    "    \"\"\"Draw a rule and a label at the first month of each dated episode.\"\"\"\n",
+    "    for event_year, (event_label, side) in HISTORICAL_EVENTS.items():\n",
+    "        position = next((j for j, year in enumerate(years) if year == event_year), None)\n",
+    "        if position is None:\n",
+    "            continue\n",
+    "        ax.axvline(x=position, color=COLORS[\"neutral\"], alpha=0.6, linewidth=1.0)\n",
+    "        ax.annotate(\n",
+    "            event_label,\n",
+    "            xy=(position, 1.7 if side == \"top\" else -0.7),\n",
+    "            ha=\"center\",\n",
+    "            va=\"bottom\" if side == \"top\" else \"top\",\n",
+    "            fontsize=7,\n",
+    "            color=COLORS[\"neutral\"],\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "104172ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, (ax_band, ax_equity) = plt.subplots(\n",
+    "    2, 1, figsize=style.FIGSIZE[\"dual_v\"], height_ratios=[1, 2], sharex=True\n",
     ")\n",
-    "plt.show()"
+    "\n",
+    "rows = np.where(labels_2 == risk_on_cluster, 1, 0)\n",
+    "draw_swimlanes(ax_band, rows, 2, lane_cmap)\n",
+    "ax_band.set_yticks([0, 1])\n",
+    "ax_band.set_yticklabels([\"Risk-off\", \"Risk-on\"])\n",
+    "ax_band.set_ylim(-0.5, 1.5)\n",
+    "mark_events(ax_band, factors_df.index.year.tolist())\n",
+    "\n",
+    "cumulative = (1 + equity_returns).cumprod()\n",
+    "positions = np.arange(len(cumulative))\n",
+    "for cluster, colour in ((risk_on_cluster, COLORS[\"recede\"]), (risk_off_cluster, COLORS[\"blue\"])):\n",
+    "    masked = np.where(labels_2 == cluster, cumulative.to_numpy(), np.nan)\n",
+    "    ax_equity.plot(positions, masked, color=colour, linewidth=1.2)\n",
+    "ax_equity.set_yscale(\"log\")\n",
+    "ax_equity.set_ylabel(\"Growth of 1 unit invested (log scale)\")\n",
+    "ax_equity.set_xlabel(\"Year\")\n",
+    "ax_equity.set_xticks(ticks)\n",
+    "ax_equity.set_xticklabels(tick_labels)\n",
+    "ax_equity.grid(True, alpha=0.3)\n",
+    "\n",
+    "style.add_message_title(\n",
+    "    ax_band,\n",
+    "    \"Risk-off months come in short bursts, not in long bear markets\",\n",
+    "    subtitle=\"Upper: assigned regime. Lower: cumulative equity index return, coloured by regime\",\n",
+    ")\n",
+    "style.show_with_alt(\n",
+    "    fig,\n",
+    "    \"A two-row regime band above a rising cumulative return curve on a log scale. The \"\n",
+    "    \"risk-off row is occupied in many short bursts spread across the whole century rather \"\n",
+    "    \"than in a few long blocks, and the curve is drawn dark through those same stretches.\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "aa4a6682",
-   "metadata": {
-    "lines_to_next_cell": 0,
-    "papermill": {
-     "duration": 0.002033,
-     "end_time": "2026-07-11T19:31:19.053646+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.051613+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "19c251bb",
+   "metadata": {},
    "source": [
-    "## Regime Timeline Visualization"
+    "## Volatility inside each regime\n",
+    "\n",
+    "A regime label is only worth carrying if it corresponds to something a risk manager would\n",
+    "act on, and the first thing to check is whether the two environments differ in how much\n",
+    "the market moves. The series below is the standard deviation of the equity index return\n",
+    "over a trailing twelve-month window, annualized by multiplying by the square root of\n",
+    "twelve, drawn in the colour of the regime assigned to each month. The dashed rules are the\n",
+    "average of that rolling series within each regime."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "dc819042",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:19.058374Z",
-     "iopub.status.busy": "2026-07-11T19:31:19.058210Z",
-     "iopub.status.idle": "2026-07-11T19:31:19.061498Z",
-     "shell.execute_reply": "2026-07-11T19:31:19.061181Z"
-    },
-    "papermill": {
-     "duration": 0.006233,
-     "end_time": "2026-07-11T19:31:19.061891+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.055658+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "2b58a5e0",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_regime_timeline(\n",
-    "    labels: np.ndarray,\n",
-    "    dates: pd.Index,\n",
-    "    n_regimes: int,\n",
-    "    title: str,\n",
-    "    ax: Axes | None = None,\n",
-    ") -> Axes:\n",
-    "    \"\"\"Plot regime assignments as a timeline heatmap (one row per regime).\"\"\"\n",
-    "    if ax is None:\n",
-    "        fig, ax = plt.subplots(figsize=(16, 0.8 * n_regimes + 1))\n",
+    "rolling_vol = equity_returns.rolling(ROLLING_VOL_MONTHS).std() * np.sqrt(MONTHS_PER_YEAR)\n",
     "\n",
-    "    years = [pd.Timestamp(ts).year for ts in dates]\n",
-    "\n",
-    "    # Create binary matrix: (n_regimes x n_months)\n",
-    "    regime_matrix = np.zeros((n_regimes, len(labels)))\n",
-    "    for i, label in enumerate(labels):\n",
-    "        regime_matrix[label, i] = 1\n",
-    "\n",
-    "    # Plot each regime as a swim lane. origin='lower' so data row k anchors\n",
-    "    # at y=k (matching the \"Regime k+1\" yticklabel below).\n",
-    "    ax.imshow(\n",
-    "        regime_matrix,\n",
-    "        aspect=\"auto\",\n",
-    "        cmap=\"Blues\",\n",
-    "        vmin=0,\n",
-    "        vmax=1,\n",
-    "        extent=(0, len(labels), -0.5, n_regimes - 0.5),\n",
-    "        interpolation=\"nearest\",\n",
-    "        origin=\"lower\",\n",
-    "    )\n",
-    "\n",
-    "    # Y-axis: regime labels\n",
-    "    ax.set_yticks(range(n_regimes))\n",
-    "    ax.set_yticklabels([f\"Regime {i + 1}\" for i in range(n_regimes)], fontsize=10)\n",
-    "\n",
-    "    # X-axis: decade markers\n",
-    "    year_ticks = []\n",
-    "    year_labels_list = []\n",
-    "    for j, year in enumerate(years):\n",
-    "        if j == 0 or years[j - 1] != year:\n",
-    "            if year % 10 == 0:\n",
-    "                year_ticks.append(j)\n",
-    "                year_labels_list.append(str(year))\n",
-    "\n",
-    "    ax.set_xticks(year_ticks)\n",
-    "    ax.set_xticklabels(year_labels_list, fontsize=9)\n",
-    "    ax.set_xlabel(\"Year\", fontsize=11)\n",
-    "    ax.set_title(title, fontsize=12)\n",
-    "\n",
-    "    # Add horizontal grid lines between regimes\n",
-    "    for i in range(1, n_regimes):\n",
-    "        ax.axhline(y=i - 0.5, color=\"white\", linewidth=2)\n",
-    "\n",
-    "    return ax"
+    "rolling_vol_by_regime = (\n",
+    "    rolling_vol.groupby(regime_name)\n",
+    "    .agg([\"mean\", \"median\", \"max\"])\n",
+    "    .rename(columns={\"mean\": \"Mean (%)\", \"median\": \"Median (%)\", \"max\": \"Max (%)\"})\n",
+    "    .mul(100)\n",
+    "    .loc[[\"Risk-on\", \"Risk-off\"]]\n",
+    ")\n",
+    "rolling_vol_by_regime.index.name = \"Regime\"\n",
+    "rolling_vol_by_regime.style.format(\"{:.1f}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "a7db1f83",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:19.066790Z",
-     "iopub.status.busy": "2026-07-11T19:31:19.066724Z",
-     "iopub.status.idle": "2026-07-11T19:31:19.455493Z",
-     "shell.execute_reply": "2026-07-11T19:31:19.454983Z"
-    },
-    "papermill": {
-     "duration": 0.391832,
-     "end_time": "2026-07-11T19:31:19.455791+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.063959+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABTcAAAFECAYAAADyTQrfAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAXEVJREFUeJzt3Wd4FGX79/FfQiC90EIRQu9dQUGEAIICSpMqKF25FQSx0BQhSpGiqHRUioiKoCBKuREVRRDp8AeV3osgLQRSgFzPC5/snd1sS5Ew8v0cBwfZuepc58zu5szsrI8xxggAAAAAAAAALMY3uycAAAAAAAAAABlBchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAFmmePHi6t69e3ZPI92Sk5NVuXJljR49Orun4tSMGTMUFRWlxMTE7J4KAADAbYXkJgAAyLDDhw+rX79+Klu2rIKCghQUFKSKFSuqb9++2rVrl13dkSNHysfHR76+vjp+/HiavmJjYxUYGCgfHx/169fPtv3IkSPy8fGRj4+PRo0a5XQeXbp0kY+Pj0JCQjzOOWUezv7NmDEjnSvg3m+//aaRI0fqyJEjWdqvO477lzNnThUvXlz9+/fXpUuXbtk8rObTTz/V8ePH7Y69f9r58+c1YcIE1a9fX/nz51dERIRq166thQsXpqnbvXt3JSUlaebMmVk+j9OnT2vIkCFq2LChQkND5ePjo7Vr1zqte/36dcXExKhkyZLy9/dXyZIlNWrUKN24ccOu3ubNm9WvXz9VqlRJwcHBioqKUocOHbRv3740fbo6H318fNSkSRO3c7927ZpGjhzpcr4Zdfz4ccXExOjee+9V7ty5lS9fPjVo0EBr1qxxWv/SpUt6+umnlT9/fgUHB6thw4batm2bXZ30xNvR6NGj5ePjo8qVK2fJ/gEA8G/il90TAAAA1vTNN9+oY8eO8vPzU5cuXVStWjX5+vrqjz/+0Jdffqnp06fr8OHDKlasmF07f39/ffrppxo0aJDd9i+//NLteAEBAfr000/16quv2m2/evWqvvrqKwUEBKRr/tOnT0+TDL3vvvvS1Ycnv/32m2JiYtSgQQMVL148S/v2JGX/rl69qu+++06TJ0/Wtm3b9PPPP/+j4+7du1e+vtb7+/mECRPUqVMnhYeH37Ixf/nlF73yyitq3ry5Xn31Vfn5+emLL75Qp06dbMdOioCAAHXr1k1vv/22nnvuOfn4+GTZPPbu3atx48apTJkyqlKlin755ReXdZ944gktWrRIPXv2VM2aNbVx40YNHz5cx44d06xZs2z1xo0bp/Xr16t9+/aqWrWqzpw5oylTpujuu+/Wxo0b7ZJ08+fPTzPOli1b9O677+qhhx5yO/dr167Z1qlBgwbp3HPXvvrqK40bN06tW7dWt27ddOPGDX300Udq0qSJZs+erR49etjqJicn65FHHtHOnTv18ssvK1++fJo2bZoaNGigrVu3qkyZMpLSF+/UTpw4oTFjxig4ODjL9g8AgH8VAwAAkE4HDhwwwcHBpkKFCubUqVNpyq9fv27effddc+zYMdu2ESNGGEnmscceM9WrV0/TpkmTJqZt27ZGkunbt69t++HDh23tJJkdO3bYtVuwYIHJmTOnadGihQkODvY495R5nDt3Lj27nCGLFi0ykswPP/yQpf1evXrVZZmr/evYsaORZH799dcsncu/wbZt24wks2bNmls67qFDh8yRI0fstiUnJ5tGjRoZf39/ExcXZ1e2ZcsWI8l89913WTqP2NhYc/78eWOM+2N206ZNRpIZPny43fYXX3zR+Pj4mJ07d9q2rV+/3iQmJtrV27dvn/H39zddunTxOKdevXoZHx8fc/z4cbf1zp07ZySZESNGeOwzPXbv3p3mHEpISDDly5c3RYoUsdu+cOFCI8ksWrTItu3s2bMmIiLCPP7447Zt6Y13io4dO5pGjRqZ6OhoU6lSpczuGgAA/zrW+7M6AADIduPHj9fVq1c1Z84cFSpUKE25n5+f+vfvr6JFi6Yp69y5s3bs2KE//vjDtu3MmTP6/vvv1blzZ5dj1qlTRyVKlNAnn3xit33BggVq2rSp8uTJk4k9+p9du3ape/fuKlmypAICAlSwYEH17NlT58+fT1P35MmT6tWrlwoXLix/f3+VKFFCzzzzjJKSkjR37ly1b99ektSwYUPbx2xTf3x22rRpqlSpkvz9/VW4cGH17ds3zUfHGzRooMqVK2vr1q2qX7++goKCNGzYsHTvV7169SRJBw8etNv+66+/qmnTpgoPD1dQUJCio6O1fv36NO3Xrl2rmjVrKiAgQKVKldLMmTNtH4FPzfGem3PnzpWPj49+/vln9e/f3/Zx3D59+igpKUmXLl1S165dlTt3buXOnVuDBg2SMcauz+TkZL3zzjuqVKmSAgICVKBAAfXp00cXL160q7dlyxY9/PDDypcvnwIDA1WiRAn17NnT49osXbpUuXLlUv369e22p+zfgQMH1L17d0VERCg8PFw9evTQtWvXPPbrSYkSJdJc2ezj46PWrVsrMTFRhw4dsiu75557lCdPHn311VeZHju10NBQr86fdevWSZI6depkt71Tp04yxth9vPr+++9Xrly57OqVKVNGlSpV0u+//+52nMTERH3xxReKjo5WkSJFXNY7cuSI8ufPL0mKiYmxnWMjR4601fn+++9Vr149BQcHKyIiQq1atfI4viRVqlRJ+fLls9vm7++v5s2b68SJE7py5Ypt++LFi1WgQAE99thjtm358+dXhw4d9NVXX9nuk5reeEvSTz/9pMWLF+udd97xOGcAAO5UfCwdAACk2zfffKPSpUtn6GPc9evXV5EiRfTJJ5/o9ddflyQtXLhQISEheuSRR9y2ffzxx/Xxxx/rzTfflI+Pj/766y+tXr1a8+fP16pVq9I1jwsXLtg9zpEjh3Lnzq1vv/1Whw4dUo8ePVSwYEHt2bNHs2bN0p49e7Rx40ZbMu/UqVO69957bffaK1++vE6ePKnFixfr2rVrql+/vvr376/33ntPw4YNU4UKFSTJ9v/IkSMVExOjxo0b65lnntHevXs1ffp0bd68WevXr1fOnDltczt//ryaNWumTp066YknnlCBAgXSta+SbPf9zJ07t23b999/r2bNmumee+7RiBEj5Ovrqzlz5qhRo0Zat26d7r33XknS9u3b1bRpUxUqVEgxMTG6efOmXn/9dVtiyRvPPfecChYsqJiYGG3cuFGzZs1SRESENmzYoKioKI0ZM0YrVqzQhAkTVLlyZXXt2tXWtk+fPpo7d6569Oih/v376/Dhw5oyZYq2b99uW6uzZ8/qoYceUv78+TVkyBBFREToyJEjHm93IEkbNmxQ5cqV7dY8tQ4dOqhEiRIaO3astm3bpg8++ECRkZEaN26crc7ly5d1/fp1j2MFBAR4vDfsmTNnJClNck2S7r77bqfJ51shJUkXGBhotz0oKEiStHXrVrftjTH6888/ValSJbf1VqxYoUuXLqlLly5u6+XPn1/Tp0/XM888ozZt2tiSi1WrVpUkrVmzRs2aNVPJkiU1cuRIxcfHa/Lkyapbt662bduWoVtFnDlzxnZ/4RTbt2/X3XffneZ2DPfee69mzZqlffv2qUqVKm77lNLG++bNm3ruuefUu3dvt+0BALjjZfOVowAAwGIuX75sJJnWrVunKbt48aI5d+6c7d+1a9dsZak/Lv3SSy+Z0qVL28pq1aplevToYYwxLj+WPmHCBLN7924jyaxbt84YY8zUqVNNSEiIuXr1qunWrVu6Ppbu+K9YsWLGGGM35xSffvqpkWR++ukn27auXbsaX19fs3nz5jT1k5OTjTGuP+J79uxZkytXLvPQQw+Zmzdv2rZPmTLFSDKzZ8+2bYuOjjaSzIwZMzzuW+r927t3rzl37pw5cuSImT17tgkMDDT58+e3faQ9OTnZlClTxjz88MO2+absf4kSJUyTJk1s21q0aGGCgoLMyZMnbdv2799v/Pz8jOPbyWLFiplu3brZHs+ZM8dISjNOnTp1jI+Pj/nPf/5j23bjxg1TpEgREx0dbdu2bt06I8ksWLDAbpxVq1bZbV+yZImR5DQenhQpUsS0bds2zfaUtezZs6fd9jZt2pi8efPabUuJk6d/qdfGmfPnz5vIyEhTr149p+VPP/20CQwMTN8OpoO7j6V/8cUXRpKZP3++3fYZM2YYSaZy5cpu+54/f76RZD788EO39dq2bWv8/f3NxYsXPc7X3cfSq1evbiIjI20fuTfGmJ07dxpfX1/TtWtXj3072r9/vwkICDBPPvmk3fbg4OA0x4gxxixfvtxIMqtWrXLZp7t4T5kyxYSHh5uzZ88aYwwfSwcAwAWu3AQAAOkSGxsrSU6vPmvQoIF27txpezxhwgS99NJLaep17txZEydO1ObNm5U7d25t3rxZY8aM8Th2pUqVVLVqVX366ad64IEH9Mknn6hVq1Z2V1F564svvlBYWJjtccrVaKmvSktISFBcXJxq164tSdq2bZvq1aun5ORkLV26VC1atFDNmjXT9O3py17WrFmjpKQkPf/883ZXez311FMaNmyYli9fbveFJf7+/naPvVGuXDm7x1WqVNGcOXNsa7Vjxw7t379fr776apqP3D/44IOaP3++kpOTZYzRmjVr1KZNGxUuXNhWp3Tp0mrWrJm+/vprr+bTq1cvu3W577779Msvv6hXr162bTly5FDNmjXtrgBctGiRwsPD1aRJE/3111+27ffcc49CQkL0ww8/qHPnzoqIiJD091XF1apVc3kVpjPnz5+3u6LV0X/+8x+7x/Xq1dOSJUsUGxtrO4beeuutNB+Tdyb1GjpKTk5Wly5ddOnSJU2ePNlpndy5cys+Pl7Xrl3L0HGfGc2bN1exYsX00ksvKSgoSPfcc49+/fVXvfLKK/Lz81N8fLzLtn/88Yf69u2rOnXqqFu3bi7rxcbGavny5WrevLktphlx+vRp7dixQ4MGDbL7yH3VqlXVpEkTrVixIl39Xbt2Te3bt1dgYKDefPNNu7L4+Hj5+/unaZPyJWeu1sVdvM+fP6/XXntNw4cPT9cV0gAA3IlIbgIAgHQJDQ2VJMXFxaUpmzlzpq5cuaI///xTTzzxhMs+atSoofLly+uTTz5RRESEChYsqEaNGnk1fufOnfXWW29p4MCB2rBhQ4buPyn9/fF4Zx/7vXDhgmJiYvTZZ5/p7NmzdmWXL1+WJJ07d06xsbF23/icHkePHpWUNgGZK1culSxZ0lae4q677kpz/0JPUpK3586d03vvvafDhw/bJW73798vSW4TTZcvX1ZCQoLi4+NVunTpNOXOtrkSFRVl9zjlW8kd78saHh5ulyTcv3+/Ll++rMjISKf9psQoOjpabdu2VUxMjCZNmqQGDRqodevW6ty5s9PEkyPjcJ9Pd3NPSYRevHjRlty85557PI7hyXPPPadVq1bpo48+UrVq1dzO010CPS4uzu78zJEjR5YkyAICArR8+XJ16NBBbdu2lfR34n38+PEaPXq0y4/bnzlzRo888ojCw8O1ePFi5ciRw+UYX3zxhRISEjx+JN0TV+eY9PetIf773//q6tWrXn0D+c2bN23faL5y5co0CerAwEDbR/ZTS0hIsJU74y7er776qvLkyaPnnnvO4/wAALjTkdwEAADpEh4erkKFCmn37t1pylLuwZlyf0d3OnfurOnTpys0NFQdO3ZMc786Vx5//HENHTpUTz31lPLmzauHHnooXfP3pEOHDtqwYYNefvllVa9eXSEhIUpOTlbTpk2VnJycpWN5y1VyxJ3UydsWLVqoSpUq6tKli7Zu3SpfX1/bvkyYMEHVq1d32kdISIgtQZNZrhJazranTjQmJycrMjJSCxYscNo+JWnn4+OjxYsXa+PGjfr666/13//+Vz179tRbb72ljRs3ur3PZd68ed1edelq7qnneeHCBSUlJbnsI0VgYKAtsZtaTEyMpk2bpjfffFNPPvmky/YXL15UUFCQ22Ni4sSJiomJsT0uVqyYV+ekNypVqqTdu3frt99+08WLF1WxYkUFBgZq4MCBio6OTlP/8uXLatasmS5duqR169a5vXJV+vsLwsLDw/Xoo49myXyzwlNPPaVvvvlGCxYscPpHmEKFCun06dNptqdsc7bP7uK9f/9+zZo1S++8845OnTpl256QkKDr16/ryJEjCgsLy7IvUQMAwOpIbgIAgHR75JFH9MEHH2jTpk22L51Jr86dO+u1117T6dOnNX/+fK/bRUVFqW7dulq7dq2eeeYZ+fll3duZixcv6rvvvlNMTIxee+012/aUqxxT5M+fX2FhYU4TvKm5urou5RuT9+7dq5IlS9q2JyUl6fDhw2rcuHFGd8GpkJAQjRgxQj169NDnn3+uTp06qVSpUpKksLAwt+NFRkYqICBABw4cSFPmbFtWK1WqlNasWaO6det6leStXbu2ateurdGjR+uTTz5Rly5d9Nlnn6l3794u25QvX16HDx/O1Dwfe+wx/fjjjx7rdevWTXPnzrXbNnXqVI0cOVLPP/+8Bg8e7Lb94cOHbV9K5UrXrl31wAMP2B5nJDnujo+Pj92XAq1YsULJyclpjqOEhAS1aNFC+/bt05o1a1SxYkW3/Z4+fVo//PCDunfv7tXVtilzcSb1Oebojz/+UL58+by6avPll1/WnDlz9M477+jxxx93Wqd69epat26dkpOT7f5I8+uvvyooKEhly5a1q+8p3idPnlRycrL69++v/v37pykvUaKEBgwYwDeoAwDw/5HcBAAA6TZo0CB98skn6tmzp7777rs0397t7iO+KUqVKqV33nlH8fHx6U6Qjho1Sj/88IM6duyYrnaepFyh5zh/xySCr6+vWrdurY8//lhbtmxJc99NY4x8fHxsyZNLly7ZlTdu3Fi5cuXSe++9p6ZNm9oSNB9++KEuX77s8VvjM6JLly4aPny4xo0bp06dOumee+5RqVKlNHHiRHXu3DnNlY3nzp1T/vz5lSNHDjVu3FhLly7VqVOnbFehHThwQCtXrszyeTrq0KGDpk2bpjfeeCPNfVlv3LihuLg4RURE6OLFi4qIiLBLdqVckersI8Op1alTR2+++aYSExO9Tqo5yug9NxcuXKj+/furS5cuevvttz2237Ztm8ePbJcsWdIuaf5Pio+P1/Dhw1WoUCG75N/NmzfVsWNH/fLLL/rqq69Up04dj3199tlntvtQeivlvqOO51ihQoVUvXp1zZs3T0OHDrXdv3P37t1avXq129tmpJgwYYImTpyoYcOGacCAAS7rtWvXTosXL9aXX36pdu3aSZL++usvLVq0SC1atLA7pryJd+XKlbVkyZI021999VVduXJF7777ru2PEwAAgOQmAADIgDJlyuiTTz7R448/rnLlyqlLly6qVq2ajDE6fPiwPvnkE/n6+qpIkSJu+3GXMHAnOjra6UdgMyssLEz169fX+PHjdf36dd11111avXq106v6xowZo9WrVys6OlpPP/20KlSooNOnT2vRokX6+eefFRERoerVqytHjhwaN26cLl++LH9/fzVq1EiRkZEaOnSoYmJi1LRpU7Vs2VJ79+7VtGnTVKtWLa8SL+mVM2dODRgwQC+//LJWrVqlpk2b6oMPPlCzZs1UqVIl9ejRQ3fddZdOnjypH374QWFhYbYvCxo5cqRWr16tunXr6plnntHNmzc1ZcoUVa5cWTt27MjyuaYWHR2tPn36aOzYsdqxY4ceeugh5cyZU/v379eiRYv07rvvql27dpo3b56mTZumNm3aqFSpUrpy5Yref/99hYWFqXnz5m7HaNWqld544w39+OOPGb7NQUbuublp0yZ17dpVefPm1YMPPpjmo/f333+/XZJy69atunDhglq1apWhObozatQoSdKePXskSfPnz9fPP/8s6e+kWooOHTqocOHCqlixomJjYzV79mwdOnRIy5cvt92PV5JefPFFLVu2TC1atNCFCxf08ccf243n7BhfsGCBChcurAYNGng978DAQFWsWFELFy5U2bJllSdPHlWuXFmVK1fWhAkT1KxZM9WpU0e9evVSfHy8Jk+erPDwcI0cOdJtv0uWLNGgQYNUpkwZVahQIc38mzRpYvujTrt27VS7dm316NFDv/32m/Lly6dp06bp5s2bdrcH8Dbe+fLlU+vWrdPMKeWPLM7KAAC4o2Xb97QDAADLO3DggHnmmWdM6dKlTUBAgAkMDDTly5c3//nPf8yOHTvs6o4YMcJIMufOnXPbpyTTt29f2+PDhw8bSWbChAlu23Xr1s0EBwd7nLOneZw4ccK0adPGREREmPDwcNO+fXtz6tQpI8mMGDHCru7Ro0dN165dTf78+Y2/v78pWbKk6du3r0lMTLTVef/9903JkiVNjhw5jCTzww8/2MqmTJliypcvb3LmzGkKFChgnnnmGXPx4kW7MaKjo02lSpU87pc3+3f58mUTHh5uoqOjbdu2b99uHnvsMZM3b17j7+9vihUrZjp06GC+++47u7bfffedqVGjhsmVK5cpVaqU+eCDD8yLL75oAgIC7OoVK1bMdOvWzfZ4zpw5RpLZvHmzV/N0FcdZs2aZe+65xwQGBprQ0FBTpUoVM2jQIHPq1CljjDHbtm0zjz/+uImKijL+/v4mMjLSPProo2bLli1erVvVqlVNr169vJpjyj4dPnzYq75dSenH1b85c+bY1R88eLCJiooyycnJmRrXGXfzSG3cuHGmfPnyJiAgwOTOndu0bNnSbN++PU1/0dHRXvdpjDF//PGHkWReeOGFdM99w4YN5p577jG5cuVKc56uWbPG1K1b1wQGBpqwsDDTokUL89tvv3nsMyX2rv6lPo+NMebChQumV69eJm/evCYoKMhER0enOebTG29H6X0uAADgTuFjjBefGwMAAAActG7dWnv27ElzT1Irmj9/vvr27atjx47ZPsJ8O0lMTFTx4sU1ZMiQDF/xDAAA8G/k3deSAgAA4I4WHx9v93j//v1asWJFuj5CfDvr0qWLoqKiNHXq1OyeilNz5sxRzpw59Z///Ce7pwIAAHBb4cpNAAAAeFSoUCF1795dJUuW1NGjRzV9+nQlJiZq+/btKlOmTHZPDwAAAHcovlAIAAAAHjVt2lSffvqpzpw5I39/f9WpU0djxowhsQkAAIBsxZWbAAAAAAAAACyJe24CAAAAAAAAsCSSmwAAAAAAAAAsiXtuZrHk5GSdOnVKoaGh8vHxye7pAAAAAAAAAJZijNGVK1dUuHBh+fq6vzaT5GYWO3XqlIoWLZrd0wAAAAAAAAAs7fjx4ypSpIjbOiQ3s1hoaKgkKVfFbjq+7j1FNXhJx9ZOtP0vSVENXnLZ3rFOStvk+PPKdXGL8oYHqmzZcipetIDOXbiSpn3+PH+Pn1KW+nH+PKFp2qSUO0qpnxHpbeuuvqd5p27r+LOjlH4cx3IcI3U9T+vo2KezcVO3dzc3b/bBG45juTomvBnPU1vHup7m7GxNHXm7hp7W1NWcnMU/dV13x4Jjf87i5mw+7o5XV8e4N/uSUa76crfdGKMjx85o7759unAlSTfy3isf//AsmQ+yR8rry79lHNhzte6ZiUdWxDL1+xxn74tStqVI/X7IGVfljn1m1Vr8U8ezN+8RHeum1Hd8n+mqH3dr6+5nV+Xe9u+pnWMf6Xmf7K6NN2N6Oq7Sy/H4duznVj8fOotJeo81b+freJx4M0ZWrUd2v86kd51SODs+nG13Vcebc9/VMe5Y1935m1LuePw469tZn+6eM/5N7w/cvaa5W6/MnKeOa5jRYzH12Jnt91bx9rXJsf7tvi/u6qTmzXmV3n119R7AE2/XNSNrb24mKem3ebY8mzskN7NYykfRfXLkUlhYWJr/U8pccawTFhYm+fop58Udalivtl4c/KpCw8JVo0KUtv9+LE37GhWiJMlWlvqxszYp5Y5S6mdEetu6q+9p3qnbOv7sKKUfx7Ecx0hdz9M6OvbpbNzU7d3NzZt98IbjWK6OCW/G89TWsa6nOTtbU0ferqGnNXU1J2fxT13X3bHg2J+zuDmbj7vj1dUx7s2+ZJS75w9Px8HFC+c19o3h+mX7DiUXbsztNyws5bXp3zIO7Lla98zEIytimfp9jrP3RSnbUti9H3LCVbljn1m1Fv/U8ezNe0THuin1Hd9nuurH3dq6+9lVubf9e2rn2Ed63ie7a+PNmJ6Oq/RyPL4d+7nVz4fOYpLeY83b+ToeJ96MkVXrkd2vM+ldpxTOjg9n213V8ebcd3WMO9Z1d/6mlDseP876dtanu+eMf9P7A3evae7WKzPnqeMaZvRYTD12Zvu9Vbx9bXKsf7vvi7s6qXlzXqV3X129B/DE23XNzNp78zsnXyhkASb+nEICpK49nlJoGFdKAcg+ufPkVZeuPRWUI0km6XJ2TwcAAAAAcIcjuWkBJilOAf45Vbxk6eyeCgCoVJly8s/lJ5MUl91TAQAAAADc4UhuWoFJll8OP4/fDgUAt4JfDr+/PxpgkrN7KgAAAACAOxzZMtxRZk6dpJiRI7N7Gv9qM6dO0sypk7Ksv/59umrRpx9JktauXas8uSNsZY0aNtC777yTZWMBAAAAAABrIblpYU9376g61cuoXs0Kql+rojq0bKxFixbZyk+dPK4cvj66dOmSbduZUyc1ctiLatqglurXqqiyZUqr/3PP6fTp016N+dbEiaperaoiwsMUVbSIXn7pJSUlJdnV2bFts+o9UFdhoSEqWCBSI157zVY2dcoU3VurpgID/NWmTWu7dseOHVNYaIjdv/uqllSrVi1tdeLiruiVl59TRHiYChUsoA+mv5uOFcu4N15/XTl8fbR+3Q92248cOaKalYq5XePWTetnaI2j762k5o3u0zsTRul6qjWeOXWS7qtaUvVqVrD9W73ya7s+1q9fr3oP1FW9mhXcxuDF556ya3fm1Em7fsNCQ5Qrp58G9u3l7VKl2+nTp9WlS2cVLlRQ4WGhavXwA3rrzddt5e/N/EjtH+/6j42fUSOHvaiBzz9vt+2fSLbeuH5d40YNV948udWoTlWNH/2abty44bRuUlKiRr02WC0fqqv6tSqq7aON9NWXC23lKfENCw2xxfi+qiXt4ptyjkXfW0kP1b/nlp1jAAAAAABkBMlNi3vuhSFat+V3/bhpj/q/OFRPPtFFR48edVr32LFj6tqppfz8/DR7wZf6cdMerft5vQoVKqQff/zRq/Fu3ryp9z/4UOf+Oq8Nv2zUjz+utbsScteuXXp5QB+9+NLL+uv8BR08dFht27WzlRcqXFjDXnlVvXs/labvqKgoxV6Js/376/wFhYSGqWPHTrY6E0aPUOzlyzpy9Jh+/Gmdliz+TB999JGXq5UxxhjNnTtHefLk0VdfLHRb98ypk2nW+MOPv8jQGn+3fofmfLJUWzdv1Kxp79jVeSD6Qa3b8rvt30PNWtjKdu3apbaPtdGLL72s7zfsTFcMCha+y67fv85fUEREhB5O1X9W69b1SQX4B+i33//QxUuXNfX9BSpXvuI/Np7VfDhzsnZu26Lde37T58u+1Y6tmzVn1lSndW/euKl8+SM17YNP9OOmPRo5eqLemTBKG9f/JOl/8Y29Eqd1W37X9xt2KiQ0zC6+KefYN2s26P2PFt2ScwwAAAAAgIwiufkv4ePjoweiH1RERIT27t3rtM7IkSNUukw5vfr6OBW+q6h8fHxUoEABDR02TJ06dXLaxtGgwYNVq1Yt5cyZU0WKFNGTT3bV+vU/28pHjXpDrdt2UuvWrZUrVy4FBweratWqtvLHHntMrVu3Vr58+TyOtXTpUpnkZD322GOSpIT4eK1e+bWe6f+SIiIiVLZsWXXs0k1zZn/o1dwzatPG9Tp58qSmz5ipn35Yo3PnzrmsO3PqpDRrnDdf/gytsV/OnCpQsJAeadlWO7Zt9nq+o0a9oV69eqt169bKmQUxSE5OVsMmTb0eP702btyo7j16KCIiQr6+vioSVUyPtv5fMvbp7h31yUeuY/znn3+q31NPqn6tiurSrrkO7PvDrmzIC8+q8QM19MiDdTT13fG2qx7nzp2ru2tUt+ur82PNNHfuXNvjNWvWqGvHlsqTO0IdWjbWsmXLJEmffTxHK5cv1fTp0xQWGqIOLRvrpRdf1Lp16zRkyGDVq1lB/fv8fbXptatX9Vy/fipeLEpN6t2tbt266vJl779lfNmSz9WzTz8VKlRI+fIXUM8+/eyuxkwtMChI/3nuRRWJKiYfHx9VqXa3at5bx+Xxs/b71TKp4nvt2jXbORYaFq5ixUveknMMAAAAAICMIrn5L5GcnKy1369WfHy8qlev7rTO6v/+Vw81b+m0LMW4N99UixaPej3ujz/9qCpV/pc4++nHH3X9epLurlFdBSLzq1mzpi6TrZ7Mnv2hmj7aWgEBAZKkI0cO6vr1JJVNdVVf2fKVtGvXrgz1762vvlioRx59VG3btlX+yAL6eP58l3V/Wf+jxzWe+/40Pf9sD6/H37p5o0qXLW+3bcuvG/Tg/dX0WPMGmvrueCUmJtjKfvrxRyUl/R2Dxg/UyHQMOnfuIn//gAy198b9devqhYHP66OPPtK+ffvS3f7jj+er/4tD9f0vu1SxUlWNHzPCVvZEl87y8/PTsv/+rA/mL9KP363WhPHjvep3/97f1bFDez03cLD+On9Bw0aMVbeuT+rI4YPq9EQPNXuktZ555lnFXonT58vWaOJbb6levXp6881xWrfld7038++rHV8f/rIuXLygHTt3adl/f9b169f13HP9bOM8/2wPjXvzTadziL18WX+eOa1y5SvZtpUtX1FnTp9U3JVYj/uQmJigPf+3M83xk+KrLxaq6aOtbfHdu3dvtpxjAAAAAABkFMlNi5v6zjg1qF1F9WqW16ABffTKK68qMjLSad1z584pMrKg2/4GDxmir7/+xqux33//fW1Yv17DXnnFtu3ChQtavfJrfTT/Yx07fkLVqlZTm9atXN4j0JWjR4/quzVr1Lrt/652jL92TYGBQfLz87NtCw0N05UrV9LVd3pcvnRJa7/7r7p27SYfHx81b9FGs91cxXbx4gWPa9z9qWf1zrQ5Xo2/ZNGn2rV9q3r1+V8yrPHDj+jzZWv07c/bNf7dmVr/4w+a/Pb/kmMXLlzQwoWf6aP5H2vF9xszHIPTp07ouzVr1Kt373S1S6/PP1+kRx9toffefUdVKlfSo43v16pvlnrdvkuXJ1S2fEX5+fnpkVZt9cee/5Mknf3zjL7//nsNHDRcQcHBKlS4iHo+3U/z5s31qt8vP1+gbt26q1btuvL19VX1e2rpkUcf1ZpV3p0fknTxwnl9/+1KTZkyVREREQoMClJMzOv6fOFC3bx5U5L0zrQ5GjxkiNP2165dlSSFhoXZtoWG/v3z1atX3Y5tjNGo1waraFRxNWrSLE356VMntGnjz3bnWFxc3C0/xwAAAAAAyAySmxbX9/nBWrvx/7R+2z598c0P+uijeZo5c6bTuvny5dPZs2eyZNwFCxboteGvatV/V6tQoUK27SEhIWrRur0qV64sf39/xbz+ug4cOJDuK/LmzpmjGjVq2F1BFhgUpISEeLskXVzcFYWGhmZ+h1xYuXyJgkNC1Lx5c0nSI63a6rffftP/7dzmtH5ERO4sW+OV3yzR9MkTNeX9+cqXv4Bte6nSZVWgYCH5+vqqdJlyevb5l/Xtyv8l3EJCQtS9ew9VrlxZuXL9LwbHjhxK1/jLlixSjRo1VK1atSzZH1fCwsI0YuRIbdm6TecvXFSnJ7prxLAXdPjgfq/aFyz4v2RyYGCQLSF49s/TCggIUN58+W3ldxWN0okTJ7zq99SpE5o5c4Ya1K6iPLkj1KB2FS376iudO3fW6307dfKEkpOTVapkCVsf991bS76+vjr/l+vbG6QICgqWJMWlSi6m/BwcHOyynTFGb77xqo4ePqS3Jr8vX9+0T/XLlixSuQqV7M6xkJCQW36OAQAAAACQGSQ3/0WKFiuuZs2aa/ly51eWPfTww/o2HVedubJgwQK9MPB5rVi5yu5ejpLSJMJ8fHzS3X9ycrLmzp2jnr3srxgsXryU/Pxyav/e323b9v2xR1WqVEn3GN5a9sXnirtyRcWiiqpwoYJ66sn28vHxcfnFQnXqRmfZGr/15ut6b+Y8lSlXwW1dXx/70zirYvD1kkVpYvBPCwkJ0RPdn1ZISKgOeZncdCWyQCElJCTYJRFPnTyhIkWK2Ma6du2aXZvUdQsULKz+/Qdo7cb/04WLl7R24/8p9kqchr42WpLk45t2XR2TiClJ6BMnT9n6uHDxkq7FJyiygPsrfCUpLDxcBQoW0t4/9ti27f1jjwoULKyQ0DCnbYwxGvfGq9q9a7umvP+x03op8W3V1v4+sOXKlbvl5xgAAAAAAJlBcvNf5NTJ41q5coWqVHaeiBg5Mkb7/vhNY2KG6cypkzLG6Ny5cxo/bpwWLnT/LeApPv30Uz0/oL+Wr1ipGjVqpCnv/dTT+uarxf//3n3X9XpMjMqUKaOyZctKkm7cuKGEhATduHFDycnJSkhI0PWkJLs+vv32W/311196/PHH7bYHBAaqSbNHNX3yRF2+fFn79+/XwgXz/rEE3NatW7Vv72+a+sHH2rZ9h7Zt36EFX6zQ9Bkz9e2qbxTvkBiTpD79BqZZ44sXzmdojd+bMU/lK1ROU/7DmlW6dOmiJOnI4YOa+u54NUr1hT+9n3pa8+bN1d69e3UjVQyiipeU5DwGSQ4x+HXDOl26dCFNDP4Jg15+WTt27FBSUpKSkpK0dPGnio+PV4VKmUuoRRYoqIYNG+qdiaMVf+2azpw6qdmzpqhr126SpOrVq+vQoUPavnWTbty4oQnjx+vS5Yu29o916Ky5c+doy68bdPPmTSUlJeqXX36xXVGaN29+HTp8SMaYVGMW0MGDB22P8+WPVHSjh/Rcv37666+/JElnzpzRkiVLvN6PFq3ba/asKTpz5oz+OndWc96favdRckfjRw3Xzu1bNfWDBQoLD3da59tvv9WlSxfU1OH+sEFBQbZzLO5KrI4dPfyPnmMAAAAAAGQWyU2Lm/z2m6pXs4Lq1ayg3k+204MPNtbw115zWrdYsWL6aOEyJSUmqtvjrRR9byXVvb+OTp48qejoaEnS2DFj1Lx52vvzpXj1lWGKjY1Vo4YNFBYaorDQEFWp/L8vO+nSpYvaP95NDzZqqIIFIrVl6xYt/WqZ7R5+o0eNUnBQoMaMGa1vvv5awUGB6vv0k3ZjzJ79odq2a6dwJ4mZQa+8rpCQMEUVLaJ6D9RVq8c6qmvXruldNq/M/vBD3VOrtu6ueZ8KFiyoggULKl/+SHXv3l2BQUFaverrNG0KFS6SZo17dG5jt8azZ02xfZO2Mylr3Kd7R1tsO7RsbCtf89/lavtIQz1Qs7wG/Keb6tSN1oCXX7WVd+nSRX379tODjRqqSf273cZg3do1Cg4KVNOHH7Kbw1dfLtSDTZo7jUFWS0xMVOfHOyl/vrwqXKigli1ZpLcmv6/CdxXNdN8fL/hEiQkJerTJ/er1ZFs9UL+RXh40SJJUunRpjRs3XoMHPqOmDWopMTFRpUqVtbUtX6GyFnzyqaa9N/HvL8dqeJ9GvDbclghu3baTTp08qXx586hTm4clSQMGPK/vvlujBrWr2L40auSYtxQREaH77q2l6HsrKbp+PW3butU2Tv8+XTV2zBiX+9D7P/1VtdrdqlSxgtq3fFDVatRUj6f72srHxAzTmJhhkv6+j+aiz+br6JFDatH4ftvxk1KeYvbsD/Vgk+ZOr+pMOceaN6qtXk+0/UfPMQAAAAAAMsvPcxXcrmbNTXslYI0KUbafC99VVDeT//9VZaf//mblQoWLaOSYt5zWl6Shw4ZpqKTtvx9zOubBQ4c9zqt772f07ltjnZaNGDlSI0aOtNvmONbChZ+77DskJFRjJk62zdvVPLPC1GnTnPafM2dOrVq7WZJUvHiUtuw5qoiICFu54xpL9uvc8+l+cidljV3t2+gJkz3OfdDgwRo0eLC2/34szVqljoGzckl68+1pHsfIKu++957dY8f9Tn2cN2jQQBcuXrLV+f6HtXZtylWopC17jtrqFyxYUOPfmWHXX86cOW0/D3zhBTVo1k7S3zF6pF031agQZeuvUaNGmr3gS9u21GVFoopp85atduPfd9992vPb73b7EBwcorfefltvvf220/V+b+ZHdv068suZU4OHj9Jnn3zktM6wEf9LjBYqXMRu/11ZuPBzl+OlnGMAAAAAAFgBV24CAAAAAAAAsCSu3LQCXz8lJSUpIT5eAYGB2T0bS7unVm2VKVbAc0Vk2D21amf3FPAPu3IlVsnJyfLJyUsIAAAAACB7ceWmBfgGRepqfKK2bNqQ3VOxvJr31lGDBg2yexr/ajXvraOa99bJ7mngH7T51/W6mnBdPoH5snsqAAAAAIA7HJfdWIBPzmBd9cmjye9O0qWLF1W5anXlCTI6c+pUmrrHgv/+/8ypk2keHwv+33bH+o5S6mdEetu6q+9p3qnbOv7sKKUfx7Ecx0hdz9M6OvbpbNzU7d3NzZt98IbjWK6OCW/G89TWsa6nOTtbU0ferqGnNXU1J2fxT13X3bHg2J+zuDmbj7vj1dUx7s2+ZJSrvtxtN8bo4IH92rltiz6eP0/xfgWVI0euLJkPAAAAAAAZRXLTInwK1NbRs1v19jvvyT+nr4oWyqOTZy6mqXdXwdySZCtL/fiugrnTtEkpd5RSPyPS29ZdfU/zTt3W8WdHKf04juU4Rup6ntbRsU9n46Zu725u3uyDNxzHcnVMeDOep7aOdT3N2dmaOvJ2DT2tqas5OYt/6rrujgXH/pzFzdl83B2vro5xb/Ylo1z15W67JB0/fUEJ143icxZSjsjqWTIXAAAAAAAyg+SmRfj45pBfwXuVmHxdCYmx+mray2rw5Lg09ZZMGyxJtrLUj5dMG5ymTUq5o5T6GZHetu7qe5p36raOPztK6cdxLMcxUtfztI6OfTobN3V7d3PzZh+84TiWq2PCm/E8tXWs62nOztbUkbdr6GlNXc3JWfxT13V3LDj25yxuzubj7nh1dYx7sy8Z5aovd9slqUG3ifLJFS4/3xxZMg8AAAAAADKL5KbF+PjmlE9gXtW4+275BuVPU17j7rslyVaW+rGzNinljlLqZ0R627qr72neqds6/uwopR/HsRzHSF3P0zo69uls3NTt3c3Nm33whuNYro4Jb8bz1Naxrqc5O1tTR96uoac1dTUnZ/FPXdfdseDYn7O4OZuPu+PV1THuzb5klLvnD7fHQUCeLBkfAAAAAICswhcKAQAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAAS7otk5tz585VREREdk8DAAAAAAAAwG0sXcnN7t27y8fHRz4+PsqZM6dKlCihQYMGKSEhIUsn1bFjR+3bty9L+/TGkSNH1KtXL5UoUUKBgYEqVaqURowYoaSkpFs+FwAAAAAAAADu+aW3QdOmTTVnzhxdv35dW7duVbdu3eTj46Nx48Zl2aQCAwMVGBiYZf15648//lBycrJmzpyp0qVLa/fu3Xrqqad09epVTZw48ZbPBwAAAAAAAIBr6f5Yur+/vwoWLKiiRYuqdevWaty4sb799ltbeXJyssaOHWu7+rFatWpavHixXR/Lli1TmTJlFBAQoIYNG2revHny8fHRpUuXJKX9WPrIkSNVvXp1zZ49W1FRUQoJCdGzzz6rmzdvavz48SpYsKAiIyM1evRou3EuXbqk3r17K3/+/AoLC1OjRo20c+dOl/uWkrh96KGHVLJkSbVs2VIvvfSSvvzyy/QuEwAAAAAAAIB/WLqv3Ext9+7d2rBhg4oVK2bbNnbsWH388ceaMWOGypQpo59++klPPPGE8ufPr+joaB0+fFjt2rXTgAED1Lt3b23fvl0vvfSSx7EOHjyolStXatWqVTp48KDatWunQ4cOqWzZsvrxxx+1YcMG9ezZU40bN9Z9990nSWrfvr0CAwO1cuVKhYeHa+bMmXrwwQe1b98+5cmTx6t9vHz5stu6iYmJSkxMtD2OjY31ql8AAAAAAAAAmZPu5OY333yjkJAQ3bhxQ4mJifL19dWUKVMk/Z3oGzNmjNasWaM6depIkkqWLKmff/5ZM2fOVHR0tGbOnKly5cppwoQJkqRy5cpp9+7daa66dJScnKzZs2crNDRUFStWVMOGDbV3716tWLFCvr6+KleunMaNG6cffvhB9913n37++Wdt2rRJZ8+elb+/vyRp4sSJWrp0qRYvXqynn37a474eOHBAkydPdvuR9LFjxyomJsartQMAAAAAAACQddKd3GzYsKGmT5+uq1evatKkSfLz81Pbtm0l/Z0MvHbtmpo0aWLXJikpSTVq1JAk7d27V7Vq1bIrv/feez2OW7x4cYWGhtoeFyhQQDly5JCvr6/dtrNnz0qSdu7cqbi4OOXNm9eun/j4eB08eNDjeCdPnlTTpk3Vvn17PfXUUy7rDR06VC+88ILtcWxsrIoWLeqxfwAAAAAAAACZk+7kZnBwsEqXLi1Jmj17tqpVq6YPP/xQvXr1UlxcnCRp+fLluuuuu+zapVw9mVE5c+a0e5zyje2O25KTkyVJcXFxKlSokNauXZumr9T383Tm1KlTatiwoe6//37NmjXLbV1/f/9M7xsAAAAAAACA9MvUPTd9fX01bNgwvfDCC+rcubMqVqwof39/HTt2TNHR0U7blCtXTitWrLDbtnnz5sxMw6m7775bZ86ckZ+fn4oXL+51u5MnT6phw4a65557NGfOHLsrQwEAAAAAAADcPjKduWvfvr1y5MihqVOnKjQ0VC+99JIGDhyoefPm6eDBg9q2bZsmT56sefPmSZL69OmjP/74Q4MHD9a+ffv0+eefa+7cuZL+vvIyqzRu3Fh16tRR69attXr1ah05ckQbNmzQK6+8oi1btjhtc/LkSTVo0EBRUVGaOHGizp07pzNnzujMmTNZNi8AAAAAAAAAWSPTyU0/Pz/169dP48eP19WrV/XGG29o+PDhGjt2rCpUqKCmTZtq+fLlKlGihCSpRIkSWrx4sb788ktVrVpV06dP1yuvvCIp8x9dT83Hx0crVqxQ/fr11aNHD5UtW1adOnXS0aNHVaBAAadtvv32Wx04cEDfffedihQpokKFCtn+AQAAAAAAALi9pOtj6SlXWDoaMmSIhgwZYns8YMAADRgwwGU/LVu2VMuWLW2PR48erSJFiiggIECS1L17d3Xv3t1WPnLkSI0cOdLjXBzvrxkaGqr33ntP7733nsu5pOY4LgAAAAAAAIDbV6buuZlR06ZNU61atZQ3b16tX79eEyZMUL9+/bJjKgAAAAAAAAAsKluSm/v379eoUaN04cIFRUVF6cUXX9TQoUOzYyoAAAAAAAAALCpbkpuTJk3SpEmTsmNoAAAAAAAAAP8Smf5CIQAAAAAAAADIDiQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCX5GGNMdk/i3yQ2Nlbh4eH6ff8RlStVTKfOXlThyNy2/yXp1NmLLts71klp66yeq+2O7VMeO2uTUu4o9XzTK71t3dX3NG/HdXW3xo5xcDVG6nqe1tHb2KYe01PcvDlO3HEcy9Ux4c14nto61vU0Z2dr6sjbNfS0pq7m5Cz+qeu6OxYc+3MWN2fzcXe8ujrGvdmXjMrs8wr+HbLymLodxoG99J7nmekzvX1Irl9/3D1HO+Oq3LHPrFqLf+p4Ts/zrLPXQ29eFz29/rn62VW5t/17aufYR3reJ7tr4+1rqzOZfQ/m7v3rrXw+dPWeN+Vnb9p7O19X75uzqv9b0c+tGN/b94ue2nt77rv7ncyb597U5a5+7/LUZ3rep1uZu9c0d+uVmfPU2e8mGTkWU4+d2X5vFW9fmxzr3+774q5Oat6cV+ndV3d5Dnf+yd9nr1yJVYUyxXX58mWFhYW5rUtyM4ulJDe9WXwAAAAAAAAA9tKTX/O7RXO64xgjnfzT+ZVZ3vwFLSN/5XHVPuWxq78MOXMrr+zwdBWAu3m7u9rAkae/orv7S6irdfQ2tu7+MupufzLC1V/ZPF3tkJ7jyVl9b/6y481fIr1dQ09r6mpOnq6q9HR1pbO/jnuajzdXxKRn7TIrs88r+HfIymPqdhgH9tJ7nmemz/T2Ibl+/UnvlUyuyp1d3ehsLundn3/qeE7P86yz10NvXhc9vf65+tmbq7Xc9e+pnWMf6Xmf7K6Nt6+tzmT2PZi796+38vnQ1XvelJ+9ae/tfF29b86q/m9FP7difG/fL3pq7+257+53Mm+ee1OXe3NFmKv3ya725d/0/sDda5q79crMeersd5OMHIupx85sv7eKt69NjvVv931xVyc1b86r9O6ruzyHO//k77PpuRSTKzezWEpm+c/zl1XswWG6uHmKctfqZ/tfki5unuKyvWOdlLbO6rna7tg+5bGzNinljlLPN73S29ZdfU/zdlxXd2vsGAdXY6Su52kdvY1t6jE9xc2b48Qdx7FcHRPejOeprWNdT3N2tqaOvF1DT2vqak7O4p+6rrtjwbE/Z3FzNh93x6urY9ybfcmozD6v4N8hK4+p22Ec2EvveZ6ZPtPbh+T69cfdc7Qzrsod+8yqtfinjuf0PM86ez305nXR0+ufq59dlXvbv6d2jn2k532yuzbevrY6k9n3YO7ev97K50NX73lTfvamvbfzdfW+Oav6vxX93IrxvX2/6Km9t+e+u9/JvHnuTV3u6vcuT32m5326lbl7TXO3Xpk5T539bpKRYzH12Jnt91bx9rXJsf7tvi/u6qTmzXmV3n11l+dw55/8fTY2NlYF8np35SZfKAQAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLui2Tm3PnzlVERER2TwMAAAAAAADAbSxdyc3u3bvLx8dHPj4+ypkzp0qUKKFBgwYpISEhSyfVsWNH7du3L0v79Nbo0aN1//33KygoiAQrAAAAAAAAcBtL95WbTZs21enTp3Xo0CFNmjRJM2fO1IgRI7J0UoGBgYqMjMzSPr2VlJSk9u3b65lnnsmW8QEAAAAAAAB4J93JTX9/fxUsWFBFixZV69at1bhxY3377be28uTkZI0dO1YlSpRQYGCgqlWrpsWLF9v1sWzZMpUpU0YBAQFq2LCh5s2bJx8fH126dElS2o+ljxw5UtWrV9fs2bMVFRWlkJAQPfvss7p586bGjx+vggULKjIyUqNHj7Yb59KlS+rdu7fy58+vsLAwNWrUSDt37nS7fzExMRo4cKCqVKmS3qUBAAAAAAAAcAv5Zabx7t27tWHDBhUrVsy2bezYsfr44481Y8YMlSlTRj/99JOeeOIJ5c+fX9HR0Tp8+LDatWunAQMGqHfv3tq+fbteeuklj2MdPHhQK1eu1KpVq3Tw4EG1a9dOhw4dUtmyZfXjjz9qw4YN6tmzpxo3bqz77rtPktS+fXsFBgZq5cqVCg8P18yZM/Xggw9q3759ypMnT2Z23SYxMVGJiYm2x7GxsVnSLwAAAAAAAAD30p3c/OabbxQSEqIbN24oMTFRvr6+mjJliqS/E31jxozRmjVrVKdOHUlSyZIl9fPPP2vmzJmKjo7WzJkzVa5cOU2YMEGSVK5cOe3evTvNVZeOkpOTNXv2bIWGhqpixYpq2LCh9u7dqxUrVsjX11flypXTuHHj9MMPP+i+++7Tzz//rE2bNuns2bPy9/eXJE2cOFFLly7V4sWL9fTTT6d3150aO3asYmJisqQvAAAAAAAAAN5Ld3KzYcOGmj59uq5evapJkybJz89Pbdu2lSQdOHBA165dU5MmTezaJCUlqUaNGpKkvXv3qlatWnbl9957r8dxixcvrtDQUNvjAgUKKEeOHPL19bXbdvbsWUnSzp07FRcXp7x589r1Ex8fr4MHD6Zjj90bOnSoXnjhBdvj2NhYFS1aNMv6BwAAAAAAAOBcupObwcHBKl26tCRp9uzZqlatmj788EP16tVLcXFxkqTly5frrrvusmuXcvVkRuXMmdPucco3tjtuS05OliTFxcWpUKFCWrt2bZq+svJb0P39/TO9bwAAAAAAAADSL1P33PT19dWwYcP0wgsvqHPnzqpYsaL8/f117NgxRUdHO21Trlw5rVixwm7b5s2bMzMNp+6++26dOXNGfn5+Kl68eJb3DwAAAAAAACB7pfvb0h21b99eOXLk0NSpUxUaGqqXXnpJAwcO1Lx583Tw4EFt27ZNkydP1rx58yRJffr00R9//KHBgwdr3759+vzzzzV37lxJf195mVUaN26sOnXqqHXr1lq9erWOHDmiDRs26JVXXtGWLVtctjt27Jh27NihY8eO6ebNm9qxY4d27NhhuyoVAAAAAAAAwO0h08lNPz8/9evXT+PHj9fVq1f1xhtvaPjw4Ro7dqwqVKigpk2bavny5SpRooQkqUSJElq8eLG+/PJLVa1aVdOnT9crr7wiKfMfXU/Nx8dHK1asUP369dWjRw+VLVtWnTp10tGjR1WgQAGX7V577TXVqFFDI0aMUFxcnGrUqKEaNWq4TYgCAAAAAAAAuPXS9bH0lCssHQ0ZMkRDhgyxPR4wYIAGDBjgsp+WLVuqZcuWtsejR49WkSJFFBAQIEnq3r27unfvbisfOXKkRo4c6XEujvfXDA0N1Xvvvaf33nvP5VwczZ071+V+AgAAAAAAALh9ZOqemxk1bdo01apVS3nz5tX69es1YcIE9evXLzumAgAAAAAAAMCisiW5uX//fo0aNUoXLlxQVFSUXnzxRQ0dOjQ7pgIAAAAAAADAorIluTlp0iRNmjQpO4YGAAAAAAAA8C+R6S8UAgAAAAAAAIDsQHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACW5JfdE/i3McZIkq7ExsrcTFKsw/+SFBsb67q9Q52Uts7qudru2D7lsbM2KeWOUs83vdLb1l19T/N2XFd3a+wYB1djOMbN2XjO6roaN3V7d3PzZh+84TiWq2PCm/E8tXWs62nOztbUkbdr6GlNXc3JWfxT13V3LDj25yxuzubj7nh1dYx7sy8ZldnnFfw7ZOUxdTuMA3vpPc8z02d6+5Bcv/64e452xlW5Y59ZtRb/1PGcnudZZ6+H3rwuenr9c/Wzq3Jv+/fUzrGP9LxPdtfG29dWZzL7Hszd+9db+Xzo6j1vys/etPd2vq7eN2dV/7ein1sxvrfvFz219/bcd/c7mTfPvanLXf3e5anP9LxPtzJ3r2nu1isz56mz300yciymHjuz/d4q3r42Oda/3ffFXZ3UvDmv0ruv7vIc7vyTv89eSZnP/8+zueNjvKkFr504cUJFixbN7mkAAAAAAAAAlnb8+HEVKVLEbR2Sm1ksOTlZp06dUmhoqHx8fLJ7OjaxsbEqWrSojh8/rrCwsOyeDm4hYn9nIu53LmJ/ZyLudy5if2ci7ncuYn9nIu53rjs59sYYXblyRYULF5avr/u7avKx9Czm6+vrMaOcncLCwu64EwJ/I/Z3JuJ+5yL2dybifuci9ncm4n7nIvZ3JuJ+57pTYx8eHu5VPb5QCAAAAAAAAIAlkdwEAAAAAAAAYEkkN+8Q/v7+GjFihPz9/bN7KrjFiP2dibjfuYj9nYm437mI/Z2JuN+5iP2dibjfuYi9d/hCIQAAAAAAAACWxJWbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmxY0ZcoU1axZU/7+/mrdurVd2datW/XAAw8oLCxMJUuW1EcffWQrS0xMVIMGDRQZGamwsDCVL19es2bNsmv/+++/q27dugoKClLZsmW1bNmyW7FL8EJG457a7t27lStXrjTtifvtLTOxL168uAIDAxUSEqKQkBBFRETYlZ86dUrNmzdXcHCwoqKi9P777//DewNvZSbuxhiNHTtWxYsXV3BwsMqWLatff/3VVs45f3vLaOzXrVtnO9dT/vn6+qp///62Opzzt6/MnPM///yzateurfDwcN11110aOnSokpOTbeXE/faWmdh/++23uvvuuxUaGqqKFStq1apVduU839++EhMT9dRTT6lEiRIKDQ1V+fLlNXv2bFt5bGysOnfurLCwMBUoUEBvvPGGXfvMliN7ZDbuw4cPV5UqVeTn56fnn38+Tf8839++MhP7s2fPqkuXLipSpIjCwsJUo0aNNM/nd3zsDSzniy++MEuWLDF9+/Y1rVq1sm2/ePGiiYyMNNOnTzc3btwwGzduNGFhYWbdunXGGGNu3Lhhdu3aZa5fv26MMWbPnj0mMjLS/PTTT8YYY5KSkkypUqXM8OHDTXx8vPn6669NcHCw2b9//y3fR6SV0binuHnzpqldu7Zp0KCBXXvifvvLTOyLFStmlixZ4rLv+vXrmx49epi4uDizceNGEx4ebtauXfsP7g28lZm4Dx061NStW9fs37/fJCcnmyNHjphTp04ZYzjnrSCzz/cpzpw5Y/z8/Mz69ett2zjnb1+ZeX+XJ08eM2bMGHPjxg1z+PBhU7x4cTNjxgxbH8T99pbR2B88eNAEBwebr7/+2ty8edN8/fXXJigoyBw8eNAYw/P97S4uLs4MHz7cHDhwwCQnJ5tffvnFREREmP/+97/GGGO6du1qHn74YXPx4kWzd+9eU7RoUTNv3jxb+8yWI3tkNu5z5841K1asMG3atDEDBgxI0z/P97evzMT+4MGDZsKECeb48ePm5s2bZtmyZSYoKMjs2bPH1v+dHnuSmxY2YsQIuzdAy5cvN0WLFrWr0717d9OtWzen7X/77TdToEABM3v2bGOMMWvWrDEREREmKSnJVqd58+bmtddey/K5I+MyGvdJkyaZHj16pGlP3K0jI7F3l9w8cOCA8fX1NWfOnLFte/bZZ03Xrl2zctrIpPTG/fz588bf39/s3bvXaX+c89aR2df5cePGmQoVKtgec85bQ0bOeUnm5MmTtvLevXubvn37GmOIu5WkN/ZTp0419erVsytv0KCBGTFihDGG53sratOmjRk+fLi5evWqyZUrl9m8ebOtbPz48aZ+/frGGJPpctxevI17at26dUuT3OT53noyEvsUNWrUMB9++KExhtgbYwwfS/8XSU5OljEmzbZdu3bZbXv00UcVEBCgihUrqkCBAmrTpo0kadeuXapUqZJy5sxpq1u9evU07XF78SbuR48e1bvvvqsJEyakaU/crcvbc75Pnz7Kly+f6tSpoxUrVti279q1S4UKFVKBAgVs24j97c9T3Ddu3Ch/f399+umnKly4sIoXL67BgwcrKSlJEue8lXl7zqeYPXu2evXqZXvMOW9NnuKeJ08e9ezZUx9++KGuX7+ugwcPas2aNXrkkUckEXcr8xR7T+U831tLQkKCNm3apKpVq2rv3r1KSkpS9erVbeWpY5fZctw+0hN3T3i+t5bMxP7s2bP6/fffVbVqVUnEXuKem/8qderU0dWrVzVlyhRdv35d69ev15IlSxQbG2tX75tvvtHVq1e1du1atW3bVoGBgZKkuLi4NPfji4iI0JUrV27VLiADvIl7nz599Prrrytv3rxp2hN36/Im9vPnz9fhw4d18uRJPffcc2rbtq02b94sidhblae4X7hwQbGxsdq/f7/27dunn376SStXrtS4ceMkEXcr8/Z1Xvr7/puHDh1S165dbduIvTV5E/cOHTpo1qxZCgwMVOnSpfXoo4+qadOmkoi7lXmKfZMmTbR582YtXbpUN27c0NKlS7V+/XpbObG3DmOMevfurTJlyuixxx5TXFycgoOD5efnZ6uTOnaZLcftIb1x94Rz3joyE/ukpCR16tRJHTp0UM2aNSURe4nk5r9K3rx59fXXX+uTTz5RwYIFNWTIEPXo0cNpQitHjhyKjo7Wn3/+abuaLyQkRJcvX7ard/nyZYWGht6S+SNjPMX9448/1o0bN/Tkk086bU/crcubc75evXoKCgqSv7+/OnfurBYtWuiLL76QROytylPcQ0JCJEkxMTEKCQlRVFSUBgwYoK+//tpWTtytKT2v8x9++KFatmyp/Pnz27YRe2vyFPe9e/eqVatWmjRpkhISEnTq1Cn9/vvvGjJkiCTibmWeYl+uXDktXLhQMTExioyM1IcffqhOnTrZvR4Q+9ufMUbPPvus9u7dq6VLl8rX11chISG6du2abty4YauXOnaZLUf2y0jcPeGct4bMxD4pKUnt2rVTUFCQ3RcGEXuSm/86devW1YYNG3T+/HmtW7dOZ86cUXR0tMv6169f1/79+yVJVatW1Z49e3T9+nVb+Y4dO1SlSpV/fN7IHHdxX7NmjX799Vfly5dP+fLl0/jx47Vy5UoVLFhQEnG3uvSe876+/3var1q1qk6dOqWzZ8/athF7a3AX92rVqrltyzlvbd6c87GxsVq0aJF69+5tt51z3rrcxf3//u//VKRIEbVr105+fn4qVKiQunXrpuXLl0si7lbn6Zxv1aqVtm/frgsXLujrr7/W/v37beU839/+jDHq27evfv31V61evVrh4eGS/k5c58yZUzt37rTVTR27zJYje2U07p7wfH/7y0zsk5KS1L59eyUlJemLL75Qrly5bGXEXnxbuhVdv37dxMfHm1deecW0aNHCxMfHm8TERGOMMdu2bTMJCQnm2rVrZtasWSYyMtJ2g/nt27eb1atXm2vXrpnr16+bb775xgQFBZkFCxYYY/73jYojRowwCQkJZvny5Xyj4m0ko3G/cOGCOX78uO3fwIEDzcMPP2xOnDhhjCHuVpDR2B89etT8+OOPJiEhwSQlJZmFCxeagIAA88svv9j6rlevnunVq5e5evWq+fXXX01ERMQd9a16t7OMxt0YYxo3bmy6du1qrl69ak6ePGmqVatmRo0aZYzhnLeCzMTeGGNmzJhhihYtam7evJmmb87521dG437o0CETGBholixZYm7evGnOnj1rmjRpYp544glb38T99paZc37z5s3m+vXrJjY21sTExJjSpUubuLg4YwzP91bw7LPPmqpVq5q//vorTdmTTz5pmjVrZi5dumT27dtnoqKi7L41O7PlyD6ZiXtSUpKJj483TzzxhOnXr5+Jj4+3+9Iwnu9vbxmNfVJSkmnVqpV58MEHTXx8vNO+7/TYk9y0oBEjRhhJdv+io6ONMX9/g2J4eLgJDg42TZo0Mbt377a127x5s6lZs6YJDQ01YWFhpmrVqmbGjBl2fe/Zs8fcf//9JiAgwJQuXdosXbr0Vu4a3Mho3J31k/qbOI0h7re7jMZ+z549plq1aiY4ONiEh4ebWrVqmWXLltn1feLECdO0aVMTFBRkihQpYmbNmnUrdw1uZOac//PPP02rVq1MSEiIKVy4sBk0aJDdG1/O+dtbZp/va9Wq5fLbkDnnb1+ZiftXX31latSoYcLCwkxkZKTp0qWLOXfunK2cuN/eMhP7xo0b297bt23b1hw/ftyunOf729eRI0eMJOPv72+Cg4Nt//r06WOMMeby5cumU6dOJiQkxOTPn9/ExMTYtc9sObJHZuPerVu3NM8X3bp1s5XzfH/7ykzs165daySZgIAAu7ajR4+21bnTY+9jjMNX7AEAAAAAAACABXDPTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAGBJDRs2VIUKFZSUlJSmrH379ipatKji4uKyYWYAAAC4VUhuAgAAwJJmzJihw4cPa/z48XbbV61apcWLF2vy5MkKCQnJptkBAADgVvAxxpjsngQAAACQETExMXrzzTe1Z88elSxZUgkJCapcubIqV66spUuX/mPjxsfHKzAw8B/rHwAAAN7hyk0AAABY1tChQ1WsWDH17dtXkjRmzBj9+eefmjJlik6cOKEnnnhC+fLlU2BgoOrXr6+tW7fatf/oo4/0wAMPKE+ePMqdO7caNGigTZs22dUZOXKkQkJCtGnTJtWpU0cBAQGaOnXqLdtHAAAAuOaX3RMAAAAAMipXrlyaOXOmGjRooFGjRmn8+PF68803FRwcrBo1aigkJESTJ09WeHi4Jk+erEaNGmn//v2KjIyUJB05ckRdu3ZVqVKllJSUpE8//VT169fXrl27VLZsWds4SUlJ6ty5swYOHKgxY8Yob9682bXLAAAASIWPpQMAAMDyevbsqTlz5ujuu+/Wpk2b9Prrr+vdd9/Vvn37bInMxMRElS1bVh07dkxzn05JSk5OVnJysipXrqzHHntMY8aMkfT3lZsxMTH67LPP1LFjx1u6XwAAAHCPj6UDAADA8oYMGSJJevHFF5UjRw6tXr1aDRs2VJ48eXTjxg3duHFDOXLkUHR0tDZv3mxr9/vvv6tNmzYqUKCAcuTIoZw5c2rv3r3at29fmjEeeeSRW7Y/AAAA8A4fSwcAAIDl5cqVy+7/v/76Sxs3blTOnDnT1C1VqpQk6cqVK3rooYeUP39+vf322ypWrJgCAgLUu3dvJSQk2LUJCgrim9cBAABuQyQ3AQAA8K+TJ08eNW3aVG+88UaaMn9/f0nSL7/8ohMnTuibb75RtWrVbOWXL19WkSJF7Nr4+Pj8sxMGAABAhpDcBAAAwL9O48aN9fHHH6tChQoKDg52Wic+Pl7S/672lKQNGzboyJEjqlSp0i2ZJwAAADKH5CYAAAD+dV544QUtWLBA0dHRGjBggKKionTu3Dn9+uuvKly4sAYOHKjatWsrJCREffv21ZAhQ3Ty5EmNGDFCd911V3ZPHwAAAF7iC4UAAADwr5M3b15t3LhR1atX1+DBg/XQQw9p4MCBOnLkiO677z5JUoECBbRo0SKdPXtWrVq10jvvvKOZM2eqdOnS2Tx7AAAAeMvHGGOyexIAAAAAAAAAkF5cuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEv6f+d0GCEK8lAoAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1600x310 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABTcAAAGBCAYAAACzaIXYAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAa29JREFUeJzt3Xd4FOXax/FfGumFklCE0HtHUFAhVAWUonRQuhUEUaSoCFGKgOeggjSPFBVRQUWleBAVpUhRigdUehNEUEpIgATI8/7hmzW72ZoEwsj3c125yD7zlHvm2Zmd3MzM+hljjAAAAAAAAADAYvzzOgAAAAAAAAAAyA6SmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAyDWlSpVS79698zoMn6Wnp6tatWoaN25cXofi1MyZMxUfH6/U1NS8DgUAAOC6QnITAABk24EDBzRw4EBVqFBBYWFhCgsLU5UqVTRgwAD9+OOPdnXHjBkjPz8/+fv768iRI1n6SkpKUmhoqPz8/DRw4EBb+cGDB+Xn5yc/Pz+NHTvWaRw9evSQn5+fIiIiPMacEYezn5kzZ/q4Bdz76aefNGbMGB08eDBX+3XHcf2CgoJUqlQpDRo0SGfOnLlmcVjNwoULdeTIEbv33rUwZMgQ1alTRwUKFFBYWJgqV66sMWPGKDk52a5e7969lZaWplmzZuV6DL/99ptGjBihJk2aKDIyUn5+flq9erXTupcuXVJiYqLKlCmj4OBglSlTRmPHjtXly5ft6m3evFkDBw5U1apVFR4ervj4eHXu3Fm7d+/O0qer/dHPz08tWrRwG/v58+c1ZswYl/Fm15EjR5SYmKhbbrlF+fPnV6FChdS4cWOtWrXKaf0zZ87ooYceUmxsrMLDw9WkSRNt2bLFrs6ff/6pyZMnq1GjRoqNjVVMTIzq16+v999/32M848aNk5+fn6pVq5Yr6wcAwD9JYF4HAAAArGnp0qXq0qWLAgMD1aNHD9WsWVP+/v765Zdf9NFHH2nGjBk6cOCASpYsadcuODhYCxcu1LBhw+zKP/roI7fjhYSEaOHChXruuefsylNSUvTJJ58oJCTEp/hnzJiRJRl66623+tSHJz/99JMSExPVuHFjlSpVKlf79iRj/VJSUvTll19q6tSp2rJli9auXXtVx921a5f8/a33/+eTJ09W165dFR0dfU3H3bx5sxo2bKg+ffooJCREW7du1UsvvaRVq1bp22+/tW3LkJAQ9erVS//+97/1+OOPy8/PL9di2LVrlyZOnKjy5curevXq+u6771zWvf/++7Vo0SL17dtXdevW1YYNGzRq1CgdPnxYs2fPttWbOHGi1q1bp06dOqlGjRo6fvy4pk2bpjp16mjDhg12Sbq33347yzjff/+9Xn31Vd15551uYz9//rwSExMlSY0bN/ZxzV375JNPNHHiRLVv3169evXS5cuX9dZbb6lFixaaM2eO+vTpY6ubnp6uu+++W9u3b9fTTz+tQoUKafr06WrcuLF++OEHlS9fXpL03Xff6dlnn1Xr1q313HPPKTAwUB9++KG6du1qO1Y48+uvv2r8+PEKDw/PtfUDAOAfxQAAAPho7969Jjw83FSuXNkcO3Ysy/JLly6ZV1991Rw+fNhWNnr0aCPJ3HfffaZWrVpZ2rRo0cJ06NDBSDIDBgywlR84cMDWTpLZtm2bXbsFCxaYoKAg06ZNGxMeHu4x9ow4Tp486csqZ8uiRYuMJPP111/nar8pKSkul7lavy5duhhJZuPGjbkayz/Bli1bjCSzatWqvA7FGGPMyy+/bCSZ7777zq78+++/N5LMl19+mavjJSUlmT///NMY4/49u2nTJiPJjBo1yq78qaeeMn5+fmb79u22snXr1pnU1FS7ert37zbBwcGmR48eHmPq16+f8fPzM0eOHHFb7+TJk0aSGT16tMc+fbFjx44s+9DFixdNpUqVTPHixe3K33//fSPJLFq0yFZ24sQJExMTY7p162Yr279/vzl48KBd2/T0dNO0aVMTHBxskpOTncbSpUsX07RpU5OQkGCqVq2a01UDAOAfx3r/rQ4AAPLcpEmTlJKSorlz56po0aJZlgcGBmrQoEEqUaJElmXdu3fXtm3b9Msvv9jKjh8/rq+++krdu3d3OWaDBg1UunRpvfvuu3blCxYsUMuWLVWgQIEcrNHffvzxR/Xu3VtlypRRSEiIihQpor59++rPP//MUvfo0aPq16+fihUrpuDgYJUuXVqPPvqo0tLSNG/ePHXq1EmS1KRJE9tttplvn50+fbqqVq2q4OBgFStWTAMGDMhy63jjxo1VrVo1/fDDD2rUqJHCwsL0zDPP+LxeDRs2lCTt27fPrnzjxo1q2bKloqOjFRYWpoSEBK1bty5L+9WrV6tu3boKCQlR2bJlNWvWLNst8Jk5PnNz3rx58vPz09q1azVo0CDb7bgPP/yw0tLSdObMGfXs2VP58+dX/vz5NWzYMBlj7PpMT0/XK6+8oqpVqyokJESFCxfWww8/rNOnT9vV+/7773XXXXepUKFCCg0NVenSpdW3b1+P22bJkiXKly+fGjVqZFeesX579+5V7969FRMTo+joaPXp00fnz5/32G92ZVzl6/heuPnmm1WgQAF98sknuTpeZGSkV/vPmjVrJEldu3a1K+/atauMMXa3V992223Kly+fXb3y5curatWq+vnnn92Ok5qaqg8//FAJCQkqXry4y3oHDx5UbGysJCkxMdG2j40ZM8ZW56uvvlLDhg0VHh6umJgYtWvXzuP4klS1alUVKlTIriw4OFitW7fWr7/+qnPnztnKFy9erMKFC+u+++6zlcXGxqpz58765JNPbM9JLV26dJYr2f38/NS+fXulpqZq//79WeL49ttvtXjxYr3yyiseYwYA4EbFbekAAMBnS5cuVbly5bJ1G3ejRo1UvHhxvfvuu3rhhRckSe+//74iIiJ09913u23brVs3vfPOO3rppZfk5+enP/74QytXrtTbb7+tzz//3Kc4Tp06Zfc6ICBA+fPn1xdffKH9+/erT58+KlKkiHbu3KnZs2dr586d2rBhgy2Zd+zYMd1yyy22Z+1VqlRJR48e1eLFi3X+/Hk1atRIgwYN0muvvaZnnnlGlStXliTbv2PGjFFiYqKaN2+uRx99VLt27dKMGTO0efNmrVu3TkFBQbbY/vzzT7Vq1Updu3bV/fffr8KFC/u0rpJsz/3Mnz+/reyrr75Sq1atdPPNN2v06NHy9/fX3Llz1bRpU61Zs0a33HKLJGnr1q1q2bKlihYtqsTERF25ckUvvPCCLbHkjccff1xFihRRYmKiNmzYoNmzZysmJkbr169XfHy8xo8fr+XLl2vy5MmqVq2aevbsaWv78MMPa968eerTp48GDRqkAwcOaNq0adq6dattW504cUJ33nmnYmNjNWLECMXExOjgwYMeH3cgSevXr1e1atXstnlmnTt3VunSpTVhwgRt2bJF//nPfxQXF6eJEyfa6pw9e1aXLl3yOFZISEiWxyFcvnxZZ86cUVpamnbs2KHnnntOkZGRtu2fWZ06dZwmn6+FjCRdaGioXXlYWJgk6YcffnDb3hij33//XVWrVnVbb/ny5Tpz5ox69Ojhtl5sbKxmzJihRx99VPfee68tuVijRg1J0qpVq9SqVSuVKVNGY8aM0YULFzR16lTdfvvt2rJlS7YeFXH8+HHb84UzbN26VXXq1MnyOIZbbrlFs2fP1u7du1W9enW3fUrKkky9cuWKHn/8cfXv399tewAAbnh5fOUoAACwmLNnzxpJpn379lmWnT592pw8edL2c/78eduyzLdLDx061JQrV862rF69eqZPnz7GGOPytvTJkyebHTt2GElmzZo1xhhjXn/9dRMREWFSUlJMr169fLot3fGnZMmSxhhjF3OGhQsXGknm22+/tZX17NnT+Pv7m82bN2epn56eboxxfYvviRMnTL58+cydd95prly5YiufNm2akWTmzJljK0tISDCSzMyZMz2uW+b127Vrlzl58qQ5ePCgmTNnjgkNDTWxsbG2W9rT09NN+fLlzV133WWLN2P9S5cubVq0aGEra9OmjQkLCzNHjx61le3Zs8cEBgYax9PJkiVLml69etlez50710jKMk6DBg2Mn5+feeSRR2xlly9fNsWLFzcJCQm2sjVr1hhJZsGCBXbjfP7553blH3/8sZHkdD48KV68uOnQoUOW8oxt2bdvX7vye++91xQsWNCuLGOePP1k3jYZvvvuO7s6FStWdPkog4ceesiEhob6vI7ecndb+ocffmgkmbffftuufObMmUaSqVatmtu+3377bSPJvPnmm27rdejQwQQHB5vTp097jNfdbem1atUycXFxtlvujTFm+/btxt/f3/Ts2dNj34727NljQkJCzAMPPGBXHh4enuU9Yowxy5YtM5LM559/7rLPP//808TFxZmGDRtmWTZt2jQTHR1tTpw4YYwx3JYOAIALXLkJAAB8kpSUJElOv5m8cePG2r59u+315MmTNXTo0Cz1unfvrpdfflmbN29W/vz5tXnzZo0fP97j2FWrVlWNGjW0cOFC3XHHHXr33XfVrl07u6uovPXhhx8qKirK9jrjarTMV6VdvHhRycnJql+/viRpy5YtatiwodLT07VkyRK1adNGdevWzdK3py97WbVqldLS0vTEE0/YXe314IMP6plnntGyZcvsvrAkODjY7rU3KlasaPe6evXqmjt3rm1bbdu2TXv27NFzzz2X5Zb7Zs2a6e2331Z6erqMMVq1apXuvfdeFStWzFanXLlyatWqlT777DOv4unXr5/ddrn11lv13XffqV+/fraygIAA1a1b1+4KwEWLFik6OlotWrTQH3/8YSu/+eabFRERoa+//lrdu3dXTEyMpL+uKq5Zs6bLqzCd+fPPP+2uaHX0yCOP2L1u2LChPv74YyUlJdneQ//617+y3CbvTOZtmKFKlSr64osvlJKSovXr12vVqlVZvi09Q/78+XXhwgWdP38+W+/7nGjdurVKliypoUOHKiwsTDfffLM2btyoZ599VoGBgbpw4YLLtr/88osGDBigBg0aqFevXi7rJSUladmyZWrdurVtTrPjt99+07Zt2zRs2DC7W+5r1KihFi1aaPny5T71d/78eXXq1EmhoaF66aWX7JZduHBBwcHBWdpkfMmZq+2Snp6uHj166MyZM5o6dardsj///FPPP/+8Ro0a5dMV0gAA3IhIbgIAAJ9ERkZKktPky6xZs3Tu3Dn9/vvvuv/++132Ubt2bVWqVEnvvvuuYmJiVKRIETVt2tSr8bt3765//etfGjJkiNavX5+t509Kf90e73gbqPTX7eqJiYl67733dOLECbtlZ8+elSSdPHlSSUlJdt/47ItDhw5JypqAzJcvn8qUKWNbnuGmm27K8vxCTzKStydPntRrr72mAwcO2CVu9+zZI0luE01nz57VxYsXdeHCBZUrVy7LcmdlrsTHx9u9zvhWcsfnskZHR9slCffs2aOzZ88qLi7Oab8Zc5SQkKAOHTooMTFRU6ZMUePGjdW+fXt1797daeLJkXF4zqe72DMSoadPn7YlN2+++WaPY7gSFRWl5s2bS5LatWtnS9pv2bJFNWvWdBqnuwR6cnKy3f4ZEBCQKwmykJAQLVu2TJ07d1aHDh0k/ZV4nzRpksaNG+f0Pzykv267vvvuuxUdHa3FixcrICDA5RgffvihLl686PGWdE9c7WPSX4+G+O9//6uUlBSvvoH8ypUrtm80X7FiRZYEdWhoqO2W/cwuXrxoW+7M448/rs8//1xvvfVWlnl+7rnnVKBAAT3++OMe4wMA4EZHchMAAPgkOjpaRYsW1Y4dO7Isy3gGZ8bzHd3p3r27ZsyYocjISHXp0iXL8+pc6datm0aOHKkHH3xQBQsW1J133ulT/J507txZ69ev19NPP61atWopIiJC6enpatmypdLT03N1LG+5So64kzl526ZNG1WvXl09evTQDz/8IH9/f9u6TJ48WbVq1XLaR0REhC1Bk1OuElrOyjMnGtPT0xUXF6cFCxY4bZ+RtPPz89PixYu1YcMGffbZZ/rvf/+rvn376l//+pc2bNjgMvEmSQULFnR71aWr2DPHeerUKaWlpbnsI0NoaKgtsevKfffdpwceeEDvvfdelqTX6dOnFRYW5vY98fLLLysxMdH2umTJkl7tk96oWrWqduzYoZ9++kmnT59WlSpVFBoaqiFDhighISFL/bNnz6pVq1Y6c+aM1qxZ4/TK1cwWLFig6Oho3XPPPbkSb2548MEHtXTpUi1YsMDpf8IULVpUv/32W5byjDJn65yYmKjp06frpZde0gMPPGC3bM+ePZo9e7ZeeeUVHTt2zFZ+8eJFXbp0SQcPHlRUVFSufYkaAABWR3ITAAD47O6779Z//vMfbdq0yemXnnije/fuev755/Xbb7/p7bff9rpdfHy8br/9dq1evVqPPvqoAgNz73Tm9OnT+vLLL5WYmKjnn3/eVp5xlWOG2NhYRUVFOU3wZubq6rqMb0zetWuXypQpYytPS0vTgQMHbFfx5ZaIiAiNHj1affr00QcffKCuXbuqbNmykuyvGnQmLi5OISEh2rt3b5ZlzspyW9myZbVq1SrdfvvtXiV569evr/r162vcuHF699131aNHD7333nvq37+/yzaVKlXSgQMHchTnfffdp2+++cZjvV69emnevHlu66Smpio9Pd12pXBmBw4csH0plSs9e/bUHXfcYXudneS4O35+fnZfCrR8+XKlp6dneR9dvHhRbdq00e7du7Vq1SpVqVLFbb+//fabvv76a/Xu3durq20zYnEm8z7m6JdfflGhQoW8umrz6aef1ty5c/XKK6+oW7duTuvUqlVLa9asUXp6ut1/0mzcuFFhYWGqUKGCXf3XX39dY8aM0RNPPKHhw4dn6e/o0aNKT0/XoEGDNGjQoCzLS5curcGDB/MN6gAA/D+SmwAAwGfDhg3Tu+++q759++rLL7/M8u3d7m7xzVC2bFm98sorunDhgs8J0rFjx+rrr79Wly5dfGrnScYVeo7xOyYR/P391b59e73zzjv6/vvvszx30xgjPz8/W/LkzJkzdsubN2+ufPny6bXXXlPLli1tCZo333xTZ8+e9fit8dnRo0cPjRo1ShMnTlTXrl118803q2zZsnr55ZfVvXv3LFc2njx5UrGxsQoICFDz5s21ZMkSHTt2zHYV2t69e7VixYpcj9NR586dNX36dL344otZnst6+fJlJScnKyYmRqdPn1ZMTIxdsivjilRntwxn1qBBA7300ktKTU31OqnmKDvP3Dxz5ozCw8OzPB/0P//5jyQ5fZ7rli1bPN6yXaZMGbuk+dV04cIFjRo1SkWLFrVL/l25ckVdunTRd999p08++UQNGjTw2Nd7771new6ltzKeO+q4jxUtWlS1atXS/PnzNXLkSNvzO3fs2KGVK1e6fWxGhsmTJ+vll1/WM888o8GDB7us17FjRy1evFgfffSROnbsKEn6448/tGjRIrVp08buPfX+++9r0KBB6tGjh/7973877a9atWr6+OOPs5Q/99xzOnfunF599VXbf04AAACSmwAAIBvKly+vd999V926dVPFihXVo0cP1axZU8YYHThwQO+++678/f1VvHhxt/24Sxi4k5CQ4PQW2JyKiopSo0aNNGnSJF26dEk33XSTVq5c6fSqvvHjx2vlypVKSEjQQw89pMqVK+u3337TokWLtHbtWsXExKhWrVoKCAjQxIkTdfbsWQUHB6tp06aKi4vTyJEjlZiYqJYtW6pt27batWuXpk+frnr16nmVePFVUFCQBg8erKefflqff/65WrZsqf/85z9q1aqVqlatqj59+uimm27S0aNH9fXXXysqKsr2ZUFjxozRypUrdfvtt+vRRx/VlStXNG3aNFWrVk3btm3L9VgzS0hI0MMPP6wJEyZo27ZtuvPOOxUUFKQ9e/Zo0aJFevXVV9WxY0fNnz9f06dP17333quyZcvq3LlzeuONNxQVFaXWrVu7HaNdu3Z68cUX9c0332T7MQfZeebm6tWrNWjQIHXs2FHly5dXWlqa1qxZo48++kh169bN8j744YcfdOrUKbVr1y5bMbozduxYSdLOnTslSW+//bbWrl0r6a+kWobOnTurWLFiqlKlipKSkjRnzhzt379fy5Ytsz2PV5Keeuopffrpp2rTpo1OnTqld955x248Z+/xBQsWqFixYmrcuLHXcYeGhqpKlSp6//33VaFCBRUoUEDVqlVTtWrVNHnyZLVq1UoNGjRQv379dOHCBU2dOlXR0dEaM2aM234//vhjDRs2TOXLl1flypWzxN+iRQvbf+p07NhR9evXV58+ffTTTz+pUKFCmj59uq5cuWL3eIBNmzapZ8+eKliwoJo1a5blUQu33XabypQpo0KFCql9+/ZZYsr4TxZnywAAuKHl2fe0AwAAy9u7d6959NFHTbly5UxISIgJDQ01lSpVMo888ojZtm2bXd3Ro0cbSebkyZNu+5RkBgwYYHt94MABI8lMnjzZbbtevXqZ8PBwjzF7iuPXX3819957r4mJiTHR0dGmU6dO5tixY0aSGT16tF3dQ4cOmZ49e5rY2FgTHBxsypQpYwYMGGBSU1Ntdd544w1TpkwZExAQYCSZr7/+2rZs2rRpplKlSiYoKMgULlzYPProo+b06dN2YyQkJJiqVat6XC9v1u/s2bMmOjraJCQk2Mq2bt1q7rvvPlOwYEETHBxsSpYsaTp37my+/PJLu7ZffvmlqV27tsmXL58pW7as+c9//mOeeuopExISYlevZMmSplevXrbXc+fONZLM5s2bvYrT1TzOnj3b3HzzzSY0NNRERkaa6tWrm2HDhpljx44ZY4zZsmWL6datm4mPjzfBwcEmLi7O3HPPPeb777/3arvVqFHD9OvXz6sYM9bpwIEDXvXtyt69e03Pnj1NmTJlTGhoqAkJCTFVq1Y1o0ePNsnJyVnqDx8+3MTHx5v09PQcjeuMJJc/mU2cONFUqlTJhISEmPz585u2bduarVu3ZukvISHB6z6NMeaXX34xksyTTz7pc+zr1683N998s8mXL1+W/XTVqlXm9ttvN6GhoSYqKsq0adPG/PTTTx77zJh7Vz+Z92NjjDl16pTp16+fKViwoAkLCzMJCQlZ3vMZ7xtXP3PnznUbk6/HAgAAbhR+xnhx3xgAAADgoH379tq5c2eWZ5Ja0dtvv60BAwbo8OHDtluYryepqakqVaqURowYke0rngEAAP6JvPtaUgAAANzQLly4YPd6z549Wr58uU+3EF/PevToofj4eL3++ut5HYpTc+fOVVBQkB555JG8DgUAAOC6wpWbAAAA8Kho0aLq3bu3ypQpo0OHDmnGjBlKTU3V1q1bVb58+bwODwAAADcovlAIAAAAHrVs2VILFy7U8ePHFRwcrAYNGmj8+PEkNgEAAJCnuHITAAAAAAAAgCXxzE0AAAAAAAAAlsRt6bksPT1dx44dU2RkpPz8/PI6HAAAAAAAAMBSjDE6d+6cihUrJn9/99dmktzMZceOHVOJEiXyOgwAAAAAAADA0o4cOaLixYu7rUNyM5dFRkZKkvJV6aUja15TfOOhOrz6Zbs6jmUZrzOXxzceKkm28syMMTr41SSVavp0lvEPfjVZkmzLMl5nKNX0aR38arLL5Y71siMnbXOrf8f1lGR77a5t5naZt6Wz7eisT8e6OZ0HV+uSeWxnvzu2dRWLu3i9beusnmNMrmL2dn29mW9n47iKwVlbZ228mRdv4/HUztn+7NiHpzretnFX7iyWg19Nlp+fn0o1HebVuM6OW75w1t5VnzkdK6fcje+4zPG470tfV0Pm8bwd21kbV2WSXC6/WutxNbhbz+z0czXik7K+pxznwFF21sWbuq62k7MYnMXiarmn9tlZR1fbzhlP+6837d0dK5z17SnujPqetpu77etp2zrG5ey45s32d4zH2bmxY11H7raTszae3q+e1ttVf87Wwd26+hKTr1z9jeFqzp39reFt/66OMc76dTaGu1hdfXY4WydXcXpTz5v2jjF6quOurquxMrfxpd/M7b3d97N77HW2zNUcuYrX07mAq/OkvDyvywlvjnW+8uY45Oq952l7+nIM9KYvX+fS1/3Vl33H2/PSnMTjK1f5HsexPX3WZebte8Cbuq7G8IWzz0ZX6+3qM9Tx952fPq9ypUvY8mzukNzMZRm3ovsF5FNUVJTtX7s6DmXO6voF5JMkW7kxRuln98s/5bCCzTnd02qrQo6fyDL+Pa22SZJtWcbrDCHHT+ieVttcLneslx05aZtb/TuupyTba3dtM7fLvC2dbUdnfTrWzek8uFqXzGM7+92xratY3MXrbVtn9RxjchWzt+vrzXw7G8dVDM7aOmvjzbx4G4+nds72Z8c+PNXxto27cmexZJQHHT+lC/4FFVCgsvyDo+RKxnEru5y1d9VnTsfKKXfjOy5zPO770tfVkHk8b8d21sZVmSSXy6/WelwN7tYzO/1cjfikrO8pxzlwlJ118aauq+3kLAZnsbha7ql9dtbR1bZzxtP+6017d8cKZ317ijujvqft5m77etq2jnE5O655s/0d43F2buxY15G77eSsjaf3q6f1dtWfs3Vwt66+xOQrV39juJpzZ39reNu/q2OMs36djeEuVlefHc7WyVWc3tTzpr1jjJ7quKvraqzMbXzpN3N7b/f97B57nS1zNUeu4vV0LuDqPCkvz+tywptjna+8OQ65eu952p6+HAO96cvXufR1f/Vl3/H2vDQn8fjKVb7HcWxPn3WZefse8KauqzF84eyz0dV6u/oMdfw9MqOdF498JLlpEVf+2KEC+lXNWzZR9Vp1VKV8vPYfOZmlXpkSsZJkW5bxOsP+IydVpkSsy+WO9bIjJ21zq3/H9ZRke+2ubeZ2mbels+3orE/HujmdB1frknlsZ787tnUVi7t4vW3rrJ5jTK5i9nZ9vZlvZ+O4isFZW2dtvJkXb+Px1M7Z/uzYh6c63rZxV+4sljIlYpWenq6NP/xPX335hXbuXqfLcbfLL1/OPgABAAAAAMgpkpsWYK6kKiz1oPoNeEQdOveQJNWuHK+tPx/OUrd25XhJsi3LeJ1h68+H7do6Lneslx05aZtb/Tuup/T3NnPXNnO7zNvS2XZ01qdj3ZzOg6t1yTy2s98d27qKxV283rZ1Vs8xJlcxe7u+3sy3s3FcxeCsrbM23syLt/F4audsf3bsw1Mdb9t4e/xwLC9RvpZa3t1OTw16RNuP7FZg4bo+xQMAAAAAQG5z/3VDuC6kp/yuiLB8anZn67wOBcANLiIySo0aN1Xw5T/zOhQAAAAAAEhuWsKVVAUH51NMTP68jgQAVCg2Tv7mUl6HAQAAAAAAyU2r8JPnB6gCwLXg7+8vL57pDAAAAADAVUdyEzeUMc88pXnz5uV1GP9oD/Xuou83fZdr/TWsW1n/+9//JEmJY8bo3nvb25YF+Ptp27ZtuTYWAAAAAACwFpKbFvZQ7y5qUKu8GtatrEb1qqhz2+ZatGiRbfmxo0cU4O+nM2fO2MqOHzuqPn16q2XjempUr4oqlC+nQY8/rt9++82rMf/18suqVbOGYqKjFF+iuJ4eOlRpaWl2dbZt2ayGd9yuqMgIFSkcp9HPP29b9vq0abqlXl2FhgTbJakk6fDhw4qKjLD7yRcUqHbt2trqdOrUUXcl1FVMdJTKlimtcWPH+rDFsq9f374K8PfTzz//bFe+evVqNa5f3a5sx44d6tSpowrHxSrhlqrq2KapRj33nM6ePevVWMOeflqVK1VUdFSkypYprblvvG63fMwzT6l+zXKKioxQw7qV1bBuZX333d/JxEGPP66S8SUUEx2lVk1u0ZAnnsgyR5L0+++/q2mDGqpTu5at7NDB/Ro66CEVK1pEjetXV8M7bte6deu8iju7Nm7cqGZNm6hggfwqkD9GXe+9yy4Bveb7n1W9enXXHeSRNi1u15IlS+zKrkay9eSJ3zXokV6KjAjX3c0a6ONFC93WHzd6hO67u4nqVSulV195xW7ZpbQ0DXviEZUpXUp1q5bU6i//a7f84MGDCvD3s72vGtatrCGP9c3V9QEAAAAAIDeR3LS4x58coTXf/6xvNu3UoKdG6oH7e+jQoUNO6x4+fFg9u7ZVUGCQ5iz4SN9s2qk1a9epaNGi+uabb7wa78qVK3rjP2/q5B9/av13G/TNN6uVOGaMbfmPP/6opwc/rKeGPq0//jylffsPqEPHjrblRYsV0zPPPqf+/R/M0nd8fLySziXbfv7485RiYmLUpUtXW53nnx+tz75YpzNnk/T16m+0cOG7euedd7zcWtmTkpKsRYs+UIECBTTnzTfd1v3lp//p9tsaqFLFStq6bbu+2bRTU2e9pYsXL+rHH3/0aryQkBAt/vAjnTp9RsuWr9BHH7yr2bNn29Xp1PUBJZ1L1prvf9aa739WgwYNbMsefewx/fTzLzpzNkkLP/pcP/64XZMnTcoyzuOPD1TFylXtys4lJem2Oxpr+4//05frtqlnr9665+7WOnP6lFex++rcuXNq3aqlOnXuouO/n9DvJ05q1AuTFBcXd1XGs6Jnn35cBQvF6vjvJzRxynS9+q/x+mHzBpf1y1esrBGjXlTV6rWcLq9Vp57mv/W2Chcp6rKP5V9tsL23pkyfk9NVAAAAAADgqiG5+Q/h5+enOxKaKSYmRrt27XJaZ8yY0SpXvqJmv/GGit1UQn5+fipcuLBGPvOMunbt6rSNo2HDh6tevXoKCgpS8eLF9cADPbVu3Vrb8rFjX1T7Dl3Vvn175cuXT+Hh4apRo4Zt+X333af27durUKFCHsdasmSJ0tPTdd9999nKqlevrnz5gm3r7O/vr7179ngVe3Z9seIzhYeHa8JLE/XOO2/r0iXXX6QyZdJYde7cRS+OHatixYpJkooWK67JL7+shg0bejXeCy++qKpVqyogIECVKlVSk+Z32W1jTypXrqzw8HBJkjFG/v7+2rPXfht98sknOn3qlFq3uc+uvFqNWrqvc3fFxsYqICBADz74oAICArRnl/0Vq7ll165dSklJ0UMPPaSgoCAFBQWpavWaat26ta1O3aol3V4NuWHDBnVu10IJt1TVkAH9lHwuybbs+++/V98e96lx/erq1KaZPl/2iW1Znz69NeSJJ2yvz5w5o7pVS+rgwYOS/tp2U197TVUqV1KB/DFq2qSx7crdzp076fhvR9WjezdFRUbo0UceUf1bb5Ek3XH7bWpYt7LmzJ4mSfr18CG1bdtGheNiVbpUSf1n5mtKT0/3avv8eviQtm3ZrIFPDFd4eLiq1aitVne306cffeCyTefuvXRL/TuULzg4y7KgfPnUvWc/NWzYUP7+AV7FAAAAAADA9Yzk5j9Eenq6Vn+1UhcuXFCtWrWc1ln53//qztZtnS7LMPGll9SmzT1ej/vNt9+oevW/k5fffvONLl1KU53atVQ4LlatWrV0mWz1ZM6cN9W9ew+FhITYlb/0wrOKCA9TqZLxSk5OVq/evbPVv7c++eh9de/eQ127dlVKSoo+++wzp/XOnz+vbVs2q2u3bm77G/DYY3rphWe9GtsYo60/bFKNTNtYkpZ9+qEKFSygzm2b6515s7Mkyya+9JKiIiPUomEdbd++XQMHPm5bdvbsWQ196klNnzHT4/j/+9//dO7cOZUuW96reH1VoUIFRUdHq1u3rvrkk090/Phxn/tYvOgDzZyzUEtXrdeJ33/Tgrf+urr2XNJZtW7VUne2bqNVa7ZoxPPjNG70CK9vs1/83tuaM+dNffLpZzpx8g/de+99ate2jdLS0vTBB4tUpOhNWvDuQiWdS9aMmTO1YeMmSdLadeu15vuf1fehgbp44YIe7dddzZo205Ffj+qbb9do5YrPNHfuXNs4BfLHaO1a58nrPbt/VqHYOBUsFPv3NqtUVXt2X51kc4Yu7e/UXY3qasiAfjq4f+9VHQsAAAAAgJwguWlxr78y8a9nI9atpGGDH9azzz7n8pbekydPKi6uiNv+ho8Yoc8+W+rV2G+88YbWr1unZ579O1F36tQprVzxmd56+x0dPvKrataoqXvbt9Ply5e9XylJhw4d0perVqlf//5Zlo14fpySziVr46bNeuCBnsqfP79Pffvip59+0v+2b1XPXr0UERGh9vfeqzlznN+afvr0aV25ckU33XST2z5fnz5dI54f59X4o557ThcvXNAjjz5qK+t6f299uOzrv27hfnGSFr49V6+9+qpdu+EjRijpXLIWfbpKDz/8iIoU+Xvehw8bpl69eqt8efcJy3NJZ9W9W1eNHPmMCsVendvEo6KitG79dyqQv4CGPvWkit9UTL26ttOWLVu87mPo08NUoGAhRUZFq2mLVvpl519fPrT2268UGxurrj36KDAoSDfXq6+Wd7fTW/Pne9XvooVvaUziCypfvrwCAwP1+KBBunDhgjZu3Oh1bGu//UqRUVEa/MQTypcvn+Lj49Xt/r56b+G7tjqnTp/RHXfc4bT9+fPnFREZZVcWGRWl8ykpXsfgi0KFCum7DRv16X/XavHSLxVfspQGPHi/kpKSPDcGAAAAACAPkNy0uAFPDNfqDf/Tui279eHSr/XWW/M1a9Ysp3ULFSqkEyd8vzLOmQULFuj5Uc/p8/+uVNGifz+7LyIiQm3ad1K1atUUHBysxBde0N69e7V7926f+p83d65q166tmjVrOl3u7++vunXrKjIyUk8PHZqjdXFnzptvqkLFKrY4evbspZX//a9O/J51O+bPn1/+/v46evRorow98aWX9P7772naG+/YbjOXpEpVqit/gYIKCAhQ9Zp11Lv/o/rgg/ed9lG6bHnVqFlTffv0liRt/WGT1q9fp2HDh7sd++zZsxr4UE/dfvsdGp3pmapXQ7ly5TRj5kzt2btPh4/8qhLxJdW+XVsZY7xqnzlxGxoappTzfyX+fj9+XCVLlbKre1PxeP169Fev+j127Ff1fOB+FcgfY/s5ffq0fv3Vu/bSX1/qtW/vbrs+Xpk81usrVMPCwpSSfM6uLPlcksIyvR9yU0REhG655RYFBgUpMipaTzz9nC5fuqz169dflfEAAAAAAMgpkpv/ICVKllKrVq21bJnzKy/vvOsuffG5d1dlurNgwQI9OeQJLV/xud3zNCVlSUb6+fn53H96errmzZurvv2yXrXp6NKlS9q79+o8c/PSpUt65523dejQfhUrWkTFihbRA/f30JUrV/TZkkVZ6oeFhanWzbfo/ffey/HYE196SbNmzdSqL79y+8UvkuTn7343vnTpkvb8/3NJN21Yp/3796v4TcUUF1tIk8eP1o4dOxQXW0i//fabpL+SZ61a3qUy5cprxsyZ2ZrD7CpWrJh6939MR48e1dmzZ3LUV+EiRXTo/5+fmeHYsV9V/KbikqSI8AidP3/etixj/f9uX0zvf7BIp06fsf0kp5xXt/9/7IC/f9bt4ritChcppspVqtv18c2mnfrfjp1erUP5CpV18sTvOvXnH7ayXb/8pHIVKnnVPqf8/Pykazf9AAAAAAD4jOTmP8ixo0e0YsVyVa9W3enyMWMStfuXn/ToI4/o+LGjMsbo5MmTmjRxot5/3/mVf44WLlyoJwYP0rLlK1S7du0sy/s/+JCWfrJYu3bt0qVLl/RCYqLKly+vChUqSJIuX76sixcv6vLly0pPT9fFixeVlpZm18cXX3yhP/74w5ZEynDo0CF9+OGHOp+SovT0dK1fv15Tp76mO++8y6vYffXpp58qKSlJCxYt05at27Rl6zZt3bZdzz03Sp9+/IHTKwuHPP2cPvjgfY0ZPdp2dd7vx3/TiOHDtWbNGq/GnTxpkmbMmK4vv/paJUuWzLL8i8+XKjn5nIwx+mnHj5r/nxm6774OkqTzKSmaO3euzpw5I2OM9u7+RePHjbVtox69+uuXXbtt6/PwwCdVsWJFbdm6TXFxcUpOPqfHH+6p8hUqaNQLk656YvOXX37RpIkTdfDgQaWnp+vMmTN6/935qlChgmJicva4gdsbNtWJEye0aOFbunz5srb+sEmfL12iB3r2lCTVrlNHK1f+V3+c/F0pKcl64YVEu/aduj2gMaOftz0zNikpSZ988onOnfvrSsoCBQtp/759dm0KFy6sfZnKGiY006k/T2rG9Om6ePGirly5ooMH9mn16tVerUPx+JKqWbuuXn91ks6fP68dP27T58uWqN19XVy2uZSWptTUizLp6bp8+bJSUy/aPRYiLS1VFy9elDHGtvzKlSuSpI0bN+rnn3/WlStXdD4lRa/9a4L8/PzUoEEDr+IFAAAAAOBaI7lpcVP//ZIa1q2shnUrq/8DHdWsWXONev55p3VLliypt97/VBdTL6pXt3ZKuKWqbr+tgY4ePaqEhARJ0oTx49W6dSuX4z337DNKSkpS0yaNFRUZoajICFWvVtW2vEePHurUrZeaNW2iIoXj9P0P32vJJ58qMDBQkjRu7FiFh4Vq/PhxWvrZZwoPC1XLu+60G2POnDfVoWNHRUdHZxn/tVdfUetm9VUgf4z69+urgQMf1/ARI3zdbF6ZM+dNde3WTaXKlFORIkVsP48PGqQ/Tvyu7zdmvVW3ctXqWrN2nXbs3KHq1aoq4Zaqeqx/DwUFBdmuan30kUc0PvEZl+OOGDFcx48fV80a1RUVGaGGdSvbzckH787XPc1vU3RUpJ4bPlgduz6gJ596StJfV9otXPiuypcrq+ioSD31eH+1bn23przyiiQpIiJSxYsXt/1ERUUrKOivb74PCAjQ6lX/1f+2b9VHH36ohFuq2uZ4xdKPc3HL/i0yMlJbt21VQqOGiomOUuVKFXXm9J/65FPnX9rki6joaC1bvkIrln6sZrfX0rgxIzTi+bG251vef//9apSQoA73NFP3Dq3UuvXddu27dO+tXr16q2OH+xQTHaWqVSprYaZnZfZ5cKBef32aCuSP0YDHHpMkJb7wop4YPEhNGlTXvDemKyw8XNP/866+/OpLlSldSrGFCuq5YYPsbkuPioxwm/geN3mqTv5+XIXjYjV8yCMa9OQzurlefdvyzm2b283PgIce0O11KmrrD5s0bNjTur1ORb05a6pteYe7myo8LFTHfzuqEU8+ptvrVNTyTz+SJO3fv19t29yjhFurqu1dd2j/vt2a9sY7TvdFAAAAAACuB4F5HQCyb/a8rFdb1q4cb/u92E0ldCXd/urCosWKa+7cedr68+Es9SVp5DPPaKRkW+5o3/4DHuPq3f9RvfqvCU6XjR4zxuMzHN9//wOn5SVLltQ3367R1p8PZ4n7ali2bLmkrNuiUKFCWrflr2eI1q4cr9Ub/me3vHr16lq8+EO7tpnjnTFzpsvtKynLnGWsb0abN95aZOszo8z//29NDw0L08qVX2Rp60qbezvp+Weesr2+p31H3dO+o63vjLbu4s2Jm266SQsX2t/Gv/Xnw6pQ4e91+37nIdX6/zgc3zsZ2yqjbvee/dS9Zz/b8ltuuUVzFjhPzObLl0/z57+lJ0b8PUfV6iaoVKl4nf75sPz8/PToY4/p0f9PXDpq1KS5Bj/W166sf//+6t+/v932Kh5f0vZ+yIg185wknUu2WwdHcYWL6LVZb9nNd2YffLrK7nXm44KzNp99sc5lX926dVO3bt2u2nwDAAAAAJDbuHLTCvz8lG7Svf6CFQC4mq5cviwexgkAAAAAuB6Q3LSCgFClpqbp5Inf8zoSy2vc7E7VqlUrr8P4R2vTrqOK/f+X9uCf6bffjuqy8uV1GAAAAAAAkNy0Av/wOJ07f8nll9jAe42b3UVy8yprc28nFbupRF6Hgavk+G/H9PVXXyotKC6vQwEAAAAAgGduWoGff5BSI6vo/fcXaeeOHbq5bl1tKFlMR46fylJ3Q5ECkmRblvE6w5Hjp7ShSAGXyx3rZUdO2uZW/47rKcn22l3bzO0yb0tn29FZn451czoPrtYl89jOfnds6yoWd/F629ZZPceYXMXs7fp6M9/OxnEVg7O2ztp4My/exuOpnbP92bEPT3W8beOu3FksG4oUUHp6urb8+LPWrVunX09eUECRmj7FAgAAAADA1UBy0yICYsoqJShC6386qC0/fajG9crr2827stRrVK+iJNmWZbzO8O3mXWpUr6LL5Y71siMnbXOrf8f1lGR77a5t5naZt6Wz7eisT8e6OZ0HV+uSeWxnvzu2dRWLu3i9beusnmNMrmL2dn29mW9n47iKwVlbZ228mRdv4/HUztn+7NiHpzretnFX7iyWjPIvN+3X5eA4BRQpI7/AEJ9iAQAAAADgaiC5aSH+4YXlH15YVyQt/nia8tcbmKXO4o+nSZJtWcbrDPnrDbRr67jcsV525KRtbvXvuJ7S39vMXdvM7TJvS2fb0VmfjnVzOg+u1iXz2M5+d2zrKhZ38Xrb1lk9x5hcxezt+noz387GcRWDs7bO2ngzL97G46mds/3ZsQ9Pdbxt4+3xw1k5HxoAAAAAgOsJz9wEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSddlcnPevHmKiYnJ6zAAAAAAAAAAXMd8Sm727t1bfn5+8vPzU1BQkEqXLq1hw4bp4sWLuRpUly5dtHv37lzt01tt27ZVfHy8QkJCVLRoUT3wwAM6duxYnsQCAAAAAAAAwDWfr9xs2bKlfvvtN+3fv19TpkzRrFmzNHr06FwNKjQ0VHFxcbnap7eaNGmiDz74QLt27dKHH36offv2qWPHjnkSCwAAAAAAAADXfE5uBgcHq0iRIipRooTat2+v5s2b64svvrAtT09P14QJE1S6dGmFhoaqZs2aWrx4sV0fn376qcqXL6+QkBA1adJE8+fPl5+fn86cOSMp623pY8aMUa1atTRnzhzFx8crIiJCjz32mK5cuaJJkyapSJEiiouL07hx4+zGOXPmjPr376/Y2FhFRUWpadOm2r59u9v1GzJkiOrXr6+SJUvqtttu04gRI7RhwwZdunTJaf3U1FQlJSXZ/QAAAAAAAAC4+gJz0njHjh1av369SpYsaSubMGGC3nnnHc2cOVPly5fXt99+q/vvv1+xsbFKSEjQgQMH1LFjRw0ePFj9+/fX1q1bNXToUI9j7du3TytWrNDnn39uu5py//79qlChgr755hutX79effv2VfPmzXXrrbdKkjp16qTQ0FCtWLFC0dHRmjVrlpo1a6bdu3erQIECHsc8deqUFixYoNtuu01BQUFO60yYMEGJiYlebjEAAAAAAAAAucXn5ObSpUsVERGhy5cvKzU1Vf7+/po2bZqkv65iHD9+vFatWqUGDRpIksqUKaO1a9dq1qxZSkhI0KxZs1SxYkVNnjxZklSxYkXt2LEjy1WXjtLT0zVnzhxFRkaqSpUqatKkiXbt2qXly5fL399fFStW1MSJE/X111/r1ltv1dq1a7Vp0yadOHFCwcHBkqSXX35ZS5Ys0eLFi/XQQw+5HGv48OGaNm2azp8/r/r162vp0qUu644cOVJPPvmk7XVSUpJKlCjh3cYEAAAAAAAAkG0+JzebNGmiGTNmKCUlRVOmTFFgYKA6dOggSdq7d6/Onz+vFi1a2LVJS0tT7dq1JUm7du1SvXr17JbfcsstHsctVaqUIiMjba8LFy6sgIAA+fv725WdOHFCkrR9+3YlJyerYMGCdv1cuHBB+/btczvW008/rX79+unQoUNKTExUz549tXTpUvn5+WWpGxwcbEueAgAAAAAAALh2fE5uhoeHq1y5cpKkOXPmqGbNmnrzzTfVr18/JScnS5KWLVumm266ya5dThOAjreFZ3xju2NZenq6JCk5OVlFixbV6tWrs/SV+XmezhQqVEiFChVShQoVVLlyZZUoUUIbNmywXY0KAAAAAAAAIO/l6Jmb/v7+euaZZ/Tkk0+qe/fuqlKlioKDg3X48GElJCQ4bVOxYkUtX77crmzz5s05CcOpOnXq6Pjx4woMDFSpUqWy3U9GsjQ1NTWXIgMAAAAAAACQG3z+tnRHnTp1UkBAgF5//XVFRkZq6NChGjJkiObPn699+/Zpy5Ytmjp1qubPny9Jevjhh/XLL79o+PDh2r17tz744APNmzdPkpze9p1dzZs3V4MGDdS+fXutXLlSBw8e1Pr16/Xss8/q+++/d9pm48aNmjZtmrZt26ZDhw7pq6++Urdu3VS2bFmu2gQAAAAAAACuMzlObgYGBmrgwIGaNGmSUlJS9OKLL2rUqFGaMGGCKleurJYtW2rZsmUqXbq0JKl06dJavHixPvroI9WoUUMzZszQs88+Kynnt65n5ufnp+XLl6tRo0bq06ePKlSooK5du+rQoUMqXLiw0zZhYWH66KOP1KxZM1WsWFH9+vVTjRo19M033/BcTQAAAAAAAOA649Nt6RlXWDoaMWKERowYYXs9ePBgDR482GU/bdu2Vdu2bW2vx40bp+LFiyskJESS1Lt3b/Xu3du2fMyYMRozZozHWByfrxkZGanXXntNr732mstYMqtevbq++uorr+oCAAAAAAAAyFs5euZmdk2fPl316tVTwYIFtW7dOk2ePFkDBw7Mi1AAAAAAAAAAWFSeJDf37NmjsWPH6tSpU4qPj9dTTz2lkSNH5kUoAAAAAAAAACwqT5KbU6ZM0ZQpU/JiaAAAAAAAAAD/EDn+QiEAAAAAAAAAyAskNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJbkZ4wxeR3EP0lSUpKio6P1856Dqli2pI6dOK1icfnt6jiWZbzOXH7sxGlJspU7clfu2N7Z2K6Wu4rRFzlpm1v9O66npCzb2FO7zNvS2XZ01qezuc2o5y4+b2PKzLG9s75cvaecLfe0Xq7aOqvnGJOrmL1dX2/m29k4rmJw1tZZG2/mxdt4PLVztj879uGpjrdtvD1+eCrPzVg9tfd1Xa4Vd+O7ex9fD+vi6hjiaxtXZZLzY11ur+PV3m7u1jM7/VyN+CT3+627Y44vcXlT15vPJnexuFqeneOxN+dSmeu542n/9aa9u2OFs749xZ1R39vPU1fbyJtzNlfb0t25leO4zs4b3NV15G47OWvj6f2a03MLd+d73py75QZfzy9dnbN507+35zbuzgtdxerufNrVtnSMxZt63rR3jNFTHXd1XY2VuY0v/WZu7+2+n91jrzd/V3g6n/V0LuDqPCkvz+tywptjna+8OQ65eu952p6+HAO96cvXufR1f/Vl3/H2vDQn8fjKWSzOxvb0WZeZt+8Bb+q6GsMXzj4bXa23q89Qx98jQgIUExOts2fPKioqyu34JDdzWUZy05uNDwAAAAAAAMCeL/m1wGsU0w3HmL9+pKt/JaM7V2NsT/877c3VDZ7+p89VHXcxXattfLXH8uYqF0/tc2vb5eV71xlX/wvnax9Xe/6up23mjBViBPDP5Ok47u4qDE9XznFc8/4qV2+2F9vUd9fbNsvpOSVyX25dzefrcZD3wtXn6TPN0xxcb8cPXJ+8/Zz/p/DlUkyu3MxlGZnl3//8O7Ocv95And48LU/iuRpj5683UJJs/WaM4Vieua4jZzE51vUl7mu5ja/2WM62o6/tc2vb5eV715nM2ya7sV2L+buetpkzVogRwD+Tp+O4q+NT5nMNZ205rv3F03Zwtf2y0xeyut62WU7PKZH7cuM9kp3jIO+Fq8/TZ5qnObjejh+4Pnn7Of9PkZSUpMIFvbtyky8UAgAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFjSdZncnDdvnmJiYvI6DAAAAAAAAADXMZ+Sm71795afn5/8/PwUFBSk0qVLa9iwYbp48WKuBtWlSxft3r07V/v0xsGDB9WvXz+VLl1aoaGhKlu2rEaPHq20tLRrHgsAAAAAAAAA9wJ9bdCyZUvNnTtXly5d0g8//KBevXrJz89PEydOzLWgQkNDFRoammv9eeuXX35Renq6Zs2apXLlymnHjh168MEHlZKSopdffvmaxwMAAAAAAADANZ9vSw8ODlaRIkVUokQJtW/fXs2bN9cXX3xhW56enq4JEybYrn6sWbOmFi9ebNfHp59+qvLlyyskJERNmjTR/Pnz5efnpzNnzkjKelv6mDFjVKtWLc2ZM0fx8fGKiIjQY489pitXrmjSpEkqUqSI4uLiNG7cOLtxzpw5o/79+ys2NlZRUVFq2rSptm/f7nLdMhK3d955p8qUKaO2bdtq6NCh+uijj3zdTAAAAAAAAACuMp+v3Mxsx44dWr9+vUqWLGkrmzBhgt555x3NnDlT5cuX17fffqv7779fsbGxSkhI0IEDB9SxY0cNHjxY/fv319atWzV06FCPY+3bt08rVqzQ559/rn379qljx47av3+/KlSooG+++Ubr169X37591bx5c916662SpE6dOik0NFQrVqxQdHS0Zs2apWbNmmn37t0qUKCAV+t49uxZt3VTU1OVmppqe52UlORVvwAAAAAAAAByxufk5tKlSxUREaHLly8rNTVV/v7+mjZtmqS/En3jx4/XqlWr1KBBA0lSmTJltHbtWs2aNUsJCQmaNWuWKlasqMmTJ0uSKlasqB07dmS56tJRenq65syZo8jISFWpUkVNmjTRrl27tHz5cvn7+6tixYqaOHGivv76a916661au3atNm3apBMnTig4OFiS9PLLL2vJkiVavHixHnroIY/runfvXk2dOtXtLekTJkxQYmKiV9sOAAAAAAAAQO7xObnZpEkTzZgxQykpKZoyZYoCAwPVoUMHSX8lA8+fP68WLVrYtUlLS1Pt2rUlSbt27VK9evXslt9yyy0exy1VqpQiIyNtrwsXLqyAgAD5+/vblZ04cUKStH37diUnJ6tgwYJ2/Vy4cEH79u3zON7Ro0fVsmVLderUSQ8++KDLeiNHjtSTTz5pe52UlKQSJUp47B8AAAAAAABAzvic3AwPD1e5cuUkSXPmzFHNmjX15ptvql+/fkpOTpYkLVu2TDfddJNdu4yrJ7MrKCjI7nXGN7Y7lqWnp0uSkpOTVbRoUa1evTpLX5mf5+nMsWPH1KRJE912222aPXu227rBwcE5XjcAAAAAAAAAvsvRMzf9/f31zDPP6Mknn1T37t1VpUoVBQcH6/Dhw0pISHDapmLFilq+fLld2ebNm3MShlN16tTR8ePHFRgYqFKlSnnd7ujRo2rSpIluvvlmzZ071+7KUAAAAAAAAADXjxxn7jp16qSAgAC9/vrrioyM1NChQzVkyBDNnz9f+/bt05YtWzR16lTNnz9fkvTwww/rl19+0fDhw7V792598MEHmjdvnqS/rrzMLc2bN1eDBg3Uvn17rVy5UgcPHtT69ev17LPP6vvvv3fa5ujRo2rcuLHi4+P18ssv6+TJkzp+/LiOHz+ea3EBAAAAAAAAyB05Tm4GBgZq4MCBmjRpklJSUvTiiy9q1KhRmjBhgipXrqyWLVtq2bJlKl26tCSpdOnSWrx4sT766CPVqFFDM2bM0LPPPisp57euZ+bn56fly5erUaNG6tOnjypUqKCuXbvq0KFDKly4sNM2X3zxhfbu3asvv/xSxYsXV9GiRW0/AAAAAAAAAK4vPt2WnnGFpaMRI0ZoxIgRtteDBw/W4MGDXfbTtm1btW3b1vZ63LhxKl68uEJCQiRJvXv3Vu/evW3Lx4wZozFjxniMxfH5mpGRkXrttdf02muvuYwlM8dxAQAAAAAAAFy/cvTMzeyaPn266tWrp4IFC2rdunWaPHmyBg4cmBehAAAAAAAAALCoPElu7tmzR2PHjtWpU6cUHx+vp556SiNHjsyLUAAAAAAAAABYVJ4kN6dMmaIpU6bkxdAAAAAAAAAA/iFy/IVCAAAAAAAAAJAXSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsyc8YY/I6iH+SpKQkRUdH68yZs4qKipIkHTtxWsXi8udJPFdj7GMnTkuSrd+MMRzLM9d15Cwmx7q+xH0tt/HVHsvZdvS1fW5tu7x87zqTedtkN7ZrMX/X0zZzxgoxAvhn8nQcd3V8ynyu4awtx7W/eNoOrrZfdvpCVtfbNsvpOSVyX268R7JzHOS9cPV5+kzzNAfX2/ED1ydvP+f/KZKSkhQTE62zZ//Or7lCcjOXZSQ3vdn4AAAAAAAAAOz5kl8LvEYx3XCMkY7+nvV/aqS/r1ZwfO3s6kdPVzA4K8/c3tXYzuLKzDFGx2WOYzn7n0PHOJzF6axfd3VcxeZum2buz916ObZzXD9ncXpb11W8rt4fmcu8ubrF3fZ39p5yN5a7vr193zqLyV1f7raNu/hcvc88XZniaht4u39kjtNZuafxvG3n2Iev/wuXnat4ncXi6//25/R/DLNzNVde8eXKZ1fHEW/6uhrcHUN8aeOqTHJ+rLsadxNci6uxc7oeVytOb/Zbd8ccX+Ly9Wo/d1esePP+cRWru3MmX9bRl2Obp/3Xm/benBN5cxWWN+eUmX93t/08ne95Oi9114e78xl3c+W4HVytt2O5t58bzvpzxtO5hTfnhr7G5CtP55eO9dydO3nq3915uqtzYVefgY6xujufdnc+l7lvb+p5094xRk913NV1N15GG1/6dda3u3NzX/8OcDauN/PsKl5vj0XO6luVu78nPP194ek96Kx/V8dkZ+M6i9UdX+YmO3OZ3b9TMvr19vPH2+PJtTyfzByj49jefNZ5e3x0tc2cjetYPztcnZP4cizydE7oDldu5rKMzPLvf55VyWbP6PTmaZKk/PUG2uqc3jzN6evM5ZnbZfyembvyzO1dje0srswcY3Rc5jiWYzzO4nAWp7N+3dVxFZu7bZq5P3fr5djOcf2cxeltXVfxunp/ZC5zti6Zx3b83VlbV7E4G8td396+b53F5K4vd9vGXXyu3meZl7vbT1z16SnGzHE6K/c0nrftHPvwVCenbdxtT29izO643rT39Vh4rbgb39X7WHL9PrmW6+LuGOJLG1dlkvNjXW6v49Xebu7WMzv9XI34JPf7rbtjji9xeVPX0+eHL+8fV7G6O2fyZR19ObZ52n+9ae/NOZGnz1Fn9V29drd9nW1HR96cl7rrw935jLu5ctwOrtbbsdzbzw1n/Tnj6dzCm3NDX2PylafzS8d67s6dPPXv7jzd1bmwq89Ax1jdnU+7O5/L3Lc39bxp7xijpzru6robL6ONL/0669vdubmvfwc4G9ebeXYVr7fHImf1rcrd3xOe/r7w9B501r+rY7KzcZ3F6o4vc5Oduczu3ykZ/Xr7+ePt8eRank9mjtFxbG8+67w9PrraZs7GdayfHa7OSXw5Fjn+HlPnIaX+7w2vrtzkC4UAAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCWR3AQAAAAAAABgSSQ3AQAAAAAAAFgSyU0AAAAAAAAAlnRdJjfnzZunmJiYvA4DAAAAAAAAwHXMp+Rm79695efnJz8/PwUFBal06dIaNmyYLl68mKtBdenSRbt3787VPr01btw43XbbbQoLCyPBCgAAAAAAAFzHfL5ys2XLlvrtt9+0f/9+TZkyRbNmzdLo0aNzNajQ0FDFxcXlap/eSktLU6dOnfToo4/myfgAAAAAAAAAvONzcjM4OFhFihRRiRIl1L59ezVv3lxffPGFbXl6eromTJig0qVLKzQ0VDVr1tTixYvt+vj0009Vvnx5hYSEqEmTJpo/f778/Px05swZSVlvSx8zZoxq1aqlOXPmKD4+XhEREXrsscd05coVTZo0SUWKFFFcXJzGjRtnN86ZM2fUv39/xcbGKioqSk2bNtX27dvdrl9iYqKGDBmi6tWr+7ppAAAAAAAAAFxDgTlpvGPHDq1fv14lS5a0lU2YMEHvvPOOZs6cqfLly+vbb7/V/fffr9jYWCUkJOjAgQPq2LGjBg8erP79+2vr1q0aOnSox7H27dunFStW6PPPP9e+ffvUsWNH7d+/XxUqVNA333yj9evXq2/fvmrevLluvfVWSVKnTp0UGhqqFStWKDo6WrNmzVKzZs20e/duFShQICerbpOamqrU1FTb66SkpFzpFwAAAAAAAIB7Pic3ly5dqoiICF2+fFmpqany9/fXtGnTJP2V6Bs/frxWrVqlBg0aSJLKlCmjtWvXatasWUpISNCsWbNUsWJFTZ48WZJUsWJF7dixI8tVl47S09M1Z84cRUZGqkqVKmrSpIl27dql5cuXy9/fXxUrVtTEiRP19ddf69Zbb9XatWu1adMmnThxQsHBwZKkl19+WUuWLNHixYv10EMP+brqTk2YMEGJiYm50hcAAAAAAAAA7/mc3GzSpIlmzJihlJQUTZkyRYGBgerQoYMkae/evTp//rxatGhh1yYtLU21a9eWJO3atUv16tWzW37LLbd4HLdUqVKKjIy0vS5cuLACAgLk7+9vV3bixAlJ0vbt25WcnKyCBQva9XPhwgXt27fPhzV2b+TIkXryySdtr5OSklSiRIlc6x8AAAAAAACAcz4nN8PDw1WuXDlJ0pw5c1SzZk29+eab6tevn5KTkyVJy5Yt00033WTXLuPqyewKCgqye53xje2OZenp6ZKk5ORkFS1aVKtXr87SV25+C3pwcHCO1w0AAAAAAACA73L0zE1/f38988wzevLJJ9W9e3dVqVJFwcHBOnz4sBISEpy2qVixopYvX25Xtnnz5pyE4VSdOnV0/PhxBQYGqlSpUrnePwAAAAAAAIC85fO3pTvq1KmTAgIC9PrrrysyMlJDhw7VkCFDNH/+fO3bt09btmzR1KlTNX/+fEnSww8/rF9++UXDhw/X7t279cEHH2jevHmS/rryMrc0b95cDRo0UPv27bVy5UodPHhQ69ev17PPPqvvv//eZbvDhw9r27ZtOnz4sK5cuaJt27Zp27ZttqtSAQAAAAAAAFwfcpzcDAwM1MCBAzVp0iSlpKToxRdf1KhRozRhwgRVrlxZLVu21LJly1S6dGlJUunSpbV48WJ99NFHqlGjhmbMmKFnn31WUs5vXc/Mz89Py5cvV6NGjdSnTx9VqFBBXbt21aFDh1S4cGGX7Z5//nnVrl1bo0ePVnJysmrXrq3atWu7TYgCAAAAAAAAuPZ8ui094wpLRyNGjNCIESNsrwcPHqzBgwe77Kdt27Zq27at7fW4ceNUvHhxhYSESJJ69+6t3r1725aPGTNGY8aM8RiL4/M1IyMj9dprr+m1115zGYujefPmuVxPAAAAAAAAANePHD1zM7umT5+uevXqqWDBglq3bp0mT56sgQMH5kUoAAAAAAAAACwqT5Kbe/bs0dixY3Xq1CnFx8frqaee0siRI/MiFAAAAAAAAAAWlSfJzSlTpmjKlCl5MTQAAAAAAACAf4gcf6EQAAAAAAAAAOQFkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLIrkJAAAAAAAAwJJIbgIAAAAAAACwJJKbAAAAAAAAACyJ5CYAAAAAAAAASyK5CQAAAAAAAMCSSG4CAAAAAAAAsCSSmwAAAAAAAAAsieQmAAAAAAAAAEsiuQkAAAAAAADAkkhuAgAAAAAAALAkkpsAAAAAAAAALInkJgAAAAAAAABLCszrAP5pjDGSpHNJSTJX0pSUlPRX+ZU0W52k/1/m+DpzeeZ2Gb/bjeOmPHN7V2M7iyszxxgdlzmO5RiPszicxemsX3d1XMXmbptm7s/dejm2c1w/Z3F6W9dVvK7eH5nLnK1L5rEdf3fW1lUszsZy17e371tnMbnry922cRefq/dZ5uXu9hNXfXqKMXOczso9jedtO8c+PNXJaRt329ObGLM7rjftfT0WXivuxnf1PpZcv0+u5bq4O4b40sZVmeT8WJfb63i1t5u79cxOP1cjPsn9fuvumONLXN7U9fT54cv7x1Ws7s6ZfFlHX45tnvZfb9p7c07k6XPUWX1Xr91tX2fb0ZE356Xu+nB3PuNurhy3g6v1diz39nPDWX/OeDq38Obc0NeYfOXp/NKxnrtzJ0/9uztPd3Uu7Ooz0DFWd+fT7s7nMvftTT1v2jvG6KmOu7ruxsto40u/zvp2d27u698Bzsb1Zp5dxevtschZfaty9/eEp78vPL0HnfXv6pjsbFxnsbrjy9xkZy6z+3dKRr/efv54ezy5lueTmWN0HNubzzpvj4+utpmzcR3rZ4ercxJfjkWu5i4jz+aOn/GmFrz266+/qkSJEnkdBgAAAAAAAGBpR44cUfHixd3WIbmZy9LT03Xs2DFFRkbKz88vr8OxSUpKUokSJXTkyBFFRUXldTi4hpj7GxPzfuNi7m9MzPuNi7m/MTHvNy7m/sbEvN+4buS5N8bo3LlzKlasmPz93T9Vk9vSc5m/v7/HjHJeioqKuuF2CPyFub8xMe83Lub+xsS837iY+xsT837jYu5vTMz7jetGnfvo6Giv6rlPfQIAAAAAAADAdYrkJgAAAAAAAABLIrl5gwgODtbo0aMVHByc16HgGmPub0zM+42Lub8xMe83Lub+xsS837iY+xsT837jYu69wxcKAQAAAAAAALAkrtwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHctKBp06apbt26Cg4OVvv27e2W/fDDD7rjjjsUFRWlMmXK6K233rItS01NVePGjRUXF6eoqChVqlRJs2fPtmv/888/6/bbb1dYWJgqVKigTz/99FqsEryQ3XnPbMeOHcqXL1+W9sz79S0nc1+qVCmFhoYqIiJCERERiomJsVt+7NgxtW7dWuHh4YqPj9cbb7xxldcG3srJvBtjNGHCBJUqVUrh4eGqUKGCNm7caFvOPn99y+7cr1mzxravZ/z4+/tr0KBBtjrs89evnOzza9euVf369RUdHa2bbrpJI0eOVHp6um058359y8ncf/HFF6pTp44iIyNVpUoVff7553bLOd5fv1JTU/Xggw+qdOnSioyMVKVKlTRnzhzb8qSkJHXv3l1RUVEqXLiwXnzxRbv2OV2OvJHTeR81apSqV6+uwMBAPfHEE1n653h//crJ3J84cUI9evRQ8eLFFRUVpdq1a2c5nt/wc29gOR9++KH5+OOPzYABA0y7du1s5adPnzZxcXFmxowZ5vLly2bDhg0mKirKrFmzxhhjzOXLl82PP/5oLl26ZIwxZufOnSYuLs58++23xhhj0tLSTNmyZc2oUaPMhQsXzGeffWbCw8PNnj17rvk6IqvsznuGK1eumPr165vGjRvbtWfer385mfuSJUuajz/+2GXfjRo1Mn369DHJyclmw4YNJjo62qxevfoqrg28lZN5HzlypLn99tvNnj17THp6ujl48KA5duyYMYZ93gpyerzPcPz4cRMYGGjWrVtnK2Ofv37l5PyuQIECZvz48eby5cvmwIEDplSpUmbmzJm2Ppj361t2537fvn0mPDzcfPbZZ+bKlSvms88+M2FhYWbfvn3GGI7317vk5GQzatQos3fvXpOenm6+++47ExMTY/773/8aY4zp2bOnueuuu8zp06fNrl27TIkSJcz8+fNt7XO6HHkjp/M+b948s3z5cnPvvfeawYMHZ+mf4/31Kydzv2/fPjN58mRz5MgRc+XKFfPpp5+asLAws3PnTlv/N/rck9y0sNGjR9udAC1btsyUKFHCrk7v3r1Nr169nLb/6aefTOHChc2cOXOMMcasWrXKxMTEmLS0NFud1q1bm+effz7XY0f2ZXfep0yZYvr06ZOlPfNuHdmZe3fJzb179xp/f39z/PhxW9ljjz1mevbsmZthI4d8nfc///zTBAcHm127djntj33eOnL6OT9x4kRTuXJl22v2eWvIzj4vyRw9etS2vH///mbAgAHGGObdSnyd+9dff900bNjQbnnjxo3N6NGjjTEc763o3nvvNaNGjTIpKSkmX758ZvPmzbZlkyZNMo0aNTLGmBwvx/XF23nPrFevXlmSmxzvrSc7c5+hdu3a5s033zTGMPfGGMNt6f8g6enpMsZkKfvxxx/tyu655x6FhISoSpUqKly4sO69915J0o8//qiqVasqKCjIVrdWrVpZ2uP64s28Hzp0SK+++qomT56cpT3zbl3e7vMPP/ywChUqpAYNGmj58uW28h9//FFFixZV4cKFbWXM/fXP07xv2LBBwcHBWrhwoYoVK6ZSpUpp+PDhSktLk8Q+b2Xe7vMZ5syZo379+tles89bk6d5L1CggPr27as333xTly5d0r59+7Rq1Srdfffdkph3K/M0956Wc7y3losXL2rTpk2qUaOGdu3apbS0NNWqVcu2PPPc5XQ5rh++zLsnHO+tJSdzf+LECf3888+qUaOGJOZe4pmb/ygNGjRQSkqKpk2bpkuXLmndunX6+OOPlZSUZFdv6dKlSklJ0erVq9WhQweFhoZKkpKTk7M8jy8mJkbnzp27VquAbPBm3h9++GG98MILKliwYJb2zLt1eTP3b7/9tg4cOKCjR4/q8ccfV4cOHbR582ZJzL1VeZr3U6dOKSkpSXv27NHu3bv17bffasWKFZo4caIk5t3KvP2cl/56/ub+/fvVs2dPWxlzb03ezHvnzp01e/ZshYaGqly5crrnnnvUsmVLScy7lXma+xYtWmjz5s1asmSJLl++rCVLlmjdunW25cy9dRhj1L9/f5UvX1733XefkpOTFR4ersDAQFudzHOX0+W4Pvg6756wz1tHTuY+LS1NXbt2VefOnVW3bl1JzL1EcvMfpWDBgvrss8/07rvvqkiRIhoxYoT69OnjNKEVEBCghIQE/f7777ar+SIiInT27Fm7emfPnlVkZOQ1iR/Z42ne33nnHV2+fFkPPPCA0/bMu3V5s883bNhQYWFhCg4OVvfu3dWmTRt9+OGHkph7q/I07xEREZKkxMRERUREKD4+XoMHD9Znn31mW868W5Mvn/Nvvvmm2rZtq9jYWFsZc29NnuZ9165dateunaZMmaKLFy/q2LFj+vnnnzVixAhJzLuVeZr7ihUr6v3331diYqLi4uL05ptvqmvXrnafB8z99c8Yo8cee0y7du3SkiVL5O/vr4iICJ0/f16XL1+21cs8dzldjryXnXn3hH3eGnIy92lpaerYsaPCwsLsvjCIuSe5+Y9z++23a/369frzzz+1Zs0aHT9+XAkJCS7rX7p0SXv27JEk1ahRQzt37tSlS5dsy7dt26bq1atf9biRM+7mfdWqVdq4caMKFSqkQoUKadKkSVqxYoWKFCkiiXm3Ol/3eX//vw/7NWrU0LFjx3TixAlbGXNvDe7mvWbNmm7bss9bmzf7fFJSkhYtWqT+/fvblbPPW5e7ef/f//6n4sWLq2PHjgoMDFTRokXVq1cvLVu2TBLzbnWe9vl27dpp69atOnXqlD777DPt2bPHtpzj/fXPGKMBAwZo48aNWrlypaKjoyX9lbgOCgrS9u3bbXUzz11OlyNvZXfePeF4f/3LydynpaWpU6dOSktL04cffqh8+fLZljH34tvSrejSpUvmwoUL5tlnnzVt2rQxFy5cMKmpqcYYY7Zs2WIuXrxozp8/b2bPnm3i4uJsD5jfunWrWblypTl//ry5dOmSWbp0qQkLCzMLFiwwxvz9jYqjR482Fy9eNMuWLeMbFa8j2Z33U6dOmSNHjth+hgwZYu666y7z66+/GmOYdyvI7twfOnTIfPPNN+bixYsmLS3NvP/++yYkJMR89913tr4bNmxo+vXrZ1JSUszGjRtNTEzMDfWtetez7M67McY0b97c9OzZ06SkpJijR4+amjVrmrFjxxpj2OetICdzb4wxM2fONCVKlDBXrlzJ0jf7/PUru/O+f/9+Exoaaj7++GNz5coVc+LECdOiRQtz//332/pm3q9vOdnnN2/ebC5dumSSkpJMYmKiKVeunElOTjbGcLy3gscee8zUqFHD/PHHH1mWPfDAA6ZVq1bmzJkzZvfu3SY+Pt7uW7Nzuhx5JyfznpaWZi5cuGDuv/9+M3DgQHPhwgW7Lw3jeH99y+7cp6WlmXbt2plmzZqZCxcuOO37Rp97kpsWNHr0aCPJ7ichIcEY89c3KEZHR5vw8HDTokULs2PHDlu7zZs3m7p165rIyEgTFRVlatSoYWbOnGnX986dO81tt91mQkJCTLly5cySJUuu5arBjezOu7N+Mn8TpzHM+/Uuu3O/c+dOU7NmTRMeHm6io6NNvXr1zKeffmrX96+//mpatmxpwsLCTPHixc3s2bOv5arBjZzs87///rtp166diYiIMMWKFTPDhg2zO/Fln7++5fR4X69ePZffhsw+f/3Kybx/8sknpnbt2iYqKsrExcWZHj16mJMnT9qWM+/Xt5zMffPmzW3n9h06dDBHjhyxW87x/vp18OBBI8kEBweb8PBw28/DDz9sjDHm7NmzpmvXriYiIsLExsaaxMREu/Y5XY68kdN579WrV5bjRa9evWzLOd5fv3Iy96tXrzaSTEhIiF3bcePG2erc6HPvZ4zDV+wBAAAAAAAAgAXwzE0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAFhSkyZNVLlyZaWlpWVZ1qlTJ5UoUULJycl5EBkAAACuFZKbAAAAsKSZM2fqwIEDmjRpkl35559/rsWLF2vq1KmKiIjIo+gAAABwLfgZY0xeBwEAAABkR2Jiol566SXt3LlTZcqU0cWLF1WtWjVVq1ZNS5YsuWrjXrhwQaGhoVetfwAAAHiHKzcBAABgWSNHjlTJkiU1YMAASdL48eP1+++/a9q0afr11191//33q1ChQgoNDVWjRo30ww8/2LV/6623dMcdd6hAgQLKnz+/GjdurE2bNtnVGTNmjCIiIrRp0yY1aNBAISEhev3116/ZOgIAAMC1wLwOAAAAAMiufPnyadasWWrcuLHGjh2rSZMm6aWXXlJ4eLhq166tiIgITZ06VdHR0Zo6daqaNm2qPXv2KC4uTpJ08OBB9ezZU2XLllVaWpoWLlyoRo0a6ccff1SFChVs46Slpal79+4aMmSIxo8fr4IFC+bVKgMAACATbksHAACA5fXt21dz585VnTp1tGnTJr3wwgt69dVXtXv3blsiMzU1VRUqVFCXLl2yPKdTktLT05Wenq5q1arpvvvu0/jx4yX9deVmYmKi3nvvPXXp0uWarhcAAADc47Z0AAAAWN6IESMkSU899ZQCAgK0cuVKNWnSRAUKFNDly5d1+fJlBQQEKCEhQZs3b7a1+/nnn3XvvfeqcOHCCggIUFBQkHbt2qXdu3dnGePuu+++ZusDAAAA73BbOgAAACwvX758dv/+8ccf2rBhg4KCgrLULVu2rCTp3LlzuvPOOxUbG6t///vfKlmypEJCQtS/f39dvHjRrk1YWBjfvA4AAHAdIrkJAACAf5wCBQqoZcuWevHFF7MsCw4OliR99913+vXXX7V06VLVrFnTtvzs2bMqXry4XRs/P7+rGzAAAACyheQmAAAA/nGaN2+ud955R5UrV1Z4eLjTOhcuXJD099WekrR+/XodPHhQVatWvSZxAgAAIGdIbgIAAOAf58knn9SCBQuUkJCgwYMHKz4+XidPntTGjRtVrFgxDRkyRPXr11dERIQGDBigESNG6OjRoxo9erRuuummvA4fAAAAXuILhQAAAPCPU7BgQW3YsEG1atXS8OHDdeedd2rIkCE6ePCgbr31VklS4cKFtWjRIp04cULt2rXTK6+8olmzZqlcuXJ5HD0AAAC85WeMMXkdBAAAAAAAAAD4iis3AQAAAAAAAFgSyU0AAAAAAAAAlkRyEwAAAAAAAIAlkdwEAAAAAAAAYEkkNwEAAAAAAABYEslNAAAAAAAAAJZEchMAAAAAAACAJZHcBAAAAAAAAGBJJDcBAAAAAAAAWBLJTQAAAAAAAACWRHITAAAAAAAAgCX9H1wbqiH9br1wAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1600x390 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABTcAAAG/CAYAAACNGOMFAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAdUFJREFUeJzt3XmcjfX///HnLMwMs1lmBtnGvi+VpD4ZpNKGQoRsKYWSkrViKoT6KruKqKikUtkSRSFbyEfLYKzZCzNmLIN5//7oN+czZ+Ys15kZxpXH/XabG+d6b6/39b6u65x5zXXO8TPGGAEAAAAAAACAzfjndwAAAAAAAAAAkBMkNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALZHcBAAAAAAAAGBLJDcBAAAAAAAA2BLJTQAAAAAAAAC2RHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAkKfKly+vbt265XcYPktPT1etWrU0cuTI/A7FpcGDB6thw4b5HQYAAMBVheQmAADIlT179qhv376qUqWKChUqpEKFCqlGjRrq06ePtm3b5lR3xIgR8vPzk7+/vw4cOJCtr+TkZIWEhMjPz099+/Z1bN+7d6/8/Pzk5+enV1991WUcnTp1kp+fn0JDQ73GnBGHq59p06b5uAc8++233zRixAjt3bs3T/v1JOv8ChQooPLly+vpp5/WqVOnrlgcdvPRRx/pwIEDTsfelZaYmKjg4GD5+flp06ZNTmXPPPOMfvnlF3311Vd5Pm5CQoL69++vW265xTG+u2M2JSVFzzzzjEqXLq2goCBVr15dU6dOzVZvxYoV6tGjh+PaUKFCBfXs2VOHDx92qpf5/Hb189hjj3mM/dChQxoxYoS2bt2a0+m79Mcff2jgwIGqV6+ewsLCVLJkSd17773Z1iXDwYMH9dBDDykyMlLh4eFq1aqVdu/e7VTnwIEDio+P10033aQiRYqoePHiatKkiZYvX+41nscee0x+fn6677778mR+AAD8WwTmdwAAAMC+Fi5cqPbt2yswMFCdOnVS3bp15e/vrz/++EOff/65pk6dqj179qhcuXJO7YKCgvTRRx9p4MCBTts///xzj+MFBwfro48+0gsvvOC0PTU1VV9++aWCg4N9in/q1KnZkqF5fWfcb7/9pvj4eDVp0kTly5fP0769yZhfamqqVqxYoYkTJ2rz5s1avXr1ZR03ISFB/v72+xv6uHHj1KFDB0VERORbDP3791dgYKDOnz+fraxEiRJq1aqVXn/9dbVs2TJPx/3pp580YcIE1ahRQ9WrV3ebKLx06ZLuuusubdq0SX369FHlypX1zTffqHfv3jp58qSGDh3qqDto0CCdOHFC7dq1U+XKlbV7925NmjRJCxcu1NatW1WiRAlJUlRUlD744INsYy1dulRz5szRnXfe6TH2Q4cOKT4+XuXLl1e9evVyvA+yevfddzVjxgy1adNGvXv3VlJSkqZPn66bb75ZS5cuVfPmzR11U1JS1LRpUyUlJWno0KEqUKCAxo8fr7i4OG3dulXFihWTJH355ZcaM2aMWrdura5du+rixYt6//33dccdd2jmzJnq3r27y1g2bdqkWbNm+XyNAwDgmmAAAAByYNeuXaZw4cKmevXq5tChQ9nKL1y4YN566y2zf/9+x7bhw4cbSebBBx809erVy9bmjjvuMG3atDGSTJ8+fRzb9+zZ42gnyWzdutWp3Zw5c0yBAgXM/fffbwoXLuw19ow4jh8/7suUc+TTTz81ksz333+fp/2mpqa6LXM3v/bt2xtJZv369Xkay7/B5s2bjSSzfPnyfIth6dKlpmDBguaFF14wkszGjRuz1Zk/f77x8/MziYmJeTr233//bZKTk40xxowbN85IMnv27MlWb968eUaSmTFjhtP2Nm3amODgYHP06FHHtlWrVplLly451Vu1apWRZIYNG+Y1pttvv92Eh4ebs2fPeqy3ceNGI8m89957Xvv0xaZNm8zp06edtv31118mKirK3HrrrU7bx4wZYySZDRs2OLb9/vvvJiAgwAwZMsSxbfv27dnOy3Pnzplq1aqZ0qVLu4wjPT3dNGrUyPTo0cOUK1fO3HvvvbmdGgAA/yr2+5M6AAC4KowdO1apqal67733VLJkyWzlgYGBevrpp1WmTJlsZR07dtTWrVv1xx9/OLYdOXJE3333nTp27Oh2zEaNGik2NlZz58512j5nzhy1aNFCRYsWzcWM/mfbtm3q1q2bKlSooODgYJUoUUI9evTQ33//na3uwYMH9eijj6pUqVIKCgpSbGysnnzySaWlpWnWrFlq166dJKlp06aOt9muXLnS0X7KlCmqWbOmgoKCVKpUKfXp0yfbW8ebNGmiWrVq6eeff1bjxo1VqFAhpzvkrLrtttsk/fPW58zWr1+vFi1aKCIiQoUKFVJcXJzWrFmTrf3KlSt14403Kjg4WBUrVtT06dMdb4HPLOtnbs6aNUt+fn5avXq1nn76aUVFRSkyMlK9evVSWlqaTp06pS5duqhIkSIqUqSIBg4cKGOMU5/p6el68803VbNmTQUHBysmJka9evXSyZMnnept2rRJd911l4oXL66QkBDFxsaqR48eXvfNggULVLBgQTVu3Nhpe8b8du3apW7duikyMlIRERHq3r27zpw547Vfqy5cuKB+/fqpX79+qlixott6GXcLfvnll3k2tiQVLVpUYWFhXuv9+OOPkqQOHTo4be/QoYPOnTvnFFfjxo2z3cHbuHFjFS1aVL///rvHcQ4fPqzvv/9eDz74oMe7FVeuXKkGDRpIkrp37+44x2bNmuWo8+mnn+qGG25QSEiIihcvrs6dO+vgwYNe53rDDTdku7O7WLFiuu2227LFP3/+fDVo0MARiyRVq1ZNt99+u+bNm+fYVrNmTRUvXtypbVBQkO655x79+eefOn36dLY4PvjgA23fvv2q/SxYAADyG29LBwAAObJw4UJVqlQpR2/jbty4sUqXLq25c+fq5ZdfliR98sknCg0N1b333uux7cMPP6wPP/xQr732mvz8/PTXX39p2bJl+uCDD7R06VKf4jhx4oTT44CAABUpUkTffvutdu/ere7du6tEiRL69ddf9fbbb+vXX3/VunXrHMm8Q4cO6aabbtKpU6f0+OOPq1q1ajp48KDmz5+vM2fOqHHjxnr66ac1YcIEDR06VNWrV5ckx78jRoxQfHy8mjdvrieffFIJCQmaOnWqNm7cqDVr1qhAgQKO2P7++2/dfffd6tChgzp37qyYmBif5irJ8RmKRYoUcWz77rvvdPfdd+uGG27Q8OHD5e/vr/fee0/NmjXTjz/+qJtuukmStGXLFrVo0UIlS5ZUfHy8Ll26pJdffllRUVGWx3/qqadUokQJxcfHa926dXr77bcVGRmptWvXqmzZsho1apQWL16scePGqVatWurSpYujba9evTRr1ix1795dTz/9tPbs2aNJkyZpy5Ytjn117Ngx3XnnnYqKitLgwYMVGRmpvXv3ev24A0lau3atatWq5bTPM3vooYcUGxur0aNHa/PmzXr33XcVHR2tMWPGOOokJSXpwoULXscKDg7OljR78803dfLkSb3wwgse442IiFDFihW1Zs0a9e/f3+tYee38+fMKCAhQwYIFnbYXKlRIkvTzzz97/IzMlJQUpaSkZEvwZfXxxx8rPT1dnTp18livevXqevnll/XSSy/p8ccfdyTwb7nlFklyHDMNGjTQ6NGjdfToUb311ltas2aNtmzZosjISG9TzubIkSNO8aenp2vbtm0uk+g33XSTli1bptOnT3tMHh85csTxmcWZnT59WoMGDdLQoUMdb+MHAABZ5PetowAAwH6SkpKMJNO6detsZSdPnjTHjx93/Jw5c8ZRlvnt0gMGDDCVKlVylDVo0MB0797dGGPcvi193LhxZvv27UaS+fHHH40xxkyePNmEhoaa1NRU07VrV5/elp71p1y5csYY4xRzho8++shIMj/88INjW5cuXYy/v7/Ltw+np6cbY9y/Lf3YsWOmYMGC5s4773R66+6kSZOMJDNz5kzHtri4OCPJTJs2zevcMs8vISHBHD9+3Ozdu9fMnDnThISEmKioKMdb2tPT003lypXNXXfd5Yg3Y/6xsbHmjjvucGy7//77TaFChczBgwcd23bu3GkCAwNN1peU5cqVM127dnU8fu+994ykbOM0atTI+Pn5mSeeeMKx7eLFi6Z06dImLi7Ose3HH380ksycOXOcxlm6dKnT9i+++MLt27m9KV26tGnTpk227Rn7skePHk7bH3jgAVOsWDGnbRnr5O0n874xxpjDhw+bsLAwM336dGPM//aXu3nceeedpnr16j7P0SpPb0t/4403nM6/DIMHDzaSzH333eex71deecVIMitWrPBY74YbbjAlS5bM9rZ2V9y9LT0tLc1ER0ebWrVqOb21feHChUaSeemll7z2ndUPP/xg/Pz8zIsvvujYdvz4cSPJvPzyy9nqT5482Ugyf/zxh9s+d+7caYKDg80jjzySrWzAgAEmNjbWnDt3zhhjeFs6AAAu8LZ0AADgs+TkZEly+c3kTZo0UVRUlONn8uTJLvvo2LGjdu3apY0bNzr+9fSW9Aw1a9ZUnTp19NFHH0mS5s6dq1atWmW748mKzz77TN9++63jZ86cOZKkkJAQR51z587pr7/+0s033yxJ2rx5s6R/7tZasGCB7r//ft14443Z+s76Vu2sli9frrS0ND3zzDNOb9197LHHFB4erkWLFjnVDwoKcvtlI+5UrVpVUVFRKl++vHr06KFKlSppyZIljn21detW7dy5Ux07dtTff/+tv/76S3/99ZdSU1N1++2364cfflB6erouXbqk5cuXq3Xr1ipVqpSj/0qVKunuu++2HM+jjz7qtF8aNmwoY4weffRRx7aAgADdeOONTt8y/emnnyoiIkJ33HGHI8a//vrL8bbh77//XpIcd+EtXLjQ0h2Umf39999Od7Rm9cQTTzg9vu222/T33387zgVJeuONN5yOJ3c/Wb9Ia9CgQY5vEreiSJEi+uuvv3yYXd7p2LGjIiIi1KNHD3377bfau3ev3n77bU2ZMkWSdPbsWbdtf/jhB8XHx+uhhx5Ss2bN3NbbsWOHfv75Z3Xo0CFXX0y1adMmHTt2TL1793Z6a/u9996ratWqZTvHvDl27Jg6duyo2NhYpzXMmHNQUFC2NhnjutsvZ86cUbt27RQSEqLXXnvNqWzHjh166623NG7cOJd9AwCAf/C2dAAA4LOMt1empKRkK5s+fbpOnz6to0ePqnPnzm77qF+/vqpVq6a5c+cqMjJSJUqU8JjwyKxjx45644031L9/f61duzZHnz8p/fP2eFdvjz1x4oTi4+P18ccf69ixY05lSUlJkqTjx48rOTlZtWrVytHY+/btk/RPAjKzggULqkKFCo7yDNddd122twJ789lnnyk8PFzHjx/XhAkTtGfPHqfE7c6dOyVJXbt2ddtHUlKSzp07p7Nnz6pSpUrZyl1tc6ds2bJOjzO+lTzr57JGREQ4fZbmzp07lZSUpOjoaJf9ZqxRXFyc2rRpo/j4eI0fP15NmjRR69at1bFjR0vJIZPlcz49xZ6RCD158qTCw8Ml/fMZjb5at26dPvjgA61YscJyIs8Y4zV5npSU5JRQK1iwYJ58Jm2JEiX01Vdf6ZFHHnF8i3l4eLgmTpyorl27uvyDhyT98ccfeuCBB1SrVi29++67HsfI+CODt7eke+PuHJP++TzM1atXW+4rNTVV9913n06fPq3Vq1c7zTPjnHL1Dffnzp1zqpPZpUuX1KFDB/32229asmSJ0x8OJKlfv3665ZZb1KZNG8txAgBwLSK5CQAAfBYREaGSJUtq+/bt2coyPoMz4/MdPenYsaOmTp2qsLAwtW/f3nJy5+GHH9aQIUP02GOPqVixYo4kS1556KGHtHbtWj3//POqV6+eQkNDlZ6erhYtWig9PT1Px7LKVXLEm8zJ2/vvv1+1a9dWp06d9PPPP8vf398xl3HjxqlevXou+wgNDXUkaHIrICDA8vbMicb09HRFR0c7kl5ZZXzup5+fn+bPn69169bp66+/1jfffKMePXrojTfe0Lp169wm3qR/vigm65cTWYk9c5wnTpxQWlqa2z4yhISEOBK7AwcO1G233abY2FjHOZNxV+bhw4e1f//+bInVkydPev3Myn79+mn27NmOx3FxcU5fZJUbjRs31u7du/Xf//5Xqampqlu3rg4dOiRJqlKlSrb6Bw4c0J133qmIiAgtXrzY6xcXzZ07V1WrVs1RsvhySEtL04MPPqht27bpm2++yfYHjaJFiyooKEiHDx/O1jZjW9bEpfTPXdoLFy7UnDlzsv1h57vvvtPSpUv1+eefO11LL168qLNnz2rv3r0qWrSoI7EOAMC1jOQmAADIkXvvvVfvvvuuNmzY4PjSGV917NhRL730kg4fPqwPPvjAcruyZcvq1ltv1cqVK/Xkk08qMDDvXtKcPHlSK1asUHx8vF566SXH9oy7HDNERUUpPDzcZYI3M3d32JUrV06SlJCQoAoVKji2p6Wlac+ePY5vxc4roaGhGj58uLp376558+apQ4cOjm/lDg8P9zhedHS0goODtWvXrmxlrrbltYoVK2r58uW69dZbLSV5b775Zt18880aOXKk5s6dq06dOunjjz/2+LbvatWqac+ePbmK88EHH9SqVau81uvatavj27z379+vffv2KTY2Nlu9li1bKiIiQqdOnXLavmfPHtWtW9fjGAMHDnS6c9rTW+5zIiAgwCkhvnz5cknKdhz9/fffuvPOO3X+/HmtWLFCJUuW9Njv+vXrtWvXLscXjVlh5RzLmjxMSEhwlHuSnp6uLl26aMWKFZo3b57i4uKy1fH391ft2rW1adOmbGXr169XhQoVsiV0n3/+eb333nt688039fDDD2drt3//fkn/HFNZHTx4ULGxsRo/fryeeeYZr3MAAODfjuQmAADIkYEDB2ru3Lnq0aOHVqxYke3buz29xTdDxYoV9eabb+rs2bM+J0hfffVVff/992rfvr1P7bzJuEMva/xvvvmm02N/f3+1bt1aH374oTZt2pTtczcz3jpcuHBhScqWoGrevLkKFiyoCRMmqEWLFo4EzYwZM5SUlOT1W+NzolOnTnrxxRc1ZswYdejQQTfccIMqVqyo119/XR07dsx2Z+Px48cVFRWlgIAANW/eXAsWLNChQ4ccd6Ht2rVLS5YsyfM4s3rooYc0ZcoUvfLKKxo1apRT2cWLF5WSkqLIyEidPHlSkZGRTsmujAScq7cMZ9aoUSO99tprOn/+fI4/3/CNN97wePdnhsx38b399ts6c+aMU/l3332niRMn6vXXX1e1atWcypKSkpSYmKgnn3zS4xg1atRQjRo1fIg+544fP64xY8aoTp06TsnN1NRU3XPPPTp48KC+//57Va5c2Wtfc+fOlSRLn7+bwd05duONNyo6OlrTpk1Tjx49HOu6ZMkS/f77705/vHDnqaee0ieffKLp06e7TDRmaNu2rQYPHux0LUhISNB3332nAQMGONUdN26cXn/9dQ0dOlT9+vVz2V+zZs30xRdfZNv++OOPq1y5cho2bJhq167tNX4AAK4FJDcBAECOVK5cWXPnztXDDz+sqlWrqlOnTqpbt66MMdqzZ4/mzp0rf39/lS5d2mM/7n659yYuLs7lXVS5FR4ersaNG2vs2LG6cOGCrrvuOi1btszlXX2jRo3SsmXLFBcXp8cff1zVq1fX4cOH9emnn2r16tWKjIxUvXr1FBAQoDFjxigpKUlBQUFq1qyZoqOjNWTIEMXHx6tFixZq2bKlEhISNGXKFDVo0MDj55XmVIECBdSvXz89//zzWrp0qVq0aKF3331Xd999t2rWrKnu3bvruuuucySjwsPD9fXXX0uSRowYoWXLlunWW2/Vk08+qUuXLmnSpEmqVauWtm7dmuexZhYXF6devXpp9OjR2rp1q+68804VKFBAO3fu1Keffqq33npLbdu21ezZszVlyhQ98MADqlixok6fPq133nlH4eHhuueeezyO0apVK73yyitatWpVjj/mICdvo3Y1VkaSLi4uLlvSfPny5TLGqFWrVjmK0Z2kpCRNnDhRkrRmzRpJ0qRJkxQZGanIyEj17dvXUTcuLk6NGjVSpUqVdOTIEb399ttKSUnRwoULnT5aolOnTtqwYYN69Oih33//Xb///rujLDQ0VK1bt3aK4dKlS/rkk0908803O+4qtqJixYqKjIzUtGnTFBYWpsKFC6thw4aKjY3VmDFj1L17d8XFxenhhx/W0aNH9dZbb6l8+fLq37+/x37ffPNNTZkyRY0aNVKhQoX04YcfOpU/8MADjsRq79699c477+jee+/VgAEDVKBAAf3f//2fYmJi9NxzzznafPHFFxo4cKAqV66s6tWrZ+vzjjvuUExMjMqWLZvt4wgk6ZlnnlFMTEy2fQcAwDUtv76mHQAA/Dvs2rXLPPnkk6ZSpUomODjYhISEmGrVqpknnnjCbN261anu8OHDjSRz/Phxj31KMn369HE83rNnj5Fkxo0b57Fd165dTeHChb3G7C2OP//80zzwwAMmMjLSREREmHbt2plDhw4ZSWb48OFOdfft22e6dOlioqKiTFBQkKlQoYLp06ePOX/+vKPOO++8YypUqGACAgKMJPP99987yiZNmmSqVatmChQoYGJiYsyTTz5pTp486TRGXFycqVmzptd5WZlfUlKSiYiIMHFxcY5tW7ZsMQ8++KApVqyYCQoKMuXKlTMPPfSQWbFihVPbFStWmPr165uCBQuaihUrmnfffdc899xzJjg42KleuXLlTNeuXR2P33vvPSPJbNy40VKc7tbx7bffNjfccIMJCQkxYWFhpnbt2mbgwIHm0KFDxhhjNm/ebB5++GFTtmxZExQUZKKjo819991nNm3aZGm/1alTxzz66KOWYsyY0549eyz17Qt3+8sYY9q3b2/+85//5PmYGeeYq59y5co51e3fv7+pUKGCCQoKMlFRUaZjx44mMTExW5/lypWz3KcxxixdutRIMhMmTPA5/i+//NLUqFHDBAYGGknmvffec5R98sknpn79+iYoKMgULVrUdOrUyfz5559e++zatavb+F2t/YEDB0zbtm1NeHi4CQ0NNffdd5/ZuXOnU52M48ndT+ZrgyvlypUz9957r9XdAgDANcHPGAvvGQMAAABcaN26tX799ddsn0lqRx988IH69Omj/fv3KzIyMr/DyebIkSOKjY3Vxx9/nOd3bgIAANiVta8kBQAAwDXv7NmzTo937typxYsXq0mTJvkTUB7r1KmTypYtq8mTJ+d3KC69+eabql27NolNAACATLhzEwAAAJaULFlS3bp1U4UKFbRv3z5NnTpV58+f15YtWyx9WQwAAACQ1/hCIQAAAFjSokULffTRRzpy5IiCgoLUqFEjjRo1isQmAAAA8g13bgIAAAAAAACwJT5zEwAAAAAAAIAtkdwEAAAAAAAAYEt85mYeS09P16FDhxQWFiY/P7/8DgcAAAAAAACwFWOMTp8+rVKlSsnf3/O9mSQ389ihQ4dUpkyZ/A4DAAAAAAAAsLUDBw6odOnSHuuQ3MxjYWFhkqRdew4oLDzcUpuyTQZo/8rXPW4v22SAJGn/ytez1c8oyyi32q+7ck9t7SKn8btqZ3Wbq+3u2kqyHJ8v6+StbtZx3R1L3o4PqzFcqePIlzXytZ/84motXF0TMtfx9NhV/1aOK1+uT+7Gz1rmqo2ruWaN3cqx5upfK+O4itHb3Lythbd18Na3u37czcXXeN2tsbd95oq749XdXKz+62oeWePKGrOVPjzN3dPxYeUYtbIf3MXvaa3dcTUXTzFm5u6ab+X89TSWr89znvgyB09lnuJzdZ5auRbl9tyx0ren13jexvB2HHjbJ1b789S/t/3mqU8r+87V/H05lt3xtMbeno/dxWr1uSUnrL7u8vW529v1zdsY7spdxZzb+bs7j11t83Z8+DKWp3qZx/D0WsrTNclT7L7sZ3d1rKyjp+uBu3Fdzcfqc7u3ssvJl3E9rbGVa6pVnl7/ZB3L0/XI27XKVdwZ26w8H+ZEbo4Bd88Xnp4/PcWb2+uC1baeXrtmrWfl+cXbXF2xMn+r53zWONytQdY5eVqTzI/NpTSl/TbbkWfzhORmHst4K3pYeLjCLSY3/QIKuqybebtfQEFJ0smTJ5Weelg/rFrpqJeectDx/6zbMz/Out1duae2dpHT+F21s7rN1XZ3bSVZjs+XdfJWN+u4rtpn1LG6Dz3FcKWOI1/WyNd+8ourtci6bzNklHl67Kp/K8eVp2P9p7VrVKVKVcf1KUN4eHi2bZnLJLksz2iXuX3ma2PWa2XWa2TW9u7isFKeeQx3c3M1l6zlWcsy89a3u37czcXXeLPuO3dxuRonq6yxepuL1X9dzSNrXFljttKHp7l7Oj6sHKNW9oO7+D2ttTuu5uIpxsxcxZt5e07H8jauL3yZg6cyT/G5Ok+tXItye+5Y6dvdNcTdMZ+1f0/r4W2fWO3PU//e9punPq3sO1fz9+VYdsfTGns6X3xZ56zx+HruZ22fOT53rD5fZO03c30rzwfeYnAVc27n7+48drXN2/Hhy1ie6mUew9Pvep6uSZ5i92U/u6tjZR09XQ/cjetqPlaf272VXU6+jOtpja1cU63y9Pon61ierkferlWu4s7YZuX5MCdycwy4e77w9PzpKd7cXhestvX02jVrPSvPL97m6oqV+Vs957PG4W4Nss7J05q4amvlIx9JbtqEuXhOfsfWqWP7dYq+lKzRI192lJXQacf/s27P/DjrdnflntraRU7jd9XO6jZX2921lWQ5Pl/WyVvdrOO6ap9Rx+o+9BTDlTqOfFkjX/vJL67WIuu+zZBR5umxq/6tHFeejvWXR7z4z4ODZ2Sib5ZfgUI+zhIAAAAAgNwhuWkDxhjp6E+qWjZcY8aMVEjkdbq5fhVH+Zbf9zv+X796WaftmR9n3e6u3FNbu8hp/K7aWd3maru7tpIsx+fLOnmrm3VcV+0z6ljdh55iuFLHkS9r5Gs/+cXVWmTdtxkyyjw9dtW/lePK07FerXyUNm3apOcHDdP23WtlSt3OF6kBAAAAAK4okps2kLhrl0IDzqhvv3g1a9ZMW37f75RA8PR/V4mGjO3uyj21tYucxu+qndVtrra7a5v535zE5Mt4nsZ11T7zdisxeorhSh1HvqyRr/3kF1drkXXfZq5rZV2z9m/luPJ0rBcqVEiNGzfWU/0H6rn+/ZR87oT8QorlYLYAAAAAAOSM5+9Sx1Xht99+VUhwQdWqXS+/QwGAbKrXrK3wsEIy5/7O71AAAAAAANcYkps2kJaWpoIFCqhAwSv/ocoA4I2/v7+CCgZJJj2/QwEAAAAAXGNIbuKa0r17N82aNSu/w/hXe7xbe61cuTLP+gsPC9V///tfSVL8iBF64IHWjrIAfz9t3bo1z8ZCLlwlb+cHAAAAAFxbSG7aWLOmTRQSHKTbbqyuxg1q6KGWzfXpp586yg8dPKAAfz+dOnXKsW3//v0aMfQ5lb6ulBo3qKEqlSvp6aee0uHDhy2N+cbrr6te3TqKjAhX2TKl9fyAAUpLS3Oqs2bNGt32n1sVHhaqEjHRGv7SS5Kk8+fP6/HHHlPFCrGKCA9TjerVNHPmTJdzCg8LdfwcOnTIUf7zzz+r8W3/UWREuCpVrKD333/ft52WQ4/26KEAfz/9/vvvTttXrlypokUinbZt375d7dq1VUx0lOJuqqmaNarrxRdeUFJSkqWxBj7/vKpXq6qI8DBVrBCr996Z7FTevXs3BQcVVHhYqG67sbrCw0L1008/OconT5qkmxrcqJDgIKdEYFZHjx5Vs0Z1dH39ek7b1639UTfecL0aN6ihWjVraOnSpZbizqn169fr9mZNVaxoERUtEql6des4JaCTT6eodu3alzWGnKgQW14LFixw2nalkq3Tp0/Xvbc30n9urKZ+T3bzev5Onz5d5cuVVVhoYd13371O9V2d0xeynNPSP19s1vi2/2S7pgAAAAAAkJ9Ibtrca6+N0Y+bfteqDb/q6eeG6JHOnbRv3z6Xdffv36+GNzVQYGCgVq9Zq1UbftWPq9eoZMmSWrVqlaXxLl26pHfenaHjf/2ttT+t06pVKxU/YoSjfNu2bWrz4AN6bsDz+uvvE0rcvUdt2raVJF28eFElS5bUsm+X61RSsma+N0vPD3hOy5Ytyzan5NMpjp9SpUpJkk6dOqX77r1HHTt11t8nTmrO3I/U7+mntHr16hzsOetSU1P06afzVLRoUc2cMcNj3T9++69uvaWRqlWtpi1bf9GqDb9q8ZKlOnfunLZt22ZpvODgYM3/7HOdOHlKixYv0efz5urtt992qvPkk72VfDpFP276XcmnU9SoUSNHWclSpTR02Avq2fMxj+M89VRfVa1e02nbnwf26/mnH9eI+Je1cv12vTZmrNq1baPdu3dbit1Xp0+f1j13t1C7h9rryNFjOnrsuN55d4aio6Mvy3j/Bt99952GDB6kMeOn6NsfNqtoseJ6pHMnt/U3rlujIYMH6ZN5n+rI0WOKiY5xqu/qnH57ypvZ+pk6ZYqCgoIux5QAAAAAAMgxkpv/En5+fvpP3O2KjIxUQkKCyzojRgxX7dq19cLLY1S+fHn5+fkpJiZGQ4YOVYcOHSyNM3DQIDVo0EAFChRQ6dKl9cgjXbRmzf+Si6+++ooefbSnWrdurYIFC6pw4cKqU6eOJKlw4cKKf/llVaxYUX5+frr55pvVpGlTrbGYnFy7dq2CgoL0xBNPKCAgQA0bNtQDDz6oGTPetdQ+p75d8rUKFy6s0a+N0YcffqALFy64rTt+7Kt66KH2euXVVx1J2XLlymnc66/rtttuszTey6+8opo1ayogIEDVqlVT0+Z3Oe1jbx588EG1bt1axYsXd1vnyy+/1MkTJ3TP/Q86bf9p9UpVq1FL9913n/z9/XXffffppptu0geX6Q7ZhIQEpaam6vHHH1eBAgVUoEABNWjQQPfcc4+jjre7IdetW6eHWt2hyIhwtWrV0ukO2U2bNum2/9yqokUiVatmDX300UeOsu7du6n/M884Hp86dUo31iynvXv3SvrnTsWJEyaoRvVqKlokUs2aNnHcufvQQ+20f/9+der4sMLDQvXkE0/o5oY3SZL+c+stCg8L1ehRoyRJiYmJatnyfsVERym2fDmNfPVVpafn/LMpZ816T506dVatOvUVUqiQ+j4zSKtWrdKfB/a7rP/Vgk/VqVNnNWzYUIULF9ao0aOd6rs6p7du3ujUx4EDBzR+/P/ptTFjcxw3AAAAAACXA8nNf4n09HSt/G6Zzp49q3r16rmss+ybb9S+w8Me+xnz2mu6//77LI+76odVql27juPxD6tWKS0tTdfXr6eY6CjdfXcLt8nWc+fOaeOGDapdp47T9pEjX1XxYkV1w/X1nd52np6eLmOMU9309HT91+IdkTn15eefqGPHTurQoYNSU1P19ddfu6x35swZbd28UR0e9ryPX3t5mF57eZilsY0x2vLzBtWp7byPPvjgfRUvVlQPtWyu/3vjDZ+SZUlJSRrw3LOaMnVatjJ3+3jbfy/PPq5SpYoiIiL08MMd9OWXX+rIkSM+9zH/03maNvMj7d23Xwf//FNvjh8vSTqdnKR77m6h9u076Oix45o8Zap6Pf6Y1qxZY6nfaVOnaubMGfryq6917PhfeuCBB9Wq5f1KS0vTvHmfqmzZspoz9yMln07R1GnTtG79BknS6jVrlXw6RUOGDtWZM2d0R/PbdXuz23Xgz4Na9cOP+uSTj/Xee+85xilaJNKnu4//u22b6mY6x4sVj1KJEiW0a+cfLuvvSvjDqX5MTIzH+qt+WKVKVao5bevd+0m9NHyEihUrZjlOAAAAAACuBJKbNjd06BA1ubm2bruxmgb266Vhw15w+5be48eP67rrrvPY36DBg/X11wstjf3OO+9o7Zo1Gjrsf4m6EydO6JNPPtb7H3yo/Qf+VN06dfVA61a6ePGiU1tjjB57rKcqV66sBx/8392DI0eN1s5diTp85KhGjX5N/Z5+Sl988YUkqVGjRkpNTdXkSZN04cIFrVmzRgu++ELJycmW4s2J3377Tf/9ZYu6dO2q0NBQtX7gAc2c6fqt6SdPntSlS5e87uPBL43U4JdGWhr/xRde0LmzZ/XEk086tj311NP6/Y8EHT12XC++MlYTJrylCW+9ZXlOgwYOVNeu3VS5cuVsZQ1vuU2/bd+mBQsW6OLFi1qwYIHWrFmj05dpH4eHh2vN2p9UtEhRDXjuWZW+rpQa3dxQmzdvttzHgOcHqmix4oqMjNSDD7bRz5t/liSt/uE7RUVFqe9TT6lAgQKKi4vTww931PuzZ1vqd8qUyRoR/7IqV66swMBAPfX00zp79qzWr19vObZFixapSJEi6vfMMypYsKDKli2rp57up48/muuoc+LkKf3nP/+x3GdKSooiIyOdtkVGRupMaorL+mfOplqun3FOP9qrr2Pb0kVf6vy5c3rkkUcsxwgAAAAAwJVCctPmRo0arZXr/qs1m3fos4Xf6/33Z2v69Oku6xYvXlwHDx7Mk3HnzJmjl158QUu/WaaSJUs6toeGhqpbt+6qVauWgoKCFP/yy9q1a5d27NjhqGOMUZ/evbUjIUGff7FA/v7/OwwbNWqkiIgIFShQQHfddZcef7yX5s37RJJUrFgxffnV1/roo7kqVbKEhg4ZrG7dul/Wu8lmzpihKlVrqG7dupKkLl26atk33+jY0ex3GBYpUkT+/v55to/HvPaaPvnkY01650MVLlzYsf36669XVFSUAgICVLvu9Ro0aLBjH3mz5ecNWrt2jQYOGuSyvHxsRY16Y5JeeTled952vWbOnKH2HTqo6GXcx5UqVdLUadO0c1ei9h/4UxUrVVLrVi2z3UHqTokSJRz/L1y4sFJOn5YkHT1yROXKl3eqW6FCBf158E9L/e7du1ddHumsokUiHT8nT57Un39aay9J+/bu1fbt2536eH7Ac5bvUB0VP9TxxVFPPvGEpH/OsaxfTpWUlKRChUNd9lEopLCl+pnP6eJRMZL++WPFpPFjNHnKVEvxAgAAAABwpZHc/BcpU6687r77Hi1a5PrOyzvvustyEsyTOXPm6Nn+z2jxkqWOz9PMkJEEzODn5+f02Bijvn36aMOG9Vr6zTJFRER4HCtz4lOSbr31Vq1es1bH//pbq374UUeOHlHjxnG5mI17Fy5c0IcffqB9+3arVMkSKlWyhB7p3EmXLl3S1ws+zVa/UKFCqnfDTfrk449zPfaY117T9OnTtHzFd4opUdJjXT9/66fxhnVrtHv3bpW+rpSio4pr3Kjh2r59u6Kjiju+QbtJszv18+Yt+u6nbfrqq6+1a+dOxV2mfZxVqVKlNGjQYB08eFAnTpzIVV8xJUpo3////MwMe/fuVenrSkuSQguH6syZM46yrN84XqZMGX0y71OdOHnK8ZOSekYP//+PHch6bErZj/fSZcrohhtucOrjVFKy/rv9V0tzGDp8lOOLo6ZO++djBGrXqaNfMn0G6Ym//9Lhw4dVqXI1l31UqlrNqf6xY8ey1Xd3Tm/btk3Hjx/Vrbc0UnRUcd14w/WSpMqVKmr5N4sszQEAAAAAgMuJ5Oa/yKGDB7RkyWLVrlXbZfmIEfH6ZetWjYofqv3798sYo+PHj2vsmDH65BNrSc+PPvpIz/R7WosWL1H9+vWzlfd87HHNnj1LCQkJunDhgl6Oj1flypVVpUoVSdJTfftq7do1+mbZtypSpIhT21OnTmnx4sU6c+aMLl26pBUrVmj69Gl68ME2jjpbtmzR+fPndfbsWb3zzjtatXKl+mX6Upi89NVXXyk5OVlzPl2kzVu2avOWrdqy9Re98MKL+uqLeS7vLOz//AuaN+8TjRg+3HF33p9//qnBgwbpxx9/tDTuuLFjNXXqFK347nuVK1cuW/m8efOUnJwsY4x+275NY8e85rSPLl68qHPnzunixYtKT0/XuXPnlJaWJknq1LWn/kjY4ZhPr77PqmrVqtq8Zavj4wx+275NFy9eVGpqil55+WWdOHFCXbp29Xn/WfHHH39o7Jgx2rt3r9LT03Xq1ClNnjRJVapUyfUdubfe1kzHjh3T1ClTdPHiRf3444+aO3eOHunSRZJU//rrtWzZNzp8+LBOnz6tl1+Od2rfu3cfjRj+kuMzY5OTk/Xll1/q9P+/MzQmJka7ExOd2sTExCgx07b77rtPR48e1dQpU3Tu3DldunRJCQkJWrlyZY7n1a1bd82Z86G2b9uqc2fPavJbYxUXF6fSZcq6rN+ydTvNmfOhNmzYoDNnzmjY0KFO9T2d040aNdJX36x2HC8LFy2WJK364Uf9p3GzHM8BAAAAAIC8QnLT5gYPHqTbbqyu226srp6PtNXttzfXiy+95LJuuXLltH7DRqWdP69GNzdU3E01destjXTw4EHFxf1zZ97oUaN0zz13ux3vhWFDlZycrGZNmyg8LFThYaGqXaumo7xTp07q06evbm/WVCViorXp501a8OVXCgwM1L59+zR16hQlJCQotnw5R/uMt9teuHBBr7wcr1IlS6hY0SJ67tn+ev2N/1O7du0c/U+cOEElS8QoJjpK8+d/quUrvnN8K3lemzlzhjo8/LDKV6ikEiVKOH6eevpp/XXsqL7//vtsbarXrK0fV6/R9l+3q3atmoq7qabuvKO5ChQo4LirdVT8UI2KH+p23MGDB+nIkSOqW6e24y3JmddkyuRJKl+urCLCw/TCoH568sneeva55xzlI199VYULhWjUqJFa+PXXKlwoRC3uulOSFBoaptKlSzt+wsMjHN+SHRAQIEma9OYYFS9WVPc0u1nb/rtNK7773ult8XkpLCxMW7ZuUVzj2xQZEa7q1arq+F/H9eVXrr+0yRfhERFatHiJ5sz5UFHFi+mJXo9r8pSpjs+37Ny5sxrHxalG9Wq6vn493XPPvU7t+/Ttq65du6ltmwcVGRGumjWq66NMn5U5eMhQTZ48SUWLRKpP796SpPiXX9Ez/Z5WsaJFNOa11xQaGqpl3y7Xiu9WqEJseUUVL6bOnTo6vS09PCzUcuJbkpo1a6aRo0Zr4DO91Py2+jp+7Kg++HCOo3zJwi+czskGN9+qkaNGq22bBxUTHaVDhw851Xd1Tj/UsrkkKSgoSDElSjqOl4yPAChVqpSCQ0IsxwwAAAAAwOUSmN8BIOe++36lJGnL7/sd2+pX/9/dW6WuK6NL6c53F5YrV04jRr2h+tXLasvv+53qS9KQoUM1JEufmSXu3uM1roGDBrn8TMdy5cpliyezqKgo/bTO85e1zJz5nmbOfM9jnbyy6P/fpZZ1XxQvXlxrNu9w7LsTJ085ldeuXVvz53/maJt1Hw8dPsrjuFn3UdY+Vq76wW2ZJA0fMULDR4zI1q+rNb3/gXZ6aehzTtumvDvH7fGR16677jp99JHnt/Fn3h9Z55VRljG3fs8843Qn70033aTVa9a67LdgwYKaPft9p221boxT+fL/zNnPz09P9u6tJ/9/4jKr+++/X/fff7/Ttp49e6pnz55O2ypWrOg4HlxJPu36i4A8eeKJJ9Qw7h7H45IlS+rIqX/2wd33PaChz/dzWu8nnnhCT/z/PyJkyKjv6px2d/6XL1/+f+tx+PJ9kRcAAAAAAFZx5yYAAAAAAAAAW+LOTRsIDAzUhYsXdenSpfwOxfZatWqt8lm+QRt56/5WbdnH1xhjzD+f6+rH38sAAAAAAFcWyU0bqFy5is6eS9OOP37TjbVi8zscW2vdunV+h/Cvd/8D7Rxv7ca1YU/iTp1OSZVfoYj8DgUAAAAAcI3hNhsbqFGzplIvBGra5Df1+++/u/yWbgC40owx2rFjh6ZM/D+dPucnv0JR+R0SAAAAAOAaw52bNuDn56f06Eba/OsadenyiM6eNypXOkZ+fn6SpCN/JTnqlij+vzunjvyV5PQ463Z35Z7a2kVO43fVzuo2V9vdtZVkOT5f1slb3azjumqfUcfqPvQUw5U6jnxZI1/7yS+u1iLrvs2QUebpsav+rRxXno71iNCCSk5O1h97T+pS9C3y523pAAAAAIArjOSmTfgVDFP6dXdq/FtddfvDQ9X7yVaOsv6jP3L8v0e3lk7bMz/Out1duae2dpHT+F21s7rN1XZ3bSVZjs+XdfJWN+u4rtpn1LG6Dz3FcKWOI1/WyNd+8ourtci6bzNklHl67Kp/K8eVp2N98vBHVLlKVd399Afy9wvIwSwBAAAAAMgdkps24ufnr5saNlRgserq+Xgvx/bn3/mv4/9Zt2d+nHW7u3JPbe0ip/G7amd1m6vt7tpKshyfL+vkrW7WcV21z6hjdR96iuFKHUe+rJGv/eQXV2uRdd9myCjz9NhV/1aOK0/Hepdu3SVJfn5zfZ0eAAAAAAB5gvcQAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbOmqTG7OmjVLkZGR+R0GAAAAAAAAgKuYT8nNbt26yc/PT35+fipQoIBiY2M1cOBAnTt3Lk+Dat++vXbs2JGnffrq/Pnzqlevnvz8/LR169Z8jQUAAAAAAABAdj7fudmiRQsdPnxYu3fv1vjx4zV9+nQNHz48T4MKCQlRdHR0nvbpq4EDB6pUqVL5GgMAAAAAAAAA93xObgYFBalEiRIqU6aMWrdurebNm+vbb791lKenp2v06NGKjY1VSEiI6tatq/nz5zv18dVXX6ly5coKDg5W06ZNNXv2bPn5+enUqVOSsr8tfcSIEapXr55mzpypsmXLKjQ0VL1799alS5c0duxYlShRQtHR0Ro5cqTTOKdOnVLPnj0VFRWl8PBwNWvWTL/88ovXOS5ZskTLli3T66+/7uvuAQAAAAAAAHCFBOam8fbt27V27VqVK1fOsW306NH68MMPNW3aNFWuXFk//PCDOnfurKioKMXFxWnPnj1q27at+vXrp549e2rLli0aMGCA17ESExO1ZMkSLV26VImJiWrbtq12796tKlWqaNWqVVq7dq169Oih5s2bq2HDhpKkdu3aKSQkREuWLFFERISmT5+u22+/XTt27FDRokVdjnP06FE99thjWrBggQoVKuQ1rvPnz+v8+fOOx8nJyV7bAAAAAAAAAMg9n5ObCxcuVGhoqC5evKjz58/L399fkyZNkvRPom/UqFFavny5GjVqJEmqUKGCVq9erenTpysuLk7Tp09X1apVNW7cOElS1apVtX379mx3XWaVnp6umTNnKiwsTDVq1FDTpk2VkJCgxYsXy9/fX1WrVtWYMWP0/fffq2HDhlq9erU2bNigY8eOKSgoSJL0+uuva8GCBZo/f74ef/zxbGMYY9StWzc98cQTuvHGG7V3716v+2P06NGKj4/3ZRcCAAAAAAAAyAM+JzebNm2qqVOnKjU1VePHj1dgYKDatGkjSdq1a5fOnDmjO+64w6lNWlqa6tevL0lKSEhQgwYNnMpvuukmr+OWL19eYWFhjscxMTEKCAiQv7+/07Zjx45Jkn755RelpKSoWLFiTv2cPXtWiYmJLseYOHGiTp8+rSFDhniNJ8OQIUP07LPPOh4nJyerTJkyltsDAAAAAAAAyBmfk5uFCxdWpUqVJEkzZ85U3bp1NWPGDD366KNKSUmRJC1atEjXXXedU7uMuydzqkCBAk6PM76xPeu29PR0SVJKSopKliyplStXZusr8+d5Zvbdd9/pp59+yhbrjTfeqE6dOmn27NnZ2gQFBeV6bgAAAAAAAAB8l6vP3PT399fQoUP17LPPqmPHjqpRo4aCgoK0f/9+xcXFuWxTtWpVLV682Gnbxo0bcxOGS9dff72OHDmiwMBAlS9f3lKbCRMm6NVXX3U8PnTokO666y598sknjs/xBAAAAAAAAHB18Pnb0rNq166dAgICNHnyZIWFhWnAgAHq37+/Zs+ercTERG3evFkTJ0503PXYq1cv/fHHHxo0aJB27NihefPmadasWZL+ufMyrzRv3lyNGjVS69attWzZMu3du1dr167VsGHDtGnTJpdtypYtq1q1ajl+qlSpIkmqWLGiSpcunWexAQAAAAAAAMi9XCc3AwMD1bdvX40dO1apqal65ZVX9OKLL2r06NGqXr26WrRooUWLFik2NlaSFBsbq/nz5+vzzz9XnTp1NHXqVA0bNkxS7t+6npmfn58WL16sxo0bq3v37qpSpYo6dOigffv2KSYmJs/GAQAAAAAAAJA/fHpbesYdllkNHjxYgwcPdjzu16+f+vXr57afli1bqmXLlo7HI0eOVOnSpRUcHCxJ6tatm7p16+YoHzFihEaMGOE1lqyfrxkWFqYJEyZowoQJbmPxpHz58jLG5KgtAAAAAAAAgMsrV5+5mVNTpkxRgwYNVKxYMa1Zs0bjxo1T37598yMUAAAAAAAAADaVL8nNnTt36tVXX9WJEydUtmxZPffccxoyZEh+hAIAAAAAAADApvIluTl+/HiNHz8+P4YGAAAAAAAA8C+R6y8UAgAAAAAAAID8QHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALZHcBAAAAAAAAGBLJDcBAAAAAAAA2BLJTQAAAAAAAAC2RHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALZHcBAAAAAAAAGBLJDcBAAAAAAAA2BLJTQAAAAAAAAC2RHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALfkZY0x+B/FvkpycrIiICJ06laTw8HBLbQ4dO6lS0UU8bj907KQkqVR0kWz1M8oyyq32667cU1u7yGn8rtpZ3eZqu7u2kizH58s6eaubdVx3x5K348NqDFfqOPJljXztJ7+4WgtX14TMdTw9dtW/lePKl+uTu/Gzlrlq42quWWO3cqy5+tfKOK5i9DY3b2vhbR289e2uH3dz8TVed2vsbZ+54u54dTcXq/+6mkfWuLLGbKUPT3P3dHxYOUat7Ad38Xtaa3dczcVTjJm5u+ZbOX89jeXr85wnvszBU5mn+Fydp1auRbk9d6z07ek1nrcxvB0H3vaJ1f489e9tv3nq08q+czV/X45ldzytsbfnY3exWn1uyQmrr7t8fe72dn3zNoa7clcx53b+7s5jV9u8HR++jOWpXuYxPL2W8nRN8hS7L/vZXR0r6+jpeuBuXFfzsfrc7q3scvJlXE9rbOWaapWn1z9Zx/J0PfJ2rXIVd8Y2K8+HOZGbY8Dd84Wn509P8eb2umC1rafXrlnrWXl+8TZXV6zM3+o5nzUOd2uQdU6e1iTz49Onk1W9cnklJXnPr5HczGMZyU0rOx8AAAAAAACAM1/ya4FXKKZrzqFjJxUWFu7xjoYM3v4a5+kv3JnbZ5S72+4qm345+Nq3L381zODuL4FW/iru6U4Eb3cMWFkLd4+t/PXM1Xx9+YuW1TseXPH1roesMbj6K4232K30766NpzsnPPVv9XxxNTerMfpa1+p1IWtsmbd5e+yub2/xePrrZk7/sueqjbt2vpxfVq9zVsozj+EuRitr4a5fK31b/cur1bVw9ZfSjMc5+cuwq7lYvfZ4+guvt2tv1n6yxmz1+u1u7p7m4O3a4+0a5e74trLW7riai9XzyN3zmZXz193zr7fnD2/1cvvaxMocrFwv3a2zt9cA7sazui+ytrHynOWJp+PYFzntx9PcJPev39w9P3q7rrjr08p8rI5v5Xyxeq2wEo8VvlzPPfVh5Trry7Hgbt95apMX3D03ZI4ja7kvfVtp5+k5111/vjzXWR3XSn2rr9ny4jjNi7guJ19jlDzfsZnbGHLy+ic3db21y7w9oyw3a2XlWpyT9p6e23Maj7d2Vvr3tU9fXku7a+vp9Ye38S7X2maOy9trdl9uxeTOzTyWkVkOqv2YTm1+W0Ua9NXJjZNUpEFfSXL6f4aTGydJkqOulf9n7iOjLKPc3faMdpn/vRx87dtT/axzz5B1m6s5udrPrsZytU/c7Scra+HusatxXc3H3dxccXcs5GSdPR1znrg6rqzGbqV/d21crZmV/q2eL67mZjVGX+tavS5kjS3zNm+P3fXtLR538/F2bHs6p121cdfOl/PL6nXOSnnmMdzFaGUt3PVrpW93x4C7ufgar7s19rbPXPH12uNuraxce7P2kzVmq9dvd3P3NAdv1x5v1yh3x7eVtXbH1Vysnkfuns+snL/unn+9PX94q5fb1yZW5mDleulunb29BnA3ntV9kbWNlecsTzwdx77IaT+e5ia5f/3m7vnR23XFXZ9W5mN1fCvni9VrhZV4rPDleu6pDyvXWV+OBXf7zlObvODuuSFzHFnLfenbSjtPz7nu+vPluc7quFbqW33NlhfHaV7EdTn5GqPk/jjLixhy8vonN3W9tcu8PaMsN2tl5Vqck/aenttzGo+3dlb697VPX15Lu2vr6fWHt/Eu19pmjsvba/bk5GTFFLN25yZfKAQAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALClqzK5OWvWLEVGRuZ3GAAAAAAAAACuYj4lN7t16yY/Pz/5+fmpQIECio2N1cCBA3Xu3Lk8Dap9+/basWNHnvZpVcuWLVW2bFkFBwerZMmSeuSRR3To0KF8iQUAAAAAAACAez7fudmiRQsdPnxYu3fv1vjx4zV9+nQNHz48T4MKCQlRdHR0nvZpVdOmTTVv3jwlJCTos88+U2Jiotq2bZsvsQAAAAAAAABwz+fkZlBQkEqUKKEyZcqodevWat68ub799ltHeXp6ukaPHq3Y2FiFhISobt26mj9/vlMfX331lSpXrqzg4GA1bdpUs2fPlp+fn06dOiUp+9vSR4wYoXr16mnmzJkqW7asQkND1bt3b126dEljx45ViRIlFB0drZEjRzqNc+rUKfXs2VNRUVEKDw9Xs2bN9Msvv3icX//+/XXzzTerXLlyuuWWWzR48GCtW7dOFy5c8HVXAQAAAAAAALiMAnPTePv27Vq7dq3KlSvn2DZ69Gh9+OGHmjZtmipXrqwffvhBnTt3VlRUlOLi4rRnzx61bdtW/fr1U8+ePbVlyxYNGDDA61iJiYlasmSJli5d6ribcvfu3apSpYpWrVqltWvXqkePHmrevLkaNmwoSWrXrp1CQkK0ZMkSRUREaPr06br99tu1Y8cOFS1a1OuYJ06c0Jw5c3TLLbeoQIECLuucP39e58+fdzxOTk722i8AAAAAAACA3PM5ublw4UKFhobq4sWLOn/+vPz9/TVp0iRJ/yT6Ro0apeXLl6tRo0aSpAoVKmj16tWaPn264uLiNH36dFWtWlXjxo2TJFWtWlXbt2/PdtdlVunp6Zo5c6bCwsJUo0YNNW3aVAkJCVq8eLH8/f1VtWpVjRkzRt9//70aNmyo1atXa8OGDTp27JiCgoIkSa+//roWLFig+fPn6/HHH3c71qBBgzRp0iSdOXNGN998sxYuXOi27ujRoxUfH+/TPgQAAAAAAACQez6/Lb1p06baunWr1q9fr65du6p79+5q06aNJGnXrl06c+aM7rjjDoWGhjp+3n//fSUmJkqSEhIS1KBBA6c+b7rpJq/jli9fXmFhYY7HMTExqlGjhvz9/Z22HTt2TJL0yy+/KCUlRcWKFXOKZc+ePY5Y3Hn++ee1ZcsWLVu2TAEBAerSpYuMMS7rDhkyRElJSY6fAwcOeJ0LAAAAAAAAgNzz+c7NwoULq1KlSpKkmTNnqm7dupoxY4YeffRRpaSkSJIWLVqk6667zqldxt2TOZX1beEZ39iedVt6erokKSUlRSVLltTKlSuz9ZX58zxdKV68uIoXL64qVaqoevXqKlOmjNatW+e4GzWzoKCgXM8NAAAAAAAAgO9y9Zmb/v7+Gjp0qJ599ll17NhRNWrUUFBQkPbv36+4uDiXbapWrarFixc7bdu4cWNuwnDp+uuv15EjRxQYGKjy5cvnuJ+MZGnmz9UEAAAAAAAAkP98flt6Vu3atVNAQIAmT56ssLAwDRgwQP3799fs2bOVmJiozZs3a+LEiZo9e7YkqVevXvrjjz80aNAg7dixQ/PmzdOsWbMk/XPnZV5p3ry5GjVqpNatW2vZsmXau3ev1q5dq2HDhmnTpk0u26xfv16TJk3S1q1btW/fPn333Xd6+OGHVbFiRZd3bQIAAAAAAADIP7lObgYGBqpv374aO3asUlNT9corr+jFF1/U6NGjVb16dbVo0UKLFi1SbGysJCk2Nlbz58/X559/rjp16mjq1KkaNmyYpNy/dT0zPz8/LV68WI0bN1b37t1VpUoVdejQQfv27VNMTIzLNoUKFdLnn3+u22+/XVWrVtWjjz6qOnXqaNWqVbz1HAAAAAAAALjK+PS29Iw7LLMaPHiwBg8e7Hjcr18/9evXz20/LVu2VMuWLR2PR44cqdKlSys4OFiS1K1bN3Xr1s1RPmLECI0YMcJrLFk/XzMsLEwTJkzQhAkT3MaSWe3atfXdd99ZqgsAAAAAAAAgf+XqMzdzasqUKWrQoIGKFSumNWvWaNy4cerbt29+hAIAAAAAAADApvIlublz5069+uqrOnHihMqWLavnnntOQ4YMyY9QAAAAAAAAANhUviQ3x48fr/Hjx+fH0AAAAAAAAAD+JXL9hUIAAAAAAAAAkB9IbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlP2OMye8g/k2Sk5MVERGh33fuVdWK5XTo2EmVii6iQ8dOSpLT/zOUii4iSY66Vv6fuY+Msoxyd9sz2mX+93LwtW9P9bPOPUPWba7m5Go/uxrL1T5xt5+srIW7x67GdTUfd3Nzxd2xkJN19nTMeeLquLIau5X+3bVxtWZW+rd6vriam9UYfa1r9bqQNbbM27w9dte3t3jczcfbse3pnHbVxl07X84vq9c5K+WZx3AXo5W1cNevlb7dHQPu5uJrvO7W2Ns+c8XXa4+7tbJy7c3aT9aYrV6/3c3d0xy8XXu8XaPcHd9W1todV3Oxeh65ez6zcv66e/719vzhrV5uX5tYmYOV66W7dfb2GsDdeFb3RdY2Vp6zPPF0HPsip/14mpvk/vWbu+dHb9cVd31amY/V8a2cL1avFVbiscKX67mnPqxcZ305FtztO09t8oK754bMcWQt96VvK+08Pee668+X5zqr41qpb/U1W14cp3kR1+Xka4yS++MsL2LIyeuf3NT11i7z9oyy3KyVlWtxTtp7em7PaTze2lnp39c+fXkt7a6tp9cf3sa7XGubOS5vr9mTk5MVGRmhpKQkhYeHexyT5GYey0huWtn5AAAAAAAAAJz5kl8LvEIxXXOM+ecH/3M5/qIBAAAAAICd5dfdqsDVzJecGsnNy+T8pX9+8D+VWrwoSTq5cVI+RwIAAAAAwNWhUosX+T0ZyMKXnBpfKAQAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlq7K5OasWbMUGRmZ32EAAAAAAAAAuIr5lNzs1q2b/Pz85OfnpwIFCig2NlYDBw7UuXPn8jSo9u3ba8eOHXnapxV79+7Vo48+qtjYWIWEhKhixYoaPny40tLSrngsAAAAAAAAADwL9LVBixYt9N577+nChQv6+eef1bVrV/n5+WnMmDF5FlRISIhCQkLyrD+r/vjjD6Wnp2v69OmqVKmStm/frscee0ypqal6/fXXr3g8AAAAAAAAANzz+W3pQUFBKlGihMqUKaPWrVurefPm+vbbbx3l6enpGj16tOPux7p162r+/PlOfXz11VeqXLmygoOD1bRpU82ePVt+fn46deqUpOxvSx8xYoTq1aunmTNnqmzZsgoNDVXv3r116dIljR07ViVKlFB0dLRGjhzpNM6pU6fUs2dPRUVFKTw8XM2aNdMvv/zidm4Zids777xTFSpUUMuWLTVgwAB9/vnnvu4mAAAAAAAAAJeZz3duZrZ9+3atXbtW5cqVc2wbPXq0PvzwQ02bNk2VK1fWDz/8oM6dOysqKkpxcXHas2eP2rZtq379+qlnz57asmWLBgwY4HWsxMRELVmyREuXLlViYqLatm2r3bt3q0qVKlq1apXWrl2rHj16qHnz5mrYsKEkqV27dgoJCdGSJUsUERGh6dOn6/bbb9eOHTtUtGhRS3NMSkryWPf8+fM6f/6843FycrKlfgEAAAAAAADkjs/JzYULFyo0NFQXL17U+fPn5e/vr0mTJkn6J9E3atQoLV++XI0aNZIkVahQQatXr9b06dMVFxen6dOnq2rVqho3bpwkqWrVqtq+fXu2uy6zSk9P18yZMxUWFqYaNWqoadOmSkhI0OLFi+Xv76+qVatqzJgx+v7779WwYUOtXr1aGzZs0LFjxxQUFCRJev3117VgwQLNnz9fjz/+uNe57tq1SxMnTvT4lvTRo0crPj7e0r4DAAAAAAAAkHd8Tm42bdpUU6dOVWpqqsaPH6/AwEC1adNG0j/JwDNnzuiOO+5wapOWlqb69etLkhISEtSgQQOn8ptuusnruOXLl1dYWJjjcUxMjAICAuTv7++07dixY5KkX375RSkpKSpWrJhTP2fPnlViYqLX8Q4ePKgWLVqoXbt2euyxx9zWGzJkiJ599lnH4+TkZJUpU8Zr/wAAAAAAAAByx+fkZuHChVWpUiVJ0syZM1W3bl3NmDFDjz76qFJSUiRJixYt0nXXXefULuPuyZwqUKCA0+OMb2zPui09PV2SlJKSopIlS2rlypXZ+sr8eZ6uHDp0SE2bNtUtt9yit99+22PdoKCgXM8NAAAAAAAAgO9y9Zmb/v7+Gjp0qJ599ll17NhRNWrUUFBQkPbv36+4uDiXbapWrarFixc7bdu4cWNuwnDp+uuv15EjRxQYGKjy5ctbbnfw4EE1bdpUN9xwg9577z2nO0MBAAAAAAAAXD1ynblr166dAgICNHnyZIWFhWnAgAHq37+/Zs+ercTERG3evFkTJ07U7NmzJUm9evXSH3/8oUGDBmnHjh2aN2+eZs2aJemfOy/zSvPmzdWoUSO1bt1ay5Yt0969e7V27VoNGzZMmzZtctnm4MGDatKkicqWLavXX39dx48f15EjR3TkyJE8iwsAAAAAAABA3sh1cjMwMFB9+/bV2LFjlZqaqldeeUUvvviiRo8ererVq6tFixZatGiRYmNjJUmxsbGaP3++Pv/8c9WpU0dTp07VsGHDJOX+reuZ+fn5afHixWrcuLG6d++uKlWqqEOHDtq3b59iYmJctvn222+1a9curVixQqVLl1bJkiUdPwAAAAAAAACuLn7GGJPfQYwcOVLTpk3TgQMH8juUXEtOTlZERISO/p2k8PDw/A7nqlKkQV9J0smNk/I5EgAAAAAArg5FGvTl92Qgi+TkZMUUi1BSkvf8Wq4+czOnpkyZogYNGqhYsWJas2aNxo0bp759++ZHKAAAAAAAAABsKl+Smzt37tSrr76qEydOqGzZsnruuec0ZMiQ/AgFAAAAAAAAgE3lS3Jz/PjxGj9+fH4MDQAAAAAAAOBfItdfKAQAAAAAAAAA+YHkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJZIbgIAAAAAAACwJZKbAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsKzO8A/q2CAv75wf/sWvqKJPYLAAAAAAAZdi19hd+TgSx8OSdIbl4mfn7//OB/rospkt8hAAAAAABwVeF3ZSA7X3JqJDcvE2Okg0dPqlR0ER069s+/kpz+n1nG9kPHTkqS1/pWZe7PVV8Z5VlljsVX7tpmnpPVsVztk8x9ZN1PrupmbuNqLHdrlHWbp7pWeIvN03x9kTV+V/sqg9V95su4vsTpblwrbVytk5WYss4/a11vx4KVGH2ta6VNbq8FVvrKyzFy42qJI7f+LfPIrZxeM5E7V+t57u35ztVztKvt7spdHWt5uS8u1/7LzXO/p9c37sZwt39crU/mvrLO31VbV22szs3b/nV3zORkfb0dUznh7XX3lebpNXdu18PT60mr65ST11m+xnm1cfc6NHO51XPA0+9brsZzV9dqP+7W2V07b8eandbNCk+/d1j53drT72++jOlqbE/lWWNw1e/VuFY5/Z0tv18f+fI85qpdBivnVU5+P/eUX/GWs8nJ7+beGGO9rp8xvlSHN8nJyYqIiNDRv5NU7vahOrlxkoo06KuTGydJktP/M8vYXqRBX0nyWt+qzP256iujPKvMsfjKXdvMc7I6lqt9krmPrPvJVd3MbVyN5W6Nsm7zVNcKb7F5mq8vssbval9lsLrPfBnXlzjdjWuljat1shJT1vlnrevtWLASo691rbTJ7bXASl95OUZuXC1x5Na/ZR65ldNrJnLnaj3PvT3fuXqOdrXdXbmrYy0v98Xl2n+5ee739PrG3Rju9o+r9cncV9b5u2rrqo3VuXnbv+6OmZysr7djKie8ve6+0jy95s7tenh6PWl1nXLyOsvXOK827l6HZi63eg54+n3L1Xju6lrtx906u2vn7Viz07pZ4en3Diu/W3v6/c2XMV2N7ak8awyu+r0a1yqnv7Pl9+sjX57HXLXLYOW8ysnv557yK95yNjn53dyb5ORkxRSLUFJSksLDwz3W5QuFAAAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALZHcBAAAAAAAAGBLJDcBAAAAAAAA2BLJTQAAAAAAAAC2RHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALZHcBAAAAAAAAGBLJDcBAAAAAAAA2BLJTQAAAAAAAAC2RHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALZHcBAAAAAAAAGBLJDcBAAAAAAAA2BLJTQAAAAAAAAC2RHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAAAAAANjSVZncnDVrliIjI/M7DAAAAAAAAABXMZ+Sm926dZOfn5/8/PxUoEABxcbGauDAgTp37lyeBtW+fXvt2LEjT/u0auTIkbrllltUqFAhEqwAAAAAAADAVcznOzdbtGihw4cPa/fu3Ro/frymT5+u4cOH52lQISEhio6OztM+rUpLS1O7du305JNP5sv4AAAAAAAAAKzxObkZFBSkEiVKqEyZMmrdurWaN2+ub7/91lGenp6u0aNHKzY2ViEhIapbt67mz5/v1MdXX32lypUrKzg4WE2bNtXs2bPl5+enU6dOScr+tvQRI0aoXr16mjlzpsqWLavQ0FD17t1bly5d0tixY1WiRAlFR0dr5MiRTuOcOnVKPXv2VFRUlMLDw9WsWTP98ssvHucXHx+v/v37q3bt2r7uGgAAAAAAAABXUGBuGm/fvl1r165VuXLlHNtGjx6tDz/8UNOmTVPlypX1ww8/qHPnzoqKilJcXJz27Nmjtm3bql+/furZs6e2bNmiAQMGeB0rMTFRS5Ys0dKlS5WYmKi2bdtq9+7dqlKlilatWqW1a9eqR48eat68uRo2bChJateunUJCQrRkyRJFRERo+vTpuv3227Vjxw4VLVo0N1N3OH/+vM6fP+94nJycnCf9AgAAAAAAAPDM5+TmwoULFRoaqosXL+r8+fPy9/fXpEmTJP2T6Bs1apSWL1+uRo0aSZIqVKig1atXa/r06YqLi9P06dNVtWpVjRs3TpJUtWpVbd++Pdtdl1mlp6dr5syZCgsLU40aNdS0aVMlJCRo8eLF8vf3V9WqVTVmzBh9//33atiwoVavXq0NGzbo2LFjCgoKkiS9/vrrWrBggebPn6/HH3/c16m7NHr0aMXHx+dJXwAAAAAAAACs8zm52bRpU02dOlWpqakaP368AgMD1aZNG0nSrl27dObMGd1xxx1ObdLS0lS/fn1JUkJCgho0aOBUftNNN3kdt3z58goLC3M8jomJUUBAgPz9/Z22HTt2TJL0yy+/KCUlRcWKFXPq5+zZs0pMTPRhxp4NGTJEzz77rONxcnKyypQpk2f9AwAAAAAAAHDN5+Rm4cKFValSJUnSzJkzVbduXc2YMUOPPvqoUlJSJEmLFi3Sdddd59Qu4+7JnCpQoIDT44xvbM+6LT09XZKUkpKikiVLauXKldn6ystvQQ8KCsr13AAAAAAAAAD4Llefuenv76+hQ4fq2WefVceOHVWjRg0FBQVp//79iouLc9mmatWqWrx4sdO2jRs35iYMl66//nodOXJEgYGBKl++fJ73DwAAAAAAACB/+fxt6Vm1a9dOAQEBmjx5ssLCwjRgwAD1799fs2fPVmJiojZv3qyJEydq9uzZkqRevXrpjz/+0KBBg7Rjxw7NmzdPs2bNkvTPnZd5pXnz5mrUqJFat26tZcuWae/evVq7dq2GDRumTZs2uW23f/9+bd26Vfv379elS5e0detWbd261XFXKgAAAAAAAICrQ66Tm4GBgerbt6/Gjh2r1NRUvfLKK3rxxRc1evRoVa9eXS1atNCiRYsUGxsrSYqNjdX8+fP1+eefq06dOpo6daqGDRsmKfdvXc/Mz89PixcvVuPGjdW9e3dVqVJFHTp00L59+xQTE+O23UsvvaT69etr+PDhSklJUf369VW/fn2PCVEAAAAAAAAAV55Pb0vPuMMyq8GDB2vw4MGOx/369VO/fv3c9tOyZUu1bNnS8XjkyJEqXbq0goODJUndunVTt27dHOUjRozQiBEjvMaS9fM1w8LCNGHCBE2YMMFtLFnNmjXL7TwBAAAAAAAAXD1y9ZmbOTVlyhQ1aNBAxYoV05o1azRu3Dj17ds3P0IBAAAAAAAAYFP5ktzcuXOnXn31VZ04cUJly5bVc889pyFDhuRHKAAAAAAAAABsKl+Sm+PHj9f48ePzY2gAAAAAAAAA/xK5/kIhAAAAAAAAAMgPJDcBAAAAAAAA2BLJTQAAAAAAAAC2RHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALZHcBAAAAAAAAGBLJDcBAAAAAAAA2BLJTQAAAAAAAAC2RHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALZHcBAAAAAAAAGBLJDcBAAAAAAAA2BLJTQAAAAAAAAC2RHITAAAAAAAAgC2R3AQAAAAAAABgSyQ3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALYUmN8B/NsYYyRJp5OTZS6lKTnTv5Kc/u/ULlNdSV7rW44nU3+u+soozypzLL5y1zbznKyO5WqfZO4j635yVTdzG1djuVujrNs81bXCW2ye5uuLrPG72lcZrO4zX8b1JU5341pp42qdrMSUdf5Z63o7FqzE6GtdK21yey2w0ldejpEbV0scufVvmUdu5fSaidy5Ws9zb893rp6jXW13V+7qWMvLfXG59l9unvs9vb5xN4a7/eNqfTL3lXX+rtq6amN1bt72r7tjJifr6+2Yyglvr7uvNE+vuXO7Hp5eT1pdp5y8zvI1zquNu9ehmcutngOeft9yNZ67ulb7cbfO7tp5O9bstG5WePq9w8rv1p5+f/NlTFdjeyrPGoOrfq/Gtcrp72z5/frIl+cxV+0yWDmvcvL7uaf8irecTU5+N/fmdEY8/z/P5omfsVILlv35558qU6ZMfocBAAAAAAAA2NqBAwdUunRpj3VIbuax9PR0HTp0SGFhYfLz88vvcBySk5NVpkwZHThwQOHh4fkdDq4g1v7axLpfu1j7axPrfu1i7a9NrPu1i7W/NrHu165ree2NMTp9+rRKlSolf3/Pn6rJ29LzmL+/v9eMcn4KDw+/5k4I/IO1vzax7tcu1v7axLpfu1j7axPrfu1i7a9NrPu161pd+4iICEv1+EIhAAAAAAAAALZEchMAAAAAAACALZHcvEYEBQVp+PDhCgoKyu9QcIWx9tcm1v3axdpfm1j3axdrf21i3a9drP21iXW/drH21vCFQgAAAAAAAABsiTs3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskN21o0qRJuvHGGxUUFKTWrVs7lf3888/6z3/+o/DwcFWoUEHvv/++o+z8+fNq0qSJoqOjFR4ermrVquntt992av/777/r1ltvVaFChVSlShV99dVXV2JKsCCn657Z9u3bVbBgwWztWferW27Wvnz58goJCVFoaKhCQ0MVGRnpVH7o0CHdc889Kly4sMqWLat33nnnMs8GVuVm3Y0xGj16tMqXL6/ChQurSpUqWr9+vaOcc/7qltO1//HHHx3nesaPv7+/nn76aUcdzvmrV27O+dWrV+vmm29WRESErrvuOg0ZMkTp6emOctb96pabtf/22291/fXXKywsTDVq1NDSpUudyrneX73Onz+vxx57TLGxsQoLC1O1atU0c+ZMR3lycrI6duyo8PBwxcTE6JVXXnFqn9ty5I/crvuLL76o2rVrKzAwUM8880y2/rneX71ys/bHjh1Tp06dVLp0aYWHh6t+/frZrufX/Nob2M5nn31mvvjiC9OnTx/TqlUrx/aTJ0+a6OhoM3XqVHPx4kWzbt06Ex4ebn788UdjjDEXL14027ZtMxcuXDDGGPPrr7+a6Oho88MPPxhjjElLSzMVK1Y0L774ojl79qz5+uuvTeHChc3OnTuv+ByRXU7XPcOlS5fMzTffbJo0aeLUnnW/+uVm7cuVK2e++OILt303btzYdO/e3aSkpJh169aZiIgIs3Llyss4G1iVm3UfMmSIufXWW83OnTtNenq62bt3rzl06JAxhnPeDnJ7vc9w5MgRExgYaNasWePYxjl/9crN67uiRYuaUaNGmYsXL5o9e/aY8uXLm2nTpjn6YN2vbjld+8TERFO4cGHz9ddfm0uXLpmvv/7aFCpUyCQmJhpjuN5f7VJSUsyLL75odu3aZdLT081PP/1kIiMjzTfffGOMMaZLly7mrrvuMidPnjQJCQmmTJkyZvbs2Y72uS1H/sjtus+aNcssXrzYPPDAA6Zfv37Z+ud6f/XKzdonJiaacePGmQMHDphLly6Zr776yhQqVMj8+uuvjv6v9bUnuWljw4cPd3oBtGjRIlOmTBmnOt26dTNdu3Z12f63334zMTExZubMmcYYY5YvX24iIyNNWlqao84999xjXnrppTyPHTmX03UfP3686d69e7b2rLt95GTtPSU3d+3aZfz9/c2RI0cc23r37m26dOmSl2Ejl3xd97///tsEBQWZhIQEl/1xzttHbp/nx4wZY6pXr+54zDlvDzk55yWZgwcPOsp79uxp+vTpY4xh3e3E17WfPHmyue2225zKmzRpYoYPH26M4XpvRw888IB58cUXTWpqqilYsKDZuHGjo2zs2LGmcePGxhiT63JcXayue2Zdu3bNltzkem8/OVn7DPXr1zczZswwxrD2xhjD29L/RdLT02WMybZt27ZtTtvuu+8+BQcHq0aNGoqJidEDDzwgSdq2bZtq1qypAgUKOOrWq1cvW3tcXays+759+/TWW29p3Lhx2dqz7vZl9Zzv1auXihcvrkaNGmnx4sWO7du2bVPJkiUVExPj2MbaX/28rfu6desUFBSkjz76SKVKlVL58uU1aNAgpaWlSeKctzOr53yGmTNn6tFHH3U85py3J2/rXrRoUfXo0UMzZszQhQsXlJiYqOXLl+vee++VxLrbmbe191bO9d5ezp07pw0bNqhOnTpKSEhQWlqa6tWr5yjPvHa5LcfVw5d194brvb3kZu2PHTum33//XXXq1JHE2kt85ua/SqNGjZSamqpJkybpwoULWrNmjb744gslJyc71Vu4cKFSU1O1cuVKtWnTRiEhIZKklJSUbJ/HFxkZqdOnT1+pKSAHrKx7r1699PLLL6tYsWLZ2rPu9mVl7T/44APt2bNHBw8e1FNPPaU2bdpo48aNklh7u/K27idOnFBycrJ27typHTt26IcfftCSJUs0ZswYSay7nVl9npf++fzN3bt3q0uXLo5trL09WVn3hx56SG+//bZCQkJUqVIl3XfffWrRooUk1t3OvK39HXfcoY0bN2rBggW6ePGiFixYoDVr1jjKWXv7MMaoZ8+eqly5sh588EGlpKSocOHCCgwMdNTJvHa5LcfVwdd194Zz3j5ys/ZpaWnq0KGDHnroId14442SWHuJ5Oa/SrFixfT1119r7ty5KlGihAYPHqzu3bu7TGgFBAQoLi5OR48eddzNFxoaqqSkJKd6SUlJCgsLuyLxI2e8rfuHH36oixcv6pFHHnHZnnW3Lyvn/G233aZChQopKChIHTt21P3336/PPvtMEmtvV97WPTQ0VJIUHx+v0NBQlS1bVv369dPXX3/tKGfd7cmX5/kZM2aoZcuWioqKcmxj7e3J27onJCSoVatWGj9+vM6dO6dDhw7p999/1+DBgyWx7nbmbe2rVq2qTz75RPHx8YqOjtaMGTPUoUMHp+cD1v7qZ4xR7969lZCQoAULFsjf31+hoaE6c+aMLl686KiXee1yW478l5N194Zz3h5ys/ZpaWlq27atChUq5PSFQaw9yc1/nVtvvVVr167V33//rR9//FFHjhxRXFyc2/oXLlzQzp07JUl16tTRr7/+qgsXLjjKt27dqtq1a1/2uJE7ntZ9+fLlWr9+vYoXL67ixYtr7NixWrJkiUqUKCGJdbc7X895f///Xfbr1KmjQ4cO6dixY45trL09eFr3unXremzLOW9vVs755ORkffrpp+rZs6fTds55+/K07v/9739VunRptW3bVoGBgSpZsqS6du2qRYsWSWLd7c7bOd+qVStt2bJFJ06c0Ndff62dO3c6yrneX/2MMerTp4/Wr1+vZcuWKSIiQtI/iesCBQrol19+cdTNvHa5LUf+yum6e8P1/uqXm7VPS0tTu3btlJaWps8++0wFCxZ0lLH24tvS7ejChQvm7NmzZtiwYeb+++83Z8+eNefPnzfGGLN582Zz7tw5c+bMGfP222+b6OhoxwfMb9myxSxbtsycOXPGXLhwwSxcuNAUKlTIzJkzxxjzv29UHD58uDl37pxZtGgR36h4Fcnpup84ccIcOHDA8dO/f39z1113mT///NMYw7rbQU7Xft++fWbVqlXm3LlzJi0tzXzyyScmODjY/PTTT46+b7vtNvPoo4+a1NRUs379ehMZGXlNfave1Syn626MMc2bNzddunQxqamp5uDBg6Zu3brm1VdfNcZwzttBbtbeGGOmTZtmypQpYy5dupStb875q1dO13337t0mJCTEfPHFF+bSpUvm2LFj5o477jCdO3d29M26X91yc85v3LjRXLhwwSQnJ5v4+HhTqVIlk5KSYozhem8HvXv3NnXq1DF//fVXtrJHHnnE3H333ebUqVNmx44dpmzZsk7fmp3bcuSf3Kx7WlqaOXv2rOncubPp27evOXv2rNOXhnG9v7rldO3T0tJMq1atzO23327Onj3rsu9rfe1JbtrQ8OHDjSSnn7i4OGPMP9+gGBERYQoXLmzuuOMOs337dke7jRs3mhtvvNGEhYWZ8PBwU6dOHTNt2jSnvn/99Vdzyy23mODgYFOpUiWzYMGCKzk1eJDTdXfVT+Zv4jSGdb/a5XTtf/31V1O3bl1TuHBhExERYRo0aGC++uorp77//PNP06JFC1OoUCFTunRp8/bbb1/JqcGD3JzzR48eNa1atTKhoaGmVKlSZuDAgU4vfDnnr265vd43aNDA7bchc85fvXKz7l9++aWpX7++CQ8PN9HR0aZTp07m+PHjjnLW/eqWm7Vv3ry547V9mzZtzIEDB5zKud5fvfbu3WskmaCgIFO4cGHHT69evYwxxiQlJZkOHTqY0NBQExUVZeLj453a57Yc+SO36961a9ds14uuXbs6yrneX71ys/YrV640kkxwcLBT25EjRzrqXOtr72dMlq/YAwAAAAAAAAAb4DM3AQAAAAAAANgSyU0AAAAAAAAAtkRyEwAAAAAAAIAtkdwEAAAAAAAAYEskNwEAAAAAAADYEslNAAAAAAAAALZEchMAAAAAAACALZHcBAAAAAAAAGBLJDcBAABgS02bNlX16tWVlpaWraxdu3YqU6aMUlJS8iEyAAAAXCkkNwEAAGBL06ZN0549ezR27Fin7UuXLtX8+fM1ceJEhYaG5lN0AAAAuBL8jDEmv4MAAAAAciI+Pl6vvfaafv31V1WoUEHnzp1TrVq1VKtWLS1YsOCyjXv27FmFhIRctv4BAABgDXduAgAAwLaGDBmicuXKqU+fPpKkUaNG6ejRo5o0aZL+/PNPde7cWcWLF1dISIgaN26sn3/+2an9+++/r//85z8qWrSoihQpoiZNmmjDhg1OdUaMGKHQ0FBt2LBBjRo1UnBwsCZPnnzF5ggAAAD3AvM7AAAAACCnChYsqOnTp6tJkyZ69dVXNXbsWL322msqXLiw6tevr9DQUE2cOFERERGaOHGimjVrpp07dyo6OlqStHfvXnXp0kUVK1ZUWlqaPvroIzVu3Fjbtm1TlSpVHOOkpaWpY8eO6t+/v0aNGqVixYrl15QBAACQCW9LBwAAgO316NFD7733nq6//npt2LBBL7/8st566y3t2LHDkcg8f/68qlSpovbt22f7nE5JSk9PV3p6umrVqqUHH3xQo0aNkvTPnZvx8fH6+OOP1b59+ys6LwAAAHjG29IBAABge4MHD5YkPffccwoICNCyZcvUtGlTFS1aVBcvXtTFixcVEBCguLg4bdy40dHu999/1wMPPKCYmBgFBASoQIECSkhI0I4dO7KNce+9916x+QAAAMAa3pYOAAAA2ytYsKDTv3/99ZfWrVunAgUKZKtbsWJFSdLp06d15513KioqSv/3f/+ncuXKKTg4WD179tS5c+ec2hQqVIhvXgcAALgKkdwEAADAv07RokXVokULvfLKK9nKgoKCJEk//fST/vzzTy1cuFB169Z1lCclJal06dJObfz8/C5vwAAAAMgRkpsAAAD412nevLk+/PBDVa9eXYULF3ZZ5+zZs5L+d7enJK1du1Z79+5VzZo1r0icAAAAyB2SmwAAAPjXefbZZzVnzhzFxcWpX79+Klu2rI4fP67169erVKlS6t+/v26++WaFhoaqT58+Gjx4sA4ePKjhw4fruuuuy+/wAQAAYBFfKAQAAIB/nWLFimndunWqV6+eBg0apDvvvFP9+/fX3r171bBhQ0lSTEyMPv30Ux07dkytWrXSm2++qenTp6tSpUr5HD0AAACs8jPGmPwOAgAAAAAAAAB8xZ2bAAAAAAAAAGyJ5CYAAAAAAAAAWyK5CQAAAAAAAMCWSG4CAAAAAAAAsCWSmwAAAAAAAABsieQmAAAAAAAAAFsiuQkAAAAAAADAlkhuAgAAAAAAALAlkpsAAAAAAAAAbInkJgAAAAAAAABbIrkJAAAAAAAAwJb+H6MCdgdawTzyAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1600x470 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABTcAAAH9CAYAAADPiEhiAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAfldJREFUeJzs3XmcjfX///HnbGbGrAwzdjO2yb6UpMVQlJItRChr+YSS8pHlI5QlSylkqWwVSj6lsiWKQtmyfFQGY41EYcYMZjDX749+53znnDnrzDBz8bjfbnObOdd7e13v93Vd53i5zjk+hmEYAgAAAAAAAACT8c3vAAAAAAAAAAAgJ0huAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAgT8XGxqp79+75HYbXMjMzVaNGDY0dOza/Q3FoyJAhatCgQX6HAQAAUKCQ3AQAALly+PBh9e/fX1WqVFHhwoVVuHBhVatWTf369dOePXts6o4aNUo+Pj7y9fXV8ePHs/WVkpKi4OBg+fj4qH///tbtR44ckY+Pj3x8fDRmzBiHcXTp0kU+Pj4KDQ11G7MlDkc/s2bN8nIGXPv11181atQoHTlyJE/7dcV+/wICAhQbG6vnn39e58+fv2FxmM3ixYt1/Phxm2PvRoiNjXV4LP7rX/+yqffCCy9o9+7d+vLLL/M8hsTERA0cOFB33323goKC5OPj4/SYTU1N1QsvvKAyZcooMDBQVatW1cyZM7PVW7dunXr27Gm9NlSoUEG9e/fWH3/8YVMv6/nt6Ofpp592GfvJkyc1atQo7dq1K6e779C+ffs0ePBg1alTR2FhYSpZsqRatGih7du3O6x/4sQJPf7444qMjFR4eLhat26tQ4cO2dQ5fvy4Ro8erTvvvFNFihRRsWLF1LhxY61du9ZtPE8//bR8fHz06KOP5sn+AQBws/DP7wAAAIB5LV++XB07dpS/v7+6dOmi2rVry9fXV/v27dNnn32mmTNn6vDhwypfvrxNu8DAQC1evFiDBw+22f7ZZ5+5HC8oKEiLFy/Wf/7zH5vtaWlp+uKLLxQUFORV/DNnzsyWDM3rO+N+/fVXjR49Wo0bN1ZsbGye9u2OZf/S0tK0bt06TZs2TT///LM2btx4XcdNTEyUr6/5/g990qRJ6tSpkyIiIm742HXq1NFLL71ks61KlSo2j0uUKKHWrVtr8uTJatWqVZ6O/+OPP2rq1KmqVq2aqlat6jRReO3aNT300EPavn27+vXrp8qVK+vrr79W3759de7cOQ0bNsxa9+WXX9bZs2fVoUMHVa5cWYcOHdL06dO1fPly7dq1SyVKlJAkFS9eXB9++GG2sVavXq2FCxfqwQcfdBn7yZMnNXr0aMXGxqpOnTo5ngN777//vubMmaN27dqpb9++Sk5O1uzZs3XXXXdp9erVatq0qbVuamqqmjRpouTkZA0bNkwBAQGaMmWKEhIStGvXLkVFRUmSvvjiC02YMEFt2rRRt27ddPXqVX3wwQdq1qyZ5s6dqx49ejiMZfv27Zo/f77X1zgAAG4JBgAAQA4cPHjQCAkJMapWrWqcPHkyW/mVK1eMt99+2zh27Jh128iRIw1JxmOPPWbUqVMnW5tmzZoZ7dq1MyQZ/fr1s24/fPiwtZ0kY9euXTbtFi5caAQEBBgtW7Y0QkJC3MZuiePMmTPe7HKOfPrpp4Yk47vvvsvTftPS0pyWOdu/jh07GpKMLVu25GksN4Off/7ZkGSsXbv2ho9dvnx5o0WLFh7VXbp0qeHj42MkJSXlaQx///23kZKSYhiGYUyaNMmQZBw+fDhbvSVLlhiSjDlz5thsb9eunREUFGT8+eef1m0bNmwwrl27ZlNvw4YNhiRj+PDhbmN64IEHjPDwcOPSpUsu623bts2QZMybN89tn97Yvn27ceHCBZttf/31l1G8eHHjnnvusdk+YcIEQ5KxdetW67bffvvN8PPzM4YOHWrdtnfv3mzn5eXLl43bbrvNKFOmjMM4MjMzjYYNGxo9e/b06lgBAOBWYb7/UgcAAAXCxIkTlZaWpnnz5qlkyZLZyv39/fX888+rbNmy2co6d+6sXbt2ad++fdZtp06d0rfffqvOnTs7HbNhw4aKi4vTokWLbLYvXLhQzZs3V9GiRXOxR/9nz5496t69uypUqKCgoCCVKFFCPXv21N9//52t7okTJ9SrVy+VKlVKgYGBiouL07PPPquMjAzNnz9fHTp0kCQ1adLE+jbb9evXW9vPmDFD1atXV2BgoEqVKqV+/fple+t448aNVaNGDe3YsUONGjVS4cKFbe6Q89R9990nSUpKSrLZvmXLFjVv3lwREREqXLiwEhIStGnTpmzt169frzvuuENBQUGqWLGiZs+ebX0LfFb2n7k5f/58+fj4aOPGjXr++edVvHhxRUZGqk+fPsrIyND58+f11FNPqUiRIipSpIgGDx4swzBs+szMzNRbb72l6tWrKygoSDExMerTp4/OnTtnU2/79u166KGHVKxYMQUHBysuLk49e/Z0OzfLli1ToUKF1KhRI5vtlv07ePCgunfvrsjISEVERKhHjx66ePGi2369kZGRobS0NJd1LHcLfvHFF3k6dtGiRRUWFua23g8//CBJ6tSpk832Tp066fLlyzZxNWrUKNsdvI0aNVLRokX122+/uRznjz/+0HfffafHHnvM5d2K69evV/369SVJPXr0sJ5j8+fPt9b59NNPdfvttys4OFjFihVT165ddeLECbf7evvtt2e7szsqKkr33XdftviXLl2q+vXrW2ORpNtuu00PPPCAlixZYt1WvXp1FStWzKZtYGCgHnnkEf3++++6cOFCtjg+/PBD7d27t8B+FiwAAPmN5CYAAMiR5cuXq1KlSjl6G3ejRo1UpkwZmyTlJ598otDQULVo0cJl2yeeeEIff/yxNfn1119/ac2aNS6Tos6cPXtWf/31l/XHkij75ptvdOjQIfXo0UPTpk1Tp06d9PHHH+uRRx6xSbqdPHlSd955pz7++GN17NhRU6dO1ZNPPqkNGzbo4sWLatSokZ5//nlJ0rBhw/Thhx/qww8/VNWqVSX9kzjr16+fSpUqpTfeeEPt2rXT7Nmz9eCDD+rKlSs2sf799996+OGHVadOHb311ltq0qSJ1/tr+QzFIkWKWLd9++23atSokVJSUjRy5EiNGzdO58+f1/3336+tW7da6+3cuVPNmzfX33//rdGjR6tXr1569dVXtWzZMo/Hf+6553TgwAGNHj1arVq10rvvvqsRI0aoZcuWunbtmsaNG6d7771XkyZNyvY25T59+ujf//637rnnHr399tvq0aOHFi5cqIceesg6V6dPn9aDDz6oI0eOaMiQIZo2bZq6dOmin376yW1smzdvVo0aNRQQEOCw/PHHH9eFCxc0fvx4Pf7445o/f75Gjx5tUyc5OdnmeHL2k5qamq3/b7/9VoULF1ZoaKhiY2P19ttvO4wjIiJCFStWdJh8vhHS09Pl5+enQoUK2WwvXLiwJGnHjh0u26empio1NTVbgs/exx9/rMzMTHXp0sVlvapVq+rVV1+VJD3zzDPWc8ySpJ4/f74ef/xx+fn5afz48Xr66af12Wef6d57783x58+eOnXKJv7MzEzt2bNHd9xxR7a6d955p5KSkhwmLe37tHxmcVYXLlzQyy+/rGHDhlnfxg8AAOzk852jAADAhJKTkw1JRps2bbKVnTt3zjhz5oz15+LFi9ayrG+XHjRokFGpUiVrWf369Y0ePXoYhmE4fVv6pEmTjL179xqSjB9++MEwDMN45513jNDQUCMtLc3o1q2bV29Lt/8pX768YRiGTcwWixcvNiQZ33//vXXbU089Zfj6+hrbtm3LVj8zM9MwDOdvSz99+rRRqFAh48EHH7R56+706dMNScbcuXOt2xISEgxJxqxZs9zuW9b9S0xMNM6cOWMcOXLEmDt3rhEcHGwUL17c+pb2zMxMo3LlysZDDz1kjdey/3FxcUazZs2s21q2bGkULlzYOHHihHXbgQMHDH9/f8P+JWX58uWNbt26WR/PmzfPkJRtnIYNGxo+Pj7Gv/71L+u2q1evGmXKlDESEhKs23744QdDkrFw4UKbcVavXm2z/fPPPzckOVwPd8qUKWO0a9cu23bLXPbs2dNme9u2bY2oqCibbZZ1cveTdW4M45+5nTBhgrFs2TJjzpw5xn333WdIMgYPHuww1gcffNCoWrWq1/voKVdvS3/jjTdszj+LIUOGGJKMRx991GXfr732miHJWLdunct6t99+u1GyZMlsb2t3xNnb0jMyMozo6GijRo0aNm9tX758uSHJeOWVV9z2be/77783fHx8jBEjRli3nTlzxpBkvPrqq9nqv/POO4YkY9++fU77PHDggBEUFGQ8+eST2coGDRpkxMXFGZcvXzYMw7uPMAAA4FbBFwoBAACvpaSkSJLDbyZv3Lixdu/ebX08adIkDRo0KFu9zp07a/Lkydq2bZuKFCmibdu2ady4cW7Hrl69umrVqqXFixfr3nvv1aJFi9S6detsdzx54r///a/Cw8Otj4ODg21+S9Lly5eVmpqqu+66S5L0888/67777lNmZqaWLVumli1bOrxjy/6t2vbWrl2rjIwMvfDCCzZv3X366ac1bNgwrVixwubLRQIDA51+2Ygz8fHxNo9r1qypefPmWedq165dOnDggP7zn/9ke8v9Aw88oA8//FCZmZkyDENr165V27ZtVapUKWudSpUq6eGHH9ZXX33lUTy9evWymZcGDRroxx9/VK9evazb/Pz8dMcdd9jcAfjpp58qIiJCzZo1019//WXdbnnb8HfffafOnTsrMjJS0j93FdeuXdvpXZiO/P333zZ3tNqz/+by++67T59//rlSUlKsx9Abb7yR7W3yjmSdQ0nZvv28R48eevjhh/Xmm2/queeeU5kyZWzKixQpop07d7od53ro3LmzXn31VfXs2VPvvPOOKleurDVr1mjGjBmSpEuXLjlt+/3332v06NF6/PHHdf/99zutt3//fu3YsUMDBw7M1RdTbd++XadPn9aoUaNs3treokUL3XbbbVqxYkW2u29dOX36tDp37qy4uDibL0Oz7HNgYGC2NpZxnc3LxYsX1aFDBwUHB+v111+3Kdu/f7/efvttLV682GHfAADgHyQ3AQCA1yyfzefo7bWzZ8/WhQsX9Oeff6pr165O+6hbt65uu+02LVq0SJGRkSpRooTLhEdWnTt31htvvKGBAwdq8+bNOfr8Semft8c7envs2bNnNXr0aH388cc6ffq0TVlycrIk6cyZM0pJSVGNGjVyNPbRo0clZU9AFipUSBUqVLCWW5QuXTrbW4HdsSRvz5w5o6lTp+rw4cM2idsDBw5Ikrp16+a0j+TkZF2+fFmXLl1SpUqVspU72uZMuXLlbB5bvpXc/nNZIyIibJKEBw4cUHJysqKjox32a1mjhIQEtWvXTqNHj9aUKVPUuHFjtWnTRp07d/YoOWTYfc6nq9gtidBz585Zk5u333672zE84ePjo4EDB+rrr7/W+vXrs51HhmG4TZ4nJyfbJNQKFSqUJ59JW6JECX355Zd68sknrd9iHh4ermnTpqlbt24O/8NDkvbt26e2bduqRo0aev/9912OsXDhQkly+5Z0d5ydY9I/n4e5ceNGj/tKS0vTo48+qgsXLmjjxo02+2k5p9LT07O1u3z5sk2drK5du6ZOnTrp119/1apVq7IlvQcMGKC7775b7dq18zhOAABuRSQ3AQCA1yIiIlSyZEnt3bs3W5nlMzgtn+/oSufOnTVz5kyFhYWpY8eOHt+l9cQTT2jo0KF6+umnFRUVZU2y5JXHH39cmzdv1r///W/VqVNHoaGhyszMVPPmzZWZmZmnY3nKUXLEnazJ25YtW6pmzZrq0qWLduzYIV9fX+u+TJo0SXXq1HHYR2hoqDVBk1t+fn4eb8+aaMzMzFR0dLQ16WWvePHikv5JCi5dulQ//fSTvvrqK3399dfq2bOn3njjDf30009OE2/SP18U4+quS2exZ43z7NmzysjIcNqHRXBwsDWx64wl4Xv27NlsZefOnXP7mZUDBgzQggULrI8TEhJsvsgqNxo1aqRDhw7pf//7n9LS0lS7dm2dPHlSklSlSpVs9Y8fP64HH3xQERERWrlypdsvLlq0aJHi4+PzLFmcWxkZGXrssce0Z88eff3119n+Q6No0aIKDAzUH3/8ka2tZZt94lL65y7t5cuXa+HChdn+Y+fbb7/V6tWr9dlnn9lcS69evapLly7pyJEjKlq0qM2d5wAA3KpIbgIAgBxp0aKF3n//fW3dulV33nlnjvro3LmzXnnlFf3xxx/ZvkDGlXLlyumee+7R+vXr9eyzz8rfP+9e0pw7d07r1q3T6NGj9corr1i3W+5ytChevLjCw8MdJnizcnaHXfny5SVJiYmJqlChgnV7RkaGDh8+bP1W7LwSGhqqkSNHqkePHlqyZIk6deqkihUrSvrnzjtX40VHRysoKEgHDx7MVuZoW16rWLGi1q5dq3vuucejJO9dd92lu+66S2PHjtWiRYvUpUsXffzxx+rdu7fTNrfddpsOHz6cqzgfe+wxbdiwwW29bt262XybtyOHDh2S9H+J26wOHz6s2rVru2w/ePBgmzs+Xb3lPif8/PxsEuJr166VpGzH0d9//60HH3xQ6enpWrdunUqWLOmy3y1btujgwYPWLwnyhCfnmH3yMDEx0VruSmZmpp566imtW7dOS5YsUUJCQrY6vr6+qlmzprZv356tbMuWLapQoUK2hO6///1vzZs3T2+99ZaeeOKJbO2OHTsm6Z9jyt6JEycUFxenKVOm6IUXXnC7DwAA3OxIbgIAgBwZPHiwFi1apJ49e2rdunWKiYmxKXf1Fl+LihUr6q233tKlS5e8TpCOGTNG3333nTp27OhVO3csd+jZx//WW2/ZPPb19VWbNm300Ucfafv27dk+d9Py1uGQkBBJyvbNzE2bNlWhQoU0depUNW/e3JqgmTNnjpKTk91+a3xOdOnSRSNGjNCECRPUqVMn3X777apYsaImT56szp07Z7uz8cyZMypevLj8/PzUtGlTLVu2TCdPnrTehXbw4EGtWrUqz+O09/jjj2vGjBl67bXXsn0u69WrV5WamqrIyEidO3dOkZGRNskuSwLO0VuGs2rYsKFef/11paen5/jzDXPymZtnz55VRESEzZ2hV65c0euvv65ChQqpSZMmNm2Tk5OVlJSkZ5991uUY1apVU7Vq1bzcg5w5c+aMJkyYoFq1atkkN9PS0vTII4/oxIkT+u6771S5cmW3fS1atEjSP//x4Sln59gdd9yh6OhozZo1Sz179rSu66pVq/Tbb7/Z/OeFM88995w++eQTzZ4922Gi0aJ9+/YaMmSIzbUgMTFR3377bbbPHJ40aZImT56sYcOGacCAAQ77u//++/X5559n2/7MM8+ofPnyGj58uGrWrOk2fgAAbgUkNwEAQI5UrlxZixYt0hNPPKH4+Hh16dJFtWvXlmEYOnz4sBYtWiRfX99sX4Ziz9k/7t1JSEhweBdVboWHh6tRo0aaOHGirly5otKlS2vNmjUO7+obN26c1qxZo4SEBD3zzDOqWrWq/vjjD3366afauHGjIiMjVadOHfn5+WnChAlKTk5WYGCg7r//fkVHR2vo0KEaPXq0mjdvrlatWikxMVEzZsxQ/fr1XX5eaU4FBARowIAB+ve//63Vq1erefPmev/99/Xwww+revXq6tGjh0qXLm1NRoWHh1u/LGjUqFFas2aN7rnnHj377LO6du2apk+frho1amjXrl15HmtWCQkJ6tOnj8aPH69du3bpwQcfVEBAgA4cOKBPP/1Ub7/9ttq3b68FCxZoxowZatu2rSpWrKgLFy7ovffeU3h4uB555BGXY7Ru3VqvvfaaNmzYkOOPOcjJ26i//PJLjRkzRu3bt1dcXJzOnj2rRYsWae/evRo3bpxKlChhU3/t2rUyDEOtW7fOUYzOJCcna9q0aZKkTZs2SZKmT5+uyMhIRUZGqn///ta6CQkJatiwoSpVqqRTp07p3XffVWpqqpYvX27z0RJdunTR1q1b1bNnT/3222/67bffrGWhoaFq06aNTQzXrl3TJ598orvuust6V7EnKlasqMjISM2aNUthYWEKCQlRgwYNFBcXpwkTJqhHjx5KSEjQE088oT///FNvv/22YmNjNXDgQJf9vvXWW5oxY4YaNmyowoUL66OPPrIpb9u2rTWx2rdvX7333ntq0aKFBg0apICAAL355puKiYnRSy+9ZG3z+eefa/DgwapcubKqVq2arc9mzZopJiZG5cqVy/Y5r5L0wgsvKCYmJtvcAQBwS8uvr2kHAAA3h4MHDxrPPvusUalSJSMoKMgIDg42brvtNuNf//qXsWvXLpu6I0eONCQZZ86ccdmnJKNfv37Wx4cPHzYkGZMmTXLZrlu3bkZISIjbmN3F8fvvvxtt27Y1IiMjjYiICKNDhw7GyZMnDUnGyJEjbeoePXrUeOqpp4zixYsbgYGBRoUKFYx+/foZ6enp1jrvvfeeUaFCBcPPz8+QZHz33XfWsunTpxu33XabERAQYMTExBjPPvusce7cOZsxEhISjOrVq7vdL0/2Lzk52YiIiDASEhKs23bu3Gk89thjRlRUlBEYGGiUL1/eePzxx41169bZtF23bp1Rt25do1ChQkbFihWN999/33jppZeMoKAgm3rly5c3unXrZn08b948Q5Kxbds2j+J0to7vvvuucfvttxvBwcFGWFiYUbNmTWPw4MHGyZMnDcMwjJ9//tl44oknjHLlyhmBgYFGdHS08eijjxrbt2/3aN5q1apl9OrVy6MYLft0+PBhj/p2Zvv27UbLli2N0qVLG4UKFTJCQ0ONe++911iyZInD+h07djTuvffeXI3piOUcc/RTvnx5m7oDBw40KlSoYAQGBhrFixc3OnfubCQlJWXrs3z58h73aRiGsXr1akOSMXXqVK/j/+KLL4xq1aoZ/v7+hiRj3rx51rJPPvnEqFu3rhEYGGgULVrU6NKli/H777+77bNbt25O43e09sePHzfat29vhIeHG6Ghocajjz5qHDhwwKaO5Xhy9pP12uBI+fLljRYtWng6LQAA3BJ8DMOD94wBAAAADrRp00a//PJLts8kNaMPP/xQ/fr107FjxxQZGZnf4WRz6tQpxcXF6eOPP87zOzcBAADMyrOvJAUAAMAt79KlSzaPDxw4oJUrV6px48b5E1Ae69Kli8qVK6d33nknv0Nx6K233lLNmjVJbAIAAGTBnZsAAADwSMmSJdW9e3dVqFBBR48e1cyZM5Wenq6dO3d69GUxAAAAQF7jC4UAAADgkebNm2vx4sU6deqUAgMD1bBhQ40bN47EJgAAAPINd24CAAAAAAAAMCU+cxMAAAAAAACAKZHcBAAAAAAAAGBKfOZmHsvMzNTJkycVFhYmHx+f/A4HAAAAAAAAMBXDMHThwgWVKlVKvr6u780kuZnHTp48qbJly+Z3GAAAAAAAAICpHT9+XGXKlHFZh+RmHgsLC5MkHTx8XGHh4R63K9d4kI6tn6xyjQdJko6tn2yzPTey9p31t6XMMp79WJYye1njtH/sqF9PYnJXx1VfjtrY/+3osX27rPtiX8+bGFzFZuGq/7wYy9Knu7l1ti0vjju45808sybm4+48K0hyEpenbcx4bbnea5fX8+DN85azsfNrbVzFbuEqLmfH1/XanxvZryevWxxx95rPUV1H27O2cffayt1rHE+POU/32ZPXd+7WytVr0dyssyevca8Hb17nWv7ObZ+O/t3gzetwZ8dpbuc+p+1cHceO2ljq5eTfHK7auhrf0VpmZT+Pzv7NZl/XWT/2++Tp+I5idXee5dW/gfKLq2uRhbN5y1rm6jx1d6w5+3e+q5idxZbbtbker3WyxuboGLeP0dG1Jb9fBzmaS2fP1d6cT87G8vQ1lLMYvX3tkJtjyFE8F1JSVCmurDXP5grJzTxmeSt6WHi4wr1Ibvr4FVJ4eLh8/ApJkrWtZXuuYsrSd9bfljLLePZjWcrsZY3T/rGjfj2JyV0dV305amP/t6PH9u2y7ot9PW9icBWbhav+82IsS5/u5tbZtrw47uCeN/PMmpiPu/OsIMlJXJ62MeO15XqvXV7PgzfPW87Gzq+1cRW7hau4nB1f12t/bmS/nrxuccTdaz5HdR1tz9rG3Wsrd69xPD3mPN1nT17fuVsrV69Fc7POnrzGvR68eZ1r+Tu3fTr6d4M3r8OdHae5nfuctnN1HDtqY6mXk39zuGrranxHa5mV/Tw6+zebfV1n/djvk6fjO4rV3XmWV/8Gyi+urkUWzuYta5mr89Tdsebs3/muYnYWW27X5nq81skam6Nj3D5GR9eW/H4d5GgunT1Xe3M+ORvL09dQzmL09rVDbo4hl9dODz7ykS8UAgAAAAAAAGBK3LlpIocPHdKar1frt99+1ZWMDI/bGSd/VL9/PZPtt6VMUrbtWcvsWeo6euyoX09iclfHVV+O2tj/7eixfbus+2Jfz5sYXMVm4ar/vBjL0qe7uXW2zVVb5B1v5rkgrElw4cKqV+92NXuouYoXL56vsQAAAAAAIJHcNI2NP3yv4UMGq3BIYdWrW0+Fo4p63PbJx+5XiWIR2X5byiRl2561zJ6lrqPHjvr1JCZ3dVz15aiN/d+OHtu3y7ov9vW8icFVbBau+s+LsSx9uptbZ9tctUXe8Wae83tNDMPQ+fPn9d67M7Vo4Yea9s4sxVWokG/xAAAAAAAgkdw0hYyMDI0eOUL33HOPxo0fr0KFnH/OkiM7fzumulXLZfttKZOUbXvWMnuWuo4eO+rXk5jc1XHVl6M29n87emzfLuu+2NfzJgZXsVm46j8vxrL06W5unW1z1RZ5x5t5LihrcvbsWf2rTx9NmjBeM2a/l9/hAAAAAABucXzmpgns2L5dFy+mqW+/fl4nNgEgLxUtWlRPPvWU9uzZpbNnz+Z3OAAAAACAWxzJTRP444+T8vX1VVxcXH6HAgCqUqWKDMPQn6dO5XcoAAAAAIBbHMlNE8jMzJS/v798fHzyOxTTGz1qlEaPGpXfYdzUevTorvnz5+dZfzVrVNfy5cslSfPnz1e9unWsZRXiYrVs2bI8Gwue8ff/5xNNMjMz8zkSAAAAAMCtjuSmid3fpLGCgwIVHhaqiPAw1axRXZ9++qm1/MiRI/Lz9dGFlGTrtmPHjmnUsJdUpnQpRYSHqU3zRpo49hX98ccfHo354bzZqlO7lhLurK5H7m+gtyaNUYbdN7dv2rRJPbs8pvvuqKoSMdEa+cor1rLnn3tO5cuVVcKd1VW2TGm9MX60Tftff/1VzZo+oKiiRfRQozvU55lndPnSJYflpUqWUJ9nntHFixe9nTqvvTfjbd1RvbxWrVpls90yx+fPn7duO3bsmHr06G6d4yqVK+n5557TX2f+9GisD+fNVqe2DykyIlzlypbRvwcNyjbH0j9f8NLovnuzjZ+UlKRHHnlYTRrWVNkypTVp4kSbdjt27FCvru0UGRGuShUr6IMPPrAp37hxo7o/0UZFIiNUtkxpDRs69LomsRITE9WqVUtFFy+myIhwVat6myZOmGAt/9/eX/Too49et/Fz6v4mjfX2W2/ZbLseydaUlBR16dJZCXdWV8kSMRrz2mse1Y+MCHdY3125JL3//vuqelu8wkJDVCEuVl988UWe7hMAAAAAAHmF5KbJvf76BKVcSNX55BS9PmGinuzaRUePHnVY99TJE2pwZ335+/tr46bNOp+cojkf/VfFikdrw4YNHo137Vqm3nt/jtZt2qV5i5Zpx7afbO6E3LNnj9o91lZP9eyjbzfvVtKhw2rXvr21/Nm+ffXrb/u0Yesv2rlrt/Yn/mqTfOvapbOqVInXH6f+1MfLvtaePbv1/qypDst37/mf9uzZ7TbZk1uGYeirZUsUERGpuXPnuKx77NgxNbizvgL8A6xz/MPGTSpZsqR2bNvi0XjXrmVqxKsTdeavv7X5x5+0YcN6h3ebzpwxQ4GBgXZtr6lN61aqV7eevvn+Z61d963eeWe6Fi1aJEk6f/68Hm3xiB5u2VZ/nz2nhYsWa8Dzz2njxo3W9m3btFbC/c30199n9cPGTfrkk4/13nvX74tjWj7aQrVr1daRo8f099lz+nTpf/kW7iyef/45nT17VsvXbtaG73/Q+++/ly0h7aj+kaPHHNZ3V/7uu+9qyptvaNHij5VyIVU//rRFNWvWvK77CAAAAABATpHcvEn4+PioRYsWioyMVGJiosM6s9+Zopo1a+o/r05QbGysfHx8FFWsuHo+01+dOnXyaJzuvZ9V/fr15R8QoJgSJdWiVTtt2rTRWj5mzGvq1au3Gj/wkAIKFVJISIhq1aplLa9atapCQkIk/ZM09PX11YGDB6zlhw4dUpeuXVWoUCEVKRqlli1b6eCBfQ7LixcvrpYtW+l/e//n1Vx5a926dTr9558aOnKcvvryS505c8Zp3VGjRqpmzZp69733rHMcExOjocOG6aFHWnk0Xvfez6p6zdoKCAhQmTJl9OSTT9nMsSQdP35cU6a8qdcn2N6VmZiYqMTERL0ycqT8AwIUHx+vnj176f333pUkbd68WYGBgWrfsav8/PzUoEEDtX3sMc2Z874kKTk5WWfPntWjrdvLz89PsbGxeuCBptr7v+szx3/99ZeSkpL0TJ8+Kly4sPz8/FS9enV16NDBWsfd3ZAH9u/X3Q3vUkR4mJo0TtDx48etZQcPHlTz5g+pWFRRVa5U0eZOy9GjRqlt2zY2fRUtEqn169dbH3/88ceqU7uWihaJVIM762vz5s2SpEEvvaQffvhBQ4a8rPCwUD3yyMN6/PEOOnbsmLp0fkLhYaF69l//kiSdPn1aXbt2UelSJVWmdCkNfOEFpaenezQ/Fy9e1Ccff6zXXhujsPAIValSRf37P6d5TpLsWetHRkZmq++u/Nq1axo18hVNeett1a1b13r8ViDZDAAAAAAooEhu3iQyMzP1xRdf6NKlS6pTp47DOj9u2qCOnZ5w2c+E119Xy5aevwV4x7afVLPm/yUvv9+wQRkZGer82MNqem9dPfxw82zJ1gmvv259y/r+xN/Uv/9z1rKXXhqkDz/4QJcuXdJfZ05r2bLPdV/jpg7LT506pWXLPtejj7b0ON6cmDt3ju5rfL8eePARlSpVSh99+KHTumu+/trtHM9/b4ZXc7zh+w02cyxJffs+q1dGjlJUVJTNdsvbxw3DsNm2Z88e699Zyyzb/vf/y4sWLaoePXrqi/9+rCtXrigpKUnr1q3VIy1aeByvN6KiohQfH69ePXtoyZIlTu86dmXhwo+0cNFi/Xn6jAqHhOiVV0ZIkq5evapWLR9V7Vq19fuJk/rvZ59r0qSJ1rtY3Vm5cqUG/3uQ5s6br7/+PquXhwxV61Yt9ffff2vyG2/ovvvus945vXLlKi1Z8qnKlSunhYsWK+VCqmbOmiXDMNSmdSuViCmhAweTrHcbjx0zxjpOndq1nMaUmJiojIwMm3O6dp061vX0tr4n5X/++ad2/vyzKsTFqlzZMnrm6aeVkpLi0ZwBAAAAAHCjkdw0uWHDhqpokUiFhYaofbvHNHz4fxQdHe2w7rlzZ1W6dGmX/b08ZIi++mq5R2N//uli7dm5Q8OGD7duO3v2rD755GO9OuEtrfz2J9WuVVtt27TW1atXbcb4Yftv2vvLr2r3eBeVKFHCWtb84Ye1adNGRYSHqXnj+ipTtqxat33cYXnpUiVVpmxZ9ezZ06N4c+Ls2bNa9vnnatG6vXx8fNS165Mu35p+5swZt3Pc/em+Hs/xe++9p82bNtnM8eLFi5V++bKefPLJbPXj4+MVGxurka+8ooyMdP3yyy+aN2+uNTnVsGFDpaWl6ZOF83XlyhVt2rRJyz7/3CZ51eHxx/X50sUKKRysKpUrqUWLR9W8eXOP4vWWj4+Pvv1uvWrVqq3XXh2tShUrqEb1avrmm2887uNfz/ZVXFycgoKC1LlzF/28Y4ckacuWLfrjjz/02pgxCgoKUq1atdSvX38tWDDfo35nzHhHgwb9W/Xq1ZOvr68ee+wx3XbbbVq5cqXHsW3fvl0HDhzQxEmTVLhwYUVFRWnI0GFavPj/kpm7du9R586dHbZPTU1VSEiI9Qt8JCkyMlIXLlzIUX135WfPnpUkrVu3Vlu3bdfPO3fpyJHDenHgQI/3GQAAAACAG4nkpsmNGzdeZ8+dV9rFS/ptX6I++GCBZs+e7bBuZGQRnThxIk/GXbX8c82cNlnT3/tQJUuWtG4PDQ1V9+49VKlyvAoVCtToV1/VwYMHtX///mx9VK1aVVVuq6aePbpLks6dO6cHmzVV795PKzXtor7dvEchISEaMeQFh+V//X1WISEhevLJrnmyT44sWrhQ4eHhuve+JpKkJ596Sr/++qt++uknh/WLFSuWZ3O8cOFCvTLiP1r99RrrHJ89e1bDhg7ROzNmOmwTEBCgz5d9oZ27durhJg30ZNcu6t69h/UOz6ioKH3x5Vf6euUXKlWyhIYNHWJTnpiYqLZtWmvg4BG6eOmyfj9xUvv2/aahQ4bkyT45UqJECU1+4w39b+8v+vP0GTVv/rDaPdbWmmjzpL1FSEiINVH3+++/q1SpUipUqJC1PK5CBZ34/XeP+j165IiGDx+mokUirT+7du3SSS/W98iRIzp//ryKRRW19vF4h/b680/PvlwqNDRUFy9etPnPgeTkZIWFheWoviflkvTykKEqVqyYihUrppeHDNXy5V95vM8AAAAAANxIJDdvIpUqVdLDDz+iFSsc3xXY8J4ELVnySa7HWbhwod54/VVNnb1AleOr2pTVrl3b5rGPj4/Lvq5euaIDB/75zM2kpCRdunRJzz3/vAoVKqTwiAg980wfbdzwrcPyIkWK6Jln+mjlihW53idn5s6do+TkZLV4oKEeanSHEhrdJx8fH82d4/juzQcfeihP5njV8s/14sAXtHLVapvPLN2zZ49Onjype+5uqOjixXTH7fUkSZUrVdTSpUslSdWrV9fXX6/Ruk279PPOXUpPT1ejhARrH/fcc4/mLvxcZ/76Wxu+/0Gn/jylRo3+Kf/f//6nMmXKqOlDLeTv76+SJUvqyae6aeXK6zfHWRUtWlQjR41SWlqaDh8+nKu+ypQpo5MnT+rKlSvWbUePHFHpMmUk/V+izyItLc3mDtYyZctq0uQ3dPbceevPhdQ0vfz/E72+vtkvn/bbypYtq+joaJs+zp1PVsqFVI/2IT4+XgEBAdq9e7d12+5du5x+wY+7+p6UBwUFeRQbAAAAAAAFAcnNm8iRI0e0atVK1azhOPHRp/9A7d61S+NGD9OxY8dkGIbOnf1b89+fqU8+8Swht3rFF3phwPOaOmuBbqtaI1t576ef0YIF83XkcJKuXrmiV0ePVuXKlVWlShWlpqZq3rx5On/+vAzD0P/+9z/NmT1NDz74kCTptttuU2hoqGbOmKGrV68qLS1V77//nuKrVndYfuHCBb3//nuqW7duDmfMtR07dmj37t36es03WvjflVr435X6eecuzZw1W0uWfKK0tLRsbUaNGq3du3bp2X/9yzrHZ86c0cQJE7RmlWd3v61e8YUmjxulFStXZdu3hg0bKunQYf2885/E5fIV/7xFesP3P+iRRx6R9E8CNC0tTVcyMvTZZ59p3ry5Gj78P9Y+du7cqYyMdF26dEnvvfeeNqxfrwEvvCBJuv3223Xy5EmtX/e1MjMzdebMGX300Yeqc53m+Ny5cxrxn/9o3759unbtmi5evKgpb76pokWL6rbbbstV33feeadiYmI08pVXlJ6err1792r69Gl66qlukqS69erppx9/1L59+3T58mUNHzbMJhnft28/vTF5knbs2CHDMHTx4kWtXbtWv///Oz+jY2KUlJRkM2ZMTIwOZdlWv359lS1bViP+8x9duHBBhmHo6NGjWrVqlUf7ULhwYT3esaNeeWWEUi+k6MCBA5o+fZp69urttn5ycnK2+u7Kg4OD1aVLV02cOEHnzp3T+fPnNXHiBLVq1drDWQcAAAAA4MYiuWlylm9rDg8LVaP77tUDDzTViFdecVi3ZKky2rJ1mzLS09XwrgaKjAhXj85tdeb0KSX8/zv7xo8bp0ceedjpeDPenqiUlBT16d5R991RVffdUVU1a1S3lnfp0kX9+vXXv3p0UrNG9bR9x3Yt++JL+fv7y8fHR4sXL1LlShXVqH41tW3TWvcm3K8p//8brENDQ/XFl1/p448XK7p4MbVqdo/Onz+vUePedFheIS5W58+f17z5C/JoNm3NnTNHjRs3VqNGjVSseLSKFY9WiRIl1L17d4WGhjpMCJcvX15btm7T5fTL1jm+5+6GOnHihOrd0eCfft+d7naOU9NSdX+Txta1tcxxYGCgypQpY/2xvCW7VKlSKly4sCTp0yVLFFu+nJrcXUtvvjFZn32+zObuz2nTpurBRncoJrq4li79VGvXfatSpUpJkuLi4rRo8cd6b+bbiipaRLVq1lB0dLTefHNKnsypvUKFCunEyRN6tMUjKhIZodjy5bRp8yatWLlKISEhueo7ICBAX361XDt+3qFSJUuoTetWGjjwRevnW95///165pk+uveeu1WlciXVqFnT5u3eLVu21Ljxr6vPM08rqmgRVawQp6lT37Z+adOAAS9o3bq1Klok0voFUUOGDtM770xX0SKR6te3r/z8/PTlV8t14uQJVa9WVUUiI9Ty0RZKOnjQOk7NGtW1cOFCp/sxbdp0RURE6JH779J9996jnj176amnnrKWP/LIwxo/bly2+uXKlnFY3135lLfeUqlSpVSxQpyq3hav8uXK640338zpMgAAAAAAcF35u6+Cgurb79a7LI+NjdW1TEM7fztm3Va+fHmNGveG6lYtJ0nWshIlSuiPc8c0dNgwDXXR55drNqlu1XI2fdo/Hvzyy2rW6glrmUVISIjWrPnGOq6lnSUpJ/3zlunvf9iYrY6j8uvtnRkzHG4PCAjQ7ydOWh9fy7T99vHy5ctr3rz52dpZ9qPnM/1t5sXel2s2SZLLOhaWNc7qtTFj9NqYMdb5szd37jw99+/RTvtv1aqVylau49H4uRUSEqK5c+e5rHPo8BHr3927d1f37t0dlklSmzZt1KZNG+vjKlWq6Ouv1zjte9LkyZo0ebL1ce/etndEdujQQR06dHDYtkGDBvrl199strVs2VItW7a02RYdHe1yH/+39xenZZIUHh6uRYsWO13PlStXOazvrj9nQkJC/jl+XS8LAAAAAAAFAnduAgAAAAAAADAl7tzELSWhceP8DuGm17p1G8XGxuZ3GLiODMNwXwkAAAAAgBuA5KYJhIaGKiMjQykpKQoPD8/vcEytMcnN6y7r28Jxc/rrr78k/XNtAgAAAAAgP/G2dBOod/sd8vHx8fgblgHgejEMQ6tWrlR0dIzKlS+f3+EAAAAAAG5x3LlpAtHR0Xr4kUf15ptv6PixY7qzQQMFBwfLx8fHo/aJh0/pWtrpbL8tZZKybc9aZs9S19FjR/16EpO7Oq76ctTG/m9Hj+3bZd0X+3rexOAqNgtX/efFWJY+3c2ts22u2iLveDPP+b0mhmHo3Llz+nbdOq37dp1eHPSyx9cgAAAAAACuF5KbJjFk2H9UtGiUVq1crk+WfOJV26Mn/lb50lHZflvKJGXbnrXMnqWuo8eO+vUkJnd1XPXlqI39344e27fLui/29byJwVVsFq76z4uxLH26m1tn21y1Rd7xZp4LyprExlXQ4CHD1bpN2/wOBQAAAAAAkptm4efnp2f79VefZ/vqr7/+UkZGhsdta7T4jz5ZOibbb0uZpGzbs5bZs9R19NhRv57E5K6Oq74ctbH/29Fj+3ZZ98W+njcxuIrNwlX/eTGWpU93c+tsm6u2yDvezHNBWJPChQuraNGi+RoDAAAAAABZkdw0GV9fX0VHR3vVxqdQqMqUKZPtt6VMUrbtWcvsWeo6euyoX09iclfHVV+O2tj/7eixfbus+2Jfz5sYXMVm4ar/vBjL0qe7uXW2zVVb5B1v5pk1AQAAAAAgO75QCAAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCkVyOTm/PnzFRkZmd9hAAAAAAAAACjAvEpudu/eXT4+PvLx8VFAQIDi4uI0ePBgXb58OU+D6tixo/bv35+nfXoqNjbWuo+Wn9dffz1fYgEAAAAAAADgnL+3DZo3b6558+bpypUr2rFjh7p16yYfHx9NmDAhz4IKDg5WcHBwnvXnrVdffVVPP/209XFYWFi+xQIAAAAAAADAMa/flh4YGKgSJUqobNmyatOmjZo2bapvvvnGWp6Zmanx48crLi5OwcHBql27tpYuXWrTx5dffqnKlSsrKChITZo00YIFC+Tj46Pz589Lyv629FGjRqlOnTqaO3euypUrp9DQUPXt21fXrl3TxIkTVaJECUVHR2vs2LE245w/f169e/dW8eLFFR4ervvvv1+7d+92u49hYWEqUaKE9SckJMTbaQIAAAAAAABwneXqMzf37t2rzZs3q1ChQtZt48eP1wcffKBZs2bpl19+0cCBA9W1a1dt2LBBknT48GG1b99ebdq00e7du9WnTx8NHz7c7VhJSUlatWqVVq9ercWLF2vOnDlq0aKFfv/9d23YsEETJkzQf/7zH23ZssXapkOHDjp9+rRWrVqlHTt2qF69enrggQd09uxZl2O9/vrrioqKUt26dTVp0iRdvXo1hzMEAAAAAAAA4Hrx+m3py5cvV2hoqK5evar09HT5+vpq+vTpkqT09HSNGzdOa9euVcOGDSVJFSpU0MaNGzV79mwlJCRo9uzZio+P16RJkyRJ8fHx2rt3b7a7Lu1lZmZq7ty5CgsLU7Vq1dSkSRMlJiZq5cqV8vX1VXx8vCZMmKDvvvtODRo00MaNG7V161adPn1agYGBkqTJkydr2bJlWrp0qZ555hmH4zz//POqV6+eihYtqs2bN2vo0KH6448/9Oabbzqsn56ervT0dOvjlJQU7yYUAAAAAAAAQI54ndxs0qSJZs6cqbS0NE2ZMkX+/v5q166dJOngwYO6ePGimjVrZtMmIyNDdevWlSQlJiaqfv36NuV33nmn23FjY2NtPvsyJiZGfn5+8vX1tdl2+vRpSdLu3buVmpqqqKgom34uXbqkpKQkp+O8+OKL1r9r1aqlQoUKqU+fPho/frw1SZrV+PHjNXr0aLfxAwAAAAAAAMhbXic3Q0JCVKlSJUnS3LlzVbt2bc2ZM0e9evVSamqqJGnFihUqXbq0TTtHiUFvBAQE2Dy2fGO7/bbMzExJUmpqqkqWLKn169dn6yvr53m606BBA129elVHjhxRfHx8tvKhQ4faJERTUlJUtmxZj/sHAAAAAAAAkDNeJzez8vX11bBhw/Tiiy+qc+fOqlatmgIDA3Xs2DElJCQ4bBMfH6+VK1fabNu2bVtuwnCoXr16OnXqlPz9/RUbG5vjfnbt2iVfX19FR0c7LA8MDMx14hYAAAAAAACA93L1hULSP1/a4+fnp3feeUdhYWEaNGiQBg4cqAULFigpKUk///yzpk2bpgULFkiS+vTpo3379unll1/W/v37tWTJEs2fP1/SP3de5pWmTZuqYcOGatOmjdasWaMjR45o8+bNGj58uLZv3+6wzY8//qi33npLu3fv1qFDh7Rw4ULrFyIVKVIkz2IDAAAAAAAAkHu5Tm76+/urf//+mjhxotLS0vTaa69pxIgRGj9+vKpWrarmzZtrxYoViouLkyTFxcVp6dKl+uyzz1SrVi3NnDnT+m3peXkHpI+Pj1auXKlGjRqpR48eqlKlijp16qSjR48qJibGYZvAwEB9/PHHSkhIUPXq1TV27FgNHDhQ7777bp7FBQAAAAAAACBvePW2dMsdlvaGDBmiIUOGWB8PGDBAAwYMcNpPq1at1KpVK+vjsWPHqkyZMgoKCpIkde/eXd27d7eWjxo1SqNGjXIbi/3na4aFhWnq1KmaOnWq01iyqlevnn766SeP6gIAAAAAAADIX7n6zM2cmjFjhurXr6+oqCht2rRJkyZNUv/+/fMjFAAAAAAAAAAmlS/JzQMHDmjMmDE6e/asypUrp5deeklDhw7Nj1AAAAAAAAAAmFS+JDenTJmiKVOm5MfQAAAAAAAAAG4Suf5CIQAAAAAAAADIDyQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKfkYhmHkdxA3k5SUFEVEROj8+WSFh4d73O7k6XMqFV1EJ0+fkySVii5isz03svad9belzDKe/ViWMntZ47R/7KhfT2JyV8dVX47a2P/t6LF9u6z7Yl/PmxhcxWbhqv+8GMvSp7u5dbYtL447uOfNPLMm5uPuPCtIchKXp23MeG253muX1/PgzfOWs7Hza21cxW7hKi5nx9f12p8b2a8nr1sccfeaz1FdR9uztnH32srdaxxPjzlP99mT13fu1srVa9HcrLMnr3GvB29e51r+zm2fjv7d4M3rcGfHaW7nPqftXB3HjtpY6uXk3xyu2roa39FaZmU/j87+zWZf11k/9vvk6fiOYnV3nuXVv4Hyi6trkYWzecta5uo8dXesOft3vquYncWW27W5Hq91ssbm6Bi3j9HRtSW/Xwc5mktnz9XenE/OxvL0NZSzGL197ZCbY8hRPCkpKYqMjFBysvv8GsnNPGZJbnoy+QAAAAAAAABseZNf423p14lhSCf+PKcTf55z+nfWbZbtjv7O+pO1D0dt3PXtrF/7PlzVcffjaXtHc+OqL2f75emcuOrD031xNqeuxnC2f+62uTp+XI3vbr29XV9Xx66rWNzF6agvZ+1d7Z83/bmr600/3sTsSV1Pj09Hx5Ozx66OCU/3wdnx5+lx7M01wtUY3pxf3h7jzo55T/bDm7Fcxexsvdztj7M+PVkXb+L3dP7d7aO3c+XNHLg7jnK6Hq7OI2/2w9kYnq61J+vqal/yYt2cjeXq2HV0ffH0GPXmuPT0uHZ2DfRkv5ztm6vYXZ07eXFc3agfb+J1tJ/Ofjvqx1FdT/Y5J9djZ8eqq/XPzXUut9dGT9cnL8dx1ZezsTx5bsrLecjJc15Ox7+e7fJiTjy5Lnk6Zl7N2c364+zYz+08eTLnrs47T+p6cix4e97ndl+9KcvLca7XmDdqn9z16ez1jiexuXttk9v4Pe3HU9y5mccsmeU//05W+QeGSZLObZuuIvX7Z/vb4ty26ZKkIvX7O/w7K8t2+9+WMnv2/TnrN2v/WdvlhLsx7Ou5GtPZ/tlv82RO7Ofe3Vw7KnO0Ru7GcLZ/jsZ1FLuj48f+t7N9cjeGJ1wdu45i8qTMWV/O+na1f970566uN/14E7Mn43l6fDo6npwdp86OV3f76SwuR8dUTo4xT69vjvbZk/PL22PcURxZx3BXz9Ox3F3znD0HeHKNsu/Tk3XxJn5357GrczMnPDnO3NX19Dh0tx6uziNv9sPZmmQdOyfnjrPnDUfjWMpyum6unqOcHbv2vDlG3XH1vO/pOeMoLmf75aieo7ruxsvL4+pG8SZed69ZXB0zjvr39Hrizbw4ux5auFr/3FzncnttdNWvs2MzL/p21pezsTx5bsrL4zgnz3k5Hf96tsuLOXH1ms3bMfNqzm5Wzl6D2m/LSb/u5tyb1785vYa668+TPt3x5vXd9Rrneo15vfv35vVuVt7Mt7vXNrnh6XGZkpKimCju3AQAAAAAAABwEyO5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJQKZHJz/vz5ioyMzO8wAAAAAAAAABRgXiU3u3fvLh8fH/n4+CggIEBxcXEaPHiwLl++nKdBdezYUfv378/TPr2Vnp6uOnXqyMfHR7t27crXWAAAAAAAAABk5/Wdm82bN9cff/yhQ4cOacqUKZo9e7ZGjhyZp0EFBwcrOjo6T/v01uDBg1WqVKl8jQEAAAAAAACAc14nNwMDA1WiRAmVLVtWbdq0UdOmTfXNN99YyzMzMzV+/HjFxcUpODhYtWvX1tKlS236+PLLL1W5cmUFBQWpSZMmWrBggXx8fHT+/HlJ2d+WPmrUKNWpU0dz585VuXLlFBoaqr59++ratWuaOHGiSpQooejoaI0dO9ZmnPPnz6t3794qXry4wsPDdf/992v37t1u93HVqlVas2aNJk+e7O30AAAAAAAAALhB/HPTeO/evdq8ebPKly9v3TZ+/Hh99NFHmjVrlipXrqzvv/9eXbt2VfHixZWQkKDDhw+rffv2GjBggHr37q2dO3dq0KBBbsdKSkrSqlWrtHr1aiUlJal9+/Y6dOiQqlSpog0bNmjz5s3q2bOnmjZtqgYNGkiSOnTooODgYK1atUoRERGaPXu2HnjgAe3fv19FixZ1OM6ff/6pp59+WsuWLVPhwoXdxpWenq709HTr45SUFLdtAAAAAAAAAOSe18nN5cuXKzQ0VFevXlV6erp8fX01ffp0Sf8k+saNG6e1a9eqYcOGkqQKFSpo48aNmj17thISEjR79mzFx8dr0qRJkqT4+Hjt3bs3212X9jIzMzV37lyFhYWpWrVqatKkiRITE7Vy5Ur5+voqPj5eEyZM0HfffacGDRpo48aN2rp1q06fPq3AwEBJ0uTJk7Vs2TItXbpUzzzzTLYxDMNQ9+7d9a9//Ut33HGHjhw54nY+xo8fr9GjR3szhQAAAAAAAADygNfJzSZNmmjmzJlKS0vTlClT5O/vr3bt2kmSDh48qIsXL6pZs2Y2bTIyMlS3bl1JUmJiourXr29Tfuedd7odNzY2VmFhYdbHMTEx8vPzk6+vr82206dPS5J2796t1NRURUVF2fRz6dIlJSUlORxj2rRpunDhgoYOHeo2HouhQ4fqxRdftD5OSUlR2bJlPW4PAAAAAAAAIGe8Tm6GhISoUqVKkqS5c+eqdu3amjNnjnr16qXU1FRJ0ooVK1S6dGmbdpa7J3MqICDA5rHlG9vtt2VmZkqSUlNTVbJkSa1fvz5bX1k/zzOrb7/9Vj/++GO2WO+44w516dJFCxYsyNYmMDAw1/sGAAAAAAAAwHu5+sxNX19fDRs2TC+++KI6d+6satWqKTAwUMeOHVNCQoLDNvHx8Vq5cqXNtm3btuUmDIfq1aunU6dOyd/fX7GxsR61mTp1qsaMGWN9fPLkST300EP65JNPrJ/jCQAAAAAAAKBg8Prb0u116NBBfn5+eueddxQWFqZBgwZp4MCBWrBggZKSkvTzzz9r2rRp1rse+/Tpo3379unll1/W/v37tWTJEs2fP1/SP3de5pWmTZuqYcOGatOmjdasWaMjR45o8+bNGj58uLZv3+6wTbly5VSjRg3rT5UqVSRJFStWVJkyZfIsNgAAAAAAAAC5l+vkpr+/v/r376+JEycqLS1Nr732mkaMGKHx48eratWqat68uVasWKG4uDhJUlxcnJYuXarPPvtMtWrV0syZMzV8+HBJuX/relY+Pj5auXKlGjVqpB49eqhKlSrq1KmTjh49qpiYmDwbBwAAAAAAAED+8Opt6ZY7LO0NGTJEQ4YMsT4eMGCABgwY4LSfVq1aqVWrVtbHY8eOVZkyZRQUFCRJ6t69u7p3724tHzVqlEaNGuU2FvvP1wwLC9PUqVM1depUp7G4EhsbK8MwctQWAAAAAAAAwPWVq8/czKkZM2aofv36ioqK0qZNmzRp0iT1798/P0IBAAAAAAAAYFL5ktw8cOCAxowZo7Nnz6pcuXJ66aWXNHTo0PwIBQAAAAAAAIBJ5Utyc8qUKZoyZUp+DA0AAAAAAADgJpHrLxQCAAAAAAAAgPxAchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJiSj2EYRn4HcTNJSUlRRESEzp9PVurla5KkUtFFdPL0uWx/W5SKLiJJOnn6nMO/s7Jst/9tKbNn35+zfrP2n7VdTrgbw76eqzGd7Z/9Nk/mxH7u3c21ozJHa+RuDGf752hcR7E7On7sfzvbJ3djeMLVsesoJk/KnPXlrG9X++dNf+7qetOPNzF7Mp6nx6ej48nZcerseHW3n87icnRM5eQY8/T65mifPTm/vD3GHcWRdQx39Twdy901z9lzgCfXKPs+PVkXb+J3dx67OjdzwpPjzF1dT49Dd+vh6jzyZj+crUnWsXNy7jh73nA0jqUsp+vm6jnK2bFrz5tj1B1Xz/uenjOO4nK2X47qOarrbry8PK5uFG/idfeaxdUx46h/T68n3syLs+uhhav1z811LrfXRlf9Ojs286JvZ305G8uT56a8PI5z8pyX0/GvZ7u8mBNXr9m8HTOv5uxm5ew1qP22nPTrbs69ef2b02uou/486dMdb17fXa9xrteY17t/b17vZuXNfLt7bZMbnh6XKSkpioyMUHJyssLDw13WJbmZxyzJTU8mHwAAAAAAAIAtb/Jr/jcopluOYfzzczPKzf9YSu7vhOJ/BHOHOQQA3Gp47gMAmBnPY8gLN9tx5E1OjTs385gls/zn3zfvnZtF6vfXuW3Tc9ROksu2Oe0b/4c5BADcanjuAwCYGc9jyAs323GUkpKimCjP7tzkC4UAAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZUIJOb8+fPV2RkZH6HAQAAAAAAAKAA8yq52b17d/n4+MjHx0cBAQGKi4vT4MGDdfny5TwNqmPHjtq/f3+e9umpVq1aqVy5cgoKClLJkiX15JNP6uTJk/kSCwAAAAAAAADnvL5zs3nz5vrjjz906NAhTZkyRbNnz9bIkSPzNKjg4GBFR0fnaZ+eatKkiZYsWaLExET997//VVJSktq3b58vsQAAAAAAAABwzuvkZmBgoEqUKKGyZcuqTZs2atq0qb755htreWZmpsaPH6+4uDgFBwerdu3aWrp0qU0fX375pSpXrqygoCA1adJECxYskI+Pj86fPy8p+9vSR40apTp16mju3LkqV66cQkND1bdvX127dk0TJ05UiRIlFB0drbFjx9qMc/78efXu3VvFixdXeHi47r//fu3evdvl/g0cOFB33XWXypcvr7vvvltDhgzRTz/9pCtXrng7VQAAAAAAAACuI//cNN67d682b96s8uXLW7eNHz9eH330kWbNmqXKlSvr+++/V9euXVW8eHElJCTo8OHDat++vQYMGKDevXtr586dGjRokNuxkpKStGrVKq1evdp6N+WhQ4dUpUoVbdiwQZs3b1bPnj3VtGlTNWjQQJLUoUMHBQcHa9WqVYqIiNDs2bP1wAMPaP/+/SpatKjbMc+ePauFCxfq7rvvVkBAgMM66enpSk9Ptz5OSUlx2y8AAAAAAACA3PM6ubl8+XKFhobq6tWrSk9Pl6+vr6ZPny7pn0TfuHHjtHbtWjVs2FCSVKFCBW3cuFGzZ89WQkKCZs+erfj4eE2aNEmSFB8fr71792a769JeZmam5s6dq7CwMFWrVk1NmjRRYmKiVq5cKV9fX8XHx2vChAn67rvv1KBBA23cuFFbt27V6dOnFRgYKEmaPHmyli1bpqVLl+qZZ55xOtbLL7+s6dOn6+LFi7rrrru0fPlyp3XHjx+v0aNHezWHAAAAAAAAAHLP67elN2nSRLt27dKWLVvUrVs39ejRQ+3atZMkHTx4UBcvXlSzZs0UGhpq/fnggw+UlJQkSUpMTFT9+vVt+rzzzjvdjhsbG6uwsDDr45iYGFWrVk2+vr42206fPi1J2r17t1JTUxUVFWUTy+HDh62xOPPvf/9bO3fu1Jo1a+Tn56ennnpKhmE4rDt06FAlJydbf44fP+52XwAAAAAAAADkntd3boaEhKhSpUqSpLlz56p27dqaM2eOevXqpdTUVEnSihUrVLp0aZt2lrsnc8r+beGWb2y335aZmSlJSk1NVcmSJbV+/fpsfWX9PE9HihUrpmLFiqlKlSqqWrWqypYtq59++sl6N2pWgYGBud43AAAAAAAAAN7L1Wdu+vr6atiwYXrxxRfVuXNnVatWTYGBgTp27JgSEhIctomPj9fKlStttm3bti03YThUr149nTp1Sv7+/oqNjc1xP5ZkadbP1QQAAAAAAACQ/7x+W7q9Dh06yM/PT++8847CwsI0aNAgDRw4UAsWLFBSUpJ+/vlnTZs2TQsWLJAk9enTR/v27dPLL7+s/fv3a8mSJZo/f76kf+68zCtNmzZVw4YN1aZNG61Zs0ZHjhzR5s2bNXz4cG3fvt1hmy1btmj69OnatWuXjh49qm+//VZPPPGEKlas6PCuTQAAAAAAAAD5J9fJTX9/f/Xv318TJ05UWlqaXnvtNY0YMULjx49X1apV1bx5c61YsUJxcXGSpLi4OC1dulSfffaZatWqpZkzZ2r48OGScv/W9ax8fHy0cuVKNWrUSD169FCVKlXUqVMnHT16VDExMQ7bFC5cWJ999pkeeOABxcfHq1evXqpVq5Y2bNjAW88BAAAAAACAAsbHcPZNOTfQ2LFjNWvWrJviy3hSUlIUERGhP/9OVnh4eH6Hc10Uqd9f57ZNz1E7SS7b5rRv/B/mEABwq+G5DwBgZjyPIS/cbMdRSkqKYqIilJzsPr+Wq8/czKkZM2aofv36ioqK0qZNmzRp0iT1798/P0IBAAAAAAAAYFL5ktw8cOCAxowZo7Nnz6pcuXJ66aWXNHTo0PwIBQAAAAAAAIBJ5Utyc8qUKZoyZUp+DA0AAAAAAADgJpHrLxQCAAAAAAAAgPxAchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSj6GYRj5HcTNJCUlRRERETp/Plnh4eH5Hc51cfL0OZWKLpKjdpJcts1p3/g/zCEA4FbDcx8AwMx4HkNeuNmOo5SUFEVGRig52X1+jeRmHrMkNz2ZfAAAAAAAAAC2vMmv+d+gmG45J0+fU1iYZ8lNZ9l1y3bLHY+SrI/tf1vKvInPVRuzZ/xzc3dp1rl11pe7NfO0nrd3szpae0/Gs5TZj+WovaWOt/viKnZv4vS075zUu1H95KRPT9bC/liwcHedsN/mTSzOjj9nYzvb5km5o7gt2+1jcRSbp+O742gdXNVzVsfZfjjr29F6OerHURv7WDxZF1fr6m4ce86OM2fHoTueHGfu6nq7T+7mxpv5chSbq/PR0/lxtq5Z43L1tz1nz0GezLUna+zp9fR6vSbxZO6dxeDqedrZtcjddc1ZfWfXHFd9esKT1xrePLd7e4y52m938+zs9UPWvixcPXe4OpY94Ulc3lxX3T1v5JQn57t9uafXsKxtnZU5G8PVuLl9nrCPxV0/rq63zs5Td2M5it/ZPuTmWmDfT9a2ueHu+cHVWJ6em1nrevO6xAycHdPOtuWUs+uds7E8fW73JDZn56uzPu37d7eW3r6+yzquu+fzrH148hruRhx/njzfu6pjz931x9Pnz6x1c3NtcXV8uHoOcBSPxYULKR6Pz52becySWQ6s+bTO//yuR22K1O+vc9umO91epH5/6zbLY/vfljJPuWvjLCazyGn89nPrrC93a+ZpPU/WzlEsjuJ0NZ6lzH4sR+0tdbzdF1exexOnp33npN6N6icnfXqyFvbHgoW764T9Nm9icXb8ORvb2TZPyh3FbdluH4uj2Dwd3x1H6+CqnrM6zvbDWd+O1stRP47a2Mfiybq4Wld349hzdpw5Ow7d8eQ4c1fX231yNzfezJej2Fydj57Oj7N1zRqXq7/tOXsO8mSuPVljT6+n1+s1iSdz7ywGV8/Tzq5F7q5rzuo7u+a46tMTnrzW8Oa53dtjzNV+u5tnZ68fsvZl4eq5w9Wx7AlP4vLmuurueSOnPDnf7cs9vYZlbeuszNkYrsbN7fOEfSzu+nF1vXV2nroby1H8zvYhN9cC+36yts0Nd88Prsby9NzMWteb1yVm4OyYdrYtp5xd75yN5elzuyexOTtfnfVp37+7tfT29V3Wcd09n2ftw5PXcDfi+PPk+d5VHXvurj+ePn9mrZuba4ur48PVc4CjeCyMaxlK/997Ht25yRcKAQAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMqUAmN+fPn6/IyMj8DgMAAAAAAABAAeZVcrN79+7y8fGRj4+PAgICFBcXp8GDB+vy5ct5GlTHjh21f//+PO3TE0eOHFGvXr0UFxen4OBgVaxYUSNHjlRGRsYNjwUAAAAAAACAa/7eNmjevLnmzZunK1euaMeOHerWrZt8fHw0YcKEPAsqODhYwcHBedafp/bt26fMzEzNnj1blSpV0t69e/X0008rLS1NkydPvuHxAAAAAAAAAHDO67elBwYGqkSJEipbtqzatGmjpk2b6ptvvrGWZ2Zmavz48da7H2vXrq2lS5fa9PHll1+qcuXKCgoKUpMmTbRgwQL5+Pjo/PnzkrK/LX3UqFGqU6eO5s6dq3Llyik0NFR9+/bVtWvXNHHiRJUoUULR0dEaO3aszTjnz59X7969Vbx4cYWHh+v+++/X7t27ne6bJXH74IMPqkKFCmrVqpUGDRqkzz77zNtpAgAAAAAAAHCdeX3nZlZ79+7V5s2bVb58eeu28ePH66OPPtKsWbNUuXJlff/99+ratauKFy+uhIQEHT58WO3bt9eAAQPUu3dv7dy5U4MGDXI7VlJSklatWqXVq1crKSlJ7du316FDh1SlShVt2LBBmzdvVs+ePdW0aVM1aNBAktShQwcFBwdr1apVioiI0OzZs/XAAw9o//79Klq0qEf7mJyc7HFdAAAAAAAAADeO18nN5cuXKzQ0VFevXlV6erp8fX01ffp0SVJ6errGjRuntWvXqmHDhpKkChUqaOPGjZo9e7YSEhI0e/ZsxcfHa9KkSZKk+Ph47d27N9tdl/YyMzM1d+5chYWFqVq1amrSpIkSExO1cuVK+fr6Kj4+XhMmTNB3332nBg0aaOPGjdq6datOnz6twMBASdLkyZO1bNkyLV26VM8884zbfT148KCmTZvm8i3p6enpSk9Ptz5OSUlx2y8AAAAAAACA3PM6udmkSRPNnDlTaWlpmjJlivz9/dWuXTtJ/yQDL168qGbNmtm0ycjIUN26dSVJiYmJql+/vk35nXfe6Xbc2NhYhYWFWR/HxMTIz89Pvr6+NttOnz4tSdq9e7dSU1MVFRVl08+lS5eUlJTkdrwTJ06oefPm6tChg55++mmn9caPH6/Ro0e77Q8AAAAAAABA3vI6uRkSEqJKlSpJkubOnavatWtrzpw56tWrl1JTUyVJK1asUOnSpW3aWe6ezKmAgACbx5ZvbLfflpmZKUlKTU1VyZIltX79+mx9Zf08T0dOnjypJk2a6O6779a7777rsu7QoUP14osvWh+npKSobNmyLtsAAAAAAAAAyL1cfeamr6+vhg0bphdffFGdO3dWtWrVFBgYqGPHjikhIcFhm/j4eK1cudJm27Zt23IThkP16tXTqVOn5O/vr9jYWI/bnThxQk2aNNHtt9+uefPm2dwZ6khgYGCuE7cAAAAAAAAAvOf1t6Xb69Chg/z8/PTOO+8oLCxMgwYN0sCBA7VgwQIlJSXp559/1rRp07RgwQJJUp8+fbRv3z69/PLL2r9/v5YsWaL58+dL+ufOy7zStGlTNWzYUG3atNGaNWt05MgRbd68WcOHD9f27dsdtjlx4oQaN26scuXKafLkyTpz5oxOnTqlU6dO5VlcAAAAAAAAAPJGrpOb/v7+6t+/vyZOnKi0tDS99tprGjFihMaPH6+qVauqefPmWrFiheLi4iRJcXFxWrp0qT777DPVqlVLM2fO1PDhwyXl/q3rWfn4+GjlypVq1KiRevTooSpVqqhTp046evSoYmJiHLb55ptvdPDgQa1bt05lypRRyZIlrT8AAAAAAAAAChav3pZuucPS3pAhQzRkyBDr4wEDBmjAgAFO+2nVqpVatWplfTx27FiVKVNGQUFBkqTu3bure/fu1vJRo0Zp1KhRbmOx/3zNsLAwTZ06VVOnTnUaS1b24wIAAAAAAAAouHL1mZs5NWPGDNWvX19RUVHatGmTJk2apP79++dHKAAAAAAAAABMKl+SmwcOHNCYMWN09uxZlStXTi+99JKGDh2aH6EAAAAAAAAAMKl8SW5OmTJFU6ZMyY+hAQAAAAAAANwkcv2FQgAAAAAAAACQH0huAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAU/IxDMPI7yBuJikpKYqIiNBvB44ovmJ5j9qcPH1OpaKLON1+8vQ56zbLY/vfljJPuWvjLCazyGn89nPrrC93a+ZpPU/WzlEsjuJ0NZ6lzH4sR+0tdbzdF1exexOnp33npN6N6icnfXqyFvbHgoW764T9Nm9icXb8ORvb2TZPyh3FbdluH4uj2Dwd3x1H6+CqnrM6zvbDWd+O1stRP47a2Mfiybq4Wld349hzdpw5Ow7d8eQ4c1fX231yNzfezJej2Fydj57Oj7N1zRqXq7/tOXsO8mSuPVljT6+n1+s1iSdz7ywGV8/Tzq5F7q5rzuo7u+a46tMTnrzW8Oa53dtjzNV+u5tnZ68fsvZl4eq5w9Wx7AlP4vLmuurueSOnPDnf7cs9vYZlbeuszNkYrsbN7fOEfSzu+nF1vXV2nroby1H8zvYhN9cC+36yts0Nd88Prsby9NzMWteb1yVm4OyYdrYtp5xd75yN5elzuyexOTtfnfVp37+7tfT29V3Wcd09n2ftw5PXcDfi+PPk+d5VHXvurj+ePn9mrZuba4ur48PVc4CjeCwuXEhR1cqxSk5OVnh4uMvxSW7mMUty05PJBwAAAAAAAGDLm/ya/w2K6ZZjGP/8SJ7fQXE9eDpeXmXoPc3We/I/D+7+59mTPt3F7WocT+5EuNHrmROu/vcup3d0OBvnes+FuztvPO3jesZplmOioMcI4Obk7jruyd1AFgXp+akgyav9vRXmLa/3saDNWV7ePQbzK2jH563A2d26BUFBigWeu57rVhCPCW9uxeTOzTxmySz/+ff/ZZaL1O+vc9umZ/v7RvB0vNzE5Wr/itTvb/3b3RxYtlvauIrHvk5O4nc3jrs4czrujeZsPz2Zb2/270bMRdZYczre9Y7TLMdEQY8RwM3J3XXc1XOvvYL0/FSQ5NX+3grzltf7WNDmzJPX1Lh1FLTj81bg6N/GBWUNClIs8Nz1XLeCeEykpKQoJsqzOzf5QiEAAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCkVyOTm/PnzFRkZmd9hAAAAAAAAACjAvEpudu/eXT4+PvLx8VFAQIDi4uI0ePBgXb58OU+D6tixo/bv35+nfXpq7Nixuvvuu1W4cGESrAAAAAAAAEAB5vWdm82bN9cff/yhQ4cOacqUKZo9e7ZGjhyZp0EFBwcrOjo6T/v0VEZGhjp06KBnn302X8YHAAAAAAAA4Bmvk5uBgYEqUaKEypYtqzZt2qhp06b65ptvrOWZmZkaP3684uLiFBwcrNq1a2vp0qU2fXz55ZeqXLmygoKC1KRJEy1YsEA+Pj46f/68pOxvSx81apTq1KmjuXPnqly5cgoNDVXfvn117do1TZw4USVKlFB0dLTGjh1rM8758+fVu3dvFS9eXOHh4br//vu1e/dul/s3evRoDRw4UDVr1vR2agAAAAAAAADcQP65abx3715t3rxZ5cuXt24bP368PvroI82aNUuVK1fW999/r65du6p48eJKSEjQ4cOH1b59ew0YMEC9e/fWzp07NWjQILdjJSUladWqVVq9erWSkpLUvn17HTp0SFWqVNGGDRu0efNm9ezZU02bNlWDBg0kSR06dFBwcLBWrVqliIgIzZ49Ww888ID279+vokWL5mbXrdLT05Wenm59nJKSkif9AgAAAAAAAHDN6+Tm8uXLFRoaqqtXryo9PV2+vr6aPn26pH8SfePGjdPatWvVsGFDSVKFChW0ceNGzZ49WwkJCZo9e7bi4+M1adIkSVJ8fLz27t2b7a5Le5mZmZo7d67CwsJUrVo1NWnSRImJiVq5cqV8fX0VHx+vCRMm6LvvvlODBg20ceNGbd26VadPn1ZgYKAkafLkyVq2bJmWLl2qZ555xttdd2j8+PEaPXp0nvQFAAAAAAAAwHNeJzebNGmimTNnKi0tTVOmTJG/v7/atWsnSTp48KAuXryoZs2a2bTJyMhQ3bp1JUmJiYmqX7++Tfmdd97pdtzY2FiFhYVZH8fExMjPz0++vr42206fPi1J2r17t1JTUxUVFWXTz6VLl5SUlOTFHrs2dOhQvfjii9bHKSkpKlu2bJ71DwAAAAAAAMAxr5ObISEhqlSpkiRp7ty5ql27tubMmaNevXopNTVVkrRixQqVLl3app3l7smcCggIsHls+cZ2+22ZmZmSpNTUVJUsWVLr16/P1ldefgt6YGBgrvcNAAAAAAAAgPdy9Zmbvr6+GjZsmF588UV17txZ1apVU2BgoI4dO6aEhASHbeLj47Vy5Uqbbdu2bctNGA7Vq1dPp06dkr+/v2JjY/O8fwAAAAAAAAD5y+tvS7fXoUMH+fn56Z133lFYWJgGDRqkgQMHasGCBUpKStLPP/+sadOmacGCBZKkPn36aN++fXr55Ze1f/9+LVmyRPPnz5f0z52XeaVp06Zq2LCh2rRpozVr1ujIkSPavHmzhg8fru3btzttd+zYMe3atUvHjh3TtWvXtGvXLu3atct6VyoAAAAAAACAgiHXyU1/f3/1799fEydOVFpaml577TWNGDFC48ePV9WqVdW8eXOtWLFCcXFxkqS4uDgtXbpUn332mWrVqqWZM2dq+PDhknL/1vWsfHx8tHLlSjVq1Eg9evRQlSpV1KlTJx09elQxMTFO273yyiuqW7euRo4cqdTUVNWtW1d169Z1mRAFAAAAAAAAcON59bZ0yx2W9oYMGaIhQ4ZYHw8YMEADBgxw2k+rVq3UqlUr6+OxY8eqTJkyCgoKkiR1795d3bt3t5aPGjVKo0aNchuL/edrhoWFaerUqZo6darTWOzNnz/f6X4CAAAAAAAAKDhy9ZmbOTVjxgzVr19fUVFR2rRpkyZNmqT+/fvnRygAAAAAAAAATCpfkpsHDhzQmDFjdPbsWZUrV04vvfSShg4dmh+hAAAAAAAAADCpfEluTpkyRVOmTMmPoQEAAAAAAADcJHL9hUIAAAAAAAAAkB9IbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFPyz+8AbjaGYUiSLqSk/N+2axlK+f+Ps/59Q+LxcLzcxOVq/4xrGda/3c2BZbuljat47OvkJH5347iLM6fj3mjO9tOT+fZm/27EXGSNNafjXe84zXJMFPQYAdyc3F3HXT332itIz08FSV7t760wb3m9jwVtzjx5TY1bR0E7Pm8Fjv5tXFDWoCDFAs9dz3UriMeEJa9mybO54mN4Ugse+/3331W2bNn8DgMAAAAAAAAwtePHj6tMmTIu65DczGOZmZk6efKkwsLC5OPjk9/hWKWkpKhs2bI6fvy4wsPD8zsc3ECs/a2Jdb91sfa3Jtb91sXa35pY91sXa39rYt1vXbfy2huGoQsXLqhUqVLy9XX9qZq8LT2P+fr6us0o56fw8PBb7oTAP1j7WxPrfuti7W9NrPuti7W/NbHuty7W/tbEut+6btW1j4iI8KgeXygEAAAAAAAAwJRIbgIAAAAAAAAwJZKbt4jAwECNHDlSgYGB+R0KbjDW/tbEut+6WPtbE+t+62Ltb02s+62Ltb81se63LtbeM3yhEAAAAAAAAABT4s5NAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTROaPn267rjjDgUGBqpNmzY2ZTt27NC9996r8PBwVahQQR988IG1LD09XY0bN1Z0dLTCw8N122236d1337Vp/9tvv+mee+5R4cKFVaVKFX355Zc3YpfggZyue1Z79+5VoUKFsrVn3Qu23Kx9bGysgoODFRoaqtDQUEVGRtqUnzx5Uo888ohCQkJUrlw5vffee9d5b+Cp3Ky7YRgaP368YmNjFRISoipVqmjLli3Wcs75gi2na//DDz9Yz3XLj6+vr55//nlrHc75gis35/zGjRt11113KSIiQqVLl9bQoUOVmZlpLWfdC7bcrP0333yjevXqKSwsTNWqVdPq1attyrneF1zp6el6+umnFRcXp7CwMN12222aO3eutTwlJUWdO3dWeHi4YmJi9Nprr9m0z2058kdu133EiBGqWbOm/P399cILL2Trn+t9wZWbtT99+rS6dOmiMmXKKDw8XHXr1s12Pb/l196A6fz3v/81Pv/8c6Nfv35G69atrdvPnTtnREdHGzNnzjSuXr1q/PTTT0Z4eLjxww8/GIZhGFevXjX27NljXLlyxTAMw/jll1+M6Oho4/vvvzcMwzAyMjKMihUrGiNGjDAuXbpkfPXVV0ZISIhx4MCBG76PyC6n625x7do146677jIaN25s0551L/hys/bly5c3Pv/8c6d9N2rUyOjRo4eRmppq/PTTT0ZERISxfv3667g38FRu1n3o0KHGPffcYxw4cMDIzMw0jhw5Ypw8edIwDM55M8jt9d7i1KlThr+/v7Fp0ybrNs75gis3r++KFi1qjBs3zrh69apx+PBhIzY21pg1a5a1D9a9YMvp2iclJRkhISHGV199ZVy7ds346quvjMKFCxtJSUmGYXC9L+hSU1ONESNGGAcPHjQyMzONH3/80YiMjDS+/vprwzAM46mnnjIeeugh49y5c0ZiYqJRtmxZY8GCBdb2uS1H/sjtus+fP99YuXKl0bZtW2PAgAHZ+ud6X3DlZu2TkpKMSZMmGcePHzeuXbtmfPnll0bhwoWNX375xdr/rb72JDdNbOTIkTYvgFasWGGULVvWpk737t2Nbt26OWz/66+/GjExMcbcuXMNwzCMtWvXGpGRkUZGRoa1ziOPPGK88soreR47ci6n6z5lyhSjR48e2dqz7uaRk7V3ldw8ePCg4evra5w6dcq6rW/fvsZTTz2Vl2Ejl7xd97///tsIDAw0EhMTHfbHOW8euX2enzBhglG1alXrY855c8jJOS/JOHHihLW8d+/eRr9+/QzDYN3NxNu1f+edd4z77rvPprxx48bGyJEjDcPgem9Gbdu2NUaMGGGkpaUZhQoVMrZt22YtmzhxotGoUSPDMIxcl6Ng8XTds+rWrVu25CbXe/PJydpb1K1b15gzZ45hGKy9YRgGb0u/iWRmZsowjGzb9uzZY7Pt0UcfVVBQkKpVq6aYmBi1bdtWkrRnzx5Vr15dAQEB1rp16tTJ1h4FiyfrfvToUb399tuaNGlStvasu3l5es736dNHxYoVU8OGDbVy5Urr9j179qhkyZKKiYmxbmPtCz536/7TTz8pMDBQixcvVqlSpRQbG6uXX35ZGRkZkjjnzczTc95i7ty56tWrl/Ux57w5uVv3okWLqmfPnpozZ46uXLmipKQkrV27Vi1atJDEupuZu7V3V8713lwuX76srVu3qlatWkpMTFRGRobq1KljLc+6drktR8Hhzbq7w/XeXHKz9qdPn9Zvv/2mWrVqSWLtJT5z86bSsGFDpaWlafr06bpy5Yo2bdqkzz//XCkpKTb1li9frrS0NK1fv17t2rVTcHCwJCk1NTXb5/FFRkbqwoULN2oXkAOerHufPn306quvKioqKlt71t28PFn7Dz/8UIcPH9aJEyf03HPPqV27dtq2bZsk1t6s3K372bNnlZKSogMHDmj//v36/vvvtWrVKk2YMEES625mnj7PS/98/uahQ4f01FNPWbex9ubkybo//vjjevfddxUcHKxKlSrp0UcfVfPmzSWx7mbmbu2bNWumbdu2admyZbp69aqWLVumTZs2WctZe/MwDEO9e/dW5cqV9dhjjyk1NVUhISHy9/e31sm6drktR8Hg7bq7wzlvHrlZ+4yMDHXq1EmPP/647rjjDkmsvURy86YSFRWlr776SosWLVKJEiU0ZMgQ9ejRw2FCy8/PTwkJCfrzzz+td/OFhoYqOTnZpl5ycrLCwsJuSPzIGXfr/tFHH+nq1at68sknHbZn3c3Lk3P+vvvuU+HChRUYGKjOnTurZcuW+u9//yuJtTcrd+seGhoqSRo9erRCQ0NVrlw5DRgwQF999ZW1nHU3J2+e5+fMmaNWrVqpePHi1m2svTm5W/fExES1bt1aU6ZM0eXLl3Xy5En99ttvGjJkiCTW3czcrX18fLw++eQTjR49WtHR0ZozZ446depk83zA2hd8hmGob9++SkxM1LJly+Tr66vQ0FBdvHhRV69etdbLuna5LUf+y8m6u8M5bw65WfuMjAy1b99ehQsXtvnCINae5OZN55577tHmzZv1999/64cfftCpU6eUkJDgtP6VK1d04MABSVKtWrX0yy+/6MqVK9byXbt2qWbNmtc9buSOq3Vfu3attmzZomLFiqlYsWKaOHGiVq1apRIlSkhi3c3O23Pe1/f/Lvu1atXSyZMndfr0aes21t4cXK177dq1XbblnDc3T875lJQUffrpp+rdu7fNds5583K17v/73/9UpkwZtW/fXv7+/ipZsqS6deumFStWSGLdzc7dOd+6dWvt3LlTZ8+e1VdffaUDBw5Yy7neF3yGYahfv37asmWL1qxZo4iICEn/JK4DAgK0e/dua92sa5fbcuSvnK67O1zvC77crH1GRoY6dOigjIwM/fe//1WhQoWsZay9+LZ0M7py5Ypx6dIlY/jw4UbLli2NS5cuGenp6YZhGMbPP/9sXL582bh48aLx7rvvGtHR0dYPmN+5c6exZs0a4+LFi8aVK1eM5cuXG4ULFzYWLlxoGMb/faPiyJEjjcuXLxsrVqzgGxULkJyu+9mzZ43jx49bfwYOHGg89NBDxu+//24YButuBjld+6NHjxobNmwwLl++bGRkZBiffPKJERQUZPz444/Wvu+77z6jV69eRlpamrFlyxYjMjLylvpWvYIsp+tuGIbRtGlT46mnnjLS0tKMEydOGLVr1zbGjBljGAbnvBnkZu0NwzBmzZpllC1b1rh27Vq2vjnnC66crvuhQ4eM4OBg4/PPPzeuXbtmnD592mjWrJnRtWtXa9+se8GWm3N+27ZtxpUrV4yUlBRj9OjRRqVKlYzU1FTDMLjem0Hfvn2NWrVqGX/99Ve2sieffNJ4+OGHjfPnzxv79+83ypUrZ/Ot2bktR/7JzbpnZGQYly5dMrp27Wr079/fuHTpks2XhnG9L9hyuvYZGRlG69atjQceeMC4dOmSw75v9bUnuWlCI0eONCTZ/CQkJBiG8c83KEZERBghISFGs2bNjL1791rbbdu2zbjjjjuMsLAwIzw83KhVq5Yxa9Ysm75/+eUX4+677zaCgoKMSpUqGcuWLbuRuwYXcrrujvrJ+k2chsG6F3Q5XftffvnFqF27thESEmJEREQY9evXN7788kubvn///XejefPmRuHChY0yZcoY77777o3cNbiQm3P+zz//NFq3bm2EhoYapUqVMgYPHmzzwpdzvmDL7fW+fv36Tr8NmXO+4MrNun/xxRdG3bp1jfDwcCM6Otro0qWLcebMGWs5616w5WbtmzZtan1t365dO+P48eM25VzvC64jR44YkozAwEAjJCTE+tOnTx/DMAwjOTnZ6NSpkxEaGmoUL17cGD16tE373JYjf+R23bt165btetGtWzdrOdf7gis3a79+/XpDkhEUFGTTduzYsdY6t/ra+xiG3VfsAQAAAAAAAIAJ8JmbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAwJSaNGmiqlWrKiMjI1tZhw4dVLZsWaWmpuZDZAAAALhRSG4CAADAlGbNmqXDhw9r4sSJNttXr16tpUuXatq0aQoNDc2n6AAAAHAj+BiGYeR3EAAAAEBOjB49Wq+//rp++eUXVahQQZcvX1aNGjVUo0YNLVu27LqNe+nSJQUHB1+3/gEAAOAZ7twEAACAaQ0dOlTly5dXv379JEnjxo3Tn3/+qenTp+v3339X165dVaxYMQUHB6tRo0basWOHTfsPPvhA9957r4oWLaoiRYqocePG2rp1q02dUaNGKTQ0VFu3blXDhg0VFBSkd95554btIwAAAJzzz+8AAAAAgJwqVKiQZs+ercaNG2vMmDGaOHGiXn/9dYWEhKhu3boKDQ3VtGnTFBERoWnTpun+++/XgQMHFB0dLUk6cuSInnrqKVWsWFEZGRlavHixGjVqpD179qhKlSrWcTIyMtS5c2cNHDhQ48aNU1RUVH7tMgAAALLgbekAAAAwvZ49e2revHmqV6+etm7dqldffVVvv/229u/fb01kpqenq0qVKurYsWO2z+mUpMzMTGVmZqpGjRp67LHHNG7cOEn/3Lk5evRoffzxx+rYseMN3S8AAAC4xtvSAQAAYHpDhgyRJL300kvy8/PTmjVr1KRJExUtWlRXr17V1atX5efnp4SEBG3bts3a7rffflPbtm0VExMjPz8/BQQEKDExUfv37882RosWLW7Y/gAAAMAzvC0dAAAApleoUCGb33/99Zd++uknBQQEZKtbsWJFSdKFCxf04IMPqnjx4nrzzTdVvnx5BQUFqXfv3rp8+bJNm8KFC/PN6wAAAAUQyU0AAADcdIoWLarmzZvrtddey1YWGBgoSfrxxx/1+++/a/ny5apdu7a1PDk5WWXKlLFp4+Pjc30DBgAAQI6Q3AQAAMBNp2nTpvroo49UtWpVhYSEOKxz6dIlSf93t6ckbd68WUeOHFH16tVvSJwAAADIHZKbAAAAuOm8+OKLWrhwoRISEjRgwACVK1dOZ86c0ZYtW1SqVCkNHDhQd911l0JDQ9WvXz8NGTJEJ06c0MiRI1W6dOn8Dh8AAAAe4guFAAAAcNOJiorSTz/9pDp16ujll1/Wgw8+qIEDB+rIkSNq0KCBJCkmJkaffvqpTp8+rdatW+utt97S7NmzValSpXyOHgAAAJ7yMQzDyO8gAAAAAAAAAMBb3LkJAAAAAAAAwJRIbuL/tWMHJAAAAACC/r9uR6AzBAAAAIAluQkAAAAALMlNAAAAAGBJbgIAAAAAS3ITAAAAAFiSmwAAAADAktwEAAAAAJbkJgAAAACwJDcBAAAAgCW5CQAAAAAsyU0AAAAAYCncV56EgnjevAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1600x550 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABTcAAAI6CAYAAADyjXzzAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAhi9JREFUeJzs3Xt8z/X///H7ezbb2Illc7Y5DTkXUn2MonSSQonKMUpKSnL4CJ9iMaUQVhkqHSSpnHIoCp+Kij4+nwxzjEQOmw1z2Ov3h9/e373fex/3fs/2yu16ubwveb9ez8Pj+Xy+Xu/Xe49e7/fbYhiGIQAAAAAAAAAwmYDiDgAAAAAAAAAACoPkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAA/CouLk69e/cu7jC8lpubq4YNG2rChAnFHYpDI0aMUKtWrYo7DAAAgBKF5CYAAPDJ3r17NXjwYNWtW1dlypRRmTJl1KBBAz355JP69ddfbcqOGzdOFotFAQEBOnjwYIG2MjMzFRoaKovFosGDB1u379u3TxaLRRaLRS+//LLDOHr27CmLxaKwsDC3MefF4egxe/ZsL2fAtf/9738aN26c9u3b59d2XbEfX1BQkOLi4vT000/r1KlTVywOs/nwww918OBBm2PvSjl9+rSGDx+u+Ph4BQcHq0qVKuratavOnDljLfPMM89o27Zt+uKLL/zef1pamoYOHaobb7xRISEhslgsTo/ZrKwsPfPMM6pataqCg4NVv359zZo1q0C5tWvXqm/fvtbXhpo1a6p///76448/bMrlP78dPR577DGXsR8+fFjjxo3T1q1bCzt8h3bs2KHhw4eradOmCg8PV6VKlXTXXXdpy5YtDssfOnRIDzzwgKKiohQREaF7771Xe/bssSlz8OBBjR8/Xi1btlS5cuV0zTXXqG3btlqzZo3beB577DFZLBbdfffdfhkfAAB/F4HFHQAAADCvpUuX6sEHH1RgYKB69uypJk2aKCAgQDt27NDixYs1a9Ys7d27VzVq1LCpFxwcrA8//FDDhw+32b548WKX/YWEhOjDDz/UP//5T5vt2dnZ+vzzzxUSEuJV/LNmzSqQDPX3nXH/+9//NH78eLVt21ZxcXF+bdudvPFlZ2dr7dq1mj59un7++Wdt2LChSPtNS0tTQID5/h96cnKyunfvrsjIyCvab0ZGhhITE/X7779rwIABql27to4dO6bvvvtOOTk5KlOmjCSpYsWKuvfeezVlyhR16tTJrzH8+9//1rRp09SgQQPVr1/faaLw0qVLuv3227VlyxY9+eSTqlOnjr766isNGjRIJ0+e1KhRo6xlX3jhBZ04cULdunVTnTp1tGfPHs2YMUNLly7V1q1bVbFiRUlShQoV9N577xXoa+XKlVqwYIFuu+02l7EfPnxY48ePV1xcnJo2bVroObD3zjvvaM6cOerSpYsGDRqkjIwMpaSk6IYbbtDKlSvVvn17a9msrCy1a9dOGRkZGjVqlIKCgjR16lQlJiZq69atio6OliR9/vnnmjRpkjp37qxevXrp4sWLevfdd9WhQwelpqaqT58+DmPZsmWL5s2b5/VrHAAAVwUDAACgEHbv3m2ULVvWqF+/vnH48OEC+y9cuGC88cYbxoEDB6zbxo4da0gy7r//fqNp06YF6nTo0MHo0qWLIcl48sknrdv37t1rrSfJ2Lp1q029BQsWGEFBQcY999xjlC1b1m3seXEcO3bMmyEXyieffGJIMr755hu/tpudne10n7PxPfjgg4Yk44cffvBrLH8HP//8syHJWLNmzRXv+4knnjCioqKMPXv2uC27aNEiw2KxGOnp6X6N4fjx40ZmZqZhGIaRnJxsSDL27t1boNzChQsNScacOXNstnfp0sUICQkx/vzzT+u29evXG5cuXbIpt379ekOSMXr0aLcx3XrrrUZERIRx9uxZl+U2b95sSDLmzp3rtk1vbNmyxTh9+rTNtr/++suoUKGCcdNNN9lsnzRpkiHJ+PHHH63bfvvtN6NUqVLGyJEjrdu2b99e4Lw8d+6cUa9ePaNq1aoO48jNzTVat25t9O3b16hRo4Zx1113+To0AAD+Vsz3v9QBAECJMHnyZGVnZ2vu3LmqVKlSgf2BgYF6+umnVa1atQL7evTooa1bt2rHjh3WbUeOHNHXX3+tHj16OO2zdevWio+P1wcffGCzfcGCBerYsaPKly/vw4j+z6+//qrevXurZs2aCgkJUcWKFdW3b18dP368QNlDhw6pX79+qly5soKDgxUfH68nnnhC58+f17x589StWzdJUrt27awfs123bp21/syZM3XttdcqODhYlStX1pNPPlngo+Nt27ZVw4YN9dNPP6lNmzYqU6aMzR1ynvrHP/4hSUpPT7fZ/sMPP6hjx46KjIxUmTJllJiYqI0bNxaov27dOl1//fUKCQlRrVq1lJKSYv0IfH7237k5b948WSwWbdiwQU8//bQqVKigqKgoDRw4UOfPn9epU6f06KOPqly5cipXrpyGDx8uwzBs2szNzdXrr7+ua6+9ViEhIYqNjdXAgQN18uRJm3JbtmzR7bffrmuuuUahoaGKj49X37593c7NkiVLVLp0abVp08Zme974du/erd69eysqKkqRkZHq06ePzUfGC+vUqVOaO3euBgwYoPj4eJ0/f145OTlOy+fdLfj555/73Hd+5cuXV3h4uNty3333nSSpe/fuNtu7d++uc+fO2cTVpk2bAnfwtmnTRuXLl9dvv/3msp8//vhD33zzje6//36XdyuuW7dOLVq0kCT16dPHeo7NmzfPWuaTTz7Rddddp9DQUF1zzTV6+OGHdejQIbdjve666wrc2R0dHa1//OMfBeJftGiRWrRoYY1FkurVq6dbb71VCxcutG679tprdc0119jUDQ4O1p133qnff/9dp0+fLhDHe++9p+3bt5fY74IFAKC4kdwEAACFsnTpUtWuXbtQH+Nu06aNqlatapOk/PjjjxUWFqa77rrLZd2HHnpIH330kTX59ddff2nVqlUuk6LOnDhxQn/99Zf1kZcoW716tfbs2aM+ffpo+vTp6t69uz766CPdeeedNkm3w4cPq2XLlvroo4/04IMPatq0aXrkkUe0fv16nTlzRm3atNHTTz8tSRo1apTee+89vffee6pfv76ky4mzJ598UpUrV9arr76qLl26KCUlRbfddpsuXLhgE+vx48d1xx13qGnTpnr99dfVrl07r8eb9x2K5cqVs277+uuv1aZNG2VmZmrs2LGaOHGiTp06pVtuuUU//vijtdwvv/yijh076vjx4xo/frz69eunf/3rX1qyZInH/T/11FPatWuXxo8fr06dOumtt97SmDFjdM899+jSpUuaOHGibr75ZiUnJxf4mPLAgQP1/PPP66abbtIbb7yhPn36aMGCBbr99tutc3X06FHddttt2rdvn0aMGKHp06erZ8+e+v77793GtmnTJjVs2FBBQUEO9z/wwAM6ffq0kpKS9MADD2jevHkaP368TZmMjAyb48nZIysry1pnw4YNOnfunGrXrq2uXbuqTJkyCg0N1U033eTwo+GRkZGqVauWw+TzlZCTk6NSpUqpdOnSNtvzPjr/008/uayflZWlrKysAgk+ex999JFyc3PVs2dPl+Xq16+vf/3rX5KkAQMGWM+xvCT1vHnz9MADD6hUqVJKSkrSY489psWLF+vmm28u9PfPHjlyxCb+3Nxc/frrr7r++usLlG3ZsqXS09MdJi3t28z7zuL8Tp8+rRdeeEGjRo2yfowfAADYKeY7RwEAgAllZGQYkozOnTsX2Hfy5Enj2LFj1seZM2es+/J/XHrYsGFG7dq1rftatGhh9OnTxzAMw+nH0pOTk43t27cbkozvvvvOMAzDePPNN42wsDAjOzvb6NWrl1cfS7d/1KhRwzAMwybmPB9++KEhyfj222+t2x599FEjICDA2Lx5c4Hyubm5hmE4/1j60aNHjdKlSxu33XabzUd3Z8yYYUgyUlNTrdsSExMNScbs2bPdji3/+NLS0oxjx44Z+/btM1JTU43Q0FCjQoUK1o+05+bmGnXq1DFuv/12a7x544+Pjzc6dOhg3XbPPfcYZcqUMQ4dOmTdtmvXLiMwMNCwf0tZo0YNo1evXtbnc+fONSQV6Kd169aGxWIxHn/8ceu2ixcvGlWrVjUSExOt27777jtDkrFgwQKbflauXGmz/bPPPjMkOVwPd6pWrWp06dKlwPa8uezbt6/N9vvuu8+Ijo622Za3Tu4e+efmtddeMyQZ0dHRRsuWLY0FCxYYM2fONGJjY41y5co5/MqH2267zahfv77XY/SUq4+lv/rqqzbnX54RI0YYkoy7777bZdsvvfSSIclYu3aty3LXXXedUalSpQIfa3fE2cfSz58/b8TExBgNGza0+Wj70qVLDUnGiy++6LZte99++61hsViMMWPGWLcdO3bMkGT861//KlD+zTffNCQZO3bscNrmrl27jJCQEOORRx4psG/YsGFGfHy8ce7cOcMwDD6WDgCAA9y5CQAAvJaZmSlJDn+ZvG3btqpQoYL18eabbzpso0ePHtq9e7c2b95s/a8nd19ee+21aty4sT788ENJ0gcffKB77723wB1Pnvj000+1evVq62PBggWSpNDQUGuZc+fO6a+//tINN9wgSfr5558lXb5ba8mSJbrnnnsc3rFl/1Fte2vWrNH58+f1zDPP2Hx097HHHlNERISWLVtmUz44ONjpj404k5CQoAoVKiguLk59+/ZV7dq1tWLFCutcbd26Vbt27VKPHj10/Phx652F2dnZuvXWW/Xtt98qNzdXly5d0po1a9S5c2dVrlzZ2n7t2rV1xx13eBxPv379bOalVatWMgxD/fr1s24rVaqUrr/+eptfmf7kk08UGRmpDh062NwBmfex4W+++UaSFBUVJenyXcX2d766c/z4cZs7Wu09/vjjNs//8Y9/6Pjx49ZzQZJeffVVm+PJ2SP/D2nl3cVpsVi0du1a9ejRQ0888YSWLFmikydPOjx/ypUrp7/++sur8flLjx49FBkZqb59+2r16tXat2+f3nrrLc2cOVOSdPbsWad1v/32W40fP14PPPCAbrnlFqfldu7cqZ9++kndu3f36YeptmzZoqNHj2rQoEE2H22/6667VK9evQLnmDtHjx5Vjx49FB8fb7OGeWMODg4uUCevX2fzcubMGXXr1k2hoaF65ZVXbPbt3LlTb7zxhpKTkx22DQAALuPX0gEAgNfyvpsv/8dr86SkpOj06dP6888/9fDDDztto1mzZqpXr54++OADRUVFqWLFii4THvn16NFDr776qoYOHapNmzYV6vsnpcsfj3f08dgTJ05o/Pjx+uijj3T06FGbfRkZGZKkY8eOKTMzUw0bNixU3/v375d0OQGZX+nSpVWzZk3r/jxVqlQp8FFgdz799FNFRETo2LFjmjZtmvbu3WuTuN21a5ckqVevXk7byMjI0Llz53T27FnVrl27wH5H25ypXr26zfO8XyW3/17WyMhIm+/S3LVrlzIyMhQTE+Ow3bw1SkxMVJcuXTR+/HhNnTpVbdu2VefOndWjRw+PkkOG3fd8uoo9LxF68uRJRURESLr8HY3eyluPe+65x+Z/Ftxwww2Kj4/Xpk2bHMbpLnmekZFhk1ArXbq0X76TtmLFivriiy/0yCOPWH/FPCIiQtOnT1evXr0c/g8PSdqxY4fuu+8+NWzYUO+8847LPvL+J4O7j6S74+wcky5/H+aGDRs8bis7O1t33323Tp8+rQ0bNtiMM28NHX1X6rlz52zK5Hfp0iV1795d//vf/7RixQqb/3EgSUOGDNGNN96oLl26eBwnAABXI5KbAADAa5GRkapUqZK2b99eYF/ed3Dmfb+jKz169NCsWbMUHh6uBx980OO7tB566CGNHDlSjz32mKKjo61JFn954IEHtGnTJj3//PNq2rSpwsLClJubq44dOyo3N9evfXnKUXLEnfzJ23vuuUeNGjVSz5499dNPPykgIMA6luTkZDVt2tRhG2FhYdYEja9KlSrl8fb8icbc3FzFxMRYk172KlSoIOny3Y+LFi3S999/ry+//FJfffWV+vbtq1dffVXff/+908SbdPmHYux/nMiT2PPHeeLECZ0/f95pG3lCQ0Otid28hFZsbGyBcjExMQ5jOnnypNvvrBwyZIjmz59vfZ6YmGjzQ1a+aNOmjfbs2aP//Oc/ys7OVpMmTXT48GFJUt26dQuUP3jwoG677TZFRkZq+fLlbn+46IMPPlBCQkKhksVF4fz587r//vv166+/6quvvirwPzTKly+v4OBg/fHHHwXq5m2zT1xKl+/SXrp0qRYsWFDgf+x8/fXXWrlypRYvXmzzWnrx4kWdPXtW+/btU/ny5a2JdQAArmYkNwEAQKHcddddeuedd/Tjjz+qZcuWhWqjR48eevHFF/XHH38U+AEZV6pXr66bbrpJ69at0xNPPKHAQP+9pTl58qTWrl2r8ePH68UXX7Ruz7vLMU+FChUUERHhMMGbn7M77GrUqCFJSktLU82aNa3bz58/r71791p/FdtfwsLCNHbsWPXp00cLFy5U9+7dVatWLUmX77xz1V9MTIxCQkK0e/fuAvscbfO3WrVqac2aNbrppps8SvLecMMNuuGGGzRhwgR98MEH6tmzpz766CP179/faZ169epp7969PsV5//33a/369W7L9erVy/pr3nkJPEe/3n348GHVq1evwPa9e/eqSZMmLvsYPny4zZ3Trj5yXxilSpWySYivWbNGkgocR8ePH9dtt92mnJwcrV27VpUqVXLZ7g8//KDdu3dbfyTIE56cY/bJw7S0NOt+V3Jzc/Xoo49q7dq1WrhwoRITEwuUCQgIUKNGjbRly5YC+3744QfVrFmzQEL3+eef19y5c/X666/roYceKlDvwIEDki4fU/YOHTqk+Ph4TZ06Vc8884zbMQAA8HdHchMAABTK8OHD9cEHH6hv375au3ZtgTvPXH3EN0+tWrX0+uuv6+zZs14nSF9++WV98803evDBB72q507eHXr28b/++us2zwMCAtS5c2e9//772rJlS4Hv3cz76HDZsmUlqcAvM7dv316lS5fWtGnT1LFjR2uCZs6cOcrIyHD7q/GF0bNnT40ZM0aTJk1S9+7ddd1116lWrVqaMmWKevToUeDOxmPHjqlChQoqVaqU2rdvryVLlujw4cPWu9B2796tFStW+D1Oew888IBmzpypl156SRMnTrTZd/HiRWVlZSkqKkonT55UVFSUTbIrLwHn6CPD+bVu3VqvvPKKcnJyCv39hq+++qrLuz/z5L+LLyEhQU2aNNHnn3+uv/76y3pH5qpVq3Tw4EE99dRTNnUzMjKUnp6uJ554wmUfDRo0UIMGDQoxCu8dO3ZMkyZNUuPGjW2Sm9nZ2brzzjt16NAhffPNN6pTp47btj744ANJ8uj7d/M4O8euv/56xcTEaPbs2erbt691XVesWKHffvvN5n9eOPPUU0/p448/VkpKisNEY56uXbtqxIgRNq8FaWlp+vrrrzVs2DCbssnJyZoyZYpGjRqlIUOGOGzvlltu0WeffVZg+4ABA1SjRg2NHj1ajRo1chs/AABXA5KbAACgUOrUqaMPPvhADz30kBISEtSzZ081adJEhmFo7969+uCDDxQQEKCqVau6bMfZH/fuJCYmOryLylcRERFq06aNJk+erAsXLqhKlSpatWqVw7v6Jk6cqFWrVikxMVEDBgxQ/fr19ccff+iTTz7Rhg0bFBUVpaZNm6pUqVKaNGmSMjIyFBwcrFtuuUUxMTEaOXKkxo8fr44dO6pTp05KS0vTzJkz1aJFC5ffV1pYQUFBGjJkiJ5//nmtXLlSHTt21DvvvKM77rhD1157rfr06aMqVapYk1ERERH68ssvJUnjxo3TqlWrdNNNN+mJJ57QpUuXNGPGDDVs2FBbt271e6z5JSYmauDAgUpKStLWrVt12223KSgoSLt27dInn3yiN954Q127dtX8+fM1c+ZM3XfffapVq5ZOnz6tt99+WxEREbrzzjtd9nHvvffqpZde0vr16wv9NQeF/Rj11KlT1aFDB918880aOHCgMjIy9Nprr6lu3boFkphr1qyRYRi69957C9WXMxkZGZo+fbokaePGjZKkGTNmKCoqSlFRURo8eLC1bGJiolq3bq3atWvryJEjeuutt5SVlaWlS5fafLVEz5499eOPP6pv37767bff9Ntvv1n3hYWFqXPnzjYxXLp0SR9//LFuuOEG613FnqhVq5aioqI0e/ZshYeHq2zZsmrVqpXi4+M1adIk9enTR4mJiXrooYf0559/6o033lBcXJyGDh3qst3XX39dM2fOVOvWrVWmTBm9//77Nvvvu+8+a2J10KBBevvtt3XXXXdp2LBhCgoK0muvvabY2Fg999xz1jqfffaZhg8frjp16qh+/foF2uzQoYNiY2NVvXr1At/zKknPPPOMYmNjC8wdAABXteL6mXYAAPD3sHv3buOJJ54wateubYSEhBihoaFGvXr1jMcff9zYunWrTdmxY8cakoxjx465bFOS8eSTT1qf792715BkJCcnu6zXq1cvo2zZsm5jdhfH77//btx3331GVFSUERkZaXTr1s04fPiwIckYO3asTdn9+/cbjz76qFGhQgUjODjYqFmzpvHkk08aOTk51jJvv/22UbNmTaNUqVKGJOObb76x7psxY4ZRr149IygoyIiNjTWeeOIJ4+TJkzZ9JCYmGtdee63bcXkyvoyMDCMyMtJITEy0bvvll1+M+++/34iOjjaCg4ONGjVqGA888ICxdu1am7pr1641mjVrZpQuXdqoVauW8c477xjPPfecERISYlOuRo0aRq9evazP586da0gyNm/e7FGcztbxrbfeMq677jojNDTUCA8PNxo1amQMHz7cOHz4sGEYhvHzzz8bDz30kFG9enUjODjYiImJMe6++25jy5YtHs1b48aNjX79+nkUY96Y9u7d61Hb7qxevdq44YYbjJCQEKN8+fLGI488Yvzxxx8Fyj344IPGzTff7Jc+88s7xxw9atSoYVN26NChRs2aNY3g4GCjQoUKRo8ePYz09PQCbdaoUcPjNg3DMFauXGlIMqZNm+Z1/J9//rnRoEEDIzAw0JBkzJ0717rv448/Npo1a2YEBwcb5cuXN3r27Gn8/vvvbtvs1auX0/gdrf3BgweNrl27GhEREUZYWJhx9913G7t27bIpk3c8OXvkf21wpEaNGsZdd93l6bQAAHBVsBiGB58ZAwAAABzo3Lmz/vvf/xb4TlIzeu+99/Tkk0/qwIEDioqKKu5wCjhy5Iji4+P10Ucf+f3OTQAAALPy7CdJAQAAcNU7e/aszfNdu3Zp+fLlatu2bfEE5Gc9e/ZU9erV9eabbxZ3KA69/vrratSoEYlNAACAfLhzEwAAAB6pVKmSevfurZo1a2r//v2aNWuWcnJy9Msvv3j0YzEAAACAv/GDQgAAAPBIx44d9eGHH+rIkSMKDg5W69atNXHiRBKbAAAAKDbcuQkAAAAAAADAlPjOTQAAAAAAAACmRHITAAAAAAAAgCnxnZt+lpubq8OHDys8PFwWi6W4wwEAAAAAAABMxTAMnT59WpUrV1ZAgOt7M0lu+tnhw4dVrVq14g4DAAAAAAAAMLWDBw+qatWqLsuQ3PSz8PBwSdLuvQcVHhFRzNFI1dsO04F1U4q0zfzPHe3L46yMo7L5y3sbg7+4itPdWHztV3I9fnf1vanrqrw3bRXFXDjqQ7o8N4Xtr6jjvBLz4CszxAjg76mw19C8svb/ddTu1cyf88Cceq+kzZmv7ynx98GxAPw9FOV1pqRdwyTpdGamasdXs+bZXCG56Wd5H0UPj4hQRAlIblpKlfZ7HPZt5n/uaF8eZ2Uclc1f3tsY/MVVnO7G4mu/kuvxu6vvTV1X5b1pqyjmwlEf0uW5KWx/RR3nlZgHX5khRgB/T4W9huaVtf+vo3avZv6cB+bUeyVtznx9T4m/D44F4O+hKK8zJe0alp8nX/nIDwoBAAAAAAAAMCXu3DSZ3NxcnTp1Sjk5OR6VNy5k648//vBrDPZt5n/uaF8eZ2Uclc1f3tsY/MVVnO7G4mu/kuvxu6vvTV1X5b1pqyjmwlEf0uW5KWx/RR3nlZgHXxU2xrJly5bY/5sHAAAAALg6kdw0idzcXM15+y0tX/aljh790+N6Zf/6S13vu8evsdi3mf+5o315nJVxVDZ/eW9j8BdXcbobi6/9Sq7H766+N3VdlfemraKYC0d9SJfnprD9FXWcV2IefOVLjLVq19EDDz6ku+/p5OeoAAAAAADwHslNk5iUNEHLl32pLvd3UYuWLVWmTBmP6u3cd0R14yr6NRb7NvM/d7Qvj7MyjsrmL+9tDP7iKk53Y/G1X8n1+N3V96auq/LetFUUc+GoD+ny3BS2v6KO80rMg68KE6NhGDp16pTWrlmjpAn/0sWLF9X5vvuLKEIAAAAAADxDctME/vrrLy1b+oWeeWaoevTo4VXd0hEH1Kx+db/GY99m/ueO9uVxVsZR2fzlvY3BX1zF6W4svvYruR6/u/re1HVV3pu2imIuHPUhXZ6bwvZX1HFeiXnwlS8x3n777XpxzBi9Oy9V93a+z6MvdwYAAAAAoKjwg0ImsGXzjzIMQ3fffXdxhwLgKmexWHTnXXfpzz+P6MCBA+4rAAAAAABQhEhumkBWVpaCgoL4IQ8AJcI111wjSco6fbqYIwEAAAAAXO1IbpoEH/0EUFIEBHDpAAAAAACUDPyFiqvK+HHjNH7cuOIO42+tT5/emjdvnt/aa9TwWi1dulSS9OVnn6jH/XdY99WMj9OSJUv81hcAAAAAADAXkpsmdku7tgoNCVZEeJgiI8LVqOG1+uSTT6z79+3bp+uvraFTp05Ztx04cEB9+vRW1SqVFRkRrrp1auvpp57SH3/84VGfr06Zou733a6oyAhVr1ZVzw8bpgvnz9uU2bhxo/5x802KCA9Th3801+zpr1r39enTWzc0qa2I8DDr49///rd1/+8H9uvpgY+qXetGqla1ipInT7Zp+3//+586tL9V7Vo3UuVKFTVwwACdOXPGi1krnJf+9S+VCrBoxYoVNtsPHzqoUgEWv87xe3NTCszxebs5li7/enWbf9xcoP/fD+zXnXfeoejy5RzOYbduXVWlciVFRUaoVs14vTN7mu2YDh/WXXfdqfCwsrrr1tZ6++23PYq7sNLS0tSp0z2KqXCNoiIj1KB+PU2eNMm6/z/b/1siv2/2lnZt9cbrr9tsqxkfp3Vrv/JrP5mZmerZs4eiIiNUqWKsXn7pJZ/KZ2ZmavTzTzndb398THj5Zb+OBwAAAAAAfyK5aXKvvDJJmaezdCojU69MmqxHHu6p/fv3Oyx74MABtWrZQkGBQdqwcZNOZWTquw0bValSJa1fv96j/i5duqQx/5qsY38d16Z/f6/169fprZmvW/fvSvtNXe6/T88Ne15/HT+hL77aoFtvu9OmjW7dH1Hm6Szro3Xr1ta2nx3cTwkNGmr1tz9rzdqv9eabM/TBBx9Y6z7cs4fq1k3QqvU/aduv/9Gvv25zm+zxlWEYmjdvrsqXL6/U1Dkuy/pnjnMLzLGju01nzZyp4OBgu7qX57B5s+Y68udRh3P44otjtWfvPp3KyNQ369brq2Wf6/3337fu79njIVWMragjfx7VpKkz9cLw5z2OvTDuufsuNWncRPv2H9DxEyf1yaJPFV+zZpH1ZzZPP/2UTpw4oX37D2j9t9/pnXfe1rvvvlvo8k8//ZQyMzKc7rc/Pj788AOb4wMAAAAAgJKE5ObfhMVi0V133aWoqCilpaU5LDNu3Fg1atRIb739tuLi4mSxWBQbG6uRo0ape/fuHvUz/IUXdG2jJgoKClLVqlX1yCOPauvPm63735k9Tf369Vfnzp1VunRphZYpozoJ9T1qe//edO3ft0cDnnhGgUFBSkhIUN++/fTO229Zy+zZs0c9H35YQaVLq0KFCrrnnk76z/b/eNR+Ya1du1aHDh3SrNkp+vKLL3TyxHGnZf0xx737P1Fgjjdu3GBT5uDBg5o69TW9Msn2rsy0tDTt37dHL44dqyAnc9ioUSNrUtRiscgSEKDdu3ZJktLT07VhwwZNTEpS2bJl1bBxM/Xo0VNz56Z6FLu3/vrrL6Wnp2vAwIEqU6aMSpUqpWuvvVbdunWzlnH30fNdO3fqxtY3KDIiXO3aJurgwYPWfbt371bHjrfrmujyqlO7ls2dluPHjdN993W2aat8uSitW7fO+vyjjz5S0yaNVb5clFq1bKFNmzZJkoY995y+++47jRjxgiLCw3TnnXfogQe66cCBAxr9/FOKCA/TE48/Lkk6evSoHn64p6pUrqSqVSpr6DPPKCcnx6P5OXPmjD7+6CO99NLLioqKUt26dTV48FOa6yTJ7q583v4nnh7mtD374yMg3/EBAAAAAEBJQ3LzbyI3N1eff/65zp49q6ZNmzoss+qrr/Rg94dctjPplVd0zz2efwR4/bfrVbtuPevzn7f8oPPnz6t5s6aKjamgpwY8qn17023qLPviU10TXV6NGl6r1159Vbm5uZfHYBiSJEOGzbh+/fVX6/Pnnhum9959V+fOndORI0e0ZMlnuvvuezyOtzBSU+forrvvVpcuXVS5cmUt+2Kx07JFNceNGjW22TZo0BN6cew4RUdH22zPm0vDcD6HkvTkoEEKK1tGcTWq6+yZM+rVu7ck6ddff1WlSpUUGxtrLdukaVP9x66+v0RHRyshIUH9+vbRwoULnd517MqCBe9rwQcf6s+jx1SmbFm9+OIYSdLFixfV6Z671aRxE/1+6LA+XfyZkpMna+XSJR61u3z5cg1/fphS587TX8dP6IURI3Vvp3t0/PhxTXn1Vf3jH/+w3jm9fPkKLVz4iapXr64JydOVeTpLs2bPlmEY6nxvJ1WMrahdu9Otdxvn/6h30yaNbe6szS8tLU3nz5+3OaebNG1aYD09LZ+3v269Bi7by398ZGVlWY8PAAAAAABKGpKbJjdq1EiVLxel8LCy6trlfo0e/U/FxMQ4LHvs2DFVqVLFZXsvjBihL79c6lHfb7/9tjZt3Kh+Awdbt2VmnNLHH3+kd997XwcO/q46CfX13FOP6eLFi5Kkp556Wp8u+0Z/Hj2mt9+Zo2nT3tC0N96QJMXF1VSlylU1e/prOn8+R//97381d26qMjMzre13vOMObdy4QYktG1y+E65aNfXt29ejeAvjxIkTWvLZZ3r00V6yWCx6+OFH9MXij52WL6o5HjV6tHXbhx9+qJxz5/TII48UKJ+QkKBKlatq7IsvKifH8RxK0pszZyrzdJZ++HGz7up0v8qVKydJysrKUlRUlE3ZqKgonT592qN4vWWxWPT1N+vUuHETvfSv8apdq6YaXttAq1ev9riNx58YpPj4eIWEhKhHj576+aefJEk//PCD/vjjD7308ssKCQlR48aN9eSTg/Xl54s8anfmzDc1bNjzat68uQICAnT//ferXr16Wr58ucexbdmyRbt27dLk5GSVKVNG0dHRGjFylD788P+SmVu3/aoePXo4rJ+VlaWyZcsqMDDQus3Vergr72l7+Y+PRx551Hp8AAAAAABQ0pDcNLmJE5N04uQpZZ85q992pOndd+crJSXFYdlrrrlGhw4d8ku/CxYs0Itj/qmVX63SNRX+7y6/0DJl1bt3HzVs2FDBwcF6/Kln9fuBfTqwb48kqXnz5ipXPlqlSpXSDTfcoBdeGKGFCy8nCwODgvTqjHeUtuO/uqNdKz3ycE/17t3HenfiyZMndVuH9urf/zFt2LJDfx0/obJly+qRRx72y5gc+WDBAkVEROjOOy9/b+gjjz6qPem79P333zssX1RzXKlSJUmXk62jRo7QmzNnOawT9P/n8Jetv6ha1SoF5jC/gIAAXX/99SpTtqyeHzZMkhQWFqaMjAybchkZGQoPD/fLmBypWLGiprz6qv6z/b/68+gxdex4h7rcf59OnDjhcf08ZcuWtSbqfv/9d1WuXFmlS5e27o+vWVNHj3j2w0779+3T6NGjVL5clPWxdetWHfZiffft26dTp07pmujy1jYe6NZVf/75p0f1w8LCdObMGev/HJBcr4e78t60l3d8hIeHW48PAAAAAABKGpKbfyO1a9fWHXfcqWXLHN8VeNvtt1sTib5YsfQzPTv0GS1fsVKNG9t+XLqu3fdrWmRx2ZYlwPYQrFW7rt58+32t3bhVP/+yVTk5OWqTmCjp8vdBnj17Vk89/bSCSpdWuXLlNGDAQC1ftsznMTmTmjpHGRkZqlG9mipXqqjENv+QxWJR6hzH33lY1HP866+/6vDhw7rpxtaKqXCNrr+uuSSpTu1aWrTo8h2JtWrX1VdfrdLRY38VmENHLl68qN27L3+nYuPGjXX48GEdPXrUun/b1q1q2KiRz2PyRPny5TV23DhlZ2dr7969PrVVtWpVHT58WBcuXLBu279vn2IqXk4U5yX68mRnZ9vc4Vq1WjUlT3lVJ06esj5OZ2XrhREjJF1O/tmz31atWjXFxMTYtHHyVIYyT2d5NIaEhAQFBQVp27Zt1m3btm5VIyfr4a583v5dab951J4kXbhwwXp8AAAAAABQ0pDc/BvZt2+fVqxYrkYNHScqxo0br21bt+qJxx/XgQMHZBiGjh07psmTJunjjz1LyH344YeaMnGcli1foWbNmhXYf1+3hzR//jylpaXpwoULemvW66pWI07V4y7/+vXChQuVlXVahmFoy5YtmjzpFd1/fxdr/V1pv+nsmTO6cP68Fi9erLlzUzV69D8lSfXq1VNYWJhmzZypixcv6vTp03rnnbcdxuEPv/33P9q2bZu+WrVaP/+y1foYNTZJCxd+rOzs7AJ1/DHHK5d97nSOW7durfQ9e62xLF12+SPS67/9znp36a6035Sdna3zDuZw//79+vTTT5WVlaXc3Fxt2rRJH78/T7fddrskqVatWrrppps0etQonTlzRtt/3aoPPligvn37FXoeXTl58qTG/POf2rFjhy5duqQzZ85o6muvqXz58qpXr577Blxo2bKlYmNjrR/R3759u2bMmK677718vDVr3lzf//vf2rFjh86dO6fRo0bJYvm/ZPygQU/q1SnJ+umnn2QYhs6cOaM1a9bo999/lyTFxMYqPd32+2RjY2P1+8H/+97QFi1aqFq1ahrzz3/q9OnLx/3+/fu1YsUKj8ZQpkwZPfDgg3rxxTHKyMjQrl27NGPGdPXt179Q5fP2z5o+xeF+R8fH9OnTrMcHAAAAAAAlDclNk8v7teaI8DC1+cfNuvXW9hrz4osOy9aoUUM//LhZ53LOqfUNrRQVGaGbbmytQ4cOKfH/39mXNHGi7rzzDqf9/XP0KGVlZ+mWdm2t/T7Qqb11/x1336cnnxysW29pp4qxMfpt+3/02ow51u/4m/nmDN3d/kZFRoTrkYd76oknBunZ556z1l+9cqnubt9a7W5srNdenaLFny2x3rkYFhamz7/4Uh999KHa39xMNePjdOrUKc2dN9/XaXTo808/Utu2bdWmTRtVrFjR+rinc1eFhYU5TFb6Y45nvjG5wBw3anitJCk4OFhVq1a1PvI+kl25cmWVKVNG0uU5jKtRXdHlyxWYQ0ma9sbrql6tqsqXi1L/fn31QM9e1rsRJWnBBx/q0OFDio2poBeGPq5XJk22xu5vpUuX1qHDh3T3XXeqXFSk4mpU18ZNG7Vs+QqVLVvWp7aDgoL0xZdL9dPPP6lypYrqfG8nDR36rDre1VmSdMstt2jAgIG6+aYbVbdObTVs1Mjm49n33HOPJia9ooEDHlN0+XKqVTNe06a9Yf3RpiFDntHatWtUvlyU9QeiRowcpYUfzFf5clF6ctAglSpVSl98uVSHDh/StQ3qq1xUpO65+y6l795t7adRw2u1YMECp+OYPn2GIiMjVb1aVf3j5pvUt28/Pfroo9b9d955h5ImTvS4/PTpMxQWFuF0v/3xMXjwUzbHBwAAAAAAJYnFyP+zyvBZZmamIiMj9efxDEVERPilzUWfLNSb01/Xxo2bvK77y28H1Kx+db/E4azN/M8d7cvjrIyjsvnLexuDK+PHjZMkjf3//3XFVZzuxuKLvHkobLvexuSqvDdt5ZXt06e3EhPbqncR/MJ2/rkp7NwXxZpdyfb9wdcY09PT1b37g3rrnXm6tmFDP0YG4O+uXIvBOrl5RoF/e1rP/r+O2r2a+XMemFPvlbQ5K9fi8o9+lqSYUDw4FoC/h6K8zpS0a5h0Ob8WGx2pjAz3+TXu3DSBgIAAXbp0SeShAZQEeT9I5Oh7RwEAAAAAuJICizsAuFexYiVdunRJe/fuVc2aNYs7HFNLbNu2uEP427v33s6Ki4sr7jBQhHbtuvwDQ7H5fqkeAAAAAIDiwG03JnB9ixYKDS2jlNmzrXdMoXDatm2rtiQ4i1Tnzp3VtGnT4g4DReTUqVN679131ahRE5UvX764wwEAAAAAXOW4c9MESpcurTFjx2vMqBG6446Ouq75dQoNDbX5ZWdn/vgrQ5WuifRrPPZt5n/uaF8eZ2Uclc1f3tsY/MVVnO7G4mu/kuvxu6vvTV1X5b1pqyjmwlEf0uW5KWx/RR3nlZgHXxUmRsMwdPLkSW35aYtCQkI1/uWkIooOAAAAAADPkdw0icS27ZQ6/32t+mqldvz2P/159JhH9Rau+FEP3NHSr7HYt5n/uaN9eZyVcVQ2f3lvY/AXV3G6G4uv/Uqux++uvjd1XZX3pq2imAtHfUiX56aw/RV1nFdiHnxV2BjLlC2rvv0G6LaOdygmJqYIIgMAAAAAwDskN02kdp06ql2njld1FrYYrJR3/PuLV/Zt5n/uaF8eZ2Uclc1f3tsY/MVVnO7G4mu/kuvxu6vvTV1X5b1pqyjmwlEf0uW5KWx/RR3nlZgHX5khRgAAAAAAPMF3bgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMqkcnNefPmKSoqqrjDAAAAAAAAAFCCeZXc7N27tywWiywWi4KCghQfH6/hw4fr3Llzfg3qwQcf1M6dO/3apjeWLVumVq1aKTQ0VOXKlVPnzp2LLRYAAAAAAAAAjgV6W6Fjx46aO3euLly4oJ9++km9evWSxWLRpEmT/BZUaGioQkND/daeNz799FM99thjmjhxom655RZdvHhR27dvL5ZYAAAAAAAAADjn9cfSg4ODVbFiRVWrVk2dO3dW+/bttXr1auv+3NxcJSUlKT4+XqGhoWrSpIkWLVpk08YXX3yhOnXqKCQkRO3atdP8+fNlsVh06tQpSQU/lj5u3Dg1bdpUqampql69usLCwjRo0CBdunRJkydPVsWKFRUTE6MJEybY9HPq1Cn1799fFSpUUEREhG655RZt27bN6dguXryoIUOGKDk5WY8//rjq1q2rBg0a6IEHHvB2mgAAAAAAAAAUMa/v3Mxv+/bt2rRpk2rUqGHdlpSUpPfff1+zZ89WnTp19O233+rhhx9WhQoVlJiYqL1796pr164aMmSI+vfvr19++UXDhg1z21d6erpWrFihlStXKj09XV27dtWePXtUt25drV+/Xps2bVLfvn3Vvn17tWrVSpLUrVs3hYaGasWKFYqMjFRKSopuvfVW7dy5U+XLly/Qx88//6xDhw4pICBAzZo105EjR9S0aVMlJyerYcOGDuPKyclRTk6O9XlmZqa30wgAAAAAAACgELxObi5dulRhYWG6ePGicnJyFBAQoBkzZki6nOibOHGi1qxZo9atW0uSatasqQ0bNiglJUWJiYlKSUlRQkKCkpOTJUkJCQnavn17gbsu7eXm5io1NVXh4eFq0KCB2rVrp7S0NC1fvlwBAQFKSEjQpEmT9M0336hVq1basGGDfvzxRx09elTBwcGSpClTpmjJkiVatGiRBgwYUKCPPXv2SLp8p+hrr72muLg4vfrqq2rbtq3ThGhSUpLGjx/v7TQCAAAAAAAA8JHXyc127dpp1qxZys7O1tSpUxUYGKguXbpIknbv3q0zZ86oQ4cONnXOnz+vZs2aSZLS0tLUokULm/0tW7Z0229cXJzCw8Otz2NjY1WqVCkFBATYbDt69Kgkadu2bcrKylJ0dLRNO2fPnlV6errDPnJzcyVJo0ePto5p7ty5qlq1qj755BMNHDiwQJ2RI0fq2WeftT7PzMxUtWrV3I4HAAAAAAAAgG+8Tm6WLVtWtWvXliSlpqaqSZMmmjNnjvr166esrCxJl39tvEqVKjb18u6eLKygoCCb53m/2G6/LS9BmZWVpUqVKmndunUF2sr/fZ75VapUSZLUoEED67bg4GDVrFlTBw4ccFgnODjY57EBAAAAAAAA8J5P37kZEBCgUaNG6dlnn1WPHj3UoEEDBQcH68CBA0pMTHRYJyEhQcuXL7fZtnnzZl/CcKh58+Y6cuSIAgMDFRcX51Gd6667TsHBwUpLS9PNN98sSbpw4YL27dtn872iAAAAAAAAAIqf17+Wbq9bt24qVaqU3nzzTYWHh2vYsGEaOnSo5s+fr/T0dP3888+aPn265s+fL0kaOHCgduzYoRdeeEE7d+7UwoULNW/ePEmX77z0l/bt26t169bq3LmzVq1apX379mnTpk0aPXq0tmzZ4rBORESEHn/8cY0dO1arVq1SWlqannjiCes4AQAAAAAAAJQcPic3AwMDNXjwYE2ePFnZ2dl66aWXNGbMGCUlJal+/frq2LGjli1bpvj4eElSfHy8Fi1apMWLF6tx48aaNWuWRo8eLcn3j67nZ7FYtHz5crVp00Z9+vRR3bp11b17d+3fv1+xsbFO6yUnJ6t79+565JFH1KJFC+3fv19ff/21ypUr57fYAAAAAAAAAPjOq4+l591haW/EiBEaMWKE9fmQIUM0ZMgQp+106tRJnTp1sj6fMGGCqlatqpCQEElS79691bt3b+v+cePGady4cW5jsf9+zfDwcE2bNk3Tpk1zGou9oKAgTZkyRVOmTPG4DgAAAAAAAIArz6fv3CysmTNnqkWLFoqOjtbGjRuVnJyswYMHF0coAAAAAAAAAEyqWJKbu3bt0ssvv6wTJ06oevXqeu655zRy5MjiCAUAAAAAAACASRVLcnPq1KmaOnVqcXQNAAAAAAAA4G/C5x8UAgAAAAAAAIDiQHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApmQxDMMo7iD+TjIzMxUZGalTpzIUERFR3OHo8NGTqhxTrkjbzP/c0b48zso4Kpu/vLcx+IurON2Nxdd+Jdfjd1ffm7quynvTVlHMhaM+pMtzU9j+ijrOKzEPvjJDjAD+ngp7Dc0ra/9fR+1ezfw5D8yp90ranPn6nhJ/HxwLwN9DUV5nSto1TLqcX4uKilRGhvv8GslNP8tLbnoy+QAAAAAAAABseZNfC7xCMV11DOPywxPu7hC0v/vR0d0Lefs8aTdvn6M6ntQ1A1/v6nN3Z4mnc+7p2np6l6ovd6446svZnbbetO3Jnbz2fXu6Pr6UK8wxUJzHvSdrYT+3zjh7ffD0/9o7O/4d9Wn/GuVsmyf7HcWdP15Xx5Gj18nCcnb3ubNyzso4G4ejth2N0dG/nfXhqr6rPvKeu+sjfzlHXB0zno7Ffjyerqm766Q7zo4h+/g9nS9nsTn6tyfr5mqsjmJ19e/8XL0eeDrX7sp4c1emq/K+XNMdxeTs9TaPu/dY3hxvrq6nnrbtqE1PePJew9Nru/02T48xb9rOH6Oz9zmOxubp/Pnj2HR3PXb3OuHJNbwwPH1/5en7CPt2HZV3997PWb/OYvL2+mcfi7vrjSfXWVfXaUftODuvvTnfPTlHPenfkcK+dtrX9WZNvT0fvClfVHzpy91reWHnPz9n1xxnfTnr29V7Und9uzrunfH2PYO7fZ6cb/YxefMerqhen+3bdxWnfTl3a+bsPXP+fZ6WzR+HP143nMXv7HjN339+p09netw/d276WV5m+c/jnt+5Wa7FYJ3cPMPp9nItBlu35T23/2/ePk/azdvnqI4ndc2gsPHbz62ztjydc0/X1lWsjmJxFKer/pzF7Kh+Xhlvx+Iu3vx9e7o+vpQrzDFQnMe9J2thP7fOOHt98OR4s4/FXZ/2r1HOtnmy31Hc+eN1dRw5ep0sLEfr4KqcszLOxuGobUdjdPRvZ324qu+qj7zn7vrIX84RV8eMp2OxH4+na+ruOumOs2PIPn5P58tZbI7+7cm6uRqro1hd/Ts/V68Hns61uzKevp4W1XsST+Y+f7k87t5jeXO8ubqeetq2ozY94cl7DU+v7fbbPD3GvGk7f4zO3uc4Gpun8+ePY9Pd9djd64Qn1/DC8PT9lafvI+zbdVTe3Xs/Z/06i8nb6599LO6uN55cZ11dpx214+y89uZ89+Qc9aR/Rwr72mlf15s19fZ88KZ8UfGlL3ev5YWd//ycXXOc9eWsb1fvSd317eq4d8bb9wzu9nlyvtnH5M17uKJ6fbZv31Wc9uXcrZmz98z593laNn8c/njdcBa/s+M1f//5GZfOK+c/b3t05yY/KAQAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSmRyc968eYqKiiruMAAAAAAAAACUYF4lN3v37i2LxSKLxaKgoCDFx8dr+PDhOnfunF+DevDBB7Vz506/tumpuLg46xjzHq+88kqxxAIAAAAAAADAuUBvK3Ts2FFz587VhQsX9NNPP6lXr16yWCyaNGmS34IKDQ1VaGio39rz1r/+9S899thj1ufh4eHFFgsAAAAAAAAAx7z+WHpwcLAqVqyoatWqqXPnzmrfvr1Wr15t3Z+bm6ukpCTFx8crNDRUTZo00aJFi2za+OKLL1SnTh2FhISoXbt2mj9/viwWi06dOiWp4MfSx40bp6ZNmyo1NVXVq1dXWFiYBg0apEuXLmny5MmqWLGiYmJiNGHCBJt+Tp06pf79+6tChQqKiIjQLbfcom3btrkdY3h4uCpWrGh9lC1b1ttpAgAAAAAAAFDEfPrOze3bt2vTpk0qXbq0dVtSUpLeffddzZ49W//97381dOhQPfzww1q/fr0kae/everatas6d+6sbdu2aeDAgRo9erTbvtLT07VixQqtXLlSH374oebMmaO77rpLv//+u9avX69Jkybpn//8p3744QdrnW7duuno0aNasWKFfvrpJzVv3ly33nqrTpw44bKvV155RdHR0WrWrJmSk5N18eJFp2VzcnKUmZlp8wAAAAAAAABQ9Lz+WPrSpUsVFhamixcvKicnRwEBAZoxY4aky4m+iRMnas2aNWrdurUkqWbNmtqwYYNSUlKUmJiolJQUJSQkKDk5WZKUkJCg7du3F7jr0l5ubq5SU1MVHh6uBg0aqF27dkpLS9Py5csVEBCghIQETZo0Sd98841atWqlDRs26Mcff9TRo0cVHBwsSZoyZYqWLFmiRYsWacCAAQ77efrpp9W8eXOVL19emzZt0siRI/XHH3/otddec1g+KSlJ48eP93YaAQAAAAAAAPjI6+Rmu3btNGvWLGVnZ2vq1KkKDAxUly5dJEm7d+/WmTNn1KFDB5s658+fV7NmzSRJaWlpatGihc3+li1buu03Li7O5rsvY2NjVapUKQUEBNhsO3r0qCRp27ZtysrKUnR0tE07Z8+eVXp6utN+nn32Weu/GzdurNKlS2vgwIFKSkqyJknzGzlypE2dzMxMVatWze14AAAAAAAAAPjG6+Rm2bJlVbt2bUlSamqqmjRpojlz5qhfv37KysqSJC1btkxVqlSxqecoMeiNoKAgm+d5v9huvy03N1eSlJWVpUqVKmndunUF2sr/fZ7utGrVShcvXtS+ffuUkJBQYH9wcLDPYwMAAAAAAADgPa+Tm/kFBARo1KhRevbZZ9WjRw81aNBAwcHBOnDggBITEx3WSUhI0PLly222bd682ZcwHGrevLmOHDmiwMBAxcXFFbqdrVu3KiAgQDExMf4LDgAAAAAAAIDPfPpBIenyj/aUKlVKb775psLDwzVs2DANHTpU8+fPV3p6un7++WdNnz5d8+fPlyQNHDhQO3bs0AsvvKCdO3dq4cKFmjdvnqTLd176S/v27dW6dWt17txZq1at0r59+7Rp0yaNHj1aW7ZscVjn3//+t15//XVt27ZNe/bs0YIFC6w/iFSuXDm/xQYAAAAAAADAdz4nNwMDAzV48GBNnjxZ2dnZeumllzRmzBglJSWpfv366tixo5YtW6b4+HhJUnx8vBYtWqTFixercePGmjVrlvXX0v358W6LxaLly5erTZs26tOnj+rWravu3btr//79io2NdVgnODhYH330kRITE3XttddqwoQJGjp0qN566y2/xQUAAAAAAADAP7z6WHreHZb2RowYoREjRlifDxkyREOGDHHaTqdOndSpUyfr8wkTJqhq1aoKCQmRJPXu3Vu9e/e27h83bpzGjRvnNhb779cMDw/XtGnTNG3aNKex5Ne8eXN9//33HpUFAAAAAAAAULx8+s7Nwpo5c6ZatGih6Ohobdy4UcnJyRo8eHBxhAIAAAAAAADApIolublr1y69/PLLOnHihKpXr67nnntOI0eOLI5QAAAAAAAAAJhUsSQ3p06dqqlTpxZH1wAAAAAAAAD+Jnz+QSEAAAAAAAAAKA4kNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKFsMwjOIO4u8kMzNTkZGROnUqQxERER7VOXz0pCrHlHO6/fDRk9Ztec/t/5u3z5N28/Y5quNJXTMobPz2c+usLU/n3NO1dRWro1gcxemqP2cxO6qfV8bbsbiLN3/fnq6PL+UKcwwU53HvyVrYz60zzl4fPDne7GNx16f9a5SzbZ7sdxR3/nhdHUeOXicLy9E6uCrnrIyzcThq29EYHf3bWR+u6rvqI++5uz7yl3PE1THj6Vjsx+Ppmrq7Trrj7Biyj9/T+XIWm6N/e7JursbqKFZX/87P1euBp3Ptroynr6dF9Z7Ek7nPXy6Pu/dY3hxvrq6nnrbtqE1PePJew9Nru/02T48xb9rOH6Oz9zmOxubp/Pnj2HR3PXb3OuHJNbwwPH1/5en7CPt2HZV3997PWb/OYvL2+mcfi7vrjSfXWVfXaUftODuvvTnfPTlHPenfkcK+dtrX9WZNvT0fvClfVHzpy91reWHnPz9n1xxnfTnr29V7Und9uzrunfH2PYO7fZ6cb/YxefMerqhen+3bdxWnfTl3a+bsPXP+fZ6WzR+HP143nMXv7HjN339+p09nqn6dOGVkuM+vkdz0s7zkpieTDwAAAAAAAMCWN/k1PpZeRA4fPSnDkPVx6E/b5/YPd/v9Ve/Qnydt6rh7br/Nvqyrf3sSm6uy7tpxFKezes7i83T+Crs+3tQtzBx4Orfu1sfZXJaEh7/OHU+PF0fng7NzwJexeLIOJWXeS0JcJSEGb+Nydcy5ep0tjvnydByeXj88uW6U5GPDXcy+vCZfqbG6ei0r7DW7JD4Key55Mm5374/8tWaO1sWXNfH1muXs2HE0D/bbnZV3td3TMTu7Hnu75s7mqTDvD0vKw93cFvbY8nY9PLnOefPeypdrmbvXBk+OY0/n2l283sy3t+evJ326ux54Mo4rcV4U17lXnOe7s/dK/rw2e/vewV/r4O959eQa4Ml5W5zHgT/O7cLOW1GNxdftnpTxmAG/ysjIMCQZwY0eM85eMKyPkKZP2jy3f7jb7696IU2ftKnj7rn9Nvuyrv7tSWyuyrprx1Gczuo5i8/T+Svs+nhTtzBz4OnculsfZ3NZEh7+Onc8PV4cnQ/OzgFfxuLJOpSUeS8JcZWEGLyNy9Ux5+p1tjjmy9NxeHr98OS6UZKPDXcx+/KafKXG6uq1rLDX7JL4KOy55Mm43b0/8teaOVoXX9bE12uWs2PH0TzYb3dW3tV2T8fs7Hrs7Zo7m6fCvD8sKQ93c1vYY8vb9fDkOufNeytfrmXuXhs8OY49nWt38Xoz396ev5706e564Mk4rsR5UVznXnGe787eK/nz2uztewd/rYO/59WTa4An521xHgf+OLcLO29FNRZft7sr8+fxy/m1jIwMt7k47twEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiUyuTlv3jxFRUUVdxgAAAAAAAAASjCvkpu9e/eWxWKRxWJRUFCQ4uPjNXz4cJ07d86vQT344IPauXOnX9v0Vk5Ojpo2bSqLxaKtW7cWaywAAAAAAAAACvL6zs2OHTvqjz/+0J49ezR16lSlpKRo7Nixfg0qNDRUMTExfm3TW8OHD1flypWLNQYAAAAAAAAAznmd3AwODlbFihVVrVo1de7cWe3bt9fq1aut+3Nzc5WUlKT4+HiFhoaqSZMmWrRokU0bX3zxherUqaOQkBC1a9dO8+fPl8Vi0alTpyQV/Fj6uHHj1LRpU6Wmpqp69eoKCwvToEGDdOnSJU2ePFkVK1ZUTEyMJkyYYNPPqVOn1L9/f1WoUEERERG65ZZbtG3bNrdjXLFihVatWqUpU6Z4Oz0AAAAAAAAArpBAXypv375dmzZtUo0aNazbkpKS9P7772v27NmqU6eOvv32Wz388MOqUKGCEhMTtXfvXnXt2lVDhgxR//799csvv2jYsGFu+0pPT9eKFSu0cuVKpaenq2vXrtqzZ4/q1q2r9evXa9OmTerbt6/at2+vVq1aSZK6deum0NBQrVixQpGRkUpJSdGtt96qnTt3qnz58g77+fPPP/XYY49pyZIlKlOmjNu4cnJylJOTY32emZnptg4AAAAAAAAA33md3Fy6dKnCwsJ08eJF5eTkKCAgQDNmzJB0OdE3ceJErVmzRq1bt5Yk1axZUxs2bFBKSooSExOVkpKihIQEJScnS5ISEhK0ffv2Andd2svNzVVqaqrCw8PVoEEDtWvXTmlpaVq+fLkCAgKUkJCgSZMm6ZtvvlGrVq20YcMG/fjjjzp69KiCg4MlSVOmTNGSJUu0aNEiDRgwoEAfhmGod+/eevzxx3X99ddr3759bucjKSlJ48eP92YKAQAAAAAAAPiB18nNdu3aadasWcrOztbUqVMVGBioLl26SJJ2796tM2fOqEOHDjZ1zp8/r2bNmkmS0tLS1KJFC5v9LVu2dNtvXFycwsPDrc9jY2NVqlQpBQQE2Gw7evSoJGnbtm3KyspSdHS0TTtnz55Venq6wz6mT5+u06dPa+TIkW7jyTNy5Eg9++yz1ueZmZmqVq2ax/UBAAAAAAAAFI7Xyc2yZcuqdu3akqTU1FQ1adJEc+bMUb9+/ZSVlSVJWrZsmapUqWJTL+/uycIKCgqyeZ73i+3223JzcyVJWVlZqlSpktatW1egrfzf55nf119/rX//+98FYr3++uvVs2dPzZ8/v0Cd4OBgn8cGAAAAAAAAwHs+fedmQECARo0apWeffVY9evRQgwYNFBwcrAMHDigxMdFhnYSEBC1fvtxm2+bNm30Jw6HmzZvryJEjCgwMVFxcnEd1pk2bppdfftn6/PDhw7r99tv18ccfW7/HEwAAAAAAAEDJ4PWvpdvr1q2bSpUqpTfffFPh4eEaNmyYhg4dqvnz5ys9PV0///yzpk+fbr3rceDAgdqxY4deeOEF7dy5UwsXLtS8efMkXb7z0l/at2+v1q1bq3Pnzlq1apX27dunTZs2afTo0dqyZYvDOtWrV1fDhg2tj7p160qSatWqpapVq/otNgAAAAAAAAC+8zm5GRgYqMGDB2vy5MnKzs7WSy+9pDFjxigpKUn169dXx44dtWzZMsXHx0uS4uPjtWjRIi1evFiNGzfWrFmzNHr0aEm+f3Q9P4vFouXLl6tNmzbq06eP6tatq+7du2v//v2KjY31Wz8AAAAAAAAAiodXH0vPu8PS3ogRIzRixAjr8yFDhmjIkCFO2+nUqZM6depkfT5hwgRVrVpVISEhkqTevXurd+/e1v3jxo3TuHHj3MZi//2a4eHhmjZtmqZNm+Y0Flfi4uJkGEah6gIAAAAAAAAoWj5952ZhzZw5Uy1atFB0dLQ2btyo5ORkDR48uDhCAQAAAAAAAGBSxZLc3LVrl15++WWdOHFC1atX13PPPaeRI0cWRygAAAAAAAAATKpYkptTp07V1KlTi6NrAAAAAAAAAH8TPv+gEAAAAAAAAAAUB5KbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWLYRhGcQfxd5KZmanIyEj9tmufEmrVsG4/fPSkKseUc1rP3X5/1Tt89KQkWeu4e26/LX9/7v7tSWyuyrprx367fXlP4rMfq7s4C8PTuoWZA0/ac7TGrubHm5ivBH+dO54eL/bzkl9h18JRDJ6sQ3EqaXGVhBgccRWXq2NOcv46W9RxeVve1Wup5Pj64cl1w1+Kuk1Xr82FbdMfcXlT1v61THJ9TTATR+eZ5P5c8mTcro73wsbnrEwef1yLnZ1/3tR3dOy4e09hz9Ptno7ZUSzevJ9zdaw4+7dZOIo/73ne/sIcW96uh6N/Oyqfnzfv9b2J191rg6u/DfLH5qiP/HE7a7Mw43B2jLur465Pd9eD/H06a/NKnBfFde4V5/XP1d8f/ro2e/veIc+V7NfT9vI4uwa4Oh/yylypeF314cu5XZg+Jf+fV96+3hV2zJmZmYqKilRGRoYiIiJc1ie56Wd5yU1PJh8AAAAAAACALW/ya4FXKKarjmFcfuD/mPH/hAMAAAAAUJTM+gkKoCh5k1MjuVlEci5dfuD/1O44RpJ0cvOMYo4EAAAAAICSoXbHMfydDNjxJqfGDwoBAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwpRKZ3Jw3b56ioqKKOwwAAAAAAAAAJZhXyc3evXvLYrHIYrEoKChI8fHxGj58uM6dO+fXoB588EHt3LnTr216qlOnTqpevbpCQkJUqVIlPfLIIzp8+HCxxAIAAAAAAADAOa/v3OzYsaP++OMP7dmzR1OnTlVKSorGjh3r16BCQ0MVExPj1zY91a5dOy1cuFBpaWn69NNPlZ6erq5duxZLLAAAAAAAAACc8zq5GRwcrIoVK6patWrq3Lmz2rdvr9WrV1v35+bmKikpSfHx8QoNDVWTJk20aNEimza++OIL1alTRyEhIWrXrp3mz58vi8WiU6dOSSr4sfRx48apadOmSk1NVfXq1RUWFqZBgwbp0qVLmjx5sipWrKiYmBhNmDDBpp9Tp06pf//+qlChgiIiInTLLbdo27ZtLsc3dOhQ3XDDDapRo4ZuvPFGjRgxQt9//70uXLjg7VQBAAAAAAAAKEKBvlTevn27Nm3apBo1ali3JSUl6f3339fs2bNVp04dffvtt3r44YdVoUIFJSYmau/everatauGDBmi/v3765dfftGwYcPc9pWenq4VK1Zo5cqV1rsp9+zZo7p162r9+vXatGmT+vbtq/bt26tVq1aSpG7duik0NFQrVqxQZGSkUlJSdOutt2rnzp0qX7682z5PnDihBQsW6MYbb1RQUJDDMjk5OcrJybE+z8zMdNsuAAAAAAAAAN95ndxcunSpwsLCdPHiReXk5CggIEAzZsyQdDnRN3HiRK1Zs0atW7eWJNWsWVMbNmxQSkqKEhMTlZKSooSEBCUnJ0uSEhIStH379gJ3XdrLzc1VamqqwsPD1aBBA7Vr105paWlavny5AgIClJCQoEmTJumbb75Rq1attGHDBv344486evSogoODJUlTpkzRkiVLtGjRIg0YMMBpXy+88IJmzJihM2fO6IYbbtDSpUudlk1KStL48eO9mkMAAAAAAAAAvvP6Y+nt2rXT1q1b9cMPP6hXr17q06ePunTpIknavXu3zpw5ow4dOigsLMz6ePfdd5Weni5JSktLU4sWLWzabNmypdt+4+LiFB4ebn0eGxurBg0aKCAgwGbb0aNHJUnbtm1TVlaWoqOjbWLZu3evNRZnnn/+ef3yyy9atWqVSpUqpUcffVSGYTgsO3LkSGVkZFgfBw8edDsWAAAAAAAAAL7z+s7NsmXLqnbt2pKk1NRUNWnSRHPmzFG/fv2UlZUlSVq2bJmqVKliUy/v7snCsv9YeN4vtttvy83NlSRlZWWpUqVKWrduXYG28n+fpyPXXHONrrnmGtWtW1f169dXtWrV9P3331vvRs0vODjY57EBAAAAAAAA8J5P37kZEBCgUaNG6dlnn1WPHj3UoEEDBQcH68CBA0pMTHRYJyEhQcuXL7fZtnnzZl/CcKh58+Y6cuSIAgMDFRcXV+h28pKl+b9XEwAAAAAAAEDx8/pj6fa6deumUqVK6c0331R4eLiGDRumoUOHav78+UpPT9fPP/+s6dOna/78+ZKkgQMHaseOHXrhhRe0c+dOLVy4UPPmzZN0+c5Lf2nfvr1at26tzp07a9WqVdq3b582bdqk0aNHa8uWLQ7r/PDDD5oxY4a2bt2q/fv36+uvv9ZDDz2kWrVqObxrEwAAAAAAAEDx8Tm5GRgYqMGDB2vy5MnKzs7WSy+9pDFjxigpKUn169dXx44dtWzZMsXHx0uS4uPjtWjRIi1evFiNGzfWrFmzNHr0aEm+f3Q9P4vFouXLl6tNmzbq06eP6tatq+7du2v//v2KjY11WKdMmTJavHixbr31ViUkJKhfv35q3Lix1q9fz0fPAQAAAAAAgBLGYjj7pZwraMKECZo9e/bf4sd4MjMzFRkZqT+PZygiIqK4wylRyrUYLEk6uXlGMUcCAAAAAEDJUK7FYP5OBuxkZmYqNjpSGRnu82s+fedmYc2cOVMtWrRQdHS0Nm7cqOTkZA0ePLg4QgEAAAAAAABgUsWS3Ny1a5defvllnThxQtWrV9dzzz2nkSNHFkcoAAAAAAAAAEyqWJKbU6dO1dSpU4ujawAAAAAAAAB/Ez7/oBAAAAAAAAAAFAeSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADClwOIO4O8quNTlB/7P7pUvSWJeAAAAAADIs3vlS/ydDNjx5pwguVlELJbLD/yfKrHlijsEAAAAAABKFP5WBgryJqfGx9KLiGFIh/48afNf+387e+6qvKuHs7KO4nBUxptY3I3NXdzejMub8u7G6Mn43c1jYR+u2ve17cLGUpwx8PDP+V0SH/46V/5u82LGeHnYrl1JXb+ium5d6Xjzz3P+h309Z++lCvuexF+xX+k5dDVXntZztu3v8PDHe0df+i1pc1lS4yrq9SiOmD19jXNV1tV2+7quzl9v31N58jecs9cOV39LXg1/ezgbo6uHfT131y5Pcgmerqc3r/1muD54eowV1zg8PRdcncvujhlPjiFP1tXT89zddn/NvacshuFNcbiTmZmpyMhI/Xk8QzVuHaWTm2eoXIvBOrl5hiTZ/NvZc0lOy7virGzedldt2ffrLhZHbboap6ex+lre3Rg9Gb+7eSwsV+vga9uFjaU4Y4B/zu+SyF/nypXo60ozW7z4P46ukyVFUV23ioon1+P8XL33cLbdm/ck/or9SnI0T5L749O+Xt68edOGWfjjvaMv/ZaUYyVPSY3LXkmPzxF3f9/Zl81TmL87HP3NYt+mJ+24is3d33D5+7fn7G/Jq+FvD2djdMXba5cnuYT89fP6cBavfSyuxuauTHHz9BgrruPO01yAs7l2dj65OwYKs66enufOjiFX7Xo795mZmYqNjlRGRoYiIiJcluXOTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZUIpOb8+bNU1RUVHGHAQAAAAAAAKAE8yq52bt3b1ksFlksFgUFBSk+Pl7Dhw/XuXPn/BrUgw8+qJ07d/q1TU/s27dP/fr1U3x8vEJDQ1WrVi2NHTtW58+fv+KxAAAAAAAAAHAt0NsKHTt21Ny5c3XhwgX99NNP6tWrlywWiyZNmuS3oEJDQxUaGuq39jy1Y8cO5ebmKiUlRbVr19b27dv12GOPKTs7W1OmTLni8QAAAAAAAABwzuuPpQcHB6tixYqqVq2aOnfurPbt22v16tXW/bm5uUpKSrLe/dikSRMtWrTIpo0vvvhCderUUUhIiNq1a6f58+fLYrHo1KlTkgp+LH3cuHFq2rSpUlNTVb16dYWFhWnQoEG6dOmSJk+erIoVKyomJkYTJkyw6efUqVPq37+/KlSooIiICN1yyy3atm2b07HlJW5vu+021axZU506ddKwYcO0ePFip3VycnKUmZlp8wAAAAAAAABQ9Ly+czO/7du3a9OmTapRo4Z1W1JSkt5//33Nnj1bderU0bfffquHH35YFSpUUGJiovbu3auuXbtqyJAh6t+/v3755RcNGzbMbV/p6elasWKFVq5cqfT0dHXt2lV79uxR3bp1tX79em3atEl9+/ZV+/bt1apVK0lSt27dFBoaqhUrVigyMlIpKSm69dZbtXPnTpUvX96jMWZkZLgsm5SUpPHjx3vUFgAAAAAAAAD/8Tq5uXTpUoWFhenixYvKyclRQECAZsyYIenyXYwTJ07UmjVr1Lp1a0lSzZo1tWHDBqWkpCgxMVEpKSlKSEhQcnKyJCkhIUHbt28vcNelvdzcXKWmpio8PFwNGjRQu3btlJaWpuXLlysgIEAJCQmaNGmSvvnmG7Vq1UobNmzQjz/+qKNHjyo4OFiSNGXKFC1ZskSLFi3SgAED3I519+7dmj59usuPpI8cOVLPPvus9XlmZqaqVavmtm0AAAAAAAAAvvE6udmuXTvNmjVL2dnZmjp1qgIDA9WlSxdJl5OBZ86cUYcOHWzqnD9/Xs2aNZMkpaWlqUWLFjb7W7Zs6bbfuLg4hYeHW5/HxsaqVKlSCggIsNl29OhRSdK2bduUlZWl6Ohom3bOnj2r9PR0t/0dOnRIHTt2VLdu3fTYY485LRccHGxNngIAAAAAAAC4crxObpYtW1a1a9eWJKWmpqpJkyaaM2eO+vXrp6ysLEnSsmXLVKVKFZt6viYAg4KCbJ7n/WK7/bbc3FxJUlZWlipVqqR169YVaCv/93k6cvjwYbVr10433nij3nrrLZ/iBgAAAAAAAFA0fPrOzYCAAI0aNUrPPvusevTooQYNGig4OFgHDhxQYmKiwzoJCQlavny5zbbNmzf7EoZDzZs315EjRxQYGKi4uDiP6x06dEjt2rXTddddp7lz59rcGQoAAAAAAACg5PA5c9etWzeVKlVKb775psLDwzVs2DANHTpU8+fPV3p6un7++WdNnz5d8+fPlyQNHDhQO3bs0AsvvKCdO3dq4cKFmjdvnqTLd176S/v27dW6dWt17txZq1at0r59+7Rp0yaNHj1aW7ZscVjn0KFDatu2rapXr64pU6bo2LFjOnLkiI4cOeK3uAAAAAAAAAD4h8/JzcDAQA0ePFiTJ09Wdna2XnrpJY0ZM0ZJSUmqX7++OnbsqGXLlik+Pl6SFB8fr0WLFmnx4sVq3LixZs2apdGjR0vy/aPr+VksFi1fvlxt2rRRnz59VLduXXXv3l379+9XbGyswzqrV6/W7t27tXbtWlWtWlWVKlWyPgAAAAAAAACULF59LD3vDkt7I0aM0IgRI6zPhwwZoiFDhjhtp1OnTurUqZP1+YQJE1S1alWFhIRIknr37q3evXtb948bN07jxo1zG4v992uGh4dr2rRpmjZtmtNY8rPvFwAAAAAAAEDJ5dN3bhbWzJkz1aJFC0VHR2vjxo1KTk7W4MGDiyMUAAAAAAAAACZVLMnNXbt26eWXX9aJEydUvXp1Pffccxo5cmRxhAIAAAAAAADApIoluTl16lRNnTq1OLoGAAAAAAAA8Dfh8w8KAQAAAAAAAEBxILkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAU7IYhmEUdxB/J5mZmYqMjNSpUxnKOndJlWPK6fDRk6ocU06SbP7t7Lkkp+VdcVY2b7urtuz7dReLozZdjdPTWH0t726Mnozf3TwWlqt18LXtwsZSnDHAP+d3SeSvc+VK9HWlmS1e/B9H18mSoqiuW0XFk+txfq7eezjb7s17En/FfiU5mifJ/fFpXy9v3rxpwyz88d7Rl35LyrGSp6TGZa+kx+eIu7/v7MvmKczfHY7+ZrFv05N2XMXm7m+4/P3bc/a35NXwt4ezMbri7bXLk1xC/vp5fTiL1z4WV2NzV6a4eXqMFddx52kuwNlcOzuf3B0DhVlXT89zZ8eQq3a9nfvMzExFRUUqIyNDERERLsuS3PSzvOSmJ5MPAAAAAAAAwJY3+TU+ll5EDOPy49CfJwv8+9CfJ62PvH3Oyto/8rfhbL+7tkvKw91YHM2J/dgcjdXRfLjq09P+nZW1j8tZnJ7062q/fRve9ufLOjnqy367o5icraGzthy17c06ulsLd/91d1x5Erur/c7a9mSsnh7znh5vns67u/OkMMeYt225mwN/v945ex31x9gLM0eevEZ5Gq83r5+u4vE0vsKO25c19fb1z9357q919GTdfD2fvFnTwhxHnrTt6nXZk9dxf8yvN/H52q6nx5uz65E/j6uiqlfU7Tk73715fSvsunl6fDh7L1GYY7Yorx1F8fAl5is13pI4p8W11v7stziP15K4pp7EeSWPeW/eK3lS1tP2PH2f7Os6F9f5c6X7vJJz56/3Wf5ae0/b8RR3bvpZXmb5z+OXM8vlWgzWyc0zJMn673ItBlvL5+3Lv9/+3/nlb8PZfndtlxTuxpK/TN6/89hvc1Xfvrx9n57276ysfVzO4vSkX1f77dtwdTx5Mreeyj+H+fuyH7OjmByN2VVbjtq2r+dsfPbtOZobV3NoP9f5+8u/3V3srvbbz419u67G6i42Z3G6a8dZnI7icvWa5A1v23I3B56cp97Gl8eTeS4K3r5GeXpc5C/jSR1n8di34695cHVOetqHt69/7s53X3hyLc/ft6/nkzdr6kk8rvryJp78Cns9Lmw87uLz9XXN0+PN2fWoMApb19+vWf5qz5P3O5L747ow6+Zqu6v3L97EZd++t3WKmy8xX6nxltS/c6Qrv9b+7Lc4j9eSuKaOFOZ9ur/6te/HH3/TetKep++TPeFNzFeCWY47qXBz56/3Wf7OMbiSmZmp2Gju3AQAAAAAAADwN0ZyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmRHITAAAAAAAAgCmR3AQAAAAAAABgSiQ3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokNwEAAAAAAACYEslNAAAAAAAAAKZEchMAAAAAAACAKZHcBAAAAAAAAGBKJDcBAAAAAAAAmBLJTQAAAAAAAACmVCKTm/PmzVNUVFRxhwEAAAAAAACgBPMqudm7d29ZLBZZLBYFBQUpPj5ew4cP17lz5/wa1IMPPqidO3f6tU1PTZgwQTfeeKPKlClDghUAAAAAAAAowby+c7Njx476448/tGfPHk2dOlUpKSkaO3asX4MKDQ1VTEyMX9v01Pnz59WtWzc98cQTxdI/AAAAAAAAAM94ndwMDg5WxYoVVa1aNXXu3Fnt27fX6tWrrftzc3OVlJSk+Ph4hYaGqkmTJlq0aJFNG1988YXq1KmjkJAQtWvXTvPnz5fFYtGpU6ckFfxY+rhx49S0aVOlpqaqevXqCgsL06BBg3Tp0iVNnjxZFStWVExMjCZMmGDTz6lTp9S/f39VqFBBERERuuWWW7Rt2zaX4xs/fryGDh2qRo0aeTQfOTk5yszMtHkAAAAAAAAAKHqBvlTevn27Nm3apBo1ali3JSUl6f3339fs2bNVp04dffvtt3r44YdVoUIFJSYmau/everatauGDBmi/v3765dfftGwYcPc9pWenq4VK1Zo5cqVSk9PV9euXbVnzx7VrVtX69ev16ZNm9S3b1+1b99erVq1kiR169ZNoaGhWrFihSIjI5WSkqJbb71VO3fuVPny5X0Zus14x48f75e2AAAAAAAAAHjO6+Tm0qVLFRYWposXLyonJ0cBAQGaMWOGpMt3MU6cOFFr1qxR69atJUk1a9bUhg0blJKSosTERKWkpCghIUHJycmSpISEBG3fvr3AXZf2cnNzlZqaqvDwcDVo0EDt2rVTWlqali9froCAACUkJGjSpEn65ptv1KpVK23YsEE//vijjh49quDgYEnSlClTtGTJEi1atEgDBgzwdugOjRw5Us8++6z1eWZmpqpVq+aXtgEAAAAAAAA453Vys127dpo1a5ays7M1depUBQYGqkuXLpKk3bt368yZM+rQoYNNnfPnz6tZs2aSpLS0NLVo0cJmf8uWLd32GxcXp/DwcOvz2NhYlSpVSgEBATbbjh49Kknatm2bsrKyFB0dbdPO2bNnlZ6e7sWIXQsODrYmTwEAAAAAAABcOV4nN8uWLavatWtLklJTU9WkSRPNmTNH/fr1U1ZWliRp2bJlqlKlik09XxOAQUFBNs/zfrHdfltubq4kKSsrS5UqVdK6desKtMWvoAMAAAAAAADm59N3bgYEBGjUqFF69tln1aNHDzVo0EDBwcE6cOCAEhMTHdZJSEjQ8uXLbbZt3rzZlzAcat68uY4cOaLAwEDFxcX5vX0AAAAAAAAAxcvrX0u3161bN5UqVUpvvvmmwsPDNWzYMA0dOlTz589Xenq6fv75Z02fPl3z58+XJA0cOFA7duzQCy+8oJ07d2rhwoWaN2+epMt3XvpL+/bt1bp1a3Xu3FmrVq3Svn37tGnTJo0ePVpbtmxxWu/AgQPaunWrDhw4oEuXLmnr1q3aunWr9a5UAAAAAAAAACWDz8nNwMBADR48WJMnT1Z2drZeeukljRkzRklJSapfv746duyoZcuWKT4+XpIUHx+vRYsWafHixWrcuLFmzZql0aNHS/L9o+v5WSwWLV++XG3atFGfPn1Ut25dde/eXfv371dsbKzTei+++KKaNWumsWPHKisrS82aNVOzZs1cJkQBAAAAAAAAXHlefSw97w5LeyNGjNCIESOsz4cMGaIhQ4Y4badTp07q1KmT9fmECRNUtWpVhYSESJJ69+6t3r17W/ePGzdO48aNcxuL/fdrhoeHa9q0aZo2bZrTWOzNmzfP6TgBAAAAAAAAlBw+fedmYc2cOVMtWrRQdHS0Nm7cqOTkZA0ePLg4QgEAAAAAAABgUsWS3Ny1a5defvllnThxQtWrV9dzzz2nkSNHFkcoAAAAAAAAAEyqWJKbU6dO1dSpU4ujawAAAAAAAAB/Ez7/oBAAAAAAAAAAFAeSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADAlkpsAAAAAAAAATInkJgAAAAAAAABTIrkJAAAAAAAAwJRIbgIAAAAAAAAwJZKbAAAAAAAAAEyJ5CYAAAAAAAAAUyK5CQAAAAAAAMCUSG4CAAAAAAAAMCWSmwAAAAAAAABMieQmAAAAAAAAAFMiuQkAAAAAAADAlEhuAgAAAAAAADClwOIO4O/GMAxJ0unMzMvPL51Xpt2/jUvnreXz9jkrW6D9fG042++u7ZLC3Vjyl8n7dx77ba7q25e379PT/p2VtY/LWZye9Otqv30bro4nT+bWU/nnMH9f9mN2FJOjMbtqy1Hb9vWcjc++PUdz42oO7ec6f3/5t7uL3dV++7mxb9fVWN3F5ixOd+04i9NRXK5ek7zhbVvu5sCT89Tb+PJ4Ms9FwdvXKE+Pi/xlPKnjLB77dvw1D67OSU/78Pb1z9357gtPruX5+/b1fPJmTT2Jx1Vf3sSTX2Gvx4WNx118vr6ueXq8ObseFUZh6/r7Nctf7Xnyfkdyf1wXZt1cbXf1/sWbuOzb97ZOcfMl5is13pL6d4505dfan/0W5/FaEtfUkcK8T/dXv/b9+ONvWk/a8/R9sie8iflKMMtxJxVu7vz1PsvfOQZXrHm1/59nc8VieFIKHvv9999VrVq14g4DAAAAAAAAMLWDBw+qatWqLsuQ3PSz3NxcHT58WOHh4bJYLMUdjlVmZqaqVaumgwcPKiIiorjDwRXE2l+dWPerF2t/dWLdr16s/dWJdb96sfZXJ9b96nU1r71hGDp9+rQqV66sgADX36rJx9L9LCAgwG1GuThFRERcdScELmPtr06s+9WLtb86se5XL9b+6sS6X71Y+6sT6371ulrXPjIy0qNy/KAQAAAAAAAAAFMiuQkAAAAAAADAlEhuXiWCg4M1duxYBQcHF3couMJY+6sT6371Yu2vTqz71Yu1vzqx7lcv1v7qxLpfvVh7z/CDQgAAAAAAAABMiTs3AQAAAAAAAJgSyU0AAAAAAAAApkRyEwAAAAAAAIApkdwEAAAAAAAAYEokN01oxowZuv766xUcHKzOnTvb7Pvpp5908803KyIiQjVr1tS7775r3ZeTk6O2bdsqJiZGERERqlevnt566y2b+r/99ptuuukmlSlTRnXr1tUXX3xxJYYEDxR23fPbvn27SpcuXaA+616y+bL2cXFxCg0NVVhYmMLCwhQVFWWz//Dhw7rzzjtVtmxZVa9eXW+//XYRjwae8mXdDcNQUlKS4uLiVLZsWdWtW1c//PCDdT/nfMlW2LX/7rvvrOd63iMgIEBPP/20tQznfMnlyzm/YcMG3XDDDYqMjFSVKlU0cuRI5ebmWvez7iWbL2u/evVqNW/eXOHh4WrQoIFWrlxps5/X+5IrJydHjz32mOLj4xUeHq569eopNTXVuj8zM1M9evRQRESEYmNj9dJLL9nU93U/ioev6z5mzBg1atRIgYGBeuaZZwq0z+t9yeXL2h89elQ9e/ZU1apVFRERoWbNmhV4Pb/q196A6Xz66afGZ599Zjz55JPGvffea91+8uRJIyYmxpg1a5Zx8eJF4/vvvzciIiKM7777zjAMw7h48aLx66+/GhcuXDAMwzD++9//GjExMca3335rGIZhnD9/3qhVq5YxZswY4+zZs8aXX35plC1b1ti1a9cVHyMKKuy657l06ZJxww03GG3btrWpz7qXfL6sfY0aNYzPPvvMadtt2rQx+vTpY2RlZRnff/+9ERkZaaxbt64IRwNP+bLuI0eONG666SZj165dRm5urrFv3z7j8OHDhmFwzpuBr6/3eY4cOWIEBgYaGzdutG7jnC+5fHl/V758eWPixInGxYsXjb179xpxcXHG7NmzrW2w7iVbYdc+PT3dKFu2rPHll18aly5dMr788kujTJkyRnp6umEYvN6XdFlZWcaYMWOM3bt3G7m5uca///1vIyoqyvjqq68MwzCMRx991Lj99tuNkydPGmlpaUa1atWM+fPnW+v7uh/Fw9d1nzdvnrF8+XLjvvvuM4YMGVKgfV7vSy5f1j49Pd1ITk42Dh48aFy6dMn44osvjDJlyhj//e9/re1f7WtPctPExo4da/MGaNmyZUa1atVsyvTu3dvo1auXw/r/+9//jNjYWCM1NdUwDMNYs2aNERUVZZw/f95a5s477zRefPFFv8eOwivsuk+dOtXo06dPgfqsu3kUZu1dJTd3795tBAQEGEeOHLFuGzRokPHoo4/6M2z4yNt1P378uBEcHGykpaU5bI9z3jx8vc5PmjTJqF+/vvU557w5FOacl2QcOnTIur9///7Gk08+aRgG624m3q79m2++afzjH/+w2d+2bVtj7NixhmHwem9G9913nzFmzBgjOzvbKF26tLF582brvsmTJxtt2rQxDMPweT9KFk/XPb9evXoVSG7yem8+hVn7PM2aNTPmzJljGAZrbxiGwcfS/0Zyc3NlGEaBbb/++qvNtrvvvlshISFq0KCBYmNjdd9990mSfv31V1177bUKCgqylm3atGmB+ihZPFn3/fv364033lBycnKB+qy7eXl6zg8cOFDXXHONWrdureXLl1u3//rrr6pUqZJiY2Ot21j7ks/dun///fcKDg7Whx9+qMqVKysuLk4vvPCCzp8/L4lz3sw8PefzpKamql+/ftbnnPPm5G7dy5cvr759+2rOnDm6cOGC0tPTtWbNGt11112SWHczc7f27vbzem8u586d048//qjGjRsrLS1N58+fV9OmTa3786+dr/tRcniz7u7wem8uvqz90aNH9dtvv6lx48aSWHuJ79z8W2ndurWys7M1Y8YMXbhwQRs3btRnn32mzMxMm3JLly5Vdna21q1bpy5duig0NFSSlJWVVeD7+KKionT69OkrNQQUgifrPnDgQP3rX/9SdHR0gfqsu3l5svbvvfee9u7dq0OHDumpp55Sly5dtHnzZkmsvVm5W/cTJ04oMzNTu3bt0s6dO/Xtt99qxYoVmjRpkiTW3cw8vc5Ll79/c8+ePXr00Uet21h7c/Jk3R944AG99dZbCg0NVe3atXX33XerY8eOklh3M3O39h06dNDmzZu1ZMkSXbx4UUuWLNHGjRut+1l78zAMQ/3791edOnV0//33KysrS2XLllVgYKC1TP6183U/SgZv190dznnz8GXtz58/r+7du+uBBx7Q9ddfL4m1l0hu/q1ER0fryy+/1AcffKCKFStqxIgR6tOnj8OEVqlSpZSYmKg///zTejff/2vv/kOrqv84jr90bru79+hsbrN0TshhSGvLSPqp05xmhF00RbHpoITABTKFWvTHumVD9kc/mMEUJAjFxKSVSjH6QxHUbZT9GrINauGUnCbNdPd67vT9/SO4eb+zze7F7R57PuAyOJ/zOfdzePH57PLm3PtxHEd9fX1x5/X19Wn8+PEjMn4kZrjcd+3apYGBAa1du/am/cndu25lzs+dO1d+v1+ZmZlas2aNli5dqv3790sie68aLnfHcSRJoVBIjuOosLBQGzdu1IEDB2Lt5O5N/+b//M6dO/Xcc88pLy8vdozsvWm43Ds6OhQMBvXee+8pEono7NmzOnXqlGpqaiSRu5cNl/19992nvXv3KhQKKT8/Xzt37tTq1avj/h+QfeozM23YsEEdHR1qamrS2LFj5TiO+vv7NTAwEDvvxuySbcfoSyT34TDnvSGZ7F3X1YoVK+T3++M2DCJ7ipt3nCeeeELHjh3T77//rqNHj+q3335TWVnZP54fjUbV1dUlSSopKVF7e7ui0Wis/bvvvtMDDzxw28eN5AyV+9dff62Wlhbl5uYqNzdX9fX1+vLLL3X33XdLInev+7dzfuzYv5f9kpISnT17Vr29vbFjZO8NQ+VeWlo6ZF/mvLfdypy/dOmS9u3bp/Xr18cdZ85711C5//jjjyooKNCKFSs0btw43XPPPaqsrNShQ4ckkbvXDTfng8GgTp48qYsXL+rAgQPq6uqKtbPepz4zU1VVlVpaWtTc3Kzs7GxJfxWu09PT9f3338fOvTG7ZNsxuhLNfTis96kvmexd19XKlSvluq7279+vjIyMWBvZi93SvSgajVo4HLY33njDli5dauFw2K5evWpmZt9++61FIhHr7++3HTt2WH5+fuwH5k+ePGnNzc3W399v0WjUDh48aH6/33bv3m1mf++oWFtba5FIxA4dOsSOiikk0dwvXrxop0+fjr2qq6vt6aeftp6eHjMjdy9INPtff/3Vjhw5YpFIxFzXtb1795rP57Pjx4/Hrj137lx76aWX7MqVK9bS0mITJ078T+2ql8oSzd3MrLy83NatW2dXrlyxM2fOWGlpqW3ZssXMmPNekEz2ZmaNjY02bdo0u3bt2qBrM+dTV6K5//zzz5aVlWWfffaZXbt2zXp7e23RokVWUVERuza5p7Zk5nxbW5tFo1G7dOmShUIhKyoqssuXL5sZ670XbNiwwUpKSuzChQuD2tauXWvPPPOM/fHHH9bZ2WmFhYVxu2Yn247Rk0zurutaOBy2iooKe+WVVywcDsdtGsZ6n9oSzd51XQsGg7Zw4UILh8M3vfZ/PXuKmx5UW1trkuJeZWVlZvbXDorZ2dkWCARs0aJF9tNPP8X6tbW12cMPP2zjx4+3CRMmWElJiTU2NsZdu7293R5//HHz+XxWVFRkTU1NI3lrGEKiud/sOjfuxGlG7qku0ezb29uttLTUAoGAZWdn25w5c+yLL76Iu3ZPT48tWbLE/H6/FRQU2I4dO0by1jCEZOb8uXPnLBgMmuM4NmXKFHv11VfjPvgy51Nbsuv9nDlz/nE3ZOZ86kom988//9xmz55tEyZMsPz8fHvhhRfs/PnzsXZyT23JZF9eXh77bP/888/b6dOn49pZ71NXd3e3SbLMzEwLBAKx18svv2xmZn19fbZ69WpzHMfy8vIsFArF9U+2HaMj2dwrKysHrReVlZWxdtb71JVM9ocPHzZJ5vP54vq+8847sXP+69mPMfu/LfYAAAAAAAAAwAP4zU0AAAAAAAAAnkRxEwAAAAAAAIAnUdwEAAAAAAAA4EkUNwEAAAAAAAB4EsVNAAAAAAAAAJ5EcRMAAAAAAACAJ1HcBAAAAAAAAOBJFDcBAAAAAAAAeBLFTQAAAHjSggULNGvWLLmuO6ht5cqVmjZtmi5fvjwKIwMAAMBIobgJAAAAT2psbNQvv/yi+vr6uONfffWVPv30UzU0NMhxnFEaHQAAAEbCGDOz0R4EAAAAkIhQKKStW7eqvb1d9957ryKRiIqLi1VcXKympqbb9r7hcFhZWVm37foAAAC4NTy5CQAAAM96/fXXNX36dFVVVUmS6urqdO7cOW3btk09PT2qqKhQbm6usrKyNG/ePH3zzTdx/T/++GM9+eSTysnJ0V133aX58+ertbU17pw333xTjuOotbVVjz32mHw+nz788MMRu0cAAAD8s3GjPQAAAAAgURkZGdq+fbvmz5+vLVu2qL6+Xlu3blUgENDs2bPlOI4aGhqUnZ2thoYGPfXUU+rq6lJ+fr4kqbu7W+vWrdOMGTPkuq727NmjefPm6YcfftDMmTNj7+O6rtasWaPq6mrV1dVp0qRJo3XLAAAAuAFfSwcAAIDnvfjii/roo4/00EMPqbW1VW+99ZY++OADdXZ2xgqZV69e1cyZM7Vq1apBv9MpSdevX9f169dVXFys5cuXq66uTtJfT26GQiF98sknWrVq1YjeFwAAAIbG19IBAADgeTU1NZKkzZs3Ky0tTc3NzVqwYIFycnI0MDCggYEBpaWlqaysTG1tbbF+p06d0rJlyzR58mSlpaUpPT1dHR0d6uzsHPQezz777IjdDwAAAG4NX0sHAACA52VkZMT9vXDhgk6cOKH09PRB586YMUOS9Oeff2rx4sXKy8vTu+++q+nTp8vn82n9+vWKRCJxffx+PzuvAwAApCCKmwAAALjj5OTkaMmSJXr77bcHtWVmZkqSjh8/rp6eHh08eFClpaWx9r6+PhUUFMT1GTNmzO0dMAAAABJCcRMAAAB3nPLycu3atUuzZs1SIBC46TnhcFjS3097StKxY8fU3d2t+++/f0TGCQAAgORQ3AQAAMAdZ9OmTdq9e7fKysq0ceNGFRYW6vz582ppadGUKVNUXV2tRx99VI7jqKqqSjU1NTpz5oxqa2s1derU0R4+AAAAbhEbCgEAAOCOM2nSJJ04cUIPPvigXnvtNS1evFjV1dXq7u7WI488IkmaPHmy9u3bp97eXgWDQb3//vvavn27ioqKRnn0AAAAuFVjzMxGexAAAAAAAAAA8G/x5CYAAAAAAAAAT6K4CQAAAAAAAMCTKG4CAAAAAAAA8CSKmwAAAAAAAAA8ieImAAAAAAAAAE+iuAkAAAAAAADAkyhuAgAAAAAAAPAkipsAAAAAAAAAPIniJgAAAAAAAABPorgJAAAAAAAAwJMobgIAAAAAAADwpP8BYVPoJMLPhqoAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1600x630 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Create swim lane figures for each cluster count\n",
-    "start_year = factors_df.index.min().year\n",
-    "end_year = factors_df.index.max().year\n",
-    "\n",
-    "for n in n_regimes_list:\n",
-    "    fig, ax = plt.subplots(figsize=(16, 0.8 * n + 1.5))\n",
-    "    labels = gmm_grid[n].labels\n",
-    "\n",
-    "    plot_regime_timeline(\n",
-    "        labels=labels,\n",
-    "        dates=factors_df.index,\n",
-    "        n_regimes=n,\n",
-    "        title=f\"GMM Factor Regimes (n={n}) - {start_year} to {end_year}\",\n",
-    "        ax=ax,\n",
-    "    )\n",
-    "\n",
-    "    # Add metrics annotation\n",
-    "    bic = gmm_grid[n].bic\n",
-    "    aic = gmm_grid[n].aic\n",
-    "    sil = gmm_grid[n].silhouette\n",
-    "    ax.text(\n",
-    "        0.02,\n",
-    "        0.98,\n",
-    "        f\"BIC: {bic:.0f}  |  AIC: {aic:.0f}  |  Silhouette: {sil:.3f}\",\n",
-    "        transform=ax.transAxes,\n",
-    "        fontsize=9,\n",
-    "        verticalalignment=\"top\",\n",
-    "        bbox=dict(boxstyle=\"round\", facecolor=\"white\", alpha=0.8),\n",
-    "    )\n",
-    "\n",
-    "    plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "795ac806",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002718,
-     "end_time": "2026-07-11T19:31:19.461587+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.458869+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Two-Regime View: Risk-On vs Risk-Off\n",
-    "\n",
-    "The two-regime split separates periods of broad factor outperformance from\n",
-    "periods of broad underperformance. It is the model that BIC and silhouette\n",
-    "select above; the analysis below characterises the two regimes empirically."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "1e068e45",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:19.467645Z",
-     "iopub.status.busy": "2026-07-11T19:31:19.467552Z",
-     "iopub.status.idle": "2026-07-11T19:31:19.470796Z",
-     "shell.execute_reply": "2026-07-11T19:31:19.470183Z"
-    },
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.006828,
-     "end_time": "2026-07-11T19:31:19.471094+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.464266+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "1084c676",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# Historical events for annotation\n",
-    "historical_events = {\n",
-    "    1929: (\"Great Crash\", \"top\"),\n",
-    "    1937: (\"Recession\", \"bottom\"),\n",
-    "    1973: (\"Oil Crisis\", \"top\"),\n",
-    "    1987: (\"Black Monday\", \"bottom\"),\n",
-    "    2000: (\"Dot-com\", \"top\"),\n",
-    "    2008: (\"GFC\", \"bottom\"),\n",
-    "    2020: (\"COVID\", \"top\"),\n",
-    "}\n",
+    "fig, (ax_band, ax_vol) = plt.subplots(\n",
+    "    2, 1, figsize=style.FIGSIZE[\"dual_v\"], height_ratios=[1, 3], sharex=True\n",
+    ")\n",
     "\n",
-    "# Use n=2 for cleaner, more stable regime identification\n",
-    "n_regimes_book = 2\n",
-    "labels_2 = gmm_grid[n_regimes_book].labels\n",
+    "draw_swimlanes(ax_band, rows, 2, lane_cmap)\n",
+    "ax_band.set_yticks([0, 1])\n",
+    "ax_band.set_yticklabels([\"Risk-off\", \"Risk-on\"])\n",
+    "ax_band.set_ylim(-0.5, 1.5)\n",
     "\n",
-    "# Ex-post labeling for interpretability (NOT predictive)\n",
-    "regime_equity_returns = factors_df[\"Equity indices Market\"].groupby(labels_2).mean()\n",
-    "good_regime = regime_equity_returns.idxmax()\n",
-    "bad_regime = 1 - good_regime"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c5c1b377",
-   "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.002639,
-     "end_time": "2026-07-11T19:31:19.476422+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.473783+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Risk-On vs Risk-Off Regime Timeline\n",
-    "Swim lane panel showing regime assignment alongside cumulative equity returns."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "4a2eaa61",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:19.482437Z",
-     "iopub.status.busy": "2026-07-11T19:31:19.482308Z",
-     "iopub.status.idle": "2026-07-11T19:31:19.848975Z",
-     "shell.execute_reply": "2026-07-11T19:31:19.848489Z"
-    },
-    "lines_to_next_cell": 0,
-    "papermill": {
-     "duration": 0.370361,
-     "end_time": "2026-07-11T19:31:19.849417+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.479056+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABMUAAAIyCAYAAADL6X36AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA42VJREFUeJzs3Xd4FFX/NvB7djebXkknHQi9+NAEKUEgFKnSRaVYQEFUQIogTdoDCEGIIo80RRERAZFeBaRIld4DCQkkpPe2e94/8u78ssmmkkLY+3NdudidOXPOmTnT9suZM5IQQoCIiIiIiIiIiMiIKCq7AkRERERERERERBWNQTEiIiIiIiIiIjI6DIoREREREREREZHRYVCMiIiIiIiIiIiMDoNiRERERERERERkdBgUIyIiIiIiIiIio8OgGBERERERERERGR0GxYiIiIiIiIiIyOgwKEZEREREREREREaHQTEiIiozAQEBkCQJkiThwYMHlV2d58qDBw/kbRMQEFDZ1XluPMs+c/ToUXnZ4cOHl0v9jN369evlbTxr1qwSL+/j4yMvX1nu3LmDXr16wdnZWa7L9u3bAQCJiYkYO3YsvL29oVQqIUkSPvnkkyLz3LJlCyRJgkqlwsOHD8t3BahU/v77b7m9z549W9nVISKi5xSDYkREVdisWbPkm35JkhAYGJgvzfnz5/XSSJKE9PT0Sqht6R09ehSzZs3CrFmzcOnSpWIvl3e9JUmChYUF6tWrh0mTJiEuLq78Km2EcgdQdH9KpRIODg4ICAjAxo0bK7uKhcrIyMDKlSvRrl07ODg4QK1Ww83NDb1798Yff/xR2dUrE1X9mDh+/DgGDx4MT09PmJqaws7ODi1atMC8efOQmJiYL71Go0Hfvn2xc+dOPH36NN/8SZMmITg4GKGhodBqtcWqg1arlQOEffv2hbe3tzzvr7/+wjvvvIO6detCoVDI2/jo0aMG83ry5AnGjBkDHx8fqNVqODs7Y9CgQbh582a+tDt37sSoUaPQuHFjODk5Qa1Ww8vLCyNHjswXmMt7bTD0V9xA8l9//YWPP/4YzZo1g6urq3xcDBo0CJcvXza4zPnz59G7d29Uq1YNZmZmqFevHhYsWIDMzEy9dBcvXsSUKVPQunVrVK9eHWq1Gk5OTujZsyeOHz9eaL1CQkJgZWUlr8/LL7+sN/+VV15B8+bNAQAzZswo1roSEZEREkREVGXNnDlTAJD/FAqFePDggV6aUaNG6aUBINLS0sqlPu3bt5fLCAkJKbN8c6/nunXrir1c3vXO+9esWTORnZ1dZvUsTHp6ujh+/Lg4fvy4uHz5coWUWdHWrVtX5DZfvny53jKXL1+Wt0t6enqJyjty5Iic77Bhw56p7uHh4aJx48aF1n3IkCEiKyvrmcqpbCU9JiIjI+X2efjwYYnL8/b2lvN+VhMnTiy07l5eXuLatWt6y9y5c0eeX6tWLbF//35x/PhxERMTI4QQonr16gKAMDExEZs3bxbHjx8X9+/fL7QeO3fulPPcu3ev3ryPP/7YYN2OHDmSL5+wsDC5/Lx/1tbW4ty5c3rpa9euXeC6V6tWTdy9e1dOm/faYOjv3XffLdZ279KlS4F5mJmZiZMnT+ql37dvn1Cr1QbTBwYG6u1fhq5Pua9nW7duLbBenTt31kvfsmXLfGm+++47ef6VK1eKtb5ERGRc2FOMiOgFotVqsWbNGvl7SkoKfv7553IvNyUlpdzLeFZbtmzB4cOHMXv2bHnauXPncOrUqQop39TUFG3atEGbNm3QsGHDCimzMjVp0gTHjx/Hrl270KFDB3n6119/rZeuYcOG8nYxNTWt6GoCyDluXn/9dfz7778AAC8vL3z//fc4ePAg5s6dC3NzcwDApk2bMG3atEqpY3kozjHh7Owst4+Xl1dlVBMAEBwcjCVLlgAAlEolJkyYgAMHDuCnn36Sj6fQ0FD07NkTycnJ8nIRERHy51atWqFz585o06YNHBwc9Oa7ublh4MCBaNOmDXx9fQuty7p16wAA9vb2ePXVV/Xmubi4oH///vjqq6/g7+9faD6ff/45wsPDAQA9evTA3r178cUXXwAAkpKSMHz4cAgh9JZp1KgRgoKCcODAAQQFBcHGxgYAEBMTgzlz5sjpRo4ciePHj+f78/HxkdP06dOn0Prl5ufnh/nz52P//v34/vvv4ebmBgBIT0/HlClT5HRpaWkYMWKE3CNs+vTp2Lp1Kxo0aAAA2L9/P1atWqWXt6urK6ZNm4Y9e/bg559/Ru3atQHkHJfjx483WJ8NGzbgwIEDMDMzK7Teffr0gUKR83Nn/fr1xV5fIiIyIpUdlSMiotLL3RvA2tpaABAeHh5Co9EIIYRYs2aN3jzdX+6eYuPHjxetWrUSrq6uQq1WC0tLS/HSSy+JxYsX5+sVo1ve29tbXL58WXTq1ElYWlqK9u3bCyEM9xR79OiR8PLykv/nf8OGDUIIIbRarVi7dq1o3bq1sLa2FmZmZqJRo0YiKChIrn/uMg39FdVrLHfa3D3XGjZsKE//+eef9ZbJzMwUX331lfjPf/4jLCwshIWFhWjRooX48ccf8+Wv0WjE7NmzRfXq1YW5ubkICAgQFy9eNLgdQkJC5Gm67ZW3Db///nsxa9Ys4erqKqytrcXgwYNFXFyciImJEW+++aawsbER9vb2YtSoUQZ7+23fvl107NhR2NnZCbVaLfz9/cWsWbNEamqqXrqQkBAxZMgQ4ebmJlQqlbC1tRV169YVw4cPF//++6+cLnfPr5kzZxa6rfOmz72O58+fl6er1Wq9ZQrqXfjbb7+JV155RdjY2AgTExPh4uIiXnnlFTFp0iSh1WqFEAX3FJszZ448vWnTpiI+Pr7Qem/dulVOr1KpxJ07d/Tmr1+/Xq/+ERER8nbMvb7//POPCAgIEObm5sLFxUVMmzZNb1825KOPPpLz+P333/XmzZs3T54XHBwsl1mctitISY+JgvaB4tbDUE+xy5cvCzs7O7mn0YEDBwqtc1pamnBycpLzmTVrlt782NhYYW9vL8//6quvhBD6+1bev2HDhpXqvJKRkSHMzMwEANG3b99C692yZctCe4o5OjrK83P38K1Tp448/cSJE/L0/fv358sjKChITlu3bt1C65P7OPT19S1y39Q5dOhQvmvB9u3b5bzMzc3l6Zs3b5and+nSRZ5+6tQpeXqDBg3k6cePHxcpKSl6eV+6dEmvPSIjI/XmR0ZGCgcHByFJkpg7d26hPcWEEKJJkyYCgPDz8yvW+hIRkXFhUIyIqArLHVAZPny4MDExEQDErl27hBD/96Ps/fffLzAoZmpqWuCPwxEjRuiVp5tua2srqlWrli8AkjfAERsbK+rXry8ACEmSxOrVq+W83n777QLLHTRoUL4yyzIo1qBBA3n60aNH5emZmZmiY8eOBZY3adIkvfzHjRuXL42tra3w8fEpVVCsRo0a+fLr2rWraNGiRb7p06ZN06vLF198UWC927ZtKzIyMoQQQmRlZQl/f/8C0/7vf/+T8yyroNi5c+fk6T4+PnrLGAqKHT16VCgUigLrqPuBbigolvtxqUaNGsmPyRXmzTfflJfp379/vvlZWVnC1dVVTrNmzRohhH6burm5CXNz80K3pyGnT5+W077xxht681566SUB5DzaFx0dXaK2K0hJjwlD+0BJ6pE3KBYSEiLc3NwEkBNg1J2rCnPw4EE5D7VabbBNJ0yYoLe/C1E+QbGTJ0/K6b788stC611UUEx3vgYgnj59Kk9v2rSpPP2///1voWXs2rVLTtusWbNC044cOVJOu2jRokLTFuXatWtyXo6OjvL03EHe2bNny9OzsrL01jc2NrbAvFNSUvTaIykpSW/+oEGDBAAxZswYvXNAQUGx3Ov9+PHjZ1pvIiJ68fDxSSKiF4SLiwt69OgBAPj+++9x5coVnDlzBgDw7rvvFrjctGnTsGnTJuzduxdHjx7F77//jpYtWwLIedzk0aNH+ZZJSEiAUqnE6tWrsW/fPoP5p6WloUePHrh27RoAICgoCO+99x4A4LfffsMPP/wAAKhduzY2bdqEnTt3ygMlb968GZs3bwaQM7D2iBEj5Hw///xz+VGg7t27F3v7nDt3DkePHsWcOXNw9epVAEC9evXQpk0bOc3y5ctx6NAhAMDLL7+Mbdu24bfffpMf51m0aJG8TW/duoUVK1YAABQKBWbMmIGdO3eiRYsWpX7z5oMHD7Bo0SJs3rwZ1tbWAIC9e/fi+vXr+P777/Htt9/Kab/77jv589mzZ/Hll18CyHkMbM2aNdi7dy9ee+01ADnbcNmyZQCAmzdv4vbt2wCATp06Ye/evfjzzz+xYsUKdOvWrcweYUxISMCJEyewe/dufPbZZ/L0UaNGFbnszp075UHP58+fj0OHDuGXX37B9OnTUa9evQLfZPj777/jgw8+AADUqVMHBw4ckB+TK8z169flz02aNMk3X6VSoX79+gbT6zx+/Bj/+c9/sGPHDowbN06enrudDGnZsiVq1qwJAPjzzz+RkZEBALh//z4uXrwIAOjatSuqVatW5m1XnGPCkNLW4+nTp+jSpQseP34MlUqFTZs2FesYzr29vby8DLZp7nbTpV+xYoXe47rdunWTzx2zZ8/WG8jd1dW1WOeVGzduyJ917VZauvMKkHN+TElJwf79+/VeJhIWFlZoHlu3bpU/d+vWrcB0cXFx2LRpEwDAzMwMI0eOLGWtCy8397nPxcVF/qxSqfTarbBzZO6827ZtCysrK/n7zp07sXnzZnh6emLBggXFqmvudjJ07BIRkXFTVXYFiIio7Lz77rvYtm0b/vzzT5iYmADIGYNG9wYuQ1599VUsXrwYZ86cQXR0NLKzs+V5QghcuHABHh4e+ZbbuHEjOnfuXGC+b7/9Ns6dOwcA+O9//6sXKMj9FsIxY8bI+b/zzjs4ffq0nGbQoEFo06YNDh48KKevVatWkT/aDRkwYIDe99dffx0rV66EUqk0WK/x48fD0dERADB06FD57WUbN25Ey5YtsWPHDnm8n759+8rjMr3yyiuoXr060tLSSlzHQYMGyQGkH374Abt27QIAfPrpp3jnnXcAACtXrsS1a9cQHR2NhIQE2Nra4qeffpLzGDFihDyW0ejRo+U8Nm7ciMmTJ8v7BZATQKtVqxZ8fHygUCgwduxYvfoMHz682G+oy+vSpUto27at/N3KygqzZs3ChAkTilw2dx1r1aqFxo0bo1q1ahg0aJAc/Mvr/Pnz+OWXX6DValGzZk0cOnQIzs7O8vwrV64gISFBbxl/f384OzvrvbXQycnJYP65p+fNBwDUajW2bt0qB6e///57pKam4u7du0Wu79ChQzF79mwkJiZi//796NmzJ3777Te9+QBK1HbFUZxjwpDS1qN79+64ffs2FAoFfvjhB7z++uvyvKioKDnQpmNra4uGDRuWun0aNmyImJgYebpufDSd3G+N1I35V5To6Gj5s729fZHpCzNhwgQ54D9v3jzMmzcvX5rC3hT8v//9D2vXrgWQM+ZXYcfWunXr5HPS4MGDUa1aNXleRkYGzp49m2+ZgrbH7t27MXfuXACAg4OD3jGZe3xJtVqtt1zu7wWNQ3n+/Hl89NFHAHLaRBfMB3LGWfvwww8BAKtWrZL/46Aoudspd/sREREBAHuKERG9QLp27QpPT09kZWXh119/BQC5d5Yh//zzDzp06IAdO3bgyZMnegExnfj4+HzTzMzMCg2IAZADYkOGDMGkSZP05uX+8Ttu3Di0bdsWbdu21atr7h4Z5eHcuXNISkoqsF4DBw6U66ULiOWu1/379+Vpup51QM4PsDp16pSqTi1atJA/5+5V0axZM/mzLlAH/F/b5K73/Pnz5Xr37NlTnn7z5k0AOUEmXbDqxx9/RI0aNWBlZYVWrVph8eLFck+lspacnIzz58/LPcAKM3ToULm30YABA+Do6AgXFxe8/vrregHS3K5evYqMjAwoFArs3LkT7u7uevM/+ugjebvo/nbv3g0A8mDlQE5vJkNyT7e1tc03v06dOnLPGIVCIf8QN3T85PXmm2/Kn3XBMN2/1tbW6NWrF4DybztDx4Qhpa2H7pwwefJkDBkyRG/e7t2787WPLjhSFu1THnRB8dIaPnw4li9fDjs7O3latWrVEBAQIH/PPS+35cuXy70uXV1dsXfv3gLXWwihN7j9mDFj9OY/fvw437bPHdDObevWrejbty8yMzNhZWWFP//8Uy+4aGlpKX/Oux/oBt/Pm07nxIkTePXVV5GQkCD3JGzatKk8f8GCBXj06BGGDBlSol7Cz9pORET0YmNQjIjoBaJQKPQeNTQzM9P7wZ3XqlWrkJWVBSDn7We7d+/G8ePH8fbbb8tpDAUxcvfAKYiut8nvv/+u95hScZX1Gy1DQkIQFRWF/v37A8h5U90bb7xR4h9MhupV0ON8JZX7R63ujWmAflAgt5LUPTs7Ww4a7d69G1999RW6du0KLy8vpKWl4fTp05g0aRI+/vjj0q9ALu3bt4dGo8GZM2fkYNGmTZsQHBxc5LINGjTA+fPnMW7cOLRs2RK2traIiorCtm3b0KVLF5w8eTLfMrr9TavVYvLkydBoNMWua7169eTPuR9d08nOzpYfA86bXidvryGVqvid8WvWrCkHVv/44w/cvXtX7rnz+uuvy2+/LOu2K+0xUdp66Nrou+++k4O0xZF7e4eGhiIuLi5fGt2bQ/OmL2u5g9KG6lFS48aNQ1RUFC5duoSrV68iIiICfn5+8vzcj+3qzJs3D5988gmEEPD09MRff/2FWrVqFVjGgQMHcOfOHQA5gffcQfaS2LBhAwYNGoTMzEzY2dlh//79aNWqlV6a3G+3jIyMlD9nZ2fr9drLnQ7IeStlly5dkJiYCFNTU/z222/o27evXhrdm0I3bdoESZIgSZLem23PnDkDSZIQFBSkt1zudsrdfkRERACDYkREL5yRI0fKAZV+/foV2NMAAMLDw+XPCxYsQLdu3dCmTRu9HzOGFCcItGTJEigUCmRkZKB37956Pb90j/cBwJEjRyByXvyi93fv3j05Te4AUXF6GhXEyckJ//vf/+QAxvnz57Fjxw6D9bp//77BeunGHKtRo4acNvejR3FxcSX6wV8Wctd73bp1BuudkpICU1NTCCFgZWWF8ePHY8+ePXj48CGioqLg6+sLICeIWVYUCgVatGiB//73v/K0efPmFfpIGJAT7Ktfvz6WL1+O06dPIz4+Xu45pdVqsX379nzL9O/fX/6B/scff+TrDXP06NF820T3aGifPn3kdNu3b9frBQjk/Ah/8uQJgJxHwAobu6m0dI9IxsfHy4+IAfq9yMqj7Yo6JgwpbT2WLl0KAIiNjUW3bt3kbQrk9JrK2z5Hjx4FkPNIsi6YkZmZiZUrV+rlGx8fLz9GCOi3Z1mrW7eu/Lk4j8YWh4mJCRo3boz69esjKipKHk/RxMQEXbp00Us7efJkTJ8+HUBOj70TJ07oHf+GfPPNN/LnvMcFkBOgMnTOyC04OBgjRoyARqOBs7Mzjh49mi8gBug/cpk7eH327Fm5J3KDBg30gsjbtm1Dz549kZqaCktLS+zatQu9e/cudJ1KInc7lWfAlIiIqiaOKUZE9ILx9vZGcHAwnjx5IvcAKSytzoIFCzBs2DDs2bMH+/bte+Z69OnTB9nZ2fjss88QFxeHrl274vTp03Bzc8PQoUPlH95vvfUWpk2bhlq1auHp06e4c+cOdu3ahW7dumHmzJkA9HvhbN26Fb6+vjAxMUHz5s1LPLi4nZ0dRo0ahYULFwLIGTxf9yN66NChco+THj16YNKkSfDw8MDjx49x8+ZN7NixAxMmTMDw4cPRu3dvTJ48GUIIbN26FV9++SX+85//YPny5aUaT+xZvPHGG1i+fDmAnPHHYmNj0ahRI8THx+PevXvYv38/vL29sXbtWoSHh6NTp04YOHAg6tWrBxcXF4SEhMiPn+V+5Gn9+vVyz8OZM2di1qxZparf0KFD8cUXXyAsLAyRkZH44Ycf8P777xeYftGiRTh69Chee+01eHl5wdLSUm+fNPR4npmZGXbs2IGWLVsiJCQE3333HTw9PTFt2rQi69e3b180b95c/uH+6quvYsaMGfDx8cHp06f1xnoaN24c3NzcSrgFijZ48GCMHz8e2dnZOHDgAADA3d0dr776qpymJG1XEoUdE4aUth7jxo3D7du3ERwcjAcPHqB79+44duyY3kDqhpiZmWHGjBnyuISzZ89GUlISAgMD8fTpUyxcuBCxsbEAcgI8he1bz6pp06YwMzNDeno6Lly4kG/+9evX5cHcdXUCgL/++ksez0p3Xr58+TImTJiAAQMGwMfHB/fv38f8+fPl3qjvvvuu3r728ccfyy8OsLOzw4IFCxAaGorQ0FAAOdspby+w0NBQ/PnnnwByekkNGjSoxOu8bNkyjB8/HkDOOF8LFixAUlISTpw4IafRBcN69uwJd3d3REREYP/+/Zg2bRqaNm2q9wj66NGj5c9btmzBkCFDoNFoIEkSZs6cCVNTU728def5N954I9+LMO7evSv3PvX29sYnn3yC9u3b66XRvbDCz88Prq6uJV5/IiJ6wZXXay2JiKj8zZw5U37V/OTJkwtNi1yvuE9LSxNCCHHmzBkhSZLePEmSRKtWreTv69aty5eHt7e3wTLat28vpwkJCRFCCPHuu+/K0xo3biwSEhKEEEK8/fbbeuXm/Zs5c6ac7+XLl/PVM3cZxVnn3GnDw8OFiYmJPO/EiRNCCCEyMjJEx44dC61X7u0xbty4fPNtbGyEt7d3vnJDQkLkae3bt5fzyN2GufMeNmyYPP3IkSOFbmMhhPjiiy8KrfewYcOEEEKEhYUVmm7UqFFynuvWrTPYHgXJnT73OgohxOLFi+V5/v7+QqPRFLg+X375ZYH1UygUcnsdOXIk3/pdu3ZN2NraytPXr19fZL1126VBgwaFbpuBAweKzMxMeZmC2lQIobcPFFe3bt30yhs/fny+Oha37QpS0mPC0D5Qknrk3Q7Z2dmia9eu8rTAwEC9bVqYTz75pNByPT09xZUrV/SWMbSPGNoeBZ3TDOnXr58AIOzt7UVWVpbevNzHc0F/OhcvXiwwTbt27URycrJe3rm3paE/Q+vw+eefy/OLukYUJPcxWtQ6CSHEvn37hFqtNpguMDBQZGdny2lzn+cK+ivsPJ+7fVu2bJlvfmRkpFAoFAKAmDhxYqnWn4iIXmx8fJKIyIi1aNEC27ZtQ8OGDWFmZob69etjy5YtCAwMLLMyvv32W3Ts2BFAzrg//fr1Q1ZWFjZs2IAffvgB7du3h62tLdRqNby8vNCxY0d8/fXXeo+QNWzYED/88APq1q1b4p5hhri7u+sN9L1o0SIAOY/G7d27F19//TVatGgBa2trmJmZwdfXF6+99hrWrFmjN87N0qVLMWvWLLi7u8PMzAxt27bFkSNH9Hq2WVhYPHN9i2POnDn4888/0bVrV1SrVg0mJiaoXr062rRpg4ULF8pvx3RwcMDMmTPRvn17uLm5wcTEBObm5mjUqBHmzp2LFStWlEv93nvvPfltcbdv3y70Eb3u3btj1KhR8mNWSqUSDg4OCAwMxL59+/DKK68UuGy9evWwZcsWeUyv9957r1g9Hz08PHD27FksX74cbdq0gZ2dHUxMTOS3Sf7+++/YvHmz3psXy1re8f/yfi/PtivomDDkWeqhVCqxefNmNGjQAEDOWFKFvQwkt2XLluHo0aMYMGAAqlevDhMTE1hbW6Np06b48ssvcfnyZTnf8qTrPRkXF4cjR46UOh93d3e8+eab8PPzg4WFBSwtLdG0aVMEBQXh4MGDBgejL4nMzEysWbMGQM6jzLl7aJWnwMBAnDx5Ej179oS9vT1MTU1Rt25dzJ8/Hzt37izy7aZlafv27fIj96V9ky4REb3YJCH4ShYiIqLSEELkG18tJiYGXl5eSE1NhZ2dHWJiYvTGRCOiqk2r1aJRo0a4du0aBg4cKI8BRs+fFi1a4OzZs+jWrZv8tlkiIqLceJdORERUSkuWLMHUqVPx999/IywsDCdOnED//v2RmpoKABgwYAADYkQvGIVCIY93uHXrVnlML3q+/P333/JLUHQ9ZYmIiPJiTzEiIqJSmjVrVoE/turWrYvjx4+jWrVqFVwrIiIiIiIqDv73NRERUSkFBATgtddeQ/Xq1aFWq2FlZYWXXnoJc+bMwT///MOAGBERERHRc4w9xYiIiIiIiIiIyOiwpxgRERERERERERkdBsWIiIiIiIiIiMjoMChGRERERERERERGh0ExIiIiIiIiIiIyOgyKERERERERERGR0WFQjIiIiIiIiIiIjA6DYkREREREREREZHQYFCMiIiIiIiIiIqPDoBgRERERERERERkdBsWIiIiIiIiIiMjoMChGRERERERERERGh0ExIiIiIiIiIiIyOgyKERERERERERGR0WFQjIiIiIiIiIiIjA6DYkREREREREREZHQYFCMiIiIiIiIiIqPDoBgRERERERERERkdBsWIiIiIiIiIiMjoMChGRERERERERERGh0ExIiIiIiIiIiIyOgyKERERERERERGR0WFQjIiIiIiIiIiIjA6DYkREREREREREZHQYFCMiIiIiIiIiIqPDoBgRERERERERERkdBsWIiIiIiIiIiMjoMChGRERERERERERGh0ExIiIiIiIiIiIyOgyKERERERERERGR0WFQjIiIiIiIiIiIjA6DYkREREREREREZHQYFCMiIiIiIiIiIqPDoBgRERERERERERkdBsWIiIiIiIiIiMjoMChGRERERERERERGxyiDYhqNBkFBQXjppZdgYWEBKysr1KlTB2PGjCm3Mh88eIBZs2Zh/fr1haaLjo7GmDFj4O3tDbVaDTc3NwwYMAAJCQllXqfhw4dDkqQi60RERPQ8SEtLw7Rp01CjRg2o1WpUq1YNffv2xdWrV+U0AQEBkCQJR48eBQBIkgRJkgrMszTX3bxlFGT9+vWQJAnDhw8vyWoS0QtCd/5RqVSwtbXFSy+9hFmzZiEtLa3YecyaNQuzZs0qv0oSGYns7GwsXrwYDRo0gJmZGRwcHNChQwdcuHABGo0GS5YsQb169WBqagpbW1sEBgbixIkTAHKOQ0mS8OGHH+rlOX/+fEiShBEjRuDBgweQJAmurq4AIH+XJAkmJiawt7dHy5YtERQUBI1GU+HrTwWThBCisitR0QYMGIDffvsNvr6+GD16NOzs7PDvv/9i69atePLkicFlsrOzoVKpSl3m0aNH0aFDB7Rv377Am+i4uDg0b94c9+7dQ+fOndGvXz8kJiZiy5Yt+PXXX+Hj41Om9Ro+fDg2bNiAdevW8YadiIiee507d8bBgwfRpk0bvPnmm7h+/TpWrlwJCwsLnD17FnXq1MHhw4cRFRWFV199Fc7OznJAzNDtTmmvu8eOHdMroyAhISE4c+YMfH190bJlyzLbDkRUNejOPxs2bEB0dDTWrVuHq1evonXr1vjrr7+KdQ9f2DmMiIqvX79++P3331GrVi18+OGHMDExweHDh9G7d28cO3YMa9asQYMGDfDBBx/g8ePHWLx4MTQaDQ4ePAgvLy/UqFED9vb2ePz4MdRqNQCgbt26uHnzJo4ePQpvb2/4+vrCxcUFT548wYMHD+Dr6wtbW1t88803ePjwIb777js8fPgQAwcOxObNmyt5i5BMGJnjx48LAMLOzk5ERUXpzUtMTJQ/AxAAxPTp04Wrq6uYOXOm0Gg0YsGCBaJmzZrC3Nxc1K1bV6xbt05eZvjw4cLZ2VmYmJgIFxcXMWzYMJGYmCiOHDki56f7GzZsWL66zZkzRwAQbdq0yTdPo9HI+TRt2lT0799fWFtbiyNHjoiVK1cKLy8vYWpqKuzs7ESnTp3E9evXhRBCREdHi549ewo7OzuhVquFt7e3WLJkiRBCiGHDhgkA4sMPPxTNmzcXVlZWok+fPiItLa0MtjQREVHZOXz4sAAgXFxc9K5TY8eOFQDE22+/LYQQon379gKAOHLkiBDi/67nhpT2upu7DK1WK8aPHy9cXV2FiYmJcHJyEkOGDBFCCLFu3Tq9a/7u3btFgwYNhJmZmbCyshJNmjQRV69eLcOtRETPE935R3fOSktLE35+fgKA+Omnn4QQQty/f1/069dPODk5CVtbW9GxY0dx4cIFveV1f97e3gWW9cMPP4gmTZoICwsL4eDgIBYsWCCEECIqKkqMGDFCuLm5CSsrK/Hyyy+LQ4cOCSGECAkJEQCEk5OT+OCDD4SdnZ1o2LChOHHihOjataswNzcXAQEB+X4zEVU1x44dEwCEra2tePr0qd68u3fvCkmShKmpqXj8+LE8fcmSJQKAaNeunRDi/+4vfv/9dyGEEGfPnhUAhJ+fn9BqtfLx5OLiIoQQ+b4LIURkZKSws7MTAMTff/9d3qtNxWR0j0+ePn0aANC2bVs4OTkByHl0Ijo6GhkZGcjKytJLf/z4ccybNw8dOnTAkiVLMHXqVNSvXx8zZ86Eo6MjRowYgX379gEAGjZsiDlz5iAoKAgdO3bEhg0bsHDhQtSrVw9ffPEFgJxo8qZNm/DBBx8UWLe+ffvmm6dQ/F9TnT9/HnZ2dli6dCm8vLzg6uqKiRMnYsWKFfjwww9x5MgRvPvuuwCAH3/8ETt37kT//v2xevVqDBs2LN9jJNu3b8fIkSPh4eGB7du345dffinVtiUiIiovZ8+eBQC0atUKZmZm8vSOHTsCAM6dO1fiPEt73c3t33//xdKlS1GzZk18//33+Oyzz2Bra2uwvKlTp+L+/ftYtmwZFi9ejJdffjnffQcRvbjMzMzQvXt3AMDff/8NjUaDHj16YOvWrXj77bcxdepUHDt2DF26dEFMTAw2bdokL7tp0yasWLECWVlZ8m+X6OhoaLVaefknT55g/vz5mD17NiwsLAAAb775JtatW4fAwEDMnz8fN27cwGuvvYZbt27JeT99+hSSJKFr1664cuUK2rVrh5YtW6J169Y4evQogoODK3ZDEZUx3fW+Xbt2cHR01Jt3/vx5CCFQt25d+dFHIP/9he7Jqh9//FHvX0O/rwvi7OyMNm3aAMg5B9DzofTPA74g0tPT5eAYAOzZswddu3aVv//444/w9PQEAEyaNAkAsGPHDuzYsUNOs3v3bnTu3Bn37t3Dhg0bkJKSIs+7cOECnJ2d8eqrr+LLL7+Es7MzBg8e/Ex1rlGjBv73v//J3w8ePIgFCxbg8ePHeuUCOUE4IOegMzExQZMmTTBw4EC9/D755BOMHj0aYWFhmD9/Pu7evftM9SMiInqR5L3u5la9enXY2Njg9u3bOHToEBo2bIgJEyYYTFu3bl38+++/2LVrFxo1aoTevXujcePG5Vl1InrOiP//GKQkSbh16xauX7+OmjVrYsmSJQCAEydO4M8//8SxY8cwePBgDBkyBADk3w+6IVl0QkJC8OuvvwIA5s2bh5EjR8rzUlJScODAAZibm+P777+HSqXC7du3sXLlSuzevVv+DwFzc3N8/fXXOHz4MH755RfUrFkTs2bNwpo1a3Do0CH+NiAC0L9/f4wdOxa7du1CVFQUfvnlF0iShGHDhpUon9znAHo+GF1PsVatWgHIueDExMRArVbjwIEDaNSokcH0uoBYbitWrMCBAwfkv3fffRcHDx7EN998A1dXV2zbtg0rVqwAAHkgzeLs9Lq65Q646Wi1Wvmzh4eH/Dk1NRUffvghoqOjsXbtWuzfvx+mpqZIT08HAHTp0gWXLl3CO++8g7S0NIwePRqvvvqqXt66oKCJiQmAnPFSiIiInifNmzcHAJw6dQoZGRny9MOHDwMAmjVrVuI8S3PdzcvJyQk3btzAnDlzYGtri4ULF6Jx48YGxyj98ccfsW3bNjRp0gSHDx9Gt27d5PsFInrxpaamYteuXQCA1q1by9Nz/04o6jdD48aN9X6H5O7ZUhhdvobyt7GxgVKplH8L2NvbAwCUSiUA/jagqk93vT9+/DhiYmL05jVt2hSSJOHGjRuIjIyUp+e9v7CyskL//v2RmZmJd955B1FRUejQoQO8vb2LXY8nT57Ig/fnPgdQ5TK6oNgrr7yCAQMGIC4uDq1atUJQUBAiIiKQnJxc5LL9+vUDAKxbtw4PHz7E1atXsXTpUly8eFFOk56ejqioKGzZskVvWQcHBwDAnTt3sHHjRty4cSNf/mPGjEGNGjVw7NgxdO3aFatXr8bSpUvRqlUrhIaGFlgvSZKQnZ2N2NhY/Prrr3o/Fn777Tf8/PPPsLOzQ/PmzWFmZlZoXkRERM+jDh06oFOnToiMjERgYCBWr16NTz/9FMHBwbCyssLUqVNLnGdpr7u53b59GzNmzIAQAk2bNoWTkxNSU1MRHR2dL+2ECRNw584d+Pv7yz25eU0mevFt2bIFS5cuRYsWLfDgwQO0bt0aAwcORO3atVG/fn3cuXMHkyZNwqJFi7Bv3z44OTmhXbt2AP7vN0RwcDD++usv2Nvbo1OnTvKfmZkZBgwYAACYNm0ali9fjuDgYHz99dewtLREYGAg0tLS8N5772HlypX48ccfYWZmhtdee63StgdRRWvTpg1ef/11xMfH45VXXsHy5cuxatUqDBw4ECdPnsTIkSORkZGBwMBAfPvtt5gxYwamTZsGlUqF2bNny/noHqH8888/AQAjRowosuz09HRs2rQJCxYsQIsWLZCQkICBAwcyKPY8qdwhzSpHVlaWWLx4sWjQoIFQq9XCxsZG1K9fX3z00UciPDxcCGF4YF6NRiMWLlwo/P39hZmZmXBxcRHdunUTFy9eFFqtVrz//vvC0tJSeHl5iXnz5gkAon379kIIIbRarRgyZIiwsLAQAOTBL/OKiooSH374ofD09JQH7O3bt6+Ij4+XB/zV5anz3XffCScnJ2FnZydmzpwpqlWrJtd99+7dolGjRsLS0lKYmZmJhg0bim3btgkh/m+gfd3LAmbOnCkAiMmTJ5fNhiYiIipDqamp4vPPPxd+fn5CpVIJe3t70adPH3HlyhU5TUkG2heidNfd3GU8fPhQtGnTRtjb2wsTExPh5eUlvvzySyFE/oH2x40bJ5djZ2cnevbsKSIiIsp0GxHR80N3/lEoFMLa2lo0bNhQzJgxQ6Smpspp7t+/L15//XXh6OgoD7R//vx5eX5QUJBwcHAQAESXLl0KLGvt2rWiUaNGwtzcXNjb24v58+cLIQwPtH/w4EEhRP6BwHXnvJYtWwoh/u8cNmjQoDLfNkQVLSsrS/z3v/8V9erVk2MAbdq0EefOnRPZ2dli8eLFom7dusLExERYW1uLTp06iePHj+vlodVqha+vrwAgbGxsREpKijyvoIH2AQiVSiVsbW1F06ZNxdKlS0V2dnaFrjsVThKC7/clIiIiIiIiIiLjYnSPTxIRERERERERETEoRkRERERERERERodBMSIiIiIiIiIiMjoMihERERERERERkdFhUIyIiIiIiIiIiIwOg2JERERERERERGR0GBQjIiIiIiIiIiKjw6AYEREREREREREZHQbFiIiIiIiIiIjI6DAoRkRERERERERERodBMSIiIiIiIiIiMjoMihERERERERERkdFRVXYFqgqtVouIiAhYW1tDkqTKrg4RERERERERUZkQQiApKQnu7u5QKIyn/xSDYsUUEREBT0/Pyq4GEREREREREVG5CAsLg4eHR2VXo8IwKFZM1tbWAIDatWvjn3/+QatWrXDq1Cm9fw05deoUAMjzc6fVarWIjIxE7969cfr0ab1obO7l8n7OW5Zuvk7uZUqiuMsVli5vHQtbD93n3HJv08LyzLv9DaU7evQoateubXD75q6boXoYKqekilqHorZF3nS562SonoXVI2+5uRVWbt46Gkpf3H0yb/qC/jWUrqiyi8qrPBS3LQprX6p85bmvVMR+aAwKOjc8az4F0V2bAcDFxQUKhaLQc7ahc1RR18i86QuqX2XuQ8U9dxm6BhfnuqZj6Lqo+17Q9b+wPEu6rxR1D1ec/IpzH5hXq1atDO5rRdWzMvaTgu4zi1NmSdugqP3uWde1oo+pkmwnwPB9jqHpQM597qRJk7Bjxw7cunULAQEBhR4LhhSUpqj786LOZQXVuSrJfXzeunULpqamhd7H6xT0O0b3uTCluY8tzvFZ2fcjxTmP5037PNVZx9A+ARTvfFXac2ZRv82Ls61Ksi01Gg1u3bolxz6MBYNixaR7ZFKpVMLGxsbgv4bY2NjIy+m+6z5LkgRJkqBWq6FUKvVuhnIvl/dz3rJ083VyL1MSxV2usHR561jYeug+55Z7mxaWZ97tX1C6grZv7roZqoehckqqqHUoalvkTZe7TobqWVg98pabW2Hl5q2jofTF3Sfzpi/qOCpoXzBUdkmOybJS3LYorH2p8pXnvlIR+6ExKOjc8Kz5FER3bQYgXzsKO2cbOkcVdY3Mm76g+lXmPlTcc5eha3Bxrms6hq6Luu8FXf8Ly7Ok+0pR93DFya8494F5KZVKg/taUfWsjP2koPvM4pRZ0jYoar971nWt6GOqJNsJMHyfY2i6bp5arYYkSUXeMxW2HxpKU9T9eXHKqurXv9zHp42NDUxNTQu9j9cp6HeM7nNhSnMfW5zjs7LvR4pzHs+b9nmqs46hfQIo3vmqtOfMon6bF2dblWZbGttwUcbzoCgREREREREREdH/x6AYEREREREREREZHQbFiIiIiIiIiIjI6DAoRkRERERERERERodBMSIiIiIiIiIiMjoMihERERERERERkdFhUIyIiIiIiIiIiIwOg2JERERERERERGR0GBQjIiIiIiIiIiKjw6AYEREREREREREZHQbFiIiIiIiIiIjI6DAoRkRERERERERERodBMSIiIiIiIiIiMjoMihERERERERERkdFhUIyIiIiIiIiIiIwOg2JERERERERERGR0GBQjIiIiIiIiIiKjw6AYEREREREREREZHQbFiIiIiIiIiIjI6DAoRkRERERERERERodBMSIiIiIiIiIiMjoMihERERERERERkdFhUIyIiIiIiIiIiIwOg2JERERERERERGR0GBQjIiIiIiIiIiKjUy5BsQcPHkCSJFy6dKlM0xIREREREREREZWFUgXFhg8fDkmSIEkSTExM4Ovri0mTJiE9PR0A4OnpicePH6NBgwZlWtm8wsLCMHLkSLi7u0OtVsPb2xsff/wxYmJiyrVcIiIiIiIiIiKq2krdU6xr1654/Pgx7t+/j2XLluG7777DzJkzAQBKpRKurq5QqVRlVtG87t+/j2bNmuHOnTvYtGkT7t69i1WrVuHQoUNo1aoVYmNjy61sIiIiIiIiIiKq2kodFDM1NYWrqys8PT3Rp08fdOrUCQcOHACQ/5HIuLg4DB06FE5OTjA3N0etWrWwbt06g/lqNBqMHDkSderUQWhoaIHljxkzBmq1Gvv370f79u3h5eWFbt264eDBgwgPD8e0adPktD4+Ppg/fz5GjhwJa2treHl5YfXq1YWuX0ZGBhITE/X+iIiIiIiIiIjoxVAmY4pdvXoVJ0+ehFqtNjj/iy++wPXr17Fnzx7cuHED3377LRwdHfOly8jIwIABA3Dp0iUcP34cXl5eBvOLjY3Fvn378OGHH8Lc3FxvnqurK4YOHYrNmzdDCCFP/+qrr9CsWTNcvHgRH374IT744APcunWrwHVasGABbG1t5T9PT8/ibAoiIiIiIiIiIqoCSv18459//gkrKytkZ2cjIyMDCoUCK1euNJg2NDQUL730Epo1awYgp+dWXsnJyXjttdeQkZGBI0eOwNbWtsCy79y5AyEE6tata3B+3bp1ERcXh6dPn8LZ2RkA0L17d3z44YcAgMmTJ2PZsmU4cuQIateubTCPqVOnYvz48fL3xMREBsaIiIiIiIiIiF4QpQ6KdejQAd9++y1SUlKwbNkyqFQq9OvXz2DaDz74AP369cOFCxcQGBiIPn36oHXr1npphgwZAg8PDxw+fFiv99fo0aOxceNG+XtycrL8OXdPsKI0atRI/ixJElxdXREVFVVgelNTU5iamhY7fyIiIiIiIiIiqjpK/fikpaUlatasicaNG2Pt2rU4c+YM1qxZYzBtt27d8PDhQ3z66aeIiIhAx44dMXHiRL003bt3x+XLl3Hq1Cm96XPmzMGlS5fkPwCoWbMmJEnCjRs3DJZ348YN2Nvbw8nJSZ5mYmKil0aSJGi12pKuNhERERERERERvQDKZEwxhUKBzz//HNOnT0daWprBNE5OThg2bBg2btyIoKCgfAPdf/DBB1i4cCF69eqFv/76S57u7OyMmjVryn8AUK1aNXTu3BnffPNNvvKePHmCn376CYMGDYIkSWWxekRERERERERE9IIpk6AYAAwYMABKpRLBwcH55s2YMQM7duzA3bt3ce3aNfz5558GxwP76KOPMHfuXPTo0QMnTpwotLyVK1ciIyMDXbp0wbFjxxAWFoa9e/eic+fOqF69OubNm1dWq0ZERERERERERC+YMguKqVQqjB07FosWLUJKSorePLVajalTp6JRo0Zo164dlEolfvnlF4P5fPLJJ5g9eza6d++OkydPFlherVq1cO7cOfj5+WHgwIGoUaMG3n//fXTo0AGnTp2Cg4NDWa0aERERERERERG9YEo10P769esNTp8yZQqmTJkCQH8Q/OnTp2P69OkGl/Hx8ck3YP748eP13vxYEG9v7wLrktuDBw/yTdONT0ZERERERERERManzHqKERERERERERERVRUMihERERERERERkdFhUIyIiIiIiIiIiIwOg2JERERERERERGR0GBQjIiIiIiIiIiKjw6AYEREREREREREZHQbFiIiIiIiIiIjI6DAoRkRERERERERERodBMSIiIiIiIiIiMjoMihERERERERERkdFhUIyIiIiIiIiIiIwOg2JERERERERERGR0GBQjIiIiIiIiIiKjw6AYEREREREREREZHQbFiIiIiIiIiIjI6DAoRkRERERERERERodBMSIiIiIiIiIiMjoMihERERERERERkdFhUIyIiIiIiIiIiIwOg2JERERERERERGR0GBQjIiIiIiIiIiKjw6AYEREREREREREZHVVlV6CqUSqVyMzMNPivIZmZmfJyuu+6z5IkQZIkaDQaKJVKKBQKg8vl/Zy3LN38vHUs7bo9S7q8dSxsPXSfc8u9TQvLM+/2LyhdQds3d90M1cNQOSVV1DoUtS3ypstdJ0P1LKweecvNrbBy89bRUPri7pN50xd1HBW0LxgquyTHZFkpblsU1r5U+cpzX6mI/dAYFHRueNZ8CqK7NgOQrx2FnbMNnaOKukbmTV9Q/SpzHyruucvQNbg41zUdQ9dF3feCrv+F5VnSfaWoe7ji5Fec+8C8lEqlwX2tqHpWxn5S0H1mccosaRsUtd8967pW9DFVku0EGL7PMTRdN0+j0UCSpCLvmQrbDw2lKer+vDhlVfXrX+7jU/eborD7eJ2CfsfoPhemNPexxTk+K/t+pDjn8bxpn6c66xjaJ4Dina9Ke84s6rd5cbZVZW/LqkASQojKrkRVkJiYCFtbW0yZMgVmZmZlkmd2djb27NkDAOjWrRtUKsYoyxK3LxERlRSvHVRRuK/Rs+D+U764fSkvY9gn0tPTsXDhQiQkJMDGxqayq1Nh+PgkEREREREREREZnRcvvFnOJkyYgM6dO+PMmTNo2bKl3r+GtGzZEgDk+bnTZmRk4PHjx9i+fTsmTZoEU1NTg8vl/Zy3LN18ndzLlERxlyssXd46FrYeus+55d6mheWZd/sbSte8eXM0b97c4PbNXTdD9TBUTkkVtQ5FbYu86XLXyVA9C6tH3nJzK6zcvHU0lL64+2Te9AX9ayhdUWUXlVd5KG5bFNa+VPnKc1+piP3QGBR0bnjWfAqiuzYDkK8dhZ2zDZ2jirpG5k1fUP0qcx8q7rnL0DW4ONc1HUPXRd33gq7/heVZ0n2lqHu44uRXnPvAvM6cOWNwXyuqnpWxnxR0n1mcMkvaBkXtd8+6rhV9TJVkOwGG73MMTQdy7nPDw8PRp08f/PHHHzh79myhx4IhBaUp6v68qHNZQXWuSnIfn3/88QcUCkWh9/E6Bf2O0X0uTGnuY4tzfFb2/UhxzuN50z5PddYxtE8AxTtflfacWdRv8+Jsq5Jsy8TERCxcuLBYaV8kDIqVkFqthkajMfivIRqNRl5O9133WQgBpVIJIQTUarVeHrmXy/s5b1m6+XnrWNp1e5Z0eetY2HroPueWe5sWlmfe7V9QuoK2b+66GaqHoXJKqqh1KGpb5E2Xu06G6llYPfKWm1th5eato6H0xd0n86Yv6jgqaF8wVHZJjsmyUty2KKx9qfKV575SEfuhMSjo3PCs+RREd20GIF87CjtnGzpHFXWNzJu+oPpV5j5U3HOXoWtwca5rOoaui7rvBV3/C8uzpPtKUfdwxcmvOPeBeanVaoP7WlH1rIz9pKD7zOKUWdI2KGq/e9Z1rehjqiTbCTB8n2Noum6ebh8q6p6psP3QUJqi7s+LU1ZVv/7lPj5127qw+3idgn7H6D4XpjT3scU5Piv7fqQ45/G8aZ+nOusY2ieA4p2vSnvOLOq3eXG2VUm2ZVU/bkuLj08SEREREREREZHRYVCMiIiIiIiIiIiMDoNiRERERERERERkdBgUIyIiIiIiIiIio8OgGBERERERERERGR0GxYiIiIiIiIiIyOgwKEZEREREREREREaHQTEiIiIiIiIiIjI6DIoREREREREREZHRYVCMiIiIiIiIiIiMDoNiRERERERERERkdBgUIyIiIiIiIiIio8OgGBERERERERERGR0GxYiIiIiIiIiIyOgwKEZEREREREREREaHQTEiIiIiIiIiIjI6DIoREREREREREZHRYVCMiIiIiIiIiIiMDoNiRERERERERERkdBgUIyIiIiIiIiIio8OgGBERERERERERGR0GxYiIiIiIiIiIyOgwKEZEREREREREREaHQTEiIiIiIiIiIjI6DIoREREREREREZHRKdOg2IMHDyBJEi5dulSmaUsrNTUV/fr1g42NDSRJQnx8vMFpRERERERERERkXEoUFBs+fDgkSYIkSTAxMYGvry8mTZqE9PR0AICnpyceP36MBg0alEtldcLCwjBy5Ei4u7tDrVbD29sbH3/8MWJiYvTSbdiwAcePH8fJkyfx+PFj2NraGpxGRERERERERETGRVXSBbp27Yp169YhKysL58+fx7BhwyBJEv773/9CqVTC1dW1POopu3//Plq1agV/f39s2rQJvr6+uHbtGj777DPs2bMHp0+fhoODAwDg3r17qFu3rl6QztA0IiIiIiIiIiIyLiV+fNLU1BSurq7w9PREnz590KlTJxw4cABA/kci4+LiMHToUDg5OcHc3By1atXCunXrDOar0WgwcuRI1KlTB6GhoQWWP2bMGKjVauzfvx/t27eHl5cXunXrhoMHDyI8PBzTpk0DAAQEBOCrr77CsWPHIEkSAgICDE4rSEZGBhITE/X+iIiIiIiIiIjoxVDinmK5Xb16FSdPnoS3t7fB+V988QWuX7+OPXv2wNHREXfv3kVaWlq+dBkZGRgyZAgePHiA48ePw8nJyWB+sbGx2LdvH+bNmwdzc3O9ea6urhg6dCg2b96Mb775Br///jumTJmCq1ev4vfff4darQYAg9MMWbBgAWbPnl3cTUFERERERERERFVIiYNif/75J6ysrJCdnY2MjAwoFAqsXLnSYNrQ0FC89NJLaNasGQDAx8cnX5rk5GS89tpryMjIwJEjRwod4+vOnTsQQqBu3boG59etWxdxcXF4+vQpnJ2dYWFhAbVarfdIp6FphkydOhXjx4+XvycmJsLT07PQZYiIiIiIiIiIqGoocVCsQ4cO+Pbbb5GSkoJly5ZBpVKhX79+BtN+8MEH6NevHy5cuIDAwED06dMHrVu31kszZMgQeHh44PDhw3q9v0aPHo2NGzfK35OTk+XPQoiSVrvETE1NYWpqWu7lEBERERERERFRxSvxmGKWlpaoWbMmGjdujLVr1+LMmTNYs2aNwbTdunXDw4cP8emnnyIiIgIdO3bExIkT9dJ0794dly9fxqlTp/Smz5kzB5cuXZL/AKBmzZqQJAk3btwwWN6NGzdgb29f4OOXREREREREREREQCmCYnoLKxT4/PPPMX36dINjhQGAk5MThg0bho0bNyIoKAirV6/Wm//BBx9g4cKF6NWrF/766y95urOzM2rWrCn/AUC1atXQuXNnfPPNN/nKe/LkCX766ScMGjQIkiQ9y2oREREREREREdEL7pmCYgAwYMAAKJVKBAcH55s3Y8YM7NixA3fv3sW1a9fw559/GhwP7KOPPsLcuXPRo0cPnDhxotDyVq5ciYyMDHTp0gXHjh1DWFgY9u7di86dO6N69eqYN2/es64SERERERERERG94J45KKZSqTB27FgsWrQIKSkpevPUajWmTp2KRo0aoV27dlAqlfjll18M5vPJJ59g9uzZ6N69O06ePFlgebVq1cK5c+fg5+eHgQMHokaNGnj//ffRoUMHnDp1Cg4ODs+6SkRERERERERE9IIr0UD769evNzh9ypQpmDJlCgD9QfCnT5+O6dOnG1zGx8cn34D548eP13vjY0G8vb0LrEtuQUFBxZpGRERERERERETG5Zl7ihEREREREREREVU1DIoREREREREREZHRYVCMiIiIiIiIiIiMDoNiRERERERERERkdBgUIyIiIiIiIiIio8OgGBERERERERERGR0GxYiIiIiIiIiIyOgwKEZEREREREREREaHQTEiIiIiIiIiIjI6DIoREREREREREZHRYVCMiIiIiIiIiIiMDoNiRERERERERERkdBgUIyIiIiIiIiIio8OgGBERERERERERGR0GxYiIiIiIiIiIyOgwKEZEREREREREREaHQTEiIiIiIiIiIjI6DIoREREREREREZHRYVCMiIiIiIiIiIiMDoNiRERERERERERkdBgUIyIiIiIiIiIio8OgGBERERERERERGR0GxYiIiIiIiIiIyOgwKEZEREREREREREZHVdkVqCqEEACAxMREaDQag/8aotFo5OV033WfMzIykJmZCSEEEhMTYWpqanC5vJ/zlqWbr5N7mZIo7nKFpctbx8LWQ/c5t9zbtLA8827/gtIVtH1z181QPQyVU1JFrUNR2yJvutx1MlTPwuqRt9zcCis3bx0NpS/uPpk3fVHHUUH7gqGyS3JMlpXitkVh7UuVrzz3lYrYD41BQeeGZ82nILprMwD52lHYOdvQOaqoa2Te9AXVrzL3oeKeuwxdg4tzXdMxdF3UfS/o+l9YniXdV4q6hytOfsW5D8wrMTHR4L5WVD0rYz8p6D6zOGWWtA2K2u+edV0r+pgqyXYCDN/nGJqumyeEQGZmZpH3TIXth4bSFHV/Xpyyqvr1L/fxqdvWhd3H6xT0O0b3uTCluY8tzvFZ2fcjxTmP5037PNVZx9A+ARTvfFXac2ZRv82Ls61Ksi116XTrZiwkYWxrXEqPHj2Cp6dnZVeDiIiIiIiIiKhchIWFwcPDo7KrUWEYFCsmrVaLiIgIWFtbQ5KkSqlDYmIiPD09ERYWBhsbm0qpA5UO265qYrtVXWy7qottVzWx3aoutl3Vxbaruth2VdOL3m5CCCQlJcHd3R0KhfGMtMXHJ4tJoVA8N9FSGxubF/IgNAZsu6qJ7VZ1se2qLrZd1cR2q7rYdlUX267qYttVTS9yu9na2lZ2FSqc8YT/iIiIiIiIiIiI/j8GxYiIiIiIiIiIyOgwKFaFmJqaYubMmYW+nYieT2y7qontVnWx7aoutl3VxHaruth2VRfbrupi21VNbLcXEwfaJyIiIiIiIiIio8OeYkREREREREREZHQYFCMiIiIiIiIiIqPDoBgRERERERERERkdBsWIiIiIiIiIiMjoMChGRERERERERERGh0ExIiIiIiIiIiIyOgyKUYWRJEn+s7CwQKNGjbBly5bKrpZBAQEBkCQJR48ereyqEBERUSnkve+oW7cuvv32W3l+WV3rfXx8IEkSHjx4UGTaWbNmyXVavXq1PH3t2rXy9ClTpjxTfQxJT0+X8yciQKPRICgoCC+99BIsLCxgZWWFOnXqYMyYMQD+77jO/RcQECAv/+DBAwwbNgzu7u5Qq9Xw9PTEsGHDKmltiOhZqCq7AmR8fvjhB0RERGDatGkYOnQoAgIC4OTkVNnV0jNjxgxERUWhXr16lV0VIiIiegY//PADEhISMH36dHz44Yfo2LEj/P39K7taWLlyJd5//335MxFVnMGDB+O3336Dr68vZs2aBTs7O/z777/YunUrgoOD5XRfffUV3N3dAQDOzs4AgJCQEDRv3hwxMTEYOHAgOnfujMjISGzcuLFS1oWIng17ilGFGzBgACZPnowGDRogKysLISEhAIDU1FRMmjQJPj4+sLS0xH/+8x/8+eef8nKnT59Gp06d4ODgAEtLS/Tp0wcAoNVqsXDhQtSqVQsWFhaoV68e1q9fDwAQQmDChAlwc3ODWq2Gs7Mz3njjDQDA/fv3ERAQABsbG5iZmaFWrVr4+eefAQBz5szBkCFDcP36dQDAv//+iy5dusDe3h5OTk7o27cv7t27BwBYv349JElCly5d0L17d9jY2KBp06a4e/duRWxOIiIiKsSrr76Kzp07w8HBAQCQkJBgMN2IESPg4uICtVoNV1dXDB8+HElJSQBy7ieWLVuGunXrwtzcHC4uLvjhhx/y5fHPP//A3t4ebm5uuHz5coF18vf3x5UrV3D06FH8/fffuHjxYr5AXUpKCsaPHw9vb29YWlqiSZMmej3sdb1XZs+ejerVq8PZ2Rnff/+9PH/9+vXw8PCAo6Mjli1bppd3UlISWrZsCTs7O5iamsLX1xfz588HAIwcORKSJOGPP/4AAMTExECtVsPf3x9CiALXiaiqOHHiBH777TfY2dnhzJkzmDRpEt5//30EBwfjzp07emlbt26NTp06oVOnTmjZsiUAYO7cuYiJicHQoUOxefNmvPvuu5g2bRquXbtWGatDRM+IQTGqcDExMTh79izu378Pe3t71K1bFwAwceJELF68GAEBAfjiiy+g0Wjw+uuv4+rVq3jw4AE6d+6Mv/76Cx988AGWL1+OGjVqAACWLFmCqVOnon79+pg5cyYcHR0xYsQI7Nu3D//++y+WLl2KmjVr4vvvv8dnn30GW1tbAMDXX3+Nv/76C2PGjMG3336Lfv36QaPR5KtvfHw8unTpgkOHDmHixIl47733sH37drz22mvIysqS0x0+fBht27ZFQEAALly4gLlz51bA1iQiIqLCeHh4oE6dOggJCcHw4cPRvHlzg+kaNmyIOXPmICgoCB07dsSGDRuwcOFCAMDSpUsxfvx4aDQaLFu2DJMmTYJSqdRb/vTp0+jcuTPs7e1x4sQJNGrUqMA69erVC56envj666+xYsUKuLq6on///nppxo8fj2XLlqFRo0ZYtmwZYmJiMGjQoHyPe164cAEff/wxnj59io8++ghpaWm4fv063n33XSQnJ2PWrFk4d+6c3jK6/8xbsmQJFi1aBDc3N0ybNg0HDhzAxIkTIUmS3Htt8+bNyMrKwqhRo/j4Jb0QTp8+DQBo27at/LRKdHQ0oqOjkZGRoXd/36pVKzg5OcHJyQnTpk3TW/7111/Xy1eh4E9roqqIj09ShfPw8AAAmJubY9euXbC2tgYAbN26FQCwYcMGvfQHDhyAmZkZkpOT8dZbb2HevHl683XL7dixAzt27JCn7969G9OnT4eNjQ1u376NQ4cOoWHDhpgwYQIAyMG4Q4cOITU1Fc2aNct3QwoAJ0+eRGRkJDp37ixfDHfu3ImrV6/i6tWrcrrAwEBMnToVBw4cwM6dO9lTjIiI6Dmwe/duaDQazJkzBxs3bsQbb7yBzp0766XRarW4d+8eNmzYgJSUFHn6hQsXAAC//vorAGDVqlV49dVXDZbz9ttvw8XFBX///Tfc3NwKrZNSqcTo0aMxY8YMKBQKTJ06NV/Aadu2bQCA7777Du7u7khKSsLEiROxbds2vbGNvv/+ezg5OWH58uWIiIhAeHg4Dh06BI1Gg0GDBmHs2LHo168ffv/9d3mZ1NRUnD59GvPnz9f7D8ELFy6gc+fO6N69O3bv3o1bt25h48aNMDMzw4gRIwpdJ6KqKj09XW8olz179sif165dC09PTwCAl5dXhdeNiMofw9lU4Xbs2IEPP/wQaWlpeP/995GWlqY3f8uWLThw4ID817Nnz2Llu2LFCr3l3n33XTg5OeHGjRuYM2cObG1tsXDhQjRu3BhPnjzBqFGjcOLECfTt2xcRERF4++23MXTo0GKVZeh/SnUXUxMTEwBAdnZ2sfIiIiKi8tOhQwf06NEDw4cPR3Z2NjZv3pwvzcGDB/HNN9/A1dUV27Ztw4oVKwAg3z1KYdzc3BAeHq439ENh3nvvPahUOf8/PXr06CLTF9RLqzT3H0FBQThw4AC6dOmCPXv24N133wXwf+v72WefyUNQnDp1CgMGDJAfPyWq6lq1agUg5zFK3ePBBw4cMNi7s1WrVvLjk7pHnHXLb9++XS+tVqst34oTUblgUIwqXGBgIIKDg9GuXTvcvHkTQUFBAIB+/foByPkf0UePHuHixYuYNWsWwsPD0a1bN1hZWWHTpk2YPn061qxZI/f40i23bt06PHz4EFevXsXSpUtx8eJF3L59GzNmzIAQAk2bNoWTkxNSU1MRHR2Nb775Bvv374ebmxtatGgBAAgNDc1X39atW8PFxQVHjhzBggULMH36dFy5cgW1a9dGgwYNKmCLERERUWlt2bIF69evl988qRt+wZD09HRERUXlezv2gAEDAOQEr1atWoWlS5fmG1T7t99+Q+3atTFq1CisXbu2yHo5OTlh/fr1WLt2rcGeZbpHsz744AOsXr0aQUFBkCQp3yNbhnTq1AlKpRKbN2/GypUrMXbsWIPpkpOT8eDBA+zbt09vevv27dG8eXPs2rVLrgPRi+KVV17BgAEDEBcXh1atWiEoKAgRERFITk4u1vLTpk1DtWrV8OOPP2LIkCFYs2YNFi5ciIYNG5ZzzYmoXAiiCgJAABBpaWlCCCHOnz8vJEkStra2IiYmRqSkpIhJkyYJX19fYWpqKtzd3UW/fv3EgwcPhBBCnDhxQnTo0EHY2dkJCwsL0atXLyGEEBqNRixcuFD4+/sLMzMz4eLiIrp16yYuXrwoHj58KNq0aSPs7e2FiYmJ8PLyEl9++aUQQoi1a9eK2rVrC3Nzc2FhYSFatGghjh8/LoQQon379gKAOHLkiBBCiEuXLonOnTsLOzs7Ua1aNdG7d29x9+5dIYQQ69atEwDEsGHDhBBCHDlyRAAQLVu2rKhNS0RERHno7jsACKVSKdzd3cWHH34o0tPThRD613qtVivef/99YWlpKby8vMS8efMEANG+fXshRM69xqJFi0Tt2rWFqampcHZ2Fhs2bBBCCOHt7S0AiJCQEPHo0SPh6+srFAqFWL9+fb46zZw5UwAQkydPLnJecnKy+PTTT4Wnp6ewsLAQjRs3Fps3b863fjq6ety4cUMIkXN/Ur16deHq6iqmT5+ulz4yMlIEBAQIU1NT0axZMzF27FgBQMycOVPOb/PmzQKAaNSo0TO0AtHzKSsrSyxevFg0aNBAqNVqYWNjI+rXry8++ugjER4enu94yuv+/fvirbfeEi4uLkKlUgk3Nzfx5ptvVvBaEFFZkITga2SIiIiIiCjH2bNn8csvv2Dp0qVYs2YNRo4cWdlVIiIiKhcMihERERERkczHxweRkZEYNGgQ1qxZk+9Nm0RERC8KBsWIiIiIiIiIiMjocKB9IiIiIiIiIiIyOgyKERERERERERGR0WFQjIiIiIiIiIiIjA6DYkREREREREREZHQYFCMiIiIiIiIiIqPDoBgRERERERERERkdBsWIiIiIiIiIiMjoMChGRERERERERERGh0ExIiIiIiIiIiIyOgyKERERERERERGR0WFQjIiIiIiIiIiIjA6DYkREREREREREZHQYFCMiIiIiIiIiIqOjquwKVBVarRYRERGwtraGJEmVXR0iIiIiIiIiojIhhEBSUhLc3d2hUBhP/ykGxYopIiICnp6elV0NIiIiIiIiIqJyERYWBg8Pj8quRoVhUKyYrK2tAeTsIDY2NpVSB61Wi6dPn8LJycmoIrcvArZd1cR2q7rYdlUX265qYrtVXWy7qottV3Wx7aqmF73dEhMT4enpKcc+jAWDYsWke2TSxsamUoNi6enpsLGxeSEPwhcZ265qYrtVXWy7qottVzWx3aoutl3Vxbaruth2VZOxtNuzDhcVEBCA4cOHY/jw4WVToXL24rYkERERERERERGVu02bNqF///64dOkSvvzySwwePBhLly5FSkoKAODBgwcYPnw4vL29YWZmhtq1a2PRokXQarV6+ezcuRNt27aFg4MDrKys8Oqrr+LkyZN6aWbNmgVJkgz+ZWdnl6je7ClGRERERERERESlsnLlSnz00Ufy94SEBNy/fx+bN29Gr169YGtrixYtWuDp06ewsrJCnTp1cPXqVUyePBkREREICgoCAKxfvx4jRowAAHh7e0OSJBw5cgQdOnTAsWPH0LJlS71yHR0dUaNGDb1pJe3pxp5iRERERERERERUKhs3bgQABAUFoV27dvjuu+9w+/ZtBAUFwcbGBlu2bMHTp08BAKdPn8alS5fw7bffAsgJqIWFhQEAvvnmGwBAixYtEBISgvv376NNmzbIzMzEF198ka/c1157DadPn9b7UyqVJao7g2JERERERERERFQqGRkZAIDQ0FCkp6dDrVajVq1a+Pjjj+Hs7Kz3iKRuPDbdvxqNBkeOHAEAOZ2ut5fukUgA+Ouvv5CVlaVX7tatW2Fubg43Nzf06NEDFy9eLHHdjSYoFh8fj2bNmqFJkyZo0KAB/ve//1V2lYiIiIiIiIiIqrTevXsDAJYuXYp//vkHn376KXr16oV9+/YBALp37w4rKysAQMuWLdGkSROMHj1aXj48PBwAMHDgQADAmTNn4OfnBz8/Pxw/fhwAkJmZiejoaHkZpVIJV1dX+Pj44MmTJ9i1axdatWpV4sCY0QTFrK2tcezYMVy6dAlnzpzB/PnzERMTU9nVIiIiIiIiIiKqsr744gssX74cjRs3hiRJiI+Px86dO9G1a1fs2rULfn5+2L9/Pzp06ACFQoGIiAgMHz5c7gVmYmICAPjss8+wZMkS1K5dG5GRkTAzM0OvXr3kcnTp3njjDURFReHOnTu4ceMG9u7dCyCnx1pwcHCJ6m40QTGlUgkLCwsAORtKCAEhRCXXioiIiIiIiIio6lIqlRg3bhwuXbqEdu3aYeLEiejQoQOA/xtvrFWrVjh8+DDi4+MRFRWFkSNHyjGZ2rVrA8h5XHLChAm4efMmUlNTcf36dbi6ugIAqlWrhmrVqgEA/P394eDgIJffpUsXeV5oaGiJ6l5lgmLHjh1Dz5494e7uDkmSsH379nxpgoOD4ePjAzMzM7Rs2RL//POP3vz4+Hg0btwYHh4e+Oyzz+Do6FhBtSciIiIiIiIiej4kJycjLS2tTPJauXKl/AgkANSvXx/dunUDAKSnpwMATpw4AY1GAwCIi4vDxIkTAeS8QbJjx44AgKioKFy/fl3O59ixY9iwYQMAYNCgQXLPsv/+9796wa8DBw7ITwL6+PiUqO6qEqWuRCkpKWjcuDFGjhyJ119/Pd/8zZs3Y/z48Vi1ahVatmyJoKAgdOnSBbdu3YKzszMAwM7ODv/++y8iIyPx+uuvo3///nBxcTFYXkZGhjxYHAAkJiYCyBn4LfcgcRVJq9VCCFFp5VPpse2qJrZb1cW2q7rYdlUT263qYttVXWy7qottVzVV9XaLjY1FYmIiFAoFEhIS5OmSJMHU1BTm5ualznvJkiUYN24c3N3dkZCQgPv37+Px48cAgMDAQADA6NGjER4eDk9PT9y7dw+pqalQKpVYtWqV/FRfaGgomjdvDh8fH5iYmODu3bsQQqBGjRr48ssv5fK+/fZbTJ06FZ6enrC0tMTNmzcBAJaWlvjkk09KVPcqExTr1q2bHGk0ZOnSpXjvvfcwYsQIAMCqVauwa9curF27FlOmTNFL6+LigsaNG+P48ePo37+/wfwWLFiA2bNn55v+9OlTOdJZ0bRaLRISEiCEkN/UQFUD265qYrtVXWy7qottVzWx3aoutl3Vxbaruth2VVNVbbfMzEwkJyfne3OjjhAC6enpz9RrbPr06di4cSOuX7+O5ORkZGRkwMfHByNGjJAH1A8MDMTWrVtx69YtmJmZITAwENOmTUO7du3kfJydnREQEIDLly8jMTERHh4e6N27N2bMmKH3uOTnn3+OLVu24Nq1a7h//z68vb3xyiuv4IsvvpAfxSwuSVTBgbUkScK2bdvQp08fADmNbGFhgd9++02eBgDDhg1DfHw8duzYgcjISFhYWMDa2hoJCQl45ZVXsGnTJjRs2NBgGYZ6inl6eiIuLg42NjbluXoF0mq1ePr0KZycnKrUQUhsu6qK7VZ1se2qLrZd1cR2q7rYdlUX267qYttVTc9zu+nCOrrHC3XThBC4desWsrOzAQCmpqbQaDTw9fWFmZkZ4uLiYG5uDhMTEyQmJsLR0REJCQnPFPMICAjA8OHDMXz48Gdap4pSZXqKFSY6OhoajSbfo5AuLi5yN7qHDx/i/fffl3eMjz76qMCAGJCzs5iamuabrlAoKvUAkCSp0utApcO2q5rYblUX267qYttVTWy3qottV3Wx7aoutl3VVJbtptVqIUkSEhISYGdnV+Lls7OzcefOHdSuXRt3796FJEmoWbMmFAoFrl27hs2bN6Nr166wtLSEqakpnJ2dYW9vrxc40w1OD/zfmx2NzQsRFCuOFi1a4NKlSyVeLjg4GMHBwfKAcEREREREREREpREZGQlzc3M8fPgQpqamSEtLQ2hoKBo1alTksufPn8eOHTtgamoKT09P+Pv74+rVq3JPsWvXrsHFxQW3b9/Gv//+i+7duyMzMxN16tQx2OmnPBw9erRCyikrL0RQzNHREUqlEpGRkXrTIyMj5dd3ltaYMWMwZswYJCYmwtbW9pnyIiIiIiIiIiLjIoRARkYGwsPDkZycLE9PS0vD0aNH8euvv2LJkiWIiYmBjY0NHBwcULduXSiVSgA5wzm99dZbMDMzg7e3N0xMTLB//340atQIQggolUooFApkZWXh8ePH8PX1xYoVK+Dh4cHeiEV4IbaOWq1G06ZNcejQIXmaVqvFoUOH0KpVq0qsGREREREREREZq6ysLFy7dg23bt3SC4jpem7VqFEDb731FiwsLLB161YkJycjLi4OXbt2xdtvv434+HgEBwcjJCQEN27cwJ07d/DGG2/g66+/RrVq1aBWq1G3bl3UrVtXfgxTqVTC09OTAbFiqDI9xZKTk3H37l35e0hICC5dugQHBwd4eXlh/PjxGDZsGJo1a4YWLVogKCgIKSkp8tsoiYiIiIiIiIgqyt9//w0LCwsoFApIkgRLS0u4u7tDqVRCpVIhOzsbjRs3RmhoKM6fP4+33noLaWlpuHfvHiIjIxEZGYk33ngDycnJcvoePXqgRo0aAKD3RkYA8PDwQHZ2NhwcHPTGDqOCVZmg2Llz59ChQwf5+/jx4wHkvGFy/fr1GDRoEJ4+fYoZM2bgyZMnaNKkCfbu3Ztv8P2S4phiRERERERERFQSukcZ/fz8oFar4e/vLz8OqaNWqwEAXl5e8PLykpcbOHAgJEmChYUFIiIioNVqUbt2bQQFBaF69eoFlqlUKuWAGRVPlQmKBQQEyIPHFWTs2LEYO3ZsmZbLMcWIiIiIiIiIqDgSEhJw6tQp3Lp1C3/88QeGDRuGt99+u0R5vPzyy2jatCn8/f0xd+5cqFQqzJ07t9CAGJVOlQmKERERERERERFVtPj4eDx58gS3b9/Ga6+9VmC6W7duYdu2bejWrRtOnjwJSZLQu3fvEpVlYmKCyZMnAwDu3LkDpVKJxo0bo3bt2s+0DmQYg2JERERERERERHloNBqEhIQgJSUFX3/9Nc6dO4f//Oc/8PDwMJj+n3/+wdGjR1GrVi28//77mDx5MiwtLUtdfq1atXD8+HH5MUsqewyKFYFjihERERERERFVbUKIQgefj4mJgUKhQGJiIoQQMDU1RVRUlDy/c+fOOHv2LPbs2YP33ntPb9mEhARYW1ujbdu2cHBwQNeuXfONH1ZaVlZWZZIPGcagWBE4phgRERERERFR1RAfH4/U1FS4u7sjMzMTKpUKaWlpuHv3LlQqFRQKBTw9PfWCTampqXj06BESExNhamoKU1NTeZ5arYaPjw/q1KmDJUuWYNWqVXjnnXegUCiQkJCA5ORkREdHQ5IkKBQK1KxZs8wCYlT+GBQjIiIiIiIioirr8ePHck+vrKwsAEB2djbi4uL00mVnZwPI6RVmZWUFIQQePnyIhIQECCGwevVqtG3bFk2aNIGpqSlsbW3h4+MDANBqtahevTpCQkJw584dxMXFwdzcXM5bCAGNRgMbG5uKWWkqE4rKrgARERERERERUXGlpaVBq9UiLS0NDx48QFRUFDQajRwQAyAHxCRJgiRJsLe3h7e3N5RKJRISEvDw4UNERkYiISEBAJCZmYnHjx/j2rVraNGiBfz9/eHt7a1Xbo8ePQAAv/zyC4QQyM7OhqmpKdzc3GBhYQEgJ3hGVUe59hTLysrCkydPkJqaCicnJzg4OJRncURERERERET0ghJC4PHjx3j69CkkSYIQQp7n6uoqB7/S0tIQFhYGlUqF2rVr640nFhsbi6SkJMTHx8vTfH19YWNjg99++01+9DF3LzAd3Rsgf//9d9y/fx/jx49HnTp1AABOTk6Ijo6GnZ1deW4CKmNlHhRLSkrCxo0b8csvv+Cff/5BZmamvAN6eHggMDAQ77//Ppo3b17WRZcLDrRPREREREREVLmysrJw+/Zt+RFIXUBMpVLBw8NDbwxwExMT1KtXT06Te4B9Nzc3mJmZ4enTpxBCwMbGRn7ksaiAlo+PDxQKBbRaLby8vNC4cWN5niRJcHJyKpN1pYpTpkGxpUuXYt68eahRowZ69uyJzz//HO7u7jA3N0dsbCyuXr2K48ePIzAwEC1btsSKFStQq1atsqxCmeNA+0RERERERETFp9Vqce/ePTx69Ah+fn548uQJWrRoUejbHwuSmZmJ9PR0PHz4EFqtFgqFAr6+vsjKyoK1tTVUKsNhDd1jk3mZm5vD3NwcCQkJyMzMLFEgS61Ww8zMDKmpqRg3blyJ14WeP2UaFDt79iyOHTuG+vXrG5zfokULjBw5EqtWrcK6detw/Pjx5z4oRkRERERERETFEx4ejr///huHDx/GBx98gDVr1mD79u0IDg5G27ZtkZWVhfT0dFhbWxeZlxACN2/elHt8mZiYoHbt2mXydscaNWogPT1d7y2UxalPx44dERkZyeGhXhBlGhTbtGlTsdKZmppi9OjRZVk0EREREREREVWilJQUREdHw9vbG9bW1sjIyEDz5s2xfft2HD58GDVq1MDTp08BANWrV4ejo6O8bFZWFpRKJS5cuAArKytotVoIISCEgEqlgoWFBby9vaFQlM37AtVqNdRqdYmWkSQJX375ZZnVgSpfuQ60DwB3797FvXv30K5dO5ibm+sNcEdEREREREREL4aYmBgAOWNvLV68GJmZmXjw4AHatGkDT09PeT6Q06PM1tYWKpUKx48fR1ZWFiIjI1G/fn1kZGTo5VuzZk2YmppW6LqQcSi3oFhMTAwGDRqEw4cPQ5Ik3LlzB35+fnjnnXdgb2+Pr776qryKJiIiIiIiIipUWloalEolTExM5DcZRkREwNnZGSYmJpVdvedSeno6IiMjoVQqYW5ujsTERFhbWyMpKQnZ2dlITU3VG3BerVbD398fvXr1gpubG7RaLWxtbaFUKhEbG4vIyEhcuHABwcHBGDVqFDZs2IA+ffqgV69esLS0hEKhgLm5OduDyk259fn79NNPoVKpEBoaCgsLC3n6oEGDsHfv3vIqtswFBwejXr16VeZtmURERERERFQ4jUaD27dv48aNG7hx44Y8MHx0dDRCQkIqu3rPFa1Wi4iICNy7dw+3bt1CfHw8YmJi8OjRIyQmJiI8PByJiYlITU0FADg5OeV7vLBVq1byE2O2trZwcXEBkNOZxtvbGwEBAVCpVEhLS0OdOnVQvXp12NnZwcbGhgExKlfl1lNs//792LdvHzw8PPSm16pVCw8fPiyvYssc3z5JRERERET04hBC4Pbt2/L3rKwsXLlyRf6elpaGx48fw9nZuUwGdK+KhBCIj49HUlISVCqVPA4YAJiZmUGpVCItLQ3W1tZISUmBRqORe3a5ubnly8/W1ha+vr6IiYmBnZ0dJEmCo6MjoqOjIUkSJk+eDIVCgU6dOul1qiEqb+UWFEtJSTG4M8fGxvJZYCIiIiIiIqpQ8fHxiIqKgiRJyMzMhFKphL+/P+7du4fMzEwoFArY2dkhNjYWUVFR0Gq1qF69emVXu8IJIXDr1q1843rZ2dnBwcEh31sjdYPhFzX4vLW1td6y1atXh42NDVQqlbwsA2JU0crt8cm2bdvihx9+kL9LkgStVotFixahQ4cO5VUsERERERERkZ5Hjx7h4cOHSEtLk8e98vPzg1qtRt26deHn54fatWvD09NTftrJWF8QFxERgYyMDEiSJAexzM3N5TdK5iVJUqnfxmhtbQ1zc/Nnqi/Rsyi3nmKLFi1Cx44dce7cOWRmZmLSpEm4du0aYmNj8ffff5dXsUREREREREQAcsYOCw8PR1xcHADAysoKqamp8Pf313uCKXewx8HBAREREfIYWQkJCYiMjIRWq0WdOnUqdgUqQFZWFtLS0qBWq5GWlobo6GgAOW98tLCwQHZ2diXXkKj8lFtQrEGDBrh9+zZWrlwJa2trJCcn4/XXX8eYMWMMPmNMREREREREVBparRapqalIT0+Ho6OjPD0kJAQpKSkAgGrVqsHDwwNCiEJ7gUmShMTERBw5cgQPHjzAiBEjoNVqAQDZ2dlQqcrtZ3SFe/ToEWJiYgAAKpVKDoC5uLjIjzK+SOtLlFe57t22traYNm1aeRZBRERERERERkyr1eLmzZvIysoCANjb20Or1eLOnTvIysqCQqGAp6cn7OzsABTvscjz58/j+++/h6+vL7RaLdRqNTIzM5GamgobG5vyXJ1yl5mZibt378rbSyc7OxsKhQImJiZwdnaupNoRVawyDYpdvny52GkbNWpUlkWXm+DgYAQHB0Oj0VR2VYiIiIiIiADkDG4OAE+fPoWVlRUsLS0BAElJSYiKioKvr2+px3mqSjIyMvDw4UNkZWVBkiQIIeRgmFarhSRJ8PX1hZWVVYny7dixI2xtbeXvkiTJj2A2bty4TNehKEIIuSeclZXVM491FhUVJQfEFAoF3N3dkZCQgKSkJFSvXh0ODg5lUW2iKqFMg2JNmjSRT0SFkSSpygSZxowZgzFjxiAxMVHvpEhERERERFTREhMT0bdvXzg7O8Pb2xs9evTAypUr0a1bN5w/fx7Dhw+HUqnE48ePX/g3J2ZlZeHWrVvy78+aNWvizp078lsTTUxMUKdOnVIFB+vXr4/69evj/v37uHfvHtq0aYOPPvoIQggsXboUzs7OcHV1LdP1yUuj0SAsLAwJCQlQKBTQarVQKpXw8fEpcZAPyAmuhYaGIj4+HkDOOuoejXRwcEBKSkqp8iWqyso0KBYSElKW2REREREREVEuiYmJePr0KRo0aIBLly7B3NwcN27cwPXr1/HWW29BqVQCAKKjo5GcnIyaNWvK014U6enpUKvVuH37NoQQMDMzg5+fH0xMTODp6YmsrCyo1WrY2dk9c68qPz8/+Pn5AQD69++PNWvWQAiBU6dOoW/fvmWxOvlkZmYiMzMT9+7dk6fpxjTTaDS4d+8eatWqJY/5lZeuh5xu3YUQCAsLk3u6AYC7u7veWGGSJDEgRkapTINi3t7eZZkdERERERER5XLs2DFYWVlh4MCBSEpKQqdOndC6dWtMmzYNZmZm0Gq1qFatGuLi4nDv3j1YWFhgz549sLS0xNChQyu7+s8sOjoa4eHhMDExQXZ2NkxMTFCrVi25N1h5Pvo3atQonD9/HomJifD09HymvDIzM/HkyROoVCo4OjrK9Q8PD0dMTIz83dTUFF5eXkhOTka1atUQGhqK//3vf3jw4AF++uknvaBfTEwMTpw4AR8fH9jZ2cHLywtarRb37t1DWloaAECpVMLPz6/AgBqRsSn310hcv34doaGhyMzM1Jveq1ev8i6aiIiIiIjohbJnzx4AOW8NtLa2hkKhQOfOndGpUye9AImzszOmT5+OsLAwaLVamJqaYsiQIVV2nLGsrCyEhoYiOTlZ/q5QKPQCYhVh9erVePDgARISEqDRaErUC08IgYiICDg7OyM5OVke18vMzAxAzjrdvHkTjo6O0Gg0kCQJtWvXhiRJchDL19cXWVlZuHr1Ku7evYtatWrJ+a9duxaBgYEQQiA+Ph7x8fHQarXy9vH19a3yLwkgKmvlFhS7f/8++vbtiytXruiNM6Y7UVeVMcWIiIiIiIieB6mpqUhOTkadOnUwYMAAREVFyfPyPiaoVqsxcOBALF++HEDOgPRbtmzB1q1bMXbsWLRr165C6/6sIiIi5ICYmZkZMjIy4OPjAxMTkwqvi7m5ORISEpCeni6/4KAwISEh8PDwQGRkJGJiYhAfHy+/6TE2NhYnTpyAh4cH9u3bB5VKhRo1aqBOnTqwt7c3+Phn3759sW/fPvzxxx8QQqBVq1ZIS0vDTz/9hLt37+Krr77CvXv3cOfOHTloVrduXajV6jLfFkRVXbmF1D/++GP4+voiKioKFhYWuHbtGo4dO4ZmzZrh6NGj5VUsERERERFRlfbo0SMMGjQIt2/fRkREBLKyspCamorw8HDMmjULixcvLjIPhUKBt956C/v378eiRYsAAF999RUUCgXMzc1x6NCh8l6NZ6LVauVxtB49eiQPDu/n5wd/f380aNAA1tbWlVI3SZJw+vRpnD17tsi0d+/exaNHj3Ds2DHExMQAALKzswEAtra22LBhA3bt2oXMzEzs2LEDO3bsQMeOHeHv7w8nJyeDeTZr1gxKpRI//fQTfvjhB8ycORNmZmbo3bs3pk6dCisrK9y+fRsrVqzA6dOn0ahRIwbEiApQbj3FTp06hcOHD8vPRysUCrRp0wYLFizAuHHjcPHixfIqmoiIiIiIqMr66quvcOPGDYSHh8PBwQFPnz6V50mSBDs7u2Ln5eDggFdffRX169fHtWvX8PTpU2RmZsLR0RE3b96Ev7//c/dIpRACt2/fRmZmJiwsLJCSkgIgZwxrXSDsWQfQfxaSJCE4OBidO3dGQEBAgemSk5Px1ltvYfjw4Xj55ZcBADY2NsjKykJWVhYcHR0xfvx43L9/HxkZGVi4cCGysrKK7H2mVqvRqFEj+Td1UlISbt26hfbt28PHxwcAkJCQgKysLHTu3LlStxXR867cgmIajUY+YTk6OiIiIgK1a9eGt7c3bt26VV7FEhERERERPVd0vbwkSYKZmRkkSUJKSgr8/f310gkhkJ6ejvPnz6Nr165wcHDQGxMKALy8vKBUKuVeVMU1atQojBs3DlZWVnjppZdw9+5dZGRk4PHjx6hevXqZrGdZ0L0lUTf8ji4gVr169RIFA8uTk5MTbGxs9B5fNeSrr75CSkoKjh8/js6dO8PR0RHW1tYQQiAqKgpmZmZo0KABfH198fDhQ9SrV6/YdVi2bBk6dOgASZKwevVq1KxZUy+Y9s4772Dw4MF8oyRREcotKNagQQP8+++/8PX1RcuWLbFo0SKo1WqsXr1afqVtVRAcHIzg4GCOgUZERERERKUSHR2N1NRUAP8X5NF91gUyUlNTce/ePfzzzz+Ij49H9erVERoaiqZNm8LJyQnZ2dlISkoqdWAoICAAixYtQpMmTWBhYYE6derg8uXLOHfuHNzd3SFJEq5fv47k5GS0aNECkZGRsLGxgbm5+TOvf3GFhYUhNjYWAKBSqeDp6YnQ0FD5DY3PE19fX4SGhhY4PzU1FadOnYKfnx/WrFkDU1NTeZ4u4KdjaWlZooAYANjb2+O9996DqakpGjdunG++JEkMiBEVQ7kFxaZPny6f8OfMmYMePXqgbdu2qFatGjZv3lxexZa5MWPGYMyYMUhMTIStrW1lV4eIiIiIiKoQjUaD+Ph4SJIEJycnJCcnIz09XW/MrHPnzskDxjdt2hQzZsxAly5d9MbMMjExeeYAVdeuXeXParVaHsOqVq1aOHLkCOrWrQt7e3tcv34dWVlZOHnyJHr06FFmg9nrBpfX9Xx78uQJHB0dkZmZibCwMKSnpwPIGTfMysoKkiSVOFhUUXx9ffHvv/8iPj4+X6Dyxx9/hIWFBWbPng0bGxu9gFhZkSQJY8eOLfN8iYxNuQXFunTpIn+uWbMmbt68idjY2ALfoEFERERERFRVZWRkQKPRwMLCQm/6kydPIISAlZUV3NzcAOSMAXX//n2kp6dDo9EgOzsbSqUSDg4OsLGxQb169SpkYPRXXnkFO3bswOnTp7FmzRp4e3tj5syZyMrKQlhYGJYvX47w8HD06NFDHquqtFJSUhASEgKtVgsLCwtIkoTk5GRERkZCkiS595Sbm5teMPB5G+9MR7c9Hjx4gCZNmujNW7VqFT799FMoFAr57Y9E9Hwqt6BYQkICNBoNHBwc5GkODg6IjY2FSqWCjY1NeRVNRERERERUoe7cuQONRgNbW1solUp4eHhAkiT5scnc43bpenylp6dj7ty5UCgU6Ny5M1566aUKrXPr1q2hUCjw448/Ijs7Gy1btkTDhg0RFhYGW1tbvPbaa2jbti2uX7/+TEExrVaLQ4cOwdvbG4D+I6RAzuOE5ubm8PT0rNDHNZ+Fp6cnAOD8+fN6QbE9e/YgKSkJ169fh6WlJVSqcvvJTURloNzC7oMHD8Yvv/ySb/qvv/6KwYMHl1exREREREREFUrXSwzI6RwQGxsLIQTCw8ORmpoKU1NTmJmZyelVKhUSExNx8OBBHD16FMeOHUNgYGCF19vGxgbe3t6IiYmBSqXC+++/D6VSCR8fH/j4+OCzzz6DEALVqlWTg3ul8eOPP+L8+fMICQmBt7c3HBwcYGFhAXd3d/j7+8Pb2xt+fn5VJiAGAFlZWQCA3bt3601fsWIFACAwMBDdunWr8HoRUcmUW1DszJkz6NChQ77pAQEBOHPmTHkVS0REREREVKHCwsLyTbty5Qqio6MBANWqVcs3f9myZVi5ciWEEOjevXul9SjSjRe2cOFCvad8dB4+fIjRo0djz549Jc47Li4ON27cwOnTp3HixAm0adMGdnZ28PT0RK1ateDk5ARzc3PY2dlVuR5VnTt3hpeXF+7cuYNPPvlEHnRfo9HAxsYGL7/8ciXXkIiKo9yCYhkZGcjOzs43PSsrC2lpaeVVLBERERERUYVJS0uTHweUJAnZ2dnYu3cvMjIykJWVBT8/Pzg5OeVb7q233pJ7Gw0aNKhC65zbd999h40bNxbYU61p06bQaDQl6tig1WoRFhaGyMhIZGZmYtSoUVizZs1z9wbJZ2FiYoL+/fsDAE6fPo2NGzfi6dOnePz4Mdq1a1fJtSOi4iq3cHyLFi2wevVqufuozqpVq9C0adPyKpaIiIiIiKjChISEAMgZIF6lUiEhIQH79u2DEAKvvfaa3qDxufXq1Qtz585FdnY2/Pz8KrLKeqpVq2awJ5uOh4cH6tSpg9OnTyM5ORmmpqaFvo1Sq9Xi1q1byMzMBJAzfpqvr2+ZvcHyeTJw4EAoFAo8ffoUnTp1wjfffAMAFT42HBGVXrkFxebOnYtOnTrh33//RceOHQEAhw4dwtmzZ7F///7yKpaIiIiIiKhcZWVlISkpCWlpacjKyoJarYajoyMUCgUcHBywatUq+Pj4FPoGSaVSidmzZyMjIyPfGyufN56envKjgkqlEps2bcKlS5fwyy+/wNbWVk6n1Wrx999/w8bGRn6jpL29/QsZEAMACwsLvP322/LbRM+ePQsAsLS0rOSaEVFxldvjk6+88gpOnToFT09P/Prrr9i5cydq1qyJy5cvo23btuVVLBERERERUblJTEzE9evXERYWJo8ZVr16dSgU//fTyt/fv9CAmE6PHj3Qr1+/cqtrWWnevDni4+OhUCgQGxuLAwcOIDw8HHfu3JHTZGVlYcqUKbCxsUFqairq1KkDLy8vg4+Ovmisra0RHx+PsLAweHp6okuXLpVdJSIqpnIdzbBJkyb46aefyrMIIiIiIiKiChMfHw8g5w2SWq0WXl5esLGxqdxKlbPBgwejf//+uHbtGlauXCk/GrlmzRo0a9YMAPDFF19g7969UCqVmD59OtRqdbECgy+KEydOQAiBKVOmQKlUVnZ1iKiYyi0oduHCBZiYmKBhw4YAgB07dmDdunWoV68eZs2aZVQnSCIiIiIiqtq0Wi1CQkKQnJwMlUqFevXqAcgZXN8YqFQqKBQKhIWFwczMDEIInDp1Su4ttmfPHlSvXh1TpkwxyscHJ06ciHbt2qFNmzaVXRUiKoFyC4qNGjUKU6ZMQcOGDXH//n0MGjQIr7/+OrZs2YLU1FQEBQWVV9FERERERERlKi4uDsnJyQAAW1tbowmG5Xbp0iWkpaXh448/hkKhgEKhwK1bt9C8eXOMHz8erVu31htjzJiYmppymCCiKqjcxhS7ffs2mjRpAgDYsmUL2rdvj59//hnr16/H1q1by6vYMhccHIx69eqhefPmlV0VIiIiIiKjlp6ejpCQEGi12nIrIysrC48ePcLDhw8RFRUFjUaDO3fuIDw8HEDOeGHVq1cvt/KfZ8nJybC0tES3bt0wfPhw2NrawtPTE0+ePMFLL72EGjVqVHYViYhKpNyCYkII+WJ18OBBdO/eHUDOm0t0A1JWBWPGjMH169flN4kQEREREVHlePjwIRITExEWFlam+WZlZeHJkydISEjAnTt3EBMTg/j4eDx+/BghISFITU2FEAJmZmYwNzc3yl5iADB69Gj89ddfcHd3hyRJ6NGjh/yCAd3jlUREVUm5PT7ZrFkzzJ07F506dcJff/2Fb7/9FgAQEhICFxeX8iqWiIiIiIheQImJiUhPTweQM9i9ra0tFAqFPMi97j/kSxOYiYyMRExMjPxdpVLBwsICiYmJSElJAQDUrl3b6MdFliRJbxuoVCrUr18fGo0GWVlZlVgzIqLSKbegWFBQEIYOHYrt27dj2rRpqFmzJgDgt99+Q+vWrcurWCIiIiIiKkBWVha0Wi3UajUkSYIQorKrVKTs7Gx8++236NSpEwDA2toaSUlJePjwIQDA3d0darUaYWFhsLCwgJ+fX6H5PXz4UO75ZWVlBa1Wi4SEBAA540IJIeDr6wtTU1PcvHkT2dnZ8PX1hZmZWfmuaBWlG1vMxMSksqtCRFRi5RYUa9SoEa5cuZJv+uLFi/mKWiIiIiIiA7RaLcLDwxEXFweFQoHatWuXWbAhPDxcHsbE09MTycnJSEpKgpWVFYCc4U8SEhKgVquRlpYGMzOzSn+LoFarxb59+7BmzRo0a9YMtra28PHxwfXr16HRaAAAERERcvqkpCRcvXoVjo6OcHZ21us1FhERgeTkZKSlpcnT4uLi5M/VqlWDh4eHXvm1atWSgz5ERPTiKbegWEH4PyxERERERIaFhobKvZY0Gg0yMzPLJCiWlpamN65vRESEHFSKj49HamoqbGxs9NJYW1sX2euqPGk0Gly/fh3e3t4YNGgQLCws8OjRI9SrVw8eHh5ITEyEJEmIjY0FAFhaWiIlJQUajQaRkZGIjIyEq6srnJ2dcebMGZiZmcljgbm7u0OpVCIsLAxqtRo+Pj4wNzfPVweVqsJ/LhERUQXiWZ6IiIiI6DkghJDHzHJycsLTp0+f+fHG2NhYWFhYyI8aOjo6IjExEZmZmQAABwcHxMbGIjMzUw6IKZVKaDSaSn+0MjY2Vh4nrGvXrrh79y7atGkDALCzs4OdnR2ys7PloJivry+ioqKgVCrx+PFjAMCTJ09w79493Lp1C3Xr1oWDgwOsra3h5OQEALCysoKJiYnRDpxPRGTsGBQjIiIiIqpEWVlZiIqKQnp6OjIyMmBjYwMLCwt5XmnFxMTg0aNH8ne1Wo3q1avDxsYGMTExcHd3h0qlglKphBAC0dHRkCQJ9erVw507d5CRkfHM61ZaQghERkYCyAnSubi44KWXXsqXTqVSwcfHR07n5uYGICeo+OTJE0RFRWHTpk04ceIEZs6ciZdffllveWMfOJ+IyNgxKEZEREREVAmEEAgNDUV8fLzedGtra/mRydIExR4+fAiNRoOkpCQAOcEiExMTVK9eXc7f2toaQM6YXQqFAk5OTtBqtTA3N4dCoYCFhYXcgyxv4Cg6OhoajQZxcXGwsLCAo6Mj1Gp1mT1qqNFo5HVQq9WoXbt2oWN62dra5psmSRLc3Nzg4uKCiRMnwsfHB7169SqT+hER0YuDQTEiIiIiogqWkZGBBw8eyI9LqtVqmJmZwdnZGZaWlvLjjSUNimVlZekF2ZydneXeU4WRJAmenp7y92vXrmHBggWYOHEievbsKU8/f/48njx5Ajc3NyiVSmRkZMiD1dvb28PLywtATsBPq9VCq9XCxMQECQkJEELAzs6u0HrExsYiLCxM/u7r6/tMg9wrFAp4e3tjwoQJpc6DiIheXOUWFBs/frzB6ZIkwczMDDVr1kTv3r3h4OBQXlUgIiIiInou6B7ls7W1zdczrFatWvLjkjq6XleFBcWEEAgLC4ObmxuSk5P1Bsk3NTWFqalpsQJihri5uSEuLg63bt2Sg2JarRZjxoxBYGAgevfuDYVCIY/5BeS8yTEhIQHe3t44f/48zM3NYW5uLo9bJkkSbGxsDAa5EhMTsX//ftSsWROSJMHU1BTu7u58SRcREZWrcguKXbx4ERcuXIBGo0Ht2rUBALdv34ZSqUSdOnXwzTffYMKECThx4gTq1atXXtUgIiIiIqp0n3zyCZKTkzF37lxIkgRJkmBpaQkvLy+Db5dUKBRQqVQFBsVOnz6NvXv3om/fvnjy5AlMTU3leZIkoUaNGs/01sp69erB1NQUd+/eladlZmYiMzMTly5dwqxZswAAUVFRcHBwQGpqKkJDQ6HVanH27FmcO3cObdu2BQB5IHwhBCIiIuDh4ZGvvIEDB6Jt27awtbVFrVq15HHCiIiIylPp+yIXoXfv3ujUqRMiIiJw/vx5nD9/Ho8ePULnzp0xZMgQhIeHo127dvj000/LqwpERERERJXi2LFjaNu2LVq0aIFBgwYhJCQEb7zxBrKzs2FlZYVGjRoVGbhSqVTyY5Q6ukH54+Pjcfr0aWRmZsoBMTMzM6hUKtSpU+eZAmIAYGJiAn9/f1y+fBkDBw5EUlISLl26hOzsbPTp0wcKhQIKhQKurq5Qq9Wws7NDw4YNYWZmhj/++AM///wzhBDy2x11j2bGxMQgOztbLicuLg5r1qxBREQE/v77b7Rt25YBMSIiqjDl1lNs8eLFOHDgAGxsbORptra2mDVrFgIDA/Hxxx9jxowZCAwMLK8qEBERERFVuAsXLmDixInyeGE3btwAAISFhcHHxwc1atQoVj4//vgj/vnnH+zevRsqlQrR0dEIDw8HALi6umLZsmVwdHRERESEPHaYEAKSJJXJetSpUwdXrlzBzZs3MXjwYDRr1gwA8r3BUUc3LtmECRPQr18/tGrVCgqFQq5TSkoKYmNjERoaCj8/P5w9exaSJCEhIQHOzs5Yu3YtH5ckIqIKVW49xRISEhAVFZVv+tOnT5GYmAgAsLOzy/e/X0REREREVZmdnR1cXV3x5Zdf4tSpU2jRogVMTEwwbNgwtG7dutj5WFpa4smTJzhz5gwSExNx7tw5ADk9yFxdXeHv7w8nJyc0bNhQHjusrAJiAOS3V5qamqJnz56IioqCjY0N/Pz8ClzGwsICXl5eaNeunTx2mK5OujomJSXhyZMnWL58OaKjo9G1a1fs3LkTrq6uZVZ3IiKi4ijXxydHjhyJbdu24dGjR3j06BG2bduGd955B3369AEA/PPPP/D39y+vKhARERERVbj09HTMnTsXPXv2hKWlJb7//nucPXu2xEGfIUOGAAC2bNmCjz76CJGRkQgLC0P9+vXh6uoKpVIJAM/0dsbCjB07Ft27d8fPP/8MCwsLdOrUCXv37i11by6VSiUHxv744w9cuXIFMTExqFevHszNzcuy6kRERMVSbo9Pfvfdd/j0008xePBgedwAlUqFYcOGYdmyZfh/7d13dFTV/jbwZ0pm0nvvIRBCS+hFEBDp0i0URQTh4iXYYgMVuGBDsaASRexggR8qKAqIgIICIj2EEkgIpJFeJn3afv/gzbnkhprMyTDJ81mLtZxzzuy9T75OCE/22Ru4NCX7k08+kWsIRERERERNpri4GFVVVTAYDNBoNHXCqoYEV+Hh4XBxccHQoUOxdu1aHDt2DG+++aYlh3xNoaGhWLp0KYBLO2RagoeHB4qLi9GrVy906NDhpmbOERERWZpsoZizszM+/vhjvPPOOzh37hwAoFWrVnB2dpau6dy5s1zd15ORkYGpU6ciLy8ParUaCxYswL333ttk/RMRERFR85WdnY38/Hzp9ZV2WGyIJ554ApWVlXj44Ydx2223yTYrrKnY2dmhbdu20Ov1sLOzs+jjnkRERDdLtlCslrOzMzw9PaX/tha1Wo3ly5ejc+fOyMnJQbdu3TBy5Eg4OTlZbUxEREREZPuKi4ulQEytVsPFxQUuLi4Wabu5/hJXo9FYewhERETyrSlmNpuxZMkSuLm5ISwsDGFhYXB3d8dLL70Es9ksV7dXFRAQIM1M8/f3h7e3N4qKipp8HERERETUfJjNZmRkZAC4NDusQ4cOCA0NtfKoiIiI6EbIFoq98MILWLFiBZYuXYojR47gyJEjePXVV/H+++9jwYIFN93e7t27MXr0aAQGBkKhUGDjxo31rklISEB4eDjs7e3Rq1cv/PPPP1ds69ChQzCZTAgJCbnpcRARERFRy2UymVBRUQGTyYS9e/di586dEELAyckJXl5e1h4eERER3QTZHp/88ssv8cknn2DMmDHSsZiYGAQFBWHOnDl45ZVXbqq9iooKxMbGYsaMGZgwYUK98+vWrUN8fDxWrlyJXr16Yfny5Rg2bBiSk5Ph6+srXVdUVIQHH3wQH3/88TX7q6mpQU1NjfRap9MBuPTbQGvMdKvtWwhhtf6p4Vg728S62S7WznaxdrapJdUtPT0dOp0OH3/8Mdq3b4++ffsCuLQovS3ef0uqXXPD2tku1s42Nfe6Ndf7uh7ZQrGioiJER0fXOx4dHd2gxxZHjBiBESNGXPX822+/jVmzZmH69OkAgJUrV+KXX37BZ599hnnz5gG4FHSNGzcO8+bNu+5ON6+99hoWL15c73h+fj6qq6tvevyWYDabUVpaCiGEzS+y2tKwdraJdbNdrJ3tYu1sU0uoW3V1NWpqaqSfA3v16oXs7GzU1NTY9LIcLaF2zRVrZ7tYO9vU3OtWVlZm7SFYhWyhWGxsLFasWIH33nuvzvEVK1YgNjbWon3p9XocOnQI8+fPl44plUoMHjwY+/btAwAIIfDQQw9h0KBBmDp16nXbnD9/PuLj46XXOp0OISEh8PHxgaurq0XHf6PMZjMUCgV8fHya5YewOWPtbBPrZrtYO9vF2tmm5ly3yspKrFu3Dh06dIC9vT0UCgXCwsLQqVMnaw/NIppz7Zo71s52sXa2qbnXzd7e3tpDsArZQrE33ngDd911F7Zv344+ffoAAPbt24eMjAxs3rzZon0VFBTAZDLBz8+vznE/Pz+cPn0aALBnzx6sW7cOMTEx0npka9asueoPNFqtFlqttt5xpVJp1Q+AQqGw+hioYVg728S62S7WznaxdrbJ1uqWmpqK8PBwqFSqa16XmZmJr7/+Go899hhCQ0MRHBwMd3f3phlkE7G12tF/sXa2i7WzTc25bs3xnm6EbKHYgAEDcObMGSQkJEjB1IQJEzBnzhwEBgbK1e1V9evXr8U+I0tERERE//XPP/9gzpw5mDx5Mh544AEUFRUhMjISGo0GQgjk5eWhsrIS4eHhUKvVmDFjBu644w64urpCoVBYe/hERERkIbKFYgAQGBh40wvqN4S3tzdUKhVyc3PrHM/NzYW/v3+j2k5ISEBCQgJMJlOj2iEiIiKiW4OHhwe6d++O2NhY5OTkAABycnIQGhqKV199Fd999x2WLFmC4uJiqFQqdO7cGW5ublYeNREREVmaRUOxxMTEG742JibGYv1qNBp069YNO3bswLhx4wBcet53x44dmDt3bqPajouLQ1xcHHQ6HX8YIiIiIrIxQghUVVVBrVZDo9EgIyMDlZWVuOeee+Ds7AyDwQCNRoPS0lLk5uYiNzcXTk5OKCoqQkBAAOzt7REUFGTt2yAiIiIZWDQU69y5MxQKBYQQ17xOoVDc9Myr8vJypKSkSK/T0tJw9OhReHp6IjQ0FPHx8Zg2bRq6d++Onj17Yvny5aioqJB2oyQiIiKilsVkMuH06dMwGo0ALq2XUrucRvv27eHk5AQ3NzecPXsWlZWVyMnJwdSpU/HCCy/Az88PQgg+LklERNSMWTQUS0tLs2RzdRw8eBB33HGH9Lp2Z8hp06bhiy++wMSJE5Gfn4+FCxciJycHnTt3xtatW+stvk9EREREzVtSUhJSUlLQqlUrKdgSQkiBWOvWreHk5CRdHxoaiqKiIhQUFECj0cDT0xMAGIgRERE1cxYNxcLCwizZXB0DBw687gy0uXPnNvpxyf/FNcWIiIiIbMvhw4cRGxsLIQQ0Gg2ioqKgUqmQn58PtVpdJxADLu06HhAQgICAAFRVVcHOzs5KIyciIqKmZNE9N//+++8bvrayshInTpywZPeyiIuLw8mTJ3HgwAFrD4WIiIiIruPEiRN48803sXHjRnh6eiI6OhoqlQoA4OPjAw8Pj2u+38HBoSmGSURERLcAi4ZiU6dOxbBhw7B+/XpUVFRc8ZqTJ0/i+eefR2RkJA4dOmTJ7omIiIiohfvjjz+gUCgwYsQIhISE8BFIIiIiuiqLPj558uRJfPjhh3jxxRcxZcoUREVFITAwEPb29iguLsbp06dRXl6O8ePHY9u2bejUqZMluyciIiKyCLPZjOzsbLi7uwMAnJycGK5YWElJCfbv34/k5GQ4OztDo9Fg+PDh8Pb2bnCb+fn56NevH7p164aePXtacLRERETUHFk0FLOzs8Njjz2Gxx57DAcPHsRff/2FCxcuoKqqCrGxsXjyySdxxx13SIuX2gKuKUZERNRyCCFw4cIFlJaWwmQy4cMPP8Thw4fx5JNPQqPRYODAgdYeok3Kzc3Fa6+9hiNHjmDo0KGwt7fHHXfcgW+//RaDBg3C2rVr8dhjjyEjIwMFBQVo27btTYeQRqMRFy9eBAB06NBBjtsgIiKiZsaiodjlunfvju7du8vVfJOJi4tDXFwcdDod3NzcrD0cIiIiklFJSQlKS0sBAGfPnsWmTZvQo0cPnDp1Ct9++y0++OAD+Pr6ory8HFFRUVAqLboSRbOVm5uLnTt3AgDWrVuH7t27Izo6Go8++ihycnJw//33Q62+9GOpXq9HQUEBFi9ejMGDByM0NBRRUVFwdna+Zh+pqakQQsDFxQUuLi6y3xMRERHZPtlCMSIiIiJbYjKZkJGRAQCIiIhATEwMjEYjxowZg6SkJHz++edYsmQJFi1aBKVSiaqqqnq7GFJder0eJSUlMJvN+PDDD2FnZ4fnn38e7dq1w7Bhw6QgrNbFixeRl5eH5ORklJaWIiIiArm5uXjrrbfwyiuvQK1Ww8/Pr87ukEIIJCcno6ysDEIIdOzYsalvk4iIiGwUQzEiIiIiABcuXIAQAk5OTnB1dQUA3H///QCAPn36YNCgQWjTpg2EEAAuBT4MxS6pqanB3r17UV5ejgceeABKpRK5ubnIyckBACgUCvj6+qJNmzbYvn37VdtRKpX49NNPMXHiRMTFxSEoKAj79u2DVqtFQUEB7OzsUFhYiKioKDg4OKCoqAjjx4+HnZ0dZsyYgTZt2kg7TRIRERFdD0MxIiIiavHKy8tRVlYGAAgPD7/iNW+//Tby8vKQlZWFmpoalJSU4J133kFkZCQmTZoErVbbhCO2vpqaGumet23bhj179uC3335Dt27doNFoUFFRAYVCAa1WCy8vL3h5eV23TW9vb6SkpCA7OxuOjo7o3bs3HnnkEQQHB6OmpkaaIVZQUIDy8nJ89NFHKC4uhlKpxLFjxzBlyhRZ75mIiIiaF4Zi18GF9omIiJong8GA7OxsVFZWwmAwAAACAgLqPdJ3OV9fX/j6+uKJJ57AyZMnpZlQGzZswIYNG1rMDpUpKSl49NFHMWPGDFRVVeHHH39Eq1atAABfffUVBg4cCG9vb/j7+yMoKOiG21WpVPj222/h5uYmzcgDgLvuugvFxcXw8PBAYmIiioqKUFZWhqSkJMTExOCTTz6Bvb29xe+TiIiImjeuDnsdcXFxOHnyJA4cOGDtoRAREZEFpaWloaSkBHq9HkIIODo6wtfX97rvE0LA09NTCsQcHR0RGBiI06dPyz3kW0JJSQnS09Oh0+mwe/duGAwGXLx4EcOHD4eDgwM2b96MhIQE5Ofn31QgVqt2Y6PLA0aFQgFPT0/pMUyNRgMfHx+sXbsWK1asYCBGREREDSLrTLEdO3Zgx44dyMvLg9lsrnPus88+k7NrIiIioisqKytDRkYGDAYDVCoVvLy8UF5ejtatW9/Q+xUKBRYuXIjIyEikp6dj7NixqKmpQVVVFfLy8m4oWLueN998E1qtFj169ECPHj2aZJ0sIQSMRiNUKlWdXTXz8/ORl5cHk8kkzd7y8vJCfHw8Xn31VcTGxmLdunWws7ODk5MTqqqq0K1bNwwfPlyWcQYEBCAgIECWtomIiKhlkS0UW7x4MZYsWYLu3bsjICCgxTxOQERERLcug8GA8+fPS7+sq30csiFqF+EHgN9//x0KhQJPPfUUnnzySXTt2rXBYzSbzTh8+DBmzpwJBwcHJCUlwc7ODgqFAkqlEj4+PvD09Gxw+1dSWVmJlJQUCCHg5uaG8PBwFBcXo7CwEBUVFXWuVSqVcHNzw913342+ffvC398fZrMZeXl5ePrpp7F7924888wzFh0fERERkRxkC8VWrlyJL774AlOnTpWrCyIiIqIbVlFRgZSUFACAvb09QkJC4ODgYJG277jjDhw4cABJSUl4/PHHsXHjxmsuLJ+YmIi2bdvWW5xfCIHc3Fw8++yzMBgMMJvNUCqV0ppnAJCRkQGdToewsDAIIaBQKBr1y0ez2SztvJmfn49nn30WcXFxCAsLk67x9/eHu7s7lEqltNh97fHLDR8+HCNHjmzwWIiIiIiakmyhmF6vx2233SZX80REREQ3zGg0IjU1FQDg4OCA1q1b13lE0BJ69OiBwYMH49dff8XDDz+MdevWXXFHyuzsbFRXVyMpKQk+Pj4wGo0ICwuDSqXCmTNnUF1dDYVCgQ4dOsDR0RFmsxmZmZlwcHCAXq9HQUEBSktLcfHiRej1euzZswcODg7w8PDA7bffDrVaDbPZfENhmV6vR1ZWFvR6PVQqlRSMHTlyRArFvL294evry1n/RERE1OzIttD+zJkz8c0338jVfJNJSEhA+/bt0aNHD2sPhYiIyOaZzWbk5+fL1r7BYEBVVVW9Y9u3b4cQAg4ODoiKirJ4IFbrtddeg7e3N86dO4cPP/yw3vn77rsPDzzwAHbt2gWVSoX9+/dj7ty5+P3333H48GEpEAsICICjoyOAS48rhoaGwsfHB0FBQYiMjARwacH70tJS7Ny5E3Z2dvD09MSJEydw7NgxJCUlITU1FRcvXkRGRgZqamrqjEMIgby8PJw6dQo6nQ4AEBUVhSFDhmDp0qU4deoUsrKypD4ZiBEREVFzJNtMserqaqxatQrbt29HTExMnan2APD222/L1bVFxcXFIS4uDjqdTtoNiYiIiG5eXl4eLl68CABQqVTSulhVVVXQ6XSoqqqCs7MzhBAwmUw3HVxlZmaisLAQAGBnZ4dWrVpBo9FgyZIluPPOO5GRkSH7o31qtRpvvPEGZsyYgaKiojrnLl68KO1QuWXLFjzyyCPIycnB4MGD4eHhIS2mHxUVdc3dFJ2dneHo6IjKykoAl34RWVlZCaPRCLX60o92QghUVFRI64EVFRXBy8sLrq6ucHR0xPnz56Vzjo6O8PHxgUajAQAMHToUQ4cOteBXhYiIiOjWJFsolpiYiM6dOwMAkpKS6pzjbxuJiIhaBr1eLz22qNfrpeOZmZkwmUwoKytDWVmZdLy0tBTApQDN398ffn5+V227dr2toqIiZGdnw2QySecMBgPOnj0LZ2dn7Nu3DyUlJXjrrbdkmyF2uW7dusHf3x+HDx+W1vwCgE8++QTApdlkXbt2hYuLC4YPH47hw4cjOzsbBQUFaNWq1TUDsVp+fn7Iy8uDWq1G+/bt6/zysby8HABw7tw5aLVaCCFQU1ODwsJCKTSsFRYWBnd3dwvdOREREZFtkSUUM5lMWLx4MTp16gQPDw85uiAiIiIbkJGRUScMCwoKQklJCSoqKpCdnS0dt7e3h1qtRnV1NYxGo/RePz8/CCFQXFyMrKwstG7dGg4ODqiurkZycnK9/kJDQ+Hq6oqUlBRUV1dDp9Nh4cKFiI2NlWZCyU2hUCAkJAQHDhzAgQMH0LNnT5jNZvz5558IDg7GyJEj6/2CMDAwEP7+/jcc2rm6usLV1fWK55ydnQEAnTp1kvopLCxEXl4ejEajtPNmZGSkdC0RERFRSyRLKKZSqTB06FCcOnWKoRgREVELYjabUVZWBqPRiNzcXBgMBiiVSri5ucHf3x8ajQbu7u44deoUzGYz3N3d4enpCRcXF+n9eXl52LhxI1atWoXPP/8cTk5OKC8vx2uvvYaYmBj06tULgYGBUp8KhQLe3t4ICAiQQqCoqCicOXMGNTU18PHxafIlENq3b48DBw5g9+7d6N69O4QQeOWVV6DX6686Y97Ss9gu78fLy0vaDdNgMKC0tJSBGBEREbV4sj0+2bFjR5w7dw4RERFydUFERES3CKPRiOLi4jqzv4D/zpq6/BE9tVqNyMhI6PX6qz6616tXL3z00Uc4fPgwunbtCiEEbr/9dsTExMDNzQ0Gg0F6dPBKIZNCoUDbtm0hhLDkbd6wmTNnYvXq1di1axc2bdqENWvWQKPRSDs6WpOdnR28vb2tPQwiIiIiq5MtFHv55Zfx9NNP46WXXkK3bt3g5ORU5/zVpvwTERGR7TAYDCgoKEBeXp50TK1WQ6FQwMnJCSEhIVecAeXo6CjtrnglsbGxmDdvHqKjoyGEQEREBLp06QKdTof09HS4uLggMDDwuuuUWmsdUzc3N0RFRSE5ORlt2rTBiRMnEBgYCAcHB6uMh4iIiIjqky0Uq93dacyYMXV+IK1dcPbyxXBvZQkJCUhISLCZ8RIRETWlc+fOobq6GgCkRyP9/f0tEkb17NkTSUlJ6Nu3rzSjzNXVFR07dmx0202h9mswadIk6XHPG1lEn4iIiIiahmyh2O+//y5X000qLi4OcXFx0Ol0Tb4eCRERUWNdvvuhpRkMBlRXV0OpVCI0NNTif09GRETY9DIML730En755RfcdtttKCgoAMAduImIiIhuJbKFYgMGDJCraSIiItkYjUYolUqLL3p+LZWVlaisrISnpyeqqqpgNpvh4uICIQSMRiMKCwvh6ekJjUaDqqoqFBcXw9PTE1qt9pohS05ODnJzc6HVahEeHt6oWUqXh2u1j0yWlpYCADw9PfmLoyto27Yt2rZtCwDw9/dHTU0N1GrZfvQiIiIiopsk209mu3fvvub5/v37y9U1ERHRTTMajTh37hyqqqqg0WgQGRkJjUZzxWsbMvvq8uUDLl68CHt7e9TU1MDJyQmZmZkwmUzIysqSrlcqlTCbzdLr3NxcaDQa6PV6AEB+fr40hoCAAPj4+ODChQvQarUQQsBkMqGwsBAAUFNTg+TkZLi4uCA8PPymAz+DwYBTp05dcdF6lUqFgICAm2qvJVKpVNdcQ42IiIiImp5sodjAgQPrHbv8HxBco4uIiJpaeXk5MjIyEB4eLi14bjabkZ2djeLiYimE0uv1OHXqFBwdHREZGQmlUomKigqUl5ejsLAQRqMRWq0WPj4+8PT0vGafFRUVSEtLu+rfe7WP1alUqjrX1I5FoVBApVLBaDRKgVhtOFYbUmVnZ6O0tBQVFRX12vf29kZFRQWqqqpQVlaGlJQUeHt7w8PD44aCPaPRiLNnz9YLxGrDt7CwsCadVUdEREREZCmyhWLFxcV1XhsMBhw5cgQLFizAK6+8Ile3REREV5WZmQm9Xo8zZ84gOjoaGo0GZ8+elRaKV6lUiIqKQnp6OioqKlBZWYnjx4/Xm7UFANXV1cjMzKwXLgkhYDabcfbsWRgMhnrvAy7tzqhSqaBUKmEymaBSqRARESE9WqdQKFBYWAitVgtnZ2epv4qKCjg4OMDR0bHObLCcnBwpEHNwcIBCoYDZbIa3tze8vLyk9ycnJ6OqqgoZGRkoLi5Gq1atrjj2vLw8aS3N3NxcaczR0dFQKpUQQjAIIyIiIiKbJ1sodqW1RYYMGQKNRoP4+HgcOnRIrq6JiIjqKCsrw/nz52E2m6FUKvHHH3/gzTffxNNPPw3gUggVFhYGV1dXKBQKtG7dGgaDASkpKdDr9dL7tFotHBwcEBgYiPT0dOh0Opw/fx4qlQrl5eUIDg7Gpk2bUFlZiZ49e0r9+/n5wd/fH8ClWWhqtfq6oVJtmFXL3t6+zppgCoUCarUafn5+KC0thUqlQlBQ0FXXDbO3t0ebNm1QXFyMgoIClJeXIy0tDU5OTvDx8UFOTg7y8/PrvKc2LNRqtWjVqhVUKpXUNxERERGRrWvy1V79/PyQnJzc1N0SEVELIYRATU0NjEYjAEhrddXO2PL394dOp8Pw4cOl90RFRdULk+zs7NCuXTtp4XtHR8c6YVBgYCB0Oh10Op10LC0tDbm5uUhNTYW/vz+6dOkCX1/fOmuTXW2dssaIioq6oescHR3h6OgId3d3pKSkoKysDGVlZcjJyZGuqX1c08XFBTU1NXBxcZECPSIiIiKi5kS2UCwxMbHOayEELl68iKVLl6Jz585ydUtERC2Y2WxGcnKytPZWeXk5ampqAFwKuWof/3vhhRdw7NgxnD9/HkOGDLnmroy1a4/9L61Wi5CQEGRkZEClUkGr1aKyshIDBgzA+PHjERERYfkbtBBHR0f4+/tDr9ejvLwcer0eSqUSwcHB8PDwsPbwiIiIiIiahGyhWOfOnaFQKOotzNu7d2989tlncnVrcQkJCUhISODGAEREtyghhLSe1vnz5+t8v64NxLRabb1dF2NjYxEbG9uovj09PaVZVQqFAtnZ2SgpKUFQUFCj2pWbQqGAn5+f9NpkMkGpVPKxSCIiIiJqUWQLxdLS0uq8ViqV8PHxueZv429FcXFxiIuLkxYcJiKiW4fJZMKZM2ekmWHApb9voqKikJWVBQcHB3h4eMj6d8/lfzcEBQXd8oHYldSuFUZERERE1JLItnXUrl274O/vj7CwMISFhSEkJAT29vbQ6/VYvXq1XN0SEVELcu7cuTqBmLu7Ozp27Ag7Ozs4OjrCz8/P5n4ZQ0RERERETUO2UGz69OkoLS2td7ysrAzTp0+Xq1siImoBzGYzUlNTUVlZCZVKhejoaPj6+iIsLIyPABIRERER0Q2R7fFJIcQV/2GSmZnJxxCJiKjBzGYzTp06Je0u6efnB61Wi4CAACuPjIiIiIiIbInFQ7EuXbpAoVBAoVDgzjvvhFr93y5MJhPS0tIwfPhwS3dLRETNXO0vW9LT02E0GqFSqdCmTRtotVprD42IiIiIiGyQxUOxcePGAQCOHj2KYcOGwdnZWTqn0WgQHh6Ou+++29LdEhFRM2YymZCcnAyDwQDg0mL67dq14wLxRERERETUYBYPxRYtWgQACA8Px8SJE7nAMRERNVpeXp4UiKnVavj5+TEQIyIiIiKiRpFtTbFp06ahpKQEX331FVJTU/HMM8/A09MThw8fhp+fn01uWU9ERE2rpKQEeXl5qKqqAgC0b98ednZ2Vh4VERERERE1B7KFYomJiRg8eDDc3Nxw/vx5zJo1C56envjhhx+Qnp6O1atXy9U1ERHdIkwmE4xGI6qrq6FQKGA0GuHp6XlD7y0pKcGFCxek1wEBAQzEiIiIiIjIYmQLxZ588kk89NBDeOONN+Di4iIdHzlyJKZMmSJXt0REZGVCCAghkJmZieLi4nrnFQoFPDw8rtlGZmYmCgsLAQAeHh7w9/eHRqORZbxERERERNQyyRaKHTx4EKtWrap3PCgoCDk5OXJ1S0RETSQ7OxvFxcVQq9UIDQ2FWq1GRUUF0tPTIYSQrlMqlVAqlVAoFDAYDEhPT4ejo+MVd42sqqrCuXPnYDQaAQDe3t583J6IiIiIiGQhWyim1Wqh0+nqHT9z5gx8fHzk6paIiGSUk5ODkpIS2NnZoby8HABgNBpx5syZetfa2dkhODgYrq6u0rH09HQUFxcjJycHISEhyMnJgYuLCxQKBTIzM6HX66VALSwsDO7u7k1yX0RERERE1PLIFoqNGTMGS5Yswf/93/8BuPS4THp6Op577jncfffdcnVrcQkJCUhISIDJZLL2UIiImkxNTQ2AS8FWQUEBTCYTiouLpR0ga88HBASgtLQU1dXVMJvNAK49uysoKAjFxcUoKSlBSUkJACA/P7/ONY6OjoiMjIRSqZTj1oiIiIiIiADIGIq99dZbuOeee+Dr64uqqioMGDAAOTk56N27N1555RW5urW4uLg4xMXFQafTwc3NzdrDISKSldFoxLlz56TdHu3s7KQgDLj0Cw5fX18Alx6L9Pb2ll5fuHABTk5O8Pb2vmr7KpUKwcHByM/Pl4I1lUoFs9kMDw8PuLq6wsXFhYEYERERERHJTrZQzM3NDb/99hv++usvJCYmory8HF27dsXgwYPl6pKIiBpBCIGUlBQprAIgBWJOTk7QaDTX3AEyLCzshvrx8vKCl5cXdDod1Go1HB0dGz94IiIiIiKimyRbKFarX79+6Nevn/T68OHDWLhwIX7++We5uyYiohskhEBOTg5qamqgVCoRHR2N/Px8qFQq+Pj4yDJz6/K1xoiIiIiIiJqaLKHYr7/+it9++w0ajQYzZ85Eq1atcPr0acybNw+bNm3CsGHD5OiWiIgaICsrCwUFBdLr8PBw2NnZITAw0IqjIiIiIiIikpfFQ7FPP/0Us2bNgqenJ4qLi/HJJ5/g7bffxqOPPoqJEyciKSkJ7dq1s3S3RER0k6qqqpCeno7q6mrpWEhICFxcXKw4KiIiIiIioqZh8VDs3Xffxeuvv45nnnkG33//Pe6991588MEHOH78OIKDgy3dHRERNUBeXh4uXrwovQ4ODoaHhwcXuCciIiIiohbD4qFYamoq7r33XgDAhAkToFarsWzZMgZiRES3iNLSUikQc3Z2RkhICDQajZVHRURERERE1LQsHopVVVVJO4kpFApotVoEBARYuhsiImqA6upqnD9/HgDg4+PDdcOIiIiIiKjFkmWh/U8++QTOzs4AAKPRiC+++ALe3t51rnnsscfk6JqIiK6ipKQE6enpAC7t/MhAjIiIiIiIWjKLh2KhoaH4+OOPpdf+/v5Ys2ZNnWsUCgVDMSKiJpSRkYGioiIAgEajQUREhJVHREREREREZF0WD8VqH8shIqJbQ15enhSI+fn5wc/Pz8ojIiIiIiIisj5ZHp8kIqJbQ0FBgbSoflhYGNzd3a07ICIiIiIiolsEQzEiomYqNTUV5eXlAC7NEGMgRkRERERE9F8MxYiImhmTyYSzZ8+ipqYGABAQEABfX18rj4qIiIiIiOjWwlCMiKgZyczMRGFhofS6devWcHJysuKIiIiIiIiIbk1Kaw+gKY0fPx4eHh645557rD0UIiKLqaqqQkpKCk6ePCkFYlqtFtHR0QzEiIiIiIiIrkLWUCw1NRUvvvgiJk+ejLy8PADAli1bcOLECTm7varHH38cq1evtkrfRESWVlBQgOPHj+PMmTOoqKiAwWAAAISHhyM6OhpardbKIyQiIiIiIrp1yRaK7dq1C506dcL+/fvxww8/SIs9Hzt2DIsWLZKr22saOHAgXFxcrNI3EVFDVFVVIS0tDcXFxXWOp6enIysrC2azGQDg4uICX19fREdHw83NzRpDJSIiIiIisimyhWLz5s3Dyy+/jN9++w0ajUY6PmjQIPz999833d7u3bsxevRoBAYGQqFQYOPGjfWuSUhIQHh4OOzt7dGrVy/8888/jbkFIiKry87Ohk6nQ3p6Ok6fPo20tDScPHlSCsmCgoIQGxuLVq1aISAggLPDiIiIiIiIbpBsodjx48cxfvz4esd9fX1RUFBw0+1VVFQgNjYWCQkJVzy/bt06xMfHY9GiRTh8+DBiY2MxbNgw6bFNIqJbhdlshl6vhxDiiucqKyuRk5OD48ePo7y8HCqVCgqFAjU1NdDpdNJjkpGRkfD29m7q4RMRERERETULsu0+6e7ujosXLyIiIqLO8SNHjiAoKOim2xsxYgRGjBhx1fNvv/02Zs2ahenTpwMAVq5ciV9++QWfffYZ5s2bd9P91dTUoKamRnqt0+kAXPoHa+3jSk3NbDZDCGG1/qnhWDvbZOm6VVdXw97eHhkZGSgpKQEAREREwNnZGWazGenp6SgrK6v3Pm9vb7i6uiI/Px9msxkODg5wd3eHRqPh/1NXwc+c7WLtbBPrZrtYO9vF2tku1s42Nfe6Ndf7uh7ZQrFJkybhueeew/r166FQKGA2m7Fnzx48/fTTePDBBy3al16vx6FDhzB//nzpmFKpxODBg7Fv374Gtfnaa69h8eLF9Y7n5+ejurq6wWNtDLPZjNLSUgghoFS2qI1DbR5rZ5ssWbfS0lJUV1dDpVLBZDJJx9PS0gAACoWizswxpVIJJycnODg4ALgUzF/+aGRtqEZXxs+c7WLtbBPrZrtYO9vF2tku1s42Nfe6XemX8y2BbKHYq6++iri4OISEhMBkMqF9+/YwmUyYMmUKXnzxRYv2VVBQAJPJBD8/vzrH/fz8cPr0aen14MGDcezYMVRUVCA4OBjr169Hnz59rtjm/PnzER8fL73W6XQICQmBj48PXF1dLTr+G2U2m6FQKODj49MsP4TNGWtnmyxVt927d8PDwwMApEAsMDAQFRUVKC0tBQApEGvbtm2ddRipYfiZs12snW1i3WwXa2e7WDvbxdrZpuZeN3t7e2sPwSpkC8U0Gg0+/vhjLFiwAElJSSgvL0eXLl3Qpk0bubq8ru3bt9/wtVqt9ooLViuVSqt+ABQKhdXHQA3D2tmmxtbt4MGD8PDwQHV1NVq3bo2cnByEhITA1dUVPj4+EEKgrKwMer0ebm5usLOzs/AdtFz8zNku1s42sW62i7WzXayd7WLtbFNzrltzvKcbIVso9tdff6Ffv34IDQ1FaGioXN0AuLTejkqlQm5ubp3jubm58Pf3b1TbCQkJSEhIqPO4ExHRleTn56OiogIKhQI6nQ4rVqzA/v370bdvXzz99NPw8vKCl5dXnfcoFAqrzT4lIiIiIiJqyWSLAgcNGoSIiAg8//zzOHnypFzdALg0K61bt27YsWOHdMxsNmPHjh1XfTzyRsXFxeHkyZM4cOBAY4dJRM1cbm4uSktLUVJSArPZjLS0NGi1Wggh6m06QkRERERERNYl20yx7OxsrF27Ft9++y2WLl2KmJgY3H///Zg8eTKCg4Nvur3y8nKkpKRIr9PS0nD06FF4enoiNDQU8fHxmDZtGrp3746ePXti+fLlqKiokHajJCKS08GDB2FnZwe1Wg2tVgtPT09s2LABTk5OdRbQJyIiIiIioluDbDPFvL29MXfuXOzZswepqam499578eWXXyI8PByDBg266fYOHjyILl26oEuXLgCA+Ph4dOnSBQsXLgQATJw4EW+++SYWLlyIzp074+jRo9i6dWu9xfeJiCypNvA6deoUTCYTnJ2d0bp1a3h6esLJyQnApUckiYiIiIiI6NYi20yxy0VERGDevHmIjY3FggULsGvXrptuY+DAgdedbTF37lzMnTu3ocO8Iq4pRkRXU1RUhKysLKSmpmLZsmW47777LL67LhEREREREclD9u0F9uzZgzlz5iAgIABTpkxBx44d8csvv8jdrcVwTTEiupLU1FRkZGTAbDYjMTERADBmzBgrj4qIiIiIiIhulGwzxebPn4+1a9ciOzsbQ4YMwbvvvouxY8fC0dFRri6JiJpERkYGCgoKoNVq4ePjg4ULF+KBBx7gYvpEREREREQ2RLZQbPfu3XjmmWdw3333wdvbW65uiIiaRGVlJXQ6HcxmM1atWoXIyEi0bdsWQUFBAIBWrVpZeYRERERERER0M2QLxfbs2SNX002Ka4oRtVxCCJhMJlRWViI1NRUAkJubi02bNqF9+/aYNm2alUdIREREREREDWXRUOynn37CiBEjYGdnh59++uma19rK2jtxcXGIi4uDTqeDm5ubtYdDRDISQqCmpgb29vbIzs5GQUEBhBAoKCgAAGi1WoSEhODxxx9H+/btuaskERERERGRDbNoKDZu3Djk5OTA19cX48aNu+p1CoWCM6+I6JaTmZmJoqIiKBSKOrvdKhQKKBQKtG3bFgqFAu3atbPiKImIiIiIiMgSLBqKmc3mK/43EdGtwmw2o6amBg4ODnWO5+XloaioCACkQMzHxweVlZXSemGcGUZERERERNR8KOVqePXq1aipqal3XK/XY/Xq1XJ1S0R0VUIIvPLKK5gyZQpOnTqF48eP48SJE7hw4QLy8/MBABEREejQoQOio6Ph7+8PZ2dnAIBSKdu3SyIiIiIiIrIC2f6VN336dJSWltY7XlZWhunTp8vVrcUlJCSgffv26NGjh7WHQkSNVDsDbMKECdDr9TCbzTAajSgpKYHRaIRGo4GrqyvUajW0Wq2VR0tERERERERyki0UE0Jc8VGjzMxMm1qwPi4uDidPnsSBAwesPRQiukGXrwd2uerqaowZMwYuLi44d+4coqKi4OfnB+DSo5ERERFNOUwiIiIiIiKyIouuKQYAXbp0kRalvvPOO6FW/7cLk8mEtLQ0DB8+3NLdEhEBAKZNm4YJEybAzs4Ow4cPR3Z2NrRaLXJzc6UNPu644w64urpCoVDAwcEBNTU18PT0hL29vZVHT0RERERERE3F4qFY7a6TR48exbBhw6T1eABAo9EgPDwcd999t6W7JaJmzGg04sSJE3B3d0dYWBgAoKSkBO7u7nWuq6ysRHl5Odzc3ODh4YGkpKR6s8aUSiXs7e3rzGStbZOIiIiIiIhaDouHYosWLQIAhIeHY+LEiZx5QUSNkpmZiRkzZmDZsmUoKSlBaWkp/vzzT3z55ZdYs2YNAOD8+fMIDw9HWVkZFi5ciKCgIFy8eBFmsxlKpRJmsxk+Pj4ICAjgDpJEREREREQEQMY1xaZNm8ZAjIgaLTExEWVlZdi1axeAS+uF+fr6IigoCD/88ANmzJiBwsJCPProo6iurkZBQQG8vLzQsWNHBAUFoV27doiKikJgYCADMSIiIiIiIpJYfKZYLZPJhHfeeQf/93//h/T0dOj1+jrni4qK5OraohISEpCQkCCtRURETUcIgVdffRVVVVW4//774enpidLSUmlx/C1btqCsrAzZ2dno1q0bzp07h06dOknhl7e3NwDUWduQiIiIiIiICJAxFFu8eDE++eQTPPXUU3jxxRfxwgsv4Pz589i4cSMWLlwoV7cWFxcXh7i4OOh0OpvaNZPIlr333ntwcnLC6dOnodPpEBoaCi8vLwCQ1hEbPHgwHBwc0LNnT8yePZuzwIiIiIiIiOimyPb45Ndff42PP/4YTz31FNRqNSZPnoxPPvkECxcuxN9//y1Xt0Rk46qqqrB69Wp4e3vjr7/+gq+vLz799NN613l4eGDUqFF45JFHGIgRERERERHRTZNtplhOTg46deoEAHB2dkZpaSkAYNSoUViwYIFc3RKRDTObzVi+fDn0ej3Onz+PFStWQAghPS5JREREREREZCmyhWLBwcG4ePEiQkNDERkZiW3btqFr1644cOAAtFqtXN0SkQ3Ky8vD0aNH4efnh7KyMoSHh2PWrFlwdHS09tCIiIiIiIiomZLt8cnx48djx44dAIBHH30UCxYsQJs2bfDggw9ixowZcnVLRDZECIGUlBR88cUX8PPzgxAC06ZNw9q1axmIERERERERkaxkmym2dOlS6b8nTpyI0NBQ7Nu3D23atMHo0aPl6paIbjE1NTWoqKiAp6dnneOJiYlYvXo1fHx88PPPP8PFxQUPP/wwNBqNlUZKRERERERELYlsodj/6tOnD/r06dNU3VlMQkICEhISYDKZrD0UIpuRl5eHH3/8Ebt378aTTz6JI0eOwNHREXq9Hg888ABUKhWUSiVOnDiBWbNm4f7778fMmTOhVjfZtyQiIiIiIiJq4Sz6L9Cffvrphq8dM2aMJbuWTVxcHOLi4qDT6eDm5mbt4RDdssxmMzIyMvDtt9/im2++AQDMnTsXKpUKf/zxB8aMGYNvvvkGhYWFCA4ORkhICJYsWYLu3btz90giIiIiIiJqchYNxcaNG3dD1ykUCs68ImpGzGYz0tLSsH//fqxbtw4qlQpeXl7w9vaGTqfD/PnzYTQa0bNnT0RHR2PFihWYM2cOFAoFAzEiIiIiIiKyCouGYmaz2ZLNEdEtymAwQKlUYs+ePXBzc4NCoYAQAv7+/oiMjMSCBQsQGxtb730xMTHIyspCv379EBAQgK5du1ph9ERERERERERNuKYYEdkug8GAvLw8eHt7o7y8HHl5edDr9Vi2bBmefvppuLu7Q61Wo3fv3rjjjjuuOfsrKCgIzz//fBOOnoiIiIiIiKg+2UKxJUuWXPP8woUL5eqaiCyopKQE999/Pzp06IBJkyZBpVIBAIQQGDt2LEpKSlBeXo677rrLyiMlIiIiIiIiunGyhWIbNmyo89pgMCAtLQ1qtRqRkZEMxYhsxPPPP4+MjAyEh4cjPz8fAQEBEEIgLCwMISEh8PLysvYQiYiIiIiIiG6abKHYkSNH6h3T6XR46KGHMH78eLm6JSILOnXqFP7++294e3vjrbfegr29PQCgpqYGWq3WyqMjIiIiIiIiargmXVPM1dUVixcvxujRozF16tSm7JqILqPX65GSkoKgoCA4OzvDZDJBr9fD2dkZ8fHxuHjxIqKjoxEaGgo3NzcsXLhQCsQAMBAjIiIiIiIim9fkC+2XlpaitLS0qbttsISEBCQkJMBkMll7KEQW8+KLL8JsNmPKlCnSGmEA4ODggD179qCqqgqFhYXo27cvnnrqKQwcONB6gyUiIiIiIiKSgWyh2HvvvVfntRACFy9exJo1azBixAi5urW4uLg4xMXFQafTwc3NzdrDIWqw2t0jv/rqK2zduhVdu3ZFVVUVnJ2dpWuqqqrwwQcfoLCwEBs2bIAQAqNGjbLiqImIiIiIiIjkIVso9s4779R5rVQq4ePjg2nTpmH+/PlydUtElxFCAADS09MxevToOucGDRqE2267DSaTCWq1GhUVFUhJSYGdnR3uvPNODB061BpDJiIiIiIiImoSsoViaWlpcjVNRDfAaDTi8ccfR8+ePREeHo4+ffrgyJEjsLe3xxNPPIEJEyYAANTqS98GnJyc0KZNG5jN5jqPVBIRERERERE1R02+phgRya+srAznzp1DUVERQkNDodVq8eqrr8LLy+ua73N0dGyiERIRERERERFZl2yhWHV1Nd5//338/vvvyMvLg9lsrnP+8OHDcnVN1KJVVFTg3LlzAIDFixfD29sbNTU11w3EiIiIiIiIiFoS2UKxhx9+GNu2bcM999yDnj17QqFQyNUVUYthNpuhUCigUChgNBqRmZkJX19f6HQ62NnZIS8vD3q9HgDg7u6OsLAwK4+YiIiIiIiI6NYkWyj2888/Y/Pmzejbt69cXRC1KNXV1fjtt9+gVCoxbNgwnD17Fi+//DLi4+OldcFqubm5MRAjIiIiIiIiugalXA0HBQXBxcVFruaJWhSTyYRJkybBZDIhODgYJ06cwMWLFxEZGYm8vDwYjUYAgI+PD9q1a4fw8HDrDpiIiIiIiIjoFidbKPbWW2/hueeew4ULF+TqgqjF2LVrF86dO4d3330XWq0WCoUC3t7emDFjBkaMGIFu3bqhU6dOCAwMhEajsfZwiYiIiIiIiG55sj0+2b17d1RXV6NVq1ZwdHSEnZ1dnfNFRUVydU3UrBgMBrz33nvQaDRYtWoV2rRpAwAQQtRZq0+plC3jJiIiIiIiImp2ZAvFJk+ejKysLLz66qvw8/PjQvtEDZCXl4e8vDw8+eSTKCoqkgIxAPxMERERERERETWCbKHY3r17sW/fPsTGxsrVhU368ssvERwcjDvvvLNR7XTr1g3Lli3DoEGDLDQy6/jXv/4FX19fvPzyy/XOff/99/jwww+xfft2K4zMuoQQiI+PR2BgIIYOHQpPT0/069fP2sMiIiIiIiIiajZke94qOjoaVVVVcjXfZBISEtC+fXv06NGj0W3t3bsX69atQ0RERL1zs2fPRqdOnaBWq/H8889ft61Dhw5ZPRDr1q0bNmzY0Kg2jh8/js6dO1/x3N13393gQKy6uhqTJk1C27ZtoVQqsWrVqnrXrFy5EtHR0XB3d8ewYcPqrH934sQJTJw4ESEhIXB1dUXv3r1x+PBh6fwjjzwCZ2fnOn8UCgWeeOKJBo33f23evBk7duzAwYMHkZGRAT8/P6hUKou0TUREREREREQyhmJLly7FU089hT/++AOFhYXQ6XR1/tiKuLg4nDx5EgcOHGhwG3q9HiNGjED//v3x+++/Y8CAARgyZAgqKysBXFoz6rbbbsPXX38NT09PdOvWzVLDl43BYEBSUhJiYmIa3IYQAidOnJBlNmFFRQXGjh2Lb7/9FgqFot7X9J133sHy5cvx3XffoaCgAK1atcLMmTOl82lpabj77rtx7NgxFBYWonPnzrjvvvuk8ytXrkR5ebn054MPPoCXlxcWLFhgkfErFAoEBATg1VdfxahRo+Dr62uRdomIiIiIiIjoEtlCseHDh2Pfvn2488474evrCw8PD3h4eMDd3R0eHh5ydXtLWrVqFc6dO4f09HRMnjwZycnJeOSRR+Do6AgAsLOzw7Rp0+Dj44P8/PzrhmIbNmxAly5dpNcdO3bE0qVLMXDgQLi4uKBr165IT08HANx///146qmn6rz/2WefxQMPPADgUmD38ssvIyoqCu7u7hg5ciRycnKka7/44gu0b98erq6u8PX1xcKFC5GdnQ1XV1cYDAbExsbC2dkZx44dgxACH374ITp06AA3Nzf069cPycnJUltFRUWYOnUqXF1dERUVhbVr18JsNiMyMvKK9xkbG4sff/wRAPDdd9+hW7duWLx4MUJDQ+Hm5obXXnvtql8jLy8vTJ48GTU1NVCr1ejYsSOqq6sBACaTCa+88gree+89dOzYEWq1GpMnT8bu3bthMpkAAKNGjcJ9990HT09P2NnZYeTIkUhLS5POX664uBjPPPMMXn/9dXh5eV11TEII/P3333j55ZdhNpvrnS8rK4Ner0d2djZCQkKwfPnyq35tiIiIiIiIiKhxZFtT7Pfff5eraZuTmpqKvn37wtXVFW5ubnB0dMTdd99d77pDhw7B09MT4eHh12zv6NGj6Nq1KwCgqqoKp0+fxh9//IE1a9bAz88PI0eOxKpVq/Dyyy8jJiamTi3S09Px8ccf49ixYwCAqVOnQqfT4Y8//oCnpyf+9a9/4ZlnnsGaNWuwf/9+LF68GNu2bUObNm2Ql5eHrKwsBAYG4pNPPsGHH36Iv/76S2r7ueeew44dO7Bhwwa0atUKCxcuxMyZM/Hnn3/CaDRi2LBh6NOnD3Jzc5GXl4f+/fujU6dOV9w1saamBidPnpTu88iRIzh9+jSeeuopnDt3Drt27cKwYcMQHx8PrVZ71a/VwYMHERUVheTkZAgh0KFDB+Tk5KCwsBCtW7eGyWSCSqVCcnIyjEbjFRevN5lMeP/99zF69OgrPsI4f/58tGnTBjNmzLjiGGqDuZycHPz444/YsmUL7rjjDvTt21e65uzZs9LMwVr29vZXvS8iIiIiIiIiahzZQrEBAwbI1bTNmTp1KoYNG4YTJ04gJCQEJ0+eRPv27etdd/jwYSkEupYjR45g+PDhAC6tyaVUKvHVV1/B29sbAOrMLoqJicGKFSuk1y+88AJmz56N0NBQ7Ny5E7/99hsuXLgAFxcXAMCsWbPw8MMPAwBSUlKgUChQUVEBAPD19ZUe4zty5Eid2Wpnz57Fu+++i9OnT0uh3r///W+89dZbAICvvvoKNTU1ePfdd6FQKBAWFoYBAwZIs+X+V1JSEtzc3BASEiL1N3v2bEyZMgUA0L59ewghrrsD4+bNm9GmTRsIIQAAZ86cgaOjI9RqNfr164cxY8Zg6tSpWLRoESIiIuoFdNXV1XjggQdQUFCAb775pl77+/fvx+eff45Dhw7VG0tlZSWWLFmCXr164fz58xg0aBD69++PLVu2YN26dVIotm3bNjg5OcHR0REqlQoajQYA4Onpec17IyIiIiIiIqKGky0U27179zXP9+/fX66ubzldu3ZFSkoK4uPjUV5ejp49e2Lt2rUYNWpUnesOHz58Q+uJHT16FPPnz5f++7bbbpMCMeBSUPbYY48BuPQIYmZmJkpLS3Hu3Dls27YNZ8+eBQD89NNPKC8vl4In4NIjfu3atQMA3HvvvUhOTsY999wDhUIhzSIDLoVUtQEVAPzyyy8wGo31Fs2vDXZ+/PFHTJw4sU5wlJubi/Hjx1/xHv83dDt69CieffbZOvfYpk0bKUC6klOnTuHQoUOYMmUK/Pz8kJ+fD4PBgJKSEsTGxuLEiRP45JNPkJqaip49e8Lf37/O+3NycjB27Fj4+/vjzz//hLOzc52vk9lsxr///W88/vjj6NChA0wmE4qKigAAKpUK999/P+zt7eHp6Ylff/0VERER6NSpEzw8PPDHH39g3rx5GDhwIJ577jlMmTIF/fv3R58+fa56P0RERERERERkObKFYgMHDqx37PJA5EprMzVnbm5usLOzwzfffIP4+Hj88MMP9UKx2gDnWgoKCnDx4kVpcfojR47UCdJMJhOOHTsmBUqBgYHw9vbGyZMnsWDBAixcuBCurq4AgMLCQixYsOCqi8NrNBosWbIES5YswZ49ezBw4ECMGjUK7dq1w7Fjx7Bs2TLp2sLCQkybNg2ffvrpFdvKz8+Hj4+P9PrixYvYvXs3/vOf/1zx+stDsby8POTk5NSZRXfo0KE6odnlhBD46aefsHv3buTn5yMgIAD+/v7w9PREUVERKisrsXXrVnz33Xf44IMPEBUVhfXr12PLli0oLi4GAJw7dw7jxo3DpEmTsGDBAlRXV8PBwQHZ2dkwGAwoKyvD+vXrkZOTg9mzZ+PUqVMwGAwALq2d9vzzz6OiogKurq6YNWsWhg0bBl9fX/j5+WHy5MlYuXIldDodXnnlFajVavj5+TEQIyIiIiIiImpCsi20X1xcXOdPXl4etm7dih49emDbtm1ydXvL2bp1KzZt2oSKigoYjUZkZWVh586d6NevH4BLAU51dTWysrKQmZmJDh06SAvCX0lSUhJat24tzVq6fH0x4NLsKKVSiTZt2kjHOnXqhDfffBOZmZmYPXu2dLxHjx5Yv3490tLSAAAlJSXYsGEDhBDIzMzEd999h7KyMpjNZuTk5MDV1RVhYWEwGAxSeHR5W1u2bEFiYiIAoLy8HFu3bpV2Gm3fvj2+/vprlJWVITMzU1oEv1OnTle8z8tDsSNHjiAyMlIK84BLodjVHjX99ttvkZCQADc3NyiVSsyaNQs1NTXQaDTw9/eHUqmE2WzGrFmzcNttt2Hv3r246667oNVqkZ6eji+++AKDBw/GkiVLcNddd+HgwYNIT0/HqVOnUFRUhLKyMuTl5WH58uV49tlnUV5eLgViCoUCHh4e6NKlC6ZOnYrt27fDw8MDnTp1kkLhRx55BN999x2GDx+OBx98EO+//z4eeuihq9aciIiIiIiIiCxPtplibm5u9Y4NGTIEGo0G8fHxOHTokFxd31LMZjMWL16MKVOmwGAwYNeuXXjkkUekRdk3b95cZ8ZYx44d4ezsDJ1Od8X1spKSkqRHFM1mMxITE+vNoIqNja2zNlZsbCyWL1+OjRs3Qq3+b8nnzJmD8+fPo2/fvtDpdPDy8sJdd92F8ePHo6CgAG+88QamT58OOzs7dO7cGb/++qu0BtiTTz6JQYMGwWg04syZMxgzZgxOnjyJMWPGoKCgAK6urrjtttswZMgQAMDChQsxadIkBAUFISIiAgMGDEBWVladRxIv/5olJibWCcX+NwA7dOgQHnnkkSt+zU+cOIHffvsNv/32G4BLO1G2b98eJ06cAHBpE4hnnnkGNTU1aN26NUaOHIn77rtPmr04f/586PV6PPLII9JC/G5ubti2bRsUCgW8vb2xePFi9OzZEw8++CDy8vJgMBjQrl07qNVqGAwGvP/++1dclL9W69at4ePjg7KyMgQHB1/1OiIiIiIiIiKSh0LUrkDeRE6fPo3u3bujvLy8KbttNJ1OBzc3N5SWltaZsXSj9u/fj8TERMyaNavBYzCbzcjLy4Ovr+8Vd2xs6YqKipCamgqNRgN7e3u0bdv2ht6n1+uRlZUFR0dHeHp6Ys6cOdi/f7+04cCoUaPQqlUrZGVlwdXV9Yr1v96i/6ydbWLdbBdrZ7tYO9vEutku1s52sXa2i7WzTc29bo3NPGyVbDPFah+jqyWEwMWLF7F06dJ6i7G3BImJiYiJialzrLKyEk888QRGjx4NX19f9OzZUwpWhBAwmUx1ZnbRf+3fvx9FRUUoKSlBSUkJ7OzssHXrVixYsAAmk6nOxgPXo9FoEBERIb2ePHkyIiMj8dBDD8HV1VWqybVmdF1vF0wiIiIiIiIiurXIlrh07twZCoUC/zsRrXfv3vjss8/k6vaWYzAYpBlilZWVOHnyJJydnVFdXY309HSUlpYiODgYSqUSx48fh06nw5o1axAeHo4uXbqgW7dudRaoJyA9PR0XLlxA27Zt8fbbb6O0tBTLli3D/v37ceHCBURGRsLLy6vB7Q8aNAiDBg2y4IiJiIiIiIiI6FYjWyhWu3h7LaVSCR8fH9jb28vV5S3nwoULWL9+PYYMGYJdu3ZBp9MhNDRUWqTex8cHS5Ysgb29PUpLSyGEwI4dO7Bv3z54enrC398f2dnZcHZ2hoODg5Xv5tag1+uxcOFCHD9+HO+++y5efPFF7Ny5E+fPn8eHH37ImXVEREREREREdENkSxDCwsLkatommEwmzJkzB0II9OzZEx999BF8fHwwePBgREdHQ6FQICIios5i7IWFhRg4cCBuv/129O7dG6WlpVi7di22bNmCefPmWfFurKd259I2bdrg7Nmz+PPPPzF9+nQcO3ZM2sFzwIABVh4lEREREREREdkai4diO3fuxNy5c/H333/XW5yttLQUt912G1auXInbb7/d0l3fEoxGI5KTk7Fjxw5kZGSga9euuP322+Hl5YUjR45g9OjRV32vl5dXnYDHzs4Oe/bswZkzZ9C2bVuUlpbCy8sLoaGhsLOzQ2BgINzd3ZvgrpqewWDASy+9hC5dumDlypX497//jaSkJOzevRtz5sxp1IYFREREREREREQWD8WWL1+OWbNmXXG3Ajc3N8yePRtvv/12swvFahfGP336NEwmE/r06QOdTof4+HgoFAp06NABHTp0uKk27ezs8NJLL+Ghhx5Cbm4u1q1bh+XLlwO4FBpduHABBoOh2a05VlFRgfHjx6OsrAze3t7o2bMnIiIiEBISgv79+6N///7WHiIRERERERER2TiLh2LHjh3D66+/ftXzQ4cOxZtvvmnpbq1CCIGcnBz89ddfiIyMhFqthhACdnZ28PDwwNNPP93oNdTatWuHmTNnIigoCBMmTEB2djaCgoLg5uaGnJwcnDlzBh4eHja/llZmZiZ+/vlnmEwm7NmzBzk5OXB2dsbEiRPh6+uLpKQkdOrUCRqNxtpDJSIiIiIiIqJmwOJJSm5uLuzs7K7eoVqN/Px8S3d7Q37++Wc89dRTMJvNeO655zBz5sybbiM1NRVHjx6Fq6srDh8+jE2bNmHp0qXSTptKpRLR0dFQKpUWG/esWbOg1+tx++23o6KiAr6+vlAqldi+fTveffddaLVarFixAr169bJYn5aSmJgIIQTKy8sRGRkJHx8fqFQqFBQUoLi4GEajEUajESaTCVu3bsVDDz0EpVKJ/v37Y9myZdIGA506dbLynRARERERERFRc2K55Ob/CwoKQlJS0lXPJyYmIiAgwNLdXpfRaER8fDx27tyJI0eOYNmyZSgsLLzpdr7//nvs378fGzduRFVVFfz8/HDs2DFEREQgLCwMERERFg3Eamk0Gjg5OdU5FhMTg7Zt26KmpgaPP/44dDqdxfttjD///BMzZsxAWloannjiCYwfP1469sorr6CyshJ6vR5msxkKhQIfffQR1Go1xo4di/fee487bhIRERERERGRbCye3owcORILFixAdXV1vXNVVVVYtGgRRo0aZelur+uff/5Bhw4dEBQUBGdnZ4wYMQLbtm276XZOnTqFe+65B6NHj8aECRPw+eefY/78+XB3d4e7uzucnZ1lGP2V9ejRA+vXr0dsbCwqKyvx+OOPw2AwNFn/11JZWYlly5bBbDZDp9Nh5MiR8Pb2xqFDh3Dw4EEkJycjJSUFKpUKUVFRiImJgZ+fH0aNGoV7771XlmCRiIiIiIiIiKiWxR+ffPHFF/HDDz8gKioKc+fORdu2bQEAp0+fRkJCAkwmE1544YWbbnf37t1YtmwZDh06hIsXL2LDhg0YN25cnWsSEhKwbNky5OTkIDY2Fu+//z569uwJANJaXLWCgoKQlZV10+P4/PPP4erqCqPRiPPnzyM4OPim27C0Tz/9FP3798ehQ4cwdOhQrF27Fn5+fjAYDFCpVE0SMJnNZiQmJsLT0xNeXl5ITU3FnDlz4OPjg27dutW5rnXr1hg6dChnghERERERERGR1Vg8FPPz88PevXvx73//G/Pnz4cQAgCgUCgwbNgwJCQkwM/P76bbraioQGxsLGbMmIEJEybUO79u3TrEx8dj5cqV6NWrF5YvX45hw4YhOTkZvr6+N91fTU0NampqpNe1jyaazWaYzWYolUq0atUKZrP5pttuKLPZDCFEvT7VajU++ugjxMfHY+rUqThw4AC6deuG0aNHAwDGjBmDF198UZYxVVVVYc2aNXByckJRURH++ecfPPXUU1CpVIiIiEDr1q3rjbd2XE35tbO2q9WObm2sm+1i7WwXa2ebWDfbxdrZLtbOdrF2tqm516253tf1yLJlYVhYGDZv3ozi4mKkpKRACIE2bdrAw8OjwW2OGDECI0aMuOr5t99+G7NmzcL06dMBACtXrsQvv/yCzz77DPPmzUNgYGCdmWFZWVnSLLIree2117B48eJ6x/Pz86/4aGhTMJvNKC0tlRb0v5yfnx9Wr16NvXv34rPPPsN//vMf6PV6AMB3330Hd3d33HfffRYf0/Lly7F582ZERESgY8eO6N27N2pqauDo6Ag3Nzerbapwq7lW7ejWxbrZLtbOdrF2tol1s12sne1i7WwXa2ebmnvdysrKrD0Eq5AlFKvl4eGBHj16yNkFAECv1+PQoUOYP3++dEypVGLw4MHYt28fAKBnz55ISkpCVlYW3NzcsGXLFixYsOCqbc6fPx/x8fHSa51Oh5CQEPj4+MDV1VW+m7mG2gXpfXx8rvohHD9+PH7++WcAQGhoKJ555hk8+uij+O233xAbG4t+/fpBoVBYZDy///47Nm/eDLVaDaVSiZEjR6J3797Iz89v0Oy85uxGake3HtbNdrF2tou1s02sm+1i7WwXa2e7WDvb1NzrZm9vb+0hWIWsoVhTKSgogMlkqvdYpp+fH06fPg3g0iOGb731Fu644w6YzWY8++yz8PLyumqbWq0WWq223nGlUmnVD4BCobjmGJRKJb744gtUVVVBq9VCpVKhZ8+e+Oeff/Doo48iJiYGq1evtsg9vPfeewCAhQsX1lnfzd/fv9FtN0fXqx3dmlg328Xa2S7WzjaxbraLtbNdrJ3tYu1sU3OuW3O8pxvRou56zJgxOHPmDFJSUvCvf/3L2sORjUKhgKOjI1QqFQBg2LBhAC79T56YmIj77rsPRqOxQW1XVVUhMzMTe/fuRVpaGvz8/OpteEBEREREREREdKtrFjPFvL29oVKpkJubW+d4bm5uo2ctJSQkSLtm2qp7770XAQEBiI6OxujRo3HmzBl89913mDRp0g29v7S0FG5ubvjhhx/g4OAApVKJI0eOAACeeOIJGUdORERERERERCSPZjFTTKPRoFu3btixY4d0zGw2Y8eOHejTp0+j2o6Li8PJkydx4MCBxg7Tqvr16wdvb2+8/PLLAHDFzQKutNvEa6+9hoEDB+Kll17Cf/7zH+zduxdbt27Ft99+CwcHh2tufkBEREREREREdKuymZli5eXlSElJkV6npaXh6NGj8PT0RGhoKOLj4zFt2jR0794dPXv2xPLly1FRUSHtRkmX9OnTB2q1GgcPHkT//v2xb98+mM1mODk5wc7ODqNHj5auXbNmDb799lsAwPr16wEArVu3xvr16+Hs7Ix+/fq12OeOiYiIiIiIiMi22UwodvDgQdxxxx3S69qdIadNm4YvvvgCEydORH5+PhYuXIicnBx07twZW7durbf4/s1qDo9PXs7R0RGBgYHYvXs3du/eDeDSGmRLly6Ft7c3TCaTtBbZX3/9BQAYPHgwjh8/jieffBIjR47EiBEj4O3tzUCMiIiIiIiIiGyWzYRiAwcOhBDimtfMnTsXc+fOtWi/cXFxiIuLg06ng5ubm0XbthYvLy+kp6fD3t4e1dXVEEKgoKAA3333HXr06IFHHnkEAJCfnw8vLy+89dZbUCgU0vt9fX2tNXQiIiIiIiIiIovgVJ8W6M0338T+/fuxd+9e2Nvbw87ODnfddRdOnTqFTZs2QQiBjIwMpKSkoFevXnUCMSIiIiIiIiKi5sBmZoqR5fj4+Ej//cMPP8BkMsHT0xOjRo3C2rVrsXPnTuzZswcAYGdnZ61hEhERERERERHJhjPFWrjg4GCEhYUBADp37gwAWLZsGc6cOQOlUsmNCoiIiIiIiIioWWIodh0JCQlo3749evToYe2hyG7kyJFo1aoVsrOzkZiYiJiYGLRq1crawyIiIiIiIiIisjiGYtcRFxeHkydP4sCBA9YeSpN47rnnAFzakbJ25hgRERERERERUXPDNcWojj59+uDvv/+GRqPhAvtERERERERE1GwxFKN6HB0drT0EIiIiIiIiIiJZ8fHJ62hJa4oREREREREREbUUDMWuo6WtKUZERERERERE1BIwFCMiIiIiIiIiohaHoRgREREREREREbU4DMWIiIiIiIiIiKjFYShGREREREREREQtDkOx6+Duk0REREREREREzQ9Dsevg7pNERERERERERM2P2toDsBVCCACATqez2hjMZjPKyspgb28PpZJ5pi1h7WwT62a7WDvbxdrZJtbNdrF2tou1s12snW1q7nWrzTpqs4+WgqHYDSorKwMAhISEWHkkRERERERERESWV1ZWBjc3N2sPo8koREuLARvIbDYjOzsbLi4uUCgUVhmDTqdDSEgIMjIy4OrqapUxUMOwdraJdbNdrJ3tYu1sE+tmu1g728Xa2S7WzjY197oJIVBWVobAwMBmORPuajhT7AYplUoEBwdbexgAAFdX12b5IWwJWDvbxLrZLtbOdrF2tol1s12sne1i7WwXa2ebmnPdWtIMsVotJ/4jIiIiIiIiIiL6/xiKERERERERERFRi8NQzIZotVosWrQIWq3W2kOhm8Ta2SbWzXaxdraLtbNNrJvtYu1sF2tnu1g728S6NU9caJ+IiIiIiIiIiFoczhQjIiIiIiIiIqIWh6EYERERERERERG1OAzFiIiIiIiIiIioxWEoRkRERERERERELQ5DMStYsWIFunfvDq1Wi3HjxtU5d+jQIfTr1w+urq5o1aoVVq9eLZ2rqanBwIED4evrC1dXV0RHR2PVqlV13n/q1Cn07dsXjo6OiIqKwk8//dQUt9RiNLR2l0tKSoJGo6n3ftZOXo2pXXh4OBwcHODs7AxnZ2e4u7vXOZ+dnY2RI0fCyckJoaGh+Pjjj2W+m5ajMXUTQuC1115DeHg4nJycEBUVhf3790vn+ZmTV0Nr9+eff0qftdo/SqUSjz32mHQNP3Pyaszn7q+//kLv3r3h5uaGoKAgzJ8/H2azWTrP2smrMbX77bff0LVrV7i4uKB9+/bYunVrnfP8nimfmpoazJo1CxEREXBxcUF0dDQ+++wz6bxOp8OUKVPg6uoKPz8/vPTSS3Xe39jz1HCNrd2CBQvQqVMnqNVqPPHEE/Xa5/dMeTSmbnl5ebj//vsRHBwMV1dXdOnSpd73Q9bNxghqct9//73YsGGDiIuLE2PHjpWOFxcXC19fX/Hhhx8Ko9Eo/v77b+Hq6ir+/PNPIYQQRqNRJCYmCoPBIIQQ4sSJE8LX11fs3r1bCCGEXq8XkZGRYsGCBaKqqkps2rRJODk5ibNnzzb5PTZXDa1dLZPJJHr37i0GDhxY5/2snfwaU7uwsDCxYcOGq7bdv39/MX36dFFeXi7+/vtv4ebmJv744w8Z76blaEzd5s+fL/r27SvOnj0rzGazOH/+vMjOzhZC8DPXFBr7/bJWTk6OUKvVYs+ePdIxfubk1ZifUzw9PcWrr74qjEajSEtLE+Hh4WLlypVSG6ydvBpau9TUVOHk5CQ2bdokTCaT2LRpk3B0dBSpqalCCH7PlFt5eblYsGCBSElJEWazWezbt0+4u7uLX3/9VQghxIMPPiiGDRsmiouLRXJysggJCRFffvml9P7GnqeGa2ztvvjiC7F582Yxfvx48fjjj9drn98z5dGYuqWmpoply5aJjIwMYTKZxE8//SQcHR3FiRMnpPZZN9vCUMyKFi1aVOcHll9++UWEhITUueahhx4S06ZNu+L7T548Kfz8/MRnn30mhBBi+/btwt3dXej1eumakSNHioULF1p87C1dQ2v3zjvviOnTp9d7P2vXdBpSu2uFYikpKUKpVIqcnBzp2Jw5c8SDDz5oyWG3eDdbt8LCQqHVakVycvIV2+Nnruk09u+6119/XbRr1056zc9c02nI5w6AyMrKks7PnDlTxMXFCSFYu6Z0s7VLSEgQt99+e53zAwcOFIsWLRJC8HumNYwfP14sWLBAVFRUCI1GIw4cOCCde+ONN0T//v2FEKLR58nybrR2l5s2bVq9UIzfM5tWQ+pWq0uXLuLTTz8VQrButoiPT95CzGYzhBD1jiUmJtY5NmrUKNjb26N9+/bw8/PD+PHjAQCJiYno0KED7OzspGs7d+5c7/1keTdSuwsXLuDdd9/FsmXL6r2ftbOeG/3czZ49G97e3ujTpw82b94sHU9MTERAQAD8/PykY6yd/K5Xt7///htarRbffvstAgMDER4ejueeew56vR4AP3PWdKOfuVqfffYZHn74Yek1P3PWc73aeXp6YsaMGfj0009hMBiQmpqK7du346677gLA2lnT9Wp3vfP8ntm0qqur8c8//yAmJgbJycnQ6/Xo3LmzdP7yr31jz5Nl3UztroffM5tOY+qWl5eHU6dOISYmBgDrZosYit1C+vTpg4qKCqxYsQIGgwF79uzBhg0boNPp6lz3888/o6KiAn/88QfuvvtuODg4AADKy8vrrXXk7u6OsrKyprqFFutGajd79mwsWbIEXl5e9d7P2lnPjdRuzZo1SEtLQ1ZWFh599FHcfffdOHDgAADWzlquV7eioiLodDqcPXsWZ86cwe7du7Flyxa8/vrrAFg3a7rRv+uAS+uLnTt3Dg8++KB0jLWznhup3X333YdVq1bBwcEBrVu3xqhRozB8+HAArJ01Xa92Q4YMwYEDB7Bx40YYjUZs3LgRe/bskc6zdk1HCIGZM2eiTZs2mDBhAsrLy+Hk5AS1Wi1dc/nXvrHnyXJutnbXw89d02hM3fR6PSZNmoT77rsP3bt3B8C62SKGYrcQLy8vbNq0Cd988w38/f0xb948TJ8+/YohikqlwoABA5CbmyvNPHJ2dkZpaWmd60pLS+Hi4tIk42/Jrle7r776CkajEVOnTr3i+1k767mRz93tt98OR0dHaLVaTJkyBaNHj8b3338PgLWzluvVzdnZGQCwePFiODs7IzQ0FI8//jg2bdoknWfdrONm/q779NNPMWbMGPj4+EjHWDvruV7tkpOTMXbsWLzzzjuorq5GdnY2Tp06hXnz5gFg7azperVr27Yt1q1bh8WLF8PX1xeffvopJk2aVOd7KmsnPyEE5syZg+TkZGzcuBFKpRLOzs6orKyE0WiUrrv8a9/Y82QZDand9fBzJ7/G1E2v1+Oee+6Bo6NjnYX0WTfbw1DsFtO3b1/s3bsXhYWF+PPPP5GTk4MBAwZc9XqDwYCzZ88CAGJiYnDixAkYDAbp/NGjR9GpUyfZx03Xrt327duxf/9+eHt7w9vbG2+88Qa2bNkCf39/AKydtd3s506p/O+3zpiYGGRnZyMvL086xto1jWvVLTY29prv5WfOum7kM6fT6bB+/XrMnDmzznF+5qzrWrU7fvw4goODcc8990CtViMgIADTpk3DL7/8AoC1s7brfe7Gjh2LI0eOoKioCJs2bcLZs2el8/yeKT8hBOLi4rB//35s27YNbm5uAC4FlnZ2djh27Jh07eVf+8aep8ZraO2uh98z5dWYuun1etx7773Q6/X4/vvvodFopHOsmw1q8lXMSBgMBlFVVSVeeOEFMXr0aFFVVSVqamqEEEIcPnxYVFdXi8rKSrFq1Srh6+srLVh75MgRsW3bNlFZWSkMBoP4+eefhaOjo/j666+FEP/dGWjRokWiurpa/PLLL9wZyMIaWruioiKRkZEh/XnyySfFsGHDRGZmphCCtWsKDa3dhQsXxK5du0R1dbXQ6/Vi3bp1wt7eXuzbt09q+/bbbxcPP/ywqKioEPv37xfu7u7cYcZCGlo3IYQYPHiwePDBB0VFRYXIysoSsbGx4uWXXxZC8DPXFBpTOyGEWLlypQgJCREmk6le2/zMyauhtTt37pxwcHAQGzZsECaTSeTl5YkhQ4aIBx54QGqbtZNXYz53Bw4cEAaDQeh0OrF48WLRunVrUV5eLoTg98ymMGfOHBETEyMKCgrqnZs6daoYMWKEKCkpEWfOnBGhoaF1djBs7HlqnMbUTq/Xi6qqKvHAAw+IuXPniqqqqjobWvB7pnwaWje9Xi/Gjh0r7rzzTlFVVXXFtlk328JQzAoWLVokANT5M2DAACHEpZ2A3NzchJOTkxgyZIhISkqS3nfgwAHRvXt34eLiIlxdXUVMTEydbc6FEOLEiRPitttuE/b29qJ169Zi48aNTXlrzV5Da3eldi7fFUoI1k5uDa3diRMnRGxsrHBychJubm6iR48e4qeffqrTdmZmphg+fLhwdHQUwcHBYtWqVU15a81aYz5zubm5YuzYscLZ2VkEBgaKZ599ts4PmvzMyaux3y979Ohx1Z3t+JmTV2Nq9+OPP4ouXboIV1dX4evrK+6//36Rn58vnWft5NWY2g0ePFj6GfPuu+8WGRkZdc7ze6Z8zp8/LwAIrVYrnJycpD+zZ88WQghRWloqJk2aJJydnYWPj49YvHhxnfc39jw1XGNrN23atHqf2ct3Y+b3THk0pm5//PGHACDs7e3rvPeVV16RrmHdbItCiP/ZaoaIiIiIiIiIiKiZ45piRERERERERETU4jAUIyIiIiIiIiKiFoehGBERERERERERtTgMxYiIiIiIiIiIqMVhKEZERERERERERC0OQzEiIiIiIiIiImpxGIoREREREREREVGLw1CMiIiIiIiIiIhaHIZiRERERERERETU4jAUIyIiIpKJEAKDBw/GsGHD6p374IMP4O7ujszMTCuMjIiIiIgYihERERHJRKFQ4PPPP8f+/fvx0UcfScfT0tLw7LPP4v3330dwcLBF+zQYDBZtj4iIiKi5YihGREREJKOQkBC8++67ePrpp5GWlgYhBB5++GEMHToUXbp0wYgRI+Ds7Aw/Pz9MnToVBQUF0nu3bt2Kfv36wd3dHV5eXhg1ahRSU1Ol8+fPn4dCocC6deswYMAA2Nvb4+uvv7bGbRIRERHZHIUQQlh7EERERETN3bhx41BaWooJEybgpZdewokTJ9ChQwfMnDkTDz74IKqqqvDcc8/BaDRi586dAIDvv/8eCoUCMTExKC8vx8KFC3H+/HkcPXoUSqUS58+fR0REBMLDw/HWW2+hS5cusLe3R0BAgJXvloiIiOjWx1CMiIiIqAnk5eWhQ4cOKCoqwvfff4+kpCT8+eef+PXXX6VrMjMzERISguTkZERFRdVro6CgAD4+Pjh+/Dg6duwohWLLly/H448/3pS3Q0RERGTz+PgkERERURPw9fXF7Nmz0a5dO4wbNw7Hjh3D77//DmdnZ+lPdHQ0AEiPSJ49exaTJ09Gq1at4OrqivDwcABAenp6nba7d+/epPdCRERE1ByorT0AIiIiopZCrVZDrb7041d5eTlGjx6N119/vd51tY8/jh49GmFhYfj4448RGBgIs9mMjh07Qq/X17neyclJ/sETERERNTMMxYiIiIisoGvXrvj+++8RHh4uBWWXKywsRHJyMj7++GPcfvvtAIC//vqrqYdJRERE1Gzx8UkiIiIiK4iLi0NRUREmT56MAwcOIDU1Fb/++iumT58Ok8kEDw8PeHl5YdWqVUhJScHOnTsRHx9v7WETERERNRsMxYiIiIisIDAwEHv27IHJZMLQoUPRqVMnPPHEE3B3d4dSqYRSqcTatWtx6NAhdOzYEU8++SSWLVtm7WETERERNRvcfZKIiIiIiIiIiFoczhQjIiIiIiIiIqIWh6EYERERERERERG1OAzFiIiIiIiIiIioxWEoRkRERERERERELQ5DMSIiIiIiIiIianEYihERERERERERUYvDUIyIiIiIiIiIiFochmJERERERERERNTiMBQjIiIiIiIiIqIWh6EYERERERERERG1OAzFiIiIiIiIiIioxfl/Yfqs9Jn2WVsAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1400x550 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "def plot_two_regime_view():\n",
-    "    \"\"\"Create swim lane + cumulative return figure for the two-regime model.\"\"\"\n",
-    "    # Create figure with swim lane panel + cumulative returns\n",
-    "    fig, axes = plt.subplots(2, 1, figsize=(14, 5.5), height_ratios=[1, 2], sharex=True)\n",
-    "\n",
-    "    # Panel 1: Regime swim lanes\n",
-    "    ax1 = axes[0]\n",
-    "\n",
-    "    # Create binary matrix: row 0 = Risk-Off, row 1 = Risk-On\n",
-    "    regime_matrix = np.zeros((2, len(labels_2)))\n",
-    "    for i, label in enumerate(labels_2):\n",
-    "        if label == good_regime:\n",
-    "            regime_matrix[1, i] = 1  # Risk-On row\n",
-    "        else:\n",
-    "            regime_matrix[0, i] = 1  # Risk-Off row\n",
-    "\n",
-    "    # Use grayscale-friendly colors for swim lanes. origin='lower' so data\n",
-    "    # row 0 (Risk-Off) anchors at the bottom of the axis and row 1 (Risk-On)\n",
-    "    # at the top, matching the yticklabels below.\n",
-    "    cmap_swim = ListedColormap([\"white\", \"#2d2d2d\"])\n",
-    "    ax1.imshow(\n",
-    "        regime_matrix,\n",
-    "        aspect=\"auto\",\n",
-    "        cmap=cmap_swim,\n",
-    "        vmin=0,\n",
-    "        vmax=1,\n",
-    "        extent=[0, len(labels_2), -0.5, 1.5],\n",
-    "        interpolation=\"nearest\",\n",
-    "        origin=\"lower\",\n",
-    "    )\n",
-    "\n",
-    "    # Y-axis: regime labels\n",
-    "    ax1.set_yticks([0, 1])\n",
-    "    ax1.set_yticklabels([\"Risk-Off\", \"Risk-On\"], fontsize=10)\n",
-    "    ax1.axhline(y=0.5, color=\"gray\", linewidth=1.5)\n",
-    "\n",
-    "    # X-axis setup\n",
-    "    years = [pd.Timestamp(ts).year for ts in factors_df.index]\n",
-    "    decade_ticks = []\n",
-    "    decade_labels = []\n",
-    "    for j, year in enumerate(years):\n",
-    "        if j == 0 or years[j - 1] != year:\n",
-    "            if year % 10 == 0:\n",
-    "                decade_ticks.append(j)\n",
-    "                decade_labels.append(str(year))\n",
-    "\n",
-    "    # Add historical event markers (BLACK labels, not red)\n",
-    "    for event_year, (event_label, pos) in historical_events.items():\n",
-    "        try:\n",
-    "            idx = next(j for j, y in enumerate(years) if y == event_year)\n",
-    "            ax1.axvline(x=idx, color=\"black\", linestyle=\"-\", alpha=0.6, linewidth=1.5)\n",
-    "            y_pos = 1.7 if pos == \"top\" else -0.7\n",
-    "            va = \"bottom\" if pos == \"top\" else \"top\"\n",
-    "            ax1.annotate(\n",
-    "                event_label,\n",
-    "                xy=(idx, y_pos),\n",
-    "                xycoords=(\"data\", \"data\"),\n",
-    "                ha=\"center\",\n",
-    "                va=va,\n",
-    "                fontsize=8,\n",
-    "                color=\"black\",\n",
-    "                fontweight=\"bold\",\n",
-    "            )\n",
-    "        except StopIteration:\n",
-    "            pass\n",
-    "\n",
-    "    ax1.set_xlim(0, len(labels_2))\n",
-    "    ax1.set_ylim(-0.5, 1.5)\n",
-    "\n",
-    "    # Panel 2: Cumulative equity returns colored by regime\n",
-    "    ax2 = axes[1]\n",
-    "    equity_returns = factors_df[\"Equity indices Market\"]\n",
-    "    cum_returns = (1 + equity_returns).cumprod()\n",
-    "\n",
-    "    # Plot with regime coloring\n",
-    "    for i in range(len(cum_returns) - 1):\n",
-    "        color = \"#d0d0d0\" if labels_2[i] == good_regime else \"#2d2d2d\"\n",
-    "        ax2.plot(\n",
-    "            [i, i + 1], [cum_returns.iloc[i], cum_returns.iloc[i + 1]], color=color, linewidth=1.2\n",
-    "        )\n",
-    "\n",
-    "    ax2.set_yscale(\"log\")\n",
-    "    ax2.set_ylabel(\"Cumulative Return (log scale)\", fontsize=10)\n",
-    "    ax2.set_xlabel(\"Year\", fontsize=10)\n",
-    "    ax2.set_xticks(decade_ticks)\n",
-    "    ax2.set_xticklabels(decade_labels, fontsize=9)\n",
-    "    ax2.grid(True, alpha=0.3)\n",
-    "\n",
-    "    # Annotations\n",
-    "    ax2.annotate(\n",
-    "        f\"${cum_returns.iloc[-1]:.0f}\",\n",
-    "        xy=(len(cum_returns) - 1, cum_returns.iloc[-1]),\n",
-    "        xytext=(10, 0),\n",
-    "        textcoords=\"offset points\",\n",
-    "        fontsize=10,\n",
-    "        fontweight=\"bold\",\n",
-    "    )\n",
-    "    ax2.annotate(\n",
-    "        \"$1 invested in 1927\",\n",
-    "        xy=(0, 1),\n",
-    "        xytext=(10, 10),\n",
-    "        textcoords=\"offset points\",\n",
-    "        fontsize=9,\n",
-    "        style=\"italic\",\n",
-    "    )\n",
-    "\n",
-    "    fig.suptitle(\n",
-    "        f\"Market Regimes: Risk-On vs Risk-Off ({start_year}-{end_year})\",\n",
-    "        fontsize=12,\n",
-    "        fontweight=\"bold\",\n",
-    "        y=1.02,\n",
-    "    )\n",
-    "\n",
-    "    plt.show()\n",
-    "\n",
-    "\n",
-    "plot_two_regime_view()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "07cb380c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003022,
-     "end_time": "2026-07-11T19:31:19.855670+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.852648+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Volatility by Regime\n",
-    "\n",
-    "A key question: does volatility differ meaningfully between regimes?\n",
-    "If Risk-Off periods have higher volatility, this validates using regime\n",
-    "detection for risk management."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "21a60705",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:19.862326Z",
-     "iopub.status.busy": "2026-07-11T19:31:19.862167Z",
-     "iopub.status.idle": "2026-07-11T19:31:19.868511Z",
-     "shell.execute_reply": "2026-07-11T19:31:19.867911Z"
-    },
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.010275,
-     "end_time": "2026-07-11T19:31:19.868845+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.858570+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Calculate rolling volatility (12-month window, annualized)\n",
-    "equity_returns = factors_df[\"Equity indices Market\"]\n",
-    "rolling_vol = equity_returns.rolling(12).std() * np.sqrt(12)\n",
-    "\n",
-    "# Create regime indicator series\n",
-    "regime_indicator = pd.Series(labels_2, index=factors_df.index)\n",
-    "\n",
-    "# Calculate volatility statistics by regime\n",
-    "vol_by_regime = []\n",
-    "for regime, name in [(good_regime, \"Risk-On\"), (bad_regime, \"Risk-Off\")]:\n",
-    "    mask = regime_indicator == regime\n",
-    "    vol_in_regime = rolling_vol[mask].dropna()\n",
-    "    vol_by_regime.append(\n",
-    "        {\n",
-    "            \"Regime\": name,\n",
-    "            \"Mean Vol\": vol_in_regime.mean(),\n",
-    "            \"Median Vol\": vol_in_regime.median(),\n",
-    "            \"Max Vol\": vol_in_regime.max(),\n",
-    "        }\n",
-    "    )\n",
-    "\n",
-    "vol_df = pd.DataFrame(vol_by_regime).set_index(\"Regime\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "75f7bcd6",
-   "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.00295,
-     "end_time": "2026-07-11T19:31:19.874944+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.871994+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Volatility Regime Chart\n",
-    "Regime bands with rolling volatility, showing how risk environments differ."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "1f84dc8f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:19.881492Z",
-     "iopub.status.busy": "2026-07-11T19:31:19.881372Z",
-     "iopub.status.idle": "2026-07-11T19:31:20.180541Z",
-     "shell.execute_reply": "2026-07-11T19:31:20.179988Z"
-    },
-    "papermill": {
-     "duration": 0.303134,
-     "end_time": "2026-07-11T19:31:20.181022+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:19.877888+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABIwAAAIFCAYAAACwOWaFAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3Xd4FNX7NvB7d9N7b5BA6CBFBMQAUpQiKEhHQAnFRpEmShNBEPlZEUUBleYXEKVKEaR3RDoizUBCEFJIIL1skp33j7wz7iS7m90ku5td7s915Uoyc2bOmTkzszPPnnNGIQiCACIiIiIiIiIiov9Pae0CEBERERERERFR1cKAERERERERERERyTBgREREREREREREMgwYERERERERERGRDANGREREREREREQkw4ARERERERERERHJMGBEREREREREREQyDBgREREREREREZEMA0ZERERERERERCTDgBEREZnF8OHDoVAooFAocOjQIWsXx2rmzJkj7YdVq1ZZuzhmtWrVKmlb58yZY5Y89B1X4rSaNWtatDy6xMXFSfl27NjRYvlWJbZy/m/YsAEKhQIODg64ffu2tYtDOhw/flw6lk6fPm3t4hARPVIYMCIisiPawQldPz4+PtYuIrZu3Yo5c+Zgzpw5iIuLq/T1Hzp0qNQ25+bmytLk5+cjMDBQlm737t2VXhZziouLk/bj1q1by0yfnZ0Nd3d3aXtv3bqlM11UVJSUZu3atZVc6rKZul3lceHCBSmPqhzMMIWuc9/BwQFBQUF47rnnsGvXLmsXscrRaDRSILFPnz6oUaOGNO/w4cMYNWoUGjZsCKVSWWbwKzExEWPHjkXNmjXh5OSEoKAgDBo0CNeuXSuVdvv27XjjjTfQrFkzBAYGwsnJCRERERg5cmSpoFVZ13SFQoHhw4cbtb2HDx/GhAkT0LJlS4SEhMDJyQmhoaEYNGgQLl26pHOZs2fP4sUXX4S/vz9cXFzQqFEjLFiwAGq1Wpbu/PnzmDZtGtq0aYNq1arByckJgYGB6NmzJ44ePWqwXLGxsfDw8JC256mnnpLNb9u2LVq1agUAeP/9943aViIiqiQCERHZjdmzZwsA9P54e3tbrCw3btwQjh49Khw9elRIS0uTpkdHR0vlOXjwYKXne/DgwVLbvXr1alman376qVSaXbt2VXpZBEFeJytXrqy09WpvZ3R0tFHLvPTSS9IyCxYsKDU/Pj5eUCgUAgDB1dVVyMzMNKlMK1eulNY/e/Zsk5YVlbVd+o4rcZkaNWpI05KSkqS0t2/frtRyGhIbGyutv0OHDpW+fl3KOvcVCoWwdetWi5RFEPTXU1Wyfft2af/s3r1bNm/ChAk696Oua9adO3eEatWq6Uzv6ekpnDlzRpa+fv36euvJ399fiImJkdKWVa8AhFdffdWo7e3WrZvedbi4uAgnTpyQpf/9998FJycnnem7du0qFBYWSmnfeOMNvetWKpXCpk2b9JarS5cusvStW7culWbZsmXS/L/++suo7SUioopjCyMiIjvVvXt3HD16VPZjyVY0devWRbt27dCuXTt4e3tbLF9dfvjhB9n/33//vdnzzM7ONnsepnrppZekv3/55ZdS8zds2ABBEAAAzz//PDw8PCxWNmOZclwFBQVJaSMiIixUQusTz/0tW7agWbNmAABBEPD1119brAxV6fzXZ+XKlQAAX19fPPPMM7J5wcHB6N+/Pz7//HPUq1fP4HpmzJiBu3fvAgBeeOEF7N69G7NmzQIAZGZmYvjw4dJ5JWratCm+/PJL7N27F19++SW8vLwAAKmpqZg7d66UbuTIkaWu40ePHpV1vezdu7fR21yrVi189NFH2LNnD3744QeEhoYCAPLy8jBt2jQpXW5uLkaMGCG1JHrvvfewadMmNG7cGACwZ88eLF26VLbukJAQzJw5E7t27cK6detQv359AMUtuSZPnqyzPKtXr8bevXvh4uJisNy9e/eGUln82GLvXXuJiKoUKwesiIioEml/G21Mq5Pk5GTh5ZdfFry8vARvb2/hlVdeEe7fv6+ztYa+ljL6WoSUbEmk3epC18+2bdsENzc3KV+NRiOtq7CwUAgICBAACH5+foJarda7Tdrl8fT0lP6+fv26IAiCEBMTI7Wi0Z6v3cLohx9+ELp27SqEh4cLbm5ugrOzs1CnTh1h3Lhxwv3792X5dejQQVrH2bNnhREjRgj+/v6C+BGra7+p1Wrhueeek6a/9tpr0vYeOXJE6NmzpxAQECA4OjoKNWvWFCZNmiQ8ePBAZ54lfwzVe35+vuDj4yOl/eeff2Tzn3rqKWmedouAs2fPCv379xeCg4MFR0dHITg4WOjXr1+plhP6Wu5s2bJF6Nmzp1CzZk3Bw8NDcHR0FCIiIoThw4cLsbGxJm2XvhZquo5ZXeWpUaOG3jxmz54ttGvXTvr/5s2bsu3r3bu3NK/ktmsr2cLo/PnzQseOHQVXV1chNDRUeO+994SCggJBEARh3759Utphw4bJ1nPhwgVp3gsvvKA3P0HQf+5v2rRJml6vXr1Sy128eFF46aWXhJCQEMHR0VEICwsTRo0aJdy5c0dnWnE7qlWrJsyZM0fYu3evUee/SLueLl68KDz99NOCq6urUL9+fWHDhg2CIAjChg0bhEaNGglOTk5C06ZNhf3795cqS3JysjBp0iShTp06gpOTk+Dj4yP06NFDOHnypMH9JMrPzxdcXFwEAEKfPn0Mpm3durXObRGJ1yYAQlxcnDS9QYMG0vRjx45J0/fs2VNqHV9++aWUtmHDhgbLc/bsWSltZGSkUFRUVMbWFtu/f7903Im2bt0qrcvV1VWa/vPPP0vTu3XrJk0/efKkNL1x48bS9KNHjwrZ2dmydWsfvwCEpKQk2fykpCTBz89PUCgUwocffmiwhZEgCMLjjz8uABBq1apl1PYSEVHFsYUREdEjSq1Wo0uXLlizZg0yMjKQnp6O//3vf+jcubNVyuPp6YkBAwYAAG7fvo3jx49L806cOIGUlBQAQP/+/eHo6GjUOhs1aoQmTZoA+K+V0ffffw9BEFC/fn088cQTOpfbsGED9uzZgzt37iAnJwf5+fmIiYnB4sWL0b59e+Tl5elcbsCAAVi5ciVSU1P1lkkQBIwYMUJq7fXKK69g6dKlUCgU+OGHH9CxY0ds374dKSkpKCgoQFxcHBYuXIioqCg8fPjQqO3Wx8nJCX379pX+125lFB8fj1OnTgEAvLy80KNHDwDAtm3b8NRTT2Hjxo1ISkpCQUEBkpKSsGnTJkRFRWHbtm1l5rt7925s374dcXFxyMrKQkFBAeLj47Fq1So89dRTSE5OrtB2VaZRo0ZJf69bt076Oy8vD3v37gUA1KtXDy1atDBqfXFxcejQoQMOHTqE3NxcJCQk4MMPP8S4ceMAAM888wwiIyMBAFu2bJGNt6W9b4cMGVKu7RG0WraEhYXJ5u3atQtPPvkk1q9fj8TERBQUFODevXtYvnw5WrVqhdjYWCltbGysbDvu3r2LOXPmYMqUKeUqV3p6Op555hkcPXoUubm5uH79OgYOHIhZs2ZhwIABuHLlCtRqNS5duoTevXvLjv34+Hg88cQTWLhwIWJiYqBWq5GWlobffvsN7du3N+qYPHv2rHQe67sOmLItInd3d51/a1/PunTpUmoddevW1bmcLt9884309+jRo6WWN2V55pln4ODgYFS+x44dk/5u06aN9HfLli2l6+/ly5elemnXrh3c3Nz0rhtAqfnjx4/HgwcPMGbMGLRt27bM8ov1dOvWLSQmJpaZnoiIKo4BIyIiO7V69WqDg6OuWLECFy9eBAD4+/tjxYoV2LBhAzIzM81SntDQUBw9ehTdu3eXpn311VdSF4vmzZvLHta1B1zWfgAcPHiwSfm++uqrAIAff/wROTk5UncG7bxKGjRoEFasWIGdO3fi0KFD2LlzJ4YNGwYAuHr1KjZv3qxzufj4eMyePRu///47Fi5cqDPN5MmTpW0TA0xKpRJ3797FuHHjoNFo4Onpia+//hq///47RowYAQC4fv06ZsyYAQD4+uuv8dVXX0nr1O5+OHPmTIP7Q1+3tI0bN0rBhRdffBEuLi7Izs7GqFGjUFBQAKD44fS3337DmDFjAAAFBQUYNWpUmd3vunbtimXLlmH79u04dOgQdu/ejbfffhsAkJSUJAXzKrJdxtq4caO0HwFgxIgRUh4jR47EgAED4OnpCUB+DO7fv1/aTlOOwdu3b+Opp57C9u3bMW/ePKhUKgDAsmXLcOnSJSgUCqmOMzMzZce6+Lebmxt69epldJ7Jyck4duwYtm7dinnz5knT33jjDenvnJwcREdHIz8/Hw4ODpg/fz727NmDd999F0DxIM5iPQPAzJkzkZaWBqC4O9WWLVuwaNEi3Lhxw+hyaUtLS0PdunWxbds26ZgUBAEffvghXnzxRezYsQPt2rUDULxftIN3Y8aMwb///gsAGDZsGHbv3o0lS5bAw8MDBQUFGDlyZJnH5NWrV6W/69SpU65tEIldrwDgyy+/RHZ2Nvbs2YMLFy5I0+/cuWNwHZs2bZL+1r5GlvTw4UP89NNPAAAXFxeMHDmynKU2nK/2CwmCg4Olvx0cHODn56cznaF1P/3007Iurtu3b8fPP/+M8PBwLFiwwKiyatfTlStXjFqGiIgqyKrtm4iIqFKVNUCqdpeR7t27S9O/+eYbabp2F5PK7JJW1nRRvXr1BKB48Fex65k4SGxYWFiZ3S+0y9O6dWshNTVVcHZ2FgAIQ4cOFQAIjo6OQlJSkqwLlHaXtPj4eOG1114TIiMjpWW1fyZNmiSl1V7HjBkzDNZJy5Ytpb979eol61q3cOFCad6IESOkAYOPHDkiddXz9vaWtr88g14LQnH3vqCgIGlZsauedreb3377TRAEQdi8ebM0rUWLFrL1tGjRQpq3ZcsWQRD0d0lLTU0VJk+eLNSvX19wdXUttT+1uwSVtV0V7ZJmaLrotddek+afPXtWEAT5oL7Xrl0zuI+1u6S5ubnJBn0Wj0EAwty5cwVBKD7elEqlAEDo2bOnIAiCcO/ePanr5EsvvWQwP0EwfO4HBQWVGvh9y5Yt0vzu3btLx9vRo0eFmjVrCkDxQNn3798XioqKBA8PDym99qDD06ZNK1eXNADCjRs3BEEQhNOnT8v2V0ZGhiAIxV3TxOkTJ04UBKH4WBL3S0hIiKzcffr0kdJv3LjR4P76+OOPpbQlB7wuqawuadrHk74fQwNTf/fdd1K6WrVqGRwk/PPPP5fSDh8+XDYvLy9Ptj/EH3127twpDWrt5+cn6073zDPPSPmsWLFCtlx4eLg0T9/6z5w5I3h7ewsABGdnZ1kXzoyMDKF69eoCAGHnzp2CIJS+buuyZMkSKc3PP/+sd7uIiKjyyNulEhGR3ejevbusJQUg/6ZY+7Xq4iuLAeDJJ580f+EMGDlyJKZNm4bU1FTs3r0bDRo0wPXr1wEUt/wxtvuFyM/PD/369cO6deukFiO9evVCUFCQzvSZmZlo06aN1IJBF7GlRUk9e/Y0WJYzZ84AAGrWrIkNGzbIutZpt9RYuXKlNCCvtvT0dNy7dw/Vq1c3mI8hKpUKAwYMkLq1/PLLLxg2bBj+/PNPAMWtzcQuM9plat26tWw9Tz75JM6ePVsqXUlFRUXo3Lkzzp8/rzeNvv1pLaNGjZIGRl+7di2aN2+OHTt2AACaN28ua1FSlgYNGsgGfX7yySel41A8B8PDw9G1a1fs3r0bu3fvRmpqKrZv3y61+DK1VV1J9+/fx99//y2bpl1nu3btwq5du0otJwgCrl27hjp16iArKwtAcWsnceBjAIiKiipXmXx8fKQuS9otVurXry+18AoICJCmi8dITEyMtF8SExPx9NNP61y/dguisgha3fbKY/jw4cjIyMDs2bOlcvr7+6NJkyY4dOgQgOLt1WXRokWYNGkSgOJBo3fv3q13kHBBEGQDTY8dO1Y2PyEhQef+0LV9mzZtwpAhQ6BWq+Hh4YEdO3agRo0a0nzt7mn5+fmyZcWBsEumEx07dgzPP/88MjIy4ODggJ9++knWhXPBggX4999/MXjwYKnrqzEqWk9ERGQ6dkkjIrJT2m+IEn9Kjimhi0KhKHN6UVGR9Lc4tlBliY6OlsbZWLNmDX799VdpXnnHcRG7pen7X9uWLVukYFGDBg3w888/4+jRo7IuZhqNRuey2gE5XcTuSHFxcVi0aJFRZS+pMt6+ph2A+OWXX2RvR+vXr1+pcU500XeclHT8+HEpWBQaGorVq1fjyJEjUrcaQP/+tJbWrVvjscceAwD89NNPOH36tPQWrPIegyJ9+03sIllQUIBffvlF6o7m6+uL5557zqQ8oqOjUVBQgN27d8PNzQ2CIOCTTz7B9u3bTS5vyePN2Hovi3ZQRDsILL4trCRTgwVlnSfawaiKjg0GFI/Hk5ycjAsXLuDy5cu4d+8eatWqJc0Xjydt8+fPx8SJEyEIAsLDw3H48GGD1+i9e/fin3/+AVAceGzZsmW5yrp69WoMGjQIarUaPj4+2LNnT6nAn/Zb2JKSkqS/CwsLZWO0aacDit+e1q1bN2RkZMDZ2RkbN25Enz59ZGnu3bsHoPjcErtLd+rUSZp/6tQpKBQKfPnll7LltOtJu/6IiMh8GDAiInpEaT/MiC1fAEgDH5ek/YCnPeCoOHizsbQfDnUFCkJCQqRvnbdv3y4FFurUqVPuB6SOHTtK419ERESga9euetOKgQGg+Bv8gQMHol27dnoHutZW1sP0jBkzpAedqVOnyoIm2q/unj17NgRBKPWTnZ0ttW4paz8a0qZNG+k183/99ZcseKUdTNIuk9gCSdf/hl47rr0/hwwZgmHDhultFQJUbLuMZUweYgAnISFBeiW4QqHAoEGDTMrr+vXryMjIkP7XPr+0z8FevXpJx8by5cuxf/9+AMUBPCcnJ5PyBIrHmunWrZs0JhEA6VXvgLzOoqOj9R5v3bp1Q1BQkNTqJzs7W9Z65+TJkyaXrSLq1KkjnWe1a9dGYWFhqXKr1WrZq+l1adiwofR3TExMpZTN0dERzZo1w2OPPYbk5GT8/PPP0vRu3brJ0k6dOhXvvfcegOLBoY8dO2bwPAKAb7/9Vvq7ZOsioDh4o6setX3zzTcYMWIEioqKEBQUhEOHDulsJSaOHwUUv3RAdPr0aRQWFgIAGjduDF9fX2neli1b0LNnT+Tk5MDd3R07d+7Eiy++aHCbTKFdT40aNaq09RIRkX7skkZEZKfEgW9LatWqFZydndGrVy+pG8r7778PV1dXeHh4YPr06TrXpz3g6BdffAEPDw/ExMRgxYoVJpVL+wFjzZo1UKlUUKlUsgeUUaNGYdu2bcjNzcW5c+cAVKxbjkKhwNdff40//vgDLVu2NNitTbtbxooVK1CrVi3ExMTgww8/LHf+olq1amHr1q149tlnkZ+fj+HDhyMkJASdOnVC//79MW3aNOTn5+P//u//oFAoEBUVhZycHMTGxuLgwYPIzc2V3tSlvR+PHTuGXbt2wdPTE/Xq1dPb3U4kBj4+/fRTAP8NyBsWFob27dtL6bp27Qp/f3+kpqbizJkzGDduHJ5//nn89ttvUpAxICBA51ufRNr7c9OmTWjXrh0ePnyIadOm6Uxfke0ylnYeu3fvRvv27eHi4oImTZpIgdFXXnkF06ZNg1qtlt5w1a5dO4SHh5uUV3Z2NgYNGoRx48bh4sWLWL9+vTRP+2HayckJr7zyChYuXCh19QMq3h3trbfewieffIKcnBxcvHgRe/bsQdeuXdGlSxcEBgbi/v37+PHHH+Hn54cuXbqgqKgIcXFxOH78OC5evIgrV65AqVSiZ8+e0sDTr7zyCmbNmoX4+Phyt5QrLz8/P3Tv3h2//fYbbt68iV69emHUqFHw9PTE7du3cf78eWzevBknT54s1fpFW4sWLeDi4oK8vDzpGqPtypUr0sDKDx48kKYfPnxY9sZGALh06RLefvttDBgwADVr1sStW7fw0UcfSa2cXn31VYSGhkrrmDBhgjS4u4+PDxYsWID4+HjEx8cDKB7MumRwPD4+XuoWGRAQYHLgEgAWLlwoBT+dnZ2xYMECZGZmyj4nxOtwz549ERYWhnv37mHPnj2YOXMmWrRogffff19K++abb0p/b9iwAYMHD0ZRUREUCgVmz54NZ2dn2brFz54hQ4bg8ccfl5UtJiZG6iZbo0YNTJw4ER06dJClEVsq1qpVCyEhISZvPxERlYMlBkoiIiLLKGvQawBCbGysIAiCkJ+fLzRr1qzU/KZNm+ocQFitVgsRERGl0jds2NCkQW+3b9+us1zaCgoKhJCQENn8K1euGLUPjBk8VaRr0OuMjAwhNDS0VPnatm2rczu11yHuW311Ig4WvmbNGmmat7e3cOnSJUEQBOH777+XBj/W9dOhQweD+0g7j7KcO3eu1LITJkwolW7r1q2Co6OjzvI4OjoKv/76q5RW12DShYWFsmNK1/40ZbsqY9Dr+/fv6xzMvOSAxv3795fN//bbb43at9qDXlerVk3nQN+6BkG+fPmyLE1oaGiZg7yLtI+zkoOFjx07VprXuXNnafrOnTt17gdd+/LWrVuCj4+PweuFKYNea69be39pHwv6BkC/ffu2NGhyWdc5Q/r16ycAEHx9fYWCggK9+1Pfj+j8+fN607Rv317IysqSrbtGjRoG16u9b0QzZsyQ5k+dOrXMbdNF+1pV1jYJgiD8/vvv0qDYJX+6du0qFBYWSmm167s8dVLWdTspKUm6Nk6ZMqVc209ERKZjlzQiokeUk5MT9u7di6FDh8LLywteXl4YPHgw9u3bpzO9o6Mjtm7diqioKDg5OaF69er44IMPZK9BN8YLL7yAzz77DLVr19Y7Vo6DgwOio6Ol/5s1aybrQmJOnp6e2Lt3L5555hl4eHigWrVqmDt3bpldXEwxdOhQ6Zv69PR0dO/eHXfu3MGrr76KI0eOoG/fvggODoaDgwOCg4Px5JNPYtasWbIuKQ4ODti2bRvatWsndRcyha7Bm8XXm2t78cUXcfLkSfTv3x9BQUFwcHBAYGAg+vbtixMnTpT5uneVSiV1TfH29kZgYCAmTJiAH374QWf6im6XMQICArB161Y0b94crq6uetOJ3dLEcg0YMMDkvOrUqYMDBw6gbdu2cHFxQUhICGbMmIElS5aUSvvYY4/JBhcfOHCgyYO86zJx4kRpPfv27ZNaavTo0QNnzpzBK6+8gurVq8PR0REBAQF4/PHHMXnyZGzYsEFaR2RkJA4fPoyOHTvCxcUFoaGheO+992QtTtzc3CpcVmNERETg/PnzeOedd9CgQQO4uLjA09MTDRo0wLBhw7Bt2zajWoKNGDECQPHYOAcPHix3ecLCwvDyyy+jVq1acHNzg7u7O1q0aIEvv/wS+/bt0zkwtCnUajWWL18OoLg7pXbLHnPq2rUrTpw4gZ49e8LX1xfOzs5o2LAhPvroI2zfvl0ak80Stm7dKnUfHT58uMXyJSJ61CkEga8cICIiOXGMkBo1aiAuLs4qZThy5IjUJeHjjz+WjcVCZAmFhYVwd3eHWq2WukGZ29y5czF79mwAxeMdWfuthdoEQSg1Tte0adPw8ccfAyjuqiq+8csWaDQaNG3aFH///TcGDhwojTlEVc+TTz6J06dPW+w8JCKiYmxhREREVUpubi6SkpKkFhgqlarCb6YiMoVarUZaWhoWL14svUJ82LBhZs0zKysLMTEx0hhHDRo0qFLBIqB4sPT169fjxo0buHHjBr766iuphaGjoyP69u1r5RKaRqlUSsG5TZs2SWMIUdVy/PhxnD59GgDwwQcfWLk0RESPFrYwIiKiUqzZwqhjx444fPiw9P9rr72G7777zqJloEfbnDlzZA+mDRs2xKVLl/R2oawMJVvurF27tsoFSvW9BVAcVF7Xm7uIiIjIdrGFERERVUkBAQF444038OWXX1q7KPSI8vDwQPfu3bFjxw6zBotECoUCNWrUwKJFi6pcsAgofuNa06ZN4e3tDUdHR4SFhaFfv344fPgwg0VERER2iC2MiIiIiIiIiIhIhi2MiIiIiIiIiIhIhgEjIiIiIiIiIiKSYcCIiIiIiIiIiIhkGDAiIiIiIiIiIiIZBoyIiIiIiIiIiEiGASMiIiIiIiIiIpJhwIiIiIiIiIiIiGQYMCIiIiIiIiIiIhkGjIiIiIiIiIiISIYBIyIiIiIiIiIikmHAiIiIiIiIiIiIZBgwIiIiIiIiIiIiGQaMiIiIiIiIiIhIhgEjIiIiIiIiIiKSYcCIiIiIiIiIiIhkGDAiIiIiIiIiIiIZBoyIiIiIiIiIiEiGASMiIiIiIiIiIpJhwIiIiIiIiIiIiGQYMCIiIiIiIiIiIhkGjIiIiIiIiIiISIYBIyIiIiIiIiIikmHAiIiIiIiIiIiIZBgwIiIiIiIiIiIiGQaMiIiIiIiIiIhIhgEjIiIiIiIiIiKSYcCIiIiIiIiIiIhkGDAiIiIiIiIiIiIZBoyIiIiIiIiIiEiGASMiIiIiIiIiIpJhwIiIiIiIiIiIiGQYMCIiIiIiIiIiIhkGjIiIiMgurFq1Cj4+PtYuhl6WLN/w4cPRu3dv6X9BEPD666/Dz88PCoUCFy5cQMeOHTFx4kSzliMuLk7Kj4iIiGwLA0ZERERkVsOHD4dCoYBCoYCjoyMiIyPx7rvvIi8vr1LzGTRoEG7cuFGp6zTFwYMH0aNHD/j7+8PNzQ2NGjXC22+/jbt371q8LIsWLcKqVauk/3fv3o1Vq1Zhx44dSEhIQOPGjbF582bMmzev0vIsGaQCgPDwcCk/IiIisi0MGBEREZHZPffcc0hISMCtW7ewcOFCLFu2DLNnz67UPFxdXREUFFSp6zTWsmXL0LlzZ4SEhGDTpk24cuUKli5divT0dHz++ecWL4+3t7esNdPNmzcRGhqKNm3aICQkBA4ODvDz84Onp6dZy6FSqaT8iIiIyLYwYERERERm5+zsjJCQEISHh6N3797o3Lkz9u7dK83XaDRYsGABIiMj4erqimbNmmHjxo2ydWzbtg1169aFi4sLOnXqhNWrV0OhUCAtLQ1A6S5fc+bMweOPP44VK1YgIiICHh4eGDNmDIqKivDJJ58gJCQEQUFBmD9/viyftLQ0vPrqqwgMDISXlxeeeeYZXLx4Ue+2/fvvvxg/fjzGjx+PFStWoGPHjqhZsybat2+PH374Ae+//77O5W7evIkXX3wRwcHB8PDwQKtWrbBv3z5Zmm+//Vba5uDgYPTv31+at3HjRjRp0gSurq7w9/dH586dkZ2dDUDe2mf48OF46623EB8fD4VCgZo1awJAqS5p+fn5mDp1KsLDw+Hs7Iw6depg+fLlAICioiKMGjVKqp/69etj0aJFsn29evVq/Prrr1JrskOHDunsknb48GE8+eSTcHZ2RmhoKKZNm4bCwkJpfseOHTF+/Hi8++678PPzQ0hICObMmaN3/xMREZF58OseIiIisqjLly/jxIkTqFGjhjRtwYIFWLNmDZYuXYq6deviyJEjePnllxEYGIgOHTogNjYW/fv3x4QJE/Dqq6/i/PnzmDJlSpl53bx5E7t27cLu3btx8+ZN9O/fH7du3UK9evVw+PBhnDhxAiNHjkTnzp3RunVrAMCAAQPg6uqKXbt2wdvbG8uWLcOzzz6LGzduwM/Pr1QeGzZsgFqtxrvvvquzDPrGLcrKykKPHj0wf/58ODs748cff0TPnj1x/fp1RERE4MyZMxg/fjz+97//oU2bNnjw4AGOHj0KAEhISMDgwYPxySefoE+fPsjMzMTRo0chCEKpfBYtWoTatWvju+++w+nTp6FSqXSWZ9iwYTh58iS++uorNGvWDLGxsUhJSQFQHNCrXr06NmzYAH9/f5w4cQKvv/46QkNDMXDgQEyZMgVXr15FRkYGVq5cCQDw8/PDvXv3ZHncvXsXPXr0wPDhw/Hjjz/i2rVreO211+Di4iILCq1evRqTJ0/GqVOncPLkSQwfPhxt27ZFly5ddJadiIiIKh8DRkRERGR2O3bsgIeHBwoLC5Gfnw+lUonFixcDKG7Z8tFHH2Hfvn2IiooCANSqVQvHjh3DsmXL0KFDByxbtgz169fHp59+CgCoX78+Ll++XKp1UEkajQYrVqyAp6cnGjVqhE6dOuH69ev47bffoFQqUb9+fXz88cc4ePAgWrdujWPHjuHPP/9EcnIynJ2dAQCfffYZtm7dio0bN+L1118vlcc///wDLy8vhIaGmrRPmjVrhmbNmkn/z5s3D1u2bMG2bdswbtw4xMfHw93dHS+88AI8PT1Ro0YNNG/eHEBxwKiwsBB9+/aVAm9NmjTRmY+3tzc8PT2l7mG63LhxA7/88gv27t2Lzp07AyiuA5GjoyM++OAD6f/IyEicPHkSv/zyCwYOHAgPDw+4uroiPz9fbx5AcYup8PBwLF68GAqFAg0aNMC9e/cwdepUvP/++1Aqixu/N23aVOqyWLduXSxevBj79+9nwIiIiMiCGDAiIiIis+vUqROWLFmC7OxsLFy4EA4ODujXrx8AICYmBjk5OaWCAWq1WgqQXL9+Ha1atZLNf/LJJ8vMt2bNmrJxeoKDg6FSqaTAhDgtOTkZAHDx4kVkZWXB399ftp7c3FzcvHlTZx6CIEChUJRZlpKysrIwZ84c7Ny5UwoA5ebmIj4+HgDQpUsX1KhRA7Vq1cJzzz2H5557Dn369IGbmxuaNWuGZ599Fk2aNEG3bt3QtWtX9O/fH76+viaXAwAuXLgAlUqFDh066E3zzTffYMWKFYiPj0dubi7UajUef/xxk/K5evUqoqKiZPurbdu2yMrKwr///ouIiAgAxQEjbaGhoVIdERERkWUwYERERERm5+7ujjp16gAAVqxYgWbNmmH58uUYNWoUsrKyAAA7d+5EtWrVZMuJrXzKy9HRUfa/+Ka2ktM0Gg2A4iBOaGgoDh06VGpd+rqW1atXD+np6UhISDCpldGUKVOwd+9efPbZZ6hTpw5cXV3Rv39/qNVqAICnpyfOnTuHQ4cOYc+ePXj//fcxZ84cnD59Gj4+Pti7dy9OnDiBPXv24Ouvv8bMmTNx6tQpREZGGl0Gkaurq8H569evx5QpU/D5558jKioKnp6e+PTTT3Hq1CmT8zKGoToiIiIiy+Cg10RERGRRSqUSM2bMwHvvvYfc3Fw0atQIzs7OiI+PR506dWQ/4eHhAIq7oJ05c0a2ntOnT1d62Z544gkkJibCwcGhVFkCAgJ0LtO/f384OTnhk08+0TlfHJS7pOPHj2P48OHo06cPmjRpgpCQEMTFxcnSODg4oHPnzvjkk09w6dIlxMXF4cCBAwCKgyht27bFBx98gPPnz8PJyQlbtmwp13Y3adIEGo0Ghw8f1lvWNm3aYMyYMWjevDnq1KlTqsWVk5MTioqKDObTsGFDnDx5UjbW0vHjx+Hp6Ynq1auXq+xERERkHgwYERERkcUNGDAAKpUK33zzDTw9PTFlyhRMmjQJq1evxs2bN3Hu3Dl8/fXXWL16NQDgjTfewLVr1zB16lRpvJ1Vq1YBQLm6g+nTuXNnREVFoXfv3tizZw/i4uJw4sQJzJw5s1TAShQeHo6FCxdi0aJFGDVqFA4fPozbt2/j+PHjeOONNzBv3jydy9WtWxebN2/GhQsXcPHiRQwZMkTWimbHjh346quvcOHCBdy+fRs//vgjNBoN6tevj1OnTuGjjz7CmTNnEB8fj82bN+P+/fto2LBhuba7Zs2aiI6OxsiRI7F161bExsbi0KFD+OWXX6SynjlzBr///jtu3LiBWbNmlQrY1axZE5cuXcL169eRkpKCgoKCUvmMGTMGd+7cwVtvvYVr167h119/xezZszF58mRZN0EiIiKyPn4yExERkcU5ODhg3Lhx+OSTT5CdnY158+Zh1qxZWLBgARo2bIjnnnsOO3fulLpXRUZGYuPGjdi8eTOaNm2KJUuWYObMmQAq3m1Nm0KhwG+//Yb27dtjxIgRqFevHl566SXcvn0bwcHBepcbM2YM9uzZg7t376JPnz5o0KABXn31VXh5eel9m9sXX3wBX19ftGnTBj179kS3bt3wxBNPSPN9fHywefNmPPPMM2jYsCGWLl2Kn376CY899hi8vLxw5MgR9OjRA/Xq1cN7772Hzz//HN27dy/3ti9ZsgT9+/fHmDFj0KBBA7z22mvIzs4GUByw69u3LwYNGoTWrVsjNTUVY8aMkS3/2muvoX79+mjZsiUCAwNx/PjxUnlUq1YNv/32G/788080a9YMb775JkaNGoX33nuv3OUmIiIi81AIut6/SkRERFTFzZ8/H0uXLsWdO3esXRQiIiIiu8NBr4mIiMgmfPvtt2jVqhX8/f1x/PhxfPrppxg3bpy1i0VERERklxgwIiIiIpvwzz//4MMPP8SDBw8QERGBt99+G9OnT7d2sYiIiIjsErukERERERERERGRDAe9JiIiIiIiIiIiGQaMiIiIiIiIiIhIhgEjIiIiIiIiIiKS4aDXJWg0Gty7dw+enp5QKBTWLg4RERERERERUaUQBAGZmZkICwuDUmm4DREDRiXcu3cP4eHh1i4GEREREREREZFZ3LlzB9WrVzeYhgGjEjw9PQEA9evXx59//omoqCicPHlS9luXkydPAoA0X1dafdPE5Ur+rS+tSHsZUxi7nKF0JctoaDvEv7Vp71ND6yy5/41JV1LJPHTNL6t+DSlrG8raFyXTaZdJVzkNlaNkvtqM2TeG9pWxx2TJ9Pp+60pXVt5lrcscynMuU9VjzmPFEsfho0DftaGi6zF1WUD3NVvXNaqsz8iS6fWVz5rHkLHXLl2fwcZ8rol0fS6K/+v7XDe0TlOPlbLu4YxZnzH3gSWZWq+GPt/MfZzou880Jk9T66Cs466i22rpc8qU/QTovs/RNb3kvLLumYw5Do2939LO09B67OnzT991X9czkb7nGO3lDeVj6n2sMeente9HjLmOl0xblcqsb77ImOtVea+ZZT2bG7OvTNmXRUVFuH79uhT7MIQBoxLEbmgqlQpeXl46f+vi5eUlLSf+XzKtvmna+ZXMW1dakfYypjB2OUPpSpbR0HaIf2vT3qeG1lly/xuTrqSSeeiaX1b9GlLWNpS1L0qm0y6TrnIaKkfJfLUZs28M7Stjj8mS6cs6j/QdC7ryNuWcrCzlOZep6jHnsWKJ4/BRoO/aUNH1mLosoPuaresaVdZnZMn0+spnzWPI2GuXrs9gYz7XRLo+F8X/9X2uG1qnqcdKWfdwxqzPmPvAkkytV0Ofb+Y+TvTdZxqTp6l1UNZxV9FttfQ5Zcp+AnTf5+iaXnJeWfdMxhyHxt5vaedpaD329Pmn77qv65lI33OM9vKG8jH1PtaY89Pa9yPGXMdLpq1KZdY3X2TM9aq818yyns2N2Vfl2ZfGDMHDQa+JiIiIiIiIiEiGASMiIiIiIiIiIpJhwIiIiIiIiIiIiGQYMCIiIiIiIiIiIhkGjIiIiIiIiIiISIYBIyIiIiIiIiIikmHAiIiIiIiIiIiIZBgwIiIiIiIiIiIiGQaMiIiIiIiIiIhIhgEjIiIiIiIiIiKSYcCIiIiIiIiIiIhkGDAiIiIiIiIiIiIZBoyIiIiIiIiIiEiGASMiIiIiIiIiIpKp1IBRfHw8PDw8kJ6ebjBdXFwcFAoF0tLSKjN7IiIiIiIiIiKqBCYHjDp27AhnZ2d4eHjAz88PHTp0wJkzZwAAERERyMrKgre3d6UXFADWr1+PFi1awN3dHX5+fhgwYABiYmLMkhcRERERERER0aOqXC2MPv74Y2RlZSExMRGtW7dG3759K7tcpSxevBhjxozBzJkzkZqaiqtXryIsLAxRUVG4ffu22fMnIiIiIiIiInpUVKhLmpOTE6Kjo3Hnzh3cv3+/VFezvXv3omnTpvD09ERwcDBGjx6tcz1//PEHqlWrhs2bN+ucn5mZienTp+Orr75C37594eLiguDgYCxatAhNmzbF7NmzAfzX1e1///sf6tSpAx8fHwwfPhwFBQUV2UwiIiIiIiIiokdKhQJGubm5WL58OQICAuDr61tqfnR0NN555x1kZmbi1q1beOWVV0ql2blzJ/r27Yt169bpbal04sQJ5ObmYuDAgaXmDRkyBHv27JFN27VrF86fP48rV65g//79WLt2rd5tyM/PR0ZGhuyHiIiIiIiIiOhRVq6A0fTp0+Hj4wN3d3esW7cOmzdvhoODQ6l0jo6OiImJwf379+Hu7o42bdrI5q9cuRKjR4/G7t270aFDB735paSkICAgAE5OTqXmhYWF4f79+7Jp77//Pjw9PREWFobnnnsOZ8+e1bvuBQsWwNvbW/oJDw8va/OJiIiIiIiIiOxauQJGCxYsQFpaGu7cuYNq1arh0qVLOtNt2bIFly9fRv369dG8eXP88ssvsvkff/wxXn75ZTRt2lSatnbtWnh4eMDDwwOPPfYYACAgIAApKSk6u5bdu3cPgYGBsmkhISHS3+7u7sjMzNS7LdOnT0d6err0c+fOnbJ3ABERERERERGRHatQl7Rq1arh+++/x9SpU3Hv3r1S85944gls2rQJKSkpmDVrFoYMGYKkpCRp/q5du7Bu3Tp8+umn0rShQ4ciKysLWVlZ+PvvvwEAUVFRcHFxKRVwAoCffvoJXbp0Kfc2ODs7w8vLS/ZDRERERERERPQoq1DACCgOCnXs2BEfffSRbLparcb//vc/PHz4EEqlEj4+PgAg67oWGRmJw4cPY8mSJViwYIHePLy8vDB//nxMmDABW7duRV5eHpKTkzF58mScP38ec+bMqehmEBERERERERHR/1d64KFymDlzJjp16oRBgwbJpq9btw4TJ06EWq1GREQE1q1bB39/f1kXsRo1auDw4cPo1KkTCgsLMWvWLJ15TJgwAYGBgZg7dy6GDh0KJycnPPPMMzh58iQiIyMrYzOIiIiIiIiIiAjlCBgdOnSo1LSoqCjk5eUBAARBkKbv2rVL5zpq1qwpSxceHo6YmJgy8x4yZAiGDBmid37J9QLAl19+WeZ6iYiIiIiIiIjoPxXukkZERERERERERPaFASMiIiIiIiIiIpJhwIiIiIiIiIiIiGQYMCIiIiIiIiIiIhkGjIiIiIiIiIiISIYBIyIiIiIiIiIikmHAiIiIiIiIiIiIZBgwIiIiIiIiIiIiGQaMiIiIiIiIiIhIhgEjIiIiIiIiIiKSYcCIiIiIiIiIiIhkGDAiIiIiIiIiIiIZBoyIiIiIiIiIiEiGASMiIiIiIiIiIpJxsHYBqipvb28kJCTAx8en1G9dEhISAECaryutvmniciX/1pdWpL2MKYxdzlC6kmU0tB3i39q096mhdZbc/8akK6lkHrrml1W/hpS1DdrTDZVBe56xx4+++brqzZh9Y2hfGXtMlkxf1nmk71jQlbcp52RlKc+5TFWPOY8VSxyHjwJ914aKrsfUZQHd12xd16iyPiNLptdXPmseQ8Zeu3R9BhvzuSbS9bko/q/vc93QOk09Vsq6hzNmfcbcB5Zkar0a+nwz93Gi7z7TmDxNrYOyjruKbqulzylT9hOg+z5H1/SS88q6ZzLmODT2fks7T0PrsafPP33X/ZL7Qde0sq6JJfMx9T7WmPPT2vcjxlzHS6atSmXWN19kzPWqvNfMsp7NjdlXpuzLwsJCo9IBgEIQBMHo1I+AjIwMeHt7Y9q0aXBxcbF2cYiIiIiIiIiIKkVeXh7+7//+D+np6fDy8jKYlgGjEsSA0fXr1/Hqq6/i559/xqBBg2S/dRk0aBAASPN1pdU3TVyu5N/60oq0lzGFscsZSleyjIa2Q/xbm/Y+NbTOkvvfmHQllcxD1/yy6teQsrahrH1RMp12mXSV01A5SuarzZh9Y2hfGXtMlkyv77eudGXlXda6zKE85zJVPeY8VixxHD4K9F0bKroeU5cFdF+zdV2jyvqMLJleX/mseQwZe+3S9RlszOeaSNfnovi/vs91Q+s09Vgp6x7OmPUZcx9Ykqn1aujzzdzHib77TGPyNLUOyjruKrqtlj6nTNlPgO77HF3TS84r657JmOPQ2Pst7TwNrceePv/0Xfd1PRPpe47RXt5QPqbexxpzflr7fsSY63jJtFWpzPrmi4y5XpX3mlnWs7kx+8qUfZmZmYn69esbFTBilzQ9QkJCkJaWhtDQ0FK/dUlLSwMAab6utPqmicuV/FtfWpH2MqYwdjlD6UqW0dB2iH9r096nhtZZcv8bk66kknnoml9W/RpS1jZoTzdUBu15xh4/+ubrqjdj9o2hfWXsMVkyfVnnkb5jQVfeppyTlaU85zJVPeY8VixxHD4K9F0bKroeU5cFdF+zdV2jyvqMLJleX/mseQwZe+3S9RlszOeaSNfnovi/vs91Q+s09VgxlMbYY6+sdehiar0a+nwz93Giq86MzdPUOijruKvotlr6nDJlPwG673N0TS85r6x7JmOOQ2Pvt7TzNLQee/r803fd1/VMpO85Rnt5Q/mYeh9rzPlp7fsRY67jJdNWpTLrmy8y5npV3mumvnNXO29j96kx3N3djUoHcNBrIiIiIiIiIiIqgQEjIiIiIiIiIiKSYcCIiIiIiIiIiIhkGDAiIiIiIiIiIiIZBoyIiIiIiIiIiEiGASMiIiIiIiIiIpJhwIiIiIiIiIiIiGQYMCIiIiIiIiIiIhkGjIiIiIiIiIiISIYBIyIiIiIiIiIikmHAiIiIiIiIiIiIZBgwIiIiIiIiIiIiGQaMiIiIiIiIiIhIhgEjIiIiIiIiIiKSYcCIiIiIiIiIiIhkKi1gFB8fDw8PD6SnpxtMFxcXB4VCgbS0tMrKWvLHH3+gUaNG8PT0xFdffQUAeP311+Hn54eQkJBKz4+IiIiIiIiIyB6ZFDDq2LEjnJ2d4eHhAT8/P3To0AFnzpwBAERERCArKwve3t5mKej69evRokULuLu7w8/PDwMGDEBMTIwszXvvvYfBgwcjMzMT48ePx7Fjx7Bx40bExsYiMTHRLOUiIiIiIiIiIrI3Jrcw+vjjj5GVlYXExES0bt0affv2NUe5ZBYvXowxY8Zg5syZSE1NxdWrVxEWFoaoqCjcvn1bShcbG4smTZrI/o+IiDBbEIuIiIiIiIiIyB6Vu0uak5MToqOjcefOHdy/f79UV7O9e/eiadOm8PT0RHBwMEaPHq1zPX/88QeqVauGzZs365yfmZmJ6dOn46uvvkLfvn3h4uKC4OBgLFq0CE2bNsXs2bMBACEhIYiNjcXgwYPh4eGBr776Cq+99hr++usveHh4YPjw4TrXn5+fj4yMDNkPEREREREREdGjrNwBo9zcXCxfvhwBAQHw9fUtNT86OhrvvPMOMjMzcevWLbzyyiul0uzcuRN9+/bFunXr9LZUOnHiBHJzczFw4MBS84YMGYI9e/YAABITExEREYGffvoJWVlZGD9+PJYuXYomTZogKysLq1at0rn+BQsWwNvbW/oJDw83YS8QEREREREREdkfkwNG06dPh4+PD9zd3bFu3Tps3rwZDg4OpdI5OjoiJiYG9+/fh7u7O9q0aSObv3LlSowePRq7d+9Ghw4d9OaXkpKCgIAAODk5lZoXFhaG+/fvm7oJpbYnPT1d+rlz506F1kdEREREREREZOtMDhgtWLAAaWlpuHPnDqpVq4ZLly7pTLdlyxZcvnwZ9evXR/PmzfHLL7/I5n/88cd4+eWX0bRpU2na2rVr4eHhAQ8PDzz22GMAgICAAKSkpKCgoKBUHvfu3UNgYKCpmyDj7OwMLy8v2Q8RERERERER0aOs3F3SqlWrhu+//x5Tp07FvXv3Ss1/4oknsGnTJqSkpGDWrFkYMmQIkpKSpPm7du3CunXr8Omnn0rThg4diqysLGRlZeHvv/8GAERFRcHFxaVUwAkAfvrpJ3Tp0qW8m0BERERERERERDqUO2AEFAeFOnbsiI8++kg2Xa1W43//+x8ePnwIpVIJHx8fAJB1XYuMjMThw4exZMkSLFiwQG8eXl5emD9/PiZMmICtW7ciLy8PycnJmDx5Ms6fP485c+ZUZBOIiIiIiIiIiKiE0oMPmWjmzJno1KkTBg0aJJu+bt06TJw4EWq1GhEREVi3bh38/f2RmZkppalRowYOHz6MTp06obCwELNmzdKZx4QJExAYGIi5c+di6NChcHJywjPPPIOTJ08iMjKyoptARERERERERERaTAoYHTp0qNS0qKgo5OXlAQAEQZCm79q1S+c6atasKUsXHh6OmJiYMvMeMmQIhgwZYjBNXFyc7P/hw4dj+PDhZa6biIiIiIiIiIj+U6EuaUREREREREREZH8YMCIiIiIiIiIiIhkGjIiIiIiIiIiISIYBIyIiIiIiIiIikmHAiIiIiIiIiIiIZBgwIiIiIiIiIiIiGQaMiIiIiIiIiIhIhgEjIiIiIiIiIiKSYcCIiIiIiIiIiIhkGDAiIiIiIiIiIiIZBoyIiIiIiIiIiEiGASMiIiIiIiIiIpJhwIiIiIiIiIiIiGQYMCIiIiIiIiIiIhkHaxegqhEEAQCQkZGBoqIinb91KSoqkpYT/y+ZVt807fxK5q0rrUh7GVMYu5yhdCXLaGg7xL+1ae9TQ+ssuf+NSVdSyTx0zS+rfg0paxvK2hcl02mXSVc5DZWjZL7ajNk3hvaVscdkyfRlnUf6jgVdeZtyTlaW8pzLVPWY81ixxHH4KNB3bajoekxdFtB9zdZ1jSrrM7Jken3ls+YxZOy1S9dnsDGfayJdn4vi//o+1w2t09Rjpax7OGPWZ8x9YEmm1quhzzdzHyf67jONydPUOijruKvotlr6nDJlPwG673N0TS85r6x7JmOOQ2Pvt7TzNLQee/r803fd1/VMpO85Rnt5Q/mYeh9rzPlp7fsRY67jJdNWpTLrmy8y5npV3mtmWc/mxuwrU/almE6MfRiiEIxJ9Qj5999/ER4ebu1iEBERERERERGZxZ07d1C9enWDaRgwKkGj0eDevXvw9PSEQqGwWjkyMjIQHh6OO3fuwMvLy2rlINOw3mwX6852se5sF+vONrHebBfrznax7mwT68122XPdCYKAzMxMhIWFQak0PEoRu6SVoFQqy4yyWZKXl5fdHaCPAtab7WLd2S7Wne1i3dkm1pvtYt3ZLtadbWK92S57rTtvb2+j0nHQayIiIiIiIiIikmHAiIiIiIiIiIiIZBgwqqKcnZ0xe/ZsODs7W7soZALWm+1i3dku1p3tYt3ZJtab7WLd2S7WnW1ivdku1l0xDnpNREREREREREQybGFEREREREREREQyDBgREREREREREZEMA0ZERERERERERCTDgBEREREREREREckwYERERERERERERDIMGBERERERERERkQwDRkREREREREREJMOAERERERERERERyTBgREREREREREREMgwYERERERERERGRDANGREREREREREQkw4ARERERERERERHJMGBEREREREREREQyDBgREREREREREZEMA0ZERERERERERCTDgBEREREREREREckwYERERERERERERDIMGBERERERERERkQwDRkREREREREREJMOAERERERERERERyTBgREREREREREREMgwYERERERERERGRDANGREREREREREQkw4ARERERERERERHJMGBEREREREREREQyDBgREREREREREZEMA0ZERERERERERCTjYO0CVDUajQb37t2Dp6cnFAqFtYtDRERERERERFQpBEFAZmYmwsLCoFQabkPEgFEJ9+7dQ3h4uLWLQURERERERERkFnfu3EH16tUNpmHAqARPT08AxTvPy8vLauXQaDS4f/8+AgMDy4z6UdXBerNdrDvbxbqzXaw728R6s12sO9vFurNNrDfbZc91l5GRgfDwcCn2YQgDRiWI3dC8vLysHjDKy8uDl5eX3R2g9oz1ZrtYd7aLdWe7WHe2ifVmu1h3tot1Z5tYb7brUag7Y4bgsc8tJyIiIiIiIiKicmPAiIiIiIiIiIiIZBgwIiIiIiIiIiIiGY5hRERERERERI8MjUYDtVptkXwKCgqQl5dnt+Pg2CtbrztHR0eoVKoKr4cBIyIiIiIiInokqNVqxMbGQqPRmD0vQRCg0WiQmZlp1ADDVHXYQ935+PggJCSkQuVnwIiIiIiIiIjsniAISEhIgEqlQnh4uNlbjgiCgMLCQjg4ONhs0OFRZct1JwgCcnJykJycDAAIDQ0t97oYMCIiIiIiIiK7V1hYiJycHISFhcHNzc3s+dly0OFRZ+t15+rqCgBITk5GUFBQubun2V5nPCIiIiIiIiITFRUVAQCcnJysXBIi8xODogUFBeVeBwNGRERERERE9MgwR4uRoqIiXL9+HXfu3Kn0dROVR2Uc5wwYEREREREREVWAWq1GYWEh8vPzrV0UokrDgBERERERERFRBeTm5gKA1V7BHhcXB4VCgQsXLlRqWnq0MWBEREREREREVAHZ2dkAUO7BhQ0ZPnw4FAoFFAoFHB0dERkZiXfffRd5eXlSmvDwcCQkJKBx48aVnr+2O3fuYOTIkQgLC4OTkxNq1KiBCRMmIDU11az5WtrNmzfRv39/BAUFwcvLCwMHDkRSUpLBZYqKijBr1ixERkbC1dUVtWvXxrx58yAIgpTms88+Q1BQEIKCgvD555/Llj916hRatGiBwsJCs2xTeTBgRERERERERFROgiBIASPt4EBleu6555CQkIBbt25h4cKFWLZsGWbPni3NV6lUCAkJgYOD+V6EfuvWLbRs2RL//PMPfvrpJ8TExGDp0qXYv38/oqKi8ODBA7PlbUnZ2dno1q0bFAoF9u/fj+PHj0OtVqNnz57QaDR6l/v444+xZMkSLF68GFevXsXHH3+MTz75BF9//TUA4NKlS3j//fexfv16/PTTT3jvvffw119/ASh+g9+bb76JpUuXmrUOTcWAEREREREREVE5aTQauLm5QalUGgwoVISzszNCQkIQHh6O3r17o3Pnzti7d680v2Q3s4cPH2Lo0KEIDAyEq6sr6tati5UrV+pcd1FREUaOHIkGDRogPj5ebxnGjh0LJycn7NmzBx06dEBERAS6d++Offv24e7du5g5c6aUtmbNmvjoo48wcuRIeHp6IiIiAt99953Bbdy9ezfatWsHHx8f+Pv744UXXsDNmzel+W3atMHUqVNly9y/fx+Ojo44cuQIACAhIQHPP/88XF1dERkZiXXr1qFmzZr48ssvDeat7fjx44iLi8Py5cvRpEkTNGnSBKtXr8aZM2dw4MABvcudOHECL774Ip5//nnUrFkT/fv3R9euXfHnn38CAK5du4amTZvimWeewbPPPoumTZvi2rVrAIBPP/0U7du3R6tWrYwupyUwYERERERERERUTgqFAgEBAVCpVGZrYaTt8uXLOHHiBJycnPSmmTVrFq5cuYJdu3bh6tWrWLJkCQICAkqly8/Px4ABA3DhwgUcPXoUEREROtf34MED/P777xgzZgxcXV1l80JCQjB06FD8/PPPsu3//PPP0bJlS5w/fx5jxozB6NGjcf36db1lzs7OxuTJk3HmzBns378fSqUSffr0kYJwQ4cOxfr162V5/PzzzwgLC8PTTz8NABg2bBju3buHQ4cOYdOmTfjuu++QnJwsy2f48OHo2LGj3nLk5+dDoVDA2dlZmubi4gKlUoljx47pXa5NmzbYv38/bty4AQC4ePEijh07hu7duwMAmjRpghs3biA+Ph63b9/GjRs30LhxY9y8eRMrV67Ehx9+qHfd1lJ12joRERERERERWdiW4zux5cSuMtPVDq2J2S9PkU37YM1nuJkQC0EobqkDQKtLkQAIABRAnzY90Kft8+Uu444dO+Dh4SG9iU2pVGLx4sV608fHx6N58+Zo2bIlgOIWPyVlZWXh+eefR35+Pg4ePAhvb2+96/vnn38gCAIaNmyoc37Dhg3x8OFD3L9/H0FBQQCAHj16YMyYMQCAqVOnYuHChTh48CDq16+vcx39+vWT/b9ixQoEBgbiypUraNy4MQYOHIiJEyfi2LFjUoBo3bp1GDx4MBQKBa5du4Z9+/bh9OnT0nb/8MMPqFu3rmy9oaGhBluCPfXUU3B3d8eMGTOwYMECAMC0adNQVFSEhIQEvctNmzYNGRkZaNCgAVQqFYqKijB//nwMHTpU2kcfffQRunTpAgBYsGABGjZsiM6dO+OTTz7B77//jjlz5sDR0RGLFi1C+/bt9eZlKQwYERERERER0SMrJz8XqRllj78T6O1XatrDzDSkZjw0Ko+K6NSpE5YsWYLs7GwsXLgQDg4OpQIs2kaPHo1+/frh3Llz6Nq1K3r37o02bdrI0gwePBjVq1fHgQMHZK2G3nzzTaxZs0b6PysrS/rblBZUTZs2lf5WKBQICQkp1dpH2z///IP3338fp06dQkpKihTUiY+PR+PGjREYGIiuXbti7dq1ePrppxEbG4uTJ09i2bJlAIDr16/DwcEBTzzxhLTOOnXqwNfXV5aPGATSJzAwEL/88gvGjBmDxYsXQ6lUYvDgwXjiiScMvgXvl19+wdq1a7Fu3To89thjuHDhAiZOnIiwsDBER0cDKN63b775prTM6tWr4enpiaioKNSvXx+nT5/Gv//+i5deegmxsbGyVk7WwIARERERERERPbLcnF3h71U6GFSSl5tXqWmOChV83LygVKmgKSqCIAhwcHT8/3P/a2Hk5uxaallTuLu7o06dOgCKW940a9YMy5cvx6hRo3Sm7969O27fvo3ffvsNe/fuxbPPPouxY8fis88+k9L06NEDa9aswcmTJ/HMM89I0+fOnYspU+QtqerUqQOFQoGrV6+iT58+pfK7evUqfH19ERgYKE1zlPZDMYVCYbBlT8+ePVGjRg18//33CAsLg0ajQePGjaFWq6U0Q4cOxfjx4/H1119j3bp10hhDla1r1664du0a0tLS4OjoCB8fH4SEhKBWrVp6l3nnnXcwbdo0vPTSSwCKu6Ddvn0bCxYskAJG2lJSUvDBBx/gyJEjOHXqFOrVq4e6deuibt26KCgowI0bN8yybaZgwIiIiIiIiIgeWX3aPl/u7mIj2g+Cu7s7AgMDkZycjJycHDRq1AhAcWucwsJCODg4QKFQVFp5lUolZsyYgcmTJ2PIkCGlxhQSBQYGIjo6GtHR0Xj66afxzjvvyAJGo0ePRuPGjdGrVy/s3LkTHTp0AADpte/a/P390aVLF3z77beYNGmSLM/ExESsXbsWw4YNK/d2pqam4vr16/j++++l7ma6xgt68cUX8frrr2P37t1Yt24dhg0bJs2rX78+CgsLcf78ebRo0QIAEBMTg4cPy24Bpk9AQAAUCgUOHDiA5ORk9OrVS2/anJycUi2QVCqV3iDZpEmTMGnSJFSvXh2nT59GQUGBNK+wsFDq4mhNHPSaiIiIiIiIqJzEIIFSqYQgCBYZ+HrAgAFQqVT45ptvdM5///338euvvyImJgZ///03duzYoXP8obfeegsffvghXnjhBYMDOgPA4sWLkZ+fj27duuHIkSO4c+cOdu/ejS5duqBatWqYP39+ubfH19cX/v7++O677xATE4MDBw5g8uTJpdK5u7ujd+/emDVrFq5evYrBgwdL8xo0aIDOnTvj9ddfx59//onz58/j9ddfh6urqyyQNX36dFmgSZeVK1fi1KlTuHnzJtasWYMBAwZg0qRJsvGXnn32Wdk4Uj179sT8+fOxc+dOxMXFYcuWLfjiiy90tsjau3cvbty4gbFjxwIAWrVqhWvXrmHXrl347rvvoFKp9I71ZEk2FTBasmQJmjZtCi8vL3h5eSEqKgq7dv03OFleXh7Gjh0Lf39/eHh4oF+/fkhKSrJiiYmIiIiIiMgeaTQaCIIAlUoF4L/AkSUCRg4ODhg3bhw++eQTZGdnl5rv5OSE6dOno2nTpmjfvj1UKhXWr1+vc10TJ07EBx98gB49euDEiRN686xbty7OnDmDWrVqYeDAgahduzZef/11dOrUCSdPnoSfX9nd+vRRKpVYv349zp49i8aNG2PSpEn49NNPdaYdOnQoLl68iKeffrrUW91+/PFHBAcHo3379ujTpw9ee+01eHp6wsXFRUqTkJCA+Ph4g+W5fv06+vfvj0aNGmHu3LmYOXOmrHUWANy8eRMpKSnS/19//TX69++PMWPGoGHDhpgyZQreeOMNzJs3T7Zcbm4uxo0bh2XLlknHTPXq1fH1119jxIgRmD9/PlavXq235ZglKQRLHM2VZPv27VCpVKhbty4EQcDq1avx6aef4vz583jssccwevRo7Ny5E6tWrYK3tzfGjRsHpVKJ48ePG51HRkYGvL29kZ6eDi+v0n1ULUWj0SA5ORlBQUEGB9aiqoX1ZrtYd7aLdWe7WHe2ifVmu1h3tot1Vzny8vIQGxuLyMhIWQChvMRxZvz9/eHl5YW0tDQ8fPgQ9evXh4ODg9m6pJHx/v33X4SHh2Pfvn149tlnjV7OHupO3/FuSszDpsYw6tmzp+z/+fPnY8mSJfjjjz9QvXp1LF++HOvWrZMG7Fq5ciUaNmyIP/74A0899ZQ1ikxERERERER2SBxjRgziiYEFG2qTYXcOHDiArKwsNGnSBAkJCXj33XdRs2bNKvGKeltkUwEjbUVFRdiwYQOys7MRFRWFs2fPoqCgAJ07d5bSNGjQABERETh58qTegFF+fj7y8/Ol/zMyMgAUR/ENjeBubmLzRmuWgUzHerNdrDvbxbqzXaw728R6s12sO9vFuqsc4n6srHGGCgsLAfw3dpEYOBLzAVDqN5mXWq3GjBkzcOvWLXh6eqJNmzZYs2aN1OLLFLZed+JxXjK2Ycp1xOYCRn/99ReioqKQl5cHDw8PbNmyBY0aNcKFCxfg5OQEHx8fWfrg4GAkJibqXd+CBQvwwQcflJp+//595OXlVXbxjabRaJCeni678FDVx3qzXaw728W6s12sO9vEerNdrDvbxbqrHAUFBdBoNCgsLJSCPRUhvu5dpVLJglAFBQVSEElshWSr3ZpszbPPPovz58+Xmm5qfdtD3RUWFkKj0SA1NRWOjo7S9MzMTKPXYXMBo/r16+PChQtIT0/Hxo0bER0djcOHD5d7fdOnT5eNvp6RkYHw8HAEBgZafQwjhUKBwMBAfijYENab7WLd2S7Wne1i3dkm1pvtYt3ZLtZd5cjLy0NmZiYcHBzg4FB5j8JKpRIajUZap1KplK1f+2GdbIst152DgwOUSiX8/f1lYxiZMn6X2QNGV69exfr163H06FHcvn0bOTk5CAwMRPPmzdGtWzf069cPzs7ORq/PyckJderUAQC0aNECp0+fxqJFizBo0CCo1WqkpaXJWhklJSUhJCRE7/qcnZ115q9UKq1+MVYoFFWiHGQa1pvtYt3ZLtad7WLd2SbWm+1i3dku1l3FKZVKKBQK6aeitFugaDQaWZc0hUIBQRCkfGy1lcqjyh7qTjzOS143TLmGmO1qc+7cOXTu3BnNmzfHsWPH0Lp1a0ycOBHz5s3Dyy+/DEEQMHPmTISFheHjjz+WjSNkCo1Gg/z8fLRo0QKOjo7Yv3+/NO/69euIj49HVFRUZW0WERERERERkRQwcnFxgbe3t/Qgbqtj3hCVZLYWRv369cM777yDjRs3lhpXSNvJkyexaNEifP7555gxY4bBdU6fPh3du3dHREQEMjMzsW7dOhw6dAi///47vL29MWrUKEyePBl+fn7w8vLCW2+9haioKL4hjYiIiIiIiCqVOC6OSqWStVri4ORkL8wWMLpx44ZR/f2ioqIQFRWFgoKCMtMmJydj2LBhSEhIgLe3N5o2bYrff/8dXbp0AQAsXLgQSqUS/fr1Q35+Prp164Zvv/22wttCREREREREpC07OxvAf118xIARWxiRvTBbwMjUwaGMSb98+XKD811cXPDNN9/gm2++MSlvIiIiIiIiIlNptyzSHsOIyB5YdMS0hIQE9O/fH4GBgfDz80PPnj1x69YtSxaBiIiIiIiIqMIcHR1lb0Oz5hhGcXFxUCgUuHDhQqWmLa+cnBz069cPXl5eUCgUSEtL0zmNqjaLBoxGjhyJxo0b4/Dhwzhw4ACCg4MxZMgQSxaBiIiIiIiIqMLEt6GJzDWG0fDhw6WWTI6OjoiMjMS7776LvLw8KU14eDgSEhLQuHHjSs27pDt37mDkyJEICwuDk5MTatSogQkTJiA1NVWWbvXq1Th69ChOnDghDSmja1pVdvToUfTq1QthYWFQKBTYunWrbH5BQQGmTp2KJk2awN3dHWFhYRg2bBju3btncL01a9aUva1P/Bk7dqyURhybOTw8HGvXrpUtv2HDBvTs2bPSttMQswaMJkyYIPXrBICYmBhMnToVjRo1wuOPP44JEybg+vXr5iwCERERERERUaXTfvU6UBww8vPzM+m15cZ67rnnkJCQgFu3bmHhwoVYtmwZZs+eLc1XqVQICQmRtXiqbLdu3ULLli3xzz//4KeffkJMTAyWLl2K/fv3IyoqCg8ePJDS3rx5Ew0bNkTjxo0REhIChUKhc1pVlp2djaZNm+od8iYnJwfnzp3DrFmzcO7cOWzevBnXr19Hr169DK739OnTSEhIkH727t0LABgwYAAAYPv27Vi3bh327NmDTz75BK+++ipSUlIAAOnp6Zg5c6bFhuExa8CoevXqaNGiBbZt2wYAGDRoEFq3bo1p06bh7bffRq9evTB06FBzFoGIiIiIiIio0gmCIAsOKZVKeHt7Q6VSVXpezs7OCAkJQXh4OHr37o3OnTtLgQagdDezhw8fYujQoQgMDISrqyvq1q2LlStX6lx3UVERRo4ciQYNGiA+Pl5vGcaOHQsnJyfs2bMHHTp0QEREBLp37459+/bh7t27mDlzJgCgY8eO+Pzzz3HkyBEoFAp07NhR5zRdbt68iRdffBHBwcHw8PBAq1atsG/fPmn+jBkz0Lp161LLNWvWDHPnzgVQ/Pa68ePHw8fHB/7+/pg6dSqio6PRu3dvQ7u4lOeeew4ffvgh+vTpo3O+t7c39u7di4EDB6J+/fp46qmnsHjxYpw9e9bgfgwMDERISIj0s2PHDtSuXRsdOnQAAFy9ehUdO3ZEy5YtMXjwYHh5eSE2NhYA8O6772L06NGIiIgwaVvKy6wBo3feeQe7du3CkiVL0LdvX4wePRrz589HQUEBioqK8Mknn+Drr782ZxGIiIiIiIiIKl3JLmli6x5XV1ez5nv58mWcOHECTk5OetPMmjULV65cwa5du3D16lUsWbIEAQEBpdLl5+djwIABuHDhAo4ePao3EPHgwQP8/vvvGDNmTKntCwkJwdChQ/Hzzz9DEARs3rwZr732GqKiopCQkIDNmzfrnKZLVlYWevTogf379+P8+fN47rnn0LNnTykAM3ToUPz555+4efOmtMzff/+NS5cuScPdfPzxx1i7di1WrlyJ48ePIyMjo1R3slWrVpmlhVN6ejoUCgV8fHyMSq9Wq7FmzRqMHDlSKk+zZs1w5swZPHz4EGfPnkVubi7q1KmDY8eO4dy5cxg/fnyll1sf87VX+/8iIyOxa9curF27Fh06dMCECRPw2WefVfnmZ0REREREVUF8fDzOnj2Ldu3aITAw0NrFIbI7ZzZ+izObl5SZLrhOU/SZ+994MoIg4MS3b+P3u//IpgEKSI+7xf+iZd/RaNl/TLnLuGPHDnh4eKCwsBD5+flQKpVYvHix3vTx8fFo3rw5WrZsCaB43JySsrKy8PzzzyM/Px8HDx40OKbQP//8A0EQ0LBhQ53zGzZsiIcPH+L+/fsICgqCm5sbnJycEBISIqXRNa2kZs2aoVmzZtL/8+bNw5YtW7Bt2zaMGzcOjz32GJo1a4Z169Zh1qxZAIC1a9eidevWqFOnDgDg66+/xvTp06WWQYsXL8Zvv/0my8fb2xv169fXW47yyMvLw9SpU6VWQcbYunUr0tLSMHz4cGlat27d8PLLL6NVq1ZwdXXF6tWr4e7ujtGjR2PVqlVYsmQJvv76awQEBOC7777DY489Vqnboc0ig16npqZi6NChOH36NM6fP4+oqChcunTJElkTEREREdm0/fv3Y/bs2Th//ry1i0Jkl/JzMpGVklDmT066fGBnQRCgznwoS5OdmojsVK3l/v/f+TmZFSpjp06dcOHCBZw6dQrR0dEYMWIE+vXrpzf96NGjsX79ejz++ON49913ceLEiVJpBg8ejOzsbOzZs0cWLHrzzTfh4eEh/ZTcZnPKysrClClT0LBhQ/j4+MDDwwNXr16VdfEaOnQo1q1bJ5Xnp59+koa6SU9PR1JSEp588kkpvUqlQosWLWT59OnTB9euXau0chcUFGDgwIEQBAFLlpQdfBQtX74c3bt3R1hYmGz6nDlzEBMTg7/++gt9+vTBggUL0LlzZzg6OuLDDz/EsWPH8Oqrr2LYsGGVtg26mDVgtH//fgQHByMwMBDVq1fHtWvXsGLFCixYsACDBw/Gu+++i9zcXHMWgYiIiIjIpondTnjfTGQezm6e8AgILfPHzdtfWkYQBAiCAGdPX1kad/8QuPtrLff//3Z286xQGd3d3VGnTh00a9YMK1aswKlTp7B8+XK96bt3747bt29j0qRJuHfvHp599llMmTJFlqZHjx64dOkSTp48KZs+d+5cXLhwQfoBgDp16kChUODq1as687t69Sp8fX0r3ApyypQp2LJlCz766CMcPXoUFy5cQJMmTaBWq6U0gwcPxvXr13Hu3DmcOHECd+7cwaBBgyqUb0WIwaLbt29j7969Rrcuun37Nvbt24dXX33VYLpr165hzZo1mDdvHg4dOoT27dsjMDAQAwcOxLlz55CZWbFgpCFm7ZI2duxYvPvuuxg7dix2796NiRMn4tSpU+jUqRPOnTuHuXPn4vHHH+eb0oiIiIiItGg0GiQnJ6OoqAguLi4AUOq11URUOVr2H2NydzGxpU37CV+hevXq0rTc3FyoVCo4OztDEAQUFhbCwcGhUodkUSqVmDFjBiZPnowhQ4boHTMpMDAQ0dHRiI6OxtNPP4133nkHn332mTR/9OjRaNy4MXr16oWdO3dKgy4HBQUhKChIti5/f3906dIF3377LSZNmiTLMzExEWvXrsWwYcMqvJ3Hjx/H8OHDpe5kWVlZiIuLk6WpXr06OnTogLVr1yI3NxddunSRyuvt7Y3g4GCcPn0a7du3B1A8qPe5c+fw+OOPV6hsuojBon/++QcHDx6Ev79/2Qv9fytXrkRQUBCef/55vWkEQcAbb7yBL774Ah4eHigqKkJBQYGUN1C8feZi1hZGCQkJeP755+Hi4oLnnnsO9+/fl+Y5Oztj/vz5ege7IiIiIiJ6VKWkpCApKQkpKSlSVxHtV1YTkXVpNBoAkL0lzZIGDBgAlUql9/Xq77//Pn799VfExMTg77//xo4dO3SOP/TWW2/hww8/xAsvvIBjx44ZzHPx4sXIz89Ht27dcOTIEdy5cwe7d+9Gly5dUK1aNcyfP7/C21W3bl1s3rwZFy5cwMWLFzFkyBBpX2sbOnQo1q9fjw0bNpR68/pbb72FBQsW4Ndff8X169cxYcIEPHz4UBbM2rJlCxo0aGCwLFlZWbJWVrGxsbhw4YLUPa6goAD9+/fHmTNnsHbtWhQVFSExMRGJiYmyFlHPPvtsqfGmNBoNVq5ciejoaGmwdF1++OEHBAYGomfPngCAtm3b4sCBA/jjjz+wcOFCNGrUyOgBtsvDrC2MevXqhf79+6NXr144duwYevToUSqNOQdoIiIiIiKyFTExMYiIiEBubi6uXLkCb29veHp6St9Yp6SkWLmERCQSWxhZ62VODg4OGDduHD755BOMHj261HwnJydMnz4dcXFxcHV1xdNPP43169frXNfEiROh0WjQo0cP7N69G23atNGZrm7dujhz5gxmz56NgQMH4sGDBwgJCUHv3r0xe/Zs+Pn5VXi7vvjiC4wcORJt2rRBQEAApk6dioyMjFLp+vfvj3HjxkGlUqF3796yeVOnTkViYiKGDRsGlUqF119/Hd26dYNKpZLSpKenl9nT6ezZs+jSpYv0/+TJkwEA0dHRWLVqFe7evYtt27YBQKnWSwcPHkTHjh0BADdv3ix1/d63bx/i4+MxcuRIvfknJSVh/vz5svGnnnzySbz99tt4/vnnERQUhNWrVxvchopSCGYctUqtVmPZsmW4du0amjVrhpEjRxqMnlUFGRkZ8Pb2Rnp6utF9D81BbIYcFBRktag1mY71ZrtYd7aLdWe7WHe2ifVmHoIgoHXr1ujduzfi4uLQt29fFBYW4oUXXgBQ/K1yo0aN8P3335c7D9ad7WLdVY68vDzExsYiMjJS6upZXmq1Gv/88w8CAgIQHBwsTc/JyTF7lzQyjUajQcOGDTFw4EDMmzfPqGXsoe70He+mxDzMGr1xcnLCW2+9Zc4siIiIiIhsXkFBAQoLC/HYY4/h0KFDOHbsGObOnSvN9/PzYwsjoipE7CZlq8EEe3b79m3s2bMHHTp0QH5+PhYvXozY2FgMGTLE2kWzOWYLT//xxx9Gp83JycHff/9trqIQEREREVVpWVlZKCwsxOXLl/HNN9/ggw8+kLUkCQgI4BhGRFWItbukkX5KpRKrVq1Cq1at0LZtW/z111/Yt2+fzjGcyDCzBYxeeeUVdOvWDRs2bEB2drbONFeuXMGMGTNQu3ZtnD171lxFISIiIiKq0v79918AQEhICOrWrSsbawMofkPRw4cPkZ2dDbVaDTOOKkFERhDPQV1dBHl+Wld4eDiOHz+O9PR0ZGRk4MSJE9Ib08g0ZuuSduXKFSxZsgTvvfcehgwZgnr16iEsLAwuLi54+PAhrl27hqysLPTp0wd79uxBkyZNzFUUIiIiIqIq7e7duwCAatWq6ZwfFBSEp556CrGxsSgqKkK9evX0vkqbiMxPX5c0tjgie2K2gJGjoyPGjx+P8ePH48yZMzh27Bhu376N3NxcNGvWDJMmTUKnTp0qZSR1IiIiIiJbJrYwql69us75TZs2Rbdu3VBUVASg+F6biMqnMloAsUsaVXWVcZxb5JVlLVu2RMuWLS2RFRERERGRzREDRvpaGNWoUQO5ublSVzU+pBKZTjx/1Gp1hVvoGeqSRlQV5OTkAKjYFwxV+x33RERERESPgJiYGLi6usLHx0fn/IYNGyIjIwN37txBYWGhZQtHZCccHBzg5uaG+/fvw9HRsULBnry8PGg0GhQUFCAvL0+anp+fLwV07eHV7I8qW647QRCQk5OD5ORk+Pj4lBoTzxQMGBERERERWVm9evUQGBho8MHEy8sLXl5eePDgAQfVJSoHhUKB0NBQxMbG4vbt2xVaV05ODtLS0lBYWAgXFxdpekFBAYDiVh2CIECj0UCpVNpc0OFRZw915+Pjg5CQkAqtgwEjIiIiIiIrGzJkiPSgaYitPrgQVRVOTk6oW7cu1Gp1hdazc+dOLFu2DB9++KHsde23bt2CQqFAZGQkNBoNUlNT4e/vz65rNsbW687R0bFCLYtEDBgREREREVmZqS2G2MKIqPyUSqWsVVB5ZGdnIzExEc7OzrJ1qVQqCIIAFxcXaDQaODo6wsXFxSaDDo8y1l0xi2z5rVu3LJENEREREZHNYushItuRn58PoLjFUkkM6JK9sEjAqE6dOujUqRPWrFkjGxCMiIiIyJ5lZmZi27ZtOHbsmLWLQnaCQSWiqkHs0ubs7CybrlAoGDAiu2GRgNG5c+fQtGlTTJ48GSEhIXjjjTfw559/WiJrIiIiIquJiYlBtWrV4ObmhuzsbGsXh4iIKom+FkYM6pI9sUjA6PHHH8eiRYtw7949rFixAgkJCWjXrh0aN26ML774Avfv37dEMYiIiIgs6vr169i5cydUKhXu3r1r7eJQFcYxjIhsC1sY0aPAoqM3OTg4oG/fvtiwYQM+/vhjxMTEYMqUKQgPD8ewYcOQkJBgyeIQERERmUVWVhaGDBmCn376CRs3boRKpUJubi6ysrKsXTSqwoxpmcDWC0RVg9jCqGTACGBAl+yHRQNGZ86cwZgxYxAaGoovvvgCU6ZMwc2bN7F3717cu3cPL774oiWLQ0RERGQWeXl5uHz5Mm7fvo2AgAAEBAQAAFtVU6XhAymRdYmtRku+QYstjMieOFgiky+++AIrV67E9evX0aNHD/z444/o0aOHdHJFRkZi1apVqFmzpiWKQ0RERGRWRUVFAIpfy+vn54egoCCkpKRIXRiIiMi2xcbGAgBcXFxk09kKkOyJRVoYLVmyBEOGDMHt27exdetWvPDCC6UisUFBQVi+fLnB9SxYsACtWrWCp6cngoKC0Lt3b1y/fl2WpmPHjlAoFLKfN998s9K3iYiIiEif9PR06W9HR0colUqcPXsWr7/+Ok6dOmXFklFVZWyLBD6MElUNoaGhcHJygoODvA0GWxiRPbFIC6O9e/ciIiKiVJBIEATcuXMHERERcHJyQnR0tMH1HD58GGPHjkWrVq1QWFiIGTNmoGvXrrhy5Qrc3d2ldK+99hrmzp0r/e/m5la5G0RERERkQFpaGgBg/PjxeOWVVwAUj3Px8OFDaR5RSQwGEdkOhUIBT09PnfMYMCJ7YZGAUe3atZGQkICgoCDZ9AcPHiAyMlJqtl2W3bt3y/5ftWoVgoKCcPbsWbRv316a7ubmhpCQkIoXnIiIiKgcxKBQWFiYNCCqn58fgOJuakQVxQdSIuvKycmRNVoQiYFfnqNkDywSMNJ3smRlZZXq82kKsbm3eAMmWrt2LdasWYOQkBD07NkTs2bN0tvKKD8/XxrhHgAyMjIAFN/MWfOGTqPRQBAE3lTaGNab7WLd2S7Wne2y57oTA0ZeXl7S9on3ItnZ2Ta9zfZcb9YkCAIUCoXR+7U896qsO9vFuqt6srOz4e7urrdOxDpjvdkmez7nTNkmswaMJk+eDKA4yvr+++/LgjZFRUU4deoUHn/88XKtW6PRYOLEiWjbti0aN24sTR8yZAhq1KiBsLAwXLp0CVOnTsX169exefNmnetZsGABPvjgg1LT79+/j7y8vHKVrTJoNBqkp6dDEIRSXfmo6mK92S7Wne1i3dkue6478e05Go0GycnJAP57BXNSUpI0zRbZc71ZU1FRkex40Sc7OxtAcUv9kmOnlIV1Z7tYd1VPVlYWfHx8Sp2z4rU+OTkZgiCw3myUPZ9zmZmZRqc1a8Do/PnzAIq/Mfnrr7/g5OQkzXNyckKzZs0wZcqUcq177NixuHz5Mo4dOyab/vrrr0t/N2nSBKGhoXj22Wdx8+ZN1K5du9R6pk+fLgW2gOIWRuHh4QgMDISXl1e5ylYZNBoNFAoFAgMD7e4AtWesN9vFurNdrDvbZc91J3a3j4yMlLrki62OVCpVqW76tsSe682aHj58CKVSWeaxIQgCsrOz4evrC1dXV5PyYN3ZLtZd1ZOXlwdvb+9S56xarUZeXh4CAgKklzCx3myPPZ9zpvTyMmvA6ODBgwCAESNGYNGiRZUWgBk3bhx27NiBI0eOoHr16gbTtm7dGgAQExOjM2Dk7OwsjS2gTalUWv3AUCgUVaIcZBrWm+1i3dku1p3tste6E7vN+/r6Stvm4eEBoHjcC1vfXnutN2sT96sh4vzy7n/Wne1i3VUdhYWFyMvLg4eHR6n6EMcwEuuL9Wa77LXuTNkei2z5ypUrKyVYJAgCxo0bhy1btuDAgQOIjIwsc5kLFy4AKH7tIREREZElpKWlwcHBQTYgqtg1Pycnx1rFoirM1AFyLTGgrkajwaZNm7Bv3z6z50VkCzZv3oyuXbvixIkTAHS/jZuDXpM9MVsLo759+2LVqlXw8vJC3759DabVN75QSWPHjsW6devw66+/wtPTE4mJiQAAb29vuLq64ubNm1i3bh169OgBf39/XLp0CZMmTUL79u3RtGnTCm8TERERkTHS09Ph7e0te006A0Zka5KSkuDn5wdXV1cUFhaaPGYSkT0RBAGrVq1CYmIi/v77bwCGA0ZE9sBsV33tmyRvb+9KWeeSJUsAAB07dpRNX7lyJYYPHw4nJyfs27cPX375JbKzsxEeHo5+/frhvffeq5T8iYiIiIyRlpZW6v7H2dkZSqWSASPSy5gHTUs+jK5cuRIpKSmIjo7GrVu3UK9ePYvlTVSVrFmzBp9++qnUakgMnmq3IhWxhRHZE7MFjFauXKnz74oo66QLDw/H4cOHKyUvIiIiovJKTU1FeHi4bJpCoYC7uzsDRlQpzP0wqtFosGHDBiiVSkRHR0sDuRM9ipRKJQRBgIuLC/Ly8pCQkABAdwsjEQNGZA/sa/QmIiIioiqgVatWeOKJJ0pNd3V1lV6LTqTN2IdLS7Uw0mg0cHNzQ3BwMFxdXfnwS4+0gIAAAMDUqVMBAPfv3wfALmlk/8zWwqh58+ZGnyznzp0zVzGIiIiILG7UqFE6uyqwhRHZCgcHB6hUKoSEhMDZ2Rm5ubnIz89HcnIyAgIC4Orqau0ikhUdPXoUH3zwAQYPHoxRo0ZZuzhml5ubCwDw8/ODg4MDUlJSAHDQayoOHv7111948skn4e7ubncBQ7MFjHr37m2uVRMRERFVafoeFNzc3PDgwQMLl4ZshSkPGpZ4GFWr1XBycoKzszMAID4+Hjk5OSgoKECtWrXMnj9VXbdu3UJycjIuXrxo7aJYRF5eHoDia3hQUJB0HecYRo+2pUuXIicnB88++yxu3ryJRo0awdHR0drFqlRmCxjNnj3bXKsmIiIiqtIEQdD58O/m5oZ///3XCiUiMp1arYajo6MUMBJbx3l4eFizWFQFiMdCWlqadQtiIWLAyMXFBUFBQbhx4wYA3QEjEQNG9s/X1xcXLlxA27Zt4eLiYnetiwAzBoyIiIiIHmX6AkYcw4h0qYpjGBUWFsLJyQlOTk6yeXwQptjYWADA7du39QbI7Ul+fj6A/wJGly9fBgCdXTPZwujR0bZtW9SvXx8BAQFITU1FYWGh9AY9e2G2rfHz88ONGzcQEBAAX19fgxcRNs0mIiIie2HoIcHd3R2FhYUoKCiwu2brVHFVqUuaWq0GADg5OUl5OTs7Iz8/nw/ChJiYGHh6eqKoqAiJiYkIDQ21dpHMShzDyMXFBa1atYJKpcKuXbsMdkkj+6dQKKBQKKBSqQDALt8mabaA0cKFC+Hp6Sn9zROHiIiIHiX6WhgBxd05vL29LV0ksgOWuqfWDhh5eHigfv36EAQBN27cgEajsUgZ7FFRURF+++03uLm5oX379lCpVFAqbevF1Xl5eYiNjcULL7yA/v374+bNm3YfMNLukqZ97WYLo0ebWMdiq6LCwkJrFscszBYwio6Olv4ePny4ubIhIiIiqlIMPSSIAaPs7GwGjEimqj1cFhQUAIDUHc3FxUWaVtXKaktu3boFHx8feHl54cqVK/Dy8kJkZKQ0Py8vD/n5+VX6+nDz5k0UFRXB398fAODl5WXlEpmfGDBydXXFc889h4MHDwKA1LJEF54n9q9kwMgeWxhZJJytUqmQnJxcanpqaqrBk4ws5++//8a2bds4rgIREVEFiTeQulqC1K5dG1999RWysrIsXSyyM5bskiZiy4mKu3TpEj744ANp/2pfJ3Jzc/HPP/8gLi5Oml8V+fr6YtSoUWjVqhUAICQkxMolMj8xYCQOAD9//nwcOXIEwcHBpdLyPHl0PAoBI4uMyKTvZMnPzy81iB5Zx9y5c3H16lWEh4ejefPm1i4OERGRXfL19YWvr6/NdUEhy6hKQzgYChixS1r5Xbx4EcnJyahRowYSEhJk14Jbt25J+7YqD5zr7e2Njh07IigoCMnJyXb5kFxSXl4eFAqFdD44ODjAx8dHZ9qqdB6TebFLWgV99dVXAIpPmh9++EH2Cs6ioiIcOXIEDRo0MGcRyEjihxVvAIiIiCrGUAujxo0b4+7du4/EN/JkHpYew0h7cHbxfpEtJ0x37949JCcnY9++ffDx8UFQUBCSkpKkbn779+9HQEAAFApFlX/rmPi8YM8D/ZaUl5dn9GvT2cLo0cEWRhW0cOFCAMU7cunSpbLuZ05OTqhZsyaWLl1qziKQiezxICciIrIGXQ8W/IKG9DH14dLcD6MlxzAC2MKovARBwODBg+Hs7IysrCxUq1YNQHEwTtzPycnJcHd3h6+vL/Ly8qp00Eg89h7FgJEpGDCyf+J5yhZG5RQbGwsA6NSpEzZv3gxfX19zZkeVwB4PciIiIksy9JDAB26qKGu8JU2bUqnkg7CJFAoFmjVrhkOHDgEAXn75ZQDFAaOcnBwAwC+//AKVSoUvvvhCChhVVeL1S6lUQqlUMmBUAlsYPTo0Gg0UCgUUCgVUKpVdngsW6UB/8OBBBotshPgtBxEREVUMWxiRqapSixJ9ASOxyxSZ5oknnpD+fvbZZwEUB4w0Gg0yMjJw69Yt1KxZs0odA/owYGQYA0aPDu2WgCqVyi4bX1hsNLV///0X27ZtQ3x8fKlR/7/44gtLFYP0EC9oVfmNDERERLbA0EMCx4ChymKpt6Rpj2EEFB/DDHia7rHHHgMAuLi4SGOYifv24MGDEAQBdevWldJX5WuEWDalUgkHB4dHJmDk5eVlVFpbCPpR5dAOGB04cACJiYmYN2+elUtVuSwSMNq/fz969eqFWrVq4dq1a2jcuDHi4uIgCIIs2k7WI37wi6+MJCIioophCyMyRVULELCFUeVydHREgwYNpPGLgP/GANq5cycAwMvLyyZap4jXL4VCAaVS+Uh84ZyXl4egoCCj0tpCHVLl0A4YnTp1CteuXbO7gJFFuqRNnz4dU6ZMwV9//QUXFxds2rQJd+7cQYcOHTBgwABLFIHKIF74c3NzrVwSIiIi22ZMCyMGjEgXU97AZG6GAkY8fk2nUqnwf//3f9JLgYD/xg51dnYGAERFRdlE6xTtFkb2Om5LSRz0mnTRDhi5u7vbZZ1bJGB09epVDBs2DEDxK+dyc3Ph4eGBuXPn4uOPP7ZEEagM4sHNFkZEREQVI36m6nrw46DXVFks1SWNg15XDl1vPfPw8ABQ/IWtg4MDIiIibKJ1inYLIwcHBwiCYNfXNEEQOIYR6SQIgvRFkKOjo10GTy0SMHJ3d5c+dEJDQ3Hz5k1pXkpKiiWKQGUQD262MCIiIqoc7JJG5sAWRrZHEASdASN3d3cAQFJSEkJDQ6Xrg7hMVaXdwkgs87179+xywF+guCVYUVERA0ZUivZ57eDggMLCQrurd4sEjJ566ikcO3YMANCjRw+8/fbbmD9/PkaOHImnnnrKEkWgMogXeLYwIiIiqhgOek2mqorHg/jmXLYwqjh9rQ5VKhVUKhWSk5MRFhamM01VpN3CSByHKTU1FQ8fPrRmscxGfD4yNmCUn58PAMjKyjJbmahqKBkwAuzvCyGLDHr9xRdfSCfMBx98gKysLPz888+oW7cu35BWRbCFERERUeViCyMylSnBAmt1SeOg16bTbpFTUkFBAXJzc0sFjKryPtbeHu1yurm5WatIZmVqwEgMHNhC8I8qRjtgJAZPCwsLpb/tgUUCRrVq1ZL+dnd3x9KlSy2RLZlAbGHEgBEREVHFGHrQ4xhGVFGW7pImvvpdpFQqefyayNC4ZmlpaQCAkJAQWZqqHDDSbmEktkQDqnaZK8LUgJGrqyuA0ucO2R+NRlMqYGRv4xhZpEsaVX3iTQEDRkRERJVD36DXHAOGSqqKD9qGWhgBVbPMVZWhgJHYjSswMFDnMlWRdgujiIgIBAcHy6bbm4yMDJPSiy2M7HVMJ/qPri5p9lbvZmth5Ovra/Q3IA8ePDBXMchIhYWFUCgUDBgRERFVkKGHQ4AtNKhymPvhXN8YRtqt5Oyp24U5lfXmxMDAQISGhupNU9WIrSrEsorHiL0GjPLz8+Hm5gZnZ2ej0isUCiiVSrtraUKl6eqSZm/1braA0ZdffmmuVZMZqNVqqFQqDnpNRERUQWU9NHHQYNLHmGCBtd+SxoHbTafdhaukPn36oE+fPtL/ttCCS7sbDmAbZa6IevXqYdmyZahWrZrRyzg4ONhd4IDkSgaC2cLIRNHR0eZaNVUyQRCgVqvh5OTEFkZERESVhC2MyJaJb3oqOQ6LvQcHzMHQoNdlLVMVCYIg2xZ7PybE67Up9adSqRgwsnMlz2sxYGRv9W6RQa+B4h23detWXL16FQDw2GOPoVevXmzKWgUUFhZCEASoVCoGjIiIiCqorIcmjmFEJZXnQbsqdEkj45TVTVVbVe6SVlhYiMLCwkeuhZGhFmL6qFQqKehK9qnkea39ljR7YpGAUUxMDHr06IG7d++ifv36AIAFCxYgPDwcO3fuRO3atS1RDNJDvCFwcHBglzQiIqJKYqiFkb3dUJLlmDugII7JwS5plac8AaOqsn+3bt2Ka9euoVWrVigqKoK3tzfc3NxkLc/sPYhYnhZGDg4O0Gg0VaYeqfLpCxjZWwsji7wlbfz48ahduzbu3LmDc+fO4dy5c4iPj0dkZCTGjx9viSKQAdqvTc3OzkZaWhouXbpk5VIRERHZJo5hROVlSjDIHMfQlClT8NRTTyE2NrbMt6TZa3DAHEwJGJVcxpoEQcAnn3yCdevW4d1330VSUhKcnZ0f2RZGpnZJA+wveED/4RhGlejw4cP4448/4OfnJ03z9/fH//3f/6Ft27aWKAIZoB0wSkpKQvv27aFSqXD+/Hkrl4yIiMh2cQwjsjVxcXHIzc3F6dOnoVar4ejoWOo4Zgsj05nSpakqBV8UCgWCg4ORlZWFgoICZGZmwtnZGWq1+pEaw6g8Y1DZa/ck+o++gJG9BQkt0sLI2dkZmZmZpaZnZWWV+tbCkAULFqBVq1bw9PREUFAQevfujevXr8vS5OXlYezYsfD394eHhwf69euHpKSkCm+DPRMDRuI3nmITSnE6ERERGc/YFkb2+nBFpjPlWDBnl7SMjAwAxW87Fl+Ioi9/Bj2NZ8tjGOXl5SEoKAijRo3CmDFjpGNCu5z2HkQszxhG9ho8oP+UPC7sNUhokYDRCy+8gNdffx2nTp2SbpD++OMPvPnmm+jVq5fR6zl8+DDGjh2LP/74A3v37kVBQQG6du2K7OxsKc2kSZOwfft2bNiwAYcPH8a9e/fQt29fc2yW3RADQ+KA108//TQEQUB8fLw1i0VERGSTyno45AM36WPNYMGDBw+QmJgIT09PZGVlIS0tTWfAyN6DA+Zgq13SACAtLQ21atXChAkTAPz31jx2STPMXoMH9J9HZdBriwSMvvrqK9SuXRtRUVFwcXGBi4sL2rZtizp16mDRokVGr2f37t0YPnw4HnvsMTRr1gyrVq1CfHw8zp49CwBIT0/H8uXL8cUXX+CZZ55BixYtsHLlSpw4cQJ//PGHuTbP5okBI3d3d7i6uqJNmzYAipslExERUfnoezgUv3G2t5tKsqzKfjg/dOgQAODxxx8HUHx/qFAoSuUjviBF+wtbMsyULk1VKfiiVquRnZ0NX19faZoYRNQuX1UqszmUJ2AknidpaWnmKBJVAY9KlzSzjmHUv39/vPrqq+jWrRt+/fVXxMTE4OrVqwCAhg0bok6dOhVaf3p6OgBIYyOdPXsWBQUF6Ny5s5SmQYMGiIiIwMmTJ/HUU0+VWkd+fr7slYdiU1yNRmPVb/7EUfUtUQZx+/v374/o6GhcvnwZABAbG8tvP01kyXqjysW6s12sO9tlr3Unbo++bRO/qLlx4wYaNGggfStpK+y13qyprGNGm/iQUp46MFR3v/32GwCgXr16OHHiBCIiIhASEqK3+6S175VtiSn1q72MdlprnHepqakAAB8fHylf8aFYuyzi8WGvx0TJejCGl5cXUlNTkZGRgYyMDKhUKvj7+5uriGQGZZ1z2oEhjUYjfZYXFBRU+fPAlPKZNWD08OFDPP/88wgLC8OIESMwYsQI9OzZs1LWrdFoMHHiRLRt2xaNGzcGACQmJsLJyQk+Pj6ytMHBwUhMTNS5ngULFuCDDz4oNf3+/ftWfcW8RqNBeno6BEEwKZpdHuIYT/n5+bh//z7c3d0BFAfgdu3ahSZNmmD06NFmLYO9sGS9UeVi3dku1p3tste6E7t4p6eny76UEnl6eqKgoABFRUVISEgwaTzHqsBe682axAeP3NxcJCcnG0xbUFAAoHgsUFNbdBiqu8DAQADFX+rWrl0bo0aNgru7e6nyiAFPtVpdZlmpWE5ODoDia0JZzxfiNSMjI0Oqa8A6592tW7cAFHdDE+taLJ92/YvHb3Z2tl0eE2L9paammtSt0MPDQ2qMkJGRYXctT+xdWeeceC3Mzs6GIAiy46Sqnwe6xpfWx6wBo/379+P27dtYuXIlfvzxR8yfPx8dOnTAq6++in79+sHZ2bnc6x47diwuX76MY8eOVaiM06dPx+TJk6X/MzIyEB4ejsDAQHh5eVVo3RUhvq4yMDDQ7B8KYoDI398fQUFBCAwMhEKhQGxsLJKTk+Hn54egoCCzlsFeWLLeqHKx7mwX68522WvdPXz4EBkZGfDx8dF7L6FSqZCYmAgfHx94eHhYuIQVY6/1Zk0FBQVISUmBm5tbmfdcubm5ePDgAdzd3U2+PzNUd2Lrh4YNG6J169YAir90Fe8TRZmZmUhPT4enp6fsDcikX0pKCjIzM+Hn51dqf5aUmZmJtLS0UvvXGuedGDCqXr26dKzl5OQgLS0NKpVKmiYev66urnb5zJCbmysN/m3qOGMpKSlISEiAv7+/VZ8tyXTiOefv749FixbBz88PI0aMkOZnZmbi4cOH8PLygp+fn9RoxcPDo8qfBy4uLkanNWvACABq1KiBOXPmYM6cOThw4ABWrFiB1157DePGjcPgwYMxcuRItGjRwqR1jhs3Djt27MCRI0dQvXp1aXpISAjUajXS0tJkrYySkpIQEhKic13Ozs46A1dKpdLqN0EKhcIi5RDHUHB2dpbyCgsLQ3BwMPLy8pCZmWn1fWFLLFVvVPlYd7aLdWe77LnuDG2Xq6srgOIHLVvcdnuuN2sQ96O4XysrrS766k77frBJkybIzc2Fi4tLqXTa/7P+TWPMOWNo/1r6vNMe/kPM08XFBc7OzvD09JSmiV1x7LXVoSAIUCgU5eo+rL2MPe4be6dQKJCTk4P//e9/cHd3x8iRI6WgofhbPCfFAeE1Gk2Vr2tTymfRLXnmmWewZs0aJCYmYsGCBVi/fr30DYYxBEHAuHHjsGXLFhw4cACRkZGy+S1atICjoyP2798vTbt+/Tri4+MRFRVVadthb8TmdOJBDgDPP/88qlWrBi8vL+nDgoiIiCqH+GWVri5rRNYg3g86OzujevXq8PDw0PlQYe8DHJuDKW9Js+ab8koSB2zW/iLewcEBDRo0QLVq1aRp9n5MVCQAIC5X1ce0If3E49vDwwMXLlyQpnPQazOJjY3FqlWrsGrVKqSnp8sGqC7L2LFjsW7dOvz666/w9PSUxiXy9vaGq6srvL29MWrUKEyePBl+fn7w8vLCW2+9haioKJ0DXlMx8QZBewyFJk2awNHREXFxcYiJibFW0YiIiGyOMQ+HTk5OUCgUDBgRgPI9aFf2w7l4LDo6Okrjg+pSlQIaVZlarUZqairy8vKkFoW29pa0Bw8eAIDsLWm6iNtVFcpsDhVpOVWV6pPKJyUlBb6+vvjss88QGxuL5s2bA/gvCCjWsdiazN7egGqRgFFeXh42btyIFStW4MiRIwgPD8eoUaMwYsQIhIeHG72eJUuWAAA6duwom75y5UoMHz4cALBw4UIolUr069cP+fn56NatG7799tvK2hS7JA6opx0waty4MbKzs+Hq6orc3Fzk5uZKH3ZERERUNkMP1mL3hqysLAuWiKo6a7ZA0XU/aCh/PgDrJwgCbt26JQXhxH1rSt1Vhf2bkJAAAEaPvVMVymwObGH0aEtJScHDhw+RlJSEmjVrQqPRoKCgoNSXQwwYlcOff/6JFStW4Oeff0ZeXh769OmD3bt349lnny3Xh50xFyEXFxd88803+Oabb8pT5EeS+GGmfYPg5+cHNzc36cB/+PAhA0ZERERGMOWhSaPRoKioqFxjY9CjrbIfztVqNVQqldStQh8GjMqWnJyM/Px8qFQqFBUVSW9OtLUuaYWFhXB2di6zhZFCoYBCobDbY6IiASOeL7bv/v37AAA3NzcoFArcunUL2dnZ0gsr7L1LmlnHMHrqqadw6tQpzJs3D/fu3cO6devQuXPnKnUhJHkTZJFCoUBUVBRatWoF4L8mqURERGScsu53vL29AUD26mx6NFWFh8n8/HzZvaA+fAAu28OHDwEANWvWlLXOMSVgVBX278iRI7F69eoyW50BYMBIj6pUn1Q+KSkpACAFiLKzswFAaiGck5MDwH4DRmZtYXTmzBk88cQT5syCKsHJkycBAP/++6/sjXXOzs7SK1YZMCIiIjKOsQ8Gbm5u0hgnprzilh5t5vriVa1W63xzsL78rfUAXFRUhJiYGHh4eMgGXq4qHj58iPz8fLi7u8PDwwPZ2dnIyMgAYHtd0goKCowKFgHF22av3a7YJe3RJgaMAgMD4eLigvv370OpVCI3NxcqlUr68odd0sqBwSLbIEZL/fz8Ss0Tm6CK35QQERGRccp6OBSDRHl5eZYoDtkAawYU1Gq10cEBc+RvrLy8POTl5UGj0VSJgJEgCMjMzIRarUZAQIAUHBIfIku24C+LtQNyAHD27FkcOHAAXbt2hbu7u1HL2HMLIw56/WhLTk4GAAQEBEgNKoqKivDvv/8iPDxcOjbsNWBk1i5pZBvED9saNWqUmicGkVJTUy1aJiIiIltl7IOB2JqDb0qjqkCtVttElzTx2/7yPsBXtjt37qBTp05YtGgRgP/GBBW/kNUOwpnyljRz02g02LRpE7Zv315q3pIlS7B7924AZQ+CLrLXgJEgCBUKGLGFke1LSUmBl5eXrAWmSqVCjRo1ZMeFvXZJqxpXWrIq8UZVVzNk8cK/f/9+i5aJiIjIVpV8c4o+KpUKCoUC6enpligWVWGmPGg/yl3SNBoN0tLSAFSdh7LQ0FB4e3vjxIkT0tuTgP8CLcYE4bRZav/m5OTAw8MD/v7+pfLy9fWVhqUwtvz2GjAq+ep0U1k7wEoVd+HCBajV6jLTMWBEdksMGOkaP6F69eoA7O/AJyIiMjdjHjDEbyf5MEGAbXRJs+YDsHg/qlKpUFBQgKKiIqufO4IgoGXLlqhduzb++usvZGdnQ6lUSt1TTO2Spr1ec/rrr79w+vRpuLu7S4P2ipydnaVeBsYGjJRKpdXrwhzEAKA4wLGpGDCyfQ4ODkZ1zWSXNLJb4tgJur5V8vf3h6urK3x8fCxcKiIiIttkyoOBi4uL1NKIyJpsIWAktvYQy3n58mXExsZavBzaBEFAu3btMHr0aAClB4pWKpUmnd+WuhacO3cOf/31FwDg7t27snnZ2dlSCyNju2LZWwuj/Px8LF26FEOHDgVQfKyVB7uk2T53d3dERESUmU5sYcSAUTkkJSXhlVdeQVhYGBwcHKBSqWQ/ZF2GuqQBxUEjjmFERERkGmMHuLWnhywyP3N2SavqASPxQUx8MAOsP5aRIAgIDw/HrVu3pPFuSrbKKU/AyNz7d9OmTbhx4waA0g+46enpCAgIAAAkJiYatT57u5apVCosX74ct27dwpdffokXXnihQuuzp33zqCksLJRdc/QR4xr21jPHrG9JEw0fPhzx8fGYNWsWQkND+S1aFZOfnw9nZ2e99eLv71/qmwciIiLSzdQHAz5IUHmOAXN0SavqYxiJgQ3twJa1v3wWX7nerl07ZGZmIjs7u1TAyNXV1ehWB5bYv4IgID09HS4uLnBzcys1Pkt6ejr27duHkSNHwsvLy6h12mPA6J133kFoaCjatWtX4TGM2MLIdhkbMLLXFkYWCRgdO3YMR48exeOPP26J7MhEeXl5Bm8Q/P39cfnyZekDkYiIiMpmyiu0iQDrHg+mviXNGsQHMe1yWjtIIeavVCrh7OyM7OzsUvuoTp065V6vOSgUCjg4OKBJkyZwdnZGTk6O7KE4PT0dISEh8Pb2Nmmd9hQU0Wg0qF+/Pvz8/Cp8zNtbMO1RU1RUZFRg2l5bGFnk6T88PJwnSRWWn5+vc8Brkb+/P4qKivgWFyIiIiMY+5Y0MQ3vkcgU5gjYiG/3quqvUBcDRtpfYFr74Uz7LVpiwKUigRNLBOTUajVyc3Ph6+srfWksDlEBABkZGSYFiwD7u5aJdVgZX5bb27551DzqLYwsEjD68ssvMW3aNMTFxVkiOzJRfn6+wRsE8S0JHMeIiIiobKa+Ip0PEmTtLmnim6CM6ZIGWO+4Fcvp5eWFGjVqQKVSWf3hTLuFkbe3N3x8fODr61vu9VmiS1pGRgYAwNvbW/rSWHwJTl5eHvLy8hgwquSAkT21vnqUCILAMYzMtWJfX19ZhDw7Oxu1a9eGm5tbqeauDx48MFcxyAjGdEkDigNG5WlSS0RE9Cgy9RXa7J5GxjDHcSK2LjH2FerWbmHk5OQEZ2dnJCYmWv1BXLtFoZubG2rUqFGp6zWHtLQ0AMUBI/F4SklJgY+PjxRMMnbsIpF2oMsermWVGTACrN91kspHPA4e5RZGZgsYffnll+ZaNVWy/Px8qRWRLmxhREREZDxTWxiJy9jDQxZVjLWOAVtpYVRYWAiVSiXtJ5VKJZXdWrS7pFUGSxwD4jAT3t7ecHNzg0KhQF5eHmJjY6V6NbWFkRhYsZdrmdhKhF3SHm263syoD1sYmSg6Otpcq6ZKVlYLI/Gif/r0afTo0cNSxSIiIrJpHPSazKkyH0DFt2QZO4ZRZedvrNzcXNk5o1KppK5U1qLdJa2ymDvAoN0lzcHBAXXr1sWNGzfg4OCAlJQUABVrYWQPbLFL2pkzZ5Cbm4uoqCijAhxUNjH4Y0oLI3sLGFlkDCOVSoXk5ORS01NTU63+Kkwqe9BrV1dXAEBMTIylikRERGSzytvCiB5d1q5/W+iSJghCqYdulUoFjUZj1f1X2S2MxHWZc5u0WxgB/7UsUyqVePjwIQAGjGytS5ogCHjw4AG8vLzwzz//WL2rpr0QWxiZ8pY0e+uSZpGAkb4TpKzBlsky8vPzDbYwql+/PgCgdu3alioSERGRzTOlhZG9PGSR+ZmjVZrYwqgqd0kTy+jj4yNNqwpdQMzRwkh7veZQMmCkVCqhUChQWFiIxMREAKa1NgOAnJwcAPbzsGxrLYwUCgU2bNiA3Nxc6VyhiitPCyN7OQdEZm2r9tVXXwEoPoB/+OEHeHh4SPOKiopw5MgRNGjQwJxFoDIUFhaiqKjI4A2C+KaHzMxMSxWLiIjI5nz44Yf4999/8e677wIwfdBrImsdM+I4QMYGCawRMBK7nrm5uUnTtANG1uqCoz3odWUxd1fVkgEjoPhht7CwEDVr1sSLL76IWrVqmbROZ2dn5ObmIicnx2DPBVtR2QEjQRDMPr7TjRs3cO/ePdSpU6fSA5iPKjFgZEoLI3vrkmbWK+vChQsBFF9Ily5dKtvRTk5OqFmzJpYuXWrOIlAZxCbIhi7sDg4O8PT0lN6oQERERHKCIGDHjh3St+zG4hhGZCpzviXNlICRpbu85ObmApDfs1aFBzR76JIGFO/LoqIiREZGon///qhZs6ZJ6wwODkZaWppUT7ausrukmVt+fj4ePnwIlUoldd+0lbJXZaYMeq1UKqFUKhkwMkVsbCwAoFOnTti8ebPUUoWqDvHbmrKaIGu/ZpOIiIjkLly4IAWLTGlxwC5pBFi//k0d9NrSgc7U1FRpbJ2qFjCyxS5p4j29p6enNM3BwQE5OTlSazNTW2w5OztDpVIhLS0N1apVq7zCWklltzAS12mu8XuTkpIA/FdvDBhVDvHaYuz4blXhzY2VzSJH0cGDBxksqqLEb5TKChh5e3uzhREREZEec+fOlf42ZfwCBoyovMzxlrSqOoZRQkKCVEZdD8HWHLPFXC2MzOnixYtwcHCQBYUcHByg0WhQUFAABwcHk8ugUCigVCpRWFgoPV/YMnMEjO7du2e24KY49pQYUOWg15XDlC5pYjpzBrCtUa8W6exbVFSEVatWYf/+/UhOTi61oQcOHLBEMUiLRqOBWq1GVlYWAMNd0oDigBHfkkZERKSb9rePhYWFJj9sMWBEgPW6KIoBl6r6ljSxm03JlitiuTMyMuDv72+x8mgzRwsjc+9fXb0GxAfigoICo4+Dkry9vZGSklLmC3VsgTm6pD148AC+vr6ycX0rixgwEsf4YsCocpjSJQ0ovoZWZsAoNzcXaWlpCA0NBQD8/fffEAQBTZo0sdjnhUVaGE2YMAETJkxAUVERGjdujGbNmsl+yPI2btyIJ598El9//TUA47qk5eXlSV3YiIiI6D+urq5wdXUFwBZGZF7mfEtaVR702snJCX5+frJpAQEBUCgUyMnJsVq3NHMMeq29XlFsbCxWrVqFnTt34uzZsxVat4eHBxo2bCibpv2Gp4oEjADY/POCWq2WuhVVRsBI+9g01xvC7969CwBwd3cHUPUCRv+PvfOOk6Qo//+nJ8fd2Rxudy/sXt47soDAHQhIkIygIIokEQQVUPnhlyCggoiowFcUBRQDfEEBiZLhyMlbLu3d7u3ebc47s5Nj1++Ppfp6Zid0z3RP2Kv368WL25np7uqu6qeqPvXU88RiMWzevBnd3d2FLoos5GRJA5T3MLryyitx3HHHYcOGDeB5XhWPxkzkxcPo0UcfxWOPPYYTTzwxH5djSIAav4GBAQDSPIwAwOVyob6+Xt3CMRgMBoNRYkxPT8NqtSIQCCAWi8ny1ACYYLS3k039K9lmfD4fAOnbLvItGPE8n/Sd0uv1sNls8Hg8GB8fF1bh80k+tqSNj4/jzTffxCeffIITTjhBiOeUDYQQTE9Pz8lULa77bAUjKprLDf5fbGzfvl1RzzFxfar13uzevRvAbFwqt9tddIIRFTtKLb4PXQCSsyVNzqJRKj788EM89thj8Pl8qKqqwltvvVUwR5u8eBgZDAa0tbXl41IMidCOhhqXTGq3w+EAkNyFlcFgMBiMvR2n04mysjIAsyuSUiePLEsaQ0yh2o3H45H1+3wLRrFYLOXEnb53hQrwq4aHUeLzdTqdaG1txcknnwyO49Dc3Jz1ub1eL6LR6BxvLbEHRbbPUqvVQqvVzpv5AsdxitSrw+FATU0NAPU8fw4++GCcdtppQiDzYsvUVWpCEUWuh5FOp1NEMHrppZfw0ksvYWRkBCeddBIikQgefPBBABCy4OWLvFjWa665Br/97W/Z6lkR0d/fD2CP0ZLjYcRgMBgMBmMPkUgEbrdb6CvlDNSZhxGjGDj44IPxgx/8AMuWLZP0+3wKRjzPgxCScoWfLnrKzeqlFDzPKyYsUBKfr8/nw/XXXw+v1wuLxYKJiYmst33RRePEhERbt27FH/7wBwBAb29vliWfFZsIIUUnWEiFEKKKCEjbr1rvzdq1a3H22WfHZUkrJgoZmD4XCrUljb6fMzMzGB0dhcvlQnV1tXDufL5febGsb7/9Nl5//XW88MILWL169Rw3xyeeeCIfxWCI6O/vh81mE4JeS8mSBgATExOql43BYDAYjFKCrqZTb1w5HkYUJhjt3RR6S1pNTQ322WcfoQ3LKYPaXnKZshTRzws1QVbrGYjr1+PxYGZmBjabDW+88Qbuvvtu3HPPPVi/fr3s86YSjCoqKqDRaNDb25uTB5PVaoXL5SpZ70lxO1Jjm6Fa7TQajUKn0wneYcUmGFEPo2IrVybkBr3W6XSKiDn0/Y/FYigvL8f111+PDz74AH6/H3a7Pa/PMS+CkcPhwOmnn56PSzEk0t/fj8WLFyMQCGDnzp0ZG/bw8DAA4IMPPsCXvvSlfBSRwWAwGIySYHp6GgCELE1yBnLMw4iRDWoFWJa7JS4fghF9n1IJRoWeIBNCFN8OJw5uC0BY4LVYLGhsbASwJw6pXKi9ShSMVq9ejXvvvTerc4oR10ehtgnmghLbiZJBn4Vatj4ajcJkMhVcQE0F9TBKLNd///tfDA4OYt9990VLS0shipaWbDyMlGhD4m3CVMA9+OCDMT4+jpGRkfnnYfTQQw/l4zKMDAQCAVx33XVoaWnB1NQUDjzwQBiNRuzcuRM9PT1pj91///0BAH19ffkoKoPBYDAYJQNdsa+trQWwZ4uKFEp1FZ6hDoVqD7kIRmqTycOITsQLtQVKzvsulUgkEjexppNHm82G5cuXA9iTFQuYrYfJyUlEIhFBUEoFFYwSYxgpRaEFvFwRx9pRsn2r6WFEtwAWs4cRFYxo/B1azu7ubqxYsQKBQKCQxUtJJvuTyPLlyxURSsVhYMTno+VQS9hMRl5l34mJCbz99tt4++23s97atGHDBpx88slobGwEx3F46qmn4r7/5je/Kewjpv8df/zxCpS+9OF5Hq+99ho++OADALMD2+9///v4wx/+gEsuuSTtsfvvvz/22WcfbN++XVjlYDAYDAaDsUcwqqurAyBvksE8jBjZomSbkZsRqhCCUaqyFXqCrIaHEc02Rp+vWDCqr6+HwWAQEtcQQtDV1YXh4WFMTExkfA7UXqklGBWrh4tU6ETcaDQKAaSVQM12KhY1Ci2gpsLv988p2+bNm7Fjxw4AKEiGQynI3ZJ29NFHK6I9zMzMwGAwYN26dfjc5z4nfE7fr3nnYeTz+XDllVfi4YcfjnMr/cY3voF77rkHFotF1rn22WcfXHjhhTjjjDOS/ub444+P82rKFJ9nb4Equ83NzTjvvPOwfPlyVFdXo7q6WtLxjY2N+PTTT/HXv/4Vl112mZpFZTAYDAajZKATsPr6egDZeRgxwWjvRm79F9OWNLWR6mFUKIFCja1XBoMBPp8PPM9Dq9UKgpHVaoVWq8XChQsFwYjjuLiAwtFoNG3241QxjJSi0PWRK1QgWLBggaKCkZrvjFjUKLbnHwgEwPN8nEdMLBbDq6++Co7jhLAnxdoHyt2SVltbC41Gg1gsJtkrKRkzMzOoqqqas020EIJRXjyMrr76arz55pt45pln4HK54HK58O9//xtvvvkmrrnmGlnnOuGEE/DTn/40bUwko9GI+vp64T+1DGKpQT2DlixZgpaWFixZskTW8V/84hcBAIODg4qXjcFgMBiMYuXee+/F7373u5Tfv//++wBmJwRWq1X4txyKdbDM2DvIVjDKB8UuGKkRxylxUigWjABg0aJFGBoaQjAYFLb40IzH4tgnydi4cSMAyA5wLpVC10e2EEIQDoeFXTBKZ91T87kUs2C0c+dO7Ny5EwBQVlYGAHjuuefw85//HK+//rqwFa3YPKIocj2MqKdUKBTK6boul0tIOiVm3gpG//rXv/DAAw/ghBNOQFlZGcrKynDiiSfij3/8I/75z38qfr033ngDtbW1WL58OS677DJMTU0pfo1ShHYgbW1tiEQisg3h+vXrYTabMTo6qkbxGAwGg8EoSp5//nk8/fTTKb+nK6Tl5eWw2WxsSxoja+QID2psSStGD6NMQa9pCIr5tCWNjtHppJAu+lLBiMYhev3114WJqdVqxfXXX4+bbrop7bnpwq+cHR5yKDbBQio//vGPceCBB+KFF14AgDlZvXNlb/QwEoupWq1WEIwqKyvR2NiI448/HqeccgqA4ihvMuR6GNGdTbkKRm63u2gEo7xsSfP7/cK+fjG1tbXw+/2KXuv444/HGWecgcWLF6Onpwc//vGPccIJJ+C9995L2tGEQqG4CqWpcROzE+QbnueFFQOl8Hg8sNlsqKurw+DgoOxzazQarF69Glu2bEE4HFZceZ8PqFFvjPzA6q50YXVXupRK3VVWVmLHjh2IxWJJJ9RtbW3Yvn07mpubsW7dOmHAKOe+Cj3ukEOp1FspQZ+l3Ocqtw5S1V2214/FYqq3AzoZTicKaTSagr1DdAuqktemdiYSicBoNMLtdsNqtQr3efzxx+OTTz7BLbfcggMOOAAAYDKZ4HK5YLPZ0pZl0aJF2LVrl2rPipY9Go2WlI1oa2tDa2srysvLhXIrUX76zlFisZhQT7kKjbt378bu3buFDJ0ajUYQMPPxbkqB4ziYTCYsXLhQ8CaqrKzEfffdh/LyciFjdzG2F/FWOvruZYJuBw0Gg1nfTzQahcfjiWuLFPp+5Vq/co7Ny4z/0EMPxU033YSHH35YcJcMBAK4+eabceihhyp6ra9+9avCv9esWYO1a9eitbUVb7zxBo4++ug5v7/ttttw8803z/l8YmICwWBQ0bLJged5zMzMKLpqMTAwAJ7n8fbbb2PlypUYHx+XfQ6dTodAIIBHH31U2KLG2IMa9cbID6zuShdWd6VLqdRdRUUFQqEQent7k8a0mJqaglarhdvtxuGHHw673Y5QKISxsbGMHht00crtdsdl5ylmSqXeSgk65nS73XHxaFJBt8/IHculqjs6kZucnJTkZUQXfKemplRfQKTeNU6nM6WXESEEoVAoq7FtrvA8D7/fr+i1aX1MT0/D7/fD6XTCbDbD5XKBEIL169fjqaeewtatW/Huu+9i8eLF8Pv9MBgMiEajacvi9XphNptVe1bUps3MzEhqy8XC4YcfjgMPPBC7d++Gy+VCb2+v4BGTC/Sdo/bd6/Vi06ZNIISgvb1dVpybaDSKq6++GtXV1Tj55JMRiUSwcOFC4XuXyyW0nUK9D4lEo1FoNBq4XK649uD3+xEKhQRBJtNWynxAxT2NRiOIwLRcHo9H0vOk4uDk5CQmJyeF4OlyvEdphjSDwTDnmvT8Pp8vp/qV87zzIhj99re/xXHHHYempibss88+AIBPP/0UJpMJL774oqrXXrJkCaqrq7Fz586kgtF1112Hq6++Wvjb7XajubkZNTU1ihiJbKGrFTU1NYoNxrRaLfx+P1avXo1169ZldY7W1la8//77iEajQvpgxh7UqDdGfmB1V7qwuitdSqXu6Ootz/NJ+75wOIyysjLU19cjFAohEAjAYrEk9a5OxOPxwOVywW63q5a1SGlKpd5KiZmZGczMzKCsrExSbJmpqSno9XrZY7FUdRcMBhEMBlFbWyt5YuPz+VBRUQGz2YyhoSHY7XZVxs4zMzMAgOrq6pTbhOgEK99j00gkgrGxsazqIh0ejwdutxs2mw2VlZUIBoNwOBxwOBxC3f3sZz/DV77yFeGZ19XVwWQygRCStizhcBh2u121Z+Xz+eByuWC1WiUn1ikGQqEQgsEgvvCFL0Cv16cNHC4H+s6Vl5fD6XTC6/XC5XJh4cKFczKDRaNRaLXalO9gV1cXtm/fDmBWTDziiCPw+OOP40c/+hF4nofD4YDdbsf4+DhisVjB52o8z2NsbAxmsxm1tbUIBAJwOp3QaDTCvUciEUxNTcFkMhW8vAMDA3C5XKirq0NtbS14nhfaQU1NjaTyEUIwPj4uePAEAgGEQiHJxwOz7xAwm0gj8RhCiBBnK5fnRZ14pJAXwai9vR3d3d34+9//LjTyc845B1/72teEtJFqMTg4iKmpqZSp+oxGY9IsahqNpuCDII7jFC0HbXx2uz3rc65ZswYAsHDhwoI/n2JF6Xpj5A9Wd6ULq7vSpRTqjibPGB8fx/Lly+d87/F4hL518eLFss4tvu9ifgaJlEK9lRJ0gij1mYp/n821Ul2Hrqxngh5Lz7V582ZUVlZi7dq1isfGobE69Hp9yvvVarWIRCJ5b4/Ua6SyslLRa1OvLZqBzePxoKWlJa7ulixZguuvvz5uO5LBYMj4HAKBACoqKlR7VtRjplQ9EG02m+JBzDmOE57Lq6++CpvNJvQl9BmNj49jZGQElZWVaG5uTnoe8by5pqYGvb292LRpE5YvXw6NRiO0G7p9qtDPXxz/R1w+cawlKgIXQ3uhnp4Gg2FOLKh09kcMIQSLFi0SPCKnp6cF4cxisUgS1ale4nK5kl6Tepjm8rzkHJu3IDQWiwWXXHJJzufxer1CpHUA2LVrFzo6OlBZWYnKykrcfPPNOPPMM1FfX4+enh786Ec/QltbG4477ricr13qUNezXFJEKhXIi8FgMBiMUoF6/oyNjSX93uv1Zp2RlQW9ZgCFr38anFZu0OtoNAqXy4WpqSnU1taqEkjZYDBknPxKjS+iNHSCKWe1XgrJgl7bbLY5v2toaMD4+DgOPfRQwSuGxmNNhd/vVy3gNbBHMCq2eDSZUPsdpO33jTfewPr16wHMvj/Ug4Uu7KeD1q1WqwXP8xgYGEBDQ8Mcbyiz2ax4nOBsSMxwSNuEeBurOCZPIfD5fHjjjTfQ0tIilE9sB+VmSaPeZDRgNX1HJyYmMDU1JUkw6u3tTfu91WqF3+9XJUNjMlQVjDZs2CDpd3K2R3388cc46qijhL/pdrLzzz8f9913HzZt2oS//OUvcLlcaGxsxBe/+EXceuutSb2I9jboHvBcBCNqkJhgxGAwGIy9AUKIIAalEow8Hk/KFeFM5DM9OWN+oXSWNDltkXrWDA8P49133wWgfBpyCs/zGeO8zDfBSJwJye12IxQKJRWCPve5z8X9rdfr08ZCI4SoLhgVU5YuOcgVTeVCz/v9739fECEikQh2796Nuro6oX7pd8mgv7HZbJicnER/f7+w+0OMTqcTgsAX0msnMcOY2WzGPvvsE2e7qPdVodpLb28vmpqaEAgEBL1ALF7JzZKWiE6nQ2VlJSYmJiTrEVRUOvHEE5N+bzab4fP5EA6H86JxqCoYHXnkkRlXzjiOk6UoHnnkkWk7SLVjIpUyVDBKtkIhFeZhxGAwGIy9CUKI4GEk9nCm8DwPr9eb9WIM8zBiiJHr4aMU2QpGoVAIn3zyCfbZZx9wHKfKincsFpMkGNEMb/mcIPt8PnAcp3gKdrFgRIVqKR4oBoMhbaDpYDAIQoiqIUFKXTBSC3rumpoa6PV6hMNhOJ1OeDweDA4OoqqqChqNRghanQwqGNntdkxOTsLv96OlpWXO78TtpxgEo8T3N/E506xuhaC3txczMzNxNkzcdlPdgxyofUgnBooZGRkBADQ1NSX9ngrUoVAoL4KRqi2ooqICzc3NuOGGG9Dd3Q2n0znnv+npaTWLwBDhdrvBcRysVmvW56CNspSyHjAYDAaDkS3iScRHH30053uv1wtCSE7eu/Q6DEahoIF5pdLU1CRMgo444gg0NjYCUKcdSxWMgPyLFMFgUBWvFBqrKBqNCpPDgw46KONxmQQjuk2JeRjNJV+CESFE8FbZvn07+vv7hUUJm82GSCSSUjyhAeArKiqEdpEssHjilsZCQQWSTO9vIT2Muru78e9//xvArJgHxD83uVvSkkFjw0kVjIaGhqDT6YTyJELn4/nK6K6qYDQyMoJf/OIXeO+997BmzRpcdNFFePfdd1FWVibs7aP7+xjqQ/c/56I0sy1p6vDCCy/gzjvvZEIcg8FgFBmEEFgsFixZsgRutxsffPBB3Pe5bvdmHkYMILv6L+SWNK1Wi5aWFlgsFpx11llYu3at4mWi5ytWwYgG6VXau0h8/kAgIHicSMmel2lLGj2XmoIRFdCYYDQX2k6p+LBlyxZs2LABHMfBaDQKn+/atStpPVIPo6qqKlRVVaG5uRlLliyZ8zv6vkgVKNRCqndOIT2Mdu7cif7+fqxatUoQ35TckgZA8EJM926KGRkZQX19fcrnRsXCsbExDA0NZV0uqagqGBkMBnzlK1/Biy++iO3bt2Pt2rW44oor0NzcjP/5n/8peCPe20gVME8OtIEyYUNZfv3rX+Phhx/Gtm3bCl0UBoPBYIigE+Dzzz8fAHDrrbciEAgIn+eaUILFMGJkQ6G3pAGz3hBLly5NmwY8V6jokGmxsxCCEb1ntQQjKrrIEXlolrRUwl0+PIyAwgoA2ZIPwYieny7Ab926FT09PeA4DmazWfAc8fl8SXfhUMGotrYW++yzD37+85/HxfalFIuHkRzBqBACIyEEPT09WLJkCfR6fdKA7Up4GNHjpWgfhBAMDw8LXpvJoO2I5/mMQe6VIG+bGltaWnDjjTfilVdewbJly3D77bfn5QYZe3C5XDkLRszDSHk+/PBDjI6OAgDq6+sLXBoGg8FgiKETr4MPPhjV1dWYmprCf//7X3z44Ydwu92KCUbMw4gBFE5AzHWyrFY7ljrhpBO8fC9oqikymEwmaLVaQeSREneIjtNTeTLkUzBiHkZzoefX6XQghGD79u3Q6XRYs2YNFi5ciNraWiGBQrLYNHTuXFdXh5aWFhBCkgqWxeZhlElsoVvS8t0PulwujI2NoaGhAUDyjG1KeBgBs8JyNBrNeI/j4+Pwer3CNsVkaLVaIdh5yccwooRCIfzjH//AMcccg/b2dlRXV+O5555L+yAYysLzPEZGRoQgWtnCYhgpz5NPPin8O197URkMBoMhDTq44zgOV155JSoqKuDz+WAymTAxMcEEI0bBKOSWtEQKLRjRcWm+FzTVFBmo6EI9jOQIRqnG6fkSjLq6uvDJJ5+oeg2lyadgpNVqodPpsHz5chxyyCFx100VIHn79u0YGBiARqNBQ0MDmpubEYlEkpZZHPS6kNB5TSYPwWRCTT7wer04/PDDccABBwjlSIynpETQa2BPvWbalrZx40YAyBjnWaPRQKvV5mXsoGqWtA8//BAPPfQQHn30USxatAgXXHABHnvsMSYUFYD3338fPM9j2bJlOZ2HdkRM2FCOyy67DF6vF2+++Sbz3FKBf//736ipqUFDQwMWL15c6OIwGIwSgw4cOY7DaaedhqefflrYgkMIEQSjXD1456NgdP/99+Nvf/sbbr/9dnz+858vdHGKGrn1T9ufktcvZcHIZrPB7XbnPKmTg1hMVgMqGMkReagXRCbBSM0saQDw8MMPw+l04pxzzlH1OkqSD8GIotfr0d7ejj/96U9zvqN1KBaMIpEIvvKVr4DjOJSVlaGmpgYmkymlqJDsHIWAip2ZniudV0YikZw9eeRQXl6OSy+9NC4bmVarVTzoNT0vMPtu0vl0Otrb2zP+Jl9bP1WtkUMOOQQtLS347ne/Kyh3b7/99pzfnXLKKWoWgwHgpptuAjAbeyEXmIeR8nAcJ7hCMiFOWQghsNlssFqtktLRMhgMRiLiSSHHcXjooYcAAD09PfD5fOjq6gIASQPAZMxnD6NPPvkELpcLnZ2dOQtGg4ODMJvNqKqqUqh0szz44IPQ6/X42te+VtD009nABKM90PFpId4jNQUjAML4pZQ8jCorK/MSjFdJaBDzfJCuPSfzMNLr9YI4YLPZUFFRgd27d2c8f6E9jGiw50zP1WQyIRgMIhwOqy5miqHePuJtfYkijFJb0ui13G532gUmuki1evXqjOfMV3Y51SW8/v7+tCIFx3EFb8zzHbfbjfHxcTgcDmFfbLawGEbKw/N83tMj7i0MDw/jqquuwv3334+KiopCF4fBYJQgqbwIurq68Mtf/hKTk5MAIMSik8t8CnodDoeh0WiEgXV/fz8AoK+vL6fz8jyPqakp6HQ6RQWjcDiMv/71r5iamsLjjz+ORx55BFarVbHzZwOLYRQPnQxJScsN5HeCnA8PI0CeyJMYw+j999/HXXfdhW984xs4+uij8yYYVVVVIRAISPamKAby6WGUTnygbTlx6xJtbxqNBsuWLUu7a0TszVIoeJ5HNBqVlBG9vLwcLpcr75pAMsFIq9XGiXVKCUZ0rpfpPC6XCwAkzVs0Gk1e6lhVGZXn+Yz/MbFIfT755BMQQnDhhRfmfC6a9pEJRspBCGFCnErQlf9SDL7IYDCKA/EgXYzFYkE0GoVer8f/+3//D6eeempW558PHkaxWAydnZ3o7OxEd3c3eJ7Hpk2bMDQ0BKvVis2bN2Pbtm1Zb4+gk1ylV/8NBgN+8pOfoLm5Gddeey1eeOEF8DyPwcHBok/MUgxZ0sQU2sNoPgtG1MNIjmBEJ5Gvv/46li5diubmZnz00Ud5E4yoSFDs75GYfApG6dozx3FzMmpFIhFZgd3pfdD6LgR0TkMzbKejUDtYpHgYKbUljd5jpqyKTqcTAOBwODKeM1/zm9LyvWVkxe9//3sAwLp16xQ5n8FgYFvSFIR5GKlHd3c3gFkjLTaoTqcTnZ2dgorv8/kwOTlZ0hM2BoOhDqkmhevWrcObb76JDz74AOeee27Og8lStj/hcFgYF4TDYTzzzDO45JJLAMwOjo844ghEIhHB5sqFTpjV2C5SUVGB3/zmNwgEAmhra8Mbb7yBE088Ef/4xz8Uv1Y6Cl3/uW7HUUswopO1vVkwkhN3KDGwbnt7O1555RWEw2GUl5cLnpD5EoxmZmZUvY6SFItgBMxNwU7FF61WKzkWsE6nK+g2W1pmKVm8Mm2lVAsaNFxcHzSQNJ03xGIxIW5hLki1kXI8jPKVXS7vraisrAy9vb35vuxeC8/z6O7uhl6vx5IlSxQ5J/MwUhYmGKnH5s2bwXEcrFZr3CDS5/MhHA5jZmYGkUgEu3btwsjISMGDAzIYjOIj1aSQxjTKVSiaDx5GNBtSS0sLNBoN9Ho9dDodzj//fJxzzjnC5DGbZzUxMYGpqSkAyk/M6UDbaDRi//33jwuTQFd5842ce9wbYhhRsTBT/1xIwUgtshGMEifegUAAgUBAOBedjKq99bKsrAxA6QlGalNeXg6bzZbxXUtMwU7nB2effTYeffRRSdcyGo0F7Vd27NgBQJrQT7PG5Xt+GYlEoNfr4+qD2pJEwUgppApG9B1KR2JZ1SJ/Ycg/o1QGRA9cdAjM+vSNo65tLU6/5e9xnz1549cwtnNTxvMfeMZlOPDLlwt/h/0ePHhxfEBIPsZDo537kp32k7+iftm+wt8977+Il+/+QdLrRCNRnFoxBYvZggcvPAQXPvh+3Pdv3H8Ttr/xRMbyLvncsfji9+8CMNsZhUIh/PU7R8PnHM947PqLb8LKL3xZ+Ht6oBuPXXtGxuMA4Lx7Xoatql74+9Pn/oL3/n5nxuMqFrTiK798Ku6z5267FAOb38147NoTvo7Pf/1HcZ/9/tw1ksp7wg9/B2PDUuHv/k/fxvO/uCztMdFoFJFwBIAlTjB69693YNMLf814zeY1n8eXrvtD3Gf/98PT4BzqyXjsoV/7Afb50vnC396pUfztymMzHgcAZ//iCVQ277nXztf+iTf/dHPG46wVtfj6/74a99lLv7kavR++nPHYFUeegSO/FX+NBy88BOFg8oDWdZOTOKsOePHHp2D56d8F394OjUYDjuPgHuzChp/eEPd7mqIykQv/9C4Mlj0psz/+5+/w8RP3ZSyv2jYiFXJshBiDyaqIjaDky0ZYKmqFv4vdRpx47X1o2edw4W8pNoLy7X9sjvt7vtiIxL4unzZCzLHfvROthxwn/D3a1YGnfvJ1EJ4gGotCq9WmHPjmYiNOu/lvAPaMj0rNRjz36x+g551nwPM8TEYTCAii0SjObdJA+8mfAQDBWAzbdh+ElTf8Me5YKTYiEolg6Ze+hYb9jhaekWLjCAJEopFZ26/RChO0M2uciH3wNwDXxd+rijaChmkwXXMPlh+y5x1LZSOi0ShAgA36PUN5qTYi8Z1rWvN5NJ94edykSa6NoMd6p8bw10ukbc+UYiOop8y7Oj1o8ZLZiFfu/gF2vPM8OE4DnS71+F1JGzHW/Sk2/PS8lGMHMdnYCD7Gw9KwBH7DSgCzXkFutxtP3fR1jPcktxF+vx9n1njwxi1nI/zV7yIQmBWGtFotFtTXoHLLIzizJoQnvn902ol8rjZC7GFUCuMIW1W94GWnxjgi8Z3LZCNi0Rh4wmPDZ20rFovhzJpJ6N+9H/2fHiFpHEHP8bZoC1Q+xxHBQBBanRahc67G5874lvB5qnEEtb+visqr1lyD53lw4BCNRcFxHN4ULWY07n8MFh77TUxOTqKqqgrRaBQnlg9JGuelGkcAyDiWoDbC6XSirKwMn/77jxltRCwWg7WhFSvv+FecDZIyjghEpIvreReMSgXf1ChiuvSKqL1mwZzP/DNT8E6OZDx/yO+J+5sQSDoOAPhofBC0aDiY9lirFkDYC+/03ICcIa9L0nWDHpfwb+ph5HOOSzo2EgrE/c3HYpLvlSQoppGAT9KxRutcVTbgnpZWN765+62lljcWCSX8HZZ8LGCJU9ZDPrekYwPuuSk1/a4JaXUTiB8gEZ6X3g4TVvEioYCMe40n6JHWDkNe15zPvNOjCPu9SX9Pd00HXOPgI2HEYjEhQBwfjSA0MympfIk6d8jvkVTeUrERFINlbtaGbGwEhdmIucQi4Tl/Z/veMBsxF7k2Qkw0HO/hyUcj0tthDjYicaW51GzEy88/gyZu1gPIm+YxRwKeOYuGUm2EhsRgMBiE49W2EVYt4A965nyeDxvBF8JGzMz14JJrI+ixPB+VXN63NmzAKee2CcemsxGZ/A6CHpekPl1JGxGNhFQfR+jtlfCb/EIMUQAIzExmHPeH3ZMI+T0IBmcnkWazGXabHbpoADot4J8eS3vdXG2EOIaRqUTGEdTLrljHEVYtgJBH9jgi3buj9jgiCgDR+PJmGkeIy1vIccTY2JiwQ8GskdaelBhHOJ1OVFRUSLYRBnvVHA8jKeOIYFS6V1LeBaPzzjtPkotVobFW1Wf0MLKUz83UYSmvgq26IeP5jaJVBgDgOMw5LpWHkUYXHyxLZzClvObE+AR4wqOutg4G81z3U6PNIam8JrtjzzFGI3w+H6yNtakPEKE3xrvQarRaSdcEAC5BgdWbrZKOtThq5nxmLquUVjdJOgCp5dXqjQl/GzIeG41EEY3NuloHAns6PKO1TNJ1zWVz9zJbHDVJO6NE9AltgtNoJN+rJmE1TW80SzrWWjG33Zjs0tqh0eaY85mtsh5hS/KVwWgkCnCzA1mN3iAY1FAoBK3eAGN5taDy8zyfcpUw0XPYaLFLa4cq24hUyLERYgwmZWwEJVldJ2PvshGGOX9LPTZZOeaDjUjmYZSIWjZCjM4QH5hTo9PDVt0geH7otDpwmuTbCHK1ERzHCWJIKdmIQCAAdyCMgFmHmpq57xQlFotBb7bPEYwy2Qi6IltWUQWdTid4myhlIwiZ9YbSarRxbdDpdMIbInO2I6ppI/gYjxgfg0aijZhdjQf0+tRD+VQ2IvGdozZCLBhlbSO49DaCEALCE0xOTeGXd/4KhxxzEurq6mbPlWAjqMeBTqeLK1sqG2Fy1AAE0KV7JkraCK1eGEdk8jDKxkbwPA+9zYGAJwCLxbKnHZZXpzw2GAhixj0Dh8MBo8WOwPTsuNJkMuXVRog9jMpLYBwhftfVGEckvnOZbAQfm00ORUCEeEbT09Ow2+ySxxHUpiS+P2LUHEe4XC6EQ2EYrQl9VYpxBPWIEpdXjbkGtfuURI+fitpGWK1W+Hw+IWNaiOhQUZM5Q2eqcQSQur+hcNxs3+N0OrFgwQJpNiI2ayMSt+JKGUdoIzEA0rZec6RU9ojlCbfbjfLycszMzBRU2OJ5HuPj46itrc0pYNlFF12ErVu34v3338/8Y4l8/etfx8jICF555RXFzjlfyKbetm7divHxcXzve9/DJZdcgiuvvFLlUu49bN26FQaDAeXl5RgZGcHSpUthNpuxadMmWK1W6HQ6LFiwAFNTUxgbG0NVVRUaGxsLGiSQIR+l7CUj/5RC3U1NTWFwcBCLFy9WbVywadMm2Gw2xWINqg2tt6GhIVxwwQX49re/jcsvvzzl70dHRzE2NoZly5ZJisMCzIoFExMTGB8fR2trK0ZHRxEKhbB69WqlbgNutxu7du1CU1MTqqr2TAZuuukmPPnkk3j66afh8XjQ0tIiKTV0LkxMTGB4eBhtbW2S4svs3Lkzq+eR7J2LRqPYunUrqqqq0NTUlFX5p6enMTAwgEWLFqV8Vh999NHshFyvx/e+9z189atfxYEHHgij0Yja2lpBOKL09fXB5XJhzZo1kuzDzp07EQwG0d7entU9yCUQCKCrqwt1dXWor6/PfIBMZmZmsHv3bvziF7/A2NgYXn755Yz28vnnn8f/+3//D7/61a9w7LHH4rbbbsMjjzyCV155BbW10sQXJdi1axdOPfXUkhnX8jyPzZs3o6KiAi0tLYqfO5t+bmxsDKOjo1i2bBk2b96Miy++GD/+8Y/x1a9+VdLx+ei70vHtb38bn376Kd577z1Jvx8ZGcH4+DhWrFghKVB2tvT29sLj8aCiogLl5eVJ7RV99m1tbbjwwgsxOTmJV199NcnZpOP3+9Hd3Y36+vo5to6W67TTTgMArF+/Hvfcc0/Gc9I6XrJkCex2e8bfi5Gjeag+OgsEAnj77bexbdu2Od8Fg0E8/PDDahdhryYajSqeCYFlSVMWnueFlJMsmLiy0P3otIOOxWKCF5fRaMSiRYvigt0x/ZzBYCRC7YKagpbYw6iUeOKJ2bgkn/98+thJqWzswMAAzjrrLPzxj3/E0NCQ8DnP89i+fTvGx2djl8x6R3CKB/ZMlbJ9wYIF0Gg0mJmZAc/zOV23FOpViWxfUvrR4eFhYcWeTlJoNqKJiYk5v49Go3F9eCZorJd8PfN8ZUkLBAKShdbEoNc0NqbU45Wi1IJeF+N7Kh670nqUkqKeQpMMFCqhSygUEtqjFMT3qxaEEHg/2zvd3NycUtwW7z7YvXu3IkkQMtlIm80257eZyMczA1QWjLq6urBy5UqsW7cOa9aswfr16zE8PCx8PzMzgwsuuEDNIuz1yH1ZpcCypCkLz/NCRy7eksbIHZ7n49JlhkIh9PTMBugTG1dqcItxwMBgMAqL2pNCtc+tJm+88QYAZPRySXV/HMdhx44d2L59O0466SQ88sgjAICnn346Tsyh6aGVttGpBKPW1lb86U9/Ev7ONkPOU089hWeffVZSubO5N6WeR74Eo2effRaPPfYYpqamEIvF0N/fjwMPPBA6nS5pBr1oNCors16+MgZR8ikYSV38pWN+KhLQcaUcoUEJqGDkdmfe1lgM5GNhQC7i9lyqgpEcTyGxSKMWNLNpYma0RMRZF3U6nSIeT5lspPhdGRgYkHTOfNk8Vd+Ka6+9Fu3t7RgfH8eOHTtgt9tx+OGHo7+/X83LMkTIfVmlQAUjNrnOHfoMmYeR8hBCBA8jalC9Xq/g0SV2u2eCEYPBSEW+BKNStD9NTU2wWq3Q6/Vpf5dqoEy3XlVVVWHdunVYtmwZfvrTn+L5559Hf38/2trahO1FVDBS8jmlEozq6+sxOTkpDMKzvSbdzqbGhE2p9kgIEUQFNQUjQgi2bdsGt9uNsbHZgMtLliwRtqglO06uYERjXOXLC74YPYzou0ifgd/vFybI+USv12PJkiWKpiNXk2K0v8m840tJMAqHw7LmoPkSP3iez+hMIRavbDYbmpubc75uJhvpcrkAAMcff7yk7Wjicpa0h9G7776L2267DdXV1Whra8MzzzyD4447DkcccQR6e3vVvDTjM+S+rFIwGGaDBxfKAM0nqFGkHQBdQWDkjni1iHZC9LOGhoa4QSjbksZgMFLBBKPU6PV6SfF2UtlYo9EIrVYLi8WC0047DcFgEC0tLZiamsLBBx8cd+50dvqTTz7Ba6+9Br/fL7nshJCUgtHq1atx/PHHCzGlspnA+P1+vPXWWwD2TASknEdOO8u1zczMzGDTpk3YvXu37GsnkqkfHRoagsfjQXNzs7DVkMaKodvUxNAAsXIEIzp58njmZrhTk3wIRlJ3CyQKRsFgMO/b0Sjf+973sH79+oJcWy75sPNyydXDiN6LN136ShUp1i1psVgso5ApFoxCoZAiHnqZ2hbdvrlu3TrJseTmhWAUCATmTMruu+8+nHzyyVi/fj26urrUvDwD6m1JA/K3gjOfoYNHuvrDBCPloM+W4zjBoNI2m+jaXUwuyAwGo7gQ2xK1+Mtf/oK//e1vGX/ndrsxPT1dNOKS1Al9OjGBTmYrKyuxZs0afPGLX8Q///nPOQF6021XGB8fR1VVFfr7+yU9m76+PmzZskXw6k01echli0Rvby86OjpACMHIyAg2b95cdIuliX2fmoLRxx9/DGDWq2hqagoAhFV7nU43J1YUnQDJEYzoJMvnm814FgqFBK8jNciHhxGdsEodpyTGMJLjnaQ0FosF1dXVBbm2XIpRMEoWw0hOXdJ3p1DzNblOC/nYkkbPLUcwCgaDigpGmTyM5CRYoPczNjam6g4u6VY4C1asWIGPP/4YK1eujPv83nvvBQCccsopal6eAfU8jIDZjljKyiIjNfRF12g0MJlMbEuagiTzMIpEItDr9XMGoGxLGoPBSEU+JhKbNm2S9Lv+/n7EYjFUVFSoVhY5RKNRWVtdEm0sIQQWi0Ww0QaDIWW2lnSD7eeffx7nnHMOAGnjHr/fD57nhZgRaghGO3fuRCQSEWLpEULg9/tBCEnaluT2P0q0x8RrqikY0Yw8K1aswGuvvQatViuICeJ4IeLMbYA8wYj27263G+FwGDt27AAAtLe3q7IwlK8taf/v//0/LFy4UNIxdIxOhbJCCkZVVVUlsxBajIJRrh5GGo0GdrsdHo8HPp8PQ0NDqK2thcPhUKO4cwgGg0W3JS2VV2m6sijlYURJZSOph5Gc+tHpdDCZTAgGg6ru/FF1Wf30008XAhgmcu+99+Kcc85hEzSVCYfDinsY0ZemlDyMOjo6cMUVV+Cll14qdFHiSBSMSqVjLQWSeRiJB6Ni2JY0BoORinxMJJqamiQFhy22SU0kEsnJw4gQArPZLNjldIN4eo5kk4ndu3cL3jtSBCypE+hcBKPXXnsNsVgMDocDTU1NKC8vByFEiN+TK9FoNOc+i06e6H2qKRitX78e9957L1atWoV77rkHL7/8sjCZTBZrJRvBCNjjQTwwMKB6ION8CEYajQarVq3CvvvuK+mYYvIwynfWulwo5qDX2WZJA/Zk3hoaGkIgEMDk5KSyhUxDth5Gam6vkioYiXcmxGKxvHgYZSMYmUwmLFu2TPUxgapvxXXXXYfnn38+5fe/+93v8pbJYG9FLQ8js9mMV155RdHzqsnHH3+MDRs24LXXXit0UeIQd1As+5yyiJ+t2JAmm0wwDyMGg5GKfIg0NTU18Hg8GTNl0rIUi62S6mGUTjCyWCzCOdIN4lPZaZ7nMTIyImt1WrwdnOO4lMfkMoHp6OgAMBunp6qqSthil2nCJrWdhcNhxQQj+uzUFIxCoZDgAaTX6+O2KlFRSPycp6enAcgP2Es91DZv3iwESVfrfVH7PRTXh1TRJ1EwKmQMo3xnrcuFYrGpYnINeg3saQ+FyMIsNyxKMXkY0WdP4+Ip8Q6psSWNntdgMKjqyFE8MipDcaLRKKLRqOIeRgsXLsTnPvc53HHHHUKgxFKh2DqtRA+jQhj0+YrYw0ir1WKfffbBPvvsg9bW1jm/ZYIRg8FIRT5WnunkOZWYEIlE4PV6hbIUS1+mhIeRxWKBwWAAx3FpBYtU3j7T09Nxi2Op7PiHH36I559/Hhs3bgTP89DpdFixYgXa29tV2ZJWUVGB2tpa4flYLBZYrVbEYjFFVvnpxDGXfouKMVSwy+Vc6eqOEJI2ay99/mJxqLOzEwAwODgoqxx0zLtx40ZMTEwAUM9jQW0xOdXCVzoS49YU2sMIUD8grxIUm/cmMDeODiBfuKAeRlqtFiaTSdiOqzaxWAzRaLToYhjJFYyyFeqSIcXDSKvVwm63yz632hnMCyoY9fT04Atf+EIhizCvoZ2F0h5GNpsNDQ0NAGY7ZADYsGED3nvvPUWvoyTU+BRbZjexqMFiGCmLWIzLRDENEBgMRnGRLw8jAMIEN5He3l709PQIfxeLYJSrhxHP8zCbzbBYLBknxanOMTw8DGDPVqRUz2ZqagoLFiwQ4grR+Hbp+ohcFhMmJyfnxJ2h9Uy9Z8TIvYYckSdRcKTQyRM9Vy4T+1T1EwqF0NXVBZ7nU45Hk21Jm5ycxCOPPDInSUUmDAYDgsEgnnzySSEbm1pjP7VtA8dxaG1txaJFiyQfI45hRAhBIBBQNP6KHJJ5jhUrxSgY0ZAKuWxJ0+l0aG9vR3t7O6xWKwgh2LZtm7D9SS3ofKbYsqQVs2DkcrlQVlaWVRtUOyFVQQUjr9eLN998s5BFmNfQRqO0h9HRRx+NSy65BADw0Ucfged53HLLLbj99tuL1kODBv8rtrhLYlHDaDSyGEZpiEajslYa5XgFMA8jBoORimIQjBKvXSy2Sq6HUSKEEFitVkmiQKrV55GREQAQknCkE4yA2YE/FYyyvWYm/H4/PB4P6urq4j6n95nufqW2Mzn9Vnd3N3p6euYIJ4mZyHIRVlJNhqampjKObZJ5ooyPj+P5559PGQQ9FXq9XhARqXdFqXoYAbP3IMfjQCwY0W2LhfIwylfKbyUoRsEImH03qIeRVquVlWRAfA4gXhj2er2KljMROt+SG6Q73RZhJZAqGFGxLlvPrlTnBNJ7GMndjpZ4bo/Hk13hMqBqlrS777477fdDQ0NqXn6vh6q7SnsYAbOD2y9/+cvYb7/90NnZCaPRiHA4XHSGlkJf+GIQZHiex8TEBGw2W5yoUVNTUxKdaiF48cUXcf/992N4eBhvv/12SkPvdDoxMTGBRYsWyUqFzQQjBoORinxMJKqrq6HX62E0GjE5OZkxFfV88TCik1mLxZLR/iY7Rzgcxvbt2wFkFozGx8cRjUZhNpvB87zkcmczgaGBrRMFIyX7GnEQcCkZfyKRCILBYFx222g0Co7jUFlZCY7jcsq+l6qOxc851eSRll+8LZ9OaOVm49VoNIKIWFlZCaB0PYxyYXBwUHiehRKMmIdR7og9jEwmU07lq66uht1uR3d3t+p1ko2HEbDnftWC2vJMNpOWRUkPIwBCxsxkTE9PY8GCBVmdl9rZ6enpjOOHbFBVMPr+97+PhoaGlI2l2Lw95htqbUmj7L///mhubkY0GoXJZErqYl0sUMWVBi8rFNFoFC+//DIaGxsBxAeaXLduHRoaGuasfNK/+/r60NLSUnSdWT5wu92ora1Fd3c3pqenhdV4MTzPY2hoCLFYDG63WxioyNmSxgQjBqM4cbvdQkp5AGhsbExqB9SApkVXk9raWtTU1MDhcGBsbGzOgC/ZVq5iQKkYRjS2j5RziO+9v78fbrcbZrMZVqsVwWAw7ertyMgIFi9enHZ7VCIajUb28x4dHQUA1NfXzzlX4j1Q5PY/csQn+luv1xsnHsRiMWi1WlgsFtlbvxJJtyUNAFasWJHymSdu/6BlBZBVPA/qYVRfXw+/379XCUb0Gff19Sk+2ZULi2GUO1qtFuFwWJGthfRdNxgM8Pl8CpUwOdnOQam9pbZJaaR6GNGyZLsVMBXpvG3dbjfa2tqyOm9VVRVeeuklPPTQQ7jppptw+OGH51LMOai6JW3hwoX49a9/jV27diX977nnnlPz8ns92aq7UjnssMOwdOlS1NXVwW63F1yMSQdNV6y2C2Ym3nnnHdTV1SEQCIDjOMFwBYNBITimOI5ROBzG5s2b8fjjj+M73/kO/vGPfyiWkreUeO+99/Dxxx8DmE2VK4YQgkgkgt27d8fFY2AeRgzG/IGmtqXkcwJCCFF9ElFdXY1jjz1WcINPJHHCWyy2SqqHESWZYGS1WmEymTJO6pPZ6Wg0ilNOOQVvv/22ILKlEnfcbjdGR0cRjUYlb0mj11VKMMrWYykZ2Sx0jI+PC8Gkgdn3SG7aernlCYVC0Gg0aceidPImLovX64XRaMxqC87w8DB0Op0gKqsdv7KYRAa9Xo/a2lqYzeaCexgxwSh3CCGIRqNwOp3Q6/WK2H69Xo9wOKzqnCjbOSjdgrd161Yh06GSyBGMtFqtMLdV28OI53ncfvvt+Na3vpX1eemCE+1/lERVweiAAw7AJ598kvL7dG5ZjNxRK4YRpaKiAhaLBfX19aiqqkIgECiaVc9EPB4PtFqt6kHe0sHzPK677jrccccdaG1txapVq1BRUQGr1YqysjIhexeNtwTsSbFoNpvxuc99Du3t7di2bVshil9QpqamhEFjYma+mZkZbNu2DR6PR+joabBHQLqHEbNHDEbxQt9tmpo8m0mkXDo7O/Huu+/mJVmC0WjEunXr5ghjwJ4Jg3giUwx9bSwWk7W1C0guGFEPkkxe54neOdPT0wiFQigrK4Ner88Yb2hmZiYuHo6aghHdJpfMCy7T+aROWJN5XKVC/Nx5no9LBKLUKn46wYhmwUuFRqOBTqeL+43X6xViEMnl7rvvxqOPPioIJaUcwygb2traMDY2Jiww0kXTfJMPwYjneUEMzuU+i7UuxTFY9Xq9IuWjwqyaYTqyDYvCcVzcGF7p+qCeVVIXk+l9qC0YEUJQX18v7EDJBnqsGt5jqgpGt9xyC84666yU369atQq7du2Sdc4NGzbg5JNPRmNjIziOw1NPPRX3PSEEN954IxoaGmA2m3HMMcegu7s7m+KXPGp7GImhrszFmhbe7XZDr9djZmamYAPt559/XshSUlNTA51Oh5aWFrS1tcFkMglGVWzA6Va6Qw89FJdffjkAYN9998172QuN1+sVBvqJgpF4gFBVVQUAQhYcQP7gm8FgFB90wkH7s3zY8auvvhr33XefsBii5qRHq9UiEAjAYDAI6YgpYs9JOtAvBnE7MWByOtIJRjRGTabJC8dxmJqawoUXXoj//d//FfpHOv7I5Ck6MzMT56GrpmBEs8Ymm2Rkc75U5QKktQWe56HT6eBwOIS/CSGKbvtIVsexWAyRSETSpFGr1ca9Yx6PJ2vByGazYdmyZYoE804FIaRoRYaWlhaEQiF8+OGHAPYEfM83tG1NTEzMGbspRSwWw65duzA2NibErsqGYq3LpqYmLFy4EP/+97/xyCOPKHJOajPV3KqYjWBEdwzIHb/LgdoCqYvJamzrTOVhBEjzfEoFjdmmRogYVQWjVatW4cADD0z5vV6vn5NyNBM+nw/77LMP/vd//zfp93fccQfuvvtu/P73v8cHH3wAq9WK4447riiCHecbNYNeJ0IHfGrvic0Wt9sNo9EInucLVsaXX34ZAHD99dcn/Z7WE6036i6q0+lQVVWV14lSseH1euFwOKDVauF2u/H+++8jHA7jN7/5DcbGxsBxHFatWiUEGJXrYUR/VwyTMEbpEwqFSsIFv5Sgq6xKpP+WSk1NDU488UQEAgFUVFSoEk9BzLp164QtTGJvGzrAdTgcwgpiMfQDiXWSjkwxjIDMC04ajQYDAwPYtWsX3n33XWEAT0WFTB43MzMzcVno1BSMOI6DyWTC4sWLJZ9Pbv8jx8OIeoLRhZdwOCy0MbFXcy4kq2O65UXKNRIFo1w8jMTnBNSJX7ljxw5BgCw2kaG5uRnAngyCX/7ylwtSDvr8eZ5XbUGZvsccxyEUCqGvry+rOV+xCkbl5eVwOBwwGo2yMwamIh9hGLKJYcRxXNzv1SifTqeTXKZgMCjch1LbOlN5GFHbJ7VfSgZdNFdDIFZVMFKDE044AT/96U9x+umnz/mOEILf/OY3uP7663Hqqadi7dq1ePjhhzE8PDzHE2lvQO2g12LogK9YBSOPxyO87PnelsbzPP76179iw4YNaG9vR3t7e9Lf6XQ6aDQaYWBDB1hSV0+VhhCC/v5+9Pb2FnxyQgeORqMR69evx6233oprr70Wb7/9NgwGAwYHB6HX66HVaqHRaIQYFYB048u2pDGUYGpqCtu3b0dXV1ehi1JyUC+esbExDA4Oxr2P1B7S/iwfglEoFMIjjzyCiooKtLS0qH49YI8HVTLBiPYRQHEIRkp5GFVUVGB8fBzLly/PeA66cmqxWITnQgWrTM/G7XbH9QdqCUaEEIyPj2PNmjVJJ59KZQGS62Gk0WiEcZDH40FPT0/ceZQi2XsrRfhJfC4+ny9nwYiidJKdQCCAUChUtCIDFYy6urqg1+tx0EEHFbhE6m0jpu+m0WgEIQQul0t2Fu6xsTEhUHqx1aUayIl/5vP5supvst3l0traKrQVNcbk0WhUctw2k8mUty1pcucsybBYLDCZTJiamoLX64XH41HMu1LVLGn5ZteuXRgdHcUxxxwjfFZeXo6DDz4Y7733Hr761a/OOSYUCsUFGabbW8R7vAsBdRfOpQxUYRcHAFYLsWBUDANZMTzPw+PxCAExp6amctojmulaifW2Y8cOlJeX4zvf+Q7233//ODfmZASDwbj2Z7Va485H40aowXPPPYdnn30WWq0Wt956K1wul9ABU1f2fEMIEQSjlStX4tlnn0UwGEQsFsPXvvY1jI+PY+nSpcIz0el0CIfDgnGX+h4lCk2M0kEJe5krg4ODCIfDgmhOAzcy0iOuu+effx5VVVXCJJEmAgD2ZOOig6ls7GAkEhHSqkthcnIS9fX1WLZsWd7qkt7fwMAAfD4fGhoahEm32MOpGMYodBKu0+kyloX2eYnvKc/zsFqt2G+//QQv4HTQYJ40TTwwV9BJ9myCwSCCwWDcM5QqBNEg1bFYTNJkcmRkBD6fD0uWLEl6fnrdxO9SPaNMSHkXqGAkniiJMw4q1Zbos6Lno3VUVlaW8RrUZsZisbh+P9eymc1mYcyglBjQ19cX93e++h+pfR2NnbVr1y6sXLmyYP0R3fJI26gaZUgVxFjOtRJjsCpdzmIYoyQjXZ3MzMxgYGAAhBCUlZXJztJMPcoMBoPs+162bBkGBwcxMzODaDSqmKhNt+FK6bOA2QyN4njASiUroG0hHA4L4xoq7OSaFKGiogLT09MYGhoSdICVK1cmFcnkXGdeCUZ0IEG3pVDq6upSRgy/7bbbcPPNN8/5fGJioqDb2Hiex8zMDAghWb8o1PU6EAhgfHxcyeLNgRrsoaGhOemACw2NG9Ta2opLL70UANDT0wObzZbU+OWSESdZvV1xxRUIhUK49dZb0djYmLYu6EBydHRUMFJ+vx/j4+OCMfF4PKp5wjz22GP49NNPUV9fjxdffBGrV68GMDt5CYVCBVl58fv9IIRAp9PhtttuAzC7rU+v12PJkiWCqy59rnQPNHWFn56elrSVJBaLIRaLYXx8XPEVV4a6KGEvcyEWi8HpdMZ9Fo1GVbe78wFx3fX19cVtU+/p6UEkEkFtbS2CwSA0Gg0mJycB7LGLcpicnEQsFkNVVVXGFcZYLIapqSksXbo0r/VI7TzP80LSA/p/cWB/t9udl2DcqeB5Xmjz4XA44zOiYwSfzxf3WyqwSrHTsVhM8BwIhUJCtlHaJqg4kayPpC76iR4sUvpS2hePj49L6gNpspe6urqkzyUSiQh9jRjqXTw1NSWpz6JjVJfLlXa8ShepwuFw3JY8YHZyMjMzo1hQZEIIQqGQcG/Uo9vtdgsxp1JBn/PY2BgCgYDQ7yvx/hFCMDo6mvW20mg0ikAgICyOJnosSa2zXJHa13m9XiETr9frLWhfVF1djcnJSUl2IhvEdtButyMYDMLr9WJ0dFTyeEBcn06nU/HdEoUeoyRCxZx0toOOvYHZ93fLli2w2+3CO5AJapeznYOK7a5Sz4zaf6ltUbwlLbHvyqUM1Av1vffeQ1NTE8rLywVPLK/Xm5MHallZGSYmJuLa9MTERFL7lMkmi5lXglE2XHfddbj66quFv91uN5qbm3HDo3fAYErvRtfasAg3nHtN3Ge3/uNX6BnZnfG6px16Ak77/InC3/5QAJff+6M9PyB7VoSQMD65/pyr0da4Z1/8hzs24nfPPjjnGoFAEA1fXI7HO/+Df/e+BpPBhN9f+cu43zz44j+wYct7Gct74NJ9ccUpF8V9dtUfboDT6wIABD+71oMf/RPGTU/H/e6bx56DI9d+Xvh7cHIY1//ltozXBIC7vnULKu0Vwt//+fg1PPrmkxmPW1DVgJ9988cA9gwip+x+PPzfJ4GNs7/RanXQaD57uGSP++QBi9bi3KPOiPNC+uavrpRU3qtO/zbqHdWoqamBRqPB2x3vQbdfJQwaDg99/E/g49TH/vmaexCNRjE1NYXKyko8/PJjeH3z29BpdeA0HAgBotEINBottNo9xrN94Ur84MuXx53rf/78cwxNZQ7+99X1p+P4A78g/O0N+dB43ApYrVY8s/sNPLP7DXDgQECg1+nj2uJPz78OTdV7ntEbm97Fn1/OHJCvwubAry+9Ne6ze59+AB93dyT9PR/j0fDF5eixTODZja/gwuPOxfLly4VBwk+f/C1CkT1egtFoDITw0HAa8IQXyn35SRfic8v3E363c3gXfvrIXaLjoiAE0Ot0c965311xByzGPV4JT737PJ5674WM96qqjUiDVBuRiJo2Ih252giHtRwcx6GmpgYv/fcN2TaCcuc/f4ctfZ0pjtjDcfsfhXOOOgMA8POf/xwOhwPvuDcJ33OfNSCdfm4Xe80Zl2HN4lXC35t3bcOvnrgv4zWBWRsh5pHXn8CL/30943FK2ohpjxNX33+jpPJKshGivm5qagrvPrsZdrMNlxxxDi6//HK0tbXhwQcfxB9eeBhdo73Q6rSIRGYzhul0cwdA69oPxYXHnRv32bfv+SGC4SCikSgIiGBTExHbiKmpKWjtBozV+PGjv94657eJKGUjCCG476W/YNdY/+zixWf2F5jtszgA0VgUWo0WZxz+pYLZCJ7nhS0cY7qZjM+IEKC1ugUXf/FrQqY7ALj5/34Fl28GOp0e6bSYbx57Dg5f9TkMDAxAq9UiiDBuffI3APa8Z6n6yLu+dYuwxaGmpgYf9nbgtc534scASaA2IhwOIxgMoqqqCr956v6MNmJmxo2y5TVYsGBB3L3ScUQsGovrmyixGA+ej+GaMy/H/kvXCp+nshE8TxCLRePuQ2wjQqEQ/v7av/Dm1vc+ey6a2UkDAWL8rMfH7HukU8xGTExMIBAN4bbP2kM08tl2yiS2EIi3ETzP470dn+CVF98Gz8/2+zvN40nblpxxBB/jEeNjwnufzkakgtbZWZ87Ca01s6K2yWRCz8hu/PXdf2Vsv4AyNoLW2R9e+Rt6R3enPa79nM8jOuTFeV88W2iHhRpH/O31f+K/uzanbAeUbMYRhCeIxqL46uGn4eTDj0d/fz9mZmYwPjOJu579Q8byAsC1p14h/Luqqgpvbn1P2XFEkjmdeBxBkTrXyHUcQUXisrIyvLDxtaTjCPreaDVaxHgei6ub8cOzvoPy8nLhN+lsRCAQQMMXl+OxbS/A1FQmexxB7eHPvvljLKrdsyU8l7nGb5+8Hx/u+C+0Gi002tQiFLURdOspANz35t8Q4TPHYpMy1wCZtYl+vx/6Tj10Oj0IIfju0d9ERUWFEKsqGxtRX1+Pvr4+/OWtxzHsGks75gkHpW/VnVeCEQ0WOTY2hoaGBuHzsbGxlJmljEZj0hg/0x4X9OH0+21ryqvmqJ5uvwdTbmeKI/YQCAfj99JznKTjgNmOXnxsJBZJeazOrIcn5ANCPpiN5jnl9YX8kq7rDfrmHOv0zsQdqzPr4Q354A3FK/ORzwYqFEIg+V6B+P2coUhI0rFWowWEEOzcuRP33DM7gHJ6ZhCVIIxHSRR+vz/uunLqhuM4aDQaaDQaPPf889CZ9ZLOodFo4gJb+4J+uAPejNf0BDxz6saVUDepCEVCwrGTk5PYvXs3GpevQDAWQjAQSnssIfF1E4mmbofxcHPK6w360h6rM+sRJhH4QrP1smTJErjdbhBC4PS6EAhl9gaMxOLbYYyPSa5XDRdf5kA4KK0d6i3w+XxC2mig+GyEGLVtRCqUsBH0vZNjIxLL6wlIqxt/OBC3NcpoNCZ/V5PE+Iwm1E1UTjtMKK8/HJB0rFI2giK1vLJthEEDd9ALcLNu1UuXLsWnn36K6elp+EMBuPyZvSCojRAz7XEhEMoccFVsI6anp8FpOIQRlXS/2dqIZOOIYDSEGX/mlb9C2wjqzh7jeEnHNpbNTlrF13UHvJL6uUg0Ao/HA6fTCYvFAn8ggGjgM+8gCbF0qYeRxWJBgI9Kuia1EXSltqurCzM+d+Z75QCNXovly5dnPY7I1UZQD8fxqXFMe/JnIziOAx9LUt4UdSS2ETqdDpFYRCgv7feTl0H+OIKSi43wi35jNBoR42OS2hKgnI3gOE7yOOLc08/AyV84Oa4MhRhHBCIhzAQ8Gd/VnMYRsdmtSzabDTMzMzLGpEAstsdLKRqN5n0cQZFa3lzHEeJjpY4j/GG/ECeUkslG0DloLuOIaCwmbxwhMNdGeCT2N9RGGI1Gwf7P+N0IpBGVhfJJnWt89i4EonvmWgTxsQqzsRGVlZVobGyEN+SffefSlTUkPeFBXgSju+++O+nnNItEW1sb1q1bl7M75+LFi1FfX49XX31VEIjcbjc++OADXHbZZbLOVWmvyOhhVGaZG62+zFKGqrLKjOcXrzIAADgu4TgCPsZ/poDGq4I6bXy1GfWGpNf0+33weLyorKyAXm+A2TBXGLOZrJLKazfPDTxYYdujMofDITidLpSV2WE2x6syRn38c9RqNJKuCcydIJkMJknHOmzl6OvrQ2dnJ95++200NjZi5dLlGPZMfLZHnq7KfRY0kufhD/hhMBhg0pvmtEWp5dUn1M0777wD6+oa1NbWSnJlF8frMOoMKDPbPluF5ABChIm1VnSdMot9znkctnL4JAx+TIY9QdxeeeUVEAKYdSaRyylJWMXcUx/ahLpJ1Q4TEbcbit1sS3lsJBLG9LQTdpsNNtNsNr7FixdjdHQUoVAIVfYKBIwicYvMrjZRV9rZlWVuTjvUaXVx15z1MOKh0+oQjdG0m9rZtpBQdxajOeO9xqJRWAxmeDyeOMFIORuRGqk2IhE1bUQ68mkjCOEBcHAkKVuZxS7pulbjHht33nnnwe/34y1XB6itjkWjsx4En7U9MXqdfs7fUu81WTmkHKuUjQBmn7fU8kqzEbN9XfSzbX1l9tk6aGtrw5lnngmHw4HOzk6YDSaUW8qg0+kQjUY+W6Gbu6hDbYSYKrsDAYMJkejs4IjjNEm3pInb4cTEBAhPYNGb5vRpScnCRgCpxxGVNgeisSg4cNDqdHFBSqkXTaFtBPXeNemMmY8lBGaDac4WsDKzDTwf29PPpcCoN8BqteKuu+7CvffeC5/Pj2pzNTScBlpalyn6SI1GI2zFslgsIPoIysy2z1ZdU68yUxthMpng9/sRi8VgM6e3h1OTk4jGYlh32DosWbIk7jt63Gw8l7n3HPe5iFQ2gvD8rLeZVguNZs+YZXp6GgMDA9DpdDDpjaiwln82+f+sP0syvlTKRsy209l2SMuX6n0D4m2EVquFXqsX2v70tBN2uw0Wy9x3Ws44QvzOaLXa1DYi8X0SQccHeo0Oer0ekUhkNtGGRhs/TkuHgjai3Cqtryq0jaBYTZbZ55SkTxSTzTiCtjPjZ9el4y2tRiu7bzUYDNBqtbLmGokkH0fMfefE4wiK5LlGjuMIcX+Sahwx2+YJ9HrdbF9osMzZKpXORvh9Pni8XlRWVmY1juBjsdlF+IT2kstcw2IwS7L91EZotVpBMKq0OxCMZPbIkTLXACHgNBy8Hi8sVgt0Wt1nHsXxY9psbERjYyNWrFiBj52de2w/p0k6l5HjYQSSBxYtWkSsVivhOI5UVlaSyspKwnEcsVqtpK6ujnAcR1pbW0l/f3/Gc3k8HrJx40ayceNGAoDcddddZOPGjaSvr48QQsjtt99OHA4H+fe//002bdpETj31VLJ48WISCAQklXVmZoYAIDMzMzndc67EYjEyMjJCYrFY1ue4//77yZo1a0hnZ6eCJUtOR0cHWbNmDfnzn/+s+rWkMD4+Tjo6OkhHRwd58803ic/nE77zeDyko6ODjI+PC599/PHHpKOjgwSDQbJt2zayffv2rK6bWG9nnnkmOeywwyQf73a7SUdHB5mYmCA7d+4kmzZtEr7jeZ50dHSQ3bt3Z1W2ZGW99957SWdnJ5menib/93//R6666ioyPDwc97tAIEA6OjokvZ9q8NZbb5E1a9aQf/7zn8Jn09PT5KOPPiIvvPBC0mMikYhQ/zzPS7rO2NiY0C7osVu3bk35+9HRUdLb20uGhoaSft/f3086OjrIjh07JJeBkR1S7WU0GiUdHR1x71WudHV1zWknfX19pKOjg0SjUcWuM1+hdfeHP/yBrFmzhrz55pvCd06nk3zyySeko6ODfPrppyQSiRBCCOnu7iZbtmyRdR2fzyecp6OjI2NbefLJJ8maNWvI66+/LvuelCJZ+wmHw6Sjo4MMDg4WoER7iMVi5M033yRr1qwhDzzwQMbf03ePjtUo9F2RM9a59NJLybHHHks6OjrIwMBAXJmSXYMQQnbv3k1ee+01Mjk5STo7O0lHRwdxu92Srzk5OUk6OjqIy+VK+v3LL79MDjroILJmzRpy3nnnpT3X0NCQMN4ghBCv10umpqaEPiMcDksqk9frJR0dHWRsbEz4LBaLkU2bNgl2rqOjQ7je6Oio8Jtcx5ep2Lp1K9mxYwchZLaf7ujoIJOTk5KOdTqdpKOjgzidTvL666+TNWvWkMcffzznMoVCIdLR0UG2bduW1fE8z5PNmzeTrq4uEovFCM/zxOfzCW1CbvvNBTXrTk3U7BNdLhfp6Ogg09PThJA9Y+Vdu3ZJPkdPTw/59NNPFS8bpdjqjc410r2bW7ZsIV1dXXG/n5iYkHyN++67j6xZs0awB3KhY3GPx5PV8cmg43yv1yv5mAsuuIDsu+++itXdzp07yebNm8nLL79MLrjgAqHtDg8Pk46ODsl6RSpefPFF0tHRQTZu3CjUG/2PviMUOZpHanlNQX7+85/joIMOQnd3N6ampjA1NYWuri4cfPDB+O1vf4v+/n7U19fjqquuyniujz/+GPvttx/22292f+DVV1+N/fbbDzfeOLsX8kc/+hGuvPJKfOtb38JBBx0Er9eL//znP4qlwyslqCqabMud0lgsFmi1Wvh8PrzzzjuqXy8dsVhMiK3Q2tqKdevWxQVpo7EMIpEIpqamcPfddyMQCGBkZARarRYGg0GxFKxarTbOuyQTtGzhcFhYwaJwHJdz9HwxXV1d+MMf/oBzzjkHN954I5YvX44vfOELcds5gT3thwavzDc0+KA4vW5ZWRn6+vpSBsLT6XQwmUyy0hfT+6TX4zgubTrQ8fFxuN1uTExMoK+vb87zodcNBAJCMFNG4aDvFLAnfTv9z+VyYfv27bICAFJiCe7SwB5PwXykfp8v0KCxbW1twmcOh0PYHlxRUSE8V5p1Ryo8zwvvIH2nMyW1oMGVKyoq0v5OTZJ5XdOV4WLItkPfJynpslOlcab3ISehgtVqFdqC2HMl8dkQQtDf3w+Xy4VoNIrq6mpUVlYKv5NzTTqGTNVujEYjampqYDKZcMEFF6Q9F61XWs6hoSEMDAzIDmIueEiLnml/f79wXmHL4GfvSj6C7YpTRtNnJTVILn0usVhMCJgrNf11OqjXiLgPkEo4HMbg4CBisRgMBoOw/ZmOeSl7Qyr2XBC3eb/fj66uLsUCSyemI+c4Dnq9Pi4DNmVsbAzT09NJz5GPoOXFQip7DMza9c7OTkSjUeF3iTYrE8PDw0Ifmu1zlXvNTPh8vrgstlKJRCIwGo2KJhsihGDjxo3CvCESiQj3mWs7bG9vRywWQ2trK+x2e5zdp1nvsiEvW9Kuv/56/Otf/0Jra6vwWVtbG+68806ceeaZ6O3txR133IEzzzwz47mOPPLItDfLcRxuueUW3HLLLYqUvZShxjLdpFcprFYrCCE47LDD0N/fr/r10kE7dL1eHycyUOgAJBqN4vLLL8euXbvw1ltv4cYbb4RON+tuTCeUub644XBY1vOnZTvnnHNw++23IxQKYcWKFXH3ppTxXLJkCS655BL88Y9/xFtvvYXVq1fjW9/61pzfcRwHrVZbsM6UTuLFdanVajPai2XLlmU1IaAdSqa0m3QfeDQahcvlwhtvvIETTjhBCC4ZiUSEwXMoFILVOtcNnpEfCCF46aWXYLFYUFVVBWBW8KMZL2a3Oc3GLpMj8AKzg5nECTN9V6LRaF7s73zga1/7Go499ti4IMEAcPjhh8/5rUajEdLSSpkE0yCoAFBeXo7x8XGEQqG0E9nBwUEAs/EAionE+EGFhAoRUib1qSYo9G85ttpmswlBQTdv3izEr0xcVPH7/XA6nXC5XNBoNDCZTEKsM0DeM6T9Q7JJKACsWrUKP//5z7Fo0aK4oLDJSLx+tgP4RIGMtnOO42C324XMZ1SIyqdgFIlEBMFI6qKlWDBqbW3Feeedh+XLlytSrsbGRgwMDGDXrl1YtmyZ5OO8Xm9SgQHIz/OcL4hj/k1OTiIQCGDnzp1obm7O2saSzzIaJxOdjUajkOWL4zj09PQgFAoJ47KKioq43ydb+JnPpLLHPT09CAaDc8Rrcf1JgWY5NBqNWYu+Svd1g4ODgk2SU9d33nmn4ISgBNRGElHGvGg0Okf4zJbGxkYhaRO9BiEkZ2eIvAhGIyMjSVdOotGokO6+sbExq9VdRjyRSAQvvvgi/vznPwsDnHx4GFmtVvA8PxtT5rMJWaGghjCVVxkN2haJRHDiiSdiaGgIRx11FNasWQNgj8DW3d2NhoaGjIO/dEQiEZjNqffFJyvb9u3b4Xa74ff7hdTwFCU9jGKxGNatW4cVK1bgyCOPTLtKTEW0fCNOLZ1M/EuH3BU/sZBIRbJUnSMhBLFYDHa7HWVlZdi+fTt+/etf409/+hOuv/56HHfccYhGo9Dr9QiHw2z1scD4fD709fXFiQ/i9Ki0f5LiKZEIDXotRjzxYewhGo0iHA6jr68Per0eTU1Ngr2NxWKzMUEkCNPi55tpcEUIEURgo9EIm82G8fFx+P3+lN5DTqcTp59+Ok4++eS4bJnFQLqV4VyRK95k42GU7Jpy7aPNZoPP58N7772H9vb2uO/EiyriZyVeACovL8/oQZqIVqsV0pO3tLTM+Z5eU8rkKHEilCgcSX0e4vuj4hgwmwBGPDHIp4cRz/OIRqPo7OwUJoxSr0ufg9vtRmNjI4477jgsXLhQkXI5HA5Zq+s8z2NyclLoG2w22xxhg3kYSUfsLSJ+bnI9voBZIXhgYACRSAQOh0Pof8XtzGAwCOnJdbrZbFRiD47E+mIeRrN1QeccGo0GK1euFJ6pXG8fvV6Ps846Cz/5yU+KRjDS6/UIBoOyRayampqs+qlUUMHoy1/+Mo477jgAygpGiddauXIleJ7H2NgYJicnEQ6Hs9IF8iKnHnXUUbj00kuxceNG4bONGzfisssuwxe+8AUAs6tEixcvTnUKhkRuueUW/PjHP0ZXVxc2bdoEAClXR5SErtQGAgFh5a9Q8Dwfp9wmg3oUHHbYYTjvvPNw5JFHCt/RwW8oFBIGYNkSDodlT0Iff/xxALMeMqeeemrcd0p6GNHz7LPPPhnLKHcLSCbEndStt96K22+/PenvBgYGBI81OcJbrtTW1kKn06W85z3BAPWoqqrCYYcdhq9//euYmZnBPffcI6ywioOYMwrHSy+9hJdeekn4m04U7XY7HA6H8LncNk69XBIHmmLxkTHL9PQ0tm7diu7uboTDYfh8PuzYsQMDAwMAIEzopQzK6G8yPV+/349t27YhGo2ioqICK1asgM1mA8dxSbfY7t69G+eddx6ee+45wQW92CYRSm9NFtPd3Y3NmzdLXoWU42EExG9XomQrGPX19eF3v/vdHEFPfA3qDUTPT8tZW1uLtrY22aEKHnjgAVx77bVJn70cUWZOlrnPjpUrAorPEwjMBp5taGhAbW0tGhoasHDhQnAclzfBiBAi9I30XuTYVFo/VOADct+eQdFoNHHZhzIRDocxMjIiZNerq6ub431abLahmBF7qIi99LLpc3t7exEMBhGLxTA1NZV0ok37BqfTiZGRkbh3Npm92ds8jChimzMyMgJgViBZtmxZ3Psi18NIifdX7jUzQcuybNmygta1ePyi1+uFTJy0DSotPlPbR+dQtK+QfR4lC5WKBx54AJWVlTjggAOENPYHHnggKisr8cADDwCYHQD86le/ykdx5jV08nP22Wejrq4OOp0uLyukVHAIBoNZrdIriZR9oNTzg76wYuLSFOdoVORuSYtGozjkkENwxhlnoLm5ec731LVQCeSo2VQwyvbar7/+Ok455RS8++67ePXVV/Hiiy+ir68PAPDEE0/gn//855xjRkdH4XK5hNgjagtGHMehvLxcyLaY7p7phEpct9dcc43gXUePE8fLYhSOZ599VmhvHMdhxYoVaG9vx6JFi9Dc3Izq6moA8gWeVLaGeRjFw/O8IAxptVqUlZUJfZV40ix1cEknHJkGPtRDgOM44XpUcIlEInPe7Y6ODmzatAkPPfQQ3njjDRxyyCFSbzGvpOoHfD4fOjs7sxoQ0q2zhJA5nq2pkONhBKQWjOT2s2Jv08TxjXhRhdrptrY2tLe35zwWqq6uRjQaTfp85cSfEAs9YnFEbv8q9hKg3vq0D9JqtXA4HHGLPWpPkjiOQ1NTk/B3RUUF6urqJB9P+1Oj0ShbjJQCXSiUQmLcwWRtXBwzh5EesYcK9fLgOC5jLDkxu3fvxqZNmxCLxWCxWASPL/qex2WX+mwRe2RkRPAmTuedubd5GCXGPyOECAvkDQ0NczxQ5Hr70BisubwbSnsYZRMvTw3EgpHuswyod955J7q6ulS10XSBJNt4tHnZklZfX4+XX34Z27dvR1dXFwBg+fLlcXuTjzrqqHwURTFisRgCgQAMBkNeYlQQQuDxeDJ679BO9sILL8T1118/J3CyWoRCISGoYKEnSVIGR9QzAJg7IBEHxKSdWSQSEbaXyTE2kUhEVvvQ6/X4wQ9+kPJ7upVOCeQMcFO5E0vFYDBg9+7deOedd1BdXY39998fMzMzCAQCgrjC8zw6Ozvxwx/+EMcddxxOO+00AMB3v/tdXHjhhXOCcauByWQSJiPiSX9iG0kmGAHA5z//eTzzzDNCwE7a6TLBKD1jY2MIhUJoampSpcM85phjsHTpUqxcuVIQDMTtuK6uLm77gVRS2Rr6t1LB80sdGu9Lr9cLMdlosHFqT5O9Z6kwGo3weDxJbTEhBF1dXcI2BI1Gg1WrVsXVt8ViSSqKHHHEETjyyCPxxhtvoKGhoWgnEMk8jHieR39/P8LhMEZHR2V5bO/cuROvvfYaDj74YACzsR4cDkfGdzGbSb1SHkbA7AJZopeQWDCiwqLRaFSkLmtqagDMxtVLjEmXjSjj8XjivJjlTmjEK/B08pHM25H2P/lYVXc4HJiamoJGo0Fzc7OsuqW2ORaLCccpWWa9Xg+v1yupzVHPfFonycbRxWofihFaj3QsTe2LHMFIPLdobm5GNBrF9PS0IOCK67Surg7T09NxffDixYsxOjo6Jw6ZlF0J841E8Yw+W4vFkvTdoLHfpM7vqD3KBTUEIzU8eOQiHvMYDAYQQoSA/GrOn+l8JdvwP3l9O1asWIFTTjkFp5xyimKB7ApFMBhET09P3jJH3X777TjqqKOEVaRU0IkqXTHPl7eP0WjExo0bsWLFioIH45QihIjLmPiMHA4H1qxZA5vNhmAwKLjAdnd3y87qINfDKBNqbEmT6mEkPkYuS5cuhd1uxzvvvIPf/e53GBkZASEEH3zwgXDe8fFxjI2NYXBwEBs3bhSM6oIFC7Bq1SpFVxqlkM5LJJVgdPDBB+O73/1uXIA88YCdkZyJiQk4nU5VbAchBO3t7fjKV74Cg8GQduCfrWCUaGvoIIzF5ZuFblERr1rSQPr03ZAjGFFvw2Q2fteuXTjrrLPw7rvvgud5mM3mOb+j721ie4vFYrjooovwyCOP4Oyzz5Z+g3kmWT8wNjYm2CWv15syOHMi/f39uPjiiwWbRb2Atm7diq1bt2LLli2Cd14iSnkYyR3AU7EmWQwqmrAC2LOQpdTEnsYzpHH1Eq8LSBMRaN04nc44G5GLhxGQPM6fVqtVJTZGKjQaDZYuXYrW1lbZ9SqelEajUclbVKWi0+mE7eLpnnUkEokb66XayrY3CQy5Qt8LOoehi4+RSESyRyS12ytWrIDJZIoLhQHMrY/q6mohYy49Xvw+UJTKTlWKJGY0FG/RT0RqaAq6NTXX+adaglGhEScr0Ov1KCsrw6mnngqTyZS0b1EKmtQpW5ualxlYLBbDn//8Z7z66qsYHx+fU/mvvfZaPoqhKPmOUdHY2IhIJIKXX34ZIyMj8Hq9QlYvyuDgIEZHR+FwOAqWmUev18dlJigEUlb6KioqhP26ySYpdDWcDpzpOeUYQKoaKynaKSkYyVkRFYsn2dwPx3E48cQT4fF40Nvbi9HRUTQ3Nwt1AMy2X9p5hcNhhEKhpCum+SJdavSPP/4YTU1Nc4Sg9vZ2eDyeuOCler1+zu+i0Si6urpgtVoVC+pZrNDnkco7kqa2B2YHfnKzlGWCTg7S2USO49LGrEpFqoEmHaDujQPQZNAV3GTCDa0fOd6L6WIb0AwhNEMUzaAlRiwQiq9JzyfO6FqMfPjhhzCbzRgdHUV1dXWcjbFarfD5fJienpbklfmvf/0L09PTsFgsGBgYwNFHH43e3t64IJyptqgVKoYRrf9kNoWWmxCCQCCg6EIDvV6yhULqFSPlXqqrq6HVajE6Oho3hpTbt4s9coDkCU6oSAKURkw1OqFXI34YHbt0dnbC4XCk7HvpuMRiscDv96csR6E9FUoJsc3mOA5lZWXCe+T3+yWFHKDtl/blNDYL9VJPHMvW1NSgpqYmTjCl23nFdiefQeGLhUSxmQqk6eohmdiWDFofudreXBeqEyk2wQiYtc8LFixAS0sLXnvtNbjdblXnzzabDU6nMysPsLwIRt/73vfw5z//GV/60pfQ3t4+L4xstivS2XLQQQfBaDTi97//vZAa8vrrrwcA7NixA1dccQXGxsZgtVrzsnUnFWJFuFCTJSmraeKVuFQCSGJnAshbAaTBH5UU78TpGHN9j7LxMMrWXZLneaxatQrbtm2DRqPB4YcfDrvdjomJCeE3AwMDQln8fj+CwWBeA10nku4dn5qagk6nEzLrURYtWoSxsTHU1tYKAew8Hg8ikUhcZ+X3+xGJRObESZhv8DyP3t5eaDSaOc+KQoOKArMTU6UFI+p1kSkrhFarVWxLGhU650NfpwSphAWDwYBAICB7hTfdyiPP8zj44IPR3t4OnudTel2IyyU+Vk45CsVTTz2Fyy+/HA6HA9FoVGi3FosFFRUV8Pl8km3nl7/8ZdTV1eHLX/6y0FetWrUKExMT0Gg0wraOZH0OFanyLRhRr5zEbWH0M4/Hg5mZGcUH3tTDaGZmBm63W4jJCcgb82g0GlRVVaGqqgqdnZ2CjcomRqBYMEq1+EUpdHxJKVAPIyUmnImIz0ezZiXabp7n4XQ6wXEcqqur0d/fXxSTzFJH/AxXrlwpZN71eDyS22WyxAhms1mwB6ne9WRxSZMJRsVu95UkUTCiW2PTjZNocOZMyPU8TXc9YP4LRvSzgw46SPWkUWazGU6nM6vF2bwIRo8++igee+wxnHjiifm4XF7Id1BT2nkNDQ0Jn01PT6O+vl7YygPMrtDX1tbmpUzJyDXWjRJIGfSL4x6kGpRUV1fDaDTCbrdjdHQUMzMzsgwXNZpKb0kDlHm++RaMmpqasG7dOnz3u9+F3W6H1+sVtlACs1sjqLHkeR48z2eV+lEp0t3zM888A6/XK6TEpGg0GkGwTTw+GAzCYrGgu7t7Tvae+Yq4vaaKpyZuA1K9IuQgjmOSDp1OJyueApB+oMm2Iu6BChqJz4m2h1TfpyLdQDIWi+Hwww+Hw+FAd3c39ttvvzm/SeU9WCoTh+uvvx42mw319fXgeV4QoKuqqmRnp4rFYli9enXcu8lxnDCOCAaDCAQCSePxyfW8VSrodXt7O4499lghy64Ym80Gj8cjeIko6cFJt2t4vV7s2rULwOzk12AwZJ1lyWg0IhwOxz0bOf2C2Os4WT3Q75LFeypGqHCvRv8vfj7hcBibN29GeXk5tFotGhsb4957k8kkSbCa7324UlAbbzKZhHqg/88lLo74bzkZNul7MTU1JYglxSAm5AuxYDQwMIBQKDQntmMi6TyMotEoent7Acxu2ZWbuj4dcsdlqeB5Pu+hLZKRTDACknvMKg21qS6XS7ZglJe3w2AwoK2tLR+Xyhv0xcqHhxHdc33ttdfGdXjd3d0A9rgQWq1W8DwvxC8qBEqnQcwGKe6lGo1GMIypBrsmkwk1NTUwmUzCSqacFUCqxCu9JQ2AsO0vF7IJep2LYGQwGFBWViYYKbPZjImJCej1enznO99BTU2N4G3S0tKS1XWUJN2WtPHxccnCLPVwIIQIWd/oOUthi0AuJEvZKsbr9SISiQhBaalXnpJQt/dM7Vzs2i6VdO+QnIw88x36HFIN9qmop5RgVFtbi7GxMRx77LFJj0/lPUjfy2KfBB5wwAFYvnw5ysvLUVFRgQULFmDRokWw2+2y3fgjkYiQqSUZdHyRbFtaNh5GiWTjBbR06VL86le/wpe+9KU539EBcTgchlarFeKcKIHYw4jS2dmJ3t7erFevFy5ciBUrVggeF3IRC03Jxhq0TedjMqIEYsFILQ8jcXubmZnB9PS04KVC68BsNsNoNMJqtaaN69LQ0FBQr/5SwWq1YunSpXHB+NONsZKRLJMmPYfUYMZiDyOn04nh4eGUMZDmM2LhjNqzTOnmqTidbIzkdrsRCATwzjvv4KGHHgIAbN++XZEyKpU8pFg8jMTkW8CiiwbZxNfMy5O75ppr8Nvf/lbxiUChySbmRTbQSVRbWxvOPfdcIWA4FYzoy05jNaTr3NRG6T2ncujt7UVPT49kzxk5KVGzcY1MFRg5F2g5ent7sWXLFsmBTZORbw+jxGtptVpMTU3BZDKhtbUVixYtEjKTrFy5EkBhXejpPSd2VuFwGE6nU3K6YDrhikQi6O/vBzAriNnt9rj4PfMR8b0li/tBA+3W1NQIGQiVnqzTwaAUDyNAXhtPJ07r9XrEYrGCJwEoBlJ57tBnQ+tIKcEIAA455BBhgp9IKnuWbMtDqSHXVmdKzEDPNzU1Ba/XG3depTyMlHze4vecpt1WCiq6JN433XKcjWeaVqsVBPNst6SlyvgKzGaGWr58edIA4cVI4hhBDYxGI9asWYPFixfHCYxAvLhNF7vTLQ7RODmM9HAcB4vFEmdr5IT2oIGUUy06SLUhYqEk0TNvvocIECN+XoQQmEymjB6I6eZ3tB4WLVqEgw46CL29vWhsbMy5nCaTSRGRR26cRDURP/t8jw8NBoMQ+0sueZG23n77bbz++ut44YUX5rg+A8ATTzyRj2IoDk0jrzZi4eGaa66Bx+PBYYcdhg8++AAXXnhhXHDPnp6egq5q53urnpiuri5UVlZK9pxpbm5OumKRjEQ3Vimo4WGUaGj6+/uxdOnSrM4lJ9Bfrp5jqcSp4447Dh6PBytWrMDU1BQmJiag0+mEgX4hB2J09XxmZgZerxfV1dVxcZekehjR+qeZ4axWKyoqKhAKheDxeBAKhRRdBS8mxBMZKo6J3zfaHhwOhxAcW8kJJCEEsVhM0vYCKr4Gg8GkcW8SEcegSvYOiRMjFCoJwdjYGLRabUG9ToHUHkZWqxUGg0GwlUoKRplc68W/FR9bDAPKXJBjq3meRzQaTRoLiEJFkg8//BB33303/ud//gennHIKAPkeRsBcL12lBSPxu6b04hkVIOkzXrBgAfr7+6HT6RAKhXKa2CghGCUba2g0mpLYikYRv39Kv4sGgwFWqxVlZWXQaDQoKyuD1WrFli1bBFueylYxlCfdIg0hBP39/SgvL4/bOpNYL3LH1+K+g9b5okWL4HQ69yrhL1E4S9cHUOjzCgaDc35P63C//fbDUUcdpVg5aeawXL2DqG0tBg8jcX9XiEVxg8GQlU6QlyfncDhw+umnY/369aiurkZ5eXncf6UK3XKglOeU2+3GSSedhB/+8IfCZzTTB70eMBvYUqPR4OOPP0YoFBK8MqjHQyE9Fgq1Jc3tduNf//oXjEajMIjNZBjsdjscDodqHkZqxDCiE6uKigpotVohOHQ20HuRcv+5CoGpMshcdNFF+P73vw+NRoP/+7//w65du1BdXY1ly5YJKZELhdVqhU6nw/vvv49AIICBgQFMTExgfHwcgHzBiLaHJUuWANjTLvIhOhcK2l5MJhMIIejs7MSuXbviUqnTVLdqeCcGg0EQQiTt1aYrzck8oZLR19cn/DZZ55tY7/mGEILR0VHBi6uQpBJxysrKsHz5cuFzqX1proJRqolKsaxA5oJUWy0eW6TrozQaDex2OxobGxEKhfDMM88I3xWjh5F4a4rSSRNsNpvgEQTsiXNDM/3l0nbE/YDU5yFOEV/qnnEU8bhN6XFkMo8hrVYLvV4vxKhkglH+SOdh5PP54HK50NfXh927d6eMcyfXw0jcd3i9XhgMBlgsFixYsKBgCzuFgD4vcWypTNBxlDjuJEWt90apcbKcHRVqQ5+9VquVJNQpjTg7rRzyYhHpfsb5Bn0xeJ5HLBZDMBjMaZ+42+1Gf38/Jicnhf2Fw8PDgiAk9pw56KCDsGnTJhxxxBGCUHTeeefNiXOUb/K9JW1gYABbt27FBx98gA8//FAIrisuixIUy5Y0Snl5OTQaDaamprIWLKliL1Uw2rx5M2praxEMBgXRQ+61UuFwOPDqq68iHA7ji1/8InQ6nRDIvVBotVoMDQ3h73//OzQaDfbdd18EAgHZghG1E4QQQewF9rQpj8dT0G2kapI4oYzFYnC73ejs7MTixYsRCoUEbx41MizSupIyGGpsbITT6YTT6URDQ0PGgQW1BQsXLkzqkST2MAqHw9Dr9Xmd0BVTYPVMg0mj0YhgMJjVoD8ROR5GyWIYlfqkQeqijdPpxMDAAIDMfaXVakVlZSWWLVuGDz74AK+99hqOPPJIRbKk8TyvaBsVC8RKt32aDpyOuQwGA/R6vbBok8tkRK/XZzUpMplMQlw8NdMx5wtxW8zXOJKKfjMzM7JFUEb20PFnMlslts10jgWkjoMnFfp+BAIBRKPRgiZWKTQcxwk2XMpzaGhowNTUFFwuF2pqauI845XKjJaIWDDKxVOymAQj2gfSMAz5hj5TuYuZhX9yJYx40HnFFVfg8MMPx0cffSR8H4vFsG3bNiGbRia6urpQV1eHn/3sZ9iwYQOAPaKDzWaLUyKvuOIKXHDBBdBqtUIwysrKSpjN5oKujOTbw+iFF17A+++/D5/PB71eH/eMlDQM4kB5UlFjS9rChQuxZs0alJeXC/eabRwjuWmA//a3v6Gurg6dnZ2KX8tiseDYY49FLBbD+Pg4wuEwDjzwQNnXUZpjjjkGp59+Ok466SRYLBZ4vV4heLNcwQhAXAdLjXayYLLzBXEAUb1ej4qKCsHbaGxsDIQQYaCidApVYE92DSlb/jQaDYxGoyBqpYPneWHrWiovRVrvY2Nj6OzsxOjoaBZ3kD0+n08oa6HjB2YScWw2G1avXi1ZOE23RViKYJRsokK3L5a6hxFNyJGpDxaLE5kGjvSZ7LvvvgCAt956C5AIKzwAADtxSURBVEDuHkbZZAWTco3FixfHBddVkmXLlqG6ulq4F3Esy1zaTjbe9hzHYenSpWhpaUFjY2PJi0VA/DPMV9wlGmtlZmYmq22WjOyh2Un7+vriRCLad9MsgqkWguXWEx1n0GvN13AAUuA4TngOUgQjjuNQVVUFYDaGrriPYR5G0qH3Uqitwtk+U9Us4v77749XX30VFRUV2G+//dJ2ZP/973/VKoaqiN3a6QTjk08+wUEHHQRg9gWiwRCl0NHRgYmJCWi1WtTW1qKzs1MQgVpbW+N+u2rVKkxMTMBut8PlcgEojiwY+fYwOuCAA6DRaLB69WpcddVVsFgs2L17NwB1BKNi8DCiZaEGPhfBSM4zOvfcc+HxeLBgwQLs2rUL4XAY9fX1kga6Uq517LHH4umnn4bb7RbeoUKj0Wjwne98B8CerUo084PUgKriCZy4UzabzTCZTAiHw0WZvUEJxBPKVatWAZidJG7btk0QNBIFo1zE5kAgEJfO1WAwIBgMSl5FrKioQCAQSCuwhMNhDA0NCR5jqaADXLrtJ9+TOZpxEJjti5QSroeGhuD3+9HW1ib5nqjHbKo2LvfZcBwXl05cDE1vnul94jgubjtvMQ0ocyVd+mMKbeNSgvZWVlYiEong7LPPxqOPPiq8T7l6GNF/l0pgeEIIvvKVr4DneSxcuHBO8NBchFnxOEHu+1AqAa2lIH7/8jWZt9ls0Gg0mJmZEZ4lE4zyg1arRTAYhMvlgsfjwcqVK4XPgFnvxmRZ7ChiD24pJNr3vV0wogsnUscHjY2N8Hq9goeW2HGC9stKQs/vdrtzisVYjP270lumpSIWjOTYOdUs4qmnnioMKk477TS1LlNQaMMLBAIYHBzE8ccfj4aGBiGSPzVwyYK9JuOjjz6C2WyGwWDAXXfdhR//+McAkgsOer0e++23H5YvX44NGzbAZrMVRQc3Pj6O6667DkcffTSuueYa1a+3YMEC6HQ6LF++HCaTSRjAquGKDhQ+hpEY+n7lEsNIjofRN77xDTidTvT39wsCqcvlkiwYZeqQ1q5di0WLFuHQQw+VVKZ809zcjF27dqG5uRmHHXaYrM6Lth/xigLHcUIQ7YmJCclZ10qJZJ00zZZC21Dib7KZPNIUuWNjY7DZbLDZbIL4ni5leCJ0K0u6d2psbEwoe7o27XA4EA6HMTU1lfeYbgMDA4JQBczaIqUEI7oKL0eEUiP7XTrBSIpdI4QgHA4L23iU8BIpFjQaTcY2Rxca6uvrJWUUbWhoEIL20wyt2XoYvfrqqzAYDDjggAPiylLs0DY8MTGB/fffH0D8vedyH6W+FVIp6Pun0+ny+i6WlZXB5XIJCxnzwQ6UAuJsxTSrKN05odfrhe/pwniiraILclLfn0QPo2KYNxUKao/l9s/l5eVztvTR8YDS/Tw9f64Z7IpJMGppaUFzc3PBrk/FVbmB3lV7U2666aak/55P0MFBZ2cn3G43Fi9ejEWLFqG/vx+Dg4NCgEQgc5ySaDSKnTt3YtWqVdh3333hcDjQ3d2N5cuXCy6AiVRVVWHBggXCIK4YqK6uxtDQEHbu3JmX6yVm+qIGS+ktGMXkYUShgYKz3dIkZ1WBUlZWhqqqKoTDYXg8HsmdrRQPmoqKCjz99NOyypNP9Ho9Wltb0dTUJHtVinaiiZ4uVDByuVzzUjBKNQmvr69HLBZDKBQSPCNz8U70er3C+0aD+dKYHnJiFBiNRnAcFye2JELb/OLFi9MG09ZqtWhoaEB1dTW2bduWt+yVkUhEiHtXXV2NyclJRQNv0/fY7/dL3kaj0+kUH6glCkaxWAzbt2+f48mXDI7jUFFRgenpafh8PthsNqF+imFAmStarTZjnQeDQSHFrlQ4jkNbWxt27tyJgYEBYXuuHA8jYI8XGA3IXkrZiY455pi4v8X3nmqsJgUmGM1C22O+J/LNzc2YmZlBOByeF1v7SgX6rC0WC3w+n5CogtqIyspKTE5OCvHlks2j2tvbZV+PCUazEEJk93l04TMUCglzz0gkoooN02q1sNvt8Hg8cLlcghdgph01ifHc5GSFzgeFtDG0/uSOtYvjyZUo1HB1dHQAAJqamgAAmzdvhtfrjZsk0eCrqdBqtbjnnntw2WWXwWKx4L777sPhhx+O1atXp52UNDQ0ACjcXshErFYrFi5cKATTVJtkqrHdbofdbldUNMpFMFI7eGI0Gs1qkh2LxWRPYrVaLZqamrB48WJwHIeBgQHcf//9KZ/1xMQEwuGw0PmXOlqtNisXZhpbLFE4sdvtMJvNCAaDwsrmfEIcqF+M2WxGW1sbVq9eLdiuXDyM6KBPq9UK7Y2eS877x3Ec9Hp9WhGWLhTYbDZJnb44+LXaDA8PC1sm6+vrhUFVMBjErl27sGPHDjidzpyuQe85U3sVCxZqbLlMFIwIIULWUin1QreUjoyMIBQKoaenB0Dm+yoF6BbYVHaZeldlE/B17dq1WLlyJd59913h3ZX6jlEx88MPP4TRaMTQ0BB8Pl9OQkuhEWdpyiUsAPNomSVVNiy10Wg0wpheDY9IRnKoDaeJIwKBgNDHlpeXw2w2CwsTFosl53aRuPV9bxaM6OK63L45MRwG7XvVemepXe3r64PL5UqapU1MKBTCli1bhHno1NQU+vr6ABSPYFRIaP3JnZuq9uQqKipQWVkp6b9SxWq1wmQyoby8HAcddBAOOeQQAMB9992HBx98EFqtFi0tLSmzAIjheR5ms1kIvicVKhgVk9FbunQpBgYGcnYhlEIywWjx4sVYsmSJ4ql6geyCXqu5ckjFRLmTUfr7bGNHcBwHo9GIO++8E/feey/OPvtsXHnllXHPZ3h4GG+++SYOO+wwAHu3oV68eDFWr16d9BnQOhSLyqUS0yMTclZ1colhJM70EYlE4oL5ZWMbCSEpRSO5nhkcxwlZeNTG7XaD53nodDpUVlYKA4KJiQm43W4Eg0H09/dj8+bNQkwuudC26XK54HQ64fP54u4tFoth165d2LZtW1zcCbUFI7FXmBR7SOMH+P1+dHd3g+d5GAwGLFiwQNFyFgI6cO/q6poT2NLlcmFiYgKEkKzszNq1a+FwOPC73/1OmDBIfWej0Sh27NiBjRs34vXXX0dHRwecTmdJT85puzYYDDnfx97cR1KMRqOQTCDftLS0CIIoIz9QW0VFAY/HI9gVOjaqq6uD2WyWnGgkHUww2gO1V3LtDp3T0HqiY6Vsw2NkQizkiq+filAoBJ7nMT09jampKYyMjAhzE2Zj92zjlDtvVO1N+c1vfqPWqYsKk8mEtWvXYt26daipqUEsFsMtt9yCYDCI1atXg+M4OJ1OeL3etIPmbOMnUANaTC/BsmXL8PLLL6O3t1eWq2g20JS8at9/Nt4PascwAmZFS5fLhVAoJOs61FDkMigzGo2Ynp4Gx3HYsWMHduzYgW3btmH16tWIRqO49tprccQRRwiT1mJqo8VERUUFxsfHodfrMTQ0hOnpafA8j9bW1qTp2kuJVB5GycjFw0j8rvn9/rhJstxVlLq6OgwMDMDtds95/jzPx22jk4per8+Lh5FGo4FWq8Xq1auFv4E9W4AcDofQvkZGRmC1WmUPmGn9RCIR9Pf3A5gddC9evBgGgwHDw8NCjKeBgQEsW7YsL4IRXaDQ6XSSs+JVVVUJMaYMBgNWrFhR0uIFhT7rYDCIcDgcF+SSrrQCyGor+8qVKwXxcf369fj85z8v2euypaUF27dvR3d3N4aGhmC1WvH888/LLkMxQSciSkw8aZuW6iU3H7FYLHOSvOQTKvAz8kNra2tctkSv1yv051TUN5vNWLZsmSLXS4xHujd79mXrYUSTStAFKpoJXK2wCjqdDmvXrgUhBJs3b5aVAXR4eDhunMDmIbPodLriEYzOP/98tU5dVNhstrj4RPX19aivr4/7jdVqhcfjgc/nS7m9LFvjRScu+Q6qmg6aZeLJJ5/EE088gfPPPx8LFy5U5Vr5yi6VLuh1qsFdPjyMxIGv021dTISWLZstCZSenh5MTk7i6KOPRjQaxZtvvonXX38dq1evxujoKMbGxtDX14fly5cD2Ls75nTQuDl0KxVtYz09PaiurhY8HmjMH+rdMjMzA7vdXtSD22w8jKQIRoODg/B6vTAYDFiyZIkwwBRvzaWTL7mCUUVFBQYHBzExMQGn04lVq1YJ73e28cJo6mC1J4LhcDjuGdDnz3EcVqxYAb1ej6amJnR1dSEYDGJqakr2II/neRiNRmF1ka5UdXd3w2KxCNc3GAwIh8PCoFItwYg+Uxq3aeXKlZKvVVFRIWSTa21tnTeTdHHwZbF9mJiYED6rrq7OaoDf0tKClpYWnHnmmRgfH0dtba3k52az2TAwMIDKykrcfPPNQlsqZex2u7A4mCtqjZMYjGKGvjtVVVWYnJxEKBSCVqtVJZyDeJwhJyHGfCRbDyNgT5w8j8cDQgjMZrOqW4vpNlGdTpcxHTxdPKLjFLojIhgM5i2WZLGj0+lkJ2lQbaZBVxilUAzp4LOlqqoq40tCB2xDQ0NYsmQJJicnUVNTE2cMs/Uwqqurw8knn4z99ttPZsnVY/HixQBmld133nkH9fX1+Na3vqXKtfIZGydxRTsUCqGrqyvlilg+YhjRyZlcV1A6wc6lbJOTk7BYLDj//POxdu1a/N///R+am5uF2Bi33HILWlpa8I9//AMA0gYS3pvhOA4GgyHOS6yyshLT09OYnJyEw+GATqcTYtMAe9piTU2N7G2s+YQKBVIGZXKCXjudTsHbZ+fOnUJ7rqioEFL0ZjsY4jgOVqsVXq9XSBVLofFt5L43Op1O2AKklnAajUbnBHw2GAxobGyE0WgUysxxHKqrqzE4OCj7Pug90K3YwOzqL/VaEYtIFRUVGBsbE8qjhmAEzI41ysvLhWC1cq5jMBig1WqF7KTzBavVCr/fD57nhfcpFothcnISHMfJEtWU5uGHH8bk5CRaWloKcn2lUdIjpdQ9ShmMXFiwYAHsdjt27doFQogqCyxiwUjt+KLFTi6CUVVVFUZHR4Wt7flK2qLX6zNu7/d6vdDpdLDb7QiFQrBYLCgvL8f09PReX+cUnU4Hn88nK8yKaoKRw+HI+KInprOdr5SXl+Pjjz/GL3/5S/zsZz+DyWQCz/NCkGwg+wjuVqsVP/vZzxQtb64ccMABaGpqwiGHHIJPPvkEb7zxhmqCUb48jIA9k/TR0VEQQmC328HzPPx+f9KOLR8eRnTy6Xa7ZXWuSpTt7LPPxumnny6co7q6GmazGeeffz7Wr1+PQw89FA6HQ/AwGh8fL6ireTFjNBoFkd1oNKK5uRkWiwWDg4PYuXOn0MZpG6STwEJ3fuFwGIODgyCEoKysDNPT01i4cKEgZEajUcnvpxwPIyqwEULighTToOwmkwlut1t4N+XS2tqK/v5+OJ3OuDTt1E5XV1fLOh+dUNLBixLQTDLicwNzvQaTZaAS1w8AQVzINGEVx4yj8fMACN49Ho8Hfr8/zvONDu7UEox2794tLFJIzdpG0ev1aG9vVzyrZqGpr6+HVqvF8PCwcG/U5lssloK65VsslnkjFjEYDGWx2+1YsGCBIjHBkiHeLcC83mfJpj+g4xi6OCdnh0Mu6PV6BAKBlPMdv9+PSCQCrVaL+vp6RKNR1NXVwWQylVQ2TrVJHNNKQTXB6PXXX1fr1CWHTqdDc3MzysrKhEF04kQvWw+jYkSj0eDII4/EypUr0dbWhpGRETz33HP44he/mNWK9rPPPguNRpP0+HyuEtDJ+tjYGIBZj5mZmRm8+eabGBkZQV1dHXbv3o3Vq1ejtrY2LzGMgNkOMBqNorOzEytXrpTUySrhYUQ9Yyif+9znsHv3bpjNZuG8JpMJbW1tCAaDOWdnms+IY4xQj0u6gkOz4HEch1WrVoEQgrGxMUxOTio60RXHEZCK0+kUAhtT0WHHjh0AZrcG0W1YUpAT9JoQIgRH9fl8CAQCgieTRqMRgmR6PJ6s4rQAe94NOvgAZu9Rq9XK3kZDPQB9Pp9igpHP50NPT48QP4gKZ1Lsjbi9AbPbH3meR3t7e9o+KFmSAQBYsmQJPB6P0BZoLCVAvXS2YtdyKpZlW9fzcVtCogBL22ApJxphMBjzG+oBqxbiBDaZtjbNd3LxMKLjGEII9Hp93hYh6LgsGo0mnb9Qb+e6ujpotVq2zTcF2WTvVU0wWr9+vVqnLklWrVqFm266CW63G2VlZXMM1XwSjADg8MMPh9FoRHl5OVasWIGmpib897//xcEHHyzrPKFQCMFgEIsXL4ZGo8F7772HFStWCHGSCuFhRPF4PIjFYnj88cexceNG1NfX49JLL8WOHTuwZMmSvHgYaTQarF69Gtu2bZOlFIfDYWi1WkXbG52snXbaabBarZienoZGo8GyZcsQDAax7777Knat+YbYaIvFCCoQ0e1DtL6qq6sxOTmp2H5sur3SZrMJ3hpSoJ4lNI03/T8AIcW5VFFSjodRNBqFyWTCggUL4Ha7sWvXrjmT/rKyspy2O4sFI5PJhHA4jEAgAIvFIltgKC8vh8fjUTRTGhUAotFoXCBjKc9P7P0jjpuVadU1Xaw9u92OpqYmDA0NwWazCb+hbVRNwYjGLBDHb9rbSXyf6JZgpQRLBoPBKDXEfTfbAjpLNn2z+DkuXbpUyeKkhY7LQqHQnLFlNBoV5jbMmyg9RSUYJeJyufDAAw+gs7MTALB69WpceOGFsl3IS5l99tkHfr8fu3btmhNzZr5F7F+7di02bNiA6667DjqdDhMTE1kpvf/5z3/w0UcfYdmyZXjnnXdwxRVXoK6uDi+99BI4jsurYCTePkk9GxoaGlBVVQWn04m+vj6cddZZGB4eRiQSEQboansYabVa2O12zMzMSN6W5vf7FX9uNIDgwoUL0dvbC5PJBEIItFpt1iv/ewtVVVVwuVwA4tsLDfSXuIUjG3fSdNDYNG63G1NTU5KCF05PTwsZmKxWK5xOJ6qqqoRsb4mpcTNB7zWT4EG3YtFnIF7pUhKxYATsCXidzXvjcDgwODioyoqmXq+PC2IvJfMhx3GCa/fIyIjweSAQSCvwZfIWqqqqQmVlpZDtRsox2dLW1oaZmRn09fUJ1yr1AMpKkpiogaavZ8+IwWDsrVB7yHEcmpubC1yawpKLh5FGo8GSJUsA5Dc0Ah2PJctiS++DzTcyk41glJeZ9scff4zW1lb8+te/xvT0NKanp3HXXXehtbUV//3vf/NRhKLBYrEI0drFE6P55mFks9lw4oknoqWlBfX19dBoNMJ2BTn861//wqeffopYLIa7774bRqMRV155Jb72ta/hySefzColZLaIPYyqq6uxZs0aLF26FKtXrxZSVb///vvo6enB5s2bha1r+TCmUoJfBwIBOJ1ORCIR1Z5bbW0tqqurcdppp+GEE06Yl1s91MBmswmdnBQDnui9kSvieqLtFkjdngghmJycBAA0NDSgubkZixYtQn19vTAhzUYwFXsopSJRXNfpdGhra1N8q02iYET/zmYwotVqYTKZ4uIt5QoV5BoaGgSxtrm5WfJ7TYNH0ixhwKyQ7HQ6UyatkLKwkTgIVUswEsdNoO9BMWcMzDdiDyNCiBDAndlkBoOxt6LRaFBeXo6qqipmCz8j277ZbrfnLXYRJd0CIR0HzKcEFmojJxlRXkZXV111FU455RT88Y9/jFO1Lr74Ynz/+9/Hhg0b8lGMokGr1YLneWzevBkrV66EwWBQbVBdDGg0Guh0Ovj9foRCIckrnIQQHH/88RgdHUUwGATHcTj55JMxMjICo9EoqNv5FIyokTKbzeA4DlqtFqtXr8aGDRuwcOFCXHjhhXj55Zfh8XjyaryoYOR2u1PGWOnp6UEsFhM8vdTYJ15fX6/4OfcW6uvrMTk5KUn4oJl5lPIwoufR6XSIRCKYnp7G6OgoIpEIqqqq4Pf7sWTJEmi1WkxPTyMajQreKNSjhXqL0vZOxSap7Z96DmXK+JdMXKfxipQkMc4PvW62Hho01pjH41FkkEXL5XA4UFFRITujDO2LabyhSCSCiYkJYVtaslThcvqpRC84NQbndFttLBZjE4AExIIRje3FtqMxGIy9GY7jsGjRokIXo6gopXknHTulE4zYwpF0aFgJKeTlqX788cdxYhEwW6E/+tGPcOCBB+ajCEVJX18fnnnmGVx//fXzzsMoEYvFgnA4jK6uLqxevVqSgQqFQmhvb8dRRx2F8vJyIT17NBrF2Wefjf7+fgD5e2biiay4/HSvbFVVFWpqanDMMcfAbrfj8ccfB5A/wWjHjh2YmJhAMBjESSedNOc3dDJFt6CYzWbVy8WQjs1mk7WnXqvVKuZhRD1HqPAyMDAgfEc9ULZt24bly5djcHBQ+C6Z8JEotEgVWKgAS2MfpZr8i8UtNaHvOI2Pk6uNNhqNCAQCisadEmeSkSuW0HLU19ejpqYGn376aVz2vWTnSxX0Ohn0Ock5JhtoOaVso9ybSPQwYlmBGAwGg5FIKS206HQ6aDQawcMagLDdn44BmGCUGZrJfuvWrZKPyYusWFZWJkzuxQwMDCjuzvaTn/xEcLum/61YsULRa+RKQ0MDWltb8cILL+Cxxx7Dv//9b8RiMWEVcD5CU23TOClSoDFdrFYrrFYr9Ho99Ho9zGaz0NiB/KnjZrMZOp1O2AJCaW1tRU1NDfbff3/hM3qvQH4EI5fLhTvuuAOxWAyNjY1ztr7wPC9MEOlEnglGpY2SHka0rZaXlwseTuXl5ULb1el0IIQI7qv03Uu2PYvGx8km6Dvt8NO5ydJ2rPbkl94j3T6cq2BEn1WugxlCCHbs2CEIRtlSXl4uJCYAgMbGRmFLYap4UHJi7am9JY1CM7QwN/R4xNmA5luMRAaDwWAoQynNO2l2Zjq+5HkeLpdLSEIEsH5OChzHweFwyApYnhcZ7itf+Qouuugi3Hnnnfj85z8PAHjnnXfwwx/+EOecc47i11u9ejVeeeUV4e9iUxvp9qEbbrgBX/rSl3DjjTfisccem/eNvLm5Gd3d3ZicnMwYmPW9995DZ2cnDjjgAHg8njnB0anRCIVCeTN2qbJH7bfffnj11VcBxAfUyyf19fW49tpr0dLSgnA4jMHBQSxfvlz4nqrx5eXlmJmZAVBanQRjLlK8caQi9tppbm7GggULoNFoEAwGMTk5iYqKCuzcuVOIW0QFhVTxuQghwm/k2DUqqni93pTbZ/I1KOA4DlVVVZiamsL4+LjwbmfbnyR63GQLzRwJIKesa7W1taitrRX+pp6SHo8n5bZAOeKPRqOJC2Kulr1ZtmyZIu/AfEPsYTSft7wzGAwGI3tKre80Go2YmZnBjh074sYqdJ5TbHP+YkZOZtm8PNU777wTHMfhG9/4hrA6rNfrcdlll+H2229X/Ho6na4kYqk0NjbigAMOwIcffijE6JnPA1+LxQKNRgOfz4doNJr0pe7s7ERfXx9eeukluFwu1NfXY/Xq1UnPp9Pp4twSi4177rlHVlrxXDnrrLPA8zy2bNkypw1Ro0q9RuazN9veAn1/YrFYzh1k4oSS/t9kMqGpqUmIg5LouZbKq8PhcAjxtOTYM+r1NjY2hsnJSdhstjkZ4vK5ilRTU4OpqSmMjY0JzyTb6yZ63GQLfZ5Go1GVOGTUcy1ZXyTXU0WcKEBNezNf+8xcSCYYzfdFKQaDwWDIo9T6TzqnSlzYol5HTDBSh7w8VYPBgN/+9re47bbb0NPTA2B2G4/FYpEVoVsq3d3daGxshMlkwqGHHorbbrttzqSjWDjjjDOwdetWEELi4lHMVywWi5ACmbJt2zZcfPHFOO2007B69Wo0NTXhK1/5CnQ6HQ444ICU56JGI9cVe7XIZ6pJikajgc1mg9frBc/ziEQi4DgOmzdvRnl5OYLBIBobG/NeLobyiIMK59pBZhICNBoNysrKBO80Sqo2vmDBAixYsEB2Oej+dEIIIpFI0qxi+YphBMz2XbW1tRgfHxc+y1UwytVe0fuvqKhQRTCi9+fz+WAymeKeM7XdUu+BJngAmHdLvqFjCZ7n2ZY0BoPBYMRBvcBLbd5JHQUMBgOi0ajQv1GPa9bPqUNeZTiLxYI1a9YAmK3wu+66C3fccQdGR0cVu8bBBx+MP//5z1i+fDlGRkZw880344gjjsCWLVuSxksKhUJxXio0vo54kKUm7e3tQjaampoa4ZriQJXzCbPZDK/Xi3A4LEwgnn32WXi9XnR1dSEWi+FPf/oTfvWrX6GlpSXt/YtTixfLcyqGeiOE4O9//zteffVVhMNhXHrppQCAQw45BEajsWieVbFRDHUnBxqMeffu3Vi8eHFOAoo4EHOq+29ubo4TjJQSQBIRi8qJdjgajQqrSOLtTmrWXV1dHdxut7D9VbzdTg50UBaLxXIqp3hQpMb9Urva09MDs9mMtra2rK+t0Wgytq1Se+9KjVgsJtSB+J3JFVZvpQuru9KF1V1pUuz1VqzlSkZ9fT10Oh3q6uowOjoKr9eLaDQqjE/Ens1KUOx1lwty7klVwSgUCuEnP/kJXn75ZRgMBvzoRz/Caaedhoceegj/8z//A61Wi6uuukrRa55wwgnCv9euXYuDDz4YCxcuxGOPPYaLLrpozu9vu+023HzzzXM+p9mm1Eav1+Oggw4CMPu86Eo2z/OYmZkBIWRerczSZzo5OQmDwYDx8XH8/e9/BzA7sN26dStGRkZgNpuFeCmpoEG7OI6L8wAoJMVQb1u3bsULL7wg/P34449jenoafr8fX//614vmWRUbxVB3chC75Q4NDeUUxJwKNE6nM+3qTEVFBWKxmCCsq9GWxFu2otEoBgYG4PP5YLVa4fP5hEHB1NSUIJKpXXdUJMrF1tBJu8fjyUpwolCvXDpIUhqx128gEMDQ0JDQ1uhWYqfTKelcYnEsVdsqtfeu1AgGg0J9KdlmWL2VLqzuShdWd6VJMdYbXXxzuVx5me8qicFggNPphNFoFOaSdEfFxMSEotcqxrpTCo/HI/m3qgpGN954I/7whz/gmGOOwbvvvouzzjoLF1xwAd5//33cddddOOuss1R3HXM4HFi2bBl27tyZ9PvrrrsOV199tfC32+1Gc3MzampqUFZWpmrZKE1NTRgbG8OqVaviAqNSr6P51EBnZmbg8XhgtVrhcDjwwx/+EIQQ2O12DA8PIxKJYPHixairqyt0UbOiGOrt+OOPh9frxerVq/H1r39dSJH9ne98R1aAs72NYqg7uZhMJoyOjqK6ujppxjKphMNhBAIB1NbWZrTJPM9j69at0Gg0cUGTlYLjuDlblcWeLZFIBFqtFnV1dXmzl7FYDKFQCHq9Put7jkQimJqagslkSnqOSCSC4eFhVFVVgRCCsbExhEIhEEKwYsUKQRybnJyE2+1GVVVVTnWeCqfTGbdtOBgMYsGCBYhGoxgbG0NZWZnkZ+D3+4W6q6mpSeoFV4rvXakwOTkJvV4Pm82GmZkZVFRUKJaZltVb6cLqrnRhdVeaFGO9BYNBuN1uVFdXp0wyUipMTEyAEAKtVouamhpFt9kVY90pRdEEvX788cfx8MMP45RTTsGWLVuwdu1aRKNRfPrpp3nbM+n1etHT04Ovf/3rSb83Go0wGo1zPtdoNHlrGMcccwx0Ot2ciRoNTDyfGigNkhuLxTAwMICenh6sX78eRqMRL730EoDZrVOlfM+FrjeDwYBzzz0XsVgMer0eMzMzWLJkScl3CPmg0HUnF/o+8TyfU5nFGcAy2WaO41BfXw+DwaDKc0q0x9Qjgm6tMZvNWLZsWdJyqVV3tEy5nF/sDZV4jlAohB07doAQgnA4DL1eHyeahUKhuLoG9qSTVxpxXCqO4xCNRhGLxYTy0OQFcqHxqZJRau9dqZC4hTJdHWQDq7fShdVd6cLqrjQptnpbtGhRoYugCIQQmM1m+P1+QTRSmmKrO6WQcz+qCkaDg4NC0OL29nYYjUZcddVVqopFP/jBD3DyySdj4cKFGB4exk033QStVotzzjlHtWvmSjLBar5CJyORSAQVFRX42c9+hqVLl+Lpp5+G0WhEKBTCwoULC1zK+YFWq0VTUxN27dqFpUuXFro4DBUQx/HKhVgsJqRBzwTHcap6ACZmXqNCRSAQQDQaRXl5uWrXllqmbEiM+eR0OqHT6WC32zE0NCRseRNvyaurq8PY2FjcFjZa12p554rPa7fb4Xa7sW3bNmElSk7/TV3e5R7HUAYay4FlSWMwGAzGfITjOCxduhSEEFW26TNmUVUqi8VicQNtnU4Hm82m5iUxODiIc845B8uXL8fZZ5+NqqoqvP/++6ipqVH1ugxp0FX2aDQKv9+PyspKVFZWCvUFQJXMP3srVVVVAIAlS5YUuCQMNRC/T7nA83zRTCapqCxOQ6/VaoV7LITATp9NLrGH6AoVz/MIBALo7+9Hb28vuru74fF4wHEcKisrEYlEEAwGUVZWJmw5Ewsv9DmolSWOnler1cb118FgEBzHyRLsqqurYbfbUVFRoXg5GZlJFIzm2+oog8FgMBjA7BirENmp9xZU9TAihOCb3/ymMMAPBoP49re/PSfuwhNPPKHYNR999FHFzsVQHurSFwqFMDMzA47jYDabhRgZ3//+9/GFL3yh0MWcN1CvAIfDUdiCMFSBTu7FXinZQD2MigHq6WQ0GmE2mzE9PR3nnVIIYUuv10Ov1+ccM4hmDevt7RU+o9nu6uvr59wnXXARC0ZyvMGygZ5Xq9WiqqoKJpMJ4+Pj8Hq9qKurkzUgq66uZgsABYRmRaNebcUiCjMYDAaDwSgdVBWMzj///Li/zzvvPDUvxygBaDwFv98Pn8+HmZkZrF27FitWrMDy5cvZtgWFWbp0KTZv3oyWlpZCF4WhAkptSeN5vmhWZrRaLdauXQtgNgmB0+mEzWaD3W6H1WpVZHuYXAwGA1atWpXzeWhMGfrvpqYm9Pf3CwEVgdkYQZOTk3HiTKKHkVreRbRcZrNZiFVEn7vL5UJlZaVq12UoD/MwYjAYDAaDkSuqCkYPPfSQmqdnlCAcx8FkMqGjowMbN24UYlzR7xjKctVVV+Gqq64qdDEYKkE9TXIVjKLRaFF6H5SVlWHNmjXzxjbQrXWxWAw2mw1lZWUwm81x8YGsVmucJ5Ner0coFEJPTw9isRgikYiq4p5Op5sTVFyj0TCxqAQhhAiCkZpeaQwGg8FgMOYvqgpGDEYy6uvr8fHHH+M///lPyux1DAYjMxzHQavVZr0lbXBwENFotKiDBc6nSa5Go0EsFgMhBEajEVqtNmnGNzEcxyEYDMZ9Rj0159OzYSgP9Uzzer0FLgmDwWAwGIxShfknM/KO1WrFJ598gurqaqxcubLQxWEwShqdTpeV2BOLxTA1NYWZmRkAQGNjo9JFYySg1WqFeDJSg3fT34tpampiYhEjI3RbI8dxqm5jZDAYDAaDMX9hIwhGQbj44otzyjjEYDBm0el0Qup5OYRCIeHfcrNfMbJDHENGqmC0dOlS+P1+BAIBGI1G6PV62O12tYrImEdUVVUJmTIZDAaDwWAwsoEJRoy8o9Vqcc455xS6GAzGvIFuc6JeJzQzUiwWg8FgmOONMjQ0BI/HAwCora0VAhwz1EUcvFpq8G6DwQCDwcAyHTIYDAaDwWAw8g4TjBgMBqOEoSKEx+NBWVkZYrEYtmzZAmA2YHIsFkNVVVXcljOn0ynEPaqrq2NiUZ4Qe1UWY5BxBoPBYDAYDAZDDBOMGAwGo4RpaGhAX18fRkZGUFZWJmw14zgOkUgEQPz2M2BWrOA4Dg6Hg4lFeaStrQ0ajYYFrGYwGAwGg8FglARspsBgMBgljMPhgFarRTAYxNjYGKampgAgLnaJWBQihCASicBsNmPBggV5L+/eDK0HJhYxGAwGg8FgMEoBJhgxGAxGidPc3AwAGB0dxfT0NACgpqYGRqMxztMIACKRCAghkmPoMBgMBoPBYDAYjL0TJhgxGAxGiVNeXo7q6mrhb4fDAYPBgBUrVsBoNMYFW6b/lpqli8FgMBgMBoPBYOydsBhGDAaDMQ9YsGCB4D20cOFC4XODwQC32w23243h4WEh2xbzMGIwGAwGg8FgMBjpYIIRg8FgzBMWLVo05zMqDA0PDyMUCmFsbAwAoNMx889gMBgMBoPBYDBSw7akMRgMxjxGr9cDmM2UJg5+zTyMGAwGg8FgMBgMRjrYEjODwWDMY8QBrysqKtDQ0ACNRsMydTEYDAaDwWAwGIy0MA8jBoPBmMeUl5dDq9WisrISjY2N0Gq1TCxiMBgMBoPBYDAYGWEeRgwGgzGPsdlsaG9vL3QxGAwGg8FgMBgMRonBPIwYDAaDwWAwGAwGg8FgMBhxMMGIwWAwGAwGg8FgMBgMBoMRBxOMGAwGg8FgMBgMBoPBYDAYcTDBiMFgMBgMBoPBYDAYDAaDEQcTjBgMBoPBYDAYDAaDwWAwGHEwwYjBYDAYDAaDwWAwGAwGgxEHE4wYDAaDwWAwGAwGg8FgMBhxMMGIwWAwGAwGg8FgMBgMBoMRBxOMGAwGg8FgMBgMBoPBYDAYcegKXYBigxACAHC73QUtB8/z8Hg8MJlM0GiYrlcqsHorXVjdlS6s7koXVnelCau30oXVXenC6q40YfVWusznuqNaB9U+0sEEowQ8Hg8AoLm5ucAlYTAYDAaDwWAwGAwGg8FQHo/Hg/Ly8rS/4YgUWWkvgud5DA8Pw263g+O4gpXD7XajubkZAwMDKCsrK1g5GPJg9Va6sLorXVjdlS6s7koTVm+lC6u70oXVXWnC6q10mc91RwiBx+NBY2NjRu8p5mGUgEajQVNTU6GLIVBWVjbvGujeAKu30oXVXenC6q50YXVXmrB6K11Y3ZUurO5KE1Zvpct8rbtMnkWU+bUZj8FgMBgMBoPBYDAYDAaDkTNMMGIwGAwGg8FgMBgMBoPBYMTBBKMixWg04qabboLRaCx0URgyYPVWurC6K11Y3ZUurO5KE1ZvpQuru9KF1V1pwuqtdGF1NwsLes1gMBgMBoPBYDAYDAaDwYiDeRgxGAwGg8FgMBgMBoPBYDDiYIIRg8FgMBgMBoPBYDAYDAYjDiYYMRgMBoPBYDAYDAaDwWAw4mCCEYPBYDAYDAaDwWAwGAwGIw4mGKnMvffeiwMPPBBGoxGnnXZa3HeffPIJDj/8cJSVlWHJkiV4+OGHhe9CoRCOPPJI1NbWoqysDCtWrMD9998fd3xnZycOO+wwWCwWLFu2DE8//XQ+bmmvIdu6E7NlyxYYDIY5x7O6U5dc6m7RokUwm82w2Wyw2WxwOBxx3w8PD+PEE0+E1WpFS0sL/vjHP6p8N3sPudQbIQS33XYbFi1aBKvVimXLluGDDz4QvmfvnLpkW3dvvfWW8K7R/zQaDb773e8Kv2HvnLrk8t69/fbbOOSQQ1BeXo4FCxbguuuuA8/zwves7tQjl3p7+eWXsf/++8Nut2PVqlX4z3/+E/c9s5fqEgqFcMkll2Dx4sWw2+1YsWIFHnzwQeF7t9uNc889F2VlZairq8Ott94ad3yu3zOyI9d6u+GGG7BmzRrodDp8//vfn3N+Zi/VI5e6Gx8fx9e+9jU0NTWhrKwM++233xybOO/rjjBU5V//+hd58sknyXe+8x1y6qmnCp87nU5SW1tL7rvvPhKNRsn7779PysrKyFtvvUUIISQajZJNmzaRSCRCCCFk69atpLa2lmzYsIEQQkg4HCatra3khhtuIIFAgDzzzDPEarWS7u7uvN/jfCXbuqPEYjFyyCGHkCOPPDLueFZ36pNL3S1cuJA8+eSTKc+9bt06csEFFxCv10vef/99Ul5eTt544w0V72bvIZd6u+6668hhhx1Guru7Cc/zZPfu3WR4eJgQwt65fJCrvaSMjo4SnU5H3nnnHeEz9s6pSy7jlMrKSvLzn/+cRKNRsmvXLrJo0SLy+9//XjgHqzv1yLbeenp6iNVqJc888wyJxWLkmWeeIRaLhfT09BBCmL3MB16vl9xwww1k586dhOd58t577xGHw0FefPFFQggh3/jGN8hxxx1HnE4n2bFjB2lubiZ/+ctfhONz/Z6RHbnW25///Gfy/PPPk9NPP51873vfm3N+Zi/VI5e66+npIb/85S/JwMAAicVi5OmnnyYWi4Vs3bpVOP98rzsmGOWJm266Ka5Df+6550hzc3Pcb775zW+S888/P+nx27ZtI3V1deTBBx8khBDyyiuvEIfDQcLhsPCbE088kdx4442Kl31vJ9u6+/Wvf00uuOCCOcezussf2dRdOsFo586dRKPRkNHRUeGzyy+/nHzjG99Qsth7PXLrbWpqihiNRrJjx46k52PvXP7Ita/7xS9+QVauXCn8zd65/JHNeweADA0NCd9ffPHF5Dvf+Q4hhNVdvpBbb//7v/9LjjjiiLjvjzzySHLTTTcRQpi9LBSnn346ueGGG4jP5yMGg4F89NFHwnd33HEHWbduHSGE5Pw9Q1mk1puY888/f45gxOxl/smm7ij77bcfeeCBBwghe0fdsS1pBYLneRBC5ny2adOmuM9OOukkmEwmrFq1CnV1dTj99NMBAJs2bcLq1auh1+uF3+67775zjmcoj5S66+vrw29/+1v88pe/nHM8q7vCIfW9u/TSS1FdXY1DDz0Uzz//vPD5pk2b0NDQgLq6OuEzVnfqk6ne3n//fRiNRjzyyCNobGzEokWLcO211yIcDgNg71whkfrOUR588EFcdNFFwt/snSscmequsrISF154IR544AFEIhH09PTglVdewZe+9CUArO4KRaZ6y/Q9s5f5JxgM4sMPP8TatWuxY8cOhMNh7LvvvsL34uef6/cM5ZBTb5lg9jK/5FJ34+Pj6OzsxNq1awHsHXXHBKMCceihh8Ln8+Hee+9FJBLBO++8gyeffBJutzvud88++yx8Ph/eeOMNnHnmmTCbzQAAr9c7J7aKw+GAx+PJ1y3stUipu0svvRS33HILqqqq5hzP6q5wSKm7v/71r9i1axeGhoZw5ZVX4swzz8RHH30EgNVdochUb9PT03C73eju7kZXVxc2bNiAF154Ab/4xS8AsHorJFL7OmA2nlFvby++8Y1vCJ+xuiscUuru7LPPxv333w+z2Yy2tjacdNJJOP744wGwuisUmert2GOPxUcffYSnnnoK0WgUTz31FN555x3he1Zv+YUQgosvvhhLly7FGWecAa/XC6vVCp1OJ/xG/Pxz/Z6hDHLrLRPsvcsfudRdOBzGV7/6VZx99tk48MADAewddccEowJRVVWFZ555Bv/4xz9QX1+P/9/e/YZUef5xHP945taZntRhWok2i1gb2hGjnlTig+wf5IxqUCuLUAhq0B9GC4JCag+2iBZBlBF7smASh/4tVhH9oW0h0j9KwrmWK4tlJhnmcedo39+D2L3uXy2Xx3MO6PsF58m57vvyus+H6/Lw5dz3tWHDBi1fvvyVBYa33npLxcXFevDggfOLFZ/Pp/b2dtdx7e3tGjp0aEzGP5j1lt13332n7u5ulZeXv/J8souf/zLvioqKlJSUpCFDhujTTz9VaWmpAoGAJLKLl95y8/l8kqSqqir5fD6NGjVKq1ev1rFjx5x2couPN/lft3//fn388cfKyMhw3iO7+Oktu4aGBpWVlWnHjh3q6urS/fv3dfPmTW3YsEES2cVLb7mNGzdONTU1qqqqUmZmpvbv36+FCxe61lNyiw0z08qVK9XQ0KDDhw/L4/HI5/Ops7NT3d3dznEvfv6RtiNyfcmtN8y72Igku1AopAULFigpKcn1UOvBkB0FoziaMmWKfvnlFz169EgXLlzQn3/+qeLi4n89PhwOq7GxUZLk9/tVX1+vcDjstF+9elXjx4+P+rjx+uxOnz6t2tpaDRs2TMOGDdPXX3+tH3/8USNGjJBEdvH2pvPO4/lnmfT7/bp//75aWlqc98guNl6XW0FBwWvPZc7F13+Zc0+ePNHBgwdVWVnpep85F1+vy+769evKzs7WggULlJiYqJEjR2rZsmU6fvy4JLKLp97mXFlZma5cuaK2tjYdO3ZMjY2NTjvrZWyYmVatWqXa2lqdOnVKqampkp4X9N5++21du3bNOfbFzz/SdkSmr7n1hvUy+iLJLhQK6ZNPPlEoFFIgENA777zjtA2K7GL+1KRBJhwOWzAYtI0bN1ppaakFg0H766+/zMzs8uXL1tXVZZ2dnVZdXW2ZmZnOwyOvXLlip06dss7OTguHw/bDDz9YUlKSHThwwMz+2cVi8+bN1tXVZcePH2cXi37W1+za2trs7t27zmvt2rU2c+ZMa25uNjOyi4W+ZvfHH3/Y+fPnraury0KhkNXU1JjX67WLFy86fRcVFVlFRYU9ffrUamtrLS0tbUDthBBPfc3NzKykpMSWLl1qT58+tXv37llBQYFt3brVzJhzsRBJdmZme/bssZycHOvp6Xmpb+ZcdPU1u99//93effddO3TokPX09FhLS4tNnz7dlixZ4vRNdtETyZyrq6uzcDhsT548saqqKhs7dqx1dHSYGetlrKxcudL8fr+1tra+1FZeXm6zZ8+2x48f26+//mqjRo1y7bYVaTv6LpLcQqGQBYNBW7JkiX322WcWDAZdD5dnvYyuvmYXCoWsrKzMpk2bZsFg8JV9D/TsKBhF2ebNm02S61VcXGxmz3etSE1NteTkZJs+fbrduHHDOa+urs4mTpxoQ4cOtZSUFPP7/a6tas3M6uvrbfLkyeb1em3s2LF2+PDhWF7agNfX7F7Vz4s7mJiRXbT1Nbv6+norKCiw5ORkS01NtUmTJtnRo0ddfTc3N9usWbMsKSnJsrOzrbq6OpaXNqBFMucePHhgZWVl5vP5LCsry9avX+/6Isaci65I18tJkyb96y5MzLnoiiS7I0eOWGFhoaWkpFhmZqYtXrzYHj586LSTXfREkltJSYnz/XL+/Pl29+5dVzvrZXQ1NTWZJBsyZIglJyc7rxUrVpiZWXt7uy1cuNB8Pp9lZGRYVVWV6/xI29E3kea2bNmyl+bsizuGsl5GTyTZnTt3ziSZ1+t1nfvll186xwz07BLM/m+rBAAAAAAAAAxqPMMIAAAAAAAALhSMAAAAAAAA4ELBCAAAAAAAAC4UjAAAAAAAAOBCwQgAAAAAAAAuFIwAAAAAAADgQsEIAAAAAAAALhSMAAAAAAAA4ELBCAAAoB+YmUpKSjRz5syX2nbv3q20tDQ1NzfHYWQAAABvjoIRAABAP0hISNC3336r2tpa7d2713n/9u3bWr9+vXbt2qXs7Ox+/ZvhcLhf+wMAAPgbBSMAAIB+kpOTo507d+rzzz/X7du3ZWaqqKjQjBkzVFhYqNmzZ8vn82n48OEqLy9Xa2urc+6JEyc0depUpaWlKT09XXPmzNGtW7ec9qamJiUkJKimpkbFxcXyer06cOBAPC4TAAAMAglmZvEeBAAAwEAyd+5ctbe3a968edqyZYvq6+uVl5enyspKLV26VMFgUF988YW6u7t15swZSVIgEFBCQoL8fr86Ojq0adMmNTU16erVq/J4PGpqatLo0aOVm5ur7du3q7CwUF6vVyNHjozz1QIAgIGIghEAAEA/a2lpUV5entra2hQIBHTjxg1duHBBJ0+edI5pbm5WTk6OGhoa9MEHH7zUR2trqzIyMnT9+nXl5+c7BaNvvvlGq1evjuXlAACAQYhb0gAAAPpZZmamVqxYoY8++khz587VtWvXdPbsWfl8Puf14YcfSpJz21ljY6MWLVqkMWPGKCUlRbm5uZKkO3fuuPqeOHFiTK8FAAAMTonxHgAAAMBAlJiYqMTE51+1Ojo6VFpaqq+++uql4/6+pay0tFTvv/++9u3bp6ysLD179kz5+fkKhUKu45OTk6M/eAAAMOhRMAIAAIiyCRMmKBAIKDc31ykivejRo0dqaGjQvn37VFRUJEn66aefYj1MAAAAB7ekAQAARNmqVavU1tamRYsWqa6uTrdu3dLJkye1fPly9fT06L333lN6erqqq6v122+/6cyZM1q3bl28hw0AAAYxCkYAAABRlpWVpZ9//lk9PT2aMWOGxo8frzVr1igtLU0ej0cej0fff/+9Ll26pPz8fK1du1bbtm2L97ABAMAgxi5pAAAAAAAAcOEXRgAAAAAAAHChYAQAAAAAAAAXCkYAAAAAAABwoWAEAAAAAAAAFwpGAAAAAAAAcKFgBAAAAAAAABcKRgAAAAAAAHChYAQAAAAAAAAXCkYAAAAAAABwoWAEAAAAAAAAFwpGAAAAAAAAcKFgBAAAAAAAAJf/ATHKckfNnJmRAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1400x500 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Risk-Off / Risk-On rolling-volatility ratio: 1.30x (30% higher volatility in Risk-Off).\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Mean (%)</th>\n",
-       "      <th>Median (%)</th>\n",
-       "      <th>Max (%)</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Regime</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>Risk-On</th>\n",
-       "      <td>9.8</td>\n",
-       "      <td>8.7</td>\n",
-       "      <td>29.7</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Risk-Off</th>\n",
-       "      <td>12.7</td>\n",
-       "      <td>10.9</td>\n",
-       "      <td>31.8</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "          Mean (%)  Median (%)  Max (%)\n",
-       "Regime                                 \n",
-       "Risk-On        9.8         8.7     29.7\n",
-       "Risk-Off      12.7        10.9     31.8"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def plot_volatility_by_regime():\n",
-    "    \"\"\"Plot regime bands and rolling volatility with comparison statistics.\"\"\"\n",
-    "    # Create figure with regime bands panel + volatility\n",
-    "    fig, axes = plt.subplots(2, 1, figsize=(14, 5), height_ratios=[1, 3], sharex=True)\n",
-    "\n",
-    "    # Panel 1: Regime bands (same as the cumulative returns chart)\n",
-    "    ax1 = axes[0]\n",
-    "    regime_matrix = np.zeros((2, len(labels_2)))\n",
-    "    for i, label in enumerate(labels_2):\n",
-    "        if label == good_regime:\n",
-    "            regime_matrix[1, i] = 1  # Risk-On row\n",
-    "        else:\n",
-    "            regime_matrix[0, i] = 1  # Risk-Off row\n",
-    "\n",
-    "    cmap_regime = ListedColormap([\"white\", \"#2d2d2d\"])\n",
-    "    ax1.imshow(\n",
-    "        regime_matrix,\n",
-    "        aspect=\"auto\",\n",
-    "        cmap=cmap_regime,\n",
-    "        vmin=0,\n",
-    "        vmax=1,\n",
-    "        extent=[0, len(labels_2), -0.5, 1.5],\n",
-    "        interpolation=\"nearest\",\n",
-    "        origin=\"lower\",\n",
-    "    )\n",
-    "    ax1.set_yticks([0, 1])\n",
-    "    ax1.set_yticklabels([\"Risk-Off\", \"Risk-On\"], fontsize=9)\n",
-    "    ax1.axhline(y=0.5, color=\"gray\", linewidth=1)\n",
-    "    ax1.set_title(\"Regime Classification\", fontsize=10)\n",
-    "\n",
-    "    # Panel 2: Volatility time series\n",
-    "    ax2 = axes[1]\n",
-    "\n",
-    "    # Plot rolling volatility colored by regime\n",
-    "    for i in range(len(rolling_vol) - 1):\n",
-    "        if pd.notna(rolling_vol.iloc[i]):\n",
-    "            color = \"#d0d0d0\" if labels_2[i] == good_regime else \"#2d2d2d\"\n",
-    "            ax2.plot(\n",
-    "                [i, i + 1],\n",
-    "                [rolling_vol.iloc[i] * 100, rolling_vol.iloc[i + 1] * 100],\n",
-    "                color=color,\n",
-    "                linewidth=1.2,\n",
-    "            )\n",
-    "\n",
-    "    # Add horizontal lines for regime means\n",
-    "    ax2.axhline(\n",
-    "        vol_df.loc[\"Risk-On\", \"Mean Vol\"] * 100,\n",
-    "        color=\"#4a7c59\",\n",
+    "for cluster, colour in ((risk_on_cluster, COLORS[\"recede\"]), (risk_off_cluster, COLORS[\"blue\"])):\n",
+    "    masked = np.where(labels_2 == cluster, rolling_vol.to_numpy() * 100, np.nan)\n",
+    "    ax_vol.plot(positions, masked, color=colour, linewidth=1.2)\n",
+    "for regime, colour in ((\"Risk-on\", COLORS[\"copper\"]), (\"Risk-off\", COLORS[\"amber\"])):\n",
+    "    ax_vol.axhline(\n",
+    "        rolling_vol_by_regime.loc[regime, \"Mean (%)\"],\n",
+    "        color=colour,\n",
     "        linestyle=\"--\",\n",
-    "        linewidth=2,\n",
-    "        label=f\"Risk-On avg: {vol_df.loc['Risk-On', 'Mean Vol'] * 100:.1f}%\",\n",
+    "        linewidth=1.2,\n",
+    "        label=f\"{regime} average\",\n",
     "    )\n",
-    "    ax2.axhline(\n",
-    "        vol_df.loc[\"Risk-Off\", \"Mean Vol\"] * 100,\n",
-    "        color=\"#8b4513\",\n",
-    "        linestyle=\"--\",\n",
-    "        linewidth=2,\n",
-    "        label=f\"Risk-Off avg: {vol_df.loc['Risk-Off', 'Mean Vol'] * 100:.1f}%\",\n",
-    "    )\n",
+    "ax_vol.set_ylabel(f\"Trailing {ROLLING_VOL_MONTHS}-month volatility, annualized (%)\")\n",
+    "ax_vol.set_xlabel(\"Year\")\n",
+    "ax_vol.set_xticks(ticks)\n",
+    "ax_vol.set_xticklabels(tick_labels)\n",
+    "ax_vol.legend(loc=\"upper right\")\n",
+    "ax_vol.grid(True, alpha=0.3)\n",
     "\n",
-    "    # X-axis setup\n",
-    "    years = [pd.Timestamp(ts).year for ts in factors_df.index]\n",
-    "    decade_ticks = []\n",
-    "    decade_labels = []\n",
-    "    for j, year in enumerate(years):\n",
-    "        if j == 0 or years[j - 1] != year:\n",
-    "            if year % 10 == 0:\n",
-    "                decade_ticks.append(j)\n",
-    "                decade_labels.append(str(year))\n",
-    "\n",
-    "    ax2.set_xticks(decade_ticks)\n",
-    "    ax2.set_xticklabels(decade_labels, fontsize=9)\n",
-    "    ax2.set_xlabel(\"Year\", fontsize=10)\n",
-    "    ax2.set_ylabel(\"Rolling 12-Month Volatility (%)\", fontsize=10)\n",
-    "    ax2.legend(loc=\"upper right\", fontsize=10)\n",
-    "    ax2.grid(True, alpha=0.3)\n",
-    "\n",
-    "    fig.suptitle(\n",
-    "        f\"Equity Market Volatility by Regime ({start_year}-{end_year})\",\n",
-    "        fontsize=12,\n",
-    "        fontweight=\"bold\",\n",
-    "        y=1.02,\n",
-    "    )\n",
-    "\n",
-    "    plt.show()\n",
-    "\n",
-    "    vol_ratio = vol_df.loc[\"Risk-Off\", \"Mean Vol\"] / vol_df.loc[\"Risk-On\", \"Mean Vol\"]\n",
-    "    print(\n",
-    "        f\"Risk-Off / Risk-On rolling-volatility ratio: {vol_ratio:.2f}x \"\n",
-    "        f\"({(vol_ratio - 1) * 100:.0f}% higher volatility in Risk-Off).\"\n",
-    "    )\n",
-    "    return (\n",
-    "        (vol_df * 100)\n",
-    "        .round(1)\n",
-    "        .rename(columns={\"Mean Vol\": \"Mean (%)\", \"Median Vol\": \"Median (%)\", \"Max Vol\": \"Max (%)\"})\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "vol_summary = plot_volatility_by_regime()\n",
-    "vol_summary"
+    "style.add_message_title(\n",
+    "    ax_band,\n",
+    "    \"The risk-off cluster sits on the higher-volatility stretches of the century\",\n",
+    "    subtitle=f\"Trailing {ROLLING_VOL_MONTHS}-month standard deviation of the equity index, \"\n",
+    "    f\"annualized by the square root of {MONTHS_PER_YEAR}\",\n",
+    ")\n",
+    "style.show_with_alt(\n",
+    "    fig,\n",
+    "    \"A two-row regime band above a rolling volatility series in percent. The dark risk-off \"\n",
+    "    \"segments concentrate on the peaks of the volatility series, and the risk-off average \"\n",
+    "    \"rule sits above the risk-on one.\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e5bf5e66",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003235,
-     "end_time": "2026-07-11T19:31:20.187735+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.184500+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5fa93e49",
+   "metadata": {},
    "source": [
-    "### Persist Figure 1.5 inputs\n",
+    "### Figure 1.5 inputs\n",
     "\n",
-    "The publication-quality version of Figure 1.5 is rendered by\n",
-    "`book/01_process_is_edge/figures/scripts/generate_figure_1_5_factor_regimes_volatility.py`.\n",
-    "That script reads the arrays persisted below so the book build does not\n",
-    "re-fit the GMM."
+    "The print version of Figure 1.5 is drawn by\n",
+    "`book/01_process_is_edge/figures/scripts/generate_figure_1_5_factor_regimes_volatility.py`\n",
+    "in the book repository. It reads the arrays written below, so the book build renders the\n",
+    "figure from this notebook's fit rather than re-estimating the mixture."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "9399c748",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:20.194597Z",
-     "iopub.status.busy": "2026-07-11T19:31:20.194517Z",
-     "iopub.status.idle": "2026-07-11T19:31:20.197727Z",
-     "shell.execute_reply": "2026-07-11T19:31:20.197303Z"
-    },
-    "papermill": {
-     "duration": 0.007218,
-     "end_time": "2026-07-11T19:31:20.198022+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.190804+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "f299218e",
+   "metadata": {},
    "outputs": [],
    "source": [
     "ARTIFACT_DIR = OUTPUT_DIR / \"figure_1_5\"\n",
@@ -1643,10 +938,10 @@
     "    ARTIFACT_DIR / \"inputs.npz\",\n",
     "    dates=factors_df.index.astype(\"datetime64[ns]\").astype(\"int64\"),\n",
     "    labels_2=np.asarray(labels_2, dtype=np.int64),\n",
-    "    good_regime=np.int64(good_regime),\n",
+    "    good_regime=np.int64(risk_on_cluster),\n",
     "    rolling_vol=rolling_vol.to_numpy(dtype=float),\n",
-    "    risk_on_mean_vol=float(vol_df.loc[\"Risk-On\", \"Mean Vol\"]),\n",
-    "    risk_off_mean_vol=float(vol_df.loc[\"Risk-Off\", \"Mean Vol\"]),\n",
+    "    risk_on_mean_vol=float(rolling_vol_by_regime.loc[\"Risk-on\", \"Mean (%)\"]) / 100,\n",
+    "    risk_off_mean_vol=float(rolling_vol_by_regime.loc[\"Risk-off\", \"Mean (%)\"]) / 100,\n",
     "    start_year=np.int64(start_year),\n",
     "    end_year=np.int64(end_year),\n",
     ")"
@@ -1654,646 +949,374 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b536a16e",
-   "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.003273,
-     "end_time": "2026-07-11T19:31:20.204540+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.201267+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "69e4ff74",
+   "metadata": {},
    "source": [
-    "## Factor Behavior by Regime"
+    "## What each factor earned in each regime\n",
+    "\n",
+    "The volatility check says the two environments differ in how much the market moved. The\n",
+    "more useful question for portfolio construction is whether the strategies behave\n",
+    "differently in them, because a strategy that earns its premium in both is a diversifier\n",
+    "and one that only earns it in the calm environment is leverage on the market in disguise.\n",
+    "\n",
+    "Each bar below is the mean monthly return of one series over the months assigned to one\n",
+    "regime, multiplied by twelve. This is an average within a set of months, not the return of\n",
+    "a strategy that switched between them - no rule available in real time would have produced\n",
+    "this partition."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "89e168a5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:20.211829Z",
-     "iopub.status.busy": "2026-07-11T19:31:20.211695Z",
-     "iopub.status.idle": "2026-07-11T19:31:20.300614Z",
-     "shell.execute_reply": "2026-07-11T19:31:20.300123Z"
-    },
-    "lines_to_next_cell": 0,
-    "papermill": {
-     "duration": 0.093255,
-     "end_time": "2026-07-11T19:31:20.301012+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.207757+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+UAAAHsCAYAAAC0UwxrAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAtbpJREFUeJzs3XdYE1nbBvA7oQsK0ouoqFixYO/oWhAWG3ax997XtirYu2Lva1lXbGt3bVhRd11dV127KIgdVBQU6ef7w495EwmQKBCE+3dduUhmzpx5JpOEPDlnzpEJIQSIiIiIiIiIKNvJtR0AERERERERUV7FpJyIiIiIiIhIS5iUExEREREREWkJk3IiIiIiIiIiLWFSTkRERERERKQlTMqJiIiIiIiItIRJOREREREREZGWMCknIiIiIiIi0hIm5URERERERERawqSciIgojzlz5gxkMhlkMhl69Oih7XC0omjRotJzQMr4+iAiyl5MyomIvkN+fn7Sl2ZVNzMzsyzdv7+/P/z8/ODn55el+0lPjx49Uh23np4e7O3t4e3tjb/++uub6g8NDZWOcd++fZkTdB725fnq169fqjK///67UhlbW1stRPpt9u3bJ71uQkND1domNDRU5fvYxMQErq6umDFjBj59+pS1gRMRkdboajsAIiL6/vj7++Px48cAoNXE/EuJiYl48eIF9u7di8OHD+P8+fOoVq3aV9UVGhqKqVOnAgC6d++OVq1aZWKktH37dixevBjGxsbSsnXr1mkxosyxb98+bN68GQDQoEEDFC1a9Kvr+vjxI65du4Zr167h6tWr2LNnTyZFmT5XV1cEBQUBAGxsbLJln0REeRlbyomIvnMeHh4ICgpSuh09elTbYX2zjx8/ql22Z8+eCAoKQkBAAIoUKQIAiI+Px5o1a7IqvEyjyXHmJtHR0dixY4f0+PHjxzhx4kSW7/d7eL6DgoIQGBiIwYMHS8v27t2LJ0+eZMv+TU1NUbduXdStWxfOzs7Zsk8ioryMSTkR0XfO2tpa+gKdcqtZsyaAzwnIwIEDUbVqVdjY2EBfXx+mpqaoVasWNmzYoLK+o0ePwtPTE1ZWVtDX14eDgwPatm2Lx48fY9OmTZDJZFIrOQCl7rYphBBYu3Ytatasifz588PQ0BClS5fGxIkT8f79e6X9NWjQQNr+6tWr6NWrFywtLWFiYqL2c1C4cGHUrVsXHTt2xLBhw6TlqpKYoKAgtGjRQjo+JycnjBo1CpGRkUoxNWzYUHq8efPmVNfYKsat2E1Z8dKCTZs2ScsVr2EOCwtDmzZtYGpqChcXFwDK3buPHz+OKVOmoFChQjA0NESdOnVw/fp1peO4fv06WrZsCWtra+jp6cHCwgKVKlXCgAEDEBYWpvZzBwCnTp1C9erVYWhoCCcnJ/j7+0vrNmzYIMXl6+urtN3+/fuldUOHDlV7f/nz5wcArF+/Xmk/ycnJ0rovafJaVuwO3qBBA5w7dw61atWCkZGRUqL7pf/++w8FCxaETCaDkZERAgMDAQAJCQlYtGgRqlSpAmNjYxgbG6NGjRrYunVrqn2mtJIDQMOGDaU4zpw5o/bzU7duXTRq1AjLli2DqamptPzp06dK5T58+AA/Pz+4uLjAyMgIBQoUQIMGDXDkyJFUdX769AkjRoyAlZUVTExM0KJFC4SGhqq8tj6ta8oVX6NHjhzBsGHDYGFhAXNzcwwZMgRxcXEICwtDixYtYGJiAltbW0yaNAnJyclKsQghsHHjRtSpUwcFChSAkZERKlasiCVLlqQqS0SUJwgiIvru+Pr6CgACgOjevXua5V68eCGVU3WbOnWqUvmpU6emWfb06dNi48aN6dYnhBDJycmiY8eOaZYpXbq0ePv2rbRPNzc3aV2xYsVS1ZeW7t27S+V8fX2l5QsWLJCW9+jRQ2mbdevWCblcrjKuUqVKSXEpxvTlLeX5ViwTEhKi8txs3LhRWl6kSBGVx1mkSJFUx/Pl8wBAFC1aVCQkJAghhHj9+rWwsrJKM8YTJ06k+9ydPn1aKlumTBmhp6eXqo7Zs2cLIYSIjo4WJiYmAoAoUaKEUj29evWSyl+8eFHt89W3b1/p/q1bt0RiYqJwcHAQAES/fv2kdTY2NtL2mryWQ0JCpOX29vbC0NAw1flTPB8p29jZ2QkAQl9fXxw+fFgIIUR8fLxo1KhRmvsdO3Zsqn2m9f5Jy5fbpkhOThYFChSQloeGhkrr3r17J8qXL5/m/lasWKG0j5YtW6Yq4+joKMzNzVPtV/H1ofj5ongOixcvnqq+rl27Cicnp1TL161bpxRLt27d0oy7Q4cO6b2MiIhyJbaUExF95xRbcb9s3cqXLx+mTZuGnTt34vjx4zh9+jS2b98udUmdP38+4uPjAQBXrlxRagnt3bs3Dh48iICAALRr1w5yuRyenp4ICgpSGoBLsds8AOzcuRPbt28HABQsWBBr167F3r17UaFCBQDA3bt3MXHiRJXHEhYWBl9fXxw7dgyLFy9W+zkICwvD+fPnsWPHDixduhQAoKOjgz59+khlnj17hiFDhkitscuWLcOxY8fQs2dPAMC9e/ekuJYtWybVAyhfIvDzzz+rHVdaXr16hUWLFuH48eMqn4snT55g7ty52LNnDxwdHQF8bok9duwYAODPP/9EREQEAKBTp044ceIE9u3bhwULFsDNzQ06Ojpqx3Lnzh20a9cOhw8fxsiRI6Xlfn5+eP36NUxMTNC+fXsAQHBwMC5dugQASE5OxuHDhwF87gVQq1YttfdZuXJluLq6AvjcWv7HH3/g2bNn0NXVTXO0b01ey4qeP3+OQoUKYevWrfjjjz9Ujg0QEREBd3d3vHjxArq6uggICICnpycAYMmSJTh58iQAoGbNmti7dy92796NUqVKAQDmzZuHS5cuwc7ODkFBQfDw8JDqXbp0qfS6STledZw/fx4nT57E0KFDERUVBQBwd3eXLs0AgJ9//hn//fcfAMDT0xOHDx/Gli1bpPfmyJEjpZ4ix48fx/79+wEAhoaGWLRoEfbt2wcrKyu8fftW7bgUvXz5EmvXrsX69eshl3/+Ovnrr7/i06dP2L59u9JYE4qXkezevRtbtmwBAJQqVQoBAQE4ePCg1Ltnx44dSpc1EBHlCdr+VYCIiDSn2Bqr6qbYunXw4EHRpEkTYWlpKXR0dFKVvX79uhBCiOHDh0vLOnXqlO7+v2xlVNSiRQtp3bJly6Tl//33n7S8YMGCIjk5WQih3OI8ceJEtZ8DxVa7L2/FihWTWjpTLF68WFrfs2dPERQUJIKCgsS5c+dEvnz5BABhamoqkpKShBBptxam+JaW8rVr16Z7PMOHD5eWz5kzR1ru7+8vhBDi6NGjSi21YWFh0vOpDsVjK1y4sEhMTJTW1alTR1q3ZcsWIYQQFy5ckJYNHTpUCCHEn3/+KS0bP358hvtUPL5Vq1aJFStWCADC0tJSuLu7CwCiRYsWSq3Gii3lQqj/WlasQy6Xi7t376aKR/F8VK1aVSq7bds2pXIVK1aUyu3cuVN63UybNk1aPmTIEJXHmV7ruKKMWtn79u0roqKipPJJSUmiYMGCAvjcqh8YGCjFNWjQIGm7BQsWCCGEGDhwoLRs9OjRUj13795V2UKvTku54nu1XLly0vINGzYIIT638ufPn18AEGZmZlJZxRb7pUuXSnGvW7dOWu7l5aXW80ZElFtw9HUiou+ch4dHqtbWlBGT9+zZgzZt2qS7/bt37wAA9+/fl5Z5eXl9dTyK9dSoUUO67+Lignz58iEmJgaRkZGIiIiAtbW10rbNmzf/6v0qCgsLw6NHj9KMa+PGjdi4cWOq7d6/fy+1rGaljI7Tzc1Num9hYSHdTzlX9erVg7OzMx48eIB58+Zh3rx5yJ8/PypXrgwfHx/07t1bar3MSNWqVZVa1qtXr44LFy4AgPQc1q5dG6VLl8bdu3exY8cOLF68GAcOHJC26dSpk1r7UuTj44OffvoJr1+/lnoA9O3bN83ymryWFTk7O0ut2mm5cuUKAGDcuHGpjkXxdZPSY+BLd+7cSbf+b3Xp0iV8+vRJut7+9evX0hgI8fHxaNy4cbpxKb4XFN+TpUqVQsGCBZXGU1BX9erVpfvm5ubS/apVqwL4PNaEubk5oqOjlc6L4vOpOP6DqriJiPIKdl8nIvrOqRroLaVL7/Lly6VyPXr0wPHjxxEUFIQmTZpIy3PSwEpfO/2Sr68v4uLisGXLFsjlciQmJmLEiBG4du2axnWpOzq34sBYSUlJ0v3Xr19nuG1Gx1mwYEHpvq7u/34/F0IA+NyV+8KFC5g2bRp++OEH2NraIjo6GmfPnkW/fv0wb948tY5BFcXjUtS7d28AQHh4OI4fPy4l5eXKlZMuTdCEqakp2rZtKz12cHBQ6vr9pa99Lavzmkr5UWLNmjW4e/euWvEryuwR3YUQePz4MerVqwcAuHHjBgYOHJgpcaV1fjWlOACd4g9ABQoU+Oa6v4cR8omIMhOTciKiXOzZs2fS/WXLlqFJkyaoXbu20vIUJUuWlO6nXCucFsUv4V8mQor1/P3339L9mzdvIiYmBsDnpNPKyipVvd+SMOjr66Nr167o1q0bgM+JsuJ1rYpx+fr6QgiR6vbx40epVTW9YwSUk5KXL19K5dSZ1utbEyMhBKysrDB58mScPHkSL168wKNHj6QR6zWZz/qff/5ROr6Ua8YBoFixYtL9bt26QU9PDwAwc+ZM3Lp1C8DXtZKnULzmv0ePHuleC6/Ja1mROs/1okWLAABv376Fh4eHdD4B5dfNo0ePVL5uUq45BzJ+3aircOHC2Lhxo/SjzJ49e/Dvv/8CACwtLaUfbkxMTBAdHZ0qpqSkJKk3SPHixaV6L1++LN2/d+/eV7WSfwvF5/P06dMqn8+HDx9ma0xERNrGpJyIKBdTHBhqypQpOHbsGLp164bbt2+nKuvj4yPd37ZtG/r164fDhw9j586d8PHxwblz56T1ii25y5Ytw/nz56VBpzp37qy0z/Xr12Pfvn3o2rWrtLxDhw6Z1mL3pXHjxkl1HzhwQGr5bNu2LQwMDAAAc+bMwdSpU3H8+HHs27cPixcvRosWLdCyZUuVx3j+/HkcOXIE58+fR3h4OACgRIkS0vqhQ4di5cqV8PLyUuqem1UuXryIKlWqYNasWdi1axdOnz6NAwcOSD96xMXFqV3X48eP0b17dxw5cgRjxoyRuq4bGBigWbNmUjlra2vpsoaUMgDQsWPHrz6OevXqYfbs2fD19cWAAQPSLavJa1lTw4YNk6ZKCw0NhaenJz58+ABA+X3h5eWFzZs34+TJk9i6dSsmTZqE8uXLY+fOnVIZxdfN1q1bcfbsWZw/f/6r4ipevLhSb4L58+cD+Jz4p/wY8uHDBzRt2hTbt29HYGAgNm3ahDFjxqBEiRL466+/AEBpcLvly5dj2bJl2L9/v9J7NbsoPp9du3bF6tWrcfLkSWzfvh3Tp09HzZo1peMkIsozsvMCdiIiyhzqTom2a9euVINGGRoaiipVqqgcjGrKlClpDjalWG706NGp1ru5uQkhPg/w1KFDhzTrSW9KNMUB0zKS1pRoQgjx448/Suv69OkjLU9vSjTFYxBCiISEBGFra5uqTMrgbbdv31ZZV+nSpTMc6C2j41F8rhWnoUs5zqCgoHQHBkuZziwtigN5FStWTOVxzJgxI9V2hw4dUipTvXr1dPeT1vGtWrUqzXJpDfSmyWtZsQ7Fc6roy/ORmJgomjVrJi1r2rSpiI+PF3FxcelOifbleT548KDKMulJa0o0IYS4fPmytFxXV1eaFi0yMjLdKdG+fB2pmhLNwcHhq6dEU6w7rfdwWq/59KZEU/V+JiLK7dhSTkSUi7Vt2xZr1qyBs7MzDA0NUa1aNRw9ehQuLi4qy0+dOhWHDx9Gs2bNYGFhAT09Pdjb28Pb2xtOTk5SOV9fX/Tr1w/29vapWrxlMhm2bduG1atXo3r16jA2NoaBgQFKliyJ8ePH46+//lJqTcwKo0ePlu7/+uuvUnfkPn364Ny5c/D29oaNjQ10dXVhY2OD6tWrY/LkyVi5cqW0na6uLg4cOIC6detKA2wpKlOmDH777TeUKFEC+vr6cHFxwc6dO9GhQ4csPTbgcxfgcePGoWbNmtJxmJiYoFq1alixYgXGjRundl316tXDgQMH4OrqCgMDAxQpUgQLFy5UOfVbs2bNYG9vLz3+lq7rmtL0tawpHR0d7NixQ6rv+PHj6Nu3L/T19XH06FEsXboU1atXR/78+WFoaAgnJyf8+OOP2LBhA1q3bi3V4+XlhQULFqB48eJK4wF8rapVq6J+/foAgMTERKmrvZmZGf78809Mnz4dFStWhJGREfLlywdnZ2e0bdsWAQEB0jRjABAQEIBhw4bBwsIC+fLlw48//ohz585JXeyNjIy+OVZ1bd68GVu2bIGbmxtMTU2hr6+PwoULo1GjRli6dCkGDRqUbbEQEeUEMiH+f9QYIiIiogz06tULGzduhFwux9OnT2FnZ6ftkEgNQohUP6DdvXsXZcqUAQBUqFAB169f10ZoRER5HqdEIyIionSJ/x8E7+HDh9IggE2aNGFC/h0ZM2YMLC0t0ahRI9jZ2eHOnTv46aefpPXZ0cODiIhUY1JORERE6Xr8+LHS5QsymQyTJk3SYkSkqTdv3khd379Ur149jBo1KpsjIiKiFLymnIiIiNSio6ODUqVKYdu2bahbt662wyENNG/eHI0aNYKNjQ309PRQoEAB1KxZE0uWLMHJkydhaGio7RCJiPIsXlNOREREREREpCVsKSciIiIiIiLSEiblRERERERERFrCpJyIvkrRokUhk8lSTbGjjk2bNknb+vn5ZX5wlOuFhoZKr6EGDRpk234HDx4MmUyGUqVK4Xu5+uvChQvSc3X58mW1t0t5n2bVe9TPz0+Ka9OmTRpvn7Jt0aJFMz02dV2+fBk//PADzM3NpXiuXbsGAHj58iW6dOkCe3t7yOVyyGQy+Pv7ay1WSt+3/E/7Wrt27YJMJoOuri4eP36cbfv9Fh8/fkTBggUhk8kwf/58bYdDlGswKScipS/HKTddXV1YW1ujWbNmOHLkiLZDTFdUVBRmzZqF6tWrw8zMDAYGBnB0dETHjh1x7tw5rcQkhMCaNWtQrVo1GBsbw8TEBDVr1sTWrVtVlk9OTsaqVavg6uqKfPnywdTUFI0bN8bJkydVlg8ODoaPjw9sbGxgYGCA4sWLY9y4cYiKisrKw8pWmzZtgp+fH/z8/PDu3Ttth4OwsDCsX78eADBs2DDpy7uq98+Xtx49ekj1KH75T+t25swZAEBSUhJmzpyJ4sWLw9jYGK6urjhw4ECq2GbNmgWZTIaAgIBU6+rUqYNq1aoBAKZMmZLJz8pnij+SKN5MTEzg6uqKGTNm4NOnT1my78xy8OBBtGzZEnZ2dtDX14e5uTnq16+PZcuWITY2NlX5qKgoeHl54fTp04iMjEy1vkePHvjtt9/w4sWLb/4B59dff0X37t1Rrlw5FCxYEAYGBihRogSGDx+O169fp9pvRq8vVT+03Lx5E126dIGDgwMMDAxgbW2NevXqSa/5792ZM2ekz5OUH060KTk5WToPrVu3RpEiRaR1mpzv6OhoDBo0CFWqVIGVlZU0iF/VqlUxa9asVO+7ffv2wdXVFcbGxihevDhmz56N5ORkpTIpP+T1798/VdzGxsbo27cvAGD+/Pn48OFDZjwdRCSIKM/z9fUVANK8yWQysW/fPqVtLl++LIKCgkRQUJDG+9u4caNUt6+v7zfFfuvWLVG4cOF04x8zZsw37eNrdOvWLc14JkyYkKp89+7d03zuN2/erFT22rVrwtTUVGX5SpUqiaioqOw6zCzl5uYmHVdISIjSupCQEGmdm5tbtsQzevRoAUDo6+uL9+/fS8szev8AEH369JHKFylSJMPy58+fF0IIsXDhQgFAdOzYUVy8eFGULVtW6OjoiCtXrkj1PX36VBgbG4u6deumGfuaNWukuv/77z+1jjflfarOe1TxfKR1a926tdI2jx8/lj5DXr16pVZMilLqLVKkiMbbKoqPjxedOnVKN/aKFSuKZ8+eKW134sQJaX2tWrXEqVOnRFBQkPjw4YOIi4sTcrlcABAWFhbi0KFDIigoKFUd6jIwMEgzNicnJ/HmzRupbFqfJYq3GTNmKNX/+++/C319fZVlGzVq9FUx5zSK79ONGzemWq/4vswOBw8elPZ39OhRpXWanO8nT56ke66bNm0qlf3777+FXC4XZcuWFRcvXhQdO3YUAMTixYulMklJSaJy5crCzMxMREREqIz93r17Uv3Lli3L3CeGKI9iUk5ESl9WPDw8RFBQkNi7d6+oWLFilnwxy6ykPDo6Wjg5OUl1ubi4iK1bt4oTJ06IMWPGCB0dHWndypUrMy3+jJw8eVLar42Njdi2bZvYsWOHsLe3lxLtv//+Wyq/f/9+qby9vb3Yvn27WLx4sdDV1RUAhImJiXj58qVU3tXVVSrfr18/sX//flG/fn2t/giRFXJSUp6QkCBsbGwEAPHjjz8qrVNMLhVvRYsWlWI8dOiQVF7xB62U27p166SydnZ2Ij4+XgghRM2aNQUAcfXqVSHE/5L0iRMnSvX5+PgIuVwu/vnnnzTjf/XqlZQkjh49Wq1j/pakPCgoSAQGBorBgwcrLQ8LC1Nr3+rIrKR8zJgxUl1GRkZi+vTpIjAwUKxfv17pB7+aNWuKpKQkabvNmzdL66ZMmaJU5+PHj6V19evX/6b4hBDC0NBQ1K1bV6xevVqcOHFCTJ8+XSmJVtz//fv3U72+Tp8+LUxMTFT+MPPw4UORL18+6fjHjh0rDh48KA4dOiQWLVok/Pz8vjn+nCCnJeXe3t4CgChYsKD0fk+hyfl++fKl8Pb2FqtXrxZHjhwRf/zxR6ofZu7evSuEEGL8+PECgFi0aJEQQoh//vlHABC1a9eW6kv5LPL39083/nLlygkAokqVKpn1lBDlaUzKiUjpy0r37t2l5b///ru0vGTJkkrbpPUFZvXq1aJKlSrC2NhY6OvrC3t7e9GoUSMxd+5cqUxaSXnv3r2l5Z6eniIuLi7duFMSFADC3NxcvH37Vmm9n5+ftN7a2lp8+vRJCCHE6dOnlY736NGjomrVqsLAwEA4OjqKJUuWpNqXJgmA4pd8xS+0c+bMkZYrtpx6eHhIywMCAqTl/fv3l5YvWLBACCHEpUuXpGVlypQRycnJQgghnj9/LmQyWZpf8r6kmPBeuXJF+Pj4CBMTE2FjYyN8fX1FcnKyuH79umjQoIEwNDRM83mJi4sTc+bMERUrVhT58uUTRkZGokKFCmL27Nmpzp/ia+bFixeiS5cuwszMTJiYmIj27dtLrT+K50fVLSQkJFVSfu3aNfHDDz8IIyMjYWNjI37++WelBCopKUnMmDFDlCtXThgaGkrn2tPTU6xfvz7Dc3r27Flpf6qehy+lfNlNadlSjEWVIUOGqHxPpPwAc/PmTSGEEMuXLxcAxKhRo4QQQly4cEEAEH379s0wpkqVKgkAolixYhmWFeLbkvIUycnJSr06Ll68KK1LK0m6du2aaNGihbCyshK6urrC3NxcVKxYUfTv3188fvxYKqfqPRkYGCglL+bm5uL69evpxv38+XOlZGfTpk1K6x88eCD9OAZA/P7770KI9Hs7pNdSffr06VTbq+PYsWOplo0YMUKqw8PDI93td+/erfR+UTRo0CBp3a+//qpWPF9SPJfr168Xfn5+wtbWVuTPn1907NhRREZGijdv3oguXbqIAgUKiIIFC4r+/ftLn8mKdu3aJRo0aCBMTU2Fvr6+cHJyEoMHDxbPnz9XKqf4PB87dkxMnjxZODg4CAMDA1G7dm1x7do1qWx6nycprz3FcxIRESG6d++u8vNJ8TmtU6eOKFCggNDT0xM2NjaiTp06YuzYsdLnclri4uKEoaGhAFL3IBHi28+3EEKYmZlJ5S9fviyEEGLkyJECgFi+fLkQQoibN28KAKJy5cpCCCHevXsnrK2tRZkyZURCQkK69SvGk5k/thHlVUzKiSjNpFzxi1yDBg2UtlH1pXLLli1pfvFxcHCQyqlKyidMmCAta9Sokcova1+qW7eutI2q1uE3b94ofeE+efKkEEI56StSpIjUgqh4O3HihFJdmiTlffv2lcrPnz9fWr5s2TKlhFqIz0lLgQIFpOWKSYdiS1zLli2FEMo/RPTs2VNpv4q9Bv799990Y1RMyosXL57q+IcOHar0pU7V8xIbG6vUQv/lrX79+kqJueJrplixYqnK+/j4pDo/qm5fJuWFChVSagVMua1bt07a97Rp09Ksr06dOhme01mzZknl1blko1evXlL5efPmpVv2w4cP0mtAV1dXqYtzyg8848ePF9HR0dJ5++OPP0RSUpKoUqWKMDU1FeHh4RrF9OLFiwzLZ1ZSrvj6Dg0NldapSspfv34trKys0jxXiq+/L9+TV65cEfnz5xcAhKmpqVIX/7SsX79eqsfW1lZlItKmTRupTNeuXYUQ2Z+Uq7JixQqpjrZt26Zb9ocffpDK7ty5U2mdo6OjAD5fljF9+nTh7OwsDAwMhLOzs5g3b16GPygJoXwuVX2eNGvWTFSvXj3V8p9//lmpnrFjx6b53Nna2opHjx5JZRWfZ1WfJ0WLFpXOZ3qfJ6qS8jJlyqT5+SSEEGfOnFH5fyPlllFCe/HiRans9OnTM3x+hVD/fEdGRir1vLG2thYxMTFCCCEOHTokgM8/zERFRUkt52PHjhVC/C9pP378eIbxKP6/V/wxmYi+Dgd6IyIl4eHhOH/+PPbt24fp06dLy1UN+PKl/fv3AwB0dXWxevVqnDx5Er/99htGjx4NJyenNLdbsmQJZs+eDQCoV68eDhw4AENDwwz3d/v2bel+pUqVUq03NzeHo6OjyvIpHj9+jObNm+PgwYPo2LGjtHzNmjUZ7j8tpUqVku5v3boVT58+xfPnz7F582Zp+ZMnTwAAkZGRSoOz2djYSPetra2l+yEhIQA+D6ilqmxa5dURHR2NgIAAzJo1S1q2bNky2NraYu/evRg4cKC0XPF58ff3lwbSc3R0xLZt2xAQEIDChQsDAM6dO4fFixer3OenT5+wdetWrFy5Evr6+gCA7du34/3793B1dUVQUJDSOd21axeCgoIQFBQEOzs7pbqePn2KihUrYv/+/Rg2bJjKWFNem2ZmZti6dSsCAwOxZcsWDBgwIFV9qty5c0e6X6JEiXTLRkZGSgOuGRoaolevXumW37p1q/QaaN26Nezt7aV1vr6+aNeuHebOnYv8+fPj0qVLmDFjBjw8PLBx40b8888/8PPzg5WVFYQQePnyZZqDiinGreq9kJnOnz+PkydPYujQodKxubu7Kw1mpcqff/6JiIgIAECnTp1w4sQJ7Nu3DwsWLICbmxt0dHRUbvfgwQN4eHggOjoaJiYm+OOPP1ClSpUM41R8HlxcXKCrq5uqjOLrMKX87t27MXHiRGl5z549pdfnzz//jF27diltn7LO1dU1w5jUtWfPHum+h4dHmuXu3r2LU6dOAQDs7e3RunVrad2HDx+kz6L4+HhMnjwZDx48QFxcHB48eICxY8eq9dmvKDQ0FPPmzcOOHTuQP39+AMDRo0dx+/ZtrF+/HqtWrZLKKr5HL126hHnz5gH4/L5ZsGABDhw4gIYNGwL4PJr9oEGDVO7zyZMnmDt3Lvbs2SN95oeGhuLYsWMAgKCgIPTs2VMqP3HiROmceHp6pqrv3bt3aX4+AZ8HBUwZHG3WrFk4efIktm/fjkmTJqFs2bIZjuCuyedJiozO9/jx4yGTyVCwYEFpILYKFSrgwIEDMDIyAgD8+OOPmDZtGi5duoQCBQpg7ty56NChA3x9fXH37l0sX74cLVu2RJMmTQAAERERiI+PVxlPdn6eEOUJ2v5VgIi0L72BqqytrVMNNCaE6paelEFj8uXLJwIDA5UGw1Kk2FJeuXJlqdt1jRo1Ug1Spur623fv3gkhhFK3UlXd/YT43zW5wP8GN1JsibW2thaxsbFCiM/X5qUsr1SpkuZP5P8LDw8XlpaW6bbO6OrqCiGECAsLU1qu2O1R8dr04sWLCyGUWzu/vI61Xr160rqMuqEqtpSvXbtWWq7Y4pzSsyAiIkLl81KhQgVp+cGDB6XligMYVaxYUVqu+JrZu3evtLxZs2bScsUup+peU66vry9dc5+UlCRdH2tmZiaVT3kdODg4iD///FN8/Pgx3efnS4qXGKS8XtKi2JuhR48eGdat+DyeOXNGZZkPHz6IR48eSZclfNnNdPHixdK5MzExURq4KcWqVauk/ezYsSPDuDJzoLe+ffumem+raik/evSotGzs2LEiLCwsza7AKeUsLCykXiJGRkapnkNV1/zfv39fCCFEnz59pHo6deqkcj+rV6+WypQoUSLV86PqOcrqMQ9+/vlnqf6aNWum2zI7dOhQqeyX14d/OUhYkSJFxO+//y6WL1+uNNhYRj1vFM9l586dpeU//vijtHzy5MnS8pTrkQFIn+fDhg2TlimOexARESHFIpPJpG7kii3lw4cPl8orXiakeF20JteUZ/T5lNLCDEDs2rVLvH79Ot3n50tz586Vtv9ykDdV1Dnf48aNS/W+q1q1qrhw4UKqsvHx8eLhw4fiw4cP0jJ3d3dhYGAggoODRWBgoPR86Orqip49e6b6zLxz5460n4EDB2p0/ESUGlvKiShdERERuHXrllple/bsCZlMhpiYGDRu3BimpqZwdHREly5dcOXKFZXbXL16FUII5M+fH4cPH5ZaVlK0bdsW9erVU7r9+++/AIACBQooxZlW/ClMTU1Tra9ZsyYMDAwAABYWFtLyb5mCy8rKCoGBgUqtYjKZDG3atJEem5mZAfg8vYyiuLg46b5iC0VKOcXyimXTKq+O6tWrS/cLFiwo3a9atSoAwNLSUlqm+Lzcv39ful+jRg2V9SmWUeTm5ibd/9bnvXTp0lKvAblcLh2DYl29e/cGADx79gy1atWCiYkJSpQogf79+6cZY1pEOtNbCSGwevVq6fHgwYPTrev8+fO4ceMGAKBcuXJKz4siY2NjODk5QU9PDwAwbdo0hIeHw9/fH6dOncLIkSNhbW2NNWvWwNraGiNHjsTx48fVjjurXbp0Sa0p0erVqwdnZ2cAwLx581C4cGGYmpqiQYMGWLduXaqpmwDgzZs3Us8Qf3//VM/hL7/8kuozZObMmQAy5zMku40ZM0aKv3Tp0jhw4IDKFn7g85zSW7ZsAQDo6emhX79+SutTPvtS/Pzzz/D29sbgwYPh7e0tLU9rakZVFN//5ubm0v2UzxNA9WdKWp8nlpaWKFasGIDPr+Hg4OBU+8zMzxN16vPx8ZGeu3bt2sHS0hI2Njbw9vZGYGCgRvvK6H2p7vkeOHAgzp07h71796Jr164AgCtXrqBp06Z4+fKlUlk9PT0UK1ZM+j9x8OBBHDt2DKNGjUKBAgXQpk0bvHz5Ev7+/mjUqBE2btyIGTNmaBQ3EWmGSTkRKenevTsSEhJw9OhR5MuXD0IIzJs3DwcPHsxw26ZNm+LChQvo27evNN/206dP8dtvv8HNzQ2PHj1KtU1Kd9To6GiN51AuW7asdF/VvLNv376VumZ+WT6FYhKq+EXnW79wVKxYEVevXkVISAguX76MN2/eYPjw4dL6cuXKSftXTAxevXol3Vf8IpXS/b9o0aIqy6ZVXh2KiYZc/r9/C4pxpVDnecmo6yaQuc+7Yl1f1peiT58+OHLkCLp27QoXFxfo6+vj4cOHWLt2Ldzc3DL88q6YRKiakzrFiRMn8ODBAwCfkxPFRESVlStXSvczSuBT3Lt3D8uWLUOLFi3QtGlTbN++HQAwYcIE9OvXD+PHjwcA7NixQ2k7xbgVjycrCCHw+PFj1KtXDwBw48YNpcsg0pIvXz5cuHAB06ZNww8//ABbW1tER0fj7Nmz6Nevn9S9WZFil/Y5c+akel+kR/Ez4ebNm0hMTExV5vr16yrLZ7fk5GT0798fCxcuBPC5a/KZM2dgZWWV5ja//fab1OW6devWqS7VsLCwQL58+aTHipcXKN5XvMQmI5p8ngCZ85mS2Z/jGdXn4uKCf/75B8OGDUONGjVgamqK8PBw7N27F+7u7rh48WK69avzeaLp+S5SpAjq1auHVq1aYcuWLahfvz6Azz/MHDhwIM1Y4uPjMWrUKNjb22PixIk4cuQI3r9/j7Zt22L48OFYtmwZAO1+nhDlBUzKiSgVXV1duLu7Y+zYsdKyyZMnZ7idEAK1atXC2rVrcfXqVURHR0tfKGJiYnD06NFU2wwcOFC6Nm3lypWYM2eO0vrQ0FCIz4NSSrcGDRoAAFq1aiWV27hxY6rEasWKFVLrsZWVFWrXrp3hMWS2okWLomrVqihYsCAWLFggLffy8gLw+ctmnTp1pOWKX+b+/PNP6X5KclO3bl2l9SlfEp89e4awsDAAn79QpiT9WalkyZLS/b///lu6f+nSJZVlNKX4hV5VC6kmhBBo1qwZtmzZgv/++w8fPnzAiBEjAHz+MSOjL9FlypSR7qtqqUuhSZIdHh6O33//HcDnhCWldSsjI0aMgFwux6JFiwD878eYlCQq5YebL1vHFOPOjuSycOHC2Lhxo5TU7NmzR+rlkhYhBKysrDB58mScPHkSL168wKNHj2BiYiLV8aVChQph5MiRAD6PpfDjjz/i48eP0no/P79UnyGbNm0CAHh6ekrXDL98+VIaCyDFo0ePsG/fPumx4mdOdkpMTETXrl2xdu1aAJ97+Jw5cybVuBJfyuj1KJfLUatWLelxymfIl/cVx+bIKml9nrx58wYPHz4E8PnzUt1rsL+U2Z8n5cqVw5IlS/DXX3/h3bt32L17t1S34mtGlYw+TzQ532n1QFH8ISO9Hx0XL16M4OBgzJ07FyYmJjn284Qot1Pd34mICMDQoUMxb948xMTE4Pr16zh+/DiaNm2aZvlhw4bhxYsXaNKkCRwdHaGrq4ugoCBp/ZfdrYHPLTWHDx9GzZo1ERkZiYkTJ6JQoULo0qVLhvH169cPy5cvR2hoKN68eQM3NzeMHz8e1tbWOH78uPSDAPB5wCx1Bo9LS8oXnCJFiigNtpaWVq1awdXVFVWqVEFsbCx+/fVXqbXCzs4Offr0kcoOGDAAR44cAQCMHj0aMpkML1++xIYNGwAAJiYm0vNRvXp1uLq64t9//8W9e/fQv39/eHl5YeHChVKC3rt3b6mbc1bq3Lmz1PV68ODBiI6Ohkwmk1pqgc+DdX0txdaqdevWwdPTE0ZGRhm2PqvStm1b5M+fH/Xq1UOhQoWQmJiodEmFqtemIsUfTq5evSr9SKIoLCwMhw4dAvC55ahDhw7p1rlu3TrpR6Nu3bpJiWd6Dh06hKNHj2L8+PEoXrw4gP99aU7pZp3y98tB1VIS4mLFisHW1jbDfWWG4sWLo23btlJr/vz587Ft27Y0y1+8eBHDhg1DmzZt4OzsDEtLS9y4cQMxMTEA0j5PCxYsQHBwMA4ePIh//vkH7dq1S7dbdwo7OzsMGTJE+oFjwIABCAsLQ61atRAaGorp06dLrefVq1fPtKS8aNGiePz4MQD1WnPbtGkjfX44OjrCz89P6bIiU1NTlC9fXmmbCxcuSK38Li4uUsvpl/r27St1T585cyYsLCzw8uVL6QcQQ0ND/PjjjxoeoeY6deqEpUuXAgCWL18Oe3t7ODs7w9/fXzrv7u7uSl3iNaH4efL7779Ll4NUq1YtVTf+jMybNw9nzpzBjz/+iMKFC8PY2FgaVA7I+POkSpUqMDQ0RGxsLK5evZpqvSbne8iQIXjx4gW8vLxQvHhxxMfHY8+ePTh79qxUvnLlyirjePHiBWbMmIFatWrBx8cHgOafJ4Dy5yMRfaXsuHCdiHK2tKZEE0KIwYMHS+saN24sLVc10JviPONf3oyMjMTDhw+FEKoHSDp9+rTQ09MTAISenl6qKcnScuPGDWlKn7RuI0aMUNrmy3nKFaUs/3Lqs7SWp6VixYoqYylQoIA4f/58qvJpTaMkk8lSDbT377//Ks39rHirVKlSqgG1VElrELW0pmpSdfyxsbFKg8t9eUtvSrS0jj1lyighlKeQ+3L/6Q2kpWo/jRo1SjNOGxsbabCptCQkJAhbW1sBQHh5eaksM3HiRKnOcePGpVtfYmKiKFy4sFT+9u3b6ZYX4vPcxs7OzsLOzk5ER0dLy//55x8hl8tFzZo1xcWLF0WtWrWEXC4XV69elcq8evVKmsJJ1fSBqmTGlGhCfB6sMWW5rq6uNC2aqoG3goKC0n0vz549W6r3y9fEhw8fpLnYAYhevXqpdZzx8fGiffv26e7XxcVFPHnyROXzo+o5ymigN02nREsvtrT20blzZ2n9qlWr0q0/veNfuXJlhvGlNYhaWu/ttD5/vnZKNMW60zovN27ckAYVVbyl7F+Tz6fp06enGadcLlf5Gf+llKn2ChYsmGrgNk3Od3pT8AEQHTp0SDOGbt26CZlMJs1jLsTn95G9vb2wsLAQgYGBYsCAAQJQHjRPiP8N1le1atUMj5WIMsbu60SUrpSusgAQGBiYbvdTHx8fdO/eHaVKlYKpqSl0dHRgbW2NVq1aISgoSBqsR5UGDRpI0+MkJCSgTZs2StdypqV8+fL477//MH36dFSpUgX58+eHnp4eHBwc0K5dO5w+fTrNabmyko+PD6pUqYKCBQtCX18fhQsXRr9+/XDjxg2VrQq//PILVqxYgUqVKsHQ0BAFChRAo0aNcOLECXTr1k2pbKVKlXD58mV07twZ1tbW0NfXh5OTE8aOHYuzZ8+mGiwvqxgYGODEiROYM2cOKlSoACMjIxgaGqJ8+fKYPXs2jh8/LnUN/hr9+/fHuHHjULhwYaWup19j0KBB6NChA4oXLw4TExPo6urCwcEBPj4+OH/+fIYDeOnq6kq9FU6cOIHo6Gil9fHx8VLPBrlcjgEDBqRb36FDh6TuwT/88INSd9a0+Pv748GDB5gzZ45Sq3rlypWxd+9eaYDFjx8/Ys+ePUoDDe7bt0/qstujR48M95WZqlatKrXSJiYmSq3SqpQsWRLjxo1DzZo1YWNjA11dXZiYmKBatWpYsWIFxo0bl+a2xsbGOHTokDSl3C+//KLWOBV6enrYsWMH9u7di+bNm8PGxgZ6enowMzNDnTp14O/vj7///huFChXS8Mi1JyIiQupOXaBAgQx7Hv32229YvHgxypcvD0NDQ+TPnx8NGzbEkSNH1BoLILPMnTsXO3fuhJubGwoUKAA9PT0ULVoUgwcPxtWrVzUaK+NL5cuXx5YtW1CmTBmNW8a/5Onpif79+8PFxQUFCxaEjo4OzM3N0bRpUxw7dkytluOUKdoiIyNx+vTpr46lY8eOaN++vdJnm42NDdzd3bFly5Y0e6ZcunQJv/76K3r06KHU+8jY2BgnTpxApUqV4O3tjWPHjmHGjBkYMmSIVOb+/ftSy312f54Q5VYyITh8IhERUUaePHmCEiVKID4+HitXrszWZOVbVa9eHZcvX4aHhwf++OMPtbbZtGkTevbsCV9fX/j5+WVtgER5THJyMipUqIBbt26hffv2qQZSy8nGjh2L+fPnw8rKCiEhIRrN9kFEqrGlnIiISA2Ojo7SWAD+/v7fzZRAFy5cwOXLlwEAU6dO1XI0RAR87lHj6+sL4PM17ooD6+VkHz9+xLp16wB8Ts6ZkBNlDg70RkREpKYVK1ZgxYoV2g5DI3Xq1PlufkAgykvatWv33b03jY2N050Wkoi+DlvKiYiIiIiIiLSE15QTERERERERaQlbyomIiIiIiIi0hEk5ERERERERkZbkiYHekpOT8fz5c+TPnx8ymUzb4RAREREREVEuJ4RAdHQ07O3tIZen3R6eJ5Ly58+fw9HRUdthEBERERERUR7z5MkTFCpUKM31eSIpz58/P4DPT0aBAgW0HA0RERERERHldlFRUXB0dJTy0bTkiaQ8pct6gQIFmJQTERERERFRtsnoEmoO9EZERETpio2NRatWrVCyZElUrFgRTZo0QXBwMAAgPDwczZo1g7OzM1xcXHDu3Lk06wkLC0Pz5s1RqlQplC1bFsuWLQMAhISEoEaNGihXrhxmzZollb9z5w5atGiRtQdHRESkZUzKiYiIKEP9+vXDvXv3cP36dbRs2RJ9+vQBAIwfPx41a9bEgwcPsHHjRnTu3BkJCQmpthdCoHXr1ujWrRvu3buH27dvo3379gCAFStWYPDgwbhx4wY2b96M6OhoCCEwYsQILFmyJFuPk4iIKLsxKSciIqJ0GRoawtPTU+p+V7NmTYSGhgIAdu7ciQEDBgAAqlWrBnt7e5w9ezZVHSdPnoSBgQHatWsnLbOxsQEA6OnpISYmBgkJCUhOToZcLsfq1avRtGlTODk5ZfHRERERaVeeuKaciIiIMs+SJUvQsmVLvHnzBgkJCbC1tZXWFS1aFGFhYam2uX37NqysrNCxY0fcu3cPRYsWxcKFC1GsWDEMGzYMPXr0wJo1azBmzBi8f/8eu3fvxvHjx7PzsIiIciwhBBITE5GUlKTtUEiBjo4OdHV1v3nabSblREREpLZZs2YhODgYJ0+exKdPn9TeLjExEadOncJff/2FcuXKYfXq1Wjfvj2uXLkCOzs7HDt2TCrbrl07LFy4EKdPn8aqVatgYGCA2bNno0iRIllxSEREOVp8fDxevHiBmJgYbYdCKuTLlw92dnbQ19f/6jqYlBMREZFaFixYgD179iAwMBD58uVDvnz5oKuri5cvX0qt5aGhoShcuHCqbQsXLgxXV1eUK1cOANC1a1cMGjQICQkJ0NPTk8r9/vvvKF68OCpVqoQyZcrg77//xpUrVzBlyhRs3rw5ew6UiCiHSE5ORkhICHR0dGBvbw99ff1vbpWlzCGEQHx8PCIiIhASEgJnZ2fI5V93dTiTciIiIsrQokWLEBAQgMDAQJiZmUnL27Vrh9WrV8PPzw+XL1/Gs2fP4Obmlmp7Dw8PjB07Fs+ePYODgwP++OMPlClTRikhf/fuHZYsWSK1msfExEAul0Mul+PDhw9ZfoxERDlNfHw8kpOT4ejoiHz58mk7HPqCkZER9PT08PjxY8THx8PQ0PCr6mFSTkREROl6+vQpRo8ejWLFiqFhw4YAAAMDA1y6dAlz585F165d4ezsDH19fWzdulVKtKdMmQJ7e3sMGDAAxsbGWL16NX788UcIIWBqaort27cr7WfcuHHw8/ODkZERAGDSpEmoWrUq9PX1sWHDhuw9aCKiHORrW2Ap62XGuZEJIUQmxJKjRUVFwdTUFO/fv0eBAgW0HQ4REREREVGGYmNjERISAicnp69uhaWsld45UjcP5U8uRERERERERFrCpJyIiIiIiIiyVWhoKGQyGa5du5apZb9HvKaciIiIiIjoO+PVugWev3qeLfuyt7HHob0HNNqmR48e0qwZurq6KFSoENq1a4dp06bB0NAQjo6OePHiBSwtLbMiZMmTJ0/g6+uLo0eP4vXr17Czs0OrVq0wZcoUWFhYZOm+1cWknIiIiIiI6Dvz/NVz2DUqmT37Onn/q7Zr1qwZNm7ciISEBPzzzz/o3r07ZDIZ5s6dCx0dHWk6zazy6NEj1KpVCyVLlkRAQACcnJxw69Yt/PTTTzhy5Aj++usvmJubZ2kM6mD3dSIiIiIiIsp0BgYGsLW1haOjI1q1aoXGjRvjxIkTAFJ3SY+MjISPjw+srKxgZGQEZ2dnbNy4UWW9SUlJ6NWrF0qXLo2wsLA09z948GDo6+vj+PHjcHNzQ+HCheHh4YHAwEA8e/YMP//8s1S2aNGimDVrFnr16oX8+fOjcOHCWLt2beY9GelgSzkRERGly9vLHeHPnmg7DFg7OGLPoWPaDoOIiL7CzZs3cfHiRRQpUkTl+smTJ+P27ds4cuQILC0tERwcjE+fPqUqFxcXh06dOiE0NBRBQUGwsrJSWd/bt29x7NgxzJw5U5pqM4WtrS18fHywY8cOrFy5EjKZDACwcOFCTJ8+HRMnTsTu3bsxcOBAuLm5oVSpUt949OljUk5ERETpCn/2BK2swrUdBvY903YERESkiUOHDsHExASJiYmIi4uDXC7H8uXLVZYNCwuDq6srqlatCuBzy/WXPnz4gB9//BFxcXE4ffo0TE1N09z3gwcPIIRAmTJlVK4vU6YMIiMjERERAWtrawCAp6cnBg0aBAAYN24cFi9ejNOnT2d5Us7u60RERERERJTpGjZsiGvXruHSpUvo3r07evbsiTZt2qgsO3DgQGzfvh2VKlXC2LFjcfHixVRlOnXqhI8fP+L48eNKCfmAAQNgYmIi3RQJIdSOt0KFCtJ9mUwGW1tbhIdn/Y/STMqJiIiIiIgo0xkbG6NEiRKoWLEifvnlF1y6dAkbNmxQWdbDwwOPHz/GyJEj8fz5czRq1AhjxoxRKuPp6YkbN27gzz//VFo+bdo0XLt2TboBQIkSJSCTyXDnzh2V+7tz5w4KFiyo1P1dT09PqYxMJkNycrKmh60xJuVERERERESUpeRyOSZOnIhJkyapvFYcAKysrNC9e3ds3boV/v7+qQZaGzhwIObMmYMWLVrg7Nmz0nJra2uUKFFCugGAhYUFmjRpgpUrV6ba38uXL/Hbb7+hQ4cO0vXk2sSknIiIiIiIiLJcu3btoKOjgxUrVqRaN2XKFOzfvx/BwcG4desWDh06pPJ68KFDh2LGjBnw8vLC+fPn093f8uXLERcXB3d3d5w7dw5PnjzB0aNH0aRJEzg4OGDmzJmZdmzfQusDvc2ePRt79uzB3bt3YWRkhNq1a2Pu3LlKF9PHxsZi9OjR2L59u/Skrly5EjY2NlqMnIiIiIiISDvsbey/ev7wr9lXZtDV1cWQIUMwb948eHh4KK3T19fHhAkTEBoaCiMjI9SrVw/bt29XWc+IESOQnJwMT09PHD16FLVr11ZZztnZGVeuXIGvry/at2+Pt2/fwtbWFq1atYKvr2+OmKMcAGRCkyvfs0CzZs3QsWNHVKtWDYmJiZg4cSJu3ryJ27dvw9jYGMDnbgqHDx/Gpk2bYGpqiiFDhkAul+PChQtq7SMqKgqmpqZ4//49ChQokJWHQ0RElOvUdS2bM0Zfj7DG+X9vazsMIqJsExsbi5CQEDg5OcHQ0FDb4ZAK6Z0jdfNQrbeUHz16VOnxpk2bYG1tjX/++Qf169fH+/fvsWHDBmzbtg0//PADAGDjxo0oU6YM/vrrL9SsWVMbYRMRERERERF9M60n5V96//49AEhdCf755x8kJCSgcePGUpnSpUujcOHC+PPPP1Um5XFxcYiLi5MeR0VFAQCSk5OzZfQ8IiKi3EQmlwMy7Q9DI5PL+X+ciPKU5ORkCCGkG+U8KedGVa6p7v+sHJWUJycnY8SIEahTpw5cXFwAfB4ZT19fH2ZmZkplbWxs8PLlS5X1zJ49G1OnTk21PCIiArGxsZkeNxERUW5WrERJGJtqfxyXYmam2TJfLBFRTpGQkIDk5GQkJiYiMTFR2+GQComJiUhOTsabN29STakWHR2tVh05KikfPHgwbt68meEoehmZMGECRo0aJT2OioqCo6MjrKyseE05ERGRhh4F30d5S+0nw49eW8Pa2lrbYRARZZvY2FhER0dDV1cXuro5KnWj/6erqwu5XA4LC4tU15SrOw5AjjmzQ4YMwaFDh3Du3DkUKlRIWm5ra4v4+Hi8e/dOqbX81atXsLW1VVmXgYEBDAwMUi2Xy+WQy7Xf/Y6IiOh7IpKTAaH9buMiOZn/x4koT5HL5ZDJZNKNcp6Uc6Mq11T3f5bW/7MJITBkyBDs3bsXp06dgpOTk9L6KlWqQE9PDydPnpSW3bt3D2FhYahVq1Z2h0tERERERESUabTeUj548GBs27YN+/fvR/78+aXrxE1NTWFkZARTU1P07t0bo0aNgrm5OQoUKIChQ4eiVq1aHHmdiIiIiIiIvmtaT8pXrVoFAGjQoIHS8o0bN6JHjx4AgMWLF0Mul6NNmzaIi4uDu7s7Vq5cmc2REhEREREREWUurSfl6gztb2hoiBUrVmDFihXZEBERERERERFR9tB6Uk5ERERERESa8fZyR/izJ9myL2sHR+w5dCxT6wwNDYWTkxP+/fdfVKpUKdPKfq2YmBh07doVJ06cQHR0NCIjI6Gvr59q2ZdTdWcGJuVERERERETfmfBnT9DKKnumq9z3TPNtevTogc2bNwP4PG1YoUKF0K5dO0ybNg2GhoZwdHTEixcvYGlpmcnRKnvy5Al8fX1x9OhRvH79GnZ2dmjVqhWmTJkCCwsLqdzmzZsRFBSEixcvwtLSEqampli9enWqZVmBSTkRERERERFlumbNmmHjxo1ISEjAP//8g+7du0Mmk2Hu3LnQ0dFJc4rrzPLo0SPUqlULJUuWREBAAJycnHDr1i389NNPOHLkCP766y+Ym5sDAB4+fIgyZcrAxcVF2l7Vsqyg9SnRiIiIiIiIKPcxMDCAra0tHB0d0apVKzRu3BgnTpwA8LlLukwmw7Vr1wAAkZGR8PHxgZWVFYyMjODs7IyNGzeqrDcpKQm9evVC6dKlERYWlub+Bw8eDH19fRw/fhxubm4oXLgwPDw8EBgYiGfPnuHnn38G8HnQ8YULF+LcuXOQyWRo0KCBymVZhS3lRERERERElKVu3ryJixcvokiRIirXT548Gbdv38aRI0dgaWmJ4OBgfPr0KVW5uLg4dOrUCaGhoQgKCoKVlZXK+t6+fYtjx45h5syZMDIyUlpna2sLHx8f7NixAytXrsSePXswfvx43Lx5E3v27IG+vj4AqFyWFZiUExERERERUaY7dOgQTExMkJiYiLi4OMjlcixfvlxl2bCwMLi6uqJq1aoAgKJFi6Yq8+HDB/z444+Ii4vD6dOn073G+8GDBxBCoEyZMirXlylTBpGRkYiIiIC1tTXy5csHfX19pS71qpZlBXZfJyIiIiIiokzXsGFDXLt2DZcuXUL37t3Rs2dPtGnTRmXZgQMHYvv27ahUqRLGjh2LixcvpirTqVMnfPz4EcePH1dKyAcMGAATExPppkidKbi1jUk5ERERERERZTpjY2OUKFECFStWxC+//IJLly5hw4YNKst6eHjg8ePHGDlyJJ4/f45GjRphzJgxSmU8PT1x48YN/Pnnn0rLp02bhmvXrkk3AChRogRkMhnu3Lmjcn937txBwYIF0+z+np2YlBMREREREVGWksvlmDhxIiZNmqTyWnEAsLKyQvfu3bF161b4+/tj7dq1SusHDhyIOXPmoEWLFjh79qy03NraGiVKlJBuAGBhYYEmTZpg5cqVqfb38uVL/Pbbb+jQoQNkMlkmH6nmmJQTERERERFRlmvXrh10dHSwYsWKVOumTJmC/fv3Izg4GLdu3cKhQ4dUXg8+dOhQzJgxA15eXjh//ny6+1u+fDni4uLg7u6Oc+fO4cmTJzh69CiaNGkCBwcHzJw5M9OO7VtwoDciIiIiIqLvjLWDI/Y9y759ZQZdXV0MGTIE8+bNg4eHh9I6fX19TJgwAaGhoTAyMkK9evWwfft2lfWMGDECycnJ8PT0xNGjR1G7dm2V5ZydnXHlyhX4+vqiffv2ePv2LWxtbdGqVSv4+vpKc5Rrm0x8D1e+f6OoqCiYmpri/fv3KFCggLbDISIi+q7UdS2LVlbh2g4D+yKscf7f29oOg4go28TGxiIkJAROTk4wNDTUdjikQnrnSN08lN3XiYiIiIiIiLSESTkRERERERGRljApJyIiIiIiItISJuVEREREREREWsKknIiIiIiIKAfLA2Nzf7cy49wwKSciIiIiIsqB9PT0AAAxMTFajoTSknJuUs7V1+A85URERERERDmQjo4OzMzMEB7+eVrKfPnyQSaTaTkqAj63kMfExCA8PBxmZmbQ0dH56rqYlBMREREREeVQtra2ACAl5pSzmJmZSefoazEpJyIiIiIiyqFkMhns7OxgbW2NhIQEbYdDCvT09L6phTwFk3IiIiIiIqIcTkdHJ1MSQMp5ONAbERERERERkZYwKSciIiIiIiLSEiblRERERERERFrCpJyIiIiIiIhIS5iUExEREREREWkJk3IiIiIiIiIiLWFSTkRERERERKQlTMqJiIiIiIiItIRJOREREREREZGWMCknIiIiIiIi0hIm5URERERERERawqSciIiIiIiISEuYlBMRERERERFpCZNyIiIiIiIiIi1hUk5ERERERESkJUzKiYiIiIiIiLSESTkRERERERGRljApJyIiIiIiItISJuVEREREREREWsKknIiIiIiIiEhLmJQTERERERERaQmTciIiIiIiIiItYVJOREREREREpCVMyomIiIiIiIi0hEk5ERERERERkZYwKSciIiIiIiLSEiblRERERERERFrCpJyIiIiIiIhIS5iUExEREREREWkJk3IiIiIiIiIiLWFSTkRERERERKQlTMqJiIiIiIiItIRJOREREREREZGWMCknIiIiIiIi0hIm5URERERERERawqSciIiIiIiISEuYlBMRERERERFpCZNyIiIiIiIiIi1hUk5ERERERESkJUzKiYiIiIiIiLSESTkRERERERGRljApJyIiIiIiItISJuVEREREREREWsKknIiIiIiIiEhLmJQTERERERERaQmTciIiIiIiIiItYVJOREREREREpCVMyomIiIiIiIi0ROtJ+blz59C8eXPY29tDJpNh3759Sut79OgBmUymdGvWrJl2giUiIiIiIiLKRFpPyj9+/IiKFStixYoVaZZp1qwZXrx4Id0CAgKyMUIiIiIiIiKirKGr7QA8PDzg4eGRbhkDAwPY2tpmU0RERERERERE2UPrSbk6zpw5A2traxQsWBA//PADZsyYAQsLizTLx8XFIS4uTnocFRUFAEhOTkZycnKWx0tERJSbyORyQKb1znWQyeX8P05ERN8Ndf9nfVNSnpSUhNjYWBgbG39LNelq1qwZvL294eTkhIcPH2LixInw8PDAn3/+CR0dHZXbzJ49G1OnTk21PCIiArGxsVkWKxERUW5UrERJGJvaaDsMFDMzRXh4uLbDICIiUkt0dLRa5WRCCKFupW/evMG2bdtw4sQJXLp0Ca9fvwYA6Ovro2TJkqhXrx7atWsHNze3rwpaJpNh7969aNWqVZplHj16hOLFiyMwMBCNGjVSWUZVS7mjoyMiIyNRoECBr4qNiIgor3KrVgEtLbWfDO9/bY2zl29oOwwiIiK1REVFoWDBgnj//n26eahaLeVhYWGYMmUKtm/fDnNzc9SsWRODBg2CpaUlDAwM8O7dO4SGhuLKlStYs2YNnJyc4OvrCx8fn0w7oBTFihWDpaUlgoOD00zKDQwMYGBgkGq5XC6HXK797ndERETfE5GcDAjtdxsXycn8P05ERN8Ndf9nqZWUly1bFu3atcOJEydQt25dyGSyNMtGRERg586dmDZtGp48eYLx48erF7Ganj59ijdv3sDOzi5T6yUiIiIiIiLKbmol5bdu3UKRIkXUqtDKygqDBw/GoEGD8Pz58wzLf/jwAcHBwdLjkJAQXLt2Debm5jA3N8fUqVPRpk0b2Nra4uHDhxg7dixKlCgBd3d3teIhIiIiIiIiyqnUSsrVTcgVyWQyODg4ZFjuypUraNiwofR41KhRAIDu3btj1apVuHHjBjZv3ox3797B3t4eTZs2xfTp01V2TyciIiIiIiL6nnzzlGgnTpzAiRMnIIRA48aNNW7BbtCgAdIba+7YsWPfGiIRERERERFRjvRNo6XMmzcP7dq1Q0hICG7duoUWLVpg1qxZmRUbERERERERUa6mVlIeExOjcvny5ctx6dIl7Nq1C3/88QdWrlyJ5cuXZ2qARERERERERLmVWkl5qVKlsH37dtUVKAzzzmlKiIiIiIiIiNSnVha9detWzJkzB/Xr18eNGzek5f3790fNmjXRvn17eHl5YeDAgRg4cGCWBUtERERERESUm6iVlLu5ueHq1avo0KEDGjdujEGDBiEyMhI///wzfv31Vzg6OqJUqVL4/fffMXny5KyOmYiIiIiIiChXUHv0dblcjsGDB6Njx46YNGkSSpcuDV9fXwwcOBCenp5ZGSMRERERERFRrqTxReAWFhZYtWoVjh8/jh07dqBSpUo4d+5cVsRGRERERERElKuplZR/+vQJU6ZMQc2aNeHq6or+/fvDysoKZ8+exfjx49GlSxd06NABz549y+p4iYiIiIiIiHINtZLyfv36YdOmTfD29kbv3r3x77//omnTphBCoFOnTrh79y5KlCiBihUrYsaMGVkdMxEREREREVGuoNY15QcPHsS2bduka8fbtm0LBwcHPHr0CMWLF0e+fPkwc+ZM9O7dG6NGjcrSgImIiIiIiIhyC7VayosUKYLTp09Lj0+ePAk9PT3Y2toqlStWrBj27duXqQESERERERER5VZqtZSvXbsWHTt2xLp166Cvr4+EhASsW7cOxsbGWR0fERERERERUa6lVlJeo0YNPHjwAPfv30dcXBxKlSqFfPnyZXVsRERERERERLma2vOU6+rqomzZslkZCxEREREREVGeotY15atWrUJcXJxGFf/33384derUVwVFRERERERElBeolZRv2rQJRYoUwciRI3Hx4kUkJCSoLPf8+XNs2LABjRs3Ru3atREZGZmpwRIRERERERHlJmp1X7906RL27t2LJUuWYOnSpdDT00PJkiVhZWUFAwMDvHv3DiEhIQgPD4e5uTm6d++OrVu3phqdnYiIiIiIiIj+R+1rylu3bo3WrVsjNDQUgYGBuHLlCl68eIHY2FgUKVIETZs2RZ06ddCgQQPo6ellZcxEREREREREuYLaSXmKokWLok+fPujTp09WxENERERERESUZ6h1TTkRERERERERZT4m5URERERERERawqSciIiIiIiISEuYlBMRERERERFpCZNyIiIiIiIiIi1hUk5ERERERESkJRpPiZacnIz169dj9+7dePr0KWJjY5XWy2QyPHz4MNMCJCIiIiIiIsqtNE7Kx40bh4ULF8LNzQ0NGzaEvr5+VsRFRERERERElOtpnJT/9ttvmDp1KiZPnpwV8RARERERERHlGRpfUx4bG4vatWtnRSxEREREREREeYrGSbmPjw8OHjyYFbEQERERERER5Skad1+vWbMmJk2ahFevXqFJkyYwMzNLVcbb2zszYiMiIiIiIiLK1TROyrt27QoAePz4MXbs2JFqvUwmQ1JS0rdHRkRERERERJTLaZyUh4SEZEUcRERERERERHmORkl5bGwshg4dijFjxqB+/fpZFRMRERERERFRnqDRQG+GhoY4e/Ysu6cTERERERERZQKNR19v2rQpjh8/nhWxEBEREREREeUpGl9T3rNnT/Tv3x/R0dHw9PSEjY0NZDKZUpnKlStnWoBEREREREREuZXGSbmXlxcAYOXKlVi5cqVSQi6E4OjrRERERERERGrSOCk/ffp0VsRBRERERERElOdonJS7ubllRRxEREREREREeY7GA70RERERERERUebQuKVcLpenGtjtS7ymnIiIiIiIiChjGiflixYtSpWUR0ZG4vjx43j+/DlGjBiRWbERERERERER5WoaJ+VpJd1+fn7o1q0b3r59+60xEREREREREeUJmXpNeZcuXbBmzZrMrJKIiIiIiIgo18rUpPzevXtITk7OzCqJiIiIiIiIcq2vuqb8S/Hx8bhz5w527dqFzp07Z0pgRERERERERLmdxkn5mDFjUi0zMDBAoUKFMHz4cEyePDlTAiMiIiIiIiLK7TROytk9nYiIiIiIiChzaHxN+ZYtW/DmzRuV696+fYstW7Z8c1BERERE2jZ37lyULFkScrkcMpkMZ86ckdYdOHAALi4uMDAwgJOTU7oD3fbo0QMymSzVzc/PDwAwffp0mJubw87ODhs3bpS2+/XXX1GnTh0IIbLqEImIKAfQOCnv2bMnHj58qHJdSEgIevbs+c1BEREREWlbbGwsvLy8ULhwYaXlwcHBaNOmDT5+/IglS5bAysoKAwYMQGBgoMp6Bg4ciICAAOlma2sLAKhRowYePnyIKVOmoEOHDqhduzYGDBiA2NhYvH79GuPGjcOaNWsgk8my/FiJiEh7NO6+nt6vtZGRkcifP/83BURERESUE/j6+gIALl68iMePH0vL16xZg8TERIwaNQoDBgxAsWLF4O7ujmXLlqFx48ap6qlRowZq1Kgh1fXy5Uu4uLjAw8MD169fBwDUqVMHYWFh2LNnD+Li4jBy5Ej07NkTLi4u2XCkRESkTWol5UeOHMGRI0ekxwsXLoSNjY1SmdjYWJw6dQqVKlXK1ACJiIiIcpIHDx4AgNSCXqRIEQDA/fv3M9x24cKFAIDRo0cDAMqXL4+GDRuia9euAD73SLx06RL++usvrFu3LtNjJyKinEetpPz+/fs4ePAgAEAmkyEoKAgGBgZKZfT19eHi4oJZs2ZlfpREREREOZS613w/fPgQ+/btg729vTSFrFwuR2BgIK5duwZ9fX0UK1YMLi4uWLt2LbZv3y59r5o0aRK6deuWZcdARETao1ZSPnz4cAwfPhwA4OTkhH379qFixYpZGhgRERFRTuTs7AwAUpf2sLAwpeWJiYlITEyErq4udHX/91Vr8eLFSE5OxrBhw6Cvry8tl8vlqFy5MoDPU8/WrVsXtWvXhqmpKdatW4fk5GT06dMHbdu2Rb58+bLlGImIKPtofE15SEhIVsRBRERElKOcO3cO9+/fR0REBADg8OHDCA4ORr9+/bB48WIsXrwYBgYG2LBhAwBg6NChAIAZM2Zg6tSpGDduHObMmQPg8ww1GzduRP78+TFgwACV+7t69Sp+/fVX3Lp1C8nJyUhOTsYff/wBANJjIiLKfTQefR0AXr9+jfHjx6NRo0YoWbIkbt26BQBYsmQJ/vrrr0wNkIiIiEgbfvnlF/Tt2xePHj0CACxYsAB9+/aFs7Mzdu/ejXz58mHo0KEIDw/HihUr0KRJkzTrWr16NWJiYtCnTx+YmpqmWp+UlIQ+ffpg7ty5sLS0hImJCRYvXoxTp07h9OnT8Pf3h4mJSZYdKxERaY9MaDj55dWrV9GoUSOYmprCzc0NW7duxeXLl1G5cmWMHTsWjx8/xo4dO7Iq3q8SFRUFU1NTvH//HgUKFNB2OERERN+Vuq5l0coqXNthYF+ENc7/e1vbYRAREalF3TxU45bykSNHolatWnjw4AE2bNigNLhJjRo12FJOREREREREpCaNrym/fPky9uzZAz09PSQlJSmts7KyQni49n9JJyIiIiIiIvoeaNxSbmxsjKioKJXrwsLCYGFh8c1BEREREREREeUFGifl7u7umDFjBt68eSMtk8lk+PTpE5YsWQJPT89MDZCIiIiIiIgot9K4+/rcuXNRp04dODs7o2HDhpDJZJg0aRJu374NmUyGGTNmZEWcRERERNnOq3ULPH/1XNthwN7GHof2HtB2GERElAU0TsodHBxw7do1LF68GCdOnEDx4sXx5s0b+Pj4YNSoUTA3N8+KOImIiIiy3fNXz2HXqKS2w8Dzk/e1HQIREWURjZNyADAzM8PUqVMxderUVOvOnTuH+vXrf3NgRERERERERLmdxteUp2X//v2oXbs2GjZsmFlVEhEREREREeVqaiXlycnJmDdvHsqUKQNjY2O4uLhg9+7dAIDjx4+jfPny8Pb2xqtXr7B27dosDZiIiIiIiIgot1ArKV++fDnGjx8PmUyG5s2bI3/+/OjYsSN+/vlneHh4IDIyEmvXrsW9e/fQu3fvrI6ZiIiIiIiIKFdQKylfv349OnfujFu3bmH79u34888/MWfOHMyePRt169aVknFd3a+6RJ2IiIiIKEOXLl1C/fr1kT9/flhbW2PkyJGIj49XWbZBgwaQyWRKN39/f6mesmXLwsTEBO3atUNcXBwA4M2bN3BwcMDNmzez65CIiNRLyh89eoTu3btDJpNJy3r16gUAmDBhAoyNjbMmOiIiIiIiAOHh4WjWrBmuX7+OuXPnws3NDf7+/pg5c2aa21haWiIgIEC6eXp6AgB++ukn6OnpwdfXF7///ju2bdsGABg9ejS6d+8OFxeXbDkmIiJAzaQ8JiYGpqamSstSHltbW39TAOfOnUPz5s1hb28PmUyGffv2Ka0XQmDKlCmws7ODkZERGjdujAcPHnzTPomIiIjo+3Lx4kW8e/cODRs2xKBBgzB9+nQAny+zTIuxsTG8vLzQrl07dOzYESVLfp7eLjo6Gk5OTmjatCkMDAwQFRWFwMBAXLhwAZMnT86W4yEiSqF2f/N79+4pdU9PSkoCANy9ezdV2cqVK6sdwMePH1GxYkX06tUL3t7eqdbPmzcPS5cuxebNm+Hk5ITJkyfD3d0dt2/fhqGhodr7ISIiIqLvl62tLQDgxo0bePDgAf744w8AwNu3bxEZGYmCBQum2iYsLAz58+eHrq4u6tevjzVr1qBEiRIYPHgw+vfvj/3798PBwQFeXl5wd3fH6tWrYWRklK3HRUSkdlLeo0cPlcu7dOkidWsXQkAmk0kJuzo8PDzg4eGhcp0QAv7+/pg0aRJatmwJANiyZQtsbGywb98+dOzYUe39EBEREdH3q2bNmhg8eDBWrFiBkiVLIl++fNDT00NCQgKSk5NTlW/dujV69eoFc3NzBAQEYNu2bejRowfOnz+PPn36wN3dHc+ePUP58uUxbdo01KpVC0WLFkWDBg3w6NEjuLm5Yf369TAwMNDC0RJRXqJWUn769OmsjkOlkJAQvHz5Eo0bN5aWmZqaokaNGvjzzz/TTMrj4uKkATsAICoqCsDnqd1UfWgTERFR2mRyOSBT64q3LI8ju/+Py2QyyCDLuGA2xMHvMMDSpUvx008/4cmTJzA2NkaVKlVQpEgRFCxYEDExMQAg9aQcOnSotF3VqlWxbds23LhxQ3oeHRwc4ODggGvXrmHz5s24fv06RowYAblcjuvXr8PR0RH16tVDnz59sv9AiShXUPdzW62k3M3N7ZuC+VovX74EANjY2Cgtt7GxkdapMnv2bEydOjXV8oiICMTGxmZukERERLlcsRIlYWxqk3HBrI7DzBTh4eHZuk/nYiVQ0NQuW/epikmx5Gw/9pxozpw5cHBwQFJSEjZt2gQhBIYPH47w8HDY2X0+TyEhIYiPj4ePjw+aNWsGS0tLHDp0CABQrVo1pecxKSkJvXr1wvjx4yGEQExMDO7du4clS5YgJiYGkZGRfN6J6KtFR0erVS5XzmE2YcIEjBo1SnocFRUFR0dHWFlZoUCBAlqMjIiI6PvzKPg+yltqPzF59Nr6mweY1dSDR8GwK6r9XgIvHgVn+7HnRBEREdi4cSM+ffqEkiVLYuPGjejWrZtSmZTnycnJCRs3bkRERAQsLCzQo0cPzJkzB1ZWVlLZxYsXo2DBghg2bBgAYPr06ejatSvmz58PDw8PDBo0iLMMEdFXU3cMtBydlKcM6PHq1Svp18+Ux5UqVUpzOwMDA5XX/8jlcsjl2v/HSkRE9D0RycmA0H7XaZGcnO3/x4UQEBDZus+04uB3GOC3335Lc50Qyudp586dGdY3evRojB49WnpcoUIFXL9+/esDJCJSoO7ndo7+dHdycoKtrS1OnjwpLYuKisKlS5dQq1YtLUZGRERERERE9O203lL+4cMHBAcHS49DQkJw7do1mJubo3DhwhgxYgRmzJgBZ2dnaUo0e3t7tGrVSntBExEREREREWUCrSflV65cQcOGDaXHKdeCd+/eHZs2bcLYsWPx8eNH9OvXD+/evUPdunVx9OhRzlFORERERERE3z2tJ+UNGjRIdQ2QIplMhmnTpmHatGnZGBURERERERFR1lMrKZfL5ZDJ1J+jMykp6asDIiIiIiIiIsor1ErKFy1aJCXliYmJ8Pf3h76+Plq1aiXNGb5v3z4kJCRg5MiRWRowEREREeUdXq1b4Pmr59oOA/Y29ji094C2wyCiXEitpHzEiBHS/XHjxsHV1RX79u1TGuJ9wYIFaNmyJV68eJHpQRIRERFR3vT81XPYNSqp7TDw/OR9bYdARLmUxlOibdq0CYMGDUo155pcLsegQYOwefPmTAuOiIiIiIiIcq4//vgDlStXRqVKleDi4qIyHwwNDYWOjg4qVaok3R4+fAjg8+xbNWrUQLly5TBr1ixpmzt37qBFixbZdhzapPFAb58+fUJoaKjKdaGhoYiNjf3WmIiIiIiIiCiHE0KgS5cuOHPmDCpUqIDQ0FCULl0a3t7eyJ8/v1LZ/Pnz49q1a6nqWLFiBQYPHgwfHx+ULVsWQ4cOhYmJCUaMGIHVq1dn05Fol8ZJeatWrTBu3DgYGRmhVatWMDU1xfv377F3715MmDCB84cTERERERHlETKZDO/evQMAREVFwcLCAgYGBmpvr6enh5iYGCQkJCA5ORlyuRyrV69G06ZN4eTklEVR5ywaJ+UrVqxATEwMevXqhV69ekFPTw8JCQkQQqB169ZYvnx5VsRJREREREREOYhMJsOOHTvg7e0NY2NjREZGYs+ePdDX109V9uPHj6hWrRqSkpLQqlUr/Pzzz9DR0cGwYcPQo0cPrFmzBmPGjMH79++xe/duHD9+XAtHpB0aJ+X58+fH7t27cefOHfz99994+fIl7OzsUK1aNZQpUyYrYiQiIiIiIqIcJjExETNmzMCePXtQv359XL58GS1atMB///0HS0tLqZydnR2ePXsGa2trvH37Fh06dMDChQsxduxY2NnZ4dixY1LZdu3aYeHChTh9+jRWrVoFAwMDzJ49G0WKFNHGIWYLjZPyFGXKlGESTkRERERElEddu3YNz58/R/369QEA1apVQ6FChfDvv/+iSZMmUjkDAwNYW1sDAMzNzdGrVy9s27YNY8eOVarv999/R/HixVGpUiWUKVMGf//9N65cuYIpU6bk6gHFNR59HQASEhKwevVq9O7dG02bNsWDBw8AADt27MCdO3cyNUAiIiIiIiLKeRwdHfHixQspBwwODsbDhw9RqlQppXLh4eFISEgAAMTFxWHPnj1wdXVVKvPu3TssWbIEvr6+AICYmBjI5XLI5XJ8+PAhG45GezRuKX/06BEaN26M169fw9XVFefPn0d0dDQA4Ny5czh69Cg2btyY6YESERERERFRzmFjY4O1a9eiffv2kMvlSE5OxvLly1G4cGFMmTIF9vb2GDBgAM6fP48pU6ZAR0cHiYmJ+OGHH/Dzzz8r1TVu3Dj4+fnByMgIADBp0iRUrVoV+vr62LBhgzYOL9tonJQPGzYMVlZW+Pvvv2FmZqZ0Eb+bmxsmTJiQqQESERERERFRztSpUyd06tQp1fJp06ZJ9729veHt7Z1uPWvWrFF63LdvX/Tt2zdzgszhNE7Kz5w5g4CAAFhaWiIpKUlpna2tLV68eJFpwRERERERERHlZhpfU66rqwshhMp1r169gomJyTcHRURERERERJQXaJyUu7m5YeHChdKF+sDn+emEEFi7di0aNWqUqQESERERERER5VYad1+fO3cuateujbJly6JFixaQyWRYsWIFbt68iQcPHuDvv//OijiJiIiIiIiIch2NW8pLly6NK1euoHbt2ggICICOjg4OHTqEEiVK4O+//0bx4sWzIk4iIiIiIiKiXEfjlnIAKFasWK6evJ2IiIiIiIhS8/ZyR/izJ9oOA9YOjthz6Ji2w8gUGifl06ZNQ+nSpdG+fftU6549e4YNGzZgypQpmRIcERERERER5Rzhz56glVW4tsPAvmfajiDzaNx93c/PD506dcKAAQOQmJiotO7p06eYOnVqpgVHRERERERElJtpnJQDnxPznTt3omHDhggP1/6vJERERERERETfo69Kyt3d3XHp0iW8efMGVapUweXLlzM7LiIiIiIiIqJc76uScgBwdnbGpUuXUKlSJbi5uWHTpk2ZGBYRERERERFR7vdVo6+nyJ8/Pw4cOICJEyeiV69e+OGHHzIrLiIiIiIiIqJc75uScgCQyWSYPXs2KlasiN69e2dGTERERERERER5gsZJeXJyssrlHTt2RI0aNRAWFvbNQRERERERERHlBd/cUq7IyckJTk5OmVklERERERERUa6lVlLeokULLFy4EM7OzmjRokW6ZWUyGfbv358pwRERERERERHlZmol5dHR0UhKSgIAREVFQSaTZWlQRERERERERHmBWkn56dOnpftnzpzJqliIiIiIiIiI8pSvnqeciIiIiIiIiL6NWi3lixYtUrtCmUyGkSNHfnVARERERERERHmFWkn5mDFj1K6QSTkRERERERGRetRKytOam5yIiIiIiIiIvh6vKSciIiIiIiLSErVaylWJjY3Fo0ePEBsbm2pd5cqVvykoIiIiIiIiorxA46Q8Pj4eAwcOxNatW5GYmKiyTMqc5kRERERERESUNo27r0+dOhXHjx/Hpk2bIITA8uXLsXHjRjRq1AhFixbFwYMHsyJOIiIiIiIiolxH46R8165d8PPzQ/v27QEA1atXR7du3XD8+HHUrVuXSTkRERERERGRmjROyp8+fYqSJUtCR0cHhoaGiIyMlNZ16dIFu3btytQAiYiIiIiIiHIrjZNyOzs7vHv3DgDg5OSEM2fOSOvu37+fWXERERERERER5XoaD/TWoEEDBAUFoXnz5ujbty/GjBmDO3fuQF9fH/v27UPnzp2zIk4iIiIiIiKiXEfjpHzmzJl4/fo1AGDEiBEQQmD37t349OkThg0bhilTpmR6kERERERERES5kcZJua2tLWxtbaXHI0eOxMiRIzM1KCIiIiIiIqK8QONryomIiIiIiIgoc2jcUu7k5ASZTJZumUePHn11QERERERERER5hcZJecuWLVMl5ZGRkTh79iyEEPD29s604IiIiIiIiIhyM42Tcn9/f5XL4+Pj0apVKzg5OX1rTERERERERER5QqZdU66vr48hQ4Zg/vz5mVUlERERERERUa6WqQO9vX79GtHR0ZlZJREREREREVGupXH39T179qRaFh8fjzt37mD58uX44YcfMiUwIiIiIiIiotxO46S8bdu2Kpfr6enB29sby5Yt++agiIiIiIiIiPICjZPykJCQVMsMDQ1hbW2d4VRpRERERERERPQ/GiflRYoUyYo4iIiIiIiIiPIcjZNyAEhKSsKlS5fw9OlTxMbGplrfrVu3bw6MiIiIiIiIKLfTOCm/evUqvL298eTJEwghUq2XyWRMynOpokWLwsDAAEZGRgCACRMmoEOHDkpl/vzzTwwcOBAAkJCQgLp162Lp0qUwMDDAlStX0KdPH8THx2PcuHHo3r07AODUqVPYsWMH1qxZk70HREREREREpGUaJ+UDBw6EqakpNm/ejLJly0JfXz8r4qIcaseOHahUqVKa6ytWrIjLly9DT08PycnJaNOmDVauXImRI0dizpw5WLp0KapUqYLy5cuje/fu+PTpE/z8/HDgwIHsOwgiIiIiIqIcQuOk/NatW9i1axfc3NyyIh76zuXLl0+6Hx8fj0+fPkkDAOrp6SEmJgaxsbHQ0dEBAPj5+WH48OEwMzPTRrhERERERERaJdd0g5IlSyIqKiorYqHvQLdu3VC+fHn07t0bERERKsuEhoaiYsWKsLS0hKmpKQYNGgQAmDJlCmbNmoWmTZti/vz5uHbtGh49eoQ2bdpk5yEQERERERHlGBon5YsXL8bs2bNx9+7drIiHcrBz587hxo0buHr1KiwtLaVrwr9UtGhRXL9+HS9fvkRcXBz27NkDAChTpgzOnTuHf/75B82bN8fo0aOxZMkSBAQEoE2bNujZsyciIyOz85CIiIiIiIi0SuOkfMiQIXj27BlcXFxQuHBhVKhQQelWsWLFrIiTcoDChQsD+NwNfcSIEQgKCkq3vImJCTp27Ijffvst1Tp/f3+0a9cOZmZmmD59Onbs2IH69evD398/K0InIiIiIiLKkTS+prxKlSrSNcKUd3z8+BEJCQnStd8BAQFwdXVNVS44OBhFihSBnp4e4uPjsXfvXlSoUEGpTEhICE6cOIEjR44gKioKiYmJkMlkkMvl+PDhQ3YcDhERERERUY6gcVK+adOmLAiDcrpXr16hTZs2SEpKghACxYoVw5YtWwAAffr0QYsWLdCiRQucOnUKS5cuhY6ODhITE9GoUSNMnjxZqa7hw4fD398fMpkMpqam6Ny5M8qXLw8TExPs2LFDG4dHRERERESkFRon5ZQ3FStWDP/++6/KdevXr5fu9+vXD/369Uu3ri+nP/Pz84Ofn983x0hERERERPS9+aqk/Pjx49i9ezeePn2K2NjYVOtPnTr1zYERERERERER5XYaJ+Xz58/HuHHjULRoUZQpUwampqZZERcRERERERFRrqdxUr5ixQoMGTIES5cuzYp4iIiIiIiIiPIMjadEe/v2LVq1apUFoRARERERERHlLRon5c2bN8f58+ezIhYiIiIiIiKiPEXj7us9e/bEwIED8enTJzRp0kSat1pR5cqVMyM20iJvL3eEP3ui7TBg7eCIPYeOaTsMDB06FMuXLwcA3LlzB6VLl05VpkGDBjh79qzSssWLF2PEiBG4dOkSevbsibCwMHh4eGDr1q0wMDDAmzdvUKFCBRw7dgwuLi7ZcixERERERJRzaJyUN23aFAAwd+5czJ07FzKZTFonhIBMJkNSUlKmBejn54epU6cqLStVqhTu3r2bafug1MKfPUErq3Bth4F9z7QdAXD48GGsXr0ahoaGKmcbUGRpaYlly5ZJj1N+oPrpp5+gp6cHX19fjBs3Dp6enujZsydGjx6N7t27MyEnIiIiIsqjNE7KT58+nRVxpKtcuXIIDAyUHuvqcnp1yh6vXr1Cr169MHHiRGzevBmPHz9Ot7yxsTG8vLxgZGQEHR0daXl0dDScnJzQtGlTTJkyBVFRUQgMDMSFCxdw48aNrD4MIiIiIiLKoTTObt3c3NJdHxIS8tXBpEVXVxe2traZXi9ReoQQ6NGjB0qUKIEpU6Zg8+bNGW4TFhaG/PnzQ1dXF/Xr18eaNWtQokQJDB48GP3798f+/fvh4OAALy8vuLu7Y/Xq1TAyMsqGoyEiIiIiopwoU5qcX79+jR07dmDbtm3466+/MrX7OgA8ePAA9vb2MDQ0RK1atTB79mwULlw4zfJxcXGIi4uTHkdFRQEAkpOTkZycnKmx5VYyuRyQaTwOYJbEoa1ztnnzZpw6dQoHDhzAw4cPkZiYCAAIDQ2Fg4MDjI2Nlcq3atUKPXr0gLm5ObZv346AgAD06NED586dQ69evdCkSRM8e/YM5cuXx/Tp01GzZk0ULlwYDRo0wKNHj1C/fn2sW7cOBgYG2jhcIrUMGzYMK1asAADcunVL5fgKHTp0wJUrV/DixQsULFgQLVq0wMKFC5EvXz48ePAAXbt2xa1bt1CrVi0EBATAwsIC8fHxqFy5MhYuXAh3d/fsPizKQF7+nyCTySCDLOOC2RBHXv0Ow3NA6ti4cSP69OmD33//PdVMUf/99x+GDh2K8PBw6Orqolq1ali+fDmMjIwQGRmJtm3b4vXr16hbt670Py4iIgIdOnTAsWPHoKenp4Ujyrny8v8ETakb31cn5TExMdi7dy+2bduGwMBAJCQkwNXVFYsXL/7aKlWqUaMGNm3ahFKlSuHFixeYOnUq6tWrh5s3byJ//vwqt5k9e3aq69CBz2+ujK4Jps+KlSgJY1MbbYeBYmamCA/XzrXtt27dQnx8PJo1a6a03MPDA7/88gsaNmwIADA0NAQAdOzYUSpTrFgxBAQE4Pr161L8BgYGKFasGC5duoRNmzbh1KlTGD9+PBITExEYGAhXV1e4urrCx8cnm46QSDOBgYFYs2aNNL7CmzdvVL4/g4KC0KFDBxQuXBgbNmzA2rVrIZPJ4Ofnh0mTJuHZs2cYN24c5s2bhzlz5uCnn37CggULULp0abi6umrtPU9py8v/E5yLlUBBU7ts3acqJsWS8+x7g+eAMvLkyROsXr0aVapUwfv371Odp48fP8LPzw9ly5ZFUlISBg0aBF9fX4wZMwa//PILqlWrhlGjRqFt27Y4d+4cSpcujSFDhuCnn35CZGSklo4q58rL/xM0FR0drVY5jZLypKQkHD16FNu2bcOBAwcQExMDW1tbJCYmYvv27Wjfvv1XBZseDw8P6X6FChVQo0YNFClSBDt37kTv3r1VbjNhwgSMGjVKehwVFQVHR0dYWVmhQIECmR5jbvQo+D7KW2r/Rf7otTWsra21su8ePXqgevXq0uMhQ4YgIiIC/v7+aNKkCRwdHQF8/qCPi4vDjz/+iJYtW8LKygq///47AKBu3bpK8SclJWHChAmYPXs2ypYtC11dXYSFheHAgQP49OkTjIyMtHa8ROl59eoVRo8ejQkTJmDLli14/PgxLCwsVL5eQ0JCpB4fxYoVg7e3Nx48eABra2skJCSgUKFCaNOmDdatW4ekpCS8efMGW7duxb///svXfw6Vl/8nPHgUDLui2m8RevEoOM++P3gOKD3Jycno0qULVq5ciZ9++gmmpqapztOXj+vWrYubN2/C2toaBQsWxPv372FpaQkhBGxtbXH16lXY2dkp5SH0P3n5f4KmUhrvMqJWUn7hwgVs27YNu3btwuvXr2FhYYEuXbqgc+fOcHFxgYWFRbZd821mZoaSJUsiODg4zTIGBgYquwDL5XLI5dr/UP8eiORkQGi/O4hITtbaOXNxcVEaFX3s2LEAAHd3dxQqVEhaLpfLYWRkBEdHRyxbtgwRERGwsLBAz549MXfuXKX4/f39YWJiIv2gNGXKFPj4+MDX1xeenp7o3r07X6OU4wgh0KtXL5QoUQK+vr7YsmULgLQ/UxXHSTh06BAAoHHjxpDL5ejfvz9at24NFxcXmJmZoUePHujfvz9mzJgBOzvtt4SRann5f4IQAgIiW/eZVhx59f8DzwGlZ9GiRahTpw6qVasGIOPv+x8/fsSGDRswe/ZsyOVydOvWDd27d0eVKlXQqlUrODo6om/fvvjjjz++i/OtzrS9z58/x+DBg3HixAno6uqiefPmWL58OUxNTb9q2t68/D9BU+rGp1ZSXq9ePchkMjRs2BCjRo1C06ZNpRHQ379///VRfoUPHz7g4cOH6Nq1a7bulyg0NFTpsRDKXxB27NiRYR2jRo1S6sXh4uKC69evZ0p8RFlly5YtOHXqFA4dOoSQkBBpfIWwsDA4OjqmGl8B+Pz+GD16NH755Re0bt1a+lHLw8MDYWFhCA4ORtmyZREQEAC5XI4WLVqgefPmuHbtGipVqoRNmzbBwsIiW4+TiIi+Lzdv3sTvv/+Oc+fOqVU+Pj4eHTp0QNOmTdG6dWsAn2fO2b17t1Rm5MiRGDduHIKDgzFr1iwAwKRJk1CxYsXMP4BvpO60vT4+Pjh79iwmTZqEqKgoLFmyBEIIbN26ldP25hBqpe7ly5eHEAJnz57FkiVLsG3bNrX7x3+rMWPG4OzZswgNDcXFixfRunVr6OjooFOnTtmyfyKivC4kJATx8fFo2rQpnJ2d8ezZMwCfe42cOHECsbGxSl8G4uLi0LFjRyxevBi9e/fGrl27lKYItLa2Ru3atRETEwNfX1+sWbMG/v7+uHfvHu7evYs7d+5k+vgkRESU+wQFBSE0NBTOzs4oWrQo/vrrL/Tr1w+rVq1KVTYhIQEdOnSAnZ0dlixZorK+v//+G+Hh4fDy8sKwYcMwf/58zJs3D8OGDcvqQ9GY4rS9NjZpX99969YtnDlzBq6urpg2bRr8/f1hb2+PgIAAvH79WmnaXgMDA6VpeydPnpyNR5S3qZWUX79+HTdv3sRPP/2EBw8eoEePHrC1tUX79u2xf/9+yGRZNyLm06dP0alTJ5QqVQrt27eHhYUF/vrrL1hZWWXZPomI6H/at2+PXbt2SbeUz98lS5agevXqMDIygpGRkZSYN23aFDt37kSVKlXQuHFj7Nq1CwcPHkxV7+DBgzFw4ECUKVMGSUlJePXqFdatW4eIiAipNZ6IiCgtAwcOxIsXLxAaGorQ0FDUrFkTa9euxcCBA5XKJSYmomPHjjA3N5cGH/1SQkICxo0bh0WLFgH43M1dJpNBLpfjw4cP2XI86vpy2t70PHjwAACUZq4qXLgwkpOT8fDhQwwePBgHDx5EpUqVYGFhAS8vLwwYMACrVq3itL3ZSO2B3sqWLYtZs2Zh1qxZ0jXmu3fvxu7duyGTyaRfnOrXr5+pAW7fvj1T6yMiIs2ULVsWZcuWlR6PGTMGwOfk297ePlX5lG6E//zzj9SrqUiRImjevLlUZs+ePbh9+7b0GT98+HBcuHABEydORJUqVTB8+PAsOx4iIsr9pkyZAnt7ewwYMAA7duzAnj17UKFCBbi6ugIA6tSpI01/BgDz589Ht27dpFbnadOmwdPTU1qXk3zNZWWKFC/B7NOnD9zd3aVpe6dNm4ZatWqhaNGi0rS9bm5uWL9+PaftzUJfNSVanTp1UKdOHSxduhTHjh1DQEAA9u/fj3379qFIkSJ49OhRZsdJREQ5REbjK3z5WBVvb294e3tLj+3t7XH+/PlMiY+IiPKmM2fOSPenTZsm3ffx8clwytmJEycqPfby8oKXl1emxpdZFC8rU+Tu7o69e/dK0/kaGhrC2dkZAPD48WOpXFhYGORyOYoXLw4AcHR0hKOjI65du4bNmzfjv//+w/DhwyGXy/Hff//BwcEBbm5u6NOnTzYdYd7z1fOUA4COjg48PT3h6emJT58+Yd++fQgICMis2Ii0wqt1Czx/9VzbYcDexh6H9h7QdhhERERElIO0b99eaQC2QYMGISIiQumyMgD49OkTypUrh/r16yMoKAhTpkxBVFQUXrx4gc6dO8PS0lKqIykpCX379sXs2bNhZWWFpKQkBAcHY/369YiJieFlZVnsm5JyRUZGRujUqRMHYKPv3vNXz2HXqKS2w8Dzk/e1HQIRERER5TCaXlb222+/YfDgwVi4cCF0dHTQuXNnpa77wOdxYkxMTNCzZ08AwOTJk+Hj44MpU6bA09OTM19lsZw9sRsREYCGDRuiYMGC0NfXR6FChTB06FDExcWpLCuTyVLdrl27BgBYv349bG1tYW5ujpkzZ0rbnDt3DiVKlMCnT5+y43CIiIiIMk1oaCiEENIc5UIICCFgaGgIAChUqBD279+Pjx8/IioqCr/99hvMzMyU6hg1ahROnz4tPU6Ztvfjx484dOhQhtep07fJtJZyIqKsUqlSJXTu3BkymQwLFy7E8uXLUbp0aQwePFhl+fr16yuNvFq0aFHExsZi0KBBaNGiBSwsLDBp0iR06tQJDg4O6NevH1asWMFRRomIiIgo2zEpJ6Icb/HixXj79i3evXuH3bt34+7du+lOxejk5ARPT08UKFBAWvbu3TskJCSgSpUqKFSoENauXYvo6GjMmDEDVapUgbu7e3YcChERERGREiblRPRdKFmyJN68eQPg8yiq6Y0AumXLFmzevBn58uVDx44dsXz5cpiZmaFbt27S6KqNGjWCTCbDunXrcOPGjWw5hu8NBz0kIqKcxNvLHeHPnmg7DFg7OGLPoWPaDoNyESblRPRd2LNnD16+fIkFCxZg+/btaN26Ndq0aZOq3OjRo1GjRg3I5XLMmTMHv/zyC+zs7DBjxgxs3rwZP/30E+Lj41GhQgXUq1cPM2fOxJUrVzB27FjExMSgf//+GDdunBaOMOfhoIdERJSThD97glZW4doOA/ueaTsCym2YlBPRd6F+/frS/Q4dOmDTpk1o3bo14uPjIZfLoa+vDwBYsGCBVC4pKQkdOnRQaglPmUJk+fLl0NfXR69evaTryuvXr49GjRrB29tbmteTiIiIiCgrMSknohzt6NGj2LZtG+rUqQMhBJYtWwYAqFixIs6dO4eGDRuiRo0a+Ouvv3D48GH88ssvaNiwIfT19bFkyRIAQN26dZXqfPr0KaZOnYqgoCDIZDIkJSXh3LlzCA///Ot7UlJS9h4kERERUQZyymVlkc+fAVZ62g4jV2FSTkQ5mqWlJf777z/s3bsXiYmJcHBwwPjx4+Hr64sLFy4olS1atCiioqIwdepUREdHo1ChQpg2bZo0f2eKQYMGYfDgwdLUIcuXL8eIESPwzz//YMKECdJyIiIiopwip1xWFnH/DgAm5ZmJSTkR5WhVq1bFv//+q3JdgwYNIISQHpcrVw4nTpzIsM4DB5QHDWvXrh3atWv3bYESEREREX0FubYDICIiIiIiIsqrmJQTERERERERaQmTciIiIiIiIiItYVJOREREREREpCVMyomIiIiIiIi0hKOvE1GOlFPm4rS3scehvQcyLkhERERE9BWYlBNRjpRT5uJ8fvK+tkMgIiIiolyM3deJiIiIiIiItIRJOREREREREZGWMCknIiIiIiIi0hIm5URERERERERawqSciIiIiEhDsbGxaNWqFUqWLImKFSuiSZMmCA4OTlXuv//+Q/369VG6dGm4uLigV69e+PTpEwAgMjISDRs2RPny5TFo0CBpm4iICDRo0AAJCQnZdjxEpD1MyomIiIiIvkK/fv1w7949XL9+HS1btkSfPn1SlTE0NMTy5ctx9+5dXL9+HR8/fsTcuXMBAL/99hsaNmyI//77D3fv3sXNmzcBAKNGjcKcOXOgp6eXrcdDRNrBpJyIiIiISEOGhobw9PSETCYDANSsWROhoaGpyjk7O6NChQoAAB0dHVSrVk0qp6enh5iYGCQnJyMuLg76+vo4evQoChYsiJo1a2bXoRCRljEpJyIiIiL6RkuWLEHLli3TLfPx40esX79eKtelSxcEBwfD1dUVjRs3hoODA2bOnImZM2dmR8hElEPoajsAIiIiIqLv2axZsxAcHIyTJ0+mWSY+Ph4dOnRA06ZN0bp1awCAsbExdu/eLZUZOXIkxo0bh+DgYMyaNQsAMGnSJFSsWDFrD4CItIpJORERERHRV1qwYAH27NmDwMBA5MuXT2WZhIQEdOjQAXZ2dliyZInKMn///TfCw8Ph5eWFevXq4ddff4UQAj169MDZs2ez8hCISMuYlBMRERERfYVFixYhICAAgYGBMDMzU1kmMTERHTt2hLm5OdauXStdg64oISEB48aNw/bt2wF87uYuk8kgk8nw4cOHrDwEIsoBmJQTEREREWno6dOnGD16NIoVK4aGDRsCAAwMDHDp0iVMmTIF9vb2GDBgAHbs2IE9e/agQoUKcHV1BQDUqVMHK1askOqaP38+unXrBhsbGwDAtGnT4OnpKa0jotyNSTkRERERkYYKFSoEIYTKddOmTZPu+/j4wMfHJ926Jk6cqPTYy8sLXl5e3x4kEX0XOPo6ERERERERkZYwKSciIiIiIiLSEiblOdjcuXNRsmRJyOVyyGQynDlzJs2yQggsWLAAzs7O0NfXh42NDcaPHw8AePDgAapXrw5jY2M0btwYb968AfB5ao6yZcvi2LFj2XE4RERERERE9AUm5TlYbGwsvLy8ULhw4QzLTpo0CT/99BPMzc2xfPlyjB8/Hvr6+gCA6dOn4+XLl5g5cyYuXbqEpUuXAvg8p2alSpXg7u6epcdBREREREREqnGgtxzM19cXAHDx4kU8fvw4zXIxMTFYvHgxTExMcOzYMejr6yvNkxkdHQ07Ozu4u7tj4cKFiIqKwp07d7B69Wpcv349y4+DiIiIiIiIVGNSngvcunULnz59goWFBVxcXPDs2TMUKlQIS5Ysgbe3N/r164fWrVujbNmyMDMzQ/fu3dG3b1/MmDFDmnqDiIiIiNL2MjgYdV3LajsMWDs4Ys8hXnpIlJswKc8FdHR0AABv3ryBr68vihUrhn79+qFz58549uwZPDw8EBYWhuDgYJQtWxYBAQGQy+Vo0aIFmjdvjmvXrqFSpUrYtGkTLCwstHw0RERERDmPTnICWlmFazsM7Hum7QiIKLPxmvLvkBACsbGxiIuLAwAUK1YMcvnnUzl+/Hh069YNpUuXRlxcHMLCwgAA1tbWqF27NmJiYuDr64s1a9bA398f9+7dw927d3Hnzh0sXrxYa8dERERERESUF7GlPAc7d+4c7t+/j4iICADA4cOHERwcjMaNG8PJyQk2NjZ4+fIlzMzM4OPjg19//RVjx45F0aJFcevWLdjb26NMmTJKdQ4ePBgDBw5EmTJlkJSUhFevXmHdunWIiIhAYmKiNg6TiIiIiIgoz2JSnoP98ssv2Lx5s/R4wYIFAICQkJBUZZctWwaZTIYtW7ZACIGGDRtiwYIFMDQ0lMrs2bMHt2/fxvbt2wEAw4cPx4ULFzBx4kRUqVIFw4cPz+IjIiIiIiIiIkVMynOwTZs2YdOmTSrXCSGUHpuamiol8Kp4e3vD29tbemxvb4/z589/c5xERERERET0dXhNOREREREREZGWMCknIiIiIiIi0hIm5URERERERERawqSciIiIiIjUdufOHTRq1AhGRkawtLTEsGHDEB8fr7Ls3LlzUaJECRgaGsLS0hItW7bEkydPAACHDh1C0aJFYWpqikGDBknbPHjwAHZ2dnj58mW2HA+RtnGgtxzGq3ULPH/1XNthIPL5M8BKT9thEBEREVEOkpiYiBYtWuDJkyeYMWMG/v33XyxbtgwFChTAjBkzlMqePn0a48ePh4ODA5YtW4aDBw/iwIEDMDY2xrZt2zBo0CAUL14cPj4+mDVrFtq1a4eGDRuiX79+mDp1KmxtbbV0lETZi0l5DvP81XPYNSqp7TAQcf8OACblRERERPQ/x44dQ3BwMLy9vTFmzBh8/PgRO3fuxLJly1Il5cnJyQAAa2trNGnSBE+ePMHBgwdhbm4OAIiOjkbZsmXRuHFj/F97dx6XU/b4AfzzPO2LooS0KFETY0qyhUGMzJB18CMqWjDWYUZjGcLYxj7G0gwq2zCK4WtfIltjj9CXGCkjwiCpaDm/P7y6X1dlKupp+bxfr16v7rnnnuece57n3nPuPffc2bNnIyUlBWvWrEFmZib8/PxKvWxEqsJOORERERERFUpcXBwAwNLSEgCgp6eH6tWr4/79+3jw4AFq1qwpxe3QoQOmTZuGGTNmwNraGgDQrl07LFiwAAAwevRozJgxAytWrMDHH3+Mjz/+GK1atUJERAQUCkUpl4xIdfhMORERERERFZsQIt/wuLg4LF++HNbW1ggPD4evry+OHj2KyZMnAwCmT5+OuLg4nD59GufPn8ekSZPg5+eH1NRUNG3aFFZWVvj6668LTJ+oomCnnIiIiIiICqV+/foAgDt37gAAXrx4gcePH8PAwAAmJibIyMiQJn3bsWMHHj16hK5du6JXr14YN26cFJ6rXr16aNasGQ4cOICLFy9i8uTJGDt2LBo2bIiIiAgsWbIEhw8fLuVSEpUuDl8nIiIiIqJCcXNzg42NDfbs2YMFCxYgOjoaWVlZGDlyJI4dO4b27dujefPm+PPPP2Fr+3qepLCwMHz88cc4cOAAAKBRo0ayNFNTUzFixAgEBwdDW1sb2dnZiI6ORnBwMIDXk8sRVWS8U05ERERERIWirq6OHTt2wMXFBVOmTMHevXsxYsQITJ06NU/cbt26Ye7cudDR0cGoUaMQGRmJvn37YsWKFbJ4kyZNQvv27eHq6goA+PHHH/HixQssXrwY3t7e6NSpU6mUjUhVeKecqByJi4uDl5cXHj16BENDQ4SEhKBhw4b5xhVCoEOHDrhw4QKePn0KALh9+zb+7//+D6mpqfDw8MCkSZMAvH7faEBAAHbu3FlaRSEiIqJyKndo+dvatWuX5/nvgIAABAQEvDO9n376Sbbctm1baUI5osqAd8qJypGhQ4fC398fN27cQEBAALy9vQuMu3jxYtjY2MjCli9fjhEjRuDy5csIDQ3F8+fPIYTA2LFjsXTp0hLOPRERERERvY2dcqJyIjk5GefOncPAgQMBAL1790ZiYiJu3ryZJ+7Vq1fxxx9/4LvvvpOFa2hoIC0tDZmZmcjJyYFSqcSqVavQqVMn6VUlRERERERUetgpJyonEhMTYWpqCnX110+dKBQKWFpaIiEhQRYvMzMTfn5+CAoKgpqammzd6NGjsX37drRs2RLffPMNnj17hrCwMIwdO7a0ikFERERERG/gM+VEFcz06dPRq1cv2NvbIz4+XrbO1NQU+/fvl5b79OmDhQsX4siRI1i5ciW0tLQwZ84c1KlTp5RzTURERERUObFTTlROWFhYICkpCVlZWVBXV4cQAgkJCbC0tJTFi4yMREJCAn7++WdkZWUhJSUFVlZWOHv2LExMTKR44eHhsLGxgaOjI+zt7XHmzBmcO3cOU6dORWhoaGkXj4iIiIioUmKnnKicqFGjBpycnLBhwwZ4e3sjPDwc5ubmqFevnize8ePHpf/j4+Ph6OiY547506dPsXTpUumueVpaGpRKJZRKJVJTU0u8LERERFR+dO3ZDfce3FN1NvDk3t+AiYaqs0H0wbFTTlSOBAUFwdvbG7Nnz4aBgQGCg4MBAL6+vujWrRu6detWqHQCAgIQGBgIHR0dAMCUKVPg7OwMTU1NrFmzpsTyT0REROXPvQf3YNrBVtXZwMMbsQDYKaeKh51yonLEzs4OUVFRecJXr16db3wrKyvpHeVvCgoKki37+fnBz8/vg+SRiIiIiIgKj7OvExEREREREakIO+VEREREREREKsJOOREREREREZGKsFNOREREREREpCLslBMRERERERGpCGdfJyqj7t+8idaNG6g6G6hhZoFtu/arOhtERERERBVSuemUL1++HPPnz8f9+/fh4OCAZcuWoVmzZqrOFlGJUcvJRA+TZFVnA3/8reocEBERERFVXOVi+PqWLVswbtw4TJs2DRcuXICDgwPc3NyQnKz6DgsRERERERFRcZWLTvmiRYvg5+eHwYMHo0GDBli1ahV0dXWxdu1aVWeNiIiIiIiIqNjK/PD1V69e4fz585g4caIUplQq0bFjR0RFReW7zcuXL/Hy5UtpOSUlBQCQk5ODnJycks3we1IoFFBAoepsQKlUAgrVX7NRKJWlXmesAzlV1AFQdupBoVCU+eNGSWEdUC5FJT4e8XegemWlDirzeZl1IFfZ20aVvR6KorD5UwghRAnn5b3cu3cPZmZmOHXqFFq2bCmFT5gwAZGRkTh9+nSebQIDAzF9+vQ84a6urlBXL9vXIa7fuIHMzFeqzgayXr2Cpobq95WGhibq231Uqp/JOpBTRR0ArIe38bfAOlAl1gHrIBfrgHWgSpW5DgDWw9tUVQ9FkZWVhYiICDx79gwGBgYFxlP93iwBEydOxLhx46TllJQUWFhYIDw8/J07g4jobW2bfoLu1VU/f8WOR1Wwd+9eVWdDJSpzHTRt0xymrral+pn5SYq4gbPH814Ep9JTmX8HRETlVUpKCqpVq/av8cp8p7x69epQU1PDgwcPZOEPHjxArVq18t1GS0sLWlpaecKVSuXr4RZERIUkcnIAofqhUSInp9IevypzHQghIKD6AW1CiEr7/SsrKvPvgIiovCrs8bLMH1U1NTXRpEkTHD58WArLycnB4cOHZcPZiYiIiIiIiMqbMn+nHADGjRsHLy8vODs7o1mzZliyZAlevHiBwYMHqzprRERERERERMVWLjrl/fr1w8OHDzF16lTcv38fjo6O2LdvH2rWrKnqrBEREREREREVW7nolAPAyJEjMXLkSFVng4iIiIiIiOiDKfPPlBMRERERERFVVOXmTjkREVVONcws8Mffqs7F63wQERERfWjslBMRUZm2bdd+VWeBiIiIqMSwU05E9A68S0tEREREJYmdciKid+BdWiIiIiIqSeyUExEREZVxHLVDRFRxsVNOREREVMZx1A4RUcXFV6IRERERERERqQg75UREREREREQqwk45ERERERERkYrwmXIiIqIyqnbN2rh3+Iaqs4HaNWurOgtEREQVFjvlREREZdSu7TtVnQUiIiIqYRy+TkRERERERKQi7JQTERERERERqQg75UREREREREQqwk45ERGVO3FxcXBxcYGtrS2aNm2Kq1ev5hvv6NGj0NHRgaOjo/SXnp4OADh37hwcHR3RoEEDhIaGSttERERg6NChpVIOIiIiIk70RkRE5c7QoUPh7+8Pb29vhIWFwdvbG2fPns03rp2dHaKjo/OEz507Fz/99BOaNGmCRo0awcvLC+np6QgMDMTOnZxgjYiIiEoH75QTEVG5kpycjHPnzmHgwIEAgN69eyMxMRE3b94sUjoaGhpIS0tDRkYG1NTUAACBgYEYM2YMqlat+qGzTURERJQvdsqJiIqosEOnASAmJgbt2rWDvb097O3tsW3bNgAcOv0+EhMTYWpqCnX114O9FAoFLC0tkZCQkG/8W7duwcnJCU2bNsWKFSuk8KlTp2L27Nno1KkT5s+fj+joaPz111/o3bt3qZSDiIiICGCnnIioyHKHTt+4cQMBAQHw9vbON15aWhq6d++OH374AbGxsbhy5QratGkD4H9Dp8+ePYvp06cDgDR0et68eaVVlArPyckJd+/exYULF7B9+3asWrUKv//+OwDA3t4ex44dw/nz5+Hu7o7x48dj6dKl+O2339C7d28MHjwYT548UXEJiApW2AuEwcHBsnkVqlevjl69egEAbt++jebNm6Nhw4aYPXu2tE1sbCy6detWKuUgIqrs2CknIiqCogyd3rRpE1q0aIHWrVsDANTU1GBiYgKAQ6eLat26dVKH4tChQ0hKSkJWVhYAQAiBhIQEWFpa5tnOwMAAhoaGAABzc3P0798fx48fzxNvyZIl6NOnD6pWrYqZM2diy5Yt+PTTT7FkyZISLRfR+yjsBcLBgwcjOjpa+qtVqxY8PDwAAMuXL8eIESNw+fJlhIaG4vnz5xBCYOzYsVi6dGkploaIqPJip5yIqAiKMnT62rVr0NLSQteuXeHo6AhPT088fPgQAIdOF5Wnp6fUoQgICICTkxM2bNgAAAgPD4e5uTnq1auXZ7ukpCTk5OQAAJ4/f45du3ahcePGsji3b9/GwYMHMXToUGRmZiIrKwsKhQJKpRKpqaklXziiYiju3AqnT59GcnKydBc89wJhZmYmcnJyoFQqsWrVKnTq1AnW1tYlXg4iIuLs60REJSYrKwuHDh3Cn3/+idq1a2PSpEkYPnw4wsLCpKHTAJCdnY1OnTph/fr1+O233xAWFgYDAwMsWrQI1apVU3EpyqagoCB4e3tj9uzZMDAwQHBwsLTO19cX3bp1Q7du3RAeHo6VK1dCXV0dWVlZ6NOnDwYPHixLa8yYMViyZAkUCgUMDQ0xYMAANGrUCPr6+tiyZUtpF42oUN51gTC/C1S51qxZg0GDBkFDQwMAMHr0aHh7eyMoKAjffPMNnj17hrCwMBw4cKBUykFERIBCCCFUnYmSlpKSAkNDQzx79gwGBgaqzg4RlTPr1q3DokWLAAD9+/fHrFmz8M8//0BdXR1CCJiamuLEiRN5GsILFizA5cuXsW7dOgDA1atX4ebmhrt378riLVy4EHp6evD09ISzszMuX76M9evXIz4+XnrenIjoTefPn8eAAQNw/fp1KaxZs2aYO3cuXF1d893mxYsXMDU1xZ9//okGDRrkG6dPnz6YPHkyHj16hJUrV0JLSwtz5sxBnTp1SqQcREQVWWH7oRy+TkT0L4o7dLpv3744e/YsUlJSAAB79uyBg4ODLA6HThNRYRV3boVcW7duRcOGDQvskIeHh8PGxgaOjo4YNWoUQkJC4Ofnh6lTp5ZIeYiI6DV2yomIiigoKAhBQUGwtbXF3Llz8wyd3rlzJwDA0tISkyZNgouLCz755BNERERg1apVsrQKGjq9fPlyjBw5slTLRWVfeno63NzcYGxsDIVCASsrq3/dZs2aNbCxsYGWlhYaNGiA7du3A3jdiRs2bBgMDQ1hbW2NPXv2SNvMnDkT/fv3L6liUDEV9wJhrjVr1sDHxyffdU+fPsXSpUsxbdo0AK/fHqFUKnmBkIioFHD4OhERUTmRmpqKQYMGwcLCAsuWLUOdOnUQHx9fYPzIyEi0a9cOjRs3hr+/PxYuXIjbt2/j6tWr+Pvvv9GhQwdMmTIFx44dQ3x8PO7cuYPr16+jXbt2iI6ORs2aNUuvcFRk169fh7e3Nx4/fizNrdCoUSMA8rkVcuM6Ozvj3r17qFKlSp60hg4din79+klD33/99VcsWrQImpqaWLNmDZydnUuvYEREFURh+6GVolP+7NkzVK1aFYmJieyUExFRuXfjxg00bdoUlpaWiImJKTCep6cnduzYgc2bN+Pzzz9HcHAwxo4di2HDhuHTTz/FgAEDsGvXLmzbtg3h4eG4c+cOunTpgr59+xb4ei0iIiIqnJSUFFhYWODp06fSK1rzUyk65Xfv3oWFhYWqs0FERERERESVTGJiIszNzQtcXyk65Tk5OdJwLYVCoerslHm5V3Q4skB1WAdlA+tB9Sp7HWzcuBFfffWVtPzs2TMAhb9T3rp1a8TExODEiRNo1KgRDh06hN69e6Njx44IDw/Hq1evEBMTg6pVq0JPTw+tW7fG7t27sWvXLoSGhkJXVxcTJ06Ep6dnpa2DsqCy/w7KAtaB6rEOygbWQ9EIIfD8+XPUrl0bSmXB07lViveUK5XKd16ZoPwZGBjwx6ZirIOygfWgepW1Dnr06IH69etLy7n7QF9fH8Drd1O/uV+ysrKQlZUFdXV1qKurw87ODjExMdIzx48ePQIA2NvbS9u1b98eAPDll19KE7/NmDEDR44cQUREBL777jvpsytjHZQlrAPVYx2oHuugbGA9FN67hq3n4uzrREREZZSpqSk6duwo/QHA6tWrERYWBuD1xG+rV6/GsWPHAAA//PADdHR0MGXKFACQ7rIHBgYiKCgI8+fPh5qaGoYPHy77nB07diAmJgaTJ09GdnY2gNevzzpx4oT0yi0iIiIqGeyUExERlSN+fn74/vvvAQCPHz+Gn58f1q5dm2/c9u3bIygoCE+fPsWoUaOgrq6OLVu2wN7eXoqTkpKCkSNHYtWqVdDS0oK9vT0mTJiADRs24MaNG1iwYEGplIuIiKiyqhTD16lotLS0MG3aNGhpaak6K5UW66BsYD2oHusgr3dNBRMYGIjAwEBZmL+/P/z9/QvcxsDAAImJibKwefPmYd68eQCAly9f4tatW6wDFeLvQPVYB6rHOigbWA8lo1JM9EZERERERERUFnH4OhEREREREZGKsFNOREREREREpCLslBMRERERERGpCDvlJNOuXTuMHTtW1dkgogrml19+gYWFBZRKJZYsWVLinxcfHw+FQoHo6OgS/yz6n8DAQDg6Oqo6G0SlJiQkBFWrVlV1NigfVlZWpXK+odd4/H8/7JRXIO7u7ujcuXO+644fPw6FQoHLly+Xcq7KPm9vbygUCgwbNizPuhEjRkChUMDb27v0M1ZEPBjmdf/+fYwaNQp169aFlpYWLCws4O7ujsOHD6s6a+VC7m9DoVBAQ0MDNWvWxGeffYa1a9ciJyen0OnkvnIrICAAf//99ztnAv9QLCwskJSUhI8//rjEP6s0FXTh9O2OQVpaGiZOnAgbGxtoa2vDxMQEbdu2xY4dO/JNd+HChahWrRoyMjLyrEtLS4OBgQF++umnD1WMCqGk6iI3DYVCIXt1Xa6tW7dCoVDAysrqA5SiYnvzGPbmX0FtpeLo168fbty4IS3zXCz3dh0YGxujc+fObI+WIlW1hby9vdGjR48S/YyKhJ3yCsTHxwcHDx7E3bt386wLDg6Gs7MzPvnkExXkrOyzsLDA5s2bkZ6eLoVlZGRg06ZNsLS0VGHOqLji4+PRpEkTREREYP78+YiJicG+ffvQvn17jBgxolhpZmdn59sZffXq1ftmt8zq3LkzkpKSEB8fj71796J9+/YYM2YMunbtiqysrEKlkZCQgMzMTHTp0gWmpqbQ1dUt4VwDampqqFWrFtTVK+ebP4cNG4Zt27Zh2bJl+O9//4t9+/bhyy+/xOPHj/ONP2jQILx48QLbtm3Lsy4sLAyvXr3CwIEDSzrbFVJR6yKXnp4ekpOTERUVJQtfs2YNz0tFkHsMe/Pvt99++2Dp6+jooEaNGh8svYrozTo4fPgw1NXV0bVrV1Vnq1IoibYQlQx2yiuQrl27wsTEBCEhIbLw1NRUbN26FT169ED//v1hZmYGXV1dNGrU6F9PTAqFAn/88YcsrGrVqrLPSExMRN++fVG1alUYGRmhe/fuiI+P/zCFKiVOTk6wsLCQNUi3bdsGS0tLNG7cWAp7+fIlRo8ejRo1akBbWxutW7fG2bNnpfVHjx6FQqHA/v370bhxY+jo6MDV1RXJycnYu3cv7O3tYWBggAEDBiAtLU3aLicnB3PmzIG1tTV0dHTg4OCAsLCwPOkePnwYzs7O0NXVhYuLC65fvw7g9V2V6dOn49KlS9LV6JCQkHyH8D59+hQKhQJHjx59rzyXdV999RUUCgXOnDmD3r17w9bWFg0bNsS4cePw559/AgAWLVqERo0aQU9PDxYWFvjqq6+QmpoqpZF7x2vnzp1o0KABtLS0kJCQACsrK8ycOROenp4wMDCAv78/XF1dMXLkSFkeHj58CE1NzXJ9Z15LSwu1atWCmZkZnJycMGnSJOzYsQN79+6VjgNPnz6Fr68vTExMYGBgAFdXV1y6dAnA633YqFEjAEDdunWhUCik48OOHTvg5OQEbW1t1K1bF9OnT5d19BUKBVavXo2ePXtCV1cX9evXx86dO6X1T548gYeHB0xMTKCjo4P69esjODgYgHz4ek5ODszNzbFy5UpZ2S5evAilUok7d+78aznKm507d2LSpEn44osvYGVlhSZNmmDUqFEYMmRIvvFr1KgBd3d3rF27Ns+6tWvXokePHjAyMkJAQABsbW2hq6uLunXr4vvvv0dmZmaB+cjvbnKPHj1ko49evnyJb775BmZmZtDT00Pz5s2l41NFUNS6yKWuro4BAwbI6uTu3bs4evQoBgwYkCf+ypUrYWNjA01NTdjZ2WH9+vWy9QqFAkFBQejatSt0dXVhb2+PqKgo3Lx5E+3atYOenh5cXFxw69atD1PwMiL3GPbmX7Vq1QAAcXFx+PTTT6GtrY0GDRrg4MGDsnZP7vnx6dOnUnrR0dGy49ibIyMKOhcPGTIkTyc0MzMTNWrUwJo1a0p6F6jcm3Xg6OiI7777DomJiXj48CEAICYmBq6urtDR0YGxsTH8/f1l5+LcO64LFiyAqakpjI2NMWLECNmxJzk5Ge7u7tDR0YG1tTU2btwoy4MQAoGBgbC0tISWlhZq166N0aNHl84OUKHCtIWKe2yYO3cuatasiSpVqsDHx0c20iowMBChoaHYsWOH9Fs4evRohW0rfQjslFcg6urq8PT0REhICN58/fzWrVuRnZ2NgQMHokmTJti9ezeuXLkCf39/DBo0CGfOnCn2Z2ZmZsLNzQ1VqlTB8ePHcfLkSejr66Nz587l7u7hkCFDpAY98LohOnjwYFmcCRMmIDw8HKGhobhw4QLq1asHNzc3/PPPP7J4gYGB+Pnnn3Hq1CnposWSJUuwadMm7N69GwcOHMCyZcuk+HPmzMG6deuwatUqXL16FV9//TUGDhyIyMhIWbqTJ0/GwoULce7cOairq0uNun79+mH8+PFo2LChdDW6X79+RSp/UfNclv3zzz/Yt28fRowYAT09vTzrcxtQSqUSP/30E65evYrQ0FBERERgwoQJsrhpaWmYN28eVq9ejatXr0p3RBYsWAAHBwdcvHgR33//PXx9fbFp0ya8fPlS2nbDhg0wMzODq6tryRVWBVxdXeHg4CBdxOrTp490Eef8+fNwcnJChw4d8M8//6Bfv344dOgQAODMmTNISkqChYUFjh8/Dk9PT4wZMwbXrl1DUFAQQkJCMGvWLNlnTZ8+HX379sXly5fxxRdfwMPDQ/q9ff/997h27Rr27t2L2NhYrFy5EtWrV8+TX6VSif79+2PTpk2y8I0bN6JVq1aoU6fOv5ajvKlVqxb27NmD58+fF3obHx8fRERESBcpAOCvv/7CsWPH4OPjAwCoUqUKQkJCcO3aNSxduhS//vorFi9e/F55HTlyJKKiorB582ZcvnwZffr0QefOnREXF/de6ZYVxamLXEOGDMHvv/8uXRANCQlB586dUbNmTVm87du3Y8yYMRg/fjyuXLmCoUOHYvDgwThy5IgsXu7FxOjoaHz00UcYMGAAhg4diokTJ+LcuXMQQuRpMFdUOTk56NWrFzQ1NXH69GmsWrUKAQEB75VmQediX19f7Nu3D0lJSVLcXbt2IS0trcjn6vIuNTUVGzZsQL169WBsbIwXL17Azc0N1apVw9mzZ7F161YcOnQoz/fwyJEjuHXrFo4cOYLQ0FCEhITIbhB5e3sjMTERR44cQVhYGFasWIHk5GRpfXh4OBYvXoygoCDExcXhjz/+kC4YV1SFbQsBRT82/P777wgMDMTs2bNx7tw5mJqaYsWKFdL6b775Bn379pWNknBxcalUbaUiE1ShxMbGCgDiyJEjUlibNm3EwIED843fpUsXMX78eGm5bdu2YsyYMdIyALF9+3bZNoaGhiI4OFgIIcT69euFnZ2dyMnJkda/fPlS6OjoiP379793eUqDl5eX6N69u0hOThZaWloiPj5exMfHC21tbfHw4UPRvXt34eXlJVJTU4WGhobYuHGjtO2rV69E7dq1xY8//iiEEOLIkSMCgDh06JAUZ86cOQKAuHXrlhQ2dOhQ4ebmJoQQIiMjQ+jq6opTp07J8uXj4yP69+9fYLq7d+8WAER6eroQQohp06YJBwcHWRq3b98WAMTFixelsCdPnsi+I8XJc1l3+vRpAUBs27atSNtt3bpVGBsbS8vBwcECgIiOjpbFq1OnjujRo4csLD09XVSrVk1s2bJFCvvkk09EYGBgMUpQNuT+NvLTr18/YW9vL44fPy4MDAxERkaGbL2NjY0ICgoSQghx8eJFAUDcvn1bWt+hQwcxe/Zs2Tbr168Xpqam0jIAMWXKFGk5NTVVABB79+4VQgjh7u4uBg8enG/+3v7uX7x4USgUCnHnzh0hhBDZ2dnCzMxMrFy5UgghClWOsuDtY3Su4OBgYWhoKC1HRkYKc3NzoaGhIZydncXYsWPFiRMn3pl2VlaWMDMzE9OmTZPCvv/+e2FpaSmys7Pz3Wb+/PmiSZMm0vLbx6H88pt7TBVCiDt37gg1NTXx999/y+J06NBBTJw48Z35VbWSrIs303B0dBShoaEiJydH2NjYiB07dojFixeLOnXqSPFdXFyEn5+fLI0+ffqIL774Qlp++/cUFRUlAIg1a9ZIYb/99pvQ1tYuROnLBy8vL6Gmpib09PRkf7NmzRL79+8X6urqsu/e3r17Ze2e3PPjkydPpDhvH8/eru/8zsVCCNGgQQMxb948adnd3V14e3t/yOKWSW/XAQBhamoqzp8/L4QQ4pdffhHVqlUTqamp0ja7d+8WSqVS3L9/X0qjTp06IisrS4rTp08f0a9fPyGEENevXxcAxJkzZ6T1ue3hxYsXCyGEWLhwobC1tRWvXr0q6SKXGYVtCxXn2NCyZUvx1VdfydJp3ry57LufXxuiIraVPhTeKa9gPvroI7i4uEjD3W7evInjx4/Dx8cH2dnZmDlzJho1agQjIyPo6+tj//79SEhIKPbnXbp0CTdv3kSVKlWgr68PfX19GBkZISMjo9wNgTMxMUGXLl0QEhKC4OBgdOnSRXbX7datW8jMzESrVq2kMA0NDTRr1gyxsbGytN58dr9mzZrSUM83w3Kv4N68eRNpaWn47LPPpH2or6+PdevW5dmHb6ZramoKALIrwe+jKHku68QbI0Xe5dChQ+jQoQPMzMxQpUoVDBo0CI8fP5YN09fU1Mx3LgZnZ2fZsra2NgYNGiT99i5cuIArV66Ui0kCi0MIAYVCgUuXLiE1NRXGxsay7+/t27ffeQy4dOkSZsyYIdvGz88PSUlJsv3/5r7X09ODgYGB9D0cPnw4Nm/eDEdHR0yYMAGnTp0q8PMcHR1hb28v3S2PjIxEcnIy+vTpI+WnOOUoqz799FP89ddfOHz4ML788ktcvXoVbdq0wcyZMwvcRk1NDV5eXtJoq5ycHISGhmLw4MFQKl83F7Zs2YJWrVqhVq1a0NfXx5QpU97rHBITE4Ps7GzY2trK9ntkZGS53O/5KU5dvCl3FFdkZCRevHiBL774Ik+c2NhY2bkJAFq1avWv5yYAsruFNWvWREZGBlJSUgpdvrKuffv2iI6Olv0NGzYMsbGxsLCwQO3ataW4LVu2LLF8+Pr6SqPxHjx4gL179/7rIwwVxZt1cObMGbi5ueHzzz/HnTt3EBsbCwcHB9md3FatWiEnJ0d6RA8AGjZsCDU1NWnZ1NRUOhfExsZCXV0dTZo0kdZ/9NFHsjvBffr0QXp6OurWrQs/Pz9s37690POilFeFbQsBRT82xMbGonnz5rI0CvP7qWxtpaKonDPgVHA+Pj4YNWoUli9fjuDgYNjY2KBt27aYN28eli5diiVLlkjP0Y4dO/adw8wVCkWeH/Wbz/CkpqaiSZMmeZ7dAV53csubIUOGSMNzli9fXux0NDQ0pP9zZ65+k0KhkCYMy31uavfu3TAzM5PF09LSeme6AN45C3ZuQ/rNOizo+c+i5Lmsq1+/PhQKBf773/8WGCc+Ph5du3bF8OHDMWvWLBgZGeHEiRPw8fHBq1evpMnIdHR0pH39pvyGgvn6+sLR0RF3795FcHAwXF1dpaHRFU1sbCysra2RmpoKU1PTfJ8BftdrglJTUzF9+nT06tUrzzptbW3p/3d9D3MbdXv27MHBgwfRoUMHjBgxAgsWLMj3Mz08PLBp0yZ899132LRpEzp37gxjY2MpP8UpR2kzMDDAs2fP8oQ/ffoUhoaGsjANDQ20adMGbdq0QUBAAH744QfMmDEDAQEB0NTUzDf9IUOGYM6cOYiIiEBOTg4SExOlx3iioqLg4eGB6dOnw83NDYaGhti8eTMWLlxYYH6VSuW/nkPU1NRw/vx5WYMbAPT19d+9M1SspOsil4eHByZMmIDAwEAMGjTovSYvzO8cUtTzSnmjp6eHevXqFWvbopxD/42npye+++47REVF4dSpU7C2tkabNm2KlVZ583YdrF69GoaGhvj1118Lncb7tkksLCxw/fp1HDp0CAcPHsRXX32F+fPnIzIyMk/aFUVh2kK5SvPYUJnaSkXBO+UVUN++faFUKrFp0yasW7cOQ4YMgUKhwMmTJ9G9e3cMHDgQDg4OqFu3ruw1HvkxMTGRPQMVFxcnu4vl5OSEuLg41KhRA/Xq1ZP9vd0oKQ9yn4XPfVb+TbkT6Jw8eVIKy8zMxNmzZ9GgQYNif+abE4i9vQ8tLCwKnY6mpiays7NlYbkXRt6sw8rw3mYjIyO4ublh+fLlePHiRZ71T58+xfnz55GTk4OFCxeiRYsWsLW1xb17997rcxs1agRnZ2f8+uuv2LRpU4W9CxIREYGYmBj07t0bTk5OuH//PtTV1fN8f/N7vjuXk5MTrl+/nmebevXqSQ3hwjAxMYGXlxc2bNiAJUuW4Jdffikw7oABA3DlyhWcP38eYWFh8PDwkOWnOOUobXZ2drhw4UKe8AsXLsDW1vad2zZo0ABZWVn5vvYsV+5F3LVr1yI4OBgdO3aUGkunTp1CnTp1MHnyZDg7O6N+/fqy58/z8/Y5JDs7G1euXJGWGzdujOzsbCQnJ+fZ77Vq1Xpn2qpW0nWRy8jICN26dUNkZGSBxxR7e3vZuQkATp48+V7nporO3t4eiYmJsu9n7sRXuYpzDs3vXAwAxsbG6NGjB4KDgxESEpJnzprKRKFQQKlUIj09Hfb29rh06ZLsXH3y5EkolUrY2dkVKr2PPvoIWVlZOH/+vBR2/fp12QR9wOuL7O7u7vjpp59w9OhRREVFISYm5oOUqSwqTFuouOzt7XH69GlZ2Nu/n4J+C5WlrVRUvFNeAenr66Nfv36YOHEiUlJSpCEh9evXR1hYGE6dOoVq1aph0aJFePDgwTtP2q6urvj555/RsmVLZGdnIyAgQHblzMPDA/Pnz0f37t0xY8YMmJub486dO9i2bRsmTJgAc3Pzki7uB6WmpiYN93v7ro2enh6GDx+Ob7/9FkZGRrC0tMSPP/6ItLQ0aRKk4qhSpQq++eYbfP3118jJyUHr1q3x7NkznDx5EgYGBvDy8ipUOlZWVrh9+zaio6Nhbm6OKlWqQEdHBy1atMDcuXNhbW2N5ORkTJkypdh5LU+WL1+OVq1aoVmzZpgxYwY++eQTZGVl4eDBg1i5ciU2b96MzMxMLFu2DO7u7jh58iRWrVr13p/r6+uLkSNHQk9PDz179vwAJVGtly9f4v79+8jOzsaDBw+wb98+zJkzB127doWnpyeUSiVatmyJHj164Mcff5QubuzevRs9e/bMM8w/19SpU9G1a1dYWlriyy+/hFKpxKVLl3DlyhX88MMPhcrb1KlT0aRJEzRs2BAvX77Erl278n2vcy4rKyu4uLhIj/N069ZNWtexY8dilaO0DR8+HD///DNGjx4NX19faGlpYffu3fjtt9/wn//8R4rXrl079O/fH87OzjA2Nsa1a9cwadIktG/fHgYGBu/8DB8fH/j5+QGAbCKl+vXrIyEhAZs3b0bTpk2xe/dubN++/Z1pubq6Yty4cdi9ezdsbGywaNEiWUPQ1tYWHh4e8PT0xMKFC9G4cWM8fPgQhw8fxieffIIuXboUfSeVktKoi1whISFYsWKFNLLjbd9++y369u2Lxo0bo2PHjvjPf/6Dbdu2SZMsVma5x7A3qauro2PHjrC1tYWXlxfmz5+PlJQUTJ48WRYv9+J4YGAgZs2ahRs3brxzZAiQ/7k4d9Sbr68vunbtiuzs7EKf2yuCN+vgyZMn+Pnnn5Gamgp3d3c0a9YM06ZNg5eXFwIDA/Hw4UOMGjUKgwYNyjOhYUHs7OzQuXNnDB06FCtXroS6ujrGjh0LHR0dKU5ISAiys7PRvHlz6OrqYsOGDdDR0anwd2j/rS309iMuhTVmzBh4e3vD2dkZrVq1wsaNG3H16lXZY49WVlbYv38/rl+/DmNjYxgaGkp9iIrWVvogVPc4O5WkU6dOCQCySV4eP34sunfvLvT19UWNGjXElClThKenp2wShrcnrvn7779Fp06dhJ6enqhfv77Ys2ePbKI3IYRISkoSnp6eonr16kJLS0vUrVtX+Pn5iWfPnpVCSd/fuyazEkI+KVF6eroYNWqUVNZWrVrJJhbJb1KYtyeBESLvRDA5OTliyZIlws7OTmhoaAgTExPh5uYmIiMjC0z37clmMjIyRO/evUXVqlUFAKmOrl27Jlq2bCl0dHSEo6OjOHDgQL4TvRU1z+XBvXv3xIgRI0SdOnWEpqamMDMzE926dZPKvmjRImFqaip0dHSEm5ubWLdunWxf5LcfhHg90Vvu5DFve/78udDV1c0zAUp55OXlJQAIAEJdXV2YmJiIjh07irVr18om/kpJSRGjRo0StWvXFhoaGsLCwkJ4eHiIhIQEIUT+E70JIcS+ffuEi4uL0NHREQYGBqJZs2bil19+kdbjXyaanDlzprC3txc6OjrCyMhIdO/eXfz1119CiPwnORRCiBUrVggAwtPTM095/60cZcWZM2fEZ599JkxMTIShoaFo3rx5nv00e/Zs0bJlS2FkZCS0tbVF3bp1xejRo8WjR4/+Nf20tDRhaGgojIyM8kx89+233wpjY2Ohr68v+vXrJxYvXvzOSa5evXolhg8fLoyMjESNGjXEnDlzZMfU3DhTp04VVlZWQkNDQ5iamoqePXuKy5cvF2f3lKqSqouCjj253p7oTYjX3+26desKDQ0NYWtrK9atWydb//bvKb/fSH7ng/LszWPYm392dnZCiNcThLVu3VpoamoKW1tbsW/fvjz76cSJE6JRo0ZCW1tbtGnTRmzduvWdE70VdC4W4vW5vk6dOrK2WUX3dh1UqVJFNG3aVISFhUlxLl++LNq3by+0tbWFkZGR8PPzE8+fP5el8XY7bcyYMaJt27bSclJSkujSpYvQ0tISlpaWYt26dbJz9fbt20Xz5s2FgYGB0NPTEy1atJBNcFuR/VtbqLjHhlmzZonq1asLfX194eXlJSZMmCA7/icnJ4vPPvtM6Ovr55mEuiK1lT4UhRBFmAWAiIjeKT4+HjY2Njh79iycnJxUnR0iIioChUKB7du3o0ePHh887dTUVJiZmSE4ODjf+TSIKgu2lfLi8HUiog8gMzMTjx8/xpQpU9CiRQueZIiICMDrybEePXqEhQsXomrVqrJHZ4gqE7aVCsZOORHRB3Dy5Em0b98etra2CAsLU3V2iIiojEhISIC1tTXMzc0REhLyXjPoE5VnbCsVjMPXiYiIiIiIiFSEr0QjIiIiIiIiUhF2yomIiIiIiIhUhJ1yIiIiIiIiIhVhp5yIiIiIiIhIRdgpJyIiqiACAwOhUCjy/H388ccfJP3o6GgEBgYiLS3tg6RHREREfCUaERFRhaKjo4OIiAhZmK6u7gdJOzo6GtOnT8fIkSM/WJpERESVHTvlREREFYhSqUSLFi1UnY1CSU9Ph46OjqqzQUREpFIcvk5ERFTBvXjxAiNHjoSdnR10dXVhZWWFYcOG4dmzZ3nirlu3Do0bN4a2tjaqV6+OL774Anfu3EFISAgGDx4MADAxMYFCoYCVlZW0XUxMDNzc3KCnpwdDQ0N8+eWXSEhIkKWtUCgwd+5cBAQEoFatWqhRo0aJlpuIiKg84J1yIiKiCiYrK0u2nJaWhuzsbMyaNQsmJiZITEzErFmz0KNHDxw5ckSKN3/+fEyYMAE+Pj6YNWsWMjMzERERgYcPH6JLly6YMmUKfvjhB+zbtw+GhobQ0tICACQmJuLTTz+FjY0NNmzYgIyMDEyePBlt27bF5cuXUaVKFekzli5dihYtWmDNmjV58klERFQZsVNORERUgbx48QIaGhqysPXr12PlypXSclZWFqytrdG6dWvcuHEDtra2ePbsGQIDA+Hv74+goCApbvfu3aX/bWxsAABNmjRB9erVpfDFixcjMzMTBw4cgJGREQCgcePGaNCgAUJCQjBq1CgprpGREbZt2waFQvFhC05ERFROsVNORERUgejo6ODYsWOysLp162L9+vVYtGgR4uLi8OLFC2ldbqc8KioKaWlp8PHxKfJnHj9+HK6urlKHHAA++ugjODg44MSJE7JO+eeff84OORER0RvYKSciIqpAlEolnJ2dZWHbt2+Hp6cn/P39MWvWLBgbGyMpKQk9e/ZERkYGAODx48cAgNq1axf5M588eQJHR8c84TVr1sQ///yTJ4yIiIj+h51yIiKiCm7r1q1wdHSUDUuPjIyUxTE2NgYA3Lt3D+bm5kVK38jICMnJyXnCHzx4AFtbW1kY75ITERHJcfZ1IiKiCi49PR2ampqysI0bN8qWW7ZsCV1dXQQHBxeYTm4auXfXc7Vu3RqHDx/GkydPpLDr16/j8uXLaN269ftmn4iIqEJjp5yIiKiC++yzz3DmzBnMnDkThw4dwrhx43D48GFZHENDQ0ybNg2rVq3C0KFDsWfPHuzatQvjx4/HuXPnAAD29vYAgOXLl+P06dOIiYkBAHz99dfQ0NBAp06d8Mcff2Dz5s3o0qULLC0t4e3tXaplJSIiKm/YKSciIqrghg4divHjx2PZsmXo1asXEhMTsWnTpjzxJkyYgLVr1yIqKgo9e/aEt7c3bty4Ib1PvHHjxggMDMSGDRvg4uICd3d3AICFhQUiIyNRrVo1eHh4wN/fHw4ODjh69KjsdWhERESUl0IIIVSdCSIiIiIiIqLKiHfKiYiIiIiIiFSEnXIiIiIiIiIiFWGnnIiIiIiIiEhF2CknIiIiIiIiUhF2yomIiIiIiIhUhJ1yIiIiIiIiIhVhp5yIiIiIiIhIRdgpJyIiIiIiIlIRdsqJiIiIiIiIVISdciIiIiIiIiIVYaeciIiIiIiISEXYKSciIiIiIiJSkf8H3TEbHNPDhXUAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1200x500 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Period: 1927-2024 (1176 months)\n",
-      "Regime distribution: Risk-On 900 (76.5%), Risk-Off 276 (23.5%)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Risk-Off (%)</th>\n",
-       "      <th>Risk-On (%)</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>Value</th>\n",
-       "      <td>5.3</td>\n",
-       "      <td>1.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Momentum</th>\n",
-       "      <td>0.4</td>\n",
-       "      <td>4.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Equity</th>\n",
-       "      <td>2.2</td>\n",
-       "      <td>9.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Bonds</th>\n",
-       "      <td>4.2</td>\n",
-       "      <td>0.8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Carry</th>\n",
-       "      <td>-0.6</td>\n",
-       "      <td>3.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Defensive</th>\n",
-       "      <td>-0.5</td>\n",
-       "      <td>4.2</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           Risk-Off (%)  Risk-On (%)\n",
-       "Value               5.3          1.6\n",
-       "Momentum            0.4          4.5\n",
-       "Equity              2.2          9.5\n",
-       "Bonds               4.2          0.8\n",
-       "Carry              -0.6          3.5\n",
-       "Defensive          -0.5          4.2"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "35bea765",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "def plot_factor_returns_by_regime():\n",
-    "    \"\"\"Compare annualized factor returns between Risk-On and Risk-Off regimes.\"\"\"\n",
-    "    # Calculate mean factor returns by regime\n",
-    "    regime_labels_2 = pd.Series(labels_2, index=factors_df.index, name=\"regime\")\n",
-    "    factor_by_regime = factors_df.copy()\n",
-    "    factor_by_regime[\"regime\"] = regime_labels_2\n",
-    "\n",
-    "    # Mean returns by regime (annualized)\n",
-    "    regime_means = factor_by_regime.groupby(\"regime\").mean() * 12\n",
-    "    regime_means.index = [\"Risk-Off\" if i == bad_regime else \"Risk-On\" for i in regime_means.index]\n",
-    "\n",
-    "    # Rename columns for readability\n",
-    "    col_renames = {\n",
-    "        \"All asset classes Value\": \"Value\",\n",
-    "        \"All asset classes Momentum\": \"Momentum\",\n",
-    "        \"All asset classes Carry\": \"Carry\",\n",
-    "        \"All asset classes Defensive\": \"Defensive\",\n",
-    "        \"US Stock Selection Value\": \"US Value\",\n",
-    "        \"US Stock Selection Momentum\": \"US Mom\",\n",
-    "        \"Equity indices Market\": \"Equity\",\n",
-    "        \"Fixed income Market\": \"Bonds\",\n",
-    "        \"Commodities Market\": \"Cmdty\",\n",
-    "    }\n",
-    "    regime_means_display = regime_means.rename(columns=col_renames)\n",
-    "\n",
-    "    # Create bar chart comparing regimes\n",
-    "    fig, ax = plt.subplots(figsize=(12, 5))\n",
-    "\n",
-    "    x = np.arange(len(regime_means_display.columns))\n",
-    "    width = 0.35\n",
-    "\n",
-    "    bars1 = ax.bar(\n",
-    "        x - width / 2,\n",
-    "        regime_means_display.loc[\"Risk-On\"].values * 100,\n",
-    "        width,\n",
-    "        label=\"Risk-On\",\n",
-    "        color=\"#4a7c59\",\n",
-    "        edgecolor=\"black\",\n",
-    "        linewidth=0.5,\n",
-    "    )\n",
-    "    bars2 = ax.bar(\n",
-    "        x + width / 2,\n",
-    "        regime_means_display.loc[\"Risk-Off\"].values * 100,\n",
-    "        width,\n",
-    "        label=\"Risk-Off\",\n",
-    "        color=\"#8b4513\",\n",
-    "        edgecolor=\"black\",\n",
-    "        linewidth=0.5,\n",
-    "    )\n",
-    "\n",
-    "    # Add value labels\n",
-    "    for bar, val in zip(bars1, regime_means_display.loc[\"Risk-On\"].values, strict=False):\n",
-    "        height = bar.get_height()\n",
-    "        ax.annotate(\n",
-    "            f\"{val * 100:.1f}%\",\n",
-    "            xy=(bar.get_x() + bar.get_width() / 2, height),\n",
-    "            xytext=(0, 3 if height >= 0 else -10),\n",
-    "            textcoords=\"offset points\",\n",
-    "            ha=\"center\",\n",
-    "            va=\"bottom\" if height >= 0 else \"top\",\n",
-    "            fontsize=8,\n",
-    "            fontweight=\"bold\",\n",
-    "        )\n",
-    "\n",
-    "    for bar, val in zip(bars2, regime_means_display.loc[\"Risk-Off\"].values, strict=False):\n",
-    "        height = bar.get_height()\n",
-    "        ax.annotate(\n",
-    "            f\"{val * 100:.1f}%\",\n",
-    "            xy=(bar.get_x() + bar.get_width() / 2, height),\n",
-    "            xytext=(0, 3 if height >= 0 else -10),\n",
-    "            textcoords=\"offset points\",\n",
-    "            ha=\"center\",\n",
-    "            va=\"bottom\" if height >= 0 else \"top\",\n",
-    "            fontsize=8,\n",
-    "        )\n",
-    "\n",
-    "    ax.set_ylabel(\"Annualized Return (%)\", fontsize=11)\n",
-    "    ax.set_xlabel(\"Factor\", fontsize=11)\n",
-    "    ax.set_xticks(x)\n",
-    "    ax.set_xticklabels(regime_means_display.columns, fontsize=10)\n",
-    "    ax.axhline(y=0, color=\"black\", linestyle=\"-\", linewidth=0.5)\n",
-    "    ax.legend(loc=\"upper right\", fontsize=10)\n",
-    "    ax.grid(axis=\"y\", alpha=0.3)\n",
-    "\n",
-    "    n_on = (labels_2 == good_regime).sum()\n",
-    "    n_off = (labels_2 == bad_regime).sum()\n",
-    "    ax.set_title(\n",
-    "        f\"Factor Returns by Market Regime\\nRisk-On: {n_on} months ({n_on / len(labels_2) * 100:.0f}%) | Risk-Off: {n_off} months ({n_off / len(labels_2) * 100:.0f}%)\",\n",
-    "        fontsize=12,\n",
-    "        fontweight=\"bold\",\n",
-    "    )\n",
-    "\n",
-    "    plt.show()\n",
-    "\n",
-    "    # Display per-factor returns as a DataFrame for easy comparison.\n",
-    "    period_label = (\n",
-    "        f\"{factors_df.index.min().year}-{factors_df.index.max().year} ({len(factors_df)} months)\"\n",
-    "    )\n",
-    "    print(f\"Period: {period_label}\")\n",
-    "    print(\n",
-    "        f\"Regime distribution: Risk-On {n_on} ({n_on / len(labels_2) * 100:.1f}%), \"\n",
-    "        f\"Risk-Off {n_off} ({n_off / len(labels_2) * 100:.1f}%)\"\n",
-    "    )\n",
-    "    key_factors = [\n",
-    "        c\n",
-    "        for c in [\"Value\", \"Momentum\", \"Equity\", \"Bonds\", \"Carry\", \"Defensive\"]\n",
-    "        if c in regime_means_display.columns\n",
-    "    ]\n",
-    "    factor_summary = (regime_means_display[key_factors].T * 100).round(1)\n",
-    "    factor_summary.columns = [f\"{c} (%)\" for c in factor_summary.columns]\n",
-    "    return factor_summary\n",
-    "\n",
-    "\n",
-    "factor_summary = plot_factor_returns_by_regime()\n",
-    "factor_summary"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b34cfd8a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003577,
-     "end_time": "2026-07-11T19:31:20.308422+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.304845+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "**Interpretation**: The regime split reveals distinct factor behavior:\n",
-    "\n",
-    "- **Value is countercyclical**: Returns *increase* during Risk-Off (+5.3% vs +1.6%),\n",
-    "  consistent with the value premium's tendency to compensate for distress risk.\n",
-    "- **Momentum is procyclical**: Much weaker during Risk-Off (+0.4% vs +4.5%),\n",
-    "  reflecting momentum's vulnerability to sharp reversals.\n",
-    "- **Carry and Defensive turn negative** in Risk-Off (−0.6% and −0.5%) — these\n",
-    "  strategies that appear safe in calm markets lose money when conditions deteriorate.\n",
-    "- **Bonds outperform in Risk-Off** (+4.2% vs +0.8%), consistent with the classic\n",
-    "  flight-to-quality effect.\n",
-    "\n",
-    "For portfolio construction, this suggests Value and Bonds provide genuine\n",
-    "diversification during stress, while Carry and Defensive do not."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7bde3a0f",
-   "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.003488,
-     "end_time": "2026-07-11T19:31:20.315460+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.311972+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Regime Statistics\n",
-    "\n",
-    "Compare key metrics between Risk-On and Risk-Off periods."
+    "annualized_by_regime = (\n",
+    "    factors_df.groupby(regime_name).mean().mul(MONTHS_PER_YEAR * 100).rename(columns=SHORT_NAMES)\n",
+    ").loc[[\"Risk-on\", \"Risk-off\"]]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "4fa63c04",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:20.323256Z",
-     "iopub.status.busy": "2026-07-11T19:31:20.323160Z",
-     "iopub.status.idle": "2026-07-11T19:31:20.329841Z",
-     "shell.execute_reply": "2026-07-11T19:31:20.329409Z"
-    },
-    "lines_to_next_cell": 0,
-    "papermill": {
-     "duration": 0.011597,
-     "end_time": "2026-07-11T19:31:20.330453+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.318856+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Volatility ratio (Risk-Off / Risk-On): 2.23x\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<style type=\"text/css\">\n",
-       "</style>\n",
-       "<table id=\"T_86dc3\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_86dc3_level0_col0\" class=\"col_heading level0 col0\" >Months</th>\n",
-       "      <th id=\"T_86dc3_level0_col1\" class=\"col_heading level0 col1\" >% of Time</th>\n",
-       "      <th id=\"T_86dc3_level0_col2\" class=\"col_heading level0 col2\" >Ann. Return</th>\n",
-       "      <th id=\"T_86dc3_level0_col3\" class=\"col_heading level0 col3\" >Ann. Volatility</th>\n",
-       "      <th id=\"T_86dc3_level0_col4\" class=\"col_heading level0 col4\" >Sharpe Ratio</th>\n",
-       "      <th id=\"T_86dc3_level0_col5\" class=\"col_heading level0 col5\" >Max Drawdown</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th class=\"index_name level0\" >Regime</th>\n",
-       "      <th class=\"blank col0\" >&nbsp;</th>\n",
-       "      <th class=\"blank col1\" >&nbsp;</th>\n",
-       "      <th class=\"blank col2\" >&nbsp;</th>\n",
-       "      <th class=\"blank col3\" >&nbsp;</th>\n",
-       "      <th class=\"blank col4\" >&nbsp;</th>\n",
-       "      <th class=\"blank col5\" >&nbsp;</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th id=\"T_86dc3_level0_row0\" class=\"row_heading level0 row0\" >Risk-On</th>\n",
-       "      <td id=\"T_86dc3_row0_col0\" class=\"data row0 col0\" >900</td>\n",
-       "      <td id=\"T_86dc3_row0_col1\" class=\"data row0 col1\" >76.5%</td>\n",
-       "      <td id=\"T_86dc3_row0_col2\" class=\"data row0 col2\" >+9.5%</td>\n",
-       "      <td id=\"T_86dc3_row0_col3\" class=\"data row0 col3\" >8.6%</td>\n",
-       "      <td id=\"T_86dc3_row0_col4\" class=\"data row0 col4\" >1.11</td>\n",
-       "      <td id=\"T_86dc3_row0_col5\" class=\"data row0 col5\" >-22.9%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th id=\"T_86dc3_level0_row1\" class=\"row_heading level0 row1\" >Risk-Off</th>\n",
-       "      <td id=\"T_86dc3_row1_col0\" class=\"data row1 col0\" >276</td>\n",
-       "      <td id=\"T_86dc3_row1_col1\" class=\"data row1 col1\" >23.5%</td>\n",
-       "      <td id=\"T_86dc3_row1_col2\" class=\"data row1 col2\" >+2.2%</td>\n",
-       "      <td id=\"T_86dc3_row1_col3\" class=\"data row1 col3\" >19.1%</td>\n",
-       "      <td id=\"T_86dc3_row1_col4\" class=\"data row1 col4\" >0.12</td>\n",
-       "      <td id=\"T_86dc3_row1_col5\" class=\"data row1 col5\" >-76.9%</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x77467c3af4d0>"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "6afbe975",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "def compute_regime_statistics():\n",
-    "    \"\"\"Calculate and display comprehensive regime statistics.\"\"\"\n",
-    "    # Calculate comprehensive regime statistics\n",
-    "    equity_returns = factors_df[\"Equity indices Market\"]\n",
-    "    regime_series = pd.Series(labels_2, index=factors_df.index)\n",
+    "fig, ax = plt.subplots(figsize=style.FIGSIZE[\"single_tall\"])\n",
     "\n",
-    "    regime_stats_list = []\n",
-    "    for regime, name in [(good_regime, \"Risk-On\"), (bad_regime, \"Risk-Off\")]:\n",
-    "        mask = regime_series == regime\n",
-    "        returns = equity_returns[mask]\n",
+    "x = np.arange(annualized_by_regime.shape[1])\n",
+    "width = 0.38\n",
+    "ax.bar(\n",
+    "    x - width / 2,\n",
+    "    annualized_by_regime.loc[\"Risk-on\"],\n",
+    "    width,\n",
+    "    label=\"Risk-on\",\n",
+    "    color=COLORS[\"recede\"],\n",
+    ")\n",
+    "ax.bar(\n",
+    "    x + width / 2,\n",
+    "    annualized_by_regime.loc[\"Risk-off\"],\n",
+    "    width,\n",
+    "    label=\"Risk-off\",\n",
+    "    color=COLORS[\"blue\"],\n",
+    ")\n",
+    "ax.set_xticks(x)\n",
+    "ax.set_xticklabels(annualized_by_regime.columns, rotation=30, ha=\"right\")\n",
+    "ax.set_ylabel(\"Mean return within the regime, annualized (%)\")\n",
+    "style.zero_line(ax)\n",
+    "ax.legend(loc=\"upper right\")\n",
+    "ax.grid(axis=\"y\", alpha=0.3)\n",
     "\n",
-    "        # Basic counts\n",
-    "        n_months = mask.sum()\n",
-    "        pct_time = n_months / len(mask) * 100\n",
-    "\n",
-    "        # Return statistics (annualized)\n",
-    "        mean_ret = returns.mean() * 12\n",
-    "        vol = returns.std() * np.sqrt(12)\n",
-    "        sharpe = mean_ret / vol if vol > 0 else 0\n",
-    "\n",
-    "        # Drawdown\n",
-    "        cum_ret = (1 + returns).cumprod()\n",
-    "        peak = cum_ret.cummax()\n",
-    "        drawdown = (cum_ret - peak) / peak\n",
-    "        max_dd = drawdown.min()\n",
-    "\n",
-    "        regime_stats_list.append(\n",
-    "            {\n",
-    "                \"Regime\": name,\n",
-    "                \"Months\": n_months,\n",
-    "                \"% of Time\": pct_time,\n",
-    "                \"Ann. Return\": mean_ret,\n",
-    "                \"Ann. Volatility\": vol,\n",
-    "                \"Sharpe Ratio\": sharpe,\n",
-    "                \"Max Drawdown\": max_dd,\n",
-    "            }\n",
-    "        )\n",
-    "\n",
-    "    regime_stats_df = pd.DataFrame(regime_stats_list).set_index(\"Regime\")\n",
-    "\n",
-    "    # Volatility ratio (printed; the table itself displays below).\n",
-    "    vol_on = regime_stats_df.loc[\"Risk-On\", \"Ann. Volatility\"]\n",
-    "    vol_off = regime_stats_df.loc[\"Risk-Off\", \"Ann. Volatility\"]\n",
-    "    print(f\"Volatility ratio (Risk-Off / Risk-On): {vol_off / vol_on:.2f}x\")\n",
-    "    return regime_stats_df.style.format(\n",
-    "        {\n",
-    "            \"% of Time\": \"{:.1f}%\",\n",
-    "            \"Ann. Return\": \"{:+.1%}\",\n",
-    "            \"Ann. Volatility\": \"{:.1%}\",\n",
-    "            \"Sharpe Ratio\": \"{:.2f}\",\n",
-    "            \"Max Drawdown\": \"{:.1%}\",\n",
-    "        }\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "compute_regime_statistics()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "698b7f5c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005016,
-     "end_time": "2026-07-11T19:31:20.342849+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.337833+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "**Interpretation**: The regime split is stark. Risk-On delivers a Sharpe of 1.11\n",
-    "while Risk-Off drops to 0.12 — equity exposure during Risk-Off is essentially\n",
-    "uncompensated risk. The −76.9% max drawdown in Risk-Off reflects the Great\n",
-    "Depression and underscores that these are not mild corrections.\n",
-    "\n",
-    "The direct volatility ratio here (2.2x) is much larger than the rolling-window\n",
-    "average reported earlier (1.3x). The rolling measure smooths over extreme months,\n",
-    "while this calculation captures the full variance within each regime. The direct\n",
-    "measure better reflects what a portfolio actually experiences during Risk-Off."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "45a96902",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004784,
-     "end_time": "2026-07-11T19:31:20.352044+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.347260+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Regime Duration Analysis"
+    "style.add_message_title(\n",
+    "    ax,\n",
+    "    \"Value and bonds hold up in the risk-off months; carry and defensive do not\",\n",
+    "    subtitle=\"Mean monthly return within each regime times twelve, by series\",\n",
+    ")\n",
+    "style.show_with_alt(\n",
+    "    fig,\n",
+    "    \"Paired bars per factor. Value and bonds have taller risk-off bars than risk-on bars; \"\n",
+    "    \"momentum, equity, carry and defensive have taller risk-on bars, with carry and \"\n",
+    "    \"defensive falling below zero in the risk-off months.\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "2d89a60f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T19:31:20.360147Z",
-     "iopub.status.busy": "2026-07-11T19:31:20.360053Z",
-     "iopub.status.idle": "2026-07-11T19:31:20.365559Z",
-     "shell.execute_reply": "2026-07-11T19:31:20.365108Z"
-    },
-    "papermill": {
-     "duration": 0.010108,
-     "end_time": "2026-07-11T19:31:20.365897+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.355789+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Total regime transitions: 267 (avg 4.4 months between switches)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<style type=\"text/css\">\n",
-       "</style>\n",
-       "<table id=\"T_1b1f2\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_1b1f2_level0_col0\" class=\"col_heading level0 col0\" >Avg duration (months)</th>\n",
-       "      <th id=\"T_1b1f2_level0_col1\" class=\"col_heading level0 col1\" >Max duration (months)</th>\n",
-       "      <th id=\"T_1b1f2_level0_col2\" class=\"col_heading level0 col2\" >Episodes</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th class=\"index_name level0\" >Regime</th>\n",
-       "      <th class=\"blank col0\" >&nbsp;</th>\n",
-       "      <th class=\"blank col1\" >&nbsp;</th>\n",
-       "      <th class=\"blank col2\" >&nbsp;</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th id=\"T_1b1f2_level0_row0\" class=\"row_heading level0 row0\" >Risk-On</th>\n",
-       "      <td id=\"T_1b1f2_row0_col0\" class=\"data row0 col0\" >6.7</td>\n",
-       "      <td id=\"T_1b1f2_row0_col1\" class=\"data row0 col1\" >110</td>\n",
-       "      <td id=\"T_1b1f2_row0_col2\" class=\"data row0 col2\" >134</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th id=\"T_1b1f2_level0_row1\" class=\"row_heading level0 row1\" >Risk-Off</th>\n",
-       "      <td id=\"T_1b1f2_row1_col0\" class=\"data row1 col0\" >2.1</td>\n",
-       "      <td id=\"T_1b1f2_row1_col1\" class=\"data row1 col1\" >14</td>\n",
-       "      <td id=\"T_1b1f2_row1_col2\" class=\"data row1 col2\" >134</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x77467c3af390>"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "2338226c",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# Calculate average duration\n",
-    "durations = {}\n",
-    "for regime, name in [(bad_regime, \"Risk-Off\"), (good_regime, \"Risk-On\")]:\n",
-    "    regime_mask = labels_2 == regime\n",
-    "    runs = []\n",
-    "    current_run = 0\n",
-    "    for val in regime_mask:\n",
-    "        if val:\n",
-    "            current_run += 1\n",
-    "        elif current_run > 0:\n",
-    "            runs.append(current_run)\n",
-    "            current_run = 0\n",
-    "    if current_run > 0:\n",
-    "        runs.append(current_run)\n",
-    "    durations[name] = (np.mean(runs), np.max(runs), len(runs))\n",
+    "annualized_by_regime.T.style.format(\"{:+.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d632f48e",
+   "metadata": {},
+   "source": [
+    "The two long-short strategies named for safety, carry and defensive, are the ones that\n",
+    "stop paying when conditions deteriorate. That is the shape a reader should take away:\n",
+    "a strategy's average return over a full sample says nothing about whether it will be there\n",
+    "in the environment a portfolio needs it in, and the only way to find out is to condition\n",
+    "on the environment and look."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93f0501c",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "## Regime statistics\n",
     "\n",
-    "transitions = int(np.sum(np.diff(labels_2) != 0))\n",
+    "The table below characterises each regime through the equity index alone. Every statistic\n",
+    "is computed on one stream: the monthly returns of the months the model assigned to that\n",
+    "regime, concatenated in date order with the months in the other regime removed.\n",
     "\n",
-    "duration_df = pd.DataFrame(\n",
+    "For the mean, the standard deviation and the Sharpe ratio that is an ordinary conditional\n",
+    "statistic - the average of a set of months does not depend on their order. **Maximum\n",
+    "drawdown** is different, because it is a path statistic: it compounds the stream, tracks\n",
+    "its running high-water mark, and reports the largest percentage fall from that mark to a\n",
+    "later point. Compounding a stream whose gaps have been closed up is not the same as\n",
+    "compounding the index, so the number below describes an investor who held equities during\n",
+    "one regime and held nothing during the other. The section after the table shows how far\n",
+    "apart the two readings are."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "717b57d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def drawdown_path(returns: pd.Series) -> pd.Series:\n",
+    "    \"\"\"Fractional decline from the running high-water mark of the compounded stream.\"\"\"\n",
+    "    wealth = (1 + returns).cumprod()\n",
+    "    return wealth / wealth.cummax() - 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6472f5f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "regime_statistics = pd.DataFrame(\n",
     "    [\n",
     "        {\n",
-    "            \"Regime\": name,\n",
-    "            \"Avg duration (months)\": durations[name][0],\n",
-    "            \"Max duration (months)\": durations[name][1],\n",
-    "            \"Episodes\": durations[name][2],\n",
+    "            \"Regime\": regime,\n",
+    "            \"Months\": int(len(returns)),\n",
+    "            \"Share of sample\": len(returns) / len(equity_returns),\n",
+    "            \"Return, annualized\": returns.mean() * MONTHS_PER_YEAR,\n",
+    "            \"Volatility, annualized\": returns.std() * np.sqrt(MONTHS_PER_YEAR),\n",
+    "            \"Sharpe ratio\": sharpe_ratio(returns, periods_per_year=MONTHS_PER_YEAR),\n",
+    "            \"Max drawdown\": float(drawdown_path(returns).min()),\n",
     "        }\n",
-    "        for name in [\"Risk-On\", \"Risk-Off\"]\n",
+    "        for regime, returns in (\n",
+    "            (name, equity_returns[regime_name == name]) for name in (\"Risk-on\", \"Risk-off\")\n",
+    "        )\n",
     "    ]\n",
     ").set_index(\"Regime\")\n",
-    "\n",
-    "print(\n",
-    "    f\"Total regime transitions: {transitions} \"\n",
-    "    f\"(avg {len(labels_2) / transitions:.1f} months between switches)\"\n",
+    "regime_statistics.style.format(\n",
+    "    {\n",
+    "        \"Share of sample\": \"{:.1%}\",\n",
+    "        \"Return, annualized\": \"{:+.1%}\",\n",
+    "        \"Volatility, annualized\": \"{:.1%}\",\n",
+    "        \"Sharpe ratio\": \"{:.2f}\",\n",
+    "        \"Max drawdown\": \"{:.1%}\",\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c9d2508",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pooled_vol_ratio = (\n",
+    "    regime_statistics.loc[\"Risk-off\", \"Volatility, annualized\"]\n",
+    "    / regime_statistics.loc[\"Risk-on\", \"Volatility, annualized\"]\n",
     ")\n",
-    "duration_df.style.format({\"Avg duration (months)\": \"{:.1f}\"})"
+    "rolling_vol_ratio = (\n",
+    "    rolling_vol_by_regime.loc[\"Risk-off\", \"Mean (%)\"]\n",
+    "    / rolling_vol_by_regime.loc[\"Risk-on\", \"Mean (%)\"]\n",
+    ")\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"Risk-off volatility is **{pooled_vol_ratio:.2f}x** risk-on volatility measured on \"\n",
+    "        f\"the pooled monthly returns, against **{rolling_vol_ratio:.2f}x** measured as the \"\n",
+    "        \"average of the trailing twelve-month series.\"\n",
+    "    )\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3e7ec85f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003566,
-     "end_time": "2026-07-11T19:31:20.373140+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.369574+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "97dcc286",
+   "metadata": {},
    "source": [
-    "**Interpretation**: With 267 transitions over 98 years, the model switches regime\n",
-    "roughly every 4 months on average. Risk-Off episodes are short (avg ~2 months)\n",
-    "— they capture acute stress periods rather than prolonged bear markets. This\n",
-    "choppiness has practical implications: a strategy that reallocates based on these\n",
-    "signals would trade frequently, incurring transaction costs that may erode the\n",
-    "regime-timing benefit. Regime models are more useful for *understanding* market\n",
-    "dynamics than for high-frequency tactical allocation."
+    "The two ratios answer different questions and a reader should expect them to differ. The\n",
+    "rolling series smooths each month against the eleven around it, so a single extreme month\n",
+    "raises twelve windows a little; the pooled standard deviation lets it enter once, at full\n",
+    "size. The pooled figure is the one that describes what a portfolio holding through the\n",
+    "regime experiences, and the rolling figure is the one a monitoring dashboard would show.\n",
+    "Reporting either alone would be defensible; reporting one and calling it \"the\" volatility\n",
+    "ratio would not."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0b120944",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003533,
-     "end_time": "2026-07-11T19:31:20.380310+00:00",
-     "exception": false,
-     "start_time": "2026-07-11T19:31:20.376777+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "5d8738f4",
+   "metadata": {},
    "source": [
-    "## Key Takeaways\n",
+    "### What the restricted drawdown actually measures\n",
     "\n",
-    "- **BIC favors two regimes**: K=2 has the lowest BIC and highest silhouette score,\n",
-    "  though AIC prefers more clusters. The two-state model offers the most interpretable\n",
-    "  and stable regime split.\n",
-    "- **Regimes capture distinct risk environments**: Risk-Off has 2.2x higher volatility,\n",
-    "  a Sharpe of 0.12 (vs 1.11), and a max drawdown of −77%.\n",
-    "- **Value is countercyclical**: +5.3% annualized during Risk-Off vs +1.6% during Risk-On.\n",
-    "  Carry and Defensive, despite their names, turn negative in Risk-Off.\n",
-    "- **Momentum is procyclical**: +4.5% during Risk-On vs +0.4% during Risk-Off — weakest\n",
-    "  factor during market stress.\n",
-    "- **Regime signals are noisy**: With transitions every ~4 months on average, this model\n",
-    "  is better suited for understanding factor dynamics than for tactical allocation.\n",
+    "The drawdown reported for the risk-off regime is large, and it is worth reading where it\n",
+    "came from before quoting it. The cell below finds the high-water mark of the restricted\n",
+    "stream and the month it fell furthest below it, and puts the drawdown of the index itself\n",
+    "over the same span beside it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7eaffe1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "risk_off_returns = equity_returns[regime_name == \"Risk-off\"]\n",
+    "risk_off_drawdown = drawdown_path(risk_off_returns)\n",
+    "trough_month = risk_off_drawdown.idxmin()\n",
+    "peak_month = (1 + risk_off_returns).cumprod().loc[:trough_month].idxmax()\n",
     "\n",
-    "**Next**: `macro_regimes.py` switches from style returns to macro indicators (UNRATE,\n",
-    "DFF, T10Y2Y, CPIAUCSL) and validates the resulting clusters against S&P 500 volatility\n",
-    "and drawdowns. See Chapter 1 §1.4 for the workflow context."
+    "index_over_span = equity_returns.loc[peak_month:trough_month]\n",
+    "index_drawdown = float(drawdown_path(index_over_span).min())\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"The restricted stream peaks in **{peak_month:%B %Y}** and reaches its low in \"\n",
+    "        f\"**{trough_month:%B %Y}**, a fall of \"\n",
+    "        f\"**{risk_off_drawdown.min():.1%}** spread over \"\n",
+    "        f\"**{trough_month.year - peak_month.year} years**. Over the same span the equity \"\n",
+    "        f\"index itself fell at most **{index_drawdown:.1%}** from its own high-water mark.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d254edc4",
+   "metadata": {},
+   "source": [
+    "Nobody lived through the first of those two numbers. It is the arithmetic of a stream that\n",
+    "keeps every month the market was falling and discards the ones in which it recovered, so it\n",
+    "accumulates the losses of a century of separate episodes into one uninterrupted decline.\n",
+    "The statistic is not wrong - it is the correct drawdown of the object it was computed on -\n",
+    "but the object is a construction of this notebook, and a reader who takes it for a crash\n",
+    "has been misled by a table that never said which object it meant.\n",
+    "\n",
+    "That is the general form: a conditional statistic inherits the assumptions of the\n",
+    "conditioning. Averages survive it, because a mean does not care in what order its terms\n",
+    "arrive. Anything that reads a path - a drawdown, a run length, a time to recovery, a\n",
+    "stop-loss - is a different statistic once the path has been cut up, and reporting it\n",
+    "without saying so is how a number that means one thing gets read as another."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a76bfb35",
+   "metadata": {},
+   "source": [
+    "## How long the regimes last\n",
+    "\n",
+    "A regime label is useful to a strategy only if it persists long enough to act on. An\n",
+    "**episode** below is a maximal run of consecutive months carrying the same label, and the\n",
+    "table reports how many episodes each regime had and how long they ran."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3737b1dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "episode_id = (labels_2 != np.roll(labels_2, 1)).cumsum()\n",
+    "episode_lengths = (\n",
+    "    pd.DataFrame({\"regime\": regime_name.to_numpy(), \"episode\": episode_id})\n",
+    "    .groupby([\"regime\", \"episode\"])\n",
+    "    .size()\n",
+    "    .rename(\"months\")\n",
+    "    .reset_index()\n",
+    ")\n",
+    "\n",
+    "duration = (\n",
+    "    episode_lengths.groupby(\"regime\")[\"months\"]\n",
+    "    .agg([\"mean\", \"max\", \"count\"])\n",
+    "    .rename(\n",
+    "        columns={\"mean\": \"Mean length (months)\", \"max\": \"Longest (months)\", \"count\": \"Episodes\"}\n",
+    "    )\n",
+    "    .loc[[\"Risk-on\", \"Risk-off\"]]\n",
+    ")\n",
+    "duration.index.name = \"Regime\"\n",
+    "duration.style.format({\"Mean length (months)\": \"{:.1f}\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "104b020d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "switches = int(np.sum(np.diff(labels_2) != 0))\n",
+    "months_between_switches = len(labels_2) / switches\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"The two-cluster model changes regime **{switches}** times over \"\n",
+    "        f\"{end_year - start_year} years, about once every \"\n",
+    "        f\"**{months_between_switches:.1f} months**.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95b9eccb",
+   "metadata": {},
+   "source": [
+    "That is the finding that decides what this model is for. A label that changes several\n",
+    "times a year cannot drive a reallocation: the turnover would be paid on every switch,\n",
+    "including the ones the model reverses a month later, and the transaction costs would\n",
+    "arrive whether or not the regime call was right. The same label is useful as a lens on\n",
+    "history and as one input to a risk report, which is the use Section 1.4 argues for.\n",
+    "\n",
+    "A model built to be acted on would be built differently. It would carry a transition\n",
+    "structure that makes staying in a regime more likely than leaving it - a hidden Markov\n",
+    "model is the standard choice - and it would be fitted forward in time so that each\n",
+    "month's label used only the months before it. Chapter 9 introduces both."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f830dda9",
+   "metadata": {},
+   "source": [
+    "## Key takeaways\n",
+    "\n",
+    "- **The number of clusters is a decision, not an estimate.** BIC, AIC and the silhouette\n",
+    "  score reward different things, so they will disagree; pick the one whose objective\n",
+    "  matches what the labels are for, and say which you picked and why.\n",
+    "- **Cluster numbers carry no meaning until something outside the model names them.** Here\n",
+    "  the average equity return within each cluster does the naming, and a different seed can\n",
+    "  renumber the clusters without changing the partition.\n",
+    "- **Condition on the environment before trusting a factor's average.** A strategy's\n",
+    "  full-sample premium can be entirely earned in one environment, which is invisible in the\n",
+    "  pooled number and decisive for whether it diversifies anything.\n",
+    "- **State how a conditional statistic was built.** Restricting a return stream to the\n",
+    "  months in a regime and concatenating them produces a drawdown no investor experienced\n",
+    "  unless they held only during that regime; the same number is either informative or\n",
+    "  misleading depending on whether that construction is stated.\n",
+    "- **Fitting on the whole sample buys description, not prediction.** Every label here is\n",
+    "  informed by the months after it, so the labels cannot be used as features. Walk-forward\n",
+    "  fitting is what makes them usable, and Chapter 6 onward introduces it.\n",
+    "\n",
+    "**Known limitations.** The mixture has no notion of time: it can assign January 1932 and\n",
+    "January 2019 to the same cluster and has no mechanism preferring a month to keep the\n",
+    "previous month's label, which is why the episodes are short. The AQR series are monthly, so\n",
+    "nothing here resolves anything faster than a month. And the panel is a century long, over\n",
+    "which the composition of the asset classes and the microstructure of the markets changed\n",
+    "considerably; the model treats 1927 and 2024 as draws from the same set of distributions.\n",
+    "\n",
+    "**Next**: `macro_regimes` asks the same question of macroeconomic indicators rather than\n",
+    "factor returns, and checks the resulting clusters against realized equity volatility."
    ]
   }
  ],
@@ -2305,37 +1328,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 8.391714,
-   "end_time": "2026-07-11T19:31:21.500484+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "01_process_is_edge/factor_regimes.ipynb",
-   "output_path": "01_process_is_edge/factor_regimes.ipynb",
-   "parameters": {},
-   "start_time": "2026-07-11T19:31:13.108770+00:00",
-   "version": "2.7.0"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "ee3fe79aa4dc66f375c978d55c90ade2231023d5",
-   "executed_at": "2026-07-11T19:32:04.417579+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {}
   }
  },
  "nbformat": 4,

--- a/01_process_is_edge/factor_regimes.ipynb
+++ b/01_process_is_edge/factor_regimes.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "# Factor-based regime detection\n",
     "\n",
-    "**Chapter 1 · §1.4 Market Regimes: Change Is the Constant**\n",
+    "**Chapter 1 · §1.4 Keeping up with changing market regimes**\n",
     "\n",
     "**Docker image**: `ml4t`\n",
     "\n",
@@ -49,7 +49,7 @@
     "\n",
     "## Book reference\n",
     "\n",
-    "Chapter 1, Section 1.4, \"Market Regimes: Change Is the Constant\". `macro_regimes` is the\n",
+    "Chapter 1, Section 1.4, \"Keeping up with changing market regimes\". `macro_regimes` is the\n",
     "companion notebook and estimates regimes from macroeconomic indicators instead.\n",
     "\n",
     "## Prerequisites\n",
@@ -2600,7 +2600,8 @@
    "outputs_digest": "3dfcb307002f7d1b930ea9ad13d24a6eb6faa8d3c825e7856b0db1ffe9362ed8",
    "parameters": {},
    "production": true,
-   "source_py_blob": "31c4c45f24afe92089bfdfbb35ad299aa986468a"
+   "source_py_blob": "9ac295e42f617269561a199f1c86308c9ec610a3",
+   "notes": "prose synced from the .py at 2026-09-08T23:49:16.213393+00:00 without re-executing; every code cell is identical to blob 31c4c45f24af"
   },
   "papermill": {
    "default_parameters": {},

--- a/01_process_is_edge/factor_regimes.ipynb
+++ b/01_process_is_edge/factor_regimes.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0d594e87",
-   "metadata": {},
+   "id": "db620c71",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012001,
+     "end_time": "2026-09-08T23:43:31.984305+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:31.972304+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# Factor-based regime detection\n",
     "\n",
@@ -65,8 +73,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9397f172",
-   "metadata": {},
+   "id": "c86b0a64",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004157,
+     "end_time": "2026-09-08T23:43:31.992974+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:31.988817+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Setup\n",
     "\n",
@@ -78,9 +94,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "444f3f5b",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "60ea80a3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:32.001887Z",
+     "iopub.status.busy": "2026-09-08T23:43:32.001750Z",
+     "iopub.status.idle": "2026-09-08T23:43:44.823896Z",
+     "shell.execute_reply": "2026-09-08T23:43:44.823426Z"
+    },
+    "papermill": {
+     "duration": 12.832898,
+     "end_time": "2026-09-08T23:43:44.829833+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:31.996935+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Factor-based regime detection - Gaussian mixture regimes over AQR factor returns.\"\"\"\n",
@@ -118,9 +148,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "01f13bd4",
+   "execution_count": 2,
+   "id": "3718e1cb",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:44.849990Z",
+     "iopub.status.busy": "2026-09-08T23:43:44.849672Z",
+     "iopub.status.idle": "2026-09-08T23:43:44.855265Z",
+     "shell.execute_reply": "2026-09-08T23:43:44.854485Z"
+    },
+    "papermill": {
+     "duration": 0.017832,
+     "end_time": "2026-09-08T23:43:44.857536+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:44.839704+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -133,8 +176,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45ed9112",
-   "metadata": {},
+   "id": "9c109fc9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002431,
+     "end_time": "2026-09-08T23:43:44.866060+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:44.863629+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Settings, and what each one decides\n",
     "\n",
@@ -158,9 +209,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e7164a2b",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "b7bd8687",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:44.880970Z",
+     "iopub.status.busy": "2026-09-08T23:43:44.880650Z",
+     "iopub.status.idle": "2026-09-08T23:43:44.906585Z",
+     "shell.execute_reply": "2026-09-08T23:43:44.904886Z"
+    },
+    "papermill": {
+     "duration": 0.031674,
+     "end_time": "2026-09-08T23:43:44.907010+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:44.875336+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "N_REGIMES_GRID = [2, 3, 4, 5, 6]\n",
@@ -175,8 +240,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "408b798c",
-   "metadata": {},
+   "id": "0a36ecf1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002497,
+     "end_time": "2026-09-08T23:43:44.912344+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:44.909847+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Load the factor panel\n",
     "\n",
@@ -187,10 +260,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "839b5910",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "55cb0fa4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:44.919915Z",
+     "iopub.status.busy": "2026-09-08T23:43:44.919798Z",
+     "iopub.status.idle": "2026-09-08T23:43:45.030309Z",
+     "shell.execute_reply": "2026-09-08T23:43:45.029464Z"
+    },
+    "papermill": {
+     "duration": 0.115222,
+     "end_time": "2026-09-08T23:43:45.030749+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:44.915527+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AQR Century of Factor Premia: 1182 months, 44 series\n",
+      "Covering 1926-07 to 2024-12\n"
+     ]
+    }
+   ],
    "source": [
     "aqr_raw = AQRFactorProvider().fetch(\"century_premia\")\n",
     "\n",
@@ -203,8 +299,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90f96dd6",
-   "metadata": {},
+   "id": "f93d179e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00484,
+     "end_time": "2026-09-08T23:43:45.042707+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.037867+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### The nine series used here\n",
     "\n",
@@ -225,9 +329,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2d9496a6",
-   "metadata": {},
+   "execution_count": 5,
+   "id": "2957af9d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:45.067223Z",
+     "iopub.status.busy": "2026-09-08T23:43:45.067072Z",
+     "iopub.status.idle": "2026-09-08T23:43:45.075675Z",
+     "shell.execute_reply": "2026-09-08T23:43:45.074994Z"
+    },
+    "papermill": {
+     "duration": 0.02487,
+     "end_time": "2026-09-08T23:43:45.076090+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.051220+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "FACTOR_COLUMNS = [\n",
@@ -260,8 +378,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9af3887f",
-   "metadata": {},
+   "id": "08d93b4c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002743,
+     "end_time": "2026-09-08T23:43:45.087495+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.084752+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### What is actually in the panel\n",
     "\n",
@@ -275,10 +401,122 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4bf8ff2b",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "aad7d75f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:45.106740Z",
+     "iopub.status.busy": "2026-09-08T23:43:45.106249Z",
+     "iopub.status.idle": "2026-09-08T23:43:45.228251Z",
+     "shell.execute_reply": "2026-09-08T23:43:45.227860Z"
+    },
+    "papermill": {
+     "duration": 0.1344,
+     "end_time": "2026-09-08T23:43:45.231764+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.097364+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_9bb58\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_9bb58_level0_col0\" class=\"col_heading level0 col0\" >First month</th>\n",
+       "      <th id=\"T_9bb58_level0_col1\" class=\"col_heading level0 col1\" >Months quoted</th>\n",
+       "      <th id=\"T_9bb58_level0_col2\" class=\"col_heading level0 col2\" >Mean (% / month)</th>\n",
+       "      <th id=\"T_9bb58_level0_col3\" class=\"col_heading level0 col3\" >Std (% / month)</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Series</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "      <th class=\"blank col2\" >&nbsp;</th>\n",
+       "      <th class=\"blank col3\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bb58_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
+       "      <td id=\"T_9bb58_row0_col0\" class=\"data row0 col0\" >1926-07</td>\n",
+       "      <td id=\"T_9bb58_row0_col1\" class=\"data row0 col1\" >1182</td>\n",
+       "      <td id=\"T_9bb58_row0_col2\" class=\"data row0 col2\" >0.21</td>\n",
+       "      <td id=\"T_9bb58_row0_col3\" class=\"data row0 col3\" >1.40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bb58_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
+       "      <td id=\"T_9bb58_row1_col0\" class=\"data row1 col0\" >1926-07</td>\n",
+       "      <td id=\"T_9bb58_row1_col1\" class=\"data row1 col1\" >1182</td>\n",
+       "      <td id=\"T_9bb58_row1_col2\" class=\"data row1 col2\" >0.30</td>\n",
+       "      <td id=\"T_9bb58_row1_col3\" class=\"data row1 col3\" >1.64</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bb58_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
+       "      <td id=\"T_9bb58_row2_col0\" class=\"data row2 col0\" >1926-07</td>\n",
+       "      <td id=\"T_9bb58_row2_col1\" class=\"data row2 col1\" >1182</td>\n",
+       "      <td id=\"T_9bb58_row2_col2\" class=\"data row2 col2\" >0.21</td>\n",
+       "      <td id=\"T_9bb58_row2_col3\" class=\"data row2 col3\" >1.29</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bb58_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
+       "      <td id=\"T_9bb58_row3_col0\" class=\"data row3 col0\" >1926-07</td>\n",
+       "      <td id=\"T_9bb58_row3_col1\" class=\"data row3 col1\" >1182</td>\n",
+       "      <td id=\"T_9bb58_row3_col2\" class=\"data row3 col2\" >0.25</td>\n",
+       "      <td id=\"T_9bb58_row3_col3\" class=\"data row3 col3\" >1.29</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bb58_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
+       "      <td id=\"T_9bb58_row4_col0\" class=\"data row4 col0\" >1926-07</td>\n",
+       "      <td id=\"T_9bb58_row4_col1\" class=\"data row4 col1\" >1182</td>\n",
+       "      <td id=\"T_9bb58_row4_col2\" class=\"data row4 col2\" >0.34</td>\n",
+       "      <td id=\"T_9bb58_row4_col3\" class=\"data row4 col3\" >4.28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bb58_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
+       "      <td id=\"T_9bb58_row5_col0\" class=\"data row5 col0\" >1927-01</td>\n",
+       "      <td id=\"T_9bb58_row5_col1\" class=\"data row5 col1\" >1176</td>\n",
+       "      <td id=\"T_9bb58_row5_col2\" class=\"data row5 col2\" >0.67</td>\n",
+       "      <td id=\"T_9bb58_row5_col3\" class=\"data row5 col3\" >4.52</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bb58_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
+       "      <td id=\"T_9bb58_row6_col0\" class=\"data row6 col0\" >1926-07</td>\n",
+       "      <td id=\"T_9bb58_row6_col1\" class=\"data row6 col1\" >1182</td>\n",
+       "      <td id=\"T_9bb58_row6_col2\" class=\"data row6 col2\" >0.65</td>\n",
+       "      <td id=\"T_9bb58_row6_col3\" class=\"data row6 col3\" >3.44</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bb58_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
+       "      <td id=\"T_9bb58_row7_col0\" class=\"data row7 col0\" >1926-07</td>\n",
+       "      <td id=\"T_9bb58_row7_col1\" class=\"data row7 col1\" >1182</td>\n",
+       "      <td id=\"T_9bb58_row7_col2\" class=\"data row7 col2\" >0.14</td>\n",
+       "      <td id=\"T_9bb58_row7_col3\" class=\"data row7 col3\" >1.04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bb58_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
+       "      <td id=\"T_9bb58_row8_col0\" class=\"data row8 col0\" >1926-07</td>\n",
+       "      <td id=\"T_9bb58_row8_col1\" class=\"data row8 col1\" >1182</td>\n",
+       "      <td id=\"T_9bb58_row8_col2\" class=\"data row8 col2\" >0.41</td>\n",
+       "      <td id=\"T_9bb58_row8_col3\" class=\"data row8 col3\" >4.59</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7d287172da90>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "coverage = pd.DataFrame(\n",
     "    [\n",
@@ -298,8 +536,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d683b0d",
-   "metadata": {},
+   "id": "39a4ad5c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006438,
+     "end_time": "2026-09-08T23:43:45.244893+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.238455+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Prepare the panel for clustering\n",
     "\n",
@@ -318,10 +564,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d44a9055",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "135d87ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:45.258346Z",
+     "iopub.status.busy": "2026-09-08T23:43:45.258213Z",
+     "iopub.status.idle": "2026-09-08T23:43:45.291083Z",
+     "shell.execute_reply": "2026-09-08T23:43:45.289222Z"
+    },
+    "papermill": {
+     "duration": 0.040919,
+     "end_time": "2026-09-08T23:43:45.291869+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.250950+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Complete months: 1176 (1927 to 2024)\n"
+     ]
+    }
+   ],
    "source": [
     "factors_pl = aqr_raw.select([\"timestamp\", *FACTOR_COLUMNS]).sort(\"timestamp\").drop_nulls()\n",
     "\n",
@@ -337,9 +605,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20df3f57",
+   "id": "dc0eacb2",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006164,
+     "end_time": "2026-09-08T23:43:45.304538+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.298374+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## Fit a grid of mixture models\n",
@@ -376,9 +651,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3e78bd47",
-   "metadata": {},
+   "execution_count": 8,
+   "id": "aef3b604",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:45.320092Z",
+     "iopub.status.busy": "2026-09-08T23:43:45.319964Z",
+     "iopub.status.idle": "2026-09-08T23:43:45.324986Z",
+     "shell.execute_reply": "2026-09-08T23:43:45.324543Z"
+    },
+    "papermill": {
+     "duration": 0.014495,
+     "end_time": "2026-09-08T23:43:45.327851+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.313356+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "@dataclass(frozen=True)\n",
@@ -395,9 +684,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "35ef3ead",
-   "metadata": {},
+   "execution_count": 9,
+   "id": "7bedcd52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:45.356404Z",
+     "iopub.status.busy": "2026-09-08T23:43:45.356208Z",
+     "iopub.status.idle": "2026-09-08T23:43:45.364436Z",
+     "shell.execute_reply": "2026-09-08T23:43:45.363938Z"
+    },
+    "papermill": {
+     "duration": 0.027312,
+     "end_time": "2026-09-08T23:43:45.364965+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.337653+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def fit_gmm_grid(\n",
@@ -430,10 +733,108 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fd8e66f5",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "id": "0cded4ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:45.394676Z",
+     "iopub.status.busy": "2026-09-08T23:43:45.394520Z",
+     "iopub.status.idle": "2026-09-08T23:45:11.883223Z",
+     "shell.execute_reply": "2026-09-08T23:45:11.882079Z"
+    },
+    "papermill": {
+     "duration": 86.499425,
+     "end_time": "2026-09-08T23:45:11.883730+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:45.384305+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_a9750\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_a9750_level0_col0\" class=\"col_heading level0 col0\" >BIC</th>\n",
+       "      <th id=\"T_a9750_level0_col1\" class=\"col_heading level0 col1\" >AIC</th>\n",
+       "      <th id=\"T_a9750_level0_col2\" class=\"col_heading level0 col2\" >Silhouette (mixture)</th>\n",
+       "      <th id=\"T_a9750_level0_col3\" class=\"col_heading level0 col3\" >Silhouette (k-means)</th>\n",
+       "      <th id=\"T_a9750_level0_col4\" class=\"col_heading level0 col4\" >Switches</th>\n",
+       "      <th id=\"T_a9750_level0_col5\" class=\"col_heading level0 col5\" >Smallest cluster (months)</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Clusters</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "      <th class=\"blank col2\" >&nbsp;</th>\n",
+       "      <th class=\"blank col3\" >&nbsp;</th>\n",
+       "      <th class=\"blank col4\" >&nbsp;</th>\n",
+       "      <th class=\"blank col5\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a9750_level0_row0\" class=\"row_heading level0 row0\" >2</th>\n",
+       "      <td id=\"T_a9750_row0_col0\" class=\"data row0 col0\" >26,170</td>\n",
+       "      <td id=\"T_a9750_row0_col1\" class=\"data row0 col1\" >25,617</td>\n",
+       "      <td id=\"T_a9750_row0_col2\" class=\"data row0 col2\" >0.270</td>\n",
+       "      <td id=\"T_a9750_row0_col3\" class=\"data row0 col3\" >0.234</td>\n",
+       "      <td id=\"T_a9750_row0_col4\" class=\"data row0 col4\" >267</td>\n",
+       "      <td id=\"T_a9750_row0_col5\" class=\"data row0 col5\" >276</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a9750_level0_row1\" class=\"row_heading level0 row1\" >3</th>\n",
+       "      <td id=\"T_a9750_row1_col0\" class=\"data row1 col0\" >26,173</td>\n",
+       "      <td id=\"T_a9750_row1_col1\" class=\"data row1 col1\" >25,342</td>\n",
+       "      <td id=\"T_a9750_row1_col2\" class=\"data row1 col2\" >0.115</td>\n",
+       "      <td id=\"T_a9750_row1_col3\" class=\"data row1 col3\" >0.113</td>\n",
+       "      <td id=\"T_a9750_row1_col4\" class=\"data row1 col4\" >448</td>\n",
+       "      <td id=\"T_a9750_row1_col5\" class=\"data row1 col5\" >56</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a9750_level0_row2\" class=\"row_heading level0 row2\" >4</th>\n",
+       "      <td id=\"T_a9750_row2_col0\" class=\"data row2 col0\" >26,259</td>\n",
+       "      <td id=\"T_a9750_row2_col1\" class=\"data row2 col1\" >25,149</td>\n",
+       "      <td id=\"T_a9750_row2_col2\" class=\"data row2 col2\" >-0.024</td>\n",
+       "      <td id=\"T_a9750_row2_col3\" class=\"data row2 col3\" >0.096</td>\n",
+       "      <td id=\"T_a9750_row2_col4\" class=\"data row2 col4\" >577</td>\n",
+       "      <td id=\"T_a9750_row2_col5\" class=\"data row2 col5\" >3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a9750_level0_row3\" class=\"row_heading level0 row3\" >5</th>\n",
+       "      <td id=\"T_a9750_row3_col0\" class=\"data row3 col0\" >26,388</td>\n",
+       "      <td id=\"T_a9750_row3_col1\" class=\"data row3 col1\" >24,998</td>\n",
+       "      <td id=\"T_a9750_row3_col2\" class=\"data row3 col2\" >0.006</td>\n",
+       "      <td id=\"T_a9750_row3_col3\" class=\"data row3 col3\" >0.087</td>\n",
+       "      <td id=\"T_a9750_row3_col4\" class=\"data row3 col4\" >600</td>\n",
+       "      <td id=\"T_a9750_row3_col5\" class=\"data row3 col5\" >8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a9750_level0_row4\" class=\"row_heading level0 row4\" >6</th>\n",
+       "      <td id=\"T_a9750_row4_col0\" class=\"data row4 col0\" >26,598</td>\n",
+       "      <td id=\"T_a9750_row4_col1\" class=\"data row4 col1\" >24,930</td>\n",
+       "      <td id=\"T_a9750_row4_col2\" class=\"data row4 col2\" >0.003</td>\n",
+       "      <td id=\"T_a9750_row4_col3\" class=\"data row4 col3\" >0.077</td>\n",
+       "      <td id=\"T_a9750_row4_col4\" class=\"data row4 col4\" >654</td>\n",
+       "      <td id=\"T_a9750_row4_col5\" class=\"data row4 col5\" >3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7d28700fd450>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "gmm_grid = fit_gmm_grid(factors_scaled, N_REGIMES_GRID)\n",
     "\n",
@@ -475,9 +876,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60d28595",
+   "id": "5da82fef",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.007651,
+     "end_time": "2026-09-08T23:45:11.900893+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:11.893242+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### Reading the three criteria against each other\n",
@@ -490,9 +898,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "cd992f1f",
-   "metadata": {},
+   "execution_count": 11,
+   "id": "0bd9804a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:11.913027Z",
+     "iopub.status.busy": "2026-09-08T23:45:11.912843Z",
+     "iopub.status.idle": "2026-09-08T23:45:11.916240Z",
+     "shell.execute_reply": "2026-09-08T23:45:11.915644Z"
+    },
+    "papermill": {
+     "duration": 0.01144,
+     "end_time": "2026-09-08T23:45:11.917516+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:11.906076+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def plot_selection_criterion(ax: Axes, values: list[float], label: str, best: str) -> None:\n",
@@ -507,10 +929,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c36f8c20",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 12,
+   "id": "55a84e1c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:11.928560Z",
+     "iopub.status.busy": "2026-09-08T23:45:11.928033Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.236912Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.235970Z"
+    },
+    "papermill": {
+     "duration": 0.3151,
+     "end_time": "2026-09-08T23:45:12.237444+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:11.922344+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAEtCAYAAADzz5/bAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAd+5JREFUeJzt3XVYFekXwPHvpaVbVEQMEFEEsbtr7bW7E3PX7s611u5VZG1d11hr7e5uXRUFFGnpuL8/0PuTFBUE5Xyex+fhzp1558xlRs595533KKKiIpUIIYQQQggVtcwOQAghhBAiq5EESQghhBAiEUmQhBBCCCESkQRJCCGEECIRSZCyoZiYGIytnek7ZFyatxk9aQ6OpWoTEREJgLG1M70GjALg1NlLGFs7s2XH3gyJN7N8yeeUFST+XaVkxtxlGFs78/S/F5+9jw/bvvJ6/aVhZmsfXz/f2tad+yhWpi75ilbiyLEzGbafjj1/odpPbTOsfSEyWrZJkJzK1cfY2hlja2fy2JejZsP2Cf5z6DtkHMbWzsTExKiW3bxznxYd+pG/WBWcytXn19HTCAoOSdP+mrbtjbG1M7PmL0+wPL33863079UJ91Xz0NHRzuxQEpg4fQFO5ep/ctn3plajDl+cmKX37yo8PAJja2c8tu5Ol/ZE5omMjGLQ8Mloa2sxfcIwSjg7Zti+Jo0ezJK5kzOsfSEyWrZJkADsC+XHfdU8Rv7Sl7f+AbTrPojAwOBk1z1/6Ro1GrTHy/s1Y4f3x61nBy5cvsGLl16f3I+ffwCnzl6iYrlS7N53JNV1v2Y/31LuXDkpWcIps8NI4rWvX5qWfW++5hjS+3f15u33/3mKeK993xIeEUHDejVo36oJZqYmGbavAvltKFrELsPaFyKjZasEydTEiEb1azKgT2e6dWhJVFQ0nl7eya77y6hpmJuZcHD3Brp3akWf7u05dXALTo6FP7mffQeOYWigz5hhbty9/4jHT5+luG5a9+MfEMiEafMpW70Zue3KUrdpZx49iW/3uecrjK2dWbdxG+27D8bGsRK1GnXgpZePavsTpy9QvubP2BatzIjxs1KM5+ad+9Rq1IFchcpSoWZztu7cByTf85XYw8f/8XP7PuR1qECzdr0JDPp/8rlrz0HK1/wZ68LladSqBzfv3Fe916BFdxxL1Va9TryvV16v6dBjCDZFKlK2ejMOHDmh2m7Ttr/xfOmluhWW3LLU2kjsU5/TiTMXqNGgHXnsy1GjQTtOnrmYbDtO5eozbOwMRk2cQ2HXmjiVq8+J0xdU7/u+9aPXwNGqXsOZ85YTHR0NxN9+8XzpxaZtfyfbczNj7jLyOlRgrftWXCs1ws6lOtPmLCEuLi7Zzy8gIIhBwyfjULIWBYtXY/i4mSiVCac/i4uLo1Wn/hRyrpYgOT919hLO5X8CwO2X8RhbO/Pc85Xq/YP/nqBy3VbYFKnIyAmzVcvDwyMYO2UuhV1rUrR0HX77fZUqvo8tX+NB0dJ1sClSkdad+/Pk6XNiYmJYvX4LNRq0w7pweVwrNeKfw8cTfLYjxs9i+LiZFCxejcp1W3Hn3iNmzF2GQ8lalK7ahBu376nWv//wCU3a9MK6cHmq1m/DpSs3k8ThsXU3xtbO/Hv8DLUbdySvQwW6u41Q/U4S3478sP7xU+eB+HOxU69fmTlvOUVK1qJs9WacPHOR1eu3ULx8fYqVqcuxk+cS7NP7ta/qnKzVqAN37z/6ZMwfrvWdfx9Q9TpHRkYlaPfZ85e06ToQmyIVca3UiNXrt6BUKnnu+Yri73tWFy77I0kv64db5cdOnqNOk06Urd4MSP3aOXP+ClXqtcYsn6uqh/7Dtfzxdf0h7j82bqd1lwHkK1qJ1p3788rrNT37jyJf0Uo0bds7wRfWfw4fp0KtFvHnRpcB+Lz2BSAwKJgOPYaQ16ECxcvXZ8qsRURFRSf5nQrxtbJVghQTE0tgYDDnL11j21//YJ3biiL2BZOs99bPn7v3H9GqWQMM9PVUyxUKRZr2s3vfYWpVq0jZUs6Ymhin2Iv0OfuJjY3l8rXbdGnfguGDe3Przn2GjpmeYJ1RE+ZQvJgDndv+zOVrt1i0fD0Anq+8ad15AAqFGtMnDiM6OuUkZ9iYGfi89mXmpOFUqlCa8PCINB0zwOoNW6hZrSIN6tXg2Mnzqj/sR0+cpWvf4dgXKsCsKSPx8w+kSetevElDL0l0dDStOvfn2o07jBnmRvkyJejceyjePm8YO9wN+0L5MTczYePq+fTu1i7ZZam18bFPfU537z+iRYd+6OnpMmfaaHLkyEHzDn259+BxsrGv+mMzwSEhDOrXFX//AEZP+g2IT0Y69vyFQ/+eYswwN1o0qcfMecuYNX8FAOtXzAWgcoXSbFw9nyoVyyRpO+RdKBs3/8WQ/t2oULYkcxauZM8/R5OsFxcXR8dev7Blx166d2rFoL5dcLAvkOQcmzF3GUdPnmP9irnYWOdWLXd0KMTIX/oC0KtrWzauno+Fuanq/dV/bKFbx5YUtivA8jUeqsRk7JS5rFj7J53bNadPj/bMmLuMvQcSxvfk6XNGTpiNq0sxJo0ZjK5uDjQ0NVBXV+f4qfPUrlGZyWOHoFQq6T1oLO9Cw1Tbrlj7J+HhEQzo3Ynbdx9SvUFbHjx6Sr8eHXjy3wumz1kCxP8xbdq2N6/f+DJl3C/YWOemXfdBhIWHJ/s7GzR8Mq2bN6R8GVd27D7AgSMnk10vOX/vP8KtO/cZ2Lcrr7x8aNGxH3/vP0K/Hh0IDnnH6ElzEqx//tI17AvlZ8KoQTx6+ozubiOIi4tLU8yDhk/GOo8VyxZMQVtbS7U8LDycZu36cPvuQ6aO/5UqFUszdMx03DftwsLclAUz478wNGlQm4Wzkr+F27nPMCpXKM3sqSNTvXbehYbRvvtglEolMycNJ59NHhwd7Ph9zsQUP6ORE2ZTpqQzP9WpzsF/T1GqSmPy2eShyU+1OX7qPO6bdwFw8coN2nUbjHVuK6ZPHIanpxeDR04BYNHy9ew/dJyRv/alXcsmhIaFo6mpkebfkxBpla3OqsvXbmFbrLLq9bpls9HQSPoRPH8R/w05T+6cn72PgIAgTpy5yO9zJhAdHUPNqhXYve8wvw7o8VX7sTA3Y9/2NXh5v+bG7Xvktc7NpSs3EvQE9O7WlhFD+qi+gT968h8AO/76h4jISBb/NhFXl2I0/qkWGzbtTHY/Bvp6oFDg7FSEzu2bf9axjx8xkO6dWuHz2pfN2/fw6HH8/les24SGhgaL507CQF8PCzNTWnXuz9Zd++jfq1OqbZ69cJU79x7y++wJNG5Qi4iISP7c9jeHj52mU9ufMTUxIjwikob1aqi2SbzsxOkLqbbxwac+p3UbtxMdHcO8GWOxK2iLq3NRytX4mXUbtzN7ysgksZd0KaYag3Hk2GlOn7sMwM3b9zl/6TpD3LrRo3NrVYwr121izDA3GtStBoB1nlwJjiuxRb9NomgRO2pVq8jufYfZf+gYTRrUSrDOzTsPOH3uMqN+7cuwQb2SbWffoWPMWbiSmZOGU7FcyQTvmZmaUK60CwDOTkWSxLNu+RwK2xXAQF+fS1dv8ujxMwoXKsAfHjto9XMD+vXsAMCe/f+y98BRGv/0//i0dbTR1NRAT0+Xxj/VomuHlqr3Nq6eT3DIO67dvEMxR3v2/PMvDx89xdWlmOqzXfTbRAA279iDf0AQ65bNRqFQsGn73zx4f+79vf8IPq99WTpvMq4uxShZwokqdVtz6cpNqlYqm+SzmD9zHLVrVKJ4MQcOHT2l6qVNC0sLMzauno9CoeDYyXMcOnqKLX8sIkcOHY6dPMeR42eJi4tDTS3+e2m9WlUZP3IgALfu3OcPjx08f/GKU+cupRizbT5rAMqVLsH8meOSJLqHj57hv+eezJ85lk5tf6ZD66bsO3iM5Wv/pFO7n6letTwAdgVtqVG1QrLH0bJpfcaNGACkfu0UL+pAYFAwv00bTYum9Ql5F8qCpeuoVb1iip9R725t+XVAD976+bNp29/Uq12FscP74+cfwIZNO3nw6CkAq9dvQTeHDovnTkJLS5OwsHBGjJ9FVFQ0Bvp6KBQK8uTKScOuNZL9P1yI9JCtzizHwoWYNWUk/v6BnD5/ma59h/P0mWeS5CXv+2/QiXsY0mLfoWPExMTQb8g4+n00yPa/Z57kt837xfsJDnlHn8FjOXD4BIUK5CMsPIKw8AhiY2NV62hqagKgoaGBibEhkZHx3c4fbpkUyG/zyf0sXziVWfOWU6dpJ0qVKM608b9SwrnoJ7cD0Hz/H5W5Wfy4hsj33d7PX7ykUAEbVS/Zh4Ghz5+//GSbz96vM3D4JAYOn6Ra/tYvIE0xfU4bn/qcnr94hW4OHQoVyAdAYbsC6ObQ4fmL5I/j42+15qYmqtsAz96v7+xURPV+CeeiXL1xB/+AQIwMDdJ0XB/+NuayssTIyAB//8Ak6zx77gmAU1GHFNuZOH0hAL5v/dO0348l/Z1H8crLh9jYWDZt+5tN2/5Wrauvr5tgW+vcVuzevIpJMxZStHRdOrdvzrgRA9DTzcHU2YtZumojRkYGqnEywSHv/r/fjz5bM1NTgoPfqZIFUxMT/nsWfyvsw5eQn9v3TbDvlI71Q7vm7/eZ+PZVajTU1VUxmL3/PD60Z2pqQmxsbIIE6ePkprBdfE+2f0BgqjF/SJCcnYok29P84Vx0LhZ/bqmpqeHi5MjZC1fSfBwftoXUr52CBfKho63Nnn/+pWgROw4fO02eXJaptv3h/yhzs/heyA/nz4ffcVRU1PvjeEVoWDj2JRIm5P4Bgbj16oi6hjpDx0xn4oyFjBven+ZNvu+HMkTWlK0SJENDfSpXKA1A4wa12LJjL+cvXkuynoW5KQVsbdi2az/DBvdCTzf+P/bo6GjVBZ6S3XsP4+pclFmT43sUIiIjady6J3/vP8Kgfl2/eD9LVrpz9PhZLp/YTYH8NvQdMi7BH5/UWFqYA3Dj9j2qViybZPzJx8zNTJkzbTQjfulDmy4D6djrV25fOJCm/aQkn401R46dIeRdKAb6ely7cTd++fv/7LW0NPAPCCImJgYNDQ1CPvpDmM8mDwAjf+mboHejgG18EqOmpk5kZMLH2RMv+1QbH3zqc8pnk0fVq2BfKD8PHj0lLDyCfDbWn/V52L5f//rNuzRtWAeAazfuYGigj6mJsWqsTuLjSonPa1+CgkJUfzw/9uF22e27D/ipTrVkt69aqQwuTo78vvwPWjb7CYdEt50//EFPazx5cluhpqZG/dpV6dO9vWq5malxknUrlHXl4F/rOXHmAs3b98PI0IDKFUozd9FqVi2aQYum9flz29+4/TI+TftOLF/e+N/9/JljKVTAVrXc0aHQZ7WjpRV/Pb5560eB/DYJztH08PBxfM9JAVubVGP++DZjcj6ci9dv3cXVpRhxcXFcv3X3s8/R/7eX8rVjoK9Hp3Y/s3LdJnbvO4yhgT5/LJ+TUlOft9+8ublz7yEbV89HXV1dtdzczAQNDQ0G9O5Mz85tGDP5N7q7jcTVuViSL6BCfK1slSD5BwSx98BR3r7159ip8wSHvKNS+VJJ1lMoFPw2bRTNO/SjbtMudOvYgpiYWFav38KvA3rwc+O6/NS8G/lt87Ly9/+PAwoMDOb46fP8OqAnpUsWVy13KlqY3fsOJ0mQPrWf1s0bqtYND48gIjKSQ0dPERoWzt5//k3zcTeqX5OZ85YxddZiXnV8zZ4Utg0MCqZNlwHUrlGZXFaWvAsNRV09+WFquXJacP/R0zSNI+rVpQ0Hj5zE7Zfx1K1VhSUr3TE2MqRl0/jBv3YF83Ps5Hl+HR3/WR4+dlq1bYWyJXEsXIg/PLajpqbAwtyUh4+fMXXcLwDY5svD2QtXWLp6I6VLFKd0yeJJln2qjbR+Tl3at+APj+38OnoabVs2xmPLbjQ1NejaocUnP4OPORUtTNlSLvzhsQPrPLl45eXD1Rt3GDqwJwqFAnV1dWzy5ubkmYts3bmPUiWcku3VmjZnCQ3r12Tj5r9QKBR0aNM0yTrOTkVwdS7K/MVr0dDQwNzUhLsPHjNj4jDVOjMmDsc6jxWbt+/hl1HT2Ld9TYLeiQ9/JDdt24OpiTG1qldK9fh0dLTp1LYZHlt3k9c6N8Uc7blx8y6D3LolWG//oeMsX+NB88b1CAoOISYmBnV1NdW4t3MXrxIaGsbv78fSfYlG9Wsydc5iFq/YQJf2LdDU1CAgMFj1RSmt7AraAjB19mIqlivFynWbvjimD06fu8zilRuIjYnFY+tuGtWvicn7B0lSivlTCVKt6hWwzWfNvPe/7yvXbuP71p9xwwd8UYypXTth4eGs2bCVti0bk9vKMn7sn7kpSqUyzeM1U9KtUyu2/fUP8xav4edGdXnz1o98efOgrq5OrwGjMDU1wcWpCF4+b1AoFKil8P+UEF8jW51VDx//R4ceQxg+fia37z5g7PD+DOjTOdl1a1StwIFdf2BibMikmb+zaMUGKpUvxU91q6NUwrvQULbu3JfgSa1/jpwgOjomyaDayhVKc/XGnWQf3U9tPx/r26M9ZUo6M23OEq5cv60au5IWRYvYsWzBVN689WPCtPk4Fi5EYbsCSdYzNNCnacM6bN25j19HTUM3Rw5WL5qZbJsd2/7Mo8fP0tR1X7NaRdYuncWDR08ZPnYGJsZG7N6ykpyW8T02A/p0poRzUXbvO0x0TDRTxv4/cdHS0mSr+xLKlnJh2WoPps1Zwtu3/gQHx3+D/7V/D5ydijBt9mLW/7kj2WWfaiOtn1PRInZsd19KcMg7ho6eRmhYGNvdl1Kk8Of1Rqirq7Nx9TxqVavI1NmL2bZrP8MH92b44N6qdWZPGYmOtjbDxs1I8Uk5C3NTxk2ZyytvH9YsmZng1sjH+/pz7ULq16nKouXrmTF3KVqamgmeRtTU0EBPV5dJY4Zw9sKVJE/N5cubh5G/9OXRk2eMnjiHx0+ff/IYZ0wcTt/uHdj7z7+MHD+L+4+eEhAYlGCdUiWcsMppwdQ5i5m3eA2tmzekf+9O1KxWgVY/N2DLjr24b97FwBSu0bQwMTHi7y2ryGeTh9kLVrBw6Tre+vl/9lNP9WtXpWnDOty4dY9zF6+mS09J25aN+OfQCeYuWs1PdaqzcPb4r45ZT1eXXR7LKepQiDGTfuPkmYvMnjKSjm2bfVGMqV07ujlyULFcSf7ac4i5i1bTe9AYqtRtTY/+Scfjfa5ypUvw59oFBAQGMWriHLbs2EtwSPxt1HatmnDl2i1+GTWVew8es+i3iapeNyHSkyIqKjLl+y0iRbfuPqBO4068uHf6k7fdhEhPM+YuY9b85Vw9tSdN48qEyAhHjp2hbbeB3Dp/AKucFoSGhdGj/yjOnLvMi3sZN0O3EN9KtrrFll4eP31G++6DGflLH0mOhBDZ0stX3kRHxzD9t6WUL+vKk/+ec+LUeRrWr5nZoQmRLiRB+gLGRobMnjKSerWqZnYoQgiRKdq0aMStuw/Yve8wW3buxTq3FW69OvFL/+6ZHZoQ6UJusQkhhBBCJJKtBmkLIYQQQqSFJEhCCCGEEIlIgiSEEEIIkYgkSEIIIYQQiUiCJIQQQgiRiCRIQgghhBCJSIIkhBBCCJGIJEhCCCGEEIlIgiSEEEIIkYgkSEIIIYQQiUiCJIQQQgiRiCRIQgghhBCJZJsEqVmnwTx88lz1OuRdKOXrdlC9njR7GU+eeabaxmr3Hcxf5p7se/2GTeXE2csAHDx6Bo9t+1Jty9vHl9o/90o13s+V+Jg+SC3uL3H5+h1+X/lnmtb19vGl37CpqtdXb9ylU9/R6RaLEEIIkRE0MjuArGLC8L7p1lbdGhXTra2sqJRLUUq5FM3sMIQQQogMIwnSe536jmZwnw64Ojty5MR5VvyxjdCwcAICgymYPy8jB3UHwNcvgHHTF3P7/mMK5MvDrAlD0NBI+DFu3nmAR0+fM25ob16/8WPKbyt45fMGn9dvsTQ3pV7NijT9qQZxyjj++HM3J89dJiAohGljBmBfyJaOfUbx1i+ATn1H06heNVo2qcPegyfw2L6P2Ng4SrsW49d+nVBTU+PqzXssWOaOQk1BgXzWKR7fi5feDB0/l5der7HOnZNxQ3thZGjAuUs32LD5b0LDwkGhYOLwvhSwtebqjbts230YE2ND7j96ytLfxqGjrQXAibOX2bLrAEvnjOXZi1dMmr2c0LBwjI0MmDTSjVw5zQHwefOWASNn4B8QRKe+o+nWvhmGBnpERcfw+woPLly9BUqYPekX8uSyJDQ0jLlLN3D3wVMUCnDr3pZK5Upk0G9cCCGESFm2ucUGMG76Ijr1HU2nvqPp8+uUZNeJiY1l2txVTBzRj72bFlOhjDPtmv9EsSKFgPhbRr+6dWbTylk8fPKCKzfupbrPdZv+Il/eXOxcP58po/uTN48Vfbu1BiAyIgrHwgVY8/tkqlUsxeadB9BQV2felGGYm5mwYdl0Wjapw407Dzlw9AzrFk9l06rZvHsXxslzVwgOCWXs1EX86taZ9Uum0app3RTjiIiIZMLwPmxaNQsdbS02bNkDQG4rC2ZOGMKGZdOpUbkMazbuVG1z6twVypcuztpFU1TJUWI79/5LsSKF2Lr2NyaNdCOnhanqPStLc0YP6YGDfX42LJtOtUqlAfAPCKRuzYq4L5uOjXUu/v7nGACLVm3CydGOTatmsXTOWOYu+YPY2LhUP18hhBAiI2SrHqQpowdgXzAfED9ep07z3knWUVdTw9zMGP+AQCKjoggNDUehUKjeL17UHmMjAwDsC9rw1j8g1X1aWZjz5Jkn0dExBAQGw/+bIkcOHcqUdAKgWBE7du45kmwbp89d5fkLL3oNnghARGR8YnX73iPyWlvhXKwwANa5c6YYh30hWwz09QCoXN6Vv/Ydfb+NFReu3OT85Zvce/iUqOho1Tb58uamcvmSqR5fzSplmblwDWs27uLnhjVRU/t0zm1laU7hQrYAFC1SkGfPXwFw8twVbt19xK69/wIQF6ckMCgYM1PjT7YphBBCpKdslSClhUKh4KfalVnlvpNla7dS2rUYtauXT3ZdDXUNUKbeXu3q5fl7xHG6D5yAibEhQ926JN+WhjrKFBpToqRWtXIM6p1wAPbJs1dQV//8TkB1dXV0dLQBmPLbcrS1tGhcvxqVypZg8epNH6336badixXmjyVTOfjvGTq7jWHiiH64Fi+S5lg01DX+f9RKmDSyH4UK2HzO4QghhBDpLlvdYkurvQdPMG/KUP5cNYshfTuioa7+yW0UKFDGJU1wDvx7hiY/Vcd9+XR+nzkSW5vcn2zLxMSI0NAwIiKjAKhYtgT7D5/mxUtvALxfvyU2No4ihQvw8PFznr2I74G5dfdRim36vH5LTEwMUVHR/LX/KBXKuABw6vxVWjSujWPhgtx79N8nY0vs5p2HKFDQqF41XIoV5uqNuwnet8ppzhtf/zTdKqtYrgRrNu4iOjoGpVKJl8+bz45HCCGESA/Sg5SM4kXt6TpgPMaGBujp6lAwf156dW6R6jYVyrjw5479qnE2/2/LjuET5nPo2Fk0NTSwzp2TxvWqkTePVYpt6WhrUbdGRdr2GEbzRrXp0KohA3q2ZcSk+Wioa2BkqM+EEX2xMDNh+MCuDJ84HwN9PcqULIZuDp3k29TRZvDo2bx560/50sVp1qAGAN3b/8zY6YuwNDejXKnin/lJwaOnz5m/zJ2w8HAszEyT9HLltrKkoG1eWncfSrf2zbCyNEuxrUG927NgmTvte49ER0ebsq5OuPVo89kxCSGEEF9LERUV+YmbRNnLK+83jJ66kLW/T0FdXY2AwGA69h3FmF96Ub6082e313/EdPp1a41j4YLExMYyb8kGgkPeMXXMgAyIXgghhBDpQXqQEjEzNaagbV66DxxPTGwsyjglLZvUpez7wdSfq071CsxftpGIiEiioqOxK2DDwF7t0jlqIYQQQqQn6UESQgghhEhEBmkLIYQQQiQiCVI623foJKvdd2ToPj6u+/a1EtdV+5IacJC2+nNCCCHE90LGIGVz6VVX7UevPyeEECJ7yTYJ0t0HT/h9hQfvwsIx0NNlyuj+mJuZsOfgCTbv/AeUUMQ+P4P7dkRfT5fV7jsIeRfGkL4dARgxcT5VKpSkQZ0qTPltBTbWubh55yEPHz+jQhkXRg3pwfHTl1i6dgsQP4nj7Em/YGVprorhzIVrLF+3jajoKOwK5GPsr73Q0dHGY9s+/j15gfCICHJbWTB5VH/0dHMQExPDyvXbOXX+KhrqGvxUuxJtm/8EoJpx+sHjZzRvVIseHZsnON6Utu03bCr1a1Xm73+OUatqOaxymqvqqg0aNROf12/p1Hc05Us707db6xRjbtZpMH27tmLzzn/o0KoRb3z9VfXnlEol6zf/zeFj51AqlZQrVZy+3VqjqanBavcdRERG4eX9hnuP/qNAPmtmTRicpJ6dEEIIkZmyxV+lkHehDJ84j/HD+lLGtRj+AUGYGBty/dZ91m/azaoFEzE2MmDe0g0sXrWJkYO7f7LNG7cfMH3sQCIio2jYtj/tWzagWqXSPP7vBUCShOWV9xtWbtjOkjljMNDXZfm6rezaf5S2P9fH1bkIrZvVRV1dnSFjZnPg39M0b1Qbj+37efjkOesWT0VLU4PA4BBVe8Eh7/htylCePX9FF7exdGjZUDU7NpDqtvsOnmDJ7DFoaWkmuFW3cMZIytftwIZl0z8ZM8Dp81dZtWAS6upqbN55QNXOwaNnOH3+Kqt/n4imhgZjpi3CY/s+urRtAsCV63eZP204OtpatOw2lCs37n3xU4JCCCFERsgWY5Bu33tMbitLyrgWA8DUxAiFQsHpC9eoXb08JsaGKBQKWjWty8lzV9LUZhlXJ3R0tDE2MsAmjxVv/QNTXf/C5Zu8fuNH/+HT6NxvDCfOXsH3bXwdNxvrXBz49wzT56/mpddrXnq9BuJ7odo1/wkdbS3U1NQwNTZStVexbAk01NUpmD8vmpqaBASFJNhfatu2alYPLS3NTx5jajEDtG3+U7LlSE6du0rj+tXJoaODhoYGzRvV5tS5q6r3P9Sz09HRTlM9OyGEEOJbyxY9SHFxcQkKzqZEoVCo1lMoFMTExqapfQ0NdVCmPluCEiUuTg7MHD84wfLwiAh6DJpA43rV6NCyAZbmprwLDYvfRhkHn4hboVAku//Utk1r/baUYv5/O58uwRIfY8qHkZZ6dkIIIcS3li16kIoVKcSLl95cu3UfgDdv/QmPiKBS2RIcPnaOwKAQlEol23YfpHI5VyB+wsh7D54QGRXF02cvufPgcZr2ZWVpjvfrt0mWl3F14tLV26p6aQGBwYSFR/DC05vAoBBaNqlDTktzHj15rtqmQhkXtuw6QFRUNEqlEs9XPmk+5i/d1srSDG8f31Rj/pTK5V3Zc+A4ERGRxMTGsmPPESq9/1yFEEKI70G26EEyMjRgxrhB/L7Sg6joGIyNDBgxsBsuTg50btsEt+HTQAkO9vn55f2g7BqVy7Lv0CladR1KmZJOVK1Y+hN7iVe+tDN/bt9Pp76jGT+sj6oyfd48Vkwa6cbs39ehRIluDh1GDOpGwfx5qVDGhfa9R5HPOhd5clsS977obcfWjVi8ahMd+45CR0eb6hXL0KVdkzTF8aXbNm9Um16/TKZmlbIM7tMh+Zht86baRt0aFfF540e3AeNRKBSUKVmM9i0apCluIYQQIiuQmbSFEEIIIRLJFrfYhBBCCCE+hyRIQgghhBCJSIIkhBBCCJFItkmQDvx7mk59RzNw5ExiY+MyO5wM9bn11Lx9fOk3bKrq9dUbd+nUd3Q6R5U1bN55gCm/rcjsMIQQQmRx2eIpNoC9B0/SrsVP1KtZKbNDEUIIIUQWly0SpGVrt3D3wRO8fHzxfv2WxvWqsXDFRl56vSY4JJRWTevSqmldFq/ehKamBr07twRg3+GTXL52lwnD+3Dr7iN+X+lBWHgEpsZG/OrWGVub3Fy9cZcFyzeqynNs3nlAVZNs36GT3Hv4HwGBQbwLDWPmhMFMnLmMJ8880dLUZFCfDpQt6UT3gRPo2Loh1T6aSsDbx5cRk+ZTtWJpTp+/SlDwO6aNHUAR+wIAydaQ09HRpmOfUbz1C6BT39E0qleNlk3qsPfgCTy27yM2No7SrsX4tV8n1NTiOw993rxlwMgZ+AcE0anvaLq1b4ahgR5R0TH8vsKDC1dvgRJmT/qFPLksCQ0NY+7SDdx98BSFAty6t6VSuRKquL183jBy0gIAgkNCCY+I5OD25bwLDWP+MnfuP/wPhZqCNs3q0bBuVQB8/QL4bdEfvPR+jYaGOr06taBi2fg2m3UaTNd2Tdl78AR+/oEM7d+FqzfucfrCVXRz5GDOpF8wNTFKMa64uDhWbdjB4ePnMDM1RltLCwtzk4w94YQQQnz3ssUttr7dWuNgn59BfdrTtV1TDA30ad+iAWsXTWHpnDEsXr2JkHeh1KtZiaMnL6J8Pyv10ZMXqFezIsEhoYycvIDBfTrgsWImPzesycjJC9J0q27PweN0aNWQhTNGcuHyLV56v2bburksmzuOog4FAbCxtsLI0CDJtk+fvcSpSCHWLppM1Yol2bTjHwBVDbnFs0azccUMcuTQYfGqTWioqzNvyjDMzUzYsGw6LZvU4cadhxw4eoZ1i6eyadVs3r0LS1BOxcrSnNFDeuBgn58Ny6ZTrVJ8kuYfEEjdmhVxXzYdG+tc/P3PMQAWrdqEk6Mdm1bNYumcscxd8keCzyG3lSUblk1n3eKp5LQ0Y9iALgD8vtID3Rw6bFwxg0UzR/HHpt3cuP0AgMmzl+NcrDAeK2YybcxAVcmVD3zfBrBi3nhaNa3LmKm/U6VCSTYun4luDh3+OXI61bj++fc05y/fZP3SaSz7bSz58uZK20kjhBAiW8sWPUiJaWpqoKOjzZqNu3jyzBMFCl6/8aNQARu0tbV48p8nlhZmPH32kpIujly8cou8uXNS1KEQANUrl2H+cnc8X3l/cl+lXIqqen2KF7NHS1OTWQvX0ubnetja5AFgwvC+yW6bI4cOZd4XcS1WxI6de44AJKghB9CqaV16/zI52SK7p89d5fkLL3oNnghARGQUjoULfDJuK0tzCheyBaBokYI8e/4KgJPnrnDr7iN27f0XgLg4JYFBwZiZGifYftOO/VhZmlOrarn3cVxj5YIJKBQKTIwNqV2tPKfPX8OuYD6u3brP3ClDAbDOnZPSJYpy8cotrHPnBOJn5lYoFDg52mFkZICTo118XA4F8fULSDWusxeu06xBDfR0cwCQJ1dOHj19jhBCCJGabJkgnbt0gyVrNtO7cwtaNK5Nl4djiXvfa1S/ZkX+PXkB69w5qVapNBop1BtToADii4zFxKRcs+3j7U2NjVi7aDLnL99k/Iwl1K5Wno6tG6UpZg0NdZQpFC37uIZcYkqU1KpWjkG9O6RpP8nuW13j/3tWwqSR/VQzhCfn8dMX7Nr3L+sWT01xHRLVZ/s4fkUKxds0NDQSvVZHGaFMNa6Y2Ng014wTQgghPsgWt9gSO3fpBqVcilK5fEkCAoMICQlVvfehZ+P4mUvUq1ERiO+9een9mjv3nwBw/MwlcuTQIW8eK8xNjXnxygc//0BC3oVy4sylFPf79NlLAoKCKV/amWYNa3Lu8o0vij+1GnIm78fjRERGAVCxbAn2Hz7Ni5fxvV3er98muTVoldOcN77+abplWLFcCdZs3EV0dAxKpRIvnzcJ3o+OjmHybysYNqArhgZ6/4+5fAm27T6IUqkkMCiEw8fOUbGcK7o5dCjh5MD2PYcBeOX9hotXb1PGtdhnfSYpxeXi5MA//54mOjqGmNhY7j548lntCiGEyJ6yZQ9Sg9qV+W3JeroNGI+Tox021v8fl2JuZoK5mTHer99i//4Wk6GBHjPGDWb+sg1EREZhbGTAzPGDUVdXw8Y6Fw1qV6ZDn1EULmRLjSpluf/ov2T3Gxgcwuzf1xISGgbA8AFdAZi5YA2uzkWoU71CmuJPrYacjrYWdWtUpG2PYTRvVJsOrRoyoGdbRkyaj4a6BkaG+kwY0RcLs/8PVM5tZUlB27y07j6Ubu2bYWVpluK+B/Vuz4Jl7rTvPRIdHW3Kujrh1qON6v2/9h/lv+cvWbpmM0vXbAZgwfQRDOzVnnlLN9Ch9ygUagq6tG2Cc1F7AMYP78Oc39ex9+AJNDTUGT2kh+r2WlqlFNfPDWvy5OkL2vYcjpWlOQVsrQkNC/+stoUQQmQ/UostCzh/+SZXb9ylX/c2n15ZCCGEEBkuW95iy0qCgkPYe/AEbX6un9mhCCGEEOI96UHKApRKZYqDrIUQQgjx7WXLMUhZzcfJUb9hU/F57UcOHW2C34VSysWRof27oKebg32HTnLy7BVmTRwCQFh4BMvXbeXazfsoFGBrk4chfTuqHv9PLyfOXmbLrgMsnTM2yXs+b97SovMv/NKvEz83qqVa3qzTYGZNGIJ9wXwAXL5+h1UbdhAWFoGmpjrtmjegVrVy6RqnEEIIkV4kQcqCBvVpT9UKpYiJiWHImDkc+Pc0zRvVTrCOUqlk1OQFFLEvwB9LpqKursaFK7fQ1tb6prEeOX6ehvWqcvj4uQQJ0sdu3H7AjPmrmTtlGLY2uQkOCeWxzEUkhBAiC8sWCVJcXBxL127h6o27hIaF41i4EGN/7cW70DA69xvDwhkjyJc3N4NHz6JRvWrUrFKWMxeusXzdNqKio7ArkI+xv/ZCU1OTWb+v4fK1u2hqqtOlbVPq10pY2+30+Wusct9OTEws1rlzMrR/FyzMTLh64y4bt+0jb56cXL52FxQwZ9Iv5LayTDZmpVKJn38Q4RER5MubO8n7N+88xOeNH/OnDVeVDSn7flLJj925/5gVf2wnMDiE6Ohohg/sRgknh0+WMtn+92G27DqAkaF+qj1Sh46fY9qYAfQfPp3Xb/zImcwTcKvdd9Krc0tsbeKPw9BAD1dnxxTbFEIIITJbthikraamRvVKpVm9cBIeK2dx/9FTLly5iZGhPv17tOW3xeu5cOUWampq1Khchlfeb1i5YTtL5oxh8+o55Mllya79R3n89DnHT19i69o5rFs8lXKliifYj+crH6bPX8W0MQPxWDET56KFmfpR5fjb9x7xU+0quC+fjk2eXOzefyzZeBcu96BNj2E07TiIXDktVDNHf+zhk+cUdSioSo5SYm5qwthfe7Jh6TS6tG3KopV/qt5LqZTJ1Zv38Ni+j+Vzx7F64SRcijkk2/azF16EhYWTN48VZUo6ceTE+WTXe/T0OU6OhVKNUwghhMhKskWCBPElJnbsOcK0uat49y5MVeurZtWyaGioM2P+aob274xCoeDC5Zu8fuNH/+HT6NxvDCfOXsH3bQD5bPLgYFeA8TOX8t/zl0l6Vi5evUXZkk6qOXxaNK7NlRv3CI+IAP5fvkNNTY2iRQri5x+YbKyD+rRny5rf2LtpMbmsLPh17G/JrqdMw/B6SwtTXnq/4feVf7L34IkENc4+lDJRKBQUK2KniufsxevUq1FRVT7EOk/ycxIdPn6O8qWdAahYxoXDx8+lGEdaYhVCCCGyimxxi+2Nrx9uw6fTsXUjenVugZqagri4+L/YUdHR+PkHoqGhTkRE/OzTSpS4ODkwc/zgJG39PnMkN+88ZMmazeTPZ82w/l1S3XdKD6clKN+RAjNTY35uWJPtuw8lea9QARu2/32I2Ng41NVTznNXrt/O0+cvafNzfRrXq0bP9zXZksTzUSmTmJhYdD4xlkmpVHL4+Dni4uLo1Hc0sbFxPPN8xYuX3gkm3gQolN+GW3cfkidX8rcThRBCiKwmW/Qg3X3wlBw5dGhUtyp6ujl49sJL9d76TX9TsWwJfunXiWnzVhEbG0cZVycuXb3NrbuPAAgIDCYsPAJvH1+8fN5QvKg9nVo35uzF6wn2U8bViYtXb/PKO77MxY69R3AtXoQcOjpfFHdcXBwHjpxRFcn9mEuxwpibmrBqw3bi4uJLhFy8citJKY1T56/SoHYVSjg58PDJszTt18WpMEdPXiQ0NAylUqn6HD724PEzwsLD2bxmDhuWTcdj5UxqVC6bbC9St/ZNWbl+B8894z/30LBwtu0+hFK6lYQQQmRR2aIHqVSJouw/fIoOvUeRP18e1WDh/56/4tCxs7gvn04OHR32Hz7F5p3/0L5lAyaNdGP27+tQokQ3hw4jBnVDGadk0ao/8Q8IJjIqikG92yfYT948Vowa3INRUxYSGxuLda6cjB3a+7PjXbjcg9UbdhIdE0OBfHkYN7RXknUUCgWzJg5h8apNtO89Ek1NTWzz5mbI+5IjH3Ro2YBl67awedc/VK1QKtXepg+qVijFrbuP6NRvDJbmpji9LwnysUPHzlG/ZuUExXh/ql2ZBcs30q19swTrujo7MmxAFybNXk5UdDRampq0bV5f5n4SQgiRZclEkUIIIYQQiWSLW2xCCCGEEJ9DEiQhhBBCiEQkQRJCCCGESEQSJCGEEEKIRCRBEkIIIYRI5IdPkJRKJTExMTLnjhA/CLmmRVYk5+WP54dPkGJjY6ncoAuxsbGZHYoQIh3INS2yIjkvfzw/fIIkhBBCCPG5JEESQgghhEhEEiQhhBBCiEQkQRJCCCGESEQSJCGEEEKIRCRBEkIIIYRIRBIkIYQQQohENDI7ACGEEOJH9fL0JKLDfL+qDU1dC6wrTUiniERaSYIkhBBCZJDoMF+i33lldhjiC8gtNiGEEEKIRCRBEkIIIYRIRBIkIYQQQohEJEESQgghhEhEEiQhhBBCiEQkQRJCCCGESEQe8xdCCPHD+mv/UbbtPoS+ni5TRrlhaWGmem/zzgMcOnaG0LAI+vdoQ+XyJfH28aVNz+Hks84FQM2q5ejcpnFmhS8yUYYlSMEhocxcuAbPlz4YGeozeZQbhgZ6zF/mzvXbDzAy1Gfi8L5YWphx6+4j5i5ZT2xsHPVrVaJdi58IDAph3PTF+AcEUb92JTq0bAikfrILIYQQH/gHBOG+ZQ8eK2Zy6vxVlqzZwqSR/QAIDQsnMiqKVQsm8dzTC7fh09hfzhUAR/sCLJs7LjNDF1lAhiVIt+89omWTOpRwcmDRqj/x2L4PK0tzUCjYuHwGnq98MDE2Ijo6hqlzVzB3yjBy5bTgxUtvANZ67KJqxVI0/ak6nd3GUqV8SfT1dFM82YUQQoiPXbhyC/uCtujoaOPi5MCcRetU7+np5lD1DOXPl4fY2Fgio6IBMDIyyJR4RdaSYQlShTIuqp+dHO04evIi127eZ9LIfigUCmzed1+evXgdB7sCWOfOCcSfqB+WN65fHQ0NDZyK2HHu0g0MDfRTPNmFEEKIj/n5B2JjbQWAuakxsXFxRERGoaOtlWC9B4+fYZ07p2r546cv6Np/HHp6ORjq1hlbmzzJtr/978Ps2HMYAKVSmYFHIjLDNxmDdOX6XYoXtefy9TtcvHqLsdMXYV/QlhGDuuHl40uOHNoMnzCP12/9GNS7A67Fi+AfEKRKmmysc/HWL5Do6Jg0nexy0gohhECR8G+AMk6JQpFwlZjYWBau8KB3l1YAWFqYMW5YH4rY5Wfzrn+YvWgdS+eMTbb5Fo1r06Jx7fh2YmKo3KBLhhyGyBwZniA9eebJpWt36N+zLYtXb0JfT491i6YwbMI8Tp69Qlh4OI+fvmDe1OF4vvJh+rxVeKyciUKhgPcndpwyDoWaIk0nO8hJm5lWbjn21W30al09HSIR6S25cYU79x5h9z/HMXl/S2LiiH4UsLXmuacX0+atIjw8ktIlijKwd3siIqOYPHsZzz29Ke1ajEG926NQKDh1/ior/tiGhro6Y3/tRaECNl8co5x/4mMWZibcvvcYAF+/ADQ1NdHWSviFesGyjZR0LkLZkk4AqKur4VzUHoAm9WuwZdfBbxu0yDIyNEEKCAxmwsylTB0zAG0tLcxMjHApVhg1NTVKuTji5f0Gc1MT8uezxtBAD8fCBQgMDgHA1MSIl16vKVTABs+XPhQqYIOhgd4nT3YhRMZIblxhDh1tenVuQaO6VVXrKZVKJs1ezq9unXAsXJCnz18CsGvvEXJZWTBt7ECGjJnNpau3KVG8CHMXr2ft4sl4efsye9E6Vs6XquUi3qlzV7hx5yHPPb3w8vbFxMQQmzy5KJQ/L/VqVUI3h06q25dxdWLl+u1ERERy7eZ9KpRxwWPbPizMTahTvQLb/z6Mn38gv/TrqNrm8PFzuBYvgqmJEafOXcHBzjaDj1JkVRmWIEVFRTN6ykJ6dmpOofx5AahUzpWjpy/SskkdLl+/S/NGtShcyJa1HrsIDQvn2YtX5Hz/VFrFsiW4dus+tja5uX3vMR1bN0JPN0eSk10I8W0kN67QxtoKY0P9BOs9e+GFhoY6RR0KAVDQNv76P3PxOq2b1UOhUODi5MDZSzfQ0tLE2MgAU2MjjAwMePD4GSHvQjHQ1/tmxyWynuOnL+GxfT9OjnaULlGUxvWqYWlhRlBQCF6vfXnw6BkDR86gfGlnOrdtgoa6erLtmBgb0qVdU7oPmoCBni5TxgzAfcseFAoFr7zfsGCZO/nzWdPFLf4WWsfWjbC0MGPs9MX4+QdiZmrM+KG9v+WhiywkwxIk9617efD4Ges37WaN+04A5k4dxswFa9i55wilSxSjfGlnFAoFPTr+TK8hk1DGKRk7tBcAXds1Zdz0xfy17ygN61ZRjUdKfLILIb69D+MKA4OC8di2j2Vrt1LSxZFBfTrg5fMGUxMjJs1exqOnL+jarik1q5TFzz9QNbdMPutcPH76grf+gaoHNtTV1bDOnRM//8AkCZKMK8xeLMxNWThjBLo5dIiKikZLSxMAHUszclqaUcLJgdbN6nL1xr0Uk6MPGtWtmqCH85d+nVQ/n/5nQ7LbLPst+TFHInvJsASpe4dmdO/QLMnyuVOGJllWr2Yl6tWslGCZkaE+v88cmWTdxCe7EOLb+nhcYUBgMPVqVkJXV4cRE+dz8N8zaGlp8vjpC5bMHoNCTUHnfmOoVrE0ChTExX0YV6hETU2BQqFIZlxh0oGFMq4weynqUFD1c9+hU1nz+6Qk6ygUCkq6OH7LsEQ2I6VGhBBplnhcoZWlOda5c2JqbESNymV47umFuZkJVjnNyWlphqW5KWamxgSFhGBuZoLnq/h5zjxf+mBuaoK5mQkv3i+LjY3jlc8bzE2NM/EIRVbjYGfLmQvXMjsMkQ1JqREhRJokHlcYGRXFgSNnaFi3KhGRkVy6docGdargWLgAr7xe89YvgNjYOEJCQjE2NKBiWReu3bxPpXKuXL99nw6tGlK0cAGCQ0LxDwjipddrHO0LoKenm9mHKrKQgMBgRkxagK1NbtTV//+dfv2SaZkYlcgOJEESQqRJ4nGFsXFx1K5anp6DJxAQGEyNKmWpUbkMCoWCUUN6MmTMHCKjohgxqBtqamo0bVCDybOX06H3KMqWKk5JZ0cUCgXD+ndh4KiZaGpoME4GxIpEWjSpQ4smdTI7DJENSYIkhEiTlMYVdmnXJMmyMq7FcF8+PcEybS0tpo0dmGTdCmVc5IlUkSLX4kUICAzmta8fDnb5MzsckY3IGCQhhBBZ1t6DJ+g7dCpjpv4OgLePL5PnLM/kqER2IAmSEEKILMt9617+WDJVNTYtl5UFT5+9zOSoRHYgCZIQQogsS01NkaDeZmhYOOEREZkYkcguZAySEEKILKtcqeKs+GMbkZFRnD5/Dfete6hY1jWzwxLZgPQgCSGEyLLcurdBR0cbA31d1v35F+VKFadf99aZHZbIBqQHSQghRJb14PFzOrdpTOc2jVXLLl69TRnXYpkYlcgOpAdJCCFEljV70dokyxYu35gJkYjsRnqQhBBCZDlTf1sBCgWv3/gxde5K1XKf12/R1c2RiZGJ7EISJCGEEFnOT3WqAHDl+h1KFHdQLc9laY6To31mhSWyEUmQhBBCZDmuxYsAMHGkG85FEyZEgUEhGBsZZEZYIhuRMUhCCCGyrHlL1ydZNnT8b5kQichupAdJiGwmOCSUV96vMTU2IqelWWaHI0Sy9h8+BcSfrx9+BvB+7Yt/QHBmhSWykRQTpFPnrnDjzkOee3rh5e2LiYkhNnlyUSh/XurVqoRuDp1vGacQ4ivcuf+EDVv+5uWr1+jp5cDS3JTA4BD8/YPQ19eleaNa1K5WHjU16VQWWYP3a18AwsIiuHrjrmq5VU5z5k4ZmllhiWwkSYJ0/PQlPLbvx8nRjtIlitK4XjUsLcwICgrB67UvDx49Y+DIGZQv7Uzntk3QUFfPjLiFEGm0dM1mgoLf0bNTCwrlz5vk/cCgEP7ad5RBo2Yxf/pwuaZFltC9w88AGBka0KJx7UyORmRHSRIkC3NTFs4YgW4OHaKiotHS0gRAx9KMnJZmlHByoHWzuly9cU/+IxXiO9C3W2sUCgUQ/wWoWqXSCd43NjKgS7smdG7bWLWeEFlFw7pV2bLrAL5+AfTv0ZbwiAh8XvuRP1+eNG3/1/6jbNt9CH09XaaMcsPS4v+3lTfvPMChY2cIDYugf482VC5fEqVSyVqPXRw9eRFLC1OmjO6P/vtCuSJ7SdKfXtShoOr2Wd+hU5PdSKFQUNLFMWMjE0Kki4+Tng1b9qBUKj+5nhBZxfR5KwkIDObshesAREZGM2vhmjRt6x8QhPuWPaxZOIkWjWuzZM0W1XuhYeFERkWxasEkZowbxPT5q1EqlTx8/IyzF2+wYdl0ShR3YOPWvRlxWOI7kOqAAwc7W85cuPatYhFCZLC2zeszcdYyHjz6j8dPX6j+CZFVPXzygj5dW6GhGX/Dw9jIgLDwiDRte+HKLewL2qKjo42LkwPnLl1Xvaenm4PObRqjrq5G/nx5iI2NJTIqmjMXr+Nc1B51dTVcijlw9tKNjDgs8R1I9Sm2gMBgRkxagK1NbtTV/59LrV8yLcMDE0Kkv2VrtwIw6u4j1TKFAnasn59ZIQmRKi1NDd6FhvGhg/P2vcdp3tbPPxAbaysAzE2NiY2LIyIyCh1trQTrPXj8DOvcOdHR1sLPPxC7gvkAyJc3F2/9AtLnQMR3J9UEqUWTOrRoUudbxSKEyGA7N0giJL4vfbq2ov/w6bzx9Wf0lIVcvHqbyaPc0raxggS3lJVxShLfSY6JjWXhCg96d2n1fhsFcXHx28TFKVFTS/nW8/a/D7Njz+H4tlO4dS2+X6kmSK7FixAQGMxrXz8c7PJ/VsPBIaHMXLgGz5c+GBnqM3mUG4YGesxf5s712w8wMtRn4vC+WFqYUbF+Rwraxj9d41ysML+6dSYiMorJs5fx3NOb0q7FGNS7PQqFglPnr7Lij21oqKsz9tdeFCpg8+VHL0Q2ExkVxV/7jvLWLxC3Hm2IiIjE+/XbNA94FeJbq1DGBVub3Jy/fAuUSvp2a03ePFZp2tbCzETV4+TrF4CmpibaWgl7jxYs20hJ5yKULekUv42pCZ6vvAF48coHc1OTFNtv0bi26gm7mJgYKjfo8rmHJ7KwVMcg7T14gr5DpzJm6u8AePv4MnnO8jQ1fPveI1o2qYP78ukUtrPFY/s+du07CgoFG5fPYOSg7pgYGwFgYWbKhmXT2bBsOr+6dQZg194j5LKyYOOKGTx78YpLV28THR3D3MXr+X3mSIb278LsReu+5tiFyHamzY0f8PphbGFEZFSaB7wKkVkiI6PR1tLEyMgAvc8oVFvG1YlHT54TERHJtZv3qVDGBY9t+zh07CwQ3wPk5x9It/bNVNtULOvCjdsPiI2N49rNe1Qo45LehyO+E6kmSO5b9/LHkqnovX/EMZeVBU+fvUxTwxXKuFDCKb7AoJOjHb5vA/jnyGnaNKuHQqHAxjoXmu8H3RkZ6SfZ/szF67g4OaBQKHBxih8od+f+Y4yNDDA1NqKIfQEePH5GyLvQzzpgIbKzrxnwKkRm+HP7fnoMnsDh4+fYf/gkHXqP4lwaB06bGBvSpV1Tug+awK69R+jXvTWvff146xfIK+83LFjmzkuv13RxG0unvqM5fPwcdgXzUbl8STr1Hc2tuw9p37JBBh+hyKpSvcWmpqZIMJgtNCyc8IjP/8/0yvW7FC9qz+Xrd7h49RZjpy/CvqAtIwZ1Q0NdHT//QHoOngQo6d+zHc5F7fHzDySfdS4A8lnn4vHTF7z1D8Tm/TJ1dTWsc+fEzz8QA329z45JiOzoawa8CpEZdu49wrZ1czF9f8fh6bOXjJuxmPKlndO0faO6VWlUt6rq9S/9Oql+Pv3PhmS36dquKV3bNf3yoMUPIdUEqVyp4qz4YxuRkVGcPn8N9617qFjW9bN28OSZJ5eu3aF/z7YsXr0JfT091i2awrAJ8zh59go1Kpdh2thBONjZcvz0JSbOWsquDQtQ8NFAOWX8QDmFQpHMgLukA+hk4JwQyevdpSX9h0/H1zfg8we8CpEJzE2NVckRQAFba3S0tTMxIpFdpJoguXVvg8f2/Rjo67Luz7+oVK4EHVs3SnPjAYHBTJi5lKljBqCtpYWZiREuxQqjpqZGKRdHvLzfAOBc1B6A2tXK89vi9URERmFuFj9QztYmN54v4wfKmZuZ8OL94LnY2Dhe+bzB3NQ4yX5l4JwQyatYtgT58+X5ogGvQnxLH+bnKlK4AFt2HaCkc/zkxJ6vfCglExWLbyDVBOnB4+d0btOYzm0aq5ZdvHqbMq7FPtlwVFQ0o6cspGen5qr6T5XKuXL09EVaNqnD5et3ad6oFmcuXMPGOhd581hx5cZdLM1N0dHWomJZF67dvE+lcq5cv32fDq0aUrRwAYJDQvEPCOKl12sc7QuoxkcJIT5txR/b6N2lJT83rKla9vsKDwb2bp+JUQmR1PCJCaek2LLroOpnhSK+hI4QGSnVBGn2orVJJoVcuHwjHitnfrJh9617efD4Ges37WaN+04A5k4dxswFa9i55wilSxSjfGlnnr3wYu6S9bzx9UdTS4Pxw/sA0LRBDSbPXk6H3qMoW6o4JZ0dUSgUDOvfhYGjZqKpocG4ob2/9LiFyJbOXrpO7y4tVa+9X7/l35MXJEESWY7M2SUyW7IJ0tTfVoBCwes3fkydu1K13Of1W3TT+Ihl9w7N6N6hWZLlc6cMTfA6f748LJg+Isl62lpaTBs7MMnyCmVc5LFLIT7Tz52GoFDEJ0QV63dULc9pYU7LpjIZrBBCJJZsgvRTnSoAXLl+hxLFHVTLc1ma4+Ro/20iE0Kkmw/fxgePnpXsFxIhhBAJJZsguRYvAsDEkW6qAdQfBAaFYGxkkPGRCSHSXbOPxh59cODf09SrWSkTohHi88TExPDWPxArS/PMDkVkA6lOFDlv6foky4aO/y3DghFCZKy1HrsSvI6Li2Otx1+ZE4wQabBwxUbe+PoRFxdH90ETaN19GGs27szssEQ2kGwP0v7Dp4D4emoffgbwfu2Lf0Dwt4lMCJFu3IZNQ6FQ8NLrNf2HT1ctf+3rRwFb60yMTIjUnbt0kwE923Hy7BUc7QuydPYYOvUbQ/cOP2d2aOIHl2yC5P3aF4CwsAiu3rirWm6V0zzJIGshRNY3dmhvUCoZOGom3T56eCKXpTm5rCzS1EZyBah37j3C7n+OY/L+tvvEEf1UCVdoaBgtuw3FrXsbGtSpIgWoxReJjo7m0dMX/LljP5NHuaGnpyvVE8Q3kWyC9CEzNzI0UE24KIT4fuXKGT9mY/Gs0eS0NPuiNj4UoC7h5MCiVX/isX0fOXS06dW5RYJSDh+s27QbMxNj1esPBainjR3IkDGzuXT1NiWKF2Hu4vWsXTwZL29fZi9ax8r5E74oPvFjatfiJ9yGTaNF49pYWZpz+95j6fUU30SqY5Aa1q3Kll0HWLx6EwDhERH89/zVNwlMCJH+3voH0tltDM07DwHA581btu0+lKZtkytADWBsmLTYtOcrH27eeUjl8v8vTSQFqMWXaN6oNkd2raJP11YA2BfMx6DeHTI5KpEdpJogTZ+3koDAYM5euA5AZGQ0sxau+RZxCSEywJxF65g0wk01A72luSl7D5347HY+FKAG8Ni2j3Y9RzB3yXpiYmMBWLx6EwN6tkNN7f+1EhMXoH7rF5BiAerEtv99mLY9h9O253A69Bn12fGK78+H4R37D59K8O/IifOcuXAtk6MT2UGqM2k/fPKCyaP6c/bSDQCMjQwIC4/4JoEJIdJfVFQ0tja5Va8VCgWRkdGf1cbHBagDAoOpV7MSuro6jJg4n4P/nsHSwhR9PV2cHO24cOXm//f1FQWopb5i9nPm4nVcnR05cfZykvcUCgU/1a6cCVGJ7CTVBElLU4N3oWF8+P/q9r3H3yImIUQGyZvHiotXbqFQxA+iXrlhe4KE6VMSF6D+eD6aGpXL8NzTi1v3HvHw8XN6DJrAm7f+aGlqYmFm8lUFqEX2M6BnOwBmTRiSyZGI7CrVBKlP11b0Hz6dN77+jJ6ykItXbzN5lNu3ik0Ikc6GD+zKlN9W8OS/l9Rt2RfX4kWY8L7+4ackLkAdGRXFgSNnaFi3KhGRkVy6docGdapQs0pZ1Tar3XeQK6cFZUo68d+LV1KAWgjx3Ug1QapQxgVbm9ycv3wLlEr6dmtN3jxW3yo2IUQ6MzM1ZsH0EYRHxN8qz6Gjk+ZtExegjo2Lo3bV8vQcPIGAwGBqVClLjcplUtxeClALIb4nqSZIED8wW1tLEx0dbfTSWKhWCJE1BYeE4r5lD3cePCaHjjYVy5SgyU81UFdP9XkNIOUC1F3aNUlxmx4dm6t+lgLU4kssXbuFft1aZ3YYIhtKNUH6c/t+1njsxKmIHerqasxdvJ5xw3pTvrTzt4pPCJGOpv62Am1tLZrUr4GGhjp/7TuKp5ePPDYtsqzb9x4RGhYuX9DFN5dqgrRz7xG2rZuLqbERAE+fvWTcjMWSIAnxnfL08mHTqtmq15XLudKx72hJkESWVb1SGboNGE/Tn6qjrq6uWt6qad00bf/X/qNs230IfT1dpoxyw9Li/xOl3n/0H/OXufPuXRgeK2cC4O3jS5uew1VTUtSsWo7ObRqn4xGJ70WqCZK5qbEqOQIoYGuNjrZ2hgclhMgY1rlzJvg2rqauhoW5SSZHJUTKHjz6D6cihXjyn+f/FyYzFURy/AOCcN+yB48VMzl1/ipL1mxh0sh+qvfNTI1p0bg2f/y5O8F2jvYFWDZ3XLrEL75fySZIj5++AKBI4QJs2XWAks6OQPzsuKVcHL9ddEKIdLFwxUYg/lH6YRPmUriQLQDer99iYSYJksi6xn7FwP0LV25hX9AWHR1tXJwcmLNoXYL3LcxMKOZQKMl2Ru9rC4rsLdkEafjE+Qleb9l1UPWzQgF9ZcCcEN8V/fePzhd1KJhguZ0UhhVZnOcrHxav2kRQcAjL543H1y+AW3cfpfrE5Ad+/oHYWMc/eW1uakxsXBwRkVHoaGulut3jpy/o2n8ceno5GOrWGVubPOlyLOL7kmyCtHPD/OQWCyG+Ux8KUAvxvZk2dyVd2zdjyfuaoMaGBrhv2ZOmBAkFyczUnvomlhZmjBvWhyJ2+dm86x9mL1rH0jljk113+9+H2bHncHzbH+1H/Bg++Zi/EEJkZyu3HPvqNnq1rp4OkWRPwSGhlC3pxJI1mwHQ1NQgMjIqTdtamJmoKkD4+gWgqamJtlbqvUfq6mo4v68z2KR+jQR3UBKTEjg/tk9PfiKEEEJkElMTI54881T1/GzasR+zNJajKePqxKMnz4mIiOTazftUKOOCx7Z9HDp2NsVtDh8/h59/IEqlklPnruBgZ/v1ByG+S2nuQYqJieGtf2CC2ktCiO/L6zd+5LSMf8z5+q37XLlxj2YNayR4WlWIrGT4wK6Mnb6Y555e1G/VFyNDA2ZPTFt9NhNjQ7q0a0r3QRMw0NNlypgBuG/ZoyqIPH3+Km7dfYSXty+d+o7m1/5dsLQwY+z0xfj5B2Jmasx4md0920o1QVq4YiNtf66PuZkJ3QdN4NkLLzq1biTjGYT4Tk2YuYRJI93Q1tZiwsylOBcrzIQZS1k0a1RmhyZEsmysc7Fu0RQ8X/kASvLmyZWmmd8/aFS3Ko3qVlW9/qVfJ9XPo4f0THabZb8lP+ZIZC+pnmXnLt3E3MyEk2ev4GhfkP2bl7D/8KlvFZsQIp0FBIWQ09KMXfv+pXvHn5k8yo03b/0zOywhUhQbG8eVG3e59/Apdx885eDRM/J3SHwTqfYgRUdH8+jpC/7csZ/Jo9zQ09PFQF8vTQ0Hh4Qyc+EaPF/6YGSoz+RRbhga6DF/mTvXbz/AyFCficP7qmY1/TB76fypw3B1diQwKIRx0xfjHxBE/dqV6NCyIZD6rKhCiNTp6eowf9kGLl+7yx9LphIdHYOebtoL1grxrQ2fOI9HT59jVyAfGhrxM2krFAp+ql05kyMTP7pUE6R2LX7Cbdg0WjSujZWlObfvPaaArXWaGr597xEtm9ShhJMDi1b9icf2ffHjlxQKNi6fgecrH0w+GvewZM1m8uaxUr1e67GLqhVL0fSn6nR2G0uV8iXR19NNdVZUIUTqxg/ry659Rxg+qBuamhrcuvuIhnWqfnpDITLJf89fsXXt3E/OXSREeks1QWreqDbNG9VWvbYvmC/NNZs+rs7t5GjH0ZMXuXbzPpNG9kOhUGDzvs4NxA8WjYuLU83uC3D24nUa16+OhoYGTkXsOHfpBoYG+qnOiiqESJ2tTW6G9P3/GAwnRzucHO0yMSIhUlesSEGioqIlQRLfXLIJ0tUbd3F1dkzxPu/ndm1euX6X4kXtuXz9Dhev3mLs9EXYF7RlxKBuKFCwdO0WJo3ox+qNO1Xb+AcEYZ07JxA/SO+tXyDR0TFpmhVVJu8SIqHFqzfRv0db3IZNUz3Bk+D92aMzISohUvZxeZzBo2fhXMw+wftSYFlktGQTpDMXr+Pq7MiJs5eTvPe5936fPPPk0rU79O/ZlsWrN6Gvp8e6RVMYNmEeJ89e4V1oGGVci5HLyiLJfnif3MQp41CoKdI8K6pM3iVEQuVLOQPQulm9TI5EiLT5UB5HX083zUM7hEhPySZIA3q2A2DWhLTNNZGSgMBgJsxcytQxA9DW0sLMxAiXYoVRU1OjlIsjXt5vuHbrHn7+QZy/fJNX3m+4++AJU8cMwNTEiJderylUwAbPlz4UKmCDoYHeZ8+KKoSAku+LTFepUDKTIxEibT5MJ3Pn/pMkNQSDgt9x/vJNypUqnhmhiWwiw2bSjoqKZvSUhfTs1JxC+fMCUKmcK0dPXyQmNpbL1+9SwNaauVOG8ceSqaxeOIkKZVwY1r8LBW3zUrFsCa7duk9MTAy37z2mfGnnZGdFFUII8eOatXANB/49zcGjZ4iLiwNg5YbtTJu7ko1b92ZydOJHlmG12Ny37uXB42es37SbNe7xY4vmTh3GzAVr2LnnCKVLFKN8aecUt+/arinjpi/mr31HaVi3imo8UuJZUcWXkfpS2VNUVDRaWpqZHYYQafb4P08OHz9PWFg4Dx49Y2Dv9jx99hL35TPoP2I6HVo1zOwQxQ8q1QRp6dot9OvW+osa7t6hGd07NEuyfO6UoSluM+6jKd2NDPX5febIJOsknhVVCJF2fYdOZc3vkzI7DCHSzMTYkLlThhIeEUGPQRMBCA0Lx9jIAAXJDEIVIp2keovt9r1HhIaFf6tYhBAZzMHOljMXrmV2GEKkmZ5uDu4/+o8r1++hqaGBf0AQQUEhKJVK1cSRQmSEVHuQqlcqQ7cB42n6U3XU1f9/IrZqWjfDAxNCpL+AwGBGTFqArU3uBPWs1i+ZlolRCZGyXp1b0G/oVCzMTahfszK9hkzC1dmRrv3Hqca3CpERUk2QHjz6D6cihXjyn+f/Fyb3XL0Q4rvQokkdWjSpk9lhCJFmtaqWo3qlMqqEvku7JgB4+bzBzNQ4EyMTP7pUE6SxH40JEkJ8/1yLFyEgMJjXvn442OXP7HCESNF/z1+RP18ert26n+z7JZwcvnFEIrtJNUHyfOXD4lWbCAoOYfm88fj6BXDr7iNqVC7zreITQqSjvQdPsHHbPqKjo9mxfj7ePr6sct/B+GF9Mjs0IRJw37qH8cP6MH+Ze5L3FIrsfVtYnkL+NlJNkKbNXUnX9s1YsnoTAMaGBrhv2SMJkhDfKfete1m/dBq9hsQ/yZbLyoKnz15mclRCJPUhad+wNPsmQiJzpZogBYeEUrakE0vWbAZAU1ODyMiobxKYECL9qakpEtQuDA0LJzwiIhMjEuLTPF/54OcfyMeVNeUWm8hoqSZIpiZGPHnmqRqXvWnHfhkUJ8R3rFyp4qz4YxuRkVGcPn8N9617qFTONbPDEiJF0+ev4p8jp7HJkwv194/1Z/dbbOLbSDVBGjagC+NmLOG5pxf1W/XFyNCA2RO/rj6bECLzuHVvg8f2/Rjo67Luz7+oVK4EHWUmYpGFnbt0k72bFmNkaJDZoYhsJtUEKV/e3KxbNAXPVz6Akrx5ciWYO0UI8X158dKHzm0a07lN48wORYg0KWKXnxw6Ol+8/V/7j7Jt9yH09XSZMsoNSwsz1Xv3H/3H/GXuvHsXhsfKmQAolUrWeuzi6MmLWFqYMmV0f/T1dL/6OMT3J9UEqWv/cZQt6USZkk4Ud7ST5EiI79zEWUsJCn5H6RJFKVPSidIlimFibJjZYQmRxNa/DgJgZmrMqCkLKVvSKcH7aZmw2D8gCPcte/BYMZNT56+yZM0WJo3sp3rfzNSYFo1r88efu1XLHj5+xtmLN9iwbDoe2/eycete+nRtlU5HJb4nqSZIo4b04Mr1O3hs28eEJ88pXMiWsiWdaCkTzQnxXdqwbDqBQSFcvXmPqzfusWVX/B+htNRnCw4JZebCNXi+9MHIUJ/Jo9zYufcIu/85jolR/O2PiSP6kSe3JfOXunP3wRM0NTUZP6w3+fLmJiIyismzl/Hc05vSrsUY1Ls9CoWCU+evsuKPbWioqzP2114UKmCToZ+B+D48fPxM9bOJkUGC12mdsPjClVvYF7RFR0cbFycH5ixal+B9CzMTijkUSrDszMXrOBe1R11dDZdiDvy2ZL0kSNlUqgmSfcF82BfMR8smdbh59xF/7TvKwhUekiAJ8R2Li4sjOjqGqOgowsLD0dPNkabtbt97RMsmdSjh5MCiVX/isX0fOXS06dW5RYIC0vcf/Udp12KMHNyd7X8fZsX67UwfO5Bde4+Qy8qCaWMHMmTMbC5dvU2J4kWYu3g9axdPxsvbl9mL1rFy/oSMOnTxHUmPiYr9/AOxsbYCwNzUmNi4OCIioxI8yZncNnYF8wGQL28u3voFfHUc4vuUaoL05/b9XL5+B89XPjjY5aeEkwPd2jf7VrEJIdJZ+14j0dfXxblYYapXKsOg3h3SnCBVKOOi+tnJ0Y6jJy9iY22FsaF+gvUc7PKrZul2crTj4NGzQPw389bN6qFQKHBxcuDspRtoaWlibGSAqbERRgYGPHj8jJB3oRjo66XPAYvv0tK1W9DNoUOzBjWSHZwdExvLvycu8O+J80wfPwgN9RSK1irixxR9oIxTfrrzSaEgLi5+m7g4JWpqKW+w/e/D7NhzOL5tpTLF9cT3KdUEyX3rHgrmz0vH1o1wLV4E69w5v1VcQogMUKZkMW7fe8ytOw9RV1dDQ0MdJ0f7VL9RJ+fK9bsUL2pPYFAwHtv2sWztVkq6ODKoT4cEf6zi17MD4r+Z57POBUA+61w8fvqCt/6B2Lxfpq6uhnXunPj5ByZJkOQPUfbSp0tL/j15gV/H/YZCoUaeXBZYWpgRFBTCK583BAQGU7tqecYN651yckT8LbTb9x4D4OsXgKamJtpaqZ/rFqYmeL7yBuDFKx/MTU1SXLdF49q0aFwbgJiYGCo36PKZRyqyslQTpP1blvLo6QsuX7vD/GXuvPb1w75gPilLIMR3alDvDgAEBoVw5cZd/tp3lOET5nPs7zVpbuPJM08uXbtD/55tCQgMpl7NSujq6jBi4nwO/nuGBnWqAPDWL4Bd+/5lxbzxACj46Ju5Mv6buUKhSOYbftJv7PKHKHtRU1OjdrXy1K5WntCwcF689MbLxxcTY0PyWedK83x8ZVydWLl+OxERkVy7eZ8KZVzw2LYPC3MT6lSvkOw2Fcu6MGPBamJj47h2816CnlORvaSaICkUCvLlzUVQcAghoaHExMRw9ca9bxWbECKdeb9+y9Ubd7l8/S7Xbt7D0FCflk3TPqYwIDCYCTOXMnXMALS1tLCyNFe9V6NyGZ57egEQERHJqCkLGda/C6YmRgCYm8V/M7e1yY3ny/hv5uZmJrx4/209NjaOVz5vMJfJaMVH9HRzUMS+AEXsC3z2tibGhnRp15TugyZgoKfLlDEDcN+yR5WET5+/ilt3H+Hl7UunvqP5tX8XnIvaU7l8STr1HY1VTjMmj+qf3ockvhOpJkj9hk3lweNnFLErQNmSTvTv0VaeMBHiO9bFbSxlSzpRtpQTbt1bY26W8u2DxKKiohk9ZSE9OzWnUP68REZFceDIGRrWrUpEZCSXrt2hQZ0qxMXFMeW3FdSuVp4yHz2aXbGsC9du3qdSOVeu375Ph1YNKVq4AMEhofgHBPHS6zWO9gXQkzlnRDpqVLdqgocIfunXSfXz6CE9k92ma7umdG3XNKNDE1lcqglSm2b1KenimOZBnEKIrO2frUtRU/uy+czct+7lweNnrN+0mzXuO4mNi6N21fL0HDyBgMBgalQpS43KZfjnyGlOnL2Czxs/9h48AcC0sQNp2qAGk2cvp0PvUZQtVZySzo4oFAqG9e/CwFEz0dTQYFw6PLkkhBDpIdUEqUqFkty885DTF66hACqVc8XJ0e4bhSaESG/hEZEsXrWJU+evoEBBpXKuDOjVDt0cn56puHuHZnTvkPQp1i7tmiR4/VPtyvxUu3KybUwbOzDJsgplXGSch0hRZFQUu/Ye5a1/AP17tCU8IgKf137kz5cns0MTP7hUv0ruO3SSyXOWo66uhrq6OpPnLGf/4VPfKjYhRDpbsHwjmpoaLJ87nmVzx6Glpcm8pRsyOywhUjRt7koCg4I5e+E6AJGR0cxamPaHCoT4Uqn2IG3ZdYDVCydh/H6W3FZN6zJw5IwUvx0KIbK2ew+fsnH5DNXrwX060LHv6EyMSIjUPXzygsmj+nP20g0AjI0MCAuPyOSoRHaQag9SbFycKjmC+BMzNi4uw4MSQmScoOB3qp+DQ0IzMRIhPk1LU4N3oWGqCR4/zGskREZLtQepiF1+5i/bQOtm9QDY+tch1Qy5QojvT+tm9egxaIJqDpjDx8/RuU3jTI5KiJT17tKS/sOn4+sbwOgpC7l49TaTR7lldlgiG0g1QRrStyO/r/yTHoMmolAoqFzOlV/6dkxTw8kVtjQ00GP+Mneu336AkaE+E4f3BYWCuUvW4/nSB00tDcYP60NB27wEBoUwbvpi/AOCqF+7Eh1aNgTgr/1H2bb7EPp6ukwZ5YalhdnXfwpCZBON6lYlb+6cnHk/nmPMLz1xLlY4c4MSIhUVy5Ygf748nL98C5RK+nZrTd48VpkdlsgGUk2Q9PR0GTWkB6O+oOHkCltaWZqDQsHG5TPwfOWDibERgcEh9OzYnEIFbNi2+xAe2/Yxflgf1nrsomrFUjT9qTqd3cZSpXxJ9PV0cd+yB48VMzl1/ipL1mxh0sh+X3joQmRPLk4OuDg5qF6/eeuPpblpJkaU/azccuyr2+jVuno6RJL1rfhjG727tOTnhjVVy35f4cHA3u0zMSqRHSSbID1++iLZleOUSjZu3ZOmmUWTK2x57eZ9Jo3sh0KhUNVfsjAzwcLMhIDAYF56+WBf0BaAsxev07h+dTQ0NHAqYse5SzcwNNDHvqAtOjrauDg5MGfRus88XCGyp4UrNia7PC5OydmL19m2bu43jkiItDl76Tq9u7RUvfZ+/ZZ/T16QBElkuGQTpOET5ye7skIRPzfS5/pQ2PLy9TtcvHqLsdMXYV/QlhGDuqGhrs6NOw9xGzoVV2dHBvaKrxXlHxCkKo5rY52Lt36BREfHYGMd37VqbmpMbFwcEZFRSQptSmFLIRLST3F2agWjf0l+NmEhMtPPnYagUMQnRBXr/39oR04L888qjyPEl0o2Qdq5IfkE6Ut8XNhy8epN6OvpsW7RFIZNmMfJs1eoUbkMzkXtOfb3WjZs+ZsZ81cxdmjv+Fo5yg+FLeNQqClAQTKFLZPuUwpbCpFQ9w4/Z3YIQnyWD3+HBo+exYLpIzI5GpEdJXnMf+fef7l552GqG71+48dq9x3ExMamul7iwpZmJka4FCuMmpoapVwc8fJ+o1pXU1ODVk3rqua6MDUx4qXXawA8X/qobsW9eOUDgK9fAJqammhraSXdsRBCZemazcxcsIYnzzyTfT8oOIQ/Nu1mwIgZn7ymhfjWmn009uiDA/+ezoRIRHaTpAepXCkn3LfsZcmazbgUK0yeXJZYWpgRFByCl48v9x/+R2RUFJ1aN0JDXT3FhhMXtoT4UiVHT1+kZZM6XL5+l+aNarFr37842hfAvpAtx05fIl/e3ED8kwvXbt3H1iY3t+89pmPrRujp5mDl+u1ERERy7eZ9KU8gRBr0696G2/ces/KP7bz0eo2+vi45LUwJCAzBPyAIPb0cNG9UiwXTR6Cu/mV12oTIKGs9dlG1QinV67i4ONZ6/EW9mpUyMSqRHSRJkHJbWTJiUDf8A4K48+AJLzy9efDkOabGhthY56JaxdJpqoGTuLAlwNypw5i5YA079xyhdIlilC/tzHNPb+Yv24DPGz/0dHUYN7QPEF9Nedz0xfy17ygN61ZRjUfq0q4p3QdNwEBPlyljBqTnZyHED6tYkULMmjgEgMCgELx83mBibISVpVn87Wwhshi3YdNQKBS89HpN/+HTVctf+/pRwNY6EyMT2UWKj/mbmhhRuZwrlPuyhlMqbDl3ytAEr21tcrNwxsgk6xkZ6vP7zKTLG9WtSqO6Vb8sKCEExkYGCWbIFyIrGju0NyiVDBw1k24f/S3JZWlOLiuLTIxMZBepzoMkhBBCZIZcOc0BWDxrNDktZUJg8e3JgAMhhBBZ1lv/QDq7jaF55/hbxD5v3rJt96FMjkpkB8kmSBGRUcQlU5TW+/VbIiIiMzwoIUT6evz0BS9eeidZ/u/JCzx68jwTIhIibeYsWsekEW7ovZ/Ly9LclL2HTmRyVCI7SDZBWrxqE+feP27/sTv3HrNkzeYMD0oIkb4WrvAgLi7ppKkOdvlZtGpTJkQkRNpERUVja5Nb9VqhUBAZGZ2JEYnsItkxSLfuPWRo/85JlteqVg6P7fsyPCghRPoKfvcuwR+ZD/LksiQoJCQTIhIibfLmseLilVsoFBAaGsbKDduTPZdTklqB85der5k4aynhEZF0bNWQejUr4e3jS5uew8n3vhxWzarl6Nymcbofl8j6kk2QYmOT3l77IDIyKsOCEUJkDAUKwsIj0M2hk2B5aFg4cbFSjkdkXcMHdmXKbyt48t9L6rbsi2vxIowf1jtN2/oHBKVa4Hzhio10bdcUl2KF6dBnFJXKuQLgaF+AZXPHZcjxiO9HsrfY7Avm4+9/klab3r3/GAXfT/oohPh+NKhThbHTFuHrF6Ba9sbXj7HTFlG/lky4J7IuM1NjFkwfweGdKzi8cwW/zxyJuZlJmra9cOVWggLn5y5dV70XGxvH+cs3cSlWGD09XWysc3H1xj0AjGQaDEEKPUgDe7XHbdg0jp66iJOjHUqlkpt3HvHmrT9L54z51jFmeyu3JE1WP1ev1tXTIRLxvWrRuDahYeG06TEMIwMDlCgJDn5H+5YNaNu8fmaHJ0SK9h8+lezyn2pX/uS2fv6BKRY4DwoJwdjQQDX4O74oegB2BWx4/PQFXfuPQ08vB0PdOmNr8+nJkcWPJ9kEydjIgPVLp/LvyQs8fP+ES/1alahVtRyamjJ1khDfG4VCQZe2TWjfogGe7+sZ5s1jJdezyPJOnL2c4PXd+0+oVql0mhKk1AqcK1AQ99F7cUolCjUFlhZmjBvWhyJ2+dm86x9mL1rH0jljk21++9+H2bHncHzbSrlV/aNJ8X9HDQ0N6taoSN0aFb9lPEKIDKSpqSFlGsR3ZdaEIQleP332ki27DqRpWwszE27fewwkLXBuZKhPyLtQ3oWGoa+ni+dLH8qVKo66uhrORe0BaFK/Blt2HUyx/RaNa9OicW0AYmJiqNygy+censjCkk2QFq7YmOpGg3p3yJBghBAZo07zXkByNdeUgIJDO1Z844iE+DLWuXNy8eqtNK1bxtUpSYFzj237sDA3oU71CpQv7cy1W/cp4eSA5ytvXIsX4fDxc7gWL4KpiRGnzl3Bwc42Yw9IZFnJJkj67+/JCiF+DOuXTv/0SkJkQR9/YY+JieXug6dYmJumaVsTY8MkBc7dt+xRFWge3LsD42cuYfm6rfTt1ho93RxYWpgxdvpi/PwDMTM1ZvzQtD0xJ348ySZI3Tv8/K3jEEJkoA91rRK7fus+h4+fY9iArt84IiHSJuEXdgWN61WjRpUyad4+cYHzX/p1Uv2cy8qCVQsmJljfuag9y35LfsyRyF5SnAfp4tVb5M1jRZ5clsxYsJq7D55SrEghBvRsh55ujm8dpxAinTx49B+Hjp/j3xMXUCqV1Ksp4wxF1iVf2EVmSTZBWrTqTy5euUVsXCyVy5ckLjaOoW6dOXz8HAtXbGT0kJ7fOk4hxFd47unFoWPnOHz8HEqlkgplnNHU1GDLmjmoqUnNapF1hYaFs3jVJk6dv4ICBZXLl6R/z7ZJJj0VIr0lmyCdOHOJzWvm8PqNH217Dmfn+gXktDSjWJFCdOw7+lvHKIT4Su16jaBJ/RrMnTKUvHni54W5fnuMJEciy1uwfCM5dLRZPnc8ANt2H2Le0g2M/bVXJkcmfnTJJkg5dHTQ1tLCxjoXVpbm5LSMr12joaGBpobMmyLE92bsr705cuIcQ8bMpqSzI+XLOBMTE5vZYQnxSfcePmXj8hmq14P7dJAv6uKbSDbbiVMqefyfJyiVaGpqqn4GiIqO+aYBCiG+Xv1alahfqxJBwSEcPXWRrX8d5MVLb8ZNX0yDOlUoV6p4ZocoRIqCgt9hZKgPQHBIaCZHI7KLZBOkyKgohk+Yp3r98c+K5KZSEUJ8F4wMDWjWoCbNGtTkzVt/jhw/z8r12yVBEllW62b16DFoAnWqVwDg8PFzdG7TOJOjEtlBsgnSrg0LvnEYQohvzdLclHYtfqJdi5/StH5wSCgzF67B86UPRob6TB7lxs69R9j9z3FM3hf3nDiiHwVsrTl1/ior/tiGhro6Y3/tRaECNkRERjF59jKee3pT2rUYg3q3R6FQJLuuEB80qluVvLlzcubCdQDG/NIT52KFMzcokS3IgCIhRJrcvveIlk3qUMLJgUWr/sRj+z5y6GjTq3OLBPPMREfHMHfxetYunoyXty+zF61j5fwJ7Np7hFxWFkwbO5AhY2Zz6eptShQvkuy6QnzMxckBFyeHzA5DZDOSIAkh0qRCGRfVz06Odhw9eREbayuM348N+eDO/ccYGxlgamyEkYEBDx4/I+RdKGcuXqd1s3ooFApcnBw4e+kGWlqaya5roK/3jY9OZFXnLt3gj0278fMPTFAQdsf6+ZkYlcgOJEESQny2K9fvUryoPYFBwXhs28eytVsp6eLIoD4deOsfiI11LgDU1dWwzp0TP/9A/PwDyfd+eT7rXDx++iLFdRMnSFI1/dNWbjn21W30al09HSJJX9PmraRzmyYUK1IIDXX1zA5HZCMZliAlN17B0ECP+cvcuX77AUaG+kwc3hcdHZ0k65maGBEYFMK46YvxDwiifu1KdGjZEIC/9h9l2+5D6OvpMmWUG5YWZhl1CEKIZDx55smla3fo37MtAYHB1KtZCV1dHUZMnM/Bf8+go6OdIIlRxilRKBQoUBAXF788TqlETU2BQqFIdt3EpGp69mWdKyctm9TJ7DBENpRhs8R9GK/gvnw6he1s8di+j137joJCwcblMxg5qDsmxkbJrgew1mMXVSuWYv3Sqfxz5DQvXnrjHxCE+5Y9rFk4iRaNa7NkzZaMCl8IkYyAwGAmzFzK1DED0NbSwsrSHOvcOTE1NqJG5TI89/TC3MyEF6+8gfiyRa983mBuaoy5mQme75d7vvTB3NQkxXWFCA0NIzQ0jCoVSvHPkdOq1x/+CZHRMqwHKbnxCtdu3mfSyH4oFApVt3py6wGcvXidxvWro6GhgVMRO85duoGhgT72BW3R0dHGxcmBOYvWZVT4QohEoqKiGT1lIT07NadQ/rxERkVx4MgZGtatSkRkJJeu3aFBnSoULVyA4JBQ/AOCeOn1Gkf7Aujp6VKxrAvXbt6nUjlXrt++T4dWDVNcV4jazXujUKim4ANQvVYo4Mw/7pkXnMgWvskYpA/jFS5fv8PFq7cYO30R9gVtGTGoW4J7yh/WA/APCMI6d04AbKxz8dYvkOjoGGys48skmJsaExsXR0RkFDraWgn2J+MVhEh/7lv38uDxM9Zv2s0a953ExsVRu2p5eg6eQEBgMDWqlKVG5TIoFAqG9e/CwFEz0dTQYNzQ3gA0bVCDybOX06H3KMqWKk5JZ8cU1xXi7AFJgETmyvAE6ePxCotXb0JfT491i6YwbMI8Tp69Qo3KZZKsB8SPQ1B+GK8Qh0JNAQqSGa+QdJ8yXkGI9Ne9QzO6d2iWZHmXdk2SLKtQxiVB7zCAtpYW08YOTNO6QqTm1LkrVC5fMrPDED+4DE2QEo9XMDMxwqVYYdTU1Cjl4oiX95tk1wMwNTHipddrChWwwfOlD4UK2GBooMfte48B8PULQFNTU7W+EEKIH0enfmOS/QKsjFMSGRUtCZLIcBmWICUerwBQqZwrR09fpGWTOly+fpfmjWolux5AxbIluHbrPrY2ubl97zEdWzdCTzcHK9dvJyIikms378u3TiGE+EEN7tMh2eUKhQI7mW1dfAMZliAlHq8AMHfqMGYuWMPOPUcoXaIY5Us7s9bjryTrrZw/ga7tmjJu+mL+2neUhnWrqMYjdWnXlO6DJmCgp8uUMQMyKnwhhBCZyLV4kcwOQWRzGZYgpTReYe6UoWlaT0dHm99njkyyvFHdqgnKGgghhPjxLF69if492uI2bFqyc2Mtnj06E6IS2YnMpC2EECLLKV/KGYDWzep9VTupTS780us1E2ctJTwiko6tGlKvZiWUSiVrPXZx9ORFLC1MmTK6P/oy9cQX+55neJcESQghRJZT0sURgCoV/j8YO+RdKHq6OVBTS9scxx8mF/ZYMZNT56+yZM0WJo3sp3p/4YqNdG3XFJdihenQZxSVyrnyyus1Zy/eYMOy6Xhs38vGrXvp07VV+h6c+C5IgiSEECLLOXXuCnq6OXB1jk+UFizfyLbdBzEyNGDOpF8o6lDok21cuHIrxcmFY2PjOH/5JhOH90VPTxcb61xcvXGPx/+9wLmoPerqargUc+C3JeslQcpivlWvlCRI6ex77k4UQoisYsOWvcyaMBiAG3cecujYWTavnoPPm7fMX+bO6oWTPtmGn39gipMLB4WEYGxooJq5PX5C4gD8/AOxK5gPgHx545eJ7ClbJ0gvT08iOsz3q9rQ1LXAutKEdIpICCGylsz6fzI8IgJTEyMANu/4hzY/1yNvHivy5rFi7pINaWsklcmFFSiI++i9OKXy/YTEHxVVjosvqpyStFRt0NS1SFusqUjcRkZ8ic6oL/cZEeu36kTI1glSdJgv0e+8MjsMIYTIsjLr/0k1hYKHT54THPKOKzfuMHJwNyC+OoKWlmaa2rAwM0lxcmEjQ31C3oXyLjQMfT1dPF/6UK5UcYKC3qmKKr94FV9UOSVpqdogX6C/X2kb6SaEEEJ8Q/26t6Hf0Kn8MnYOg/t0xMjQAIAtuw5S1tUpTW2UcXXi0ZPnCSYX9ti2j0PHzqKmpkb50s5cu3Wfd6FheL7yxrV4ESqWdeHG7QfExsZx7eY9mZA4G8vWPUhCCCGypnKlivPP1mXExMaQQ0dHtbykiyO2eXOnqQ0TY8Mkkwu7b9mjmldpcO8OjJ+5hOXrttK3W2v0dHNgVzAflcuXpFPf0VjlNGPyqP4Zcnwi65MESQghRJakqamBpmbCP1MOdvk/q43Ekwv/0q+T6udcVhasWjAxyTZd2zWla7umn7Uf8eORW2xCCCGEEIlIgiSEEEIIkYgkSEIIIYQQiUiCJIQQQgiRiCRIQgghhBCJSIIkhBBCCJGIJEhCCCGEEIlIgiSEEEIIkYhMFCmEEEJkc9+qAOz3RHqQhBBCCCESkQRJCCGEECIRSZCEEEIIIRKRBEkIIYQQIhFJkIQQQgghEpEESQghhBAikR/+MX+lUglATExMkvdiYpXExH5d+4pYZYK24+Livq5Bksb6vbSZke0CqKuro1Aovrp98X1L7Zr+Xq6V76VNyJj/Jz/4ka7p1M5L8f34+JxUREVFKjM5ngwVERFB9SY9MjsMkQ5O7fsDDY0fPqcXnyDX9I/jR7qm5bz8MXx8Tv7wCVJcXBxRUVFf9E2lQ59RbFw+I13jyYg2M6rdrNbmj/RtU3w5uaZ/nDZ/pGv6S8/LrPY7+dbtZrU2P/79/RipeyrU1NTQ0dH5om0VCkW6f7vJiDYzqt3vpU2Rvcg1/eO3+T360vPye/qdfC+xplebMkhbCCGEECIRSZBS0bxR7e+izYxq93tpU4i0+p7O6e8lVrmmv8739Dv5XmJNrzZ/+DFIQgghhBCfS3qQhBBCCCESkQRJCCGEECIRSZCEEEIIIRKRZzOTERwSysyFa/B86YORoT6TR7lhamL0VW2+eevP3CXr8Xzpg6aWBuOH9aGgbd50idfbx5c2PYczf+owXJ0dv7q9ivU7qmJzLlaYX906f3WbALfuPmLukvXExsZRv1Yl2rX4KV3aFeJT5JqWazqrye7nJGTMeZme56QkSMm4fe8RLZvUoYSTA4tW/YnH9n0M6Nnuq9pUKBT07NicQgVs2Lb7EB7b9jF+WJ90iXfJms3kzWOVLm0BWJiZsmHZ9HRrDyA6Ooapc1cwd8owcuW04MVL73RtX4jUyDUt13RWk93PSUj/8zK9z0lJkJJRoYyL6mcnRzuOnrz41W1amJlgYWZCQGAwL718sC9o+9VtAly/dZ+4uDgKF0qf9gCMjPTTra0PLl27jYNdAaxz5wQgf7486b4PIVIi17Rc01lNdj8nIf3Py/Q+J2UM0idcuX6X4kXt06WtG3ce0qhtf/577kXLJnW+ur3Y2DiWrt3y1d86EvPzD6Tn4En0HDyRG3cepkubXj6+5MihzfAJ8+jsNoarN++lS7tCfC65puWazmqy4zkJ6X9epvc5KQlSKp488+TStTs0qlc1XdpzLmrPsb/X4lzMnhnzV311e/sOn6SMazFyWVmkQ3T/N23sIBbPHkWLxrWZOGtpurQZFh7O46cvGDu0N8MHdGPu4vXp0q4Qn0Ouabmms5rsek5C+p+X6X1OSoKUgoDAYCbMXMrUMQPQ1tJKt3Y1NTVo1bQuZy/d+Oq2Tpy5xOnz1+gxaAJnL15nzuI/ePLM86vbdS5qj7aWFrWrlefduzAiIqO+uk1zUxPy57PG0EAPx8IFCAwO+eo2hfgcck3LNZ3VZOdzEtL/vEzvc1LGICUjKiqa0VMW0rNTcwrlT58nAHbt+xdH+wLYF7Ll2OlL5Mub+6vbnDtlmOrnKb+toEHtyl/9xMKZC9ewsc5F3jxWXLlxF0tzU3S0v/7CLVvSibUeuwgNC+fZi1fktDD76jaFSCu5puWazmqy8zkJGXNepvc5KQlSMty37uXB42es37SbNe47AVg5fwI6Otpf3GYJpyLMX7YBnzd+6OnqMG5o+jxZkN5yW1kyd8l63vj6xz8mOjx94jQzNaZHx5/pNWQSyjglY4f2Spd2hUgLuablms5qsvM5CRlzXqb3OSm12IQQQgghEpExSEIIIYQQiUiCJIQQQgiRiCRIQgghhBCJSIIkhBBCCJGIJEhCCCGEEIlIgiSEEEIIkYgkSEIIIYQQiUiClEmio2NY7b6DTn1H07HPaIaOn4uXzxuadRrMwyfPv6jNqzfuMuW3FekcqRAiLeSaFlmNnJNfR2bSziRzl6wnOiaG1QsnoaWlyc07D9O1Fo8Q4tuSa1pkNXJOfh1JkDKBz5u3HDt9iV3uC9DS0gSgeFH7JOv1GzaV1s3qUbVCKQBq/9yLDUunYWlhxqzf13D52l00NdXp0rYpefNYMXnOCsLCI+jUdzTDB3ajcCFblqzZzLlLN1AqlXRo1ZDG9apx9cZdtu0+jImxIfcfPWXJnDHMX+aeoL36tSp9089EiO+ZXNMiq5Fz8utJgpQJHj/1pICtNbo5dL5w++ccP32J/VuWEhUdQ2RkFCbGhvTs1JyrN+8xbmhvAP7YtBttLU02rZpFVFQ0nd3GUqlsCQBOnbvCjPGDGD6wKw8e/ZekPSFE2sk1LbIaOSe/niRImUX55SXw8tnkwcGuAONnLqV9i58o6lAo2fVOnbtKyLtQzl26AUBUdDQ+b97Gt5E3N5XLl/ys9oQQqZBrWmQ1ck5+FUmQMkHB/Hl58uwlYeERqWb3ChTExMQmWa6jrcXvM0dy885DlqzZTP581gzr3yXJekqlkgE926pO0A+u3riLuvr/x+entT0hRPLkmhZZjZyTX0+eYssEuXKaU6W8K3OXrCcqKhqA+4/+4/zlmyhQoIyLA8DM1Jgbtx+gVCo5cuI84eERAHj7+OLl84biRe3p1LoxZy9eB8DK0hyf129Rvv/WUKlcCTZs2UtoaBgAXj5vko0npfaEEGkj17TIauSc/HrSg5RJhg/sxmr3HXTtPw51DXUszU0Z0rcjlcu74r51L1PHDKBt8/qMnvo7F6/eplHdqtgVzAdAaFg4i1b9iX9AMJFRUQzq3R4AJ0c7oqKjaddrBIP7dKRjq0a8exdG1wHj0dHRpqCtNeOH9UkSS0rtCSHSTq5pkdXIOfl1FFFRkV9+k1IIIYQQ4gckt9iEEEIIIRKRBEkIIYQQIhFJkIQQQgghEpEESQghhBAiEUmQhBBCCCES+R8dcRJCAPMqRgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 583.3x300 with 3 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Three bar charts over cluster counts two to six. BIC rises with the count, AIC falls with it, and the silhouette score falls sharply after the smallest count and hovers near zero at the larger ones."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, axes = plt.subplots(1, 3, figsize=style.FIGSIZE[\"triple_h_tall\"])\n",
     "\n",
@@ -538,10 +989,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "575cec26",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 13,
+   "id": "12dc2c30",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.256905Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.256736Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.267109Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.266581Z"
+    },
+    "papermill": {
+     "duration": 0.023309,
+     "end_time": "2026-09-08T23:45:12.267939+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.244630+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "BIC is lowest at **2 clusters** and the silhouette score is highest at **2**, while AIC keeps falling out to **6**, the largest count fitted."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "bic_choice = int(selection[\"BIC\"].idxmin())\n",
     "aic_choice = int(selection[\"AIC\"].idxmin())\n",
@@ -557,8 +1035,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f28aa7b9",
-   "metadata": {},
+   "id": "2d0d721b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008466,
+     "end_time": "2026-09-08T23:45:12.288508+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.280042+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "When the criteria disagree, the choice is made on what the model is for. AIC targets\n",
     "predictive likelihood and keeps buying clusters as long as they raise it, and the last two\n",
@@ -575,9 +1061,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f882b37d",
-   "metadata": {},
+   "execution_count": 14,
+   "id": "b82e6ed3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.310910Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.310729Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.316894Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.316280Z"
+    },
+    "papermill": {
+     "duration": 0.018432,
+     "end_time": "2026-09-08T23:45:12.317726+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.299294+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "N_REGIMES_SELECTED = 2"
@@ -585,9 +1085,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd083a69",
+   "id": "e5cc3d01",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.015111,
+     "end_time": "2026-09-08T23:45:12.340789+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.325678+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## What each cluster count partitions\n",
@@ -601,9 +1108,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "593d2a26",
-   "metadata": {},
+   "execution_count": 15,
+   "id": "52e05cc4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.367270Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.367082Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.371235Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.370417Z"
+    },
+    "papermill": {
+     "duration": 0.016881,
+     "end_time": "2026-09-08T23:45:12.371703+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.354822+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def decade_ticks(dates: pd.DatetimeIndex) -> tuple[list[int], list[str]]:\n",
@@ -617,9 +1138,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "baca3c3c",
-   "metadata": {},
+   "execution_count": 16,
+   "id": "859f03db",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.391017Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.390852Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.399469Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.398588Z"
+    },
+    "papermill": {
+     "duration": 0.017468,
+     "end_time": "2026-09-08T23:45:12.399984+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.382516+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def draw_swimlanes(ax: Axes, rows: np.ndarray, n_rows: int, cmap: ListedColormap) -> None:\n",
@@ -642,10 +1177,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "15eb7058",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 17,
+   "id": "2763b7a0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.420158Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.419981Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.741391Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.737307Z"
+    },
+    "papermill": {
+     "duration": 0.335205,
+     "end_time": "2026-09-08T23:45:12.742207+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.407002+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAJZCAYAAABSlMqRAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaQpJREFUeJzt3Xd4FFUXx/HfJgESmvTepEgXpBdBUWwgIoKigoCCCFhAUKQICFIURcSXJoIixYaoqIhdERQVBEFApUnvvaQsSeb9I2RNJju7M5u2Wb+f5+EhO3Pn3nPu3Jk97C5Zl9sdZwgAAAAeYdkdAAAAQLChQAIAADChQAIAADChQAIAADDJ0QVSfHy8CpWrp/6Pj/K6f9c/e1WoXD1NmjJLkjRz7iJdXqe19h88nCXxTZoyS4XK1dOuf/ZmyXjBYs++AypUrp7GT56epeO9MG1Ohvc9YuwLqtXoBsXGxmVov6t+WqtC5eppwVsfSMr6tWnXNbfcrR59hwR0bPsuvXVVy1szOKLstWffAd1yRy+VqdZUjz7xTHaHk+kWv7dMhcrV0/erfs7uUIAsF7QF0s9rN6hQuXoqU62pomNiMqTPuzvfqsXzXlbZ0iUzpL+s8szEl1W32S3ZHUbQeGDAULXv0jvD+9224x8VKldPq35a69n2SN8eWvjaS4qMzJPh46UUrGtz5kvP6pnhAz2P23bobvkPkv+CF16eozW/btDwIQPU4547vK6ZYJRT4gSCSdAWSMuWf63GDa7Uxfh4ff3djxnSZ5HChdSiaQO5XK4M6S+rHDl2IrtDCCpHjmbOfBw5ejzNtjKlS6rhVXUzZbyUgnVt1q5ZTZUvr+B5/F9fi7v37lfxYkX0aL+eatzwSq9rJhjllDiBYBKUBVJiYqI+Xv6V7rjtZl3dvJE+Xv61Z9/K1b+o+fV3qFLtVnpq9PNpjn3/oxWq37K9qta7VlNnvJ5qn/ktr7rNbtGTT0/S8GdeUPUG16tus1u0cvUvnvY//vybWt/cVUUrNlChcvVUqFw91Wp0Q5oxT506o4FDx6lGw7aqcuW1GjrqORlG2l8v1b5L71TH9398lAqVq6f4+HhJ0ux5i1W78Y2qULOluvZ8RDt37VH7Lr319pKPtW//wVRvJx44eETd+zyuCjVbqmmbTvr865WefguVq6dXX39LfR8drvI1WmjfgUNa+eMvanF9Z5Wp1lTXtb9X3678KU18hcrV05T/zVXfR4erUu1WuuWOXtqz74CeHDlRleteozbt79Xe/QclSSdPndaYCVPVtE0nlanWVDfd3lPbd+5OezIlffDx5ypUrp5eX/ieJOn06bN6eMhoXV6nta5qeavnbabktle1vFXlqjdX+y69tWHjllR91W12i378eZ1+/HldqrdPJenQ4aPq+dATqlDral1/a7dUb1et+Op7tWjbJWluez2qw0eOpep38XvL1OGuPpKkDnf1UaFy9byeIydzJEm/rPtdbTt0V7nqzdWu8wOWc+R0bfo6/8nc7ot69IlnVKl2K9Vo2FZDRkzQufMX1Kb9vWp2XSdJ0sWLF1WmWlNdXqe1EhMTJUnNruuke3sP8sRxc6eentz37T+ot5d8rELl6mnxe8skSX/+vUN33vewKtS6Wlc2v8WzXZISEhP08ozXVa9FO1Wr30bvfbA8TZzJbzd+9OmXatf5AVWq3Ur9Bj2tPfsOqGvPR1ShZkv16vek3O6LnmM+/OQLNb/+DpWr3lwd7uqjTVv+8uxr36W3ej/8lF6e8bqqXHmt3v9ohQzD0IK3P1DDVh1UsfbV6vvYCJ09d97rnE2aMkt1mt6sy+u0Vt/HRujY8ROeflevWadjx0968ve2ZhISEvTS9Hmq0/RmVa13rYaNmeyJvf/jo3Rd+3v1xqIlanxNR11ep7VemTXf65qwmqOOd/dV+RotdEe3fjp95qynzcoff9F17e9V2Sua6br29+qHH3+VZL22U4qOifG8Ul2h1tXq8/Awr28r+8pt7W+b1K33INVo2FaVarfSEyMneq6bSVNmqWq9a/XJim909Y13qULNlho2ZrKtfvs/Pko33Haf3n7/E9VqdIOmTp/nd76AjBCUBdJvGzbrwKEjuvG6q3XT9a31+dcrFRsbp30HDqlrz0flcoVp4jNP6uLFeNNxf6jPI8NUtnQpPTtqiE6dPuN3rNfmv6Oz585p4ID7dfLkKY0Y+6Ik6fyFaHXrPUiGYei5sUNVsUJZ1apRTa+88Eyq4xMTE3Vf38F6d+mn6t3jLg3s30s1rqjs+JWAnbv2aNiYyWpQv47GjhykvHmjFJErQk8PfVhXVL1cxYoW1qK5U/XQA/fq4sWLuqvnI9qwcYtGPvmwmje5Sj0fekKHDh/19Dd+8nTFxrk19blRKlemlPo9NlJyufTcuKdUu+YVinO7vcYx4YUZKlWyhHrcc4fW/LpBja/pqITERN3fvYs2bNyi/126mSckJGjdhs3q1a2Lhg56SH9s+UtPjJyYpr/NW7fpkSFj1KtbZz1w310yDEMPPjpcn37+rQYNuF+dO96sx4aO1e+btupCdLQeGjhSZUqX1MQxT6pMqRJpCs1pz49S4UKXqWb1Klo0d6o6d7zZs2/xe8tUq0ZV9bznDv32+2b9b/abkqRff9uoex8YpHJlSmniM09q376DGjTs2VT9tm7ZRH16dpUkjXzyYS2aO9XyXNmdo91796vTPQ8pLCxpvbpcLvXq96TX4tkbq7Vp5/xL0ttLPtbCdz5Un55dNaBPd8XExip3rlxq3aKx/tq2S6fPnNXmrduUmGjo1Okz2rbjH50+fVZ/bdulq5s3ShPPm69OkSS1atFYi+ZOVeuWTXTs+Andemcf/bltp8aOGKiO7W7Q5RXLe47Zu++gfvltox59qKfCwsI0dNRzSkhI8Jrv48PGq8Mt16tpo3p65/1P1PrmrmrRtKGubtFYH336pVZ8+b0k6duVP+n+/kN1RdXKev7ZYTpx8rQ6du2royle3frym1Va+vHnGjtykK65uok++vRLPfbkWDW8qq7Gjxqi1T+t9foZuedemqXJL7+qrne014gnBuiLb35Qj4eeUGJiop4e+rBqVq+iwoUu8+Tvbc1Mf3WBxj33itrf1EbDhwzQW+8t05z5b3vGWL9xi9778DMNeLC7ihUtrLHPvaLjJ076XQ+SNOipZ3Xj9a3U/ubr9O3KNZ5idOtf29Wl+wDly5dXL0wYoaioKHXu3l9//r3D1toeMmKiXpn9pjrdeqNGPjFA1a+o7PVtZV+5/fn3DuXPn09PD31E17Zqprlvvqulyz73HHv8xClNmjJLvXvcqerVKmv2vMXauPlPW3O25c9tenHaHA0d9JA6dbjJ1lwB6RWR3QF489HyL1W5UgWVLVNK17ZqpmFjJuvbH9Zo2/Zdio2L0/QXn1GD+nV0W7u2WvD2v68+LH5vmVwul96YNVklihdVvTo19Onn3/ocq2H9OpoxZZwk6evvVmv1mnWSpB07d+v0mbN6ccIIdbn9Fp07f0Evz3xDbdu0THX8pi1/a/WadRo+pL+eHNg34JzzROZRrlwRypcvr25r11b3d79TklSxfFkVKXyZYmLjdOvN10lKehVty5/b9MrkMbqtfVvFxsbprSUf66vvVqvHPXdIkiqUL6t5M55Trly5JEkFCuRXrlwRat6kgaeNNx3bt9W4px9XQkKCXl/4nqpXq6yXJj2txMREvfr6W/p7xz+SpOLFimr5+/N08NARbdz8p8qXK6O1v21M9eR/+sxZdX/wcdWqUU2Tnx0uSdq9Z7+++m61nhzYVz27dZYM6a33lunTL77VE1c8qKioKEXmya3rrm2hHvemjfO6a1ooKjKPihQu7JmPPfsOSJL6PXCvnnq8n+Lj4zX3zXe1fWdSrHPffFd5oyI1fcpY5c6dS9HRMXpq9PNyuy8qd+6k+SlftrSurF1DktSs8VVq1aJxuudo0bsfKTomVv978RmVLFFMxYoW0b0PDNTuPfutF0IKVmvzp1/W+z3/klSgQL5L56qIet7b2fOE17plE02bNV+/bfhD23fu1pV1aujAwcNa8+t6lS9bRpK8Fkjtb7pWklSubGnP3E+fs0AnTp7S8vdfV8tmDdMcU6J4Ub0172W5XC5t3vq35i9eqmPHT6pUyeJp2j499BH17nGXmjaqpy++WaVe93bWwAH3a8PGLfrsi+/0945dkqRX33hbERERmj5lrArkz6fiRYvorp6P6L0Pl+uRvj0kSRcvxmvxvJdVoVxSPnPeeFuVK1XQ5HHDJJe0fcduLV22QpOfHeYZPzExUa/Nf0eNrqqrUU89Kknat/+QXpk9X5u2/K3mTRqoSOHCOnPmnCd/b2tmzhtvq1WLxho+pL8k6cef12n55996YpOkDxbNUlRUpE6dPqtxz72iXbv3qVjRImkXgcmopx5V7x536fCRY3rn/U+0/dJae2PR+7p4MV4vTXpa1apUUoN6tdXsujv0xqL3NfnZYT7X9qlTZ/T2ko/VrWtHjXv6cZ/j+8qtx713qPvdt+uPrX8rOjpGH336pdau36Sunf/9oP4bsyarerXKKpA/v9au36TtO3arXp2afucsOiZWc16ZmCVvdwPJgq5AMgxDy5Z/rf0HDqlU1Sae7cuWf6V8eaMkKdVnIlLau++gChTIr+LF/N9okuXK9e8UFCtS2POybpXKFRWZJ48+WfGNatespq++W62ypUukOX73nn2SpLqXbkCBKlemlJa985rGTpqm2o1vUs9unTXqqUeVP19eL2MmPcE+NnSsHhs61rP9+IlTnp9r16jqKY4kacnCGRr//HQ1u+4O3Xh9K00YNcTrPOaKSJqP8PBwFS5cyDM/YWFhKly4kNyXXnk6e+68+g16Wp9/tVJVK1dUdEysomNiU7068Mai9z2Pk/7Opd17k2J/YdqcVP/r7Pjxk4qMzKMVS9/Q2EnTVK95O93ZqZ3GjXxcJYoXtTWHyflGRESocKGCiotLOpd79h7QhegYXXHVdananzx12usTtd9xbM7Rnj1JhVvTNp1SHX/M5qsFVmvTzvmXpE4dblJ0TKyen/qqXpo+T4Mf6a2+99+jZk2uUq5cEVq7/g9t27FLNa6oooIF8mvNrxt0uOJxFbqsoOrUvMJWjMmx1K1d3ev+iPBwz6upyQWA1auXyfNatGjhS/knnc8iRQpJkif/PXv3q2rlCiqQP6kAvKperaTtKQrPIoUv8xRHyXEeOnJMleq08mxLLo6TnTx1WufOX1C9ujU921L2XT/Fditu90UdOHREBw4dUaXa/45VtXLF1LleOrfFiiTlGhfnfU7Mkueo2KU5inP/u8bzRkV6xqlerbLyRkVqz17/xfg/yfewWt7PYTJ/ua1es06PPDFGhw8fU6MGSYXM2bPn/MTvtj1n9WzMP5CRgq5AWv/7Zu0/cEgvPzdKtS/dpOcueFcrvlqpAX26S5I2bv5T17RsmuatihIliurs2XPas/eAKlUsJ5vvZHhVIH8+9bj3Ds15420tW/6VChbIr/mzX0jTLvkmvHnr32p347U++8ydO0InT51RfHy8IiIidM70GYgWTRvoi4/e1Moff1HnbgN0WcECGvHEAIWFhSsu7t/PA1SsUFaSNGxw/1T/aq9cyXvhKCW9EvXa9EkaNexR3Xpnbz3yxDP6bOnrlu39mTFnob79/ietW7lMlS+voP6Pj9LbSz5O1SbpVZtx6v3wU5ryv7l6eugjqlg+KfYH7rsz1Uvlyf97q3bNanpvwXRt3rpN7bo8IEma/fL4VP2GhaeeD38qli+jLX9u06K5UxUeHu7ZnnyT/rffpHec7T5Z+R330nla+NpLKnRZQc/2WjWqpflsVSD9+jv/LpdL3bverrs736pps+brqdHPq2b1qmrdsokaNbhSW//arj//3qGHH7xPJUoU1acrvlFMTKxaNGuosLC0774nFzop5/7f9b9NLZo2CDgnJypWKKevv/tR585fUIH8+bRh49ak7RXL+TimrHLlzqXpL4715BEREZ6qTZHChVQgfz79vmmrZ5u/vs1rJnfuXCpTqoTKliml0cMe87Tz9g+djFSxQll9+e0qbd+5W1dUvVx/b9+l6JhYVaxQzmucKVUo/+859MVfbv0fH6Va1avol28/VJ48ub1+1imQfoHsEnSfQVq2/GvlyZNbd3fpoMYNr1TjhleqY/sbdPbsOV1WsIAkafzz0/XWko/V97ERqY7t2D7pA9BPjX5Oby35WE+MnBBwHNExMZq34D3dc+dtGvJoH70wfriKFSuSpiirV7emGtSrranTX9dL0+dpwVsfaNiYyTIMQ2VKJb3ilPzWSLUqlys2Lk5DRkzUwKHj9NV3qz39fPbl97qt64N6c/FSbdz0p+Lj4xV+6aZWqWJZHT12QjPnLtLa3zapRdOGqlW9quYvfl9rfl2vHbt267Mvv1epksW85rJn3wG17dBdM15bqO9X/Sy3+6Kn70DFxMQqNi5OX367SlP+N1efrvgmTZsH7rtTHdu3Vd/779a0WW/o7+27dHml8rrumuZa8uFn+u6HNfpnzz4tW/6Vihcvqg0bt+jGjj0098139cu63xV/0XuclSqU1aYtf2nRux/5valL0gM97tKF6Bi9NH2edu7aozW/rtfBQ0cUEZH63weVLj2ZvPbmO1r26Ve2Pytk5d47b1NUZKSm/G+u/vx7hzZs3KLNW7cpf768/66Nn9d5Phxtl93zP2bCVD08ZLTe/2iF/tmd9CpBcoHYukUTrd+4RTv/2auGDeqq0VV1tW3Hbm3YtNXr22vJx1YoX0Y//Pir3vtguXb9s1ddbr9FBfLnU79BI/Xm4qV6ecbrmrfgPadT5UjfXncrISFBDw8ercXvLdMzk6ap0GUFdeft7SyP6dPzbu3dd1CvzX9H/+zZp5Wrf9GFC6l/fUhYWJge7HW3fvt9s559/n96bf47evPtpWre5CpdafEKmbc106fX3Vq7fpPeXfqp9uw7oC+++cH2ZxKHP/OCrrnlbp08ddreZFzSq1sX5coVoSEjJuitJR9ryIiJypUrQvd372IZZ7JiRYvotnZt9daSjzV20jQtfm+ZHntyrNzui2nuYb5yi4mJ0b4Dh7X048/1wIChjuJPz5wBmSWoCiTDMLTss6/UtFH9VB8QbNG0gcLCwrT5z7816+XxOnr8hMZMmKpa1auqerXKnnY3XtdKzwwfqE2b/9LEF2aoQ7u2npfhncobFaWWzRrqo0++1JT/zdVDA0eq9U1d1eeRYanahYeH663Xp+mWG6/R/2a/qUlTZip3rlyKj4/X9W1aqmKFsnr1jaQPGz7ar6euqldby5Z/pYvxF/Xs04M9/TS6qq5KlSyu8S9M10vT56lr51v1yENJ778PeaSP6tWtqQmTp+vNt5Yqd+5cem/hDDVtVF+z5i7WhBdm6Pjxkzp7Nu3/ypGk0iVLqE3r5npt/jsaNvp5Va1cUS9NejqgeUnWv083NWlYTxNemKHfft/s+RBoSslvkQwd9JAKFiigwcOTCtZ5059Xpw43adG7H2nU+Je0/+BhnTx1WlWrVFK9ujU1dfo8PTPxZV3TqplGP/VYmn6fGT5QFcqV0fAxk7Vs+Vd+Y23W+Cq99frLOnX6jIY/84LeXfqp1//B1LJZQ/W8t7N++vk3jZn0cpr/6eZU5csr6KN3XlWe3Lk1dtI0vfbmuzp56rQMw1Dlyyvomqub6tMV3zj+L9h2z3+n227Wvv2H9OTTk/Ttyp80Zthjnld5Wrdsov0HDikyT27VvKKKGl1VV4mJidp/4JBlgSRJk58dpsg8efTkqEn64cdfVaZ0SS17Z47Kli6pEWNf0OL3likqKtL5ZDlw/bUt9frM5/X39l0a+vQkFS50mZa9O0clS3j/B4Ikde54s/734jPatuMfPTXqeX325fc6f+FCmnbDBvfXE489qHfe/0QTXpihG9u00oI5U7y+oiZ5XzOP9eupZ4YP1Oqf12no05O05pf1XtebNxcuRGvjH39qza8b7E3GJbVrVtP7C2fq7LnzemLEBF2Ijtb7C2eqZvWqlnGm9L8Xn1Gvbp21+L1lGj1+qgzDUGxcnJo0qqc6tapr3oL3lJCQ4DO3F8YP1/ETJzVh8nTVrF5V9a+sZTv+9MwZkFlcbndc+v6ZHKK+/u5H3fPAY/rj589VqmRxXYiOVp9HhuvHNeu098+M+b1MAJDSxYsXVaPhDXrr9ZfVtFH97A4H+E8Lus8gBYv9Bw7p4sV4TXxxppo3baCd/+zRylU/69Zbrs/u0ACEoLg4t7rcN0AN6tVWk4b2Pr8DIPPwCpKF2Ng4jRz3opYt/0rnzl9QuTKldMdtN2vwI70z/S0EAP89hmHo/Y9W6LZ2bZUnT+7sDgf4z6NAAgAAMAmqD2kDAAAEg6ArkGLj3Hp59iJ1e2iYuj00TCOenZbqKwRyiuY3dde582n/l0xGSkhI1NjJs9TtoWF6+4MVWrxkub74NukD5IcOH9OAJ1P//qBOPQYFNM4Nd/TVocPp+x9ddmzbucdWjFkxtxlhwJPjU81bpx6DtG3nHp/HpDyHgZi7cKmmzloY8PGS9M4Hn+vZF191dMzKn9alWW+S9Mqct7Tud2e/88m8BnLK+U7p829Wq0f/EXps2HNKSPj31zgs//IHzV241PM4I86X2fIvf9BTz1h/VY4/5nUbiLGTZ2nnpV8tYc45p3C7L2romJd04uTpTB/rqWemavmXP2T6OHAm6D6kPfGlOSqQP5/enDlB4WFh+vK7NRrw5AS9Nef5NL/59r/u2ImT+nbVr/r6g9dS/dZl5Fzd7myf3SFkqMf63pvdIWSLT7/4Qfd2aaebr786u0PJFmOG9s/uENItd+5cmjx2sP+GCFlB9ax64NBR/bp+sz5a9IoiLv1Cu5uua6HPv1mtr1auUfsbWmvAk+N1feum+uGn37R95151vq2tendP+v6pzX/u0EszF+hCdIxKlyym0U/2U5HCl3n6X79xq2bPX6IKZUtp2669crmkkYP76ooqFbVn30FNn/u2jh0/pQvRMep3/126vnXTpBi69NNDPbvo829/1IFDRzXi8T5q2fQqSdKnX6zU4veXKyEhUY0b1NGQAT0sf2eKr/EvXozXjHnvaM3apO8z637Xrbrt5mu1fuNWLVn2lQoXKqi/tu/SzBdHKTJPbsUnJOjxkZMVHx+v3o+N1ugn++mTL1aqQP68uvWma/TosEk6eeqMevQfoQe6ddKHy7/R4SPH1aP/CDVvXE/9H+iqH3/ZoNlvLJH7olvVKlfU00P6KjIyj3b8s0/PT3tdsbFxurxiWV2Mj0+Ty/Ivf9CGTX8qITFRm7ZsU+0aVXTX7Tdr7sKl2rZjj+7vdrvu7HijJOmPrdv1ypzFio6JVZFCl2nIwz1VqULSb+/9btWvevXN95U3Ko9Km772w87c9n5sjO7requubfnv90vFxMZq2uzF2rZzj86dv6BrWzbWw33uTnMuFi1ZrtKlimvdhs0qWbyYHn3wHs1d+IG2/L1D7dq20oDeScfs3ntQL86Yr1OnzypvVJQGPtRNdWpW9bk2nn3xVf2xdbsGj3pBtapX0agnHpIkrVqzXq+8ulg7/tmr/vd3Vcd2bVLFNXXWQhXIn1d97uus71ev1fS5bys8PEzVq1bS6Cf7pfrllq++uUSff71auXPnUoebrlX3u5K+8+rYiVMaNXG6Nv+1Q5UrltXzYx5XRESEPvtqlT5c/o1iYuOUL2+Uxo98VMWLFk76DrIFS/XV92tUtEgh5cmdW8WLJf2Wcat1KUnvf/yV3v3wc11WML8KFyoob556Zqpat2io9je21rMvvqoK5Upr05Zt2rZjt1o0qa/hj/dJ1X7g8OfSrFNJWrbiO61as177DhzWyMEPqmXTq2QYht5852Ot+Hq1DMPQLW2v1v333p6qv2dffFXVq1bSd6vXqk6Nqnq4z9365IuVeueDFZIh1bzicg3qf5+iIiN1y139NX/GsypTqoSmvbpIv6z7Q2+99rwk6b5+IzTmqf6qevm/X8RrtS5mvf6utv69UwcPH9OhI8c9MX2/eq1mvv6uJOmHn37zPPlana89+w5q8itv6MSpMypYIJ+eHtJXFcqVTpXfz+s26dX5SxQfn6BiRQtp0qiBadb5y7MXacGspC+SfueDz7V91x6NeuIh/f7HX5r8yhtKSExQ6ZLFNX7ko5o6a2GadWt1Xx3w5Hjd0raVPl7xndpe00xdO/37xdE9+o/QoH7ddfbchTQ5l7r0+6qmzlqo/Pny6sEenbVj117d13+E5r0yVrWqV9HbH6zQsWMn9ciD92jm6+9q/catuhAdo1rVq+rpIX0VHh6mpZ98pcVLPlOuXOFq1qieBvXrnuqXSy5eslzf/PCLYmJjVaZUcY0b/ojy5Y3yel3tP3hEYyfP1oXoGBW6rIDGDntYpUsW0w139NWCmRNUulRxLVn2pd5eukIXomN0ITpGlSuW1eSxg/XagqWW69rqHJ49d0GTX3ld23ftVakSRXU8C16lQgDc7jgjWP58s/Ino8/AUWm2z5j7lvHi/1433O44o8/AUcYzz083omOija1/bTeaXN/VOHv2rHHi5EmjS89Bxr79Bw23O85498PPjOenvZaqn5/XbjDa3t7b2LbjH8PtjjPeXvqp0f2hpwy3O844dvyEsX1n0vZ1G/4w2t7e24iLizXc7jijYZs7jQ8//cqIi4s1Fr33sdFzwAjD7Y4z1m74w+j7+Bjj7LlzRkxMjDF83FTjy+9We445cfKk7fHnvPmeMW32AiM2NsY4e/as0em+x4zDR44aP6/dYDS5vqvxzcqf0szLnr37jWtu7el5/Py0ucbMeW95xjLPZcM2d3p+/mfPPuOeB58wjp84acTFxRrTZi8w3nznIyM6Jtro2O0RY/mX3xtud5yxd/8Bo/lN9xp79u5P1deHn35ltL+7v7Fn737j7Nmzxk2dHzSGjZ1iXLhwwfh53e9Gq3b3GXFxscbxEyeNG+7oY2zYtMVwu+OML75ZZdzRY6ARExNj7Pxnj3Fdx/uNHbt2G253nPH5N6uM9nf3dzS3I8e/bPzy28ZUscXFxRrrN24x4uJijTNnzxjXduhp/L19V5pzcW2HnsbmP7cZ0dEXjO4PDTX6DBxlnDp1ytiz74DR6Lq7jMNHjxrRMdFGp/seNb74ZpXhdscZGzZtMW7s3MczvtXacLvjPPOT8vGs19824uJijW9W/mTc1PnBNOc05Tm864HBxhffrDLi4mLTzP+x4yeMhm3uNI4cPWacP3/eOHDosOF2xxkz571ldOs71Dh67HjSeenS11i1Zp3hdscZW//abpw5e8Zwu+OMcZNnGi/NnJ90Lpd/ZXTrO9Q4dfq0ERsbY0yaOscYNfEV3+ty3e9G+7v7G4cOHzHc7jjjjcUfeL12Hx/xnPHhp18ZbnecMWriK8YjQ8cbZ8+eNY4eO240aXu359xbrVNfc/zJ598ZI8e/bERHXzAuXLhg9H5slPHHlr9SHTtq4ivG7d0f9ZyvX3/baNx278PGkaPHjLi4WGPS1DnGuMkzDbc7znjqmSnG0k++NNzuOKNH/2FGzwEjjIOHDhtHjh4zburS13M/cLvj/K6LPgNHGV99/2Oa3GbOe8tzfn2dr+iYaOPu3kOMrX9tN9zuOOOHn9Yag4ZPStXXrt17jetvf8DY+vcOw+2OMw4fOeq5Nh8f8Zxnnd/de4jnmAXvLPOc24HDJxrz3/rQiIuLNXbv3ed13fq6r/YZOMp44JGRxvnz59PkeXfvIcbPazd4zTn5z8offzV6P/q04XbHGW++85HRd9AYY+7CJYbbHWc8Nmyi8cNPaz1zGxsbY0THRBudew40vl/9i+F2xxmt2t9nbNrylxEdE23s3X8gTf8bN/9pREdfMOLiYo0BT4wz3l76qeV19dzLrxmTps5Juq/uO2DExsYYbneccc2tPY09e/cbBw8dNprdeI+x/8BBIzr6gnHXA4M99x2rde3rHI6e+Iox/sXZRmxsjHHm7Bnjvn7DPNcJf4LnT1C9giSXS0Zi2v9Ul2gkyhX2778MWja9ShHh4apyeXnlypVLp86c0+69B3Tk+Ak9OWaKpKTP51xesWyavooVLeR59aJV84Z6aeYCxcfH67KC+XX4yDHNev1d7d57UKfOnFV0dIzyXfo+oNYtGsrlcqlOzap654PPJUmr16zXnr0H1XfQM5KSPj9Vq3rlNGPaGX/VmvU6d/6C1qzdKElyX7yow5d+w3LF8mXUqnnab0pPj1/WbdKRoyf0yNAJl8aLV4sm9bVv/2HFud1qe00zSVKpEsWUO5f3tzavqFxRpUslvepzRdWKatrwSuXKFaEra1VTdEysLkTHaPOf21W+TEnVrpH0ikubVk00dfZC7TtwSL9t3Kpmja70/Ku4XJmSnr7tzq23l/JdLpeKFy2sxe8v17YduyVJ+w8eTrMeSpUopiuqJH0hZs3qVVT4sgLKly+v8uXLq6JFCunEidM6c+a8YmPdatMq6YuTa9eoqrKlS2rznzvUvHHS76rxtjastGqe3Laa3381dryljd546yOdj47RTW1apNpXsEA+3XRdCz3z/Ex169JejRvU8ey7svYVKnRZ0tfyXFGlgo6fTPoS2/LlSmnVT+v128at2vzXDs98//TL7+rU/jrPl0GXLV1S23clfVbKal3+9Ovvuvm6lip66Ytky5X999z50qRBXUVG5lFkZB5VKFtKx0+eTvOqiDfe5njVmt+05e+deuDR0ZKSvvH90JHjql7t8jTzmPwb9Vf/skE3tGnuecXrrttv0kODx2nYoN5q1uhKrd2wWVdfur/UrXWFftu4VREREWp8Ve1Ur07s23/Y77qwy9v52n/gsPbsO6RxL8yWJBmGUn27gCT9+tsfatKgrudVrZSvltvRrm0rvbZgqcLCwtTh5mu8ttn85w6f99W7Ot0c8EcfrrqypkZNnK6Y2Fit27BFd99xi9776Avd26W9tv61U/VHPCIpaT0u/eRrbf17l86fj9b+g0ckSZ073KApM97UvZ3bqXWLtL/9vUK50vr8mx+1ccs27T94xHOct+vq+tZN9dy0eZq36EPdcev1aV6pzp8vryLz5NGpM+cUGRmp2Ng4pfwiFG/rOjEx0fIc/vTrRr06dbTCwsIUFRmpYpeuIwSXoCqQqlQqp5279ysmNlZRkf/+rqEtf+7ULW3TvpfvcrmSvnDSMGQYhsqVKak3Z9j//rWIiHDlypVLYWFhWvbZd1rx9Srd362Tet7TUdff3keJXr6LKyIiQoaSthsy1PbaZhr4UPcAsk09vmEYevTBe9IUQus3bk3396Z5Y8hQ/bo19NzoQam2b9+5R+EpvoHdrojwf5dS8ttAVt9l5pJLkkvx8QmpvjzWHF+gc7tt5x49PeF/6tuji265/modPznd67lMHX/qOCIiwmV1hNXMpFwb/pi/KNWbOzveqOtbN9WSZV+qa58n9for4zxP7C6XS888NUA7d+/TawuW6t2PPteUZ59MO054hGQknYvHhj2nq+rW0B23Xq9aNapo9Zr1kqT4BB/nwWJdfvndGkWm83f1JF+7zo5Jcf0Zhu654xbddftNPo+xyk1Kmsfktd6kYV3NefN9/bZxq+rXraEra1+h71avVe7cudS0YV2/sWXEN4f9e76Snkznzxhv+ZZ9omHI72XqSrrOvGnTqokaN6ijTz7/Xl17P6Hpz4/0/OMtmb/7anruTZF5cqtOzar6/Y+/deDQUbVsWl9TZr6pLX/uUNXKFRQZmUdHj53Qw0Mn6r6uHdS3ZxeFhbmUeOkf0QMe6KpDh4/pzXc/1htvL9Pcl5/xFGsxsbHqM3CMbrv5WnW/s71KFCui8xeiJXm/rurVqa75M8bri29+VM+HR+qZpwaowZU1/401Mo+uvbqRnp/2uuLi3Lr1pmtUr4737+f79znJ+hzGJ8Snuecg+ATV/2IrU6qEWjatr2mzFys+IUGGYeizr1bp8NHjns8DWaldo6qOHD2hb1f9Kkm6EB2jU6fPpml37vwFnT5zTpK05KMv1bxRPYWFhWn1L+vVplUTNW1YVzv/2Wcr3pZNr9JnX63W3v2HJEmHjhxP9T9WEr28GmY1/tXNrtKCdz/VhUsX8cHDR23FYKVUyWI6euxkqnhKlSjq+d8pTRrU1dr1m/XH1u2SpFOnzyo6Jlbly5VWXJxbazdsliT9vWO3YlN8e7tTdWpW0/5DR7Tlr52SpO9/XKuoqEiVL1tK9etU15q1G3X8RNIrHH+k+OLZQOY22W+/b9HlFcuq7bXNlJCYqCNHA/9fkOXLlVJkZG59/+NaSdKWv3bqwKGjns8g+VKqRDEdCvD73BITE7V+058qXKiget93hxITEvXPnv2e/WfOntOOXXtVpVJ59b//Lv3y22bFe/msWLKz5y5o85/bdU/ndqpcqbz+2rbLs69+3Rpa8c1qXbwYr/iEBG39e6dnn9W6rF+3ur794VdduBAtwzA86ygjpFynvlzdrIHe++gLz/8ysnPNXN30Kn313RqdPnNOhmFoybIv1KpZ0vfTFS9aWJcVzK9vV/2qBlfWVL3aV+iPrdv159871fiqOqn6CXRdJK0J/9+9V75cKRW6LL/e+eBzGYYht/uijh4/mapNkwZ19PO6Tdq996Akaf/BI0nXiCvpVXdJKlakkPYeOKwTJ0/r3PkLWnkpXklav+lP5Y2K1N133KLSJUtoy187UsSYNP9276uB5tysUT19+sVKVa9aSS6XS7WuqKyln3ylJg2T5nvr37sUFRWpDjddo3x5ozy5xrnd+mPrdpUuVVyP9rlHu/ceSPW/zfbuO6TTZ87pzo43qmSJYtp+6X+PWl1Xm7Zsk0sudbj5WtWvU13rN25NFWd8QoK+X71Wc6aO1uI5z6nXPR39/iPS1zmsX6eGPvlipaSke+/eA4cczSmyRlC9giRJwwb11qtvLFHPASMlQ6pYvrRmvDDS78u4lxXMrxfGDtG0Vxdp3sIPlCdPLj3c+x41rJ/6CxMTEhM16eW52n/giEqVLKoRjz8oSepy242aMfdtffPDL2rSoI5KFi/qN9ar6tbQow/eo6fGTlVEeIQuK5hfY57qr+JFC+ualo204N2P9eiDqf8Xj9X4993VQefPR+v+R0crMjKPqlQqp9FP9nMydamUKVVCVSqVV9feT+iBbp3U7oZW6tzhBvUdPE7Xt26qQf26a+ywhzX5lTdkyFDeqEg9NfABValUXmOHDdDUmQuVJ09u1a5R1fOhykAULJBPk0YN0tRZCxQb51ahywroudGDkj4gWe1y3de1gx4aPE5FixRS04ZXeo6zO7fPvTxPDerV1I0p3oJq06qJfvzld/UYMFJXVKmoyyuWCzj+iPBwPT9msF6cPl+vLViqvFGRmjR6kK0vQb693XUaNWmGGlxZU89eervALrf7or5b9atenr1I589Hq3njeroyxb9Yo6Nj9dqCpTp09LguXIjW4P73pfoAt1nBAvl09x23qO/jz6h0yeKqU7Oqjp84LUm649brtXPXXt3z4FCVKlFMlSuV04XopG+6t1qX17RopD+2blePASNVolgR1a19haP8fDGvUys3X99Sx06c1IAnx1/6YHkRTRj5aJq3olKqX7eGet7TUQ8PnSAZUo0rLtfg/vd59jdrdKXe/egLjXqir6IiI5Uvb5QSExPTvH0V6Lpo3rie3nr/M/XoP8Ln9e3pf8Z8ffLF98qdO5fuu6uD561vKektpOGP99HTE/+nMJdLJYoX1YjBfVSnRlW9sfgjbflrp2rXqKL2N7RS937DVb1qJV3Xuqn+2v6PEhIStX7jVk17dZEuXIhR1coVdF3rpLcLzevWzn3VSc5VK1dINd//e22xnnrsAUlSw3q1NGXmm7rvrg6SpEZX1dZnX61S94eG6/KKZT2vcMXGxumDT7/RizPm6+y5C+p+560qVfLf+1SVy8urRZP66vbQcFUsV1ply5RQYqJheV0t++xbTZ21UNExMSpetEiaV64jwsNVuWI53fXAk8qfL0oF8udT9WqX66FeXQI6h48P6KFnX5ytbn2HqVzZkipfppTt+UTW+U/9Jm3z/+j4r40fin5et0nrN271/I8zAMhoG/74S4ve+1QvjhsiKenVuu79huvNGeNVqULaz7oiNATdK0iAXWfOntOnX6zU4AE9sjsUACGsYvnSyp0rl+5/ZJQuxscrPDxcQwb0oDgKcf+pV5AQegzDcPyBcgAA/AmqD2kDTlEcAQAyAwUSAACACQUSAACASdAUSIZhKD4+3vKXCwIAAGSVoPlfbAkJCWrVvpf+3PKHJOn0/o0qVK5eqp99bUu5L3m/JM8+b7zt87fNaqyUcaU8zhyLncdm5j7N49uZD3Nf3uJ3coydMb3NRcrjnAr0uFDwX8k95VpKZvXYaj1a9Wl3bPO2lOxcs1b3B39x2MnJ6pryFnOg68VuvP7idJprIOOYt/maL8nePdjXz1lxDVo9nyTz9xzkrb/k4zIrzowax26fdtZBMifxmOc7aF5BAgAACBYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACYUSAAAACaWBVKnHoO0beceSVKc261+g8dp2WffOR5g/cat6jd4nLr1HabHhj2no8dOBB4tAABAFvD7CpJhGJow5TXVql5FHdu1cdS5YRha+/sWTRw9UIvnPKfy5Upp9vwlAQcLAACQFSL8NZiz4H1diI7RmKH90+wbPm6aDhw6kmpb+xtbq2unmyVJLpdLD/W807OvYb1aev/jL32OlzcqyufPvral3OetDzv7/G2zGstOX04fe2MnV19t/I0d6Hz5Oz6QXO3G8F/xX8nd7nXi5Hq3O3f+2tldx4FcX1b7A80pPevFbry+xsus+Ozeo+0c6+uxnft+ZrGTQ1bNt9M+0ztOIM/LmRWPy+2OM7zt6NRjkFo3b6iln3ytbl3aqf8DXQMeJNn4KXNUumRx9e7eKc2++Ph4tWrfS6uWz1dEhN+6DQAAINP4fIvt65U/a87U0frki5Xau/9Qugb65bc/tHHz37q3yy3p6gcAACCz+SyQnh7SV7WqV1HPu2/TSzMXyDBSv9g0fNw09eg/ItWfdz/8PE0/m7Zs04vT5+vliU8pKjLSVmBlqjVL87OvbSn3JT9Ouc/bH2/7/G2zGss8rrdtdh97mwtf49uZD19jBXKMnTG9zYWvcfwJ9LhQ8F/J3ds1aPXY6li72+2083YvSLndTj/+ri9/41vF46uf9KwXu/F6O8bqsb/2gY5j3uZrvuzeg+3e9zOL1fOJ3ecgb/1lRuy+nnMzu0876yAj4vH5XlbRIoUkSZ07tNXHK77Xyh/X6dqrG3v2Txo90O8Af+/YrbGTZ+n5ZwarbOkStgOLjolJ87OvbSn3WbX1N47dbU7H8tXeX3x22/ubDyfH2jnGzphO+/Mn0ONCwX8ld7trye5162u7nXaB9GkVq9Pr3FdfTvtxwm68vsYMJNdAxjFvC/QeZNWH3eeRjGRnTCfznVlxB7I2M6pPp+sgULY+7BMREaHBA3po/JRX1bRRXduvAknSoBHPK1euCI1/8VUlJiZKkkY/2U9VK1cILGIAAIBMZlkgfbjg5VSPG9avpQ8XTnM8wIr3Zjk+BgAAIDvxm7QBAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMIrI7gGSGYUiS4uPjPdu8/exrW8p93vqws8/fNqux7PTl9LE3dnL11cbf2IHOl7/jA8nVbgz/Ff+V3O1eJ06ud7tz56+d3XUcyPVltT/QnNKzXuzG62u8zIrP7j3azrG+Htu572cWOzlk1Xw77TO94wTyvJyR8YSHh8vlckmSXG53nOHo6EwSGxurNh37ZHcYAADgP2rV8vmKiEh67ShoCqTExES53e5U1VsguvcbrkWzJ2VgZMEllPML5dyk0M4vlHOTQju/UM5NIr+cLDtyS1mDBM1bbGFhYYqMjEx3Py6Xy1P9haJQzi+Uc5NCO79Qzk0K7fxCOTeJ/HKy7M6ND2kDAACYhFyB1LnDDdkdQqYK5fxCOTcptPML5dyk0M4vlHOTyC8ny+7cguYzSAAAAMEi5F5BAgAASC8KJAAAABMKJAAAABMKJAAAABMKJAAAAJOgKZAMw1B8fLznO9kAAACyS9D8+s2EhAS1at9Lf275Q6f3b/RsL1Sunk7v35jqb0lptiUfk3J/yuO98bXPTjvzWHaO9RWruV+rfXbnw9wmZX9WY6TcbvcYb7H7y8nbON54y9EuqzlIL1/zH2hfVo+TtyXzN4bTubXbr5Mxva0XO8fauRaT+7Vak1ZzZ2feUvbtbx1b3V+83ZO8tbMay1v8/q5Vf/cXf7zdj6yuG6t7jlWO5lit8vIVk5N5szPnvvq3yieQeQ2U3WvCau3bWTPexrNz7/AWm9Vju7xde1bXkFUc/p7LrZ4L/V3vQfMKEgAAQLCgQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADCJyO4AzPJGRXl9bP7b3zarx3b32Wln53hf8QTSr5P58NYmI8b2xW6/dufe3NbJcSnbOz0ukH4DHSOj12wgcaR3fpyssfSOHcj17jSWQNex1fG+5sffGnKSU0ZcK1ax+RvD6boNdC2nZ97snj+7P2eWrH5ucXKfdDKHTvh73gokX6u+/W1P5nK74wx/gWeF+Ph4tWrfS6uWz1dERNDVbQAA4D+Et9gAAABMQqZAKlOtmaO2Kdv7e5wVfI2X1bEA2cV8Hab8OTuuSyvBFEtGy2l5+Ys3eX9Oycscp9U18V+RnTmHzHtZ0TExAbf19zgr+BozO+IBskPKtW71czAItngyUk7LzV+8yftzSl6+no9ySg4ZKTtzDplXkAAAADIKBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAICJZYHUqccgbdu5R5IU53ar3+BxWvbZd44H+PGXDXpo8Dh17f2kej38tP7ctivwaAEAALKA31eQDMPQhCmvqVb1KurYro3jAaIi8+iFsUP07rwXdGObFpr1+nsBBQoAAJBV/H7VyJwF7+tCdIzGDO2fZt/wcdN04NCRVNva39haXTvd7HncoF4tGYaho8dO6MChI6pdo0oGhA0AAJB5fBZIy7/8QUs/+VrdurRTeHjaF5smjR5oa5DFS5Zrxrx31LRhXT0+oEdgkQIAAGQRn2+xfb3yZ82ZOlqffLFSe/cfCniQ7nfdqm+XzdUVVSpq2NiXA+4HAAAgK/h8BenpIX1Vq3oV9bz7Nr00c4GmThgql8vl2W/nLbZkUZGR6nlPR7Xt9KAuXoxXrlx+390DAADIFj6rlKJFCkmSOndoq49XfK+VP67TtVc39uz39xZbbJxbs15/R727d1aB/Hm1as1vqli+DMURAAAIarYqlYiICA0e0EPjp7yqpo3qKioy0lbneXLnUuWK5TVoxPM6e+68ChcqqHHDH05XwAAAAJnNskD6cMHLqR43rF9LHy6c5qhzl8ulju3aBPTrAQAAALILv0kbAADAhAIJAADAhAIJAADAhAIJAADAhAIJAADAhAIJAADAhAIJAADAhAIJAADAhAIJAADAhAIJAADAJGS+NTZvVFTAbf09zgq+xsyOeIDskHKtW/0cDIItnoyU03LzF2/y/pySl6/no5ySQ0bKzpxdbneckW2jpxAfH69W7Xtp1fL5iogImboNAADkQLzFBgAAYBKUBVKZas08f5Ifp/zb37aUfZj7S9nG1zH++vDWzqqN1WNvuVjF53Q+vLXxNYa37XaPsTMn3nKyw+r8OjnW6XGB9BvoGHbmxt/58Xe8r7Z2+3UyppM+/V0HVn3ZXVdO5s3qvNq9Prxde/7uQ/7WkJ1r1d/9xUnuvsa2itfffdJu31Yx+Zs3b8c5uQ/6mr/0zGtGsBuHr3VkZ/16O85XW29xBDo/vs6Xr/PnLX5f68+qD18xB+V7WdExMV4fp9zua5uvn32NZTWukz7s7LeTn699drZZ9elrDLvxB3qM3WOt2jo5LmV7p8cF0m+gY2TE+cmKtk76Se/5tTOvdufJbiyB3Dus2gR67dmJP9A2vgQ6x+m5DpzcP5yc10DOhd19GX0fscPuHNvNx+4Y/toGMo6TPp08j9mN38nzbrKgfAUJAAAgO1EgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmERkdwDJDMOQJMXHx6fanvzY/Le/bVaP7bSx04ev7Xb7svOz1T478+Gtjb/YfeUUSL5W2+305a2tk+NStnd6XCD9BjqGk7lJzznI6GP8HW+3z0CuCavt6blWU7YLtB+r433Nj788ncSSEddKoGM4XbeBrmW713Qg98H0rMXMkp7nCV99edue3uc0u33YicHf+XNyTvz1kXJ7eHi4XC6XJMnldscZztLIHLGxsWrTsU92hwEAAP6jVi2fr4iIpNeOgqZASkxMlNvtTlW9BaJ7v+FaNHtSBkYWXEI5v1DOTQrt/EI5Nym08wvl3CTyy8myI7eUNUjQvMUWFhamyMjIdPfjcrk81V8oCuX8Qjk3KbTzC+XcpNDOL5Rzk8gvJ8vu3PiQNgAAgEnIFUidO9yQ3SFkqlDOL5Rzk0I7v1DOTQrt/EI5N4n8crLszi1oPoMEAAAQLELuFSQAAID0okACAAAwoUACAAAwoUACAAAwoUACAAAwoUACAAAwCZoCyTAMxcfHe760FgAAILsEze8nT0hIUKv2vVJ9UZwkFSpXT6f3b7R87I/T9hnNV/z+YvO2P3lbyr8leR0jkNz9HZue+bSai+QcJFnOjXnevLGaD1+xe+vXWwzmGL2dR29xeWvj7XhvMXubF2/7vM2BVQ7mOTUfY5WD3Ry95WwnFyfXgb9z5msMc/xWa93qOghkPKu1aHWcOS5fa9pXn96Od7purObLVzxOrlWrv63ae9tuzt1pfE7aWeWTUZw81/m7b/q73/rLx996Mcfh61z442s9WI3jbbvVtewrB1/XatC8ggQAABAsKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMIrI7AH/yRkX5fOz0+KzmK35/sXnbn7zN/LevNk74OzY982k1F75y8PbYVwxO9/nq1+k+O2N7axvIXNvdl1E5OMnRzti+jktPv4HE7+Qayojx7G53eh3bub6crhu78+WvH1/t7NzT7PaVGfHZiS0zpOf5wdt+p+vBzn5f49g93io+p9eaVRu7OXpr53K74wyfR2eR+Ph4tWrfS6uWz1dERNDXbQAAIITxFhsAAIBJ0BVIFWperTLVmkmS529vP5v/mLfb4a2dr22+xvI2rreYneRlFY+/Y81tnPzxl6/TPr3Nobe/rebJ3xz7mg9fffjq1+6Yds6T1bz6GtfumL7mwM6583aMvz7txGTnuvB1Duxev95i9DaGVZuU2zIrDm/j2L1uffXt61rzdYy/uP3l7CvO9MyX3TWY3nic5pfV7JwHJ+c6PefLaQx21rBdduK2Wvd2x7VzrQfde1nRMTGOfrY61ulYdrb5isFfX4Hm5SunzJiTlMc4nX8nfXobw984/sb1dqzT8+QvBqftfMXkND87bQI5d1bxON3vdDwnx/gTyHlOuc3ONR5IHFbj2G1vtc1ubE7XspNrLNCYfI3r9D6WEWvPyf7MZuc8BHKv8dXG6ThW+wK5n9nt305uTse1MxdB9woSAABAdqNAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMKFAAgAAMLEskDr1GKRtO/dIkuLcbvUbPE7LPvsu4IF27Nqrq9v11PIvfwi4DwAAgKzg9xUkwzA0YcprqlW9ijq2axPQIPEJCZr08jxVubxcQMcDAABkpQh/DeYseF8XomM0Zmj/NPuGj5umA4eOpNrW/sbW6trp5lTb3lm6QtWrVlKc253OcAEAADKfzwJp+Zc/aOknX6tbl3YKD0/7YtOk0QP9DrB3/yF9+uUPmvfKWL00c4Hf9nmjohz9bHWsHd7a+9rmKwZ/fQWal6+cMmNOUh7jdP6d9OltDH/j+BvX27FOz5O/GJy28xWT0/zstAnk3FnF43S/0/GcHONPIOc55TY713ggcViNY7e91Ta7sTldy06usUBj8jWu0/tYRqw9J/szm53zEMi9xlcbp+NY7Qvkfma3fzu5OR3Xzly43O44w9uOTj0Gye2+qBfGDtYTo6do9pRRqlCutK2BkyUmJurhoRPVu3snNapfW8+++KoaXFlT7W9snaZtfHy8WrXvpVXL5ysiwu8LWwAAAJnGZyXy9JC+qlW9inrefZtemrlAUycMlcvl8uz39xbb3zt26/CRY5r9xnuSpAOHjmrj5r/lcrnU7oZWGZ0LAABAhvBZIBUtUkiS1LlDW3284nut/HGdrr26sWe/v7fYal5RWR8unOZ5nPwKUjAWR2WqNdPB7T9ndxgAAHjF81TWsvV7kCIiIjR4QA9Ne3WRYmJjMzumbBEdE5PdIQAAYInnqaxl+RmkrJbdn0EqVK6eTu/fmOXjAgBgB89TWYvfpA0AAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgXRJ3qio7A4BAABLPE9lLQqkSw5u/zm7QwAAwBLPU1mLAgkAAMAkaAukMtWapfk55TZf7ZMfpzzO2x9v7by1t4rHKtaUx1nF7e0YX7lZxeLrmIySnr685ZaRsfkbOyf162/M7Bg3q3m7Bn099nasVZ92x/a23ds1bfXY399Oxvd1X/PVT3qvWat4rNpZ3UP9HZsR7N47fZ0vX88JTu67GcHq+cTJc5B5X2bEnpH3dqs5tord7nNqevOOSNfRmSg6JibNzym3+WpvdXx6xvHVn7+xnPbn73h/7e22sSs9fdmdj8yQWeNkVfzZPWZ2sLoG7VwDVnNkd+6cHG/nHmD1t5Pxs+Padxqv03u1nf1OOHle8Lbd7v08O+5bdtek3XwyUkbe2+1e93bHzqicg/YVJAAAgOxCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGASkd0BJDMMQ5IUHx/v2ebt55TbzLzts9veV//e9pnb+RvbTmy+YrUTp7/+0yO9fQWSa0bIrHGyKv5gGTcr+VsrTq9DX9udtrMbm7+/nYzv9L7mpI2/Y53Ea+c+mVHxBdpXoGvLyX03I9hZx06uC199pldG3dvtPAdn1DZfwsPD5XK5JEkutzvOcHR0JomNjVWbjn2yOwwAAPAftWr5fEVEJL12FDQFUmJiotxud6rqLRDd+w3XotmTMjCy4BLK+YVyblJo5xfKuUmhnV8o5yaRX06WHbmlrEGC5i22sLAwRUZGprsfl8vlqf5CUSjnF8q5SaGdXyjnJoV2fqGcm0R+OVl258aHtAEAAExCrkDq3OGG7A4hU4VyfqGcmxTa+YVyblJo5xfKuUnkl5Nld25B8xkkAACAYBFyryABAACkFwUSAACACQUSAACACQUSAACACQUSAACACQUSAACASdAUSIZhKD4+3vOltQAAANklaAqkhIQEtWrfSwkJCWn2FSpXL9XfdhQqVy/VcSn/2O0zZXurmHyN6S8+O+NYtbczRjCwmqecLCPn324fdtZIZoxvZ8zMjMsqbyfz4TQ+b9emuQ+r+4u32NMTZyBzm1FrJZC4/Z239IxtdX/1dm7Mx5jj8Xf+/P2cmezG7+sY877MWBO+5jTQfu0+P1vla3UN2u3LLGgKJAAAgGBBgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGASkd0B2JE3KirV306OsTrOTp9O9/kbM9C2Vu2dzEd28TdPOVFGzr/dPjJrzpys0/S0ccrfHAd6L3Da3s745jaBro+MulYy6nwEsjYz6tpwcn+1mn9fcQRyfFbdt5zG7++YjIw7s8Yxrxsn17+v9RfIXKbkcrvjDL/RZ4H4+Hi1at9Lq5bPV0REjqjbAABAiOItNgAAAJOgK5Aq1LxaZao1kyTP395+Nv9Jud0uc1ur4839e3vs6zhz31YxeuvHbj5Wc+b0j7/j7PTrLV9zfFZzYbdPO/NhZ3x/x9pp66uNr5j95W5nfF/x2M3RX//+rkdv+/zF4W+92InHTn9O+nQyz05iM8djdY3668fffSgj4nYy9+mJwe79wNu4vran9zxnxBpID7v3J3/b09PG7n5/MnIufV0PVtszIr+gey8rOibG0c9Wxzody06/dtt72x9o/HZz8haj0/mwe5ydfv3lHsicOsnH7vh2xrHTNpA16XT92WEnP/N+u219HZPetR5IPHb7C7TPQDg9h4HcC5zmZkd6102g915/9wN//Wf0ec6odRCoQO5P3ranp43d/f5k5Fw6eW4MZC1bCbpXkAAAALIbBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIAJBRIAAIBJRHYHYJY3KsrRz1bHOh3LTr9223vbH2j8dnPyFqPT+bB7nJ1+/eUeyJw6ycfu+HbGsdM2kDXpdP3ZYSc/8367bX0dk961Hkg8dvsLtM9AOD2HgdwLnOZmR3rXTaD3Xn/3A3/9Z/R5zqh1EKhA7k/etqenjd39/mTkXDp5bgxkLVtxud1xho34Ml18fLxate+lVcvnKyIi6Oo2AADwH8JbbAAAACYUSJeUqdYsu0OwFMyxAQCyBs8FWYsC6ZLomJjsDsFSMMcGAMgaPBdkLQokAAAAEwokAAAAE8sCqVOPQdq2c48kKc7tVr/B47Tss+8cD7D8yx90wx191aP/CPXoP0JjJ88KPFoAAIAs4Pf/0xuGoQlTXlOt6lXUsV2bgAa59urGGjn4wYCOBQAAyGp+C6Q5C97XhegYjRnaP82+4eOm6cChI6m2tb+xtbp2ujnVtsKXFUhnmAAAAFnHZ4G0/MsftPSTr9WtSzuFh6d9N27S6IG2Bvl53Sb9/NsfyhuZR3173akGV9YMLFoAAIAs4PND2l+v/Flzpo7WJ1+s1N79hwIa4OpmDfTUwN6aN22s7ujQVsPGTpXbfTGgvgAAALKCz1eQnh7SV7WqV1HPu2/TSzMXaOqEoXK5XJ79dt5iu6xgfl1WML8k6cY2LTRlxgIdPX5S5cqUzMg8AAAAMozPAqlokUKSpM4d2urjFd9r5Y/rdO3VjT37/b3FFh8fr6WffK2Ot7RRnjy5tfrn9cqdK0KlShZLf+QAAACZxNa3wkZERGjwgB4aP+VVNW1UV1GRkbY6DwsLU0REuB55aqLOnD2vggXya/LYwYoID09X0AAAAJnJ5XbHGdkdhJT0alOr9r20avl8RUTYqtsyVKFy9XR6/8YsH9eOYI4NAJA1eC7IWvwmbQAAABMKJAAAABMKJAAAABMKpEvyRkVldwiWgjk2AEDW4Lkga1EgXXJw+8/ZHYKlYI4NAJA1eC7IWhRIAAAAJln//+kdKlOtWaqq2fzY3zF22mcmX/GXqdZMUtp/FSRvt9p3cPvPqf5ObmfelxHxOt3vq43VXPjK19uxKdtb8Xb+rebO17HJj80xWvXrry9/45hzNm/3l7u32Hzl6K9fqxzNP3uL11ccTq9pK1ZzZLX+rPjK09d4dte6nbjN2/3FYh7H6nzYYXdN+4vHKiZf4/n6O2V7c/92cg/0XuUtj0Dm1Skn14W3+XHy/OLrHmi13+51b6d/b/36eh7zla/d5y2r+7jVXAV9gRQdE+Pzsb9j7LTPTL7it4rNV8zJ+8x/W21zyt+xTuff13Yn8QZ6Tn3Nj5Nc7ZxHO+fNyT5v2zNrruzOhd05cRJHRq/XQK4rcxuna9jpWHaOc7quArlXBjJ2eq4bb+38/e3vOG9tM2LdW/WfVc8pgawhp88v6R3D3+NA7tVW599XLIHcv+wcz1tsAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhRIAAAAJhHZHYA/eaOifD72d4yd9pnJV/xWsfmKOXmf+W+rbU75O9bp/Pva7iTeQM+pr/lxkqud82jnvDnZ5217Zs2V3bmwOydO4sjo9RrIdWVu43QNOx3LznFO11Ug98pAxk7PdeOtnb+//R3nrW1GrHur/rPqOSWQNeT0+SW9Y/h7HMi92ur8+4olkPuXneNdbnec4S/wrBAfH69W7Xtp1fL5iogI+roNAACEMN5iAwAAMAnaAqlMtWaZ1t7c1ttjf23S03+g0hMDkBOkXLfmn71dl1kpGK6prIghGPIEktldj5mxboP2vazomJhMa29u6+9xRvcfqPTEAOQEKdet1c/Z5b8SQzDkCSSzux4zY90G7StIAAAA2YUCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwIQCCQAAwCQiuwNIZhiGJCk+Pt6zLeXPdjhpb27r7Vg7bdLTfyDSEwOQE/i7B2Tnug6GayorYgiGPIFkdtdjRqzb8PBwuVwuSZLL7Y4z0t1jBoiNjVWbjn2yOwwAAPAftWr5fEVEJL12FDQFUmJiotxud6rqLRDd+w3XotmTMjCy4BLK+YVyblJo5xfKuUmhnV8o5yaRX06WHbmlrEGC5i22sLAwRUZGprsfl8vlqf5CUSjnF8q5SaGdXyjnJoV2fqGcm0R+OVl258aHtAEAAExCrkDq3OGG7A4hU4VyfqGcmxTa+YVyblJo5xfKuUnkl5Nld25B8xkkAACAYBFyryABAACkFwUSAACACQUSAACACQUSAACACQUSAACACQUSAACASdAUSIZhKD4+3vOltQAAANklaAqkhIQEtWrfSwkJCQEdX6hcvYDbenvspD+n/ds5xunxGXEMkN2s1m3yNcm6znzMMYKJ3fWYGes2aAokAACAYEGBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYBKR3QFklLxRUQG39fc4vbHY6c9Xm0DiSW8OQHawWres56zDXCOY2F2PmbFuXW53nJHhvQYgPj5erdr30qrl8xURETJ1GwAAyIF4iw0AAMAk6F+qKVOtmQ5u/9nysb9j7LTPTL7iL1OtmSSliS95u9W+g9t/TvV3cjtv+5zOg7djfeXjhLe5MLMa25yvP+a8rebJ37Epj7GK0Vd/5r6sjk/Z1lveKR/7y9tb31Zx+evX3zx6y9HbmvPVf3rXlK8YzO2s+MrT33iBXidW6zy5f3/XorkPq7mww+6atrqWfOXobzx/9y2rsXytxZQ5eIvJyb3Q28+ZxclznbfnCTv3fKv7mrdY/J1/c39O+reK3Wrd+xvH31z5uo9bXe9BXyBFx8T4fOzvGDvtM5Ov+K1i8xVz8j7z33b32Y03kNjs9u2vL2/b/cXlb0xf8+TvWG9tnfYXyDrwd5ydY5yed3/77c6Jkziya035ame3n/SM52ud24nFqr2TGAIZ28n6CuReZtW/0/WVUWvBzliZIZC5dfr8kt4x/D12Mle+1kF6x/HXp9XxvMUGAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgEvTfxZY3KsrnY3/H2GmfmXzFbxWbr5iT95n/trvPbryBxGa3b399edvuLy5/Y/qaJ3/HemvrtL9A1oG/4+wc4/S8+9tvd06cxJFda8pXO7v9pGc8X+vcTixW7Z3EEMjYTtZXIPcyq/6drq+MWgt2xsoMgcyt0+eX9I7h77GTufK1DtI7jr8+rY53ud1xhr/As0J8fLxate+lVcvnKyIi6Os2AAAQwniLDQAAwCQoC6Qy1ZoF3C55m3lfmWrNPH/M23z1b+4vZT/+jnXKV5/+xgtUoH36O87b/AcqvXln9LyZ11B6xrCaJ/Pas3v+ncSRntjtXjfZyUkc3q51b238HW913rz9cdq/uc+M5C13u9e4r5ydjuutTydx2R3b6nz56z8YBHofyIi8fD1/ZuS8ZeU58DVWUL6XFR0TE3C75G3mfb7a2unfql8nsaXnmED6S++Y6TnOzvxn1FiZfbyv/pyuC199WfXnpO9A2uaUtepUoPNmdZzTnJ3Og53+M/s+4GTdpXeteuvDzv07I9aek+eOYGMnvoxYj/76zch7vK9xMpuvsYLyFSQAAIDsRIEEAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgQoEEAABgYlkgdeoxSNt27pEkxbnd6jd4nJZ99l1Ag6z4erXu6zdCPfqP0PPTXldiYmJg0QIAAGQBv79J2zAMTZjymmpVr6KO7do4HmDLXzu04N2PNXvKKBUskF/bdu5RWBgvXAEAgODlt0Cas+B9XYiO0Zih/dPsGz5umg4cOpJqW/sbW6trp5s9j5d+8rXuuv0mXVawgCSpetVKfoPKGxXlt41Vu+Rt5n2+2trp36pfJ7Gl55hA+kvvmOk5zs78Z9RYmX28r/6crgtffVn156TvQNrmlLXqVKDzZnWc05ydzoOd/jP7PuBk3aV3rXrrw879OyPWnpPnjmBjJ76MWI/++s3Ie7yvcTKbr7Fcbnec4W1Hpx6D1Lp5Qy395Gt169JO/R/oGtDgDw56Rte1aqKf123SyVNndV/XW3VjmxZp2sXHx6tV+15atXy+IiKC8iviAADAf4TP97q+Xvmz5kwdrU++WKm9+w8FNMC589Havfegnh/zuCaOekwTp87V6TPnAuoLAAAgK/h8qebpIX1Vq3oV9bz7Nr00c4GmThgql8vl2W/nLbaSxYvoyjpXKDIyj8qXLaUyJYvr4OGjKnRZgQxOJX3KVGumg9t/zu4wAADwiueprOWzQCpapJAkqXOHtvp4xfda+eM6XXt1Y8/+SaMH+h2g7bXNteLr1brpupY6cPCIjh4/qQrlSqcv6kwQHROT3SEAAGCJ56msZevDPhERERo8oIfGT3lVTRvVVVRkpO0Bbml7tfbuO6Se/UfqYny8xgztp/z58gYcMAAAQGaz/JB2VsvuD2kXKldPp/dvzPJxAQCwg+eprMUvJAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQAIAADChQLokb1RUdocAAIAlnqeyFgXSJXxDMgAgmPE8lbUokAAAAEyCtkAqU61Zmp9TbnPSh7fjnPZld7xA+s3IvIJNVs293bFzUv9ZISNyyKx5SL6ezP1bbffVT2bFkN7+7YwfyDGhsDa98TbnvnJNef78tbMax9vPmcmcm7f4reK12hfM91xf15JVf1b5mvtJ73Ua4fiILBIdE5Pm55TbnPTh7TinfTkZL7OPC3Q+skNWzb3dsXNS/1khI3LIrHmw6jfQ6yWzYsjMdRBI36GwLq14u/f5ytfuXJjbOR0nI9kZ0ypef/syW3rXq93YrY4xn7f0nr+gfQUJAAAgu1AgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmFAgAQAAmATtd7HljYpK83PKbU768Hac076cjJfZxwU6H9khq+be7tg5qf+skBE5ZNY8WPUb6PWSWTFk5joIpO9QWJdWvN37fOVrdy7M7ZyOk5HsjGkVr799mS2969Vu7FbHmM9bes+fy+2OMxwflQni4+PVqn0vrVo+XxERQVu3AQCA/wDeYgMAADAJugKpQs2rPT+XqdbM8ufkx+af0yNlX+btVv0nH+PrOF8x24nJSTtze2/jmmP29thfe6v9Vu38xeltv3menJxfO/37OjbQcf315SuGjFrHVuN6G8tJP4H0ZzeOQK8Pq3EyYg6zgtX9w9/9JOXjQOYrUBmxppy2zUj+xs3udZOee4CTNWNnjIx4Ps0ogcSdEfkF3XtZ0TExGfJzesf2tt3bfl9jZkScdttaxWhnXKtjApkPf+3S03dGzJud2H3NoVO+8nA67+kd18l+b+2czJnTONJ7HWfkOctKTuYtM9eLXYGsgfS2zUgZdV1klvScUydrxs4YmfV8mt6+Armn+OvTStC9ggQAAJDdKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMKJAAAABMgubLag3D8PwcHx/v92erfeY2gfDWh53+fR3n7bHdWJ22sxOHv/j8tfcXk7mdk3OVEXNmp3+7OTgd104sVjFk5Dr2108gcxlof3b3pXfOM/KcZTVf695Om6zKN6PXVFZzct1nh/TcAzJ6zWT0fS+j+nL6/GOnz2Th4eFyuVySJJfbHWekaZENYmNj1aZjn+wOAwAA/EetWj5fERFJrx0FTYGUmJgot9udqnoLRPd+w7Vo9qQMjCy4hHJ+oZybFNr5hXJuUmjnF8q5SeSXk2VHbilrkKB5iy0sLEyRkZHp7sflcnmqv1AUyvmFcm5SaOcXyrlJoZ1fKOcmkV9Olt258SFtAAAAk5ArkDp3uCG7Q8hUoZxfKOcmhXZ+oZybFNr5hXJuEvnlZNmdW9B8BgkAACBYhNwrSAAAAOlFgQQAAGBCgQQAAGCSo/5v4NsfrNBbS5br7jtuUbc72+vv7f/o2SlzZBiGutx2gzq1v17nzl/Q1FkLtW3nHsXHJ2joY/erwZU1FRvn1rjJs7Rn3yE1blBHAx/qlq7ft5TR7OSW7MKFaN35wBN6uPfdan9j66DPTbKfX6ceg5Q3KlLhYWEqW7qkJo0eqISERL04fb42bdmmqpUr6OkhfZUrV3AtXbv57dl3UBNeek0xMXFqfFVtPfZQt6A/f3ZyW7N2o2a9/q7nmN37Duq1qWNUtXLFkDl33636VTPmvSNJerj33WrTqknQr027uS1492N98vlKFS5UUE8P6asK5UoHdW5nz13Qc9Pmad/+w7qsYH6NG/6wwsLCNGridJ08dUa33HC1ut95qyTpo8++1ZJlXyp/vrx6dvjDKlG8qE6fOee1bbBwkp/5HEsKmfy8tStS+LIsyy9HvYLUoG4NNWlY1/P4+Vfe0FOPPaB508bqnQ8+1/6DRxQWFqbb212nRbMn6eE+d+u1BUslSR9++rVKlyquRa9O0u69B7R2/ebsSsMrO7kle+PtZSpauJDncbDnJtnPzyWX3pw5QQtmTdSk0QMlSavW/KYz585r8ZznlDcqUp99tSpbcvDFTn6GYWjs5Nka+FA3LZg1Qe1vai0p+M+fndyaN66nBbMmasGsiRox+EFd3ayBqle7PGTOnSRNnb1QMyaP1LxXxurVN9+XFPxr005uu3bv19crf9HCWRPV577Oem7aPEnBndvmP7frzo43auHsiaperZIWv79cry/+UNe0bKQ3Z47Xiq9Xa+/+Qzp56owWvvuJ5k0bqy633aAZ85KKeG9tg4nd/KS051gKnfy8tZOyLr8cVSBVr3a5Spcs5nl8+Ohx1alZVZGReXR1s6v04y8blC9vlK6sfYXOX4jWnr0HdUWVipKkH3/9XfXr1pDL5VL9ujX009qN2ZWGV3Zyk6R9Bw5r05ZtatW8gadtsOcm2c+vQIG8iggPT3Xsj7/+rqvq1pCkS/n9nmVx22Unv917DyoiIly1a1SVy+VSlUrlJQX/+bN77pLNmPuOHn3wXkmhc+4kqVDBAsqfL0qXFSzgaR/s+dnJbdfu/apfp7oiI/OoUf1a2r3noM6dvxDUubVoUt8TW91a1XTs+Cn9dOk6ioiIUN2a1bRm7Ub98tsfuqJKJUVG5lH9ujW05lIO3toGE7v5SWnPsRQ6+XlrJ2VdfjmqQDIrVLCA/ty2SxcuROvvHbt19PhJSdKhI8fVvuvDWvHNavW7/05J0omTp1WxXGlJUsVypXX8xKlsi9sOq9ymz31bjz54r8LC/n0LJqflJlnnFx+foEeemqge/Udo1ZrfJCXlVyE5v/KldfzE6ewK2zZv+R08fFRFCl+msZNnqXu/4frmh18k5bzzZ3XuJGn33gPKkye354YdKudOkvrdf5ceHDRWs994T61bNJSU8/LzlluZ0sX1++a/dfFivDb/uUPuixd17PipHJPbb79v1ZW1r9DJU2dUrkxJSVKFcknxJuVQSpJUrEghJSQmKjbO7bVtsPKVn5VQzC+5nZR1+QXHG8oBevKx+zX5lTdUpPBlqnp5BeXPl1eSVLpkMX27bJ4++3qVnhg1RTNeGCmXXEpMTPqVT4mGkarACEbeclu7YbPy58ururWq6ZffNnna5rTcJOtzN3Lwg7q8Yln9tX23nhj1oj55e7pcrqTv6pOS/s6p+UXHxGrHrr2aMXmkXGEu9RwwUte2bJzjzp/VuZOk739cp+aNr/Q8DpVzl5CQqE+//EH9e3fViq9X68SpM+rU/vocl5+33GpVr6IWjevpgUdHq3njK1WqZDHlzxeVI3LbuXuf1m7YokcevCfpM3BG8nWUKFeYS3JJhvHvr/ozEg25XElfYZGmbRDym5+FUMsvZTsp6/LL0a8gXVW3hubPGK+Xxj+p+PgElSlV3LMvPDxMt97YWtt27lFsnFvFihbWvgNJ71Pu239YxYoUzq6wbfGW2zc//KJtO/aoz8Ax+vjz7/XGWx/p19/+yHG5Sdbnrlb1KoqKjNRVdWuodKniOnrspIoVKax9Bw5LSnqLMafmV6xoYZUqWUwlSxRViWJFVLRIIZ05dy7HnT9f191f2/9R1csreB6HyrnbtHWbChbIp1bNGmjCyEe1feceHTpyPMflZ3Xu+t1/lxbOnqi+Pbvo9JmzKlqkcNDndur0WY15bqbGj3xUeXLnVpHCl3k+L7Zv/2EVL1pYxYsW1t5LORw7cUq5cuWybBts7ORnJZTyM7eTsi6/HF0g7dy9TwkJiTpy9IR+Xf+HWjVvqO9Xr9Uvv/0hwzC07vctyp8vSnly51LLpvW1YdNfMgxDv2/+Sy2a1s/u8H3yltuwgb21cPZEzZ02VrfdfK3uv/d2NWlYN8flJnnPb9OWbdry105J0o5/9uncuQsqU6q4Wja9Shs2/SVJ2rAp5+ZXq3plHTh4RMdPnNKRoyd07twFFSpYIMedP2+5JTty9ISKFinkeRwq5y4sLExb/9qp6JhYXYiO0bETpyTDyHH5ecvNMAzt+GefJOnjz1fq6qYNFB4eFtS5ud0XNeLZaXqwR2dVvTzps3wtm16lDX/8pfj4pLcKmzeupyYN6mr7zj2KjY1LyqFJfcu2wcRuflZCJT9v7azaZoYc81Ujx06c0pCnX9CJU2cU5nKpYoUyatboSn3+zY8KCwvTwL7d1LB+LR0/cUovznhTe/cdkiFDTz32gOrXraE4t1vjJs/W7r0H1bTRlXr0wXuC5r9S280tpbkLl6p0yeJqf2ProM5Nsp/f0eMnNXXmQu0/eETuixc15OGeatKgjhITEzVlxpv6/Y+/dUXViho5+MGg+vZqJ+fv1/Wb9b85bynO7dagft3Vokn9oD5/TtfmXQ88oZkvjFSxS/+iC5VzZxiG5i36QMu/WiWXXLqn8y26s+ONQZ2f3dzOX4jW6EkzdPT4SZUtXUIjB/dVwQL5gjq3eYs+1OIln6pShTKKj0+QJE0Z/6SefeFVnTh5Wrfe1Fr3dG4nSfrki5V654MVKpAvr54d+aiKFy2sM2fPa9TE6WnaBgu7+Xk7x9OfHxEy+XlrN2fqGMW5L2ZJfjmmQAIAAMgqOfotNgAAgMxAgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQAAGBCgQQgaA0Z9aI+XvGd5/Hqnzeoz8Axqb5fCwAyAwUSgKDVu3snLVqyXAkJSV+auvC9T9Tnvs5B85vGAYSu4Pi98QDgRa3qVVS+bCmt/GmdihYppMREQ00b1tWPv2zQ7DeWyH3RrWqVK+rpIX0VGZlHi5cs1zc//KKY2FiVKVVc44Y/onx5ozR34VK5XC79sXW7Che6TGOG9svu1AAEOb5qBEBQ2/r3Tk2dtUgFC+RT19tvUtkyJTVi/DT977kRKpA/r2a/8Z4KFSqoe+64RX9u26VqlSsoPDxcj4+crFbNG6hzhxs0d+FSLf3ka73+v2dVumSx7E4JQA7AK0gAglqt6lVUsEBenTt/QY0b1NGHn36jI0dP6JGhEyRJ7ovxnm9pr1CutD7/5kdt3LJN+w8e0f6DRzz9XN+6GcURANsokAAEvZpXVNa589FyuVwyZKh+3Rp6bvSgVG1iYmPVZ+AY3Xbztep+Z3uVKFZE5y9Ee/aHh/ORSwD2cccAkKM0aVBXa9dv1h9bt0uSTp0+q+iYWO3dd0inz5zTnR1vVMkSxbR9555sjhRATsYrSABylPJlS2nssIc1+ZU3ZMhQ3qhIPTXwAVW5vLxaNKmvbg8NV8VypVW2TAklJvIRSwCB4UPaAAAAJrzFBgAAYEKBBAAAYEKBBAAAYEKBBAAAYEKBBAAAYPJ/olsXzE1npIcAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 583.3x600 with 5 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Five stacked panels, one per cluster count. The two-cluster panel shows one row occupied most of the time and the other taking short scattered stretches. Each panel below it is more finely speckled than the one above, with no row holding a long uninterrupted stretch by the largest count."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "lane_cmap = ListedColormap([COLORS[\"bg_light\"], COLORS[\"blue\"]])\n",
     "ticks, tick_labels = decade_ticks(factors_df.index)\n",
@@ -680,8 +1244,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05e2a5fe",
-   "metadata": {},
+   "id": "8fbb9b3d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008012,
+     "end_time": "2026-09-08T23:45:12.762487+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.754475+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "No band settles down as clusters are added. An added cluster does not carve out an era the\n",
     "earlier models had merged; it takes months from across the whole century, so each panel is\n",
@@ -694,8 +1266,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6054702d",
-   "metadata": {},
+   "id": "cdaa9c4d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008598,
+     "end_time": "2026-09-08T23:45:12.782176+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.773578+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## The two-cluster model: risk-on and risk-off\n",
     "\n",
@@ -714,9 +1294,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d3864953",
-   "metadata": {},
+   "execution_count": 18,
+   "id": "26e6a8e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.802810Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.802639Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.807842Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.807160Z"
+    },
+    "papermill": {
+     "duration": 0.016985,
+     "end_time": "2026-09-08T23:45:12.810348+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.793363+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "labels_2 = gmm_grid[N_REGIMES_SELECTED].labels\n",
@@ -735,8 +1329,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d6af75b",
-   "metadata": {},
+   "id": "5330021a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005551,
+     "end_time": "2026-09-08T23:45:12.822070+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.816519+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### The timeline against dated events\n",
     "\n",
@@ -750,9 +1352,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6795b94e",
-   "metadata": {},
+   "execution_count": 19,
+   "id": "4ce19466",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.833585Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.833419Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.837673Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.836730Z"
+    },
+    "papermill": {
+     "duration": 0.010725,
+     "end_time": "2026-09-08T23:45:12.838184+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.827459+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "HISTORICAL_EVENTS = {\n",
@@ -768,9 +1384,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1f8325da",
-   "metadata": {},
+   "execution_count": 20,
+   "id": "3c5388d5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.849775Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.849606Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.857840Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.856763Z"
+    },
+    "papermill": {
+     "duration": 0.015134,
+     "end_time": "2026-09-08T23:45:12.858774+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.843640+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def mark_events(ax: Axes, years: list[int]) -> None:\n",
@@ -792,9 +1422,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bdfb68cc",
-   "metadata": {},
+   "execution_count": 21,
+   "id": "501c4bb6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.880550Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.880359Z",
+     "iopub.status.idle": "2026-09-08T23:45:12.885186Z",
+     "shell.execute_reply": "2026-09-08T23:45:12.884284Z"
+    },
+    "papermill": {
+     "duration": 0.018081,
+     "end_time": "2026-09-08T23:45:12.885714+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.867633+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def plot_by_regime(ax: Axes, values: np.ndarray, in_risk_on: np.ndarray) -> None:\n",
@@ -818,10 +1462,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f3ae3d8e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 22,
+   "id": "8d161458",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:12.897945Z",
+     "iopub.status.busy": "2026-09-08T23:45:12.897767Z",
+     "iopub.status.idle": "2026-09-08T23:45:13.423561Z",
+     "shell.execute_reply": "2026-09-08T23:45:13.421155Z"
+    },
+    "papermill": {
+     "duration": 0.532327,
+     "end_time": "2026-09-08T23:45:13.423995+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:12.891668+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAH1CAYAAAANogGZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAArE5JREFUeJzs3Xd0FFUbx/HvlvSQXglJKKETQq/SVBREQQQRFcGuiL0gCIiCAmIBFVFAUVFsiA1RARUFEZDee0sC6b0nW94/QgLZtE3YZDPzPp9zPJLdKfd3Z3bzZModTWFhgRkhhBBCCFFKa+8GCCGEEEI0NFIgCSGEEEJYkAJJCCGEEMKCFEhCCCGEEBb+bwqkAUPHMv7BZ6qcZvO/O/BqEsWKL76zyToLC4t48LGphLXtS6+rR2I0Gvnmu7V06HE94e2v4veNW2yyHluJ7DWUEWMftHczbOaFl1+nXbfB5OcX2GR5K7/5Ea8mUWz9b7dNlmeNyF5DGTJyQr2tryGLvRBPsw79Wfzh5zWe1x79OPfN9/FqEsXpM9H1ut66VvI5+GvzNns3RYg6pZoCKbLXULyaROHVJIrAFt3pdfVIPl25uvT9xW/N5qWpT9Rrm7776Te++f4Xbhx6NTOnPoHBYOSJybNwcnJkzszn6BzVrl7bc7nln32DV5Mou62/Pjz64Hg+W/YWzs5O9m5KpY6fPINXkyg2/7vD3k3hpTkLiew11K5tqGq/bBwUwMqPFjJ21I313CphK/c+Mplho++zdzOEsIre3g2wpVYRzXhxyuPEJyTx/Zr1PPH8LCJaNKVvr660b9uy3ttzNvo8AE9MvIfWLZsTHXuBvPx8bhxyNXeOGVHv7blcQmKKXddfHxoHB9I4ONDezahSQmKyvZtQKiHJ/vtEVfulVqulT88u9dgaYWv/D987Qj1UcwQJwMfbkxuHXM39E27j1ZnPArB770Gg7CH2wsIiHnv2JZq270ebrtfyzAuvkpWdU255by/+GO/QTqz7Y1Ol6/x+zTp6X3MLTVr35qYx97P/0FGg+PD6vLfeB6DnoJFMfGoGHS/+df72+5+U+0u95PTeDz+v54ZR99K0fT8efnI652LOc9uERwlr25e7H36OwsKiatcNMGz0fdz1wNO8/vZSInsNpVXnq/nmu7UATHxqBq8t+AAAryZRZf6iKygoYMbst2jT9Vo69BzC3/9sB8BsNvPy3Ldp2WkQzSMHcP+kKRX+ct+2Yw9DR91Dk9a96T5gBBv+/AeA7Jxcnps+l9ZdrqF1l2uYPGMe2Tm5AJyLOY9Xkyg++fxbbrv7McLbX8VtEx7l/IUEHnh0KuHtr+Lm2x8iPT2zdD2/bviLPteOJqxtX267+zHiE5LKtWXiUzPwahKFwWAozfrGO8uY+NQMmkcOoNfVIzlw+Fi5+dIzMhl3/1OEtulDx95Dmf3au2X6fceu/Vx/8wRC2/Th3kcmU1RUVNpHyz75ii5X3URY277cfu8TnD0XWzpfZK+hvDRnIVNfep3w9lfxxjvLuGnM/QDcNOb+So+cZGblMOmZFwlvfxV9rhnFlm27St/zahLFg49NLbOOkv28ZJ/auGkr140YT89BIwH44KOVtO9+XXHfTXiUU6fPMWz0fXy56idiYi/g1SSKiU/NqHTaqsx9830iogay5tc/uOq6MYS17cuUmfNL36+qj6raL+HSfvLK/EVWrasqZ8/FMvaexwlr25cuV93Eh59+jdlcPCRcySmkP/7awuDhdxHapg/3TXq+dDsXFhbx7LQ5NOvQv/SodVWn5ld+8yOd+g4jImogr8xfhMlkAsBoNPLWoo/o0HMIEVEDmTJzful+tmPXfu6870nadL2Wpu378ey0OaX78dw336d1l2v4468tdO57I09NmV1uG7TsNIgf1/5Or6tH0rrLNby37DP+2bqTgTfcTtP2/Viw6KPS6X/fuIVb7nyY5pEDaNX56tJtULJNBg+/iy+/XUO7boPLzFfimRdeJahFD/buPwzA0eOnGDH2QZq07s2AoWPZsWs/ULxvbtm2ky3bduLVJIq5b75v9feKEPagqgLJYDCSnpHJ/kNHWbL8CwBaRjQtN92Xq37is6++5/4Jt/HI/ePIy8/H0cGhzDQbN23l5XnvMOP5x7j+mv4Vru/Pv//lnomTaRXRnNdmTyElNZ0Rtz1IYlIKo0YM4Zbh1wPw5pxpPDHxbhbOK/6lM2LYYN5+bUaFy3xqyivcNPQaenaL4qtv19B/yG306dmVq/p054ef1/Pr+r+qXXeJNb/+we59h3hi4t1oNBomz5iH0WjkoXvvoE/PrgB8/uECpk+eVDrPth17SU1P5/GJd5OWls4LL78BwF+bt7HgveUMu34Qzz/1EGbMODk6lmn7sROnGTH2QTIzs5n78mQGXNWTpuFNAHhy8ixWfPkdj9w/jon33cknK7/laYsv9ikz59OjaxQ3XDeIdX9splv/4YSHhTDihsH8tXkbn331PQD/7drHHfc+SZPGQcx56TliYi7wpMWyKjPnjcX4eHvy2EPjOXr8NHPeWFxumnc/+JRf1v/FlGcmcsetI8jJzcPB4dLB1qUff8mtI2+gd48ufPfTOn77vbiA/nTlap6bPpcBV/XglRnPcODgUW65cyK5eXml83604hsOHj7Gay8/z22jbuT+CbcBMO25SXz+4YIK23z46AmcnZx4ZcYzZGZlM/7BZ8jJzbUqL8CEh5+jX5/uzH9lCqdOn2PKzPl06dSBl6c9iaurC3oHPdMnT6JVRDP8fL35/MMFPHTvHZVOW53klDTmvvk+942/ldYtm/PBRyvZd/BItX1U1X5Zm3VVJjcvj5F3PMzBw8d55cVn6N+3O89Om8NnX35fZronJs/itlE30rtHF1b/+Fvpdn53yad8+OnX3D/httLtN+P5xxjQr2eF69u4aSvPPHY/fXt14413lvHTL78DsGjJCmbNe4dh1w9i6jOP8MU3P7L0ky8BOHLsJO7ubkyf/CgD+/Xiw0+/ZvWPv5UuMyk5lSenvMLD993B/RPGlltnUnIq8xcu4YG7b8fToxHTXn6DJ5+fxbjbbiYo0I/Z8xeVFiI79xygedMwZk1/iratI5j75vtlrrM7dOQ4b7y9lMlPPsTIm64vs57Pvvqej1Z8w7tvvESnju1Iz8jk5tsfIiExidkzniasSWPuuO8JcvPyePu1GXh7edK2dQs+/3ABo0YMsep7RQh7UdUptp17DtC0fT8AXJydmT3j6QqLm0aN3ADw9/Nhwh2jyl2jci7mPDPnLOSG6wby1KR7geK/Gkt+0Wm1WjwaubPk4y/R6/UsevNlGrm74e/rw5gJj/LN92t59MHxtGzRDIBB/XrRvFkYLi7OALRs0ZSrB/SpMMP0yY9y3/gx9OwWxbo/NnP3HaN44pF72LPvEL+s28ixk6cBql03QIC/L198tBCNRsPBw8f4ZOVqkpJT6RTZliaNi0893Tjk6jLr79qpA++9OQuA3zf+wz9bdwLg7lbcZ16eHtwxZgQP3XtHubZ/tOIbCgoK+fLjtwlr0pi7xhYfsUhNS+fbH39l1IghPPHIPQDsPXCEb77/hddmTSmd/6F7b+eZx+4nOSWVL1f9xJDB/Zk++VFSUtNY8eV3HDtRnP3DT7/G1cWZRW++jKOjA7m5eTz/4msUFhbh6OhQrl2XGzHsWl59sfjo4spvfuTEyTPlpmnk7oZGoyEkOJAb77kavb7sx2TBvBkMvvoqOnZow/o/N3Pi1FmguHAKDPDjrbnT0Wg0FBYVH2n4feMWht9wLQCuri58/uECPD0aAdCxfRsAenXvTL8+3Stsc1RkW96cMw0o/sU3a9477Nx9gAFXVfwL2dKtNw9lxvOPAcUXOjs46HFzc2X4Dddyz7hbAQgPDcHH25O8/ILSfaKyaa3x8fvzad2yOY3c3dmxez8nTp4lqkPbavuosv2yNuuqzIY/t3DmXAwL5k1n/O23MO62m1m7biMfLP+C8XfcUjpdZdv5v137iGgezrTnJmEwGPjimx9xcXEmPDSkwvW9+8bLtG/bkmsH9uXHtRv4Zf1f3HzjdSz9+Ev69enO1GcmArBl207W/vYnjz44nvF33MK4sTdz4PAxcnPz+OHn9ezYvZ/bLl5/ZTKZmDXtyXIFy+WWL36N1i2bk5OTy4uvLmDuS5MZfPVV5OXlM+OVtzh1JprAAD+mPP0wRUVF7N1/hB5do/j7n+3s2LWf3j2KT2fm5uWz9J05dO0cWdzO7cVHMHftPchrCz7gkQfGcevIGwD46ZffiU9IYvFbs+jSqQNdO0fS//rb2LFrP1cP6IOLsxM+3t6l2zcjIwuo+ntFCHtR1RGkdq0jWPPNh3Tv0hEfb0/uH38bGo2m3HQjb7qeRW++zKKlnxHV5waWLP+i9PA6wMLFH5OWnkFySmrp66t++IWm7fvRtH0/+g4u/kVxLjqWiOZhNHIvLh5KLro+d9lplZpyuPjL2NfXu/jni0e2fHy8AEoPwVuzbr1OV5rfz9cHgILCwqrXf9kRAj8f79L1de/akS+Wv836PzbTvsf1zHljcekh/xJnz8Xi5elBWJPG5V4HyvzS6tyxuL1noy+1tyRrSVtL+8LH+2L2wovZz5OTm0erzlfTtH0/Js+Yh9lsJjUtvcpsly+zeD3eFFx26qzEpAfv4qUXnuDZaXPoNmAEq3/8tewyLvaR38V2FRQUlmaJ6tC2tM9LMp67eC0aQLPwJqXFkbUu34dbt2wOYFXWEpf3e5PGQfz41TLOnI2hfffref7F10pPdVqqybSWSvrZ7+J+XLLfWdNHNVXZuipzLrrs/qjVaukU2a709dLlVrKdI9u35sy5WP7esp3v16wnNy+fkKDKr3Ur2XzBQQF4ejYiLS2DwsIizsclsPnfHaXfK9/9tI6k5FQA/tm6ky79buL6ERNKjzhlZmaVWW5VRSBU9F1S/POl75LiPD/8vJ4OPYcw8o6H2LTlv+J1ZWWXXVdk+XXNeWMxhYVFJCWllr5Wsh1vuXMiTdv3o//1xUfYSnJZsuZ7RQh7UdURJA8Pd/r16c605yZx8+0P8f5HK3n60fJ3TGg0GsbddjNjR93I2+9/wvMvvkbb1hGlX9qB/r7MnPoEDz0xjc+/+oHxd9zCtQP7suabDwFwdio+4hQe1oTfN24hKzuHRu5u7NlXfA4+/OJppbp0pevW6nQA5OcXWH2X1w3XDWTo4AF8vfpnHn5yOmGhjRl3282l74eFNmb9n5uJOR9HaEhw6eslp9n2Hjhc+tqei9crNA1rQmZ22S/j6oSHNubQkeN8/uECdBdzwKVfkFfKwcGBxx6awAMTxjJt1hvcN2kKXaI6VDtf07Am7D1wGLPZjEajKc0YHlbxkQUAra74b5SSX77VOX7xKFqzpmEX26on8eIvn8LCIvLz86tdRp+eXVj3w6f8vWU7o+58BE+PRrzw7CNotToKCgqsmra2quuj2uyXNRUedml/7NKpAyaTib0HDpe+Xp17x93Kux98yojbiofEuP6afgwbMqja+eITksjIyKJZ01AcHR1oHBRASOMgXpzyeOk07m6uQPG1P+1at2D7n9/j5ORYZ3ec5ucX8NAT07hzzAjmz57C+bgEonrfYNW8bVq1YNxtNzP1pfncedsIBvbrVXoUbcG86UQ0b1o6bbs2EUDx9rXcx6r7XhHCXlRVIJUYcFVPevfozIJFH3HX2Jvx9/Mt8/7MVxeQnJpGv97dOXM2BgCdTld68eQzjz/AbaNuZM2vf/Diqwu44fqBBAb4ERjgV2Y5D949lnW/b2LS0y9y/bX9eW/pZ3h5enDrzdZ9wVyJK11304u/DF5b8AGD+vemf98eVU6/9OMv2fzvDoYMHlD6S/ry4gTgrttH8vHn33LHvU/w8H13cuZcDB3bt2H4DdcyesRQ1vz2B28v/hiz2cwv6zcyZuQNeHt71rhAunf8GFb98CtvLfqIW266nsTkFMJDQ8qdCqsNs9nMQ4+/gI+PN50i23IhPhGNRlNayFTlwXtu58kps3l66it07tiehe8tp3nTMK4d1LfSeUq2w7JPvyInJ5fhw64td9Tz2PHTzF+4BB9vLxa+/zGdOrajY/vWALRs0YztO/Yy543FbN+5lwyLowyWfln/Fx98tJJRw4eQkZmFwWBAdzFb0/AQ/t2+i8Uffk73zh1JSkmtcNqioiJuGHUvzZqGsvSdOdX2S036qKb7pbUaBwUQExvH2ehYrh3Uh6bhTXhr0XL0ej279hwkKTmVGZMfs2pZH634Bi9PD+6fcBt6nY7OUe3JysrB29uzwulfff09bhx6DZ9/9UPxH2djbwbg/rvHMmveO3y9+md69ejM0eOnGD2i+OaNvLw8Ys7Hs/qn3/h94z826YOKFBkMFBUZOHbiDN98/wurvl9r9bwvTX2Cawb24avVa3h66qv8+/u33DT0Gl55fRGLlqzg7jtH4+CgJy09s/T0cdOwEP7btY/Pv/6BTpHt+Hf7rmq/V4SwF1WdYiuh0WiY+swjZGXn8NqCJeXeHzl8CDGxcTw3fS5//v0vM6c8Xub24ZJD06/MeIbcvDymz36rwvVcM7Avyxe/xrETp5k8fS7eXp78+PXScoVUXbjSdd8/YQxX9e7GkuVfsOC98nemWBo86CoMRiMvvPw6X6z6iYn3j2PMyLLFWFSHtnzz6btotVqemzaHdb9vwsW5+LqrBa/N4K6xI1m0dAWLP/ycCbffwlvzKr5QvTq9unfmi+ULSUvPYOpLr/P16p/LnRKoLY1Gwx1jRrBrzwGenvoKR46d5N03Xqr0+pLLTbhzFK/Nep6Nm7cxbdYbtG/Xiu9Wvo+ri0ul8/Tt1ZUJd4zi3227mDl3YYV3491803XsPXCEl+e+TZeo9qxY+iZabfFHd87MZ/Hx9mTl1z9wdf/eVV6TAtCtcyRBgf688voi3lr0EbeNupFHHyq+Zu2ZR+8nKrItr85fxKdfrK50WrMZsnNy+Oa7taRnZFa5vpr2UU33S2vdcetw0jMyWfPrH7i5uvL9yg9o3yaCaS+/waYt/zF/9hTuun2kVcu6ZmBfkpJTeeOdZbw87x1uvv0h2nW/rsKLw/39fOjepSMvvvIWF+ISWL74tdLrzh5/eAIvTX2Cf7btZPL0uWzdvrt0P379lakkp6Ty6vxFtG0dQaeOdTNmWiN3N+bMfJZDR47z+sKl3DT0Gvz9fKya18FBj1arZd7Lkzl9Npq3Fn2Et7cnP329jPCwEOYvXMLbiz8mOSW19FT9S1OfIKxJY6bOnM+PazdY9b0ihL1oCgsLzNVPJoQQlxw4fIzrho8n+sg/pdeO/b+49qZxdOnUgfmzp2A2m/lv1z6uv3kCr858lkkP3GXv5gkhbESVp9iEEHXn5Omz3Hnfk0x5+uH/u+IIiu/uS0pJpVl4KM7Ojnz30zqcnBwZ1K+XvZsmhLAhOYIkhKiR5JRUdu45wJBrB9i7KXbx95btzHx1YfFYRW5uREW2YfKTD9Gre2d7N00IYUNSIAkhhBBCWFDlRdpCCCGEEFdCNQXSyPFPcvxU2edE9b5+XIXPWFOSlNR0Js98q8yzwOrK+IkvsHvf4eonrKF1f25h5Srrbx+ujbj4JAbf8mCdrkNJPvxsNQve/8yq6dauv/SswZWr1rLuzy112bQas/wMzH5jSY320517D/HO0i9qvN6vvvuN2W+Uvwu2ruzed7he11dT9v6MVfT9tHvfYcZPfMFOLYJTZ2N4ef77dlu/qFtykXYD5+vjxfyXn7Z3M67I9VdXPg6QaFjuvHWYvZtQzpV+Brp1ak+3Tu1t2CIhirVoGsrMyRPt3QxRR/5vCqSR459kxNBBbN2xj+SUNG658drSXwZXj7iPO28dxrad+0nPyOL+u0Zx/dXFz0r7ed3frPx2LUajie5dOvDMI+PRarUMHTORh+6+lR/W/snTj4znq+9+pVNkG8bcfGkcGpPJxOLlX7N732FycvNo1zqC6c88iE6nZfWaDaxc9QsODjp6dYviyYfHse/gMea/8zFGk5HgQH9emfYYZrOZ60Y9xNZ1n2M2m/ng429Y/9dWMjOzMZnMhIYEsnzRbB6fMpdr+vdk07+7OHEqmlHDr+W+ccXPlTp45CRvLV5BTm4ewYF+vPjcw/h4exKfmMy8hR+RlJxGSHAA6RUMMrh732FW/bgBby8Pjp44zeI3ZnDydHSFy/v9720s+WQVObl5pKVn0qJZKFOeuI+DR05y4vQ5Zjz7EGvXb2LP/iMYTSb2HzpO+zYtGHPzED78bDXHT57jnjtv5tYR1wGwZfsePvh4FYVFhbRsHs70Zx6s1ejK/2zbw7LPvsVgMNKkcSDPPno3/r7ejJ/4Ak88NI6undrxzQ/rWPLpKtZ9uwS9TsfkmW9x09CBXNWzM59+9RO//v4PZrOZoddexT133ExcfBLTXn2Hvj07s2nrLubNeJLpcxZx1203MrBv2Weqbdu5nyWfrMJgMOLn68XcGU/w+aqfycrO5amJxbeFP//SAvr36cqw6/oz+40lhIYEse/gMU6djWHMzdfj7eXBD2v/JCk5jZenPEJUh9asXb+JTf/u4rWXngJgwfuf0cjdlfvvGlVm/Smp6by95HNiLySQmZXDmJuvZ8zN17Pqx/V888N6XF2c+fr731i+aDbvLv2CRu6uXNO/F09Nm8/3nxU/yy8vP59bxj/Ft5+8RV5ePvPf+Zjo8/E4Ojow+bF76NA2osw6K9t2J8/E8Nrby8nLz6dJ40BOnDrHotdeIDjIn97Xj2P96iU0cnfj+KlzPP/yAr5fsZCs7JzSz8D7y79m4+b/2HfwGCHBAQwe2Jt/d+xjzvTi0aj3HDjKshXfsvj16aVt+fvfnXz9/W8sfn06u/cd5vNVawkNCWTnnsOggddffprGQQGYTCaWrVjNhr+24uvjhZOjI/5+xaOzFxUZeO+jr9i6Yx9ms5lxY25k+JCBzF3wIQH+Ptw37hY2/LWV3/74hzdmPVs62GdF+0lhURHz3/mYlLQMPBq5Mf2ZB8nMymHW60vIzctn/MQXmPz4vWzbua/KfaR1RFM2/rODDm0i6N29Y6W5KpOSms5bi1dw5tx5HBz1PPHgnXSJaseBwyd4Z+lKcvPy8fHy5JlJE2ga1rjc/GejL/DGe5+Qlp6Jq4sLTzx0Jx3aRhAXn8T4R6ax4bulFfa/td8n1nw/QfGz4l59axnHTp5Fo4FpTz9I4yB/br3nGb76cD6eHo0wm83ces8zvD13CiHBl/rE8nu8cZB/hfv2ydPRzFnwIalpGSQkpRASHMBtI4cQ1aF16X4aF5/E8y8voG+vzmz6dxdOjg5MffJ+PvtmDfsPnaBTZGtmTp6IRqPhXMyFcvtAWJPgCvMJ+1HNKTZrODk58sGbM1i28CWWf/E9p88WP3spL7+AFk1DWbbwJea/9DRzF35IekYW+w4d57c/t/Dxolf4ctl8srNz2bS1+EGN6RlZxF5I4ONFs+nYvhXBQf74WIykq9VqGXRVdz58+2VWLn2NoydOs33XfgAWL/+aOTMeZ+XS17h91FA0Gg0rv13LjdcP4KsPX2fy4/eUPnagxMEjJ/npt79YuWQea75chJubM3NffBL9xZFnj508y5uvPMc786bw8cofyM8vICs7hzlvLWPujCf4+qPXGdC3G59+9SMAs19fQpeotqxcOo9pzzyATlvx7rB56y56d+/I8ndnU1RUVOHyDEYjr765jJeef4Sfv1xEnx5R3DHqhnK/OAF27T/Cg+NHs3LJPPbsP8o3P/zG6y8/wyvTH+ODj7/BbDZzPi6RpSu+5b3Xp/HVh68TEhzA97/8WeNtHnM+njkLlvHqtMdZuWQeUe1b88rF0xi9unVk18VD9jv3HKJty+YcPX4Gg9HIgSMn6NKxLes3buVczAVWLpnLyiXz+G/3QY6dOFPa3x6N3Pn0vVcJDvInrElQueesxV5I4OX57zPtmQf57IM5zHj2IauKvP2HjjN3xhO8OetZ3vvwK3Jy8li6YCY3DRnAiq/X1KgPPBq5c+foYSx/dzaLX5/Gog+/JCs7h1tHXEe/3l14YPwoVrw/p3Q/AmgWHoKXZyMOHT0FwL//7aN75w64ubrwyptLueWma/nqw/nMmvII89/9uMz6Ktt2BqORqbMWMubm6/j8g7k8+fA4klPTa5Rl4r230aZVM1546n7enjuFwYN6c/DICVLTMoDi07nDriv/gOrLHTxyghsG9+ezD+YQFhLMj79sBODXP/5h2879fLr4Vd5/YzrhoZd+Ya38di1Ojg58uew1Vix+lZWr1pKalsGk+29n7frNnDl3no9X/sAzkyaUHwn9sv3E39+HGXMW8dTEu/jqw/nce+dIFi37kg5tI3hg/Cj69e7CivfnVPi5sfTtTxuY/9JTTLp/bJW5KjP7jSU0DQth5dJ5vP/GDNq0ak5mVg5TZi3kyYfHsXLJPG658RqmzFqI0WgqM6/BaOT5l99i1I3XsnLJPJ58+E6mzFpg1SUN1nyfgPXfT7m5+dw5ehgrFr/K8CEDmbfwQ9zdXLluUG9++f2fi31zkkB/3zLFEZT/Hq9s31704Zdc3a8HP3z+NpPuG0unyDalf8hd7vTZWDpHtuWz9+cQ4O/LzHmLefzBO1m5dB6bt+7m6Ini75eK9gHR8KjmCJJWo8FsuvQhLnlsiPayL6uuUe3QaDT4eHvSvnUEh46donnT4kcbdO1UPFJts/AQ/H29OXkmmu07D3Au+gIPPvkSAPkFhbRr3bx0eeNuvbH0y/CxByp+CnVIcCCr1/zO4WOnyc7OJfZCAgCjbhrMm+99yh2jbqB/n24A3HBtP5atWI1Wq+WmIeVvofbz8cJkMpOVlYNGAwUFRaUjKgP07dkZvU5Hi2ahODg4kJaRxdno8yQkp/DczDcBMBpNNAsPITcvn30Hj/HWq88B4OnRqPTBt5bCQxvTr3dXoPiLpqLl6bRa/Hy9SE1Lp6CwkJycvAofFAzQqnk4wUH+xf+OCKdn1444OOjp2K4luXn55OTmsX3nfhISU3h08qsAFBYZ6NOjU4XLq8p/uw/Qs2tk6VPiRw8fzOLlX5OXn0+vbh1Z8um3GIxGzsclMuqma9m55xBarYamYSG4ubqweesuDh07xb2PvQgU/7Ual5CMRyN3nJ2cGD18cOm6KjrU/t+uA/ToEklEs1CAckV0ZXp0icTZ2YmI5mE4OznRr1cXNBoNkW1b8ve/u2rUBw4Oepydnfjo8+85dTYGDRoSElMq3d4lhl57FX9s2kaHthH8sWk7N17Xn9y8fHbuOURqWgaLP/oKoNwvxcq2XUxsPAWFhVw7oHi8oKAAPxyvcBwlJ0dHbrp+IGvXb2LsLUPZvnM/jz94Z5XzBAX40TqiKQDt27bg7LniB6z+u30vI4ddjZtr8ajeIcGBnDhdfF3j5q27ycrOYeuOfRczFRGfmEy71i145N7bmPjsbO4cPazCIzaX7yex5+M5FxPHrNc/AMBsptbPnBsxdFCZbVhZrork5uWzc+9h5s18Co1Gg6tL8Yj3//63l9DGgbS/+Oy0Qf16sOCDz4g5H4eTo2Pp/DGx8eTnFzKoX/GjYNq3iSAkOJCDR07SNLT80abLWfN9UpPvJz9fr9IjXP16d+WtxSsoKjIwevh1PP/SAsaOHML6jf9yw3X9Kpy/5Hu8qn070N+X1PRMDAYDaRmZlX63ubg406NL8XMbO7SNwM3VpfQZkS2ahZKUnIaLs5PN9gFRt1RTIAX4+ZCafumxB8mp6bi5uuDqWvFjHvR6HS5OFe+Uer0OF2cnzJi5dmAvnnhoXIXT6ap5PldiUgqTJs/hrttu4sEJo9FqNZhMxaMqPHLvbcTFJ/Hp1z/x8Zc/8uHClxjUrwfdu3RgzW9/cdt9z7LotWn4+lz6hRoU6EerFuG8OO89cnLzePyhOwkOLP9oEY1Gg16vA7MZs9lMk8aBfPreq2WmKXkquzXPPbo8Z2XLA7hhcD+WffYd7y//hu5dOjB4UO9ql63XXdoFS56lZjabMWOmU2Qb5r34ZLXLqKmS77bIdq04c+48+w8dJ6J5GJ07tuXNxZ+id9DRs0tkaVtuv2VomVOnUHzqRKvVVvpFWcJkNlPRJBqNBoPRaEVbL27Li0q2a/GbYDBW/+TzrTv28d5HX/HQhNGMHj6Yu49Px2SufnSPwQN788CTL/HA+NEcOX6aWVMeobDIgBkz770+rdJfWJVtuxOnzqHT6arsM4Oh+j6xdMuN1/D41Hk0b9qErlHtSn/ZW0Ov01PSEwajsdLPg9ls5rEHbi/9xX65szHn8WjkTk5uXoXzXr6flPwy/OS9V8r8cVOR6vaRqj67l+eqlNlc5g/IStuBBrBmupJ/aDAYjKUPJLZkzfdJTb6fLqfX63BwcECn0xIaEkSTxoHsO3iMbTv3M/He2yqcp0x7Ktm3bxjcj9lvLGH7zv00CQnkuUfvrr4turK/XvV6HWbMNdoHhH2pZuv07NaRH9b+icFgwGw28+2P6+nZNbLMBzTmfDxQfBj00NFTdIpsXe69/3YfJCc3jxbNwujbszO/bPiH6Ng4AOISkssdai6x6MMv+WPT9jKvHT52GhcXZ266fgBuri6cjb4AQEFhIQcOnyA4yJ/H7r+ds9HnSUlNZ/f+I7i6ODP2lqEEBwZw6OjJMstLSEohMTmFD96cwecfzOWm66sfqK99mwgSElP4c/N/AKXXB7m7udIsvAm/XjwEfSE+0arTHZUtD4qv13pr9rN8sew1npp4V5lTNjXVo0skO3Yf5MDhEwCkpWeSm5ePwWjkmRlvcC7mgtXL+W/3Qc7HJQKw+uff6dKxLS7Ozjg46Okc2YbVP22gS8e2NA1rzIW4JPYdPEaPrsV/BV7Vqwvf/LCOlIt9cyE+sdJ1vTz/A/YeOGqx/g5s27m/dNvHXkjAaDTh6+PFkWOnKCgsLN4fj52saJFV8vPx5vipaHJy80hMSuG/3QdK39NoNJgvFkFbd+yjW6f29OvdlbT0DLKyLh3xCQrwI66C579B8dGupmGN+fTLH+nXqwt6vR5XF2c6d2zLshWrMZlMGI0m4hKSLTJXvO1CmwRTkF/Ijj0HgeJTT/mXPdndz8eLfQePYTAa+fX3zZXmLm7zpXX6+njROqIpSz5ZxTArPhOV6RTZhl//+IeiIgMGo5HDx06VvndVr86s+Ppnci7+4i7ZD85Gn+ePTdtZtvAl/ti0nWMnz1a5jtAmQXh5uvPVd79hNpspLCwiMTm1NFd8QnLpdrPFPlIZVxdnOnZoxRerf8FsNpNfUEhiUgod2rYkNi6h9NTqX1t24OLiTGhIEGg0mMym0hzOzo78tWUHAIeOnuJ8XCId2kbg7dmIoqIijp88S0FhIev//LfSdtji+ykrO4f0jOLrk1b9sJ4+3aNKC4/bRg7hrcUriOrQutrCuap9e826v3lwwmhWLp3HazOfKj0qVBtV7QOiYVHNEaQ7Rt3A20tXctfEF9BqtIQ2CSpX5f/1zw5WrvqZ/PxCXnzuoTI7+eo1v/PaO8vRoGHujCdwdnKkc2QbHnvgdp5/eQF6nR5PD3dmPj8R/wo+HOcvJJZ7vVvn9vyyYTPjHppKs/CQ0sPA+fkFfPfzH7zx3idkZuUw7tYbCfD3Ze2GTby95HNycvKIaB7G1f17lPmL2s/XG4PByG33PYezkyM+3p5EtmvFvXfeXGm/eHq48/rLz/D2ks/56LPvcHJyYNJ9t9O1UztmPPcQcxd8yKof1tGiWWjxl2A1qlpex/atuOexF/HyaISbqzMtmoXy4ITR1S6zIqEhQbw8ZRLz3/kYM2ZcXZx5/ol7CQkO5FzMhdK/MC+Xk5vH6Lsv3e1087CrGXfrjUx98n6mzn4bo9FIk+BApj/7UOk0Pbt15M33PuHhe8ag0Who17o5u/cfoXVEMwCGXNOXpJRUHnnulYsX7frw6rSKn/p+LuZC6Rd1ibAmwUx96n6mz3kXrUZDgL8vLzx9P1f368na9ZsZc8+z9OgayQCLC7ut0TWqLa1ahHPbfc/SsV0rrh3Qq/SXa+eObZnz1jLuHD2MYYP78cZ7n3LvYy8S2a5lmYtBr+nfk2defIN//9vHG7OfKbeOodf046XXFrNkwczS12ZOnsgbiz7h9geex8nRgWHX9ee2kUNK369s27VoGsrLUx9hweLPcHJypGP7VqUPhgZ4YPwo5iz4kLBVQYwbcyN/bdlZYe5hg/vz0muL+WXDZt6eNwW9TsfQa69i3sKPiGrfqsb9WOKWG6/h1Olobn9gMkEBfjRv2qT0qNBdY24iOzuXex57EWdnJ1o0bcL0Zx5i3sKPmHTf7Xh6uPPUxLt49a1lLH/n5dKjoZb0Oh2vzXyaN977hDXr/sLR0YG7xtzEtQN6EdmuJYVFRdzx4PM8+fBdNtlHAHbtPcyqn9bz6rTHyxwtmfncROa/+zF3PPg8Ls7O3DduJH17dmbujCdZ8P4K8gsK8fJsxLwXn0Sn0xLo70NYSDCrflzPrSOuK86x6BOWrViNq0vx9ZAlR17uufNmHpsylxbNwhg+ZCBr1v1VYdts8f3k7+fDa28vJzo2jqBAX1546oHS97pEtSUjM7va69JK+6SSfbtj+1a8/u4nrPh6DY4OesJDG3PbyCG1OgJU1T4gGpb/m5G0R45/ktdmPkWrFuHl3rv87pmG7Nff/+Hg0ZM89+jdmM1m9h86zqTJc1j37Qel103Yy/m4RF545W2WvzMbnU5LWnomd02cyrSnH6R39yi7tk00XINveZAVi18tvSatNkwmE3PeWkbH9q0YPnSQDVunDiaTiUmT57Dg1ck4OzlWP4OK7Nx7iI8++47Fb0yv9nR4VcbeP5l35k0hwM+HwsIips5eSPPw0NIL5IU6qeYI0v+DDm0jWL/xX8Y/Mg2jwYiLixOvTn/M7sURFJ8OaNE0lPsefxGD0YjZZObWEdfTs2ukvZsmVOzEqXNMnf02UR1ac+MVnF5Ts0+/+okxI677vyuOnpv5JvEJKcx+4dErKo6g+Ejy1FlvU1hYRGFREZ06tGb82Jts1FLRUP3fHEESQoj/R5VdLC2EqJpqLtIWQghRnhRHQtSOFEhCCCGEEBakQBJCCCGEsKD4AslsNpeOfSSEEEIIYQuKv4vNaDTSb9jdHDlUPEheeuw+vJpElfl3yf/1Dg74+fmTnJxE8pmdpe8BZeaxBctlX94uy3ZW9NrlbTUUFVk1f2XLsuyHil6rbHmW/VPd8izfv7w/KltmVf1UW7Zajr2pJYelmuSq6nMLVPpzVZ8vW7TXcj+vaH+uajk12e+t/ZwC+DXrVua7w3Ka2vRBTT+jtenr2m6f6ra15ffqs09O5O7bRxAU4Ffh935F27Syaerys1my3/+19jPadLmmwu/Vy9tjqbJ+qWz62qjPPrh8e1W1/pr2k6XL51P8ESQhhBBCCFuTAkkIIYQQwoIUSEIIIYQQFqRAEkIIIYSwIAWSEEIIIYQFKZCEEEIIISxIgSSEEEIIYUEKJCGEEEIIC1IgCSGEEEJYkAJJCCGEEMKCFEhCCCGEEBakQBJCCCGEsCAFkhBCCCGEBSmQhBBCCCEsSIEkhBBCCGFBCiQhhBBCCAtSIAkhhBBCWJACSQghhBDCghRIQgghhBAWpEASQgghhLAgBZIQQgghhAUpkIQQQgghLEiBJIQQQghhQQokIYQQQggLUiAJIYQQQliQAkkIIYQQwoIUSEIIIYQQFqRAEkIIIYSwIAWSEEIIIYQFKZCEEEIIISzoq3qzz5C7iGgWSlZ2DkGB/kx/5kFCggN4ef77TLpvLH6+3uXmWbt+E0eOn+HZRyfUWaOFEEIIIepSlUeQnJ0cWfH+HFZ/uoCr+/Xgg4+/AWDm5IkVFkdCCCGEEGpQ5RGkElqtlq5R7fj1938AGDn+ST5+dzYOeh1TZr1NfGIyjYP8mfvik2Xm++jz78nPL2DS/WPLvG4wGnlnyUp27T2Mk5Mjz0yaQPs2LVi7fhPHT50lPiGFw8dOcf9doxhxwyDbJBVCCCGEsJJVBZLJZOK3P7fQOqJpmdf/230QR0cHVn38JgmJKbi6OJe+t/fAUXbsPsCi+S+UW95Pv/5FYnIqny+Zy6mzsUye+RbfLH8dgP2HTrDotamci43jxbnvSYEkhBBCiHpXZYGUX1DI+IkvEJ+YTP8+3Xj6kfFl3u/YvhUff/kjSz/9lrG3DC19PTMrm5nzFvPC0w+g1+vZc+AoCxavAGDy4/eyc89Bru3fC41GQ0SzUFxcnIiOjQegfZsI3NxcaRXRlLT0zArb9e1PG1i9ZgMAZrO59umFEEIIISpQZYFUcg3Sqh/Xcy4mrswRIgBfHy+WvzuL337/h7snTWfR/KkA/LFpG/feOZIvV/9Cjy4d6BzZhhXvzymdz2wGNNU0TKertPgZPXwwo4cPBsBgMNBv2N3VxBRCCCGEsJ5Vt/mPHHY1u/Yd4uSZmDKvnzl3nry8fIZd159m4SEcP3UOgGv69+K+cbfg5urClu17yy2ve+f2/PH3dsxmM6fOxpCbm0doSNCVpxFCCCGEsAGrCiS9Xs/D94xh4fuflTmqk56ZxdPT32Ds/c+h1Wro1S0KAI9G7gA8fM8Y3l/+NUVFhjLLG37DIHx9vBj30FRefXMps194DAcHqy6HEkIIIYSoc1VWJX/++FHpvwf06caAPt0A+H7FQgA6R7Zh2cKZZeYZdl1/hl3XH4DQkCBWLp1XfqU6XYXjJF0+r+X6hRBCCCHqi4ykLYQQQghhQQokIYQQQggLUiAJIYQQQliQAkkIIYQQwoIUSEIIIYQQFqRAEkIIIYSwIAWSEEIIIYQFKZCEEEIIISxIgSSEEEIIYUEKJCGEEEIIC1IgCSGEEEJYkAJJCCGEEMKCFEhCCCGEEBakQBJCCCGEsCAFkhBCCCGEBSmQhBBCCCEsSIEkhBBCCGFBCiQhhBBCCAtSIAkhhBBCWJACSQghhBDCghRIQgghhBAWpEASQgghhLAgBZIQQgghhAUpkIQQQgghLEiBJIQQQghhQQokIYQQQggLUiAJIYQQQljQ27sBtuLq4lLlv11dXNDp9Oj1elycnKucp67aY7mOitZZ8trlbTXq9VbPX5M2WL5W1fIqW3d1/V5VW61Z5pWw9Ta1F7XksGRtrqo+t1X9bM0+VxPVLc/az2dt93trp3Nxci733WFNu6xRk89obdZT27ZZu210On2l01Q1X2XT1OVns2S/t2Z9tnq9NuqrDypbV00+59W1NTcvr8zPmsLCArM1DW2oDAYD/Ybdzea1n5TpyIrEJybzyZc/cvftIwgK8KunFtaOktoqRF2Sz0LNSH9VTkl9o6S21pX67gOvJlGkx+4r/VlOsQkhhBDi/97lxRGosEBq3LJXuX9f/lpF71nOY4v/LJdt2Yaq2lRdruqmtaYfLF+rbHmW/VPd8izfr2z+ivrcmlzWstVy7E0tOSzVNldl+1ZFP9tqndUtr6r9uarl1GS/t/ZzWt13yJX0e00+o7VZz5XuE5W9Zvn+51/9QPf+N1f6vX/5z5bLrIvvqup0739zmfVV9vvGUmX9Yst212cfWPuZrmk/VUU11yCVuPwcYsm/Lc8rVvVeRdPasi1Vraeqdde0ndX1g+VrlS3P2r6ztt8rer2qfqotW25He1JLDku1zWXt57amny9r11ubtlT2Xk32+9p8TmszjTXz1tW6rnSfqOw1y/cNBgN5BfkYiooqncaa/ae+Ppt5Bfll1mftem39GbB2HXXBcntVtf6a9lNVVHcESQghhBDiSkmBJIQQQghhQQokIYQQQggLUiAJIYQQQliQAkkIIYQQwoIUSEIIIYQQFqRAEkIIIYSwIAWSEEIIIYQFKZCEEEIIISxIgSSEEEIIYUEKJCGEEEIIC1IgCSGEEEJYkAJJCCGEEMKCFEhCCCGEEBakQBJCCCGEsCAFkhBCCCGEBSmQhBBCCCEsSIEkhBBCCGFBCiQhhBBCCAtSIAkhhBBCWJACSQghhBDCghRIQgghhBAWpEASQgghhLAgBZIQQgghhAUpkIQQQgghLEiBJIQQQghhQQokIYQQQggLUiAJIYQQQljQV/ZGnyF3EdEslKzsHIIC/Zn+zIOEBAfw8vz3mXTfWPx8vcvNs3b9Jo4cP8Ozj06oVWNenv8Bp87G8Pzj9xCfmMLHX/zAwL7duP+uUbVanhBCCCFEbVRaIDk7ObLi/TmYTCZWr/mdDz7+htkvPMrMyRPrpCFJKWnsO3iM71YsAGDpp9/y9CPj6dKxbZ2sTwghhBCiMtWeYtNqtXSNasf5uEQARo5/kvSMLHJycnns+bnces8zPDF1Hrl5+WXm++jz73nvw6/KLc9gNPLW4hXc+eAU7n3sRQ4dPQXAC7PfISU1nXsfe5EvV//CgcMnmLfwI7bu2GeLnEIIIYQQVqv0CFIJk8nEb39uoXVE0zKv/7f7II6ODqz6+E0SElNwdXEufW/vgaPs2H2ARfNfKLe8n379i8TkVD5fMpdTZ2OZPPMtvln+OrOmPMKzL77J8ndnAbB5224ee+AO2rZqXm4Z3/60gdVrNgBgNptrFFgIIYQQojqVFkj5BYWMn/gC8YnJ9O/TjacfGV/m/Y7tW/Hxlz+y9NNvGXvL0NLXM7OymTlvMS88/QB6vZ49B46yYPEKACY/fi879xzk2v690Gg0RDQLxcXFiejYeFycnaxu9Ojhgxk9fDAABoOBfsPurklmIYQQQogqVXqKreQapAfGj8bZyanMESIAXx8vlr87i8ZB/tw9aToX4otPwf2xaRvDhw7ky9W/YDab6RzZhhXvz2HF+3Po0DYCsxnQ1GkmIYQQQogrUu01SCOHXc2ufYc4eSamzOtnzp0nLy+fYdf1p1l4CMdPnQPgmv69uG/cLbi5urBl+95yy+veuT1//L0ds9nMqbMx5ObmERoSZJs0QgghhBA2UG2BpNfrefieMSx8/7My1/ukZ2bx9PQ3GHv/c2i1Gnp1iwLAo5E7AA/fM4b3l39NUZGhzPKG3zAIXx8vxj00lVffXMrsFx7DwaHaS6GEEEIIIepNpZXJnz9+VPrvAX26MaBPNwC+X7EQgM6RbVi2cGaZeYZd159h1/UHIDQkiJVL55VfoU5X4ThJwUH+ZaZf/Pr0GsQQQgghhLAdGUlbCCGEEMKCFEhCCCGEEBakQBJCCCGEsCAFkhBCCCGEBSmQhBBCCCEsSIEkhBBCCGFBCiQhhBBCCAtSIAkhhBBCWJACSQghhBDCghRIQgghhBAWpEASQgghhLAgBZIQQgghhAUpkIQQQgghLEiBJIQQQghhQQokIYQQQggLUiAJIYQQQliQAkkIIYQQwoIUSEIIIYQQFqRAEkIIIYSwIAWSEEIIIYQFKZCEEEIIISxIgSSEEEIIYUEKJCGEEEIIC1IgCSGEEEJYkAJJCCGEEMKCFEhCCCGEEBakQBJCCCGEsCAFkhBCCCGEBb29G3ClzGYzAAaDofS1iv5tMBgwGIyYTCYMBmOV89hCZW2obJry015qa03mr0kbLF+ranmVrbu6fq+qrdYs80rYepvai1pyWLI2V1Wf26p+tmafq4nqlmft57O2+73105X/7rCmXdaoyWe0Nuupbdus3TYl+1BN56tsmrr8bJZsR2vWZ6vXa6O++qCyddVkH7emrTqdDo1GA4CmsLDAbG1jG6L8/HwGjbjf3s0QQgghhMJtXvsJen3xsSPFF0gmk4nCwsIyVV9NjXt4Kp9/MNfGLbM/teYC9WaTXMqi1lyg3mySS1nqO9fltYTiT7FptVqcnZ2vaBkajaa0YlQTteYC9WaTXMqi1lyg3mySS1nsmUsu0hZCCCGEsCAFEjDqpsH2bkKdUGsuUG82yaUsas0F6s0muZTFnrkUfw2SEEIIIYStyREkIYQQQggLUiAJIYQQQliQAkkIIYQQwoIUSEIIIYQQFqRAEkIIIYSwIAWSEEIIIYQFKZCEEEIIISwovkAym80YDAbMZhnOSQghhBC2ofgCyWg00m/Y3RiNxlovw2Qy2bBFDYdac4F6s0kuZVFrLlBvNsmlLPbM1eCebLdl+x527TtCRmYWkx+/BydHxzpfp8lkRKtVfK1YjlpzgXqzSS5lUWsuUG82yaUs9sxVb2v98rtfuen2R1m5am3paz/88id3PjSFh56eRWJSCgB9enTi8QfvICjAj5jzCfXVPCGEEEL8H6rsEp16K5C6RLahR9fI0p9T0zL47Os1fPT2y4wePpj3PvoaAI1Gw+LlX3Po6ElCQwLrpW06XYM7kGYTas0F6s0muZRFrblAvdkkl7LUZS6Tycy+o+dY/89+Nm47XO79euvR1i2bERzoV/rz9l0HaNWiKc7OTnSKbMPr7358scEmHrn3Njb9u4vfft/CiBsGlVvWtz9tYPWaDcClys9gKALM6HT6i9cjmdFotGi1WoxGAwBare7iOoqvV9Lp9JhMRgwGIzqdDp1OV820JsxmE6CxmFYLaKyaVqPRotFUPq1er8dgMJS2//JptVodZrO50mm1Wk3ptVharQ6j0YhGU9xner2DxbSW/WIuPddb0z68NK3m4nqr7u/ibWbZhzXrb6PRVJqt4j4sqqS/dZhMlfdhzfq7bL9cmtaaPqy4v00mMw4ODjbsb/vusyX9bTAY0Ol01e6z9d3f1n5HVLbPXv4Zawj9XdPviMv70PI7ojiz2SZ9aI/viMr622Qy4ejopNjviMr6u6ioCJ1Oq9jviMqmtdwPbdXfyWnZ/LntELn5Rbg5O+LgUNw3l7NbyZmSmk5YkyAA/Hy8MJpM5BcUsu6PLUSfjyMjI4vbR99Q4byjhw9m9PDBABgMBvoNuxu93gG9vjhOyf9L6PUOZX6+/HymTqfHbDZfNm9V0+qAS51Yd9PqK5324hyVTqvXX5rWZDKWWW/1/VLVcitvf0372/ppK+9Dk8lU5uea9TfYrr8daj1tRf1tMBSh0Whs2N/232d1OjCbTVV8Pu3X35VPa90+a/kZawj9fXGOSqe1tr8NhiJFf0dUNm1JYaTU74jKptXptKWvKfE7oib74ZX2t8lk4ujpOBwc9PRr34zmoQFotRos2e+YnKbseT+zyYxGQ4VHjOqlMaqk1lyg3mySS1nUmgvUm01yKYvtc+0/GsPJ6ARaNw2iVbPgSqezW4Hk7+vNwSMnAUhKScPBwaFe7lirSHGlqz5qzQXqzSa5lEWtuUC92SSXstQkl9lcfFrRUnZuPodOxpKRmUdKQjSpmYU0bdaM7pHNq1ye3QqkHl0iWfrpt+TnF7Bn/1H69OhUo/lLrkOyxQCRRqOhgsNyyqfWXKDebJJLWdSaC9SbTXIpS3W58vIL+HvHUV5/4x3CQ/xZvnhe6XvZObls33eMU9EpaLQ6nBwcuBCXwa6dO1h0Y3+cnKruL01hYUGdD0GdlJLGM9NfJyUtA61GQ3hYYxa99gJr1v3NV9/9SiM3V2ZPewx/X+8aL7vkGqTNaz8pdy7S+mVUdI5T+dSaC9SbTXIpi1pzgXqzSS5lqSpX9PlkNmw9hNFoYv1vv3D11YMozEnlkftuQ6vRsPyzVSz77DvuGDuaFhEtcdBriYlLI9DXgxHXdq123fVSINUlWxRIxQNRqe/wpFpzgXqzSS5lUWsuUG82yaUsleVKzchm296TmMxmeka2IK+gkC9X/8LuPfvx9nCmS8f2TH6x+GjSyX0b8fP1IT45nf1HY2ga4lfltUcl1DlwQo3JxW3Ko9ZskktZ1JoL1JtNcilL+Vxms5ndh86Rmp7DgO5t8Pf1AOD5x8Yz7Nb7WLd+J2t/+xOAbz9bjJ+vDwBBfl4EXeVl9ZoVWyDZ8hokGaJdedSaTXIpi1pzgXqzSS5lqShXYkomefmFNA/1J7Sxb5n3ggP9AcjKzqFDu1Z079qx1utWbG+OHj6YL5fN5/MP5tq7KUIIIYSoJ6djEohLSqdFWPmnbSx+azY/fLkEgKTkVDw9GtV6PYo9gmRLMkS78qg1m+RSFrXmAvVmk1zKYpnrfEIayz/9kt49u+LnXb74cXR0oFPHdtw3fgytW1Z9G3911NmjNWQymVQ5hoRac4F6s0kuZVFrLlBvNsmlDEVFBk7HJrB/7z5uHVn8VA2j0chfW3bRb8BAekWGodNVfBLMy9ODN+dMu+I2KPYUmy2VPKtFbdSaC9SbTXIpi1pzgXqzSS5l2H3kHDNffZupL73O3gNHgOJTZpMef4YDu/6lVUSzOm+DYo8g2fIi7f+nq//VQ63ZJJeyqDUXqDeb5GrI8guKSM3I4XxcKpHt2/Lbb+s4dvwUnSLbEp+YDEBggF81S7ENxRZIJQ+sLRkH6Uqo6bDk5dSaC9SbTXIpi1pzgXqzSa6GIzElk5Pn4ukRFYFep+XtZV9z4lQ0UV26YTbDwD6dWfyBGxfiEzl66gIbNu0GIMDft5ol24ZiCyRb+n8dol3J1JpNcimLWnOBerNJLvsxGI2s33yA3PxCvDxcuJCYgcFgJCY+lRsGRHE+Lok27SIxm43cOqQ3DnoNOTk5xMancOTUeU6eiQEg0F+OIAkhhBBCBQoKi1i9bicajRmDwURqRg5hwT64ujhx9HQc2/edpl279ni7aenaqQPenm4AuLo44+ruTX6hgesH9SbI1522bSLqpc1SIAEajTqvVVdrLlBvNsmlLGrNBerNJrnql9lsJisnn//2naKgoJCenSJwc3HCQa/D29ONxJRMziekkZqRTaC/D0MHRJWZ39fHG4PJjI+HK9f3780twwbUW9sbZo/WM41GHRe3WVJrLlBvNsmlLGrNBerNJrnq1+nYJFav+48LiWl0bt+UNs2DCQ/xo3GgNy7OjoSH+KHXaUnPzMXLw63c/Hq9jvffW0RqQnS9t12xR5DkUSPVU2suUG82yaUsas0F6s0mueqP0Wji1LkEGrm5MLR/R1xdnCos5IL8vcjKycfLw7X8Qi5O375dy7pubvlVFxYW2OI+ebspuYtt89pP0OtrV+8ZDEUN/uK22lBrLlBvNsmlLGrNBerNJrmuXEFBIYkpmYQE+VRZlP23/xRxSRk0C/GjY5uwWq3r59/+YP/BYzw16V5cXJxr2+RaUewRJFv6fxmiXU3Umk1yKYtac4F6s0muK2M2m1m99i9Onosn9vwFrhvUl9HD+pWbLi4xnbjEdFxdnGgbEVLr9Q27/mpuHHLNlTS51hrW8Tg7MZnUNQJpCbXmAvVmk1zKotZcoN5skuvKpKRl4+Htj4+XJ+3btyc128CGLQc5eDz2YjvMnLuQzPb9p0hIyaRLu3Ac9LUfo8me20sKJNQ3RHsJteYC9WaTXMqi1lyg3myS68rEJ2dwITGdm4f2I7JtCwCi41I4ez6Z9MwcTpyJY+eB0zjq9fTr1grfCh4oWxP23F7qPNZYYw3z6v8rp9ZcoN5skktZ1JoL1JtNctWU0WhCqy1efnpWDu6uzvh5u5Od48WZmCQ0QPSFJGb89it+QaEEBQVx+0198HCv4KLrGrPf9lJsgWTLu9hqe3F3Q6fWXKDebJJLWdSaC9SbraHmMhpN5OQVUFBQRHZeAY3cnPGrwdGXusoVG5/KqegE0jJzyMsvIju3AK9GLjg7OeLn3QiT2YynmzN6vQ43Dy+y0+IYPOpaGxVH9t1echfbxWU01A/NlVBrLlBvNsmlLGrNBerN1lBzHTwRy7a9J3F00JFfYMDJUc+EkeUvfq5MXeTKyStg/T8HyC8oIryxLwkpWfh6utKxTRheHm6YzWbM5uILt7/8eSs6nZZbh/RAfwXXHFmy5/ZqeHuJXSi6RqyCWnOBerNJLmVRay5Qb7aGmSs+KR0PdxcMBiM6nRFXZ0eS07JqcBTJdrnMZjMXEtP5Z+cx8guLGNq/IwG+nuWm02g0F4cp0nDn8D51NFil/baXFEg03CHar5Rac4F6s0kuZVFrLlBvtoaWy2g0ER2fQmpGDgE+HnTr0IzsnBzuuO9Jjh3oyfTJj1q1HFvmiolLYcuuE+TmFxDW2LfC4qj8+uvmWiF7bi8pkGi4Q7RfKbXmAvVmk1zKotZcoN5sDS3X2fNJ/L3jKE4ODrRtEYy7mzNurk4cOXIcbw93q5djy1yHTpwnOzefW2/ogVej8o//qE/23F4Nq5S2E5PJaO8m1Am15gL1ZpNcyqLWXKDebA0pl9lsZs/hc5hNZsYM7UGgnxdQXBQEBfoTl5BEQnKGVcuyVa7CIgNxSem0ahpk9+II7Lu95AiSEEIIYQdnYpPQ6bT07twSB4eyv46DgvxJScvmvkenkBAfz46/vq/TthQWGth79By5+QU4Oujx9bmy8YvUQAokQKez3RX3DYlac4F6s0kuZVFrLlBvNnvnyszO4/DJ8zRr4s+xM/FkZufRIiyg3HQD+vYkI1/L5s2bOXX6bLV3c11JLqPRxL97jnP8bAIA3h6utL+Cx4PYkj23l5xio3hodDVSay5QbzbJpSxqzQXqzWbvXJt3HmP/sRg2bjuEwWAgslUYTo7lHzI7+cmHaBHREi8vL0wmE/GJyVUu90pyHT8bT2p6Di3DAwkN9qFj67AGc62WPbeXYo8g2XKgyOKhzNX315Jac4F6s0kuZVFrLlBnNpPJRG5ePvn5+aTnGHBy0BHW2K/e1p+Snk1efiEebs7kFxbRyF1L+4jGFU6r1Wq4+5b+5KSc5Z/Nm4iOOU+TxkGVLrui7WU2myksMlBkMOLu6lzJfGYOnYwlN7eAmwd3RattWMdN7LkfKrZAGj18MKOHDy4dKPLKNIxK2fbUmgvUm01yKYtac4Hasm3euosNf/3HkeMnyc3JZMSoOwAYN6IPrs5O9dKG//afIr+giGEDO5GSkY2XuytOTuWPHpXQ63X06dGFNq0j+Gf7Xvr07FrF0stur4ysXDbvOkZCUgb+Po0Y2LMdHu4u5eaKjkshOyefTm3CG1xxVEzuYrOrhjiqqi2oNReoN5vkUha15gL1Zfvtj3/57qe1bN++HUNREQXZqXi6O7Nzz5F6WX9uXgFJKZmEh/jh7elGRFggflZcCN2pYzu6durAn3//y+GjJyqdznJ7HT8bT1ZWPq2aBrJt23Y++3J1uXmyc/M5eDwWT3cXWjYNrHmoemDP/VAKJIqHMlcjteYC9WaTXMqi1lygvmxHjx3Fz8+fu24fxbrvP+GRu0ey6J2FPDjpGZtcqlGVlPRs/t5xDBdnJ0ICvWs0r4ODA717dGbb9p2cizlf6XQGg4H0zBwAjpw6z97D5/Bo5Ey/7m3Z+MfvrP3tD0wmEwUFRfy3/xQnzsaz90g0SalZdG7fDLdKTsHZmz33QymQgIY69PyVU2suUG82yaUsas0Fast2+vQ5ivKzeXlq8cjUOp2WUcOvJzMrh6g+NxAXn1hn696x/xQxcSlk5uQRFuxb4/n9/XwASEpOrXSaVWs3MXXWAnbvO8zuw+fQ6rSEBRdfX9WrZxf+3b6b83EJbNl9gl/+2MqnX3xHQnI6zUL8aBpSf9dh1Zz99kMpkGh4Q8/bilpzgXqzSS5lUWsuUFe2nNxcYs5foEun9mVy3XX7SIYPu4bomAvsPXC4To4kxSWlU1hkpF2LEO4eeVWtHuTq51N81CklJa3ceylpWfy59TB7D57ku+9/Yt2m3eTkFtCva2siW4cC0KZlcwBOnDzDkaNHSbwQzYnT0WRl5xLZJuwK0tU9e+6H6vkEXAGtVl0XI5ZQay5QbzbJpSxqzQXqynbk6EkMBiNhTRqXyeXr480D99xO82Zh/LZxJ3/+u9/m6465kEJ6Zg6tWwTXekwfX9/iAik5tWyBlJNbwP5jMZyMTqBJaCi9evVm5659ZGdl0DjQq3S6Fs3CAXh32RfMmDkbQ0E2vfv2o7CwEB9P+4+WXRV77ofqugqvloxGI3q9+mpFteYC9WaTXMqi1lyg/Gxp6Rn8tG4zjUOakJmZxV133ka/Pj3K5erQphXnomPpZYJTsal0ycjB20ZFQ25eAdFxKbi7OuPnZf1z1Sz5+XrTrGkoZosxgX76czdZOfkE+3nQrmVbWjYLISsnj6t7tStzW3/7ti1xdnJi9579vPzSiwwd2Jltuw7TpnXTWrepvthzP6xRgZSekUUjdzd0OuV+aIQQQqjf7r0HScvVUHA+DY0GOnXvS9fOkYCpzHROTo60btmcnTu207NHD/YdPsXA3h2veP1b95zgdEwiOXmF9OzY/IoGXnRzdeX8hXhOnTlX+tqZszH8/OP33DLiBvp1b4u7qwPNQwMrXE9wUABarYaMjAwm3DoYj0buRDRvWuv2/L+oskBKTErhi9W/sv/QcXJy83B3cyU7JxcHBz1NQxtz683XE9W+VX21tc5oteoaDK2EWnOBerNJLmVRay5QVrbU9GwOHo9FrzfTrkUIXp4e7N57iDUb/uHpxx7mqh4d8PJwQ6/XYTKVLyD+/b34Fvirb7yT+PhEDu/ccEXtiUtMK33IbLC/J2FXeBG0RqPBy9OD9Iys0td27N7P/gMHuH3UELw8XDGZTFUWYdv/+gGz2YxHo9ofybIHe+6HlRZIy1d+z8EjJxl54zU8fM8YnJ0cS98zGk2cOhvD6p82sOKrH3ntpafR1/PzUmw7kra67tYoodZcoN5skktZ1JoLlJMtL7+Qb9ftIC8nk5kvvsiD997BU489xK+/byYnM52hg7ri5HRpIMiqcrVu2Zzdew+SkpqGl6cnWq2mVkd+TpxLIDu3gBsGROFzBafWLufl6UFGZmbpz39v2U5M7AV69+gMVL+9QkOCbdKO+mbP/bDSAmnsLUNxdal4XASdTkurFuFMfep+cvPy6704AtuOpK3GIfVBvblAvdkkl7KoNRcoJ1tKejYAPTu3BSArK4f9x2IYf8/9REX4lSmOoOpcXaLacS76PGv/PkBGVjYbfvuVq/t24clJ91jdnuS0TE6cTaBpEz+bFUcAnh6NiDkfV/rz4aMn8ffzxffiHW5K2V411SAfNXJ5cRRzPp5Fy74kIzOLD956kaSUNA4cPsHV/XpUWkQpi3ru1ihLrblAvdkkl7KoNRcoJVtaZi4Bvh6EhwTg6OgAWj0FBUVEtQmnc/umFcxRea4APz/+3b6LvAIDY+8YR2ZmJm7egRgMxipvz09MyeR0TAIpadkkpGTi6+1Oz6gWVx7uMl6eHhw4dAyAH35ej7uHF6O6Rl02hTK2V8018EeNvPrmUm656Vpy8wsA8PJoxGdfr6nThtUntQ2pX0KtuUC92SSXsqg1FzTsbCnpWZyPT8VgMJKSlkViSiY+Xm74eHvRyMuP+OQMWoRX/OiMqnKFNC6eZ8/efQR76Zj81MP8tfFP/t2+q9J50jNy+PGP3Zw8l0BSahb+Po3o0DKk0ofD1paXpwf5BQXk5xew/s/NHD58jGefeKD0/Ya8va5Eg3/USGZWDj27Rpb+7OCgp6CgsM4aVd/UNqR+CbXmAvVmk1zKotZc0LCzbfjnIG9/uIqnXphHSno2rs6OODk64OPtxcmTJ3Fz0tLIreICpapcjYOLCyQ/P2/69uxCsJ8Ha3/dwLYdeyqd5/i5eHQ6DR1ahnLH8D5cf1UkEeFBVxawAhEtwunUsR2JySnk5ubh5+OBn69P6fsNeXtdiQb/qBEfb09OnY2h5Fq1L1f/gq+PVx02q74p42LEmlNrLlBvNsmlLGrNBQ05W35hEYcPHeS33/8iIyuHNs2LL0BuHBTAXxs3svKzT6u4uLryXIEBfvTu0ZlOke3w9fUmokVTAE6cPFvh9AaDgeWffI6jpoiotmE4OuiLT/PVAV8fb/buP8yRYyfZtGVH6bVHlzTc7XVlGuBF2peb/Pg9TJ+ziHMxFxg6ZiKeHo14beaTddy0+qOmIfUvp9ZcoN5skktZ1JoLGm62nNx8nJ0c8fX1o1//gRiMZppcfL5ZYKAfJpOJAP/Kn3dWVS6dTsev331S+nMjdzcGXNWD9MvuHrvcmZhEHBwcyUpNuKJxjqzRtVMHfLw9+fe/faSmpRMc5F/m/Ya6va6UPXNZVSCFNQnm43dnE3M+HjATGhKsqsEitVr1ZLmcWnOBerNJLmVRay5ouNkSUjLJzM6jf+/OnItLw90JAn09AAgOKC4aHBwq/9VW01wFBYUcPHyi3Osmk5k9R2Lo0ac/d97Up0bLrI1OHdsx95WZnL2QDhQf7bpcQ91eV8qeuaoskHJycsv87O/rBUBuXh4rvlrDpPvH1lnD6pPRaECvr5vDovak1lyg3mySS1nUmgsabra4xHT8vN25pndPGrm5kF9QWHr0ZtKD47n5putKryWqSE1zhYWGsHPPQbJzcnF3cy19/fsNO0jPyiUk0Ktenhem0WjoHBnBvPmPAhAUUPYIUkPdXlfKnrmqLJAGj3oIjQYsx2nSaGBAn2512S4hhBCiDLPZTHJ6NoVFBjzcXdBoNLi6XBrnyNvbE29vT5uus32bliSm5vDzb38yesQQdDodaRk5GE1mWoYH0rtzhE3XV5UmwQGcOReNj7cnrVs1r7f1/r/SFBYWKPrKrpKBIjev/aTWtwOaTCZVHp5Uay5QbzbJpSxqzQUNL5vRaGTjtiPEJqTSqW0Yndo2rdVyapOrSes+FBYVUlRk4Oiu3zkenUJ6Zi49o5oT4Gvbgqw6Ia16kZObx94ta2ka3qT09Ya2vWzFnrlqVFHk5uVjNl160J/bZYcblUwpQ+rXlFpzgXqzSS5lUWsuaHjZjp2JJzY+lfYtG9O+ZWitl1ObXAH+PpyNPo/ZbGbnngN89/OfXH/9tfVeHAE8fP+dnIs+T3hYSJnXG9r2spUG+aiRy/25+T/eWPQJGZlZmM3Fp9gC/H35fsXCOm5e/ZAh2pVHrdkkl7KoNRc0vGxxSekUGoy0bxmKQxWjWlenNrncXF0xm81EdYxk36HjnD51kuy0yOpnrAMzJj9W4esNbXvZij1zWXXcaskn3/DazKe4qlcX/vhhGR+8+SI3Xte/rtsmhBBCkJObT25uAe0jQspcc1RfdHodjo6O3DnhXo6dimHP/sP06dm13tsh6pdVBZKbqwuR7VrSLCyEg0dOEtmuJTt2H6zrttUbnU6dQ7SrNReoN5vkUha15oKGle3chRTikjPw9b7yh7/WJtew6wfRsX1rQvw9iD1/AY1GQ9OwJtXPWI8a0vayJXvmsmrNfj7exJyPZ1C/Hiz84HPORl8ofS6bvXz70wZWr9lgk/OTRqNRlc+xUWsuUG82yaUsas0Fts9mNptLL9GwdlDF6AvJGAwmYuNSCPTzILyxX/UzVaM2uZ574kGee+JBTpyNR6/T0axpGM7O9X8kqypq3Rftmcuqu9iiY+Pw9vKgkbsbP/6ykS3b9zB6+GB6dLXPOdjL2eIuNoOhSJXjR6g1F6g3m+RSFrXmAttn+/H3XSSmZjFsYBSNAywfk1Helt3HOXs+GYPBSEGhgc7twukeeeW3tl9prui4FMKCKx+p217Uui/aM5dVFUVggC9Ojo4AjLhhEDcNGUBmVk6dNqw+yRDtyqPWbJJLWdSaC2yfLS0rB40GktOyqi2Qtu87xbnzybg5O5KYmoWbqxNRrWt/59rlrjRXQyyOQL37oj1zWbXmF2a/TVr6pWfRxCUkM+etZXXWqPqmxrEjQL25QL3ZJJeyqDUX2DZbbl4BZhOYTWYOnYjlVHQ8RqMRo9FUZrqYuBTik9LYfzQaZ2dHRlzblQkjr+KmQZ1t9hBYtW4zyVUH67ZmoqSUdLy9PEp/DgkOICE5pc4aVd+MRoO9m1An1JoL1JtNcilLQ89lNptJTKn4QauW8vILOXLqPPkFhRiNJptlM5vNLPv8R4oMRjwauZCVU8DWPSf56NtNHDl1vnS6/cdi2LrvJL9u2k8jdxeu6tIKjUaDk6MDHu4uNmkLNPxtVluSy/asOsWm12k5c+48zcKLB6aKjo3DZFTnoFRCCKEW+45GM2vuQrp0aMH0yY9WOe3G7YeJjU9j295TODs60C0ynLjEdAK8XWnRNAQHh9odwUlMSiEpLYfQRn707NiCk+fiOR2bjFarYd/RaMxmcHdz5sip8xQVGWjfMhRHBy0Bvh7VL1yIOmRVgfTghFuZ9Nyr9OwWCWjYvnM/U5+6r46bVn+0WvUNrgXqzQXqzSa5lKUh5zKbzew/FsO+fftIS46vskAqMhgxGc046LUUGYzodVr+23+W777/nj82rGfrH6tp27p2zxz7/LsNfLRsKdOem0hY44GkZeYSHZdKq2ZBZGTlcexMHG6uzpiMZm4d0hMnp7q9ILchb7MrIblsz6oCqVe3jix7+yW27zqA2Wzi3jtvJjQkqK7bVo/UejRMrblAvdkkl7I03Fx5+YXkFxTh6upCTm5epdOZzWb2HD7HhaR0unVoRuNAL/Lyi9iw5SCensWP0khMSqlVgVRYZEDr2IgHHriXYdcNQqvV0rldOJ3bhQNwITGNjVv3k5qRQ5Mgrzovjoo13G12ZSSXrVlVIOXk5hESHMAtN15DdGwcBw6fwN/PB2cnx7puX70ofhie+qpvteYC9WaTXMrSUHMZDEb2HjmHv08jPNzdyMjIqHTaPYfPceJsHBHhAbRt0RgXZ0fMZjODerbG2ZzJd9+uIjGpdtecJqVmERzgx9V9OtKsafm70BoHeBPq70Z+YRHdO7eq1TpqqqFusysluWzPqou0Z8xZRFxCMrl5+Ux67lV++OVPZs1/v67bJoQQoobMZjM7DpwmJi6VQF8PvL0akZ2TW+G0JpOJmLgUPBu50r9bG1yci//o1Wg0NGviT8vmxUVN4sWbckwmE6npWWTn5ls1SO+ZmEQyc/JoHOBV6TT9+3TjuoG98fZwq2FSIeqWVUeQLsQnERzoxzc/rOOOW4cxduQQxtz7bF23rd7IEO3Ko9ZskktZGmKuM7FJRMel4O/rQc+oCNzcXMnNq/gU23frd5CRnU9kqyboLR4Aq9PpCfDzJdDfl+zsHAxGI5t3Hi8eTVqvo3PbMKLahKPVVjwqdkp6NqmZObRt3hg/70Y2z1lbDXGb2YLksj2r1qzTavnyu1/5ed3fLF0wEyh+PptayBDtyqPWbJJLWRparvikdA4ej8XT3ZUekc3R6bS4ubpQWFhEUVFRmTvRCouKSM3IJTTYhx4dW5RbltFoxN/fl4SkFM7FnOfwsdOci4knwLcRObkF7Dl8DicHPTqdjguJaTjodfTo2AJHRz1Go4ndh85gNJqICA+w+tEi9aGhbTNbkVy2Z9Van3vsbr749hceuGsUbq4u7DlwlH69u9R12+qRXNymPGrNJrmUpeHkOhd9gW0Ho3F00NMtshnubs4AuLm6AsXXknp5OhCXlE5ubiE7Dp5Gp9XQullwJUs008jdDScnR5KT0/h13R/MffN9/v7tK9q26sSGfw+yfd9JjCYzpovdEBbiR1iwL/sPnSAuMZ32LZsQbMVjRepXw9lmtiW5bM2qAqlTZBs6RbYp/blzZBui2tfPBXX1QYZoVx61ZpNcytJQcp0+E82stz6mS7fuDOjRvswpLdeLR/tzc/NwdXHhkadmMOTGkbg4O9AjqgWhlTw6Q6PRotFo8Pf1ISkllfMXEgAIDQnG0VFPWLAvm7dsp2ePrrQMD+T42QTS0rMJC/bl+RdfJS4hhR0bv6v78DXUULaZrUku26v1cSs1DWuupiyXU2suUG82yaUsDSHXzFcXsGXbTnbvO4yrg5HHJ9xQ5v2SyyFycvM4ceYw2VlZGPIyiGjVgQ4tm1R6+qskm4dHI86cjUEDuDg74+1VfOt/h1ZNGDdyEE0aB+Hh4c6OA2eIjksFcxFpaRncddvwBvfEe2gY26wuSC7bU98Jy1owGg2qfAqyWnOBerNJLmWxd67klFR27ztEamoGg6++irGjbiw3TXhYCL17dCb6QhL5RgcmT36WwX07VLvskmwFBQWkZ2RyLjaOYUOuLi2oNBoNHdpdOpPQPNSfjOw8ziflMOnRxxjcN9J2QW3I3tusrkgu27OqNHvyhdcuXuR36Zkoq9ds4MbbJ7H/0PE6a5wQQojKHTtxhs3/7uDeCWP4+pN36d+3R7lpvDw92frfHqIvpJJfUETPqOY1WsfPqz7ig7fn8dyTk7h2YJ9Kp3N3debI8TPEJ6UT2a4FIY0Da5xHiIbEqgLp8LHTDL/zMYaOmcjWHfsA2LZzP48/eCdLV3xbpw2sD2ocXAvUmwvUm01yKYu9c508dRaAli2aVjpNq4imODs7E5+UhquLIx7urlYtuyRbcFAAY0cN5eF7RjN29E2VTh/e2I8zJ44ybepkmgQ03Oeo2Xub1RXJVQfrtmaigsJCVrw/h/den8ayiwVRYnIqgwf2JjW18hFahRBC1B1v/2Aef/Rhojq0q3SaFs3CmT3jOY4e3E1EiGedtcXX252ZUyaxd8taAv0rvvBbCCWx6hokX28v/Hy8cHF2Kh2PoKjQgEajwcFR+ZcxmUxGVV7gptZcoN5skktZ7Jnr7Plksgs0tOvQiaBAv0qnc3R0YMIdN3P3nSNx0Fv/13hNs2k0GoL9vaye3l5kX1QWe+ayqrrp2qkdd0+aTl5+AW6uLjw1bT4paRl88e0vNHKX4eGFEKI+mc1mTp6Lx2w2c/N13aqd3tFB+X/IClHfrPrUPP/EvWzc/B8B/r60b92cg0dO0rxpKKvXbGDiPbfVdRvrnAzRrjxqzSa5lMVeudIycjgbm0y7liF19tBw2WbKIrlsz6o163U6rh3Qi+jYOC7EJxHVoTUajYZ77rjZ5g3auPk/Dh07RXp6JlOevK9ehhg3mYyq3LnUmgvUm01yKYu9csXEp6LRQFhQ3V3rI9tMWSSX7Vm11nMxF5gyayG5ufloNBpcXZyZN/NJwppUNkR9eV9+9ytfrFrL2FuGcuetwwD44Zc/WfXjetzdXJk9dRIB/r70692FQf168MkXP3Ls5Dnatyn/jCBbs+ap1Eqk1lyg3mySS1nskWvXvmNEJ2RhMpsJ9K+7i65lmymL5LI9q658emvxCh6acCs/rnyHHz5/mwfvHs0biz6t0Yq6RLahR9dLA4elpmXw2ddr+Ojtlxk9fDDvffQ1AHq9HoPRyIEjJ2jRLLRG66i9hvMgRdtSay5QbzbJpSz1m+u//af54rtfycnNZczQnjW66LrmZJspi+SyNauOIKWmZTLwqu6lPw/s253ln39foxW1btmM4MvutNi+6wCtWjTF2dmJTpFteP3djwEwmUwsWvYlk+4bW+m59W9/2sDqNRuAS9WlwVAEmNHp9BiNRsCMRqNFq9ViNBYPcFkynoLJZASKz22aTEbMZjMGgwGdTlfNtCbMZhOgsZhWC2ismrbk+UaVTavX6zEYDKXtv3xarVaH2WyudFqtVnMx+6X2F/cL6PUOFtNa9osZk8lU2qaa9OGlaTVotdX1ofHiNrPsw5r1t0ajKc1WcR8WVdLfOkymyvuwZv1dtl8uTWtNH1bc36DBbDbbsL/tu89e6u/iz1h1+2x993dNviMq2mer2g9t3d8FhYXEJaZy1VVXEdnCDzcXB4xG4xV9R1zehxV9R5RkU+J3RGX9XXJAQqnfEZX1d/FnrEjB3xGV9+Hl+2Fd9rflmEtWFUjOzk4cOX6atq2KR2A9cvw0Tld4YWBKajphTYIA8PPxwmgykV9QyKdf/sipMzH8+OtGunVuT79eXcrNO3r4YEYPHwyAwWCg37C70esdSq9XsrxuyXKY8stvGdTp9JjNRZfNW9W0OuBSB9bdtPpKp704R6XT6vWXpjWZjGXWW32/VLXcyttf0/62ftrK+9BgKCrzc836G2zX35ZD4NekD8tPazAUodFobNjf9t9ndTowm01VfD7t19+VT2vdPntl+6H105rNsOtQNBnZ+fTs2IKI5sGVTntx6Zctt3b9bZmteD3K+Y6obNrL/2isfFpoqN8RlU17+fe9Er8jarIf1lV/W7KqQHr8wTt4buabhIYUfyhjLyQw78UnrJm1cpqy5xbNJjMaDTx0961XtlwhhFCZtes2cvBELH16dqVlU3mEhxD1waoCKbJdS75cNp+DR04C0KFtxBWPf+Tv6126vKSUNBwcHHByrJvbVasjQ7Qrj1qzSS5lqYtceXn5aLQ6nJ0u/XX7+8Z/+Oyr7zm+5896GzRPtpmySC7bs/reuUbubvTuHlX68+atu+jXu2utV9yjSyRLP/2W/PwC9uw/Sp8enWo0f8l1SGq9cl8I8f/HbDbz5IyFdO7anXYRITQJaER2Tg7xyRm0aBZGgDzCQ4h6U2WBNP6RaWgquIDcbDJTUFhkdYGUlJLGM9NfJyUtA61Gw9ad+1j02gvcfcfN3PfETBq5uTJ72mM1anjJdUgl1yBdCRmiXXnUmk1yKYutc8Wcj+PgwYN06NCBo6fj2PjnRuKT0rjv3rtpEVa/p9ZkmymL5LI9TWFhQaWHYHbvP1LxTBoNLZuH4e5m3VOh61JJgbR57Se1HlSy4ovAlE+tuUC92SSXstgyV2Z2HoeOneO3PzYxsE8XTpzP4q35c3F3c+GfDavqbMTsysg2UxbJZXuVVhRxCcl06di22gVciE+kcVCATRtV39Q4+iioNxeoN5vkUhZb5Tp4IpbTMYkkJmfQrVt3+vXqiOvB02i0Wtq1bVXvxRHINlMayWV7la556397+e3PLVw3qA89unQgONAfBwc9ZrOZpORUjp44yw+//ImPlwdTnrofva5+L6Sy5TVIJpPp4i2J6qLWXKDebJJLWWyRKyc3n6OnLmA0GIlsHUZIoDd6vY6uHZqz468fcHWxz80rss2URXLZXpWn2HLz8vnp17/Yd/AYMRfiyc8vQKfT0TjIn4hmYYy88Wq7Hz2SU2yVU2suUG82yaUsV5rLZDLx2Q9bcHZ2oHenCMIa+1U/Uz2RbaYsksv2qqwoXF2cGXvLEMbeMqS+2mMnMkS78qg1m+RSlivLlZ6ZS0GRgTYtghtUcVRMtpmySC5bU98l77WgxsOSoN5coN5skktZrjTXX5v/5fSxA7g4NrxfbrLNlEVy2Z4USFD6PBa1UWsuUG82yaUsV5prw5+b+WDpRwT5edmmQTYk20xZJJftKfaydxkoUoj/H/FJ6Wgx4Ozsikcj+w8vUpniBw2beOu95SSlZDJyxE10aheOq4tThdN27dGHZs1byACQQjRAVRZIH33+fZUz3zdupE0bUxO2HChSjYNrgXpzgXqzSa7yMrPzWLLiOxYufIf77rubq/t04obrBtqucVfg8lznYs6zaMkKgkJb0MgnmPTsIr77eR3RZ1swdtQN5ebNzM5D5+RGn96967PJVpN9UVkkl+1VWSBlZecAcPjYKXy8PQkKKL6I8MSpcwQH+dd96+pNwzv/bxtqzQXqzSa5LO08eIaAwMYsevNVZs9fSHpyIgP79cJBr8PBwd537VzKtWDRR3yycjW9e3Zl1otTmXjXjfS+ZhS//bKWZi1a4uftTvOwIDQXH09wPiGNoiIjIUE+9mp8NWRfVBbJZWtVFkhPPjwOgEcnz+HVaY+j0xVXcnn5+Ux/9d26b109kSHalUet2SRXWWZz8WONwkODuWFAFMdPnuDA8RhCWvVi+eLXGXnT4DporfVKchmMRk6cjiY40J+fv1lWemFpeFgI637fxKy5b7N/325++HoZnSPbotVqSU3PxsPdhWB/L7tmqIzsi8oiuWzPqrUmpaSW+dnZyYkL8Ul10iAhhCiRmp5DTFwqPl5uADz1yL0M6NMDs9lMckqKnVsH+fkFmM1m9h2J5oEHH+aLT5eUuesmrEljXFxcyEhLZPacuRw4lcLhUxfIysrh6KlY3FyccHay91EwIURFrLpIu0vHdkydtZAxI69Hp9Oxdt3fhIUE13Xb6o0M0a48as0mucq6kJRGoJ8noRdPQ3l5eTD06h7MnAVx8Ym2bGKNJSSl8+jT0xk/bgw4NMLd1ZlO7ZuXmebhe+/gmmuvpXO7FuQVGtiy+wTb955k4oeLKSoy8PualXZqffVkX1QWyWV7Vq35qYl38dk3a3h/+TcYjAY6dWjD4w+Nq+u2VUkeNVI9teYC9WaTXGXFJaaTnJZFoK9n6WvBF0fvX/PrH+Tk5vLarCk2a2dNbNt3io2bt9KiTXvatuvAyMHdSq8vKtG8WRjNm4WV/pyQksX+o9F4+/hzw7V9cHdzqe9mW032RWWRXLZnVYHk6OjAfeNu4b5xt9R1e6xmy7vYzGYToL4dS625QL3ZJFcxo9HEv7uPc/Z8Mq2bBaHXX5q3kbsbg/r3Ij4pk6YtO5KZnYeHe/0VGvMXLuHXP7bg4OBEYIA/zi7u+Hm7W9WGru2b4uigo3ObJ+jasVU9tLb2ZF9UFslle1Zdg3To6CkmTJrGqAlPARCfmMyqH9fXacPql1z9rzxqzSa5AM5dSObomTiah/oT1Ta83Puzpj/NO2+8jM7RhbPnk23VyGrl5hfg5t0Yvd6BIUOux8XZkYVvvYExL82q+XU6LZ3ahjf44qiY7IvKIrlszaojSK+/+zEvPz+JF+e9B0CAnw8/r/+bW0dcV6eNqy9qPCwJ6s0F6s0mucBgMHImNgmdTkePji0qPDIT2a41hUUGzl5IY9M/22gf0bjSdaSmpXPo2Blc3T3p3K5pje6IMZnMaLUazGYzh07EcvJcPOHhTXh/4RyahwYw4truHDx8nGsG9LJ6mUoh+6KySC7bs6pAKiwsomlY49KfNRoNBQVFddao+mY0GlT5FGS15gL1ZpNccComkVPRiXTr0JRGbs6VTufooOf00b289e6HRLVpSr++3SucbuOmrfz850569+lDakYOTZv406yJP/pqvnjzCwr5acM2zp06xtgxI9m69ySN/b1p0yyYFuGBAISHNaZF8/JHuNRA9kVlkVy2Z9WfUqEhQfy36wAaDeTk5LLwg8/KFExCCGELZrOZU9EJBPt70rZFSLmLni2NGj4EnU7HN9+vrXSaQ0dOsHbNTwT7NiI3r5AdB85w7ExctW05cTaBr1evYdHSz/ht0wGC/L24qlur0uJICKFuVhVIkx+/hy9W/8KpM7Fcf+tEzpy7wLOTJtR12+qNRqO+wbVAvblAvdn+33PFJ2cQG59GgK8nLs6O1U4f0SKcawb2IeZ8HEajEYCMrFz2HD7L4ZPnKSoyEBjSjIfvH891/ToxbFBnnPQ6Tkcnkp6Rxc59hytddkxcCsOHDaFt29aAkdbNgvC0eA6cWrcXqDeb5FIWe+ay6hSbt5cHC+c8T15+PgAuzs6kZ2TVacOqY8vb/Kv7K1Wp1JoL1Jvt/z3XsdNx+Hq507IGR2latmjKx59/y5FjJ+nQrjX/7T3OmQtp7Nu9g9Ejb0Tj6M4tI4fj5FRccDUN9WfXwbPces/TTBg/jrTsg3SPbIaHuytabXE7Y+NTyc0vJKJ5KKs+WUhmTiEhgd61zqVEas0muZTFnrmsKs3ueWwGUFwYuTgXXxPw7Itv1F2rrDB6+GC+XDafzz+Ye8XLMpmMNmhRw6PWXKDebGrIlZKeTUZWLgWFl65TrCrXhYQ0ktOyyMsrIC0zB28PV3y83K1eX+eo9qSlZ7Bz9wGOHj/FF1+twt1ZQ9dOHTgVk4i7qxNtW1y6JCDYzwuNBm4dcxthjQNJSs3iu/U72fDvAc7EJpFfUMT+YzGYMdMjsjmN3N0qLI6qy6V0as0muZTFnrmqPIL0y4bNAGRm5ZT+GyAuIYnUtMy6bZkQQnGKDEa27DpOfHIGXdqF4+3hRkZ2HgVFhfTuVP7W9rikdLbtO0luXiHG/EzyCg007dKuRuts2aIpADHn4+A/+P7Hn7l52EBGj7qOA8dj8GjkgpPjpYs8g/y9uGVwdzQa8PFyJzevgCOnLnD09AXSM3MJ8PGksMhAVOswHBzUOTqxEKJ6VX764xKKn7eWm5vP7svO1QcF+vHm7GfrtmX1SIZoVx61ZlNyrvyCInYeOE1OXgHuLk6cPZ/MkVMXcHJ0YPvWf1n19Te8NXd66fRxiensO3oOZ0cHtFoNn377Gxs3/sWB7b/VaL2hTYofexQTewFHRweCAv3p2ikSR0c9XTs0Kze9VqvB1/vSESpXFye6dmhGeGM/9h07R2x8CkaTmQgrTvMpeXtVR63ZJJeyNNhHjZSMnO3p0YjRw+371Oy6JEO0K49asyk515mYRA6fukBUm1ASU7KIS0onIjyQvl1a8tP3X/Pzr3/w/NOPkJaWhnsjLw4ej8WEmWah/jg7OdKqZUt8PV1p0jioRut1c3Wld4/O6PV69h44QnJKGiHBNb/TzM+nEQN6tCUpJRM/70ZWjZek5O1VHbVmk1zK0uAfNRLVvhVFRQYcHPRs+Gsr23cd4K4xNxIeqo5b/WWIduVRazal5srOK+D42XjCQ3yJahOOwWCkoLAIFxcnnBwduP6a/jQJbcof/x5iy7//0veqfmTnFnBD/440CfYF4PnH767RtUeXy8nNY/PWnQQH+uPr41XrCzv1Oh3BARVfb1QRpW4va6g1m+RSlgb/qJE5Cz4kKzuHhMQUln76Lb7ensx+Y0ldt60eqfPqf/XmAvVmU16uM7FJbPrvKAWFRYQG+uLs5IC7mzO+3o1wvXir/tUD+9G8dSSZuYUMHNAfrVZLVJvQ0uIIqHVxBBDSOIgLcQkkp6Th62N9gXPllLe9rKfWbJJLWRr4XWy5eXn4eHuy6qf1PHzPGCbeexu5ufl13bZ6o9er89ytWnOBerMpLVd0XDIHj8eQlZPHNb3b0Tai4qPKgf5eeHu44u/jwdCBnRkztEeF1wfVViM3V8beMY64hCR8fbxsttzqKG171YRas0kuZbFnLqvW7OvjxeSZb3EhIYlH7r2N3Lx8XF0rfwRAfbDlOEgGg0GVO5dac4F6sykpV0FhEYeOn6fIYGRo/6iqn2ZvNnPr0J4UFhpwdCzOZ8vh3zp1bMeO/afJy8vD3b32R6JqSknbq6bUmk1yKYs9c1m11ldeeIx1G//l0R63o9VqiY6N487Rw+q6bVUaPXwwo4cPxmAw0G/Y3Ve4tCsvshomteYC9WZTTq4zsUnExKfSM6riB8qWVZyrpDiytUceuIv4xFQ8GjnTp1tknayjYsrZXjWn1mySS1nsl8uqbysfb0+6RrXjTPR5wpoE06ZlM5qFh9R12+qNDNGuPGrNZu9cJU+vt0ZiSvFYaC3CAqqdtj5yBQX48Pac5+t8PZez9/aqS2rNJrmUxZ65rFrzJ1/+yMIPPmPRsi8BiItPYvqr79Zpw+qTDNGuPGrNZutcZrOZ7Jx8YuNTyMsv4Oz5JPLyC8kvKCQmLpkiw6VRak/HJPLbP/s5eupClcssLDJwPiGVM7FJhAX74ubiVG07ZHspj1qzSS5lsWcuq44g/fr7P6xcMpd7H58JQHCQP4nJqXXasPpkMhmtGvNEadSaC9SbraJc+QVFbN1zHJPJTK9OEbhVc/2fyWTCaDJzNjaZmLhkLiSmARo0Gg3OTg7k5RVgMJnR6zUE+nrRpV04CSkZHD55gdSMHAoLDAT4NsLHq1G5ZSckZ3D45HmS07Np5OZMq2ZBVn2B/T9tL7VQazbJpSz2zGVVgaTRaNBotJR8D6amZZCfX1iX7RLi/5rZbMZgMKLX69hx4DQnzxU/U2zXobP07tySo6cvYDCYCA7wIsjPs3S++KR0TsUkEX0hGa1Gg1anxd/Hk9bNgkjJyKaw0ICzkwNoNLg4OrDr0Bl++GMXrk6OeHm60bpZEEfPxPP7v4e4dWjPcsXPvqPRnD2fzIAerWkc4EMjN/verCGEEHXFqgJp6LVX8cqbS8nOzmXVj+tZ9eN6hg8ZWMdNqz9arfoG1wL15gL1ZtNqdZjNZj75fjMGg5GrurbkfEIa7Vs1QavREJeUznfrd+Dm4kRqeg4JyRlc3y8SjUZDbn4B/+w+QZHBQNPGvgT6e+Hq7IiPlzuODnqaNvEvt77oCynEp6TTrlUIzUMDaOTqgouzIwdPnGf7vlP06hQBgMFg5PjZeJJSs+jYOpTWzWo2SKyat5daqTWb5FIWe+ayqkCaMHY46zf+i8FgYN/BY9x7580Mueaqum5bvbHFUAENkVpzgXqzmc1m4pIySExI4rNPP6Jo0qP4+frSpV04ep2OvUfPkZNbgFcjN3y93DlwPJa4xDQ8Pdz4bdN+HB10dG0XTrPQ6i+cBriuXyR5+YU4OzmUHi1qERbI2dhkDp88T9uIxiSnZrPn8Fny84twdXWkfcua36Ch5u2lVmrNJrmUxZ65rCqQ1q7fxMCrunPdoD513R67kCHalUet2cxmEweOxxDRPJSnnngUraM7LZsG4uxUPCJ11/bFgytqNBouJKRxMjqB37ce5usvPqdjVEeefngc/r4eNVqny8XRrktoNBpahAeSlZvP71sOkptXiLeHG53bhRPk51ntNVCV5VLr9lJjLlBvNsmlLPbMZVWBtOfAUT74ZBWdOrTm+qv70qt7R/SqeiieOq/+V28uUFs2k8lMcloWWTk5pKZnE+zvxfX9OmI0mnC6bOygy68JCvTzxNvDjcTUDHbv2UtBfi7+0x6xSXuaNfGn0GDgdHQi/j4edI9sXq6Qqhl1ba9L1JoL1JtNcimL/XJpCgsLrDp+ZTAY+G/3Qf7ctJ0DR07So0sHnpk0oa7bV6nLR9I+FxPH5rWfqHIUUfH/4cDxGPYfjaGwyECArweDerXF1bn62+cBcnIL2H/4JJ7ujrRr09LmbTObzaq9hVgIISpjdYEExbcP79p3mD83/cff/+7kl68X12XbrFIykvaVFEgyRLvyqClbXl4Bv/1zAJ1OS+umgQT6e+PVyNXezbIpNW2vy6k1F6g3m+RSlgb/qJFdew/zx6btbNm+hzYtmzHkmr48NfGuum5bPVLnxW3qzQVqyXbiXDzb956iyGBkUK+2NAn0Qq93sHez6oA6tld5as0F6s0muZSlgV+kvXj51wy5pi8PThiNl2f5weOUToZoVx61ZDsXm4xOq6FrpxaEN/bDZDLZu0l1Qi3by5Jac4F6s0kuZbFnLqsKpI/eebmu22FX1j57SmnUmgvUkS0zJ4+Y+FRCAr1p26L41nk15KqI5FIetWaTXMpiz1xWFUhbd+zjky9/JCU1vcyYBKs/XVBnDatPRqMRvV591bdac4E6sh09eQF3Vyc6twsvfU0NuSoiuZRHrdkkl7LYM5dVBdKrby1lwtgRdGgbobLb+4Wwj7z8QpLSsvBwd8Hfp2bjFgkhhKh7VhVIIcGB3Driurpui93IEO3Ko/Rsuw+f5XxCGgN7ti3zutJzVUZyKY9as0kuZbFnLquOW11/dV9+/f0fcnJyy/ynFjJEu/IoOVtsfCop6dm0aR5M0xC/Mu8pOVdVJJfyqDWb5FKWBv+okaWfriIzKwcAjQbM5uL/b/n1szptXH2RIdqVR8nZ9h+LIT4pg6t7tcPRoexHUMm5qiK5lEet2SSXsjT4R438tuqDum6HEP8XElIySE7LomPrUNxr8UwzIYQQ9aPKU2wGg6G+2mFX6hyYT725oGFnKzIYyMkrqPD1Tf8dxauRK21bNK5w3oac60pILuVRazbJpSz2zFXlEaRpr77LazOfos+Qu7j8UUxqO8UmQ7QrT0PMZjabOX42njMxiZjN0KpZMC3CAkrfP346Dp1OS0RYIJ6VPEqkIeayBcmlPGrNJrmUpcE+auT5x+8FYP3qJfXSGPtR58Vt6s0FDSVbYZGBgsIiXJ2d2H34LCfOxuPm7ER6di4Go5Hmof5oNBry8gs5fOoC7m4utGoWVMUSG0Yu25NcyqPWbJJLWRroRdo+3p4AuLup68GZlmSIduVpCNlycvP5c/thcnIL8PVqRFJqJs2a+NM9sjk7DpzmwPFY0jJy8PFyZ/+xGADaNA9Cr6/8gsOGkKsuSC7lUWs2yaUsDf5RIw3Rtz9tYPWaDTa5BVCrVeeOpdZcYP9sp6ITOHY6nozMPFydHTkTm0SArwc9oyLQajUE+3tx/GwCuw+dJa+gCIPRiLubM01D/Ktcrr1z1RXJpTxqzSa5lMWeuTSFhQXVVhgmk6lcI9MzshrEg2sNBgP9ht3N5rWf1Po8pcFQpMoL3NSaC+yTrbDQgFar4WxsElv3nsTN1YluHZrh7+NBXn4hGo0Gb083AEwmM39uP8TZ2GQauToT6O/JwB5tq1mDereZ5FIetWaTXMpiz1xWVRT3PDaDT997tcxrz774Bh++re6H2ApRwmg0sXnXMc7Hp2IGwhv70bVDMxq5Fd+q7+LsWGZ6rVZDn04t6de1NQaDETe5pV8IIRSlygLplw2bAcjMyin9N0BcQhKpaZl127J6JEO0K099Z4uOSyE1IwdvTzcaB3jRuV2zap8y7eriBICTo/V//ah1m0ku5VFrNsmlLPbMVWWBFJeQBEBubj679x0ufT0o0I83Zz9bty2rV3L1v/LUb7ajp+NIz8zlrhF9cHZyrH6GWlPrNpNcyqPWbJJLWRroXWz3jbsFAE+PRowePrheGmQPxddYqa/6VmsuqN9sGZk5xCel0z4ipI6LI/VuM8mlPGrNJrmUxZ65qiyQUtMz8PHy5KpenYlPTC73flCAXwVzCaEeuXkF/PjnHny93WnfMsTezRFCCFFPqiyQXnt7Oa/NfIrxE18ANJQ91KVRzQCSOp1iRzuoklpzQf1kM5vN7D50FldnRzq3Dat09GtbUus2k1zKo9ZskktZ7JmryjW/8sJjAKxfvbReGmMvRqNRlUO0qzUX1E+28wlpxManERLkTZMg3zpdVwm1bjPJpTxqzSa5lMWeuaocgcnBQX2dXTG5uE156j7bmdgkXF0d6dg6FI2m6jvWbEet20xyKY9as0kuZWmgF2mXWLPub5Z++i2paemA+h5WK0O0K09dZyssNJCRlYeTg75eTq2VUOs2k1zKo9ZskktZGvyjRt7/6GumPn0/kW1bVvkcKaWSIdqVp66zHTl9geS0LHp1alGn67Gk1m0muZRHrdkkl7LYM5dVBVKz8BD69epS122xG6PRoMoh2tWaC+o2W35BIdFxKfh5uRMRFlgn66iMWreZ5FIetWaTXMpiz1xWFUjDruvP8pXf07931zKvRzQPq5NGCWFPx88kYDKaaRfRWJVHTIUQQlTPqgLpw8++A+DndZtKX9NoYPWnC+qmVfVMjYNrgXpzQd1lM5vNxCWlY8ZMi7CAOllHVdS6zSSX8qg1m+RSlgb7qJES361QRyEkRHXOxCSSm19ASKC3as/pCyGEqJ5VBVJFo2iDekbSNpmMqvxlqNZcUDfZzGYzR07HodVqiWzVxKbLtpZat5nkUh61ZpNcymLPXFYVSJYjaeflF9CyeTjL351Vh00Ton4dPX2BwiIDTUP8cXF2sndzhBBC2JFVBZLlSNq//72NpOTUOmmQPcgQ7cpj62zZufmcO5+Mu4sTbVs0tumya0Kt20xyKY9as0kuZbFnrlodt7p2QC/W/Pa3rdtiN0aj0d5NqBNqzQW2zZaXX8g/O4+Rl19Ei7BAnJ3sd6usWreZ5FIetWaTXMpiz1xWlWabt+4q/bfBYGTvwWPkFxTWWaPqnwzRrjy2yZaemcO2vafIyikgIjyA5na4c60stW4zyaU8as0muZSlgT9q5Kvvfiv9t0ajwdfHizkzHq+zRtW3+nvOVv1Say648mxmsxmzGXYfOktmTh49OzYnPMTfRq2rPbVuM8mlPGrNJrmUxZ65rCqQ3nt9Wl23o1RGZjaz31hCnx6duOXGa+plnTJ+hPLUNpvJZGL34XNkZOUQ4ONBTl4hTUP8G0RxBOrdZpJLedSaTXIpiz1z1du9c19+9ys33f4oK1etLX3th1/+5M6HpvDQ07NITEoBwNPDnTtGDa2vZgHFQ5mrkVpzQe2zxcansfvQWc5dSOHAsVgcHHR2u6W/ImrdZpJLedSaTXIpiz1z1dvl4V0i23DydHTpz6lpGXz29RpWLpnH5m27ee+jr3l5yiP11RzxfyK/oAidTotepyUmLoWdh84QEuhNy/BATGYTft4euDg72ruZQgghGphaF0gZmdl4erhbPX3rls0IDrw0sOT2XQdo1aIpzs5OdIpsw+vvfmz1sr79aQOr12wAiq8lATAYigAzOp3+4lXvZjQaLVqttrQCLTlUZzIVXxWv0+kxmYyYTGYMBgM6na6aaU2YzSZAYzGtFtBYNa1Go0WjqXxavV6PwWAobf/l02q1uovXzlQ8rVarKb3iv6T9xf0Cer2DxbSW/WLGZDKVtqkmfXhpWg1abXV9aLy4zSz7sOb9XZKt4j4s4tiZeA6dvEBIgDc+nq4cOxOPh6szjQO9aR7qZ4P+Ltsvl6a1pg8r7m+zuXiftl1/23ef1el0mEzm0s9Ydftsffe3td8Rle+zle+HSviOuLwPLb8jNBptaTalfkdUNK3JdPnvjIr6u3iftU1/1+c+a8ZgKFLsd0Tl05bdD+uyvy1P59W6QHp86lw+fe/V2s5OSmo6YU2CAPDz8cJoMpFfUMipM9F89/MfZGRm0yw8hM6RbcrNO3r4YEYPHwyAwWCg37C70esd0OuL45T8v4Tlk4AvH5VTp9Oj0ZhKX6t6Wh1wqQPrblp9pdNenKPSafX6stNePm/1/VLVcitvf0372/ppq+pDU6XTms1mNm4/SnxyJkVFBuKS0jhxLh4Pdxd6dWmJu4uzRRuupL8thwSoSR+Wn9ZkMqHRaGzY3/bfZ3U6Ln5Rayuc1nKfrc/+rnzauthnG+Z3RGXTmkwmdDolf0dUPG1J0VH1tGC7/q6ffVav11fxGWvY+2xV/V3RflhX/W2pygLpmx/WVfpeenpWlQuulubS0R8As8mMRgPt20TwyrTHrmzZNSRDtCtPVdnOnU8mOTULs9lM+4jGaLTFp9haNQ0uVxw1NGrdZpJLedSaTXIpS4N91MiHn31Hh7YR+Hh5lHuvoPDKxkHy9/Xm4JGTACSlpOHg4ICTo1wLIq5cdFwqri5ODO7bAVcXeWSIEEKImquyQLq6Xw+uu7oPXTq2Lffe+Eeu7Nb/Hl0iWfrpt+TnF7Bn/1H69OhUo/lLrkO6/ChUbckQ7cpTUTaDwcD2XQc5djaFoAAfRRZHat1mkkt51JpNcimLPXNpCgsLKq0wCgoL0el06HXlxyH4ZcNmbhjcz6qVJKWk8cz010lJy0Cr0RAe1phFr73AmnV/89V3v9LIzZXZ0x7D39e7xgFKrkHavPaTcucXrWU0GlS5c6k1F5TPlpiSwba9p4hPiOefv/7g7ddfxtvT+psIGgq1bjPJpTxqzSa5lMWeuaoskJTAFgWSwVBU7cVaSqTWXFA+25Zdxzl08jw9OjYn2M+NQH+/KuZuuNS6zSSX8qg1m+RSFnvmUl+5WSvqHKJdvbnAMltBoQFfL3ei2oQpfMh9Jbe9KpJLedSaTXIpSwN91MieA0crvM2+IbDtNUjqHKJdrbmgbDaj0ciZ2CQaB3gpvDhS7zaTXMqj1mySS1nsmavKe+fe/uBzAO5/Yma9NKYmRg8fzJfL5vP5B3OveFkyRLvylGTLyy9ky+7jGAwG/Hwa2blVV06t20xyKY9as0kuZWmwjxpxc3XhianziI6NY8qsheXen/fik3XULCGsc/R0HHsPncLbVUtUmzB7N0cIIYRKVFkgzXx+Ijv3HCI6No5+vbvUV5vqnTwFWXm0Wh0Gg5ELCWk0aRzEyMFdFX96DdS7zSSX8qg1m+RSFnvmqrJACvDz4YbB/QgPDaZ9m4j6apMQVklMzeR8YhrdIpupojgSQgjRcFh1F1v7NhFs+Gsrm7fuAjT0792Vawf2quOmVc2WF2nLEO3KE30hmT+27EGvc6Kxv5e9m2Mzat1mkkt51JpNcilLg33USIkVX//E5q27uWnIQDQaDV//sI74xGTGjbmxrttXqZIH1paMgyT+f6Rn5rB+yyFcHJwJC3Am0M/T3k0SQgihMlYVSOs3buXDhS/h7Fz86IZrB/TkgSdftmuBZEtqHH0U1Jlr296THDoRi7eHK706RRAa7GvvJtmUGrcZSC4lUms2yaUs9sxl1ZrNJjOOjpdGsnR0cMRsUvQA3GWYTCZVjiGhplypGTls2nGUtIwc/Hwa0bdzS/x8yj9EWenUtM0uJ7mUR63ZJJey2DOXVQVSz66RTHvlXUYPHwzA6p9/p0fXDnXasPpkNpsA9e1YasoVcyGZIoORqLZhdGoThslktHeT6oSattnlJJfyqDWb5FIWe+ayqkB65L7b+Oybn1m8/GsA+vXqwrgxw+q0YfVLrXdAKTvX2ehYsnINFBSZiI1PIye3gM5tw9FoNJhMJns3r44oe5tVTnIpj1qzSS5lsV8uxT6s9vK72M7FxF3Rw2rNZrMqbxNXeq6Jz82hY+ceODs5YjSZaNuiMX27tAKUn60ykktZ1JoL1JtNcimLPXMp9p5AedRI9ZSe65/Nm/nu6xU0D/XH0UGPVyPX0veUnq0ykktZ1JoL1JtNcilLg33UiBD1LS0zB28PN5JS0omJvUD3LpEM6NHW3s0SQgjxf8bqAqmgsJD09CzMXDojFxTgVyeNqm9qHFwLlJdr/sKlePg3oW3LZmRk5jLr5ZkM7NmuwmmVls1akktZ1JoL1JtNcimLPXNZVSB99Pl3fPzFjzg5OqDTlTRWw/rVS+qwafVJfedtizXcXOmZOeTmFRLk71n6AVj2yVfcNeFetHoXHB10XNW7M5Ftm1ayhIab7cpILmVRay5QbzbJpSz2y2VVgbT6p9/55L1XiGgWWtftsQsZor1+JSQm8/PGHWh1zvz999/cO+5WNBSSlJxCelIszz40Gr1ej6Nj5btnQ812pSSXsqg1F6g3m+RSFnvmsmqtrVs2pXl4SF23Rfyf2Prfbp55ZgpaYx7XXDOI6bPms/KbtcycMZUHJozG1dW5yuJICCGEqGtV/hYqfjgtRDQLY/47H9O3Z6cy7/fr3bXOGlYdWz6sVoZor197DxwBoGtkBAGBQfz8gxfeni6Mv3Uovj7WPVetoWa7UpJLWdSaC9SbTXIpiz1zVTkO0qTnXq18Ro2GRfNfqJNG1UTJw2qvZBwko9GoyiHaG2Ku7Nx8rh9xFwB//fIFDg4OpKdn4uVVs8eGNMRstiC5lEWtuUC92SSXstgzV5UVxXuvT6v0PaNRPSMZyxDt9aOwsIjX316GwWjihsH9cXAofr5fTYsjaHjZbEVyKYtac4F6s0kuZbFnLquuQXryhdfKvfbEC/Ns3hj7kav/68OuvQd4+70PuWZgX2ZOfeIKl9awstmO5FIWteYC9WaTXMrSQO9i23PgKGazmQvxSew5cLT09QvxiZyLiavzxtWX2p6aa+gaWq6vvl1Lv97dGHvLDVe8rIaWzVYkl7KoNReoN5vkUhZ75qpyzWvX/Q1ASmo6H65YXfp6UKAfLz8/sW5bVo8MhiL0egd7N8PmGlKuc+eT6dVvEBER0US2b33Fy2tI2WxJcimLWnOBerNJLmWxZ64qC6Tpzz4EgJ+vNw/fM6ZeGiTU52zMBX7fdhw/70Y8dPcYVT5QUQghhLpYdQ1SYZGB/3YfpKCwsK7bYxcajfoG14KGkSsrO4cde4/z71/r6RXV3GbjGzWEbHVBcimLWnOBerNJLmWxZy6rflsF+Pmw6sd1vPTaYlq1CKdHl0h6dI2068jathwHSa1HNOyRq6CgkONnLvDTbxsJ8HYn0N+bhx+dzKwZkwny97bZemSbKYvkUh61ZpNcymLPXFWOg2TJaDRx8OhJVv+0gT83/8c/v3xal22zii3GQZJzt7aRm5fH3DfeJzMfzp45zclTp4iKbM8vv21g/Y8r6NE1ymbrkm2mLJJLedSaTXIpS4O9BqnE0RNn2LnnEDv3HiI6Np52rZvz9CP/a+/O46Ks9geOf2ZBNkFAdlRERXBBcc8tzdIsS7upbXZttexnZmW3RUuv5ZbVLUvTFltc2tQWbb1lbqnXfSdzFxcEQUREtmHm9weCSoCDzjBzjt/363Vf94U9DOfznJFOM8+cZ7CzxyYUUmgp4q0Z83jnvU8ZMewhFs5+iyWrtrF6/VZe7daNls2buHqIQgghhN3sWiA9OHwMbVo25e7+N9GpfaKTh1T9dNx9FKq368+9R0nNOMM7/5lIv5u6YTab6X5Nc2r7mWnaNB5PzxoO/XkyZ2qRLvXo2iZdanFll11vse3dn8yGLUls2LKTYylpxMXWp03LptxyY7fqGGOl5FYjFauurn0HD7N+51H8fL3o1aU5HtWwb4XMmVqkSz26tkmXWlzZZdfl4Y0a1OOu23szfvRwnnh0EIWFFiZP/cjZY6s2xVuZ68fZXSknMlm0ZD3/GDSMY0eTSWwSXS2LI5A5U410qUfXNulSiyu77Pq32ay5X7NxaxJ79yfTvEksHdokMGRwf2ePrRrpefW/M7vGjH+TerHNMRg9GPviKFo3jSIqzHGfUrs0mTO1SJd6dG2TLrW46a1GSmSfOcvgO/vSqkU8njUcey2JO5At2qvmRHoGCxf9zA098njp2ccJCqiJ0Vi9T2KZM7VIl3p0bZMutbjtrUZKPDn0XnJyzrJ52y4MBgPN4xvi6+vj7LFVG4vFouWTy1ldy/9YR2raCdq0iCM4yM/hj28PmTO1SJd6dG2TLrW4ssuun7pz116eH/cWURGhGAwGjh5PY/KYJ2ka19DZ46smV77ZpHtyfNfp7DN8vmAxfjVrcuMN1zr88e0nc6YW6VKPrm3SpRbXddm1QHr7/c+YPPYpmsUXL4h27trHWzPn8v6bY506uMo4didt2aK9Ilmns0lJP01KWhY5p9OZ9Po0+vS9nQG39yUsNNgBo7w8MmdqkS716NomXWpx+1uN5JzNLV0cATSLb8jZ3DynDcoeA/r2ZEDfnqUf878SskV7xcZNmorFWJOuXTqwaPFv7Ez6i6cfD+SW3j0cMMLLJ3OmFulSj65t0qUWV3bZtTQLrOXP8tUbSr9esXojAbVcc+2JM1itRa4eglNcadeW7UmsXL2eM5nH6N21Jd7eXkRFRdKrRxc8a7h2S3uZM7VIl3p0bZMutbiyy65XkEYOu4/nxr3JWzPmAODp6cmUfz/l1IEJ1/py4ff8Z9qHREWGc8ftffCr6cPM157HaBzl6qEJIYQQTmfXAikyPITP3n+Vw0dTAKgbFYHJpM/7nUajfruPwuV3/fDLUrIKPGiVmMjIYfcT26j+ucdznzmXOVOLdKlH1zbpUosru+z6N95jz4zHZDJSv14U9etFabU4Ahxyobc7upyus7n5rPjfFrZs3sS/Rz9VujhyNzJnapEu9ejaJl1qcWWXXa8gxcfWZ9XazXTu0MrZ43GJ4q3M9Vt9X07XX/tT6NSlGwmxUYQH13LOwBxA5kwt0qUeXdukSy2u7LJrgZR56jTPjXuL+vUiL3r16NPpE5w2sOql59X/Ve3KPH2W5JQMjEYjMXVDnTQmR5E5U4t0qUfXNulSi5vfamRAv14M6NfL2WNxGR13HwX7u9JOZLB9TwoZWWfw9fKkaWwdt//I6NU+Z6qRLvXo2iZdanH7W420btHE2eNwqat1i/aNOw5w6Fg6Y8aM5ZZb+3J99y6EB9cipk5INY7y8lytc6Yq6VKPrm3SpRa3vdXIpq1JmEwmWjaPA+ChJ8ZyKus0AI/eP5Be13Vy/girhZ4Xt1XWVVRUxFdff0dcfAvuuXMAUaG16Nm5eTWO7UpdfXOmNulSj65t0qUW13VV+nG0D2YvJCQ4sPTr/IICpk0Zzb+f+z/mLfjB6YOrLlfjFu1btiXx3vsfc/RAEiMevYf7BvWvxpFduatxzlQmXerRtU261OK2txrJyc0jMvz8xboRYcGl/7MU6rNrpzvt7+NIlXX9tmwVEeGh9LyuM74+XtU4Kse4GudMZdKlHl3bpEstruyq9CcbDQbyCwpKv35t3Eig+JUknSajqMji6iE4RWVd+RYICw2hTSuV3lY772qcM5VJl3p0bZMutbiyq9JVzg3dr2HCGx+Qm3f+xrR5efm8OvUjundp6/TBCefYsHkHsU1a8vK4sXh4uPaeakIIIYQ7qvQttrtvv5mp783l9sFPERMdBcD+g0fo3qUd993dr1oGWJEFi35l4eJfHbLL5tW0RXthYSF33vc4N9zQgxmvv+iCUTnG1TRnOpAu9ejaJl1qcWVXpQskk8nI0/83mHvvuIW9+5Ox2Ww0jKlLeGhwdY2vQgP69mRA355YLBa69rn/ih7ratqifcu2PzEYIDY6XOm3Sa+mOdOBdKlH1zbpUovb32okNDiI0OAgZ4/FZa6mLdr3H0wmPSOT2EYNXDMoB7ma5kwH0qUeXdukSy2u7FL3JYSrgNVqvaLvP3rsON98/wvHU08AUFhoYf3mJAAaxNS94vEJIYQQupIFEmAyud/uo6dO5/Ddb5tYtu5PrFbrZS2Wkvaf4IGhzzJy1ARycvP5bskmomJimTJ+NI1iop0w6urjjnPmCNKlFl27QN826VKLK7v0PKNVVFRU5HZbtO8+eJyMrDPsPXiEBfMXEN8omgcHD8TH2/uS35tfUMDytX9y4HAqISHBHEw+yl8HUjCbTdx83TU0jgl3+3utXYo7zpkjSJdadO0CfdukSy2u7JJXkAB326K9sNDCjt1HCKrlS/O4+mzZtoMXX3mDteu3VPp9JRezPTfmVaa9+x71owLpd/MNmIwGPpn9OYX5ecTWD1N+cVTMvebMcaRLLbp2gb5t0qUWN79IW3futkX7H2u3cHDvLv55V1/q1wkhbMoY5i38mfyiv1+olpaRhYfZhNUGh46eYMmKdSxdsZYe3a6h17VtqWGwcDz9NJs2byOxWUOlP7l2IXebM0eRLrXo2gX6tkmXWtz2ViNXC3daNJzJySHtVB6BgYHUCQvEw2ymVYumHDh+llwLLFmzjbBaXoRHRJB8LINjaadITT+FDbBabcTGNuTW3j0Y+vA9mEwmru/eGavRm9+XLuXuAX1dnecw7jRnjiRdatG1C/Rtky61uLJLFkgUb2VuNrvHjtKbtuzk0aHDmDD2X3h7F98jzWAwEBsdxoYdBxj38gQK8/N5bOgQfPxrY7Xa6No2jtz8AkKC/AkJ8uO2G4p3ObdYCjGbPejVrQ29urVxZZbDudOcOZJ0qUXXLtC3TbrU4souWSC5mR1JuwFo3jT2oj9vFluHepHBrFnRjGV/rGPTpg08cE9/OnZIxGzSb+8LIYQQwpVkgYT7bNFeWFiIV60wnnv2KVo2b3LRPzOZjAT4+zB65GP06NqBuvXq0qVDq0ofz126nEHXNulSi65doG+bdKnFbW81opPUtHT+3HOIkNAw4mIiMJsvPOmuvfo/N6+A+d/9yspVa2ma0JyBfXsTUMu/3GPrR9ehfnQdOx9Z1081gL5t0qUWXbtA3zbpUot8is1pbDYbWdlnWfTf1azZsJUe3bvx399X0LRJE+pGhtK0URRWq9Vlq1Sr1cqXP63ljzWbaJHQjMYNomgYHeawx9b1vyp0bZMutejaBfq2SZdaXNml7QLJarWyfP0uUlIzKLKCt39thgy+k9z8Qj77bB6p6Vlkn8rgX4/fT50oxyxILseq/20kaetG7hnYh67tE/Dw0O8iOyGEEEI1en4uEFi6Yg1Ll61iyZKlmE1G+vVoTYfEWLq1b8LCT6fSIjaSeZ/PZ8WqdS7dyjxpTzLLli8nKjTA4YsjXbeeB33bpEstunaBvm3SpRa51YgT/PL7Sn78ZRnzZ0+jSVyjC/6JAW9vL3r26ELXTu3YuGUHd/bvg6enZ7WNzWazkfTXAZasWMPOXft4edwY4mIbOPzn6Lr1POjbJl1q0bUL9G2TLrW4sku/swls3LGfdRuTiK4bWWZxdF5IcG3Ons1l+659LFqyCS9vL+JjIoitH+708S1d8T8OpZ3F5BVEvTp5xNULdtJP0vWiPdC3TbrUomsX6NsmXWqRi7QdJjevgJQTWTz51Ah6d2le6bEfzXyTmR9/SXJyMrt27eJ7WwHvTZ3g1PFZrVY+mvsVBw4e5tvPP8DPryZens657kjXredB3zbpUouuXaBvm3SpxZVdWp3RrUn7+GHZFlJOnCI+JgIvr8rfNouuE8qkl4bz9KN3kJOdyYJvf+J0drbTxnfoaDqPPT2WY8fT6dO7ByHBgU5bHIG+W8+Dvm3SpRZdu0DfNulSiyu7tDmj782ax4RX36IgP59buidW6aPyRUUW7h/Un4SmcXy96BeHjSn5SAqZWafJzS9g25/JbNxxgNDIGBpE12HIfXc67OdUpKjI4vSf4Sq6tkmXWnTtAn3bpEstruwyFBTkK/3GpcVioWuf+6np48X69ev5fv6HdOnYroqPUYjNBl163UFubh7rln17yVefLuXpF8aTmpGNr68vx1NSuO+BBwisVZNOrRrh5Vnjih7bXiX3YtORrm3SpRZdu0DfNulSiyu73O4VpJTUdEaPf5vxb7xP1ukzdn/f1NfG8su3s+l8Tdsq/0yj0YSHhwf3DerP0ZRUVq5eX+XHuNCBg4dZuXoDQQE1ia4TRrP4BhTmnKR7+ybVtjgCfbeeB33bpEstunaBvm3SpZar4lYjn3/9E5/N/4G7br+JQQP7APDtj78z/7v/UtPXh1deGEZoSG2+/2U5g++8lRMZp1iyYi2333K9XY/fuH4EZnPdKxrjjT268uuSlSz47id69uhy2Y+zfdd+PDzM3NyzKzf17H5FYxJCCCFE9au2V5BaJ8TTvk1C6dcnM7OY8+ViZk0dx4C+PZk+60sAMk6eIjwsmIjwYNIzMqtlbFZrEQANG0TTp89NdOrem+NpmWzYtK1Kj5ObV8DsL76hwODN0888S68eXZ0xXLuVdOlI1zbpUouuXaBvm3SpxZVd1fYKUlxsDBFh5/f7WbtxO40b1sfLy5PEhHhee+djAIJrB3Ds+AnST54iNCSo3MdasOhXFi7+FSjedBGK36cEGyaTmaKiIsCGwWDEaDSWXuRV8lJdyQk3mcxYrUXnjjdgMpm4+YbO3Pvwk7zw3D7CQmrz4rOP06/PDeeOtWKzWUuPPf+4Rk6fPsOPyzaQtD+dTh2iaRwThs1mxWKxXXSswWDEYDCUGcP5xzWbzVgsltLxX3is0WjCZrNVeKzRaDjXUnys1Wo9d17AbPYoc2zZ82LDarWWjqkq5/D8sQaMRtMlz3fxnJU9h+UdW/H5vrCt/HNYWMH5NmG1VnwOq3a+Lz4v54+15xyWf76LiorOfe2o813xOYSKn4eOes6WnO+Sv2OXes5W9/m293dERc/Zyp6HrjjfVf0dceE5LPs7wmazlbap+DuiovNdvPGgh7K/Iyo63yXzqurviIqOLfs8dOb5Lvt2nsv2Qco4eYp6dYo3ZQwOCqDIaiUvv4A+vbox9b25GDDw/JMPlfu9A/r2ZEDfnsD5i7TNZo/S3TbL7rpZ9gKvCz82aDKZMRpNGAwGACLDQ+jRrSOWwkIyMrPYvC2J/v1uOnesCTCV+7ifL/ieUeNeY+6sd7i5R6vSx7NvDGUf11zhsee+o8Jjzebzx3p41LhoHJc+L5U9bsXjr+r5tv/Yis+3h4fxorbKjv3744LjznfZiwercg7/fqzJZMZgMDjwfFflvFzJsRWfQ5Op+OuS+arsOXvuOyp8XEef74qPte85W/bvmDuc73PfUeGx9p7vC+fs/J+p8zuiomNLHl/V3xEVHVujhmclf8fc/3dEVZ6HzjrfZbnuIm3D+Vd/AGxWGwYDRIQFM3nMk0waM4Ja/jWrZSglK+8Szz81lC8+eYfQkNp8ufB7ux7jf+s30a51C67r2racyXSNsl060bVNutSiaxfo2yZdanFll8sWSCG1A0k+ehyAExmZeHh44Fmj+j7hdbGLdzowm81ERoTRKCaa9IxM7n34qUq/22Kx8NvSVXh4eODj7e3MgVaR0js4XIKubdKlFl27QN826VLLVXirkfatE3j/0wXk5eWzedsuOrVPrNL3l1yHdOGrUJerold83pg0GpvNxvakv9i4eTttWiWUe9ze/Yfw9/enW5cOVzwWR3KXV7KcQdc26VKLrl2gb5t0qcWVXdWyQDqRkcnIF18jIzMLo8HAmg1bmfbqKO6/5zYeGjEWP18fXhk9vEqPWXIdUsk1SFeion0W/P1qMuT+uxj98uts2rqz3AXSX/uPMu+rxaQcTyW6buQVjcPRdN0XA/Rtky616NoF+rZJl1q03wcppHYgs2dM/Nuf33pjN269sVt1DKFSRUWWCi/WatE8ng2btxMTXZch999V+ueFhYXk5Rfw/EuTWLp8JZ41ahDXuGF1DdkulXWpTtc26VKLrl2gb5t0qcWVXS57i00V3t5eBAbU4mhKKkVFVkym4su2pn8wh5cnv0NggD+9b7iWenWjaNk83sWjFUIIIYQjyAKJS7+EFxYazO49+3nv04UsW7GakY/fR8rxNGIbRPPw/Xfx4D8HnvtIo3vR9SVX0LdNutSiaxfo2yZdatH+LTZncORF2pdy4w3X8sEnXzBqzHgAOrZtzu/L12A0Gi96200IIYQQenC7m9Xaa0Dfnnz+wRTmzpx0xY91qa3Mx416kgG39cZsNhEYUIu09AyOHjtOVGTYFf9sZ9J163nQt0261KJrF+jbJl1qcWWXsguk6vbW5DGkH9xELX8/fl+2mrO5eUSGu/cCSQghhBCXRxZI/H1r+/KUbIse17gBew8con3bliQ0i3P20K6IPV2q0rVNutSiaxfo2yZdanFllyyQoPSGgPbo0rEtMdF1WbdhKyHB5d9M111UpUs1urZJl1p07QJ926RLLa7sUnbJ6ciLtIvv9mvflfKxDeuzd/8hABo3anDFP9uZqtKlGl3bpEstunaBvm3SpRZXdim7QHLkTtpg/1bmna9py/BHBuNb04fYhvWv8Oc6m55bzxfTtU261KJrF+jbJl1q0fxWI+6uKnsY+dX05aXnnwCgRg333rXUHfdmchRd26RLLbp2gb5t0qUWV3bJNUgUb2VeFTVqeLj94giq3qUSXdukSy26doG+bdKlFld2Kf8KUsk1SBbL5Z/E4u/V7+VJXbtA3zbpUouuXaBvm3Sppbq7TCYTBkPxz1N+gVRUVLyJ1HX9HnbxSIQQQgihspU/fILZXLw0MhQU5Dv/Xh1OZLVaKSgouGjVV1X3Dn3BITtyuxtdu0DfNulSi65doG+bdKmluru0egXJaDTi5eV1RY9hMBhKV4w60bUL9G2TLrXo2gX6tkmXWlzZJRdpCyGEEEKUIQskoP+tPV09BKfQtQv0bZMutejaBfq2SZdaXNml/DVIQgghhBCOJq8gCSGEEEKUIQskIYQQQogyZIEkhBBCCFGGfp8JLOPzr3/is/k/cNftNzFoYB/+2nOAV954H5vNxoC+PflHn+vJPpPDmzPmsHvfISyWIp594gFat2hCXn4BL0+ZwaHDKbRr3ZwRjw667L2WHM2erhI5OWcZ+OAzDHvoLvr0ulaLrn8MfhIfby9MRiNREWFMGjOCoiIrr0/7hG07d9OoQT1eHPkIHh7u8xS3t+3Q4WNM+M8H5Obm065VM554dJDyc7Zm/VZmfPRl6fccPHyMD94cS6MG0W47Z/bO19KV65g+6wsAhj10F9d1be/Wz0V7u2Z/uYjFPy8nMMCfF0c+Qr06EW7bdTo7h8lTZ3H4yHFq+dfk5ReGYTQaeWniNE5mZnFTzy7cO/AWAL798Xfmf/dfavr68MoLwwgNqc2prOxyj3W1qnSVnVfAbbvA/rbyjgsKrFUtbdq/gtQ6IZ72bRJKv3717Y957okHmTV1HF98/TNHjqViNBq57eYezJ05iWEP38UHsxcC8M33vxERHsLc9yZxMPko6zftcFXG39jTVeLjz7+jdmBA6dc6dBkw8Om7E5g9YyKTxowAYOWajWRln2He+5Px8fbix19XuqShIva02Ww2xk2ZyYhHBzF7xgT63HgtoP6cdWzXktkzJjJ7xkRGPT2ELte0Ji42xq3nzN7n4psz5zB9ymhmvT2O9z5dALj3c9Gerv0Hj/Db8rXMmTGRh//Zn8lTZwHu27Xjzz0M7NeLOTMnEhdbn3kLfuCjed/QrXNbPn13PD/99gfJR1I4mZnFnC8XM2vqOAb07cn0WcWL9vKOdQf2dsHf5xXctwvsbyvvOKieNu0XSHGxMUSEBZd+fTwtneZNGuHl5UmXa1qxau1mfH28adGsMWdyznIo+RiNG0YDsGrdFhIT4jEYDCQmxLN6/VZXZfyNPV0Ah48eZ9vO3XTt2Lr0WB26/Px8MJe5y/OqdVtolRAPcK5rS7WN2x72tB1MPobZbKJZfCMMBgMN69cF9JizEtM//ILhQ+4B3HvO7O0K8Pejpq83tfz9So9XvWv/wSMkNo/Dy8uTtolNOXjoGNlncty2q1P7xNJxJTSN5UR6JqvP/Z0xm80kNIllzfqtrN24ncYN6+Pl5UliQjxrzo2/vGPdgb1d8Pd5BfftAvvbyjsOqqdN+wVSWQH+fvy5ez85OWf5a+9B0tJPApCSmk6fO4fx05I/GPrAQAAyTp4iuk4EANF1IkjPyHTZuC+loq5pH37O8CH3YDSefztGhy6LpYjHn5vI4MdGsXLNRqC4q15JV90I0jNOuWrYdimv7djxNIICazFuygzuHfoCS1asBfSYM4CDyUfx9KxR+otcpTmrqGvoA3cw5MlxzPz4K67t1AZQvysyIoQtO/6isNDCjj/3UlBYyIn0TCW6Nm5JokWzxpzMzKJOZBgA9eoUj7V4/OEABAcFUGS1kpdfUO6x7qayroqo0AX2t5UcB9XT5vo3j6vZv554gClvf0xQYC0axdSjpq8PABFhwfz+3Sx+/G0lz7z0BtNfG40BA1Zr8TZRVpvtokWGuymva/3mHdT09SGhaSxrN24rPVb1LoDRTw8hJjqKXXsO8sxLr7P482kYDMX35oPi/3fnLii/7WxuHnv3JzN9ymgMRgP3/d9oundup8WcASxbtYGO7VqUfq3SnJXXVVRk5fv/ruCxh+7kp9/+ICMzi3/0uV75rqZxDenUriUPDh9Dx3YtCA8Lpqavt9t37Tt4mPWbd/L4kLuLr3mzlfydsWIwGsAANtv5rf9sVhsGQ/HtLP52rBu5ZFcF3L0L7G+78Dionrar7hWkVgnxfDJ9PP8Z/y8sliIiw0NK/5nJZOSWXteye98h8vILCK4dyOGjxe9rHj5ynOCgQFcN+5LK61qyYi279x7i4RFjWfTzMj7+7FvWbdyufBdA07iGeHt50SohnojwENJOnCQ4KJDDR48DxW8tunMXlN8WXDuQ8LBgwkJrExocRO2gALKys7WYM4Bdew7QKKZe6dcqzVl5XduSduPv50vXa1ozYfRw9uw7REpquvJdUPzK2JyZE3nkvgGcyjpN7aBAt+7KPHWasZPfZfzo4XjWqEFQYK3S68QOHzlOSO1AQmoHknxu/CcyMvHw8KjwWHdhT1dF3LkL7G8rexxUT9tVt0Dad/AwRUVWUtMyWLdpO107tmHZH+tZu3E7NpuNDVt2UtPXG88aHnTukMjmbbuw2Wxs2bGLTh0SXT38CpXX9fyIh5gzcyIfTh1H397deeCe22jfJkH5rm07d7Nz1z4A9h44THZ2DpHhIXTu0IrN23YBsHmbe3dB+W1N4xpw9Fgq6RmZpKZlkJ2dQ4C/n/JzViI1LYPaQQGlX6s0Z+V1GY1Gknbt42xuHjlnczmRkQk2m/JdNpuNvQcOA7Do5+V06dAak8notl0FBYWMemUqQwb3p1FM8XV7nTu0YvP2XVgsxW8TdmzXkvatE9iz7xB5efnF42+fWOGx7sDeroq4axfY31becRUd62ha32rkREYmI198jYzMLIwGA9H1IrmmbQt+XrIKo9HIiEcG0SaxKekZmbw+/VOSD6dgw8ZzTzxIYkI8+QUFvDxlJgeTj9GhbQuGD7nbLT5abW/XhT6cs5CIsBD69LpW+a609JO8+e4cjhxLpaCwkJHD7qN96+ZYrVbemP4pW7b/ReNG0Yx+eojb3N26KnO2btMO3nn/M/ILCnhy6L10ap+o/JyVuOPBZ3j3tdEEn/uvPXedM3u7bDYbs+Z+zQ+/rsSAgbv738TAfr2U7zqTc5Yxk6aTln6SqIhQRj/9CP5+vm7bNWvuN8yb/z3160VisRQB8Mb4f/HKa++RcfIUt9x4LXf3vxmAxb8s54uvf8LP14dXRg8npHYgWafP8NLEaX871tXs7SpvXqe9Osptu8D+tvKOe//NseQXFDq9TesFkhBCCCHE5bjq3mITQgghhLgUWSAJIYQQQpQhCyQhhBBCiDJkgSSEEEIIUYYskIQQQgghypAFkhBCCCFEGbJAEkIIIYQoQxZIQggljXzpdRb9tLT06z/+t5mHR4y96F5bQghxuWSBJIRQ0kP3/oO583+gqKj45qlzvlrMw//s7xY7jAsh1Of6PeKFEOIyNI1rSN2ocJav3kDtoACsVhsd2iSwau1mZn48n4LCAmIbRPPiyEfw8vJk3vwfWLJiLbl5eUSGh/DyC4/j6+PNh3MWYjAY2J60h8CAWox9dqir04QQbkBuNSKEUFbSX/t4c8Zc/P18ufO2G4mKDGPU+Km8M3kUfjV9mPnxVwQE+HP37Tfx5+79xDaoh8lk4qnRU+jasTX9b+3Jh3MWsnDxb3z0zitEhAW7OkkI4SbkFSQhhLKaxjXE38+H7DM5tGvdnG++X0JqWgaPPzsBgIJCS+kd2+vVieDnJavYunM3R46lcuRYaunjXH/tNbI4EkJcRBZIQgilNWncgOwzZzEYDNiwkZgQz+QxT150TG5eHg+PGEvf3t25d2AfQoODOJNztvSfm0xyOaYQ4mLyW0EIoY32rRNYv2kH25P2AJB56jRnc/NIPpzCqaxsBvbrRVhoMHv2HXLxSIUQ7k5eQRJCaKNuVDjjnh/GlLc/xoYNH28vnhvxIA1j6tKpfSKDHn2B6DoRREWGYrXK5ZdCiIrJRdpCCCGEEGXIW2xCCCGEEGXIAkkIIYQQogxZIAkhhBBClCELJCGEEEKIMmSBJIQQQghRxv8DDkjpHHpyMZAAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 583.3x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "A two-row regime band above a rising cumulative return curve on a log scale. The risk-off row is occupied in many short bursts spread across the whole century rather than in a few long blocks, and the curve is drawn dark through those same stretches."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, (ax_band, ax_equity) = plt.subplots(\n",
     "    2, 1, figsize=style.FIGSIZE[\"dual_v\"], height_ratios=[1, 2], sharex=True\n",
@@ -859,8 +1532,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7cf05cc1",
-   "metadata": {},
+   "id": "2f59e667",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009483,
+     "end_time": "2026-09-08T23:45:13.440285+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:13.430802+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Volatility inside each regime\n",
     "\n",
@@ -874,10 +1555,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fc4b8703",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 23,
+   "id": "e98a9b68",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:13.454551Z",
+     "iopub.status.busy": "2026-09-08T23:45:13.454375Z",
+     "iopub.status.idle": "2026-09-08T23:45:13.469055Z",
+     "shell.execute_reply": "2026-09-08T23:45:13.468659Z"
+    },
+    "papermill": {
+     "duration": 0.025719,
+     "end_time": "2026-09-08T23:45:13.469594+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:13.443875+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_1f898\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_1f898_level0_col0\" class=\"col_heading level0 col0\" >Mean (%)</th>\n",
+       "      <th id=\"T_1f898_level0_col1\" class=\"col_heading level0 col1\" >Median (%)</th>\n",
+       "      <th id=\"T_1f898_level0_col2\" class=\"col_heading level0 col2\" >Max (%)</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Regime</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "      <th class=\"blank col2\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_1f898_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
+       "      <td id=\"T_1f898_row0_col0\" class=\"data row0 col0\" >9.8</td>\n",
+       "      <td id=\"T_1f898_row0_col1\" class=\"data row0 col1\" >8.7</td>\n",
+       "      <td id=\"T_1f898_row0_col2\" class=\"data row0 col2\" >29.7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_1f898_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
+       "      <td id=\"T_1f898_row1_col0\" class=\"data row1 col0\" >12.7</td>\n",
+       "      <td id=\"T_1f898_row1_col1\" class=\"data row1 col1\" >10.9</td>\n",
+       "      <td id=\"T_1f898_row1_col2\" class=\"data row1 col2\" >31.8</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7d282c715950>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "rolling_vol = equity_returns.rolling(ROLLING_VOL_MONTHS).std() * np.sqrt(MONTHS_PER_YEAR)\n",
     "\n",
@@ -894,10 +1634,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b47b5dfa",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 24,
+   "id": "8bd850b9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:13.484966Z",
+     "iopub.status.busy": "2026-09-08T23:45:13.484801Z",
+     "iopub.status.idle": "2026-09-08T23:45:13.806404Z",
+     "shell.execute_reply": "2026-09-08T23:45:13.805887Z"
+    },
+    "papermill": {
+     "duration": 0.32957,
+     "end_time": "2026-09-08T23:45:13.806923+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:13.477353+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAH1CAYAAAANogGZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzsnXd8FEUbx79XUum9d0SKiBSpAoI0RVEQsSGgiICoryLSBBFQBARBaYICgiAqoIKiAmIBFAFp0nuHEEpCQpK73O3u+8flLneXu+Rqkl3n+/m8r+Fud3Z+M7O7zz3zzDO69HSzgkAgEAgEAoHAgT6vKyAQCAQCgUCQ3xAGkkAgEAgEAoEbwkASCAQCgUAgcEMYSAKBQCAQCARu/CcMpOVfr6FoxQZs27E75GWPHv8+dZt0xGQyZ3tc0YoNeOHlUSG77qz5S6jVsD01G9zLgUPH2HfgMK0796JCrea8N32eT2W8N30eRSs24NTpcyGrV7gwmczUbdKR0ePfz+uqeGXLXzspWrEBX63+IahyuvbsT8NWD3r8zp92OHv+IkUrNuD9DxcEVZ9wEcw9ceFSHNXuaMPcT5cBWcfyMwOGcu8DT4asrvmB7MZFbuD+zMmOcD5zBYLcQhMG0uDXxlK0YgOP/9vy186wXvulF/rw+ScfEB0dFdbrOHP+4mXGTvyAyhXLM3Hs69xWoypjJ37AsROnmTh2KN0e6JBrdQF4e9JM6je/P6zXiI6O4vNPPuClF/o4PqvVsL3PxmA46PBQbwa/NjZXr+mpHf4LPPficLr27O/4d/mypVm+cCZPPOrZYBg/+lXmTJ/g9fxgSUszUbRiA5Z/vSaocvJiDAWCp2eOM3l9L/pDqPpOoH2MeV2BUDDwuafo2rkdkiTTd+DrtG55NwOfewqAurVrcu7CpbBdu3y5MpQvVyZs5Xvi7LmLADz5WDee7PkQAGfOXeCOOrV47pleuVoXgCtXr+fKdRo3rO/4W5Ikrl1PyJXreuPK1evcVrNarl/XuR3+K1yJdx1jer2els0aeT2+erXK2Z4fLPHXQlNeXo0hf/H0zLGTH+5FfwhV3wm0jyY8SHfVr8ODXdrTtfO9AFSsUI4Hu7TnwS7tKVG8mOO4nbv+pfMjfalUuyXPvTgci8UC2G7wD2Yv5I5mXajZ4F5GjptKeroly3XqN7+ftyfNZNTb71Ol3j38vXOPw3tltVoB+Hjhcurd3YnKdVrxeN+XOHnqbJZytu3YTcmqjXl70kyvmvYdOMyDj/Wn4u0taHnfo3z3wwbANo3z4GO2X8Kvj36Xrj37U7/5/Zw7f4ldew9QtGIDzp6/6FJWQsJN/jd8ArUbd6DGnfcyfOxkFCVr+quuPftTt0lHx7990da1Z39WrFzL+QuXKFqxgePX8MVLV+j9/GtUrtOKZu268/MvfzjKLVqxAfMXfcELL4+iUu2WnL942aUe3trQPiVz9vxFSlRphCzLTJnxscNTmHgzid7Pv0al2i25s8X9TJwyK0s/KorCJ599SaN7HqJynVY8+dz/OHP2gksfvzHmPUa9/T63N7qP+s3v54+t27O0VdGKDTh/4RIrVq7N8mv02InT9Hh6EJVqt6T7UwNJvJnkuPbSFd/QuPVDVKl3Dy+8Mpqk5Fse+1+SJWbOWUSDlg9w213t+PqbdS7Xtk9NKYrC5A8+5vZG97l4Tt+ZOttx/OW4ePoOHEbluvdw34NPc+FSnOO7nzb+TssOPW1t3e9l4q5cBTKnSHbu+peWHXrSs/eLWeq48detFK3YgLU//uL47JU3xlOrYXskSSI93cJ70+dxR7MuVLujDS+8MpqrXl5ONxISGffuDJq1607525rR+ZG+HD95xtEnf/79D3/+/Q9FKzbgvenzHNOHzjqdcR7Lns7v0r0vTe99xHEfXLp8haIVG7Bw6dcu5Zy7cImHn3iB8rc1o0mbbsxesJTNf+6gQYsHABgy9C3HPffe9Hnc3ug+Nv3+Jw1bPchrIycCsP2fvXR4qDcVb2/BA48+59DlbQwdPnqCx54ZQuW693Bni/tdxlZ24yK7e86X55I/zxw73u5FO8E+c1PT0hwe6sp17+H5ISMd4Qw5jd1Nv/9Jx27PUKl2S/oPGYHFYmHLXzu99p3zFK29jN+3/O0YT/2HjGDmnEXUuPNeps6cT9GKDZg5Z5GjrtNnfUqpao0d97tA/WjCQPKVBYtX8Fj3B2jRtBHfrF3Pz79sBmD2/KVMmPwRXTu3Y9TrL/LF12tY8NkKj2UsXPo1Bw4dZcr4Edx5R22X706eOsvIcVNpdNcdjH/zVWJjYzBGuDrpLl2+Qt+Bw7j3nmaMHfGyx2tcib/Gw4+/QOLNZKZMHEmN6lXoN+gNftu8jbq1a/LmG0MAeL7v44wZPoQPp4ylZIli1KpZjWWfzqBUyeKOsmRZ5pkXhvLV6h/o36cX/xvcj9q1qqPT6fxqO2/axgwfQq2a1ShZohjLPp3BwOeewmKx0KvvS+zZd5A33xhCi6YN6TtwGJfj4h3lvTN1NiZzOjMmj6Vi+bJ+tWGpksWZPulNAHp068yyT2dQt3ZNZn28hB83/M7I1wfz1GMPk5KaRoTbuUuWr+aNMe/R9p6mvDP2dfYfOEKPpweTmpbmOOaTz74kKTmZ/734LDduJDB6/LQs7bFk/nQAWre8m2WfzqBNq6aO7z5d+hX33duKrl3a89vmvx0vuO9+2MArb4ynccP6vDP2dbb+tdPrC/7c+Uts37WPlwf2Ra/XM3zsZCRJynLcqu9+YvIH8+jauR0jXhsEwKD+T9Pzkcwpz+Vfr6Fu7Zr0fbIHu/YeYNbHSwDYsWsfTz33KhXLl2XS229w/vwlXs14qdt5qv//6NX9AUYOHZTl2m3vaUbRIoXZsGkLYBtr6zdtptsDHTAYDEz+YB5TZ87n8R5dGT3sRdZv2kyfgcOQZTlLWZIk8c+eA/R7uifDXx3I/oNHGPbmJAA+nDKWYkWLUOf2Giz7dAaPPtzFY5t5w9P5T/V6mGMnTnP46AkANmzagl6v56H773M5d+LkWezee4B33nqdB7u0x2QyU6/ObYwcOhiAF5590uWeu3rtBq+OfIdB/Z/i+b5PcObcBbo/ORC9Xs+kt99Ap9PRb9AbKIricQxdvXadBx97nsPHTjJ+9P94+IGOVKtSyVEfb+Miu3vOl3vK32eOHW/3op1gn7mvj57ERx8vofuDnXhz2IvcXqs60dFRPo3d/w2fwOOPPkiLpo1YveZnfv5lM3Vr1/TadzmxYdMWVq/9mfFvvsqzvXvSomlDvlu30fH9+l82075NC4oWKexTeYL8jyam2HxlxuSxdGx/D3feUZsNv25x/JJbsHgFrVvezajXbTfOn3//w7qff/UY5xEbG8OyT2dQpHChLN9FRUcREWGkQIFYuj3QgWd7P+byvTndQt+Bw4iJiebTOZMxGAzIsuziRShcqCBff7uOxJtJLJwzmfvubcWDXdrz44bfmb94BV8u/ojmdzcE4M56tWnR1DbNEBMTQ/FiRXiwS3uXa/578Chbt/3DqNcH88b/Xgi47bxpq1KpAsWLFSHNZHZc+4+t2zl4+BgfTR1Ht64dMJnMfLFyLRt/20qfJ3sAULlSBRbOmUxERIRfbQgQGxNDu9bNAbitRjXHdQsVLIBOp6NCuTI8+Gx7jMasw3vB4hWUKV2SD94bg06nI91iYdibk/jltz8dsVuN77rDEb/yy29b2brtnyzluHsrAYcn6q0Rr9C/Ty/irlzly1Xfc/zEace1q1etzNQJI0EHx0+cYfWan5g6cWSW8kuXKsEXC2ei0+k4cOgony1fzdVrNyhbppTLcTt27SM2JpqpE0diNBpZveYnAGrXquHwJA567ilGvDYIq9XKp0u+4vhJW30+XfIVsTHRzJ4+nsjICFJT0xjx1hSXX/IvvdCH/734LGALEDeZbb/ejUYjBQvE8tD997F+02ZkWWbvv4dsL9quHZFlmU8++5ImDes7fgicv3CZjz7+jH8PHuWu+nVcdJQqWYJ1qxZy6fIV9h04TKWK5dm5ax+KotC+bUtioqMoXqyYo63dvaTZ4en8cmVLM/KtKXz7/Qbq1r6N9b9uoWWzRpQuVcLl3EKFCgBQo3oVnu39mOOHRfO77wKgQYb32o4sy0x481W6P9QZgHfen01qmolZ096mTOmSlCxRnKcyvJaextDsBUu5fiOBdasW0ap54yxavI2Lo8dPeb3n2rdtmeM9FcgzB7zfi3aCeeYmJNxkxcq1PP34w0wY85pLub6MXU/Xfuj++7z2XU5YLFaWL5xJ5YrlAXiq18O8POxtTp85T+HCBdm5+1/mfDAhh1IEauI/5UGyexNKZky7mc3ppKdbuHj5Clv+2knVeq2pWq8136xdz9VrNzyWUa1KRY/GEUDF8mVZ8+UnnD5znnp3d2bEW1O4lZLq+P6Hn39l5+5/SbyZ5LiRz1+87Lhu1XqtOX/xsmO+v0HGS6RI4ULUrF6Fs+cuZL1oDpw5ex6A+vVq53Bk9uSkzfWatnq+Mnw8Veu1pnbjDqSnW1ziFOrVrpnFOPL3Ou4MeeEZ3h79P4a9OYkmbR92GAsudTt3gQZ31HG86BreWRfIjLEAXLxOJYsX8+j6z46IDMOsZImMcZZx/pmzFzh15hxV77D19Ucff8bV657HmdFgcNSxZIniGeWkZzmufr3bSU0z8c3a9Wz+cwenz16ggltMnL2djUYjxYoWxmy2ODSnpKZRq2F7qtZr7Zh6vZGQ6Di3gZMhM2POIsc4fbyvzejp0a0z8Vevs/ffQ/z8y2ZKlSxOy2aNuJGQSPKtFJfzGzbIaOuzWcdxUvItnur/Knc068K4d2eSkppGaprJo9csFBQqWICHH+zEmnUbMZvT+WPL3w6jxpkJY4YysP9T9O7/Gq07P85vm7flWHaDOzI1nz1rG1fN2nWnar3WPPXc/wC89rv93qlf73aP33sbF9ndc77cU6F85jgTzDP3tP3ZVTdrW/gydj1dOxiKFyviMI4AHnmwEwViY1izbiObfv8Lo9HAA53uDeoagvzFf8qD5InIyAjKly1NhfJleWvkK47PCxaIDai8ls0asf67Jfzx53YeffpFihQuxOhhtvgNnU7H4nlTeXXkRMZMmMaCWe9RplRJvv/6U8f5ZUqVpErlCgDs/fcwHdq14mZSMidOnaVj+3v8ro/9hj5w6GiON29kpJEbCTexWq0YjUaS3eJjvGnT6w2YzZlpDuz1Hzl0sMuv4OpVXQNnvZFdG9rRG2y2vfN1IyIieHlgXwb0fYI3J0yj/5CRNGpwB9WqZk5RVK1ckb37D6EoCjqdjj3/HnKps6/YX1LO18+JKpUrEBEZwexp4x3nG40Gv67rzqMPd+GdqbN54ZXRADRqUI9+vXv6Vp9K5Tl4+BjLPp2BwZBZD7th585TvbpxT4smABQpYvuR0Lrl3ZQsUYxNf/zFpt//5KH778NgMFC8WFEKFSzA3oz2BdizL6Otq1TMUvacBZ/z6+9/8c8fa6herTKDXxvLipVrHd/rDQa/2todT+c/3ethVqxcy1erf8BkTs8yvQa258CYN17ilUH9GPTqGJ589n+cOvAHen3W8ecJ+7j6/JMPXKZe6ta+zeMYyrxfj2UbhO7tOt7uuZzuqWCeOZ7uxezw9ZlbuVJmW2TR6+fYdamvh76LjLT9iIi/dp3q1SpnefZ5wmZkd+THDb9zW82qYnpNg/znDSSA5/s9wYTJH/HV6h9o3rQhR46dpOfD/i9b/3HD73y8cDmPduvCzaRkrFYrBkOmk+6h+9vT/aHOXIm/xshxU3n68Udoe08zWre826Wcxx55gGkffcLb733IlavX+HnjH0iSxMBn/c/r0qB+HRo1qMeM2YswGo2ULF6MQ0dP8N7bb1C+bGkAtm77h+rVKnNbjWr8tvlvXh9ti/3Y+NtWn7RVrVKBv7bvYu6ny7i74Z20bNaYurfX5LPlq9DrdZQqWZxjJ87wztihQbehnTKlShIdFcUPP//KnXfUpmWzxrz1zgcUL16Mu+rX4VJcPDqdzvHwtvPCs0/y6siJDB31Dg3vrMfMOYuoXrUyHdq18qtdDQYDlSuVZ/OfO/j6m3U08WFl2fN9n+D5l0byyWdf0rH9PZw7f8kxdREoq779iaSkW4wd8TKSJHFX/bqkpKRSqGCBHM99rk8vVn73Ex/MXkiPhzoTf+06VSpV8Dg1Cbbp1CqVXA1Jo9FItwc68O3a9Rw+dtLxwtPr9Qzo9wQz5ixi4pRZlC1TiiUrVtOiaUPuzPCOlCtTiiPHTxF/9TppaSZMZjMbft1CSmoaP/y0yeU6VStXYMeufSz76jvuql/XMfVlx30su+N+/h11a9GyWSOqVqnIO+/P9ji9ZrFYeKLfK9x1Z11uq1GVGzcS0Ol06NA5DIoVK7+neLGidGjn2ZB46rFuzFnwOdNnfcpTj3XDZDITERHhuOfdx1DPR+7n/Q8XMOjVN3n9pedJSLxJoUIF6d8n+9Wp2d1zvtxTwTxz3O/FVs2b5HiOL8/ckiWK0+2BDnyxci2lShanZo2qbN+5l2nvjvZ77Drjqe/saQvemTqbVs2bsGCx5xhUd57u9QgPPtafk6fPMdGH55tAXfynpti88cqgvrw96n9s/fsfho95j23bd3tdXZQdTRrWp2yZUrzz/mw+mL2Qxx99kJcGZs6p26de+vfpxe23VWfoqHc8JpgsW6YUa7/6hMKFCjJ8zHscP3maRXOn0K5NC7/rZDAY+GLRh9zfqS2zPl7Ce9PnEhkRgdVq5b52rahSuQLzMx4GLw/qS8MG9VizbiMWq4WJYzJv+Oy0vf7S8zSoX4d3p85myReriYyM4OvP59CsyV3M+3Q5774/h2vXbpCUlHOb5tSGdmJiopkyYQQ3k5IZPnYye/cf4qleD7Nrz36GjnqHw0dPMGva21le6H2ffpQpE0bw25a/eXPCNOrVrcU3y+cRGxPjd9tOnTiS6Kgo3hj7Hpv/3JHj8Y8+3IVZ097m2InTjBg7hR83/M6tlBS/r+tMm1ZNkWSJ6R99wqRpc+nV9yXqNe3M+k2bczy3+d0N+WLRTBISbzLq7ff5avUPAY377g915tDRExQvVtTFezFy6GCGvTKAL1d9z7vvz6FTu9YsXTDd8Qv+mSd7cPzEGf7avovBzz9N08YNePf9Oezae4Dn+z7uco23R/2PyhXLM2rcVNY4BcbacR/L7ng6X6/X89Rj3Yi/et3j9JrRaOSpXt3Y8OsWXhv5DjeTkln88VRiYqKpUqkCI4cO5vjJM4x++31OeFgVBrZ0A999OZ+oyEjGv/chnyz5ihsJiY7Vc+5jqHy5Mqz5cgEVypVh9Pj3Wf71GmJionPsg+zuOV/uqWCeOe734p5/D+Z4jq/P3FnT3qbf04+y/Os1vPXODBRFwWQ2BzV2PfXd/R3b8siDndi3/zDbduzms499S0jbslkjqlauSFJysphe0yC69HRz1vXeAoFAFTz34nBS00x8ufgjFEXh7PmL3N32YZ57phdTJozI6+rlez6a9xmTP5jHvm0/UqpkiZxPEAickGWZezo+Rq3bqvtsVAnUg5hiEwhUzIWLcZw4dZYP5y6mePGirP9lM1arRJcObfK6avmaS5ev8MPPv/LB7IW8+MIzwjgS+M2OXftY/tUajp44zZIF0/O6OoIwIDxIAoGK2X/oKMPHTmbfv4eIiIyg7u01eWVwP+7veG9eVy1fs2T5akaPf5/2bVsyd8ZEn2K2BAJn7n/0WU6eOsuI1wblGCMmUCfCQBIIBAKBQCBwQwRpCwQCgUAgELghDCSBQCAQCAQCN4SBJBAIBAKBQOCGMJAEAoFAIBAI3BAGkkAgEAgEAoEbmjCQFn/xHX0Gj+bJAcNpdf8z9Bk8mj6DR7Np83a/yln/658sX7kOgHUbNjPi7RkAXL+RyPBxH/i9aaknTOZ03pvxKZ0efYEvv/nZ8fnNpFuMmzyXPi++yZMDhvPblpwzM4eLTz9fzboNmZmYJ06b71JXf3jxjXe4HHc1VFUDYMTbM1zqFygde7yQY92+/OZnJk6bH1D5/+w9yEcLvsjxOPf2Xr5yHet//TOga/qDJMmMnzqPpweOZMU3rhv7uvdb9z6vcuyk52zRuY1z+1yOu8qLb7zj1/njp87j5Jnzfl/Xl/GiNnbvO0SfwbZ9/NLTLQwf9wHXbyQGXe6MeZ/z6eers3zeonNvkm8Flj1+3YbNLmV++vlqZsz7POA6CgQ5oYlEkc8+9QjPPvUIl+Ou0ufFN1k6b1JA5XRu73k/rhLFizJ1fGj22TEa9HRu35IrV6+7fL5n/2G63NeKFnc34NDRk7z4xrs0a3InsT5sMyDInzS5qx5N7qrn93lPP9Y1DLXJytXrN/h1yw5++eYTx87naiDY9hk3fHCIaqItIiMjQvacEwi0gHqeigGye98hVq7ZSLGihTly/BRzp41l9dqNbNq8nTSTifJlSzFh1EsUiI3hy29+5vips4wdNtCljORbKXR6dCDb1i8DoHPPQQzs25Off/2Ti5fjGf3a87Rq1hCr1cqUjxbzz96D3Lhxk6ioCOrUqs6H7410lGU0GmnUoC7rNm5xuca9rTI3rK1TqzoGvZ6bN5M9Gkidew6if+/u/LhxCyZzOmNef4Ef1v/BP3sPUqFcaaaOH0pUZCS3UlKZMe9zjhw7jU6v44nuXXiwc1vA5iG4r00zNv+1i+Mnz/Fotw70792DlWs28PV3G4iNiearb39m0eyJAJw5f5E3xk3nyLHTNL+7AW8OHeBSp737jzD1o8VIskS5MqV4582XmTHvc/YfOs7Qse9T9/YajB02kOUr13ls+08/X43JnM6ly/EcPn6a6lUqMmXcqxiNRpKSU5j60SKOnzpH2dIluOb0C3fbzn0s/XItKalpoNPx9vDBVK9a0WO/X7h0hSkfLsJkMlOtSgUsVmuWtpVlmU+Wrmbj79soUbwoUZGRlCpp2yHcYrEyZ+GXbNu5D0VR6N3rQR7o2JpHer/Cx9PfomL5MgAMeeNdnn36EVJS0/jq25+Z+/4Yrt9I5MP5y7hw6QpJySn0eqQzvR7p7LG9Zy34gkIFY3n+mUexWKzMXfQl2//Zj06no1P7lvR5/CF0Oh0Tp82ncsVy/HvwGMdOnKFl07sY9drzWTR9v/4PvvzmJ1CgTq1qvDr4GaKjo3jtzalYrVb6v/IWb70xiJrVbZu8Tpw2P0u/AWzZtpuP5i/nxOlzDH72cR5+oB0AP6z/g+Wr1iFJMnc3uoPXX+zj2G8NICUllelzl3Lo6Cl0OhjS/0nuad7Q1tafr2bjb9soUrgQFcqVIiIigrHDBvLp56tJvpXKa4OfAWxewzYtG9O1UxtmzPucQgVjebBzW14e+R43Em7SZ/Bonn3qEWZ/uoKp44dSo2olAF4aPonnnn6ERg3qOurTZ/BoXh3Um0YN6nq9DwBOnD7vdbwcOHyCD+YuJSU1jXJlSvLWG4NISU3jpeGTWDL3XQoWjKXfkDGMerU/9WrXzNInAAePnGD+Z6tITErGYrEw/JXnaFi/NpfjrjJi/AzatrqbrX/v5mbSLd4d8zJ1alVn975DLFu5jkoVyvDPnkOgg/fHD6V82dLZtpm3+8Sdjj1eYOncd1FQGDl+JgBJySmkmcysX/Ux164nMPWjxZy7GEdkZATDX36WO+rUxJyezsx5y9i17xAlSxTFYpFo1vgOj7qXfvk9e/Yf5mbSLZ5/pged27di8LB36P1YV1o1s23e/M70BTSsX5uunWwZ4X/fupO5i74CYPNfuxyG3NXrCYydNJsDR05QvUoFpox7DaPRyNnzl5j60WKuJ9ykcKECjHn9BSpXLOeow/UbiYyZNJtr1xOIjY1m9GsDuL1mVUefp5lMVCxfhuMnzzJ7ymjKlS1Fi8692bB6PoUKFuDYybOMGD+Db5fOJM1k4sOPl3Ps5FmSb6Vwb6u7GfL8E4DtOXt/h9as/ek3OrRtTo8HO2R5hnTrcq/HdhLkPZqYYsuJLdt20eLuO1k0ayLRUZE0alCHBTPe4osFU5AkmZ83bc25ECeSkm8RFRXJ/A/eou8T3fhsxVoAft2yg8PHTrFy0TRWLp4G6Jgy7jW/67v3wFGKFS1M2TIlvV6/QIEYFs+eSPMmdzJqwkye6HE/XyyYQlz8Nf7cvheAjxYsJzYmmmXz32PW5FF8tmIN+w4cdZRz9MQZpr/zBh9NHsni5d9hMpl57OFOtG7RiAF9HmXpvEkYDQYA4q/eYOKol/j84/f46ZetnLtw2aVOy1et48HObfny0/cZ/sqzFCwQy9hhAylZohgfTHzD8ZLNru137T3E8FeeY8WCKRw7eZZd+w7bdMxfRuFCBVnxyRQmj3uV6Kgoxznly5Zi8rjXWDpvEu1bN2Xhsm8c3zn3u9FoYNSEmfR6pBOffzyJF/s/7tgw1JmfNm3l73/+Zcncd5k3bQxVKmU+VJevWkdUZAQrPpnC0rnvsnzlOpKSbtHp3pb8usU2nXv9RiIXL8fTsH4dl3ILFyrI0z27smjWROa+/yazP11B8q0Ur+1tZ9nKH7gUd5Wl897l04/eZsu2XWz4bZvj+30HjvLumy/z+cfvsW7jliz9snf/EZasWMPsKaNZNv89YmKimf3JCowGAx9MfIPYmBiWzpvkMI4Aj/1mQ2HWlFG8OXSAY6pj38Fj/Pzrnyye/Q4rPpnKrVupbN62y6UOsz5ZQf26t7HikynMfX8M0+d8hiTJtrbeaWvrT2aOo0jhQln6IzvKli7J6Neep3ataiydN4l2rZvS8+FOrP3pNwDir90gLv4ad9WvnW05nu4DqyR5HS/Jt1KY9MEnvDf2f3y18H3atmrCki/XUKlCWXp268jcRV/yw/o/aFCvllfjCKBk8WKMeX0AS+e+S78nH2GW03TsqTMXqF+nJotmTaBtq8asWJ05BXrg8HEe6NiGzz+eROUK5Vjz4285tlV294nn40uzdN4kFs9+hzKlS/DGy/0Am+HS46EOfPnpVCaMfJGpsxYDsOzrH7h6PYHl8yfz0XsjKV6ssNey69Wpwacfjmfq20OZNONTEm8m83j3zg4d5vR0tu/aT7vWTR3n3HvP3XTv2p7uXduzdN4kypa2PRsvx13l9SF9M54Z59i17zBWSWLspNm8NvgZvvx0Ks893Z3Zn7huYrzht78oEBvD14umMX3CMKpWLu/S58s+fo9XB/V2+THmjeioKB7s3JaFH41n6bx3WfPTr5w+e9Hx/br1fzBn6ps83r2Lx2fIjYSbOV5DkDdo3oMEUKVSeVq3yNxlvHLFcvy86U/2HTzGhUtXuHDpit9ltmnZGJ1Oxx11ajric8qUKoHJZCY1zUzCzWQkSUKn1/lV7q2UVKbN+ozXh/RFp9Px5/Y9zP9sJQAPdbmXxx7uZLt+C9v169e9jWMnz1C1cnkAat9WnavXbgCwddseFswch06no1jRwnS8twVb/95DgztuB6BVs4YYDQZqVKtEREQECTeTKRcd5aFW0LRRfaKjo4iOjqJyhbJcu5Ho8ovsgQ6t+WTpavR6PQ91aetVX3Ztf2e9WhQtYntJ1qpRmWs3EgD4a8c+5s94C71eT0x0NCWLF3WcU7F8Wbbv+pe///mXw8dOkW7JjBNz7vfzF+Iwp6fToW1zwPZyjYyIyFK/v7bvpXvX9hSIjQGgQrkyHM/YqX3Ltt0k30ph2859AKRbLMTFX+P+DvfwzgcL6PN4N37bupMO9zbHYHD97RERYSQ6OoqFy77l5Jnz6NBxJf56jltcbNm2m8HP9cJoNGI0GunW5V62bNtF5/YtgZz7Zev2PXRs14JiRW0vrF6PdGbg0AmMfLV/ttf1ROsW9jF/m+PFsXXbbs6eu8QLr74N2GLs6t5e3eW8zdt2sf/Qcb79YRMAsqyQeDMp27YOlIc6t+WZQaMY/NwT/PL739zf4R4Xb5YnPN0HJpPZ63g5cPgEV65d541xtv23JEmmWpUKADz56P089/JbHDh0gvkz3sr2uqVLFWfP/iN8+e16jp8863IvxMRE07RxfQDuqHMb33z/i+O7sqVLcnvNqoDN2Djj9DL2Rnb3SXasWP0jZUuXpEPb5qSmmfhnz0FuJNxk7sIvARzxRH9u38ugZ3s5pmrtBownGmd486pVqUDpksU5cfocrZs3Zs6nXxJ/7QYHD5+gWaM7fAov8PTMuHAxjrPnLzPh/Y8BUBSIdnuutWx6Fz+s38ysT1bQ65FOREVGcvrsRZ+eEe7odDpKlSjG8lXrOHbiDAAXLsU5xkSv7l2IjLSV4+0ZUrxYkRyvI8h9/hMGkvPLKs1k4vn/jaNbl3vp/VhXSpcszq2U1IDLNhqNKNh+Wda9vQYFCsTw+tj3sVisjB85hKjISJ/LSjOZGDZ2Go8+1IEWdzcAbA9vu9vZ8/UNWf7twTFiQwc6D/aaTqezleP1RA/XdDu2Xeum3N3oDr7/+Xce7z+M2VPedBhtdvxpe6PBSEazYpWsWTwrdiZO+5ioyEi63X8v9zRryOxPM38pOve71WrFYDCg89QATlglCYOXaymKwssDnnQxtu1Iksz5i3H8umU7Qwf3yfL9tp37mLPwSwb27UnPbh3pd2wMso/t7YJO51WDL32oy+Z8X3EecwoKHe5tzv8G9vZ+ggLjR77o4qWC7Ntap9NhlSS/61awQCxtWjbmjz938uuW7UwYNcTnc53vg+zGi6IoVCxfhiVz3s3yXfKtVKxWCXN6eo6LOhYsWcWpsxd4osf9dOtyLwMyjEx3jEaD4xmT5TuD0fFNdm2W3X3ijROnzvHtuk0snp0ZBK+gMOf9N7MY9lZJwmjwf0LCaDQQEx2FwaCnx0Md+HHDFo6fOsuj3Tr6X1bGM8NuEH025x2vxnGVSuVZMu9dft+6k5eGT2JAn55Ur1Ihx2eE1Zq1fY+dPMuYd2fxQp+e3H/fPVy7Mdvl3nZ+DmX3DBHkP/4TU2zOnDt/mcSbyTz2cCfKlC7JcW8rc3QgK7JfZR84coJiRQrzycy3+WzOO9zT3Lth4056uoWR42fS/O4G9Hiog1/X9cY9LRqycs16FEUh8WYyG3/bRqvmjXI8r2zpkly+4t9qnd3/HiY2JponetxPuTKlOXjkRJayfG57N+66ozbfr/8DgITEJM5dzJxG2vL3bnp260jd22tw+Phpr2VUqlgOszmdnXsOALZpFZPZnPVa9Wvz06atWCxWrJLEoaMnHd/d07whS7/6gZQMo+5SXLzjuy73tWLNT79xKyUtiyEANgOpyV31aN2iMQmJN0lOzlzJk117t27RiG++34RVkkgzmfj+59+5x4c+dNS5WUM2/raNxJvJKIrCyjXraR3CMdCqWUN+3Jg55Xr5yjUkyfW+adW8IQuXfYvFYkVRFEe73XXH7V7bukTxohw+ehJzejqnzlzg4NETnutZpiTxV2+4XLNnt04sX/Uj0dFRlC9bOkcNnshuvNSrXZMr8df5NWOlaUpqGgmJSQB8tOALnujRhad6PsD0OUuyvcaWv3fTtWMbGtavzbGTZwKqpzPZtZnX+0Sn82ioWyxWJkybzxsvP0vhQjZjKDYmmoZ31uGTpauRZRlJkrl85RoADevfzg8bNiPLMmkmU7aewPMX4wDYsfsAqakmalSz3S8PdW7Lr1t3cO5CHHdleLmdsY3Jazm2Q6WKZSlapCBffvMziqKQnm4hPsOrbufwsVOYzTZvUfs2zdixe7+tz03enxElixdl34GjWCWJn37JjCHdtfcg1apUoMO9zZFkmSvxrgtwnMnuGSLIf/wnPEjO1KhWiZZN7+LpgaOoUrEcFcqXRpazPiDuqF2Txcu/4+CRk1SuWNansqtXqciho6d44vnhREYYKVWyOC3ubkBPp19D6zZu5qtvfiYu/jo7dh/gx42b+WjyKD7/+nt2/3uYWylp/JqRnqBd66Y8+9QjAWt95YWn+WDuUnoPHIVOr6Pfkw/ToF6tHM+7r00zXn9rGn/t2Me0ia/neLwkyezed4gP5y8jJcNAaN/GFj/wyAPtGfveHBrdWYdxwwf51PbuvPZiHyZO+5inXxhJxQplqFQ+sz/6P92DMZNmUbpkCZo3udNrGdFRkYwf+SIz5n5OVFQk9WrX9DgN0OPB+zh56hxPDhhO2dIlqV61oi2wFXim10PcupXKsy+/RXR0FDWqVuStNwbZgqfbtaRnv6G80Kenx+t37diaaXOW8NzLb1G/7m0u02DZtXfvxx5kzsIv6TNotCNIu1O7Fjm2mZ276tem75MPM2T4u6BA7VrVGJoRxJsdzv02cfRLXo9rWL82Lw94khHjZ2A0GClSuCDjRgymVIlijmP+N/BpZs77nKcHjiQ6Oopmjeoz5Pkn6PFQB06cPs+TA4ZTrkwpihQu6DinfetmrNuwhV7PDqNp4/q0dVrE4Ez5sqWpUbUSj/cfxnNPd+eBjq2pVKEssdFRPNChtc/t5E5246VI4YK8P/51Ppy/jIWff0NUVARD+j+JJMucPX+JscNeQFHgp1+28uuWHdxV/3Ymvj+foS/2oVKFzLHb+7GuzFv8FV9++xNtWzbJMi3rL9m1mbf75LbqlUlPt/DHX//QtmUTx+ff/fgrp89eYO7CLx3TaTMnjWDc8MFMm/0ZTw4YQVRkBF07teHx7l147ukevDt9AU8OGEH5sqUoV6aUxzoWKhjLz5v+ZOpHttilSWNfITrK5mUvWCCWGlUrUrF8WY+enxZ3N+CLVT/SZ/Bo3npjkNd2MBoMTBk3lGlzPuP79b8TGRnBM70eckydgc2QnzZ7CalpacRER/PWGwNtfT4qs8/vrFeLCGPmK3JAn0eZNONTKq8sS+9eD/L7n/8Atuf0n9v30ufFN6lVowrVqmQNfreT3TNEkP/QpaebA/DzCzyxaPm3REZG0PuxB5FlmY2//82H85fx41dz87pqAkG+x9sqUn85c+4ib74zi0WzJ/g1xR1Ops9ZQuf2rbijjveg7f86NxJuMnjYO8ybPobiRfNHTI59VV+5sp4NPoG2+c95kMJJs8b1mbfoazb8tg2LxULxokWYNOaVvK6WQPCf4f1ZtjQbo18bkG+Mo61/76FgwVjq1a6R11XJt3z2xRq+X/87Lw94Kt8YRwKB8CAJBAJBGFEURUyhCAQq5D8XpC0QCAS5iTCOBAJ1IqbY3Pj089WUK1PKkcHVVz5a8AXb//mXlk3vcmRRBVtQ9herfsSg1zu2QFEUhVVrN7L+1z9JSk6hYf3avPHKs16XsgsEAoFAIMhdhAcpRHz5zU/MePcNF+MI4Paa1Xio870unyUl3yLxZjLzpo1l+fzJHD5+mp9/8S+bt0AgEAgEgvChGQ/S/b0GM7DfY3y37leGvtiH6lUret2H7Or1BKbN+owLl69gNBp4oU9PWjVr6HFfLGevzta/9/DJ56uwWiUqli/DsJf6UapEMf43ajKKovDamPd56fknHUkeAWpWq0RSUjI/bsysa5HChRjQ51HHv++sW4u4+JzzewgEAoFAIMgdNONBSryZzIVLV1g8eyJ31quV7T5kE6Z+TIM7bmf5/Mm8++YrTJrxKRcuXcl2X6zzF+OYNOMT3n3zFZbPn0yDerfzzrT5AI7NaD+ePtbFOPIFi8XKzj37aRzAru8CgUAgEAjCg2YMJLAl1bMHRG7dtofHu3fJsg9ZapqJPfuPOJI3Vixfhrsb1mPHrv3Zlr1j936aNa7v2LG9Z7eO7Np3mDSTKag6L1z2DbfXrErDHDbUFAgEAoFAkHtoykDKNhOt2z5kzitLdDovm5TlQLCLU77+bj3/HjrG6KEvBFeQQCAQCASCkKIpA8kZb/uQxcZE07B+bVZ9bwsKung5nh27D9C00R2A9z2omjaqz47dB7h42bZ3zuoffqHRnXWIic55x2lPfL/+D376ZSvvvz3UkWpfIBAIBAJB/kAziSJbdO7NhtXzHbtM30pJ5YO5Szl6/IzHIO33P1rMxbh4lyBtgFNnLvD6W9MoVqQw0ya+7pLVdevfe1iwdBWSJFGxXBmGvdzPseeU+/UBkpJTeGn4u6Smmbh6PYEqFcvx2COdqXNbNfoOeZPKFcsREREBioLRaGTRrAm51VwCgUAgEAiyQTMGkkAgEAgEAkGo0OwUm0AgEAgEAkGgCANJIBAIBAKBwA1hIAkEAoFAIBC4IQwkgUAgEAgEAjdUbyApioLVakVRRKy5QCAQCASC0KD6vdgkSaJ1134cPmjLhJ14YR9FKzZw+dv5MzvO3wEu54QC97Ld65BdnTzhy/nejvfUDu6feSvPvX1yKs/9e+f28FZmdu0UKKEqJ6/Rig53AtXlbWx5+rc/91cg9c3pGeLtfgpk3Pt6n3q7bk71ygl/79FA2jrYMeHtM0/PTjuenvue+tTbMblxb3p6VruT01hz/szb8cHULdx4q7cv96UzvtTV+TzVe5AEAoFAIBAIQo0wkAQCgUAgEAjcEAaSQCAQCAQCgRvCQBIIBAKBQCBwQxhIAoFAIBAIBG4IA0kgEAgEAoHADWEgCQQCgUAgELghDCSBQCAQCAQCN4SBJBAIBAKBQOCGMJAEAoFAIBAI3BAGkkAgEAgEAoEbwkASCAQCgUAgcEMYSAKBQCAQCARuCANJIBAIBAKBwA1hIAkEAoFAIBC4IQwkgUAgEAgEAjeEgSQQCAQCgUDghjCQBAKBQCAQCNwQBpJAIBAIBAKBG8JAEggEAoFAIHBDGEgCgUAgEAgEbhiz+7Jll2eoWa0SybdSKFumFGNef4EK5Uozfuo8hvR/gpIlimU5Z92GzRw+dpphL/UNW6UFAoFAIBAIwkm2HqToqEiWzpvE6iUzaN+6KR8v/hqAccMHezSOBAKBQCAQCLRAth4kO3q9nsYN6vLTL1sB6N7nVRbPmkiE0cDICR8SF3+N8mVL8d5br7qct3DZt5hMZoY8/4TL51ZJ4qP5y9m19xBRUZG8PqQv9WrXYN2GzRw7eYa4K9c5dPQkzz/zKA8/0C40SgUCgUAgEAh8xCcDSZZlfv71T26vWdXl8x27DxAZGcHKxdO5En+d2Jhox3d79x9h5+79zJ46Okt5a3/6nfhrN1g2/z1OnrnA8HEf8PWi9wH49+BxZk8ZxdkLl3nrvTkeDaRVazey+vuNACiK4rNYgUAgEAgEAl/I1kAymdPpM3g0cfHXaNOyCUNf7OPy/Z31arF4xRoWLFnFEz3ud3yelHyLcZPnMnroAIxGI3v2H2HG3KUADH/lOf7Zc4AObZqj0+moWa0SMTFRnLsQB0C92jUpUCCWWjWrkpCY5LFePbt1pGe3jgBYrVZad+0XcAMIBAKBQCAQuONTDNKAPj2Jjopy8RABlChelEWzJlC+bCn6DRnDpbh4ADZt/ptu99/LitU/oigKDevXZum8SSydN4k76tREUQBd9hUzGgzCOyQQCAQCgSBP8GmZf/eu7dm17yAnTp93+fz02YukpZno2qkN1apU4NjJswDc16Y5/Xv3oEBsDH9u35ulvLsb1mPTH9tRFIWTZ86TmppGpQplg1cjEAgEAoFAEAJ8MpCMRiODnu3FzHmfu3h1EpOSGTpmGk88/wZ6vY7mTRoAULhQQQAGPduLeYu+wmKxupTX7YF2lChelN4DR/Hu9AVMHP0yERE+hUMJBAKBQCAQhJ1srZJf1yx0/N22ZRPatmwCwLdLZwLQsH5tPpk5zuWcrp3a0LVTGwAqVSjL8gWTs17UYPCYJ8n5XPfrCwQCgUAgEOQWIpO2QCAQCAQCgRvCQBIIBAKBQCBwQxhIAoFAIBAIBG4IA0kgEAgEAoHADWEgCQQCgUAgELghDCSBQCAQCAQCN4SBJBAIBAKBQOCGMJAEAoFAIBAI3BAGkkAgEAgEAoEbwkASCAQCgUAgcEMYSAKBQCAQCARuCANJIBAIBAKBwA1hIAkEAoFAIBC4IQwkgUAgEAgEAjeEgSQQCAQCgUDghjCQBAKBQCAQCNwQBpJAIBAIBAKBG8a8rkCoiI2JyfZv589yOidc9XG/Rk51yum7nOqcUx3cPwvk2jm1e3Z19aXMYAh1n+YVWtHhTqC6chpbvt7zwV7X/TNf789Ax72/xwX6fSjqEOh1QjUm3D/ztS/8PS+37s2crheqzwMhN59Pvt7TgepOTUtz+bcuPd2s+FG/fIfVaqV1135sWfcZRqNm7D2BQCAQCAS5SNGKDUi8sM/xbzHFJhAIBAKB4D+Ps3EEGjSQyt/WPMvfzp95+s79nFD8z71s9zpkV6ecdOV0rC/t4P6Zt/Lc2yen8ty/93a+pzb3RZevhKqcvEYrOtwJVJe3seXp36G6Zk7lZTeesyvHn3Hv632a0zMkmHb35x4N5DrBjglvn3l7/nh77jv/O7vzcuve9PSs9vS+8Xae+2ehrHdutoGv97S/7ZQdmpuTcp5DtP/tPq+Y3Xeejg1lXbK7TnbX9reeObWD+2feyvO17Xxtd0+fZ9dOgRLKfsxLtKLDnUB1+Xrf+nt/+XrdQOri7Tt/xn0g92kgx/hybriuFeyY8PZZIGMj0GPCga/Pam/n5fRZMOR2G/jyub/tlB2a8yAJBAKBQCAQBIswkAQCgUAgEAjcEAaSQCAQCAQCgRvCQBIIBAKBQCBwQxhIAoFAIBAIBG4IA0kgEAgEAoHADWEgCQQCgUAgELghDCSBQCAQCAQCN4SBJBAIBAKBQOCGMJAEAoFAIBAI3BAGkkAgEAgEAoEbwkASCAQCgUAgcEMYSAKBQCAQCARuCANJIBAIBAKBwA1hIAkEAoFAIBC4IQwkgUAgEAgEAjeEgSQQCAQCgUDghjCQBAKBQCAQCNwwevuiZZdnqFmtEsm3UihbphRjXn+BCuVKM37qPIb0f4KSJYplOWfdhs0cPnaaYS/1Dagy46d+zMkz5xnxyrPExV9n8RffcW+rJjz/zKMBlScQCAQCgUAQCF4NpOioSJbOm4Qsy6z+/hc+Xvw1E0e/xLjhg8NSkavXE9h34CjfLJ0BwIIlqxj6Yh8a3VknLNcTCAQCgUAg8EaOU2x6vZ7GDepy8XI8AN37vErizWRSUlJ5ecR7PPbs6/xv1GRS00wu5y1c9i1zPv0yS3lWSeKDuUt5+oWRPPfyWxw8chKA0RM/4vqNRJ57+S1WrP6R/YeOM3nmQrbt3BcKnQKBQCAQCAQ+49WDZEeWZX7+9U9ur1nV5fMduw8QGRnBysXTuRJ/ndiYaMd3e/cfYefu/cyeOjpLeWt/+p34azdYNv89Tp65wPBxH/D1oveZMPJFhr01nUWzJgCw5e/dvDzgKerUqh6kRIFAIBAIBAL/8Gogmczp9Bk8mrj4a7Rp2YShL/Zx+f7OerVYvGINC5as4oke9zs+T0q+xbjJcxk9dABGo5E9+48wY+5SAIa/8hz/7DlAhzbN0el01KxWiZiYKM5diCMmOsrnSq9au5HV328EQFEUvwQLBAKBQCAQ5ESOMUgr12zg7PnLLh4igBLFi7Jo1gR+/mUr/YaMYfbUUQBs2vw3zz3dnRWrf6RpoztoWL82S+dNcpynKIAuuEr37NaRnt06AmC1WmndtV9wBQoEAoFAIBA4kWMMUveu7dm17yAnTp93+fz02YukpZno2qkN1apU4NjJswDc16Y5/Xv3oEBsDH9u35ulvLsb1mPTH9tRFIWTZ86TmppGpQplQ6NGIBAIBAKBIATkaCAZjUYGPduLmfM+d5nOSkxKZuiYaTzx/Bvo9TqaN2kAQOFCBQEY9Gwv5i36CovF6lJetwfaUaJ4UXoPHMW70xcwcfTLRETkGAolEAgEAoFAkGt4tUx+XbPQ8Xfblk1o27IJAN8unQlAw/q1+WTmOJdzunZqQ9dObQCoVKEsyxdMznpBg8FjnqRyZUu5HD/3/TF+yBAIBAKBQCAIHSKTtkAgEAgEAoEbwkASCAQCgUAgcEMYSAKBQCAQCARuCANJIBAIBAKBwA1hIAkEAoFAIBC4IQwkgUAgEAgEAjeEgSQQCAQCgUDghjCQBAKBQCAQCNwQBpJAIBAIBAKBG8JAEggEAoFAIHBDGEgCgUAgEAgEbggDSSAQCAQCgcANYSAJBAKBQCAQuCEMJIFAIBAIBAI3hIEkEAgEAoFA4IYwkAQCgUAgEAjcEAaSQCAQCAQCgRvCQBIIBAKBQCBww5jXFQgWRVEAsFqtjs88/e38WXbHhQpf6pBTnXL6Lqc651QH988CuXZO7Z5dXX0pMxhC3ad5hVZ0uBOorpzGlq/3fLDXdf/M1/sz0HHv73GBfh+KOgR6nVCNCffPfO0Lf8/LrXszp+uF6vNAyM3nk6/3dDC6DQYDOp0OAF16ulnxs475CpPJRLuHn8/raggEAoFAIFA5W9Z9htFo8x2p3kCSZZn09HQXq89feg8axbKP3wtxzfIereoC7WoTutSFVnWBdrUJXeoit3U52xKqn2LT6/VER0cHVYZOp3NYjFpCq7pAu9qELnWhVV2gXW1Cl7rIS10iSFsgEAgEAoHADWEgAY8+1DGvqxAWtKoLtKtN6FIXWtUF2tUmdKmLvNSl+hgkgUAgEAgEglAjPEgCgUAgEAgEbggDSSAQCAQCgcANYSAJBAKBQCAQuCEMJIFAIBAIBAI3hIEkEAgEAoFA4IYwkAQCgUAgEAjcEAaSQCAQCAQCgRt5lpc8/toNps9ZwvkLcUREGnnrjUH8tmUHa376nWJFCgHw9ogXqV61Yl5VUSAQCAQCwX+UPEsUefV6AjdvJlOzemVWrtnA4WOnKF+2FGVKl+Shzm3zokoCgUAgEAgEQB56kEqVKEapEsVISEziwqU4atWoyq2UFIoWLphXVRIIBAKBQCAA8jgGad/BYzz05EucPnuJxx7uBMDylet4asAIps9ZglWScixDURSsViuKInZMEQgEAoFAEBryfC82i8XK0q/WcjnuKs/3eRSrVSI2NpoRb8/gkQfa07VTmyznrFq7kdXfbwRsBtLZ85f5bc0nGI1GDAYjkiQBCjqdHr1ejyRZAdDrDQDIss3wMhiMyLKEJEno9QYMBkMOx8ooigzo3I7VAzqfjtXp9Oh03o81Go1YrVZH/Z2P1esNKIri9Vi9Xpeh3Xas/TwAozHC7Vj3dlGQZdlRJ3/aMPNYHXp9Tm0oZRiz7m3oX3vb6+q9DS1e2tuALHtvQ//a27VdMo/1pQ09t7eiKBiNESFs77wds/b2liQrer0hxzGb2+3t6zPC25h1vsfyQ3v7+4xwbkP3Z4R9PIaiDfPiGeGtvWVZJjIySrXPCG/tbbVa0Ov1qn1GeDvWfRyGs73t7WMnzw0kgORbKTze/w1+/Gqu47MVq38kITGJF/s/ke25VquV1l37sWXdZxiNgc0YWq0WjMaIgM7Nz2hVF2hXm9ClLrSqC7SrTehSF3mpK8+m2L5dt4mjx0+jKAq/bd1JuTKlWPPjb0iSTEpqGjv3HOT226rlSl0MhjwLxQorWtUF2tUmdKkLreoC7WoTutRFXurKsys3rF+HGfOWEhd/nQKx0Yx5fSCb/9rFgFfHkZCYRPs2zWjfummu1EWSpIC9T/kZreoC7WoTutSFVnWBdrUJXeoiL3Xliym2YBBTbN7Rqi7QrjahS11oVRdoV5vQpS7+k1Ns+QlbIJj20Kou0K42oUtdaFUXaFeb0KUu8lKXNlvUT2zR+tpDq7pAu9qELnWhVV2gXW1Cl7rIS13abFE/sS/10xpa1QXa1SZ0qQut6gLtahO61EVe6hIGkkAgEAgEAoEbwkCCLMmhtIJWdYF2tQld6kKrukC72oQudZGXurS3JlAgEAgEgv8ALbs8Q81qlUi+lULZ0iUZM2wgFcqVZvzUeQzp/wQlSxTLcs66DZs5fOw0w17qmwc1VhfCgwQu2wVoCa3qAu1qE7rUhVZ1gXa1aUlXdFQkS+dNYvWSGdx7TxM+Xvw1AOOGD/ZoHKmRvOwv4UESCAQCgUDF6PV6Gt1Zh/W/bgOge59XWTxrIhFGAyMnfEhc/DXKly3Fe2+96nLewmXfYjKZGfK865ZeVknio/nL2bX3EFFRkbw+pC/1atdg3YbNHDt5hrgr1zl09CTPP/MoDz/QLvM8q5Vpc5Zw7MQZbqWkMfJ/z1G1cgUGD3uHrxa+D8C6jZs5e/4yLz73OIuWf8uG37YRGWHkzddf4PaaVXlm0Gge6tKWn37Zytxpb/LZF9+xc88hkpJvMbDfY3S8twU3k24x5t1ZnLtwmfhrN6hepSLvTxiK1SrxzvQF3ExKplnjO3lt8DPodLqA21UYSIgU7WpEq9qELnWhVV2gXW2h1HXow6c9fl699xSiS1TEdP0Cp5aN8HhM3f8tByDp+N9c+HGW1+99QZZlNv7+N7fXrOry+Y7dB4iMjGDl4ulcib9ObEy047u9+4+wc/d+Zk8dnaW8tT/9Tvy1Gyyb/x4nz1xg+LgP+HqRzcD59+BxZk8ZxdkLl3nrvTkuBpLRaKT7A+25/bZq7Ni1n4XLvmXO+29SvFgRzl24TOWK5fhz+156P9aV7bv2c+L0eb5YMJm4+GtMn7OE6RPf4FZqKknJt1g0awI6nY52rZsx6NnHuXDpCv8bNYWO97bg2x82Ub1qBT6aPJKZH39OzepVKF+2NIOGTmDYS/24rXplJs34lINHTnJHnZo+t6M72rwD/ESkaFcfWtUmdKkLreoC7WrTki6TOZ0+g0cTF3+N1i0a8/oQ17iiO+vVYvGKNSxYsoonetzv+Dwp+RbjJs9l9NABGI1G9uw/woy5SwEY/spz/LPnAB3aNEen01GzWiViYqI4dyEOgHq1a1KgQCy1alYlITEpS50KFy7EwmXfcOjoKeLirwHQ7p67+XP7HsqVKcXZc5eoU6s6sz5ZweGjJ+k3ZAwAMU7GW48HOzg8PyWKFWH5qnUcOnqK+Gs3AChevAhnL1zCYrGSlJwCQEpqGoePneadafMdbdPy7gZBta82RknQqHq3lWzQqi7QrjahS11oVRdoV1vodOXk5YkuUTHHYwrf1py6/2se0PXtMUgr12zgzLkLLh4igBLFi7Jo1gR+/mUr/YaMYfbUUQBs2vw3zz3dnRWrf6RpoztoWL82S+dNcpynKEAOM1NGgwFFcW3LS3HxvD52GoOffZwHO7Vl0LCJALRt2YSJ0+ZTs3plmjSsazN+FIWnenblsYc7ZSnbnhwyJSWVl0dOpt+T3RjxyrPs3H0AgBZ3N2Dpl2t59uWx1LmtGp3btcRisRAbG82Sue8GNa3mUo+QlKJyQtWY+Q2t6gLtahO61IVWdYF2tWlRV/eu7dm97wgnTp93+fz02YukpZno2qkN1apU4NjJswDc16Y5/Xv3oEBsDH9u35ulvLsb1mPTH9tRFIWTZ86TmppGpQplc6zHkeNnqFyxHG1aNubcxcuOz8uULoHVamXT5u20bXW37RqN7mDtT7+TkpKKLMsO75Az5y7GERlhpHP7VtxISMKcng7Alr928cgD7Vk+fzJjhg0kMjKCAgViKV+2ND/+sgWAK/HXsxhw/iIMJET+CDWiVW1Cl7rQqi7QrjYt6jIajQx89jFmzvvcxShITEpm6JhpPPH8G+j1Opo3sU05FS5UEIBBz/Zi3qKvsFhcs1V3e6AdJYoXpffAUbw7fQETR79MRETOE06NG9QlNdXEcy+P5d+Dx4mJinJ8d0/zRvz59x4a1LsdgOZN7qR9m6Y8+/Jb9HtpLNt37c9SXs1qlalQvgx9X3yTNT/9RplSJQCoVbMqi7/4jt6DRjHg1fFMn7MEk8nMW28M5PuffufpgSN594NPSElN87MlXdGlp5tV7Ue1Wq207tqPLes+C3heWeyCrD60qk3oUhda1QXa1SZ0qQtPusZP/ZgnenTh9ppVSUpOofegkcx4dzg1qlYK6bVFDJJAIBAIBALV0KZFI6bNtnmNJEniyUcfoHqViiG/jjCQ0KbLFbSrC7SrTehSF1rVBdrVJnSpC0+62rVuSrvWTcN/7bBfQSAQCAQCgUBlCAMJbaWed0arukC72oQudaFVXaBdbUKXushLXcJAEggEAoFAIHBDGEiIlPpqRKvahC51oVVdoF1tQpe6yEtdwkDCto+NFtGqLtCuNqFLXWhVF2hXm9ClLvJSlzCQAEXR5sDSqi7QrjahS11oVRdoV5uWdLXs8gx9Bo+m+zP/Y8jwSVy8HA/A+KnzuHY9weM56zZsZtrsJQFfc/zUj+nz4pscPHKCTZu303vQKD79fHXA5eVEXvaXNn1yfqO91PM2tKoLtKtN6FIXWtUF2tWmHV32vdhkWWblmg18vPhrJo5+iXHDB4flelevJ7DvwFG+WToDgAVLVjH0xT40urNOWK5nI+/6SxhIgMGgzfwRWtUF2tUmdKkLreoC7WoLpa4zG//n8fPyLUYSWbAc6bcuc2nbZI/HVO34IQApV/Zw9d/PvH7vjcSkZNItVr5as4nHH76PJnfVY/2vfwHQvc+rLJ41kQijgZETPiQu/hrly5bivbdedSlj4bJvMZnMDHn+CZfPrZLER/OXs2vvIaKiInl9SF/q1a7B6Ikfcf1GIs+9/BYd723O/kPHmTxzIa8NfoYWd9u2Mbl85RofzF3ClfjrREREMHncqxw4dJztu/Yz8tX+ALwzbT4d7m3BnfVq8d6MTzl28izlypRkwqiXSElJZfrcpRQtUgir1cprg/swfc5nnL1wGatVYuKol6hetSKHj53inekLSEhIIiU1jfr1bmP2lNFs/XsPcxd+iSRLPPvUI3S5755s2zE7xBQbIEnWnA9SIVrVBdrVJnSpC63qAu1q04quixfj0Ol0XLmehCzL/LRpC7fXrOpyzI7dB4iMjGDl4umMfm0AsTHRju/27j/Czt37GdivZ5ay1/70O/HXbrBs/nuMHjqAsZNmY7VamTDyRSqWL8OiWRN48tEHqF2rGuNHvugwjgCKFC7IywOeYum8SdzdsB5rf/qN5nffya59h1AUBVmW2X/4OI0b1GXJijXcWa8WXy18n07tWvLdj5sA2LZzL53bt+TtES8SHRXBM70eYsmcd+n1cGe+WLUOgHmLvmZAn0dZu2IW1atWZMQrz5F4M5l5i7/i04/G8/m89/j6uw1YrYH3t/AgCQQCgUAQADl5eSILlsvxmAJlGlKgY0O/r3057gpWq5X1G37lh3U/0bpFI14f0s/lmDvr1WLxijUsWLKKJ3rc7/g8KfkW4ybPZfTQARiNRvbsP8KMuUsBGP7Kc/yz5wAd2jRHp9NRs1olYmKiOHchjpjoKHIiNiaa5FspzPx4GfsOHKVGtUrEREdTo1oljp04g1WSqHt7DSIijOzYfQCzOZ3vf/4dSZJp1rg+AJUqlOPuhncAYDDoMRqNzF30FfsPHcegt/l1ShQvQuLNZMwmM6lpaeh0Og4cPsG164kMGjoBgOSUVBJvJlOyRDG/2xeEgQSAXq9NR5pWdYF2tQld6kKrukC72rSi69LleIxGI08+/ihR+nTOnL/o4iECKFG8KItmTeDnX7bSb8gYZk8dBcCmzX/z3NPdWbH6R5o2uoOG9WuzdN4kx3mKQsChP79t2cGqtRsZ0OdR6te9jb927AWg3T13s3X7HqySRNtWTTKuozDxzZdcNpm9HHfVYQQBHDp6ig/mfs7g5x6ndfNGzFv8FQCtWzTmk6WrWPndBh7peh8Vy5fh9LmLNG5Qh0ljPU99+os2RkrQaCdozxWt6gLtahO61IVWdYF2tWlDl9mSDkBUVCTdu7Zn997DnDh93uWY02cvkpZmomunNlSrUoFjJ88CcF+b5vTv3YMCsTH8uX1vlrLvbliPTX9sR1EUTp45T2pqGpUqlPWpXrv2HaZNy8Y0uON2Tpw+5/i8ZdO7+GfvIfb+e4Tmje/MuM4dfPnNz8iyTEpqGknJKVnK+/fgce6qX5tmjetz+txFx+e/bt7OmNcHsnzBZJ7M8I7Vq12DvfuPcibjuCvx132qszeEgYRI0a5GtKpN6FIXWtUF2tWmFV2XLl0BbJu5Go1GBvR9lJnzPkdRFMcxiUnJDB0zjSeefwO9XkfzJrZYocKFCgIw6NlezFv0FRaLa5xOtwfaUaJ4UXoPHMW70xcwcfTLRET4NuHU5b5WrNuwmSHD34XMqlCoYAFiY6IpVrQw0RlTdf2eehizOZ2nXhjJyyPe4+LlK1nKu6f5XRw4fJwBr47nxo2bjs9r1azCG+Om88yg0bw0YhIrVv9I8aJFGD10AG++M4s+g0ez9Ku1PtXZG7r0dLOS82H5F6vVSuuu/diy7jOMxsBmDK1WC0ZjRIhrlvdoVRdoV5vQpS60qgu0q00rukaPf5+yVe+gYtkS9OjcVDO63PGm67mX32LutDFERUZw+Ngpho2dzo9fzw3ptUUMEiJFuxrRqjahS11oVRdoV5tWdJnN6UiShE5nmzLUii53vOlqcXcDBr8+kXSLhajISN4aPijk19Zmi/qJLMuazPmhVV2gXW1Cl7rQqi7Qrjat6DKZzbZtODIMJK3ocsebrgF9HmVAn0fDeu2ADaSExCQOHzvF2QuXuXgpnuLFClO5QjlqVq9E1coVQlnHsGNLZa69gaVVXaBdbUKXutCqLtCuNi3oSryZzPUbN6kqS46Qcy3o8kRe6vLbQLocd5XPv/6Bk2fO0+CO2ylfthStmt1F4s1kzl64zMbft5FusfDM4w+FOf14KNHGqoasaFUXaFeb0KUutKoLtKtN/bq+XruJC3E3aCjLTnHQ6tflGRVtNbJt5z46t29Jgztu93rM5SvX+GH9H9xZrxZGFbj8tOiWBO3qAu1qE7rUhVZ1gXa1aUGXJT0di8WCIivIss1E0oIuT+SlLr8NpB4Pdcjy2V879nLq7AVKlyzOva3uplyZkmGfGwwlkmTVZPS/VnWBdrUJXepCq7pAu9q0oCs9PR3JakVWZMeyfi3o8kRe6go6D9L8JSvZf/g4lSuU48Tp8wx/+4NQ1EsgEAgEAoEHzOlmLFarbW8zRdWZevI1AQVpnzh1jprVKwNw4eIVxg0fhNFopFmT+jzx/HCfyoi/doPpc5Zw/kIcEZFG3npjECWKFWXspNncSLjJ/R3vofdjDwZSPb/R6bSZL1OrukC72oQudaFVXaBdbVrQZTKZsFotKIqCkjHFpgVdnshLXQEZSL9t3cman36j35MP81Dntgwe9g4lixfj3IXLPPXoAz6VodPpGPDMo9SsXpmVazawfOU6ChaIpW2rJjzyQDv6DhlDmxaNqVyxXCBV9At7HgmtoVVdoF1tQpe60Kou0K42Legym0xYLVZw8iBpQZcn8lJXQAbSgD6PciX+Op8sXU3pUsX58L2RpKWZKFyooM/pyEuVKEapEsVISEziwqU4atWoyqq1G+h2fzuMRiP169zGtp37csVAkmVJMxsYOqNVXaBdbUKXutCqLtCuNi3oSklNxZLhQbIbSFrQ5Ym81BVwHqQypUsw8tX+HDxygnenL6Bl07t4oGNrv8rYd/AYQ4a9Q6MGdXnlhd4sWLKSiuXLAFC5YjmuXU/0eN6qtRtZ/f1GAEeAmtVqARQMBiOSJAEKOp0evV6PJNn2mdHrbdHw9r14DAYjsixlHK/DYDDkcKyckZPB/Vg9oPPpWJ1Oj07n/Vij0YjVanXU3/lYvd5gc6l6OVav12VosR0ry3JGu4DRGOF2rHu7KLakYxl18qcNM4/Vodfn1IZSRp8F197O2jy3ocVLexuQZe9t6F97u7ZL5rG+tKHn9pYkKePfoWrvvB2z9va232M5jdncbm9fnxHexmx241ANzwjnNnR/RiiK4tCmxmeEt/aWJClDqzqfETqdntTUVKyWjBgk2XacvV/V+ozwdqz7OAxne9vbx05Ae7EdOnqSBUtWkZJqonixwgzq14uTZ87zyx9/07NbR5rcVc/nsiwWK0u/WsvluKv8tnUn676cQ3R0FMtW/kBScgovPvd4tueHYi82RVE06Z7Uqi7QrjahS11oVRdoV5sWdD3d/1V+27KDQS8OoWrVKvR55B5N6PJEXuoKyG/1zrQFDH2xD5/MHMdTPbvy3sxP6dC2OeNHvsjho6f8KisiwkivRzrz1859FC9WhAsZOxSfvxBHqRLFAqme39itdK2hVV2gXW1Cl7rQqi7QrjYt6DKb0ylfvhxVKldw5EHSgi5P5KWugAwk2c2is09zRUVG8szjD/lUxrfrNnH0+GkUReG3rTupUqk8rZo1ZM/+I1itVg4cPkGLuxsEUj2/sbvgtIZWdYF2tQld6kKrukC72rSgK81kJuHGdUqVKOZ4/2pBlyfyUldAc1Jjh73A9DlLSElNo3jRIox+bYDfZTSsX4cZ85YSF3+dArHRjB02iOLFijB20my+W/crD3Zu44hHCj/ac0va0Kou0K42oUtdaFUXaFeb+nWZzWaioyLR63ROeZDUr8szKlrFdvnKNerVrsnMSSOyPe5SXDzly5b2+n3VyuX58L2RWT7/aHLWz8JNoLFL+R2t6gLtahO61IVWdYF2tWlBV5rJTHR0FDq9zjHFpgVdnshLXf7vxbZjLz//+ied2rWkaaM7KFemFBERRhRF4eq1Gxw5fobvfvyV4kULM/K151WxF5vVatXk4NKqLtCuNqFLXWhVF2hXmxZ01ahWGb1eh16ny1ippWSszlO3Lk/kZX8FtBdblw73sPan35m36GvOX4rDZDJjMBgoX7YUNatVZthLfbP1HuU/tJqqXau6QLvahC51oVVdoF1t6tf178EjFC5U0BELbItDUr8uz+SdroDMstiYaJ7o0YUnenQJdX3yBJGiXX1oVZvQpS60qgu0q00LuqxWCaPBgF5vM5BsC6fUr8sTealLmy3qJ1rMHQHa1QXa1SZ0qQut6gLtatOCLlmSMBgM6O0eJFmbOZAgb/tLGEhkZhXVGlrVBdrVJnSpC63qAu1q04IuqyRhNLp6kLSgyxN5qUsYSAKBQCAQqAhJktHrDcRERVKmRGHHSjZBaAkoBmnhsm+z/b5/7+4BVSavMKhgpV0gaFUXaFeb0KUutKoLtKtNC7qskhWj0YDZYuXK9SRAG7o8kZe6AjKQkm+lALY92YoXK0LZ0iUBOH7yLOXKlgpd7XIJWVbQ4tjSqi7QrjahS11oVRdoV5sWdMmSjMGQOQFk37RW7bo8kZe6AjKQXh3UG4CXhk/i3TdfcXRUmsnEmHdnha52uYQtlbn2RpZWdYF2tQld6kKNuq5dv0GRwoWJiMj+8a9Gbb6gBV22VWxGnOOXtaDLE3mpK6gYpKvXb7j8OzoqiktxV4OqUN6gzeh/7eoC7WoTutSFunQpisL8LzYya8kPPhytLm2+o35dkiyhN+jRYc+DBFrQ5RkVbTXiTKM76zJqwkx6de+MwWBg3fo/qFyhXKjqlmtoMfsoaFcXaFeb0KUu1KYr/up1zGYTRYoUzvFYtWnzFS3osudBsnuQFBRN6PJEXuoKyoP02uBnuP22qsxb9DUzP/6cAgViefP1F0JVt1zDarXmdRXCglZ1gXa1CV3qQm26/vrnAOnpFiIiInI8Vm3afEXtumzxRjIGg8Epk7b6dXkjL3UFZZpFRkbQv3cP+vfuEar65BFaXSKpVV2gXW1Cl7pQj664q4noIgpSu3YtH5eFq0ebf6hblyTZ8gIZjQbH7JPYaiQ8BOVBOnjkJH2HvMmjfV8DIC7+GivXbAhJxXITkaJdfWhVm9ClLtSk6+yl68TfSKZE0UJYJTnjpeodNWnzB7XrkiQZsC1/1znF56hdlzdUu9XI+7MWM37EEAoUiAWgdMni/LDhj5BULDexZyPVGlrVBdrVJnSpCzXokmWZ/YeOsffQacqWKkKB2CgAJFnO9jw1aAsEteuySrYpJ4NzDJKiqF6XN/JSV1AGUnq6haqVyzv+rdPpMJstQVcqt7G7LLWGVnWBdrUJXepCDbqSkm8xZtJc1n77NU3rVyfCaFsybbVmbyCpQVsgqF2X1ZoxxWYwYJ9jU1C/Lm/kpa6gDKRKFcqyY9d+dDpISUll5sefuxhMAoFAIMhbkpJv8cfvv1G/Tg3KliqKMSNvnVWjL1StIzum2PSZeZBymC4VBEZQBtLwV57li9U/cvL0BTo/NpjTZy8xbEjfUNUt19DrtZdcC7SrC7SrTehSF2rQlZxs2/mgaJEiQEZwLzl7kNSgLRDUrss+xWY0Gl1WsaldlzfyUldQq9hKFC/KzEkjSDOZAIiJjiYhMSkkFctNcgpWVCta1QXa1SZ0qQs16EpKTgagcOGCgH1qJnOqxhtq0BYIatdlD9LW6/VkOpAU1evyRl7qCsqDdH+vwfy2ZQcx0dHEREcD8OqbU0JSsdzElspce2hVF2hXm9ClLtSgKyn5FgCFC2UYSEbbY3/dH3u5cfOW1/PUoC0Q1K7L6mmZP+rX5Y281BWUgRQdFclX3/7M+KnzSElJBdQ6FarN6H/t6gLtahO61EX+12WfYitU0GYglSpuy6JtTrfm8Os8/2sLDHXrsgctG/ROy/zFViNhISgDqXDhgsydNoYaVSvRd8gYR8C22hAp2tWHVrUJXepCDbrsU2xFMqbYShUrRMlitr912bx81KAtENSuS7JmepDEViPhJSgDyRYYpqd3rweZ/NarzFn0JWfOXgpV3XINkaJdfWhVm9ClLtSgS6fT07BBPQoWLADYVj9VqVASyD5HsRq0BYLaddnzV4mtRsJPUKbZlLdedfxds3plFn44nm/X/RpsnfIAVc4L+oBWdYF2tQld6iL/67qRkMiefQeJiMh83GfnOcok/2sLDHXrshsMBkPm6i6x1Uh4CMhAupF4k+JFi6DT64iLv+byXesWjUJSsdxEpGhXH1rVJnSpCzXoyjbOKJuv1KAtENSuS3LJg+RYx6Z6Xd7IS10BGUhTPlzElHGv0WfwaGwBVM53mY4Nq+eHpHK5hV6vzYGlVV2gXW1Cl7pQgy67gaTzECCqZGMhqUFbIKhdV+YqNqPTViPq1+WNvNQVkIH0zuiXAdiwekFIK5NXSJIVozEir6sRcrSqC7SrTehSF2rS5WIg+TDDpiZt/qB2XbJjFZsex1YjiqJ6Xd7IS10BmWbOc9nubNm2K+DKCAQCgSC0eJpic9hHWg1b0TB2D5LBaRWbIDwE5EHq8+KbHjtGkRXM6RZat2gcbL1yFZGiXX1oVZvQFTzJKSaOnr5EiSIFqVapdFivpYb+ckyxubiNcn6zqkFbIKhdlz0DunMeJLHVSHgIyEB6dVBvj5/rdDpuq145qArlBSJFu/rQqjahK3guxN1g98GzlC9dNOwGkpr6y3MMknfUpM0f1K5LkjznQVK7Lm/kpa6ADKRGd9YJdT3yFFsqc+1Z31rVBdrVJnQFj30KIu7aTSRJxmAIX5CnGvrL0/tF58Mcmxq0BYLadTkyaTutYlMU9evyRl7qCioP0plzF1m47FsuXLqC7LRfypI57wZdMYFAIAiENFM6YJuKuHojibKliuZthfIJHsMitOl00DQOD5Ih8/WtVe9RXhOUgfT2lHm0a92UuPjrDOjzKEeOnyJChenODQb11dkXtKoLtKtN6AqOP7fvYtGKnyleogRLFy+ksHEsTz3WLWzXU0N/BfryVIO2QFC7LruHVO+SB0n9uryRl7qC22oEhb5PdKPu7dUoWCCGPo934+9//g1V3XINu0WuNbSqC7SrTegKDoNeT4GCBSlYqBDm9HROnDwT1uupob885UFyTjDoDTVoCwS169IBTZs0oECBWEeovW2Zv7p1eSMvdQVlIMXGxJB8K4XmTRqw9uffOXH6PHHx10NVt1xEq+5JreoC7WoTuoLBbE5n1ddfUjRaQq/Xc/rs+TBfUT395SlIO3vUo80/1K0rLc3Mjn/22fIh2WOQnP5fe+SdrqAMpD6PP0TizWSaNa6PyWRm0NAJPNK1fajqlmuIFO3qQ6vahK7gMJnNpKamUrJ4EWbNnk3Px58O6/XU0F/ZTbFlN/umBm2BoHZd6RYLABEREZlxZYrYaiQcBDW51+LuBo6/3x7xol/nJiWnMPnDhZy/EEeRwgWZMGoI3/zwC2t++p1iRQo5yqxetWIwVfQJkaJdfWhVm9AVHKY0MwAx0VGkocNiDa97Xg39Zd9OxGWKzYfz1KAtENSuy5KxWW1kZIRbHiR16/KG6rYasfPjxi0eP3+gY+sczz1w+DiPPdyJhvVrM+uTL1i+ah0x0VG80LcnD3VuG0y1/EakaFcfWtUmdAWHyWwzkKKiojBbdMhyeN3zauovT1uNZNc6atLmD2rXZUnP8CA578WG2GokHARlIP3x1z8u/z505CT33nO3TwZSy6Z3Of6uX/c2ft28g8oVy1K0cMFgqiQQCP7DmM22Jf7RUZHcknTIspzDGf8BPFpBTrucClSF3YMUEZFpNIhuDA9BGUhTxr3m8u9TZy7w1bc/+13Orr2HuLNeLRJvJrF85TrmLfqaxnfV5X+DemM0ZE0QtWrtRlZ/vxHInF+3Wi2AgsFgzIh6t83J6vV6JMk2oOwpy2XZnmjLiCxLyLKC1WrFYDDkcKyckbRK53asbdNAX47V6WxLM70dazQasVqtjvo7H6vXG1AUxeuxer3OEfFvr7+tXcBojHA71r1dFMfLxN82zDxWh16fUxtKGX3m3ob+t7ddm+c2tHhpbwOy7L0N/Wtv13bJPNaXNvTc3raEb0oI2ztvx6y9ve33WE5jNtj2TklNASAqMhJdmowkyxntHPj4zn7Meh+H+eUZYW9fexmSJKHImZ95e0bodHrHd2p9Rng61u5VVOszwpzhJdXrdY78g7IsZ9xjFtU+I7wf6zoOw9ne7tuahDTBQMXyZdixe79f55w8c56dew7y0oAnSUhMost99xAbG82It2ewftOfdO3UJss5Pbt1pGe3jgBYrVZad+2H0RiBMSMHk9EtF5O7e855TtNgMKLTSY6Gyf5YA84ZPcN3rNHrsRlneD3WaHQ+1rXDc24Xf47VB3Sse06LwNtQQq83+nise7kQuvZ2d/0G196yLKHT6ULY3nk/Zg0G22KbzHssuzFLtuXm1N4Wi+2hGxMTjSHZRLrF6qhLoOM7+zGrBDEOc+cZYf/OtjWFHqNR72gLvV7vcl3ncmVZwmBQ8zPC87H2F7NanxGSZHvhx0RHOxwItmeGIZt7LP8/I7wd62kchqu93QnKQPpw/jLH31arxKGjpyhVsrjP5yckJjFu8lzeefNloiIjKVu6pOO79q2bcvb8pWCq5zOyLGtyoz+t6gLtahO6gsM5BkmvNyOHee5BDf3lcRWbDzFIatAWCGrXZV/FZowwumw1onZd3shLXUEZSAULxDr9S0e3LvfSvk1Tn85NT7cweuKHDOjzKDWrVcKcns7Pv/zJg53bYjKb2bnnoEfvkUAgEHjDZLIZSNHRkRj0+rAHaasJ+4onl78DaB5FUQLIqSQIBZIkkZ4RpB3pHIOk2RxIeUtQBlL/3j0CPvfzr3/g6IkzLFmxhoWff4Mky3Rs24IBr44jITGJ9m2a0b61b8ZWsIgU7epDq9qEruBw9SCFP0hbDf3lKZO247tsXqzu2iRJZsl3W4mKMPJ0t5ahrWQuooY+88aIiXM4euwEABFOHiQUdevKjrzUFdSVL1+5xtqffuPajUQXN+6Y11/I8dz+vbvTv3f3LJ/3e+rhYKoUEJIkZZmb1AJa1QXa1SZ0BYd9FVtMdBT6XPAgqaG/sptiyw53bTeTU7FaJSRJwpxuISpSnUvK1dBnnrBYLKSZLY7EiRERESiOxYiKanXlRF7qCuqqb4ybTuUKZalXuyZGo5rnPrXqntSqLtCuNqErGLJ6kMJ9XfX0V7BbjVxPuInRoEOS4WZyGqVLqNNAUlOfOTNxymxSbqUgZQSZR0ZEYJYyY5DUqitn8k5XUAaSoihMGvu/UNUlzxAp2tWHVrUJXcFhsVhtK3oMBvQ6HVKYp9jU0F+ePEgOU8mPrUa2/vkXX323iUcfexxzRhyMGlFDn3niVkoKKakpSI48SEbSHeNbbDUSDoK6cpO76nHi1LlQ1SXPECna1YdWtQldwaHICoqioNfrHdcMpxdJDf1lt49cPUjOm5x6xl2bJMmkpqYCkG6xhrCGuYsa+swTVqtEutnsWOYfESG2Ggk3QXmQLlyKY8jwSZQtU8Ll8yVz3g2qUrmNSNGuPrSqTegKDru3RK/XodfbXh7hXCasqv5y3mnEBxeSuzZJkkhLSwPgVqo5DBXMHULRZ8tW/kTZMiXp0ObuENUqZ6ySFbM53ZHc0BakbYu5+y9tNXI5PpFUk5nqlUqHfTVlUAbS0489GKp6CAQCQdDYMwvrdDoMdg/Sf3wfBo9B2o7vfC9HkmVMGQbS9n0nuXLtJp3uqR9s9VSH1WrlwtUU4m+ac9dAslhJTzc7MqNHRkS45EH6LyBJEp8tX8WqNT/y3NPdGTLgmbBeLygDqdGddUJVjzxFi8m1QLu6QLvahK7gcF7S7uxBChdq6C/7Un5/f227a5OsEqlpqY5/R0ep01sRbJ8lJN7k1q1blCtXNkQ18g2rJGE2mx39aHDahss2rZz/x2IgOOuyWiWmTJ8FwImTZ8J+7aAMpKPHT7Pim5+4diPRxVM7e+roIKslEAgE/mP/JW2LQbIbSP+Rn9c5EOx0hCRJpKWmOf7taZ/M/wLXbyRy61YyxohKuZo002qVSE83YzRGOHIg/dfyddpX8AGYMlJ6hJOgDKQ3351FmxaNadOyiapvFlmWNBngplVdoF1tQlew18mcYtNnrH6RwmggqaG/PK5i8+HN6q5NkmXS0lK5s0ZJ/j15TbVTl8H22Y2Em9y6lYxOpyfdYs21fFB2DxJO3iLnIG01jMVAcNZlD1AHMJlMYb92UAZS4UIFeGXg06Gqi0AgEASFszFgMIR/ik1NeMyk7YeR44h9iTT6fW5uY5UkLBYrMdFRIS/7RkIiCTduoEfCZM69hJlWi5X4uDjM6emZ02uORNr5ty9CiX0M6nS6/O9Buqd5I/7Ze5Amd9ULVX3yBJGiXX1oVZvQFRz2Jf4Ael34p9jU0F+ethrxZWbG01YjAEZD+NMnBMPR05fZsvMIFcoUp9M99TEYXL0qwfaZJd1CuXKlkTGQbpFyPiFEWCUrERFGxox4iYrlywFOffof2WpEyRhzRoPB5k0LM0G16O9//sOi5d8RGxOd8YkC6Niwen7wNctFZFnS5ODSqi7QrjahK8jrOMWE5EYeJDX0l0dHjw8Wkrs2e/yHPZwiv3qQUlLNyAqcj7vBles3sVolihcpSMECtvdUsH12I/EmZ89e5M677g57IlJnrFYJg8HASy/0cXxm70ZFUVQxFgPBWZd9DBqMBkymfO5BmjLutVDVI08J5EZPTEzCYrVQqmSJnA/OI/LrAywUaFWb0BX8dezB2RFGA4ULxoR1ik1N/aXzYBVlV3t3bXKGB8lg1Hv8Pr+QkpbpWUhNTeePnUdQFIXne90LBF9vq9WK1WrLJC5LuWcgWaw2D5IzjmX+KPm2P4LFWZfdi2lQgwepXJmSoapHHuP/UoBGbR7ixo1EEi/sC0N9QoWWlzhoVZvQFQyyLDvlhlFIupUW5mDi/N9fmVNszp9mTs14x1WbPf4jwmCLucmvQdqpaZmehbhrN5Fk2W2aLcjVfLKMNWO7j9z0IElWyetiKFtX5P+xGBiZuuw/dowGA2mmfG4g7TtwlI8WfMHFy1ccbmyjwcCPX88NSeVyC0MAK/DUMBQD0aUWtKpN6AoSpyk2nX2Zfxhf5Gror2z3YsvGQnLXZpXs0xt2D1Ioahd6km4mUDDayC2TlRSTiQijwUVlsH0mWaU8MZCsVisGo2cPEqhjLAaCsy57exuNKvAgTf1oMX2f7MYP6zfz+pA+HD1xhsSbyaGqW64RWIr2zF+puZUHw1+0mnoetKtN6AoORcGxvN/+XyWMMUhq6i+X55QPDqSsW43Yf73bXhv50YN034NPs2vvAbp06kD7zg+SmJSGVZJcX7JB9pltii3DQMrFKTarJBGRxUCy/VdR/htbjdi9mEajEXMurGILKmlCRISRTu1acluNyiQm3aJTu5Zs/mtXqOqWz7E9HOwdJhAI8h7bFJvtb30ueJDUQLYeJH+2GrF7kAx6dDpdvox5uXL1GoBj4VC6xYpBrw9pXSVZduyHJkm51wZWixWj0dVL5JwH6b+A8yo2U373IBUpXJCr1xO4p3kjvlz9E0nJt7iRcDNUdcs1AkvRbhuYFosVozF/rhzQaup50K42oSs4nD26ulxY5q+G/vK0zN+XIAF3bfb4D4NBjz6fGkj2/ffswcwWixW9Xu8yFRZsn1mtElarzVjM1Sk2ScpiIDnnQVLDWAwEZ10OD1KEkZtJ4Z+tCsqD9ELfx1AUhYb1a1O1cnkWfLaKvk8+HKq65XNsDwdLhqtVIBDkPbYXhVsepHz4Is8LPCaK9OP8TA+SAZ1eF9apy0CJiYlGr9NRp1Y1AKySjNEQWg+SVbJitdhWseX+Mn8vMUj5ryvCgr29I4zG/J8osl7tGo6/B/Z7jIH9Hgu6QnlBICna7eNRsubfKTatpp4H7WoTuoK9jnMepMw4wfBdTwX95Um/D3NsWbYayYi30ev16HT50/AsVqwoJUoU48Xne/Pxio0kJ96gUuWKLk0QbJ/JkpwnMUgel/ln/NeeBynfj8UAcNZl92J27/EoVapVQ5blsGrWXmvmFhk3nPAgCQT5B0VRHKvXxGa1rnjMpO1PDJKc6UHKr1NssiRjMBgwGvVcOn+K99+fSmJCQkivYbVKWKW8WOZvzbrM35EH6b+B3SAtUqQoqabwOyeEgUSgKdozptgs+ddA0mJWVTta1SZ0BYcsy47A1cwYpPC9xNTQX/aXp6fFttm9WN212eNujAZDvg3SliQJg16PXq/ns8+WALYl4a579AXXZ1YpcxVbbiaK9BSDpMt0IaliLAaCp2zumbnOwnvtkBtIFy/Hc/DIyVAXG1YCeYDaO8b+SyI/ouVNOrWqTegKDucg7dyZYsv//eVxFZsPqUnctclOWYx1Ol2+9MzJsowuY8qlQEwMgGMRjb0dgu0zq0sepFxcxWaVsiwIcqxiQx1jMRCcdTkM0lzapDfkBtL0OUtY/+uffLJ0daiLDhuKEoCBlNEx1nzsQQpEl1rQqjahK9jrkKtB2mrqL3/ztblry5xis69iC1nVQoZz1mz7Un/33EHB9pksy0gZBpLFYs01T5rV6mGZv1MeJDWNRX9w1mU3lnIrOD3kPrmxwwZSrGhh/ty+J9RFh5EAEj2qIgYpfyawDA1a1SZ0BYOsZOZByo1l/mroL8/L/F2/84z7ViPOQdr5dYpNxpCxLDwqOgqweZAsFpvxbGuC4PrMarU6nvuHTl6iUb2qxMZEBVWmr9c1uq9iA0oXL5yRCDP/j8XAyNRlH4O5tXgvKA/SwmXfcvnKNZfPihUtDECrZg2DKTpXCSRFu/3hkJ8NJK2mngftahO6gsTDFJvYaiS7VWzecdcmSZLDONLrdflyFZssSQ4PUkRERMZ/7Tps9Q22z6xWCYvF4jGmK5xYJQmj2yo2g9FA/I0kzGaLKsZiILhuNZIRg0T4p88hSANJp4OhY6by0ohJ/PTLVky5sHlcOJACiCOyd0x+XuYfiC61oFVtQldwKErWPEjh3mpELXhcxZYN7tqcp690uvC/nAJBclr2bZ+OsicatFc32D6TZBlLejq1qpYFci/dgdXDZrX2xJhWSVbVWPQHZ112b3BmcHp4rx3UFNtzT3fnuae7c/T4aX75YztfrPqROrdX46lHu1K1cvlQ1TFf4vAg5eMYJIHgv4anPEj50dORm3g2ZPxfBSQ7TV/pdPnUgyTLjpijkiWKYzQaHUZdqAJ67fFHduMkN9bYS5JEbEw0UVGRLp8bM7TlZrqBvMSerNSxik0NQdqSLJN8KwW9QUfJ4sV4a/Icvl23KRRF5wqBJJqSVTDFpsWkYXa0qk3oCg5FURyeI53OnlwunFuN5P/+stsxOie/kS/TQ+7aJKdl5vk1D5IkyegzvCzffvEx187sokSxorYvM6obbJ9ZM17SuWmAS5LMrZRUx9i2Y9ciSeFNmJiXOOtyD9IOd9MH5UFa/f1G1vz4G4UKFuDx7l0Y/sqz6PV6nnn8QZ4ZNJruXe8LVT3DjP+TyXa3vTUfG0jaDdoD7WoTuoLBtllt7i3zV1N/eV7F5nuQtlWSHMZHfl3mL8mZMUjuZI6D4PpMcqQ70LuVGz7s6WQMbivy9HpbPJitTuoZi/6RqcthIKFDIfxtH5SBdOjoKd58/QVur1nV5fOY6GiefeqRYIrOVQLbasTWUfnZQNJq6nnQrjahKzhc8iDlwjJ/NfRXdi+R7Fom61YjkmNaKd8u85fkzKmvDDKnY2wE22dWqzUjF5R96i782EM5smTSxjbVJ8mSKsZiIDjrcqxiy6XZzaBas3TJ4lmMo4/mLwega6c2wRSd77F7kPLzFJtA8F9DAUeiQJ1jq5H/RnxGjvjrQHLDNUg7f06xyVJWIyHUAb3WjJVyeqccROHGsYu90YOBZNDn6p5weYl7Ju1wW+lBGUh/7dzr8u/LV66xafP2YIrMEwJJ0S47ptjy7yo2raaeB+1qE7qCwzbFZvs7NzxIaugvT3mQfEka6a7Nvs+Z7fz8GfwuK4rX5e6KY5l/4H0mywomc7rNk5MLqyTtOLZ5MWatu9GgxyrJqhiLgeCy1YjkFoMU5msH1KI9+ryGTmcziFrd/4zj8zKlSvLYI51CVrncQpZlv3NIyBnZPfNzJu1AdKkFrWoTuoLD41YjYXyBqaG/AvVwuGtzmWLT508PkiRJ6A1eptgyqhtIn1mtVg4dPcHeo3FcvZ7k2LDXudxw4phi82Ag2T1IahiLgeCsy+4N1ut0oOTTGKRvls4A4NXRU5g5aURIK5QX2FKZ+2kgZTx0L8XFh6FGoSEQXWpBq9qErmCvo6DXuW01EkYDSU395W8mbbu2YyfOMGnaHK5cveYSpJ0/DSQPMUiOv2z1DaTPzl24RJvOj9OgwV2Y0y3o9HqnbM65F6TtPQZJVtVY9AdnXe4epHA3fVBTbFowjmz4H/1vt2SnzPiYv7bvDnWFQoRWVzWAdrUJXcGQ+3mQ8n9/2V/g/iaKtB915OgJvvthA9euJ7jEIOXHKTbbKjY3IyGLp8f/PktPtwBwR52ajqDhTM9ULsQgZUyxRUR49iBZ/zOr2HI3D1JAHqTZn67gpeefZMgb73r8VTJ76uigK5ab+D295hT0mXgziRMnz9CyWaNQVytotOhutaNVbUJXcNgyadvzIIX/BaaG/spuq5HsWsauLenWLcffdg9Gfl3FJkuyo//tOGK0lcC3GrHvEnFbjcps/XtXrhtI9sVAnupuzJhiU8NYDARnXarIg9SiSQMAHu/eJeALJyWnMPnDhZy/EEeRwgWZMGoIer2esZNmcyPhJvd3vIfejz0YcPn+IElWjMYIP47P2NU6w7WZeDMpXFULCn91qQmtahO6gkNR5KzL/MO81Yha+sv1x2zOFpJdW/zV6/R9tj/rvl/rFKSty5XgZH+R5cxs33bcA3oD6bM0kwmAqMhIZNkWi5VLC6kA5yBt76vY1DQW/cFZV5Yg7fwYg9T4rroAtGnZOMt3vuYFOnD4OI893ImG9Wsz65MvWL5qHRaLlbatmvDIA+3oO2QMbVo0pnLFcoFUMazYO6lT+3v46ZfN+dZAEgj+azgHaduX+Vv/I0ugveHIpO1kH7nH5WRH/NXrpKRCdEw0pUqWAGwvZW8JGfMSmyfFrV4hWOZv9yBFR0XYVkrmsgfJEYPkIUi7ZLFCmEwW215tGjSQnLFvqeJYgBHm6wVkIH393XqPn8uywrfrNvHVwvdzLKNl07scf9evexu/bt7BoaMn6XZ/O4xGI/Xr3Ma2nftyxUCyJ/zyFXsuhqiYaIB8ayD5q0tNaFWb0BUcipL58DTo9VStUJJrCckuhlMoUUN/ZTfFlh12bTExUVj1eq7GX6VMyaK2MoH0fLiCV5Izs33bybSP7LFY/vdZmsNAikKWbRsi27duyZWtRuwxSB4MpNjoKG6mpHExPpEalcuGvS65jXN/uaxisy1jC+u1AzKQjp044/kLnY7nn+nhd3m79h7iznq12Pr3biqWLwNA5YrluHY90ePxq9ZuZPX3G4HMm99qtQAKBoMxYwpMQafTo9frHbsB23d1tgd6GQxGZFlCkmSUjPwZ2R9rWymQbk4HICZj48CExJvIsuzxWNC5lKvT6TPS9Hs+1mg0ZnjhlCzH6vUGFEXxeqwt5bzzsTJWq21AGY0Rbse6t4viGHz+tmHmsTr0+pzaUMroM53P7Z31WD2KomT0ubc2tHhpbwOy7L0N/Wtv13bJPNaXNvTc3rYXfCjb23sbgvdxGKoxa29vSbL1e85jNrj2tu0XZkRRFCTJSnSU7Rd1ckoqsdGRAY3v7MZsduMwL9rbUxsqGePMXoa9ncD2i9xef/dnBNieqydPnSUxVSY1NYUypUtitVocRofFko5eb8hHzwgZneMYnVNZtmkqq9WCLNue9f48I1JSUgGIjopEUWT0Or1j7EmSvQ3D94xIt9jrmpHKwOnYWtXKcOD4Bf7ee5Iq5Uuo9hnh7Vj7OLT9126UK47/D2V7692mZwMykMYMGxjIaR45eeY8O/cc5KUBTzJv0VcOi1BWZIeL3J2e3TrSs1tHwNY4rbv2w2iMcLgf3d2Q7m5H50yrBoMRRbE4nZvdsQZsyw1t9YqMjKJggVjWrPuFy3HP8fO3n3k41pc6uB/rvt+O+y8e78cajc7WtqvLNed2ya5c7/X3t719P9Z7G8qyxeXf/rU3hK693V3a/rRh1mOtVgs6nS6E7R3MOAzNmDUYbLFB3u/P0La3XqdztGHB2GiSbqWRbpEpXNCfe8G3Met+j+WH9s44I/PPDM+ZfXsMo1HvFGyt9/qMsFpt95gsKyQmJABQpnRpjMYIhzfO/W9vdcqNZ4Si2AwKo9HouLf0er0jL5LBoM8wAi0+lAvObWg3UGILxNi8kQaDSzyWP8/ZQJ4R9rCOyMjIzIB5p2NjoiNJSk51fKbGZ4S3Y+3jEDJzmtnaRUJRQtve7gRkIO3ed4hGDery48YtHr9/oGNrn8pJSExi3OS5vPPmy0RFRlK8WBEuXLpCzeqVOX8hjprVKwdSvbAjOSxfPWPfGseIESO4ePlKHtdKIBAoiuLYagQgKtL2iDOn57/poNxGR9YgbV8mKCRZJinpJrVq1aLWbdVtZzttsxGOqctAyFyl5p4HKfgVT44YpOgoDm3/CZ0Ojp6Oc7luOMkuBgnsqwrzX9B8KEhOSeXQkdOULVvKkaDZZlxJ+XOK7c8de2nUoC5//PVPlu90Op1PBlJ6uoXREz9kQJ9HqVmtEgCtmjVkz/4jVK1cngOHT/DM4w8FUj2/8TdFu2M3Z70es8nmes0nzwgXtJp6HrSrTegKDuc8SABRkbZfiOaMPDahRg395WmrkUxbyfsLxq5NskrEXbpE3MkdTqfnXhZpX8lcXey+is3230wDyv8+s69ii4mOdskFBbmzWa19xwZPMUi2ukA+XFQYEo4cO83BMwn8e/Q8RpcYpHy6zP/lAU8BMGXca1m+83XTvM+//oGjJ86wZMUaFn7+DQDT33mDie/P57t1v/Jg5zaOeKRw42+KdkfMhMFAutl24+TKXeInWk09D9rVJnQFh0JmHiSAyAwPUnqYPEiq6C8PbxFffs/ZtUkZm7O6nJ+LG7X6iv3d477ViLu3LJA+c/Yg2cnNzWqtduPPwzJ/yL9bv4QCU1oaCQkJFCtSECnVtiBK51jFlg89SHY8bTXyv9GTmT0l50SR/Xt3p3/v7lk+/2jyyGCqFBD+pmiXHMG1ekxpabbP8uFSYq2mngftahO6gsO2Wa2TBykj87A5TCuu1NRfHqfCsnm/2LVJHgyK3PSe+IKiKJy5eBXIGo/lkK3Yj/W/z+wGUkx0tFO5ubjM354HyYthl18zm4eClNRUjh05TPMWzRyGomOZf370IO3ZfwSAS3FXHX/b/h3P2fOXQ1OzXMW/+TFnV250dIRtRYSUH2Mc8uG8X8jQqjahKxgUBS9TbOG6P/N/f2XmQfKwF1u2Z9qOt3mQ3LfvsJedP17K/+w/xc79JwBPMUg2Mr0N/veZTqejYoVyLh6k3MrmDJlTbJ4SRdrrkl/6ItSkppowm80oGDCZbCvI7fst5stEkevW/wHA9RuJfLp0tePzsmVKMn7E4NDULBfxFvjmDVmyL503MGxIHzZu3MTZ8xfDUbWg8FeXmtCqNqErOGyb1TpPsRmIijQ69tIKNWroL08vEV8Cqx0rKz1NsZF73hNfiLuW5EhnoHM3gNwMmUD67Oq161y4eJkCsTHuxeZykLbnVVdaDtI2mc1cvWrzDp67dA3IvZjfoJb5lyxRjEHP9gpphfICq9Xq103jmA/O+FUVHR1FapopLHULBn91qQmtahO6gkNxm2KLjozAnG7FFCYPkpr6y+MMWzYvVbs22cM+X7m5zUZOpKaZuXw10ZHnyl1o5hSbPR+S/32WkmILpShYoIBTuXkwxZatByl/rSoMFbdupXD40EEijToiYgrTvt29FCwQC9dS86cHyY7dOEpNMzmsd4ACBWKDq1Wu418jy5JE6VIliMpIFBkTE43JlP8MpPwTIRAOtKpN6ArqKm4vCL1eT0SEIWyr2NTQX5kZpP19cdrOkyQpS+yLzj2wJw+5lnALyEzc644uS0oD/+ucnJJCRISRyMhMD06uTrFJORtItrpoz0BKSU0lKekmdauVpEypVljbtKBY0SJw9lr+3GrEzm9bdvD+7M+4mZScMfcPpUuV4NulM0NUvdzB39TzVkkm/up1h/UaEx1FerrF81x9HqKGbRACRavahK7gUBQlS5CuzYsUHgNJq/0FmdokWc66fUeQxsHq9TuJiY7kgbYNgqojQJo5nZJFC6LH7iV0n2Kz/Scz3YH/fXbrVoqL98hWjmu54SSnZf65FbScF6Sm2pwPxYoUpGmjqgDsP3be9mV+9iB9/NnXTBn3GstW/sDbIwZz4tR5duzeH6q65Rr+WtyZ1ryt+aIzVjakmcw2118+QWu/JJzRqjahKzhkD7+goyKNYQvSVkN/ecqD5Eu17cdbrVbvgc8BvKDM6RauJ97y6g3xl1upZq4l3qJ8Sduz171PHDFJ2QSrZ8epsxeJu3KNWKf4I+dy8sMyf3tdZEVRyZpK37GHr8TGOMV/5VIerqB+/hSIjaF+3duoVrkCBw6foH7d29i5+0Co6pZr2PeE8RUpYz8Yu9s5NmPT2rSMJf/5BX91qQmtahO6gsPmQXI3kCIwhcmDpIb+8pgo0ocXjF2bJMkYsiydD/wFlZiUaq+Y/yc7sXnbLmYuXseuf48BYLQbcV5ikDLzIOXcZ3/tPs43G3ZiTrewdv0Wbianek11kBsJGq2Od473RJGQf4LmQ0lKqm28eAyQD/MkW1AGUsnixTh/MY52rZuyaPl3rFyzgdSMfBFaxt2aL1+2NHc3upO0fBioLRD8l5BlOcsL8ujBvfy2/gdHeg6B8yRUzi8Y235zri/mYF5QaeZ09DodcpCWhSJJxMbG4tgb01FHzx4if4yHs5eucS3hFsm3TKSbbMvMY2LcPEiZBftX8QCwWLNf5m9fuRlsm+ZHChWI5c47ajtifiH34r+CMpBeGvAkRQoX4vaaVenSvhU7dx/gpf5PhKpuuYb7Dr454Z60y2ROZ+fuf0nLZ8ahv7rUhFa1CV3BoShZl3kfPHSYtevWh+XXtRr6y2MeJDeviiecN0oNpQcpPV1CVhTb/+RgEuwqpKamQkZMkX3TY/c6uQeU+9Jn1oxULjdvpZGWloLZbHKEUriXmxsJGq2SQulSJVzyMHmqixY9SFevJ/DvgSMe43vDrTcoA6lyxXIULmQLXHv4gXZMHT+URg3qhKRiuYm/jSy5LfPPnGLLXx4kLd4sdrSqTegK/jruU2x2gykcv67V0F+B1tF+ntUqZQnSDiZRpNXJk/fX7uMB1Q1sz+HNf/zmZCDpXOpmx22Vv091Tk+3EGG0rX5MSU4mOjqGYsWKuhyTW/uBAegjYhk/8V3q173d8/caNpDsRrTzfZ1bsX8BBWl//d16j5/LssK36zbx1cL3g6pUbuP3ViOSqwcpJsNAym+5kNS0DYK/aFWb0BUc7luNgPMKn3AYSOrpr8C3GvGeKDIQnA2kUxeuck8Tzy/9HMuxShz491+63N8VvV5HudIleLBrF5rf3dD1QLdtUXLqM5M5ncgIA2lmKzeT00gzmbh5M5GlH09xKzZ39gP7ctX3vDd5GtMnvZllhaZ7XbS43Yhjjz0n7bkVcxWQgXTsxBnPX+h0PP9MjyCqk1f4uYrN6hqDZI+uz29B2mrYBiFwtKpN6AoGhayr2HQZD9bgpnO8kf/7y2MmbZ/qnfHSlWQPeZBs/w3khWy1ZvZDMJ4ASZZITk4GbB6UapUrsGz+lCzHuSeKzKnPEhISGfb660ycNAWzxYLZnLFRbZTr9FZuvaRNJjNpJhPlypbyeoyWl/nbDFq3VZhZcluFh6AyaWsFf7OqZqZ9t52XXz1IasnwGwha1SZ0BYeiZN2s1P5vWQm9gaSG/vL4AvchyNquzVN+N12mdeB3fawhCpaXJJm0tFRy3lHOv61GzOZ0295fimLLwm5OR6fTERHhHqieO9NamQHa3uut5Rgk+/6KHtNU5EcPkjMbf9/Glm27AB1tWjSmw73NQ1Ct3MXvrUasnqfY8lsMkpq2QfAXrWoTuoLDttWI62f2X9fhiEFSS39lzQ2UQTZNYtcmyXLWKbYg4m/sHqQIo4EIQ+BhsJL9OayTKVuqhPcD3YzBnPrMlOExUmQJc7rNgxQVGZm1DXMpBsluILkbaJ7qos0pNsnD1GLutH1Qd/bSr9ayZdtuHupyLzqdjq++W09c/DV693owVPXLJQIL0jYa83eQdn7YBiB8aFWb0BXUVRTFsdO3Hfu/wzPFlv/7K/DtJzKDtLN4kJzK9he7B6lgbFRQRquUkc+oRKySbUZu90SROfWZyZyecZiM2WzzIEVFZ93GJLem2HLKog1gj19WNLjMX5blrAsvcikPUlAG0obftvHpzLcdSw87tG3GgFfHq85A8nurEavrKrb8OsX2X9gGQWsIXcHhOUg7Y/l3GF4eau+v7Fokc6sR71NsgbSofQm9wWAg3ZoeQAk27MG73rJL23F/mebUZ/aYI1Awpdum29zjj2zl5PIUW3YepDAuRMhrPG0fpIo8SIqsuGzeFxkRqUoL1t06zQmr25ywPQV9Wj7bsNZfXWpCq9qEruCwxyt4unY4YpDU0F8ePUg+bDbraDcp6xRbUMv8HT8w9chS4H3iSNjr4zSdvao59Zl9is2ABUmSSUk1uSQptJNbL+mcsmg710WLU2yyB69wMOPPH4LyIDVrXJ8335lFz24dAVj9wy80bXxHSCqWm0iS5Egy5gtWt2X+9lVsqflsFZu/utSEVrUJXcHhKQ+SPoyr2NTQXwqBxSDZtUmShMEtuWIwOYCskozRaMBo0CMFM8VmN5BySPzorj2nPjObbF6t+LiL/PbHSm4kJLpsc+Febm55kLKLQdJ0HiTJwxRbLq0eDcpAerH/43z+9Q/MXfQVAK2bN6J3r64hqVh+xhEcmOHajY6KonLF8ui0NzYFAlUhK1m3GnH8ulahdzvc+NIiVknyOo0VyAs5OtJI6eKF0Ot1SEEYrXbvU06b3vobK2T3IOlR+Gf3PooXK0rxYkWCLjdQfIlBCnSMJ6ekUTA2Ol9vumyLQXKfYrP9N18Hacdfu8GzTz3Cs089EqLq5A1+bzXithdbbGw05y5c4kbizZDXLRjUsA1CoGhVm9AVHJ6mk8L5S18N/WVrE9fPfHkf+rLVSCBRSNcTU5AVhWKFY5EkOeAgcnu6FU9bUDjjvsw/pz4zZwRpFyhg8xpZrJZsY5DCbXf7EoMUiAdp7abdXLl2k+6dmlCyWKHgKhlGZFl25DKzk1tJOoMykF4ZOZkSxYvSuX0r7mvTjCKFC4aqXrlKoFuN2OeEozJunvwWg6RFd6sdrWoTuoK9TjZ5kMIwxaaG/vJsgORskNi1ec6DZD/G//qY0i0ULhjjiB0K1EDylGHZI27ziTn1md2DVLCAbRut4sWKUrtWjSzHGXQ6ypQojCHMcWgWfzxIfnRIusWKAly8kpCvDSRJlh0GoB1fpohDQVAG0qrPPuDwsVNs2rydF157m6qVKtDlvla0a900VPXLFfzdLsAquU+x2QL47L888gtq2gbBX7SqTegKDlmWs7z6Mw2k//ZWI57IzlhQFBlZtrWmt61G/DUQFUXBZLZQukRhh1dKkrJOofiCe7oVb7h7kHLqM/tzvGCBWAAuXLxM/NVrWY6LjorgyvUkChfMGp8USqy+xCAFkEnbfj8EM82ZG8iynNVLmEsxV0FHF9apVZ2Xnn+SxbPfoVqVCrw1eU4o6pWvkdwSRRqNRgwGAyaTObvTBAJBmLiVksrbHyz1uCQ4nKvY1EDgeZCck+J6yyLtX3kWi4SiKERHRjiMrkADta1um4Z7w9+cOXYPUqFCthkRSZIdK5WdiYgwEhlh5FZaeJ/7dg9SqDNp29Mt5PfYPNnjBtQ28nUMkslkZuv2Pfy6eTuHjp6idYtGfDz9rVDVLdcwGiNyPsgJu0VvcBqwMdFR+c6D5K8uNaFVbUJXYBw7foqSpcp4NAbCmShSFf3laS82H+wlozHCkfxWnyWTdkbRfs5xpGU8I6OjIhxTZIF6MOxB2u7xUV5xbDWSfZ/Zn+OFCsY6PisQG+vx2IKxUaSkhtlA8imTtu2//kyx2Q3M/G4g4TEPUsZX+TkGqdvTL9Ok4R3c3+EeJowaooqU+57we6sRt2X+YItDSstnHiS1bIMQCFrVJnQFxplzFxy/tL3lQQpHjja19FfWZdE5e4CsVqvDeAnVViOJSakULRRDuVJFuXQ1AciMJfIXxzL/HNrfPalljluNZDzHCxfOjMvx5EECKFW8MEkpaUF56XLCt0za/o9xu3cwPBnmQ4ckZY1BIsDx5y9B3dmrl8ygUMECoapLHuJfK1utWee+o6MinTKw5hfy+S+DoNCqNqErEM6dv4QUURzImggwnEHaaugvT8kzfXuVKznmGvI3BuTI6cskJqdRuXwJEpNTKV6kgMND4i++JorMuhw/+zpHRkbQtHEDRwwS4DEPkp3L8YmkW6xERYbHm5gZ85rzFNu1hGSqVCiZY5mKoqhnis3TMn/HX/k4BkkbxpH/2wVIHua+o6OjMvfwySeofRuE7NCqNqErMNJMZseL1ttWI+GIQVJ/f3l/weh0eq+B0IGmTpAzkkQCREYYuXEzheSUwFb/Sj5Psbl6G9ItUrZHx8dfY8eufRSIjSUywmb0ePMgxUTbvk8zWXystf9YLBYMBkO2Hipzhpfp36PnfSrT6uS1y+/Zt2VF8b7M38eq//b3YRat+oNzl6/7de387xvOBfxZQTFi7BQ+//IbIOsUmymfLfMPZGWIWtCqNqErMEwmE8YI20vKWx6kcPxSVkN/ecqDlGX/Vg/o9XqPPwYh8L3YJFl2LIsvUdT2A/tGYgpVK5TysyTnVWw5TbHZ/1JYsXItB46eo3O7prRp5Xm1tT1UIjo6iohII+kWCwUKeI5BisnYxDbNlE7Rwp6PCRar1Zrt9BpAqWIFMRr0REb69kq3T0dDaDyrcVcT2bn/NLWqleX2auWCLs8ZRfYQpO1jks7N23axeecRypcrj1X2X2vQd/f5i3Hs3X+EPU7/UxuS5LuL9+CRY45NaQ1uU2z5zYPkjy61oVVtQldgpJnMjsUT7vs2hTNRpBr6K9v4mGy3GrF6zTWUmSfSzxxycmbAbaEC0ZQoWjD4GKQcjFRnA3n77gPM+fgTlnyx2uvx9nx2MdHRREbYDKACMd48SBkGUpie/SfOxnH24rUcDfEyJYtSIDaKSB/j4eKvXWP1V8uB0PxwiL+RxOWriX57aHxBkiUPU2y+TRJfvhRHiZJlMKdnPBv8/EETlAdp0oxP+OmXrVSuUM5hLOh0sGTOu8EUm69xbmAXD1J0VD6MQRII/huYTGYiHFNsrt+FNwZJnfj6gpEkiUIFCxAV6bpZq3tuIV+RnbJyG40GrifeoliRwEI1vHm33LErtUoSde9qQeHvfuTS5Stej08zmTEYDEREGB0rx7xNsSFbib90lrgrJaleqbTfGnIiJS0di9WKPgeNYAvU9vVHQGpKKv/s2s2jjz8dEgNJlmxlhGOPNEUObLPaTX/8xcD/jaZ2nbr07tMXA0a/tQZlIG3b+S8/rJhNkcL5NwunL/izXYAkZ85fG/P5Mn81bIMQKFrVJnQFhslkIsZuIHnLgxSWKbb8318ePUg+LJPW6w3IikLyrZQsxwW6D5kkyxgMtpMz0y8E1i+OFXY5JIq0a7Vfp0TJElzMxkAymUzEREeh0+lodFd9zl+8Qs3qVTwem3D9OtOmz6BIzFBaNqnvv4gc0Ot1HjOZez5Wj8WafXyVHZPJ7DAwQxGbZ83oi3As5POYB8mHGKSoDO/fmdOnKVQgFrNF8vtHUlAGUp3bqhETHR1MEfkE32/QtNTMOCPnwEXbMv/8FYOkhhU2gaNVbUJXIKSZzBTKgyBtNfSXgof96Xw80/4S9Tpt6WddJFlxeJAyDdfA+sW+mjjHKTZcDeSa1auRmpLkdeoxLc1EdLRt+6gvF39I3NVEypYq6rFsu4cp0JV4OaHT6ZAlKceVerZjfTdY7WEiiqKExoNkN5DC4EHKbhVbdga+/TuTKY36t5Xjn0MX/J7ODchA+vq79QCUKF6UURM/pFljV8u51yOdAyk2z7B1gG+/BG8mJWMwGJAk13nR0iVLUK5M6XyVF8UfXWpDq9qErsAwmcwoGd5drwZSGKbYVN9f2bwbZVnOTMboLVGkv6vYZJkIp0SNer0u4FVUPk+xZdRVcjKQ//x7F8m3UihcKOv+oWkmMzFOMUfejCPInEWwWMKzik2WlYwYnJzHmE6n89nYsed60hGarUYyV8WF/geD7R7zPw+S84xOYaes6P4Q0Jv82Ikzjr+LFSnk8u+w+NjyETeTkqlUoRwPPXAfMdGZOzxHR0dx7sIlLl+5SqUKoY3iFwgE2ZNmMjleDlnyIAWQRE9LZBeknVOL2L1uWYO0A4tBkiTZZXNXvV4fsAfDbvDmtBeb3qCnXKkiDrH2BJAJiTc9Gkj2KTZfCLcHySpJlCxZCoMu5zbS+RGD5Jjt0IVm6lmy2vpCwbak/mL8Dbq2vSvg+DJnZFnGaHDNMeVLHiT7ljHFixUlNsY20+WvMRiQgTRm2EDAs+sr8WZyIEXmKQaDb82wYOm3FC1WjPb3NGXimKEu31WrUhGA02fO5xsDyVddakSr2oSuwEhLM4EXN384PUhq6C9FIesPVx9+yBoMRq+r2Bxl++kxsMUgZZal1+lCMMWW82a1l6/epEzJogCOmNmr1xNZvW4zNSuXptsD9zmOT00zUbRIYZ/qYF9+b7WEyUCyyjz9TF96PdAsx2P98cY5PEi60ORBcsQ+KRCfcJPUtPSQbYKreMiDpNfrKFOicNYM207YNc6YPNaxVY6/dQpqmf+zL4/N8tmwt6YFU2SeYHfV5sTpi9c5ceIU5vSs7tSqGQbSmbMXQlq3YPBVlxrRqjahKzDSTObMl7XXPEihN5DU2l+ZqYG8vxwlKTOo1asHyU/vgyy77qsViik2933i3LF7rOwGVaFCNq/G5asJzJu/kAlTZrkcbzKZHR6HnDDmggcJwOhLDBK+T3naPUh6P6blsr12RvUsVgmzOeP9GCKHracptgijgSvXk0jNJkGn3YMUHR3piFOTpFxYxfbjxi0oKCQl3eLHjVscn1++cpUbCUk+l7Pim5/4YuU6nuhxP08/1pVPP1/Nmp9+p1gRm4X/9ogXqV61YiBV9BPfGi0+3rbyoXSpElm+q1yxAlUrVyQu/mpIaxYcWp5S0Ko2oSsQTE77IGZxltiDgcOSMTj/91d2iSJzODMzW7W3vdj8rIstUaSbgRTkKracptjsMUp2Y6NwIdv7JSnZRKHCRbh61XVFm8lkJtrHxUf2TNuWMHqQwDWljDf0Ov89SMF48OwoisK5S7b8R/sPHQO9kSJFioTMg+RuVAOObV3SPTgr7JgdGyNHOYzkXJliu3zFZgSkppnZve+Q4/OyZUoyfeIwn8tpVL82J06dc/nshb49eahz20CqFTC+bhdw7apNd/HixbJ8V65MKc6cu8D5C5dDWrdgUP82CN7RqjahyzdWfvsjRQoXotN9rQGoUb0KBQt4zlVjf7iGI1Gk2vsruxbR6fTZxCDZC/C9Te0rpuzL/MG2Oi5gAynDa5PTFJvduLMHEhctaps+M5ktFCtWjFMnT3ArJdWx91qN6lWoUK6MT3WwxyBZw+RBir9mMzyMRh88SHqdzx49h4EUhIFq5++9J7FaZWRZ4vfffqVHj4eRCF1aDVnJGsoTlZEx3JTuvd3tHqSoqEjHGMiVIO3+vXsAtrncnt06BlIEALffVo1yZVw31itaOGvQXLjxNbvmjRs3AChSpEiW74oWLUxUVCRX4q+FtG7BoIZtEAJFq9qELt8Y8PIoihcrwqn9mwHYvfcA5SvXALIaLZn5dkI/xaaG/lIUJUtcli8OJL1en7mKzUsmY39szswgencPUoCZtGXP3i13HN6DDC0VK5SnRdOGJKekUrJUKVo1b0L81WsULFAZRVHYs+8glSuW96kOmavYQm8gLfniG66nGihYqLAP+81l9Je/U2xBBMlnlmVGkmUiIyJ54KFHqFS+NGcuJYQsrYYsK1lijfR6PRFGA+nZrB50eJCiozMNpNzMg9SzW0fM6ekkJia7BOuVLZ3zbsLeWL5yHfMWfU3ju+ryv0G9PboWV63dyOrvNwKZvwqtVgugZAQWSoCCTqfP2E/InmbcVpYs25eHGpFlCavVisFgzFi+7/lY0HHxwgXat2tDq6Z3oSiK07F6QEfpkiW4fCU+45eSjKLIgM6lXJ1On7Ec07kOmccajcaMXyNKlmP1egOKong91p5UzH6s1WpxPIyMxgi3Y93bRXE8qPxtw8xjdej13tvQ3t62PtNl297u7eJ6rB6r1erQ5rkN7ftyube3AVn23ob+tbdru2Qe60sbem5vSZKIjIwKYXt7b0PwPg5DNWbt7W21WjAYjDmOWV/bG2wvPHs/p6enO97WVqvkcn/an60Wi8VRD3+fEd7GrPM9lh/a21MbyrKMTqfLSE1i+6/9WrKc2YbuzwhZlki3pGfUyXaNTGNGyegDqyPlSU5j1v4y0+t1jmvqdTqkjPHhS3s7l2v32iiKnPEM99LeGfekPQapYvkyHDtxhrZmK4os8+ff/5CamobVanFM2RgNhow65TS+9Y7xZ0/xEqpnxNZtO6jdoCXRURFOer2PWRQlo3wl22eErCicvRBvq4Nej+QYA4GNWbvRodNBREQERYsUhEsJWCySj22Y/TPZPn5t91pmG0ZGGjGbrV7bJS0j11OEUe9IAWK12urk7Znsnk4hKANp0fJvWbT8O6IiI5yseB0bVs8PqLwHO7ely333EBsbzYi3Z7B+05907dQmy3E9u3V0eK6sViutu/bDaIxwWPPueYiMRtclgs6/YAwGI4qiOJ3r+djUtDRu3LhOqeKFqVK5gsdj77uvLTpsnW+b985s7Ozr4H6s0euxGWd4PdbZFavX612um3O7ZFeu9/r7296+H+u9DfV62eXf/rU3hK69IwI+1lt763S6ELZ3MOMwNGPWYLC9xLzfn4G1tyRJjn+b09OJj7vAgP79eKhTK5c2tMeg6HSZ90Ooxqz7PZYf2jvjDMdf9nghezsYjXoMGddyH2vO5SqKjC5jHY/BaECvNzjGrP16Or3Bqdzsx6zFHk/j1GZ6vQ6r5H4v+9Y3pUuXpl6dWkRERGZ7bFRUhjGX4SmJjIxk9qyZnI9LcEyRyYqC0RjhWIATGRWZ7bPTXoeMopGk7MZ3YM8IWVaY+PZYrp7+J6OfcmoXHYoCf+4+RsO6VSkQE5Xl2DPnLnD2ciLXbqZSuHBhDAa9Q7v3crMfs7Jsu7b9h0isPX5Lh09taCvXe7vIsozBYHCrl4GoCCM3U9JINVkoXDDG6dyMZ0KGB6lAbAGiIm1toSjudXLvG1eCMpBWrd3IZ3PeoWa1SsEU48DZ89S+dVPOnr8UknJzwpckXOkZkfnuexI507HT/Vy9kX/SHKg6gV0OaFWb0JUzDq9xhudJURTS0y1EGvVMffvVXM2krYb+8pQHybcpNoOjzdyTMQaSKNLzFJseOcDpqbbtO1GvYcscj7Nfzzmou0SxQpyPS3C8iO1TiZaMmJYIo2+vRvv52U31BEqmh9m3MWbXeejEJW6rWtbFQALY/OcOFiz7nvbt29GhY2cWffg2W3YdDXqTdXvgvX0o2OODgpm6i7uayPm4G9SsXBrFw1YjAM3vqskfO46w8uftPH5/sywxiM4xSHqD6zSrrwQ1gV6rRhWqV6kQTBEOzOnprPnxNyRJJiU1jZ17DnL7bdVCUnYosN8A9uh5T/iTqEsgEASGfUrO/l/7tEhkRITHhIj2h+t/N1Fk1uzivuLIg5TFwLL9OyEplX+PnCMlNedtlqyShE7numQ9mCBhc7rV8TLODvv1HAaHXk/ZkkUpUiiG0iVsAdv2sWTJmOqze5Zywu7ZCccyf3u7+Np3zn2kyArx15NITEpxfHYjIZHqNWqS4cgjKioCq1UmOSW4TdYlyTW3VUTGqkJ/jRFnDp64yJ5DZzl94VrGFFtWU6V86WI80LYBxQoX4LtfdmeJZXNdxaanVPFCLgsEfCEoD1KbFo2Z+tFiWjW7y+Xz1i0a53ju1esJvD7mfa4n3ESv0/HXjr3c3fAOBrw6joTEJNq3aUb71k2DqZ7PyLLkwUXtijnd1tgR2RpI4VpKHBi+6FIrWtUmdPlSlmuskf3ejIzyfG+GM0hb7f2V3ePKOeYoixcj4z1zIe46N5PTiI6KoFa17BPkyoqCorhmOjcEkQfJlG4hNsq7R99RVZ1t+sf+wtbpoFK5ElQuX4Ir544Cmd4le7C1P9tFRRiNYUkUKUlSRt19fKnr4MqVOMqUKUu6xcr6rfvR/b+9646Tm7q6R23q9r4u694rbhgbgymmmdBbAgRCAim0dJKQhJAEkpBKPggkgdADhA6hd2wDtjHuvXvX29vM7jTV7w/N02hmpBlN2Rqd3y/FOxrNu9LT033n3nsuKHztkuUAVIdB3Uyo52QZGixD5+TIqONUGaQLTlsAQRA1hysXBikUJs4NB0kyaDUCdR6VFnsxsroMLR0+9ATCKC70aJ8zDI2pk8bD7VYbD/cEwpbkEvTIyUF696O1AICnnn9D+xtFUZYcpMryUjx6351Jf7/6S+fmMqQ+Ax/1RlOF2GiKthkkGzb6GJIutKYu+qmfzZhQ5P/ms2mkg2T1pStpyd/GOkjEoXBZcFQ0NopJCLFlyyBFBJQWpW9loSYq07GqN93LltXYDsIgqfYQfSMr4Lg+YpAUxXJ4DVBZo3fffgtfuuLLCIR4KIqqdE5CrJEID0EgzwobzZWldX3UsgNRRy/wqLlHgRCv/T0bbNl9BO1dvQBiVY6proPLyaG5zYdwREBUQhGAKke0/9AROJ1qqNHpYA1FnlMhJwfp3t/fmsvXBw2stAsgITZHCgeJylNfm3xhKLRByBbD1TbbrvTQL7yBYDAWYjNzkHLsGp8KQ+F+KUjVi818vWIY1rTM3+ngQENCY1MXSkpLDXf4idCHuAiyFSoUJQmiJMOVgtHXg2VoNDYeBUvHNrv6sRDnjTSdtRpiA6IJ6H3EIFm5rrHjRUSieTfd/gDcTg6hiIAIL8Ll5BCORLTNhCNqH8PQWtV1tkwoYZAIyP/P9l24ZVc9+Oj1lCQFskkOEgEJ6YkJqvY9Pb0oLCjQ5r7TwSEQzCycmPPTvWX7HqxeuxEU1NDazGkTcz1lv0Othkl9KYjn6UyxU9JyHVI0h+xPWLFrqGK42mbbZe1cBD5/jxZCM8sP1IQi+0D1esjfrxSXJFWrkeICNxSK1cJjVphz0uZB/zKlsgyxRSICKIqylINEfnPzxk148aWXsfzYpwGo4UDCTBCmLKsQG8eiL4QiFVlJK4KpB88L4KMO0tY9sZZX4YgAl5NDhOc1B9DBqefVO4hZO0iyHHcf6Bw3JDQFOBwseF6ELMuq85ZCkJWEzUiVJEFPb0BrKwOoDFJHd29mY8no6AS8+tZH+OXv7wfD0GAYBrffdV9c65Ghg/QPKPG8U+0sYh2uBwuLNFjG0RcYrrbZdqU9k1auzeFIfWMsB8mEQerLZrVD4n4ZVbFl2Goksd8Zw9C46PQFOP3EBeQn0sJI2JGE2DJdM0VJhqIoaUUi9eMlYTB9axLyfa2KjYTYLDJTgJqDJPRRFVsmDJIoxMLNepAqtUiEh8Dz2LJ5E/xdaleIbAUU9TBjkKQsGSRBklEYDddJsgwlDbtFZEKIzhVBT08AhQUx4Wmng4tqp1nvn5iTg/T0C2/ggbtvx9evuhjXXXUR/vmXX+Cp51/P5ZQDAitsD6HxU+UgabkOg8RBMqXVB8n4csFgYOj6ArZd6UF2+zwvYPuuvZqDZMbu0n2YgzRc7xcQFYc0aTUCAKXFBVopuSUGySAHiM5yU0mOtsp6lBV7td/VOz+EoSGOIEm2tlrmD6jiiH2RgyRlWAAgiiIifCyEVOB2oKaiWJOeiUR4hMJhPP7ow3j/vfcBJLdhyW6ccoLTmz2DJMtKtDqR0/6t9mKzEGJLdJB6e+MYpKqyIhR53QiGrIfZcnKQJFlGiS4rqqS4MG8N6voTlnSQ0iSCArqHfZDkIZnZ9aNf34c/P/hyP48mvxgK+jPZwLYrPcjLrLa6Eg0NTWkLKPqSQRoK98s45J++VYiqwGycg6SdheghWWDSNDaKNnqZZrhmKqQE3trhPYGwJkXgdMYa0dIagxJ1uqNMEJtBDlJfhdhkWUli7lJBEEXwkYjmbK44fhaCYR4NLWqLrEiERzCglv2Xlqrtstgse5TpkVjmH7ummb8HSe4RCdlJsgxZkUGlcBSJgyQk5SAFUFQQc5DGjaqAPxDCFl34MR1ycpCmTRqHP9/3KBqbW9HY3Iq/3P84pg4i7SKr0LcvMEOslHjoMEhGdgWCQYR5ER5P+uqPwQwr92wowrbLyrnUhdDl9uJIczf2HW4GYB4WyfolbGksg/9+Gekg6RRzTL8nSaJpDpJ2Hiq9o0VArr8h25Apg6TE/3460DSlsTx6MkLLQdKStDOvYuurJO10uTeJ4HkewWAQLY31oBQRhV43KEBLTA5HIggEVQeppEjVf8q2iSuBoiiaUCQBkwOD5PP1gFEiUKSYVEC6BHLWgEHieQHhSCQuxEaOy2RcOTlI3/nmlQiFI/jazb/Atd++HeFwBN/95pW5nHLQIhQMY9aMKSiNdoI2QixJu79GlTmam9vgcjlB0bYkgY2hCfKinTCuDpIk4zd3/QVAegZJ6QMl7SELjflJDa2KzYzJyEBRO8ZGxTwUr8uJyrLCjF/Q5PesBjhpioYUfYHq80hjScrx/d0yC7H1TZl/ponToiCA53n4O5twzcUnw+XkwLKMFj7jeR6hYBAAUFyiMkjE/mxDbEpU2yoxrwzIbkPS1NKC733/FmzfthVAlEEyaFarB3F89EnavcEAli5egLFjRml/y6a6LqfyC6/Xg59859pcTjEoYIUm33/oCLZu343K8jLTYwYbg2RkVygcQU+Pmsk/WKrtUqGzuxcuJwdPgmz+UAhtZAPbrvQg4ZApk8ZAEES88cZRAObsbl8KRQ6F+6UoimVHQg99qxGzFzWdAYMkGbBRgiihrbMn45dpNgySqCVgx9aSpCRtUsWWQYjtisu/CCGDxF+rUBTZchI6EBv7+LF1sf54DI1QmEdzSxs2bNqGMK9euOIog8QmMGiZQhQl1FQUo1DX5oOmKZQUejJKMCcIBFQHjvRzkyU5LYPEMckMUigYwZpPP8PsmVPjxgVklpCek4MkCCLWrN2Ito6uuB3EJeednstpByW279wLiqIwdcoE02OyTTjsT4iiqO2W1OS3AR5QCrR1+vHf9zehrNiLc09NLz5q438DMW0eBtUjYv0bTdsA9aNQ5Je++m188NEn+O+z/8K8OTP6/PesIOVGKM0lMcobMj5NBknaupd+tlVU5Pes7u/UprhRBknHDiWW+ZMcpEwYpJoRdejStfTIFzJlkLQ2KQ59M1aVQdqybRe2bt8NhmGwe+N7Wm5OrlVsvCChud2HyrJYLjLHMOjuCaIiXJjim8bQHCSvCyHEmK2UITaGhtfjjKMTw2E138ztijnD2QjG5uQg/eC2P6KppR3TJo+LSXgPckbCCFbaBXT7/DjlxCXwejymx1CDLEnbyC5RjOUVDBamywy9wQgEUTLUrhjqLR7MYNuVHsTBZxgaI0dUAwAmTxyHKZONNy+56rKkQqJdBw/VIxgKo6Ojy/Q76zdux47d+3HO6SdqybJmeOixZ/H3h/6Nfz/4F4wfV5e3cVMWOCV9q5F0OUhW1A6MEr5JuC3zEFvC76cBTVNavpi+H5fWyDYqGxATHbWeg8TkoV2HEeSE3J50MCpWYBkGoiShsDDWc666slz7PNcQW5hP7lHKMDRomtISrjNBIBoCLPB4EArGWKFUbBTD0AgEI+D52O+FwrFGtQQURYHRKapbQU4O0tGmVjz5z98NbaE0C1AUBes+24RjF85NeRzJpxvMjocoSZB1rRoGM8IR9eEbzNfTRv+DzAeGYXDconm45spLUFpShGmmDhLJQeq7edTlD6C4wA2/Xy2pbmxqMT324X+/iCee/A9mTP03FqRxkF7475tYvOxkHGzuwfgs618MGSSL1WdGrE/caTJIK9CStGkDBinLHCSroCla622mb1tB/n97Rxf++fhLaGxsBJCZUCTDZPbStQpZTl29lQheSNYDY1lVZ4psKhLnAcPS4FhGY9AyBXFK9EKRFEXBwbFZOUi9UQbJ63GjLShqrF/KZHWDPLgYg+SKOzTT5sg5eTbz505HU0s7Ro+syeU0A4507QLaOzoRDIUxZvTIlMcNthCbkV2iKGkP82Bqi2IEInBmNM6h0OIhG9h2pYd+sR9RW43f3v5DTazWCNlWSlkBw7Do7gninTXb0NbRBYeDQ13dGDQ2t5uPP/ou5Szkl7icTkiiiKPNXRBFKU7k0CqMHCTtXykuCcOwFhgk7UfSjiPmbOma1WYd4sms0z1FUxBFCQ4HFzcXye83NrcgQhWgu9MPILNWI0xU7DKdXk+mkDIVihSJsxLPIAFAOKxuNk85cUncd1iGhiBKkMT8MUgA4OTYOEbHKkiIraDAC6rDpz3rqa4DYUP1M5AwSC5XYu5qZq1tclq1vnD6ifjWD+7AmFHxXZzvuesnuZy23yHLUsoFvL6hCcfMmYHJE8enPM9gc5CM7NKH2AbLOM1AGCQAaG7vRkdXL8aMLEeBx532ng1V2HalhxaqiS7+6cIhfamDJMsSGpo60eUP4uM1q+HxePHFy69AYXEpREky7B5OnAFJSr9rj/A8OjrasHbtOhxtbMSZy+dh7oz8tXNKtQLIshQLZ5oko1MW9JQIjPKZEnuhWUUsxGbteJqiIEkSOJaNm4vELkEQse7zTzBxgrrGZ1Tmz8TmVz6T9tUQm/XzfeuaS3DJeadjZG1V0tgIu/SFM0+J+w6Zn9mG2CIGDBKg9noLRZJVvdMhEAwBALxeN2i6R2OQUjFplAGDFIn+drKDRGekz5TTinXHH/+JU088FrOmTzZcCIYK0jkKBw7VY+Pm7bjpG1elPG6wdQ03sksUpSGTgxThBVBQF/F1mw+gud2HTzfvB0PTuOKcxQM9vD7BYHdas0U+7SLhAKsVPn1ZxaYoipYjt/z4xSjxcJgxdSL2Hm4x9T5IxZMVp4DnebQfPABuIovyimPgcrnTfsdojEmehAXPQlEULSHebAefiVAkAFRXFMW9K7JO0tbK/K3nIMnRvnn6uagpSQsiNm/aiI721ujx1kNbejXqbBg+M2TKSBUXFaC8rDTub2Q8xJFJrM4jDlQm7Tf0iAk7xjuUDgeL7t5gxufTGCSPBwxNQxTTJ2kbaXGFTEJsTH8ySE6nAzd//YpcTpE3HHrnu2CZ+Mk04rgfwVFQC763CY2f/Nbwe2NX3A2AQqBlI9q2PJz0OeetxuF61SOfWHwUh96+OekYT/UcVM2+BhRNYQK9Cl2fPgd/gsNYMv4MlEw4EwBw9OM7IQSScxQqZ18Nb/Uxqj0Gv5OZTUCwdTM6tz8W91lNIIBLZ/NownLIsoLu/a+j+8AbpjYBQOuWfyHYsjnpmL62iWtsxgyagdvjQT31LfU3lUMYr6xC/fvPxC2OnLcaI5eozOVgtkkPcp/0c0+Botk1XGzS25UPmxyRCC5aVqQtmulsomkKT/14NGrYl3Ho7Q/yZhOxyxNworbyS/jCySehezGDo9v/ihJWRP17L2iLN7Fp14EmrJjUhMt+PBreo/fgUGfM4TG6T7esVHfRo0a0IhR5Aor/MgBqqN/qffr5BRFIkivu+Kplv1evZWgPDr19b9I5OG81qhf9ELIi46JlRajufgiH3n467hhP9RxQVeep/2h4Dof270s6j94m7sg/MUbsQOtqD0iQjxZElFILIUkzM7JJlCQsZMPg9jlw6Ij6ck51n2pCEXx3pYTbnmABUNrcqw4G8dSPR6OkeBtO/dEo1PsKcfeLNfB63Jafp/KOI1jIimj88HnNGc/H8/TrSyX88DHa1CYgfo3wHXwTPYfejvu8KMJjAl2LtojaM28M8xkOvf2e9rkkyVjIhkC1LwdwhWaT1TXCEeGxkBXQ89nzCNK0ZpOH8mGu8hgOvf0sEtWqUt2n00e3Y8S1NfB6VZmAwtBaPPXj0Sgu3hd3HfVrRNvWh7CQ/RhcG4NDb6sO0ZhQDy5aVqQxSMSmGWIQVC+FQ28/ZmgTGRtBTmUlZ61YhjfeXY1AIBj3n6EGs9wFgkOHVWnysjQJlVqILT/DyhlGXreixHZfg52tUHT7UlIZqJX3DtCY+hq2XelB5q3VCp++rAqUZQWyosDttLbX9PcGMxKSVRRVJC8mhpcfvZ1YDpL5YBiG0bFcqRmkdKueLMugKCrKHiWfS8yS3ctkXimKApZl49b7xAbjM6dPxrZ1b2Lh/DkZjMF6JV8myKQZL2A8zzmWAcvQaGjpiB5jnKyf7yRzj9sJhqEzmuuhCA+a5TBh/DiUlZZg2vhaywxhIkgUJ5FBUiMS1gdF8Xwk69t6xsXfgL9H1X+gKCJpD6x5/bE038wfRFHEspVXY9WrD2ddTSeKAljWPOZ8w/duw6frN2L9hy+lTArcvOsI1m7ej/NOnYeq8tTOVH/AyK4X//sWnnjhXaw47QxcfOYilBYN3pYjl151A9xFVVhy/DKUl3jR5QuiuNCNLn8QV52/BE6HM/1JhhjSzcWhinzatX7DFqw490r86qffxY1pwt4A8OHqtTj3suvwp9/cimuuvCQvYyBY9fE6fOGSa3HHbd/H9deqXQQ+Wr8buw404qrzj08KPXywdice+fdzeOG5Z/DSU//Aiccfm/L8C088FxzL4rUXH8N/XluLudPqsGi2uRabEZaf9UV0dnVjyyexRuKhMI/HXlqDaRNGYNmCKYbfE0UBDz76DG75+e/w6rP/wtLFyVpkjS1d+O8Hm7B03mTMmBQrYnnzvTU42NCB8848HjWVZeAFEQ8/vwpTxtXixEUx8b7Dje14c9VWLF80FZPH1Sad3wxHW7rw6gebcPz8yZg+MXXxDACs+mw3vnHDd0FDxsbVL2tz8eO1n+OsC7+CSy5Yif88/yoef+DPOPuMky2PAwA+23YQn28/hIvPWITS4vytpwtOOAcOjsPH7z5n6XizZ+yBZz7A4f278X/3/A2P/P2POHflqdpngWAET7zyMWZOGoUl8yZlPMa1m/dj864juGzlYhQVxNjQVZ/txs79jfjyecfD5bT23L/24SY0NHdh4axxOGb6WGzdU49312zBL372E1z1pQtx910/N/3uP//zAcaMKMdpx88CAPzjoSfxw5/9Fv995kEcf9wC7bjn3lwPQZRw2UprKRo5hdjeeOb+XL4+ZNDa1oGjjS1pKya0ruGDmJgRRUnLKxgsuVJmEEVJaw8hijIKC1yoLCtClz84aLSmbPQ/NHVnq7vr6GPbF/O9oVHtAzdqROzlHksaTT4+FOF1vaOs9YD0ej1wRHNHIllUBhnBanJzTP3ajEEirHnM2Lc+WI/H//Mqlp20Alt3N6C8pEhLAk5kRLLV4cm4zJ9Wk7SdrviXNRkPaRWSTQ5RPhq+GkGWlYzK/M2g5vIkt1kBVBkAAFoydKbQcsESJlQ22mOBII+iAjeOmT5WHRvDaOdPl4tFCBqCw/WqXIPboIotE7YsL9zzc6+8nf6gQYx0lQeiJFqiOgebUKSRXXFVbINknGYQJUmncCvCyXGxBzGDJo5DCUOhdUU2yGurEZI4bHEO9GWSdmOjmquhlzpJDNsQhMI8uv1BuKLidVZeqJEID6fDAUf0xb1zfyNe+zA5LyYVjJW003tINM1o18wsDcGogui9VZ/i9Tfewuuvv4pOXxAtHX7tBU1eyARaq4+MW41kVuZPUzTkaBWbfi5qrTbEZJVtq9CcvDzPLznDViNmz5jaZkWtCE4spsq1io3ct8TbEHvmrN/XAq8TNRWxyAtNUToHKfV1oChKc9IVRcG9/3gUQHL7ISLJYBV5ecu8/MYH+TjNoIUkyWAs7CxizWoHr+MhShLkqNMx2KvYRFHSnDiHg8XImtI+1bSxMTSgV9K2gr4UipRkGdOnTkJtTay0WpMGAvDof17Hb+59Gp9v2YWNOw6jNxjG9AlqSMjKrj0S4aPaPbr+ZRkK8KVqNZLukmhVbGaOSEIFkSwrCEZkiKKAvbt2wtcbQlNbt/YCTnxBxxikzBgMMuxMWo1IkpyUhsEw8WxeJj3YYufoGwYp01YjZqBpWstdS2TIaJoCRWVfxaY5MIkClExmfc8URUF9Uyd43TjUykMRLpfTtBE1AaUbCynxLystQUlxfHP5THWQ8uIgDfV3lZxGRVQUJUt6FIOtWa2RXaIwdFqNyHIsxEZTNAo8Tu0aS33QPXswIN1cHKrIp13pWI1ExOj+/M/3Q4frsWPXXhQUxHJPKF2MrcvXg/379+OD9XuxY18DxoyoQEWZumhbCbHxvMogURSFC05TcylcJk15t+9twGMvrcG2PQ0ZWGB+TfStRkwZJO000ZcTL8AdbcdECD5JkjWnlk1watksGSRkyiDRFCRZFdrUz0VaK3NX7wWXRZ5ctlpO6aBk2GrE7BljdG1WEh1EkjifNYNkEgLTtMcsvmNihRfxbWBkWUE4HElLeFIUpfkh4YgqEnn2GSdj9Mj4vDYmQx2kvDhI37j64nycZtBClq0p2A42B8kIathqiITYRElbCLv8AVSVFQ86MU4b/Q/tpZ1hFRvJXcrvWEjbE91YdDlIsiyjqakZGz/fgNdffRl1NaXaWmJlJxvhBS1MUFFaCJqmTKtw/L0hhMJ8Uu9CRVGSqoGs+BWKoqC7R61KNsuFieUgqQhFBHg9qrNIR39TlGRNzyaRQeI4BiOqSjJeMzWhSKs6SFGhSDZBrFQTijRhWKwg14avZkjXxd4qGJrWWEejQia1l1yec5DIu1Cydl+N+vQRpxZA0n1LAhUbS9igD1vsnHT/MEjhcATNraqc/pJFc7W/P/zkS9mecsCQTuFXZZDSX6rB9vI2bjUiar3YBrMjB0TDgboxul2ctlOhqOGZqzMcVbSBfLcasdZhnqBPhSITfgPQtz5QIMsSQsEAPnz/PfzmZzdh8vgRurAOEYyUDLvBS5KqZK2vhKNpOsXGRv1d0v5BG6NizrSkWgKa23uw+4Ca7JquF1vs5cTD41UZJEVTDJe1EFpiDpLH5URTWzc6DRpSp4Im95FBiE2OpkoYtRohDkI2OUgsS8PtcuTdQZIydJDMnjFan6RtYF9lWaEpK5kOspmDRGcWYpMMNhp6Ucd0rV/0IT7CICWW+JNx6XvTpUNWDtIHq9fjzEu+hcu//iNc/JXvYe2Grdpn769el80pBxTpFk5JksBYeHA0Zn2QMDNGdqk5SEOj1YgoioDOBpczlqSdbdXFYEdfvMQHA/JpF9lVWq1iczqdOG7xQpSUlORtDNpYtG7jOgcpgUESRRF+vw8Tx48BTcd6xpFF+qHnVuHZN9bF5RYpioIde+sBxDcfpSnKdGNDWJCm1i4cbjTvBQdYY15a2n3ai9Vsg5iYpN3a1o6SQjdYltHCjqIkmecgMTQKvW74ekNpx6NHrNWIdZ2cUCiIstLSuLmYeC+yyUGiKRqhMJ91PzMzyLJsvVIT5s+YmqRtXqUXjgho7fBnNUbyrkvKQcowxCYZsMI0TWs5cOnD6VRSDpIRgzRxTDVKizxo77LmkGflIP3z0efwtz/cindfeAA/+e61+Os/nsCLr6nqnIP8nWsIJQ31LkqSpYTQwZZAbGSXKIhDplmtPqbPsgxoms6qfHQoId1cHKrIp12JvdjSYeTIkTj/4ssxY2ZM/G/dhu1Ycf41ePw//81tLAZtT/SsiixJEEURDMNoTpRW5h99KStQoChAW1ePdg5ZVvDuJ9uj54sPO5g9t5Eoc0TTND7ZGFO1VpO0Ew624FeIkpS2iiixzcOGzzfi+9//IZ57/D6sefs/oKgogyQa5yABgK+jEXt27cTL732OhubO9AODbnNn0T/y+fyQZRmlJUVxc1FLEtfGl02ILTO2xCpkWbFcqQmYP2MMTccYPAMH0Ot2IhCKZJVDZeaoZrpOa6ywrhtGXIgtTehTX+Zv1qgWAIoLVB29Q0dTbyC0MVg6KgEsx2DaZLWp3zGzpuLvf/o53nx3DR59+uUkYbShgdRPmSTJlh4cs/LegYOBYq0k6UJsg/tlLEkSeCECmqZQ4FYn+1DI88oNtpZ2OmSag0TCOnoV6pb2DqxfvwF79x/Ky1iMGSQ1xCaKYlyIQF9aLsuytrDr1w056lw5nE5QugIRmjKvwgnzApwOFtUVxegJhONeeKYhthRJ2pKkaGtEuiRtMvaubh8AoLi4CBRFaWrcGoNk8KL7bN16tHb40dzmQ0d3T9LnhuOODtu0ui4BnZ2q41VZWQH9XKQTQ2zZVLH1UZK2JEkZ9WIze8ZoRscgGdxHT3Rt/dezH6K5rTujMaZN0ra4CTdkkChKY5DShT4pSs8gmTtIHrfKKlnVE8vKQRpXNzIurFbg9eDPd/wQGzbtwJ59h7M55YAi3U5UkkRLu1Wi25Dvd/e+g/W446//xiP/eT39wToYjTmuWe0gZ5BEUURLUyNOPW4GLjlLVRwmCyI1THWQrLIiQw35tCvTHCSOjc/5UZEscJgNSH5PvAMSS1xW2RMRnK47vBbWkSXwghR3LgJZllFQWIin//0w7vvTL7S/07R5iO3D997Grq2fo7ayGEVel5asbbRhowDUVBSnVDmWFUXLIzJzRBKTtLt9aqimtESt1FPZC10OkgGDVFjoBXm/Ws0ByvS+tXeoDlJVZUXcXNTywbQcqRzK/POug6Rk9NyYHcvQdEoH0B2dAwrUcFumYwSSHXAmSwYpMcQWY5DSOEjQ5cERB8mZ7CARwVXeolRGVm+Z737rKm0QBC6XE3/45fdx8XmnZXPKAQUpgTT/3CKDRFP4ZM1q7DvcmK+hAQB8/l5UVtfC15NZnN7ILlESh04OkqRWD44dVan9jexUrJRID0Wkm4tDFfm0SzYIa6WC1sdMl7emECcmx02CKIpJjhoVo1UgyxIkUYx78euTtAXdPNZvWMj/5xLWHYoyD7G9/e4HWL1mDYoLPPD1htBOQnYGOkgURaG53YdgiE9pW/oQG/mJeAaJ6M+wDA1JUvuwVZUXGd6zwgIvakao2lCWnYwMc5BOXrYId93xM5x28tK4uRhjf3JwkOg+cpAyZJDMnjE1B8m8GmzO1DocP38yACCQYj4YwUxji9auibXnKyYnkRBO1phHCwxS9P9HwuY5SDRNg2MZLRydDlmVlhQVenHikgVJf+c4Flde8oVsTjmoIYoSnAbeaCLGjKjA2StPx9EWX15/X4qqoOZjFy4KorYYDHYGSRKlJMd08IUxbfQ3YgySteeBNagaC0UX0Vxzo9RS7GTnQz23+puiJILTJVrrE4MFHYNEduOfbTuITTsOAUh2TIg2jBECgSBG1FajtNiLqvKiuKRvIwdJHWOKEJusaL9ldlhiDlJ3tx80TaMwmqDNMGr+SySaCGy0hhUWFoCLVhxZDVPFysstHY6J40Zh4riLAEBTlVbHl7uSNt1nrUZkS/p76aDPQTISPGZZBrVVJQCgyTpYhSIrhk5c5jlIRAfJjEFKcx10Zf4kBymxzQiB08GC78sQWyrc9OPf5PuUfY50VL1kUQcJAMpLChEKR3D/A09g4+bt+Rge+Ki3a6WSTg8ju4ZSFZskSUkLqtWcg6GKvuw8P5DIp12xvB/rIoEME1MTbm73Y89htUVIrs+AoihJLzHDHCTds6tP0uYTKtcANdma+EDJuR3mIbbe3iAKPGrfttYOP3y9YfW8BuGomOp/sj1qD0QFkiyjvKIc06dPA2eSW6p3tPy9QRxqaEZBgTeWkB5lkGI5Jsn3rLDAq21ArQoWZqqDpId+LiaGx3LLQcrveiqbOB9mMHvG1Gqw1A5goceFutpytHX4LbMrQHoGKdMcJL29DG09B4mmKI1VJDlIZqSGg2MRsRhiy4pB+s+Lb5p+1m0xyW5wIU2StgGTYQavx4Xmpibc89c/Y+rkCfj0vedzHp0gqLvdTFRVVRgkaetzkAaBgySKIvYfPIIpk8YnfyZJSTseSqsU7JfhDQCGqwOYP7u0l20GjCrLMJpYIUPTGvuk5BgWkYwYpLgcJNVB8rhiStvaC1WU4lorkJeJ/nxJDhJFQTRSyBdFhCMRFBR4dNW0sY2QGYOUuAY8+8Y6dPmDuPSsYyFJCpYtOwEP3f2zNFdBdcLaOntxwvIVqKuJtXdgGBoRQTRkCAgKCgoQUDJrOZIpgxQP/UuYsHmZz6nYOfqmik2SpQyb1ZokaUcb9QLmTAzLMigr8WLTziPoDUQsF1vJimK4aY3pIGWYpJ0YYpPNma9EkI1AqhwkAPB3NGHVx2txyZmL0m7cstrWPfDY8/j0sy3Ys+9Q0n8ifGYxzMGAdG0QJFm2/OBUlRch0NMFQE0+zAd4QVBzHTJ8ePV2KYoCfyCELl9vrBfbIPAyWtt9OPULV+Kyq2/S/naksQN7DjZBNHBMycOYrfLrYMf/UqsRf28w46RQIPNebID6EguGIohEhCjrkx91bVlKXhviGCRJVHOQdMwEYYIlWcaqVR8jEvBpxwPxLGniy8eMQeoNqKGRAq/XcmsVfeWP9rfod0NhPsrgpnmBaMaqVYLjxo/HytNPjtka7YGWivXzeGLrpFUtoZhQZOYeUmKrkRG1VSD0Q1YMktYuJf9l/vlpNRJTj06Vy1PkdQMAAuGI6TFJv2nCIOUtSTujKrbYv6dOHg+3O1koEgAOHtiPF156Fbv3Hkg7rqwYpJOXLcJpJy/BvNnTkj778rduzeaUgxpEx8QKxo6swFVfugCPPfZ4UqO8bBEO8xBFES4uewmF9s4evPrRJjQ0dSASicDBMlrIgdiXzWKTK1q7eiEDaG3r0P728ca98PeGIAhicnNFOwdpWKA3EMZH63cDAE5YOBVFBW7L342V+VvfMIiShGCYx+c7DmFUTVls55jjPDLa5VM6p0EUVQaJ1fX4iuVEieAKKuFv2otKb3GsM7q+DD0xB8kkSTsQUAs4vF5PUid1tdIueew0RSUlqZMXFNHFSeuE6pxBXlCdXYdDH05k40NsBucrKSnCnoYjKC0tyzzEluOa5XG70NjUqvXsyiYHKdZwd7C2GqEsJaGTcv9g0LqDpCgKjKKAmYbYjFr2qHPdYhWbLgfJ5+/Brj0HTJ3dU046AaWVIyAqFrQNLY0+Ad/51pWYPWOy4WeXnX9GNqccUKRrg2BpodBh7rQxcDo4LX6aK3iehygIGdKt8XbtOdwMnpdw9ZWX4g933ApeVPMfjrZ04Ss33IaHn30PgZD1ByNfkCQZXo8HPb1qSTIviFoMXJKTmwSTHS6GbZn//0arkcbWLjS2dqOxtRv+DFWUtQ7zGeRnkBeqg2MhSjGF4lx3/YpinhenQIEoiUk6SLH2Fgp8vSHMnDFdHUt0kPqcISN9GaOXTm9AbVUSH2IjDpLxLp+ikxkk4lztPtgMyQKDoU/SJomvTp2DpIr9ybrwYfL5Tjp+Ib5/7fkAMk/Szgb6uchxHDxulxb5yKXMP58MkioXo+Sl1YgkKxBFEaUlxSkdQLeLQ2mRB2IGdiiyEluTdSDPxNY99ThwpCXteWIMkj78qZMnSFvmH2OQxGh+kcOEUJg0aQIKSqtBM+kLr7J6yzgdDtOcnLNWLMvmlAMKK61GMm1iyHFcXAlvLojwPARRzHi3pLero8sPl5PDRSuXYdniY6LnFbF1dz2OW7Ycokxj94GmvIw3E0iyArfbg26fmru2acdhjdmSDHKQYiG2wS1ymS2Gq0J4ol2CLpSSqc3kucokX+SERVMBkJeFpOUg5Xq9jUNsMZZTMmKQyGJP0WBoGgUel3Y8GSOBUYjNyDkIRENshV6vdlw62ygqOQeJ49RXQkNzpyqzkWZjqBeKJOJ7Tr0zGHXojF6AiXZRVOYthLILscVfl+KiQvC8kDWLTnSwMknSVhQFnb7k/nuJY8xkY252v5fMm4RvfvWL2PTx64al7wQcx6LLH0wp/ZD0myY5SMSx7gmEcbS129J5vB5nnEOon8PpcpDUHG31+hMm08zZJXPaylwbntvwDJGu1FeSkpmMdOA4FoKQeX6FESIRHqIoZFyxQewSRRHXXvdNvPPai6AoSkvAi/ACegJhFBd5oWBgXs6yLMPt8cDv74EsK9i8+wiKo+EWtfu2SZL2MM3V+V9pNaLfPFhN5ASA7Tv3oCtE43vf/z5mTp9i+Xu1FcUAVIZSlGKhi1z1tEQ5WatG34tNEPiogxTvNACAQqkiii6n+hlhWfTOv3GILXmO9AaCWHLsfFRXVWjfU2Qdg2SwdhBhWz0URa81lp451wtFksogfYiNfJ+wEmYOCFHdthqmigkUWjo8Dolzsbi4ELwgYNqUCZmfLAqGpjJy7nbub8JrH27CvsPG7IomZZGHViMcy+Cy809HcVHqnNhEVXRrv2nMTjocLBycunaT/00FQZQQCEbiHHK9g5S+zD/GIJG1xWGSaJ7Y6icVBtRBevL51/GFL96AJ555FQDQ7evBjbf8Bpdf9yM8/kxuPZIyQ+qnzKiaKh0cHBenQ5ILIjwPURChZLwaqMfvP3gEkQiPcWNUMTaGocEyNCIRAR63A2XFBQAGpqpNkmV4PB4Iooi2jm4oClBS5FV335KctAsgu5VBkF/eR/jfqGLTvwgzqf7Zsm03PvxwFaZOGIXyshLL3yMKuoIgRhmk+B5c2UIxKODQqtiiDNL4CRNxxWXnap+TteTVN98HEEsM1hikOAcpwfkySdLu6OzCx2s3aC+FpKa2RiE2AwdJ7f8VY2mth9gUOFgGNZXFcZuaWMWeeq5UDI0qCZD+fhApAiC7Mv/EuVhUWAg+wmtNTrOBJCs42tKF/RbCSQBwqLENwRBv2ntOS2rPgEHKde2IObvWF1f9fNHD63ZqkQAreV2iQZUdRVHo9XdZOgeta8YmRFM0zL6jMUgWCgJycpC+/ZPfgeeFOEfguVfextlfvB5btu9J+/15s6Zi0fxZ2r//9cQLOHHpAjzyt1/j9XdW40hD/4R80sWdJQMaPe05OVaj+nJFJBxR2agMnQJi16tvvI8lx87H8hMWa585HRzCvICjLV0xp2MAvA5JUlBWVo4VK07DN759KyLBHtRWlmgLd+IOlow1k53VUEI2ORB6tHf2oLXDl/OLP99ItCtOIDGDcGkoHMKa1R+hssR6UjegziOKosALEkRJ5yDlWA1p9ILQsyqyIuPA/n340oVn6cairiUk7EZeCqSiTu8wJofY1JBVomPT0dkNACgrLYkeF9t9mzECRqrcsixr44/wAgq8qa+zvmKvvbsX/gS1f73OkL4RqRGqy4vgShECIujs7sW6LQfifj8TJM7F4qJCiJKEqsqKzE+mIbMqODrqzBxsaENja1fS52QuZJKDlOvaoS8usArSaicRDENjxdKZls9DnBW9c01RFN595x317xZsI8MmDJKZdle/MUg7dh/AOZffiDMv+SY+Wb8ZAPDpZ1tw03WX4x+PPpv2+1MmjUNtdWxSfrxuE+bOmgqWZTFr2iTtnH0NvbKq8edixl2eVQYpTw4SL0AUhYy7RhG7xkyaiWnTp2PJovnaZ3zIj9YW1QGNLdDWf0EURRw80oxn3liHNRvSO8NmkGUZp51xJk45ZTn27j+Cp578N0ZUlcSoVZMQm5Dmng1VpJuL6bB+6wG8+M7nONDQmqcR5QeiKIAXRLy1eis+334wbnHKJMQWCKovYI8nMweJoihwLIMwL8SF2KQcHUlJ52zFfkz9H8KCAvEvOjKn2WgSKacl+aZnkGJVnPE/2dnVDQAoi7Jq+mo3UzG/hNJogJRtR8cPaOE/M+iTtCMRAc6E3m6aRpAkpWWjegJhrX9cKuiPySZnKPEZK/B6AAAV5aUZn4tg6bxJADKo2iJshyihsSXZQVr9mVrhaVXxGch97UhsGwOocg8HG9rgM1HYlhXjJG0AKCrwaMekQ6zKLn6OOKJaRpZajWTIIPl7w/h8+8GUIcWcXM4Iz+OZh/6Irm4/fnf3gzhu4Ry0tndixfLj8PC/X8r4fJ1dPowaUQ0AqBtVi/aObsPjnn35bTz3ytsAYjdTnRwKGIaNXmwFFEVHtRTUSRZLzCQ6KqzaK0mSAJDO0/HHkklHMurVOG/isTQAKu68HMeqobFoCT05lqLo6M5NPwZZOy/LstG8CEU7NhwOQ4EXoigjEAzD6WAMj9ULgtE0A1mWEQiG0OELYuVZZ6my/6IAiqLx5JP/RkeXH1//1s1gozs7NaFUSHsNFUXBH/76IApKq+HwFEOW5Oh5KdB08jVMvN7qPSM5B+pnM6dOQDAYRHGhGxSlaMqvNE3HXUMi7Ed+0/waCibXm4nuwM2vNzmW2Gp2rNF1UbTu5+nmoaJLxIwdq2rPsCmvYey88df748/3oT5K2ZMqGP11STdnzY7NZs4mXm9RFPHYy59CUYCWDh9GVJaAQBDUDYD+GiqKuigKogiagnYNe3vVxFa3y6l7Hq1d75qKIrR29sDjcmgOiyAKUUfG+pzVH0scJPLcyLKszVFyXnXxlqEoVPRc6uekyoa85FVRSSHOeVS/F7uPlC4RlWUo7Xp3dKgv2ZLiIkiSBCpaPQaojg6FWHd4skaoSdqx54hlOciy2nfS43KguycENmqb2Zwl10JRFIR5AaVFHl0zbEl76apOKQVJEk3XCAfHIBjm1efc5HoDiPWYg7rBUsdvfX6rRTecZvfyExbjpdfegcvpiN7HzNcIVlfJZmWNkCTVXl6QopIKUtyxXdEEblGytiaT+aO/N0ZrhPH8jl0XQGX71HtOY9ueemzaVY+K0gKcd+r8pDVCkWVQ0ecgcY2A9m6OycmYrREkHBf7jnqs08GhBwBFKUlrROK9kaNrXqwikTFZI9R/1zd1oL6pAzWVxaipKAGgJLUvyslBKi8tQUVZCdwup+bhCby6IHCOzE9N6eKIsiKbeqYXnbMCF52zAoB6IZetvBp77vsaEpxPjL/id3CVj4Loa8GBx28xPNf0m58AQCFwYD0aXvu/pM+5ElUfg2VZdK5/EW1rk5WxiyYuwqiVN4OmaTS8ejf8+9bhp7PbIUkS9tx7FQCg8tgLULn4QgDA/sd+iEjn0aTzjDrrRhRNWgyWZbHj7su1v58YbEckIqBwdxE+qwBOPOUkhNvrseuxHxpSsKpNQODABhx48Y+Y2NOLwgNe7Fmn7rqdZSPh9bjR1uFDZfun8B7agBkREc6DLPZ87IyzCYBmE4EoipjV0AzeeTraPMfBHwjh0JM/Ad+Z3KSX2AQgzibt2gXDcI78ItyucShhgvjpHBlH//V1zPH34l/nulHsWYc9916F6Tc/AZblIB3djBm77wV/xIE9OgrVWTYSE668CwDQ9ulzKe8TwwANr94TZxNBJvcJAPbce3XS50Bs7oU7GtLMPcC/91Nt7ul3+3qbOta9kNImWZYRWPMgZvTsAwAEjziwM3p99DYdfvLWNDYxhvcpU5t696+Le55kWcb0nhAijjK8HJiLqtNOQmX7p6jqWAvxsAN7dMxD0cRFiMy6DO9+sgPTut9Fefig9tlxXR3417lusIdWgZkxFQBj6T7tuPtyjBAlFAbCYBgK82ga/zrXjfekICiKsrBGxN8ngh9Ob0JzgNLCZZ3rX4S46mnMCPFob3Dhy2VtuOAcFxpfv0dbIwIfP4J/neuGx7MbhbvvhnjEiRmhCOA4E+zMr0OWFUw8+BicfCdC9U7s1IVtHOPPA1ABmqa1tQUAVggtOPZcN/zPfA9VX/49GJoGE2zDjrsvx+3zu0HTFHbf8+U4m2iahqtjJ/bc+xft7yN7Q1AUBYXVY9A+5+sYN7oSXZ+9bDr3ak6/QR3X1icxsXELOI7Brm0xgT529AkAJkOWFdTteQi7D/7N9D45HQ5M2Por7D7sQWI+zfgrfge2uBbdjQfAvvFjzIi+UNuOutAVZeTIGmF0n4DY80RRdNwaMV+W8f5Nk8Fxh9D85t+yWiN4QcSMYAT+eif2cGzaNaIqEELvuCshcWUIdzRg9z2/jvt8TE8Q/zrXjRdEypJNANC94RV0rH8x6ZhUa7neJu+cs9Vzfnw39qyOipcGwpguqo71Xu83MHnJ6dCvEWN61Odn92713aJfIxof/QFm9ITAHuKw48NY6NRojXAHI5ghiDjc9E+4ykdpNp01AVh+vBuuD36DPZ/G5pXepuY378WITR9ClmV8vAlYSfmx/Fw3QlvfQPmJX0TyGqFghk9lxOpHnAVJmg2aprHj7su1sRHkFGKbP3c6rr7+p7jmxp+D5wV859a70NHlw7+ffU1rVpgJykqL0dCoJrnVNzSjMgfKMxOkomk1dduMkuXihatyhSRKCAaDYBgKXf4gJEnC2k17EQhGUpa7q+xTBN3dPiQGlj1ut1aWqm+NYAWCICLCRyAJEZQVe6EoueUv0bQa/ohEIqApGhQVS+5MvDdayGGYJmlnm2b572deAc9H4jRoBhP0j8LESRPR0d2jyy8zv5mJSteJ7Esm0NofSGreEGFVckXqKI9i+rn2d13Vmzo+2XQikBBbYoKpLMtxPdDMqt0Sfz8xIZc46G6XAycsmIKq8uKU50BCWCbpeaViOUjpEqodDhZQzLU7d+5vxKsfbI6xDVkieU2ho7lD2Sc5Z1MBRtM0RlSVpOwvmUn4Odf6Dn3uHAFRypZllSHMChauSUwZPf7vsRSL1MZRiI5bN3/M39lU3OlS9WWjeD6S9atGlCS8v2odqirLMWPKeGzbuQ/jx47Gc6+8jUXzZmHG1PRlkw889hzcLhcuv3gl/nL/4xhZW4XzV56Mq771U/zuF9/RQm6mY4gySKtefTjrJDVRFOJ0SvToDQQxaspxuPzSc3HvH39p+ZxnXXgN9uw7gH2bP8hqTATd/gBWXng1KspKce03vom2rh4snT0aZ19yHb5/y08we+poLJ4z0fC7oijglp/fhQcf/Q92fvY2amuqtM+uu+kn+GzzbnzjWzfg2LkTsHbTfkwaW4OTjk1WR0/E8y+/gWu+dQseuOe3qBs/BZt2HsYlZy5CSZoyUiO89uEmtLT7MW/6aJy44jyce/bpeOT+u/D0f1fh69+4AVdffhH+8rtYL6jWDh/eX7sLU8ZVY8bEUaZJkV3+APYdbsHI6lKMqOofRzsfSDUXU+Er3/wBPlj9Gda8+zz++/4mLJ47EbOnjO6DEWaHxtZO/Pf9zVg0ezw27jgMhqZQVOhBa4cf82aMxYKZ4+KO33OwGR+s24nyEi8uPH2R9vfrv/dzPPH0Sziycw2KCgsyGoOiKHj9w83gRRGnLZ2FCbNOwAlLF+LpR+7J2q7jTrkAoihh/YexlIJdBxrx0frdOPOE2fjeLbdh1cfr0bRvbdz3/vbA4/ho3U6cfMqpOOvEOXjtw82YO60Oi2ZPwAtvrkVXTxiiJOOU42ZgQl3suT1Y34wHn3gJZ5+yCIsXqnpmLa3tuPSqGzBubB0euk/deT/7xjpIkoxLVy7GMUvPRmGhFx+98XTcGP7zujqmS848FrIs41/PfQQAKC3y4sLTF1qai7Is44FnPkRdbTmCYR5jR1Zg3oyx2udbdtfj00374HU74XSwuOiMRabn+vjzvdi2twGXn7MEXneyiN/W3fX4ZJPKkJJgwwWnLUBFaWHKMSYi22csFRqaO/Hah5uxbMEUTJswIu3xL7z9GYJhHh6nA6EIjy99YUnc5298tBlvvrcaF688HksWzrE0hlztCkd4PPriGkybMALLFqgSGk+/+ilkRUFPIIzFcydg9pS6uO88/tIaFBa4ce4p85LOFwrzeOylNZg+YQSOX5BakuP1jzajsbUbX73oxLi/L1p+HvbsO4g1bz+LGdMmmX7/pXc/R0dXD0RJxgvPPolPPlmLziMbTZPcH35+ldYo+vj5kzF94kjD43LabrIMgxXLj9P+PXeWKsb2lS+dl/a7bR1d+N5Pf4+OLh9oisInn23GHbfehJ/deQ9efPU9nH36CWmdo/4A0UnJRgeJz0OZ/5rP92LBoiX43jcvxc5DHRBFGQcP12vKufpqICMEQyFUV1agproy7u9ejxsOh0p7OqIKrIltB8ywd/8hLFowB1MmjwcY9YEMRQSUZGJYFJKkqsVGwiT5VnWyaqK6NZEE+xwcB19PEJt2HsG2PUdx6crF4AwkGI40tmPjjsPo9geHlIOULXhegM/XrZWzDzYhzUi055rb6UBRgRsd3b0g3IQR0xGJFjjwCfc/GE3S9maYpA2oO+Szls+FIErgWCaak5eHKrbEViNamT9pF2GgE8NxGgvGJRRJ3PaLX+CiSy9HTe3IJEai0OPEPff8DT2dLZqD9Pb7q7Fp605c95UvasfRNAVBTFbm1oOm1DwlRVHwxqotkGWV7cpEoZxsxSVZRntXT5wzB8SYYFlOr6lE9JN4XjR0kAiDcdHpC/Hye5+DF6QBaY9khFhzVutK4DRFgeMY+HqT5yDLspg2bToWz5+d13GmRnIBQEQQUeB2ogfGUQLZpNUIELsmVpK0RUk2LITios9IugR0fcRGzeNk0lQAKmoLFjkmcGqEnBykT9ZvxsNPvoSOzu64B/m5R/6c9ruV5aV49L47k/7+19/+KJchZYVUJfyWhaoS4OA4iDlWsfl7Qzja0oVLLliJulEjsLe+C4qi4OChekTCYQCpHSSGYdDV7Udnd3fSQuLROUgcF19mnA4frFqLbdt3Y+qk8Th0VO2hlk3TUSC6cNIUKstLcMlF52P58ccCAGqrSjFjxnSMGxvPgpCqGl6QwAsS2jr9mgPU2NqF2soSNQcu6vSFc9A2GQgkzsW1m/ejobkTpy2dicIU/coEQYTT4Ygrqx5MCEd4ODkWLEtj1uRR+HzHYdSNKEdLh99QgZgsWh5XfNl3MBiC0+nIqus6AXFIGJbJQ5m/nFQtE6sCU9R2OQZjdXAcOPL8RcdDNijt7Z3aepPoIJWWFIGiKHR1qzkiPC/go9VrMWXSeBy/ZKF2HE3FWpKYthqJVrG1d/egobmLDFp7sVi5xrEkbPU6uhJKqxlSAGLgSCai0ONCVXkRQhEepUhmo8ka43Y5NHuycY9ymTum59Q5glZA5CEcnFqIkHiPiNxCJs5qrnYlVrERdfTSYvVeGK0pZnMLQEbyMaIoJVWwAbFnI5Lm/aJvVisKYtoQ/EWnL8K2vQ3Ysrse2/c1YHRtmSETmZODdOef/okvX3YOZk6bmHEZ/GCCLCswGz7ZYWbSVRkgOki5MUjd/gBqKopRVaE2veVYNYOfdpXg2zddD5qiwKdQApZlRW2FYMB+edw6Bolj1IqWNBN53YYtuPjL1+OKK6/G1665EhzHIRzsxbaNn2LSiAKMG1WZ8vtGkKI7y3F1I/CPv/xC+/vk8aOx5s0nk453JITUCFNypLEdH6zdCZqhcelZiyGTmHZGu+GBR+JcPNLUgS5fAD2BcEoHKcLz4BxcTJhvkDFIH320Crf8/Hd45T8PYOni+Zg4phrhiID1Ww8avlTIy1B1oGLsQyAYgttl3KU7U7AMmwcGSU7ukagrfZck42ITh4PTdsd6BikYCiEYCmtOV+ITyTAMSoqLtLJ+f08P/vPCa7j0wrNRNyoW2iE6SG+s2oJQmEeJQSoRkQKob+rUQlYKdDv/FOtizNRYXhcAuJLK/NVrc3DvTogjqwAkh2IIPG4HWjv86PQFDFnfnmjPPqeD01i67FqNpLcrU+ibs4pRSYN0ua0UrTpIiqKW++vXNpWZzMy2XO1KFIoMhXkoiqK1jjF6P0R4wdxByqBhrSAat7V58qG/wu/vSdooJ40dAC/waiGPJKXVoyrwujB32hhs2V2PUIhHa4ff0EHKKUl7RG0VLj73NEybPB6TJozR/jPUkKq9g1Y6mWF+k8PhQnV1De780z+yHpc/EEZzuw8FbvWFwDIMmpua8P577+H4JQuj7UzMF/hYSWvyU1Pg9cDtUXUqWFbtQZSOCg0EAvD5/Gg8vAsrVxyvjtHvw6OPP4U9e/dmZaOU4UJA03ScM04cAV9vCGFexLbNG3Hbr/+kvfh8/swaoQ409HMxGIpoduzY14AHn/0QT7/2qeH3eEGA08Fl1GeoPxGOqI2QnU61xJ6maVO2SxQl9PSG4I6yRyEdCxgMhrF40TF5GZNaBpzbJkal8xNDbFFEy/ONNigOBweB58FQivb9UIjHo899oH5VjKCowI0CT3KoqbSkGJ1dMQaJ/E0POqq43dDUCUE0DkVR0UTutg5/3AYwprVkzclW+5Cp8y1JBylq2/3/eABvvvl2yvNUlBaCYWgEDLrJ+3tDCIV5TB5brfVtU3/b0hDj0BftfIje04EjrXjk+VVo7/KnPJ70MCNOES+IeOfjbXjl/Y0AohvHDDfludqVKBT5xqqtKPA4MX+Gmh+YuOnase8oNqxfi3nTjd/5sRBb6nH5e0OQZRnVBgUBtTVVmDC+TtvMpxr7ow8/BEmSIAiCtvlIBaeDxVXnHw8F6kbM0Ia0Z0mB009eitffWY1AIBj3n6EH86cs1hgzs0vl8Xhw9GgD9h84nPWoNLn56ERjWQa7du7A62++AyctwMExaRriqv2BaINtBcsy+Pyzz7B35xZUlxfH9W4yA1FMP/nEJZriLenrxmdZ4SBbaGeQCJqOUc+kxxNxFJubGrBxy3Y0t6qhv8EWakqP2Fx879Md6AmoodQDDe2QJNm0kaTAC3BwnK5T/MDbreoAqTovZH7om2VqbFfCvGvt9KO+uROFXnVjEAqr3w2HI9i8bWfe2GqWYfomB0lXDSSZ5N44HA6UlZdDUmJriyBKONqkCnyySgSXrVxsyKSUlRajK8ogaX2nEl4IKoOk6KqDDBwkmoIoyRAlGbVVJRr7E9uwWPU+FK11TFKIjaahKAp4nk/ZKBWA5hB3+pLFInsCYXT4AigvKYq3J6scpPyzymQOBMI8JFnB/iNthscFQxH4eoLaxpD0KXt79TYcqG9DU7SxazYMUs6tRqL/qygKdh9ogihKmDl5NFwuThuTHrwgYv7CxaahPbWJb3oGqa3TD39vGHUjytOMLMXYKbXvoSAIEETRkqI56UvKMLRpKkZOIbZ/PPIM/D0BbYCq7Diw5vXHcjltv8Os+q25pQ1XXvsdAMi4T4+nINrfLIemqmRikRcJx9LgBXUc5WWlONjSjE5fAHsPN2PSmJqk77Msa6pg6+vpRSDQi2BPBxiGTu7dZABNwl13vRzRRY+Ic2UCXhDBCyIYObMHe+r4WhxsaENPIKy1qSDhzCsuPQ/vrd6AUET992BruZEO+rlIypkdHIPJY2uw+2Cz6aI52EJssixj+76j2LTzMEqLChAKRxkk3U4wFsqJH+uho+0A1ET91g4/QmF1bh1tasOiBXNx7IK5eRljXnKQDLqZ63M5FFk2zL1xcBzcbjcoxHI4ZEVBZVUVfnX7T/GFU49L+g7BlCmT4ClQwwFErT+xMSfJQVIUmKoo0JT6m0dbunDGsln4fMdhhCOCVppvtSq4trIEja3dcDpYuF3JDJLTwUJRFLicyWxYIjiWSZIwiPAC9h1uBgA4ozmI5JqlKpE3Q64tOYxA5jLJ3zHKyVQUBZ9tO4iDDarz5HZyGoMUDEfijpOzYJDy1WpEgRra7+4JYtqEEXECknqIWq818w2LPhfODORzs3tpxS4KFHhebeouiqIlBonA7eS0TVjSb1s+iwHeeOb+XL4+aJDYbZvgnw8/hS3bduPi887CTd+8OqNzejxRBymHBVgyYJD4qCPi8bghyRJkWUFru9/QQRJF0XQH+8Obr8ONX/+ylthm1JcpEUaLMXnhWXUgn3rhLdRUV2D5knlYu3kfPvl0Lc5bebKl7xIsnjsRtZXFeHP1Nm3nSqqdliw6BgeaQwjzUfVWSU6ZSDjYoJ+LoiiCYxkcM30s5kytQ0d3AJ1Rhd1ECIIwqJK02zp7sHHHYRQXuOHvDaK5TU0C1r8kjXIUJElGOMxjdG0pqsuLUVPhhyhKaG1rxx/vexznX3IlzjrRWtlzOljNQZJlGY+8uBouB4cvnh3vuJCKGT307TfMGr46HBxcLjcURY5pG0kyXC4XTjt+AcaONM/nO/+Ci3CgvhWyrGjMXOKOmY5T0lYM9+AURWmq38WFHm2d0dhZk3UxEcGoA7tswRSNUdaPg2yiHc70Ly0jVq+9qwe7D6oOkiP6Ms7lcbZqVyYg95g43EaaQV3+IHYdaIpdZ4pCcaEHLqear0raZSiKknHqAZC7XXrHXpZlVJYVanmvQDITRNbeVAVMaqg39VpENuZm9lqyiyKK/CJEUUzKVU0Fl9NhyiBlFWITU4Z1hiKMHYNAUFWV/cVPvh2XAGkFC+eqkge5PMiaZx19+FhG5yC5XZgzNapJYfob0SRtwxAbi8KCAk1LhuQspAIJseknK3GQeBMGqam5FXf+9XE89Oy7ePrVT9DUFcFnW9VGk7wgYcXJy7Di+Lkpf9cIseqYaIgtOiedDg5ulyMuQX5osUixe3DjDTfhjZf/o93nVN3OeV7dNZHKF3GAGaSGlk6EIwJmTRmF3mAEgYCaC5bIdDAMHefMdfkC2HekFRWlRXA4GDS3+xDmBXT7evDRR6vRWH9Ak4DIFQwTa9ewZfcRfLJxb1zjbYLeYASCIKE3EE5i5mQThgiIVrEZ9WqDGmJzud1QZEknYElEMFMv7vq2FmSeG4XY9DCtYgNQVV6EQq8LLBGZ1L5rTfZjxdKZOPeUeRhdU5b0GWkVBMASg8SyNISEOa4PK7Oag5R9knZfqMyS9YiExowYpA1bD6KowIUir1s7rrTYi3BEhCDK4KJVXHLUQcmkUa2K3OzSO/ZHW7o0Z9dMwoAw3EbJ1QQk1JsKie+5ZKS3i6IoCIKATZ9/jt7eIDLR1/S4HabzKCt389Y7/g+/u+07WHLGlXEOwFANsVEmneFz0Vz5wuknAMhNTTs2cdSL7OBYIBqy87jdmDmpGGs3H0AkYuywUhRtqUkkYE15Vwux6VsfRB+iiEkOkq+nF6UVNeBFINDRjVAoBJam8PSLbyMoOVBS5M1qkWOZeL0fQVCTZRmGhtftjMtjEMT0VQ39AV9vEJIoo6zEXOCQzMVwOIJwJIKiwlhlBcPQpowYz/MoKVaPZRlmwENs5Pe90QIDEoJ1ueJfknQCc9nlD4ChKTVhVxculCQeDQ318LBixpIbZlCTtGXIsowN2w5BECWMH12F6gQHbM/+IwDUypf65g7U1Zbr2C85SbFXn+wqK4qhoi/HMnC5XJAlXlcJZs1BYrREfDnWmDPB8SwucINjaQiiDCjGSkh0lLHo9gfVxHkmXr3ebF1MRGkKgViGpjQHKV2iLQBwDINQgnNB8vAAaDk7WpZUFv6RVbsygZ4NdXCMoYPU2umHy8mhsMCN7miLjkKvC8fNnYAd+xrBcQzau3qhyCqDxGTIIOXLLimal0ZywkjINYlBshJio3MPsVmxi6IoCDwPRQyDZuiMroWTY9ETCGv6aHpk9da45aZrAABvPff3bL7ep5BlGU/+91OMri3HCQtTq3cSUBSFe/7xKB578nn87pc/wvJlag+dYJadw8k5VbHI7LWQiMdOXhQOjkEgGAJFUXC5nCAdyhtaOvHoi6tx+vGz4hZ3KioEZ5SknQiaptI6c6JAcpB0ITZnagZJEiX4fN0oKyvHoUMH4fF4QQHwRSqgKFLWrTGIZgZ5qfCiqNHvlWWF6PIF4HKyCEeEnFsT5AsvvfM5whEBV1+wzPQlSF5O/h7VwSsujjlIJDlZLedNcJAEQbsXpcWelItWf4DcF5IzEomGYRJfkqQcHQCee+VdHO2MwOVyo6TIo+WiSLIMKUqBOy28ZK2CYVhEIiF0+4Pa3Pf1BOOeofb2Ttzxh7/hlFNOAVfsxZoNexCeMQ5TxtdqVWA0ZewgkSR1o50x53CozXjDIS2ZlTzv6Z6JWHK7rK0viQzS+Lpq7DvSCkEMqxtXg/NQtKodo+lC6UI/ejtyARNtdgtAK+xIBZZlIAbDcX/Th5W1/Ecd25Ep+iLcHkuDoFEc7WKfCFmWwXEMSgrdamuM6EZn1pQ6zJpSh4/W70J7V6/GIHEZqmLnahf5Pil8IflkatUglcwgSaQJbAoGyULqBgnBmYXYrNhFQQ2xBXp9OGbubFSUlaT9DgGZl+EID46Nf9dn5XKWlaoLSIHXk/Sf+qPN2Zwyb6BpGsEwn5FAoCxLWL9hM3bvPYh1GzYDUCdvIBQCx7FJYQGrcDoc2g4vGyQySC4nB57n4XK5tEnDcQwiEQHhiJAUIpNlybAM2QhWJjJZjPWNiMkLzyxJWxBFtLW2osfvx5uvvYJQOKwxURRFZdVTC4gt+OSh9bgcqChTnYllC6Zg3oyxmDlpVHQMEprbutHS7svqt/IFsuMKhJLLmAlIUr/Pr3YsLy6KZ5AA4xJ+no+VtgZDfNyueyBAQnxOjgVFUTEGKeElqS8O8Pn8cLnUBarI645jSghDaYWFsIrSsjIsXXYSVm/YA1FShfn8vfGyEGvWfo733/8ALiqEY6aPhdPB4aPPdmtVk0bVRvG5HIohg0tFS/+JmGyh1w1ZlqPMT2rnVl+pKJg4SOUlBaitKtH/YvIYqNhLXf9vt1a1lPvGQh9ic1oIsVGUmuC8aecR7W9tnX5t9ETUVrvGWeTa5cOuRBAnWRRlOBwsOgwq8URd4nW0tjDuc71jLWfBIOXDLoqitHXKE1dxmhxhEKPaRakcGEs5SAnvueTP09tFQmxulxPPPvxn3P+n29J+h4DMd6NE7ewYpNv/bHhRFFnBgcMNeOahP2Zz2ryBjYYiMgGJj9/5h79hzacbcMqJS/DZ51ssxc3NwHFcTgxSYpm/y+lIKpc95+Rj8Nbqbej0BQwZIMlEKDIRVAY5SHEMEslBMlE6FQUBD/7z7/jSxeegsrwM4VAIsu6aZssgJZazt3f1xr1Yjpk+Blv31KvjFiW8uWoLeEHCVy86MWPJhmzQ1unH+2t3YsyIChw7ZwJEUdLmZCAYSRmWAFRnAYh3kNgUJfwkSRuI7sIHWAeJjJFlGDg4BhGeB8MwScmWegpe4EMAWwyapsAwdJy9hKHMdrNihAf++mus33YIskJh5qSR2Lb3qLZ7JiAtfUaNrMGEuip0dPeg0xdAMMLD4WCNk7TjWo0YM0h1o2qwa+8RzJsyPWajIIKmqaRE50QwcdfFOMQGqG1dVMTK/fUgTJEmVJk2FyRz0DSlMc/pyvwBaOkm2/c2YO60OsiyDLeLQzDMQ5JkbazkGst9kE+UDcgazbEMnA5OFelNcJ6laDsNM5kKvfK0lFUOUu6gKDXH2O3i4HHHF1QkJ2kba+zpkVEOUg4hQkWR1XG7MxeR1TNIicjq7XTCkvmGf6dA4fqvXZbNKfMKNfnSuoNE00zcYxYMhvC3Bx5HW3snSoqLsh6Hw8GZhp6sILHM3x1lkJyO2MQtKvBg+sSRWL1hT9JEpGkGsmydQUp3zUSDMn+S25OKQQKAWTOmov5oM8LhsLarZFk2aweJS+g5JoiSFjMncDk4lJcUIMLzWpWbIIpgmPyxEGaIRAR0+4NgmU4AE9DdG0JxgRu+3hB6DYTwCOioM6uF2PQMEhtjVJJ+jxe0lyTHMAik6C/UHxB19DvHMuB5wfDFr19AIxEer/z3Kfzw29ep36WTHYF8OkjVVRU4++QKKIqC3mAY2/YehZzQ9qS3V3WQCryqQ0ucjlCYR0mhR80xMmOQEGUCDJ6/0uIiXHreqdq/OY5BIBTBiKqStCEF4jiu3rAbDUei1V0GTOz8GWMhK4ppGEpjkKIvbNLepbhQDRHRGfafNILa7y5ZA8sU0TGFwjz2HWlBXU05Wjt6UFLogcsZE0JdMHMcOv0BeLLYwObDLiNcfs4SCLyIjbtU9ktNtI45n2QumCU1E8X1nqBaDJBpFVs+7FLZXhGhsBAXambo+BCbJMno7Q2l1SSzVOafJsRmxS6yPmRDaLidsX6iicjq7bRyxQnZfK3foCazWt9BK4qiCVyqlR2x8tmcej5xXNYCioBxmb/A88lhigQNDgI1ByJ9k0hyDtLc0gyxEFtsMaYoCk6nw9RB0r7DsfC4XWqSNstCEPiog5TdC49OiJeLBgl2FE2ho7sXG7YdBsvSEEUZvCDBlT0paH180Zc7Sdbs7O6FrzcUTQxOpX4eDTdFQ2xFRbGEbrIYGVVSqaWt6rVk2czmf19A0npJ0eBYNsp8Jl94fXFAhOexft1a1FR8D4COKZFlbX7lMweJgOTykd/Soze6LhQURB0kV8xBAlQZj0SGNr7MX7IUFiQVZFXl6TdkxHFsavPh8FFVU8fIQWJZRktqNiJa6IQQ2ynHTUenL4DKaKg6lwKT2FhjSdpW7h35TaeDxefbD2lBqJE1pVg6b7J23Pi6KozPckz5sMsIXrcTcDt1Jf+yxrCQecUytG49TtjQRu/Hjn2NEEQp4/6W+bBLzeURUVVRrAm1AlEGKbp56PIF8Obqrejo6sb4MSNTnq+kyGPoeOiRLsRmxS5BMC4CsQKXk0N1RZEhQZCVg/Tkc6/hixeehV//4e+GZQQ//d512Zw2b2AzZJAURUZPbwDFxYWoKCtFMBjLk8lczTQGp4PLqR8bmTj6HeVN37omWWtEJzSnh0o7StZoR0UtFT98tA1jTDRYYiG2+GnjdDhMmTJRV4Y8pm4k/v3MyxAFAT/40U8BN+A1aKVgBYR9lqJVXYKYTPdyUYdCEES4nQ70iGHw/cSsaAn2ujYSBR6nWjKeImlcbRfAYFTdWNxyy/cxfdpU7TOWMWaQyH0h7ArLMgOemC5Jsd5KZcVeU/l/SlcckOgEMQYhtr5wkICYQ5vkIEUZpEKvyqq4XaqMBGFbUikekw2KlVAJqSBLVKI2gn7DQ/qTGYXYgKiSNUyytKMvaOJ4e9zOuLAKmYu5gKbpmASHBQapqMCFjm4Wi+dOwPtrd6GprTtujPlAPuxKBaNQuKRjVM2qisk82nuoGSzLZNzbMh92URQFQZKTpoteVysY5uHvDaGyxIOVy+emPF+EF9BlkI+lh9F7Tg8rdpE10JmFg8RxLFra/RhZnSxTkZWDVFZaAgCDtu8aQ2fmIAEUensDKCwoQHlZKY40NGrJ1bk45Q4HpyVRZoqm1i70BMJaBQHBjdd+MelYShe7Tvgk2k08/QIdEUREBBGrNuzBqJpyw++IBmX+gGqnWbdlsjiyHIu7fvUjLJo/B1+74UeaM5fYrd0qaIqGLARx5PBhiAtVJyKpRDP6b38gjLracvQEwimb++YT5F74ekLgBREdvl4ttJaaco7ea5pDedUoVFVWaJ/EHIZ454c4FhqDxDBRSn9g8hgAxDGXc6bWIcLzhtWU+tAuqXQjL1KSpBqXpG1BbDAbaN3YzUJsUQbJ43IiGIqgNxiGLMuQZCmpWW1cV3bFGoOrJUi70z8P+vPxCffe/FjzjZ75+HKv9qJpClIGOkgnLpqGExcRZfxdWl+2VFo7maNvRWONxFoJo8vEMUgJo9LNm8ljqjFvxtgMfzl3u0hY2KjpMNmYEVvmzZ6a9P1EODgWvCClFOtNn/uW3i6ny4UvX30NTjphUdpjk8eorktGZEZWDtLpJy8BAFx6/hnZfL3PwTKMtsOzdDzLoqc3gMICD0aPqoUoKWht68CokTW4+vKLsh4Hx3FaLkmmeP2jLSpFayk8Fq2MSPDm1FYjxkKRiYjp1qgaQpVlyVS/WcVMKgYpkXUaWxdPyRZ4suvMznEcHvznPzBuwkScEZ2PiQ4SEV4r8DhRXlKAI00dOTF6mUC/OPb0hhDhBS3fJpXeFEliJpVuXt2OvtDj1FgoPXhexOkrTsFxi+ZFzxFjmhxZOEiNrV0I8yLGjijP2sESdQ5SSbEHoigaFguoDIO64CYySHS0I7oky+D7oMw/fhzGYng9WohNZZC8HifeevN1/OgHb+ObX73csEpNX8VmlUEirwCnBb0u/QuWvKzMdL4YmgYUkzAFlXw+PfKhNs3QtE6B3/q9c3AsOI7RVLrzpX2lnqtvNdH01ZeiJOHw0Q50dKshc5ahdet1/Pf0OkB6Js8q8mEXGUMik1la7EF9cydkWdHkN6zcEwentpkRU2jRpctBsmIXy3KYOWs2Ro5KHfIzHGP0/EaN33O6oqFwGK+/swYNjS1xnYRv/voVuZw2ZxBBvXR45qW30NUTwZfOPwX+nl6MGT0S11zzVWzZfQSfb/oeFi84Bt+/6dqsx+HguKzK/HlB1MZvRQMi1tMqUchLjOZIpF+gZ08ZjUNH29Dc7oevJ2ToIBHngk1ikMxzkBJZpzF1IzGithp+nw+lJSWG3cqtQBRFLD1uMSbNnK91wE5mkNTf7A1GUFiglo/zfP+EnvT34uNN+yAIIhwsizCfLMegB0leD4YiYFlGK2sGVMHS3qDa7FKPHQdacPrKc3HmqWrxBAktiqKUkeQ+wXuf7kAwxOOq84+H05GdgyRJspZXwzIMfvfLH8NrwI7ok7SNwmgkXE7mVyY9ljIBUSA3CrHRNA2PW50/Do5FMKBWjDY2txqydPoqNsViT62zls+BJCmaU58KrO58RAnc7Lo4HZypmOKomnIcONKmvSASkY+WHBRFoaSkFMceuwhVVRXpv6DD6JoybaOQTwapL1qN6KEPsfUEwnj3k+3aGq0ySNH5kZCDRNG5OUj5sSsmKaNHYYEboiijuyegyQBYuSdk/eGFFA5SGqFIK3aRDb47ixAbcfSMGr/ndDV/due9EEURjc1tOO2k47B3/xGMHFGdyynzAjahfYEZVq/bghmz52Pb3qP49Z13Yt60OoQiIn57568AAM4swz8EDocjqzL/9Rt3IRTwwe211lLBPMSmRHuxpff0Z0+tQ0VZIf77/iZTVWyi2ZKUg+TkMHL0WMN8DJKkTiZ4RXkZ2js68X93/wmb1ryaQwhIwW9u+w52HWzG+q0Ho+MyZpAAoMDjQHGBO6mNQV+BsESjasvQ0uYDw9BwOBiEeQGSlCrERpJUOdRWFsc5yKVFHridjiR2tDcYhgKgtFgNA8Ue+OxslTQqXUa2+eyJ7OfZpy0FayB8pxeKJGW2+ueOtCIhz5GlSqgswdB0HLvX6etFhy+EmurquPvAMhRmzZ6D448/Hi/+961kB0lXxWa1XFst/7Y4Tl2+kqQ1NDZjkMzlO8aPqkRdbXnSyzCG/CQzT5gwAePGj8e4ceMy+p4sK2hpV+Uu8pmD1BetRvSIVV9KmjOhr0gm5exmDBLDUFlW9+ZuFwmFJf7+qJoy1Dd2oL6xU2OordwTffjKa7KapEvStmIXYVKzSdmgabVIgzdgkHJyy5ua2/CXO2/B3FlTcPrJS3H7j6/H0aaWXE6ZFzAMjaamRvzunifwzkefobG1G1v31GuVJwTbtm7Bww/+A1t37EWXL4jK8hK4HExGMfNUcDgy10E60tCIb377R9i/Z5fl75glaZNWI0atDozg5EjbEOMwlFGrEQB49IG/4rQzVmLXgca036EoCqXFquOXjWYFAUXRcLtdqC4v1oTEEilf8gBTFIWiAg98vSEtqbWvIUUf+tmTR6PA40SEF7SXWCrhNCKR39LuTxIuY1kGoIC2rp64v/cGwyjwxMRDyQL2xqotSXPeCohjlUuid2L1pJn0v14o0ohBIvmEfB8IRSaNhabjnNdAMILzL7oUzz31r7jjXv73Pfj2zTfCXaQyIkkhKl0Vm2zSLDoXkOvFcbHefGZJ2hzHAopi6CSxLJPCOcpjS47oe89KAroeJUUxRWrGArNmeTh90GpED3K/O7p7EUrQ1mEZRvs8MexJ1nGVSczcIcyHXaRhbqLDXVNRDJZVQ56xJrWZMEjmqQ2xZrVmuVnpf6eyrAhejxOF3uze2RzHGPZhzOmKulxOSJKMOTOm4ON1m8CxLI40NOVyyryAYWg0NzWjtHIEGlq7sW7zfnyycR9aOvxxx+3bdwCHDh5Ely8AmqZQ4HFh4tgRWH78wuh5ctu1ODjOVEDRDDzP48iRelSWmvfrSoRZmT8dfblYofiBmGijUSdqQF+yH7/QjR5RDVGSsX3f0aQEYtGg8u1rV1+KL170BRQWpBZLTAXyMFVVFMHf3YkDe3ehpiI+LKhvoVDgUVuz+PrNQYrF1cuKC6AosYUzVZI2sUuUJMNwi8vBxQma8YIIRQGqdeXhMyeOQoHHCV9PKKNcPAAI6xwqK01+SefvRJSVFMSJYZotfnoBukhEFZPUP3eqjo6EiJaD1DchNvW34kNs5Nol7qYpioLLySEYDf8kCtzRCTlI+X4hV5cX4bi5EzFz8miIknGzWgIHx6r77yzIhXwl+BPHPZUzZoTK0kIUR0Pj+WSQ+rpwgTznn27ahy5dmxSiCeZ1O1FW7MWI6tK47+lDbNmEFPNhF2E/E9kcktd7tKVTF2JLf0/IxjhVZwtNENkkxGbFrmULpuDyLyxBoUmbl3RwsKwhg5RTiO2UE47FvgOHcdKyRfjaTbfhkadexpJFc3M5ZV7AMgy6urrQ2tqCcaNHaCyG3kMMhcLw+XswbeokFBYUYOm8yTrFapXZyLW3TW1NFcaNHZ0ygz8RZIzaLsPCyhZTYI1/UUmSaDnEBsReBGal8EbODqBqwyxfNBUnnXEBnl28AE8/8n/aZzEGKbY4/uDm3GUgJEkEy3JgGQY3fuU8bNm2A6VF8Q8HuYYUrerxFHpdWlVMX4PcC4amMXPyKLR2+jFmRAVa2v2mDlJLuw+fbtqH8XVVEARjlVqXi0Nndyzx/0hjBxiaQt2Icu1vTieHqeNH4LNtBzPWQ2ps644pW6dxkHbtb8RHn+3G2JEVOO34WUm2ED0dIHa/EqFnkCKRZI2vkkIPOrp7+7zMH0iufo05SMnjdjljEh7JDG0s4fv6G2/ChLr8ph24nA7MmjIaPYEwjjtuKY455hhUV1cZHktCHNkEX8zuWbbINB+upMirbWjymYOUb7sSwWgJ/wrao8+q1+1EIBSBx+1ASZEHF52RXG2ldxCy2Zzn0y4jZ8XpYBMYpPRjLPS4wETbf5khXYitr+8XoIqjGq2VOTlIF52zQtNe+df//RKHG5owYdzoXE6ZFxQWuCDyIbS2tKC6qhqiot4cfQ8sf08vKivKcNKyxTjv9GNRWxXTQCB5Drk6SIIoYMeuvegNBC2zJfqQVFV5kaVFhew8jGh02WIvNkCd8BRFmTJIZiE2AJg0tgZejxs+v9/yd/IFt8uBYxfMTfo7RVFwuzitEqyitACHjrb3S/m7vnS1orQA569YAJahsW7LAdMqtrauHrR0+DWm02iH5nZyiPCiZkNHdy86fQGUl8QzjiS52woLpMe+wy1wOlhEeDGtg0TmlRF9rjZxtVZgIMsq0xIKR5JCaA6ORSAUQSisPruOfsxBipC8J4N8EJeD0xjb5BwkCq2tLfjRz5/CRRdfhpqamj4ZL8vQKCwqQmFREYoLjRnnVCG2foOiMhOZasoVF3pQUuhGd08or1VsfQ09C8nzAspLvOjoVpkkolJuhPg8t4GR5yAjMFofnQ4W3f5gRknahQUuSLKs2W8EOUog9EUTYavgRRGdBmPM6a31ze//Gg/+9XYAarhtysSxuZwub6ApCt2+HhSXBBEOh+F0FcLl4OLK+CI8j7b2TtA0heqKkrjvk0U4V2VSohfV0dll2UHSszTnnWrc0iUR5EWkGLQasdqLDVAf0JqKYtOQnCCIoGnacHdDURRKS4rR1Z3gIPHGid25wqqs/pXnHq/9/6ICN2RZQbc/iLIS6yHMbKAJRUZ1rFxOTnv5mr2s9MwQYFx+HesbJMDjdmoJ9YksB3GuMskjEkQJvp4gXA7VCev2BzC6psx04WJYkoCZ/BuyosSFDMzuFx0Vitx1oBENTe1AQjiqqFANsVSPHIsbv/m1nFr/pANNU3HVr5GIcYgNUBmk5iY1566joyvuM4pSixKCvQHwfBilxdnR/unAaiFkc20dB8uoycBZhdjy45RUlBZYKppJ/n0Ki+dORGmxN07uIlf0VasRAv17Jhjm4esJobayBBFeiFOnTh6XzkHKIucqL3ZFn3UjZ9bBcRBESVtTLDFIUXv3HGxCSaEbMyfHEyiCKEJJIbaqjqXvnWO1WjbPSdpTJ43FmrUbczlFn6DQ68bBAwfQUF+PQwf2oqTAjYggoMsf8xD1lH2iI0ReNrk6SOVRB6mzs9vyd4zaeaQDbcIgKYqiCkVmsPsKhXl0+429/fMuuBC//OUvTL9bWOBFw9Em/O4v9wNQk4c/+UydH4nSALkim3tTVuRFTUVxyl5o+YKR+Jl5taGKRGfGiIEpLfKgqqxIsyEcEUBRyS9xkn+VSdPmw0fbAYrChDo1XLNtdwOefXO9eWI7Sa7WMUi9wTBEUVIrGnXjN7tfJH9HkmQ4nE4U6XrPAeo9K/C6UFZRizPPPB0F3r5xNoBYxRxBIBQGECte0KOmsgS+7k54vV5MmjA27jNFEtHV3orxEybC4XChqsxaNWqmIDv4VAwxw9AAlV2ILV8tOc49dT4uOG1hVt+tG1GBQq87r4xvX7UaIZg+cSQu/4KqzcbzIjiOwRdOPgYXnbEoJUuSa4gtn3aZhdgANT+ytrLEskbf1Rcsg6woOHS0Xft7OCLgwWc+xOMvrcGRpo6kzb0efX2/AAxm5KcAACpsSURBVPV6G62VOb21urr9uOX2v2Bs3Yi4h/SRe+/I5bQ5g2MotLe3Ycqk8fj2dRfD7XLizTW7EAzF4qBE+dnh4JKkzEm3+lTVRlZQXqYm4XV2+Sx/x6ydRyqYvXhJqxGrSdqA+hD4A2HDzxxOD4pLUg4EoiRj847DONrShS27jkBU1B1EvhmkbGT1XS4Hmtt9aGn3oaqiCA6WzamVTCok9tEDYlo7Vh0ko8XU5eTQ2umHvzeEqvIiRHi1B1visZpYZAYMUkd3L7p8AcydWqd+V5LhAIVPN+/HiqUzk46P5SqJ2LzzCCaPr8GLb2/Q8g30LzWz+0WuTzDC49qvfxMXJ+RmFBa40BsIo8DjxPg85/IkIsKLCIYi2H+kFVVlhWjr6MHomrI4LSqCkdWluOyc5fjj7TfCwcWH/cpKi9AbCMHt8SAS6kVxlAXLNyiKwjHTx2jNNs2OueryS1BbnVnbCqDvW3IMFPraLpqm4fWoidj+QAgei9o8uYbY8tJqJPq/RusicZCONnehwOuy7LQ6OLXnpqRb90JhPtqvMf05+mMeml3v3HKQzj0NF517Wi6n6BOMrCnH7s/fA89HMKJWXVQ9bgcC4RhzYKYKDQBlZcVgWRZFBYVJn2WCsrISAGqIzSrM2nmkApmoRgySnEGSNqAm+Ea6egwTy4UUaqjRXwRF0Vh+ymnYc7AJb7z+mlaC31cCf5mAMIMH6luxbW8DlsybhCnjavvkt0jLikTnVN+cVQ9BECGKEigqpo9i5LqVRCvD6ps7MHFMNcK8AJdBCCibEBsJ13ndTrhdDlSUFoBjWbR1+hAK81qjVgLiBIbCAtZu2Y8wzyMY5uFycghHBMs5SAAQjDJingQxyeJoVUowzKPKQLw0n+B5tSKw09eLfUda0BMM48wT55ju+pcunq91qteDYRhMGFODouISfO1LK/t0zAtnjU97zG9+/u0+HYMNY9RUFKO7J2g5B5TOsYotP1DHYDTnCzwuFBW4QFE0xuiKQqyAY+PL6In8CGFtBjBDDkCeHaT3V63DScsWYd7saTkNqq/AMDQqykvi/uZxO9He1au9+LX+VU4HGCb+Mnzn+q/iO9d/NedxjK0bjS9ddglWffo5pk2ZiNkz0/euMSulTwXahEEi3nkmOixOB6fKyUtykhYHL4gpk8avuPR8vP3+ajgdLJrbOvHI409hydKlAPLPICXeMysgOyBfbwguB4v9R1owuqYM/mgIqaayJG/jkw0YJPXfdJIj29jSiS27GxAKC9GFRIICQDF4L5cUejBmZAXCEQG8IKIg6swkgs0ixEZCZTWVJbjyXPW+bdxxCAfqW+HvDSX9DplvyxZMxqrP9mDzrnoA0LqQ6203u1+0lvNAo7ayOGl+ORwslsybBIam+oztI1gyfxLe+2QHnA4W7V09KCv2xmnxGMHMru9+8/K+GGK/IptnbCigv+yaNmEEdh5oNNzAGIE4JWpCe+YOUl7sosw1iTiWgb9XjS5kqvStCjHGHCR9VVtZsRdnnzTX9Lv9cb/MJAuyclMffuqlnAYzEAj52vDog/dj6/bdAKDpqjg4zjA5Kx8YM2Y06htb8fiTz+GfDz9l6TvZhNj0Okj/fOxF3PjDX0NRFE1cz2qSNhBzIozUtAVR0sqGjXD15RfiiQf+jLoRFVqTTzl6bfOdg5TNPdO/fAu8LjQ0d+GtNVvx1uqteOW9jXj9w835G59swiDRyQzSR+t340hTB3qCIbgcHI4hTSoNYu8MQ6PA40R9UydCEQENLV2GVWT6diNWEYnmS+gdEcK6GTFRxI6iAjdOWDgl6XP9eczuF0nkbu/uQU8gbLhznTlpFKZNyLzHUqYo8qqhMDGqHVZdkT53qK/WjsGA4Wpbf9lVXlqIay48EV84eZ6l47XNQpa6WXmxSzFP0tZvkIoKMgsbcxwTt4aQ/L4vnDQX569YkCTvoUd/3C/TfoR9/suDBNWVJTj9zLPx6fYmBEVGC7Gpuip9Q/B53Q6Ngvf5e9IcrSKrEJumwCrj5dfewapVq/Cjb1+Louju16qSNgCUF3tRUVqALl8gqZGsIEiWHDcKwLvvf6ier6wEkydPMhWyyx6Z3zO9g1RRWgiKotHa4UdtZTHaOnviYuSZQpZl7K9vRXmxF21dPSkYJCr5dyhKFYDkBShOYN70MZgzZbTpQ0uclkAwAkVRDOX1Yw1rM3OQEpulkmtm5CBpTiDDYGR1qab1EjNLb7vxtQ1HK8V8PaEkHav+BnmOeF6EvzeEsSOt9A4b6OBAX2K42tZ/dmXC3pPNAs1ky5TmwS4iFGmwUSGskcft0AQ8rYJj4x2kbn8IHMugpMhj4Rr1/f0yqxrMykHaf6Aep134dYNPFAAU3nru79mctk+xeOExONAcRiAUgaLEGBKHg+sz6XmaphEMBsBxHGYfs8BUMNLfE4KsKCgp8mgMUiZNB8mDtW1vAyqqakDTNDZt24PjFqrifZnkIJWXFuKzzzaAFnswuvZk7e+SJEOSZcOE1UQ4OBrBoNpQ9bTlx+KJf/zO8u9bRTb3jKYpsAwDUZJQUqSGT2orizGhrgqvf7QlruFypth3uAUfrFPbwzg4FrVVxaitLEl2kCg6KRQqSTJcLk7Tn6JpOiXFTkKfgaAaGnQbNIF1sAwqywot6d/sO9KK7XvrEY4IyXIB0d/asO0gPt20D5eedWws500nZVDodcPrcYJjGXRHm+nGJ6ibtBGILn6SJGestJxvkPESRs4odJmIvm5bMZAYrrYNVruIU1KaQispFfLSaoSMxWD9IRsxXpBQkEKuwAgcy0KSZE2/rdsfgMvJWWou2x/3yyzElpWDVDeqFn/89Q9yGlB/g6IonL9iPh5/+WOIkqyV+TscXJ+KBt7+45tw8GgHiopL0dzmQ21VSdIxz721HoIo4ZqLTtBykByZlPnrnK6Kigq4XE785Pa7tK7fmVSxVZQW4qF/PYS9xy3AeWfFHCTi/VthkLq7OtHc2IjZs2dj4oTMGlRaRbb3rKKsAM1tPjg5FlPGxxK0GZpOm68jywo6fb2I8CJGJrQJaO+KaRgJooiWdj9EKVmQ0ijEJkoyvNEeQlZKWomD1BtU57BRlYzT6UB7Vw+8nvQL2efbDmrJpONGxbMmjuhv+XpDkCRZ018CkqUMzjt1Prr8ATzz+jr177qFzex+nXzcDBxp7AAvSilp9v4A2WgQJXkrjS/7WnB0IDFcbRusdpH1J1smO592mZX5X3bWYgiSmLGoI1mzBFGC00GjvavHUggb6J/7ldcQG8uxqK22Qj8PLpAdaoQXYjlIDkefSpkvXzofE5s78dqHm9HlDyQ5SJIkQxAlHDxwAI8/G0J3RzeA7HKQAOCERTPxz7+HcPjwEY05ylRTo7SkCJ1d3XF/4wURLidnqcv0xLGjcPqpJ+DkZYuw9NhjMvptq8j2npFWEok0tioUltpB4gUBz7/1GTiWwdUXLItbJMK8gJrKYhw/fxJefX+zWiJvwLYZdVeXZBkOhsH5K+bDaYGhI4tNhBdQVuw1TAKlaQoupwOhkBXNJ0UVtASSwqqEMZSj1yakc5CMpAz0znh8DpL5/eI4VnWQ+rDPmhVoITbROoPUH20QBgrD1bbBaleBx4mq8qKMK8QI8tpqxCAHiaIoTbg1UxDbSKGPbNAQ1wz9cb/Mqtiycs1OPj65j8xQAE3T4Di16R4fl4PUtyjwqC8UI4HCppY2ULKAtZ98jLDsxMfrNwHILKlZ/6KuG12r/e2GG27IarylpSVJ2k0RXkA4Ilia1JMnjMavfnIDTlo2+ObJ+NFVqC4v0hJyCRjGAoNEyu8pCj06rShZVkXQaIpCWXFhVPNDNrxW+uasBJIkg2EZVJYVJZW5G4E4LTwvotMXMBUC9bgcKXsgEQiijOJCLy4+cxFmTBoV/1vEUY9OsZDufLJBIrp+YbVadcYwqnOWrmKsr0HGK4oyWJa2FE62YSNfqCwrwnmnzscx08cO2BjIypTvilEFQGuHH4Kgisjqm3cPBuS1iu3qL52b02AGEg5W7e0UY5C4PpcyJ2EOf28w6bM9e/fjjjvuwIyp4+BrOwxvgUo7ZpLUrKdDqyvV3YfT6URr0xEAQG/AvA+OEcpKi9HVHXOQ2rt6sGO/2lbB7RocO69s79mcqXU499T5SfQuY4FBIqExXhCx91CzlsfWGwyjsrQAVeWqTo+DY6HIxjskmqLiqjJkWYaiKJqTYcUuja4mFYImFDRxkNKF7SKCCI/bEVUsjl8YNamH6Cl27j+K3qDqHBoxSEbK4erfze2iaRoKrDE2fQlNcFVRIIqyVgmYCv3RBmGgMFxts+0yRyqhyFxA1kJeELV11swpSUR/3K+yYq+hoOv/TBUbQVkhix//7NeYNlnNjVFzffo2S55jGdTVlqOlw5+UqN3U0obu7m6ceepSnLliOa68/rbodzIPsbmcHAq97mhCnIQpE1RF5GDIWBnbDGWlJRBECaIogmVZrNtyAA3NnQAG/iUWQ37vGWsiNa8HebCdDhYbdx7Ghu2HUF7sxegR5Whq82HMCDXs7HCwUGDcvbzA60JPMHY/SL5BjOK1koMUX1lmVqXodHKgoDI9jElljCyrautmzCCp7nA5WVA0g4MN7RhRVYoZk0YZtlNhTBmk9K0EMi0dzjdiyefmWjDJGK6VXsDwtc22Kx2ylRowQ8xBkrTKWusMUt/fr9JiLyaMrkr6+/+cg3TScXPgcTvR3NIGQA2xqZn1feullpcWgBfVBqClxbFGqWQcI2qq1Y7G0cnAZsAgURSFS85chPrmTng9Tmxc818oioLVn6wHAAQCycxVKkydMhmLlq3Am6u3YeXyuWB1Lzr3ACfSEuT7npk1K4z/TfXelJcUAIqCpnYf/L0hbNqpMnVEmoGwLolCm4C6KIQjgqpKzjKxnChdZVg6uxwcg4rSglhXbZMXOR1t/SIriqlQP2k0a+YgOR0crrv0JIiShKPNXXhz9VZda5tYFZv2m/pwm24jkMqu5cdOQ1d3IOPS4XxDE1yNVjOaOZV69MfaMVAYrrbZdqUHlWcGieSutnb6sedQEwDrauH9cb8oisICA1X6wRME7Ce4XE7UjarFpi07AGTWFDYXlBV70dzmQ0d3fLjrSL06WaqrVPaBOEiZ9mIrKfJiVrRT8qiRtRg9agSmT52IKZPGY8mx1oTKCH783etQVV4CX09AbXirC9EMdCl2X4HkIKUKR5GQ0oiqUpx98jysPHEuBB3rRBwiQh0bLQCkK3kwmjxNzplJa4ECrwsd3QFNc8hsJ6Y1MU7RSb2l3Rcde+rfZxlGu/dkB5gZg2SO6vJiTJ0wwlJ38L6EJriaEYNkw8bwgZaDlGGVWjqQgpWWtm4cqFdJgcGUg2SGQccgLT3zSkwYq77o58ycgu9df1Xef+OrV18BhXbizTffgtOR3GqkL0BYo25/zEHq7vZjzvyFuH/p8aiK5g4R9eRMyvzNMHvmdKx9/4WsvvvJR+/gX4/9BytPXI1IRK1gu/SsYy1XHvQ18n3PyMOaOhxFXpzq58UJeiUkqXfR7HFgGApzok1f9SBJ2MEQj+JCT1JVnRW7WIZBaZFHayps7iDFh4yMsOdQMwBg3oz0cgzkd2LlyMkMUlzekY6mHwptK2hdDhIQb5cZhoJd2WK42mbblR59lYPU0uHX/mZ1UziQ92vQzZTK8jI8et+dffobE8aPxYRJU3FFRTlKS4ohSVJGwozZoMDjgINj45SG3/3oE3z/Bz/GPX/8pa4Un+Sk5L6bzsWuslI1ibmpuRVhXoDH5UgSERxI5PuekestSbKpwxELKamfe9wOlBR6NGFER3Q8Xo8LyxZMMW34WF5SgAP1LSgscMUSFqPntGrX3Kl1+GTTPoiiZKpzRRY5KQWDRFynVC1kCMiCRsZMHC+9nRRFaQ13E1uN9PUzlitijJt1Bmko2JUthqtttl3pkW8HiTPoDWmVQRrI+zXoZkmxLj+nr+BxOTB23Hhg3HiUl5VoHef7EhzLghdE8IKEI/VNaO/yoyPkwP/99U847/TFuiMV3X/niuzPUlujJqwdbWwGQ7MoHOD8kGTkN3Evxo5IcJg8FlLCi5OiKCi6cejLws2E1DiWQUd3Lzq6e1FY4MaIqtK437dqV0mRB6FoU9j0IbYUYUNJAsvQloTfmAQHiWFoFHldSd+lKRqSIifQ9IM/MZbYQcKs1l4Sg9+u7DFcbbPtSneOfCdpFxW4ce6p8/DJ53vR2qm23bJOAgzc/Rp0DlJHZzeu/fbtABTccO2XMGfG5KRjnn35bTz3ytsAYouZ2vNMAcOw0WRbBRSltmyQJFX4jSR6OTj15nMsA0WRowu+CIZhko4lzhPDsNGSbBkAlXAsDYBKeyzL0OAFEU+99BZKKtXwy5jRI+B0kJ5tFP7+p9vwl9/8CAUeFyRJAkXFzkvTDBRF0c7Lsmy0dxuxNVZCrh4LrRccy3IJxyZeFyXGkDCsFvK7/6GnseKs81FbWQxRFAyvS+x6U6DpdNdQit6zxGuY2fXW25Z4rHpd1M8oio67hgzDRHU44q9hZakXpcVetHb4MKqm1PB6x3J5ZEiSBJqmcfrSGXjlgy0IhXkwNBU3JqN5qCclRFHSFN3JHFbHpqS8LpIkxYUBFUWCKCYfSxwUQeAhipzhnBVECQxDQ1EU0+tNriGiycsHG9owqroUPb0h8NFEcf3comgAMqBAPZ8sK9ozln7Opprf8XM2dqz59Y5dw/j5bXYsqfoDAEWWoNB0yjmbah5ms0YYz1mj+a273jmtEbFrmLhGALH5nMk1HCxrhNn1JjZkukZkd737fs6S66I+Y0IW1zt2DYkvIkkCACavc7a82IuVy2fjoefXqN+BAlEU0l7vxHnYl9c7MRl80DlId/z0ZkydNBYfrF6PX/zub3jh0b8kHXPROStw0TkrAKgL87KVV4NlOY2GS6TjElU4C71q7gjL0GAYFjTNaLvHxGPjElAZBtDVA2V6LKlaqq9v0Bwkp4OLO5ZlWbjd8WrGyVS//ryJtsbr0Oh39+mui35yLJo/B5dcsBLvfbQOc+ctQsnccXHH68eU/rzmuSjZXm/tpW3h2OTzAonXsKKsGIrSAH8gbKDaGl2AZJJAT+4ZUFJcqDErDgcX912j6xLfFoRCTyACt8uBogIPWJbTZCBSjZ9lWbhdsTnidDjiq8dIixmGMF2M7tmIP68sK2AZdf6nu4ZOhzr2nkAYh462I8wLWlWj3lY66iGxDAuKosEw6phiz5j5nFWRan4b3xsrx+rnt9mxqiaTeg84TrUt1ZxNfMZyXSOsH8uaHhv9humxVq+3Ue9IK9fQaEwDsUaYHUs21ZmuEWbHRr9hemxfz1kCh8OR4hmzdg05jkWYF7W5n+rYTM6rHxPL0hBFOW69THW9jXuY9s31TsSgSyOfM2MynA4HViw/Dr29QYQj6ZWAMwXHsbj0rGNx/mkLAEDzIvsaLMvA5+/Bux+s0f7Wl3k9udhVXVWBG77+ZbS3t+H3v/89RD6Ux5Hljnzfs0KvC93+IDp95qKasd1c/MM6dVwtxo6s0HKQUkGf5L551xF8unk/FFnBhDo1pGnVLn3OkFmuDMlNSuzt1NjajdZosmSqnKuk8+mOEyUZobBgKBxKFjP9uPrrGcsVFE2pKr8WczCGil3ZYLjaZttljstWLsa1lyzPfTApQDZV1nOQBu5+DSoGac3ajagbVYvRI2uwYfMOVFWU9VkDy8QKpP4AyzLYv/8IxoyKNUm10ttsoFBSXKT9//KykoEbSD8gMQHZCGbJu/NmjLX8O5zOQRJECRQFVJQUZjBSaGNIlzakVWVFHbt3Pt4OQRQRDvPo7gnhxEVTIWbgIOlzchpbu8ALoqFwKDks34me/QGaoqAoil3ib8NGH2HR7AkIhSOoqSgZ6KGkxaB6O4+oqcIf730ErW2d4Bwsfv7Db/TL7/aXaBjHMmhtacP6DZtw/iVXAOhbBylXuwazg5Tve0ZCQKkcJKOy9kyRWNqqKPHq5JnYRVEUUsg2xZX5+3tDaGrt0hK7AbWvmiRJcHDWNiGqkKmapkD6ChoJhxYXeSB09cCt08waKsJ8NK3mmplVBiYfPzTsygbD1TbbroEFYcutYiDtGlQO0rgxI/GXO28Z6GH0GTiWQbfPB1EUsXvXTkyYMD6pe/pgQmGBF4BKhXrcg62KLf9g0zSszawFhTH0ZfAE2bZvoaJshxkIg9PdE8CRpg5NNZuAF6SMQmzRHwUUBQxNQZIVVJYls1/nnDwPDc2dqKkssX7eQQKaoiAp5u1bbNiw8b8DexVALKO/r8EyDHw+Vbl42aIZ2Lx+DcqKvX32e7naRRJ3B6OwWl/cs3QNa42as2aD2VNGa8whQ9OorYw1zs3ErrNOmI2VJ84x/Zw4cqs+24Nte+shybKm5A2ojSNFSc5IxZuMubqiGG6XAxWlxuHBUTVlcf/ur2csV6g5SIplBmmo2JUNhqtttl1DCwNp1+B78w1jsCwNv19Njj1t+SKcd+aJAzyi9Ljx618e8BYQ/QW13Yj5w5goFJktjp0zEW6nA83tPowfXYmJY2qyOk9tVEPJDCQU6HJyCEcEcCyDpfMno7zYiydf/RRC1EGKiZSmx4qlMwEoGDuyMqsxD3bQ0bDlUMyfsmHDRn5hO0joPynzo4f3Y/r0aTjlpOP7JWSVD7t+8ZNv5z6QPkBf3DM2DYOUjxAbweypdZht8Pf8tgtQxxmOCBhdW4ZR1WUYO7JCszHCixmxJQAwdmRFVmMZjCykEWhaFf+0ek2Gil3ZYLjaZts1tDCQdtkhNiBtF/d8oburE3VjJ2DM2In98nv9ZddAoC9sY+jUDhLJT8olSTsd8mmXfpzHTB+LWVPUHocMo1bA+QJqi5RMQ2zZYKjMxVgVm9Uy/6FhVzYYrrbZdg0tDKRdtoMEoL+kzMeNrUNxcTEEPtwvvzd8JfWBvrCNZZiUSdq9gRA8bic8WSZVW0P+7NK/5BOrJTmWRXtnLwCgRpcD1XcYGnNx+sSRYGga5SVWWx4NDbuyw3C1zbZraMFuNTKgsNKHKh+YNmUCtr+6CsfMSm6f0hfoL7sGAn1hG8OaV7Ft2nkYew+3gGEYuPrQQcqnXfpQoJOLf9SXHDMRew41o8jrRm0/VJsNlbk4dmQlCjwujLEYShwqdmWD4WqbbdfQwkDaZTtI6D+dhYnjx+BHN47pl98Cho4uRjboC9tYmtYq1RLh7w1BUYBZk0bm/Xf1yKddegbJkcAgTRpbg0lja/pt8Rkqc9HrccLrcaY/MIqhYlc2GK622XYNLQykXXaIDbb0/FBEX9imlvlLhtpCvcEIGJrCglnj8/67euTTLpJoTFFUUufsxB5ifY3hOheHq13A8LXNtmtowW41YsPGIEBxkQflwUIIooSG5k6MGVEBhqHR7Q/C1xNEZXnRkKKxiws9mDimGhWlVvNpbNiwYcMGge0gwaYmhyL6wjaOYdDe1YNNOw9j884jAAVMnzASlWWF6AmEseSYSXn/zUTk0y6Xk8MJC6doPdkGEsN1Lg5Xu4Dha5tt19CCHWKzYWMQoLKsEG6XKuCoQG0HcrS1S2vR4eCG3n6CZRi78aoNGzZsZAF75YQt0T4U0Re21VQUg+dFdPkCoCi1d56DZRER1AaviYnOfYHhes9su4Yehqtttl1DCwNpl+0g2bARBcexmDKuFjwvYmJdNVxODpIsg+eHLoNkw4YNGzayg73iw5ZoH4roK9tG1ZbCHwihprIEnb4ABFECL6hVFIlaQn2B4XrPbLuGHoarbbZdQwsDadfwvKIZQpYza9g5VDBc7QL6zraxIyu1Rqx7DzcjEIogHOEBABzX99dyuN4z266hh+Fqm23X0MJA2mWH2AAoinl7iaGM4WoX0D+2cSyDcETA4cYOsCzTLyX+w/We2XYNPQxX22y7hhYG0i6bQQIADHwZdN9guNoF9IdtHKvuWrxuB84+6Zg+/z0Vw/We2XYNPQxX22y7hhYGzi6bQQKGJS0JDF+7gP6xjTyWc6bVobjQ0+e/Bwzfe2bbNfQwXG2z7RpaGEi7bAYJqpQ5y3IDPYy8Y7jaBfSPbScfNwOzpvSgqMDdp7+jx3C9Z7ZdQw/D1TbbrqGFgbRryDtIpG+WKGbfr0X97vCjJ4erXUD/2VZW7NH9Xt9juN4z266hh+Fqm23X0EJ/28UwsXzTIe8gSZKqUXPSuV8b4JHYsGHDhg0bNoYyVr36MFhWdY0ono8kty4fQpBlGTzPx3l9meKKb/wYj9//mzyPbOAxXO0Chq9ttl1DC8PVLmD42mbbNbTQ33YNKwaJpmm4XK6czkFRlOYxDicMV7uA4WubbdfQwnC1Cxi+ttl2DS0MpF12FZsNGzZs2LBhw0YCbAcJwIVfWDHQQ+gTDFe7gOFrm23X0MJwtQsYvrbZdg0tDKRdQz4HyYYNGzZs2LBhI9+wGSQbNmzYsGHDho0E2A6SDRs2bNiwYcNGAmwHyYYNGzZs2LBhIwHDryYwAU8+/zr+/cyruOyCM3H5xSuxe+9B/OqP/4CiKLjonBU4f+Up6OkN4M/3PYY9+w9DFCX88KavYN7saQhHePzyrvtwuL4JC+fNxM1fv7xfOrpbgRW7CAKBIC6+5vu4/quXYeVpJwwLu87/8rfhcbvA0DRG1lbjNz+/GZIk4w/3PIwt2/dg4vg6/PR714HjBs8Ut2rb4fpG3PGnfyIUimDhMTNw09cvH/L37JP1m3Hfv57WvnOovhH//PNtmDh+zKC9Z1bv1/ur1uHeB58CAFz/1ctw0rJFg3ouWrXr0adfxitvfIjSkiL89HvXoW5U7aC1y98TwG/vfhD1Dc0oLirAL398PWiaxs/uvAedXT6cueJ4XHHx2QCAF197D8+89BYKvB786sfXo6qyHN2+HsNjBxqZ2JV4XwEMWrsA67YZHVdWWtwvtg17BmnerKlYNH+W9u/f/fUh3HLTNXjw7tvx1PNvoKGxBTRN47yzTsbj9/8G13/tMvzz0ecAAC/89x3U1lTi8b//BoeOHMX6z7cNlBlJsGIXwUNPvoTy0hLt38PBLgoUHvnbHXj0vjvxm5/fDABY9ckG+Hp68cQ/fguP24XX3l41IDaYwYptiqLg9rvux81fvxyP3ncHVp5+AoChf8+OWzgHj953Jx6970785LvX4vjF8zBl0rhBfc+szsU/3/8Y7r3rVjz419vx90eeBTC456IVuw4casA7H67FY/fdia9deSF+e/eDAAavXdt27sXF556Gx+6/E1MmjcUTz76Kfz3xAk5cugCP/O3XeP2d1TjS0ITOLh8ee/oVPHj37bjonBW490HVaTc6djDAql1A8n0FBq9dgHXbjI4D+se2Ye8gTZk0DrXVFdq/m1vbMXPaRLhcThy/+BisWbsRXo8bs2dMRm8giMNHGjF5whgAwJp1mzB31lRQFIW5s6bi4/WbB8qMJFixCwDqjzZjy/Y9WHbcPO3Y4WBXYaEHbEKX5zXrNuGYWVMBIGrXpn4btxVYse3QkUawLIMZUyeCoihMGDsawPC4ZwT3PvAUbrz2SwAG9z2zaldJUSEKvG4UFxVqxw91uw4casDcmVPgcjmxYO50HDrciJ7ewKC1a8miudq4Zk2fhLb2LnwcfWZYlsWsaZPwyfrNWLthKyZPGAuXy4m5s6bik+j4jY4dDLBqF5B8X4HBaxdg3Taj44D+sW3YO0iJKCkqxM49BxAIBLF73yG0tncCAJpa2rHy0uvx+rur8Y2vXAwA6OjsxphRtQCAMaNq0d7RNWDjTgczu+554EnceO2XQNOxcMxwsEsUJdxwy5348jd/glWfbACg2lVH7Bpdi/aO7oEatiUY2dbY3Iqy0mLcftd9uOIbP8a7H60FMDzuGQAcOnIUTqdDW8iH0j0zs+sbX7kE1377dtz/0H9wwpL5AIa+XSNqK7Fp224IgohtO/eBFwS0tXcNCbs2bNqB2TMmo7PLh1EjqgEAdaPUsarjrwEAVJSVQJJlhCO84bGDDansMsNQsAuwbhs5Dugf2wY+eNzP+MFNX8Fdf30IZaXFmDiuDgVetVt7bXUF3nvpQbz2zip8/2d/xL2/vxUUKMiyKhMlK0qckzHYYGTX+o3bUOD1YNb0SVi7YYt27FC3CwBu/e61GDdmJHbtPYTv/+wPeOXJe0BRam8+QP3fwWwXYGxbMBTGvgNHcO9dt4KiKVz1rVuxfOnCYXHPAOCDNZ/huIWztX8PpXtmZJckyfjvWx/hm1+9FK+/sxodXT6cv/KUIW/X9CkTsGThHFxz489x3MLZqKmuQIHXPejt2n+oHus3bscN135RzXlTyDMjg6IpgAIUJSb9p8gKKEptZ5F07CBCWrtMMNjtAqzbpj8O6B/b/ucYpGNmTcXD9/4af/r1DyCKEkbUVGqfMQyNs087AXv2H0Y4wqOivBT1R9W4Zn1DMyrKSgdq2GlhZNe7H63Fnn2H8bWbb8PLb3yAh/79ItZt2Drk7QKA6VMmwO1y4ZhZU1FbU4nWtk5UlJWi/mgzADW0OJjtAoxtqygvRU11BaqrylFVUYbyshL4enqGxT0DgF17D2LiuDrt30PpnhnZtWXHHhQVerFs8TzcceuN2Lv/MJpa2oe8XYDKjD12/5247qqL0O3zo7ysdFDb1dXtx22//Rt+feuNcDocKCst1vLE6huaUVleisryUhyJjr+towscx5keO1hgxS4zDGa7AOu2JR4H9I9t/3MO0v5D9ZAkGS2tHVj3+VYsO24+Pli9Hms3bIWiKPhs03YUeN1wOjgsPXYuNm7ZBUVRsGnbLiw5du5AD98URnb96Oav4rH778QDd9+Oc85Yjq986Twsmj9ryNu1ZfsebN+1HwCw72A9enoCGFFTiaXHHoONW3YBADZuGdx2Aca2TZ8yHkcbW9De0YWW1g709ARQUlQ45O8ZQUtrB8rLSrR/D6V7ZmQXTdPYsWs/gqEwAsEQ2jq6AEUZ8nYpioJ9B+sBAC+/8SGOP3YeGIYetHbxvICf/OpuXPvlCzFxnJq3t/TYY7Bx6y6IohomPG7hHCyaNwt79x9GOBxRx79orumxgwFW7TLDYLULsG6b0XFmx+Ybw7rVSFtHF77309+jo8sHmqIwpm4EFi+YjTfeXQOapnHzdZdj/tzpaO/owh/ufQRH6pugQMEtN12DubOmIsLz+OVd9+PQkUYcu2A2brz2i4OitNqqXXo88NhzqK2uxMrTThjydrW2d+LPf3sMDY0t4AUB37v+KiyaNxOyLOOP9z6CTVt3Y/LEMbj1u9cOmu7WmdyzdZ9vw//949+I8Dy+/Y0rsGTR3CF/zwguueb7+Nvvb0VFdLc3WO+ZVbsURcGDjz+PV99eBQoUvnjhmbj43NOGvF29gSB+/pt70dreiZG1Vbj1u9ehqNA7aO168PEX8MQz/8XYuhEQRQkA8Mdf/wC/+v3f0dHZjbNPPwFfvPAsAMArb36Ip55/HYVeD351642oLC+Fz9+Ln915T9KxAw2rdhnd13t+95NBaxdg3Taj4/7x59sQ4YU+t21YO0g2bNiwYcOGDRvZ4H8uxGbDhg0bNmzYsJEOtoNkw4YNGzZs2LCRANtBsmHDhg0bNmzYSIDtINmwYcOGDRs2bCTAdpBs2LBhw4YNGzYSYDtINmzYsGHDhg0bCbAdJBs2bNiwYcOGjQTYDpINGzaGJL73sz/g5dff1/69+tON+NrNt8X12rJhw4aNbGE7SDZs2BiS+OoV5+PxZ16FJKnNUx/7zyv42pUXDgqFcRs2bAx9DLxGvA0bNmxkgelTJmD0yBp8+PFnKC8rgSwrOHb+LKxZuxH3P/QMeIHHpPFj8NPvXQeXy4knnnkV7360FqFwGCNqKvHLH98Ar8eNBx57DhRFYeuOvSgtKcZtP/zGQJtmw4aNQQC71YgNGzaGLHbs3o8/3/c4igq9uPS80zFyRDV+8uu78X+//QkKCzy4/6H/oKSkCF+84Ezs3HMAk8bXgWEYfOfWu7DsuHm48Asr8MBjz+G5V97Bv/7vV6itrhhok2zYsDFIYDNINmzYGLKYPmUCigo96OkNYOG8mXjhv++ipbUDN/zwDgAAL4hax/a6UbV449012Lx9DxoaW9DQ2KKd55QTFtvOkQ0bNuJgO0g2bNgY0pg2eTx6eoOgKAoKFMydNRW//fm3444JhcP42s234ZwzluOKi1eiqqIMvYGg9jnD2OmYNmzYiIe9KtiwYWPYYNG8WVj/+TZs3bEXANDV7UcwFMaR+iZ0+3pw8bmnobqqAnv3Hx7gkdqwYWOww2aQbNiwMWwwemQNbv/R9bjrrw9BgQKP24Vbbr4GE8aNxpJFc3H513+MMaNqMXJEFWTZTr+0YcOGOewkbRs2bNiwYcOGjQTYITYbNmzYsGHDho0E2A6SDRs2bNiwYcNGAmwHyYYNGzZs2LBhIwG2g2TDhg0bNmzYsJEA20GyYcOGDRs2bNhIwP8D62Z0yq501U0AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 583.3x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "A two-row regime band above a rolling volatility series in percent. The dark risk-off segments concentrate on the peaks of the volatility series, and the risk-off average rule sits above the risk-on one."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, (ax_band, ax_vol) = plt.subplots(\n",
     "    2, 1, figsize=style.FIGSIZE[\"dual_v\"], height_ratios=[1, 3], sharex=True\n",
@@ -940,8 +1709,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8d2d047",
-   "metadata": {},
+   "id": "577fd3ea",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009864,
+     "end_time": "2026-09-08T23:45:13.823752+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:13.813888+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Figure 1.5 inputs\n",
     "\n",
@@ -953,9 +1730,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "173e864c",
-   "metadata": {},
+   "execution_count": 25,
+   "id": "5c9ad29c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:13.851669Z",
+     "iopub.status.busy": "2026-09-08T23:45:13.851486Z",
+     "iopub.status.idle": "2026-09-08T23:45:13.858095Z",
+     "shell.execute_reply": "2026-09-08T23:45:13.857715Z"
+    },
+    "papermill": {
+     "duration": 0.030135,
+     "end_time": "2026-09-08T23:45:13.863844+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:13.833709+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "ARTIFACT_DIR = OUTPUT_DIR / \"figure_1_5\"\n",
@@ -975,8 +1766,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce1085ae",
-   "metadata": {},
+   "id": "d53405ee",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012707,
+     "end_time": "2026-09-08T23:45:13.883753+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:13.871046+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## What each factor earned in each regime\n",
     "\n",
@@ -993,9 +1792,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fa204a48",
-   "metadata": {},
+   "execution_count": 26,
+   "id": "e96aed80",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:13.904809Z",
+     "iopub.status.busy": "2026-09-08T23:45:13.904645Z",
+     "iopub.status.idle": "2026-09-08T23:45:13.914815Z",
+     "shell.execute_reply": "2026-09-08T23:45:13.914426Z"
+    },
+    "papermill": {
+     "duration": 0.023332,
+     "end_time": "2026-09-08T23:45:13.916853+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:13.893521+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "annualized_by_regime = (\n",
@@ -1005,10 +1818,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8a9b6e65",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 27,
+   "id": "39acc4bc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:13.932053Z",
+     "iopub.status.busy": "2026-09-08T23:45:13.931785Z",
+     "iopub.status.idle": "2026-09-08T23:45:14.265371Z",
+     "shell.execute_reply": "2026-09-08T23:45:14.264848Z"
+    },
+    "papermill": {
+     "duration": 0.347734,
+     "end_time": "2026-09-08T23:45:14.268625+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:13.920891+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAGRCAYAAACex0zVAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAgt1JREFUeJzs3XV4E1kXwOFf0tSxFodSoFiR4u7u7g67uC2wLG6LOyxui7vb4u4OxR0KFKgr9Sb5/ijN0tIG2TZp+c77PPssnUxmzr2ZmZzce2euIjw8TIsQQgghhNBRGjsAIYQQQoikRhIkIYQQQohYJEESQgghhIhFEiQhhBBCiFh++gRp0/Z9pLErwpnzV4wdSrwKlKxFg5bdvlg+bc5S0tgV4eWrNwaJo26zLjiVrffN60fX7eVrt35of05l61G3WZd4X4+vXhKK63s3chaqzJK/NybI9pzK1qNJ254Jsq3PfWucCX28vH77jnrNu5IlTxkG/PEnWq2WURNmkaNgJQqWqo23j2+C7CchvH77jjR2RZg1f4WxQ0nSvvWcOnP+CmnsirBp+76vrmuI42LfwRNkL1iRG7fuJvi2oyX29UYkP8kiQdJoNOQrXoNqDdrHWH7o2BnS2BVh9/4jRopMJGdZMmVg06q/aNui4Xe/d/WG7aSxK5IIUX3pv8T5X8z6awWXr91m5JC+dG7XnMvXbrNk5UbKlCzCxDGDSWtrY9B4Pvdr32HyZZZEGOK4qFG1PJv+/ovChfIn+LaNTY7lpEtl7AC+hVKppG7NKqzfshsfXz9sbdIAcPzUeczMTKlVvZJxAxTJklKppHyZ4j/0XncP7wSOJn7/Jc7/wuWNK+nT2TKgd1Qr3+Yd+wHo3qUttapXNHg8nzNk/Qv9XN64Aol7XKSwtqJiuZKJsm1jk2M56UoWLUgA9etURavVcu7iNSCqWffYyfNUq1yOd+/d6DlgJIXK1MU+fwW69RtO4MegOLfTZ/BY0tgVITIyEviyW8LPL4B+Q8aRs1BlilVoyPrNu7/YRnBICHMXraJCrVZkyVOGCrVace3mHd3raeyKMHvBSvoMHouDUxXKVm/GvYdPdK/fuf+IGg07YJ+/Aj36jyQkNExv2Tdt30fRCg3IXaQqk2cuQqPR6Opg5dqtFK/YCPv8FWj360BcXrvq3udUth5Dx0xj5J+zyFe8Bk5l63H2wlXd6y5vXGnarhfZHMvTqlM/vH38dK9ptVomTJtPnqLVcHCqQvd+I3D38Iozvus371KnaReyOZbn177DiIiI+Kb4YvvWeon9mcXuRm3QshuN2/Rg1IRZ5ClajWIVGrL/0IkvthPdLTN55iLddnMXqcqBwyepWLs19vkrMGL8zC/e12fwWGbMWwZEfdaf//oLCwtj7KS5OJaoSaEydWPU9+OnL2jStid2+cpRpV5brt/8srsguizXb96lfM2WtOzY94s437i+p0nbnmTJU4aSlRuzaMV6tNqYjzPTaDS07tyf3EWq8sb1fZz1GB4ewbQ5SylUpi45C1Wm52+j8PTy1tXhhcs38PTy0XW19B08FoBWnfvR59O/P/9M8hStxr6DJyhbvRn5itdg8coNXLh8g6r125GjYCXmLVr1TfuOrtf4ziGnsvW4eOUGF6/cII1dEabNWap73wc3D7r0+gP7AhWp0bADru/dAPDzD6Bj98FkcyxP4XL1mDRjIeHhEVy6egvHEjXjbIUODgnhz6l/4VS2HvYFKtK93whCQ8Nwfe/G7yMnU7xiI7LmLUvLjn1xc/cE4Pyl66SxK8Lpc5ep3aQzZao105Vn+erN9BwwkmyO5Zkxbxlp7IrE6DJq1r4XNRp2+CIGQ1xrtFoti1duoEDJWhQsVVuXDEdTq9XMXbSKQmXqkrtIVUaMn0l4eES8x8XVG87UbNQRu3zlqN/iV569cIlRP3v/OUaTtj3J5lie5h164+cfoPdz+vwcX7U+qvXW+d4jXXxN2/Wi+qcehm+5hn9L3dy5/4iGrbphl68c5Wu0YO8/x+LcToOW3ejU43dmzV+BU9l65C1Wne27D+pe/xgUzNAx08hXvAb5itdg2NjpfAwKBvQfy8L4kk2CVKVCGaytLDl9LupL8OHj57z74E6jejVwfedGUHAIwwb2pGXTeuzad4RlqzZ99z60Wi09BozknyOnGNT3F1o0qctvwybgfPdhjPWUCiVnL1ylVdN6jBvxGx6eXvT6bXSML6mps5dga5OaAb068/jpS6bOXgJA4McgWnfuj7uHF5PHDSFzpgz4BwTqjev0ucsMGdCdCmVLMnvBSt2X/bpNuxg6ZhpVKpZm8tgh3Lv/mOYd+hAcEqJ778q1WwkIDGRg31/w8fFl1ITZQNQFr0O3wdy++4DxIwdSqkRhXN+56d535vwV5i1eTYM61Rg+uBdatJibmcUZ34o1W2jVrD7lShdn9/6jHDlx7pvji/Yj9aLPuYvXcPfw4s9Rg7CysqR7/xG8/+D+1fd5efsybc5SunVuRb48DixbtYk79x/FWKfXr+0pX6YEABv/nseYYf10r1257oyPnx+/9emKr6+frr79/ANo2q4X7h6eTBr7O/Z2WWjfbWCcdQHQvttAWjerz4jfe3/x2qTpC7nlfJ/J44bQsG51QkPDUCgUMdaZNmcpp85dZt3yOdjbZYlzH9PnLmXmX8tp07wBo/7oy9GT5+jc6w80Gg1jhvUjf75c2KRJzca/51G5Qml6/tIOgBG/96HXr+2/2J6nlw8z/1pOj67tSJ0qJaMnzGbQ8Il0bNOUTBnTMWnmIl2SrW/f0eI7h+bPGItNmtTkz5eLjX/Po0WTurr3bNq+jwKOuenSrjk3ne+zcNk6ABYuW8ehY2cYMaQP7Vs1ISg4BFNTFd4+vri5e+IWR/I/ZNRUFixbR7OGtRn9R1/y5XXAwsKcwMCPvHj1hv69OtGnR0dOnLnIlFmLY7y3S++hVCpfipmTR+iWTZ65iNCwcOZNH0vvbh2wtLBg78HjQNTxf+HyDZo2rB1jO4a61uw/eILRE2ZTopgTY4YP4N37mOfKouXrmTh9AQ3qVGPkkL5s3r6PFWu3xHlcuLxxpVm7XiiVSqb+ORSFQkHX3kNjxDxo+CRq16hEg7rVOXX2sm6sU3yf0+ca1auBUqnk2Mmo60xA4EcuXomqu2+9hn+tbtw9vGjSpid+/oHMmDSCXA7Z6dp7KKfPXY6z/g4cPsmtOw8Y2KcrCoWCYWOno1aro8o6bCLrt+ymb/eO9OnWgbWbdvL7iEmA/mNZGF+y6GIDsLAwp3qV8pw+fxmtVsvxU+dRKpXUq1WFtLY21KhanifPXmJpacGGrXvi/HX+NS6vXTl++gJDB/akS4cWoIXN2/fxz9FTFC1cIEYs+7auwNvHl9t3HpI7Vw4uX72Ft48v6dLaAtCkQU2mjPsDiLpoP3v+CojqFnT38GLtslm6i+HGbXv1xrVw9gQK5s9DzaoV2HfwOIeOnaFpw9qsWLOFjBnSMXfaGBQKBeEREfwxeionTl+kcf2aAJQoWojFcyYCcOL0BS5cvgHA7TsPePDoKRNHD6Z7lzZA1Jiu6FakFNbWAKRJnYr2rZvE+YUYbd70sdSqXpHChRw5duq87tfit8QX7UfqRR+bNKlZtXgGAOZmZnTvP4KTZy/RqW2zr753zdKZ5MvjQMoUKbh+6y7PnrtQ5LOxD0Wd8mOXJSMADetWj/He+Op7/6ETuLl7smTuRIoXLUSJYk5UrtOG6zfvUqVimS9i6N+zMwP7/gJEtXR9LmXKqM8ml0N2funY6ovk6OCx08yav4LpE4ZRoWxUIhccEkJ4eFTLnpmZKRbm5qxcu5WSxZwYO3wAAG9dP7Bg2VruPnhCudLFsbWxwd8/UFfGIk5RdVC2VFGKOsU9FmT1khnky+NAUFAw46bMY9qfw6hVvSIhIaGMnTyXF6/ekD6drd59R287vnOoepXyWFqYY2tjo4stuo56/9qe4YN7ExkZyd/rtvHsRdR7UqawRqFQkDVzRhr+Uh2VKurS16heDVwenCdN6lQxyuHr68+WHfvp0KYJE8cMjvFa/ny52bd1BS6vXblz/zHp09ly/dadGOu0alpPV7Zo9tmysmrxdExNTQFo3KAme/85zqQxv3Pm/BUiIiJp3CDmeWGoa82GrXtIkzoVKxdOw8LCHJs0qbh45Ybu9RVrtlCpfClGDukDwMUrNzh45BT9e3b+4riYPGsRwSGhLJz9JxkzpCNdWlvax2o9Hjt8AN06t8bN3ZOtOw/oYo7vc/pchvRpqVS+FEdPnGPYoF6cOntJV3ffeg3/Wt1s33MQP/8AVi2eTo2qFWhYtzqHjp1h+ZotVKtcLs6YNq/6C4VCwf2HT1i7aReeXj6YmZmyc99hWjSpqzufne89YvueQ8yYOCLOY1kkHcmmBQmgfp1qvHn7nhevXnPq3GUqlC1BWlsbHj15TsXaralYuzUr1mzBVKUiIPD7Wx+i+9JnzV9BjoKVyFGoEu/dPPDy8omxXnh4BAP++JN8xWsyZPQU3esBAR9165h+dmKnS2tD2Kcvpzdvo7o7HHLaf3Nc0d9/mTNlIHXqlPj6+uviLVIov+4LstinC8DrN/9+oX7+6yudrY3uSzK62yW+OEqVKMzm1fM5dvI8BUvXYersJbpuydii95Hu0+DMsLDwb44v2o/Uiz6fJw358joA4PNZF6I+0Z9durSfyhMe/s37ja++o8vcvEMfchSsROU6UUmpZ6xjK1qReBIQgIljfqdXt/Z07DaYSnXafPGr9s+p87/Y9pBRU6OO6YKVGDJqKj6+fgR+DIqxn2JFPn0+erpBvya67tJ+qrvo+rC1TQNAeHj4N+87vnNI7/4/JR8qlQqbNKkIC4t6T7+enfhz1ED+GD2VklWasGvfYd17YidHAK9evwXAqUC+L1774OZBvRa/ULxSI2YvWIFWq41x7gMxEupoBR1z6+ID6NimKa7vPnDz9j2On7pAiaKFyJ4ta4z3GOpa88b1PXZZM2NhYf7Fa+HhEbz74M75S9d1x9Du/UfjPXZfv4461stUa0aOgpVo/+tAADy9/13/y3Ps65/T55o3qsNN5/t4eHpz5MQ5ihYuQA57u2++hn+tbqLP1+hjNHWqlOR2yM7rN3GfGyoTE901JzpxDQsP1yWFnx8P0ddBl3i2JZKOZNOCBFCnRiWUSiX/HD7Fleu3mTx2CAB/jJ6GiYmSV/fPkTKFtd5b1c0+XaA8PL3JkjkjgR//vdBEX5x+7dSKZo3q6JZnzZwxxjZ27D3Ehq17OLp3HWVKFmXanKW6MSlfkyFDOgDu3HtE4YKOAF+MH4mPm7sn/v6B5MyRDYAc9nY433uIVqtFoVBw+1Mzcnb7rPo2ExVH+n/jiP7lEjuO+rWrUq9WFbbt+ofeg8Zgny0LHds0/aZYvze+76kXM7NPn6GXNw457QkM/BjnetGePnsZFU/2bN8c+9coTUwACA0Ni/NLJbboY2ve9DHkdsihW17AMfd37zuFtRVjhvbnt95d6T1oDO1+GcjL+2d1r1epWJqiTgVYsGwtrZrVxzFvLgb3+5X2rRoDkDFDOmxt0pAyhXWMrofbdz59Ptntvjum75EQ+1aamBAWpn/s3udMTU0Z0KsLPbq0ZfTE2XTrN4LiRQrpzqXY7LNFdUvef/j0i9cmzljI69euPL55ggzp09KgZTdeuXz/oxUqlC1BdvusHDp2hrMXr9K9c5sv1jHUtSZD+rRcveFMSEgolpYWMdYzMzMlS6YMZM2SiXEjftMtT2FtFee2os/vDSvnxkg+Czjm4fadB3pjju9ziq1R/RoMGT2Vk2cvcersJfp27xi172+8hn+tbqLL4Hz3ETWrVcA/IJDnL19/9yD0HJ+OZ+d7nx3rn477HPZRr33vsSwMJ1klSLY2aShXujh/LVlDeHgEDepEfbGHhITg5eXD/kMnuOV8n7eu78maOQMQdYs0EDVYtFJZ8uTOAcDwcTPImT0bazfu1G0/Z45sVK9Sjh17DpEmdSpyZLfj7v3HjB85MEYcISGhAJw4fZFbzg9Ys3HHN5ehZtUKWFlasGDpWpRKJZeu3sTXz1/ve6bMWkzDejXYuHUvCoWCjm2bAtDzl3YMGjGJ30dOpljhgvy1eDUOOeypWa3CV+MoWcyJLJkysG7zLuyyZOLZSxfu3n+MXdbMQFST+vlL16lbq4ouwTD5lBR8q6/FlyVTBt66fsDljet31UueXDmAqDEdFcqWZMWaLV+s4+cfwNhJc8mTOwcz5i4jS6YM1KxW/rvi1yf64jZj3jKqVS5H5Qql9a7fqF4NJs9axKLl6+naoSWmpip8/QKoVL7Ud+03IiKCtl1/o2jhAuTJlQMfH18UCgUK/m0xm/bnMOyyZmLrzgP8PnIKB3euIm/unOTNnTPGtnp0bcu8xauZNGMhmTKmZ92WXZQrXYzCBb9sNUlISqXyP+87h31Wrt28w8ZteynqVEDX7RgXrVZLr99GYWtrQ1Gn/Lx380ChUKA0UXL1hjO9Bo5m4ujBMbp906W1pXH9mmzesZ/06WzJnSsHV687M3vKKEJCQvHzD+DIibO8cnnLtZvOpP/UavC99dC+VWNWrd+Oh6f3F91rYLhrTZMGtbhw+QaDR06mQtkSLFm5Icbr3bu2ZeL0BWzb9Q9lSxfj8dMXtGwS9w/R9q0as3jFBuYs/Jv2rRoTGhqGqanpV491fZ9TbLY2aahasQyLV2zAw9ObJg1qAd9+Df9a3bRqWp/ZC1by57T5uHt6ceT4WdRqNb0+jbf6VrY2aWjZpB4Hjpxk/pI1aLVaDh07Tetm9bGxSQ18eSwXKpD3u/YhEk+y6mIDaFC3Gn7+AZQoWoisn8aBTBzzO6ZmpoyfMg8zMzPq1qqiW790ySIUKpCPVeu3o1ar6dimKVUqluHshas8f/WaxXMn6tZVKBSsWjSDZo3qsHHbXsZOnovrezd8fP1ixNC2ZSNqVq3AkpUbOHz8DP17dv7m+DOkT8uGlXNRKBSMnjAbM1NTvV+u6dPZUqp4YcZNnsv7D+6sXjJD94unS4cWzJg4nNPnrzB64mwKFsjL7k1LsbK0/GocFhbmbFr1F1kyZ2Ts5Lm8e+9G88b//uKqVa0ikWo1oybMYvOO/fTp3pHWzep/czm/Jb72rRrj5x/AgcMnv6te6tWqQtOGtblz7xGXr91i7bJZX6yTOlVK3D29GD1hNpkypmfb+kVYW8X9i/dHdO/SmorlSrJ89WbmLV711fVtbFKzf9tKsttnZeZfy5m/ZA1e3j66LrhvpVKpaN+6McdOnWfwiMn4BwSyZtlMLC0tdOuYqlRYW1kxYfRgLl29Ge/D/kb83oc/fuvB1p0HmDJrMbWrVWL9ijkolYl/Wfiv+/5z5EDs7bIwcvxM9n0a6BwfhUJB+9ZNuHn7Hr+PnMyjJ89ZOPtPsmfLSnh4BJ6e3mzb9c8X71s4+0+6dmjBpu37GDd5HlqtltCwMIYN6kkOezvGTp6Lm4cX7Vo2/qE6AGjXqjGeXj5xdq+B4a41XTu0oH+vzhw/dYG/Fq+mW6zWrN96d+HPkQO5cOUGw8ZM4/LVWwTE03LrkNOevVuXY25mxoRp81m5bhs+vn5fbSnX9znFpVnjOtx/+ITChRx1LYHfeg3/Wt1kypie/dtWkiplCoaNmcazF69YvWRGnOOPvmbejLF0atuMRSvWs+TvjXRp15y50/+9C/R7jmVhWIrw8LBv698RIpmI7vJ4eEMuNuLrRk2YRVBQCPNnjjP4vt3cPSlYug4zJg7X3SwhhEgaklUXmxBCJKT1m3ezffdBDu1aY/B97zt4guWrN5PNLjOd2zU3+P6FEPpJgiSE+L+VyyE7J/Zv1A2mNRQ//wAG/DGeTBnTs3TeJN2NB0KIpEO62IQQQgghYkl2g7SFEEIIIRJbskmQmnUexMwFMccJLF+3g3J1OhopooTz94ZdHDx2Tvf3pNnL2br7y7mhIKoenr54neAxHDx2jr837Erw7X6P8PAIho2fq3ua9/fUy4SZS3nh8tYQYcbwwc2TWs17Jvp+vH38GDZ+7nff9fYtJs1ezq07/z6nZcGKzdxw1v+8moTUrPOgBNtWuTod452H8UcY6vONS2J+5kKIr0s2Y5BSpbTmhvMDwsMjMDMzRaPRcO7STWzSfPkUXJE8mZmZMnPC7z/03vHD+iRwNElLWts0P1w33+u3nvFPKyMMx5CfuRDiS8kmQYqMVFO8cH4uXXemaoVS3HnwlNw57bl83Vm3zv1Hz5m7ZD1BwSFkzpiOcUN7Y2uTmkPHz7Pn4ElCQsOwtrJk8ugBpE9rw8Fj57h97zFarZZ7D5+RJnVKZk/8g1SxHjpXp2VvunVsxqHj5wkNC2fMkJ78c/QsN5wfkDVzBmZO+B1zMzM+BgUzb+kGHj99hUKpoG2zujSsE/VMpr5DJ1OjchnOXbrJsxdvaNG4Jt06NmfHvmNs33sMK0sLtu05wupFUZMYurx9x9Dxc3j89BVlSxVh9O89YsR00/khi1dtYfXCqPU/uHsxYPhUtq+erXuWzK07D9mx7zg2aVLx+NlLlswey/OXb76oo7sPnrJk9TYAzl26ycwJv7Ny/S7yOGSnbfOoyRM79xnFoN4dKV6kAH2HTqZezUrsP3yamlXKksLa6qv1OG/pBlJYW9Gjcwuev3xDpz6jWLVgAgXy5WLL7sN4evrwW68O1Grek/VLpnDh6u3vqpfY8cVV15+LiIhk8aqtXL5+B61WS8fWDWlctyrePn7MX74R1/fuBAQG0bppHVo3jXo+1Nt3bsxZvA5Pb1/MzcwYM6QnlhbmaLQa1m7ex7nLN/D1D2TK6AEUyJcrxv6adR5En19as3X3YTq2bkSZ4oWYs2Q9D5+8RKGAft3aUbFsMdw9vJk0eznv3Dxwc/ciQzpb6taoQMfWDandoheXj278rmPSy9uXmQvW8OadG2Zmpgwb8AuF8v/79O6lq7dx+vw17tx/QtbMGZg/bQTD/5xH5fIlaFC7MpNmLydb1kzcuf+EFy5vad20DjZpUrH34Ck8vXyZMKIvRQrlQ6vVsm7rfg6fuIBWq6VezYr80r4p3j5+jJm6CC9vX6ysLBg1uAf5Pj2sNVKtplPvkXh5+9K5zyga1a3KjdsPqFSuOA3rVOH85ZsM+3MeB7cuxtYmNfOWrscuSyZaNanNP0fPsmnnQdRqDaWKF2JI384xnqG068Bx7j96rkucb919xMp1O1k6Z2y814n4qNVqFizfhPP9x4SEhjG4T2dKFClA61+HMHPC7+T69Aye/sOm8muHphT/NG2KWq1hxoJV3Lj9EFNTE7q2a0q9mhXj/Uz+3rALhULBvYfPsEmTmt/7dorxmV+8eptla3YQHhFOHofsjBnSE1NT0zj3IYT475JNF1toaBi1q5fn8IkLABw+cZ461cvzMShqNvTAj0FMnbuSaWMHsm3VLKpUKMm6rVEPyMubKzsLpo9g47Jp5LTPyrY9/3bT3LzzkG4dm7F5xXQiI9WcOn/1i30HBH7E2tqSNYsmUbZkYUZO/Iu2zeuxecUM3Dy8uHjVGYAFKzZhZWnBxuXTWDh9JGu37OPO/Se67Tx57sKcyUNZMH0EazbtJTQ0jFZNalOpXHF6dG7B+qVTUX16WrWHpw+TRvZnw7JpHD5xgTeuH2LEVLxIfiIi1Dx57gLAsdOXqFez4hcP2jt/+SblShVm9cJJRERExFlHVSuWolmD6jRrUJ31S6eS6dNj+PU5ePQsi2eOpk2zut9Uj2VLFtZ141x3fkCJIgV03Tg3nR9SuoRTjPV/tF701fXnNu08iLmZKVtWzmD9kils2nEQH19/UqVMQYeWDVi9cBJLZo1m0d9bCPwYRKRazbA/51KzSlk2LZ/OvClDsbfLBEBYaDgF8jmwasFEqlYoGW834IUrt1j51wSqVyrNwpVbcCqQhy0rZ7Bk1hjmLF6LWq1hzZa9ZM+Wmd3r5jFpVH+yZc1En1+/fD7Otx6Tk+esoHmjmmz9eyYTR/Rl5sKY3dR9fm2DY96cjBrcnfnTRnyxH4C7D54ybexA5kz8g8V/byUoKIQV88bTqG4V1m87AMCx05d5/fY9m5ZPY9Py6Vy7dZ8nz15x7PQlrK0s2b56NnMm/kEO+yy67apMTJg7aSjp0tqwfulUWjWpTZmShbl55xEANz4dJzc/HTc3nB9Sungh7jx4ypFTF1mzaDJbVs7k48dgzl2+GSPmmlXKcuXGXd08eifPXaVOjQp6rxPxiYiMpHrlMqxeOIkBPdozcdZStGhp2aQ2+w+fBsDDywc3Dy+KOjnq3vf85WvOXLjO9tWzWLNoMmVLFv7qZ7Jz/3GGD+zG+GG9Y8Tw7oMHK9bvZPGs0Wz9exZZM2dgz6FT8e5DCPHfJZsWJI1WS9FC+ZgxfzU+vv7cffCMYb/9qns66/1Hz3H38mbo+DlA1K+3nNmjnsCazS4T5y/d4uadh9x//Fw3EztAXofsuulI8udz0I1/ia1yuRIoFAqcCuTh6QsX3YXeMY+DbtLGC5dvs+Kv8SgUCmzSpKJW1XJcuHKbIoWipk+oUKYYKhMTcuXMhqmpKb7+gWSOZx6v0sWdsLAwx8LCHPusmfDy8cPeLrPudYVCQZtmddh36DTDfvuF42cuM/PPwV9sJ3u2LFQqV+KrdfS9WjerG+PW5K/VY7HC+Rk7dREhoaHcuP2Ats3rsX3vUdq3bMDDxy8oOqr/N+33a/US7Wt1ff7yLQI/BnH5etQs7OEREbh5eGFrkxoLC3NWbdzDC5e3KFDg7uGNSmXCx6AQGtSuDEQ9qTuapaWFLsErlD8Puw+ciDP2di3qY/Jp2oRzl29y7+Ez9vxzEgCNRouffwCZ0qfjhctbIiIi8fUL4LMZRL7wtWMyOCSqrn18/VmyaivAD43Pia7z3A72WJibU6ls8aj95s/D2Us3P9XnTR48ecGvA6IethgcEsoHdy/Kly7KP0fPsXDlFlo3rY25mZnefZUt6cTaLXvRarU433/CL+2acvn6HUoUKUBwSCj2dpn5Z9U2Xr95T89BfwIQGhaVoH4udaqUFC6Yl2s371G+dDEuXrlNz84tf+gcsDA317W6lSpWiI9BIbh7eNOoThU69R5Jn1/bcuLMlS9+oGS3z4pjHgfGTV9Ch5b1KeiY+6ufSY3KZcmc8csfKFdv3MXdw5v+w6YAEB4RSfnSRePchxAiYSSbBAmi5i6qVbUssxevo0KZorpWBYiax8cuS0bWLZ4S4z1arZbfRkynmJMjzRvWoIBjLi5cvhXn9lUmJl99HL5KZfLF3/G+RQGKOL7gFApF1Ha+cZLa+NatVa0c67bu5/GzV6ROmUKXoHzO5LN5jOKro3hCJ1IdGe/rJnHMj6SLN456tDA3o1D+3Djfe8K7Dx5UKFOUOUvW8eDR86gv3m+Y8PWL/XxDHcZX11qtlgE92umSx2iXr99h8aqt9OrSkpaNa9H16Rg0Wi0ajRaFAt2M3fpi0hJ3TDHmstPChBF9ye0QczbxWtXKsX/4Gbr9Nh6bNKn4o19XvfuL3ucXMWijd6Nl8azRpEwR/1xl30pXl5/v99OOtFot7ZrX03VHfm7d0imcuXCd/sOm0qNzS+pUj39OvCyZMmBpYcHdh88wNzOjVLGCLFm9jdv3HlO6WCEUCgVatNSsWpaBvfTfoFGvRkVOnruKtZUljnlzkjpViu86B+JiYqJEgQJLC3NSWFtRuXwJzl68zqnzV5k4sl+MdS3MzVgwfQR3Hzxl8aqt5MxuR79ubfV+JvGdV1q0FHVyZPq4QV+8FnsfQ/t3/aGyCSFiSjZdbNHq1azE6fPXqF+rUozlBR1z4+7hzanz1wAICg7B1y+AgMAg7j96RrsW9XHIkY3HT18mWmwVyxVjx76jaLVa/PwDOX76MhXKFv/q+zJlSMcHd89v2ocCBVqNBgBzMzNqVyvP1LkrdS0b+sRXR//G4KVbN61tGu49fIZareHW3Ue8++DxTfHpU7ZkEf45epZ8uXOgUCgokNeBXQeOU7rEl7N1/xvTt9XL96pYthjrt/1DUFAwAO/dosp3+fodShYtSKVyJfD18ycwMOrXvb1dJsxMTTl66hIAAYFBurr7ERXKFmPVxj1ERESi1Wp1+z9y8iJN6ldjw7KpLJg+IkaX1PeysrSgWOH8rFy/C41Gg1qtifEZR4v92f+IimWLs33vUV3LYXR5Hj19SVhYODWrlKV65TJcu3UvxvtsbFITFBRMaFi4blnZkoXZvucIxQvnx9raihTWVpy9eF3XSlehTDEOHf+3e/WDuxdqtUb3fo0mKmkrX7oo9x4+48TZq9StHjVBsr5zID7RrYsA/xw9Sw77LLqbQ1o2rs2mnYewsDD/4gfKBzdP3rt5ULhgXjq3acyla87f/JnEVrq4E9dv3efew2cA+PoFRLXSxbEPIUTCSHYJUtbMGdi4fJpuYGS01KlSMGvCEDbvPEiHniMYMHwqL11cSZXSmrbN69Fz8J8MGTsrUe96+61nBwI/BtOx10j6D59K13ZNKFLw6zMz16hchoPHz/PrgHH4xDPbdrRK5YqzYfu/E2vWq1kR1/fuVK349Vnh46sjgHKlivDoyUs69xnF85dvaFK/Gq7v3GnT7Q8uXXOmZLGCX93+15QtWZgzF69Tokh+AEoUKcDJc1cpU9wpzvW/p16+V6fWjXDKn5tfBoyjc9/RrFy/C61WS4NalXjw+Dm/DhjHnoOndN13KpWKmX/+zt5Dp+jQawR/jJutSwJ+xMBeHbC2sqBDrxF06TeGPf+cAqBwwTys3byPDr1G0LXfGMZMWci1m/e+srX4jR/WB3dPb9r1GM4v/cdw7tKNL9ZpUKsyy9Zsp9/QKUSq1T+0n7o1KtC4XlX6Dp1M5z6jmLN4PaGhYXxw9+K3EdNp12MYN24/oFPrhjHeZ2FuRp3qFWjXfSgbPx3X0cdJ9GDnEkUKcPrCdUoWjToGizk5MqBHO4ZPmEen3qOYMmeF7vioUqEk67ftB6LuiixTojCnL1yjXOkigP5zYOHKzew9dOqLsmXKkJYV63bSuc8oDh0/z4QRfXUtidmyZsLKwpz6NSt98b6g4BBmzF9Np96jmLtkPQN7dQC+7TOJLVvWTEwY0Y+ZC9bQsfdIhk+Yxwd3z3j3IYT47+RJ2smYVqtl1cbdqNUaenVtZexwRALoP3wqfX9tQ4F8uYhUq5m7eD0BgR+ZPHqAsUP76T1+9op9h04zfOCv3/welzfvGD15IasXTfzq+CohRPKSrMYgiX/5+gXQe8gk7LJkYMro34wdjkggtauVZ97SjYSGhhEeEUEeB3t5LpEBhIWHs2HbAQZ8R13PWriGG84PGDW4hyRHQvyEpAVJCCGIapH92iB8IcT/j2Q3BkkIIRKDJEdCiM9JgiSEEEIIEYskSEIIIYQQsST5BEmr1RIZGfnVBzgKIYQQQiSUJJ8gqdVqKjXoivoHn88ihBBCCPG9knyCJIQQQghhaJIgCSGEEELEIgmSEEIIIUQskiAJIYQQQsQiCZIQQgghRCySIAkhhBBCxCIJkhBCCCFELJIgCSGEEELEIgmSEEIIIUQsKmMHIIQQQoiEtWLb6UTbds821RJt20mJJEhCCCGESFDl63Yid85sBH4MIlPG9IwZ0pOsmTMwYeZS+nVrS7q0Nl+85+Cxczx6+oo/+ncxQsRfki42IYQQQiQoC3Mz1i+dyq5186heqTTL1mwHYPywPnEmR0mRtCAJIYQQIlEolUpKFCnA4RMXAGjWeRBrFk7CVGXCiInzcfPwIkum9EwbNyjG+1Zt3ENoaBj9ureNsTxSrWbB8k3cdH6IubkZQ/p1oaBjLg4eO8fTFy64uXvz8MkLundqQZP6/60rUBIkIcRPJ41dkUTZrp/rnUTZrhA/K41Gw5FTF8mXO0eM5ddu3cfMzJQda+bg7uGNlaWF7jXne4+5fusei2aO+mJ7+w+fwcPLh43Lp/HCxZVh4+eyffUsAO4+eMaiGSN57fqBcdMW/+cESbrYhBBCCJGgQsPC6dxnFHVb9cbH158BPdvHeL1wwbx4evuyYt1OLD9LjgICPzJ++hJ+6dAMlUrF7XuP6dxnFJ37jOL+o+fcuH2fmpXLolAoyJ0zG5aW5rxxdQOgoGNurK2tyJs7B75+Af+5DJIgCSGEECJBRY9B6tG5JRbm5jFaiADS2qZh9cKJZMmUnq79xvDezQOAk+eu0LheVbbsOoRWq6WYkyPrl05l/dKpFMqfG60WUOjft8rEBK1W+5/LIAmSEEIIIRJFswbVuXnnAc9fvY2x/NXrd4SEhNKgdmVyZs/K0xevAahRuSzdOjbH2sqSi1edv9heqWIFOXn2KlqtlhcubwkODiFb1kyJEruMQRJCCCF+MknlWUUqlYrev7Tmr6UbWDhjpG65X0AgU+f9TUBgIPZ2mSlbsggnz14hVcoUAPT+pTUjJvxFmRJOmJr+m6o0rl+Nl6/f0bHXSMzNTZk0akCM1xOSIjw87L+3Q8UhIDCI6fNX8dbVjdSpUjBxZD+USiVjpy7Cx9eferUq0rFVw69uJzIykkoNunL+4FpUKsnnhBBfJ4O0hRD/VaJlHPcfPaNVk9oUc3Jk4crNbNp5kIiISKpUKEnT+tXo0m8MlcuVwN4uc2KFIIQQQgjxQxJtDFL50kUp5uQIgFOBPHh6+XLpmjNFnRxRqVQ45c/D5evya0wIIYQQSY9B+qxuOj+kcMG8XLhyC7ssGQGwt8uMl7dfnOvv3H+cXQeOA+hGokdGRgBaTExUqNVqQItCoUSpVKJWRwKgVJoAoNGoATAxUaHRqD9tQ4GJiclX1tWg1WriWFcJKL5pXYVCiUIR/7oqlYrIyEhd/J+vq1RGjbyPb12lUvGp7LHXBZXKNNa6setFi0aj0cX0PXX477oKlMqv1WHi13dUvUTEU98maDTx1+H31XfMevm8vr9eh4aqb+Mes1+r7/iP2cSt78SiVqvlGiHXiHjrRa4RyecaEde6KpUpn0u0MUjRXri8ZfTkhaxbMpn6rftycOtiLCzM2bjjHwICg+j7axu975cxSEKI7yVjkIQQ/1Wi3ubv6xfA+OlLmDx6AOZmZtjapMb1vTsAb13dSJ9M5mMRQgghxP+XREuQwsMjGDVpPj06tyB3zmwAVChTjNv3HhMZGcn9R88pVypxfuUJIYQQQvwXidZntWH7Pzx57sK6LftYtWE3AHMmD2XSrOXsPXiKhnUq68YjCSGEECLhJFY3M3xbV3P5up3InTMbgR+DyJQxPWOG9CRr5gxMmLmUft3aki6OHqSDx87x6Okr/ujf5YfimjBzGS9c3jL8t19w8/Bmzea9VK1Qku6dWvzQ9hItQerWsRndOjb7YvmC6SMSa5dCCCGESAKipxrRaDTsOnCCZWu2M2lUf8YP65Mo+/P09uXO/SfsXj8PgBXrdvJ7384UL5z/h7cpU40IIYQQIlEolUpKFCnAuw9Rc6016zwIP/9AgoKCGTB8Gq1+GcLAkdMJDgmN8b5VG/ew+O+tX2wvUq1m7pL1dOg5gl8HjOPB4xcAjJq0AG8fP34dMI4tuw5x7+Ezpv+16j89TkhuCxNCCCFEotBoNBw5dZF8uXPEWH7t1n3MzEzZsWYO7h7eMSazdb73mOu37rFo5qgvtrf/8Bk8vHzYuHwaL1xcGTZ+LttXz2LiiL78MW4OqxdOBOD8lVsM6NGe/Hkdfjh2aUESQgghRIIKDQunc59R1G3VGx9ffwb0bB/j9cIF8+Lp7cuKdTux/Cw5Cgj8yPjpS/ilQzNUKhW37z2mc59RdO4zivuPnnPj9n1qVi6LQqEgd85sWFqa88bVLVHKIAmSEEIIIRJU9BikHp1bYmFuHqOFCCCtbRpWL5xIlkzp6dpvDO/dorrgTp67QuN6Vdmy6xBarZZiTo6sXzqV9UunUih/bj49Y9QgJEESQgghRKJo1qA6N+884PmrtzGWv3r9jpCQUBrUrkzO7Fl5+uI1ADUql6Vbx+ZYW1ly8arzF9srVawgJ89eRavV8sLlLcHBIWTLmilRYpcESQghhBCJQqVS0fuX1vy1dINu6jAAv4BAfh8zm7bdh6JUKihbMuqxBKlSpgCg9y+tWbp6GxERkTG217h+NdLapqFjr5FMmbOCSaMGYGqaOMOpE32qkf9KphoRQnwvmWpECPFfSQuSEEIIIUQs8TbJ+PoF8OjpS167fuDdew9sbVJhnzUzuR2ykcM+qyFjFEIIIYQwqC8SpA9unmzY/g8vXN5SpFA+smRKT4UyRfHzD+S16weOn7lMeEQEndo0+k9PqBRCCCGESKq+SJAuX79DnerlKVIoX7xv+uDuxT9Hz1K4YF5UJiaJGqAQQgghhKF9kSA1b1Tzi5UuXXPm5WtXMqSzpWqFUmTOmI4enX9s8jchhBBCiKTuq4O0l6/bwb1Hz7DPmpnnr94y7M+5hohLCCGEEMJo4kyQnr98o/u36zt3unVoRuXyJejWsRmvXT8YLDghhBBCCGOI8y620xeus+/wabq2a0KjOlXo88dk0tna8Mb1A+1b1Dd0jEIIIYQQBhVngtSjcwvcPbxZuX4XGdLbMn/aCEJCQkmVMkWiPbFSCCGEECKpiHcMUsYMaRkxqBtlSjgxZc4Krty4i0old6wJIYQQ4ucXZ3PQwycvWLFuJ0HBodjapKJ319a8cHnLyEnzadm4FiWLFjR0nEIIIYQQBhNngjR59gqmjx+EvV1m7jx4yrS//mbFvPFUKlec7XuOSoIkhBBCiJ9anF1sGq0WhUKh+zt6Bl5zMzM6tWlkmMiEEEIIIYwkzhaksX/0ZM7idQQFh2CbJjWjBvcwdFxCCCGEEEbz5Vxs7l4UdMzNX1OH633jezcPsmTKkGiBCSGEEEIYy5dzsV1z5sipi9SuVp7SxQuROWN6TE1VaLVaPL18ePzMhb2HTmGbJhUjBneXudiEEEII8dOJcy62ujUrsv/wGZau3s7b926EhoZhYmJClkzpyZ3Tnj/6d5HWIyGEEEL8tOIcg2RlaUHb5nVp27yuoeMRQgghhDC6r05WK4QQQgjx/0YSJCGEEEKIWCRBEkIIIYSIJc4xSKs27tH7pm4dmyVKMEIIIYQQSUGcCVLgxyAgak42W5vUZMqQDoBnL16TOVN6w0UnhBBCCGEEcSZIg3p3BKD/sKlMGf0bJiZRPXEhoaGMmbLQcNEJIYQQQhiB3jFInt4+Mf62MDfnvZtnogYkhBBCCGFscbYgRSteuAAjJ/5F62Z1MDEx4eDRs9hnzWyo2IQQQgghjEJvgjS4Tyc2bD/A0tXbiVRHUrSQI7/16mio2IQQQgghjEJvgmRmZkq3js3p1rG5oeIRQgghhDA6vWOQHjx+QZd+o2nRZTAAbh5e7Nh3zCCBCSGEEEIYi94EadbCNUwY3g9raysAMqSz5Z9jZw0SmBBCCCGEsehNkMLDI8hhn0X3t0KhICwsItGDEkIIIYQwJr1jkLJlzcS1m/dQKCAoKJgV63fGSJiEEEIIIX5GeluQhv32C5t3HeLFK1fqtOrDq9fv+aNfF0PFJoQQQghhFHpbkNLapuGvqcMJCQ0FwNLCAl+/AIMEJoQQQghhLHpbkOq17sPp89ewtLDA0sICgEGjZxgkMCGEEEIIY9GbIFmYm7FtzxEmzFxKUFAwAFqtQeISQgghhDAavQlSqlQpWDJ7DLlyZKNLvzG6AdtCCCGEED8zvWOQtFpQKpV0bN2QsiULM2nOclxevzdUbEIIIYQQRqE3QZoxbpDu37kd7Fk1fwJ7Dp5K7JiEEEIIIYwqzgTJx88f2zSpUSgVuHl4xXitUrniBglMCCGEEMJY4kyQZsxfzYzxg+ncZxSgAD4fma3g2K7lBglOCCGEEMIY4kyQJo8aAMCxXSsMGowQQgghRFIQ511spqbxD006f/lmogUjhBBCCJEUxJkJde47Os7b+bUaLWHhEVQqVyKx4xJCCCGEMJo4E6RBvTvGubJCoSCPg32iBiSEEEIIYWxxJkjFC+c3dBxCCCGEEEmG3ucgubx5x6qNe3B9745Gq9EtX7d4SqIHJoQQQghhLHoTpD9nLKVapdK4eXjTo3MLHj97ialK71uEEEIIIZI9vXOxadHSpW1jCuTLSQprSzq3acyVG3cNFZsQQgghhFHobQ6ysrQk8GMQZUsWYf+RM5iZmeHm4f3NG9+y+zCbdxykbfN6dGjVgL837GLf4TPYpE4JwJ/D++KQw+6/lUAIIYQQIoHpTZA6t2mEn38gZUo4cfTURXr/PpFunZp/88aLOzny/OWbGMt6dmlJozpVfixaIYQQQggD0JsglStVRPfvP4f3/e6N58uTk8wZ08VYliZViu/ejhBCCCGEIelNkA4dPx/n8vq1Kv3wDjftOMjS1dspUbQAA3t3RGVi8sU6O/cfZ9eB4wBotVHzwEVGRgBaTExUqNVqQItCoUSpVKJWRwKgVEZtS6NRA2BiokKjUX/ahgITE5OvrKtBq9XEsa4SUHzTugqFEoUi/nVVKhWRkZG6+D9fV6k0QavVxruuUqn4VPbY64JKZRpr3dj1okWj0ehi+p46/HddBUrl1+ow8es7ql4i4qlvEzSa+Ovw++o7Zr18Xt9fr0ND1bdxj9mv1Xf8x2zi1ndiUavVco2Qa0S89SLXiORzjYhrXZXKlM8pwsPDtMRj+IR5Mf5++PgFVSuWYki/LvG95Qt/b9iFpYUFHVo1wM3Di8hINVZWFgz/cx5N61enQe3Ket8fGRlJpQZdOX9wLSq5g04I8Q3S2BX5+ko/wM/1TqJsVwiR9OjNOGaMHxzj75curmzbc+SHd5Ypw7/dbdUrleb12/c/vC0hhBBCiMSi9zb/2OyyZOTarXs/tKOw8HD2HTqNWq0hKDiE67cfkC9Pzh/alhBCCCFEYtLbgjR/+UbdvyMj1Tx88pL06Wy/acOe3r4MGTMLb19/lAoFl645U6pYIXoMGo+vXwDVK5eheqXS/y16IYQQQohEoDdBSmFt9dlfChrXrUr1yt+W1KRPa8P6pVO/WN61fZPvClAIIYQQwtD0JkjdOn77M4+EEEIIIX4WehOkD+5e7D98Gi8fP93t9gBjhvRM9MCEEEIIIYxFb4I0dPwc7LNmoqBjblSqL59XJIQQQgjxM9KbIGm1WqaOHWioWIQQQgghkgS9t/mXLFrwi7nUhBBCCCF+dnpbkFzfu9Fv2FQyZUwbY/m6xVMSNSghhBBCCGPSmyB1aNXQUHEIIYQQQiQZehOk4oXzGyoOIYQQQogkQ2+C9OTZK7bsPoyXjx98NqXtopmjEjksIYQQQgjj0ZsgjZ6ykMrlSlC5fElUJnKbvxBCCCH+P+hNkFKltOa3Xh0MFYsQQgghRJKg9zb/imWLc8P5gaFiEUIIIYRIEvS2IJ25eIPVm/ZiZWnxaYkWUHBs1/LEj0wIIYQQwkj0Jkgzxg82VBxCCCGEEEmG3gQpc8Z0hopDCCGEECLJ0Jsg3bn/hAUrNvPugzsaTdR9/ioTEw5tX2KQ4IQQQgghjEFvgjRzwRq6tGvMP0fPMaRfZ548d8HPP9BQsQkhhBBCGIXeu9hMTVXUrlaePLns8Qv4SO1q5Tl36aahYhNCCCGEMAq9LUipU6XA09uXimWLs3XXYQICP+Lj62+o2IQQQgghjEJvC1LPLq3QarUUc3Ikh30WVqzdSZd2TQwVmxBCCCGEUehtQSromEv3715dW9Gra6tED0gIIYQQwtj0tiAJIYQQQvw/kgRJCCGEECKW706Q3n3w4MHjF4kRixBCCCFEkvDdCdKcxes4euoiK9fvSox4hBBCCCGMTu8g7biM/aMXNmlScfHq7cSIRwghhBDC6L7agvT0xWvOXrqh+9vKygKACmWKJV5UQgghhBBGpDdBWrtlH38t28CilVsA+ODmyZgpCw0SmBBCCCGEsehNkA6fuMCCaSOwtIxqNcqcKT0eXj4GCUwIIYQQwlj0JkgKhQKFQolCEfW3j68/oaHhhohLCCGEEMJo9A7SrlezIpPnrODjx2B27DvGjn3HaFy3qoFCE0IIIYQwDr0JUpe2jTl2+hKRkZHcuf+EXzs0pW6NioaKTQghhBDCKL56m3/tauWpXa28IWIRQgghhEgS9CZIdx88ZcP2A3h6+aJFq1u+bvGURA9MCCGEEMJY9CZI42csoWHtKrRqkgeVysRQMQkhhBBCGJXeBCmdrQ3dOjYzVCxCCCGEEEmC3gSpWYPq7Nx/nIplYz41O1OGdIkalBBCCCGEMelNkHz9Ali8aitLV2/DxCT6kUkKju1aboDQhBBCCCGMQ2+CtGPfMdYvmUJuB3tDxSOEEEIIYXR6n6TtkMMOe7vMhopFCCGEECJJ0NuCVKRQPkZOmk+ZEk4xlrduWidRgxJCCCGEMCa9CdJb1w/YpE7J0+cu/y6MnphNCCGEEOInpTdBGvNHL0PFIYQQQgiRZMSZIN2685DiRQpw6Pj5ON9Uv1alRA1KCCGEEMKY4kyQLl5zpniRApy9dOOL1xQKhSRIQgghhPipxZkgDejRHoCpYwZ+9vyjf4WEhmJpYZG4kQkhhBBCGIne2/x//W0sH9y9cPfw1i1bvWkPdVr25vyVW4kenBBCCCGEMehNkN66utFz0J906jOKg8fPAXDv4TMWzhjF+q0HDBKgEEIIIYSh6U2QFEoF29fMZuOyqWzbfQQAHz9/ihTMS3BIiEECFEIIIYQwNL0JUuqUKVEolKBQYG1lCUBoaDgAKpVJ4kcnhBBCCGEEep+DVKtqWZp3GoQWLXkcstOm21DUajVzFq8jrU0aA4UohBDJ14ptpxN8mz3bVEvwbQohYtKbIPX5tQ2VypUgrW0aMmdMh7uHN+nS2nD8zCWZbkQIIYQQPy29XWwAPr7+XPh0x1qG9Lb4+QdQt0ZFsmXNlOjBCSGEEEIYg94Eac7idZw6f5Wd+48D4O7pzZ8zlhokMCGEEEIIY9GbIF27dZ9xQ3tjbm4GQKYM6fAP/GiQwIQQQgghjEVvgmSiVBIZqUahiPr77Ts3IiMiDRGXEEIIIYTR6E2Q2resz5Cxs/H1C2DBis30HDyBDq0bfNcOtuw+TKN2/dm04yAAfv6BDBg+jQ49R7Bxxz8/HrkQQgghRCLRexdbwzpVsLfLzIUrt9BqYdrYgRR1cvyuHRR3cuT5yze6v1dv2kOVCiVpWr8aXfqNoXK5EtjbZf6x6IUQQgghEoHeBGnS7OWM/aMXhQvm/eEd5MuTk8wZ0+n+vnTNmcb1qqFSqXDKn4fL1+9IgiSEEEKIJEVvguTj64+HpzcZ0qdNsB36+PpjlyUjAPZ2mfHy9vtinZ37j7PrQNSdc1qtFoDIyAhAi4mJCrVaDWhRKJQolUrU6qhxUUpl1NO9NRo1ACYmKjQa9adtKDAxMfnKuhq0Wk0c6yoBxTetq1AoUSjiX1elUhEZGamL//N1lUoTtFptvOsqlYpPZY+9LqhUprHWjV0vWjQajS6m76nDf9dVoFR+rQ4Tv76j6iUinvo2QaOJvw6/r75j1svn9f31OjRUfRv3mP1afcd/zCZufScWtVr9A/Wd8KKOf7lGyDVCrhEJWd8qlSmf03slKZQ/D137j6VmlbKYmPw7XGlgr4763qaXQqGAT0mPRqtBoVR8sU7LxrVo2bgWAJGRkVRq0BWVyhSVKirc6P/rChGrUFEffJTYF0v965oAJgZYVxXvup/eEe+6KtX3rBs7pu9ZV/lD6yaN+oaEq2/TH17XMPVt/GP2a/X9X47ZH63vxPJf6jAhfb5fuUb8yLog14iEXjd5XSO+vt2vPihSS4tGNUmdKgUprK10//0XtjapcX3vDsBbVzfSp7X5T9sTQgghhEhoeluQunVsnuA7rFCmGLfvPSaHfRbuP3pOpzaNEnwfQgghhBD/ReJ11gOe3r4MGTMLb19/lAoFl2/cYcro3xg7dRF7D56iYZ3KuvFIQgghhBBJRaImSOnT2rB+6dQvli+YPiIxdyuEEEII8Z98dbLac5dusmPfMQA0Gg3ePn6JHZMQQgghhFHpbUGas3gdgR+DePT0Fa2a1MbDy4cpc1aycMZIQ8UnhBAiCVux7XSCb7Nnm2oJvk0hvpdMViuEEEIIEYtMViuEEEIIEYveLrYOrRrEmKz28Inz9O/RzlCxCSGEEEIYhd4EqUHtythlzcTF/zBZrRBCCCFEcvPV2/yLFMxLkf8wWa0QQgghRHKjN0Haf+QMK9fvwsfXD4iaQk2hgIuHNxgiNiGEEEIIo9CbIC1dvY1Rv/fAKX8eVKrEnwhSCCGEECIp0Jsg5cqZjUplixsqFiGEEEKIJCHOBOn5yzcAFC+cn9Wb9lC5XIkYr+d2sE/8yIQQQgghjCTOBGnYn/Ni/P3P0XO6fysUsGvdvNhvEUIIIYT4acSZIO1eLwmQEEIIIf5/6R2DNHnOCsYM6Rlj2bhpi5k4sl+iBiWEEEKI5CmNXZEE36af650E3+bXxJkguXl4odXCoycvcffwRosWgPdunty6+9CgAQohhBBCGFqcCdKkWcsBePvejb5DJ6ONyo/InDEdv/XsYLDghBBCCCGMIc4EafGs0QBMnr2cMX/0MmhAQgghhBDGptT3oiRHQgghhPh/pDdBEkIIIYT4fyQJkhBCCCFELHpv81erNdy88xBvHz+00SO1gfq1KiV6YEIIIYQQxqI3QRo+YR5PX7iQxyG7brJahUIhCZIQQgghfmp6E6SXLq5sXz0HC3MzQ8UjhBBCCGF0escgOebNSXh4hKFiEUIIIYRIEvS2IGXNlIFBo2ZQpFDeGMsH9uqYqEEJIYQQQhiT3gTJwsKMCmWKGigUIYQQQoikQW+C1K1jc0PFIYQQQgiRZMSZIB07fYna1cqzauOeON/UrWOzRA1KCCGEEMKY4kyQvLz9AAj8GGTIWIQQQgghkoQ4E6T2LesDMKi3DMYWQgghxP8fvWOQPgYFc+rcVbx8/PjsQdrSxSaEEEKIn5reBOn3MbNQqzXkz+uge5K2EEIIIcTPTm+C5B/wkc0rZmBiInPaCiGEEOL/h97Mp2ihfHh6+xgqFiGEEEKIJCHOFqThE+ahUCgIDAyi39Ap5MmVPcbr08cNMkRsQgghhBBGEWeCVLl8CUPHIYQQQgiRZMSZIDWoVRmAB49fUNAxV4zXrt26n/hRCSGEEEIYkd4xSDMXrv5i2fxlGxMtGCGEEEKIpCDOFqTJs5eDQoG7hzeT56zQLXdz98LKytJgwQkhhBBCGEOcCVL92lFdbDedH1CssKNueeYM6XAqkNcwkQkhhBBCGEmcCVLxwvkBmDx6AAUdcxs0ICGEEEIIY4szQbp15yHFixTg9dsPvH774YvX69eqlOiBCSGEEEIYS5wJ0sVrzhQvUoCzl2588ZpCoZAESQghhBA/tTgTpAE92gMwY/xggwYjhBBCCJEU6L3N/5f+Y1m2Zju37j4iMjLSUDEJIYQQQhiV3slqRw7uzk3nB2zacZDxL16TL3cOypRwolWT2oaKTwghhBDC4PQmSHlzZSdvruy0alKbuw+fsffgKeYv3yQJkhBCCCF+anoTpM07D3HD+QFv37nhmCcnxZwc+bVDM0PFJoQQQghhFHoTpA3bD5ArZzY6tWlE8cL5scuS0VBxCSGEEEIYjd4E6dC2JTx7+YYbtx8wb+kG3D29yZsrO+OG9jZUfEIIIYQQBqc3QVIoFGTPlhn/gEACg4KIjIzk1p1HhopNCCGEEMIo9CZIfYdO5slzF/LncaBsycL0796O3A72hopNCCGEEMIo9CZIbZvVo0TRAlhbWRoqHiGEEEIIo9ObIFUuX8JQcQghhBBCJBl6n6QthBBCCPH/SG8Lkvhv0tgVSfBt+rneSfBtCiGEECImvQnSk2ev2LL7MF4+fqD9d/mimaN+eIcV6nUiV45sABQplI8h/br88LaEEEIIIRKD3gRp9JSFVC5XgsrlS6IyMUmQHaZPa8v6pVMTZFtCCCGEEIlBb4KUKqU1v/XqkKA7TJ06RYJuTwghhBAioelNkCqWLc4N5weULFowwXbo7eNHj0ETAC39e7SnSMG8X6yzc/9xdh04DoBWG9W3FxkZAWgxMVGhVqsBLQqFEqVSiVodCYBSGdXKpdGoATAxUaHRqD9tQ4GJiclX1tWg1WriWFcJKL5pXYVCiULx77oJLaoeouLXarWfYgCVypTIyEg99aJFo9Ho4v+eOvx3XQVK5dfqMPHrW6VS6eohdn2bmJig0WhjrftvvXy+bsw6/HLd2PXyeX1/vQ4NVd8Jf8zGXd9x1+HX6lupVHwqj2HrO7Go1eofqO+EF3X8f099J941IrHKJ9eI5HuNSAxqtTrR61ulMo2xT0V4eJiWeHTuO5qXLq5YWVp8WhL1xXds1/IfLuSdB09xzJODMxeus2ztDvas/0vv+pGRkVRq0JXzB9eiUiWvMeUySFsI40iMcw9+7Pxbse10gsfRs021BN/mj/rZyye+38/y3ac345gxfnCC7zC6xahW1XLMXrSO0LBwLMzNEnw/QgghhBA/Sm9b2N8bdpE5Y7ov/vtRF6/e5u07NwBu3nlIhnS2khwJIYQQIsnR24Lk4+uPh6c3GdKnTZCdZcmUgTmL1+Hh6YOpmYpxw3onyHaFEEIIIRKS3gSpUP48dO0/lppVymJi8m9j08BeHX9oZzmzZ+WvqcN/6L1CCCGEEIbylVHPWlo0qmmYSIQQQgghkgi9CVK3js0NFYdIRIlxlwnInSZCCCF+XnoTpFUb98S5vFvHZokSjBBCCCFEUqD3LrbAj0Ex/jt59goKhaFCE0IIIYQwDr0tSIN6xxyM7eHpzfzlmxI1ICGEEOJnlpQeZCri912Ppk6Rwpq7D58lVixCiDjIGDIhhDA8vQnS8AnzUHzqU4uMVPPsxWvy5c5hiLiEEEIIIYxGb4JUuXwJ3b8VKGjdpDbFixZI9KCEEEIIkfgSq4X6Z6A3QUphbUWV8iVjLDty8gJ1a1RM1KCEEEIIIYxJ711sqzfFvM1fo9GwetPexIxHCCGEEMLo4mxB6jd0CgqFAtf37vQfNlW33N3TG4ccdgYLTgghhBDCGOJMkMb80Qu0Wn4bOZ1fP3soZOYM6cicKb3BghNCCCGEMIY4E6TMGdMBsGjGKDJmSGvQgIQQQgghjE3vIG0vHz+GTZjLx4/B7Fo3DzcPL85fvkWrJrUNFZ8QXyXPCRJCCJHQ9A7SnrVwDROG98Pa2gqADOls+efYWYMEJoQQQghhLHoTpPDwCHLYZ9H9rVAoCAuLSPSghBBCCCGMSW8XW7asmbh28x4KBQQFBbNi/c4YCZMQQgghxM9IbwvSsN9+YfOuQ7x45UqdVn149fo9Q/t3NVBoQgghhBDGobcF6YO7F39NHU5IaCgAlhYWBglKCCGEEMKY9LYgzV2yDohKjCQ5EkIIIcT/C70JUpN61VmyaisBgUEEBQXr/hNCCCGE+Jnp7WJbvnYHfgGBbNxxEIUCtFpQKODi4Q2Gik8IIYQQwuD0JkiHti8xVBxCCCGEEEmG3i42IYQQQoj/R5IgCSGEEELEIgmSEEIIIUQsescgfQwK5tS5q3j5+KHV/ru8W8dmiR2XEEIIIYTR6E2Q/hg7m4hINfnzOqBSmRgqJiGEEEIIo9KbIPn6B7B5xUxMTKQnTgghhBD/P/RmPk758+Dp7WOoWIQQQgghkgS9LUgKpZJ+Q6eQJ1f2GMunjxuUmDEJIYT4P5bGrkiibNfP9U6ibFf8nPQmSEWd8lHUKZ+hYhFCCCGESBL0JkgNalU2VBxCCCGEEEmG3gTJ28ePbXuO4PreHc1n9/lLF5sQQgghfmZ6B2mPmbKQgI9BuL53p2KZYqS1TUMeh+z63iKEEEIIkezpTZCCgkMYMbAbhfLnwTGvA0P6dubB4+eGik0IIYQQwij0Jkjm5uaEhoVTvEh+Tp67QlBwCO8+eBgqNiGEEEIIo9CbIDVvWIN3H9ypXK4Et+48ol7rvlQuV8JQsQkhhBBCGIXeQdr1albU/Xv53HEEBAaRKqV1ogdlaCu2nTZ2CEIIIYRIQvS2IPn6BTBv6QbGTVsEgEaj4dbdRwYJTAghhBDCWPQmSJNmLydn9qy8fP0OADMzUxb/vdUggQkhhBBCGIveBOmDuydN61dHqYxazcrSgrDwcIMEJoQQQghhLHoTJCtLSzy8fFAoov4+ff4alhbmhohLCCGEEMJo9A7S/r1vJwaPmom7pze/9B+Lu4c3syb+bqjYhBBCCCGMQm+CVNAxN8vnjePew2e6v3/Gu9iEEEIIIT6nN0ECSGFtRblSRQwRixBCCCFEkhBnglS+bidsbVIREaEmKCgYjVaLQgFaLSgUcPHwBkPHKYQQQghhMHEmSF3aNeb85VvkzpmNOtUrULq4EyYmesdzCyGEEEL8NOJMkHp1aUXPzi25c/8Jh09cYOGKzVQsW4z6tSqRwz6roWMUQgghjEJmWvj/FW+zkEKhoKiTIyMHd2fRrFG8++BBh14jePXpoZFCCCGEED+reAdpR0ZGcunaHQ6dOM/rt++pWaUs/bq3JUumDIaMTwghhBDC4OJMkGYtWsuN2w8oXjg/bZvVpaiTo6HjEkIIIYQwmjgTpMvX7pAqpTX3Hj3j+u37aLVa4N+72Hatm2fQIIUQQgghDCnOBGn3ekmAhBBCCPH/66sPihQiPmnsEv4Bon6udxJ8m0IIIcT3MkqCtPfQKXbsO0YKaysmjexHhvRpjRGGEEIIIUScDP70Rx9ffzZsO8Cq+RNo2bgWi1dtM3QIQgghhBB6GTxBunrzHnlz5cDCwpyiTo5cvu5s6BCEEEIIIfQyeBebt48f9naZAEhnmwa1RkNoWDgW5mZ63xcUFIxKFRWuiUqFhbkZoWHhqCMjdeuYmppiZmZKSGgoGrVGt9zMzAxTUxXBIaFoNf8uN7cwR2VikpDFS3RBQcHA18sUvV5y9K1lsrCwQKlUJGos4eERRERE6P5O6GMvvjIFB4ckYqmiRO/bWGWysrJEo9ESGhoaY7m1tRWRajVhoWG6ZQqlEitLCyIiIgkPD9ctV5oosbSw+OJzSizRZfveMiVWHGD8zyk5iS7z9xx7yYlarfnu8ym5+Px4TYhrRFzXPWtrqxj7NPwYJAW6xwYAaDVRE+F+buf+4+w6cDzq9U/rDhgxDYVCwfNXrnRs3YAenZqzeuMutu45Sk77LADUrFKWDq0asnDFZh48fs5Ll3dkzpSO3l1bUbl8SXoOmoCJSdTOvHz8+HN4X4o55ePm1bM8eupCxvS2WFlaMGFEP9LZpqHfsCkAePv6ExERyc41c/Dx9adL/7GktUlNCmtLTExMWLVgInfuP2be0g34+gUSEhpGySL58XK5wdGTl/h7425SpbRGrdaQLq0NsycOYd+hU6zf9g9BwSFkzZyeSuWK82uH5ixetYUbtx+g0Wp5/vItQ/p2ommD6kyZs5Kzl2/Sd+hkANo0rUudGhWYNHMp7909efriDQ7ZszJ0QFecCuSl1a9DSJ/WBoAP7l4snzuOdLZp6D98Ks9eviV7tsyYmapYNGMUnt5+TJi5BAB3Tx9SpLBk68qZ3H/0nP7Dp5E1cwYszM2wtUnN3MnDOH3+Kuu27qd8+fIAVK1Yit/7dmL9tgMcOXERS0tzQsPCKebkyB/9u7B2yz72HDyFWq0hY3pbGtetSvNGtZg8eznPX70hPCKS128/MHlUPyIjI/hj7Cyev3pL5ozpAOjbrR0lixbg97Ez+fgxhJev35E3lz0TR/QjrW1qdmzbQpZMUeu+fe/O/o3z8fbxZ/SUhbxwcSW3QzasLM1ZMmssN50fsnjVFgDeffDEMU8O/po6jHOXbjJ6yiJy5bDDxESJQ3Y70tgNSrjj/pNatWrg7unDgmnDKZQ/N536jiIsLJx0tmkAGD+sL+nTRn1OIaFhfHDzwiFHVhbNGIWXjx99h04hQzob3Wd1cOti7j18yvS/VvP2vTu5c9qRJWN6poz9jSMnL7JtzxEAXr/9QPXKpRk1uDu7/znJX8s2MWxIwpfPz/UOg0bPIDw8goDAIPwDP7JmwURsbVLTvMtgLC0tsEmdEq0Wls4eg5e3L0cvP03wOKZNGkWPTs1ZsW5nnNeI2YvWxnmN6NpvbJzXiH7DpvDoqQtd+49J0GvEpNH9f+gakTVfuQSvM4C3jy5+9zVi/bo18V4jPL18ge+/RqxaMivea0Tl8iX4bcT0OK8RfYdOivMa0azz72TJlI6+Qyd/9Rpx6zuuEeOG9WH3gePsP3KG925eWFqY07heFbq2a8LMhWu5//AZpqYqPgaF0LBOZTq1bsjcJRsoU7YspqYq0tqkpkvbxlSrVIah42bj6e1LcEhojGtE625Dv/ka8cb1fZzXiPvxXCOOn7nExbNR37VxXSPyOGQDoHiRAgzo0Z7Vm3Zz/vIt3ri6YZMmFR1a1qdJ/er8MS7quFcowNc/kE2rF1KnejnGTlnE1dv3SZ0yBalSWjOodyeKFc5Pj0Hjv+saMW76Yjr1GYWvXwB5c9uzeOZobt19wqRZy7C1SQVAZKSadUumcP7yDRav2oa3jx/Zs2WmoGNu/ujfle17j3D8zGWAePOIdUumxjgfFOHhYVoM6Oipi5y+cJ3p4wbh4eVDp96jOLpzWbzrR0ZGUqlBV45sX5JoLUhJ4RevlCnplSlz7jIktHdPok7QpPA5JcaXrJ/rne8u06qdZxM8js5NKyTrY+9r51OmXKV+sGb0833rLNcIKdP/bZlityAZPEHy9Qug+8DxbFo+nbOXbnLlxl3GD+sd7/rRCdL5g2t1CZIQhvCzP8YgqZQvMSYD7dmmWoJvMylJjM8OktbxKYSxGTzjsEmTiq7tm9Jt4HhSWlsxafQAQ4cghBBCCKGXUZpkGtWpQqM6VYyxayGEEEKIrzL4bf5CCCGEEEmdDOoR4v+UjDcRQoj4SQuSEEIIIUQs0oIkRDykhUUIIf5/SYIkhBDJjCTvQiQ+6WITQgghhIhFEiQhhBBCiFgkQRJCCCGEiEXGIAkhjOpnnxZECJE8SQuSEEIIIUQskiAJIYQQQsQiCZIQQgghRCySIAkhhBBCxCIJkhBCCCFELJIgCSGEEELEIgmSEEIIIUQskiAJIYQQQsQiCZIQQgghRCySIAkhhBBCxCIJkhBCCCFELJIgCSGEEELEkuQnq9VqtQBERkYaORIhhBBC/MxMTExQKBRAMkiQ1Go1ANWadDdyJEIIIYT4mZ0/uBaVKio1UoSHh2mNHI9eGo2G8PDwGFldctGx90g2Lptm7DASjZQvefuZy/czlw2kfMmdlC/pSlYtSEqlEgsLC2OH8UMUCoUuE/0ZSfmSt5+5fD9z2UDKl9xJ+ZIHGaQthBBCCBGLJEiJqEWjWsYOIVFJ+ZK3n7l8P3PZQMqX3En5kockPwZJCCGEEMLQpAVJCCGEECIWSZCEEEIIIWKRBEkIIYQQIhZJkIQQQgghYpEE6QdpNBrdNChCCMNTqzXGDiHRaDQ/b9n+n/ys3xFarfb/4hiVBOkHKZVKFAoFH9y9CA4JNXY4Ce7/4eD/mf3MyQNEXaBNTKIuXz/bsarValEqf86yxcXH19/YISSY6IQo+vz7fPaHnyVZ0mq1KBQKlEolH4OCCQoKNnZIiUYSpO/w+QEeGhrGuGmL+HPGEjZsO8DzV2+NGFnCiT6xoy/Q+w+f5tqt+8YMKcHFvlA9ePycC1duGymaxBGdPFy+fuenTOAVCgXvPnjQf/hU/t6wm6OnLho7pP/s8y/VyMhI5i3dwJwl6/ng5mnkyBJO9KTj0Ynf85dv+GvZBkJCf45j1MvHD/j3/Dt2+hLL1+4gNCw82U2VFVv0dTO6HLMXrWPkxPm8fP3OmGElKkmQvsPnB/iTF6/Jni0Ly+eO497DZxw5eSHZZ9Kf/yqPiIhk9qJ1HDx+npXrd7Fu634jR5cwon/9RIuMjOTZyzd8cE/+X0KfJ34vXVzpMWgC+w6fZtOOgxw8ds6IkSW8gMAgVm3cTZN61ahTvTzL1mzn7Ts3Y4f1Q6KThehz7+07N85cuIFSqSAwMIgtuw8n2x9g0cfkxatRP0Cip5+I+JQohYSGkTVLRiwtLJJ9C8uVG3fpMfBP3d/zlq5n885DlC1VBDNTVbJtDYweTvL5dfPCldv4+PoxdmgvnArk0S1P7p9hbJIgfcXnB7XLm/fs/uckoaFh3L77iAePXzD8z3lYWVrQumkdrK2tjBjpf6dQKHj7zo0Bw6ex6O8tpLC2ZPnccQzs1YGN2//hYzJOAD//9RMUHMKS1dvw8vZFpVKh0Wh1rSzJ9SIGUWXzD/hIeHgE7z64U6NyGSaM6Mujpy95+sIlWXa7RX8e0f8/ee4qAGamKiIj1bh7ejNr4VoqlClOhvS2Rovzv4hurY0+9ybOWsaegyfp/Utr+vdoh6mpilt3HupaX5IThUJBQGAQ46YvxsPTG9f37kyYuYxJs5bz+u178jjYc/XGPXx8/ZNtC0v0eVW2ZGHs7TKzY98xADQaLc0b1iBjelv8/APx8w8Ekk8SEX3ORQ8nufPgKcfPXMbPP5CAwI8EBYew+8AJDp+4wL5Dp/EP+IhCoUg25fsWkiDFwcvbV5cMKJVKwsLDAXB5+46HT17w+NkralYpy7Vb92lUtyozJ/xOhnS2vH773phh/ycajYZL15zZvvcoVSqUJIW1Fecv38LNw4tC+XNTrlRhZi9aa+wwv1v0SR598T166hJrNu/F5fU7Nu44yIkzV6hRuTSXrzkTEhqq+7JK6uK6ScDL25fVm/bw/NUb3Dy8OXnuCj0G/kkxJ0cG9+msa6FIDnz8osalRH8e0f9ftHIzqzftwcLCnLDwcC5edaZvtzb80b8L5mZmBAQGGS3m/+LIyQuMn76YLu0aM/aPXnh6+/L85VsypLMlfx4H3Ny9cL7/xNhhfpc5i9fx4PELUqW0pkndarTvOYL12/bTs0tLypQszNot+3jh8paGtStz6ZqzscP9YdHn1f7Dp7EwN2PHvmOEhoVTokgBzl66wdrN+5g4axl9h04BSNKJYPTg6x37jvHSxVW3fPeBE0yatQxvH39GTppPhTLFaNawBvZ2mfELCOTSdWdWrt8FJO3yfa/kc8U0oImzlnPs9GU0Gg3Xbt3n99GzAKhQuhjZsmbiyo27pE6Vgib1q+nG6Mxbup75yzcly1aWOw+eolQquXnnIS9c3lK/ViXat6hHhTJF2bn/OAAjBnXn2OnLPHj8wsjRfrvPB7t+cPPk8vU7bN51kGYNajBzwu80rluVfYdPc/vuY0oWK4i7h7eRI/42vn4BbNl1mDeuH4Cozw8gXVobXN+7ExQcQh4He5RKJcMHdqNTm0YA3L73mNCwcKPF/a0ePH7OuKmLdb+49x06rRtjNGXMb+zYd4yw8HCKOeUnb67shIaG8TEomDmL13Hv4VNjhv5V0a0N0f8/ee4qoWHhlCpWiKcv3mBuZoa9XWZqVC7D/sOnCQ0Lp2ypwqg1Gu4/eq77sZaURZftl/ZNyZsrOwBhERFEqtWUKVGYzBnT0bB2ZerXqsTqTXt4+uI1FubmQPJowY3rx8m8pes5d/kWv/frTP68DixcsYmqFUsxfdxgRgzqxl9Th5MyhVWSv36GhIahVCpxKpCH3A72RKrVaDQaXN6+Z+mcseTMnpWnz11wefueqhVKUb9WJdo1r0eObFnIldPO2OEnOEmQPtFoNLoTu2XjWly65oyHlw+lixfCzz+QE2euYGqqolSxgoSEhnHr7iMG9+mEU4E87D14ElAwefQAUiTxbrbY3Swub96z+O8t3H3wlBaNamKfNTPXb9/H2tqKyuVL8ubtB27deYiVpQXjh/XBNk2qZNOEqlAo8PT2ZdXG3ezYfxxzM1PcPbzx9PIBwCGHHb1/ac0N54fsO3Ra98snqZYvOi5rK0taNqlF6lQpeeHylrWb97J2yz4AmtavxrHTlynq5EhuB3s2bv+HtZv30X3geC5ddTZi9F8XXb70aW1wyGHH/iOnAQgI/Mjdh8/w8fOnQL5clCpWkPnLNtG2eV3s7TLx98bd9Pp9IimsrahQppgxixCvSLUa+Le1wcREiVqtYdOOgxw9eZG0tmlo3bQOK9btBKBDqwa4eXhx9uJ1Ulhb0aReNVo1qY25mZnRyvCtostoa5Oa3kMmsXrTHob278qkUf2ZuWANEHVulipWiO6dWhD4MYjDJy8AJPkW3OgfXQqFgpDQUN31NCw8gtZN65ApQzoG9e7ItVv3efLcBYi6UWLExL+wtLAgc6Z0Row+fpGRkazftp+9B08BkDtnNibPWcHx05dRKpV4+fjRoedwjp++xJpFkyhSMC8AZy5ep//wqTx/9YYq5UsaswiJImkfjQYSGRmJUqnUndiVy5cgdaoUHDhyFoAenVuwftt+wsLDKZAvF/4BgRw/fZmXLq50atOIP4f3ZXCfTlhZWhizGPEKCg7RDbI2MVFGxX/mMl7evmTLmolaVcux99ApsmTKQG4He+4+eIrre3cK5HMgV85sXLp+B4A61cuTOVP6JNuEGv0lFM0/4COzFqzhjasbv/VsT7HC+Wnfsj7Hz17RrVPQMRd/9O9CmRJOHD9zGUiaTcRqtUYXl9JESVBQCMvWbOfug6eM+r0HDx+/4MDRs5ibmZHHwR61WkO3js1oXK8qfgGBtGpSh37d22JhnvS+YDUaDRrNv+XLkD4tVSuWwvneE96+c6NmlbKYKJWcPBs1/uiX9s04cvICL1ze0qJRLSaM6MeyOWPp1bWVMYsRp8CPQWzYdgA3dy8g6hidtWgtR09dxMREScfWDTl76QYent781rM9Lm/fc+HKbVJYW1G+dFGevXxDpFqNQw47rK0sjVya+EW3/Gi1WlzevGP52h0A/N63M9v3HiU4JJRKZYuTIZ0ty9dFvebt40f+vA4M6d+F1KlSEPgx6XePKhQKIiIimbVwDb+PnsXO/VHjjbx9/FB/am2xSZOKahVLsWLdTkxNVbh7elO+dFEWTB+BbZrURi5BTD6+/py7dBOVSkW5kkW48+AJvw4Yx5PnrymQLxcXr97G3cObqhVKUqRQPgb27oi9XWac7z3m8vU7FHPKz289OzBn0lBsbZJW2RLC/22CFBQUzOETUb9aVCoV7908GDdtEas37eGDmye/dmjGrU8DsatWLIWtTWqWr93Jo6cvsba2olSxQroLlpmZqTGL8lVKpYIHj55z8Ng5rt68x8vX7zh66hKPnr7ExERJxTLF0GqjmvtrVC5DREQk5y/fRKlU0q5Fffp3b2fsIugV3RWjMjEB4IbzA9598CB1qhTkyZWdx89e6tYtX7oY/v6BnL10A/j3tuMyJQuTI1tWIGm2IEUn70tXb2PJ31tJmcKaYoUdefLMBaVCQf8e7QgMDGLN5r28/tT1ZpsmNeVKFWFQ747UqV7emOHH6cOnpEGpVKJUKrn/6Dl7Dp7E5c07ihfOj2OenGzfe5TMmdJT0DEXd+4/4YObJ+Hh4RRwzMWJM1GJbvq0NqRMYW3MosQrZQprvHz8OHPhOvOXb+SW80Py58nJnn9OAlC9Umls06Ri/5EzAPTs0pIxUxcC0KZZXfp3b6c7rpMypVKJt48fCoWCVClTcPXmPc5duklBx1yULu7E9L/+BmDc0F6cuXCd7gPHs/NAVPf9nXtPsLS0SJKf4eeJH8CDxy/YvOsQNmlS0bltY06fv8ala840qFWZDdsP8OzlGwCyZM7Ai1dvef32PU3rV6dx3arGKkKcorva3T29yZQxqlXrtesHLl1zJoW1FQUdc9G8YQ3CwyO4evMuhfLnxt4uM/2GTmH89CUsWLGJyMhIUqdKoetG/Rn93yZIdx485f7j5wQEBvHwyQv+nLEUpwJ5CQ+PYOma7aS1TUP5UkXYfziqmX9Ivy58DApi2J/zsMuSkSb1q5E1cwYjlyJ+avW//eSWFhZkypiOeUs3cPzMZYo5OVLMyZFbdx/x9p0bmTOlJ2f2LBw9eRELCzOcCuTB1iYNGo2GVCmT3kUr2rVb9xkwfBqHT14gIDCIV6/f8Uv/sWzZdYgxUxbyxvUD7VvUI31aW46dvoRCoSBLpvSUKFqAnfuOE6lWo1Kp8PL2ZcO2A7pbj5NCC1LscQ6RajVjpizE09uXxvWqYmqqokC+XLqWTnu7zLRvWZ+MGdJy9uL1JD8WJyIikj5DJvHoaVTyumHbAabOXYmXtx/9hk3FPyCQGlXK4OHlw03nh9SoXIasmTPQa8hEJs9ZyaDenZJkixF8OY4mY/q0rFi/k6DgEEoULUiD2pVJkcKaDdsOAFCnRgX2HDzF3QdPaVSnCv26tU3yTyqO3VXvHxBIv2FTuXX3EbY2qWlQuxKHT1wgKDiEYb/9EtXl9OwVeXJlZ8yQXnRu05heXaI+v3OXb5Evdw4jlEI/jUaj6/KLviY8ee7Clet3yJ/XgXKlitC+ZQP+3rCbKhVKkj+vA+u27KNt92G8e+/Bir/Gkz1bFmMWIV7jpi5i+bod5M/rgFKpZPWmPRQvnJ9Jo/qTKWNabjg/AKBF41qcuXiD8PAIBvRozx/9u1KssCOLZ42mUrkSRi5F4vu/SpCif7FCVP/4W1c3Uqawwi5LJgb17kj9WpV49fodwSGh7Nx3jFZN6+D63p2V63ehUqkYNbgH21fPol3zekYsxddFP88oup8colrJ8ud10GX7tauXxz/gI1dv3gMgVcoUKJQKzl26Ra2q5ahTvXySHg9w8ept1mzaQ7sW9WhcpwoajYbHz17RvVNz5kwaSuDHILbuPkKkWk3rpnXYse8YGo0GK0sLypcqyoCe7XW/zE1NVQzq3ZF6NSsauVRRoi/MCoUCdw9vAj8GoTIxIUUKK9KntSEsPIInz16RMoU1hQvmxcvHj8ufukH7/tqGpbPHUtTJ0ciliFt4eAQQVecNalfWHX+pU6fk7wUTqFmlLKGhYWzZdZhsWTJRprgTu/85gY9fAH1+bcPYP3qxZtFEcufMZsxixEmr1ca4MeDZi9dAVDdurarlSGdrQ1h41AMD27eox/a9R/Hx9Uet1pDHwR7/gKiW0FZNauueVJxURbdoHj11ieNnLpM6VUoa1KrEph0HAWjRqBYajYb9R86QwtqKxnWrMnnOSiCqPiqX//fLdfSQHkmuhQWiWsU+uHsxfvoSVqzbydlLN2jesAYFHHPpboaoXL4E2bJm4u8NuxnQoz29urbij/5d6Ne9LRnSJb3HTkQPQ+jbrQ2nzl0jKDgEf/9A3rh+4OVrVyqVLUH6tLacvnAdgDIlnEiTOiW7DpwgIiKSwgXz0rR+dSwtkuZwkoSWdM/ABObj68/g0TO54fwAtVqDY56cABw6fp5UKa0pkC8XR09dokqFkrRvUY+HT17g7uHFwN4dUan+beJODgdG9PNwRk6cz+jJCzl4/By/9WxP907NOX3hOi9dXEmf1obypYpy/9EzWnQZzPnLNxnSt3OS7Ir5XHSryqvX72hUtyrlSxfF0tKCNKlTUrp4IUoULcimHQepW6MC3r5+3L73mHKlipDC2oo1m/cCkDFDWl2iqNVqSZ0qJcWLFDBWkb6gVCoJCQ1lyept9BsW1aQdFBRMozpVePnalQtXbjFjwRr+WrYBS0sLUqdKwd2HT9FoNGRIn5ZsWTMZuwhfiHqw4x7d+BOtVksO+yy6JLVO9fIEBgZx7PQlpo4dyIWrt3n28g11qpdHo9Fy7NQlAEoVK6R72GBSo1AoUCgUePv4MXnOCgaPmcmUuSvJlycnA3q05/bdR9y88xCA4kUKUL1yafr8MYm/N+yif4/2SfoX+a27j3j+qfsIou407D9sKgeOnmH52h14evvSonEtQkJDOXg86qGkJYoWYM8/UV2mfbu1ZerY3+LcdlLoQoxUq9m4/R+u376Pl7cvAG4eXkyevZy8ubJTKH9uZi9ax+17j6lQphhv3rlx99Pdo+1a1OP8lVv4BwSSPVsWShYtaMyi6KUyMeHtOzeOnY4ab/n3hl2UKFoAxzwOnL14g4iICCqVK05g4EfmLd3A/iNn6NymEbWrlcfUNGmed4np/yZBsrVJTf/u7bh49TZ7D0X1/zeoXQk3D2/Uag0+vv5cvHqLfHlykCKFNSYmJhw5dZG8ubLzS/umZM6YNO8+gC+bu286P2TLrkM4FchD0/rV2b73KHfuP6FwwbzkzWXP1j2Hgahfcn27taV7pxbMmTSUDOnTGiP87xLd1H3/8XNCQ8MA0HxKmtLapuGly1veuH6ge6cW5M2Vnf2Hz+Dh5cOw336lTbO68W7PmGJ/fm/fuTFy4nzSpErJzrVzCQkNY/c/JynomJtZE4bQrWNzFs0chY9vANntMtOsQXV6dGqRpFscrKwsqFqxJFeu3+XU+WsoFApSp0yhu+3Z3MyMXQeOo1KpKFPCiWxZMrFp50Gsra2YMKIvHVs3NHIJ4hbXuTdw1AzKly7KzrXz8PMP4J+jZ0mTOiWVy5fg7IXrXLlxl/NXbjG4T2dmTRjC3/MnJMkWMYD3bh5MnrOC2QvXEvap9U+j0bDnn5PUqVGBRTNGUbhgXrbvOYqVpQXNG9Zk4YrN3H3wFA8vH8qVKoyFRdQt/NmyZkqS3Yb7j5yh56A/uXnnIecv32L9p67P4OBQ0qW1oU2zOpQvXZRuHZvx17INFHNyJL2tDddvP8DDywfHPDlZMW88qVOlNHJJvhT7+Hz3wYMxUxeSLq0NE0f05fzlW7xweUuV8iVQqzWcuXgdxzw5ad+yAU+fu+Dj408O+6wxnpb9/yTpXlETQYUyRalbvQLb9x7l+au3mJiYoFKZYGKiJCwsHFubNKzbsp9ZC9dQv1YlXR95Uhfd3O356ZfP/cfPuXP/CaVLOFG5fAka1q7C3xt2o1Ao6Ni6Ec9fvqV+675cuu5MhnS2SaZr6XtUq1iaOw+eEh4egcrERDfY+t7DZzx+/gqXN+/w9PYlt4M9KVNYkzljOlJYWyWpC7R/wEfg38/v7oOnBIeEYpsmFeEREbpfsr1/ac3VW/d4+uI1H9w8OXHmCv2GTiGtbWosLS1Il9YmySVHoaFhrN2yD+d7j3WfUa4c2ejfox3nL9/k8IkLlC7hhK+fP9c+dbOZm5tx+boza7fsI3WqFNSuVg5I2jdBRH92l645ExERSYmiBfDx9Scg8CMW5mbUr1mJh09e8OTZK1o1rYNDjmzMX76RO/efoNFosLfLbOQSxO+Dmyctuw6hcIE8bF45g4KOuXRdiMEhobqbVHp2acnVW/d48Pg5NauUpWGdKvy1bCOpU6ZgcJ/OZMrw74/LpHac+vj5M/2vVYwZ0ot5U4aRL08OXaLjH/gRL29fAgKDiFSraVq/Omq1hhcurhQrkp/06Wx0j11IaneHRnf3xn44bFBwCDnts9K8YQ3y5clJy8a1WbB8E5kzpcepQB4uXnXG5c17HPPkZOGMkXRt38RIJUga/q/azBQKBfny5KRDywYcPXmR9OlsuHTNmZaNa5E5U3q6tmvC/UfPKFrIkYwZkn5rSrRnL14z7a+/yZo5IxXLFqNaxVL4+Prz+OlLHLJnpUm9aly8epsd+47RqkltJo7sR0hIKHmS8d0HBfI5cP/RM46evkSjOlV03S4prK2wz5qZBSs2U79mJWpWLRvjfUnhAu0f8JFpf/1NwXy56NSmEd4+fkyfvwr/gI9Rt0KnT0vfX9sya9EaAj8GUaRgXvI42HPw2DnataiHqZmKPr+2oXTxQsYuSpzOX7nF4r+3UrhgHooXzk9IaJguySlXqggWFuacPn8NH19/OrRuyGvXD5Qu4cSvHZqhVCoJDQ1jYO8OSbI7O/acVK9ev2PqvL9Ja5sa5/tPKFm0IMN++4Ulq7bRtH51qlUqzb1Hzzl1/hoZ0qelfcv6NKxTJUnf/BAtc6b05M6ZTdf9/M/RsyiVSupUr0DmTOkJDg7B1y+ATBnSUSCvA2s272P2xCH0/bUNkZFq3Wf++WDnpMY2TWoa1qnMC5e3OOSwY/OOQ9japGbN5r10at0QKysLdh04QYtGNdFoNOS0z4pd5gxYWJjrngWUFEUfo3fuP2Hjjn8oXqQABfLlwsrCHD//QMLCw1GZqGjRqCYHjpzh7KUbVChTjOCQEN2xmVS7sg0paR61iaxxvWoUK+xIQOBHXN6858qNuwBkzZyBOtUrJOnkKK75tM5fuUWvrq3p/UtrFqzYjK9fALlyZuP5q7c8fPISMzNTmtSrxukL14hUq7HLkjFZJ0cQ9VmVK1WErbsOc+bCdXx8/Vm7ZR/3Hj6jb7e2zJ08VJccJaVWIwA3d0/S2qahbs2KaDQa3Dy8cMyTk+Vzx/H0xWtu3nlAzuxZccydU/f4/rbN6vH2nRsKFFQpXzJJJkfRx+ZLF1e6tG3MqME9KFwwL6lTpQD+HT9WzMmRru2bcPLcVU6cuaIbuK1QKOjargm9f2mdJJOjz59FFe3Zy9fUqlqWCSP68uzFay5evU3VCqWwMDdj885DAFQqV5yIiEi0RJU/OSRH0aaPH0TPwRMYMnY2py9cJ2+u7JiYKHHMk5Obdx6xY98xXri8BUVU1/DZSzdQKpWYmZnq7qRNqslRtMF9OjFh5jI69R5F+dJFGdynE69eu7Jk1TaG9OuCt48f0/76m9/HzCJXjmxYWJgnyUeBxP5uuPPgKQtXbqZmlXJYWpgzdupCMmZIh0KhYOP2g4SFhxMSGoZDDjvdWNwWjWr9lM8z+lGK8PCwpPdJG8gLl7dMnLWMkYO66wZtJ1Wxf4XdvveYYk6OaLVaeg6egGOenDx/9Za8ubIzuE8n/PwD2bzrEKYqFe1b1sfayjJJ/5L7UQePnePR01e8cf2ATZpU9OvWRjeWKimVV63W6Jq7Hz97xeQ5K1AqFPTt1hbX9+5cuHKLwI/B5MudgwE922FpYcEb1w/0Hz6VGeMHkz+vQ9RjCZLAgNbYIiIi2br7MIUL5aNIwbwMHT+HHNmyUr5MUSIiIkmV0poU1lbYZckIRD17SqVScffBU1Zv2sPHoGD+nj/ByKWI3+efXWRkJAeOniWHfVaKOTmyY98xjp2+RFhYOLWqltNN63L/0XN6Dp7A2QNrkv3g1tmL1uHj68fUsQNjLL9++z4HjpyNmmS3RzsCAoNYuWEXK+aNT9IPtYzLP0fPcvGqM9PGRZUxLDycFl0Gs37JVGxtUvPk2SvSpbUhrW0a4wb6DSIiIjE1VXHmwnVu33vE4D6dAfhzxhJSp0pB66Z1Wbp6G/4BH/Hx86f3L62pVLa4kaNOmpL3mfsfaDQacuXIxuoFk5L0JJ7Rv1Siv+g9vX2ZOHMZb1w/ULtaedq3rE/VCqXYuucIG5dNI3WqFGi1WiwszCleOD8f3D0x+fSlmlSShYTUoHZlGtSujJe3L+nS2gD/JkZJpbwazb9fsBqNhpDQMNKkSkn6dLaULVmYJ89esXnnIf4c3ofCn5rtHz19SZ5c2enfvR02n6Z3SYrJEfDpacE+nL98kyIF89K9Y3P2HznD+OmLccqfh/uPnpMze1ZKF3eifcv6KBRRdVG4YF4mjOibJAe3wr/dadGfXUhoKJNnryDwYzA+fifo+2sb8ud14Njpywwf2I2CjrmAqAeVlixakKEDuqJWqzExSTrH4o/o170NzTsPJiw8HHMzMzQaDRev3qZ44fwULpgXM1NTXctaWHhEskuOAOrXqsSK9Tt5+86NbFkz8eDRc0oXd8LaOqos+ZLgD+jYj5U4c/E6y9bsoFLZ4jRvVJPwiAh8/QIJDQ3DwsKcnl1aMmTsbHp1bc24ob1xvvcYhxx2uuum+NL/dQtScuLy5h0nz13F1FRFvtw5yZXDjhXrd5I7pz0lihZg9qJ11KhcBsc8OVm3dR/FnKKm1fh/k5RajT4fr/LB3Yupc1dS1CkfdlkyUr1SGWbMX0XZkkWoWbUsU+auRK1WkytHNu49eoapSsXwgb8m2bn9zl+5hYenNy0a1QLA3cObuUvW06huVSqWjZoPLTgkFDNTFR+DQrjz4AkHjpxl8qj+uruakouHT14wb+lGihTKS5rUKenYqiFHT11k5fpd7Fw7l3lL1+Pm4U3+PA5cuHqLwgXz0eeX1sm+5ehzew6e5Pmrt9SpVp6/lm0gt4M9v/fprPsso1stkrN7D58xe/FaypcuysWrzrRrXi/J3sDy+XXu+cs3qFQqLly9hV3mjNx79Aw3dy8mjOjLrwPG0bJJbRrUqszNOw85e+kGQ/t3NW7wyYgkSElQ9BerVqtFrVaz7/Bpnr18g6WFOfsPn2HogK7UrVGRE2eucP/xc+rWqIBWq+XAkbM8feFCneoVaNWktrGL8X9JrdZw6bozeR2yk8LaEmtrKwICg1iwfCOliheioGNu+g6dzNpFkzl/+RZPX7jQpW1jrK2tuH33MReu3NI9FTspc773mAEjpnFyz9+6wbg79h3jxau3dGnbmMyZ0sdYf/veo/j6ByT5O0M//+IJDQvn6s27XL52hwKOuXj+8g2Pnr5k4YxRWJib0WPQn1StUIoOrRpw/sotbjo/JH9ehyT/LLEfodFoqNOyNzmzZ6Vft7YUKZTP2CElin5Dp5ArZzb6d2+XpO+ehKiHrh46cZ61m/dha5OaNKlTMnfyUIKCghk8ZhbdO7XA3MyU/UfO4O3jh49fAJ3bNKJmlbJf37gAJEFKUuJq/fDzD6RR+/783rczzRrUYOnqbXwMDuG3nu2JiIhk885DREZG0qlNI1KmsNaN7xCGt//IGfYePEWmDGkxMTEhJDSM2ROHEBoaxowFa3DInpVrt+6TNUsGRgzsxsegYBau2EyO7FlpVKcKKaytYox3SerGTFmIhYU5Y4b0BKIu2H/OWELNquWoXqk0t+895uHjF7i8fc+TZ6/o260tZUsWNnLUcYvr3PPy9mXVxj24e3ozd/JQPLx8WLt5H1kyp6djq4a8dHGlY++R/LN1UZKbhDQx+PkHkib1v92hSam1NqEk1fMvdl37+Pmz5O+tWFhYMKBnO27decTJc1epWaUsZUsW5uS5q2zZdYjlc8djYqLE+d5jChXIk2S76ZOqpHck/B+LPgFuOD9g14HjPHnuQprUKenUuhGHjp8HoFObRri+c9PN+F24YF7Sp7PVvVeSI+OIfp7K+GG9mTp2IGP/6IVCASvW7cTT2xeNRsOFq7fp1bUVIwZ2A6IeSVC+TFHCQsN1F+WkeHGOz9ABv3DmwvWou5iIel5R5fIl2LbnCAD58zqQ1jY1eXNlZ/3SqUkyOQoKCgb+PfeOnb7E0PFz2LHvGBGRapo2qE6GdLZcv32fDOlsqVSuOM73nvD67XscctgxdEBXVCaqJHenZGKITo6i75b62ZIjSHrnX/RxFV3XV27c5aWLK7ZpUlPAMTfunl54+/jhVCAPeRzsuXzdmaCgYGpULkMKayuOn4l6An1RJ0dJjn5A0joa/s8EBQUzfvoSfHz9dcvWb9vPvKUbcPfw5q+lGzhw9Cw9u7TEy9uXMxevk8LaimqVSrNz3zF8/QIoW7IwrZrUTpYDI38mtmlS06hOFW7dfQREJQuDenfi8bNXhISGkTdXdhzz5CQ0LIyg4BBmL1rH5et3qFK+JF3bN0mSt7V/TdQdMXWYvXCtblnVCqVIYW2Jf0AgFuZmSba7Nyg4hOnzV/H3xt26Zf8cPcveQ6do3rAmHp4+jJ48n5z2WcmUIR237j7Cx8+fYk6OZEhny6VrzgA0a1CDVCmtf8pkIT5JLYn4WX0+AFut1rB971EmzV7O8rU72LL7MA1rVyaFtTX3Hj7DytKCYoXzExYewaETFwCYMuY36tZImmOokgs50o0oKDiEMxevs//IGSDqLpl7D5+xdPZY+nZrS6umdbj38CmvXr/jt54dmL9sIwBN61enbYt62KRJZcToRWyD+nRk6erthIWHA1HPanLIYcfuAydo37I+DtntWLNpLz0HT8DKyoJypYoYOeL/rmeXloSGhbNq4x7OXLzOyEnzyZY1s+7OtKQwlUtcrK0scX3nzp37T7h++z4Avn4BVCpXgnKlitCve1si1RoOnThPnerl8fML5MLlW1hYmNOra0vatUjaY8RE8qdQKAgPj2De0vXMX76R8IgIDm5dTKumtblx+z7v3TyoVbUst+484sWrt+TOmY1iTo44ZLcDkB/NCUASJAN7/vKNbloMjVaLY56cPHnmgsubd1haWBAQGMSp81cBKFIwLxERal6/fU+1SqUxNTXlwpXbAFQpX9JoZRBxs7SwoPcvrZm1YI1uWcUyxfD09iU0LIwm9asxaVR/lswaQ99f2xgx0oQ1ekhP0tmm4cCRs1SvXIZBvTsaO6Q4HT11kSfPXun+rl+rEpkzpufk2atEqtX4+gcSFBRMRETU+dmlbWNOnL1C5kzpyWGfRfcMnKT6WAKRvEV3p0X//+LV2/xz7BwmJio+BgVz8aozb9+5UdTJkWJO+dm+9xjlSxclIjKSyzfuRA2kr16BEkWTzsTbyZ0kSAbk6e1L576j2br7CGq1hkwZ0pE3V3Zc37tz+MQFQkPDqFO9AjedHxL4MUh3QY74lFCtXzJFdwu1SJqa1q/GtU+/7iDqabbFCjvqutBsbVLrniz9s8idMxtN6ldj1oTfaVSnirHDidOr1+/Yse8Yc5asx+XNeyBqBvfcDvakS5uGU+eu0rhuFc5dusnVT3PD+fj6U6a4EwAtGteiQhk590TiiFSrdd1p0f8/eOwc5y/fpGeXlvTs0pIC+Ry4eechJkolVSuW4oO7J+ev3KJ7p+bUrVFRxp8mAkmQDCh9Wht6dW3F1j2H2bTzH0LDwqlUtjiN61XlwZMXPHj8gkrliqNQwNipi5gwcynv3Tx0T/k2T2ITIoovKZVKJo8awIiJ81m+bgenzl/FqUDSnbMpISXlcTg5s2elUZ2qpE6Vgp37j3P01EWKOTly4/YDShQtyNWb90ifzpaWjWtx8txV+g+byrHTl3S/xmWAq0hoXt6+uhscVCYmvHfzYMHyTew/fBoPLx8G9elEaGgYb1w/6H5Mu7x5z72Hz7DLkpEm9aphmyY1WTJlIEM6WyOX5uckt/kbWEREJANHTSdHtqzkymnHs5dvqFmlLGFh4Rw8fp7xw3qjVCh58Pg5b1w/0LheNWOHLH5Av6FTyO2QjX7dkv7zVH42oaFhbN1zhKKF8lEof27dL+s3rh84fPICDtnt2LzzEH/078KRkxepWbUcd+4/RqPW0rV9E8LCw3n05CVFnRyNXBLxM9JoNPy9YTdnL96gWcMaVCpbnJDQUEZPXkitquX4GBzMsxevGTW4B6fOX8XlzXv+6N+V4JAQ/t6wm4zp09K2eV1pMTKApPuT7ydlaqqiY6uGQNRt0Ndv3Wfr7iNUKFOMiIgI9h8+g6mpiqJOjpIcJWMLpo9kcJ/OkhwZ2Pkrt+jafyzv3TxQKpUEBYfqXrO3y0yGdLaoTExoWr865y/f4syF62TLkpESRQry6s073r5zw9zMTJIjkWjOXryB63t3Vi2YQMvGtUifzoZnL99QrVIpurZvQreOzShRtADL1m6nZePafHD34uylG6ROlZKmDarTsnEtSY4MRBIkIyhXqgjunt7Y22WmU5tGZEhnS1h4OL26tqZY4fzGDk8kALkV2rCin83z0sWVLm0bM2pwDwoXzKsb7xU9p2GlssV54fKWrFky0KVdY0oWK0RAYBB5HOz5o38XsmXNZLQyiJ+fVqvF+f5jqlQoiYWFOWHh4SiVSgICP3Lu8i0ATFUqShd3Ijg4FIUCypcuyvOXb1Cro+YPTW5T9SRnkoYagUKhoM8vrVm2Zgd/9O9CUHAI5mZm5M6ZzdihCZGsREREsnX3YQoXykeRgnm5/+gZObJl5fa9x0RERJIqpTUprK2wy5IRgHRpbcibKwf3Hj4ja+aMjB/WW7ctae0TiU2hUBAUHIrLm3dAVDIE0KJRLbbsOsy+Q6dpUr8awcEhpEhhhUqlom3zusYM+f+aJEhGktvBnvCIcN3s0UKI72dqqsLd04fzl29SpGBeundszv4jZxg/fTFO+fNw/9FzcmbPSuniTrr57cqWLMyrN++IiIgwcvTi/1GNymU4euoint6+pE9rQ0hoKJYWFjSpV43DJ85z9+FTHj15SaumUQ9Y/RmndEkuZJC2ESXVeX+ESMrOX7mFh6c3LRrVAsDdw5u5S9bTqG5V3WMwgkNCMTNV8TEohDsPnnDgyFkmj+qPubkZCoVCzj1hNN4+fmzbcySqJ+Gz56HtPnCCgvlz4+cfSI5sWciYIa0RoxQgLUhGJRdoIb5fSmsrRk2aT6M6VTEzMyVjhrSULFaQC1dukSuHHZkzpcfKMuq5U2lSp8Tdw5s8uexjjN2Qc08YS1rbNNSvVYnxM5YAkC9PTv45epa0tmmoW7Mi+XLnMG6AQkdakIQQyc6YKQuxsDBnzJCeAISHR/DnjCXUrFqO6pVKc/veYx4+foHL2/c8efaKvt3aJsnJcsX/r6cvXvP46Uuc7z+Jumu5blVjhyRikQRJCJHs+Ad8pEWXwSyfN45cOaJubjhy8gJ7Dp5i+dxxhIaFc+bCNQI/BifJyXKFiKbVapPsnIX/76SdWQiR7PyvvTtGTSAKAjA8lUaUpA9KEG8gLAhrITbbpkpvnyt4Azsv4BVsbAWbVJZis2DhCWIukM7i1Vvsg+8r3wGGnynevL0O4uuzis1293xblEUM+r34ffzFS7cT1bIUR7SeOGovGyQgW6vvdcxn05iMh7E/HONj9N7aY7lAXgQSkK36do/LtY7TzzkW86K1x3KB/AgkIHv+igGaZqIA2RNHQNNMFQCAhEACAEgIJACAhEACAEgIJACAxD+XpltO+5AJlwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 583.3x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Paired bars per factor. Value and bonds have taller risk-off bars than risk-on bars; momentum, equity, carry and defensive have taller risk-on bars, with carry and defensive falling below zero in the risk-off months."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, ax = plt.subplots(figsize=style.FIGSIZE[\"single_tall\"])\n",
     "\n",
@@ -1050,18 +1892,111 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "73505c2e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 28,
+   "id": "b11ae1ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:14.295517Z",
+     "iopub.status.busy": "2026-09-08T23:45:14.295332Z",
+     "iopub.status.idle": "2026-09-08T23:45:14.301082Z",
+     "shell.execute_reply": "2026-09-08T23:45:14.300710Z"
+    },
+    "papermill": {
+     "duration": 0.02774,
+     "end_time": "2026-09-08T23:45:14.301718+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.273978+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_aaf2a\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >regime</th>\n",
+       "      <th id=\"T_aaf2a_level0_col0\" class=\"col_heading level0 col0\" >Risk-on</th>\n",
+       "      <th id=\"T_aaf2a_level0_col1\" class=\"col_heading level0 col1\" >Risk-off</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_aaf2a_level0_row0\" class=\"row_heading level0 row0\" >Value</th>\n",
+       "      <td id=\"T_aaf2a_row0_col0\" class=\"data row0 col0\" >+1.6</td>\n",
+       "      <td id=\"T_aaf2a_row0_col1\" class=\"data row0 col1\" >+5.3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_aaf2a_level0_row1\" class=\"row_heading level0 row1\" >Momentum</th>\n",
+       "      <td id=\"T_aaf2a_row1_col0\" class=\"data row1 col0\" >+4.5</td>\n",
+       "      <td id=\"T_aaf2a_row1_col1\" class=\"data row1 col1\" >+0.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_aaf2a_level0_row2\" class=\"row_heading level0 row2\" >Carry</th>\n",
+       "      <td id=\"T_aaf2a_row2_col0\" class=\"data row2 col0\" >+3.5</td>\n",
+       "      <td id=\"T_aaf2a_row2_col1\" class=\"data row2 col1\" >-0.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_aaf2a_level0_row3\" class=\"row_heading level0 row3\" >Defensive</th>\n",
+       "      <td id=\"T_aaf2a_row3_col0\" class=\"data row3 col0\" >+4.2</td>\n",
+       "      <td id=\"T_aaf2a_row3_col1\" class=\"data row3 col1\" >-0.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_aaf2a_level0_row4\" class=\"row_heading level0 row4\" >US Value</th>\n",
+       "      <td id=\"T_aaf2a_row4_col0\" class=\"data row4 col0\" >-1.0</td>\n",
+       "      <td id=\"T_aaf2a_row4_col1\" class=\"data row4 col1\" >+20.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_aaf2a_level0_row5\" class=\"row_heading level0 row5\" >US Momentum</th>\n",
+       "      <td id=\"T_aaf2a_row5_col0\" class=\"data row5 col0\" >+10.7</td>\n",
+       "      <td id=\"T_aaf2a_row5_col1\" class=\"data row5 col1\" >-0.7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_aaf2a_level0_row6\" class=\"row_heading level0 row6\" >Equity</th>\n",
+       "      <td id=\"T_aaf2a_row6_col0\" class=\"data row6 col0\" >+9.5</td>\n",
+       "      <td id=\"T_aaf2a_row6_col1\" class=\"data row6 col1\" >+2.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_aaf2a_level0_row7\" class=\"row_heading level0 row7\" >Bonds</th>\n",
+       "      <td id=\"T_aaf2a_row7_col0\" class=\"data row7 col0\" >+0.8</td>\n",
+       "      <td id=\"T_aaf2a_row7_col1\" class=\"data row7 col1\" >+4.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_aaf2a_level0_row8\" class=\"row_heading level0 row8\" >Commodities</th>\n",
+       "      <td id=\"T_aaf2a_row8_col0\" class=\"data row8 col0\" >+4.0</td>\n",
+       "      <td id=\"T_aaf2a_row8_col1\" class=\"data row8 col1\" >+8.5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7d282c65da90>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "annualized_by_regime.T.style.format(\"{:+.1f}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "40ad308f",
-   "metadata": {},
+   "id": "dfebe786",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004357,
+     "end_time": "2026-09-08T23:45:14.313691+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.309334+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The two strategies a calm market reads as safe income - carry, which collects a yield\n",
     "spread, and defensive, which is long low-risk assets - are the ones that stop paying when\n",
@@ -1075,9 +2010,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "739e4c7d",
+   "id": "b349c02e",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.004665,
+     "end_time": "2026-09-08T23:45:14.322953+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.318288+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "## Regime statistics\n",
@@ -1098,9 +2040,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ba714c80",
-   "metadata": {},
+   "execution_count": 29,
+   "id": "cfc9dccc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:14.332717Z",
+     "iopub.status.busy": "2026-09-08T23:45:14.332594Z",
+     "iopub.status.idle": "2026-09-08T23:45:14.335094Z",
+     "shell.execute_reply": "2026-09-08T23:45:14.334529Z"
+    },
+    "papermill": {
+     "duration": 0.007875,
+     "end_time": "2026-09-08T23:45:14.335377+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.327502+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def drawdown_path(returns: pd.Series) -> pd.Series:\n",
@@ -1111,10 +2067,81 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4347fcc0",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 30,
+   "id": "0203777e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:14.345916Z",
+     "iopub.status.busy": "2026-09-08T23:45:14.345792Z",
+     "iopub.status.idle": "2026-09-08T23:45:14.354377Z",
+     "shell.execute_reply": "2026-09-08T23:45:14.353795Z"
+    },
+    "papermill": {
+     "duration": 0.014216,
+     "end_time": "2026-09-08T23:45:14.354674+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.340458+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_c9fba\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_c9fba_level0_col0\" class=\"col_heading level0 col0\" >Months</th>\n",
+       "      <th id=\"T_c9fba_level0_col1\" class=\"col_heading level0 col1\" >Share of sample</th>\n",
+       "      <th id=\"T_c9fba_level0_col2\" class=\"col_heading level0 col2\" >Return, annualized</th>\n",
+       "      <th id=\"T_c9fba_level0_col3\" class=\"col_heading level0 col3\" >Volatility, annualized</th>\n",
+       "      <th id=\"T_c9fba_level0_col4\" class=\"col_heading level0 col4\" >Sharpe ratio</th>\n",
+       "      <th id=\"T_c9fba_level0_col5\" class=\"col_heading level0 col5\" >Max drawdown</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Regime</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "      <th class=\"blank col2\" >&nbsp;</th>\n",
+       "      <th class=\"blank col3\" >&nbsp;</th>\n",
+       "      <th class=\"blank col4\" >&nbsp;</th>\n",
+       "      <th class=\"blank col5\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c9fba_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
+       "      <td id=\"T_c9fba_row0_col0\" class=\"data row0 col0\" >900</td>\n",
+       "      <td id=\"T_c9fba_row0_col1\" class=\"data row0 col1\" >76.5%</td>\n",
+       "      <td id=\"T_c9fba_row0_col2\" class=\"data row0 col2\" >+9.5%</td>\n",
+       "      <td id=\"T_c9fba_row0_col3\" class=\"data row0 col3\" >8.6%</td>\n",
+       "      <td id=\"T_c9fba_row0_col4\" class=\"data row0 col4\" >1.11</td>\n",
+       "      <td id=\"T_c9fba_row0_col5\" class=\"data row0 col5\" >-22.9%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c9fba_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
+       "      <td id=\"T_c9fba_row1_col0\" class=\"data row1 col0\" >276</td>\n",
+       "      <td id=\"T_c9fba_row1_col1\" class=\"data row1 col1\" >23.5%</td>\n",
+       "      <td id=\"T_c9fba_row1_col2\" class=\"data row1 col2\" >+2.2%</td>\n",
+       "      <td id=\"T_c9fba_row1_col3\" class=\"data row1 col3\" >19.1%</td>\n",
+       "      <td id=\"T_c9fba_row1_col4\" class=\"data row1 col4\" >0.12</td>\n",
+       "      <td id=\"T_c9fba_row1_col5\" class=\"data row1 col5\" >-76.9%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7d282c506350>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "regime_statistics = pd.DataFrame(\n",
     "    [\n",
@@ -1145,10 +2172,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3a59be42",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 31,
+   "id": "5be89c4f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:14.365252Z",
+     "iopub.status.busy": "2026-09-08T23:45:14.364963Z",
+     "iopub.status.idle": "2026-09-08T23:45:14.370346Z",
+     "shell.execute_reply": "2026-09-08T23:45:14.368910Z"
+    },
+    "papermill": {
+     "duration": 0.011062,
+     "end_time": "2026-09-08T23:45:14.370714+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.359652+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Risk-off volatility is **2.23x** risk-on volatility measured on the pooled monthly returns, against **1.30x** measured as the average of the trailing twelve-month series."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "pooled_vol_ratio = (\n",
     "    regime_statistics.loc[\"Risk-off\", \"Volatility, annualized\"]\n",
@@ -1169,8 +2223,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86115a2d",
-   "metadata": {},
+   "id": "fc295b16",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00843,
+     "end_time": "2026-09-08T23:45:14.387968+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.379538+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The two ratios answer different questions and a reader should expect them to differ. The\n",
     "rolling series smooths each month against the eleven around it, so a single extreme month\n",
@@ -1183,8 +2245,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3933271c",
-   "metadata": {},
+   "id": "2724f018",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007325,
+     "end_time": "2026-09-08T23:45:14.405855+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.398530+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### What the restricted drawdown actually measures\n",
     "\n",
@@ -1196,33 +2266,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9fad275c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 32,
+   "id": "07594b81",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:14.424828Z",
+     "iopub.status.busy": "2026-09-08T23:45:14.424694Z",
+     "iopub.status.idle": "2026-09-08T23:45:14.438158Z",
+     "shell.execute_reply": "2026-09-08T23:45:14.437836Z"
+    },
+    "papermill": {
+     "duration": 0.025501,
+     "end_time": "2026-09-08T23:45:14.438885+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.413384+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The restricted stream peaks in **August 1986** and reaches its low in **March 2020**, a fall of **76.9%** spread over **34 years**. Over the same span the equity index itself fell at most **55.4%** from its own high-water mark."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "risk_off_returns = equity_returns[regime_name == \"Risk-off\"]\n",
     "risk_off_drawdown = drawdown_path(risk_off_returns)\n",
     "trough_month = risk_off_drawdown.idxmin()\n",
     "peak_month = (1 + risk_off_returns).cumprod().loc[:trough_month].idxmax()\n",
     "\n",
+    "restricted_drawdown = float(risk_off_drawdown.min())\n",
     "index_over_span = equity_returns.loc[peak_month:trough_month]\n",
     "index_drawdown = float(drawdown_path(index_over_span).min())\n",
     "display(\n",
     "    Markdown(\n",
     "        f\"The restricted stream peaks in **{peak_month:%B %Y}** and reaches its low in \"\n",
     "        f\"**{trough_month:%B %Y}**, a fall of \"\n",
-    "        f\"**{risk_off_drawdown.min():.1%}** spread over \"\n",
+    "        f\"**{abs(restricted_drawdown):.1%}** spread over \"\n",
     "        f\"**{trough_month.year - peak_month.year} years**. Over the same span the equity \"\n",
-    "        f\"index itself fell at most **{index_drawdown:.1%}** from its own high-water mark.\"\n",
+    "        f\"index itself fell at most **{abs(index_drawdown):.1%}** from its own high-water \"\n",
+    "        \"mark.\"\n",
     "    )\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b00006a1",
-   "metadata": {},
+   "id": "1821fa96",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01288,
+     "end_time": "2026-09-08T23:45:14.458821+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.445941+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "Nobody lived through the first of those two numbers. The risk-off months are selected by\n",
     "the mixture's assignment, not by the sign of the equity return, so the stream holds gains\n",
@@ -1244,8 +2351,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "769f9f87",
-   "metadata": {},
+   "id": "24184602",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00633,
+     "end_time": "2026-09-08T23:45:14.476395+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.470065+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## How long the regimes last\n",
     "\n",
@@ -1256,10 +2371,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e11958d8",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 33,
+   "id": "d9b0b783",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:14.492809Z",
+     "iopub.status.busy": "2026-09-08T23:45:14.492685Z",
+     "iopub.status.idle": "2026-09-08T23:45:14.509486Z",
+     "shell.execute_reply": "2026-09-08T23:45:14.509150Z"
+    },
+    "papermill": {
+     "duration": 0.027868,
+     "end_time": "2026-09-08T23:45:14.510652+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.482784+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_889ea\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_889ea_level0_col0\" class=\"col_heading level0 col0\" >Mean length (months)</th>\n",
+       "      <th id=\"T_889ea_level0_col1\" class=\"col_heading level0 col1\" >Longest (months)</th>\n",
+       "      <th id=\"T_889ea_level0_col2\" class=\"col_heading level0 col2\" >Episodes</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Regime</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "      <th class=\"blank col2\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_889ea_level0_row0\" class=\"row_heading level0 row0\" >Risk-on</th>\n",
+       "      <td id=\"T_889ea_row0_col0\" class=\"data row0 col0\" >6.7</td>\n",
+       "      <td id=\"T_889ea_row0_col1\" class=\"data row0 col1\" >110</td>\n",
+       "      <td id=\"T_889ea_row0_col2\" class=\"data row0 col2\" >134</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_889ea_level0_row1\" class=\"row_heading level0 row1\" >Risk-off</th>\n",
+       "      <td id=\"T_889ea_row1_col0\" class=\"data row1 col0\" >2.1</td>\n",
+       "      <td id=\"T_889ea_row1_col1\" class=\"data row1 col1\" >14</td>\n",
+       "      <td id=\"T_889ea_row1_col2\" class=\"data row1 col2\" >134</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7d282c506850>"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "episode_id = (labels_2 != np.roll(labels_2, 1)).cumsum()\n",
     "episode_lengths = (\n",
@@ -1284,10 +2458,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3df7b386",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 34,
+   "id": "194aba79",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:45:14.525406Z",
+     "iopub.status.busy": "2026-09-08T23:45:14.525241Z",
+     "iopub.status.idle": "2026-09-08T23:45:14.529518Z",
+     "shell.execute_reply": "2026-09-08T23:45:14.528882Z"
+    },
+    "papermill": {
+     "duration": 0.012874,
+     "end_time": "2026-09-08T23:45:14.530943+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.518069+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The two-cluster model changes regime **267** times over 97 years, about once every **4.4 months**."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "switches = int(np.sum(np.diff(labels_2) != 0))\n",
     "months_between_switches = len(labels_2) / switches\n",
@@ -1302,8 +2503,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87982249",
-   "metadata": {},
+   "id": "3b9781b5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0066,
+     "end_time": "2026-09-08T23:45:14.544250+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.537650+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "That is the finding that decides what this model is for. A label that changes several\n",
     "times a year cannot drive a reallocation: the turnover would be paid on every switch,\n",
@@ -1321,8 +2530,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23458fe4",
-   "metadata": {},
+   "id": "7f2db3c1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007547,
+     "end_time": "2026-09-08T23:45:14.561018+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:45:14.553471+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key takeaways\n",
     "\n",
@@ -1363,6 +2580,39 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T23:45:30.304140+00:00",
+   "executor": "local-uv",
+   "library_digest": "5c6cff9e7067767cd11d73fec3dd7f1c5b8a9af5570ee2ea53c7dfce7b154c8e",
+   "outputs_digest": "3dfcb307002f7d1b930ea9ad13d24a6eb6faa8d3c825e7856b0db1ffe9362ed8",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "31c4c45f24afe92089bfdfbb35ad299aa986468a"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 106.612052,
+   "end_time": "2026-09-08T23:45:17.325938+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.build.2193386.ipynb",
+   "output_path": "~/ml4t/public-teach-a/01_process_is_edge/.factor_regimes.papermill.2193386.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T23:43:30.713886+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/01_process_is_edge/factor_regimes.ipynb
+++ b/01_process_is_edge/factor_regimes.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "eb2a2f0d",
+   "id": "c8fc813e",
    "metadata": {},
    "source": [
     "# Factor-based regime detection\n",
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9f5352c",
+   "id": "2e6725a2",
    "metadata": {},
    "source": [
     "## Setup\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31e7eac3",
+   "id": "e44b4376",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,6 +97,7 @@
     "import structlog\n",
     "from IPython.display import Markdown, display\n",
     "from matplotlib.axes import Axes\n",
+    "from matplotlib.collections import LineCollection\n",
     "from matplotlib.colors import ListedColormap\n",
     "from ml4t.data.providers import AQRFactorProvider\n",
     "from ml4t.diagnostic.metrics import sharpe_ratio\n",
@@ -117,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "628c36ce",
+   "id": "8b6c331e",
    "metadata": {
     "tags": [
      "parameters"
@@ -131,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc0a5e40",
+   "id": "06adc491",
    "metadata": {},
    "source": [
     "### Settings, and what each one decides\n",
@@ -157,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "811bfe08",
+   "id": "c9a7ca4a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28ab4491",
+   "id": "990059a1",
    "metadata": {},
    "source": [
     "## Load the factor panel\n",
@@ -186,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "702ee31e",
+   "id": "870703c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80237ea1",
+   "id": "e9e2b080",
    "metadata": {},
    "source": [
     "### The nine series used here\n",
@@ -224,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "217eec89",
+   "id": "c8be45b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bfb9ccc4",
+   "id": "71024149",
    "metadata": {},
    "source": [
     "### What is actually in the panel\n",
@@ -274,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90757261",
+   "id": "dc71c7e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0cd6662",
+   "id": "b3be5b23",
    "metadata": {},
    "source": [
     "## Prepare the panel for clustering\n",
@@ -306,16 +307,18 @@
     "missing observation recovered - it is an invented one, and a mixture model would treat it\n",
     "as evidence for a cluster.\n",
     "\n",
-    "The nine series are then standardized to zero mean and unit variance. Without that step\n",
-    "the equity market series, whose monthly standard deviation is several times a long-short\n",
-    "strategy's, would dominate every distance and the clustering would be a partition of\n",
-    "equity returns alone."
+    "The nine series are then standardized to zero mean and unit variance. The coverage table\n",
+    "above shows why: the widest series in the panel has several times the monthly standard\n",
+    "deviation of the narrowest, and a Euclidean distance is dominated by whichever coordinate\n",
+    "moves furthest. Standardizing puts every series on the same footing, so the partition\n",
+    "reflects the direction the panel moved in rather than which column happened to be measured\n",
+    "on the largest scale."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2cc95a7",
+   "id": "f97754e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +336,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a30ebe0c",
+   "id": "ccfb8f8f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -373,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c095783",
+   "id": "98f487d3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c766f988",
+   "id": "af52b160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f205aeb8",
+   "id": "b9482314",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,14 +474,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82c4cd25",
+   "id": "be63baec",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "source": [
     "### Reading the three criteria against each other\n",
     "\n",
-    "The bars below carry the same three columns. Both information criteria are drawn on a\n",
+    "The bars below draw three of the table's columns. Both information criteria are drawn on a\n",
     "zoomed vertical axis, because the differences between candidate models are small relative\n",
     "to their level and would be invisible on a scale that started at zero; the silhouette\n",
     "panel is drawn on its natural scale, which includes zero."
@@ -487,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "170301c6",
+   "id": "58b84ec9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "879c7290",
+   "id": "75f7fb1c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94cef716",
+   "id": "00628471",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +556,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "799f40c8",
+   "id": "e17c321a",
    "metadata": {},
    "source": [
     "When the criteria disagree, the choice is made on what the model is for. AIC targets\n",
@@ -572,7 +575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eaa7a46c",
+   "id": "14ad0dd0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +584,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a70719db",
+   "id": "a615a98a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -598,7 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9aa30b4",
+   "id": "6313658a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -614,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd30d574",
+   "id": "8b84129e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17aa1a31",
+   "id": "ec3a7a60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -676,7 +679,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b1f4d82",
+   "id": "98935308",
    "metadata": {},
    "source": [
     "No band settles down as clusters are added. An added cluster does not carve out an era the\n",
@@ -684,13 +687,13 @@
     "more finely speckled than the one above it. A mixture has no notion of time and nothing in\n",
     "it prefers a month to keep its neighbour's label, so there is no mechanism by which more\n",
     "clusters could produce longer stretches. That absence is the reason the last section of\n",
-    "this notebook points at a hidden Markov model, which supplies exactly the mechanism this\n",
-    "one lacks."
+    "the section on how long the regimes last points at a hidden Markov model, which supplies\n",
+    "exactly the mechanism this one lacks."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "508ee49f",
+   "id": "6880e28b",
    "metadata": {},
    "source": [
     "## The two-cluster model: risk-on and risk-off\n",
@@ -711,7 +714,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89e5491d",
+   "id": "5a4b81c4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,7 +734,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a5b4506",
+   "id": "0a0fcd17",
    "metadata": {},
    "source": [
     "### The timeline against dated events\n",
@@ -747,7 +750,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f9e1740",
+   "id": "ed065fc6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -765,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09caa091",
+   "id": "ae888074",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +792,32 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104172ec",
+   "id": "39b3df59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_by_regime(ax: Axes, values: np.ndarray, in_risk_on: np.ndarray) -> None:\n",
+    "    \"\"\"Draw one line whose every segment takes the colour of the month it starts in.\n",
+    "\n",
+    "    Colouring by masking each regime into its own line would drop the segment that spans a\n",
+    "    transition, and would draw nothing at all for a one-month episode, which is most of\n",
+    "    them here.\n",
+    "    \"\"\"\n",
+    "    y = np.asarray(values, dtype=float)\n",
+    "    points = np.column_stack([np.arange(len(y)), y]).reshape(-1, 1, 2)\n",
+    "    segments = np.concatenate([points[:-1], points[1:]], axis=1)\n",
+    "    drawable = np.isfinite(segments[:, :, 1]).all(axis=1)\n",
+    "    colours = np.where(in_risk_on[:-1], COLORS[\"recede\"], COLORS[\"blue\"])\n",
+    "    ax.add_collection(LineCollection(segments[drawable], colors=colours[drawable], linewidths=1.2))\n",
+    "    finite = y[np.isfinite(y)]\n",
+    "    ax.set_xlim(0, len(y) - 1)\n",
+    "    ax.set_ylim(finite.min() * 0.9, finite.max() * 1.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "061eb86d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -805,10 +833,8 @@
     "mark_events(ax_band, factors_df.index.year.tolist())\n",
     "\n",
     "cumulative = (1 + equity_returns).cumprod()\n",
-    "positions = np.arange(len(cumulative))\n",
-    "for cluster, colour in ((risk_on_cluster, COLORS[\"recede\"]), (risk_off_cluster, COLORS[\"blue\"])):\n",
-    "    masked = np.where(labels_2 == cluster, cumulative.to_numpy(), np.nan)\n",
-    "    ax_equity.plot(positions, masked, color=colour, linewidth=1.2)\n",
+    "in_risk_on = labels_2 == risk_on_cluster\n",
+    "plot_by_regime(ax_equity, cumulative.to_numpy(), in_risk_on)\n",
     "ax_equity.set_yscale(\"log\")\n",
     "ax_equity.set_ylabel(\"Growth of 1 unit invested (log scale)\")\n",
     "ax_equity.set_xlabel(\"Year\")\n",
@@ -831,7 +857,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19c251bb",
+   "id": "13ed31d7",
    "metadata": {},
    "source": [
     "## Volatility inside each regime\n",
@@ -847,7 +873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b58a5e0",
+   "id": "6769ae37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,7 +893,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1084c676",
+   "id": "114548eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -880,9 +906,7 @@
     "ax_band.set_yticklabels([\"Risk-off\", \"Risk-on\"])\n",
     "ax_band.set_ylim(-0.5, 1.5)\n",
     "\n",
-    "for cluster, colour in ((risk_on_cluster, COLORS[\"recede\"]), (risk_off_cluster, COLORS[\"blue\"])):\n",
-    "    masked = np.where(labels_2 == cluster, rolling_vol.to_numpy() * 100, np.nan)\n",
-    "    ax_vol.plot(positions, masked, color=colour, linewidth=1.2)\n",
+    "plot_by_regime(ax_vol, rolling_vol.to_numpy() * 100, in_risk_on)\n",
     "for regime, colour in ((\"Risk-on\", COLORS[\"copper\"]), (\"Risk-off\", COLORS[\"amber\"])):\n",
     "    ax_vol.axhline(\n",
     "        rolling_vol_by_regime.loc[regime, \"Mean (%)\"],\n",
@@ -914,7 +938,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fa93e49",
+   "id": "6df30909",
    "metadata": {},
    "source": [
     "### Figure 1.5 inputs\n",
@@ -928,7 +952,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f299218e",
+   "id": "35ba202a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -949,7 +973,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69e4ff74",
+   "id": "b6821add",
    "metadata": {},
    "source": [
     "## What each factor earned in each regime\n",
@@ -968,7 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35bea765",
+   "id": "5dc0bb27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -980,7 +1004,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6afbe975",
+   "id": "1a4a4452",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1025,7 +1049,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2338226c",
+   "id": "2a40ec4a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1034,19 +1058,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d632f48e",
+   "id": "bb6240b5",
    "metadata": {},
    "source": [
-    "The two long-short strategies named for safety, carry and defensive, are the ones that\n",
-    "stop paying when conditions deteriorate. That is the shape a reader should take away:\n",
-    "a strategy's average return over a full sample says nothing about whether it will be there\n",
-    "in the environment a portfolio needs it in, and the only way to find out is to condition\n",
-    "on the environment and look."
+    "The two strategies a calm market reads as safe income - carry, which collects a yield\n",
+    "spread, and defensive, which is long low-risk assets - are the ones that stop paying when\n",
+    "conditions deteriorate. Value and bonds go the other way and earn more.\n",
+    "\n",
+    "A strategy's average return over a full sample therefore says nothing about whether it\n",
+    "will be there in the environment a portfolio needs it in. Finding out means conditioning\n",
+    "on the environment and looking, which is what makes a regime label worth estimating even\n",
+    "when nothing can act on it."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "93f0501c",
+   "id": "86508232",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1070,7 +1097,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "717b57d4",
+   "id": "f8bb7f0b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1083,7 +1110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6472f5f5",
+   "id": "655d862e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1117,7 +1144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c9d2508",
+   "id": "f61bd812",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1140,7 +1167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97dcc286",
+   "id": "df7acaa4",
    "metadata": {},
    "source": [
     "The two ratios answer different questions and a reader should expect them to differ. The\n",
@@ -1154,7 +1181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d8738f4",
+   "id": "2139d015",
    "metadata": {},
    "source": [
     "### What the restricted drawdown actually measures\n",
@@ -1168,7 +1195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7eaffe1",
+   "id": "db49641d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1192,14 +1219,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d254edc4",
+   "id": "6292ceaa",
    "metadata": {},
    "source": [
-    "Nobody lived through the first of those two numbers. It is the arithmetic of a stream that\n",
-    "keeps every month the market was falling and discards the ones in which it recovered, so it\n",
-    "accumulates the losses of a century of separate episodes into one uninterrupted decline.\n",
-    "The statistic is not wrong - it is the correct drawdown of the object it was computed on -\n",
-    "but the object is a construction of this notebook, and a reader who takes it for a crash\n",
+    "Nobody lived through the first of those two numbers. The risk-off months are selected by\n",
+    "the mixture's assignment, not by the sign of the equity return, so the stream holds gains\n",
+    "as well as losses - its average monthly return is positive. What it does not hold is the\n",
+    "months in between, and closing those gaps puts a loss from one decade immediately beside a\n",
+    "loss from the next, with none of the recovery that separated them. Compounded, decades of\n",
+    "separate episodes read as one uninterrupted decline.\n",
+    "\n",
+    "The statistic is not wrong; it is the correct drawdown of the object it was computed on.\n",
+    "But the object is a construction of this notebook, and a reader who takes it for a crash\n",
     "has been misled by a table that never said which object it meant.\n",
     "\n",
     "That is the general form: a conditional statistic inherits the assumptions of the\n",
@@ -1211,7 +1242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a76bfb35",
+   "id": "bb7531df",
    "metadata": {},
    "source": [
     "## How long the regimes last\n",
@@ -1224,7 +1255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3737b1dd",
+   "id": "79b070a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1252,7 +1283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104b020d",
+   "id": "ca5634cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1269,7 +1300,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95b9eccb",
+   "id": "f3fc0ebe",
    "metadata": {},
    "source": [
     "That is the finding that decides what this model is for. A label that changes several\n",
@@ -1281,12 +1312,14 @@
     "A model built to be acted on would be built differently. It would carry a transition\n",
     "structure that makes staying in a regime more likely than leaving it - a hidden Markov\n",
     "model is the standard choice - and it would be fitted forward in time so that each\n",
-    "month's label used only the months before it. Chapter 9 introduces both."
+    "month's label used only the months before it. `09_model_based_features/11_hmm_regimes`\n",
+    "builds the first, and `09_model_based_features/13_regime_as_feature` turns the result into\n",
+    "a feature a model downstream can read."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f830dda9",
+   "id": "483abfab",
    "metadata": {},
    "source": [
     "## Key takeaways\n",

--- a/01_process_is_edge/factor_regimes.py
+++ b/01_process_is_edge/factor_regimes.py
@@ -94,6 +94,7 @@ import polars as pl
 import structlog
 from IPython.display import Markdown, display
 from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
 from matplotlib.colors import ListedColormap
 from ml4t.data.providers import AQRFactorProvider
 from ml4t.diagnostic.metrics import sharpe_ratio
@@ -239,10 +240,12 @@ coverage.style.format({"Mean (% / month)": "{:.2f}", "Std (% / month)": "{:.2f}"
 # missing observation recovered - it is an invented one, and a mixture model would treat it
 # as evidence for a cluster.
 #
-# The nine series are then standardized to zero mean and unit variance. Without that step
-# the equity market series, whose monthly standard deviation is several times a long-short
-# strategy's, would dominate every distance and the clustering would be a partition of
-# equity returns alone.
+# The nine series are then standardized to zero mean and unit variance. The coverage table
+# above shows why: the widest series in the panel has several times the monthly standard
+# deviation of the narrowest, and a Euclidean distance is dominated by whichever coordinate
+# moves furthest. Standardizing puts every series on the same footing, so the partition
+# reflects the direction the panel moved in rather than which column happened to be measured
+# on the largest scale.
 
 # %%
 factors_pl = aqr_raw.select(["timestamp", *FACTOR_COLUMNS]).sort("timestamp").drop_nulls()
@@ -372,7 +375,7 @@ selection.style.format(
 # %% [markdown]
 # ### Reading the three criteria against each other
 #
-# The bars below carry the same three columns. Both information criteria are drawn on a
+# The bars below draw three of the table's columns. Both information criteria are drawn on a
 # zoomed vertical axis, because the differences between candidate models are small relative
 # to their level and would be invisible on a scale that started at zero; the silhouette
 # panel is drawn on its natural scale, which includes zero.
@@ -517,8 +520,8 @@ style.show_with_alt(
 # more finely speckled than the one above it. A mixture has no notion of time and nothing in
 # it prefers a month to keep its neighbour's label, so there is no mechanism by which more
 # clusters could produce longer stretches. That absence is the reason the last section of
-# this notebook points at a hidden Markov model, which supplies exactly the mechanism this
-# one lacks.
+# the section on how long the regimes last points at a hidden Markov model, which supplies
+# exactly the mechanism this one lacks.
 
 # %% [markdown]
 # ## The two-cluster model: risk-on and risk-off
@@ -590,6 +593,25 @@ def mark_events(ax: Axes, years: list[int]) -> None:
 
 
 # %%
+def plot_by_regime(ax: Axes, values: np.ndarray, in_risk_on: np.ndarray) -> None:
+    """Draw one line whose every segment takes the colour of the month it starts in.
+
+    Colouring by masking each regime into its own line would drop the segment that spans a
+    transition, and would draw nothing at all for a one-month episode, which is most of
+    them here.
+    """
+    y = np.asarray(values, dtype=float)
+    points = np.column_stack([np.arange(len(y)), y]).reshape(-1, 1, 2)
+    segments = np.concatenate([points[:-1], points[1:]], axis=1)
+    drawable = np.isfinite(segments[:, :, 1]).all(axis=1)
+    colours = np.where(in_risk_on[:-1], COLORS["recede"], COLORS["blue"])
+    ax.add_collection(LineCollection(segments[drawable], colors=colours[drawable], linewidths=1.2))
+    finite = y[np.isfinite(y)]
+    ax.set_xlim(0, len(y) - 1)
+    ax.set_ylim(finite.min() * 0.9, finite.max() * 1.1)
+
+
+# %%
 fig, (ax_band, ax_equity) = plt.subplots(
     2, 1, figsize=style.FIGSIZE["dual_v"], height_ratios=[1, 2], sharex=True
 )
@@ -602,10 +624,8 @@ ax_band.set_ylim(-0.5, 1.5)
 mark_events(ax_band, factors_df.index.year.tolist())
 
 cumulative = (1 + equity_returns).cumprod()
-positions = np.arange(len(cumulative))
-for cluster, colour in ((risk_on_cluster, COLORS["recede"]), (risk_off_cluster, COLORS["blue"])):
-    masked = np.where(labels_2 == cluster, cumulative.to_numpy(), np.nan)
-    ax_equity.plot(positions, masked, color=colour, linewidth=1.2)
+in_risk_on = labels_2 == risk_on_cluster
+plot_by_regime(ax_equity, cumulative.to_numpy(), in_risk_on)
 ax_equity.set_yscale("log")
 ax_equity.set_ylabel("Growth of 1 unit invested (log scale)")
 ax_equity.set_xlabel("Year")
@@ -658,9 +678,7 @@ ax_band.set_yticks([0, 1])
 ax_band.set_yticklabels(["Risk-off", "Risk-on"])
 ax_band.set_ylim(-0.5, 1.5)
 
-for cluster, colour in ((risk_on_cluster, COLORS["recede"]), (risk_off_cluster, COLORS["blue"])):
-    masked = np.where(labels_2 == cluster, rolling_vol.to_numpy() * 100, np.nan)
-    ax_vol.plot(positions, masked, color=colour, linewidth=1.2)
+plot_by_regime(ax_vol, rolling_vol.to_numpy() * 100, in_risk_on)
 for regime, colour in (("Risk-on", COLORS["copper"]), ("Risk-off", COLORS["amber"])):
     ax_vol.axhline(
         rolling_vol_by_regime.loc[regime, "Mean (%)"],
@@ -772,11 +790,14 @@ style.show_with_alt(
 annualized_by_regime.T.style.format("{:+.1f}")
 
 # %% [markdown]
-# The two long-short strategies named for safety, carry and defensive, are the ones that
-# stop paying when conditions deteriorate. That is the shape a reader should take away:
-# a strategy's average return over a full sample says nothing about whether it will be there
-# in the environment a portfolio needs it in, and the only way to find out is to condition
-# on the environment and look.
+# The two strategies a calm market reads as safe income - carry, which collects a yield
+# spread, and defensive, which is long low-risk assets - are the ones that stop paying when
+# conditions deteriorate. Value and bonds go the other way and earn more.
+#
+# A strategy's average return over a full sample therefore says nothing about whether it
+# will be there in the environment a portfolio needs it in. Finding out means conditioning
+# on the environment and looking, which is what makes a regime label worth estimating even
+# when nothing can act on it.
 
 # %% [markdown]
 # ## Regime statistics
@@ -882,11 +903,15 @@ display(
 )
 
 # %% [markdown]
-# Nobody lived through the first of those two numbers. It is the arithmetic of a stream that
-# keeps every month the market was falling and discards the ones in which it recovered, so it
-# accumulates the losses of a century of separate episodes into one uninterrupted decline.
-# The statistic is not wrong - it is the correct drawdown of the object it was computed on -
-# but the object is a construction of this notebook, and a reader who takes it for a crash
+# Nobody lived through the first of those two numbers. The risk-off months are selected by
+# the mixture's assignment, not by the sign of the equity return, so the stream holds gains
+# as well as losses - its average monthly return is positive. What it does not hold is the
+# months in between, and closing those gaps puts a loss from one decade immediately beside a
+# loss from the next, with none of the recovery that separated them. Compounded, decades of
+# separate episodes read as one uninterrupted decline.
+#
+# The statistic is not wrong; it is the correct drawdown of the object it was computed on.
+# But the object is a construction of this notebook, and a reader who takes it for a crash
 # has been misled by a table that never said which object it meant.
 #
 # That is the general form: a conditional statistic inherits the assumptions of the
@@ -944,7 +969,9 @@ display(
 # A model built to be acted on would be built differently. It would carry a transition
 # structure that makes staying in a regime more likely than leaving it - a hidden Markov
 # model is the standard choice - and it would be fitted forward in time so that each
-# month's label used only the months before it. Chapter 9 introduces both.
+# month's label used only the months before it. `09_model_based_features/11_hmm_regimes`
+# builds the first, and `09_model_based_features/13_regime_as_feature` turns the result into
+# a feature a model downstream can read.
 
 # %% [markdown]
 # ## Key takeaways

--- a/01_process_is_edge/factor_regimes.py
+++ b/01_process_is_edge/factor_regimes.py
@@ -57,7 +57,8 @@
 #
 # - Monthly return series and standardization (subtracting a mean, dividing by a standard
 #   deviation) so that series with different scales contribute comparably to a distance.
-# - The AQR Century of Factor Premia parquet under `data/aqr_factors/`. Download it with
+# - The AQR Century of Factor Premia dataset, which `AQRFactorProvider` reads from
+#   `data/factors/aqr` under `ML4T_DATA_PATH`. Fetch it with
 #   `uv run python data/factors/aqr_download.py` if it is missing.
 #
 # ## What this notebook establishes, and what it does not
@@ -594,17 +595,18 @@ def mark_events(ax: Axes, years: list[int]) -> None:
 
 # %%
 def plot_by_regime(ax: Axes, values: np.ndarray, in_risk_on: np.ndarray) -> None:
-    """Draw one line whose every segment takes the colour of the month it starts in.
+    """Draw one line whose every segment takes the colour of the month it ends in.
 
-    Colouring by masking each regime into its own line would drop the segment that spans a
-    transition, and would draw nothing at all for a one-month episode, which is most of
-    them here.
+    The segment from month t-1 to month t is the move month t produced, so month t's regime
+    is the one that colours it. Masking each regime into its own line instead would drop
+    every segment that spans a transition, and would draw nothing at all for a one-month
+    episode, which is most of them here.
     """
     y = np.asarray(values, dtype=float)
     points = np.column_stack([np.arange(len(y)), y]).reshape(-1, 1, 2)
     segments = np.concatenate([points[:-1], points[1:]], axis=1)
     drawable = np.isfinite(segments[:, :, 1]).all(axis=1)
-    colours = np.where(in_risk_on[:-1], COLORS["recede"], COLORS["blue"])
+    colours = np.where(in_risk_on[1:], COLORS["recede"], COLORS["blue"])
     ax.add_collection(LineCollection(segments[drawable], colors=colours[drawable], linewidths=1.2))
     finite = y[np.isfinite(y)]
     ax.set_xlim(0, len(y) - 1)

--- a/01_process_is_edge/factor_regimes.py
+++ b/01_process_is_edge/factor_regimes.py
@@ -14,111 +14,285 @@
 # ---
 
 # %% [markdown]
-# # Factor-Based Regime Detection
+# # Factor-based regime detection
 #
 # **Chapter 1 · §1.4 Market Regimes: Change Is the Constant**
 #
 # **Docker image**: `ml4t`
 #
-# ## Purpose
+# Markets do not behave the same way in every year. The same value strategy that earns a
+# steady premium through a long expansion can lose money for a decade, and the same
+# momentum strategy can give back years of gains in a single quarter. A **regime** is a
+# stretch of time over which the joint behaviour of returns is stable enough to be treated
+# as one environment: the averages, the volatilities and the correlations hold roughly
+# still inside it and shift when it ends.
 #
-# Demonstrates unsupervised learning for market regime detection using Gaussian Mixture Models (GMM)
-# on factor returns from the AQR Century of Factor Premia dataset.
+# Nobody publishes a regime label. This notebook estimates one from the data with a
+# **Gaussian mixture model** (GMM), which treats each month's vector of factor returns as
+# a draw from one of a small number of multivariate normal distributions and infers both
+# the distributions and which one each month most likely came from. The inputs are monthly
+# returns to nine factor strategies from AQR's Century of Factor Premia dataset, which
+# starts in 1927.
 #
-# ## Learning Objectives
+# ## Learning objectives
 #
-# - Apply GMM clustering to factor return time series.
-# - Evaluate cluster count with BIC, AIC, and silhouette scores.
-# - Visualize regime timelines with historical event annotations.
-# - Compare factor performance across regimes.
+# By the end of this notebook you will be able to:
 #
-# ## Book Reference
+# - Fit a Gaussian mixture model to a panel of monthly factor returns and read off the
+#   cluster it assigns to each month.
+# - Choose how many clusters to keep by comparing three criteria that measure different
+#   things, and say what each one rewards.
+# - Read a regime timeline against dated market events and judge whether the clusters
+#   correspond to periods a reader would recognise.
+# - Measure what each factor earned inside each cluster, and say what that implies about
+#   which factors diversify each other when conditions deteriorate.
+# - Explain why a label fitted on the whole sample cannot be used as a trading signal.
 #
-# Section 1.4 of Chapter 1, "Market Regimes: Change Is the Constant" — style-regime view that
-# precedes the macro-regime view in `macro_regimes.py`.
+# ## Book reference
+#
+# Chapter 1, Section 1.4, "Market Regimes: Change Is the Constant". `macro_regimes` is the
+# companion notebook and estimates regimes from macroeconomic indicators instead.
 #
 # ## Prerequisites
 #
-# - Familiarity with monthly return series and StandardScaler-style preprocessing.
-# - Conceptual exposure to mixture models and information criteria.
-# - AQR Century of Factor Premia parquet at `data/aqr_factors/` (download via
-#   `uv run python data/factors/aqr_download.py` if missing).
+# - Monthly return series and standardization (subtracting a mean, dividing by a standard
+#   deviation) so that series with different scales contribute comparably to a distance.
+# - The AQR Century of Factor Premia parquet under `data/aqr_factors/`. Download it with
+#   `uv run python data/factors/aqr_download.py` if it is missing.
 #
-# ## Background
+# ## What this notebook establishes, and what it does not
 #
-# Inspired by [Two Sigma's 2021 paper](https://www.twosigma.com/articles/a-machine-learning-approach-to-regime-modeling/)
-# which uses GMM on an 18-factor "Factor Lens" to identify four market regimes. We work with
-# AQR's longer history (1927+) over Value, Momentum, Carry, and Defensive across multiple asset
-# classes. There is no objectively "correct" number of regimes; we sweep 2–6 clusters to show
-# how granularity shapes the regime map.
-#
-# ### Scope: descriptive, not predictive
-#
-# This notebook fits the GMM and the StandardScaler on the **entire factor-return history**
-# and then assigns regime labels back over that same history. The result is an *ex-post*
-# characterization of how the factor space partitions, useful for narrative and for
-# visualizing where macro events fall within the partitioning. It is **not** a regime
-# classifier that can be used for prediction: using these labels as features in a trading
-# strategy would constitute look-ahead because the partition itself was estimated with
-# future data. Lookahead-safe label construction (walk-forward fitting, point-in-time
-# information sets, embargoed cross-validation) is introduced from Chapter 6 onward, and
-# the case-study chapters (Ch16-20) demonstrate how predictive regime features are
-# constructed and evaluated.
+# The model is fitted on the whole history and the labels are assigned back over that same
+# history. What comes out is a description of how the factor space partitions, and a way
+# of seeing where dated events fall inside that partition. Every month's label is informed
+# by every other month, including later ones, so the labels describe the sample rather than
+# forecast it. Building regime labels a strategy could have acted on requires walk-forward
+# fitting on information available at each date; Chapter 6 onward introduces that machinery
+# and the case-study chapters apply it.
 
 # %% [markdown]
-# ## Imports
+# ## Setup
+#
+# The AQR provider logs its download and cache decisions through `structlog`, which writes
+# to the notebook rather than through the standard library's logging module. Raising its
+# threshold to `WARNING` keeps the data-loading cells readable while leaving anything that
+# reports a problem visible.
 
 # %%
-"""Factor-Based Regime Detection — unsupervised regime detection using GMM on AQR factor returns."""
+"""Factor-based regime detection - Gaussian mixture regimes over AQR factor returns."""
 
 from __future__ import annotations
 
-import warnings
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
-
-warnings.filterwarnings("ignore")
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import polars as pl
+import structlog
+from IPython.display import Markdown, display
 from matplotlib.axes import Axes
 from matplotlib.colors import ListedColormap
 from ml4t.data.providers import AQRFactorProvider
+from ml4t.diagnostic.metrics import sharpe_ratio
 from sklearn.cluster import KMeans
 from sklearn.metrics import silhouette_score
 from sklearn.mixture import GaussianMixture
 from sklearn.preprocessing import StandardScaler
 
+import utils.style as style
 from utils.paths import get_output_dir
 from utils.reproducibility import set_global_seeds
 
+structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.WARNING))
+
+COLORS = style.COLORS
+
 # %% tags=["parameters"]
-# Production defaults (Papermill overrides for testing)
+# Production defaults (Papermill overrides these when the test suite runs the notebook)
 SEED = 42
 
 # %% [markdown]
-# ## Configuration
+# ### Settings, and what each one decides
+#
+# `SEED` fixes the initialization of every estimator below. A Gaussian mixture is fitted by
+# expectation-maximization from a random start, so two runs from different starts can land
+# on different local optima and swap which cluster is numbered 0; fixing the seed is what
+# makes the figures in this notebook reproduce.
+#
+# `N_REGIMES_GRID` is the set of cluster counts to fit and compare. Two is the smallest
+# number that partitions anything. Six is where the search stops: the point of the sweep is
+# to show how the criteria move as clusters are added, and by six they have already
+# separated.
+#
+# `MONTHS_PER_YEAR` annualizes monthly statistics. Multiply a mean monthly return by it and
+# a monthly standard deviation by its square root.
+#
+# `ROLLING_VOL_MONTHS` is the width of the moving window used to draw a volatility series.
+# Twelve months is short enough to move inside a regime and long enough that a single month
+# does not dominate the estimate.
 
 # %%
+N_REGIMES_GRID = [2, 3, 4, 5, 6]
+MONTHS_PER_YEAR = 12
+ROLLING_VOL_MONTHS = 12
+
 OUTPUT_DIR = get_output_dir(1, "factor_regimes")
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 set_global_seeds(SEED)
 
+# %% [markdown]
+# ## Load the factor panel
+#
+# The AQR Century of Factor Premia dataset holds monthly returns to long-short factor
+# strategies built inside several asset classes, plus the returns to holding each asset
+# class outright. The provider returns one row per month and one column per strategy.
+
+# %%
+aqr_raw = AQRFactorProvider().fetch("century_premia")
+
+date_range = aqr_raw.select(
+    pl.col("timestamp").min().alias("first"), pl.col("timestamp").max().alias("last")
+)
+print(f"AQR Century of Factor Premia: {aqr_raw.height} months, {aqr_raw.width - 1} series")
+print(f"Covering {date_range['first'][0]:%Y-%m} to {date_range['last'][0]:%Y-%m}")
 
 # %% [markdown]
-# ## Helper Functions
+# ### The nine series used here
 #
-# A small container for GMM fit diagnostics, and a grid-search function
-# that fits multiple cluster counts and reports BIC, AIC, and silhouette.
+# Four of them are cross-asset long-short strategies, applied across equity indices, bonds,
+# currencies and commodities at once:
+#
+# - **Value** buys what is cheap relative to a fundamental anchor and sells what is
+#   expensive.
+# - **Momentum** buys what has risen over the past year and sells what has fallen.
+# - **Carry** buys what pays a high yield and sells what pays a low one.
+# - **Defensive** buys low-risk assets and sells high-risk ones.
+#
+# Two apply the value and momentum definitions inside the US stock market alone. The last
+# three are the returns to simply holding each asset class - equity indices, fixed income,
+# commodities - rather than a long-short strategy, and they are what places a month in a
+# risk environment rather than a style environment.
+
+# %%
+FACTOR_COLUMNS = [
+    "All asset classes Value",
+    "All asset classes Momentum",
+    "All asset classes Carry",
+    "All asset classes Defensive",
+    "US Stock Selection Value",
+    "US Stock Selection Momentum",
+    "Equity indices Market",
+    "Fixed income Market",
+    "Commodities Market",
+]
+EQUITY_COLUMN = "Equity indices Market"
+
+# Short names for the figures and tables below; the full AQR column names do not fit on an
+# axis.
+SHORT_NAMES = {
+    "All asset classes Value": "Value",
+    "All asset classes Momentum": "Momentum",
+    "All asset classes Carry": "Carry",
+    "All asset classes Defensive": "Defensive",
+    "US Stock Selection Value": "US Value",
+    "US Stock Selection Momentum": "US Momentum",
+    "Equity indices Market": "Equity",
+    "Fixed income Market": "Bonds",
+    "Commodities Market": "Commodities",
+}
+
+# %% [markdown]
+# ### What is actually in the panel
+#
+# Clustering treats every month as a point in nine dimensions, so a month is usable only
+# when all nine series are quoted. The table below reports, for each series, the month it
+# starts, how many observations it has, and its mean and standard deviation over the raw
+# file. Read it before anything computed from the panel: it says which series shortens the
+# usable history and how far apart the series are in scale, which is why they are
+# standardized before the distance is taken.
+
+# %%
+coverage = pd.DataFrame(
+    [
+        {
+            "Series": SHORT_NAMES[column],
+            "First month": aqr_raw.filter(pl.col(column).is_not_null())["timestamp"].min(),
+            "Months quoted": aqr_raw.select(pl.col(column).is_not_null().sum()).item(),
+            "Mean (% / month)": aqr_raw.select(pl.col(column).mean()).item() * 100,
+            "Std (% / month)": aqr_raw.select(pl.col(column).std()).item() * 100,
+        }
+        for column in FACTOR_COLUMNS
+    ]
+).set_index("Series")
+coverage["First month"] = pd.to_datetime(coverage["First month"]).dt.strftime("%Y-%m")
+coverage.style.format({"Mean (% / month)": "{:.2f}", "Std (% / month)": "{:.2f}"})
+
+# %% [markdown]
+# ## Prepare the panel for clustering
+#
+# Months in which any of the nine series is unquoted are dropped rather than filled. A
+# forward fill would repeat the previous month's return, and repeating a return is not a
+# missing observation recovered - it is an invented one, and a mixture model would treat it
+# as evidence for a cluster.
+#
+# The nine series are then standardized to zero mean and unit variance. Without that step
+# the equity market series, whose monthly standard deviation is several times a long-short
+# strategy's, would dominate every distance and the clustering would be a partition of
+# equity returns alone.
+
+# %%
+factors_pl = aqr_raw.select(["timestamp", *FACTOR_COLUMNS]).sort("timestamp").drop_nulls()
+
+factors_df = factors_pl.select(FACTOR_COLUMNS).to_pandas()
+factors_df.index = pd.DatetimeIndex(factors_pl["timestamp"].to_pandas())
+
+factors_scaled = StandardScaler().fit_transform(factors_df)
+
+start_year = factors_df.index.min().year
+end_year = factors_df.index.max().year
+print(f"Complete months: {len(factors_df)} ({start_year} to {end_year})")
+
+# %% [markdown]
+# ## Fit a grid of mixture models
+#
+# There is no test that returns the true number of regimes, so the count is a modelling
+# choice made by comparing candidates. The helper below fits one mixture per candidate
+# count and records three quantities for each.
+#
+# **BIC**, the Bayesian information criterion, is the fitted log-likelihood penalised by the
+# number of free parameters times the log of the sample size. **AIC**, the Akaike
+# information criterion, applies the same idea with a constant penalty of two per parameter.
+# Both are better when lower, and BIC's penalty grows with the sample, so on a long panel it
+# is far more reluctant than AIC to buy an extra cluster. A full-covariance mixture spends
+# parameters quickly - each additional cluster costs a mean vector and a covariance matrix
+# over nine dimensions - which is what the two criteria are pricing differently.
+#
+# The **silhouette score** measures something else entirely. For each month it compares the
+# average distance to the other months in its own cluster against the average distance to
+# the months of the nearest other cluster, and reports the normalized difference; the score
+# is the average over months. It runs from -1 to 1, it is better when higher, and a negative
+# value means the typical month sits closer to a different cluster than to its own. It is a
+# geometric statement about separation and knows nothing about likelihood.
+#
+# K-means is fitted alongside for the same counts. It partitions on distance to a centroid
+# with no covariance and no probabilities, so putting its silhouette beside the mixture's
+# says how much of the separation is coming from the shape the mixture is allowed to fit.
+#
+# The last two columns count things none of the three criteria look at: how often consecutive
+# months carry different labels, and how many months the emptiest cluster holds. A criterion
+# can only say how well a partition fits. Whether the partition holds still long enough to be
+# called a regime, and whether every cluster in it has enough months to say anything about,
+# are separate questions, and these two counts are the cheapest way to ask them.
 
 
 # %%
 @dataclass(frozen=True)
 class GmmFitResult:
-    """Results from fitting a Gaussian Mixture Model."""
+    """One fitted mixture and the three quantities used to compare it against the others."""
 
     model: GaussianMixture
     labels: np.ndarray
@@ -128,23 +302,13 @@ class GmmFitResult:
     silhouette: float
 
 
-# %% [markdown]
-# ### Grid Search for Optimal Cluster Count
-# Fit GMM across multiple cluster counts and evaluate with BIC, AIC, and silhouette.
-
-
 # %%
 def fit_gmm_grid(
     x: np.ndarray,
     n_components_list: Iterable[int],
     random_state: int = SEED,
 ) -> dict[int, GmmFitResult]:
-    """
-    Fit a grid of GaussianMixture models and report diagnostics.
-
-    BIC and AIC are more appropriate for mixture models than silhouette,
-    but silhouette can still be helpful as a coarse separation check.
-    """
+    """Fit one full-covariance mixture per requested cluster count."""
     results: dict[int, GmmFitResult] = {}
     for n in n_components_list:
         model = GaussianMixture(
@@ -156,593 +320,382 @@ def fit_gmm_grid(
         )
         model.fit(x)
         labels = model.predict(x)
-        probs = model.predict_proba(x)
-        bic = float(model.bic(x))
-        aic = float(model.aic(x))
-        sil = float(silhouette_score(x, labels)) if n >= 2 else float("nan")
         results[n] = GmmFitResult(
             model=model,
             labels=labels,
-            probabilities=probs,
-            bic=bic,
-            aic=aic,
-            silhouette=sil,
+            probabilities=model.predict_proba(x),
+            bic=float(model.bic(x)),
+            aic=float(model.aic(x)),
+            silhouette=float(silhouette_score(x, labels)),
         )
     return results
 
 
-# %% [markdown]
-# ## Load Factor Data
-
 # %%
-aqr_raw_pl = AQRFactorProvider().fetch("century_premia")
+gmm_grid = fit_gmm_grid(factors_scaled, N_REGIMES_GRID)
 
-print(f"AQR Century of Factor Premia: {aqr_raw_pl.height} months, {aqr_raw_pl.width - 1} factors")
-date_range = aqr_raw_pl.select(
-    pl.col("timestamp").min().alias("min"), pl.col("timestamp").max().alias("max")
-)
-print(f"Date range: {date_range['min'][0]} to {date_range['max'][0]}")
+kmeans_labels = {
+    n: KMeans(n_clusters=n, random_state=SEED, n_init=10).fit_predict(factors_scaled)
+    for n in N_REGIMES_GRID
+}
 
-# %% [markdown]
-# ## Understanding the Data
-#
-# The AQR "Century of Factor Premia" dataset contains monthly returns for various factor
-# strategies across asset classes. Key columns we use:
-#
-# | Factor | Description |
-# |--------|-------------|
-# | **Equity indices Market** | Global developed equity market return (value-weighted) |
-# | **All asset classes Value** | Cross-asset value factor (long cheap, short expensive) |
-# | **All asset classes Momentum** | Cross-asset momentum (long top-quantile past returns, short bottom-quantile) |
-# | **All asset classes Carry** | Cross-asset carry (long high yield, short low yield) |
-# | **All asset classes Defensive** | Cross-asset low-risk anomaly |
-#
-# The "Equity indices Market" is what you'd earn investing in a global equity index -
-# essentially the aggregate return from holding developed market stocks.
 
-# %% [markdown]
-# ## Select Factors
+def switch_count(labels: np.ndarray) -> int:
+    """How many times consecutive months carry different labels."""
+    return int(np.sum(np.diff(labels) != 0))
 
-# %%
-factor_cols = [
-    "All asset classes Value",
-    "All asset classes Momentum",
-    "All asset classes Carry",
-    "All asset classes Defensive",
-    "US Stock Selection Value",
-    "US Stock Selection Momentum",
-    "Equity indices Market",
-    "Fixed income Market",
-    "Commodities Market",
-]
 
-available_cols = [c for c in factor_cols if c in aqr_raw_pl.columns]
-print(f"Selected {len(available_cols)} factors for regime detection:")
-for col in available_cols:
-    na_count = aqr_raw_pl.select(pl.col(col).is_null().sum()).item()
-    na_pct = na_count / aqr_raw_pl.height * 100
-    print(f"  {col}: {na_pct:.1f}% missing")
-
-# %% [markdown]
-# ## Prepare Data for Clustering
-
-# %%
-factors_pl = (
-    aqr_raw_pl.select(["timestamp"] + available_cols)
-    .sort("timestamp")
-    .fill_null(strategy="forward")
-    .drop_nulls()
-)
-
-factors_df = factors_pl.select(available_cols).to_pandas()
-factors_df.index = factors_pl["timestamp"].to_pandas()
-
-scaler = StandardScaler()
-factors_scaled = scaler.fit_transform(factors_df)
-
-print(
-    f"Factor data: {len(factors_df)} months ({factors_df.index.min().year} to {factors_df.index.max().year})"
-)
-
-# %% [markdown]
-# ## Regime Detection with GMM
-
-# %%
-n_regimes_list = [2, 3, 4, 5, 6]
-
-# Fit GMM grid
-gmm_grid = fit_gmm_grid(factors_scaled, n_regimes_list)
-
-# Also fit K-Means for comparison
-kmeans_results = {}
-for n in n_regimes_list:
-    kmeans = KMeans(n_clusters=n, random_state=SEED, n_init=10)
-    labels = kmeans.fit_predict(factors_scaled)
-    kmeans_results[n] = (kmeans, labels)
-
-# Report model selection criteria as a DataFrame (lower BIC/AIC is better; higher silhouette is better).
-selection_df = pd.DataFrame(
+selection = pd.DataFrame(
     {
-        "n": n_regimes_list,
-        "BIC": [gmm_grid[n].bic for n in n_regimes_list],
-        "AIC": [gmm_grid[n].aic for n in n_regimes_list],
-        "Silhouette (GMM)": [gmm_grid[n].silhouette for n in n_regimes_list],
-        "Silhouette (K-Means)": [
-            silhouette_score(factors_scaled, kmeans_results[n][1]) for n in n_regimes_list
+        "Clusters": N_REGIMES_GRID,
+        "BIC": [gmm_grid[n].bic for n in N_REGIMES_GRID],
+        "AIC": [gmm_grid[n].aic for n in N_REGIMES_GRID],
+        "Silhouette (mixture)": [gmm_grid[n].silhouette for n in N_REGIMES_GRID],
+        "Silhouette (k-means)": [
+            silhouette_score(factors_scaled, kmeans_labels[n]) for n in N_REGIMES_GRID
+        ],
+        "Switches": [switch_count(gmm_grid[n].labels) for n in N_REGIMES_GRID],
+        "Smallest cluster (months)": [
+            int(np.bincount(gmm_grid[n].labels).min()) for n in N_REGIMES_GRID
         ],
     }
-).set_index("n")
-selection_df.style.format(
+).set_index("Clusters")
+selection.style.format(
     {
-        "BIC": "{:.1f}",
-        "AIC": "{:.1f}",
-        "Silhouette (GMM)": "{:.3f}",
-        "Silhouette (K-Means)": "{:.3f}",
+        "BIC": "{:,.0f}",
+        "AIC": "{:,.0f}",
+        "Silhouette (mixture)": "{:.3f}",
+        "Silhouette (k-means)": "{:.3f}",
     }
 )
 
 # %% [markdown]
-# **Interpretation**: BIC is minimised at K=2 (26,170) and silhouette is maximised
-# at K=2 (0.27); AIC keeps falling out to K=6 (24,930). BIC penalises model complexity
-# more heavily than AIC, making it the standard choice when the goal is interpretability
-# rather than maximum likelihood. We proceed with K=2 — a Risk-On / Risk-Off split that
-# both BIC and silhouette select on this 1927-2024 panel.
+# ### Reading the three criteria against each other
 #
-# The silhouette scores turn negative for K≥4 (−0.02 at K=4, near-zero for K=5 and K=6),
-# indicating that higher cluster counts produce overlapping, poorly separated regimes.
+# The bars below carry the same three columns. Both information criteria are drawn on a
+# zoomed vertical axis, because the differences between candidate models are small relative
+# to their level and would be invisible on a scale that started at zero; the silhouette
+# panel is drawn on its natural scale, which includes zero.
 
-# %% [markdown]
-# ## Model Selection Visualization
-#
-# The charts below show BIC, AIC, and silhouette scores for different cluster counts.
-# Note the y-axis is scaled to highlight differences between models.
 
 # %%
-metrics = {
-    "BIC": [gmm_grid[n].bic for n in n_regimes_list],
-    "AIC": [gmm_grid[n].aic for n in n_regimes_list],
-    "Silhouette": [gmm_grid[n].silhouette for n in n_regimes_list],
-}
+def plot_selection_criterion(ax: Axes, values: list[float], label: str, best: str) -> None:
+    """Draw one criterion as bars, highlighting the count it favours."""
+    bars = ax.bar(N_REGIMES_GRID, values, color=COLORS["recede"])
+    chosen = int(np.argmin(values)) if best == "min" else int(np.argmax(values))
+    bars[chosen].set_color(COLORS["amber"])
+    ax.set_xlabel("Clusters")
+    ax.set_ylabel(label)
+    ax.set_xticks(N_REGIMES_GRID)
+
 
 # %%
-fig, axes = plt.subplots(1, 3, figsize=(14, 4))
+fig, axes = plt.subplots(1, 3, figsize=style.FIGSIZE["triple_h_tall"])
 
-# BIC (lower is better) - zoomed y-axis
-ax = axes[0]
-bars = ax.bar(n_regimes_list, metrics["BIC"], color="steelblue", edgecolor="black")
-best_idx = np.argmin(metrics["BIC"])
-bars[best_idx].set_color("#D4A84B")
-ax.set_xlabel("Number of Clusters", fontsize=11)
-ax.set_ylabel("BIC (lower is better)", fontsize=11)
-ax.set_title("Bayesian Information Criterion", fontsize=12)
-ax.set_xticks(n_regimes_list)
-# Zoom y-axis to show differences more clearly
-bic_min, bic_max = min(metrics["BIC"]), max(metrics["BIC"])
-bic_range = bic_max - bic_min
-ax.set_ylim(bic_min - 0.1 * bic_range, bic_max + 0.1 * bic_range)
-
-# AIC (lower is better) - zoomed y-axis
-ax = axes[1]
-bars = ax.bar(n_regimes_list, metrics["AIC"], color="steelblue", edgecolor="black")
-best_idx = np.argmin(metrics["AIC"])
-bars[best_idx].set_color("#D4A84B")
-ax.set_xlabel("Number of Clusters", fontsize=11)
-ax.set_ylabel("AIC (lower is better)", fontsize=11)
-ax.set_title("Akaike Information Criterion", fontsize=12)
-ax.set_xticks(n_regimes_list)
-# Zoom y-axis to show differences more clearly
-aic_min, aic_max = min(metrics["AIC"]), max(metrics["AIC"])
-aic_range = aic_max - aic_min
-ax.set_ylim(aic_min - 0.1 * aic_range, aic_max + 0.1 * aic_range)
-
-# Silhouette (higher is better)
-ax = axes[2]
-bars = ax.bar(n_regimes_list, metrics["Silhouette"], color="steelblue", edgecolor="black")
-best_idx = np.argmax(metrics["Silhouette"])
-bars[best_idx].set_color("#D4A84B")
-ax.set_xlabel("Number of Clusters", fontsize=11)
-ax.set_ylabel("Silhouette (higher is better)", fontsize=11)
-ax.set_title("Silhouette Score", fontsize=12)
-ax.set_xticks(n_regimes_list)
-
-fig.suptitle(
-    "GMM Model Selection: BIC and Silhouette Agree on K=2; AIC Prefers K=6",
-    fontsize=14,
-    y=1.02,
+plot_selection_criterion(axes[0], selection["BIC"].tolist(), "BIC (lower is better)", "min")
+plot_selection_criterion(axes[1], selection["AIC"].tolist(), "AIC (lower is better)", "min")
+plot_selection_criterion(
+    axes[2], selection["Silhouette (mixture)"].tolist(), "Silhouette (higher is better)", "max"
 )
-plt.show()
+for ax, values in ((axes[0], selection["BIC"]), (axes[1], selection["AIC"])):
+    span = values.max() - values.min()
+    ax.set_ylim(values.min() - 0.15 * span, values.max() + 0.15 * span)
 
+style.add_message_title(
+    axes[0],
+    "BIC, AIC and silhouette do not pick the same number of regimes",
+    subtitle="Highlighted bar is the count each criterion favours; note the zoomed axes on BIC and AIC",
+)
+style.show_with_alt(
+    fig,
+    "Three bar charts over cluster counts two to six. BIC rises with the count, AIC falls "
+    "with it, and the silhouette score falls sharply after the smallest count and hovers "
+    "near zero at the larger ones.",
+)
+
+# %%
+bic_choice = int(selection["BIC"].idxmin())
+aic_choice = int(selection["AIC"].idxmin())
+silhouette_choice = int(selection["Silhouette (mixture)"].idxmax())
+display(
+    Markdown(
+        f"BIC is lowest at **{bic_choice} clusters** and the silhouette score is highest at "
+        f"**{silhouette_choice}**, while AIC keeps falling out to **{aic_choice}**, the "
+        "largest count fitted."
+    )
+)
 
 # %% [markdown]
-# ## Regime Timeline Visualization
+# When the criteria disagree, the choice is made on what the model is for. AIC targets
+# predictive likelihood and keeps buying clusters as long as they raise it, and the last two
+# columns say what it is buying at the larger counts: a partition that changes label more
+# often, containing at least one cluster with too few months to describe. A sliver of the
+# sample with its own covariance improves the fit and is not a regime anyone can name.
+#
+# BIC's sample-scaled penalty and the silhouette's separation test both ask for clusters
+# distinct enough to survive being described, which is what a regime has to be if it is going
+# to appear in a risk report. The rest of this notebook works with the two-cluster model on
+# that basis, and the timelines in the next section show what the larger counts do with the
+# clusters they add.
+
 # %%
-def plot_regime_timeline(
-    labels: np.ndarray,
-    dates: pd.Index,
-    n_regimes: int,
-    title: str,
-    ax: Axes | None = None,
-) -> Axes:
-    """Plot regime assignments as a timeline heatmap (one row per regime)."""
-    if ax is None:
-        fig, ax = plt.subplots(figsize=(16, 0.8 * n_regimes + 1))
+N_REGIMES_SELECTED = 2
 
-    years = [pd.Timestamp(ts).year for ts in dates]
+# %% [markdown]
+# ## What each cluster count partitions
+#
+# Each band below is one fitted model. A month is shaded in the row of the cluster it was
+# assigned to, so a solid horizontal stretch is a period the model held in one regime and a
+# speckled stretch is one it switched through repeatedly. Comparing the bands shows what the
+# extra clusters buy: whether an added cluster carves out a recognisable era, or whether it
+# scatters across the whole century.
 
-    # Create binary matrix: (n_regimes x n_months)
-    regime_matrix = np.zeros((n_regimes, len(labels)))
-    for i, label in enumerate(labels):
-        regime_matrix[label, i] = 1
 
-    # Plot each regime as a swim lane. origin='lower' so data row k anchors
-    # at y=k (matching the "Regime k+1" yticklabel below).
+# %%
+def decade_ticks(dates: pd.DatetimeIndex) -> tuple[list[int], list[str]]:
+    """Positions and labels for the first month of each decade in a monthly index."""
+    years = dates.year.tolist()
+    ticks = [
+        j for j, year in enumerate(years) if year % 10 == 0 and (j == 0 or years[j - 1] != year)
+    ]
+    return ticks, [str(years[j]) for j in ticks]
+
+
+# %%
+def draw_swimlanes(ax: Axes, rows: np.ndarray, n_rows: int, cmap: ListedColormap) -> None:
+    """Shade each month in the row given by *rows*, one row per regime."""
+    matrix = np.zeros((n_rows, len(rows)))
+    matrix[rows, np.arange(len(rows))] = 1
     ax.imshow(
-        regime_matrix,
+        matrix,
         aspect="auto",
-        cmap="Blues",
+        cmap=cmap,
         vmin=0,
         vmax=1,
-        extent=(0, len(labels), -0.5, n_regimes - 0.5),
+        extent=(0, len(rows), -0.5, n_rows - 0.5),
         interpolation="nearest",
         origin="lower",
     )
-
-    # Y-axis: regime labels
-    ax.set_yticks(range(n_regimes))
-    ax.set_yticklabels([f"Regime {i + 1}" for i in range(n_regimes)], fontsize=10)
-
-    # X-axis: decade markers
-    year_ticks = []
-    year_labels_list = []
-    for j, year in enumerate(years):
-        if j == 0 or years[j - 1] != year:
-            if year % 10 == 0:
-                year_ticks.append(j)
-                year_labels_list.append(str(year))
-
-    ax.set_xticks(year_ticks)
-    ax.set_xticklabels(year_labels_list, fontsize=9)
-    ax.set_xlabel("Year", fontsize=11)
-    ax.set_title(title, fontsize=12)
-
-    # Add horizontal grid lines between regimes
-    for i in range(1, n_regimes):
-        ax.axhline(y=i - 0.5, color="white", linewidth=2)
-
-    return ax
+    for boundary in range(1, n_rows):
+        ax.axhline(y=boundary - 0.5, color=COLORS["bg_light"], linewidth=1.5)
 
 
 # %%
-# Create swim lane figures for each cluster count
-start_year = factors_df.index.min().year
-end_year = factors_df.index.max().year
+lane_cmap = ListedColormap([COLORS["bg_light"], COLORS["blue"]])
+ticks, tick_labels = decade_ticks(factors_df.index)
 
-for n in n_regimes_list:
-    fig, ax = plt.subplots(figsize=(16, 0.8 * n + 1.5))
-    labels = gmm_grid[n].labels
+fig, axes = plt.subplots(
+    len(N_REGIMES_GRID),
+    1,
+    figsize=(style.PAGE_WIDTH, 1.0 * len(N_REGIMES_GRID) + 1.0),
+    sharex=True,
+)
+for ax, n in zip(axes, N_REGIMES_GRID):
+    draw_swimlanes(ax, gmm_grid[n].labels, n, lane_cmap)
+    ax.set_yticks([])
+    ax.set_ylabel(f"K = {n}", rotation=0, ha="right", va="center")
 
-    plot_regime_timeline(
-        labels=labels,
-        dates=factors_df.index,
-        n_regimes=n,
-        title=f"GMM Factor Regimes (n={n}) - {start_year} to {end_year}",
-        ax=ax,
-    )
-
-    # Add metrics annotation
-    bic = gmm_grid[n].bic
-    aic = gmm_grid[n].aic
-    sil = gmm_grid[n].silhouette
-    ax.text(
-        0.02,
-        0.98,
-        f"BIC: {bic:.0f}  |  AIC: {aic:.0f}  |  Silhouette: {sil:.3f}",
-        transform=ax.transAxes,
-        fontsize=9,
-        verticalalignment="top",
-        bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
-    )
-
-    plt.show()
+axes[-1].set_xticks(ticks)
+axes[-1].set_xticklabels(tick_labels)
+axes[-1].set_xlabel("Year")
+style.add_message_title(
+    axes[0],
+    "Adding clusters makes the timeline switch more often, not cleaner",
+    subtitle="One panel per fitted model; a month is shaded in the row of the cluster it was assigned",
+)
+style.show_with_alt(
+    fig,
+    "Five stacked panels, one per cluster count. The two-cluster panel shows one row "
+    "occupied most of the time and the other taking short scattered stretches. Each panel "
+    "below it is more finely speckled than the one above, with no row holding a long "
+    "uninterrupted stretch by the largest count.",
+)
 
 # %% [markdown]
-# ## Two-Regime View: Risk-On vs Risk-Off
+# No band settles down as clusters are added. An added cluster does not carve out an era the
+# earlier models had merged; it takes months from across the whole century, so each panel is
+# more finely speckled than the one above it. A mixture has no notion of time and nothing in
+# it prefers a month to keep its neighbour's label, so there is no mechanism by which more
+# clusters could produce longer stretches. That absence is the reason the last section of
+# this notebook points at a hidden Markov model, which supplies exactly the mechanism this
+# one lacks.
+
+# %% [markdown]
+# ## The two-cluster model: risk-on and risk-off
 #
-# The two-regime split separates periods of broad factor outperformance from
-# periods of broad underperformance. It is the model that BIC and silhouette
-# select above; the analysis below characterises the two regimes empirically.
+# The mixture returns cluster numbers, not names, and the numbering carries no meaning - a
+# different seed can swap it. To describe the two clusters they have to be identified by
+# something outside the model, and the natural choice is the series that says what the
+# market as a whole was doing: the average return to holding equity indices inside each
+# cluster. **Risk-on** and **risk-off** are the market's ordinary terms for the environments
+# that result, meaning periods when investors were adding exposure to risky assets and
+# periods when they were shedding it.
+#
+# Naming the clusters this way uses the whole sample, exactly as fitting them did. It is a
+# description of what the partition turned out to be, not a rule that could have been
+# applied in 1929.
 
 # %%
-# Historical events for annotation
-historical_events = {
+labels_2 = gmm_grid[N_REGIMES_SELECTED].labels
+equity_returns = factors_df[EQUITY_COLUMN]
+
+mean_equity_by_cluster = equity_returns.groupby(labels_2).mean()
+risk_on_cluster = int(mean_equity_by_cluster.idxmax())
+risk_off_cluster = int(mean_equity_by_cluster.idxmin())
+
+regime_name = pd.Series(
+    np.where(labels_2 == risk_on_cluster, "Risk-on", "Risk-off"),
+    index=factors_df.index,
+    name="regime",
+)
+
+# %% [markdown]
+# ### The timeline against dated events
+#
+# The upper panel is the same swim-lane band as above, restricted to the two-cluster model,
+# with seven dated episodes marked. The lower panel is the cumulative product of the equity
+# index returns on a logarithmic scale, drawn in the colour of the regime each month was
+# assigned to. A logarithmic scale is what makes the 1930s comparable to the 2010s: equal
+# vertical distances are equal percentage moves, so a fall of a given percentage takes up the
+# same space on the axis wherever in the century it happens.
+
+# %%
+HISTORICAL_EVENTS = {
     1929: ("Great Crash", "top"),
     1937: ("Recession", "bottom"),
-    1973: ("Oil Crisis", "top"),
+    1973: ("Oil crisis", "top"),
     1987: ("Black Monday", "bottom"),
-    2000: ("Dot-com", "top"),
-    2008: ("GFC", "bottom"),
-    2020: ("COVID", "top"),
+    2000: ("Dot-com peak", "top"),
+    2008: ("Global financial crisis", "bottom"),
+    2020: ("COVID-19", "top"),
 }
 
-# Use n=2 for cleaner, more stable regime identification
-n_regimes_book = 2
-labels_2 = gmm_grid[n_regimes_book].labels
-
-# Ex-post labeling for interpretability (NOT predictive)
-regime_equity_returns = factors_df["Equity indices Market"].groupby(labels_2).mean()
-good_regime = regime_equity_returns.idxmax()
-bad_regime = 1 - good_regime
-
-
-# %% [markdown]
-# ### Risk-On vs Risk-Off Regime Timeline
-# Swim lane panel showing regime assignment alongside cumulative equity returns.
-
 
 # %%
-def plot_two_regime_view():
-    """Create swim lane + cumulative return figure for the two-regime model."""
-    # Create figure with swim lane panel + cumulative returns
-    fig, axes = plt.subplots(2, 1, figsize=(14, 5.5), height_ratios=[1, 2], sharex=True)
-
-    # Panel 1: Regime swim lanes
-    ax1 = axes[0]
-
-    # Create binary matrix: row 0 = Risk-Off, row 1 = Risk-On
-    regime_matrix = np.zeros((2, len(labels_2)))
-    for i, label in enumerate(labels_2):
-        if label == good_regime:
-            regime_matrix[1, i] = 1  # Risk-On row
-        else:
-            regime_matrix[0, i] = 1  # Risk-Off row
-
-    # Use grayscale-friendly colors for swim lanes. origin='lower' so data
-    # row 0 (Risk-Off) anchors at the bottom of the axis and row 1 (Risk-On)
-    # at the top, matching the yticklabels below.
-    cmap_swim = ListedColormap(["white", "#2d2d2d"])
-    ax1.imshow(
-        regime_matrix,
-        aspect="auto",
-        cmap=cmap_swim,
-        vmin=0,
-        vmax=1,
-        extent=[0, len(labels_2), -0.5, 1.5],
-        interpolation="nearest",
-        origin="lower",
-    )
-
-    # Y-axis: regime labels
-    ax1.set_yticks([0, 1])
-    ax1.set_yticklabels(["Risk-Off", "Risk-On"], fontsize=10)
-    ax1.axhline(y=0.5, color="gray", linewidth=1.5)
-
-    # X-axis setup
-    years = [pd.Timestamp(ts).year for ts in factors_df.index]
-    decade_ticks = []
-    decade_labels = []
-    for j, year in enumerate(years):
-        if j == 0 or years[j - 1] != year:
-            if year % 10 == 0:
-                decade_ticks.append(j)
-                decade_labels.append(str(year))
-
-    # Add historical event markers (BLACK labels, not red)
-    for event_year, (event_label, pos) in historical_events.items():
-        try:
-            idx = next(j for j, y in enumerate(years) if y == event_year)
-            ax1.axvline(x=idx, color="black", linestyle="-", alpha=0.6, linewidth=1.5)
-            y_pos = 1.7 if pos == "top" else -0.7
-            va = "bottom" if pos == "top" else "top"
-            ax1.annotate(
-                event_label,
-                xy=(idx, y_pos),
-                xycoords=("data", "data"),
-                ha="center",
-                va=va,
-                fontsize=8,
-                color="black",
-                fontweight="bold",
-            )
-        except StopIteration:
-            pass
-
-    ax1.set_xlim(0, len(labels_2))
-    ax1.set_ylim(-0.5, 1.5)
-
-    # Panel 2: Cumulative equity returns colored by regime
-    ax2 = axes[1]
-    equity_returns = factors_df["Equity indices Market"]
-    cum_returns = (1 + equity_returns).cumprod()
-
-    # Plot with regime coloring
-    for i in range(len(cum_returns) - 1):
-        color = "#d0d0d0" if labels_2[i] == good_regime else "#2d2d2d"
-        ax2.plot(
-            [i, i + 1], [cum_returns.iloc[i], cum_returns.iloc[i + 1]], color=color, linewidth=1.2
+def mark_events(ax: Axes, years: list[int]) -> None:
+    """Draw a rule and a label at the first month of each dated episode."""
+    for event_year, (event_label, side) in HISTORICAL_EVENTS.items():
+        position = next((j for j, year in enumerate(years) if year == event_year), None)
+        if position is None:
+            continue
+        ax.axvline(x=position, color=COLORS["neutral"], alpha=0.6, linewidth=1.0)
+        ax.annotate(
+            event_label,
+            xy=(position, 1.7 if side == "top" else -0.7),
+            ha="center",
+            va="bottom" if side == "top" else "top",
+            fontsize=7,
+            color=COLORS["neutral"],
         )
 
-    ax2.set_yscale("log")
-    ax2.set_ylabel("Cumulative Return (log scale)", fontsize=10)
-    ax2.set_xlabel("Year", fontsize=10)
-    ax2.set_xticks(decade_ticks)
-    ax2.set_xticklabels(decade_labels, fontsize=9)
-    ax2.grid(True, alpha=0.3)
-
-    # Annotations
-    ax2.annotate(
-        f"${cum_returns.iloc[-1]:.0f}",
-        xy=(len(cum_returns) - 1, cum_returns.iloc[-1]),
-        xytext=(10, 0),
-        textcoords="offset points",
-        fontsize=10,
-        fontweight="bold",
-    )
-    ax2.annotate(
-        "$1 invested in 1927",
-        xy=(0, 1),
-        xytext=(10, 10),
-        textcoords="offset points",
-        fontsize=9,
-        style="italic",
-    )
-
-    fig.suptitle(
-        f"Market Regimes: Risk-On vs Risk-Off ({start_year}-{end_year})",
-        fontsize=12,
-        fontweight="bold",
-        y=1.02,
-    )
-
-    plt.show()
-
-
-plot_two_regime_view()
-# %% [markdown]
-# ## Volatility by Regime
-#
-# A key question: does volatility differ meaningfully between regimes?
-# If Risk-Off periods have higher volatility, this validates using regime
-# detection for risk management.
 
 # %%
-# Calculate rolling volatility (12-month window, annualized)
-equity_returns = factors_df["Equity indices Market"]
-rolling_vol = equity_returns.rolling(12).std() * np.sqrt(12)
+fig, (ax_band, ax_equity) = plt.subplots(
+    2, 1, figsize=style.FIGSIZE["dual_v"], height_ratios=[1, 2], sharex=True
+)
 
-# Create regime indicator series
-regime_indicator = pd.Series(labels_2, index=factors_df.index)
+rows = np.where(labels_2 == risk_on_cluster, 1, 0)
+draw_swimlanes(ax_band, rows, 2, lane_cmap)
+ax_band.set_yticks([0, 1])
+ax_band.set_yticklabels(["Risk-off", "Risk-on"])
+ax_band.set_ylim(-0.5, 1.5)
+mark_events(ax_band, factors_df.index.year.tolist())
 
-# Calculate volatility statistics by regime
-vol_by_regime = []
-for regime, name in [(good_regime, "Risk-On"), (bad_regime, "Risk-Off")]:
-    mask = regime_indicator == regime
-    vol_in_regime = rolling_vol[mask].dropna()
-    vol_by_regime.append(
-        {
-            "Regime": name,
-            "Mean Vol": vol_in_regime.mean(),
-            "Median Vol": vol_in_regime.median(),
-            "Max Vol": vol_in_regime.max(),
-        }
-    )
+cumulative = (1 + equity_returns).cumprod()
+positions = np.arange(len(cumulative))
+for cluster, colour in ((risk_on_cluster, COLORS["recede"]), (risk_off_cluster, COLORS["blue"])):
+    masked = np.where(labels_2 == cluster, cumulative.to_numpy(), np.nan)
+    ax_equity.plot(positions, masked, color=colour, linewidth=1.2)
+ax_equity.set_yscale("log")
+ax_equity.set_ylabel("Growth of 1 unit invested (log scale)")
+ax_equity.set_xlabel("Year")
+ax_equity.set_xticks(ticks)
+ax_equity.set_xticklabels(tick_labels)
+ax_equity.grid(True, alpha=0.3)
 
-vol_df = pd.DataFrame(vol_by_regime).set_index("Regime")
-
+style.add_message_title(
+    ax_band,
+    "Risk-off months come in short bursts, not in long bear markets",
+    subtitle="Upper: assigned regime. Lower: cumulative equity index return, coloured by regime",
+)
+style.show_with_alt(
+    fig,
+    "A two-row regime band above a rising cumulative return curve on a log scale. The "
+    "risk-off row is occupied in many short bursts spread across the whole century rather "
+    "than in a few long blocks, and the curve is drawn dark through those same stretches.",
+)
 
 # %% [markdown]
-# ### Volatility Regime Chart
-# Regime bands with rolling volatility, showing how risk environments differ.
-
+# ## Volatility inside each regime
+#
+# A regime label is only worth carrying if it corresponds to something a risk manager would
+# act on, and the first thing to check is whether the two environments differ in how much
+# the market moves. The series below is the standard deviation of the equity index return
+# over a trailing twelve-month window, annualized by multiplying by the square root of
+# twelve, drawn in the colour of the regime assigned to each month. The dashed rules are the
+# average of that rolling series within each regime.
 
 # %%
-def plot_volatility_by_regime():
-    """Plot regime bands and rolling volatility with comparison statistics."""
-    # Create figure with regime bands panel + volatility
-    fig, axes = plt.subplots(2, 1, figsize=(14, 5), height_ratios=[1, 3], sharex=True)
+rolling_vol = equity_returns.rolling(ROLLING_VOL_MONTHS).std() * np.sqrt(MONTHS_PER_YEAR)
 
-    # Panel 1: Regime bands (same as the cumulative returns chart)
-    ax1 = axes[0]
-    regime_matrix = np.zeros((2, len(labels_2)))
-    for i, label in enumerate(labels_2):
-        if label == good_regime:
-            regime_matrix[1, i] = 1  # Risk-On row
-        else:
-            regime_matrix[0, i] = 1  # Risk-Off row
+rolling_vol_by_regime = (
+    rolling_vol.groupby(regime_name)
+    .agg(["mean", "median", "max"])
+    .rename(columns={"mean": "Mean (%)", "median": "Median (%)", "max": "Max (%)"})
+    .mul(100)
+    .loc[["Risk-on", "Risk-off"]]
+)
+rolling_vol_by_regime.index.name = "Regime"
+rolling_vol_by_regime.style.format("{:.1f}")
 
-    cmap_regime = ListedColormap(["white", "#2d2d2d"])
-    ax1.imshow(
-        regime_matrix,
-        aspect="auto",
-        cmap=cmap_regime,
-        vmin=0,
-        vmax=1,
-        extent=[0, len(labels_2), -0.5, 1.5],
-        interpolation="nearest",
-        origin="lower",
-    )
-    ax1.set_yticks([0, 1])
-    ax1.set_yticklabels(["Risk-Off", "Risk-On"], fontsize=9)
-    ax1.axhline(y=0.5, color="gray", linewidth=1)
-    ax1.set_title("Regime Classification", fontsize=10)
+# %%
+fig, (ax_band, ax_vol) = plt.subplots(
+    2, 1, figsize=style.FIGSIZE["dual_v"], height_ratios=[1, 3], sharex=True
+)
 
-    # Panel 2: Volatility time series
-    ax2 = axes[1]
+draw_swimlanes(ax_band, rows, 2, lane_cmap)
+ax_band.set_yticks([0, 1])
+ax_band.set_yticklabels(["Risk-off", "Risk-on"])
+ax_band.set_ylim(-0.5, 1.5)
 
-    # Plot rolling volatility colored by regime
-    for i in range(len(rolling_vol) - 1):
-        if pd.notna(rolling_vol.iloc[i]):
-            color = "#d0d0d0" if labels_2[i] == good_regime else "#2d2d2d"
-            ax2.plot(
-                [i, i + 1],
-                [rolling_vol.iloc[i] * 100, rolling_vol.iloc[i + 1] * 100],
-                color=color,
-                linewidth=1.2,
-            )
-
-    # Add horizontal lines for regime means
-    ax2.axhline(
-        vol_df.loc["Risk-On", "Mean Vol"] * 100,
-        color="#4a7c59",
+for cluster, colour in ((risk_on_cluster, COLORS["recede"]), (risk_off_cluster, COLORS["blue"])):
+    masked = np.where(labels_2 == cluster, rolling_vol.to_numpy() * 100, np.nan)
+    ax_vol.plot(positions, masked, color=colour, linewidth=1.2)
+for regime, colour in (("Risk-on", COLORS["copper"]), ("Risk-off", COLORS["amber"])):
+    ax_vol.axhline(
+        rolling_vol_by_regime.loc[regime, "Mean (%)"],
+        color=colour,
         linestyle="--",
-        linewidth=2,
-        label=f"Risk-On avg: {vol_df.loc['Risk-On', 'Mean Vol'] * 100:.1f}%",
+        linewidth=1.2,
+        label=f"{regime} average",
     )
-    ax2.axhline(
-        vol_df.loc["Risk-Off", "Mean Vol"] * 100,
-        color="#8b4513",
-        linestyle="--",
-        linewidth=2,
-        label=f"Risk-Off avg: {vol_df.loc['Risk-Off', 'Mean Vol'] * 100:.1f}%",
-    )
+ax_vol.set_ylabel(f"Trailing {ROLLING_VOL_MONTHS}-month volatility, annualized (%)")
+ax_vol.set_xlabel("Year")
+ax_vol.set_xticks(ticks)
+ax_vol.set_xticklabels(tick_labels)
+ax_vol.legend(loc="upper right")
+ax_vol.grid(True, alpha=0.3)
 
-    # X-axis setup
-    years = [pd.Timestamp(ts).year for ts in factors_df.index]
-    decade_ticks = []
-    decade_labels = []
-    for j, year in enumerate(years):
-        if j == 0 or years[j - 1] != year:
-            if year % 10 == 0:
-                decade_ticks.append(j)
-                decade_labels.append(str(year))
-
-    ax2.set_xticks(decade_ticks)
-    ax2.set_xticklabels(decade_labels, fontsize=9)
-    ax2.set_xlabel("Year", fontsize=10)
-    ax2.set_ylabel("Rolling 12-Month Volatility (%)", fontsize=10)
-    ax2.legend(loc="upper right", fontsize=10)
-    ax2.grid(True, alpha=0.3)
-
-    fig.suptitle(
-        f"Equity Market Volatility by Regime ({start_year}-{end_year})",
-        fontsize=12,
-        fontweight="bold",
-        y=1.02,
-    )
-
-    plt.show()
-
-    vol_ratio = vol_df.loc["Risk-Off", "Mean Vol"] / vol_df.loc["Risk-On", "Mean Vol"]
-    print(
-        f"Risk-Off / Risk-On rolling-volatility ratio: {vol_ratio:.2f}x "
-        f"({(vol_ratio - 1) * 100:.0f}% higher volatility in Risk-Off)."
-    )
-    return (
-        (vol_df * 100)
-        .round(1)
-        .rename(columns={"Mean Vol": "Mean (%)", "Median Vol": "Median (%)", "Max Vol": "Max (%)"})
-    )
-
-
-vol_summary = plot_volatility_by_regime()
-vol_summary
+style.add_message_title(
+    ax_band,
+    "The risk-off cluster sits on the higher-volatility stretches of the century",
+    subtitle=f"Trailing {ROLLING_VOL_MONTHS}-month standard deviation of the equity index, "
+    f"annualized by the square root of {MONTHS_PER_YEAR}",
+)
+style.show_with_alt(
+    fig,
+    "A two-row regime band above a rolling volatility series in percent. The dark risk-off "
+    "segments concentrate on the peaks of the volatility series, and the risk-off average "
+    "rule sits above the risk-on one.",
+)
 
 # %% [markdown]
-# ### Persist Figure 1.5 inputs
+# ### Figure 1.5 inputs
 #
-# The publication-quality version of Figure 1.5 is rendered by
-# `book/01_process_is_edge/figures/scripts/generate_figure_1_5_factor_regimes_volatility.py`.
-# That script reads the arrays persisted below so the book build does not
-# re-fit the GMM.
+# The print version of Figure 1.5 is drawn by
+# `book/01_process_is_edge/figures/scripts/generate_figure_1_5_factor_regimes_volatility.py`
+# in the book repository. It reads the arrays written below, so the book build renders the
+# figure from this notebook's fit rather than re-estimating the mixture.
 
 # %%
 ARTIFACT_DIR = OUTPUT_DIR / "figure_1_5"
@@ -751,287 +704,274 @@ np.savez(
     ARTIFACT_DIR / "inputs.npz",
     dates=factors_df.index.astype("datetime64[ns]").astype("int64"),
     labels_2=np.asarray(labels_2, dtype=np.int64),
-    good_regime=np.int64(good_regime),
+    good_regime=np.int64(risk_on_cluster),
     rolling_vol=rolling_vol.to_numpy(dtype=float),
-    risk_on_mean_vol=float(vol_df.loc["Risk-On", "Mean Vol"]),
-    risk_off_mean_vol=float(vol_df.loc["Risk-Off", "Mean Vol"]),
+    risk_on_mean_vol=float(rolling_vol_by_regime.loc["Risk-on", "Mean (%)"]) / 100,
+    risk_off_mean_vol=float(rolling_vol_by_regime.loc["Risk-off", "Mean (%)"]) / 100,
     start_year=np.int64(start_year),
     end_year=np.int64(end_year),
 )
 
 # %% [markdown]
-# ## Factor Behavior by Regime
+# ## What each factor earned in each regime
+#
+# The volatility check says the two environments differ in how much the market moved. The
+# more useful question for portfolio construction is whether the strategies behave
+# differently in them, because a strategy that earns its premium in both is a diversifier
+# and one that only earns it in the calm environment is leverage on the market in disguise.
+#
+# Each bar below is the mean monthly return of one series over the months assigned to one
+# regime, multiplied by twelve. This is an average within a set of months, not the return of
+# a strategy that switched between them - no rule available in real time would have produced
+# this partition.
+
+# %%
+annualized_by_regime = (
+    factors_df.groupby(regime_name).mean().mul(MONTHS_PER_YEAR * 100).rename(columns=SHORT_NAMES)
+).loc[["Risk-on", "Risk-off"]]
+
+# %%
+fig, ax = plt.subplots(figsize=style.FIGSIZE["single_tall"])
+
+x = np.arange(annualized_by_regime.shape[1])
+width = 0.38
+ax.bar(
+    x - width / 2,
+    annualized_by_regime.loc["Risk-on"],
+    width,
+    label="Risk-on",
+    color=COLORS["recede"],
+)
+ax.bar(
+    x + width / 2,
+    annualized_by_regime.loc["Risk-off"],
+    width,
+    label="Risk-off",
+    color=COLORS["blue"],
+)
+ax.set_xticks(x)
+ax.set_xticklabels(annualized_by_regime.columns, rotation=30, ha="right")
+ax.set_ylabel("Mean return within the regime, annualized (%)")
+style.zero_line(ax)
+ax.legend(loc="upper right")
+ax.grid(axis="y", alpha=0.3)
+
+style.add_message_title(
+    ax,
+    "Value and bonds hold up in the risk-off months; carry and defensive do not",
+    subtitle="Mean monthly return within each regime times twelve, by series",
+)
+style.show_with_alt(
+    fig,
+    "Paired bars per factor. Value and bonds have taller risk-off bars than risk-on bars; "
+    "momentum, equity, carry and defensive have taller risk-on bars, with carry and "
+    "defensive falling below zero in the risk-off months.",
+)
+
+# %%
+annualized_by_regime.T.style.format("{:+.1f}")
+
+# %% [markdown]
+# The two long-short strategies named for safety, carry and defensive, are the ones that
+# stop paying when conditions deteriorate. That is the shape a reader should take away:
+# a strategy's average return over a full sample says nothing about whether it will be there
+# in the environment a portfolio needs it in, and the only way to find out is to condition
+# on the environment and look.
+
+# %% [markdown]
+# ## Regime statistics
+#
+# The table below characterises each regime through the equity index alone. Every statistic
+# is computed on one stream: the monthly returns of the months the model assigned to that
+# regime, concatenated in date order with the months in the other regime removed.
+#
+# For the mean, the standard deviation and the Sharpe ratio that is an ordinary conditional
+# statistic - the average of a set of months does not depend on their order. **Maximum
+# drawdown** is different, because it is a path statistic: it compounds the stream, tracks
+# its running high-water mark, and reports the largest percentage fall from that mark to a
+# later point. Compounding a stream whose gaps have been closed up is not the same as
+# compounding the index, so the number below describes an investor who held equities during
+# one regime and held nothing during the other. The section after the table shows how far
+# apart the two readings are.
 
 
 # %%
-def plot_factor_returns_by_regime():
-    """Compare annualized factor returns between Risk-On and Risk-Off regimes."""
-    # Calculate mean factor returns by regime
-    regime_labels_2 = pd.Series(labels_2, index=factors_df.index, name="regime")
-    factor_by_regime = factors_df.copy()
-    factor_by_regime["regime"] = regime_labels_2
-
-    # Mean returns by regime (annualized)
-    regime_means = factor_by_regime.groupby("regime").mean() * 12
-    regime_means.index = ["Risk-Off" if i == bad_regime else "Risk-On" for i in regime_means.index]
-
-    # Rename columns for readability
-    col_renames = {
-        "All asset classes Value": "Value",
-        "All asset classes Momentum": "Momentum",
-        "All asset classes Carry": "Carry",
-        "All asset classes Defensive": "Defensive",
-        "US Stock Selection Value": "US Value",
-        "US Stock Selection Momentum": "US Mom",
-        "Equity indices Market": "Equity",
-        "Fixed income Market": "Bonds",
-        "Commodities Market": "Cmdty",
-    }
-    regime_means_display = regime_means.rename(columns=col_renames)
-
-    # Create bar chart comparing regimes
-    fig, ax = plt.subplots(figsize=(12, 5))
-
-    x = np.arange(len(regime_means_display.columns))
-    width = 0.35
-
-    bars1 = ax.bar(
-        x - width / 2,
-        regime_means_display.loc["Risk-On"].values * 100,
-        width,
-        label="Risk-On",
-        color="#4a7c59",
-        edgecolor="black",
-        linewidth=0.5,
-    )
-    bars2 = ax.bar(
-        x + width / 2,
-        regime_means_display.loc["Risk-Off"].values * 100,
-        width,
-        label="Risk-Off",
-        color="#8b4513",
-        edgecolor="black",
-        linewidth=0.5,
-    )
-
-    # Add value labels
-    for bar, val in zip(bars1, regime_means_display.loc["Risk-On"].values, strict=False):
-        height = bar.get_height()
-        ax.annotate(
-            f"{val * 100:.1f}%",
-            xy=(bar.get_x() + bar.get_width() / 2, height),
-            xytext=(0, 3 if height >= 0 else -10),
-            textcoords="offset points",
-            ha="center",
-            va="bottom" if height >= 0 else "top",
-            fontsize=8,
-            fontweight="bold",
-        )
-
-    for bar, val in zip(bars2, regime_means_display.loc["Risk-Off"].values, strict=False):
-        height = bar.get_height()
-        ax.annotate(
-            f"{val * 100:.1f}%",
-            xy=(bar.get_x() + bar.get_width() / 2, height),
-            xytext=(0, 3 if height >= 0 else -10),
-            textcoords="offset points",
-            ha="center",
-            va="bottom" if height >= 0 else "top",
-            fontsize=8,
-        )
-
-    ax.set_ylabel("Annualized Return (%)", fontsize=11)
-    ax.set_xlabel("Factor", fontsize=11)
-    ax.set_xticks(x)
-    ax.set_xticklabels(regime_means_display.columns, fontsize=10)
-    ax.axhline(y=0, color="black", linestyle="-", linewidth=0.5)
-    ax.legend(loc="upper right", fontsize=10)
-    ax.grid(axis="y", alpha=0.3)
-
-    n_on = (labels_2 == good_regime).sum()
-    n_off = (labels_2 == bad_regime).sum()
-    ax.set_title(
-        f"Factor Returns by Market Regime\nRisk-On: {n_on} months ({n_on / len(labels_2) * 100:.0f}%) | Risk-Off: {n_off} months ({n_off / len(labels_2) * 100:.0f}%)",
-        fontsize=12,
-        fontweight="bold",
-    )
-
-    plt.show()
-
-    # Display per-factor returns as a DataFrame for easy comparison.
-    period_label = (
-        f"{factors_df.index.min().year}-{factors_df.index.max().year} ({len(factors_df)} months)"
-    )
-    print(f"Period: {period_label}")
-    print(
-        f"Regime distribution: Risk-On {n_on} ({n_on / len(labels_2) * 100:.1f}%), "
-        f"Risk-Off {n_off} ({n_off / len(labels_2) * 100:.1f}%)"
-    )
-    key_factors = [
-        c
-        for c in ["Value", "Momentum", "Equity", "Bonds", "Carry", "Defensive"]
-        if c in regime_means_display.columns
-    ]
-    factor_summary = (regime_means_display[key_factors].T * 100).round(1)
-    factor_summary.columns = [f"{c} (%)" for c in factor_summary.columns]
-    return factor_summary
-
-
-factor_summary = plot_factor_returns_by_regime()
-factor_summary
-# %% [markdown]
-# **Interpretation**: The regime split reveals distinct factor behavior:
-#
-# - **Value is countercyclical**: Returns *increase* during Risk-Off (+5.3% vs +1.6%),
-#   consistent with the value premium's tendency to compensate for distress risk.
-# - **Momentum is procyclical**: Much weaker during Risk-Off (+0.4% vs +4.5%),
-#   reflecting momentum's vulnerability to sharp reversals.
-# - **Carry and Defensive turn negative** in Risk-Off (−0.6% and −0.5%) — these
-#   strategies that appear safe in calm markets lose money when conditions deteriorate.
-# - **Bonds outperform in Risk-Off** (+4.2% vs +0.8%), consistent with the classic
-#   flight-to-quality effect.
-#
-# For portfolio construction, this suggests Value and Bonds provide genuine
-# diversification during stress, while Carry and Defensive do not.
-
-# %% [markdown]
-# ## Regime Statistics
-#
-# Compare key metrics between Risk-On and Risk-Off periods.
+def drawdown_path(returns: pd.Series) -> pd.Series:
+    """Fractional decline from the running high-water mark of the compounded stream."""
+    wealth = (1 + returns).cumprod()
+    return wealth / wealth.cummax() - 1
 
 
 # %%
-def compute_regime_statistics():
-    """Calculate and display comprehensive regime statistics."""
-    # Calculate comprehensive regime statistics
-    equity_returns = factors_df["Equity indices Market"]
-    regime_series = pd.Series(labels_2, index=factors_df.index)
-
-    regime_stats_list = []
-    for regime, name in [(good_regime, "Risk-On"), (bad_regime, "Risk-Off")]:
-        mask = regime_series == regime
-        returns = equity_returns[mask]
-
-        # Basic counts
-        n_months = mask.sum()
-        pct_time = n_months / len(mask) * 100
-
-        # Return statistics (annualized)
-        mean_ret = returns.mean() * 12
-        vol = returns.std() * np.sqrt(12)
-        sharpe = mean_ret / vol if vol > 0 else 0
-
-        # Drawdown
-        cum_ret = (1 + returns).cumprod()
-        peak = cum_ret.cummax()
-        drawdown = (cum_ret - peak) / peak
-        max_dd = drawdown.min()
-
-        regime_stats_list.append(
-            {
-                "Regime": name,
-                "Months": n_months,
-                "% of Time": pct_time,
-                "Ann. Return": mean_ret,
-                "Ann. Volatility": vol,
-                "Sharpe Ratio": sharpe,
-                "Max Drawdown": max_dd,
-            }
-        )
-
-    regime_stats_df = pd.DataFrame(regime_stats_list).set_index("Regime")
-
-    # Volatility ratio (printed; the table itself displays below).
-    vol_on = regime_stats_df.loc["Risk-On", "Ann. Volatility"]
-    vol_off = regime_stats_df.loc["Risk-Off", "Ann. Volatility"]
-    print(f"Volatility ratio (Risk-Off / Risk-On): {vol_off / vol_on:.2f}x")
-    return regime_stats_df.style.format(
-        {
-            "% of Time": "{:.1f}%",
-            "Ann. Return": "{:+.1%}",
-            "Ann. Volatility": "{:.1%}",
-            "Sharpe Ratio": "{:.2f}",
-            "Max Drawdown": "{:.1%}",
-        }
-    )
-
-
-compute_regime_statistics()
-# %% [markdown]
-# **Interpretation**: The regime split is stark. Risk-On delivers a Sharpe of 1.11
-# while Risk-Off drops to 0.12 — equity exposure during Risk-Off is essentially
-# uncompensated risk. The −76.9% max drawdown in Risk-Off reflects the Great
-# Depression and underscores that these are not mild corrections.
-#
-# The direct volatility ratio here (2.2x) is much larger than the rolling-window
-# average reported earlier (1.3x). The rolling measure smooths over extreme months,
-# while this calculation captures the full variance within each regime. The direct
-# measure better reflects what a portfolio actually experiences during Risk-Off.
-
-# %% [markdown]
-# ## Regime Duration Analysis
-
-# %%
-# Calculate average duration
-durations = {}
-for regime, name in [(bad_regime, "Risk-Off"), (good_regime, "Risk-On")]:
-    regime_mask = labels_2 == regime
-    runs = []
-    current_run = 0
-    for val in regime_mask:
-        if val:
-            current_run += 1
-        elif current_run > 0:
-            runs.append(current_run)
-            current_run = 0
-    if current_run > 0:
-        runs.append(current_run)
-    durations[name] = (np.mean(runs), np.max(runs), len(runs))
-
-transitions = int(np.sum(np.diff(labels_2) != 0))
-
-duration_df = pd.DataFrame(
+regime_statistics = pd.DataFrame(
     [
         {
-            "Regime": name,
-            "Avg duration (months)": durations[name][0],
-            "Max duration (months)": durations[name][1],
-            "Episodes": durations[name][2],
+            "Regime": regime,
+            "Months": int(len(returns)),
+            "Share of sample": len(returns) / len(equity_returns),
+            "Return, annualized": returns.mean() * MONTHS_PER_YEAR,
+            "Volatility, annualized": returns.std() * np.sqrt(MONTHS_PER_YEAR),
+            "Sharpe ratio": sharpe_ratio(returns, periods_per_year=MONTHS_PER_YEAR),
+            "Max drawdown": float(drawdown_path(returns).min()),
         }
-        for name in ["Risk-On", "Risk-Off"]
+        for regime, returns in (
+            (name, equity_returns[regime_name == name]) for name in ("Risk-on", "Risk-off")
+        )
     ]
 ).set_index("Regime")
-
-print(
-    f"Total regime transitions: {transitions} "
-    f"(avg {len(labels_2) / transitions:.1f} months between switches)"
+regime_statistics.style.format(
+    {
+        "Share of sample": "{:.1%}",
+        "Return, annualized": "{:+.1%}",
+        "Volatility, annualized": "{:.1%}",
+        "Sharpe ratio": "{:.2f}",
+        "Max drawdown": "{:.1%}",
+    }
 )
-duration_df.style.format({"Avg duration (months)": "{:.1f}"})
+
+# %%
+pooled_vol_ratio = (
+    regime_statistics.loc["Risk-off", "Volatility, annualized"]
+    / regime_statistics.loc["Risk-on", "Volatility, annualized"]
+)
+rolling_vol_ratio = (
+    rolling_vol_by_regime.loc["Risk-off", "Mean (%)"]
+    / rolling_vol_by_regime.loc["Risk-on", "Mean (%)"]
+)
+display(
+    Markdown(
+        f"Risk-off volatility is **{pooled_vol_ratio:.2f}x** risk-on volatility measured on "
+        f"the pooled monthly returns, against **{rolling_vol_ratio:.2f}x** measured as the "
+        "average of the trailing twelve-month series."
+    )
+)
 
 # %% [markdown]
-# **Interpretation**: With 267 transitions over 98 years, the model switches regime
-# roughly every 4 months on average. Risk-Off episodes are short (avg ~2 months)
-# — they capture acute stress periods rather than prolonged bear markets. This
-# choppiness has practical implications: a strategy that reallocates based on these
-# signals would trade frequently, incurring transaction costs that may erode the
-# regime-timing benefit. Regime models are more useful for *understanding* market
-# dynamics than for high-frequency tactical allocation.
+# The two ratios answer different questions and a reader should expect them to differ. The
+# rolling series smooths each month against the eleven around it, so a single extreme month
+# raises twelve windows a little; the pooled standard deviation lets it enter once, at full
+# size. The pooled figure is the one that describes what a portfolio holding through the
+# regime experiences, and the rolling figure is the one a monitoring dashboard would show.
+# Reporting either alone would be defensible; reporting one and calling it "the" volatility
+# ratio would not.
 
 # %% [markdown]
-# ## Key Takeaways
+# ### What the restricted drawdown actually measures
 #
-# - **BIC favors two regimes**: K=2 has the lowest BIC and highest silhouette score,
-#   though AIC prefers more clusters. The two-state model offers the most interpretable
-#   and stable regime split.
-# - **Regimes capture distinct risk environments**: Risk-Off has 2.2x higher volatility,
-#   a Sharpe of 0.12 (vs 1.11), and a max drawdown of −77%.
-# - **Value is countercyclical**: +5.3% annualized during Risk-Off vs +1.6% during Risk-On.
-#   Carry and Defensive, despite their names, turn negative in Risk-Off.
-# - **Momentum is procyclical**: +4.5% during Risk-On vs +0.4% during Risk-Off — weakest
-#   factor during market stress.
-# - **Regime signals are noisy**: With transitions every ~4 months on average, this model
-#   is better suited for understanding factor dynamics than for tactical allocation.
+# The drawdown reported for the risk-off regime is large, and it is worth reading where it
+# came from before quoting it. The cell below finds the high-water mark of the restricted
+# stream and the month it fell furthest below it, and puts the drawdown of the index itself
+# over the same span beside it.
+
+# %%
+risk_off_returns = equity_returns[regime_name == "Risk-off"]
+risk_off_drawdown = drawdown_path(risk_off_returns)
+trough_month = risk_off_drawdown.idxmin()
+peak_month = (1 + risk_off_returns).cumprod().loc[:trough_month].idxmax()
+
+index_over_span = equity_returns.loc[peak_month:trough_month]
+index_drawdown = float(drawdown_path(index_over_span).min())
+display(
+    Markdown(
+        f"The restricted stream peaks in **{peak_month:%B %Y}** and reaches its low in "
+        f"**{trough_month:%B %Y}**, a fall of "
+        f"**{risk_off_drawdown.min():.1%}** spread over "
+        f"**{trough_month.year - peak_month.year} years**. Over the same span the equity "
+        f"index itself fell at most **{index_drawdown:.1%}** from its own high-water mark."
+    )
+)
+
+# %% [markdown]
+# Nobody lived through the first of those two numbers. It is the arithmetic of a stream that
+# keeps every month the market was falling and discards the ones in which it recovered, so it
+# accumulates the losses of a century of separate episodes into one uninterrupted decline.
+# The statistic is not wrong - it is the correct drawdown of the object it was computed on -
+# but the object is a construction of this notebook, and a reader who takes it for a crash
+# has been misled by a table that never said which object it meant.
 #
-# **Next**: `macro_regimes.py` switches from style returns to macro indicators (UNRATE,
-# DFF, T10Y2Y, CPIAUCSL) and validates the resulting clusters against S&P 500 volatility
-# and drawdowns. See Chapter 1 §1.4 for the workflow context.
+# That is the general form: a conditional statistic inherits the assumptions of the
+# conditioning. Averages survive it, because a mean does not care in what order its terms
+# arrive. Anything that reads a path - a drawdown, a run length, a time to recovery, a
+# stop-loss - is a different statistic once the path has been cut up, and reporting it
+# without saying so is how a number that means one thing gets read as another.
+
+# %% [markdown]
+# ## How long the regimes last
+#
+# A regime label is useful to a strategy only if it persists long enough to act on. An
+# **episode** below is a maximal run of consecutive months carrying the same label, and the
+# table reports how many episodes each regime had and how long they ran.
+
+# %%
+episode_id = (labels_2 != np.roll(labels_2, 1)).cumsum()
+episode_lengths = (
+    pd.DataFrame({"regime": regime_name.to_numpy(), "episode": episode_id})
+    .groupby(["regime", "episode"])
+    .size()
+    .rename("months")
+    .reset_index()
+)
+
+duration = (
+    episode_lengths.groupby("regime")["months"]
+    .agg(["mean", "max", "count"])
+    .rename(
+        columns={"mean": "Mean length (months)", "max": "Longest (months)", "count": "Episodes"}
+    )
+    .loc[["Risk-on", "Risk-off"]]
+)
+duration.index.name = "Regime"
+duration.style.format({"Mean length (months)": "{:.1f}"})
+
+# %%
+switches = int(np.sum(np.diff(labels_2) != 0))
+months_between_switches = len(labels_2) / switches
+display(
+    Markdown(
+        f"The two-cluster model changes regime **{switches}** times over "
+        f"{end_year - start_year} years, about once every "
+        f"**{months_between_switches:.1f} months**."
+    )
+)
+
+# %% [markdown]
+# That is the finding that decides what this model is for. A label that changes several
+# times a year cannot drive a reallocation: the turnover would be paid on every switch,
+# including the ones the model reverses a month later, and the transaction costs would
+# arrive whether or not the regime call was right. The same label is useful as a lens on
+# history and as one input to a risk report, which is the use Section 1.4 argues for.
+#
+# A model built to be acted on would be built differently. It would carry a transition
+# structure that makes staying in a regime more likely than leaving it - a hidden Markov
+# model is the standard choice - and it would be fitted forward in time so that each
+# month's label used only the months before it. Chapter 9 introduces both.
+
+# %% [markdown]
+# ## Key takeaways
+#
+# - **The number of clusters is a decision, not an estimate.** BIC, AIC and the silhouette
+#   score reward different things, so they will disagree; pick the one whose objective
+#   matches what the labels are for, and say which you picked and why.
+# - **Cluster numbers carry no meaning until something outside the model names them.** Here
+#   the average equity return within each cluster does the naming, and a different seed can
+#   renumber the clusters without changing the partition.
+# - **Condition on the environment before trusting a factor's average.** A strategy's
+#   full-sample premium can be entirely earned in one environment, which is invisible in the
+#   pooled number and decisive for whether it diversifies anything.
+# - **State how a conditional statistic was built.** Restricting a return stream to the
+#   months in a regime and concatenating them produces a drawdown no investor experienced
+#   unless they held only during that regime; the same number is either informative or
+#   misleading depending on whether that construction is stated.
+# - **Fitting on the whole sample buys description, not prediction.** Every label here is
+#   informed by the months after it, so the labels cannot be used as features. Walk-forward
+#   fitting is what makes them usable, and Chapter 6 onward introduces it.
+#
+# **Known limitations.** The mixture has no notion of time: it can assign January 1932 and
+# January 2019 to the same cluster and has no mechanism preferring a month to keep the
+# previous month's label, which is why the episodes are short. The AQR series are monthly, so
+# nothing here resolves anything faster than a month. And the panel is a century long, over
+# which the composition of the asset classes and the microstructure of the markets changed
+# considerably; the model treats 1927 and 2024 as draws from the same set of distributions.
+#
+# **Next**: `macro_regimes` asks the same question of macroeconomic indicators rather than
+# factor returns, and checks the resulting clusters against realized equity volatility.

--- a/01_process_is_edge/factor_regimes.py
+++ b/01_process_is_edge/factor_regimes.py
@@ -16,7 +16,7 @@
 # %% [markdown]
 # # Factor-based regime detection
 #
-# **Chapter 1 · §1.4 Market Regimes: Change Is the Constant**
+# **Chapter 1 · §1.4 Keeping up with changing market regimes**
 #
 # **Docker image**: `ml4t`
 #
@@ -50,7 +50,7 @@
 #
 # ## Book reference
 #
-# Chapter 1, Section 1.4, "Market Regimes: Change Is the Constant". `macro_regimes` is the
+# Chapter 1, Section 1.4, "Keeping up with changing market regimes". `macro_regimes` is the
 # companion notebook and estimates regimes from macroeconomic indicators instead.
 #
 # ## Prerequisites

--- a/01_process_is_edge/factor_regimes.py
+++ b/01_process_is_edge/factor_regimes.py
@@ -249,6 +249,13 @@ coverage.style.format({"Mean (% / month)": "{:.2f}", "Std (% / month)": "{:.2f}"
 # on the largest scale.
 
 # %%
+missing = [c for c in FACTOR_COLUMNS if c not in aqr_raw.columns]
+if missing:
+    raise ValueError(
+        f"The AQR file is missing {missing}. Re-fetch it with "
+        "`uv run python data/factors/aqr_download.py`."
+    )
+
 factors_pl = aqr_raw.select(["timestamp", *FACTOR_COLUMNS]).sort("timestamp").drop_nulls()
 
 factors_df = factors_pl.select(FACTOR_COLUMNS).to_pandas()

--- a/01_process_is_edge/factor_regimes.py
+++ b/01_process_is_edge/factor_regimes.py
@@ -193,6 +193,13 @@ FACTOR_COLUMNS = [
 ]
 EQUITY_COLUMN = "Equity indices Market"
 
+missing = [c for c in FACTOR_COLUMNS if c not in aqr_raw.columns]
+if missing:
+    raise ValueError(
+        f"The AQR file is missing {missing}. Re-fetch it with "
+        "`uv run python data/factors/aqr_download.py`."
+    )
+
 # Short names for the figures and tables below; the full AQR column names do not fit on an
 # axis.
 SHORT_NAMES = {
@@ -249,13 +256,6 @@ coverage.style.format({"Mean (% / month)": "{:.2f}", "Std (% / month)": "{:.2f}"
 # on the largest scale.
 
 # %%
-missing = [c for c in FACTOR_COLUMNS if c not in aqr_raw.columns]
-if missing:
-    raise ValueError(
-        f"The AQR file is missing {missing}. Re-fetch it with "
-        "`uv run python data/factors/aqr_download.py`."
-    )
-
 factors_pl = aqr_raw.select(["timestamp", *FACTOR_COLUMNS]).sort("timestamp").drop_nulls()
 
 factors_df = factors_pl.select(FACTOR_COLUMNS).to_pandas()

--- a/01_process_is_edge/factor_regimes.py
+++ b/01_process_is_edge/factor_regimes.py
@@ -892,15 +892,17 @@ risk_off_drawdown = drawdown_path(risk_off_returns)
 trough_month = risk_off_drawdown.idxmin()
 peak_month = (1 + risk_off_returns).cumprod().loc[:trough_month].idxmax()
 
+restricted_drawdown = float(risk_off_drawdown.min())
 index_over_span = equity_returns.loc[peak_month:trough_month]
 index_drawdown = float(drawdown_path(index_over_span).min())
 display(
     Markdown(
         f"The restricted stream peaks in **{peak_month:%B %Y}** and reaches its low in "
         f"**{trough_month:%B %Y}**, a fall of "
-        f"**{risk_off_drawdown.min():.1%}** spread over "
+        f"**{abs(restricted_drawdown):.1%}** spread over "
         f"**{trough_month.year - peak_month.year} years**. Over the same span the equity "
-        f"index itself fell at most **{index_drawdown:.1%}** from its own high-water mark."
+        f"index itself fell at most **{abs(index_drawdown):.1%}** from its own high-water "
+        "mark."
     )
 )
 

--- a/01_process_is_edge/macro_regimes.ipynb
+++ b/01_process_is_edge/macro_regimes.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a87cefa7",
+   "id": "48007952",
    "metadata": {
     "papermill": {
-     "duration": 0.028868,
-     "end_time": "2026-09-08T23:42:21.838439+00:00",
+     "duration": 0.002792,
+     "end_time": "2026-09-08T23:58:55.789805+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:21.809571+00:00",
+     "start_time": "2026-09-08T23:58:55.787013+00:00",
      "status": "completed"
     }
    },
@@ -75,13 +75,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3d30f6d",
+   "id": "c85d97f2",
    "metadata": {
     "papermill": {
-     "duration": 0.009336,
-     "end_time": "2026-09-08T23:42:21.860590+00:00",
+     "duration": 0.00232,
+     "end_time": "2026-09-08T23:58:55.794644+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:21.851254+00:00",
+     "start_time": "2026-09-08T23:58:55.792324+00:00",
      "status": "completed"
     }
    },
@@ -92,19 +92,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6c9216d6",
+   "id": "9b6c7b12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:21.895756Z",
-     "iopub.status.busy": "2026-09-08T23:42:21.895573Z",
-     "iopub.status.idle": "2026-09-08T23:42:29.859705Z",
-     "shell.execute_reply": "2026-09-08T23:42:29.859177Z"
+     "iopub.execute_input": "2026-09-08T23:58:55.802365Z",
+     "iopub.status.busy": "2026-09-08T23:58:55.802058Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.225162Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.224618Z"
     },
     "papermill": {
-     "duration": 7.990986,
-     "end_time": "2026-09-08T23:42:29.861004+00:00",
+     "duration": 3.428844,
+     "end_time": "2026-09-08T23:58:59.226112+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:21.870018+00:00",
+     "start_time": "2026-09-08T23:58:55.797268+00:00",
      "status": "completed"
     }
    },
@@ -140,19 +140,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e350b658",
+   "id": "7a5497b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:29.886472Z",
-     "iopub.status.busy": "2026-09-08T23:42:29.886263Z",
-     "iopub.status.idle": "2026-09-08T23:42:29.892090Z",
-     "shell.execute_reply": "2026-09-08T23:42:29.888397Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.234517Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.234391Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.236553Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.236011Z"
     },
     "papermill": {
-     "duration": 0.019416,
-     "end_time": "2026-09-08T23:42:29.892694+00:00",
+     "duration": 0.005714,
+     "end_time": "2026-09-08T23:58:59.236881+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:29.873278+00:00",
+     "start_time": "2026-09-08T23:58:59.231167+00:00",
      "status": "completed"
     },
     "tags": [
@@ -167,13 +167,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2657111f",
+   "id": "840ff25c",
    "metadata": {
     "papermill": {
-     "duration": 0.012747,
-     "end_time": "2026-09-08T23:42:29.911404+00:00",
+     "duration": 0.002436,
+     "end_time": "2026-09-08T23:58:59.241931+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:29.898657+00:00",
+     "start_time": "2026-09-08T23:58:59.239495+00:00",
      "status": "completed"
     }
    },
@@ -202,19 +202,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "3c04a241",
+   "id": "003c6edb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:29.940710Z",
-     "iopub.status.busy": "2026-09-08T23:42:29.940533Z",
-     "iopub.status.idle": "2026-09-08T23:42:29.982128Z",
-     "shell.execute_reply": "2026-09-08T23:42:29.981646Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.247573Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.247460Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.300932Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.300235Z"
     },
     "papermill": {
-     "duration": 0.059141,
-     "end_time": "2026-09-08T23:42:29.983373+00:00",
+     "duration": 0.057062,
+     "end_time": "2026-09-08T23:58:59.301466+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:29.924232+00:00",
+     "start_time": "2026-09-08T23:58:59.244404+00:00",
      "status": "completed"
     }
    },
@@ -236,13 +236,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e7c38db",
+   "id": "1f89c901",
    "metadata": {
     "papermill": {
-     "duration": 0.008773,
-     "end_time": "2026-09-08T23:42:30.005250+00:00",
+     "duration": 0.002578,
+     "end_time": "2026-09-08T23:58:59.307105+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:29.996477+00:00",
+     "start_time": "2026-09-08T23:58:59.304527+00:00",
      "status": "completed"
     }
    },
@@ -258,19 +258,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "c0b0a91c",
+   "id": "fa28fd99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:30.027819Z",
-     "iopub.status.busy": "2026-09-08T23:42:30.027642Z",
-     "iopub.status.idle": "2026-09-08T23:42:30.078437Z",
-     "shell.execute_reply": "2026-09-08T23:42:30.074387Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.313187Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.313038Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.324829Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.324295Z"
     },
     "papermill": {
-     "duration": 0.061457,
-     "end_time": "2026-09-08T23:42:30.079033+00:00",
+     "duration": 0.015489,
+     "end_time": "2026-09-08T23:58:59.325217+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.017576+00:00",
+     "start_time": "2026-09-08T23:58:59.309728+00:00",
      "status": "completed"
     }
    },
@@ -295,13 +295,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7b11cb2",
+   "id": "7dddf403",
    "metadata": {
     "papermill": {
-     "duration": 0.008106,
-     "end_time": "2026-09-08T23:42:30.097764+00:00",
+     "duration": 0.002725,
+     "end_time": "2026-09-08T23:58:59.330947+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.089658+00:00",
+     "start_time": "2026-09-08T23:58:59.328222+00:00",
      "status": "completed"
     }
    },
@@ -318,19 +318,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "ead5ed53",
+   "id": "127920c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:30.132663Z",
-     "iopub.status.busy": "2026-09-08T23:42:30.132481Z",
-     "iopub.status.idle": "2026-09-08T23:42:30.179553Z",
-     "shell.execute_reply": "2026-09-08T23:42:30.179161Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.337310Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.337187Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.350051Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.349524Z"
     },
     "papermill": {
-     "duration": 0.078803,
-     "end_time": "2026-09-08T23:42:30.186810+00:00",
+     "duration": 0.016639,
+     "end_time": "2026-09-08T23:58:59.350384+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.108007+00:00",
+     "start_time": "2026-09-08T23:58:59.333745+00:00",
      "status": "completed"
     }
    },
@@ -587,14 +587,22 @@
    ],
    "source": [
     "metadata = load_macro_metadata().to_pandas().set_index(\"series\")\n",
-    "inventory = metadata.loc[\n",
-    "    [c for c in macro_raw.columns if c != DATE_COL], [\"description\", \"native_frequency\", \"formula\"]\n",
-    "].rename(\n",
-    "    columns={\n",
-    "        \"description\": \"Series\",\n",
-    "        \"native_frequency\": \"Published\",\n",
-    "        \"formula\": \"Derived as\",\n",
-    "    }\n",
+    "\n",
+    "# Reindex rather than select: the metadata file is maintained beside the data file and can\n",
+    "# fall behind it, and a column it does not describe should appear in this table saying so\n",
+    "# rather than stopping the notebook or vanishing from it.\n",
+    "inventory = (\n",
+    "    metadata.reindex([c for c in macro_raw.columns if c != DATE_COL])[\n",
+    "        [\"description\", \"native_frequency\", \"formula\"]\n",
+    "    ]\n",
+    "    .rename(\n",
+    "        columns={\n",
+    "            \"description\": \"Series\",\n",
+    "            \"native_frequency\": \"Published\",\n",
+    "            \"formula\": \"Derived as\",\n",
+    "        }\n",
+    "    )\n",
+    "    .fillna({\"Series\": \"not described in the metadata file\", \"Published\": \"unknown\"})\n",
     ")\n",
     "inventory[\"Derived as\"] = inventory[\"Derived as\"].fillna(\"-\")\n",
     "inventory.index.name = \"Column\"\n",
@@ -603,13 +611,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e36ff1d",
+   "id": "098e5407",
    "metadata": {
     "papermill": {
-     "duration": 0.01505,
-     "end_time": "2026-09-08T23:42:30.213356+00:00",
+     "duration": 0.002695,
+     "end_time": "2026-09-08T23:58:59.355945+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.198306+00:00",
+     "start_time": "2026-09-08T23:58:59.353250+00:00",
      "status": "completed"
     }
    },
@@ -633,37 +641,44 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "acbacb68",
+   "id": "cb4e2cef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:30.224643Z",
-     "iopub.status.busy": "2026-09-08T23:42:30.224490Z",
-     "iopub.status.idle": "2026-09-08T23:42:30.226501Z",
-     "shell.execute_reply": "2026-09-08T23:42:30.226155Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.362083Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.361966Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.364422Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.363972Z"
     },
     "papermill": {
-     "duration": 0.009472,
-     "end_time": "2026-09-08T23:42:30.228116+00:00",
+     "duration": 0.006075,
+     "end_time": "2026-09-08T23:58:59.364724+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.218644+00:00",
+     "start_time": "2026-09-08T23:58:59.358649+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
-    "CORE_SERIES = [\"unrate\", \"dff\", \"t10y2y\", \"cpiaucsl\"]"
+    "CORE_SERIES = [\"unrate\", \"dff\", \"t10y2y\", \"cpiaucsl\"]\n",
+    "\n",
+    "missing = [c for c in CORE_SERIES if c not in macro_raw.columns]\n",
+    "if missing:\n",
+    "    raise ValueError(\n",
+    "        f\"The FRED panel is missing {missing}, which the core model is built on. \"\n",
+    "        \"Re-run data/macro/download.py; data/macro/README.md lists what it fetches.\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4c710dc1",
+   "id": "41ccfd4f",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.012308,
-     "end_time": "2026-09-08T23:42:30.255032+00:00",
+     "duration": 0.002675,
+     "end_time": "2026-09-08T23:58:59.370791+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.242724+00:00",
+     "start_time": "2026-09-08T23:58:59.368116+00:00",
      "status": "completed"
     }
    },
@@ -684,19 +699,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "2e591208",
+   "id": "04adf617",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:30.291612Z",
-     "iopub.status.busy": "2026-09-08T23:42:30.291344Z",
-     "iopub.status.idle": "2026-09-08T23:42:30.299152Z",
-     "shell.execute_reply": "2026-09-08T23:42:30.298885Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.376911Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.376798Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.379487Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.378918Z"
     },
     "papermill": {
-     "duration": 0.028233,
-     "end_time": "2026-09-08T23:42:30.300658+00:00",
+     "duration": 0.00643,
+     "end_time": "2026-09-08T23:58:59.379839+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.272425+00:00",
+     "start_time": "2026-09-08T23:58:59.373409+00:00",
      "status": "completed"
     }
    },
@@ -716,19 +731,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "44f805f8",
+   "id": "e78693f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:30.324186Z",
-     "iopub.status.busy": "2026-09-08T23:42:30.324056Z",
-     "iopub.status.idle": "2026-09-08T23:42:30.366836Z",
-     "shell.execute_reply": "2026-09-08T23:42:30.366499Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.385935Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.385781Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.390058Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.389658Z"
     },
     "papermill": {
-     "duration": 0.05761,
-     "end_time": "2026-09-08T23:42:30.367578+00:00",
+     "duration": 0.008055,
+     "end_time": "2026-09-08T23:58:59.390612+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.309968+00:00",
+     "start_time": "2026-09-08T23:58:59.382557+00:00",
      "status": "completed"
     }
    },
@@ -755,13 +770,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "247a6779",
+   "id": "a119fbaf",
    "metadata": {
     "papermill": {
-     "duration": 0.00848,
-     "end_time": "2026-09-08T23:42:30.389847+00:00",
+     "duration": 0.00296,
+     "end_time": "2026-09-08T23:58:59.397313+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.381367+00:00",
+     "start_time": "2026-09-08T23:58:59.394353+00:00",
      "status": "completed"
     }
    },
@@ -785,19 +800,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "f362110d",
+   "id": "db15fa96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:30.422010Z",
-     "iopub.status.busy": "2026-09-08T23:42:30.421864Z",
-     "iopub.status.idle": "2026-09-08T23:42:30.446479Z",
-     "shell.execute_reply": "2026-09-08T23:42:30.445927Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.403815Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.403698Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.413054Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.412486Z"
     },
     "papermill": {
-     "duration": 0.044435,
-     "end_time": "2026-09-08T23:42:30.447204+00:00",
+     "duration": 0.01325,
+     "end_time": "2026-09-08T23:58:59.413438+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.402769+00:00",
+     "start_time": "2026-09-08T23:58:59.400188+00:00",
      "status": "completed"
     }
    },
@@ -825,13 +840,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a444375",
+   "id": "4f06a395",
    "metadata": {
     "papermill": {
-     "duration": 0.01331,
-     "end_time": "2026-09-08T23:42:30.471588+00:00",
+     "duration": 0.002734,
+     "end_time": "2026-09-08T23:58:59.419126+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.458278+00:00",
+     "start_time": "2026-09-08T23:58:59.416392+00:00",
      "status": "completed"
     }
    },
@@ -849,19 +864,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "2807cd90",
+   "id": "b68f5e72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:30.500472Z",
-     "iopub.status.busy": "2026-09-08T23:42:30.500334Z",
-     "iopub.status.idle": "2026-09-08T23:42:30.615663Z",
-     "shell.execute_reply": "2026-09-08T23:42:30.615277Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.425750Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.425542Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.458800Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.458436Z"
     },
     "papermill": {
-     "duration": 0.130215,
-     "end_time": "2026-09-08T23:42:30.616123+00:00",
+     "duration": 0.037493,
+     "end_time": "2026-09-08T23:58:59.459377+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.485908+00:00",
+     "start_time": "2026-09-08T23:58:59.421884+00:00",
      "status": "completed"
     }
    },
@@ -871,70 +886,70 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_c7847\">\n",
+       "<table id=\"T_52cce\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_c7847_level0_col0\" class=\"col_heading level0 col0\" >count</th>\n",
-       "      <th id=\"T_c7847_level0_col1\" class=\"col_heading level0 col1\" >mean</th>\n",
-       "      <th id=\"T_c7847_level0_col2\" class=\"col_heading level0 col2\" >std</th>\n",
-       "      <th id=\"T_c7847_level0_col3\" class=\"col_heading level0 col3\" >min</th>\n",
-       "      <th id=\"T_c7847_level0_col4\" class=\"col_heading level0 col4\" >25%</th>\n",
-       "      <th id=\"T_c7847_level0_col5\" class=\"col_heading level0 col5\" >50%</th>\n",
-       "      <th id=\"T_c7847_level0_col6\" class=\"col_heading level0 col6\" >75%</th>\n",
-       "      <th id=\"T_c7847_level0_col7\" class=\"col_heading level0 col7\" >max</th>\n",
+       "      <th id=\"T_52cce_level0_col0\" class=\"col_heading level0 col0\" >count</th>\n",
+       "      <th id=\"T_52cce_level0_col1\" class=\"col_heading level0 col1\" >mean</th>\n",
+       "      <th id=\"T_52cce_level0_col2\" class=\"col_heading level0 col2\" >std</th>\n",
+       "      <th id=\"T_52cce_level0_col3\" class=\"col_heading level0 col3\" >min</th>\n",
+       "      <th id=\"T_52cce_level0_col4\" class=\"col_heading level0 col4\" >25%</th>\n",
+       "      <th id=\"T_52cce_level0_col5\" class=\"col_heading level0 col5\" >50%</th>\n",
+       "      <th id=\"T_52cce_level0_col6\" class=\"col_heading level0 col6\" >75%</th>\n",
+       "      <th id=\"T_52cce_level0_col7\" class=\"col_heading level0 col7\" >max</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_c7847_level0_row0\" class=\"row_heading level0 row0\" >Unemployment rate (%)</th>\n",
-       "      <td id=\"T_c7847_row0_col0\" class=\"data row0 col0\" >276.00</td>\n",
-       "      <td id=\"T_c7847_row0_col1\" class=\"data row0 col1\" >5.75</td>\n",
-       "      <td id=\"T_c7847_row0_col2\" class=\"data row0 col2\" >2.02</td>\n",
-       "      <td id=\"T_c7847_row0_col3\" class=\"data row0 col3\" >3.40</td>\n",
-       "      <td id=\"T_c7847_row0_col4\" class=\"data row0 col4\" >4.20</td>\n",
-       "      <td id=\"T_c7847_row0_col5\" class=\"data row0 col5\" >5.00</td>\n",
-       "      <td id=\"T_c7847_row0_col6\" class=\"data row0 col6\" >6.70</td>\n",
-       "      <td id=\"T_c7847_row0_col7\" class=\"data row0 col7\" >14.80</td>\n",
+       "      <th id=\"T_52cce_level0_row0\" class=\"row_heading level0 row0\" >Unemployment rate (%)</th>\n",
+       "      <td id=\"T_52cce_row0_col0\" class=\"data row0 col0\" >276.00</td>\n",
+       "      <td id=\"T_52cce_row0_col1\" class=\"data row0 col1\" >5.75</td>\n",
+       "      <td id=\"T_52cce_row0_col2\" class=\"data row0 col2\" >2.02</td>\n",
+       "      <td id=\"T_52cce_row0_col3\" class=\"data row0 col3\" >3.40</td>\n",
+       "      <td id=\"T_52cce_row0_col4\" class=\"data row0 col4\" >4.20</td>\n",
+       "      <td id=\"T_52cce_row0_col5\" class=\"data row0 col5\" >5.00</td>\n",
+       "      <td id=\"T_52cce_row0_col6\" class=\"data row0 col6\" >6.70</td>\n",
+       "      <td id=\"T_52cce_row0_col7\" class=\"data row0 col7\" >14.80</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_c7847_level0_row1\" class=\"row_heading level0 row1\" >Fed funds rate (%)</th>\n",
-       "      <td id=\"T_c7847_row1_col0\" class=\"data row1 col0\" >276.00</td>\n",
-       "      <td id=\"T_c7847_row1_col1\" class=\"data row1 col1\" >1.76</td>\n",
-       "      <td id=\"T_c7847_row1_col2\" class=\"data row1 col2\" >1.91</td>\n",
-       "      <td id=\"T_c7847_row1_col3\" class=\"data row1 col3\" >0.04</td>\n",
-       "      <td id=\"T_c7847_row1_col4\" class=\"data row1 col4\" >0.10</td>\n",
-       "      <td id=\"T_c7847_row1_col5\" class=\"data row1 col5\" >1.04</td>\n",
-       "      <td id=\"T_c7847_row1_col6\" class=\"data row1 col6\" >3.12</td>\n",
-       "      <td id=\"T_c7847_row1_col7\" class=\"data row1 col7\" >5.41</td>\n",
+       "      <th id=\"T_52cce_level0_row1\" class=\"row_heading level0 row1\" >Fed funds rate (%)</th>\n",
+       "      <td id=\"T_52cce_row1_col0\" class=\"data row1 col0\" >276.00</td>\n",
+       "      <td id=\"T_52cce_row1_col1\" class=\"data row1 col1\" >1.76</td>\n",
+       "      <td id=\"T_52cce_row1_col2\" class=\"data row1 col2\" >1.91</td>\n",
+       "      <td id=\"T_52cce_row1_col3\" class=\"data row1 col3\" >0.04</td>\n",
+       "      <td id=\"T_52cce_row1_col4\" class=\"data row1 col4\" >0.10</td>\n",
+       "      <td id=\"T_52cce_row1_col5\" class=\"data row1 col5\" >1.04</td>\n",
+       "      <td id=\"T_52cce_row1_col6\" class=\"data row1 col6\" >3.12</td>\n",
+       "      <td id=\"T_52cce_row1_col7\" class=\"data row1 col7\" >5.41</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_c7847_level0_row2\" class=\"row_heading level0 row2\" >10Y minus 2Y Treasury (percentage points)</th>\n",
-       "      <td id=\"T_c7847_row2_col0\" class=\"data row2 col0\" >276.00</td>\n",
-       "      <td id=\"T_c7847_row2_col1\" class=\"data row2 col1\" >1.06</td>\n",
-       "      <td id=\"T_c7847_row2_col2\" class=\"data row2 col2\" >0.97</td>\n",
-       "      <td id=\"T_c7847_row2_col3\" class=\"data row2 col3\" >-1.06</td>\n",
-       "      <td id=\"T_c7847_row2_col4\" class=\"data row2 col4\" >0.24</td>\n",
-       "      <td id=\"T_c7847_row2_col5\" class=\"data row2 col5\" >1.00</td>\n",
-       "      <td id=\"T_c7847_row2_col6\" class=\"data row2 col6\" >1.88</td>\n",
-       "      <td id=\"T_c7847_row2_col7\" class=\"data row2 col7\" >2.84</td>\n",
+       "      <th id=\"T_52cce_level0_row2\" class=\"row_heading level0 row2\" >10Y minus 2Y Treasury (percentage points)</th>\n",
+       "      <td id=\"T_52cce_row2_col0\" class=\"data row2 col0\" >276.00</td>\n",
+       "      <td id=\"T_52cce_row2_col1\" class=\"data row2 col1\" >1.06</td>\n",
+       "      <td id=\"T_52cce_row2_col2\" class=\"data row2 col2\" >0.97</td>\n",
+       "      <td id=\"T_52cce_row2_col3\" class=\"data row2 col3\" >-1.06</td>\n",
+       "      <td id=\"T_52cce_row2_col4\" class=\"data row2 col4\" >0.24</td>\n",
+       "      <td id=\"T_52cce_row2_col5\" class=\"data row2 col5\" >1.00</td>\n",
+       "      <td id=\"T_52cce_row2_col6\" class=\"data row2 col6\" >1.88</td>\n",
+       "      <td id=\"T_52cce_row2_col7\" class=\"data row2 col7\" >2.84</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_c7847_level0_row3\" class=\"row_heading level0 row3\" >CPI, change over 12 months (%)</th>\n",
-       "      <td id=\"T_c7847_row3_col0\" class=\"data row3 col0\" >276.00</td>\n",
-       "      <td id=\"T_c7847_row3_col1\" class=\"data row3 col1\" >2.58</td>\n",
-       "      <td id=\"T_c7847_row3_col2\" class=\"data row3 col2\" >1.81</td>\n",
-       "      <td id=\"T_c7847_row3_col3\" class=\"data row3 col3\" >-1.96</td>\n",
-       "      <td id=\"T_c7847_row3_col4\" class=\"data row3 col4\" >1.63</td>\n",
-       "      <td id=\"T_c7847_row3_col5\" class=\"data row3 col5\" >2.32</td>\n",
-       "      <td id=\"T_c7847_row3_col6\" class=\"data row3 col6\" >3.25</td>\n",
-       "      <td id=\"T_c7847_row3_col7\" class=\"data row3 col7\" >8.98</td>\n",
+       "      <th id=\"T_52cce_level0_row3\" class=\"row_heading level0 row3\" >CPI, change over 12 months (%)</th>\n",
+       "      <td id=\"T_52cce_row3_col0\" class=\"data row3 col0\" >276.00</td>\n",
+       "      <td id=\"T_52cce_row3_col1\" class=\"data row3 col1\" >2.58</td>\n",
+       "      <td id=\"T_52cce_row3_col2\" class=\"data row3 col2\" >1.81</td>\n",
+       "      <td id=\"T_52cce_row3_col3\" class=\"data row3 col3\" >-1.96</td>\n",
+       "      <td id=\"T_52cce_row3_col4\" class=\"data row3 col4\" >1.63</td>\n",
+       "      <td id=\"T_52cce_row3_col5\" class=\"data row3 col5\" >2.32</td>\n",
+       "      <td id=\"T_52cce_row3_col6\" class=\"data row3 col6\" >3.25</td>\n",
+       "      <td id=\"T_52cce_row3_col7\" class=\"data row3 col7\" >8.98</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7dbe0e277620>"
+       "<pandas.io.formats.style.Styler at 0x78ccd988b4d0>"
       ]
      },
      "execution_count": 10,
@@ -954,13 +969,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dba6d4b",
+   "id": "8aec18ae",
    "metadata": {
     "papermill": {
-     "duration": 0.007441,
-     "end_time": "2026-09-08T23:42:30.633426+00:00",
+     "duration": 0.002767,
+     "end_time": "2026-09-08T23:58:59.465169+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.625985+00:00",
+     "start_time": "2026-09-08T23:58:59.462402+00:00",
      "status": "completed"
     }
    },
@@ -974,19 +989,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "6f0ccad9",
+   "id": "0c55e40b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:30.646846Z",
-     "iopub.status.busy": "2026-09-08T23:42:30.646611Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.072533Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.072286Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.471708Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.471495Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.546243Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.545532Z"
     },
     "papermill": {
-     "duration": 2.434388,
-     "end_time": "2026-09-08T23:42:33.073031+00:00",
+     "duration": 0.079268,
+     "end_time": "2026-09-08T23:58:59.547215+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:30.638643+00:00",
+     "start_time": "2026-09-08T23:58:59.467947+00:00",
      "status": "completed"
     }
    },
@@ -1017,13 +1032,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a89bbbb0",
+   "id": "886f8cba",
    "metadata": {
     "papermill": {
-     "duration": 0.009609,
-     "end_time": "2026-09-08T23:42:33.091510+00:00",
+     "duration": 0.005811,
+     "end_time": "2026-09-08T23:58:59.560219+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.081901+00:00",
+     "start_time": "2026-09-08T23:58:59.554408+00:00",
      "status": "completed"
     }
    },
@@ -1037,19 +1052,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "4bc916e3",
+   "id": "131a7c4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.120071Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.119934Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.138641Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.138184Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.572048Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.571914Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.580240Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.576976Z"
     },
     "papermill": {
-     "duration": 0.032248,
-     "end_time": "2026-09-08T23:42:33.142487+00:00",
+     "duration": 0.0153,
+     "end_time": "2026-09-08T23:58:59.580788+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.110239+00:00",
+     "start_time": "2026-09-08T23:58:59.565488+00:00",
      "status": "completed"
     }
    },
@@ -1059,14 +1074,14 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_a1df2\">\n",
+       "<table id=\"T_7a099\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_a1df2_level0_col0\" class=\"col_heading level0 col0\" >Unemployment rate (%)</th>\n",
-       "      <th id=\"T_a1df2_level0_col1\" class=\"col_heading level0 col1\" >Fed funds rate (%)</th>\n",
-       "      <th id=\"T_a1df2_level0_col2\" class=\"col_heading level0 col2\" >10Y minus 2Y Treasury (percentage points)</th>\n",
-       "      <th id=\"T_a1df2_level0_col3\" class=\"col_heading level0 col3\" >CPI, change over 12 months (%)</th>\n",
+       "      <th id=\"T_7a099_level0_col0\" class=\"col_heading level0 col0\" >Unemployment rate (%)</th>\n",
+       "      <th id=\"T_7a099_level0_col1\" class=\"col_heading level0 col1\" >Fed funds rate (%)</th>\n",
+       "      <th id=\"T_7a099_level0_col2\" class=\"col_heading level0 col2\" >10Y minus 2Y Treasury (percentage points)</th>\n",
+       "      <th id=\"T_7a099_level0_col3\" class=\"col_heading level0 col3\" >CPI, change over 12 months (%)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Cluster</th>\n",
@@ -1078,38 +1093,38 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_a1df2_level0_row0\" class=\"row_heading level0 row0\" >0</th>\n",
-       "      <td id=\"T_a1df2_row0_col0\" class=\"data row0 col0\" >4.34</td>\n",
-       "      <td id=\"T_a1df2_row0_col1\" class=\"data row0 col1\" >4.62</td>\n",
-       "      <td id=\"T_a1df2_row0_col2\" class=\"data row0 col2\" >0.02</td>\n",
-       "      <td id=\"T_a1df2_row0_col3\" class=\"data row0 col3\" >3.28</td>\n",
+       "      <th id=\"T_7a099_level0_row0\" class=\"row_heading level0 row0\" >0</th>\n",
+       "      <td id=\"T_7a099_row0_col0\" class=\"data row0 col0\" >4.34</td>\n",
+       "      <td id=\"T_7a099_row0_col1\" class=\"data row0 col1\" >4.62</td>\n",
+       "      <td id=\"T_7a099_row0_col2\" class=\"data row0 col2\" >0.02</td>\n",
+       "      <td id=\"T_7a099_row0_col3\" class=\"data row0 col3\" >3.28</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_a1df2_level0_row1\" class=\"row_heading level0 row1\" >1</th>\n",
-       "      <td id=\"T_a1df2_row1_col0\" class=\"data row1 col0\" >7.85</td>\n",
-       "      <td id=\"T_a1df2_row1_col1\" class=\"data row1 col1\" >0.11</td>\n",
-       "      <td id=\"T_a1df2_row1_col2\" class=\"data row1 col2\" >1.84</td>\n",
-       "      <td id=\"T_a1df2_row1_col3\" class=\"data row1 col3\" >1.47</td>\n",
+       "      <th id=\"T_7a099_level0_row1\" class=\"row_heading level0 row1\" >1</th>\n",
+       "      <td id=\"T_7a099_row1_col0\" class=\"data row1 col0\" >7.85</td>\n",
+       "      <td id=\"T_7a099_row1_col1\" class=\"data row1 col1\" >0.11</td>\n",
+       "      <td id=\"T_7a099_row1_col2\" class=\"data row1 col2\" >1.84</td>\n",
+       "      <td id=\"T_7a099_row1_col3\" class=\"data row1 col3\" >1.47</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_a1df2_level0_row2\" class=\"row_heading level0 row2\" >2</th>\n",
-       "      <td id=\"T_a1df2_row2_col0\" class=\"data row2 col0\" >4.19</td>\n",
-       "      <td id=\"T_a1df2_row2_col1\" class=\"data row2 col1\" >1.30</td>\n",
-       "      <td id=\"T_a1df2_row2_col2\" class=\"data row2 col2\" >0.61</td>\n",
-       "      <td id=\"T_a1df2_row2_col3\" class=\"data row2 col3\" >1.91</td>\n",
+       "      <th id=\"T_7a099_level0_row2\" class=\"row_heading level0 row2\" >2</th>\n",
+       "      <td id=\"T_7a099_row2_col0\" class=\"data row2 col0\" >4.19</td>\n",
+       "      <td id=\"T_7a099_row2_col1\" class=\"data row2 col1\" >1.30</td>\n",
+       "      <td id=\"T_7a099_row2_col2\" class=\"data row2 col2\" >0.61</td>\n",
+       "      <td id=\"T_7a099_row2_col3\" class=\"data row2 col3\" >1.91</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_a1df2_level0_row3\" class=\"row_heading level0 row3\" >3</th>\n",
-       "      <td id=\"T_a1df2_row3_col0\" class=\"data row3 col0\" >5.18</td>\n",
-       "      <td id=\"T_a1df2_row3_col1\" class=\"data row3 col1\" >1.43</td>\n",
-       "      <td id=\"T_a1df2_row3_col2\" class=\"data row3 col2\" >1.46</td>\n",
-       "      <td id=\"T_a1df2_row3_col3\" class=\"data row3 col3\" >4.39</td>\n",
+       "      <th id=\"T_7a099_level0_row3\" class=\"row_heading level0 row3\" >3</th>\n",
+       "      <td id=\"T_7a099_row3_col0\" class=\"data row3 col0\" >5.18</td>\n",
+       "      <td id=\"T_7a099_row3_col1\" class=\"data row3 col1\" >1.43</td>\n",
+       "      <td id=\"T_7a099_row3_col2\" class=\"data row3 col2\" >1.46</td>\n",
+       "      <td id=\"T_7a099_row3_col3\" class=\"data row3 col3\" >4.39</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7dbe0e2e6e90>"
+       "<pandas.io.formats.style.Styler at 0x78ccd98e6e90>"
       ]
      },
      "execution_count": 12,
@@ -1125,14 +1140,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ee0197e",
+   "id": "d00cf775",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007265,
-     "end_time": "2026-09-08T23:42:33.160806+00:00",
+     "duration": 0.005802,
+     "end_time": "2026-09-08T23:58:59.592397+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.153541+00:00",
+     "start_time": "2026-09-08T23:58:59.586595+00:00",
      "status": "completed"
     }
    },
@@ -1159,19 +1174,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "da6bc2d4",
+   "id": "bc645e98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.191108Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.190987Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.195198Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.194618Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.604957Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.604820Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.607882Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.607499Z"
     },
     "papermill": {
-     "duration": 0.015455,
-     "end_time": "2026-09-08T23:42:33.195509+00:00",
+     "duration": 0.010105,
+     "end_time": "2026-09-08T23:58:59.608468+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.180054+00:00",
+     "start_time": "2026-09-08T23:58:59.598363+00:00",
      "status": "completed"
     }
    },
@@ -1200,19 +1215,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "8567f41f",
+   "id": "92c75097",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.222920Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.222804Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.247014Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.246751Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.616140Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.616019Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.621883Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.621523Z"
     },
     "papermill": {
-     "duration": 0.04184,
-     "end_time": "2026-09-08T23:42:33.247649+00:00",
+     "duration": 0.010199,
+     "end_time": "2026-09-08T23:58:59.622185+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.205809+00:00",
+     "start_time": "2026-09-08T23:58:59.611986+00:00",
      "status": "completed"
     }
    },
@@ -1303,13 +1318,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e9a8541",
+   "id": "03141a46",
    "metadata": {
     "papermill": {
-     "duration": 0.019575,
-     "end_time": "2026-09-08T23:42:33.279667+00:00",
+     "duration": 0.003252,
+     "end_time": "2026-09-08T23:58:59.629396+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.260092+00:00",
+     "start_time": "2026-09-08T23:58:59.626144+00:00",
      "status": "completed"
     }
    },
@@ -1329,19 +1344,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "8ad09190",
+   "id": "9fc9967d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.314434Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.314316Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.350739Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.349755Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.636554Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.636442Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.652520Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.652016Z"
     },
     "papermill": {
-     "duration": 0.050652,
-     "end_time": "2026-09-08T23:42:33.351199+00:00",
+     "duration": 0.020412,
+     "end_time": "2026-09-08T23:58:59.652992+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.300547+00:00",
+     "start_time": "2026-09-08T23:58:59.632580+00:00",
      "status": "completed"
     }
    },
@@ -1371,13 +1386,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b7135c9",
+   "id": "ee0be104",
    "metadata": {
     "papermill": {
-     "duration": 0.007068,
-     "end_time": "2026-09-08T23:42:33.367649+00:00",
+     "duration": 0.00314,
+     "end_time": "2026-09-08T23:58:59.659886+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.360581+00:00",
+     "start_time": "2026-09-08T23:58:59.656746+00:00",
      "status": "completed"
     }
    },
@@ -1400,19 +1415,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "1db3be9d",
+   "id": "76862d75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.382082Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.381883Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.401607Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.398553Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.666976Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.666853Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.678775Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.678192Z"
     },
     "papermill": {
-     "duration": 0.027963,
-     "end_time": "2026-09-08T23:42:33.402261+00:00",
+     "duration": 0.016036,
+     "end_time": "2026-09-08T23:58:59.679126+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.374298+00:00",
+     "start_time": "2026-09-08T23:58:59.663090+00:00",
      "status": "completed"
     }
    },
@@ -1422,13 +1437,13 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_7e4ee\">\n",
+       "<table id=\"T_9dd4c\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_7e4ee_level0_col0\" class=\"col_heading level0 col0\" >Months</th>\n",
-       "      <th id=\"T_7e4ee_level0_col1\" class=\"col_heading level0 col1\" >Annualized volatility (%)</th>\n",
-       "      <th id=\"T_7e4ee_level0_col2\" class=\"col_heading level0 col2\" >Deepest index drawdown reached (%)</th>\n",
+       "      <th id=\"T_9dd4c_level0_col0\" class=\"col_heading level0 col0\" >Months</th>\n",
+       "      <th id=\"T_9dd4c_level0_col1\" class=\"col_heading level0 col1\" >Annualized volatility (%)</th>\n",
+       "      <th id=\"T_9dd4c_level0_col2\" class=\"col_heading level0 col2\" >Deepest index drawdown reached (%)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >regime</th>\n",
@@ -1439,34 +1454,34 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_7e4ee_level0_row0\" class=\"row_heading level0 row0\" >Tightening</th>\n",
-       "      <td id=\"T_7e4ee_row0_col0\" class=\"data row0 col0\" >72</td>\n",
-       "      <td id=\"T_7e4ee_row0_col1\" class=\"data row0 col1\" >10.4</td>\n",
-       "      <td id=\"T_7e4ee_row0_col2\" class=\"data row0 col2\" >19.4</td>\n",
+       "      <th id=\"T_9dd4c_level0_row0\" class=\"row_heading level0 row0\" >Tightening</th>\n",
+       "      <td id=\"T_9dd4c_row0_col0\" class=\"data row0 col0\" >72</td>\n",
+       "      <td id=\"T_9dd4c_row0_col1\" class=\"data row0 col1\" >10.4</td>\n",
+       "      <td id=\"T_9dd4c_row0_col2\" class=\"data row0 col2\" >19.4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_7e4ee_level0_row1\" class=\"row_heading level0 row1\" >Expansion</th>\n",
-       "      <td id=\"T_7e4ee_row1_col0\" class=\"data row1 col0\" >51</td>\n",
-       "      <td id=\"T_7e4ee_row1_col1\" class=\"data row1 col1\" >12.2</td>\n",
-       "      <td id=\"T_7e4ee_row1_col2\" class=\"data row1 col2\" >14.0</td>\n",
+       "      <th id=\"T_9dd4c_level0_row1\" class=\"row_heading level0 row1\" >Expansion</th>\n",
+       "      <td id=\"T_9dd4c_row1_col0\" class=\"data row1 col0\" >51</td>\n",
+       "      <td id=\"T_9dd4c_row1_col1\" class=\"data row1 col1\" >12.2</td>\n",
+       "      <td id=\"T_9dd4c_row1_col2\" class=\"data row1 col2\" >14.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_7e4ee_level0_row2\" class=\"row_heading level0 row2\" >Recovery</th>\n",
-       "      <td id=\"T_7e4ee_row2_col0\" class=\"data row2 col0\" >100</td>\n",
-       "      <td id=\"T_7e4ee_row2_col1\" class=\"data row2 col1\" >15.7</td>\n",
-       "      <td id=\"T_7e4ee_row2_col2\" class=\"data row2 col2\" >52.6</td>\n",
+       "      <th id=\"T_9dd4c_level0_row2\" class=\"row_heading level0 row2\" >Recovery</th>\n",
+       "      <td id=\"T_9dd4c_row2_col0\" class=\"data row2 col0\" >100</td>\n",
+       "      <td id=\"T_9dd4c_row2_col1\" class=\"data row2 col1\" >15.7</td>\n",
+       "      <td id=\"T_9dd4c_row2_col2\" class=\"data row2 col2\" >52.6</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_7e4ee_level0_row3\" class=\"row_heading level0 row3\" >Inflation</th>\n",
-       "      <td id=\"T_7e4ee_row3_col0\" class=\"data row3 col0\" >53</td>\n",
-       "      <td id=\"T_7e4ee_row3_col1\" class=\"data row3 col1\" >17.7</td>\n",
-       "      <td id=\"T_7e4ee_row3_col2\" class=\"data row3 col2\" >42.2</td>\n",
+       "      <th id=\"T_9dd4c_level0_row3\" class=\"row_heading level0 row3\" >Inflation</th>\n",
+       "      <td id=\"T_9dd4c_row3_col0\" class=\"data row3 col0\" >53</td>\n",
+       "      <td id=\"T_9dd4c_row3_col1\" class=\"data row3 col1\" >17.7</td>\n",
+       "      <td id=\"T_9dd4c_row3_col2\" class=\"data row3 col2\" >42.2</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7dbe0c0b0690>"
+       "<pandas.io.formats.style.Styler at 0x78ccd80c07d0>"
       ]
      },
      "execution_count": 16,
@@ -1501,13 +1516,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35c4ebb9",
+   "id": "5bd996c4",
    "metadata": {
     "papermill": {
-     "duration": 0.006797,
-     "end_time": "2026-09-08T23:42:33.416267+00:00",
+     "duration": 0.002979,
+     "end_time": "2026-09-08T23:58:59.685492+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.409470+00:00",
+     "start_time": "2026-09-08T23:58:59.682513+00:00",
      "status": "completed"
     }
    },
@@ -1523,19 +1538,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "024828f3",
+   "id": "e0be252c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.431367Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.431176Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.439888Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.439307Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.692331Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.692219Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.694521Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.693980Z"
     },
     "papermill": {
-     "duration": 0.020957,
-     "end_time": "2026-09-08T23:42:33.443057+00:00",
+     "duration": 0.006422,
+     "end_time": "2026-09-08T23:58:59.694913+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.422100+00:00",
+     "start_time": "2026-09-08T23:58:59.688491+00:00",
      "status": "completed"
     }
    },
@@ -1548,19 +1563,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "d260f07f",
+   "id": "c6a988be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.459402Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.458715Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.463516Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.462874Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.701607Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.701510Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.703698Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.703381Z"
     },
     "papermill": {
-     "duration": 0.012393,
-     "end_time": "2026-09-08T23:42:33.464416+00:00",
+     "duration": 0.006228,
+     "end_time": "2026-09-08T23:58:59.704110+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.452023+00:00",
+     "start_time": "2026-09-08T23:58:59.697882+00:00",
      "status": "completed"
     }
    },
@@ -1576,19 +1591,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "b178fd97",
+   "id": "c0ea14ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.484562Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.484390Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.487968Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.487640Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.711653Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.711539Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.714145Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.713684Z"
     },
     "papermill": {
-     "duration": 0.011603,
-     "end_time": "2026-09-08T23:42:33.488886+00:00",
+     "duration": 0.007044,
+     "end_time": "2026-09-08T23:58:59.714539+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.477283+00:00",
+     "start_time": "2026-09-08T23:58:59.707495+00:00",
      "status": "completed"
     }
    },
@@ -1607,19 +1622,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "e39c9b58",
+   "id": "edb9fdac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.510553Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.510385Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.517760Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.517359Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.721999Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.721891Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.724462Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.724031Z"
     },
     "papermill": {
-     "duration": 0.02573,
-     "end_time": "2026-09-08T23:42:33.520379+00:00",
+     "duration": 0.00692,
+     "end_time": "2026-09-08T23:58:59.724917+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.494649+00:00",
+     "start_time": "2026-09-08T23:58:59.717997+00:00",
      "status": "completed"
     }
    },
@@ -1639,19 +1654,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "80bb93ad",
+   "id": "333adc38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.533336Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.533160Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.539538Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.538609Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.732987Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.732804Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.735823Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.735389Z"
     },
     "papermill": {
-     "duration": 0.013648,
-     "end_time": "2026-09-08T23:42:33.540045+00:00",
+     "duration": 0.007753,
+     "end_time": "2026-09-08T23:58:59.736209+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.526397+00:00",
+     "start_time": "2026-09-08T23:58:59.728456+00:00",
      "status": "completed"
     }
    },
@@ -1678,19 +1693,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "d4228d24",
+   "id": "07b0e27e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.561704Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.561526Z",
-     "iopub.status.idle": "2026-09-08T23:42:33.569356Z",
-     "shell.execute_reply": "2026-09-08T23:42:33.568927Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.743293Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.743175Z",
+     "iopub.status.idle": "2026-09-08T23:58:59.746070Z",
+     "shell.execute_reply": "2026-09-08T23:58:59.745647Z"
     },
     "papermill": {
-     "duration": 0.017598,
-     "end_time": "2026-09-08T23:42:33.570111+00:00",
+     "duration": 0.006917,
+     "end_time": "2026-09-08T23:58:59.746419+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.552513+00:00",
+     "start_time": "2026-09-08T23:58:59.739502+00:00",
      "status": "completed"
     }
    },
@@ -1718,19 +1733,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "6c4d149a",
+   "id": "d976ea26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:33.589078Z",
-     "iopub.status.busy": "2026-09-08T23:42:33.588907Z",
-     "iopub.status.idle": "2026-09-08T23:42:34.529831Z",
-     "shell.execute_reply": "2026-09-08T23:42:34.529160Z"
+     "iopub.execute_input": "2026-09-08T23:58:59.754079Z",
+     "iopub.status.busy": "2026-09-08T23:58:59.753978Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.160015Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.159481Z"
     },
     "papermill": {
-     "duration": 0.95459,
-     "end_time": "2026-09-08T23:42:34.532536+00:00",
+     "duration": 0.410495,
+     "end_time": "2026-09-08T23:59:00.160335+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:33.577946+00:00",
+     "start_time": "2026-09-08T23:58:59.749840+00:00",
      "status": "completed"
     }
    },
@@ -1784,13 +1799,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57464adc",
+   "id": "1ae10e6a",
    "metadata": {
     "papermill": {
-     "duration": 0.006255,
-     "end_time": "2026-09-08T23:42:34.547370+00:00",
+     "duration": 0.003052,
+     "end_time": "2026-09-08T23:59:00.166627+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:34.541115+00:00",
+     "start_time": "2026-09-08T23:59:00.163575+00:00",
      "status": "completed"
     }
    },
@@ -1805,19 +1820,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "97bc0b97",
+   "id": "848a9721",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:34.560987Z",
-     "iopub.status.busy": "2026-09-08T23:42:34.560816Z",
-     "iopub.status.idle": "2026-09-08T23:42:34.570794Z",
-     "shell.execute_reply": "2026-09-08T23:42:34.570166Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.174318Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.174173Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.179933Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.179263Z"
     },
     "papermill": {
-     "duration": 0.0196,
-     "end_time": "2026-09-08T23:42:34.573246+00:00",
+     "duration": 0.010478,
+     "end_time": "2026-09-08T23:59:00.180266+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:34.553646+00:00",
+     "start_time": "2026-09-08T23:59:00.169788+00:00",
      "status": "completed"
     }
    },
@@ -1865,13 +1880,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f276579b",
+   "id": "7bec8250",
    "metadata": {
     "papermill": {
-     "duration": 0.013652,
-     "end_time": "2026-09-08T23:42:34.602282+00:00",
+     "duration": 0.003011,
+     "end_time": "2026-09-08T23:59:00.186395+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:34.588630+00:00",
+     "start_time": "2026-09-08T23:59:00.183384+00:00",
      "status": "completed"
     }
    },
@@ -1897,14 +1912,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5232cc1",
+   "id": "e24ac83a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006946,
-     "end_time": "2026-09-08T23:42:34.616541+00:00",
+     "duration": 0.003537,
+     "end_time": "2026-09-08T23:59:00.193110+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:34.609595+00:00",
+     "start_time": "2026-09-08T23:59:00.189573+00:00",
      "status": "completed"
     }
    },
@@ -1929,19 +1944,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "c67c2b6e",
+   "id": "b4b6d0f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:34.635696Z",
-     "iopub.status.busy": "2026-09-08T23:42:34.635524Z",
-     "iopub.status.idle": "2026-09-08T23:42:34.646500Z",
-     "shell.execute_reply": "2026-09-08T23:42:34.639268Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.200177Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.200006Z",
+     "iopub.status.idle": "2026-09-08T23:59:00.203662Z",
+     "shell.execute_reply": "2026-09-08T23:59:00.202323Z"
     },
     "papermill": {
-     "duration": 0.024426,
-     "end_time": "2026-09-08T23:42:34.649846+00:00",
+     "duration": 0.007933,
+     "end_time": "2026-09-08T23:59:00.204139+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:34.625420+00:00",
+     "start_time": "2026-09-08T23:59:00.196206+00:00",
      "status": "completed"
     }
    },
@@ -1965,19 +1980,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "08aee56b",
+   "id": "3fc14091",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:34.682259Z",
-     "iopub.status.busy": "2026-09-08T23:42:34.682070Z",
-     "iopub.status.idle": "2026-09-08T23:42:51.304241Z",
-     "shell.execute_reply": "2026-09-08T23:42:51.303582Z"
+     "iopub.execute_input": "2026-09-08T23:59:00.211854Z",
+     "iopub.status.busy": "2026-09-08T23:59:00.211755Z",
+     "iopub.status.idle": "2026-09-08T23:59:01.024427Z",
+     "shell.execute_reply": "2026-09-08T23:59:01.024011Z"
     },
     "papermill": {
-     "duration": 16.636133,
-     "end_time": "2026-09-08T23:42:51.304708+00:00",
+     "duration": 0.822625,
+     "end_time": "2026-09-08T23:59:01.030222+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:34.668575+00:00",
+     "start_time": "2026-09-08T23:59:00.207597+00:00",
      "status": "completed"
     }
    },
@@ -1987,13 +2002,13 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_ba18c\">\n",
+       "<table id=\"T_30913\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_ba18c_level0_col0\" class=\"col_heading level0 col0\" >Agreement with the fit above</th>\n",
-       "      <th id=\"T_ba18c_level0_col1\" class=\"col_heading level0 col1\" >Silhouette</th>\n",
-       "      <th id=\"T_ba18c_level0_col2\" class=\"col_heading level0 col2\" >Smallest cluster (months)</th>\n",
+       "      <th id=\"T_30913_level0_col0\" class=\"col_heading level0 col0\" >Agreement with the fit above</th>\n",
+       "      <th id=\"T_30913_level0_col1\" class=\"col_heading level0 col1\" >Silhouette</th>\n",
+       "      <th id=\"T_30913_level0_col2\" class=\"col_heading level0 col2\" >Smallest cluster (months)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Change</th>\n",
@@ -2004,58 +2019,58 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_ba18c_level0_row0\" class=\"row_heading level0 row0\" >random start 0</th>\n",
-       "      <td id=\"T_ba18c_row0_col0\" class=\"data row0 col0\" >1.00</td>\n",
-       "      <td id=\"T_ba18c_row0_col1\" class=\"data row0 col1\" >0.327</td>\n",
-       "      <td id=\"T_ba18c_row0_col2\" class=\"data row0 col2\" >51</td>\n",
+       "      <th id=\"T_30913_level0_row0\" class=\"row_heading level0 row0\" >random start 0</th>\n",
+       "      <td id=\"T_30913_row0_col0\" class=\"data row0 col0\" >1.00</td>\n",
+       "      <td id=\"T_30913_row0_col1\" class=\"data row0 col1\" >0.327</td>\n",
+       "      <td id=\"T_30913_row0_col2\" class=\"data row0 col2\" >51</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ba18c_level0_row1\" class=\"row_heading level0 row1\" >random start 7</th>\n",
-       "      <td id=\"T_ba18c_row1_col0\" class=\"data row1 col0\" >0.79</td>\n",
-       "      <td id=\"T_ba18c_row1_col1\" class=\"data row1 col1\" >0.320</td>\n",
-       "      <td id=\"T_ba18c_row1_col2\" class=\"data row1 col2\" >16</td>\n",
+       "      <th id=\"T_30913_level0_row1\" class=\"row_heading level0 row1\" >random start 7</th>\n",
+       "      <td id=\"T_30913_row1_col0\" class=\"data row1 col0\" >0.79</td>\n",
+       "      <td id=\"T_30913_row1_col1\" class=\"data row1 col1\" >0.320</td>\n",
+       "      <td id=\"T_30913_row1_col2\" class=\"data row1 col2\" >16</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ba18c_level0_row2\" class=\"row_heading level0 row2\" >random start 123</th>\n",
-       "      <td id=\"T_ba18c_row2_col0\" class=\"data row2 col0\" >0.79</td>\n",
-       "      <td id=\"T_ba18c_row2_col1\" class=\"data row2 col1\" >0.320</td>\n",
-       "      <td id=\"T_ba18c_row2_col2\" class=\"data row2 col2\" >16</td>\n",
+       "      <th id=\"T_30913_level0_row2\" class=\"row_heading level0 row2\" >random start 123</th>\n",
+       "      <td id=\"T_30913_row2_col0\" class=\"data row2 col0\" >0.79</td>\n",
+       "      <td id=\"T_30913_row2_col1\" class=\"data row2 col1\" >0.320</td>\n",
+       "      <td id=\"T_30913_row2_col2\" class=\"data row2 col2\" >16</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ba18c_level0_row3\" class=\"row_heading level0 row3\" >random start 2024</th>\n",
-       "      <td id=\"T_ba18c_row3_col0\" class=\"data row3 col0\" >0.81</td>\n",
-       "      <td id=\"T_ba18c_row3_col1\" class=\"data row3 col1\" >0.308</td>\n",
-       "      <td id=\"T_ba18c_row3_col2\" class=\"data row3 col2\" >20</td>\n",
+       "      <th id=\"T_30913_level0_row3\" class=\"row_heading level0 row3\" >random start 2024</th>\n",
+       "      <td id=\"T_30913_row3_col0\" class=\"data row3 col0\" >0.81</td>\n",
+       "      <td id=\"T_30913_row3_col1\" class=\"data row3 col1\" >0.308</td>\n",
+       "      <td id=\"T_30913_row3_col2\" class=\"data row3 col2\" >20</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ba18c_level0_row4\" class=\"row_heading level0 row4\" >drop first 1 months</th>\n",
-       "      <td id=\"T_ba18c_row4_col0\" class=\"data row4 col0\" >0.79</td>\n",
-       "      <td id=\"T_ba18c_row4_col1\" class=\"data row4 col1\" >0.321</td>\n",
-       "      <td id=\"T_ba18c_row4_col2\" class=\"data row4 col2\" >16</td>\n",
+       "      <th id=\"T_30913_level0_row4\" class=\"row_heading level0 row4\" >drop first 1 months</th>\n",
+       "      <td id=\"T_30913_row4_col0\" class=\"data row4 col0\" >0.79</td>\n",
+       "      <td id=\"T_30913_row4_col1\" class=\"data row4 col1\" >0.321</td>\n",
+       "      <td id=\"T_30913_row4_col2\" class=\"data row4 col2\" >16</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ba18c_level0_row5\" class=\"row_heading level0 row5\" >drop first 3 months</th>\n",
-       "      <td id=\"T_ba18c_row5_col0\" class=\"data row5 col0\" >0.73</td>\n",
-       "      <td id=\"T_ba18c_row5_col1\" class=\"data row5 col1\" >0.255</td>\n",
-       "      <td id=\"T_ba18c_row5_col2\" class=\"data row5 col2\" >4</td>\n",
+       "      <th id=\"T_30913_level0_row5\" class=\"row_heading level0 row5\" >drop first 3 months</th>\n",
+       "      <td id=\"T_30913_row5_col0\" class=\"data row5 col0\" >0.73</td>\n",
+       "      <td id=\"T_30913_row5_col1\" class=\"data row5 col1\" >0.255</td>\n",
+       "      <td id=\"T_30913_row5_col2\" class=\"data row5 col2\" >4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ba18c_level0_row6\" class=\"row_heading level0 row6\" >drop first 6 months</th>\n",
-       "      <td id=\"T_ba18c_row6_col0\" class=\"data row6 col0\" >0.82</td>\n",
-       "      <td id=\"T_ba18c_row6_col1\" class=\"data row6 col1\" >0.323</td>\n",
-       "      <td id=\"T_ba18c_row6_col2\" class=\"data row6 col2\" >20</td>\n",
+       "      <th id=\"T_30913_level0_row6\" class=\"row_heading level0 row6\" >drop first 6 months</th>\n",
+       "      <td id=\"T_30913_row6_col0\" class=\"data row6 col0\" >0.82</td>\n",
+       "      <td id=\"T_30913_row6_col1\" class=\"data row6 col1\" >0.323</td>\n",
+       "      <td id=\"T_30913_row6_col2\" class=\"data row6 col2\" >20</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_ba18c_level0_row7\" class=\"row_heading level0 row7\" >drop first 12 months</th>\n",
-       "      <td id=\"T_ba18c_row7_col0\" class=\"data row7 col0\" >0.77</td>\n",
-       "      <td id=\"T_ba18c_row7_col1\" class=\"data row7 col1\" >0.291</td>\n",
-       "      <td id=\"T_ba18c_row7_col2\" class=\"data row7 col2\" >4</td>\n",
+       "      <th id=\"T_30913_level0_row7\" class=\"row_heading level0 row7\" >drop first 12 months</th>\n",
+       "      <td id=\"T_30913_row7_col0\" class=\"data row7 col0\" >0.77</td>\n",
+       "      <td id=\"T_30913_row7_col1\" class=\"data row7 col1\" >0.291</td>\n",
+       "      <td id=\"T_30913_row7_col2\" class=\"data row7 col2\" >4</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7dbdeeb51d10>"
+       "<pandas.io.formats.style.Styler at 0x78ccc4f51e50>"
       ]
      },
      "execution_count": 26,
@@ -2092,19 +2107,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "fcf0adf5",
+   "id": "55ac678c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:51.369797Z",
-     "iopub.status.busy": "2026-09-08T23:42:51.369601Z",
-     "iopub.status.idle": "2026-09-08T23:42:51.383607Z",
-     "shell.execute_reply": "2026-09-08T23:42:51.382653Z"
+     "iopub.execute_input": "2026-09-08T23:59:01.041759Z",
+     "iopub.status.busy": "2026-09-08T23:59:01.041630Z",
+     "iopub.status.idle": "2026-09-08T23:59:01.045151Z",
+     "shell.execute_reply": "2026-09-08T23:59:01.044533Z"
     },
     "papermill": {
-     "duration": 0.056344,
-     "end_time": "2026-09-08T23:42:51.384118+00:00",
+     "duration": 0.009961,
+     "end_time": "2026-09-08T23:59:01.045557+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.327774+00:00",
+     "start_time": "2026-09-08T23:59:01.035596+00:00",
      "status": "completed"
     }
    },
@@ -2136,13 +2151,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d1b84d4",
+   "id": "144617c2",
    "metadata": {
     "papermill": {
-     "duration": 0.007138,
-     "end_time": "2026-09-08T23:42:51.399348+00:00",
+     "duration": 0.005359,
+     "end_time": "2026-09-08T23:59:01.056922+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.392210+00:00",
+     "start_time": "2026-09-08T23:59:01.051563+00:00",
      "status": "completed"
     }
    },
@@ -2165,13 +2180,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81440803",
+   "id": "f2c90274",
    "metadata": {
     "papermill": {
-     "duration": 0.006856,
-     "end_time": "2026-09-08T23:42:51.413452+00:00",
+     "duration": 0.00522,
+     "end_time": "2026-09-08T23:59:01.068159+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.406596+00:00",
+     "start_time": "2026-09-08T23:59:01.062939+00:00",
      "status": "completed"
     }
    },
@@ -2187,19 +2202,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "26e7feaf",
+   "id": "fac036b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:51.429744Z",
-     "iopub.status.busy": "2026-09-08T23:42:51.429552Z",
-     "iopub.status.idle": "2026-09-08T23:42:51.440608Z",
-     "shell.execute_reply": "2026-09-08T23:42:51.439278Z"
+     "iopub.execute_input": "2026-09-08T23:59:01.082520Z",
+     "iopub.status.busy": "2026-09-08T23:59:01.082392Z",
+     "iopub.status.idle": "2026-09-08T23:59:01.087678Z",
+     "shell.execute_reply": "2026-09-08T23:59:01.087310Z"
     },
     "papermill": {
-     "duration": 0.020195,
-     "end_time": "2026-09-08T23:42:51.441145+00:00",
+     "duration": 0.015027,
+     "end_time": "2026-09-08T23:59:01.088360+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.420950+00:00",
+     "start_time": "2026-09-08T23:59:01.073333+00:00",
      "status": "completed"
     }
    },
@@ -2227,13 +2242,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a2e990d",
+   "id": "c2aa96ba",
    "metadata": {
     "papermill": {
-     "duration": 0.01717,
-     "end_time": "2026-09-08T23:42:51.470234+00:00",
+     "duration": 0.007133,
+     "end_time": "2026-09-08T23:59:01.104064+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.453064+00:00",
+     "start_time": "2026-09-08T23:59:01.096931+00:00",
      "status": "completed"
     }
    },
@@ -2251,19 +2266,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "bef5f695",
+   "id": "18fe86fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:51.500436Z",
-     "iopub.status.busy": "2026-09-08T23:42:51.497510Z",
-     "iopub.status.idle": "2026-09-08T23:42:51.778197Z",
-     "shell.execute_reply": "2026-09-08T23:42:51.774114Z"
+     "iopub.execute_input": "2026-09-08T23:59:01.118632Z",
+     "iopub.status.busy": "2026-09-08T23:59:01.118456Z",
+     "iopub.status.idle": "2026-09-08T23:59:01.286547Z",
+     "shell.execute_reply": "2026-09-08T23:59:01.286022Z"
     },
     "papermill": {
-     "duration": 0.295531,
-     "end_time": "2026-09-08T23:42:51.778751+00:00",
+     "duration": 0.176051,
+     "end_time": "2026-09-08T23:59:01.286874+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.483220+00:00",
+     "start_time": "2026-09-08T23:59:01.110823+00:00",
      "status": "completed"
     }
    },
@@ -2319,13 +2334,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fd4794a",
+   "id": "ef0a040b",
    "metadata": {
     "papermill": {
-     "duration": 0.014799,
-     "end_time": "2026-09-08T23:42:51.804322+00:00",
+     "duration": 0.00525,
+     "end_time": "2026-09-08T23:59:01.297795+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.789523+00:00",
+     "start_time": "2026-09-08T23:59:01.292545+00:00",
      "status": "completed"
     }
    },
@@ -2345,13 +2360,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a42eb33c",
+   "id": "cafd31d9",
    "metadata": {
     "papermill": {
-     "duration": 0.013016,
-     "end_time": "2026-09-08T23:42:51.830509+00:00",
+     "duration": 0.005258,
+     "end_time": "2026-09-08T23:59:01.308329+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.817493+00:00",
+     "start_time": "2026-09-08T23:59:01.303071+00:00",
      "status": "completed"
     }
    },
@@ -2370,19 +2385,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "f2f7b6ae",
+   "id": "100a9a9b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:51.874423Z",
-     "iopub.status.busy": "2026-09-08T23:42:51.874247Z",
-     "iopub.status.idle": "2026-09-08T23:42:51.908621Z",
-     "shell.execute_reply": "2026-09-08T23:42:51.908186Z"
+     "iopub.execute_input": "2026-09-08T23:59:01.320048Z",
+     "iopub.status.busy": "2026-09-08T23:59:01.319889Z",
+     "iopub.status.idle": "2026-09-08T23:59:01.336381Z",
+     "shell.execute_reply": "2026-09-08T23:59:01.335899Z"
     },
     "papermill": {
-     "duration": 0.058413,
-     "end_time": "2026-09-08T23:42:51.909678+00:00",
+     "duration": 0.02315,
+     "end_time": "2026-09-08T23:59:01.336892+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.851265+00:00",
+     "start_time": "2026-09-08T23:59:01.313742+00:00",
      "status": "completed"
     }
    },
@@ -2432,45 +2447,80 @@
   },
   {
    "cell_type": "markdown",
-   "id": "960b69cd",
+   "id": "24cea05a",
    "metadata": {
+    "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006938,
-     "end_time": "2026-09-08T23:42:51.923707+00:00",
+     "duration": 0.004881,
+     "end_time": "2026-09-08T23:59:01.347333+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.916769+00:00",
+     "start_time": "2026-09-08T23:59:01.342452+00:00",
      "status": "completed"
     }
    },
    "source": [
     "### What the filter let through\n",
     "\n",
-    "Nothing in that assembly asked what the columns are, and the metadata table at the top of\n",
-    "the notebook says what got in. Nine of the columns are Treasury yields at maturities from\n",
-    "one to thirty years, which move almost as one series. `YIELD_CURVE_SLOPE` is defined as the\n",
-    "ten-year yield minus the two-year, which is the definition of `t10y2y`, already in the\n",
-    "panel - the same spread enters twice under two names. Nominal and real GDP are both\n",
-    "present, published quarterly, so each repeats its value for three months at a time. And\n",
-    "three price indices enter as levels, which is the treatment the core panel rejected for one\n",
-    "of them."
+    "Nothing in that assembly asked what the columns are, and the metadata table at the top of the\n",
+    "notebook says what got in: Treasury yields at maturities from one to thirty years, which move\n",
+    "almost as one series; a derived column whose formula is the ten-year yield minus the two-year,\n",
+    "which is the definition of a series already in the panel under its own name; nominal and real\n",
+    "GDP, published quarterly, so each repeats a value for three months at a time; and three price\n",
+    "indices entering as levels, which is the treatment the core panel rejected for one of them.\n",
+    "\n",
+    "Two of those are checkable without reading the metadata at all. Columns holding the same\n",
+    "series differ by nothing anywhere in the panel, and a series published quarterly and carried\n",
+    "forward to a monthly grid is unchanged from the previous month in two months out of three."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "e43d11ef",
+   "id": "1bf11650",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:51.940863Z",
-     "iopub.status.busy": "2026-09-08T23:42:51.940647Z",
-     "iopub.status.idle": "2026-09-08T23:42:51.946452Z",
-     "shell.execute_reply": "2026-09-08T23:42:51.946025Z"
+     "iopub.execute_input": "2026-09-08T23:59:01.355106Z",
+     "iopub.status.busy": "2026-09-08T23:59:01.354984Z",
+     "iopub.status.idle": "2026-09-08T23:59:01.357822Z",
+     "shell.execute_reply": "2026-09-08T23:59:01.357291Z"
     },
     "papermill": {
-     "duration": 0.015998,
-     "end_time": "2026-09-08T23:42:51.947408+00:00",
+     "duration": 0.007329,
+     "end_time": "2026-09-08T23:59:01.358180+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.931410+00:00",
+     "start_time": "2026-09-08T23:59:01.350851+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def duplicate_pairs(frame: pd.DataFrame, tolerance: float = 1e-9) -> list[tuple[str, str]]:\n",
+    "    \"\"\"Column pairs that hold the same standardized series to within *tolerance*.\"\"\"\n",
+    "    columns = list(frame.columns)\n",
+    "    return [\n",
+    "        (a, b)\n",
+    "        for i, a in enumerate(columns)\n",
+    "        for b in columns[i + 1 :]\n",
+    "        if float((frame[a] - frame[b]).abs().max()) < tolerance\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "89a4c23c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:59:01.366006Z",
+     "iopub.status.busy": "2026-09-08T23:59:01.365869Z",
+     "iopub.status.idle": "2026-09-08T23:59:01.397126Z",
+     "shell.execute_reply": "2026-09-08T23:59:01.396669Z"
+    },
+    "papermill": {
+     "duration": 0.035672,
+     "end_time": "2026-09-08T23:59:01.397607+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:59:01.361935+00:00",
      "status": "completed"
     }
    },
@@ -2478,7 +2528,7 @@
     {
      "data": {
       "text/markdown": [
-       "The largest gap between `t10y2y` and `YIELD_CURVE_SLOPE` anywhere in the panel is **7.8e-16** after standardization, and nominal GDP takes **92 distinct values** across **276 monthly rows**."
+       "Comparing every pair of columns finds **1** holding the same standardized series: `t10y2y` and `YIELD_CURVE_SLOPE`. The column that repeats itself most is `gdp`, unchanged from the month before in **67%** of the panel."
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -2489,26 +2539,28 @@
     }
    ],
    "source": [
-    "duplicate_check = (extended_df[\"t10y2y\"] - extended_df[\"YIELD_CURVE_SLOPE\"]).abs().max()\n",
-    "gdp_distinct = int(extended_df[\"gdp\"].round(6).nunique())\n",
+    "duplicates = duplicate_pairs(extended_df)\n",
+    "carried_forward = (extended_df.diff() == 0).mean().sort_values(ascending=False)\n",
+    "stalest = str(carried_forward.index[0])\n",
     "display(\n",
     "    Markdown(\n",
-    "        f\"The largest gap between `t10y2y` and `YIELD_CURVE_SLOPE` anywhere in the panel is \"\n",
-    "        f\"**{duplicate_check:.1e}** after standardization, and nominal GDP takes \"\n",
-    "        f\"**{gdp_distinct} distinct values** across **{len(extended_df)} monthly rows**.\"\n",
+    "        f\"Comparing every pair of columns finds **{len(duplicates)}** holding the same \"\n",
+    "        f\"standardized series: {', '.join(f'`{a}` and `{b}`' for a, b in duplicates) or 'none'}. \"\n",
+    "        f\"The column that repeats itself most is `{stalest}`, unchanged from the month before \"\n",
+    "        f\"in **{carried_forward.iloc[0]:.0%}** of the panel.\"\n",
     "    )\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ac164797",
+   "id": "0251bf0c",
    "metadata": {
     "papermill": {
-     "duration": 0.011139,
-     "end_time": "2026-09-08T23:42:51.966782+00:00",
+     "duration": 0.006368,
+     "end_time": "2026-09-08T23:59:01.410545+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.955643+00:00",
+     "start_time": "2026-09-08T23:59:01.404177+00:00",
      "status": "completed"
     }
    },
@@ -2521,20 +2573,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "id": "07466752",
+   "execution_count": 33,
+   "id": "97e8eca4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:51.990711Z",
-     "iopub.status.busy": "2026-09-08T23:42:51.990456Z",
-     "iopub.status.idle": "2026-09-08T23:42:56.950963Z",
-     "shell.execute_reply": "2026-09-08T23:42:56.947155Z"
+     "iopub.execute_input": "2026-09-08T23:59:01.424035Z",
+     "iopub.status.busy": "2026-09-08T23:59:01.423855Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.085742Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.085263Z"
     },
     "papermill": {
-     "duration": 4.973071,
-     "end_time": "2026-09-08T23:42:56.951512+00:00",
+     "duration": 1.669381,
+     "end_time": "2026-09-08T23:59:03.086236+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:51.978441+00:00",
+     "start_time": "2026-09-08T23:59:01.416855+00:00",
      "status": "completed"
     }
    },
@@ -2588,13 +2640,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "250779f1",
+   "id": "f61d6bf4",
    "metadata": {
     "papermill": {
-     "duration": 0.015937,
-     "end_time": "2026-09-08T23:42:56.990184+00:00",
+     "duration": 0.003851,
+     "end_time": "2026-09-08T23:59:03.095185+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:56.974247+00:00",
+     "start_time": "2026-09-08T23:59:03.091334+00:00",
      "status": "completed"
     }
    },
@@ -2608,20 +2660,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "f8581794",
+   "execution_count": 34,
+   "id": "3fe3e193",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:57.031750Z",
-     "iopub.status.busy": "2026-09-08T23:42:57.031623Z",
-     "iopub.status.idle": "2026-09-08T23:42:57.051392Z",
-     "shell.execute_reply": "2026-09-08T23:42:57.044256Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.103904Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.103786Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.111350Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.110825Z"
     },
     "papermill": {
-     "duration": 0.035391,
-     "end_time": "2026-09-08T23:42:57.052312+00:00",
+     "duration": 0.01253,
+     "end_time": "2026-09-08T23:59:03.111698+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:57.016921+00:00",
+     "start_time": "2026-09-08T23:59:03.099168+00:00",
      "status": "completed"
     }
    },
@@ -2631,12 +2683,12 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_14d75\">\n",
+       "<table id=\"T_5059f\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_14d75_level0_col0\" class=\"col_heading level0 col0\" >Share of variance</th>\n",
-       "      <th id=\"T_14d75_level0_col1\" class=\"col_heading level0 col1\" >Cumulative</th>\n",
+       "      <th id=\"T_5059f_level0_col0\" class=\"col_heading level0 col0\" >Share of variance</th>\n",
+       "      <th id=\"T_5059f_level0_col1\" class=\"col_heading level0 col1\" >Cumulative</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Component</th>\n",
@@ -2646,63 +2698,63 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row0\" class=\"row_heading level0 row0\" >PC1</th>\n",
-       "      <td id=\"T_14d75_row0_col0\" class=\"data row0 col0\" >45.6%</td>\n",
-       "      <td id=\"T_14d75_row0_col1\" class=\"data row0 col1\" >45.6%</td>\n",
+       "      <th id=\"T_5059f_level0_row0\" class=\"row_heading level0 row0\" >PC1</th>\n",
+       "      <td id=\"T_5059f_row0_col0\" class=\"data row0 col0\" >45.6%</td>\n",
+       "      <td id=\"T_5059f_row0_col1\" class=\"data row0 col1\" >45.6%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row1\" class=\"row_heading level0 row1\" >PC2</th>\n",
-       "      <td id=\"T_14d75_row1_col0\" class=\"data row1 col0\" >34.8%</td>\n",
-       "      <td id=\"T_14d75_row1_col1\" class=\"data row1 col1\" >80.3%</td>\n",
+       "      <th id=\"T_5059f_level0_row1\" class=\"row_heading level0 row1\" >PC2</th>\n",
+       "      <td id=\"T_5059f_row1_col0\" class=\"data row1 col0\" >34.8%</td>\n",
+       "      <td id=\"T_5059f_row1_col1\" class=\"data row1 col1\" >80.3%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row2\" class=\"row_heading level0 row2\" >PC3</th>\n",
-       "      <td id=\"T_14d75_row2_col0\" class=\"data row2 col0\" >7.5%</td>\n",
-       "      <td id=\"T_14d75_row2_col1\" class=\"data row2 col1\" >87.9%</td>\n",
+       "      <th id=\"T_5059f_level0_row2\" class=\"row_heading level0 row2\" >PC3</th>\n",
+       "      <td id=\"T_5059f_row2_col0\" class=\"data row2 col0\" >7.5%</td>\n",
+       "      <td id=\"T_5059f_row2_col1\" class=\"data row2 col1\" >87.9%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row3\" class=\"row_heading level0 row3\" >PC4</th>\n",
-       "      <td id=\"T_14d75_row3_col0\" class=\"data row3 col0\" >5.8%</td>\n",
-       "      <td id=\"T_14d75_row3_col1\" class=\"data row3 col1\" >93.6%</td>\n",
+       "      <th id=\"T_5059f_level0_row3\" class=\"row_heading level0 row3\" >PC4</th>\n",
+       "      <td id=\"T_5059f_row3_col0\" class=\"data row3 col0\" >5.8%</td>\n",
+       "      <td id=\"T_5059f_row3_col1\" class=\"data row3 col1\" >93.6%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row4\" class=\"row_heading level0 row4\" >PC5</th>\n",
-       "      <td id=\"T_14d75_row4_col0\" class=\"data row4 col0\" >2.4%</td>\n",
-       "      <td id=\"T_14d75_row4_col1\" class=\"data row4 col1\" >96.0%</td>\n",
+       "      <th id=\"T_5059f_level0_row4\" class=\"row_heading level0 row4\" >PC5</th>\n",
+       "      <td id=\"T_5059f_row4_col0\" class=\"data row4 col0\" >2.4%</td>\n",
+       "      <td id=\"T_5059f_row4_col1\" class=\"data row4 col1\" >96.0%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row5\" class=\"row_heading level0 row5\" >PC6</th>\n",
-       "      <td id=\"T_14d75_row5_col0\" class=\"data row5 col0\" >1.8%</td>\n",
-       "      <td id=\"T_14d75_row5_col1\" class=\"data row5 col1\" >97.8%</td>\n",
+       "      <th id=\"T_5059f_level0_row5\" class=\"row_heading level0 row5\" >PC6</th>\n",
+       "      <td id=\"T_5059f_row5_col0\" class=\"data row5 col0\" >1.8%</td>\n",
+       "      <td id=\"T_5059f_row5_col1\" class=\"data row5 col1\" >97.8%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row6\" class=\"row_heading level0 row6\" >PC7</th>\n",
-       "      <td id=\"T_14d75_row6_col0\" class=\"data row6 col0\" >1.0%</td>\n",
-       "      <td id=\"T_14d75_row6_col1\" class=\"data row6 col1\" >98.8%</td>\n",
+       "      <th id=\"T_5059f_level0_row6\" class=\"row_heading level0 row6\" >PC7</th>\n",
+       "      <td id=\"T_5059f_row6_col0\" class=\"data row6 col0\" >1.0%</td>\n",
+       "      <td id=\"T_5059f_row6_col1\" class=\"data row6 col1\" >98.8%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row7\" class=\"row_heading level0 row7\" >PC8</th>\n",
-       "      <td id=\"T_14d75_row7_col0\" class=\"data row7 col0\" >0.6%</td>\n",
-       "      <td id=\"T_14d75_row7_col1\" class=\"data row7 col1\" >99.4%</td>\n",
+       "      <th id=\"T_5059f_level0_row7\" class=\"row_heading level0 row7\" >PC8</th>\n",
+       "      <td id=\"T_5059f_row7_col0\" class=\"data row7 col0\" >0.6%</td>\n",
+       "      <td id=\"T_5059f_row7_col1\" class=\"data row7 col1\" >99.4%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row8\" class=\"row_heading level0 row8\" >PC9</th>\n",
-       "      <td id=\"T_14d75_row8_col0\" class=\"data row8 col0\" >0.2%</td>\n",
-       "      <td id=\"T_14d75_row8_col1\" class=\"data row8 col1\" >99.7%</td>\n",
+       "      <th id=\"T_5059f_level0_row8\" class=\"row_heading level0 row8\" >PC9</th>\n",
+       "      <td id=\"T_5059f_row8_col0\" class=\"data row8 col0\" >0.2%</td>\n",
+       "      <td id=\"T_5059f_row8_col1\" class=\"data row8 col1\" >99.7%</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_14d75_level0_row9\" class=\"row_heading level0 row9\" >PC10</th>\n",
-       "      <td id=\"T_14d75_row9_col0\" class=\"data row9 col0\" >0.1%</td>\n",
-       "      <td id=\"T_14d75_row9_col1\" class=\"data row9 col1\" >99.8%</td>\n",
+       "      <th id=\"T_5059f_level0_row9\" class=\"row_heading level0 row9\" >PC10</th>\n",
+       "      <td id=\"T_5059f_row9_col0\" class=\"data row9 col0\" >0.1%</td>\n",
+       "      <td id=\"T_5059f_row9_col1\" class=\"data row9 col1\" >99.8%</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7dbdb83b60d0>"
+       "<pandas.io.formats.style.Styler at 0x78cc594ba210>"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2723,20 +2775,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "id": "fad29b33",
+   "execution_count": 35,
+   "id": "a526af34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:57.072351Z",
-     "iopub.status.busy": "2026-09-08T23:42:57.072207Z",
-     "iopub.status.idle": "2026-09-08T23:42:57.080107Z",
-     "shell.execute_reply": "2026-09-08T23:42:57.079827Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.120349Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.120187Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.123820Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.123331Z"
     },
     "papermill": {
-     "duration": 0.018203,
-     "end_time": "2026-09-08T23:42:57.080960+00:00",
+     "duration": 0.008463,
+     "end_time": "2026-09-08T23:59:03.124090+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:57.062757+00:00",
+     "start_time": "2026-09-08T23:59:03.115627+00:00",
      "status": "completed"
     }
    },
@@ -2766,13 +2818,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "531b7284",
+   "id": "58b9b503",
    "metadata": {
     "papermill": {
-     "duration": 0.023921,
-     "end_time": "2026-09-08T23:42:57.119687+00:00",
+     "duration": 0.003739,
+     "end_time": "2026-09-08T23:59:03.131809+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:57.095766+00:00",
+     "start_time": "2026-09-08T23:59:03.128070+00:00",
      "status": "completed"
     }
    },
@@ -2786,20 +2838,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "id": "bf08c672",
+   "execution_count": 36,
+   "id": "886296d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:57.163409Z",
-     "iopub.status.busy": "2026-09-08T23:42:57.163284Z",
-     "iopub.status.idle": "2026-09-08T23:42:57.175066Z",
-     "shell.execute_reply": "2026-09-08T23:42:57.174823Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.141077Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.140908Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.147975Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.147578Z"
     },
     "papermill": {
-     "duration": 0.04228,
-     "end_time": "2026-09-08T23:42:57.178496+00:00",
+     "duration": 0.012705,
+     "end_time": "2026-09-08T23:59:03.148467+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:57.136216+00:00",
+     "start_time": "2026-09-08T23:59:03.135762+00:00",
      "status": "completed"
     }
    },
@@ -2872,7 +2924,7 @@
        "Heaviest 4  YIELD_CURVE_SLOPE  dgs30   dgs20             t10y2y"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2890,13 +2942,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "183028d6",
+   "id": "f7748d93",
    "metadata": {
     "papermill": {
-     "duration": 0.009012,
-     "end_time": "2026-09-08T23:42:57.199555+00:00",
+     "duration": 0.003623,
+     "end_time": "2026-09-08T23:59:03.155978+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:57.190543+00:00",
+     "start_time": "2026-09-08T23:59:03.152355+00:00",
      "status": "completed"
     }
    },
@@ -2911,13 +2963,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4c138f8",
+   "id": "870615d0",
    "metadata": {
     "papermill": {
-     "duration": 0.01118,
-     "end_time": "2026-09-08T23:42:57.222847+00:00",
+     "duration": 0.003703,
+     "end_time": "2026-09-08T23:59:03.163411+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:57.211667+00:00",
+     "start_time": "2026-09-08T23:59:03.159708+00:00",
      "status": "completed"
     }
    },
@@ -2931,20 +2983,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "id": "1858e81e",
+   "execution_count": 37,
+   "id": "f134ebc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:42:57.246984Z",
-     "iopub.status.busy": "2026-09-08T23:42:57.246868Z",
-     "iopub.status.idle": "2026-09-08T23:43:04.343844Z",
-     "shell.execute_reply": "2026-09-08T23:43:04.343554Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.171963Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.171848Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.492706Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.492452Z"
     },
     "papermill": {
-     "duration": 7.109364,
-     "end_time": "2026-09-08T23:43:04.344625+00:00",
+     "duration": 0.328349,
+     "end_time": "2026-09-08T23:59:03.495555+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:42:57.235261+00:00",
+     "start_time": "2026-09-08T23:59:03.167206+00:00",
      "status": "completed"
     }
    },
@@ -2954,11 +3006,11 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_cf95f\">\n",
+       "<table id=\"T_f2485\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_cf95f_level0_col0\" class=\"col_heading level0 col0\" >Silhouette</th>\n",
+       "      <th id=\"T_f2485_level0_col0\" class=\"col_heading level0 col0\" >Silhouette</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Model</th>\n",
@@ -2967,29 +3019,29 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_cf95f_level0_row0\" class=\"row_heading level0 row0\" >Core, 4 chosen series</th>\n",
-       "      <td id=\"T_cf95f_row0_col0\" class=\"data row0 col0\" >0.327</td>\n",
+       "      <th id=\"T_f2485_level0_row0\" class=\"row_heading level0 row0\" >Core, 4 chosen series</th>\n",
+       "      <td id=\"T_f2485_row0_col0\" class=\"data row0 col0\" >0.327</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_cf95f_level0_row1\" class=\"row_heading level0 row1\" >Extended, 25 series</th>\n",
-       "      <td id=\"T_cf95f_row1_col0\" class=\"data row1 col0\" >0.419</td>\n",
+       "      <th id=\"T_f2485_level0_row1\" class=\"row_heading level0 row1\" >Extended, 25 series</th>\n",
+       "      <td id=\"T_f2485_row1_col0\" class=\"data row1 col0\" >0.419</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_cf95f_level0_row2\" class=\"row_heading level0 row2\" >Extended, 10 principal components</th>\n",
-       "      <td id=\"T_cf95f_row2_col0\" class=\"data row2 col0\" >0.397</td>\n",
+       "      <th id=\"T_f2485_level0_row2\" class=\"row_heading level0 row2\" >Extended, 10 principal components</th>\n",
+       "      <td id=\"T_f2485_row2_col0\" class=\"data row2 col0\" >0.397</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_cf95f_level0_row3\" class=\"row_heading level0 row3\" >Extended, 25 series, k-means</th>\n",
-       "      <td id=\"T_cf95f_row3_col0\" class=\"data row3 col0\" >0.448</td>\n",
+       "      <th id=\"T_f2485_level0_row3\" class=\"row_heading level0 row3\" >Extended, 25 series, k-means</th>\n",
+       "      <td id=\"T_f2485_row3_col0\" class=\"data row3 col0\" >0.448</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7dbdb83b6210>"
+       "<pandas.io.formats.style.Styler at 0x78cc594ba350>"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3029,14 +3081,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52a819eb",
+   "id": "3926a757",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010501,
-     "end_time": "2026-09-08T23:43:04.363886+00:00",
+     "duration": 0.008231,
+     "end_time": "2026-09-08T23:59:03.510095+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:04.353385+00:00",
+     "start_time": "2026-09-08T23:59:03.501864+00:00",
      "status": "completed"
     }
    },
@@ -3052,20 +3104,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "id": "5409248f",
+   "execution_count": 38,
+   "id": "b09d78f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:04.387188Z",
-     "iopub.status.busy": "2026-09-08T23:43:04.387058Z",
-     "iopub.status.idle": "2026-09-08T23:43:04.397468Z",
-     "shell.execute_reply": "2026-09-08T23:43:04.395148Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.525365Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.525216Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.533939Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.533387Z"
     },
     "papermill": {
-     "duration": 0.023281,
-     "end_time": "2026-09-08T23:43:04.397861+00:00",
+     "duration": 0.017649,
+     "end_time": "2026-09-08T23:59:03.534501+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:04.374580+00:00",
+     "start_time": "2026-09-08T23:59:03.516852+00:00",
      "status": "completed"
     }
    },
@@ -3126,7 +3178,7 @@
        "Extended, 25 series           4         4                   0"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3162,20 +3214,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
-   "id": "f4fb1dd5",
+   "execution_count": 39,
+   "id": "f95ca4e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:04.418555Z",
-     "iopub.status.busy": "2026-09-08T23:43:04.418436Z",
-     "iopub.status.idle": "2026-09-08T23:43:04.424569Z",
-     "shell.execute_reply": "2026-09-08T23:43:04.423897Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.554943Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.554813Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.560473Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.559599Z"
     },
     "papermill": {
-     "duration": 0.018984,
-     "end_time": "2026-09-08T23:43:04.424973+00:00",
+     "duration": 0.017099,
+     "end_time": "2026-09-08T23:59:03.560933+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:04.405989+00:00",
+     "start_time": "2026-09-08T23:59:03.543834+00:00",
      "status": "completed"
     }
    },
@@ -3209,13 +3261,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e259f434",
+   "id": "4b12b6d3",
    "metadata": {
     "papermill": {
-     "duration": 0.011741,
-     "end_time": "2026-09-08T23:43:04.449244+00:00",
+     "duration": 0.008175,
+     "end_time": "2026-09-08T23:59:03.577364+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:04.437503+00:00",
+     "start_time": "2026-09-08T23:59:03.569189+00:00",
      "status": "completed"
     }
    },
@@ -3237,14 +3289,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6811f37",
+   "id": "87c13df7",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.017246,
-     "end_time": "2026-09-08T23:43:04.477424+00:00",
+     "duration": 0.003969,
+     "end_time": "2026-09-08T23:59:03.623884+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:04.460178+00:00",
+     "start_time": "2026-09-08T23:59:03.619915+00:00",
      "status": "completed"
     }
    },
@@ -3257,20 +3309,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "id": "ab6128f6",
+   "execution_count": 40,
+   "id": "7f49cafd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:04.602982Z",
-     "iopub.status.busy": "2026-09-08T23:43:04.602846Z",
-     "iopub.status.idle": "2026-09-08T23:43:04.615639Z",
-     "shell.execute_reply": "2026-09-08T23:43:04.615108Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.632828Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.632718Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.635694Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.635291Z"
     },
     "papermill": {
-     "duration": 0.042161,
-     "end_time": "2026-09-08T23:43:04.622030+00:00",
+     "duration": 0.008069,
+     "end_time": "2026-09-08T23:59:03.636055+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:04.579869+00:00",
+     "start_time": "2026-09-08T23:59:03.627986+00:00",
      "status": "completed"
     }
    },
@@ -3297,20 +3349,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
-   "id": "48a21152",
+   "execution_count": 41,
+   "id": "16e7146f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:04.672723Z",
-     "iopub.status.busy": "2026-09-08T23:43:04.672594Z",
-     "iopub.status.idle": "2026-09-08T23:43:05.085943Z",
-     "shell.execute_reply": "2026-09-08T23:43:05.084997Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.645410Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.645292Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.744202Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.743680Z"
     },
     "papermill": {
-     "duration": 0.444542,
-     "end_time": "2026-09-08T23:43:05.089673+00:00",
+     "duration": 0.104573,
+     "end_time": "2026-09-08T23:59:03.744854+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:04.645131+00:00",
+     "start_time": "2026-09-08T23:59:03.640281+00:00",
      "status": "completed"
     }
    },
@@ -3338,20 +3390,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
-   "id": "3b1e567f",
+   "execution_count": 42,
+   "id": "9ce599ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:05.130477Z",
-     "iopub.status.busy": "2026-09-08T23:43:05.130346Z",
-     "iopub.status.idle": "2026-09-08T23:43:05.354207Z",
-     "shell.execute_reply": "2026-09-08T23:43:05.353504Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.762960Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.762736Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.849070Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.848603Z"
     },
     "papermill": {
-     "duration": 0.248565,
-     "end_time": "2026-09-08T23:43:05.354534+00:00",
+     "duration": 0.097026,
+     "end_time": "2026-09-08T23:59:03.849773+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:05.105969+00:00",
+     "start_time": "2026-09-08T23:59:03.752747+00:00",
      "status": "completed"
     }
    },
@@ -3379,13 +3431,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b21588c",
+   "id": "030870e7",
    "metadata": {
     "papermill": {
-     "duration": 0.0158,
-     "end_time": "2026-09-08T23:43:05.380482+00:00",
+     "duration": 0.004872,
+     "end_time": "2026-09-08T23:59:03.860447+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:05.364682+00:00",
+     "start_time": "2026-09-08T23:59:03.855575+00:00",
      "status": "completed"
     }
    },
@@ -3410,20 +3462,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
-   "id": "040801e0",
+   "execution_count": 43,
+   "id": "6a061ea8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:05.427057Z",
-     "iopub.status.busy": "2026-09-08T23:43:05.426913Z",
-     "iopub.status.idle": "2026-09-08T23:43:05.451469Z",
-     "shell.execute_reply": "2026-09-08T23:43:05.451154Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.871218Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.871052Z",
+     "iopub.status.idle": "2026-09-08T23:59:03.877868Z",
+     "shell.execute_reply": "2026-09-08T23:59:03.877473Z"
     },
     "papermill": {
-     "duration": 0.04394,
-     "end_time": "2026-09-08T23:43:05.452213+00:00",
+     "duration": 0.012952,
+     "end_time": "2026-09-08T23:59:03.878188+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:05.408273+00:00",
+     "start_time": "2026-09-08T23:59:03.865236+00:00",
      "status": "completed"
     }
    },
@@ -3461,20 +3513,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
-   "id": "0836395f",
+   "execution_count": 44,
+   "id": "928db61e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:05.484735Z",
-     "iopub.status.busy": "2026-09-08T23:43:05.484611Z",
-     "iopub.status.idle": "2026-09-08T23:43:05.914170Z",
-     "shell.execute_reply": "2026-09-08T23:43:05.913457Z"
+     "iopub.execute_input": "2026-09-08T23:59:03.895231Z",
+     "iopub.status.busy": "2026-09-08T23:59:03.895048Z",
+     "iopub.status.idle": "2026-09-08T23:59:04.007680Z",
+     "shell.execute_reply": "2026-09-08T23:59:04.007023Z"
     },
     "papermill": {
-     "duration": 0.450321,
-     "end_time": "2026-09-08T23:43:05.914553+00:00",
+     "duration": 0.123837,
+     "end_time": "2026-09-08T23:59:04.008627+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:05.464232+00:00",
+     "start_time": "2026-09-08T23:59:03.884790+00:00",
      "status": "completed"
     }
    },
@@ -3521,20 +3573,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
-   "id": "717d46d3",
+   "execution_count": 45,
+   "id": "c34ae7cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T23:43:05.965753Z",
-     "iopub.status.busy": "2026-09-08T23:43:05.965630Z",
-     "iopub.status.idle": "2026-09-08T23:43:05.977300Z",
-     "shell.execute_reply": "2026-09-08T23:43:05.977049Z"
+     "iopub.execute_input": "2026-09-08T23:59:04.030371Z",
+     "iopub.status.busy": "2026-09-08T23:59:04.030181Z",
+     "iopub.status.idle": "2026-09-08T23:59:04.034072Z",
+     "shell.execute_reply": "2026-09-08T23:59:04.033540Z"
     },
     "papermill": {
-     "duration": 0.04709,
-     "end_time": "2026-09-08T23:43:05.978014+00:00",
+     "duration": 0.015654,
+     "end_time": "2026-09-08T23:59:04.034651+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:05.930924+00:00",
+     "start_time": "2026-09-08T23:59:04.018997+00:00",
      "status": "completed"
     }
    },
@@ -3565,13 +3617,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a958c30",
+   "id": "16d3d492",
    "metadata": {
     "papermill": {
-     "duration": 0.014427,
-     "end_time": "2026-09-08T23:43:06.023150+00:00",
+     "duration": 0.008929,
+     "end_time": "2026-09-08T23:59:04.053312+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:06.008723+00:00",
+     "start_time": "2026-09-08T23:59:04.044383+00:00",
      "status": "completed"
     }
    },
@@ -3592,13 +3644,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "313d1af6",
+   "id": "573c8975",
    "metadata": {
     "papermill": {
-     "duration": 0.024781,
-     "end_time": "2026-09-08T23:43:06.072688+00:00",
+     "duration": 0.00874,
+     "end_time": "2026-09-08T23:59:04.070898+00:00",
      "exception": false,
-     "start_time": "2026-09-08T23:43:06.047907+00:00",
+     "start_time": "2026-09-08T23:59:04.062158+00:00",
      "status": "completed"
     }
    },
@@ -3664,25 +3716,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-08T23:43:26.930101+00:00",
+   "executed_at": "2026-09-08T23:59:12.119950+00:00",
    "executor": "local-uv",
    "library_digest": "25dd94a0db06c6b2d32b8530229346ee7688b6880ee16748d54e4d4ff6e8cce3",
-   "outputs_digest": "30d5dc703cfeabd70e826ad932d98ddc7b21e4604c4061ed07101f6c07300d1c",
+   "outputs_digest": "cedf0254eace5a3a5845834f48c243cb83216d7dda8136b63e2a62e55b7eaa72",
    "parameters": {},
    "production": true,
-   "source_py_blob": "57a0071248e7c059bce93a53fbe19b4e935a49fd",
-   "notes": "prose synced from the .py at 2026-09-08T23:49:18.246948+00:00 without re-executing; every code cell is identical to blob 301944be49ad"
+   "source_py_blob": "5ec184d1dc2878ac96b65b0c4bcfb83d8df49e1f"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 48.377082,
-   "end_time": "2026-09-08T23:43:09.221741+00:00",
+   "duration": 10.759703,
+   "end_time": "2026-09-08T23:59:05.898607+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-a/01_process_is_edge/.macro_regimes.build.2201572.ipynb",
-   "output_path": "~/ml4t/public-teach-a/01_process_is_edge/.macro_regimes.papermill.2201572.ipynb",
+   "input_path": "~/ml4t/public-teach-a/01_process_is_edge/.macro_regimes.build.2404168.ipynb",
+   "output_path": "~/ml4t/public-teach-a/01_process_is_edge/.macro_regimes.papermill.2404168.ipynb",
    "parameters": {},
-   "start_time": "2026-09-08T23:42:20.844659+00:00",
+   "start_time": "2026-09-08T23:58:55.138904+00:00",
    "version": "2.7.0"
   }
  },

--- a/01_process_is_edge/macro_regimes.ipynb
+++ b/01_process_is_edge/macro_regimes.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "92c8ab34",
+   "id": "e507c676",
    "metadata": {},
    "source": [
     "# Macro-based regime detection\n",
@@ -49,8 +49,10 @@
     "\n",
     "- `factor_regimes`, which introduces Gaussian mixture models, the silhouette score, and\n",
     "  why a model fitted on the whole sample describes rather than predicts.\n",
-    "- The FRED panel under `data/macro/` and the S&P 500 daily series under\n",
-    "  `data/equities/sp500/`.\n",
+    "- The FRED panel, which `load_macro` reads. It needs a `FRED_API_KEY` and one run of\n",
+    "  `uv run python data/macro/download.py`; `data/macro/README.md` covers both.\n",
+    "- Daily S&P 500 index closes, which `load_sp500_index` reads. This one ships with the\n",
+    "  repository and needs no download.\n",
     "\n",
     "## A caveat that applies to every number below\n",
     "\n",
@@ -65,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f46f3218",
+   "id": "76d142c2",
    "metadata": {},
    "source": [
     "## Setup"
@@ -74,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e91ee6b5",
+   "id": "b54e0771",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa8a4ff3",
+   "id": "7250b7da",
    "metadata": {
     "tags": [
      "parameters"
@@ -122,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fb3ff5a",
+   "id": "ea2a6f87",
    "metadata": {},
    "source": [
     "### Settings, and what each one decides\n",
@@ -149,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9088e8d7",
+   "id": "1e71ab6e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6eccf8d",
+   "id": "33829016",
    "metadata": {},
    "source": [
     "## The FRED panel\n",
@@ -183,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae73e29b",
+   "id": "8b2fc5ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16ef9589",
+   "id": "ac99f133",
    "metadata": {},
    "source": [
     "### What the panel holds\n",
@@ -212,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dfffee16",
+   "id": "c2a3647b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d038ddc",
+   "id": "8b359d99",
    "metadata": {},
    "source": [
     "## Four indicators that describe conditions\n",
@@ -255,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33676987",
+   "id": "2424a7a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bad35586",
+   "id": "c32cfe9e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -285,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fcb8b5e4",
+   "id": "daba61db",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2654a6ba",
+   "id": "8ab5395d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de38ec00",
+   "id": "a54135d4",
    "metadata": {},
    "source": [
     "### Why the price index enters as a rate, not a level\n",
@@ -341,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53297f80",
+   "id": "dd857540",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7631caa",
+   "id": "ba28e057",
    "metadata": {},
    "source": [
     "### The four series before anything is fitted\n",
@@ -375,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9498a2a",
+   "id": "abe90b5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99ea5c23",
+   "id": "9dc9b348",
    "metadata": {},
    "source": [
     "## Fit the mixture\n",
@@ -402,7 +404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "176fc900",
+   "id": "e7c1773b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,7 +425,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a7b3ddb",
+   "id": "178d0518",
    "metadata": {},
    "source": [
     "### What the clusters contain\n",
@@ -435,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a053215e",
+   "id": "9f795ee9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01138576",
+   "id": "471f9e91",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -473,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1297c221",
+   "id": "d7df10ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e10a4389",
+   "id": "d3f07436",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +522,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcf6c6b7",
+   "id": "18dadf23",
    "metadata": {},
    "source": [
     "## Do the regimes correspond to anything the market did?\n",
@@ -538,7 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd8dbb22",
+   "id": "ebbe642a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +560,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39274e19",
+   "id": "4bc80a76",
    "metadata": {},
    "source": [
     "### Two statistics per regime, and what each one is\n",
@@ -579,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6253bf15",
+   "id": "c5c99d2c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea274e90",
+   "id": "a1e73691",
    "metadata": {},
    "source": [
     "### The regime panel\n",
@@ -623,7 +625,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e16a5c8f",
+   "id": "a3adf24e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a551af7e",
+   "id": "2b231ddc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -648,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee1c3bbf",
+   "id": "71035622",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +667,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af308aae",
+   "id": "b8e794c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,7 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79e92c77",
+   "id": "678c5745",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -708,7 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77b431b2",
+   "id": "32561aa4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -734,7 +736,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34a2ea3f",
+   "id": "86800f81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -771,7 +773,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c568a52",
+   "id": "8321e4a4",
    "metadata": {},
    "source": [
     "### Reading the panel honestly\n",
@@ -784,7 +786,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cf17065",
+   "id": "2ae984fb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,7 +813,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d06f303",
+   "id": "52d583be",
    "metadata": {},
    "source": [
     "The volatility ordering is economically legible: a tightening cycle is a calm market with an\n",
@@ -835,7 +837,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad8401ea",
+   "id": "41182be7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -860,7 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0bd6db08",
+   "id": "71b5773a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +884,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd92e691",
+   "id": "55d292d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -914,7 +916,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b844f84",
+   "id": "64915a4a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -931,7 +933,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d366c7c6",
+   "id": "a9974640",
    "metadata": {},
    "source": [
     "None of these partitions is wrong. They are answers to the same question from starts the\n",
@@ -952,7 +954,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cabd39fa",
+   "id": "4539e915",
    "metadata": {},
    "source": [
     "### Figure 1.6 inputs\n",
@@ -966,7 +968,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "477f32c3",
+   "id": "7e619240",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -992,7 +994,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44a4bb26",
+   "id": "85b87da0",
    "metadata": {},
    "source": [
     "## How the four indicators move together\n",
@@ -1008,7 +1010,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "960e1466",
+   "id": "63699037",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1047,7 +1049,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1dbdc3f7",
+   "id": "64acc918",
    "metadata": {},
    "source": [
     "Unemployment and the yield spread move together, and the fed funds rate moves against the\n",
@@ -1065,7 +1067,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "837ff507",
+   "id": "e928ba29",
    "metadata": {},
    "source": [
     "## The counter-experiment: every series in the panel\n",
@@ -1082,7 +1084,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54561487",
+   "id": "95cfd24e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1117,7 +1119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73b88908",
+   "id": "9c79482a",
    "metadata": {},
    "source": [
     "### What the filter let through\n",
@@ -1135,7 +1137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e7d9a05",
+   "id": "f3b61f42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1152,7 +1154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8551ed93",
+   "id": "64eced1f",
    "metadata": {},
    "source": [
     "### The series, drawn\n",
@@ -1164,7 +1166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fae15c7f",
+   "id": "61381e12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1201,7 +1203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53e51bdb",
+   "id": "913442e9",
    "metadata": {},
    "source": [
     "### How much independent variation is left\n",
@@ -1214,7 +1216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56e7ad49",
+   "id": "8f990b8f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1234,7 +1236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a203356",
+   "id": "018a2415",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1249,7 +1251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed685852",
+   "id": "8eb0c723",
    "metadata": {},
    "source": [
     "### Which columns each direction is made of\n",
@@ -1262,7 +1264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f632b125",
+   "id": "0f134c30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c8b81ec",
+   "id": "f61273e5",
    "metadata": {},
    "source": [
     "The leading direction is the trend the small multiples showed, and the second is the level\n",
@@ -1291,7 +1293,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26792cdb",
+   "id": "f72c8534",
    "metadata": {},
    "source": [
     "## Fit the same models to the extended panel\n",
@@ -1304,7 +1306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "490ead49",
+   "id": "d3f0923e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1342,7 +1344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45e7318d",
+   "id": "18301aa2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1359,7 +1361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9774bb6",
+   "id": "6dd5a858",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1394,7 +1396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea5c0afe",
+   "id": "5591a7f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1413,7 +1415,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7df10c33",
+   "id": "ada03043",
    "metadata": {},
    "source": [
     "A model with as many episodes as clusters and none of them revisited has assigned every\n",
@@ -1433,7 +1435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5327d27c",
+   "id": "5a46d996",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1447,7 +1449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46a4985c",
+   "id": "0d11bf0a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1473,7 +1475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1d6c81f",
+   "id": "51b6acb6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1485,7 +1487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87ba6e34",
+   "id": "95e9e8ce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1496,7 +1498,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e536c23",
+   "id": "47b0f40a",
    "metadata": {},
    "source": [
     "## Clustering the indicators rather than the months\n",
@@ -1520,7 +1522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c8df6d3",
+   "id": "6ea3185c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1544,7 +1546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b166ccfd",
+   "id": "c002fc90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1575,7 +1577,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c27f87a9",
+   "id": "0f2a75b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1591,7 +1593,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6b417eb",
+   "id": "f6b01376",
    "metadata": {},
    "source": [
     "A merge at zero distance is two copies of one column, and the tree finds it before it\n",
@@ -1610,7 +1612,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "934655d3",
+   "id": "9d051806",
    "metadata": {},
    "source": [
     "## Key takeaways\n",

--- a/01_process_is_edge/macro_regimes.ipynb
+++ b/01_process_is_edge/macro_regimes.ipynb
@@ -2,111 +2,90 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "28b6a492",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007494,
-     "end_time": "2026-07-18T19:35:39.935145+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:39.927651+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "7f8fa95e",
+   "metadata": {},
    "source": [
-    "# Macro-Based Regime Detection\n",
+    "# Macro-based regime detection\n",
     "\n",
     "**Chapter 1 · §1.4 Market Regimes: Change Is the Constant**\n",
     "\n",
     "**Docker image**: `ml4t`\n",
     "\n",
-    "## Purpose\n",
+    "`factor_regimes` estimated regimes from what the factors themselves earned. This notebook\n",
+    "asks whether the same partition can be recovered from outside the market, using\n",
+    "macroeconomic series published by the Federal Reserve Bank of St. Louis through its FRED\n",
+    "database: unemployment, the policy rate, the shape of the yield curve and inflation.\n",
     "\n",
-    "Demonstrates unsupervised learning for market regime detection using macroeconomic\n",
-    "indicators from FRED, paired with S&P 500 volatility and drawdown for validation.\n",
+    "The appeal of macro inputs is that they are not returns. A regime estimated from returns\n",
+    "is at risk of restating the volatility it was fitted on; one estimated from the labour\n",
+    "market and the rate environment is a statement about conditions, which can then be\n",
+    "checked against what the equity market did. That check is the second half of this\n",
+    "notebook, and it is what separates a regime model that has found something from one that\n",
+    "has partitioned the calendar.\n",
     "\n",
-    "## Learning Objectives\n",
+    "## Learning objectives\n",
     "\n",
-    "- Cluster monthly macro indicators with GMM, K-Means, and hierarchical methods.\n",
-    "- Validate macro clusters against realized equity volatility and drawdown.\n",
-    "- Compare a four-indicator core view to an extended FRED panel.\n",
-    "- Use PCA preprocessing to filter noise before clustering.\n",
+    "By the end of this notebook you will be able to:\n",
     "\n",
-    "## Book Reference\n",
+    "- Turn irregularly published economic series into an aligned monthly panel without\n",
+    "  letting a later release inform an earlier month.\n",
+    "- Explain why a series that trends has to enter a clustering as a rate of change rather\n",
+    "  than as a level, and recognise the failure that follows from ignoring it.\n",
+    "- Attach economic names to unnamed clusters through a stated rule, and say what the rule\n",
+    "  assumes.\n",
+    "- Check estimated regimes against realized equity volatility and drawdown, and read the\n",
+    "  result including the case where a regime holds too few months to support a claim.\n",
+    "- Judge a clustering by whether it recovers recurring conditions rather than by its\n",
+    "  separation score, and show why the two can point in opposite directions.\n",
     "\n",
-    "Section 1.4 of Chapter 1, \"Market Regimes: Change Is the Constant\" — macro-regime\n",
-    "follow-up to `factor_regimes.py`. Figure 1.6 in the chapter is generated here.\n",
+    "## Book reference\n",
+    "\n",
+    "Chapter 1, Section 1.4, \"Market Regimes: Change Is the Constant\". Figure 1.6 in the\n",
+    "chapter is the regime-and-volatility panel drawn below.\n",
     "\n",
     "## Prerequisites\n",
     "\n",
-    "- Familiarity with monthly time-series resampling and standardization.\n",
-    "- Conceptual exposure to mixture models, K-Means, and dendrograms.\n",
-    "- FRED panel and S&P 500 daily series materialized via `data/macro/` and\n",
-    "  `data/equities/sp500/` loaders.\n",
+    "- `factor_regimes`, which introduces Gaussian mixture models, the silhouette score, and\n",
+    "  why a model fitted on the whole sample describes rather than predicts.\n",
+    "- The FRED panel under `data/macro/` and the S&P 500 daily series under\n",
+    "  `data/equities/sp500/`.\n",
     "\n",
-    "## Structure\n",
+    "## A caveat that applies to every number below\n",
     "\n",
-    "1. **Core Analysis (4 indicators)** — UNRATE, DFF, T10Y2Y, CPIAUCSL → CPI YoY.\n",
-    "2. **Extended Analysis** — full FRED panel (after coverage filtering) for a richer\n",
-    "   but noisier view of economic conditions.\n",
-    "3. **Comparison** — silhouette scores across core, extended, and PCA-reduced models.\n",
-    "\n",
-    "## Key Insight\n",
-    "\n",
-    "Macro regimes line up with distinct *volatility* environments more cleanly than they\n",
-    "line up with average returns. This makes macro indicators useful for risk management\n",
-    "(anticipating volatility shifts) rather than return prediction."
+    "FRED serves the latest revision of each series. Unemployment, industrial production and\n",
+    "the price indices are all restated after their first publication, sometimes substantially,\n",
+    "so the value this notebook reads for a month in 2008 is not the value anyone could see in\n",
+    "2008. That is acceptable here because the labels are descriptive and nothing acts on them.\n",
+    "A strategy would have to read `load_macro_initial_release`, which serves the value as it\n",
+    "stood at each date, and would also have to wait out the publication lag - the\n",
+    "unemployment rate for a month is released in the first days of the next one."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "42579ad2",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002073,
-     "end_time": "2026-07-18T19:35:39.939512+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:39.937439+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "a027db60",
+   "metadata": {},
    "source": [
-    "## Imports"
+    "## Setup"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "45798e15",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:39.944604Z",
-     "iopub.status.busy": "2026-07-18T19:35:39.944499Z",
-     "iopub.status.idle": "2026-07-18T19:35:41.980466Z",
-     "shell.execute_reply": "2026-07-18T19:35:41.979916Z"
-    },
-    "papermill": {
-     "duration": 2.039468,
-     "end_time": "2026-07-18T19:35:41.981112+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:39.941644+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "dd2060f8",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"Macro-Based Regime Detection — unsupervised regime detection using FRED macro indicators.\"\"\"\n",
+    "\"\"\"Macro-based regime detection - clustering FRED indicators and validating against the S&P 500.\"\"\"\n",
     "\n",
     "from __future__ import annotations\n",
     "\n",
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\")\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import polars as pl\n",
     "import seaborn as sns\n",
+    "from IPython.display import Markdown, display\n",
+    "from matplotlib import pyplot as plt\n",
     "from matplotlib.gridspec import GridSpec\n",
     "from scipy.cluster.hierarchy import cophenet, dendrogram, linkage\n",
     "from scipy.spatial.distance import pdist\n",
@@ -116,2488 +95,1396 @@
     "from sklearn.mixture import GaussianMixture\n",
     "from sklearn.preprocessing import StandardScaler, scale\n",
     "\n",
-    "from data import load_macro, load_sp500_index\n",
+    "import utils.style as style\n",
+    "from data import load_macro, load_macro_metadata, load_sp500_index\n",
     "from utils.paths import get_output_dir\n",
-    "from utils.reproducibility import set_global_seeds"
+    "from utils.reproducibility import set_global_seeds\n",
+    "\n",
+    "COLORS = style.COLORS"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "9749426e",
+   "execution_count": null,
+   "id": "c5960642",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:41.986270Z",
-     "iopub.status.busy": "2026-07-18T19:35:41.986179Z",
-     "iopub.status.idle": "2026-07-18T19:35:41.987640Z",
-     "shell.execute_reply": "2026-07-18T19:35:41.987432Z"
-    },
-    "papermill": {
-     "duration": 0.004777,
-     "end_time": "2026-07-18T19:35:41.988230+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:41.983453+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
    },
    "outputs": [],
    "source": [
-    "# Production defaults (Papermill overrides for testing)\n",
+    "# Production defaults (Papermill overrides these when the test suite runs the notebook)\n",
     "SEED = 42"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0aed6a2e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002094,
-     "end_time": "2026-07-18T19:35:41.993690+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:41.991596+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "4adc7ebb",
+   "metadata": {},
    "source": [
-    "## Configuration"
+    "### Settings, and what each one decides\n",
+    "\n",
+    "`SEED` fixes every estimator's random start, which is what makes the cluster numbering\n",
+    "and the figures reproduce.\n",
+    "\n",
+    "`N_REGIMES` is the number of clusters fitted throughout. Four is taken from the Two Sigma\n",
+    "study this notebook follows, which reports four regimes over an eighteen-factor panel. It\n",
+    "is a choice, not a result: `factor_regimes` shows how the model-selection criteria are\n",
+    "compared when the count is being decided rather than inherited.\n",
+    "\n",
+    "`PANEL_START` is the first month the panel is allowed to contain. The FRED file begins in\n",
+    "2000, and the series used here are all quoted from that point, so the bound is set two\n",
+    "years later for the same reason a rolling statistic drops its warm-up: the year-over-year\n",
+    "inflation rate needs twelve prior months before it exists.\n",
+    "\n",
+    "`MAX_MISSING_SHARE` is how much of a series may be unquoted before it is dropped from the\n",
+    "extended panel. `MIN_COPHENETIC` is the level above which a dendrogram is usually taken to\n",
+    "summarise its distance matrix faithfully; it is a convention, quoted here so the number\n",
+    "the notebook computes has something to be read against."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "91810570",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:41.998350Z",
-     "iopub.status.busy": "2026-07-18T19:35:41.998291Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.052170Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.051582Z"
-    },
-    "papermill": {
-     "duration": 0.05682,
-     "end_time": "2026-07-18T19:35:42.052622+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:41.995802+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "c9101e4f",
+   "metadata": {},
    "outputs": [],
    "source": [
+    "N_REGIMES = 4\n",
+    "PANEL_START = pl.datetime(2002, 1, 1)\n",
+    "MAX_MISSING_SHARE = 0.5\n",
+    "MIN_COPHENETIC = 0.7\n",
+    "MONTHS_PER_YEAR = 12\n",
+    "ROLLING_VOL_MONTHS = 12\n",
+    "DATE_COL = \"timestamp\"\n",
+    "\n",
     "OUTPUT_DIR = get_output_dir(1, \"macro_regimes\")\n",
     "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "set_global_seeds(SEED)\n",
-    "\n",
-    "DATE_COL = \"timestamp\""
+    "set_global_seeds(SEED)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "03ea771e",
-   "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.002247,
-     "end_time": "2026-07-18T19:35:42.057277+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.055030+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "66b66308",
+   "metadata": {},
    "source": [
-    "## Helper Function\n",
+    "## The FRED panel\n",
     "\n",
-    "Reusable function for regime visualization. Both GMM and K-Means results\n",
-    "use the same heatmap format for easy comparison."
+    "The loader returns one wide frame with a daily date index and one column per series.\n",
+    "Series that are not published daily carry their most recent value forward, so the file has\n",
+    "no gaps to interpolate and the frequency a series was actually observed at has to be read\n",
+    "from its metadata rather than from the column."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "f5e058c5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.062208Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.062108Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.065373Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.065087Z"
-    },
-    "papermill": {
-     "duration": 0.006175,
-     "end_time": "2026-07-18T19:35:42.065615+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.059440+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "a0110c71",
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "def plot_regime_heatmap(\n",
-    "    assignments: np.ndarray,\n",
-    "    dates: pd.DatetimeIndex,\n",
-    "    title: str,\n",
-    "    n_regimes: int = 4,\n",
-    "    is_probability: bool = True,\n",
-    "    figsize: tuple = (14, 4),\n",
-    ") -> None:\n",
-    "    \"\"\"\n",
-    "    Plot regime assignments as a heatmap.\n",
-    "\n",
-    "    Parameters\n",
-    "    ----------\n",
-    "    assignments : np.ndarray\n",
-    "        Either probability matrix (n_samples, n_regimes) for GMM\n",
-    "        or hard labels (n_samples,) for K-Means\n",
-    "    dates : pd.DatetimeIndex\n",
-    "        Dates corresponding to each sample\n",
-    "    title : str\n",
-    "        Plot title\n",
-    "    n_regimes : int\n",
-    "        Number of regimes\n",
-    "    is_probability : bool\n",
-    "        True if assignments are probabilities, False for hard labels\n",
-    "    figsize : tuple\n",
-    "        Figure size\n",
-    "    \"\"\"\n",
-    "    fig, ax = plt.subplots(figsize=figsize, layout=\"tight\")\n",
-    "\n",
-    "    # Convert hard labels to one-hot if needed\n",
-    "    if not is_probability:\n",
-    "        one_hot = np.zeros((len(assignments), n_regimes))\n",
-    "        one_hot[np.arange(len(assignments)), assignments] = 1\n",
-    "        data = one_hot\n",
-    "    else:\n",
-    "        data = assignments\n",
-    "\n",
-    "    im = ax.imshow(data.T, aspect=\"auto\", cmap=\"Blues\", vmin=0, vmax=1)\n",
-    "\n",
-    "    # X-axis: years\n",
-    "    years = [pd.Timestamp(ts).year for ts in dates]\n",
-    "    year_ticks = [j for j, y in enumerate(years) if j == 0 or years[j - 1] != y]\n",
-    "    year_labels = [str(years[j]) for j in year_ticks]\n",
-    "    ax.set_xticks(year_ticks[::2])\n",
-    "    ax.set_xticklabels(year_labels[::2], fontsize=9)\n",
-    "\n",
-    "    # Y-axis: regimes\n",
-    "    ax.set_yticks(range(n_regimes))\n",
-    "    ax.set_yticklabels([f\"Regime {i + 1}\" for i in range(n_regimes)])\n",
-    "    ax.set_ylabel(\"Regime\")\n",
-    "    ax.set_xlabel(\"Year\")\n",
-    "    ax.set_title(title, fontsize=12)\n",
-    "\n",
-    "    cbar = plt.colorbar(im, ax=ax, shrink=0.8)\n",
-    "    cbar.set_label(\"Probability\" if is_probability else \"Assignment\")\n",
-    "    plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e6a364ea",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002134,
-     "end_time": "2026-07-18T19:35:42.069951+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.067817+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "# Load FRED Macro Data\n",
-    "\n",
-    "We load all available FRED macro indicators once, then select subsets for analysis.\n",
-    "The dataset includes ~17 series after filtering for data quality."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1202d185",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002098,
-     "end_time": "2026-07-18T19:35:42.074171+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.072073+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Load Full Dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "e02997c7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.079226Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.079137Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.089055Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.088756Z"
-    },
-    "papermill": {
-     "duration": 0.012995,
-     "end_time": "2026-07-18T19:35:42.089398+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.076403+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded FRED macro data: (9497, 26)\n",
-      "Date range: 2000-01-01 00:00:00 to 2025-12-31 00:00:00\n",
-      "Available series: ['dff', 'dgs1', 'dgs2', 'dgs3', 'dgs5', 'dgs7', 'dgs10', 'dgs20', 'dgs30', 't10y2y', 'vixcls', 'icsa', 'walcl', 'cpiaucsl', 'cpilfesl', 'pcepi', 'unrate', 'payems', 'civpart', 'indpro', 'm2sl', 'gdp', 'gdpc1', 'YIELD_CURVE_SLOPE', 'YIELD_CURVE_5_10']\n"
-     ]
-    }
-   ],
    "source": [
     "macro_raw = load_macro()\n",
+    "if macro_raw[DATE_COL].dtype == pl.Date:\n",
+    "    macro_raw = macro_raw.with_columns(pl.col(DATE_COL).cast(pl.Datetime))\n",
     "\n",
-    "# group_by_dynamic requires Datetime, not Date\n",
-    "if macro_raw[\"timestamp\"].dtype == pl.Date:\n",
-    "    macro_raw = macro_raw.with_columns(pl.col(\"timestamp\").cast(pl.Datetime))\n",
-    "\n",
-    "print(f\"Loaded FRED macro data: {macro_raw.shape}\")\n",
-    "print(f\"Date range: {macro_raw['timestamp'].min()} to {macro_raw['timestamp'].max()}\")\n",
-    "print(f\"Available series: {[c for c in macro_raw.columns if c != 'timestamp']}\")"
+    "print(f\"FRED panel: {macro_raw.height} rows, {macro_raw.width - 1} series\")\n",
+    "print(f\"Covering {macro_raw[DATE_COL].min():%Y-%m-%d} to {macro_raw[DATE_COL].max():%Y-%m-%d}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0e15a11e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002439,
-     "end_time": "2026-07-18T19:35:42.094509+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.092070+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "d8d2fd22",
+   "metadata": {},
    "source": [
-    "## Available Indicators\n",
+    "### What the panel holds\n",
     "\n",
-    "| Category | Series | Description |\n",
-    "|----------|--------|-------------|\n",
-    "| **Labor** | UNRATE | Unemployment rate (%) |\n",
-    "| **Interest Rates** | DFF | Federal Funds effective rate (%) |\n",
-    "| | T10Y2Y | 10Y-2Y Treasury spread (yield curve) |\n",
-    "| | T10YIE | 10Y breakeven inflation |\n",
-    "| **Prices** | CPIAUCSL | Consumer Price Index |\n",
-    "| | CPILFESL | Core CPI (ex food & energy) |\n",
-    "| **Volatility** | VIXCLS | VIX volatility index |\n",
-    "| **Credit** | BAMLHE00EHYIEY | High yield spread |\n",
-    "| **Housing** | CSUSHPISA | Case-Shiller home price index |\n",
-    "| **Money** | M2SL | M2 money supply |\n",
-    "\n",
-    "For the **Core Analysis**, we use only 4 fundamental macro indicators."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b13e216b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002141,
-     "end_time": "2026-07-18T19:35:42.098873+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.096732+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "# Core Analysis: 4 Macro Indicators\n",
-    "\n",
-    "We use four indicators that reflect real economic conditions:\n",
-    "\n",
-    "- **UNRATE**: Unemployment rate - labor market health\n",
-    "- **DFF**: Federal Funds rate - monetary policy stance\n",
-    "- **T10Y2Y**: Yield curve slope - recession signal\n",
-    "- **CPIAUCSL → cpi_yoy**: CPI year-over-year inflation rate (not the level, which trends upward)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "998eabe9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00214,
-     "end_time": "2026-07-18T19:35:42.103177+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.101037+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Select Core Indicators"
+    "The metadata companion says what each column is, how often the source publishes it, and\n",
+    "whether it is an observed series or one this repository derives from others. Both facts\n",
+    "matter downstream: a quarterly series entering a monthly clustering repeats each value\n",
+    "three times, and a derived column can duplicate a series that is already in the panel\n",
+    "under its own name."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "3ea904be",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.108137Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.108057Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.110342Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.110054Z"
-    },
-    "papermill": {
-     "duration": 0.005154,
-     "end_time": "2026-07-18T19:35:42.110568+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.105414+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Core indicators selected: 4/4\n",
-      "  unrate -> unrate\n",
-      "  dff -> dff\n",
-      "  t10y2y -> t10y2y\n",
-      "  cpiaucsl -> cpiaucsl\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Core 4 indicators (case-insensitive matching)\n",
-    "CORE_INDICATORS = [\"unrate\", \"dff\", \"t10y2y\", \"cpiaucsl\"]\n",
-    "\n",
-    "macro_columns = macro_raw.columns\n",
-    "core_cols = []\n",
-    "col_name_map = {}\n",
-    "\n",
-    "for indicator in CORE_INDICATORS:\n",
-    "    for col in macro_columns:\n",
-    "        if col.lower() == indicator:\n",
-    "            core_cols.append(col)\n",
-    "            col_name_map[col] = indicator\n",
-    "            break\n",
-    "\n",
-    "print(f\"Core indicators selected: {len(core_cols)}/{len(CORE_INDICATORS)}\")\n",
-    "for col in core_cols:\n",
-    "    print(f\"  {col} -> {col_name_map[col]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "264ab345",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002359,
-     "end_time": "2026-07-18T19:35:42.115157+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.112798+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Resample to Monthly"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "70a87d6f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.120060Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.119995Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.124700Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.124451Z"
-    },
-    "papermill": {
-     "duration": 0.007884,
-     "end_time": "2026-07-18T19:35:42.125281+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.117397+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Monthly data: 289 months\n",
-      "Date range: 2002-01-01 00:00:00 to 2026-01-01 00:00:00\n"
-     ]
-    }
-   ],
-   "source": [
-    "macro_monthly = (\n",
-    "    macro_raw.select([DATE_COL] + core_cols)\n",
-    "    .sort(DATE_COL)\n",
-    "    .group_by_dynamic(DATE_COL, every=\"1mo\", label=\"right\")\n",
-    "    .agg([pl.col(c).last() for c in core_cols])\n",
-    "    # Forward-fill carries last observation through release lags; the small\n",
-    "    # backward-fill catches any leading nulls in early months. The latter\n",
-    "    # introduces a one-period look-ahead at the panel boundary — acceptable\n",
-    "    # for a regime-detection demo, not for a backtested strategy.\n",
-    "    .fill_null(strategy=\"forward\")\n",
-    "    .fill_null(strategy=\"backward\")\n",
-    "    .drop_nulls(subset=core_cols)\n",
-    ")\n",
-    "\n",
-    "# Filter to 2002+ where most FRED series have good coverage\n",
-    "if macro_monthly.height > 0:\n",
-    "    min_date = macro_monthly[DATE_COL].min()\n",
-    "    if min_date is not None and str(min_date) < \"2002-01-01\":\n",
-    "        macro_monthly = macro_monthly.filter(pl.col(DATE_COL) >= pl.datetime(2002, 1, 1))\n",
-    "\n",
-    "print(f\"Monthly data: {macro_monthly.height} months\")\n",
-    "if macro_monthly.height > 0:\n",
-    "    print(f\"Date range: {macro_monthly[DATE_COL].min()} to {macro_monthly[DATE_COL].max()}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "605f4520",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002231,
-     "end_time": "2026-07-18T19:35:42.130950+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.128719+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Standardize for Clustering"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "865dc125",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.136129Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.136053Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.152638Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.152209Z"
-    },
-    "papermill": {
-     "duration": 0.019741,
-     "end_time": "2026-07-18T19:35:42.152909+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.133168+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Core Indicator Statistics (raw):\n",
-      "       unrate     dff  t10y2y  cpi_yoy\n",
-      "count  277.00  277.00  277.00   277.00\n",
-      "mean     5.75    1.76    1.07     2.58\n",
-      "std      2.02    1.91    0.97     1.81\n",
-      "min      3.40    0.04   -1.06    -1.96\n",
-      "25%      4.20    0.10    0.24     1.64\n",
-      "50%      5.00    1.04    1.01     2.33\n",
-      "75%      6.70    3.09    1.90     3.24\n",
-      "max     14.80    5.41    2.84     8.98\n"
-     ]
-    }
-   ],
-   "source": [
-    "if macro_monthly.height > 0:\n",
-    "    macro_df = macro_monthly.select(core_cols).to_pandas()\n",
-    "    macro_df.columns = [col_name_map.get(c, c) for c in macro_df.columns]\n",
-    "    macro_df.index = macro_monthly[DATE_COL].to_pandas()\n",
-    "\n",
-    "    # Convert CPI level to YoY percentage change — the level is non-stationary\n",
-    "    # and would make the clustering capture \"early vs recent\" rather than\n",
-    "    # \"inflationary vs non-inflationary\"\n",
-    "    macro_df[\"cpi_yoy\"] = macro_df[\"cpiaucsl\"].pct_change(12) * 100\n",
-    "    macro_df = macro_df.drop(columns=[\"cpiaucsl\"]).dropna()\n",
-    "\n",
-    "    macro_scaled = StandardScaler().fit_transform(macro_df)\n",
-    "\n",
-    "    print(\"Core Indicator Statistics (raw):\")\n",
-    "    print(macro_df.describe().round(2))\n",
-    "else:\n",
-    "    macro_df = pd.DataFrame()\n",
-    "    macro_scaled = np.array([])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9e1a981a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003474,
-     "end_time": "2026-07-18T19:35:42.159064+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.155590+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Fit GMM with 4 Regimes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "8fe90a48",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.167876Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.167775Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.257808Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.257469Z"
-    },
-    "papermill": {
-     "duration": 0.094592,
-     "end_time": "2026-07-18T19:35:42.258170+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.163578+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Macro regime silhouette score (n=4): 0.252\n"
-     ]
-    }
-   ],
-   "source": [
-    "if len(macro_df) > 0:\n",
-    "    n_macro_regimes = 4\n",
-    "    gmm_macro = GaussianMixture(\n",
-    "        n_components=n_macro_regimes,\n",
-    "        covariance_type=\"full\",\n",
-    "        random_state=SEED,\n",
-    "        n_init=10,\n",
-    "        reg_covar=1e-6,\n",
-    "    )\n",
-    "    gmm_macro.fit(macro_scaled)\n",
-    "    macro_labels = gmm_macro.predict(macro_scaled)\n",
-    "    macro_probs = gmm_macro.predict_proba(macro_scaled)\n",
-    "\n",
-    "    macro_silhouette = silhouette_score(macro_scaled, macro_labels)\n",
-    "    print(f\"Macro regime silhouette score (n={n_macro_regimes}): {macro_silhouette:.3f}\")\n",
-    "else:\n",
-    "    macro_labels = np.array([])\n",
-    "    macro_probs = np.array([])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fd585176",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002341,
-     "end_time": "2026-07-18T19:35:42.263062+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.260721+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "We use 4 regimes to match the Two Sigma approach. The silhouette score measures\n",
-    "cluster separation — higher is better, with values above 0.25 indicating\n",
-    "reasonable structure. Unlike factor_regimes, we skip BIC/AIC model selection here\n",
-    "because the goal is interpretability (matching known economic phases), not\n",
-    "statistical optimality."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dd15fa18",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002262,
-     "end_time": "2026-07-18T19:35:42.267628+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.265366+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Regime Characteristics"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "445198a0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.272786Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.272701Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.276681Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.276407Z"
-    },
-    "papermill": {
-     "duration": 0.007084,
-     "end_time": "2026-07-18T19:35:42.276988+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.269904+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Regime Characteristics (mean values):\n",
-      "        unrate   dff  t10y2y  cpi_yoy\n",
-      "regime                               \n",
-      "0         4.70  1.36    1.12     2.15\n",
-      "1        12.30  0.07    0.47     0.56\n",
-      "2         7.62  0.11    1.88     1.58\n",
-      "3         4.43  3.79    0.24     4.01\n"
-     ]
-    }
-   ],
-   "source": [
-    "if len(macro_df) > 0:\n",
-    "    regime_chars = macro_df.copy()\n",
-    "    regime_chars[\"regime\"] = macro_labels\n",
-    "    regime_means = regime_chars.groupby(\"regime\").mean()\n",
-    "\n",
-    "    print(\"Regime Characteristics (mean values):\")\n",
-    "    print(regime_means.round(2))\n",
-    "else:\n",
-    "    regime_means = pd.DataFrame()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6b750c6f",
-   "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.002266,
-     "end_time": "2026-07-18T19:35:42.281630+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.279364+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Assign Interpretive Labels"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "ecf2af46",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.286608Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.286537Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.289041Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.288791Z"
-    },
-    "papermill": {
-     "duration": 0.005456,
-     "end_time": "2026-07-18T19:35:42.289362+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.283906+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "22ccc1c8",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "def create_regime_labels(chars: pd.DataFrame) -> dict[int, str]:\n",
-    "    \"\"\"Create short, descriptive labels based on economic characteristics.\n",
+    "metadata = load_macro_metadata().to_pandas().set_index(\"series\")\n",
+    "inventory = metadata.loc[\n",
+    "    [c for c in macro_raw.columns if c != DATE_COL], [\"description\", \"native_frequency\", \"formula\"]\n",
+    "].rename(\n",
+    "    columns={\n",
+    "        \"description\": \"Series\",\n",
+    "        \"native_frequency\": \"Published\",\n",
+    "        \"formula\": \"Derived as\",\n",
+    "    }\n",
+    ")\n",
+    "inventory[\"Derived as\"] = inventory[\"Derived as\"].fillna(\"-\")\n",
+    "inventory.index.name = \"Column\"\n",
+    "inventory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34160de8",
+   "metadata": {},
+   "source": [
+    "## Four indicators that describe conditions\n",
     "\n",
-    "    Uses a priority cascade on cluster-mean values. Thresholds are approximate\n",
-    "    and tuned for the 2002-2025 US macro environment.\n",
-    "    \"\"\"\n",
-    "    labels = {}\n",
-    "    for regime in chars.index:\n",
-    "        c = chars.loc[regime]\n",
-    "        if c[\"unrate\"] > 10:\n",
-    "            labels[regime] = \"Crisis\"\n",
-    "        elif c[\"unrate\"] > 6 and c[\"dff\"] < 0.5:\n",
-    "            labels[regime] = \"Recovery\"\n",
-    "        elif c[\"dff\"] > 3 and c[\"t10y2y\"] < 0.5:\n",
-    "            labels[regime] = \"Tightening\"\n",
-    "        elif c[\"cpi_yoy\"] > 4:\n",
-    "            labels[regime] = \"Inflation\"\n",
-    "        elif c[\"unrate\"] < 5 and c[\"dff\"] < 2:\n",
-    "            labels[regime] = \"Expansion\"\n",
+    "The core model uses four series, each standing for one thing a reader can name:\n",
+    "\n",
+    "- **UNRATE**, the unemployment rate, for the state of the labour market.\n",
+    "- **DFF**, the effective federal funds rate, for the stance of monetary policy.\n",
+    "- **T10Y2Y**, the ten-year Treasury yield minus the two-year, for the shape of the yield\n",
+    "  curve. A negative value means short-dated debt yields more than long-dated debt, an\n",
+    "  inversion that has preceded most post-war US recessions.\n",
+    "- **CPIAUCSL**, the consumer price index, for inflation - entered as a rate of change,\n",
+    "  for the reason given below.\n",
+    "\n",
+    "Four is few enough that every cluster can be described in a sentence, which is the point\n",
+    "of a regime label. The extended panel later in the notebook is the counter-experiment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4eaa0f6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CORE_SERIES = [\"unrate\", \"dff\", \"t10y2y\", \"cpiaucsl\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f61249c1",
+   "metadata": {},
+   "source": [
+    "### From daily rows to a monthly panel\n",
+    "\n",
+    "`group_by_dynamic` cuts the daily frame into calendar months and `last()` takes the final\n",
+    "observation inside each. Labelling each window by its right edge is what keeps the panel\n",
+    "honest: the window covering January is stamped 1 February, so the row carries only\n",
+    "observations from January and nothing dated later reaches it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46c08577",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "macro_monthly = (\n",
+    "    macro_raw.select([DATE_COL, *CORE_SERIES])\n",
+    "    .sort(DATE_COL)\n",
+    "    .group_by_dynamic(DATE_COL, every=\"1mo\", label=\"right\")\n",
+    "    .agg([pl.col(c).last() for c in CORE_SERIES])\n",
+    "    .drop_nulls(subset=CORE_SERIES)\n",
+    "    .filter(pl.col(DATE_COL) >= PANEL_START)\n",
+    ")\n",
+    "\n",
+    "print(f\"Monthly rows: {macro_monthly.height}\")\n",
+    "print(f\"Covering {macro_monthly[DATE_COL].min():%Y-%m} to {macro_monthly[DATE_COL].max():%Y-%m}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c2e9367",
+   "metadata": {},
+   "source": [
+    "### Why the price index enters as a rate, not a level\n",
+    "\n",
+    "The consumer price index rises almost every month of the sample. Clustering on the level\n",
+    "would put every early month in one cluster and every late month in another, because that\n",
+    "is the largest source of variance in the column, and the resulting partition would be a\n",
+    "statement about the calendar rather than about inflation. The year-over-year percentage\n",
+    "change removes the trend and leaves the quantity a reader means by inflation: how much\n",
+    "prices rose over the past twelve months. Taking it costs the first twelve months of the\n",
+    "panel, which is why the panel starts a year after `PANEL_START`.\n",
+    "\n",
+    "The other three series are already rates and need no such treatment. All four are then\n",
+    "standardized, so that unemployment measured in percentage points and the yield spread\n",
+    "measured in the same unit but with a quarter of the spread contribute comparably to the\n",
+    "distances the clustering works on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b2020ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "macro_df = macro_monthly.select(CORE_SERIES).to_pandas()\n",
+    "macro_df.index = pd.DatetimeIndex(macro_monthly[DATE_COL].to_pandas())\n",
+    "macro_df[\"cpi_yoy\"] = macro_df[\"cpiaucsl\"].pct_change(MONTHS_PER_YEAR) * 100\n",
+    "macro_df = macro_df.drop(columns=[\"cpiaucsl\"]).dropna()\n",
+    "\n",
+    "macro_scaled = StandardScaler().fit_transform(macro_df)\n",
+    "\n",
+    "PANEL_FIRST_YEAR = macro_df.index.min().year\n",
+    "PANEL_LAST_YEAR = macro_df.index.max().year\n",
+    "print(f\"Clustering panel: {len(macro_df)} months, {PANEL_FIRST_YEAR} to {PANEL_LAST_YEAR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f37aa939",
+   "metadata": {},
+   "source": [
+    "### The four series before anything is fitted\n",
+    "\n",
+    "The table reports each series in its own units over the clustering panel. Read the spread\n",
+    "between the quartiles against the range: the policy rate spans the whole distance from the\n",
+    "zero bound to above five percent, and the unemployment rate is tight around its median\n",
+    "with one extreme excursion. Those shapes are what the mixture is about to partition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa973adb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "UNITS = {\n",
+    "    \"unrate\": \"Unemployment rate (%)\",\n",
+    "    \"dff\": \"Fed funds rate (%)\",\n",
+    "    \"t10y2y\": \"10Y minus 2Y Treasury (percentage points)\",\n",
+    "    \"cpi_yoy\": \"CPI, change over 12 months (%)\",\n",
+    "}\n",
+    "macro_df.rename(columns=UNITS).describe().T.style.format(\"{:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9852d97",
+   "metadata": {},
+   "source": [
+    "## Fit the mixture\n",
+    "\n",
+    "The same estimator as `factor_regimes`: a full-covariance Gaussian mixture, restarted ten\n",
+    "times from different initializations, keeping the fit with the highest likelihood."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49e91e60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gmm_core = GaussianMixture(\n",
+    "    n_components=N_REGIMES,\n",
+    "    covariance_type=\"full\",\n",
+    "    random_state=SEED,\n",
+    "    n_init=10,\n",
+    "    reg_covar=1e-6,\n",
+    ")\n",
+    "gmm_core.fit(macro_scaled)\n",
+    "core_labels = gmm_core.predict(macro_scaled)\n",
+    "core_probabilities = gmm_core.predict_proba(macro_scaled)\n",
+    "core_silhouette = float(silhouette_score(macro_scaled, core_labels))\n",
+    "\n",
+    "print(f\"Core model silhouette: {core_silhouette:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c15c08d",
+   "metadata": {},
+   "source": [
+    "### What the clusters contain\n",
+    "\n",
+    "The mixture returns numbers. The table below is what those numbers mean: the average of\n",
+    "each indicator over the months assigned to each cluster, in the original units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29fc54ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster_means = macro_df.groupby(core_labels).mean()\n",
+    "cluster_means.index.name = \"Cluster\"\n",
+    "cluster_means.rename(columns=UNITS).style.format(\"{:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a9dbb7a",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "### Naming the clusters\n",
+    "\n",
+    "A cluster number is not a regime name, and the names have to come from somewhere the\n",
+    "model cannot supply. The rule below reads each cluster's average indicators and applies\n",
+    "the first description that fits, in a fixed order. Both the ordering and the thresholds\n",
+    "are judgements about the post-2002 US economy, chosen so that each name means what a\n",
+    "reader expects: high unemployment is a crisis whatever the rate environment; high\n",
+    "unemployment with the policy rate at the floor is the aftermath rather than the crisis\n",
+    "itself; a high policy rate with a flat curve is a tightening cycle.\n",
+    "\n",
+    "The rule is stated in one place so that it can be argued with. A different reader would\n",
+    "set different thresholds and get different names over the same partition, and that is the\n",
+    "honest situation: the clustering is estimated, the naming is asserted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8000c98b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def name_clusters(means: pd.DataFrame) -> dict[int, str]:\n",
+    "    \"\"\"Attach an economic description to each cluster from its average indicators.\"\"\"\n",
+    "    names: dict[int, str] = {}\n",
+    "    for cluster in means.index:\n",
+    "        row = means.loc[cluster]\n",
+    "        if row[\"unrate\"] > 10:\n",
+    "            names[cluster] = \"Crisis\"\n",
+    "        elif row[\"unrate\"] > 6 and row[\"dff\"] < 0.5:\n",
+    "            names[cluster] = \"Recovery\"\n",
+    "        elif row[\"dff\"] > 3 and row[\"t10y2y\"] < 0.5:\n",
+    "            names[cluster] = \"Tightening\"\n",
+    "        elif row[\"cpi_yoy\"] > 4:\n",
+    "            names[cluster] = \"Inflation\"\n",
+    "        elif row[\"unrate\"] < 5 and row[\"dff\"] < 2:\n",
+    "            names[cluster] = \"Expansion\"\n",
     "        else:\n",
-    "            labels[regime] = \"Transition\"\n",
-    "\n",
-    "    # Ensure unique labels\n",
-    "    seen = {}\n",
-    "    for r, label in list(labels.items()):\n",
-    "        if label in seen:\n",
-    "            if chars.loc[r, \"unrate\"] > chars.loc[seen[label], \"unrate\"]:\n",
-    "                labels[r] = f\"{label} (High Unemp.)\"\n",
-    "            else:\n",
-    "                labels[seen[label]] = f\"{label} (High Unemp.)\"\n",
-    "        seen[label] = r\n",
-    "    return labels"
+    "            names[cluster] = \"Transition\"\n",
+    "    return names"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "2b6e8ccd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.294442Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.294372Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.296323Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.296067Z"
-    },
-    "papermill": {
-     "duration": 0.004887,
-     "end_time": "2026-07-18T19:35:42.296604+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.291717+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Assigned Regime Labels:\n",
-      "  Cluster 0: Expansion\n",
-      "  Cluster 1: Crisis\n",
-      "  Cluster 2: Recovery\n",
-      "  Cluster 3: Tightening\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "849ea344",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "if len(regime_means) > 0:\n",
-    "    regime_labels_map = create_regime_labels(regime_means)\n",
-    "    print(\"Assigned Regime Labels:\")\n",
-    "    for regime, label in sorted(regime_labels_map.items()):\n",
-    "        print(f\"  Cluster {regime}: {label}\")\n",
-    "else:\n",
-    "    regime_labels_map = {}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "296327f4",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002337,
-     "end_time": "2026-07-18T19:35:42.301308+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.298971+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Macro Regimes and Market Volatility\n",
+    "cluster_names = name_clusters(cluster_means)\n",
+    "if len(set(cluster_names.values())) != len(cluster_names):\n",
+    "    raise ValueError(f\"Two clusters received the same name: {cluster_names}\")\n",
     "\n",
-    "**Key insight**: Macro regimes coincide with different VOLATILITY environments,\n",
-    "even when return patterns are less clear.\n",
-    "\n",
-    "**Implication**: Macro regime indicators are useful for RISK MANAGEMENT\n",
-    "(anticipating volatility shifts) rather than RETURN PREDICTION."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6e5a3925",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002337,
-     "end_time": "2026-07-18T19:35:42.305970+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.303633+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Load S&P 500 for Validation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "a8ba5f61",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.311041Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.310975Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.324010Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.323743Z"
-    },
-    "papermill": {
-     "duration": 0.016147,
-     "end_time": "2026-07-18T19:35:42.324457+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.308310+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded S&P 500 for validation: 552 months, 1980-01-31 to 2025-12-31\n"
-     ]
-    }
-   ],
-   "source": [
-    "sp500_raw = load_sp500_index().to_pandas()\n",
-    "sp500_raw[\"timestamp\"] = pd.to_datetime(sp500_raw[\"timestamp\"])\n",
-    "sp500_raw = sp500_raw.set_index(\"timestamp\")\n",
-    "\n",
-    "sp500_monthly = sp500_raw[\"close\"].resample(\"ME\").last().to_frame()\n",
-    "sp500_monthly[\"returns\"] = sp500_monthly[\"close\"].pct_change()\n",
-    "sp500_df = sp500_monthly\n",
-    "\n",
-    "print(\n",
-    "    f\"Loaded S&P 500 for validation: {len(sp500_df)} months, \"\n",
-    "    f\"{sp500_df.index.min().date()} to {sp500_df.index.max().date()}\"\n",
+    "regime_name = pd.Series(\n",
+    "    [cluster_names[label] for label in core_labels], index=macro_df.index, name=\"regime\"\n",
+    ")\n",
+    "ordered_names = [cluster_names[cluster] for cluster in cluster_means.index]\n",
+    "pd.DataFrame(\n",
+    "    {\"Name\": ordered_names, \"Months\": regime_name.value_counts()[ordered_names].to_numpy()},\n",
+    "    index=cluster_means.index,\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ebf443ce",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002374,
-     "end_time": "2026-07-18T19:35:42.330829+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.328455+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "9a976628",
+   "metadata": {},
    "source": [
-    "### Compute Regime Statistics"
+    "## Do the regimes correspond to anything the market did?\n",
+    "\n",
+    "The clustering has seen no market data at all. If the four groups are picking up real\n",
+    "conditions rather than an arbitrary carve-up of a four-dimensional cloud, then equity\n",
+    "returns should behave differently inside them, and the difference should be in the\n",
+    "direction economic reasoning predicts.\n",
+    "\n",
+    "The S&P 500 daily series is resampled to month-end closes and aligned to the macro panel.\n",
+    "The macro rows are stamped at the right edge of the month they summarise, so the nearest\n",
+    "month-end close within five days is the close of the month whose data the row carries."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "95edba96",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.336021Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.335955Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.342788Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.342524Z"
-    },
-    "papermill": {
-     "duration": 0.009847,
-     "end_time": "2026-07-18T19:35:42.343046+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.333199+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Regime Statistics (sorted by volatility):\n",
-      "              months  annual_vol  max_dd_pct\n",
-      "regime_label                                \n",
-      "Expansion         77        12.0        14.6\n",
-      "Tightening        98        15.0        42.2\n",
-      "Recovery          98        15.2        52.6\n",
-      "Crisis             4        16.0         9.9\n"
-     ]
-    }
-   ],
-   "source": [
-    "if len(macro_df) > 0 and sp500_df is not None:\n",
-    "    events = {2008: \"GFC\", 2020: \"COVID\", 2022: \"Inflation\"}\n",
-    "\n",
-    "    sp500_aligned = sp500_df.reindex(macro_df.index, method=\"nearest\", tolerance=pd.Timedelta(\"5D\"))\n",
-    "    sp500_aligned[\"regime\"] = macro_labels\n",
-    "    sp500_aligned[\"regime_label\"] = [regime_labels_map[r] for r in macro_labels]\n",
-    "    sp500_aligned[\"peak\"] = sp500_aligned[\"close\"].cummax()\n",
-    "    sp500_aligned[\"drawdown\"] = (sp500_aligned[\"close\"] - sp500_aligned[\"peak\"]) / sp500_aligned[\n",
-    "        \"peak\"\n",
-    "    ]\n",
-    "    sp500_aligned[\"volatility\"] = sp500_aligned[\"returns\"].rolling(12).std() * np.sqrt(12)\n",
-    "\n",
-    "    regime_stats_fig = sp500_aligned.groupby(\"regime_label\").agg(\n",
-    "        {\"returns\": [\"mean\", \"std\", \"count\"], \"drawdown\": \"min\", \"volatility\": \"mean\"}\n",
-    "    )\n",
-    "    regime_stats_fig.columns = [\"mean_ret\", \"std_ret\", \"months\", \"max_dd\", \"avg_vol\"]\n",
-    "    regime_stats_fig[\"annual_vol\"] = regime_stats_fig[\"std_ret\"] * np.sqrt(12) * 100\n",
-    "    regime_stats_fig[\"max_dd_pct\"] = -regime_stats_fig[\"max_dd\"] * 100\n",
-    "\n",
-    "    regime_stats_fig = regime_stats_fig.sort_values(\"annual_vol\", ascending=True)\n",
-    "    regime_order = regime_stats_fig.index.tolist()\n",
-    "    n_regimes_fig = len(regime_order)\n",
-    "\n",
-    "    print(\"Regime Statistics (sorted by volatility):\")\n",
-    "    print(regime_stats_fig[[\"months\", \"annual_vol\", \"max_dd_pct\"]].round(1))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9124ca54",
-   "metadata": {
-    "lines_to_next_cell": 2,
-    "papermill": {
-     "duration": 0.002368,
-     "end_time": "2026-07-18T19:35:42.347813+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.345445+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Regime Timeline with Market Validation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "fa5f29aa",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.352999Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.352939Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.625406Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.624999Z"
-    },
-    "papermill": {
-     "duration": 0.275531,
-     "end_time": "2026-07-18T19:35:42.625718+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.350187+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABV0AAAJZCAYAAAC6KJW+AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAoLtJREFUeJzs3Xd8TecDx/FvdiQiidh777333nvULGorLa3VqtLS+rVqV60apahRRe2g9t7U3mIGkSFDxk3y+yNyJRIEh4h+3q+Xl3PPec45zzm557m53zznORahoSGRAgAAAAAAAAAYwjKxKwAAAAAAAAAA7xNCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCrzDHj58qM8++0zZsmVX8uROypUrt7p27aarV6/K1tYu1r9SpUqb1ztw4IDq1q0rFxdXpUmTVo0bN5anp2ciHgkAwAgPHz5U3759lSVLVqVI4azixUto5cq/ZTKZNGzYcGXPnkOOjslVpEhR/fHHIknSkCFfydbWTuvWrTNvZ/v27bK1tVO/fv00f/582draaebMmZKk3LnzyNbWTo6OyZUlS1a1adNW586de+vHeu3aNdna2unDDzs8t9yVK1dUsmQpJUvmoGrVqsc5nudt/7vvvteWLVvM82rVqi1bWzsFBwcbcgwAAAD477JO7AoAiF9kZKQaN26iffv2qVmzZqpXr65u3LipxYsXKTw8XJJUrlw5ffLJJ5IkV1cXSdKJE/+qdu06sra21uDBg+XmllJr167V3bv3lC5dusQ6HADAa4r5udCqVSvVrFlDZ86c0dGjR3Xo0CGNGzdOTZo0UZ06tTV9+gx16dJFqVOn0gcftNSECRP099+r1LBhQ0nSqlWrJEktWrTQ9evX4+zL2dlZkyZN0rFjRzVt2nTt3LlTR48eUfr06d/qMSfE8uUrdPLkSfXu/bGaNm2qmzdvJmg9Dw8PjRo1SoMGDVLNmjUlSV9/PVQ9evSQra3tm6wyAAAA/gMIXYF31JYtW7Rv3z7Vrl1Lf/651Dz/yy+/MPdaTZs2rWrWrCFJsre3lySNHz9ewcHBWrBggdq0aS1J+vjjjxUREfGWjwAAYKToz4U6dWrrjz8WmucHBgYqXbr0ypw5s5YuXSIrKytVqVJFRYoU1ejRP2nr1i3KmjWr1q5dq/DwcFlZWWn16jVKkyaNKleurD/++CPOvuzt7fXhh+314YftlSZNWg0bNkwzZvyqkSNHvMUjfqJbt+5asGCBPvmkj5YvXyFHRwctXfqnjh8/pq+//lqSNH36DAUEBKpq1Sqx1m3Z8gPt3LlTISEhKlCggH75ZbJSp06t2rXrSJLGjRuncePG6cKF8/rf/37Qzp071bRpE9nZ2en770dp3rx5evjwoSpVqqjJkycrS5Ysz6xPkSKF3/q5AQAAwLuJ4QWAd9Tx48clSXXr1pUkBQQEyMvLSwEBAQoLC5MU1VMpQ4aMypAhoz777POn1qsTa3uWllzuAJCURbfvderEbt+vXLmqkJAQlSpVSlZWVpKkfPnyKWXKlDpz5owkqUWL5nrw4IF27typw4cP68aNG2ratIm5/PNE7+/YsaMGHs2rOX36jLp06aLLl69o3Lhxqly5spo3by5JGjx4sHr16hlnnfLly+mnn0br22+/kaenpz79tK9Sp06toUOHSpIaNWqkBQsWKHXq1LHWmzt3rkaNGqUyZcpo6NCvtHnzP/roo87PrQ8AAAAQjRQGeMdZWFhIkgYOHGQOWLdt2yZJqlq1qjZsWK8NG9Zr4MCBiVlNAMA7rEWLFpKkv//+W3//HTW0QMuWLRO0bmRkpKQnn0eJaeTIERo+fJikqOEBsmfProIFC0qSqlSprDJlysQqbzKZdOLEv/r007766quhun37ts6cOSNHR0dVr15NUlRA3aZNazk6OsZad+PGTZKkiRMnaMCAAapWrar27NmjgICAZ9YHAAAAiEboCryjihcvLknmB3x8/vln+vDDD2OVSZMmjWrWrKmaNWuqQIH8sdbbvPmfWGUZXgAAkrbo9v2ff2K37zlyZJednZ2OHDlibuvPnz8vb29vFShQQJJUpkwZZc6cWatXr9Hff/+tVKlSqWrVqgnab/T+ihcvYdShvDJXV1dZW0eNjhU9vvnz/PPPP1q6dKnq1aundevWqmTJkgoJCZGU8BA5ulx85V+2PsC7aPaC5Spft4O+H/fra2+rfN0OKl+3g+543pckNe/0ucrX7aCjJ6J63fcZPErl63bQuk07X3tfAAC86whdgXdUjRo1VL58ea1fv0GdOn2kQ4cO6cEDrxeuN2DAANnb26t379768cfRmjlzppo2baqTJ0+9hVoDAN6U6M8Fd/eN6tixk+bOnasvv/xSP/00Rn379tX169fVpk1bzZo1S+3atZckDRnypaSowLB582a6deuWLly48MKhBYKDg7Vo0WJ98cUXGjFihNzc3OK9dT+pCAgI0KlTp3Tq1JPPQmdnF0nSgQMH9Oefy+KsU69e1PA+/fsP0MSJE7Vt23ZVrFhRyZMnfyt1BhIiOsQcPWlOrPmm8HA1aNNH5et20LJVmwzf7/fjflX5uh00e8HyWPNbN6ur1s3qysEhWbzrVa9URq2b1VW2LBklSes27VT5uh3UZ/Aow+sI/JdF/8GjfN0OWr95l3l+cEio6n7wsXnZvkMnErGWwPuPB2kB7ygLCwutXr1KQ4cO1apVq7Vy5UplzJhBXbt2VaFChZ65XtGiRbRp00Z98823+umnn2RlZaUyZUorbdo0b7H2AACjRX8ufP311+bPhezZs2vkyJFq3LiRLC0ttXDhQq1fv145c+bUb7/9Fmv815YtW2ry5F8kPRlu4Fn8/PzUo0cPubm5qXHjxvruu5FKnz79Gz2+N6F27dpq3ry5NmzYIDs7W1WqVFFbtmyVJBUuXEj169fTP/9s0d69e9W6datY63bu3Fk3btzU3LlztXnzZtWqVVOTJ09OjMMAnqlh7So69u85bd11QAP6dJKtrY0k6cDhf+Xj+1A2NtaqU73CW6tP/94dn7u8VdM6z10OwHh/rd6sBrUrS5I2bdurh/4BL1gDgFEsQkNDIhO7EgAAILbvx/0aq2fCzz98qTIlnzwZ/Y7nfbXsPMA83mbBfDk1++eRb72er6t83Q6xXltaWsjZyUmF8udStw7NlTd39je6/6MnzuiTL36QJA0b2FMN61R5o/tLivoMHqVj/55TurSptHL+pGeWi3kuJalO9QoaOaRPrDKffvGDjjy+zViSFs8ao2xZMhhW13WbdmrU+JmSpKljhqpE0QKvvc0lK9wVEBio9GlTv/D9EfO6nTZumIoXzhdr+fmLV9X50+GSpCrlS+qnEf0TVIfXPa6jJ87o6L9nJUltmteTU/In49fOXrBccxaulCSt+H2i0qdLHe/+nnWtrNu0U3fu3ldyR0e1bVHvpeqVEBOnL9Cff29U9Uql9cPwzyRJx0+e07rNu3Tq7EU98PZVeHiEMqRLo/q1KumDJrXNwWO0a9dva8a8P3X0xFmFhIYqW5YMatOsnjmEiGn95l1a+re7rl2/LTtbW5Uoml8fd24d6316+twl/fbH37p89YZ8/B4qMjJSaVKlVPnSRdX1w+ZydUnxwuMy6hiqVSqtRm0/0aPgEA3t3123797X0RNnde7iVYWGhsnezk7lShVWZKR07uJV+QcEKlPGtGrXor7q1ayk6zfvaOioybp89YYsLCzk4uykzBnSKvBRsLwe+Cgg8JEsLS0UFmZS6eIFNXn0V+Y2IabiRfJp2thh5jY9+r3UvNPn8rzrZX4fRa87bGBP3bl73/zei+mrz7vpx0lzVCh/Ls2aNEKSdOnqDXX8+Cs5ONhr3eKpsre3e+E5Bv7Loq+9FE7J9dA/QLN/HqGC+XKpU++hunvf2xy8Thg1WIFBjzRv8Sp53vVScHCIXF1SqHL5kurXs73s7e206K/1+mXWIuXOkUW//fKdfPz81aHXV/IPCNSk/30R6/dTALHR0xUAgCRgzcYdsX6pXb1xuzlwfZ9ERETKx++hdu0/qiMnzmjBjB+UIR099ZOi7XsOyT8g0Bzw3bjlaQ7+kpKlf7vL866XihfJ98LQtVbVcubQdevOA3FC1y27Dj4pW62c8ZV9hqP/njWHWw1rV4kVur6udZt3mkN5o0PXO3e9tHJd1Nj2HVo3Ms/fuHWv1m7cEavspavX9cusRTpy4rTGfz/YPP/a9dvq2X+E/AOCzPMuXPLQ9+N+1QNvX3Vs09g8f/7S1Zr+25/m16GhYdqx57COnjijmRNHmIPXy1dvaO/B47H2f+vOPf21erOOnjirBTN+kKXl80dxM/IYqlcuo/Wbd2ntpp369/SFWNsMDgnR9j2HJUnZsmRQyWIF9M/2/Ro5ZoauetzSX6s3K+hRsKSoh+b5+D6Uj+9DZUiXWpXKFpedvZ2Onjija9dv69Cx0zp19pKqVyojH9+Hunb9tgrmy6mC+XIpU4a0zz3e+BTMl0tlShTSwaOnlDqVq6pXinoQXu3q5TV55iKdOntJ12/eUZZM6bVjzyFJUvWKpQlcgZfQsE4VLVmxQctWbVJYmEkXr1xXh1aNtHDZWnMZz3teSpXSRYXy51JERIT2HTyhleu2KFkyO/Xt0V7tWtbXwaMndeDISc1dtEpnL1zRQ/8AdWjViMAVeAHGdAUAIAnYufeI/B5G9UoID4/Q+k27XrDGmxUcEmro9tKlTaV9GxfKfdkMVSoX9cCooEfBct+yx9D9PK1E0QLat3Gh9m1cSC9Xg4WGhmnj1r3m12s27nhjfyiIjIxUSKix78lXUbpEITmniBrzdfvuQ3EeYrl15wFJkr2dnfl9nti6d2xpvgbSp0v9zHKJca0sX7NZYWEm5ciWSQXy5jTPt7SyVMPalfXbL99p2+rfNOWnoXJ8PIbo3oMndPbCFXPZyTP/kH9AkKysrDRh1GCtWfSL8j3uQT9rwXLdu/9AknT33gPNXrBCkpQvd3atXvSLJowaLCsrK/kHBGnyzD/M28ySKb1GfNlbqxb+rB1r5mr6uGHmn/sVj5u6eOX6C4/NyGOoULqopKgeuDmyZVKzhjUkSS4uTsqVPbN5O8UK5dPwQb3UtUNzSdIff61X0KNg2dnZSooKO9ctnaqfvu2vzu2aKVuWjLK3s1W+3DnM2/hj2Tq1alrH/PMoV6qI+vfu+ErDBpQvXdQ89EGmDGnVv3dH9e/dUcns7VWvZiVJMj9wa8fj4Lh+rbi9kwE8W6YMaVW+dBFt3XVQsxeskJWlpVo0rhWrTNsW9dWySW2lTe0mR4dkypo56g9MB49EjYNuYWGhbwZ/LFeXFJq76G/tO3RC+fPkUK/OH7z14wGSGnq6AgDwjkuXxk2e9x5o49Y9at2srvYfPqF7Xt7m+U/bd+iElq501xWPm1FBbWRUqFmjShl91Lap7B9/wZaigs0Ff67R9t2HdNvzvmysrZUlU3p179hCFcoUi3VL8aBPP9JVj9vasnO/wsPDtWl51O3H+w//qz+WrdO5i1cVEhqq9GlTqUaVsnH2lRDOKZKrSf3q2r3/mCTp3n3vWMsfePvqtz9Wau+hE/J64KPkjg4qXbygenT6QJkzpjOX83vorwnTFmj3/qOys7VVo3pVlTFdGo3+OephM8+7ZfqO5321+Cjqtu/O7ZsqIjxCqzZsU0REpJrWr66Pu7TWtt0HNWv+X/Ly9lWhfLk05LNusQKrwMAgzVu8Wjv2HpbnPS/Z29mqSMG86tGxRawhEw4ePaXfF6/SFY+bCgx6JOcUTsqZLZOaN6qpqhVKPfM8JfRnHPP4Bvftopu3POW+dY9MJpNKFy+kL/p1kXMKJ/N2jxw/o59/XSiPG3eUKUNa9e7a5qV+ftGi35trNm7XB01qyxQervWbd8ZaFpN/QKDGTfld5y9d0wNvXz0KDpFziuQqWjCPundsqRzZMpnLRt8yWbxIPrVoWEtz/lihG7fu6n/D+sZbl7MXrujTL39QUFCwsmXJoKljv1ZKF2edu3hV8xav0olT5xUQGKTUbilVrVJpde/YQg7J7OMMl3Ds33PmW6e7dWiu7h1bxtmXtZWVqlUqrVXrt8nL21cnTl8w93Y9f+mabt25J0mqVK64ktnbS3r16yeh5yz6fEWLfm9HDxcR3/AC8Xn6WilRJL95W5LkedfLfH4a1K6siIgIuW/ZIzs7W61bPEWOjg5R5yHGEAufdm+nD1s1jHd/ERER5l7DNSqXibWsT9c25oBSkkoWK6D6tSrpr9WbJUX1qs6fJ4d8/fx14Mi/kqRSxQqo/ONwsl3L+vp29DSFhZm0ZddBtWtRX1t3HVBYmEmS1P6DBkrt5qrUbq4qVayADhw5qQNH/pWvn79cnJ1U7KkezMUK51Pxwvm1/XFvTGvrZz+k7k0cwz0vb2VIl1q3Pe+raf3q2rn3iCSpfs3KMoWbdOnqDUnSnbv3JUnZHz/EKjw8XJJUpnhB7dp/TDbW1krp4qybt+/ql1mL4q33ngPHFBgYFO8yIzVvVEPL12yW+5Y9alS3qi5eua50adxUomj+N75v4H3zQZM62nvwhI6cOKMqFUoqfdpUsZYPGTlJew4ci7Oej5+feTqlq7Ma1amiBX9G9ZBt37KBrK2Jk4AXoacrAADvuOheZWvco25FXb1huySpUd2q8ZY/fe6SDhw5qftePgoNDVNoWJiu37yjeYtWafSk2eZyQY+C9fGA7zRv0Spdu35boaFhCgx6pLMXrujM+ctxtjvz9+VavmazfP38Fd1hcfWGbRowbKwOHz+tgMAghYWZdP2mp+YtWqXPvhptDjFeSozekDHHRrz/wEdd+g7XirVb5HnXSyZTuHz9/LV5+3516/etrt+8Yy479PvJ2rRtr4IeBcvH76EWLF2j2QtXvHRVVq7dovlL18jvYYD8AwK1cNlaffXdJH3z41Rdv+mpoKBgHTx6St/+NM28TtCjYPUa+L0WLlurG7c8FRZmkn9AkPYcOKae/b/TiVPnJUXdOj342/E6+u9Z+fr5KyzMJK8HPjpw5KQOHT393Hol9Gcc0/Tflmrxig3y8X0o/4Agbd11UOOnzjcvv37zjgYMG6uLV64rNCxMVzxuash3k3TN4/ZLn7cqFUrJKbmDLlzy0PlL17TnwDE98PZTxvRpVLxI3NAkICBIm7btlceN2woIDFJ4eLi8ffy0bfch9R40St6+fnHWuXTlur4ZPVXXrt82h0dPu3b9lgYMG6ugoGBlzZxBU34aqpQuzjp45KR69h+pHXsOy9fPXyZTuO7cva/Fy9frk8H/e61es7WqPhk2ILpn69PT0UMLvM718yrn7G1q2bi2JCkkJFSbtu8zz9/6eIgFKysr1atZ8ZnrX7l2Uz6+DyVJhfLnjrUsZlgZLTQ0zDydOlVKSdKFyx6KiIhqT6J7bj09feHSNUlRoXh8y7NmjnqAXEREpC5e8Yh3v8dOnjMPnVGsUF7lyJopTrmnGXoMlz1Uv1ZUz9BlqzaZ69KwTmW5Oj9pQ11dnCVJ127cirVf78fn2X3LbrXv8aX+/HujpKiHXu1cO888rqokhZlMOn7qvHn4hOi6varo7UQ+tZ2c2TKrSME8uuflrQnTotqpujUqysLC4rX2B/wXlStVxPyH6ad7pQcEBpkD1++Hfqo9G+ard9fWkmL9OqYr127qz1WbzONNT/1tifwDAt9C7YGkjdAVAIB3XNUKpeScIrkuXb2u3fuPac/B47K0tFCjOvGHrhXKFNPMid9qw5/TtWv971q7eIoqlInqHbVp2z7zMAVLV7qbb4MtWayAls4Zqy1/z9bk0UOUN1e2ONsNCQ3VD8P6aeuq2ZoxYbgCgx5p8sxFioyMlKtzCs3+eaTcl80w90r79/SFWA8DSwi/hwFa7b5dUtRDtapVfNLbc9b8v3TfK6p367Rxw7RjzVzNmzpKKZySyz8gUDPmLZMkHTp2yhw6FC6QW2sW/aL50/4X+9tDAoWGhmnGhG+0Yv4kOThE9Uzctf+oGtetqk3LfzUf68kzF3XPK6pX7tKV7rp89YasLC01+tvPtWPNXP352zhlypBWoWFh+vnXhZKkcxeumEOW3375TjvXztPKBZM0ckgfFS2U57n1SujPOCYLCwvNmPCN1i2Zau4FuX3Pk1vg5y5apdCwqPr06/Wh/lkxU5/1+lA+fg9f+rzZ2dqoTvWoQG2N+44nfyioUzXe0MTJyVE/Dv/MfLv21lWz9dXn3SRJD/0DtGnrvjjr+AcEqXHdqlq/dJrWLp6iwk8Fc3fueemzr36Sr5+/smRKpyk/fSW3lC6SpLFT5ikszKS8ubLpz9/Gaceaufr2i48lRT1saI37DvPt9Oke9wgqXiSf+fb6+Hq5RitRJL/cUkaFWzGHGIgOG5M7Oqh8qaKvff0k9JytnD9J3R7fTi5F9Wbdt3Hhcx+KlhDp06XWvo0LVbxIVK/P6CFC9m1cqOGDeqlQ/lzmdmTtxp3m9aJ7g5YtWdj884hPzBA0e9aMz62Lx43b2rQt6nizZEqvogWjrh/fGO/dmCFnzOnoYNfXzz/e5Q7xlI1WtVEXVW3cRX0GjdJD/wCVKJJfY78b+ErB4OseQ4PalWVhYaGbt+8qMjJS+XJnV/YsGXX0xJNxlE+fu6Tvx/0a5+FVp89F/ZEtIiJSV6/f0t3HQy7s2n9UY6fM1Tc/To1V/tzFa0qXxk2StGHLbk2YNt/8c31ZaR9v5+zFqxozeW6scSabPx4mYf/hqJ6+0cEygJdjYWGhsSMH6JefvlKpYgVjLbO3tzP/frN4+QaNGj9T85esiVUmJDRU34yeqpCQUA3o3UmN61WV510vjZ40560dA5BU0R8cAIB3nI2NjerWqKg//96o78bOUHh4uMqVKmL+svq01KlS6td5y3T42Gk98PGVyfSkF2BkZKRu3vaUc4pc2nvwhHn+t1/0Vmo3V0lS6eKF4t1u/ZqVVP1xIJQzW2btP/yvAoMeRS2rXUkF80WN8fdxl9bmgGn/4X/VtEH1Fx5jzFuTJSmFU3J91uvDWLfi73tc34DAIPUZNCrONo4cPyMpKgCN1rldU6Vyc1UqN1c1qldV8xatemFdYqpSoaQ5/MiWOaO5B3Cntk3klNxRpUsUMh/r3XsPlCZVSvN5DY+I0JCRk+Js8+yFqwoMDDKHeZL0+5LVKvq4h1zFssXj7QUXU0J/xjE1qV/NfCwVShfTlWs3FRZmkrePn1K5uerkmagH8LildFbb5vVkYWGhVk3r6I9l68whzMtoUr/a49uDdys4OERWlpZqWLeKZsz9M07Z5I4OunP3vuYu/ls3bnrqUXBIrOUxezFHc0ruoAGfdJKdbfy34I/75XcFh4QoU4a0mjLma6V6/P6+fvOObt6+Kykq2GvddVCcdY8cP6MPmtR+6WOWonru1ahcVstWbTIPMeDokMy8zyoVSsrW1kZH/z37WtfPq5yzt61lk9r6YcIsnTl/WVeu3VRERISu3/SUpBeOCxsz4IweLzU+t+7c0+dfj1FwSIgcHZLpf1/3feFDrF5qbOEYRV8Uph7996y+GDFBk0d/JWurFw8xEM2IY8iQLo2KFc6rY/+ekxQVUP5vwiwdPh7Vaz5n9sx66B+gbbsOKmvmDDKZTLrqEdXjNVVKF3l5+6pi2eI6cvyMgkNCZG1lpQfevjp55qJ6dGqp78bOMO/L29dPXdo11eFjp3XmwhUtW7VJFhYWqlaxdIKPOVrxwvlUv1Yl7dp3VCvXbVHuHFnUoVXUQ9NqVC6rSTMWyu9hgPLnyRGrdy+Al5M1c4Z4ryFrKyuN/PIT/fzrQl26cl0OyezVoVUj/fr7MnOZX2Yu1uWrN1S+dFE1bVBdtauX19ETZ7V110Gtdt+uJvWqvcUjAZIWQlcAAJKAJvWr6c+/N5pv5XrWL7gREREa9M04XbgU9zbYaCGPH4IV3YPK0SGZOXB9ntw5ssR67ffwSc+wtKnd4p32fYVekpJkMpni3OLtE6MnWnwe+kf17vR64Guel+bxLbpPTydU+rRPxre0s7MxT0cH3jYxxjMLe9xLNCHH/DAgSPnz5FDndk21eMUG7dhz2PygGDs7Ww3o3VFN6scftr3MzzimzBmejHkbfXtgVL2jbmG//8BHkuSW0iVWuJQ6lesrha55cmZVvtzZde7iVUlSxbLFn/k+W7xigybPjH8MSUnx3u6fOWP6ZwauUtRT2yUpR7ZMcnN1Ns9/0ftIevJeelU1q5bTslWbJEUNKxAzRI8efuB1r59XOWdvW+1q5fXLzEXyDwjUmo3bzePYpnBKrkplX/9BYh43bqvvkB9138tHjg7JNH7UYOWK0U65xLi1PjDoyTikQY+CzdPRQ5i4OD8Z2zggMGbZRzG296SMJO1YO1choaG6cu2m/jdhli5fvaFj/57Trr1HVL1yGa3btFOjxs+MtU70eNJv4himjR0mSTKFh+u7MdO1eft+SVK7lg3Ur2f7WPX45scp5tC1Y5vGat2sriRpwLCx2nfohEzh4Vq7cIq5N3L9WpXUoHUfc8/3VG6umj5+uJ62b+PCWK+f7lEdXcdo0Q/oiY+trY3KlSqijVv3qkFtHqAFvIwX3c3w9LX69MMdO7dvap4e9OlHGvTpR+bXDsns9de8Ca9fSeA/gNAVAIAkIGe2zCqUP5dOnb0kV5cUqly+RLzlbt6+aw7jShcvpBFDeiuli7Mmz1ykxcvXxyrr4pxCN2/fVWDQI3k98DH3BHwWu6ce6hPzAUzRt9ZLihXQOT8VUjxLurSptOL3ibp45boGfzNe97y8NW7KPOXOkVWF8kf12HR1dpKXt6+yZEqvpXPGxtlGdM+vVG4u5nn3H/iYA4ynH8qVEFZW8fc2e14vtujz6pDMXhv/mhHnQRORkZHmULNX51b6qG0TXbjsoRu3PfX3um06dfaiJkxfoAZ1qsS7n5f5Gceqc4yH+8TXYS+1m6tu3bmnB96+sep438vnmdt8kSb1q5lD16b1qz2z3NadUT07bW1tNG3sMOXLnV3XbtxSh15fPXOdmCF4fIoVzqfjJ89p594jmjh9gQZ+EvWF0TXGe7JZgxr68rOucdaN2YvQQi9/q3iRArnNDwzbvvuQkiWLChtdnJ1UukRUT/LXvX5e5py9yXEwn3d+7O1s1ahuVS1evl7uW/YohVNUj9Va1crFCv7jE3M8Z7+HAXH+aHLl2k31HfKjvH38lMIpuSb98IXy58kRq0yenFllaWmhiIhIedx40vPX48aTcYrzPB4CIW+ubNq4da+kqF7C0UMjRK9naWmh3Dmyxqmnna2t8ufJocZ1q2rSjKgQ48Ztz+ce25s6BinqD1bDf5hqvt2/S/tm6vlR3CeM58mZzRzKPkvMNj8iIkIPH//RL6WL87NWMcyps5d08OhJ7dp/VE7JHRlaAACQJDGmKwAASUSnNo1VpXxJde/Q4plPjA2N8eAdGxtr2dna6uyFK3LfsjtO2Yplipmnvxv7q27c8lTQo2AdPXFGu/YdeWF9ChfIbR4HbP3mXTp74Yoe+gdq5u9/mcuUK1UkoYcnCwsL5cmZVf37dJQUNb7glBhP0C73+Knd12/e0ewFy/XQP1DBwSE6eeaixk6ZpwV/Ro1BVrRgXvM6C/9cK29fP126cl1rNm5PcF1eR/nSUccc9ChY46b8Lm8fP4WEhur8pWua9ttSTZqxQJJ06eoN/fbHSl2/5akc2TKpRuUyypMzKiAOCQlVUFBwvNt/mZ/xyyhcIGrogQfeflqy0l2BQY+0bNWmV+rlGq1OtfKqWrGUalcrpwplnt2zMbqXsIWFhRwd7BUQGKg5C17+wWcxde/QQjWrlJUk/bV6s3loiSyZ0itj+jSSpPX/7NL2PYcUHBwiv4cB2r3/mAZ/O17HTp4zb8fJyUFS1PARAQl8aruFhYVqPN63l7evbtyKCuGqVSxtDtJf9/p5mXPmlNzRPH352s0EHUNCOTlFbdvPz18PvH3jLG/RqKYsLCzk6+dvHvKgYQJ6LcYcV/rKU3W+cNlDn3zxP3n7+Cmlq7Omjv06TlgpRYXcZUtGncMjJ85o36ET8nrgo8XLN0iKun5qPh4ypUblsrKxiWpXF/21Xl4PfLTv0AkdfjxsSdmSRcw9XSf/+of2HDgmrwdRD7K7cNlD62KMv5shXdT7q2GdKuZxbqP/RfdyfRPHEBoapi9HTjIHrp90axtv4CpJNaqUkdXj96L7lt3y9vXT+YtXzcMT5M6ZVckdHczlPW7cMT+wLl/ubHG2Z7T9h09o1vzlcnVOoe+HfvrCIVcAAHgX0dMVAIAkonL5kqpcvuRzy2TLnF6ZMqTVzdt3tffgcdVq3kOSlDF9mjgPgWndvK627jqgi1eu69CxU7HGtuzWofkL9+XokEx9e7TXTz//Jh/fh+ra95tYywvlz6WGtZ8/bmN8qlUsrfx5cujshSs6cfqCDhw5qbIlC6tHp5Y6cORf3ffy0ZyFK+M8DCb6YUElixVQyaIFdOTEGR3996watvlEUtS4hWZvsOdfm+b1tHXXQV2+ekOrNmzTqg3bYi2Pvk324UN/zZq/XLPmL4+zjYL5ciqFk2Oc+dLL/YxfRpf2TbV15wGFhoVp8q9/aPKvf8jS0kJOyR1f+QnFjo4OGv3N5y8sV6lccZ2/dE0hIaFq1+NLSTIHo6/KwkIaPriX7nl56+SZi/r192Vyc3NR47pV9UXfLhr4zTiFhobpq+9+jrNuuxb1zdP58+TQhUseuu15X7Vb9JQk/fzjEJUpEf/Yx9FqVS2nRX/F7nlcu1o58/TrXj8vc85ihnmDvx0vSapbo4JGfNnnuceQEPnz5NCOPYf1KDhEjdp9Kkn66vNu5uExMmVIq3KlimjfoaixjrNnyagCeXO+cLs5smVSSldnefv46dTZi7EC6KUr3c0PvvL28VPHj2P37u3Wobn5YWf9en6oU2cvyj8gSAOGxe4h36NjS6V5PJxD2jRu6t6xhab/9qfOXbyqxu37mss5JXdQv54fml9v23NIi1dseMb5yK6qFUrFuyymN3EMp85e1N6Dx83Lps5Zoqlzlphfp0ubynzLcYZ0adSlfTPNXrBcZy9cNbeTUlSv+KeHI4ge89nWxkbFCuXVm9a9Y8vnPrAOAICkgJ6uAAC8R6ytrTV25ACVLFpAyeztlDa1m/r1bK96NSvGKeuQzF4zJnyjzu2bKluWDLK1sZGDg73y58kRb4+r+DRrUEPjvx+kkkULyNEhmaytrZQ5Yzp91LaJfhn9lbnn2Mvq1bmVeTq651+aVCk195fv1aJxLaVLm0rW1lZycXZS/jzZ1bl9U9Wv9aT33P+G9VXtauWVzN5OLs5OateygT5oWse8PPo25zfB0SGZfh0/XB1bN1KWTOlkY2Mtp+QOypU9i9q2qGcO9DJlSKumDaorR9ZMSu7oIFsbG6VPm1pNG1TXT9/2f+b2X+Zn/DKyZEqv8aMGKXeOLLKxsVa2LBn0v6/7KVeOzK+13YTo1KaJ2jSvJ1eXFHJIZq/qlcvou68+efGKL2Bna6sxIwYoU4a0kqSffv5Nu/cfU5mShTVr0ghVq1hars4pZG1tpdSpXFWyWAH1790xVi/LHh1bqnK5EnJK7vCMvcQvf54c5v1KUWNgFiucL1aZ17l+XuacFS6QWx93aa20qd1kaWnsHxxaNa2jejUrxRnvNKYWjWqZpxM6NqelpaUaPL6mt+069Mr1y5Ylg2ZOHKGqFUvJKbmjbG1tlCdXVg0f1Esd2zSOVbZTmyYaNqin8uTKKltbGzkld1TViqU0c+IIZcvy5AE0TetXV6H8ueXqnEJWVlZySGavvLmyqedHH2jKmK9fud0z4hheRrcOzfX1gB7KnTOrbG1s5OiQTOVKFdH0ccPjPOE8+uFuVSuWkqPjy10LAAD8V1mEhoa8xOM7AQAA3n1nzl9W2tRu5ofA3Pa8p/5fj9H1m55ydUmhNYumPHO8VgDGWr1hm36cNEc2NtZa8fvEF44fHe3OXS+16TZIYWEmzf55pArme3EP2f+qfYdOaMCwsWrVtI4G9Olk6Lbv3X+gFh8NUHh4uGb/PEIF8+UydPvxCQ4JVYtOn8vOzlZLZo957kPzACQ95et2kBT34YLA+4bhBQAAwHtnjfsO/b1+q1ycnWRlZSlvn4eKjIyUpaWFBvTuROAKvAXLVm3S0pXuuu15X5LUoFblBAeukpQ+bSo1b1hTf/69UX8sW6sfhn/2pqqapEVGRuqXmYtkaWmh9h80MHz7S1a4Kzw8XFUqlHzlwHXx8vX64691CgsLV+N6VfVp93bmZd+OniZfv4f6+cch5nn2drb6oEltzZq/XH+t2qwPWzV87eMA/kuad/pcnne9JEWN/ZzCyVG5smdR80Y1EzQECgBjELoCAID3TsliBXTp6nV53Lgj/4AguTg7qXCB3GrfsoGKvoXxCAFIfg/9devOPSV3dFDFssX02ccfvnilp/Tv3VH9e3d8A7V7fxw8ekpXr99S8SL5lC5NKsO336/Xh+rX6+V/dtEuX7uhyTMXqXCB3HJ0SKY/lq1TiSL5VaFMMe07dEI79x7Rwl9/jLNevZoVo0LXNZvVrmV9WVryxzLgZZUsVkCZ0qfVhcseOnDkpA4cOakOrRrpk+5t4y1vMpme+bBWAC+PqwkAALx3alUtp1pVy724IIA3hochvR079hyWpDjjsH4+9CddvnZTfg/9ZWVppZzZM6lHpw9UtmRhSdL3437V+s271LxhTT3w8dWBIyeV0sVZfXu0U/XKZSRJfQaP0rF/z6lTm8Y6fe6yTp65qPTpUmvIZ13jjFH8LFc9bkXV5+MOyp41o2o07a4rHjdVokh+jf1lnrp1aB7vQ+AypEujDOlS67bnfV247KF8ubO/8jkC/qtqVC6rFo1qSorqcT555iItXLZWNauW1eSZf5iv739PX9Cpc5c06uu+Cgszad7iVfK866Xg4BC5uqRQ5fIl1a9ne9nb22nSjIVautJdbVvU02e9OmjNxh36YcIsVa1YSqO/+VyHjp1SvyGjlSlDWi2bO16PgoM1fsrv2rnviBwdHdS7S+s49QwJDdWCpWu0efs+3b3vrbSpU6pmlXLq1LaJ7O1s9eXIidq594j69+6o1s3qaubvf2nuor/NdVjtvl0/Tpyt0sULafLoIYa0XYAR+HMhAAAAACRR5y9dkyRlz5Ix1vw7d71Usmh+Na5XTUUL5dHpc5c1dNTPeuDtG6vcynVbZDKZlCdnVt25e1+jJsxUYNCjWGUW/LlWLs5OypQxrTxu3NZ3Y39NcP2yPa7XuCnzNPjbCZKkHFkzaeb85Uqe3EFtW9Z/5rrZs2aSJJ05fyXB+wMQv7Yt6iulq7Mkacfew+b5C/5cK1tbG9WvVUnOTsnlec9LqVK6qFa1cmpQJ+qBhivXbdGsBcslSSWL5pcknTh1Pur/k+ckSf+euhBrfsliUWO1Tv51kdZt3iXJQqWKFdSMucvi1G30pN80Z+FKBT0KUZ3q5RX0KERzF/2tMZN/e7zPqG0dj97n4/+Pn4z9OnqfMY/tVdsuwAiErgAAAACQRPkHBEqSHB0dYs2f9MOXKpgvlxwdkilr5gyys7NVUFCwTp69GKtc2ZKFNf77wRo7cqAkKSgoWNdv3olVpkn9ahr1dV99M6iXJOnO3fvy9fNPUP1yZc+sfj3b6+59b128fF0ftmooN1dn/bV6k776vJuWrnBX+x5fqlPvodrwz+5Y6zo6JJMkPfQPSODZAPAsFhYW5iFIfHwemufXqlpWP/84REP791CxwvnUtkV9tWxSW2lTu5nbD0k6eOSUJKl4kfyysrTUhUseCnoUrBOnLyhr5gzy8Xuoqx63zMFoqaIFFRERofX/7JIkfdGvi74e0EM/fhN7fG5fP3+5b4m69n8Y1k9D+/fQD8P6SZI2/LNbvn7+5jD1xKnzMplMOnP+irJmzqCLlz0UGPTIHLqWeip0fZ22CzACwwsAAAAAQBKV/HHYGhSjd+rJMxf1yRf/U1iYKU55H9+HsV5H37afwsnRPO/Ro+BYZfLnziFJcnqqjIuzU4Lq2K5lA7VrGfWQr/DwCHXr941aNKol/4AgTZm9WKO//Vz37nvrf+NnqkDeHOaQJ7rHbYrkjs/cNoCEiYyMlOe9qIdrubqm0PVbUX9cKV4kf6xyQ0ZO0p4Dx+Ks7+PnJymqzcmTK5vOXrii7bsP6ebtu/qqf3eN+fk3HT5+WqfPXpYklSiWX75+/goNDZMkZXt8XT/dK/+25z3zdPasGWP9H728QN6ccnVJIW8fP23atk/BISHq2LqRRo2fqa27DurWnXtydEimfI/bqmiv23YBr4uergAAAACQROXNlU2SdPX6LfO8LTsPKCzMpAJ5c2rzipnavuY3czgbGRl7fWtrK0lRveCexVxGcct4PfDRteu35fXAJ0H1XbrSXX4P/dWr8we6cPmaJKlMiUIqUTS/wiMidOnqDXPZa4+PKW/ubAnaNoBnW7x8g7x9ooLTKuVLmufb2tiYp/0DAs2B6/dDP9WeDfPVu2vUGKwx247o2/0X/LlGklShdFHlzplVy1ZtUnBIiHJkzaSULs5ycXYyb//a9duSYrdVUtT4zdGiy0T/H3N5icfh8II/1yiZvZ3q1qggF2cnLVgaVYeihfLKyip2xPW8tgt4G+jpCgAAAABJVJUKJfX3+q06fOy0urRvJklyezxu47XrtzRx+gJduXZTwSEhb2T/0+f+qfWbd6lB7coa/vgW3me543lfsxcs1/dDP1Uye3tzj9YvR0wy92rNmim9ueytO/eUOpVrnN5rABJm664DunDpmi5c9tDZC1FjI3do1Uj588R/TSWzt5ODg72CgoK1ePkG7T14XDv3HolTrmSxAlq4bK2uXb+tjOnTKJWbq4oWyqulK93NyyXJ0tJS9WtV0qoN2zTml7k6cPSkDh8/HWtbLs5OqlujgjZu3auho35WuVJFtP/wv5KkejUrmnullixWQFt2HtC167dVqlhBWVtbq0jBPOb6PT20APAuoKcrAAAAACRR5UoVUdbMGXT81DnzrcOtmtZRrarlJEkHjvyrRnWrKJWba2JWU5I0dso8VShTTBXLFpckVS5XQu1aNtD5S9fkec9LfXu0V64cWSRJ7lv3SJI+aFI7Tu81AAlz5PgZrdu8U/e8HqhsycIaM6K/Pune9pnlra2tNfLLT5QpQ1pdunJd97181KFVozjlihXKa+5FWqxwPvO8aDEfaNWv14eqX6uSIiMjdejoKfXo2DLO9oZ81k2d2zeVvZ2dNm3bJztbW3Vu11Rf9utqLlOqWMEn+493n0+WA+8Ki9DQkMgXFwMAAAAAvIv2HjyugcPHqVXTOhrQp1NiV+e1BYeEqkWnz2VnZ6vFs8bI3s42sasEAMBLI3QFAAAAAAAAAANxnwYAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF1fUmRkpEwmkyIjIxO7KgAAAAD+o/heAuBptAvAu8U6sSuQ1ISHh6tyw85aMW+8rK2tFBERLktLK0kyT8c371nTSaWstbWVXF1djT+heG0mk0nu7u6qV6+erK2t5ePjI5MpnJ8rAHN7IL3bnzGUffNlIyIitWXLP6pZs5asra3jLftf+Ex4+jMTSMqiv5fsWjeP9zMASbQLwLuGq/AVRUREKCLCQuHhEZIsJMk8Hd+8Z00nlbIm02udLrxFUYFrBD9XAOb2QHq3P2Mo++bLRkZGKiIi8vHvL/F/RvCZAAAAABiH4QUAAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAayTuwKAAAAAABeTbNmLWRhkdi1gNFcXV00f/78xK4Gkqj3rV3gekBSRegKAAAAAEnUtGnTZG1tldjVgMF69eqV2FVAEva+tQtcD0iqGF4AAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIHey9D1p59/09TZSxK7GgAAAAAAAAD+g6wTUqjP4FE6dfaSrK2szPNsbW3kvmzGG6vY6/jys66JXQUAAAAAAAyxadteLVnhrktXrysszKTiRfJp2thhkqQ7nvc1dc4Snbt4VV7evrK3s1W+3NnV86MPVCBvTknSwaOnNH7q7/J64KNSxQrq64E9lcLJUZK0av02zZz/lxbPGmOeB7zrnndNSFLzTp/L865XrHWsLC21e8N8SVwTeDsSFLpKUp+ubdW2Rb03WRcAAAAAAPCUS1dvyNLSQpkzptOVazdjLbtz97527D2sooXyqmTRAjpw5KQOHDmpM+cva8nssXJxdtKI0dNkb2+napVKy33Lbs1fulqfdm+nB96+mjpnsQb37UK4hCTleddETK2b1TVPW1lG3ewdERHBNYG3IsGha3zOX7yqT774Qb9O/EY5s2XWQ/9Adeo9VD0+aqmGtavo+3G/ysLCQv7+gTp07JQypE+jwZ92VtFCeSVJ7lt2a8HStfK85yWn5I6qX7uSenb6QBYWFpKk8nU7aHDfLlq+erM873upRJH8+vaL3kru6KDQ0DCN+WWudu8/KpMpXGlTu+nrgT1UIG9OfT/uVyV3dFD/3h0lSWcvXNHE6Qt01eOWUrm5qEv7ZqpTvYIkafaC5Tp38ZrSpUmljVv3yNEhmT7t3k61qpV7nVMDAAAAAIAh+nRtI0maNmdJnIApc6b0Wj5vgtKkdpMk3bpzTx90HiD/gCD9e+aCihTMIx+/h/qkVVt1aNVIVz1u6qpH1DYmTJuvQvlzq3a18m/3gIDX9LxrIqboXCgm34f+XBN4K15rTNe8ubOrW4fm+uaHqQoOCdUPE2epaKG8ali7irnM5m371KheVW1aMVMtGtXS4G8nyD8gUJLknMJJP37zmf5ZOUtjRg7QqvXbtGnb3lj72LrzgH4Z85X+XvCz7nl5a8mKDZKk9f/s0qUr17Vs7nhtXjFTP37zmdxcXeLU0T8gUP2/HqPa1cprw5/TNLhvF42eNEcnTl8wlzlw5F8VK5xX7stmqOdHH+jHSbMVGPTodU4NAAAAAABvXGo3V3PgKklhYWExlqWUSwonuTqn0LK/N2n4D1N04ZKHsmfNpN37j2nfoRMa3LdLYlQbeCvqtOylms27q8fnI7Xv0AlJ4prAW5Pg0HX63KWq3aKn+V+/IaMlSW1b1Fea1CnV47MRunTlur7o2znWeiWLFVDlciVkbWWlFo1qKqWrs/YcOCZJKl+6qLJkSi8LCwvlyZlVtauV19ETZ2Ot/2Grhkrp4iyn5I6qXrGMzl28JkmytrJS0KNgXbt+W5GRkcqSKb3SpnHT0/YePC4X5xRq1bSOrK2tVaJIftWpXkEbNu8yl8mbK5tqVS0nKytL1a9VSWEmk27c8kzoqQEAAAAAINE99A/UyDFRz16pX6uSCubLKUtLS40Y0kf29nbac+CYKpQpplZN6mj81Hnq8dEH8rhxW936fas23QZpyuzFCg+PSOSjAF5fCidHValQUrWqllPWTOl16uxFDf52gs6cv8w1gbcmwcML9O7SJt4xXS0sLNS8YU19OXKi+vZoL0dHh1jL06VJ9dRrN9338pEk7T/8r+YsXKkbt+7IZApXWJhJ5UoXiVXeLaWLedre3k5Bj6J6oNarVUle3r4aM3mu7t5/oMrlS6hvj/ZycXaKtf69+95KnzZ2HTKkT63jJ88/2UeMHrIWFhays7VVED1dAQAAAABJxM3bdzVw+Fhdv+mpBrUra2j/HuZlZUoU0tI5Y82vJ06fL1eXFGpQq5JadOqvFo1qqUqFkuozeJSyZEynJvWrJ8YhAIaZN2WUeejKiIgIde37jc5fuqbtuw+pQN6cXBN4K15reAEp6i9pE6bNV9MG1fX7ktXyvBf76XBPv757/4FSp3JVWJhJX333s5o1rK7Vf/yif1bOUrOGNaTIhO3X2spKnds11YIZP2jJ7DG6e++B5ixcEadcmtQpdeepJ9bd8fRSmlQpX+5AAQAAAAB4B504dV49Ph+hG7fuqnvHlho+qJesrOL/un/m/GWtXLdVX37WTbfu3FPQo2AVK5xXhQvkVnJHB52/7PGWaw8Yy++hvx76B8SaF/k4bAoJDYtTnmsCb8prPUhLkn6cOFvFCufVkM+6ySFZMo0YPU1Txw4zN/BHjp/RngPHVLZUEa3buFMPvH1VoUxxhYaFKTQsVM5OTrK1tdHpc5e0eds+FS6QO0H7PXz8tFI4JVeObJlkb28nW1sbWVlZxSlXvnQxTZi2QMvXbFbTBjV06sxFbdq2VxNGDX7dQwcAAAAA4I3bsfewdu49onMXr0qSPG7c0ffjfpVzCic1rltV/YaMVmhYmLJkSq+H/gGaOH2BJKlO9QoqmC+neTum8HCNnjRHrZrWUd5c2eTr5y9bGxtNmb1Yq923y9fPX9kyZ0iUYwRexvOuiUpli6n/sLEqVayA0qRy0/lLV3XhkoesrKzMD1WPxjWBNynBoeu035Zo5u/LYs3r0r6ZLly+pvnT/idJ6tO1tXr2H6l5i/9Wtw4tJEm1q5fX6g3bNfyHKUqfLrV+GjFAKZwcJUkDP+msn36eo29/ClaJIvlVs2pZ3bvvnaD6ePv4adyU33Xv/gPZ2dmqdPGC6taheZxyKZwcNWHUYE2asVDTf/tTqdxcNbhvZxUtlDehhw4AAAAAQKK5eNlD62M8l8Tbx0/rN+9SurSpVKlsMYU+fnjW9Zt3dP3mHXO5PDmzxgpdF/+1XoFBj9SjY0tJkouzk4YO6KEZc5fqyPEzqlezkpo1qPGWjgp4dc+7Jto2r6salcvqxKnzOnzsjBwdkqlsycLq0r5ZrOtB4prAm2URGhqSwBv6X973435VckcH9e/d8U3t4q0zmUyq3LCz/vptrKytrRQeHm7uYRs9Hd+8Z00nlbKWlpZKnTr22Lh4N5hMJrm7u6tevXqytrbW/fteioiI4OcKwNweSO/2Zwxl33zZyMhIbdmyRTVr1pS1tXW8Zf8LnwlPf2YCSVn095Kls0bL2jruHX9I2nr16qU1a1YndjWQxLyv7QLXA5Kq1x7TFQAAAAAAAADwBKErAAAAAAAAABjojd5XNXxQrze5eQAAAAAAAAB459DTFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBrBO7AgAAAACAV9OnTx9ZWCR2LWA0V1eXxK4CkrD3rV3gekBSRegKAAAAAEnU33+vkLU1X+sAPEG7ALwbGF4AAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQNaJXYGkJjIyUpJkMoVLksLDw/V4lnk6vnlJvaylZaRMJtPrnDq8ISaTSeHhEeafj8kUroiICH6uAMztgfRuf8ZQ9m2UjVR4RMTj318s4i37X/hMePozE3ialZWVLCwsErsaCfLkewnvZ+BNol0A8LSEtgsWoaEhkW+hPu+N4OBgVW/aPbGrAQAAAMBgu9bNk7V10uiXwvcS4O2gXQDwtIS2C4SuLykiIkKhoaFJ6q9dAAAAAF4sKf2Oz/cS4O1IStcY7QLwdtDTFQAAAAAAAAASAQ/SAgAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0fUmRkZEymUyKjIxM7KoAAAAA+I/iewmAp9EuAO8W68SuQFITHh6uyg07a9e6ebK2/u+cvj179iowMFBBQUFycHCQpBdOJ4WySaGOLyobHh6uPXv2qGLFirKyspKjo6MqVqzw1n+uL7NfAMDbZTKZ5O7urnr16r33v79Ef7ZJcT+7nv7MTOzP8P9K2Xe5jkn595f/6vcSAM9GuwC8W7gKkSCBgYEKCQlRaGiorKysJOmF00mhbFKo44vKhoeHy2QyKSQkxLwsMX6uAAC8C6I/26S4n11Pf2Ym9mf4f6Xsu1xHAACAN4XhBQAAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABrJO7AoAAAAAAF5Nnbr1ZJHYlcB7IXXqVFqyZEliVwMGoF3Am0RbkXCErgAAAACQRHXp0kVWltzAiNc3Z86cxK4CDEK7gDeJtiLhuAoBAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGOiVQtd5i1fpmx+nJLh8+boddOGyx6vs6pX89PNvmjp7yVvbHwAAAAAAAABEs45vZo2m3czTIaGhsrKykrWVlSSpaKG8mvi/LwyrwB3P+2rxUX9tWv6rnJI7GrLNLz/rash2AAAAAAD4L9q0ba+WrHDXpavXFRZmUvEi+TRt7DDz8uadPpfnXa9Y61hZWmr3hvmSpINHT2n81N/l9cBHpYoV1NcDeyqFU9R3/lXrt2nm/L+0eNYY8zwASd+VazfVtd83CgkJVUpXZ61bMlV3PO9r6pwlOnfxqry8fWVvZ6t8ubOr50cfqEDenJLe3/Yi3tB166o55uk+g0epSvlSatui3lurFAAAAAAASDyXrt6QpaWFMmdMpyvXbj6zXOtmdc3TVpZRN9NGRERoxOhpsre3U7VKpeW+ZbfmL12tT7u30wNvX02ds1iD+3ZJcgEKgGcLDgnV8B+myGQKjzX/zt372rH3sIoWyquSRQvowJGTOnDkpM6cv6wls8fKxdnpvW0v4g1dX2T2guW6ePm6fhrRX1JUkv3DxFm66nFL+XJnV/68OXTm/OVYfwU7dfaSRv40XZ73vVSiSH59+0VvJXd0ULd+30qSmn7YT1JUL9W6NSrq/MWrmjxzkS5eua4UTo7q2Lqxmjaobt7/uYvXlC5NKm3cukeODsn0afd2qlWtnCTp+3G/Krmjg/r37mjuSfvN4I81Z+EK+T0MUJUKJfXV591kbR11+Ft3HdS0OUvk6+evmlXKysvbV/nzZFf3ji1f8bQCAAAAAJB09enaRpI0bc6S54au/Xt3jDPP96G/fPwe6pNWbdWhVSNd9bipqx5R25gwbb4K5c+t2tXKv5mKA0gUk2YskOd9L3Vs3UjzFq8yz8+cKb2Wz5ugNKndJEm37tzTB50HyD8gSP+euaAiBfO8t+3Faz9Iy2Qy6YsRE1S+dFG5L5uhPt3aaO3GHXHKbd15QL+M+Up/L/hZ97y8tWTFBknSnMkjJUmr/pisravmqG6Ninrg7at+X/2k5o1qasOf0/XTiP6avWC5Dh07Zd7egSP/qljhvHJfNkM9P/pAP06arcCgR8+s575DJ/T7tP9p0ayfdPjYaW3culeSdP3mHY0cM10DP/lI7n/NUIG8OXXgyMnXPS0AAAAAALz36rTspZrNu6vH5yO179AJSZJLCie5OqfQsr83afgPU3ThkoeyZ82k3fuPad+hExrct0si1xqAkbbuOqhV67fpi75dlSlD2ljLUru5mgNXSQoLC4uxLOV73V68duh66uwl+T0M0EftmsrGxloF8+VSzarl4pT7sFVDpXRxllNyR1WvWEbnLl575jY3bNmtYoXzqlbVcrKyslTObJnVsE4Vbdq2z1wmb65s5uX1a1VSmMmkG7c8n7nNrh82l6NDMqV2c1W5UkV07uJVSdI/O/arVLGCKl+6qKytrNS0QXVlyZju1U8IAAAAAADvuRROjqpSoaRqVS2nrJnS69TZixr87QSdOX9ZlpaWGjGkj+zt7bTnwDFVKFNMrZrU0fip89Tjow/kceO2uvX7Vm26DdKU2YsVHh6R2IcD4BXd8byv0ZNmq2GdKqpbo8Jzyz70D9TIMTMkSfVrVVLBfDnf6/bilYYXiMnrga/cUrqYH7QlSelSu5m7AkdzS+linra3t1PQo2f3Sr1z10v7Dp1Q7RY9zfMiIiJUtFDeJ9tzfbI9CwsL2dnaKug5PV3dUjrH2n9AYJC5/mljJO6SlDZN7NcAAAAAAOCJeVNGycLCQlLU9/Wufb/R+UvXtH33IRXIm1NlShTS0jljzeUnTp8vV5cUalCrklp06q8WjWqpSoWS6jN4lLJkTKcm9asn1qEAeA079x2Rf0CQPO96aeDwcbrv5S1JCggI0sDh4/T1wB5K6eKsm7fvauDwsbp+01MNalfW0P49zNt4X9uL1w5dU7m5yNvHV6bwcHPw6nn/QYLXt7C0iDMvbeqUqlqhlL4f+unrVu+FUrm56PS5y7Hm3b33QAXz5Xzj+wYAAAAAIKnxe+gvSXJO4WSeF6lISVJIaFic8mfOX9bKdVs1a9II3bpzT0GPglWscF4VLpBbyR0ddP6yx9upOADDRUZd+jpy4kys+aFhYdp78LhCgkN14tR5DflukvweBqh7x5bq1qH5M7f3PrUXrx26FsqfS8kdHTV/yWp1atNYFy57aOvOA8qeNWOC1ndxTiFLSwvdunNP+XJnlyTVq1lJS5YP07ZdB1W5fAlJ0hWPWzKZTCqQ19gwtGaVsvp98WodOHJSJYsV0IZ/duv6c4YpAAAAAADgfbdj72Ht3HvEPDSfx407+n7cr3JO4aRKZYup/7CxKlWsgNKkctP5S1d14ZKHrKysVKd67NuLTeHhGj1pjlo1raO8ubLJ189ftjY2mjJ7sVa7b5evn7+yZc6QGIcIwABtW9RT2xb1zK/XbdqpUeNnKqWrs9YtmaqrHrfUb8hohYaFKUum9HroH6CJ0xdIkupUrxCr0+P71l68duhqbW2tMSP668dJc7Twz7XKnyeH6taoqGvXbyVofXs7W3X9sIUGfD1WYSaTBn3aWXVrVNDEH77QtDlL9NPk3xQREalsWTKoR6eWr1vdOLJmzqDhg3pp7C9z5evnr5pVyqpUsQKysbExfF8AAAAAACQFFy97aP3mXebX3j5+Wr95l9KlTaW2zeuqRuWyOnHqvA4fOyNHh2QqW7KwurRvFueu0cV/rVdg0CP16Bj1fd7F2UlDB/TQjLlLdeT4GdWrWUnNGtR4q8cG4O3x8fVT6OOHZ12/eUfXb94xL8uTM2usNuN9ay9eGLpOGzsszrzuHWOHn7lyZNGcySPNr0f/PCfWOKn7Ni6MVf7pFLxbh+ZxuhbnzZVNP/84JN46Pb1/Sdq8YqZ5evigXubp9OlSx9l//94dY72uVa2calV78vCvNt0GqX6aSvHuGwAAAACA9133ji3j/e4d7dsvPk7Qdjq2aayObRrHmle3RoUXPnAHQNLUsE4VNaxTxfy6RNECcXK5Z3nf2gtLIzZy/OQ53b33QBERETp07JQ2bd2rGlXKGrHpt2LX/qMKDHqk0NAwLfprvby8fVWuVJHErhYAAAAAAACAJOi1hxeQpFue9zT8x6nyDwhUmlQp1btrG5UtWdiITb8VBw6f1Pdjf1V4eLiyZEqvsSMGxBoQHAAAAAAAAAASypDQtWHtKmpYu8qLC76jBn36kQZ9+lFiVwMAAAAAAADAe8CQ4QUAAAAAAAAAAFEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMJB1YlcAAAAAAPBq5s6dK4vErgTeC6lTp0rsKsAgtAt4k2grEo7QFQAAAACSqE0b3WVtzdc6AE/QLgDvBoYXAAAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMJB1YlcgqYmMjJQkmUymRK7J2xUeHhH1LyLqf0kvnE4KZZNCHV9UNjw8QhGRkY/nWyg8PCLB709Df64vsV8AwNtlMpn+M+109GebFPezK85nZhL6vE/KZd/pOj51XVhZWcnCwkJJwX/1ewnwttEuAHhaQtsFi9DQkMi3UJ/3RnBwsKo37Z7Y1QAAAABgsF3r5snaOmn0S+F7CfB20C4AeFpC2wVC15cUERGh0NDQJPXXLgAAAAAvlpR+x+d7CfB2JKVrjHYBeDvo6QoAAAAAAAAAiYAHaQEAAAAAAACAgQhdAQAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRur6kyMhImUwmRUZGJnZVAAAAAPxH8b0EwNNoF4B3i3ViVyCpCQ8PV+WGnbVr3TxZW3P6kPhMJpPc3d1Vr169RH1PzpkzRw8ePJAk+fj4ytXVxfx/zHnPmn7fyiaFOlI2aZZ9mW25ubmpW7duAhLyWRGzHX+Z90587X/M6bd9rTyv7u/KZyZgBL6XAHga7QLwbuEqBGCIBw8eyN8/QJIUGBgoa2tr8/8x5z1r+n0rmxTqSNmkWfZltgW8jJjt+Kuu9y5cKwAAAMC7gOEFAAAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRugIAAAAAAACAgQhdAQAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRugIAAAAAAACAgQhdAQAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGsk7sCgAAAAAAXk3lKlVlkdiVwHslXbp0WrFieWJXA6+BdgH/Ne9qu0XoCgAAAABJVKGCBWVhQbwC45w6dSqxq4DXRLuA/5p3td1ieAEAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADWb/Oyn0Gj9Kps5dkbWUla2tr5cyeWf16tlf+PDmMqh8AAAAAAEgkm7bt1ZIV7rp09brCwkwqXiSfpo0dZl7evNPn8rzrFWsdK0tL7d4wX5J08OgpjZ/6u7we+KhUsYL6emBPpXBylCStWr9NM+f/pcWzxpjnAYARvh/3q9Zv3hVn/ozxw1W0UF6FhoZp4PBxunzthvwDApXc0UG5c2RV944tVKRgHknSxq17NWPuUvkHBKlqxVIa8lk32dhERakz5v6pXfuOat7UUeZ5T3ut0FWS+nRtq7Yt6ikszKRff1+mr777WX8v/Pl1N/tWmEwmWVu/9ikAAAAAAOC9dOnqDVlaWihzxnS6cu3mM8u1blbXPG1lGXVTbUREhEaMniZ7eztVq1Ra7lt2a/7S1fq0ezs98PbV1DmLNbhvFwJXAG9M9UqllTpVSvPr1KlcJUnhEeHy8vZR2ZKFlczeXoeOndKhY6d05vxluS+brsCgR/phwixlyphWBfLm1PrNu1Qgbw61bFxbl67e0OLlG/TLT189M3CVDAhdo9nYWKtBrcr6Y9k6+fg+lIuzk5at2qTla/6Rt4+fcufMoi/6dlG2LBklSYGBQZo+d5n2HDiqhwGBypopvX4c/rnSpnGTt4+fxk/9XUf/PSs7W1vVq1lR3Tu1lLWVlTp+PFTtWtZXg9qVzfvu//UYFSucTx+1baKgR8GaNmepdu8/qtDQMJUtVUQDP+mk5I4OuuN5Xy0+6q+vB/TQvMWrFPQoWHWqV5B/QKCGD+pl3t78pat17N9zmvi/L4w6PQAAAAAAJDl9uraRJE2bs+S5oWv/3h3jzPN96C8fv4f6pFVbdWjVSFc9buqqR9Q2Jkybr0L5c6t2tfJvpuIAIOmDJrVVomiBOPOT2dtr8awx5tfnLl5Vl0+HKzDokXz8/HXvvrdCw8LU9cPmqlmlrOq37q0rHrcUERGhn36eo0Z1q5h7xD6LYaFrcEio1mzcLhdnJzk5OWrF2n+0xn2Hxn03UOnTpdaKNf9o0DfjtXjWGNnYWOv78TMVHByimZNGyM3VWRevXJedna0k6ZvRU+Xm6qLlv0+U38MADRw2Vvb2durcrqnq1awo9y17zKHrA29fHT5+WkM+6yZJ+t/4mbKystKCGT/I2tpKP06crfFTf9e3X/Q213XX/qOaO+V72Vhb65bnPfX8fKQGfvKRHJLZS5LWbdqlnh99YNSpAQAAAADgvVanZS+FR4QrR9bM6vphM5UvXVQuKZzk6pxCy/7epPMXr+nCJQ+1bVlfu/cf075DJ/THzJ8Su9oA3nNfjpyk0LAwZUiXWs0a1FDrZnVlYWFhXj5n4Uo98PbVoWOnJEmN61VVajdX2dpYy9bGRjN//0ubtu6Vr5+/cmTNqOVr/pHnvQealICOmq/9IK3pc5eqdoueqtG0mzZt26cfh38maysrLV/9j3p0aqnMGdPJ2spKrZvVVUhomE6fuyRvHz/t2HNYQz7vptRurrK0tFTeXNnk4uyke17eOnL8jD7r9aEcktkrfdpU+qhdU/M4DHVrVNCxk2d1z8tbkrRp+z4VLZRXadO4ycf3obbvOaRBn3aWU3JHJbO3V49OH+ifHfsVHh5hrnO3Di3klNxR9vZ2ypkts7Jlyahtuw5Kkk6euShfP39VLlfidU8NAAAAAADvtRROjqpSoaRqVS2nrJnS69TZixr87QSdOX9ZlpaWGjGkj+zt7bTnwDFVKFNMrZrU0fip89Tjow/kceO2uvX7Vm26DdKU2YtjfW8HgNdhY2OtksUKqGbVsipVrKA8btzRpBkLtWSle6xyazft0Mp1W3Tz9l2lSumi0sULSZKcUzhp6IAeCg0N1ZETZ9SgdmWVK1VUM+b9qYGfdNLOfUfVqfdQte/xpRYuWxtvHV67p2vvLm3UtkU93fPy1hffTtClqzdUrHA+3bnrpZFjpsvS8kmuG2Yy6Z6Xt2xsbGRrY6N0aVLF2d59L2/Z2toopauzeV7G9GnMIWsqN1eVLFpAm7buVYfWjbThn91q0zxq7Jg7d+8rIiJSLT/qH2ublhaWeuDja36dNrVbrOWN6lbRus071bBO1P91a1SQra3N654aAAAAAADea/OmjDL3GouIiFDXvt/o/KVr2r77kArkzakyJQpp6Zyx5vITp8+Xq0sKNahVSS069VeLRrVUpUJJ9Rk8SlkyplOT+tUT61AAvEe+7Nc1Vo/WSTMWaulKd23ZsV/tWtQ3z185f5KCQ0K1//AJfT1qsr75caqyZEynvLmzq26NCqpbo8KTbY6YqFLFCip7loz6sOcQffZxB6VN7aYvR05UnpzZVKZEoVh1MGx4gTSpUuqrz7up96BRqlqxlNKkTqnPP+6g8qWLxinr7eOn0LAw3b33QGnTxA5AU6dKqdDQMHn7+JmD1zt37ytNjEFv69eqpPlL16h8maK6cdNT1SuVkRQVplpaWmjNol9kb28XZ793PO9LkiwtLWLNr1OtvH6ZuUhXPW5py44DmjJm6OudDAAAAAAA3nN+D/0lRfUIixapSElSSGhYnPJnzl/WynVbNWvSCN26c09Bj4JVrHBeFS6QW8kdHXT+ssfbqTiA996NW57Kkim9+XVkZFTbFPq4bQoMeiRHh2SSJHs7W5UvXVT29nYKCgrWpWs3lDd39ljb27broI6cOKNFs37SyTMXFR4RoZJFCyhd2qgOpRcuX3tzoask5c2dXcWL5Nfvi1frgya1NWv+cmVIl1pZM2dQYGCQjpw4q5LFCiilq7OqlC+pMb/8pq8+766Uj8d0TZfGTWlSpVTJogX0y6xF+qJfF/k9DNC8xavUoNaTB2dVrVBKY36Zq19mLlLViiXNY7G6pXRRlfKlNG7q7/q0ezu5ODvpgbevTp69qGoVSz+z3o6ODqpWqbS+HT1V6dOlVt5c2Yw8LQAAAAAAJEk79h7Wzr1HdO7iVUmSx407+n7cr3JO4aRKZYup/7CxKlWsgNKkctP5S1d14ZKHrKysVKd6hVjbMYWHa/SkOWrVtI7y5somXz9/2drYaMrsxVrtvl2+fv7KljlDYhwigPdQ2+5fqHCB3MqeJaPuP/DRvkMnJEV15JSkNe479NfqTSqUP5eS2dvr+KlzCgoKlq2tjYoVyhdrWwGBQZowfYE+7tJaaVKlVNbHYe4PE2cpmX1UJpk1nvbrtcd0fVrndk21xn27qpQvqYZ1Kuur735Wzebd1bbHl9q0ba+53PDBvZQmlZu69P1GtVv21JjJcxUSEipJGjmkj0JCQtW84+fq1f87VSxTTB1aNzSva29vp+oVS+vAkZOqHyOMlaRhg3rKKbmDuvb9RjWbd9fHA7/X+YvXXljvxvWq6eKV62pUp4oxJwIAAAAAgCTu4mUPrd+8S1eu3ZQUdefq+s27tG33QWXKkFY1KpfVVY/bWr95lzzvPlDZkoU1dcxQFcyXM9Z2Fv+1XoFBj9SjY0tJkotz1HiJwcEhOnL8jOrVrKRmDWq89eMD8H5q07yuAgKCtHn7Pp04dV55c2XTsIE91a5lA0lSjmyZ5OLspL0Hj2vd5p0KDHqk6pXLaPq4YcqYPk2sbU2bs1Tp0ripRaOakqRcObKob4/2unPXS+cvXVO7FvXjfTbUa/V0nTZ2WJx5hQvk1o61cyVJLRvXVsvGteNdN7mjg778rKu+jGeZW0oX/TD8s+fue9igXho2qFec+Y4OyfRZrw76rFeHOMvSp0utfRsXxru99GlTycbGOtZYDQAAAAAA/Jd179hS3R8HpfH59ouPE7Sdjm0aq2ObxrHmPT1eIgAYJb5cMKYyJQrFGQ7gWb7o1yXOvPYfNFD7Dxo8dz3De7omReHhEVrw51rVrFI21lg0AAAAAAAAAPCy/vOh623Pe6rVvIeO/3tOvTq3SuzqAAAAAAAAAEjiDH2QVlKUIV0abVs9J7GrAQAAAAAAAOA98Z/v6QoAAAAAAAAARiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQISuAAAAAAAAAGAgQlcAAAAAAAAAMBChKwAAAAAAAAAYiNAVAAAAAAAAAAxE6AoAAAAAAAAABiJ0BQAAAAAAAAADEboCAAAAAAAAgIEIXQEAAAAAAADAQNaJXQEAAAAAwKs5dfq0LBK7EnivpEuXLrGrgNdEu4D/mne13SJ0BQAAAIAkatfOHbK25msdgCdoF4B3A8MLAAAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGMg6sSuQ1ERGRkqSTCZTItcEiGIymRQeHpHo78mIiEhFRERdHxGRUdPR/8ec96zp961sUqgjZZNm2ZfaVkRkorcNeDck5LMiVjv+Eu+d+Nr/mNNv/Vp5Tt3flc9MvLusrKxkYWGR2NVIEL6XAG8H7QKApyW0XbAIDQ2JfAv1eW8EBweretPuiV0NAAAAAAbbtW6erK2TRr8UvpcAbwftAoCnJbRdIHR9SREREQoNDU1Sf+0CAAAA8GJJ6Xd8vpcAb0dSusZoF4C3g56uAAAAAAAAAJAIeJAWAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRugIAAAAAAACAgQhdAQAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKHrS4qMjJTJZFJkZGRiVwUAAADAfxTfSwA8jXYBeLdYJ3YFkprw8HBVbthZu9bNk7U1pw+Jz2Qyyd3dXfXq1eM9CQCI18t+VgwcOEi3bt2SJN29e1dp06aNNR1zXsaMGTV+/Lg3V3kD8ZmJ9wnfSwA8jXYBeLdwFQIAACCWW7duycfHW5Lk6+srW1ubWNMx5wEAAACIi+EFAAAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRugIAAAAAAACAgQhdAQAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRugIAAAAAAACAgQhdAQAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGsk7sCgAAAAAAXk2pUqUTuwr4j8mUKZPWrl2T2NXAc7xL7QLvF/yXEboCAAAAQBIVFPRIUmRiVwP/ITdv3kzsKuAF3qV2gfcL/ssYXgAAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRugIAAAAAAACAgQhdAQAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRugIAAAAAAACAgQhdAQAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRugIAAAAAAACAgQhdAQAAAAAAAMBAhK4AAAAAAAAAYCBCVwAAAAAAAAAwEKErAAAAAAAAABiI0BUAAAAAAAAADEToCgAAAAAAAAAGInQFAAAAAAAAAAMRugIAAAAAAACAgd670LVG0266dPWGYeUAAAAAAAAA4GVYJ3YFXuTEqfOat3iVTp+7pMhIKV2aVKpbo4LaNK8nG5u41d+6ak6CtpvQcgAAAAAA4Nk2bdurJSvcdenqdYWFmVS8SD5NGzssVpm/Vm/WynVbdPPWXdnZ2SpH1owa9XVfpXJz1catezVj7lL5BwSpasVSGvJZN/P3/Rlz/9SufUc1b+qoeDMAJD0ver/cf+Cjyb/+oQNH/lVIaJgK5M2pT7u3VcF8uSRJB4+e0vipv8vrgY9KFSuorwf2VAonR0nSqvXbNHP+X1o8a4x5HpBY3umerrv3H9OAYWNVtmQR/fnbeG1eMVPfD/1UV6/fkpe3b6yyJpMpcSoJAAAAAMB/2KWrN2RpaaHMGdPFu/yXWYs0furvunvvgapXLq1qlUop6FGwAoMeye+hv36YMEsODslUtmRhrd+8S6vdt5m3u3j5Bn35WVcC1/fI894vkZGRGjh8nP7ZsV9ZM2dQhdLFdPzkOfX98kd5PfBRRESERoyeprAwk6pVKq3dB45q/tLVkqQH3r6aOmexPv+4A4Er3gnvbKsVGRmpidPnq0PrRmrbop55frYsGTR8UC/d8byv8nU76OsBPTRv8SoFPQrW+qXTVL5uB/0+7X/KkzOrzl+8qrFT5unq9VuysbZWofy5Ne67gZKU4HIAAAAAAODZ+nRtI0maNmeJrly7GWvZHc/7WrJig2xsrDVn8khlzZwh1vLT5y4rNCxMXT9srppVyqp+69664nFLERER+unnOWpUt4qKFMzz1o4Fb97z3i+79x/VxcseckvprOnjhsna2lpfjpionfuOaNHyDerQuqF8/B7qk1Zt1aFVI131uKmrHlHbmDBtvgrlz63a1cq/9WMC4vPOhq43bnnqtuf9F14su/Yf1dwp38vGOu6hjJs6X5XKltDMid/KZArX6fOX491GQssBAAAAAICEO3TslCIiIpXSJblGT5qjcxevKZWbi1o1raPWzeoqU4Y0srWx0czf/9KmrXvl6+evHFkzavmaf+R574Em/e+LxD4EvEXnL12TJOXOkVXWj3Oegvlzaue+I7pw6ZpcUjjJ1TmFlv29SecvXtOFSx5q27K+du8/pn2HTuiPmT8lYu2B2N7Z4QV8/PwlSalTuT63XLcOLeSU3FH29nZxlllbW8nznpe8HvjI1tZGxQvni3cbCS0HAAAAAAASztv3oSTJy9tXj4JDVL1yaXne89LE6QvkvmW3nFM4aeiAHgoNDdWRE2fUoHZllStVVDPm/amBn3TSzn1H1an3ULXv8aUWLlubyEeDN+2Bt58kKVkye/O8ZPZR017evrK0tNSIIX1kb2+nPQeOqUKZYmrVpI7GT52nHh99II8bt9Wt37dq022QpsxerPDwiEQ5DkB6h3u6uqRILkm67+WjTBnSPrNc2tRuz1z29YAemrNwpTp/OlxOyR31QZPaatW0ziuXAwAAAAAACZfS1dk8PeF/g5XSxVmWlpZat2mnduw5ono1K6lujQqqW6OCudyXIyaqVLGCyp4loz7sOUSffdxBaVO76cuRE5UnZzaVKVEoMQ4Fb4Fbyqj3y6NHweZ5QY+nU6V0kSSVKVFIS+eMNS+fOH2+XF1SqEGtSmrRqb9aNKqlKhVKqs/gUcqSMZ2a1K/+9g4AiOGdDV2zZEqv9GlT65/t+9W5fdNnlrO0tHjmskwZ0urbLz5WZGSk/j19Qf2GjFbhArmVL3f2VyoHAAAAAAASLneOLM9clixZ3DtWt+06qCMnzmjRrJ908sxFhUdEqGTRAkqXNpUk6cLla4Su77E8ObNJki5c9pDJZJK1tbVOn730eFnWOOXPnL+sleu2atakEbp1556CHgWrWOG8Klwgt5I7Ouj8ZY+3WX0glnc2dLWwsNCAPp307eipcnRMpjrVy8s5hZOu37yjBX+uVf1alV64jfWbd6lcqSJK6eqs5MkdZGFpIUvLuCMqJLQcAAAAAACIbcfew9q594jOXbwqSfK4cUffj/tVzimc1K9ne5UrVUT7D/+rAV+PVc7smbVp215ZWlqoUZ0qsbYTEBikCdMX6OMurZUmVUplzZRekvTDxFnmW8yffhAXkp7nvV8+7d5WubJn0aWr19V70P+UKqWLdu0/Kns7O7X7oEGs7ZjCwzV60hy1alpHeXNlk6+fv2xtbDRl9mKtdt8uXz9/ZeP9gkT0zoauklSpXHFNGDVYcxf9rZm//yVJSpvGTfVqVjR3K3+eQ8dOa+qcJXr0KFgpXZ31afd28f5lJKHlAAAAAABAbBcve2j95l3m194+flq/eZfSpU2lfj3ba+SQT/TLrEXate+Irt+8ozw5s6nrh81UomiBWNuZNmep0qVxU4tGNSVJuXJkUd8e7fXHX+sUFmZSuxb1Vblcibd6bDDei94v478fqJ9//UMHjpzUhcvXVLRgHn3SvZ1Su8V+5s/iv9YrMOiRenRsKUlycY4aH3jG3KU6cvyM6tWspGYNarzVYwNisggNDYlM7EokJSaTSZUbdtaudfPMT9IDEpPJZJK7u7vq1avHexIAEK+X/axo27adfHy8JUn37t1XmjSpY03HnOfqmlJLlix+c5U3EJ+ZeJ9Efy95cPWwJL7S4e1xcHDQ8ePHErsaiMe72C7wfsF/GffQAwAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAAAAAAAAAAYidAUAAAAAAAAAAxG6AgAAAAAAAICBCF0BAAAAAAAAwECErgAAAAAAAABgIEJXAAAAAAAAADAQoSsAAAAAAAAAGIjQFQAAAAAAAAAMROgKAACA/7d354ExXe8fx98z2UkiRCIliF1otfZdteiuuqq2SrW1tHZVat+3tlQXqpbaqdJvRRfaatX2s7RoUYRkJmKLRCKSiKyT3x8jVyJB6BCtz+svs+Te55x57hnz3HPPFRERERERB1LRVURERERERERERMSBVHQVERERERERERERcSAVXUVEREREREREREQcSEVXEREREREREREREQdS0VVERERERERERETEgVR0FREREREREREREXEgFV1FREREREREREREHEhFVxEREREREREREREHci7sAEREREREROTGFCniUdghyB0mMDCwsEOQa7idxgXli9zJVHQVERERERH5l/rjj99xdtbPOhG5ROOCyO1BywuIiIiIiIiIiIiIOJCKriIiIiIiIiIiIiIOpKKriIiIiIiIiIiIiAOp6CoiIiIiIiIiIiLiQCq6ioiIiIiIiIiIiDiQiq4iIiIiIiIiIiIiDqSiq4iIiIiIiIiIiIgDqegqIiIiIiIiIiIi4kAquoqIiIiIiIiIiIg4kIquIiIiIiIiIiIiIg6koquIiIiIiIiIiIiIA6noKiIiIiIiIiIiIuJAKrqKiIiIiIiIiIiIOJCKriIiIiIiIiIiIiIOpKKriIiIiIiIiIiIiAOp6CoiIiIiIiIiIiLiQCq6ioiIiIiIiIiIiDiQiq4iIiIiIiIiIiIiDqSiq4iIiIiIiIiIiIgDqegqIiIiIiIiIiIi4kAquoqIiIiIiIiIiIg4kHNhB/Bvk5WVBUBGRkYhRyJil5GRQWamTTkpIiJXdL3fFVlZkJXzcT7/zsrx3n/Ld5C+M+VanJycMJlMhR1Ggeh3icitoXFBRC5X0HHBlJaWmnXNd4khJSWFB9q9UdhhiIiIiIiIg23+fgHOzv+OeSn6XSJya2hcEJHLFXRc+HeMHLcRV1dXNoTMLfSzXR17DGHJrEmFtn+5vSgfJCflg2RTLkhOygfJSfmQPycnp8IOocBcXV0pFxjAklmT/jWz8P6rdDzdPm7GZ6Fx4b9Fx+u1qY+urmOPIQUeF1R0vU5msxl3d/fCDgOTyfSvOdsmN5/yQXJSPkg25YLkpHyQnJQP/35msxmz2YyLi0thh3LH0/F0+7jTPwuNC9d2p+dIQaiPrs5kMhX4pIZupCUiIiIiIiIiIiLiQCq6/ks927ZNYYcgtxHlg+SkfJBsygXJSfkgOSkf/hv0Od4e9DncPvRZqA+uRf1zbeqjq7ue/tGNtEREREREREREREQcSDNdRURERERERERERBxIRVcRERERERERERERB1LRVURERERERERERMSBnAs7AIHUtDRGTpyBNfIEbq6uFPfx5p3er1K2TABx8ecY+94sTpyKxtXFhYG9X6X2PdUBrvpatj/+/Ju+QybTu+vLdHjmkcJonlynm5EPfx8K58PPFpGWnkFaWjpPPNSCju2fKMxmSgHcaC4sWB7C2vWbOXbiNJNG9uX+JvWMbY7/4HP2HjiCm6srHh5u9OvRkRrVKhVWE+U63Ix8yMrKYt6S//HThm24uDjj4+3FjPeHFVYT5TrcaD5cbQxISUll4odzOBBqwWw206NLex5s3qAwmykFdDPyIVtE5Ale7TWCdo8+QP83XymM5kk+tmzfwydzlmKzZfFK+yd48tEHCjukO8bgMR+yZ+9B6t1Xk4kj+gL2/2tPmDqbtPR0Hm3dnNc7Pl3IUd4ZTkfHMub9zzgbn4CTkxNdXnqKVi0acvzkaUZM/JTEpPPUr303g/p0wWQyFXa4t4TGhtyUIwWTkpLKi10H8UDzhvTp9pLGtMucjIpmwtQ5xMWfw2w2M/ej0VgiThSoj1R0vU20e+wBGte/F5PJxMqQn5g0fS4z3x/OzHkruDu4MtMnDuZAaDjvjp3O/xZ+iLOz81VfA0g6n8zMeStoXP++wm2cXDdH58OUj+bRtdOzNG9cl3MJSbz4xiCaNqxNhfJlCrupcg03kgv1a99Nm5aNmTBtdp7t3d+0Hu/2fwNnJye2bN/DsAmf8M2i6be+YXJDHJ0PX63+kTDrMZZ+PhkXF2di4+JvfaPkht1IPlxtDFi66gdcXFxYtWAaJ6OieaPPaOreG0wxb6/CbagUiKPzASAjI4PJ0+flOlkjhS8jM5OPZy/l0/eG4lm0CF16Def+pvV0rN4iLzz1ME88fD9rf95sPDd1xgLGDulJhfKBdB8whvub1qNyhbKFGOWdwcnJTL8er1C1Unli4+J5tdcImjS4l5nzvuT1js/QrFFtho77iK07/qRZo9qFHe5Np7EhL+VIwSxYHkLN6pWNxxrTchv3wWy6d36O++6pzrmEJFxcXArcR1pe4Dbg5upKkwb3GWdW7g6uzKnTZwD4ddMOnn68FQA1qlWiZIni7N576JqvAUydsZAuL7WjmLfnrWyO/EM3JR9MJhKTkgH7WSxnFye8vYreymbJDbjRXKhZvRJl7vLPd5vNG9fF2cnJ2F7MmbNkZGbe7KaIA9yMfFi66nveeu0FXFzsJ+t8S/jc5FaIo9xoPlxtDPhl43bj70oH+FO7VnU2bv3jlrZLbszNyAeAeUu/4cEWDSlbptStbI5cw4FD4VQoXwb/kiUo4uFOo3r3smPXvsIO645R594aFPVwNx7HxJ4lI9NG5YrlcHIy0/r+xmzdsacQI7xzlPQtTtVK5QH7/2F8vL1ISDjPvgNHaNrwPgAebtWULTt2F2KUt47GhryUI9d27EQUR4+donH9ewGNaZezRBzH2cmJ+y5eJVTM25Oz8QkF7iMVXW9DX63+kRaN63AuIZGMzMxcP4LvKlWS0zGxV30N4NfNOzGZTDRvXPcWRy+O5oh8GP52N+YsWsVTHfvS/vWB9Hi1vYor/0IFyYXrsWL1OprUv9f4wS3/Lv80H86fTybubAKbtu3i9T6jeL3PKNb/tv0mRy03y43kw+VjwOmYWAL8fS/9XYAfUdHXN67I7cER+fD3oTD2Hwjj+XYP3aqwpYDOxMXj51vCeOxXsjgxZ84WYkR3tjOxZ/HzLW481udROA4dsWKz2XBzc8Xby9M4CeXne+d8Hhobrk45kr9PZi/jzdfaG481puV27GQURTzcGThyKp17DmPB8pDr6iMVXW8zC5aHcPzkad7s8sINbyM2Lp4Fy1Zr3a3/AEfkA8DiFd/So8sLrF7yEctmT+HzBSuxHj3hoCjlVnBULmRb98sWft20g3f7ve6Q7cmt5Yh8yMi0kZmZSWpqOvM+HsP4ob346PMlHAk/6sBI5Va4kXzQGPDf5Yh8SElJ5f1PFjCk/+t39Bp3IvLvcC4hibHvzWJw39cKOxS5TSlH8rfp/3ZRNjCAcoF3FXYot63MTBt/7g/lnV6vMufD0fy+ez+7/jpQ4L/Xmq63kaUrv2fj1j/4ePK7uLu74e7uhpPZidi4eGOGwqnTZyjl50sxb68rvnboiJUzcfF0est+M5Rz5xLZvG038ecS6NGl/RX2LrcbR+VD/LlENv7fH4wb2guAMnf5UzO4Mnv/Pqw1Xf8lricXCmL9b9uZt+QbPpkyhBLFi93EyOVmcFQ+FPP2pIiHO4+0agrYZzXeU7MqBw9bqHLxMiy5/d1IPlxpDCjl50tUdCwlL565PxUVQ8O699zS9sg/46h8OH4qmtMxsfQcNBGApKRkbFk2EpPOM/KdHre8XZJbyRI+xMTGGY9jzpzVTTELUUnf4sTEXprhFHPmLCV9fQovoDtMWlo67475kFdeaEutmlXJysoiITGJrKwsTCYTMZfNSPsv09iQP+XIle0/FMb637bz6+adXLiQQkZGJkWLeGhMy8HPtzjBVStQ6uLVYI0b3EtqalqB+0gzXW8Ty7/+gZ9/28ZHk97Fy/PSWpsPtmjAN9//AsCB0HBiYs9Sp1b1q77WtGFtflgxk28WTeebRdN5oHkDXnv5aRVc/0UcmQ9enkVxd3Pjjz//BiD+XCIHDoVTMSjwFrdKbsSN5MLVrN+4nc8XruTjyUMI8C950+KWm8PR+dCmZWO2//EXYJ8BcDA0nEoVyt2c4MXhbiQfrjYG5Py7k1HR7Nl7iBa6gdK/hiPzoXKFsqz96jPj/5IvPP0wTzx0vwqut4ka1SthiThO9Jk4ki+ksP2Pv2hUTydICoufb3GczGbCLJFkZtpYv3EbzRrVKeyw7ghZWVmMn/o5de+rwaOtmwFgMpmoGVyZrTv+BODHX/+PpnfIDZI0NuSlHLm6t157gZClH/PNoun07voSTz76AK93fFpjWg7B1SoSF59AQuJ5bDYbf+4LpVrlCgXuI1NaWmrWLY5ZLhMdE0u7jn0pc5c/RS4uyu7i4sK8j8cQd/YcY977jJNRMbg4O/N2z87Uva8GwFVfy2ncB59TpWJ5OjzzyC1tl9yYm5EPO3fvZ+a8L8nMtJGRmcGTj7TkxWcfK7Q2SsHcaC7MX7aab77/hfhziRTxcMfV1YWFMyZQ3MebZo91xrd4sVw32PtkypA7+q6m/xY3Ix/OJSQyfupsTp6KAeCZtq14tm2bQmujFNyN5sPVxoALKSlMmDqHQ0esmM1munV+jtb3NyqU9sn1uRn5kNPcxV+TmJSspatuI5u37eKTOcux2Wx0bP8ETz32YGGHdMfoPXgSYdZILqSk4u1VlAnD+mAymZg4bQ5p6ek80qopb7zybGGHeUf4a38obw4cn+uO4SMHvYmbqwsjJn5K0vlk6t1Xk0F9umA23xnzzTQ25KYcKbjvf9pEeMRx+nR7if0HwzSm5bDt97/4dO5yyIIGde+mb/eOBe4jFV1FREREREREREREHOjOLuWLiIiIiIiIiIiIOJiKriIiIiIiIiIiIiIOpKKriIiIiIiIiIiIiAOp6CoiIiIiIiIiIiLiQM6FHYCIiIgjHD58mHHjxhMQEEBaWhpeXl706dMbf3//f7TdvXv3snfvXjp27OigSAtuzZpv2bhxI05OTgwbNpRixYrd0v1HR0czYMDbLFq00Lija1paGp07v8qsWZ/d8njyM3DgO/Tp05ty5coVdihXtG/fPpydnQkODr7me7ds2cq8efMoWbKk8Vznzp24++67r2ufPXv2YtSokXny/5tvvuGHH9bi4+NjPNe/fz9Kly59Xdu/kt9+28j+/fvp1atngd7/T45bi8VCXNxZ6tWre8PxRkREMHbsOGbOnIG7uzsAu3fvZuHCRYwdO4avv/6aJk2aUL169atuZ8qU92jVqlW+saxcuZKsrCzat2+f57WYmBhWrFiBxWLF2dkZkwnatGlD69atb7hN/9SpU6eYNWsWQ4cO5dSpUyxYsJCjR48SEBDApEkTc71306ZNhISEYLNlUb16dbp160pGRga9evVmwID+VKtWDbCPJWPGjKV3715GX6alpTFr1udERkaSlWXD09OTnj174u/vz8KFi0hJSaF7924AZGVl8fHHn+Dl5Unz5s1ZtWoVQ4YMKXCbfvnlF3755VfS09PIyoIyZcrQsePL+Pn50bdvP8xmE05OzqSkpPDcc8/SsmVLzp49y1tv9WTRooW4uLhccduHDx9m5cpVDBs29JpxZGVl8e2337J16/9hs9lISUmhbt26vPpq5wK3Jds/yf+YmBhGjRrNzJkz8ry2cOEiSpb05fHHH7/u7f4TWVlZvPba68yY8SlFihS56nu//fZbWrdujYeHB2Af10qVCqBJk8Z89913xMXF0alTp1zf34mJiWzZsoVHH330VjRHREQEUNFVRET+IywWC/feW4uBAwcC8MEHHxASsoauXd/4R9utVasWtWrVckSI1yUpKYmQkBBmzPjUKAZls9lsRhH0ZrJYLAQFBeXaV0REBD4+PrdFwTU1NZWYmBgCAwMLO5SrWrt2HS1btizQey0WC23atOall1664f2dO3eOlJSUfAuXFouV9u2fp02bNje8/asJCztCpUoVC/z+f3Lcbtq0CT8/vxuOFSAoKIhq1arxyy+/8Pjjj2OxWJg7dx7Dhw+jWLFivPbaawVuR7duXfN9LSwsjDZtHsrzfFRUFGPGjKV9++d56623MJvNnD17lh07dl5XGxw5HqSkpDB16jT69u2Dm5sbXl5edOvWlc2bt5CQkJDrvX/8sYuQkBBGjRqFp6cnw4YNY9euXdSrV4+2bZ8gJGQNgwa9Q1JSEpMnT+GVVzrmKl6npKTQunUratSoAcAXX8xn2bLl9OvXlyefbEv//gN44YX2+Pj4sHTpMlJTU+nduxdms5no6GjOnDmT6+TElSxevISwsDDefnsAvr6+ZGVlsW3bNlJSUrhw4QJRUVEsWDAfDw8P/vzzT6ZOnUaLFi2wWCwEBgZeteB6vUJC1hAaGsrYsWNwc3MjIyODkydPXtc2srKygH+W/0eOhFGxYv7HaXh4OI0aNbyh7f4Tp06dwtvb+5oF16SkJL75ZjVPPPGE8dzTTz9t/DssLJx69eoBub+/Dx48xL59+1V0FRGRW0pFVxER+U+wWKwEBpY1HgcEBJCRkWE8PnHiBEuXLiM+Pp4LF5Jp1+4pWra8H7DPRFy2bDkZGekEBwezf//fDBjQn8DAQEaMGEHHjh2pVq0aH3/8Me7uHpw+fZoTJ07QpEkTatW6hzVrvuXkyZM8/PBDxo+/K+0vKyuLL79cwZ49e7DZbNhsNkaPHoW3t7cR67Fjx5g8eQo2m40RI0bSvv3zrFmzhho1anLgwAGKFi3Ku+8OZt26H/n111/JzMzE39+fXr16UrRoUdav/4WdO3fi7u7O0aNHKVGiOF26dOHLL1dw/PhxAgMDGTjw7WsWaiwWCxUrVsjzXHZR7dSpU0yYMJFmzZqxd+9e4uPj6dnzLWrWrAnAxo0bWb9+PWlpabi6utGz51sEBASwd+9eli//krJlAwkPD8dsdqJ3716sXr0aqzUCT8+iDBs2DHd3dzZu3MhPP/2Mm5sbCQkJODk5MXDg2/j5+WG1WilXrpzRjvz6w8PDgy5dXmP69A8pXrw4AEuXLsPJyUyHDh0YMWIEVapUwWKxcvLkSdq1exJPT09+/XUDUVFRvPTSi9x/vz1Pjhw5wooVX3H+fBJpael07PgytWvXJi0tjTfe6Mrzzz/Hzp07iY6OoVOnV2jatClffDGfXbt2ER0dzcqVKxky5F1KlChxxT63Wq088sjDeZ7Pysriu+++Y/v2HaSlpeLj40OfPn3w8vIiLS2NJUuWsG/ffooU8aBRo0ZXLKhYrVaefvqpXM+lpaXx+utvMH/+Fzg72/9r+PrrbzB9+od4eXnRvXsPHn/8cXbt2kVUVBRPPPE4bdu2BeDAgQMsXryE9PR06tSpw5EjYbRo0QKAH35Yy8aNv2Gz2UhPz2DAgP55ZiRf67j99ddfWb/+FzIyMkhPT6dz507cd999rF69mp9/Xo+fnx+//baRHj26ExAQwLJlyzl69ChJSUnUqlWLLl1exWQyXbG/AZ599hmmTfuQOnXqMHXqNPr06U3p0qU5deoUkydP4aOPpgOwe/ce1qxZw4ULFwDo2vUNKleuTFxcHCaTycivHTt2sGrV10AWDz74IGFh4bz5ZqU8+/3ss1m0bt2KBx54wHiuePHixuc/fPgIXnrpRaMo+cEHU2nWrBmNGjXk448/xsvLm8jIoyQnX6BChSACAwONQtTJkyeZNGkyH3zwPmazmZUrV/H3339z4cIFypUrS8+ePfMtJq5Y8RW1a9embFn7Z+Lr6wvY8ya7kJVt5cqVdO7c2Ri7KlWqRGRkJPXq1aNNmzaEhKwhIiKC+fMX8OCDD9CoUaNcf+/t7W20DcDDw4O4uDijH5o1a8oPP6ylZElfDh48wMiRI41jPTCwLAcPHqR58+ZX/Wz379/Pxo0bmT79Qzw9PQEwmUw0adIEsOdvyZIljRmT/v7+2Gw2o81XOo5u1J49u6lfvz5ubm4AODs7G8eEzWZj1aqv+f33nWRm2qhYsSI9enTH2dmZ5cu/JDY2loSEBE6fPk3z5s2vK//PnDnD3LnziImJoVSpUhQvXpzKlfPmpM1m49ixY/z99wHmz19AYmIinTt3okGDBqxZs4aoqCi6dbPPPo6Pj2fEiJGMHz8u10m4TZs2s23bNgYPHgRARkYGAwe+Q79+fQkKCrri91Z4eDiVKtljshf/p5KYmMSFCxeoUKECvXr1JDU1lcGD38VmszFo0GAqVarIa6+9Rteu3Zg//wvMZjMWi4UOHV4AML6/U1NT+fzzz3FxceGddwbRpk0b1q1bR48e3alatSoAP/30M4cOHaJPn94O/cxFROTOpqKriIj8J1itFmNGS1RUFOHh4fTsab/EOSEhgaHDR1MioAIfTppAUlIS/fsPILhmTV7rOYRSXllMnjQRf39/Vq9eTWxsLKVLl8ZmsxEZeYygoCDAXiC6++67GTZsKOfOnaNHjzdxd3dnxIjhnDp1ilGjRvP000+TkJDAzJmf0bt3LwICAoz9NW3ahL/++oujR48yZcpkTCYTSUlJFC1aNFdbypYtS5s2rTl/PpmXX34Jm83Gxx9/QvXqwYwdOwaTycT69evZvXs348aNxc3NjXnzviAkZA0vvfQiFouF8+eT6NOnN0WKFOHtt99m+fIv6du3Dy4uLvTq1ZuTJ08SGBjIli1bOXw4NN8ZfRaLlWbNml72nMUoRFgsFpKTk2nSpDEdOrzAunXr2LBhAzVr1uS33zYSGhrKyJEjcXFxYcOGDaxa9TW9evXEYrGQlJREhw4dKFGiBBMmTGDWrM8ZPHgQxYoVY9iw4Rw8eJDatWsTHh5OcvJ53n57ACVKlGDOnLl8//0PvPpq54s/0u2xXK0/qlatSmjoYRo1akhkZCR//PE7U6bYi9oREUepW7cuo0eP4vDhw4wZM5ZXX+3MmDGj+fPPP/nqq5Xcf//9HD9+nKVLl9G/fz+KFStGdHQ0o0ePYebMGURERJCZmUmFChVo27Ytu3btYs2aNTRt2pTnnnuWrVu38sEH7xcojyMiIlix4quLRTt45ZWO1KpVi1WrVmEymRg3bixms5mvvvqKtWvX0r59e2bPnoOPjw8ffjiNCxcu0K9ffx54oGWebSclJXHmzBlmzvzMKET27duH5ORkAgMDjYJrdHS0McsxPj6e+Ph4ihf3YcyY0URGRjJp0mTatm3L8ePH+eyzWQwbNpSAgAC+++47IiMjCQoK4ujRo2zYsIFJkybi7Gy/bNvJySlPTFc7bgHq1avHgw8+CMChQ4dYunQp9913H+3atWP16hAmTZpoFMwmTJjI448/Rteub2Cz2Rg3bjx///33NZdmqFy5MqVLl2bo0GF0797NmI1psVioUMF+0mH//v2sX7+ewYMH4eHhwf79+1m8eAljxowmLCzcOCb27dvHqlWrGD58OMWKFeOLL+bj4uKSazkHgMjISMLCwhg06J18Y7KPPZG5in5Wq5VOnV65GJuVSpUqMWzYMJydnVm7di1Wa4Tx3kWLFvPCC+1xc3Nj5szPCA6uzksvvQjAjBkz2bJlS65iL9jHyV9//ZXPPpuZJx6r1T5DOufjuLg47rnnHuO55OQLlCplL+S6ubnx6KOPMmrUaO6///5csxLzc+jQIX766SeGDHnXeK5du3YMGjQYb29v47jO5uHhwfnz56+6TbCfiHnwwQeMguvlLBarUfTMyMggJGQNDRo0uFi8szr8Koc6deqwdOkydu/eQ61atWjRorlxEubLL1dw7tw5Jk+ejNlsZsqU9/jtt99o3bo1FosFmy2TgQMH4uHhYZyEKUj+V61alQkTJtKx48vUrVsXi8XCu+8OYfjwYXniO378OBcuXCAoqDzPPPM0Bw4cYPr0j2jQoAHVq1dn48ZNxnvnz1/AU0+1y3PVQ1BQeb766ivj8Q8/rCU4OJigoKCrjtM5x3Oz2cyAAQOMto0bN54DBw5Qq1YtHn74YeLj441j4fDhwwQGBmI2mzl//jyJiYkEBATk+v52c3OjSpUqtGnTmrp17csxREREEBoaStWqVYmPj2fNmjVMmDDeUR+1iIgIoKKriIj8B6SlpXH8+Am+/noVK1euJDo6mnfeGWhcerp27TrcXZ04Fv43Pd7siZdnUZycnJg2YxFlfIvQ7omHjEuxy5UrT8WKFTCbzRw7dgxfX1/c3NxISUkhNjaWjh1fxmw2YzKZKFKkCM8887RRwMq+LHLt2nXExsYydeo0I0YnJydsNhteXl6Eh4ezfPmXNGhQn8qVK+fbpvBwC02aNAbss2Y9PDx48cUOxr6+/vp/jBgx3ChElCtXlrCwcMBeyHrxxRdzFRqee+5ZY5kCm81mvNasWdM8hdVsOYs8ueOyzxKzWKy0adMmR9Ei09juypUrcXd3Y+jQYRdfy8hVzHrqqXZGscFkMvPkk22NH+8mk8koRIeH29uS/d6goPKEhoYar9Wufd81+yM4OJjQ0FAaNKjP7Nlz6NKlC66urhw7dgxPT0/atWtn7DcgoJRx6X3OOFavXs2ZM2cYP36C0RceHu5GPzRs2MAo7mVmZlK0qKfR1oLOlouKisLFxYVp06bmej4lJYXvvvsef38/49LztLQ0mjdvzunTp9m3bx8zZnx6MSYP/P39jBljOVmt9kLd5YWFdevW5SnuZRcbLRYLVatWMWYUZmZe+oxXrw7hscceJSAg4GKfl6Ns2bK4urri7u5OfHw8ixcvoUGD+tSoUSPPjNNrHbcZGRn8+OOP7N69h4yMdFJSUo3LqU+ePImPj49RlNm/fz9Hjhxh6dJlLF26DIDk5GTjUuxrueeeu41ZwtksFqsx03vlypWcO5fAyJGjAPsxlD0L1GIJN2YNrlr1NS+80MHI5XLlyhEbG5tnfxEREZQufVeeEy7Zjh8/jq9vCeOYTUqyz/jz9/cnJSWFmJgYJkwYbxTKy5cvz6ZN9oLY3r17SUpKolmzZkRFRbFt2zasVis//LAWsOdTzZo18uxzx44d1KpVK8/l3fHx8SQmJuaapRwREUGFChVyfaZWq5UHH7xUyK1V6x7Wrl17zfVKt23bxsKFixg48G1j1iGAn58fPj4+vPJKx1xXAgCcOXOmQGuZHj16lBYtrjwb1mq1Eh4ezqBBg3FxcaZGjZo888zTxmtPPdXumvu4Hu3ataNp06bs2bOH7dt3sHr1aqZP/xB3d3d+/vlnZsz41Dg5Ua5cWeLjzxmxjB49ysj368n/rVu3UqZMGaPYWK5cOUwmU75jhMVioWHDhtSpUwewn5BISEjAZrPPvI2JiSE5OZnQ0FDi4uKMEyI5lS5dmrNnz5KSkkJaWhrr1q0z1gK+2jgdHm4xjr+IiAhWrw4hJiYGuDQ22mMMp379+jlivjRehYdfOgFy4sQJ4/s7+7UePbobf1ejRjDbt2+nbdu2FwvIT90Wy+aIiMh/i4quIiLyrxcZGYmbmxvTpk3DZDLx5ZdfsmzZcuOHo9VqpXv37mRkOTNi0gyWjB/C7r8OMnPel1T0d2bnX0eYs7wvaWnpVCztTZ17qxt/l5icTtsXe5GWmkRxdxN/H7JQ974aWK1WfIr78lrvkTRvXJdvv19LSW834++6detGnTq188RarVo1pk79gN27dzNnzlxq1arFyy/nXb/TYrHQsePLxvbuvrumcWnt+fPnSUpKynXzI3uhLIiMjAyOHz9h3MAmJSWFuLizxo/S+Ph4gDwz7y6XmJhIYmIipUqVMp6LjY0lOjrauCGU1WrlySfb5or53ntrkZiYSGpqqlEIvJzVGkGHDh1yxR4c/BZw6fLW8uXLk5mZSURERK5CjH0tQnuxIDw8nOeee/aq/QH2H9eLFy/m559/xs/Pz5i9ZrVaqV69ulE4sscRfNk2Khgxv/vu4HzXj73873IuyxAWFl7gNU4tFivly5fP8/zJkycpXbp0npsYAWzfvoPy5csbxbcLFy4QGXnsigWV/LZvL6xWMx6HhobmKLrmbdulPrHy8MOX1io9fPiwUfAoVaoUH300nT///JOvv/4fP//8M/369cu132sdt8uWLSc1NZVRo0bi7u7OsmXLyMjIBHIXV7Jjad261Q3f8O7o0aN5ToBYrdYcBbgI5syZnWu2Zbbw8HDjpkNWqzXXZduHDx/O9/N3d/fAZrtyQThnIQng0KFQY8a9/bL3CrkKtkFBQRw/foKMjAwWLVpsFJciIo5Su3ZtBgzof60u4PjxE8YxkzsWC2XLljVyDOwF8eyCH9g/y/T09FzLBUREHKVixYqYzWbS0tIYMWIkNpuNYsWKGbMsV65cydat/8eoUSO56667cu03LS2NU6dO5flczp8/T1hYGMHB/a7ZJnd392v0s4U33+xB7dq5x+pz585x9uxZo88dqWTJksbN0jp16kxUVBTu7u4UL148V8HbvtTII5w5cwYnJ6dcY8/15P8XX3yRqw8PHz5MqVKl8i34h4WF58nfChXsJyHNZjNVqlQ2luMZOPDtfJfucHZ2JjCwDJGRkfz220YeeeQRihUrdtVxOntmd4UKFYiPj+fDD6fz9tsDqFy5MsnJyXTr1t34LMLDLXm+P7K/73LOls0+TgCjD3N+7wUHB7Nw4SJ2795DXFwcrVrlLSCLiIj8Uzf/LhwiIiI3Wfalttk/AJ944glOnDhh3KDE19eXnTt3Ur/O3bRu2YhREz9m+mcLGDagK3HxSZyNi2XxrIl8NHEAsaePsT/06MXtWqhapTLL575Hry7PUj6oPEPHf8z55AuEh4fj6+ePJeI4Tk5mnn2sBW0fa5Nrf9mz7OLj44mNjSU9PZ2oqCi8vb1p2bIlDRrUJzU1JU97EhMTSU5ONgqe9iLepR/CHh4eODs7ExUVBdhnOf31117jMvhSpUoZxSH7zbDKGwXbnEWzqylatChFixZl3779gL14O2/eF7Rp08bYdvbMyWxWq4VKlSpRpEgR0tLSOHjwoPFaeLh9NlNSUhJJSUlGgeXMmTM4OzsbM4xOnDhByZIlcXNz49ixY6Snp3P8+HHAvv7iwYMHeeCBliQnJ5OQkMBdd9111f4A+1qTx4+fYM2ab+ncuVOOvLHkKojZLxOvlOv17MKGr68v27fvMF6Ljo4mKSkpx3Zy/p3V2M7p06dz3ewnPj6e//3vf/n2udWaf9HVx8cnVz5nZWVhsVgA8Pb24sSJE6SmpmKz2Vi4cCHu7u75rhtrtVoJCsq7/YSERLy87LNXo6Ki2LDhN6NYkV/bsvvM29sbq9UK2Gemff/9D0bB5tixYxQpUoQmTZrQsuX9pKSk5tnvtY5bq9VKzZo1cXd3JywsjB9//MnYd1RU7n719fXlr7/2kpJiP57S0tI4duwYcPU+v9Q3EXmOi5xFd1/fEuzYcenzzy4y5mzH5X2yb98+Nm/enG8BvEaNYBISEti583fjudjYWDZt2gzYL/X39PQC7DeM++abb3LNPs6Zp2CfZe/t7c2SJUupUKGCUWTz9S1BaGgo587ZZ0xmn8jIT2ZmZq5CajZ7PucuHJcrV46IiAgyMjJISUlhzpy5PPPMM5fddO9S/7m6ujJlymTef/89hg8fRlpaGtOnT+fAgYOMHz8uT8E1u4+LFy+eZ5brhg2/UadOHby87P1z5MgRNm/enG+bGjVqyLp160hOTgbsJ3W2b9/O6dOnSUlJ4dSpU1ecFV6mTBlcXV3z3e6N2LdvH4mJicbjzZu34OnpSVBQED4+Ppw7d84YUzZv3kx8fDy1a9fOlV/Zrif/c+ZkUlISixYtzrfNYM+tyMhjxnuXLl3G888/Z7xevXp1Zs+eQ8OGDY11f/NTvnx5tmzZysGDB3jsMfuNq671veXn54ebmxsnT56kSBEPKlWqREZGBl988YWx7q7NZiMmJibX+JbzJFd4+KXxKuf4ffk4nN1nrq6ufP7553Tr1vWaaz+LiIjcCM10FRGRfz2LxUKVKlWMx56entx7773s3Pk7Tz3Vjueee5ZZs2bRr19/XFxciD4eRYM69alSqTyR0eepWTSesWPGUK1aNYoVK8aufeFkZtqwWKy8+GIHPIsWISLiKI893Io9oUsJsx4jPNyCb8lSFC1ahFdfbMe4ceN59tlnAHLtz9XVFU9PT958s4cxgyctLQ0XFxfKlCnDG2+8nm97chaA7JevX7qbtNls5q233uT999/HZsvC19eXYcOG4uHhkedy9ssLNDl/oB46dIiQkDXGDU9yMpvN9O/fj8WLF7Nw4UKcnZ1o3Lgxzzxjb2NUVBRFixY1Ch/ZM2pLly6N2Wymd+9ezJ07FzBhNpsIDq5BpUqVLhb+gowfuDlnJl3e9rCwcBo1asQ333zD/Pnz8fHxYejQIcaamtnbMZlMV+wPABcXF/z8/Hj44YdyzXSyWKw0aNAg174ff/yxXK9nzxzr1OkVZs+ew9atW3B2dqF48eL069eX9PR0Tp8+nevS65zF3IYNG7Bo0WJ+/PEnBg8exF9//UVo6OE8/Z39d9k3d8upRIkSdOrUiSlT3sPFxQWz2UzjxvabZQUHB1OzZg0GDHgbHx8fSpQoccXlDCwW+8y5y7Vu3YqlS5fx++9/4O/vj9lszjWb9bXXuuSK8YEHWgLQocMLfPrpDH755VejKFKxYsWLN62ZTVJSEm5ubhQvXvyKeX6147ZduyeZM2cu3367hurVgylatKjRtjp1avPppzPYs2cPXbu+QaNGjTh48BDvvDMId3d3nJ2def755yhbtiy7du26Yp+Dvah56tSpXMdcVFQUnp6exmzA7t27M3/+AkJCQjCbnbjrrgAGDBjA6dOn8fDwMI6DTp06GWvslilTGmdn53wLXJ6engwdOoQlS5awYsUKbLZMihQpYix10bBhAz744AOmTZuGj48Prq6uuWYf33tv3rVGy5cvz4YNG5g+/UPjOfs6lm0YPnwE7u5umM1OPPLIw/nO4LzrrgDOnLm0FML333/Pt99+x/nz5zGbzezZs4cRI4ZTpkwZqlWrRt26dRk48B3MZjMPPdQm19ICYC9kt2v3ZL59/t133/N//7eNwMBAxowZezH+cvTq1SvH31vzFMKTkpL44YcfGDt2jPHc2rXr8j2ZAPDUU08ZNyQ0mUykp6dTpUpl6tSpg8VioUSJEnmKulDwk1PXIzQ0lLlz5+Hk5ISTkz2Hsmdxu7u706HDC4wYMQKw3yhs6NChxo2hLj+mryf/27RpwwcffED//gPw9vbGzc0t39nXGRkZnDhxgoYNGzBw4DtkZdl4+ulnjJnnYC+2e3h48Nxzz161reXLl2fhwkUMGjTImCF9te+tnOsiV61alYCAu+jbtx8lS5akdOm7jO8ss9lMixbNGTRoMFWqVKFbt66cPn3aKACHh4cby1nk/N4MCrLPph048B1at25ljIP2JVECr1pAFhER+SdMaWmpBVvsSkRE5D/irXfG06JxPWrVrMIbfUZeLKxk4WZKw9mUydkUF1YumErJEj7MXriKXzbtIC7+HGaTmfPJF5g8sh8tmtTl+582sfx/a1kya1JhN+k/afbs2VSsWJHWrVv/o+388ccuvv32W0aPHlWos5myb27Tr19frR14i6jPCy4qKoqpU6fx/vvvFXYoVzR16jSaNm1irP0ZExPD3LnzGDx4UK5ZtrfS4cOHWblyFcOGDS2U/d8qGRkZjBkzhueff97hNxgrDBaLhRkzZjJp0kSHzmgWERHJSTNdRUTkjlXKzxc/z0wqB3lfXK+uCq+80tGYIbnuly38tGEb0ycOomyZAEwmEw89240sLp2vNOuSxJsmPDz8HxVck5OTGTFiBK6ubrzzzsBCv3zUbDYzatTIQo3hTqM+L7iAgAAeeeRhkpOT89xM63YQHR1NkyaNc93szM/PjyFD3i3EqO4MISEh/Pzzeh5++KH/RMF1+PARJCcn069fXxVcRUTkplLRVURE7li+JXyocW9jihb1oNcbL+JTzIvYuHh27N5Py6b1OZ98ARcXJ4p5e5GensHir74jOTnvGqxyc0yZMuUf/X2RIkWYOnWqg6IR+e9r1apVYYdwRf7+/vj7+xd2GHn4+vrSvHnzwg7jpmrXrp2x9MV/wfjx4wo7BBERuUPoRloiInJHGz6wG16eRXit90haPf0GPd4eR+iRCAAea9OcCuUDeaZTP559dQBubi74+eW9QZGIiNyZfH19adHiv110FRERkRujNV1FREREREREREREHEgzXUVEREREREREREQcSEVXEREREREREREREQdS0VVERERERERERETEgVR0FREREREREREREXEgFV1FREREREREREREHEhFVxEREREREREREREHUtFVRERERERERERExIH+HzxpiMMgw0YmAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1400x600 with 12 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "def plot_regime_timeline_validation():\n",
-    "    \"\"\"Plot regime swim lanes with volatility and drawdown validation bars.\"\"\"\n",
-    "    if len(macro_df) > 0 and sp500_df is not None:\n",
-    "        years = [pd.Timestamp(ts).year for ts in macro_df.index]\n",
-    "        n_months = len(macro_df)\n",
-    "\n",
-    "        year_ticks = []\n",
-    "        year_labels_fig = []\n",
-    "        for j, year in enumerate(years):\n",
-    "            if j == 0 or years[j - 1] != year:\n",
-    "                if year % 4 == 0:\n",
-    "                    year_ticks.append(j)\n",
-    "                    year_labels_fig.append(str(year))\n",
-    "\n",
-    "        fig = plt.figure(figsize=(14, 6))\n",
-    "        gs = GridSpec(\n",
-    "            n_regimes_fig, 4, figure=fig, width_ratios=[3.5, 1, 1, 0.05], wspace=0.12, hspace=0.08\n",
-    "        )\n",
-    "\n",
-    "        swimlane_axes = [fig.add_subplot(gs[i, 0]) for i in range(n_regimes_fig)]\n",
-    "        vol_axes = [fig.add_subplot(gs[i, 1]) for i in range(n_regimes_fig)]\n",
-    "        dd_axes = [fig.add_subplot(gs[i, 2]) for i in range(n_regimes_fig)]\n",
-    "\n",
-    "        # Grayscale-friendly palette (distinct in B&W print)\n",
-    "        # Ordered from light to dark to match volatility ordering\n",
-    "        REGIME_COLORS = [\"#e0e0e0\", \"#a0a0a0\", \"#606060\", \"#202020\"]\n",
-    "        colors = REGIME_COLORS[:n_regimes_fig]\n",
-    "\n",
-    "        for i, regime_label in enumerate(regime_order):\n",
-    "            raw_regime = [r for r, lbl in regime_labels_map.items() if lbl == regime_label][0]\n",
-    "            mask = macro_labels == raw_regime\n",
-    "            stats = regime_stats_fig.loc[regime_label]\n",
-    "            color = colors[i]\n",
-    "\n",
-    "            ax_swim = swimlane_axes[i]\n",
-    "            for j in range(n_months - 1):\n",
-    "                if mask[j]:\n",
-    "                    ax_swim.axvspan(j, j + 1, color=color, alpha=0.85)\n",
-    "\n",
-    "            ax_swim.set_xlim(0, n_months)\n",
-    "            ax_swim.set_ylim(0, 1)\n",
-    "            ax_swim.set_yticks([])\n",
-    "            ax_swim.set_ylabel(regime_label, fontsize=9, rotation=0, ha=\"right\", va=\"center\")\n",
-    "\n",
-    "            if i < n_regimes_fig - 1:\n",
-    "                ax_swim.set_xticks([])\n",
-    "            else:\n",
-    "                ax_swim.set_xticks(year_ticks)\n",
-    "                ax_swim.set_xticklabels(year_labels_fig, fontsize=8)\n",
-    "                ax_swim.set_xlabel(\"Year\", fontsize=9)\n",
-    "\n",
-    "            for event_year, event_label in events.items():\n",
-    "                try:\n",
-    "                    idx = next(j for j, y in enumerate(years) if y == event_year)\n",
-    "                    ax_swim.axvline(x=idx, color=\"black\", linestyle=\"-\", alpha=0.3, linewidth=0.8)\n",
-    "                    if i == 0:\n",
-    "                        ax_swim.annotate(\n",
-    "                            event_label,\n",
-    "                            xy=(idx, 1.25),\n",
-    "                            xycoords=(\"data\", \"axes fraction\"),\n",
-    "                            ha=\"center\",\n",
-    "                            fontsize=7,\n",
-    "                            color=\"black\",\n",
-    "                            fontweight=\"bold\",\n",
-    "                        )\n",
-    "                except StopIteration:\n",
-    "                    pass\n",
-    "\n",
-    "            ax_vol = vol_axes[i]\n",
-    "            vol_val = stats[\"annual_vol\"]\n",
-    "            ax_vol.barh([0], [vol_val], color=color, height=0.6, edgecolor=\"black\", linewidth=0.5)\n",
-    "            ax_vol.set_xlim(0, 22)\n",
-    "            ax_vol.set_ylim(-0.5, 0.5)\n",
-    "            ax_vol.set_yticks([])\n",
-    "            ax_vol.text(\n",
-    "                vol_val + 0.3,\n",
-    "                0,\n",
-    "                f\"{vol_val:.0f}%\",\n",
-    "                ha=\"left\",\n",
-    "                va=\"center\",\n",
-    "                fontsize=9,\n",
-    "                fontweight=\"bold\",\n",
-    "            )\n",
-    "\n",
-    "            if i == 0:\n",
-    "                ax_vol.set_title(\"Volatility\\n(ann. %)\", fontsize=9, fontweight=\"bold\")\n",
-    "            if i < n_regimes_fig - 1:\n",
-    "                ax_vol.set_xticks([])\n",
-    "            else:\n",
-    "                ax_vol.set_xticks([0, 10, 20])\n",
-    "                ax_vol.tick_params(labelsize=7)\n",
-    "\n",
-    "            ax_dd = dd_axes[i]\n",
-    "            dd_val = stats[\"max_dd_pct\"]\n",
-    "            ax_dd.barh([0], [dd_val], color=color, height=0.6, edgecolor=\"black\", linewidth=0.5)\n",
-    "            ax_dd.set_xlim(0, 60)\n",
-    "            ax_dd.set_ylim(-0.5, 0.5)\n",
-    "            ax_dd.set_yticks([])\n",
-    "            ax_dd.text(\n",
-    "                dd_val + 1,\n",
-    "                0,\n",
-    "                f\"{dd_val:.0f}%\",\n",
-    "                ha=\"left\",\n",
-    "                va=\"center\",\n",
-    "                fontsize=9,\n",
-    "                fontweight=\"bold\",\n",
-    "            )\n",
-    "\n",
-    "            if i == 0:\n",
-    "                ax_dd.set_title(\"Max\\nDrawdown\", fontsize=9, fontweight=\"bold\")\n",
-    "            if i < n_regimes_fig - 1:\n",
-    "                ax_dd.set_xticks([])\n",
-    "            else:\n",
-    "                ax_dd.set_xticks([0, 20, 40, 60])\n",
-    "                ax_dd.tick_params(labelsize=7)\n",
-    "\n",
-    "        start_year = macro_df.index.min().year\n",
-    "        end_year = macro_df.index.max().year\n",
-    "        fig.suptitle(\n",
-    "            f\"Macro Regimes and Market Volatility ({start_year}-{end_year})\",\n",
-    "            fontsize=11,\n",
-    "            fontweight=\"bold\",\n",
-    "            y=0.98,\n",
-    "        )\n",
-    "\n",
-    "        fig.text(\n",
-    "            0.5,\n",
-    "            0.02,\n",
-    "            \"Regimes from: Unemployment, Fed Funds Rate, Yield Curve (10Y-2Y), CPI  |  Sorted by volatility\",\n",
-    "            ha=\"center\",\n",
-    "            fontsize=8,\n",
-    "            style=\"italic\",\n",
-    "            color=\"#505050\",\n",
-    "        )\n",
-    "\n",
-    "        plt.show()\n",
-    "\n",
-    "\n",
-    "plot_regime_timeline_validation()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "015905a8",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002574,
-     "end_time": "2026-07-18T19:35:42.631020+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.628446+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Persist Figure 1.6 inputs\n",
-    "\n",
-    "The publication-quality version of Figure 1.6 is rendered by\n",
-    "`book/01_process_is_edge/figures/scripts/generate_figure_1_6_macro_regimes_volatility.py`.\n",
-    "That script reads the arrays persisted below so the book build does not\n",
-    "re-fit the clustering pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "841b23eb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.636731Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.636619Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.642067Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.641738Z"
-    },
-    "papermill": {
-     "duration": 0.009033,
-     "end_time": "2026-07-18T19:35:42.642589+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.633556+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "8c01afc3",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "if len(macro_df) > 0 and sp500_df is not None:\n",
-    "    ARTIFACT_DIR = OUTPUT_DIR / \"figure_1_6\"\n",
-    "    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)\n",
-    "    annual_vol_by_regime = regime_stats_fig.loc[regime_order, \"annual_vol\"].to_numpy(dtype=float)\n",
-    "    max_dd_by_regime = regime_stats_fig.loc[regime_order, \"max_dd_pct\"].to_numpy(dtype=float)\n",
-    "    np.savez(\n",
-    "        ARTIFACT_DIR / \"inputs.npz\",\n",
-    "        dates=macro_df.index.astype(\"datetime64[ns]\").astype(\"int64\"),\n",
-    "        macro_labels=np.asarray(macro_labels, dtype=np.int64),\n",
-    "        regime_order=np.asarray(regime_order, dtype=object),\n",
-    "        raw_regime_for_order=np.asarray(\n",
-    "            [\n",
-    "                next(r for r, lbl in regime_labels_map.items() if lbl == label)\n",
-    "                for label in regime_order\n",
-    "            ],\n",
-    "            dtype=np.int64,\n",
-    "        ),\n",
-    "        annual_vol=annual_vol_by_regime,\n",
-    "        max_dd_pct=max_dd_by_regime,\n",
-    "        event_years=np.asarray(list(events.keys()), dtype=np.int64),\n",
-    "        event_labels=np.asarray(list(events.values()), dtype=object),\n",
-    "        start_year=np.int64(macro_df.index.min().year),\n",
-    "        end_year=np.int64(macro_df.index.max().year),\n",
+    "sp500 = load_sp500_index().to_pandas()\n",
+    "sp500[DATE_COL] = pd.to_datetime(sp500[DATE_COL])\n",
+    "sp500 = sp500.set_index(DATE_COL)\n",
+    "\n",
+    "sp500_monthly = sp500[\"close\"].resample(\"ME\").last().to_frame()\n",
+    "sp500_monthly[\"returns\"] = sp500_monthly[\"close\"].pct_change()\n",
+    "\n",
+    "aligned = sp500_monthly.reindex(macro_df.index, method=\"nearest\", tolerance=pd.Timedelta(\"5D\"))\n",
+    "if aligned[\"close\"].isna().any():\n",
+    "    raise ValueError(\"A macro month found no S&P 500 close within five days\")\n",
+    "\n",
+    "print(f\"Aligned {len(aligned)} months of S&P 500 closes to the macro panel\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b726f8e",
+   "metadata": {},
+   "source": [
+    "### Two statistics per regime, and what each one is\n",
+    "\n",
+    "**Annualized volatility** is the standard deviation of the monthly returns of the months\n",
+    "assigned to a regime, multiplied by the square root of twelve. It describes the months in\n",
+    "that regime and nothing else.\n",
+    "\n",
+    "**Maximum drawdown** is taken differently, and the difference matters. The running peak is\n",
+    "computed over the whole index, in calendar order, and each month's decline from that peak\n",
+    "is measured; the number reported for a regime is the deepest such decline observed in one\n",
+    "of its months. It is therefore the worst point of the index reached while conditions were\n",
+    "in that regime, not the drawdown of a portfolio held only during it. A regime that occupies\n",
+    "few months can miss a trough that fell just outside it, and one does below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcb56e43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aligned[\"regime\"] = regime_name.to_numpy()\n",
+    "aligned[\"drawdown\"] = aligned[\"close\"] / aligned[\"close\"].cummax() - 1\n",
+    "\n",
+    "regime_stats = aligned.groupby(\"regime\").agg(\n",
+    "    months=(\"returns\", \"count\"),\n",
+    "    monthly_std=(\"returns\", \"std\"),\n",
+    "    worst_drawdown=(\"drawdown\", \"min\"),\n",
+    ")\n",
+    "regime_stats[\"annual_vol\"] = regime_stats[\"monthly_std\"] * np.sqrt(MONTHS_PER_YEAR) * 100\n",
+    "regime_stats[\"max_dd_pct\"] = -regime_stats[\"worst_drawdown\"] * 100\n",
+    "regime_stats = regime_stats.sort_values(\"annual_vol\")\n",
+    "regime_order = regime_stats.index.tolist()\n",
+    "\n",
+    "regime_stats[[\"months\", \"annual_vol\", \"max_dd_pct\"]].rename(\n",
+    "    columns={\n",
+    "        \"months\": \"Months\",\n",
+    "        \"annual_vol\": \"Annualized volatility (%)\",\n",
+    "        \"max_dd_pct\": \"Deepest index drawdown reached (%)\",\n",
+    "    }\n",
+    ").style.format(\n",
+    "    {\"Annualized volatility (%)\": \"{:.1f}\", \"Deepest index drawdown reached (%)\": \"{:.1f}\"}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa0e88d5",
+   "metadata": {},
+   "source": [
+    "### The regime panel\n",
+    "\n",
+    "One row per regime, ordered by the volatility of the months it holds. The left panel shows\n",
+    "when each regime was in force, with three dated episodes marked; the two right panels are\n",
+    "the statistics above, so the ordering of the bars can be read against the pattern of the\n",
+    "bands. This is the panel that appears as Figure 1.6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "888f994b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EVENTS = {2008: \"Global financial crisis\", 2020: \"COVID-19\", 2022: \"Inflation\"}\n",
+    "REGIME_SHADES = [COLORS[\"recede\"], COLORS[\"copper\"], COLORS[\"amber\"], COLORS[\"blue\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7da5d43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def year_ticks(dates: pd.DatetimeIndex, every: int) -> tuple[list[int], list[str]]:\n",
+    "    \"\"\"Positions and labels for the first month of every *every*-th year.\"\"\"\n",
+    "    years = dates.year.tolist()\n",
+    "    ticks = [j for j, y in enumerate(years) if y % every == 0 and (j == 0 or years[j - 1] != y)]\n",
+    "    return ticks, [str(years[j]) for j in ticks]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fa9df3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def draw_regime_row(ax, occupied: np.ndarray, colour: str, label: str) -> None:\n",
+    "    \"\"\"Shade the months a regime was in force across one full-width row.\"\"\"\n",
+    "    for j in np.flatnonzero(occupied):\n",
+    "        ax.axvspan(j, j + 1, color=colour)\n",
+    "    ax.set_xlim(0, len(occupied))\n",
+    "    ax.set_ylim(0, 1)\n",
+    "    ax.set_yticks([])\n",
+    "    ax.set_ylabel(label, rotation=0, ha=\"right\", va=\"center\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10c95ef6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def draw_stat_bar(ax, value: float, colour: str, limit: float, heading: str | None) -> None:\n",
+    "    \"\"\"Draw one horizontal bar with its value written at the end.\"\"\"\n",
+    "    ax.barh([0], [value], color=colour, height=0.6)\n",
+    "    ax.set_xlim(0, limit)\n",
+    "    ax.set_ylim(-0.5, 0.5)\n",
+    "    ax.set_yticks([])\n",
+    "    ax.text(value + limit * 0.02, 0, f\"{value:.0f}%\", ha=\"left\", va=\"center\", fontsize=8)\n",
+    "    if heading:\n",
+    "        ax.set_title(heading, fontsize=8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c46564d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mark_events(ax, dates: pd.DatetimeIndex, label_them: bool) -> None:\n",
+    "    \"\"\"Draw a rule at the first month of each dated episode, labelling it on the top row.\"\"\"\n",
+    "    for event_year, event_label in EVENTS.items():\n",
+    "        position = next((j for j, y in enumerate(dates.year) if y == event_year), None)\n",
+    "        if position is None:\n",
+    "            continue\n",
+    "        ax.axvline(x=position, color=COLORS[\"neutral\"], alpha=0.35, linewidth=0.8)\n",
+    "        if label_them:\n",
+    "            ax.annotate(\n",
+    "                event_label,\n",
+    "                xy=(position, 1.3),\n",
+    "                xycoords=(\"data\", \"axes fraction\"),\n",
+    "                ha=\"center\",\n",
+    "                fontsize=6,\n",
+    "                color=COLORS[\"neutral\"],\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92694486",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def draw_panel_row(fig, grid, i: int, regime: str, first: bool, last: bool) -> None:\n",
+    "    \"\"\"Draw one regime's timeline row and its two statistic bars.\"\"\"\n",
+    "    shade = REGIME_SHADES[i]\n",
+    "    ax_band = fig.add_subplot(grid[i, 0])\n",
+    "    draw_regime_row(ax_band, regime_name.to_numpy() == regime, shade, regime)\n",
+    "    mark_events(ax_band, macro_df.index, label_them=first)\n",
+    "    if last:\n",
+    "        ax_band.set_xticks(ticks)\n",
+    "        ax_band.set_xticklabels(tick_labels, fontsize=7)\n",
+    "        ax_band.set_xlabel(\"Year\")\n",
+    "    else:\n",
+    "        ax_band.set_xticks([])\n",
+    "\n",
+    "    stats = regime_stats.loc[regime]\n",
+    "    heading = (\"Annualized\\nvolatility\", \"Deepest index\\ndrawdown\") if first else (None, None)\n",
+    "    draw_stat_bar(fig.add_subplot(grid[i, 1]), stats[\"annual_vol\"], shade, 25, heading[0])\n",
+    "    draw_stat_bar(fig.add_subplot(grid[i, 2]), stats[\"max_dd_pct\"], shade, 70, heading[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "531276cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ticks, tick_labels = year_ticks(macro_df.index, every=4)\n",
+    "n_rows = len(regime_order)\n",
+    "\n",
+    "fig = plt.figure(figsize=(style.PAGE_WIDTH, 0.85 * n_rows + 1.4))\n",
+    "grid = GridSpec(n_rows, 3, figure=fig, width_ratios=[3.5, 1, 1], wspace=0.15, hspace=0.15)\n",
+    "\n",
+    "for i, regime in enumerate(regime_order):\n",
+    "    draw_panel_row(fig, grid, i, regime, first=(i == 0), last=(i == n_rows - 1))\n",
+    "\n",
+    "fig.suptitle(\n",
+    "    \"Ordering the macro regimes by volatility does not order them by drawdown\",\n",
+    "    fontsize=10,\n",
+    "    ha=\"left\",\n",
+    "    x=0.02,\n",
+    ")\n",
+    "fig.text(\n",
+    "    0.5,\n",
+    "    0.0,\n",
+    "    \"Regimes from unemployment, the fed funds rate, the 10Y-2Y spread and 12-month CPI change\",\n",
+    "    ha=\"center\",\n",
+    "    fontsize=7,\n",
+    "    color=COLORS[\"neutral\"],\n",
+    ")\n",
+    "style.show_with_alt(\n",
+    "    fig,\n",
+    "    \"Four stacked timeline rows, one per regime, beside two columns of horizontal bars for \"\n",
+    "    \"annualized volatility and the deepest index drawdown. The volatility bars grow \"\n",
+    "    \"steadily down the rows while the drawdown bars do not follow the same order.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d374475",
+   "metadata": {},
+   "source": [
+    "### Reading the panel honestly\n",
+    "\n",
+    "The volatility ordering is what the panel was sorted on, so it is monotone by\n",
+    "construction and says nothing on its own. The drawdown column is the informative one,\n",
+    "because nothing forced it to agree, and it does not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0e684d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "smallest_regime = str(regime_stats[\"months\"].idxmin())\n",
+    "smallest_span = regime_name[regime_name == smallest_regime].index\n",
+    "deepest_month = aligned[\"drawdown\"].idxmin()\n",
+    "deepest_regime = str(aligned.loc[deepest_month, \"regime\"])\n",
+    "vol_spread = float(regime_stats[\"annual_vol\"].max() - regime_stats[\"annual_vol\"].min())\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"The smallest regime, **{smallest_regime}**, holds \"\n",
+    "        f\"**{len(smallest_span)} months**, running from \"\n",
+    "        f\"**{smallest_span.min():%B %Y}** to **{smallest_span.max():%B %Y}**, and the index \"\n",
+    "        f\"was never more than \"\n",
+    "        f\"**{regime_stats.loc[smallest_regime, 'max_dd_pct']:.0f}%** below its peak in any \"\n",
+    "        f\"of them. The deepest reading of the whole panel, \"\n",
+    "        f\"**{regime_stats['max_dd_pct'].max():.0f}%**, falls in \"\n",
+    "        f\"**{deepest_month:%B %Y}**, which the naming rule calls **{deepest_regime}**. \"\n",
+    "        f\"Across the four regimes the annualized volatility spans \"\n",
+    "        f\"**{vol_spread:.0f} percentage points**.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a33d50c8",
+   "metadata": {},
+   "source": [
+    "The two lines above are the check earning its place, and both of them cut against the\n",
+    "regime story rather than for it.\n",
+    "\n",
+    "The cluster the rule names Crisis is the handful of months in which unemployment averaged\n",
+    "above ten percent, and by the time unemployment reached that level the equity market had\n",
+    "already fallen and turned. The market's own worst point lands in a different cluster\n",
+    "entirely - one whose name, assigned from the policy rate and the unemployment rate, reads\n",
+    "as the aftermath. Neither name is a mistake in the rule; both are the same fact about the\n",
+    "data, which is that the labour market registers a shock the market has already priced.\n",
+    "\n",
+    "A statistic computed on four months is an anecdote whatever it says, and the volatility\n",
+    "spread across the four regimes is a few percentage points. Regimes estimated from\n",
+    "macroeconomic conditions do separate equity volatility, and they separate it weakly. A\n",
+    "reader should hold that conclusion at the strength these numbers support rather than at the\n",
+    "strength the idea invites, and the notebook has to report the small cell rather than\n",
+    "quietly drop it for being small.\n",
+    "\n",
+    "The lag is structural, not a property of this sample. Unemployment is measured over a month\n",
+    "and published in the next; prices move on expectations of the same conditions. Macro\n",
+    "regimes are therefore evidence about the environment a portfolio is already in, not a\n",
+    "signal about the one it is heading into, which is the use Section 1.4 argues for."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a073ace7",
+   "metadata": {},
+   "source": [
+    "### Figure 1.6 inputs\n",
+    "\n",
+    "The print version of Figure 1.6 is drawn by\n",
+    "`book/01_process_is_edge/figures/scripts/generate_figure_1_6_macro_regimes_volatility.py`\n",
+    "in the book repository, which reads the arrays written below rather than re-fitting the\n",
+    "clustering."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7a71339",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ARTIFACT_DIR = OUTPUT_DIR / \"figure_1_6\"\n",
+    "ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "np.savez(\n",
+    "    ARTIFACT_DIR / \"inputs.npz\",\n",
+    "    dates=macro_df.index.astype(\"datetime64[ns]\").astype(\"int64\"),\n",
+    "    macro_labels=np.asarray(core_labels, dtype=np.int64),\n",
+    "    regime_order=np.asarray(regime_order, dtype=object),\n",
+    "    raw_regime_for_order=np.asarray(\n",
+    "        [next(c for c, name in cluster_names.items() if name == regime) for regime in regime_order],\n",
+    "        dtype=np.int64,\n",
+    "    ),\n",
+    "    annual_vol=regime_stats.loc[regime_order, \"annual_vol\"].to_numpy(dtype=float),\n",
+    "    max_dd_pct=regime_stats.loc[regime_order, \"max_dd_pct\"].to_numpy(dtype=float),\n",
+    "    event_years=np.asarray(list(EVENTS), dtype=np.int64),\n",
+    "    event_labels=np.asarray(list(EVENTS.values()), dtype=object),\n",
+    "    start_year=np.int64(PANEL_FIRST_YEAR),\n",
+    "    end_year=np.int64(PANEL_LAST_YEAR),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7497994d",
+   "metadata": {},
+   "source": [
+    "## How the four indicators move together\n",
+    "\n",
+    "A clustering on four correlated inputs is not a clustering in four independent\n",
+    "directions, so the correlations are worth seeing before the extended panel raises the\n",
+    "question at a larger scale. Only one triangle is drawn: the matrix is symmetric and the\n",
+    "other half carries no additional information. The scale is fixed to the full range a\n",
+    "correlation can take, so the colours mean the same thing here as in any other correlation\n",
+    "figure in the book."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8482664f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correlations = macro_df.rename(columns=UNITS).corr()\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=style.FIGSIZE[\"single_tall\"])\n",
+    "sns.heatmap(\n",
+    "    correlations,\n",
+    "    mask=style.upper_triangle_mask(correlations),\n",
+    "    annot=True,\n",
+    "    fmt=\".2f\",\n",
+    "    cmap=style.ml4t_diverging(),\n",
+    "    vmin=-1,\n",
+    "    vmax=1,\n",
+    "    center=0,\n",
+    "    square=True,\n",
+    "    linewidths=0.5,\n",
+    "    cbar_kws={\"shrink\": 0.7, \"label\": \"Correlation\"},\n",
+    "    ax=ax,\n",
+    ")\n",
+    "ax.set_xlabel(\"\")\n",
+    "ax.set_ylabel(\"\")\n",
+    "style.add_message_title(\n",
+    "    ax,\n",
+    "    \"No pair of the four indicators is close to independent\",\n",
+    "    subtitle=\"Pearson correlation over the clustering panel\",\n",
+    ")\n",
+    "style.show_with_alt(\n",
+    "    fig,\n",
+    "    \"A lower-triangular correlation heatmap of four macro indicators on a red-to-blue scale \"\n",
+    "    \"fixed between minus one and one. The unemployment rate and the yield spread are \"\n",
+    "    \"strongly positive, the fed funds rate is strongly negative against the yield spread, \"\n",
+    "    \"and inflation is moderately negative against unemployment.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a45f3607",
+   "metadata": {},
+   "source": [
+    "Unemployment and the yield spread move together, and the fed funds rate moves against the\n",
+    "spread. Both are the same mechanism seen from two sides: the Federal Reserve cuts the\n",
+    "short rate when the labour market weakens, which pulls the front of the curve down and\n",
+    "steepens the spread, and it raises the short rate when the economy runs hot, which flattens\n",
+    "or inverts it. Inflation is the least entangled of the four and is still not independent of\n",
+    "them.\n",
+    "\n",
+    "That is the case for clustering jointly rather than thresholding one series at a time. Any\n",
+    "single indicator tells the same story as its neighbours plus its own noise; the joint model\n",
+    "reads all four positions at once, which is how it can separate the tightening cycle from\n",
+    "the recovery even though both involve an unusual short rate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e051679b",
+   "metadata": {},
+   "source": [
+    "## The counter-experiment: every series in the panel\n",
+    "\n",
+    "The core model uses four series chosen for what they mean. The obvious question is whether\n",
+    "adding the rest of the file would do better, and the obvious way to answer it is to fit the\n",
+    "same mixture to everything and compare the separation scores.\n",
+    "\n",
+    "That comparison is the trap this section exists to spring. The extended panel is assembled\n",
+    "with no judgement at all beyond a coverage filter, which is exactly how such a panel is\n",
+    "usually built."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca27ef09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "value_columns = [c for c in macro_raw.columns if c != DATE_COL]\n",
+    "monthly_full = (\n",
+    "    macro_raw.sort(DATE_COL)\n",
+    "    .group_by_dynamic(DATE_COL, every=\"1mo\", label=\"right\")\n",
+    "    .agg([pl.col(c).last() for c in value_columns])\n",
+    "    .filter(pl.col(DATE_COL) >= PANEL_START)\n",
+    ")\n",
+    "\n",
+    "missing_share = {\n",
+    "    column: monthly_full.select(pl.col(column).is_null().sum()).item() / monthly_full.height\n",
+    "    for column in value_columns\n",
+    "}\n",
+    "kept_columns = [c for c, share in missing_share.items() if share <= MAX_MISSING_SHARE]\n",
+    "\n",
+    "extended_pl = monthly_full.select([DATE_COL, *kept_columns]).drop_nulls()\n",
+    "extended_df = extended_pl.select(kept_columns).to_pandas()\n",
+    "extended_df.index = pd.DatetimeIndex(extended_pl[DATE_COL].to_pandas())\n",
+    "extended_df = extended_df.apply(scale)\n",
+    "\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"The coverage filter keeps **{len(kept_columns)} of {len(value_columns)}** series, \"\n",
+    "        f\"and dropping the months in which any of them is unquoted leaves \"\n",
+    "        f\"**{len(extended_df)} months**, the same window as the core panel.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "697d2090",
+   "metadata": {},
+   "source": [
+    "### What the filter let through\n",
+    "\n",
+    "Nothing in that assembly asked what the columns are, and the metadata table at the top of\n",
+    "the notebook says what got in. Nine of the columns are Treasury yields at maturities from\n",
+    "one to thirty years, which move almost as one series. `YIELD_CURVE_SLOPE` is defined as the\n",
+    "ten-year yield minus the two-year, which is the definition of `t10y2y`, already in the\n",
+    "panel - the same spread enters twice under two names. Nominal and real GDP are both\n",
+    "present, published quarterly, so each repeats its value for three months at a time. And\n",
+    "three price indices enter as levels, which is the treatment the core panel rejected for one\n",
+    "of them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2604831",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "duplicate_check = (extended_df[\"t10y2y\"] - extended_df[\"YIELD_CURVE_SLOPE\"]).abs().max()\n",
+    "gdp_distinct = int(extended_df[\"gdp\"].round(6).nunique())\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"The largest gap between `t10y2y` and `YIELD_CURVE_SLOPE` anywhere in the panel is \"\n",
+    "        f\"**{duplicate_check:.1e}** after standardization, and nominal GDP takes \"\n",
+    "        f\"**{gdp_distinct} distinct values** across **{len(extended_df)} monthly rows**.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92937c2d",
+   "metadata": {},
+   "source": [
+    "### The series, drawn\n",
+    "\n",
+    "Every kept column standardized and plotted on shared axes. The point of the small multiples\n",
+    "is the shape of each panel, not its level: how many of them are the same line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "313d67dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_columns = 5\n",
+    "n_rows_grid = int(np.ceil(len(extended_df.columns) / n_columns))\n",
+    "fig, axes = plt.subplots(\n",
+    "    n_rows_grid,\n",
+    "    n_columns,\n",
+    "    figsize=(style.PAGE_WIDTH, 0.85 * n_rows_grid + 0.6),\n",
+    "    sharex=True,\n",
+    "    sharey=True,\n",
+    ")\n",
+    "for ax, column in zip(axes.flat, extended_df.columns):\n",
+    "    ax.plot(extended_df.index, extended_df[column], color=COLORS[\"blue\"], linewidth=0.7)\n",
+    "    ax.set_title(column, fontsize=6)\n",
+    "    ax.tick_params(labelsize=5)\n",
+    "for ax in axes.flat[len(extended_df.columns) :]:\n",
+    "    ax.set_visible(False)\n",
+    "\n",
+    "fig.suptitle(\n",
+    "    \"Slow trends dominate the panel; only the VIX and claims spike\",\n",
+    "    fontsize=10,\n",
+    "    ha=\"left\",\n",
+    "    x=0.02,\n",
+    ")\n",
+    "style.show_with_alt(\n",
+    "    fig,\n",
+    "    \"A grid of small standardized time-series panels sharing their axes. Several rise \"\n",
+    "    \"steadily from one end of the window to the other, the Treasury yields move together \"\n",
+    "    \"in broad waves, and only the VIX and initial jobless claims show sharp isolated \"\n",
+    "    \"spikes against an otherwise flat line.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f57440ed",
+   "metadata": {},
+   "source": [
+    "### How much independent variation is left\n",
+    "\n",
+    "Principal component analysis puts a number on the redundancy the figure shows. Each\n",
+    "component is the direction of greatest remaining variance, and the cumulative share says\n",
+    "how much of the panel's total variation the first few directions account for."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "077b8240",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pca = PCA(n_components=min(10, extended_df.shape[1]))\n",
+    "reduced = pca.fit_transform(extended_df)\n",
+    "\n",
+    "explained = pd.DataFrame(\n",
+    "    {\n",
+    "        \"Component\": [f\"PC{i + 1}\" for i in range(pca.n_components_)],\n",
+    "        \"Share of variance\": pca.explained_variance_ratio_,\n",
+    "        \"Cumulative\": np.cumsum(pca.explained_variance_ratio_),\n",
+    "    }\n",
+    ").set_index(\"Component\")\n",
+    "explained.style.format(\"{:.1%}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a87796e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "two_component_share = float(explained[\"Cumulative\"].iloc[1])\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"Two directions account for **{two_component_share:.0%}** of the variance across \"\n",
+    "        f\"**{extended_df.shape[1]} columns**.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10e1105a",
+   "metadata": {},
+   "source": [
+    "### Which columns each direction is made of\n",
+    "\n",
+    "The share of variance says how much a direction carries; the loadings say what it is. Each\n",
+    "column below lists the four series with the largest absolute weight in that component,\n",
+    "heaviest first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "744d93d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loadings = pd.DataFrame(pca.components_.T, index=extended_df.columns, columns=explained.index)\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        component: loadings[component].abs().sort_values(ascending=False).index[:4].tolist()\n",
+    "        for component in explained.index[:4]\n",
+    "    },\n",
+    "    index=[f\"Heaviest {i + 1}\" for i in range(4)],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f8dc16c",
+   "metadata": {},
+   "source": [
+    "The leading direction is the trend the small multiples showed, and the second is the level\n",
+    "of the long end of the Treasury curve. Neither is a regime. The series that move when\n",
+    "conditions break - the VIX, initial jobless claims - do not appear until the third and\n",
+    "fourth components, which between them carry a small share of the variance. A mixture fitted\n",
+    "on this panel is therefore fitted mostly on where in the sample a month sits, which is what\n",
+    "the episode count is about to show."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91d7dbe1",
+   "metadata": {},
+   "source": [
+    "## Fit the same models to the extended panel\n",
+    "\n",
+    "A mixture and a k-means partition, both at the same cluster count as the core model, plus a\n",
+    "mixture on the ten leading principal components to see whether reducing the redundancy\n",
+    "changes the answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69ab3048",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gmm_extended = GaussianMixture(\n",
+    "    n_components=N_REGIMES, covariance_type=\"full\", random_state=SEED, n_init=10, reg_covar=1e-6\n",
+    ").fit(extended_df)\n",
+    "extended_labels = gmm_extended.predict(extended_df)\n",
+    "extended_probabilities = gmm_extended.predict_proba(extended_df)\n",
+    "\n",
+    "kmeans_labels = KMeans(n_clusters=N_REGIMES, random_state=SEED, n_init=10).fit_predict(extended_df)\n",
+    "\n",
+    "gmm_pca = GaussianMixture(\n",
+    "    n_components=N_REGIMES, covariance_type=\"full\", random_state=SEED, n_init=10, reg_covar=1e-6\n",
+    ").fit(reduced)\n",
+    "pca_labels = gmm_pca.predict(reduced)\n",
+    "\n",
+    "comparison = pd.DataFrame(\n",
+    "    {\n",
+    "        \"Model\": [\n",
+    "            f\"Core, {len(CORE_SERIES)} chosen series\",\n",
+    "            f\"Extended, {extended_df.shape[1]} series\",\n",
+    "            \"Extended, 10 principal components\",\n",
+    "            f\"Extended, {extended_df.shape[1]} series, k-means\",\n",
+    "        ],\n",
+    "        \"Silhouette\": [\n",
+    "            core_silhouette,\n",
+    "            silhouette_score(extended_df, extended_labels),\n",
+    "            silhouette_score(reduced, pca_labels),\n",
+    "            silhouette_score(extended_df, kmeans_labels),\n",
+    "        ],\n",
+    "    }\n",
+    ").set_index(\"Model\")\n",
+    "comparison.style.format(\"{:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbaa3177",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "### The score says the extended panel is better. Look at what it bought.\n",
+    "\n",
+    "An **episode** is a maximal run of consecutive months carrying the same label. Counting\n",
+    "them separates a model that recovers recurring conditions from one that has cut the sample\n",
+    "into consecutive blocks: a condition that recurs produces many episodes and revisits\n",
+    "earlier labels, while a chronological cut produces exactly as many episodes as it has\n",
+    "clusters and never returns to one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b79cd2db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def episode_count(labels: np.ndarray) -> int:\n",
+    "    \"\"\"Number of maximal runs of consecutive months sharing a label.\"\"\"\n",
+    "    return int(np.sum(np.diff(labels) != 0)) + 1\n",
+    "\n",
+    "\n",
+    "episodes = pd.DataFrame(\n",
+    "    {\n",
+    "        \"Model\": [\n",
+    "            f\"Core, {len(CORE_SERIES)} chosen series\",\n",
+    "            f\"Extended, {extended_df.shape[1]} series\",\n",
+    "        ],\n",
+    "        \"Clusters\": [N_REGIMES, N_REGIMES],\n",
+    "        \"Episodes\": [episode_count(core_labels), episode_count(extended_labels)],\n",
+    "    }\n",
+    ").set_index(\"Model\")\n",
+    "episodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd700d49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extended_episodes = episode_count(extended_labels)\n",
+    "core_episodes = episode_count(core_labels)\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"The extended model splits {len(extended_df)} months into **{extended_episodes} \"\n",
+    "        f\"episodes** from **{N_REGIMES} clusters**, against **{core_episodes}** for the core \"\n",
+    "        \"model.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19db7899",
+   "metadata": {},
+   "source": [
+    "An extended model with as many episodes as clusters has assigned every month to the\n",
+    "cluster of its neighbours and never revisited an earlier one. It has partitioned the\n",
+    "calendar into consecutive eras. That is what the trending levels put into the panel - three\n",
+    "price indices, two GDP series, money stock, payrolls - and it is precisely the failure the\n",
+    "core panel avoided by taking a rate of change instead of a level. The silhouette score\n",
+    "rewards it, because consecutive eras of a trending panel are far apart in the space the\n",
+    "score measures distance in.\n",
+    "\n",
+    "The lesson generalises past this dataset. A separation score answers \"are these groups far\n",
+    "apart\", and a regime model has to answer \"would this label have told me something the next\n",
+    "time conditions like these arrived\". Nothing forces those two questions to have the same\n",
+    "answer, and a panel assembled without judgement is where they come apart."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48057bfe",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "### The two partitions, drawn\n",
+    "\n",
+    "Assignment probabilities from both mixtures over the same months. Darker means the model\n",
+    "was more confident the month belonged to that cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c006ac35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_assignment_heatmap(probabilities: np.ndarray, dates: pd.DatetimeIndex, claim: str) -> None:\n",
+    "    \"\"\"Draw per-month cluster assignment probabilities as a heatmap.\"\"\"\n",
+    "    fig, ax = plt.subplots(figsize=style.FIGSIZE[\"single_wide\"])\n",
+    "    image = ax.imshow(probabilities.T, aspect=\"auto\", cmap=\"Blues\", vmin=0, vmax=1)\n",
+    "    positions, labels = year_ticks(dates, every=4)\n",
+    "    ax.set_xticks(positions)\n",
+    "    ax.set_xticklabels(labels)\n",
+    "    ax.set_yticks(range(probabilities.shape[1]))\n",
+    "    ax.set_yticklabels([f\"Cluster {i}\" for i in range(probabilities.shape[1])])\n",
+    "    ax.set_xlabel(\"Year\")\n",
+    "    fig.colorbar(image, ax=ax, shrink=0.8, label=\"Assignment probability\")\n",
+    "    style.add_message_title(ax, claim)\n",
+    "    style.show_with_alt(\n",
+    "        fig,\n",
+    "        \"A heatmap with one row per cluster and one column per month, shaded by assignment \"\n",
+    "        \"probability.\",\n",
     "    )"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "41ea3ea4",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004698,
-     "end_time": "2026-07-18T19:35:42.650712+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.646014+00:00",
-     "status": "completed"
-    }
-   },
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b1a379b",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "### Key Insight Summary"
+    "plot_assignment_heatmap(\n",
+    "    core_probabilities, macro_df.index, \"The core model returns to conditions it has seen before\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "3e624760",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.659031Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.658921Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.665684Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.665367Z"
-    },
-    "papermill": {
-     "duration": 0.010739,
-     "end_time": "2026-07-18T19:35:42.666135+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.655396+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Months</th>\n",
-       "      <th>Annual vol (%)</th>\n",
-       "      <th>Max drawdown (%)</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>regime_label</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>Expansion</th>\n",
-       "      <td>77</td>\n",
-       "      <td>12.0</td>\n",
-       "      <td>14.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Tightening</th>\n",
-       "      <td>98</td>\n",
-       "      <td>15.0</td>\n",
-       "      <td>42.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Recovery</th>\n",
-       "      <td>98</td>\n",
-       "      <td>15.2</td>\n",
-       "      <td>52.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Crisis</th>\n",
-       "      <td>4</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>9.9</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "              Months  Annual vol (%)  Max drawdown (%)\n",
-       "regime_label                                          \n",
-       "Expansion         77            12.0              14.6\n",
-       "Tightening        98            15.0              42.2\n",
-       "Recovery          98            15.2              52.6\n",
-       "Crisis             4            16.0               9.9"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "id": "79ff9cc0",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "insight_table = (\n",
-    "    regime_stats_fig.loc[regime_order, [\"months\", \"annual_vol\", \"max_dd_pct\"]]\n",
-    "    .rename(\n",
-    "        columns={\n",
-    "            \"months\": \"Months\",\n",
-    "            \"annual_vol\": \"Annual vol (%)\",\n",
-    "            \"max_dd_pct\": \"Max drawdown (%)\",\n",
-    "        }\n",
-    "    )\n",
-    "    .round(1)\n",
-    ")\n",
-    "insight_table"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9f24bd5f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002591,
-     "end_time": "2026-07-18T19:35:42.671827+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.669236+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Correlation Heatmap"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "1de33573",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.677392Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.677333Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.768590Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.767949Z"
-    },
-    "papermill": {
-     "duration": 0.094539,
-     "end_time": "2026-07-18T19:35:42.768925+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.674386+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApUAAAJHCAYAAADBp62DAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaDdJREFUeJzt3Xd0FFUbx/HfZtMLgXQIoRdp0jsIoUoHQcWCooj6giKIFVBAigUQFFGRIk0FBBRQkF4lSBMLIL0FSAIJ6ZUk7x/IhpDqLkk2+v2ck3OYmTszz0yW5Mkz994xJCcnpQsAAACwgE1RBwAAAIDij6QSAAAAFiOpBAAAgMVIKgEAAGAxkkorNWHqbPV5Ynimdc07P665i1cWTUCQJP24caead35cV0Ku3rVjXgm5quadH9ePG3fetWMCAFDYbAvjJD9u3KmJ076QJH0+7S3VrV090/b09HT1fvwlhV2LUIsm9TRtwiuFEdZd0+eJ4apUvmyxi/t2V8Ova/W6rbqvRSNVq1y+UM8dfDlUS779QfsP/alr4ZGytTOqcoUAtb+vqXp1bSdHB/tCjaegbNi6R9cjo9X/gfuLOhQAAO66Qkkqb7G3t9PGbXuyJJW//n5MYdciZG9nV5jhFDvb186X0WgskGNfC7+ueUu+U2lf70JNKn/+5VeNnjRT9na26tKhlSqVD1DKjRv6/chxfTL3G509f0lvDB9UaPEUpI3b9ujM+eAsSaWfr5e2r50vW2Oh/ncEAOCuKtTfYi0a19PWXfs0YsgTsr0tOdq4LUj3VK2oyOiYwgxH6enpSkpOKTaVMAf74hHn7RISE+Xk6JjttsshYXr73Vny8/HSJ++/KS/PUqZt/Xp21MVLIdqz77DFMeT2fU5KTpadra1sbIquJ4jBYCiW31sAAG5XqEllx8Dm2rHngPYf+lPNG9eVJKWk3NDWXfv01KO9tHz1xiz7fPXtj9r+8wFdCL6ixKQkVSznryf691S71k2ytP1py24t/36jzpwPlr2drSpXCNDAR3uracM6kjIeUz/Yq5NmL/hWZ84F639PP6z+D9yvS1fCNGveUh349YiSU1JUpWKAnnq0t1o2rf+Pr/NKyFU98OQIvfDMI3JxcdKS5T8o7FqEqlQM0CsvDFTN6pUztd+x54C+WLBCwZdDVbaMrwY/2Tfb4zbv/LgGPd5HzwzI2B52LUJzFq3U3v2/KSomVl4epdSs0b0a8b8BsrOzVVR0rBYuXaNfDv6uKyFXZbAx6N6a1TTk6YdV9e+K5KHfjmroa5MlSROnfWHqqjBm5LPq1uk+SdKWnb9o8bK1OnvhkpwcHdSs0b0aMqi/fLw8TLFMmDpb23bt06LPJuvDTxfptz+Pq1G9Wnp/3Ihsr2fJ8h8Vn5CoUSOeyZRQ3hLg76eH+2RU9W6kpmrR0jVat2mXwq5FyNOjpDq1ba5Bjz8ge/uMKndO3+dqlctp6GuT9c6bQ3XmXLB+2LhT4RGR2rDic7m5uujIX6c0Z9FK/XnslG6kpqpGtUp6/qmHVLdWtZy/2ZJ27jmo1eu36sSp84qKiZWPl4e6dmytJ/v3ktF4M1kd8upE/fr7X6bvo3SzQvndohmmz8vt91uSDhw+ormLVur4qfOytTWqfp17NGTQw6pQzt/UZu7ilZq35Dstnz9VC75ZrZ17Dio9PV1tWzbSKy8MlKOjg6ntvoN/aN5X3+nMuWClpqbK26uU2rZsrP89/XCu1wcAQH4UalJZ2tdLtWtU0cZtQaakMmj/b4qLj1eHts2zTSqXf79BrZo3UOd2LZRy44Y2b9+r0RM/1tR3RmZK+OYtWaW5i1epTs2qGjygr+zsbHXkr9M6ePiIKamUpAvBV/T2u7PUu1s79ezSVuXLllbE9Sg9O2K8EpOS9FCvzipRwlXrN+3Sa+M+1KQxw9S2ZWOzrnfj9j2Kj09U767tJMPNBPnNdz7SyoUfytb25q3/5eAfGjXhI1Uo56/nn35I0dGxmjRtTqZkLSdXw69r0LCxio2NV6+ugSofUFpXr13Xtt37lJiUJDs7W10OCdPOPQfU7r6mKuPnrYjrUfp+3VYNeXWSvp7zvrw9S6lCOX8NfqKv5ixaqV5dA1Xv7+4JdWreTKZu9YmtUa2S/vfUw4qIjNLy7zfo9yMntfDTiXJzdTHFlJqapuGj3lfd2tX1wuBH5OjgkG3skrT7l0PyL+2je/NI2m55d/pcrdu0S4Gtm+iRvl105K/TWrRsrc5dvKz3x2ZOXLP7Pt/y5Vffy9bOVo/266qUlBTZ2drqwOEjennMFFWvUlGDHu8jg8FGP27cqRdfn6zPpr6lWvdUvjMckx837ZSTo6P6P9BFTk6OOnj4iOYsWqm4+AS9OPhRSdLA/r0UG5egq9ci9NJzj0mSnJyyr+BK0r5Df+rlMVPkX9pbgwb0UVJSilas2ahnR7yjhbMmqrSfd6b2YybPVBlfH/3vqYd0/NQ5rflpu0qVdNfQZ/pLks6cC9YrY6epSsUADX7i5v+P4Muh+v3oyXzdewAA8lLonbg6BbbQZ18uU2JSshwd7LVh68+qX6eGvLOpVEnSsvlTMz22fLBnRz05dIy+WbXelFRevBSi+V99pzYtG2nymGGZHmWmp2d+C2Xw5VBNn/SamjW617RuxudLFHE9KtMgol5dAjXg+Tf18eyvdV/zhmY9Hg0NC9fy+dNUwu1m0lW+bGm9Nm669h74Q62a3Yx91ryl8ijprtkfvi1XF2dJUv069+ilUe/Lz9cr1+N/Nn+ZIq5Hau5H41WjWiXT+mef7Ge67soVArR8/tRM8Xdp30r9n3lNa3/arqcf6yOPUu5q3riu5ixaqTo1qur+9q1MbW/cuKFZ85aqUoWy+mzaGNNj2rq1qumVt6dp6aqfNPiJjMppckqK2t3XVEPyqH7FxcXr6rXruq95wzzvoySdPH1e6zbtUs/72+rNEc9Ikvr26KhSJUvo6xXrdPDwUTWsV9PUPrvv86HfjppinP/JBNPnKj09XR98/KUa3FtD0ye9JoPBIEnq3a2dHnv2dX2x8Ft99O4bOcY2/o2hmT6jD3Rvr/c/mq9Va7fouScflL29nZo0rCPv7zcoJjYu0/3NySdzv1EJNxd9MX2c3Eu4SpLatGioJ4eO1pzFK/X2q89nal+tcgWNfnmwaTkqJlZrN2w3JZX7Dv2plJQb+nDiayrp7pbn+QEA+KcKvSNZ+/uaKikpRT//8qvi4hP0877D6hTYPMf2t/+yjo6JU2xcgurVrq4Tp86Z1u/cc1Bpael6+rE+WZK/WwnCLWX8vDMlGpIUtP+walavnGkAkbOTo3p1DdSV0Ks6e+GSOZeq9m2amRJKSapb+x5JN/sSSjcHx5w8fV5dOrY2JZSS1KRhHVW87RFndtLS0rRzz0G1atogU0J5y63rtre3M92T1NQ0RUXHyMnJUeXKltbx2+5hTo6dOKvrkdHq271Dpn5/LZvWV/mAMtn2eXyge/s8jxsXnyBJcnbOuVp3uz37f5MkPdK3S6b1j/btKkn6+Y44svs+39KlQ+tMn6sTp8/r4qUQdQpsoajoWEVGxSgyKkaJiUlqVK+WDv9xXGlpaTnGdvux4uITFBkVo3p1qisxKUnnL17O1/Xd7tbnolvH+0wJpSRVqVROjevXVtDf9+J2fbq1y7Rct3Z1RUXHKi4uXpLk5nrz87Uz6GCu1wIAgLkKvVJZqmQJNa5fSxu37VFiUpLS0tIUmE3/yFt27/1VC775XidPX1BySopp/e3J4qUrYbKxMeSZiEnK8thQkkJCw9XuvipZ1lcI8P97+zVVrhCQ57Hv5OftmWn5VoIZExt387hh4ZJu9h28U7mA3JO+yKgYxcUnqFKFsrnGkJaWpmXfb9CqtZt1JeSqUm9LKG5PWHISEnbNFM+dygeU1u9HTmRaZzQa8/Xo3sXZSZIUH5+YZ1vp5vfAxsagsmV8M6339CgpN1dnU5y3ZPd9vqXMHdsuXgqRdLNPaE5i4xIy/YFwuzPngjV74bc6ePioKVk27XfHcn7c+lxkd88rlPPXLwf/yDIAys8nc1W7xN9dEqJj4+Xi4qz2bZppzU/b9e70ufps/jI1qldLbVo2UrvWTYp0kBIA4N+jSOYw6RTYQu/NmKeI61Fq3qhupj55tzv8x196bdyHqlenul55caC8PErKaDTqx407tXHbHrPOXZijbHP6ZX3nI/mCtHDpGn2xcIW6d26jZ5/spxJurjIYDPro8yVKS7/7FSt7u/yNpHZxcZaXZymdPnfxn53gjspzTnL7PjvcMQr81vfjhWceMQ1eupOzU/Z9Q2Ni4zTk1YlycXbS4Cf6yr+0r+zt7XTi1DnNmrdU6YVUFczxnv99bY4O9vps6hgd/O2o9uw7rL0HftfmHXv1fb2a+mjyG6YBRQAAmKtIkso2LRvp/Y/n689jpzRh1As5ttu2e7/s7e00Y9LrmUb33vnmEf/SPkpLS9fZC5fMmmPRz9dTF4KvZFl/69FlXn0bzeXnc7OSeatSdrsLF7PGc7uS7m5ycXbSmXPBubbbtmufGtatmam/nSTFxMXJ3T2jUnlnN4GMGL1M8TSqVytzjMFXslTI/omWTetp9bpt+uPoSdWpWTXXtn6+XkpLS1fwpZBMo58jrkcpJjbeojj8S/tIklxcnNSkQe1/tO+h348pKjpW7749XPXr3GNan90bd3K6x3e69bnI7jNw/uJllXR3y3GaptzY2Niocf3aaly/tl56TlrwzWrNXvCtDv529B9fNwAAdyqS8oSzk6NefXGgnhnwgFo1a5BjO6ONjQwyZOoDdiXkqnbuOZip3X0tGsrGxqD5X32Xpb9YfqqCzRvX09Hjp/XHbSNhExITtXr9NpX29c7XY3VzeHmWUtXK5bV+0y7F/t33Tbo59Ute/ThtbGx0X4uG2v3LIR07cSbL9lvXbWNjk+UebNn5i65eu55p3a1R2jGx8ZnW16hWUaVKltB3P25VcnJG94Og/b/p3IXLatGkXt4XmoPHH+wuJ0cHvTt9riKuR2XZHnw5VMu++0mS1OLv2QKW/r18yzcr10uSWloQxz1VK8q/tI++XrFO8QlZH8dfj4zOcd9bFcLb73FKyg2t/GFzlrZOjg6mPo65ufW5WLd5l6mrhCSdPndR+w79YZo54Z+Iio7Nsu7WH2Apt3UrAQDAXEX2Co9uHe/Ls02LpvX0zar1GjH6A3UMbKHrkdFauXaTypbx1amzF0ztAvz99GT/Xvry6+/1/MgJatuysezsbHXsxBl5eZbKcyTyEw/30KbtQXp5zBQ92KuTSri5at3mXbocclWT3xpWoH3O/vfUQ3rl7al67uV31L1zG0XHxGrF6k2qVL6s4hNz72/4/FMPad+hPzTklUnq1TVQFcqVUXhEpLbu3KfPP3xLbq4uatm0vuZ/9Z0mTp2tOjWr6fS5i9qwdY+pOndL2TI+cnN11nc/bpGzs6OcHB1U657KKuPno6GD+mvitC805NWJ6ti2uSKuR2n59xtV2tfbolcOli3jq/FvDNGYyZ+o/zOvqUuHVqpcoaxSbtzQH0dPauuuferasbUkqWrl8urasbVWr9um2Nh41b/3Hh09fkbrNu3SfS0aZhr5/U/Z2Nho1IhnNGLMFD327Ovq1uk+eXt66Gp4hA7+dkwuzk6a+s7IbPe9t2ZVubm6aMLU2XqoVyfJYNBPW3abHjvfrnrVCtq8Y68+mr1ENapVkpOTo1rn8EfVC888opfHTNHg4ePVo3MbJSUna8XqTXJxdtYzAx74x9c4/6vvdPjPv9SiST2V9vFSRGS0Vv2wWT5eHlnecAUAgDms+r1wjerV0qiXB2vxsrX66PMlKu3nraGD+utK6NVMSaV0cxqdMn7e+nbNRs1e8K0cHOxVpVJAvqZv8Sjlri+mj9WseUu1Ys1GJSWnqErFcpoy/mWzJj//J5o3rqtJo4dp9sJv9fn85fIv7aPRIwdrV9AhHfr9WK77+nh5aO5H4/XFwhXauHWP4uIT5O1VSs0a1TVVHp/s31MJiUnatG2PNu/8RdWrVNC0Ca/o0/lLMx3L1tZWb73ynD6bv1wffPylUlNTNWbksyrj56Nune6Tg4O9Fi9fq0/nLZOjo4PatGyoIYP659gfNr9aN2+oJZ+/q6++/VG7gg7pux+3yM7OVlUqltOLgx9Vry6BprZvjnhGZfx8tG7TTu3Yc0CepUrqiYd7aNDj/zzJulODujU1Z8Y4ffnV91qxZpMSEpLk4eGuWtUrq/cdI6tv517CTVPfGamZc77W7IUr5ObqovvbtVSj+rU0fNT7mdr27dFBJ09f0I8bd2rpqp/k5+uVY1LZpEFtTZ/0quYuXqU5i1fK1mhU/Xvv0dBB/VXGzyfbfXLTunkDhYRe0w8bdioqOkbuJdxUv849GvxE30wzDwAAYC5DcnJS4Y0aAQAAwL8SQz4BAABgMZJKAAAAWIykEgAAABaz6oE6AAAAyL8PP12kXXsPKST0mhZ+OinH+bvX/LRdi5etVXp6uhrWralXXxwoW1vL0kIqlQAAAP8Sga2baPa0t3J9ccvlkDDNWbhCn097S99+OU0RkVH6ft02i89NUgkAAPAvUb/OPfLx9sy1zdZd+9SqWQN5epSUwWBQn27ttWl7kMXnJqkEAAD4DwkNC89UySzt663QsHCLj1vgfSpftK9W0KdAMXN21ldFHQKszNtfv1HUIcDK7Jowv6hDgJUZ2Sr7voFFrTDznDYrZmnl2k2m5b49Oqpfz46Fdv68MFAHAACgGOjX8+4kkb4+nrp0Ocy0fCX0qnx9cn9knh88/gYAAPgPCWzVRLv3HlJ4RKTS09P13Y9b1KFNM4uPS6USAADgX+K9j+Zpz77DioiI0vBR78vZyVErFnyoydPnqHWzBmrdvKH8S/vomQF99dzL70iS6t9bQ326tbP43CSVAAAAZjIaijqCzN54aVC260eNGJxpuVfXQPXqGnhXz83jbwAAAFiMpBIAAAAW4/E3AACAmYwGK3v+XYSoVAIAAMBiVCoBAADMZG0DdYoSlUoAAABYjEolAACAmehTmYFKJQAAACxGpRIAAMBM9KnMQKUSAAAAFqNSCQAAYCb6VGagUgkAAACLkVQCAADAYiSVAAAAsBh9KgEAAMzE6O8MVCoBAABgMSqVAAAAZmL0dwYqlQAAALAYlUoAAAAzUZ3LwL0AAACAxahUAgAAmIk+lRmoVAIAAMBiVCoBAADMxDyVGahUAgAAwGJUKgEAAMxEn8oMVCoBAABgMSqVAAAAZqJPZQYqlQAAALAYSSUAAAAsRlIJAAAAi5FUAgAAwGIM1AEAADATUwploFIJAAAAi1GpBAAAMBNTCmWgUgkAAACLUakEAAAwE30qM1CpBAAAgMWoVAIAAJiJPpUZqFQCAADAYlQqAQAAzESlMgOVSgAAAFiMSiUAAICZGP2dgUolAAAALEalEgAAwEz0qcxApRIAAAAWy1dS+dfJs1q/ebckKTomTtfCrxdoUAAAAChe8kwqV67dpEnT5mjeklWSpOiYWI1979MCDwwAAADFR55J5ep12zTno3FydnaSJJUt46vIqJgCDwwAAMDaGQ2GQvuydnkmlXZ2dnJ0sM+0zmikKyYAAAAy5Dn6u6S7my4EX9GtBPnHjTvl6+NZ0HEBAABYPUZ/Z8gzqRz+/OMa+94snb94Rb0eGyYXZydNeWdkYcQGAACAYiLPpDLA309zPxqvC8FXlJ4ulStbmsffAAAA4o06t8szO3x93HTZ2NioQjl/VSzvL6PRRq+Pm14YsQEAAKCYyLNSGXL1WpZ1wVdCCyQYAACA4sQa+1RevBSid6bMVlR0jFxdnDRm5HOqVKFspjZpaWmaOedr7T3wu4xGo9zdXPXG8EEK8Pcz+7w5JpXf/bhF3/24VReDQ/Tk0NGm9XFxCapY3t/sEwIAAKDgvP/RfPXuGqhune7T1l37NHHabM2fOSFTm117D+n3Iye1+LPJsrW11Zdff6/Pv1yuSWOGmX3eHJPKZo3qqnzZ0vpg5gK99NzjpvUuzk6qUrGc2ScEAABAwYiIjNKxk2c0493XJUmBrRpr2qyFungpJFMV0iCDUlJSlJScIqPRqLj4BPl4e1h07hyTytK+Xirt66Wlcz+w6AT/Vm2HPqHmA/upTJ3qOrJ+hz7v82yObR3dXPXo55NUp3s7pSQkavsni7Ru4sx8b0fxUtPPTS/eV1ll3B11KSpBM3ec0bHQ7F8Y4OvmoEUDGikhJdW07rdLURq77phpuc+9pdWrThmVdLbT8dAYfbT9tC5HJxb4dcByBqNRFYe9KO9OnZSenq6rGzfp7MyZUmpqlrbNNm7IvK+9vRLOndfhgQP/8bFg/UJPHVXQN58qOuyK3H3LqPmjQ+RTqUae+x3f9ZP2fPWJmjw4WLXa95IkBf95QPtXfan4yGuSDPIqV0WNH3xGHv4VCvYiIMn6BuqEXY2Ql0dJ2RqNkiSDwSBfb0+FXg3PlFS2alZfB387qu79X5Czs6O8PUvp06ljLDp3nn0qE5OStWL1Rp04fV7JKSmm9e+9PdyiExd3kZdDtW7iJ6rRoaVKli2da9uHZ46Xi0dJjSrXUm4+nhq+eYnCz1/SL4tX5Ws7ig83B1u907Wm5gWd0+bjYepQ3UfvdKuhgUsOKi4551/+jy3cn+32tlW81Leev95cc0SXoxP1eKMAje9WQ88t/VVp6QV5Jbgbyj75pNzuvVeHHh8gSao5dYoCBgzQxQULsrTd26lzpuV6Cxbo2pYtZh0L1i0pLkabPx2vRn2eUpVm7XVq7xZtnvWO+k6YIwdn1xz3i48M1x8bV6rUHcmiR0AldX5pgpzdPZSWmqpj23/Q1s8nqd+EOQV8JShsK9Zs0sq1m0zLfXt0VL+eHc061rETZ3XmXLDWfP2xXJyd9On8Zfrg4/ka9/oQs+PLc/T3ezPm6kroVf1x7KQa1q2pkNBr8vPxMvuE/xaHv9ug31ZvVOy167m2s3NyVKP+3bV6zFQlREUr7ORZbZu5UC0HPZyv7SheWlTyUHhcktYfC1VKWrrWHwvV9fgUtaxk3gsDWlby1MZjYboYmaDUtHQtOXBRpUs4qnbpEnc5chQE325dFbxwkVLCw5USHq7gRYvk071bnvu51qgh5wrlFbZuncXHgvU5fzhIziU9Vb31/TLa2al66/vlVKKULhwOynW/oG8+U71u/bMkns7uHnJ2v/XYMl0GGxvFhocqLfVGAV0BbmdjMBTaV7+eHfXNnA9MX9kllD7eHroWEakbfz/FSE9PV+jVcPl6Z/49tH7zbjWsV1Nuri6ysbFR1w6tdfC3Y1mO94/uRV4NTp65oFdffEouzk56sFcnzZoyWsdPnrXopP8lftUry87BQcGHj5rWBR8+Kv9778nXdhQvFT1ddDo8LtO609fiVNHTJdf9Zvevr28GNta4LjUUUNLJtN5gkHTHkxXD3+eBdTO6ucrB11dxJ0+a1sWdPCVHPz8ZXXL//vl276brv/yi5PBwi48F6xMRfFYeZStlWudRtqIigs/luM+5g7uVkhivKs3aZ7s9NiJMX414WIteeEC/LP9C997/oGyMeT6MxL+QR0l3Va9SQRu2/CxJ2rZ7v3y8PLKM6vYv7a2Dh48qJeXmHx8///KrKt8xQvyfyvMT52B/873fRqONEhIT5eLspOtR2fcPQ1YOrs5KjI1T2m39nuIjo+Xo5pKv7ShenOyMikvK/Bg7NumGnOyM2baPSkjRsBW/6dS1ODna2uixRgF6t2ctPfvNr4pPSdW+89f1RJNy2nHyqi5HJWpAk3KysTHI2T7748F6GJ2cJUk3YmNN62792+jsrNS4uGz3s3F0lFf79jo5cZLFx4J1upGUKHunzD/j7Z1dlZKUkG37pLhY7V/1pToNeyfHY7p6+Oix6cuUkhivk0Fb5FLK+67GjOLl9WFPa+K0L7Rw6Rq5ODtp9Mib4z4mT5+j1s0aqHXzhurbo6POXbisAf8bJVtbozxLueu1YU9bdN48k8oSbi6KjolTi8b1NHzUBypZwk0+XpaNDvovSYqNl72zk2yMRlPi6OTupsSYuHxth3ULrOqtl9pWliSFxSTpUHCk3Bwy/7dycTAqKiH7x1CJN9J0POxmchCXnKov9pxTYDVv1fRz04GLkdr4V5g8Xew1rmsNOdvbatNfYboQEa+YRB5rWbvUhHhJkq2Li25ERZn+LUmp8fE57ucVGKi0xCRFBGU8CjX3WLAOp3/Zpj1fz5J0M/krfU9dJcfHZmqTnBAnR1f3bPffv2q+qrbsKHffvKfzs3N0Vo023fT1K4/Ko+wMuXmZP+cgiq/yAWU0Z8a4LOtHjRhs+re9vZ3eHPHMXT1vnknltAmvymi00bNP9tPGbXsUHROnrh1a5dj+zk6k//XelyHHTys1JUVl69bQhUN/SpIC6tXU5T/+ytd2WLdtJ69q28mrpuXONXzU594ymdpU9nTRyt8u5/uY6XcMwPnmYLC+ORgs6eZAoB61/fTH5Sjzg0ahSI2JVVJoqFyqVlXi5Zvff5eqVZUUGpprZdG3R3eF/bQ+06huc48F61C5aaAqNw00LZ/4eaOObFmdqU1E8BnVat872/2vHDus5MR4Hd2yRtLNBPTahVMKPXVE7Z4blaV9utKVmpKi2PAwkspCYLDG2c+LSK59KlNT0zR81PuSbg5J79yupR7s1UkuLs457nNnJ9J/KxujUbYODrKxNcpgY5Ctg4OMdnZZ2qUkJOrgsh/Uc8JIOZZwk0+VCmr74pPaPXdZvrajeNlzJkJeLg7qXMNHtjYGda7hIw8Xe+05G55t++o+rgoo5SQbg+Roa6NBzcpLko7+PQWRi71RZf/uY+nhbK+R7aoo6GyEzl/P/jEZrEvYuvUq+8QTsvPwkJ2Hh8oOGKDQtT/k2N4pIEButWsr9IcfLT4WrFf5es0VH3lNJ37eqNQbKTrx80YlRF1X+Xotsm3f7fVp6v3WJ+o15mP1GvOxvMpXUe2OD6jFY0MlSWf271B02GWlp6UpKT5Wvyz7QrYODvIsV7kwLwvIvVJpNNooMSlZaWlpsrHJc0zPf0rXMS+q+7jhpuVPEo/rxPa9+jCwv15Yt0Cndu3TT+9+Kkla+sJYPTZ7st4LDlLy3/NQ3j5dUF7bUXzEJN3Q2HVH9UKbyhraupIuRSZq7Lpjiv27n6W3q73mPNJAg785pKuxySpdwlFPNi0nD2f7m4/CQ2P05tojiv97eiFXB1u9ff898nVzUHxKqraduKov954vykvEP3BxwQLZupdQg6+WSJLCNmzUxcWLJUmVXxkpSTo9dZqpvU/37or+7XclBgf/o2OheHFwcVOHIW8r6JvPtHfp5yrhU0bth7wtB5ebo7pjI8L03fgh6jP2U7l6+MjZvVSm/Y22drJ3cjE9Lo8ND9PB7xcpMSZStg6O8qpQTZ1fmpil3yYKhg2VShNDcnJSrrPdTf9skS5eClXndi3l7ORgWt+6ecN8neBF+2qWRYh/nbOzvirqEGBl3v76jaIOAVZm14T5RR0CrMzIVuWLOoRsba7auNDO1eHk/kI7lzny7FN56sxFSdKa9dtM6wwGQ76TSgAAgH8rg5EnubfkmVTOmjK6MOIAAABAMZavmVGvhV/X5ZCrSk1LM62rX4fJuQEAwH8bo78z5JlULvh6tb5a8aPKlPaW0TRYx6D5M3OehBUAAAD/LXkmlT9s3KEVC6bJvYRbYcQDAABQbDD6O0OevUtLlXQnoQQAAECu8qxUNmlQW9M/W6xOgS3kYJ8xuXeVSuUKNDAAAABrZ2Aeb5M8k8r1m3dLknYFHTKtMxiklQunF1xUAAAAKFbyTCpXLSJ5BAAAyA59KjPkmVSGhF3Ldr2fj9ddDwYAAADFU55J5VMvvCWDDEpXupKTU5SYlCR3NzetW/5pYcQHAACAYiDvPpXLP8u0vH33fp08c6HAAgIAAEDx84+HLLVt1Vh79h0ugFAAAACKF4PRUGhf1i7PSmVcXLzp36lp6Try1ynFxScUaFAAAAAoXvJMKjv2fU4Gg5SeLtnY2CjA31cj/jegMGIDAACwagYj81TekmdSueenxYURBwAAAIox0msAAABYLM9KJQAAALLH5OcZqFQCAADAYlQqAQAAzGSwoVJ5C5VKAAAAWIxKJQAAgJlsmFLIhDsBAAAAi1GpBAAAMFNxeH1iYaFSCQAAAItRqQQAADATlcoMVCoBAABgMZJKAAAAWIykEgAAABajTyUAAICZmKcyA3cCAAAAFqNSCQAAYCZGf2egUgkAAACLUakEAAAwk40NlcpbqFQCAADAYlQqAQAAzGRg9LcJdwIAAAAWo1IJAABgJhtGf5tQqQQAAIDFqFQCAACYiXkqM1CpBAAAgMVIKgEAAGAxkkoAAABYjKQSAAAAFmOgDgAAgJmY/DwDdwIAAAAWo1IJAABgJiY/z0ClEgAAABajUgkAAGAmg431VSovXgrRO1NmKyo6Rq4uThoz8jlVqlA2S7tTZy/qw08XKuJ6tCTp+YEPqm2rxmafl6QSAADgX+T9j+ard9dAdet0n7bu2qeJ02Zr/swJmdokJibp9XEf6u1Xn1fd2tWVmpqm6JhYi87L428AAAAz2RhtCu0rPyIio3Ts5Bl1bt9SkhTYqrFCr0bo4qWQTO02btujWvdUUd3a1SVJRqONSpUsYdG9oFIJAADwLxF2NUJeHiVlazRKkgwGg3y9PRV6NVwB/n6mdmcvXJK9na1GvjVVV69FqHLFchr27KMWJZYklQAAAGYyFOLo7xVrNmnl2k2m5b49Oqpfz45mHSs1NU37fz2iOR+Nk7dnKX325XJNmfmlJr/1ktnxkVQCAAAUA/165p1E+nh76FpEpG6kpsrWaFR6erpCr4bL19szUztfb081qFtTPl4ekqT727XU8NHvWxQffSoBAADMZDDaFNpXfniUdFf1KhW0YcvPkqRtu/fLx8sj06NvSWrfpqmOnTijuLh4SdKe/YdVtVI5i+4FlUoAAIB/kdeHPa2J077QwqVr5OLspNEjn5UkTZ4+R62bNVDr5g3l5+OlJ/v31LMj3pHBxiBvz1J646VBFp2XpBIAAMBMBhvre+hbPqCM5swYl2X9qBGDMy136dBKXTq0umvntb47AQAAgGKHpBIAAAAWI6kEAACAxehTCQAAYKb8vunmv4A7AQAAAIsVeKXy7KyvCvoUKGYqDn2sqEOAlXn+1VlFHQKszP6UnUUdAqzOgKIOIFv5nT/yv4A7AQAAAIvRpxIAAMBMVCozcCcAAABgMSqVAAAAZrLGN+oUFe4EAAAALEalEgAAwEwGo7GoQ7AaVCoBAABgMSqVAAAAZmL0dwbuBAAAACxGUgkAAACL8fgbAADATDZMKWTCnQAAAIDFSCoBAABgMZJKAAAAWIw+lQAAAGZiSqEM3AkAAABYjEolAACAmahUZuBOAAAAwGJUKgEAAMxkYJ5KE+4EAAAALEalEgAAwEz0qczAnQAAAIDFqFQCAACYiUplBu4EAAAALEalEgAAwEw2VCpNuBMAAACwGJVKAAAAMzFPZQbuBAAAACxGUgkAAACLkVQCAADAYvSpBAAAMBPzVGbgTgAAAMBiVCoBAADMRKUyA3cCAAAAFqNSCQAAYCbmqczAnQAAAIDFSCoBAABgMR5/AwAAmMnGaCzqEKwGlUoAAABYjEolAACAmZhSKAN3AgAAABajUgkAAGAmKpUZuBMAAACwGEklAAAALEZSCQAAAIvRpxIAAMBMvKYxA0klAADAv8jFSyF6Z8psRUXHyNXFSWNGPqdKFcpm2zY9PV0vvv6ujp86p02rvrDovKTXAAAAZjIYbQrtK7/e/2i+encN1PL5U/X4Qz00cdrsHNsuXbVe/qV97satIKkEAAD4t4iIjNKxk2fUuX1LSVJgq8YKvRqhi5dCsrQ9cy5YO/cc1ICHe9yVc/P4GwAAwEzWNk9l2NUIeXmUlO3f7yQ3GAzy9fZU6NVwBfj7mdrduHFD786Yp9EvPyPjXeoXSlIJAABQDKxYs0kr124yLfft0VH9enY061jzlnynti0bqUI5f10JuXpX4iOpBAAAMFNhjv7u1zPvJNLH20PXIiJ1IzVVtkaj0tPTFXo1XL7enpna/fr7MYVeDdeKtZuUmpqquPgE9XliuOZ//I5KlSxhVnwklQAAAP8SHiXdVb1KBW3Y8rO6dbpP23bvl4+XR6ZH35L0+Ydvm/59JeSqnhgyWt8tmmHRuUkqAQAAzGSwMRZ1CFm8PuxpTZz2hRYuXSMXZyeNHvmsJGny9Dlq3ayBWjdvWCDnJakEAAD4FykfUEZzZozLsn7UiMHZti/t523xHJUSSSUAAID5rLBSWVSsaxw8AAAAiiUqlQAAAObi3d8m3AkAAABYLMekct/BPyRJcXHxhRYMAAAAiqccH39/On+ZmjSsoyGvTdLCWZMKM6Zipaafm168r7LKuDvqUlSCZu44o2OhMdm29XVz0KIBjZSQkmpa99ulKI1dd8y03Ofe0upVp4xKOtvpeGiMPtp+WpejEwv8OmC5tkOfUPOB/VSmTnUdWb9Dn/d5Nse2jm6uevTzSarTvZ1SEhK1/ZNFWjdxZr63o3ipV76UxvSprXJeLjp/LVYTV/2p3y5EZtv2mcDKGtyuSsYKg+Rsb6vhiw5qy58hquFfQuP63it/DycZDAadCY3VjPV/6eDZiMK5GFgkJTVVU1Zu1boDR2UwGNS1UU29+kA72Wbzqr93v92sbb+fVGxikpwd7NWpfnWN6NVWdrY3B4aMnPe9Dp+5pITkFLk7O6lP8zp69v4WhX1JgEmOSeWN1FQtXrZW1yOjtfz7DVm2P9S7c4EGVhy4Odjqna41NS/onDYfD1OH6j56p1sNDVxyUHHJqTnu99jC/dlub1vFS33r+evNNUd0OTpRjzcK0PhuNfTc0l+Vll6QV4K7IfJyqNZN/EQ1OrRUybKlc2378MzxcvEoqVHlWsrNx1PDNy9R+PlL+mXxqnxtR/FRwslOs55qrA/XHdOag5fUs6G/Pnmqsbq+v00xiTeytJ+77bTmbjttWu5Q20/jH7xXu/8KkyRdvp6g4YsO6kpkgiSpfW0/zXq6sdqM36SkG2mFc1Ew25yfgnT4zCV9N3qQJGnoZys0d2OQnu/SMkvbh1vX10s975Ozg72ux8brlfmr9eXmX0yJ4/NdWqq8dynZ29nqSkS0hnz2rcp4uqt741qFek3/dQYjo79vyfHx95vDBykk7JqSklJ04tS5zF+nzxdmjFarRSUPhcclaf2xUKWkpWv9sVBdj09Ry0qeee+cjZaVPLXxWJguRiYoNS1dSw5cVOkSjqpd2rzXJaFwHf5ug35bvVGx167n2s7OyVGN+nfX6jFTlRAVrbCTZ7Vt5kK1HPRwvrajeGlf20+h0Ylaue+iUlLTtHLfRV2LSVL72n557yzpgSYBWn/4silhjIpPMSWUBoOUlpYuFwdbebk5FNg14O75fu8fGty5ubzdXeXt7qpnOjfT90F/ZNu2kp+nnB3sJUnp6ZKNwaALVzN+vlQt4y17u5u1IYNBMhgMuhCW+88foCDlWKmMi0vQqy8+JT8fLw14uEdhxlRsVPR00enwuEzrTl+LU0VPl1z3m92/vow2Bh0PjdW8oHO6eNsvCBkytzX8fZ7fL0ffxchRlPyqV5adg4OCDx81rQs+fFT3jxqar+0oXqqVdtPxO/7/Hr8SrWql3fLc19fdUS2qeevRmbuzbPt5fCc52xtla7TR6gPBunQ94a7FjIIRHZ+o0MgYVS/rY1pX3d9HV65HKyYhSW5OWf8wmLdxr+ZsCFJCcopKujhpeK82mbZPWrZRa375U4kpN1TGo4R6Nq1d4NcB5CTPPpWbd+4lqcyBk51RcUmZH2PHJt2Qk132pfCohBQNW/GbTl2Lk6OtjR5rFKB3e9bSs9/8qviUVO07f11PNCmnHSev6nJUogY0KScbG4Oc7Smt/5s4uDorMTZOaakZn534yGg5urnkazuKF2d7W8UkpGRaF5OQImeHvGd0692orE5cidbRS1n/qGw5dqMcbG3UsU5p2dsxkUdxEJ+ULEmZkkc3J8eb2xKTs00qB3VqpkGdmulMSLjWHTgqLzfXTNtHP9xJbz7YUceCQ7T9j1Mq4exYgFeAbDH5uUmefSojI2PoU/m3wKreeqltZUlSWEySDgVHyu2OXwwuDkZFJWTtJyVJiTfSdDwsVpIUl5yqL/acU2A1b9X0c9OBi5Ha+FeYPF3sNa5rDTnb22rTX2G6EBGfbb8rFF9JsfGyd3aSjdFoShyd3N2UGBOXr+2wbt3ql9HbD9SRdLP/495T1+TuZJepjaujna7HJeV5rN6NArRo15kctyfdSNMPv17Sdy/fp7Nhsfr1HI8+rdmtR9mxCUkq5ep889+JNz8Hzo72ue5byc9T1fy99daSdfrixcxdYWxsDKpVrrT2n7igD7/fpnGPdimA6IG85ZhUvjl8kNZt2qXEpGSdOHUu80aDIdt9JGnFmk1auXZTxoomD1oao9XYdvKqtp28alruXMNHfe4tk6lNZU8Xrfztcr6PmX7HAJxvDgbrm4PBkm4OBOpR209/XI4yP2hYnZDjp5WakqKydWvowqE/JUkB9Wrq8h9/5Ws7rNuPv17Wj79m/Azo0zhAA1pVyNSmepkSWrQz52RRkppV8ZRXCQf9cOhSnue0NRpU3suFpNLKlXB2lG9JNx2/FKYA71KSpOPBYfIr5ZZtlfJON1LTMvWp/KfbUUCoVJrkmFR6epTUgId7qLSvtzq0bZbvA/br2VH9enY0LXefs9+yCK3YnjMRGty8ojrX8NGW41fVvrq3PFzstedseLbtq/u4Kj4lVZciE2RvvPn4W5KO/j0FkYu9UaWc7RUcmSAPZ3sNa1NJQWcjdJ6+UsWCjdEoG1tb2dgaZbAxyNbBQelpaUpNyfzoMyUhUQeX/aCeE0Zq7iPDVMLHU21ffFJr3vowX9tRvGz5M0SvdKuhPo0DtPZQsHo0KCtvNwdtPRKS6359mgRoy58hWZ5U3FfDRyHXE3Q6LFZ2RoMeb1VRvu5OOnCGKYWKg17NamvOhiDVq+QvSZq7MUh9mt+bpV18UrI2/npc7e6tKjcnB526ck1zNgSpRY0KkqTLEVE6eiFELWpUlKOdnX4/d1lf7zikR9s0KMzLATLJMal86oW3ZPh71MhnXy6Tre3Npjdu3JC7m5vWLf+0cCK0YjFJNzR23VG90KayhraupEuRiRq77phi/+5n6e1qrzmPNNDgbw7pamyySpdw1JNNy8nD2f7mo/DQGL259oji/55eyNXBVm/ff4983RwUn5KqbSeu6su9jLQvLrqOeVHdxw03LX+SeFwntu/Vh4H99cK6BTq1a59+evfm/5ulL4zVY7Mn673gICX/PQ/l7dMF5bUdxUd0QopeWLBfY/rU1qjetXT+apxeWHBA0X93k/Er6ajVI9uo17QdCom8OSdtCSc7ta/lp//Nz/pHeSlne73SvYZ8Szgq6UaaTobEaOiX+xUcwYsqioNn72+hqLhE9Z44T5LUrXEtPdOpuSRpwtKbXc3e6n+ze9n6A0f14XfblHwjVR5uzupQr5r+17WV6VhLth3UuK9/Ulp6urxLuOqRNg30dMf8F4Fwdxh4TaOJITk5KdcZEGfNXaqyZXzV4/6bI85+2LBDwVfCNOTp/E1v8m+uVMI8FYc+VtQhwMr8/Oqsog4BVmZ/h9wrufjvMQYOKOoQspW6aV6hncvYcVChncsceabXvxz8Xb26BsrGxkY2Njbq2SVQew/8XhixAQAAWDcbY+F9Wbk8k8qUGzd0/mJGp/MLwVeUckcfMQAAAPy35TlR2pCnH9ZzL7+jKpXKSZJOn72oUS8PLvDAAAAArF4xqCAWljyTytbNG+qbOVX151+nJEl1alRVSfe83wQBAACA/468X+kgqVTJEmrdjGkKAAAAbsfo7wzcCQAAAFiMpBIAAAAWI6kEAACAxfLVpxIAAADZYPS3CZVKAAAAWIxKJQAAgLmoVJpQqQQAAIDFqFQCAACYyWCkUnkLlUoAAABYjEolAACAuXijjgl3AgAAABajUgkAAGAuRn+bUKkEAACAxahUAgAAmMlApdKESiUAAAAsRlIJAAAAi5FUAgAAwGIklQAAALAYA3UAAADMxeTnJtwJAAAAWIxKJQAAgJkKc0qh9EI7k3moVAIAAMBiVCoBAADMxeTnJlQqAQAAYDEqlQAAAOZi9LcJdwIAAAAWo1IJAABgJoOR0d+3UKkEAACAxahUAgAAmIvR3yZUKgEAAGAxKpUAAADmolJpQqUSAAAAFiOpBAAAgMV4/A0AAPAvcvFSiN6ZMltR0TFydXHSmJHPqVKFspnaHDh8RJ/OW6aExEQZZFCLpvU05OmHZWPBZO4klQAAAGYyWOEbdd7/aL56dw1Ut073aeuufZo4bbbmz5yQqY2bq4smjHpB/qV9lJScrGFvvKf1m3erW6f7zD6v9d0JAAAAmCUiMkrHTp5R5/YtJUmBrRor9GqELl4KydSuepUK8i/tI0lysLdX1UrldSX0qkXnJqkEAAAwl42x8L7yIexqhLw8Ssr27zf9GAwG+Xp7KvRqeI77hEdEatvufWrZtL5Ft4LH3wAAAMXAijWbtHLtJtNy3x4d1a9nR4uOGRcXr1fHTtPjD3ZTjWqVLDoWSSUAAIC5DIX30Ldfz7yTSB9vD12LiNSN1FTZGo1KT09X6NVw+Xp7ZmkbF5+g4aOnqHXzhnqkb1eL4+PxNwAAwL+ER0l3Va9SQRu2/CxJ2rZ7v3y8PBTg75epXXxCokaM/kDNGt2rpx7tfVfOTaUSAADAXIVYqcyv14c9rYnTvtDCpWvk4uyk0SOflSRNnj5HrZs1UOvmDbX8uw06evyMEhOTtOPn/ZKkdq2bauCjvcw+ryE5OSn9rlxBDrrP2V+Qh0cxVHHoY0UdAqzMz6/OKuoQYGX2dwjJuxH+U4yBA4o6hGwZL/5eaOdKDbi30M5lDutLrwEAAFDs8PgbAADATOlW+Pi7qHAnAAAAYDEqlQAAAOaiUmnCnQAAAIDFqFQCAACYy2Ao6gisBpVKAAAAWIykEgAAABYjqQQAAIDF6FMJAABgLhvqc7dwJwAAAGAxKpUAAABm4o06GbgTAAAAsBiVSgAAAHNRqTThTgAAAMBihuTkpPSCPMG+wPYFeXgUQ8+3eKOoQ4CVaTllaFGHACtTY/fWog4BVmZIk7JFHUK2DFfPFtq50r0rFtq5zEGlEgAAABajTyUAAIC56FNpwp0AAACAxahUAgAAmIl5KjNwJwAAAGAxkkoAAABYjKQSAAAAFqNPJQAAgLnoU2nCnQAAAIDFqFQCAACYy2Ao6gisBpVKAAAAWIykEgAAABbj8TcAAIC5GKhjwp0AAACAxahUAgAAmKkwX9No7UOCqFQCAADAYlQqAQAAzGVDfe4W7gQAAAAsRqUSAADAXIz+NuFOAAAAwGJUKgEAAMxFpdKEOwEAAACLkVQCAADAYiSVAAAAsBh9KgEAAMxFn0oT7gQAAAAsRqUSAADATLz7OwOVSgAAAFiMSiUAAIC56FNpwp0AAACAxahUAgAAmMtg7T0dCw+VSgAAAFiMSiUAAIC56FNpwp0AAACAxahUAgAAmKkw56m0dtwJAAAAWIxKJQAAgLmssFJ58VKI3pkyW1HRMXJ1cdKYkc+pUoWyWdqt+Wm7Fi9bq/T0dDWsW1OvvjhQtrbmp4bWdycAAABgtvc/mq/eXQO1fP5UPf5QD02cNjtLm8shYZqzcIU+n/aWvv1ymiIio/T9um0WnZekEgAA4F8iIjJKx06eUef2LSVJga0aK/RqhC5eCsnUbuuufWrVrIE8PUrKYDCoT7f22rQ9yKJzk1QCAAD8S4RdjZCXR0nZGo2SJIPBIF9vT4VeDc/ULjQsXH6+Xqbl0r7eCg3L3Oafok8lAABAMbBizSatXLvJtNy3R0f169mxCCPKjKQSAADATOmF+JrGfj3zTiJ9vD10LSJSN1JTZWs0Kj09XaFXw+Xr7Zmpna+Ppy5dDjMtXwm9Kl8fzzsP94/w+BsAAOBfwqOku6pXqaANW36WJG3bvV8+Xh4K8PfL1C6wVRPt3ntI4RGRSk9P13c/blGHNs0sOjeVSgAAADOlpxd1BFm9PuxpTZz2hRYuXSMXZyeNHvmsJGny9Dlq3ayBWjdvKP/SPnpmQF899/I7kqT699ZQn27tLDqvITk5qUBvx77A9gV5eBRDz7d4o6hDgJVpOWVoUYcAK1Nj99aiDgFWZkiTrPMsWoOUG2mFdi47W+t+wEylEgAAwExp1liqLCLWnfICAACgWKBSCQAAYCbqlBlyrVSeu3C5sOIAAABAMZZrpXLEmA8UUMZP/Xp2VOvmDWQoxLmYAAAArF0apUqTXCuVKxd8qAd6tNeKNZvUb+DLWrL8B0VFxxZWbAAAACgmcq1U2tjYqG3LxmrbsrH+OnlWb4yfoblLVqlzYAs980RfeXuWKqw4AQAArE46o79N8hyoc/FSiFas2aStu/apdbMG6tWlrQ4cPqoRoz/Qks/fLYwYAQAAYOVyTSqHj3pfFy+F6IHuHfT1F+/JzdVFklS9akWt27SrUAIEAACwVvSpzJBrUtmrS6DatGwkG5usXS+/+uK9AgsKAAAAxUuuSWVg6yaFFQcAAACKsWxHfwdfDtXQVyep75MjNOPzJUpKTjZtGzx8XGHFBgAAgGIi26Ry6icLFNi6iSaNGaao6Fi9+Pq7iotPkCQlJacUaoAAAADWKr0Qv6xdtkllRGS0+vXsqHuqVtTY155Xiyb19OLr7yo2Ll7Mfw4AAIA7ZdunMikpOdPywEd6yc7WVi++/q7i4xMLJTAAAABrx+jvDNkmlRXKlVHQ/t/UvHFd07rHHuwmGxuDZs75ptCCs3YGo1EVh70o706dlJ6erqsbN+nszJlSamqWts02bsi8r729Es6d1+GBA//xsWDd6pUvpTF9aqucl4vOX4vVxFV/6rcLkdm2fSawsga3q5KxwiA529tq+KKD2vJniGr4l9C4vvfK38NJBoNBZ0JjNWP9Xzp4NqJwLgYWaTv0CTUf2E9l6lTXkfU79HmfZ3Ns6+jmqkc/n6Q63dspJSFR2z9ZpHUTZ+Z7O4qXKyePaOfiWYoKuyx3X3+1GfCC/KrUyHO/I9vXaceimWrZ/1nV7dTHtP7MoT0KWj5PcZHh8ipXWYFPDVep0gEFeQlAFtkmlRPefCHbxo/07ar2bZoVaEDFSdknn5Tbvffq0OMDJEk1p05RwIABurhgQZa2ezt1zrRcb8ECXduyxaxjwXqVcLLTrKca68N1x7Tm4CX1bOivT55qrK7vb1NM4o0s7eduO625206bljvU9tP4B+/V7r/CJEmXrydo+KKDuhJ5s09z+9p+mvV0Y7UZv0lJN9IK56JgtsjLoVo38RPV6NBSJcuWzrXtwzPHy8WjpEaVayk3H08N37xE4ecv6ZfFq/K1HcVHYmyM1n00Ts0ffFrVW7TX8T1b9ONHY/X4+/Pl4Oya435x18N1+KeV8ihbIdP661eCtfmLD9Tp+TdVtlZ9HfphqdZ/PF79J86WjdFYwFcD3qiTIds+lfb2drK3t9N3P25RYmJSpm0+Xh6FElhx4Nutq4IXLlJKeLhSwsMVvGiRfLp3y3M/1xo15FyhvMLWrbP4WLAu7Wv7KTQ6USv3XVRKappW7ruoazFJal/bL1/7P9AkQOsPXzYljFHxKaaE0mCQ0tLS5eJgKy83hwK7Btw9h7/boN9Wb1Tsteu5trNzclSj/t21esxUJURFK+zkWW2buVAtBz2cr+0oXs4c2iOXUp6q2aaLjHb2qtmmi5zdS+nMwT257rdzySw17PGIHF3cMq0/EbRV/vfUVYV6TWVrZ6+GPR5VQkyUrpz4syAvA8gi26TylsN/HFffgS9rxudLdPFSSGHFVCwY3Vzl4OuruJMnTeviTp6So5+fjC4uue7r272brv/yi5LDwy0+FqxLtdJuOn45OtO641eiVa20Ww57ZPB1d1SLat5ate9Clm0/j++kQ5O76OOBjbT6QLAuXU+4azGj6PlVryw7BwcFHz5qWhd8+Kj8770nX9tRvIQHn5VnQKVM67zKVVJ48Nkc9zl9YJeSE+N1T8sO2R7Pq1zG8Yy2tipVppyu5XI83D1phfhl7XKd/Hz8G0MUcT1Kq9dv07A33lWFcv56sFcntWhSr5DCs15GJ2dJ0o3YWNO6W/82OjsrNS4u2/1sHB3l1b69Tk6cZPGxYH2c7W0Vk5B52q2YhBQ5O+T6X02S1LtRWZ24Eq2jl6KzbGs5dqMcbG3UsU5p2dvl+rcgiiEHV2clxsYp7bY+1PGR0XJ0c8nXdhQvKYkJWR5zOzi5KiUx+z8WE+NitGf5PPUYOSnb7SlJCbJ3zvxZsHd2yfF4QEHJ8zedRyl3PfVob9WtVU3vTJmtce9/plIlS+iVF55U4/q1s7RfsWaTVq7dZFoecXfjtRqpCfGSJFsXF92IijL9W5JS4+Nz3M8rMFBpiUmKCAqy+Fgoet3ql9HbD9SRdLP/495T1+TuZJepjaujna7HJWW3eya9GwVo0a4zOW5PupGmH369pO9evk9nw2L167ncH6mi+EiKjZe9s5NsjEZT4ujk7qbEmLh8bYd1OxG0VdsX3RxU5ebpo7I16yspLiZTm6SEODm5uWe7f9DyearRurNK+vpnu93OwUnJd/yuSI6Pk52j012IHnmhS2WGXJPKpORkbdjys1as3SxHB3u98MwjCmzdRCdOn9OoiR/ru0UzsuzTr2dH9evZ0bS8L7D9XQ/aGqTGxCopNFQuVasq8fJlSZJL1apKCg3NtbLo26O7wn5an2lUt7nHQtH78dfL+vHXy6blPo0DNKBVhUxtqpcpoUU7c04WJalZFU95lXDQD4cu5XlOW6NB5b1cSCr/RUKOn1ZqSorK1q2hC4du9oMLqFdTl//4K1/bYd2qNW+nas3bmZaP7tyg3zd9n6lN+MUzmUZz3y746K9KTow37ZOcEKewcyd15eQR3T90jDzLVtS1ixkD/lJv3ND1KxfkeceAHqCg5foc7YEnRujXP/7SGy89rS+mj1WHts1kNNqoRrVKapJNlfK/JmzdepV94gnZeXjIzsNDZQcMUOjaH3Js7xQQILfatRX6w48WHwvWacufIfJ1d1KfxgGyNRrUp3GAvN0ctPVI7n2S+zQJ0JY/Q7KMEL+vho+q+bnJaGOQo52NngmsLF93Jx04w5RCxYGN0ShbBwfZ2BplsDHI1sFBRju7LO1SEhJ1cNkP6jlhpBxLuMmnSgW1ffFJ7Z67LF/bUbxUatBCcdev6ejODUq9kaKjOzcoLjJCFRu0yLZ93zHT9fD4T/XQuE/00LhP5F2hqurf309tnnhR0s2k9dKx33T+931KTUnWwR+WytHVXWWq1SnMywJyr1QunDVRXp6lst325ohnCiSg4uTiggWydS+hBl8tkSSFbdioi4sXS5IqvzJSknR66jRTe5/u3RX92+9KDA7+R8dC8RGdkKIXFuzXmD61Nap3LZ2/GqcXFhxQdMLNZNGvpKNWj2yjXtN2KCTy5osESjjZqX0tP/1v/v4sxyvlbK9XuteQbwlHJd1I08mQGA39cr+CI+gWURx0HfOiuo8bblr+JPG4Tmzfqw8D++uFdQt0atc+/fTup5KkpS+M1WOzJ+u94CAl/z0P5e3TBeW1HcWHo6ubug4bqx1LZmnXV5+qpK+/ur40zjSqOyY8TN+MeU6PTJwtN08fObtnnnXFaGsneydn0+PyUqXLqsPgV7X769mKvX5N3uWrqOuwsUwnVEiY/DyDITk5Kdvbce7CJW3cFqTQqzdHKPt6e6pDm2aqVKHsPzrBv/XxN8z3fIs3ijoEWJmWU4YWdQiwMjV2by3qEGBlhjT5Z/lHYQmLTcm70V3i45r1SYc1yfbx94o1mzRizBSlpNxQreqVVat6ZaWk3NDIt6fq29UbCztGAAAAWLlsH38v/36DFs6apBJ3TFfx+EPd9cxLY/Vgr06FEhwAAACKh2yTyrS0tCwJpSS5uTrzOiIAAIC/kRdlyDapbN64roa98Z56dmmr0r5ekqQrode0Zv12NW9ct1ADBAAAgPXLNql8ecgTWr95t9Zv3p1poE7n9i3UpX2rQg0QAADAWhWH1ycWlmyTSoPBoK4dW6trx9aFHQ8AAACKoX/8EuHde38tiDgAAACKnfT0wvuydv84qZz6yYICCAMAAADFWbaPvz+avSTbxunpUmwcb/IAAACQpLTiUEIsJNlWKlet3SInR0e5ujhn+nJzdZbBYCjsGAEAAGDlsq1UVqpQVu3ua6oqFQOybFuzfntBxwQAAFAsUKfMkG2lcvATfeVgb6fIqJgs21589tECDwoAAADFS7ZJZYsm9RTg76eXRr2XZdvi5WsLPCgAAIDiIC298L6sXbaPv1NSbig5OVlpqemKi08wjWOPjUtQYmJSoQYIAAAA65dtUrlo2RrNW/KdDAap4wPPmta7ODvpkb5dCi04AAAAa8bg7wzZJpWDHn9Agx5/QB98/KVeG/ZUYccEAACAYibXyc9JKAEAAJAf//iNOgAAAMCdsn38DQAAgLylMVOlCZVKAAAAWIxKJQAAgJkY/Z2BSiUAAAAsRqUSAADATMXhTTeFhUolAAAALEZSCQAAAIvx+BsAAMBMDNTJQKUSAAAAFqNSCQAAYKbiNvl5Wlqapn+2WEH7f5MkPdznfj3Yq1OWdknJyXp78iydvXBJDvb2KlWyhF59caAC/P1yPDZJJQAAwH/ET1t+1tkLl7Rs3lTFxsVr4NDRali3pipVKJulba+ugWreuK4MBoO+Xb1R786Yq0+njMnx2Dz+BgAAMFN6euF93Q1bdu5Vry6BMhpt5F7CVe3bNNOm7UFZ2jnY26tFk3oyGAySpNo1quhK6LVcj01SCQAA8B8REhYuPx8v03JpXy+FhIXnud/y7zfovuYNcm3D428AAAAzpRXi8O8VazZp5dpNpuW+PTqqX8+OmdoMHj5OFy+FZLv/wlmTzDrvgm9WK/hyqGa+92au7UgqAQAAioF+PbMmkXeaM2Ncrtv9fDwVEnZNdWpWlSRdCb0mPx/PHNt/9e2P2vHzAX383htydHTI9dg8/gYAAPiPaNe6qVav36bU1DRFRcdqy469at+mWbZtv1m5Tpu2B+mjd9+Qm6tLnsemUgkAAPAfcX/7Vjp64oweenqkDAaD+j/QRVUqBkiSdgUd1K69hzRqxGCFXQ3Xx198Lf/SPnrhtZuPze3s7DTv4/E5HpukEgAAwEypaUUdwT9jNNro1RcGZrutdfOGat28oSTJx9tTQRuW/KNj8/gbAAAAFqNSCQAAYKbCHP1t7ahUAgAAwGJUKgEAAMyUSqXShEolAAAALEalEgAAwEz0qcxApRIAAAAWo1IJAABgpuI2T2VBolIJAAAAi1GpBAAAMBN9KjNQqQQAAIDFSCoBAABgMZJKAAAAWIw+lQAAAGbijToZqFQCAADAYiSVAAAAsBiPvwEAAMyUxtNvEyqVAAAAsBiVSgAAADOlUqo0oVIJAAAAi1GpBAAAMBOvacxApRIAAAAWo1IJAABgplQKlSZUKgEAAGAxKpUAAABmok9lBiqVAAAAsFiBVyp3TZhf0KdAMbM/ZWdRhwArM7vX1qIOAVbmWKt2RR0CrE3yiaKOIFvMU5mBSiUAAAAsRlIJAAAAi5FUAgAAwGKM/gYAADATo78zUKkEAACAxahUAgAAmIk36mSgUgkAAACLUakEAAAwE30qM1CpBAAAgMWoVAIAAJgpjTfqmFCpBAAAgMWoVAIAAJiJ0d8ZqFQCAADAYlQqAQAAzMTo7wxUKgEAAGAxkkoAAABYjMffAAAAZkrl8bcJlUoAAABYjKQSAAAAFiOpBAAAgMXoUwkAAGAmXtOYgUolAAAALEalEgAAwEy8pjEDlUoAAABYjEolAACAmXhNYwYqlQAAALAYSSUAAICZUtPTC+3rbkhLS9O0WQvVb+DL6jfwZX27emOe+/ywYYead35cO/YcyLUdj78BAAD+I37a8rPOXrikZfOmKjYuXgOHjlbDujVVqULZbNtfCbmq1eu3q3aNKnkem0olAACAmVLT0gvt627YsnOvenUJlNFoI/cSrmrfppk2bQ/Ktm1aWpomT5+rkUOfkJ1d3nVIkkoAAID/iJCwcPn5eJmWS/t6KSQsPNu236xcr3trVdM9VSvm69g8/gYAADDT3aog5seKNZu0cu0m03LfHh3Vr2fHTG0GDx+ni5dCst1/4axJ+T7X6XMXtf3n/fps6ph870NSCQAAUAz065k1ibzTnBnjct3u5+OpkLBrqlOzqiTpSug1+fl4Zmn32x/HdSX0qh58+hVJUkRElN4/P1/h4ZF6oEeHbI9NUgkAAPAf0a51U61ev03tWjdVbFy8tuzYqynvvJKl3QM9OmRKHoe8OlEP97lfbVo0yvHYJJUAAAD/Efe3b6WjJ87ooadHymAwqP8DXVSlYoAkaVfQQe3ae0ijRgw269gklQAAAGYqzD6Vd4PRaKNXXxiY7bbWzRuqdfOG2W77dErefSsZ/Q0AAACLUakEAAAwU3GrVBYkKpUAAACwGJVKAAAAM1GpzEClEgAAABajUgkAAGAmKpUZqFQCAADAYlQqAQAAzESlMgOVSgAAAFiMpBIAAAAW4/E3AACAmXj8nSHPSuXeA78XRhwAAAAoxvJMKud/9Z0eHvSKln33k+Li4gsjJgAAgGIhNS290L6sXZ6Pv7+YPlbHT53TqrWb9dCgV9W2ZSP169lJFcv7F0Z8AAAAKAby1aeyepUKenPEMzpx+rxeG/uhVq/bpgZ1a2rYc4+pSsWAgo4RAAAAVi5fSeW+Q39qxeqNOn3uovr26KAe97fVod+P6Y3x07ViwYcFHSMAAACsXJ5JZf9nXlPJEq56sHdntW3ZWEbjzW6Y7Vo30dqfthd0fAAAAFarOPR1LCx5JpXjXv+f7qlaMdtt0ye9dtcDAgAAQPGTZ1J5T9WK2rLzF+0/9KckqUnDOmrXukmBBwYAAGDtblCpNMlzSqF5S77TomVrVKGcvyqW99fiZWv15dffF0JoAAAAKC7yrFRu271Pc2eMk6OjgySpZ5e2Gjx8vJ56tHdBxwYAAGDV6FOZIc9KZXp6uimhlCQnR0elp3MDAQAAkCHPSmXN6pU1/oPP1LNLoCRp7U/bVbN65QIPDAAAwNpRqcyQZ1L58pABmr/ke308+ytJUuP6tfTUY70LOi4AAAAUI3kmlQ729hr6TP/CiAUAAKBYSaVLoEmeSeUDT4xQ727t1LtrO5V0dyuMmIqV0FNHFfTNp4oOuyJ33zJq/ugQ+VSqked+x3f9pD1ffaImDw5Wrfa9JEnBfx7Q/lVfKj7ymiSDvMpVUeMHn5GHf4WCvQjcNSmpqZqycqvWHTgqg8Ggro1q6tUH2snWmLX78rvfbta2308qNjFJzg726lS/ukb0ais7W6MkaeS873X4zCUlJKfI3dlJfZrX0bP3tyjsS8JdcOXkEe1cPEtRYZfl7uuvNgNekF+VvH9OHNm+TjsWzVTL/s+qbqc+pvVnDu1R0PJ5iosMl1e5ygp8arhKleaVucVB26FPqPnAfipTp7qOrN+hz/s8m2NbRzdXPfr5JNXp3k4pCYna/skirZs4M9/bgcKWZ1L50buva9UPW/Tos6+racM66tezo2rdU6UwYrN6SXEx2vzpeDXq85SqNGuvU3u3aPOsd9R3whw5OLvmuF98ZLj+2LhSpe5IFj0CKqnzSxPk7O6htNRUHdv+g7Z+Pkn9Jswp4CvB3TLnpyAdPnNJ340eJEka+tkKzd0YpOe7tMzS9uHW9fVSz/vk7GCv67HxemX+an25+RdT4vh8l5Yq711K9na2uhIRrSGffasynu7q3rhWoV4TLJMYG6N1H41T8wefVvUW7XV8zxb9+NFYPf7+/Fx/TsRdD9fhn1bKo2yFTOuvXwnW5i8+UKfn31TZWvV16IelWv/xePWfOFs2RmMBXw0sFXk5VOsmfqIaHVqqZNnSubZ9eOZ4uXiU1KhyLeXm46nhm5co/Pwl/bJ4Vb62o3DQpzJDnqO/yweU0Yj/DdCqhdNVt3Z1jZk0U0+/+JY2bN3znx8Ffv5wkJxLeqp66/tltLNT9db3y6lEKV04HJTrfkHffKZ63fpn+YXi7O4hZ3ePv5fSZbCxUWx4qNJSbxTQFeBu+37vHxrcubm83V3l7e6qZzo30/dBf2TbtpKfp5wd7CVJ6emSjcGgC1evm7ZXLeMte7ubf/cZDJLBYNCFsOvZHgvW68yhPXIp5amabbrIaGevmm26yNm9lM4c3JPrfjuXzFLDHo/I0SXzE6ITQVvlf09dVajXVLZ29mrY41ElxETpyok/C/IycJcc/m6Dflu9UbHXcv+/bOfkqEb9u2v1mKlKiIpW2Mmz2jZzoVoOejhf24GikGelUro5rdAvh/7Q5h175eToqI5tm2vT9iBt3fWL3h87oqBjtFoRwWflUbZSpnUeZSsqIvhcjvucO7hbKYnxqtKsvU7+vCnL9tiIMK2e8KJSEhOUrnTV7fKQbIz5+jahiEXHJyo0MkbVy/qY1lX399GV69GKSUiSm5NDln3mbdyrORuClJCcopIuThreq02m7ZOWbdSaX/5UYsoNlfEooZ5Naxf4deDuCg8+K8+AzD8nvMpVUnjw2Rz3OX1gl5IT43VPyw76a/fGLMfzKpdxPKOtrUqVKadrwWflX6Pu3Q0eRcavemXZOTgo+PBR07rgw0d1/6ih+dqOwkOlMkOe2crCpWu0et02VSzvrwEP9VDThnUkSY/07aoHnxpZ4AFasxtJibJ3csm0zt7ZVSlJCdm2T4qL1f5VX6rTsHdyPKarh48em75MKYnxOhm0RS6lvO9qzCg48UnJkpQpeXRzcry5LTE526RyUKdmGtSpmc6EhGvdgaPycstcvR79cCe9+WBHHQsO0fY/TqmEs2MBXgEKQkpiQpanEg5OrkpJzP7nRGJcjPYsn6ceIydlf7ykBNk73/lzxyXH46F4cnB1VmJsnNJSU03r4iOj5ejmkq/tQFHIM6m8Fn5dMya/pnLZ9P2YMOqFLOtWrNmklWszKnCNnvz3/NV0+pdt2vP1LEk3k7/S99RVcnxspjbJCXFydHXPdv/9q+arasuOcvf1z/Ncdo7OqtGmm75+5VF5lJ0hNy8/yy8ABerWo+zYhCSVcnW++e/EpJvbHO1z3beSn6eq+XvrrSXr9MWLmR9f2dgYVKtcae0/cUEffr9N4x7tUgDR4245EbRV2xfdHCzh5umjsjXrKykuJlObpIQ4Obll/3MiaPk81WjdWSVz+Dlh5+Ck5Pj4TOuS4+Nk5+h0F6KHtUiKjZe9s5NsjEZT4ujk7qbEmLh8bQeKQp5J5cihT+a47Z6qFfXC65P1yfujTOv69eyofj07mpan7T5vYYjWo3LTQFVuGmhaPvHzRh3ZsjpTm4jgM6rVvne2+185dljJifE6umWNpJsJ6LULpxR66ojaPTcqS/t0pSs1JUWx4WEklcVACWdH+ZZ00/FLYQrwLiVJOh4cJr9SbtlWKe90IzUtU5/Kf7od1qFa83aq1rydafnozg36fdP3mdqEXzyTaTT37YKP/qrkxHjTPskJcQo7d1JXTh7R/UPHyLNsRV27eNrUPvXGDV2/ckGedwzoQfEWcvy0UlNSVLZuDV04dLO/bEC9mrr8x1/52g4UBYs760X/h/8qKl+vufavnKcTP29U5aaBOv3LNiVEXVf5etlP+9Lt9WlKT8t4VLHti3flX6uharTtJkk6s3+HvMpXlZuXn5IT43Vo9WLZOjjIsxxvMCouejWrrTkbglSv0s0q09yNQerT/N4s7eKTkrXx1+Nqd29VuTk56NSVa5qzIUgtalSQJF2OiNLRCyFqUaOiHO3s9Pu5y/p6xyE92qZBYV4O7oJKDVooaPlcHd25QdVbtNPxPVsVFxmhig2y/znRd8z0TI80N3w2WeVqN1Ltdt0l3Uxaf9u4Sud/36eyNerp4I/L5ejqrjLV6hTK9cAyNkajbGxtZWNrlMHGIFsHB6WnpSk1JSVTu5SERB1c9oN6ThipuY8MUwkfT7V98UmteevDfG1H4aFPZQaLk0qD4W6EUTw5uLipw5C3FfTNZ9q79HOV8Cmj9kPeloPLzf5TsRFh+m78EPUZ+6lcPXzk7F4q0/5GWzvZO7mYHpfHhofp4PeLlBgTKVsHR3lVqKbOL03M0m8T1uvZ+1soKi5RvSfOkyR1a1xLz3RqLkmasHSDJOmt/p0lSesPHNWH321T8o1Uebg5q0O9avpf11amYy3ZdlDjvv5Jaenp8i7hqkfaNNDTHZsV8hXBUo6ubuo6bKx2LJmlXV99qpK+/ur60jjTqO6Y8DB9M+Y5PTJxttw8fW6bAeKmmz8nnE2Py0uVLqsOg1/V7q9nK/b6NXmXr6Kuw8YynVAx0XXMi+o+brhp+ZPE4zqxfa8+DOyvF9Yt0Kld+/TTu59Kkpa+MFaPzZ6s94KDlPz3PJS3TxeU13agsBmSk5MsSrGfHDpaC2dl36Fc+nc9/sbdMTxlZ1GHACsz2yUw70b4TznWql3ejfCfMjP5RFGHkK2nl/1eaOea/3DWJ1/WJM95KgEAAIC8WJxU+np53o04AAAAUIzl2Kfy4qUQBfj76dSZC9lur1KpnCTpg/EvF0xkAAAAVo6BOhlyTCpnfL5E0ya8otfGTc+yzWCQVi7Muh4AAAD/TTkmldMmvCJJWrWI5BEAACA7VCoz5GtKoT+PndL+X/+UQQY1blBLte6pUtBxAQAAoBjJc6DOV9/+qLcmz1RUdKwio2M0ZvIn+mblusKIDQAAwKrdSEsvtC9rl2elcvX6bVowa6LcS9ycqPepR3tr8PBxeqRv1wIPDgAAAMVDnkmli7OTKaGUJPcSrnJxdirQoAAAAIoD+lRmyDOpbFivpiZMna0endtIkn7ctEuN69cyTTV0a2ohAAAA/HflmVRu3blPkvTr739lWr95xy9MLQQAAP7TqFRmyDOpHPG/x1W39j0q4eYiSYqOidPvR06oVbP6BR4cAAAAioc8R3/PWbTSlFBKkpurs+YsXlGgQQEAAKB4+cfv/jYYDEpLpdQLAACADHk+/nZ2ctTvR07o3lrVJEm/HTkhZ2fHAg8MAADA2tGnMkOeSeXQZx7RG+/MUPmA0pKki5dC9d7bwws6LgAAABQjeSaVdWpW1TdzPtCfx06alt1cXfLYCwAA4N+PSmWGfL37u4Sbi1o0qVfAoQAAAKAgpaWlafpnixW0/zdJ0sN97teDvTpl2zY5OUUff/G1fjn4u+zt7VS1UjmNe31IjsfOV1IJAACArIpbpfKnLT/r7IVLWjZvqmLj4jVw6Gg1rFtTlSqUzdL20/nLZDBIy+dPlcFgUHhEZK7H/sejvwEAAFA8bdm5V726BMpotJF7CVe1b9NMm7YHZWmXkJiotRu26/mBD8pgMEiSPD1K5npsKpUAAABmSi9mlcqQsHD5+XiZlkv7eunPY6eztLt0OUwl3Fy1cOka7f/1iBzs7TRowANqXL92jscmqQQAACgGVqzZpJVrN5mW+/boqH49O2ZqM3j4OF28FJLt/gtnTcr3uVJTUxUSek0VyvlryKD+On7qnF568z19/cX78ijlnu0+JJUAAABmSivESmW/nlmTyDvNmTEu1+1+Pp4KCbumOjWrSpKuhF6Tn49nlna+Pl6ysTGoc7uWkqTqVSqojJ+3Tp29qCY5JJX0qQQAAPiPaNe6qVav36bU1DRFRcdqy469at+mWZZ2Jd3d1KheLf1y8HdJ0uWQMF0OuaoK5crkeGwqlQAAAGZKTy9efSrvb99KR0+c0UNPj5TBYFD/B7qoSsUASdKuoIPatfeQRo0YLEl6bdjTmvzhHM2at1Q2Bhu9Puxp+Xh55HhskkoAAID/CKPRRq++MDDbba2bN1Tr5g1Ny/6lfTRryuh8H5vH3wAAALAYSSUAAAAsRlIJAAAAi9GnEgAAwEzFbfLzgkSlEgAAABajUgkAAGCmwpz83NpRqQQAAIDFqFQCAACYKT2tqCOwHlQqAQAAYDEqlQAAAGYqbq9pLEhUKgEAAGAxKpUAAABmYvR3BiqVAAAAsBiVSgAAADPxRp0MVCoBAABgMSqVAAAAZqJSmYFKJQAAACxGUgkAAACLkVQCAADAYvSpBAAAMFMab9QxoVIJAAAAi1GpBAAAMBOjvzNQqQQAAIDFqFQCAACYiUplBiqVAAAAsBiVSgAAADOlUak0oVIJAAAAi1GpBAAAMFM681SaUKkEAACAxUgqAQAAYDEefwMAAJgpPa2oI7AeVCoBAABgMSqVAAAAZmJKoQxUKgEAAGAxkkoAAABYjKQSAAAAFjMkJyfRGaCQrFizSf16dizqMGBF+EzgdnwecCc+EyhOqFQWopVrNxV1CLAyfCZwOz4PuBOfCRQnJJUAAACwGEklAAAALEZSWYj69qBfDDLjM4Hb8XnAnfhMoDhhoA4AAAAsRqUSAAAAFiOpBAAAgMV497eVuBJyVUEHftcD3dsXdSgoBPc/+Ly+nDlB4dej9O6MuTIajRry9MNydXHOtNys0b1FHSryYe7ilRrwcA852Nvr519+1ZxFK3XmfLD6dGuvEf8bYGqXlpam6Z8tVtD+3yRJD/e5Xw/26pTrsZOSk/X25Fk6e+GSHOztVapkCb364kAF+PsV6DUBwD9FpbKQ3EhNzXX7ldCr+v7HLYUUDazFuk271CmwhRZ9OknNGt2bZRnFw7wl3yk5OUWSFODvp9EvD9Zj/bplaffTlp919sIlLZs3VfM+fkdfr/hRZ84F53n8Xl0DtWzeFC3+fLJaN2+gd2fMvevXgKLz8pgpOn/xclGHAViMSmU+NO/8uDaunC03VxdJGVWm0n7e6vPEcHVp30r7f/1T4RFR6nF/Gz31aG9J0pBXJ6pKxXI6duKMHOztNePd1/XKW1MVFR2rpKRkValUTm+OGCQnR0e9//GXCgm7pif+N0q+Pp6aMn6kLl4K0YzPF+t6ZLSSU26oV5fAPKsasE67gg5q1rxlsrU1mpLFTTuCtHnHXjk42GvLjr3q0LZZpuVZU0abPnOwXu9/NF+S9PzICTLa2GjGu6+rXNnS2rHnQJa2W3buVa8ugTIabeRewlXt2zTTpu1BeqBHBz05ZLRWLZwuR0cHSdLb785SvdrV9UCPDmrRpJ7pGLVrVNHXK9dJkrbu2qfV67bqo3ffkCSlpqap38AR+nDia6pY3r+Arxx3y4cTXy3qEIC7gqTyLoiNi9ecGeMUGRWjfgNfVrdO98nHy0OSdCH4ij6bOka2trZKT0/X+DeGyL2Em9LT0zVl5gJ9u3qjnni4p14f9pRmfL5Eiz6bLOnmL4e3352lsa/9TxXKlVFiYpKeGT5Ote6prJrVKxfl5eIfioiM0sRpc/T5tLdUsby/vl+3VVHRserYprnOX7yiqpXKq/8D90tSlmVYv9dfelrfr9uqz6e9lecfASFh4fLz8TItl/b10p/HTsvbs5Qa16+tn7b+rN5d2yniepQO/HpEbwwflOUYy7/foPuaN5AktWnRSDPnfK3zFy+rfEAZ7dp7UP5lfEkoi9gfR0/qk7nfKD4+UelK17NP9NP0zxerXesmOnj4qGLj4tW7Wzs9/mB3SVKfJ4br/bEjVK1y+WyPN/WThfLyLKmBj/SSJJ2/eFnD3nhPKxdNV3Jyij78dJGOHT8jSWp3XxMNevwBHTtxRuPe/0xL534gg8EgSRo8fLyefqy3mjeuWwh3Af9FJJV3QafAFpKkku5uKlPaR1dCrpqSyvvbt5St7c3bnJ6erqWrftLP+w4rNTVVcXEJqlOzarbHvBB8RWfOB+vtdz8xrYuPT9TZC5dIKouZI8dOqUrFANMv+h6d2+rDTxcVcVSwNg/17qz3ZsxT767ttHr9NnUMbCZnJ8dMbRZ8s1rBl0M18703JUlGo436du+glWs36+UhT2jlms28J7qIRUXH6vXx0zV5zDDVq3OP0tLSFBMbL0mKuB6tLz+ZoKjoWA0cOkb31qyme2tVy/OYD/bqqOGjP9CAh3rIaLTRqh82q1fXQNkajZr91bdKSbmhxZ9PVlJysp57eYLKly2jDm2byb2Eq/Yd+lNNG9bR8VPnFBkVTbcaFCiSynww2tgoLS3NtHyr79Qt9vZ2mdqm3tZ/0um2Xwobt+3RgcNH9dmU0XJxcdby7zfo4OGj2Z4zPT1dJdxcTZVL/Hv8XTTAf5Cfj6dCwq6Z/pi8EnpNfj6ekqRa91SWo6O9Dh4+qtXrtunj997ItO9X3/6oHT8f0MfvvWF6RC5JPbsE6tFnX1OXDq0UfCVUrZs1LLwLQhZ/Hjup8mVLq16deyRJNjY3uzpIUo/728hgMKiku5vatGyk/b8eyVdSWT6gjCqW89euoINq2qiONm3bqyWz35Uk7f/1Tw179lHZ2NjIydFRXTq00r5f/1CHts30UO/OWrFmo5o2rKOVazfpgR4dTFVLoCAwUCcf/Mv46shfpyVJ23fvV0JiklnHiYmNV0l3V7m4OCsuPkE/btpp2ubi7KTYuATTcrmA0nJxdtIPG3aY1l28FKKo6FgzrwJFpXaNqjp19qLOXbjZEf+HDTuUknKjiKPC3eTs7Jjp/29O2rVuqtXrtyk1NU1R0bHasmOv2rdpZtr+UO/OemfK56pQrozKlS1tWv/NynXatD1IH737RpZH7CXcXNS6WUO9MX6GendtJ6ORH+vFxT/J724miJv005af1bhBbXmUcs/+mMo4aNtWjXXq7EUdP3VOu4N+VfdO91kaMpArfvrkw/DnH9f0zxbryaGjdfz0OdNfnf9Ulw6tlJiYrIcHvaKXx0xRvdrVTdsqVyqniuX99dizb+jVsdNkazRq6jsjtf3nA3r8+Tf16ODXNXn6XCUlJ9+ty0IhKVWyhEa/PFhvvDNDA54fpYuXQs3+DME6Pdq3q1568z098b9R2rx9r3o+9qK+WbVeP2zYoZ6PvahdQQclSfe3b6XyAWX00NMjNWjY2+r/QBdVqRhgOk5g6yZKSExU39seYYddDdfHX3yt2Lh4vfDaJD3xv1EaNGxspvP36hqoyKgY9eoSWDgXjBzVqVlNFy+H6PAff0m6OY3UrWLAuo03CwlR0bHaueeAGtWrle/jNm1YR+HXI7Xg69WZujg0rl9bazfsUHp6uhISE/XTlt1q0qCOJMnWaFSfbu302tgPdV/Lhgz8Q4HjNY0AYCWOnTijse99qqVzP5CNTf7/5v/q2x917uJljX55cAFGh/z689gpffzFV4pPSJSNwaDBT/bTh58uUvv7murAr0f+8UCdW75esU4bt+3RglkTTeviExKzHahzy/XIaHXrP1SLPpuc6Q8YoCCQVAKAFZg8fY72HfxTb454Rk0b1sn3fo8Ofl0Gg0HTJ70qH2/PAowQlshv4pibkW9NVYc2zdSlQ6t877N11z6t+mGzPnl/lNnnBfKLgToAYAVGjTCvyvj1nPfvciSwNsdOnNFbkz9RxfL+ptlG8mP4qPd18VKI3nt7eMEFB9yGSiUAAFbg1bHTFBoWnmmdm6uLZk0ZXUQRAf8MSSUAAAAsxuhvAAAAWIykEgAAABYjqQQAAIDF/g/uUA+KRkDPWAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 800x600 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "if len(macro_df) > 0:\n",
-    "    fig, ax = plt.subplots(figsize=(8, 6), layout=\"tight\")\n",
-    "    sns.heatmap(\n",
-    "        macro_df.corr(),\n",
-    "        annot=True,\n",
-    "        fmt=\".2f\",\n",
-    "        cmap=\"RdBu_r\",\n",
-    "        center=0,\n",
-    "        ax=ax,\n",
-    "        square=True,\n",
-    "    )\n",
-    "    ax.set_title(\"Macro Indicator Correlations\", fontsize=12)\n",
-    "    plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "97c160f9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002728,
-     "end_time": "2026-07-18T19:35:42.774531+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.771803+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "**Interpretation**: Unemployment moves *with* the 10y-2y spread (positive\n",
-    "correlation ~0.70): when the labour market deteriorates, the curve typically\n",
-    "steepens as the Fed cuts the front end. The Fed Funds rate moves *against*\n",
-    "the spread (correlation ~−0.73): hiking cycles flatten or invert the curve.\n",
-    "CPI YoY is largely orthogonal to the other three — inflation regimes can\n",
-    "coexist with both recession and expansion. These pairwise correlations show\n",
-    "why a single indicator is a noisy regime signal and motivate joint clustering."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "720f16b8",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002644,
-     "end_time": "2026-07-18T19:35:42.779893+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.777249+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "# Extended Analysis: All FRED Indicators\n",
-    "\n",
-    "Now we expand beyond the 4 core indicators to use all available FRED series\n",
-    "(~17 indicators after quality filtering). This provides a richer but noisier\n",
-    "view of economic conditions."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "acea7e64",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002638,
-     "end_time": "2026-07-18T19:35:42.785201+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.782563+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Prepare Full Dataset\n",
-    "\n",
-    "Using the same data loaded at the start, we now select ALL series with\n",
-    "sufficient data coverage (< 50% missing)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "2e210877",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.791217Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.791139Z",
-     "iopub.status.idle": "2026-07-18T19:35:42.810337Z",
-     "shell.execute_reply": "2026-07-18T19:35:42.810001Z"
-    },
-    "papermill": {
-     "duration": 0.022804,
-     "end_time": "2026-07-18T19:35:42.810693+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.787889+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extended dataset: 277 months, 25 series\n",
-      "Series used: ['dff', 'dgs1', 'dgs2', 'dgs3', 'dgs5', 'dgs7', 'dgs10', 'dgs20', 'dgs30', 't10y2y', 'vixcls', 'icsa', 'walcl', 'cpiaucsl', 'cpilfesl', 'pcepi', 'unrate', 'payems', 'civpart', 'indpro', 'm2sl', 'gdp', 'gdpc1', 'YIELD_CURVE_SLOPE', 'YIELD_CURVE_5_10']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Use the already-loaded macro_raw data\n",
-    "value_cols_full = [c for c in macro_raw.columns if c != DATE_COL]\n",
-    "\n",
-    "macro_monthly_full = (\n",
-    "    macro_raw.sort(DATE_COL)\n",
-    "    .group_by_dynamic(DATE_COL, every=\"1mo\", label=\"right\")\n",
-    "    .agg([pl.col(c).last() for c in value_cols_full])\n",
-    "    .filter(pl.col(DATE_COL) >= pl.datetime(2002, 1, 1))\n",
-    ")\n",
-    "\n",
-    "# Identify columns with >50% missing, exclude market price columns\n",
-    "total_rows = macro_monthly_full.height\n",
-    "null_fractions = {\n",
-    "    col: macro_monthly_full.select(pl.col(col).is_null().sum()).item() / total_rows\n",
-    "    for col in value_cols_full\n",
-    "}\n",
-    "# Exclude columns with too much missing data and market price columns (SP500)\n",
-    "exclude_cols = {\"sp500\", \"SP500\"}\n",
-    "good_cols = [col for col, frac in null_fractions.items() if frac < 0.5 and col not in exclude_cols]\n",
-    "\n",
-    "macro_clean_full = (\n",
-    "    macro_monthly_full.select([DATE_COL] + good_cols).fill_null(strategy=\"forward\").drop_nulls()\n",
-    ")\n",
-    "\n",
-    "macro_data_full = macro_clean_full.select(good_cols).to_pandas()\n",
-    "macro_data_full.index = macro_clean_full[DATE_COL].to_pandas()\n",
-    "macro_data_full = macro_data_full.apply(scale)\n",
-    "\n",
-    "print(f\"Extended dataset: {macro_data_full.shape[0]} months, {macro_data_full.shape[1]} series\")\n",
-    "print(f\"Series used: {list(macro_data_full.columns)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "110ee697",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002779,
-     "end_time": "2026-07-18T19:35:42.816408+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.813629+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Visualize All Series"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "a56ec1b8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:42.822338Z",
-     "iopub.status.busy": "2026-07-18T19:35:42.822250Z",
-     "iopub.status.idle": "2026-07-18T19:35:44.438773Z",
-     "shell.execute_reply": "2026-07-18T19:35:44.438165Z"
-    },
-    "papermill": {
-     "duration": 1.619995,
-     "end_time": "2026-07-18T19:35:44.439113+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:42.819118+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABkEAAAM1CAYAAADHGVZMAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3XV4FdfWx/Hvkbi7ESNYcHeHAi3Qlpa60Uvd7dZu3d3euntpS1sq0AJtobi7BUtICHH3o+8fgVPSBCmWEH6f5+lTMjNnZk9ysjNnr73XMlgsNU5ERERERERERERERESaGWNjN0BEREREREREREREROR4UBBERERERERERERERESaJQVBRERERERERERERESkWVIQREREREREREREREREmiUFQUREREREGsnjL7zDhMtva+xmNAtZ2Xn0G30p02fNOyHXm3D5bTz+wjuur1et3US/0Zeyau2mE3L9fW747xPc8N8nDuvYyqpqzjj/Bmb+ufA4t0r+KXVXJgNPv5wdaRmN3RQRERGRU465sRsgIiIicqqYPmseT7z4boP7Ljt/HDdMvhCoHVzNzsl37fP08CAxPoaJZ57GGacNqvO6VWs3cePdTx3wmo/ddyOnDe1X77wGgwEfby/Cw4LplNya8WOG0KFdq8O6jxv++wSr122hRXQE3370Yr39y1au59b7nwXgyQduYfig3od13qYiKzuPDz7/njUbUsjLL8LX15u4mEi6d2nP1Zef29jNO+HmL1nFl1NnsCt9D5XV1YQEBdCudSLjRg+hX68uAOQVFPHjjD8Z3L8nbZLiG7nFciDf/DATb29PRg7p59q2fPUGZv65iHUbt5KbX0hIUAA9urbnmssnEhoSVO8c6zZu5Y0PppCyPQ0fby9GDO7DdVeej7eXZ53jLBYr7336Hb/9sYDS8gpaJcZx7RUT6d2jU53jPv7qRxYsWUVmVi6VldWEhwXTv3dXJl10FkGB/oe8p00pO5gxewGr1m4iKyefAH9fOrRL4tpJ5xHXIqre8Wnpmbzy9ues27gVs9nMgD5dueWaS+pcKy19D7/M+otlK9eTmZWLl5cHbVslcNVl55LcpmWD7fh97hK+nvYb23dmYDabSIiL4dpJE+nZtQMAifEx9O/dlfc+/Y5nHrrtkPclIiIiIseOgiAiIiIiJ9jVl59LdGRYnW0tE2LrfN06KZ6Lzz0dgPzCYn7+bS6Pv/AOVquNs84YVu+c5589qsHBuY7JrQ943srKatIy9vDn/KX8+OscLjxnDLdee+lh3YO7uxu79+SwccsOOrRLqrNv5pxFuLu7YbFYD+tcTUlGZjaTb3kID3d3xo0eQlREKPmFxaRsT+Pzb3455kGQ+26bjMPhPKbnPJa++HY6r7//Fd06t+OyC8fj6eHO7j05LF+9kd//WuIKguQXFPHB5z8QFRF2ygZBunZqx9yfP8TN3DQ/YtlsNr6ZNpMLzhmDyfR3QoA3P/ia0rJyhg/qQ2xMBJlZuUz9eTYLl67h0zefJCQ40HXs1h27uPnep0mIi+aWay4hL7+QL6fOICMzm5efvLvO9Z548R3+nL+cCyaMJjYmkumz5nPHgy/wxnP306VjW9dxKdvSaN0ynpFD+uHt7Ula+h5++nUOi5at4dO3nsTLs25w5Z8+/+YX1m3ayvBBfWiVGEtBUQlTf5rNpBsf4L1XHyFpv741N6+A6+96Ah9vL6678nwqq6r5cuoMdqRm8MFrj+HmVvuz++m3ufwycy5DB/binPEjKa+oZNr0P7n61kd46cm76d29Y502vP/Zd3z4xTSGDezFGacNwmazszNtN3n5RXWOmzBuBHc88Dy79+TQIjri8H5wIiIiInLUmuYTuoiIiEgz1q9XlwPOJt4nLCSIMSMGur4ee9pgJk66gyk//NpgEKRLx3aHteLin+cFuGHyhTz8zBtM+f43YqMjOWf8yEOep0VUBDa7ndlzF9cJgtRYLPy1cAUDendlzoLlhzzPsVRjseBmNmM0HnnG1yk//EZlVQ2fvPkUURGhdfYVFpccbRNdqqqr8fL0xNxEB8wBbHY7H305jd7dO/Lq0/fW238svx9N0b6f0eEyGo14uLsfxxYdnQVLV1NUUsqIwX3qbL/l2kvo0qFNnd+bvr26cMNdTzD1p9lcO+k81/a3P/oGf18f3nzuf/j4eAMQFRHK0698wNKV6+mzd5XHxi07mD13CTdddRGXnDcWgNNHDuSSa+7l9fen8N4rD7vO+fRDt9Zra6fkVtz/xGssWLLatZLtQC4853QevfdGVwADYOSQvlx67X189vXPPHLPDa7tn0z5iarqGj56/XEiw2t/v9u3TeLW+55h+ux5nH3GcABGDevHVZedU2d1y/jRQ7joqnv44PPv6wRBNmzezodfTOPmay7monNOP2hbe3XrgJ+vDzNmz+eaKyYe9FgREREROXaa7qcuEREREXEJCvQnPjaK7anHPp+8p4c7D999PRMuu42Pp/zIhHEjMBgMh3zdqGH9mDb9T2655mLXAOqCJauprrEwfHCfekGQrJx8Pv/mZ1as2Uh2bgGeHh706Nqem6+6iKh/rIwpK6/gg89/4K9FKygoLCYwwI8eXTpw67WXEBjg50oD9th9N7IzbTe/zJpHQWExM6e+jZ+vD3/MW8pnX/9ManomXp4e9O3ZmRsmX0h4aPBB7ylzTw7hocH1AiAAwYEB9bYtXr6WT776kZTtuzAaDXTt1JYbJ19Ey4QWrmMef+Ed5sxfxqdvPcVLb37K2g0p9OzagWcfuZ3HX3iHVes288Onr7iOdzgcfDNtFj/9OofMrFx8fLwY3L8HN/znQvz9fFzHbd66k3c+/pYt21Kpqq4hJCiQ7l2SeeDOaw56j4erpKSMisoqOndo0+D+fd+P/VOyPfHiu66Ubw/ceQ1jRw1mzfotfPPjLDZt2UFhcQlBAf4MG9Sb6648H0+Pv4MG+75PUz54nhdf/4Tlqzfg4eHO6SMHcePkC+usXigrr+CVtz/nr4UrMBgMDOrXnQsbGIDevjOdr77/lTXrt5BfUIyvrzf9enXh5qsvIsDfz3Xc+599xwef/8CX7z7LR19OY8mKtURGhPHpm0/idDr5+Ksf+WH6H5SWVdChbRJ33nhFvWvt+z688dz9dO/S/qDp77p1bsebzz/g+vq3PxYw5fvfSE3PxMPdnT49OnHTVRcRER5S53XTZvzJ59/8Ql5BEUkJsdxyzcUNnr8h8xatJCoirN4KhG6d2tVvX6d2+Pv5kpa+x7WtoqKSZas2cOE5Y1wBEIDTRw7i1Xe+4I95S1xBkDkLlmEyGjl7v4Cth7s748cM5e2PviEnt6Deve1vX39QVl55yPtq6P0ZGxNJYnxMnfbXtms5A3p3dQVAAHp370hci0j++GupKwjSrnVivXMG+PvRpWNbVq3bXGf71z/8RkhQABecPRqn00lVdU291GD7mM1mundJZv7iVQqCiIiIiJxACoKIiIiInGDlFZUUl5TV2RYY4HeAo2vZ7HZy8wvx8/VpcH9lZVW9cwIE+PseVkDD28uTIQN68PNvf5G6K7POIP6BjBrWn/c/+55V6za78t7PmrOInl3bE9xALv/NW3eyftM2Rg7pR3hoMFk5eXz/yx/ccPeTfPXus3h6etTeS1U11935OLvS9zBu9BDatEqgpLSM+YtXkZtfWOd79dEX0zC7mbl44hlYrVbczGbX4HNym5Zcf+UFFBaX8M20mazbuI1P3nzigN9DgMiIUFas3siKNRtd93Qgv/6+gMdfeIc+PTpxw+QLqKmx8P0vf3DdnY/xyRtP1gns2O0Obrv/Wbp0bMtNV1+Ep4fHAc/77KsfMn32fMaNGsx5Z48iKzuPqT/NZuv2Xbz78kOYzWYKi0u49b5nCQr047Lzx+Pn601WTj5zFx671TdBgf54eLizYMlqJp45igB/3waPS4iL4erLz+W9T7/jrDOG0XVvqqNO7WsHp/+cv4yamhomjBtBgL8vm1J2MPXHWeTmF/LUA7fUOZfd4eD2+5+jfbskbrr6Ylas3sBX382gRVS4a4WS0+nk7kdeZt3GFM4eO4KE2Gj+WrSCx59/h39atmoDe7JyGTtqMCFBgezctZsff51D6q5M3n/1kXq/G/974jViYyK5btL5OKlNU/bup1P5+Msf6d+7C/16dSVlexq33v8sNpvtoN+/rp3a8fDd19XZlp1TwDuffEtQwN+/Hx9/+SPvfjqVEYP7cOaYoRSVlDH1p1lcf9cTdd6vP/02l2df/ZBO7VtzwYQxZGblcvcjL+Hv50t42MGDewDrN22jbauEQx4Htb+DVdXVBAT8/TPfnrYbu91eL0Dg5mamdcs4tm7f5dq2dfsuYltE1gmWALRvW7sCbuvOXXWCIE6nk5LScux2OxmZ2bz54deYjEa6d04+rPb+k9PppLC4hJbxf/djufmFFBWXNrgKr33bJBYtW3vI8xYUFRMYUPf3YMWajXRKbs0302bx8VfTKCktJyQ4gCsuPIvzzhpV7xztWiUyf/FKKioq631/REREROT4UBBERERE5AS75d5n6m1bPPPzOl/b7XZXUKOgqJjPv5lOQWEJ544/rcFzPvnSew1u/+Wr1+vk9D+YlvG1ufMzs3IOKwgSGxNJcpvEvYGPDpSVV7B4+VruvXVyg8f37921XsqugX27c/VtjzBnwXJOH1mbpuuLb6ezM203Tz90K0MH9HIde+XFZ+N01q2fYbFa+fD1x10rCmw2G298MIWWCS1468UHXOmJunRow10PvciU7387aF2P888azW9/LOTme56mdVI83Tq1o0eX9vTu3tEVpIHaQeKX3/qUM8cM5d7b/r7fM04bxAWT/8snU36qs91itTJ8cB9u+M8FB/2ert2Qwk+/zeWRe25g9PD+ru3du7Tn9v89xx/zljF6eH/Wb9pGWXkFrz59T51B3f1TFx0to9HIJRPH8uEXPzDhslvp2qkdnTu0oV/PzrTdbyA8OCiAfr268N6n39EpuXWD6db2X/Fx9hnDaREdwdsffUt2bn6dWfkWi5URQ/rwn0smAHDOuBFcceP/+HnmX64gyPzFq1izfgs3XnUhl543bu9xI7np7ifr3cM540dy8cQz6mzrmNyKh55+g7UbUuj6j1UQrVrG8dh9N7q+Liou5Ytvp9O/d1deeOxOV9Dk7Y++4ZMpPx30+xcTFU5MVLjr6xqLhevueJzQkCDuuOFyoHZ11Puffcc1V0xk0kVnuY4dOrAnV9zwAN/9/DuTLjoLm83G2x99Q+ukeN547n+u1E+JcTE88+oHhwyC2Ox2MrNyGdSvx0GP2+frH37DarUxckhf17aCwmIAQhvoT0KCA1m7MaXOsQ31O6HBtYXW8wvq1sooLCph3EU3ub4ODw3mkXtvICEu+rDa+08z/1xIXn4RV1/+92qLfe1vqF0hwYGUlpVjsVhxd3dr8Jxr1m9hw+btdX5OpWUVFJeUsW7TVlau3cR/LplARHgI02fN46U3P8VsNjFh7Ig654mOCsPhcJKWkVWvnpKIiIiIHB8KgoiIiIicYHfddAWxMVEHPWbpyvWcfv71dbaNHTWYm66+qMHj/3PJhDrFhvfx92t49n5DvL3+XolxuE4b1p+PvpjGf2+6kjnzl2E0GhkyoCcp21LrHbv/QLjNZqOisooW0RH4+XqTsj3NFQSZu2A5rVvG1QmA7PPPmfunjxxU57ybt6ZSVFzKVZeeU6c+w4A+3YiPjWbRsjUHDYK0TGjBp28+yUdfTmPh0tV8s2MX30ybibeXJ7dcc4mrHsuyVespK6/ktKH96qzAMRqNdGiXxMq1m+qd+5xxI+pt+6c/5y/F18eb3t071jlvu9aJeHt5smrtJkYP74/f3hnkC5eupnXLuONWW+Tqy88lPjaK73/+naUr17F4+Vre+fhb2rSK59F7biAhLuaQ59j/51NVXU1NjZVO7dvgdDrZun1XnSAIUG/QuGvHtvz6+0LX14uWr8FkMnHOuL9r15hMRiaeNYo1G1LqvHb/a9dYLFRV1dCxXSsAUran1QuCTPjHz2j56g1YrTbOO2tUnffeBRPGHDII8k/P/9/H7EjL4M3nH3ANxM9duByH08mIwX3q/LxDggKJjYlg1drNTLroLNf7+urLz61T+2LsqEG8/v5Xh7x2aVk5TqcT/4Osgtpn9fotfPD5D4wY3KfOaqiaGgsAbm71gwTu7u7U1Fj/PtZiwb3B49z2nstaZ7u/ny+vPn0vFouVrTvSmLtwBVXVNYdsa0PS0vfwwuuf0DG5NWeMHNRA++v/ruxra43F0mAQpLC4hIefeZPoyDAuPX+ca3vV3r6ypLScx++7iZFDa4NGwwf15tJr7+PjL3+s937et7KnpLT+yj0REREROT4UBBERERE5wdq3TTpkYfQO7ZK45orzcDgc7EzbzcdfTaOsvAK3Awx2JyXG1inWeyQqq2oHHQ+Uz74hpw3py+vvfcni5WuZ+eciBvTuio+3V4PHVtdY+HTKT0yfNY+8gqI6qzrKK/7O/b87K4dhA+sHQBoS/Y9aItm5+QDExdYPMsXHRrFu49ZDnjOuRRQP3309druD1PRMFi5dzRff/sIzr35AVGQYvbt3ZHdmDgA33fNUg+f45/fAZDIdsh4JQEZmDuUVlZxxwQ0N7i8qLgWgW+dkhg3sxQef/8CU73+je+dkBvfvwahh/Q84kx1qv8/7BoOhtkbBgdJc7TNqWH9GDetPRUUlG7fsYPrs+cyas4i7HnqRL9595pDFwLNz83nv0++Yv3gVZeUV9dqzP3d3N4L+kUrNz9enzuuyc/IJDQ6s9z6Nb1H/Z15SWs6HX3zP7LlLXN+7v69dVe/46IiG30+xMZF1tgcF+h80rdo//TD9D6bPmsc9t/6HjsmtXNt3Z2bjdDo5/z93Nfg6s8l80HaYzWaio8Lqve5A9qX4OpC09D3c++grtExowX23X1Vnn8fegJLVaq33OovFgofH3+87D3d3LA0eZ917rrrvUTc3s6v/Gti3Gz27duDaOx4jKMCfgX27Ybc7KC6p+/Pz9/OtF9AoKCzmrodewNfHm6cevKVOHZm/218/jdm+tjb0Xq6qruauB1+ksqqat598sM77bt85zWYTw/Zb5WY0GhkxpC/vf/ZdvdVO+xxOmkIREREROTYUBBERERFpggL8/VyDgn17diY+Noq7HnqRb6b9xkXnnnGIVx+Znbtqi663iI48xJF/Cw0JolvnZL76bgbrNm3lqQdvPeCxL735CdNnzeOCs8fQsX1rfL29wGDgoadfr5fm6nB5eBx8AP5omExGWiXG0ioxlk7Jrbjx7qeY9edCenfviMPpAODhu68jOCiw3mvN+w2+Ari7mV3F4w/G4XAQFOjPI/c0HAQJ2lsPxWAw8NSDt7Jh83YWLFnF0pXrefKl9/jqu19579VHDhjIevmtz5gxe77r638W6D4YHx9vevfoRO8enTCbTcyYPZ+NW3YctG6D3e7g1vueobSsgsvOH0d8bDSenh7kFRTyxAvv1vu5mw7je/RvPPDk/7F+8zYumTiW1klxeHt64nA6uf1/z+Hc+zPc3/F4P23csoNX3vqcM8cMdRXe3sfhcGIwGHjpif82+P74NwHJg/H3q60NVFZWccBjcnILuO3+Z/H18eKlx++qF8jbt3olf29aqf0VFBa7Ul3tOzavoLDecfmFtWmwQkOC6u3bX+cObQgNDmTWnIUM7NuN3LwCzrni9jrH7CtAv095RSW3P/A8ZeWVvP3ig4T94xr72l9wgPb7+/nWCyBarTbue+xVdqRm8PJTd5OUEFtnv7+fD+7ubvj5etcJuACuYF5ZWUWdIEjp3p/BoYKPIiIiInLsKAgiIiIichIY0Kcb3Tq345MpP3H22OF4eR6bwdF9Kquq+WvhSiLCQv51Hv5Rw/rz9Mvv4+frTf9eXQ943Jz5yzl95CBuufYS17Yai4Xy8rqrAVpERbAzbfe/asM++wYb0zOy6hU2T9+d1eCM7MPRbu/KnX0DwDFREQAEBQYc9Qqc/cVER7Bi9UY6d2hTJ5XTgXRMbkXH5FZcd+X5zPxzEY88+ya/z13MmacPa/D4S88bx+jhA1xf+/sd/mqG/bVrnciM2fNdA8oHmtW+Iy2D9N3ZPHjXtZxx2t+piZatXH9E14W9xevXbKKyqrpOkGDX7qw6x5WWVbBizUauuuxcJl86wbU9IzP78K+19/2SkZldp75HUXFpvVUtDSkqLuV/T7xG66Q47rppUr39MdHhOJ1OoiPDiGtgJUtD7dj/fW2z2cjKzqNVy7iDtsNsMhETFc6enLwG95eUlnHr/c9isVp559mHGgxSJCW0wGQysWVbap1aIVarjW070xk+uI9rW+ukOFat3VSv+PfGLTsAaNMy/qDtBaixWF2rdYKDA3j16Xvr7G+13zlqLBb++9CLZOzO5rVn7iUxvn6atvDQYIIC/Nm8dWe9fZtSdtA6qe730OFw8Njzb7Ni9Uae+N/NDQb7jEYjbZLi2ZyyE6vVVmdlyr66J4H/WNmUlZ2H0Wg46M9bRERERI6tYzvVSkRERESOm8vOH09JaTk/zph7TM9bXWPh0efeorSsnCsuOvNfp2kZPqg3ky+dwF03TWow3/4+RqMR/jHz/9sfZ2F31J2RP3RgL7btTGfuwuX1znGoFSPJbRIJCvTnh+l/ulLvACxevpa09D307931oK9fs34LNlv9dDmLlq0BalNqAfTt0Qkfby8+mfJjg8f/M/XS4RoxuA92h4OPvvih3j6b3e4aeC8tq6j3vWiTVDsobGkg3c8+ifEx9O7e0fVfu/0KnP9TdXUN6zdta3DfkhVrAVwDuZ4etfVkyv4R0Nq3umH/NExOp5Ovp8084HUPpX+vrtjtdr7/5XfXNrvdwdQfZ9U5zmTc9z6u+32a8sNvh32tXt06Yjab+PbHWXW+318fxjnsdgcPPv06VpuNpx68tcHfjaEDemEyGvng8x/q/TydTqerbkRym0SCAmrf1/unc5o+a3697/mBdExuzZat9Wv1VFVXc8cDL5BXUMhLT/y3XsqtfXx9vOnVrQMz/1hIReXfqcR+/WMBlVXVDN8vHdTwQb2xOxxMmzHHtc1isTJ91jw6tEsiIjzEde3qBmp/zJm/jLLyCtf708Pdvc77tnf3jq4Ant3u4MEnX2f95u08+cDNdGrf+oDfg6EDe7Fw2Rpycgtc25av3kD67myGD+pT59gX3/yU3/9awl03T2LoQdLzjRjcF7vDUWeFVY3Fwqw5i0iMi6m3ImXL9lQS41vgu19wSERERESOL60EERERETlJ9OvVhZYJLZjy/a9MPHNknWLYazdswWKx1HtNq8S4OrPE8wqK+O2PBUBtDZC09Ez+nL+UgsISLjr3jHpFfA+Hr483V1124GLj+wzo05Xf/liIj483ifExbNi0jeWrN9ZLC3PJeWOZM38ZDzzxf4wbPYS2rRMoLatgwZJV3H3zlbROOvAscrPZzI2TL+SJF9/lhv8+wWlD+1FYVMI302YRFRHGheeMOWgbP/vmF1K2pzJkQC9aJdamvknZnsavvy/A38+XCybUvt7Hx5v/3nwljz3/Flfc+ACnDelHYKAfObkFLFy2hs7t23DXTVcc8nvyT907J3P2GcP59Ouf2bYznd7da1NPZWRm8+f8Zdx+/WUMH9SbGbPn8/0vvzOkf09iosOprKzmx1/n4OPtRf/eXf71dRtSXWPhmtsfpWNyK/r27Ex4WAjl5RXMW7SSNRtSGNy/B21bJQDQIjocP19vfpj+B97ennh5etChXRIJsVHERIXz+ntfkZdfhI+3F3MXLD+sVRQHMrBvNzp3aMNbH35NVk4+iXExzF24vF6NDx8fb7p2asfn30zHZrMTFhLE0lXrycpueDVEQ4IC/bn43DP49OufueuhF+jXqytbd6SxePk6AvemJjuQH6b/wco1m5gwdgSr1m6qsy84MIDePTrRIjqCayZN5K0PvyErJ4/B/Xvg7eVFVnYefy1awVmnD+OS88ZiNpu5ZtJEnn31Q2665ylGDunLnuxcps+aV2eFysEM7ted3/5YQPrurDqrEB555i02pexg3OghpKVnkpae6drn5eXJkP49XV9fN+k8rrn9MW747xOcdfpw8vIL+fK7GfTp0Yl+vf5+33Vo14rhg3rz1kffUFRSSovoCGbMnk9WTj7333G167iMzBxuufdpRgzpS0JsNAaDgS1bd/Lbn4uIigjjggmjD3lfr737BfOXrGJg326UlpW7+rd9xowY6Pr3FReeyZ/zl3Lj3U9ywYQxVFZV88W300lKjGXcqMGu46Z8/xvf//w7HZNb4+nhXu+cQwb0dK3GO3vscH7+bS4vvPEx6Zm1q81+/X0B2Tn5PP/YnXVeZ7PZWL1uC+eM//f9rIiIiIgcOQVBRERERE4iF088gydeeJeZfy5i7H6Ddt9Mm9Xg8ZMvnVAnCLJtxy4efe5tDAYD3l6eRISFMLBPd8aPGUqHdknHte23X38ZRqORWXMWYbFY6dS+Na89cy+3/e+5Osd5e3ny1osP8v5n3/HXohXM+H0+QQH+9OzWgfCwQxcXHztqMB4e7nz2zc+8+cHXeHp6MGRAD26YfOEhi1lfceGZzJqzmNXrNzPrz0VU19QQGhzIaUP6cuUlE4iO/HvAefTw/oSFBPLp1z/zxdTpWKxWwkKC6NqxLeNGDz7IVQ7unlv/Q7vWiUyb8Sdvf/wNJpORqIgwxgwfQOe9s9y7dW7HppQd/P7XYgqLSvHx8aJ92yQevfeGOm08Gr6+3tx322QWLlvDL7PmUVhYgtFoJC42kpuuuojzz/57gNpsNvPgXdfy1off8NxrH2G323ngzmsYO2owLzx2Jy+9+Rmfff0z7u5uDOnfk4lnnsZl199/RO0yGo0898gdvPL258z8YyEGg4GBfbtzyzWXcMUN/6tz7KP33sBLb37Kdz/PxumE3t078tIT/2X8xTcf9vWunXQe7u7uTJv+ByvXbqZD2yRefeoe7nzohYO+bl8h7x+m/8EP0/+os69b53b07tEJgMsvOJO4mCimfP8rH35euwIoPCyE3t07Mahfd9drzj5jOA67gy+mTuf1974iKbEFzz1yB+9+OvWw7mNg3+4EBvjxx7ylXHnx2a7tW3fuAuCXmX/xy8y/6rwmMiK0ThCkbetEXnvmXt74YAqvvvM5Pl5ejB89lOv/c3696z1093W8+8lUfvtjAWVllSQlxvLCY3fSrVM71zHhocEMHdiLlWs28evs+djsdiLDQ5l45mlMuugsAvwPHmgC2La3/QuWrGbBktX19u8fBIkID+HN5x/gtXe/4M0PvsbNzUT/3l255ZpL6tQD2XfODZu3sWFz/dVQ33/yMl6RtUEQTw93/u+5+3jj/Sn8MnMe1dU1tE6K44XH76Jvz851Xrd89UZKy8o5Y+SgeucUERERkePHYLHUHFkVShERERERETlpfPjFD0yfNY9vPnyxXiFvOf7ueeRlMMCzD99+6INFRERE5JjRk6+IiIiIiMgp4MJzTqeqqobf/1rc2E055aSlZ7Jw6WquuWJiYzdFRERE5JSjlSAiIiIiIiIiIiIiItIsaSWIiIiIiIiIiIiIiIg0SwqCiIiIiIiIiIiIiIhIs6QgiIiIiIiIiIiIiIiINEsnVRDkr0UrmHD5bQAUFZdy091PMWLCVdz/xGsA/DhjDuMuupHhZ00mZXta4zVUROQI7d/PiYg0V+rrRKS5Uz8nIs2d+jkROZmYG7sBR2rajD8xGo3M/u5djEYjNpuNl976lFefuoeundo1dvNERBpNfkERz772IVu2ppJfWMwnbz5Jm6T4xm6WiMgxtXDpaj7/5hd2pGVgNpnp2qktt113KeFhIY3dNBGRYyJlWypPv/IBe7LzcDqdJMTFcMPkC+imz7si0kxkZedxzhW34+Xp4drWvUt7XnjszkZslYg0RydtEGRPdh6J8TEYjbWLWQoKS7BYrCQlxjZyy0REGpfRaKRvz85Muuhsrrr14cZujojIcVFeUcWl54+jW+dkDAZ48Y1P+d+Tr/PeK+r3RKR5iIwI5emHbiMyvDa4+9fCFdz14AtM//pNPD3cG7l1IiLHzo9fvIafr09jN0NEmrEmHQTJzSvgyZfeY8OW7cRGRzJ0YC8A7n/iNeYtWonBAD//NperLjuX9z79DoCzLrmF4KAApn78UmM2XUTksByon9u374kX32Njyt/7fvx1Dj98+goAX303g69/mElZeQX+/r5cedFZnHn6MIKDAjh3/GmNdEciIvUdj75u9PD+da5x4YQxXHHj/7DZ7ZhNphN5eyIix6WfC/D3I8DfDwCHw4HRaKSyqprComKiI8Mb4zZF5BR2PPo5EZETpUkHQR5+5k2iIsOY/tUbZOcWcMcDzwPw1AO38PgL7+Dr483t118GwLCBvTjnitsVPRaRk8qB+rl9+2JbRPLco3eQm1d3X/ruLN75ZCofv/4ECXHRFBaVUFhU0hi3ICJySCeir1u9fgsJsTEKgIhIozie/dxp51xDVVU1doeD00cOVABERBrF8eznLrn2Xux2B+3btuTGyReREBd9wu5LRE4NTbYwek5uAWs2pHDT1Rfh6elBQlw0E8YOb+xmiYgcMwfr5/btu+E/F+Lp4U5ciyjO3q8PNBqNOJ1OUnftprrGQnBQAK1axjXWrYiIHNCJ6OtStqfx7idTufXaS07YfYmI7HO8+7nZ37/L79Pe5+G7r6Nrx7Yn9N5EROD49XMBAX68/+qjfP/Jy0x5/zlioyO59b5nqKiobJT7FJHmq8kGQfILi3B3dyM4MMC1LTIitBFbJCJybB2sn9u3LzDA7+99YX/3gS2iI3jwrmuZ+tNsxl54A7fe9wxbd+w6cY0XETlMx7uv256awR0PPM+dN15O7x6djvPdiIjUdyKe6Tw93BkzYiBTvv+NtRtSjuPdiIjUd7z6OW8vTzq0S8JsNuPn68PN11yMzW5n3aZtJ+jORORU0WSDIKHBQVgsVgqL/14il5Nb0IgtEhE5tg7Wz+3bV1xS5tqXnZdf5/Ujh/Tljef/x/Qpb9KqZRyPPvfWiWm4iMi/cDz7uu2pGdxy79Ncf+X5jBkx8DjfiYhIw07kM53NbicjM/sY34GIyMGdqH7OYDBgMByHGxCRU16TDYJEhIfQuUMb3vzga6prLOzK2MO0GX82drNERI6Zg/Vz+/a9/dE3VNdYyMjM5scZc1yv3ZWxh2Ur11NdY8HNbMbbyxPTfnnwaywWaiwWAKxWGzUWCw6H48TeoIgIx6+v25m2m1vufZprrziPcaOHNMq9iYjA8evnFixZzfad6djsdqqra/j4qx/JzS+ka6d2jXKfInLqOl793MYt20lLz8Rud1BZVc0b70/BgIFO7Vs3yn2KSPPVpAujP3rvDTz10vuMveAGYmMiGTdqCD/+NufQLxQROUkcrJ979N4bePLF9xh74Q3ERkcyZsQAZs1ZBIDVZufdT6eSmp6J0WCkVcs4HrzzGtd5h47/j+vfV936MABvPHc/3bu0P4F3JyJS63j0dV9OnU5xSRmvvvM5r77zuetaX773LJHhSqEqIifW8ejnSkrL+L/3viAvvzbVTFJCLC8+dhctoiMa7T5F5NR1PPq5zKxc3v1kKgWFJXh6utO+bRKvPH0Pvj7ejXafItI8GSyWGmdjN0JERA7tkyk/sXLNJl575t7GboqIyHGjvk5Emjv1cyLS3KmfE5GmpsmmwxIROdWlbEslLX0PTqeTLdtSmfrjLIYP7t3YzRIROabU14lIc6d+TkSaO/VzItLUNel0WCIip7KikjKee+01CotLCAr058zThzF+9NDGbpaIyDGlvk5Emjv1cyLS3KmfE5GmTumwRERERERERERERESkWVI6LBERERERERERERERaZYUBBERERERERERERERkWZJQRAREREREREREREREWmWmlwQxOl0YrPZcDpVqkREmif1cyJyKlBfJyLNnfo5ETkVqK8TkeagyQVB7HY7g8ZOwm63N3ZTRESOC/VzInIqUF8nIs2d+jkRORWorxOR5qDJBUFERERERERERERERESOBQVBRERERERERERERESkWVIQREREREREREREREREmiUFQUREREREREREREREpFlSEERERERERERERERERJolBUFERERERERERERERKRZUhBERERERERERERERESaJQVBRERERERERERERESkWVIQREREREREREREREREmiUFQUREREREREREREREpFkyH+qAex59mdXrNtOzaweeevBWqqtruO/xV9mTnYfJaGTCuBGcd9aoeq97/7Pv+Om3uQT6+wFwxw2X07VTu2N/ByIiIiIiIiIiIiIiIg04ZBDkgrNHM270EH6dPd+17bILxtO9czKVVdVcedOD9O3ZmdiYyHqvvez88Q0GSERERERERERERERERI63Q6bD6t6lPT5enq6vPT096N45GQBvL0/iW0RRUFh83BooIiIiIiIiIiIiIiJyJA65EuRgcnIL2J6aQdvWCQ3un/L9r/z46xw6t2/DTVdfhPd+wZT9Tf1pNt/9PBsAp9N5NE0SEWmS1M+JyKlAfZ2INHfq50TkVKC+TkSaG4PFUnPI3mzV2k1M/Wk2Tz14q2ubxWLlxruf4qJzT2f4oN71XlNYVELA3nogb7z/FQajgZuvvviQDbLZbAwaO4n50z/GbD6qGI2ISJOkfk5ETgXq60SkuVM/JyKnAvV1ItIcHDIdVkOcTiePPf82/Xt3aTAAAhAcFIDJZMRkMjJu9BA2b915VA0VERERERERERERERH5N44oCPLWh1/j6eHOlReffcBj8guKXP+et3glifEtjuRSIiIiIiIiIiIiIiIiR+SQ69huvudptqemU1Vdw5mX3Mxj997IZ9/8QmJcDJdffz8AN0y+kL49O/PuJ1NJbpPIoH49eOODKWzdsQuDwUBcTCT33Dr5uN+MiIiIiIiIiIiIiIjIPocMgvzfs/fV27Z45ucNHnvNFRNd/3747uuPolkiIiIiIiIiIiIiIiJH54jSYYmIiIiIiIiIiIiIiDR1CoKIiIiIiIiIiIiIiEizpCCIiIiIiIiIiIiIiIg0SwqCiIiIiIiIiIiIiIhIs6QgiIiIiIiIiIiIiIiINEsKgoiIiIiIiIiIiIiISLOkIIiIiIiIiIiIiIiIiDRLCoKIiIiIiIiIiIiIiEizpCCIiIiIiIiIiIiIiIg0SwqCiIiIiIiIiIiIiIhIs6QgiIiIiIiIiIiIiIiINEsKgoiIiIiIiIiIiIiISLOkIIiIiIiIiIiIiIiIiDRL5kMdcM+jL7N63WZ6du3AUw/eCsDGLTt48sV3sVitnD5yEJMvnVDvdbv35PDgU69TVl5Br24dufuWKzEYDMf+DkRERERERERERERERBpwyJUgF5w9mgf/e12dbS++8TGP3XcjX3/wAouXr2F7aka91735wRQmX3oOUz9+iZLSMhYuXXPMGi0iIiIiIiIiIiIiInIohwyCdO/SHh8vT9fXeQVF2OwOWrWMw2QyMnJIPxYuXV3nNU6nk/WbtjGgT1cARo8YwIKlq45ty0VERERERERERERERA7ikOmw/im/oIiwkCDX12GhQaxet6XOMSWl5fj7+brSX4WFBJGXX3TAc079aTbf/TwbqA2giIg0N+rnRORUoL5ORJo79XMicipQXycizc2/DoIcDxPPPI2JZ54GgM1mY9DYSY3bIBGRY0z9nIicCtTXiUhzp35ORE4F6utEpLk5ZDqsfwoNCSKv4O9VHXn5RYSGBNY5JsDfl9Kycle0OO8fq0dERERERERERERERESOt38dBAkLCcJkNLJ9Zzp2u4Pf/1rMwL7d6xxjMBjokNzKVQx95p+LGNC32zFpsIiIiIiIiIiIiIiIyOE4ZBDk5nue5n9P/h+Llq/lzEtuZv2mbdx54xU89PQbXDD5Lvr27EyrxFgAnnr5PTZv3QnAjZMv5P3PvmPipDvw9/VhQO+ux/VGRERERERERERERERE9nfImiD/9+x9DW7/8r1n6227//arXf+OjYnk4zeeOIqmiYiIiIiIiIiIiIiIHLl/nQ5LRERERERERERERETkZKAgiIiIiIiIiIiIiIiINEsKgoiIiIiIiIiIiIiISLOkIIiIiIiIiIiIiIiIiDRLCoKIiIiIiIiIiIiIiEizpCCIiIiIiIiIiIiIiIg0SwqCiIiIiIiIiIiIiIhIs6QgiIiIiIiIiIiIiIiINEsKgoiIiIiIiIiIiIiISLOkIIiIiIiIiIiIiIiIiDRLCoKIiIiIiIiIiIiIiEizpCCIiIiIiIiIiIiIiIg0SwqCiIiIiIiIiIiIiIhIs6QgiIiIiIiIiIiIiIiINEvmI33hrow9PPjU639/vTuLx+67kSH9e7q2Pf7CO6xZvwUfby8AnnrwVlpERxxFc0VERERERERERERERA7PEQdB4mOj+fStpwCorKrmnMtvo3f3jvWOu/36yxnYt9uRt1BEREREREREREREROQIHJN0WPMXr6Jn1w54eXoei9OJiIiIiIiIiIiIiIgctSNeCbK/P+ct5fSRAxvc93/vfck7H39Lv95duPaK8zCZ6sddpv40m+9+ng2A0+k8Fk0SEWlS1M+JyKlAfZ2INHfq50TkVKC+TkSaG4PFUnNUvVlFRSXnXXkXP3z+Ch7u7nX25RcUERIciMVq5fHn36Frp3ZMPPO0g57PZrMxaOwk5k//GLP5mMRoRESaFPVzInIqUF8nIs2d+jkRORWorxOR5uCo02HNW7yK3j061guAAISGBGEwGPBwd+f0kQPZvHXn0V5ORERERERERERERETksBx1EOSPeUsZMaRvg/vyC4oAcDgczF+yisT4mKO9nIiIiIiIiIiIiIiIyGE5qnVs5RWVbErZwdMP3ura9tTL7zFh7AiS27TkkWffori0DKfDSYfkJM4/a/RRN1hERERERERERERERORwHFUQxNfHmxlfv1ln2/23X+369+vP3X80pxcRERERERERERERETliR50OS0REREREREREREREpClSEERERERERERERERERJolBUFERERERERERERERKRZUhBERERERERERERERESaJQVBRERERERERERERESkWVIQREREREREREREREREmiUFQUREREREREREREREpFlSEERERERERERERERERJolBUFERERERERERERERKRZUhBERERERERERERERESaJQVBRERERERERERERESkWVIQREREREREREREREREmiUFQUREREREREREREREpFkyH82LJ1x+Gz7eXhgNBvx8fXjj+f/V2b97Tw4PPvU6ZeUV9OrWkbtvuRKDwXBUDRYRERERERERERERETkcRxUEAXj35Yfx9vJscN+bH0xh8qXnMLBvN+5//FUWLl3DwL7djvaSIiIiIiIiIiIiIiIih3Tc0mE5nU7Wb9rGgD5dARg9YgALlq46XpcTERERERERERERERGp46hWghgwcMNdT2A0GrhgwhhGDx/g2ldSWo6/n68r/VVYSBB5+UUNnmfqT7P57ufZQG3wRESkuVE/JyKnAvV1ItLcqZ8TkVOB+joRaW6OKgjy9ksPEh4aTH5BEbfc+wxJCbG0ahn3r88z8czTmHjmaQDYbDYGjZ10NM0SEWly1M+JyKlAfZ2INHfq50TkVKC+TkSam6NKhxUeGgxAaEgQ/Xp3IWV7mmtfgL8vpWXlrohxXkERYSFBR3M5ERERERERERERERGRw3bEQZCq6moqKqsAqKyqZuWaTSTGx7j2GwwGOiS3YuHSNQDM/HMRA1QUXURERERERERERERETpAjTodVWFTKvY++AoDD4eDM04fSvm0ST738HhPGjiC5TUtunHwhDz71Oq+8/Rk9u3ZgQO+ux6jZIiIiIiIiIiIiIiIiB3fEQZCYqHA+e/upetvvv/1q179jYyL5+I0njvQSIiIiIiIiIiIiIiIiR+yoaoKIiIiIiIiIiIiIiIg0VQqCiIiIiIiIiIiIiIhIs6QgiIiIiIiIiIiIiIiINEsKgoiIiIiIiIiIiIiISLOkIIiIiIiIiIiIiIiIiDRLCoKIiIiIiIiIiIiIiEizpCCIiIiIiIiIiIiIiIg0SwqCiIiIiIiIiIiIiIhIs6QgiIiIiIiIiIiIiIiINEsKgoiIiIiIiIiIiIiISLOkIIiIiIiIiIiIiIiIiDRLCoKIiIiIiIiIiIiIiEizpCCIiIiIiIiIiIiIiIg0S+YjfWFObgGPPv8WRcWlmEwmrrz4bEYM7lPnmMdfeIc167fg4+0FwFMP3kqL6Iija7GIiIiIiIiIiIiIiMhhOOIgiMlk5LbrLqNNUjwFhcVMuulB+vfugpenZ53jbr/+cgb27XbUDRUREREREREREREREfk3jjgIEhoSRGhIEAAhwYEE+vtRWlpRLwgiIiIiIiIiIiIiIiLSGI44CLK/LdtScTgcRISH1Nv3f+99yTsff0u/3l249orzMJnqlyGZ+tNsvvt5NgBOp/NYNElEpElRPycipwL1dSLS3KmfE5FTgfo6EWluDBZLzVH1ZiWl5Vx/5+Pce9tkOndoU2dffkERIcGBWKxWHn/+Hbp2asfEM0876PlsNhuDxk5i/vSPMZuPSYxGRKRJUT8nIqcC9XUi0typnxORU4H6OhFpDuovy/gXLBYr9z76MpddML5eAARqU2YZDAY83N05feRANm/deTSXExEREREREREREREROWxHHARxOp088eI79OjantNHDmzwmPyCIgAcDgfzl6wiMT7mSC8nIiIiIiIiIiIiIiLyrxzxOrZ1G7fy+19LaZUYy7xFKwF46O7r+Wbab0wYO4LkNi155Nm3KC4tw+lw0iE5ifPPGn3MGn4ycjidGA2Gxm6GiIiInEQqa2x8uyQVD7MJJ7Bkay41Vjvn9UtkRKfoxm5es+JwOlmckkub6ADC/D0buzkiIsdctcXOd0vT2FNUyW1jO+DWQM1OEZGTmdPpZGFKLgu25HBB/0QSw/0au0ki0gQccRCkS8e2LPrts3rb77/9ate/X3/u/iM9/Ulp5c58lm7Lo6LGRo3VTqCPOwHe7vRtHcY3i9NYviOPTnHBtInyx9PNREWNDacTercKpUNsUGM3X+SktW5XIb+szOBIChyF+3syeUQbBSgPw+bdxSxMyWF4x2haRtR/kHQ6nRj0fRQ5piw2O498uxqH00lkoBcOh5Ox3WMxGQ28OWszLUJ8aBsd4Dp+e3Yp7/+xlQ6xgQzvGEVMsE8jtv7kUlxh4Zlpa9mZW463u4nHL+xBbEjd75/D6SS7uIroIG/XtiqLDbPJqIFEkWNo5c58Pv1rO1a7g5cu74Onu6nO/qlL0nA4nUzsm6BnuMPkcDpJzyvn5ekbMZuM2OwOXpuxiTvGdaj3/FZtseNmNmAy1vZrVpuDpdvz8Pdyo3N8cGM0X6RZsjucLN2WS8e4IPy93Ovsc+595oja75lDDq2k0sIbMzezJbOYdjGBPPHdWl6e1Lve97chxRUWFmzJoU/rME2GEWmGVNHoKFTW2PD2MLMls5iUPSV8Om87Y7q0ID7UFw83EyWVFnbklPH1olTGdI3hhct6s2pnATklVVRb7Xi5m3A4nDzy7WpemdRHAxUi/9LGjCKW78hn+qoMxvWIJcjH41+f49vFqXSOD6ZP67Dj0MLmwe5w8uWCHUxbvoueLUP572fLaN8ikNO7xbK7sAI/TzfySquZszELL3cTFw9Mon2LQKqtdjLyy2kZ4a+HSJF/YUNGEam5ZYzvEce05elUW+w8f1kvPNzqDgIWlNfw2q+beHVSH7KKq/hi/g5WpxYwolM0GQUV3PTBEu4/pzO9ktS/HUxRRQ1TFqayKCWHjnFBfHJeN75ZnMo9ny/nv2d2omtCMAaDgfyyap77cT2bdhfz1EU96BwfjMVm57aPl5JfWs1VI9pyercWjX07IieNWWszGdYhCjdz7UD790vT+GlFOu5mEwXl1Vw5tA1zNmbx7ZJULhvcyvW60ioLXy3Ygb+3OymZJdx9Vqd6/aPUVV5t5dFvV7Mzp4xhHaO49rR2lFdZufPTZXw2bweXDk5yBZPmbMjind+3MCg5khtHJwMwZdFOfl+/h7IqKy9d3psEzaoWOWoWm537v1rJ1j0ljO8Zx9Uj2tbZvzAll2enrePm09szqotSyx+O1Nwy/vfVSjrEBvF//+mHn5cbT32/lud/XM8j53dzBXYB5mzMYsnWXO4+qzMmowGLzc6tHy/B7nCSsqeEO8d3bMQ7EWleVuzIZ3VaQb1+DqDaasfDbDwhE2oVBDlCJZUWrnp7AXGhvuzKK6dNlD+3nN6BIe0j6x1bVmXFz8sNgFaR/vX2+3i68cJPG3jh8t6YjJrJJHIoO3PK2JJZzIdzttG/bTg3n96ewcn1f/cOh8Xm4KuFOwAnPZPC9Du4n4Kyan5bk8nv6/fg4Wbi5Sv6EBfqS0mlhV9WZvD+HykkhPtSbXUQ7OvONSPbkltSOxCbUVCB2WggMsibPYWVRAR68tylvY4oUCXS3DmdTnbklFFSaSHY14MXf95AQVkNAd7ufLs4lYfP69bgAN+E3vH8uX4P7/yewrpdhSTHBHLv2Z3plhgCwIxVGbw7O4Uu8cG4mzVA2JBFKbm8/tsmOsYFccsZ7enRMhSjwcAVQ1oT7OPB8z+tp6LGRniAJ04ntG8RSJ/WYbw8fSOXD2nFpt3FeLmbuOfszjz343q6JQYTGagZmyKHkpFfzmu/biLY14OeSaFUWWx8vSiV605rR4CPO4He7rSM8KNttD/3fLGCs3rF4e/lzi8rM9iQUUTb6ADuP6cLj01dw6szNnL3WZ0b+5aarKLyGh78ehURAV58eetQ19+TIF8PHj6vG498u5p5m7MJ8/ekXUwAP6/IYPLwNrz/RwqJYb74e7vz4/J0nryoB/M2ZfPJX9t5+LxujXxXIicHu8OB0wnm/VaLWu0Ockuq+GHZLux2J09c2IMnvl/LJQOT8Pb4e4hu5tpM+rcN570/UrDYHIzrEdsYt3DSKKuy8vQP6xjbPZZLBiW5tt8xriN3fbaMJ75by4UDWpIQ5svcTVl8PGc7bmYjf27Yw2mdY5izMQsfDzMPntuVG95fzCWDWuqZTuQYyC+t5oWf11NZY+f8fokEeNddlXXP58tpFxPA9aOSj3tbFAQ5QtOW76J1pD+d4oO5flS7BoMb++wLgBzIZYOTuPGDxXy9aCeJ4X5kFVVydu94Le0WacCatAIe/24NieF+3DC6HcM7Hl0+/NO7xrAxo4g3Zm6mZ1I+N49JVkonYN7mbN74bTPtWwRy3Wlt6ZkU6po5E+DtziWDkuo8XO7vrF7xWO0OcIKb2UiVxcZDX69i4ZZcPbyLNODJ79eydlchIX6eZBdX0ikumP5tw3n+x/VcPLAlHQ+QMtPNZOSuMzvx1YKdtG8RyE1j2tcJ5I7u2oLf1mQybVk65/dPPFG306SVV1tZn15EjdXO6tQClmzL44bR7RjSPqreseN7xjGmawvyyqrZllVCQVkNZ/eOB8DphB+X78LdbOKW0zvQMsKPwe0j+XDONu6f0OVE35ZIk7dkay4zVu/mnD7xeLmbWZ1aANQ+1/VMCmXuxmwiArwY2iGyznNY66gAWkf6M2dDNsktAvho7lbaxwRy4YCW+Hq6cfeZnbjm3YWk5ZWTEObbWLfXpFhtDn5emU713vTM3y5Oo2NsELeNbV9nFjRAfJgv714zgFWp+eSWVDNj9W5uG9uBge0iMBph1to92OwOTu/WgrbRAUQGejH5rQVszSqhTVTAAVogcmqqtth5948Uzu+X4Bo8/3judqqtdteqqoz8cm7/ZBl2h5OYYG/um9CZ6CBvYoK8+XNDFuN6xLIju5SZazNZv6uQD64fSF5pNf+bspL2LQIbTEl8qioqryG3tJqW4X5kFVfWjhGE+XHhgJZ1jvP2MPPsJb149/cUHv12NV7uJsqqbdxzVidKq6y88dtmPpu3gxqrnatHtCUqyJsB7cKZuiSNm8a0b6S7E2k+vlq4k+6JIeSUVLN0W16dlW2ZhRXsyi8nv6ya+DBfzuh2fMeLFAT5l8qrrbwxczPLtuXx2AXdj0ktD3eziZtGt+fFXzbg5+VGRn4F/dqEK/ejyD+k7Cnhye/XcsOo5GNWDNjH042Hz+tGfmk1d3++nI/mbOPKYa1PyUBIXmk1O7JL2ZBRxMy1mdw1viN9Wocf0bn2z43v5W5mcPtIFmzJURBE5B+yiytZsSOfj28cTKCPO1abA5PJgM3u4LTOMYcc1GsV6c+DE7s2uM9kNHDdqHY89PUqhnWMIszfkxqrHaPB4Eo/cyopr7Zy9+fLcTic+Hu7E+zrwRuT+xF6kHR9bmYj0UHedWqAAEzsm8DEvgl1tl08oCVXv7OQjPxyYkM1GCuyT2F5Da/O2ESH2ECe/2k91VY7ZqOR3q1CWburEKvdwfdL07igf8sGn79Gd43hq4U7mbvJjfE94pg0tLVrX6i/J6d1jubrRTu5Z7/VIHaHg0UpubibjXRvGXpK1ex55/ctbMwopnWUPyt3FnB+v0RGd4054AQ7N7PR9bw3vmeca/voLi0Y3aVuir8Ab3dGd4lh6pI0BXxF9uN0Onnmx3VsSC+itNLChN7xxIb6sCglB4fz79qJ01ftpl+bcG4f16HO7+Tp3Vrwy8raFM8fzNmGAbh0cCtC/DwJ8fNkWIcoflqRzm1jO9S57pKtuczZmEX7FoGc1Sv+BN9147HaHNz9xXKKKyy4m41Y7U7G96hdAdJQX+fn5cad4zvicDqZtmwXpVVWerQMxel0EubnidFooLC8hr57U2Sf1zeR2z9ZyoUDWhLqp7TOIvtzOp04nBxWFpXSKgtzN2bxwuW9WZVawMKUnDpBkCXb8uiaEMJ5fRN46JtVxIX61psAWFlj47Gpq/HxcOOmMckE+R55dhEFQf6lT//aTmFZDU9d3LNOIdKj1SUhmE9vGgzAde8uZE9RpYIgInsVlFVzy0dLKKm0cs3ItscsALK/UH9PnrioB/d8vpzvl+066LFe7ibuPbszPVqGHvN2NJbt2aXc8/lyooK8iQ3x4emLex50hdu/NaBtBO//sVUzNUX+Yc7GbLq3DCHQp3ZZ8L7ghLvZdEx+V9q3CKRfm3A+/HMrQb4e/LQinSAfd1dqmQFtw/HxrF2xWl5txcfDjM3uxGQyNJsVqZU1NjzdTbwyfSORgV7875wu9WZDHwuh/p4M7xjF27NTeHBiVzxVo0AEgOmrMmgXE8AD53YFYFtWCe/9sZWrR7Tl2ncX8v4fKbiZjQzr2HBq0wFtI5i3OYcwf0/O+0fwEeDcPglc994i0vPL8fV047+fLcfucGAyGnE4nbSLyea/Z3ZqNn1aQ8qrrWQWVlJebWXBlhxeu7Iv4QFex+VaZ/eO57p3FzJ1SRoTescdl/5U5GSTU1LF6tQC3ryqH7d/soyl2/JoFeVPcYUFu6O2wHmQjwd/bszisfO71euPBraL4N3fU/hmUSrbskr48PpBdTKKnNkzjts+XsrlQ1oR7OvBj8vTWb4jjy2ZJUzoHc/n83eQEOZHl4TgE33rx01xhYUdOaV1PnM7nE6MBgM/LN+Fl5uZt2/rz/r0IgC6JoQc8pxGg4Fz+iS4vjYYDHSMqz+xOT7Ml55Jodz20VLaxwZyYf+WWoUjQm0A5LVfN1FttbsmnzicThal5DKgbbhrMktljY2l2/KYvS6TNtEBJIb74eVu4rO/tlNebcVoMHDde4uorLFx1Yg2dIgN4sL+Lfl47jZeuKy361p7iipZvDWPKosdo9HI1CVpXD2yfl2Rw6UgyCFY7Q6Wbstj8+5i8kqrWbkzn/+b3K/ejMBjKSrIm8zCSnq0PPSxIqeCH1ek0zoqgFvPaH9ca0pEB3nz3rUDKa2yHPS49elFPP3DOu6b0DwCIeXVVp77cT3n90/kgv7Hp+MJ9vXgvL4J3PnJUiKDvLlqeBtX3QKRU5XT6WTOhiwuHdxwarlj5cphrbn23YWYjUbevKofO3LKWLglh4KyGt6ctZnkmEDGdo/l1RkbaR3pT3pBBT1bhnLrGe1P+lVx1RY7N7y/iFB/TzLyK3j32gHHdcDuymGteWzqGq5/bxHDO0bVKeYscqpat6uwzqy/1lEBPHdpL6A2heaG9CKuO63dAX83PdxMPHKQGhThAV4M7xjFVwt2khDuS5i/B+f2SaBrQggVNTbu+mwZD05ZxXWj2uFhNpJbWo23u5m/NmUzaWirk66fszucvDVrM90TQ+nftnYFx6d/bWfWukzC/Dw5v1/icQuAAIT5e/LUxT156ZcNzFyzm8cv7EFk4PG7nsjJYNPuYpIi/IgJ9uGVSX1wOp3c+tFSuiQEU1ljY+2uQgrKaogJ9m5wMq23h5nTOkfzy6p0Jg1tXS+lelyoL72SQvn0r+3cfHoy3y5OZWTnaCYNbU2rSH8CvN159sd1/GdYG0Z2jiazsILoIG+27CkhPtS3Tq2Rk0FljY2Hv1lFam45b0zuS2yoLzXW2me6iwcm8e3iVB6a2BWT0XhYwY8jcee4jmzPLmX2uj28OmMjr17Z97hcR+RkMndTNku25lFltVFaZcFkMLArv4Jnpq3jrav6uVbDP/zNKiotdga2Dee0vc+AkYHexIf5snRbHiWVFkL9PBg/tDX92tQ+y4ztHss3i1PZnFlMckwgq1ILePib1ZhNBv43oQtBvh7c8/lyRnaOJjH8yIKSJ1dPeII5nU6enbaO1NxyercKpU20PxcPSjquARCA6ODaQsIiUvsA9Ovq3Tx2QfcTUlTb092Ep/vBP8iN6OSFyWjgqR/W4u/lztm94k7K5ceF5TVMW7aLDRlFxIb4MLHv8a0ZcOngVgztEMW3i1P5c0OWgiByylufXkR5tdW19P54Cfb14K7xHfH1dCMu1Je4UF+GdaitgbGnqJLfVu/mmWnrOK9fAnaHk4HJEUxZuJOP5mzj/P6JmE3Gk2ZVw7LteXw8tzatYc+WofywLI1AH3fcTUb+M7x1vUJ8x5qvpxtPXtiDRVtzefmXDVzQP1FF6eWUVmWxsTWrlLvGd2pw/+ThbY7JdS7s35JbPlrC8h353D62A71a1fargWZ3Xr6iDx/P3caT36/F083IzpwyvNzNWGwO2kb7079txDFpw4ny4Z9bWbEjn782ZePj0ZW4UB9+X7+HUZ1jWLmzgLHdj3/q0bbRAbx5VT8e/Ho1S7flnpTPwSLH0qbdxSS3CARwjRfdNrYDIb4erE8v4utFqZRWWnj20l4HDLxee1o7rj2t3QGvMXl4G65/fxEhfh5ggMsGt3KloxnbvQXBvu689MtGSqosfDRnG31bh7Fse23+/ZOttsVn87bj5W5iVJdo3p6dwqPnd2NhSg7FlRZenr6RbokhdIo7vqtePNxMdIgNItTPk2veXUiN1Y7HSfI8LHK8zN+czXn9EliYkss9n6+gvNrKkPa1K3lXpRYQG+rL9uxSUnPL+fSmwfUCsAPaRTBj9W7ySqu4flSyKwACtcHgMV1bMGXhTh45rxsrduQzsF0EneOC6JkUisFgYHzPOO74ZBlXj2jD7sJKSiotxIX6sGl3MQ+fV3+V3T8pCHIQPy5PZ0dOGa9d2feQxc2PpZhgb5ZszTth1xNpypbvyCMiwIvkmMDGbkodQztEERfqS1ZRJa/+uumk/PD35szNlFZZad8isM5D9PHUIsSH07rE8PQPa13LmUVOVTNW72Zk5+gTMkh+oPo+0UHe/Gd4G0Z3jSE6yNv1wbxDiyCe/2k93y/bhaebiZGdorlu1IE/mDcFW7NKeO7H9YzqEsPzP23AQO2K3icv7OEamDgR3MxGBidH8O7vW9iRU9bk/n6JnEibdhcT6udJxHFeKRDq78ndZ3Xi8/k76P2PwLKflxs3jG7Hfz9bTrXVzlMX9yQ1pww3s5HXft3ElIWpGAy1aZ46xgYRdpA6QY1ta1YJv63ZzeuT+7FiZz5P/rCWyhob/duGc8PoZOwO5wl5ngMwGY10igtiy54SzjohVxRpujZnlnDxPwpyD2xXG2BtFeVPeIAnTidHlW44PMCL605rx6szNjG2e2yd33WDwUD/thGk51fw0ZxtjO8Ry+q0Qq4Y2pov5++grMqK3eGkfYtAeiaFEtdItcsWbMnhzZmb8XAzcfngVgzrGOXal11ciZvJSKXFzsy1mbwyqQ/Bvh7c9+UKHpiyirJqK5cPbkVuaTWnHYf02AcSHuCJn6cbO3LKaH8CnydFmhqn08nWrFIm9k3Ex9PM1wtT8XI38/PKDNpE+bMqtYCzesUzfVUGQztENrgCbXByBDPX7GZkpxj6NDAR8Px+iVz77kIWpuSycmcBk4e3rvM5dtLQ1nRPDOGRb1djMhoI9fNk5c583M1Gpi5Ow9vDTEK4Lx1aBDJ3U7Zr4t8+CoI0YNPuYjIKyvls/naevLDHCQ2AQO2ARKZWgogAsGRr3nGfJX2kWkb40TLCj+CjKMx0Iu0uqHDly16xM5+NGcW8fU3/4z4z+p/aRQdgtdfmjWzfIvCk+f6JHEuF5TUs2ZbLW1f1b+ymABAT7FPn6/gwX169si9VFhvZxVV8uWBHI7Xs8FhtDl7+ZSPn9Uvggv4tmTS0FTtzyohrpBQQBoOBttEBbMksURBETmmrdhbQJb5+vvXjoWtCyAHTopiMRh67oDt2h5MAb3c6xgbhcDoJ8/fEZndQXGnhwz+3UlRh4Zd7Tzsh7f23LDY778xO4eze8UQFeTO+RxyndYqhvNrqKhJ6ogIg+7SNDuD3dZkn9JoiTU15tZX0vPIDDpC7mYwM/cdA3JE6rXMMZqPxgNc6p088Xu4mxvWIdaUYjA7yJiO/Ag83E7PXZfLpvO1M++/IY9KefyM1t4yXp2/g5jG16VZf+3UjLUK8aR0VgNPp5Mnv19ZmRDHA+B5xrkDNs5f04tslqaTmljOiUzS+nid2fM5gMNAm2p+UPSUKgsgpLa+0mtJKKy0j/EiOCWBEx2j+3JDF679tYvLwNjz09SoWbMlh3uZsXpnUcPq4yEBvPrh+0AGv4eflxnWj2vHy9A3Y7c4GV3x1jg/m4oEtiQjwcqU+3ZpVwqszNpIcE8jn87cTEeBFflm1giCHsnRbHs/9tI6IAC8mD29Du0b44Bod5E1eaRVPfb+W0V1jmkXNAZF/y+GsLSC3Ymc+5/bt2djNOagTOcP4SK1OLeCpH9YSHeRNRY2NcH9Pnrq4xwkPgACYTUa6JQTzzLR1DO0QecAUGSLN2ex1mXSOCybqOKfYPBomowFfTzdaRbrx0MQD5+NvbI69Bfo83Uycu7fYpbvZ1CjPcPtrFxNIyp6SRm2DSGOyO5zM35LDrWc0jTQs/xw4MxoMdT5nje7S4kQ36bCUVll4/sf1lFVbMRmNnLdf+tLaNK6Nl56lTZQ/OSXVFFdYCPQ58c+UIk3B6tQC4sJ8XcHI423/1RP/5G421ctQ0K9NOP32Zh4c3zMWq81xzNuUWVjBih35jO8Zh9FgwOl01kv7tXJnPj1ahroCQhszipi+aje3jQ1gR04ZWUVVPHpBdzzdTHVWzHh7mLliSOtj3uZ/o210AIu35hLs686Q9nW//yWVFjzMjdsXi5wIW7NKSQjzdaVJNpsMjOgURXyYL22i/BmUHMkz09YxeXgbYkN8DnG2AxucHImXm4nt2aUHnMy2fyp3Py83IgO9GNA2ApPRQGF5Dd8uTuWsXnH1XqcgCLWpEqYs3Elqbhlr0gq5c1xHBrRrvNywof6eBHi7YzDAUz+s5eGJ3egcf3zzHYo0NXM3ZvHyLxuJD/MlKeLIih5JrXmbs3l1xkZuGtO+XiS8sdxyent6twrj+2W7GrspIidclcXGb2syuXZk28ZuyklvVWoBH/65lRqrnWcv7YXZdPyKnv9b7aID+GZRKg9+vYqHJnbFrQm1TeR4s9kdbMgowuFw0jVBn2MOxy8rM5i6JBV3s4lJQ1u7ip7/uT6L4koLg5IjGdc9tkkNtPl6utEi2JsP/tzKBf0TaXEUgx4iJ6sVO/LpeZJMXDUaDMe8rkVWUSU3f7gEh6N21nZplYX/+3UTvVuFMXl4G9ez2Y7ssjrBjbHdY7n1oyUs2ZaLl7uZQckRdIw9MSsH/63uiSH8tSmbF3/eQM+WofjsDao7nU7u+3IFBWU1nNUrjnN6JzSpPlrkWNqWVUqb6Lop/UxGI22jA4DaOkgXD2x5TNKK9moV5qrvdrj2rYYN9vU4YH0lfRoDZq3N5K9N2bSLDuTtq/s3agAEav8wfXrTYO6b0IXz+iby5YKdjdoekcawKCWXSwcn8frkfgcsHicH53A6+XF5Ov/36ybuO7tLkwmAAPh4utExNojdBRVY7cd+NpI0b+XVVsqrrY3djCNSWWPjv58tJzrIm16tTo4PzE2Vw+nk3dlb6Ncm3JU3uinpEBvELWe0Z3tWKTtzyhq7OXKScDid/LwynQenrOT9P1IorbI0dpP+NafTyd2fL+eBKasYlBzhSskiB7ZiRz6f/LWN60e146xecbz260b2FFWyfHses9ZlMqF3POf3S2yU9H6HcuWwNuwpquSnFel1tpdXW3lj5ma+WrCDovKaRmqdNFV5pdVMWbiTKQt3UnGSPdNV1tgoKKtm/uZsrnlnIct35NMr6dR9ptuaVUJiuB9dE0NYsi2Xx79bw5iuLVifXsQN7y9mTVoBADtyyupMbowP8+W/Z3bigXO6MrRDJOf0bro1NltHBfDmVf2JCvJmQ0axa/u6XUUUV1i45+zOrNxZwF2fLaOoQv2dNE8bMooOmeY3PMCrSY/fNb2nqBOoxmpn9ro9fL1oJ9ePakf/to0b/NjfvjfNuB6xfLc0jVWpBXRPDMFqc1BSZSHUr+kW7JOmxeF0UlJhodJiIzLQ+4TnCj4S1VY7q1MLuGxwq8Zuykmr2mLnf1NWUlhew2MXdG+SOenDAzxxNxvZXVBBYrhW+8ihrU0r5PP529mcWYKB2kHmAW3DCQ/wontiCG7mpj/QtnR7Hk7g0fO7aWDwX0jZU8I7s7fg6W7mpjHJ5JdWk7KnhPIaG+f3S2ySP3uT0cDg5EjmbMhi8+5i1ywpgOU78lidWkj3xBB6tAxp0h8W5MRIzS3jx+XplFdbSc0t58yecSzemsObM7dw79mdG7t5h8XucPDU9+sID/Akt7SaNyb3O+4F0ZuLT/7axpVDa4t/Op1OFqbkcsN7i/DxNONw0KQ+p/5Tn9Zh2OwOvlpYd+LerLWZbMwoIiLAi++XLeTR87srn/4pzmZ38N3SNOwOJzPXZpIY7ke1xcaCLTm8emXfk+JzKsC7v6eweGsuRoOBjnFBbM0qoV1MwKFf2AzkFFcRE1r3c1taXjnxYb7Ehfjw2bzttAjx4bx+iUzoHc9vazJ54ru13Da2A3uKKmn5jwwP+yYgd4xrmitA/qlTXBDr0gtdBZ2nr8pgVJcYuieG0DkuiFdnbOKOT5Zxz1mdGj0tqzQNVRYbuwsqSIr0x3iSPu8v2ZpLYrgf27JK6TLh5F7de1RBkAVLVvN/732Bw+HksvPHcebpw+rs37hlB0+++C4Wq5XTRw5i8qUTjqqxx9rPKzP4dfVuxnRtQb824Yd+QSPw9XTjP8Pa8OR3a1yzbBZsyebtqwc0yZlA0viqLXZembGRlTvzAbDYHNgdTsym2g7XzWTEbDRyyxntm+T7fmdOGV8t3EmwnwdxoVpSf6S+WrgTgwHevrr/MV/yfKwYDAYSwnxJyy2vEwSxOxys2JFP66iAJjezW068tLxyvluSxubMYkqrrJzXN4EHJ3bFanOwKCWXZTvy2VNYgbvZRJf4YEZ2jq6z1L6pWbYtj/5twptU2qambn16IY9+u4aJfRPILq7iwSmrKKm04OVu4swecU0yALK/5JhAtuxXG6S82sqLP2+gV1IYL/2ygbbRAdw5vuMJL/QpjW/FjnxWpRYQ4O3Gt4vTGNw+En8vN569tCehfp4Mbh/Bde8u4vXfNlFUbiE8wJNrRrZtskGzBVtySNlTwpq0Ai4f0pr4MN/GblKT4HA6sTucuJmMVNbY2JxZXKcWSbXFzq68cnrvTftgMBi4cXQ7tmSWMLxjFFUWuyv/dlOV3CKQXXnlVNbY8PYw43A6mbF6N1cMacWg5EhmrMrgie/W8MqkPoQHKDB2KimvtvLajE20jPBjybZcbHYnYf6ejOkSw4UDWmJzOLnmnYUsSslhUHIkdoezSQdDiiss/LUpm3P7xFNjczB5eBscTudJO7j5b300ZxsPnNed1NwyTEYDcaG1n+W6JoTQOT6I9/90cFrnGKC2DuS4HrH4eJh57sf1BPt6EORzcn+26xwfzNTFaUDtpOoVO/N5dXAfoPZ+7xjXgWnL03nw61U8fXHPJv2ZRI6f8morW7NK8fEwc/9XK3A4oG+bMO4Y1/GkSY9bbbXz2LerSYzw48fl6cSF+hAT7H3ST8g/4lF0m93Oa+9+wevP3Y+vjzdX3vQAQwb0JMD/74GsF9/4mMfuu5HE+BZce8ejDBnQk1aJscek4UfD7nBQXGHhl5XpXDOynSvfalN1ercWxIb48Mi3q3HiJCLAi/f/SOH60ckUldfoQVIor7byyLerSc0to8bqoFNcEM9d2guz0YCb2USIrwdGI2QXV+FwONmWXcpLv2zgsfO7N7mi3p/N2w7AbWd0aLIf8psap9PJnqJKTEYjTqeTN2duZtPuYl68ok+TDYDsEx/mS1peuevrKouN+79aSV5JNRU1Nga0C2fysDYnrNCgND6n08nuggo+mLONovIaMgoqGNEpmpvGJJMY7keA99+FV8f3jGN8zzhsdge/r9/D9uxS7v1iBfec3YleSf8uh+iJUFJpYcXOfM7tm9DYTTlpFJRV8+T3a7lmZFtGdYnBanPw3E/rGdkp2jULr6lrFxPAL6syXEVCv1+6i6QIf+4c39EVEHlgykpevLxPkx74kWNnR3Ypa3cV8uWCnXSKC2JrlpVHzutWbyZskI8HD07sysItOSRF+vHr6t1Y7Q56JYXSp3XT+vzidDqZuiSNiwa2ZGC7CPy9FNSD2rQ5D3+ziphgH24cncwT361hXXoRlw5KYmiHSCIDvdmeU0qgjzshfn8/68QE+xATXDsZ6GSY+Bbs60F4gBdb9pTQPTGEDelFVFvs9N074eqM7rFs2VPCR3O3cc9ZJ8fKJjk62cWV/LYmk5Q9JdgdTjbtLmZguwjG94ir8/nEzWTgvH4JvDM7hRmrd7N1TwnPXtqryQ4ez16XSYfYQC7dL2PBqRIAAViZWsD9X61k/a5C2kQH8OLlvUnPL+fsXvHEh/kytnsLhnaIrPOaYR2j2JFTSnHlyZfe8Z+6xAfz0i8byCioILekikBv9zq1kAwGAxN6x2OzO3jh5w28fXX/I7rOrrxyYkN9Tqn31snurVlbSM8vZ3ByJFOXpFJYbsGJk0lDWjO0QxT3frmC39bsZnyP+sW6m6JVOwtIL6ggq7iKSUNb8cnc7Yzr0fjj+UfriJ+oNm3ZQWJ8DOGhtUth+vbswtKV6xk1rPaXPK+gCJvdQauWtT/gkUP6sXDp6kYNgkxdkkZ5tZWUPSWsTy8iKtDrpPkA3TEuiIHtIiiptHD1yLY8+u1qLnx5DnaHk69vH9bkBzrl2MsrreaL+Tuw2Oyk51cQ5u/JK5P64mE2Eurv2eAfzH0fpmJDfbHYHDz0zSqeuLBHnRQdjamyxsaatEL+7z99VVjxMDmdTl6dsYm5m7IwGgx4upkY0C6Cm09vf1IESNtFBzJ1SSqXDkrCzWzk60WpmI0GPrxhIHml1bwzO4V3/0jRB+ZTxIItObzx22bKq62c2TOOkZ2iSY4JIOQQM07MJiNjurYAapepv/DTBs7rl0h4gCeDkyMP+toTZcbqDN6cuYVwf886+ZDlb3uKKvH3cquzImLJtjwSwvwY1aV2VqGb2cj/zunSWE08Iq2j/CmptJBVXEVUoBdzNmZx4+hkoHbF730TOnPdu4uYuzGLEZ2iG7m1cjw5nU7e/2Mrv63dTZf4YG4+PZkh7Q9er6tjbJCrUGyvpFB+XpnBcz+u57lLe5HUhAYJc0qqyMivYETH6FOyKKzT6Wxw+/t/pFBpsbNoay6RgV6UVVt5+uIevDM7hSmLdvLf8Z3ILa2mdWTAST/5J7lFABsziuieGMLqtAK6twypM+P1iiGtuO69RaTsKWkynz3k+NieXcr9X62ka3wwEQFeXDWizUFXO47p2oIgHw8Ky2tICPPltRmbGNohkpGdo/H3cj/g6xrD2l2F9G+C2RROlPP7J1JebeeakW255cMlZBdXkVNSTUK4L0aDgetHJTf4uqtGtMVxgH7yZBLg7c7ITtF8vWgnAV7udD9AStNRXWL45K/tVFRbXUXU/6m82srOnDJiQ33qrJCpsdq59eMl3D62I0PaR5JZWIGXu1kZEpqg9Pxynv1xPe5mI3sKKxmUHMGfG/Zwbp8EBrSLYHVqAUPaR2IwGLh0UBLv/5HCmK4tXBOjmvKqkMVbcxnZKZpJQ1sD4HRSZxXryeqIgyD5hcWEhfydCywsNIi8/KK/9xcUERYSVGf/6nVbjvRyRy0tt4wvF+wgPswXHw8zn908GJPRcFLNuLvljPaupdT/95++bM8u44EpK8ktrSZWA8anhMzCCn5dvZvyahurUgvoFBdEUqQ/yTGBjOwcjZf74f9Kj+nagsoaG89MW8dzl/Yi2Ncdi81BUYWFQG/3Rpl1tiq1gIhALwVA/oWfVqSzKrWAD64bSGmVlS2ZJYzpGnPSfJAe1jGSn1emM2XRTgYlR/LTinSev7QX7mYTMcE+3HJGe657dxFbMouVV7UZK6m08P4fW1m2PY+bxiTTPTHkgB8YDmVI+yhSc8tZsSOPHTllpOeV0zUxxDWI2BhsdgffLk7jrvEd6ds6/KT5/Tze8kur+XpxKpcNTiK3pJr7v1pJZIAX/zunCyF+HphNRlbuzKdnUkhjN/WoeLmb6dkylDkbsujfNpzSKgud4/9+P7qbTVw+pBWf/LWdIe0jlSqtmXI6nUxbns5fm7N5Y3J/Io+gVkbrqADuGBdAmL8nr/26iacv7snWrBI6xwc3+mzRjRnFJEX6n5IBEICr31nI85f3Jcz/76C90+lk+Y58/ntmJ16evpGvFu7k3rM70ykumNcn92PJ1lxe/GUDEQFeDEpuujU/DtfAthG8NXsLFw5oydq0QsZ2rzv5McTPk+Edo5m5ZreCIM2Yw+nkjZmbObNHbJ3VEgdjNBhcaZotNjsvT9/Ib2syyS2p5rpR7Y5nc/8Vu8NJyp4S/jOsTWM3pdGc1zcBs7l2nCAx3JfP5m0n0Nu9zkrtA2nsv1PHyvn9Ern+/UU4nXDX+E4NHhPg7U6wrzupeeUNfgapttr531crKSivwWZ3cP+ELnSOrx1f3ZpVgs3u5PulafRsGcJ9X67EanPwv3O6nDS1U04FNVY7D0xZxdAOkZiNRi7s37LeJPuhHf6e6NK/bThTFu7k7s+Xk1tSRffEUO4c3/FEN/uwWO0Olm3P47ELuru2ndcvsRFbdOw0ibW1U3+azXc/zwbqzqKpttiptNgI9vWg2mJn3uZsRnSK+leFREsqLbiZjLwyYyPjesTyn2FtXFG3k43RYMC4t66Du9lE+xaBhAd4kVtSpSDIKaDaYufx79bSItiblhF+TB7emsHJkUf1Xp7QO54tmSVc+eZ81zaT0UCYvyfvXzfwWDT7X1myLZd+bU6O1Vn/1oH6uaOxJq2AT+dt56mLehLi50mIn+dJV2DcZDRy29gO3PPFCmatzWRC7/g6M1tD/Tw5q1ccn8/fwRMX9mjElsrxsnJnPi/+vIHkmEDeuKrfMckzum/Gyvr0QqYuSePHFemM7xFHRY0ND3NtfuITuVJq/pYc3ExGBiVHnlSTL45EQ31dRkEliRF1Z6yXVVm57eOl2BwO/DzdmLMxi3P71P5Nmvz2AuJCfXhoYlfWpxdx6aDDG0RpykZ2jua931Mwmwx0SwjB3Vx3oHhQciRfzN/Bgi05dT4wSfNQWmXhmWnrSc8r5/5zuhxRAGR/F/RPZNPuYia9OZ/KGhv3nt2Zge0adxB94+5iOsQGNmobTpSG+rm4MF8em7qauFBfKmtsXHtaO6otNqosdpJbBDKgbThLt+W56n4A9G0Tzi2nt+e1XzfRoRED9cdK79ZhfDR3Gz+vSGd7dildEuoXTx3eMYoHv17FdaPa1esH5eSXnl/Oh3O2UVJhOeIBM3eziXvO6syuvHJu/2Qp43vGEhnoDTj/1TjQ8ZBRUIHD6SQ+7NQYeznU59deSaFMWZTKTWMaXv3RXIUHePHONQPYuqeU3q0OPDM+MdyP1NyyBoMgn8zdhrvZyEc3DOKP9Xt49NvVJEX60yLYmxA/T3olhZKyp4RbPlpKbIgP3RJDeP23TbxxVf/D+ixRUW3FCao3dxzNXJtJgLcbk4a2PqwAn9Fg4LlLezF73R683E28M3sLrSL9iAv1pVti05rwtT2rFLPJQOuoprPi+Fg54iBIaHAgeQWFrq/z8oto3zbp7/0hQeQVFNXZHxoS2OC5Jp55GhPPPA0Am83GoLGTuPjVv6i2OXE6nUQHe2OxOSgoq42SntE9lopqKx5upoPOlssuruTGDxaDE9pGB3DZ3g/RJ2MA5EAiAjzJKa5q7GbIcWK1OXh62lrWpBVisdXW+rhvQudj9gBoMBi4b0JnamwOyqutmIwGDBi49P/+chU2PFFsdgfLt+fXiTY3Jw31c5mFlcSF+dXrk5xOJ6m55RiNBuJDfVi3q4iUrBJGdY4hwNsNg8FAZY2Nl6dv5OoRbU/62XSJ4X48dn43fl+/h4sHtqy3/+xe8fznrfls2l1M+yZWw0aOXGWNjR+W7eL7ZWncMCqZ4R2jjvnf505xwXSKC2ZDehGfzdtOq0h/8sqqufGDxTx/aS8STlDQ8I/1exjTNabZB0Cg4b7u3i+Wc+Xwtvh7uRMfVpvn/vf1e4gO9ua8fgk8+u0aWkf6c16/RAyAzeHkndlbuOadhQR4u5MYfvIXV+6VFMp7v6fw+bwd3HR6/cECk9HAWb3i+WHZLteyeWkeduaU8dxP64kN8eHdawcck2crd7OJhyd2488Ne6i22vlk7ja+W5JGYoQfZVVWyqqsnNG9xQlNB7hpdzFXDj35A5aHo6F+7u7xnfhhRQYeZhMbdxfx1d4MBJ3ignAzGbl4YBLjesTW+zswKDmSvm3Cm3RKjMNlNBi4bHArXvx5A9HBPg1OamgT5U+gtzvLtucfUeDOZndQVmVVrbgmaN2uQp76YS3DOkRx85jko07XHR/my7jusTz8zWpMRgOd4oK4aUz7Y9TaI5Oyp5jWkQGNHow5URrq6/Y3vmccyS0Cm0WKnH8r1M+T0LYHn7hVGwQpr7e9sLyGmWszeeny3rjtTenbp1UYS7fn8f3SXRSUVzNpSGuuH9WOVakF9GwZSoCPO7+uzmD+5uxDTpZZk1bACz9vIDrIm2cv6alnymOs2mLn8/nbmbk2kzvGdfxXK5y8Pcyc1au2ZERheQ2/rMygosbGhzcMwrMJlTjYnFlMckxgs1m9tb8jfgpv3y6JnWm7yc0vxNfHmyUr1vKfS8527Q8LCcJkNLJ9ZzqJ8S34/a/F3HvbVYd9/scu6E6ovxee7iY27y6mxubAbDTw2q+byC6uYvrqDML8vRjaPpKEMF+cwObdxVRZ7djtDrw8zGzKKGZo+yiGdYgiKdIPN3Pz+2MVGehFdomCICe7tNwyvl6USrXVjt3x9yyLwvIa3MxGXp3UBy8PM0E+7sf8ocuwt47Evk7X6XTi5+nGnqLKE1qQbkNGER5upmYZbT6QWz9aip+3O53jg7HaHbSJCqBHyxA+n7eDtbsKceKkdWQA6fnlxIX68uX8HTipDeo6nE5igrwZvTdP/smuXUzgAdNd+Xm5Mb5HHF8t2MHjWg1yUqqssfHH+j0s3ppLpcWGyWgkLa+MluF+PH1xT9pEHd9AXse4IJ69tJfr67dmbebbJWn898yGl7AfS4XlNaxPL+K2Mzoc92s1VZcNbsXcjdlUWWxkFlZy1Yg2/Lp6N5cMakmPlqH0bR3GxL4JrgdtN5OBm8a055w+CVRb7M3iw5vZZOTNq/uTXVR5wJSPIztF8/HcbaTmltNSdWNOOk6nEyewJq2QlMxiWoT4kFFQwXdL0jinTwIXDmh5TAOhnu4mzugei9XmYMWOfLomhrC7oIKYYG9CfD14dcZGwvw8ST4BkwfS88vZU1hxSqet9HQ3cdne1D9ZRRHc8P5ivHbku7Z5e5gPGABrDgGQfQa2i6BjbBCVFluD+w0GA8M6RDJnQ9YBgyCF5TU8PnUNDqeTc/rE16mbM235Ln5akcG71wzAanfw+fwdDOsQeUq/904Uq92Bw+HEw82Ew+lkTVohAV5uJIT78cGfW5m1NpOrRrRx1Wg7FiYNa42T2uDXzLWZjOnagt0FFVhsDuZvzsbdbOKuMzv+q5TQR2PljgLaxZzck8+OpQBv91MyAHK4EsP9mLZ8F1CbJu73dXvo3zacH5btoltCSJ3JWEG+Hozp2gJ/Lzee+mEdHWKDCA/wqvP7dH7/RKYs3HnAleXTlu2iymLju6W7mDS0Nd8s3sn8LTlNpj5iU1ZZY8PL3YTBYKDaasfDbGzw80fKnhL+79dN+HqaeXhit6NKT3bhgJZc0D+RWz9ayu/r9jSpouObM0ua7d/VI/5rYTaZuOWai7np7qdwOBxcev44Avz9uOOB57nv9qsICwnizhuv4KGn38BitTJmxIB/VRS9VaSfK9dgr73Lhp1OJxeUJLIjp4z/ndOVrKJKtmSW8OeGLOwOBz1ahuLjYcbNZKSixkZyi0AuHZTUKLUNTpSIAC9S9pQ0djPkCGzMKGJRSi42h5P5m7MZlBxBx9CgOn/Q9uVH9fM6ccsYDQYDLUK8ySioOKFBkEUptamwmmO0+UC+um0I23PK2ZBehNlkZHVqAV8t2EG7mEA+vnEQKXtKWLAlh/smdCbA253MwgocztqAb3Gl5bjMnG+qzu4dx+S3FrhmJcjJYdPuYj6eu40d2aUkhPsxvGMUQT4eWO0OYkN8Gm2g9+xe8Vz//iKuKGl13NNizVqbSfsWgYT6H32ar5PVmK4xjOsZD8DSbbl88td2gn3d6d8mAqPBwAPndm3wddFB3iewlcefp5vpoKuPPN1N9G0TxtxNWQf83XA6nRRVWDAZDfXyb5dUWvDzcjul/o42ltySKn5fv8e1Uj2zsILMwkoqamz4ebrRNTGY5TvycTcbeeaSnrQ+joFeN7ORpy7uWW97jc3BW7O28OqVfY7rs0K11c4z09ZxTp+Ew8oJfyqICvLmpjHJ+Hu7nZIDhIE+7gT6HPi9MLRDFF8vSqWk0kKAtzvbs0spKq+he8tQ5m3KZtryXbQI8aFrQjDvzE7h07+2Exvqy9juLViUkktljY33/0whv6yG/NJqfl+fyb1ndXaNGcixsT27lM/n73AFHQrLazAaoGWEH1a7k5IKCzU2O2ajEV9PM69P7nfUqf7+yWgwMHl4bf2N9PwKbv94KfF7J8CO6hzNX5uymbokzRVsPJ5mrc1kQ0YRV49se9yvJc1D6yh/0nLLKauy8uaszczfnMOWPSXM25TNkxc1PLGvX5twHjmvW4OroId3jOabRanM25zNsH+sBqmy2Pjkr+20ifLnmpFtGdUlBi93Ex/N2UafVmFHvTLrRNk3IfhErZ63Oxy89/tWpq/KwMvDjK+HmbzSarolhnDTmGT+WL+HTZkljOocjclo4MVfNnBO7wQu6J94TGr4GQwGzu+fyFuzNtMixJuCshpGdIo+Bnd25JxOJ1syizl774qV5uaoogOD+vVgUL+6v7wvPfFf1787Jrfiy/eePZpL1GEw1KYKcEkMqVdw7VQTEeDFvM3ZVFvtTWr5lDQsI7+cjIJKiitq+GjuNoa0j8THw42rR7at94esMcUE+7C7oOKEXa+82sqcjVk83kxTYR2Im8noStcDtcWmHE6nawCrR8vQOh+eY4JrZw+fijWA/L3cGds9lm8Xp/LQxG44nU7yy2rqFCCVE6eh2lpOp5OFKbnMXJtJXkkVVruToooaLhzQkpvHJBMb2nRSGkUFedMlPpiFKblM6B1/6BccoYVbcpi6JI1Hz+923K5xsunTOpw+rcMbuxlN1pD2kbzx22auGNKKsiobq9MK6BQXRKifJ3aHg//7dTO/r9+Dh5uRq4a3pUNsIC1CfLDbndz4wWJO79qCSwYlsT69kK1ZpQxoG743l7ocyKrUAmasyuDm09sf1iB+yp4S7v9qBd0SQgjy9SAqyIueSaG0CPbG39sdfy+3JjHYMLZ7C75dnMqWzJLjuhrk93V7MBkNXDY46dAHn0IaexCjKYsK8qZ1lD9zNmRhMBj4dN42cEKPpFC2ZZUyvGMUF/RPxN1sYkDbCFL2lLAho4gXf95AZY2dxy7oxmfzdmA2Gnjmkp4s3ZbHKzM28vp/+h0yTda6XYV8v2wX153W9pTqGxdsyeG7pWkMbBfBuX0SDnm80+nklekbSW4RyIRe8ZhNBqKCvLHZHaTsKcFqd9C/TQQmk4F1uwppGeFHkM/xTVF2zci2ZBdX1Sk83L5FIPd+sYJx3WOPa4q0Gqudj+du47axHfTZQw5b9N6+7plp60jPL+fh87ry6Ldr6JoQfMB01gaDgZ5JDQfP3UxGLhqQxEdztrqeDfdZm1ZImL9nnZXvwzpG8cvKDO75YjluJiPPXtqr0SbKLNySw7r0Qq4flUxuSRUfz91GQrgfE3rFU1RRwzPT1tG+RSAbM4rxcDPx8HldcTebqKix4u91eBMs7A4nPyzbxfzN2bywN9XYoaxJK2RhSg6vT+6Hw+mkrMpKiJ8HUxamctXbCwnz9+D0brG8MXMzFpuDO8Z1POY12Aa2i2B7dikPfb0Kg8FAUoSfa9KU1e5g6bY8Wkb4nbDJYWt3FVJWZT2hE6JPpOa7ROIUERHoRUZBBZe+9he3je3Q6EURTzVWm4Mamx1vDzNWW22OWgAntQ+PDmft0sd9NR5enr6B2BAfPMwmrjutXZP9gNQixIft2aUn5Fq7CyqYsXo3SRH+zXbJ3b+hGbwHNq57LFe9vYDs4kq+WZTK7HV7GN8zjjN7xhLk48HKnflEB/uQENZ0BttPZuXVVj6euw2LrXal5eKtuYT6eWB3OPlrUzZ3jOtIQpgvP61Mp7zKSmpeOXkl1ZzbN4H4MF9MBgOJEb6H/eB6ovVoGcryHfnHLQhSUW3ljZmbuW1sh2ZR8FZOjG4JIXh7mHn6h3WsSy8iyMedT/9yEOrnQcqeUlqEePPJjYPYkVPGJ39t5/0/U/ByNzOsQxQG4PulaRgM8P3SXSTHBDB1cRpPX9LzsPrF/NJqyqutJ6xWTlPw7eJUvl2SRlSgF2/N2sI5feKJDvKmvNrKLyszSIrwZ1jHKMqrrWzaXYzF5uC9P1K4ZGAS5xzGQGJj8nI3M6JTNL+syjhuQRCH08lPK9K5aEDLUyZHvhwb5/dP5PmfNgDw8MRupOdX8Mlf23jx8t7E7TdpwtvDTLfEELomBLM1qxSrzUHXhBC6JvxdRHZ4xyhW7sznlRkbefi8bvWepZ1OJzkl1WzeXcwbMzfTMsKP137dzJMXdm/yK6qdTicllVY83UwsTMmhT+swfD3d+H5pGl0TQogN9QEnrrTfTqeTgvIaqi12NmQUMTg5kkUpubzz+xbO7BnHVwt2MrxDlCtg4HA6ySmuIuofg2urUgsoqqjhquFt6gV1/7mC9kStdooP8yX+H3/LWkcF0D42iNnr9nB+/yMrxH445m7KIsjXg14HGJwWOZBxPWJ57sf13DC6Hb2SwjivXwID2h75mN2ITlFsyCji6R/W8dylvVwrJpbtyKfXP4q0Gw0GbhyTzKy1mSxKyWVtWuEJKcBdY7Vz75crGNstlpGdo3E6nXy5cCe78sppFenP7HV78PEws2BzDou35pJdVEWvVqGs3FlAQpgvJVVW/vfVSkL9PNmWXcoH1w+kotrmyo6Snl/OE9+tJdDHnb6tw+gSH0xMiA8v/LSeXfnlWPamCe3X5tCTrpZuy6N/24h6fcud4zsyeXgb3M1GvD3M9G0dxqbdxcdtvPWKIa2Y0Dued39P4c+NWUTvKcFggKmL0yiqsNA1IfiAK+ePpcVbc3nx5w1cOax1k5jQczwoCHKSiwz0osbqoHNcEO/+voW/NmVTWmkhJsQHHw8zpZUW7E4nlTU2ogK9iQ31oXtiCDVWO3llNcSH+lBpsZNdVImXu5m8smrWpBYQ5OtB5/hg1qYVkldaRUywDyWVFiotNloE++Dv5Ubp3ihp60h/vD3MtYXqjQZySqrx9jAT4ls7WFZcacHHw4zRAJlFlXiYTVhsdjZnluB0OmkTHUC1xU611U6wrwcZ+RVkFVcSHeRNVJA3GQXleLubiQryJrekmshAL8IDPLHaHBgMBnw8a1OgOZxO7A4njr1L6FyVNZz7/rd3u7Pu99Dp/MfxdfY1/Nqi8praKPOWHCw2B17uJmqsDhz7ndxAbSTfaKz9A+RmMnLL6e3r5LVtqmJDvJmzMcs127vaYqegvBq7w4nJaMBoMGAyGjCbjJiMtfdmNtV+ve+DR7XFjs3hwM1kxM1sxEDtg7bV7sRud2BzONmYUcyLP68n1N+Tm09v3EJ30vSF+nvSMymUWz9aSrCvB09c2IMfV+zimncW4XA6iQz0orC8Bh8PM4nhfsSG+pAcE0h+aTUz12Zy7WltsdodLNySS43NTnJMIC0j/Ajz8yTU37POsluH00nN3hV2+wrR78sT2hxV1tjYtLuYLZnFRAV542Y28tGcbcSF+lBjtfPWrM2M7xFHWZWVihob5/RJ4Inv1mB3OOnXJpzYUB/axgQwoG0Evp4nLn3f0eiWGMLHc7dRY7Uf84c8u8PJx39tJyHMlwFttepBDp/ZZOShiV15cMoqrhnRlhGdovhmcSomo4E7x3ckxM8TN5ORED9PercKw2Z38N3SND6bt4NrR7bFZDSwKrXANTHmq4U7ufeL5dw0pj19W4fVW7qfVVRJSaWF5TvyXXmrT7a0Mja7A/vePPW5JVXMXreHiX0TWJNWQHyYLw5n7X3mFFeRWVjJ6rQCaqwOooO92ZlTyjMX9yTIx527PlvOI9+sprTKitFgoEt8EL+tyaSoooZpy3fhZjJhMhqY0CveVdSyqRvZKZq7P1+OxWbH3XzsP8xOX5lBtdXGwGRNwpJ/p1dSGEPbR1JebaVzfDCd44MZ2SkaT/eG36cGg4F7zupEtdXe4L4bRidz60dLeHPmZq4f1a5OUO6XlRm883sKZqOBh87rRrvoAG78YDHfLU1jYt/jN3B+JLZnl7Ijp5SOsUH4eLjx+m+bWLItD38vN0xGAx/P3UaXhGDmbcomKTIHL3czOcWVjOwUTV5pNZszS8goqMBoMBAZ6MXn83ZgtTt44JyudEkIJj2/gge/XsWQ9pH4ebkxc20mO7JLefXKvsSF+jBteTp2h5MZqzI4q1f8STEIdnrXFrz/Rwrn9k04Lil0ckuq+GZRGuf3T2i2nwPk+OnfJpyrR7RhVOfaOp5XDGl9VOer7e/accP7i5m9rrZOTrXVztJtudxzVud6x7eK9KfV3vG639bsPq5BEKfTydQlaWzLLqW00so7v28hIdyXkkoLhWU13Dg6mXd/T6F1pD/3nN0Zh8PJN4tTuXRQEN0TQ3BSO4Zmtdem80zNLaPaYue7JWl8Nm8743rEkVNcxcqd+ZzTJwE3s5GNGcVMWZRKVKAXXu4mXrq8Dz+tSOeP9XvqBEEyCysI9vWoUz/I6XSydHveAes27p/WsUWIzwFr+h0LBkNtmtuh7SN5bOoawgM88fdy54zusQxoG8417y4ku7jqmKcc/Kd96QVPlufcI2GwWGoaGvttNDabjUFjJzF/+seumiBycCl7SmgV6c97v6fg7+1GZKAXabnl1NjsBHq7YzQa8HY3k1VcxY7sUjbtLsbNbCTE14OckirMJiNRQd5UVFtxN5sYlBxBdnEVa9MK6dEyhOhgb9LzKwjyccfPy43t2WXUWO0EeLuTU1Ll6pz2vZG8PczU7Ffgu3ZQvHYw3cfDjNVeG7xIjgnAaDCwJbMEX8/aYoF5pdWE+HnQKrI2f2JOSRWJ4X5U1tjYXVhBeIAXuSVVVFnqPgDXXuHEMRkNjOgUzfgesYT7e5JXWo2Xu5mwAE/2PRqdzA9JuSVVXP3OQsym2oBHlcWO2WjAzWzE7nC6/muIeW9wpKEPKQ0de9eZnU65FUzq547czpwylm3P4+ze8a4UgNUWO2XVVkL9PKi22knNLSc1t4zdBRUs255HlcXOiE7R/Lp6N/5ebgxoF4Gfpxvr0wvZXVhJQVk1ZpMRb3czJpOBQG93duWVY3M4cTMZ8fE0U1xhISrIiy7xwXi7m6my2okI8KR7YihlVVaMRjAZjRgMtQGF1NwyiissVFvtuJmMrt+X2FAfzEajKzhqNBgw7hdYNBrA17M2lUpxhQW7w0GYvyc1Ngchvh4YDAYKyqqx2h0EertjMhoor7Zhdzrx2/u6aqsdm91BgLc7+aXVuJmNlFdbmb5qNxZbbbA5LbecoooaPNxMlFRaKK+2ERnoRbuYALKKqrDY7AzrEMWE3vF7A0KOevW1sooq8fV0O6E1i44lp9PJf95aQP824cSEeONhNuHhZsLDzYiH2YTZZMRmr71vX08zXu5mvNxNuJkaLpRnszsorbKyOrWAX1ZmUFFj46GJXY/rA3NTp77uxNiXiq5nUmiDqVHnbsziwzlbsdgc9GkVRv+24XRvGcqcDVm8+3sKHm5GYkN8uXJYa/JKq3l5+gbG94gjLtSHvq3DT1htPZvd4eoP9783g8GAze5g5c4CPN1MxIX5sHBLLgu25OBmMrC7sJLSKgu9ksLYllVKlcWG0WDA4XRSXm3DaKhdOR0Z6EV0kDdtowNwApkFFYzvGVcvBVZxhQUv99r+4OO521i+I5/z+iYwpH3kSfds53Q6mfzWAq4f1e6YBrY2pBfx44p01qQV8Nj53U9I8fWmSv3ckds3Ee1Y/V7lllTxyLer8fYwc91p7WgV6U9BWTXXv7+Ye87qRJuoANczy/bsUu79YgV+Xm6c2yfhhBSkde4tJv7r6t1cP7qdq0baWzM3kxjhR2SAF8//vIGEMF+2ZdWuyO+VFMrlQ1qxp6iSHi1DWLY9nzkbszijWwtenr4RL3czY7u1YMueEiIDvUgI86VXqzDMRgMGA8xau4ceLUNcqzcqa2zM3ZTFmtRCSqus9GoVSl7J/7N31+FRnWkfx78zE3f3ECEQJLhbKVDqUHe3rW1tty7bt75127Zb3bobtEALtBR3S3DiRtx1MvL+EZiSJlgIIYTf57p6lcw5Z44kc885z/0899PAjl2VjnvPCH8PhvcM4pTBkcfECHWL1cY1by7mn9OSWowQOlxNFhsfLNjBgs27mNA3jJum9um0eQq6IsW6rmVVajHP/pjM+D6heLk7syW3gpeuHLnPeLqrvI6b31vG/26ecMRKx23ILOWZH5IZFBPAlRMTWLajiC+XpmOz2bnqxF7tGn3/+pwt/Loxj0n9w6msM5MY4cuUAeEtyhnOWpdDRlE1N57UB2cnIwUVddzy3nIum9CThFAfftuUz4JNuzhzWDQ3Tu0DNHd4XLGjiFdnb+HT2yceVOmszmCx2vhoYSrnjIwhYK/f079/TCbEx41rd8+RdCSsTS/h2RkpfHjLhG49r7aSIMehBrMVV+fmRpzKOjOuTqZ99ro5WHa7nUaLDYvVhqerE3agstaM0+4GxMo6M00WW4dMQGu326k3Wx2BqqaxCXOTDZPJgGl3g+Iee74DDLtTE3/9TthfwuKv2+79P+Pu0Q/dWV2jhZLqBuz25iy4j7tzi+tk3z3yxmKzY7HasFjtNFltNFltjgZYZ5Ox+TVL8yiZvUeOGI0Gx7+PN4pzncdqs2Gz/VkmYF/r5JfVUd9kpbHJSkWtmfhQb7zdnamub6K6volQX3e25lWyPb8Ss6V55MD2/EpSC6rw83DBTnPvf5vd3jz5cbAXgd5uuDk3j3wzGg3YbHbyyuqw2ZtHrO0pl2fbvZ3NDjabnco6M2aLDT9PFwwGKK1uTlaU1TRit9sJ8HLFxclEeW0jtt3JD4PBQE1DE41NNtxcTJgMBqobmgjwcsFibe4hPaZ3CEHertQ0WIgN8SLQy5VGiw1fd2cCvF2PeC3nrmhech6r00pobLLS2GTDbLHSaLHRuDuR5GQyUm+2UF1vcYz0MxrAzcUJN2cjJqORBrOV+iYLFmvz8p6h3kzqH86pg6MO+7v1WKdY13XY7Ha251WyfEdz8qCyzoyXuzO3n9avVSmT7fmVfLsik8KKeoqrGrjttL54ujrT0GRxrOPp5kxJVQNr00tpaLLSN9IXi9XOzoLmeUiiAj2x2uxsyinHboeoAI8W92AmY3N5gVWpxazYUYSfpysZRdU4m4z0ifQlxNedvLJaUrLLiQzwoLbB4ughWFTVQHyIN6cOjsRqt+Pn4UK4vwfr0ktxdTY2l4Bam8OZw6JxMjaPRj2eG67enb+dynozt5/Wr92jQVILqgjwcsXb3Zml2wr5zy9bOWtED07oG9aqhMTxRnGua2losvLFknRmrcthcGwA5bVmogI8uOvMpFbr5pbWklZYxWtztvDcZSPouZ/653s/Px+qmoYmXpm1mZTsciw2G73CfMkvr2NivzB2lddRUFGPs8lIaU0DZ4+I4dxRsZTXNlJT37Tf+dQyiqrxdHU67Ofr2oYmXvx5EzHBXpw/KhbPY2RE797emrsNq83G30/tmMoCe+ZEySqp4brJvUmK9j/mkuAdTbGu68koqub7lVks2LyLpy4exqDYgP2u//CXaxkUE8AFY/Y9Aq6teR8P1mPfrCc+1JsrTkhwvFZRa8Zg4KDmXGvLppxy/v1DMv/929hDqjawKaec93/fQXlNI8PigxgSF8grszbz/s3jef/3HSzfUYTNbucfZyQx7hjokLs+o5QXf97ER7dO6NDyoza7nRd/2sSW3Aqq6s387aREThkU1WHv3xUpCSIi0skU56Qz7GnEl8NntzcneevN1t1JD6tjxKPb7tEjHi7No0WO98TH3hTruiab3c7OXVXEBHu1OXJkD7vdzqKtBbw2Zws+7s2dIZpfh6p6M+4uTozvE4qLk5Ht+ZU4mYxEB3qyeGsB1Q3Nc6T1DPXB2WSkpLqhxXubLTYqas0MiQtgXGIoVfVNxAR7YbXZSC9sHgns6erEmN4hFFbWYzTA8J5BmIxGqurNeLk5HxM9lLuCtIIqHvxiLXWNFkJ83YgM8CTMz53q+ibHqN26xuYEV4ivOx6uThRV1lNRa8bFyYjZaiO7pGZ3hxYI8XHjmkm9mNA37GieVpehONc1VdWbeWvuNqrrm/jX+YP3mwD8alk6czfmcen4nuzYVYmT0Yi3uzND4gIJ8XXjg993snBLAcPiAzlnZAz55XX4e7owMiHY0alwW14l4f7NZVk3ZpURE+RFsI8bfp4uPDcjBT9PFy4cE4ezk5GEMB9W7ixmbXoJZouNKycmtJjgWA5dclYZz81I4aO/n3BISe/y2kYq65pHk89PzmdzbgWTk8L5ZUMuuaW1PHf5CAL1uwEU67qyilpzi9JN+7JkWyHv/badKQMi2FVeh7+XK2cMjSbC3wOb3c5bc7eRVlDFs5eN2G8HwrbkltZy2wcreP/m8S1GMHSEJqutQzrO3vfpatIKqwnxdePmk/vg4mTa5wT1XY3VZue6txZz66l9GdHz0Eb22ux2ymoa2/ye+XpZBr9uzOWmqX0I8nEj7jiYF1BJEBGRTqY4JyLHA8W67kEJ1WPfnsmS80rryCurZVdFPb4ezo7a2O4uJuz25lE29Y0Wgn3dmkv1WJpH+O6pq222WPHzdD2uR9b8leLcsc9mt/P8zBS25VUyLjEEO1BW3ci6jFLqGi2M6R3ChWPj+HltDslZZQR4u1JQXg+G5s9WTYOFUF93Sqob8PVwoX+0H9nFtVTVmymraWRwbCCPnD/4uBz93lmsNhtX/WcxA3r4M7JXMDFBXoT5NSd17XY7VfVNFFbWYwC83V0oqKjj08Vp7MivxM3FiQazBR8PF4bHB7E5p5xh8UFcfkLPY2aeu86gWHfss1htfLIojep6M6F+7uSU1rI6tYS7zujPhswyVqeV4OXmRJ9IX26a2mefI0Lsdjvv/baDtMIqLp+QQKifO9+uyKCu0co/p7UedddVlNU0UlzVcMBOQF3VRwt3UlhRz71tzP2yL3a7ndfnbGFucj6JEb4MjQtkTXoJN56USJ3ZytPfb+TZy4bvdyRkd6PoJSIiIiIibVIC5NhnMBgI8nYjyNvtgOUy9k8NgtL9GA0G7pk+wPHvPSxWG7sq6neX8zNw5xl/Tp5b29BEdkktzk5G/DxcCPJpe7TA4ZTRkoNnMhp58uKh/LGlgB9XZVFQUY/F2jyvXn55HTY7+Ho0x6/q+ia83Z05Y2g0j54/BG/35vKOrs6mY3aeO5GD4WQycs2klhOzL9lWyIs/b8LLzZl/XzocO3bu+2wNuaV1WKw2rj6xF4mRvmQUVvPF0nTiQrzJL69jW14Fw3sG8cyPG6lrtGK323nhypFH6cwOToCXa4ePUulM4xJDefCLtYc0MmbO+lw2ZJbxxnVjSMkuZ216Cb3CfHjkq3VYrHZuO63vcZUAASVBREREREREROQ41VZ5vT0l/tri6eZM3yi/A76vSmR2ntgQb64O8ebqE5sbedMLqympbqBHkFeLkW9tzXmwrySWSHc3vk8oCWE+OJsMjtJvz102gnnJeRgMBh74fA1WW/PcricPimBNegl+Hi6OUnE3n9yXvLJaNudUkHCcNaZ3tp6h3ri7mNiUXc6QuMADrl9vtvD5knRuO60vMcFexAR7ceawaAAGxgTQM9SbcH+PA7xL96MkiIiIiIiIiIiIdAvxod7Eh7aub69ROSIthfm5t/g51M+dy3dPbn7OyBiq65sI9Hbd58jgyABPIgPaThhLxzEYDIxKCOb7VVnUNloY3jOoRVkvq83Obyn5VNU34enqxB+bdxER4MHIhNZziIw/BiaDP1KUBBERERERERERERERADxcnfBwVbNxV3HWiB58uiiNTxen8dyMFAK9XRmbGMKW3ApKqxtwdTIRH+pNQ5OV/tH+nD86Vonfv9Bfs4iIiIiIiIiIiIhIFxQZ4Ml9Zw/EbrdTXNVAZnENf2zexamDIwn38yAxwhfXY3DS986kJIiIiIiIiIiIiIiISBdmMBgI8XUnxNe9zXJXsm8HN6W8iIiIiIiIiIiIiIjIMUZJEBERERERERERERER6ZYOuRxWQ0MjDzzxKvkFxZiMRs45cwoXnHVyq/Xe++Q7Zv7yB34+3gD845YrGTygz+EfsYiIiIiIiIiIiIiIyEFo15wgV1w0jaED+1JX38A1f3+E0cMHEh0Z1nq9C6e1mSARERERERERERERERE50g65HJabmytDB/YFwMPdjZiocErLKjr6uERERERERERERERERA5Lu0aC7FFYVEpqRg6JvWLbXP7l93OYMWcBA/v15u83XIKHu1ub6307cx7f/TQPALvdfjiHJCLSJSnOicjxQLFORLo7xTkROR4o1olId2MwmxvbjGZX3vwgVqut1euvPHMfwYH+mM1N3Hrv01xy3mlMnjCy1Xpl5ZX47p4P5I33vsBgNHDbDZce8IAsFgsTzriaxbM+xMnpsHI0IiJdkuKciBwPFOtEpLtTnBOR44FinYh0B/uMXh+/9fQ+N7Lb7Tz+/H8ZO3JQmwkQgAB/X8e/zzxlIi+88WH7j1JEREREREREREREROQQHfKcIABvffAVbq4uXHPp2ftcp6S03PHvRcvXEhcT1Z5diYiIiIiIiIiIiIiItMshj2MrKi7lk69/Jq5HJFfe/CAAt1x3MaOHD+Sdj76lb+84JowZxhvvf8mOtCwMBgM9IsO4747rOvzgRURERERERERERERE9uWQkyAhwYEs//XTNpf97arzHf9+9N6b239UIiIiIiIiIiIiIiIih6ld5bBERERERERERERERES6OiVBRERERERERERERESkW1ISREREREREREREREREuiUlQUREREREREREREREpFtSEkRERERERERERERERLolJUFERERERERERERERKRbcjraB/BXdrsdAIvFcpSPRETk0JhMJgwGwwHXU5wTkWPVwcY5UKwTkWOX7ulEpLvTPZ2IHA/2jnVdLglitVoBmHTW9Uf5SEREDs3iWR/i5HTgsKo4JyLHqoONc6BYJyLHLt3TiUh3p3s6ETke7B3rulwSxMXFhR5RYXz632cOOisNcPlND/Dpf585pH115W06c1/aRr+jY2GbztxXe7cxmUwHtW5749zhHJu20d+ptun8fXXHbQ42zoHu6Q5nm87cl7bp3H1pm2Pjd3Sk7+mOhWugbfQ76o7bdOa+uvo2uqfrutt05r60TefuS9t0/u9o71jX5ZIgRqMRo9GIs7PzIW1nMBgOOot9LGzTmfvSNvodHQvbdOa+2rvNwd4QtjfOHc6xaRv9nWqbzt9Xd9zmUB58dU/X/m06c1/apnP3pW2Ojd/Rkb6nOxaugbbR76g7btOZ++rq2+ierutu05n70jaduy9t0/m/o71jXZecGP28aVO77H46a5vD2a4z9tOVt2mPzvwddbfroM9E+7bprHNp77668jbt0dX/TrvbdejK16C9++rK27SHzqdrb9NeXfmcuvLfQnu3627XoStv0166p+va27RHVz8fXYeufQ3au113uw46n659Ddq7r668TXt09djd3a5DV74G7d3XX7cxmM2N9o46oKPp25nzOH965138rkrXQddgD12HZt3tOnS382kPXYNmug66Bnt0t+vQ3c6nvXQddA320HVo1p2uQ3c6l8Oh69BM10HXYI/udh262/m0h65BM12HZroOR/cadJskiIiIiIiIiIiIiIiIyN66ZDksERERERERERERERGRw6UkiIiIiIiIiIiIiIiIdEtKgoiIiIiIiIiIiIiISLekJIiIiIiIiIiIiIiIiHRLSoKIiIiIiIiIiIiIiEi3pCSIiIiIiIiIiIiIiIh0S0qCiIiIiIiIiIiIiIhIt3RMJUEWLlvDOVfeebQPQ0TkiFGcE5HjgWKdiHR3inMiIiIiXYfT0T6AzvbhFzP4+MuZjp/tdmhobOSZR+7gxPEjjuKRiYh0jJLScp597QO27cigpKyCj958it49Y1qss3DZGv7z7hcUl5aTmBDLA3deT2yPiKN0xCIih27pyvV8+vXPpGXm4GRyYvCARO686XJCggMd6yjWicixbPvODJ555X3yC4qx2+3E9ojklusuYsiAPo51FOdEpLOcc+Wd3HnT5UwcOxyAtz/6hkXL1pKVnc9506dy181XtFi/uLScZ15+j/XJ2/D18eKaS8/mrNMnHdS+Xn/3c5asWEdJaQW+Pt6cdfokrrp4eoefk4gcP46pkSAd4epLzuL3Ge87/vvXPTfi5enB6BGDjvahiYh0CKPRyOjhA/n3o3e1uTwrJ5//+/db3HHj5fz67X8ZNqgf9z32EhartZOPVESk/Wpq67n8wjP58dPX+O7jl/DwcOehp/7jWK5YJyLHurDQIJ751538+u1/mfvd21x2/unc/cgLNDSaAcU5ETm6oiJC+fv1lzB+zNA2l//rmTcI8Pdl9tdv8NTDt/Gf975gXfLWg3pvFxdnnnnkTuZ+9w4vPXkPP87+nR9n/96Rhy8ix5kuPRKkqLiUp156l03bUomOCGsxUqOouJQnX3yXzdv/XDZjzgJ++PgVAL74bjZf/fAr1TW1+Ph4cc0lZzH9tNYZ559+XcjUE8fg5urSWaclIuJwJOJcgL8v502bus99/vL7UoYO6sv40UMAuPays/l25lw2pmxn2OB+R/R8ReT4dCRi3SmTx7bYx8XnnMpVtz6ExWrFyWRSrBORTnUk4pyvjze+Pt4A2Gw2jEYjdfUNlJVXEBEWojgnIp3mwSdfo7ColH898wYmo5FTJo/jvjuuBWD+whWt1s/NLyR583aeeug23N3c6N8ngZMnj+XnXxcydGBf7nvsZXrF9+D6K85zbPPsqx9gMBi49/ZruPGqCxyvx/aI4MRxw9m4aQdnnz6Zr374hYXL1vDm8w871pn3x3I++OwHvnj3uSN4FUTkWNalkyCP/vtNwsOCmfXFGxQUlfKPh59vsSw6KoznHvsHRcUtl2Xn7uLtj77lw/88SWyPCMrKKykrr2z1/kXFpaxcm8z7rz3eKecjIvJXRzrOtSUtPadFeSwnJydie0SSmpGtB2YROSI6I9atT9lGbHQkTiYToFgnIp3rSMa5qef+jfr6Bqw2G6edNJ6IsBBAcU5EOs/TD9/eqhzW/qRmZBMY4EeAv6/jtd7xMXz383wApp1yIi+/9THXXX4uBoOBRrOZ+QtX8Ooz97V6L7vdzoaU7Zw0cTQAp04Zx5sffEV+QZEjHs6au4gzTj6hI05VRLqpLlsOq7ColA2btvP3Gy7Bzc2V2B4RnHPG5BbLbrn2YtxcXegRFc7Zu5dBcykYu91ORlYuDY1mAvx9SYjv0WofP89dRM+4HvTpFddp5yUiskdnxLm21DU04OXp0eI1by8P6uobOu7kRER264xYtz01k3c++pY7brzM8ZpinYh0liMd5+Z9/w7zf3yPR++9icFJiY7XFedEpKuqr2/E29OzxWteXh7U1dUDMGbEIMxNFtbvLo+1cOkaQoIC6JfYs9V7vf3hNzQ0NnLutCkA+Pp4M2H0UGbPWwxAUUkZ65O3cdqU8UfylETkGNdlkyAlZeW4uDgT4Pdn1jgsNKjFMj9f7z+XBQc5/h0VEcojd9/ItzPnccbFt3DHA/9mR1pWi/e32+3MmruIaadMPMJnIiLStiMd5/bFw82Nmrq6Fq/V1Nbj4e52OKcjItKmIx3rUjNy+MfDz/PPW69k5LABjtcV60Sks3TGPZ2bqwunThnPl9//wsZN2wHFORHputzdXampbRmfamvr8PBwB8BkMnLaSeOZtTuRMXveYs48pfVIjo+/mtk8QuTp+3B3+zO2nXnKRObMX4LdbmfO/CWMHJZEYIDfkTshETnmddkkSFCAP2ZzE2UVfw4FLiwqbbGsorLasayguKTF9idNHM0bzz/ErC/fJCG+B48991aL5avXb6akrIJTp4w7gmchIrJvRzrO7UvP+Gh2pmU7frZYLGRk5dEzLvpwTkdEpE1HMtalZuRw+/3PcPM1F3LqX3r/KdaJSGfpzHs6i9VKTl4BoDgnIp3LaDAc9LoJcT0oKStvERd3pGXTM/bP+DTtlIn8sWQ1WTn5rE/exil/aZ/7+KuZ/DDrd15/9kFCggNbLBs5NAmr1cb65K3MnrdYpbBE5IC6bBIkNCSQgf178+b7X9HQaCYrJ58fZ//eYtl///c1DY1mcvIKmDF7gWPbrJx8Vq1NoaHRjLOTEx7ubph214fe4+df/+DEcSPw9mo5PE9EpLMcyTjXaDbTaDYD0NRkodFsxmazAXDq5HGs3bCFZas2YDY38eEXM/Dz9WbwgD6dePYicrw4UrEuPTOX2+9/hhuvuoAz2xjZq1gnIp3lSMW5JSvWk5qejcVqpaGhkQ+/mEFRSZkjjinOiUhnCvD3JS+/yPGzxfLnc6bNZqPRbMZisQDNo9wG9tsd+xoa2bwtjbkLljLt1D/v2aIjw+idEMsjT/+H0SMGthhN9+nXP/P9T7/xxnMPEh765+i5PYxGI2ecfAKv/PdTqqtrGT9qyBE8cxHpDgxmc6P9aB/EvhQUlfD0S++xeVsq0ZFhnDhuBDN+WcAPH79CQVEJT734Llt2pBEdEcaEMUOZu2AZX73/AqkZOfz7lffIyM7DaDCSEN+Df9x8Bb12TxpXWVXD9Etv46Un79GEcSJyVB2pODfmlMtb7euN5x5k6KDmmPfH0tW88d6XFJWUkZgQy4N33UBsj4hOPXcROX4ciVj35AtvM3v+EtxcXVrs6/N3nyUspPlhWbFORDrLkYhzs+Yu4uOvZlJc0lxSq2dsNNdedk6LZ1jFORHpLItXrOPlNz+huqaWkyeNoaHR7JiXY4/Tp07gkbtvBJrn6njm5ffYkLIdH29Prr3sHM46fVKL9WfPW8wTL7zNc/93FxPGDHO8PuaUy3FyMuHs5OR4bVBSIi8/da/j510FxZx39T+46JxTuOPG1s+/IiJ769JJkEPx0ZczWbthC6/9+/6jfSgiIkeE4pyIHA8U60Sku1OcExFptj5lGw8/9TozPnsNp79UcDmQhoZGTr/oFt599f9alNkSEWlLly2HdSDbd2aQmZ2P3W5n284Mvp0xl8knjDzahyUi0mEU50TkeKBYJyLdneKciEhrTU0Wvvh2NtNPO/GQEyB2u51vZsyld88YJUBE5KA4HXiVrqm8sprnXnuNsopK/P18mH7aJKadcuLRPiwRkQ6jOCcixwPFOhHp7hTnRERaWpe8lX8+/AK9evbg8vPPOKRtrVYbJ5/3N3x9vHnmkduP0BGKSHfTbcphiYiIiIiIiIiIiIiI7O2YLYclIiIiIiIiIiIiIiKyP0qCiIiIiIiIiIiIiIhIt9TlkiB2ux2LxYLdripdItI9Kc6JyPFAsU5EujvFORE5HijWiUh30OWSIFarlQlnXI3Vaj3ahyIickQozonI8UCxTkS6O8U5ETkeKNaJSHfQ5ZIgIiIiIiIiIiIiIiIiHUFJEBERERERERERERER6ZaUBBERERERERERERERkW5JSRAREREREREREREREemWlAQREREREREREREREZFuSUkQERERERERERERERHplpQEERERERERERERERGRbklJEBERERERERERERER6ZaUBBERERERERERERERkW5JSRAREREREREREREREemWlAQREREREREREREREZFuyelAK9z32MusT97K8MH9efqRO2hoaOSBJ14lv6AYk9HIOWdO4YKzTm613XuffMfMX/7Az8cbgH/cciWDB/Tp+DMQERERERERERERERFpwwGTIBedfQpnnjKROfMWO1674qJpDB3Yl7r6Bq75+yOMHj6Q6MiwVtteceG0NhMkIiIiIiIiIiIiIiIiR9oBy2ENHdQPT3c3x89ubq4MHdgXAA93N2KiwiktqzhiBygiIiIiIiIiIiIiItIeBxwJsj+FRaWkZuSQ2Cu2zeVffj+HGXMWMLBfb/5+wyV47JVM2du3M+fx3U/zALDb7YdzSCIiXZLinIgcDxTrRKS7U5wTkeOBYp2IdDcGs7nxgNFs3cYtfDtzHk8/cofjNbO5iVvvfZpLzjuNyRNGttqmrLwS393zgbzx3hcYjAZuu+HSAx6QxWJhwhlXs3jWhzg5HVaORkSkS1KcE5HjgWKdiHR3inMicjxQrBOR7uCA5bDaYrfbefz5/zJ25KA2EyAAAf6+mExGTCYjZ54yka070g/rQEVERERERERERERERA5Fu5Igb33wFW6uLlxz6dn7XKektNzx70XL1xIXE9WeXYmIiIiIiIiIiIiIiLTLAcex3XbfM6RmZFPf0Mj0y27j8ftv5ZOvfyauRyRX3vwgALdcdzGjhw/knY++pW/vOCaMGcYb73/JjrQsDAYDPSLDuO+O6474yYiIiIiIiIiIiIiIiOxxwCTI688+0Oq15b9+2ua6f7vqfMe/H7335sM4LBERERERERERERERkcPTrnJYIiIiIiIiIiIiIiIiXZ2SICIiIiIiIiIiIiIi0i0pCSIiIiIiIiIiIiIiIt2SkiAiIiIiIiIiIiIiItItKQkiIiIiIiIiIiIiIiLdkpIgIiIiIiIiIiIiIiLSLSkJIiIiIiIiIiIiIiIi3ZKSICIiIiIiIiIiIiIi0i0pCSIiIiIiIiIiIiIiIt2SkiAiIiIiIiIiIiIiItItKQkiIiIiIiIiIiIiIiLdkpIgIiIiIiIiIiIiIiLSLSkJIiIiIiIiIiIiIiIi3ZLTgVa477GXWZ+8leGD+/P0I3cAsHlbGk+9+A7mpiZOO2kC111+TqvtcvMLeeTp/1BdU8uIIUnce/s1GAyGjj8DERERERERERERERGRNhxwJMhFZ5/CI/fc1OK1F9/4kMcfuJWv3n+B5as3kJqR02q7N9//kusuP5dvP3yJyqpqlq7c0GEHLSIiIiIiIiIiIiIiciAHTIIMHdQPT3c3x8/FpeVYrDYS4ntgMhk5aeIYlq5c32Ibu91OypadjBs1GIBTpoxjycp1HXvkIiIiIiIiIiIiIiIi+3HAclh/VVJaTnCgv+Pn4CB/1idva7FOZVUNPt5ejvJXwYH+FJeU7/M9v505j+9+mgc0J1BERLobxTkROR4o1olId6c4JyLHA8U6EeluDjkJciScP30q50+fCoDFYmHCGVcf3QMSEelginMicjxQrBOR7k5xTkSOB4p1ItLdHLAc1l8FBfpTXPrnqI7iknKCAv1arOPr40VVdY0jW1z8l9EjIiIiIiIiIiIiIiIiR9ohJ0GCA/0xGY2kpmdjtdqYv3A540cPbbGOwWCgf98Ex2Tov/6+jHGjh3TIAYuIiIiIiIiIiIiIiByMAyZBbrvvGR566nWWrd7I9MtuI2XLTv5561X865k3uOi6uxk9fCAJcdEAPP3yu2zdkQ7ArdddzHuffMf5V/8DHy9Pxo0cfERPREREREREREREREREZG8HnBPk9WcfaPP1z999ttVrD951g+Pf0ZFhfPjGk4dxaCIiIiIiIiIiIiIiIu13yOWwREREREREREREREREjgVKgoiIiIiIiIiIiIiISLekJIiIiIiIiIiIiIiIiHRLSoKIiIiIiIiIiIiIiEi3pCSIiIiIiIiIiIiIiIh0S0qCiIiIiIiIiIiIiIhIt6QkiIiIiIiIiIiIiIiIdEtKgoiIiIiIiIiIiIiISLekJIiIiIiIiIiIiIiIiHRLSoKIiIiIiIiIiIiIiEi3pCSIiIiIiIiIiIiIiIh0S0qCiIiIiIiIiIiIiIhIt6QkiIiIiIiIiIiIiIiIdEtO7d0wKyefR57+z58/5+7i8QduZeLY4Y7XnnjhbTakbMPTwx2Apx+5g6iI0MM4XBERERERERERERERkYPT7iRITHQEH7/1NAB19Q2ce+WdjBya1Gq9u26+kvGjh7T/CEVERERERERERERERNqhQ8phLV6+juGD++Pu5tYRbyciIiIiIiIiIiIiInLYOiQJ8vuilZw0cXSby15/93OuuOlB3vzgK6xWW0fsTkRERERERERERERE5IDaXQ5rj9raOlK27OTxB29ttezmay4kMMAPc1MTTzz/Nj/M+o3zp09ttd63M+fx3U/zALDb7Yd7SCIiXY7inIgcDxTrRKS7U5wTkeOBYp2IdDcGs7nxsKLZnPlLWLk2mf+775b9rrd05Xp+X7yKR+6+cb/rWSwWJpxxNYtnfYiT02HnaEREuhzFORE5HijWiUh3pzgnIscDxToR6Q4OuxzWb4tWMmUfpbBKSssBsNlsLF6xjriYyMPdnYiIiIiIiIiIiIiIyEE5rBRuTW0dW7an8cwjdzhee/rldznnjCn07R3P/z37FhVV1dhtdvr37cmFZ51y2AcsIiIiIiIiIiIiIiJyMA4rCeLl6cHsr95s8dqDd93g+Pd/nnvwcN5eRERERERERERERESk3Q67HJaIiIiIiIiIiIiIiEhXpCSIiIiIiIiIiIiIiIh0S0qCiIiIiIiIiIiIiIhIt6QkiIiIiIiIiIiIiIiIdEtKgoiIiIiIiIiIiIiISLekJIiIiIiIiIiIiIiIiHRLSoKIiIiIiIiIiIiIiEi3pCSIiIiIiIiIiIiIiIh0S0qCiIiIiIiIiIiIiIhIt6QkiIiIiIiIiIiIiIiIdEtKgoiIiIiIiIiIiIiISLekJIiIiIiIiIiIiIiIiHRLSoKIiIiIiIiIiIiIiEi3pCSIiIiIiIiIiIiIiIh0S06Hs/E5V96Jp4c7RoMBby9P3nj+oRbLc/MLeeTp/1BdU8uIIUnce/s1GAyGwzpgERERERERERERERGRg3FYSRCAd15+FA93tzaXvfn+l1x3+bmMHz2EB594laUrNzB+9JDD3aWIiIiIiIiIiIiIiMgBHbFyWHa7nZQtOxk3ajAAp0wZx5KV647U7kRERERERERERERERFo4rJEgBgzccveTGI0GLjrnVE6ZPM6xrLKqBh9vL0f5q+BAf4pLytt8n29nzuO7n+YBzckTEZHuRnFORI4HinUi0t0pzonI8UCxTkS6m8NKgvz3pUcICQqgpLSc2+//Nz1jo0mI73HI73P+9KmcP30qABaLhQlnXH04hyUi0uUozonI8UCxTkS6O8U5ETkeKNaJSHdzWOWwQoICAAgK9GfMyEFsT810LPP18aKqusaRMS4uLSc40P9wdiciIiIiIiIiIiIiInLQ2p0EqW9ooLauHoC6+gbWbthCXEykY7nBYKB/3wSWrtwAwK+/L2OcJkUXEREREREREREREZFO0u5yWGXlVdz/2CsA2Gw2pp92Iv0Se/L0y+9yzhlT6Ns7nluvu5hHnv4Pr/z3E4YP7s+4kYM76LBFRERERERERERERET2r91JkMjwED7579OtXn/wrhsc/46ODOPDN55s7y5ERERERERERERERETa7bDmBBEREREREREREREREemqlAQREREREREREREREZFuSUkQERERERERERERERHplpQEERERERERERERERGRbklJEBERERERERERERER6ZaUBBERERERERERERERkW5JSRAREREREREREREREemWlAQREREREREREREREZFuSUkQERERERERERERERHplpQEERERERERERERERGRbklJEBERERERERERERER6ZaUBBERERERERERERERkW5JSRAREREREREREREREemWnNq7YWFRKY89/xblFVWYTCauufRsppwwqsU6T7zwNhtStuHp4Q7A04/cQVRE6OEdsYiIiIiIiIiIiIiIyEFodxLEZDJy501X0LtnDKVlFVz990cYO3IQ7m5uLda76+YrGT96yGEfqIiIiIiIiIiIiIiIyKFodxIkKNCfoEB/AAID/PDz8aaqqrZVEkRERERERERERERERORoaHcSZG/bdmZgs9kIDQlstez1dz/n7Q+/YczIQdx41QWYTK2nIfl25jy++2keAHa7vSMOSUSkS1GcE5HjgWKdiHR3inMicjxQrBOR7sZgNjceVjSrrKrh5n8+wf13XsfA/r1bLCspLScwwA9zUxNPPP82gwf04fzpU/f7fhaLhQlnXM3iWR/i5NQhORoRkS5FcU5EjgeKdSLS3SnOicjxQLFORLqD1sMyDoHZ3MT9j73MFRdNa5UAgeaSWQaDAVcXF047aTxbd6Qfzu5EREREREREREREREQOWruTIHa7nSdffJthg/tx2knj21ynpLQcAJvNxuIV64iLiWzv7kRERERERERERERERA5Ju8exJW/ewfyFK0mIi2bRsrUA/Ovem/n6x18454wp9O0dz/89+xYVVdXYbXb69+3JhWed0mEH3pVYbTa25FYQHeiFn6fL0T4cERERERERERERERHhMJIgg5ISWfbLJ61ef/CuGxz//s9zD7b37Y8Zi7cW8MGCndQ0NBHs48YLV4zEw/XgLmtlnRkAXw8lTkSka6s3W0jOKsNssTG+TygGg+FoH5KIiIhIl1bb0ITJZMTN2XS0D0VERI4h5bWNNFlsVNSZifT3wNPN+YDbpGSXEezjTpifeyccocixRzMaHYbZ63L4aGEqN5/ch3F9Qnn8m/W88etW7pk+oNW6JdUNBHm7OX5etr2QV2ZvIT7Ei39fNqIzD1ukW6uub+LzJWlcP6U3JuNhTXskuy3aWsCrszcT5O1GdX0TxVUNnDsq9qC2rTdbWLBpF6cMjsJkVOJEREREjh//nbcdgH9OSzrguna7HUAdTUTkmGOz2zEqdnWYJdsKeXnWJsxNNtxcTPh6uPB/FwwhKtBzn9tsz6/kX1+tx9PNifvPHkhkgAcALiYjOwuqGBwb2FmHL9JlKQnSTlnFNbz3+w6eungYfaP8ALjzjP7c8t5yVu4sZlSvYKD5ZvbTxWl8tSyDJy8eyuDYQJosNv47bxuXT+jJZ4vT2JRdTlIP/6N4NiLdx3crM/lpbQ7j+4TSP7rl56qosh6LzU6Ev8dROrpjT0l1A2/8spW7zkhifJ9QUguquO/T1QyODSQ+1Hu/29abLTz0xVp27KrCyWTk5EGaF0qkoxRU1OPt5nRQvcK6IqvNxlfLMpg6MJJgH7f9rttktbFzVxW9w31wMim5LSLHjoyiarJLarh4XByRAftuvPpkUSo/rc3BbLEypncIt53a76CrC4iIHE2ZxTX866t1vHTVyBYdf6V9tuVV8PLPm7jv7IEM7xkEwHu/7eDpHzby6tWjcXZqfS9st9t5ZdZmLj+hJ05GA499s57GJhvuLiYi/D1IL6rm/ZvGE3SAe+4jZVVqMdkltZw/Ovao7F9kDz1JtkOT1cZ7v23n1MFRjgQIQKC3Gzed3IfnZiTz9rxtbMwsY8m2Qn7dkMepgyP5ZFEaf2zexSeLU/FwdebMYdFMGxbNl8vSj97JiHQj5bWN/LQ2m56h3qxJL2m1/H8LdnL/Z6spr2k8Ckd3bPpscRrD4gMZ3ycUgIQwH04fGs37v+9w9FiE5oTH099v5IMFOxyvzVidDcDd05L4eFEqdY2Wzj14kW7KarPxyFdr+WzJsXv/kF9ez+dL0rntg+WUVDfsc73y2kb+/v5yHvlyLdf9dwmLtxYckeOx2my8+NMmLnx5AXf8bwXJWWVHZD8icvywWG3kltaSFO3P50vS2ZBZyiNfrmXG6iyWbit03EeZLVZ+XJXFPdOTeO2a0VTWmnll1uYjdlyVdWYyiqoxW6xHbB8icvxYl15CWU0jb/26jbpGCzUNTUf7kLq8XzbkMmtdTovXLFYbM9dk89yMFC6d0JORCcEYDQaMBgPXTuqFs8m4z7bDHbuqKK1pZNqwaM4aEcP/bpnAh7dO4KoTEwjycWNwbACz1ue0ue2RVtdo4bU5W/hqWToNZn3vyNGlJMhBWJ9RytPfb+S3lHzSCqq45b1llNWauWRcfKt1J/UP59nLR9BosfHUDxt5bc4WrpnUi+sm96a4qp4fVmWxJq2ES8fHYzQYOGtEDNvzK9maV9H5JybSzSzcXEBiuC/njopldWrLJIjVZmNdRilB3m48OyMFq83W5nt8vTyDF35KIbOoujMO+bAt2VbIJ4tSySmp6fD3Lq9p5I/NBVz8l1h30dg4dpXX8di3G1i5swiL1cZzM1IorWnk57U5LNxSwCeLUvlhVRZXn9iLif3CiArw4OvlGfu87iJy8BZvLaSosoF1GaWtllXXN/HIl2spqdp3YgHAarO3SGR2trzSWmKDvUgI82Hx1kLe+HUrN7+7jE8WpWKx/hknVu4sxsvNmS/vmsTVJ/bi9V+2tnneh2vO+jy251fyxEVDmdgvjMe/3cCW3IqD2rayzswT327g+5WZHX5cIsez1IIqHv92/VGNVYdq72PNL6/DZDJw5xn9WbGziBd+2oSfpysbMst4e/423vh1K1abjc05FXi7OzM8PogeQV7ceUZ/VqUVU1BR3+b7Ho6Za7K54vVF3Pvpam54eynZh3D/WNPQxLLthR1yHCJybKs3/5nsSMku5/zRsRRV1XPhywu4+JU/+GPzLmaszmZtGx0Tjwc5pbW88FNKm8ssVhufLk7j3d+288HvO/h2RSbv/76D/87bxs9rczhnVAxnj4hpsY2Tycgdp/fnx1VZrE4tJqu4Zez+Y/MuxieG4OLUPP+Ul5szAV6unD4kmofOHcR5o2L5ZX1epz2LZxbXODpAfr4kjR6BngR5u7EytahT9i+yL906CWK1HdzNYr3Zwg+rstoMCE0WG2/8uhVXZxNfLE3nzg9XMjkpgteuGYW3e9slKBLCfLj9tH68eOVIzh4Rw6SkcNxdnPjw1hN49ZrRvHn9WE7oGwaAt7szZwyN5tGv13PjO0tZubO4/ScscpxbuLWAE/uHMyw+kOySWkcjYFW9meSscpxMBp68eBhV9WY+XZzWavvymkY+X5xGbYOFDxbs7OzDd6iqN5NaUIXtAA+8czfm8dqcLeSV1fGPj1exOnX/8SO7pGafPa6r65u47YPlfLY4DbPFypz1ufzfN+sZHBtAjyCvFut6uTnz6jWjCfN1562527jvszVszavg/y4YwrjEUF6dvZnCynpOGRzJwJgADAYD109JZMbqbM578XeenZGsXiAih+GntTlcPqEnu8rrKKqsb7FsTXoJ6zPLeObH5H328l2yrZCznpvPbR+sOOh7pY6WW1ZHVKAn4/uE8sOqLP7YvIvLJvRk5c5i7vl0NbvK6wDYmFXG8PhAnE1GJvUP55wRPVokG1ILqtieX3lYx1LXaOHTxanccFJvEiOaE+mXTejJyz9vorGp5TVsbLKyYkeRo0HSYrXx8JdrabRY+WxxGumFx0YCXeRY8PmSNFallpBbVne0D+WA/jNnC9vzK7nk1T94bfZmGpusZBXX0CPIixBfd84fFUukvwd3ndmfRy8YwgtXjGRLbgUPf7mO3zblMzQ+yDEXSIivO6MSgvnoj50UVtSzLa+Cq95Y1CIp0h51jRY+X5LGoxcM5uu7JjF1QAQPfrGWyjrzAbctqW7gnx+v4ukfko/bRk2RI+WD33eQWlB1tA/joNSbLSzcsotr31zCMz8kNydycyuY0CeU168dw4e3TOAfZ/bnjV+38tmSNJ7+YSOPfLWOd3/bTnX98TNCZENGKX9sLmhzVMyq1GJcnYw8c+lwiqsb2JxTTn5ZHUu3FfHYhUOYNqxHm3Npxod6c97oWJ74bgMPfL7G0X7505ps5iXnM3lAxD6PJ6mHPwYDbM8/8n9ns9blcPsHK7jtg+XMWJ3N7PW53Di1D5P6h/P+7zt4/Nv1zN2Yd1z9PUjX0W2TIBsyS7no5QVc+uofzF6Xs8/eM2aLlce+Wc/7v+/gj81/lljYmFlGfnkds9bl4OZs4s4z+vPGdWN46aqRXDIu/qAmXI4O9OSyCT0dE0Tta6Koi8fG88DZAzl7RAxP/7CRerNKxohA88Pa+oPs8ZtWUEVGUTVjE0PwcnOmT6Qva9JLsNnt3P/ZGh79ej1D44LwcHXi7mkDmLk62/HQZ7fb+d+CnXy6OI3+0f7ccXp/NuWUO0aDVNWbHcfRGSWdvl2RyZ0fruT5mc29R2obmqiobf2A+suGXP42JZH7zx7IDVMSef2XrS0aNLNLahyJlC25Ffzz41W8PmdLm/v8eFEq7i5OrEkv4Ya3l/LJolROHhTJ7af3a3N9b3dnbjq5D69cPZqGJiuXT0jA292ZW07pw7s3juPuaQO4dlJvx/oJYT48fN4gnr1sBPlldfy0Nrvd10fkeFZZZ2bnrkpOGhBBnwjfVqMi1qaXcNaIHgA8t49Rb/OS87hobBzVDU2sSWtuzLLb7Xy2OI3c0lrSC6s7tGzg8h2tE7S5pbVEBXgwpncIFbVmTh8Szfg+obx01Uh6h/ty32eryS+vIzmrjIExAY7tTh8azdbcCt7/fQc5pbU8/f1G/vXVOgoqmhtJG5usB0yK/PWecMm2QoJ93BjRM9jx2vThPfDxcOGV2Ztp2J0Iqao3c88nq3ny+40s3lbIh3/s5MWfNmGzw6MXDOGCMXH83zfrmJ+cz4bMjh+tInI8ySyqZmNmGQlh3qxLb/152ppXQU5p7X7fo6SqgVWpxY7PMDQ/I362OI3KOjMLNu8ir2z/73GwdlXWc/fHq5jYL4xNORUs3V5IVnENMbs7klwyvidPXzrc8TwY4uvOi1eOJMzPnT82FzA8vuWEtVeckECd2cKt7y/n2RkpmIxG3p637bBGhPy6MY/IAE+GxgViMBi4bEJP+kT48savW1t0vDFbrLwyazMLtxRgt9uxWG3855et9Az15pZT+vD6nC1K+Ip0kF3ldXy/KotFHVjus8li4+WfN5FXVsuvG3N56vuNLe4XD6cDzF0freS1OVu4elICm3LKWbq9CAMQG9I8V2SQjxuT+oczsV8Y9589kKcvGc6YXsHklNRy1RuLeGXW5uOiM1za7hi5La/1Pem85HymDoykb6Qf9501kEcvGMIj5w/m49tOIPwAc5deMi6eb/4xGYMBtuZVsnRbIZ8vSefh8waRFL3veYaNBgND4gIPum2lvX7ZkMvHC1P592XDOX90HLPW5TB9eA9igr04e2QPrpucSL8of37ZkMvVby5ic075ET0ekb865mZbs9vtVDc04e3m7Ogt81fV9U08+d1G/nZSIv6ezQ+wnm7OTOzXPPoitaCKbXmVnDE0iplrsqlpsHDj1ES+WpbBif3DAAMv/ryJQG9XiqsauP20fpiMBkxGE73CfTv8nNxcTAyJa77x/WpZOjt3VbV44Bc5Xr01dxuLthbw8d9PwNfDBYAfVmUxsV8YAV6ujvUWbN7Fm79u5aIxcXjtniR4RM8gVqeWEOjtSnV9E/dMT3LcnMWHetMvyo/Z63K4ZHxPckpr+XF1FjabnbunD8DP04XTh0Txz49XcfbIGAoq6lm8tYCTB0UyPzmfl64adcBJwQ9HXmkdpw6O5PdNu1ifUcqjXzeXghjXJ5SbpvbBz9OFJquN9KJq+kY1x6QpA8L5dHEqGzJLGRYfRHZJDbe8t5wJfUO5bnJvnv5hI+eMjOG7lZmkFlSREOZDaXUDv2/axdjEEOYn5/Pm9WMI9nFj1rpcBsUGEBvsdYAjBT9PF/5z7WhHPHZ3ccLdpe2vlmHxzRO7nTI4ksVbC7lgTFwHXTGR48eGzDJigr3w93JlWHwQ69JLOXVwFLUNTaxJL2VdeikPnTuIi8fG84+PVjIvOZ9TB0cBzeU9Uwuq2JBZxi0n98XJaOC7lZm4u5ioqDPz1bIM5iXnUVnXRJC3K09cPIwwP/fDPuY3ftnKqrRSNmSWcv7oWM4aEUNeWS2DYgPw9XDh3rMGMDi2+b7HxcnETVMTcTYZuON/K7DboXfEn/devh4u/Ov8IczZkMut7y2jZ5gPIxOCeXZGCref1o9nfkhmV3kd/7luDDFtxLC3523j9027OGVwJFdNTCC3tI75Kc0Po3szGQ08dO4g/v1jMle8vpAT+oZhMICvpws3n9yH52ak0DPUm0BvV+48vR/OJiMXjY3DZDQwa10OuyrqmJwUwd9OSmzzmlTVm3EyGltNfFxQUd8h11zkWLd8RxEjEoJJjPBlXcafyd093vhlK1X1Tbx81UgC25iIt7HJyt8/WI7NDuePiuXCsXGYLVZen7OVqnoz36/KJNTXncKKeu6ZPoDRvUOw2+18tDCVq0/sdcjH+8h5g1myvZipAyP5enkGK3YUU2+2MHT3vQ/Qqmevu4sTd5zen/NHx7Zq+IoK9OSxC4eyIbO5N/FVJyZwy7vLWZdRysCYANZnlJIY4eu4P/6rmoYmxz3xHr+l5HPeqFjHPZvBYODWU/ty76ereeaHZK6amEBUoCcvzNzEzoIq1mWUsmJnEcu2F+Ht7sxb14/F082J8hozd364AoPBwDkjY7jihJ777CBotdnb7NHcUY70+4scaXPW5+Lt5tzmXGSVdWZ+WpPNRePicTa1/RlLL6zmjV+34unqxOMXDQWaO7ss2VbIku2FeLk5M7pXMC/MTOGN68fg7+nKl0vTuWxCz3Yd7/g+YcSH+XJC3zAWbinkpZ83ccHouBafQ4PBwN9P/bMjXWKEL6cPjSanpIY3ft3Gw1+t5dnLhh9Ux+JjVWpBFb4ezmzNq3BMbg7NbZXrM0q5cWrr+8N9/Y73ZjAYcHU2MaJnMLPW5pCSXc6NUxMZHBt4wG2HxAYyZ0Nuu3/3B1Ja3cB/523jyYuH0S/Kj35Rfpw2JMqx3MXJ5GiTPX90LLPX5fDU9xu54oQEeof7EBfqvc+O4yId5ZhKgtjtdv729lJ2VdTz2IVDGBYfRFFlPUajgaC9bn5TC6rw93Th5EHND7TnjYplzvpcxwfuk0WprM8oY1VqMVvzKnjkvMH0i/Jjzvpc3vttx+4gZae0upFAL1dG7BW0jrS+kX5szatQEkSOe8lZZaxOKyYq0JOf1+aQVVzDNZN68b/dE2+fM7K5TubMNdl8sSSde6YPYGTCn714h/cM4stl6RRW1nPG0Ggm7C5Bt8e5o2J5dkYyJw2MZH1GKYNiArjllL6E+jbHkuunJDKpfziPfbueukYrF4yJY8bqbMYmhvDcjGQGxwbSM8ybE/qG8f2qrDbnCGqv/PI6Th0Sybr0Uv7zyxamDYvmnJExvP/7Du74cAXPXDqc2oYmXJ1MROx+aDYZjUxOiuCTRansyK8kt6yOsYkhlFU38re3l5IU7c8l4+Kpa7Twwe87eOqSYcxYk833K7NYtr2I8X1CHQ/gf21oOJB9JaT3ZWhcEO/M20692bLPhInI8aS8phFfT5eDuvFfl17iSCgOjQ/k25WZWKw2Pl+SzryUfFycjPSJ9MVkNHLFxAQ++H0Hk5PCcXEy8c2KTLblVZAY4UuonzunDoliS24FL/yUQlmNmdtP60dmcQ2DYvybEyXvLWNivzBOHxJFTYPF0WHjUPWN8mVnQRVXn9iLN+du5ZTBUeSW1hEd6AnA+D6hLdbfU0JvcGwgxVUNrR4KB8UGMCg2gA2ZpQT7uBHs48bt/1vJXR+t5OwRMdQ0NPHZ4jQePHdQi+2Ss8qYn5LPPdMH8NLPm9iYWUZGUTUmo5GH/rIuQICXK89cOpzMompe/HkTeWV1vHHdGML9PbDZ7UxJimiRxDAYDFwwJo4LxsRRUFHPTe8uZfrwaML8WjZu2ux2Hv1qPWarjRum9MbXw4W4EG/WppfwxLcb+Oafkw/qQVikO9uQWcakpHD6Rvrx6aJUzBaro9b5rvI6cktrGZMYwgOfr+XRCwYTGeDZYvu16SV4uztz7aTevD1vG2N6B/P5knQ8XE08c+kYdu6qYmxiCMt3FPPczBTG9A7Bx92ZxdsK25UEcXM2ORLOY3oF8+XSdFycjPzjzKQDbvvXY9/b4NhAR+PWBWNieWf+dswWG5V1Zkb3Cubeswa22iY5q4yHv1zL6N4h3H5aPz5YsJNeYT7kltUyqldwi3X9PV154YqRvDN/O7f/bwVnDI1mfWYp7944nke+Wsu2vEpeuGIEAV6ujlLQl03oyfThPcgvr+O5GSmE+bk7zv2vx/HczBRevGIkoR2U3G1sslJW00i4vwcbM8v494/JPHPZ8IPquCPS1djtdhZs3sUNJ/XmlVmbWyUvl24r5MtlGeyqqOef05LavE/8bmUmIb5urNzZPE+Eu0vz/d7tp/en3mxheM8gAr1cqWmwcOt7yxkYE8CatJJ2N4RfPqEnTk7N9z6nDo6kwWzhwrEH17EtOsiLJy4ayq3vL2f2+lymDTu0Z85jRWOTleySWi4YE8vW3fPLpRdW8+bcrQR7uxEX6t3q3vBQjUwI5ukfNnLWiB6Ods4DGRIXwGtztlBZZ95nAv1wzE/JZ1BMwH5HpOzt9KHRuLmYmLUulw8W7OCModGOuZOddB8sR8gx1fpUUWdmV0U9J/QNZUNmGRW1Zt7cPV/HPdMHOB7O0wqridurl/aUARF8vCiVjxbuJMzPnY2ZZbxw5QjWZ5QyunewI+Hwr/OHcM8nq5ifks8ZQ6MZ0zsEVyfjITfwHY4+kX6sVwkFEZKzyhiVEExCuA9vz9uOASivbcRmb24EPGfknw1dD5wzsFXvh9hgL/pH+RMb4tVqYjGAIXGBjE0M5bkZyTiZjIxMCG7V+7ZnmA9PXzKcoqoGhsYFNvdyMRn4elkGdY0WflydzedL0mkwW9uVBFm8rZCJ/SNa3NBabXZ2ldcRGeDJsJ5BzFmfy0kDIwjycePeswbw3m87ePzbDUxOCqd3uE+L+HTG0GhqGy2kZJeTnF3Om9ePITLAg7kb8xmR0Fxr+tLxPbn1/eV8viSd+cn5jO4VzIqdxdx6at9DPv72CvNzJ9jXjWd+SGZM75AWPUTKaxt54PO1jEoIJirQg/F9QnF3cSIluwwPFyd6hvl02nGKdIZ6s4W/f7CcS8b15Mxh0ftdd+m2QpZuL+KpS4YBzaPanE0GFmzexZwNubx05UiigzwdPevG9wnluxWZfLIojYvHxrE5p5zXrhmNv1fzg4+/Z/NoD6vNxs5dVfSO8HXEo1G9QjhlUCRzNuRx/+drwA7f3T2lXed4z/QkTCYnXJyMfLUsg99S8qluaHIkcfdl+AE6oewd9++dPoCU7DKmD+9BWU0jN727jPUZpQyODeD1OVuYPCCCjxamctHYeEYmBHPn6f35dWMej180FJvdvs+HQZPRQM8wH568eBhpBVVE7U7cHOjBPczPnZEJwfy4KpvRvYMZtHt+JICFmwuoqDPTJ8KX52emYLbYePyioXy/MguLzU5RZf1+G0X35aEv1nLSgAgmJYXz05psMBz4OEW6onqzhe35ldx1ZhKhvm54uTuzJbeCwbGBrNhRxMasMgbEBHDP9AG8/9sOHv5yHS9eOZIAr+ZR/Pd9uhovN2dO6BvGyIRg3p2/nb9/sIKJ/cJ46NxBhPi6E+LbfM83NjGE14NHM3djPhlF1TzcRkL0UMUEexHh78EpgyLx32vk8uE6c1g0q1JLmNA3lJEJwdz07lK25lXQN9LPsY7ZYuX1X7Zw4Zg4tuZVcuv7y2kwW5m7MY+RCUGtRp9B8wi7e6YPYOXOIp74biOXjIvHz9OFh84dhAFDmwkMb3dnEt19OXdUDPNT8lslQWx2O+//vgMXk5FHv15Hk9XGXWcmHXTj2L7MWJPNl0vTuWBMHLPW5hAR4MHLP2/ipatG7rdXeW5pLa/N2cIFY2LxdnNu8X0ncrTkldVR22hhQp8wvlqWweacckb1CnEsX7P7mXflzmLembedG6cmtnj2s1htrEkr4fGLhuJsMvLSz5vILavlhL5hjO8T2mJ0xt3TkliXUUpaYTVnDG2dtGyPE/qGMaFP6CG1lzk7GblxaiLPzkghJsjrmOz8a7fb+XJZBv2j/No8/sziGrzcnJjQN4wfV2dR12jh/s/XMKZXMAu3FHDlxITDPoZRvYJ48uKhLe4vDyTQ241e4T4s3VbIvJR8hscHcfG4eMffyYbMUjbnVLQrQWaz25m7MZ/rJh9aJ4LJSRFMToogs7iGf360knnJeXi6OvPgOQMdVTxEOtIxlQTJLa0l2MeNUb2C+XZFJgu37OKuM5Ooa7Tw9A8bOWlAc9mBjKJq4vf6wPh6uHDB6DiyS2r4dUMew3sG0Tvcl95/KW0V5ufO238bx7LtRQzvGYSfZ8dnRw+kb5QvHy/ayZ0fruDhcwcT5PPnCJeVO4tZn1HKtOHR7Xo4FjmW7CyoYnjPIE7oG8bOXVX0DPXh3d+2M6l/OIu3FdBgtvLl0nR6hvm0OfzTYDA4hgTvy99OSuTxbzeQnFXGjVP7tLlOVKCno9HLzaW5B+KeGwOL1cYPq7IcZVwO1QszN+Hm4kx8iDfzU/KZMiACsGMHQn3dmNAnlKLKeuJ2xzODwcC1k3tT+MNGPl6YyoV/KScV7OPGraf0xW63U1hZ7+hhsneSwcPViXunD+DVOVvw93Ll3rMGsDa9lIROTi6cMiiKNWklfLE0jZMHRTgeXH9em4OnqxNFVfWsTC1m8dZCTh4UyYs/bWJSUji3n9b2HCX7Y7PbKayod4x0Ka1uIMDLtVMT3CL7MnNNNnWNVhZvLSA2xAsPFydKqhvYmlfBVRP/fJBYnVbMy7M2c8/0ASTuLg+1p77vq7O3cO7ImFYPC0aDgXvPGsBdH62ioKKeyACPNktEmYxG+uzViLZHbIg3N5/ch+nDo8kpaX/dfBcnE067e3CP6xPC2/O277Mxrr3iQ70dZQoDvd245sRevDZnC1eekMDc5HzWpJdSb7bwxO7vhdG9QxjdO2R/b9lCgJcrAQnBB15xL6cPieLhL9cxLzmPqQMjGdDDn8gAD979bTs3ndyHE/qGYbfb+XldDvd9ugZnk4EAL9fdv6vW93kWqw2zxdbmdSupaiA5q4wduypJyS5j6fYirDb7QTUw2Ox2DBz6qD6RQ7Ehs5RFWwsP6ns8OaucIB83R+eUoXGBrEsvpbLOzOtzmuevuHFqIkaDgeun9KaqvoknvtvAM5cOZ+GWXRiNBnLLarm7XxImo4HHLhqKm7OJYJ/WZbOgeSTGNZMOffTHvhgMBl6+ehRuzqYOe09ojqX/vmy44+eLx8bz0s+bePXq0dQ1WsgoqqasthFnk5FLxvekscnKy7M2c+GY2OZ5Rw6QWB7VK4R/XzqchPDme8KD6al8Qt8w3vttB8/+mEyvcB8G9PDHDuzcVUVNQxMvXz1q96gYE//+IZnnrxhxwJr3+7NyZzGjEoJJyS7nonFxnDooir+9s5SVO0sYm7jvmP7+7zuw2uy8MHMTNrudIXGB3D0tCavNjouTSSW15KjYlFNOYoQvzk5GBvTwJzmrOQlis9upqDWzMauMK09I4Myh0dz9ySrC/Nw5e3c1hHfmbyeruAZXZyO9wn04e0QMHy3cyS2n9HXcJ+7NYDAwLD7IMZq4o7Tn3mFYfBA3TOnNY9+u528nJXLKoI5JynSW1IIqvl2ewXcGA/86f3Cr+6yU7Obfa0yQJ+4uTny/u/TsnWc0lz883FEg0HzvfjAlsP5qXGIIHy1MxcvNiQWbd2E0NM9ZZbHaeOPXrRSU1zO6V/ABOx6WVDdQUWt2tCFsz6ukrtHSojLHoYgN9uLOM/pjMhpIK6x2dG7Y1yhCu92u+1Zply6bBPllQx5nDm/ZezuvrI6oAA+Sov15fuYmgrxdGdM7BJPRwODYAO76aCU9Q31IL6zmxL8MCdvTaFnb0LTf/Xq4OnHSwIiOPZlDEB/izSmDotiQWcrK1GLOGNrcK7S5Ru1O3F2cuPX95fSN9OPO0/t32NBika7Ebrezc1cVl4yLx9fDhX+cmUSD2cp3KzM4f3QsW/MqeOnnTazLKOXlq0a2ez9uziYeu3AIa9JKiAk69MSik8l4WPNaTBsWzXu/baeyrsmRYOkT6Uu4nzsmo5GBMQGtbqpMRgP3nz2QTxaltSohs4fBYNjvzVXfKD/evH4MFqsNFycTYw6hIbCjnD86lnNGxnDtW4tZn1HG8J5B1JstzFqXw4PnDGJgTAB1jRYe/Xod/1uwg6RoPwor6tu1rxU7inh+5ib+c91oGsxW7vpoJRePi+fS8UemHqrIwbLb7fy8NodbT+nLa3O28Ng36+kV5oPJZGRbXgWXjIvHxclEZlE1z8/cxG2n9WtVyuTckbGM2J0wbktkgCePXTCE52amMCUpvF3HGRng2WGdL04aEEFBeT23n37oCc1DceqQKHbsquLFnzdx8dg4ftu0i5MHRnZo4uVABscG8uEtEzBbbTz7YzLJ2WVkl9QyOSnc8fsyGAxMG9ZcyqCy1sz7C3ayq7ztWPfmr1v5bdMuYoK86BXuw00n93GUzVqfWUrvCF8m9Q8nt7SWpy4Zxuacct6ev73FvE1/ZbfbefzbDZRUNdA3yg8fd2cum9BTPaSlw323MouNmaVcNTFhv2U4ymoaeWvuVqYN/3MU09C4QN6ev53Z63O576wBDIgJwMWp+W/fYDBw+2n9eOjLtTz7YzK7Kuq5bEJPxiWGOMpn7Sm915k6OgHSlvNGx5KcXc5rc7bQ2GRlXUYpAV6uXDyuuT6/h6uTo9Tfwc5rmdTj0EZqeLs7c+HYOKrqzMxal8PnS9Kbu/PY4ZHzB+Pr4cKNU/tgt9ux2+3c8+lq/DxcuGxCzzbvP+saLTz2zXpcnE2E+rpx/ug4RzKsotbMzl1VPHzuoBYjbE4bEsXs9Tn7TIJszCxjc24F7944Dl8PFyrrzPzrq3W8+es2UrLLGdcnhGsn9T6k8xbpCJtyyh2jowbFBPDVsgzsdjsvzExh0dZCgrxdiQn2wmAw8PB5g3nwizVEBXqSGOHLnPW5hPq5My4xFKPBQHyoN49duP8OgF3J1IGRhPm58+R3Gwn0cjtgkrYrWbGzmNG9Q/Byc2bhloJWz+srdxYxZUAEBoOBIbGB/LA6iwl9wjAYDEQHHd3SfeMSQ/lgwU6umdSL+FBvHvhsDT3DfFibXoLJaGT68B58sjiN/7tgyH7f59XZW0jJLuO6Sb0ZmdBcWWJkQtBhlbHaU758TO8QquubeHZGMi9cObLVPanVZue+z1YzpncI542Kbff+5PjUZZMgH/6xkzGJoazPKKO+ycK0YT3IKa0lKtCTQG83Ivw9WgzxC/F15x9nJvHMD8mYLdYW5bD25vmXCeK6GieTkb+dlMh3KzNZk1biSIJsyCyjss7MK1ePwmyx8fHCVP7+wXJOHxLNhWNi231ey7YX7bNnqMjRUlzVQG2jxTECAppHYXx06wkYDM1JgO9WZnLbaX0P+0bC2WQ8KkkAaK6pml5cyw1TEqmqb2Jech4+7s5EBOy/d4iTyXjYPRaNBoOjceBoMRkNTE4K5+vlGQzo4c+85HzC/NwZsPsB3MPVieevaE5ybcgs5T+/bG3XfrbmVWI0wHMzUrDZ7UzsF86M1dkkRfsfk0Owpfsormqgsq6JCX1DWbhlF15uzizfUYQd8HZzZkNmGYkRvjz27QbOGRnTZs3fvUdA7EvfKD/evXEcXaFdOzLAk/vObl3DvqMZDQbuOL05aTQkLpBTh0Th497594B7RvS+es1oADKLqtuM8T7uLvi4uxDu586uirpWy7fnV7JwSwFPXzKMyromvl6ezvMzU7h4bDz//jEZJ5OBcYmhLUqq9Qjy5JvlmazLKN1nz89Z63LJKq5h2rBoiqsaWLy1kJqGJm4+uW+bEyuLtEdhRT0pWWWE+3vw68Y8PFycOHNYNCVVDS1GvTc0WXni2w0M6BHAuSP/7Aw3ODYQm83O7af3Y0QbvUydnYw8fN4gXpm1mfKaRsb0Cjnq9zidwWgwcPe0JG7/3woazFbOHBrNgs27mNivfQnv9tpTEvbqE3thtdnJLqkhs7imRS9lg8HANZN6ERfqzbzkfLbkVrR5/z0vOY+GJiuTksJJyS7ngc/X8Oxlw/lt0y7mJ+eTEObdqsTYyQMj+WJJOrm72wr2ZrU1l+W6aGycI/nm6+HC/WcP5Pb/raBHkBez1uVw7sjYo1IFQroXu93Oiz9v4ooJCQfsrGqx2kjJLuekAc0dcAf0COC5GSl8tjiNLbkVvHHdGJz3Ks2eGOHLbaf247mZKc0lo8O8efbyEdjt9iN+XkfKgB4BXD6hJ+//voPECF/HvENd3fIdRVwyLh5/L1ee+m4jN5/cx9H4X17TyPb8Kh48pzkBPTg2gAWbdzEkrms8c4b6ufPkxUNJivbHyWTksgk9eePXrYT5uvPA2QPxdHXiuv8uoaLWvM+YuCGzlB35ldxxen9+XpvDx4tScXcxcdPUjimvvaf6xU3vLGXhlgIm9W/5nTZ7fQ5FlfV8vjiN/lF+bY5mlz9lFlXz4cJUbjwp8bBGYnYXXTYJEh/qzU3vLiPYx43c0jpO7BdOXlmdY5Ly+84a0OqLZVh8ELed1peZa3II7MD6q0fD8PggPl+cRmOTFVdnE3M3NpdScHEy4eJk4pZT+jI5KZyPF6Vx6/vLefP6sfvt3Wi12dqsk/rp4lSCvN14/KKhrE4rZktuBVeekKChZXJU7dhVRUyQF65/6UW35+8yIcyH+9qYCPJY4+Zi4rnLRwBQVFnPf37ZioerEzFHuYdIZ7pgdBybc9bzyFfrKK5q4NpJvdqMP2F+7hRXNWC12dssWbA2vYSZa7Jpstg4c1iPFr0Bt+dXcvWkXpRWN1LXaOHayb3xX+zCLxtyDyoJYrHa2FlQRc9Q7+OiUUU6z85dVcQEe+LqbOKR8wfjbDLyzA/JVNU3Dy+fuzGPuRvz6BnqzcUHOenkvhyPEwwaDAZHI1tn9Mo+GAeqbxzm50FyVpnj56ziGsL83JmxOoszhkbTf3eP0f7Rfvzf1+u588OVjOkdzIbMMkYmtEx0uDiZOGNYND+symozCdJksfHl0nRuP72fo3xBUWU9t76/HIBfN+bx7o3j91lCSORgLdpawOC4QJKi/fnwj50A+Hu68OyMFB46dxCjegWzeGsBny1Jx9fdmdtP69fiXsDb3ZlPb5+43xFKPu4uPHLeYOrNVsfo2uOBr4cLj54/hPLaRobGBXLh2LijFu/23Lf3iWy7UcpgMDCpfzhVdU0t4tweVpudmWtyuOrEBE7oG8YpgyJ5a+42Hvh8DRV1Zq6fnNhm0t/P04VxfUKYvT6Xv52U2GLZ18vSqW1sYtpf5twK9/fg1WtGE+jlytM/bGTO+hwu0QhhOUy5ZXX8sbmA2GAvzh+9//u2Txen4e3mTP+o5u91P08XooM8+WpZBv++bHibnVRP7B+OxWrn6+UZXH7C7lGbx3i7zWlDoli0tYBLXv2Dayf14twu3rO/qLKevLI6hsUH4eZiws3FxP/+2MkVExL4ZkUGf2zeRWKEjyNZOyQuEA9XJwbFHHrpqiNl7wT1uaNiW13zXuE+rNhZ5JjryW63szGrjLKaRnoEefH6nC1cOr4nk/qHM6l/ON8sz+Dr5RkMjeu4c3RzNnHlxAQ+XZTGCX3DMBkN5JTW8sqszaQXVvPweYPIKq7hwS/WMigmgBP7h9Er3PeA8w0ej35cnU1uaS1//2A5UwdEcsNJvfc7h1Z3d1hJkCUr1vP6u59hs9m54sIzmX7apBbLN29L46kX38Hc1MRpJ03gusvPOej3vnZSbzbnVXL2iB7c8b+VrM8sJbe0lrNHNA+N3leNuon9wju998uR0CPIE38vVxZuKeDE/mGsTitxNJbu0SfSj6cuHsoV/1lEdklNmzebVpudd+Zv45cNeQyPD+LGqYmOiQDrGi3klNSyq7yepdsKeWvuNiw2G0aDgStOOPzJmqTzVdaZ8XJzOuaD2uaccvpEHtyw/e4ixNedcH930gurue3UI1smpivxcHXisQuH8NniNIB9ljII8nbDbrdTWt3giGF7FFXW88R3G7h0fE9cnUy8PGsTqQU9sFhtNDRZSS2o4vbT+rXoHTh1UCS3f7CCqnozPu777uXy6uwtVNaZm+tHxwby0LmDjsvGZDkydhZUOUqU7Emw3XxKHxqbbFhtNp6bkUJVfROvXD1KnROOE+H+7sxNbi6HNT85n9fmbOHCMbGsyyhtUebC18OFZy4dzvIdRUzsH4bdTpsJ4tOHRPHt8gzSC6tbNR4u2V6Ih6tTixIUIb7uXDAmjk8XpRIV6MmsdTlcfWLHzZUgx6fkrDJG9gpmfJ9QbHY7+WV1vDRrE+4uJr5clk6onzuvzNrM36YmcmK/cJydWn/PHkyJNoPB0Kkl77qK5s928+d7f6XGuooIf3d+3dj2iLd6s4Vxu+8FDQYDN05N5KWfLfSN9Gsxx91fnTEkmv/7Zj11jRamDoygf7Q/Czbt4qe1OTx9ybA2O7HsaSwblxjK/JT8o5IEsdntzFydzaSk8GPidyf7tyq1GBcnIyt2FuNsMtI/2p8gbzcsNhtB3n92KFiXUcqsdTm8dOXIFvFuyoAILFabo8NDW04aGHFUy7d3NCeTkeevGMmOXZU8+Plaeob6MKid8212hs05FfQM9XZ81zx6wRBenbWZi19ZQKC3K9dPSaTnXvdbAV6ufHbbxDa/17qqcYmhzFidTXZJLUNiA/hhdTZZxdVEBniyPb+SwbEBTBv+Z2L5/NGxnDYkqsM7IJzQN4wP/9jJD6uymL0uh5LqRs4ZGcMTFw3Fw9WJYfFBTOofzsy12cxYnU1uWR3PXT6CWFW5cahpaGLx1gJeuHIkNpudp3/YSGKEL5PaWSK5O2j3XaLFauW1dz7jP889iJenB9f8/WEmjhuOr8+fH/gX3/iQxx+4lbiYKG78x2NMHDechLjo/bzrnxLCvOmzOys+vGcQs9flUlRZf1Rquh4NBoOB6yf35pXZm2lssuLr4UJcSOsPs8FgICrAk9zSujaTILPW5bAuo5R/Xzac+cn53PbBCq4+sRf1Zgvh/h4EeLsybVg0L8/azLD4QC4aG88/P17F9OE9dCPWhe09EVSTtTlx9fKsTSzcXMDQ+EAePnfwMfVFW1rdgLuLE6/N2ULPUG82ZJYdl4m4v52USICXa4vSEMcDdxcnrp+SuN91nExGgrzdKKiob5UEmbkmm5EJwY6J4gfF+PPanC0YDAZ2ldfh4mRsVX4mOtCTXuE+/LG5gOl71R3fo6Cinie+3cANJyXSP9off08X7vtsDd+vzOKCMbHYObgGGZH92bmrqtXcPv6ef45k3VNCSY4f4X7uFFTUYbfb+WDBDk4aGMEPq7JwdTY5Jp/cw83F9OdDzD7Cka+HCycNjOCd+ds5ZXCko6RAXaOFb5ZncOaw6Fax7LxRMQyPD6K2sYmnvt/IpePjj8oouCaLjdKahg6ZQFSOniaLjS25FVw/JRF/T1cuHBPH9vxK5qfk8/BFg3np503c/sEKzh0Vc8xNjivtExHgwa7yemx2e4v4syGzlEGxAS06c5mMRu6ZPuCA79kn0pc+kb5sya3AYIB+UX58syKDayb1OuAIvKQe/rw5d6ujAkNneu+3Hcxck02jxcpFY+M7dd/S8VanFnPeqFi+WpbOtrxKRiYEYbHaqa5v4qWrRlJQUc+ni9NYn1HK305KbFXW+Xie36B3uC/XTu7FK7M388Z1Y7psQntLXgX9ovwcP8cGe/HSVSPJLqklwMu1zZJex1K7DMCJ/cPIKq6htqGJ53/axNSBETx0zkA83ZypqDXj5mJqEbsNBsMRKZ/qZDJy8sBIPvxjJ+eOjOHskTEE/KXij7+XK1dN7AUT4bPFaTz4+RrOHRXDmN4hBzWfYVFlPf/6ah0mkxGr1cZNJ/dp14TzXdVvKfnEh3o7ysxfNDaer5alc0K/5tE136/MJD7Uu1ud84G0O7Js2ZZGXEwkIUHNWdrRwwexcm0KJ08aC0BxaTkWq42E+ObGpZMmjmHpyvUHnQTZ27D4QL5dkcml4+MJ9D5+GgdH9w5hUlYZb8/fztkjeuyzF2hUoAc5pbWtXrfb7cxel8Ol43vSN9KPvpF+DIsP4sM/dtJosWK12ekb6cf5o+M4d1QsBpoDWN8oP+ZuzDvghM+VdWY+XphKXlkdT148VL2jj7CGJitWq42VqcV8uTSDO8/oz5bccj5bnE6fSF9Kqxt54/oxvPTzJj5fmtb8ZXCMePCLtRRXNeDp6sS6jFIazBYGxhzaxIzdwb5qtkuzUD93CitbThjc0GTl1415PH7Rnz2kY0O8eemqUUBzmaxteZVtJiymDoxgxupspg2LbhVfV6cW0zfKzzEMGOCGKb155odk1qSX0Dvc54CJG+l4drud2etzSc4q447T+3fZB6SDYbXZSS2oOuz5faR7CfVzp8liZ8euKqrrm7h2Ui9W7ChiSFxgmyM9DsYFo+P4eFEqL/+8iSGxgfh6OPP8zBQCvVw5vY2e1SajkfhQb+x2O67OJrbmVnZ6r0y73c7LszaxIbOMj/5+gmMCeDn2bN9VibuLEz2C/myM6B3uw+vXjiY22Iu3/zaOsppGIg8wH5p0HyG+7lhtNkqqmkf3llQ3kF5YzcbMsnb3TjUYDDx24VA2ZJby8qzNbMwqo6LW3OZcWn8V7ueOr4cL2/Mrj/hccaXVDWzMKiPAy5WaBgsLNu3i6hN7MXdjHheOidOoz2NYXaOFLbmV/OPMJEprGkkI8+adedsxGQ24OptYsHkXP63JIcTXjRunJnJC3wP/bR5vTh0cxZKthXy9PKPLjkLdklvBZeNbJiwNBkO3mmPX39OVO8/oD8Bdf1nW2XMnnTEsGpsdLpsQf8BqJ5eOjychzIef1+Xw+ZJ0XrpyJLEh3vucGgDg53U5hPi6c+awaHaV1/PkdxvpF+XH+aNjj/m5Q+12O3PW53LhXiWVJyeF88OqLD5emIqXmxNfLcvAxcnIa9eObjFarTtrd+tBSVkFwYF//lEEB/lTXFL+5/LScoID/VssX5+8rc33+nbmPL77aR5AmxM79Y/25+lLhjkmyz2e3Di1D6cOjiLQe99znEQHepKc9ee1L6iow8PVicyiGqrqmxxDiqG51MzYxBC251fyz49X0Tu8uVfh3g2EZw6N4t3fdnDuqNg2H7i35lWwcmcxv2/Kp1eYL5V1ZmasyT6uey4caZV1Zh75ch0VdY2YLTYG9gjg/s/WEBPsyR2n92N+Sj73nz2QHkFeXD85kSe+28CFY+Jwd+n6DYRFlfUUVNTz4DmDSAjz5l9fr8fN2dTtJmM9UJyTAwvzc6egojkJsjWvgtnrchmbGIKfhwt9ItounzYsPmifyaXxfUJ5Z/525iXnc2L/sBY9ndekl7TabnBsIIkRvtQ2WpiXnM8VJyR0eo9BaP77eer7jZw0IILRbUwq2l0UVNQT5O2Kk8nIrvI6jAYDc5PzmJ+ST6ivO09+t4GnLhl2zDUY1DQ0sTa9lBBfN4wGg6NnTnehWHd4XJxMxIV4MS85jzA/d7zcnLl+Su/DmsgwyMeNf5yZRHZJDeszS/FydWJ7fiXv3Dhuvx1YDAYDA3r4k5Jd1ilJkJLqBowGAwFerszZkMumnApcnU2sTi3ZZ6lE6fo2ZJQyoId/i1ht2Cv2ebg6HXMJbcW5w+NsMhLi686u8nqcTEYe+GyNo5PLXWf2P6z37hflR01DE6/M2sy04T0OahSbwWAgKdqflOzyI9roNWtdDu//voPYYC+KqxoorzVzz/QkRvcK4ZvlGXywYCdJ0X4M6BFwzH0mBDbnlhPq60aIrzu3n9Zc2nhdeinBPm5EB3ny2pwt9Arz4Z/Tko6ZOQY7O9YZDQYuHBvHCz9t4vIJPbtcJ9uS6gayi2vou9dIEDmy/D1duXLiwVUIMRgMjOoVzKhewbw7fzuv/7KVilozhZX1TE4K5+aT+7RoH2tosjJ3Yx4PnjPIEfv7RPqyLr2EJ77bwN3TkhjVK4Qmqw0Dx978islZ5VTVN7WoOuBkMvLgOQP5x8er8PN04YmLh/LL+lxe+nkzT1489LiodNElvl3Pnz6V86dPBcBisTDhjKtbLDcaDMd8Fu5wHCirHBXoyez1uY6fn/0xhZhgL2x2O5OSwtv8kk2M8OWisXGM6hXcatmoXsG8M387q1OL22xg+3xJOjabnStP6MWUAeFsyinn8W83cNKACJXQOkLe+GUroX7uTBkQQUl1A9dN7t0io31i/z97TfWP9iPc351PF6fh6mSioKKOe7vwJOIbs8roHe7j+Fu8fnJvGpqsR/moOt6B4pwcWLifBxnF1RRU1PPYN+tpstrYmlfB6F7B7WoId3dx4poTe/HZkjSyS2ocIzsam6ykZJdz/eTerbZ59IIhGA1w6/vLWba96KjU00zJLmfFzmLqGi3dLglS29DENysyGZUQzENfrqVflB8DYwL4ZnkGAHY7vHTVSEJ83LnmzcVHvMGiI23Pr+SLpekUVzWQVVzDsPhAhsa3v3d/V6VYd/h6hfuwcEsBg3b/bU9O6pja30PiAlm+o4jc0louHhd/UJ0NBvYIYH5Kfofsf39Wpxbz3MwUzBYboxKCWZ9ZykPnDmJLbgU/rc0mJtgTb3fnfc7h1B3tXfr0WNNksfH9qkySov2Zl5LPLSf3PdqH1KEU5w5fuL8H+eV17CyoJNjXnb+dlMjs9bmHXf7OxcnEoJgAahosXDgm9qC36xPpy5q0ksPa9/7MS87jk0WpPHnxMPpF+dFktZFaUEWfCF8MBgN3T0ti0dZC/rdgJ/VNVu6ZPoCk/cwLIV3PpuyKVp127ztrICaTAaPBwOlDDr0iytF2NGLdwJgAnE1G1qaXMKpX13nOSS2o4v7P1jCxf1iL0rXSNV04No67d5f5HxoXwFtzt3HdW0u46eQ+jlFYH/y+g8gAzxaf28QIXxIjfIkM9OSlnzfj476D8lozQd6uvHTVKBot1mPi92+z2/lo4U7OGBrdqj04OsiLD26egKebE0aDgZggL+743wq+Wpp+VObG6mztToIEBfhRXFrm+Lm4pJx+iX9esKBAf4pLy1ssDwr0a+/uZD+iAz3ZVV5Pk9VGQUU9qQVV5JY1l8d65tLh+9xuX3MumIxGTh8Szcy1OYz6S+Oi2WJlS045r1w9ylHDckCPAPpF+fHKrM3NdfQvHnrUhlLVNjSxcGvBMXmTsS+7yutYlVbMezeObzFXxL6G9BkMBm49pS+vzt6C1WanuKqBHbsqiQrw7JK9ijZmlbVoxBwSd/zUI5RD0zPMm3kpeazYUURihC9J0f58tDD1sBIBpw+NJtjHjf/O2851k3tjMBj4aW02IT5uLSZS32NPg/XkpHAWbyvolCTIjl2VvD5nC/84M4mYYC8+X5LGaUOimLcxj7yyWnJKaqmoay75cCyM/tqXJouNx77dQF5ZLd+uyOTUwZE0WWxsy6vg3ukDcHYyYrXZ6bH7u+fUIZH8sCqLxAhf5ibnMSUpokvGuD0Wby2gpqGJCX1C6R/lx+z1udw9LeloH5Z0Qb3DffllQ16Hl1YYEhvIN8szSYre/wTDexsY48+bv26locmK2xEa+TZ7XQ4fLNjJHaf3o0+kH18sTWfasB4Mjg2kR5AXyVnl3Pzucmx2O6cNieKGKb2PmV607VVW08g9n6xidO8Qrp3U64AlILqSmoYm/vXVOsprzXyxNJ1AL1eG91S5T2kp0t+D3LJa6hst9I30ZURCMCMSWnfOa4+7zkjC2WQ8pM9NXIg33yzP3OfyrbkVxIV4t2vi3+r6Jj74fSd3nZHkmEvA2WSk717zee45f7vdzs/rcnjsm/XccnJfvNyciA/17rYlwdeml7A6tYQrJyZ06Xu4g5GSXcaZw1q2QRxrc0F0BUaDgdOGRPHGr9uw2WFMF+nwtWDzLsb3CXWUiZKuzdfDhXdvGu/4+alLhrFsexEvz9rM1twKSqsb2bS7XbOtDicn9A1jQLQ/WSU1+Hm48N9527n+v0uorm/i7JExXDOpV5ccNdFktWEyGpi1LoeKWjPnjY5tc729567xcHXigXMG8eAXa/Byc2ZaG/OlHqva6lDU7m+afn16kp6ZS1FJGV6eHqxYs5FrLzvbsTw40B+T0UhqejZxMVHMX7ic+++8vt0HL/sW5OOGs5OBvNJaFm8rZEzvELJKarDboWdo+8psnDI4ktnrc3jp583cdWZ/xwd8a24lnm7OrRoHL5vQk/s/W4O/pwsLtxR0WmmsPcMy9/xhz9mQy4d/pBIX4k2fCF+Wbi8i2MeN3uE+jnWOZs+6erMFu52DusmrN1v4ZUMei7cWMC4x9JAmy+4V7svr147GYDDwzvztPPLlOmx2O/+7ZUKXKjNlt9tJzirj7mkHnvBQJCHMh13l9axOK2FQbACnDYmiss7c4iGyPQbGBFBR20h2SS2pBVV8sTSdf186fL9xYkCPAL5dkdlqUs+OlltayzM/JBPu586Dn69lQIw/pdWNPHLeYOrNFm58ZxkBXi74ebgyY3U2L+/uoZJWWM3QYyyhuHBLAZV1Zt67aTzLthcxrk/ofhtdzxgazZ3/W8llry3EbLHRZLFxbhcuy7gpp5yzR8RwYv9wCirqWJdRytD4Y+t3JJ0jcXd5v45OgvSL8uOyCT05a3iPg55jI9TXHX8vV7bmVhyRTgp5ZbW8+9sOnrpkmKNxcE8ZEYAAL1f+fdlwbHY7hRX1/PvHZF6fs5WpAyOw2uz0i/I7KmUJj6Qmi42nf9hIfKgPq1NLCPJ245yRMUf7sA7a499uwN/TlWcvG8FHC3cSF+Ld7Ua8yeHrEezJ8h3FNFms9O/gEQ9tTUx8IHHBXpTVNFJZZ25V2aC0uoEHvljDmUOj2zUf3I+rs+gV7sPIhAMnAw0GA9OG9cDJaOTr3aNgS2saefuGsTRZbYT4uh/y/ruq6vomXp61GV8PFx76ci0vXTnymB39VtPQRGpBtUbvdJALRscS6OXK63O2sGx7UYv2qKPBbrezamcx109pXSVAjg0Gg4FxfULx9XDhjy27iAz04PopvfcbU/29XPHfPRH73dOSWLq9iKRoP/49Ixmb3c4NXWx+0CaLjTs/WonFaqO0upFHLxh80B2Y4kO9+b8LhvDQF2sZ0MOf2GOwXLPdbqe6ockxaryxycojX63juctHtFiv3UkQJ5OJ2/92KX+/92lsNhuXX3gmvj7e/OPh53ngrusJDvTnn7dexb+eeQNzUxOnThnXrknR5cCMBgMDegSwNqOUPzbv4vopiZgttsNq7Pf1cOHlq0dx2/sr2JhZ5njwXZ9ZyuDYgFbv2zvcly/vPJEl2wr5fmVWpyVBXp29BaMBbj+9P1abndnrcokN9uLLpen0ifBl5pocrHY754+K5cT+Ybz08ya83JwZ0zuE5TuKuGf6gE57eP5scRrfrczEbLERHeiJu4uJHkFe3HRyH0xGA2kFVUQHeuLp5sxPa7L5Ymk64f4ejO4dwtSBh14KY8/v6IIxsQR5u7J4WyELNu9i2rCuk9nNLa2lpsFy2I3Ycnzw9XAh1NeNjVllXDQ2bnet/MO/+XB1NjEoNoBHvlqH1WbjwXMG0Su87TlG9ugZ6k2T1UZOSe0RmwgvOauM//tmPWcMjebaSb1YvqOI2etzefDcQXi6OfOPM5O4fnLi7qGs8NAXa7ntf8sprmwAA9x6Sl9+S8nnknE9O3VS4/KaRpKzywnwcmFAjwPv12qzU9vYxIw1WZw9IgZ3FyemDDhwzAvyduP9m8ezLa+SirpGPvwjlbTCak4ZFNnlSmTVNjSRXvjnw3GYnwfv3jjumH3YlyMrKtCTUF83eoX5dOj7OpmMXDIu/sAr7uXPeUHK20yC5JfXsWRbIReOiWtj6wP7fEk6k/qHORIg+2I0GAj39+DRC4Zw36er2ZRTjsVqI6mHP+ePiqWizrzP+Z+6oo8XpuLt7kywjxvJWWVcfWIv1mWU8s3yDHw8XLBYbdw9LYnVaSV88PsOpg+Ppslix2KzdanOLH9VVFnPtrxKvrzzRJydjB3yHS3dU48gL75cmgHYiTiMOY86iqebM6G+bszdmEdmcQ03TEl0TAD84+psYoO9mL0+lzOGRu93jiazxcr/fbOBfpG+9In0Y0APf5ZuL+KKCT0P6Tv/tCFRjhF7T3+/kYe+XEt2SS3XTe6936So1WZjx66qLvFstadCw6mDo0jJKqdftB/OJiNWmw0w8NbcrSSE+XD/2QO57q3FrM8sY2hcIOU1jY6Gx67MbrezNr2U9MJqbHY7fSN9u1WS6mgyGAxMGRDBsPgg7vl0FV8sSeeyCUenTM/XyzJYuLWA0ppGBsWq89KxLqmHP0ntmGs6yMeNs0Y0t6M9fuFQ7v5kFb7uLtQ0NLFkWyGnD43m/H2MujjSrDY7Xy/PIHVXFU5GA2cOjSE60POQz7NPpB/TR/TgtTlbePEYSEpvyCylpsHCwBh/PF2dmLM+j/d+285F4+I5aUAEny1Ow9bGXEaHNeZwwphhTBgzrMVrLz15j+PfSX0T+PzdZw9nF3KQRiUE8+niVKw2O8Pjgzpk6KW/pyuTB4QzNzmPIXGB1DVamJ+cz2179dDbm4uTiTG9Q3jjl61kFdccsYZB2J2NTy1m2Y4iDDQHs7IaM3bgX+cP5tGv15NfVscTFw/FANz72Wq+XJbOCX3DSMkuZ016CVEBnrzw0ybuP3vgPnuoLdi8i13ldVwyLr5FEEjOKuN/C3Zyz1kDDurGvbq+ia+WpfPs5SOIDPAgOaucJouNXzbkcsf/VuDl5kx2SQ3Q3Lt57sY8/jktiaFxgYcdfPw9XTl3VCy+Hi58tzKT04dEd5keeRuyyugX5aehwnLQeoX7UlzVSO8DJCkO1QVj4tieV8mUAREH1YPQyWQkMcKPzbnlRyzW/bQ2h3NGxjhKF45NDGVs4p8TmxkNBscDOsC9Zw1k4ZYCxvQOYWNWKa/O3kJssBfP/LiRl68atc+H9iarjVlrczh1SNRhl7vZkFnKU99vJDLAg4KKekJ93alpaOL6KYmM6R1CXlktdY0W4kO9Kaio58fV2SzfUURFrRkfd+dDLi+2J4Fltdn4bHE62/IqqWu0dLkkyNa8SkJ83VuM6OvqN5Zy9JiMBt6/ecLRPgyHgT0C+GVjLm/8upW4EK8WJUc/+H0HK3YWkxTtf8BEBtBi9FxlnZnFWwt598ZxB30sAV6uvLM7gVha3cBN7y5jTVoJNpudxy8aut8e5fnldbg5mwjooMa1PSUHDrV36pJthcxal4PNbsdmsxMX6s2FLy/AzdnE+aNj2ZpXwYPnDMLV2cSY3sF88PsO3vh1GylZZQR4ufLsX3q0dSUp2eX0Cvc55svayJEXE9Q88gIgIuDoJ0GguSTWJ4vSCPZx458fr+Tlq0eRU1LLnPW5PH3pML5bkcnvm3bttzH2x1XZVNQ2smNXFb9uzCM60JOCirrDGkl39aRevDAzhTtP78/b87cR4e/R5ryeAD+vzeXd37bz+EVDW4wIzimpYX1mGf2j/Oh5kAn2DZmlfPjHTooqG0gI82FivzDyyuqYMiCcyIDWJWP3ZrfbeXPuNhZuKeCPzQVsya1gYA9/TuwfzqeLU7HZwGiEV68ZjZuziTOHRvPhgp0s2VbIvI15vHz1KBI6uCNAR2qy2PjPL1tYlVqCm4uJ0uoGHr1gyNE+rG7Hz9OFh84dzD2frCIhzGeff/dHSmWdmW9WZDAuMZShcYFHrCyoHFvC/T341/lDePCLNfSP8ueyCT15a+42CivriQ32YlRC8CFVcTkUmcU1/LF5Fy5ORlalFmO2NI8QzC+rI6mHP1efmOCYtqA9Lhobz28pu1i6vajFhOpdTb3ZwvMzUzAaDJTXmgn3d6em3sKlE3qyJq2EzxanERfixSPnDW61re5Qu4mRCUG88etWTh0c2aENylMHRnL7Byt4d/52iqsbCPd33+9QXncXJwbGBLA2veSIJkGe+SGZNekl3DS1D15uzrw6ezPQXOsvxNedt24Y22L9Jy4ahoerE7HBXuSV1VJc1UB8qDf3frqG+z5bTUFFPW9cN6bF8Ofskhre+GUrHq4mlu8ooleYDzef3JfPlqTx89ocgrxd+T0ln8v3MbfK3pKzyogK9HT0ytkTUCb0DWVuch6FFQ08dckw5m3M4+3523n43EEd3qNxfJ9QvluZyQs/peDn4cLF4+KP+kT2yVnljolfRQ5G73AfCirq2lWTeX/6Rvodcq+5/lF+bMou5/Qh0dQ0NLXqnftbSj4JYT7tioXltY2sTi3musm9DnqbAC9XR+/AEN9IrFY7k5LC+XRxGo9/u4F/TktqsyzJjNVZfPhHKqvTShiZEMzkpHCcnYws3VbIrxvz6B3uc9C9eX/dmMeZw6K5amIvKmrNrNhZBMBLP2+iV7gv2/MqMJmMDIsPJKOwmrhQb+6dPoCeod5YbPZ2P1yYjEbeumEspdUN/O3tpZTVNHZYQ2dH2JBZysB29DoS6QoG9PDnldmbyS+rY+m2QhqbbJwzMoZNOeWszyzl1MGRfLIodb/z0AHMXp/Dp4vSmDYsmh5BXjQ0WekZ5k2o36H1nN2TQAz0duOmqX1oaLJiAJ7+oTnh21ZP3Or6Ju7/bA2B3q68cMXIVnGwrtFy0A33Nrudt+dtY+7GfGx2OxP7hdHYZCXUz51Lx/V0fD/tnfCx7E6Y1Jut/HfuNm49tS9+Hi7Umy2MTAimuKoBD1enVt8jJqOR+84eyOx1OUxOCuf7VVl8vTyDxibrPuf2O5qSs8oYGKNYJwfm7e5MgJcLjU02fNpRvupIiAvxJjm7nFevGcWrs7dw/2drKK5q4Popvekd7svIhGB+XpfTKglisdqoqDNTVtPI18sz+L8Lh5AU7U9RZT03vbuMQTEBh5UYjPD34KWrRgFgMhl4dfZmXrt2dKs5OCvrzHyxNI2J/cJ4+vuNGAzNc9jllNSyLb+SyAAPft+Uz8tXtV0D/68+X5LOgB4BnNA3lIVbCvh+VRaR/h7c9sEKzhsVy9jEELbkVjC2dwh2mufE8PVwYWBMAMu2F7E+o5QnLhrKBwt28PzlI1iweRdzNuRywZg4/DxciPD3cEwwfNaIGOrMVoqrGhjXJ5RPF6fhZDRw+YSeXbIsyw+rskgtrOY/142myWpjfnL+MVeG9lgRG+zF7af148WfN/HkxUM7vCPc/ny+JJ1+UX6aB0RaSYzw5ZO/T8TdxYTBYCDYx42VqcUs3VbIxwtT+ceZSYxMCOqQTm/phdX4eDgT4OXKq7M24+xkxMfdmbNHND/3L95ayOMXDSHM7/A7FLg5m7hsQjyfLkplXGIIBoOhyzxXr00vYUtuBacOjmJ+ch5hfh48f8UIGpuszFyTza7yei4YHcuFY+LabJvZQ0mQbiLQ242pAyM4bfDBTXR5sKIDPbn99H6kFlTh6mTi1lP6HvCDPDQukJWpxUesNntJdQMrU4v54ObxjkniBscGUNdo2WfGde/eiZEBno7eK49fOISvl2dQ02BhVWoxi7YWMiQ2gKr6Jn5em8PZI3pw+tBoNmaW8dXyDG58ZyluLiZeumokuaW1/G/BTi47iOHNG7PK2mzsdzIZW/SonDa8B6N6BR+RobSuziYev3Aor/+yhW15lUT4ezgmPaqsM/PfedtwMRm568wjP1Gv3W5n1rpc1meUcuGY2CO+P+k+Th0cdVgToXeksYkh3P3xKmavy+G/87Zz3ugYrjwhAYPBQF5ZLa/N2UJStD9PXTLswG/2F4u2FNAvyq/dNzNGg4HThzbHlmsn9aK8ppH7P1vDWSN6OBrOrDY7v6Xk8+XSDB69YDBLtxWxYHM+v6XkU93QhIerE6N7BfPDqiwuHBvnqK+5Lza7nY2ZZUzb3ePCz9OFU3d/Jw2PD2LOhlyum9SLAG9X7vjfCoK83bh7WlKHTfhrMhoI8XVnQA9/Plucxt9PPfD3VWdZm17K5UdpGL/I4Qr1c6dnqDdnj4whwt+DB79Yg9li5fuVWVxzYm9O6BfK5a8toriqgeB93IfVNDTx6aI0ThsSRUZxDT+uzsbLzYmpAyMP69j2Lp2XWVzD499u4PkrRuDu8ucjjsVq46WfNxEX4kV+eR23fbCcmCAvrpnUi4VbCpiXnE9hZXNnmL/OedeW9MJqFmwu4MUrR2I0Gpi5OosAfw+25FZw/dtLGB4fRFZxDRV1Zu4/eyBv/rqV9MJqnExGogI9iAr0YEKf0BbxaX/3fYkRvo55YmoaLXy+JA3sMHVgRIc88HYUu91OcnZ5izldRPYnJsiLmgZLl/munjIgnMQIX7zcnLnj9H58uyKTUQnB9N39HDk0PpBXZ28mOauMQG9XIgM8WbilgNfnbKGhyYrJaODaSb0cpS9DfN25/bR+Hdp4NKl/OCnZ5Tz69XqevWy4o5GnpqGJR79ex+DYQO6elkRKdjkAs9fnMiQukPvOHoirs4nr31ri6PSyP9X1TWzLq+Te6QMI8nFrUSY2taCKd+Zv55sVGQR4ujIvOY/S6kYCvV0pqW7E39OFyjozN0xJZEhcIK/HjQFwXMe2eLg6cd3k5vkWCivqueHtpbi7mJi9PpdbTul7OJfsiNiQWcqZQ6MdbREH0ylS2m9C3zBKqxsd8xVcMCbugJ3XzBYrLk7t7zS3Jq2E3zfl88rVo9r9HtK97Z3cHhgT4KhE8FtKPq/O3oyHqxPjEkOx2mxszatkUv9weoX7EBXgQb3ZioerE6U1jaQVVBHg5UpqQRVnj4xpMcK4pLqBB79YQ5C3GyMTgqmqN/Pm9WNblPQ/sf+hVVI4kEn9w3n/952kFlRRVtPIU98n89C5gzp9JNbeMoqqeer7jfSL8ts9mhoeu3AIRoMBdxcnLhrbstzv/krHKgnSjdxx+pHJUE/qH86kQ/hgDY0P5IMFO2losuJsMmKz21tMwGm12ckqriG+nZO2L9laSFK0v+OmA5oDUHt62IT4uvP3U/vxxZI0PlmUis0OBRV1hPm68+TFQ+mz+8t1UlI4CWHezFiTzdUn9sLLzZkwP3demd08DHZUr2AKK+r5dWMeYX7unDzoz4d6u93Oxqwyrp10cBNpHclaokE+bjx24VB+WpPN8p3F9I7wJa+sls+XpBPu505KdjnXTu59xEeIrEkr4fMladx2Wr8Dzr0gsrf2ftaPhLgQb/pG+fHm3G1cNDaO3zftwtfdhWnDe/DO/O2M7xPK6rQSNuWU73eiRKvNxgOfr2VgD39HUnXFzmLGJXbMEFST0ci9Zw1kybZCPl+SRs9QH+an5NHQZKOosp47Tu/HiJ7BjOgZTJPFxuu/bKFXuA9nDo3GYDCwJbeCuRvzOH/0/mv+ZxbV0GS10Tu8dfmCIB+3Fr2Wn7t8JK7Oxg5LgOzt76f244HP13DJq38wLjG0VQnHtiY9PZKKKuvJL69jcCfOyyLS0V6+epTjoeyGKYms2D1B6J4kRr8oP1alFnPG0D87dlTWmVmTVkJkgAc/rc2hZ5gPl++OcXM35vHanC0d+kD1t5MS+ddX65p7cJ89EGhOzr740yZKqxt58pKhjoa9+Sn5XPvWEgb28OfKiQks217Ij6uz+PupB27AX51azJDYAMd97O2777+bS7WWsGNXJUnR/qzYWcTdH6/i9KFRPHTuIKrrm5ibnM9pQ6La3eh7xYQETv9/9u47vK3ybAP4fbSnLdny3iPDTpy9JyMhYYW9KbNsKHRQWr7SltJCoS20ZW8KZZRRyirQMAMJIXtPx3svydrznO+PYytx7CS248S2fP8uuOxIOtIrWX599D7v8zyTM/HSV6VYvqVuSGWD7OwoR9ibsmhEAJCTZILDGxzsYUSlWgzRwKJJp8ZVJ3TNxrUatchPMePu19cjI8GAy+cX4O8fb8fPzizBxJwENLb7kHdQ1sJAL04BwC1LxuIXr67Dp5tro304n/t8D0w6NX565ngIghBdjDu4POgl8/Lx6Mc78OvzJ8HlD2NnjQOj0+MwvaDrXLyhvAU5ScYeNxgWpsbhocunQ5IkhCIifvvmRkybaMNl8wsQFiW8sbIM9XYvThiX2q/nl2LR44kfzobDE8Tv/70J1508ZkiVTg6FReyqa8dNQzA4E8vOnpGDokwL1pY241evr0ea1QCFIGBqQSIun1/YJcNzS2UbfvPmRtxx+jgsLO77+/Cp/+3C/7bU4talRUcs/UZ0sJNL0rGgOBVrS5uxbl8LFAoBJ4xLxaeba/DGyiDaO/7umfVqhEUJ8QY1HJ4gTDo16uxe3LKkCJ6AXKYiWoUAAP8lSURBVO6ptMGJqfk2NLb78PWO+mi51GNJo1JiZmESXv22DNuq7Jicl4D31lYe9yBIZbMbn2yqwbgsKzaUteCEcWm4bWkRlm+pw7gsS79/N4fGShLFlHSrAbY4LV79Zh/Wl7Wg1RXA5fMLolkH73xfgVe+LsVj187uV5mYr3c2DHjGy8xRyXj12zJcdULhIRf6smymLh+ONSolbjplLP70/lbkJJmwr8GJsRnx+GRTDU4YlwqNSol2bxDf7WmCNxBGyRAqhTJzVBKe+2IP/u/19ciyGbGwOBWXzS/AL19dh693NGDZtGPTPF2SJAiCgLdWV+CcGTn9OikhGkounpsPrUqJS+cVYFq+Db96Yz2+3tkAXzCCn545HklxOry/ruqwQZBPNtWizR3AZ1vrsHxrHZZMzMCOGgd+PMCp15NyE/DQe1vx7Oe7kZ9sRlaiEb86d2KXoJJapcBPDsoGO39WLh56bysWdOzC2lTRimBExKXzCroEuDdWtGJ8lhUq5ZE/qKb2sfxNX6RY9Hjkqpn4fm8zXvpqL25ZWhRdvO3cmfOXK2YclwCs2x/Cf9ZWoSgjHsYh3MyY6EgO3JW2dFJmNMur08xRSfh4Yw2+2dmIm04Zi1BExG/e3IDkOD2qWtyIM2jw8JX7mywunpCO9AQDcgewdKpKKQd8r3p8Bapb3Hhq+W4YtCqUNTrx8JUzEafXIE6vQUaCEQuKU+HwBKOZKxkJBvz05TW4cHbeETejrN3X0iWLt5MgCJg5Kin6IXHW6CR8tb0Bp03JhEKQM9VuOsoa9zqNEhkJRiydlIGH3tsKq1GLjAQDJuUmDOhuekmSUNbo6nXvAAD4aEM1FpWkH/MP5xQ7LpyTh1BYHOxh9MlNpxRBIQBP/G8X/vLhNvx82QTM7shQPjgAcqwoFQrMG5uCDeWtcHiCWLW7Ce3eIJ744ewu52U9OW1yJhocPvzkH2sQb9RgUm4C3lpdjqeum9Mls+y7Pc3dAiMHEwQBGpUS9x9QClGtFAYkOJuZaERGggFmnRp//3gHijLjUZKdgKxeZOsda7vr22HQqpA5RHrZjCSdmZFLJ2eitN6JUETEq9+WobTeiesWjYHVqIUgAI98tB0Li1Px6Mc70ODwwmrUHnbRtN7uxX3vbMK4LCtS4vVYsbMBT/5wTp/LdRJ1UisV3fp5njlVXmOzuwPQqpUdGXsSZhQmISJKsHuCuOufa/Hwh9tR3uRCcrwOdy4rwbhMKyIdDb6PV1+aBUUpuPftTbhyYSGWTsrEVU+sQFmjq98b2fvK5Qvhd29vQk6SEav3NqPZ6cffr54FQRC6bDjvDwZBaMAJgoC7z5mI3761EeOzrLju5DG4/93NSDRrYYvT4V8ry1CSk4DXV5ZFd+odSrPTj/9trsV5s3KhUytRZ/eivMmFOWMGthxOXrIJVywo7HNw5cRxaUg0adHmDnRkp2hxwzOr8N2eJjS2+/Hy16UQANx38ZQhs3sdkLNNphfYMK3A1mUh4+SSdPx3Y3W/giC+YBiPfLQd88emYN5BZR78wQj+2pE+Xpgah5pWD35z/qSBeCpEg2p8ljUa4CjKtODhK2di1e5GLJqQgTi9BqdMzMDNz63q1pB3X4MT3+xqREm2FS9/XYqfLRuPcZlWbKu248H3tiDHZhrwrDCTTo2ijHhUt3rw87NKer1QNTXfhjljknHd0yth0KgwJT8R26rtyE82Y36RHMj0BsL4z5pKXL+od71DjrV4gwYnl6ThuS/2YHdtO1rdcvDm6x0NGJUWH/3aH59sqkFNqweXzis47LwuSRLufWsj/KFItMQDUayaNSoJ/1xRiuIsK/7v9fXwBeXmhOfNzEWjwwdBQLT2OyCfKx4uONxfFqMGJTkJ+MuH2+DyhZFtM+KX50zslv2lViq6lO7KSzZjUUk67ntnExYWp2Hl7kaIooQfLCjEtIL9Pdqa2n0obXBhasGRa7+bdGqcMbV7sGQgTMlLxM1LivDh+irsbXDi4Stmdvlg+s73FdCrldGyiH21fEsd/v7xDiydlIHZo5MxOS/xkA3gJUnC8i11WLW7CY9eM6tfj0cj05HKbA5FnaXp7j5nItq9wUFr3j0hJwGvrNiHPXVOnDo5E4Wpcb06bxQEAdeeNLrLeYk/GMFnW/b3uaxp9eD7vc146qAem8ebIAj47YWT8fbqCry/tgo7ahz42Zkl0eslSUKrO9CtN0pflDY4EadX9+mce0tlG0qyrEOmjNtIZDProj/3qfk2/PWj7bj1+dUw6VQYnR6PrEQjbj+tGKdNycRjH++EWqXA08t3YWJuQrS/T6pFj731TviCYby+sgwFKXEQRQlvfVeOW5YWMQBCx4y1Yz3gwMwKlVLuK/L7S6biqf/twsLiVJw9PSeaBXe8t9JNyU/E3efIQX5BEHDS+HS8v67quPXHef6LPciyGfGr8yYhFBaxu659wAIwQ2dVlmJKXrIZz94wF2qlAoIg4KdnjMefP9gGQQCuWDgKc8ck4/pnVqK8yXXIXTMRUcRD721BdasH3+xswOS8RCgVAqbkJR62xlt/CIKAC+ccvtTLoRycZnz6lCz85YPt0Hf0DkmK03X54D9U/Kqjbv+B5o5JxlPLd6Gy2d3nLJ1/rSpHTasHz36+B/9eU4kFRalYVJIOs16NJ/+3E60uP25ZUoSyJhfuOH0cd0VTTMpJMnX53Um3GlCUYcGNz6xCvEGNH58xHp9vrcPqPU0Ym2HB26srcOm8/OhuuxmFSbjnvEkIR6RjMr6zpmfDEwj3eafujYvHYlFJOsakx0OlVODt1RX4eFMt5o1NwfItdfhiWx0yEgyYN3ZgSngNBKVCgQnZVvz+35ugVSlRlGnB36+ehTq7F3//eAeuOWn0IRf1DiUQiuDlr0thNWnx1fYG/GBhAZZM3B9IdvqCqGr2YGxGPDZWtKK2zYvnb5rXpT8BUSxKsxrwxh0nQqkU8J81lZiYkxDNIjjeCwlzxyTjsU924obFY6K77nrj+kVj8NTyXdhd147FE9LR4gzglRWlXYIgr31bhvlFKYN+XicIAhYWp2JhcSrufWsjNlW0Ij/FDFGS8NmWOvzjq71Ijtf3q/SWyxfCS1/txfWLxmBzRRse/nAbzpiShUvm7e9r1JnZC8gBk5dXlOLnZ5X0qqcKUSxIitMdsgfS8ZCTZIJGpYBeo8IPFhy5P+XhLJ6QjqeW78aFc/IgSvLi04njUofEInBGghG3nzYOG8pb8fgnO7tc98W2evztv9vxwk3zD9kX9HC8gTB+8+YGSBLww5NHY/bo5COer4XCIj7ZVIsbF4/t8+PRsWHQqnD3uRMhSRJeWbEPn2yqwaPXyDvGR6fF4+8dwfmqFjc2lLVid3073lpdDkjypimDVoUx6fG4cfFYqFWKbmV0iY6ndKsBv7toymAPA0qFoksWy7Jp2fjRC6tx5cLCaBCnr9rcAeyqbT/ihvadtQ58s0vOxlIIArRqZbc116PBT+V0zBzYiGrW6GT8+YoZqGpxY0HHzuElEzPw4pd7UZQRj/lFqchMNMIbCOOVFaXwhyIIhCLwBSN4/sZ5WL23GSt2NmB9WSt+duaxb9x9NJZNy8K0gkTE6TUw64fXQr9Rp8asUUn4cnt9tzq4h9Ps9OP9dVX48w9mID3BgE831eCrHQ3YWN6KM6dlYdWeJjzxwzlIitNh7hBaJCU6Hq5fNAZt7gDWlDbj9+9swknj0/DU9XORFKdDTasHGQel00/KPfIO4/6a088+I1q1EuMO2LW9qCQdr36zDz//51o0OHw4Y2oWTh6fPuR2xU0rsGFXbTv+9IPp0T5SSXE6hMIidlQ7ML6PZQq/3F6PBJMWj14zC2tKm/G3/+5AmyuAS+YVoLrVgx+/9D2UCgE5SSbUtXlx0Zx8BkBoxOjcrXZuR436wTJ7dDK+3dWIk/pYi1+lVHQpe+oNhPHeukqUNbqQl2zC8i11WLGzAU/8cPZAD/moTMpNxIbyFiTH6/HqN/vgCYRw11kT8Nf/bse+Rlefd6p/taMeGQkGnDk1C8umZaO8yYU7X1mLokwLSrKtuP/fW7Cz1oFTJ2dGz+XvOL0YM0cNbJY2ER2aQhAwvcCGjETjUZ97Tc23IcFUgV+8ug7t3iASTFr8aIgtBI9Ji0NTuw9t7gBEUcKKnQ14fWUZrCYtvtvb1KeAd6f/rK1ERoIRi0rS8eZ3FfhkUy3+eNm0w2a9fbihGiadCrNGD16DYOqZIAi4YmEhLpqT1+Nmr2ybCdk2eaOa3RNAuyeI3ONUwo5ouMtKNGL26CT88rV1uHNZSZ/KpXZ6+etSfL61Dg9cNg0alQKfbqrFJfPyYTPrEBElKATA7Q/jz+9vxSVzC45Zr2QhGAwcm+2m/RQOhzH/9KvwzUcvQaXiwkEsa3MHcMMzK5FtM6G2zQObWYeqFg/GZVlg1KrQ7PTj3gunwGKUU6UjooQVOxowb2zKkGqOFmvW7mvG45/sxIs3z+/1SfUrK0pR0eTGPQeUuHL7Q7jthdVweoO46ZQiLJqQfoxGPPxwnhuZJElCICRCp4mNeumlDU5sr3ZgzpjkQd0NeTiiJMEXCHfLPHv8050QANzch6aWoiTh5ue+w/kzc6PzWWWzGz99eQ3uXDYe//6+EoWpcbhsfgFe+HIPxmdZsbA4dcgFho4nznU03D3y4Ta0ugOIN2iwrdqOW5cWHbFO/vFW0ezG7S+uhkalwHUnj8GJ49KgVinw5w+2ItGkw9Un9n5TCwD87JU1OGl8Wpe+J//bXIt/fL0Xo9Li0ejw4fpFY/D4pzvR7PRjycSMPs2lsYbzHA0WqaNG/ECcZ/iCYbz5XTnyks2YOyYZSsXQ+6x96/PfIcGkxebKNkzItmLJpEzYPQF8t7upS1+S3vAHI7jy8RX4v3MnYkJOAvzBCG55/jucPSMbZ07NhssXwocbqnH+zFyoVQpIkoQH3t2CLVVt+NmZJV0yBEcKznVEI1uko1zcW9+VY35RKhZNSO91adumdh9ueGYVlk7KwAfrq6FWKjAmPQ4NDh9yk83YVmWHUaeCPxjBxJwE/OKcCX2u2NBbnL1o0CSYtHj99hOgUiqwtrQZoYiEUWlxsJm1EAShS6o9ACgVAk4c37ddfdR3k3IS4QmEe717MBwR8b/Ntbj9tK71AU06NR68bBqUCiG6A5toJBMEIWYCIABQmBo3aLWwe0shCD2W3ltQlIIH3t2CGxaP6fUH/Q1lrXD7Q1hYnBq9LCfJhCsXFuK+dzajONOCyxcUQK9RddlNTkTD19UnjsbzX+yB0xfEX6+aOehlsHqSYzNiXJYV587I6bIwt7AoFY99uhNXLCyEUtG7D5INDh9K652456CSqYsnpMPpC8EbCOPWJUWwxenwpx9MR12bt0uWIBEdPwO5yUKvUeHKhX0LmB5vYzPi8fnWevzpB9MxuqOvW4vLj+c+3wO7J9Cn+fmrHfVIidejpCMjWKdR4kenFuO+dzYhN8mEN7+rwNaqNtS1efGTM8Zhxc4G7Kx14Nkb5g27Sg9ERANBqRBw8dx8TM1PxMcba/DIh9vx6DWzUNnsRlGm5bDH/ndjDaYX2HDD4rE4b1YuTFo1tGoFVuxsgNMXwmXz8uELRmDQqpCfYj5mARCAQRAaZCqlvPg0vbD7rrqRvHt2MKlVCkzLt+H7vc2HXOAUJQkefxiCADy9fDfiDBpMye9ewudYpbARER2N4kwrVEoFNlfaMSXvyOXHIqKI11eW4fQpWd0yEc+YmoWpBTakWw2HOJqIhiuLUYOfDvEyrIIg4P5Lpna7fEp+IiRJwqaKVkzN792u5de+3YfZo5O7NZIXBAHnz8rtcpnVqB2SQSEiik3nzMjBwuLUaAAEkBtkF2da8NX2BpwzI6dX9xMRRby3tgrnzMjpst4wMTcB583MwS9fW4/iTAsev3Y2fvXGBvztvzuwem8TbjqliAEQIhrxRqXFIy/ZjGue/AY//+daVLW4cf+l01CYEoefvPw9jFoVfnRqMbI6ys9FRAlfbq/HrUvlrGHbARukFxYf/03uQy/PkYgG3YxRSfh6RwNW7W5CeZMLvmAYgHzSGAxH8Lu3N+GSv32Fi//6FWrbPPj9RVOOabSWiGggKRUC5o9NwYodDYe9nShJiIgSnv1sD3zBMM6Z3v0DtiAIDIAQ0ZCjVChw0vh0fLal7rC3K21wYlNFK77YVodVu5twzUmjj9MIiYh6LyPBiJLs7s1xF5Wk47OtddHyYEfy8cZaiJLUY4WJS+YV4J2fnoSHLp+OjAQjfnPBZKzd14xL5hZ0yQQmIhrJVEoFTpmQgRaXHxfMzsOf39/aMQ8DuclmPPCfLfCHIgCALZVtEEWpVxsPjwdmghBRNzMLk7ChrBX/WlWGeocPvkAYJ5ekY0tlG1rdAWQmGvHSLfOhVSm5I4aIhqUFxan49b824JYlRT32mdpd145fvbEeWrUSeo0Sv71gckyVMyOi2Ld0UgZuevY7NDv93Xo3eQNheANh/PpfGxARJahVCvzkjPFDtscTEVFP5o5JwVPLd2FPvRNj0uN7vM2uWgf+8sE2TMm34Yttdfj5WSVQK3veD3xgU+3cJBNeuW0hN/sRER3korn5OGViBpLidNhaZcezn+/G1SeMwhlTs/DTl9fg0021WDIpAy98uQdLJ2UOmV5TDIIQUTcGrSpa/kGSJNTZvXju8z04Y2oWphfYkGjWwaDl9EFEw9fotDiYdGq8vrIMU/MT4faHkBKvhy8UwStfl6KmzYuzp+dgTHo8SrKtXT4UExENB6kWA2YU2vCftZX4wYJCfLShGpIEnDY5Ez96cTUaHD7ML0rBT86Qz/kOtShIRDRU6TRKnDQ+HR+ur+4WBKlt82D5FjnLbXy2FU5fEL84e0KvSwQCYACEiKgHaqUiWv7+xsVjcd87m3Di+DSolAosm5aNd76vQGmDEwaNChfNyRvk0e7HVUwiOixBEKLpwEREsUIQBNx+WjH++c0+fLm9HiadCnV2L9RKBU4uSce8sSlYOjmTH36JaFi7YHYefvHqOqwpbYZBo0IwLOKLbXVQKQQ8c8NcpMTrhszuPCKi/jhjahZ+9MJqXDgnD699uw9bKtuwZGImmpw+VDV7MDE3ATcuHgulgud0REQDLT/FjBdumhftszR3bAqe+Ww33P42/O2qmdFe0ENBn4Mgfn8Av7zvb6hraIZSocA5Z5yMC846pdvtnnvlHbz/yVewxJkBAD+5+QpMKhl79CMmIiIiGgATchLwUM7++tI7axzYU9+OZdOyuzTLJCIargpT4/DIVTPx1fZ6XDA7D3Z3AD96cTVuXVrMfkZEFBOyEo1YOikDNz+7CgWpZvzkjPG4/93NiIgSHr92NjISjIM9RCKimHbgZ2edWonbTpXPM60m7SCOqrt+ZYL84KIzMWVCEbw+P66+9R7MmjYBWRndG0X94MIzewyQEBEREQ01RZkWFGVaBnsYREQDKivRiB8sKAQApFkN+MctC1jWlIhiyg2Lx2LppEwkxcllmy+bV4CqFg8DIEREg2De2JTBHkKP+nz2q9NpMWVCEQDAoNchJzMNrW2OHoMgRERERERENHQwAEJEsSgnyRT9/tyZuYM3ECIiGpKO6gy4sakVpeXVGDMqt8fr3/j3x3jv4y8xoXg0br3uEhj0uh5v9/b7y/HOB8sByE2YiYhiDec5IhoJONcRUazjPEdEIwHnOiKKNUIwGOhxNrviprsRiYjdLv/rA3chKdGKYDCEW35+Py4571ScNH9Gt9u12dsR39EP5PHnXoegEHDbdZcecUDhcBjzT78K33z0ElQq7lIiotjDeY6IRgLOdUQU6zjPEdFIwLmOiGLBIWevl5+8/5AHSZKE3/3pKcyZMbHHAAgAJFjjo9+fsWQh/vz4S/0fJRERERERERERERERUR8p+nPQky/8CzqtBldfevYhb9PSao9+v+K79cjLyezPQxEREREREREREREREfVLn/PYmppb8cqbHyIvOwNX3HQ3AODmay/GrGkT8Mw/3kbR6DzMnz0Vjz//Bvbsq4QgCMjOSMVdt1874IMnIiIiIiIiIiIiIiI6lD4HQZKTEvHdp//s8brrrzw/+v1vfn5T/0dFRERERERERERERER0lPpVDouIiIiIiIiIiIiIiGioYxCEiIiIiIiIiIiIiIhiEoMgREREREREREREREQUkxgEISIiIiIiIiIiIiKimMQgCBERERERERERERERxSTVYA/gYJIkAQDC4fAgj4SIqG+USiUEQTji7TjPEdFw1dt5DuBcR0TDF8/piCjW8ZyOiEaCA+e6IRcEiUQiAIATz/rhII+EiKhvvvnoJahUR55WOc8R0XDV23kO4FxHRMMXz+mIKNbxnI6IRoID57ohFwTRaDTIzkzFP596oNdRaQC4/MZf4p9PPdCnxxrKxxzPx+Ix/BkNh2OO52P19xilUtmr2/Z3njuasfEYvk95zPF/rFg8prfzHMBzuqM55ng+Fo85vo/FY4bHz+hYn9MNh9eAx/BnFIvHHM/HGurH8Jxu6B5zPB+Lxxzfx+Ixx/9ndOBcN+SCIAqFAgqFAmq1uk/HCYLQ6yj2cDjmeD4Wj+HPaDgcczwfq7/H9PaEsL/z3NGMjcfwfcpjjv9jxeIxffngy3O6/h9zPB+Lxxzfx+Ixw+NndKzP6YbDa8Bj+DOKxWOO52MN9WN4Tjd0jzmej8Vjju9j8Zjj/zM6cK4bko3Rzztz8ZB9nON1zNEcdzweZygf0x/H82cUa68Dfyf6d8zxei79fayhfEx/DPX3aay9DkP5NejvYw3lY/qDz2doH9NfQ/k5DeX3Qn+Pi7XXYSgf0188pxvax/THUH8+fB2G9mvQ3+Ni7XXg8xnar0F/H2soH9MfQ33ujrXXYSi/Bv19rIOPEYLBgDRQAxpMb7+/HOcvO34v/lDF14GvQSe+DrJYex1i7fn0B18DGV8HvgadYu11iLXn0198HfgadOLrIIul1yGWnsvR4Osg4+vA16BTrL0OsfZ8+oOvgYyvg4yvw+C+BjETBCEiIiIiIiIiIiIiIjrQkCyHRUREREREREREREREdLQYBCEiIiIiIiIiIiIiopjEIAgREREREREREREREcUkBkGIiIiIiIiIiIiIiCgmMQhCREREREREREREREQxiUEQIiIiIiIiIiIiIiKKSQyCEBERERERERERERFRTGIQhIiIiIiIiIiIiIiIYtKwC4K89Pp7+PUDjx31/ZxzxR34etW6ARgREVH/XXrdXfh29cbBHgYR0ZDW2/O2j/63AlfcdPdxGBER0cA46axrUVpePWiPz3mTiI61A+e55155B3f99pHoddW1Dbjmtntw8tk/xN+ffrXfj7Fh8w4sPvf6ox4rEcUu1WAPoK+uuuSswR4CEdGAee3ZBwd7CEREREQ0SL547/nBHgIR0TF1uHnulTc/QEFeNl549L7jOCIiGomGXSYIERERERERERERDW91Dc0oyM0a7GEQ0QgwJDNBXv/3x1i5eiMee2h/Wu5nX63Gs6+8g8UnzMLefVV48Lc/xu695bjl5/fj6Ud+jYLcLDhdHlxx09247srzcPriBfB4vHjyxbew8vsNcLo9yMlMwwP33IGU5MQuj1fX0IQHHnkeO/eUQaFQIDc7HX9/4BfQ6bTH+6kT0QhzzhV34I4bL8fCOdOwZv1WPP2Pt1FVUw+tVo0LzlqCKy9edtg56vV3/ot/f/g52uztsFricNE5S3HBWacM9tMiIgIgn7+98e7HeO5v9wIAfvm7v2Hrzj348PXHAQB/f/pVhMJhzJs1BU+9+Caqaxug02mwcM403Hb9ZdBpNT3e76HmSyKiwXKoz543/uw+nLX0RHy5cg1q6hpRUjQK//fT65GUaAUAzF5yOf7xxB8wuiAHu0sr8PATL6O8shZKpQLTJ4/DT2+5EvFxZgBdzxsB4OtV6/DXp/6Jd1/+62HHkJKciNff+S/+9e6ncLk9iIsz4epLzsKyU08clNeKiIangZjnDnTNbb/G7tJybNm+B8/84y388Tc/xowp47H8q+/wjzfeR2NTK7IyUnDHjT/AhHGjAQCffrESz73yb7TZ22Ew6HHO6SfhmsvOOe6vBRENP0MyCLLkxDl44vk30NjUGg1YfPz5tzj15HkIR8LR240ZlYdrLz8Hv77/cTz/6O9w/yPPYuL4MTh98QIAwH1/eQZ+fwDP/PW3SLTGY29ZFbQ9fJh+6sW3kJmegkf+cCcAYMfuMiiVyuPwTImIZLtLK/Dzex/Bb+68EfNnT4E/EERFVR2Aw89Rqck2PPbg3UhOSsCGzTvxk3v+hNGFuZjYcZJIRDSYpkwswm8fehIerw8GvQ6bt++GTqtFRVUtcrMzsG7zDlxz2dnQatT4xR3XojAvGw1NLfjpPX/GG+98jKsu7V4G9XDzJRHRYDncZ8/3P/kKD//+TqQmJ+KhR1/EvQ8+2WXDXyeFIODmay7CuLEFcLo8+L/f/x1PPP8v/PLHPzyqMVTV1OPpf7yNlx77PXKz09Fmb0ebvX1Anz8Rxb6BmOcO9MKjv8PNd/4eC2ZPw8XnLgUArFqzCY8++xr+9NufYFRBDlasWo87f/Mw3nzhT9Bo1Ljvz8/g0Qd/icklY+Fye1Bd23DMnzcRxYYhWQ4rwRqP6ZPH49MvVwIA2hztWLtxG5YumtvtthefeyqSkxJw3e2/RWlZFX5+21XyMfZ2fL1yHX5xx7VISrRCoVBgTGEuLPHmbvehUinR2uZAfWMLVCoVJowbDbV6SMaHiChGvfffL7Fo4SycOH8GVCoVTEYDxhcVAjj8HHXi/BlISU6EIAiYOqkYs6ZOwMbNOwfzqRARRSVY45GdkYrN23Zjz75KpCbbMHfmJKzfvAPtTjfKKmowZUIxJpWMxZjCXCiVCmSkJePs007Chi09z2WHmy+JiAbDkT57nnvGycjNTodOp8WtP7wE6zfvQFNza7f7GVWQg4njx0ClUiHBGo+Lzzv1kHNhX8agUCggSRLKK2vgDwSRYI1HYX72gL4GRBTbBmqeO5J3PliOy84/HWNG5UGhUOCEedORk5WGVWs2A5A/G1dU1cLj8cJsMqJ4TMGAPk8iil1DdqX/1EXz8OKr/8EVFy3D8i+/Q0nRKKQm27rdThAEnHP6ybjr3kdw23WXwmg0AADqG1ugUat7POZgt153CZ5/5d/40S8eAAQBpy+ej2suOwcKxZCMERFRDGpoasHE8WN6vO5wc9SnX6zEa+/8F/UNLZAkCf5AAGmpScd59EREhzZlYjHWb96BRKsFUycWY3xxIT79YhUSLPEozMtCnNmIHbv34ckX3sS+imoEgkFEIiKyM9N6vL/DzZdERIPhSJ89D7w8wRoPjVqN5lY7kpO6lmmurm3Ao8+8hp17yuD1+yGJElSq3lUoONwYMtNTcM/PbsDb7y/H7x9+BuPHFuKWH17SrTQNEdGhDNQ8d8THaWjBUy++hede+Xf0snA4gubWNuh1Ovzp3p/g9Xc+xuPPvYGCvCxcf8X5mDqpuH9PiohGlCEbBJk/eyoe/NsL2LW3HJ98vhLnnrmox9s5XR48/MTLOOu0E/GPN97HSQtmIDXZhrQUG4KhUJeSWoeSYInHnbddDQAoLa/G7b/8Iwpys3Di/BkD/ryIiHqSmmxDTV1jj9cdao4qGpOP+/70NB7+w88xZWIRVEol7vrtI5Ak6XgOnYjosKZOLMLL//oACdY4XHDWEowbW4CH/v4irPFmTJkof2j99QOP44xTFuKhe38MvU6HN/79Cf67fEWP93e4+ZKIaDAc6bNnQ1NL9Ps2RzuCoVC0Vv6BHvr7i8jOTMU9dz4Is8mIr1etw+///Ez0eoNOB78/GP13a6uj12NYtHAWFi2cBX8giGdffhv3PvQkXn36j/19ykQ0wgzUPHckyUkJOP+sU3DuGSf3eP30yeMxffJ4hMNhvPPBZ7jr3kfwv3ee7vPjENHIM2RTHXRaDU6cPwNPvfgmyqtqcdIhAhIPPPIcJpWMwS9uvxann7IAv/3jE4hERCRY47Fg9lQ89OgLaGm1QxRF7C6tQLvT1e0+Pvt6NRqa5F3UZqMBCoWCPUGI6Lg669QTsPyr7/DVyrUIRyJwe7zYtrMUwKHnKJ8vAAkSEixxUAgCVq3ZhO83bB3kZ0JE1NXkCUXYW1aFrTtKMXH8aJhNRiTbEvDpF6swrWPnntfrh8lkgF6nQ0VVLd796LND3t/h5ksiosFwpM+e//nvF6isroM/EMQTz72BSSVje9wdLfdP0sNo0KOxqRWvvvVRl+tHF+Zi+VffIRAMora+Ce98sH+uPNwYKqvrsGb9VvgDQahVKhj0On7eJaI+Gah57kjOW7YYr739EXbtLZcrHfgDWLNhG5qaW9Fmb8dXK9fC4/VBqVTCaNBzLiOiXhuymSCAXBLrljv/gMUnzIbRoO92/bsffY49+yrw8hN/AADcfM2FuP7H9+Kl1/+Day8/F/fceQMef+4NXH3br+H1+ZCblYEH7vlRt/vZvbcCf3/mVbhcXpjNBpy5ZCHmz55yzJ8fEVGnMaPy8MA9t+OZf7yN+/78NAw6HS48ewnGFxUeco4SBAFXXnwWbr3rfoiiiHmzpmD+LM5dRDS0WOLNyMvOgMGgg16nAwBMmzQOe8uqMKlkLADg57dfjb8//RqeeP4NjBmVh0ULZ+Ob79b3eH+Hmy+JiAbL4T57nnHKQvz6j4+jpq4R48cW4t67burxPm6/4TI8+LcX8M4Hy5GVmYqlJ81FeWVt9Pobrjofv/3jEzjtwpuRl5OBUxfNwzsf7g+EHGoMoXAEz7z8NsqraqEQFCjMz8Y9P73+2L4gRBRzBmKeO5L5s6YgGAzhgb8+h7r6ZqjVKhSPKcDPbr0Soijizf98ij/85VmIkojsjDTc/6sfsZQ9EfWKEAwGWDeFiIiIiIiIaICdc8UduOPGy7FwzrTBHgoR0THBeY6IhgOGS4mIiIiIiIiIiIiIKCYxCEJERERERERERERERDGJ5bCIiIiIiIiIiIiIiCgmMROEiIiIiIiIiIiIiIhiEoMgREREREREREREREQUk4ZcEESSJITDYUgSq3QRUWziPEdEIwHnOiKKdZzniGgk4FxHRLFgyAVBIpEI5p9+FSKRyGAPhYjomOA8R0QjAec6Iop1nOeIaCTgXEdEsWDIBUGIiIiIiIiIiIiIiIgGAoMgREREREREREREREQUkxgEISIiIiIiIiIiIiKimMQgCBERERERERERERERxSQGQYiIiIiIiIiIiIiIKCYxCEJERERERERERERERDGJQRAiIiIakV78ci/W7mse7GEQERERERER0TGkGuwBEBEREQ2GimYXEs3awR4GERERERERER1DzAQhIiKiEUmSgHBEHOxhEBEREREREdExxCAIERERjUiSJCEiSoM9DCIiIiIiIiI6hhgEISIiohEpIgFhBkGIiIiIiIiIYtoRe4Lcde8j2LhlJ6ZNGof777kdfn8Av7zvb6hraIZSocA5Z5yMC846pdtxz73yDt7/5CtY4swAgJ/cfAUmlYwd+GdARERE1A+SJLEcFhEREREREVGMO2IQ5KKzl+CMJQvx8fJvopf94KIzMWVCEbw+P66+9R7MmjYBWRmp3Y79wYVn9hggISIiIhpsLIdFREREREREFPuOWA5rysRiGPW66L91Oi2mTCgCABj0OuRkpqG1zXHMBkhERER0LIhsjE5EREREREQU846YCXI4jU2tKC2vxphRuT1e/8a/P8Z7H3+JCcWjcet1l8BwQDDlQG+/vxzvfLAcgLwrk4go1nCeIxp6RGaCDDjOdUQU6zjPEdFIwLmOiGKNEAwGjjibbdi8A2+/vxz333N79LJgMIRbfn4/LjnvVJw0f0a3Y9rs7Yjv6Afy+HOvQ1AIuO26S484oHA4jPmnX4VvPnoJKtVRxWiIiIYkznNEQ8NPX16DvGQTbl1aPNhDiUmc64go1nGeI6KRgHMdEcWCI5bD6okkSfjdn57CnBkTewyAAECCNR5KpQJKpQJnLFmInXvKjmqgRERERAOJmSBEREREREREsa9fQZAnX/gXdFoNrr707EPepqXVHv1+xXfrkZeT2Z+HIiIiIjomRFFCOMIgCBEREREREVEsO2Ie2213PYDS8ir4/AEsu+w2/O4Xt+CVNz9EXnYGrrjpbgDAzddejFnTJuCZf7yNotF5mD97Kh5//g3s2VcJQRCQnZGKu26/9pg/GSIiIqLekiQgIrIxOhEREREREVEsO2IQ5NEHf9ntsu8+/WePt73+yvOj3//m5zcdxbCIiIiIji1RYiYIERERERERUazrVzksIiIiouFOlCSEmQlCREREREREFNMYBCEiIqIRSS6HxUwQIiIiIiIioljGIAgRERGNSBLLYRERERERERHFPAZBiIiIaEQSJSAcYTksIiIiIiIioljGIAgRERGNSHJPEGaCEBEREREREcUyBkGIiIhoRJIkCRE2RiciIiIiIiKKaQyCEBER0Ygkl8NiJggRERERERFRLGMQhIiIiEYklsMiIiIiIiIiin0MghAREdGIJEkSImyMTkRERERERBTTGAQhIiKiEUmUwEwQIiIiIiIiohjHIAgRERGNSGyMTkRERERERBT7VIM9ACIiIqLBIIpyIISIiIiIiIiIYheDIERERDQiiZIExkCIiIiIiIiIYtsRgyB33fsINm7ZiWmTxuH+e24HAGzftQ9/+MszCIZCOHXRfFx7+Tndjqupa8Q99z8Gl9uD6ZPH4+c/uhqCIAz8MyAiIiLqBwlgY3QiIiIiIiKiGHfEniAXnb0E99x5Y5fL/vL4S/jdL2/Bv57/M75buwml5dXdjnvi+Tdw7eXn4u2XHka704WV328asEETERERHS1RlBCKMBWEiIiIiIiIKJYdMQgyZWIxjHpd9N/NrXaEIyIK87OhVCqwaOFsrPx+Y5djJEnC1h17MXfmJADAkpPn4tvvNwzsyImIiIiOgiRJHSWxGAghIiIiIiIiilV97gnS0mpHUqI1+u8kmxUbt+zqcpt2pxtxZlO0/FVSohXNLfZD3ufb7y/HOx8sB8AGpUQUmzjPEQ09YsevYliUoFayZOdA4FxHRLGO8xwRjQSc64go1gyJxujnL1uM85ctBgCEw2HMP/2qwR0QEdEA4zxHNPSIHR/oIhEJauUgDyZGcK4joljHeY6IRgLOdUQUa45YDutgtkQrmlv3Z3U0t9hhS7R0uU18nAlOlzsaLW4+KHuEiIiIaLB1nqeERTZHJyIiIiIiIopVfQ6CJCVaoVQoUFpWhUhExGdff4d5s6Z0uY0gCBhXVBhthv7pF6swd9bkARkwERER0UCIlsNic3QiIiIiIiKimHXEIMhtdz2A//vDo1i1djOWXXYbtu7Yi5/eciV+/cDjuOjan2HWtAkozMsCANz/yLPYuacMAHDLtRfjuVfewflX/QRxJiPmzph0TJ8IERERUW8dWNuYmSBEREREREREseuIPUEeffCXPV7+2rMPdrvs7h9fF/0+KyMVLz3++6MYGhEREdGxIR4QBIkwE4SIiIiIiIgoZvW5HBYRERHRcCceEPdgJggRERERERFR7GIQhIiIiEacLuWwmAlCREREREREFLMYBCEiIqIR58Dkj4jIIAgRERERERFRrGIQhIiIiEaczp4gaqWC5bCIiIiIiIiIYhiDIERERDTidJbD0qgULIdFREREREREFMMYBCEiIqIRpzPsoVYpEI4wE4SIiIiIiIgoVjEIQkRERCNOZx8QtVLBniBEREREREREMYxBECIiIhpxOqphyeWw2BOEiIiIiIiIKGYxCEJEREQjjnRgY3T2BCEiIiIiIiKKWQyCEBER0YgT6QyCqFgOi4iIiIiIiCiWMQhCREREI05nOSw5E4TlsIiIiIiIiIhiFYMgRERENOJIkgSFAKjYGJ2IiIiIiIgopjEIQkRERCOOKEkQBAEqhYAQM0GIiIiIiIiIYpaqvwdWVtfhnvsf2//vmnr87pe3YOGcadHL7vvz09i0dReMBj0A4P57bkdmespRDJeIiIjo6IkSIAiAUiEwE4SIiIiIiIgohvU7CJKTlY6Xn7wfAOD1+XHuFXdgxpTx3W7345uuwLxZk/s/QiIiIqIBJpfDEqBSKhCOMAhCREREREREFKsGpBzWN99twLRJ46DX6Qbi7oiIiIiOKVFCRxBEQERkOSwiIiIiIiKiWNXvTJADfbHie5y6aF6P1z367Gt4+qW3MHvGRNxw5QVQKrvHXd5+fzne+WA5AHlnJhFRrOE8RzS0iKIEQQBUCmaCDCTOdUQU6zjPEdFIwLmOiGKNEAwGjmo283i8uODqn+Hdf/4VWo2my3UtrXYkJlgQDIVw35+exqSSsTh/2eLD3l84HMb806/CNx+9BJVqQGI0RERDCuc5osFX0eTCXa+uw+zRyUiO1+HSeQWDPaSYw7mOiGId5zkiGgk41xFRLDjqclgrvtuAGVPHdwuAAIAt0QpBEKDVaHDqonnYuafsaB+OiIiI6Kh1lsNSq5gJQkRERERERBTLjjoI8vmK73Hywlk9XtfSagcAiKKIb1ZvQF5OxtE+HBEREdFREyW5HJZaqUAwHBns4RARERERERHRMXJUeWxujxc7du/DA/fcHr3s/keexTmnn4yi0fn47YNPwuF0QRIljCsqwIVnLTnqARMREREdLUmS5EwQpQL+EIMgRERERERERLHqqIIgJqMB//3XE10uu/vH10W/f+yhu4/m7omIiIiOCVFCRyaIAJdfHOzhEBEREREREdExctTlsIiIiIiGG0mSoFAI0KiUCIUZBCEiIiIiIiKKVQyCEBER0YjT2RhdpRQQijAIQkRERERERBSrGAQhIiKiEUeUJAgA1CoFM0GIiIiIiIiIYhiDIERERDTidJbDUisVCDIThIiIiIiIiChmMQhCREREI44oyo3RNcwEISIiIiIiIoppDIIQERHRiCNBgkKQM0HYE4SIiIiIiIgodjEIQkRERCNOZ2N0tVKBMIMgRERERERERDGLQRAiIiIacURRgiDIjdGDLIdFREREREREFLMYBCEiIqIRR5JYDouIiIiIiIhoJGAQhIiIiEYcUUI0E4RBECIiIiIiIqLYxSAIERERjThdMkFYDouIiIiIiIgoZjEIQkRERCOO2BEE0TAThIiIiIiIiCimMQhCREREI060HBYzQYiIiIiIiIhimupoDj7nijtgNOihEASYTUY8/qf/63J9TV0j7rn/MbjcHkyfPB4//9HVEAThqAZMREREdLQkSYJCIZfDCotSNDOEiIiIiIiIiGLLUQVBAOCZR34Dg17X43VPPP8Grr38XMybNRl33/c3rPx+E+bNmny0D0kHWbW7EbNGJ3PxhoiIqJc6gx5qlZwUGwqL0KqVgzwqIiIiIiIiIhpox6wcliRJ2LpjL+bOnAQAWHLyXHz7/YZj9XAjlj8Uwf3vbkFpg3Owh0JERDRsiBIgQC6HBYB9QYiIiIiIiIhi1FFlgggQcPPPfg+FQsBF5yzFkpPmRq9rd7oRZzZFy18lJVrR3GI/utFSN75gGACwvdqB0WnxgzwaIiKi4SFaDkvFIAgRERERERFRLDuqIMhTD9+DZFsCWlrt+NEv/oiC3CwU5mf3+X7efn853vlgOQB5UYJ6zx+MAAC2V9txzoycQR4NER0K5zmioUWSAEEQoFLImzXYHH1gcK4joljHeY6IRgLOdUQUa44qCJJsSwAA2BKtmD1jInaXVkSDIPFxJjhdbkiSBEEQ0NxqR1Kitcf7OX/ZYpy/bDEAIBwOY/7pVx3NsEYUX0cQZEeNI/paE9HQw3mOaGiJiBIUghwI0agUzAQZIJzriCjWcZ4jopGAcx0RxZp+9wTx+f3weH0AAK/Pj/WbdiAvJyN6vSAIGFdUiJXfbwIAfPrFKsxlU/QB5w2GYTVq4AtGUGf3DvZwiIiIhgUJ+zcOqJUKZoIQERERERERxah+Z4K02Z34xb1/BQCIoohlp56A4jEFuP+RZ3HO6SejaHQ+brn2Ytxz/2P461OvYNqkcZg7Y9IADZs6+YMRmPVqqJQK2D1BZCQYB3tIREREQ54kAR2VsOQgCDNBiIiIiIiIiGJSv4MgGWnJeOWp+7tdfvePr4t+n5WRipce/31/H4J6wRcMQ69RQSEI8AbCgz0ciiGNDh9SLPrBHgYR0TEhihIUnZkgKgWCzAQhIiIiIiIiikn9LodFQ4MvGIFeo4RRq4LHzyAIDYw6uxc3P7eKDdCIKGaJEiAwE4SIiIiIiIgo5jEIMszJQRAVjDoV3IHQYA+HYoTDE0QgLHJRkIhiliR1zQThfEdEREREREQUm/pdDouGBl8wDJ1aCUDJclg0YFy+IAA5yKZRKQd5NEREA088MAiiFNgYnYiIiIiIiChGMRNkmPOHIjBoWQ6LBpbLJ7+XfMHIII+EiOjYOLAclkalZCYIERERERERUYxiJsgwJ2eCqKBSCnB4goM9HIoRzmgmCANrRBSbJEmCQiFHQVRKBUJh9kAiIiIiIiIiikXMBBnmujRGZzksGiBuPzNBiCi2iRK6lsNiJggRERERERFRTGImyDDXGQTRaZQMgtCAcflDAJgJQkSxS5SkaDkstVKBIHuCEBEREREREcUkZoIMc75gGHqNCkatGp6OheuIKEKSWNaD+s/l6wyCMBOEiGKTJEkQIEdBNCoFM0GIiIiIiIiIYhSDIMPcweWwREnC/72+Hv/8Zt9gD42Gsf1BEGaCEFFsEiVAqegsh8UgCBEREREREVGsYhBkmPMFw9BplDDq5CDIxxtrUNHsxofrq+HnLn7qJ7c/BIUg8D1ERDFLFA8oh6VSIMRyWEREREREREQxiUGQYc4fjHSUw1LB45eDIDcuHotUix5fbK8b7OHRMOX0hWAza1kOi4hiliRJEARmghARERERERHFOgZBhjlfMAK9WgmjVo1QRERVixvFmRbMGpWEnTXtgzo2uzuAYJiL6MOR2x9CcrwOXpbDIqIYJQFQMBOEiIiIiIiIKOYxCDLM+YJh6LVyJggAmHRqJMXpkGLRo7HdN6hj+8uH2/DV9oZBHQP1XSgiwheMIClOz0wQIopZoiRB0ZEJYtKpYfcEBnlERERERERERHQsMAgyjIUiIsKiBL1GCbVKAY1KgYLUOAiCgJR4PZoGOQjS6grA4Q0O6hio79wdTdGT43XwMxOEiGKUKCJaDqsky4qtVXaIkjTIoyIiIiIiIiKigabq74GNTa24909Pwu5wQqlU4upLz8bJC2Z2uc19f34am7bugtGgBwDcf8/tyExPOboRU5SvY4Far5Z/jEatCoWpZgBASrwera4AQmERatXgxLravUG4OhbUafhw+UPQa5Qw69SobvEM9nCIiI4JSZKi5bBGp8chLEooa3ShMDVucAdGRERERERERAOq30EQpVKBO278AUYX5KC1zYGrbr0Hc2ZMhF6n63K7H990BebNmnzUA6Xu/MEIBABatRzkiDdoMCYtHgCQYNZCqRDQ7PIj3Wo47mOLiCJcvhCDIMOQyxeCSaeGXquMBtqIiGLNgeWwlAoFJmRbsbG8lUEQIiIiIiIiohjT7xQBW6IVowtyAACJCRZY4sxwOrlr/HjyBiPQaZTRch73XTwFM0YlAQAUgoCkeB0aHYNTEsvpC0EC4PSxHNZw4w9FoNcoodeo4GVPECKKUaIEdPz5BABMzkvExoq2wRsQERERERERER0T/c4EOdCuveUQRREpyYndrnv02dfw9EtvYfaMibjhygugVHaPu7z9/nK888FyAHJ5CuodXzAMvWb/j9Bq1Ha5PjV+8Jqjt3vk4AczQYYfXzACnVoJvUYJf6jnIMiuWgfavSHM7Ai60ZFxniMaWiRJgkKx/5xkUm4Cnv18N/wheQ6k/uFcR0SxjvMcEY0EnOuIKNYcdRCk3enG7x56Cr+449pu19109YVITLAgGArhvj89jXc/+hznL1vc7XbnL1scvTwcDmP+6Vcd7bBGBH9Q3rF/KMnxejS1+4/jiPbrbIjOIMjwE+hYANSrVfAFei6H9d2eZjQ5fQyC9AHnOaKhRZQAhWJ/Kki61YBEkxbbq+2Ymm8bxJENb5zriCjWcZ4jouFKkiQ0O/1Ijtcf8bac64hoOImIEuyeAIJhEQ0OH2rbPDhzanaX2xxVECQYDOEX9z6CH1x0JiaMG93teluiFQCg1Whw6qJ5+OKbNUfzcHQQORPk0EGQFIselc3u4zii/dq9QWhVCjgZBBl2fB1l1vQaJXyHKIfV7g3Ce4gACRHRcCBKUpdyWIIgYFJuIjaWtzIIQkRERETDlihJaGr3o7rFjapWD6qa5a81rR4EQhG8f1f3zclERMOBKElodPhQ1eJGZYsHVS1uVDV7UNPmQTAsQiEISLXokZFgGLggiCRJ+P1fnsbUScU4ddG8Hm/T0mqHLdEKURTxzeoNyMvJ6O/DUQ98wUiXclgHS4nXYU1p83Ec0X7t3hAyEoyoaHZ1aT5LQ58/JJdZ02tVh2yMziAIEQ13Ug9/mybkJOA/ayoHaURERERERL0jSRIaHD7sqm3HzloHKpvdcPlDcPvDcPlCECUJ6VYDsm1GZNtMmFpgQ3aiERkJxsEeOhHREXVmrpU2OLG3wYnSeif2Nbrg8oWgVAhITzAgx2ZCts2I2aOSkZ1kQrpVD6Xi0O3P+x0E2bJ9Dz77+nsU5mVhxar1AIBf//wmvPmfT3DO6SejaHQ+fvvgk3A4XZBECeOKCnDhWUv6+3DUg87eDYeSEq/vd2N0tz+Ef60qx7Undc/w6Y12bxCZiQaUNbngDYRh0qn7dT90/PmDEWg7eoKERQmhiAj1Qb182r1BBMLiII2QiOjoiRK6BUGyEo2os3sHaURERMNPZbMba0qbUdHsRiAUgShJMOvUsBi1sBg1sBg1sBo1SLUYkBKvg8CNUUREveL0BdHU7ofHH4Y3GIY3EIYnEEZtmweVzW5UNLvhD0ZQkBqHsRnxOGViBuIMaph0asTp1UiO13f7HE9ENNQ4PEHU271ocfnR7PSj1RVATZsHpQ1OuHxhZNuMGJUWh9mjk3H5gkIkmLSwGjVQ9WN+63cQZOL4MVj1ySvdLr/7x9dFv3/sobv7e/fUC/5QGAbt4TJB9LB7ggiE5EXtvvh8az3eXVOJy+cX9PlYQH4Tp1oMUCkEOH0hBkGGEV8oAr1aCZNW/pm1e4OwmXVdbtPulXeWdJIk6ag+1O6ua0dWovGw72ciooEkHVQOCwBSLXp4AvLuObOef7eIiHpS3erBNzsb8O2uRjQ6fJicl4jRafHQaZQQIG+mcniD2FnrhcMThN0TQHO7H0lxOpw0Pg1ZNhPGZVkACXjgP1swJj0e583MhcWoGeynRkQ0KPzBCFrdfpQ1urC92oHNlW2obvUgTq+GUaeCQaOCQSt/TbPqsagkA7nJ8g5ojarv6zVERIMhGI6grNGF3XVO7Klvx65aB5ra/bCatEiK0yHRrEWSWYdp+TZcPDcfecnmw27+7yuuOA5jR8oEsRg10KgUaHL6kZXY+5RHSZLwvy21AOQF8N40zTpYuzeInCQTzHq13Bzd2ue7oEHiD0ZgMWqgVimQFKdDvd3bLQji9AWjO6irWz343Vsb8cwNc/sdCHn04x04Z0YOTi5JP+rxExH1hih2D94atCrE6dVocHhh1scP0siIiIaeBocXX+9owDc7G1Hb5sW0AvnD6fQC22HL83YKhCL4vrQZ3+1uwnd7mlHR7IJWrcTUfBtqWj344VPfoiTbiqIMCxYUpyDVYjgOz4qI6PgSJQlt7gBqWj3YWN6GTRWtaHD44AmEoVIKyEo0YlymFZfPL8DE3ARuJiWiYavdG0RNq9yro6zRjT117ShvcsGgVWF0ejzGpMVhUUk6RqfFwXic5joGQYYxb+DwjdEFQUByvB5N7b4+BUEqmt1oavfBqFXBcRRBkHiDGma9Gk5fsM/H0+Dxh/YH19KsBtTZvSjJToheHwhF4AtGoBDkgFldmxf1Dh/a3AEkHhQs6S2nL4iGg0q3+YJh1LZ5UZga1/8nQ0R0CKIEKHsI3KZZDah3+DAqjUEQIqLaNg/eWFmOb3c1YkpeIs6flYsZhUl9zt7VqpVYUJSKBUWpAOTPCpXNbozLskKpEFDa4MTOGgc2lLfitW/3oSA1DguKUjB3bEq3zThERMNBg8OLLZV21Nm9qLN7Ud7kQrPTj0hEgi1OhwnZVpw7MxdZiUYkmrWI06tZMpCIhqWIKKGy2Y3t1XZsr3FgR40dbe4gEs1aZCYYkZNkwtkzsjEmPR4p8fpBm+uGbBDkn9/sw1UnjhnsYQxp/lDkiB8KUuJ1aGzv3hekrNGFnCQTlIrub7x6uxcZCQaEIhLaPf0LYLS4AkgwyX/IXb5Qv+6DBoc/GIGuI7iWbtWjrq3r+6fdK78nREl+D9o9AQBAWZOrX0EQSZLg9IW6BUG+2dmIt1aX49kb5vXnaRARHZaE7uWwALkkVoO9f/20iIhiQVO7D9/uasTK3U0obXDixHFpePK62QOanRFv0GBCzv5NNoWpcShMjcOZ07Lh9AWxancTVuxsxAtf7sWY9HhMzkvEhGwrRqfHs8Y9EQ053kAY26rt2FzRhq1Vdjh9QTg8QYzNiEeWzYTRaXFYOikTqRY9ksw6qFWcx4ho+AqFRextcEaDHjtrHBAlCWMzLBiXacHpUzJRkBI35EreD63RHODt7yowY1QKijMtgz2UIcsXjBw2EwTobI7u73KZKEm469W1+L9zJ2JSbmK3Y+yeIKxGLQJhEQ5v34Mg/mAEzU4/MhOMMOs1cHoZBBlODswESbcasKPGgZueXYU7Th+HMenxcPpCMGpV8ATk5myOjkBZeaMb0wuSev04kiThmc9248I5eQhHJDQ4ujYjrmxxo8Hu6xKUISIaKD2VwwI6giAONkcnopHF4w9he40D3+xsxDc7G1CSk4DFE9Lx6/MnId5wfHt1xOk1WDopE0snZaLNHcD3e5uxpbINH66vgj8UQXGmFROyrZiQk4DCVDOUCi4mEtHxFRElvPbtPvxnTSVCERGiBKRZ9ZiYk4ALZufCatIix2Zijzkiihn1di++3dWI9WWt2FPfDr1GiXGZVkzOTcDl8wuQl2wa8udkQzYIctmCAvzmzQ246oRROH1K1mAPZ0jyBcNHrMGbHK/HvgZnl8vq7V74ghFUt3h6DIK0uQOwmrQIhCLRXf99UWf3wqBVwWLUoDDVjHVlLTh7Rk6f74cGhz8Uib6vMhIMePWbfQiEReytd2JMejzavUEkmLQIiyK8wQjsniA0KgXKmlx9epwWVwAfrK9GSbbcMKbB4UNElKAQ5FJuVS0eSACqW90sS0NEA06SgB6SIZFmkYO/RESxRJIkbK2yQ5KA4iwLlAoBTe0+7KhxYEulHSt3NyLRrMPY9Hg8c8PcfpXDPRYSTFqcOjkTp07OhCRJqGzxYGtlG7ZU2fHO9xWIiBLGpscjO8mE3CQTcpJMyE40cQMNER0Tbe4A1pe14MP11QiEIvj9JVORaNJCq1Ye94AxEdGxJEkSypvc+HRzDdbta0GrK4CJuQk4YVwqbl1ahIwEw7Ar4TdkgyAXzMpFisWAV78pYxDkEHy92CGfl2zCRxuqIUpStJF1WaO8WF3T5unxGLtbLmXVucDdV7Vtnugvw9JJmfjXqnKUN7mQl2zu830NFdWtHny1vR4/WFA42EM55nzBMLRqOXqbnmBEICwCkF8DAHB4gog3aOD2h+ANhGH3BDA+yxp9X/VWRUfQpLzJDZVCgN0TxIPvbUFhShwunJOHqhY3dGolKpoZBCGigXfg38UDZSYaUN7kgscfOm4N2oiIjrX/banF81/shV6jRCAUQTgiIRQRUZBixoScBNx30RSMzbAM9jAPSxAE5HYEO86clg1RklDe6MKeeicqm934Yls9Kpvd8ATCmJBtRYpFj4wEIwpSzEiO1yFOr4Feoxx2H9iJaPB5/CF8vq0e//xmH3JsRswvSsGyadnQqBhwJaLY4fKFsLmyDXvrnVi9twktTj8WFqfi5iVFGJdpHfabTIZsEAQAijIsaHH5ERGlHntXjHS+YBiGI7wBJ+YkIBQRsaWyLZr1UdbkglatQHVrz+U+7J4gClLjoPGHUdXq7vO4atrkniKAXO/3hOJUfLqpFjeeMrbP9zVUlDY48e6aSlw8Jz/m63cGQhHo1fLUkGrRQyEImDkqCdUt8nuhs+m93aOCLyiXw5o1KgkvfLkXwXDksCeCoYiIymY3ClPjUN4s319lixupFj1a3QGs2t0EtVIBtz+EVlcAC4tTUdHc9/cgEdGRiBJ6XAgbkx6P/JQ4/PObfbh+0ZjobXbUOJBjMzIwQkTDjt0dwHOf78Hd50zExNwE7K5th0GrQnqCYVj311AIAgpS41CQGhe9TJIkNLb7sHZfC9rcAWyvtuP9dVVodQUgShJUCgEmvRpxHf+b9RqYO77Xa5TYW+/Er86bNHhPioiGlN117fh4Yw2+2dWA3CQz7jxzPKYX9r4ENBHRUOcPRbBqdyO+3N6ALZVtyEo0ojA1DlcuHIUp+YnRcvmxYEgHQWxxOoiiBLs7AFtc3xsuD3eVzW6s2NmA2aOTUXjAyX0nfzACnfrwP0KVUoETx6Xhw/XVGJdlhUohoKzRhVmjkrG1yt7jMW3uAKxGLdRKBbZWBQ+5W/ZQ6tq8yEgwRv89Jd+Gf60q6/XxQ5E3EEYwLGJ3fTvGZ1kHezjH1IEZRmqlAvdfMhWCAPzxP1uws9aBdWWtyEwwwKBRweMPw+4OID/FDJVCQKsrgDTroZtmbq5ow+Of7sSLN89HeUcmSGWzG/EGDVRKBapbPWhw+FDd4oHFqMH4LCtW7W48Ls+biEYWSZJ6LIclCAJuWjwGP3tlLXbVteOKBYVYvqUWK3Y24tTJmbhlSdHxHywR0VHYUtWGzAQjJufJG6KKYrjnoiAISLUYcObU7C6XS5IETyAMly8Epy8EV8f/Tl8w+u9mpx9j0pl9TERAeZML//i6FNur7ThpfDr+dPkM5KcM38oWRESdAiG5j3OT04/v9jTh6x0NsJm1OLkkHbcuKUKKZWiURD0WhnQQRK1UwGrSosnpH3FBEFGScPfr65CXbMYH66vxx0undfuj6wtGoNceOSJ3+pRM/ObNjbjg4S+il/3y7An4ekcDvIEwDNqubwO7JwirSQOlQkCDw4cfPvkt7j53Yo+BmJ7UtHkwo9AW/XdRRjwqm909PtZw4fGHAQDbquzDIgjS4vIDAGzmvv/eHNgYHQDGZ1vh9odg9wTxu7c2YXR6HGaOSkJNmxfeYBh2j9wjJNGsRbPTf9ggiN0TgN0dgCRJqGhyIz/ZjIpmFzITjCjOtGBqvg2fb6tDZYsb2Ta53MFr3+7r+wtARHQEoiRBcYgs0yybCS/ePB//WVuJ37y5EbNHJ+H+S6biN29uxHkzc5BqOfQ8R0Q01OysacfYjJG9uC8IAkw6NUw6NdKG/qk8ER1ngVAEq/c2YfXeZuypa0erO4DTJ2fhx6ePY68PIhr2AqEIvtxej0821aCs0QWlQgFbnBYlWVb87sLJGJMePyLKhQ75FenkeB2a2n0ojuEdSz0pa3QhGBZx74WT8ejHO/HFtjrkp4zpchtf6MiN0QEg1WLAk9fNQW2bF6GwiM2VbZiSb0OcXo2aNg/USgX0GiVSLQZERAkOTxAJRi0UgoB6hw8A8PHGGtx2anGvxl5v9yL9gIXwRLMOSXF67Kprx5S87o3YhwNPIAyNSoHt1T1nzww1b6wsgyAIfd6xHBElBMNitzp/Jp0aVqMGCSYtfnvBZAiCgE821aLNHYA/FIHVqIXNrIsGXw7F4QkiLEpodQdQ2+bBuTNzUdbkglmvxlUnjILDE8Q731dga5Udo1LjkJNkgt0T7CjBNTgnn3V2L+rtXkzNtx35xnTcSJKEPfVONDh8mDc2hSUTqc8kCTjceZ5Bq8Kl8wpw/qzcaJm/xRPS8ds3N+J3F00ZMk2DiYiOZGetA+fOzB3sYRARDSmiJGFnjQNfbq/HNzsbYTVqsKA4FUsmZmBUahxLoBLRsCNJEtz+MJy+IPzBCNp9IWyrsuOTTTVIMGmxbFo2JuclwmbWjoigx8GGfhAkTocm5+EXVoezUFhEk9OHlHg9VAfU5N1c2YbxWVYoFQoUZcbjy20NAORm0uvLW3H29BwEQiL0vazNphAEZCXKJao6M0oKUszYWePAt7sakZdsxs1LiuD0yeWvrKb9C84njkvD1zsacO1JoxERJWhUCmgP8bi+YBhufxhJ8V0zEIozLdhRbe8SBJEkCX96fytuXlIE0xA/wfAEQhiXacG+Pjb/HiwNDl+/ajwHQhEA6LHm3/yiVMwotEUnSoNGido2r1xbWaeCLU6HFmfgsPfv8AQBALtq26FWKjA6Tc4uitPLP/94gxo6tRJrSptxx2njYNCqkBSnQ2WzGxNyEvr8fAbC69+WobbNwyDIEFLT6sH9725GmzsAnVqJr7bX4+zpORibEX/IuYnoYL0t9Xhgn6MbFo/Fox/vwEPvb8VDl0/vU6lIIqLB4A9GUN7kRtEIzwQhopEtFBHR4PChttWDmjYvalo9WF/WgogoYc6YZNw7gnZCE9HwEBEltLrkslXN7X74QxEkx+tQlGGBTqNEU7sPa0tbsKuuHc1OP1pdAbS5AwhFRKiUAgwaFUw6NfKSTbjrrAmYkGMd8XPc0A+CxOvR1O7rdnmjwweLUTPsF7z+u7EGz36+GxOyrbj/0mmQJAlf7WjA93ubMXdMMgBgVGo8nvt8D0RJwsrdTXh9ZRlaXfJis/4IjdEPZ+7YFLy7phK1bV5IHZfZ3UEYtSpoVEpYTRoUpJjxw5NHo7pV7k+yfEsdZo9Oxvmzcnu8z1ZXABqVAuaDghpFmfH4dldTl8sc3iBW7GzEaZOzMD57aOelewNhZNtM2FjRhlBYHPLN0Rsdvl5lCR3Mf5ggyPWLumYiGbQq7G1wwmqSI8hJcTo0HyITZFNFK+rsXji8chBkZ60DyfF6JHaU6zJ3BEEEQUCKRY/KZjdGd9Rkzk0yHfMgiCRJeOSj7bhh0ZguO368gTBW7W6EUqmAJEkj/g/GUPH8F3swJj0eN50yFsGwiBe+2IOHP9qGdm8Q6VYDZhQmYf7YFOQmm6BUDO3fVRo84hEyQXqiVAi4cfFY3PzcKny2pQ6nTMw4NoMjIhogu+vaYTVpkDTCSgsTUWzyBsJocPjQ4PCizu5DY7sPobCIvGQz5o1NRqJZh1BHL8+tVXbsqWtHbZsXDQ4fVEoB6VYDMhIMyEw04qdnjkdJtpWfF4jouIuIIuzuINo8AbR7g3B4gmhq96Op3Ycmp/y1xSWXkper6+ig1yhR0+pBY7sfAuT1s5JsK8ZnWTCtwIbEjjL1VqN22LYiONaG/KuSHKeLNlA+0H3vbMKZ07KwZGLmIIxq4NS2eTC9wIYtVW0QJQm1rR488uE2KBQCblsqlzLKthkRjkiot8s7FhYWp+KDdVUA0K1sUV/MHp2MJz7dhUSzFhVNbkRECXZPAAkmLQB59+vfrp4FAFg6KROvfVuGNncAadZDlwBpcfmR2ENaVXGGBS98sRcRUYyeZNTb5eBWvcM75IMgnkAY47KsUAgC2tyBId0oKCKKaHL6YezHpOcLhqFWKrpkJR2KQavCvgYXxmdZAACJZi0qm9093nZNaQtKG5zR7JRdte1Iseij77U4w/7AQ2q8Hi5fEDazfF1OkgkVzW6EI2KvxtUfDm8QX2yrx+lTsro0xPxmVwNSrQZUNbujvU9o8OysdWD5ljpsq7bjuRvnQaNSQqNS4kenjYMkSWhw+FDR7MYX2+rxi9fWIcGkxe2njRtx5RSpd6ReZoIcTKdR4rL5BXh3TSWDIEQ05K0vb8Hk3ERu5CCiIccbCMMTCEMhAEqFAhGxI1ujzRstSRwMi/CHInB4gmhzB+Dp6DOaZtEj3WpAikUPlV7A2n3NePGrPUiO06PF5YdBq0JJthWT8xJx5rRsZCYYYIvTMYuXiI4ZUZLg9ofg9ofh6fjq8ofQ0pGl0eLyo8UVQKvLjzZ3AJIExBs0iDOoYTFokByvR4pFj5LsBCTH65Acr4fNrO2yDiZJEpy+EAKhCOINwz8x4Hg7qiDIt6s34tFnX4UoSvjBhWdg2akndrl++659+MNfnkEwFMKpi+bj2svP6fNjJMXr0Ojomgni8oVQ0exGTav3aIY/JDQ4fJheaMPGilY0OHzYWduOsRkWPHDp1GiwQKVUIDfZhNIGJ6pbPbh8fgGc3iB21DiOatdCvEGDuWOSMTE3AU8v340GhxdVLZ4egxwLilLx3Od7kBSnQ1Wz55D32eIM9NiMOzvJBKVCQHmTO9pgvd7u7fjaPdNnMFQ0uZCTZOrxQ6I3EJb7Ypg0QzoIsmJnA+L0akREeWIMhiNdSrkciT8Y6TELpCd6jQqhiIjTp2QBAJLMOjQfonRdnV0+kY03aKDXKLGv0YklEzNgNcpl18y6/eXXUi16CAKiP4fcJBOe+2IPVuxswF+vmomMBGOvn09v1XbMJW3uruW8lm+pw6mTMvHumgpUt3gYBBkEkiThq+0NKG1w4tPNtTi5JA3/d+7Ebj1iBEFAmtWANKsBs0cnIyKKeH9dNe7513pcsaAQogSs2NGANKse583MRUFqHMIRETVtXlQ2uyEIQIbVgPQEwyGzqFpcfsTrNUM+E4x6RxT7FwQBgDljkvHEpztR0exGbpJpgEdGRL3lD0Zg9wSiHwYD4QjCEQkRUYJaKUClVECtVECtUsAbCCMUFiEIAhQKuVSsJAESJHT8B0DOEFMIApQKAQqh43+FAIWAjq/7r+tpCul20UE30qmVMGpV0GmUx2Uxbt2+Flw6r+CYPw4RUadwRESz04/GdjlTo6ld/t7lC8ETCMPjD8PuCcDtD3c71mbWIr3jnHxMulzqVqdWwmLUwGrUIjleB6NW1eNn9s4MkUSTFpmJRgZ/iWjAdG4ab3UF0OLcH8xodvmjl7W5AwiLUkfJeDVMOhVMejUSTXIP3THp8Zgbp4PNrIPNrEWCSdvnjb6CIAxav9xY0O8gSDgSwd+feRWPPXQ3TEYDrr71V1g4dxri48zR2/zl8Zfwu1/egrycTNzwk3uxcO40FOZl9elxxqZbYPcEsbmiDRNz5XI4O2sdAIC6ttgIgmQkGJGdaEJFkwu769oxNiO+W3BjdFo8tlU7UNvmRWaiEWdOy0bNADz/u86eAAD4dFMt9jW6sKeuvctO+E4GrQp3LiuBXqPEb9/aiIgo9diIuMXl7zEIohAEjM2Ix44aR/cgiGPwf477Gpy4/aXv8fi1s5HTw4KWJxCGUatCgkmL1gMWyr/b04SPN9bgkrn5KDrGu80lSW5ar1YpDtlD5Z3VFRAlCclxOrS55Qk67YAm9UfiD0V6nV1k1quQZtVjemESAMg9QQ5RDquuzQuHJ4hAKIK8ZDN21DiifXASTJpoMAQAzp6Rg2A4Ev13fooZ7Z4gMhON+NeqcpQ1unDtSaMx+YD+Mker1i4H9g4MglS3erCvwYXfnD8Za/c1o6bNE52DBkpEFFFe345t1Q7sqnUgwaRFqsWAkmxrtHfPSBURJfx3YzXW7WvBvkYXZo9Oxp3LSjBzVFKvjlcqFDhnRg4yEw1467sKSJKE06ZkoqLZjZ++sgZmnRouXwhKpYAcmxz8rGn1wBMIIzPBgKWTMrFkUgbsniDSLHq0uAL40QurkZtswhULC5Fo0rIx9jDXn3JYnfQaFWYUJuHrHfXIXThqYAdGRF2EIyLq7V5UtnhQ1eJGVcfXZqcfvmAESoUAs17uKaZRyUEPhUJAJCIhFBERiogIhkUYNEpo1UpERAmiJEE6YA4QBCEavJAg/w0SO24X/SpJEEV5l1/nfRzKoa6SJAmBsCg/JuRyoBajBhajFlajXLIqOV6H5Dg90hMMSInX9WvDk8cfQrMrALc/hNo2LyYN8PkLEY0s4YgIX3D/5zMJEsIRCcFwBPV2H6pa3KhsdqPO7kVjux+tLj8EQUBynC66szkzwYh4gwZGnQpGrSq669mkU0GU5M0pAI5qs1GqRY/UIbpZkYiGjmBYzi5r9wZh9wRh9wTQ5g6i1eVHICQiHJEz0LyBMLzBMFy+ENrcQUiSBItRA5tZh0SzHNgoSDFjZmGSHNiI08Ji0EKrVjAIO0T1OwiyY9c+5OVkINkmn1TPmjYR36/filNOnAMAaG61IxwRUZifDQBYtHA2Vn6/sc9BELNejQtm5+HRT3ZgfJYVKqUAXzCCRLMWdfbBXzw/GhFRQpPTh1SLHrnJJpQ3ubGrrh2X9bBba+aoJPzh35sgSRJSLXpkJhpRlGEZsLHkpZhR2uDE7rp2LJnUc3mPmaOSEBFFiJKE5VtqoVQIWDyh621bXH7Y4nreLV+UYcHmijYsmya/J+odPhSkmNEwBDJBXvxqLwA5KHW4IEiiSRvtx9Li9OOh97YizarH5sq2Yx4EeXdNJV74cm+0f0xPWt0BODxBTMhJgCDIP48+B0F6mQlyQnEapuXbosGwpDgd3P4w2r3BLpHpiCiisd0HAYAvGEFesgk7ahzRBeQHL5ve5WT14JrV2TYTXrx5Pppdftz5ylrE6dV49dt9mJSbMGB/WHrKBPl8ax1mjU6CWa9GZoIRNa2HzoDqrwsf/go6rRrFmRYUZVrQ5gpgS2UbXv56LxLNOqiUAuaOScHotDhMyU+EQpCzqbJsxn41vh+K5DlF/n1aU9qCiTlW6DQqPLV8F2rbPFg8IQM/OrU42j+mr6YXJGF6QdfAyaVz81HZ4oHVqEGKRR/diduZWrqpog3//r4CL3y5B6IETCuwRbP2XL4Q7v/3Zjh9Iag7esWY9WrE6TVINGsxb2wK8pLNSDRrEadXw+0PY1edA6GwhESzFuGOBTmFIMBq1GDtvhZML7DBFqeDTq2E3ROESikgTs/dHcdaf8thdTptSibufWsTClLiYNKpMD7Lipo2LzNDiI6SJEmobJEb1q7f14IdtQ4oBQGZiUZk20woTDXjpPFpSI7XI8GkgUmnHlblTSKiBF8wDG8gDKcvBLsnEC3z0uz0o7zJhaZ2v7xJSAKsJjlAkmaVa9jH6dWwmbUYnR4Pi0ETPRdqdfnx7ppKlDbIm6pUSjnTZXqB7ZCbZ4iIfMEwGtv9gCTB4Q1GS7Z0fq1u9RyycoNCAFLi9ci2mZCdZMS4LCtSOoIeCSZtj5sme6IU0OvbEhH1RJIkeAJhODxyfw2HNxjN3Gh2+tHs9MPuDsDhDcIXjECAXJbd2rERxWKU+2kkx6mgVArQq5XQa1UwaJQw6dRIitPBatLGzDrMSNXvIEhLmwNJift3FSXZrGhuse+/vtWOpERrl+s3btnV4329/f5yvPPBcgDyG/dgy6ZlQRDklPc6uxdf72jAhbPz8O81FYiI8g4EfzAC6zArVdPmDkAUJSTF6ZCbZMKqPU2oanajKKN7JsaEbCvUSgWS4/anS3U2kx4Is0cn4c/vb4M3EMaojkyNnigVCmQmGPHEp/LP0qhVY05HA3cAaHEFkJfc8w72E8al4v11Vfj39xU4d2Yu6uxeTM5LxMcba/CLV9fhlInpOGl8OrZX2+ENhrstXPaWJEnYUmnv9a79FqcfWyrbUJxpQWN71xO8QCiCiCjB21F7NNGsjS6Uv7u2EtMLbMhNNh2XgNy+RhdOGp+Gb3Y29ticPRQR4fAEoRDkXTDhiIgW1/5F/UAogmc+242bThkLlVKBH7/0PS6em4eZo/b//LyBMPS9zATRqpVd6g/G6dWYWZiEu/65Fg9ePh3xBg28gbC8EwhAXrIZZU2u6PujM/DRmyCNLU6OtN+weAxmFibhRy+uxrZqO0qye/4ZH9h7pjdq27ww6VRdgiCr9zThioWFAIAsmxErdjb2+v560tM89+i1s5BpM3dbvKm3e1HT5oE3EMa6fa34bGsdQhERcXo1alq9SI7XYVq+DWa9GhqVAi2uALwd9XTrHT4YtSpMzbdBo1KgIMUMpy+ENKsBWyrbYPcEoFYqYDFqsLA4DQoBWLuvBS99tRcXzcnHvLEp3T6EREQJVS1uBMMiRqfFRRdcJEnC9hoHvthWD0mSsLA4FcWZFoQjUpdGXKIkQYD8Ho7Tq2H3BPHJphpsq7ajqd0PQQCUgoDC1Di8/PVeBMIiThyXhkeunHlMFm6MOnWPfUI6U0sXFqdiflEKals9MOnU0d/1xRPSo+Xl3P4Q2twBKAQBLl8ITl8Q1a1evL+uCo3tPrj9YWjVCgRDItKsBmhUCji8Qbksi1KBUEREi9OP4kwL/vF1KSKihPxkM+rsXpj1aswolAMvY9Lj5TJfFjlz6svt9VhQlAp/MIK9De1w+8OwGDTRncnLpmX3qi6oJEkjfneKBBzVa1CSnYCrTxyFJz7dCYUgwB+KwB+K4P5LpmJCzsjddX2kczqinnj8cgB6fXkrNpS1wOUPYUJ2AuaMScHNS4qQZjXEzAKZMloiQX3YjMKIKKGp3YdWl/yBvbrFjbo2L/b4Q2hw+FDd6oFKIcBqkptfVrd4MHNUEhaVpOOWpUXIShz48qEk4zxHA63L4p03CKc3iHZvSF6sC4ShVArRc0iNSoGkOB2KM62IM6jh8ASjC3xN7T40d5RkAQCLUQOFICAsSohERCiVCujUSgTDEdS0elHb5kGLKwCdWgmFQkC8QY1Ek7yb2WbWYbItEadPyUKOzSSfkx8wDauVAhuKxzjOdTTYJElCMCzC5Q/B7g7I1U7cAbS5AtEMDodnfzZHOCJF1zosRg0sBg1scTrkJJkwLd8Gq0kOdlgMGpj16pg5t6TeGxKN0c9fthjnL1sMAAiHw5h/+lVdrteolDhvZi4A+Zdg3tgUlGRb8fbqCrQ4/Xh5RSn2Nbrw2DWzjlnj5GOhweGFzayDWqlAYWocXvpqL86clt1jMEelVGBmYRK8B6ShDqRp+TZkJBjgD0VgPMKiY7ZN/lB18dx8PPzhNuxrzMYPFsiLxS3OnsthAUCqxYB7zpuEX72xHqdNzkKD3YerT0jE26srUN7kwtPLd2NCdgLeWFkmL95LwKeba/Gr8yb16bmUN7nxf2+sxz9umd+r3eNVrR6kWgwoSDF3C4K8vrIMra4AfMFItBxWTasX7V55EfePl05DbZsXG8pb+zTG/qhp9eCC2XnYUNaKPfXtGJfVtZm83R2AQgBmjU5Gjs0If1AOQHSqaHZ39FRIh1Grwt4GJ77YVt8lCFLV4ul3zw1BEHD3uRPxu7c34s1V5bhu0Rjc/+5mNDh8SLUakJFoQEO7DykdH/iT4/u2s18QBJw5Vc4iOnFcGr7a3oC99U4YtCosnZQJQE7Vfvbz3fhyewNevnVBr7Naats8GJ9lRZtbLh1h9wTR0O6LltyalJuIZz7bjepWT5dFhepWD1It+l7tBuhpnku3GnrcvdrZ2wIAFhanISJK2FnrQKvLj6n5Nmwob8Weuna0uPwIhkXEGzRITzAgHBExKS8Rbe4AVu9tQjgi4enluxBv0KDF5UeqxYBRaXEIRUTsa3DhiU93IRiOQK1SYNm0bDy9fBf+/vF25CWbMaMwCTq1Ei0uP9aWtqDF5YdCkD+ASZBPRtRKBURJwonj0qBRKfGHf29GRJSiC/p6rQr1di9aXQFYTXJQLBCKQK9RYe7YFNx0ShHSrXpERDmlPifJhIgowRMIDXomhEIQkGWTd/Rfc+Lobtd3LmAdaOYo4PxZuQDkoH1juw8Wo+aQNTs7e/a4/SGEwiJW721GRoIBexucqGp2Y0peIkobXNhY3op6h1xHeVq+DXf9cy1MOjXGZVlgMWpQ1eKGJAEOTxBvr66QSw1o5fqjhalmGLVymQGjVgWrUYP/bamD3R3Aby+YDINWBYcnCEGQn1NTuw+GjjrLZr0aCgGoafUiLIrISjTC5QshEBaRkdDze3c4iYgSjva89/QpWTh9ShZCYRF76tvxfWkz3l1TOaKDIEc6pyMC9md7rC1txvqyFuysbUe61YCp+Ym4/bRxGJdl6VNPs1ikVAhdzgeAlC7Xd/ZDaXPLPVFGpcUd8hycBhbnOTqQ0xdEmzsIrUruP2R3B7Crth0qpQLJ8TooFQLc/jCcviCc3hCcvhBcvhDcfrk/RufCXiAsQqNSIN6gQbxB3fFVPqfzhSSEwnI2cSAUiQZCBQBhUYqW0+v8f0x6PARBgMMjl2/RaQSoFIpoJppGpcT8ohRkJho7ylSpR/zmGOqOcx0NFFGSNxa7fCG4/KGOTYTy184NhU7f/obinb2D3IEQwhE5ABdvUCPBpO3yf26yCVajtqNnkBz0MByiZxARcBRBEFuCBc2tbdF/N7fYUTxmfxknW6IVza32LtfbEi39fbgoQRAwe7S8aJtq0WPtvhas2t2EBJMWH22owZKJGXhq+S6s29eCh6+ccVxqtnsDYWjVyj5HERscvuhu+JJsK165beFhG9xcecIo+EPHJggiCAJuXVrcq4yGC2fnQRAE5CSZkG414Cf/+B7nzMiBSafu6Aly6IycsRnxSIrX4/11VXD7QyhIMSPBpMHl8wuxtcqORz/ZgS1VdigVAp743y60uvzw+ENdAjNufwgfrKvC/KJU7KhxYGuVHRfNyUNmx+J0aYMTALC7zok5Y7p+GFy9pwnBiIgFRanRy6qa3ci2GZESr8f2GkeX2++ocUR30hg6giCbK+34cH01ijMsGJUmZ+0crj9NOCLi3rc24mfLSvrdwEiSpGg/mOJMC7bXOLoFQVpdAViMWvx8WQkUCgGtX+5Fi3N/ZkNlsxsAsKmiFZIkNxxft68FvmA42gi6rNGF8dld77cvlAoBVy4chTtfWYPJeYnYVm2HAAGT8xKQZjEg3uBEmtWApDgdzEexw3/u2BTc37HgXpgaFw2CbChvxeq9zVAI8vPtqb/NgTprfdc7fDh1ciY+21qHX7y6Dg5vEBOyE6KvS6pFj5NL0vHoxztw0vg0LJmYge3VDvzqjfVyr4qzSo7pgrBSIWD8AT/vBUWpXd7DPTkwcCwIAjz+EHQaZXTHVigsorrVA6NWhXijBjq1EpfPL0Rtmwd7651YsbMBgiAgJV6Pc2bk4MTxaZAkCaUNrmjNdW8wjIIUc3Sh6uwZ2XD7QtCqldhd1w5fMIJ0qwFWkwYNDh/GZVoBAdCoFId8vZSK2CgFpdMoeyytd6DO160zmHLqZPl9fKgF9M5eTO3eIIxaVbegf0SUUN7kgtsfgrdjN+GeeicaHT75PdDxQTsv2QyTToUfPLYCgFzKQOpoCty5O1CU0PEzkqDTqCBALguoEOSMQJ1aCYNWBaVCbhCclWhEmycQzSbMspmQHK/D+CwrKpvdCIsivt/bDEmS044B+XdUpVSgKMMiZzIpBMwfm4L0BAPq7V6kWgwQBKDdG4RZp+7yfN3+ELZX26EQBOg1KoxKi+uo9S+XVwt1LCQceExElFDd6gEkCdlJpqMuh3UgtUqBcVlWpFkN+OFT32LlrkbMHZuCNncAeo0yOpd0kiQJbn/4sBmd/mAELS4/MhIMqOsIJrp88u9xUYalS7aVJMmBRLVKEf2dD4VF7Kx1YHuNAwUpZuQnm2HWq7tkCrn9IWyuaMPYjHjsrG1Hs9OPzAQDijMtaHYFEApHkG0z9Sq7iOhIQhER26vt+H5vM9aUtsDhCWBSbiIWFqfhJ2eMZ5+lPtJplEjTGPpU9pSIDq8zI8PuCaK9Iyuj3RuM1o7v7EGkUSnQ4PBhc2Ub6u0+6DVKhMIiwqIEo1YV/QzS5PRDFOXSqSadCnF6DeIMamQmGmDUquUNKiYNEjsW9PqyeNfmDiAQisibKo+ijwYRUW+FIyLc/jBcfjmQ644GNcJwdwQ3Oq+Lft9xnQT5s75Zp4ZJr0Zcx/+dpaWT4vQw61UwauX50qhVwaBVwaRT9/jZl6g/+h0EKR5bgLKKGjS1tMFkNGD1us245rKzo9cnJVqhVChQWlaFvJxMfPb1d/jFHT8ciDFHZSQY8Oznu3FySTpmj0rC3/67A4FwBKUNTozNiMc/vi7FnctKuhzz1nfl8Ici0cyFgXDvWxuxcFwqTpvct34ntW3eaBCkswzL4SQc43Jf+SnmXjVjzj2g3FV+ihlZNiPWlrYgFBEhSYcvbyQIAuaOScbLK0qxdFIGjDo1Hr5yJhJNWkzJS8QNz6zEqLQ4pFr0WFPaAptZh23VDkzNT4Sqo/7+z/+5NtoMc2uVHcGIiL9/vAMPXT4dALCnvh0AsLuuvUupLgD4cns9fMEItCoF3l1TiQcunYaqVg+ybEakWPT4Ylt99LahiIjSBieCYREKAdBrlB2ZIG6UNTpx9zkTAQDpVgOcvhCqW9ww6eRJ3BMIR3+eexuc2FjRhk0VbVhYfPiF60NpdcknuelWPcZlWbBiZyNybCZ8u6sRd5w+DkqFgFZ3AInm/eXS8pLNeH1lGcIRESqlApUtbph0Kny/txlufwhXnTAKr68sw9p9LdEF9bImF86ant2vMXbKTzHj1MmZuPetjZhXlIK8JDO0aiUsRjV218nN6l64ad5RReeLMizRxdc99e3RxeFt1XZMzZfLCJU3uboFQXzBMERRglGnxvZqO/78wTacOikTyXE6jM2w4OWvSxGKiBiXZcVJ49O6HHvZvAK8+u0+vPrNPlS3ePDl9npcOr8Ay7fU4q3vynHRnPx+P59jqfN1PjjDS61SdPt9VyoEuaavzYSTS9J7vL+eykh1kutpyvPUwYtZ/c0wov06A+2H+luhVMglxQ502iHuS5IkXHPi6I6gkxoS5AVxs06NiCgvore5AxAAJJq1kAC4fCGYdGpIkoSyJle0XGA4IqGs0dVRU1WDvfVO7Gtw4vOtdahu9SAlXg+FAEzNt8GoU6HdGwQAjM+ywhsIY0eNAyadCm5/GP9aWQalQkAoIiLRrIM3EIYnEIbFqEF+shmegFxHv6ndh6R4PZQKuRyZxx9CcaYFexuccPvDAOQSfdk2E1rdckac2xdGMCJvJLAYNHB4gwN+Mp1g0uLOZSV45KPt+PvHO+QSg1oV8pJMaOsoRVeYGodtVXY0Of0oTDVjYXEaAqEIKprdEEW52V5ElPB9aTOc3pC8sBIRYTV29pkJyfO9SQu1SoGUeD1aXQFUtbiRYNLC4Q0iL9mMimYXDBoVijMt+GRTTbSfVWcpjTSrHg0OX0fGVwDZNiPSrQZ8vLEGdXYvtGoFVAoFPB1lElPi9Xjs2tkD+nrR0CNJEiqa3dhU0Ya99e2QIAdEO//mmnRq7Gtwosnph16jhEGjgk6jhFopBx3lrwJUSgVUCgFqlQJun1y+qbTRBZ1agRmFSbhx8RhMyElggI2IjqtwRERNqwdlTS5UNLnhDcq7jVvdct34NncAoYi8kcJi0EQzeju/ymXq/AhFRCSYtLh+0RgUZ1ii59mdn0mOh2O9NkBEsS0iSnB2NAZ3+oJw++VghdMbQns0cy0Yzdpw+uSNdgCgVSlg0qvlgEbHGphZJ1ciyDWbOgK/8vWdQWCzXg2dWsksDRpU/Q6CqJRK/Oj6S3Hrz++HKIq4/MIzEB9nxk9+9Sf88sc/RFKiFT+95Ur8+oHHEQyFsPTkuX1uin4kNyweg3ZvCIWpck19i1GDf67YhzuXjUdRpgU3PbsK/9tci692NKDR4cMNi8fg0821CIZFXDa/oMsO0HZvEA+9txW3nVrcpUkzAHy/txmbK9tw/aIx3cYQEUXsbXBCr5WbogpAtITKwe54aTVmjUrGhXPyoBAErC9rie7WHs7mjE7GKytK4fSF8JsLJnXZndqThcWpWLmrMRqI6kzdt8XpcMPisbAYNchIMGDemBSsL2/Fq9/swyMfbcPzN85DTZu8G/bmU4rwyopStLj8+PvVs3D7S9+j2elHUpwOpQ1OTMlLxK5aR7fHrmh2w+0PYUN5G7ZVO7C7rh3VLW6UTM5CSrweje0+/PWj7ci2yY3d1EoFwhEReo28KyfRpEWbO4hTJ2eipCNjwqhTI96gxi9eW4cEkxb5yWZUtXjwyFUzAQBbK+WMqC2V/Q+C1LR5kByvh0alxMLiNKzb14KH3tsCQRBw2uRMFGVa0OryI/GAk+EFxSl4Y1UZ/relFqdNzkJVsxtLJ2Xi7dUVmJqfiNmjk1Hd6sG3OxuxoCgVTp9cT7Y3gbAjufak0UiK02FSbmJ0N7woSZhZKAeljvYPn1Ih4JoTRyMpXoffvrkR1S1u5Cabsb3agdOnZMKgUaK8ydXtuMc+2YlQWMTd507EurIWtLoCeHlFKX559gQkmrUIhEUUpJjxQA+N5y1GDW5ZUoT5Y1PwqzfW46oTRuHcmbmYkpeIu/65dsgGQYh6IghClw/PAhDNwFEp5d/PpDhdl+v3B18EjE7rGmCcVmCLft9ZYq9zN2Vf+rr4QxHUtXmRniD3sLEaNciymbCjxhEt1WXUqpAcr4+WppMkCVUtHmyqaMWFc/KQmWCEWqVAWaMLDQ4fkuN1ECBAp1GiMNUMUQI2lbdCoRCOSdmq2aOTUZJtRaPDhxSLvqOhqBcJJi3avSGUN7lwy9Ii5CebsWZfM1buaoK5o3SZSiH3jlEIAm4/tRjFmRZUtXhQmBbXpexebZtHDo531PTWqhSYkJOAFpcfcXoNyhpdKEyLQ47N2KWHj90ThC8Yhi8YQVO7D/EGDYozLXD6Ql2Ca3ZPAHqNChqVAs6OmuS1rZ4Bf61o8Ln9ITS1+7Gv0YlNFW3YXNEGfyiCkmyrvOFAKUDsKHMYjohw+cOYOSoZuUkm+ENheIMRBEKRaJmWsCh17IYWEQqLCIREWE1aFGVacM1Jo5Gf0r0PFhHFtogooaLJFf17lJloOKbl7iKihHZvUK4d7wqgweFFeZMb5U0uVLa4oVYqkJtkQm5HhmSqxYAZZi0STXJTXKtRC72mfwt1rC9PRINFkiT4gpFoBka7d38Ao90bhN0t99Focwc6emmEIEpSNEvNpJOzLuIMcmZGRoIBRYZ4OYPtgKwNk07NTSw0bB1VT5D5s6di/uypXS57+Pd3Rr8fX1SI15598Gge4rBSLQakWvb/+6I5efjnN/swZ0wylAoFfnLGePzh35sxa1QSFk1Ix18/2o5QRIRCELCnrh1jM+SDJUnCXz7Yhl21Dry9uhy3Li3u8jhfbq/Hun0tuPqEUd1STatbPAhHRGypbMP9725BglGD+3tYQLW7A9jX4ILLF8JX2+txybx8VLV4uiwcDVcnjEvD1io77j53YrddyD3Jtpnw5HVzejyxPGViRvT7jAQjwqKEjzfWIN6gxuq9zShrdGH26GRML7ThkY+2Idsmn8CWZFvx2dY6LC5JR0WTG/937kT88T9bsKG8FSUdTeU7F9ckAKv3NiElXo9311SiqsWDbJsRyfE6eAJhrNrThC2VKry3rgpjM+JRZ/ci0lGHMMtmws/OHI/5Raldxp9uNaCx3Y9wRMKqPU3wd/zxMevV2FzZhukFNmyubMOa0mYUZ1r63OxZLoUlZ9hYjBrcd/FUREQJf/1oO9bsa+4IggS61IJWKhS49qTR+PMH2zA6LR6VLW5cOq8ABSlmTC9MgkqpwLyxKXh7dQV8wTDKGl1IidcNSCNqQRBw1vScLpcpBHkRcqCc2JGpMTotDrvq2pFi0aO0wYnxWVZIHf1kJEnCU8t3Y1pBIoozLPhuTxNESYLbH8K2KjuuPnEUVAoBc8YkR5t3H6kc2IScBLz6oxOiZWwKU+MGNLOMKFYIgtDn+USnVkYDsTMKk6KXT+noz3Oox8lJMnUrPzYhJwETcrrfXglg+gH3fSyYdGqYUuXnXpRhQVHH+QaALsHwJRMzsWRi5mHvq6iH7KuMBGM0u2r6/kqk0bKQPQWz9we+5ODXgX+vD84u6szoAhBtLJh7hPJuNHBaXH6s29eCeWNTDvs7FBFF1LZ5YXfvb6Tr6CjbYvcE4PbLfZiCYRGSJEGUAAmSXP5OkgMbra4ADFoVsmxGTM5NxKmTMzEmPb5Xva6IiA5FkiQ0tvvw7a5GvL+uGr5gGApBkMuhCAKuPKEwWs72YKIkZ5j6gmG0uQNocPhQb/ehweGDyx/aP59JEsSOep5KpSKaHerwBCBKckZoolmLpDgd8pPNmF5gQ16KGakWPYOxRDRoOntgOr1y2ShvMAJvoCMLwyeXmBI7ytuGI/Imk87NJsGOr6GIvDklFBYRCEeix4Yjcrlfs14ObJgPKDtlNWlRkBoHq1GLBJMGCSa5l8ZI78FGI8uQaIw+UOYXpUYDIIC8G/OvV82MLows31yLyXmJUAgCXvhyL6bmJ2LppEzsqnWgrMmF318yFXe/th4Xzs6LlnKJiCI2lrciIkrYWm3H5NwEtLgC0R2ypQ0ujM2wdJRnCmO73Yumdl+3UjD7Gl1ITzDgsWtm4711lfjT+9tQkm0dkAXnwZZmNfQY+Dmc3u6smTUqCQ9eNg07a9vx4fpqNLb7cOeyEph0aozNsETLHS2dlIkH/7MFr36zDzazFlPybZgxKgmPfrwDAPCbCyYjFI7ApFPDYtSgutWDBy6dir98sA3eQBgZiUbo1EoYtSosm5aNs6Zn48n/7cLEnASs3tuEpna5nIpSIeCEcWndxrmwOA2JZi2yEo1weIN44tOd+GJbHXbWtmNHjQMPXj4NP3t5LX739iacOyMHF8/Nh1Ih9DqCXtHsji5udVIqBEwvtOFfq8pxzowctLj8yEvuuvA1ozAJF8/Jw92vr4c3EEa2zdhlQS3bZkKqRY/Pt9ZjS1Vbj4ttQ924LCue/N8uPPPZbtjMOiTH65GXHEZ5kwubKtrwxbY6fLa1FhNzEpCVaIRCIeCLbfXYU+/ET88cj1SLHFxSCgISzFpM7MXO8IPr+J89o4eVViIioj7whyJ47JMd+HZXIxJNOny6qRYnjk/D1zsa0Oz0QadWQa+Rz1VEScLejh5oCUYt4gxyM8h4gxoWo9wo0qyTyw6oO/owCQIgoOOrIJ+LZSUa+92vjIhIlCTsrJE/Szc4fGh0yMGKBocvWmL2liVFmFaQCKVCLm28obwVD3+4Dat2NyE/xYx6uxd2j1wqMyJKaHH54Q/Kn9usJg1SLXqkWQwoybYizqCGQhC6zWmd2WomvRqJJjmbg30yiOhY6ezvJ28+CaDdG4LDI3/v9ocRCMuZsoGQCH8oAn8oEi011dkfQ61UwKxXwaBVw6BRwqiTgxUmnRpyUpkElVIBvUYFtVKAWiWXH1WrBGiUSqhVQse/FTDr1IgzyBkbBq2KgV6iQ4ipIAiAaACk04E7HX913iQYtSp4g2F8tqUOW6vseHdNJcw6NS6YlYuiDAtOLknDg+9txR8vnYY3VpWhptUDpULAySVp+HJbPdaXteC9tVU4cVwabllahNIGJwpT43DS+DTYzDp8sL4K73xfgSsXjupSFmpfoxMFKWaoVQqcPysPEVFCViJ3VR6JSik3m7WZdXj561KcOzMHk3LlReofnz4ORp38Gs8bm4I5dy2CKEoQBDlAcNdZEyBKEp74dCde+2YfphXYkJtsgs2sgycQwvgsKx69Zja2Vtmh6whG/PTM8SjJtkKvUUX7ydS0eaK1Dw/ljKn7S71lJhoxITsBz3+xB1PzbbjqhEKMSo3D3edMgCAAf/5gG1btaUIwLOKO08cddoczIPcmWbmrEb84e0K366bkJeLv/92BS//2NbQqRY+ZRefOzEVushmbylu79YUAgMvnF+KRj7YhTi/3ZxluLpidi/lFKRAA6Dt+57JsRug1Kvz+nU24cE4eijMteHdNJc6ZkYNgWMTjn+5EgkmLlIOClX+8dBpSLGzMSkREx99X2+tR1ujCkz+cA5tZhxe/2osN5a2YPzYFRZmWaCkzjz8MCRJuPKUIWYlGll8homPK5QtFSzs2OHywewKwu4No8wTQYPdBEIAx6fFItehRkp2AxRPkHoApFn30M1YnQRAwNd+Gx66Zjf9tqUWz048x6fGwmrRQdARn4/UaFGdZmJFGRMdVZylfpy8Epzcol5DydC0j1dbxvd0dQFiUoFUpuvQOshg00R4ZWrUCWpUSWrUSOo1SDlQc0Ahcq1awPwbRcRZzQZDDObA8xHUd/T2+2l6PjzfWYElHOu51J4/B3a+vx5WPr4BKKSDRpMOsUUlYWJyKB9/bikSTFn+8dBpeXlGKX/9rA1qcfly+oAAnjZebCJt0Kjzx6S7c+Owq3HvhZOjUSvxvSy3KGl0oyd6/w5z9A/omxaLHK7ct6LJb8eAG7ApBgEIpdLvs4rn5uO6plWhy+lCUYUFeshlqpQBBEGDWq7s0T5/RQ4mUKXmJ3U7gj2RagQ2r9jTiJ2eMj2YNzBotP86E7ASkWPRItxrw5/e34qnr58CkU6PdE4T1oAZ3tW0erNvXCqNWFe1BciCTTo037jgBzU4/nvlsN0YdVKf/wOdwqGDLnDHJKMqcC0k6dMPloUyjUiL7oD48aqUCT103Byt3N2L+2FToNMouv395ySa4/eFuJx0Hv6eIiIiOB0mS8OH6apw1PTv6t6inXnREREcrFBHR1O5Dnd2LPXVO1Du8yE40IT/FDEEAyptcqG3zoqndj9o2D1pcASSYNEi3GpFq0SPBpEWOzQSrSYvkeLnUlKqPAQurScvPw0R0TEmSBJc/hFaX3B+ovSOw4fSF9jf79gbh6sjQcHaUoVIpBcTp1bAY5HJRVqMGVpMWGQnGjr5B+0tJ6TUjakmVaNgTgsGANNiDOFA4HMb806/CNx+9BJVqcCaUiCjiuz3NyEs2Id1qgCh1b3LmD0bw8opSGLUqnDcrt8siuSRJeGNlGV77tgwKhVyDu9npx30XTcHkI+z6p2Pjw/XVqLd7cdb07G6lyo6VUFg8bBq2JEn43dub4AuGodOosLmiDdedPBqiBCyZmIF9jU786o0NiIgSLptfgPNn5R6XcdOxNxTmOSKiY41zXe99sqkGL321Fy/dsqDPGy+IaPAMtXmuweHD8i218AcjyLIZoVIoUNrghN0TgD8Uwf+zd9/RcVRnH8e/24t6l1Usy3LvvRtTbEzvvfdQAylAQiAJJZAACYReX0joNQFCKKY3Y8C99y6rd23fnfePtYUV29iWZJXV73MOh9Xu3Jk7V6PHd+eZe295nY+tVR5MJshKctGvRxI9UlxsrmxkfVkDhmHQMz2+ab3EnBQ3hZkJMTGFs4i0XGeKdf5g+MckhjewfSqqaKKjssFPRZ2Pyu2jNgKhCHEOK2kJDpLddhLdO6+TsX3Bb/ePPye4bLjsFo3QEIlRHd9T64Qs5uiC0U0/7yb+Oe2WPT6hZzKZOHNKEceO6UmDL4jbYeWpj1c1rV8h7W/n6aray97moTWZTPzimMG88e1Gaj0Brpw5gFe+WY9hwFcrSllfVs/5B/fhyBF5mupCRES6rIUbq7BYLBhGdP74iLHz4tzR/xts/yxi7LLdLq8jPy6Ia8A+lvnx9e4+b0mZpoV5Iz/W3zCi9dlzmR+3+bGMgTcQ5venjFACRET2KmIYVGxPZuyYsreszseijVUs2ljFmKJ0UuMdfLWilFDYoDAznv45STjtFtLinRRkxJOZ5NSc8SLSoQKhaDKjwRei3hddELzeF2z2Xr13x8/BphEcvmAYiM7Ckuiyk+i2key2k5YQjW+je6eRFu8kLcFBWoJDozVEpImiwQEU77Q1PTXzy2OGdHBtpDNKdNm58JC+TT/PGJZLrSfA3/+7lF8eM5jxfTN/orSIiEjn9/isFRgmMxZTdCpKk4lmC9uazTu9Npma5oXf+fXey+ymvHn7a34sYzWb963Mbo7/0/Xftcwu5c2mZnXZ+fjpCQ7SEpwd/asSkQ4UjhhUN/ipqPdRUe+nvM5HRZ2PkhovW6saMQDDgIp6H6GwQVayk4Tt3zWT3HaG9kzhokP6kp+udSdF5MAJRwyC4QihcIRAaPvC34HoQuA7FgCv90UTGc0TG80THv5QBAC3w0q8w0rC9kXB453R1wkuGz2SXdHX2++tJbmjC4DHO627rAcsIrI3SoKIdDJJbju/P2VkR1dDRESkTTxyyaQOnzpBRKQ9hCORZjfmDMOgzhtka5WHWk8AswlCYYOK+h3Jjmiio2L7nPWGYZASH32iOSPBSXqik2EFKRw1Kjoy3DAgI9FJdrJrv9fhEBFprZPv/YQwzUeRWS0mnLbtC4DbLM0TGU4b6QlOCjMTticyrMRvfz/BZSPOYVUsE5F2o2+kIiIiIiIiIi10yyvz2FYTTWa4HVZS4x0EQ2FqPdGpW1Ljo4vpRgwDi9lEWnw0wVGUlcD4PhmkJ0aTHqkJDmy6ISgindSDF0/A7bRjt5qxWczYrWaNyBCRLkNJEBEREREREZEWOmhgNvkZCWQluWj0Bals8GO3mpvmqXc79LVbRLq+nBS3RveKSJel6CUiIiIiIiLSQjOG5TTdGMxIdNIrM6GDayQiIiIiO9O4NRERERERERERERERiUlKgoiIiIiIiIiIiIiISExSEkRERERERERERERERGLSfq8J4vP5+e3tf6e4pByL2cyJxxzGqccfvst2Tz33Bm+//xnJidH5UH955XmMGDqg9TUWERERERERERERERHZBy1aGP3c049l1LCBeLw+Lrz6FiaMGUZ+bvau25127G4TJCIiIiIiIiIiIiIiIgfafk+H5XQ6GDVsIABul5OCvB5UVtW0db1ERERERERERERERERapUUjQXYoLatkzfrN9O/ba7efv/zme7z13qcMG9SPqy89E7fL2ZrDiYiIiIiIiIiIiIiI7LM9JkHOu+ImwuHILu/ff9eNZKSlEAgEufnOh7j60jNxOXdNbpx0zHQuPOtEAB5+6iWefv5Nrrn0rN0e6/W3Z/HGO7MAMAyjRSciItKZKc6JSHegWCcisU5xTkS6A8U6EYk1pkDAv9/RzDAMbrnzIYoK87nwrBP2uv26DVu49+FneeSem/e6bSgUYurRF/Dlu89itbZqoIqISKekOCci3YFinYjEOsU5EekOFOtEJBbs95ogAI/+3ys4HfafTIBUVFY3vf5i9lwKC/JacigREREREREREREREZEW2e8Ubll5Jc+9+h8Ke+Zy3hU3AXDlxWcwYcwwnvjH6wzsV8jUiaN5+OmXWbV2IyaTiZ652dx47cVtXnkREREREREREREREZE92e8kSGZGGrM/eH63n112/ilNr/9wwxUtr5WIiIiIiIiIiIiIiEgrtWg6LBERERERERERERERkc5OSRAREREREREREREREYlJSoKIiIiIiIiIiIiIiEhMUhJERERERERERERERERikpIgIiIiIiIiIiIiIiISk5QEERERERERERERERGRmGTt6Ar8L8MwAAiFQh1cExGR/WOxWDCZTHvdTnFORLqqfY1zoFgnIl2X+nQiEuvUpxOR7mDnWNfpkiDhcBiAQ46/pINrIiKyf75891ms1r2HVcU5Eemq9jXOgWKdiHRd6tOJSKxTn05EuoOdY12nS4LY7XZ65mXz/GN37XNWGuCcy3/L84/dtV/H6sxl2vNYKqPfUVco057HamkZi8WyT9u2NM61pm4qo+tUZdr/WLFYZl/jHKhP15oy7XkslWnfY6lM1/gdHeg+XVdoA5XR7ygWy7TnsTp7GfXpOm+Z9jyWyrTvsVSm/X9HO8e6TpcEMZvNmM1mbDbbfpUzmUz7nMXuCmXa81gqo99RVyjTnsdqaZl97RC2NM61pm4qo+tUZdr/WLFYZn+++KpP1/Iy7XkslWnfY6lM1/gdHeg+XVdoA5XR7ygWy7TnsTp7GfXpOm+Z9jyWyrTvsVSm/X9HO8e6Trkw+snHzui0x2mvMq0p1x7H6cxlWqI9f0ex1g76m2hZmfY6l5YeqzOXaYnOfp3GWjt05jZo6bE6c5mW0Pl07jIt1ZnPqTNfCy0tF2vt0JnLtJT6dJ27TEt09vNRO3TuNmhpuVhrB51P526Dlh6rM5dpic4eu2OtHTpzG7T0WP9bxhQI+I22qlBHev3tWZxyXPs1fmeldlAb7KB2iIq1doi182kJtUGU2kFtsEOstUOsnU9LqR3UBjuoHaJiqR1i6VxaQ+0QpXZQG+wQa+0Qa+fTEmqDKLVDlNqhY9sgZpIgIiIiIiIiIiIiIiIiO+uU02GJiIiIiIiIiIiIiIi0lpIgIiIiIiIiIiIiIiISk5QEERERERERERERERGRmKQkiIiIiIiIiIiIiIiIxCQlQUREREREREREREREJCYpCSIiIiIiIiIiIiIiIjFJSRAREREREREREREREYlJSoKIiIiIiIiIiIiIiEhMUhJkJx988jWXXndrR1dDREREREREYsBZl97IV9/O7+hqiIi0Wmvi2YyTLmPewmVtXCMRkX2nJMhOZh46mSfv/0NHV0NE5ICYt3AZM066rKOrISIiItJtvPjkX5gyYWSHHFt9PxFpSx0Zz0REWktJEBGRGBAKhTq6CiIiIiLSSahvKCKxQvFMRNqCtaMrsCcnnncdxx9xCJ9+/R1biksZOrAvv/vVZWSkpVBZVcODT77IDwuW4vcH6VOYz3133ojTYaeqppa/P/YCcxcuxYSJQw8az1UXn4HdbmPewmXceOv9XHb+Kfzj5bcwDDjhqEO55NyTMJlMvPvhF7zyr/f556N3dvTpi0g3MHHmOfzjkT/Rr6gAgJfffJ8vZv/AI/fc3PT59ddcyBtvz6KkvIJRwwbyhxuuID7OzbaSck46/xf87peX8uxLb+Hx+vjvK4/w0FMv8fHn31JX30hmRiqXnHsyhx00ntq6en5x8z0EAkEOPf5iAP52x/WMGDqA7+Yt4bFnXmXz1hIy0lK44qLTmDpxdIe1i4jElp/q0+0pZgGcd+XvOP2EmRx9+EFN+7rupr8wevggzj39WDxeH488/QpffTuPQCDI+DHD+NVV5zWLkTf98lKeffHfVNfUcdKx0znjxCO47Z7HWbpyDf2KenHHTVeTlpqMYRg88vQr/PejL/H5/aSlJPPzy87W044iss8aGz08+sxrfD1nHnUNjRTk9eCuW67j8l/fznWXn8PkcSM45syruev31zFy6ICmcmdeegMXnnUChx8yiYkzz+G6y8/hzf98RFV1HeNHD+U3111MfJwbgD/+5RHmLliGx+cjPyebay49i9EjBgE0fZedOnE0//7vJ/TKz2HJijW77fuJiLTEieddx3WXn0NDg4dX/vU+B08Zy+tvzQITnHf6cZxx0hEARCIRnnzuDd7676dYzGbOP/P4Zvt56rk3WL5qPakpSXzy5RxSk5O46pIzOHjyWABuv/dxzGYzHo+Xb+cu4vILTuOoGVN58IkX+WrOPACmThjNz392Fi6ns30bQUS6rE49EuTt9z/j1huv4t2XHiY1JYlb//IokUiE6//wVywWCy8+cTfvvfYol194GmaTCcMwuOEPfyMtJYnXn/kbzz9+F2vWbeKZl/7dtE+P18vK1et5/Zm/8fDdv+M/H3zOfz/6suNOUkTkJ3zyxRwevPu3/Pu5v1NWUcXLb77X7PMvv53HMw/dzpv/uA+Avr178vSDt/HhG09w0dknctvdj1FcUkZSYgL33XE98XFuPnnraT5562lGDB3AmnWbuPlPD3DlxafzweuPceO1F3Hr3Y+xcXNxR5yuiMSo3fXpYM8xC+DYmdN4d9YXTfsoq6hi3qLlHDl9CgB/+usT1NU38Nxjd/LGP/9GOBzirw//o9lx5y1cxvOP38XTD9zGq//+gJv/9CDXXX4O773yKDarlX+8/DYA381bwoeffsOzD9/Bx/96igf+/Bt65mW3R9OISIy4/a9PsKW4hCfu/yOz3niCG6+9GIfD3vS51Wpl+rSJvP/RV03vLV+1jvKKag6aNKbpvfc//pqH7v4db/7zPuobGrn/0eeaPhszYjAvPXU3H7z2GNMPnsBNdzxAo8fb9Pm6DVuwWMz8+7m/89fbf73bvp+ISFtYt3ErToeDt198gDtuupqHnnqJLcWlALw760v+++GXPHLPzbz2zF9ZsWodHq+3Wfk5PyxiUP/efPD64/z8Z2fzh7seaSoPMOuz2Rx7xMHMeuMJjp05jfsefY4txaW88Pifef6xP7NxSzF/f+yFdj1nEenaOnUS5KRjDqNXzxycTgdXX3ImcxcuY8GSlWzYVMz111xIYkIcVouF4UP6Y7fbWL5qHZu3lnL1pWfidDpISkzg/DOOY9ans5v2GYkYXHnJGTidDnr1zOGU42bw/kdfd+BZiojs2dmnHk1qchIJ8XEcMnkcK1ZvaPb5xeecREJ8HE6nA4iubZSanITFYmbGwRMpyO/B4mWr97j/f/33E46acRBjRgzGbDYzfEh/Jo8fycdfzDmQpyUi3czu+nRl5ZU/GbNmHjqZZSvXNSVF3vvoK8aOHEJ6WgrVNXV89vX3/PrqC0iIj8PldHLpeafw0effEg5Hmo57wZnH43I6KSzIpU9hT4YN6U/vXnnY7TamTR7NyjUbALBaLASCQdZv2EIoFCI7M52eeT3avZ1EpGuqqq7l869/4DfXXUxGWgpms5n+fXqRnJTQbLsjp0/hky+/wx8IAPD+x19xyNRxOHdKlpx96tFkpKWQEB/HZeefwoefzSYSica1Y2ZOIz7OjdVq5ZxTj8EwIqxZv7mpbFycmwvOPB6bzdrUNxQRORCSk+I565SjsFqtjBo+iB5Z6axeuxGADz75mlOPP7yp73flxWcQiRjNyufnZXPi0YdhtViYOmEUo4YPZNZnP967Gz9qKBPGDMNsNmO32/jw02+44qLTSEpMIDkpgcsvOI33PvqqKT6KiOxNp50OCyA7M73pdWpKEnabjaXL15CRntKso7jDttIKGhobmXnK5U3vGYbRLCja7TZSk5N+PEZWOuWV1QfoDEREWictNbnptdPp2OUJmqyMtGY/v/Tme7zz3meUVVRhMpnwen3U1Nbvcf8lpeX8sGAZ737449PW4XCYOPeUtjkBERF236crr6zm4y+/22PMSkyI46CJo/jvrC+55NyT+e+sL7niwtMA2FZaTiRicPL5v2h2HLPJTGV1TbNj7eB02pv1AZ0OB16vD4DRIwZxybkn8cQ/X2fDpmLGjhzCNZedSU52Zpu3hYjEnm2lFdhttmaxbncGDygiNSWJL2fP4+ApY5n16bfccfM1zbbpkfXjPrIz0wkGQ9TU1pOclMAT/3idj7+YQ1VNLWaTmUaPl9qd+nkZ6dEEjIjIgbZznwrA5XTg2d6vqqis2W3fb2f/Gy+zM9Mpr/jx3lxW5o/fc2tq6wkGQ/TIymh6L7dHJoFgkJq6+l3qIiKyO506CVJSVtH0uqqmlkAwyOCBfXjmxX/jDwRw2JsnQrIy0khJTuQ/Lz28x30GAkGqamqbgmRpWSUZaSkH5gRERH6Cy+nA5/M3/VxZVbPf+zCbTU2vFy5ZydPPvclDd99Ev6ICzGYz511xE8b2h25Mu/lSnJmexuknzOTKi8/Y72OLiOyr3fXpQqHwT8YsgGNmHsxf/v4040YNpa6+oWmNjqyMNMxmE++8+OBun3beVlK+33U8+dgZnHzsDBoaPdz9wDP87ZHnuPe2X+3/yYpIt9MjK51AMEhpWWWzG3e7c+RhU3j/469xOhw4nPZm64NANKEyeEAfAErKKrHZrCQnJfDhp9/w4aezuf/OG8jPzcZkMnH4yZdh8GPQNJtMzfa1u76fiMiBlp6WvNu+3852/hygtLySoYP6Nv1s2imeJSclYLNZ2VZa3vSAy47kc3Ji8xF3IiJ70ql7Rf/+7yds3FyMzx/gkadeZsTQAYwY0p+eeT2458FnqW9oJBQOs3DJSgKBIAP79SYzPY3Hn32NRo8XwzDYVlrB7O8XNu3TbDbx6P+9is8fYOPmYt54ZxYzD53UgWcpIt1V/z69eP/jrwmFw6xau5H3P/5q74V+QqPHi9lsJjkpgYhh8M4Hn7Nuw5amz1OTE/F4vVTV1Da9d8LRh/KfD79g7oJlhMMRAoEgi5etZsOmra2qi4jIznbXp9tbzAIYO3IwhgH3PvQsMw+djNUafX4nLTWZgyaO4d6H/9E0cqSyqobPvv6+RfVbtnIti5auIhgM4bDbcTkdWCydupssIp1IakoSB00czd0P/h8VldVEIhFWrtlAbd2uo3GPmD6Z7+Yt5uV/vccRh05udqMP4MXX36W8spr6hkae/OfrTJ82AbM5OurDZrOQlJhAMBji6ef/hcfj++l67abvJyJyoB1+8ETeeGdWU9/v0f97tdnDewCbt5Tw1n8/JRQO8/Wc+cxdsIzp0ybsdn9ms5nDD57IY8+8Rm1dA7V19Tz2zKsccdhkjX4TkX3WqUeCHHP4NH7/54fZUlzKkAF9uPXGKzCbzdxz26944PEXOP3i6wkGQ/Qt6snf7rgBu8XMvbf/ikeeepkzL72BRo+X7Ix0Tjj60KZ9ul0u+hUVcMoFvyASMTj+qEM4asbUDjxLEemufnnledx+7+McftJlDBvcjyNnTGXJ8j2v37E3E8YM49Cp4zjnZ7/FbrNxxGGTGTq4X9PnBfk5HDvzYM669EbC4Qj33vYrhg/pz22/vYrH//EaGzYVYzab6Nu7gGsuO6stTlFEBNh9ny49LeUnYxZEnwI8+vCDeOq5N/j99Zc3++zmX1/GU8+9wUXX/J7a+uhUCNOnTeDgyWP3u36NHi8PPvEiW7eVYbFYGDqoD9dfc2GrzllEupdbrv8ZDz/1Mhde83s8Xi+98nO565af77JddmY6Qwf2Ze6CZdywmzgz89DJXH3Dn6isqmXc6KH84opzAThqxlS+n7+Uk867DrfbxeknziQjI/Un67Snvp+IyIF0zMxpFJeUc8Wv7sBsMXH+Gcfz2VeuZtuMHzOMJSvW8MCTL5CSlMgfbryC/NzsPe7zF1ecy9+feIGzLrsRgKkTRuk7q4jsF1Mg4Df2vln7O/G867ju8nOYNmlMm+1z3sJl3Hjr/cx684k226eIiIiI7Flr+3T/nfUlr731Ic88dHsb10xEpHOZOPMc/vHIn+hXVNDRVREROWCeeu4NVq/dxF/++Iu9bywi0kY0bkxEREREOiWP18drb33Iiccc1tFVERERERERkS5KSRARERER6XTe++grjj79KjLSUjR1qYiIiIiIiLRYp50OS0REREREREREREREpDU0EkRERERERERERERERGKSkiAiIiIiIiIiIiIiIhKTOl0SxDAMQqEQhqFZukQkNinOiUh3oFgnIrFOcU5EugPFOhGJBZ0uCRIOh5l69AWEw+GOroqIyAGhOCci3YFinYjEOsU5EekOFOtEJBZ0uiSIiIiIiIiIiIiIiIhIW1ASREREREREREREREREYpKSICIiIiIiIiIiIiIiEpOUBBERERERERERERERkZikJIiIiIiIiIiIiIiIiMQkJUFERERERERERERERCQmKQkiIiIiIiIiIiIiIiIxSUkQERERERERERERERGJSUqCiIiIiIiIiIiIiIhITFISREREREREREREREREYpJ1bxvceOt9zF+0nDEjBnPnLdfi8/n57e1/p7ikHIvZzInHHMapxx++S7mnnnuDt9//jOTEBAB+eeV5jBg6oO3PQEREREREREREREREZDf2mgQ5/YSZHDNzGu/N+rLpvXNPP5ZRwwbi8fq48OpbmDBmGPm52buUPfe0Y3ebIBERERERERERERERETnQ9jod1qjhg4hzOZt+djodjBo2EAC3y0lBXg8qq2oOWAVFRERERERERERERERaYq8jQX5KaVkla9Zvpn/fXrv9/OU33+Ot9z5l2KB+XH3pmbh3SqaIiIiIiIiIiIiIiIgcSC1OggQCQW6+8yGuvvRMXM5dkxsnHTOdC886EYCHn3qJp59/k2suPWu3+3r97Vm88c4sAAzDaGmVREQ6LcU5EekOFOtEJNYpzolId6BYJyKxxhQI+PcazeYtXMbrb8/izluuBaIB8JY7H6KoMJ8LzzphrwdZt2EL9z78LI/cc/Netw2FQkw9+gK+fPdZrNZWDVQREemUFOdEpDtQrBORWKc4JyLdgWKdiMSCva4JsjuP/t8rOB32n0yAVFRWN73+YvZcCgvyWnIoERERERERERERERGRFtlrCveaG+9izfpNeH1+jjv7Gm77zVU89+p/KOyZy3lX3ATAlRefwYQxw3jiH68zsF8hUyeO5uGnX2bV2o2YTCZ65mZz47UXH/CTERERERERERERERER2WGvSZAH//LbXd6b/cHzu932svNPaXr9hxuuaEW1REREREREREREREREWqdF02GJiIiIiIiIiIiIiIh0dkqCiIiIiIiIiIiIiIhITFISREREREREREREREREYpKSICIiIiIiIiIiIiIiEpOUBBERERERERERERERkZikJIiIiIiIiIiIiIiIiMQkJUFERERERERERERERCQmKQkiIiIiIiIiIiIiIiIxSUkQERERERERERERERGJSUqCiIiIiIiIiIiIiIhITFISREREREREREREREREYpKSICIiIiIiIiIiIiIiEpOUBBERERERERERERERkZikJIiIiIiIiIiIiIiIiMQk6942uPHW+5i/aDljRgzmzluuBWDpirX86a9PEAgGOXL6VC4+58Rdym0pLuWWOx+ivqGRsSOHcMPPL8RkMrX9GYiIiIiIiIiIiIiIiOzGXkeCnH7CTG65/vJm7/314We57bdX8crT9zL7+wWsWb95l3KPPP0yF59zEq8/+zdq6+r5es6CNqu0iIiIiIiIiIiIiIjI3uw1CTJq+CDiXM6mn8srqwmFI/Tp3ROLxcz0aRP5es78ZmUMw2DxstVMHj8CgJmHTearOfPatuYiIiIiIiIiIiIiIiI/Ya/TYf2vispqMtJSmn7OSE9h/qIVzbaprWsgMSG+afqrjLQUyiuq97jP19+exRvvzAKiCRQRkVijOCci3YFinYjEOsU5EekOFOtEJNbsdxLkQDjluBmcctwMAEKhEFOPvqBjKyQi0sYU50SkO1CsE5FYpzgnIt2BYp2IxJq9Tof1v9LTUiiv/HFUR3lFNelpyc22SUqMp66+oSlbXP4/o0dEREREREREREREREQOtP1OgmSkpWAxm1mzbhPhcISPPp/NlAmjmm1jMpkYPLBP02LoH3zyDZMnjGyTCouIiIiIiIiIiIiIiOyLvSZBrrnxLn73pwf55vuFHHf2NSxetppfXXU+v7/rYU6/+NdMGDOMPoX5ANx535MsX7UOgKsuPoOnnnuDUy74JYnxcUweN+KAnoiIiIiIiIiIiIiIiMjO9romyIN/+e1u33/xyb/s8t5Nv7i06XV+bjbPPnxHK6omIiIiIiIiIiIiIiLScvs9HZaIiIiIiIiIiIiIiEhXoCSIiIiIiIiIiIiIiIjEJCVBREREREREREREREQkJikJIiIiIiIiIiIiIiIiMUlJEBERERERERERERERiUlKgoiIiIiIiIiIiIiISExSEkRERERERERERERERGKSkiAiIiIiIiIiIiIiIhKTlAQREREREREREREREZGYpCSIiIiIiIiIiIiIiIjEJCVBREREREREREREREQkJikJIiIiIiIiIiIiIiIiMUlJEBERERERERERERERiUnWlhbcuLmYW+586Meft2zjtt9exbRJY5reu/3ex1mweAVxbhcAd95yLXk5Wa2oroiIiIiIiIiIiIiIyL5pcRKkID+Hfz56JwAer4+TzruOcaOG7LLdL644jykTRra8hiIiIiIiIiIiIiIiIi3QJtNhfTl7HmNGDMbldLbF7kRERERERERERERERFqtxSNBdvbJF3M4cvqU3X724JMv8vizrzFx3HB+dv6pWCy75l1ef3sWb7wzCwDDMNqiSiIinYrinIh0B4p1IhLrFOdEpDtQrBORWGMKBPytimaNjR5OvfDX/Ov5+3HY7c0+q6isJi01mUAwyO33PM6IoQM45bgZP7m/UCjE1KMv4Mt3n8VqbZMcjYhIp6I4JyLdgWKdiMQ6xTkR6Q4U60QkFrR6OqwvZs9j3OghuyRAANLTUjCZTDjsdo6cPoXlq9a19nAiIiIiIiIiIiIiIiL7pNVJkI+/mMNh0ybs9rOKymoAIpEIX347j8KC3NYeTkREREREREREREREZJ+0ahxbQ6OHZSvXctct1za9d+d9T3Li0YcxsF9v/viXR6mpq8eIGAweWMRpx89sdYVFRERERERERERERET2RauSIPFxbv77yiPN3rvpF5c2vX7o7ptas3sREREREREREREREZEWa/V0WCIiIiIiIiIiIiIiIp2RkiAiIiIiIiIiIiIiIhKTlAQREREREREREREREZGYpCSIiIiIiIiIiIiIiIjEJCVBREREREREREREREQkJikJIiIiIiIiIiIiIiIiMUlJEBERERERERERERERiUlKgoiIiIiIiIiIiIiISExSEkRERERERERERERERGKSkiAiIiIiIiIiIiIiIhKTlAQREREREREREREREZGYpCSIiIiIiIiIiIiIiIjEJCVBREREREREREREREQkJllbU/jE864jzu3CbDKREB/Hw/f8rtnnW4pLueXOh6hvaGTsyCHc8PMLMZlMraqwiIiIiIiIiIiIiIjIvmhVEgTgifv+gNvl3O1njzz9MhefcxJTJozkptv/ztdzFjBlwsjWHlJERERERERERERERGSvDth0WIZhsHjZaiaPHwHAzMMm89WceQfqcCIiIiIiIiIiIiIiIs20aiSICRNX/voOzGYTp594BDMPndz0WW1dA4kJ8U3TX2WkpVBeUb3b/bz+9izeeGcWEE2eiIjEGsU5EekOFOtEJNYpzolId6BYJyKxplVJkMf+dguZ6alUVFbz89/8maJe+fTp3XO/93PKcTM45bgZAIRCIaYefUFrqiUi0ukozolId6BYJyKxTnFORLoDxToRiTWtmg4rMz0VgPS0FCaOG87KNRuaPktKjKeuvqEpY1xeWU1GWkprDiciIiIiIiIiIiIiIrLPWpwE8fp8NHq8AHi8PuYuWEZhQW7T5yaTicED+/D1nAUAfPDJN0zWougiIiIiIiIiIiIiItJOWjwdVlV1Hb+59X4AIpEIxx15MIP6F3HnfU9y4tGHMbBfb666+AxuufMh7n/sOcaMGMzkcSPaqNoiIiIirbdkUzVOu4U+2YkdXRUREREREREROQBanATJ7ZHJc4/ducv7N/3i0qbX+bnZPPvwHS09hIiIiMgB9dHiYqwWE1cfMaijqyIiIiIiIiIiB0CrFkYXERER6cqC4Qiltf6OroaIiIiIiIiIHCCtWhhdREREpCsLhSNsrWrs6GqIiIiIiIiIyAGiJIiIiIh0W6GwQVVDAI8/1NFVEREREREREZEDQEkQERER6bZCkQgAWzQaRERERERERCQmKQkiIiIi3VYwbACwpVJJEBEREREREZFYpCSIiIiIdFuhcASnzcKWSk9HV0VEREREREREDgAlQURERKTbCoUj5KW5Ka31dnRVREREREREROQAUBJEREREuq1Q2KBHspvyOl9HV0VEREREREREDgAlQURERKTbCoYjZKe4qFASRERERERERCQmKQkiIiIi3VYoHKFHspvKBj/hiNHR1RERERERERGRNqYkiIiIiHRboYhBVpKLcMSg1hPo6OqIiIiIiIiISBtTEkRERES6rWA4gsthIdlt17ogIiIiIiIiIjFISRARERHptkLhCFazmfREh9YFEREREREREYlBSoKIiIhItxUKG9isZtITnFTUKwkiIiIiIiIiEmusLS1YWlbJrfc8SnVNHRaLhQvPOoHDDhrfbJvb732cBYtXEOd2AXDnLdeSl5PVuhqLiIiItJFQOILNYiIj0UlFvb+jqyMiIiIiIiIibazFSRCLxcx1l59Lv6ICKqtquODqW5g0bjgup7PZdr+44jymTBjZ6oqKiIiItCXDMAhFjO3TYTlZWVzb0VUSERERERERkTbW4umw0tNS6FdUAEBaajLJiQnU1TW2WcVEREREDqRQxADAajHTPyeJJZuqCW9/T0RERERERERiQ4tHguxsxer1RCIRsjLTdvnswSdf5PFnX2PiuOH87PxTsVh2zbu8/vYs3nhnFhB9KlNEJNYozol0PqFwBACrxcTA3GQAlm+tYUh+SgfWqmtTrBORWKc4JyLdgWKdiMQaUyDgb1U0q61r4Ipf3c5vrruYYYP7NfusorKatNRkAsEgt9/zOCOGDuCU42b85P5CoRBTj76AL999Fqu1TXI0IiJtLhyJsLmikbWl9awpqeNnMwbsc1nFOZHOod4b5My/f8brvzoUp83C/e8uJcFl4+JD++29sOyVYp2IxDrFORHpDhTrRCQWtCp6BQJBfnPrfZx7+rG7JEAgOmUWgMNu58jpU/jky+9aczgRkXZnGAZ13iBbKhvZWN7A+vIG1pbUsaG8AbPJRO+sBIqyEjq6mrIbdd4AVQ0BemXEd3RVpJMKbh8JYrOYABhTlM6r36zvyCqJiIiIiIiISBtrcRLEMAzu+OvjjB4xiCOnT9ntNhWV1aSnpRCJRPjy23kUFuS2uKIiIgdaMBRhdUkdSzdXM3ddBaW1Php8QbyBMKnxdgoyEuiVEc9xY3pSlJ1IToobi9nU0dWW3VhZXMuf3lxInSdAUpydZLedSf0zCYQizF5VRjhicOXhAxneK3WXsr5gmFXFtQwr2PUziS2hcAQTYDZF/47zUt1sq/FgGAYmk/62RURERERERGJBi5Mgi5au4qPP59CnMJ8vvpkLwO9vuIJX//0+Jx59GAP79eaPf3mUmrp6jIjB4IFFnHb8zDaruIjI/mrwBalu8OMJhCmt9VJW66Os1su2Gi8byuqpaQyQ6LYxOC+FgwZlU5AeT5zTRnaSC6fd0tHVl73w+EM0+IJ8taKUF75ayzlT+zBzeC7ryuopqfbyw7oKLGYTZ00poqzWy13/Xsifzx5Lr4x4QuEItZ4AcU4bz32+hnfmbuLRSyeRmxrX0aclB1AwHMFqMTclPLKT3XgDYWo9QZLj7B1cOxERaQuhcIQGX4h6XxB/MEw4YhAxDCLb/2/CREq8HYvZRMSAnBR3R1dZRERERNpYi5Mgw4f055v3n9vl/Zt+cWnT64fuvqmluxcRaRXDMGj0h/h+TQWLN1ezYmsNmysasdvMuGxWMpOcZCW5yExyMbFfBmdN6U1GgpO0BIeeAO9iIobBIx8s56NFxYQiBv1zkrjl5BGM6JUGwJD8FIbkpzB9WE6zcoFQhOuf+45RhWks3VxDjSeAy24hEjEYVpDKK9+s55fHDOmIU5J2EgobWC0//r077RZS4uxsq/EoCSIi0kmFIxHK63yU1HiprPfT4AtS5w3++H9vkHpfkHpvkHpfCI8/BIDDZsZps2A2mTCbTdH/m0wYhkFVg5+IAWYz/Pv66R18hiIiIiLS1rSikYh0WeGIQWV99Evw+rJ6Fm+qZm1pPR5/CG8gTMQwKMyMZ2RhGuce1IcBuUmkxDk6utrSxmYt2srcdZU8dPFEclLdTVMb7c0Zk3vTPyeJ9WX1zByRx/CCFNaXNVDnDZKT4uKa//uW575Yw6kTCnHYzKworiUj0UmjL4TZBPnpWmukqwuFI9gs5mbv9UhxU1LtZWBucsdUSkRE8PhDbKv2UFITHbFbUhN9XVITHclrMkFmkpO0eCeJLhvxLhuJLhsZia7oz04bCS4rCS47CU4rCS4bdmv7jeqNGAZz11XQOzOBtARnux1XRERERHZPSRAR6RLCEYOlm6tZvrWG0hovq7bVsaWykYgBGYlO8tPjGJKfwnFjepLgsuGyW3E7LCS69DR3LCut8fLMp6v5xdFDyEvb/6mrRhamMbIwrennPtmJTa/vOXccf3tnCW99vwm71Uw4YuALhrGaTRhAvNOG2QSZSS5+ecwQspNdbXFK0o5CkeYjQQCyk10UV3s6qEYiIt1PnTfAmpJ61myrY3VJHWtK6iiv8xHnsJKd7KJHipvsZBdTBiRGf052k57owGI2733n7eTKp77BZrMxqV8mP6ytoKLeR70vyICcZO48a/Q+P6DRkQzDYN76Sl6bvZ7yOj9De6ZwxuRCspM1PZiIiIh0fUqCiEin5PGHWLSxivkbqiiu9rChrB6AIT1TyElxc+bk3hRlJ5LRyb4ES/vxB8Pc/sYCpg3qwfi+GW2+/14Z8fz9wvFsrGjEHwzTOzOBOm8Ah82CYcCWqkYAPl9awi//MYcbjx+224XWpfMK7m4kSLKL4mpvB9VIRCS2BUJhNpY38PmyEpZsrqaqIUBVg5/sZBd9sxMZkJvEsaPz6ZUZ36UeZDn3oL6EIvDZsm3MGJZDz/R48tPjuO7ZOTw+ayUzh+eyIw+S5LaTGu+gusFPSnzzEcqNviBldT4yEp3EO20/eUyPP0Rp7Y//Xi3fWsOKrbVMH5pDeqKz2domFfU+/jVnIw6bhcn9M1myuZoN5Q30z0li8aZqhhek8tHiYjZXNHLS+AL69kjkkyXbuOLJ2ZxzUBEnj++11zZ4d95mQmGDo0bl4Q2ESHDaKK72EAhFADCbTOSnx3WJhJCIiIjEHiVBRKRTCIYjvP7tBlYV11JR72NjeQNZSS7G9slgcv9MTpvYi0F5yUp4SJNXZ6/HbjVz6WH9DtgxTCYTvTJ+nPZq5yktdkyXNDA3md5ZCdz6+nwG5iZz9RED6aFFVbuE0PaF0XeWneJm7vrKDqqRiEhs8fhDLN1czYKNVSzcUMWG8gac22/EnziuF+kJDnqmx5Pg+ukb/p3dxH4ZWK1WDhnSo9n7fzh1JE9/sorfvvhD03uhSITDh+XyztzNDM5LJjctjgl9M1hbUse/vt8EREdlnDm5NyeN78WqbbXMXlXGoYN7kJ8eTzAcoazWy+9fmUe9L8SOlEJGopOBecn85a1FNPpDDMxNJivJhT8U5rvV5YwuSscfDPPuvM3kpLgpzErgnbmbGdYzhTe/28i0gVn88dSRuB3RWwQjeqVxzOh8fvvCD9gsZjaU1RMxIN5p5YzJvXln7mYOG9KD79ZUsHhTFQs3VmE2mXjt2/WEwwaTB2Ty0aJiHLboNGShcIQeKW76ZCcyvCCVgwZlYzErISIiIs0ZhkFFvZ8Elw2nrf2msmxLmysbuf/dpVTW++iR4qbOG8TjD3HhIX05aGB2R1ev21ISREQ61JqSOhZsqOSDhVtx2iwcPjyXlDgHA3OTNIey7NHWqkb+/d1G7jl33C43sTvC4cNzGdcng5e/Xsd1z84hLy2OoT1TKMxMaLZdSpydIT1T9BRkJxFdGL359VOYEc+GsgY8/lDTjSARka4oYhgYBh1yo7mizseTH6/k29XlZCY6Gd4rldMnFTIoL5nkOEe3ufndKyOe208f1ey9jxYV89QnK/nDKSMorvZQWe/nvv8sJT89jltOHs7Qnqks3VzNXf9axBfLS9hc2ciIgjSufXYOwwtSWbqlBo8/xFEj87ji8AGY/qdPcdXMgdR5A3yyeBveQAhMJk4Z34uinab83Ff9eiRx2qRCXvlmHdOH5uK0mZm/oYqLH/0KgH9/txGb1cxRI/M4c3JvTCYTGysa2Fbt4d15m3ngogn03L6GWiAU5rOlJZTWenn+yzW8Ons9Z08tIjvZRUmNlykDslrYyiIiEisMw+CB95Yxa1ExGYlOHrxowl5HRnYG1Y1+IhGD1HgH68sauPvtxQwvSOH8aX3YVuMhJc5BTWOAB99bRn5a3C73CaR96Nu9iHSI1dtqefO7jfywtoKhPVM4a0oRUwdkdYob2tL5vfLNeg4alE3vrM7TeUiOs3P54QOYOjCLsjof360uZ9mWmmbbFFd5SEtwcOeZo4nb3pnzBkJ8u6qcEb1Sd5kWQw6sUDiC9X9uxPXKTCA/LY7Plm7jqFH5HVQzEZF9FzEMSmu8bK3ysK3Gw9ZKD5sqG1lXWkeiy85fzxvXLiMtSmu8zF1fwdy1lcxdX8HUAdk8ftlkrZn1P6YPy+HQoT2aPRBx0aHNR7UOzk/hT2eO5qsVpfzh1JGkxDkoqfEya9FWThpfQFFW4k8m6hNddk4YV9Am9T1tYiGnTixsqu+J43rxxpwNHDM6n48WFzO2KL0p0QFQsH0E7c5lAOzW6MNOAGdM7s1Hi4p58uOV1HuDWC1mPl9WwvKtNYS2T1X58yMHMbZP2093KiIinUdlvY9PlmwjNd7B8q01LN9aS703yLNXTuWB95bx9CeruPaowR1dzb269+0l1HkDHDQwm1e+Wc/Bg7O5bPoALGYTwwp+nDK7qsHPH16dxzlT+zAgN6nZv59y4CkJIiLtJhAK8+XyUv4zbzNbKhs5eHAPHr10Euka8SH7objaw5fLS3n00okdXZXdGpyfwmDgkME9dvksGI5wxxsL+P2r8xmcn0xBejz/9+kqTJjISHTy57PHNE0bIQdedGH0XROvR47M4+0fNikJIiKdij8YZtW2WjZVNFLvDbKpooGKej/ry+oJhiJkb19APDfFzbRBWVxwcB9e/WY9D763jJtOGn7A6lVS4+GxWStZsKGSgbnJjCxM4+LD+jVbk0Ka25cRoQUZ8U0JBYDsZBfnHtTnQFZrt0wmEzvX1mm3cPbUIoCfXCvkp87RZjFz5Mg8pg/NwR8Ks63aw7+/38Svjx1CktvOmpI6/vLWYk6bVMgJY3tit6pvJCIdJxAK88PaCkIRg0F5ybp/0QYMw+D9BVt5+pNVDMxLprYxQE6qm7OnFNG3RyLpiU6uPmIg1z4zh0F5W5kxLLejq7xHq7bVsrK4liS3jee+WMs9546lf07Sbrc9fVIhhmHw4aLouV91xEBqGgM4bRaG9Ezhz/9axDGj85kxLGeXkZ7SekqCiMgBFY5E2FDWwFcrS/lgwVYS3XaOGZXPoUN6aKoZaZFXv1nPtEHZZCd3vZsrNouZG44byr+/30R5nY/nv1zLuQf14bAhOfzu5bnc8so8hhek4g+FGVWYRlaSS+uLHEDBUASbZdfO5dSBWTzywXK2VXvU/iLSbgzDoLLBT0Wdj6oGP5X1fjaUN7CmpI4aT4DaxgCJbhuFmQnEO230ykxgbFEGBRnRRbhtu0nqnjy+F395a9EBqev3ayv4YMFWFm+u5uBB2TxzxVSNaJT9YrOasVnN9O2RxPXHDW16vzAzgexkF4/NWkl5nY+rZg7c4z6CoQg2q0aSi0jrhSMGFXU+ktx2Nlc28MHCrUQiBmV1PrZVe0lwWbnvP42cPbU3J47r1W2mdmxL4YjBx4uL+XJFKZsqGrj55OGM6JW2220zk1zceMJQbn99AaU1Xs6cUtTp2rzOG+Dh95dz5Mg8xvfNYEtl4x4TIBB9sODMKUWcOaWIV79Zzz8/X0NBejzryupp+DjI8IJUnv1sNTaLmZR4Oy679Sf3J1DTGGBLVSOD85L3mjjSHUgRaXO+YJj56yv5dlUZ362pIGwYjChI5YbjhzK8IFUZbWmxkhovny8r4aGLJ3R0VVoszmlreoJyZ7edPoonPlrJ+rJ67FYzD763nBqPn4sO6cfhw3N3e3NLWie4m4XRAVx2K4Pykpm3vpKjlQQRkQPAGwixtrSeNdvqWF1Sx+aKRqoa/dR5AiTH2UmNd5Aa7yA/LZ5TJxaSFu8gJd5OVpJrv/pRLocVTyDcpnXfVNHA47Oi/16dMLaA0yYV6gu6tLmhPVO55eThXP30twzKTebgwdm7XPsbyur59XPf/+RNNBGRvan3Brn9jQWs2lZLJGIA4LBZmDYom1DEwGQy8eBFE3A7rKzeVsvdby/my+Wl/O6k4WQmacrH/fHhwq289PU6ZgzL4cbjh+51vY8RvdK459xx3P3WIirq/fz8qEEdvr5mVYOfL5aVUN0Y4LNl2+jfI4nzDuqDzWpmSH7KPu/ntEmFnDapEICKeh/vzd/CGZN7M2d1Ofe/u5Qdp3nkyDxOHFtAOGKQnnjgRyGFIwazV5VR3egnPy2OoT1Tm5JPvkCYel+QlDj7br9HG4bRrvf7VhbX8qc3F+Dxh3E7rMQ7rfzymCEUpMfz9CeruPzwAc22VxJERNpEWa2Xuesq+WFtBQs2VJKa4GBiv0x+f8oI+uUkdbqMvXRNr81ez5QBWeSmxnV0Vdqc02bh50cOavbeoo1VPPjeMp75dDUOmxm71cIvjxnM0J6pe9iL7I9QZPdJEICRhWnMX1/J0ZoSS0RaKRiKsKWqkU0VDRRXefhhXSWrt9WSHOegb3YifXokMrl/FilxdgqzEnC24bSIbrsFrz9ExDBafdOgwRfkv/O28Ors9RwxIpffnjisSyxWKl1XdrKbXxw9mMc/WsFf/7OE6UNzuO7owVTW+5i9qpwPF24lJ8XNg+8t5+GLJ+K0a9osEdk/xdUeHv1gOXEOK49cMomsJCdVDQHinVZc9l1vmfbtkcQjF0/i0Q+Xc9vrC7j7nLGa4WIfeQMhXvxqLZfPGMDkAVn7XK53VgJ/OnM0v31xLn/+1yKuOXIQ9727hJIaLzOH53HkyNx2mTYxEArz9/8u4+uVpQzJTyEz0cnPpg9gQr+MVvex0hOcTVNeTu6fycbyBsb3zcDtsPKLZ+fw33lbGNU7jZtObPvpTRt8QbyBMBmJTgzD4KmPV/LNqjJ6Zybw6jfrSXLbqfMGsFstVDf68QcjpCc4uOLwgYzvG127q94b5NnPVvPp0m1M6JvBlTMH0ugLsamygfJaH/EuG5P6ZVJS4yUvbdd7ORV1PtaW1jEgN5kkt3239TQMg2c+XU1JjZd6X5AEl4356ys5Z2oRM4fnsWpbLcu31nDD89+TnuDE7dj1mtBfqojst2A4QoM3yKaKRuauq+CHdRVsqfQwMDeJ0UXpnH9wH/LT4jTiQ9pUWa2XT5Zs48GLuu4okP01rCCVx382mU3lDYQiBos2VnHXvxZx11ljms0TLi0TChu7LIy+w8jCNF6dvZ5aT2CPHTERkR0ihkFZrZeN5Q1sLG9kY0UDWyobqWzwU9sYwGm30DM9nh4pLmYMy+G3Jw5rlznF3Q4rBtEn91p6kyYcMXj563X8+/uN9M5M4A+njlAyXtrN5AFZjOuTwebKRn793HdkJTl5/dsN9M9Jol9OIpcc1p/fvzKP575cw6WH9WdrVSMOq6VdnpYVka5t6eZqbn55HmOK0rn2qEFNif2MvcQPm9XMlTMH8sfX5nPP24u5+eQReuhzD4LhCLNXlREMRVi+tYbcVDeT+mfu937SEpzce95Y7n5rMec//AU5KW5OnVDIG3M2MGvRVm47fRSpbTwlZ6MvSChiNH0X/GxpCWtL63n0kkkHdMpkk8nUbOaI204fxdcrS5m/vrLNjxUIhbnllXmsL63nhHEFxDmsfLmilHvPHUd2sgt/MMzHS4rJTnZjGAYpcQ4KMuL4cGExf/vPEh65ZCKvf7uBr1aU0ic7kdtOG8ULX63lgf8uY3VJHWaTibQEBxvLG3j+i7UUV3sY3TuNP5w6kjpPkPkbKkmJs3Pv20uwWc2kJzi46cThVDX4KcpObKpnnTfAutJ6Pli4ldMnFRLvtFFe5+OggdlM2Z5QG1aQyrCCVCb3z2LxpmqmDcre5XyVBBHpZiKGgdcfwhMI0+gP4fGHaPQHqW4IUFztobLeD0Cf7ESKshMIhiJsqmhgbWk960rrKa/z0egPAZAab2dUYTpnTSliRK9UPQ0oB0w4YvDwB8uZMiBrt08OxDKzyUSvzAQg+nfpD4a5/vnvOWVCLxq8QTZXNjK5fxbTh+V0cE27nlA4ssdpxnpnJTCmdzo/f+Zb+mYncs5BfeilxJNIt2cYBjWeAJvKG9lQ3sCG8no2lDewqaKBcNggNy2OgvQ4eqbHM6lfJumJTtISHKTFOzrk4ZAdT7F6AqEWJUFqGgP8/b9L2Vbt4fbTRzEgN7mNayiydzarmd5ZCRw2NIdXZq/ndycNZ2xRRtPnPz9yENc++y0rttayrrQekwnOnNyb3lkJLNlczfnT+nZg7UWks1m0sYo35mygst7PGZMLOX1S7/3eh9Vi5jcnDOPXz33PL/8xh3MOKmoWl7qzUDjCIx+uoKTGy6byBlwOC+GwQb0vyEMXTWxxfyjRZef200fx3ZoKirITSE9wMnVgFg+8t4ybX57L384f3yajaX9YW8F787ewYEMlEQOOGJHLhYf05e0fNnHC2J7tvmZk/5wkHDYL783f0urpplYW13L3W4vJTnZxzZGDeH/BFgDuOXcsD72/nK1VHv589hiyk6PTvDlsFo4auevMCEeMyOWDhVv45T+/IyvJxc+PHMSYonRMJhO/PnYIVz41m349Ernt9FGYTCZWFtfy/Zpyjh6VzzX/9y1fLi/hkQ9WkJnkZHNlI0eOyOP8aX352ZNfc9kTXxOJGNx19hj69Uhic0UDVz39LTaridMn9uak8b1+8hzz0uL2eM9ISRCRLiwUjlDvC1Lvjf7X4AvR4Nv5/9HX1Y1+iqs8NPhDeP0hjO3lXXYLcQ4rboeV5DgHOSku8tLchMIG89ZX8MacDThsZnqmxdM7K4EJfTPITnaTHGcnwWXTGgXSbl76ai2ltT5u2GnRzO7qzClF9MtJ4q3vNxHvtDIgN4nHZq1gbJ90jVjYT6GwscfpsMwmEzccP5SvV5Yxf30lt702n7+eN06L/op0IxHDYPmWGpZuqWFDWT0rttZS1eAnFDHISnJSkBFPYWYCIwvTKEiPJzfVvceY0lEsZhNOmwXvfq4Lsq60ns+WbeODBVsZWZjGveeN08Mu0uEuPLgvR47Io3dWQrP389LiuPPMMWytamRIfgp13iB/eHUeHn8Ym9VMn6zE/Zp6RURiy9LN1fiCYQbnpWC3mXnq41W4HRYsZhMnjC1o8X7jnTbuP388Hy7ayr1vL+HMyb05YVzL99eVRQyD4ioPWcku7nl7MSXVXo4enUdWUi+GFaTiC4SpbvSTldy6NVRMJlPTFEwQTUZde9QgfvviXB6ftYKLD+3Hu/M2c9yYnrudzmxvGnxB7nl7MceMzufcaX2wmOD+/y7jjPs/I8Fl4+DBPVpV/5bKTnLhDYSp8wZb9J3fMAze+n4Tz325hjMnF7Fiaw3/+Hw189dXcvPJI+jbI4l7zxtHTWNgryOhIPp7OGVCIU98tILfnjiMlLgfvyOnJTj5y9ljSEtwNiVs+uckNa0fd8iQHvz9v8sYVpDKH08diTcQwmmzYDKZuO6owWypbCQcMbj55XmcPaU3izdVc/DgbAbnJzNtUOvav1VJkK++nc+DT75AJGJw7mnHcNyRhzT7fOmKtfzpr08QCAY5cvpULj7nxFZVVqS78fhDlNZ6Ka3xUlrrpWSn/1fU+/FsH5HhtFlIcNmI274QULzTtv0/K7mpbgbnJ5OXGke8y4Z7e+LD5bB2+IJS0lyDL8iD7y2j1hNg5og8xhWl47RbsJg71w2V9hSOGGwoq+fN7zZy77njiNMNGABG905ndO/0pp+XbK7hNy/8gNth5eypRWyr9jCmd3qrO5mxLrow+p7joMlkYsqALCb3z+T+d5fyy39+x5WHD2BIzxQcNotiqEiMCIYjlNR42VrZGF2svKSO6kY/26q9mE0mRvRKJT89jpnD88hIcpIa5+hSaw+4HZamPuPe+AJhnv1sNR8tLmZsn3R+d9JwhhVo6ivpHNwO6y4JkB12vsGSmeTiz2ePpbLeR60nyH3vLmVNaR0zhuUyZ3U5vmCYyf0z6Zn+4wjPJZurqajzMWVAVqdLZorI/qtq8PPmnA3UeALMWV1OostOZb2PzCQXgVCYe8+b3CbrSDjtFo4b05PMRCdPfryS48f27DbTgn+6ZBv/mbeZRJeNjeUNlNf5SHLbSY6zc+dZo0l0/Xiz3r394dsDwWI28+tjh/CbF37g0se+JmIY/LC2gttPH93UX2vwBVmwoYqIYTAoL7lpStJwJMLHi7cxpiid1HgHr3+7gaLsxKb1OQD+fPYYNlc0kpvqxtGG67btD6fdQnKcnZIa7z4lQULhCIFQpKnNZ68q49XZ67n99NEMyktmc2UjVzz5DflpcQzOSwbAZjHvUwJkhykDspjQN2O3/2bumMlidw4flsNb32/izMnREVg7J6tGFqYxsjANgPz0OJ7/ci2bKxp57NJJbTLNZYuvwFA4zANPvMBDd99EfJybC6++mWmTx5CU+OOJ/vXhZ7ntt1dRWJDHz355K9Mmj6FPoRYYle4pYhjUNAaoqPdRUecjEIrgD4Wp9waJRKLB1xeMUFbrpWR74qPOG8Rlt5CV5CI72UVWsouRvdLISnaRkegkyW0nwWnDZlVHvSvyBkL4PCFqPQG+WF7CR4uK6ZeTxPi+mbzy9Tr++s4SXHYLhw/P5byD+nTYP7gdpd4b5Prnv2dLZSOnTOi1xy+9Ahcf2o+vlpcQCEe4440FFGUl8NTHqzh/Wp9u1RHfX6HInqfD2pnJZOK6owfz9g+bePD9ZVQ1BBiSn8Ktp40kGI7o6WiRLiQciVBR52dTRQNLNtewZHM1a0vqMJtN9Ehx0zszgRG9UslIdJKZ5KIwM77LP4zgslvxBnafBFm9rZYvl5fiCYSIGDB7ZRl5aW4eunhi01QIIl1Rfloc+dunw8hKcvL8l2t5bfYGhvVMIdFt57XZ65nUP5NhPVP5cnkJK4prSXbbefC9ZSTHOTh1Yi+OGJHXwWchIvuj0RfkP/M289b3m6j3BpnYL5PsFBd3nzOWwswESmo80ZvZaXFtvpD26N7p3PfuUlZtq2tKyMYiwzDwBcO88OVaPlpczDlT+2AYBkePymdAbhJfLC9hcv+sZgmQ9pCZ5OLuc8fyyZJtHDMqnz++Np+HP1hOostGotvGe/O3EOe0YTWbuLesHpfdSkqcnb49kvhuTTmPz1rB4cNz+XDRVu4+e2yzfdss5k5xLyI72cW2as9ery+PP8QfX5tPktvO704azsINVTzx0UouOqQfg7YnPPLT4pg+NIehPVNada+gJQ8N5KfH89w1B+01mbPjwc/gT0xhvb9anARZtmIthQW5ZKZHnwyaMGY4c+Yu5vBDJgFQXllNKByhT++eAEyfNpGv58xXEkS6nIhhEAhGMJnAbDZhNkWnSdk5UPgCYUpqPJTUREdpVDX48QbDNPqCVNT7qaz3UVkfnT4h2W0nLcGBw2bBbjWT4LJhMZuwmEw4bBaKshOY1D+zKemR4LTpBmaMuvSxb/AEIzhsZkb3TueG44cyrCAVs8nECWN70ugPsaWykSc/XsX1z33PieMKSI13UJSdwCvfrGdgbnKLFhXrChp8Qf705kLyUt3ce+5Y3WTei14Z8fTKiD6tcuHBfZvm3fzTmwtZXVKH22FlWM8UBuYmY7OaNW3Wdj81Hdb/MplMHD+2gGNG51PnDXLra/M5+4HPcTusPPmzyd0uSSnSVVQ1+Fm6uZolm2tYurmazZWNGAbkpLgYlJfMUSPzGJSXTFayK2ZHd7nt1l1GgoQjEf7v09W8v2AL0wZmk+CyEzEMfnfScAbnJ6vvKTFlQG4yd5wxmlpPoKkPVFrj5bVv1/P5shL65SRy/fFDiXNY2VLpYVNFAw+9v5yUODvpCU48gRD9c5KwWy3UNAYASI6L7idiGJTUeMlp5zniRSRqU0UD//puI6u31bGtxkNhZgK/Pm4ovTLid1koOzvZTXbygflbtVnNTOibwVcrSmMmCRIIhZuSRYZh8MmSbbw6ez1bqzwUZMTzt/PH7xL7drd+RHtJT3By2sRCAH597BCufWYOA/OS2FAe4ahR+Zw6oRcmkwmPP0RJjZf5Gyp56/tN3HveOGobAzzw3jKuPmJQswW5O5MeyW5Karx73e7pT1ZRXhe9B7lwQxW3v7GAY0bnc+jQ5lNJXXf04ANV1b3an/sRbTkNf4uTIBVVNWSk/Tg0OiM9hfKK6h8/r6wmIy2l2efzF63Y7b5ef3sWb7wzC4j+YYnsr1A4QqM/RN32tTHqPAHqvEHqvAHqPMEfX3uD1HmC+ILRL4IWs5kEp42UeDsDcpMJhyNUNQaobvBT3einqiFATWOAyG6uS7PJFE1emE34gmGcNgvZydERG2kJTuKdVjITnYwtyiA90UF6QnRhzLZ+4kC6ht3FuWuPHsSQnmkkuHa9wW8ymYh32hiQm8yfzxrDWz9s4t/fb6TWE6CqwU+vjATeX7CF575wYjJBVpKLI0bkMqYonUZ/iCWbahhekNIlp4/aXNHAHW8upEeKm18dO6RFc3l2ZzvPu3n/BeN59MMV2CwRHnp/Ob5gmDiHlWuOHMT4vhks2FDFW99v5FfHDmn3p3U6g1A4st8j6SxmMylxDv546ijWlNTxz8/X8OHCrRw7pucBqmXXoj6ddKTqRj/Lt9SwbEsNq7bVbf8C6KNXRgKD85M5Y3Jv+mQnkpHo6PKjO/aHy2HF4/9xTRDDMPjLvxezpaqRBy6cQG7q7hePlN1TnOu6dr7pkpXs4uojBu2yTUFGPAUZ8fiDEe761yJsVjNOmwWz2URhZgKLN1YBcOaU3pw8vhePfLCcDxZs5dyD+rCpsoFw2ODCQ/qSmaSRVNK1dYVYt6akjptfnsuUAVmcM7WIHiluCjLi917wABnSM4VPl2zrsOO3VjgS4dMlJXy3ppzKBj+rims5bVIh4/pk8PwXa9hU2ch5B/VhTFE68c7ow7ydVWaSi39efdBuv+vtmFqxd1YCJ40rwGQykZ8WxxM/m9wBNd132cmuvSZBGnxBPlu6jZtOGs4fX53Pok1VjC1K54KD+7ZTLTu3TnFn6ZTjZnDKcTMACIVCTD36go6tkHSIcCTC1ioP68saqPMGsFnMRAyjKYlR7w0CYDJFp8nZkaRo8AUJhCIA2Lc/4ZzospHospHgspHospOZ5KRPdiKJ7uj7O26qhsIR6r1Byup8rNhag8NmITXeQe/MBFLi7KTGO0iJd+B2WDCM6JM+hgGRiEEoYhCORAhHjKZj6qk52ZPdxbmxRelYrXsPwzarmVMm9OKUCb0wDIONFY3kpripbvQ3PdG6uqSORz9cQZ03SDhikJ7goKLej9NmYXhBKttqPAztmcpZU3rjsls7bYelrNbLr5/7nqNG5XHO1D6dtp5dRWq8g9+dNByA86f1IWwYLFhfxSMfLOfetxcD0fk673xzIdccOajb3QgLhiMtnps2Oc7OmKLo8NyHP1jO5AFZuzxt1h2pTyftJRiOsL6snlXFdawsrmVFcQ0l1V56ZsQzMDeJmcNzyUh00jsroduPJnTbLXh2mg7rP/M2s7qkjgcunLDbBzHkpynOdQ+HDe0RHUlbkILbYeX7NRWU1/k476A+hCIRbnttAe/N34rJFH2a9h+fr+HgQdkUV3t44L1l3H76qF32qe+K0pV0plhXWe/jjTkbGV6Qyvz1lZwwridZSS4e+WA5x4zK55yd1m/oSJmJLkprfR1djf1S5w3wwpfrMJui63HOXVfJESNyGRfn4KJD+vL0J6v49/cbmTaoB785YViXeshyXx5260pxOSPRybItNT+5zTs/bKIoO5FRhWm4HVa+WFbC4cNz26eCXUCLkyDpqcmUV1Y1/VxeUc2g/kU/fp6WQnlldbPP09OSW3o46WL8wTC1ngC1ngA1ngCNvhA1jQE2VzayrdpDdWOAem+w6ckawzAorfVhNkHPjHhS4uyEI9GnDRJddhLdNnJT3ZhNJiKGQXwPG6nxdlLiHCS4bE2LLDlbMR3JcXqKV7oAk8lEr+1Pt2QmuZqeMhtTlM5pEwsprmrEabeSkeiktMZLjSfAd2vKGV2Uxn/mbuaM+zeRGm9nxrBcJvbLbJqebVuNl0AogtkEualx7ZJ8CIYibK32kBJnp9YT4PNlJazYWsuk/pmcP01PKrS1lO036KcPy+HgwdEv6QnOaFL4oQ+WcdXTsxmcl8KRI/PISXEzb30lNouJw4bmEO+0EY4YzF9fybItNZw5uXezTmWDL4jVYm5VDO4IobCBtZXX+oS+GXyzsow/vbmQv5w9RoupdmM75kj2+EN4AtH/ewOh7f8P47BZiHdayUlxk5Ho7FJfujqDQCjMiq21LNxYxaKNVawuqcNps9CvR3Qx5IMGZTEwN7nbJzx2x+34cTqsTRUNPPvZav546kglQER+gslkajbt7Pi+Gc0+v+us0SzaVM1hQ3Nw2iwcNjQHiK5JcNXTs/nja/MprfWxpbIRiD7BO2NYDhmJTqYOyNaaji1UXO3h+zXlRHYamGA1m5g5IlczLsSQynofCzdWYbOYmbOmnAXrq+iZEc+sRVuxWcwkuW0MzEtmW7WXk8/s1dHVbZKV7KSi3kc4YnSJh/mqGvz89sUfyEpyUVHvo6rBz/0XTGi2Jtjfzh/fgTWUnbnsFnzB8B4/f+j9ZXyzsozfnjgMk8lEz/Q4lm+t7RTrmXQWLU6CDBpQxLoNWyirqCI+zs23PyzkorNPaPo8Iy0Fi9nMmnWbKCzI46PPZ/Ob6y5pizpLJ2BsX+R7Q3kDq7bVsqq4jo0VDYQjBg2+IN5AGLPpxwRGvDM6AiMvLY7+OT1IS3AQ77QRDEfwBcKYzSaykpxkJ7u7xD8WIp2RxWwiP/3H4b9Z29eV2TEn6YxhufgCYZZtqeH9BVv4z9zN+IJhUuMdVDf6cVgthMIREt12Lpven14Z8VjMpgMynD8YjnDzy3NZU1pHOGJgNZsZlJdMdaOfG44f2ubHk+asFjM9d7pWfn3sUC45tD8fLd7Kc1+soaYxQN8eiQRCEd78biPTh+bw2dJtBELRkRMbyxtw2i30zkpgbUkd36wqw2G1cMqEXpw8oVeXmVc/GI60OmlhMpm45siBXPvMHN7+YRMnje/VNpWTTsUwDMrrfKwvq2djRSOV9X42lkdHrnp3SnjsuCnjtFlwOyy47FbcdisOmwV/KEyDL0hpjQ+3w0LvzAQKsxIoykpgYG4yPTSfPBD9u9xY3kBxtYfqhgDry+pZX1bPpopGElxWhhWkMmNYLtcdPZicFLeSSfvAbbfiCYQwDIO/vrOEY0f3ZGjP1L0XFJE9yk+Pb9bv3iHOaeO+C8bzn7mbmdgvkzG90wFYuLGK79dW8NnSEl75Zj0PXDhhl/XEyut8WC0mUuK61sjS0hovboe1VYnVQCjMgg1VmE0mRvRKbdY/21rVyIayBuauq+DTpSUMK0hp9uDNks3VpMQ7mDIgq1XnIZ2DPxjm1tcW4AuGsZijychfHDOYUYVpmEwmPly4lQ8WbmXJ5hqOHZPfqaZOTktwYhgGVQ1+MhKdHV2dn1Td6Od3L82lf04S1x09GI8/RK0n0CwBIp2L02bBv5skSHWDn69XlvHNyjIeuGgC6QnRay8/PZ7lW2spyuqca5x0hBZHC6vFws8vO4urb7iTSCTCOacdQ1JiAr+8+R5++4tLyEhL4VdXnc/v73qYQDDIEYdN1qLobSQYjlBa48UAHFZzq29QGoYRTUYEw/gCYfyhCP6m19H/N/pDlNV6Ka72UFztYWuVB28gTFaSi345iQzpmcKxY/KxWqJrbCTH2Tv9HIEi3Y3ZZMLtsDKmKJ0xRdEvZDWNAVYW1zC8IA2n3UI4EuGLZaX87T9LCIaj08xlJrpIT3QyoW8G1Y1+vl9TgcVs4pLD+jW7ibKlspFaT4BBeT8uqBoMR3jnh03MXlVGvx5JrCmpo9YTwBcMk+S288LPD6a6wU+dNxgzC8h1Vclxdk6ZUMgpEwqb3jMMg7e+38TiTdVcdEg/xvfNoMYT4L7/LCUvLY756yvplRHPQxdN3P7+Et6bvwW71UyCy8bM4XkcNrRHp71JGWqDJAiA3WrhqpkDufX1+fTJTmRYgW4udjUNviBbqzzUe4M0+kOU13nZWuWhuMqzfWRr9P28tOhc02nxDqYPzSEl3o7bbsXlsOK2W3A7rLjslp9cbyIQCrOpopF1pfWsLa3n/QVbefC95QzMS+a40fmM75vRaf9m2lp1YzSZVFYbTTCt2lbHutJ67FYzeWlxJLlt9MpIYExROoWZ8Up6tJDbYaXOG2BbjZeNFQ3cfc7Yjq6SSExLiXNw7v9Mz3PY0BwOG5pDOGLwi2fn8Pq3G9ha1cjo3ukUZMTT4Aty79tLyEh0ctdZYwiEw8Q7bWwsb8BuNZObGkdJjQePP0xBRhyN/hAOq6UpkRKORKjzBJtG/v6UaDJhG6eM70WvzB+fEC6r9VLvDdIzPb7ZSJVQOMKmikY2VjTw3epyLpven5R4B+V1PjaWN3DP24sZWZjGb04Y1lSmtMbLM5+t5tAhPUiNd+Dxh3h/wRaqGvycNaWIYQWp+INhNlc2smpbLa98sx6rOTodtsVs4uaThuO0W3jxq3V8ubyUgow48tPieejiXdcxeurjlcxbX6kkSAwoqfHwt/8sxWY189fzx+12QeTRvdN48L1lOO2WZtdcZ2CzmEmNd1Ba6+20SZCaxgC/efEHiqs8TB2YxbVHDca8fT1Sjabt3By2XUeCVNT5uOKpb3DaLFx71OCmBAhAflocqfEOkuO639qfe9KqlOnUiaOZOnF0s/f+dsf1Ta+HDOzDi0/+pTWHEKJTxpTX+1hXWs/XK0r5bvvwT7MZgiGDwsx4Lj603x5vujT4gqwpqcMXCLOtxsvWqkaKq71sq/bQ4AviD4abDSd12KJTmjisFpz2aMfKvX16nV4ZCUzqn0VuqpseKe4uN/WJiDSXHGdnfN8fh/pbzGYOGdKD4b1SMZtMhCMRNldGb9bNW19JnMPKGZN7U1Hn44+vzWdkrzS2VDaSHOdgTUkdFrOJlHgHPZJdbKpoJN5pJRwxOHJkHquKa5k6MJu8tOjTzn2yE3HaLPRIcdMjpaNaQH6KyWTihHEFnDCuoOm99AQnfzpz9C7b5qXF8fcLJ7CmpA6ITlfw/Jdr+GZVKYWZCZhNJkYVppGd4mLeukocNgvj+2bs9stNewmFDayWtrmhOqRnCpce1p9bX5/PraeNYkh+17uoI4aB2WQiFI7Q6A+xaGMVG8obWFdaz5bKRp68fEpHV7FNGIZBRb2ftSV1rCiuZf76StaW1pPktpHktuOyW8lMdJKT6mZIfgop8Q4SnFZ6psfv8tRuS9itFvpkJ9In+8ensmo9AT5cuJWHPljOh4u2cvURg2JqjZlAKMzWKg+rt9WxYmsNW6uiD9TUbH/iMDPJRUF6HMeMyqdfTiI9UtxdZkRZV+CyWyitDbNkUzX9eiS1yXUsIi1jMZs4fVIhd/17EcMKUnljzgZqPQEAjhiRx9crSjn3oc8JhiNkJDip8QQIhQ2yk11sq/Fgs5hJdNmoaQxQmJXAbaeNYlNFA/e9u5SKOl+0D9Jz1z5IOGLQ6A8ye1UZT360inF90vn1c99z4wlDyUh08eo365pG9rodVs6c3JvxfTOYu66Cl75aR603SEqcncwkFze88D15qXHM31BJvMPGESPyeGfuJlZvqyU72Y2BwYPvL8MXDPPohysIhMKYTSamDMgiyW3niY9WctaUIh79cDmBUITMJCeXHNqPyQOyMAx4+et13PjCDwRCEQ4amMWjl04kO3nPoyVH9U7nwfeWYRhGl0mU+4NhXvp6HWOK0hmSn8L7C7ZQmJnQ9FCYYRgY0OzfQl8wTDAUwWQiJm9W+wJh/vDqfAbnJXPp9P57/I6QluCkMDOB4b1SO+W0jplJLsprfdDJngGvrPfx8AfLKa72UpgRz+9PGUF2skv9rS5kd0mQf3y+hnF9Mrj+uF1n05jQN4O4Fq5/GavUGp2EYRjU+4KsK61n8aZqSmq8lNV6Ka31Ud3g3z7NTRyjCtP563njKMiIx2Qy4fGH+GDhVm57fQGZSU4SXTaCYYNAKEwwbOAPhqlq8JOe4MTtsJCd7CY31c3Bg5LISXGT6LY1S3bYrWYFQRFpdvMtLcHJiF5pu0zzM7ZPOp8tLeGgQdlU1Pk4fVIhg/OT+XpFGaW1XmYMy2VLZSPHje2J02bh6FGdrCcobS7eaWNErzQARvRKY1K/LF77dj21ngD+YIQ/vjafRn+IXhnx+IJhHvtwBSMKU0nd/lR9floc5XW+dlsvYXNlI4cPz2mz/R0+PJd6X5CH31/OAxdN6NAED0Tn/p+1qJhaT4ABOdF1E5ZtqaHOG+SwoTkYhsHr324gGI7g8YeYt76SaYOym/ohPZJdDCtIpX9OEtOHtl07tadAKMyijdWsLqmjqsFPoy/I6m11lNb6yE+Po292IieOK2BEr7QOfUoqyW3n1ImFzByRy+OzVnLlU9/wsxkDOHhQdpe5oRMKR6is91Ne56Ns+0iajeUNTevBOWwWCjMTGJSXzOD8FHJS3RSkx+PWl7MDbseaIMu21DA4P7mjqyPS7U3sn8n1xw1hUv+sXfoK0wZls63aQ1aSi/XlDUzpn4U3GOLbVeWMLUon0W3jm5VlpCc4efHrdVzzf7Np8IU4dWIhcQ4rf3h1HtMG96BHsotjRkenCmr0BbnllXms2lZHjxQX1x83lPF9M/h06TbueGMhADOG5fDkz6aQGu/gqxUlvPjVOh54bxlZSS7OmtKbgwdnYzGbCUcifLBgK55AmJ/NGNA0dU4oEuEX//iu6Tyyk138/YLxuyyi7A+GueSxr7jn7cVce9Qgpv3vv3MmOHtqET3T4+iVmUB+WvNRH7szOC+ZWk90/dGeu5mirCMZhsHCjVUs2VTd7P0lm6up8wZ5d95meiS72VTZQFq8g4cvnsTqklqe/2It68rqmT40hziHlarGAJ8sKSYUjj69esSIXK6cORCzycTyLTUUV3s4aGA2NZ4Ac1aXM3NEbof3Q/fHhrJ6nv50NcluO1cdMWivM4rcelrnXdcqK8nF0i3R3+/xYzvHurMef4g73lhIZpKTo0flMWNoLk67Hojoav53OixvIMRnS7fx5OWTd7t99GFTTbe7M1Mg4Df2vln7CYVCTD36Ar5891ms1tj6UhQIhdlS6WFzZQPF1V5Ka7yU1fmorPdRWe/HFwyTkehkaM8U8lLjyExykpXkIiPJSWq84yeTEw2+IIs2VuEPRrBZzdgsZuzW6H+ZSa5OOxRPpDuK5Tgn8lPCkQjBsIHDasYAFm6oYtW2WjZXNvL1ijISXDaqGvzkpkYXjj5+bE8Wb6wmJ9XNESPymu3LHwzz1YpS5q2v5NQJzadz2BclNV5+9sTXvHTtwW16EzYUjvCrf35HottOZqITp93C8WN6tvnaOiU1HtwOK4mu6I17fzDMok1VRKKz2LGpooGXv1nH5P5ZZCe7+GFtBduqveSluUly2/lhbQUWi4kp/bPISXVjMZvpk53AC1+uZWRhGieN64XDZm7VDfj2jnWGYVDnDbJqWy3fr6lgTUkdG8obSHLbGZSXTEaik3inlbzUOEYUpnXq0azfrCzjkQ+WMyA3iauOGNip5oePGAbbqj2sLa1vmtJrY3kD1Q1+TCYT6QkO0hOd5KW6yU+Pp2d6HD3T40lPcHSZhE6s+XTJNj5YuIXKej8/mzGgaUpMaT316aQjhSMGXywrAeCQIT2A6M3kDxZuZcXWWjBFb36W1foY3iuV648dgsthbXZfIRiKgIldbpgbhoE/FNnnhyR3bL+DzWLa49SQc9dFp9bd8eBMW/jFP+Zw8vheB3xKrDUldbjsll2m5NqdJZuref6Ltawvq2div8xmN/Z3jLYJRSK8N38LY4syeOKjFazaVofVYubEsT0ZkJvM7FVlhCMGdquZGcNyyUl1U9Po5+aX59Ej2YXZbGLZlhrS4h2U1vqIGAZJbhsDcpK57ujBuB1WgqEI97y9mPkbKgHokezmgYsm7Nd5H8hYV9Xg54onv+HgwdmcMbl3p+rztMRzX6zhlW/WA/DIJRM7JDFX3RC9v9gjxc3G8gbufWcxKXEObjl5RLOp7qRrKa3xcunjX/HWDdMxmUysKanj5pfn8tK1B6uPvY/UU2ulYCjCxooGNlc0sqWqkS2VjduHdLpIibPjC4bZUtnIpopGSmqiT8H1TI/OaZyd7GJQXjJpCQ7SE5xkJDpbfCMm3mljUn/NgSkiIp2XxWxmx3dsEzCyMI2RhdEvwJdND7Byay39c5NYsqmaLVUe7nxzEXlpbj5eUsyr36wnNy2OjAQHizdXU9MYICPRSf+cJH71z+9IS3AyvFcqR47IozAznlXb6mjwBRnRK223T5Mt2FDJwNykNn8K3Woxc+eZo3nqk1VYzCaq6v38/JlvOW1iIdnJLsb2afkUYIZh8N2aCjaU1/Pq7PUkOG30z0nCGwhT6wlQ5w2SsP2JS7vNzO2nj2ZQXjIAZ00paravynofZbU+Bm7/fIe2vCFxIBiGgTcQprrRz+JN1WyuaKTGE6Cs1suWSg/1viBZSS7G9Unn+LE96Z2VSF5q11tHYlL/TAbnJ/PYrBVc9dRsLj98AFMHZLXreQTDEWo9Aaoa/Gwoi06Ltm77IuXBcIReGfH0zkpkQt8MzphUSFayi5Q4h9aD64TcDgubKhrx+EMMzNX6WyKxwmI2NSU/duiVmcDPZgzAFwjz5McrGZSXTL8eieSkxu02Pu/phqjJZNqvhwX2Z/vRvds+EZvoslHnDbT5fnfYWN7Ac1+sYd76Spw2CwcNzKai3scpE3rhtFt58qOVTBuUTY8UF32zk3jgvaV8v7aCE8YWcPPJw39y+qrTJ/UG4LbTR1FS490+i0e0f7qjn7yz7GQ3fzt/HP/+bhMGBr88ZggJLhtbqzy4bBbsNjN3/WsRFz/6FceOyW96WPYvZ4/FajGxcGPVgWmkfbDj/lmf7ESWb61hQ1kDHy0uZmyfdK44fGCH1astZSY5cdktDM5P4T9zN3PlzPY5r29WluJ2WBlWkMpf3lrE8q21FKTHs6WqkaNH5XP+tD5tshaidByHzULEiPbR7VYLWyobyUuL63LfczqSkiA/wTAMlm6uYfGmKsIRgwSXHY8/yNrSeuq8Qeq8QbZVe3DaLBRkxJOb6qZvjyQcNjNltT62Vnlw2MwMzk/hyJF5egpORERkDxJddsb2yQBoSupPG5hNSrwdjz/MxvIGVm6rpbLez+UzBpDsttM7KwGTycTxYwuoqPPxzcpSrn/+O8JhA7vNgstuwQT0zkpg4cbov+UAFpMJp93CcWMOzBD1OKeNa48a3PTz58u28fmyEt6bv4U//3sx8U4rg/NTWFlcQ9/sJNaW1lHjCdCvRxIDc5NZsbWG6sYAM4bl4LJb+ecXazAMg8LMBLZWNTIgJ5kbjx9GeZ2PinofbruVQCjCaZMK9znBkpbgJC2hc48S9QZCLNlczcINVSzfWkt1g58aT4BAKILVbKJfThJ9shPplRHPmN7p5KfHkZvqxmWPje5tktvOjccP46sVpTzywXLe+n4TE/tlMK5PBvlt/IWn0RdkXVk9a0rqWVtax9qS6DowBtEbSz3T4+idlcjM4bn0zopOT6Iv0l2Hy26lzhtk2qDsXaamEZHY5LRbuObIQR1djXaT6LJT5wkekH0v31rD71+Zx/ShOTx9xRQ+XryNFVtryE2N45ZX5hGJGEzqn8W78zZT1eDHEwiRlxrHU5dPIcm971Nt2q2WfR41kOiyc960Ps3e23nqsDvPHM38DVX8a84G+uUkcfrEwqb4394jEwzjx8lnHv5gOZ8sKebYMT35cOFW+uckMawghZP/Z9rlrmxK/yx6ZyYQMeDml+fysxkDDvgDIhvK6rn3nSW47VYS3TZqPQHuPmcsZbVeBuYlN1ssW7quHYlmf3CnJMg+jEqTH8XGt8RWMAyDWk+Qinof5XXRaak8/hCbKxtZta2WmsYA4/pkYLWY2FDegMNmYUh+CslxdhJcNvLT4tpt7nIREZHuJGv7PNN2q4XkuFSG90rd7Xa9MuKjN8KL0rnksP7UegKkxDuwWUz8sLaSdWX1nDO1Dy77jo5jmO/WVHDo/zw9eaBMG9SDaYN6EDEMymp9VNT5WLChkpnDc1m9rZYjRuTSI8XN3HWVFFc3Mql/JqnxDj5YuJXNlY38+tghJMfZmb++kuuPG9rlprh86P3lZKXEkZnobFp3Y8f3YYvZRJ03QGW9n6qGHf9FRx+U1nrJSHQyvCCVY0blk7G9fHKcnTiHtdv0vaYMyGJYQQqzV5UxZ3U5L361jrR4B2OK0umTnUhBRjxOm4XsZFezxERlvY9Pl25j6eYaUuLsJMc5olOcER0+X1bnpboxgD8YpsEXIj3BQVFWIn2yEzhoYDaFmQmkxNmV7IgBO54oPna01uYSkdiU6LZR523bJEhFnY9XZq/no0XFXHpYP47avr7hKRN6NW1z0vgCVhbXMrYoHZPJRDhi8MPaCgblJXfomhUmk4lRhWmM2s1IkvYUjkS45+0llNZ4KciI54e1FZw8oRevzd7AH04dwdiijA6t34EQ57TRt0cS4YhBxDDYUtlIQUbbJp5qPQFe+HItX60oZUK/TFYV13LMqHzOnNKb575Yy4Dc6FqA/XM0+jOW2G3RPrkvGG4a/VWUvX9TQnd3MZsE2TEvdHVjgJpGPw2+EI3+IFurPKwpqae0xosvGKLRHyIUNkh02UhPcJKW4MDtsJKT4uaggVkMzk/Rgo0iIiJdhNthbfbv9vi+GYzvu+sXrP1dQ6QtmE0mspNdZCe7GNIzBaDZ3Px5/7P459SB2c1+7teja36RSY6zU1zlYeGGSmo9QXbOXYQj0T5YaryD1HgHhZkJjO7tIC3BQY9kd1MirLtLdNmZOTyPmcPz8AXDLNxQyfz1VdFEWUUjvu2LJDpsZsIRg3DEIBSOMCgvmYn9sqj3BqjxBPDXRQhHIvTLSeTgwdmkxDlw2CykxNu7/Bzcsmf5aXFccmg/3QwRkZiV5LKzqbKh2XuV9dHZOQbkJvH9mgom9c/c4wMUa0rqeP7L6Pod04fm0OAL8tGiYsb2yeDvF47f4+iJJLedcX1+7GdazKbd9ju7m0+WFLOquI5lW2qIGAajeqdRVuvj3vPGkZXkZPrQnH1aV6Urs5hNFGUlsqakrs2SIIZh8MXyEh6ftZIBuUlcd/Rg5q6rYHL/TE4YV4DLbuWy6f3b5FjS+ZhNJhxWc1O/f3NlI9MGZe+llOysS97d9wXCFFd7aPAF8YfC1HmClNVFR3KU13qj/6/z4Q9FcNkt0VEbThtxDitZyS4OGphFToobl92C22ElLcHZqRfHFBEREemqzplapAWD25DTZmF830zG981sem/HYuWBUASL2YTFbCIlzqEHeQSIziF9wriCjq6GiMgBk+i2Ubc5OhKkst7Hsi01/POLNZTX+ZjcP4vPl5VwxIhcxhalM6JXGg6bhZXFtbz41VrWlzXQ6Aty1Kh8pg/NYfaqMhxWM/ecO47eWXrKen/4AmE+WLiVl75ey4xhuRw3picT+mXssiZKrCdAduiTncjqbXUcNjSn1ftatLGKhz9YTqMvxJUzBzJ5e1Jv5yScxD6HzYI/GCYcMSiu9pCb1j3+ltpKp/1m9MSslWyr9VHrCeJ2WHHYzNR5g1Q1+Kms9xPnsJLosmGzmkl02chIdJGZ5KRfj0QyEp1kJjrJSHThtCu5ISIiIiKxy2wydZsbCiIiIv9r54XRn/1sDUs3VzN5QBaRiMF/5m3m5pOG887czTz18Sq8wTBp8Q62Vnk4ZnQ+Z0zqTY8Ud9OUnVMGZHXkqXRq97+7lNz0BI4Zld803VfEMCip8VLvDXLzy3OJc1j53UnDGdpz99PYdid9sxN5d/7mVu/HMAye+XQ1k/pncvrE3rrP2Y05bBZ8wTBVDX6CoQjZGjW/XzptEsRqMTF5QBYpcXYa/SF8gTCJbjup8Q56pLhIdtu7zVzQIiIiIiIiIiKyqx0Lo0cMg/nrK/nNCcMY0jOFYCjCYUNz6J2VwIR+mUQMg4UbqqjzBhlWkKKpIPdTSryDhRuq+HzpNv542kjAxHNfrOHzZSWYgEsO68/xY3t2dDU7jT7ZCawrrScUjrRqjbUVW2vZWu3hT2eOVgKkm3NuHwlS3egnyW3HprX79kunTYJcdGg/TZ0gIiIiIiIiIiJ7tGNh9PWl9fhDYQbkRtdAslnNzaa0MptMjOzgxcK7svOn9cFktvDge8u45LGvsZhNDO2Zwv9dMQVvINzmC4B3dblpcdgsZtaX1dO3hWv7fbWilEc/XM6xo/M1zangsJnxB8OEwkbT6DXZd/oLEhERERERERGRLinRZccXDPPt6nKGF6S26ql7+WkWs4nrjh7M5YcPwGIyYbOqrffEbDIxKC+ZZVtqWpQE+WFtBfe9u4RfHD2Eyf0z915AYp5z+3RYgVCQlHiNZNtfilYiIiIiIiIiItIlJbiiz/d+tmwbozTSo104bRYlQPbBoLxklm6p2e9yL3y5lrv+tZCfHzmIKQOytByAADsWRo9Q3eAnRSNB9psiloiIiIiIiIiIdEkWs5l4p5Vt1V5G9VYSRDqPHSNBDMPY5zLLt9bwr+828tfzxzNtUI8DWDvpanYsjF7dGCBVI0H2235Ph+Xz+fnt7X+nuKQci9nMicccxqnHH77Ldk899wZvv/8ZyYnR+Rd/eeV5jBg6oPU1FhERERERERER2S7RZSfRZSc72d3RVRFp0rdHIr5AmC9XlHLQwOy9bt/gC/LERys5cVwBvbTGivwP505JkNxUxbr91aI1Qc49/VhGDRuIx+vjwqtvYcKYYeTn7vrHfO5px+42QSIiIiIiIiIiItIWEt02+mQldnQ1RJqxWy3cePxQ/vzWInJT3BRl7/kanb++kvv/u5TCzAROHt+r/SopXYbTZsEfDFPd6Cc5TiNB9td+J0GcTgejhg0EwO1yUpDXg8qqmt0mQURERERERERERA6kI0fkUZSV0NHVENnF2D4ZHDK4B+8t2MLVRwza5fPKeh/3vbuUFVtrueSwfswcnqs1QGS3HDuSIA0BrQnSAi0aCbJDaVkla9Zvpn/fXrv9/OU33+Ot9z5l2KB+XH3pmbhdzt1u9/rbs3jjnVkA+zVPnohIV6E4JyLdgWKdiMQ6xTmRzumwoTkdXYWYoljXtg4fnsvvXprLJYf2x2m3NL0fMQzuf3cpboeVp6+YQpJbN7Zlz5w2CxW+IDWNfq0J0gKmQMC/22h23hU3EQ5Hdnn//rtuJCMthUAgyFU33MmZJx/JoVPH7bJdVXUtSdvXA3n4qZcwmU1cc+lZe61QKBRi6tEX8OW7z2K1tipHIyLSKSnOiUh3oFgnIrFOcU5EugPFutYzDINrn5nDlAFZnDapsOn9Dxdu5aWv1/HQRROIc9o6sIbSFbz+7XqWbK7hh7UVvHLdwbpm9tMeo9c/H71zj4UMw+C2ex5j0rjhu02AAKSmJDW9PmbmNO59+NmW11JERERERERERESkizGZTFxz5EB+8+IPDC1IYWBuMt5AiOe+WMPPZgzQzWzZJw6bheIqD3arGbdDCcn9ZW5JoUf/7xWcDjsXnnXCHrepqKxuev3F7LkUFuS15FAiIiIiIiIiIiIiXVbfHkmcMak3D72/nFA4whvfbqBHipvJ/TM7umrSRThtFoqrPQzISdK6MS2w32mjsvJKnnv1PxT2zOW8K24C4MqLz2DCmGE88Y/XGdivkKkTR/Pw0y+zau1GTCYTPXOzufHai9u88iIiIiIiIiIiIiKd3QnjCvh06Tbue3cp364u484zx+hmtuwzhy26nsyMYbkdXJOuab+TIJkZacz+4PndfnbZ+ac0vf7DDVe0vFYiIiIiIiIiIiIiMcJmMXPLySN49MMVHDK4B/1zkvZeSGQ7l92C22FlokYPtYgmEBMRERERERERERE5wHqkuLnt9FEdXQ3pgoYXpPLns8bg3D4iRPZPi9YEERERERERERERERGRA89utdA7K6Gjq9FlKQkiIiIiIiIiIiIiIiIxSUkQERERERERERERERGJSUqCiIiIiIiIiIiIiIhITFISREREREREREREREREYpK1oyvwvwzDACAUCnVwTURE9o/FYsFkMu11O8U5Eemq9jXOgWKdiHRd6tOJSKxTn05EuoOdY12nS4KEw2EADjn+kg6uiYjI/vny3WexWvceVhXnRKSr2tc4B4p1ItJ1qU8nIrFOfToR6Q52jnWdLglit9vpmZfN84/dtc9ZaYBzLv8tzz92134dqzOXac9jqYx+R12hTHseq6VlLBbLPm3b0jjXmrqpjK5TlWn/Y8VimX2Nc6A+XWvKtOexVKZ9j6UyXeN3dKD7dF2hDVRGv6NYLNOex+rsZdSn67xl2vNYKtO+x1KZ9v8d7RzrOl0SxGw2Yzabsdls+1XOZDLtcxa7K5Rpz2OpjH5HXaFMex6rpWX2tUPY0jjXmrqpjK5TlWn/Y8Vimf354qs+XcvLtOexVKZ9j6UyXeN3dKD7dF2hDVRGv6NYLNOex+rsZdSn67xl2vNYKtO+x1KZ9v8d7RzrOuXC6CcfO6PTHqe9yrSmXHscpzOXaYn2/B3FWjvob6JlZdrrXFp6rM5cpiU6+3Uaa+3QmdugpcfqzGVaQufTucu0VGc+p858LbS0XKy1Q2cu01Lq03XuMi3R2c9H7dC526Cl5WKtHXQ+nbsNWnqszlymJTp77I61dujMbdDSY/1vGVMg4DfaqkId6fW3Z3HKce3X+J2V2kFtsIPaISrW2iHWzqcl1AZRage1wQ6x1g6xdj4tpXZQG+ygdoiKpXaIpXNpDbVDlNpBbbBDrLVDrJ1PS6gNotQOUWqHjm2DmEmCiIiIiIiIiIiIiIiI7KxTToclIiIiIiIiIiIiIiLSWkqCiIiIiIiIiIiIiIhITFISREREREREREREREREYpK1oyvwU0rLKrn1nkeprqnDYrFw4VkncNhB49lSXMotdz5EfUMjY0cO4YafX4jJZKKmtp7f3fEAZRVVFBXmc+tvrsRhtzft77W3PuRvj/yTj//9FG6XswPPbN+1VRtsKynn9r8+Tm1dA5npqdx+09XEx7k7+vT22f62w9vvfcpzr/6HLcWlu/19d4drYU9t0N2uhQeeeJGv58zDarUysF9vfnPdxVgtlqb9ffXtfK7/w195/vG7KOqV3+nPJxbjHCjWgeLcDop1inOKc7Eb50CxDhTndlCsi71YpzgXpTgXpVinOBeLcQ4U63ZQrFOc26GrxLpOPRLEYjFz3eXn8tKTd/P3O2/k/seex+vz8cjTL3PxOSfx+rN/o7aunq/nLADgn6+8w8FTxvLaM38lJzuTt9/7rGlf1TV1fPPdArIz0zrmZFqordrggSde5KSjp/PC43/miMMm89wr73TcSbXA/rbDoAF9+PtdN5Kdlb7LvrrLtbCnNuhu18KE0UN54Ym/8PxjdxEMhnjvo6+a9uUPBHj5X+8xqH9RB52N4twOinWKczso1inOKc4tAGIzzoFiHSjO7aBYF3uxTnEuSnEuSrFOcS4W4xwo1u2gWKc4t0NXiXWdOgmSnpZCv6ICANJSk0lOTKCurpHFy1YzefwIAGYeNpmv5swD4Ktv53Hk9CkAHHHYZL6eM79pX48+8wqXnHsymEztexKt1FZtsGHzVkaPGATA6OGD+OzrH9r5TFpnf9uhT2E+OdmZu91Xd7kW9tQG3e1aGDd6KFaLBZPJxIB+hZRXVDXt6/lX3+WkY6bjcNja/Tx2UJyLUqxTnNtBsU5xTnEuduMcKNaB4twOinWxF+sU56IU56IU6xTnYjHOgWLdDop1inM7dJVY16mTIDtbsXo9kUgEh8NOYkI8pu1/GBlpKZRXVAPQ0OhpGi608/tLlq8hEjEYPKDjMuZtoTVt0KewJ599/T0An339AxWV1R1wBm1jX9phT7rTtbAn3fVaCIXDzPr0G8aPHgpEhxsuXbGGQ6eOa/d674niXJRineLcDop1inOKc7Eb50CxDhTndlCsi71YpzgXpTgXpVinOBeLcQ4U63ZQrFOc26Ezx7oukQSprWvgtrsf48ZrL9rvspFIhEf/7xWuuPC0A1Cz9tOaNgC45rKzmP3dQs6/6ndUVtfgdDrauIbtQ9eCroUd9rcdHnryJQYP6MPgAX0AePDJF7nyotMPZBX3i67tKF3fuhZ20LWgOLczXds/ioVrG3Q9gK6FHRTrfqRrO6q7Xts7i5VrAXQ9gOLcznRt/ygWrm3Q9QC6Fnbo7LGuUy+MDhAIBPnNrfdx7unHMmxwPwzDoK6+AcMwMJlMlFdWk5GWAkB8nLspw1peWU16WjIer491G7dwyXV/BKC8vIqzL7uR5x+7i7gusshMa9sAIDM9lbtv/SUAZeWVzPlhUUedTovtTzvsTne7FvakO14Lb7wziw2btnLv7b9uem/lmg1c/8e/AVBVVct1N93NA3f9hsKC3E59PrEa50CxDhTndlCsU5xTnIvdOAeKdaA4t4NiXezFOsW5KMW5KMU6xblYjHOgWLeDYp3i3A5dIdZ16pEghmFwx18fZ/SIQU3z55lMJgYP7NO0mMoHn3zD5AkjAZg8fkTTYirvf/w1UyaMIj7OzXuvPsq//nk///rn/WRkpPLCE3/pMn9MbdEGADW19RiGAcCzL73N8Uce2s5n0jr72w67092uhT3pbtfC13Pm8/b7n/Gn312D1WJp2s8b/7iv6VoYPLCI+++8oUM6kYpzUYp1inM7KNYpzinOxW6cA8U6UJzbQbEu9mKd4lyU4lyUYp3iXCzGOVCs20GxTnFuh64S60yBgN9os721sYVLVnLFr++gT2F+03u/v+EKHHYbt9z5EA2NHsaMGMwNP78Qs9lMdU0dN93xAOUVVRT1yufW316F02Fvts8Tz7uOFx7/M26Xs71Pp0Xaqg0++uxbnvjn6wBMGT+Sqy89E7O5U+fAmtnfdvjXux/zzIv/pqqqlpSUJKZPG8+1Pzun2T5j/VrYUxt0t2vhlAt+STgcJiE+DoBDp47ngrOOb7bPK6+/g19ddT5FvfJpb4pzUYp1inM7KNYpzinOxW6cA8U6UJzbQbEu9mKd4lyU4lyUYp3iXCzGOVCs20GxTnFuh64S6zp1EkRERERERERERERERKSluk5aSUREREREREREREREZD8oCSIiIiIiIiIiIiIiIjFJSRAREREREREREREREYlJSoKIiIiIiIiIiIiIiEhMUhJERERERERERERERERikpIgIiIiIiIiIiIiIiISk5QEERERERERERERERGRmKQkiHSoQ4+/mDXrN3d0NUREDhjFORGJdYpzItIdKNaJSKxTnJNYpiSItKsTz7uOz7/5oennT956mj6F+e1ah20l5UyceQ71DY3telwR6R4U50Qk1inOiUh3oFgnIrFOcU66EyVBREREREREREREREQkJpkCAb/R0ZWQ7uGmOx7gs6++x2b7//buNraq+g7g+PeelvYWKLW0BRM3y4MFpw6djEitboBAUWAxoNSHQLQ43AoTgzp0VkUMjLiJBrS0TmTIgKBWysKDNFCXujSbG8qGQxSiFQF5kFRaHtvb4gsSNJG9kEqBc7+fVzfn3PzPLye53zf/nHMTSQgC8gflUbG6ioUlM+jVM5uXFpXzwUefkJWZzrq//YNOqR0pfuCXNBw6zNwXl1DfcJBRIwbzq7vHnFzznXffp3TBq3y2czdZGen8unAM1+f2PXFuwybm/GkJn+/eR3JyEgPy+vHb++7mpjFF1B2oJyWaDMDUyYVcn9uXabNKeP+DbTQ2NZHT42KmFI0jp2c2wHeebVVlNcuWv0luvyupWP0WKdFkxhaMYPTIIW181yW1JTtn56Sws3N2TooHts7WSWFn5+xcvPFJELWZmcX30bVLBtMfmUjVivlMnVz4re+88+4m+vftw9rXyxh2Qx7Tnp7H2zUbWFQ6k7LZT7C0fA0fbv0EgG0fb6d4xhyKxhew9vVSpk4u5MmnS/n0s10APPXHMu68ZTjrK16ifOFsht2QB8D8OU8CsGLxHKpWzCd/UB7HW1oYOvBayl+ZzaplL9DrkmyKZ87l+PHjpzUbwMe1O4hEIqxc+jxP/W4SJS8v471NW87Y/ZV09tk5OyeFnZ2zc1I8sHW2Tgo7O2fn4o2bIDqnXJrTnQHX9SMhIWDIgFz2fVHH2IKRpESjdM++iJ7df8iH22oBWL66ipuG/IyfXnU5QRBw5RW9ybvmJ6yv/icAiYkJ7Ni1h7ov60mJRulzea//e90OHdozeEB/UqJRkpOSuGfsaLbv2M2+/XWnNRtANJrMPWNH0a5dIj++LIf8gXmsWff2Gblvks4fdk5S2Nk5SfHA1kkKOzunMEk82wNI39T5grSTn6PJSSeOpX/jWDSJw0eOAbB7zz7+vXEzqyqrT55vbm6mQ/vrAJj1+P38eelfKRj/EBd2zWRcwUgG/7z/Ka979Fgjc19cTM2//kN9w0GCyIn9wQMHGuiS2fk7zwaQmZFOYuLXP7ELu2bw3n/dZZbinZ2TFHZ2TlI8sHWSws7OKUzcBFGbCiKR722tLpkZFNycT9H42055vndOd37/+GRaWlqortlA8Yy5XN3nR0SCb8+wtHw1W7bWUvbMY3TJyqDh4CGGjr6X1vxhzhf764jFYicju2fvfrIy01uxoqTzgZ2zc1LY2Tk7J8UDW2frpLCzc3Yunvg6LLWpzulp7Ny193tZ6+bhg1hZWc2GjZtpbm6hsbGJTZu3Urt9J01NMdas+zv1DYcIgoCOHdsDkJAQcEFaJ4Igws7Pv57j0OEjJCW1IzW1A4ePHKV0wautnu/o0WO8vLiCpqYY/9uyjbVVNeQPzGv1upLObXbOzklhZ+fsnBQPbJ2tk8LOztm5eOKTIGpT4277Bc+WLGLBkgqGDsxt1Vq9L+nG9EcmUrbwNWq37yIIIuT0yOY3E+4AoPKtGp4r/QuxWIyuWRlMe7iItE6pABTeOYopj/6BpliMByfdxe2jbuSJWSUML5hIWloqE8bdwhsr17dqvh7dfkBzczMjbp9ENDmJe++6lb5XXdaqNSWd++ycnZPCzs7ZOSke2DpbJ4WdnbNz8STS2HisNU8TSTqFVZXVLFv+Jq/Mm3m2R5GkM8LOSQo7OycpHtg6SWFn5wS+DkuSJEmSJEmSJIWUmyCSJEmSJEmSJCmUfB2WJEmSJEmSJEkKJZ8EkSRJkiRJkiRJoeQmiCRJkiRJkiRJCiU3QSRJkiRJkiRJUih9BSTFQTjcTDeGAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1600x800 with 20 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "n_cols = min(len(macro_data_full.columns), 20)\n",
-    "n_rows = (n_cols + 4) // 5\n",
-    "n_plot_cols = min(5, n_cols)\n",
-    "\n",
-    "fig, axes = plt.subplots(\n",
-    "    nrows=n_rows, ncols=n_plot_cols, figsize=(16, 2 * n_rows), sharex=True, sharey=True\n",
-    ")\n",
-    "axes = axes.flatten() if n_rows > 1 else [axes] if n_cols == 1 else axes\n",
-    "\n",
-    "for i, ax in enumerate(axes[:n_cols]):\n",
-    "    if i < len(macro_data_full.columns):\n",
-    "        macro_data_full.iloc[:, i].plot(ax=ax, color=\"steelblue\", linewidth=0.8)\n",
-    "        ax.set_title(macro_data_full.columns[i], fontsize=9)\n",
-    "        ax.tick_params(axis=\"both\", labelsize=7)\n",
-    "    else:\n",
-    "        ax.set_visible(False)\n",
-    "\n",
-    "for i in range(n_cols, len(axes)):\n",
-    "    axes[i].set_visible(False)\n",
-    "\n",
-    "sns.despine()\n",
-    "start_yr = macro_data_full.index.min().year\n",
-    "end_yr = macro_data_full.index.max().year\n",
-    "fig.suptitle(f\"FRED Macro Series - Standardized ({start_yr}-{end_yr})\", fontsize=12, y=1.02)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fb67ff3e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003189,
-     "end_time": "2026-07-18T19:35:44.445799+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:44.442610+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "**Interpretation**: The visibly regime-bearing series are VIX (sharp spikes\n",
-    "in 2008 and 2020), ICSA initial claims (same crisis peaks), DFF (regime\n",
-    "shifts during hiking cycles), and the yield-curve spread T10Y2Y (recession\n",
-    "warnings ahead of 2008 and 2020). Slow-moving series (housing, monetary\n",
-    "aggregates) carry less regime information. Clustering will lean heavily on\n",
-    "the high-variance subset."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4fa252e1",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003057,
-     "end_time": "2026-07-18T19:35:44.451957+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:44.448900+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Hierarchical Clustering\n",
-    "\n",
-    "Cluster the correlation matrix to reveal indicator groupings."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "b23b0bae",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:44.459045Z",
-     "iopub.status.busy": "2026-07-18T19:35:44.458948Z",
-     "iopub.status.idle": "2026-07-18T19:35:44.636969Z",
-     "shell.execute_reply": "2026-07-18T19:35:44.636634Z"
-    },
-    "papermill": {
-     "duration": 0.182302,
-     "end_time": "2026-07-18T19:35:44.637455+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:44.455153+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA9cAAAP4CAYAAADXjQ/KAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA26hJREFUeJzs3Xt8jvUfx/H3vfvexs6GOZ8lx3IOOTPnQ04pSSiK5JBGaYosYipJ5JSS6OAQSiE5hSJ0EDqR82zMDja7t93b7w+/7ty2Ybu3azOv5+Ph8dh1Xd/r+nyve/dm7/v7va7LlJhoTRUAAAAAAMgyl9zuAAAAAAAAtzvCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOsuR2BwAgPYs+XKXFy9akWV+/dg29Pf0FSVKPAaMVdv6CJMliMat4QBG1vL+BBvd/QAULFLjpsSTp5XFPqUObppKkxu3729e7ubmqkK+PqlapoM7tmqtZo7o37fPwoBD5+Xhr6sRRt36iGfhs7Sa9MXep9mxcJkk68PNhPT1uqpbNn6ZK5cs4ffx//bD/Vx0/cUYP9eyQbce8kT/+PqGlH6/TwV+PKib2svx8vFX33urq26O9qt9dyZA+ZGTRh6u0ct1mff3Zu7e8T1JSsj74eK2aN6mvKpXK2defC4tQz8fGKHTyWDVtVCcnupslb8xdqvj4Kwp+7klJNz7nKTPn69g/p7VkzhRJ0pebdijk9QXa8vkieRQskKZ9XnKrPy/Xn2N26TFgtFo1baiRQ/vdsF1iYpI+W7tJG7fu1qnTYUpVqiqWK6W2LRqrZ9e2KuDulmOv++cbvlUhPx+1aFI/246Zk++R1NRU9X/qBfXv00Ud2zbN1mMDQHYhXAPIs7w8PfTmq+OuW1fQYbldqybq072dkpKTdfCXI1qy/HNFx8ZqwpghNz2WJJUuWcxh+eFendS6WUMlJyfrfESkvvv+gMZPelOdApspeOzQbDqzzLu7cnktnDVJpUoUu3njTPhh/6/a+t1eQ8L1tu/2aeK0Oapds6pGPfmIihbxV8SFSG38drdGT5iuTasW5HgfsltScrIWL1ujEsWKOoTrwv5+WjhrksqVKZGLvXN0Pvyi1n61VR+882qW9m/SsLYWzpqkAu5u2dyz3DOo3wOyJibmSu0Ea6JGv/Ca/v7ntPr2aK97atwtSTp05E8t+/QLmc0u6tsj534u127YqorlS2druM7J94jJZFL/Pl20eNlqBbZqLIvZnO01AMBZhGsAeZbZ7KKa1SrfsE1hfz97mzq1qiriwiVt+Gannh/1uFxc/rvy5VaOJUklihVxaNe+dRM1rFdLU99YqDr3VFXnwOZZPBvneHp63FL/c5s1MVHubmn/sI64eElTZs5XYMvGmvjckzKZTPZt7Vo10XffH3Sqrs2WopSUFLm6Wm5pfU5zc3PNc9+vNV9u0d2Vy6t82ZJZ2r+Qn48K+fk43Y8Ea6JT4Suj91hWXP/hmpEWvP+Zfv/rhBbNnuQwut6wbk316hqoE6fO5lrfMuvfn7Pseo9kpHXzhpo5533t2ffzLc0mAgCjEa4B5Ct3VSyrxMQkRUXHyr+Qb7Ycs2v7Flq74Vut+WJLpsL1v1Nu35r2vELfXqK/jp9S2dIl9OywR1W7VlV7u8TEJM1esFwbv90lk8mkToHNVCygsMOx0pvmarOlaNlnX+jLTTsUFn5Bfr7ealCnpib+f8rvrh8O6pM1G/XXsZOyJiWqQtlSGjKgt+6rV8vevxWrNkj6b0p8p8Bm9v2/2f69liz/XKfOhKmQr486tm2qJwb0so8Y/TsFdNFbk/XO4hX67ejfeuyhbhr8SI80r8W6r7YpKTlZI4c+4hCs/3Xt1GmbLUVLlq/RFxt3KDIqWqVLFNNjD3dX+9ZN7G3+nc47sF93zV/ymU6eCdOc6S9o/cbt6a6vXauqduzeryXLP9exf07Ly8tDHds21VMD+8hiSf+/wisJCXpn0Sfad/BXnY+IlL+frxo3vFfDBz0oT08PSVKbB56QJIW8vkAhr18deV/9wZuSlGZaeGbOa9igBzV74XKdORuuKpXLafzIwapYvvR/r+fX27Ri1QadDYtQwQLuqlCutIJGDHRoc72vvvlOD/XqmOH2m0lvyq81MVELl67S5q17dCk6RuVKl9SwwQ+qScPa9v16DBitVvc3kJeXhz7f8K0iL8Xouw0f6NfDf2rpJ+t05I9jiotLUJlSxfRIn85q3/r+NDXTe4/9deyk3n3/M/186HfZbDaVL1tKTw3so4b/f39LUnR0rCaEzNb3+35WIT8f9evdSb26BqZ5va+dFn7u/AXNe+9j7T1wSAnWRJUuWUyPPtjV/n2au/hj7dr7k86FRcjLy0N1alXTyKH9VNjf75Zfy4QEqz7f8K16dG6d7rR1Xx8v3VOjSrr7ZjTl/frLUo79c1qzF3ykw78fU1JSsooFFFbvboHq3S1Qw4NCdPTP4zr653Ft2LxTkhQ8dqg6t7v6+23dV1v18eqvdfrceRUu5KteXQPV/8EuaV6363/OzpwLd3iP/Ht5xJQJI/TjT7/pm23fy8OjgLq2b6nH+/dw+AB0y44f9O6STxV+IVI1q1bWyCcf0cCngx365e7mpsYN7tVX33xHuAaQJxGuAeRpyTabw7LZxSXdcPavsIiL8vAoIF8f75seS9ItTy1sULemPvzkCyUnJ2cYxtKTYE3UlJnz9VCPDirs76fFy1brhSlvac3SWSpQwF2SNPe9T7T+6216cmAfVShXSmu/2qpvd/5w02NPn71YX33znfr36aI6taoqJjZOW7/ba99+NixCTRvVUb/eneRiMmnPjz/r2eAZmjtzou6tUUXdOrTUqTPntf/n3/TaS2MkSX6+V1+3H/b/qolT56hj26Ya8cTD+vv4KS1YulLRMZc1ftRgh368/No76tmlrR5/pKe8vDzS7evBX4+o6l0V7Me/kYVLV2rZZ1/q8f49VK1KRW37bp8mTZ8rk+nqKPe/zp2P0DuLPtbgRx6QfyE/lSxeNMP132z/Xi+/9o4e6NRaTw16UGfOnte8JZ8qJSU1w+tiExISlZKSoicHPig/X2+FR1zU+yvW6cVX39asqeMlSXOmT9CI8VM1sF933d/waogu7O+ni5FRWT6v8+EXNWfRCg18qLvc3V319sIVmjh1jpbNnyaTyaSDvx7VjNlLNGRAL9WqVllx8Vf065G/dDkuPsPX9MSpswq/EKl7qt+V7vb0fjZSU1MzPN6/JkyZrSO/H9MTj/ZUqZLFtGXH9xr38ht6b84Uh2nym7btVoWyVz8AsNlSJElh4Rd0T/Uq6tG5jdzcXPXLb38o5PUFMplMDq+HlPY99s/Js3ry2VdUtnQJjRs5SL7eXjry53GdvxDpsN+0WYvVKbCZHujYSpu27dHMOR+o6l0VVaNq+tf3R0ZFa+joSXJ3d9MzQ/opoKi/jv1zWuERF69pE6PHHuqmIoULKSo6VitWbdCI8VP10fzXHMLijRz987iuJFjVqP49t9Q+K4Jefl3ly5bUpPHD5Opq0cnT5xQXf+XqthGD9MKUt1SqRFEN6nf1w7BSJQIkScs++0LvLvlM/ft0Vt17qunoX8e1YOlKubu7qU/3dvbjp/dzduZceLp9eWfxx2p1fwNNDR6pH3/6Te99tEYVypVS2xaNJElH/jiml6bNUaumDfXs8AH659RZTZw6J91j1ap+lxYvW6PU1NQb/l8AALmBcA0gz4qOuaxmnR5zWPfWtOfVsG7N/1akpirZZlNyUrIO/npUn3+5RQMf6i6z2eWmx5KujjKW+H8ou5GAIv6y2WyKiY3L1Ii41Zqo0U/1V/3aNSRdDV6PDX9RB389qsYN7lV0TKzWfLlFTzzaU/16d5Ik3Vevlh4eMv6Gx/3n5Fmt/3q7xgx7VA8+0N6+vm3LRvavr/1DOCUlRXVrV9fxE2e0/utturdGFQUULazC/n5ydU07hXnh0pWqe081vRT0lCSpcYN7JUnzlnyiQf26K6BoYYc6N7s2NOLCJd1dudwN20hXv0+frNmoQf26a1C/ByRJjerfo/ALkVq8bLVD6IqOuazZr73gEOLSW5+amqp3Fq1QxzZNFfTMoKuN6tWSq5urZs55X4891DXdD2MK+flo3MhB9uVkm00ligfoqWdfUVj4BRUPKKJqd1eUJJUuUeyG08Azc14xsZc1/82XVKZUcUlSSmqqnp88SydOnVP5siV1+OjfqlyhjB57qJt9n2aN693wdT365z+SlO7IdkY/G5JU9a4KGR5z38FD2r33J70T+qLq3lNN0tX37qnTYXp/xVpNDR7p0H7mlLEO07kDWza2f52amqrataoq/EKk1n21LU24vv499tK0OfL0LKh5r0+0TzG/dsT62hr/vt51762mXT8c1PZd+zIM1x+v/lqX465oyZwpKlK4kCSpQZ2aDm2uvfeCzZaimtUqq/sjI/Xzb3+ozjUzUm4k4uIlSUozQyW7REXH6mxYhKZPelaVK1wd3b72PCqUK6WCBdzl5+vj8L6Ni4vXe8vWaFC/7nq8f09JV1/XhIREvb9irXp2aWv/3ZrRz196atesqpFPPmI/3vc//qLtu360h+sPP/1C5cuU0pQJI2QymdS4wb2yJdv0zuKP0xzrroplFXs5TqfPnrf/jABAXkG4BpBneXl6aPZrzzusK1va8QZRK1Z/pRWrv7Ivt7y/gR7t2/WWjiXJ/gf0zdzCIF66XF0t9uAhSRXKlpIkRfx/hO3v46eUmJjkEI5cXFzUvHE9LfvsiwyPe+Dnw5KkzoHNMmwTHnFR777/mfYd/E0XI6PsI5EZTTf9l82Wot//+kejn+rvsL5Ni0Z6Z/HH+vXIX2pzTbi+dgrwjd18lOnYidNKsFrVutl919W+TyEzF+hSVIz9ms6iRQql+4f99etPnj6nsPCLatOikcMIbf17qysxMUl//3Pa4Xt0ra+++U4rVn+l02fCdCXBes0xw1Q8oMhNzycr51W8WBGH0PDveyb8QqTKly2puyqV0zuLP9asd5epxf31VbNq5ZteUx55KUpubq4Od9H/V0Y/G4uXrUl3BP5f+w7+psL+vrqnRhXH17VODX25aadD2/q1a6S5TjomNk6LPlylnXv2K+LCJdlSro5oFy2S9mfy+vfYjz8dVofW99/02u37rgncFotFpUsWV/h1o9vX2v/TYTWqf88Nfy/s2fez3vvocx0/cdo+EixJp06fu+Vw/a+cGnn18fZUsaKFNWP2e3qwe3vVrV1N/n43/1Dw1yN/6UrC1fepw/e0dnUtWf65wi9EqkSxq+/7jH7+0nNfPccPKMqXLaXz18wGOPLHMQW2bOzwejRtVDfdcO37/9kvFyOjCNcA8hzCNYA8y2x2UbUqFW/YpkOb+/XgA+11JcGqDZt36stNO7R6/Tfq2bVtpo91IxEXI2WxmOXj7Zmp/TwKFnCYKvpvCLImJkmSLl6KlqQ0NwG62U2BomMvq2ABd/u1v9dLSUlR0KQ3FB+foCEDeql0yWIqWMBdC5eu0qWomBsfOyZWycm2NH+M+xe62qeY2MvXrb/5H+1FixRy+GM6IxcvRjnUstf4f19iYi/bX5uMwsL166Nirvb32eDQdNuHZ9Cvbbv26ZXQd9WzSxsNG/SgfLw9dSEySs9PnqXE/3//blVmzsvby/E95vr/yxD+rdmwbk29OHaIPvt8kz79fKMKFnRXhzZNNeKJh9INz9LV95ubq2u62zL62fD18bphuI6OjtXFyOh0R73N102PTu97FTJzvg4d/UuD+j2gCuVKydOjoFZ/sUU79+xP0/b691hMzOVbusb5+ssUXF3NN/zeRcfE3vD3xOHf/1bQy2+oRZN6GtC3iwr5+cpkkp4YNcn+M30riv4/vIeFX0zzgWF2cHFx0ayp4zX//c/06hsLZU1M1D3V79KY4QN0d+XyGe4XHRMrSeo3NP2ZM+ERF+3h+lbC+r+8PK97T7taHL4PkZHRKnTdJSOF/NK/hOTf93FmfwYBwAiEawC3tUJ+vvY/huveU01h4Re08MNV6hjYNMOgkRV79x9S1bsqZOp661tR+P+h4VJUjHx9vOzrbxaAfb29dCXBqri4+HQD9umz5/XHXyf0RkiQfUq3dHWa+s34+njLYjGn6UPkpavLPt5eDutvZfSt7j3V9MGKdYqOuexwntcrXNhP0r+vx39/XEdGRaepnVHd69f7/v8DkedHPa4q6UxNL5nBZQHf7tirGlUr/TeVXNKBX45k2Pcbycx53YrOgc3VObC5LkXFaNuufXpr/kfyLFhAwx9/KN32Pt5eiou/opSUlFu+LvhmfLy9VLRIIU1/eczNG1/3PbEmJmrX3oMa+/RA9ezSxr4+NWVzBrs77u9zk+CfVb4+3jc87vZdP6qQr7dCXnzG3qdz5y9kuk7VKhVVsIC7ftj/i+NlLrfA7f8zAJKTkh3Wx8bGy++a91b5siU17aVRSk5O1k+HftfcxR/ruYkztfaj2Rm+B/59H858ZWy6H5pd+0FAdo66+/v76lJ0rMO6S1Gx6baNvRwn6ep7AADymuz5HxYA8ohhg/oqKjpW67/enm3HXL9xuw7//rd6dG5z88aZVKlCGbm5uTqM1qWkpGhHOqN316pXu7okacM336W7/d8Qfe1o5bnzF/TL4T8c2rla0o7kmc0uqnpXBX27c6/D+i07vpeLi0m1svCIqa4dWspiMevthcvT3b7rh6uP4qpYrrQKuLtryw7H2t/u+EFlSxfP0mN+ypYuoaJFCunc+QhVq1Ixzb/0rreWrgZA1+tGezd9u9th+d9R5ZuNWubEeUlXZzj06NxGtWvereMnz2TYrlzpEkpNTVVYeOaDYEbq16mhyMhoFSxQIN3X9UaSkpKVkpIqt2ums8fFX9HOW3wkW/3aNbRlxw/Z/ozq+rWr64f9vyjy/zNKrmdNTJLFYnYIlhu/3ZXpOgXc3fRAp9Za88UWHT+R9vsWezlOvx7+M919A/4/bf6fax7VdT78ok6cTv/RXRaLRfVr19BDPTvqQmSUYi/H29df/7Nfs1plubu76cLFqHS/p54eBTN9rreiWpWK2vX9QYeb6H33/YF02547f0EuLqZcfYwaAGSEkWsA+UqNqpXUsG5Nfbz6a/XqGmi/+Y7NlqJDR/5K0z6gqL8Civjbl8+dv6BDR/5ScnKywi9EaueeA9qy4wd1ad9CnW5wfXNW+fp464FOrbTow9Uym82qUK6U1n21TVcSEm64X7kyJdW9Uyu9vXC5LkXFqHatqrocF6+tO/dqyoQRKlempAKK+Gv2wo80dEBvxV9J0KIPV6loYf80x4m8FK0vN+1QxfKl5efjrRLFi+qJR3tp9ITpCpk5X21bNtbfx09p4Qer1K1DK4ebmd2qooULKXjsUL302juKuBCpLu1bqGjhQoq4eEnfbPteB389qk2r5svXx0t9e7TX+ys+t09X3vbdPu3e+7NeeeHpTNeVrk6RHTnkEU0Onae4+Ctq3OBeWSwWnQ0L147d+zU1eKT9zu3Xali3pmbO+UDvL1+r6lUrac++n/TjT785tHF1tahk8aL6dscPqlS+tNzcXFW5Qtk0x8rO81q4dJViYi+r7j3V5OvrrT/+OqGDvxzVsMF9M9ynetWKMpvNOvrnPypZPCBT9TLSsG5N3Ve/lka98Jr6P9hFFcuVVlz8Ff157ISsiUkafoP+eHl6qFqVinrvo8/l6VFQJheTPvzkC3l5FnS4jjkjj/fvocEjX9KwsSHq16uTfHy89Mff/8jXx1td27fI8jk91LOjvtrynZ4aO0WPPdxNxYoW1j8nzyohwar+D3ZRw7o19cmar/XmvA/VtFEd/Xr4zyyFa0kaOrCPDv/+t558drL69uioe2pcvZP7b0f/1sp1m/Tog11VK527uwcULaxqVSpowQdX7+CdmpKqDz5e53DJyl/HTurthcvVpkUjlSoeoNjLcVr26Re6q2JZ+8yRcmVK6If9v+r7H3+Rr4+XShYvKl8fbz3Rv6fefPdDhYVfUO1aVZWSkqJTZ8K0/+fDtzZLIQsefbCLnhj1siZOnaPO7Zrrn1NntfarrZLSjpAf/eO4KpQrLa8MLokBgNxEuAaQ7wzs94CGPxeiLTu+t991+HJcvIaMnpSm7dDHetvvJixJK1Zt0IpVG+Tm6io/X29Vu7uipk8ak6PPVH368YeVnGzTex+tkYuLSe1b36+He3bU7AXpj/L+K2jEIBUPKKL1X2/Th5+uVyE/HzWse/UGTm5urpr20ijNnPOBJoTMVkARfw18uLsO/HJEx/45bT9Gmxb36cDPh/XOoo91KTrG/pzr++rV0pQXRmjJis+1cetuFfLz0cO9OuqJAb2yfJ6tmjXUohIBWvrxOr0570PFxMapkK+36tWurrevuaHWkAG9ZTabteaLLVoctVqlSxbTpPHDHO4unVltWzaSp2dBfbBirb7YuEMuZpNKFQ/Q/ffVkSWDm4E90KmNzpyL0Kefb5Q1KVEN69TS5OeH64lRkxzajRs5WG8vXK6Rz7+mxKQk+3Our5dd51WtSkV9vOYrfbP9e8XHJ6h4scJ6/NEe6tujfYb7FCxQQPfVq6U9+35W62YNM1UvIyaTSdMmjtYHH6/TJ2u+1vmIi/Lx9tJdFcs63Kk+I5OfH67ps9/TK6FXP1Tp3S1QCVarVq5Lf2r4tcqVKan5r7+kue99ommzFkm6epOspwb1ceqcCvn5aP4bL+udRSv01rvLlJiUrDIli2vAQ1dvktikYW09/fhD+mztJq37aptqVqusma88pwcHP5fpWgXc3TT7tRf02dpN2vjtLn346XpJUsVypfRIny56oHPrDPed/PzTmjZrkSZPf1cBRQvp6ccf1sdr/ruxo7+/r/wL+eqDFWt14WKUvLw8VO/eag6XDQzq94DOh19U8KtvKy7+iv150v0f7KIihf308eqvtXzVBrm7uapMqRJq2+K+9LqSLapVqajJzz+td5d8qp17DqhqlQoKemaQRr3wmjw9HUfLv//xF7Vq2iDH+gIAzjAlJlqzeA9cAABwu9i2a5+mvblY65e/LTe39G9uBuQVX2/5TpNnvKtVH7xhn21x4tRZPTL0eX225PVbeoQiABiNa64BALgDNG9cT0UK++nrLelfpw/kphmzl2jbd/u0/6fDWr5yg96Yu1RNGtZ2uIzh49Vfq32b+wnWAPIspoUDAHAHcHFx0Qujn8jwxldAboqOiVXonPftTxRo07yRRjzx3zT21NRUlSxeVIGtsn55CADkNKaFAwAAAADgJKaFAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOsuR2B/KyN+Yu1c7vDyjs/AV9MPdVValULt12677epg8/Wa/U1FTVu7e6gp4ZKIvFctNtAAAAAID8gZHrG2jVrKHmvz5RxYsVybDN2bBwLfxgpd59faI+W/K6IqOi9fmGrTfdBgAAAADIPwjXN1CnVlUFFC18wzbf7tyrpo3qqrC/n0wmk3p0bqPN2/bcdBsAAAAAIP+4Y+cnr1y3WavWb7Yv9+oaqN7dAjN9nPPhFx1GtksUK6rz4Rdvug0AAAAAkH9kOlw/41YlJ/phuLcT/8hSmAYAAAAA4HqZDtdmU0504/ZVLKCwzpwNty+fOx+hYgGFb7oNyKuCgyfKarXmdjcA5AJ3d3eFhEzJ7W4AAHBbynS4dnMhXV+rVdOGeurZV/TEoz3lX8hXa77corYtGt10G5BXWa1WhYbOyO1uAMgFQUHjcrsLAADctrIwcn3nhOvX3lqs3Xt/UmRktEZPmC6PggW08v03NPXNhWrWqK6aNa6nUiUC9MSjvfTks69IkurcU009OreWpBtuAwAAAADkH4xc38Dzox5Pd/2EMUMclrt3aqXunVql2/ZG2wAAAAAA+QPXXAMAAAAA4CSmhQMAAAAA4KRMh2tXwjUAAAAAAA6YFg4AAAAAgJO4oRkAAAAAAE7immsAAAAAAJzEyDUAAAAAAE7immsAAAAAAJxEuAYAAAAAwElccw0AAAAAgJMYuQYAAAAAwEnc0AwAAAAAACcxLRwAAAAAACcxcg0AAAAAgJMyHa5dGLkGAAAAAMBBpsO16Q67o9mpM2F6JXS+omNi5eVZUMFjn1TF8qUd2nyxcbs+/XyjfTn8QqRq16qq114arXNhEeo96FlVKl/Gvn3qxFEqXbKYYecAAAAAAMhZmb/m2s2cE/3Is6a/9Z4e6NRKnds117c79yrk9fl67+0pDm26tG+hLu1b2JcfGfq82rdqYl/2KFhQS+dNNazPAAAAAABjuWR2B5PZlC/+3YrIqGgd+fOY2re5X5LUqmkDnY+I1KkzYRnu89vRv3QpKkbNGtfN7EsLAAAAALhNZX7k2jV/jFyvXLdZq9Zvti/36hqo3t0CHdqER0SqiL+fLOar52wymVSsaGGdj7ioMqWKp3vc9V9vV4c298ti+e+lvZJg1eBnJsqWkqLmjetr4MPdZTZn+nMNAMiS4OCJslqtud0N3AYiIiIUFDQut7uBPM7d3V0hIVNu3hAA7jCZv6FZPrnmune3tGHaWVcSErR5+x4tmjXZvq6wv5/WLZ8tfz9fRcdc1sSpc7Ri1Qb1f7BLttYGgIxYrVaFhs7I7W4AyCf4AAYA0se08BsIKOqvC5FRSrbZJEmpqak6H3FRxYoWTrf9tzv2qmK50qpQrpR9nZubq/z9fCVJvj5e6tK+uX469HtmX3YAAAAAQB7GDc1uwN/PV3dXLq+NW3apc7vm2vrdPgUU8b/BlPBt6nrNjc2kq9dt+3h5ymKxKDExSdt2/agqlcoZ0X0AAAAAgEEy/ygul/wxLfxWjR85WCGvL9AHH6+Tp0dBvTh2qCRp6psL1axRXTVrXE+SdOLUWf157KTatGjksP8vh/7QwqWr5OLiIpvNpnq1q2vgw90NPw8AAAAAQM5h5PomypUpqYWzJqVZP2HMkDTttny+KE27lk0bqGXTBjnVPQAAAABAHsAtqwEAAAAAcBIj1wAAAAAAOCnz11znk0dxAQAAAACQXTL/nOs77IZmAAAAAADcDNPCAQAAAABwEtPCAQAAAABwEiPXAAAAAAA4KfMj11xzDQAAAACAA0auAQAAAABwUhauuXbJiX4AAAAAAHDbysK0cMI1AAAAAADXysK08EzvAgAAAABAvsa0cAAAAAAAnJTpcO3i6poT/QAAAAAA4LbFyPVNnDoTpldC5ys6JlZengUVPPZJVSxf2qHNgZ8Pa0xwqMqVLmFft2DWJBVwd5Mkrft6mz78ZL1SU1NV797qCnpmoCwWptcDAAAAQH6R+ZHrO+yGZtPfek8PdGqlzu2a69udexXy+ny99/aUNO3KlS6hpfOmpll/NixcCz9YqfffCZF/IV+Nm/SGPt+wVb27BRrRfQAAAACAATKdlE1ml3zx71ZERkXryJ/H1L7N/ZKkVk0b6HxEpE6dCbvl1+vbnXvVtFFdFfb3k8lkUo/ObbR5257MvuwAAAAAgDyMaeE3EB4RqSL+frKYzZIkk8mkYkUL63zERZUpVdyh7Zlz4Xrs6RdldnFR53bN1avr1ZHp8+EXVbxYEXu7EsWK6nz4ReNOAgAAAACQ47JwQ7P8ca3wynWbtWr9Zvtyr66BWZ6qfXfl8lr70Wx5eXooPOKinp04U74+3mrbolF2dRcAAAAAkIfdsSPXvbvdPEwHFPXXhcgoJdtsspjNSk1N1fmIiypWtLBDO09Pj2v2KazAlo3186Hf1bZFIxULKKwzZ8Pt28+dj1CxAMf9AQAAAAC3t0wnZbOrJV/8uxX+fr66u3J5bdyyS5K09bt9Cijin2ZK+IWLl5SSkiJJiou/ol0/HFSVyuUlSa2aNtR33x/Qxcgopaamas2XWxjRBgAAAIB85o4dub5V40cOVsjrC/TBx+vk6VFQL44dKkma+uZCNWtUV80a19PW7/ZpzRdbZDabZbPZ1Lp5Q3Vp11ySVKpEgJ54tJeefPYVSVKde6qpR+fWuXY+AAAAAIDsR7i+iXJlSmrhrElp1k8YM8T+dZ/u7dSne7sMj9G9Uyt179QqJ7oHAAAAAMgDMh2uza6uOdEPAAAAAABuW4xcAwAAAADgpDv2UVwAAAAAAGQXRq4BAAAAAHASI9cAAABOCg6eKKvVmtvdMERERISCgsbldjcM4e7urpCQKbndDQC3icyPXLuYc6IfAAAAty2r1arQ0Bm53Q1kszvlQwQA2SPzw9CEawAAAAAAHGQhXHPNNQAAAAAA18rCDc0YuQYAAAAA4FqZH7m2uOVANwAAAAAAuH1l4YZmTAsHAAAAAOBajFwDAAAAAOAkRq4BAAAAAHASj+ICAAAAAMBJmR+5dmVaOAAAAAAA1+I51zdx6kyYXgmdr+iYWHl5FlTw2CdVsXxphzY//vSb5i7+RFcSEmSSSU3uq63hg/vKxcVF58Ii1HvQs6pUvoy9/dSJo1S6ZDGjTwUAAAAAkEMyP3J9h93QbPpb7+mBTq3UuV1zfbtzr0Jen6/33p7i0Mbby1NTJoxQqRIBsiYmauTzr+mrb75T53bNJUkeBQtq6bypudF9AAAAAIABMj8M7eKSP/7dgsioaB3585jat7lfktSqaQOdj4jUqTNhDu3urlxepUoESJLc3dx0V8VyOnc+ItMvLQAAAADg9pSFu4Xnjxuapd5Cm/CISBXx95PFfPWcTSaTihUtrPMRF1WmVPF097kYGaWt3+3VzFfG2tddSbBq8DMTZUtJUfPG9TXw4e4ym++s6fUAAAAAkJ9l4TnXrjnQDeOtXLdZq9Zvti/36hqo3t0CnTpmXFy8gl5+Xf37dFa1KhUlSYX9/bRu+Wz5+/kqOuayJk6doxWrNqj/g12cqgUAAAAAyDsyP3Jtzh8j1727tbxpmA4o6q8LkVFKttlkMZuVmpqq8xEXVaxo4TRt4+KvaPSLoWrWuJ4e7tXJvt7NzVX+br6SJF8fL3Vp31ybtu4hXAMAAABAPsJzrm/A389Xd1cur41bdqlzu+ba+t0+BRTxTzMlPP5Kgsa8OEON6t+jQf0ecNgWGRUtHy9PWSwWJSYmaduuH1WlUjkDzwIAAAAAkNMI1zcxfuRghby+QB98vE6eHgX14tihkqSpby5Us0Z11axxPX26ZqMO/35MCQlWbd+1T5LUutl9Gtivu3459IcWLl0lFxcX2Ww21atdXQMf7p6bpwQAAAAAyGZZeBRX/rjm+laVK1NSC2dNSrN+wpgh9q8H9uuugf3SD8wtmzZQy6YNcqp7AAAAAIA8IPMj1ybucg0AAAAAwLUI1wAAAAAAOCnT4TrVJfN5HAAAAACA/CwLI9emHOgGAAAAAAC3r8yPXJsZuQYAAAAA4Fpccw0AAAAAgJOy8JxrRq4BAAAAALhW5qeFM3INAAAAAIADpoUDAAAAAOCkLEwLN+dAN4D8ITh4oqxWa253wykREREKChqX291wmru7u0JCpuR2NwAAAHCHuGOnhfNAMeQEq9Wq0NAZud0NSPniAwIAAADcPjI/cs2juAAAAAAAcJA/hqEBAAAAAMhFPIoLAAAAAAAncc01AAAAAABO4lFcN3HqTJheCZ2v6JhYeXkWVPDYJ1WxfOk07dZ9vU0ffrJeqampqndvdQU9M1AWi+Wm2wAAAAAAt7/MJ2UXc/74d4umv/WeHujUSp++N1P9H+yqkNfnp2lzNixcCz9YqXdfn6jPlryuyKhofb5h6023AQAAAADyh0yH61STS774dysio6J15M9jat/mfklSq6YNdD4iUqfOhDm0+3bnXjVtVFeF/f1kMpnUo3Mbbd6256bbAAAAAAD5Q+avuc7EqG9etnLdZq1av9m+3KtroHp3C3RoEx4RqSL+frKYr56zyWRSsaKFdT7iosqUKm5vdz78oooXK2JfLlGsqM6HX7zpNgAAAABA/pD5cJ2aE90wXu9uacM0AAAAAABZkelwnZJf0vUtCCjqrwuRUUq22WQxm5WamqrzERdVrGhhh3bFAgrrzNlw+/K58xEqFlD4ptsAAAAAAPlDpq+5tqXmj3+3wt/PV3dXLq+NW3ZJkrZ+t08BRfwdpoRLUqumDfXd9wd0MTJKqampWvPlFrVt0eim2wAAAAAA+UMWpoXfOSPXkjR+5GCFvL5AH3y8Tp4eBfXi2KGSpKlvLlSzRnXVrHE9lSoRoCce7aUnn31FklTnnmrq0bm1JN1wGwAAAAAgf8h0uL7VUd/8olyZklo4a1Ka9RPGDHFY7t6plbp3apXuMW60DQAAAABw+8vCNdc50Q0AAAAAAG5fWRi5Jl0DAADkF8HBE2W1WnO7G3lSRESEgoLG5XY38ix3d3eFhEzJ7W4AecYd+yguAAAASFarVaGhM3K7G7gN8cED4CjTdwsHAAAAAACOMj8tnIuuAQAAAABwkPkbmuVELwAAAAAAuI0xcg0AAAAAgJMyf0OznOgFAAAAAAC3sSyMXOdENwAAAAAAuH1l4Zprxq4BAAAAALgWz7kGgFwQHDxRVqvVkFoRERGGPYvU3d1dISFTDKkFAACQlzAtHABygdVqVWjojNzuRrYzKsQDAADkNUwLBwAAAADASTyKCwAAAAAAJzEtHAAAAAAAJ2V+Wjh3NLNLSUnRm/M+1J59P0uS+vbooD7d26VpZ01M1EtT39Hxk2fk7uamQn4+CnpmoMqUKi5JGh4UorDzF+XlWVCS1DGwmR7u2dG4EwEAAAAAOCXT4TophaHrf329ZZeOnzyjTxbP1OW4eA18+kXVu7e6KpYvnaZt906t1LjBvTKZTPps7SZNm7VIc0OD7dtHPfWIWjSpb2T3AQAAAADZxCW3O3A727Lje3Xv2Epms4t8fbzUpkUjbd62J007dzc3NWlYWyaTSZJUs1plnTt/wejuAgAAAABySOZHrm35Y1r4ynWbtWr9Zvtyr66B6t0tMFPHCAu/qOIBRezLJYoV0aEjf990v08/36jmjes6rJu7+BMt+GClKpQtpWGD+6pUiYBM9QUAAAAAkHsyf0OzfHLNde9uNw/TQ0ZP0qkzYelu++CdV7NU9/0Va3X67Hm9/doL9nUvBw1TsYDCSk1N1cp1m/XcSzO1YmH+e/4tAAAAAORXd+zI9a1YOGvSDbcXDyissPALqlX9LknSufMXVDygcIbtP/rsS23f9aNmv/a8ChRwt68v9v99TCaT+nRvpzkLVyg6Jla+Pt7OnwQAAAAAIMdl+prrlNTUfPEvO7Rudp/WfrVVNluKomMua8v279WmRaN0265YtUGbt+3RW9Oel7eXp319ss2myEvR9uWtO/fKv5APwRoAAAAAbiNZmBaeE924PXVo01SH/zimBwePlclk0kM9O6pyhTKSpJ179mvn9wc0YcwQhUdc1OwFy1WqRIBGjLs6ndzV1VWLZ09WUlKSxk6cqcSkJLmYXOTr66UZk57NzdMCAAAAAGRSFqaF8yiuf5nNLgoaMTDdbc0a11OzxvUkSQFFC2vPxmXptitYoICWzJmSU10EAAAAABgg0+E6u6ZUAwAAAACQX2R+5DqFcA0AAAAAwLUyP3JNuAYAAAAAwAEj1wAAAEAeExw8UVarNbe7cUMREREKChqX293IkLu7u0JCuLcRjJOFu4UTrgEAAICcZLVaFRo6I7e7cVvLy8Ef+RPTwgEAAAAAcBLTwgEAAAAAcBLTwgEAAAAAcFLmwzUj1wAAAAAAOCBcA8jTsnq31KzcwZS7igIAACCrMh2uE5NTcqIfAJAuI++Wyl1FAQAAkFWMXOOOktPPjMzp5z0ysoqsMPJZqUY+85SfBwAAkJcQrnFHud2fGcnIKrLidn/fZ4SfBwAAkJcwLRwAAAAAACcxcu2ElJQUvTnvQ+3Z97MkqW+PDurTvV26bXsMGC03V4vc3dwkSQP6dlPblo0kSafOhOmV0PmKjomVl2dBBY99UhXLlzbmJAAAAAAATst0uLYycm339ZZdOn7yjD5ZPFOX4+I18OkXVe/e6hkG4ykTnlGVSuXSrJ/+1nt6oFMrdW7XXN/u3KuQ1+frvbe5jhDA7cmoa7y5vht3quz+GcuJnyV+ZgDciRi5dsKWHd+re8dWMptd5OvjpTYtGmnztj16cmCfWz5GZFS0jvx5TLOmjZcktWraQK+/84FOnQlTmVLFc6rrAJBj8uM13lzfjbzkdvgZ42cGwJ2IcO2EsPCLKh5QxL5colgRHTryd4btXwl9V6mpqap+dyUNH9xXhfx8FB4RqSL+frKYzZIkk8mkYkUL63zERcI1AAAAANwmMn9DM1v+mBa+ct1mrVq/2b7cq2ugencLdGgzZPQknToTlu7+H7zzaqbqzZsZrOIBRZScnKz576/UlJnz9UZIUOY7DgAAAADIc+7YkevePdKG6estnDXphtuLBxRWWPgF1ap+lyTp3PkLKh5QOIO2V0e4LRaL+vZor76PXw3WAUX9dSEySsk2myxms1JTU3U+4qKKFU3/OAAAAACAvCcLj+Ky5UQ/bkutm92ntV9tVetm9+lyXLy2bP9eoa88l6bdlYQEJSfb5O3lKUnavG2P/cZm/n6+urtyeW3cskud2zXX1u/2KaCIP1PCAQAAAOA2cseOXGeHDm2a6vAfx/Tg4LEymUx6qGdHVa5QRpK0c89+7fz+gCaMGaLISzF6YcpbSklJUWpqqkoVD9BLQU/ZjzN+5GCFvL5AH3y8Tp4eBfXi2KG5dUoAAAAAgCwgXDvBbHZR0IiB6W5r1riemjWuJ0kqVSJAS+dmfI12uTIlbzoFHQAAAACQd2U6XCcTrgEAAAAAcMDINQAAAIA8LTh4oqxWa6b2iYiIyNIz193d3RUSMiXT+wFZuKFZ/ngUFwAAAIDbg9VqVWjoDENqZSWQAxIj1wAAAMAtycroaVZlddQ1KxipBbJH5q+5ZuQaAJBHGPWHrlF/5PIHLpC3GTl6aiRGaoHskelwncLINQAgj8hvf+jyBy7ymqx+gJWVD6T4cAnA7S7z4drGyDUAAMCdgOtcAeDWMXINAAAA5BPcVRvIPZkO16kMXAMAAAB5ErMNgNyT+buFMy0cuGXZfbOl7L6pEp84A7fOiJunceM0AABuX1kYuWZaOHCr8vrNlvjEGbh1Rv4853SQP336dI7+/BPeAQB3IkauAQDIY/L6B3M3wwd3AIA7ESPXAAAAuKPwiDEAOYFwDQAAgDsKN/0CkBN4FBcAAHewnLi+m5svAgDuRJkfuU4lXP8rJSVFb877UHv2/SxJ6tujg/p0b5emXXRMrJ4ZP82+nGBN1Nlz4fryk7ny9fHS8KAQhZ2/KC/PgpKkjoHN9HDPjsacBADgjnY73KgtqzdgI5QDAIxkSky0Ziot131xc071xVAHXg10+hgbNu/Uhm926q2pz+tyXLwGPv2iXp8SpIrlS99wv48++1IHfz2qma+MlSQNDwpR3x4d1KJJfaf7dCd5xq2KYbV63OVvWC2vAE/Dahmp7nM9Da2XarMZVqvhnqqG1bK4uRhWK+TReobV+icq3rBaR8/GGlZLkvw8XA2rVdTH3bBaZheTcbVMxtUaWsq498c38cUMq1WlcEHDakmSl5vZsFr9lx00rJbVmmxYLZOB73s3A79fFQO8DKtVo5SPYbUk6cn6pQyth7wn03+lpaak5ot/2WHLju/VvWMrmc0u8vXxUpsWjbR5256b7rd+43Z17dAiW/oAAAAAAMh9PIrLCWHhF1U8oIh9uUSxIjp05O8b7vPLb38o9nKc7r+vjsP6uYs/0YIPVqpC2VIaNrivSpUIyJE+AwAAAACy3x17t/CV6zZr1fr/prj36hqo3t0cp4oPGT1Jp86Epbv/B++8mqW66zduV8e2TWUx/zf95uWgYSoWUFipqalauW6znntpplYsvH2fbwoAAAAAd5o7Nlz37pY2TF9v4axJN9xePKCwwsIvqFb1uyRJ585fUPGAwhm2j7+SoG93/KDFs19xWF/s//uYTCb16d5OcxauUHRMrHx9vG/hTAAAAAAAuY1p4U5o3ew+rf1qq1o3u0+X4+K1Zfv3Cn3luQzbf7P9e1WuWFbly5a0r0u22RQTc1n+hXwlSVt37pV/IR+CNQAAAADcRu7Ykevs0KFNUx3+45geHDxWJpNJD/XsqMoVykiSdu7Zr53fH9CEMUPs7dd/vV3dO7Z0OEZSUpLGTpypxKQkuZhc5OvrpRmTnjXyNAAAAAAATsr8yHWycY8gyOvMZhcFjRiY7rZmjeupWWPHx9gsnPVymnYFCxTQkjk8gxMAAAAAbmdZGLk27tmxAAAAAADcDjIdrlOSEnOiHwAAAAAA3LYYuQYAAACAfOJcWIT2/PiLenZpk9tdueMQrgEAAADgNpFss8liNme4/dz5CH3+5RbCdS7I/LTwZKaFAwAAAEBmNW7fX5tWzZe3l6ckqUOfp7Tk7SkqUbyoegwYrY5tmmrfwUO6GBmtrh1aaFC/ByRJw4NCVLlCWR3545jc3dw0a9p4PTdxpqJjLstqTVTlimX1wpjHVbBAAU2fvURh4Rc0YNgEFQsorNDJY3XqTJhmvfuhLkXFKDEpWd07tlKf7u1y8ZXInzIdroGMBAdPlNVqze1uAAAAAIZbuW6zVq3fbF/u1TVQvbsFZuoYl+PitXDWJEVFx6r3wGfVuV1zBRTxlySdPH1O82YGy2KxKDU1VZOfHy5fH2+lpqYq9O339dnaTRrQt5vGjxykWe8u09J5UyVJNluKXpr2jl4eN0zly5ZUQoJVT4yepBpVK6n63ZWy7wVAVh7Fxcg10me1WhUaOsOwes+89blhtQAAAIAb6d0t82H6eu1aNZEk+fl6q2SJAJ0Li7CH6w5t7pfFcjW+paam6uPVX2vX3p9ks9kUF3dFtarfle4xT54+p2MnTuulaXPs6+LjE3T85BnCdTbjmmsAAAAAMIDZxUUpKSn25cTEJIftbm6uDm1ttv+yV8GCBexfb9q6Wz/+dFjzQl+Up6eHPv18o/b/dDjdmqmpqfLx9rKPZCPnZDpcn105Kif6AQAAAAD5WqmSxfTb0b/VpGFtbftun64kZO2SytjL8fLz9ZKnp4fi4q/oy807VLxoEUmSp0dBXY67Ym9btkwJeXoU1Bcbt6tL+xaSpFNnwuTj7SVfHy/nTwp2XHMNAAAAAAYY/VR/vTF3qeZ/8JmaNKyd5XDbsW1T7di9X30ff05+vj6qXfNuhZ2/KEmqVLGsKpQrpUeGPq+SJYoqdPJYzXxlrGa9u0wfr/laKbYU+fp6a/Lzw7Pz1CDCNQAAAAAYonGDe/XZktfty08+1sf+9ZqlsxzaLpkzxf713NBgh21enh56e/oL6dawmM16fcpzDutKlyymma+MzWq3cYtccrsDAAAAAADc7gjXAAAAAAA4iXANAAAAAICTCNcAAAAAADiJcA0AAAAAgJMI1wAAAAAAOIlwDQAAAACAkwjXAAAAAAA4yZLbHQCyqsdd/obVWvNnpGG1vI5HGVbLSA1LVTK2YNlahpWqcDHMsFqnT0QZVuvAaeNqnbgYb1it8JgEw2pJUkSs2bBa4bFWw2q5mY37fN7sYjKsVor5uGG1ipUsY1wtT1fDakmSJe6CYbUunIs1rFZCXJJhtSxuxv3uKOBh3Pvjil9Bw2q5ujCOCGPxjgMAAAAAwEmEawAAAAAAnES4BgAAAADASYRrAAAAAACcRLgGAAAAAMBJhGsAAAAAAJxEuAYAAAAAwEmEawAAAAAAnES4BgAAAADASZbc7gCk4OCJslqtud0Np0VEROR2FwAAAAAgVxCu8wCr1arQ0Bm53Q2nBQWNy+0uAAAAAHnSy6/NVfGAwho2uK993diJoap7T3W9v2KtNq9eIEnqMWC03Fwtcndzs7d7adwwVa5QRj0GjNb0l8eoSqVyDseeMnO+9h44pEJ+PrpyJUH+hXz1QKfW6ti26U37tffAIb23bLUuREbJ28tTnp4F9UT/nqpdq2q69YYHhahvjw5q0aT+f3V9vWVNTFL1uytq/MjB+u6Hg/rosy+1ZM4Uh1orVn+lAz8fVujksTc8z/Qc+PmwxgSHqlzpEvZ1C2ZNUgF3t3TbS9L6jdv18eqvdOLkWY0Y0k8P9exg35aQYNXUNxfq8O/H5OLioqcGPajWzRre9PW6EcI1AAAAAOSwsU8/pseGT1CL++ur+t2VtO7rbYqLu6KWTRvo/RVrHdpOmfBMmgB9M4/07mwPj3/8fUITp76tqOgYPdyrU4b77D1wSK+EztPU4FG6p0YVSdKpM2H689jJTNdNTEzSiPFTtXLdZvXt0UEz57yvv46fcgjLX2zcricf65Pl8yxXuoSWzpt6y+2rVi6vV198Rh98vD7Nto9WbpCrq6tWvv+GzoaF64mRk1Tv3mry9fG+5eNfj2uuAQAAACCH+Xh7atzIwQqZuUCnzoRp4dJVmhj0lFxMpmyvVaVSOY1+6lF9+OkXSk1NzbDde8tWa1C/B+zBWpLKlCqepRFcNzdX3Vvjbp0LvyBXV4vat75fX2zcbt/+29G/FRUdqyb31c70sbPqrkrlVL5sKbm4pH2Nt2z/Xj06t5EklSweoDr3VNX2XT86VY+Ra+RpN7oevaPBfQEAAAAysnLdZq1av9m+3KtroHp3C3Ro07jBvdqxe78GP/OShj/eV6VKBOhcWNr7Fk2c+rbDdOmbTX9OT42qlXUpKkaXomPk7+ebbpujf/2jMcMHZOq4GbkcF68DvxzRsMEPSpK6dmipkeOnacQTD8liseiLjdvVqW0zWcxm+z6ZPc8z58L12NMvyuzios7tmqtX18AM297M+YiLKh5Q2L5conhRhYVfzPLxJMI18rgbXY/+7YZGBvcGAAAASF/vbmnDdHoe6dNZm7btto+apicr08Kvd6MR61tlUvqj6teu/2jll/pi03adOh2mJg1rq9691SVJlSuUUfFiRfTd9wfVqMG92rLjey2cNcnhOJk5z7srl9faj2bLy9ND4REX9ezEmfL18VbbFnknEzAtHAAAAAAMYnZxkYsp52PYkT+OqZCfT4aj1tLVa5IPHfkzw+1+vt6Kjol1WBcdfVmF/Hzsy4/07qxl707TJ++F6uifx7Tmiy32bV07tNAXm3Zo23d7VbFcaZUrUzLL5+Pp6SEvTw9JUkDRwgps2Vg/H/o9y8crVrSww0j1ubAIh5HsrCBcAwAAAEA+8texk5r17jI9+mCXG7Yb9EgPvb98rQ4d+cu+7vTZ8/p2515J0n31a2n919uVbLNJkg78ckQxsZdVuWLaO3oXDyiiZ4cP0HvL1yjBmihJateysX769aiWr/pKXTu0dOqcLly8pJSUFElSXPwV7frhoKpULp/l47Vu3lBrvrz6QcDZsHAd/OWomjep71QfmRYOAAAAAHnI9dcij3qyv+rVvjrdevSE6bJY/rtuedH/p1p/tPJLbdi8QwnWRBXy89GAvl3VKbDZDevcV6+WXhw7VG8vXK6LkVFyd3dTIT8fDXm0lyTpsYe6651FKzTw6WC5mEzy9Cio114erYIFCqR7vGaN6+nj1V9r9fpv1K93J3l6eqh5k3ravvtHtW6e9iZpNzrP6239bp/WfLFFZrNZNptNrZs3VJd2zW94fl9u2qH5H3ym2Nh47di9X8tXfanQyWN1d+XyeqRPZ736+kL1HvisXFxc9OzTA+Tnm/U7hUuSKTHR6vxkfDglKGhcvnnOdXafx42O+W0N466vWPNnpGG1vCz5c0LJtN2zjC1YtpZhpXquDTOs1ukTUYbV6tGyomG1TlyMN6xWeEyCYbUkycPNfPNG2cTXI3M3u3GGm9m431XmdO7ymlNmlj5uWK3fSt74j8LsVMU//T+Ec4ol7oJhtRq/dciwWglxSYbVshj4u6OAh6thtapVdm7abWY0rmRcLUkaXLfEzRshX8uff8UDAAAAAGAgpoUDAAAAQD61e+9PenfJp2nWD+jbTW1b5p07bUtSZFS0Rr8wPc36BnVr6pkh/dLdZ91XW7Vy3eY0658dPkC1a1XN9j7eCOEaAAAAAPKpJg1rq0nD2rndjVvi7+erpfOmZmqfbh1bqVvHVjnUo8xhWjgAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJG5ohtuWV4CncbWORxlW63JyimG1jGRyM/YZq6kuxj0fNNHA71lyknG1riTaDKt1OcG4Z8fGxiUaVkuSriQa9160GvhedLfkz8/nUwrFGlargIGvoTnFuJ8xSTLZjKuXaDXud1VyknG1XAsY97vDyGdqB3i7G1arUEHjnt8NSIxcAwAAAADgNMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATuJRXMg27u7uCgoal63HjIiIyNbjAQAAAEBOIFwj24SETMn2Y2Z3WAcAAACAnMC0cAAAAAAAnMTINQAAAAAYYNGHq/Ro365yd3PTrh8OauHSVTp24rR6dG6jMcMetbdLSUnRm/M+1J59P0uS+vbooD7d293w2NbERL009R0dP3lG7m5uKuTno6BnBqpMqeI5ek74DyPXAAAAAGCAxcvWKDExSZJUplRxvfjsED3Su3Oadl9v2aXjJ8/ok8UztXj2K1q+8ksd++f0TY/fvVMrfbI4VB++O1XNGtfVtFmLsv0ckDHCNQAAAADksOlvvSdJemrsFA0YNkFeXh66q1I5mc1pI9mWHd+re8dWMptd5OvjpTYtGmnztj2KuHhJnfoOV0KC1d72pWnvaPX6b+Tu5qYmDWvLZDJJkmpWq6xz5y9Ikr7duVejXnjNvo/NlqIej47S8RNncvKU7ziEawAAAADIYeNHDZYkvfv6RC2dN1X+fr4Ztg0Lv6jiAUXsyyWKFVFY+EUVLVxIDerU1Nff7pIkRV6K1o8Hf1OHtk3THOPTzzeqeeO6kqQWTerr5JkwnTh1VpK08/v9KlWymCqUK5Vt5wfCNQAAAAA4beW6zXp4yDj7v5XrNudInQcfaK9V676RJK39aqsCWzWSR8ECDm3eX7FWp8+e17BBfSVJZrOLenVpq1Xrr+63at036t0tMEf6dyfjhmYAAAAA4KTe3QKzLbAWDyissPALqlX9LknSufMXVDygsCSpRtVKKlDATft/Oqy1G7Zq9mvPO+z70WdfavuuHzX7tedVoIC7fX23jq3Ub+g4dWzbVKfPnVezRvWypa/4DyPXAAAAAGAAD48Cuhx35abtWje7T2u/2iqbLUXRMZe1Zfv3atOikX37gw+01yuh76p82ZIqW7qEff2KVRu0edsevTXteXl7eToc08fbU80a1dPzk2fpgU6t073WG85h5BoAAAAADNCvVyeNeuE1FXB304C+3TR74UeKi78ipUpbv9uroBED1axxPXVo01SH/zimBwePlclk0kM9O6pyhTL247Rq1lChby9Rr2tGysMjLmr2guUqVSJAI8a9KklydXXV4tmT7W26d2qlDZt3qnvHVsad9B2EcA0AAAAABni8f0893r+nfblty0bptjObXRQ0YmCGx/nz7xPy8/XR/Q1r29cFFC2sPRuX3bD+/p8Oq13rJvLz9c5Uv3FrCNcAAAAAcJuY+uZC7d1/SC+MeUIuLrc+tbvfkPEymUx689WgHOzdnY1wDQAAAAC3iQljhmRpv+ULp2dzT3A9rmIHAAAAAMBJhGsAAAAAAJxEuAYAAAAAwEmEawAAAAAAnES4BgAAAADASYRrAAAAAACcxKO4kKe5u7srKGhcutv6GNwXAAAAAMgI4Rp5WkjIlAy37W3VxsCeAAAAAEDGmBYOAAAAAICTCNcAAAAAADiJcA0AAAAAgJOydM11cPBEWa3W7O7LHSsiIiK3uwAAAAAAcEKWwrXValVo6Izs7ssdK6O7YQMAAAAAbg9MCwcAAAAAwEmEawAAAAAAnES4BgAAAADASYRrAAAAAACclKUbmgEAAAAAbt3Lr81V8YDCGja4r33d2ImhqntPdb2/Yq02r14gSeoxYLTcXC1yd3Ozt3tp3DBVrlBGPQaM1vSXx6hKpXIOx54yc772HjikQn4+unIlQf6FfPVAp9bq2LbpTfu198AhvbdstS5ERsnby1OengX1RP+eql2rarr1hgeFqG+PDmrRpP5/dX29ZU1MUvW7K2r8yMH67oeD+uizL7VkzhSHWitWf6UDPx9W6OSxNzzP9CQnJ2v2guX68eBvMpvNSrYlq1uHlnq4VyedC4vQgOEv2l/Da/1z8ozeXrhcJ06dkySVK1NSzwzpp/JlS0qSFn24SqvWf6OihQspMSlZlSuU0biRg+Xj7anhQSEKO39RXp4F/zv/xx9So/r3pNtHwjUAAAAA5LCxTz+mx4ZPUIv766v63ZW07uttiou7opZNG+j9FWsd2k6Z8EyaAH0zj/TurId6dpAk/fH3CU2c+raiomP0cK9OGe6z98AhvRI6T1ODR+meGlUkSafOhOnPYyczXTcxMUkjxk/VynWb1bdHB82c877+On7KISx/sXG7nnysT5bO85M1G3Xh4iUtfXeqLGazrImJOnM2/Ib7RFy8pOHPvapRT/VX+9ZNJEmbtu7W0+Ne1dK5r6qwv58kqV2rJhoz7FHZbCl68dXZen/55xr55COSpFFPPaIWTerfUh+ZFg4AAAAAOczH21PjRg5WyMwFOnUmTAuXrtLEoKfkYjJle60qlcpp9FOP6sNPv1BqamqG7d5btlqD+j1gD9aSVKZUcbVu1jDTNd3cXHVvjbt1LvyCXF0tat/6fn2xcbt9+29H/1ZUdKya3Fc708eWpPALkSrk5yOL2SxJcndzU8XypW+4z+r136jOPVXtwVq6GqRr17xbq9Z/k6a92eyiBnVq6MTpc1nqIyPXAAAAAOCkles2a9X6zfblXl0D1btboEObxg3u1Y7d+zX4mZc0/PG+KlUiQOfCItIca+LUtx2mSy+YNUkF3N3StLuRGlUr61JUjC5Fx8jfzzfdNkf/+kdjhg/I1HEzcjkuXgd+OaJhgx+UJHXt0FIjx0/TiCceksVi0Rcbt6tT22b2cCxl7jy7d2ylMS/O0P6fj+jeGlVUv04NtW52n8zmjMeLf//rHzWoWzPN+prV79KPBw+lWZ9gTdSO3ftVs9pd9nVvvfuRFn+42r48deIolS5ZLN16hGsAAAAAcFLvbmnDdHoe6dNZm7btVo/ObTJsk5Vp4de70Yj1rTIp/VH1a9d/tPJLfbFpu06dDlOThrVV797qkqTKFcqoeLEi+u77g2rU4F5t2fG9Fs6a5HCczJxnxfKltfL9N/Tzb7/r18N/atGHq/T1lu/0+pSgrJ3cNTZt3a2Dvx6VJNWpVVWP9u1q35aZaeGEawAAAAAwiNnFRS6mnL8698gfx1TIzyfDUWtJqlq5vA4d+VN3Vy6f7nY/X29Fx8Q6rIuOvqxCfj725X+vuQ4Lv6BhY6dozRdb1LNrW0lS1w4t9MWmHUqwWlWxXGmVK1PSqXNydbWofu0aql+7hrp1aKkuD49QdMzlDNvfXbm8Dh3+U+rZ0WH9ocN/qso15/zvNdfO4pprAAAAAMhH/jp2UrPeXaZHH+xyw3aDHumh95ev1aEjf9nXnT57Xt/u3CtJuq9+La3/eruSbTZJ0oFfjigm9rIqV0x7R+/iAUX07PABem/5GiVYEyVJ7Vo21k+/HtXyVV+pa4eWTp3TwV+P6sLFS/blo38el4+3l7y9PDLcp0eXNjrwyxFt/Ha3fd2mrbt18Jej6tWlrVP9SQ8j1wAAAACQh1x/LfKoJ/urXu2r061HT5gui+W/65YX/X+q9Ucrv9SGzTuUYE1UIT8fDejbVZ0Cm92wzn31aunFsUP19sLluhgZJXd3NxXy89GQR3tJkh57qLveWbRCA58OlovJJE+Pgnrt5dEqWKBAusdr1riePl79tVav/0b9eneSp6eHmjepp+27f1Tr5mlvknaj87ze+fALmvXuh0pMTJKrxaKCBQtoxqQxcnG5Ol4cF39F3R55xt6+WNHCWjhrkt6Z8aLeXrhcCz74TCaTSWVLl9DcmS+qSOFCN3xt/nX9NdeP9Oms9q3vT7etKTHRmunJ+EFB4xQaOiOzuyEDvJ5Zs7dVxtepZLc1P5wxrNbl5BTDahlpzk9pnzuYk1JLVjWsVpfPThlW6+w/UYbV6tKigmG1jkVkPKUru52/dMWwWpJkcTXfvFE28Spg3Gfm7pb8Ofltafk/Dat1vFrXmzfKJhW8sv9uxDficvmCYbXqvn7YsFqJV5IMq1XQO3M3r3KGp0/6QSkn3F8j/RtB5YT65W4tPGWXHtWKGFoPeU/+/J8RAAAAAAADMS0cAAAAAPKp3Xt/0rtLPk2zfkDfbmrbslEu9ChjkVHRGv3C9DTrG9StqWeG9MuFHmUO4RoAAAAA8qkmDWurScPaud2NW+Lv56ul86bmdjeyjGnhAAAAAAA4iXANAAAAAICTCNcAAAAAADiJcA0AAAAAgJO4oRluW3Wf62lYrYalKhlWy+Rm3LMmjTSi9lBD670237g7SraqNsiwWg/0qmVYLSOfi5tidjWsVlSCzbBakmRxMe51dOUjc6eZksoaVispIdWwWhFWY98cCS7GPe93xuD6htVyMRn7vPD8qIDFuPeiu4G1AImRawAAAAAAnEa4BgAAAADASYRrAAAAAACcRLgGAAAAAMBJhGsAAAAAAJxEuAYAAAAAwEmEawAAAAAAnES4BgAAAADASYRrAAAAAACcRLgGAAAAAMBJhGsAAAAAyCU79+zXrHeXZXn/4UEh2r77x2zsEbLKktsdAAAAAIA7VbPG9dSscb3c7gayAeEaAAAAAHLY+8vX6kJklJ4b8ZgkKf5Kgh7oP0oDHuqqX3/7U9MnjdHGb3fp49Vfa/4bL8nV1aKgl99QzaqVNbBfd/1z8oxmvbtMFyKjJEk9u7RVzy5tHGqs+2qrVqz+Sq4Wi2wpKZow5gnVqFrZ6FO9YxGu4bTg4ImyWq2G153WspzhNQEAAID0rFy3WavWb7Yv9+oaqN7dAu3LHds21aAREzVyaD+5ubnq2x0/qN691VXI18fepn3r+3Xw16OavWC5ihcrLJvNpsce7qZkm03jJr2pJx7tqXatmkiSoqJj0/Rh9oLl+njRDBUpXEjJyclKTErOwTPG9QjXcJrValVo6AzD6yZ/+Y7hNQEAAID09O7mGKavVyygsKpULqed3x9Qm+b36cvNO/VI786KjnEMyWOGPaonRk7Sd9/H6f13QmQymXTy1DklJibZg7Uk+fl6p6lRv04NTZ7xrpo2qqPGDe5V2dIlsu8EcVPc0AwAAAAADNClXQt9uWmHzpwL1+mz59WowT1p2lyKilHs5TilpKYo9nJcpo4/beIoDX+8r5KTbXo2OFSbt+3Jrq7jFhCuAQAAAMAAzZvU05E/jmnpx+vUofX9spjNDtuTbTZNnPqOhjzWSyOHPqLgqW8rMTFJZcuUkLu7mzZt3W1ve/208GSbTafPnle1KhX1SJ/Oat2soQ7//rch54WrmBYOAAAAAAZwc3NV6+b3afX6b7RiYdrLKucu/kTlShdX58DmkqSDvx7VrHeXadzIQZoxaYzemLtUH3y8Ti4mF/Xs2kY9Ov93Q7MUW4qmvrFQMbFxMptd5Ofro+CxQww7NxCuAQAAAMAwQSMGKmjEQPty53bN1bnd1TA9cmi/NG3/Va5MSb017fk0x5sbGmz/et7rE7O3s8gUpoUDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE6y5HYHILm7uysoaFxudyPLIiIicqVuqs1mXLGytQwrlepiNqyWkV6b38/Qes8/udywWi1/etqwWimphpVSqotx/0XYjDwxgyUbem4mwyrZUvPn9yzRxduwWucvxxtWK9aaf8dTini4GVYrKSXFsFo240opxcCf5yQDfycmJCQbVguQCNd5QkjIlNzuglNu5w8GAAAAACA75N+PMQEAAAAAMAjhGgAAAAAAJxGuAQAAAABwEuEaAAAAAAAnEa4BAAAAAHAS4RoAAAAAACcRrgEAAAAAcBLhGgAAAAAAJxGuAQAAAMAAA4ZNUFz8ldzuBnKIJbc7AAAAAAB3gqXzpuZ2F5CDCNcAAAAAYIDG7ftr06r58vby1D8nz2jWu8t0ITJKktSzS1v17NJGS5Z/ro3f7pab69WoNn3SsypRrIhefm2uTp4+p6TkZBUr6q8JY4aosL9f7p0M0iBcw2nu7u4KChpneN2pzUobXhMAAABIz8p1m7Vq/Wb7cq+ugerdLTDdtsk2m8ZNelNPPNpT7Vo1kSRFRccqJjZOy1du0PoVc1TA3U0JCVaZXEySpNFP9VchPx9J0tJP1mnRh6s1ftTgHD4rZAbhGk4LCZmSK3WT1s3OlboAAADA9Xp3yzhMX+/kqXNKTEyyB2tJ8vP1ls2WojKlimny9HlqWK+m7m9YWwFFC0uSNm3dra+37FJiYpKsiYny8/XOkfNA1hGuAQAAACAPMJtdtHDWZP16+A8d+OWInhg9Sa88/7RMJpM+W7tJC2a9LH8/X+3cs18Ll67K7e7iOtwtHAAAAAAMVLZMCbm7u2nT1t32dVHRsYqLv6LIqGjVrlVVgx/poXtr3K0//j6hmMtx8ihYQL7e3kpKStbnG77Nxd4jI4xcAwAAAICBLGazZkwaozfmLtUHH6+Ti8lFPbu20f0Na2tCyGxdSbDKZDKpTMni6hTYTAXc3bRxyy71ffw5+fp4q0GdGoq4cCm3TwPXIVwDAAAAgAH2bFxm/7pcmZJ6a9rzadosemtyuvuGvPiMw/JTgx7M3s7BaUwLBwAAAADASYRrAAAAAACcRLgGAAAAAMBJhGsAAAAAAJxEuAYAAAAAwEmEawAAAAAAnES4BgAAAADASYRrAAAAAACcZMntDgBZ1XBPVcNqVbgYZlitxOQUw2oZqVW1QYbWa/nT04bV2lb7fsNqlWtVzrBayY+3MaxWwsVow2rF/XHKsFqS5O7nbVgtFx8Pw2qlJCYbVstI8xqMMqzW043KGFbrRHSiYbUkKcHA/8vq/PS+YbVkcTOslIuXn2G1zN7G1VLxioaVsvmWNKwWIDFyDQAAAACA0wjXAAAAAAA4iXANAAAAAICTCNcAAAAAADiJcA0AAAAAgJMI1wAAAAAAOIlwDQAAAACAkwjXAAAAAAA4iXANAAAAAICTCNcAAAAAYIABwyYoLv5KpvebMOUtfblpRw70CNnJktsdAAAAAIA7wdJ5Uw2rlWyzyWI2G1YPhGsAAAAAMETj9v21adV8eXt5qseA0erYpqn2HTyki5HR6tqhhQb1e0CS9M/Js3r1jYWKi4tXmVLFlWC12o8xZeZ8mUwmnTh1TtExsapZrbLGjRysAu5u9m1nzp5XZFSMPlkcqmWffaENm3bK5GJS5QplFfTMQHl5euTSK5C/Ea7vEMHBE2W95ocyX7C0ze0eAAAAAJKkles2a9X6zfblXl0D1btb4A33uRwXr4WzJikqOla9Bz6rzu2aK6CIv14JnacHOrdRtw4t9dfxUxr8zES1a9XEvt/ho39r4VuTVMDdXeMnv6mPV3+lgQ93lyT9/uc/eveNifL0KKg9+37WFxt3aOGsl+Xt5anXZi3W3MWfaNzIQTnzItzhCNd3CKvVqtDQGbndjWxV54VNud0FAAAAQJLUu9vNw/T1/g3Mfr7eKlkiQOfCIuRZsID++PukOgc2lyRVrlBG99So4rBfmxb3ydOjoCSpa4cW+uzzTfZw3bp5Q/u2fQcOqW2L++Tt5SlJ6tGljV4MmZ31k8QNcUMzAAAAAMgFbm6u9q/NLi6y2WzptjPJdOMDXbO5YIECGTcz3eQ4cArhGgAAAADyCE9PD1WpVE5ffbNTknTsn9P65bc/HNp8u3Ov4q8kyGZL0Zcbd6hBnZrpHqtB3ZrasuMHxcXFS5I+//Jb3VevVs6ewB2MaeEAAAAAkIe8FPSUXn1jgVas+kqlSxVT7Vp3O2yvVqWiRk+Yrqjoqzc069ujQ7rHadzgXv39zykNGT3Z4YZmyBmEawAAAAAwwJ6Ny+xfr1k6y2HbkjlT7F+XL1tSC2dNyvA4lSuUVfDYoWnWT3zuyTTr+vfpov59umS+s8g0poUDAAAAAOAkRq4BAAAA4DaR3ug08gZGrgEAAAAAcBLhGgAAAAAAJxGuAQAAAABwEuEaAAAAAAAnEa4BAAAAAHAS4RoAAAAAACfxKC7ctixuxn02dPpElGG1kpNSDKtlpAd61TK0XkqqcbXKtSpnWK0Ptp4wrFaXo58ZVuvvy4mG1TqbkGRYLUlyczEZVsvVZFwtI8/LSBvG9TCs1rNNjfvd4elmNqyWJCWlGPd/WdzJ04bVSklMNqxWwYBChtWy+PkbVsvN08ewWi6uBQ2rJUlyN7ge8hxGrgEAAAAAcBLhGgAAAAAAJxGuAQAAAABwEuEaAAAAAAAnEa4BAAAAAHAS4RoAAAAAACcRrgEAAAAAcBLhGgAAAAAAJxGuAQAAAABwEuEaAAAAAAAnEa4BAAAAAHCSJbc7AAAAAAB3gsbt+2vgw921a+9PSkiw6vH+PdS+9f2SpJdfm6uTp88pKTlZxYr6a8KYISrs76eZcz5QkcJ+Gvhwd0nSiVNnNfL517Rq6ZtSaqoWfLBSP/50WMnJySpTqrjGj3pcPt6emjJzvlwtFp05F64z58JV995q6tG5jd5ZvELnwy+qeZN6GvVkf0nSkuWfa+O3u+XmejUeTp/0rEoUK5I7L9JtLE+F6+DgibJarbndjXwpIiIix2sY/v3zaGdcLQAAAOAGVq7brFXrN9uXe3UNVO9ugWkbmqSlc1/VmXPhGjRiou6pXkUlihfV6Kf6q5CfjyRp6SfrtOjD1Ro/arD6dA/U6Bdn6NEHu8psdtHqL75R906tZDGb9f6KtSpQwF3vvf2KJOm9j9Zo/gefKWjEQEnS3/+c0pwZE+RictHDQ8Yp9nKcZk97XknJyer12LPq2r6lihQupOUrN2j9ijkq4O6mhASrTC6mHH+98qM8Fa6tVqtCQ2fkdjfypaCgcTlew+jvX4OXvzGsFgAAAHAjvbtlEKav061DK0lSqRIBqlOrqg7+elQlihfVpq279fWWXUpMTJI1MVF+vt6SpHJlSqpC2VLauWe/7qtfS5u3fq9l86dJknbs3q+4+Hht+26fJCkpOVklihW112rWuK7c3dwkSZUqlNF99e6RxWKRxWJRhbKldOpsmMqVKakypYpp8vR5alivpu5vWFsBRQtn62tzp8hT4RoAAAAA7iQmk0k/H/pdn63dpAWzXpa/n6927tmvhUtX2ds8+EB7Lfv0C12KjlGDujXlX8j3/1tS9ezwx3RfvVrpHtvN1c3+tdnFRe5urvZlFxcX2WwpMptdtHDWZP16+A8d+OWInhg9Sa88/7Rq16qaI+ebn3FDMwAAAAAwyJebtkuSzoVF6KdDv6t2zbsVczlOHgULyNfbW0lJyfp8w7cO+9xXr5YuXorS+8vXOoyON29cXx+v/koJCVcvzUxIsOrYP6cz1Z+4+CuKjIpW7VpVNfiRHrq3xt364+8TTp7lnYmRawAAAAAwiC0lRQOGv6iEBKueHf6oShQvqqJFCmnjll3q+/hz8vXxVoM6NRRx4ZJ9H5PJpK7tW2rT1t2qVf0u+/r+fbsocVmSHh/1skymq9dJP/pgF1UsX/qW+xMXF68JIbN1JcEqk8mkMiWLq1Ngs+w74TsI4RoAAAAADNKvVyc9+Vgfh3UWi0UhLz7jsO6pQQ86LO//+bD69ujguJ/ZrKGP9dbQx3qnqTPxuScdlqdOHOWw/Pb0F+xfL3pr8q2fADLEtHAAAAAAyKOO/HFMvQc+KxcXk9q1apLb3cENMHINAAAAAAbYs3FZpvepVqWiVr7/Rg70BtmNkWsAAAAAAJxEuAYAAAAAwEmEawAAAAAAnES4BgAAAADASYRrAAAAAACcRLgGAAAAAMBJPIoLt62QR+sZVuvA6SjDal1JtBlWy0gVvEyG1kt1Me7XW/LjbQyr1eXoZ4bV+uJcrGG1CpqNe38UcTP2vz4DT0221PxZy0jHfzxgWK3PfrvbsFpnoxMMqyVJ5wys99ZjLxhWS7ZEw0qlunsbVutKqtmwWifikg2rdT7WuO+XJDUpZGg55EGMXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAORxjdv3V+zluBu2GR4Uou27fzSoR7ge4RoAAAAAACdZcrsDAAAAAJDffb7hWx3947ieH/24jp84o35Dx2vW1PG6r14tLV62RpIUF39FP/16RMnJNnl6FNTzox9XuTIl0xzrn5NnNOvdZboQGSVJ6tmlrXp2aWPk6SAdhOs7hLu7u4KCxuVojYiIiBw9PgAAAHC7alCnpj78ZL0kae+BX1Wz2l3ad/CQ7qtXS/sO/Krhjz+kMqWKa+TQfpKkzdv26M15H2rW1PEOx0m22TRu0pt64tGeateqiSQpKjrW2JNBugjXd4iQkCk5XuP68B4cPFFWqzXH6rV98oUcOzYAAACQGSvXbdaq9Zvty726Bqp3t0D7cqkSAZKkM+fCte/gbxo2+EG9vWC54q8k6PjJs6petZK2bP9BK9dtUnx8glJSUxQTm/Ya65OnzikxMckerCXJz9c7B88Mt4pwjRxjtVoVGjojx46/8a9LOXZsAAAAIDN6d3MM0+lpUKem9uz7WafOhKnuPdWUmpqqrd/tVc1qlXXh4iW9/s4Heu/tV1S6ZDH9deykhj0XYlDvkR24oRkAAAAAGKB+nRr6aOWXqn53JUlSvdrVtejD1WpQp6Yux12RxWJWEX8/paamauW6zekeo2yZEnJ3d9Omrbvt65gWnjcQrgEAAADAAA3q1ND58ItqUKeGJKlh3VoKO39B9evUUOUKZRTYspH6DX1eg595ScUCCqd7DIvZrBmTxujLTTv0yJPP69GnJmjrd3uNPA1kgGnhAAAAAGAAXx9v7f76Q/vyffVqac/GZfblMcMGaMywAfblQf0esH99bbtyZUrqrWnPpzn+3NDgbO4xMoORawAAAAAAnES4BgAAAADASYRrAAAAAACcRLgGAAAAAMBJhGsAAAAAAJxEuAYAAAAAwEmEawAAAAAAnES4BgAAAADASZbc7gCQVf9ExRtW68RF42pdTkgyrJaRUsyuhtazpaQaVivhYrRhtf6+nGhYrYJmk2G1rtiM+36dtyYbVis/M/DtYSg3D1/DalX09zCslrvFbFgtSSroZlw9S8RfhtVKTTbw/2hPP8NKeRQsZFitAA9/w2pZXPLpLyrkWYxcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkS253AAAAAADwn4iLl/Tq6wt07nyEXF1dVaZkcY0bOUiF/Hwy3OfAz4c1691lWjpvqoE9xbUYuQYAAACAPMTs4qJB/R7QJ4tnatm701SyRFHNWbQit7uFm2DkGgAAAAAM0Lh9fz35WB/t/P6AIqOiNfqp/vrn5Flt+26fLsfF64XRj6vuvdXlX8hX/oV87fvVqFpZK9dtkiQlWBMVMnO+/v7nlCxmi/wL+eitac/n1inhGoRrZBt3d3cFBY2zL0dERORibwAAAIC8p2BBdy2ePVn7Dh7S+ElvauzTj2nJnCnasuMHzVm0Qu+9PcWhvc2WopXrNqlZ43qSpO9//FmX4+K1YuEMSVJ0zGXDzwHpI1wj24SEOP4iuDZo34rg4ImyWq233L5y31GZOj4AAACQU1au26xV6zfbl3t1DVTvboFp2rVt0UiSVK1KRV1JsKpty6vL1e+upFNnzju0TU1NVeicJfL28lTfB9pLku6qWE7/nDyr0LeXqE6tamrc8N6cOiVkEuEaeYbValVo6Ixbbj//xzM52BsAAADg1vXuln6Yvp6bm6skycXl6u2v3N3cJElmF5NsNptD2zfmLlV4RKSmvzzG3r5UiQAtXzhd+3/6TfsO/qZ3Fq/QB3O5iVlewA3NAAAAACCPeWPuUp0+e16vvTRarq7/jYmGR1yUySQ1a1xPzwzpp9TUq+uQ+xi5BgAAAIA85Off/tBnazepXJmSemLUy5KkEsWLavrLY/T3P6c1771PlJoq2Ww2dWhzvypXLKsDPx/O5V6DcA0AAAAABtizcZn9a4+CBRyWA4oW1rdrF0uS7q1RxWHbtRo3uFeNG6S9zrruvdV5xnUuY1o4AAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkS253AMiqo2djDasVHpNgWK3YuETDahkpKsGW213IMXF/nDKs1tmEJMNqFXEz7r+I89Zkw2olpqQaVis/M5tyuwc5w1LQy7BaRT3dDKt1OdHY38HWZFfDaiWf+8ewWqk2415HSxHj/h4wJxv3f4tnAW/DaiUa+P8YIDFyDQAAAACA0wjXAAAAAAA4iXANAAAAAICTCNcAAAAAADiJcA0AAAAAgJMI1wAAAAAAOIlwDQAAAACAkwjXAAAAAAA4iXANAAAAAICTCNcAAAAAkMcMGjFRB34+nOX9d/1wUAOfDlbzLgP15rwPs7FnyIgltzsAAAAAAMheZUoV14vPDtG3O/cq/kpCbnfnjkC4BgAAAACD7Ni9X3Pf+0SuFosa1b9H6zdu05K3pyji4iXNnPO+bLYUVatSQTabzb7P8KAQVSpfRr8d/UsxsXFq3rienhnaTyaTSeEXIjVr3oc6cfqcTCaTmjWuqycf66OypUtIkrbv/jG3TvWOQ7hGjnF3d1dQ0Lhbbh8REZGDvQEAAAByV2RUtF59Y6Hmv/GSypctqS82bld0zGUlJSdr4tQ5enHsUDWsW1M/7P9VX27e6bDv8ZNntODNl5WcbNOw50K0aesetW/dRJOnz1PDerU0deIoSdKlqJjcODWIcI0cFBIyJVPt0wviwcETZbVa09+h2eCsdAsAAADIdivXbdaq9Zvty726Bqp3t0CHNr8d+UuVK5RR+bIlJUmdAptpxttLlJiYJLPZrIZ1a0qS7qtXS6VKBDjs27FtU1ksFlksFrVvfb/2HTykZo3r6uff/tCsqePt7Qr5+eTUKeImCNfI06xWq0JDZ6S7bcy6owb3BgAAAEhf725pw3ROMplMhtXCreFu4QAAAABggBrVKuuv46d04tRZSdLXW3YpKSlZbm6ustls2v/T1buD7z1wSGfOhTvsu3HLbiUnJyvBmqhNW3erQZ0a8ihYQLVr3a3lqzbY2zEtPPcwcg0AAAAABvD389ULYx7X+Mmz5OZqUYO6NeVRsIAK+floyoQRV29olpKialUq6q6KZR32LV+2pIaOeUUxsZfVvHE9BbZsLEl6edwwvfHOUvUbMl4Wi1nNGtfTkAG9tO/gIU2ZOV9x8VekVGnrd3sVNGKgmjWulxunfkcgXAMAAACAQRrUqamW9zeQdPVO3rt++EneXp66p0YVLZ03NcP96tWurmeHD0izvmjhQpr20qh066z76O3s6zhuinANAAAAAAb5bO0mbdn+g1JSUuThUVCTxw/L7S4hmxCuAQAAAMAgAx/uroEPd8/UPnNDg3OoN8hO3NAMAAAAAAAnEa4BAAAAAHAS4RoAAAAAACcRrgEAAAAAcBLhGgAAAAAAJxGuAQAAAABwEuEaAAAAAAAn8Zxr3Lb8PFwNqxURazas1pVE42oZyeJiMrReckqqYbXc/bwNq+Vm4OtoNvZbhtuMzbgfMUO5eXgaVsvX3bjf96W8CxhWS5LczcaN36QcjzGsllJshpWyxRr3PTO7GPdeNCXEGlbLx7OIYbUAiZFrAAAAAACcRrgGAAAAAMBJhGsAAAAAAJxEuAYAAAAAwEmEawAAAAAAnES4BgAAAADASYRrAAAAAACcRLgGAAAAAMBJhGsAAAAAAJxEuAYAAACAPGbQiIk68PPh3O4GMsGS2x0A/uXu7q6goHEO6yIiInKpNwAAAABw6wjXyDNCQqakWXd92AYAAABuZzt279fc9z6Rq8WiRvXv0fqN27Tk7SmKuHhJM+e8L5stRdWqVJDNZrPvMzwoRJXKl9FvR/9STGycmjeup2eG9pPJZMrFM8H1CNfI84KDJ8pqtaZZ79X+yVzoDQAAAJDWynWbtWr9Zvtyr66B6t0t0KFNZFS0Xn1joea/8ZLKly2pLzZuV3TMZSUlJ2vi1Dl6cexQNaxbUz/s/1Vfbt7psO/xk2e04M2XlZxs07DnQrRp6x61b93EkHPDrSFcI8+zWq0KDZ2RZv3kb/7Ohd4AAAAAafXuljZMX++3I3+pcoUyKl+2pCSpU2AzzXh7iRITk2Q2m9Wwbk1J0n31aqlUiQCHfTu2bSqLxSKLxaL2re/XvoOHCNd5DDc0AwAAAIDbDFPC8x7CNQAAAAAYoEa1yvrr+CmdOHVWkvT1ll1KSkqWm5urbDab9v909e7gew8c0plz4Q77btyyW8nJyUqwJmrT1t1qUKeG4f3HjTEtHAAAAAAM4O/nqxfGPK7xk2fJzdWiBnVryqNgARXy89GUCSOu3tAsJUXVqlTUXRXLOuxbvmxJDR3zimJiL6t543oKbNk4l84CGSFcAwAAAIBBGtSpqZb3N5Akbd/9o3b98JO8vTx1T40qWjpvaob71atdXc8OH2BUN5EFhGsAAAAAMMhnazdpy/YflJKSIg+Pgpo8flhudwnZhHANAAAAAAYZ+HB3DXy4e6b2mRsanEO9QXbihmYAAAAAADiJcA0AAAAAgJMI1wAAAAAAOIlwDQAAAACAkwjXAAAAAAA4iXANAAAAAICTeBQXbltFfdwNqxUeazWsljU5xbBaRnI1/KM8k2GVXHw8DKvlajLuvGyphpUC8ozkxCTDalmTjfshs9pshtWSpPgk4+q5ePoYVstIZm8/44p5GFcr1c24/zMTDP6bytXCuOWdjncAAAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXCNPc3d3V0RERG53AwAAAMgVzwaH6sSps5Kk4UEh2r77R0lSdMxlDR0zWQOGTdD7y9dm6diN2/dX7OW4bOvrnc6S2x0AbiQkZIqCgsbldjcAAACAXPFGSFC66/cdOCSPggW04M2XDe4RMkK4BgAAAACD/Hr4T81ZtELx8QlKVaqGDuitN9/9UK2bNdT+nw7rcly8HujcWv37dJEk9RgwWtNfHqMqlcrZj7H3wCHNWbRCl+PiNWDYBI0Y0k81qlbS7Pkf6c9jJ5WYlKSaVStr7NOPydXVoiXLP9fGb3fLzfVq/Js+6VmVKFYkV84/PyNc47YTHDxRVqtVFfqMzO2uAAAAAJKkles2a9X6zfblXl0D1btboEOb6JjLGj/5TU0NHqnataoqJSVFsZfjJUmRl2K0ZM4URcdc1sCng3VP9Sq6p0aVdGs1rFtTQwb00o7d+zV90hhJ0muzFuvemnfrhTFPKDU1VdNmLdInn3+tbh1aafnKDVq/Yo4KuLspIcEqk4sph16FOxvhGrcdq9Wq0NAZmrv3dG53BQAAAJAk9e6WNkxf79CRP1WudAnVrlVVkuTi4iJfHy9JUtcOLWQymeTn660W99fXvoO/ZRiu07Nj9379euRPfbz6K0mSNTFRLi4u8vQoqDKlimny9HlqWK+m7m9YWwFFC2fxLHEjhGsAAAAAyGNMmRxcTlWqpk0cpbKlS6TZtnDWZP16+A8d+OWInhg9Sa88/7Q94CP7ZClcu7u758hNprgrNAAAAID8qlb1Kjp1Nkw//Xo0zbTwDZt2qO491RQdc1k7dv+oyc8/naljN29cTx9++oXGjxosi9msmNg4RcfEyr+Qr+KvJKh2raqqXauqjp84oz/+PkG4zgFZCtchIVOyux+SxF2hAQAAAORbPt6eeu2lMZq94CPFX0mQi8mkIY/1liT5+flo4NPBuhwXr17dAjM1JVySRj3VX3MXf6LHhr0ok4tJZrOLnn78Ybm7uWpCyGxdSbDKZDKpTMni6hTYLCdO747HtHAAAAAAMEjNapXTPD7rjblL1a5VE4144uE07dcsnWX/em5osP3rzu2aq3O75vZlj4IF9NyIx9Ktueityemu37NxWWa6jptwye0OAAAAAABwu2PkGgAAAABy0bWj07h9MXINAAAAAICTCNcAAAAAADiJcA0AAAAAgJMI1wAAAAAAOIlwDQAAAACAkwjXAAAAAAA4iUdx4bZldjEZVsvNbNznUO4WPvPKDrbUVMNqpSQmG1bLzcD3vc24l1Bm407L0FqSsa8jkFcY+X+0XAz8fzMlxbhaLmbjahnJxN85yL94dwMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE7iUVzI89zd3RUUNM6+HBERkYu9AQAAAIC0CNfI80JCpjgsXxu0AQAAACAvYFo4AAAAAABOIlwDAAAAQB71bHCoTpw6a2jNHgNG64+/TxhaMz9gWjgAAAAA5FFvhATldhdwiwjXAAAAAGCQXw//qTmLVig+PkGpStXQAb315rsfqnWzhtr/02FdjovXA51bq3+fLpKujiJPf3mMqlQqpxWrNmjztj1KTrbJYjFrzLABqlX9rjTtJGnQiIl6ZsjDqntvdYVfiNSseR/qxOlzMplMata4rp58rI/WfbVVK1Z/JVeLRbaUFE0Y84RqVK2ca6/N7Y5wjdtScPBElXngqdzuBgAAACBJWrlus1at32xf7tU1UL27BTq0iY65rPGT39TU4JGqXauqUlJSFHs5XpIUeSlGS+ZMUXTMZQ18Olj3VK+ie2pUcdi/Q5umerhXJ0nSoSN/acrM+fpkcehN+zZ5+jw1rFdLUyeOkiRdioqRJM1esFwfL5qhIoULKTk5WYlJyVl/AUC4xu3JarXmdhcAAAAAu97d0obp6x068qfKlS6h2rWqSpJcXFzk6+MlSeraoYVMJpP8fL3V4v762nfwtzTh+o+/T+j9FWsVE3NZZrOLTp4+pwRrogq4u2VYM/5Kgn7+7Q/Nmjrevq6Qn48kqX6dGpo84101bVRHjRvcq7KlS2Tp3HEVNzQDAAAAgDzGZHJcTkpK1guvzNIzQx7WRwte07yZwf9fnyRJMru4KCUlxd4+MTHppjWmTRyl4Y/3VXKyTc8Gh2rztj3ZdwJ3IMI1AAAAABigVvUqOnU2TD/9elSSlJKSouiYy5KkDZt2SLo6dXzH7h9Vv3YNh30TExOVlJys4gFFJEmfrd3ssL10yWL67ehfkqTfjv6tE6fPSZI8ChZQ7Vp3a/mqDfa2l6JilGyz6fTZ86pWpaIe6dNZrZs11OHf/86Bs75zMC0cAAAAAAzg4+2p114ao9kLPlL8lQS5mEwa8lhvSZKfn48GPh2sy3Hx6tUtMM2UcE9PDz35WB89PvIl+fp4q23LRg7bnxzYR1NC5+vzL7eqZrXKqliulH3by+OG6Y13lqrfkPGyWMxq1rieHnuom6a+sVAxsXEym13k5+uj4LFDcv5FyMcI1wAAAABgkJrVKmvBmy87rHtj7lK1a9VEI554OE37NUtn2b/u/2AX9X+wy3/Lff77ulqVilq+cHq6NYsWLqRpL41Ks37e6xPTbX9tTdw6poUDAAAAAOAkRq4BAAAAIBcxUpw/MHINAAAAAICTCNcAAAAAADiJcA0AAAAAgJMI1wAAAAAAOIlwDQAAAACAkwjXAAAAAAA4iUdx4bbj7u6u06dP626TybCaZhfjagEAck9qis2wWilKNayWLcWwUv+vZ9y5ycVsXK38ysC/qYysZfT7HmDkGredkJApKlq0aG53AwAAAADsCNcAAAAAADiJcA0AAAAAgJMI1wAAAAAAOIlwDQAAAACAkwjXAAAAAAA4iXANAAAAAICTCNcAAAAAADiJcA0AAAAAgJMI1wAAAACQzwwYNkFx8Vdyuxt3FEtudwAAAAAAkL2Wzpua21244xCuAQAAAMAAjdv318CHu2vX3p+UkGDV4/17qH3r+yVJvx7+U3MWrVB8fIJSlaqhA3qreZN6OnUmTLPe/VCXomKUmJSs7h1bqU/3djc9XuP2/bVp1Xx5e3nm2vneaQjXAAAAAGAUk7R07qs6cy5cg0ZM1D3Vq8jDo6DGT35TU4NHqnatqkpJSVHs5XjZbCl6ado7enncMJUvW1IJCVY9MXqSalStpOp3V8rweCWKF83dc7xDEa5xW3J3d8/tLgAAAAB2K9dt1qr1m+3LvboGqne3wDTtunVoJUkqVSJAdWpV1cFfj8rXx0vlSpdQ7VpVJUkuLi7y9fHS8RNndOzEab00bY59//j4BB0/ecYertM7HuE6dxCucVsKCZmiRfvP5nY3AAAAAElS727ph+mbMZlMGW5LTU2Vj7dXpq6fvtHxkLO4WzgAAAAAGOTLTdslSefCIvTTod9Vu+bdqlW9ik6dDdNPvx6VJKWkpCg65rLKlikhT4+C+mLjdvv+p86EKTrm8g2Ph9zByDUAAAAAGMSWkqIBw19UQoJVzw5/1D6F+7WXxmj2go8UfyVBLiaThjzWW80a1dXMV8Zq1rvL9PGar5ViS5Gvr7cmPz/8pseD8QjXAAAAAGCQfr066cnH+qRZX7NaZS148+U060uXLKaZr4zN9PH2bFzmXEeRaUwLBwAAAADASYxcAwAAAIABsns0mdHpvIWRawAAAAAAnES4BgAAAADASYRrAAAAAACcRLgGAAAAAMBJhGsAAAAAAJxEuAYAAAAAwEk8igu3raGlYg2rlWI+blytQsadl5FMSWUNrZfo4m1YrXkNRhlWa8O4HobVOv7jAcNquXn4GlbLUtDLsFqS5ObhaVit5MQkw2oZKTXFZlitjksmGFYr8Ypxj9Axn71sWC1JKpJo3PfM8sEMw2rJ7GpYqZSoCMNqJZ/+27BacX8Y976POxVuWC1J8gtZaGg95D2MXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAABOIlwDAAAAAOAkwjUAAAAAAE4iXAMAAAAA4CTCNQAAAAAATiJcAwAAAADgJMI1AAAAAOSiZ4NDdeLUWcPqbd/9ow4d+cuwencKwjUAAAAA5KI3QoJUrkxJQ2ol22zasXs/4ToHWHK7A/9r777Doyj3No7fm01PCB0CoUuvgSAiSgSVLngQFCu+IiDFAiiI9BKRLr13FVABUQQFFGmKiqCCFOnSIZR00vf9I2ZNINSdnQ3h+7mucx12Znd+z8SUvfdpAAAAAHCv2L33oKbMWaK4uHjZZFPn9m314YyPNGpwT12JT9DoSfP0ycyR9ud36x2mZ1s3U7kyJdS+W3+1bNpAv+7crdSUVPXo+pLq1Kqq5JQUvTNwrCKjYpSQkKiyZUrovZ6vysfbWzv/3KuxUxaqSqWy+vvgUbV7qqm2bNupX3f+pTXrN6ttq0Zq1ayhC78iOQfhGgAAAABMEBkVo3eHfqgRA95UcLWKSk1NVXRMnP18jSrllZSUrH0HjqhS+TI6dea8jp88o3oPBCs8/JJiYuNUqkRRvdn5ef2175D6DB6vzxeMk6+Pt4b27abcAblks9k0ZvICff7lOrVv10qSdOzEab3zxv+pf69OkqSdf+5TuTIl9exTTV3ydcipCNdXGTBgoBISElzdDNyCcW+/6uomAAAAAJKkZV+t1/JV6+2P27RspLatGmV6zl/7DqpksSIKrlZRkuTm5qbcAf6ZntOicai+XrdZlcqX0Zr1W9S44UNyt1olSVarVS0ahUqSqlYqqwL58+jA4X9Uo0p5LV3xrX789Q+lpKQoNvaKqlUuZ79m0cCCqlW9klPuG/8hXF8lISFBY8aMdnUzcCvO/u3qFgAAAACSpLatrg3Td6J5o/pq37Wf3uj0vL75bqvGDnv7hs+3SFr3w0/67Y+9mj6mv/z8fPXZyrXa8cde+3N8fbwdbhdujgXNAAAAAMAE1SqX14nTZ/XH7v2SpNTUVEVGxWR6TsH8eVWpfBlNnPGx8uYJUJlSxeznUlJS9O33WyVJe/Yf1oWLESp3X0lFx8QpT25/+fn5Kjbuilav33zDdvj5+ig2Lu6Gz8Hto+caAAAAAEwQkMtPIwf11KRZnyjuSrzcLBZ1erntNc9r0ThUA96frN5vvJLpuL+frw4fO6mXuvRTSkqKhvTtJj9fHzV7/GFt/mmH2r36jvLkDlBw1Qo6e+7iddvR9LGHFDZ2ljb9tENtWz7OgmYGIVwDAAAAgEmqViqrWR8OznSsft1amR4/FvqAHgt9IMvXv9n5+WuO+fv5avKo97J8fq0albVo+ohMxypXuE+LZ4+6nWbjFjAsHAAAAAAABxGuAQAAACCbKxJYUOtXzHJ1M3ADhGsAAAAAABxEuAYAAAAAwEGEawAAAAAAHES4BgAAAADAQYRrAAAAAAAcRLgGAAAAAMBB7q5uAHCnvosrbFqtwkWLm1bL2z1nfuaVFG8ztd65mDjTanWva973R6+HS5pW6/M9FUyrVSafr2m1Cvp5mlZLknJ7WU2rlZBs7s+ZWVJl3n0lXvnYtFpTl+41rZanm8W0WpLkYzWvXnK7XubVik82rVbM5XjTal1KTDGt1uHYJNNqRSaZd1+SNCHM1HLIhnLmu3gAAAAAAExEuAYAAAAAwEGEawAAAAAAHES4BgAAAADAQYRrAAAAAAAcRLgGAAAAAMBBhGsAAAAAABxEuAYAAAAAwEGEawAAAAAAHES4BgAAAAAXafp0F505G35Hrx0/bZFat++hB5u8qAOH/8l07sSps+rUY6ie6fCOOrwxUEeOnTSiubgBwjUAAAAA3IUa1q+jmeMGKrBwgWvOjZo4T/9r3lCfzRurF59pqbBxM13QwnuLu6sbAAAAAAD3ii3bdmjq3E/l7m5V3drV7cd37TmgsVMWKCU1VZXKl9HfB4+pZ9cXVatGZc1fvFJrN/wkT4+0+DZqSC8VKVxANatVzLLGpYhI7Tt4RBM+eFeS1PDh+zVu6kKdOHVWxYMCnX+T9yjCNQAAAACY4FJEpMLGzdaMcQNVumSQVq7ZoMioGCUlJ2vgiCka1LuLQoIra8cfe7V63WZJUlR0rBYvW6NVS6bI28tT8fEJsrhZbljnfPglFciXR+5WqyTJYrGocMH8Ohd+kXDtRIRrOM2AAQOVkJDgtOs369rPadcGAAAAbseyr9Zr+ar19sdtWjZS21aNMj1nz75DKlu6uEqXDJIktWzSQOOnLVJiYpKsVqtCgitLkkKCKyuoSCFJkp+vj4oHFdbQUdNVJ6SqHqoTrEIF85t0V7gdhGs4TUJCgsaMGe206284EuG0awMAAAC3o22ra8P0zVhu0AFt+fek1eqm2ROGavfeA9q5a5869hiiYX27K/g6Q8IlqVDBfLpwKULJKSlyt1pls9l0LvyiChPKnYoFzQAAAADABFUrldOhoyd07PhpSdLXazcpKSlZHh7uSk5J1s5d+yRJO3ft08nT5yRJsXFXdCkiUsHVKqrDC61Vo0qFa1YGv1q+PLlVoWwprf3+R0nSD1u3q1CBfAwJdzJ6rgEAAADABHnzBKh/r07qO2yCPNzdVbd2deUO8Jenh4eGv/e6xk5ZqFRbqiqWK60SxYrI399PsbFx6hc2SVfiE2SxWFS8aKCaN6ovSRo5ca5++vUPXboUqR79RsnXx1vLFoyXJL37ZgeFjZulhUu/kp+vj/q/3dmVt35PIFwDAAAAgElC64UotF6I/XH3js9KkgIC/PXRjBGSpL1/H9YvO3apRFCgvL29NGfi0Cyv1fetV69bp2Txopo9YYhxDcdNEa4BAAAAwMU2bt2upSu+lU02Wa1uGtS7q7y9vVzdLNwGwjUAAAAAuFiLxqFq0TjU1c2AA1jQDAAAAAAABxGuAQAAAABwEOEaAAAAAAAHEa4BAAAAAHAQ4RoAAAAAAAcRrgEAAAAAcBBbceGuVT6/j2m1Cvt5mFbLmppkWi0zhSeY+1letIn1/olMNK2Wn6fVtFqnI+NNq+Xlbt59xSSmmFZLkoJyeZtWKyHF3HszS0qqebWsp2NMq+XpZjGtVmKqzbRaZtcrWLmAabVSksz7ZvS/EGdardwXrphWSyejTCt16op5P2OARM81AAAAAAAOI1wDAAAAAOAgwjUAAAAAAA4iXAMAAAAA4CDCNQAAAAAADiJcAwAAAADgILbiygEGDBiohIQEVzfjGuHh4a5uAgAAAACYgnCdAyQkJGjMmNGubsY1evfu4+omAAAAAIApGBYOAAAAAICD6LkGAAAAABdp+nQXzZ88XEUCC97W6xISEzVoxFQdPX5KXp6eypsnQL3f+D8VDwqUJF2KiNSw0TN06sx5eXp46J03/k81q1V0xi3gX/RcAwAAAMBd6MnmDfXp3DH6aMYI1X+wlj6YMMd+btrcT1W1Ull9Pn+c+r/dSYNHTlVycrILW5vz0XMNAAAAACbZsm2Hps79VO7uVtWtXd1+fNeeAxo7ZYFSUlNVqXwZ/X3wmHp2fVG1alTW/MUrtXbDT/L0SItvo4b0UpHCBVSvTrD99VUrldXi5Wvsjzds/kWfzx8nSapc4T4VyJdXO3ftV51aVc250XsQ4RoAAAAATHApIlJh42ZrxriBKl0ySCvXbFBkVIySkpM1cMQUDerdRSHBlbXjj71avW6zJCkqOlaLl63RqiVT5O3lqfj4BFncLNdc+7OVaxX6YC1JUmRUtJJTUpQ/Xx77+SKFC+hc+EVT7vNeRbhGtnI724q9NWC4k1sDAAAA3JplX63X8lXr7Y/btGyktq0aZXrOnn2HVLZ0cZUuGSRJatmkgcZPW6TExCRZrVaFBFeWJIUEV1ZQkUKSJD9fHxUPKqyho6arTkhVPVQnWIUK5s903QVLvtTJ0+c0eeR7zrxF3AThGtnK7WwrdjIy++3tDQAAgHtT21bXhumbsVzbAZ3hXNpJq9VNsycM1e69B7Rz1z517DFEw/p2V/C/i5N98vlqbfrxN00a2Vfe3l6SpNwBuWR1s+ripQh77/WZcxdU+KpQDmOxoBkAAAAAmKBqpXI6dPSEjh0/LUn6eu0mJSUly8PDXckpydq5a58kaeeufTp5+pwkKTbuii5FRCq4WkV1eKG1alSpoAOH/5EkLVm+Rus3btPED/oql79fplqPhtbRF6u/lyTt/fuwwi9eVq3qrBbuTPRcAwAAAIAJ8uYJUP9endR32AR5uLurbu3qyh3gL08PDw1/73WNnbJQqbZUVSxXWiWKFZG/v59iY+PUL2ySrsQnyGKxqHjRQDVvVF/nwy9q0qzFCipSSK/3eV+S5OHhobmThkqSur/6rIaOnq6nX3lbHu7uGtKnq9zdiX/OxFcXAAAAAEwSWi9EofVC7I+7d3xWkhQQ4K+PZoyQlNbT/MuOXSoRFChvby/NmTj0muv4+/lq29qPr1snX97cmvhBX4NbjxvJVuHay8tLvXv3cWkbwsPDXVofAAAAwL1n49btWrriW9lkk9XqpkG9u9rnUOPukK3CdViY61d/dnW4BwAAAHDvadE4VC0ah7q6GXAAC5oBAAAAAOAgwjUAAAAAAA4iXAMAAAAA4CDCNQAAAAAADiJcAwAAAADgIMI1AAAAAAAOIlwDAAAAAOCgbLXPNXIWLy+v2943PDw8/Jaf6+9pvd0m3TH32Aum1bKkJJlWy0zxbgVc3QSniU9ONa1WUqp5tc5ExptWy8fEn+eEZA/TakmSl9W8z7HjklJMq2V1s5hWKyXVZlqtAonmfQ19rOZ9DRNN/Bqaza9IPlc3wSk8vCNMq+Vm4u+pguFxptWKSc653/fIngjXcJqwsOG3/ZrbDeMAAAAAkB0wLBwAAAAAAAcRrgEAAAAAcBDhGgAAAAAABxGuAQAAAABwEOEaAAAAAAAHEa4BAAAAAHAQ4RoAAAAAAAcRrgEAAAAAcJC7qxsAAAAAAPeqpk930fzJw1UksOBtv/at90bq4uVIuVks8vXxVs9u7VWhbClJ0olTZzVszExFRkXL389HA95+TWVKFTO49ciIcA0AAAAAd6Gw/m8ol7+fJGnjj9sVNnaWPpoxQpI0auI8/a95Q7VoHKoNW35V2LiZmjd5uCubm+MRrgEAAADAJFu27dDUuZ/K3d2qurWr24/v2nNAY6csUEpqqiqVL6O/Dx5Tz64vqlaNypq/eKXWbvhJnh5p8W3UkF4qUriAPVhLUmzsFVksaf++FBGpfQePaMIH70qSGj58v8ZNXagTp86qeFCgeTd7jyFcI1vx8vJS7959bum5/YeNcHJrAAAAgFuz7Kv1Wr5qvf1xm5aN1LZVo0zPuRQRqbBxszVj3ECVLhmklWs2KDIqRknJyRo4YooG9e6ikODK2vHHXq1et1mSFBUdq8XL1mjVkiny9vJUfHyCLG4W+zWHjp6hnX/ulSSNC+stSToffkkF8uWRu9UqSbJYLCpcML/OhV8kXDsR4RrZSljYrQ9VibiS7MSWAAAAALeubatrw/TV9uw7pLKli6t0ySBJUssmDTR+2iIlJibJarUqJLiyJCkkuLKCihSSJPn5+qh4UGENHTVddUKq6qE6wSpUML/9moP7dJEkrV6/WdPmLtX4fwM2zMdq4QAAAADgAhbLjc6lnbRa3TR7wlC1a91ElyOi1LHHEP2xe/81z2/RKFQ7/tyryKhoFSqYTxcuRSg5JUWSZLPZdC78ogpnCOUwHuEaAAAAAExQtVI5HTp6QseOn5Ykfb12k5KSkuXh4a7klGTt3LVPkrRz1z6dPH1OkhQbd0WXIiIVXK2iOrzQWjWqVNCBw/8oOiZW4Rcv26+96afflDvAXwG5/JUvT25VKFtKa7//UZL0w9btKlQgH0PCnYxh4QAAAABggrx5AtS/Vyf1HTZBHu7uqlu7unIH+MvTw0PD33tdY6csVKotVRXLlVaJYkXk7++n2Ng49QubpCvxCbJYLCpeNFDNG9VXdEyc+odNUkJiotwsbsqTO5fGDnvH3uP97psdFDZulhYu/Up+vj7q/3ZnF999zke4BgAAAACThNYLUWi9EPvj7h2flSQFBPjbt9Ha+/dh/bJjl0oEBcrb20tzJg695jr+fr6aN3nYdeuULF5UsycMMbbxuCHCNQAAAAC42Mat27V0xbeyySar1U2DeneVt7eXq5uF20C4BgAAAAAXa9E4VC0ah7q6GXAAC5oBAAAAAOAgwjUAAAAAAA4iXAMAAAAA4CDCNQAAAAAADiJcAwAAAADgIMI1AAAAAAAOYisu3LVe/Ph302pdOBNtWq3EhBTTaplpdIfaptYr4OtpWq2afywwrVbs8ZOm1Zr48num1XIPP2RareQzx0yrJUmpR6NMq+XmF2BaLbmZ+Pm8m9W0Uu4LR5tWK7ldL9NqFaxcwLRakuRXJJ9ptUaN22JaLavFtFLysZr3M+Zj4o0V9jIvfgT5EHVgLnquAQAAAABwEOEaAAAAAAAHEa4BAAAAAHAQ4RoAAAAAAAcRrgEAAAAAcBDhGgAAAAAABxGuAQAAAABwEOEaAAAAAAAHEa4BAAAAAHCQu6sbAAAAAAD3qqZPd9H8ycN18XKkPpgwR1arVd06tJO/n2+mx3VrV3d1U3EThGsAAAAAcLE167eoccN6evnZVpKk0ZPmZ3qM7I9wDQAAAAAm2bJth6bO/VTu7lZ7b/T6Tdv03aaf5eXlqe83/azHG9TN9HjqmP7K5e/n4pbjZgjXuGsMGDBQCQkJ/x0o/7TrGgMAAABksOyr9Vq+ar39cZuWjdS2VaNMz7kUEamwcbM1Y9xAlS4ZpJVrNigyKkaNHnlQ/5w4o3JlSurZp5pK0jWPkf0RrnHXSEhI0Jgxo+2Pn5i93YWtAQAAAP7TttW1Yfpqe/YdUtnSxVW6ZJAkqWWTBho/bZEZzYMJWC0cAAAAAFzAYnF1C2AkwjUAAAAAmKBqpXI6dPSEjh0/LUn6eu0mJSUlu7hVMArDwgEAAADABHnzBKh/r07qO2yCPNzdVbd2deUO8Hd1s2AQwjUAAAAAmCS0XohC64XYH3fv+KwkaeA7r2V63tWPkf0xLBwAAAAAAAcRrgEAAAAAcBDhGgAAAAAABxGuAQAAAABwEAuaXcXLy0u9e/dxdTNuS3h4uKubAAAAAAD3NML1VcLChru6CbftbvswAAAAAAByGoaFAwAAAADgIMI1AAAAAAAOYlg4soUBAwYqISHhhs+5em55QkKyM5uUSXxskmm1kpNSTKtlJjeLxdR6Samp5hVz9zStVGqied/3Skk0rZQt2byfMVuKyT9jqTnzZ1pm/oyZyephWqnkePN+nlOScuh/L0lWE/+8pNjMqxWTbN5/s8RU876I3m7m3Ze/e879vkf2RLhGtpCQkKAxY0bf8DnMLQcAAACQXTEsHAAAAAAABxGuAQAAAABwEOEaAAAAAAAHEa4BAAAAAHAQ4RoAAAAAAAcRrgEAAAAAcBDhGgAAAAAABxGuAQAAAABwEOEaAAAAAFyk6dNddOZs+B29dvy0RWrdvocebPKiDhz+x+CW4XYRrgEAAADgLtSwfh3NHDdQgYULuLopkOTu6gYAAAAAwL1iy7Ydmjr3U7m7W1W3dnX78V17DmjslAVKSU1VpfJl9PfBY+rZ9UXVqlFZ8xev1NoNP8nTIy2+jRrSS0UKF1DNahVddRvIAuEadw0vLy/17t3nvwMlW7uuMQAAAEAGy75ar+Wr1tsft2nZSG1bNcr0nEsRkQobN1szxg1U6ZJBWrlmgyKjYpSUnKyBI6ZoUO8uCgmurB1/7NXqdZslSVHRsVq8bI1WLZkiby9PxccnyOJmMfXecGsI17hrhIUNz/S40ZRtLmoJAAAAkFnbVteG6avt2XdIZUsXV+mSQZKklk0aaPy0RUpMTJLValVIcGVJUkhwZQUVKSRJ8vP1UfGgwho6arrqhFTVQ3WCVahgfufeDO4Ic64BAAAAwAUsN+iAtvx70mp10+wJQ9WudRNdjohSxx5D9Mfu/Sa1ELeDcA0AAAAAJqhaqZwOHT2hY8dPS5K+XrtJSUnJ8vBwV3JKsnbu2idJ2rlrn06ePidJio27oksRkQquVlEdXmitGlUqsDJ4NsWwcAAAAAAwQd48Aerfq5P6DpsgD3d31a1dXbkD/OXp4aHh772usVMWKtWWqorlSqtEsSLy9/dTbGyc+oVN0pX4BFksFhUvGqjmjepLkkZOnKuffv1Dly5Fqke/UfL18dayBeNdfJf3LsI1AAAAAJgktF6IQuuF2B937/isJCkgwF8fzRghSdr792H9smOXSgQFytvbS3MmDs3yWn3fetX5DcYtI1wDAAAAgItt3LpdS1d8K5tsslrdNKh3V3l7e7m6WbgNhGsAAAAAcLEWjUPVonGoq5sBB7CgGQAAAAAADiJcAwAAAADgIMI1AAAAAAAOIlwDAAAAAOAgwjUAAAAAAA4iXAMAAAAA4CC24sItGzBgoBISEpxy7fDw8Nt+jcVicUJLsubuaTWtloe3ebVyspRU82q5+ecxrZZPobym1bJ55TKtlvzymFbKvUCiabUkKSXa27Ra1lx5TKslt5z5uyo14vb/Ht2pmMvxptXyvxBnWi1J8vCOMK2Wj9W8vqKYZBP/uJgoMdVmWq2o5BTTavkkmvdeEZAI17gNCQkJGjNmtFOu3bt3H6dcFwAAAADMwLBwAAAAAAAcRLgGAAAAAMBBhGsAAAAAABxEuAYAAAAAwEGEawAAAAAAHES4BgAAAADAQYRrAAAAAAAcRLgGAAAAAMBB7q5uAAAAAADcq5o+3UXzJw9XkcCCt/W6hMREDRoxVUePn5KXp6fy5glQ7zf+T8WDAp3UUtwM4RoAAAAA7kJPNm+oB++vIYvFos+/XKcPJszRtDEDXN2sexbhGgAAAABMsmXbDk2d+6nc3a2qW7u6/fiuPQc0dsoCpaSmqlL5Mvr74DH17PqiatWorPmLV2rthp/k6ZEW30YN6aUihQuoXp1g++urViqrxcvXmH07yIBwDQAAAAAmuBQRqbBxszVj3ECVLhmklWs2KDIqRknJyRo4YooG9e6ikODK2vHHXq1et1mSFBUdq8XL1mjVkiny9vJUfHyCLG6Wa6792cq1Cn2wltm3hAwI18iWBgwYqISEhBs/qdRT5jQGAAAAuIllX63X8lXr7Y/btGyktq0aZXrOnn2HVLZ0cZUuGSRJatmkgcZPW6TExCRZrVaFBFeWJIUEV1ZQkUKSJD9fHxUPKqyho6arTkhVPVQnWIUK5s903QVLvtTJ0+c0eeR7zrxF3AThGtlSQkKCxowZfcPnNJ76s0mtAQAAAG6sbatrw/TNWK7tgM5wLu2k1eqm2ROGavfeA9q5a5869hiiYX27K7haRUnSJ5+v1qYff9OkkX3l7e11x+2H49iKCwAAAABMULVSOR06ekLHjp+WJH29dpOSkpLl4eGu5JRk7dy1T5K0c9c+nTx9TpIUG3dFlyIiFVytojq80Fo1qlTQgcP/SJKWLF+j9Ru3aeIHfZXL3881NwU7eq4BAAAAwAR58wSof69O6jtsgjzc3VW3dnXlDvCXp4eHhr/3usZOWahUW6oqliutEsWKyN/fT7GxceoXNklX4hNksVhUvGigmjeqr/PhFzVp1mIFFSmk1/u8L0ny8PDQ3ElDXXyX9y7CNQAAAACYJLReiELrhdgfd+/4rCQpIMBfH80YIUna+/dh/bJjl0oEBcrb20tzJl4bmP39fLVt7cfmNBq3hHANAAAAAC62cet2LV3xrWyyyWp106DeXZlDfZchXAMAAACAi7VoHKoWjUNd3Qw4gAXNAAAAAABwEOEaAAAAAAAHEa4BAAAAAHAQ4RoAAAAAAAcRrgEAAAAAcBDhGgAAAAAAB7EVF7IFLy8v9e7dx/44PDz8pq/x9LQ6s0mZePt6mFbL3cT7yslSbTbTallz5TGtlnuefKbVumIz73vR1yevabWsyUmm1ZIkq5uJP9O+ecyrZSaLxbRSyScPm1brUmKKabVyX7hiWi1JcrOa13/jYzXv+yMx1cxa5v0dM9OVFPPuKyo51bRagES4RjYRFjY80+OMQRsAAAAAsjuGhQMAAAAA4CDCNQAAAAAADiJcAwAAAADgIMI1AAAAAAAOIlwDAAAAAOAgwjUAAAAAAA4iXAMAAAAA4CDCNQAAAAAADnJ3dQMAAAAA4F7V9Okumj95uIoEFrzt17713khdvBwpN4tFvj7e6tmtvSqULWV8I3FLCNcAAAAAcBcK6/+Gcvn7SZI2/rhdYWNn6aMZI1zcqnsX4RoAAAAATLJl2w5Nnfup3N2tqlu7uv34rj0HNHbKAqWkpqpS+TL6++Ax9ez6omrVqKz5i1dq7Yaf5OmRFt9GDemlIoUL2IO1JMXGXpHFYvrtIAPCNQAAAACY4FJEpMLGzdaMcQNVumSQVq7ZoMioGCUlJ2vgiCka1LuLQoIra8cfe7V63WZJUlR0rBYvW6NVS6bI28tT8fEJsrj9l6KHjp6hnX/ulSSNC+vtkvtCGsJ1DuDl5aXevfs4vU54eLjTa6S7pXsq/7Q5jQEAAABuYtlX67V81Xr74zYtG6ltq0aZnrNn3yGVLV1cpUsGSZJaNmmg8dMWKTExSVarVSHBlSVJIcGVFVSkkCTJz9dHxYMKa+io6aoTUlUP1QlWoYL57dcc3KeLJGn1+s2aNnepxhOwXYZwnQOEhQ03pY4ZAT7drdzTE7O3m9ASAAAA4Obatro2TN/MjYZxW/49abW6afaEodq994B27tqnjj2GaFjf7gquVjHT81s0CtXoSfMVGRWt3AG5brv9cBxbcQEAAACACapWKqdDR0/o2PHTkqSv125SUlKyPDzclZySrJ279kmSdu7ap5Onz0mSYuOu6FJEpIKrVVSHF1qrRpUKOnD4H0XHxCr84mX7tTf99JtyB/grIJe/+TcGSfRcAwAAAIAp8uYJUP9endR32AR5uLurbu3qyh3gL08PDw1/73WNnbJQqbZUVSxXWiWKFZG/v59iY+PUL2ySrsQnyGKxqHjRQDVvVF/RMXHqHzZJCYmJcrO4KU/uXBo77B17jzfMR7gGAAAAAJOE1gtRaL0Q++PuHZ+VJAUE+Nu30dr792H9smOXSgQFytvbS3MmDr3mOv5+vpo3eZg5jcYtIVwDAAAAgItt3LpdS1d8K5tsslrdNKh3V3l7e7m6WbgNhGsAAAAAcLEWjUPVonGoq5sBB7CgGQAAAAAADiJcAwAAAADgIMI1AAAAAAAOIlwDAAAAAOAgwjUAAAAAAA4iXAMAAAAA4CC24sJdq0whf9NqXcnjY1qtQrly5n6G3u7mfpaXlGozr1hgGdNKefoFmFbrn9hk02oV8s1nWi0/71ym1ZIkS3y0abVsnr6m1ZLFxJ9pi8W0UrEHPjat1uHYJNNq6WSUebUkFQyPM61WYS/z3s56u6WaVisqOcW0WldSzPubmWji3+ez8eb9HQMkeq4BAAAAAHAY4RoAAAAAAAcRrgEAAAAAcBDhGgAAAAAABxGuAQAAAABwEOEaAAAAAAAHEa4BAAAAAHAQ4RoAAAAAAAcRrgEAAAAAcJC7qxsAAAAAAPeqpk930fzJw1UksOBtv7Z1+x7y9HCXl6enJKl9u1Z6vEFdo5uIW0S4BgAAAIC71PB+b6j8fSVd3QyIcA0AAAAAptmybYemzv1U7u5W1a1d3X58154DGjtlgVJSU1WpfBn9ffCYenZ9UbVqVNb8xSu1dsNP8vRIi2+jhvRSkcIFXHULuA7CNQAAAACY4FJEpMLGzdaMcQNVumSQVq7ZoMioGCUlJ2vgiCka1LuLQoIra8cfe7V63WZJUlR0rBYvW6NVS6bI28tT8fEJsrhZ7NccNmaGbDabKle4T906tFPePAGuur17HuEaLjVgwEAlJCTc2YsffsXYxgAAAAB3aNlX67V81Xr74zYtG6ltq0aZnrNn3yGVLV1cpUsGSZJaNmmg8dMWKTExSVarVSHBlSVJIcGVFVSkkCTJz9dHxYMKa+io6aoTUlUP1QlWoYL5JUnTxw5QYKECSk5O1swFyzR87EyND+ttxu0iC4RruFRCQoLGjBl9R69988t9BrcGAAAAuDNtW10bpm/GYrnRubSTVqubZk8Yqt17D2jnrn3q2GOIhvXtruBqFRVYKG1ouLu7u9q1bqJ2rxKsXYmtuAAAAADABFUrldOhoyd07PhpSdLXazcpKSlZHh7uSk5J1s5daZ1HO3ft08nT5yRJsXFXdCkiUsHVKqrDC61Vo0oFHTj8j67Exys6JtZ+7fUbt7GwmYvRcw0AAAAAJsibJ0D9e3VS32ET5OHurrq1qyt3gL88PTw0/L3XNXbKQqXaUlWxXGmVKFZE/v5+io2NU7+wSboSnyCLxaLiRQPVvFF9XbocpfeGT1RqaqpsNpuCAgtpUO8urr7FexrhGgAAAABMElovRKH1QuyPu3d8VpIUEOCvj2aMkCTt/fuwftmxSyWCAuXt7aU5E4decx1/P18tmva+OY3GLSFcAwAAAICLbdy6XUtXfCubbLJa3TSod1d5e3u5ulm4DYRrAAAAAHCxFo1D1aJxqKubAQewoBkAAAAAAA4iXAMAAAAA4CDCNQAAAAAADiJcAwAAAADgIMI1AAAAAAAOIlwDAAAAAOAgtuLCLfPy8lLv3n0MvWZ4ePgdv7ZKUICBLbkxDzfzPofK6+NhWi0zebmb+1lefHyyabVSchc1rZabh49ptc5FJ5pWy93NYlqtRE9z//QF+BUwrVZ8cqpptcyUYuJtxZ44b1qtyKQU02qdumLez5gkxSTbTKsV5GPez7S/u3nfjD6J5v03izLxd8dZE/8+A2YjXOOWhYUNN/yaRod1AAAAAHAFhoUDAAAAAOAgwjUAAAAAAA4iXAMAAAAA4CDCNQAAAAAADiJcAwAAAADgIMI1AAAAAAAOIlwDAAAAAOAgwjUAAAAAAA5yd3UDAAAAAOBe1fTpLpo/ebiKBBa8rddFRkXrjXc/sD+OT0jU6TPntfrTacod4G90M3ELCNcAAAAAcJfJHZBLi6aPsD/+5PPV+n33foK1CxGuAQAAAMAkW7bt0NS5n8rd3aq6tavbj+/ac0BjpyxQSmqqKpUvo78PHlPPri+qVo3Kmr94pdZu+EmeHmnxbdSQXipSuECm665au0ldOzxj6r0gM8I1AAAAAJjgUkSkwsbN1oxxA1W6ZJBWrtmgyKgYJSUna+CIKRrUu4tCgitrxx97tXrdZklSVHSsFi9bo1VLpsjby1Px8QmyuFkyXXfXngOKjonVQw/UdMVt4V+Ea7iUl5eXevfuc0evLdvuLYNbAwAAANyZZV+t1/JV6+2P27RspLatGmV6zp59h1S2dHGVLhkkSWrZpIHGT1ukxMQkWa1WhQRXliSFBFdWUJFCkiQ/Xx8VDyqsoaOmq05IVT1UJ1iFCubPdN1Vazep2eMPy91qdeYt4iYI13CpsLDhd/zamb+dMrAlAAAAwJ1r2+raMH0zFsuNzqWdtFrdNHvCUO3ee0A7d+1Txx5DNKxvdwVXqyhJirsSrw2bf9HcScPuuO0wBltxAQAAAIAJqlYqp0NHT+jY8dOSpK/XblJSUrI8PNyVnJKsnbv2SZJ27tqnk6fPSZJi467oUkSkgqtVVIcXWqtGlQo6cPgf+zW/2/SzypYpoVIlipp/Q8iEnmsAAAAAMEHePAHq36uT+g6bIA93d9WtXV25A/zl6eGh4e+9rrFTFirVlqqK5UqrRLEi8vf3U2xsnPqFTdKV+ARZLBYVLxqo5o3q26+56ttNerJZA9fdFOwI1wAAAABgktB6IQqtF2J/3L3js5KkgAB/fTQjbWutvX8f1i87dqlEUKC8vb00Z+LQ615v9oTBzm0wbhnhGgAAAABcbOPW7Vq64lvZZJPV6qZBvbvK29vL1c3CbSBcAwAAAICLtWgcqhaNQ13dDDiABc0AAAAAAHAQ4RoAAAAAAAcRrgEAAAAAcBDhGgAAAAAABxGuAQAAAABwEOEaAAAAAAAHEa4BAAAAAHCQJTExwebqRgBmWfbVerVt1ShH1qMWtbJDLbPrUYta2aUetaiVHWqZXY9aQGb0XOOesnzV+hxbj1rUyg61zK5HLWpll3rUolZ2qGV2PWoBmRGuAQAAAABwEOEaAAAAAAAHEa5xT2nT0tz5M2bWoxa1skMts+tRi1rZpR61qJUdapldj1pAZixoBgAAAACAg+i5BgAAAADAQYRrAAAAAAAcRLgGAAAAAMBBhGsAAAAAABxEuMY9Yf/Bo/rmu62SpKjoWF24eNnFLXLcseOnXd0EZGPnzl9UUlKyJOnPPQf0+ZfrFBt3xcWtAnKOVWs33dIxI5w6c147/9yrnX/u1akz551Sw1XMuLdfd+yWJMXGxjnl+veqqOhYVzcByHbcXd0AwNmWr1qvlat/0JX4eDV7/GFFRcfogw/naOqY/obWiYqO1aafftO58xckSYULFVDogyHKHeBvaJ10PQeMVvGigWrbqpHqP1hLFovF8Bq/7titOiHVJEmnz55X0cBC9nPrfvhJjRvWM7zm3r8Pq0zJYvL29tJ3m37W3r+P6Lk2zVQwf17Da0nSpYhIzVm0QgePHFdiUqL9+MKp7xteKzbuiqbNXartv++RJNWpVU1dOzwjP18fw2v1GTpesz4crPMXLmnQiCmqUbW8ft+9XyMGvGlYjS3bdtzwfP0HQwyrJUntu/XXjb7NnfHfLCtbf/5dD9et6ZRrr9+4Tdt//0sWWXR/zap6vEFdQ69/s3Dh5+drWK1DR47f8HzZMiUMqyVJV+Lj5ePtfd17NPLeJGnZV+vUsskjmY4t/2r9Nccccez4KQ0bM1PnL1xU4YIFJEnnwi+oUIH8GvB2Z5UpVcywWulSUlL1++59Onf+oiSpcKH8qlmtkqxWY/tjzLy3afM+VZ2QaurW533Tfk9k5ZkO7+izeWNdVt8RBw7/o7CxM2Vxs2hw766aOneJdvy5T3kCcmnssLcN/Xn+fvMveiz0AUlSRGS0ho+doT//OqDyZUtqUO8uCixUwLBakhQdE6tc/n6GXhP3LsI1crwv1/yg2ROHqHPPoZKkYkULKyIy2tAaP2z5VWOmLFBIjcr2X/q//LZLM+Z/pne6v6yG9esYWk+Sli8Yr83bdmjZV+s1cebHat3iMbVs2sDQMD913lJ7uH5v+MRMb0o+WbbaKeH6gw/nasHUMJ04dVYzF3yuhvXr6P1xszRhxLuG15KkEePnqEaV8vrtjz16o/PzWrl6g8qXLemUWmOnLJCXl6fC+r8hi6SVazZo7JQFGtynq1PqeXl66qdf/9D/WjyqV57/n17q0s/Q6y9d8e11z1ksFsPDdY8uLxp6vTs1dsoCp4TrSbMW64/d+9Tk0YckSUtWfKP9h47q9Y7PGVajUZvXZLFItiw24bRYpB+/+ciwWn2GfHjdcxaLtHzh9c/fiS5vD9fCqe9neY9G3tue/Yf1176DioiI1mcr19qPx8TG2UeLGGX42Fl66ZknrvkbsmHLrwobN0vzJg8ztN4fu/dr8MhpKlggr/1v2ZlzF3Th4mUN6dtNNatVNKyWmfeWnJKijz5dpcsRUZn+m6V75n9NDKt1ow+V4q4YO3ro5Olz+uDDOTp7/oJC64WoyyvPyMvTU5LUqccQzZ4wxLBaH07/SK++9JRiYuL09sAx6vzy0xo3vLc2/fSbJs9erIkf9DWs1qJPv7KH6+nzPtV9pYqrX89OWvfDT/pw+kcaNbinYbUkqXm7bnqwdg21bNZAD9UJlpsbA3tx5wjXyPE8PDzk7eWZ6ZjRn8DPWPC55k4cqiKBBTMdP332vHr2H+OUcO3m5qYGD92vBg/dr/0Hj6rv0Ama8/EKNWlYTx3btzGkpzfjm9Or34xn9ebcCG5Wi6xWN23b/qeeeuIxPdemudp3M3aUQUbnwy/qpXYt9e2GH1W/bi3VDamubr3D9NrLTxte69CRE/poxgj7495vvGJ44E2XlJisxMQk/brzL7Vr3dQpNYwe/XEztapXuuZYTGyczoVf1H2lihtaa+LMj7M8brOl1XSGrT/v1KLpI+y/r55s/qjad+1naLj+6VvjwvPNrFhkbHi+mfQP/5x9jxcvRejg4X8Un5CoA4eO2Y/7+flowDudDa0VExub5d+PR+vX0cwFnxlaS5LGTl2okYN7qFL5MpmO7/37sN4fP1ufzBxpWC0z7+29Hq9qzfotSkhIyvTfTJJuOBzmDrTv1l9FChfI8m9kZFSMobXGTlmghvXrqGqlsvr0i7V6490P9OH7feTn66OExCRDa8XGXdEj9WpLkmYvWq5mjz8sSXqkXm3N/WiFobUyfu32/n1EC6aGyWp103NtmmvN+q2G1pKkooEFFVytoqbNXarRE+ep2eMP64kmj6hEsSKG10LOR7hGjpcndy4dP3nG/vdz9brNKlwov6E1UlNTrwnWklQ0sJBSUlIMrZXRiVNnteyr9dqw5VfVr1tLTzZroN/+2Kue/Ufr4xkfOHz9jO85rn7/4YRR6JLSQuGly5Ha+vPv6v5qO0lpX19ncXdP+zXo5emhyKho5fL3M3xkQ7rU1FTFxl2xDwOPuxLvtHtr1PBBPfFcdxUPKqLqlcvpwsXL8vb2vPkL78DKNRvU8OE69lETkVHR2rj1Nz3ZvKFT6vXoN0rD+70uq9Wql7qmfTjR7LGH1fnltobVWLHqe73wdIssP4hzxhQMSfL385Wnx39/lt3drU4bqnju/EXly5tbHh7u+nPPAR04dEzNG9V3yhQFs6d6SNLZ8xf0x+79slgsCq5a0dDf+aH1QvTQAzVVa8OPat6ovmHXzUrugFz65rutavJoPXtvWmpqqr75fqsCcuUyvF5iYtI1wVqSKle4z/BeeTPvLTb2inq/8YoCCxXQS+1aGnrtqwUWKqAZ4wdl+f395AvGTcuRpEsRUWrbqpEkaXCfLlqw5Eu98e4HmjSyr/F/ozMk3lo1Kl3vlCESE5N06OgJyWaTxZK5Q8QZv369vb30fNvmer5tc+3ac0Bfr9ukV94YqPJlSqpl0wZO/zlHzkK4Ro7Xo8uLGjxyqv45cUZPvvCm/Hx9NGbY24bWqFS+jMLGzVLrFo+pSOH/htJ9sfr7LN+oGKFHv1E6ceqsnnricS2eNdL+JrxCudJas36LITViYuK05eedks2m2NgrmebYxsY6Z3GsZ59qqnav9tb9NauoQrnSOnn6nFPnQpUoFqjIqGg1efQhvfrmYPn5+ahiudJOqdWs0cPq9NYQPfZI2jzaDZt/UYvGoU6p9crz/1PbVo3k5+sji8UiX18fvW/gfOuMVqz6Tv9r/qj9ce6AXFr+9XdOC9eXIqKUy99P3236WaEP1tIbnZ7Xy90HGBquy5QqpkdDH1DZ0tf2iH/1zUbD6mRUtVJZ9eg32t4jtHbDj6paqaz9587IYfZmzMlPZ/ZUj7UbftL4aYsUXK2CJGnCjI/Vq1t7NWrwoGE1rFY3fbryW6e/6R74zmsaNWmexk9bpPz58khK6zmvULaUBhrcSy5JQUUKae7HX6j1E48qX57cktLWpfji6+9VNIsPkB1h5r2lz7n+bvPPTg/X9R+sqdNnzmcZruvVCTa0VkJCYqbH//fck/Jwd9cb736guLh4Q2vly5tbsbFx8vPz1aDeXezHL1y8LE9PD0NrJSQm6t0h4+2h/Xz4RRUqmF8xsXGyuDnpk/1/Va9SXtWrlFfPri9p/caf9eU3PxCucVsI18jxigcFas7EoTp+8oxsNqlEsSKGDwvv16uTFi9brRHjZ+tseNqCZoGFCujR+nX0QtsWhtZK92SzhnrkodpZzg36ZJYxQ/cKF8qvpcu/Sft3wfyZ5tgWLmhs73+6Vs0aqlWz/0JZ0cCCmmTgXK6rDXm3mySpXeumqli+jKKjY1X3/upOqfXi00/ovlLF7Quavd7pOT14fw2n1JLS3qj+sXu/UlL+6x0v9HA+w+tk1WvhzNEGKclpo0H+2P236tauLnd3d1mtVkNrdGrfRl7XecM4sPdrhtZKd/joCUnS1xlWnD505LgOHTnulDnszp6Tn87sqR7zPvlC86cMsy/AeOZsuHr0H21ouJakCmVL6c+//laNqhUMvW5GxYMCNWVUP12OiNL58LQFxgoVzK+8eQKcUm9Q7y6aNu9TPf1/byv531FX7larGtavo0F9utzk1bfHzHtLn3N99Tz5dEbOue7Ztf11z737VgfD6khSqRJFtW37n5n+jrzwdAu5uVk0efYSQ2td78MwH28vvT/gDUNrfbFoQpbH3d3d9cHAtwytJWX9N8zH21utmjZQq6YNDK+HnI1wjRzv3SEfatSQnipVIuiaY0bx9vJUhxdaq8MLrQ275s04Yx731aaNGeD0GunMXnk6XcbhsZJ05ly4EhIS5W7w8NiUlFS92KWvlswe7dRAnW7SzE+09oefVLpEkP0DGItFavDw/YbXyp8vt77b9LMe/7dH/ruNP6vAvz1RzlCmVDH17D9ax06c1usdn1V8fILhNW7Uw1Q7uIrh9SRz57CbMSc/Yy0zp3p4e3tm2tmgSGBBp0yJ2LPvsNas26KiRQrJx8fLftwZq1HnzRPgtEB9dZ3+vTqpf69O9vnBztrxImPN9Htz1tZO6XOur54nL8lpc5zMmHox/L3Xszz+XJvm9hFSRrvefd3NtSaPfM/wa+LeRbhGjpfek5zRyTPnTKt/8PA/KnefcatPZ1wdtP6DIerawXmrg8bExmn+4pU6fvKMKpYro5eeecLw4V/pzF55Op1Zw2OtVjflyR2g+PgEeXt73fwFDtq8bYeWLxhvSq0eXV7Su0PHa+rcpZLSPmwaPaSX0+oNeKezfv5tl8qVKSFvby+dv3BJXV95xim1Zi9armf+11i5A9LmgEZERmv5qvV69cWnDKvx++79Nzxv5ArN6cyck2/2VI96dYI156PlatW0gWw26et1m/XwA7XsW3QZtSXX26+/bMh17pSzt3Vydqg2c2un/Pny6KV2LVWkcEHDt7e7HjP+tqT/PTYz8Jo5pcSsWunf62auRYGci3CNHOuL1d/ri9UbdOLkWb3c/b8eodjYKypdMugGrzRW78HjtfLjiYZdz8zVQUdNnKfk5BQ9WLuGNm/boenzP9VbrzlnOySzV57OyKzhscWKFlbnXsP0aP068vXxth83ckhiusIF8zvtg5CrlSpRVItnjdbxk2ckOWfqRUZenp72VWslqVCBfCpUwPjh7lLaiIpO7dvYH+fJnUubt+0wNFxPnvWJJCklNVUHDx9X0cCCslgsOnXmvMrdV8IpPaFmzsm/eqpHkcLOneqxcMlXkqR5n6zMdHz+4pWGbsmV1er1RjNzWycp527t9MrrA2VRWg/19Pmf2heyTE5OVu5cubTms2mG1crIrL8tZgZeybz7MruW2V9H5EyEa+RYdWvXUMliRTR68oJMgdDP10dlSxv3ibikLOdwSZLNZlPcFWMXFTFzddDDR0/ok1kjZbFY1LxxqLr0MnZP1ayYvfK0mcNjbampKl+mhE6eOvvfQScNSeze8Vn1D5usB2pXk6fHfyHbyN6M2Ku2pCpUIG0Bn/j4tO95o3oI00VGRWvyrMU6e/6iQuuFZPpQ4r1hE/XBIOPn4qVmMRkvOcnYHQDmTR4uSQobN0vdOzxr31v+151/6btN2wytlS45JUWrvt2kU2fOqfcbr+jS5UidPX/BKR9SXN37Hx0Ta3jvf0ZmbTcWn5CoZV+u04HD/ygx6b8PNkcO6mFYDTO3dZJy7tZO33w2XZI0dc5SFStaWC2bPiIpbX2Dk2fOG1ornZl/WyTzQqjZU0rM/BpK5oZ55EyEa+RYRQoXUJHCBbR0zmin15o0a7GaPFpPWcUko7fiMnN1UA9Pd/u2Q1fvFe4sZq88bebw2AHvOGchrKx8sXqDDh09Lpts/825lrHhulGb12SxZF4MJv2xkT2E6UZNmq+igQX10AM1teyr9fp9136F9X9DVqubTp11zhvkEsWK6OPPvtZzbZrLJpuWLFujksWds/fp/oNHNeDt/1ZJrlOrqibPWuyUWuOmLFRqaqr+3HNAUtqwyIEjpmj+lOGG1zKj9/9q+w8e1dF/TqnZ4w8rOiZWCQmJKmDw1l8jJ8yRn6+Pdu87qOfbNNfqdZsVbPAQfjO3dZJy7tZO6X7ZsUvdO46wP27VrKHad+uvbh3aGV7LzL8tZoZQM+/LzFqSa8I8ch7CNXI8M3oXSpUoqvbtWqpk8aLXnEtfGdrIWmatDhoeflkTZ35sf3w+/FKmx84YIm72ytNmDo9NTEzS0i++0fade2SxWFSnVlU9878mThm+/fuufVo6d4zcDV5FOyOzegjTnTx11j4875GHamv05Pl6d+iHGumEHut0Pbu+pKGjpmvmws/teyYPNnjV5HRubm7a8cdehQRXliTt3LXPadvO7Nl/SIumj7Cv2p3L30/JycZ+EJjOjN7/jJavWq+Vq3/Qlfh4NXv8YUVGxeiDD+cYPvXk4JHj+mTmSL3Y5T09/WRjNW9UX+8MNHYOtJnbOkk5d2undEnJyfrnxGn73+rjJ88oKcnYHvl0Zv5tMTOEmnlfZtaSzA/zyJkI18jxzOhdeLZ1UyVd541p5/8zbu9dydzVQdu0evyGj53B7JWn04ehp/fuJiUladuvfzqlp3z0pHmKjI7R0082liStXrdZx46fckqPdtHAQs7r/nGRxKRk+7/d3NzU961XNX7aIr079EMlZzhnpIL582rK6H668u9Qdx9v75u84s690/1lDfpgqtzdrbLZbEpNTdWw6/y8O+rq8JKSkqpUm3M+xDKz91+Svlzzg2ZPHKLOPYdKSlvrICIy2vA66XORrVY3XYmPl5+vjy4bXMfMbZ2knLu1U7puHdrptV7D7IulHT56Qv16dXJKrawWKszl56vcAf727x2jmBlCzbwvM2tJ5od55EyEa+R4ZvQuPNHkkeuea9Eo1P7vP/ccUI0q5R2qlf6m+IvV36vZYw9nWg3a6PmSzhy2eT09uryod4d+mGnl6VGDjds27WpmDkPfve+Qls4ZbR9q/9ADNfV856zfYDqqaJGC6tb7fYU+GJIpSDlj8bQTp85q/LRFOnTkeKZ5meuWzzS0TmCh/Nq154CqZ/gZ6tWtvcZPW6Sff9tlaK2M1m/cpu2//yWLLLq/VlX7Bz9GK1QwnyaPek8JiUmyWCRPDw/lc9L2S2VLl9C332+VLdWmE6fO6uPPvnbaAl1Z9f4PctJe4ZLk4eFxzTQWZyywF5DLT1HRsap3f7B69ButPAG5nLawnlmrGOf0rZ3qPxiiJbPL6a/9hyRJ1SqVU57cuZxS68Npi3T42AkVDSz07wKF51SiWBHFxF7RkD5d7SNUjGBmCDXzvsysJZkf5pEzEa6R45nRu3Crxk9baNjKv3/s/ltzPlqhRg0eVJuWj6t4UKAh173apYhIrVj1nfYfPCZJqlC2lNq0elz58uR2Sr1SJYJMXXnazGHouQP8lZCQaP9AJCkpyWlv7JKTklUiKFDHjp/676CTFk/7YMIcPdXicc375At92O91LftynQILFzC8zoC3O8sti++FXt3aOy3wTpq1WH/s3qcmjz4kSVqy/BvtP3hUr3d8zvBar7w+UFHRMZlWMvbx9lahAvk0pG83lTdwS783X3tBk2Z9oouXI/Rar2EKrRei7q8+a9j1MzKz919Km9N9/OQZ+7f76nWbVbhQfsPrjBveW1armzq/3FbrfvhJUdGxav7volxGM2sV45y+tZOUtq92/bq1nHLtjCqUK60eXV5UrRr/TfNYs36L2rR8XKMnzTd0fQMzQ6iZ92VmLcn8MI+ciXCNHM/M3oWbMXKU7tC+3XTpcqS+/OYHvdn3A5UqEaSnn2xs6Dy8f06cVvc+7yu4akXVDq4iSfpr30G91KWfpo3pn+Ucc0ctXPqVXn62lX27tOTkZI2Zski9X/8/w2tJ5g5DL1m8qF59a7AeC31AkvTDlu2qVKG0fbV5I3uVzVw8LTbuih5vUFfzl6xU2dLF9e5bHfTqm4P1f889aWidGy1IVd3BESHXs/XnnVo0fYS9J/TJ5o+qfdd+TgnXLZs8opLFi6p5o/qy2Wz69vsfdeSfk6peubzGTV2omeMHOVwj/edr79+H1fetV9X3rVcNaPmNXW8fb2fs3y2ljX4ZPHKq/jlxRk++8Kb8fH00dvjbhtdJ/8D2wKF/FFi4oELrhTj1g4OcvCVRTlyhef+Bo+qfYch5reqV9OG0j1SpfBnD1zcwM4SaeV9m1pLMD/PImQjXyPHM7F24GaM7DvPlza1Xnv+falQpr2FjZmrIqOnKmydA77z+su6vWdXh60+Zs0RvvfaiGjV4MMPRplr3w0+aNGuxxg1/x+EaV/tr30G9PXCMBvfppqjoGA14f7KqVS5neJ10Pbq8pHeHjs80DH30kF5OqWVLTVWlcqV1+t+tXyqULanUlFQdOHTM8G+OmNg4zZj/uc6ev6Cxw97W0X9O6eCRf9S4YT1D60iSuzXtT4mvj4/OnA1Xvny5FRnlvNEhv+/er8mzFuvk6XNKSU2RbJIs0vdfzDG8lr+frzw9/vtT6e5uVS5/P8PrSNLPO3ar27+9xxaLRc0b1dfL3fvr9Y7PaebCzw2psWHLL3r52VaaPHuxU/bPzkr6Pt6SlJCYpOMnz6hMqWJOq188KFBzJg7V8ZNnZLM5b/TL9t//0uCR0+wf+ly8FKFhfbs7pXcrJ29JlFNXaLa4WfT77v32D5F+373f/mve6PcCZoZQM+/LzFqS+WEeORPhGjlaSkqqevQbpcmj3pPFYrEP7cwJEhITtfb7H7Vs1Xfy9vLU6x2fU8P6dXTg8DH1C5ukLxZNcLjGseOnrwrWaRo3rKfZi5Y7fP2sjBn6tj75fLVe7t5ftlSb3nztBT1av45TaklpC/iYNQzdzN7kURPnqUypYvp91z5JUpHAgho8cqpTwnVwtQqKjIpW21aN9H+vD5SHh1WPP3Lt941RRk6Yo9f+7xlVrlDGvhCds1StVFY9+o2278G7dsOPqlqprLZs2yEpbQ6nUZKSknTi1Fn7FI8Tp84q8d857FaD7tPby0s9+4/WmbPh6jtswjXnjdxFIV36Pt7p9uw/rDXrNxteJ92Wn3cquGoFlSqRNvolKjpWu/ce0EMP1DS0zoQZH2vM0F6qUrGspLT7GvHhbH0yc6ShdaScvSVRTl2h+eoFClNSUjXsve6KuxKvdk8Z+zU1M4SaeV9m1pLMD/PImQjXyNGsVjfFJyQqNTXV6W/Cb4WRw8Kfat9TdWpVVd+3OqhyhfvsxyuVL6M6BvRaS5LtBg2+0TlHJCcn6+z5C8rl56vomFglJibe/EV34Ep8vHy8vRUbGydJKlQgrfcp/t95oX5+vobVWrN+yw3PO2Mu4/FTZzS83+v6Yet2SWk98s5aPNzP10cnTp1TowZ1FVy1gmLi4nRfqeLOKfZvPWd+4JLR4aMnJElfr91kP3boyHEdOnJcFovF0HDd9ZV26tRjSKaVjN/r0VFxV+INW0xqzNC39euO3Tp2/JTqP+j8eadZqVLxPo2aNM9p15+9cJkWTf9vL+Nc/r6atWiZ4eHazeJmD9ZS2n0Z9SHI1XLylkQ5bYXms+cvSMp6gUIPD3f5+nhnWujUCGaEUDPvyxVfQ8n8MI+ciXCNHK9yhdJ6Z9A4NXn0Ifn6/LeytpFvim9V21aNDLvWwqlh152D+l7PjobUKFm8qL7b+LMeb5D5jf36jdtUophzttLp3HOoKpYrozkTh+pSRKQGfTBVO/7cl2molhG6vD1cC6e+r0ZtXpPFkvbBR8b///Eb4/Zw3vrL75KkuLgr+n3XflWvUl4Wi0V/7vlbNatVdEq49nDP/Os9PiFRNjlva66pc5bo2InTqlqprO6vWVVuFjf7vHmjNXj4fn3z3VY9/khdeXg498+Y0Xsj30hovRBVq/zfSsZVK5ZV3n9XC3/52VaG1AjI5afHG9RV7tz+hkwduRWHjhy3/zslNVV79h9WiolDLC0Wi1JTjP/erxNSVavXbbb//H7z3VbVCalmeB0pZ29JlNNWaH7l9YGyKK2bMzI6OtMChblz5dKaz6YZVsvMEGrmfZlZS3JdmEfOZElMTMhZG6ECV+ne+9p5fRaLRVNGGzd/LDExKdN2Rxu2/Ko//9qv8veVUovGxv9CPnb8lNb9sE3nwi9KkgoXzK/HH6mrMqWKGV6nW+/3FVKjsqpWSuuh2b33oHbu2qdpY/rbh10aae2Gn9Tk0f+GLienpGj6vE/1RqfnDa9ltneHfqjOL7e19+oeOXZSsxct1weD3jK81rR5n8rX21vfbvhRvbq116dffKNK5cuo40ttDK+V7kp8vH7Ysl1zPlqhc+EXDP2AIqPNP+3Q0NHTFZ+QIMk5H4hcbxGudM5ajMvZ0oezX48zPnR8qv1/W+lZrW4qHhSozi+3VcVypQ2vJUldeg1Tt1eftS9y9+eeA5o2d6khC8Jl1LhNZ8XEXpG7u1WSlJycIn+/9K2xLIZuRde+a79ssSVR8WKBhgdes+/NLFPnLFWxooXVsmnaVp1fr92kk2fOq1uHdobVaPZMV1NDqGTOfZldyxVfR+RchGvAAC93729fnGfFqu/0xeoNatSwrn785Q89EFJNHV5obVitZV+t1yfLVuvx0Loq8u92R2fOXdB3m3/W822a6+knGxtWS5IuXLys5V9/l7bolqTyZUvpqSceV8EbrNyMrL3wWt9r5mO+2OU9fTzjA8NrJaek6JPPV2vzTztks9kUWi9ELz3T0inzyX/d+Zd++/0v/fbHXtlsNoUEV1admlWd1ovX5uWeeq9nR1UqVzrT1lxGrtTc4Y2BktJ6Wg8ePq6igQX/feN/XuXuK2HaYmBGy+rDxnRGf+joKrv3HlTfYRNUsngR2WzSydPnNHJQD1WpeN/NX3wbzpy7cMPzRQzcju798bPV7LGHTFvF2MzAa/a9maV9136ZpidIUvtu/bVomvG/O8wMvGbel5m1JHO/jsi5GBaOe8KFi5d1+my4UjLsX2xkz1PGuayr12/RuLB3VKhAPrVp2Uidew41NFx/tnKtFk59XwG5Mq9Y/OIzT6jjW4MND9cF8ufVay8/fc3xzj2HataHgw2rM2nmJ3rztRf07tAPZcli5RBnLLRkNj9fn0zDSNes3+K0rXvcLBa9/Gwrw4YT30iPfqNUrXI5vdn5eQWb0KObN0+AfWs4Z0lfhCts3Cx17/Cs/YOCX3f+pe82bXNqbWcyc5j71RITk5SUlGR/bOS6BhlVq1xOS2aP1l/7DtofO2OF90NHj+uhOsGmrOeRk7ckyqkrNCclJ+ufE6ftW1YeP3km0/e/kX7ZsUvdO/4XQls1a6j23fo7JRSaeV9m1pLM/Toi5yJcI8dbsPhLfbJstYoWKZhhsRmL5k0eZliNjFkwNTXVvo+2n6+PrFarYXXSr391sJbSFu1x1iJjWTl3/qKh16tZo5IkqXrl8sqbJ8Cp84NdpX+vTho6eoZGTpwri8Wi8veV1EAnrSD+VPue+l+LR/W/5o8qT+5cTqmR7pOZI7X997/0ybLVGjVpnipXuE91alV12ur8D9etpc+/XKfHHnlAXh7/TcdwRljbf/CoBrzd2f64Tq2qmjxrseF1zJK+GnnGedAZpS+mZqS/9h1S2LhZOnHqTKbjzpo2IElxV64oKjpGFotFcXHxTgnXS5d/o9GT5qvJo/X0RONQp0yTSZeTtyTKqSs0d+vQTq/1GpZpgcJ+Bq8dks7MEGrmfZlZSzI/zCNnIlwjx/t63SYtWzBOuQOcFzD+OXEmbesom3T6zHnFxl2Rn69P2mqTBr8RefD+Gnqz70i1atYg07Dwr77ZqAfvr2ForRvJqnfZEfXrpq1cvOjTVQoJrqwnGoeqbu3q2WKVd6OULF5U8yYPU2zcFUlpH744y8QP3tWKr7/X853f1QMh1dS2VaNMKxsbqXTJIJUuGaSH69bUtu1/6pPP12jt9z86LVzPWrhMkvTh9I+ctghdOjc3N+34Y699GOzOXftkcbt73/FPmPGxxg1/R32GfHjNOYtFWr7w2uOO+nD6Rxr4TmeNmjRf08cO0Ocr12Vao8Joazf8pPHTFqlm9Yqy2WyaMONj9erWPsttBR0xdUx/nTpzXt98t0VvDxyrfHlz64nGj+jJ5g0NrSPl7C2JcuoKzfUfDNGS2f8tUFitUjmnfdBpZgg1877MrCWZH+aRMzHnGjlepx5DNXuCccOXs7Lz372E01UsV1q+Pt66eClCP2zdbugq4TabTd98t1Xfb/4l04Jmj4bWUbPHHjYtjP7vxbe08uOJhl/3Sny8Nmz+VavXb9ap0+fV5LGH1LLJI/a9f+92zp6icLX4+AR9u+FHLVzypfLmCVC71s3UuOGDhn44MnLiXP32+x5J0v01q6p2zSqqHVxFuQP8DavhKrv2HMj0xj81NVXD3ntd1SqXc3XT7hrpa1JkXHOgwxsDr9n/2ijtXu2tD9/vraKBhSRJZ86Gq0f/0fp07hin1JOkhMRETZzxib78ZoOhH/Kkr2IsSUlJydesYhxYyLh53Rld/X2fHnjLlimhH7b+asjKya66t5zqckSUaSE0J+PrCEfRc40cr06tqvpw+kdq3LCevDL0lhg5/LFW9UpZHs+fL0+mYD11zlJ17/isQ7UsFouaN6rvlO2brta4TWdJWYUwm+Li4p1S08fbWy0ah6pF41CdPntei5au0rMdezt1CKlZzJiikJHNZtMvO3fru00/y8fbW40aPKj1G7dpw5ZfNGpwz5tf4BZVKldG7du1tIeZnCSrrVny/bs91t3ur32HtP33v2SRRffXquK0kQ3u1rS3GrkD/PX3waMqVDC/LkdGO6WWJHl7e2b6XiwSWNBpezT/ffCovl63Wd9v/kWVypfR8H5vGHr9nLwlkdn3ltPlzRNgHwGGO8fXEY4iXCPH++a7rZKkLdt22o85a/jjzfz6+251l2Ph+ka2/vy7Hq5b07DrLZw24uZPcoLk5GRt2bZTX6/bpH1/H1XrFo+7pB1GM2OKQrqFS7/Sl2t+UOmSQXrpmZZ64N8FuZ5r01xPv/K2obWcMQw2u3jl9YGKio7J9Mbfx9tbhQrk05C+3VT+vpIubuGd+eTz1Vr21To98tD9kqQBI6bomScb67k2zQ2v9XiDuoqMitbLzz6pbr3fV3Jyijq/3NbwOunq1QnWnI+Wq1XTBrLZpK/XbdbDD9RSbGycJOPm5r/Y5T0lJSWrReP6WjTtfRVwwg4K33w2XdL1VzE2mpmB1+x7AwAzMCwcMJEzt5CQnDdUO6PomFinLA6UbtzUhdqw5VeVv6+kWjQO1SP1asvDI2d8DmjGFIV046Yu1NNPNlaJYkWuObf/4FGn7TGc00ybu1QlixdV80b1ZbPZ9O33P+rIPydVvXJ5fbJsteF7J5vlmQ7vaPaEwfYPeiKjYtSpxxB9Nm+sU+smJ6cN/3XmegP1mr503XNGzs3fteeAfS9tZ8vJWxKZfW8A4Ew54x0rcAMZ53Vl5Ir5XEZMc5048+Msj9tsUsy/PTNGWbriW9WtXU2lSgQpNTVVvQeP17btfyp3gL9GD+nllHmn+fPl0fzJw1SoYH7Dr+1qZkxRSPd295eve45gfet+3rFb3V5NG22SPiXj5e799XrH5zRz4ecubt2d8/P1yTSCIneAv+GB1xUrk0vST986dwpJ+n35+nhneW/OuK+cvCURKzQDyEkI18jx0oe52WRTYmKS4hMS7ur5XCtWfa8Xnm4hq/XahcuMXsF71bcb1aZl2pDsDZt/1akz5/X1kinad+CIps1dqunjBhpaT5L+77knDb9mdmHmFIVLEZGas2iFDh45rsSkRPvxhVPpDbodSUlJ9jAlpQWrxMS0N/7Wu3gl+5Dgyho+dqZaNknrmVy9fovur1nFHhaNCIiuWJncDBnvK321+nTOuq+cvCURKzQDyEkI18jx0ud1pdu4dbsOXqcnxdmM2Ia6TKliejT0AZUtXfyac199s9HxAhlYrW72Idm//bFHTR97SPny5tZDD9TUzH+3Q8KtW7HIvDAxYvwc1ahSXr/9sUdvdH5eK1dvUPmyd+f8YFfq+ko7deoxJNMb//d6dFTclXg99khdF7fuzm3Y/Ksk6fdd+zMd/27TL4YFxHHD35Fk7ve9GdLvq2fXF1WjakUF5EqbJhMVHatdew44pWZO3pLI7HsDAGciXOOe0+Dh+7Vw6Vfq1L6NYdc8cuykypQqJklKTEzKtIfrzl377KuJTxzxrsO1OrVvIy9PD0VERl/zBuSNzs87fP2MUlJSZbPZZLFYtGvPATVu+N8+sUbv352TXYmPl4+3t31BpasZtcBSRufDL+qldi317YYfVb9uLdUNqa5uvcP02stPG14rJwutF6Jqlf9741+1Ylnl/Xe18JefbeXKpjnkesHQyAURMzJrZXIzzV60PNNc4Vz+vpr90TKnfQ3NXMXY7MDLCs0Acoq7d0wbcItiY+Ps/4uKjtW27X8qNu6KoTWGjvmvd7xTzyGZzmWcI53XgC186tUJVvGgQL3Vb+Q15z76bJXD18+ods3KGvD+ZI2dslBxV+JVvWoFSdLFSxE5ZpExM3R5O20/30ZtXlPjtq+pUZv//te47WtOqZm+yq+Xp4cio6JltbopwonbH+Vk6W/869etZcjPcHYwe9Fye7CW/guGzvDJ56s1cMRkRUbFKCIqWgNGTNGS5WucUsuVLBaLUlNyzhqxGb/v6UkGgFvDu2PkeI3avGafF+fm5qbiQYXVs+v1V5O9ExmHe1899NuIoeAZJSUlKzExUakptrQPCf4tEBN7RfHxCYbWeqPzC/rsi7U6f+GSPny/j9ytVklp806fa9PM0Fo5Wfo8Z2cvtJRRiWKBioyKVpNHH9Krbw6Wn58PC5nhupwZDL/85gctmBpmX0Dtlef/p049hjhl2y8z+fp4Z1ox/M89B+Tr6+3iVgEAXIlwjRzPjECTcR2xq9cUM3iNMS369CvN/fgLWSxSo6c624/7+foYHnjdrVY93/baN8DB1Spmejx1zlJ17+i8/btx+4a8202S1K51U1UsX0bR0bGqe391F7cK2YWZwdCMlcldoXvH59R32ASVLJ623d2JU+c0clAP1zYKAOBShGvAAAkJSTp09IRks2X6d/o5I7364lN69cWnNHrSfPV58xVDr32nfv19t7qLcJ3dnD1/QX/s3i+LxaIaVSvYRx4AZgZDM1Ymd4VqlctpyezR+mvfQfvjXP5+N3kVACAnsyQmJuScCUKAi7Ru30MWZd1FfTdvOXOr2nfrr0XT2OIpO1m74SeNn7ZIwdXS5snv2nNAvbq1V6MGD97klbhXREXHmhIMn2rf87rn7oXfjwCAewc914ABvlg0wdVNcCmjh77DcfM++ULzpwxT0cBCkqQzZ8PVo/9owjXsAnL5qV6dYKfXMXtlcgAAXIXVwgEDvDvkQ239+Xelpqa6uimAJMnb29MerCWpSGBBeXt7urBFuFeZuTI5AACuRLgGDBBcvaJmLPhMT77wpqbN+1QnTp11dZNMZfSK6HBcvTrBmvPRcp0Pv6hz5y9q7sdf6OEHatm3pQNcJadtWQUAQDrmXAMG2rP/sFav26zvNv2s+0oXV8smj+jR0Afk7XV39hgeOXZSZUoVkyQlJibJ09PDfm7nrn2qVb2SJOlyRFSO2f83p6jX9PrbzVks0o/fmLctGO5tXXoNU7dXn820Mvm0uUs1c/wgF7cMAABjEa4BJ0hITNTGrdu1ePkanTkbrnXLZ7m6SXfk5e797Xs0Z/x3Vo8BICu79x7McmXyKhXvc3HLAAAwFguaAQZLSUnVz7/t0nebftbpM+EKrRfi6ibdsYzDva8e+s1QcAC3gi2rAAD3CsI1YJAjx05q1dqNWrvhJxUNLKgnmjyiIe92k5+vj6ubdscyrgJ+9YrgrBAO4FaZtTI5AACuRLgGDNDhjYE6e+6iGj9aT5NHvaf7ShV3dZMMkZCQpENHT0g2W6Z/p58DAAAAkIY514ABvt/8ix6pFyJ398yfVyUmJmn519/puaeauahljmndvocsyrqL2mKRli/80OQWAQAAANkT4RowQHxCopZ/tV5nz19Qw/p1VKt6JX2x+nvN+/gLlSxRVFNG9XN1EwEAAAA4EeEaMMCwMTN06sx51ahSXjt37VOhgvm178AR9erWXvXr1nJ18+7Yu0M+VMumDVSvTg25ubm5ujkAAABAtkW4BgzwbMc++njGCLm7uysmNk4tnu2uz+eNVaGC+V3dNIcsWfGNVq/brMjIaDVrVF8tmzyi4kGBrm4WAAAAkO2woBlgAC8vD/t8a38/X5UIKnLXB2tJeu6pZnruqWbas/+wVq/brFffHKz7ShdXyyaP6NHQB+Tt5enqJgIAAADZAj3XgAFavfCGXnz6CfvjTz5frReebmF//Mz/mriiWYZLSEzUxq3btXj5Gp05G651y2e5ukkAAABAtkDPNWCAOjWr6sChY/bH99es8t/jHLIhdEpKqn7+bZe+2/SzTp8JV2i9EFc3CQAAAMg26LkGcENHjp3UqrUbtXbDTyoaWFBPNHlEjRo8KD9fH1c3DQAAAMg2CNeAAbZs25H5gMWifHkCdF/pEnf1vOQObwzU2XMX1fjRemrZ9BHdV6q4q5sEAAAAZEsMCwcMsHTFt9cci4iKVnRMrEYN7qlK5cu4oFWOe+HpJ/RIvRD7Ym3pEhOTtPzr7/TcU81c1DIAAAAge6HnGnCinbv2ac5HyzVtzABXN+WOxCckavlX63X2/AU1rF9HtapX0herv9e8j79QyRJFNWVUP1c3EQAAAMgW6LkGnKhW9UqKjbvi6mbcsdGT5unUmfOqUaW8ps1dqkIF82vfgSPq81YH1a9by9XNAwAAALINwjXgRCkpqUpNuXsHh+z9+4g+njFC7u7uiomNU4tnu+vzeWNzxB7eAAAAgJEI14ABDh05fs2xyKgYrVq7UTWrV3RBi4zh5eVhn2/t7+erEkFFCNYAAABAFgjXgAH6DPkw02OLRcqTO0APhFTTy8+1clGrHHc5IkqfrVxrfxwVHZPp8TP/a+KKZgEAAADZDguaAbiusLEzr3/SYtGAtzub1xgAAAAgGyNcAwb4c88BXb4cqQYP35/p+Mat25Uvb25Vr1LeRS0DAAAAYAaGhQMGmPvRCvV585Vrjpe7r6RGTZynSSP7uqBVjtuybUfmAxaL8uUJ0H2lS8jby9M1jQIAAACyIcI1YICY2DgVK1r4muNBRQrpckSUC1pkjKUrvr3mWERUtKJjYjVqcE9VKl/GBa0CAAAAsh/CNWCA6JjY655LSEw0sSXGmjqmf5bHd+7ap8mzF2vamAEmtwgAAADIntxc3QAgJyiQL4/27D90zfE9+w8rX54AF7TIuWpVr6TYuCuubgYAAACQbdBzDRjglRdaq+/QCerwYmtVrVhWkrR73yEtWLJSA3rlvBW1U1JSlZrCWogAAABAOlYLBwzy686/NP+TL7T/4DFJUsXypfXKc0+qTkg11zbMAYeOHL/mWGRUjFat3aiAXP7q1a29C1oFAAAAZD+Ea8BE32/+RY+FPuDqZtyyp9r3zPTYYpHy5A7QAyHV9PJzreTlyYrhAAAAgES4Bkz1cvf+Wjj1fVc3AwAAAIDBWNAMMJHtLvso6889B7Rx6/Zrjm/cul279hxwQYsAAACA7IlwDZjIYnF1C27P3I9WqGyZEtccL3dfSc35aIULWgQAAABkT4RrANcVExunYkULX3M8qEghXY6IckGLAAAAgOyJcA2Y6G4bFh4dE3vdcwmJiSa2BAAAAMjeCNeAwSIioxURGZ3lua6vPGNyaxxTIF8e7dl/6Jrje/YfVr48AS5oEQAAAJA9sVo4YJClK77VR5+tUkRk2nDpvHkC9NIzLdWudVMXt+zO/brzLw0fM0MdXmytqhXLSpJ27zukBUtWakCvznf1Ht4AAACAkQjXgAG+/X6r5i/+Uj27vqQqFe+TzSbt/fuwJs78WP/33JNq8uhDrm7iHft151+a/8kX2n/wmCSpYvnSeuW5JwnWAAAAQAaEa8AAXd8erl7d2qvcfSUzHT905LjGTV2o6eMGuqhl5vh+8y96LPQBVzcDAAAAcBnmXAMGuHg58ppgLUlly5TQpYhIF7TIXIs+/crVTQAAAABcinANGMDXx/u657y9vUxsiWvcbaugAwAAAEZzd3UDgJzgUkSkPlu5NstzERFZrxyek1gsrm4BAAAA4FqEa8AAdWpW1YFDx7I8d3/NKuY2BgAAAIDpCNeAAQa889p1z4VfvGxiS1yDYeEAAAC41zHnGnCyTm8NcXUTDBERGa2IyKyHuHd95RmTWwMAAABkL/RcA05mu8u7dZeu+FYffbZKEZFRkqS8eQL00jMt1a51U/tzHry/hquaBwAAAGQLhGvAySx38Wpf336/VV+s/l4D33lNVSreJ5tN2vv3YU2c+bHy5M6lJo8+5OomAgAAANkC4RowwKEjx697Ljkl2cSWGOvLNT8orN/rmfbwrlu7ugrke13jpi4kXAMAAAD/IlwDBugz5MPrnvP08DSxJca6eDkyU7BOV7ZMCV2KiHRBiwAAAIDsiXANGGDFouuH67uZr4/3dc95e3uZ2BIAAAAgeyNcAwY4cuykypQqJklKTEySp6eH/dzOXftUq3olVzXNIZciIvXZyrVZnouIyHrlcAAAAOBexFZcgAGGjplu/3ennkMynZs482OTW2OcOjWr6sChY1n+7/6aVVzdPAAAACDboOcaMEDG3bau3nnrbt6Ja8A7r133XPjFyya2BAAAAMje6LkGDJBxt62rd966i3fiuqFObw1xdRMAAACAbIOea8AACQlJOnT0hGSzZfp3+rmcyHY3d8kDAAAABiNcAwZISExUn8Hj7Y8z/jun9lxbcuqNAQAAAHeAcA0Y4ItFE1zdBKc4dOT4dc8lpySb2BIAAAAgeyNcA7iuPkOuv3+3p4eniS0BAAAAsjdLYmICEycBBzVu01lSVsOkbZIsWrd8psktAgAAAGAmeq4BA/zfc/9Tw4fvz3ETrI8cO6kypYpJkhITk+Tp6WE/t3PXPtWqXslVTQMAAACyFbbiAgyw48+9GjY2rXe6SOEC1/zvbjV0zHT7vzv1HJLp3MSZH5vcGgAAACD7IlwDBhg3/B01e/xhvdZrqL765gdXN8cwGXfbunrnLXbiAgAAAP7DsHDAIK2aNlDNahX16puDNHn2kn+3qrq751xnHOV+9Yj3HDYCHgAAAHAI4RowyP6DRzV87Ew9/siDeuHpFnJzu/sHhiQkJOnQ0ROSzZbp3+nnAAAAAKRhtXDAADPmf6Z1P2xTnzdfUd3a1V3dHMO0bt9DlixXQU/ruV6+8PpbdQEAAAD3EnquAQOcPX9BC6eFKZe/n6ubYqgvFk1wdRMAAACAuwI91wAAAAAAOIieawDX1bhNZynLYeF390JtAAAAgNEI1wCu6/+e+58aPnw/S4MDAAAAN0G4BnBdO/7cqy0/79Sg3l1UpHABVzcHAAAAyLaYcw3ghr76dqPmfLRcHV98Sq2aNXR1cwAAAIBsiXAN4KZOnDqrV98cJJtNslgsYs41AAAAkBnDwgHc0P6DRzV87Ew9/siDeuHpFnJzc3N1kwAAAIBsh3AN4LpmzP9M637Ypj5vvqK6tau7ujkAAABAtkW4BnBdZ89f0MJpYcrl7+fqpgAAAADZGnOuAQAAAABwEJMnAQAAAABwEOEaAAAAAAAH/T+ZMZwT4NRJxwAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1000x1000 with 4 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# clustermap manages its own gridspec; disable constrained_layout to avoid\n",
-    "# matplotlib colorbar/engine-switch errors under non-interactive backends.\n",
-    "with plt.rc_context({\"figure.constrained_layout.use\": False}):\n",
-    "    fig = sns.clustermap(macro_data_full.corr(), cmap=\"RdBu_r\", center=0, figsize=(10, 10))\n",
-    "    fig.fig.suptitle(\"FRED Indicator Correlations (Hierarchical Clustering)\", y=1.02)\n",
-    "    plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cf3d0b3f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003364,
-     "end_time": "2026-07-18T19:35:44.644519+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:44.641155+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "**Interpretation**: Four blocks emerge: a labour/yield-curve block\n",
-    "(CIVPART, UNRATE, T10Y2Y), a stress block (VIX, ICSA, high-yield spread), a\n",
-    "growth/price-level block (INDPRO, CPI, M2), and a short-rate block\n",
-    "(DFF, T10YIE). Most off-diagonal correlations are modest in magnitude, and\n",
-    "the dendrogram's high cophenetic correlation confirms that this block\n",
-    "structure is genuinely hierarchical."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "267ac484",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003288,
-     "end_time": "2026-07-18T19:35:44.651075+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:44.647787+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Comparing GMM and K-Means\n",
-    "\n",
-    "Both methods identify 4 regimes. The key difference:\n",
-    "- **GMM**: Soft assignments with probabilities (uncertainty quantified)\n",
-    "- **K-Means**: Hard assignments (each month belongs to exactly one regime)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b12597c3",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003304,
-     "end_time": "2026-07-18T19:35:44.657698+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:44.654394+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Fit Both Models"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "89d299cd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:44.665159Z",
-     "iopub.status.busy": "2026-07-18T19:35:44.665068Z",
-     "iopub.status.idle": "2026-07-18T19:35:44.950622Z",
-     "shell.execute_reply": "2026-07-18T19:35:44.950366Z"
-    },
-    "papermill": {
-     "duration": 0.293069,
-     "end_time": "2026-07-18T19:35:44.954157+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:44.661088+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GMM silhouette: 0.417\n",
-      "K-Means silhouette: 0.448\n"
-     ]
-    }
-   ],
-   "source": [
-    "n_regimes_full = 4\n",
-    "\n",
-    "# GMM\n",
-    "gmm_full = GaussianMixture(\n",
-    "    n_components=n_regimes_full,\n",
-    "    covariance_type=\"full\",\n",
-    "    random_state=SEED,\n",
-    "    n_init=10,\n",
-    "    reg_covar=1e-6,\n",
-    ")\n",
-    "gmm_full.fit(macro_data_full)\n",
-    "gmm_probs_full = gmm_full.predict_proba(macro_data_full)\n",
-    "gmm_labels_full = gmm_full.predict(macro_data_full)\n",
-    "\n",
-    "# K-Means\n",
-    "kmeans_full = KMeans(n_clusters=n_regimes_full, random_state=SEED, n_init=10)\n",
-    "kmeans_labels_full = kmeans_full.fit_predict(macro_data_full)\n",
-    "\n",
-    "print(f\"GMM silhouette: {silhouette_score(macro_data_full, gmm_labels_full):.3f}\")\n",
-    "print(f\"K-Means silhouette: {silhouette_score(macro_data_full, kmeans_labels_full):.3f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1710b087",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005042,
-     "end_time": "2026-07-18T19:35:44.965048+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:44.960006+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### GMM Regime Probabilities"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "c11861fd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:44.976434Z",
-     "iopub.status.busy": "2026-07-18T19:35:44.976325Z",
-     "iopub.status.idle": "2026-07-18T19:35:45.073006Z",
-     "shell.execute_reply": "2026-07-18T19:35:45.072549Z"
-    },
-    "papermill": {
-     "duration": 0.103114,
-     "end_time": "2026-07-18T19:35:45.073551+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:44.970437+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABN4AAAF/CAYAAACWiQTKAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAXVJJREFUeJzt3XmczVUDx/HvXcxqHTNj3/clNGNfxhbKVpaSJaGsiSRkzYOobIkUSkilSEVKJDtlS4SsyTbGMgxmzH6fP8YM12x3mN/MmPm8ve7zuL/l/M45bi5fZzGFh4fZBAAAAAAAACBVmdO7AgAAAAAAAEBmRPAGAAAAAAAAGIDgDQAAAAAAADAAwRsAAAAAAABgAII3ZDjtur+midPmpXc10pz/xcuq06Kbvli+JtXK/OTzb1WnRTddD7qZ7LX39/u+vw6rTotu2vfX4bhjE6fNU7vur6Xo2enh9TFTNWXmJ+ny7KwsMjJST3cdpG9Xr0/vqgAAAABAhmBN7wpkdhcuXtKXK37Wrn0HdelKoCSpQD5P+VStqHYtm6h0yaJx137y+bf6dOl3MplM+m7J+8rnndeurODgELV8/hWFh0eoQ5tmemPgi5JiApv2Lw6RJPV5saN6dnkmXj3eemeu1m3cIVcXZ/32w6dJ1jm2HrEsFou8PPOoQW0f9e7eQTmyuz9QXzyq7u8PZ2cnFcjnqUb1aqjbs63k7u6WjrVLX6GhYVq6/Ef5VKkgn6oV07s6kqS/Dh3Trr0H9dUn78UdO33mgn5ct1m79h7Uef9LcnV1VrnSxfXyCx1UoWzJeGVcuhKoWR8v1a59fyvaFi3fKhU1uF83FSrgHe/aVWs36csVP8n/4mV5e3nouWda6Nmnm9tds2n7bn2/5jed/Pesgm7eUu5cOVS5fGm99EJ7lSpeJNk2BVy6qh/Xbdb2P/br3IWLMpvNKlm8sHp0fkY1fSrHu/7mrWB9+Mkybd6xR6Gh4apYrqQG9emicmVKxF0TdOOmVv+yWdt//1Onz15QZGSUihUpoOfbPaUnGtVOsB5Hj/+rT5au1F9/H1N4RIQK5ffW0y0b67lnWkiSrFarnu/wlBZ9tUqtWzSUs5NTsm0DAAAAgMyM4M1A237/U2Mnz5HFYlaLJnVVumRRmU1m/Xf2gjZt36PvftygbxfPVIF8nnb3Zctm1fpNO9XtudZ2xzdt35Pk85ycsmn9xp3xgrfboaHaunOvnJyypaj+w17tKTdXZ90ODdOePw9p+Q/rdPTEac2bMS5F5aTU159MldlsMvQZDyK2P0Juh2nXvoNa9NUP2rP/sObPHCeTKePVN6Uc6feRr72k6Ghb3PvQsPCYULKb4gVvPbo8oxc6tTGkrkn5cvkaVX+8kooUyh93bNXaTfrxl01qVL+G2rd5QreCQ/T9mt/Ue/B4zXh7uF14FXI7VAOHT9at4BC9+HxbWawWfb1yrQa8MUlLPnpbuXLmiLv2uzUb9N4Hn6lx/Rrq3P4p7f/7qGbMXaLQ0DC7tp/895xyZHfXc8+0UK5cORQYGKQf123WS4Pe0oKZb6lMqWJJtmnLzr36/Jsf5VfHVy2bNVBUVJR+/nWbBo98R6Nf763WLRrGXRsdHa2hY6fpxKkz6vpsK+XKmUMrV/+qAcPf1qI5k+L65eDhE5q3aLnq1qimHp2flsVi0aZtuzV2yhz9e+a8enfvYFeHP/Ye1LC3pqtsqWLq2fUZubm46Lx/QNw/KMRq3dxPHy38Wus27lSbe+oFAAAAAFkRwZtBzl0I0Lgpc5Q/X17NfmekPPPmsTs/4OXntXL1rzInENjUrVFN6xII3tZt3KF6Natp47bdCT6zbo1q2rR9t46f/M/uL/JbduxTRGSkalevor37Dyd4b0KaNKip3LliQoZ2rZpq7OQ5+nXz7zr0z0lVKl/K4XJSKqUBYVq5tz/at26qkRNmadP23fr7yAk9VrFMgveEhobJxcU5Lav5wBzpd6vV8d8yrBaLrBbLw1QpxQKvB2n7rv0aPqin3fHmjevo5Rfay83VJe5YmxYN1fnlEfp06Uq74G3l6l919vxFffrB/1SxXMznvE71qurW9019ueIn9e/VSVJM6Dhv0XLVrVlNk8cOliQ93bKxbLZoffbl93q6ZRPlzBEzOvSlbu3i1bXtU43Utusgrfxxg0YM7pVku3yrVtT3n8+K+/xJMf9Ndh8wWguWfGsXvP22dZcOHj6ut8cMUpMGNSVJTf1qqdNLb2jBkm81YeQrkqSSxQvpm4XT7YL/Dm2e0KtvTtHSb35Ut+daydUlpr+Cg0M0YerHMW0dM0hmc+KrFOTI7q6aPo/pp3VbCN4AAAAAZHms8WaQpct/1O3QMI0Z2ide6CbFhBLPPdMi3nRSKSYkOH7yP50+cyHu2NXA69q7/7CaN66b6DMrVyitgvm9tG7jTrvj6zZuV+3qVZQzR/aHaJFUtXI5SdJ5/wC744f+OaHXRr2rJ9r1VqO2vdT/jUn669CxePfv++uweg4cq4ate6pjj9f13ZoNCa4Ddv9aY2vWbVGdFt30153RRE8911/N2vfRO7M+VUREpG7eCtb/3vtYzTv0UfMOfTTnk69ks9nsyoyOjtaylWvVpfcINWzdUy07DdA7sz7VjZvBD9wfvtViRnhduHhZkjRg2CR17fOm/jn+r/oPnahGbXvpo8++kRQTCL09Y4Fadhqghq176oV+o7Rm/ZZEy/5q5c9q98JgNWzTU/3fmKSTp8/anT9x6owmTpunDi8OUcPWPdXq+Vc0afp8Bd1IeC2360E3NXrSB2ra7mW16NhPMz9aorDwcLtrHFlb79413vwvXtZTz/WXJH269DvVadFNdVp00yeffysp8TXe1m7Yph6vjFHDNj3VvENfjZ08RwGXrtpdc/b8RY2cMEutnn9FDVv3VNuur2rs5Dm6FRySZP12/LFfUVFRqvG4/fTL8mVK2IVukpQrZw5VrVzO7r8zKSa4qlC2ZFzoJknFixZU9ccracOWP+KO7fvrsIJu3FKHNk/Y3d+hTTPdDg3Tjl1/JlnXPLlzysXZKdk2SVLJ4oXtQjcpJiitW6OqLl0JVHDI7bjjG7fukkeeXGpUr7rds5r41dLWnfsUHh4hSSqY3zveaFuTyaSGdasrPCJC5/0vxx3/ZeNOBV4LUr8ez8psNut2aKiio6MTrW9Nn8r669AxBd24lWzbAAAAACAzI3gzyPY/9qtwwXyqVL50iu+t9lh5eXt6aN3GHXHHft38u1xdXVS3ZrUk723WqI5+3bwzLni6HnRTf+z9O8nAzlH+ATF/Eb93jbc9+w+p/xuTFBwSqpe6tVO/Hs/p1q0QvTpisg79czLuuqMnTmvI6KkKunFLL7/QXq1bNNTCL77Xlh17HX7+9LlLdPb8Rb38QnvVr+2jH37aqPmLV2jYuOmKjo5Wvx7PqUqlcvpi+Rr9/Os2u3vfnbVQcz75SlUqldVr/bupdXM/rftth14b9a4iIyMfqD9iA8hcOe8GmkE3b+r10VNVplQxvdavm3yrVlRoWLheGfa21m7YphZN6mpg787K7u6qSdPm6+vv1sYr9+cN27T8+3Xq0KaZundqq1Onz+nV4VMUeC0o7ppd+/7WBf9LatXcT68P6K4nGtbWr5t/1+tjpsULHSVpzOTZCo+IUP+enVS3ZlV98/06vfP+wgdqd6zcuXNo2KsxI8sa1quut4b301vD+6lRvRqJ3rPoyx80Yeo8FSmUX4P7dFWndk/GfYZu3ooJQSMiIvXaqHf19z8n9Gzb5ho68EU9/VQTnfe/pJu3kg6pDh4+rlw5s8cLlBJz9dp15c5199cvOjpaJ/89qwplS8S7tkK5kjrvfyku5Dp24j9JUvn7ri1fpoTMZlPc+XvdvBWsa9dv6MS/ZzV55icKDrmt6tUqOVTXhOsfJBdnZ7k43x1VeezkfypXuni8UWkVy5VSaFiYzpy/mHSZgdclSbnv+Vzv+fNvubu56tKVa+r00htq8vTLeqJdb733wWfxAlxJKlemhGw2mw4ePv7AbQMAAACAzICppgYIDg7RlavX5FfXN965m7eCFRV1d6SIi4uzXJztFyA3mUx6olFtrd+0U31e7ChJ+uW3HWpYr3qy0wGbN66rxctW6cChY6pauZw2bPldzk7Z1KC2j37fcyBF7bhxM2a0yu3QMO3df0jfrv5VeXLl1OOPlZck2Ww2vffBZ/KpUkEz3x4et87ZM62aqGufEZq/eLlmTXlTUszoJ7PZrHkzx8nrzgjApn611Ln3CIfr45E7p2ZMGiaTyaQObZrp3IUAfbFijZ5p2SRuauHTLZuofffX9OO6zWrZrIEk6a+/j2rV2k0aP2KAWjS5G0D6VK2oIaPf04Ytu+yOJ9sft0P1x76DWrl6gzzy5FK1OyMBJelqYJCGD+qpdq2axh37+ru1On3mgsaP6K8WTepJktq1aqL+b7yt+YtXqHWLhnJ3c427/tyFAH2zcJq8PT0kSbWrV9HLg9/S59+s1uC+MSPI2rd5Ql06trSrX+UKpTVuyof66++jqnbn1yhWwXxeeu9/r0uSOrZtJjc3V61c/au6dmxpt8FHSri6uKhJg5qaOvszlS5RRE82rZ/k9f4BV/TJ59+qz4sd1aPz03HHG9WvrhcHjNG3q39Vj85P698z53Xh4mW7qZJSwtM17/ff2QsqkM/LofrvP/iP/j5ywq4uN24GKzwiQnk9cse73vPOsStXr8ndzVVXAq/LYjbLI3cuu+uyZbMqV44cuhJ4LV4ZLw8erzPn/CVJbq4u6tHlabV58sGmY549f1Gbtu9Wkwa1ZLHcDdmuBl6P9+t/f/1Ll0h4Q4egG7e0au0mVatczm6k7tnzAYqKitaI8TPV5smG6t+zk/YdOKLlP6zTreBgTRg50K6cQvljfg1Onzmv+rUff6D2AQAAAEBmQPBmgNgRMfdPbZOkV4a9reOnzsS9H/hyZ3V9tlW865o3rqsvV/ykw0dPKkd2dx05dkr9ej6X7LNLFi+s0iWKat2mnapauZzWbdypBnV8HmidsU4vDbN7X6pEEY0Z2ieurGMn/9PZ8xfVo/PT8aaUVa9WSWs3bFd0dLRsNmn3n4fUsG71uNBNkooUyq86Napo2+9JT8mL1ebJRnabGFQqX0p/HzluF1xYLGaVL1tCR4+fjjv229Y/lN3dTTV9Kut60N2pmLHTD/f9ddih4O3+/ihZrLDGDutr17dO2bKpdXP7IGXn7r+U1yOXmjWqE3fMarXquWeaa9yUD/XngX/swgm/Or5xoVtsOyuVL6Udu/6KC97uDWvDwsN1+3aYKt8ZXXn0xOl4wUuHts3s3j/btrlWrv5VO3bvf+DgLaU2bd+taJtNTf1q2f065M2TW0UK5dO+v46oR+enld09JoT8Y88B1a1RNUWf3aCbt+SV1yPZ6wKvB+mtd+aqYH4vu7UUw8JiRm85ZYsfcDvd2aEz7M5UzbDwcFmzJfxbqJNTNoWFRcQ7PmZoHwWH3NYF/0v6cd0WhYVFKDo6Osk10xISGhqm0W/PlrOTkwa81MnuXFh4uJwSqFdsaJ/QCDUpZrTf+Hfn6lZwiF4f0N3u3O3QUIWGhaldq6Zx5xrVr6GIiEh9/9Nv6t29o91mFjnurG13PZGpzwAAAACQVRC8GcDtzuilkNuh8c6NGNxLwSGhunY9SOPf/SjRMsqVLq5iRQpq3cadypHdTXk9cql6tYqJXn+v5o3r6Ktvf9bz7Z7UwcPH9eLzbR+oHVPGDpabm6uuB93Q8h/W6cLFy3J2uhv4nL0zZS2pdcFuBd9WeHi4wsLCVbhgvnjnEzqWmPz3rYcXG9Dk87r/uFvctMWYegboVnCIWnYakGC5167fcOj5sf1htVrk7emRYN29PPMo232hh3/AFRUpmD9euFK8SEFJ0sVLV+yO3xtg3D1WQL/ds75Y0I1bWvjFSq3f9Hu8+t8Kvn3/7SpSyL6uhQt6y2w2yf/ilXjXGuXc+Yuy2Wx6rtcbCZ63WmL6rWB+b3Vu/5S+Wvmzftm4Q9Uql1P92j56smk9ZXd3S/Y5CU21vdft0FC9MXa6Qm6H6uO3x9oF5M53As3wiPihWfidwMr5ToDl7OSkyIiEpymHh0fI2Tl+eHfvJhxPNKqjzr2HS5IG9ekiKeazeO/aaa6uLvEC/KioaI2dMkenz5zXjEnD7MLs2HqFJ1Cv2LXd7v1v+F7T5y7R73sOaNywfvF2WY29p1njOnbHmzepq+9/+k0HDx+3+9zG/hKY9Ojv9gsAAAAAD4PgzQDZ3d3k6ZFbp06fi3cuds03/4uX4527X/PGdfTdjxvk5uaipn61HR4V06xxHX302Td65/1PlStndtX0fSxlDbij2mPl4xZ0r1/bR936jtRb787VojkTZTab4wKOgS93jvcX9Vhurs5xgcXDSqz9CR2/N3yJjo5Wntw5NX5EwsFbnvsWrU/Mvf2RmMRCjdQ25u3ZOnjkuLp2bKUypYrKzcVF0Tabhox+TzZb4ovex0lgN12jRUfbZDKZNGPSsAR/ze4NmAb17aqWzf20dede7dp7UDM/WqIlX6/SJ++Pl7dX/A1JYuXKkd0udL1fRESkRk6YpZP/ntXMycNVqrj9lMucOdzllC1b3Dpn97py51jsFExPj9yKio5W4PUgu+mmERGRCrp5U54e8TdVuf9ZvlUrat3G7XHBW69B43Qx4G4Y+lK3dnr5hQ529015/xNt/2O/xo/on+D6cHk9cjtU/3t9unSlVq7+VQN6ddJTT8SfMuyZN7dO/XdOHrlz2h3Pkyvm/f19Hvs+V66H29AFAAAAAB51BG8GqVuzmlat3aRD/5xUpfKlkr8hAc0b19WCJd9KgdK4Yf0dvi+/t6eqVCyjfQeOqH3rprJaLA/0/Hu5ubropW7tNGn6fG3Y8oeaNaqjQgW8JUnu7q6q6VM50Xvz5M4lJ6dsOnchIN65hI6ltkIF82nPn4dUpVLZeOvppYUC+Tx14t8z8aYU/nc2Zq2v/N72GwGcTWDx+7Pn/ZX/zoYBN24Ga8/+Q3r5hQ52654ldN/dcwEqmN877v258wGKjrapQH7HNiFITEryu0IFvWWz2VQwv5eKFi6Q7PWlSxRR6RJF1LPLMzpw6Jj6vj5B3635TX17PJvoPcWKFNTGbbsTPBcdHa0JUz/Wnj8PadLoV+VTpUK8a8xms0qVKKwjx/6Nd+7wPydVqIB33Hp8ZUrFTNH959i/dpueHDl2StHRtkTD6HuFhYfbjVAcP2JA3HRXSXH/jcWaveBLrVm3Ra/165bohillShXTX38fjfd5O/zPSbk4O6vofSMqV6xar08+X6lO7Z7UC53aJFhmuTIltGvf37p89ZqK3RmpKSluHbvcuewDudidfosXKZRo2wEAAAAgK2BXU4N0e661XJydNXnGArvdKGPZlPR0OClmGuZr/bqpf6/nUhze9enxrF7q1k7PPt08RfclpUWTuvL29NDn3/woKWaNtEIFvPXlip8SnFYbOwXSYjGrxuOVtWXHXl2+enfB+bPnL2rn7pRt+PAgmvrVUlR0tD774rt45yKjopIcIZUa6tSoqquBQfp18+92z12+ap3cXF30eBX79di27NyrS1cC494f+uekDv1zUnVqVJUkWcyxaZf9Z2hZAjukxvp21Xq798tXrYupW/WqKW7PvZzv7KaZ3G6jktSoXg1ZzGZ9uvS7eNNBbTabgu6sBxYcHKLIqCi786VKFJHZbEpwCui9Klcso5u3gnXe/1K8c9PnLtGvm3/XG6/2UKP6ie+82rh+TR05dkpHjp2KO/bf2Qvau/+w3WYPvtUqKWeO7Fr54wa7+79bs0Euzs52YVzg9fi/B/hfvKw9+w+pQpm7u6JWrVRWNX0qx73uDd6WLv9RX674SS8+31ad2j2ZaP2b1K+pwGtB2rR9T9yx60E39dvWP1S/9uN2G7T8uul3zfxoiVo0qavBfbsmWmZTv1qSpNVrN9sdX/XzJlksFvlUtQ8xjx7/VyaTSY9VTPmuzgAAAACQmTDizSBFCuXX/94coHHvfKhOLw1T8yZ1VaZkUdlsNvlfvKx1G3fKbDbJ2yvpheCT+gt2UnyqVEhwRM/DiNkQoIXmfPKVdu7+S3VqVNWoIS9ryJip6tpnhFo195NXXg9dvhqovX8dkbubq6ZNGCpJevmF9tq176D6Dpmg9q2bKio6WitWrVfJ4oV1/OR/qVrP+/lUqaBnWjbRkq9X6/ipM6rp85isVovOnr+o37bu0pD+L9gFKqnt6ZZN9P1Pv2nS9Pn65/hpFcjnqY3bdunAoWN6rV83ux1NpZjAtd/rE9W+dVOFR0To6+9+Ua6c2dXtziYc7u5uqvZYeS39Zo0iI6PklTeP/th3MMnpyxcCLmvYW9NVu3oV/X3khNZu2K7mjes6NCorKS7OTipRtJA2bPldRQvnV84c2VWyeOF4Uzhj29WnR0d9tPAb+Qdcll9dX7m5usr/4mVt3rFHTz/VWF2fbaU9fx3W9A8Xq0mDWipaKL+ioqP186/bZDab1bh+0r9O9WpWk8Vi0e4//1ahAk3iji9buVYrV/+qyhXKyMXZSWs3bLO7r2G96nJ1iZnq2r7NE/rh540aOnaaunRsKavFqmUrf1aePLnUucPdnWRdnJ3U58UOmjZnsUZN+kC1fR/T/r+Pau2G7erb41nlynl3mmW3viNVvVollS1VTDmyu+vshYtavXazIiOj1L+X/eYICdm0fbc+/GSZihTKr+JFC8arf02fx+SRJ2a6a+MGNVX5+9J6e/p8/fvfeeXOlV0rV29QVHS0Xn6hfdw9h/45qQnTPlauHDlUvVol/fLbdrsyH6tYNi74K1e6uFq3aKgff9msqKgoPV6lvPb9dUS/bd2l7p3axFtnbte+v1WlYhnlyunYNG4AAAAAyKwI3gzkV9dXSz+eoq++/Um79h7Uj79slslkUn5vT9WtWU3tWjV56OAjrT3TsrEWffWDPv9mterUqCqfqhW14P3x+uyL77Vi1Xrdvh0mD49cqlSulJ5pdTf4KF+mhGZMGqbZC77U/CUr5O3pod7dO+j0mQv67+wFw+s9YnAvlS9TQt//9Js+XvSNLBazCuTz0pNN6qnKPQveG8HF2UkfTh2tuZ9+rZ9/3argkNsqWriAxgzto1bN/eJd/1TT+jKbTfr6u1907foNVSxXUkNfedFuba7/vTlAM+Yu0ber18tmk2r6VNaMScPUpsurCdZh0qiBmr/kW81d+LUsZos6tm2mgb07p0r7Rg55WTPmLtGseV8oIiJSL3Vrl2DwJkndO7VV0UIFtGzlz1q4NGYEordXXtX0eUwN6vhIksqULKpavlW07fd9unz1mlycnVWmZFHNmDRMlSskPYLKI08u1a1RVRs2/6FnWt79/B0/FRPu/n3kuP4+cjzefSsXz5Rr/pjgzd3NVXOnjtb7877Qoi9/kM1m0+NVKmhw367Kc98aZx3aNJPVYtWX3/6kbb/vk7enhwb37aZO7VrYXde+dVPt2LVfv+85oJDbocqTO6dq+VZW9+efVukSCffVvU7c2Qn57PmL+t97H8c7/+F7o+KCN4vFrOkTh2nOJ19q+Q+/KCwsQhXKldCYN/rYTRM9fea8IiIidS3oht6esSBemWOG9rEbcTdiUE/l986rH9dt0eYde5Tf21OD+3bT8+3t/3HgVnCIdu07qDcG9ki2XQAAAACQ2ZnCw8OSn/MIGGTE+Jk69d85Lf9senpXBZnE/oP/6JXhb2vZJ1MT3CEWxlq2cq2+WP6jli+akS5rKgIAAABARsIab0gzoWH2u5uePX9RO3bvT/Upscjaqj1WXjV9HtPSO2sRIu1ERkZq2cqf1aPL04RuAAAAACBGvCENte78ilo281Oh/N66eOmKVv64QREREVo8921GJgEAAAAAgEyHNd6QZmr7VtH6TTsVGBikbNmsqlyhtPr3fI7QDQAAAAAAZEqMeAMAAAAAAAAMwBpvAAAAAAAAgAEI3gAAAAAAAAADELylMpvNpsjISNlszOAFAAAAAADIythcIZVFRUWpQase2vTTl7Ja6V4AMfLUGJjeVQCQSV3bPSe9qwAAABxgsYWndxWQDhjxBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwgDW9KwAAAAAAAAA8iBlzl2jr7/t0MeCKFs99W2VLFUvwulVrN+nzr1fLZrPJt2pFDXu1h6xW42MxRrwBAAAAAADgkdS4QU3Nmz5W+fN5JnrNhYuXtGDxCn08fayWfzZdgdeD9P1PG9OkfgRvAAAAAAAAeCQ9/lh5eXvlTfKa37buUv3aPsrrkVsmk0ntWjXV+k0706R+TDUFAAAAAACAoaKiomWzRTt8vclklsWSOuPFAi5dtRsRVyCflwIuXU2VspND8AYAAAAAAADDREVFq9aTPZTN7Hjwlj27m/LmySWTySRJ6tCmmTq2bWZUFQ1D8AYAAAAAAADD2GzRymaO1uHr+WRz4HqTpIoK0M9fz02VDRDyeefV+QuX4t77B1xWPu+kp6emFtZ4AwAAAAAAgOFsJpNkMif7st0Z5ZZaGtevqW2/79PVwOuy2Wz6bs0GPdGwdqo+IzGMeAMAAAAAAIDxTGbFjGdLjiPj4mK8M+tT7di1X4GBQXpt1Ltyc3XRikUzNHnmAjWo7aMGdXxVqIC3Xn6hg/q+PkGS9HiVCmrXqsmDtSGF0iR4a9f9NTlls8rZyUlh4eFq1dxP3Tu1fagyJ89coBaN68m3WsVUqqU9/4uXNXH6PB078Z8K5vfSko8mG/IcAAAAAACALMFkkmPBm+PeHPxSgsdHDelt9/7plo31dMvGqfpsR6TZiLeJo15V2VLFdOlKoLr0HiHfqpVUqXypBy7v/g5MbW5urur74rO6FRyieYuWG/osAAAAAACATM+AEW8ZXZpPNfX29FCxIgV18dIVVSpfSlcDr2vG3CXyD7iisPBw+dXxVd8ez0qSDhw6pmlzFikqOloVypbU0eOnNaR/N/lUragBwyapU7sn1bBudU2cNk/ZrFad97+k8/6X5FO1gtq1aqoPP/1KAZeuyq+urwb37SZJST7vXrlyZlfVyuW076/Dado/AAAAAAAAmZIBI94yujQP3k6fuaCgGzflU6WCJGnitHnq/nxb+VSpoMioKL0xdpo2bPlDfnV8NXbyHI0b1k++1Spq7/7DWrNuS6Llnjx9VnPeGyWzyazOvYfr5q1gfTDlTUVERqrDi6+rTYtGKlm8cKLPa+pXK626AAAAAAAAIOthxJtxxk6eLZPJrDPn/DW4b1flyZ1Tt0NDtefPQwq8FhR3XcjtUJ0556//zl6QxWKJW8PNt1pFFSrgnWj5Der4yNnJSZJUqkQR1fKtIqvVKqvVqhJFC+nshYsqkN8z0ec9jBWr1uvb1eslSTZb5vlwAAAAAAAApBpGvBkndo23Xfv+1rC3psu3WiUVzO8lSVowa3xcaBbrxKkz8cowJbGdrFO2u/dbzGY5O2WLe282mxUVFa3YTCyh5z2Mjm2bqWPbZpKkyMhINWjVI9XKBgAAAAAAyBSy4Ig3c1o/sKZPZbVv3VTzFy2Xm6uLfKpW1Odfr447f/nqNV26fFVFCxdQZFSk9h04Iknad+CIzl0IeKhnJ/U8AAAAAAAAGMhkcvyVSaT5Gm+S1LNLOz3bc6j+Of6vxr/ZXx/M+0Jd+7wpmSRXF2eNGNRL3l55NXHkQE2bs1jRtmiVL1NCRQsXUPbs7g/17KSed6/Q0DA999IbioiI1K3gELXt+qqebFpfA3p1eqjnAwAAAAAAZElZcMSbKTw8LMO2JjjkttzdXCVJh4+e1PDxM7TisxlycXFO55olLnaq6aafvpTVmi65JoAMKE+NgeldBQCZ1LXdc9K7CgAAwAEWW3h6VyHdxGYlhyLKydHgrVK2o9q6ZtEjn61k6Npv2rZby1aulU02WSxmjRvWP0OHbgAAAAAAAEhEFhzxlqGDt1bN/dSquV96VwMAAAAAAAAPi+ANAAAAAAAAMIDZJMeCt8yD4A0AAAAAAADGY8QbAAAAAAAAYASTZHIgeMs8uRvBGwAAAAAAANKAyexY8CZbpgnfCN4AAAAAAABgPJODI94kgjcAAAAAAADAYSbTnXXekhNteFXSCsEbAAAAAAAAjOfwiLfMs/MpwRsAAAAAAACMZzI7OOIt8yB4AwAAAAAAgPEY8QYAAAAAAAAYgBFvAAAAAAAAgAEY8QYAAAAAAAAYgBFvAAAAAAAAgAEI3gAAAAAAAAADMNUUAAAAAAAAMAAj3gAAAAAAAAADMOINAAAAAAAAMIDZ4tiINxvBGwAAAAAAAOAwEyPeAAAAAAAAgNRH8AYAAAAAAAAYwaTMlKk5hOANAAAAAAAAhmPEGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAAjsLkCAAAAAAAAkPoY8QYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADACGyuAAAAAAAAAKQ+RrwBAAAAAAAABjAqeDt7/qImTJ2noBs3ld3dVWOG9lXJ4oXtromOjtbsBV/q9z0HZLFYlCtHdr352ksqUih/ip6VUgRvAJAGru2ek95VAAAAyPTy1BiY3lUAEnVj14z0rkK6Myp4e3fWQj3TsrFaNffTb1t3adL0eVo4e6LdNVt/36cDh47r848my2q16rMvv9fHn32jt8cMStGzUspsaOkAAAAAAACAdHeNN0deDgq8HqQjx0+pRdN6kqTG9Wso4HKgzp6/eN+jTYqIiFBYeIRsNpuCQ27L28vj4duUDEa8AQAAAAAAwHBGjHi7dDlQnh65ZbVY4p6RzyuvAi5ftZtGWr/249r712G1fn6g3Nxc5JU3j+ZOG5PSJqQYwRsAAAAAAAAMl9LgrVu/kTH3SOrQppk6tm32wM8+cuxfnTp9Tqu+/EDubq6au/BrvffBQo0fMeCBy3QEwRsAAAAAAAAMl9LgbenHU2S1Jh1deXt56ErgdUVGRclqschmsyng8lXl88prd93Pv26Tb7WKypHdXZLU8okGGjzq3QdqR0qwxhsAAAAAAAAMZzKZHH45yiN3LpUrXVy/bNguSdq4bbe8PT3i7VZaqICX9u4/rIiISEnS9j/+VKn7dj41AiPeAAAAAAAAYLwUbpzgqBGDemnS9PlavGyV3N1cNXpoH0nS5JkL1KC2jxrU8VWHNs10+swFvdB/lKxWi/LmyaXhg3qlfmXuQ/AGAAAAAAAAwxmxuYIkFStSUAveHx/v+KghveN+7uSUTSOHvJyiclMDwRsAAAAAAAAMZ1TwlpERvAEAAAAAAMBwBG8AAAAAAACAEQxa4y0jI3gDAAAAAACA4RjxBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAIbK4AAAAAAAAApD5GvAEAAAAAAAAGIHgDAAAAAAAADGA2Oxi82QjeAAAAAAAAAIeZ4v4nGTaDK5KGCN4AAAAAAABgOIenmjo0HfXRQPAGAAAAAAAAw5kc3dU08+RuBG8AAAAAAAAwntlsksxZK3kjeAMAAAAAAIDhGPEGAAAAAAAAGIA13gAAAAAAAAADMOINAAAAAAAAMAAj3gAAAAAAAAADxIx4cyR4M7wqaYbgDQAAAAAAAIZjqikAAAAAAABgAKaaAgAAAAAAAAZgxBsAAAAAAABgAEa8AQAAAAAAAAZgxBsAAAAAAABgBJMpZtRbMmyMeAMAAAAAAAAc5+hMU5kkm+G1SRtpEry16/6anLJZ5ezkpLDwcLVq7qfundo+VJmTZy5Qi8b15FutYirV0t6e/Yc099OvdTs0VCaZVLdWNQ3o1Ulms9mQ5wEAAAAAAGRmJgdHvMlkInhLqYmjXlXZUsV06UqguvQeId+qlVSpfKkHLm/UkN6pWLv4cmR318RRA1WogLfCwsM16M139POv29SquZ+hzwUAAAAAAMiMUjLiLbNI86mm3p4eKlakoC5euqJK5UvpauB1zZi7RP4BVxQWHi6/Or7q2+NZSdKBQ8c0bc4iRUVHq0LZkjp6/LSG9O8mn6oVNWDYJHVq96Qa1q2uidPmKZvVqvP+l3Te/5J8qlZQu1ZN9eGnXyng0lX51fXV4L7dJCnJ592rXOnicT93dnJSmZLF5B9wOU36CAAAAAAAILNJyYi3zCLNg7fTZy4o6MZN+VSpIEmaOG2euj/fVj5VKigyKkpvjJ2mDVv+kF8dX42dPEfjhvWTb7WK2rv/sNas25JouSdPn9Wc90bJbDKrc+/hunkrWB9MeVMRkZHq8OLratOikUoWL5zo85r61Uq07KuB17Vx2y5NmzA01fsDAAAAAAAgK2DEm4HGTp4tk8msM+f8NbhvV+XJnVO3Q0O1589DCrwWFHddyO1QnTnnr//OXpDFYolbw823WkUVKuCdaPkN6vjI2clJklSqRBHV8q0iq9Uqq9WqEkUL6eyFiyqQ3zPR5yUmODhEw96arm7PtlKFsiUTvGbFqvX6dvV6SZLNlllmIQMAAAAAAKQeRrwZKHaNt137/tawt6bLt1olFczvJUlaMGt8XGgW68SpM/HKSOoXxynb3fstZrOcnbLFvTebzYqKilZsJpbQ8xISHHJbr42eqgZ1fNW5Q8tEr+vYtpk6tm0mSYqMjFSDVj2SLRsAAAAAACAryYoj3tJ8i86aPpXVvnVTzV+0XG6uLvKpWlGff7067vzlq9d06fJVFS1cQJFRkdp34Igkad+BIzp3IeChnp3U8+4XcjtUQ0a/p9rVq6hnl2ce6rkAAAAAAABZXeyIN0demUWar/EmST27tNOzPYfqn+P/avyb/fXBvC/Utc+bkklydXHWiEG95O2VVxNHDtS0OYsVbYtW+TIlVLRwAWXP7v5Qz07qeff65rtfdPjoKYWGhmnz9t2SpCYNaqlHl6cf6vkAAAAAAABZUVacamoKDw/LsIuSBYfclrubqyTp8NGTGj5+hlZ8NkMuLs7pXLPExU413fTTl7Ja0yXXBAAAAIAsKU+NgeldBSBRN3bNSO8qpJvYrMSt1UCZzJZkr7dFRylkzRxtXbPokc9WMnTtN23brWUr18ommywWs8YN65+hQzcAAAAAAAAkLCuOeMvQwVur5n5q1dwvvasBAAAAAACAh5QVN1fI0MEbAAAAAAAAMgdGvAEAAAAAAAAGyIoj3szpXQEAAAAAAABkfmaTyeFXRrJ0+Y8KvB70QPcy4g0AAAAAAACGM2rE29nzFzVh6jwF3bip7O6uGjO0r0oWLxzvuhP/ntWMuYsVeO2GJKlfj2fVqH6NZMvfu/+wFiz5VjV9KqtNi0aqV+txWSyOjWUjeAMAAAAAAIDhjFrj7d1ZC/VMy8Zq1dxPv23dpUnT52nh7Il214SGhmnE+BkaN6yfqlYup6ioaN24ecuh8me+PVyXrgRq7YZtmrvwa70z61M92aSeWrXwU6niRZK8l6mmAAAAAAAAMJzZ5PjLUYHXg3Tk+Cm1aFpPktS4fg0FXA7U2fMX7a5bt3GHKpUvraqVy0mSLBaz8uTO6fBzvD091L1TWy375D29+9YQ7fnrsLr3H6Ver47TmnVbFB0dneB9jHgDAAAAAACA4cxmk0wOpGq2FMw1vXQ5UJ4euWW1WCTFjKrL55VXAZevqkih/HHX/XvmvJyyWTV07DRdvhKoUiWKalCfLikK3/wDruin9Vv1869bZbPZ9FK39iqQz0vLf/hFW3/fp3fGvRbvHoI3AAAAAAAAGM5054cjV0pSt34j46amdmjTTB3bNnvgZ0dFRWv3n4e0YNZ4eeXNo48++0ZTZ3+myWMHJ3vvT+u3as26LTpy7JQa1PHViMG9VOPxynHnG9arrtbPv5LgvQRvAAAAAAAAMJzZwc0VbHeuWfrxFFmtSUdX3l4euhJ4XZFRUbJaLLLZbAq4fFX5vPLaXZfPK698qlaUt6eHJOnJJvX02uh3Har319+vVZsWjfTOW68pR3b3eOfdXF00fFDPBO9ljTcAAAAAAAAYLnZzBUdejvLInUvlShfXLxu2S5I2btstb08Pu2mmktS0YS0dOXZKwcEhkqQdu/erTMmiDj2ja8dW6ti2WbzQbf2mnXE/f7Jp/QTvZcQbAAAAAAAADGdycMRbCpZ4kySNGNRLk6bP1+Jlq+Tu5qrRQ/tIkibPXKAGtX3UoI6v8nt76sXn26rPkAkymU3yyptHbw5+yaHy3/1goZo3rhvv+NTZi9SsUZ0k73UoeNu7/7DWbdyhq9eCNG3CUB05dkohIaHyrVbRoQoCAAAAAAAgazM7OJrNloIRb5JUrEhBLXh/fLzjo4b0tnv/1BP19dQTCY9MS0js6DjZpOCQ25LNFnfunP8lWa2WZMtINnhb9fNGfbJ0pVo189OGLX/E3GSxaMGSFfKtNs7hygIAAAAAACDrMmrEm1GadegbV9/mHfrYnTOZzHqpW7tky0g2eFu6fI1mTX5TJYoV0rer10uSShQrpNNnLzxAlQEAAAAAAJAVObx+WwpHvBnl28UzJZtNLw1+S59+MCHuuNlkUu7cOeTs5JRsGckGb0E3bqlEsUJ33t1peAoXugMAAAAAAEDW9qiNeCuQz1OS9NPXcx+4jGSDtzIli2rj1l1q3KBm3LFtO/epXOniD/xQAAAAAAAAZC1GrfFmhLkLv9aAXp0kSbPmLU30usF9uyVZTrLB26u9O2vwqHe1buNOhYWFa9yUD7X3r8N6/+3hKawyAAAAAAAAsiqTMsxgtmTduhUS9/ObN4MfuJxkg7dyZUroy/nv6udftymvR27l8/LQq326yCtvngd+KAAAAAAAALKWR2mNt+GDesb9fMwbfR+4nGSDN0nyyJNLXZ9t9cAPAQAAAAAAQNZmdnCNN1v6524KDg5J/iJJ7u5uSZ53KHjbvGOPjh4/rduhoXbHk5vHCgAAAAAAAEiP1oi3Zh36JlkNmy2mmtt//jzJcpIN3ibPXKDtf+zX44+Vl4tz8tukAgAAAAAAAPd7lHY1/XbxzFQpJ9ngbdO23fpy/rvyZE03AAAAAAAAPKBHacRbgXyeqVJOssGbl6eHnBnpBgAAAAAAgIfwKK3xNnfh1xrQq5Mkada8pYlel9wybMkGbyMG9dJ7H3ymNk82kkfunHbnSpcs6khdAQAAAAAAkMU9SiPebt26u7nCzZvBD1xOssHbpSuB+n3PAW3Y8ofdcUcWkAMAAAAAAACkmKXb0j9Sc8zwQT3jfj7mjb4PXE6ywdusj5dqUN+uataoDpsrAAAAAAAA4IGY5diIN1sGjOcuXLykdRt36vLVa/LKm0fNGtVRoQLeyd5nTu6CyKgotWrWgNANAAAAAAAADyx2V1NHXhnJ5h171Ln3CB04dEy2aJsOHj6mrn3f1Kbtu5O9N9kRb+1bP6GVP25Qx7bNUqWyAAAAAAAAyHoepTXe7jX302V6e/Qg1a/9eNyx7X/8qVnzvlCjejWSvDfZ4G3r7/t06vQ5LV62Sh557DdXWPzh2w9YZQAAAAAAAGQlDo9my1i5m64GBqluzap2x2pXr6q33pmb7L3JBm+d2rV48JoBAAAAAAAAihnxZnYgeYvOYCPemvjV1I+/bFbbpxrHHVuzfoua+tVK9t5kg7dWzfwernYAAAAAAADI8hwd8ZYRcrcR/5sZNy02MjJK781epK+/+0X58+XVxYCrOnPeX7WrV0m2nASDtx279qtuzWqSpK079yZ6c4M6vg9Q9azBq85gZbixkQDSzbXdc9K7CgAAAJkef+ZChmYLT+8apDtH13hzaB04g5UtVczufYWyJeJ+XrFcKYfLSTB4+/CTZXHB28yPliZ4o8lE8AYAAAAAAADHmO+8HgUvdWufKuUkGLx9Mf+duJ+vXDIzVR4EAAAAAACArOtRGvGWkCtXr+n6jVuSzRZ3rHTJoknek+wabwAAAAAAAMDDMptiXsnKYLnbiVNnNPrt2Tp7/qJMppjcLTYb3P7z50nem2zw1r77kAQXtcuWLZvye+dVE79aatOiYYZNIwEAAAAAAJD+HtXgbfrcJapTo6o+mTVeHV4copVL3tdHC79WlUplk7032am1T7dsLJPJpPatn1D/Xp3UrnVTWSwWNW9cRz5VK2jBkm+18IvvU6MdAAAAAAAAyKRip5o68spITv57Rq+89LxyZHeXzSZld3fTKy931vzFK5K9N9kRb5u379bMt4erSKH8ccca1q2ut975UAtnT1RNn8c0etIHeqlbu4drBQAAAAAAADKtR3XEm9VqVbQtWpKUI7u7rly9puzubroedDP5e5O74My5i8rv7Wl3zNvLQ2fPB0iSypcpoWvXbzxIvQEAAAAAAJBFmExKcDmzhK7LSB6rUEbbfv9TTf1qqU6NKho5cZacsmVThXIlk7032eCtUvlSmj53sQb0el45c7gr6MYtffzZN6pQNqbw/85eUJ7cOR++FQAAAAAAAMi0rCaTzA6katEZLHkb/2Z/RUfH7GQ6qG9XfbniJ4WEhKpzh6eSvTfZ4G300D56a8qHevLZfnJ2clJ4RLiqVCyr/705QJIUGhau4YN6PWQTAAAAAAAAkJk9qiPeXF1c4n7u7OSknl2ecfjeZIM3b08PfTR9rC5dvqrLV6/LK29ueXvljTtfrnTxFFUWAAAAAAAAWY/ZwRFvGS15i4yK0pJlq7R2w3ZdvnJNXp551KJJPb34fBtZrUlHa8kGb7EP8L90VZcvB6pS+VK6HRoqyT7xAwAAAAAAABLzqI54m/nR5zp4+Lj6vNhRBfJ5yj/gij7/ZrUCrwdp2MAeSd6bbPB2+swFDXtrusLCw3XrVoieaFRbe/48pPWbdmrCyIGp1QYAAAAAAABkYo/qrqa/bflDSz+eorweuSVJlcqXVtXK5fRCv5HJBm/m5AqfNmeRnnumhVZ9MVtWq0WS5FOlgv76+9hDVxwAAAAAAABZQ+xUU0deGYmri4tcXJzvO+YsN1fXZO9NNng7dvI/dWjzxJ13MQ13d3dTyO3QlNcUAAAAAAAAWVLsVFNHXuktODgk7tWjc1uNm/Kh/jn+r65dv6Ejx07pf+99pB5dnk62nGSnmnrkySX/gCsqVMA77tiZc/7y9vR4uBYAAAAAAAAgy3iUppo269A3LgC02WL+f+fuv2Qy3X2/Y9d+tX2yUZLlJBu8tW/dVCMnzlLv7h0UHR2tP/Ye1PzFK9ShbbOHqT8AAAAAAACyENOdH45cl96+XTwzVcpJNnh77pkWsljM+njhN4qOjtb7H3+uDm2aqX7tx1OlAgAAAAAAAMj8HqURbwXyeSZ4/HrQTeXOlcPhcpIN3oJu3FS7Vk3VoU3MCLcrV69p8bJVeq7XV9q0aqHDDwIAAAAAAEDW9SgFb/cKDQ3T+/OWau2G7YqIiFC2bNn0VNP6GtS3i1xdXJK8N9Hg7Z/j/2rkhPd16UqgcuXMoXfGvaYTp87ow4XL5FOlgua8OyrVGwIAAAAAAIDMyWQyyeTAzgmOXJOWPpj/pc6eu6jZ74xUoQLeunDxsj5e9I1mz/9Kwwf1TPLeRIO32fO/1BMN66hlswZatXajRk/6QF6eeTR36hiVK108tdsAAAAAAACATOxRHfG29fd9WvrxFOXKmV1SzEakb49+Vd36jkw2eDMnduLk6bPq2/NZlShWSH17PKfA60F6b/zrhG4AAAAAAABIMZPJ8VeGYrPJfF9iaDKZZZMt2VsTHfEWERkpq8UiSXJxdpK7m5s88+Z5yJoCAAAAAAAgKzKbTDI7kqqlMHk7e/6iJkydp6AbN5Xd3VVjhvZVyeKFE7zWZrPp1RFTdPTEaa1fOd+h8uvVelyjJn6gAS91Un5vT/kHXNa8RctVv5ZPsvcmGrxFRkTpm+9/iXsfERFp916K2fEUAAAAAAAASI5RU03fnbVQz7RsrFbN/fTb1l2aNH2eFs6emOC1y1b+rEIFvHX0xGmHyx/Ut6tmzF2ifq9PVGRUpKxWq5o1qqNX+3RJ9t5Eg7dKFUpp8/Y9ce8rlitp995kMhG8AQAAAAAAwCGOTiNNyYC3wOtBOnL8lN6fMkKS1Lh+DU3/cLHOnr+oIoXy21176vQ5bdmxV6OH9tFvW3c5VH5kVJR+Wr9VbwzsodGv99a1oBvKkyunwxtAJBq8zZ06xqECAAAAAAAAgOSYZZLZoeFsjidvly4HytMjd9xyaSaTSfm88irg8lW74C0yMlJT3v9Uo19/WRZzolsexGO1WDRv0XJ1bNtMkuSRO5fD90pJBG8AAAAAAABAaknpiLdu/UbGjSzr0KZZXPj1ID5d+p0a1auu4kULyf/i5RTdW8v3Me3a97dq+lRO8XMJ3gAAAAAAAGC4lK7xtvTjKbJak46uvL08dCXwuiKjomS1WGSz2RRw+aryeeW1u+7PA0cUcPmqVqxer6ioKAWH3Fa77q9p4QcTlCd3ziSf4ebmojf/N1M1fR9TPq+8djucDu7bLcl7Cd4AAAAAAABgOCN2NfXInUvlShfXLxu2q1VzP23ctlvenh7x1nf7eMa4uJ/7X7ys7gNG67sl7zv0jGvXb6hJg5qSpODgEIfrJhG8AQAAAAAAIC04ONU0pbuajhjUS5Omz9fiZavk7uaq0UP7SJImz1ygBrV91KCOb8rrKuno8X81fPxMXb56TQXyeeq9/72uUsWLpKgMgjcAAAAAAAAYztERb7aUbGsqqViRglrw/vh4x0cN6Z3g9QXye2n9yvnJljt7wVdq4ldTbVo00g8/b9SHnyzTjEnDUlQ3x7dxAAAAAAAAAB5Q7OYKjrwyghP/ntGAXs+rZPHC6t/zOR0/+V+Ky2DEGwAAAAAAAAxnlmMjwGxGV8RBEZGRypYtJjpzcXFWWHhEissgeAMAAAAAAIDhTCaTTA4MZ3PkmrQQGRGlb77/Je59eESE3XtJeu6ZFkmWQfAGAAAAAAAAw5nk2L4JGSN2kypVKKXN2/fcfV/O/r3JZCJ4AwAAAAAAQPozanMFo8ydOuahy0iT4K1d99fklM0qZycnhYWHq1VzP3Xv1Pahypw8c4FaNK4n32oVU6mW9g4ePq6psz+TJEVGRqlK5bJ6vX93OTllM+R5AAAAAAAAmdmjNuItNaTZiLeJo15V2VLFdOlKoLr0HiHfqpVUqXypBy4vsS1hU0uZkkW1cPYEWa1WRUdHa+TEWfr2x1/Vuf1Thj4XAAAAAAAgM3J0x9IMMuAtVaT5VFNvTw8VK1JQFy9dUaXypXQ18LpmzF0i/4ArCgsPl18dX/Xt8awk6cChY5o2Z5GioqNVoWxJHT1+WkP6d5NP1YoaMGySOrV7Ug3rVtfEafOUzWrVef9LOu9/ST5VK6hdq6b68NOvFHDpqvzq+mpw326SlOTz7uXi4hz384jISIWFhcuUqTJXAAAAAACAtPOoba6QGtI8eDt95oKCbtyUT5UKkqSJ0+ap+/Nt5VOlgiKjovTG2GnasOUP+dXx1djJczRuWD/5VquovfsPa826LYmWe/L0Wc15b5TMJrM69x6um7eC9cGUNxURGakOL76uNi0aqWTxwok+r6lfrXhl+l+8rOHjZ+q8f4Dq1qymDm2eMKxfAAAAAAAAMjPznVdybEZXJA2lWfA2dvJsmUxmnTnnr8F9uypP7py6HRqqPX8eUuC1oLjrQm6H6sw5f/139oIsFkvcGm6+1SqqUAHvRMtvUMdHzk5OkqRSJYqolm8VWa1WWa1WlShaSGcvXFSB/J6JPi8hBfJ76fOPJyvkdqj+9+5H2rR9t5o1qhPvuhWr1uvb1eslSTZbZvp4AAAAAAAApA5GvBkodo23Xfv+1rC3psu3WiUVzO8lSVowa3xcaBbrxKkz8cpIquOdst2932I2y/meTRDMZrOioqIVm4kl9LykuLm66IlGtfXLbzsSDN46tm2mjm2bSZIiIyPVoFUPh8sGAAAAAADICrLi5gqOjPBLVTV9Kqt966aav2i53Fxd5FO1oj7/enXc+ctXr+nS5asqWriAIqMite/AEUnSvgNHdO5CwEM9O6nn3e/s+YuKjIyUJEVERGrz9j0qXaLIQz0fAAAAAAAgq7KYTA6/Mos0X+NNknp2aadnew7VP8f/1fg3++uDeV+oa583JZPk6uKsEYN6ydsrryaOHKhpcxYr2hat8mVKqGjhAsqe3f2hnp3U8+6196/DWv79ujuj5aJU/fFK6tn1mYd6NgAAAAAAQFaVFaeamsLDwzLsomTBIbfl7uYqSTp89KSGj5+hFZ/NsNtxNKOJnWp66JqXMtfgSAAP49ruOeldBQAAAADpyGILT+8qpJvYrGTk9JmyWCzJXh8VFaUpQ4do65pFslrTZcxYqsnQtd+0bbeWrVwrm2yyWMwaN6x/hg7dAAAAAAAAkDCTKeblyHWZRYYO3lo191Or5n7pXQ0AAAAAAAA8JLNMMjswO9CWiWYQZujgDQAAAAAAAJkDI94AAAAAAAAAA5ju/HDkusyC4A0AAAAAAACGY8QbAAAAAAAAYADWeAMAAAAAAAAMwIg3AAAAAAAAwAAEbwAAAAAAAIAB2FwBAAAAAAAAMIDZFPNKji3z5G4EbwAAAAAAADAeI94AAAAAAAAAA7DGGwAAAAAAAGAARrwBAAAAAAAABmCNNwAAAAAAAMAAjHgDAAAAAAAADMAabwAAAAAAAIABTHdejlyXWRC8AQAAAAAAwHBmSWYHhrPZjK9KmiF4AwAAAAAAgOEY8QYAAAAAAAAYIQsmbwRvAAAAAAAAMBy7mgIAAAAAAAAGYFdTAAAAAAAAwABZcKYpwRsAAAAAAADSQBZM3gjeAAAAAAAAYDjWeAMAAAAAAAAMwBpvAAAAAAAAgEGMyNTOnr+oCVPnKejGTWV3d9WYoX1Vsnhhu2v27D+kuZ9+rduhoTLJpLq1qmlAr04ym80G1OguY0sHAAAAAAAApLtrvDnySoF3Zy3UMy0b65uF09TtuTaaNH1evGtyZHfXxFED9dWC9/TZhxN18PBx/fzrtodqjiMI3gAAAAAAAGA4Uwp+OCrwepCOHD+lFk3rSZIa16+hgMuBOnv+ot115UoXV6EC3pIkZycnlSlZTP4Bl1OvcYkgeAMAAAAAAIDhYtd4c+TlqEuXA+XpkVtWi+XOM0zK55VXAZevJnrP1cDr2rhtl+rVevxhm5Qs1ngDAAAAAACA4RydRRp7Tbd+I2W6k8J1aNNMHds2e+g6BAeHaNhb09Xt2VaqULbkQ5eXHII3AAAAAAAAGM5kMsUFacldJ0lLP54iqzXp6Mrby0NXAq8rMipKVotFNptNAZevKp9X3njXBofc1mujp6pBHV917tDywRqRQkw1BQAAAAAAgOGMmGrqkTuXypUurl82bJckbdy2W96eHipSKL/ddSG3QzVk9HuqXb2KenZ5JhVblTRGvBnk8s5ZyaayAAAADytPjYHpXQUAyDCu7Z6T3lUAkISUTjV11IhBvTRp+nwtXrZK7m6uGj20jyRp8swFalDbRw3q+Oqb737R4aOnFBoaps3bd0uSmjSopR5dnk7h01KGZAgAAAAAAADGMyh5K1akoBa8Pz7e8VFDesf9vEeXpw0P2RJC8AYAAAAAAADDme78cOS6zILgDQAAAAAAAIZzdP22lKzxltERvAEAAAAAAMBwRq3xlpERvAEAAAAAAMB4WTB5I3gDAAAAAACA4VjjDQAAAAAAADAAa7wBAAAAAAAABsiCM00J3gAAAAAAAJAGsmDyRvAGAAAAAAAAw7HGGwAAAAAAAGAA1ngDAAAAAAAADJAFZ5oSvAEAAAAAACANZMHkjeANAAAAAAAAhmONNwAAAAAAAMAArPEGAAAAAAAAGCALzjQleAMAAAAAAEAayILJG8EbAAAAAAAADMcabwAAAAAAAIABWOMNAAAAAAAAMEAWnGlK8AYAAAAAAADjMeINAAAAAAAAMETWG/NG8AYAAAAAAADDMeINAAAAAAAAMEDWG+9G8AYAAAAAAIA0wIg3AAAAAAAAwACmOz8cuS6zIHgDAAAAAACA8bLgXFOCNwAAAAAAABguC+ZuBG8AAAAAAAAwHmu8AQAAAAAAAAZgjTcAAAAAAADAAIx4AwAAAAAAAAxA8AYAAAAAAAAYgKmmAAAAAAAAgAEY8WaQdt1fk1M2q5ydnBQWHq5Wzf3UvVPbhypz8swFatG4nnyrVUylWibMZrPp1RFTdPTEaa1fOd/QZwEAAAAAACDzSLMRbxNHvaqypYrp0pVAdek9Qr5VK6lS+VIPXN6oIb1TsXaJW7byZxUq4K2jJ06nyfMAAAAAAAAyI0a8pQFvTw8VK1JQFy9dUaXypXQ18LpmzF0i/4ArCgsPl18dX/Xt8awk6cChY5o2Z5GioqNVoWxJHT1+WkP6d5NP1YoaMGySOrV7Ug3rVtfEafOUzWrVef9LOu9/ST5VK6hdq6b68NOvFHDpqvzq+mpw326SlOTz7nfq9Dlt2bFXo4f20W9bd6VZHwEAAAAAAGQ2rPGWBk6fuaCgGzflU6WCJGnitHnq/nxb+VSpoMioKL0xdpo2bPlDfnV8NXbyHI0b1k++1Spq7/7DWrNuS6Llnjx9VnPeGyWzyazOvYfr5q1gfTDlTUVERqrDi6+rTYtGKlm8cKLPa+pXy668yMhITXn/U41+/WVZzGZD+wQAAAAAACCzY8SbgcZOni2Tyawz5/w1uG9X5cmdU7dDQ7Xnz0MKvBYUd13I7VCdOeev/85ekMViiVvDzbdaRRUq4J1o+Q3q+MjZyUmSVKpEEdXyrSKr1Sqr1aoSRQvp7IWLKpDfM9Hn3e/Tpd+pUb3qKl60kPwvXk6ybStWrde3q9dLilkTDgAAAAAAAPZMd16OXJdZpPkab7v2/a1hb02Xb7VKKpjfS5K0YNb4uNAs1olTZ+KVYUoi8nTKdvd+i9ksZ6dsce/NZrOioqIVm4kl9Lz7/XngiAIuX9WK1esVFRWl4JDbatf9NS38YILy5M5pd23Hts3UsW0zSTEj5Rq06pFk2QAAAAAAAFlOFkze0nwOZU2fymrfuqnmL1ouN1cX+VStqM+/Xh13/vLVa7p0+aqKFi6gyKhI7TtwRJK078ARnbsQ8FDPTup59/t4xjh99/ksfbfkfc2bPk7ubq76bsn78UI3AAAAAAAAJM+Ugh+ZRZqv8SZJPbu007M9h+qf4/9q/Jv99cG8L9S1z5uSSXJ1cdaIQb3k7ZVXE0cO1LQ5ixVti1b5MiVUtHABZc/u/lDPTup5AAAAAAAAMEZWXOPNFB4elmEXJQsOuS13N1dJ0uGjJzV8/Ayt+GyGXFyc07lmiYudarrppy9ltaZLrgkAALKQPDUGpncVACDDuLZ7TnpXAUiUxRae3lVIN7FZyW8/fuFQVhIZGakmrbtq65pFDl1/9vxFTZg6T0E3biq7u6vGDO2rksULx7tu1dpN+vzr1bLZbPKtWlHDXu1heHaToZOhTdt2a9nKtbLJJovFrHHD+mfo0A0AAAAAAACJMGiNt3dnLdQzLRurVXM//bZ1lyZNn6eFsyfaXXPh4iUtWLxCiz6cJI88uTR8/Ax9/9PGuDX7jZKhg7dWzf3UqrlfelcDAAAAAAAAD8nR9dtSssZb4PUgHTl+Su9PGSFJaly/hqZ/uFhnz19UkUL54677besu1a/to7weuSVJ7Vo11eJlq7J28AYAAAAAAIDMISoqyqH126Kiohwu89LlQHl65JbVYpEkmUwm5fPKq4DLV+2Ct4BLV5U/n2fc+wL5vBRwKf5mm6mN4A0AAAAAAACGMZnM8vb00BNtX3D4nuzZ3dSt30iZ7iR1Hdo0M3x0mhEI3gAAAAAAAGAYi8WslUvel80W7fA9JpNZFos52eu8vTx0JfC6IqOiZLVYZLPZFHD5qvJ55bW7Lp93Xp2/cCnuvX/AZeXzznt/caku+RYAAAAAAAAAD8FiMctqtTr8ciR0kySP3LlUrnRx/bJhuyRp47bd8vb0sJtmKkmN69fUtt/36WrgddlsNn23ZoOeaFg71dt5P0a8AQAAAAAA4JE1YlAvTZo+X4uXrZK7m6tGD+0jSZo8c4Ea1PZRgzq+KlTAWy+/0EF9X58gSXq8SgW1a9XE8LqZwsPDbIY/JQuJjIxUg1Y9tOmnL2W1kmsCAABj5akxML2rAAAZxrXdc9K7CkCiLLbw9K4C0gFTTQEAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADWNO7ApmNzWaTJEVGRqZzTQAAQNZgS+8KAECGwd/DkJGZzTaZTKb0rgbSmCk8PIw/raWi0NBQNX765fSuBgAAAAAAyEC2rlkkq5XxT1kNwVsqi46OVnh4uCwWi17oP0pLP56S3lXK1Lr1G0kfpwH62Xj0cdqgn9MG/Ww8+jht0M9pg342Hn2cNujntPEo97PFYmHEWxZE1JrKzGazXFxcJEkmk4k022D0cdqgn41HH6cN+jlt0M/Go4/TBv2cNuhn49HHaYN+Thv0Mx41bK4AAAAAAAAAGIDgzUAd2jRL7ypkevRx2qCfjUcfpw36OW3Qz8ajj9MG/Zw26Gfj0cdpg35OG/QzHjWs8QYAAAAAAAAYgBFvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABmAP3mSEh0do+oeLtfvPQwq6cVOeefOo23Ot1aZFQ0lScHCI3v3gM23f9aecnZzUsW0z9eraLu7+5M6PmjhLBw4f0+3QMOXKkUNtnmyonl2eSetmpiuj+3jAsEn6+8gJWS2WuGNfL5wmr7x50q6RGYCR/Xzx0hV16T0i3vPq1Kyqqf8bmnaNTGdGf5b/Of6vZn70uU78e0a5c+bQS93aq2WzBmnezvT2sP08b/FybdmxV/+duaAObZtpSP8X7Mp/5/1P9efBIzp7PkCD+nTV8+2fTNP2ZRRG9nN4eIReG/2uTv93QWER4fL0yKPOHZ7SMy2bpHk705PRn+V23V9T4LUgWcwx/85qsVi0fuX8tGtgBmFkP+8/+I9eHzPV7nmhYeHq2LaZXh/QPW0amEEY/XnetfegPly4TOfOB8jby0OD+nRVnRpV07SN6e1h+jjwepBmffyF/jx4RMEht1WoQD71fqG9GtTxjSuf778YRvYz3393Gf155jsQGQnBWzKioqOU1yO3PnjnTRUq4K1D/5zU62Pek7enh2r5Pqbpc5foxs1b+v7zWbp2/YYGvfmO8nt7xv1lOLnzvbq1V9FC+eXklE0XL13RkNHvqUA+Tz3ZtH56NjtNGd3HkjSg1/NZ9g8PsYzs5/zenvrth0/jnhUREak2XQbqiYZ10qu56cLIPr55K1ivj5mql1/ooLlPjdE/x09p8Mh3VaiAt6pWLpfOLU9bD9vPhQvm08CXO+uHnzcmWH7pkkXVtGEtzVu0PC2bleEY2c8Wi0WvD3hRxYsWlNVi0b//ndcrw99W8SIFVe2x8mnd1HRj9GdZkiaMfEUN61ZPqyZlSEb2c7XHytt9/wVeC1LbroP0RMPaada+jMLIfj7vf0lvTnhfE0YOVN2aVbVj118aNfEDLZ03RYUKeKd1U9PNw/Tx7dthKluqmF55qZM88+bR9l37NW7yh1o4e4JKFCskie+/WEb2M99/dxn9eZb4DkTGwVTTZLi6uKjPix1VuGA+mUwmVa5QWj5VK+qvv48qNDRMv27+XX17PKsc2d1VtHABdXy6mVb/slmSkj0vSaVLFJGTUzZJkkkmmU1mnT0fkC5tTS9G9zFipGU/b96xR9HRNjWqn7W+6Izs44OHj8spWza1b91UFotZlcqXVqN61bVq7aZ0bHH6eJh+lqRWzfxUp0ZVubu5Jlh+x7bNVOPxynG/N2dVRvazxWJW6RJF4kYim0ySyWTSuQt8/6XmZxkx0rKff1q/VUUK5VOVSmWNbFKGZGQ//77nL5UrXVz1az8us9ms+rUfV8VyJfXzr1vTsonp7mH6uFABb3V9tpW8vfLKbDarQW0fFS2SX3//cyKufL7/YhjZz3z/3WX05xnISAjeUigsPFyHj55U6ZJF9d85f0VERKpMqWJx58uWLKaT/56RpGTPx5o6+zM1attLz7wwWCGhoWrVPOtNHbuXEX286Kvv1bxDX3UfMFo/rc9af0hLjBH9HOvHXzarRZO6cnZyMrYRGVxq9nF0tE02m82u/GibTScS+TXISlLSz3hwRvTz0LHT1LB1T3XuPUIeuXOpYb2sFdbfz4g+fnfWQj35bD/1fm28duzan8o1fjQZ+XvG6l82q02LRqlU00dbavZz4t+BZ1O1zo+ah+njwOtBOn3mgkqXKJJW1X1kGdHPfP/FZ0Q/8x2IjIKppilgs9k0ZeYnKlIwvxrVq64Dh47J1cXZbu2w7NndFBISKkm6fTs0yfOxhr3aU0NfeVFHT5zW1p37lCO7e9o0KAMyoo/79+ykEsUKycXZSXv2H9aYt2fLzc1FjerVSLuGZTBGfZYlyT/ginb/+bdeeel54xuSgaV2Hz9WsbRuh4Zp+Q/r1K5VEx06ekqbd+xRnlw507ZhGUxK+xkPxqh+nj7xDUVFReuvQ0f154F/snRYb0QfvzWsn8qXKSGz2ayN23Zr5MRZ+mjaGFUsV8qIJjwSjPw9Y//Bf3Th4iU99UTWWS4kMandzzV9KmvOgq+0ecce1av1uLb/8acOHjqmx6tUMKoJGd7D9HFERKTGTf5QTf1qqULZkmlZ7UeOUf3M9589I/qZ70BkJIx4c5DNZtPU2Yt05py/3h0/RGazWa6uLgoNC1dkVFTcdbeCb8vNzUWSkj1/L7PZrAplS8rNzUWzF3xpfIMyIKP6+LGKZZTd3U1Wq1W1q1fRM62aaMPmP9KuYRmM0Z/lNes2q2yp4nb/QpXVGNHHuXLm0NQJQ7Vu4061en6gPvp0mVo391OunDnStnEZyIP0M1LO6H62WMzyqVJBgdeD9MWKNalZ9UeGUX1c7bHycnFxlpNTNrVoUlf1az2uTdt2G9GER4LRn+XVv2xWg9o+ypObfxBJ7X4uVqSgJo4aqE+XfqeWzw3Q6rWb9USj2sqVM7tRzcjQHqaPIyIiNWrSLDk7O2nkay+nddUfKUb3M99/MYzqZ74DkZEQvDnAZrNp2pxFOnT0hN6f/Kayu7tJkooVLiCr1aITp+4OeT1+8j+VKl7EofMJiYyMynJrvElp28dmk8mgVmR8RvdzdHS01qzbojZPNjK+MRmUkX1ctVJZLXj/Lf2y4mN9PGOcrgYG6fEqWWsh3lgP2s9ImbTs56jIKJ09f/Gh6/yoScs+Npuz7h/7jO7n4OAQ/bZlV5b+/pOM7We/ur5aMvdtrft2nqZNGKqz5wOy5Hfgw/RxRESkRk/6QBERkZoydrCyZWPyU2LSsp+z6veflLb9nJW/A5H++PQ5YNqHi3Xg0HF9MOVN5cxxdxqoi4uzmvrV1vzFK3QrOERnz1/UilXr4v7Qldx5/4Ar2rh1l0Juhyo6OloHDh3T8h/WqZbvY+nQyvRlVB/fvBWsHbv2KzQ0TFFR0dr959/6bs1valQ/a04zNaqfY+3a97euB91S88ZZazfTexnZx0dPnFZ4eIRCw8L1w08bte/AEXVqlzV3633QfpakyMhIhYWHKzo6WtHR0QoLD1dkZGTc+YiImPO2aJuioqJizt/zL65ZiVH9fOzkf9q192Dcv2Zv/+NP/fLbDtXyrZLWTUx3RvXxxUtX9OfBfxQeHqHIyEj9uvl3bdm5V35ZdHc3I3/PkKR1m3YqV87sWfLPcPcysp+PHDulyKgoBYfc1qdLv9ONm7fsdrDPKh60jyMjIzXm7dm6HRqmd8cPSXADBb7/7jKqn/n+s2dUP/MdiIzGFB4eZkv+sqzLP+CK2nd/TU7ZssliuZtTtmhSTyMG91JwcIje/WChtv+xX85OTurQtple6tYu7rqkzvsHXNH/3p2rk6fPKdoWLU+PPHqqaX11f75Nlkrkjezja9dv6I1x03X67HlJUoF8XurU7km1adEwbRuZARjZz7FGT/pAzs5OGjesX5q1KyMxuo8nTZunzTv2KioqSo9VLKPBfbupZPHCadrGjOBh+3nitHnxNllp2ayBxr7RV5I0YNgk/XngH7vzL3Vrp5df6GBgqzIeI/v5yLFTmjr7M/13zl8mmVQgn5fat2mqdq2apln7MgIj+/jf/87rrXc+1LkLAbJYLCpSKL96dn1GDWr7pFn7Mgqjf8+QpF6vjlOdGlXVu3vW+n3iXkb386A339Ghoydkkkk1fSrrtX7d5O2VN20al0E8TB/vO3BErwx7W05O2WS55+8Z3Z9vqx6dn5bE918sI/uZ77+7jOxnvgOR0RC8AQAAAAAAAAbIOsOqAAAAAAAAgDRE8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAOCACVM/1vC3ZtgdC7wepKee66/NO/akU60AAACQkRG8AQAAOOD1Ad119MRp/fzrtrhjUz9YpDo1qqph3eqp8ozIyMhUKQcAAAAZgzW9KwAAAPAoyO7uptGv99bYKR+q+uOVtO+vIzp89KS+mP+Ops1ZrG2/71N4eIRqVa+ioa90V3Z3N0nS+Hfnau/+wwoJDVWRgvn1au8u8q1WUZK0Zt0Wff3dWjWo46vvf/pNVSqW1ZRxg9OzmQAAAEhFpvDwMFt6VwIAAOBRMXXOIv135oJO/HtGE958RT/8vFEWi0XDXu0hq9WiKTM/kcVi0VvD+0uSfvxlsxrVryEXZyct+26tPv/6R61cMlPubq5as26Lpsz8RL26tdMLz7VRVFSUXFyc07mFAAAASC1MNQUAAEiBgS8/r3MXAuRX11dlShXTpu279cbAHsqR3V2uLi7q3b2jft38u6KioiVJrVs0VHZ3N1mtVnV7trVstmid+PdsXHnu7m7q0flpZctmJXQDAADIZJhqCgAAkAKuLi4qWMBLJYsVkX/AZUVH29ThxSF215hNZl29dl2eHrk1f/EKbdjyhwKvB8lsMis45LaCgm7GXevlmUdmM/8WCgAAkBkRvAEAADygfF55ZTabtPrL2QmOVlu7YZvWbdyp9ycPV5FC+WUymdS8Qx/ZdHelD7PJlJZVBgAAQBrin1cBAAAeUF6P3PKrU13TPlys63dGsV0NvK5N23dLkoJDbitbNoty5cyhiIhIfbr0O4WEhKZnlQEAAJCGCN4AAAAewpg3+ihHdjf1enWcmrZ7Wf2GTtTR46clSS2bNVCJYoXVvvtr6tDjdTk7Z5OXl0f6VhgAAABphl1NAQAAAAAAAAMw4g0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADPB/sdfJcRu5za8AAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1400x400 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plot_regime_heatmap(\n",
-    "    gmm_probs_full,\n",
-    "    macro_data_full.index,\n",
-    "    f\"GMM Regime Probabilities ({start_yr}-{end_yr})\",\n",
-    "    n_regimes=n_regimes_full,\n",
-    "    is_probability=True,\n",
+    "plot_assignment_heatmap(\n",
+    "    extended_probabilities, extended_df.index, \"The extended model never returns to a cluster\"\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2cd06439",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00354,
-     "end_time": "2026-07-18T19:35:45.080914+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.077374+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "b8b54b93",
+   "metadata": {},
    "source": [
-    "### K-Means Regime Assignments"
+    "## Clustering the indicators rather than the months\n",
+    "\n",
+    "Everything so far has grouped months. The same machinery can group the columns instead,\n",
+    "which answers a different question: which indicators carry the same information? Ward\n",
+    "linkage builds a tree by repeatedly merging the two groups whose merger adds least to the\n",
+    "within-group variance.\n",
+    "\n",
+    "The **cophenetic correlation** measures how well such a tree preserves the distances it was\n",
+    "built from. For each pair of items it reads the height at which the tree first joins them,\n",
+    "and correlates those heights against the original pairwise distances. A tree that scores\n",
+    "near one is a faithful summary of the distance matrix; one that scores low has imposed a\n",
+    "hierarchy the data does not have.\n",
+    "\n",
+    "Two trees are built below and they answer different questions, so their cophenetic\n",
+    "correlations are not interchangeable. The first is over the columns and is what the block\n",
+    "structure in the figure refers to. The second is over the months."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "898a5272",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:45.088648Z",
-     "iopub.status.busy": "2026-07-18T19:35:45.088544Z",
-     "iopub.status.idle": "2026-07-18T19:35:45.172780Z",
-     "shell.execute_reply": "2026-07-18T19:35:45.172172Z"
-    },
-    "papermill": {
-     "duration": 0.088733,
-     "end_time": "2026-07-18T19:35:45.173127+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.084394+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABN4AAAF/CAYAAACWiQTKAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYClJREFUeJzt3XmczPUDx/H3zOyuvRx7su77LMeu3PdZFjmig1Q6lJ9IEiEJkXKHQoRUKqlIyX0rcqSQMzeLXefeuzO/P5bJ2F07a313l309Peb3MDOf7+f7+XzMz7Rvn8MUFxdrEwAAAAAAAIC7ypzVDQAAAAAAAADuRwRvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4Q4726effqXbLrlndjCy148+9qt2yq3b8uTerm3Lf2PPPYdUPfUZnwi5kdVNynEU/rVK7rn0UFxef1U0BAAAAALlkdQPuV0uXr9fIcTM0+6PhqlC2pP31a5FR6j3wfR3+94Tef+c11X6oSqrXStIn495WlQfKObxvs9nUrmsfnbsQoTo1qmrciDeM7YyBzpw9rw7P9LU/N5lM8vbyVKXypdS9S3s9WLFMFrYuax09fkpPvjhAbq6u+mnBFOX29srqJt13fl29WRcvXdETHR6+q/VOn/OtmjeqraD8/pIkq9WqX1Zu1NpN23Tg0DFduRqpggUC1KxRLT31WCvlcnNLVsfiZWv15cKfdebseQUG+Kpzu5bq9GiLZOXOXYjQpE/ma+uOv2W1WRVSuaL6vNxVhYIC7WViYuM0bupc7f3nsMLOh8tqtapQUH61btlAHds0k4tL2l8Fazdu08p1v2nfgSMKv3hZ+QN8VbdGNT3XpV2Kn80NW7br0/mLdPTYafnky6PQFg30XJd2crFY7GW27fxbv67erN17DujchQj5+eRVSNWKeqnbY/L380lWZ3x8gr5YuFS/rNyos2EX5OXloQplS2hA7+4KDPCTJIW2qK9Z8xfph59Xq3O7lmn2CwAAAACMRPCWiSIjo9TnrTG3Dd1u5ubmquVrNicL3nbu3qdzFyLk5upqZHMzVfNGtVWnRhUlWq06cfKsFv20Ur3eHKVZHw1X6RJFDLvvs0+109OPtzGs/oxYtmqT/Hzz6urVKK3ZsFVtH2lsyH2qPlhea5fMlqsT4cv9ZvmazTpy7ORdDd4OHD6mbTv/1owJ79hfi4mN08hxM/RAhdJqH9pUPvny6K99B/Xp59/pj517NOWDQTKZTPby3y9dpQ8mf6bG9R7Skx0e0a6/92v8tHmKiYl1+LxGRceo15ujdC0ySs880VYWF4u+XrRMPd8YqXkfv6e8eXJLkmJj4/TvsZOqXaOKgvL7y2Qy66+9BzVp+hfa889hDX/rf2n26/1Js+Tv56OWTeqqQKCfDh89oYVLVmjztj81Z+pIuef6Lzzcsu1PDXh3ooIrV9DrPbvp8NETmvPVD7p46Yre7P2cvdy0WV/rytVralK/pooUyq9TZ85p4ZIV2vT7Ls2b9p78fPPZyyYkJKjf22P1196DavtII5UuWVRXr0Zqzz+HdC0yWoEBSeVyubmpVbP6+mrRL+r0aAuHcQUAAACAzJbzftLOIpFR0Xpt8Ac6eOSYRr/dJ83QTZLqPFRVqzdsVd+e3RxmiSxfs0Xly5TQpStXjWxypipXurgeblrP/rzKA+X0+pAP9f1PK9X/1educ2XGuFgsDmObXdhsNi1fs0UtGtXR6bDz+nX1ZsOCN7PZnOKMK9yZpcvXqUCgnx6oUNr+mquLi6aPH6rKlcraX3u0VWMF5Q/Qp59/p20796hG8AOSkkK66XO+VZ0aVTXq7T72sjabVZ99+YMebdVEeXInzTBbtGSlTpw6q1mT31XFcqUkSbWrV1HXHgP15cKf9Ur3xyVJefN469NJ7zq0s0PrpvL28tDCxSvUp0cXh5ArJaOG9FZwlYoOr5UrXUIjxk7X8tWbHD6fH834UqVLFNHE0QPs///y8vTQ3AWL1bldSxUvWlCS1LtHF1WpVFZm83+7HtR6qIp6vjFSCxevUI9nO9lfX7BomXb+tU+fjBuqSuVL3batTRvW1Pxvf9L2P/eqetVKty0LAAAAAEYieMsEUdEx6jv4A+0/dFSjhvRR3ZrVnLqueePaWrf5D23b8bc9qIuPT9DqDVv13FOP6psflye7xmq16psflmvxL2t06sw5eXl5qEGdEPXs/oT9h3VJWr95u378ZbUOHDqmy1evKdDfV62a19czTzwqi+W/H4J79h+py5evaeTgVzV2yhzt2X9Yub299Hi7luraubXDvb/9cbm+/2mVToedl5uriwoF5dcTHR5RyyZ10j1mVR9MmuV36sw5h9evXovUp58v0tqN23Tx8hUF+vvq0Ucaq0unUIcf3i9fuaqJn8zX+i3bZTaZVb92sJ7s8Ii69RysIf1eUmiLBpKS9nibNf97bfl1vv3a2i27qmOb5qpWubw+/fw7nT57XmVLFdOAPs+rdIki+n7pKn3x7VKdv3BRlSqU0tv9eiioQIBDO/f8c0gz532nv/cdUkJioiqULamXn+usKjcFL7eze88BnQk7r2aNaun02fN65/2pOnc+3L6c7oZ9B45o+pxv9c/BfxUdEys/n3wKrlJBQ/q9ZC+zYu0WffHtUp04dVYySQUC/dX24UZ6vH3SLK8df+7V/94cpakfDHIIVhYuXqGvvvtZFyIuqVTxIur90lOaMW+hJGnah0Mcrh0xqJdOngrToqUrdfnyNT1YqYwG9O6uIoUK2Ou78Vl6d2BPjZs2T/sOHJG/bz71fP4JNalfQzt279PUTxfo0L/HVSDQT/3+96w9jLrh3IUIzZi7UJu37tK1yCgVDsqvJx9rpTYtG9rLONumnv1Haufuf+x/5pJUIL+/vp83UdKdf57Xb96ukCoVHWZaubq6OIRuNzSsW12ffv6djp04be/rjj/36vKVa+rYpplD2Y5tmuvX1Zu1eetOe0i9esNWVShb0h66SVLxogVVvVolrVr/uz14S01Q/qTP7dVrUWkGb7eGbjfaP2LsdB09ftr+2r/HTunf46f0Rq9nHELtDm2aac5XP2rNxq167ql2kqRqD5ZPVme1B8srT25vhzqtVqu+/uFXNaxTXZXKl1JCYqIS4hPk7p4rxbaWL1NCeXJ7a8OW7QRvAAAAALIUwZvBomNi9frgD7TvwBGNGtJb9Wo5F7pJUlB+fz1QobSWr9liD962bPtTkVFRataodorB25hJs7V0xQa1btFAndq10Jmz57Vw8QodOHRMMyYMte/ltHTFenm4u+uJDo/Iw8Nd23ft0cx53ykyKlqvvviUQ51XrkWq7+AP1LBudTVtUFOrN27V1FkLVKpEEXu7fvx5jcZPm6fG9Wuoc/uWiouL16F/j2vv/kN3FLydOZu0Kf3Ne0fFxMSq5xvv6Xx4hNq1aqL8gX76a+9BffzZN7oQcUl9X3laUtIP6W8MHa99+w+rfeumKlakoDZs2a4RY6c7ff8//96vjb/tsIcf875eov5Dx6pLp9ZatGSlOrZppivXIvXFt0v13viZmvLBIPu1f+zao9eHfKhypUvo+a7tZTKZtXT5er06YJQ+Hvt2mrN1pKS9xwoFBapiuVIqWbyI3HPl0vK1W9S1039hZ8Sly+rz1hj55Mutpzu3UW5vT50Ju6C1m7bZy2zd/peGjp6q6lUrqefzSSHM0eOntXvPAXvwlpJFS1Zq3NS5qvpAOT3R4RGdOXteA96dqNzengoM8E1W/vNvlshsMuupjqGKjIrS/G+WatiYjzVrsuMsqyvXIvXG0HFq1qiWmtSvoe9/WqWho6bIOqCnJk7/XO1Dm6pF49r6YuFSDR45WT/MnyQvT4+k/l68rBf7DJPJZNJjbZsrX948+m3bnxo1fqYiI6OTLRdNq03PPvGorkVG6/yFCPXp0UWS5OHhLunOP8/nLkTo7LlwlStTItUyN4uIuCQpaUbaDQcOHZMklS/rWEf5MiVkNpt04NAxPdy0nqxWqw7/e0KtWzZIVm+FciX1+/a/FBkVbR8/KSm4j4yKVmxsnPYdPKIvv1uqAvn9VbhQfqfam6z9Fy8ntT9v7v/af/jo9faWdCgb4OejQH9fe/9SExUdo+iYGOXN+9+Y/Hv8lC6EX1TpEkX1/sRZ+nnlBsXHJ6hUiSLq+/LTCqmaPBQsV7q4du85eEf9AgAAAIC7heDNYCPGTteF8It6b3Bv1a8dku7rWzSuo48/+1oxsXFyz+WmX1dvUrUHKygghY3H//x7vxYvW6thA3o6hAPBVSqq7+APtGr9Vvvr7w78n8OeTB1aN9WYSbO1aMkq9Ximk9zc/ts/7kL4RQ3t/7IeaZY0y6bNw43UvlsfLVm21h68bd66SyWLFdaoIb3T3UcpaXndpctXZbVadeLUWU2a/oUkqXH9GvYyXy36RafOhGnutPfss5bahzaVv5+Pvvx2qZ7q2Er5A/20fvN2/b3voF57uas9XOrQuql6v/W+0+05fvKMFnz6gX0mW+7cXhozabbmfPWDvp411h5mWBOtmvf1Ep05e15BBQJks9n0weTPFFy5gia896Z91lO70Cbq8tIAzZj7rSaNHnjbeyckJGj1ht/VPrSpJMk9l5vq1QrW8tWbHYK3v/Ye1NVrkZo0eoDDAR43L8/btHWXvDw9NHHUAIeZjLcTH5+gGfMWqkLZkvrog0H2WUulShbRyLEzUgze4uLiNW/aKLm6Jv2VktvbSxM+/lyHj55QqeL/7dF3Ifyi3h3YUy0aJ30OawQ/oCdeeFPvjJmqGRPeUaXyScszixctpNcGjdHajdvssxM/mfONrFar5k8fbd+7rEPrpho6eopmzV+kdqFNHD7TabWpRsiDCvjhV129FumwzFm688/zsRNJs7RuzCRLy/xvl8rL08Nh6fmFiEuymM3yzZfXoayrq4vy5s6tCxEXJUlXrkYqLj4+xZlq/tdfuxB+0SF4W7tpm4aOnmp/XqFsCQ16/aU7Xm79+TdLZDGb1eSm/59eCL/k0Iab+fnms7c/NV9/v0zx8Qlq1rCW/bUTp85KkhZ8/4vy5PbWgN7dJUlzFyxW3yEfaPbk4SpdsqhDPQWDArRs1YE76RYAAAAA3DXO/SSOOxZx8bLc3FyVP4WwwhlNG9RUbGy8Nv2+U5FR0dq0dZdaNK6dYtnVG36Xt5enagQ/oEuXr9of5cuUkKeHu3b8udde9uaAIjIqWpcuX1XVB8spJjbWHh7c4Onhroeb1rU/d3V1UcWypXTq7H/LQL29PXXuQoT27j98R/389PPv9EjnVxT6xP/0cr8ROnbitHq/9JTDD/Sr129VlQfKKbe3l0P/HqpWSYlWq3b9nbRs8Lc/dsvFxaJHb9pzymw267E2zZ1uT/VqFR2Wj1a6vpSvUd0aDkHGjaDoxlgcOHxMJ06dVYvGdXT5yjV7G2NiYlW9aiXt+mu/rFbrbe+9Zdufunzlmpo3+u/PuXmj2jp45LiOHD1pfy23l6ckadPvO5WQkJBiXbm9PRUTE6utO/5yuu/7DhzR5SvX9OgjjR0CmZZN6qZ6smpoiwb2gEuS/UCQ07csFfb0cHfoV7EiBZXb21PFixSyj6Uk+6zAG0uNbTab1m7cprq1qslmk8Off82QyroWGaX9h47eUZtScqef58tXrklKCmrTMuerH7Vt59/q2f1xh3GNjYuTi2vK/ybi5uaq2Nj4pHKxcUmvpXDIitv1Pfti4+IdXg+pUlGTRg/Ue0N6q31oU1ksLoqJiXWiZ8n9unqzlixbpyc7tnJYUhwbl9QuV7fkfcjl5mpvd0p2/vWPZs3/Xk0b1HRYIhodndTGqOgYffT+Wwpt0UChLRpo8vsDZbPZNP/bn5LVlcfbS7GxcXfcPwAAAAC4G5jxZrABvbtr8owv1Hfwh/p43BAVK5K0qXhiolWXLl9xKJsnt7dDUCBJPvny6KFqlbR8zWbFxMbKarU6zAK72YlTYboWGaVWj/dM8f2Ll/6735GjJzV97rfavmuvIqOiHcpdu+V5gL9vspMBc+f20qF/T9ifP925tbbt/FvP935HhQvmV42QB9WicR2n9zR7tFVjNalfU3Fx8dr+5x59+8NyJd4SUJ04fVaH/j2uRzq/kmIdEdf7d/bcBfn75ku2/1Phgs4vp8sf4O/w3Pt6yHVrgOrtlRTCXb0amdTG6zNzbres9VpktMN+e7datmqTChYIkKuri72+wgUD5Z4rl35dvcm+b1e1yhXUuN5DmjX/ey1YtEzBlSuoQZ0QtWhcxz5jsUObZlq1/ne9PuRDBfj7qEbwg2raoOZtD/c4e+7C9Xs6jpeLxaKgAv4pXaICt4xXnutB0pVrkQ6vp/RZ8vJKvnz1xnhfvX79xctXdPValH78eY1+/HlNim24eOnyHbUpJRn9PMtmu+3bK9f+phlzF6rNww3V4Za93HK5uSkhPuUgNS4uXrlyJf3Z5roensfFx6dQLu56XY6hnK9PXtXwSZpJ16R+Dc356kf1eet9fTN7rPx88ykmNk6RkVEO16Q0o27XX/9o1ISZqhnyoHo818nhvRsHdcTHJe9DbFy8vd23Onr8tAa+O1ElixfWW31fcKzz+jWVK5ZV/sD/9jksEOivKpXK6a+9yZeU2v8IONUUAAAAQBYieDNYiWKFNG5Ef/UeOFp93hqj6eOHKn+gn86dD1eHZ/o6lL11c/sbWjSuo/cnzlLExcuqXb1KqrOOrFarfPLl0bABKQdvPtf3Ybp6LVI9+4+Ul6eHXuzWUYWC8svNzVUHDh3V1FkLZLsl8LKYU54YadN/4ULxooX09awPtem3Xfrtjz+1duM2LVqyUt27tNeL3TqmPkDXFSlYwL65fL1a1WQ2m/Xx7K8VUqWifRmlzWpTjeAH1KVT6xTrKFq4QIqv3wlzKn1O7fUbI2G7/tN+rxeeVJlSxVIs6+mR8obwkhQZGaWNv+9UXFy8Ond/I9n7y9du0cvPdZbJZJLJZNKot/vo732HtPG3Hfp9+196b/xMffXdL5o5aZg8Pdzlmy+v5k0bpd+279Zv2/7Ulm27tXT5ej3SrJ6G9n/5NiOQPubUlrHekj+l9llKdVyvX2+zJv3m4aZ19Uiz+imWLV2yiMNzZ9uUkjv9PN/Yq+124d7W7X9p+NhPVKdGVb15fcnkzfx98ynRalXEpcsOy03j4xN0+epV+fsmLTPPk9tLbq6uCr++T9zNLlx/zT+FJek3a1K/hqbP+Vbrt2xX+9CmWrXuN40cN8OhzM0Hj0jSwcPH9Oaw8SpVvLBGvd0n2TJVf7989jbcHJJJUnjEJYeDIG4IOxeu1waNkbeXh8aPeMNhVqn037JVX588ya71yZfHvq/cza5ei5R7rlwOs3sBAAAAILMRvGWCSuVL6f13XtMbb49T77fe1yfj3pavb95ke32VLplyUNOwbnWNmTxbf+87pBGDeqV6n0IF8+uPnXtUuVLZ2/6wuWP3Pl2+ck2jh77mcKrgmbPn09kzRx7u7mrWqJaaNaql+PgEDRw+UXO/+lHdnmhjnwXjrGeffFSLf1mr6XO+1cRRAyRJhYICFRUdm+yky1sVCPTX9j/3KiYm1mHW28nTYenvVDoVCgqUJHl5eaTZzpSs3fSH4uLi1f/V55Tvpg3rJen4iTOaPvdb7d5zwL5sUpIeqFBaD1QorZef66xfV2/WsDHTtHLtFrW9vtTW1dVF9WsFq36tYFmtVn340Rz98PNqPfdUO4clgjcUCEyaKXbydJjDpvUJiYk6c/ZCsoArM+TLm0eenu5KTLTe0bim5tbZdze7k8/zjRmtqf1/ac8/hzRw+ESVL1NCIwe/muLeamVKJe1V9s+Bf1WnRlX76/sOHJHVarMHumazWaVKFNa+A/8mq2PvP4dVKCgwWYB1qxvLPiMjk2a51gx58LZ7EJ48Haa+Qz6QT748GjeivzyvH0bh0P7rf4/9c/CIw0Ei58Mv6tyFCD3aqrFD+ctXrqrPoDGKi4/X9DFDUwwLS5UoIhcXi85fSL4/3IXwi8qXN3kgd/rseRUvWjDVvgAAAABAZmCPt0zyULUH9O5bPXXqdJj6Dv5ACfEJqhH8gMMjteWHnh7u6v/qs3rh6Q6qVys41Xs0bVBTiVarPvvi+2TvJSQm2pft3ZhdZLtpOVx8fIK++2nlHffv8pWrDs9dXV1Uolgh2WRTQkJiuuvL7e2ldq2a6Pftf+nA4aRTEJs2rKm/9x3Ub3/sTlb+6rVIJSQm3admyINKSEjUj7/8tyTRarVq4ZIV6W5HepUvU0KFggL15cKfFRUdk+z9m5f7pmTZqk0qFBSoDq2bqkn9Gg6Ppx5rJU8Pd/26erOkpM31bbcsaSx7PZSJu75U8dY/F7PZbA/O4lNZzlihbEnlzeOtH39ZYx9TSfp19Sb7ZyizWSxmNa77kNZu2qbDR08kez+tcU2Nh3uuZEsrpTv/PAf6+yp/gF+KYdjR46fU7+2xCsofoLHD30g1HA+pWkl5cntr0U+rHF7/fukquefK5RDGNa5XQ/sOHNG+A0fsrx07cVrbd+112B/x0uWryT4rkrR42VpJ/52g6u/nk+zvpRvCIy7ptUFjZDKZNfG9AfLJlzzskqSSxQurWJGC+vHnNUpM/G/27KKfVspkMjm0KzomRq8PGavz4REaP7J/ikGwJHl5eqjOQ1X1196DOnr8vz0ojx4/pb/2HtRDKYSx+w8d1YMVy6RYHwAAAABkFma8ZaJGdR/SwNee13vjZ6r/sPGa8N6bTs8EC23eIM0ywZUrqF2rJpr39RIdPHJcNYIflIuLRSdOndXqDVvV95Wn1aR+DVWuWEa5vb00Yux0dX60hWQyadmqjWnuS3U7fd4aIz/fvHqwYln5+uTV0eOn9d3iFapTo2qas25S07l9S339wzJ9/vUSjRjUS10eC9WGLTv0xtBxCm1eX+XKlFBMTKwOHz2hNRu2atG8icqXN7ca1KmuiuVK6aMZX+rk6TAVK1JQG3/boSvX92GTgVs+mc1mDer7gvoO+VBdXhqg0BYNFODnq/PhEdr+5z55eXpo7PB+KV57Pvyiduzeq06PtkzxfTc3V9UMeVCrN/yu13s+rZ9XbNCin1aqYZ3qKlQwUFFRMfrxlzVJIUWNpD3cRk34VFeuRqp61YoK8PfV2bALWrh4ucqUKpbqbCBXVxc937WDxk+bp1ffHKUmDWrqTNgF/bxivQoFBcpk5ADeRs/nn9D23fv0Qu9havtII5UoVkhXrl7T/oNHtW3nHi3/LvV99VJTrkxxrVz3myZNn68KZUvKw8Nd9WsFZ+jzXL92sNZt/kM2m80+oy4yKlqvDfpAV69Fqstjodq8dafDNYWC8ttDIvdcbnrpmY4aO2WuBo2crFohD2rX3/u1bNUm9Xi2k305q5S0h9+Pv6xRv7fH6qnHWsnF4qIFi36Rj09ePdmxlb3cslWb9P3SVWpYJ0QFg5I+K79v362tO/5WvVrVHA4ySE3fwR/o1Jlz6tqptf7cs19/7tlvf883X17VCHnQ/rzXC0/qzWHj1WfQ+2resLaOHDuhhYtXqO3DjVS8aCF7uWHvf6y9+w+rdcuGOnr8lI4eP2V/z8PDXQ3rVLc/f/m5zvpj1x69OmCUOrVrIUn69oflypPbW8880dahrf8c/FdXrl5T/dqp/0MFAAAAAGQGgrdM1rplQ125GqmPZn6pwSM/0vvvvJbicrM7NaBPd5UvU0I//Lxan8z5RhaLWUH5A/Rwk7qqfP0H+7x5cmvs8H76aOaXmj53oXJ7e+nhJnVVvVolvTZozB3dt11oE/26erMWLPpF0dGxCvD3Uad2LfTck4/ecV8C/HzUolFtLVu1SSdPh6lwwfyaNnaI5n71o1Zv2KpfVm2Ul6eHihQqoBee7mg/6MBiMWvciDc04ePP9fPKDTKbzGpYJ0Tdu7RXj9eHK5ersXs+BVepqJkTh+mzL37QwsUrFB0dK1/fvKpUrpTahTZJ9bqVa7fIarWpXq1qqZapW6ua1mzcpi3b/lS1yuW1d/9hrVy3RREXr8jLy0MVy5XSuwN7qmCBpCWvDzepqx9/WaPvlqzUtcgo+fnkVdMGtfTC0x1S3VdNkjo9mhRsfPndz5oy8yuVLllUHwx7XRM+/tx+cENm8/XJq1mT39Xs+T9o3aY/tOinlcqbx1slihbW/55/4o7q7NimmQ4ePq6ly9drwaJlKpDfX/VrBWfo89y6ZUMtXLzCYUnwlSvXFHY+XJI0bfbXya5p1by+w+ysjm2ay8Xioi+/+1kbf9uhQH9f9enRVY+3dwxlvTw9NO3DwZo4/QvN+fJH2Ww2VatcQX16dHGYkVblgbL6a+8BrVib9FmxWMwqWjhIvXt0sf9Zp+XgkeOSlOIJotUql3cI3urVqqbRQ/to1vzvNX7aPOXLm1vdnmir57u0d7juwJGk2aw//bpOP/26zuG9Avn9HYK3EsUKadqHgzV11tea8+WPMplNql6lknq9+KQC/R0P51i9/ncVCPRzKlAEAAAAACOZ4uJi73yaE3APWbf5Dw18d6I+GT/U+dMpYWe1WvVI555qVLd6slMn4ajXgFEK8PPRO2+mfAIvjBMXF68Oz7ympzu30ePtH87q5gAAAADI4djjDfelmOubxt+QmGjVtz8ul5enh8qVLp41jbqHxMbFJdsT7JeVG3Xl6jUFV6mQRa26d7zyXGetXPebzoRdyOqm5Dg/LV8vF4uL2oc2zeqmAAAAAAAz3nB/GjVhpmJj4/VAhdKKj0/Q2k3b9Nfeg3r5uc7J9oNCcjv+3KuJ079Qk/o1lDePt/YfOqqflq1TsaIFNWfKSLm6skodAAAAAIC08NMz7kshVSrpq+9+1qbfdyouPl6Fg/Lr9Z7dnN7PKqcLyh+g/AG++vbH5bpy9Zry5PbWw83qqefzjxO6AQAAAADgJGa8AQAAAAAAAAZgjzcAAAAAAADAAARvAAAAAAAAgAEI3u4ym82mhISEZCdCAgAAAAAAIGdhl/S7LDExUfVDn9WeiwGSTFndnPvKxW1TsroJuAf5PNTrjq+93WcuI/UCzuLvPQAAgPuHxRaX1U1AFmDGGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAC5Z3QAAAAAAAADgToyfNk8bftuhs2EXNHfaeypbqliK5RYvW6vPv14im82mkCoV1f/VZ+XiYnwsxow3AAAAAAAA3JMa16+h6ePeVoH8/qmWOX32nGbOXahPxr2tbz8bp4hLl/XDz2sypX0EbwAAAAAAALgnVXuwvAID/G5bZvWGrapXK1h+vvlkMpnUPrSpVqzdkintY6kpAAAAAAAADJWYaJXNZnW6vMlklsVyd+aLhZ0Ld5gRF5Q/QGHnwu9K3WkheAMAAAAAAIBhEhOtqvnws3I1Ox+8eXt7ys8nr0wmkySpY5vmeqxtc6OaaBiCNwAAAAAAABjGZrPK1WzV3kv5ZXOivElSRYXpl6+n3ZUDEPIH+unU6XP252fCzit/4O2Xp94t7PEGAAAAAAAAw9lMJslkTvNhuz7L7W5pXK+GNv62Q+ERl2Sz2fT90lVq1rDWXb1HapjxBgAAAAAAAOOZzEqaz5YWZ+bFJXl/0ixt3rpLERGX9dqgMfL0cNfCOeM1asJM1a8VrPq1Q1QoKFAvPN1RPV4fLkmqVrmC2oc2ubM+pFOmBG/tu70mN1cX5XJzU2xcnEJbNFC3x9tmqM5RE2aqZeO6Cqla8S610tGZs+c1Ytx0HTh0TAULBGjex6MMuQ8AAAAAAECOYDLJueDNeQP7PJ/i64P6vujw/NFWjfVoq8Z39d7OyLQZbyMGvaqypYrp3IUIPfXiAIVUqaRK5UvdcX23DuDd5unpoR7PdNK1yChNn/OtofcCAAAAAAC47xkw4y27y/SlpoH+vipWpKDOnrugSuVLKTziksZPm6czYRcUGxenBrVD1OPZTpKk3XsOaOyUOUq0WlWhbEntP3hUfV/pquAqFdWz/0g93v5hNaxTXSPGTperi4tOnTmnU2fOKbhKBbUPbaqps75S2LlwNagToj49ukrSbe93s7x5vFXlgXLa8efeTB0fAAAAAACA+5IBM96yu0wP3o4eP63LV64quHIFSdKIsdPV7Ym2Cq5cQQmJiXrj7bFatf53NagdordHTdHQ/i8rpGpFbd+1V0uXr0+13sNHT2jKB4NkNpn15Itv6uq1SE0ePVDxCQnq+MzratOykUoWL5zq/Zo2qJlZQwAAAAAAAJDzMOPNOG+P+kgmk1nHT55Rnx5d5JMvj6JjYvTHzj2KuHjZXi4qOkbHT57RsROnZbFY7Hu4hVStqEJBganWX792sHK5uUmSSpUoopohleXi4iIXFxeVKFpIJ06fVVAB/1TvlxELF6/Qd0tWSJJstvvnwwEAAAAAAHDXMOPNODf2eNu642/1f2ecQqpWUsECAZKkmZOG2UOzGw4dOZ6sDtNtjpN1c/3veovZrFxurvbnZrNZiYlW3cjEUrpfRjzWtrkea9tckpSQkKD6oc/etboBAAAAAADuCzlwxps5s29YI/gBdWjdVDPmfCtPD3cFV6moz79eYn//fPhFnTsfrqKFg5SQmKAdu/dJknbs3qeTp8MydO/b3Q8AAAAAAAAGMpmcf9wnMn2PN0l67qn26vRcP/1z8F8NG/iKJk//Ql1eGiiZJA/3XBrQu7sCA/w04q1eGjtlrqw2q8qXKaGihYPk7e2VoXvf7n43i4mJVefn31B8fIKuRUapbZdX9XDTeurZ/fEM3R8AAAAAACBHyoEz3kxxcbHZtjeRUdHy8vSQJO3df1hvDhuvhZ+Nl7t7rixuWepuLDXdczFAOW3dstEubpuS1U3APcjnoV53fO3tPnMZqRdwFn/vAQAA3D8strisbkKWsWcl8eXkbPBWyXW/NiydIxeXLJkzdtdk69av3bhNCxYtk002WSxmDe3/SrYO3QAAAAAAAJCKHDjjLVsHb6EtGii0RYOsbgYAAAAAAAAyiuANAAAAAAAAMIDZpJy2LRfBGwAAAAAAAIzHjDcAAAAAAADACCbJ5ETwdv/kbgRvAAAAAAAAyAQms3PBm2z3TfhG8AYAAAAAAADjmZyc8SYRvAEAAAAAAABOM5mu7/OWFqvhTcksBG8AAAAAAAAwntMz3u6fk08J3gAAAAAAAGA8k9nJGW/3D4I3AAAAAAAAGI8ZbwAAAAAAAIABmPEGAAAAAAAAGIAZbwAAAAAAAIABmPEGAAAAAAAAGIDgDQAAAAAAADAAS00BAAAAAAAAAzDjDQAAAAAAADAAM94AAAAAAAAAA5gtzs14sxG8AQAAAAAAAE4zMeMNAAAAAAAAuPsI3gAAAAAAAAAjmHQ/ZWpOIXgDAAAAAACA4ZjxBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAIHK4AAAAAAAAA3H3MeAMAAAAAAAAMQPAGAAAAAAAAGIDgDQAAAAAAADAAwRsAAAAAAABgBA5XAAAAAAAAAO4+ZrwBAAAAAAAABjAqeDtx6qyGfzhdl69clbeXh4b066GSxQs7lLFarfpo5pf67Y/dslgsypvbWwNfe15FChVI173Si+DNIOe3TJKLC8MLZLWL26bcU/UCN/N5qFdWNwEAgHsK/40GZG9GBW9jJs1Wu1aNFdqigVZv2KqR46Zr9kcjHMps+G2Hdu85qM8/HiUXFxd99uUP+uSzb/TekN7puld6mQ2tHQAAAAAAAJD+2+PNmYeTIi5d1r6DR9SyaV1JUuN6DynsfIROnDp7y61Nio+PV2xcvGw2myKjohUY4JvxPqWBKVkAAAAAAAAwnBEz3s6dj5C/bz65WCz2e+QP8FPY+XCHZaT1alXT9j/3qvUTveTp6a4APx9NGzskvV1IN4I3AAAAAAAAGC69wVvXl99KukZSxzbN9Vjb5nd8730H/tWRoye1+MvJ8vL00LTZX+uDybM1bEDPO67TGQRvAAAAAAAAMFx6g7f5n4xOc//8wABfXYi4pITERLlYLLLZbAo7H678AX4O5X5ZuVEhVSsqt7eXJKlVs/rqM2jMHfUjPdjjDQAAAAAAAIYzmUxOP5zlmy+vypUurl9XbZIkrdm4TYH+vslOKy0UFKDtu/YqPj5BkrTp950qdcvJp0ZgxhsAAAAAAACMl86DE5w1oHd3jRw3Q3MXLJaXp4cG93tJkjRqwkzVrxWs+rVD1LFNcx09flpPvzJILi4W+fnk1Zu9u9/9xtyC4A0AAAAAAACGM+JwBUkqVqSgZk4cluz1QX1ftP/ezc1Vb/V9IV313g0EbwAAAAAAADCcUcFbdkbwBgAAAAAAAMMRvAEAAAAAAABGMGiPt+yM4A0AAAAAAACGY8YbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAACNwuAIAAAAAAABw9zHjDQAAAAAAADAAwRsAAAAAAABgALPZyeDNRvAGAAAAAAAAOM1k/5802AxuSCYieAMAAAAAAIDhnF5q6tRy1HsDwRsAAAAAAAAMZ3L2VNP7J3cjeAMAAAAAAIDxzGaTZM5ZyRvBGwAAAAAAAAzHjDcAAAAAAADAAOzxBgAAAAAAABiAGW8AAAAAAACAAZjxBgAAAAAAABggacabM8Gb4U3JNARvAAAAAAAAMBxLTQEAAAAAAAADsNQUAAAAAAAAMAAz3gAAAAAAAAADMOMNAAAAAAAAMAAz3gAAAAAAAAAjmExJs97SYGPGGwAAAAAAAOA8Z1eayiTZDG9N5siU4K19t9fk5uqiXG5uio2LU2iLBur2eNsM1Tlqwky1bFxXIVUr3qVWOvpj1x5Nm/W1omNiZJJJdWpWVc/uj8tsNhtyPwAAAAAAgPuZyckZbzKZCN7Sa8SgV1W2VDGduxChp14coJAqlVSpfKk7rm9Q3xfvYuuSy+3tpRGDeqlQUKBi4+LUe+D7+mXlRoW2aGDofQEAAAAAAO5H6Znxdr/I9KWmgf6+KlakoM6eu6BK5UspPOKSxk+bpzNhFxQbF6cGtUPU49lOkqTdew5o7JQ5SrRaVaFsSe0/eFR9X+mq4CoV1bP/SD3e/mE1rFNdI8ZOl6uLi06dOadTZ84puEoFtQ9tqqmzvlLYuXA1qBOiPj26StJt73ezcqWL23+fy81NZUoW05mw85kyRgAAAAAAAPeb9Mx4u19kevB29PhpXb5yVcGVK0iSRoydrm5PtFVw5QpKSEzUG2+P1ar1v6tB7RC9PWqKhvZ/WSFVK2r7rr1aunx9qvUePnpCUz4YJLPJrCdffFNXr0Vq8uiBik9IUMdnXleblo1UsnjhVO/XtEHNVOsOj7ikNRu3auzwfnd9PAAAAAAAAHICZrwZ6O1RH8lkMuv4yTPq06OLfPLlUXRMjP7YuUcRFy/by0VFx+j4yTM6duK0LBaLfQ+3kKoVVSgoMNX669cOVi43N0lSqRJFVDOkslxcXOTi4qISRQvpxOmzCirgn+r9UhMZGaX+74xT106hqlC2ZIplFi5eoe+WrJAk2Wz3yypkAAAAAACAu4cZbwa6scfb1h1/q/874xRStZIKFgiQJM2cNMwemt1w6MjxZHXc7g/HzfW/6y1ms3K5udqfm81mJSZadSMTS+l+KYmMitZrgz9U/doherJjq1TLPda2uR5r21ySlJCQoPqhz6ZZNwAAAAAAQE6SE2e8ZfoRnTWCH1CH1k01Y8638vRwV3CVivr86yX298+HX9S58+EqWjhICYkJ2rF7nyRpx+59Onk6LEP3vt39bhUVHaO+gz9QreqV9dxT7TJ0XwAAAAAAgJzuxow3Zx73i0zf402SnnuqvTo910//HPxXwwa+osnTv1CXlwZKJsnDPZcG9O6uwAA/jXirl8ZOmSurzaryZUqoaOEgeXt7Zejet7vfzb75/lft3X9EMTGxWrdpmySpSf2aevapRzN0fwAAAAAAgJzoXlxq+ueeA6pSqWyy13fvOaDKKbx+K1NcXGy23ZQsMipaXp4ekqS9+w/rzWHjtfCz8XJ3z5XFLUvdjaWma3/+Ui4uWZJrAgDuEz4P9crqJgAAcE+5uG1KVjcBSJXFFpfVTcgyN7ISz9BeMpktaZa3WRMVtXSKNiydk+XZStP2L2jV958me71Fxx5a/t30NK/P1snQ2o3btGDRMtlkk8Vi1tD+r2Tr0A0AAAAAAAApuxdnvCmF6WoXL12RxeLc7m3ZOngLbdFAoS0aZHUzAAAAAAAAkEH30uEKLTq+JMmkmNhYtejYw+G9qOgYtWnZ0Kl6snXwBgAAAAAAgPvDvTTj7f13+ko2m15/e6zef+c1++tmk0m+PnlVtHCQU/UQvAEAAAAAAMBw99KMt+DKFSRJP86frLx5vO+4HoI3AAAAAAAAGM7s5Iw3WzaY8XaDt5enfl6xQfsP/avIqBiH94b0eynN6wneAAAAAAAAYDijZrydOHVWwz+crstXrsrby0ND+vVQyeKFk5U79O8JjZ82VxEXr0iSXn62kxrVe+i2dY+eMFN/7NqrWtUry9vLM30NE8EbAAAAAAAAMoFRe7yNmTRb7Vo1VmiLBlq9YatGjpuu2R+NcCgTExOrAcPGa2j/l1XlgXJKTLTqytVrada9fssOfTVzjPx886WrTTc4d/YpAAAAAAAAkAFmk/MPZ0Vcuqx9B4+oZdO6kqTG9R5S2PkInTh11qHc8jWbVal8aVV5oJwkyWIxyydfnjTrz5vHW16eHs436BbMeAMAAAAAAIDhzGaTTE6karZ0rDU9dz5C/r755GKxSEqaVZc/wE9h58NVpFABe7l/j5+Sm6uL+r09VucvRKhUiaLq/dJTaYZvz3dtr/cnzdLzXTvI95ayXk4sPSV4AwAAAAAAgOFM1385U1KSur78ln1pasc2zfVY2+Z3fO/ERKu27dyjmZOGKcDPRx9/9o0+/OgzjXq7z22vG/7hdEnS8jVb7Ctgbbak1bCbfvk8zfsSvAEAAAAAAMBwZicPV7BdLzP/k9Fycbl9dBUY4KsLEZeUkJgoF4tFNptNYefDlT/Az6Fc/gA/BVepqEB/X0nSw03q6rXBY9Jsy3dzJ6Td4NtgjzcAAAAAAAAY7sbhCs48nOWbL6/KlS6uX1dtkiSt2bhNgf6+DstMJalpw5rad+CIIiOjJEmbt+1SmZJF06w/KL+/gvL7q0Cgn1xdLPbnQfn9nWofM94AAAAAAABgOJOTM97SscWbJGlA7+4aOW6G5i5YLC9PDw3u95IkadSEmapfK1j1a4eoQKC/nnmirV7qO1wms0kBfj4a2Of5NOuOjIzS2KnztGr9b7KYLVqzeJbWbf5D+w8e1UvPPJbm9U4Fb9t37dXyNZsVfvGyxg7vp30HjigqKkYhVSs6czkAAAAAAAByOLOTs9ls6ZjxJknFihTUzInDkr0+qO+LDs8faVZPjzSrl666x3/8uaxWq76Y/r6e7z1UkvRA+dKaNmuBU8FbmktNF/+yRu9++LF8ffJq11//SJJcLBbNnLcwXQ0FAAAAAABAznVjxpszj+zitz92662+L1xfuprUMD/ffIq4eMWp69MM3uZ/u1STRg1Uj2c7yXz9yNcSxQrp6InTd95qAAAAAAAA5ChG7PFmNDdXFyUmJjq8dvnKVeXJ7eXU9WkGb5evXFOJYoWuP7ve8Ww2CAAAAAAAAMje7sUZb3VrBmvslDm6dv1Qhri4eE35dIEa1qnu1PVpBm9lShbVmg1bHV7buGWHypUunv7WAgAAAAAAIEcym0xOP7KL/73wuOLi4vXwYy/rWmSUmrR7QZFR0XrxmY5OXZ/m4Qqvvvik+gwao+Vrtig2Nk5DR0/V9j/3auJ7b2a48QAAAAAAAMgZTEr3gaVZzsPdXe8N6a2Ll67o7LkLyh/gJ1+fvE5fn2bwVq5MCX05Y4x+WblRfr75lD/AV6++9JQC/Hwy1HAAAAAAAADkHE7v35aNZrzd4JMvj3zy5Un3dWkGb5Lk65NXXTqFprtyAAAAAAAAQJLMTu7fZstGudvxk2c09dMF2n/oqKKiYxzeW/7d9DSvdyp4W7f5D+0/eFTRMY436NOjazqaCgAAAAAAgJzqXpzxNnT0VJUuWVQD+nRXrlxu6b4+zeBt1ISZ2vT7LlV7sLzc7+AGAAAAAAAAgNMnlmaf3E0nT4dp9kfDZTaneT5pitIM3tZu3KYvZ4yRP3u6AQAAAAAA4A7dizPeaj9URXv+OawHK5a5o+vTDN4C/H3vaCodAAAAAAAAcMO9uMfbm72f0//6v6cSxQrL18fxcAVntmBLM3gb0Lu7Ppj8mdo83Ei+t5zeULpk0XQ2FwAAAAAAADnRvTjjbcLHnyv84mUVLRykq1cj0319msHbuQsR+u2P3Vq1/neH100madMvn6f7hgAAAAAAAMh5TMpW27c5Zd2mP/TN7LHy8813R9enGbxN+mS+evfoouaNanO4AgAAAAAAAO6IWc7NeLNlo3guf4BfhrZgSzN4S0hMVGjz+nd8egMAAAAAAABwL55q2qFNMw157yM99VjoHW3Blmbw1qF1My36aZUea9v8zlsJAAAAAACAHO1e3ONt/LR5kqStO/52eN3ZLdjSDN42/LZDR46e1NwFi5Od3jB36nvpaSsAAAAAAAByqHtxxtvmZRk73yDN4O3x9i0zdAMAAAAAAADAZDLJ7ETyZs1GM94yKs3gLbR5g8xoBwAAAAAAAO5jzs54y06527kLEZoxd6H2HzyqqOhoh/e+mzshzetTDN42b92lOjWqSpI2bNme6sX1a4eko6lAxvg81Curm4B70MVtU+742tt95jJSL+AsPmcAAAC4nzi7x5tT+8BlknfHfCx3dzd17dxaHu650n19isHb1E8X2IO3CR/PT/FCk4ngDQAAAAAAAM4xX3/cS/459K+WffOJXF3TXDSaohSv+mLG+/bfL5qX9rQ5AAAAAAAA4HbuxRlvJYsVVvjFSyoQ6H9H199ZXAcAAAAAAACkg9mU9EhT9snd1LBudb35znh1bNNcvj55HN5zZiVomsFbh259U9zUztXVVQUC/dSkQU21adkwW6WRAAAAAAAAyF7uxeBt0ZJVkqS5CxY7vO7sFmxpBm+PtmqsJcvWqn1oU+UP9NPZcxe0+Je1atG4tlxcLJo57zudv3BRz3dtf4ddAAAAAAAAwP3uXlxqmtEt2NIM3tZt2qYJ772pIoUK2F9rWKe63nl/qmZ/NEI1gh/U4JGTCd4AAAAAAACQqntxxltGpRm8HT95NtkGcoEBvjpxKkySVL5MCV28dMWY1gEAAAAAAOC+YDIpxe3MUiqXXWR0C7Y0T3GtVL6Uxk2bqytXIyVJl69c08SP56tC2ZKSpGMnTssnX57bVQEAAAAAAIAczsVkcvqRXTzaqrFMJpM6tG6mV7o/rvatm8pisahF49oKrlJBM+d9p9lf/JDq9WnOeBvc7yW9M3qqHu70snK5uSkuPk6VK5bVuwN7SpJiYuP0Zu/ud61DAAAAAAAAuP/cizPeMroFW5rBW6C/rz4e97bOnQ/X+fBLCvDLp8AAP/v75UoXz3gvAAAAAAAAcF8zm0wy32PJW0a3YEtzqakkJSQm6sy5cJ05e16BAX6KjolRdExMBpoNAAAAAACAnOTGjDdnHtlFRrdgS3PG29Hjp9X/nXGKjYvTtWtRataolv7YuUcr1m7R8Ld63aVuAAAAAAAA4H52L55qemMLtkc6vyw31/RvwZZm8DZ2yhx1btdSnR5toRYdX5IkBVeuoLFT5t6lLgAAAAAAAOB+dy8uNb2xBVvYuXBdiEj/FmxpBm8HDh/T5PcHXn+W1HEvL09FRbPUFAAAAAAAAM65Fw9XuCF/oJ/yB/qlXfAWaQZvvj55dSbsggoFBdpfO37yjAL9fdN9MwAAAAAAAORM98pS0x6vD9f08UMlSd16Dk41CJw79b0060ozeOvQuqneGjFJL3brKKvVqt+3/6UZcxeqY9vm6Ws1AAAAAAAAcizT9V/OlMtKHVo3s//+8fYtM1RXmsFb53YtZbGY9cnsb2S1WjXxk8/VsU1z1atVLUM3BgAAAAAAQM5xr8x4a9mkjv33oc0bZKiuNIO3y1euqn1oU3VskzTD7UL4Rc1dsFidu3+ltYtnZ+jmAAAAAAAAyBnuleDtZkt+XaeK5UqqVPEiOnj4mIZ/OF0Wi1lD3uih0iWKpHm9ObU3/jn4r9o/3UetHu+p1k/20u49B7RoyUo9/kJ/nT13QVPGDLqrHQEAAAAAAMD9y2QyOf3ILuZ8+YN88+WVJE2dtUA1qz+o+rVDNGHaPKeuT3XG20czvlSzhrXVqnl9LV62RoNHTlaAv4+mfTgkzaNSAQAAAAAAgJvdizPeLl25Kp98eRQbF6e/9x3SB8Nel8Vi0dffL3Pq+lRnvB0+ekI9nuukEsUKqceznRVx6bI+GPY6oRsAAAAAAADSzWRy/pFd5PH20olTZ7Vl258qX6aE3NxclZCYIJvN5tT1qc54i09IkIvFIklyz+UmL09P+fv53J1WAwAAAAAAIEcxm0wyO5OqpTN5O3HqrIZ/OF2Xr1yVt5eHhvTroZLFC6dY1maz6dUBo7X/0FGtWDQjzbo7t2upbq8MliS93b+HJOnPvw+oeNGCTrUt1eAtIT5R3/zwq/15fHyCw/MbNwcAAAAAAADSYtRS0zGTZqtdq8YKbdFAqzds1chx0zX7oxEpll2w6BcVCgrU/kNHnar7yY6tVK9WsMxmswoFBUqSCgT6aeBrzzt1fapLTStVKKV1m/6wPyqWK+nwfP3m7U7dAAAAAAAAADBiqWnEpcvad/CIWjatK0lqXO8hhZ2P0IlTZ5OVPXL0pNZv3q6nH2/jdP2xcXEKKhBgD93WbtqmYyfPqFTxtE80lW4z423ah0OcbgQAAAAAAABwO2aZZHZqOpvzydu58xHy981n3y7NZDIpf4Cfws6Hq0ihAvZyCQkJGj1xlga//oIs5lTnoSXTZ+D76vXiU3qgQmnNmr9I3y9dJYvZogOHjur5rh3SvD7V4A0AAAAAAAC4W5ydzXajTNeX35Lp+pOObZrrsbbN7/jes+Z/r0Z1q6t40UI6c/a809f9e/y0KpQtKUn6ecUGTR79lrw8PdTj9eEEbwAAAAAAAMge0rvH2/xPRsvF5fbRVWCAry5EXFJCYqJcLBbZbDaFnQ9X/gA/h3I7d+9T2PlwLVyyQomJiYqMilb7bq9p9uTh8smXJ9X6rVarTKakAxysNpv90IYrV6850RGCNwAAAAAAAGQCI0419c2XV+VKF9evqzYptEUDrdm4TYH+vg7LTCXpk/FD7b8/c/a8uvUcrO/nTUyz/gplS2rc1Lm6EHFJdWpUlSSFnQtXbm8vp9rn/KJWAAAAAAAA4E45e7BCOk81HdC7u374ebU6d39Dn3+9RIP7vSRJGjVhpjZsydjhoG+99ryuRUbL28tTLz7dUZL0176D8vfzcep6ZrwBAAAAAADAcM7OeLOl51hTScWKFNTMicOSvT6o74splg8qEKAVi2Y4VXdQgQC9O7CnJOlC+EXNXbBYS5atVXjEZaeuJ3gDAAAAAACA4dJ7uEJ2kJho1cbfd2jJsnX67Y/dstmsevbJdurcroVT1xO8AQAAAAAAwHBmObfnmc3ohjjh2InTWvLrOv2ycqNiYmLVoE51jR/ZX+9+8LE6tm2mvHlyO1UPwRsAAAAAAAAMZzKZZHJiOpszZYz25IsDlDePt3o+/4SaNawpD3d3SemfjcfhCgAAAAAAADCcKR2PrNaqeX3FxcVr+pxv9Onni3T46Ik7qocZbwAAAAAAADCcUYcrGGFIv5f0es9uWrl2i5b8ul4LFv2i0iWLKioqRpGR0fLNl9epejIleGvf7TW5ubool5ubYuPiFNqigbo93jZDdY6aMFMtG9dVSNWKd6mVjv7ae1AffvSZJCkhIVGVHyir11/pJjc3V0PuBwAAAAAAcD9zdjZb1sduSTw93NX2kcZq+0hj/XvslJYsW6vzFy7q6VcGqUXj2qmemnqzTJvxNmLQqypbqpjOXYjQUy8OUEiVSqpUvtQd1+dM5zKiTMmimv3RcLm4uMhqteqtEZP03U8r9WSHRwy9LwAAAAAAwP3oXjzV9IYSxQqpd48u6vnCE9qwebt+Wr7OqesyfalpoL+vihUpqLPnLqhS+VIKj7ik8dPm6UzYBcXGxalB7RD1eLaTJGn3ngMaO2WOEq1WVShbUvsPHlXfV7oquEpF9ew/Uo+3f1gN61TXiLHT5eriolNnzunUmXMKrlJB7UObauqsrxR2LlwN6oSoT4+uknTb+93M3T2X/ffxCQmKjY2TKdtkrgAAAAAAAPeWe+lwhdS4WCxqXL+GGtev4Vx5g9uTzNHjp3X5ylUFV64gSRoxdrq6PdFWwZUrKCExUW+8PVar1v+uBrVD9PaoKRra/2WFVK2o7bv2auny9anWe/joCU35YJDMJrOefPFNXb0WqcmjByo+IUEdn3ldbVo2UsnihVO9X9MGNZPVeebseb05bIJOnQlTnRpV1bFNM8PGBQAAAAAA4H5mlnOnfNqMbkgmyrTg7e1RH8lkMuv4yTPq06OLfPLlUXRMjP7YuUcRFy/by0VFx+j4yTM6duK0LBaLfQ+3kKoVVSgoMNX669cOVi43N0lSqRJFVDOkslxcXOTi4qISRQvpxOmzCirgn+r9UhJUIECffzJKUdExenfMx1q7aZuaN6qdrNzCxSv03ZIVkiSb7X76eAAAAAAAANwd98OMt/TK9D3etu74W/3fGaeQqpVUsECAJGnmpGH20OyGQ0eOJ6vjdgPv5vrf9RazWbluOgTBbDYrMdGqG5lYSve7HU8PdzVrVEu/rt6cYvD2WNvmeqxtc0lSQkKC6oc+63TdAAAAAAAAOcG9drjC3eDMDL+7qkbwA+rQuqlmzPlWnh7uCq5SUZ9/vcT+/vnwizp3PlxFCwcpITFBO3bvkyTt2L1PJ0+HZejet7vfrU6cOquEhARJUnx8gtZt+kOlSxTJ0P0BAAAAAAByKovJ5PTjfpHpe7xJ0nNPtVen5/rpn4P/atjAVzR5+hfq8tJAySR5uOfSgN7dFRjgpxFv9dLYKXNltVlVvkwJFS0cJG9vrwzd+3b3u9n2P/fq2x+WX58tl6jq1SrpuS7tMnRvAAAAAACAnConLjU1xcXFZttNySKjouXl6SFJ2rv/sN4cNl4LPxvvcOJodnNjqenan7+Ui0uW5Jr3LZ+HemV1E3APurhtyh1fe7vPXEbqBQAAAJDzWGxxWd2ELHMjK3lr3ARZLJY0yycmJmp0v77asHTOPZ+tZOvWr924TQsWLZNNNlksZg3t/0q2Dt0AAAAAAACQMpMp6eFMuftFtg7eQls0UGiLBlndDAAAAAAAAGSQWSaZnTg6wXYfHa+QrYM3AAAAAAAA3B+Y8QYAAAAAAAAYwHT9lzPl7hcEbwAAAAAAADAcM94AAAAAAAAAA7DHGwAAAAAAAGAAZrwBAAAAAAAABiB4AwAAAAAAAAzA4QoAAAAAAACAAcympEdabPdP7kbwBgAAAAAAAOMx4w0AAAAAAAAwAHu8AQAAAAAAAAZgxhsAAAAAAABgAPZ4AwAAAAAAAAzAjDcAAAAAAADAAOzxBgAAAAAAABjAdP3hTLn7BcEbAAAAAAAADGeWZHZiOpvN+KZkGoI3AAAAAAAAGI4ZbwAAAAAAAIARcmDyRvAGAAAAAAAAw3GqKQAAAAAAAGAATjUFAAAAAAAADJADV5oSvAEAAAAAACAT5MDkjeANAAAAAAAAhmOPNwAAAAAAAMAA7PEGAAAAAAAAGMSITO3EqbMa/uF0Xb5yVd5eHhrSr4dKFi/sUOaPXXs0bdbXio6JkUkm1alZVT27Py6z2WxAi/5jbO0AAAAAAACA9N8eb8480mHMpNlq16qxvpk9Vl07t9HIcdOTlcnt7aURg3rpq5kf6LOpI/TX3oP6ZeXGDHXHGQRvAAAAAAAAMJwpHb+cFXHpsvYdPKKWTetKkhrXe0hh5yN04tRZh3LlShdXoaBASVIuNzeVKVlMZ8LO373OpYLgDQAAAAAAAIa7scebMw9nnTsfIX/ffHKxWK7fw6T8AX4KOx+e6jXhEZe0ZuNW1a1ZLaNdShN7vAEAAAAAAMBwzq4ivVGm68tvyXQ9hevYprkea9s8w22IjIxS/3fGqWunUFUoWzLD9aWF4A0AAAAAAACGM5lM9iAtrXKSNP+T0XJxuX10FRjgqwsRl5SQmCgXi0U2m01h58OVP8AvWdnIqGi9NvhD1a8doic7trqzTqQTS00BAAAAAABgOCOWmvrmy6typYvr11WbJElrNm5ToL+vihQq4FAuKjpGfQd/oFrVK+u5p9rdxV7dHjPecM+4uG1KVjcBOQyfOQAAgHuLz0O9sroJQKqubB2f1U3IculdauqsAb27a+S4GZq7YLG8PD00uN9LkqRRE2aqfq1g1a8dom++/1V79x9RTEys1m3aJklqUr+mnn3q0XTeLX0I3gAAAAAAAGA8g5K3YkUKaubEYcleH9T3Rfvvn33qUcNDtpQQvAEAAAAAAMBwpuu/nCl3vyB4AwAAAAAAgOGc3b8tPXu8ZXcEbwAAAAAAADCcUXu8ZWcEbwAAAAAAADBeDkzeCN4AAAAAAABgOPZ4AwAAAAAAAAzAHm8AAAAAAACAAXLgSlOCNwAAAAAAAGSCHJi8EbwBAAAAAADAcOzxBgAAAAAAABiAPd4AAAAAAAAAA+TAlaYEbwAAAAAAAMgEOTB5I3gDAAAAAACA4djjDQAAAAAAADAAe7wBAAAAAAAABsiBK00J3gAAAAAAAJAJcmDyRvAGAAAAAAAAw7HHGwAAAAAAAGAA9ngDAAAAAAAADJADV5oSvAEAAAAAAMB4zHgDAAAAAAAADJHz5rwRvAEAAAAAAMBwzHgDAAAAAAAADJDz5rsRvAEAAAAAACATMOMNAAAAAAAAMIDp+i9nyt0vCN4AAAAAAABgvBy41pTgDQAAAAAAAIbLgbkbwRsAAAAAAACMxx5vAAAAAAAAgAHY4w0AAAAAAAAwADPeAAAAAAAAAAMQvAEAAAAAAAAGYKkpAAAAAAAAYABmvBmkfbfX5ObqolxuboqNi1Noiwbq9njbDNU5asJMtWxcVyFVK96lVqbMZrPp1QGjtf/QUa1YNMPQewEAAAAAAOD+kWkz3kYMelVlSxXTuQsReurFAQqpUkmVype64/oG9X3xLrYudQsW/aJCQYHaf+hoptwPAAAAAADgfsSMt0wQ6O+rYkUK6uy5C6pUvpTCIy5p/LR5OhN2QbFxcWpQO0Q9nu0kSdq954DGTpmjRKtVFcqW1P6DR9X3la4KrlJRPfuP1OPtH1bDOtU1Yux0ubq46NSZczp15pyCq1RQ+9CmmjrrK4WdC1eDOiHq06OrJN32frc6cvSk1m/ersH9XtLqDVszbYwAAAAAAADuN+zxlgmOHj+ty1euKrhyBUnSiLHT1e2JtgquXEEJiYl64+2xWrX+dzWoHaK3R03R0P4vK6RqRW3ftVdLl69Ptd7DR09oygeDZDaZ9eSLb+rqtUhNHj1Q8QkJ6vjM62rTspFKFi+c6v2aNqjpUF9CQoJGT5ylwa+/IIvZbOiYAAAAAAAA3O+Y8Wagt0d9JJPJrOMnz6hPjy7yyZdH0TEx+mPnHkVcvGwvFxUdo+Mnz+jYidOyWCz2PdxCqlZUoaDAVOuvXztYudzcJEmlShRRzZDKcnFxkYuLi0oULaQTp88qqIB/qve71az536tR3eoqXrSQzpw9f9u+LVy8Qt8tWSEpaU84AAAAAAAAODJdfzhT7n6R6Xu8bd3xt/q/M04hVSupYIEASdLMScPsodkNh44cT1aH6TaRp5vrf9dbzGblcnO1PzebzUpMtOpGJpbS/W61c/c+hZ0P18IlK5SYmKjIqGi17/aaZk8eLp98eRzKPta2uR5r21xS0ky5+qHP3rZuAAAAAACAHCcHJm+ZvoayRvAD6tC6qWbM+VaeHu4KrlJRn3+9xP7++fCLOnc+XEULBykhMUE7du+TJO3YvU8nT4dl6N63u9+tPhk/VN9/Pknfz5uo6eOGysvTQ9/Pm5gsdAMAAAAAAEDaTOn4db/I9D3eJOm5p9qr03P99M/BfzVs4CuaPP0LdXlpoGSSPNxzaUDv7goM8NOIt3pp7JS5stqsKl+mhIoWDpK3t1eG7n27+wEAAAAAAMAYOXGPN1NcXGy23ZQsMipaXp4ekqS9+w/rzWHjtfCz8XJ3z5XFLUvdjaWma3/+Ui4uWZJrAgAAAECO5PNQr6xuApCqK1vHZ3UTssyNrGT1T184lZUkJCSoSesu2rB0jlPlT5w6q+EfTtflK1fl7eWhIf16qGTxwsnKLV62Vp9/vUQ2m00hVSqq/6vPGp7dZOtkaO3GbVqwaJlsssliMWto/1eydegGAAAAAACAVBi0x9uYSbPVrlVjhbZooNUbtmrkuOma/dEIhzKnz57TzLkLNWfqSPn65NWbw8brh5/X2PfsN0q2Dt5CWzRQaIsGWd0MAAAAAAAAZJCz+7elZ4+3iEuXte/gEU0cPUCS1LjeQxo3da5OnDqrIoUK2Mut3rBV9WoFy883nySpfWhTzV2wOGcHbwAAAAAAALg/JCYmOrV/W2JiotN1njsfIX/ffHKxWCRJJpNJ+QP8FHY+3CF4CzsXrgL5/e3Pg/IHKOxc8sM27zaCNwAAAAAAABjGZDIr0N9Xzdo+7fQ13t6e6vryWzJdT+o6tmlu+Ow0IxC8AQAAAAAAwDAWi1mL5k2UzWZ1+hqTySyLxZxmucAAX12IuKSExES5WCyy2WwKOx+u/AF+DuXyB/rp1Olz9udnws4rf6DfrdXddWn3AAAAAAAAAMgAi8UsFxcXpx/OhG6S5Jsvr8qVLq5fV22SJK3ZuE2B/r4Oy0wlqXG9Gtr42w6FR1ySzWbT90tXqVnDWne9n7dixhsAAAAAAADuWQN6d9fIcTM0d8FieXl6aHC/lyRJoybMVP1awapfO0SFggL1wtMd1eP14ZKkapUrqH1oE8PbZoqLi7UZfpccJCEhQfVDn9Xan7+Uiwu5JgAAAABkFp+HemV1E4BUXdk6PqubgCzAUlMAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAgjcAAAAAAADAAC5Z3YD7jc1mkyQlJCRkcUsAAAAAIKexZXUDgFTZbDaZTKasbgYyGcHbXZaYmChJata2Wxa3BAAAAABylko+Wd0CIHWJiYlycSGGyWlMcXGx/JPAXWS1WhUXFyeLxaKnXxmk+Z+Mzuom3de6vvwWY5wJGGfjMcaZg3HOHIyz8RjjzME4Zw7G2XiMceZgnDPHvTzOFouFGW85EFHrXWY2m+Xu7i5JMplMpNkGY4wzB+NsPMY4czDOmYNxNh5jnDkY58zBOBuPMc4cjHPmYJxxr+FwBQAAAAAAAMAABG8G6timeVY34b7HGGcOxtl4jHHmYJwzB+NsPMY4czDOmYNxNh5jnDkY58zBOONewx5vAAAAAAAAgAGY8QYAAAAAAAAYgOANAAAAAAAAMADBGwAAAAAAAGAAzuBNQ1xcvMZNnattO/fo8pWr8vfzUdfOrdWmZUNJUmRklMZM/kybtu5ULjc3Pda2ubp3aW+/Pq33B42YpN17Dyg6JlZ5c+dWm4cb6rmn2mV2N7OU0WPcs/9I/b3vkFwsFvtrX88eqwA/n8zrZDZg5DifPXdBT704INn9ateoog/f7Zd5ncxiRn+W/zn4ryZ8/LkO/Xtc+fLk1vNdO6hV8/qZ3s+sltFxnj73W63fvF3Hjp9Wx7bN1feVpx3qf3/iLO38a59OnApT75e66IkOD2dq/7ILI8c5Li5erw0eo6PHTis2Pk7+vj56suMjateqSab3MysZ/Vlu3+01RVy8LIs56d9ZLRaLViyakXkdzCaMHOddf/2j14d86HC/mNg4Pda2uV7v2S1zOphNGP153rr9L02dvUAnT4UpMMBXvV/qotoPVcnUPma1jIxxxKXLmvTJF9r51z5FRkWrUFB+vfh0B9WvHWKvn++/JEaOM99//zH688x3ILITgrc0JFoT5eebT5PfH6hCQYHa889hvT7kAwX6+6pmyIMaN22erly9ph8+n6SLl66o98D3VSDQ3/7DcFrvd+/aQUULFZCbm6vOnrugvoM/UFB+fz3ctF5WdjtTGT3GktSz+xM59j8ebjBynAsE+mv1j7Ps94qPT1Cbp3qpWcPaWdXdLGHkGF+9FqnXh3yoF57uqGmPDNE/B4+oz1tjVCgoUFUeKJfFPc9cGR3nwgXzq9cLT+rHX9akWH/pkkXVtGFNTZ/zbWZ2K9sxcpwtFote7/mMihctKBeLRf8eO6X/vfmeihcpqKoPls/srmYZoz/LkjT8rf+pYZ3qmdWlbMnIca76YHmH77+Ii5fVtktvNWtYK9P6l10YOc6nzpzTwOETNfytXqpTo4o2b/1Tg0ZM1vzpo1UoKDCzu5plMjLG0dGxKluqmP73/OPy9/PRpq27NHTUVM3+aLhKFCskie+/G4wcZ77//mP051niOxDZB0tN0+Dh7q6XnnlMhQvml8lk0gMVSiu4SkX9+fd+xcTEauW639Tj2U7K7e2looWD9NijzbXk13WSlOb7klS6RBG5ublKkkwyyWwy68SpsCzpa1YxeoyRJDPHed3mP2S12tSoXs76ojNyjP/ae1Burq7q0LqpLBazKpUvrUZ1q2vxsrVZ2OOskZFxlqTQ5g1U+6Eq8vL0SLH+x9o210PVHrD/3ZxTGTnOFotZpUsUsc9ENpkkk8mkk6f5/rubn2Ukycxx/nnFBhUplF+VK5U1skvZkpHj/Nsff6pc6eKqV6uazGaz6tWqporlSuqXlRsys4tZLiNjXCgoUF06hSowwE9ms1n1awWraJEC+vufQ/b6+f5LYuQ48/33H6M/z0B2QvCWTrFxcdq7/7BKlyyqYyfPKD4+QWVKFbO/X7ZkMR3+97gkpfn+DR9+9Jkate2udk/3UVRMjEJb5LylYzczYoznfPWDWnTsoW49B+vnFTnrP9JSY8Q43/DTr+vUskkd5XJzM7YT2dzdHGOr1SabzeZQv9Vm06FU/gxykvSMM+6cEePc7+2xatj6OT354gD55surhnVzVlh/KyPGeMyk2Xq408t68bVh2rx1111u8b3JyL8zlvy6Tm1aNrpLLb233c1xTv078MRdbfO9JiNjHHHpso4eP63SJYpkVnPvWUaMM99/yRkxznwHIrtgqWk62Gw2jZ7wqYoULKBGdatr954D8nDP5bB3mLe3p6KiYiRJ0dExt33/hv6vPqd+/3tG+w8d1YYtO5Tb2ytzOpQNGTHGrzz3uEoUKyT3XG76Y9deDXnvI3l6uqtR3Ycyr2PZjFGfZUk6E3ZB23b+rf89/4TxHcnG7vYYP1ixtKJjYvXtj8vVPrSJ9uw/onWb/5BP3jyZ27FsJr3jjDtj1DiPG/GGEhOt+nPPfu3c/U+ODuuNGON3+r+s8mVKyGw2a83GbXprxCR9PHaIKpYrZUQX7glG/p2x669/dPrsOT3SLOdsF5Kauz3ONYIf0JSZX2nd5j9Ut2Y1bfp9p/7ac0DVKlcwqgvZXkbGOD4+QUNHTVXTBjVVoWzJzGz2Pceoceb7z5ER48x3ILITZrw5yWaz6cOP5uj4yTMaM6yvzGazPDzcFRMbp4TERHu5a5HR8vR0l6Q037+Z2WxWhbIl5enpro9mfml8h7Iho8b4wYpl5O3lKRcXF9WqXlntQpto1brfM69j2YzRn+Wly9epbKniDv9CldMYMcZ58+TWh8P7afmaLQp9opc+nrVArVs0UN48uTO3c9nInYwz0s/ocbZYzAquXEERly7ri4VL72bT7xlGjXHVB8vL3T2X3Nxc1bJJHdWrWU1rN24zogv3BKM/y0t+Xaf6tYLlk49/ELnb41ysSEGNGNRLs+Z/r1ade2rJsnVq1qiW8ubxNqob2VpGxjg+PkGDRk5Srlxueuu1FzK76fcUo8eZ778kRo0z34HITgjenGCz2TR2yhzt2X9IE0cNlLeXpySpWOEgubhYdOjIf1NeDx4+plLFizj1fkoSEhJz3B5vUuaOsdlkMqgX2Z/R42y1WrV0+Xq1ebiR8Z3Jpowc4yqVymrmxHf068JP9Mn4oQqPuKxqlXPWRrw33Ok4I30yc5wTExJ14tTZDLf5XpOZY2w259z/7DN6nCMjo7R6/dYc/f0nGTvODeqEaN6097T8u+kaO7yfTpwKy5HfgRkZ4/j4BA0eOVnx8Qka/XYfubqy+Ck1mTnOOfX7T8rccc7J34HIenz6nDB26lzt3nNQk0cPVJ7c/y0DdXfPpaYNamnG3IW6FhmlE6fOauHi5fb/6Err/TNhF7Rmw1ZFRcfIarVq954D+vbH5aoZ8mAW9DJrGTXGV69FavPWXYqJiVViolXbdv6t75euVqN6OXOZqVHjfMPWHX/r0uVratE4Z51mejMjx3j/oaOKi4tXTGycfvx5jXbs3qfH2+fM03rvdJwlKSEhQbFxcbJarbJarYqNi1NCQoL9/fj4pPdtVpsSExOT3r/pX1xzEqPG+cDhY9q6/S/7v2Zv+n2nfl29WTVDKmd2F7OcUWN89twF7fzrH8XFxSshIUEr1/2m9Vu2q0EOPd3NyL8zJGn52i3Km8c7R/433M2MHOd9B44oITFRkVHRmjX/e125es3hBPuc4k7HOCEhQUPe+0jRMbEaM6xvigco8P33H6PGme8/R0aNM9+ByG5McXGxtrSL5Vxnwi6oQ7fX5ObqKovlv5yyZZO6GtCnuyIjozRm8mxt+n2Xcrm5qWPb5nq+a3t7udu9fybsgt4dM02Hj56U1WaVv6+PHmlaT92eaJOjEnkjx/jipSt6Y+g4HT1xSpIUlD9Aj7d/WG1aNszcTmYDRo7zDYNHTlauXG4a2v/lTOtXdmL0GI8cO13rNm9XYmKiHqxYRn16dFXJ4oUztY/ZQUbHecTY6ckOWWnVvL7efqOHJKln/5Haufsfh/ef79peLzzd0cBeZT9GjvO+A0f04Uef6djJMzLJpKD8AerQpqnahzbNtP5lB0aO8b/HTumd96fq5OkwWSwWFSlUQM91aaf6tYIzrX/ZhdF/Z0hS91eHqvZDVfRit5z198TNjB7n3gPf1579h2SSSTWCH9BrL3dVYIBf5nQum8jIGO/YvU//6/+e3NxcZbnp54xuT7TVs08+KonvvxuMHGe+//5j5DjzHYjshuANAAAAAAAAMEDOmVYFAAAAAAAAZCKCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAACcM//ATvfnOeIfXIi5d1iOdX9G6zX9kUasAAACQnRG8AQAAOOH1nt20/9BR/bJyo/21DyfPUe2Hqqhhnep35R4JCQl3pR4AAABkDy5Z3QAAAIB7gbeXpwa//qLeHj1V1atV0o4/92nv/sP6Ysb7Gjtlrjb+tkNxcfGqWb2y+v2vm7y9PCVJw8ZM0/ZdexUVE6MiBQvo1RefUkjVipKkpcvX6+vvl6l+7RD98PNqVa5YVqOH9snKbgIAAOAuMsXFxdqyuhEAAAD3ig+nzNGx46d16N/jGj7wf/rxlzWyWCzq/+qzcnGxaPSET2WxWPTOm69Ikn76dZ0a1XtI7rnctOD7Zfr865+0aN4EeXl6aOny9Ro94VN179peT3duo8TERLm758riHgIAAOBuYakpAABAOvR64QmdPB2mBnVCVKZUMa3dtE1v9HpWub295OHurhe7PaaV635TYqJVktS6ZUN5e3nKxcVFXTu1ls1m1aF/T9jr8/Ly1LNPPipXVxdCNwAAgPsMS00BAADSwcPdXQWDAlSyWBGdCTsvq9Wmjs/0dShjNpkVfvGS/H3zacbchVq1/ndFXLoss8msyKhoXb581V42wN9HZjP/FgoAAHA/IngDAAC4Q/kD/GQ2m7Tky49SnK22bNVGLV+zRRNHvakihQrIZDKpRceXZNN/O32YTabMbDIAAAAyEf+8CgAAcIf8fPOpQe3qGjt1ri5dn8UWHnFJazdtkyRFRkXL1dWivHlyKz4+QbPmf6+oqJisbDIAAAAyEcEbAABABgx54yXl9vZU91eHqmn7F/RyvxHaf/CoJKlV8/oqUaywOnR7TR2ffV25crkqIMA3axsMAACATMOppgAAAAAAAIABmPEGAAAAAAAAGIDgDQAAAAAAADAAwRsAAAAAAABgAII3AAAAAAAAwAAEbwAAAAAAAIABCN4AAAAAAAAAAxC8AQAAAAAAAAb4P+SXsKzoI+gKAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1400x400 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "25199729",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "plot_regime_heatmap(\n",
-    "    kmeans_labels_full,\n",
-    "    macro_data_full.index,\n",
-    "    f\"K-Means Regime Assignments ({start_yr}-{end_yr})\",\n",
-    "    n_regimes=n_regimes_full,\n",
-    "    is_probability=False,\n",
+    "column_distances = pdist(extended_df.T)\n",
+    "column_linkage = linkage(column_distances, method=\"ward\")\n",
+    "column_cophenetic, _ = cophenet(column_linkage, column_distances)\n",
+    "\n",
+    "month_distances = pdist(extended_df)\n",
+    "month_linkage = linkage(month_distances, method=\"ward\")\n",
+    "month_cophenetic, _ = cophenet(month_linkage, month_distances)\n",
+    "\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"Cophenetic correlation is **{column_cophenetic:.2f}** for the tree over the \"\n",
+    "        f\"indicators and **{month_cophenetic:.2f}** for the tree over the months, against a \"\n",
+    "        f\"conventional bar of {MIN_COPHENETIC}.\"\n",
+    "    )\n",
     ")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "23b39f1e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003478,
-     "end_time": "2026-07-18T19:35:45.180464+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.176986+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Agglomerative Clustering\n",
-    "\n",
-    "Hierarchical clustering on observations (not features) shows how months group together."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0e3b75db",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003565,
-     "end_time": "2026-07-18T19:35:45.187588+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.184023+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Linkage Matrix"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 25,
-   "id": "b2946d8f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:45.195265Z",
-     "iopub.status.busy": "2026-07-18T19:35:45.195177Z",
-     "iopub.status.idle": "2026-07-18T19:35:45.198681Z",
-     "shell.execute_reply": "2026-07-18T19:35:45.198367Z"
-    },
-    "papermill": {
-     "duration": 0.007989,
-     "end_time": "2026-07-18T19:35:45.199088+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.191099+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cophenetic correlation: 0.710\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "9c08c231",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "Z_full = linkage(macro_data_full, \"ward\")\n",
-    "pairwise_dist = pdist(macro_data_full)\n",
-    "c, _ = cophenet(Z_full, pairwise_dist)\n",
-    "\n",
-    "print(f\"Cophenetic correlation: {c:.3f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "47f9b16a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003622,
-     "end_time": "2026-07-18T19:35:45.206257+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.202635+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "**Note**: The cophenetic correlation measures how faithfully the dendrogram\n",
-    "preserves the original pairwise distances; good dendrograms score above 0.7.\n",
-    "Here it reaches 0.71, so the Ward-linkage tree is a reliable summary of the\n",
-    "indicator distance structure — the block grouping above reflects real\n",
-    "hierarchy rather than an artefact of the linkage choice."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3d9890e5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003857,
-     "end_time": "2026-07-18T19:35:45.214001+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.210144+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Dendrogram"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "7e7b7f90",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:45.222492Z",
-     "iopub.status.busy": "2026-07-18T19:35:45.222369Z",
-     "iopub.status.idle": "2026-07-18T19:35:45.280670Z",
-     "shell.execute_reply": "2026-07-18T19:35:45.280319Z"
-    },
-    "papermill": {
-     "duration": 0.063639,
-     "end_time": "2026-07-18T19:35:45.281424+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.217785+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABkEAAAH1CAYAAABBblnRAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAW4dJREFUeJzt3XeYXGXZB+DfJrshJKQQ0gi99yK9KyAgoDQBGyofKtgVUVRAREDUUFRUFBQEVEB6kU7oIBKkSW/Sk5BCEhJI2ex+f4Rds8luts7M7sl9X5eXZHbmnGfOnDmbPL/zvm/VnDmz6wMAAAAAAFAwvSpdAAAAAAAAQCkIQQAAAAAAgEISggAAAAAAAIUkBAEAAAAAAApJCFICDz/2VLbd45A8/NhTnd7WuPETs+0eh+T6W+7u8Gv/dtn1na6D/9n/c9/OSaedXekyup2G860rzvtS++r3Ts5nDv9BpcvosJNOOzv7f+7blS6jYkrx/q+/5e5su8chGTd+YpduFwAAAIDKqq50AR11210P5Een/DY/O/5b+dD2Wzb52We/fExe+O+r+e0vjsnmm67f5Gf7HfKtDBs6JH/81Y/LWW6zrr/l7px8+jk57zcnZr21V690Od1Gw3Fp0KemJgMH9M8aq62U7bbaNHvvvlP691u6ghXSVe68b2yuueGOPP3cS5n57nsZPHBANt5g7ez/0V2zxaYbVLq8ipo4+e1cc8Pt2Wm7LbL2GquUfH8PP/ZULr3mlvznqecz/Z0ZGdC/f9Zfd418dPed8qEdtmx9Az3E+Rdfk9VWWSEf3G6LSpfSJtfedGcuuvyGjBs/McOHDcnB++2Rg/bdvdXXnXTa2bnh1nta/Pk1fzszw4cOSZL869//yW13PZCnnnkxL7/2RoYPWy5XXfirrnoLAAAAABXVY0OQTTZcJ0ny+BPPNQlBZs58Ny+98lp69+6dx596rkkIMuGtyZkwcXI+/KFtyl5vR40cMTR3Xndeqnv32I+qw770uY9n1Mhhqa2dl8lvT8sjjz+dX/3hr7n4yhtz6gnfyZqrr1zpEumg+vr6/PT0c3L9rfdk7TVXyScP2DPLDRmcyZOn5q77H8o3vv+znH3G8dl4g7UrXWrFTJr8ds7961VZfsSwRUKQH377C6mrq++yff3xwity3t+uykorjMx+e+2SkSOGZtr0d/LPBx/LD0/6dU74/lezxy7bddn+KunCS67NzjtutUgI8pFdd8iHP7RN+tTUVKiyRV11/ZiMPvPP2XmHLfOpA/bMo088mzPOujCzZs3OZz/xscW+dr+9dsmWH2gaJNbXJ6PP/HOWHzG0MQBJklvuuD+33fVA1llz1QwdsmxJ3gsAAABApfTYzvqw5ZbNqJHD8tiTzzV5/D9Pv5D6+mTXnbbKY0882+Rnjz05/8+bdLKxWl9fn9lz5qbvUn06tZ22qKqqylJ9Sr+f7mjbLTdpMkLm85/cJw89+mS+e/zp+d4JZ+TiP44uy2fQEe/NmpWl+/Yty75mz5mTmurq9OrVc2a3u+jyG3L9rffkE/t/JN864jOpqqpq/Nmhn943N952b3r37l3BCru36uquu3Tffs+DOe9vV2XnHbfKiT/4apNtH3LQR/PAQ4+ntnZep/dTO29e6uvqU1OzaO3l/L60pHfvXundu/tcT2bNnpOzz78s2221aU750beSJPvutXPq6+vy54uuzr577ZKBA/q3+PqN1l8rG62/VpPHHnvi2cyaPTu7LxRoffn/Ds4Pv/2FVFdX56gfnZaXXnm9698QAAAAQIX02BAkSTbeYJ3cdtc/M2v2nMZm+ONPPpfVVlkh2265Sc4468LU1dU1Nocff/L5VFVVNd5d/o+b78pNY+7LSy+/nhnvvpsVlh+eg/bZPQd87MNN9rP/576d1VdZMQftu3vOPv+yvPTy6/nKYZ/IJw/4SN6aODmn/+7CPPjwE1m671LZfZftss0WG3fZexw3fmIO+PyROe6ow7P37jslmT/NyR33PJhLzj01p//2gox95IkstVSf7PnhHfO1L3wyvXu33Ayvr6/PL359Xq6/9e6c9MOv50M7bJkXXno1F195Yx79zzOZNHlqllmmX7bdcpN840ufyqCBA5q8/uHHnspv/nhxXnr59Qwbumw+c9DemTxlas7961X5581/bfLcm8bcm0uuvCn/ffWNLNWnT7befKN8/Yufyojhy3X4eGyx6Qb5v0/vlz/8+dLcPOa+7LvXzo0/e/nVN3POBZfloUefyuzZc7L6qivmsM/slx233bzxOQ1Tbf3hjONz570P5qYx92XWrDnZavMN84NvfSHLDh7Y5Fidf/E1uer6MZn+zsxssM4aOeprn1+kpoZt/u7UYzPmrgdyxz1jUzuvNrdcMX9KryuuuzVXXHtbXh83IYMGLJOdtt8iXz70oAxYpmkD8/Jrb83FV9yQSVOmZo1VV8o3D/90zrnw8iTJWace13j8v3b0KTnxh1/LSy+/nn/ccncmT5mamy//Q+rq6nPBJdfmX/9+POPGT0xVr6psvP7a+ephn8haC4wkaNjGScd8Pa+89mauvuGOvPvue9l6841yzHe+lD41NfnduZfk1jv+mVmzZ2eXHbfK0d88LH36dM0d8rNmz8mFf78uq6w0Kt/40qebBCAN9vzwDk3+/Ma4t/K7cy/JQ488mTlz52bN1VbK/316v2y/9QcWfV8//Hqef+mV/OOWu/Puu7OyxQfWz3e/dmiz591/X3kjp/32/Dz57IsZsEz/fGK/PXLIwR9t8pw5c+bmgkuuzc2335e3Jk3JsoMGZredt83hnzuwyTHZdo9D8vGP7ZYtN9sg55x/eV57c3xWXH5EvnH4p7Ptlps02eZbk6bknAsuz/0PPpoZM9/NisuPyKcO3Csf2+ODTd5Lkpx8+jmN08M1XAdOOu3sPPz4002mLKqrq8tl19ySa2+6M6+/MSH9+vXNOmuumiMOPWix0+2dc8HlGThgmRz7nS81G64sfD2bMnVafn/epbnvX49k5sz3svKKy+eTH/9I9t5tp8bnNFy3vv7FT6V37965/NpbMm7CxPz5tyfn7vsfyrl/vSoXnfOL/Pmiq/PAQ49l5IhhufCsnybp+HXjb5ddnzvveyivvj4us2bPzmorr5DPfXKf7LLjVk0+oyS54dZ7GqeK2mu3HfOj7x7R+D2+8oJfZvmRwxpf05bv71e/d3KmTZuRk4/9Rqvn0/i3JmXWrDlZdeVRi30/Dz/2VKZNn5GPL/T76OMf2y03335/7n/wkXxk1x1aeHXzbrnj/lRVVWWPnZuGIMOWM/oDAAAAKK4eHYJssuHauWnMvXnqmRey2Sbzp716/KnnGu+AnTHz3bz08uuN0yY9/tRzWWWl5Rsb+1f+Y0xWX2WF7LDNZundu1fu+9cjOfW356euvj4H7rNbk329+vq4HP+z32W/vXfJPnt+KKusuHxmzZ6Tb/zgZxn/1uQcvO8eGbrc4Nw05r78+9HSLww9r64uRx4zOuuvu0a+/qVP56FHnsjFV9yQFZcfvkiI0/iaeXX56RnnZMxd/8rPj/92YwP5wYefyJvj3sreu++U5ZYdnJdeeT3X3HhH/vvKG/nTr09obFI/+8LLOfLYU7PckMH54mcPyLy6upz3t6uz7KABi+zr/IuuyTkXXp5dd9o6+3zkQ3l72ju5/Npb8pXvnpwLzjp5kQCgPfbcdfv84c+X5l8P/6cxBHnp5ddzxHdOzLDlls3nPvGx9O27VMbc/a98/ye/yik/+uYi68accdYFGbBM/xz2mf0zbsKkXHrVTTm9+oKcfOw3Gp9zzoWX5/yLrsl2W22SbbfcNM++8HK+dcwvUltb22xdp/3m/AwePCD/95n9MmvW7CTJn/5yRc7961XZ8gMbZv+P7ppXXx+Xq/4xJk8/+1LO+eXxjU3nK6+7Laf/7oJsuuE6+eQBe2bc+In5/k9+lQHL9MvwYUMW2def/3Z1qmuq8+kD98rcuXNTU12d/776Ru6+/6HsstPWGTVyWKa8PS1X33B7vvq9n+aiP/5ikUbnhX+/Lkv16ZPPfeJjef3N8bnsmltTXd07VVW98s6MmfnCZ/fPE0+/mOtvvSfLjxyeLxyyf4c/swU9/sSzmf7OjHxi/z0WG9g1mPL2tBx+5E8ya/bsHLzvHhk4cJnceOs9OfqEM/LT4xb9bM+/5JpUpSqHHPzRvD11ev5+1U355g9/lgvOOqXJyKHpM2bmyGNH54Pbb5Fdd9o6t9/7YH537iVZY7WVGkOLurq6HH3CGXnsieey7147Z9WVR+XF/76WS668Ka+9Pj6/OOHIpu/tyWdz131jc8DHPpx+S/fNZdfckmNOOjNX//VXjdedKW9Py5e+Nf97deA+u2XwoIF5YOxjOeWMP2bmzPfyyQM+klVXXiFf+tzH88cLr8i+e+2cTd+f/m+j9VsexXbKGX/M9bfek2233CT7fORDmTevLo898WyeePqFFkOQ194Yn1deezMf3eODbVpnZ9bsOfna936a19+ckAP32S2jRg7P7Xf/Kyefdk5mzHg3n9j/I02ef/0td2fO3LnZd8+dU/P+2j4Njj35zKy0wsh8+dCDU5/5U3t15rpx6dU3Z4dtN8seu2yXubW1ue3OB3LsyWfmtBOParzW/fjoL+dnvzw366+zeuO1Y4XlR7S4zbZ+f5O2nU9JcuKpf8gjjz+zSGi8sOdeeCVJsu7aqzV5fN21VkuvXlV57oVX2hWC1NbWZszd/8pG66/VJOQBAAAAKLqeHYJsML8x+NiTz2WzTdZP7bx5eeqZF7PXh3fMiqNGZMiyg/LYk89mzdVXzsx338tL/30tH33/TuskOeu045o0RQ/ad/d8+5hf5JIrb1wkBHn9zQn55U+PbnJX9N+vuimvvj4+Jx/7jey609ZJkn333Dmf/coxpXzbSebfnb7rB7fOYZ+Z35g+4KO75vNfOzbX3XxXsyFI7bx5+ckvfp97Hng4o3/ynWy9+UaNPzvgYx/Opw/cq8nzN1xvzRz/s9/lsSeezaYbrZtkfkOwV69eOfuXxzc21Hfdaet86kvfb/LacRMm5U9/uSKHf/7AHPqpfRsf/9AOW+TzXz0uV1x3W5PH22v4sOWyTP9+eWPchMbHfvn7v2TE8OVy3pknNt6d//GPfThHfOfEnHXu3xdplA8aMCC//tn3GwOe+vq6XHb1LZkx890s079f3p46PX+77Ppst9WmOe3Eoxqf94c/X5oLLrm22boGDuif3/z8mMbG/ttTp+fCv1+XrTffKGec/L3GEUmrrDQqp//ugtw05r58dI8PZu7c2pxz4eVZb+3V85vRx6T6/Wmg1lh9pZx82jnNhiBz5s7Neb89qcn5u8aqK+XS805rMi3WnrvukE9+8ehcd9OdjedKg3nz5uX3px3b2Mh9e+o7ue2uB7LNFhvnjJO/9/4x3C2vvzkh/7jlri4LQV5+7c359a62Upuef+Hfr8uUt6flD6f/qHEtoH333Dmf/fIPc+bZF2WnbTdv8p6nvzMjF/9xdGNTf501V81xP/1Nrr3xjhy83x6Nz5s0+e0c/70vN446+dhHPpT9P/etXHfTnY1N61vuuD9jH3kiZ516XOO+k2T1VVfM6DP/nMeffK7JuiUvv/ZmLjrnF1lx1PzG+uabrJ/PfuWY3HLHPxsXs/7D+Zemrq4ufz37Z43ByAEf3TXH/+y3OfevV2a/vXfJkGUHZdstN8kfL7wiG623VqvN7n8/+lSuv/WeHLzf7jnyK59rfPzTB+6V+vqW1w55+dU3ksw/d9rimhtuz8uvvpkTvv+V7LHL9kmS/ffeJV/57k9zzgWXLxKmvDVpSi778+lNRlg1WHP1lXPiD7/W+OfOXjf+ft5pTa/n++yWz3/tuFx85Y2NIchHdt0ho8/8c0YtP7zVY9rW72+DtpxP7TFpytT07tUrQwYPavJ4TU11Bg0YkElT3m7X9h546D+ZNn3GIqNAAAAAAIqu5ywi0IxVVx6VQQOXaVz744WXXs17s2Y3zoO+0fpr5fEnn0+SPPH0C5lXV9ekYblgw2zGzHczddo7+cDG6+WNcW9lxsx3m+xr1Mhhi0wL88+xj2XokMFNplvp23epJlM0ldL+e+/a5M+bbrhO3hj31iLPm1tbm2NPPjP3/euRnHHSd5sEIEnT4zB7zpxMnfZONlx3zSTzR38k80eRjH3kyey03eZNRhSstMLIbLtl0+Ny531jU1dfn1132jpTp73T+L/llh2clVYYkYcfe7pT7ztJll56qbz77qwkybTpM/Lvx57KrjttnXffm9W4v2nTZ2TrzTfOa2+Mz1uTpjR5/b577dxkGqZNNlwn8+rqMn7CpCTJ2EeeyNy5tTlo392bPG/hO90XtM+eOzcZ2dCwjU/s/5EmTfp999w5/fstnfsffDRJ8vRzL2Xa9BnZd8+dGwOQJNljl+1bvPN9zw/vuMh6KH361DTuZ968ukyb/k6WXrpvVl5x+cbPsek2dmhyJ/sG666R+vr6Jo3dhsffmjg5tfM6vy5Eksx8970kSb+l27YGxD/HPpr111mjSQjRb+m+2XevnTNuwsT89/1GfoM9d92hSSN+lx23ytAhgxuP94Lb+Miu2zf+uaamOuuvvUbeGP+/79Dtdz+YVVdaIausNKrJubzFpvMXnF74XN7yAxs0BiDJ/EZ//35L5833t1lfX5877x2b7bf5QOrr02SbW2++cWbMfLfZz6o1d9w7NlVVVTnsMwcs8rPmphtr0PhZ9GvrZ/FYlhsyKLt9aNvGx6qrq3Pwfrvn3fdm5ZHHn2ny/A/tsGWzAUiS7P/Rptevzl43mozyeWdmZsx8L5tuuE6e68DxTNr+/W3QlvMpmT+1XWujQJL51+LqZtZPSeZ/12fPntuOdzM/0Kuu7p1dP7h1u14HAAAA0NP16JEgVVVV2Wj9tfLof55NXV1dHn/yuSw7eGBWWmFkkmSj9dbK5dfdmmT+WiFJmjRSH3vyufzpwivyxNMvZNbs2U223TAioEFz04eMmzApK44asUiTcZUVl++aN7gYffrULNJcHLBM/7wzY+Yiz/3L36/Lu+/Nyhknf69x2rAFTZs+I+f97crceucDeXvq9CY/mzFzfpP07anTMnv2nCYN3gYLP/b6G+NTX1+fgw/7brO1V/fu/Gn33nuzG9//629OSH19fc654PKcc8HlzT7/7anTM3zo/0ZUjFxofYGB74cN098/fuPfmh+GNJxLDZYdPLDFYGLUQudIwzZWXuh8qKmpzqjlhzf+vOH/Fz6O1b17Z/mRQ9u0r2T+1E1/v/rmXHndbRk3fmLm1dU1/mzQwGUWef7IYU233XC+j1ho5Mky/ZdOXV19Zs58d5E1YjqiIaB4971ZbXr++AmTs8tOay7y+KorrfD+zyc1Gcmw8GdWVVWVFUeNyLj3A64Gw4YOWeS7O2BA/7zw39ca//zam+Pz8qtvZs+Dv9JsbW9Pm9bkzyOGLfp5DRjQP++8M/P950/POzPezTU33JFrbrij+W1Ondbs44vzxrgJGbrc4GY/58Vp/CzebdtnMW7CpKw0amSTUCBJVl1p/voWDedyg+bO08afjWj6s85eN+594JGcf/HVef7FVzNn7v8CgsWFQIvT1u9vg7acT+2xVJ8+qZ3b/NR7c+bMzVJLtX2Nnnffm5V7/vlwtt584y75DgMAAAD0JD06BEnmT4l17wOP5MX/vpbHn3yucRRIMn8kyG//dHHemjQljz35bIYut2xWWH54kvmN829+/2dZZaXl880jPp0Rw5ZLdXV1/jn20Vxy5U2pr2s6hcxSfZredV9pvXu1fRDP1ptvlAceejx/u+z6bLbJeou8l+N++pv85+nn85kD985aa6ycfn37pq6+PkceOzr19XUtbLVldXX1qaqqajKFzILaOgKgJW9NnNy4mHSSxul+Pn3gXtl68+YXpV84YGiurvc31uG6llqqfOdIc/u64JJrG6ckOvzzB2bggGVSVVWVX//hr6lr5nPs1cJ6HC0dm04cmiZWeb9h/uJ/X8sHt9uiazbaAS19hxrWp0jmn8trrLZSvnn4Z5p97sKBUYvHruH/37+ufGTX7bPnh3ds9rlrrt62qam6QuNn8XLHGvWtWdx1c+FzuDPXjUf/80yOPuGMbLrROvnuNw7N0CGD07t371x/y9255Y77O/4G2qEt51N7DB0yOPPq6jJl6rQmU2LNnVubae+8k6FD2r6Y+d33P5RZs2dnj11MhQUAAAAseXp8CNIwvdVjTz6Xx596Lp/Y73/TFa271mrpU1OTRx5/Ok8982KTednvfeCRzJk7N6N/8p2MHP6/u7cffqzti5ovP2JoXnz59dTX1ze5A/iV18d15i11uQ3WXTP77b1rvnf86Tn25N/k5z/+duO0S9PfmZmHHn0yX/zsx5us+fDaG+ObbGPZwYPSp09NXn9zQha28GMrjBqe+vr6jBo5bJG7qLvCjWPuS5Js/f70ZKOWn39HeXXv3tlqsw27ZB8N58Rrb4xvDM6S+SNKmhtts7htvPr6uCbbmDu3NuPGT8yWH9igyfNef3NCNt/0fyN1aufNy7jxk9rcFL/jngez+Sbr59jvfKnJ4+/MnJlBg9o3QqCUNtlg7QxYpn9uvfOf+fwn9211cfSRI5bLq818p155f22RkSOajr5Y+Nytr6/P629OaPMaJAtacdTwPP/Sq9nyAxt0eETBggYPGph+/fpm3ry6Vs/V9uxvheVH5F//nr/mQ3tGg6y84vJZecXlc88//5133/tsqwHl8iOG5oX/vpq6uromQcUrr83/fBa8lrZXZ64bd9w7Nn361ORXP/1+45pAyfyF2RfW1uPa1u9vqay1xspJkmee+2+222rTxseffu6l1NXVZ601Vmnztm6+/f70W7pvdtxms64uEwAAAKDb69FrgiTJemuvnj59anLz7fdn4qS3m4wE6dOnJmuvuWouv/a2vDdrdpOpsBoarwve3T5j5rvNNs1asu2Wm2TS5Ldz+z0PNj42a9bsFqe5qaStNtswJx7ztTzw0OM5cfTvU/f+VEm9ezU0BJverXzJVTc1+XPv3r2y5Qc2zN33/zsTJ/9vQd7X3hiff459vMlzP7T9lundq1fO/etViyzKXF9fn2nT3+nw+3jo0Sfz54uuzqiRwxrvah4yeFA223i9XH3DHZk0edHFghee4qsttvzAhqmu7p3LrrmlyXv4+0LHpbVt1NRU59Krb26yjetuujMzZr7b2Nhcb+3VM2jgMrnmxjuarLtx8+33tTlwSeaPQlj4eI+5+1+ZOKl9CyiXWt++S+WzB380L7/6Zn537iXNLtx905h78+QzLyZJtt1y0zz17Iv5z1PPN/78vVmzcs2Nd2T5EcOy2sorNHntjWPubVzrIkluv+fBTJoytUOLU++y09aZOOntXHPjot/pWbPn5L1ZbZtGqkHv3r2y8/Zb5s77xjY7+mLBc7XvUkslSd6Z8e4iz1vYzjtsmfr6+pz3tysX+dniFkZPki999uOZNn1GfvbLPzW77su//v2f3PvAI0nmX/MmT5mW2+56oPHntfPm5bJrb0m/pfvmAxuv22qtLenMdaN3r16pSlXjdS1Jxo2fmLvv//ciz+3bd6nMaMMxbev3t73GvzUpL7/6ZqvP23zTDTJwwDK58h9jmjx+1fVj0neppZrsf+q0d/Lyq29m1qzZWdjbU6e/v57TFunbd6kO1QwAAADQk/X4kSDzF59dPY8+8Wz61NRk3bVWa/LzjdZfKxdfcUOS+XegN9hqs/kNru/9+PTst9cuee+9+U3VZQcPzKQpU9u073333DmXX3trTjz1D3n2+f9muSGDc9OY+xqbl231j5vvygMPPb7I4wfvt0e7ttOaD263RY476ks58dSz06/f0vnBt76Q/v37ZdON1s1fL70+tbXzMmy5ZfOvh/+TceMnLvL6L372gDz48H9yxJEn5oCP7pp5dXW5/Npbs/qqK+b5F19pfN6Ko0bk8EMPzO/PuzTjJkzMTtttnn5LL51x4yfmrvsfyr577pzPHLR3q/X+c+xjeeW1NzNvXl2mvD0t/37sqTz48BMZOXxoRv/kO02m2vnu1w/NEd85MYd8+YfZZ8+ds8LI4ZkydVqeePr5vDXx7fzlD6e061gtO3hgPv3xvXLh36/Ld48/LdtuuWmee/Hl/HPs4xk8qG1z6i87eGA+94mP5dy/XpUjjx2dHbbZLK++Pi5XXndb1lt79cZFlGtqqvOFQw7IGWddmG8cfUp22WnrjJswKTfcendWWH54qtK2O9e33/oDOe9vV+Xk087ORuuvnRdffi03335/k7vYu4vPHLR3XnrljVx8xQ15+LGnsvOOW2W5ZQdl8tvTcvf9/85Tz76Yc3754yTJ5z7xsdx65z/zneNOzUH77p6BA5bJDbfdkzfHT8wpP/rmIlMnDRywTL78nZOy9+47ZcrUafn7VTdlxVEjsu+eO7e7zj133SG33/2vjD7zz3n4saey0fprp66uLq+8Ni5j7v5XfnXK0Vlv7dXbtc2vfuGT+ffjT+eL3zwh++z5oay2ygqZ/s6MPPv8yxn7yJO55Yqzk8wfhTJgmX656vox6devb5buu1Q2WHeNjBq56Oe5+abr5yO77pBLr74lr70xIdtssXHq6urz2BPPZrNN1stB++7eYj0f/tA2efHl13L+xdfkuRdfzm4f2jYjhw/NtOkz8sBDj+ehR5/MT37w1STJvnvtkqtvuD0nn35Onnn+5Sw/YmjuuPfBPP7kc/n2lw9psiB9e3XmurHd1pvm4itvzJHHjs5uO2+Xt6dOzxXX3ZoVR43IC/99tclz111r1Yx95IlcfMUNGbrcshk1clg2WHfRNWfa+v1trxNP/UMeefyZVhdH77tUnxz++Y/ntN9ekGNOPjPbbL5RHn3i2dw05r4ccehBTUb8XH7tLTn3r1fld6OPWWTdp9vueiDz5s1b7FRYL7z0au554OEk80ekzZz5bv580dVJkjVXX9kIEgAAAKBH6/EhSDJ/SqxHn3g266y1apOpUOb/bK1cfEXSr1/frLn6/6YPWWWlUfnpcd/MOedfnt/88aIst+zgHPDRXTN40ID89Iw/tmm/ffsuld/84oc543cX5rJrbk3fvn2y+87bZdstN8mRx45uc/0L3+nbYO/dml8zoDM+susOeffdWTn1t+enf7+l840vfTo/+cFXc8ZZF+aK625Nff38gOiMk7+Xj336G01eu+5aq+WMk7+X3/zxopxz4eUZPnRIvvS5j+flV99snJqowec+sU9WXmH5XHLljTnvr1clSYYPWy5bbbZRdty2bQ21P154RZL5IcHAAf2zxqor5dtfPiR7777TIs3W1VZZIX/+7Uk5969X5oZb78606TOy7OCBWXuNVXPYZ/br0LE64tCD0qdPn1x9/Zj8+7Gns8E6a+TXp3w/Rx1/Wpu38cXPfjyDBw3M5dfeml+f/dcMHLBM9t1r53z5/w5OdfX/vn4NTeqLrrghv/3jxVlz9ZUz+oTv5Je//8si53RLPv/JffLerNm59Y77c9vd/8o6a66a00/6bs4675L2vfEy6NWrV3589Jez07ab5Zob78hFl9+Qme++l2UHDcimG62br33xk42juoYsOyjn/PLH+d25l+Tya2/J7Dlzs+ZqK+fUn3wn22/9gUW2/flP7pMXXno1F/792rz73qxssekG+d43Du3QXfC9evXKL358ZC658qbceNu9ueu+f2eppfpkheWH5+D99sjKCy3C3hZDlh2Uc8/8Sc7769W5676HcuU/bsuggctktZVXzNe+8MnG51VXV+dH3z0ivz/v0ow+88+ZN29ejjvq8GZDkCQ57qjDs+ZqK+W6m+/Kb/90cZbp1y/rrr1aNl5gdFxLjjj0oGy+6fq57OpbcuU/xmT6OzMzcJn+2WC9NTL6hCOz47abJ5nfmP/dqcfmrHP/nhtvuycz330vK6+4fI476vDsvftO7T4WC+vodWOLTTfIMd/5Uv7y9+vy6z/8NcuPHJavfeGTGTdh4iIhyDcP/0x+/uvzcvYFl2f27DnZa7cdmw1BkrZ/f0vl4x/bLdW9q3PRFTfk3gcezvChQ/KtIw7JJ/Zve0B+yx33Z9nBA7PlB1qefu3ZF17OORdc3uSxhj/vtduOQhAAAACgR6uaM2d2Fy13zJLq+yf8Mi+98nou+/PplS6lUOrq6rLnwV/Nh7bfIj888ouVLqdV48ZPzAGfP7LZu9HL4eHHnsrXjj4lPz3um9llx63Kvn8AAAAAoPvp8WuCUF6zZs9p8ufX3hif+8c+ms02Xq9CFRXD7DlzFlkH4cbb7s30d2Zks00cWwAAAACAjijEdFiUz4GHHpm9dtspK4wcnvFvTcqV/xiTmurqHHLwRytdWo/25NMv5Fdn/y277LhVBg1cJs++8HL+cdNdWX3VFbPLjltXujwAAAAAgB5JCEK7bLP5xrn1zn9mypRpqampzobrrZmv/N/BWakDayPwP8uPGJYRw4bksmtuyfR3ZmTggGXykQ/vkK9+4ROpqfE1BQAAAADoCGuCAAAAAAAAhWRNEAAAAAAAoJCEIAAAAAAAQCH1yBCkvr4+tbW1qa83kxcAAAAAANC8HhmCzJs3LzvufWjmzZtX6VIAAAAAAIBuqkeGIAAAAAAAAK0RggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFFJ1pQsAutbnDj8qN912V6XLAAAA2uAjH/5gLjzn9EqXAQBQWEaCQMHcdNtdmTNnbqXLAAAAWjFnzlw3MAEAlJiRIFBAffrU5K2XHqp0GQAAwGIMX32LSpcAAFB4RoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEhCEAAAAAAAoJCEIAAAAAAAQCEJQQAAAAAAgEISggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKKTqcuxkzpy5OfOci/Kvfz+ePn1qstbqK+eE7381r70xPieeenamTX8ny/RfOscddURWX3XFcpQEAAAAAAAUXFlCkLPO+3uqqpJLzzstVVVVmTxlapLkF78+L/vttXP23n2n3H7Pgzn59LNz3m9OKkdJAAAAAABAwZV8Oqz3Zs3KdTffmS8felCqqqqSJMsNGZwpU6fl6edfyh67bp8k2XmHLTNh4pS89sb4UpcEAAAAAAAsAUo+EuSNN9/KwAHL5IJLrs3YR57MUn1q8oXPHpABy/TP0CGDU927d5KkqqoqI4YtlwkTJ2elFUYusp3Lr701V1x3a5Kkvr6+1GUDAAAAAAA9XMlDkHnz5mX8hElZdeUV8tUvfDLPvvByvvXDn+f0k77bru0cuM9uOXCf3ZIktbW12XHvQ0tQLQAAAAAAUBQlD0FGDB+aXr2qsscu86e9WmfNVTNq5LCMmzApk6ZMTe28eanu3Tv19fWZMHFyRgxbrtQlAQBAsz53+FG56ba7Kl0GsISYM2dukmT46ltUuBJgSfKRD38wF55zeqXLACibkq8JMnjQgGyx6Qb5178fT5K8Of6tvDl+YjbeYO2ss+aquXnMfUmSO+4dm+FDhzQ7FRYAAJTDTbfd1diUBCi1Pn1q0qdPTaXLAJYgc+bMdcMHsMQp+UiQJDn6m4fllDP+mN+de0l6VfXK9795WIYPHZLvf/OwnHz6ObngkmvTv9/SOfaow8tRDgAAtKhPn5q89dJDlS4DAKDLGXkGLInKEoKssPzw/O7UYxd5fJWVRuWPvzqhHCUAAAAAAABLmJJPhwUAAAAAAFAJQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEhCEAAAAAAAoJCEIAAAAAAAQCEJQQAAAAAAgEISggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEhCEAAAAAAAoJCEIAAAAAAAQCEJQQAAAAAAgEISggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSNXl2Mn+n/t2+tRUZ6k+fZIkn/vEPvnwh7bJa2+Mz4mnnp1p09/JMv2XznFHHZHVV12xHCUBAAAAAAAFV5YQJElOOuYbWXuNVZo89otfn5f99to5e+++U26/58GcfPrZOe83J5WrJAAAAAAAoMAqNh3WlKnT8vTzL2WPXbdPkuy8w5aZMHFKXntjfKVKAgAAAAAACqRsI0FOPPUPqa+vz/rrrJGvHvaJvDVxSoYOGZzq3r2TJFVVVRkxbLlMmDg5K60wslxlAQAAAAAABVWWEOT3px2XkcOHpra2Nmeff3lOOu3sHP75A9u1jcuvvTVXXHdrkqS+vr4UZQIAAAAAAAVSlhBk5PCh83dWXZ1P7L9HPvGF72X4sCGZNGVqaufNS3Xv3qmvr8+EiZMzYthyzW7jwH12y4H77JYkqa2tzY57H1qO0gEAAAAAgB6q5GuCvDdrVt6ZMbPxz7fe+c+svcYqGTJ4UNZZc9XcPOa+JMkd947N8KFDTIUFAAAAAAB0iZKPBJny9vT88KRfp66uLvX19Vlh5PAc/70vJ0m+/83DcvLp5+SCS65N/35L59ijDi91OQAAAAAAwBKi5CHICssPz4Vn/bTZn62y0qj88VcnlLoEAAAAAABgCVTy6bAAAAAAAAAqQQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEhCEAAAAAAAoJCEIAAAAAAAQCEJQQAAAAAAgEISggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEhCEAAAAAAAoJCEIAAAAAAAQCEJQQAAAAAAgEISggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFFJZQ5B/3HxXtt3jkNx1/0NJkilTp+Xbx/wiB/3fUfnM4T/II/95ppzlAAAAAAAABVZdrh2NGz8x19x4ZzZcb83Gx8469+/ZcL0186tTvp+nnn0xPzjxV7nygl+murpsZXULbz4wOjPHP1TpMiiI+rraJMnzVx9c4Uooiv4jt8iobY6udBkAAAAA0G5lGQlSV1eXU375pxz1tc+lpuZ/Acftd/8r+++9a5Jk/XXWyNAhy+bhx5e80SAzxz/U2LiGzrr/V2vn/l+tXekyKIj6ulohLQAAAAA9VlmGXFx8xY3ZeIO1s+5aqzU+Nm36O6mdNy/LDRnc+NjyI4ZmwsTJzW7j8mtvzRXX3Zokqa+vL2m9lVDVqzpr7XdppcsAaMKIIgAAAAB6spKHIC++/FruvG9sfn/acZ3azoH77JYD99ktSVJbW5sd9z60C6oDAAAAAACKquQhyGP/eTbjJkzMQYd9N0kyZcq0/OKV8/LFzx6Q3r16Z/KUqY2jQcZNmJQRw5YrdUkAAAAAAMASoOQhyAEf+3AO+NiHG//81e+dnE/s/5F8cLst8uSzL+aq68fki5/9eJ569sVMnPx2Ntt43VKXBAAAAAAALAHKsiZIS772hU/mJ6N/n4P+76jUVFfnhKO/kurqipYEAAAAAAAURNkTh7NO/d/aIEOWHZRf/+wH5S4BAAAAAABYAvSqdAEAAAAAAAClIAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSG0OQd6aNCVPPP1CKWsBAAAAAADoMtWtPWHS5Lfzo5/9Lv958rn06VOT2685N7fd9UDGPvxEfnjkF8tRIwAAAAAAQLu1OhLk1N+cnw3WXSNjrvlTqqt7J0m2/MAGeejRJ0teHAAAAAAAQEe1GoI8/tRz+fL/HZyl+vRJUpUkGTRwQKZNn1Hq2gAAAAAAADqs1RCkf7+lM/2dpoHHWxMnZ8iyg0pWFAAAAAAAQGe1GoLsvvN2OeHnv88L/30tSX1efX1cfnHmn7PXbjuWoTwAAAAAAICOaTUEOeyQ/bP2mqvkiCN/khkz38v/ff1HWXXlUTnk4I+Woz4AAAAAAIAOqW71Cb175+tf/FS+/sVPZeq0dzJo4DKpqqoqR20AAAAAAAAd1upIkOdefCUT3pqcJBk8aECqqqoy4a3Jef7FV0peHAAAAAAAQEe1GoKcdOrZmTN3bpPHZs+Zk5NOO7tkRQEAAAAAAHRWqyHImxPeykorjGzy2MorLp83x08sWVEAAAAAAACd1WoIsuyggXlj3FtNHnv9zQkZOGCZkhUFAAAAAADQWa2GILvvvF1+dMpv89iTz2XK29Py2JPP5YRfnJXdd962HPUBAAAAAAB0SHVrTzjsM/vlvVmzcuQxv8is2XOydN+l8rGPfChfOOSActQHAAAAAADQIa2GINXV1fnWEYfkW0cckrenTs+ygweWoy4AAAAAAIBOaTUEaTD9nZmZPWdOxr81qfGxkcOHlqQoAAAAAACAzmo1BHn48adz8mnnZMLESamv/9/jVVXJfTf+pZS1AQAAAAAAdFirIcjoM/+cfT7yoey9x05Zuu9S5agJAAAAAACg01oNQSZOnpLPf2qfVFVVlaMeAAAAAACALtGrtSdsv9WmeeyJZ8tRCwAAAAAAQJdpdSRIv6WXzvd+fEa23XKTLDdkUJOffeuIQ0pWGAAAAAAAQGe0GoLU1tbmg9ttniR5552ZJS8IAAAAAACgK7Qaghz33SPKUQcAAAAAAECXajUEWdDMd99L6usb/9y/f78uLwgAAAAAAKArtBqCjJswKT//1Z/y2JPPZe7cuU1+dt+NfylZYQAAAAAAAJ3Rq7UnnPbb8zNgmf4555c/ztJ9++b8356cHbbZLN//5mHlqA8AAAAAAKBDWg1Bnnj6hRzznS9l7TVWSVVVVdZaY5Ucc+QXc/GVN5ajPgAAAAAAgA5pNQTp3atX+tTMnzWrf7+lM236jPTv3y9vTZxS8uIAAAAAAAA6qtU1QdZaY+U89OhT2WaLjbPJhuvkZ7/6U/ou1SerrrxCOeoDAAAAAADokFZHghxz5JeyykqjkiRHfuWzGTRgmdTWzsvx3zui5MUBAAAAAAB0VKsjQcZPnJxNNlg7STJ40ID88MgvJkkef/K50lYGAAAAAADQCa2OBPnOcaObffy7x5/e5cUAAAAAAAB0lVZDkNQv+tDbU6end+/WXwoAAAAAAFApLU6HtfvHD09SlVmzZ2f3jzdd/+Pd92blY3t8sNS1AQAAAAAAdFiLIcjPf3xkUl+f7/zotPz8x99ufLxXVVWGLDsoK6+4fDnqAwAAAAAA6JAWQ5DNNl4vSXLNX8/MoIHLlK0gAAAAAACArtDqwh5X/WNMnnn+v0mShx97KrsdcHj2PPgreeQ/z5S8OAAAAAAAgI5qPQS5fkxWGjUiSfLHC6/Ilz738XztC5/Mb865qOTFAQAAAAAAdFSrIciMd99N//79MvPd9/LCf1/Lxz+2Wz66xwfz2hvjy1EfAAAAAABAh7S4JkiD5ZYdnMeefC4vv/JGNt5grfTu3SvvvjcrVVVV5agPAAAAAACgQ1oNQb5wyP75+tE/TU11dU79yVFJkrGPPJG1Vl+55MUBAAAAAAB0VKshyB67bJ8PbrdFkqRv36WSJButv1Y2XHfN0lYGAAAAAADQCa2GIMn/wo8GQwYPKkkxAAAAAAAAXaXZEGS/Q76Vq//66yTJ7h8/PEnz63/ccsXZJSsMAAAAAACgM5oNQX7yg682/vfPf3xk2YoBAAAAAADoKs2GIJtsuE6S5O2p0/PA2MfyyH+eyfR3ZmTggGWy2cbr5ZMH7JllBw8sa6EAAAAAAADt0eKaIFOnvZPDvvGj9Ou3dHbabvMMW25IJk6eknv++XBuufOf+fNvTsrgQQPKWSsAAAAAAECbtRiCXPj367LR+mvlx0d/Nb1792p8/IuHfDwnnfaH/OXS6/KNL326LEUCAAAAAAC0V6+WfvDgw//JYZ85oEkAkiS9e/fKoZ/aLw+MfbzkxQEAAAAAAHRUiyHIWxMnZ9WVRzX7s1VXHpWJk6eUrCgAAAAAAIDOajEEqaurX+wLW/s5AAAAAABAJbW4JsjcubW57JpbUl/ffNgxt7a2ZEUBAAAAAAB0VoshyAbrrZE77x3b4gs3XHfNkhQEAAAAAADQFVoMQc469bgu28m3fvjzTH57WnpVVaXf0n1z5Fc/l3XWXDWvvTE+J556dqZNfyfL9F86xx11RFZfdcUu2y8AAAAAALDkajEE6UonH/uNDFimf5LkzvvG5uTTzslf/nBKfvHr87LfXjtn7913yu33PJiTTz875/3mpHKUBAAAAAAAFFyLC6N3pYYAJElmznwvVVXJlKnT8vTzL2WPXbdPkuy8w5aZMHFKXntjfDlKAgAAAAAACq4sI0GS5Cej/5CHH3sqSXL6yd/LWxOnZOiQwanu3TtJUlVVlRHDlsuEiZOz0gojF3n95dfemiuuuzVJWlysHQAAAAAAoEHZQpAfH/3lJMn1t96ds869JId//sB2vf7AfXbLgfvsliSpra3Njnsf2tUlAgAAAAAABVKW6bAWtPduO+Xfjz2V4UOHZNKUqamdNy/J/NEdEyZOzohhy5W7JAAAAAAAoIBKHoK8M2NmJk5+u/HPd93/UAYNXCbLDh6YddZcNTePuS9Jcse9YzN86JBmp8ICAAAAAABor5JPhzVj5ns59uQzM3vOnPSq6pXBgwbktBO/m6qqqnz/m4fl5NPPyQWXXJv+/ZbOsUcdXupyAAAAAACAJUTJQ5DlRwzNeb85sdmfrbLSqPzxVyeUugQAAAAAAGAJVPY1QQAAAAAAAMpBCAIAAAAAABRSyafDAgAAAJYcXzl6dMbcPbbSZQDNmDOnNkmy9jYHVbgSoDm77rRlfj/66EqXUThCEAAAAKDLjLl7bObMrU2fGi0H6G6Gr7hWpUsAWjBnbq2bCErE30gAAACALtWnpjrPPXBZpcsAgB7DCK3SsSYIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEhCEAAAAAAAoJCEIAAAAAAAQCEJQQAAAAAAgEISggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkKorXQAAAAAAACTJV44enTF3j610GWU3Z25tkmTtbQ6qcCXlt+tOW+b3o48u2faNBAEAAAAAoFsYc/fYxkBgSdKnpjp9apa8MQtz5taWPPRa8o4qAAAAAADdVp+a6jz3wGWVLoMyKMfIFyNBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEhCEAAAAAAAoJCEIAAAAAAAQCEJQQAAAAAAgEISggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACik6koXALCwNx8YnZnjH6p0GSSpr6tNkjx/9cEVroQG/UdukVHbHF3pMgAAAAB6BCNBgG5n5viHGpvvVFZVr+pU9ZKXdxf1dbUCQgAAAIB20NkCuqWqXtVZa79LK10GdCtG5AAAAAC0j5EgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEjVpd7B7Dlzcvwpv8t/X30jS/Xpk2UHD8z3vnFoVlphZKZMnZYTR/8hb4x7K31qavLdbxyaD2y0bqlLAgAAAAAAlgBlGQmy71475+/nnpq//OGU7LjtZvnZr/6UJDnr3L9nw/XWzGV/Pj3HHvWl/Pjnv0ttbW05SgIAAAAAAAqu5CHIUn36ZLutNk1VVVWSZMP11sy4CZOSJLff/a/sv/euSZL111kjQ4csm4cff6bUJQEAAAAAAEuAsq8JcunVN2enbTfLtOnvpHbevCw3ZHDjz5YfMTQTJk4ud0kAAAAAAEABlXxNkAWdf/E1ef3NCfnNz3+Y2XPmtOu1l197a6647tYkSX19fSnKAwAAAAAACqRsIcjfLrs+d933UM78+Q/St+9S6dt3qfTu1TuTp0xtHA0ybsKkjBi2XLOvP3Cf3XLgPrslSWpra7Pj3oeWqXIAAAAAAKAnKst0WBdfcUNuvfOf+fXPfpABy/RvfHyXnbbKVdePSZI89eyLmTj57Wy28brlKAkAAAAAACi4ko8EeWvi5Jx5zkVZYfnh+frRP02S1NTU5Nwzf5KvfeGT+cno3+eg/zsqNdXVOeHor6S6uqwzdAEAAAAAAAVV8sRh+LDl8s+b/9rsz4YsOyi//tkPSl0CAAAALfjK0aMz5u6xlS6DApkztzZJsvY2B1W4Eopk1522zO9HH13pMgDogcoyHRYAAADd05i7xzY2raEr9KmpTp8aszzQdebMrRXWAtBh/lYCAACwhOtTU53nHris0mUANMuoIgA6w0gQAAAAAACgkIQgAAAAAABAIQlBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEhCEAAAAAAAoJCEIAAAAAAAQCEJQQAAAAAAgEKqrnQBAAAAAEX3laNHZ8zdYytdRo80Z25tkmTtbQ6qcCU9z647bZnfjz660mUAVJSRIAAAAAAlNubusY3NfNqnT011+tS4j7e95sytFbwBxEgQAAAAgLLoU1Od5x64rNJlsIQwcgZgPiNBAAAAAACAQhKCAAAAAAAAhSQEAQAAAAAACkkIAgAAAAAAFJIQBAAAAAAAKCQhCAAAAAAAUEhCEAAAAAAAoJCEIAAAAAAAQCEJQQAAAAAAgEISggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCqq50AQAAAAAAQHF95ejRGXP32EUenzO3Nkmy9jYHNXl81522zO9HH90l+zYSBAAAAAAAKJkxd49tDDwW1KemOn1qmo7VmDO3ttnApKOMBAEAAAAAAEqqT011nnvgslaft/CokM4yEgQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAoJCEIAAAAAABQSEIQAAAAAACgkIQgAAAAAABAIVVXugAAqLQ3HxidmeMfqnQZraqvq02SPH/1wRWuZPH6j9wio7Y5utJlAAAAABgJAgAzxz/UGDB0Z1W9qlPVq3vfv1BfV9sjAiUAAABgydC9OykAUCZVvaqz1n6XVrqMHq+7j1IBAAAAlixGggAAAAAAAIUkBAEAAAAAAArJdFiwhOkJC0D3hMWfLfwMACzOV44enTF3j610GW0yZ+78v3utvc1BFa6k7Xbdacv8frS/iwEA0DojQWAJ0xMWgO7uiz9b+BkAaM2Yu8c2hgvdXZ+a6vSp6b5/91rYnLm1PSZgAgCg8nrO33SBLmMB6M7pziNUAIDuo09NdZ574LJKl1E4PWnECgAAlScEAQAAAAAoo540dWa59cSpOsvJtKDtZzosAAAAAIAy6klTZ5ZbT5uqs5xMC9oxZTmbzjjrwtzzwMMZP2FSLjjrp1l7jVWSJK+9MT4nnnp2pk1/J8v0XzrHHXVEVl91xXKUBAAAAABQMabOpL2MjumYsowE2XnHrXL26T/KyBFDmzz+i1+fl/322jmXnndaDjn4Yzn59LPLUQ4AAAAAALAEKEsI8oGN1s3wYcs1eWzK1Gl5+vmXsseu2ydJdt5hy0yYOCWvvTG+HCUBAAAAAAAFV7HJ1d6aOCVDhwxOde/eSZKqqqqMGLZcJkycnJVWGLnI8y+/9tZccd2tSZL6+vqy1goAAAAAAPQ8PWaFmQP32S0H7rNbkqS2tjY77n1oZQsCAAAAAAC6tbJMh9Wc4cOGZNKUqamdNy/J/NEdEyZOzoiFps0CAAAAAADoiIqNBBkyeFDWWXPV3Dzmvuy9+065496xGT50SLNTYQEA0H29dNExmfbMfZUuo0vU185Nkjxy/AcrXEnnDVp3+6z+6VMqXQYAAEBFlSUE+fmvz839Dz6aKVOm5dvH/CL9lu6by88/I9//5mE5+fRzcsEl16Z/v6Vz7FGHl6McAAC60LRn7kv9vLmp6l1T6VI67ZZDB1e6hC5RP29uYYIpAACAzihLCPKDb32h2cdXWWlU/virE8pRAgAAJVTVuyYfOPGuSpfB+4owkgUAAKArVGxNEAAAAAAAgFISggAAAAAAAIUkBAEAAAAAAApJCAIAAAAAABSSEAQAAAAAACgkIQgAAAAAAFBIQhAAAAAAAKCQqitdAAAAAN3PV44enTF3j610GYuYM7c2SbL2NgdVuJJF7brTlvn96KMrXQYAAAswEgQAAIBFjLl7bGPg0J30qalOn5rudz/fnLm13TI0AgBY0nW/vzkCAADQLfSpqc5zD1xW6TJ6hO44MgUAACFIozcfGJ2Z4x+qyL7r6+bfXfX81QdXZP9J0n/kFhm1jWHbAAAAAAAUhxDkfTPHP5T6utpU9Sr/IanEPhdUX1dbsQAIAAAAYElTjnWXyrWGkvWQgO5OCLKAql7VWWu/SytdRtlVcgQKAAAAwJKmYd2lUq5xVI71k6yHBPQEQhAAAAAAKLMirLtkPSSWNOUYxbU45Rrh1ZKeOvKrV6ULAAAAAACA7q5hFFel9KmpLssor+b05JFfRoIA3d6bD4zuVuvW1NfN/2XX3aaS6z9yi4zapuel8ZRGpb43lfx++A4AAABQakUYxdURPXnklxAE6PZmjn8o9XW1qerVPS5Z3aWOBdXX1XaroIjKq9T3plLfD98BAAAA6Hmam2KspWm/OjodV/fr5AE0o6pXddba79JKl9FtdbdRKXQPS9L3xncAAAAAep6GKcYWnOaruSm/OjMdlxAEAAAA6DYqvehsqVR6MdtS6qkL5QLQPbRlirHO/P60MDoAAADQbVR60dlSqeRitqXUkxfKBWDJULzfvgAAUCIvXXRMpj1zX6XLaFX9vLlJkkeO/2CFK2ndoHW3z+qfPqXSZQDdzJK66GxPVMSRLQAUi5EgAADQRtOeua8xYOjOqnrXpKp3TaXLaFX9vLk9IlQCAAB6LiNBAACgHap61+QDJ95V6TIKoSeMVAEAAHo2I0EAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAKSQgCAAAAAAAUkhAEAAAAAAAopOpKFwAAAAAAlN9Xjh6dMXeP7fDr58ytTZKsvc1Bnapj1522zO9HH92pbQC0RAgCBfHmA6Mzc/xDrT6vvm7+X1Cev/rgVp/bf+QWGbWNv4QAALDkaW9jsL2NQA0/oDsYc/fYzJlbmz41HWsRdvR1C5ozt7ZTQQxAa4QgUBAzxz+U+rraVPVa/Ne6tZ83qK+rbVOoQse1Nbhqi/aEW20hAAMAlnTtbQy2pxGo4Qd0J31qqvPcA5dVbP+dHUUC0BohCBRIVa/qrLXfpV2yra5qptOytgZXbdEV22ggAAMAmK9UjUENPzqjs9MXdbWumg6pqxhlBcDChCDdUFfeHd4WXX0HeVu4yxzm68rgqqsIwAAAoPvq7PRFXa271JEYZUXnlDtgrESAKCRkSdV9flPRqCvvDm+Lcu2ngbvMAQAAoOMqPX1Rd9VdRqPQM5U7YCx3gCgkZEkmBOmmuuPd4V3FXeZAKXRmFF1XjIgzwg0AAKBnK3LAKCRkSSYEAaAQOjOKrrMj4oxwa12pp3osx9SOgi4AAADoeYQgNFGO9UjKuQaJhhUsWSo1is4It9aVeqrHUk/tKOhiSffSRcdk2jP3dfl26+fNTZI8cvwHu3S7g9bdPqt/+pQu3SYAANAzCUFoohzrkZRrDRINK4DupSdP9SjoKqaONPY72rTv6U35ac/cl/p5c1PVu6ZLt9vV20vmf0alCGwAAICeSQjCInpyk2pBGlbdT0dHGnV29JARQXSl5s7jls5R5x50bx1p7HekaV+UpnxV75p84MS7Kl1Gq7p6VAkAACwpvnL06Iy5e2yzP5szd37vY3Hry+y605b5/eju1wcRggBl09GRRp0ZPWREEF2tufO4uXPUuQc9Qzka+5ryQBEsrinS1drSZOlq3bVpAwDlNObusZkztzZ9ahbtczT32ILmzK0t298V2ksIApRVuUcaGRFEKbTlPHbuAQBFsrimSFcrxz4W1J2bNgBQbn1qqvPcA5e1+3XlvHmhvYQgAMASoxLT8pkWDYCi6GhTpLvrzk0beqa2jJxq64gno5QAOk8IArAEaUsDuK3N3nI1dtvatG5Pk7qnNqXb08DvSNO+px6X9ij3tHzdfVq0jiwM3pyOLhbekp6+iDgAsGRry8iptox4KsIopa4KhIRBsORZ+PrR3LWirdcGIQjAEqQtDeC2NHvL2dhta9O6rU3q7t6UXpz2NPDb27Tvycelvco5LV93nxatIwuDN6ezr19Qd15EvKOhUWdDIqEQAEuijqxD09H1ZErRYO+KkVNFGKXUFYFQEcIgul4516paUCXWrUqWzCBw4evHwteK9lwbhCAAS5iuaACXu7HblU3r7t6Ubk2pGvg9/bjQceVYGLw9uvMi4h0NjToTEnXnUIjF/+N7cf9AXhL/EQvQXh1Zh6Yj68losJdeZwOhIoRBdL1yrlW1oHLvL1myr1OLu36059ogBAGaaJhuZ+GpdJaEaXIAoDXlDo26cyjE4v/x3dI/kEv1j9hS3A1ZqjsdhUBAW5VjHRoNdnqajv7O78zv9e76u7uoa1UtrDtfpxY8Hxc+x7rTeVP4EKSr55LXCO5aHV2gti06s4htWxT1XGhuup0laZocAID2aO0f3801KubMrV3kH7Od/UdiKe6GLMWdjkvynYwAldBaw9wC7T1PR3/nd/T3ut/dLM6C5+OC51h3O28KH4J05VzyGsFdr6ML1LZFKbbZoOjnwsLT7ZgmBwCopPasx9KRNVhKue5Ka3MZJ133j8RS3A1ZqhEmXXVHo6YcwOK11jBfUhZoL5pyjoDozqMQ6B6aOx+723lT+BAk6br50zWCS6OcC9R2lUqfC82NoGlp5EtRR6wAAEuO9qzH0t41WMqx7kprjYru9o/EBXX1CJOuHF3SXZpy5Vq8WeBTHJ0NF7tiqjrnU/e08LnR3Gfdkc/OmhzAkm6JCEFgQV0xBVdXTLXVmXCiuRE0zY18KfqIFUprcd+VxX0HBG8sSVr7ndKW3xdL4ndmcXf1L+4u/lLerV9OpRrVUJTj05JSrcdi3ZXWlfNu0/Y2h9s6qqSUDd9yLN7cXQKfnqQ951J7QoWuOJc6Gy52Nkxc0s+nrgwaWjrPFndOLW7brY0eLPpn19XHE7qjct080cB3ZD4hCEucrpiCq7NTbXVFONGWETSVHrFSam0JtDQgO25x35WWvgOCt+6vpe+NYKtjWvud0nR9pXlJ6hd5zow3H1jijvvi7upv6S7+ctytXy6lGNVQpOPDkq09zeG2NoLL0TTsbFDUloZIWwKfjjY62rr/pOesG9Ddz6VKLua7pN/V35VBQ0vnWUvnVFu2vbhzo+ifXSmOJ91fJRZ6Tyr3+6ocN080KOJ3pKMLsQtBKkgjqnIqPQVX0cOJcmlLoNVaYKVpv3jt/a44t7u/lr43gq2Oa+v35PmrD25zCL8kHPf23tVftLv1u3pUQ2ePT2ujU9o6IqXoo1Eoj65uDveEpmGl5+xvS0OmJ64bsCSeS91RuRucbWlsdmXQ0J7zzDnUulIdzyKGvUVR7oXek8r/vipXEF7Ea05HF2IXglRQuRtR7povH9OjlE9nA61SNe276vuWOBfoeu353vS0YKu7X3/bE5i0V3umWGrQkQWkk9I3upt7Ly3VquneNVobndKWESlLymiUjt59Vso6mqul3PXQeZWes78rGjJFbLb0JG0NG9obLnT2WlLOBmelG5uUXku/h1s7T4sa9nalSk5H1tWhQFeMsPT3qO6rIwuxC0EqrJyNKHfNl097pkdpjuPc83XF9y3p3udCc83mlhrM5QxyKtUEX3i/ze1HoFV6S/L1tz1TLDVo7wLSSXka3c29l+Zq7UgtCwYsCwYrwpS2j05pbU2XogdVHb37bEFtCTCS8s4b35HGR2s1AuXV1rChPeFCVzV8S33X88KN8UqE06XU8P4qGb53F839Hm7redrTwt5yhxJFmo6ssyMsu/N7o2OEIC3ors29zqrEXfMdXVy5QU86vgvqzLHuaOBV6SZsZ5vP5fisWzpGz115QJPnNdcobW99XTHtWne+C7+5ZnNzx60jTeUFP6cFz5vmPoOWPtOmqlLVq/diamy6VkPDGg3t+cwXPh4L76c9x6G90yX21OtkqVTi+ttdlGrh6AWVa1qq5t5LSyNEFqyptYb7ggFLQ7DSE0cwLHwsyjlSpqXArauCqp6gI3efLailAGNu7bzU1//v99GNY/652Ltbu3I6l9YaHwvXtnCNC1oSm3LQXVRyCrBKhqnNXcOK1MTsae+v1KMmFz7PuzqYWNwognIu0l6JUKJI07u193rY3E0qPTFwbM/3r7lzvaijiwsVgrQnuEgW3zRqqblXXzdvkQbbwguadmUzqj2NwFJpqYakbe+1I4srN+hs87SlbSbFnIKoK5uwXbH/hbXWfF7wu9SeZnd7vn/NHaPmm+YL11n6u8NLFb529ju8OM01m1t6Hx39nBo+q5Y+g7ac91W9ei+2Kd7cWg0d+cwX13xvT3O9PdMl9uSRC3R/7ZmWKin9Hf8LN98Xbrq3teG+cMDSUrDTlqChtfdcqqm9WjsWDfspVQCxuMCtuePW8F67w6iQrvhcu0JLQUolm1ythSptucO80k25tv5jvkFP/ke9KdHobtrbsE1Ku9h8d2/Qtldb319XXBs6u432jprsbiNdFjeKoE9NdebWzmusdUGluDGgSKFE0r7f0+X+/Dsz2rc9ax+1Z0rCjhyD9ryP5s71zo4u7q4KFYK0dldyS3f6Js035JprZrW2qGlXN6Pa0whcUKkCoY42CNtzV25zje6uCl0aamlNJZqKXdWoXvhYd/Z4trXmBeteUGv7aE/zuatCnoWPUcPxaK1JvjilCGgaal1Ye8/PrvgOt0epP6e2PHdBbQ0f2rO/cijl2hGL0xXnclFHU3Yn5Vozo63TUjXsvxx3/C+u+d7Vo1S6InRpdtREVVVSX9/4mTWY+uSd7WrEt2W0TEMA0dmmfkvTiDVXZ3OjbRpet7jj1do0W0ny8HHbJwuNRlj4c2nPaKCG19fX1Tb5PBb8LMod3HTnJl5bGjGVrrct/5hv0NF/1HeHBmPS/IiihRtzCzbkuqqZ1F3ukG6t4dQVCxx3xdR13bnhVwqLu04sbqRIpY9Fd1nvqSt0xXSJXbGN9oyaLNVIl858rh25MaC5cGThYKQrz6dyh+Gl+N2VNP97ulKN946O9m3P2kfNPac9I26Tjp2/Lb2P1v5+V+m/23WVHh+CNNc4TppvqrQUYLS3EVjOJnNz+2tLw6tcgVBz2jLd0IK1LLy/9jZsO9uIX9y0M21t+rWladjaNkrVqC5lA7z5URVNR0u1dm41vK6cze62as9IrJYa/+0Z6dLwusVdXxq0d2RFW7/DpQrjWttvKTS8l64e/dKRGpKuH4XTnvdX7nO5+TC6Kkl9p0ZTLv56P3/Ks//9zvl4Fvw9t7jfOwtuu6uPZ3vOgfY8t9xrZiTNN4K7yx3/DXW01pzviNaChra85+ZGnjQ3nVRXNOLbM91XKYON5o5bayHV4ta1WfC9LKy+rrZJMNKW49bmz6QHTufVnrtpO7q4bCnqbdAVzeG23jXb0X/Ud5cGY8PrFg7NmmvCNLe9jjYHW7tDujmlaGZ1dL73lqadSxZ93619Tknr762lhl9nm6WLC1dW3Xz/Jo8vXHd7QrrWrg3tOY9KdSy6QilHLlTiWtsV0yUuvI1STxVUipsA2vO5tvea2NYRnUnT605XhtNtmV6zHPtr0NHfXYsLSBe8ni24v9amdSp12NzS/jq6r7aOuG3YV6kDoiIFww0qHoK89sb4nHjq2Zk2/Z0s03/pHHfUEVl91RXb/Pr2jpRoTzO/MzUsro5SNeZaCoSa23ZXBULNac90Qy3trz2fU2cb8W25+76149KWpuGCdbS1Ab64990epdpuc9su5bnVnFI2mbvq+tKZaZbaOjVfR9awaG1/XR2alTuUaO7YlXuUV3uOZ3vP5fa8v0qcy22/NnTuer3Alhr321Bbc9o60qytz23PdG2tbbu937/2rJmx4N3zCzZ5m2sQt6eJ3tE7/rtac83zUtbQFftrKSToikZ8W6f7Kkew0V6trWvTsL9SBBjleH/l0J67aTuzuGyDlpoAbW1adMX6KB2d+7oz/6hvrvnV3oWZS9VgbOvdn51t+jZo7TNZcLttPS9a21bD9hosfL40bLu57bYnKGrY1uI+64bXtnf9nubqaM9InpYCheYacQ3bbmtTtD3XhvaeR6U4Fl2lVCMXuuJa21ldce3rzFRBlVSqa2J791eq6S47u7/2hnRd8ftvYe29nrVlWqeO/H2iPUoRQLVnJF1Xh5AL66nf98WpeAjyi1+fl/322jl7775Tbr/nwZx8+tk57zcntWsb3WEKk8407ZOuDx/a1Dwpc2M8WXS6oe7SiG/LugatjfApRQO8pyrlubWwUk/11BXXl85uo9znVqk+v0qEEj3p90NHzuXOjKLqzudy0rHfXZ39vVOq49me71Rnv38tTd/U7N3zi2kQt7WJ3txzW3p+e0YddER7au4KpdpfuRvx3aHx3xUjebrD++hO2nM3bWfvvG2uCdCepkVzNTTU0ZkGY0vPL+U/6js7nUslGg7laPo27Ke950VLoUtVVVVqqns3qaO5KUQWd9w6Ot1Jg65qandmJE9zr2/YRpJON2E7cx1p7flt3V97jkUllPNa21mlbvAXRSnfX1vPga4aOdTW/XXF9awrpjNr7/WsPdsoQgDV3f+O0BNUNASZMnVann7+pfzqZ99Pkuy8w5Y5/XcX5LU3xmelFUa2+LqGv+DU1tamdl4a/7tBc4+19/FSPfd/j1dnrY9e1PjY89d8OpnXFftrut2Wtl3699cd9te5YzHtjQUbtu9/VebNb8xNe+OhDO/gZ9Kez3rx76/on1/Xf9Y99/0V6dwq1bWvu7w/53LHnut3V3ufO6+u+efOq0tSVZNNjx/T5PFHT9g1SbLpCWOaPlbXwjbas782Pj7lqQUCmqr379ivmx+ITHnqvqzcxfsr1XPtr+v31+TcSFo8L7rL+2vQ3GPtfbxUzy33/vrUVOepey9u/PP6O3wqSZo8tuDjbd1fS9tty3MX9/z2PLelx7qi5q6orStqLtX76+x50VJTraa6d4vb6MyxX9zjpfisW3q8O5+f7X1uZ7fR3b8PPW1/jmfP2N/iQonufD3rzteXUl2vO7u/9n7Wpfz9UITvTnOP9+7dO1VVVUmSqjlzZi96y0SZPPP8f/Pjn/8ufz/3tMbHDvvG8fnqFz6RLTbdoMlzL7/21lxx3a1Jkrq6urz6+viy1goAAAAAAHR/91x/fqqr5wdMFZ8Oq60O3Ge3HLjPbknmhyBz5sxpkuYAAAAAAAD07t278b8rGoIMHzYkk6ZMTe28eanu3Tv19fWZMHFyRgxbbrGv69WrV/r27VumKgEAAAAAgJ6oVyV3PmTwoKyz5qq5ecz8RTLvuHdshg8dstj1QAAAAAAAANqiomuCJMkrr72Zk08/J9Omz0j/fkvn2KMOz5qrrVTJkgAAAAAAgAKoeAgCAAAAAABQChWdDgsAAAAAAKBUhCAAAAAAAEAhCUEAAAAAAIBCEoIAAAAAAACFJAQBAAAAAAAK6f8BrbaJl2+sCVYAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1600x500 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "fig, ax = plt.subplots(figsize=(16, 5))\n",
-    "# no_labels=True since the point of this figure is the cophenetic-correlation\n",
-    "# summary in the title, not per-observation identity.\n",
-    "dendrogram(Z_full, orientation=\"top\", no_labels=True, ax=ax)\n",
-    "ax.set_title(f\"Ward Linkage Dendrogram | Cophenetic Correlation: {c:.2f}\", fontsize=12)\n",
-    "ax.set_ylabel(\"Distance\")\n",
-    "sns.despine()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fbfda18a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003824,
-     "end_time": "2026-07-18T19:35:45.289539+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.285715+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## PCA Preprocessing\n",
-    "\n",
-    "Reduce dimensionality before clustering to filter noise."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "01d22859",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003804,
-     "end_time": "2026-07-18T19:35:45.297011+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.293207+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Fit PCA"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "id": "47524097",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:45.305428Z",
-     "iopub.status.busy": "2026-07-18T19:35:45.305300Z",
-     "iopub.status.idle": "2026-07-18T19:35:45.309923Z",
-     "shell.execute_reply": "2026-07-18T19:35:45.309197Z"
-    },
-    "papermill": {
-     "duration": 0.009743,
-     "end_time": "2026-07-18T19:35:45.310475+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.300732+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cumulative Explained Variance:\n",
-      "  PC1: 45.6%\n",
-      "  PC2: 80.4%\n",
-      "  PC3: 87.9%\n",
-      "  PC4: 93.6%\n",
-      "  PC5: 96.0%\n",
-      "  PC6: 97.8%\n",
-      "  PC7: 98.8%\n",
-      "  PC8: 99.4%\n",
-      "  PC9: 99.7%\n",
-      "  PC10: 99.8%\n"
-     ]
-    }
-   ],
-   "source": [
-    "n_pca = min(10, macro_data_full.shape[1])\n",
-    "pca = PCA(n_components=n_pca)\n",
-    "reduced = pca.fit_transform(macro_data_full)\n",
-    "\n",
-    "print(\"Cumulative Explained Variance:\")\n",
-    "cumvar = pd.Series(pca.explained_variance_ratio_).cumsum()\n",
-    "for i, v in enumerate(cumvar):\n",
-    "    print(f\"  PC{i + 1}: {v:.1%}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "03cde021",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003829,
-     "end_time": "2026-07-18T19:35:45.318596+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.314767+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### GMM on PCA-Reduced Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "id": "0379e017",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:45.344090Z",
-     "iopub.status.busy": "2026-07-18T19:35:45.343939Z",
-     "iopub.status.idle": "2026-07-18T19:35:45.454693Z",
-     "shell.execute_reply": "2026-07-18T19:35:45.454286Z"
-    },
-    "papermill": {
-     "duration": 0.141718,
-     "end_time": "2026-07-18T19:35:45.464100+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.322382+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GMM on PCA silhouette: 0.396\n"
-     ]
-    }
-   ],
-   "source": [
-    "gmm_pca = GaussianMixture(\n",
-    "    n_components=n_regimes_full,\n",
-    "    covariance_type=\"full\",\n",
-    "    random_state=SEED,\n",
-    "    n_init=10,\n",
-    "    reg_covar=1e-6,\n",
+    "fig, ax = plt.subplots(figsize=style.FIGSIZE[\"single_tall\"])\n",
+    "dendrogram(\n",
+    "    column_linkage,\n",
+    "    labels=extended_df.columns.tolist(),\n",
+    "    orientation=\"right\",\n",
+    "    ax=ax,\n",
+    "    color_threshold=0,\n",
+    "    link_color_func=lambda _: COLORS[\"neutral\"],\n",
     ")\n",
-    "gmm_pca.fit(reduced)\n",
-    "pca_probs = gmm_pca.predict_proba(reduced)\n",
-    "pca_labels = gmm_pca.predict(reduced)\n",
-    "\n",
-    "print(f\"GMM on PCA silhouette: {silhouette_score(reduced, pca_labels):.3f}\")"
+    "ax.set_xlabel(\"Ward linkage distance\")\n",
+    "ax.tick_params(axis=\"y\", labelsize=6)\n",
+    "style.add_message_title(\n",
+    "    ax,\n",
+    "    \"The two names for the same spread merge first, at zero distance\",\n",
+    "    subtitle=\"Ward linkage over the standardized indicator columns\",\n",
+    ")\n",
+    "style.show_with_alt(\n",
+    "    fig,\n",
+    "    \"A horizontal dendrogram of the panel's columns. One pair joins at the left edge with \"\n",
+    "    \"no visible branch length; the Treasury maturities and the trending level series form \"\n",
+    "    \"two further groups, and the VIX and initial claims stand apart until the last merge.\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "id": "25ea91e5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:45.488688Z",
-     "iopub.status.busy": "2026-07-18T19:35:45.488537Z",
-     "iopub.status.idle": "2026-07-18T19:35:45.604196Z",
-     "shell.execute_reply": "2026-07-18T19:35:45.603555Z"
-    },
-    "papermill": {
-     "duration": 0.13077,
-     "end_time": "2026-07-18T19:35:45.604552+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.473782+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABN4AAAF/CAYAAACWiQTKAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZexJREFUeJzt3XdcVfUfx/H3HQKCEwHFvXdq4M5taomas6WZWWlaWWbuMn+5KlemWWqZmpWVZVmWI/fKbZqaMzcigqKyx/39gVy9AXJRDqC8nj3u7+c995zv+Z4vV668+Xy/xxQTE20TAAAAAAAAgAxlzuoOAAAAAAAAAPcjgjcAAAAAAADAAARvAAAAAAAAgAEI3gAAAAAAAAADELwh2+nU83WNmTQrq7uR6QIvBKtBmx766vtlGdbmZ1/+oAZteuhK2LU09/3vuO/+66AatOmh3X8dtG8bM2mWOvV8PV3nzgpvvDVRE6Z+liXnzi6S3k/LVm7I6q6kqv/gseo/eGxWdwO38e+pc2r0aE8dP3kmq7sCAAAA3JOsWd2B+935Cxf19eLftX33fl28FCpJ8i3sJb+aVdWpbQuVL1vSvu9nX/6gzxcukclk0pIFH6qwTyGHtsLDI9T2yZcVExOrLu1b6c1XnpWU+AN252cHSpL6PNtVzz3dMVk/3nlvplau3aLcbq5a8/Pnt+1zUj+SWCwWeXsVVOP6fnqxZxflzeNxR2Nxr/rveLi6usi3sJeaPVRHPboFyMPDPQt7l7WioqK18Ptf5VejivxqVs3q7kiS/jpwRNt37dc3n31g37b7r4N6ech4+3OLxaLC3p6qUa2SXnims4r5+ji0ER4eoUVLlmvdpp06Fxik+IQEFfctrIZ1a+nxTm3kXahgsvOOHPuR1mzcrh7d2unlF5407gIhSdqx52+tWLNF+w4c0cVLoSpUML/8a1VVn55d5ZXC12ffgSP6+PNFOnzspDzcc6tlk3p66bnH5Z7bzWG/mJhYzVnwg5av3qSr18NVvkxJ9X22q+r6P+Cw37xvftamP3frXOBFRUREycfbUw3r1lKvpx5TwQL50uz/wcPH9duqTdr910EFBl1S/nx5VK1yOfXt1U0li/sm2//k6XP68NOF2nfgiKxWqx6qV0sD+nR3ONfJ0+f168r12r5rv84FXlTu3K6qVL60Xnimi6pULJtiP/5Y96e+/Wm5jp04I6vVotIli6lvr66qXauaJKlMqWJqWLeW5iz4Qe+Nej3N6wIAAADgiODNQJv+3KO3x8+QxWJWmxYNVb5sSZlNZp06c17rNu/Ukl9X64f5U+Vb2MvhuFy5rFq1bqt6PN7OYfu6zTtvez4Xl1xatXZrsuAtMipKG7fukotLrnT1f/Crz8k9t6sio6K1c88Bff/zSh0+dlKzpoxKVzvp9e1nE2U2mww9x51IGo+IyGht371f8775WTv3HtTsqaNkMmW//qaXM+M+/PXnlZBgsz+Pio5JDCV7KFnw1uvpjnrmifaG9PV2vv5+mWo/WE0lihVJ9trjHVurSsWyiouL1+FjJ/Xz72u1ZfteLZw1wR6mnQu8qAHDJijoYohaNKmrx9o2Vy6rVcf+Pa1fVqzT+i079d3cSQ7thodHaNO2PfIt7K1V67aq//NP3Bfviexs5uff6uq162rRuJ5KFCusc4EXtfiXVdq8ba8WzBynQp4F7PseOX5Krw6boNIli2pAn+4KvhSqrxf/pjPnLmjquCEO7Y6dPEtrNu7QE53aqESxIlq2cqPeeHuSPv5ghGpWr2Tf7/DRk6pQtpQebtpA7u5uOnn6vJbeeD8t+GSccrs5Bnr/tfC7X7Xv4BG1aFxP5cuUUMjlMC1eukq9Xn5Lc6aNVrnSJez7XgwOUb83x8rDPbdeeu5xRURG6evFv+n4v2f0+UfvKleuxI/ypcvX6dcV69SsUR11bv+wrodH6Kdla/Tia6M1ZdwQ1fWr7tCHz778QXO/+knNG9VR21aNFRcXrxMnzyr40mWH/Tq1a6k33pqos+eDVLxo4XR9nQAAAICcjuDNIGfPB2nUhBkqUriQpr83PFkFRv8XntSPv/whcwo/nDesU0srUwjeVq7doofq1tLaTTtSPGfDOrW0bvMOHT1+ShXKlbJv37Blt2Lj4lS/dg3t2nswxWNT0qJxXRXIn1eS1Cmgpd4eP0N/rP9TB/45rmqVyzndTnqlNyDMLLeOR+d2LTX83Wlat3mH/j50TA9UrZDiMVFR0XJzc83Mbt4xZ8bdanX+W4bVYpHVYrmbLqVb6JUwbd6+V0MGPJfi6zWrV1aLxnUlSe3aNFXJ4r6aMnOBflu1Uc8+2UFx8fEa/u6HCr18VR9PHOkQtEjSS7266cvvfk3W7tpNO5SQkKCRb7yoV4aO1579/8ivRpU7ugabzabomFi5ubrc0fE5xYC+3VWzWkWZzTdXTKhfp6b6vzlWi5euUt9e3ezbP/3iO+XL46GZH4y0V6j6FvbShA8/17Zd+1XvRjXbgX+Oa9W6P/XKC0+pe7cASdKjDzdS9z7DNOOzRZrz4Tv2NieMei1Znx6oUl4jxn6kTX/uUatmDW7b/yc7P6r/DXvZHppJ0sNN66tH3+H68ttfNHpof/v2+YuWKjIqWl/MGKMiPom/qKlaqZxeG/6elq3aoI5tW0iSWjdvoBee6exQxde+TVM99cJQfb7wR4fg7e9DxzT3q5/0ap+n9VTnR2/b1zoPVlPePB76bdVG9Xm26233BQAAAOCI4M0gC7//VZFR0XprUJ8Upz1ZLRY93rFNise2bt5AI8Z+pJOnz6t0yaKSpJDQK9q196DGjnw11eCtepXyOnL8pFau3eoQvK1cu1n1a9dQvrx57uqaalavpD/W/6lzgUEOwduBf45pzoIf9PehY4qLj1eVimX10nOPq2a1ig7H7/7roKbP+UYnTp6Vt1dBde8WoJDQK/p84RJtXbHQvl+nnq/Lr0YVvf1mX0nSspUbNHbybH06+W2t3rBNq9ZtVVxcvFo2radB/Z9VVHS0psz8Upu37ZYkdXi0uV5+/kmHiqOEhAR999NKLf19rc4FXpSHR241aeiv/r2fVL68dzZ11r9WVa3bvEPnLwTrgaoV1H/wWIWFXdfbg/tq2qcLdejov3rs0eYa2O8ZhV4J0ydzv9PmbXsUHh6pksV99WSXRxTQqkmKbX/z4+/6bslyhV65qqqVyunNV551qIA5duK0vvnxd+3d/48uhVxRnjzualCnpl598Snlz5c3WXtXwq5p4vQv9OeufbJarHqkZUP1f/5JubrcDHf+O+4pGTNplnbvO6QlCz50mOL8+cIl9um4z/fopBee6WKfonvr11aSlq/epEU/Lte/p8/J1cVF9fwf0CsvPOUwtfrMuQua+fm32nfwiK5fj1D+/HlUs1olDX2tt/LcZmrvlm17FR8frzoPVk91n1v536jSC7wQLElat3GHjp44rb69uiUL3STJw8NdLz33eLLtK9ZsUV2/6vKvVVWlSxbVyjVbnA7eOvV8XWVLFVe3x1pr1rzvdeLkWfXr/YSe7PyIrl0P12df/qh1m3bocthV+Xh56rFHm6t7twCHwOna9XB9+OlCrd+8UyaTSY0b+OnJFMKUpPXUZk58y2H7rV/XJAkJCfr+55Vaunydzp4Lkru7myqVL62+vbo5TFt05uspST/9tkYLv/tVwSGXVa50CQ3o87RT45OaBx+onOK2fHnz6OTp8/Zt4eER2r77bz3Z+RGHaeGPPtxY02Z9pdUb/rQHb2s3bZfFbFbHts3t+7m6uKj9I8306RffKehiSLLrupVvEW9J0rXrEWn2v8Z/vj9KUoliRVSmVDGH/if2a4ceqlvLHrpJUl2/6ipZvIhWr99mD94qVyiTrM38+fKqZvVK2r3vkMP2b5csV6GC+fVExzay2WyKjIpONu02idVqlV/NKtq4dTfBGwAAAJBOBG8G2bxtr4oXLaxqlcun+9haD1SWj5enVq7dYv8h54/1fyp3bjc1rFvrtse2atZAK9Zstk91uxJ2Tdt2/a13hrykP3fuu5NLsQsMSgwnbl3jbefeA3rjrYmqVL6Mnu/RSSaTWctWbtCrQ8frk0lv2wO6w8dOauDIiSrkWUAvPNNZ8QkJmvvVTyqYP3lIlJrJMxeoUMH8euGZzvr70HH9/Nta5fXw0P6DR1TYx0sv9XpcW3b8pa++X6aypYqrbavG9mPfnzZXy1ZtVLvWTdStY2sFXgjW4qWrdOTYKc2eOipdlVxJzgUGSZLy57sZaIZdu6Y3Rk7Uw83qq03Lh+RZIL+iomP08uBxOns+SF07tFLRIj5as2Gbxk6arevXI/REp0cc2v199SZFRESpS/tWio6J1Xc/rdCrQyZo4awJ8iyYX5K0ffffOh94UQGtm6hQwQI6ceqsfv59rf49dU6fTRudbJrjW+Ony7ewl/o994QO/HNM3/20UlevReidIS+l+7qTFCiQV4NffU4Tp3+hpg/VVrOHakuSypcpmeox877+WbMXLFbLJvXU4ZFmuhx2TYuXrlS/N8dq/syxypvHQ7GxcXp9xPuKiY1Ttw6t5emZX8GXLmvztj26dj3itsHb/oNHlT9fnmTTt1OT9DXMd+NruPHPxPD20ZaNnDpekoJDLmv3voP2wLJVswZa9ONyDXr5WYdqpts5fTZQoyZ8rI4BLdTh0WYqVdxXUVHR6v/mOAWHhKpj2xYq7FNI+w8e1SdffKdLoVc0sN8zkhIr5IaMnqp9Bw6rY0BLlS5RVOu37NSYiXd3g5LxU+Zo2aqNalCnpjo80kzx8Qn66+/D+vvQMXvw5szXU0qcAvn+tLl6oGoFPdHpEZ0LvKgho6coX9488vH2vKt+3ioiMkqRUVHKn//m38ljJ88qPj4+WSiVK5dVFcqW1JFjp+zbjhw7pRLFiyRbt7FqpcTrPXLilEPwZrPZFHb1uuLj4xPD4rnfymI231W1Y+iVMJUtVdy+7eKlUF2+cjXFNdqqViqnLdv/SrPdkMtXVCC/4y9edu49oAeqVNB3P63UvG9+UtjV6yrkmV/PPvmYuj3WOlkblcuX0catuxQeHpGj17UEAAAA0ovgzQDh4RG6FHJZTRr6J3vt2vVwxccn2J+7ubkmm1JmMpn0cLP6WrVuqz14W7Fmi5o+VDvN6YCtmzfU/EVLte/AEdWsXkmrN/wpV5dcalzfL93B29Vr1yVJkVHR2rX3gH745Q8VzJ/PXmlis9n0wUdfyK9GFU0dN8Qe9nQMaKHufYZq9vzvNW3CMEmJawmZzWbNmjrKvpZWyyb19NSLQ53uj2eBfJoydrBMJpO6tG+ls+eD9NXiZerYtoV9auFjbVuoc8/X9evK9fbg7a+/D2vp8nUaPbS/2rRoaG/Pr2ZVDRz5gVZv2O6wPc3xiIzStt379eMvq+VZML9q3VIZFRIapiEDnlOngJb2bd8uWa6Tp89r9NB+atPiIUlSp4AW6vfmOM2ev1jt2jSVh3tu+/5nzwfpu7mT5OOVGEjUr11DL7z2jr787he91jfxLqGd2z+sp7u2dehf9SrlNWrCx/rr78Oq9Z9qoKKFvfXB/96QJHXt0Eru7rn14y9/qHvXtg43+EiP3G5uatG4riZO/0Lly5TQI2mEVYFBl/TZlz+oz7Nd1eupx+zbmzWqrWf7v6UffvlDvZ56TP+ePqfzF4I17q0B9mmhUmIlXVpOnTkv38Leqb4eERGpK2HXFBcXpyPHT2nqJwtlMpnUvFEdSdLJM+eUx8P9tlVN/7Vq7VblypVLjRsk/n1v1ayB5iz4QVt27FXThrWdauPs+SBNHTdE9WvXsG/74uufdC4wSPNnjrOvV9cpoKW8ChXU198v09Nd2qqwTyFt3Lpbe/f/o5dfeFI9uiVOT+/c7mG9MmSc09fwX7v2HtSyVRv1eMfWGtivp337013bymZLXOPP2a9nXFycPv3iO1UoV0offzDSHkaWKVlM7037PEODt2+XLFdsbJweblrfvi0k9IokyeuWNd+SFPIsoL8OHHbYt1AK+3l5Jn7PuhTiuPZZ6OUwtXvqFftzHy9PjR7W316pnF4r1mxW8KXLerHnzaqypP6n1K9CngV09dp1xcTEpvrZsHf/P/r70DGHr9HVa+G6EnZN+w4e0a6/Dqp3904q7FNIy1Zu0JSZC2S1Why+h0lSUV9vJSTYdPJMoKFLDQAAAAD3G3PauyC9wiMiJSnFaTsvDx6nRx/vZ3/8sHRVim20bt5QZ88H6eDh4zpz7oIOHTmh1s3TDofKli6u8mVKauW6rZKklWu3qnEDvztaZ+yJ5wfr0cf7qXPP1zVuyhwVL1pYU8YNtrd15PgpnTl3Qa2bN1TY1eu6EnZNV8KuKSoqWrVrVdPe/YeVkJCg+PgE7dhzQE0a+jvcDbJEsSJqUKdGaqdPpv0jzRwquapVLiebzab2jzS1b7NYzKpcsYzOBwbbt63ZuE15PNxV16+6vY9Xwq6pcoUycs/tpt1/ObfunX08nh2o96fNVfGihTV5zJsOY+uSK5fatW7qcNzWHX+pkGd+hzWfrFarHu/YWhGRUdqz7x+H/Zs08LeHbknXWa2yY2XLrWFtdEyMroRdU/Ub1ZWHj51M1vcuHVo5PO/WIbGiZcuOvU5de0ZYt3mHEmw2tWxSz+HrUKhgAZUoVli7/0qcCpfHIzGE3LZzn6KiotN1jrBr1297191xU+bo0cf7qf3Tr2rQ25MUFRWtt9/sa68mCg+PTHW6XWpWrN2shnVr2cPTEsWKqHKFMlqxZovTbRQt4u0QuknSmg3bVbN6JeXN4+EwXnUerKb4hATt/TvxfbNlx15ZLBZ1bvew/ViLxayuKVQtOWvtph0ymUzq3b1zsteS/g46+/U8dORfXb5yVZ0CWjhUAAa0bnzb6sX02rP/H32+cIlaNqlnvyOnJEVHx0iScuVKHky5uLgoOjr25r4xMXJJcb9cN9qKddieL28eTZswTBP/N0gv9uyi/PnzKjKd79kkJ0+f16QZ81W9SgW1ffhmte7N/if/PVlSX6NjYlJsM/RKmN55b6aKFvF2WDM0MjJKkhR29bqGv/6CuncL0MNN62vymDdVpmQxzfv652RtJf29Crt67Y6uDwAAAMipqHgzgPuNH8Ajbvxwc6uhr/VWeESULl8J0+j3P0m1jUrlS6tUiaJauXar8uZxVyHP/Kpdq2qq+9+qdfMG+uaH3/Vkp0e0/+BRPftkhzu6jglvvyZ399y6EnZV3/+8UucvBDusCXbm3AVJietDpeZ6eKRiYmIUHR2T4t3w0nOHvCL/qUJKCmgKe/93u7uuXQ+/pZ9Buh4eobZP9FdKLl+56tT5k8bDarXIx8szxb57exVM9gNyYNAllShaxGFNLkkqXSKxKubCxUsO21O6G2eJYr5as2Gb/XnY1eua+9WPWrXuz2T9vx4emcLxjn0tXtRHZrNJgRcuJdvXKGfPXZDNZtPjvd9M8XWrJXHcihbx0VOdH9U3P/6uFWu3qFb1SmpU30+PtHzIqaAmqSIrJb27d1LN6pVkMZuVP39elS5Z1OEGEB4euR1C27ScPH1OR46d0qMtG9v/PkjSgzWq6IdfVtmn5UVERtnDDkkym80qWCCf/XnS2mC3OnP+go79e1qPPt4vxXOH3vi6Xwi6JC/PAskCw1LFfZ2+jv86Fxgkr0IFHKZR/5ezX8+k9/d/39dWq1VFfVOvTkyPk6fPa9j/PlTZ0sU1fOALDq+53gipY2Njkx0XExMjV9ebQZuri4tiUtwv9kZbjqFcrlxW+w0LGtV/ULVrVVPfN95Vwfz51Kj+g4qPT9CVMMe/n/ny5kn2PSIk9IreHDVJeTzcNf7tAbJYbn6vuNn/uOT9utHXW78vJ4mMitKbb09WRGSUPh33tsP7I6lNq9Wi5rdUlZrNZrVsWl+fffmDLly85LCmXBLu1gsAAACkD8GbAfJ4uMvLs4BOnDyb7LWkNd+SFnO/ndbNG2jJr6vl7u6mlk3qJwtuUtOqeQN98sV3eu/Dz5U/Xx7VvbFweHrVeqCy/S6ejer7qUff4Xrn/ZmaN2OMzGazPeB45YWnHG7mcCv33K6KSaUaI71Su/6Utt8aviQkJKhggXwOdwm8lbPrzN06HqlJ6QdgI7w1brr2Hzqq7l0DVKFcSbm7uSnBZtPAkR/IZktIu4Es+OE5IcEmk8mkKWMHp/g1uzUYGNC3u9q2bqKNW3dp+679mvrJAi34dqk++3C0fLxTnwaaP28eh9D1v8qVKeFwZ8f/KlW8qI4cO5XmIvpJlq/eLEmaNmuhps1amOz1tZt2qF2bpvp68TL7zSckqUhhL4cbGaT0vrEl2FTXr7q6d2uX7DVJKlk8eUCbFpNMsil5MJmQ4MR7Jtkxzn89jRR0MUSvj3hfeTxya8qYNx2mbUs3p2heujFl81YhoVfs00iT9g0OCU2236XQxCmmKd0o51Y1qlWUl2cBrVy7WY3qP6iLwSH2G5Ak+fiDEfKrefOXKNfDIzTwrYm6dj1Cn05+26Eq+Nb+h6TS/3x58ySbZhobG6fh707T8X/PaOr4IQ43ZpGkfHk95OKSS3nzuDuEfJLsgfC1a+EOwdvVa4l/r24XxgIAAABIjuDNIA3r1tLS5et04J/jd7weTuvmDTVnwQ9SqDRqcMpVLykp4uOlGlUraPe+Q+rcrqVDRc+dcs/tpud7dNLYybO1esM2tWrWQMV8fSQlVgndLswoWCC/XFxy6ez5oGSvpbQtoxUrWlg79xxQjWoVk62nlxl8C3vp2L+nlZCQ4BBQnDoTKEnJqkpurZy6uS1QRW7cMODqtXDt3HtALzzTxWHds5SOu/lakIoW8bE/P3suSAkJNvkWce4mBKlJT35XrKiPbDabihbxVkknqrHKlymh8mVK6LmnO2rfgSPq+8a7WrJsjfr26pbqMaVKFE31rr/OaFT/Qa1at1XL12xOs1LUZrNp5dqt8q9ZVZ3bP5zs9S+++kkr1mxRuzZN9ejDjVWj2s21AF2deB8W8/VRRGT0bf9uSYkh3s69BxURGeUQdp06G5hs37x5PXQ+8GKy7ReCHCsfi/kW1rZd+xV29XqqQYuzX8+k9/eZcxccpoDGxcUp8ELwHa8xKCVOe3xtxPuKiY3VrPdHpRiMlStdXBaLRf8c/ddh7bfY2DgdPXFaLZrUs2+rUK6kdv91MNkNBA78c1ySVLFsyr9guFV0TKy96tTTM799ncsk5W9pIzomRoNHTdaZsxf00XvDVKZUsWTt+Xh5qmD+fDp05ESy1w4ePq4K5RzHLyEhQe9O/FQ79xzQ2JGvpnijB7PZrIrlSunQ4ROKjY1zqMBLWseuwC0VmVLiL4vMZpNTf3cBAAAA3MQabwbp8Xg7ubm6avyUOQq9HJbs9ZSqTv6reNHCev2lHurX+/F0h3d9enXT8z06pXh3ujvVpkVD+Xh56svvfpUkVa5QRsV8ffT14t9SnFabNAXSYjGrzoPVtWHLLgXfsjj5mXMXtHXH3d1p1Rktm9RTfEKCvvhqSbLX4uLjb1shlREa1KmpkNAw/bH+T4fzfr90pdxzu+nBGo43QtiwdZcuXrpZdXPgn+M68M9xNahTU5JkMSelXY7voUVLlqfah/+uJfj90pWJfatdM93XcytX18T17a5dj0hz32YP1ZHFbNbnC5ckmw6aeHfIxLWjwsMjFBcf7/B6uTIlZDabUpwGeKvqVSvo2vVwnUshXHJGi8Z1Va5MCc3/5mftP3g02evhEZH69IvvJEn7DhxRYFCwAlo3UYvGdZM9Wjatp937Dio45LKK+fqorl91+6NmtYpp9qVl03r6+9DRFG+Kcu16uH2MGtappfj4eP346x/21+PjE7T455XJjivm66NTZwIdpicfPX5K+w4ecdiveaM6stlsmvvVj8naSPraOfv1rFKxjArmz6cly9Y4TJdctnKjU++b1ERGRemNtyYpOCRUU8YOTnGKtpRYgVznwWpasXqzff1N6cbdgyOjHG7g0aJxXcUnJOin39bat8XExGrZyg2qVrmcvQoyMioqxfUH127crmvXw+13UHV1cXH4utf1q658eRPXSouPT9Db42Zo/6FjGvfWq3qgaoVUr7VZozravH2vgi6G2Lft2PO3Tp+9oBaN6znsO3nmAv2x/k+9+WovNbtx05CUtGxSX/EJCfpt1Ub7tuiYGK1cu0VlShZLVnn3z7F/VaZU8Qxdlw8AAADICah4M0iJYkX0v2H9Neq9j/XE84PVukVDVShbUjabTYEXgrVy7VaZzaY07+j3RKdH7uj8fjWqpFjpcDcSbwjQRjM++0Zbd/ylBnVqasTAFzTwrYnq3meoAlo3kXchTwWHhGrXX4fk4Z5bk94dJEl64ZnO2r57v/oOfFed27VUfEKCFi9dpbKli+vo8VMZ2s//8qtRRR3bttCCb3/R0ROnVdfvAVmtFp05d0FrNm7XwH7POPzwndEea9tCP/22RmMnz9Y/R0/Kt7CX1m7arn0Hjuj1l3okmxpXvGhhvfTGGHVu11IxsbH6dskK5c+XRz26BUiSPDzcVeuBylr43TLFxcXLu1BBbdu9/7bTl88HBWvwO5NVv3YN/X3omJav3qzWzRumOkXYWW6uLipTsphWb/hTJYsXUb68eVS2dPFkU9uSrqtPr676ZO53CgwKVpOG/nLPnVuBF4K1fstOPfZoc3XvFqCdfx3U5I/nq0XjeipZrIjiExL0+x+bZDab1bzR7b9OD9WtJYvFoh17/lYx3xbpvh6r1aoJb7+mAcPfU783x6plk3qqUa2CrBarTpw6q1VrtypvXne99NzjWrFmiyxmsxrWrZViW40b+GnWvO/1x7qteqpL2xT3uZ3uXQO0cetuvTlqsgJaNValCmUUFRWt4yfPaO3G7fpxwYcqkD+vGtV/UDWqVdQnc79VYNAllSlZTOs270hxrb/2bZpq0Y+/6/WR76t9m2a6fOWqlixbrTKlijuEUv61quqRlo303U8rdeZckOrXrqGEBJv++vuw/GpWUbfHWjv99bRarerTq6venzZXrwwdr4eb1tf5Cxe1bOUGe9XsrfoPHqs9+/7R1hXJp+7eavR7n+jg4eNq16apTp4+p5Onz9lfy53bzeGOsi/16qY+A99V/8Fj9dijLRR8KVRf//Cb6vk/YA+0pcSlAFo0rqtPvvhOl8OuqnjRwvpt1UYFBl3SiDdetO935lyQBgyboJZN66t0iaIymUz658gJLV+zRb6FvfVEpzZpfn0/mv2VNv65W43qP6ir165r+epNDq/fepfgZ5/soDUbt+nlIeP0RKdHFBEZpa++X6ZyZUqoXesm9v0W/bhcP/7yh6pXqSA3V5dkbTZ9qLZyuyVWRXYMaKFflq/TpI/n6fS5QBXx8dLvf2zShaBLmnjj+3aSuLg47dn3jzq3d7zTKQAAAIC0EbwZqElDfy38dIK++eE3bd+1X7+uWC+TyaQiPl5qWLeWOgW0uOvgI7N1bNtc8775WV9+94sa1Kkpv5pVNefD0friq5+0eOkqRUZGy9Mzv6pVKqeOATeDj8oVymjK2MGaPudrzV6wWD5ennqxZxedPH1ep86cN7zfQ1/rrcoVyuin39bo03nfyWIxy7ewtx5p8ZBq3KbSJCO4ubro44kjNfPzb/X7HxsVHhGpksV99dagPgq45YfmJI+2bCSz2aRvl6zQ5StXVbVSWQ16+VmHaXT/G9ZfU2Yu0A+/rJLNJtX1q64pYwer/dOvptiHsSNe0ewFP2jm3G9lMVvUtUMrvfLiUxlyfcMHvqApMxdo2qyvFBsbp+d7dEoxeJOknk90UMlivlr04++ae2PNMx/vQqrr94AaN/CTJFUoW1L1/Gto05+7FRxyWW6urqpQtqSmjB2s6lXK37YvngXzq2Gdmlq9fps6tk1/8CYlhuYLZo7Toh+Xa/2WndqwZZcSbAkqXrSw2j/SVI93bKO4uDit2bhND1StkOpUzHKlS6hoEW8tX7P5joI3NzdXzZz0luZ/87PWbNyu31dvkod7bpUoVkQvPNPFfnMRs9msD0a/oQ8/XagVqzfLZDKpUX0/DejTXc/2H+nQZumSxTRq8Euas+AHfTT7K5UuWUzvDOmnlWu3aPe+Qw77vjWoj8qXKaFfVqzXjM++UR53d1WuWMbh74szX09J6ti2hRLiE/TV4mWaMecblStTXB+MfkOzFyxOdt2RkdEq5Jk/zfE5ciIxsP91xXr9umK9w2tFCns5BG+VKpTRR+8N08efL9K0WQvlkTu32rdppn69H0/W7qghL2n2/MVavnqTrl2LULkyJTTp3UF68IGblak+Xp5q1qiOdu09qN9XbVRcfLyK+Hipa4dW6vXUY8qfL+11I4/e6P+mP/do0597kr1+a/BW2KeQZk58Sx/N/kozP/9WuXJZ1LBuLQ3o091hfbekNv8+dFR/H0pesfnj/KnKXSQxeHNzddH0D4br488W6dcVGxQVFa0K5Upq0pg3k91hd8eeA7p67brD3VYBAAAAOMcUExOd9pxHwCBDR0/ViVNn9f0Xk7O6K7hP7N3/j14eMk6LPpuY6vRDZE/hEZFq0/Ulvf5SD3Xt0Cqru4Mbho6eKpmk998ZmPbOAAAAABywxhsyTVS0491Nz5y7oC079mb4lFjkbLUeqKy6fg9o4Y21CHHv2Lv/H3l7FdRjjzbP6q7ghpOnz2nztj3q82zXrO4KAAAAcE+i4g2Zpt1TL6ttqyYqVsRHFy5e0o+/rlZsbKzmzxxHZRIAAAAAALjvsMYbMk19/xpatW6rQkPDlCuXVdWrlFe/5x4ndAMAAAAAAPclKt4AAAAAAAAAA7DGGwAAAAAAAGAAgjcAAAAAAADAAARvGcxmsykuLk42GzN4AQAAAAAAcjJurpDB4uPj1Tigl9b99rWsVoYXQKKCdV7J6i4AQKY5tGqSw/MiBdwcnt/6C0qTyZQpfQIAIKtZbDFZ3QVkASreAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGsGZ1BwAAAAAAAIA7MWXmAm38c7cuBF3S/JnjVLFcqRT3W7p8nb789hfZbDb516yqwa/2ktVqfCxGxRsAAAAAAADuSc0b19WsyW+rSGGvVPc5f+Gi5sxfrE8nv63vv5is0Cth+um3tZnSP4I3AAAAAAAA3JMefKCyfLwL3XafNRu3q1F9PxXyLCCTyaROAS21at3WTOkfU00BAAAAAABgqPj4BNlsCU7vbzKZZbFkTL1Y0MUQh4o438LeCroYkiFtp4XgDQAAAAAAAIaJj09QvUd6KZfZ+eAtTx53FSqYXyaTSZLUpX0rde3QyqguGobgDQAAAAAAAIax2RKUy5ygg1cKy+bE/iZJVRWk37+dmSE3QCjsU0jnzl+0Pw8MClZhn9tPT80orPEGAAAAAAAAw9lMJslkTvNhu1HlllGaN6qrTX/uVkjoFdlsNi1ZtloPN62foedIDRVvAAAAAAAAMJ7JrMR6trQ4UxeX6L1pn2vL9r0KDQ3T6yPel3tuNy2eN0Xjp85R4/p+atzAX8V8ffTCM13U9413JUkP1qiiTgEt7uwa0ilTgrdOPV+XSy6rXF1cFB0To4DWTdTziQ531eb4qXPUpvlD8q9VNYN66SjwQrDGTJ6lI8dOqWgRby34ZLwh5wEAAAAAAMgRTCY5F7w5b9hrz6e4fcTAFx2eP9a2uR5r2zxDz+2MTKt4GzPiVVUsV0oXL4Xq6ReHyr9mNVWrXO6O2/vvAGY0d/fc6vtsN10Pj9Csed8bei4AAAAAAID7ngEVb9ldpk819fHyVKkSRXXh4iVVq1xOIaFXNGXmAgUGXVJ0TIyaNPBX317dJEn7DhzRpBnzFJ+QoCoVy+rw0ZMa2K+H/GpWVf/BY/VEp0fUtGFtjZk0S7msVp0LvKhzgRflV7OKOgW01Meff6OgiyFq0tBfr/XtIUm3Pd+t8ufLo5rVK2n3XwczdXwAAAAAAADuSwZUvGV3mR68nTx9XmFXr8mvRhVJ0phJs9TzyQ7yq1FFcfHxevPtSVq9YZuaNPDX2+NnaNTgl+Rfq6p27T2oZSs3pNru8ZNnNOODETKbzHrqxSG6dj1cH00Ypti4OHV59g21b9NMZUsXT/V8LZvUy6whAAAAAAAAyHmoeDPO2+Ony2Qy6/TZQL3Wt7sKFsinyKgo7dxzQKGXw+z7RURG6fTZQJ06c14Wi8W+hpt/raoq5uuTavuNG/jJ1cVFklSuTAnV868hq9Uqq9WqMiWL6cz5C/It4pXq+e7G4qWr9MMvqyRJNtv98+YAAAAAAADIMFS8GSdpjbftu//W4Hcmy79WNRUt4i1JmjNttD00S3LsxOlkbZhucztZl1w3j7eYzXJ1yWV/bjabFR+foKRMLKXz3Y2uHVqpa4dWkqS4uDg1DuiVYW0DAAAAAADcF3JgxZs5s09Y16+6Ordrqdnzvpd7bjf51ayqL7/9xf56cMhlXQwOUcnivoqLj9PufYckSbv3HdLZ80F3de7bnQ8AAAAAAAAGMpmcf9wnMn2NN0l67ulO6vbcIP1z9F+NHtZPH836St37DJNMUm43Vw0d0Fs+3oU0ZvgrmjRjvhJsCapcoYxKFvdVnjwed3Xu253vVlFR0Xr8+TcVGxun6+ER6tD9VT3SspH6937irs4PAAAAAACQI+XAijdTTEx0tr2a8IhIebjnliQdPHxcQ0ZP0eIvpsjNzTWLe5a6pKmm6377WlZrluSaALKhgnVeyeouAECmObRqksPzIgXcHJ7fuibu7ZYSAQDgfmKxxWR1F7JMUlZyILaSnA3equU6rI3L5t3z2Uq27v26TTu06Mflsskmi8WsUYP7ZevQDQAAAAAAAKnIgRVv2Tp4C2jdRAGtm2R1NwAAAAAAAHC3CN4AAAAAAAAAA5hNci54u38QvAEAAAAAAMB4VLwBAAAAAAAARjBJztxY6f7J3QjeAAAAAAAAkAlMZueCN9num/CN4A0AAAAAAADGMzlZ8SYRvAEAAAAAAABOM5lurPOWlgTDu5JZCN4AAAAAAABgPKcr3u6fO58SvAEAAAAAAMB4JrOTFW/3D4I3AAAAAAAAGI+KNwAAAAAAAMAAVLwBAAAAAAAABqDiDQAAAAAAADAAFW8AAAAAAACAAQjeAAAAAAAAAAMw1RQAAAAAAAAwABVvAAAAAAAAgAGoeAMAAAAAAAAMYLY4V/FmI3gDAAAAAAAAnGai4g0AAAAAAADIeARvAAAAAAAAgBFMup8yNacQvAEAAAAAAMBwVLwBAAAAAAAABiB4AwAAAAAAAAxA8AYAAAAAAAAYgOANAAAAAAAAMAI3VwAAAAAAAAAyHhVvAAAAAAAAgAEI3gAAAAAAAAADELwBAAAAAAAABiB4AwAAAAAAAIzAzRUAAAAAAACAjEfFGwAAAAAAAGAAo4K3M+cu6N2JsxR29ZryeOTWW4P6qmzp4g77JCQkaPqcr/Xnzn2yWCzKnzePhr3+vEoUK5Kuc6UXwRsAZILLO2ZkdRcAINswOfUPbgBIVLDOK1ndBSBDXN0+Jau7kOWMCt7enzZXHds2V0DrJlqzcbvGTp6ludPHOOyz8c/d2nfgqL78ZLysVqu++PonffrFdxr31oB0nSu9zIa2DgAAAAAAAEg313hz5uGk0CthOnT0hNq0fEiS1LxRHQUFh+rMuQv/ObVJsbGxio6Jlc1mU3hEpHy8Pe/+mtJAxRsAAAAAAAAMZ0TF28XgUHl5FpDVYrGfo7B3IQUFhzhMI21U/0Ht+uug2j35itzd3eRdqKBmTnorvZeQbgRvAAAAAAAAMFx6g7ceLw23L1HRpX0rde3Q6o7PfejIvzpx8qyWfv2RPNxza+bcb/XBR3M1emj/O27TGQRvAAAAAAAAMFx6g7eFn06Q1Xr76MrH21OXQq8oLj5eVotFNptNQcEhKuxdyGG/3//YJP9aVZU3j4ckqe3DjfXaiPfv6DrSgzXeAAAAAAAAYDiTyeT0w1meBfKrUvnSWrF6syRp7aYd8vHyTHa30mK+3tq196BiY+MkSZu37VG5/9z51AhUvAEAAAAAAMB46bxxgrOGDuitsZNna/6ipfJwz62Rg/pIksZPnaPG9f3UuIG/urRvpZOnz+uZfiNktVpUqGB+DRnQO+M78x8EbwAAAAAAADCcETdXkKRSJYpqzoejk20fMfBF+59dXHJp+MAX0tVuRiB4AwAAAAAAgOGMCt6yM4I3AAAAAAAAGI7gDQAAAAAAADCCQWu8ZWcEbwAAAAAAADAcFW8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAAjMDNFQAAAAAAAICMR8UbAAAAAAAAYACCNwAAAAAAAMAAZrOTwZuN4A0AAAAAAABwmsn+P2mwGdyRTETwBgAAAAAAAMM5PdXUqemo9waCNwAAAAAAABjO5OxdTe+f3I3gDQAAAAAAAMYzm02SOWclbwRvAAAAAAAAMBwVbwAAAAAAAIABWOMNAAAAAAAAMAAVbwAAAAAAAIABqHgDAAAAAAAADJBY8eZM8GZ4VzINwRsAAAAAAAAMx1RTAAAAAAAAwABMNQUAAAAAAAAMQMUbAAAAAAAAYAAq3gAAAAAAAAADUPEGAAAAAAAAGMFkSqx6S4ONijcAAAAAAADAec7ONJVJshnem8yRKcFbp56vyyWXVa4uLoqOiVFA6ybq+USHu2pz/NQ5atP8IfnXqppBvXS0c+8Bzfz8W0VGRckkkxrWq6X+vZ+Q2Ww25HwAAAAAAAD3M5OTFW8ymQje0mvMiFdVsVwpXbwUqqdfHCr/mtVUrXK5O25vxMAXM7B3yeXN46ExI15RMV8fRcfEaMCw9/T7H5sU0LqJoecFAAAAAAC4H6Wn4u1+kelTTX28PFWqRFFduHhJ1SqXU0joFU2ZuUCBQZcUHROjJg381bdXN0nSvgNHNGnGPMUnJKhKxbI6fPSkBvbrIb+aVdV/8Fg90ekRNW1YW2MmzVIuq1XnAi/qXOBF+dWsok4BLfXx598o6GKImjT012t9e0jSbc93q0rlS9v/7OriogplSykwKDhTxggAAAAAAOB+k56Kt/tFpgdvJ0+fV9jVa/KrUUWSNGbSLPV8soP8alRRXHy83nx7klZv2KYmDfz19vgZGjX4JfnXqqpdew9q2coNqbZ7/OQZzfhghMwms556cYiuXQ/XRxOGKTYuTl2efUPt2zRT2dLFUz1fyyb1Um07JPSK1m7arknvDsrw8QAAAAAAAMgJqHgz0Nvjp8tkMuv02UC91re7ChbIp8ioKO3cc0Chl8Ps+0VERun02UCdOnNeFovFvoabf62qKubrk2r7jRv4ydXFRZJUrkwJ1fOvIavVKqvVqjIli+nM+QvyLeKV6vlSEx4eocHvTFaPbgGqUrFsivssXrpKP/yySpJks90vs5ABAAAAAAAyDhVvBkpa42377r81+J3J8q9VTUWLeEuS5kwbbQ/Nkhw7cTpZG7f74rjkunm8xWyWq0su+3Oz2az4+AQlZWIpnS8l4RGRen3kRDVu4K+nurRNdb+uHVqpa4dWkqS4uDg1DuiVZtsAAAAAAAA5SU6seMv0W3TW9auuzu1aava87+We201+Navqy29/sb8eHHJZF4NDVLK4r+Li47R73yFJ0u59h3T2fNBdnft25/uviMgoDRz5gerXrqHnnu54V+cFAAAAAADI6ZIq3px53C8yfY03SXru6U7q9twg/XP0X40e1k8fzfpK3fsMk0xSbjdXDR3QWz7ehTRm+CuaNGO+EmwJqlyhjEoW91WePB53de7bne9W3y1ZoYOHTygqKlrrN++QJLVoXE+9nn7srs4PAAAAAACQE+XEqaammJjobLsoWXhEpDzcc0uSDh4+riGjp2jxF1Pk5uaaxT1LXdJU03W/fS2rNUtyTQAAAAC4bxSs80pWdwHIEFe3T8nqLmSZpKzEPeAVmcyWNPe3JcQrYtkMbVw2757PVrJ179dt2qFFPy6XTTZZLGaNGtwvW4duAAAAAAAASFlOrHjL1sFbQOsmCmjdJKu7AQAAAAAAgLuUE2+ukK2DNwAAAAAAANwfqHgDAAAAAAAADJATK97MWd0BAAAAAAAA3P/MJpPTj+xk4fe/KvRK2B0dS8UbAAAAAAAADGdUxduZcxf07sRZCrt6TXk8cuutQX1VtnTxZPsd+/eMpsycr9DLVyVJL/XqpmaN6qTZ/q69BzVnwQ+q61dd7ds000P1HpTF4lwtG8EbAAAAAAAADGfUGm/vT5urjm2bK6B1E63ZuF1jJ8/S3OljHPaJiorW0NFTNGrwS6pZvZLi4xN09dp1p9qfOm6ILl4K1fLVmzRz7rd6b9rneqTFQwpo00TlSpe47bFMNQUAAAAAAIDhzCbnH84KvRKmQ0dPqE3LhyRJzRvVUVBwqM6cu+Cw38q1W1StcnnVrF5JkmSxmFWwQD6nz+Pj5ameT3TQos8+0PvvDNTOvw6qZ78R6v3qKC1buUEJCQkpHkfFGwAAAAAAAAxnNptkciJVs6VjrunF4FB5eRaQ1WKRlFhVV9i7kIKCQ1SiWBH7fv+ePieXXFYNenuSgi+FqlyZkhrQ5+l0hW+BQZf026qN+v2PjbLZbHq+R2f5FvbW9z+v0MY/d+u9Ua8nO4bgDQAAAAAAAIYz3fjPmT0lqcdLw+1TU7u0b6WuHVrd8bnj4xO0Y88BzZk2Wt6FCuqTL77TxOlfaPzbr6V57G+rNmrZyg06dOSEGjfw19DXeqvOg9Xtrzd9qLbaPflyiscSvAEAAAAAAMBwZidvrmC7sc/CTyfIar19dOXj7alLoVcUFx8vq8Uim82moOAQFfYu5LBfYe9C8qtZVT5enpKkR1o8pNdHvu9Uv7/9abnat2mm9955XXnzeCR73T23m4YMeC7FY1njDQAAAAAAAIZLurmCMw9neRbIr0rlS2vF6s2SpLWbdsjHy9NhmqkktWxaT4eOnFB4eIQkacuOvapQtqRT5+jeNUBdO7RKFrqtWrfV/udHWjZK8Vgq3gAAAAAAAGA4k5MVb+lY4k2SNHRAb42dPFvzFy2Vh3tujRzUR5I0fuocNa7vp8YN/FXEx0vPPtlBfQa+K5PZJO9CBTXsteedav/9j+aqdfOGybZPnD5PrZo1uO2xTgVvu/Ye1Mq1WxRyOUyT3h2kQ0dOKCIiSv61qjrVQQAAAAAAAORsZier2WzpqHiTpFIlimrOh6OTbR8x8EWH548+3EiPPpxyZVpKkqrjZJPCIyIlm83+2tnAi7JaLWm2kWbwtvT3tfps4Y8KaNVEqzdsSzzIYtGcBYvlX2uU050FAAAAAABAzmVUxZtRWnXpa+9v6y59HF4zmcx6vkenNNtIM3hb+P0yTRs/TGVKFdMPv6ySJJUpVUwnz5y/gy4DAAAAAAAgJ3J6/bZ0VrwZ5Yf5UyWbTc+/9o4+/+hd+3azyaQCBfLK1cUlzTbSDN7Crl5XmVLFbjy7ceHpXOgOAAAAAAAAOdu9VvHmW9hLkvTbtzPvuI00g7cKZUtq7cbtat64rn3bpq27Val86Ts+KQAAAAAAAHIWo9Z4M8LMud+qf+8nJEnTZi1Mdb/X+va4bTtpBm+vvviUXhvxvlau3aro6BiNmvCxdv11UB+OG5LOLgMAAAAAACCnMinbFLOl6fr1CPufr10Lv+N20gzeKlUoo69nv6/f/9ikQp4FVNjbU6/2eVrehQre8UkBAAAAAACQs9xLa7wNGfCc/c9vvdn3jttJM3iTJM+C+dW9W8AdnwQAAAAAAAA5m9nJNd5sWZ+7KTw8Iu2dJHl4uN/2daeCt/Vbdurw0ZOKjIpy2J7WPFYAAAAAAABAurcq3lp16Xvbbthsid3c/PuXt20nzeBt/NQ52rxtrx58oLLcXNO+TSoAAAAAAADwX/fSXU1/mD81Q9pJM3hbt2mHvp79vrxY0w0AAAAAAAB36F6qePMt7JUh7aQZvHl7ecqVSjcAAAAAAADchXtpjbeZc79V/95PSJKmzVqY6n5pLcOWZvA2dEBvffDRF2r/SDN5Fsjn8Fr5siWd6SsAAAAAAAByuHup4u369Zs3V7h2LfyO20kzeLt4KVR/7tyn1Ru2OWx3ZgE5AAAAAAAAQEpcui3rIzXnDBnwnP3Pb73Z947bSTN4m/bpQg3o212tmjXg5goAAAAAAAC4I2Y5V/Fmy4bx3PkLF7Vy7VYFh1yWd6GCatWsgYr5+qR5nDmtHeLi4xXQqjGhGwAAAAAAAO5Y0l1NnXlkJ+u37NRTLw7VvgNHZEuwaf/BI+red5jWbd6R5rFpVrx1bvewfvx1tbp2aJUhnQUAAAAAAEDOcy+t8XarmZ8v0riRA9So/oP2bZu37dG0WV+p2UN1bntsmsHbxj9368TJs5q/aKk8CzreXGH+x+PusMsAAAAAAADISZyuZsteuZtCQsPUsG5Nh231a9fUO+/NTPPYNIO3Jzq1ufOeAQAAAAAAAEqseDM7kbwlZLOKtxZN6urXFevV4dHm9m3LVm1Qyyb10jw2zeAtoFWTu+sdAAAAAAAAcjxnK96yQ+429H9T7dNi4+Li9cH0efp2yQoVKVxIF4JCdPpcoOrXrpFmOykGb1u271XDurUkSRu37kr14MYN/O+g6zmDd4PXlO1qIwFkmcs7ZmR1FwAAAO5J/DsK9w1bTFb3IMs5u8abU+vAGaxiuVIOz6tULGP/c9VK5ZxuJ8Xg7ePPFtmDt6mfLEzxQJOJ4A0AAAAAAADOMd943Aue79E5Q9pJMXj7avZ79j//uGBqhpwIAAAAAAAAOde9VPGWkkshl3Xl6nXJZrNvK1+25G2PSXONNwAAAAAAAOBumU2JjzRls9zt2InTGjluus6cuyCTKTF3S8oGN//+5W2PTTN469xzYIqL2uXKlUtFfAqpRZN6at+mabZNIwEAAAAAAJD17tXgbfLMBWpQp6Y+mzZaXZ4dqB8XfKhP5n6rGtUqpnlsmlNrH2vbXCaTSZ3bPax+vZ9Qp3YtZbFY1Lp5A/nVrKI5C37Q3K9+yojrAAAAAAAAwH0qaaqpM4/s5Pi/p/Xy808qbx4P2WxSHg93vfzCU5o9f3Gax6ZZ8bZ+8w5NHTdEJYoVsW9r2rC23nnvY82dPkZ1/R7QyLEf6fkene7uKgAAAAAAAHDfulcr3qxWqxJsCZKkvHk8dCnksvJ4uOtK2LW0j01rh9NnL6iIj5fDNh9vT505FyRJqlyhjC5fuXon/QYAAAAAAEAOYTIpxeXMUtovO3mgSgVt+nOPWjappwZ1amj4mGlyyZVLVSqVTfPYNIO3apXLafLM+erf+0nly+uhsKvX9ekX36lKxcTGT505r4IF8t39VQAAAAAAAOC+ZTWZZHYiVUvIZsnb6GH9lJCQeCfTAX276+vFvykiIkpPdXk0zWPTDN5GDuqjdyZ8rEe6vSRXFxfFxMaoRtWK+t+w/pKkqOgYDRnQ+y4vAQAAAAAAAPeze7XiLbebm/3Pri4ueu7pjk4fm2bw5uPlqU8mv62LwSEKDrki70IF5ONdyP56pfKl09VZAAAAAAAA5DxmJyveslvyFhcfrwWLlmr56s0KvnRZ3l4F1abFQ3r2yfayWm8fraUZvCWdIPBiiIKDQ1WtcjlFRkVJckz8AAAAAAAAgNTcqxVvUz/5UvsPHlWfZ7vKt7CXAoMu6cvvflHolTANfqXXbY9NM3g7efq8Br8zWdExMbp+PUIPN6uvnXsOaNW6rXp3+CsZdQ0AAAAAAAC4j92rdzVds2GbFn46QYU8C0iSqlUur5rVK+mZl4anGbyZ02p80ox5erxjGy39arqsVoskya9GFf3195G77jgAAAAAAAByhqSpps48spPcbm5yc3P9zzZXuefOneaxaQZvR46fUpf2D994lnjhHh7uioiMSn9PAQAAAAAAkCMlTTV15pHVwsMj7I9eT3XQqAkf65+j/+rylas6dOSE/vfBJ+r19GNptpPmVFPPgvkVGHRJxXx97NtOnw2Uj5fn3V0BAAAAAAAAcox7aappqy597QGgzZb4/1t3/CWT6ebzLdv3qsMjzW7bTprBW+d2LTV8zDS92LOLEhIStG3Xfs2ev1hdOrS6m/4DAAAAAAAgBzHd+M+Z/bLaD/OnZkg7aQZvj3dsI4vFrE/nfqeEhAR9+OmX6tK+lRrVfzBDOgAAAAAAAID7371U8eZb2CvF7VfCrqlA/rxOt5Nm8BZ29Zo6BbRUl/aJFW6XQi5r/qKlerz3N1q3dK7TJwIAAAAAAEDOdS8Fb7eKiorWh7MWavnqzYqNjVWuXLn0aMtGGtD3aeV2c7vtsakGb/8c/VfD3/1QFy+FKn++vHpv1Os6duK0Pp67SH41qmjG+yMy/EIAAAAAAABwfzKZTDI5cecEZ/bJTB/N/lpnzl7Q9PeGq5ivj85fCNan877T9NnfaMiA5257bKrB2/TZX+vhpg3UtlVjLV2+ViPHfiRvr4KaOfEtVSpfOqOvAQAAAAAAAPexe7XibeOfu7Xw0wnKny+PpMQbkY4b+ap69B2eZvBmTu2F4yfPqO9z3VSmVDH17fW4Qq+E6YPRbxC6AQAAAAAAIN1MJucf2YrNJvN/EkOTySybbGkemmrFW2xcnKwWiyTJzdVFHu7u8ipU8C57CgAAAAAAgJzIbDLJ7Eyqls7k7cy5C3p34iyFXb2mPB659dagvipbuniK+9psNr06dIIOHzupVT/Odqr9h+o9qBFjPlL/559QER8vBQYFa9a879Wonl+ax6YavMXFxuu7n1bYn8fGxjk8lxLveAoAAAAAAACkxaippu9Pm6uObZsroHUTrdm4XWMnz9Lc6WNS3HfRj7+rmK+PDh876XT7A/p215SZC/TSG2MUFx8nq9WqVs0a6NU+T6d5bKrBW7Uq5bR+807786qVyjo8N5lMBG8AAAAAAABwirPTSNNT8BZ6JUyHjp7QhxOGSpKaN6qjyR/P15lzF1SiWBGHfU+cPKsNW3Zp5KA+WrNxu1Ptx8XH67dVG/XmK7008o0XdTnsqgrmz+f0DSBSDd5mTnzLqQYAAAAAAACAtJhlktmpcjbnk7eLwaHy8ixgXy7NZDKpsHchBQWHOARvcXFxmvDh5xr5xguymFO95UEyVotFs+Z9r64dWkmSPAvkd/pY6TbBGwAAAAAAAJBR0lvx1uOl4fbKsi7tW9nDrzvx+cIlavZQbZUuWUyBF4LTdWw9/we0ffffqutXPd3nJXgDAAAAAACA4dK7xtvCTyfIar19dOXj7alLoVcUFx8vq8Uim82moOAQFfYu5LDfnn2HFBQcosW/rFJ8fLzCIyLVqefrmvvRuypYIN9tz+Hu7qZh/5uquv4PqLB3IYc7nL7Wt8dtjyV4AwAAAAAAgOGMuKupZ4H8qlS+tFas3qyA1k20dtMO+Xh5Jlvf7dMpo+x/DrwQrJ79R2rJgg+dOsflK1fVonFdSVJ4eITTfZMI3gAAAAAAAJAZnJxqmt67mg4d0FtjJ8/W/EVL5eGeWyMH9ZEkjZ86R43r+6lxA//091XS4aP/asjoqQoOuSzfwl764H9vqFzpEulqg+ANAAAAAAAAhnO24s2WntuaSipVoqjmfDg62fYRA19McX/fIt5a9ePsNNudPucbtWhSV+3bNNPPv6/Vx58t0pSxg9PVN+dv4wAAAAAAAADcoaSbKzjzyA6O/Xta/Xs/qbKli6vfc4/r6PFT6W6DijcAAAAAAAAYziznKsBsRnfESbFxccqVKzE6c3NzVXRMbLrbIHgDAAAAAACA4Uwmk0xOlLM5s09miIuN13c/rbA/j4mNdXguSY93bHPbNgjeAAAAAAAAYDiTnLtvQvaI3aRqVcpp/eadN59XcnxuMpkI3gAAAAAAAJD1jLq5glFmTnzrrtvIlOCtU8/X5ZLLKlcXF0XHxCigdRP1fKLDXbU5fuoctWn+kPxrVc2gXjraf/CoJk7/QpIUFxevGtUr6o1+PeXiksuQ8wEAAAAAANzP7rWKt4yQaRVvY0a8qorlSunipVA9/eJQ+despmqVy91xe6ndEjajVChbUnOnvyur1aqEhAQNHzNNP/z6h57q/Kih5wUAAAAAALgfOXvH0mxS8JYhMn2qqY+Xp0qVKKoLFy+pWuVyCgm9oikzFygw6JKiY2LUpIG/+vbqJknad+CIJs2Yp/iEBFWpWFaHj57UwH495FezqvoPHqsnOj2ipg1ra8ykWcpltepc4EWdC7wov5pV1CmgpT7+/BsFXQxRk4b+eq1vD0m67flu5ebmav9zbFycoqNjZLqvMlcAAAAAAIDMc6/dXCEjZHrwdvL0eYVdvSa/GlUkSWMmzVLPJzvIr0YVxcXH6823J2n1hm1q0sBfb4+foVGDX5J/raratfeglq3ckGq7x0+e0YwPRshsMuupF4fo2vVwfTRhmGLj4tTl2TfUvk0zlS1dPNXztWxSL1mbgReCNWT0VJ0LDFLDurXUpf3Dho0LAAAAAADA/cx845EWm9EdyUSZFry9PX66TCazTp8N1Gt9u6tggXyKjIrSzj0HFHo5zL5fRGSUTp8N1Kkz52WxWOxruPnXqqpivj6ptt+4gZ9cXVwkSeXKlFA9/xqyWq2yWq0qU7KYzpy/IN8iXqmeLyW+Rbz15afjFREZpf+9/4nWbd6hVs0aJNtv8dJV+uGXVZIkm+1+ensAAAAAAABkDCreDJS0xtv23X9r8DuT5V+rmooW8ZYkzZk22h6aJTl24nSyNm438C65bh5vMZvlestNEMxms+LjE5SUiaV0vttxz+2mh5vV14o1W1IM3rp2aKWuHVpJkuLi4tQ4oJfTbQMAAAAAAOQEOfHmCs5U+GWoun7V1bldS82e973cc7vJr2ZVffntL/bXg0Mu62JwiEoW91VcfJx27zskSdq975DOng+6q3Pf7nz/debcBcXFxUmSYmPjtH7zTpUvU+Kuzg8AAAAAAJBTWUwmpx/3i0xf402Snnu6k7o9N0j/HP1Xo4f100ezvlL3PsMkk5TbzVVDB/SWj3chjRn+iibNmK8EW4IqVyijksV9lSePx12d+3bnu9Wuvw7q+59W3qiWi1ftB6vpue4d7+rcAAAAAAAAOVVOnGpqiomJzraLkoVHRMrDPbck6eDh4xoyeooWfzHF4Y6j2U3SVNMDl711fxVHArgbl3fMyOouAAAAAMhCFltMVnchyyRlJcMnT5XFYklz//j4eE0YNFAbl82T1ZolNWMZJlv3ft2mHVr043LZZJPFYtaowf2ydegGAAAAAACAlJlMiQ9n9rtfZOvgLaB1EwW0bpLV3QAAAAAAAMBdMssksxOzA2330QzCbB28AQAAAAAA4P5AxRsAAAAAAABgANON/5zZ735B8AYAAAAAAADDUfEGAAAAAAAAGIA13gAAAAAAAAADUPEGAAAAAAAAGIDgDQAAAAAAADAAN1cAAAAAAAAADGA2JT7SYrt/cjeCNwAAAAAAABiPijcAAAAAAADAAKzxBgAAAAAAABiAijcAAAAAAADAAKzxBgAAAAAAABiAijcAAAAAAADAAKzxBgAAAAAAABjAdOPhzH73C4I3AAAAAAAAGM4syexEOZvN+K5kGoI3AAAAAAAAGI6KNwAAAAAAAMAIOTB5I3gDAAAAAACA4birKQAAAAAAAGAA7moKAAAAAAAAGCAHzjQleAMAAAAAAEAmyIHJG8EbAAAAAAAADMcabwAAAAAAAIABWOMNAAAAAAAAMIgRmdqZcxf07sRZCrt6TXk8cuutQX1VtnRxh3127j2gmZ9/q8ioKJlkUsN6tdS/9xMym80G9OgmY1sHAAAAAAAApJtrvDnzSIf3p81Vx7bN9d3cSerxeHuNnTwr2T5583hozIhX9M2cD/TFx2O0/+BR/f7Hpru6HGcQvAEAAAAAAMBwpnT856zQK2E6dPSE2rR8SJLUvFEdBQWH6sy5Cw77VSpfWsV8fSRJri4uqlC2lAKDgjPu4lJB8AYAAAAAAADDJa3x5szDWReDQ+XlWUBWi+XGOUwq7F1IQcEhqR4TEnpFazdt10P1HrzbS0oTa7wBAAAAAADAcM7OIk3ap8dLw2W6kcJ1ad9KXTu0uus+hIdHaPA7k9WjW4CqVCx71+2lheANAAAAAAAAhjOZTPYgLa39JGnhpxNktd4+uvLx9tSl0CuKi4+X1WKRzWZTUHCICnsXSrZveESkXh85UY0b+OupLm3v7CLSiammAAAAAAAAMJwRU009C+RXpfKltWL1ZknS2k075OPlqRLFijjsFxEZpYEjP1D92jX03NMdM/Cqbo+KN4MEb52WZioLAABwPyrYdbbjhlP7HJ/f+q9pm834DgG4p13eMSOruwAgg6R3qqmzhg7orbGTZ2v+oqXycM+tkYP6SJLGT52jxvX91LiBv75bskIHD59QVFS01m/eIUlq0bieej39WDrPlj4kQwAAAAAAADCeQclbqRJFNefD0cm2jxj4ov3PvZ5+zPCQLSUEbwAAAAAAADCc6cZ/zux3vyB4AwAAAAAAgOGcXb8tPWu8ZXcEbwAAAAAAADCcUWu8ZWcEbwAAAAAAADBeDkzeCN4AAAAAAABgONZ4AwAAAAAAAAzAGm8AAAAAAACAAXLgTFOCNwAAAAAAAGSCHJi8EbwBAAAAAADAcKzxBgAAAAAAABiANd4AAAAAAAAAA+TAmaYEbwAAAAAAAMgEOTB5I3gDAAAAAACA4VjjDQAAAAAAADAAa7wBAAAAAAAABsiBM00J3gAAAAAAAJAJcmDyRvAGAAAAAAAAw7HGGwAAAAAAAGAA1ngDAAAAAAAADJADZ5oSvAEAAAAAAMB4VLwBAAAAAAAAhsh5NW8EbwAAAAAAADAcFW8AAAAAAACAAXJevRvBGwAAAAAAADIBFW8AAAAAAACAAUw3/nNmv/sFwRsAAAAAAACMlwPnmhK8AQAAAAAAwHA5MHcjeAMAAAAAAIDxWOMNAAAAAAAAMABrvAEAAAAAAAAGoOINAAAAAAAAMADBGwAAAAAAAGAAppoCAAAAAAAABqDizSCder4ul1xWubq4KDomRgGtm6jnEx3uqs3xU+eoTfOH5F+ragb1MmU2m02vDp2gw8dOatWPsw09FwAAAAAAAO4fmVbxNmbEq6pYrpQuXgrV0y8OlX/NaqpWudwdtzdi4IsZ2LvULfrxdxXz9dHhYycz5XwAAAAAAAD3IyreMoGPl6dKlSiqCxcvqVrlcgoJvaIpMxcoMOiSomNi1KSBv/r26iZJ2nfgiCbNmKf4hARVqVhWh4+e1MB+PeRXs6r6Dx6rJzo9oqYNa2vMpFnKZbXqXOBFnQu8KL+aVdQpoKU+/vwbBV0MUZOG/nqtbw9Juu35/uvEybPasGWXRg7qozUbt2faGAEAAAAAANxvWOMtE5w8fV5hV6/Jr0YVSdKYSbPU88kO8qtRRXHx8Xrz7UlavWGbmjTw19vjZ2jU4JfkX6uqdu09qGUrN6Ta7vGTZzTjgxEym8x66sUhunY9XB9NGKbYuDh1efYNtW/TTGVLF0/1fC2b1HNoLy4uThM+/Fwj33hBFrPZ0DEBAAAAAAC431HxZqC3x0+XyWTW6bOBeq1vdxUskE+RUVHaueeAQi+H2feLiIzS6bOBOnXmvCwWi30NN/9aVVXM1yfV9hs38JOri4skqVyZEqrnX0NWq1VWq1VlShbTmfMX5FvEK9Xz/dfnC5eo2UO1VbpkMQVeCL7ttS1euko//LJKUuKacAAAAAAAAHBkuvFwZr/7Raav8bZ9998a/M5k+deqpqJFvCVJc6aNtodmSY6dOJ2sDdNtIk+XXDePt5jNcnXJZX9uNpsVH5+gpEwspfP91559hxQUHKLFv6xSfHy8wiMi1ann65r70bsqWCCfw75dO7RS1w6tJCVWyjUO6HXbtgEAAAAAAHKcHJi8Zfocyrp+1dW5XUvNnve93HO7ya9mVX357S/214NDLuticIhKFvdVXHycdu87JEnave+Qzp4Puqtz3+58//XplFFa8uU0LVnwoWZNHiUP99xasuDDZKEbAAAAAAAA0mZKx3/3i0xf402Snnu6k7o9N0j/HP1Xo4f100ezvlL3PsMkk5TbzVVDB/SWj3chjRn+iibNmK8EW4IqVyijksV9lSePx12d+3bnAwAAAAAAgDFy4hpvppiY6Gy7KFl4RKQ83HNLkg4ePq4ho6do8RdT5ObmmsU9S13SVNN1v30tqzVLck0AAIAsVbDrbMcNp/Y5Pr/1X9OsjwsgDZd3zMjqLgAZwmKLyeouZJmkrGTNr185lZXExcWpRbvu2rhsnlP7nzl3Qe9OnKWwq9eUxyO33hrUV2VLF0+239Ll6/Tlt7/IZrPJv2ZVDX61l+HZTbZOhtZt2qFFPy6XTTZZLGaNGtwvW4duAAAAAAAASIVBa7y9P22uOrZtroDWTbRm43aNnTxLc6ePcdjn/IWLmjN/seZ9PFaeBfNryOgp+um3tfY1+42SrYO3gNZNFNC6SVZ3AwAAAAAAAHfJ2fXb0rPGW+iVMB06ekIfThgqSWreqI4mfzxfZ85dUIliRez7rdm4XY3q+6mQZwFJUqeAlpq/aGnODt4AAAAAAABwf4iPj3dq/bb4+Hin27wYHCovzwKyWiySJJPJpMLehRQUHOIQvAVdDFGRwl72576FvRV0MfnNNjMawRsAAAAAAAAMYzKZ5ePlqYc7POP0MXnyuKvHS8NlupHUdWnfyvDqNCMQvAEAAAAAAMAwFotZPy74UDZbgtPHmExmWSzmNPfz8fbUpdAriouPl9Vikc1mU1BwiAp7F3LYr7BPIZ07f9H+PDAoWIV9Cv23uQyX9hUAAAAAAAAAd8FiMctqtTr9cCZ0kyTPAvlVqXxprVi9WZK0dtMO+Xh5OkwzlaTmjepq05+7FRJ6RTabTUuWrdbDTetn+HX+FxVvAAAAAAAAuGcNHdBbYyfP1vxFS+XhnlsjB/WRJI2fOkeN6/upcQN/FfP10QvPdFHfN96VJD1Yo4o6BbQwvG+mmJhom+FnyUHi4uLUOKCX1v32taxWck0AAJDzFOw623HDqX2Oz29dVdnGP0UB3N7lHTOyugtAhrDYYrK6C8gCTDUFAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADGDN6g7cb2w2myQpLi4ui3sCAACQRWwJ/91wu52N7AmA+wA/W+F+YTbbZDKZsrobyGSmmJho/rWTgaKiotT8sReyuhsAAAAAACAb2bhsnqxW6p9yGoK3DJaQkKCYmBhZLBY902+EFn46Iau7dF/r8dJwxjgTMM7GY4wzB+OcORhn4zHGmYNxzhyMs/EY48zBOGeOe3mcLRYLFW85EFFrBjObzXJzc5MkmUwm0myDMcaZg3E2HmOcORjnzME4G48xzhyMc+ZgnI3HGGcOxjlzMM6413BzBQAAAAAAAMAABG8G6tK+VVZ34b7HGGcOxtl4jHHmYJwzB+NsPMY4czDOmYNxNh5jnDkY58zBOONewxpvAAAAAAAAgAGoeAMAAAAAAAAMQPAGAAAAAAAAGIDgDQAAAAAAADAA9+BNQ0xMrCZ/PF879hxQ2NVr8ipUUD0eb6f2bZpKksLDI/T+R19o8/Y9cnVxUdcOrdS7eyf78Wm9PmLMNO07eESRUdHKnzev2j/SVM893TGzLzNLGT3G/QeP1d+Hjslqsdi3fTt3krwLFcy8i8wGjBznCxcv6ekXhyY7X4O6NTXxf4My7yKzmNHv5X+O/qupn3ypY/+eVoF8efV8j85q26pxpl9nVrvbcZ41/3tt2LJLp06fV5cOrTSw3zMO7b/34efas/+QzpwL0oA+3fVk50cy9fqyCyPHOSYmVq+PfF8nT51XdGyMvDwL6qkuj6pj2xaZfp1Zyej3cqeeryv0cpgs5sTfs1osFq36cXbmXWA2YeQ4793/j954a6LD+aKiY9S1Qyu90b9n5lxgNmH0+3n7rv36eO4inT0XJB9vTw3o010N6tTM1GvManczxqFXwjTt06+0Z/8hhUdEqphvYb34TGc1buBvb5/Pv0RGjjOffzcZ/X7mMxDZCcFbGuIT4lXIs4A+em+Yivn66MA/x/XGWx/Ix8tT9fwf0OSZC3T12nX99OU0Xb5yVQOGvaciPl72H4bTer13j84qWayIXFxy6cLFSxo48gP5FvbSIy0bZeVlZyqjx1iS+vd+Msf+4yGJkeNcxMdLa37+3H6u2Ng4tX/6FT3ctEFWXW6WMHKMr10P1xtvTdQLz3TRzEff0j9HT+i14e+rmK+PalavlMVXnrnudpyLFy2sV154Sj//vjbF9suXLamWTetp1rzvM/Oysh0jx9liseiN/s+qdMmislos+vfUOb08ZJxKlyiqWg9UzuxLzTJGv5cl6d3hL6tpw9qZdUnZkpHjXOuByg6ff6GXw9Sh+wA93LR+pl1fdmHkOJ8LvKhh736od4e/ooZ1a2rL9r80YsxHWjhrgor5+mT2pWaZuxnjyMhoVSxXSi8//4S8ChXU5u17NWr8x5o7/V2VKVVMEp9/SYwcZz7/bjL6/SzxGYjsg6mmacjt5qY+z3ZV8aKFZTKZVL1KefnVrKq//j6sqKho/bH+T/Xt1U1583ioZHFfdX2slX5ZsV6S0nxdksqXKSEXl1ySJJNMMpvMOnMuKEuuNasYPcZIlJnjvH7LTiUk2NSsUc76oDNyjPcfPCqXXLnUuV1LWSxmVatcXs0eqq2ly9dl4RVnjbsZZ0kKaNVEDerUlId77hTb79qhleo8WN3+vTmnMnKcLRazypcpYa9ENpkkk8mks+f5/MvI9zISZeY4/7Zqo0oUK6wa1SoaeUnZkpHj/OfOv1SpfGk1qv+gzGazGtV/UFUrldXvf2zMzEvMcnczxsV8fdS9W4B8vAvJbDarcX0/lSxRRH//c8zePp9/iYwcZz7/bjL6/QxkJwRv6RQdE6ODh4+rfNmSOnU2ULGxcapQrpT99YplS+n4v6clKc3Xk0yc/oWadeitjs+8poioKAW0znlTx25lxBjP++Ynte7SVz37j9Rvq3LWP9JSY8Q4J/l1xXq1adFQri4uxl5ENpeRY5yQYJPNZnNoP8Fm07FUvgY5SXrGGXfOiHEe9PYkNW33nJ56cag8C+RX04dyVlj/X0aM8fvT5uqRbi/pxddHa8v2vRnc43uTkd8zflmxXu3bNMugnt7bMnKcU/8MPJOhfb7X3M0Yh14J08nT51W+TInM6u49y4hx5vMvOSPGmc9AZBdMNU0Hm82mCVM/U4miRdTsodrad+CIcru5OqwdliePuyIioiRJkZFRt309yeBXn9Ogl5/V4WMntXHrbuXN45E5F5QNGTHG/Z57QmVKFZObq4t27j2ot8ZNl7u7m5o9VCfzLiybMeq9LEmBQZe0Y8/fevn5J42/kGwso8f4garlFRkVre9/XqlOAS104PAJrd+yUwXz58vcC8tm0jvOuDNGjfPkMW8qPj5Bfx04rD37/snRYb0RY/zO4JdUuUIZmc1mrd20Q8PHTNMnk95S1UrljLiEe4KR3zP27v9H5y9c1KMP55zlQlKT0eNc16+6Zsz5Ruu37NRD9R7U5m17tP/AET1Yo4pRl5Dt3c0Yx8bGadT4j9WyST1VqVg2M7t9zzFqnPn8c2TEOPMZiOyEijcn2Ww2TZw+T6fPBur90QNlNpuVO7eboqJjFBcfb9/venik3N3dJCnN129lNptVpWJZubu7afqcr42/oGzIqDF+oGoF5fFwl9VqVf3aNdQxoIVWr9+WeReWzRj9Xl62cr0qlivt8BuqnMaIMc6fL68mvjtIK9duVcCTr+iTzxepXesmyp8vb+ZeXDZyJ+OM9DN6nC0Ws/xqVFHolTB9tXhZRnb9nmHUGNd6oLLc3Fzl4pJLbVo0VKN6D2rdph1GXMI9wej38i8r1qtxfT8VLMAvRDJ6nEuVKKoxI17R5wuXqO3j/fXL8vV6uFl95c+Xx6jLyNbuZoxjY+M0Yuw0ubq6aPjrL2R21+8pRo8zn3+JjBpnPgORnRC8OcFms2nSjHk6cPiYPhw/THk83CVJpYr7ymq16NiJmyWvR4+fUrnSJZx6PSVxcfE5bo03KXPH2GwyGXQV2Z/R45yQkKBlKzeo/SPNjL+YbMrIMa5ZraLmfPiOViz+VJ9OGaWQ0DA9WCNnLcSb5E7HGemTmeMcHxevM+cu3HWf7zWZOcZmc879Z5/R4xweHqE1G7bn6M8/ydhxbtLQXwtmjtPKH2Zp0ruDdOZcUI78DLybMY6NjdPIsR8pNjZOE95+TblyMfkpNZk5zjn180/K3HHOyZ+ByHq8+5ww6eP52nfgqD6aMEz58t6cBurm5qqWTepr9vzFuh4eoTPnLmjx0pX2f3Sl9Xpg0CWt3bhdEZFRSkhI0L4DR/T9zytVz/+BLLjKrGXUGF+7Hq4t2/cqKipa8fEJ2rHnby1ZtkbNGuXMaaZGjXOS7bv/1pWw62rdPGfdzfRWRo7x4WMnFRMTq6joGP3821rt3ndIT3TKmXfrvdNxlqS4uDhFx8QoISFBCQkJio6JUVxcnP312NjE120JNsXHxye+fstvXHMSo8b5yPFT2r5rv/232Zu37dGKNVtUz79GZl9iljNqjC9cvKQ9+/9RTEys4uLi9Mf6P7Vh6y41yaF3dzPye4YkrVy3Vfnz5cmR/4a7lZHjfOjICcXFxys8IlKfL1yiq9euO9zBPqe40zGOi4vTW+OmKzIqWu+PHpjiDRT4/LvJqHHm88+RUePMZyCyG1NMTLQt7d1yrsCgS+rc83W55Moli+VmTtmmxUMa+lpvhYdH6P2P5mrztr1ydXFRlw6t9HyPTvb9bvd6YNAl/e/9mTp+8qwSbAny8iyoR1s2Us8n2+eoRN7IMb585areHDVZJ8+ckyT5FvbWE50eUfs2TTP3IrMBI8c5ycixH8nV1UWjBr+UadeVnRg9xmMnzdL6LbsUHx+vB6pW0Gt9e6hs6eKZeo3Zwd2O85hJs5LdZKVtq8Z6+82+kqT+g8dqz75/HF5/vkcnvfBMFwOvKvsxcpwPHTmhidO/0KmzgTLJJN/C3urcvqU6BbTMtOvLDowc439PndM7732ss+eDZLFYVKJYET3XvaMa1/fLtOvLLoz+niFJvV8dpQZ1aurFnjnr+8StjB7nAcPe04HDx2SSSXX9quv1l3rIx7tQ5lxcNnE3Y7x73yG9PHicXFxyyXLLzxk9n+ygXk89JonPvyRGjjOffzcZOc58BiK7IXgDAAAAAAAADJBzyqoAAAAAAACATETwBgAAAAAAABiA4A0AAAAAAAAwAMEbAAAAAAAAYACCNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAA4IR3J36qIe9McdgWeiVMjz7eT+u37MyiXgEAACA7I3gDAABwwhv9e+rwsZP6/Y9N9m0TP5qnBnVqqmnD2hlyjri4uAxpBwAAANmDNas7AAAAcC/I4+GukW+8qLcnfKzaD1bT7r8O6eDh4/pq9nuaNGO+Nv25WzExsapXu4YGvdxTeTzcJUmj35+pXXsPKiIqSiWKFtGrLz4t/1pVJUnLVm7Qt0uWq3EDf/302xrVqFpRE0a9lpWXCQAAgAxkiomJtmV1JwAAAO4VE2fM06nT53Xs39N6d9jL+vn3tbJYLBr8ai9ZrRZNmPqZLBaL3hnST5L064r1ataojtxcXbRoyXJ9+e2v+nHBVHm459aylRs0Yepn6t2jk555vL3i4+Pl5uaaxVcIAACAjMJUUwAAgHR45YUndfZ8kJo09FeFcqW0bvMOvflKL+XN46Hcbm56sWdX/bH+T8XHJ0iS2rVpqjwe7rJarerRrZ1stgQd+/eMvT0PD3f1euox5cplJXQDAAC4zzDVFAAAIB1yu7mpqK+3ypYqocCgYCUk2NTl2YEO+5hNZoVcviIvzwKaPX+xVm/YptArYTKbzAqPiFRY2DX7vt5eBWU287tQAACA+xHBGwAAwB0q7F1IZrNJv3w9PcVqteWrN2nl2q36cPwQlShWRCaTSa279JFNN1f6MJtMmdllAAAAZCJ+vQoAAHCHCnkWUJMGtTXp4/m6cqOKLST0itZt3iFJCo+IVK5cFuXPl1exsXH6fOESRUREZWWXAQAAkIkI3gAAAO7CW2/2Ud487ur96ii17PSCXho0RoePnpQktW3VWGVKFVfnnq+rS6835OqaS97enlnbYQAAAGQa7moKAAAAAAAAGICKNwAAAAAAAMAABG8AAAAAAACAAQjeAAAAAAAAAAMQvAEAAAAAAAAGIHgDAAAAAAAADEDwBgAAAAAAABiA4A0AAAAAAAAwwP8BgWNvKEtVJZQAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1400x400 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "id": "4e681b66",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "plot_regime_heatmap(\n",
-    "    pca_probs,\n",
-    "    macro_data_full.index,\n",
-    "    f\"GMM Regime Probabilities (PCA-reduced, {start_yr}-{end_yr})\",\n",
-    "    n_regimes=n_regimes_full,\n",
-    "    is_probability=True,\n",
+    "first_merge_distance = float(column_linkage[0, 2])\n",
+    "merged_first = [extended_df.columns[int(i)] for i in column_linkage[0, :2]]\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"The first merge the tree makes is `{merged_first[0]}` with `{merged_first[1]}`, at \"\n",
+    "        f\"a distance of **{first_merge_distance:.1e}**.\"\n",
+    "    )\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "58416a2d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00374,
-     "end_time": "2026-07-18T19:35:45.614413+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.610673+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "d5e067c0",
+   "metadata": {},
    "source": [
-    "---\n",
+    "A merge at zero distance is two copies of one column, and the tree finds it before it\n",
+    "considers anything else. Above that the panel resolves into groups a reader can name: the\n",
+    "series that only trend, the short and medium Treasury yields, the curve-shape series\n",
+    "alongside unemployment, and - joining last, at the greatest distance - the VIX and initial\n",
+    "jobless claims. That last pair is the only part of the panel that moves on the timescale a\n",
+    "crisis moves on, which is why the principal components leave it until third and fourth\n",
+    "place while spending the first two on trend and on the level of long rates.\n",
     "\n",
-    "# Comparison: 4 Indicators vs Extended Dataset\n",
-    "\n",
-    "How do results differ between the simple (4-indicator) and extended approaches?"
+    "What the tree does not do is choose the panel. It says which columns duplicate each other;\n",
+    "which of a duplicated pair to keep is decided on grounds the data cannot supply - what the\n",
+    "column means, and whether it is published in time to be read when a decision has to be\n",
+    "made."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9f3d6524",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003801,
-     "end_time": "2026-07-18T19:35:45.621991+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.618190+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "4a0e0a5e",
+   "metadata": {},
    "source": [
-    "## Visual Comparison\n",
+    "## Key takeaways\n",
     "\n",
-    "Side-by-side heatmaps showing regime probabilities from both approaches."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "id": "d4389c89",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:45.630620Z",
-     "iopub.status.busy": "2026-07-18T19:35:45.630515Z",
-     "iopub.status.idle": "2026-07-18T19:35:45.764970Z",
-     "shell.execute_reply": "2026-07-18T19:35:45.764492Z"
-    },
-    "papermill": {
-     "duration": 0.139799,
-     "end_time": "2026-07-18T19:35:45.765557+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.625758+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABXkAAAJZCAYAAAD8njYUAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAml5JREFUeJzs3Xd4VMUCxuEvyaZAKhAgoYTee0LviBRBUJpUKUpRpCogIipepKgoIEUQkSa9g3QEpPfeew8dQgopm+T+EbJk2SQECISF3/s897nZ2XNm5uzsWZdv58yxCQ8PixYAAAAAAAAAwCrZpnQHAAAAAAAAAADPjpAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXgAAAAAAAACwYoS8AADguflfu6lytVqpXK1W6tz7h5TuDp7BwGHjTWO498DRlO4O8EIsW73R9D7/c9r8ZK37VfscTOicji1r0LpHynUOAAAkO0NKdwAAgJcpLDxcy1Zv0obNu3T67EUFBgfL1cVZnunSqFC+XKpSoaTK+BWRjY2NJKlz7x+07+Bx0/6d2jZR2+bvmdU5Y95yjZoww/S4UP5c+nPk95KkvQeO6rM+g03PuTin1tKZo+Xk6GAqCw+P0HutuuleQKCp7NcfeqtcqWKJHku5Wq0syhwdHeSd0VMVypRQ66b15ebqnJSX5Y1y4dJVzVm8Wrv3HdHNW3dkY2sjrwyeKl44n+rWrKyC+XKldBeRTIxGo1b8u0VrN2zTqTMXFRQSorQe7sqa2UtvVS6tmtXKyzl1qpTuZop7/HPucZXL+enHAT2fut6TZy5o49bdkiTfogXkW6zgM/fxdTRw2HgtX7NJkvRxqwZq/2GjFO5R8osN0l2cndWsYe0U7g0AAK83Ql4AwBvj4mV/9RkwXBcuXTUrv3vvvu7eu69TZy5o0fJ1+nfRn0qdyineOv5Z9Z/aNKtvCoElacnKDUnuQ1BwiNZt3KE6NSqZyv7butss4H0eYWHhOn/xqs5fvKq9B45qwojvZWf34i/cSZfWQ+N++UaS5Oyc+oW396zmLl6tkeOnKzIy0qz87PnLOnv+sg4dPaWpvw9OYO/XW9vm76l+7aqSpFw5sqZsZ5LBjVt39OWA4Tp+6pxZ+fWbt3X95m3t3n9EadO4q0r5kinUw9ffqTMXNPHvhTEPWomQ9xUR+1nt4GD/wtuKHX+vjJ6EvAAAvGCEvACAN0JgULB69PtJ/tdvSpLc3VzU5L1aKpQ/l2xtbHTxyjVt3blfO/YcTLSeK/43tOfAUZUsXkiStP/QcYvQ+EmWrtxgFvIuXrH+KY/G0qD+3eTu6qL9h0+YZk4dO3lOh4+dUrHC+Z67/idxcLB/Ke08j3WbdurXsVNNj8v4FdG7NavIw8NV167f0vrNO3Xz9r2U62AKeRAaqlROTsqa2UtZM3uldHeSRUSEUX2++1UnTp+XJLm6pFbzRnVUKH9uRURE6PCx01q6akOytxv7WlqzNs3qW1xF4O7mkkK9wYvwqn9WP63X4bwDACA5EPICAN4IM+YtNwt4/xr1P2XyymB6vrRfETWuX0PnLlyRg338/3lMndpJISGhWrJigynkXbxig9lziYndZv/hE7p42V8+Wbx1+ep17T1wLMl1JKRAnhzy9kovv+IFtX7zTp05d0lSzKzFuIxGo+YuXq1V67bqwiV/SVLO7FnU5L0aql29otm2UVFRmjRjsRavWKf7gcEqlC+Xun/SSiPGTTNd2r1gynB5e6WX/7Wbatgm5nLuEkXza+zP/SXFXKobO5Prq57tdfPWHS1c9q8ehIapQuni6t21naKiojVi3DRt2rZXtra2ql65jHp82kqODg5m/dm4dY/mLl6tE6fPKTQsXN4ZPVWzWnm1bPKu2fIX8TFGRmrUH9NNj6tVKq1BX3c1m5H9bq0qOn/xitl+l65c05SZi7Vr3xHduReg1KlSqVD+XGre6B2VKlHYtF3cZTnq1Kik8qWLa8LU+bp245by586uXl3bKWe2zJo0Y7EWLV+nwKBglSiSX326fSTvjJ6mehq07qFr129JkpbNGqOR46dr6879io6OVoUyJdT9k5ZK6+Fu2n7q7CXavvugLl+9roD7QbKxsZF3Rk9VrVBKbZrVl5OTY7x1L5w2QiPHTdeufYfl5uqiBVOHm106PuanfqZZl3sPHNWkGYt14vR5hTwIlatLanlnTK8iBXOrQ+vGcokzc3vdpp2av2SNTp65oLDwcKVPl0blShVX2+b15ZkujWm7uG2NGPylDhw+oX9W/6eAgCDly5Ndvbu0VZ5c2UzbL1u9UT/88oekpF3WvmzNRlPAa2drq9E/fa28ceqrUKaEWn3wroKDQ0xl0dHRWrxivf5Z9Z/OXbgiozFSXhk9VbVCSX3YtJ7ZccZd3mDy6IGau2SNNm/fq4D7Qdq26m9JUsiDUM2Yt0zrN+3SZf/rMhjslC93dn34Qb0nLsWyYfMufTVwpCTpg/drquenrU3PHTxyUp0+/58k6a1KpTWofzeFhoVrwtR52rh1j67fvC07Wzul8XBT3tzZVLt6BVWtUCrR9uLKmtkrwRDwwqWrat35a4WHR8gro6dm/DFUqZycFBQcoubt++jWnXtycnTU1N8HqdtXQ03vNylmRmfsZ0HcMbx67YamzFyinXsP6fbdALmkTi3fYgXU/sOGyu6T2bT/4++BLJkyatrsf3Tp6jV5ZfBUxzaN9XaVsmb93b3/iMZOnKUz5y4rvWcaNWv4jlLFOScel9S+xG47/Pdp2r3vqFI5OapGtbJ6v071JL/OiXna80OKuUph9sKVunn7rnJlz6rOHzdNsP7YpX68Mnpq4dQRpvLIyCgtWv6vVv67RecuXFGE0agMnmnlV7yg+nb/WJJ05vwlTZ21VCfPnNftOwEKeRAqNxdnFciXQ60+qKcSRfJLMv/sl6Rr12/F225EhFGzFqzQmg3bdOnKdUUrWlkzealGtbJq3rCO7OP89/hJn2EB9wM1btJcbd99QLfu3JODvb3SpfVQ/jzZ9X7d6vItWuBZhgMAAKtByAsAeCOs2bDN9HeLxnXMAt64cmTLHG+5JNWoUk6LV6zXf1t3635gsCRp/eadMc9VLafFyxOfkZvDJ7NCw8J15twlLVm5QV3aN9eSFesVHR0tnyzeSpfWPdF1MZMqOjra9HfcYM1oNKrn1z9r9/4jZtsfPXFG3/90RmfOXdZn7ZuZykeO/1tzFq02Pd578Jg+6z1Iri7Pts7v1FlLdMX/hunxmg3bFRgUovuBwTp64oypfNHydfJwd1Wntk1MZX9MmadJMxaZ1Xfx8jX9OW2Bdu87ot+GfmUWBjzu8NFTunYjJvC2tbVRl/bNzALeWHGDnCPHz6jbV0PMgvf7gUHatuuAtu8+qF6ftVHDem9b1LH/0HGtWLvZNA4HjpxUj35DVbGMr9ms7e27D2rAj2M1/tdv4+3zp71+0MXL/qbHq9dv1dnzlzXxt+9Nl1kvW73JbBtJOn/xqiZfXKxDR09p9E/94q27S5/BprFwTWTd5guXrurzb4YpLCzcVHYvIFD3AgJ17ORZNa5f0xR+jvlzlv6e+4/Z/lev3dT8pWu0YctO/TH8u3jPu59HTTJ7Xxw6ekpffj9CcyYNk8HOLsG+JWbtf9tNf9euXsEs4I3lnDqVaT3e6OhofTd0jNZs2G62zcXL/po6e6n+27pHfwz/Lt41rr8eNMqs/1LMsiyffDHQ9GOLFLP29r6Dx7Xv4HH16tJGjerVSLD/5UsXl6tLagUGhWjD5t3q8cmHpvdr7GdO7LFJ0i9jpuifVf+ZyiNklP/1m/K/flNOjg5PFfImJlvWTOrUpolGTZiha9dvacLUBerWsYVG/zlTt+7ckyR1/rhpkmeEnzh1Tl37DlFg0KOw/W7Aff27cYe27Tqg34Z+pUL5LdfIXvnvFrPX/NKVa/pu6BjlyemjbFkzSYoJwz/v/7MiIoySYq7C+GXMFOXO4fPcfQm4H6TOvQaZfkQLDQvTnEWrtffA839+Py4p58f0ucs0+s+Zpm2OnTyrnl//pCyZMia5HaPRqF7f/qIdew6ZlV++el2Xr143hbxnz1/W6vVbzba5G3BfW3fGfC7+NuQr+RVP2rIc4eER6t7vR+0/ZP66nT53UafPXdS2XQf125C+8X62x/cZ9vWgUdqz/9EN5ozGSIVcuaZLV64ps3dGQl4AwGuPkBcA8NoLeRBq9o9kv2KFTH/fun3XIqDJmCGdvDJ46nEVypbQpu17dedugFb+u1k2NjYKCwuXm6uLqlYo9cSQV5Lq166q4b9P04q1m9W+VUMtezhbq17tKtq6c/8zHqF07NQ5+V+/qX2HTujs+cuSYkLlYoUezcibvXCVKeAtXCC3Wn3wrqIiozRu8lxdvOyvv+f+o6oVS6pQ/ty6cOmq5i5eIykmFG3b/H0VyJtTcxev0s69h5+pj9eu39Jn7ZvJK4Onhoz4UyEhodq++6BSp3LSVz3by2iM1M+jJkmKCXpjQ96jJ86YAl7PtB7q2LaJ0qdLo7mLV2vrzv3af/iEZi1YoQ+b1kuw7VNnL5r+Tp8ubYIhf6zo6GgN+uUPU8BbrVJpvVuzsg4fO60psxbHzD4e/7cqlCmhjBnSme179dpN1a1ZWW9VKq2xf83WmXOXdPtOgBavWK/WTeupYP5c+um3SbpzN0AHj5zU2fOXlTN7Fos+REZGamC/LgoLD9foCTN1LyBQp89d1OIV69XkvZqSpAZ1q8vD3UXubq5ydHRQcMgDLVr2r7buPKA9B47q4JGTKloor0Xdd+4GqFunlsqVLYuuPpzhHp+dew+bAt4P3q+lSuV8FRgYrAuX/LVx225T8Hjk+GlTwOvgYK9ObZooaxYvzV6wUnsOHNXtOwH6edRkDR/Ux6KN6zdv67OPmylL5owa8fvfun7ztvyv39SO3QdVoUyJRMcpIafjjHexhzMLE/PvfztMAa+ri7M++7iZPDxc9efUBTp97qIuXLqqcZPmqE+3dhb7XrtxWx+3aqAiBfPq3IWYmeDjJs01BbzlSxdTo3o1FHA/SGMmztTtOwEaOX66KpbxtXjvxHJwsFe1iqW1ZOUG3bh1R4ePnVaRgnkkxczylWKuSIidEbxp2x5JMTMku3VoIefUqXT91h3tO3jsqW8s98Mvf5hmzMbq/0VH1a1ZWZLUrGFtbdiyS4eOntKcRavkndFTSx5e0eBXrKAa148Jrwf376b/tuzWlFlLJEl1a1ZWvVpVJMV8xkZHR+t/w8abQtXmjeqorF8RnTxzQeMmzVHIg1AN+uUPTf9jqMUPMlf8b6he7SqqUr6kZi1Yqd37jygqKlpLVm5Q1w4tJEmjJswwBbylShTWB+/X0qmzFzRx2gKLY37avkyft8wU8HpnTK/OHzc1nafJ7Unnx/3AYE14uESPJDV5r6bKliyqNRu2aeW/W5LczpxFq00Br5Ojo1o3q6cCeXPqxs3bWhTnv20+WbzVrWMLZfbOKOfUqRStaF28fE0jx/2t8IgITZ29RH7FC+rdWlVUqkRhffLFQElSurTuGvR1N0mP1gKevXClKeDNmD6dOn/cVDY2Nho7cZau3bit/YeOJ/jZ/vhnWHDIA9NVMXlzZ1P7DxvJYGenazduadfew2ZXNQAA8Loi5AUAvPaC4lySLcWszxlr/eZdZuu0SglfDm6ws9M7b1fU9LnLzG62Vrt6+QSXeHhcrbcqaMyfs3TnboCGjpyoO3cDZDDYqU6NSs8V8n79w29mj6tWKKUvPmttdtO1Vese/YO/WcN35OHm+rBP5TVhakxIsPLfLSqUP7c2bdtrmolapXxJdWgd83oULZRX9Vt2NZvZmVTVq5RVqybvSpJWrN1sOt6mDWqbbvg1f8kanb1wWfcCAhUUHCIX59Rate7RrLG6NSvL5+EswQZ1q5vqWLluS6Ihb3DwA9Pfnuk8ntjXk2cu6NzDpRvSpXXX//p2lsFgUPnSxXX+4hWt37xLERFGrd+8y+JmQhnTp1O/nu1la2urcxeumGbYFS+cT59+FHMJ9a69RzR/aUyIfvnq9XhD3j7dPlJp35glISKNkRoyYqKkmBv1xYa8pX0La/LMRTpw+KTu3AuQ0Wh+Q7njp87FG/J279RK79Wp9sTXwWB4NJM2k1d65fDJrHRpPSRJbVu8Z3ou7sy+RvVqqEXjOpKkIgXy6L2W3RQeEaEdew4p4H6QxfquDd99W60+iHlfXLp8TWP/mm16XWLVrVnZFDImRVDc8X7Y38TE7X+H1o1Mr02WTBnVqtNXkmJmB/fu2tYicGzVpK7p86KMXxFFRUWZ6rO3N6hZw3fkYG8v59SpVKVCKS1YulYREUb9u3GH6XWKT623yps+Z9Zv2qkiBfPoyPEzphnpb1UqI4Mh5nMndpxcnVMrc6aMyp41kxwc7E2hanKytbVV/y86qnXnrxUWFm76/Eyd2klff9HR9PoUyJvT9IOTJHllSGe2DMTJMxdMz+fJlU1VyvtJkooUzKMC+XLp8LFTOnfxik6cPq/8eXKY9SFPTh/169lBkuTh7qr23WN+vIp9z9y5F6DDx05Lkhzs7TWwXxe5u7moYtkSunDpqtlnihTzI9DT9CU2VJekXl3aqHzp4pLMz9Pk8qTzY+feQ6bP4wJ5c+rzzjFLe5TxK6r9h46b3i9PsvLfzaa/u3/SUu/Xecv0uP47jz4rcufw0f5DxzV55mJduHxVDx6EmV09cuxkzI0OvTJ4mv1Yam9vuW776vWPrrDp1aWtKpaN+VEnlZOTen/3i6SYq3Di+2x//DMsNCxcNjZSdLTk4eaqrJkyKktmLxns7NSgbvIsowEAwKuOkBcA8NqLu5amJN24dUc+Wbyfqa76tatq+txlZpdh13+nmgICApO0v7ubi6pWLKXV67eagoZKZX3N1llNDsdPnVXIA/P1fS9euWb6u/+gUfHud/5izE3k4s5uLhjncmk3V2dly+qtk6cvPHWfCubLGaeeR0FfgbyPAhx390flgUExIe+lOP2eMmuJaWZgXLHrCyfE2fnRbMZbSbi52qXLj9rMlzu7KUyTpIL5cmn9w9mUl65YtpsvT3bZ2saE625xAs38cY7TI+5xBgfH24e4l6kXzPfo76v+MTNv/a/fUsee3ys45IHFvqa6g0LiLY8NU56kcjk/jZ88VwH3gzRi3N8aMe5vubo4q1D+XHq3VhVVr1xGUszSGfH128PdVZm80+v8xauKjo7W5avXLULeEkUfzbSN+9zjP848DRfnVAq4HyRJpmUEEhP33Ijb/1zZs8rJ0VGhYWEKDArW3YD7FudqxbK+Zo/v3Q9UYFDMmEZEGNWt79B42zx/6Uq85bFKFC2gjOnT6frN21q/ZZe6dWpptlRDrYdLNUhSvVpVNXnmYp06e1FtOn8tO1tbZc3ipbIli6pl47pmy7Y8SXw3XsuaxXz5BZ8s3urYurFGTZhhKvvso2Zm60s/SdxlRk6duWCa8fm48xevWIS8cd8zcT9Lgh6+32PPEUnK7J3B7H1VMF8ui5D3afsSt/4CeR99rsU9T5PLk86Pq9cefVYXiPMZa2dnq3x5ciQ55I17DiQ2g/63P8yX8Xnc05y3F+N8fpp93uXPGWeba4rP459hTo4OqlG1nFat26qdew+reYcvZTDYKUe2LKpYpoRaNK5j8V0AAIDXje2TNwEAwLqlTuWkzN6PLs8/dPSU6e8m79XUtlV/68OHM6WexCeLt4rHufy7UP5cypU961P1J3bWaqx6jz1+FgumDNfy2WNVrVJpSTGXkH83dKzZDKukCA0LsyizkeXatc8i7j+wbW0f1Zng5eRP0ffIyEiFh0ck+HyenI/W4bx5+478ryW8RMETPeHlMDtOm6QcZ1LatGx0+ZpNpoC3cIE8+vG7nhr3yzem2dKSFB0dFW91adMk7UeFdGk9NGn0D/rwg3dVrFBeubu5KDAoWNt3H1T/QaPM1rpOsOtPeMHc4qzxbBdnDd6nfe/GlTvOeB88cvKZ60mKtGncnmm/0FDLcy0uGxsb1axWTlLMUidHT5wxLdWQySu9ij5cvkGSOrZprP999ZneqlQ65gcsGxudv3hVsxasVPd+P8oYGRlvG/GJvfFa3P/F9yPU4yH1mQuXLbZJDg/ieZ3irgsed93m6CScTPGtxf08fXms8meuOyHPc34k12d3rIgIo2npBjs7O3X+qKnG/NRP4375Rh7urknu15Mkpd/xfYb1/6Kjvuz+kSqV9VVm7wyKiorSqTMXNGnGogR/2AQA4HXCTF4AwBuheuUymjp7qSRp5vzlerdWFaV/itltcdWvXdW0juDjgW1S+BYroCyZMury1evyypBOZfyKPFM/HpfGw01f9fhYu/cdUWBQsI6fOqeN2/aoSvmSkiSfzF6mtWnnT/k13nVpY4OnzJkePXfs5FnT3/cfrsf6MmXN7KVtuw5IMl8bNK7Q0DDTOo/xKVwwj7wypNO1G7cVFRWtsX/N1sB+XSy2O3/xirL7ZDabuXjy9AUZIyNNYdLR449uEpc187PNCE+KoyfOqFSJwg/bPG0qz+SdXlJMWB2rTbP6ppltSVmHM6lBV3R0tLwzeqrzx49uyHfs5Fl91DXmZnEbNu9Sjarl5JPFS9t3HzT1O3aGb8D9QNOscBsbm6e6EdTzeLtKWdMNmFas3aym79cyC34lKTjkgYKDQ5QhfTr5ZPbShUtXH/b/rGlG5pnzl0w/fLi6OCuNu2Wg+3gg5eHmKlcXZwUGBSt1KictnTlaqVM5mW0TFRWlCKPxicdR860KmjYnZq3j8ZPnml7LmtXKW4xhjarlVKNqTCgcFh6u738ap/Wbdurs+cu6dPlaojeVfFrbdh3Q0pUxN3qzs7VVZFSUFv7zr96qWNrspltx+xgVZR7+xb2aokTR/Br7c3+LdkJDw55pLdVMXulNf1+5dkP3A4NNN807Eudceta+xM5Ol2KWRImd+Xw0nrpftLif48cfLpUgSZGRUTp+6mx8u8Qr7n8ftu7YH+9yLgH3A00/puXJ6WNaRuHm7bu6HxgUb702NjaKjo5WdJRl+OuT2Vunz8W0efTEGdMM4iNxPmN9EriJX3yfYXZ2dnq/zlumpSaCg0PUs//POnT0lHbuPawHoaFK5eRksR8AAK8LQl4AwBuhReO6Wr1+q67duK3AoBB91PVbNW/4jvLmzqbw8AjTOoJJUa1SaV29dkPR0dF6+2Go8jRsbGz0eefWOnL8tPLnyWm6tD85uLo46/26b2naw0D77znLTCFvzbfKm/4R3+ubX9Tyg7rK4JlWt+/ce3gjrT1q0aiO6tasrMrl/DR24mxFR0drw+Zd+mv6QuXLnV1zFq16pvV4n0fNauU1Z9EqSdLI8X/rfmCQcuXwUVBwiK5cva4dew/JK4On+n/RMcE6DHZ26tKhhWk219r/tisoOER1a1ZWGnc3XbtxS+s27dTN23c1dewg5c2VTdl9Mun8xau6deeeBgwdq7o1K+vI8dP6b+tuSTHrrVarWOqFHfePI//Spx81VXh4hMZNnmsqr1wuZr3QuOtdzl28Svb2Bh05flpLV/2XbH1YvX6bFi37V5XL+8nbK71cnFOb3b0+9sZWNaqWN13CPW/JGnmmS6Osmbw0e+FKhUfEhEJl/IpYLNWQVMtWbzTdDCyhNbPjqlujshYu+1cnT19QZGSkOvcepBaN66hgvlyKiIjQ4WOntXTVBvXu2k4Z0qdTzWrltWn7XknShKnz5WBvkLu7qyb+vdBU59tVyiYpHLe1tVWNauW0YOlahTwIVfevftQH79eUu5urbt66ozPnL+u/Lbv09ecd5FusYKJ15c6RVblz+Oj0uYtmNzys9VYFs+069vyf8ubOpoL5cip9urQKefBA5y88mmkbOwZJcenKNR04fMKszMHB3rQsQVBwiIY+XHfWOXUq/TSgpz7/ZpjCwsI16NcJ+nv8EFOo7er6aBbq9t0HVbxIfjk62CtXjqzKk9NHObNn0dnzl7Xv4HF9/9M4vVW5tAx2dvJ/OHN549bdWj3f/CZwSZE2jbsK5c+lI8fPKDw8Qt8OGa0m79XUqbMXtfbhDfbietq+VCrrawp5fxkzJd7z9GUp7VtEDg72Cg+P0NETZzT892mmG68ldakGKeY9Ffvfh5Hj/9bde/dVIF9O3bx1R4tXrNeEEQOUNo27qa0z5y9p0fJ1SuvhrkkzFlmE+LFcXZx1PzBIt27f1ap1W+SVwVNp07gra2Yv1axWzhTyDhszRSEPQmUjG9O6w5JMP1wkReO2n6tqxVLKk9NHnunS6O69+6arNqKjoxUeblQqMl4AwGuMkBcA8EZwd3PRrz/0Ue/vftEV/xu6dfuu2XqScRnsEv/Po5Ojgz5u1fC5+lOuVDGLdS+TS5P3amrm/OUyGiN1+NgpHThyUsUK5VXT92trx+5D2r3/iM5dvKIfhiUcnvhk8VaT92pozqLVioyKMt2YzTl1Knll9NS167deSN/jUyh/LrVr8b4mzVikwKAQ/faH5bjVqVHpifVUr1xGd+4GaOT46YqMjNT23QdNs09jxS7rYGNjo/5fdFK3r4YoJCRU/27coX837jBtZ2Njox6dWiljhnTPeXQJS+XkZHGJcc7sWUwz7GpXr6ApM5coNCxMO/ceNoWARQvlTbYlCqKjo7T/8Antfyz0i1Xj4XIChQvkVqsm7+rvuf8oPDxCv42fbrZdurTu6t21bbL0KSns7Q36+fsv1Oe7X3Xi9HkFBgVrfCIBXPUqZfTf1t1a+9923Q8Msrh5VrasmfRJuw+S3P4nbZvowOETOnPukg4fO6XDx049eacE1HqrvE5PvGh6nC93dmX3yWS2zd17AVqwdK0WLLXcP4dPZuXO4WP5RALiW/faK6OnFk4dIUka8fs03bgVM4u888fN5FusoNq3aqgxE2fJ//pNjflzpnp3bScp5sZ7Dvb2Co+I0LGTZ9X9q5j1icf81E++xQrq216d1LXvEAUGhWjlv5vNbv71vLq0b66ufYfIaIzUjj2HtGPPIUkxVwZcemydVxsbm6fqS8smdbVy3RbdvHVXV/xvmM7TrJm9dPfe/WQ7hqRwc3VW+1YNTcHonEWrNGfRKtna2iizdwaz9dUT07RBLe3Yc0i79h3Wg9AwjZ9ieb7Y2tqqXq2qmr90jSIijPpx5F+SYo47jYdbvMfuV6yA1m/epcioKA348XdJMZ/X3/TqpKYNamvrzv3af/iErl2/pW+HjDHbt3iR/GrW8J0kvxbXb9zWjHnL433ueX5kAgDAWhDyAgDeGDmyZda0cYO1ePkG/bdll85euKLg4BA5OTkqk1d6FcqfW5XL+yXb8gkpJX26NKpRtZxWrI0JKabP+UfFvv9c9vYGDR/cRwv/+Vcr/92i85euyGiMlGdaD2X3yayqFUupSoWSpnq6dWwlN1cXLVq+XvcDg1Qwb071+KSVBg3/0xTyOjo5vJRj6timsQrlz6V5S9bo2MmzCg55oDQebsqUMb0qlCmR5BnVTd6rqVIlCmvu4lXavf+obty8I1tbG6X3TKviRfKpXq2qpm0L5c+lyaN/0OSZi7Vr32HduXtfqVM5qVD+XGreqI5K+xZ+QUcbY9SPX2nk+OnavH2voqKjVKF0cfX45EM5OsS85l4ZPDViyJf6bfx0nTl/SZ5pPdSiUR05OjokW8hbuEAeffB+LR04fELXb95WYGCwUqVyUu4cWdWofg29XaWsadvP2jdT/rw5NH/pGp08fUFh4eFKny6typcurrbN6z/Vzb+SQwbPtPpz5AAtX7tZazds16mzFxQUHCIPdzdlzZxR1SuXUcnihSTFhHzf9+0s32IF9M+qjTp34bIiI6PklTGdqlQopdZN6z3VTZtcXZw1YcR3mrVgpdZv2qmLV67JRjZK75lGuXP6qFrFUipUIHeS6qpZrZx+nzTbNFMy7g3XYrVuVl9btu/TybMXdO9eoIyRRqVPl1ZlSxZV+w8bys4uea4W2Lpzv5at2SQp5seEBnVjLotv3qiO1m3aoWMnz2nhsnWqWrGUSpUoLA93Vw39rofGTZ6jC5f8La4CyJcnh6aMHaxps5dq595DunHrjpwcHZTeM62KFcqntyqXfua+Fi+SX78M7K2xE2fp7IXLSpfWQ43efVse7q4a9OsEi+2fpi/ubq76fdg3Gv77NO3Zf1QODvaqVrGUGtV7W607f/3MfX5WHzatJ0dHB81asFK379xTNp9M6ti6sdZv3pnkkNdgMOjXQb0f/ffh4hUZIyOVwTOt/OLMOO/asbkMBjv9+992hTwIlV+xgvriszb6pFf8N6v74rM2srW11d4Dx3Q3wDwEdnCw18ghfTV74UqtXr9Nl65eU3R0tGmWb7MG78jePun/XP2k3QcxP2JeuKJ7D2+G6pXRU5XK+apdi/eTXA8AANbKJjw87PlXxwcAAK+d6Ohoi8vTA+4H6v1WPRQaFiZXl9RaOXdcsi438aZr0LqHKUDfturvFO4NAAAAAGvBTF4AABCv6fOW6X5gsCqUKSGv9Ol07cYt/TFlnulGVG9VKkPACwAAAACvAEJeAAAQr9DQME2bvdR0E7e4svtk0qcfJX2NUgAAAADAi0PICwAA4uVbtICOlT6nU2cv6F5AoOwNBmXJnFFVypdUs4bvKDW3KQcAAACAVwJr8gIAAAAAAACAFWMhPQAAAAAAAACwYoS8AAAAAAAAAGDFCHkBAAAAAAAAwIoR8gIAAAAAAACAFSPkBQAAAAAAAAArRsgLAAAAAAAAAFaMkBcAAAAAAAAArBghLwAAAAAAAABYMUNKd+BVtGnbHs1bskbHTp7Tg9BQpU+XVqX9CqtFozryyeKd0t0zGf77NM1ZtEqN6tVQry5tEt124LDxOn7ynKb/MfS52w0MClbNRp3U/4uOqluzsiSpQeseqlC6xBP78bSWrd4og8GgWm+VT9Z6n9WWHfv0429/af7k4bK3jzl9zl24ognT5uvwsVMKCAiSu7uL8uTMpsb1a6hcqWKSpD+nzdeMecu1bvFESdLeA0f1WZ/B+mvU/1Qgb05JUrlardSlfXO1bFI3ZQ4uAbMWrJRPFi+VL108SeXJLSg4RCPHT9d/W3YrMjJSZfyK6PPOreWZLk2C+0RGRmnm/OXasmOfzl28oqioaOXJ6aMOrRupeJH8ZtuWq9XKYv+0ady1bNYY0+N/N+7Qqn+36PjpcwoMDFHWzBnV5P1aerdmZdnY2EiSgkMeqMGHPfTz/75QsUJ5k+noAQAAAAAAnoyQ9zFjJ87StDn/qFql0vqqx8fy8HDTlavX9c+q/9R/8GhNHTsopbsoSTp97pL+Wf2fnFOnSumuSJKGfttDbi7OyV7vsjUblcrJ6ZUIeaOjozV+8lw1a/COKeC9fPW62nf/TrlyZFW3Di2VxsNN/tdvauuuA9p74Jgp5K1fu+oLD0NflNmLVqpC6RIW/U+oPLn1HzRK5y5cUZ9u7eToYK9xk+fq8/4/66/RA2Wws4t3n7DwcE2dvUR1alRWqw/ela2trRavWK8ufQZrxJAvVbJ4IbPtm7xXUzWrPXqP2RvM6521YIW8M3qqW4eW8vBw1c69hzV0xJ+6cfO2Pm7VUJLknDqVmrxXU+MmzdHvw/on86sAAAAAAACQMELeOLbu3K9pc/5Ruxbvq2ObxqbyEkXy691aVbR5+77nqj86OloREUY5ONg/b1f1y5gpatbgHS1fu+m560oO+XJnT+kuJEloWLicHB2ead+9B47p7PnLeuftiqayZas3SpJ+G9JXTk6OpvJ3a1VRVFSU6XGG9OmUIX26Z+z1m+vQ0VPaseeQRgz+UmX8ikiSfLJ4q3mHL7Vh8y69XaVsvPs5Ojho3uThcnN99MNDad8iatmpr2YtWGkR8mZMn06FC+ROsB8/f/+FPNxdTY9LFi+k+/eDNHP+CrVr8b5sbWNWvnm3VhX9NX2hTp25oDy5sj3zcQMAAAAAADwNQt44ZsxfrrRp3PVRy/fjfb5i2RKmv8PCwzVu0hyt3bBd9wODlS2rtz5q1UBVK5QybRO7RMJn7Zvp97/m6PylK/q+72d6q1JpHTp6SuMnz9WR42dkZ2er8qWLq8enrZTWw/2J/Vy1bov8r93Uhz/0fuaQN3a5gJGDv9Q/qzdqy459cnN1VqN6NdTqg3fNtl28fL0mz1qsu/fuq3CB3Prs42YW9cW3XMOho6f057T5Onz8tBQtZffJrE5tGqv0w7Bu7MRZ2rJzv/yv3ZSzc2qVKJJP3Tq2NF2G37n3D9p38LikR5fUf9yqgdp/2EiStHDZv5q1YIX8r99SurQeql+7qto0q28K3Jat3qgffvlDfwz/ThOmzteho6dUt2Zl9erSRktX/aeZ85bryrUbcnJ0VHafTOreqaUK5suV4Gu2fO0mFS+aX2k83Exl94OClTp1KrOAN1ZsPyTL5RoSEh0drT+nzdeCf/5VVFSUKpYpoS+6tFEqJyfTNqfPXdLoCTN04PBJ2dnZqrRvYXXr1FJeGTwlSf7Xbqphm54a1L+b3qpU2rTf8N+naeO2PVo4dYSp7MbN2xr712xt331QD0LDVDBvTnX/pJXy58khKWZcr12/pflL12j+0jWSpP5fdNSffy+Itzx2+Y5lqzdq5oIVunT5mtzcXFS3RiV1aN1YdnZPtwz4tl0H5OqSWqV9C5vKsmXNpDy5fLRt14EEQ147O1uzgDe2LHeOrLp89fpT9UGSWcAbK2+ubFq8Yr0ehIaZZtR7Z/RUwXy5tGzNJvUg5AUAAAAAAC8JIe9DxshIHTpySlUrlpLB8OSXZcDQ37V990F1attE2bJ6a8Xazeo38Df9+F0PVSrnZ9ru5u27+nXsVLVr8b4yZkinjOnT6dDRU/qszyCVK1VMA/t1UWhomMZPmasvBwzXhBEDEm03OOSBRk+Yqe6dWsUbLD6tn0ZNUu3qFfRurR7auHWPxkycpVw5spqWGdi8fZ+GjpyoujUq6e2q5XT81Dl9/cOoJ9Z74MhJdf1ysArlz62verSXq4uzjp08q2s3b5u2uXPvvto0qy/PdGl0LyBQM+cvV+fegzRjwo8y2Nmpd5d2GvDTWDk5OqprhxaSpAyeMQHw3MWr9evYqWryXk1VKFNCh46e1MRpCxQYFKJuHVuY9eW7oWP1Xp1qatOsvpycHLTv0HEN/nWCWjSuo/Kliis0LExHT5xVUFBIose0a99hvVuzillZ/jw5tGDpWv048i81eLe6cufIahbuPq15S9aoWOF8+qZXJ126ck2j/5yptGnc1flhsH79xm117jVQmb0z6rsvP1F4eITGT56rzr0Gadq4wU+1fMf9wGB1+mKgUjs56fPOreXinFpzF69Wlz6DNWfSMKX1cNfQb3voi29+VtFC+dSiUR1JUmbvDMqd0yfeckmaOX+5xvw5S00b1la3Di10/tJVjZ88V1FRUabjkGKC+zo1KumbXp0S7OOFS1flk8XbtO5trOxZM+vCpatJPlYp5hw/cvy0ihXOZ/Hc1NlL9fukOUrl5KgyfkXUpUNzU2iekANHTiq9ZxqL17xIwTzatffwU/UNAAAAAADgeRDyPnT/fpDCIyKUMcOTL6k/ffaiNmzZpT7d2qlB3eqSpHKlisn/+i1N/HuhWcgbGBSs4YN6q1D+R5eCDx7+p/LnyaGh3/YwhVe5cmRVy059tXXn/kTXOJ04bYGyZMqot6vGP4PxaVWtWMo0M7ZUiULaunO/1m/eaQp5J89cpOKF86n/wyCubMmiCg+P0KQZixKtd8yfM5XFO6NG/9jPNHsz9nL7WP2/6Gj6OzIySoUL5NZ7Lbtpz/6jKuNXRDmyZZZz6lRK5eRkdil9ZGSU/pq+UDWqltXnnVub6o6IMGrmghVq06ye3N0ezbxsUPctfdi0nunx9LnL5ObqYgqOJalCmUeztONz6/Zd3bx1V7lz+piV13m7knbvO6JFy9dp0fJ1Sp3aSSWLFdK7tSqbvQ+SKl1aD33ft7OkmPfUidPntW7TTlM4OmvhChmNkRox+Eu5u7lIkvLmyq4WHb/U8jWb1OS9mklua/bClQoKCtHE3743zSAvWbyQmn7cSzPmLVeX9s2VL3d22dvbK62Hu9kYpPFwi7c8OOSB/py2QC2b1NWnHzWVJJX2KyKDwaDf/piulk3qmsbGztb2iYF4YFCIXJxTW5S7ujjrfmBwko9Vkv6e849u3rqrZg3fMSt/5+2KqlCmhNKmcdfZ85c0acYiffL5QE39fbDFbOBYBw6f0Nr/tqlrh5YWz+XJ6aM5i1YpOOTBK7NmNgAAAAAAeL09+5TD15TNkzfR/sMnJElvVSpjVv52lTI6eeaCHoSGmsrc3VzMAt7Q0DAdOnJSb1Uqo8ioKBkjI2WMjFTWLF7KmD6tjp08m2C7Z89f1vyla9XzYbCZHEr7PgpebWxslN0nk27cvCMpJkw9fuq8KlcoabZP3CUA4hMaGqYjx0+rTo1KiV6ev23XAXXo8b3ebtBBFeu01nstu0mSLl72T7T+C5eu6l5AYDyvf1lFRBh19IT5a1i+THGzx/nyZNf9wCANHDZeO/ccUmhoWKLtSdLtO/ckWV62b2dnq+/7dtb08UP16UcfqHjhfNqx95D6DBiuP6bMe2K9j4u7LIEk5fDJrJu37poeHzh8Qn7FC5oCXknK7pNJuXP66MDD92VS7dx7SL7FCsjN1cX0PrS1s1XxIgV07ETC78PEHDp6SiEPQvVW5TKmOo2RkSpVopDCwsJ15vxl07abV0zV1593eKZ2ntbOPYf057QFateygWkpiljf9v5E1SuXUYki+dWoXg2NGPSlbt2+qyUr1sdb142bt9V/8Gj5Fi2oD963DNXd3VwVHR2tO3cDXsixAAAAAAAAPI6ZvA+5ubnIwcFe1+MsJ5CQwKBgGQx2ZkGbJKVN467o6GgFBoWY1lB9fI3d+0HBioyK0sjxf2vk+L8t6k6s/d/+mK63KpeWd0ZPBQbFzGKMjoqW0WhUYFCwnFOneuqlAlxdzGdJ2hsMCgyOqftewH1FRkYqbZw1aGOPMzH3g4IVFRUtz3QeCW5z9MQZ9f7uV1Uu56vWTd9VGg932dhI7bsPUHh4RKL1xx57msf6Eduv+4FB5uWPjUHJ4oX0XZ9PNGfRKvX4+ic5ONirWsXS6vFJK4sxjRX2sE8O9vHfNC9n9izKmT2L1FS6e+++enz9o6bOXqqmDWonWGd8Hp+1ajAYFB7x6PW4HxisPDkt13pN6+H21DNb7wUE6vCx06pUp43Fc7FLLzytgPuBkqS2n/WP9/kbSTi/4nJ1Sa0bt+5YlAcGBSc4y/ZxJ06d01c/jFTNauX0casGT9w+d04f+WTx1vFT5+Jtt2f/n+Xu5qIh33aP93xzsI/5WA17wvsYAAAAAAAguRDyPmSws1PRgnm1e/8RGSMjZbCzS3BbN1dnGY2Ruh9oHjTduRsgGxsbs+D08bVEXV1Sy8bGRm2a1Vfl8paX83u4Wd7gKdaFy/7aseeQVv67xax88Yr1WrxivWZO+EnZfTI98ViTysPdTXZ2drpz775Z+ZNmKLq6pJatrY1u3b6X4Db/bdktF+dU+uHrrqagzP/6rST1y801JjS9e8+8H7H9in0+1uNjIEm1q1dU7eoVdS8gUBu37dHI8X/LYLBLcGZpbJ2xAXNi0ni46d2aVfTr2Km6fPWa3N1yP3GfpHJzddHdx8ZDilnf2CezlyTJwSEmiI6IMJpt83jf3VxdVLZkRnVs09iiPvsEwuyk9E+ShnzbXRnTWy59kskr/VPVly1rJu3ad0TR0dFm43jh0lXlypH1iftfunJNPfv/rCIF8qhfz/ZP1fbjQsPC1evbXxQc/EB/jPgu3mUkJCkwOGZt56cJ9wEAAAAAAJ4HyzXE0bzRO7p9J0BTZi6O9/mtO/dLkooVirlx07pNO8yeX7dpp/LmymaaxRuf2PVlz1+8qgJ5c1r8zzuREGzgV1005qd+Zv9Lm8Zdlcv7acxP/eSVhPWEn4adna3y5c6ujVt2m5Wv27Qz0f1ijjGPVqzdrMjIqHi3CQuPkMFgZxbcrVq3xWI7e4PBYmavTxZvpXF307qN5v34d+MO2dsbVDBfzkT7F5eHu6vq166q0iWK6PzFhG/k5e3lKXt7g/yv3TQrTyjwjl1yIm0ajyT3JSmKFY75ISLurN0Ll67qzLmLphuKpfFwk8Fgp/OXrpi2iYgwat+h42Z1lSpRSOcvXlF2n0wW78PccQJUe4NB4RHhFn2Jr7xwgdxycnTUzVt3431/uyfyI0Z8ypUqpsCgYO3ad8RUdvGyv06euWBaNzoht27fVY9+P8orQzoN/qZ7km6oKEknz1zQxcv+KpD30fvIGBmp/oNG6fzFqxo+qI8yeKZNcH//6zfl4pxa6Z4w4x0AAAAAACC5MJM3jvKli6tVk3f157QFOnfhit6uWlYebq66eu2m/ln9n4KCH6h86eLKndNHVSuU0m/jpyssLFw+Wby1at0WHTp6Sj8O6PnEdrq0b66uXw5R/0Gj9HbVsnJzcdaNW3e0c+9hvVuzsnyLFYx3v7g3uIrl4GCv9OnSJrjP82rbvL76DBiuH4aN19tVy+n4qXMWM4nj0/mjpury5WB16ztEDeu9LVcXZ508fV7u7q6qV6uKSvsW1uyFK/XLmKmqUsFPh4+d1sp/N1vUk90nk5av2axN2/fKM62HPNOlUfp0adSu5fv6dexUpfFwU/nSxXX42Gn9PecffdCg9hODxAlT5yvgfpB8ixVQGg83nTl3Sdt3H1SzRrUT3MfRwUH5cufQ8dPml/D/NX2RTp29oBpVyylntswKC4/Qzr2HtOCftapc3k/eGT2f+Fo9jWYN3tGy1RvVo99QtWn+nsLDIzR+8lxlTO+pOjUqSZJsbW1VtUIpzV+yRlkyZZSHm6vmLVkjRUdLcUL15o3e0ar1W9W51yB98H4tZcyQTvcCAnXk+Gl5pkuj5g9vUJY9aybt2X9UO/cckqurszJ5pZe7m2uC5R1aN9LoP2fqxs078i1WQLa2trrif0Obtu3RkG+6y8nJUZJU8Z3WeqdGpUTX5S1SMI/K+BXR4F8nqGvHFnJwsNf4yXOVO0dWVa1YyrTdxL8XatL0hZo7+Vd5Z/RUaFi4Pu//s+7dD1SPTz/U2ThrAdvbG5Qvd3ZJMTfhu+J/Q75FY94LZy9c1uSZi5UhfTrVf6eqaZ9hoyZry4596taxhYJDHujwsdOm5/LmymaaPS1Jx0+eU5GCeZ566RQAAAAAAIBnRcj7mM/aN1ORgnk0b8kaDf51gh6Ehil9urQq41dELRrXMW333ZefatykOZo2Z6nuBwYrW5ZMGty/myqV9X1iG0UL5dW4X7/Rn9Pma9AvExRhNCqDZ1qVLF5IWTJlfJGH99QqlfNTn27tNGXmEq35b7sK5c+lgf26qH337xLdr1jhfBrz09f6Y8o8/TDsD9na2ShntiympQHKly6uzz5uprmLV2vZ6o0qWiiPhv2vlz74qJdZPS2bvKvLV69r4M/jFBgUoo9bNVD7DxupyXs1ZWdnp1kLVmjBP2vlmdZDH3/YUG2a1X/iMRXIm1OzF67Uuo07FBzyQOk906hlkzpq2+L9RPd7q1IpzVqw0mzpgNrVKyg8IlxzF6/Wrdt3ZWtrK++MnurSvrka1nv7iX15WhkzpNPYn/tr1IQZGjD0d9na2ah0iSLq1qmlnFOnMm33eefWGjpyooaPnabUqZ3UsnFd+WTx1sZte0zbuLu56s8RAzR+ylyNnThLAYFBSuPupkIFcqtK+Uc32/uk3Qf6edQkffXDSIWEhKr/Fx1Vt2blBMtbNK6j9J5pNHP+Cs1dsloGOztlzpRBFUqXkMH+0UdOZFSUoqLin+kd1w9fd9XI8dP148iJioyMUmnfIvr8s9ZmS6pER0cpMioqJsiWdPdugE6dvShJ6vPdr2b1eWX01MKpIyRJPlm9tWHLLq39b7tCHoQqjburypcurk5tGsvV5dFSLDv2HpIk/fbHDIv+LZgy3DQD32g0ate+I+rSofkTjwsAAAAAACC52ISHh0WndCcAa3D33n2936q7Rgz5UiWK5E/p7uAVtGXHPn03dKyWzBil1KkSXrYFAAAAAAAgOXE9MZBEaTzc1ODd6pq9cGVKdwWvqJnzV6h5ozoEvAAAAAAA4KUi5AWeQptm9ZUnZzZFRBhTuit4xYQ8CFWJovnVrGHCazsDAAAAAAC8CCzXAAAAAAAAAABWjJm8AAAAAAAAAGDFCHkBAAAAAAAAwIoR8kqKjo6W0WhUdDQrVwAAAAAAAACwLoaU7sCrIDIyUpXqttWRAC9JNo+eiIq03NjJxfxxWLDlNvGFxRlyWBQ5e2e2KAs+sPkJvX0JbGwsy5IagD++r6un5TbhDyzLIkItijz8KlmU7R76rkVZOlfHpPUNsCLv/7HDouy/CdMsN7Sz/Biv1K6Z2eMlncomW7+SKr4fzWzi+2wBgJfg8h3L7x6ZPJwsymxtn/w5dfFWiEVZ1nSpLMpCwi2/RzoaLOdX2Mbz2Xj1nvn3otuBYRbb5MjgbFFmF09dzk6W/514/DM6Kp6veUl4KRIUGV+FjzHYWb4WUfHsdyc43KIsT/Ve5gVM1ACs2uS/vjJ7/F4Ry38nA8CbLr7vSfY2EWaPmckLAAAAAAAAAFaMkBcAAAAAAAAArBghLwAAAAAAAABYMUJeAAAAAAAAALBihLwAAAAAAAAAYMUIeQEAAAAAAADAihHyAgAAAAAAAIAVI+QFAAAAAAAAACtGyAsAAAAAAAAAVoyQFwAAAAAAAACsGCEvAAAAAAAAAFgxQl4AAAAAAAAAsGKEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXgAAAAAAAACwYoS8AAAAAAAAAGDFCHkBAAAAAAAAwIoR8gIAAAAAAACAFSPkBQAAAAAAAAArZkjoiQate8jB3iBHBweFhYerbs3Kat20/nM1Nnj4BNWqVkF+xQs+Vz0J8b92UwN/Ga+Tpy8ok1d6Tf198AtpBwAAAAAAAABeFQmGvJI0sF9X5c2VTTdu3VGLDl/Kr1ghFcqf65kb69ezwzPvmxSpU6dSpzZNFBQcovGT577QtgAAAAAAAADgVZBoyBsrg2daZcuaSddu3FKh/Ll0+849/Tp2qvyv31JYeLgql/NTp7ZNJEkHj5zUsNGTFRkVpQJ5c+rEqfPq+Wkr+RYrqM69f1DTBrVVpXxJDRw2XvYGg67439AV/xvyLVZADepW15iJM3X9xm1VLu+n7p1aSVKi7cXl7uaiYoXzae+Bo8n4EgEAAAAAAADAqytJIe/5i1cVcD9QvkULSJIGDhuv1s3qy7doARkjI9Xrm2H6d+MOVS7np28Gj9a3vT+RX/GC2rP/qJat3phgvWfOX9Lon/rJ1sZWzTv0UWBQsH4b0lcRRqMatflc9WpVVc7sWRJsr3rlMsnzKgAAAAAAAACAlUo05P1m8CjZ2Njq4mV/de/UUmk83PQgNFS79x3RnbsBpu1CHoTq4mV/Xbh0VXZ2dqY1d/2KF1Rm7wwJ1l+pnK8cHRwkSblyZFUZv6IyGAwyGAzK4ZNZl65ek7eXZ4LtPY95S9Zo/tI1kqTo6OjnqgsAAAAAAAAAUkqS1uTdufewen/3i/yKF1Imr/SSpAkjB5gC2linz160qMPGxibB+h3sH+1vZ2srRwd702NbW1tFRkYpNn+Nr73n0bh+DTWuX0OSZDQaValu22SrGwAAAAAAAABeFtukbFTat7Aavltdf0yeq9SpnORbrKCmzV5qev7m7bu6cfO2fLJ4yxhp1N6DxyRJew8e0+Wr15+rg4m1BwAAAAAAAABvuiStyStJ7Vo0UJN2X+j4qXMa0PdT/TZ+ulp27CvZSKmcHPVlt4+UIX06Dfyqi4aNnqKo6Cjlz5NDPlm85eLi/FydTKy9uEJDw/TBx70UEWFUUHCI6rfsqtrVK6rzR02fq30AAAAAAAAAeFUlGPIunDrC7LGbq7NWzRtnejzgy87x7pc7p4+mjRssSTp64ox27Dkon8xekqSxP/c3bfdNr05m+w3+prvZ41E/fmX6O62He4LtxeXk5Kgl00c9cTsAAAAAAAAAeF0keSZvUm3YvEuzFqxUtKJlZ2erb3t/Kicnx+RuBgAAAAAAAACgFxDy1q1ZWXVrVk7uagEAAAAAAAAA8UjSjdcAAAAAAAAAAK8mQl4AAAAAAAAAsGKEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXgAAAAAAAACwYoS8AAAAAAAAAGDFCHkBAAAAAAAAwIoR8gIAAAAAAACAFSPkBQAAAAAAAAArRsgLAAAAAAAAAFaMkBcAAAAAAAAArBghLwAAAAAAAABYMUJeAAAAAAAAALBihLwAAAAAAAAAYMUIeQEAAAAAAADAihHyAgAAAAAAAIAVI+QFAAAAAAAAACtmEx4eFp3SnUhpRqNRleq21YblM2QwGFK6OwAAAAAAvJHSlOqSrPXd3TU6WesDgFeFXXS42WNm8gIAAAAAAACAFSPkBQAAAAAAAAArRsgLAAAAAAAAAFaMkBcAAAAAAAAArBghLwAAAAAAAABYMUJeAAAAAAAAALBihLwAAAAAAAAAYMUIeQEAAAAAAADAihHyAgAAAAAAAIAVI+QFAAAAAAAAACtGyAsAAAAAAAAAVoyQFwAAAAAAAACsGCEvAAAAAAAAAFgxQl4AAAAAAAAAsGKEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXgAAAAAAAACwYoS8AAAAAAAAAGDFCHkBAAAAAAAAwIoZEnqiQesecrA3yNHBQWHh4apbs7JaN63/XI0NHj5BtapVkF/xgs9VT0J27z+isRNn60FoqGxko/JliqvzR01la0uWDQAAAAAAAOD1lGDIK0kD+3VV3lzZdOPWHbXo8KX8ihVSofy5nrmxfj07PPO+SeHq4qyB/boos3cGhYWHq1vfoVqxdrPq1qz8QtsFAAAAAAAAgJSSaMgbK4NnWmXLmknXbtxSofy5dPvOPf06dqr8r99SWHi4KpfzU6e2TSRJB4+c1LDRkxUZFaUCeXPqxKnz6vlpK/kWK6jOvX9Q0wa1VaV8SQ0cNl72BoOu+N/QFf8b8i1WQA3qVteYiTN1/cZtVS7vp+6dWklSou3FlS93dtPfjg4OypMzm/yv30yGlwkAAAAAAAAAXk1JCnnPX7yqgPuB8i1aQJI0cNh4tW5WX75FC8gYGale3wzTvxt3qHI5P30zeLS+7f2J/IoX1J79R7Vs9cYE6z1z/pJG/9RPtja2at6hjwKDgvXbkL6KMBrVqM3nqlerqnJmz5Jge9Url0mw7tt37mn95p0a9r8v4n1+3pI1mr90jSQpOjo6KS8DAAAAAAAAALxyEg15vxk8SjY2trp42V/dO7VUGg83PQgN1e59R3TnboBpu5AHobp42V8XLl2VnZ2dac1dv+IFldk7Q4L1VyrnK0cHB0lSrhxZVcavqAwGgwwGg3L4ZNalq9fk7eWZYHsJCQ4OUe/vflGrJnVVIG/OeLdpXL+GGtevIUkyGo2qVLdtYi8FAAAAAAAAALySkrQm7869h9X7u1/kV7yQMnmllyRNGDnAFNDGOn32okUdNjY2CdbvYP9ofztbWzk62Jse29raKjIySrGTbONrLz7BIQ/U4+ufVamcn5o3qvPE7QEAAAAAAADAmtkmZaPSvoXV8N3q+mPyXKVO5STfYgU1bfZS0/M3b9/VjZu35ZPFW8ZIo/YePCZJ2nvwmC5fvf5cHUysvceFPAhVz69/UtmSRdWuxfvP1S4AAAAAAAAAWIMkrckrSe1aNFCTdl/o+KlzGtD3U/02frpaduwr2UipnBz1ZbePlCF9Og38qouGjZ6iqOgo5c+TQz5ZvOXi4vxcnUysvbjmLFyloyfOKjQ0TP9t2SVJeqtSGbVt8d5ztQ8AAAAAAAAAryqb8PCwZL3rWHDIAzmnTiVJOnrijPoM+FXzJv0qJyfH5GwmWcWuybth+QwZDEnOvQEAAAAAQDJKU6pLstZ3d9foZK0PAF4VdtHhZo+TPdHcsHmXZi1YqWhFy87OVt/2/vSVDngBAAAAAAAAwJole8hbt2Zl1a1ZObmrBQAAAAAAAADEI0k3XgMAAAAAAAAAvJoIeQEAAAAAAADAihHyAgAAAAAAAIAVI+QFAAAAAAAAACtGyAsAAAAAAAAAVoyQFwAAAAAAAACsGCEvAAAAAAAAAFgxQl4AAAAAAAAAsGKEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXgAAAAAAAACwYoS8AAAAAAAAAGDFCHkBAAAAAAAAwIoR8gIAAAAAAACAFSPkBQAAAAAAAAArRsgLAAAAAAAAAFbMkNIdAAC8GdKU6pLSXQDwhrLN7WdRFnV2v+WGUZFPrMs+f2mLsogTuyw3dElrWfYgMElt2uYsbvbY09vTYpsbhw9Z1hUZYVl2/6ZlmY3NYw3aJalfSWZn/+RtjOGWZfH1I2Mui6I7i7uaPbZ5/HgAWJW3ft1o9vjurtHJWr9VfQd1TWdZFs/npX22AmaPM2ZJb7FNy7dzW5R9UcXyM9XewNw/4HXB2QwAAAAAAAAAVoyQFwAAAAAAAACsGCEvAAAAAAAAAFgxQl4AAAAAAAAAsGKEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXgAAAAAAAACwYoS8AAAAAAAAAGDFCHkBAAAAAAAAwIoR8gIAAAAAAACAFSPkBQAAAAAAAAArRsgLAAAAAAAAAFaMkBcAAAAAAAAArBghLwAAAAAAAABYMUJeAAAAAAAAALBihLwAAAAAAAAAYMUIeQEAAAAAAADAihHyAgAAAAAAAIAVI+QFAAAAAAAAACtGyAsAAAAAAAAAVsyQ0BMNWveQg71Bjg4OCgsPV92aldW6af3namzw8AmqVa2C/IoXfK56EnLo6Cn9PGqSJMlojFTRwnn1+aet5eBg/0LaAwAAAAAAAICUlmDIK0kD+3VV3lzZdOPWHbXo8KX8ihVSofy5nrmxfj07PPO+SZEnp4/+GvU/GQwGRUVF6auBIzX/n7Vq3vCdF9ouAAAAAAAAAKSUREPeWBk80ypb1ky6duOWCuXPpdt37unXsVPlf/2WwsLDVbmcnzq1bSJJOnjkpIaNnqzIqCgVyJtTJ06dV89PW8m3WEF17v2DmjaorSrlS2rgsPGyNxh0xf+GrvjfkG+xAmpQt7rGTJyp6zduq3J5P3Xv1EqSEm0vLicnR9PfEUajwsLCZSOb5HidAAAAAAAAAOCVlKSQ9/zFqwq4HyjfogUkSQOHjVfrZvXlW7SAjJGR6vXNMP27cYcql/PTN4NH69ven8iveEHt2X9Uy1ZvTLDeM+cvafRP/WRrY6vmHfooMChYvw3pqwijUY3afK56taoqZ/YsCbZXvXIZizr9r91UnwHDdcX/usqXLq5G9d6Ot+15S9Zo/tI1kqTo6OikvAwAAAAAAAAA8MpJNOT9ZvAo2djY6uJlf3Xv1FJpPNz0IDRUu/cd0Z27AabtQh6E6uJlf124dFV2dnamNXf9ihdUZu8MCdZfqZyvHB0cJEm5cmRVGb+iMhgMMhgMyuGTWZeuXpO3l2eC7cXH2yu9po0brJAHofr+x9+1Ycsu1ahazmK7xvVrqHH9GpIko9GoSnXbJvZSAAAAAAAAAMArKUlr8u7ce1i9v/tFfsULKZNXeknShJEDTAFtrNNnL1rUYWOT8HIJDvaP9reztZVjnBuk2draKjIySrGTbONrLzGpUznp7apltWrd1nhDXgAAAAAAAAB4HdgmZaPSvoXV8N3q+mPyXKVO5STfYgU1bfZS0/M3b9/VjZu35ZPFW8ZIo/YePCZJ2nvwmC5fvf5cHUysvcddunJNRqNRkhQRYdR/W3Yrd46sz9U+AAAAAAAAALzKkrQmryS1a9FATdp9oeOnzmlA30/12/jpatmxr2QjpXJy1JfdPlKG9Ok08KsuGjZ6iqKio5Q/Tw75ZPGWi4vzc3Uysfbi2nPgqOYuWv1wFnCkSpYopHYt33+utgEAAAAAAADgVWYTHh6WrHcdCw55IOfUqSRJR0+cUZ8Bv2repF/l5OSYnM0kq9g1eTcsnyGDIcm5NwDgKaQp1SWluwDgDWWb28+iLOrsfssNoyKfWJd9/tIWZREndllu6JLWsuxBYJLatM1Z3Oyxp7enxTY3Dh+yrCsywrLs/k3LsseXU7O1S1K/kszO/snbGMMty+LrR8ZcFkV3Fnc1e5zY8nAAXn1v/Wp+s/Z1n1dO1vqt6juoazrLsng+L+2zFTB7nDFLeottWr6d26LsiyqWn6n2hiRd4A3gFWQXbf75kOyJ5obNuzRrwUpFK1p2drb6tvenr3TACwAAAAAAAADWLNlD3ro1K6tuzeT95Q0AAAAAAAAAED/m5QMAAAAAAACAFSPkBQAAAAAAAAArRsgLAAAAAAAAAFaMkBcAAAAAAAAArBghLwAAAAAAAABYMUJeAAAAAAAAALBihLwAAAAAAAAAYMUIeQEAAAAAAADAihHyAgAAAAAAAIAVI+QFAAAAAAAAACtGyAsAAAAAAAAAVoyQFwAAAAAAAACsGCEvAAAAAAAAAFgxQl4AAAAAAAAAsGKEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDGb8PCw6JTuREozGo2qVLet1v0zXQaDwVRua2tjsW1YRKTZYweDZU5uY2O5352g8CSV5fZySVKfX6ToaMu3RHzHlJR9Q8IiLbYx2FnWZbCzfB1P+gdalJX/5C/LRq+dTlLfAGsyfGwvi7K2pbJblEVGWZ6vM/ZeNHvc7dOfk61f8Uri58PdnaNebD8AAAAAKxYcZrQos4snl7geEGb++H6oxTbjd160KFswarplo+EPnqKHAFKMrZ1F0f3t5v/WZyYvAAAAAAAAAFgxQl4AAAAAAAAAsGKEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXgAAAAAAAACwYoS8AAAAAAAAAGDFCHkBAAAAAAAAwIoR8gIAAAAAAACAFSPkBQAAAAAAAAArRsgLAAAAAAAAAFaMkBcAAAAAAAAArBghLwAAAAAAAABYMUJeAAAAAAAAALBihLwAAAAAAAAAYMUIeQEAAAAAAADAihHyAgAAAAAAAIAVI+QFAAAAAAAAACtGyAsAAAAAAAAAVoyQFwAAAAAAAACsmCGhJxq07iEHe4McHRwUFh6uujUrq3XT+s/V2ODhE1SrWgX5FS/4XPU8SXR0tLp+OUQnTp/XmgV/vNC2AAAAAAAAACAlJRjyStLAfl2VN1c23bh1Ry06fCm/YoVUKH+uZ26sX88Oz7zv05i1YIUye2fQidPnX0p7AAAAAAAAAJBSEg15Y2XwTKtsWTPp2o1bKpQ/l27fuadfx06V//VbCgsPV+VyfurUtokk6eCRkxo2erIio6JUIG9OnTh1Xj0/bSXfYgXVufcPatqgtqqUL6mBw8bL3mDQFf8buuJ/Q77FCqhB3eoaM3Gmrt+4rcrl/dS9UytJSrS9x509f1kbt+7R11901LpNO5PpZQIAAAAAAACAV1OSQt7zF68q4H6gfIsWkCQNHDZerZvVl2/RAjJGRqrXN8P078YdqlzOT98MHq1ve38iv+IFtWf/US1bvTHBes+cv6TRP/WTrY2tmnfoo8CgYP02pK8ijEY1avO56tWqqpzZsyTYXvXKZczqMxqNGjJior7+vL3sbFluGAAAAAAAAMDrL9GQ95vBo2RjY6uLl/3VvVNLpfFw04PQUO3ed0R37gaYtgt5EKqLl/114dJV2dnZmdbc9SteUJm9MyRYf6VyvnJ0cJAk5cqRVWX8ispgMMhgMCiHT2ZdunpN3l6eCbb3uIl/L1TVCiWV3Sez/K/dTPTA5y1Zo/lL10iKWcMXAAAAAAAAAKxRktbk3bn3sHp/94v8ihdSJq/0kqQJIweYAtpYp89etKjDxsYmwfod7B/tb2drK0cHe9NjW1tbRUZGKTZ/ja+9x+07eEzXb97WvKVrFBkZqeCQB2rQuof++u1/SuPhZrZt4/o11Lh+DUkxM4Ar1W2baN0AAAAAAAAA8CpK0poGpX0Lq+G71fXH5LlKncpJvsUKatrspabnb96+qxs3b8sni7eMkUbtPXhMkrT34DFdvnr9uTqYWHuPG/frt1o4baQWTh2h8b98K+fUqbRw6giLgBcAAAAAAAAAXhdJWpNXktq1aKAm7b7Q8VPnNKDvp/pt/HS17NhXspFSOTnqy24fKUP6dBr4VRcNGz1FUdFRyp8nh3yyeMvFxfm5OplYewAAAAAAAADwJksw5F04dYTZYzdXZ62aN870eMCXnePdL3dOH00bN1iSdPTEGe3Yc1A+mb0kSWN/7m/a7ptencz2G/xNd7PHo378yvR3Wg/3BNtLiLdXeq1Z8MdT7QMAAAAAAAAA1ibJM3mTasPmXZq1YKWiFS07O1t92/tTOTk5JnczAAAAAAAAAAC9gJC3bs3KqluzcnJXCwAAAAAAAACIR5JuvAYAAAAAAAAAeDUR8gIAAAAAAACAFSPkBQAAAAAAAAArRsgLAAAAAAAAAFaMkBcAAAAAAAAArBghLwAAAAAAAABYMUJeAAAAAAAAALBihLwAAAAAAAAAYMUIeQEAAAAAAADAihHyAgAAAAAAAIAVI+QFAAAAAAAAACtGyAsAAAAAAAAAVoyQFwAAAAAAAACsGCEvAAAAAAAAAFgxQl4AAAAAAAAAsGKEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKyYIaU78CqIjo6WJBmNRrNyW1sbi22NxkjzbeLJyW1s4tvP+MxlL1vs6xFXfMeUlH0ff71iNoqnrmjL1zHe1yI6Kr5Wk9Q3wJpERVqeO/GdE5FRlu//SIt9X41z5FX4fAMAAABeVfF9X46ON5cw387y+78UHRXPv8Xj/XfBq/FvBQBPYnmuGo1G2dnZmTI7m/DwsDf+jA4NDVW199qndDcAAAAAAAAAIEk2LZssgyFmDi8hr6SoqCiFh4fLzs5OH37aT3+PG5LSXUIyafXJV4zna4KxfH0wlq8XxvP1wVi+PhjL1wdj+XphPF8fjOXrg7F8vbyJ4xl3Ji/LNUiytbWVk5OTpJhlCWITcFg/xvP1wVi+PhjL1wvj+fpgLF8fjOXrg7F8vTCerw/G8vXBWL5e3vTx5MZrAAAAAAAAAGDFCHkf06hejZTuApIR4/n6YCxfH4zl64XxfH0wlq8PxvL1wVi+XhjP1wdj+fpgLF8vb/p4siYvAAAAAAAAAFgxZvICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWzJDSHXiRwsLD9e3gMTp38YocHRyUxsNNvbu2VdbMXrpzL0D/+2mcrvjfkIO9vXp1basSRfJLUqLP/TBsvI6fPi9bGxsZDHb69KOmKlWicEoe5hvjRYxn594/6Nr123JxTiVJeqdGJTVv+E6KHeOb4kWM5cfdvlNERIQkKTIySmcvXNa03wcrd06fFDvON8GLGMujJ85oxLi/9eBBmGxspG6dWqpk8UIpeZhvhGcdy8kzF2vF2k26dOW6hnzbXVXKlzTVmdhzeLFexHjyHShlvIix5PtPyngRY8n3n5TzIsaT70Ap41nH8odh43Xw6Ck5OjgoVSpH9fiklQrmyyVJWrrqP81asEIXLl5Vlw4t1Kxh7ZQ8xDfGixjLcZPmaNP2vbKzjZkj+WHTeqpRtVyKHeOb4kWM5cBh47Vz72GlcXeVJJXyLayuHVqk2DG+CK/1jdfCwsO1Z/9RlStVTDY2Npq7eLXWb96psT/31w+//CGvDOnU/sNGOnrijPr+b4QWTBkug8GQ6HOBQcFydXGWJJ04fV5dvxyilXN/l60tk6JftBcxnp17/6CmDWoTPLxkL2Is41q3aacm/r1A08cPTaEjfHMk91ja2dnpvVbd1P+LTirtW1gXL/urW9+hmjXxZzk5OqT04b7WnnUsjxw/Iw93Vw369Q+Lz9PEnsOL9SLGk+9AKeNFjCXff1LGixjLuPj+83Il93hGR0fzHSiFPOtYbtq2R+VKF5fBzk6bt+/TL2OnaOHUEZKkU2cuyN7eoCmzlipf7uyEvC/JixjLuN9/bty6o+Yd+mj+5OHyeBgU4sV4EWM5cNh45cmZ7bU+H1/rb+WODg4qX7q4bGxsJEmFC+SW//VbkqR1G3eoQd3qkqSC+XLJM20a7T14/InPxZ7ckhQcHPLSjgUvZjyRMl70WC5duUH1alV9CUeC5B7LgPtBuhcQqNK+MbMDfbJ4y8UltbbvOvCyD+2N86xjWSh/LmX2zhBvnYk9hxfrRYwn34FSxosYS6SMFz2WfP95uZJ7PPkOlHKedSwrlfOTwc7OtM/NW3dljIyUJOXJlU3ZfTLL1tbmZR/OG+1FjGXc7z8PHoRK0VJUdNRLO6Y31YsYyzfBa71cw+PmLFqlyuV8FXA/UMbISKVL62F6zjujp67fvJ3oc7HGTpyldZt26n5gsIZ8050ZLCkk+cZztv6YMk85fDLr04+a8g+iFJBcYylJ12/c1r5Dx/Vdn09fUu8R1/OOZWnfwkqX1kNr/9uut6uU1dETZ3Txsr/8r998+QfzhkvKWMJ6JNd48h0o5SXfWPL9J6Ul5+cs339S3vOOp4e7K9+BXhHPMpazF61U+VLFTOESXg3JNZZzFq3S/KVrdOPmXX3V82Ol9XB/Gd1HHMk5lv+s/k8Z06dTp7ZNlDdXtpfR/ZfmjflmPnnmYl2+el2ftmv63HV1/riZ5k3+VT983VVjJs5URIQxGXqIp5Fc4/ld7081e+LP+nvcEBUrnE+9vh2WTD1EUiXnuSlJy9ZsVIXSxbl8JgUk11j+9F1P/bPqP7Xu/LXmLFqlooXyyo4vzC9Vcp+XSFl8B3p98P3n9cH3n9cL34FeH88yliv/3ax1G3eob4+PX2DP8LSScyw/eL+WZk8cpj+Gf6sps5Yo4H5gcncXiUiusezUtonmTf5Ff48bonq1q+jz/j8p5EHoi+hyinkjQt7pc5fpvy279esPveXk5Ch3N1fZ2drp9p17pm38r99SxvTpEn3ucaV9Cys4JFRnzl96CUeBWMk5nhkzxPy/jY2NmrxXU1f9b/KB/RIl97kZHR2tZas3ql7tqi/vICApeccyT65sGjH4S00dO0gDvuysW7fvKUe2zC/5iN5cTzOWePW9qPHkO9DLl5xjyfeflJXc5yXff1JWco4n34FS1rOM5doN2zXx74UaOaSv0qZhduer4kWNZZ5c2ZQ+XRrtPXDsRR8CHkrOsczgmdZ0FVrVCqXknDqVLl72f2nH8jK89iHvzPnLtWbDNo0c0tdsLZW3KpfWwmX/Soq5i+nN23flWzR/os8ZjUZdunLNVMeR42d09959ZfLi8raXJVnHMzJSd+4GmOpYv2mn0qZxk7sbMyBehuQcy1i79x9RZGSUaS0zvBzJPZa3bt811bF4+XqlcnLkztIvybOMJV5dyTmefAdKWck6lnz/SVEv4nOW7z8pJ7nHk+9AKedZxnLtf9s1fspc/Tb0K3ll8EyRfsNSco/luQtXTH9fvnpdJ89c4MeXlyS5x/JGnCUdDh87rYD7QcqSKeNLOJKXxyY8PCw6pTvxoty4eVvvtequzN4ZlDqVkyTJ3t5eE3/7XnfuBuj7n37X1Ws3ZW8w6IvP2siveEFJSvC50NAwdftqqIKDH8jOzlZOTo7q2KYx/+F9SZJ7PB+Ehqpzr0EKj4iQrY2t3N1d1L1jS+V5zdZkeRUl91jG+nbIGGXN7KUOrRulyHG9iV7EWE78e4FWrduq6OhoZffJpF6ftTXNOsOL86xjOWnGIi1c9q/uBQQqdSonOTjYa8qYQUrj4Zboc3ixkns8Uzk58h0ohST3WDo5OfD9J4W8iM9Zie8/KeVFjCffgVLGs45lxTptlC6Nu9zdXEx1jfrxK7m7uWrZ6o0aP2WuAgNDZDDYKVUqR/38/RfKlzt7ShziG+NFjOUX3wyT/7WbMhjsZGdnp1YfvKvqlcukyPG9SV7EWHb9coju3AuQna2tHB0d9EnbD8zyhNfBax3yAgAAAAAAAMDr7rVfrgEAAAAAAAAAXmeEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUj5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXgAAAAAAAACwYoaU7sCr5M9p8zXx74XxPvfpRx+oddP6T1VXad8iKloob3J1L0n+27pbfb8foQVThsvbK/1z1RUYFKyajTqp/xcdVbdm5Xi3CQ4O0cwFK7R15wFdunJN9vYGFcyXS5+0+0C5c2Q1bed/7aYatulpsX+h/Ln058jvE+1H594/KJWTk34Z2Ou5jkeSTp65oDadv9aYn/rJt1hBSVK5Wq3UpX1ztWxS97nrj2vWgpXyyeKl8qWLJ2u9z2rekjVavmaj/ho10FR2+NhpTfx7gU6euaCg4BClTeOuAnlyqGWTuiqUP7ckaeCw8Tp+8pym/zFUkrRs9Ub98MsfWjHnd3m4u5rGdlD/bnqrUukUObaEJHQevqzz8+btu/p1zFTt3HtIdnZ2qlqxpLp3bCln59RJriP2nM6ZLYtpDCQpIsKo8VPm6six0zp+6rxCw8JMYxJXg9Y9dO36rXjrnjBigAoXyC3/azfVomNfzfhj6HN/bgAAAAAAgJePkPcxjo4OGv1jP4vyjBnSPVU9E/9eqFROTi895H3Zrt28rUXL16lerarq1LaJwsPDNWPecnXoPkCTRv9P2X0ym23/SbsP5PcwXJWk1KmcXnaXLUwYMUBeTzm+STF70UpVKF3ilQh5Q0PDNHnmIn3RuY2p7MCRk/qs9yCVLVlUfbq1k3PqVLp05Zo2bt2joyfOmkLedi3eV2hoWEp1/bkkdB6+jPPTaDSqR78fJUkD+nZWWGi4Rk2YoW/vjE3yDxahYeEaOW660qZxj+e5MC1ZsV4F8uZUscJ5tWPPoXjrGPptD0VEGM3KxkycpQsXryp/3hySJG+v9KpWqZQmTJuvb3t/8jSHCQAAAAAAXgGEvI+xtbFR4QK5U7obViOTV3rNm/SrnJwcTWV+xQupwYc9NH/pWn3xWRuz7bNm9nrlXt9XrT8JCQ0Ll5OjwzPtu/a/7TIaI1WpvJ+pbOE/a+Wd0VM/ftdTdnYxK7eULF5IDepWV1RUlGm7LJkyPl/H31DrNu3UuQtXNHPCj8qWNZMkydXVWT36/agjx8+oUP5cT6xj6qwlypghnTJ5pdfxk+fMnnN1cdaqeeNlY2OjZas3Jhjy5sud3ezxg9BQnTh1Tu/UqCSDnZ2pvF7tqurWd4i6dmihNB5uT3m0AAAAAAAgJRHyPqXYS6d//v4LVSxbQpIUcD9IrT75SiWK5NP/vuqicrVaSZJG/zlTo/+cKUmm5QGio6M1Y95yLV6xXtdu3FL6dGnU+L2aat7wHVMbf06brxnzluuPEQP086hJOnH6vDJ7ZVDXji1UtmRR03ZGo1GjJszUirWbFRUVpWqVSsuvWAGLPoeHR2ji3wu0ev1W3b4boExeGdSuxfuq9VZ5s+0WL1+vybMW6+69+ypcILc++7jZE1+PVE6WM3FTp3JSlkwZdev2vSe/oM8gdrmAyWN+0LhJc7T/0Al5pvNQuxbvq06NSmbbTpqxSPOWrNGDB6Eq7VdEDepWt6gvvuUatuzYpymzlujkmQtysDcod04fde/USvlyZ9eD0FCN+XO2du07pOs37yiNh5vK+hXVZ+2byeXhZfixl8jPX7pG85eukSTTshdRUVGaMmuJlqzcoNt37sk7Y3o1a1jbrG+x74FRP/bTiHHTdPL0BXVs01gtm9TV1NlLtGTFBt28dVepUzspdw4ffdXzY2XyypDga7Z87SZVKudnFuoFBgUrjYebKeCNy9b2UdnjyzUkJDw8XMNGT9Hq9Vvk4GCvmtUqqPPHTc3a3HfouMZOnK2TZ84rlZOjKpb1VdcOLeTu5iJJ2nvgqD7rM1h/jfqfCuTNadrvywHDFRgcrLE/9zeVnb94RWMnztbeg8cUGRkl32L51fPT1qZQOqHz8LM+g+MtT+r5mVTbdh1U7hxZTQGvJJX2LSw3Vxdt27X/iSHv5avXNXP+Cv0x/FvNWrgy3m1sbGyeul8bt+7Vg9Aw1apmfv4XK5RX7m4uWr1+q5o2qP3U9QIAAAAAgJRDyBsPY2SkRVlsUFWlfEm983ZFDRnxp6aPHyoPd1cNGz1ZktSrSztJMZf/d+gxQE3eq6maD4OUHD4xQc/w36dpycoNatvsPRXMn0uHjp7S2Imz5OjgoIbvPgr5jJGRGvDjWH3wXk21a/G+/p7zj/oNHKmF00bI3S1mzc2xf83Rgn/Wqv2HjZQvd3at2bBNY/+abdH3/oNG6cCRk/q4VQNlz5pJW3cd0Pc//S43V2eVK1VMkrR5+z4NHTlRdWtU0ttVy+n4qXP6+odRz/T6BQYF6+z5yyrtW9jiuZ9HTdI3g0fJ3dVVlcr5qvPHzUwB39Ma8ONY1X+nmpo3fEeLV6zXD7/8oYL5cpqWiJi7eLX+mDJPLRrXUakShbVz72EN/nXCE+tdu2G7vh06RpXK+er7vp1lbzDo4JGTunnrrvLlzq7Q0HBFRUWpU9sP5OHuqhs3b2vyzCX6csBwjfn5a0kxl8h/8c3PKloon1o0qiNJyuwdE8KOnjBTcxatUtsW76lIwbzasmOffvptkozGSDV5r6apHxFGo74bOkbNGr6jT9p+IHc3Fy1fs0l/TJmvDq0bqUiB3AoKfqD9h08oOPhBgscTGhauQ0dP6Z23zQPwfLlzaNKMRRo/Za5qVaug7D6ZEqghacZPnqtK5fz0Q7+uOnTslP6ctkBZMmU0va+Pnzqn7l8NlW/RAhr0dTfduReg3/+arXMXruiP4d/FGzYn5Ir/DXXs+b1yZsui/r06ytbGVpNnLlbXvkM0+8+f5eBgn+B5+LznZ+waxB+3aqD2HzZKsI8XLl01C3ilmFA2W1ZvXbjk/8RjHP77NL3zdkXlyZUtya9LUqxev1XeGdNbLFVha2urQvlza+few4S8AAAAAABYGULexzwIDVOlOm0sysf98o2KFc4nSfq8c2u16vSVho6cqLcqldba/7Zr+KA+cnN1lvTo8v+M6dOZLQVw+ep1zVuyRn26tdP7dd6SFDOzLywsTH9NX6D361QzzaCMiDCq80dNTeu5ZsvirYZtemrbrgOqXb2iAu4HacE/a/XhB/XUplnMDeHKliyqT3v9oJu37pra3LP/qDZt36sRg79UGb8iMW36FdHtO/c0Yep8U8g7eeYiFS+cT/17dTLVFR4eoUkzFj31azjmz1mysZEa1H3LVGZvb1DDd6urjF9Rubik1tHjZzR55mIdO3VOf/32vQyGp38rNq5fQ43q1ZAkFSmUR1t3HtD6zbvUrkVmRUZGaerspapdvaK6dmhhOqa79+5r5b+bE6wzOjpaoybMUGnfwvrxu0c3iou7rm4aDzf16dbO9NgYGSlvrwz65PP/6eJlf/lk8Va+3Nllb2+vtB7uZu+BewGBmrtktVo0qWsKCMv4FdG9gEBNmr5IDd992xR2Go2R+qTtB3q7alnT/ouWr1fuHFlNYy5JleMswRCfU2cuyGiMNLsRniS1bFJXR46f1uQZizV5xmK5ubqobMmialD3LRUvkj/ROuNTMF8ufd65taSY99ieA0e1ftNOUzg6eeZipUvjrmH/+8I03hnTp1OPfj9q6679qlTWN8ltTfx7gdxcXTRyaF85OsQsYVGkYB41bvu5lq7aoEb1aiR4Hj73+WljIztbW9nYJB5KBwYFm2Z2x+Xq4qz7gUGJ7rtp+14dOnpK3/zVKQmvRtIF3A/Uzr2HTD88PC5PTh/NX7o2WdsEAAAAAAAvHiHvYxwdHfT7sP4W5XFn5Lk4p1b/Xh3Vre9Qbdt5QA3frW62jEJCdu07LEmqVrGU2WzhkiUKa9qcf3T95h15Z/SUJNna2qhUiUczYb290svR0UE3bt2RJJ05f0lhYeGqUqGkWRvVKpbS/kPHTY937D0kN1cX+RUvaNZmKd/CWv/bJEVGxqy9evzUeX3W3nx5hrcqlX7qkPefVf9p8Yr16t+rozKkf3QzM890adS766Ng1LdoAeXIllm9vv1FG7bs1ttVysZXXaJK+xYx/Z3KyUleGdPpxs2Y1+fGrTu6dfuuqlQwD0DfqlQq0ZD3wiV/3bh1R107tki07RVrN2vmghW6fOWaHsS5KdnFy9fkk8U7wf2OHD8tozFS1SuVNit/u0pZrdmwTZeu+JvdrK58meJm2+XLk10L/lmrkeP/VtUKpVQof64nBuS379yTJHm4m6+z6pw6lUYO6asjx89o6879OnDkhNZt2qE1G7apb/ePVP+daonW+7jYHxFi5fDJrN37j5oeHzh8QjWqljPrbxm/InJ1Sa2Dh08+Vci7c+8hvV2lnOzs7Ezva1dXZ+XNlU3HTpyV6j1V1yUl/fz0zuipzSumPn0DSRQWHq6R4/5Wh9aN5OHumqx1//vfDhmNkar52FItsdzdXHUvIFBGo/GZfngBAAAAAAApg3/FP8bWxsZsLdCEFCuUTxkzpNO167fUuH7NJ24vSQEBQYqOjlbtJp/G+/yNm7dNIa+jg4Ps7c2Hx95gUHh4hKRHwd3jN0hK6+H+WJuBuh8YFO/s5Jh67srOzk6RkZFK+3hdadzj3Sch23Yd0NCRf6ldi/dVt0blJ25fvnRxpXJy1IlT558p5HV1cTZ7bG8wKDzi8dfH/BiedEwBD2dYpk+XJsFtNmzZpf/9PE7v1ammT9o2kbubi27duae+348wtZ+QwKDgmH6lib9fAYHBpjInR0elTmW+5nHdGpUUEvJAi5ev16wFK+XinFp1alTUpx81S/CmbGEP3zMO9vGf7oXy5zKtD3v12g117jVIYybOfuqQ1+Wx8TDEGQ9JCgwMtnh/SjFj9KSZrY+7FxCk2QtXanY8a9U+azj5NOdnUri6OCs4JMSiPDAoWBnj/ADyuNkLV8rGxkY1qpYzvV8iIoyKio5SYFCwnBwdLT4bkmr1+q3KncNHubJnjfd5B3t7STHvGUJeAAAAAACsB/+Kf0YTps7T/ftByprZS8NGT9bon/o98SZIbq7OsrGx0bhfvok3pElsBujj0qX1kCTdvXdfGTzTmsrv3At4rE0XpXF30y8/9Iq3njQe7rK1tZWdnZ3u3Ltv9tyduwHx7hOfw8dOq9/A31SnRkV1bNM4yfu9KI9eH/NjeNIxubvGrA988/bdBLdZt3Gn8uTKpr7dPzaV7T14LEn9cntYv8W4PeyXu+ujoDS+t5Otra2aNqitpg1q68atO1q7YbvG/jVb7m6u+qhlgwTajKkzMCjE9LokJJNXBr1VqbRmLlihO3cDnjroT4ybq4vuBli+/nfvBZheF4eHSy9ERBjNtrkfFGz2eri5Oqt86eJqVO9ti/oeD8aT3r/kOz+lmNn/Z85fMiuLjo7Wxcv+8a5XHevCJX9dvnpd73xgGTbXbNRJvbu2M1u/O6mu3bilg0dP6dN2HyS4TWBwsOztDXJOneqp6wcAAAAAACmHkPcZHDxyUtPnLVPvru2UL3d2dejxvWYvXKVmDR/drMhgsLOY1VmyRCFJMbNFn+bS9Pjkyp5Vjo4O+m/LbuXLnd1Uvn7zLrPtSpUopL/n/iN7g0G5c/okWF++3Nm1cctuNW/4jqls3aadSerLuQtX9MU3w+RXvKD6dPsoycewecc+PQgNU4F8T545/bQyeKaVZ1oP/bdlj6pWKGUqX7dpVyJ7SdmyeiuDZ1otW70xwdnFYeHhsn9sluPqdVsttouZWRxuVlYwXy4ZDHZat3GH2bj9u3GH0ni4KWvmpAeJGTzTqkXjOlq9fqvOX7ya6DFJkv/1m2Y3V0soxL145Zoc7O3jXU/2eRQtnFcbt+5R144tTTcy3LnnkAKDQlS0cMxNwDJ4xsygPn/pqunGYPcCAnXy9Hnly5PdVFepEoV19vxl5c2VPdEbtsV3HiZUnpznpySVK1VUq9Zt0aUr15Q1s5ckade+Iwq4H6RypYonuN+HH9RT3RrmN8mbOnupLl6+pv5fdFDWpwybY61Zv02SVKNauQS38b9+y9RXAAAAAABgPQh5HxMVHa3Dx05blKfxcFNm7wx6EBqq//08TmX8ippuztS2eX39Pmm2ypYsagrRsmfNrE3b9qhY4XxK5eQonyze8snirUb13tb/fhqnlo3rqmD+XIqMjNTFy/7ae+CYfhzQ06LdhLi7uahB3bc0bc5SOTo6KF/u7FqzYZuu+F832660XxFVLFtCPb/+SS2bvKvcObPqQWiYzl24rMtXr6tfzw6mY+gzYLh+GDZeb1ctp+Onzmnlv1ue2I879wLUo9+PcnS0V7OGtXX85DnTc86pUylHtpj1ZX8bP102tjYqnD93zI3XTpzV1NlLVCBvjifeOOxZ2NnZ6sOm9TT892lKm8ZNpX2LaMeeQ9p74Gii+9nY2Khrhxb6dugYffW/kXrn7Yqytzfo8LHTKpA3pyqWLaHSvoU1bPQU/TV9oQoXyKNtu/Zr9/4jFnVlz5pJe/Yf1c49h+Tq6qxMXunl4e6qJvVravq85XJwcFDhArm1ded+rV6/VZ93bp1oYClJQ0dOlJuLswoVyC1XF2cdPHJSp89eVMN4ZrTGyuSVQZ5pPXT81DnTjfYkaciIPxUZGaWqFUspa2YvBQc/0PrNO7Vlxz41bVBbDg72T3iVn07b5u+pY8/v1eubYWryXk3duXdfv0+crYL5cqn8w9AzQ/p0KpQ/l/76e6FcnFPLzs5Wf8/5R87O5jNL23/YUB93+1Y9+v2o9+pUU9o07rpzJ0D7Dh1TscL5VLNazJqz8Z2HzqlTPdf56X/9lpq0/VztWjbQx63inz0txaxpPWXWEn01cKQ+afuBQsPCNHrCTJUvXdy0PIYkDfp1glas2WRa5ze7TyazMF6Slq3ZpJu37sq3WEGz8m27DuhBaJiOPTzvNm/fq9SpUymHT2bTuRdr9fptKlowj7wyJLzkxPGT51T84Q0mAQAAAACA9SDkfUxYWLg69BhgUV6vdhX169lBv42focCgEPXr2d70XNsW72vrzv3638+/648RA2Sws1OvLm00/Pdp+rz/zwoLC9eYn/rJt1hBfd65tXyyeGvR8nX6a8ZCpXJykk8Wb71VubRFm0/S+aNmioyM0vS5/ygqKlpVKpRU54+a6vufxpltN7h/d02dvVQL/lmrazduySV1auXMnkV1az5aN7dSOT/16dZOU2Yu0Zr/tqtQ/lwa2K+L2nf/LtE+nL9wxXQzuK5fDjF7rkTR/Br7c8xN7LJny6wFS9dq8fL1Cg0LV3rPNKpXq6o6fNjQNKszuTV5r6YCg0I0f+kaLVj6r0qVKKSverZXz69/SnS/t6uWlaOTg6bMXKxvhoyWo4O98ubObrrJ3ft1quuK/03NW7xG0+ctUxm/ovq+b2e17z7ArJ5P2n2gn0dN0lc/jFRISKj6f9FRdWtWVpcOzeXiklpLV27Q5JmL5J0xvfp0a6cGdZ98CX6Rgnm0ZMUGLV6xQaFhYcrslUHdP2ml+rWrJrpftUqltW3XAbVr8b6prFG9GlqxdrOmzlqiW3fuycnRQZm9M6rf5x1U5+1KCVf2jPLnyaERg7/U73/NUb+Bv8nJyVGVypZQ144tzcLtAV921tARE/XDsPFKm8Zdndo20doN2xUY/Gi94qyZvTTxt/9p/OS5GjZ6sh48CFO6tB4qXiSfcud4NGM9ofPwuc7P6GhFRkUpOjoq0eM1GAwaPqiPho+dpu+GjpGdna2qVCilHp1amm0XFRWlyKjE60rIT6Mm6dr1W6bHg36dIEn6uFUDtf+wkan83IUrOn3uonp3aZtgXXfuBejEqXP69KOEl3MAAAAAAACvJpvw8LDolO4EgBfr9NmLavPZ15o3efhT3TwMb455S9Zo1oIVmjvplyeuLw4AAAAAAF4tiV8bDuC1kDunjyqW9dWcRStTuit4BUVFRWnOolX6qGUDAl4AAAAAAKwQIS/whujSvrk806ZJ6W7gFXTr9l3VqVFJtatXSOmuAAAAAACAZ8ByDQAAAAAAAABgxZjJCwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXknR0dEyGo2KjmZ5YgAAAAAAAADWxZDSHXgVREZGqlLdttqwfIYMBl4SAHgaaUp1SekuAAAScHfX6JTuAgAAAF4Au+hws8fM5AUAAAAAAAAAK0bICwAAAAAAAABWjJAXAAAAAAAAAKwYIS8AAAAAAAAAWDFCXgAAAAAAAACwYoS8AAAAAAAAAGDFCHkBAAAAAAAAwIoR8gIAAAAAAACAFSPkBQAAAAAAAAArRsgLAAAAAAAAAFaMkBcAAAAAAAAArBghLwAAAAAAAABYMUJeAAAAAAAAALBihLwAAAAAAAAAYMUIeQEAAAAAAADAihHyAgAAAAAAAIAVI+QFAAAAAAAAACtGyAsAAAAAAAAAVoyQFwAAAAAAAACsGCEvAAAAAAAAAFgxQl4AAAAAAAAAsGKEvAAAAAAAAABgxQh5AQAAAAAAAMCKEfICAAAAAAAAgBUzJPREg9Y95GBvkKODg8LCw1W3ZmW1blr/uRobPHyCalWrIL/iBZ+rnoT4X7upgb+M18nTF5TJK72m/j74hbQDAAAAAAAAAK+KBENeSRrYr6vy5sqmG7fuqEWHL+VXrJAK5c/1zI3169nhmfdNitSpU6lTmyYKCg7R+MlzX2hbAAAAAAAAAPAqSDTkjZXBM62yZc2kazduqVD+XLp9555+HTtV/tdvKSw8XJXL+alT2yaSpINHTmrY6MmKjIpSgbw5deLUefX8tJV8ixVU594/qGmD2qpSvqQGDhsve4NBV/xv6Ir/DfkWK6AGdatrzMSZun7jtiqX91P3Tq0kKdH24nJ3c1Gxwvm098DRZHyJAAAAAAAAAODVlaSQ9/zFqwq4HyjfogUkSQOHjVfrZvXlW7SAjJGR6vXNMP27cYcql/PTN4NH69ven8iveEHt2X9Uy1ZvTLDeM+cvafRP/WRrY6vmHfooMChYvw3pqwijUY3afK56taoqZ/YsCbZXvXKZZz7weUvWaP7SNZKk6OjoZ64HAAAAAAAAAFJSoiHvN4NHycbGVhcv+6t7p5ZK4+GmB6Gh2r3viO7cDTBtF/IgVBcv++vCpauys7MzrbnrV7ygMntnSLD+SuV85ejgIEnKlSOryvgVlcFgkMFgUA6fzLp09Zq8vTwTbO95NK5fQ43r15AkGY1GVarb9rnqAwAAAAAAAICUkKQ1eXfuPaze3/0iv+KFlMkrvSRpwsgBpoA21umzFy3qsLGxSbB+B/tH+9vZ2srRwd702NbWVpGRUYqdZBtfewAAAAAAAADwprNNykalfQur4bvV9cfkuUqdykm+xQpq2uylpudv3r6rGzdvyyeLt4yRRu09eEyStPfgMV2+ev25OphYewAAAAAAAADwpkvSmryS1K5FAzVp94WOnzqnAX0/1W/jp6tlx76SjZTKyVFfdvtIGdKn08CvumjY6CmKio5S/jw55JPFWy4uzs/VycTaiys0NEwffNxLERFGBQWHqH7LrqpdvaI6f9T0udoHAAAAAAAAgFeVTXh4WLLedSw45IGcU6eSJB09cUZ9BvyqeZN+lZOTY3I2k6xi1+TdsHyGDIYk594AAElpSnVJ6S4AABJwd9folO4CAAAAXgC76HCzx8meaG7YvEuzFqxUtKJl9//27jxOy7JQH/g1My8zw+KCComoqKQp+BNiXA52RDsetQ5ph9TMJUJLDXNXFO24FCYdRVxCEzuc1Kw0TSuz3HOrzK3yJEpqISIICIjGNs4wvz+KyY2J4B1enuH7/UfG533v+37m+sx0d/lwvzXVOXfUyLW64AUAAAAAKLKyl7xD9x2SofsOKfewAAAAAAC8j5X64DUAAAAAANZOSl4AAAAAgAJT8gIAAAAAFJiSFwAAAACgwJS8AAAAAAAFpuQFAAAAACgwJS8AAAAAQIEpeQEAAAAACkzJCwAAAABQYEpeAAAAAIACU/ICAAAAABSYkhcAAAAAoMCUvAAAAAAABabkBQAAAAAoMCUvAAAAAECBKXkBAAAAAApMyQsAAAAAUGBKXgAAAACAAlPyAgAAAAAUmJIXAAAAAKDAlLwAAAAAAAVWqvQCACi2+Y9PqPQSAACAtVD3XY6v9BKgw3rjsfHv+NqTvAAAAAAABabkBQAAAAAoMCUvAAAAAECBKXkBAAAAAApMyQsAAAAAUGBKXgAAAACAAlPyAgAAAAAUmJIXAAAAAKDAlLwAAAAAAAWm5AUAAAAAKDAlLwAAAABAgSl5AQAAAAAKTMkLAAAAAFBgSl4AAAAAgAJT8gIAAAAAFJiSFwAAAACgwJS8AAAAAAAFpuQFAAAAACgwJS8AAAAAQIEpeQEAAAAACkzJCwAAAABQYEpeAAAAAIACU/ICAAAAABSYkhcAAAAAoMCUvAAAAAAABVZa0YVhw09ObadS6mprs7SxMUP3HZLhhxywWpNdeOm3st9HP5KGgf1Wa5wVeeJ3z+SqSTdl8ZIlqUpVdt9tYI476pBUV+uyAQAAAICOaYUlb5KMOfuEbNe3T2a/Ni+HHX1mGgb0T//t+67yZGefcvQqv3dlrNeta8acfXx69+qZpY2NOXH01/Pzex/J0H2HtOu8AAAAAACV0mbJu1zPTTZKny02y6uzX0v/7ftm7rzXM/6q6zNz1mtZ2tiYIYMbcuyIg5MkTz/zx4ybcG2aly3LDtttkynPT80pI4/IoAH9ctyoC3LIsI9lz913zphxE9OpVMorM2fnlZmzM2jADhk2dO9cOen7mTV7bobs3pCTjj0iSdqc7+0+9MGtWv9cV1ubbbfpk5mz5pTh2wQAAAAAsHZaqZJ36rQZWfDGmxm00w5JkjHjJmb4Zw7IoJ12SFNzc04/Z1zue+g3GTK4IedcOCHnjvpiGgb2y5O/m5w77n5oheO+OPXlTLjo7FRXVefQo8/Im39ZmCvGjs5bTU058HOnZv/99so2W22+wvn2HrLbCseeO+/1/OKRxzLuq6e97/VbfnJPfnj7PUmSlpaWlfk2AAAAAACsddosec+58BupqqrOtOkzc9Kxh6f7hutn8ZIleeK3z2Te/AWtr1u0eEmmTZ+Zl16ekZqamtYzdxsG9kvvXj1XOP4egwelrrY2SdJ36y2yW8NOKZVKKZVK2XrL3nl5xqvptekmK5xvRRYuXJRR512SIw4emh222+Z9X3PQAfvkoAP2SZI0NTVlj6Ej2vpWAAAAAACslVbqTN7HnvpDRp13SRoG9s9mm/ZIknzr8vNbC9rlXvjTtPeMUVVVtcLxazv9/f011dWpq+3U+nV1dXWam5dl+UO27zff+1m4aHFO/vLF2WNwQw498D/+4esBAAAAAIqsemVetOugHfOpT+yda669OV0612fQgH75zk23t16fM3d+Zs+Zmy0375Wm5qY89fSzSZKnnn4202fMWq0FtjXfuy1avCSnfPmi/MvOO+XIw/5zteYFAAAAACiClTqTN0mOPGxYDj7ytDz3/J9z/uiRuWLid3P4MaOTqqRzfV3OPPGo9OyxccacdXzGTbguy1qWZfttt86Wm/dKt25dV2uRbc33dj+47a5MnvKnLFmyNA/+8vEkyb/tsVtGHPbJ1ZofAAAAAGBtVdXYuLSsnzq2cNHidO3SOUkyecqLOeP88bnl2+NTX19XzmnKavmZvA/87HsplVa69wYAAABgBbrvcnyllwAd1huPjX/H12VvNB945PHceOudaUlLamqqc+6okWt1wQsAAAAAUGRlL3mH7jskQ/cdUu5hAQAAAAB4Hyv1wWsAAAAAAKydlLwAAAAAAAWm5AUAAAAAKDAlLwAAAABAgSl5AQAAAAAKTMkLAAAAAFBgSl4AAAAAgAJT8gIAAAAAFJiSFwAAAACgwJS8AAAAAAAFpuQFAAAAACgwJS8AAAAAQIEpeQEAAAAACkzJCwAAAABQYEpeAAAAAIACU/ICAAAAABSYkhcAAAAAoMCUvAAAAAAABabkBQAAAAAoMCUvAAAAAECBVTU2Lm2p9CIqrampKXsMHZFn5vdIUlXp5QAUyvzHJ1R6CQAAALBOqWlpfMfXnuQFAAAAACgwJS8AAAAAQIEpeQEAAAAACkzJCwAAAABQYEpeAAAAAIACU/ICAAAAABSYkhcAAAAAoMCUvAAAAAAABabkBQAAAAAoMCUvAAAAAECBKXkBAAAAAApMyQsAAAAAUGBKXgAAAACAAlPyAgAAAAAUmJIXAAAAAKDAlLwAAAAAAAWm5AUAAAAAKDAlLwAAAABAgSl5AQAAAAAKTMkLAAAAAFBgSl4AAAAAgAJT8gIAAAAAFJiSFwAAAACgwJS8AAAAAAAFpuQFAAAAACiw0oouDBt+cmo7lVJXW5uljY0Zuu+QDD/kgNWa7MJLv5X9PvqRNAzst1rjrMj/TX4+F3/j20mSpqbm7LTjdjl15PDU1nZql/kAAAAAACpthSVvkow5+4Rs17dPZr82L4cdfWYaBvRP/+37rvJkZ59y9Cq/d2Vsu82W+d9vfDWlUinLli3LWWMuzw9/em8O/dTH23VeAAAAAIBKabPkXa7nJhulzxab5dXZr6X/9n0zd97rGX/V9Zk567UsbWzMkMENOXbEwUmSp5/5Y8ZNuDbNy5Zlh+22yZTnp+aUkUdk0IB+OW7UBTlk2Mey5+47Z8y4ielUKuWVmbPzyszZGTRghwwbuneunPT9zJo9N0N2b8hJxx6RJG3O93b19XWtf36rqSlLlzamKlXl+D4BAAAAAKyVVqrknTptRha88WYG7bRDkmTMuIkZ/pkDMminHdLU3JzTzxmX+x76TYYMbsg5F07IuaO+mIaB/fLk7ybnjrsfWuG4L059ORMuOjvVVdU59Ogz8uZfFuaKsaPzVlNTDvzcqdl/v72yzVabr3C+vYfs9p4xZ746J2ecf2lemTkru+86MAfu/++r+K0BAAAAAFj7tVnynnPhN1JVVZ1p02fmpGMPT/cN18/iJUvyxG+fybz5C1pft2jxkkybPjMvvTwjNTU1rWfuNgzsl969eq5w/D0GD0pdbW2SpO/WW2S3hp1SKpVSKpWy9Za98/KMV9Nr001WON/76bVpj3zn6guzaPGSfOW/v5kHfvl49tlr8Hted8tP7skPb78nSdLS0tLWtwEAAAAAYK21UmfyPvbUHzLqvEvSMLB/Ntu0R5LkW5ef31rQLvfCn6a9Z4yqqhUfl1Db6e/vr6muTt3bPiCturo6zc3Lsrx/fb/52tKlc33+fa9/yV33/+p9S96DDtgnBx2wT5KkqakpewwdsdJjAwAAAACsLapX5kW7Dtoxn/rE3rnm2pvTpXN9Bg3ol+/cdHvr9Tlz52f2nLnZcvNeaWpuylNPP5skeerpZzN9xqzVWmBb873by6+8mqampiTJW2815cFfPpEPbr3Fas0PAAAAALA2W6kzeZPkyMOG5eAjT8tzz/85548emSsmfjeHHzM6qUo619flzBOPSs8eG2fMWcdn3ITrsqxlWbbfdutsuXmvdOvWdbUW2dZ8b/fk7yfn5h/d/bengJuz84f758jD/3O15gYAAAAAWJtVNTYuLeuBtAsXLU7XLp2TJJOnvJgzzh+fW749PvX1deWcpqyWH9fwzPweSVZ8vAQA7zX/8QmVXgIAAACsU2paGt/x9Uo/ybuyHnjk8dx4651pSUtqaqpz7qiRa3XBCwAAAABQZGUveYfuOyRD9x1S7mEBAAAAAHgfK/XBawAAAAAArJ2UvAAAAAAABabkBQAAAAAoMCUvAAAAAECBKXkBAAAAAApMyQsAAAAAUGBKXgAAAACAAlPyAgAAAAAUmJIXAAAAAKDAlLwAAAAAAAWm5AUAAAAAKDAlLwAAAABAgSl5AQAAAAAKTMkLAAAAAFBgSl4AAAAAgAJT8gIAAAAAFJiSFwAAAACgwJS8AAAAAAAFpuQFAAAAACgwJS8AAAAAQIEpeQEAAAAACqxU6QWsTeb8+vKUSr4lAAB0DN13Ob7SSwBgHTb/8QmVXgKsMzzJCwAAAABQYEpeAAAAAIACU/ICAAAAABSYkhcAAAAAoMCUvAAAAAAABabkBQAAAAAoMCUvAAAAAECBKXkBAAAAAApMyQsAAAAAUGBKXgAAAACAAlPyAgAAAAAUmJIXAAAAAKDAlLwAAAAAAAWm5AUAAAAAKDAlLwAAAABAgSl5AQAAAAAKTMkLAAAAAFBgSl4AAAAAgAJT8gIAAAAAFJiSFwAAAACgwJS8AAAAAAAFpuQFAAAAACgwJS8AAAAAQIEpeQEAAAAACkzJCwAAAABQYKUVXRg2/OTUdiqlrrY2SxsbM3TfIRl+yAGrNdmFl34r+330I2kY2G+1xvlHWlpacsKZYzPlham559Zr2nUuAAAAAIBKWmHJmyRjzj4h2/Xtk9mvzcthR5+ZhgH903/7vqs82dmnHL3K7/1n3Hjrz9O7V89MeWHqGpkPAAAAAKBS2ix5l+u5yUbps8VmeXX2a+m/fd/Mnfd6xl91fWbOei1LGxszZHBDjh1xcJLk6Wf+mHETrk3zsmXZYbttMuX5qTll5BEZNKBfjht1QQ4Z9rHsufvOGTNuYjqVSnll5uy8MnN2Bg3YIcOG7p0rJ30/s2bPzZDdG3LSsUckSZvzvdufpk7PQ796Ml8+7Zjc//BjZfo2AQAAAACsnVaq5J06bUYWvPFmBu20Q5JkzLiJGf6ZAzJopx3S1Nyc088Zl/se+k2GDG7IORdOyLmjvpiGgf3y5O8m5467H1rhuC9OfTkTLjo71VXVOfToM/LmXxbmirGj81ZTUw783KnZf7+9ss1Wm69wvr2H7PaO8ZqamjL2skn58qlfSE1128cN3/KTe/LD2+9J8tfjHQAAAAAAiqjNkvecC7+RqqrqTJs+Mycde3i6b7h+Fi9Zkid++0zmzV/Q+rpFi5dk2vSZeenlGampqWk9c7dhYL/07tVzhePvMXhQ6mprkyR9t94iuzXslFKplFKplK237J2XZ7yaXptussL53m3SDbdlr4/snK227J2Zr85p88YPOmCfHHTAPkn+Wg7vMXREm68HAAAAAFgbrdSZvI899YeMOu+SNAzsn8027ZEk+dbl57cWtMu98Kdp7xmjqqpqhePXdvr7+2uqq1NX26n16+rq6jQ3L8vyh2zfb753++3Tz2bWnLm55fZ70tzcnIWLFmfY8JPzv1d8Nd03XL/N9wIAAAAAFFHbZxr8za6DdsynPrF3rrn25nTpXJ9BA/rlOzfd3np9ztz5mT1nbrbcvFeampvy1NPPJkmeevrZTJ8xa7UW2NZ873b1+HNz23cuz23XX5aJl5ybrl0657brL1PwAgAAAAAd1kqdyZskRx42LAcfeVqee/7POX/0yFwx8bs5/JjRSVXSub4uZ554VHr22Dhjzjo+4yZcl2Uty7L9tltny817pVu3rqu1yLbmAwAAAABYl1U1Ni4t66eOLVy0OF27dE6STJ7yYs44f3xu+fb41NfXlXOaslp+Ju8DP/teSqWV7r0BAGCt1n2X4yu9BADWYfMfn1DpJUCHVdPS+I6vy95oPvDI47nx1jvTkpbU1FTn3FEj1+qCFwAAAACgyMpe8g7dd0iG7juk3MMCAAAAAPA+VuqD1wAAAAAAWDspeQEAAAAACkzJCwAAAABQYEpeAAAAAIACU/ICAAAAABSYkhcAAAAAoMCUvAAAAAAABabkBQAAAAAoMCUvAAAAAECBKXkBAAAAAApMyQsAAAAAUGBKXgAAAACAAlPyAgAAAAAUmJIXAAAAAKDAlLwAAAAAAAWm5AUAAAAAKDAlLwAAAABAgSl5AQAAAAAKTMkLAAAAAFBgSl4AAAAAgAIrVXoBa4OWlpYkSVNTU4VXAgAA5dRS6QUAsA7Ts0D7aWlpSk1NTaqqqpIkVY2NS9f5nd+SJUvy0U9+odLLAAAAAABYKQ/fcW1Kpb8+w6vkTbJs2bI0NjampqYmnx15dm64emyll0SZHPHFs+TZQciy45BlxyLPjkOWHYcsOw5Zdizy7Dhk2XHIsmNZF/N8+5O8jmtIUl1dnfr6+iRJVVVVawNO8cmz45BlxyHLjkWeHYcsOw5Zdhyy7Fjk2XHIsuOQZceyrufpg9cAAAAAAApMyfsuB+6/T6WXQBnJs+OQZcchy45Fnh2HLDsOWXYcsuxY5NlxyLLjkGXHsq7n6UxeAAAAAIAC8yQvAAAAAECBKXkBAAAAAApMyQsAAAAAUGClSi+gPS1tbMy5F16ZP097JXW1tem+4foZdcKIbNF708x7fUG+etHVeWXm7NR26pTTTxiRD/+/7ZOkzWsXjJuY516YmuqqqpRKNRl51CHZ5cM7VvI21xntkedxoy7Iq7PmplvXzkmSj++zRw791Mcrdo/rivbI8vMnnpe33norSdLcvCx/eml6vvPNC/PBbbas2H2uC9ojy8lTXsxlV9+QxYuXpqoqOfHYw7PzwP6VvM11wqpmee33f5yf3/twXn5lVsaee1L23H3n1jHbukb7ao887YEqoz2ytP+pjPbI0v6nctojT3ugyljVLC8YNzFPT34+dbW16dy5Lid/8Yj0+1DfJMntdz2YG2/9eV6aNiPHH31YPvOpj1XyFtcZ7ZHl1d/+QR5+9KnUVP/1GcnPHrJ/9tlrcMXucV3RHlmOGTcxjz31h3TfYL0kyS6DdswJRx9WsXtsDx36g9eWNjbmyd9NzuBdBqSqqio3//ju/OKRx3LVxf+VCy65Jpv23Dhf+OyBmTzlxYz+6mW59bpLUyqV2rz25l8WZr1uXZMkU16YmhPOHJs7b/5mqqs9FN3e2iPP40ZdkEOGfUzxsIa1R5Zvd//Dj2XSDbfmuxO/XqE7XHeUO8uampp88ogT81+nHZtdB+2YadNn5sTRX8+Nky5OfV1tpW+3Q1vVLJ957sVsuMF6+dr4a97z+7Sta7Sv9sjTHqgy2iNL+5/KaI8s387+Z80qd54tLS32QBWyqlk+/OsnM3jXgSnV1OSRR3+bS666Lrddf1mS5PkXX0qnTqVcd+Pt+dAHt1LyriHtkeXb9z+zX5uXQ48+Iz+89tJs+LeikPbRHlmOGTcx227Tp0P/PHboXXldbW1233VgqqqqkiQ77vDBzJz1WpLk/od+k2FD906S9PtQ32yyUfc89fRz//Da8h/uJFm4cNEauxfaJ08qo72zvP3OB7L/fnutgTuh3FkueOMveX3Bm9l10F+fDtxy817p1q1LHn3892v61tY5q5pl/+37pnevnu87ZlvXaF/tkac9UGW0R5ZURntnaf+zZpU7T3ugylnVLPcY3JBSTU3re+a8Nj9Nzc1Jkm379slWW/ZOdXXVmr6ddVp7ZPn2/c/ixUuSlmRZy7I1dk/rqvbIcl3QoY9reLcf/OiuDBk8KAveeDNNzc3ZeKMNW6/1+sAmmTVnbpvXlrtq0o25/+HH8sabCzP2nJM8wVIh5cvzplxz3S3ZesveGXnUIf4PUQWUK8skmTV7bn77f8/lvDNGrqHV83arm+Wug3bMxhttmHsffDT/vue/ZPKUFzNt+szMnDVnzd/MOm5lsqQ4ypWnPVDllS9L+59KK+fvWfufylvdPDfcYD17oLXEqmR504/uzO67DGgtl1g7lCvLH/zorvzw9nsye878nHXK57PRhhusieXzNuXM8qd3P5gP9Ng4x444ONv17bMmlr/GrDM782u//+NMnzErI488ZLXHOu7zn8kt147PBV8+IVdO+n7eequpDCvkn1GuPM8bNTI3Tbo4N1w9NgN2/FBOP3dcmVbIyirnz2aS3HHPQ/nIrgP99ZkKKFeWF513Sn5614MZftyX84Mf3ZWd+m+XGhvmNarcP5dUlj1Qx2H/03HY/3Qs9kAdx6pkeed9j+T+h36T0Sd/vh1Xxj+rnFl++j/3y02TxuWaS8/NdTf+JAveeLPcy6UN5cry2BEH55ZrL8kNV4/N/h/bM6f+10VZtHhJeyy5YtaJkve7N9+RB3/5RMZfMCr19XXZYP31UlNdk7nzXm99zcxZr+UDPTZu89q77TpoxyxctCQvTn15DdwFy5Uzzw/0/Os/q6qqcvAn982MmXP8wl6Dyv2z2dLSkjvufij7f2yvNXcTJClvltv27ZPLLjwz11/1tZx/5nF5be7r2bpP7zV8R+uufyZL1n7tlac90JpXziztfyqr3D+X9j+VVc487YEqa1WyvPeBRzPphtty+djR2ai7pzvXFu2V5bZ9+6THxt3z1O+fbe9b4G/KmWXPTTZq/Vtoe31kl3Tt0jnTps9cY/eyJnT4kvf7P/xZ7nng17l87Oh3nKXyb0N2zW133Jfkr59iOmfu/Azaafs2rzU1NeXlV15tHeOZ517M/NffyGab+utta0pZ82xuzrz5C1rH+MXDj2Wj7utng/U9AbEmlDPL5Z743TNpbl7WepYZa0a5s3xt7vzWMX78s1+kc32dT5ZeQ1YlS9Ze5czTHqiyypql/U9FtcfvWfufyil3nvZAlbMqWd774KOZeN3NueLrZ2XTnptUZN28V7mz/PNLr7T+efqMWfnjiy/5jy9rSLmznP22Ix3+8OwLWfDGX7L5Zh9YA3ey5lQ1Ni5tqfQi2svsOXPzySNOSu9ePdOlc32SpFOnTpl0xVcyb/6CfOWib2bGq3PSqVTKaV/6XBoG9kuSFV5bsmRpTjzr61m4cHFqaqpTX1+XYz53kP/hXUPKnefiJUty3OlfS+Nbb6W6qjobbNAtJx1zeLbtYGeyrI3KneVy5469Mlv03jRHDz+wIve1LmqPLCfdcGvuuv9XaWlpyVZbbpbTvzSi9akz2s+qZvnt7/0ot91xX15f8Ga6dK5PbW2nXHfl19J9w/XbvEb7Kneenevr7IEqpNxZ1tfX2v9USHv8nk3sfyqlPfK0B6qMVc3yX//jc9m4+wbZYP1urWN947/Pygbrr5c77n4oE6+7OW++uSilUk06d67LxV85LR/64FaVuMV1Rntkedo54zLz1TkplWpSU1OTIz79iew9ZLeK3N+6pD2yPOHMsZn3+oLUVFenrq42Xxzx6Xf0CR1Bhy55AQAAAAA6ug5/XAMAAAAAQEem5AUAAAAAKDAlLwAAAABAgSl5AQAAAAAKTMkLAAAAAFBgSl4AAAAAgAJT8gIAAAAAFJiSFwAAAACgwJS8AACwEr568dU547zx7/h3815fkI9/emQe/NUTFVoVAAAoeQEAYKWcetzwTHlhan5+7yOt/+7iK67N4F0GZM/ddy7LHE1NTWUZBwCAdUup0gsAAIAi6Na1S7586tE5Z+yV2fnD/fPU75/N5Ckv5rvXfD3jJlyXRx59Ko2Nb2W3nXfKaV8anm5duyRJzv/vq/Lk7yZn0ZIl2WKzTXPC0YelYWC/JMkddz+Um267M3sMbsiPfnZ/duq3Xcaee1IlbxMAgAKqamxc2lLpRQAAQFFcPOHavDRtRl7487R8dfSX8uOf/yI1NTUZdcKIlEo1GXvp/6SmpibnnTEySfLTux7MXv+6S+rranPjbXfmOzf9NLdef2m6dumcO+5+KGMv/Z8cdcSwfPbT+6e5uTn19XUVvkMAAIrGcQ0AAPBPOP4Ln8n0GbMyZPeGbNu3Tx745eM5/fgRWa9b13Sur8/Rww/KvQ8+mubmZUmST+y3Z7p17ZJSqZQjDv5EWlqW5YU/v9w6XteuXTLi0E+mU6eSghcAgFXiuAYAAPgndK6vz2a9emSbPltk5qw5WbasJQd+7pR3vKa6qjpz57+eTTbaMNdcd0vue+g3mff6glRXVWfhosVZsODN1tf22KR7qqs9ewEAwKpT8gIAwCr6QI+NU11dldu/9433fQr3zvseyd2/+HUuu/CMbNF701RVVWXfA49JS/5+Ylp1VdWaXDIAAB2QRwYAAGAVbbzRhhkyeOeMu/K6vP63p3Pnzns9D/zy8STJwkWL06lTTTZYf7289VZTJt1wWxYtWlLJJQMA0AEpeQEAYDX81+nHZL1uXXLUCedm72FfyBdPG5Mpz09NkvzHPntk6z6b51PDT86BI05NXV2n9OixUWUXDABAh1PV2Li05R+/DAAAAACAtZEneQEAAAAACkzJCwAAAABQYEpeAAAAAIACU/ICAAAAABSYkhcAAAAAoMCUvAAAAAAABfb/AQCErbbtL6riAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1400x600 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Create side-by-side comparison (if both datasets available)\n",
-    "if len(macro_probs) > 0 and len(gmm_probs_full) > 0:\n",
-    "    fig, axes = plt.subplots(2, 1, figsize=(14, 6))\n",
+    "- **Level or rate is the first decision, not a preprocessing detail.** A trending column\n",
+    "  entering a clustering makes elapsed time the dominant direction of variance, and the\n",
+    "  partition that comes back is a partition of the calendar wearing economic names.\n",
+    "- **A separation score is not a validation.** Silhouette answers whether the groups are far\n",
+    "  apart in the space they were fitted in. Whether the groups mean anything is a separate\n",
+    "  question, and counting episodes - does the model ever return to a cluster? - is a cheap\n",
+    "  way to ask it.\n",
+    "- **More series is not more information.** Nine Treasury maturities, a spread stored twice,\n",
+    "  and two GDP measures are one panel with a few directions in it, which principal components\n",
+    "  and the linkage tree both report directly.\n",
+    "- **Attaching names to clusters is an assertion.** The mixture supplies a partition; every\n",
+    "  economic name in this notebook comes from a threshold rule written by hand, and a\n",
+    "  different rule would rename the same partition.\n",
+    "- **Validate a regime model against something it never saw.** These regimes were fitted\n",
+    "  without any market data, so equity volatility and drawdown are an independent check, and\n",
+    "  the check is what surfaced a cluster too small to support the name it was given.\n",
     "\n",
-    "    # Panel 1: Core 4 indicators\n",
-    "    ax1 = axes[0]\n",
-    "    im1 = ax1.imshow(macro_probs.T, aspect=\"auto\", cmap=\"Blues\", vmin=0, vmax=1)\n",
-    "    years_core = [pd.Timestamp(ts).year for ts in macro_df.index]\n",
-    "    year_ticks_core = [j for j, y in enumerate(years_core) if j == 0 or years_core[j - 1] != y]\n",
-    "    year_labels_core = [str(years_core[j]) for j in year_ticks_core]\n",
-    "    ax1.set_xticks(year_ticks_core[::2])\n",
-    "    ax1.set_xticklabels(year_labels_core[::2], fontsize=8)\n",
-    "    ax1.set_yticks(range(n_macro_regimes))\n",
-    "    ax1.set_yticklabels([f\"Regime {i + 1}\" for i in range(n_macro_regimes)])\n",
-    "    ax1.set_title(f\"Core 4 Indicators (Silhouette: {macro_silhouette:.3f})\", fontsize=11)\n",
+    "**Known limitations.** FRED serves revised values, so no number here was available on the\n",
+    "date it is attached to; the mixture has no transition structure and no notion of time, so\n",
+    "nothing prefers a month to keep its neighbour's label; the panel starts in 2002 and holds\n",
+    "one severe recession, one pandemic and one inflation episode, which is not enough\n",
+    "repetitions of any condition to estimate how often it recurs; and the naming rule's\n",
+    "thresholds were set for the post-2002 US economy and would not transfer to another country\n",
+    "or another era.\n",
     "\n",
-    "    # Panel 2: Extended dataset\n",
-    "    ax2 = axes[1]\n",
-    "    im2 = ax2.imshow(gmm_probs_full.T, aspect=\"auto\", cmap=\"Blues\", vmin=0, vmax=1)\n",
-    "    years_ext = macro_data_full.index.year.tolist()\n",
-    "    year_ticks_ext = [j for j, y in enumerate(years_ext) if j == 0 or years_ext[j - 1] != y]\n",
-    "    year_labels_ext = [str(years_ext[j]) for j in year_ticks_ext]\n",
-    "    ax2.set_xticks(year_ticks_ext[::2])\n",
-    "    ax2.set_xticklabels(year_labels_ext[::2], fontsize=8)\n",
-    "    ax2.set_yticks(range(n_regimes_full))\n",
-    "    ax2.set_yticklabels([f\"Regime {i + 1}\" for i in range(n_regimes_full)])\n",
-    "    ax2.set_xlabel(\"Year\")\n",
-    "    ext_sil = silhouette_score(macro_data_full, gmm_labels_full)\n",
-    "    ax2.set_title(\n",
-    "        f\"Extended {macro_data_full.shape[1]} Indicators (Silhouette: {ext_sil:.3f})\", fontsize=11\n",
-    "    )\n",
-    "\n",
-    "    fig.suptitle(\n",
-    "        \"GMM Regime Comparison: Core vs Extended Indicators\", fontsize=12, fontweight=\"bold\"\n",
-    "    )\n",
-    "    plt.show()\n",
-    "else:\n",
-    "    print(\"Comparison visualization skipped - insufficient data\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b2d952ac",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004103,
-     "end_time": "2026-07-18T19:35:45.774226+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.770123+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Quantitative Comparison"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "6e96ca85",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-18T19:35:45.783272Z",
-     "iopub.status.busy": "2026-07-18T19:35:45.783136Z",
-     "iopub.status.idle": "2026-07-18T19:35:45.824947Z",
-     "shell.execute_reply": "2026-07-18T19:35:45.824630Z"
-    },
-    "papermill": {
-     "duration": 0.04742,
-     "end_time": "2026-07-18T19:35:45.825695+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.778275+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extended indicators provide better separation; the broader panel captures meaningful economic variation despite added noise.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<style type=\"text/css\">\n",
-       "</style>\n",
-       "<table id=\"T_698d9\">\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_698d9_level0_col0\" class=\"col_heading level0 col0\" >Silhouette</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th class=\"index_name level0\" >Model</th>\n",
-       "      <th class=\"blank col0\" >&nbsp;</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th id=\"T_698d9_level0_row0\" class=\"row_heading level0 row0\" >Core (4 indicators)</th>\n",
-       "      <td id=\"T_698d9_row0_col0\" class=\"data row0 col0\" >0.252</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th id=\"T_698d9_level0_row1\" class=\"row_heading level0 row1\" >Extended (25 indicators)</th>\n",
-       "      <td id=\"T_698d9_row1_col0\" class=\"data row1 col0\" >0.417</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th id=\"T_698d9_level0_row2\" class=\"row_heading level0 row2\" >Extended + PCA</th>\n",
-       "      <td id=\"T_698d9_row2_col0\" class=\"data row2 col0\" >0.396</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7293580a16a0>"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "core_sil = macro_silhouette if len(macro_df) > 0 else float(\"nan\")\n",
-    "extended_sil = silhouette_score(macro_data_full, gmm_labels_full)\n",
-    "pca_sil = silhouette_score(reduced, pca_labels)\n",
-    "\n",
-    "silhouette_compare = pd.DataFrame(\n",
-    "    {\n",
-    "        \"Model\": [\n",
-    "            \"Core (4 indicators)\",\n",
-    "            f\"Extended ({macro_data_full.shape[1]} indicators)\",\n",
-    "            \"Extended + PCA\",\n",
-    "        ],\n",
-    "        \"Silhouette\": [core_sil, extended_sil, pca_sil],\n",
-    "    }\n",
-    ").set_index(\"Model\")\n",
-    "\n",
-    "if core_sil > extended_sil:\n",
-    "    interpretation = \"Core 4 indicators provide cleaner separation; additional series add noise.\"\n",
-    "else:\n",
-    "    interpretation = (\n",
-    "        \"Extended indicators provide better separation; the broader panel captures \"\n",
-    "        \"meaningful economic variation despite added noise.\"\n",
-    "    )\n",
-    "print(interpretation)\n",
-    "silhouette_compare.style.format(\"{:.3f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cca43980",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005982,
-     "end_time": "2026-07-18T19:35:45.837885+00:00",
-     "exception": false,
-     "start_time": "2026-07-18T19:35:45.831903+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "## Key Takeaways\n",
-    "\n",
-    "- **Macro indicators line up with realised volatility**: The four regimes' mean\n",
-    "  annualised volatility runs from 12.0% (Expansion, 77 months) to 16.0% (Crisis,\n",
-    "  4 months), with Tightening at 15.0% and Recovery at 15.2%. The Crisis cell\n",
-    "  covers only 4 months on this 2003-2026 panel, so the 16.0% figure is an\n",
-    "  anecdotal upper bound rather than a regime-level statistic.\n",
-    "- **Extended indicators improve cluster quality**: The 25-indicator model achieves\n",
-    "  higher silhouette (0.42) than the 4-indicator model (0.25), but the core model\n",
-    "  is more interpretable — the trade-off depends on the use case.\n",
-    "- **Hierarchical structure is genuine**: A cophenetic correlation of 0.71, above the\n",
-    "  0.7 quality bar, means the dendrogram faithfully represents the indicator distance\n",
-    "  structure rather than imposing an arbitrary tree.\n",
-    "- **Use rates, not levels**: We use CPI year-over-year change rather than the CPI level,\n",
-    "  because clustering on a trending level would capture \"early vs late\" rather than\n",
-    "  \"inflationary vs non-inflationary.\"\n",
-    "- **GMM vs K-Means**: Similar performance (silhouette 0.42 vs 0.45), but GMM provides\n",
-    "  probability assignments that quantify regime uncertainty.\n",
-    "\n",
-    "**Book reference**: §1.4 of Chapter 1 frames these regimes as inputs to risk\n",
-    "management — exposure caps, hedging triggers, and de-risking rules — rather than\n",
-    "as return forecasts. Figure 1.6 in the chapter is the macro-regime panel rendered\n",
-    "above."
+    "**Next**: Chapter 1 closes on what a research process needs to survive changes like these.\n",
+    "Walk-forward estimation, which is what turns a descriptive regime label into one a strategy\n",
+    "could act on, is introduced from Chapter 6."
    ]
   }
  ],
@@ -2609,38 +1496,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 7.524878,
-   "end_time": "2026-07-18T19:35:46.861427+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "01_process_is_edge/macro_regimes.ipynb",
-   "output_path": "01_process_is_edge/macro_regimes.ipynb",
-   "parameters": {},
-   "start_time": "2026-07-18T19:35:39.336549+00:00",
-   "version": "2.7.0"
-  },
-  "ml4t_provenance": {
-   "source_py_blob": "25a12e9f9d9ff2afb9808b35cfa87dac56604057",
-   "executed_at": "2026-07-18T19:35:47.152781+00:00",
-   "executor": "local-uv",
-   "production": true,
-   "parameters": {},
-   "notes": "Ch01 macro panel-range prose fix (2002-2024 -> 2003-2026)"
   }
  },
  "nbformat": 4,

--- a/01_process_is_edge/macro_regimes.ipynb
+++ b/01_process_is_edge/macro_regimes.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e507c676",
-   "metadata": {},
+   "id": "a87cefa7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.028868,
+     "end_time": "2026-09-08T23:42:21.838439+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:21.809571+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# Macro-based regime detection\n",
     "\n",
@@ -67,17 +75,39 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76d142c2",
-   "metadata": {},
+   "id": "d3d30f6d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009336,
+     "end_time": "2026-09-08T23:42:21.860590+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:21.851254+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Setup"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b54e0771",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "6c9216d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:21.895756Z",
+     "iopub.status.busy": "2026-09-08T23:42:21.895573Z",
+     "iopub.status.idle": "2026-09-08T23:42:29.859705Z",
+     "shell.execute_reply": "2026-09-08T23:42:29.859177Z"
+    },
+    "papermill": {
+     "duration": 7.990986,
+     "end_time": "2026-09-08T23:42:29.861004+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:21.870018+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Macro-based regime detection - clustering FRED indicators and validating against the S&P 500.\"\"\"\n",
@@ -109,9 +139,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7250b7da",
+   "execution_count": 2,
+   "id": "e350b658",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:29.886472Z",
+     "iopub.status.busy": "2026-09-08T23:42:29.886263Z",
+     "iopub.status.idle": "2026-09-08T23:42:29.892090Z",
+     "shell.execute_reply": "2026-09-08T23:42:29.888397Z"
+    },
+    "papermill": {
+     "duration": 0.019416,
+     "end_time": "2026-09-08T23:42:29.892694+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:29.873278+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -124,8 +167,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea2a6f87",
-   "metadata": {},
+   "id": "2657111f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012747,
+     "end_time": "2026-09-08T23:42:29.911404+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:29.898657+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Settings, and what each one decides\n",
     "\n",
@@ -150,9 +201,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1e71ab6e",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "3c04a241",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:29.940710Z",
+     "iopub.status.busy": "2026-09-08T23:42:29.940533Z",
+     "iopub.status.idle": "2026-09-08T23:42:29.982128Z",
+     "shell.execute_reply": "2026-09-08T23:42:29.981646Z"
+    },
+    "papermill": {
+     "duration": 0.059141,
+     "end_time": "2026-09-08T23:42:29.983373+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:29.924232+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "N_REGIMES = 4\n",
@@ -171,8 +236,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33829016",
-   "metadata": {},
+   "id": "6e7c38db",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008773,
+     "end_time": "2026-09-08T23:42:30.005250+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:29.996477+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## The FRED panel\n",
     "\n",
@@ -184,10 +257,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8b2fc5ca",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "c0b0a91c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:30.027819Z",
+     "iopub.status.busy": "2026-09-08T23:42:30.027642Z",
+     "iopub.status.idle": "2026-09-08T23:42:30.078437Z",
+     "shell.execute_reply": "2026-09-08T23:42:30.074387Z"
+    },
+    "papermill": {
+     "duration": 0.061457,
+     "end_time": "2026-09-08T23:42:30.079033+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.017576+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FRED panel: 9497 rows, 25 series\n",
+      "Covering 2000-01-01 to 2025-12-31\n"
+     ]
+    }
+   ],
    "source": [
     "macro_raw = load_macro()\n",
     "if macro_raw[DATE_COL].dtype == pl.Date:\n",
@@ -199,8 +295,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac99f133",
-   "metadata": {},
+   "id": "a7b11cb2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008106,
+     "end_time": "2026-09-08T23:42:30.097764+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.089658+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### What the panel holds\n",
     "\n",
@@ -213,10 +317,274 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c2a3647b",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "ead5ed53",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:30.132663Z",
+     "iopub.status.busy": "2026-09-08T23:42:30.132481Z",
+     "iopub.status.idle": "2026-09-08T23:42:30.179553Z",
+     "shell.execute_reply": "2026-09-08T23:42:30.179161Z"
+    },
+    "papermill": {
+     "duration": 0.078803,
+     "end_time": "2026-09-08T23:42:30.186810+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.108007+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Series</th>\n",
+       "      <th>Published</th>\n",
+       "      <th>Derived as</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Column</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>dff</th>\n",
+       "      <td>Fed Funds Rate</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>dgs1</th>\n",
+       "      <td>1-Year Treasury Constant Maturity</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>dgs2</th>\n",
+       "      <td>2-Year Treasury Constant Maturity</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>dgs3</th>\n",
+       "      <td>3-Year Treasury Constant Maturity</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>dgs5</th>\n",
+       "      <td>5-Year Treasury Constant Maturity</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>dgs7</th>\n",
+       "      <td>7-Year Treasury Constant Maturity</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>dgs10</th>\n",
+       "      <td>10-Year Treasury Constant Maturity</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>dgs20</th>\n",
+       "      <td>20-Year Treasury Constant Maturity</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>dgs30</th>\n",
+       "      <td>30-Year Treasury Constant Maturity</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>t10y2y</th>\n",
+       "      <td>10Y-2Y Treasury spread</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>vixcls</th>\n",
+       "      <td>VIX Volatility Index</td>\n",
+       "      <td>daily</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>icsa</th>\n",
+       "      <td>Initial Jobless Claims</td>\n",
+       "      <td>weekly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>walcl</th>\n",
+       "      <td>Fed Balance Sheet</td>\n",
+       "      <td>weekly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cpiaucsl</th>\n",
+       "      <td>CPI All Urban Consumers</td>\n",
+       "      <td>monthly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cpilfesl</th>\n",
+       "      <td>Core CPI</td>\n",
+       "      <td>monthly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>pcepi</th>\n",
+       "      <td>PCE Price Index</td>\n",
+       "      <td>monthly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>unrate</th>\n",
+       "      <td>Unemployment Rate</td>\n",
+       "      <td>monthly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>payems</th>\n",
+       "      <td>Non-Farm Payrolls</td>\n",
+       "      <td>monthly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>civpart</th>\n",
+       "      <td>Labor Force Participation</td>\n",
+       "      <td>monthly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>indpro</th>\n",
+       "      <td>Industrial Production</td>\n",
+       "      <td>monthly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>m2sl</th>\n",
+       "      <td>M2 Money Stock</td>\n",
+       "      <td>monthly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gdp</th>\n",
+       "      <td>Nominal GDP</td>\n",
+       "      <td>quarterly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gdpc1</th>\n",
+       "      <td>Real GDP</td>\n",
+       "      <td>quarterly</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>YIELD_CURVE_SLOPE</th>\n",
+       "      <td>10Y-2Y spread for regime detection (&gt;0.5% = ri...</td>\n",
+       "      <td>derived_daily</td>\n",
+       "      <td>DGS10 - DGS2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>YIELD_CURVE_5_10</th>\n",
+       "      <td>10Y-5Y spread for additional regime context</td>\n",
+       "      <td>derived_daily</td>\n",
+       "      <td>DGS10 - DGS5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                              Series  \\\n",
+       "Column                                                                 \n",
+       "dff                                                   Fed Funds Rate   \n",
+       "dgs1                               1-Year Treasury Constant Maturity   \n",
+       "dgs2                               2-Year Treasury Constant Maturity   \n",
+       "dgs3                               3-Year Treasury Constant Maturity   \n",
+       "dgs5                               5-Year Treasury Constant Maturity   \n",
+       "dgs7                               7-Year Treasury Constant Maturity   \n",
+       "dgs10                             10-Year Treasury Constant Maturity   \n",
+       "dgs20                             20-Year Treasury Constant Maturity   \n",
+       "dgs30                             30-Year Treasury Constant Maturity   \n",
+       "t10y2y                                        10Y-2Y Treasury spread   \n",
+       "vixcls                                          VIX Volatility Index   \n",
+       "icsa                                          Initial Jobless Claims   \n",
+       "walcl                                              Fed Balance Sheet   \n",
+       "cpiaucsl                                     CPI All Urban Consumers   \n",
+       "cpilfesl                                                    Core CPI   \n",
+       "pcepi                                                PCE Price Index   \n",
+       "unrate                                             Unemployment Rate   \n",
+       "payems                                             Non-Farm Payrolls   \n",
+       "civpart                                    Labor Force Participation   \n",
+       "indpro                                         Industrial Production   \n",
+       "m2sl                                                  M2 Money Stock   \n",
+       "gdp                                                      Nominal GDP   \n",
+       "gdpc1                                                       Real GDP   \n",
+       "YIELD_CURVE_SLOPE  10Y-2Y spread for regime detection (>0.5% = ri...   \n",
+       "YIELD_CURVE_5_10         10Y-5Y spread for additional regime context   \n",
+       "\n",
+       "                       Published    Derived as  \n",
+       "Column                                          \n",
+       "dff                        daily             -  \n",
+       "dgs1                       daily             -  \n",
+       "dgs2                       daily             -  \n",
+       "dgs3                       daily             -  \n",
+       "dgs5                       daily             -  \n",
+       "dgs7                       daily             -  \n",
+       "dgs10                      daily             -  \n",
+       "dgs20                      daily             -  \n",
+       "dgs30                      daily             -  \n",
+       "t10y2y                     daily             -  \n",
+       "vixcls                     daily             -  \n",
+       "icsa                      weekly             -  \n",
+       "walcl                     weekly             -  \n",
+       "cpiaucsl                 monthly             -  \n",
+       "cpilfesl                 monthly             -  \n",
+       "pcepi                    monthly             -  \n",
+       "unrate                   monthly             -  \n",
+       "payems                   monthly             -  \n",
+       "civpart                  monthly             -  \n",
+       "indpro                   monthly             -  \n",
+       "m2sl                     monthly             -  \n",
+       "gdp                    quarterly             -  \n",
+       "gdpc1                  quarterly             -  \n",
+       "YIELD_CURVE_SLOPE  derived_daily  DGS10 - DGS2  \n",
+       "YIELD_CURVE_5_10   derived_daily  DGS10 - DGS5  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "metadata = load_macro_metadata().to_pandas().set_index(\"series\")\n",
     "inventory = metadata.loc[\n",
@@ -235,8 +603,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b359d99",
-   "metadata": {},
+   "id": "5e36ff1d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01505,
+     "end_time": "2026-09-08T23:42:30.213356+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.198306+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Four indicators that describe conditions\n",
     "\n",
@@ -256,9 +632,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2424a7a1",
-   "metadata": {},
+   "execution_count": 6,
+   "id": "acbacb68",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:30.224643Z",
+     "iopub.status.busy": "2026-09-08T23:42:30.224490Z",
+     "iopub.status.idle": "2026-09-08T23:42:30.226501Z",
+     "shell.execute_reply": "2026-09-08T23:42:30.226155Z"
+    },
+    "papermill": {
+     "duration": 0.009472,
+     "end_time": "2026-09-08T23:42:30.228116+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.218644+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "CORE_SERIES = [\"unrate\", \"dff\", \"t10y2y\", \"cpiaucsl\"]"
@@ -266,9 +656,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c32cfe9e",
+   "id": "4c710dc1",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.012308,
+     "end_time": "2026-09-08T23:42:30.255032+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.242724+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### From daily rows to a monthly panel\n",
@@ -286,9 +683,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "daba61db",
-   "metadata": {},
+   "execution_count": 7,
+   "id": "2e591208",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:30.291612Z",
+     "iopub.status.busy": "2026-09-08T23:42:30.291344Z",
+     "iopub.status.idle": "2026-09-08T23:42:30.299152Z",
+     "shell.execute_reply": "2026-09-08T23:42:30.298885Z"
+    },
+    "papermill": {
+     "duration": 0.028233,
+     "end_time": "2026-09-08T23:42:30.300658+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.272425+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def to_monthly(frame: pl.DataFrame, columns: list[str]) -> pl.DataFrame:\n",
@@ -304,10 +715,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8ab5395d",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "44f805f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:30.324186Z",
+     "iopub.status.busy": "2026-09-08T23:42:30.324056Z",
+     "iopub.status.idle": "2026-09-08T23:42:30.366836Z",
+     "shell.execute_reply": "2026-09-08T23:42:30.366499Z"
+    },
+    "papermill": {
+     "duration": 0.05761,
+     "end_time": "2026-09-08T23:42:30.367578+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.309968+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Monthly rows: 288\n",
+      "Covering 2002-01 to 2025-12\n"
+     ]
+    }
+   ],
    "source": [
     "macro_monthly = (\n",
     "    to_monthly(macro_raw, CORE_SERIES)\n",
@@ -321,8 +755,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a54135d4",
-   "metadata": {},
+   "id": "247a6779",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00848,
+     "end_time": "2026-09-08T23:42:30.389847+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.381367+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Why the price index enters as a rate, not a level\n",
     "\n",
@@ -342,10 +784,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "dd857540",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 9,
+   "id": "f362110d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:30.422010Z",
+     "iopub.status.busy": "2026-09-08T23:42:30.421864Z",
+     "iopub.status.idle": "2026-09-08T23:42:30.446479Z",
+     "shell.execute_reply": "2026-09-08T23:42:30.445927Z"
+    },
+    "papermill": {
+     "duration": 0.044435,
+     "end_time": "2026-09-08T23:42:30.447204+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.402769+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Clustering panel: 276 months, 2003 to 2025\n"
+     ]
+    }
+   ],
    "source": [
     "macro_df = macro_monthly.select(CORE_SERIES).to_pandas()\n",
     "macro_df.index = pd.DatetimeIndex(macro_monthly[DATE_COL].to_pandas())\n",
@@ -361,8 +825,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba28e057",
-   "metadata": {},
+   "id": "5a444375",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01331,
+     "end_time": "2026-09-08T23:42:30.471588+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.458278+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### The four series before anything is fitted\n",
     "\n",
@@ -376,10 +848,100 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "abe90b5e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "id": "2807cd90",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:30.500472Z",
+     "iopub.status.busy": "2026-09-08T23:42:30.500334Z",
+     "iopub.status.idle": "2026-09-08T23:42:30.615663Z",
+     "shell.execute_reply": "2026-09-08T23:42:30.615277Z"
+    },
+    "papermill": {
+     "duration": 0.130215,
+     "end_time": "2026-09-08T23:42:30.616123+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.485908+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_c7847\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_c7847_level0_col0\" class=\"col_heading level0 col0\" >count</th>\n",
+       "      <th id=\"T_c7847_level0_col1\" class=\"col_heading level0 col1\" >mean</th>\n",
+       "      <th id=\"T_c7847_level0_col2\" class=\"col_heading level0 col2\" >std</th>\n",
+       "      <th id=\"T_c7847_level0_col3\" class=\"col_heading level0 col3\" >min</th>\n",
+       "      <th id=\"T_c7847_level0_col4\" class=\"col_heading level0 col4\" >25%</th>\n",
+       "      <th id=\"T_c7847_level0_col5\" class=\"col_heading level0 col5\" >50%</th>\n",
+       "      <th id=\"T_c7847_level0_col6\" class=\"col_heading level0 col6\" >75%</th>\n",
+       "      <th id=\"T_c7847_level0_col7\" class=\"col_heading level0 col7\" >max</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c7847_level0_row0\" class=\"row_heading level0 row0\" >Unemployment rate (%)</th>\n",
+       "      <td id=\"T_c7847_row0_col0\" class=\"data row0 col0\" >276.00</td>\n",
+       "      <td id=\"T_c7847_row0_col1\" class=\"data row0 col1\" >5.75</td>\n",
+       "      <td id=\"T_c7847_row0_col2\" class=\"data row0 col2\" >2.02</td>\n",
+       "      <td id=\"T_c7847_row0_col3\" class=\"data row0 col3\" >3.40</td>\n",
+       "      <td id=\"T_c7847_row0_col4\" class=\"data row0 col4\" >4.20</td>\n",
+       "      <td id=\"T_c7847_row0_col5\" class=\"data row0 col5\" >5.00</td>\n",
+       "      <td id=\"T_c7847_row0_col6\" class=\"data row0 col6\" >6.70</td>\n",
+       "      <td id=\"T_c7847_row0_col7\" class=\"data row0 col7\" >14.80</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c7847_level0_row1\" class=\"row_heading level0 row1\" >Fed funds rate (%)</th>\n",
+       "      <td id=\"T_c7847_row1_col0\" class=\"data row1 col0\" >276.00</td>\n",
+       "      <td id=\"T_c7847_row1_col1\" class=\"data row1 col1\" >1.76</td>\n",
+       "      <td id=\"T_c7847_row1_col2\" class=\"data row1 col2\" >1.91</td>\n",
+       "      <td id=\"T_c7847_row1_col3\" class=\"data row1 col3\" >0.04</td>\n",
+       "      <td id=\"T_c7847_row1_col4\" class=\"data row1 col4\" >0.10</td>\n",
+       "      <td id=\"T_c7847_row1_col5\" class=\"data row1 col5\" >1.04</td>\n",
+       "      <td id=\"T_c7847_row1_col6\" class=\"data row1 col6\" >3.12</td>\n",
+       "      <td id=\"T_c7847_row1_col7\" class=\"data row1 col7\" >5.41</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c7847_level0_row2\" class=\"row_heading level0 row2\" >10Y minus 2Y Treasury (percentage points)</th>\n",
+       "      <td id=\"T_c7847_row2_col0\" class=\"data row2 col0\" >276.00</td>\n",
+       "      <td id=\"T_c7847_row2_col1\" class=\"data row2 col1\" >1.06</td>\n",
+       "      <td id=\"T_c7847_row2_col2\" class=\"data row2 col2\" >0.97</td>\n",
+       "      <td id=\"T_c7847_row2_col3\" class=\"data row2 col3\" >-1.06</td>\n",
+       "      <td id=\"T_c7847_row2_col4\" class=\"data row2 col4\" >0.24</td>\n",
+       "      <td id=\"T_c7847_row2_col5\" class=\"data row2 col5\" >1.00</td>\n",
+       "      <td id=\"T_c7847_row2_col6\" class=\"data row2 col6\" >1.88</td>\n",
+       "      <td id=\"T_c7847_row2_col7\" class=\"data row2 col7\" >2.84</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_c7847_level0_row3\" class=\"row_heading level0 row3\" >CPI, change over 12 months (%)</th>\n",
+       "      <td id=\"T_c7847_row3_col0\" class=\"data row3 col0\" >276.00</td>\n",
+       "      <td id=\"T_c7847_row3_col1\" class=\"data row3 col1\" >2.58</td>\n",
+       "      <td id=\"T_c7847_row3_col2\" class=\"data row3 col2\" >1.81</td>\n",
+       "      <td id=\"T_c7847_row3_col3\" class=\"data row3 col3\" >-1.96</td>\n",
+       "      <td id=\"T_c7847_row3_col4\" class=\"data row3 col4\" >1.63</td>\n",
+       "      <td id=\"T_c7847_row3_col5\" class=\"data row3 col5\" >2.32</td>\n",
+       "      <td id=\"T_c7847_row3_col6\" class=\"data row3 col6\" >3.25</td>\n",
+       "      <td id=\"T_c7847_row3_col7\" class=\"data row3 col7\" >8.98</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7dbe0e277620>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "UNITS = {\n",
     "    \"unrate\": \"Unemployment rate (%)\",\n",
@@ -392,8 +954,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dc9b348",
-   "metadata": {},
+   "id": "9dba6d4b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007441,
+     "end_time": "2026-09-08T23:42:30.633426+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.625985+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Fit the mixture\n",
     "\n",
@@ -403,10 +973,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e7c1773b",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 11,
+   "id": "6f0ccad9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:30.646846Z",
+     "iopub.status.busy": "2026-09-08T23:42:30.646611Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.072533Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.072286Z"
+    },
+    "papermill": {
+     "duration": 2.434388,
+     "end_time": "2026-09-08T23:42:33.073031+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:30.638643+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Core model silhouette: 0.327\n"
+     ]
+    }
+   ],
    "source": [
     "gmm_core = GaussianMixture(\n",
     "    n_components=N_REGIMES,\n",
@@ -425,8 +1017,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "178d0518",
-   "metadata": {},
+   "id": "a89bbbb0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009609,
+     "end_time": "2026-09-08T23:42:33.091510+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.081901+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### What the clusters contain\n",
     "\n",
@@ -436,10 +1036,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9f795ee9",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 12,
+   "id": "4bc916e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.120071Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.119934Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.138641Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.138184Z"
+    },
+    "papermill": {
+     "duration": 0.032248,
+     "end_time": "2026-09-08T23:42:33.142487+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.110239+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_a1df2\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_a1df2_level0_col0\" class=\"col_heading level0 col0\" >Unemployment rate (%)</th>\n",
+       "      <th id=\"T_a1df2_level0_col1\" class=\"col_heading level0 col1\" >Fed funds rate (%)</th>\n",
+       "      <th id=\"T_a1df2_level0_col2\" class=\"col_heading level0 col2\" >10Y minus 2Y Treasury (percentage points)</th>\n",
+       "      <th id=\"T_a1df2_level0_col3\" class=\"col_heading level0 col3\" >CPI, change over 12 months (%)</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Cluster</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "      <th class=\"blank col2\" >&nbsp;</th>\n",
+       "      <th class=\"blank col3\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a1df2_level0_row0\" class=\"row_heading level0 row0\" >0</th>\n",
+       "      <td id=\"T_a1df2_row0_col0\" class=\"data row0 col0\" >4.34</td>\n",
+       "      <td id=\"T_a1df2_row0_col1\" class=\"data row0 col1\" >4.62</td>\n",
+       "      <td id=\"T_a1df2_row0_col2\" class=\"data row0 col2\" >0.02</td>\n",
+       "      <td id=\"T_a1df2_row0_col3\" class=\"data row0 col3\" >3.28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a1df2_level0_row1\" class=\"row_heading level0 row1\" >1</th>\n",
+       "      <td id=\"T_a1df2_row1_col0\" class=\"data row1 col0\" >7.85</td>\n",
+       "      <td id=\"T_a1df2_row1_col1\" class=\"data row1 col1\" >0.11</td>\n",
+       "      <td id=\"T_a1df2_row1_col2\" class=\"data row1 col2\" >1.84</td>\n",
+       "      <td id=\"T_a1df2_row1_col3\" class=\"data row1 col3\" >1.47</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a1df2_level0_row2\" class=\"row_heading level0 row2\" >2</th>\n",
+       "      <td id=\"T_a1df2_row2_col0\" class=\"data row2 col0\" >4.19</td>\n",
+       "      <td id=\"T_a1df2_row2_col1\" class=\"data row2 col1\" >1.30</td>\n",
+       "      <td id=\"T_a1df2_row2_col2\" class=\"data row2 col2\" >0.61</td>\n",
+       "      <td id=\"T_a1df2_row2_col3\" class=\"data row2 col3\" >1.91</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a1df2_level0_row3\" class=\"row_heading level0 row3\" >3</th>\n",
+       "      <td id=\"T_a1df2_row3_col0\" class=\"data row3 col0\" >5.18</td>\n",
+       "      <td id=\"T_a1df2_row3_col1\" class=\"data row3 col1\" >1.43</td>\n",
+       "      <td id=\"T_a1df2_row3_col2\" class=\"data row3 col2\" >1.46</td>\n",
+       "      <td id=\"T_a1df2_row3_col3\" class=\"data row3 col3\" >4.39</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7dbe0e2e6e90>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "cluster_means = macro_df.groupby(core_labels).mean()\n",
     "cluster_means.index.name = \"Cluster\"\n",
@@ -448,9 +1125,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "471f9e91",
+   "id": "6ee0197e",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.007265,
+     "end_time": "2026-09-08T23:42:33.160806+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.153541+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### Naming the clusters\n",
@@ -474,9 +1158,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d7df10ab",
-   "metadata": {},
+   "execution_count": 13,
+   "id": "da6bc2d4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.191108Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.190987Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.195198Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.194618Z"
+    },
+    "papermill": {
+     "duration": 0.015455,
+     "end_time": "2026-09-08T23:42:33.195509+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.180054+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def name_clusters(means: pd.DataFrame) -> dict[int, str]:\n",
@@ -501,10 +1199,93 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d3f07436",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 14,
+   "id": "8567f41f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.222920Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.222804Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.247014Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.246751Z"
+    },
+    "papermill": {
+     "duration": 0.04184,
+     "end_time": "2026-09-08T23:42:33.247649+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.205809+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Months</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Cluster</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Tightening</td>\n",
+       "      <td>72</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Recovery</td>\n",
+       "      <td>100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Expansion</td>\n",
+       "      <td>51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Inflation</td>\n",
+       "      <td>53</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               Name  Months\n",
+       "Cluster                    \n",
+       "0        Tightening      72\n",
+       "1          Recovery     100\n",
+       "2         Expansion      51\n",
+       "3         Inflation      53"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "cluster_names = name_clusters(cluster_means)\n",
     "if len(set(cluster_names.values())) != len(cluster_names):\n",
@@ -522,8 +1303,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18dadf23",
-   "metadata": {},
+   "id": "1e9a8541",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019575,
+     "end_time": "2026-09-08T23:42:33.279667+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.260092+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Do the regimes correspond to anything the market did?\n",
     "\n",
@@ -539,10 +1328,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ebbe642a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 15,
+   "id": "8ad09190",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.314434Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.314316Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.350739Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.349755Z"
+    },
+    "papermill": {
+     "duration": 0.050652,
+     "end_time": "2026-09-08T23:42:33.351199+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.300547+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aligned 276 months of S&P 500 closes to the macro panel\n"
+     ]
+    }
+   ],
    "source": [
     "sp500 = load_sp500_index().to_pandas()\n",
     "sp500[DATE_COL] = pd.to_datetime(sp500[DATE_COL])\n",
@@ -560,8 +1371,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4bc80a76",
-   "metadata": {},
+   "id": "4b7135c9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007068,
+     "end_time": "2026-09-08T23:42:33.367649+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.360581+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Two statistics per regime, and what each one is\n",
     "\n",
@@ -580,10 +1399,81 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c5c99d2c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 16,
+   "id": "1db3be9d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.382082Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.381883Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.401607Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.398553Z"
+    },
+    "papermill": {
+     "duration": 0.027963,
+     "end_time": "2026-09-08T23:42:33.402261+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.374298+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_7e4ee\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_7e4ee_level0_col0\" class=\"col_heading level0 col0\" >Months</th>\n",
+       "      <th id=\"T_7e4ee_level0_col1\" class=\"col_heading level0 col1\" >Annualized volatility (%)</th>\n",
+       "      <th id=\"T_7e4ee_level0_col2\" class=\"col_heading level0 col2\" >Deepest index drawdown reached (%)</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >regime</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "      <th class=\"blank col2\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_7e4ee_level0_row0\" class=\"row_heading level0 row0\" >Tightening</th>\n",
+       "      <td id=\"T_7e4ee_row0_col0\" class=\"data row0 col0\" >72</td>\n",
+       "      <td id=\"T_7e4ee_row0_col1\" class=\"data row0 col1\" >10.4</td>\n",
+       "      <td id=\"T_7e4ee_row0_col2\" class=\"data row0 col2\" >19.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_7e4ee_level0_row1\" class=\"row_heading level0 row1\" >Expansion</th>\n",
+       "      <td id=\"T_7e4ee_row1_col0\" class=\"data row1 col0\" >51</td>\n",
+       "      <td id=\"T_7e4ee_row1_col1\" class=\"data row1 col1\" >12.2</td>\n",
+       "      <td id=\"T_7e4ee_row1_col2\" class=\"data row1 col2\" >14.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_7e4ee_level0_row2\" class=\"row_heading level0 row2\" >Recovery</th>\n",
+       "      <td id=\"T_7e4ee_row2_col0\" class=\"data row2 col0\" >100</td>\n",
+       "      <td id=\"T_7e4ee_row2_col1\" class=\"data row2 col1\" >15.7</td>\n",
+       "      <td id=\"T_7e4ee_row2_col2\" class=\"data row2 col2\" >52.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_7e4ee_level0_row3\" class=\"row_heading level0 row3\" >Inflation</th>\n",
+       "      <td id=\"T_7e4ee_row3_col0\" class=\"data row3 col0\" >53</td>\n",
+       "      <td id=\"T_7e4ee_row3_col1\" class=\"data row3 col1\" >17.7</td>\n",
+       "      <td id=\"T_7e4ee_row3_col2\" class=\"data row3 col2\" >42.2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7dbe0c0b0690>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "aligned[\"regime\"] = regime_name.to_numpy()\n",
     "aligned[\"drawdown\"] = aligned[\"close\"] / aligned[\"close\"].cummax() - 1\n",
@@ -611,8 +1501,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1e73691",
-   "metadata": {},
+   "id": "35c4ebb9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006797,
+     "end_time": "2026-09-08T23:42:33.416267+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.409470+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### The regime panel\n",
     "\n",
@@ -624,9 +1522,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a3adf24e",
-   "metadata": {},
+   "execution_count": 17,
+   "id": "024828f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.431367Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.431176Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.439888Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.439307Z"
+    },
+    "papermill": {
+     "duration": 0.020957,
+     "end_time": "2026-09-08T23:42:33.443057+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.422100+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "EVENTS = {2008: \"Global financial crisis\", 2020: \"COVID-19\", 2022: \"Inflation\"}\n",
@@ -635,9 +1547,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2b231ddc",
-   "metadata": {},
+   "execution_count": 18,
+   "id": "d260f07f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.459402Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.458715Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.463516Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.462874Z"
+    },
+    "papermill": {
+     "duration": 0.012393,
+     "end_time": "2026-09-08T23:42:33.464416+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.452023+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def year_ticks(dates: pd.DatetimeIndex, every: int) -> tuple[list[int], list[str]]:\n",
@@ -649,9 +1575,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "71035622",
-   "metadata": {},
+   "execution_count": 19,
+   "id": "b178fd97",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.484562Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.484390Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.487968Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.487640Z"
+    },
+    "papermill": {
+     "duration": 0.011603,
+     "end_time": "2026-09-08T23:42:33.488886+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.477283+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def draw_regime_row(ax, occupied: np.ndarray, colour: str, label: str) -> None:\n",
@@ -666,9 +1606,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b8e794c1",
-   "metadata": {},
+   "execution_count": 20,
+   "id": "e39c9b58",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.510553Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.510385Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.517760Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.517359Z"
+    },
+    "papermill": {
+     "duration": 0.02573,
+     "end_time": "2026-09-08T23:42:33.520379+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.494649+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def draw_stat_bar(ax, value: float, colour: str, limit: float, heading: str | None) -> None:\n",
@@ -684,9 +1638,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "678c5745",
-   "metadata": {},
+   "execution_count": 21,
+   "id": "80bb93ad",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.533336Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.533160Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.539538Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.538609Z"
+    },
+    "papermill": {
+     "duration": 0.013648,
+     "end_time": "2026-09-08T23:42:33.540045+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.526397+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def mark_events(ax, dates: pd.DatetimeIndex, label_them: bool) -> None:\n",
@@ -709,9 +1677,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "32561aa4",
-   "metadata": {},
+   "execution_count": 22,
+   "id": "d4228d24",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.561704Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.561526Z",
+     "iopub.status.idle": "2026-09-08T23:42:33.569356Z",
+     "shell.execute_reply": "2026-09-08T23:42:33.568927Z"
+    },
+    "papermill": {
+     "duration": 0.017598,
+     "end_time": "2026-09-08T23:42:33.570111+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.552513+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def draw_panel_row(fig, grid, i: int, regime: str, first: bool, last: bool) -> None:\n",
@@ -735,10 +1717,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "86800f81",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 23,
+   "id": "6c4d149a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:33.589078Z",
+     "iopub.status.busy": "2026-09-08T23:42:33.588907Z",
+     "iopub.status.idle": "2026-09-08T23:42:34.529831Z",
+     "shell.execute_reply": "2026-09-08T23:42:34.529160Z"
+    },
+    "papermill": {
+     "duration": 0.95459,
+     "end_time": "2026-09-08T23:42:34.532536+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:33.577946+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAHnCAYAAABDvKIJAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAfE9JREFUeJzt3XdgTecfx/H3zRIiQqZEEHvPmrVXbUppa9QeNUtRe+9Vo3aN1iiqpWp1qCpq1oy9t5AtEhk3ub8/Qn5cQYy4xuf1Dzf3nOd8n/Occ+/nnnPuPYbo6CgTIiIiIpLAytIFiIiIiLxuFJBEREREzCggiYiIiJhRQBIRERExY9GAtGzVBvoOm/Jc8/675yBd+455yRU9qnOfUaxe/1eyL+dtEB0dQ4tOAzh15sIrX/bISXOZMnvJK18uxG8jK1b/9lzzmm/HDVr04J+d/wFw6swFWnQaQHR0zEup874X2e/eJs069EtY1y/TgcPHqf1pl5fe7pMkx/Zvqe0kucZF5Fk9d0Dasfsg7XsMo1rDDjTr2I9lqzYQFxf3Mmt7ojIlizBj/ICX2uYNP38atOjxUtt8l9jZ2bJ49hhy5chi6VJeW537jOLA4eMJj5+0HefKkYXFs8dgZ2cLwIY/tjFy0txXUufrYOSkuWz4Y5uly3iqN6VOEXk2Ns8z0+Z/djN55vcM7t2R4kXyc/naDUZOnMtN/0C+7NziZdcoIiIi8ko9c0AymUzMnL+cru2a8H6JwgBk88nIqIHdaNahHx9/WB1vLw9GTppL7hxZ8D1+mv8OHmf14ilERkUzacZ37D1wFK/0bnild3uo7TPnLjF55vecu3iVXNl9GPBlO7zSu3Pg8HHmfLeKejUqMn/Jatq3/AgnR0cmz/qeNYunAvGnJnp3aclPv/7JsZNnKZA3B6MGdiOlvT0AS1etZ+Xq3wgICgEgpX0KenVpSe0PygNwyPckXwwYT3R0DJXrt6VMySKMHNAVgKDgEAaN/oZ9B4+RyduTsYO74+qSDoD9h44z/dtl3PDzp0jBPPTv0Y60To4P9WvkpLlkyZyB8xevsmvfYfLkzMrQrzrx7eKf2bJtD+k9XBk9qDueHq5ER8ewfPUmNm/dzY2b/vem/TxheafOXGDavGWcOXcZTw9XendtRcF8OencZxQNa1dl/R//4HcrkOXfjicgKIQpsxbz36HjpHVypOWn9RL6a15fYmP19azF7Nnvi3O6NPTs1IISRfMDsGvfYabPW8blqzeIizNhZ2fLB5XeZ+CX7anR+HPGDOpO0UJ5mb/kZyIiIokzmfhz6y4yeLozamA31m78m19/24pDqpSM6N+FnNkyP3H8g4JDGTFxDr4nzuDm4kzb5g2oVrH0I/0ICg5l0Ohv2HvgKBk83enfsx05s2Xm8y9HULNqOerXqpQwXYMWPVi/fAaOqR0AmLVgBQFBIQzp83lCe03af0X3Ds0oXbwQ/+45yJxFq/C7FUDeXFnp2akFPpm8HqnhSePXpP1XXLx8nZ6DJmJtZcXaZdM5fPT0Q9vxg85dvELzjv3Z9ftSvlu+lgVLV2OKM/H39r10bvspm7fuemq/AEJCw5643128fJ2vZy3mxOnzpHd35fPWjSlTsggAxthYFi37hXW/b8WAgU8a1KBpo1oA/LrpbxYsXUNkVDTFCuflq+6tcUrz/23/hp8/7XsOY+CXHfh28U9cuXaTBrUr07ntpwDExsbxw08bWL3hL6Iioylbugjd2jfFMbUDPQdOYO8BX/7cuovJM79n3pShZM+aKaHtJ80LULp6c+Z+PYRJM74jV44sDPyyPfsPHWfqnKXc9A+kTMnCRNy9m9CeyWTip1//ZMXqTURGRVOzalk6tf4Ea2urRPcPe/sUAInWed/GP7ez7KcNBASG0LZ5Az7+sDoAdyMjmTF/BX9v30uqlPa0b/ER1SuXAeJfx77s9Bkr1/zOuYtXqFWtHB/Xr86Ebxbie/wMxYvkZ3i/ztjYPPrS/SLbf1K2E/N12qdrq8du6226DaFujQo0qF2F6OgYPmjUkSYNa9KxVWMg/jRatw5NKVWs4BPHBWD97/+weOU6QkLDKFY4Lz07t8DNJR0z5i/nln8gI/rHv0536zuW6JgY5n49BIBJM74nVSp7Orf55KnvDyKJeeZTbP4BQfjdCqRc6fce+ru3lwc+mb04fupcwt++Xfwz5UsXY93yGdjbp2DU5HlERUfz8/dfM2H4l9y+E54w7e2wcL4YMJ76tSqzadVsqlYsxZgp8xOeP3fhCvsOHmPp3LHUrFI20doWLF1Dj8+bs2rRZE6cusCfW3cDsPfAURYt+4Upo79i1aLJeHq4MXF4r4fCQuECuZkyqg/pPVzZsnZBQjgC2LR5B00b1WLt0mlE3L3Lz+s2A3D1+k36jZhKl7ZN2LhyFlkzezNzwYpEa1v+8yZqVyvPT4smc/nqDVp1GUjJYgVYs3QqtrY2LP95IwDW1tbY2dkyccSXrF8xExMmvlv+KwABgcF06zeWSmVLsGHFTAb26oCHm0vCMqbOXUKLT+vxw7xxxMWZ6Dvsa1yc0/LrsumM6N+FmQtW8O+eg4nW9+BYpUhhx9BxM3FMnYpff5jOsK86MXLSXO6ER3A7LJyBo6bT/OM6bFw5i3KlivLZx3UY+GX7RNtdu+lvCuTNwerFUzAYDLTqMggPdxd+/u5rcmTNxLeLf3rq+C/7aQMGg4Ffl33DtDF9yZQhfaLLOnbyHI0/rM665d9QvGh+Bo+ZQVxcHHWqV+CPv3cmTLdj9wFKFM3/0JtD1Yql2bH7ADExRgAuXr5GUPBtihfJx6mzFxkydiZd2zdhw4qZFC+an54Dx3M3MvKRGp40fsu/nUB6D1emjOrDlrULHlr+07RqUp+Wn9ajepUybFm7gEb1qiWpX8AT97uIu5H0GDCe4kXysWHFTLp1aMqQcTM5c+4SAEt/XM/eA758N2MUi2aMZOPm7RzyPUl4eATjpy9kYK8ObFgxg3o1K+HgkOqRugODQvlr2x6+HvUVk0b0YsmP67lyzQ+A1es3s/6Pf5g+th8/LprEnTsRjJ26AIApo7+iUP5c9O3ehi1rFzwUjp42733ffPsD44f2pH+Ptty8FUjvIZP5tGENNq6cSc2q5bgd9v/18Mffu/jxl9+ZPq4/Py6YyOmzlx5at+avZfc9rs6g4FAuXrnOvK+H0LNTc2bOX0HE3fjtZdqcZQQEBLNq4SSmjunLnEU/cu3GrYQ2v1/xKwO+bMesiYP44aeNDB47g67tmrL82wns/u8IO3Ynvg+/yPb/tO0ksXX6pG29eJF8HPI9BcCJ0+fJlCE9B46cAOKD2NXrNymUP+dTx2X77gPMWrCSEf278Ouy6bi5pqPf8KnExsZRvEh+DvqewmQyERNjxO9WANf9/BP2y0NHT1KscL6Eth73/iDyOM8ekAKDsbW1wTH1oy+Grs5pueUflPC4RNH8VK1YCmtrK4KCQ/l3z0G+7NwSx9QOuLs6816hvAnTbt2xl4wZ0lOzallsrK2pX7MSp85cJCo6GgCjMZZeXVqS2iEVVlaJl93i07pkzuiFUxpH8uXJxuWrNwA4d+EyBfLmIHvWTHh7eVDivfycfIYLiRvV/4C8ubJhb5+C9wrlTWh3wx/bKFOyMCWK5sfGxoZPG9Zg977DibZRtUJJ3iucFweHVBQukJsiBfNQrlRRUtjZUaJoAS5duQ6AtbUVTRrWJG0aR85duIyrc1pOnb0IwO9bdpI1szeN63+AnZ0tubL74OH+/4BUs0o5ihbMg5WVFafOXuDi5et0adcEe/sU5M6RhY/rV3/sBecPjtXV6zc5cOQEXds3IYWdHblyZCFXdh+OnTzHDb9bxJlM1KhcFqc0jlStWIoTpx+/Lt8rlJcq5Usm9DNzRi/q1aiInZ0tpYsX4tKV+HX5pPH3cHPhup8/N28F4uHu8thrnMqVLkqhfDlJYWdHqyb1uXz1Btdu3KJy+ZKcOnuRW/6BAGzbdYAq5Us+NG+OrJlwTpc24UV8647/qFSuODY2Nvz621Yqly9JyfcKYGdnS7NGtbG1tWXXviOP1PCk8XvZktKvp+13u/YdxsbGmuYf18HOzjZ+OyhfirWbtgLxQaR9i0Y4p3PCOZ0TtaqWY9e+w9jZ2ZHWKQ3HT57DGBtHyfcKYGNtnWid3Ts0I62TIwXy5sAhVcqEgLRm/V+0avIhGTOkJ7VDKnp0+oy/t+8lJDTsqX1PyrxtmjXAM70bVlZW/PH3TvLmykrtD8pjY2NDiaL5SZc2TcK0q9dv5rOP65DB0x0Hh1Q0qF2ZXQ/syw/uH0nhkColndt8goNDKkoXL0x0TAw3bwUSFR3N+t//oWv7Jjg4pMLby4OypYqy7+DRhHmbf1wHr/TuZMmcAa/0btSrUZEsmTPg4pyWPDmzcvHea4W5F9n+n7adJLZOn7StlyhagEO+JzGZTBw8cpKaVcty8fJ17kZGcvjYKfLmzkZKe/unjssvG/6iUf1q5M6RBXv7FHRu+ykXL1/j9LmLFMqXk9DbYVy7cYvjp8+T1cebnNky4Xv8LKG373Dlmh8F8+VMaOtx7w8ij/PMp9g83FyIiTFyO+zOQ4fTAW75B5Pe3TXhsYtz2oT/37jpj52tLekfeEN/0LUbtzh+6hzVGnZI+Ft0dEzCpwk7O1vSOD75E7fBYEj4fxrH1AlHA94rnI8FS9dw4vR5UqW0Z/e+I3zw1ftJ6zBg4MF2Hbh5KzCh5n/+/Y9/98TXbDKZMJked+eWh2sLvR32wGMHYozxtcbFxTFn0Y/8uXUXObP5YG1tRVRUFADX/W7hkynDY+t8cH1f9/PHzTUd9insEv7mncHjoU+ST5o3NjaOek27J/wtxmikeuX3KVIgN44OqVj3+1bKl36P3/76l3y5sz+2pofHxIEHHsaP0b1+P2n8G9WrRhpHBwaOno5Xene6tP2UrD7ej10mQKqU9tinSMHtsHAyZkhP5fIl+GPrLj6qW5Ujx04xvG+nR+qsVrEUf+/YS8n3CvD3v3vp1r4pEH+qqFD+XA9N6+3lwXW/W5h70vi9bKlS2j+1X0/b7274+ePt5fHQOGXMkJ6DvieIiTHiHxBM/5FTsTLEB4PY2FhqVi2Lra0N86cO47vla/mkTW8+/rA6TT6qmeiHl/tNW1lZ4fjAtn79Zvyy73N3dSZFCjuu+9165DS1uaTM+/DrTwCZvD0f396NW0yds5Rvvl0OxI9j4QL/H/MH20qKB9enU5rUQPw+dPNWILFxcbTuOjhhGqMxljbNPkx03jSOqR/Zh4z31t+TPOv2/7Tt5L4H18OTtvX8ebMTGnaH637+HPQ9QfsWjchxL7wcPPL/IztPHRc//4TTjwAp7Oxwd3Pmul/8Kb2C+XJy0PckgUEh5MudDaMxloNHThAZGUWBPDkeev173PuDyOM8c0BycU5LBk93/t6xjw9rVU74+6Ur17l89Qb5cmdLdD7ndGmJjokhJDTsoU8I93mmd6NQ/lyJfqPnygsm/UwZ0pPew5WxUxcQGhpG4w8/oGjBPI9OaDBgikv6rek8PVz5oPL7jz299Dw2/7Obv3fsY9m88aRKac+GP7axck38V8jTu7uy+79Hj1okxiu9G/4BwURFR5PCLv5F4ur1m3iaXVeQGE8PV+zsbFm/YkbCvA8q8V4BVq/bzLzvf6J08UI0u3dNyot40vgD1KhSlg8qvc/KNb/Rd/gUVi2a/MT2bvkHEhkVRQZPdwDqfFCBKbOXkDmjF0UK5En0dFDVCqXo3Gc0LT+tT2BQCEUK5Emo7dqNmwnTmUwmrt24SZ3qFR5p40njB/FhO+6xIfrJDAYDcWbb59P6lZT97tqNW5hMpoQ3kKvXb+Lp4Y6trQ2uzmkZOaArhQvkTnTe/j3bcSsgiG59x+DqkvahN7On8fKIX68F8uYA4o9OR0VF45U+fsyetK6eNq85F2enh07/m0vv4UbDOlWoWTXx0/dP8ixj6u7mgpWVgWVzxz109Pdle9bt/2nbSWKetK2nsLOjcP5cHD56irMXrpAruw+F8uXikO9Jjp44Q7cOzYCnj4vXve3zvqjoaG4FBCVcH1WiaH6OHj+Df2AwrZrUJybGyPwlPxMbG/vQ6TWR5/HMp9gMBgPdOjRl9sIf+XfPQWJijJy9cIXBY2bwUb1qj30DTu/uQp6cWZi9aCWRkVGcv3iVzQ+cA65YpjjnL1zl53V/EhNj5Mo1P3yPn3n+nj1g36FjpLCzY96UoaxdNp3mjeskOp1LOiduBQRx+eqNhFN7T1L7g/Js2b6HrTv2YYyN5ez5y5y+d+3G8wq9fQej0YjRGMu1G7fYtHlHwnPVKpXmxOnz/LJxS8J6P3z0VKLt5MqeBZ9MXsxasILIqGhOn7vEqrV/0KB2lafWkDFDevLnzs7E6YsIuxNOUEhowumG8PAINm/dzZTRX7Fx5SwG9+740DUZz+tJ479i9W+cu3iFuLg4bGxsHvu7QL7Hz3D1+k3CI+4ybe4yypd+L+FoQoG8ObgbGcXPv/5JlQolE50/c0YvXF3SsmDJz1QqWyLhdEq9GhX565897Dt4lJgYI8t/3kR0dAylixcEwM7WluiY+O3lSeMH8W8I+w8fJzo6htjYR38Ww87W9rH9c07nxKkzF7gTHpEwzdP69bT9rnTxQsTEGFn20waio2P479AxNv+zm3o1KwLwYe0qTJu7jKvXbxIZGcWufYeJuBvJ+YtX+WXjFsIj7mJtZQUYiHrG32tqUKcKi35Yy7UbtwgPj2Dq7CVUKlv8gSNAThzyPUl0dMwjR02eNq+5Cu8XY++Bo+zad5jo6Bg2/LmNm/dOOQE0qF2Zbxf/zOlzl4iJMXLg8HECAoOT1I8n1WnOPoUdNauWY9y0BQQGhXAnPILtuw8kui08qxfZ/p+2nSTmadt68SL52bR5B1kze2Nra0Ohe4Hp2o1b5MuVFXj6uHxYqzKr1v7BqbMXiYyKZvbCH8ns7UXObD4Jyzhx5gJnL1wmT86s5MudjbMXruB74izFiiggyYt5rt9BqvB+MYb17cR3y3+l1iedGTpuJjWrlqVru08fO4/BYGB4vy5cuXaTuk27MW3uUqpWLJXwfFonR6aN7ctf2/ZQ8+NO9BgwnmMnH//J4lkUzJuTq9dvUvvTzlSu3zah/aDg0Iemy5zRi3o1K9Km2xCGjZv91HYzeXsycdiXLF75K9U/6sigMTO4ePnaC9Vao0oZMnh60LBFDyZ+s4gPKv3/21rp3V2ZMvorft20lZofd2L05HnExsYm2o61tRXjhvbkpn8Q9Zp2ZeCo6Xze+mPKliry1BoMBgMjB3QlNi6Oj9v0pkWnAWzZvpeYGCMODqnImzsbH7ftTaV6banWsAOtuw7m8LHTL9TvJ42/Z3pXRk6cS/VGn7N2098M/erzRNsokDc7o7/+lgaffYHJZKJ/z3YP9alO9fIc9D2Z8A2txFSrWJoNf26naoX/b5u5svswvF8Xps5ZSs2PO7Fr32GmjO6b8A2YahVL88NPGwm9HfbE8YP4azjW//YPH7fp/dBRqftqVi3LjG+XJ3qqtkr5UqRxdKBhix78uPb3JPXraftdqpT2TB3Tl93/HaHWJ52ZMnsJw/p2TvhmYctP61KmZGG69R1DvWbdWLnmN0JCb+Pi7MSxk+f4tG0fmnboR+H8uR775YnHaVinKrU/KEeXPqNp1LoXKVPaPzRmTRvV5vDRUzRo0YMjZtvX0+Y1lz1rJvp90ZaJ33xHw5Y9uHDpGoXz//+oWM2qZWnWuBYDR02nxsefM/f7nwi8943Xp3lSnYnp1aUFGTOkp2WXgTRu3YtNf27nTnhEkpb1JC+y/T9tO0nM07b1EkXz89+hYwmnKvPnyc7hY6fJmytrwrfwnjYu5Uq/R6c2nzBo9DfUa9oVv1sBjBvaI+HDS85sPty8FUhGr/TY2tpgb58Cn0xenDl3idw59Xts8mIM0dFRz3e8/w2ycNka7Oxsad64DiaTiaDgUDr3Gc2HtSvTpGFNS5f3Rjlw5AQrft7EuKE9sLKyIjw8gkkzFxMeHsGE4V9aurwn+unXPznke5JRA7tZupSX6m3tl7xc2k5Ens07cS+28xev4nczEP/AYO5GRnH89HlCb4eR/wkXF0viLl66RsjtMC5f9SMmxsiFy9e5cOkqBfPnfPrMFhIXF8elK9dZ9tMG2jZvaOlyXpq3tV/ycmk7EXk+78QRpOt+t5gwfRG+J85gZbDCJ1MGWn5aL0mnm+RhkVHRTJ2zhG3/7uduZBQe7i7Uq1GRTxvWeOzPL1ja3O9W8cvGLbRqUp9PGtSwdDkvzdvaL3m5tJ2IPJ93IiCJiIiIPIvX8yO/iIiIiAUpIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIu+4IWNn0HvI5FeyrA1/bGPSjO8B2Pjndjb+uf252zp97hKd+4x6WaW9sd6v8RmffT6AZh37MWX2EiIjoyxSR4MWPR75W0BgMMMnzHmmdqo17PCSKnoxCkivgQOHj7Ns1YZEnxs5aS4hoWFPnL/X4EkPPZ4yewnLf97IN9/+QFR09EupcfLM75O07MfZe+Ao23buT3K78m47fuocwyfM5qdf/3zsvnFfSGgYC5aufkWVvX1iYoz43QokMCiEiLuRr3TZtaqVo1a1cq90mW8j+xR2LJkzhsWzxmBjY83kWYstXVICV5d0j73B+OvOxtIFvGuMsbHMnL+cu3ejuB12h5af1nvpy7h6/SY9O332Utvs1aXlC81fomj+ZGlXXj6j0cjUOcuIiYkhLDyCFp/U5YefNpAqZUoio6Lo0q4J3y//lcb1q5E5oxebt+4mKiaaLdv2Mnlkb+Yv+Zmr12/ikCol6dKmoW3zhhgMhoT2t+3cz9Q5S1n4zQjOX7zC4pXryJI5A5GR0fTq0gIbGxv27Pflo7rViI6O5sTpC4nWOXLSXAb37khaJ0fdY+wFHDhyglzZfTCZYO9+X3Jl92Hs1AV4e3mw94AvhQvkZlCvDtzw83/s33sPmcyyeeMA6NxnFN3aNyVPzqzM/W4Ve/b7cjvsDh1bNaZaxdIPLXv+kp9JaW9Ps8a1+fzLEUTcjSQoJJR8ubMzfmhPduw+yKwFK4iNi6V10w+pUaUst/wDGT5hDmF3wvHydLfEKnttWVtb8Xmrj2nYogfh4RE4OKRi4bI1/PH3LuxsbRjYqwO5svtw7ORZxk9fRFRUFHU+qMBnn9Rl/pKfCQwK5fLVG9z0D6R10w+p/UF5jLGxTJ29lH0Hj5LGMTUj+nXGzc2Z4eNnc+L0edKldWL0oG7M+HY5fjcDaNFpAJ80rEHtauUBHto+NvyxjdPnLuJ3M5Djp87R7rOPqF+rEjExRiZ8s4ijJ86QzScjMUZjQp/M67cyGBg3bSHfTh3Knv2+bNq8gxH9uyTL+lRAesXW//4PuXNkoXrlMgl/O3D4OACxsXGMn76AuNg4rKyt+Kp7GwCWrlqPf0AwhfLnokHtykyft4yIiEicnZ3o2LLxQ+1v/Xcfl65cZ/vuA/yyYQuTR/ZmwMhp+GTKwPlLV2nbrAFp06ZhwZLV3A67Q82qZcmeJRNjpswnR7bMBAWHMKxvZw4cOcGKnzfh7OxE5zafMnzCbCaP7M2iH37BPyCYOFMc/b5o+0j/Zi9ciX9gMNmzZCJ3Dh9+WreZ9O6uZM2cgVSpUuLh5sKmzTtwc01Hs8a16TtsCpNH9mbWghVY21hTsmgBChfInYwjIE/z66atFMqfk2oVS2MymRg2fjZd2zXB3c2FK9f8+HbxT9SuVp7tuw+QOaMXO/YcoE/XVmzZtjehjU8a1CBPzqzMX/IzBw6f4L3CeROeK//+e/yz87+Exzf8/ImNjQOgW9+xTBrZm93/HeHKNb+EN9TIyCimzV1GZFQ0+fNkI0umDOw/dJy5362iXo2KLPtpIz07ffbI/jNuynw807tx6cp1an9QgZLvFXhFa/HNsW3XfooXzofJZGLbrv3kyu7D8VPn6NnpM7p3bEb9Zt255R8I8Ni/P07FssXp0LIRV6/f5Iv+4x8JSA+a8/UQjLGxtP9iGO1bNCIkNIzZi1Yyf/pwbKyt+bzXSKpWKMXUucuoWLY4jet/wD87/2Plmt9e6vp409na2pDJ25Nrfv4Eh9zm7IUr/DBvHH63Apg883vGDenJmCnzmTL6K5zTOdF78CRqVC0LwO2wO0wb25fQ23do2qEfFcsW58+tu7Czs2XF/AkcOnqKxSvXUb9WJc5fusqqRZPxDwjC1TktI/p34c+tu1g8e8wT6zty7Awzxvfn0tUbDBk7k/q1KrF2099ERNxl2dxxBAaHsn33AQD27Pd9pP7JI/uQPUtG/tq2h182bGFgr/bJti51iu0VO3P+MoXy5+LSlesJp8Lu23vAF08PNwb17oinhxv7DhwFoGmjWgzv15k9+49gMBj47JO6lHivALv3HXmk/YplipM5oxflShVN+FtkVDRtmzfk4w+rs/u/I7i5xIeTooXy8ufWXQBk8HKne4em2FhbExQcysJlaxjevzP9vmhLGkeHhLYa1atG6RKFOH7yHHcjHz4cf/HydQKCQhjS53OaNqoFgKeHK907NE04ghAeHoG1tYE6H5THxto6YV7/wBDy585Oofy5XnQVyws6d/EKBfLmAMBgMBAecRd3NxcAMmZIT1DwbQrkzcHpsxeJuBuJlZUVDg6pEm0rb65sXLxyjV83/c38JT8TevvOo9PkzsbtO3fInjX+k2NUVDTFi+Sjcf0PSGFnC4C9fQpaNalPiaL5+Xv7PooWyouXpxsdW/3/A0Ji+48JqF+zEp3afMo///73yLLfdSaTiZ17DlKkYB6KFsrD7n1HMMbG4uHmQpbMGbBPYYdPJi+CQm4DPPbvj+Pmmo5lP21g9qIfuRUQ9NR6Vq39gyIF85A9S0aOnjhLQGAIn385gnZfDCU49DYhoWEcPHKCejUrAuDp4fbC6+BtFBcXh5WVFXv2+3Li1DladRlEv+FTuRN+l8vXbuB3M4DegyfRputgrl6/yS3/+LHJmysbNjY2uDinxdvLgyvX/Ni735ftu/bTsvNAvp65mNthd/DJ6EVqh1RMnbMEg5XVM92oPF/u7Dg4pCJndh+C720/+w8dp17NSlhZWeHmkg472/j9PrH6ATq0bMSMb5eTM3tmvNIn31FEHUF6xbL5ZMT3+BmqVSzNpw1qsOynjeTK7vPEeawMVsTGxhESGsYNP3+mzllKj06f4ZwuTZKWaTAYsLa2IqV9CqKio9n8z25On7tEs0a12bXvMAA21vGbgr29PVFR0WACA4aH2omMjKL/yGn06dqK7FkzERUVY7Ykk9kc4JzW6aHHJd4rgE8mL76etfih02uDenXgn53/MXvRj3Ru80mS+iXJI6uPN0ePnyW9uysmkwnH1Km45R+YcATJ1TktVlZWuLu5sP73f6hYpvhj2zp64izFiuSjaME8j50me5ZMOKRKRRrH1Lg4p43f/sz4Hj/D2k1/06n1x2z+Z9cz9cfGxgYbG5uXdj3e2+TU2YsEh4bRrW/8p/6IyEj8A4Mfmsba2gqT6dF7mj/4d2Os8ZHnw8Mj6NJnNC0/rUff7q0TPvA9zq2AoPggPW04ACZMvFcoD2MGf/HQdEZjLHfvRpHCzi7pHX2HREVHc/maH17p3cBkommj2jSu/0HC82cvXCGTtyeLZox8aL5d+w499NjGxpoUdnaYTPBFx+aULVXkoefnTB7MPzv/o3PvUQz9qhP582R/pjptrK0Ttp/Y2FgiIu4+OlEi9QP4BwZja2vD3bvJezG6jiC9YvVqVMD3+BkmTF/E9Hk/UKRgbtzdXDh97hLFi+bnxk1/Rk2ay42b/pQoWgCDwcDP6/5k4OjpNGlYE0dHB2Lj4li55reET+P2KezwuxWQ5BrcXJ254efPd8t/wSGVfaLTtPi0HoPGzGDc1AUJn/xsbW1Jk9qB1ev/4ur1m0D8J7iTZ+KvEcmc0Sv+HPXEOY+9aPaPv3eyeOV60jimJlXK+GVH3I1k3LQFnDpzgczenknuhySPejUqcdD3BBOmL2LC9EXUrVGRmQtWMvGbRSxctoZ2n8Vf71OlfEl++GkjpYoVfKSNlWt+Y8L0RVhbW1HE7JTpkpXrOHHqPN8u/ong0DB27z/CwSMnCAm9jZtLuoemvb9vpEubhrCwcJauWk9cXPyLasG8OZk+dxnG2FiARPcfebJtO/fTqkl9Fs8ew+LZY2j1aX1+/OX3Z2ojTZrU+N0MJCQ0jPMXr3LuwlUALl/zw9bWluqVyxAUfPv/AdUAJlPcI+1Mn7uMDi0a4ZAqJQD5cmfjkO8pLl6+BsDNW/Gn8/LmysqOe6dgTp4+/1z9flvFX+O6gnKlipIqpT3Fi+bn101bCQ+PIC4ujlsBQWTKkJ6Q0NsJl3bcX68AN24GYDKZOH/xKgGBwXh7eVC8SD5++vUPYmKMxMQYCQoO5YafPwFBIVQsU5yS7xXE98QZANxdnZ962jUxeXNnY8eegwnLjoyKDz6J1W8ymZjx7XImDu/FuYtXOHX24ouvuMcwREdHPfrRQERE3nqffT6AUQO7kjmjFwCXrlynaYe+ZPb24odvxwP/v+g6bRrHx16MPW3uUv7cuotS7xUkMiqaZo1rkz1LJoaOm8nV6zcpWigv/+45yKpFkzl/8Sp9h09h/rRhrFr7Bynt49/IW3UZRDafjBgM8R+8xg+Lv0h79sKVWFtbUSBvDvp0a835i1cZNmE2NtZWFCucj6MnzzJr4iCLrcPXwfs1PiObT0ZiY2MpXjQfndp8in0KO0wmE98tX8umzTuwt09B4/ofULd6BY6eOMukGd8RGxtHBi93Rg/szqIf1nDI9xRR0dFERETSp1srChfIjTE2lmlzlrL3gC8p7e3p0LIRHu4uTJm1hKDgUJzSpGb04O44p3ViwdI1rPttK599UoeP6lYDHr1I+8TpC/TuGn/2oHL9tmxZu4Dw8AiGjJvFTf9A8ufJzt79R1m9eEqi9TumTsX2XQcY3Lsjh4+dZs6iH5k1ceBDXwR5WRSQRERE3nEPfqNQ4ukUm4iIiIgZHUESERERMaMjSCIiIiJmFJBEROSpGrTo8dTbHj14L64H77PWuc8oTtz7xtnwCbMJuPdTAp37jOKGn3/yFPyO6jtsSsI31F6msDvhid5r7W2m30ESEZGX7nH3WBv6VadXXInI89ERJBGRd1TvIZM5cuw0EP+L+41afcmxk2dp020IzTr04+tZixN+Z+pBc79bRZtuQ2jU6suEX+Nv32M4AYHBtOg0gL37fZm/5OdEbzR8/0jU9Hk/4Hv8DF8Onsj3K36lTbfBXLtxCwC/WwF0/HJEMvb87bJq7R80bt2Lrn3HJPxG3WefD2DWwpV07TsGo9HIuGkLaNNtMB+36c2Bw8eJjo6h1iediY2Nw2g0UqleW/47dAyAQaO/wff4Ge6ER9B32BSadezHxG8WJSzPGBvL17MW06xDP9p0G8Kxk+cAaNTqS4JCQgH4uE1v1v3+DwAz56/gj793suGPbUyZvZi+w6ZQt0lX1m78+1WupmemgCQi8o6qWKYY/+45CMD+Q8coUbQAA0d9Q/8ebVk6dywBgcFs+H3bo/OVLc6C6cOZMvorZi/8EYAR/Trj6pKOxbPHUCIJ97zr3qEpri7p+HpkH1p+Wo86H1Tgj793ArB91wGqlC/5Env69jp74Qqr1v7Bwm9GMHlkb+ztUwBw/tIVvL08mDF+ADY2NjSoVZmF34ykd5eWLFi6Bjs7W7L5ZOTcxSucPneJnNkzJ4TlM+cvkTtHFhb98AsZvDxYNncczT+um7DMXzdt5VZAEEvnjmXAl+0ZPGYGRqORooXy4Hv8DEEhoTinTZPQnu/x0xS+dxupI8fOMKRPR8YP68mSH9e94rX1bBSQRETeUeVKF2X3/vh7Ov675xCZM3pib5+CHNkyYzAYqFaxNHsO+D4y37PeYy0pqlUqzT///ofJZGL7rgNUKlfipbT7tjt45ASVyhbHMbUDKezscHVOC8Tf+aBu9QoJ06VJ48iCpatZ+cvvCXdeKFooD0eOnebIsTPUq1GRI8dOc/NWIG6uztja2rD/0HE+rFUJiL+v5n3/HTxK1fKlMBgMZM+SkZQpU3D5qh9FC8a353v8DJXKleDchSvExBgJuxORcD/HxO7F9rpSQBIReUc5pXHEydGRG37+HD1xhvcK5+NpP0h8/x5rrs5p6du9NSnvHbF4UY6pHciSOQMHfU8SZ4p75LYzkjhjbCwRdyMf+buVwZDw69LX/W7x5aAJ5Miama+6tSbu3j3QihbMw9ETZzh64gylixciOPQ2R46fTrg9UGxsXKJtm0zwyI03gSIF8nD0xFl8j58hf57spHZIxb6DR8mTM8sj0z54L7bXlQKSiMg7rGKZYvzw80ZyZstMZm9P7t6N4uz5y5hMJv78ZzfFi+QD4m9eHWeKe+w91tKlTUN4eATR0eY3sb43b9yjb4Yers4PHYGqW70CE79Z9MQbIMvD8uXKxt4DvkRFRxN2J5wr1/wemebkmYtk8vak/PvvcfnajYS/58mZlctX/Qi9fQfndE5kzezNn3/vonD++ICUL3c2tu+Kv+/didMXEuYrXiQff/2zB5PJxLmLV4iIuEvGDOnxcHfhbmQU5y5cIWc2H/LlycYvG7ZQ2Ox+jG8KBSQRkXdYhTLF+GXjFiqULY6trQ2jBnZjzJRvad6xP85pnahboyIAJd8rwOp1m8meJRPenu607DyQtZv+xuPeqRN7+xRUKluCph36snXHvoeWUbxIfn7ZuOWRZdeuXoFBo79h3vc/AVCkYB5uh4VTqawCUlIVyJuD8qWL8dnnAxgxcQ7pHzgVdt97hfISERFJm26DOXLsDClTxB/1s7OzxTF1KlycneLbypODPQd8yZc7GwBtmjdg/6FjtOwykP8OHsXO1haAerUq4eKcluYd+zN68jxGDuiGrW38l+Jz5/AhMioaW1sbCubNyb97D76xAUm/pC0iIq+FA4ePs2bDFkYO6GrpUkT0O0giImJ5sxasYOe+w4wf2tPSpYgAOoIkIiIi8ghdgyQiIiJiRgFJRERExIwCkoiIiIgZBaR7TCYTRqPxtf/hKhGRl0GveW8+jWHy0rfY7omNjaVc7VZs3/AdNjbJt1o2bD1EQHBYsrV/n30KWyKjHv3Btge5pnOketn8bNm+l8rlSiRrv+XdYDQak317etZlvKp9LjFP2w9bNkj8jvevwqt6zZPkozFMXlqjr9idiEhiYh69O/bLFhVtxOop9wy4E/HoT8iLvG1e1T6XmKTshyLyetIpNhEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiY0c1qRUTeYfNX/YOVlWU/K3f4pJJFl/+mS64xfNfHRUeQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhINSIt++IUWnQbQpP1XlKn5GS06DaBFpwEsXLaG4RNmP7XRBi16cPrcpUSf69xnFDf8/F+o6OETZnPu4pUXakNERF4/y1dvom6TrixbtQGAkNAwuvUdS7MO/Vi6aj0A/oHBtOwykCbtv+L8xasAhN0JZ/q8HyxW99vOfFxOnblA88/706xjP9Zs+AuAiLuRdO4zikatvuTA4eMAGGNjGT9tocXqfhE2if2xddMPad30Q274+dOi80AWzx7zqut6oqFfdbJ0CSIikgyKFsjN2fOXEx4vXLaGCmWK8WGtSrTsMojypd/jz627adKwJundXVmxZhMDerbn53Wb+ahuVQtW/nYzH5fx0xfRt3sbcmTNRMsugyheJD9Hjp2meJH81KpajlGT51G0UF5+3/Iv1Su/b8HKn1+iAelxTp+7RN/hU1izeCpGo5Hx0xfx36FjBAWFkiKFLXlyZmXa2H4AbN91gOlzl3H2wmU6tf6E+rUqMXLSXHyPn+HLwRPJmysbg3t35OiJs3w9azHhEXfx9HBlSJ/PcU7nROc+o6hSviTbdu7nzLnLfFSvKm2bNwSgRacB9Pi8OUUL5X3idKvW/sHynzcRHnGX8Ii7ZM2cgQnDvyS9u+tLXo0iIvIy5MqRBU+P/79G79x7iHo1K2FjY0OBPDnYte8w/oFBVHj/PTw9XLnlH8Sd8Ahuh4WTwdPdgpW/3czHxe9WAPnzZMdgMFC2VBH+3XOQyKhosmfJiIe7C5FRURhjYzl6/Cy1q5W3YOXP75kC0oO2bN/LidPnWbVwEkHBoTT/fADjh/Z8YAoT34zvz47dB5gwfRH1a1VicO+OHDhygq9H9sEzvRthd8IZ8/W3TBn9FR7uLqzZ8Bffr1hLz04tADh19iKTR/Xh4qVrtOoyiGaNamNvn+KRWhKb7k54BN98+wM/LZqMczonWnUdTM/OLRSORETeIEHBoXh7eQCQyduTgMAQvNK7cejoKfxuBZLB053V6zdTq2pZxk1dQHRMDF3bNcE5nZOFK3+7pU3jyInT58ns7cmpsxcByJ0jC4eOnsLL0x3H1A78+fcuqlQoyfS5ywgICqbdZx+RydvTsoU/g+e+SNvDzYXIyCgi7kYRHBpGbGwsBitDwvPlSr+HwWAgf54cBASFJNrG0RNnuRkQSJ+hk2nRaQA/rf2TwKDQhOfLlCyCjbU12bJkxNbWluDQsETbSWy61A6psE+RguDQMCLuRhEZGYUh0blFROR1ZTAYwGQCIM4Uh8HKQP2aldi2cz/fr/iVD2tVJiT0DvsOHaNwgVzUq1GRxSvXWbjqt1+f7q2ZMH0Rg8fOJHuWTKR2SEWF94tx42YAwyfMoW3zBvgeP8Od8AgcHR3o0rYJMxessHTZz+S5jyDlzZUNB4eU9Bo8kZgYI8P7dSGFnd2jC7CxfmwbJpMJby8Pvp85+onLMhgM8e3c20mSMp29fQoqli3G+GkLiYqKpk71ChTKnytpnRMRkdeCczonrl6/Sfasmbhy1Y/sWTPhlMaR6ePiL+dYsnIdDetUYemq9RQv8gGe7i58t3ythat++xUpkJvvZo4CYNKM7/FK74adnS1jBnUH4Pct/1K1Yil8j58he9ZMeLi7EBxy25IlP7PnDkhHT54lnVMapo7p+0zzpXd35cZNfzzTu5Evd3Zu3gpky/a9VC5XgvCIu0RHx5AubZrnLSuBMTaWrTv2sXHlLGxsnrubIiJiQWVKFuGg70l8Mnlx9MRZPvukbsJz4RF3CQ4Nw9vLA1fntJw6e4Hbt8NwdUlnwYrfDecuXsEnYwYCAoPZe8CXzm0/SXguNjaOI8dO06dba274+XP67EWy+2TEztbWghU/u+dODlkze3P81Hk+bfcVdrY2uLk6U7p4IRrVq/bE+T6sVZnBY2dStGAeRg7oysThvZg2dykLlqwmRQpburRtwnuF8z5vWQlsrK3Jmtmbj9v0IbVDShxTO5ArRxY6tmqU6JEuERGxLP/AYHoNmkhgcChWBgO7/jvM6IHdGTxmBr9s2EKd6uUTrkcCWLPhLxrUrgxAvZqV6D14EtExRkYN7GapLryVEhuXUsUKMnTcLKysrOjbvQ2pUtonTP/Xtt1UKV8SgIpli9Nr0EQ2bd5Bvx5tLdWF52KIjo568nmrx1i4bA12drY0b1yHuLg4/ty6m2lzl7Jx5ayXXeNzOeh7kqU/rmfSiF4AXL1+k+af9+f7maPwyZThkemNRiPlardi+4bvkvWI08qNuwm7E5ls7d8XZzJhZXjyVVeOqe356INiCUfwdKRNXpTRaEz27elZl/Gq9rnEPG0/bPdxxVdXjJn7r3ktW7XGysqyvxnc4ZNKFl3+myq5x/BdH5fnfgUr+V4BZi/8kT/+3kVMTAzOaZ0Szj2+DjJn9MTO1pbWXQcTYzRibW1Nr84tEg1HIiIiIg967oCUL3d2ZkwY8DJreamc0zoxdsgXli5DRERE3kC6F5uIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYsbG0gWIiIjltGtcARsbvRW8yTSGyUNHkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRne3u8dkMgFgNBqTdTmxsbHExcUl6zIA4kwmMBieWovRaEz4V+RFvYrt6VmX8ar2ucQ8bT80Go1YW1tjeMq+mhxe1Wveu0Bj+OZLbAwN0dFRJgvV81qJjIykUv12li5DRN4x2zd8Z5E7ses17+XRGL75EhtDHUG6x87Ojr/XzrfYJwEReTdZW1tbZLl2dnZk8k7P0jlj3+nXvOaf92fpnLEv1IbGMPm9jHF6ksTGUAHpHisrK+zt7S1dhojIK2FlZYWVlRW2traWLsWiDAaDRY7+vAzv0hhaYpx0kbaIiIiIGQUkEZF31Ed1q1m6BIt709fBm15/Ulmin7pIW0RERMSMjiCJiIiImFFAEhERETGjgCQiIiJi5s38bqOIiDy3XzZuYdXaP0jtkIqR/bvg7uZi6ZJeidth4YybtoArV/1wSpOaEf27YGVlxeAxMwgKDqVmtbI0b1zH0mUm2ds8jmVqfkY2n4wAFMqfiy7tmjBiwmwuXblB8aL5+aJjs2T/7ScdQRIReYcEBYeyZOU6FkwbTqN61Zi5YKWlS3pljp44Q+P6H7Bkzhhy5fBh2U8bWLhsDRXKFOP7WaPYtHkHl6/esHSZSfK2j6ObizOLZ49h8ewx9OrSkjXrN+OZ3o2lc8dy8fI19h04muw1KCCJiLxD9uz3JWc2H+ztU1C4QG527Ttk6ZJemfdLFKZIgdwAFMibA/+AYHbuPUThArmxsbGhQJ4c7Np32MJVJs3bPo5OTqkfevzvvXEyGAwULpCbna9gnBSQRETeIYFBIWTyTg+Aq3NaYuPiiIyKtnBVr97+Q8cpmC8nQcGheHt5AJDJ25OAwBDLFpZEb/s4BgaF0L7HcNr3GMbhY6cJDAohs7cnAJm9PQkIDE72GhSQRETeJYb/3wUewBRn4i2/jdcjzl28wr6Dx6hbo0L8dSz31kecKQ6D1RuyMt7ycRw96AtmTOhPo3rVGDZ+FgYMxMXdHycTVq9gnBSQRETeIW4u6bh8zQ8A/8BgbG1tSWFnZ+GqXp3gkNsMHTeLUQO7kcLODud0Tly9fhOAK1f9cHNJZ+EKk+ZtH8dC+XKSws6OahVLc+dOBK4u6bhyLf76sCtX/XB1Tv5xUkASEXmHlChagDPnLhEZGcXBIyd5v0RhS5f0ykRHxzBg5DTat/iI7FnivyFVpmQRDvqexGg0cvTEWUoXL2ThKpPmbR7Hf/cc5Mq98Lf/8HHcXZ0pU7IwB4+cxGQycejoSd4vWTjZ69CtRkRE3jHrfv+HFas34eiQipEDu70xR01e1IKla1i2aj0+mbwwGmMBmDyqDyMnziUwKIQ61cvT5KNaFq4y6d7Wcbxw6RrT5i7lln8QtnY2DOjZHp9MXoyYMIeLl69TslhBurVvkuxf81dAEhERETGjU2wiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQ7jGZTBiNRkwmk6VLERFJdnrNe/NpDJOXjaULeF3ExsZSrnYrtm/4Dhubd2e1GI1GtmzfS+VyJd6pfr+Oziz8gojrp15aezYOThjDQ19ae0kRGwcHAuwo6hqNo3cucrSZ9tKXoW325XhXX/PeJhrD5KU1KvKaiA71IzYq4qW1F3v3Nli92l08Ng7ijBAbFUF0qN8rXbaIyMukU2wiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOb1YqIvMMODi6P9Wv4Ubno6J2WLuGN8SJjqPX8eK/hbiEiIiJiWQpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIiZpwakBi168Enb3rToNIAWnQbw5aCJr6Kux/rv0DGmz/vBojWIiMirtXz1Juo26cqyVRsA+HPrLtp9MZTGrXvxy8YtAPgHBtOyy0CatP+K8xevAhB2J1zvGc/AfD3fN/GbRXTuMwp4d9azTVImGjmgGzmzZU7uWpKkWOF8FCucz9JliIjIK1S0QG7Onr8MQGxsHJev3mDWxEHcjYykYcueVC5Xkl83baVJw5qkd3dlxZpNDOjZnp/XbeajulUtXP2b48H1fN/ZC1c4evIsDqlSArwz6zlJAelBJpOJL/qPp3qV96ldrTyLV/7KTf8g+nRtRec+oyiULxeHj53iln8Q5Uu/R7cOTTEYDCxbtYG/tu3hbmQkXundGNG/Kw6pUjJ/yc9ERkVz/cYtTpy5QNbM3owf2gMbGxt+Xvcny1ZtxNbWmlLFCtHj8+Zs27WflWt+Y9bEQQCs+/0fVqzeBCbIkzMLPTp9RmqHVGz4YxsHfU9iMpnwPX6GtE6OTBrRmzSODi99JYqISPLKlSMLnh6uAFhbW9G2eUMA7Oxs8fJwJyT0Nv6BQVR4/z08PVy55R/EnfAIboeFk8HT3ZKlv1EeXM8Q/57/zbxltGnWgJVrfgN4Z9Zzkq5BGjzmm4RTbIeOnqLvF22Yv/hnrlzzY8Mf2/i8VeOEae9GRvHNuAEsnj2Gf3b+x659hwEoWigP86YM4Yd544mNjeO3v3YkzLP/0HG+6t6G5fPGc/rcJfYfPgHArIUrGTO4O8vmjafJRzUxGAwP1XXI9yTfL1/LjPEDWDp3LClT2jPj2+X/b/fwcdo2b8AP88ZhNMayZfue519TIiLy2gkIDCbsTjgZPD3wSu/GoaOnOOh7igye7qxev5laVcsybuoCRkycQ1BwqKXLfeNs27WfDJ4e5Mz6/7NI78p6TlJAGjmgG4tnj2Hx7DEUKZCbDJ7uNKxTlfY9htH+s0Y4pv7/UZkiBXNjbW1FqpT2FCucj6MnzgKQyduT3/76lzFT5nP1+k2uXr+ZME/BfDlJ6+SIvX0KcmbLREBQMAAf1a3G5Jnfs33nftxcnB+pa8eeg1SrVJp0adNgMBj4+MPqbNu1P+H5nFkz45XeHRsbG/LkykpgUMhzrSQREXn9mEwmps/7gdZNP8Ta2or6NSuxbed+vl/xKx/WqkxI6B32HTpG4QK5qFejIotXrrN0yW+U6OgYFq9YR8dWjR76+7uynp/7W2wXr1wnjWNqwiPuPnYaGxtrUtqn4G5kJO2+GErYnXCaN65N9cpliIszJT6PtQ3ce6pzm08Y0a8Lew740rrbYKKjY55Yk8FgeOQo0//btcZkSnyZIiLy5vnhp43Y2tpQr2ZFAJzSODJ9XD++nTqU3f8doWGdKly6cp3sWTOTI2smLl6+ZtmC3zCHj53idtgdeg2eRN8RUzl19iJTZi95Z9bzcwWkfQePcv3GLWZOHMiiH37hln9gwnNXrvlhMpm4FRDEPzv/o2Sxgly+coOQ0DAa1/8AD3dXzpy79NRlREVH43v8DJ7p3ejWrgkXL1975AhQ2ZJF+PPvXYSEhmEymVi19nfKlSr6PF0SEZE3yPbdB9i2az9fdW/9yAfj8Ii7BIeG4e3lgatzWk6dvcCpsxdxdUlnoWrfTMWL5GfVosnMnzac8UN6kCu7Dz07fZbw/Nu+npN0kfbgMd+Qws4OiA8uYGDkgK64uaSjxSd1GT99EZNG9ALA99gZ2u8YRtidcDq2+pic2TJjNBp5v0RhmnXsT2ZvTzJ4uT/2CNJ9kZFRrF7/F5NmfsftsHCaN65Deg9XTp//f7gqXCA3LZvUp8tXo8EEuXNm4csHBk9ERN58/oHB9Bo0kcDgUKwMBnbuPcSJ0+dxd3OhfY/hYDJRs2pZmnxUC4A1G/6iQe3KANSrWYnegycRHWNk1MBuluzGa898Pe/67zAzxg947PRv+3o2REdHvbTzTp37jOKTBjWo8H6xl9XkK2M0GilXuxXbN3yHjc0zf7nvjWU0GtmyfS+Vy5V4p/r9Ojo25ROigm68vAbjjGD1asc0Ng4OBqeiSLoIUrl6kq/nype+DG2zL8f917zpRc9j/Rr+ZHDR0TstXcJr72WModbz472Gu4WIiIiIZb3Uj1/3f5tIRERE5E2mI0giIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjI2lCxAREcspMnIbNjZ6K3iTaQyTh44giYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSM7m53j8lkAsBoNFq4klfLaDQSGxv7zvX7dWSMg9i4l9jgy2wriWLjIM4U/68xLnn2p7dtm7W2tsZgMLzy5b6rr3nJQWP45ktsDA3R0VEmC9XzWomMjKRS/XaWLkNE3jHbN3xnkTux6zXv5dEYvvkSG0MdQbrHzs6Ov9fOt9gnARF5N1lbW1tkuXZ2dmTyTs/SOWPf6de85p/3Z+mcsS/UhsYw+b2McXqSxMZQAekeKysr7O3tLV2GiMgrYWVlhZWVFba2tpYuxaIMBoNFjv68DO/SGFpinHSRtoiIiIgZBSQRkXfUR3WrWboEi3vT18GbXn9SWaKfukhbRERExIyOIImIiIiYUUASERERMaOAJCIiImLmzfxuo4iIPLdfNm5h1do/SO2QipH9u+Du5mLpkl6J22HhjJu2gCtX/XBKk5oR/btgZWXF4DEzCAoOpWa1sjRvXMfSZSbZ2zyOZWp+RjafjAAUyp+LLu2aMGLCbC5duUHxovn5omOzZP/tJx1BEhF5hwQFh7Jk5ToWTBtOo3rVmLlgpaVLemWOnjhD4/ofsGTOGHLl8GHZTxtYuGwNFcoU4/tZo9i0eQeXr96wdJlJ8raPo5uLM4tnj2Hx7DH06tKSNes345nejaVzx3Lx8jX2HTia7DUoIImIvEP27PclZzYf7O1TULhAbnbtO2Tpkl6Z90sUpkiB3AAUyJsD/4Bgdu49ROECubGxsaFAnhzs2nfYwlUmzds+jk5OqR96/O+9cTIYDBQukJudr2CcFJBERN4hgUEhZPJOD4Crc1pi4+KIjIq2cFWv3v5DxymYLydBwaF4e3kAkMnbk4DAEMsWlkRv+zgGBoXQvsdw2vcYxuFjpwkMCiGztycAmb09CQgMTvYaFJBERN4lhv/fBR7AFGfiLb+N1yPOXbzCvoPHqFujQvx1LPfWR5wpDoPVG7Iy3vJxHD3oC2ZM6E+jetUYNn4WBgzExd0fJxNWr2CcFJBERN4hbi7puHzNDwD/wGBsbW1JYWdn4apeneCQ2wwdN4tRA7uRws4O53ROXL1+E4ArV/1wc0ln4QqT5m0fx0L5cpLCzo5qFUtz504Eri7puHIt/vqwK1f9cHVO/nFSQBIReYeUKFqAM+cuERkZxcEjJ3m/RGFLl/TKREfHMGDkNNq3+IjsWeK/IVWmZBEO+p7EaDRy9MRZShcvZOEqk+ZtHsd/9xzkyr3wt//wcdxdnSlTsjAHj5zEZDJx6OhJ3i9ZONnr0K1GRETeMet+/4cVqzfh6JCKkQO7vTFHTV7UgqVrWLZqPT6ZvDAaYwGYPKoPIyfOJTAohDrVy9Pko1oWrjLp3tZxvHDpGtPmLuWWfxC2djYM6Nken0xejJgwh4uXr1OyWEG6tW+S7F/zV0ASERERMaNTbCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJDuMZlMGI1GTCaTpUsREUl2es1782kMk5eNpQt4XcTGxlKudiu2b/gOG5t3Z7UYjUa2bN9L5XIlktTvqzuGExl87qnTWadIQ2zU7ZdR4nOx9PKfpwb7dNnwLjs0GStKfg9uT367RxMT4f9C45DYOnnWbVYS966+5r1NNIbJS2tUnklMhD9xxrtPnS4u5g4YrF9BRa/n8p+nhpgI/2Ss5tWLifAn5s71FxqHt22diMibQ6fYRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGN6sVEXmHnV7zMTaWva/zS5Gz4WpLl2Axb8sYJtWrGmsdQRIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJixed4ZG7TogZ2tDVZWVtwJv0u1CqXo0q4J1tbKXCIiYjnLV2/ih1Ub+LRhTZo1ro3RaGTK7CUcOnoKpzSpGfZVJwxWVvQeMono6BhGD+xOVh9vwu6Es+iHtXTv0NTSXZAkKlPzM7L5ZASgUP5clCian++W/0pI6G2KFMhNv57tiI6OofeQSdzyD2JAz3YULZQXY2wsk2d8T98v2jy27ecOSAAjB3QjZ7bMhN0J58tBE/l9y7/UqlbuRZoUERF5IUUL5Obs+csJj9ds2AIGA0vnjOXKNT/SpXVi8cp1NGlYk/TurqxYs4kBPdvz87rNfFS3qgUrl2fl5uLM4tljEh4f8j3JjAn9sbO1o32PYRz2PcVN/0CKF8lPrarlGDV5HkUL5eX3Lf9SvfL7T2z7hQLSfY6pHSiQJweXr97g6ImzfD1rMeERd/H0cGVIn89xTudEYFAIX89azIVL17C1s+GLDs0oWigvvsfPMH3eMiLuRuKc1oleXVrik8mLNt2G0KnNxxQvkh+AUZPmUqhAbup8UJ7vV/zKps07MJlM1KxaltZNP+SGnz8DR0+nTMkibNu1n8b1PmDnvsOMGdQdgIO+J/l28U/MmjjoZXRZREReU7lyZMHTwzXh8abNOxjerzMGg4FM3p4A+AcGUeH99/D0cOWWfxB3wiO4HRZOBk93S5Utz8HJKfVDjwsXyE1cXByXrtwgOiYGn0xeHD15luxZMuLh7kJkVBTG2FiOHj9L7Wrln9j2SzkfdvNWINt3H8Ankxdjvv6WsYO/YOWCiVQoU4zvV6wFYOSkufhkysCyeeOYPWkwuXNm5XZYOP1GTKXH581ZNnccDetUod+IqcTGxlGzalm2bNsLQEyMkd37j1CpbHH++HsXl65cZ9ncsSybO469B45y6swFAE6dvUgax9R8P3M01SqV5uiJMwQFhwLw+5Z/qf3Bk1eGiIi8ffxuBbD3gC8tuwxk9NffYoyNxSu9G4eOnuKg7ykyeLqzev1malUty7ipCxgxcU7Ce4e83gKDQmjfY3j80aJjpwGYNON7mnboS9OPauHinDZhrM9dvIJjagf+/HsXVSqUZPrcZQwZO4PLV28k2vYLBaTBY76hcetefNapP00a1sQpjSM3AwLpM3QyLToN4Ke1fxIYFErE3Uj+O3Sczz6pi8FgIFVKe1KltOfoiTNk9PIgX+7sAFQqV4KIu3e5cu0GVSuUYseegxhjY9l7wJdC+XKR2iEV23ft59DRU7TpNoS23YfgHxDEjZsBANinSEGjetUASGFnR93qFdnwxzZiYozs+e8IlcqWeJHuiojIGyjibiSpHRxY9M1IgoJD2bZzP/VrVmLbzv18v+JXPqxVmZDQO+w7dIzCBXJRr0ZFFq9cZ+myJQlGD/qCGRP606heNYaNnwXAV91bs3bpNNZs2MK+g0ep8H4xbtwMYPiEObRt3gDf42e4Ex6Bo6MDXdo2YeaCFYm2/cLXIKV3d+Wzz/tTIG8O/AOD8fby4PuZox+aLuJuJJhMWBkMT23TgAEwkC5tGnLn8OHA4RNs2b6XGlXKAGAymWjSsCYff1j9oflu+PljZWWF4YFlNKxThe79x5HVx5v3CuUlVUr7F+muiIi8gVzSOVE4fy6srKwoVjgv12/conK5Ekwf1w+AJSvX0bBOFZauWk/xIh/g6e7Cd8vXWrhqSYpC+XICUK1iaSbN+J7IqGjsU9jh7uZClfIl2bv/KMWL5E+43Ob3Lf9StWIpfI+fIXvWTHi4uxAccjvRtl/4FFsaRwe6tW/K6K+/JXfOLNy8FciW7fGnxsIj7hIccptUKe0pmD8nP/y8EZPJRGRUNLf8A8mfJwdXb9zk2MlzAGz9dx8pU9qTMUN6AGpUKcuW7XvwPX6GUsUKAVC2VFF+/OV3AoNCALjud+uxtbk4pyVXdh/mfreK2tUrvGhXRUTkDVS2VFG27NiLMTaW/w4dJ6uPd8Jz4RF3CQ4Nw9vLA1fntJw6e4FTZy/i6pLOghVLUvy75yBXrvkBsP/wcdxdnVmwZDV3IyOJio5m595DZM7omTB9bGwcR46dpmjBPLg6p+X02Yvc8PPHztY20fZfykXaVSqUZOPm7az//R8mDu/FtLlLWbBkNSlS2NKlbRPeK5yXoX06MeGbRTTt0JeU9va0bd6AMiWLMHZwD6bMXkxkVDRpnRwZN6RHwk8FlC1VhEkzvqNyuRLY2saXWqNKGfwDg+jcZxQp7Oxwc3Vm9MBuj62t5r1zyvdTpoiIvL38A4PpNWgigcGhWBkM7PrvMKMHdmfExDmsXreZ4kXyU7p4oYTp12z4iwa1KwNQr2Yleg+eRHSMkVFPeF+R14NXencmz/yeW/5B2NrZMOSrzzl5+gKde48m5HYYJYrkp0bVsgnT/7VtN1XKlwSgYtni9Bo0kU2bd9CvR9tE2zdER0eZXklPLCAuLo4xX39LwXw5qVez0hOnNRqNlKvdiu0bvsPG5qXkxjeC0Whky/a9VC5XIkn9vvBHV2LCbz69YVMsGKxfQoXPydLLf44abB08yPLBjGQsKPk9uD1d2dKDmDvXX2gcElsnz7rNSuLuv+YtaBeBjYV3lZchZ8PVli7hlXvbxjCpXtVYv7W/6njm3CU+btMbE1BHp9dERETkGby1H79yZMvMT999bekyRERE5A301h5BEhEREXleCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImLGxtIFiIiI5eRs8CM2NnoreJNpDJOHjiCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIzubnePyWQCwGg0WriSV8toNBIbG5vkfhtjTRhjkzChCTC8UGkvxtLLf44aDLGmN377e3B7SthWXmAcElsnz7rNvu6sra0xGF79xvquvuYlB43hmy+xMTRER0eZLFTPayUyMpJK9dtZugwRecds3/CdRe7Erte8l0dj+OZLbAx1BOkeOzs7/l4732KfBETk3WRtbW2R5drZ2ZHJOz1L54x9p1/zmn/en6Vzxr5QGxrD5PcyxulJEhtDBaR7rKyssLe3t3QZIiKvhJWVFVZWVtja2lq6FIsyGAwWOfrzMrxLY2iJcdJF2iIiIiJmFJBERN5RH9WtZukSLO5NXwdvev1JZYl+6iJtERERETM6giQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERM2/mjz+IiMhz+2XjFlat/YPUDqkY2b8L7m4uli7plbgdFs64aQu4ctUPpzSpGdG/C1ZWVgweM4Og4FBqVitL88Z1LF1mkr3N41im5mdk88kIQKH8uejSrgkjJszm0pUbFC+any86Nkv2H8fUESQRkXdIUHAoS1auY8G04TSqV42ZC1ZauqRX5uiJMzSu/wFL5owhVw4flv20gYXL1lChTDG+nzWKTZt3cPnqDUuXmSRv+zi6uTizePYYFs8eQ68uLVmzfjOe6d1YOncsFy9fY9+Bo8legwKSiMg7ZM9+X3Jm88HePgWFC+Rm175Dli7plXm/RGGKFMgNQIG8OfAPCGbn3kMULpAbGxsbCuTJwa59hy1cZdK87ePo5JT6ocf/3hsng8FA4QK52fkKxkkBSUTkHRIYFEIm7/QAuDqnJTYujsioaAtX9ertP3ScgvlyEhQcireXBwCZvD0JCAyxbGFJ9LaPY2BQCO17DKd9j2EcPnaawKAQMnt7ApDZ25OAwOBkr0EBSUTkXWIAk+n/vw9sijPxlt/n9BHnLl5h38Fj1K1RIf46lnvrI84Uh8HqDVkZb/k4jh70BTMm9KdRvWoMGz8LAwbi4u6PkwmrVzBOCkgiIu8QN5d0XL7mB4B/YDC2traksLOzcFWvTnDIbYaOm8Wogd1IYWeHczonrl6/CcCVq364uaSzcIVJ87aPY6F8OUlhZ0e1iqW5cycCV5d0XLkWf33Ylat+uDon/zgpIImIvENKFC3AmXOXiIyM4uCRk7xforClS3ploqNjGDByGu1bfET2LPHfkCpTsggHfU9iNBo5euIspYsXsnCVSfM2j+O/ew5y5V7423/4OO6uzpQpWZiDR05iMpk4dPQk75csnOx16F5sIiLvmHW//8OK1ZtwdEjFyIHd3pijJi9qwdI1LFu1Hp9MXhiNsQBMHtWHkRPnEhgUQp3q5WnyUS0LV5l0b+s4Xrh0jWlzl3LLPwhbOxsG9GyPTyYvRkyYw8XL1ylZrCDd2jdJ9q/5KyCJiIiImNEpNhEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkj3mEwmjEYjJpPJ0qWIiCQ7vea9+TSGycvG0gW8LmJjYylXuxV+1y69cFsuzukIDApO9LlCBfLyy/K5L7yMl+HDJh057Hsc+5SpiLwbkaR5Xqf65fVjNBrZsn0vlcuVwMbmxV9e7m+j5pK6zbo4p8M7g6e22UTcf83bvuG7lzJW8uppDJOX1qiZO3eSFhSeJDjkNraP2VivXrvxwu2/LFev3Yjvr8Emyf1+neqXt1/CNmouidtscMjtZKhKRN4FOsUmIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETO6Wa2IyDvM1ec9S5eQrEKuHrZ0CcnuTR/D13WMdARJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJi5qUFpAYtenD63KUnTnP63CXa9xhOm26DuXj5OqWrNyfsTniS2r4vMCiEr4Z+TXR0zIuWLCIi75jlqzdRt0lXlq3aAEBAYDAdvxxBwxY9GTFxDnFxcUTcjaRzn1E0avUlBw4fB8AYG8v4aQstWfo744afPxXqtubA4eP8uXUX7b4YSuPWvfhl4xYA/AODadllIE3af8X5i1cBCLsTzvR5P7zUOmxeamtPsX3XAbJk9mJAz/bP3YaLc1omDP/yJVYlIiLviqIFcnP2/OWExz/+8jvvlyjMZx/XYcTEOfx38BgBQSEUL5KfWlXLMWryPIoWysvvW/6leuX3LVj5u2PmghVkzJCe2Lg4Ll+9wayJg7gbGUnDlj2pXK4kv27aSpOGNUnv7sqKNZsY0LM9P6/bzEd1q77UOl56QBo5aS6ZvD05cuw0p89e5P0Shenfsx1bd+xj9frNxMXF0Td0CuOH9Xxovo1/bmfNhr+4GxmFQ6qUjBrYjXRp0/DZ5/0JCAymRacB1K1RkRpVyvDBRx3Z9ftSAHyPn2H6vGVE3I3EOa0Tvbq0xCeTFzf8/Ok7fAoVyhRnx+4DhN6+w+hB3ciTM+vL7rKIiLwhcuXIgqeHa8LjVKlSks7JESsrK7L5ZMTGxhr/wGCyZ8mIh7sLkVFRGGNjOXr8LLWrlbdg5e+GQ74niYuLI1d2H6ytrGjbvCEAdna2eHm4ExJ6G//AICq8/x6eHq7c8g/iTngEt8PCyeDp/lJrSZZrkA4fPcXogd1YMmcsG/7czuWrN6hYtjgNalfmg0rvPxKOAHJmy8z0cf1YOmcsWTJlYOWa37CxtubrkX1wdUnH4tljaFz/g4fmuR0WTr8RU+nxeXOWzR1HwzpV6DdiKrGxcQCcv3iVAnmys/CbEVQo8x7Lf96UHN0VEZE31Ed1q/LTus18u/hnzpy/TMH8ufBK78aho6c4d/EKjqkd+PPvXVSpUJLpc5cxZOwMLl+9Yemy30qxsXHMWriSbu2bPvJcQGAwYXfCyeDpkTA+B31PkcHTndXrN1OralnGTV3AiIlzCAoOfSn1JEtAKlG0APb2KUjr5EimDOkJCAp56jwZvdPz7+5DjJ+2kKMnz3L1+s2nznP0xBkyenmQL3d2ACqVK0HE3btcuRa/8aZMaU+J9wpgMBjInycHgUmoQ0RE3h3//PsfFd4vhkOqlJy/dJWAwGAqvF+MGzcDGD5hDm2bN8D3+BnuhEfg6OhAl7ZNmLlghaXLfitt+HMbJYrmxzO920N/N5lMTJ/3A62bfoi1tRX1a1Zi2879fL/iVz6sVZmQ0DvsO3SMwgVyUa9GRRavXPdS6kn2a5BsbKzBZHriNCaTie79xlGkQG4a1qlC3tzZ2LHrwHMtz4ABMCRah4kn1yEiIu+W5as38f3MUdjY2GBjY82GP7bTtnkDxgzqDsDvW/6lasVS+B4/Q/asmfBwdyE45LaFq347/fPvPgKDQtn93xGu3bjF8VPnGDWwG7v3HcHW1oZ6NSsC4JTGkenj+gGwZOU6GtapwtJV6yle5AM83V34bvnal1KPxb/mHxdn4nZYOEdPnKHJR7XI6pORk6fPJzyfLp0T4eERREZFPzJv/jw5uHrjJsdOngNg67/7SJnSnowZ0r+y+kVE5M0VHR3DsZPniIuL48Klaw89Fxsbx5FjpylaMA+uzmk5ffYiN/z8sbO1tVC1b7fJI/vw3cxRzJ82nPdLFKZP11Zc9/Nn2679fNW9NQbDwwc/wiPuEhwahreXB67OaTl19gKnzl7E1SXdS6nnlX6LzVyFMsVYvPJXurZrwqcNa9Kh5zA8PdzInyc7AYEhANinsKN65TI0adeHj+pWo36tSgnzp3F0YOzgHkyZvZjIqGjSOjkybkgPrK0tnvtEROQ14x8YTK9BEwkMDsXKYGDXf4cZ1LsjE6YvJDIyimw+GenS7tOE6f/atpsq5UsCULFscXoNmsimzTvo16OtpbrwTomMimbo2Jm4u7nQvsdwMJmoWbUsTT6qBcCaDX/RoHZlAOrVrETvwZOIjjEyamC3l7J8Q3R0lM47AUajkXK1W3H21IkXbivGaMTWJvHsmTlTBv7b9usLL+NlKFa+HpcuXyO1YxruhCXtkPHrVL+8foxGI1u276VyuRLYPGYfeBb3t1FzSd1mY4xGsmfNrG02Efdf804c87V0Kckq5OphS5eQbN6WMXxdx0iHWkRERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImZsLF2AiIhYTsDF/djY6K3gTaYxTB46giQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERM7q73T0mk+mVLctoNL6yZSWHN71+ST5Go5HY2NjXbht53ep5kLW1NQaD4ZUv9/5r3uu8bt4UGsM3X2JjaIiOjnp1yeA1FhkZSaX67Sxdhoi8Y7Zv+M4id2LXa97LozF88yU2hjqCdI+dnR1/r53/TJ8Emn/en6VzxiZzZcnvbejH29AHeDv68Tb0AV5dP6ytrZN9GYmxs7Mjk3d6ls4Za5GjH6+LlzHOGsPkl9z7Y2JjqIB0j5WVFfb29s80j8FgsMinhpftbejH29AHeDv68Tb0Ad6efjyOlZUVVlZW2NraWroUi3qTx/ldGkNLjJMu0hYRERExo4D0Aj6qW83SJbwUb0M/3oY+wNvRj7ehD/D29ONJ3oU+Ps2bvg7e9PqTyhL91EXaIiIiImZ0BElERETEjAKSiIiIiBkFJBEREREzb+Z3G18Bv1sBTJrxPTf8/ClTqggdWnzE6K+/5er1W1QsU4xmjWtzKyCIERPmEBkVRafWn/Be4bwAhN0J59N2XzGyfxeKFsr7RvZj6459LFr+C8aYWL76og2F8uV8rftw7cYthk+YjWNqByaP7A3A8p83sm3XAcLDIxjRvys+mbws1ocX6UdwyG1GTZ5H2J1wihXOR4eWjV7rPuw7eJTFK9Zx0z+QTq0/plK5Eo/dV960fkD8rxd/OWgi+XJno91nH1m0H8/rl41bWLX2D1I7pGJk/y64u7lYuqRX4nZYOOOmLeDKVT+c0qRmRP8uWFlZMXjMDIKCQ6lZrSzNG9exdJlJ9jaPY5man5HNJyMAhfLnoku7JoyYMJtLV25QvGh+vujYLNl/+0lHkB7DPyCYr7q3ZvHsMezed5jf/95JWidH5n49mC3b9xIUEsrSH9fzSYPqTB7Zm+nfLkuYd853q8ibK6sFq/+/5+3Hsp82MmfyYMYM7s4Pqza89n1wdUlLl7afJswTGxuHl6c7sycNonXTD1n2k2X7AM/XD4CFy9ZQvfL7zJsylLrVK1io+nhJ6UNkVDRfj+rDnMmDmfPdjwCP3Vcs5Xn7AfDXtj3YvcG/OxMUHMqSletYMG04jepVY+aClZYu6ZU5euIMjet/wJI5Y8iVw4dlP21g4bI1VChTjO9njWLT5h1cvnrD0mUmyds+jm4uziyePYbFs8fQq0tL1qzfjGd6N5bOHcvFy9fYd+BosteggPQYBfLmwN3VGWtrK5zTOXHk6Gly58iKlZUV2bJ4c+rMRY6eOEvunFlxSuNIePhdIiOjOHbyLAYM5MruY+kuAM/fj6yZM3DwyEnuhEeQNYv3a9+HFHZ2uLs6J8xjbW1FhfeLAeDqkg6r1+BXZp+nHwAHfU9S+d7RC8/0bpYoPUFS+lCuVFFsbW1IkyY1KezsABLdxt7EftwJj2D97//wUd2qFq3/RezZ70vObD7Y26egcIHc7Np3yNIlvTLvlyhMkQK5gfhtwD8gmJ17D1G4QG5sbGwokCcHu/YdtnCVSfO2j6OTU+qHHv97b5wMBgOFC+Rm5ysYJwWkp7h4+XrCYTx3t/g3Lg83F26HhRNxNxKXdE4Jfwu5HcbCZWv4vHVji9X7OM/Sj7DwCCqWLc6iH9bSZ8jX1K9ZyWJ1P+hJfXiS1es3U7Nq2WSvL6metR8xMUbmLf6ZNt2G8OfWXa+szidJSh82/rmdimWLAyS6jb0OnrUf3y7+mfYtPsLGxjK3lngZAoNCyOSdHgBX57TExsURGRVt4apevf2HjlMwX06CgkPx9vIAIJO3JwGBIZYtLIne9nEMDAqhfY/htO8xjMPHThMYFEJmb08AMnt7EhAYnOw1KCA9QXh4BJNmfEevLi1J45iaW/6BAPjdCiSNowMOqVISEBQCwE3/QPxuBhAREcn4aQv5e/s+Fi77hbA7T37zfhWetR+pHVKyev1m5k0ZwtSxfZn4zXeWK/6ep/XhcTb8sY20To4Uvvep0dKepx+xsbE0rFOFSSN7MWuh5Q+jJ6UPZ89fZsu2PTRrXBvgkW3MMfXjx+xVedZ+REZG4Xv8DCtW/8bCZb/w9/Z9HDl22pJdeD6G/98FHsAUZ+I1OMD6Sp27eIV9B49Rt0aF+IB8b33EmeIwWL0hK+MtH8fRg75gxoT+NKpXjWHjZ2HAQFzc/XEyYfUKxkkB6TGMsbEMmzCbNs0b4O3lQcF8OThx+gJxcXGcv3iVvLmyUjBfDk6evkBIaBhpHFNTuEBuZk8ezMgBXalUrjhtmn1o8TeC5+lHXGwc1/38iY2Lw8PNmavX/V77PiRm/6HjbNu5n67tmr7iihP3vP3IliUjUVHRpLRPgY2Fbop5X1L64B8YzMQZ3zG4d8eEU1Pm25h9Crs3rh/29ilY+M0IRg7oSptmH1KpXHEKWvDLC8/LzSUdl6/F79P+gcHY2tomjNO7IDjkNkPHzWLUwG6ksLPDOZ0TV6/fBODKVT/cXNJZuMKkedvHsVC+nKSws6NaxdLcuROBq0s6rlyLvz7sylU/XJ2Tf5wUkB7jh582cPzUeRYuW0PnPqMICAoh9PYdOn45kqoVSuKUxpFmjWrz4y+/03vIJLq2b2LpkhP1PP1wcEhFvRoVadlpIJ37jObzVh+/9n1Y//s/jJu2gBOnz9NvxFQiI6PoP3IqwaG36dZvDJ37jCI2Nu6N6wdA13ZNGDV5Hu2+GEbHlpY9fZuUPoyePI/bYXcYMnYmnfuM4uSZC6/dvvK8/XgblChagDPnLhEZGcXBIyd5v0RhS5f0ykRHxzBg5DTat/iI7FnivyFVpmQRDvqexGg0cvTEWUoXL2ThKpPmbR7Hf/cc5Mq98Lf/8HHcXZ0pU7IwB4+cxGQycejoSd4vWTjZ69CtRkRE3jHrfv+HFas34eiQipEDu70xR01e1IKla1i2aj0+mbwwGmMBmDyqDyMnziUwKIQ61cvT5KNaFq4y6d7Wcbxw6RrT5i7lln8QtnY2DOjZHp9MXoyYMIeLl69TslhBurVvkuxf81dAEhERETGjU2wiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSSCJ6DZ7Er5v+Tni8Y/dB2n0x9KGf9hcRkbeXApJIIto2b8DSVRsSfn17yY/raPfZR8n+w2QiIvJ6sLF0ASKvo7y5spExQ3r+2fkfLs5piYszUfK9Avy75yBzFq0iOiaaHFkzM6hXB+ztU7Bs1Qb+2raHu5GReKV3Y0T/rjikSsn8JT9jMBjwPX6GdGmdGPrV55bumoiIJIF+SVvkMY6fOseU2UtJ4+jAJx9WJ4OXBwNGTeObcQNwTJ2KOYt+JG3aNDRpWJMTp8+TI2smrK2t6TlwAuVKF+WjutWYv+Rnfl63mYXfjMTTw9XSXRIRkSTSESSRx8ibKxtpHFMRdiec4kXzs2b9X9y8FUjXr0YDEB1jTLhBZCZvT377618OHzvN1es3E+4ODlClfCmFIxGRN4wCksgT5MmZlbA7ERgMBkyYKFwgN+OG9HhomruRkbT7Yij1alSkeePauLs6cyc8IuF5a2td6ici8qbRK7dIEpUoWoB9B47ie/wMAMEht4m4G8nlKzcICQ2jcf0P8HB35cy5SxauVEREXpQC0mvqhp8/1Rt9TqdeI2nS/iu+X/Frkuc1xsYyZfbil15TYFAIHb8cweyFK196269asw79nnmejBnSM7xfFyZMX0Tzz/vTd/gUbtz0J1uWjLxfojDNOvZnyJgZZPByf2I7nfuMeuxzBw4fZ/6SnxP+P2nG989U45TZS+j61RhCQsOeON2yVRvY8Me255r3cXoNnsQNP//nmve+kZPmPlMbN/z8GTlpbsL/ew2e9EzLW7JyHdUaduDE6fMAGI1Ghk+YTfsew1m2agP+gcF8/uWIhOn7Dp/CxcvXEh7HxcUxa8EKOvQcTvsewwkKDuWHnzayet1mAIKCQ+nU+/HjnVwSG9/nYT6mYXfC6TFgPM06/n//+X3LTrr0Gc2n7b7i8NFTL7zMJ5m/5GcOHD6e8P8t2/c+dtrDR0/Ruc8oOvcZxcRvFhEXF8fISXNp1WUQzTr0o8/QydyNjEzSdvM825a8+XSK7TWWP092Jo/sjTE2lk/a9KZR3ao4OKR66nw21tb07NTipdfz36FjlCpWkNZNP3zpbb+u2n320UOPy5YqQtlSRR6ZbnDvjkmaP7nt2e/LivkTXvm8b6pa1colhCOI/72rtE6ODO7dkfY9hlOzWlm8PN05cfo8zmmdwAQ+mTIkTB8VHU2Rgnno3PZTfvhpI79s3MLHH1an58CJNKhThV9/20rj+h9YomvJImVKe/p2b0PvIZMT/pbCzpYZEwZw6uxFZsxfzozxAyxYYbzQ23f4evZipoz+Cue0Tly9fhMrq/jjAX2/aEPuHFn4fvmvrP99G2VLPro/i4AC0hvh9u072NhYk8I+BUdPnOXrWYuJiTHS9rMGVCxTnCmzF3P67CXOnL9MJu/0zJo0mLbdhrBs3jhGTpqLu6sz+w4eJU/OrKRLm4a/t++jasVStPy0HkHBoYyYOIegkNuULlaQTm0+Ye3Gv9m0eTvW1tZMGNYTB4dU3AmPYOGyX4iNjSWjV3rW//EPBfLmxO9WAH26tmLMlG/xuxlAGsfUDOzVAac0qWn3xVCyZPbG9/gZWjWpx659Rzh64gyTRvQmS+b/v8k069CPZfPGPfT/kZPm4uHmwoHDx3FwSMnkkX2Ii4tjwjeLOHn6Ai7OaRk9qDt//bOboyfOct3vFlFR0XxYuzK//raVlPb2TB7ZmwOHj7N89SYMGPC7FUCvrq0olC9nwrKjo2Meqf23v3bgmNqBWtXKsffAUQ4fPYXBAOERdzl55iJp0zhSrEheNv65g9w5fOjTrTV3IyMZOWke12/cIquPN4N7d2TB0tVE3I3i7PnL3A67w7dTh/Htkp85duIcnfuMYkifz0nv/v+Lt++ERzB++iKiY2IIDrlNlfIluXrdj4GjpnPi9AUmjehFVh9v1m78m9UbNmNtZcXQrzqROaMXALMWruTmrUBGTZpLr64tH6knOPQ2A0dOJzIqGmtrKxrUrpKw7AfnLVIwDyGhYTRrXJtlqzaQ1smRogXzMGnm9zimToXv8TP069GW4kXy43v8DKMmz8M5nROBQSEAHDt5lhnzVxAdHUPvri3JkzMrEH9E7I+/d3Hdz59WTetzyPcku/YdIexOOOOH9uDMucts27mfS1eu0/LTemTO6MWYr78l4m4k9WpWolG9ao/sG0PGzeS6nz/9Rkzliw7NCA65zYiJczjke4r+PeNr3L77AAuWrCYuLo7eXVtR8IHxd3FOS8qU9gmPj548S+4cWbGysiJbFm9OnblIk4Y1WfXrH7ikS8vHH1Z/aPkp7e0pXbwQAK4uabl+w5/UDqnInycbB4+cYN+Bo3z2cd2E6a/duMXYKfO5GxlF66Yfks3Hm5GT55LWKQ1XrvrRptmHVCpXgh4DxifsX192/uyRsTx28hwz5y8n5HYY9WpWoknDmgSFhD52fKOjYxgxcQ43bgZgZ2vDN+P74x8QnOQxvc/G2hrP9G4P/a1i2eLx/XdOi5Xh0ZMST3sNCr19h9GT5xF2JxwPdxcGftmBgMBHa7O2tmbNhi1s27mfhnWrArBzz0HWbtxCyO0w5k8djq1t/Fvarn2HqFyuZHyoBby9PB6qyWAw4JPJi6Mnzz5SL4DfrQDGTplPxN1IKpQpRpVyJRPdthYuW/PQNpw5oxdd+owmZ/bM7Dt4jKoVStGqSX127j3EslUbuBUQRHR0DD07f0bWzN5P3b7FsnSK7TV29MRZ2vcYTovOA+jVuSU21taMn7aQcUN7sGD6cJasXE9MjJF/9xxixoSBdG7zCTWqlMU+hd1D7WT18ebbqcP4d88hSr5XgPnTh/Hn1l0AfLv4Z+rXrMT3M0dx/tJV/G4FsPmf3Ywc2I1pY/smHLFK7ZCKFp/UpUHtKlStWIromBh8Mnkx8Mv2rPt9K+5uLsz5egilihdi2ar1QPyLTLf2TfmqWyt++GkjA75sR5tmDfhn539J6r9PJi/mfD2EyMho/AOD+WvbHmxtbPhu5iiKFszD1h3/P7w+dUxfMnh54B8QzKyJg4iMjMI/MBgAWxsbxg/rycBeHZi/+OeHlpFY7dUrl+Hve21v27mfKuVLApAubRpmTxpEaFgYTo6OzJ82jENHT2E0Glm19g/y587OdzNHkSplSo4cOw2AU5rUTB/Xj+xZMnLi9Hk6t/kEZ2cnZk0c9FA4enAd165Wjj7dWgPxL+Qj+nel7WcN2LZrPzdvBfLLxi0snD6SPt1as+ynDQnzd27zCV7p3RjUu2Oi9SxduZ6KZYuzaMZIihXO99CyH5z3cW75B9GvRzsG9urAX//sAWDyzO8ZNaAr34zvj0u6+DejPft9aVC7Mt9OHUrObD4PtXH81Dm+HtWbogXz8GGtysybMoS2zRuwZfteqlYsRY5smRjZvyvlSr/H17MW88Xnzflu5ih++2sHMTHGR2rq1PpjShUrmHDhfEyMka+6t2FQ7/gao6Kj+WbeD8yZPJipY/qycNmax/YPICwsHHc3ZwA83Fy4HRZOjmyZCQkJ48Tp8xQtlCfR+UwmE+t++4eqFUsB8HH96oyZMp/y77/30EX6R46dpnjR/MyfNoxSxQoAEBUVw4h+nflmfH/mfPcjwEP7V2JjmSWTF1PG9OX7maP5Y8tOgCeOr52dLV92bsGC6cPxyZSBYyfPPdOYJsXP6zdTs2rZRJ970mvQkh/XUbpEIWZPHoy7qzPrfv8n0dqKFsxDqWIF6fF5cz6sVRmAjN6eTBvbjxxZMj10JNA/IBiPe+OYmLi4OP7Z+R+5svsk+vzM+StoUKcK304dxicf1gAe3baAR7ZhAP/AYD7+sAYLp49g8z+7Afh7xz6af1yHRTNG4uaajopliidp+xbL0hGk11j+PNmZMOxL2n0xlOzZMhETY+S63y2GjZ8FwN27kdja2lCscD56DZ5IGsfUdG3f5JF2vL08MBgMeLi7kMHTgxR2dsTd+4XosxeucP7SVVb9+gdhYREEh9zmq+6t+e6HX3BO50TLT+thY5P4ZvJeobwAnL94lXKl3wOgaME8fPPtAQCcHB1J4+hAeg9X3FydSWFnR3p3V06cvpCk/mfMkB4AD3cXAgKDOXv+MgcOn6Bzn1FERcVQo0oZUqW0T+hfendXMtz7pHh/HgDndGkTPjGafyJOrPa0To6ktE9BYFAI127cJKuPN1u278HbK76e+OW4YzAYSOOYmjvhdzl7/gpXrvmxY88BIiIiKV40n1kfXAkwW3ZSZPD0wNraivRurpw4dYGLV64TGBxCt35jMJl47JtAYvWcv3SVD2vHv7E4pnZ45lrc3ZyxT2FHeneXhPAZdic+QACkSpUSgI8/rM6ynzYwZfYSWnxaDzeXdAltFMyXK2F72rJ9L9f9/LkTHp7wi+UPunTlOt98+wMAERGR3A67g4tz2meq8eatQG6H3eHLwRMBEk6zPE4ax9Tc8g8EwO9WIHlzZQPg/ZKFCb19B4PBwIVL15g4YxEA34wbgLW1FQuXraFc6aIJRyo807uRLq1TQri+r0r5kqxc8xvjpy2kyUc1sbO1Ja2TIzY2NqR1cnxoPdzfvxIby2t+/qz7bSv2KVJwKyAI4InjGxUdzYo1vxEXF8eNm/5cvX4Td1fnJI/p0+w9cJSr127S/t4p5S/6jyPGaKR7h2bAk1+Dzl+8St3qFQAoUjAPO/YcpHSxgonWZu5x+5ebazr8bgUmOs/4aQuxT2FHofy5qFK+JDcTme78xasM+LIdQMJRqcTqSWwbtrWxSfhZj/t9rF2tHF/PXoJz2jQ0/7gO8Hzbt7xaCkivOWtrKz7+sDpLf9xA9w5N8UzvxuDen+Pp4ZqwQ17382f6uKdfdPzgXTLu3zIjm483xQrno2rFUsTGxmFtbUVwyG36dGvNhOmL2P2fb6LX3DzIJ1MGDh45QaliBTl09CRZMns/vFz+v+DE7tSRKlVKwu6Ecyf8LtExMYnUHT9TVp+MhN2JoE+3VphMJgwGAxv/3P7E/gHcCQ/HZDKxd79vwqk9k8mEyWR6bO01q5ZjwdI15M+T/bH1PLjMrD7e5Miaic8+qZuwHh/8NttDtWFIqN9cypT23I2MSmSZ8f9mzuhJurRpmD62HzY2NokGi8fVs3vfEY6fOkcmb0+CQ2+T1skx0XldnNNy5vxlAK5c93tkugfH08bGhpu3AnF1SUfo7fiLu2NijHRs2ZjNW3ez/OdNdO/Q9JFlhIdHsOGPbSyaMZKdew/x17b4T+Qp7f/f/8wZvWjf4iPy5c6e0Ickr697Nbq7ueCY2oGJw77EwSHVY9fXfQXz5WD/4RNUq1ia8xev0rXdp0D8m56NtTUAWTJnYNbEQQnz/PbXDgICQ2jTrMFDbdnaWj/y4SI84i7NP67D8VPnmPvdKrq1b0rE3UiMsbFcvHSNNI6pH6kpsbHsP2Ia7Vo0JEN6dzb/E38kxtPD7bHju/fAUYzGWLp3aMqM+csfu74g8TF9kvMXr/L98rVMGtkrIYBOG5v461Fi+6hPpgwc9D1J5oxeHPI9SdYHTr+b1/bg9vG4dgFKFStE935jqVezIs5pnTh55gLZfDIC8dcg3T/t+zgZvdPz36HjlCtV9KGf7Hiwnsdtww/XFT/tv3sOMbBnO3LlyJLwXFK2b7EsBaQ3QLVKpVn20wYCAoPp270N/UZMIYWdHaWLF6J10w+xtraifY9hOKRKSbEi+WjeuE6S227f4iNGTJzD8tWb8HBzZljfzsxetJLrN/xJmTLFY08pPKh+zUqMmjyPTr1G4uCQ6rEXLD/OB5VK06XPaIoXzY+Hm8tjp6taoRSHfE/SsvNAHBxSJfm2HecvXaPjlyOIjIpm9MBuAGTPmpFtu/Y/tvYSRQswftpCpoz+KknL+KRBdUZOmkfrroNxTO3AuKE9Hjttiffy03PgBHp1acmyVRvo2Kox6dKmAaBwgVwsXLaGuLillCtV9JF507u70rB2VVp0GoijowMtP62X8GOVT6unWePaDB03i9+37MQxdSqyZMrwyHwABfLm4Jtvf6DvsCm4uqZLdJr7undoSq8hk8iUIT0p7OJP7W7avINd+w5jwkS39o+GIwAHh1Rk8vake79x5MyeOeHvVcqXZNTkebRu9iE9O33GqMnfApAze2b6dG3FrIUrqVW1HD6Z4q+7ypE1E343Axg6bhYdWjZ6ZDn2Kezo3qEpHb4cgUOqlNSpXoF6NSoCEBkVzdCxMzl19iLX/fz5qG5VKpYtzpbt++j45UiqViiJU5rEQ+R9N24GMGbKfArmzUmXr0aT1ikNYwZ1f+z0ew8cZd3vWzHFmfjsk/hrkwKDQujRfzwBQSEM7t3hkXkSG8sqFUoy5uv5ZPXxJk2a+FD1pPEtmDcni1f8yldDvyb1E8YeEh/T+/7dc5BfN23F71YAfYdNoX/PdvQfOQ17e7uEb3kN69sZd9fHn94y1/LTuoycNI/f//oXN1dn2jZv+MiR3vsqlHmP6XN/IDjk9hPbTOvkyBcdm9Nv+FRsbWzwyeTFFx2bJ7mmru2aMGbKtyxe8SslihagzgflH5nmcdtwYnJky8TA0d/g7uaMt5cH7Vs0SnT7lteLbjXyhrtyzY/ZC1cyZvAXREZG0axjP5bMGUuqBy48fZcdOHycLdv30btry2eaLzziLkPGzmTyyN7JVFm8mfNX8HGD6g+dhpLHW7X2D/Lmykq+3I8e2XsT3fDzZ9LM75N9OxPL6tZ3LCP6d8EpTWpmL/yR9B4ufFRXF2W/7nQE6Q3nnM6J2Ng4OvUaSXSMkU8b1lQ4ekFHjp1m1oIVdH3M0Y+XJSQ0jPx5syscJZExNpZUKe0TrgsSeVOULl6I/iOmEmcy4e7qTMsm9SxdkiSBjiCJiIiImNFVYSIiIiJmFJBEREREzCggiYiIiJj5H9FoFFVt/803AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 583.3x480 with 12 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Four stacked timeline rows, one per regime, beside two columns of horizontal bars for annualized volatility and the deepest index drawdown. The volatility bars grow steadily down the rows while the drawdown bars do not follow the same order."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ticks, tick_labels = year_ticks(macro_df.index, every=4)\n",
     "n_rows = len(regime_order)\n",
@@ -773,8 +1784,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8321e4a4",
-   "metadata": {},
+   "id": "57464adc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006255,
+     "end_time": "2026-09-08T23:42:34.547370+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:34.541115+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Reading the panel honestly\n",
     "\n",
@@ -785,36 +1804,77 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2ae984fb",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 24,
+   "id": "97bc0b97",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:34.560987Z",
+     "iopub.status.busy": "2026-09-08T23:42:34.560816Z",
+     "iopub.status.idle": "2026-09-08T23:42:34.570794Z",
+     "shell.execute_reply": "2026-09-08T23:42:34.570166Z"
+    },
+    "papermill": {
+     "duration": 0.0196,
+     "end_time": "2026-09-08T23:42:34.573246+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:34.553646+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Annualized volatility runs from **Tightening** to **Inflation**, a span of **7 percentage points**. The deepest decline of the whole panel, **53%**, falls in **February 2009**, which the naming rule calls **Recovery** - the **third** of the four by volatility. The shallowest decline belongs to **Expansion**, the **second**."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "smallest_regime = str(regime_stats[\"months\"].idxmin())\n",
-    "smallest_span = regime_name[regime_name == smallest_regime].index\n",
+    "ORDINALS = [\"first\", \"second\", \"third\", \"fourth\", \"fifth\", \"sixth\"]\n",
+    "\n",
+    "\n",
+    "def rank_by_volatility(regime: str) -> str:\n",
+    "    \"\"\"Where a regime sits in the volatility ordering the panel is drawn in.\"\"\"\n",
+    "    return ORDINALS[regime_order.index(regime)]\n",
+    "\n",
+    "\n",
+    "calmest_regime = str(regime_stats[\"annual_vol\"].idxmin())\n",
+    "loudest_regime = str(regime_stats[\"annual_vol\"].idxmax())\n",
+    "vol_spread = float(regime_stats[\"annual_vol\"].max() - regime_stats[\"annual_vol\"].min())\n",
     "deepest_month = aligned[\"drawdown\"].idxmin()\n",
     "deepest_regime = str(aligned.loc[deepest_month, \"regime\"])\n",
-    "vol_spread = float(regime_stats[\"annual_vol\"].max() - regime_stats[\"annual_vol\"].min())\n",
+    "shallowest_regime = str(regime_stats[\"max_dd_pct\"].idxmin())\n",
     "display(\n",
     "    Markdown(\n",
-    "        f\"The smallest regime, **{smallest_regime}**, holds \"\n",
-    "        f\"**{len(smallest_span)} months**, running from \"\n",
-    "        f\"**{smallest_span.min():%B %Y}** to **{smallest_span.max():%B %Y}**, and the index \"\n",
-    "        f\"was never more than \"\n",
-    "        f\"**{regime_stats.loc[smallest_regime, 'max_dd_pct']:.0f}%** below its peak in any \"\n",
-    "        f\"of them. The deepest reading of the whole panel, \"\n",
-    "        f\"**{regime_stats['max_dd_pct'].max():.0f}%**, falls in \"\n",
-    "        f\"**{deepest_month:%B %Y}**, which the naming rule calls **{deepest_regime}**. \"\n",
-    "        f\"Across the four regimes the annualized volatility spans \"\n",
-    "        f\"**{vol_spread:.0f} percentage points**.\"\n",
+    "        f\"Annualized volatility runs from **{calmest_regime}** to **{loudest_regime}**, a \"\n",
+    "        f\"span of **{vol_spread:.0f} percentage points**. The deepest decline of the whole \"\n",
+    "        f\"panel, **{regime_stats['max_dd_pct'].max():.0f}%**, falls in \"\n",
+    "        f\"**{deepest_month:%B %Y}**, which the naming rule calls **{deepest_regime}** - the \"\n",
+    "        f\"**{rank_by_volatility(deepest_regime)}** of the four by volatility. The shallowest \"\n",
+    "        f\"decline belongs to **{shallowest_regime}**, the \"\n",
+    "        f\"**{rank_by_volatility(shallowest_regime)}**.\"\n",
     "    )\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "52d583be",
-   "metadata": {},
+   "id": "f276579b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013652,
+     "end_time": "2026-09-08T23:42:34.602282+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:34.588630+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The volatility ordering is economically legible: a tightening cycle is a calm market with an\n",
     "expensive policy rate, and the two regimes with an unusual price level or an unusual\n",
@@ -837,9 +1897,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41182be7",
+   "id": "c5232cc1",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006946,
+     "end_time": "2026-09-08T23:42:34.616541+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:34.609595+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### How much of this partition would survive a small change?\n",
@@ -861,9 +1928,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "71b5773a",
-   "metadata": {},
+   "execution_count": 25,
+   "id": "c67c2b6e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:34.635696Z",
+     "iopub.status.busy": "2026-09-08T23:42:34.635524Z",
+     "iopub.status.idle": "2026-09-08T23:42:34.646500Z",
+     "shell.execute_reply": "2026-09-08T23:42:34.639268Z"
+    },
+    "papermill": {
+     "duration": 0.024426,
+     "end_time": "2026-09-08T23:42:34.649846+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:34.625420+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def refit(data: np.ndarray, seed: int) -> np.ndarray:\n",
@@ -883,10 +1964,105 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "55d292d2",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 26,
+   "id": "08aee56b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:34.682259Z",
+     "iopub.status.busy": "2026-09-08T23:42:34.682070Z",
+     "iopub.status.idle": "2026-09-08T23:42:51.304241Z",
+     "shell.execute_reply": "2026-09-08T23:42:51.303582Z"
+    },
+    "papermill": {
+     "duration": 16.636133,
+     "end_time": "2026-09-08T23:42:51.304708+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:34.668575+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_ba18c\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_ba18c_level0_col0\" class=\"col_heading level0 col0\" >Agreement with the fit above</th>\n",
+       "      <th id=\"T_ba18c_level0_col1\" class=\"col_heading level0 col1\" >Silhouette</th>\n",
+       "      <th id=\"T_ba18c_level0_col2\" class=\"col_heading level0 col2\" >Smallest cluster (months)</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Change</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "      <th class=\"blank col2\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ba18c_level0_row0\" class=\"row_heading level0 row0\" >random start 0</th>\n",
+       "      <td id=\"T_ba18c_row0_col0\" class=\"data row0 col0\" >1.00</td>\n",
+       "      <td id=\"T_ba18c_row0_col1\" class=\"data row0 col1\" >0.327</td>\n",
+       "      <td id=\"T_ba18c_row0_col2\" class=\"data row0 col2\" >51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ba18c_level0_row1\" class=\"row_heading level0 row1\" >random start 7</th>\n",
+       "      <td id=\"T_ba18c_row1_col0\" class=\"data row1 col0\" >0.79</td>\n",
+       "      <td id=\"T_ba18c_row1_col1\" class=\"data row1 col1\" >0.320</td>\n",
+       "      <td id=\"T_ba18c_row1_col2\" class=\"data row1 col2\" >16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ba18c_level0_row2\" class=\"row_heading level0 row2\" >random start 123</th>\n",
+       "      <td id=\"T_ba18c_row2_col0\" class=\"data row2 col0\" >0.79</td>\n",
+       "      <td id=\"T_ba18c_row2_col1\" class=\"data row2 col1\" >0.320</td>\n",
+       "      <td id=\"T_ba18c_row2_col2\" class=\"data row2 col2\" >16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ba18c_level0_row3\" class=\"row_heading level0 row3\" >random start 2024</th>\n",
+       "      <td id=\"T_ba18c_row3_col0\" class=\"data row3 col0\" >0.81</td>\n",
+       "      <td id=\"T_ba18c_row3_col1\" class=\"data row3 col1\" >0.308</td>\n",
+       "      <td id=\"T_ba18c_row3_col2\" class=\"data row3 col2\" >20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ba18c_level0_row4\" class=\"row_heading level0 row4\" >drop first 1 months</th>\n",
+       "      <td id=\"T_ba18c_row4_col0\" class=\"data row4 col0\" >0.79</td>\n",
+       "      <td id=\"T_ba18c_row4_col1\" class=\"data row4 col1\" >0.321</td>\n",
+       "      <td id=\"T_ba18c_row4_col2\" class=\"data row4 col2\" >16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ba18c_level0_row5\" class=\"row_heading level0 row5\" >drop first 3 months</th>\n",
+       "      <td id=\"T_ba18c_row5_col0\" class=\"data row5 col0\" >0.73</td>\n",
+       "      <td id=\"T_ba18c_row5_col1\" class=\"data row5 col1\" >0.255</td>\n",
+       "      <td id=\"T_ba18c_row5_col2\" class=\"data row5 col2\" >4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ba18c_level0_row6\" class=\"row_heading level0 row6\" >drop first 6 months</th>\n",
+       "      <td id=\"T_ba18c_row6_col0\" class=\"data row6 col0\" >0.82</td>\n",
+       "      <td id=\"T_ba18c_row6_col1\" class=\"data row6 col1\" >0.323</td>\n",
+       "      <td id=\"T_ba18c_row6_col2\" class=\"data row6 col2\" >20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_ba18c_level0_row7\" class=\"row_heading level0 row7\" >drop first 12 months</th>\n",
+       "      <td id=\"T_ba18c_row7_col0\" class=\"data row7 col0\" >0.77</td>\n",
+       "      <td id=\"T_ba18c_row7_col1\" class=\"data row7 col1\" >0.291</td>\n",
+       "      <td id=\"T_ba18c_row7_col2\" class=\"data row7 col2\" >4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7dbdeeb51d10>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "perturbations = []\n",
     "for seed in (0, 7, 123, 2024):\n",
@@ -915,10 +2091,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "64915a4a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 27,
+   "id": "fcf0adf5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:51.369797Z",
+     "iopub.status.busy": "2026-09-08T23:42:51.369601Z",
+     "iopub.status.idle": "2026-09-08T23:42:51.383607Z",
+     "shell.execute_reply": "2026-09-08T23:42:51.382653Z"
+    },
+    "papermill": {
+     "duration": 0.056344,
+     "end_time": "2026-09-08T23:42:51.384118+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.327774+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The least agreement any perturbation reaches is **0.73**, and the smallest cluster any of them produces holds **4 months** against **51** in the fit above."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "worst_agreement = float(stability[\"Agreement with the fit above\"].min())\n",
     "smallest_ever = int(stability[\"Smallest cluster (months)\"].min())\n",
@@ -933,8 +2136,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9974640",
-   "metadata": {},
+   "id": "8d1b84d4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007138,
+     "end_time": "2026-09-08T23:42:51.399348+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.392210+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "None of these partitions is wrong. They are answers to the same question from starts the\n",
     "data does not distinguish between, and they disagree about a meaningful share of the months.\n",
@@ -954,8 +2165,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4539e915",
-   "metadata": {},
+   "id": "81440803",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006856,
+     "end_time": "2026-09-08T23:42:51.413452+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.406596+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Figure 1.6 inputs\n",
     "\n",
@@ -967,9 +2186,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7e619240",
-   "metadata": {},
+   "execution_count": 28,
+   "id": "26e7feaf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:51.429744Z",
+     "iopub.status.busy": "2026-09-08T23:42:51.429552Z",
+     "iopub.status.idle": "2026-09-08T23:42:51.440608Z",
+     "shell.execute_reply": "2026-09-08T23:42:51.439278Z"
+    },
+    "papermill": {
+     "duration": 0.020195,
+     "end_time": "2026-09-08T23:42:51.441145+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.420950+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "ARTIFACT_DIR = OUTPUT_DIR / \"figure_1_6\"\n",
@@ -994,8 +2227,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85b87da0",
-   "metadata": {},
+   "id": "0a2e990d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01717,
+     "end_time": "2026-09-08T23:42:51.470234+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.453064+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## How the four indicators move together\n",
     "\n",
@@ -1009,10 +2250,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "63699037",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 29,
+   "id": "bef5f695",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:51.500436Z",
+     "iopub.status.busy": "2026-09-08T23:42:51.497510Z",
+     "iopub.status.idle": "2026-09-08T23:42:51.778197Z",
+     "shell.execute_reply": "2026-09-08T23:42:51.774114Z"
+    },
+    "papermill": {
+     "duration": 0.295531,
+     "end_time": "2026-09-08T23:42:51.778751+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.483220+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAg8AAAGRCAYAAADioVAMAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAjBFJREFUeJzs3XV0E1kbx/Fv6kbdW6C4FCju7u4szrK4Ls7i7u7uzgLL4izusrg7FKm7e/P+UQiUtkChkCzv8zmHc5qZycwvk5A8c+fOHUVsbIwSIYQQQogvpKXuAEIIIYT4b5HiQQghhBDpIsWDEEIIIdJFigchhBBCpIsUD0L8ZJas2kS2AhV54+mdIeu7dfcBFWr9glPu0kydvfSzy5s7u9F38Lhv3u7C5evJXaQqOd0qc/f+429e36eMGD+T/MVrEB0d81XPz1+8BvWadwbgyrXbZHUtz54DxzIy4neTkXk3/7kHc2c3Tp29lAHJvq+MfM81xamzlzB3dmPzn3u++7akeBAigxQsXQdrl2I8e/5SNa3ngNEULF3nh+Zo1aw+m1fPw8nBLkPWN3riHB4/fcHE0QNpWLd6snnjpsz7Lq/vtYcXoyfOIYuzIxNHDyJXDpcM38aH+nTrwMaVczAw0P/mdbkVzMfmVfOoVrnsN63ne+3bj2VUXnXo1GvoV/+AZ+R7/jM6dvI85s5uvHztkep8nR+cR4ifWnx8POOmzmfjyjlqy2BpYU7ZUkUzbH3ur95QIF9uOrX/JcU8H7+ADNvOh16+SvrCat2iIa2bN/gu2/iQo4MdjhlUbOnp6VK+TPFvXs/32rcfy6i86uDj+/X7KCPf85+Rj5//J+dLy4MQGahc6eLsO3Sci/9eT3W+n38A3X4fQbYCFSlYug7T5iwjLi4uxXJTZy8lc96yrNn4J0XLNyBX4SpMnrmYxMREIKmpuW3n/uQtVh0X1woMHjmF+Ph41XPNnd14/uIVkNQiMm7KPIaPm0lW1/JcunIj2bbCIyIZMmoqeYpWI0/RagwdPY3wiEjVc1+99uTazbspjkLqNe/M1h17ef3GE3NnN3oOGK2aFxIaRt/B48hesBKlqjThzv1HqnmXr96keoN2OOcpQ91mnXjyzD1ZnrMXrlC/RdLR5KARk1VHlu4v39Dqt9/Jkq8cRcs3YNX67SiVScPUfNxcfvbCFcyd3diw5S8gqQWoRsP2bN25j/zFazB30epk2+w5YDTmzm6qfWju7MasBSvpOWA02QtWonTV5K/h1t0HVKvfliz5ytG1z3CiPmj6/njbSqWSTdv/pnTVJjjlLk2dph154f6ayKgo5ixaTbkaLXDMVYpyNVrw77Vbn9y3n/r8vNvuyTMXqdmoA6WqNAFg2erNuJaoSZZ85Wj5a59kLWOp5b197yHVG7TDIWcpylZrxp9/HeBjkVFRqpaRLPnL06X3sFSb/5VKJSvXbaNo+QZkyVeO1p364f7yjWr+X3sPU6RcfZzzlKFe887cuHUPgODgUHoPGkO2AhUpUq6+KtuHCpauw/lLVzl/6Srmzm6qU2qf+px8r/cc0v5cv9u/S1ZtonqDdmTJV46OPYYQHBKqeu6ho6coW7150nvUsS/ePn7A+8/18VPnqdGwPZnzlqVz7z9U77lSqWTxyo3kL14D1xI12bJjb7JMCQkJzFm0mgKlapPTrTLDxs4gNjZO9fqr1mvD2k07KFGpEdkKVGTB0nVA0ndI74FjAHArUzfVFjApHoTIQKVLFCZv7uyMnjgnxRdWYmIi7bsO5Mjxs4wc0pvmjWozbc5Sps9dnuq6wsIj2LTtbwb06UTZUsWYOX8F+w6dAODBo6eYmBgzamgfKlcozar129m153CauVZv+JO79x8xffwfFCqQN9m8/kMnsGHrX/Tq0o6enduybvNOBg6bCMD86aOxtrIgd85sbFo1FxtrS9XzRg3tTe6c2bC2smDTqrl079RGNW/foeOYmprQt3sHHj15zpRZS4CkVowmrbujpaXFlHFDUCgUdOwxJNm+yp83JyOH9Aagy68tGTW0N5FRUTRp04O79x8zacwgKpYrweCRU9i4dfdn35N37j14zKz5KxjavztNGtT67PJTZi3B0sKMvt078PDx+9cQFh7BLx364OPrz6Qxg3CwtyUkNCzN9WzZsZc+g8aSM7sLU8cPxTVfbuzsrNFSaHH63GVaNK7DmGG/4+vnT/ffR6JUKlPdt1/6+fm1xxAqlC3BjEnDePb8JcPGzqBo4QKMH9kfIyNDdHQ/3eA8ZORUvH38mDZ+KOXLliAqKjrFMoNGTGHBsvU0qV+TkYN7kSd39lSb/9dv3sWQUVOpVL4kk0YP4s7dhzRt25PIqCgiIiPp3m8kjg52TBk7BEd7W5RKJUqlkq59h7P/8An69/qNZo1q8/vQ8dy8fT/ZuudPH42FuRn58uRg06q5NGtU+5s/J1/7nn/J53re4jW0aFKXbr+15u/9R5g8czEA/167RZtO/XF2tGfKuCG8fu1J/7f//97pN3QCLZvVp0zJouzac5jDx84AsPfAMUaOn0WxIgUZ9UdfPDx9kj1v0fINTJi2gHq1qjB8UC+2/LmHFeu2quZfv3WPP3cfpFfXdlhbWTB+2gL8AwJp1qg2jerVSMo9bTTzp4/mY3LaQogMFBIaxrCBPenYYwh/7T2Mgb6eat7tuw+5dOUmA3p3osuvLQE4fe4yK9ZuZeSQ3igUihTrWzhrPK75clG9cjn2HDjKwSMnaVSvOh3aNKVdq8bcuf+IyMgo/t5/hCvXb9OyWf1UcxkZGbJp1VzMTDMlmx4YFMzOPYdo1qg2/Xr9BsDNOw/4c/dBpk8YRtVKZTE0NMTSwoz6tasme26ZkkWxtDAjKjomxbzG9WswecxgIOno6cnTFwBs2v43kVHRLJw1Djtba6ytLGnz9mg0m0tmAKwsLShdoggAhVzzUqZkUfYcOMaLl6+ZO20UHVo3pV3Lxhz45yTL1myhQ5umX/TeREZFs2LBFIoVKfhFyzeqVz3V13D0xFl8fP1Zt2wmjevXVL2utCxesZHsLllYv3wW2trayebt2baCgMAgbty6T84cLly8fJ2AwKBU9+3N2/c/+fl5p0XjOoz+oy8Abzy90dXVwdjYiIZ1q/Nbuxaffd2ZTIxBocCtYD5+bdssxfygoBC27thL25aNmDBqwCfXtWLtVuxsrZkzdRQKhYLYuDgGj5zCsZPnqVm1AoaGhhjo61G1clnV+/jC/TVHT55jSL9uSdtXwpY/97D/nxMULpRfte6qlcpiaKCPpYWFah996+fka9/zT32u3xnUt4uqwP57/xEOHTnFzEnDWbV+O0aGBiyaPR49PV0iI6P4Y8x0VQsBwNxpo6lRtTyFCuTlyImzqlaNjdt2Y25mysqFUzEw0MfC3JTzl64m2/8VypZg+KCeAJy/dJUDh0/Qp1sH1TJ/bVqKoaEBQcGhTJi2gOfurylZzE3Vz6hKpTJkzeyUYl9Jy4MQGSgiMopG9WpQomghZsxbQSYTE9U891dJXyRuBfOpphVxcyU0LJzAoOBU1/eunnCwt8XMLBOBgUnLnbt4laIVGlCr0a/sPZjUSz70E0e/2bI6pygcANWXm1uBDzK9/YJ+l/dr6Oq8Py6xtrIg5u0X4cuXSac9SlVpgotrBdp06geAX0DgJ9f38lXynFpaWhQumF81/Ut9uO8/J63X8Oq1JwDZs2X5ovW4v3xN/rw5UxQOsbFx9B08jjxFqzNo5GT8/ZP2QWhoeOrr+cLPz4fvpbOjPXu2reSF+2tcS9TijzHTVaek0rJs/iTqVK9IzcYdqNusk+pUwjsvXr4GoGD+PJ955UmZ3QrkUxXG7z5bL195YGCgz6Fda9HW1satTF169B+Fr1+A6nXOnL8CF9cKuBSogKe3r2r/fMq3fk6+9j3/ks/1hwcHeXJlJ+Dt/+WXrzyIiIwid5GquLhWYOjoaSiVymTvqe7b1iJrSwsAYmJik3K98cTZySHVVp/Y2Dg8vHw4e+FK0n50rcBfe//B76P9mNa6P0daHoTIYAqFgomjB1K7SUcszE1V012yOANJR5Dvjl5u3LqHaSYTLC3MP7lObx8/QkLCcMmatI6eA0aTP08OLp/Yjb6+HubObl+V9d36bt553yR8423z8Lu8n6KlpU1MzJdf6pY1S9IRzMaVczA3e79v8ufN9Znnvc9ZtHABEhMTuXnnvmq6nq4uAL5vOxmGhUd8cab0srW1BuDWnQcUck06BZTaOfV3smR25MGjpyQkJCQrIHb8fZCN23bzz9/rKVW8MFNnL2X63GWq+R/v26/9/JQtVZR//l7P6fOXada2F2ammRgxuFeay1tbWTJz8gj+GNiDVh1/p323Qdy9/P6UWJbMjgBfdPmsSxZnbt65j1KpRKFQqD5b7z4Hrvly8eeGRdy9/5i6zTsBMLRfNwA6tW+R7PRSalcPaWkn30ef+5x8rc+955/6XH9cfCmVSp48cyfb2/97WTM7cu/BYzatmpvs82FtZfH5XDZWXL56k6ioaAwNDZJl0tPTxdHeFidHe8YM+1013cTY6Ites5ZWUttCWsWEFA9CfAelSxShQZ1q7Dt0nMzOSV+2BV3zUKp4YdZt3oWzkwMent5cv3WPwb93TfWUBcDkmYupX6cam7b9jUKhoF2rxgBERUXx2sObXXsPc+zkua/OaWlhTvNGddh3+Djzl6xFqVRy8MhJfmlSFwsLs88+3yWrExcuX2PJqk2UKFKIEsUKfXL5Ni0asnjFRmYvXEWbFg2Jjo5BV1eXCmVLfPJ51auUxSWrM3MWrUFHR4drN+7i5x/I6KFJzfO5cmYDksaGePXGk3Wbd33hHki/6pXLYWRowIKl69DS0uLC5WsEBYekuXyn9r8wdPQ0OvX6g7o1K3Ph8nUG9O6k6ktw7OR5rt+8x9pNO5I97+N9W7Swa7o/PwePnGLZ6s00a1ibkNAw4uPj0dZOu8E5OCSUVh37UqNqBRzsbQmPiEixvLWVJQ3rVmfLjr3YWFuSM4cLl6/cZNbkETja2wJJLWOVK5Sm22+t6T9sIgOHT6JIIVfmLV5DdpcsVK9Sjhu37vHHmOn80rQeCoWC+Lg4tLW1yOaSmaqVyrBj90HMzUxxyerM7bsPGTu8X4q8Llmc+PfaLTZt/5vCBfN/9nPytT73nn/J53rd5l0YGhpw9fodHj99wbTxQwHo1OEXdvx9iDmLVtO0QS18/QPImtkJHZ3P/zw3qleDcxevMmD4JMqVLsaSlRuTze/SsRUTpi1g+679lC5ZhIePn9G80Zdd/vvuwGL+0rU0qluDmtUqJJsvpy2E+E7GDe+X7AtAW1ubTavmUL1yOSbNWMSO3QcZ2r87Q/t3T3MdNtaWjJ44Gw8vb1YvnqZqjp05aTj+AYFMnrGIfHlyJjsXnF5zp4+mfasmLFqxgSWrNvFr66bMmZayg1RqBvXpglvBfEyesYj1Wz7/g509Wxb+3rYcfT09xk+dz8r12wkMCv7kkTuAsZERuzcvwzVvTkaOn8WZ8/8yY+Iw2rdOuqLArUBeuv3WGveXbzh05BTrls5I8wf1W9naWLFx5RwUCgUjx89CT1eXiuVKprl8l19bMnnsYG7ffcigEZN57eFJXHw8rZo3oHrlcixZuZFDR08lOw8NKfft13x+ihcpiL2dDZNmLmLOotW0bFafPt07pLm8aSYTGtevyZ9/HWDQ8MkYGRqyauG0FMstnDWOjm2bsfnPPYyZNBelUkl0TAwli7tRIH8eVm/4k4SEBH5t24zpE/7g5NlLjJwwC9f8uflr81KMDA3JmcMFt4L5mLtoNeOmzKNShdKM+eN3FAoFqxdNp0mDWmza/jejJ83hjad3qqf2xg3vRxZnR4aPncGeA0c/+zn5Wp97z7/kc50rhwvzFq9h/+ETDOzTWdVvpXSJImxZM4+g4BCGj5vJ9l37CQ1L/dTVxzq2bUaf7h04euIc8xavoXOHlsnm/97jV8YN78e5S1cZOmoqFy9f/+J1N6lfk/q1q/L3viOMmzIvxVVhCrkltxCa510T9vWz+7743LoQQvOcvXCFBr90YcGMsV/cufe/QFoehBBCCJEuUjwIIYQQIl3ktIUQQggh0kVaHoQQQgiRLlI8CJFBmnToT8vOg2nZeQiN2/VjyeptqntRiCRlarX7ojEYmnTor/o7IDCYoWPnJBtx779g4qzlXL/1fvyMXkMmcfrC1U884+u2se2vtIcl/5wP93N6bN5xgH9OnP/q7arDt+4rkZyM8yBEBpo4oi+5c2QlNCyCASNn8M+JC9SpXl7dsf7TrCzNmTF+oLpjiA+0bVFP3RGEmknxIMR3YJrJGLcCeXjl4QXA3QdPmbNkAxGRUTjYWTNmSA8sLcw4ePQsuw8cJyo6BmMjQyaN7IuNlQUHjpzhweMXBAWHEB4RybSx/Rk3bSnP3F+jp6tLvx7tKFWsIH4BQcxauI43Xj7o6GjTrUNzypVKui9Ekw796dK+KQeOnOG5+xt6dWpJwzpVkuWMj49nxfqdnL10HR1tHerWKE/rZnU/u96ev/3Ctr8O0e6XBjx3f41CoeDO/SdYmJsxdmgP9v9zms07D5CQkEiJogUY1KuDasS6d1J77RbmprTvMRz/gCA69BxBg9qVqV2tHDWbdefiP5sAuHP/CQtWbCYyKhpLczMG9f4VlyyOeHn78cf4uVQqV4Jzl64TEhrO5FF9yZc7e7LtpvXaFq3aiq6uDt1/Tbr/w4GjZ7h64z5jh/bg/OUbLFu7g9i4WHJlz8qoQd0wMNBPsS+qVki69n/pmu2cPPsvt+4+wsnBlvlTh6my795/nEdP3WnWoDpd2ifdOyKt9b+jVCrZ9tch9h4+ha6ODsULu/J797bJXteqjbsIC49kQM/2APwxbi4VyxajXs2K7Np3lM07DqKrq03p4m707dqa9j1HJNvPLRrVTPN9q/NLT7p3bMHfB04wsFcHjp+5TCYTI7q0b8aqjbuIjonF08uXB09ekD2rM9PH9k8apOnmfeYs2UBoeAT+AUFkzexIj44tqFz+/eBJTTr0p1GdKly8cgv/gCCa1q9O2xb1SExMZMma7Vy/dZ+IyCjy58nJqEHd0NbWYuKs5WRxduD2vcc8fupO2ZKFGT6gCwAvX3syY8FaAoJCMM1kzKhB3cji7PDl/3nFF5HTFkJ8Bz6+AZy/fJ3CBfISFh7BlDkrmTq6H9tXz6RSueKs37YHgNw5srJg2jA2LZtKtixObN/9vll13z+naPdLfeZPHcblq3d44+XDjrWzWTp7NK55cwAwYcYy3ArkYfPyaUwe+TtT5q7izQd31vP28WfxjJGMHNiVlRtSDuK0eedBHj97ydpFk1i/ZBK1qpX7ovWeu3SdlfPGq34sd+49yh/9OjN2aA9u3XvM4RPnWbtoEltXziA8PJIzF6+l2HZqr11HW5s5E4dgbWXBhqVTaNGoZrLnhIZFMGzCPPr3aMfm5dNoWr8awybMIyEh6fTQc/c3FMyXkzULJ1CpXDG27jqUYrtpvbba1cpz4sy/qoF9Tpy5TO1q5fDw8mXFhp0snjmSbatm4uRgy+6DJ9LcFwA9O7Ukb+5sjBjQRVU4JOUPZ9bEwSycNpx1W/YQHR3z2fUDHD11kUPHzrFs9hjWL5mc7iP/JWu2M2X072xeMZ3Wzeqgo6OTYj9/6n0LDgnjjacPaxdNpJBr7hTrv3bzPkN/78TWFdN5/Owl1249AGDGwjX81rYxezcvoGn9atSoXCZZ4fCOvr4ey2aPZuW8cazZspvn7m/Q0tKiSvkSrJo/ns0rpvPwyXMuX7utes6tu4+YPLIvG5dN5cDRs7x640V8QgKjpyxiQM/2bFs1g05tm7Bo5dYU2xPfTloehMhAo6csRFdXF0MDfTq0bEipYgW5eOUWPv4BDBk7G4CEhESyZU0aCz+zsz1nL1zn2q373H34FGfH9+P3Fy/sqjpqLlQgN3q6ukyfv4ZWTWvjksWJyKhobtx5yOyJSXcBdHa0o0QRV/69dke1ngpliqFQKCiQLxf+b2/E86EzF67R/dfmqrt/WpqbfdF6Wzerm2zY4moVS+NglzT+/7mL13n5ypNu/ccBEB0TS/48yY/+P/fa03L3wRMyO9rhmjcnAFUqlGTuso289vBCX08PQ0MDShZLumtmgXy5+GvfsWTP/9Rra9qgOvr6ejx78RpbGyueu7+hWOH87D14Eh/fAPoMnQxAbFw8ZUsWVq3z433xKeVKFUFHW5sc2TKjq6tLUEgYl6/e/uT6Iel9atagBmamSTdas7I0/6LtvdOsQQ1mL15Pm2Z1qVi2eKrLfO59a9eifpqjdhZyzY25WdKN13LnyIJ/YBAAdjbWBAaFEBcXT2hYRJq5i7nlR6FQYGlhhmuenNx79IzsLs44Odixa98x7j96Tnh4ZLICtmTRghgY6GNgoE8WJ3v8A4NJTEzk5WsvJsxMukeIUkmqN40S306KByEy0Ls+Dx9SKpU4O9qxfvHkFNN/HzaNIgXz0rR+NfLnzcG5i9dV83U+uEmOpbkZaxZO4NLV24yZupgalcvQrGENIPnd+hQKxftbcX5AR0c7xbSkDImpLv+59X58h8gPfzyVKKleuTT9urdLdb1J2/30a08PBQog9desJPUr0dN6bXWqleP4mcs4O9pRuXwJdLST1lG4YF6mjemf6ro+3hdflFmhSHpPlMrPrh8gUalM621Kts74hIRU5/Xq1BIvbz/Wb9/L2q17WDVvXIplPve+fWmBpKOtw7vdXrdGeTZs28fuA8fJlzs7rZp+/r4KOjraGOrr4+sXQO+hU2jfsgHdfm2OlpaCxMTU30/VvnxbLKxbPCnFaTKRsWTvCvGduebNiY9vACfO/gsk3bY7KDiU0LAI7j54QutmdcnukpmHj5+nuY7n7m8ICgmlTAk3mtSvxsWrtzAyNKBIwbzs3HcUAA8vX/69fpeSRQt8cbayJQuzffdhYmPjUCqVvPbw/ub1litVhINHz/HqTVJ/Dy8ff9VpBYDEROUnX7uFhRkREZFEp3I3vwL5cvHGy4d7D58BcOr8FQwNDcjsZP9F2T732mpULsO5Szc4df4KtasmncIpWbQgV67f5c79JwAEBYcS+famVp9ib2uNl4//Z5f7kvWXK1mY3QdOqG6n/drDG0gqmZTKpH1rZWnOg0fPiImN5bn7G+49egpATGwsd+4/wcHehr5dWuP+yoOAwOAU+/lz79vX2P/PGYYP6MLWlTMYM6QHRoYGqS737vU8d3/DvYfPKFwwD/cfPcfQ0IAGtSphbGSI+yvPz24vs7M95mYmbPvrMEqlktjYOHzf3oL6w30lvp20PAjxnZmZmjBz/CDmL9/E6o1/oa+vS+/OrSnqlo9WTevQbcA4HOxsKJAvJ/4BwamuIzg0jBkL1hD29sdjaN/fABgztAczF6xl/z+n0dHRZsSALl/U/P9O+5YNWLRyK+17DsfAQJ8q5UrSsU2jb1pvkYJ56du1NX+Mn4uOtg5mpiaM/aMnNlYWVCpXnA3b99KnS+s0X7uBvh61qpajdZchNGtQg0Z133fyNM1kzNTR/Zm7dAPRMbGYm2Vi2pj+X3xU/Ll9Zm1lgbWVOV4+/uTO6QJAZid7xg/rzYwFa1GixMjQgD/6dSKHS+ZPbqdejYqMm76Eg0fPMn/asDSX+5L1161RAW/fADr/PgYDA30K5svNoN4dKFmsIKs2/kWzBjWoWqEUB46c5ZffBlOyWEEqlUvqWxAdHcNf+48za/E6QsMiaNeiPvZ21igUimT7ud0v9dN8375WQddcDB03B2tLC/T1dXHJ7MhvbZvg5GCbbLlT566wecd+oqNjGTOkO9ZWFhQv4srBo2dp13042bI64ZLF8bPb09HWZvrYgcxavI59/5xCT0+X9r80oHql0sn2lZ6e7le/JpFERpgUQgiR4aKio2nfYwQblk7ByNCAyKhoegycQOO6VWnaoLpquSYd+jN97IAUp/uEZpOWByGEEBnOQF+fcqUK02foZGLj4omPT6BcqcLUr1VJ3dFEBpCWByGEEEKki3SYFEIIIUS6SPEghBBCiHSR4kEIIYQQ6SLFgxBCCCHSRa62ECID6OrqqTuC+D8SF5dyAC0hfiQpHoTIIBZHJqg7QqqCao7R2B8bXV09ySbEf5CcthBCCCFEukjxIIQQQoh0keJBCCGEEOkixYMQQggh0kWKByGEEEKkixQPQgghhEgXKR6EEEIIkS5SPAghhBAiXaR4EEIIIUS6SPEghBBCiHSR4kEIIYQQ6SLFgxBCCCHSRYoHIYQQQqSL3FVT/N945v4aTy9fKpQp9tll7z96RmhYBKWLF8rQDK0cC9E3axkSlEoqXlqRYr61nhFLCzTGycCUB+F+9L23l8iEOIy0dVmYvwH5MtniGR1Gj7u78Y+NzNBsQgjxpaTl4Qeq2qhzssd/jJvL9Vv3f2iG67fuM2j0rB+6zbRcv3WfibOWf/XzJ85anq79t3PPUbJldcYvIIhfe4+kddehPHd/A0BYeAQLVmxRLZvV2YHdB45/dba03A71ZqPHzTTnT85dk9MBLyh7YRlBcZH0dykHwIBs5QmIi6TshWWcCXzBpNw1MzybEEJ8KSkexP+FiIhI/AKCcHa0Y++hU7RuWoc/fu/Ett2HANi17xjNGlRXLW9sbEQmE2Nee3hnaI774b7cCUt9nQqggV0+tnreAmCr520a2OUDoKFdPrZ63n47/Rb17fJmaC4hhEgPOW2hIdp2H0aDWpU5cOQMuro6zJ/6B5lMjLn38CnTF6wlJiaG+jUr0b5lA1Zt3EVCYiJ37j3B29efEQO78veBE9y4/YCuHZrRsE4VDhw5w+VrdwgNC8fT24+6NSrQsXWjZNuMT0hgwfLNXLt5H319PQb1/pU8ObPSqstQNiydgpGhATfvPGT3gRP06NiCKXNX4eRgy5Ubd2lUtwq6urrsO3QKO1srZk0YjLa2Fucu3WDJ6m0kJCbwW5vG1K5WnomzlpM9qzPnLt/Aw8uH6WMHYGJsxISZy4mMiqZDzxEsmjES00zGAKzauAs9PV3OXrzBL41rYmluxqqNuwgJDSdHtsyMH9aL7bsPc/Lsv9y6+4gyJdwY1PtX9h4+xZadB1EoYECP9pQsVlD1Wl+88iRvLhcA/AICqVS2GA521vj6BRIeEUloWARODrbJ9o9bgTw8euJOZif77/vmv2Wpa4SWQkFAXNLpCI/oEJwMTAFwMjDFMzo0KX9sBLoKbSx0DQmKi/oh2YQQ4kPS8qAhIqOisTA3ZcPSyViYm3L+8g3i4uKZMncVsyYMYvOK6Vy7dR+/gCAAHj99ybwpQ2lUpwqTZq2gX/e2TBvbnw3b96nW6esXwJTR/Vi3eBK79x/njadPsm3uPXQKX/9ANi2fyoiBXRk9ZREAVcqX5MyFqwCcuXCN6pVKAfDwyQtaNa3DirljWbZ2BzaWFmxYNgVf/0DuPnhCcEgYS9duZ9WC8WxcOpU//z5CfHw8AK89vVk8YwS/NK7F7gPHyexkT9cOzahQpigblk5RFQ7vHDp2joXThlGjchns7ayZMX4gm1dMw9c/kJt3H9G6WV3y5s7GiAFdGNT7V9xfeXDgyBk2LZvCynnjWLlxV7L1eXj5YmdrDYCjvQ037z7ixp1HODnY8tf+Y9StXp5p81YzYeYyAoNCALCzscLD2zdD3t8vkYgy2WMFCtWUROXH80D50TQhhPhRpOVBjRKViSi03tdvpYoVRKFQkDtHVgKDQnnl4YW3jz+D3/ZRiIyKxtcvEICihfKho6NDnpwuZMvqhJWlOWamJgQFh6rWlzN7VowMDQAomD8XT569xMzURDX/6o27VK9YGoVCQc5smTE01OfVG2/q16rI/OWbqVW1HNdu36f7by0IDAzB1toSlyyOAFhZmlO8iCs62trkzJaFwKAQwsIj8Q8IpsfACQCERUQSHBIGQMmiBdHS0iJ3Dhdu3nn02X1Tt3oFDAz0AbC3tebMhatcvHoLX78AvH38Uyx/5cY9PLx86NR3DAARkcmPyH39AsiZPQsAjepUYfSUxURFxzC0b0cOHT/PlZv3KFwwD/a21mzYvo/+Pdpha23BqXMBqebbufcou/Ydff943bzPvqbPCYqLIl6ZiLWeEf6xkTgZmOIRnVTIeESH4mRgik9sOLZ6xsQkJhAcH/3N2xRCqN/Wvw6xZccBWjWtQ9sW9ZLNe+Ppw7jpS4iKjqH9L/WpXa28mlImJ8XDD2RsbER0dIzqRzE4JAxrS/MUy2lra6FUKlEqIYuzA2sXTUw2/+KVm6q/dXS0P/hbJ82jUR0dbfT19ZJNUypJOoT9SNbMjsTGxnHz7iNyuGRGX08vxTLJt6uNElCipJhbPqaM7pdqBgCdt6/tc7Q+KKrmL99EQmIirZrUwdBAP83n16xSjt+7tUl1npmpCWHhEW//zsSCacMA2Lh9H03rV2PTjv2UKFITB1sr1m3dA0BoWARmZiaprq95wxo0b1jjs6/jSywt0IgNb25wMfgVe30e0NrRjYXuF2nt6MYenwcA7PG5T2tHN66HetLa0Y29Pj+2o60Q4vspWjAvT5+/SnXe/OWb+K1NYwoXyEO7HsMpX7ooJsZGPzhhSnLa4gcqUjAvh46fA+Dpi9cEBYfiYGed5vJZnOwJDglVXVHg45v6UXBafP0CiE9IwD8giFt3H5E/Tw5QKFQ/viWKuHL89GWUSiXP3F8TGRmlOr9fp3p5ZixYQ7WKpb54e655c3DzziPcX3l8UV5bG0t8/QI/W0xcu3mfxnWq4ORoy4uXnqrpdjZW+Pq/bYlxy8ex0xfxDwhCqVSm2Lajg22KaRGRUQSFhOHsaIe1pTmPnr7g0VN3rK0sAPD29cfZwe7LXvwXMNMx4EzpbixwbUBOYyvOlO5GW8fC5DK2xkov6ctg1KMjVLTMxoWyPTDXNWTBi/MAzH9xHktdQy6U7UEFy2yMfnz0U5sSQvyH5MmVLdXfgoSERC5dvU3hAnkwNjYii7MD1289UEPClKTl4Qfq07U1U+as5K99x9HSVjBqUDd0dNJ+C/T0dJk4oi+zFq0jISERJ0dbJo/8/Yu3FxAUQt+hUwgMDuX3bm0xN8tE9qzOeHj58Nz9DQ3rVuH5Sw/adR+Ovn7StnR1k/JULlecBSu2ULJowc9s5T1LczNGDOzKyEkL0dbWomD+XAzp+1uayxfMl4uw8Ag69BzJ9HH9cbS3TXW5lk1qMXrqYpwd7bC1sVRNr1W1HBNnLefG7YcMH9CFLu2b0XvoFPT19ahSvgS/tWmsWjaLswMHjpxJtt7dB47TpF5VABrWqcLg0bOIjYtn0si+ADx78fqLxoT4UiHx0amO7bDZ86bq78C4KFpc35JimajEeDrf+SvDsgghNF9IWBjmppkwftvSkMXZAf+3/d7UTREbGyO9rn5CB46c4cHjFwzu8+vXPf/oGdxfetK7S6sMTqY+wybMY/Sgbqr/iJ+SkJDIoNEzmTt5KApFKud2PqKrq4fFkQkZETPDBdUcQ1xcrLpjpEpXV0+yiZ+C7clpKaYtCSuWrG9UswZpn+5ctXEXhgYGyfo8BAWH0q7HcA5sWwzAzEXryJktM03qVcvg9OknLQ8ihXHTl+Dh5cvsiUPUHSVD1atZkVMXrlKvRsXPLnvr3iPKly76RYWDEEKk5lv7Rr3rqxUeEYmJsRGv33hn+Ki3X0uKh59UvZoVqVfz8z+SqRn3R68MTqMZypUszJde3VikYF4K5c/1fQMJIUQqNu84gI21BTWrlKVMCTdu3HlIkYJ5ee3hRdFC+dQdD5DiQfwf+fAKjs9RKBSf7I8ihBAZwS8giEGjZhIQFIKWQsHFq7fIntVZ1erZv3s7xkxbzLK1f9KzU0uMjQzVnDiJfDsKIYQQamJjZcGGpVPSnO9gb8PKeeN+XKAvJJdqCiGEECJdpHgQQgghRLpI8SCEEEKIdJHiQQghhBDpIsWDEEIIIdJFigchhBBCpIsUD0IIIYRIFykehBBCCJEuUjwIIYQQIl2keBBCCCFEusjw1EJkkKCaY9QdIU26unrqjpAmyZZ+cqtwoW5SPAiRQYJrfP2td78n86NHsTgyQd0xUhVUc4zG/hDq6uppbDYh1E1OWwghhBAiXaR4EEIIIUS6SPEghBBCiHSR4kEIIYQQ6SLFgxBCCCHSRYoHIYQQQqSLFA9CCCGESBcZ50EIIYRQo78PnmDHniOYGBsxcXhvbG2sVPMmzlrOjdsPMTE2BGDRjJGYZjJWV1QVKR6EEEIINQkMCmHj9n1sXj6Ns5eus3j1dsYP65VsmREDu1C8sKuaEqZOTlsIIYQQanL52h1y53DBwECfwgXzcvHKzRTLmJtm+vHBPkNaHoQQQojvYOfeo+zad1T1uFmDGjRvmHwY+4DAYLI42wNgbWlOQmIi0TGxGOi/v6/KwpVb8PELpGaVMvzWpjEKheLHvIBPkOJBCCGE+A6aN0xZLKSgAKVSqXqoTFTyYW3QoWUDjIwMSUhIoPeQyRQukIeibvnTncXLx5+9h07iHxicbHujBnVL97pAigchhBBCbWysLLj74CkAfgFB6Orqoq/3vtUha2ZH1d/lShXB/bXXVxUPQ8fOIbOTHa55c6Kjo/3NuaV4EP834uLi+fPvf2jbot5nl42OjmH3geO0blY3w3Po1amDfuPGAEStXUv8pUspljGZNQuFrS1ERibl2bKFuDNn0M6XD6N+/UBLi/gHD4hasgRiYjIkVyvHQvTNWoYEpZKKl1akmG+tZ8TSAo1xMjDlQbgffe/tJTIhDiNtXRbmb0C+TLZ4RofR4+5u/GMjMySTED+7kkULsmL9TqKjY7hx+yFlSxZm844D2FhbUKJIAf69fpeaVcoQEhrOrXuPqFW13FdtJ1GZyJTR/TIst3SY/EmVrd2eDj1HqP49ff7qi57XoecIvLz9kk27cechHXqOYNq81d+cq0bTr2siS82BI2dYtXHXFy9/8ty/mJmakJiYyPAJ82nSoT9HTl5QzZ82fzXxCQkAGBjoc/32A6KiozMsL4CWkxMG7doRPnAgEWPGYDRoEBgZpbps5IwZhPXoQViPHsSdOQOA8ahRRC1bRli3bij09DD45ZcMy3Y71JuNHjfTnD85d01OB7yg7IVlBMVF0t8l6UtsQLbyBMRFUvbCMs4EvmBS7poZlkmIn52FuSkd2zSmc7+x7N5/jF6dW+LjF4B/QDBGRgY8fPKc3/qMpmPvUdSuWg7XvDm+ajvFC7t+8e/Al5CWh5+Ugb4eG5ZOyZB1/XP8PC2b1qZejYoZsj51+efEeSaO6Mute4/JlMmILSum0WPQRGpWKcv12w9wc82Djvb75rzK5Utw7PRlGtSqlGEZdMuXJ+7SJZQRESgjIkh4/Bjd4sVVxcGHlCEhyR4rzM1RmJgQf/MmALGHDmHYrx/RGzdmSLb74b5Y6BoCbinmKYAGdvkY8egIAFs9b7PItSFTnp2ioV0+etz5++30W9yo0BfuZkgkIf4vNKhVKdn3zMBeHVR/9+veLkO28cbTm95Dp2BvZ5Vs+vrFk79qfVI8/B8JDAphwsxlePn4kyt7FsYO7YmOjjZL1/7J6fNXcHa0Jzg0LNlzjp66yImz/3L5+h0SE5X4+PpjaGBA2xb18PL2Y/CY2WxeMY0DR87w+Jk73j4B3H/0jC7tm9GobhXi4uKZsXAtdx88IYdLZuLi4wHw9Qtg2IT5hEdEkjeXC2OH9kJbO6kh7Pqt+xw5eZGg4FCcnexo3rAmc5asx8c3AF1dXaaN7c8bTx+WrNkOJF3qtHLeOO49fMr0BWuJiYmhfs1KtG/ZQPU6EhMTSUxUYmRogJ9/IDmzZcHQwAA9Xd2k13nyIoP6/JrstRcukJfNOw5kaPGgZWtLot/7lp1EPz+0bG1TXdawRw+07O1JePiQqGXLUIaGooyPR7tgQRIePECnSBG07OwyLNunWOoaoaVQEBCXdDrCIzoEJwNTAJwMTPGMDgXALzYCXYU2FrqGBMVF/ZBsQojPa9uifoauT4qH/yPzlm2iWcMalC9VhDWb/+bU+SsYGRpw885DNi6dSmxcHO17DE/2nBqVy3Dp6m3KlSpC1QolP3ma4Pa9JyyaPpyXb7wYM3UxjepWYc+hk0RGRrF5+TQCgkI4e+k6AMdOXyZ/nhwM6t0BH78AVeHwzuET51m7cCLZsjoRGRVN365tyOLswLK1f7L30Ek6t2tKk3pVAejSvhlxcfFMmbuKuZOHYmlhxuDRs6hdvTw2VhYABASFYG6W9GPnaG/LmQvXqFqhJAkJCdy885CC+XOxaft+njx/SaumdSiYPxe21pZ4+SQ/hfM19OrUQb9Ro6QHWlrEnjjxfqZCAR/0fH4ncskSlMHBkJCAYe/eGHTsSNTChUROnYphz54QFUXsiRMow8O/Od+XSCR5RgUK1ZRE5cfzkvceF0KoX9FC+QCIjokFSHYp6NeQ4uEnFR0TS4eeIwAomD8XQ/r+xpUbd3nx0oOV63cSGxdP47pVeeD3nLo1KqCnp4ueni6ZTL5+2FPXvDkxNjYid04XgoKTjkSv3bxP43pV0dLSwsbKQnWkX7p4IcZMW8y2vw7RpF61FOsqUjAv2bI6AWBkaEBYeATzlm3i1t1H5MiWOcXyrzy88PbxZ/DoWQBERkXj6xeoKh58/QKwsTJ/mzMHpplM6Dd8Or27tOLoqYvUq1mRm3cfMmpwNwaOmsXSWaPQ1dUhNjYu1df68fXbO9fNS3O/xB46ROyhQwDo//JLstYCLRsb4q9eTfGcxOfP3z//xAlV34b4q1cJf7u8TsmSJHp4pLndjBQUF0W8MhFrPSP8YyNxMjDFIzrptIpHdChOBqb4xIZjq2dMTGICwfEZ21dECPFtAgKDmThrOddu3UdLoUWRQnkZPbg7VpbmX7U+KR5+Umn1eVg2ZzTGRoaqx3OXbiAyMn1f9O86FaZFR1tbdeSZkJBAZGTK5uvsLs6smjeO3QdP0L7nCNYumoiJ8fuOg1pa71siTp79l517j9K1QzMK5s/FhX9vplifUglZnB1Yu2hiqplMM5kQGh4BgEKhYOjvvwFw695j8ufNwRtPH3Jlz4qhgQEJb19fYmJishwf+qLrt1MRd/YsJrNmEb1mDQoTE7Rz5iTu6lUUmTJhNGIEkVOmoGVri8LamvjLl8HAAL1KlYi/fx8A7Rw5SHjxAnR1MWjZkpg9e9KdIT2WFmjEhjc3uBj8ir0+D2jt6MZC94u0dnRjj88DAPb43Ke1oxvXQz1p7ejGXp/73zWTEJrooVtXdUf4pFmL1lOqWEFmjh+EUqlk1/5jzFy0jmlj+n/V+uRqi/8jxdzys+2vpCPgwOAQYmJjyZ8nJxf+vUlCQiK+fgH4BwZ/ch0W5qY8evKCxMREjp1OeYnhx/LnzcG5yzdQKpU8d39D9NvLCh89dUehpaBl41ro6eni4eWb5jqu3XpAxbLFcCuQh6cv3vcWtrWxwtc/EIAsTvYEh4Ry/VbSD5ePb0CyddjbWuPnH5Ri3UdOXqBW1XJYW5rz6MkLIiKjiI5OyhgYFIKtjeVnX2N6JHp5Eb1xIyZz52I8YQKRs2ZBVBQYGKCdJQsYGJDo749uuXKYLF6M6erVKOPiVJ0idStUINPSpWRatIi4y5dT7Wj5Ncx0DDhTuhsLXBuQ09iKM6W70daxMLmMrbHSSyrqRj06QkXLbFwo2wNzXUMWvDgPwPwX57HUNeRC2R5UsMzG6MdHP7UpIYQavPH0oXWzuujq6qCnp0vrpnXw8Ez7e/dzpOXh/8iAnu2ZPGclbbsNI5OJEWOH9qRaxZJcvnabtt2HkTtHFhzsbD65jioVSrL7wAlad/2DX1s1TDrB/QktGtZgzLQltO85ggL5cmJjlfRj7Only/T5qwkNi6CoWz5yZc+S5jpqVyvHjAVrOH3hKm6ueVTTSxcvxMbt++jUdwyLZ45g4oi+zFq0joSERJwcbZk88ndVX4p3pyA+bE24c/8J+XNnR0dbG7cCedm++x/adR9Gj9+SThE8c39D1swOn92v6RV7+DCxhw8nm6b08yO0bVvV46g5c1J9bvS6dUSvW5fhmULio1Md22Gz503V34FxUbS4viXFMlGJ8XS+81eGZxJCZBxtbS28vP1wsE/6jvfy9kNL++uHuVbExsZIzybxf2H9tr3kz5OdEkUKfNHyE2Yuo0fHFsluj5sWXV09gmuk/zTGj2B+9CgWRyaoO0aqgmqOIS4uVt0xUqWrq6ex2YTmCQwMSDHN0vLz3x0/yrlLN5g6bxWlihUE4Mr1uwwf0IWyJQt/1fqk5UH832hYuzIrN+z6ouLh3amLLykchBBC05UvXYRls0dz5XrSICyd2jbB2fHrL/WW4kH837AwN2Vgr/ZftKyBgT4jBnT5zomEEOLHyexkT2Yn+wxZlxQP4v+Kjs6Xf+TTs6wQQmiiCTOXMWZID5p2GEBqd/LetX7uV61Xvh2FEEKIn1S7tyNLTh/bP0PXK8WDEEII8ZPK7uIMgKePH5XKFk827/Dxc+TKkfWr1ivjPAghhBA/uTWbdyd7nJiYyJrNf3/1+qTlQQghhPhJ9R4yGYVCwRtPH/oMfT/qsI9fgKpV4mtI8SCEEEL8pEYN7g5KJb8Pn0andk1U0x1srVUDRn0NKR6EEEKIn5SDnTUAi6aPwM4248atkeJBCCGE+MmZmhrz1/7jvPH0QalMVE3v173dV61POkwKIYQQP7nRUxZz5sJVzl26jrGRIZ5efigUX18CSPEghBBCqNHfB0/Qtvswug+cgK9f8ntkvPH0oUu/sbTtPozDx8999Ta8vP2YN+UPChfMQ62q5Rg/vDceXj5fvT4pHoQQQgg1CQwKYeP2fayeP57mDWuwePX2ZPPnL9/Eb20as2LOGJav20F4RORXbcfAQJ+EhETcXPNw4d+b6Oro8OqN11fnluJBCCGEUJPL1+6QO4cLBgb6FC6Yl4tXbqrmJSQkcunqbQoXyIOxsRFZnB24fuvBV22nWsVSPH3+kioVSrLn4EkatOmDa96cX51bOkwKkUHMjx5Vd4Q0BdUco+4IadLV1VN3hDRpaja5Vfh/w869R9m17/33QrMGNWjesEayZQICg8ninHSzKmtLcxISE4mOicVAX4+QsDDMTTNhbGwEQBZnB/wDgr4qS5vmdVV/r1k4gZdvvMiRLfNXrQukeBAiw1gcmaDuCKkKqjmG4Bo1Pr+gGpgfParR+01+pMW3aN4wZbGQggKUSqXqoTJRqbqBlQIFiR/MS1QqUWilcnerdDIw0CdPThd27TtKswZf990gxYMQQgihJjZWFtx98BQAv4AgdHV10ddLavEyMzUhLDyC8IhITIyNeP3Gm9LFC6Vr/TWbdQNSFhxKpZLMTvZSPAghhBD/NSWLFmTF+p1ER8dw4/ZDypYszOYdB7CxtqBmlbKUKeHGjTsPKVIwL689vChaKF+61r9+yZRUpysUYGfz9YNGSYdJIYQQQk0szE3p2KYxnfuNZff+Y/Tq3BIfvwD8A4IB6N+9HRu27aX7wAn07NQSYyPDdK3fwc5a9S8sPILHz9xxsLPG3taa2Li4r84tLQ9CCCGEGjWoVYkGtSqpHg/s1UH1t4O9DSvnjfvmbazbuod/r9/Bzz+ISmWL4+Xtx5ylG5g5ftBXrU9aHoQQQoif3KFj51gwdRiGhgZAUlHi6x/41euT4kEIIYT4ySkUChQKLdWVHIFBIURHf/3VRHLaQgghhPjJ1alenkmzVxAeHsmOPUfYsecIDWtX/ur1SfEghBBC/OR+bdWQIycvEB8fz627j+jUtjG1q5X/6vVJ8SCEEEL85Jas2U6vTi2pWaVshqxP+jwIIYQQP7m7D54QERmVYeuTlgchhBDiJ1elfEk69R1D47pV0NbWVk3/pXGtr1qfFA9CCCHET+7RkxcUzJeTZy9ev5+o+Pr7ZEjxIIQQQvzkGterRoF8X38L7o9J8fAf98z9NZ5evlQoU0zdUX4qZy9dx97Gilw5smboemvb5GZEjspoKxQsf/UvGzxuqOY5G5iypXAr1WMjbV2s9YxxOTkDI21dFuZvQL5MtnhGh9Hj7m78YyMzNBuAXp066DduDEDU2rXEX7qUbL52vnwY9euneqwwMUEZHk5Yjx7o1aqFXr16KExNUQYEEDlzJone3hmSq5VjIfpmLUOCUknFSytSzLfWM2JpgcY4GZjyINyPvvf2EpkQ98P2mxCabs6S9axZODHD1pdmh8mtfx2iQes+bN5xQDUtOCSMvn9MpW23YWzasZ/ExETadP2D1x5JXxDx8fE07ziQoODQdIU4ePQsB4+e/cqXkLajpy7Spd9YWvw2iL8Pnvhs3ufub+jQcwQdeo6gbO32qr+9ff0zPFtG2bnnKNmyOqs7BgBNOvRXdwTgyz5PB46cYdXGXWnOd8nsyK79xzI0l6mOPgtcG9D25nbqXlnP0ByVyGZooZr/JjqUipdWqP5dCHrFkAcHARiQrTwBcZGUvbCMM4EvmJS7ZoZmA9BycsKgXTvCBw4kYswYjAYNAiOjZMskPHhAWI8eqn8Jr18TuXgxAIkBAYQPGUJYx44kPH+OfuvWGZbtdqg3Gz1upjl/cu6anA54QdkLywiKi6S/Szngx+w3If4LGtWpypLV2wgNiyAiIlL172ul2fJQtGBenj5/lWzams27qVSuOI3rVuHX3qOoWKYYLZvUZvf+4/zevS1nL16nRJECWJibpitE3RoVvi79JyQkJPLqjRdLZo4iKjqapr8OoGqFUp/Mm93FmQ1Lk+5AVrVRZ9XfmioiIhK/gCCcHe3UHUWjZMTnKbOTPX7+QURERGJsbPT5J3yB6tY5uRHiyevoEAD+8XtMA7t8LHC/kGLZshZZcDDIxA7vuwA0tMtHjzt/A7DV8xY3KvSFuxkSS0W3fHniLl1CGRGBMiKChMeP0S1enLgzZ1Jfvnp1Er28SLhzB4D4q1cB0LK3R2FtTfy//2ZYtvvhvljoGgJuKeYpgAZ2+Rjx6AgAWz1vs8i1IVOenfoh+02I/4Ll63YQHBrGpg8aBBQKOH9o41etL83iIU+ubDjYWSebduHfmzSsUwUdHR0K5svFxSu3aFS3Kh16jqDbr83Ztf8Yg3t3TPacibOW45LZkdMXrhIVHcOIAV1Yv3Uv9x49Y+TArpQtWZhVG3dhaGBA2xb16DVkEtUqluLg0XOER0Qwb/IfONjb0GvIJPp2bUO+3Nk5cOQMDx6/YHCfX/nnxHlWrN+Jjo4Ondo2oVbVpGtYtbW16NyuKQB6ero42tkSHBJKrWrlPpk3LRNnLSdPThcOHz/H793aYmlhxqTZKwgJDaNUsUIM6Nkeb98A5ixZj49vALq6ukwb2x8bKws27zjArn3HMNDXY2DvDhQv7ErVRp05sWe1at3lShWhaoWStO8xgga1K3Ho2DmKuuUjWxYn6teqhFKppF334ayYO0b1Y/bilSd5c7kA4OXtx8jJC8nibM+TZ6/IltWJ0UO6o6+nx7lLN1iyehsJiQn81iZpYJCPX4+NtSXT5q0mKCSUbFmcmDC8N689vFO8xoNHz/L4mTvePgHcf/SMLu2b0ahuFbr2H49/QBAdeo6gT5fWWJibsmDFFoJCQrE0N2Pa2P4YGRpw4MgZ1m75m4DAEPT1dWlQqzK9u7RizebdHDl5ET1dHUYO6kaenC7J9r2ZaSbuPnhCcEgYA3t1oHTxQkRGRTN9/hqevniFaSYTRgzoQmYn+89+nrz9AliyZjsAl6/dYcXcscxfvpmzF69hbGzEmCE9yJktM3lyuuD+2hPXvBlzntDJwBTP6Petch7RoTgZpF5o93Upy0L3i6k+1y82Al2FNha6hgTFZdylV1q2tiT6+akeJ/r5oWVrm+byBs2bEzExeTOoYd++6DdsSMzBg8QeOpRh2T7FUtcILYWCgLikoyiP6BDVfv0R+02I/4KDfy7J0PWla5yHwKAQ1VFuFmcH/AOCMdDXo0blMqzcuAt9PT1csjimeJ6Xjz8r543DzTUPsxdvYNywXgzo0Z6tu1L/cgkLj2TV/HEUL1KAwyfOfzLThu37mDSyL+uXTKZk0QKpLuMfEERYeARODnZflDctZy9eZ8W8cRQumJcpc1YyuE9Htq2aSVR0DPcePsPM1IS+XduwYekUShRxZe+hkwCs2bKb1QvGs2LeWPLmyvbJbYRHRhIaFs6ahRNoUKsS/5xIOip95v6GzM72yY6CPbx8sbN9X+B5evvSuV1TNi2fSlxcPEdPXiQ4JIyla7ezasF4Ni6dyp9/HyE+Pj7F65k4cxlN6ldj07KpDOzVAYVCkeprBLh97wljhnRn+rgBbPxzHwAThvXC2sqCDUunULJYQSwtzBgztAeblk3FwtyUk+f+JT4hgXnLNrF8zhh2rptNJhNjendpxeVrd3j64jVbVkxj2tj+rFi/I8V+USoTWT5nDJNG9mX6/NUolUrWbfkbC3NTNi+fRtvm9Zg4a3mq+/Tjz1ORgnlpUq8qTepVZeW8cYSGhXPgyBm2r5nFvClDyeyU9Bm3t7XCw8v3iz4bXyJRqUz2WAEoP5oGSac3Spg5cybwRbqfm156deqQadkyMi1bhk7BgslnKhSQxja0XFyScnl4JJsetXAhIU2botDVxbB372/O9yUS+XjfKFRTvtd+E+Jj+u06pPinaSIiIrl09TaXr9355jEf0tVhUvHBl0miMhGFVtJlHs0aVKdx+37Mnjg41ecVL+KKQqEgT04XtLS0MDI0IE8uFwK3hqS6fKliBZOWz5GVJx+dOvlY3eoVWLB8M53aNaFEkZTFg1KpZMGKLfzWpjHa2lpflDctjepUQUdbm4jIKB48fsGktz9W0TGxlC3hRoF8OQkLj2Desk3cuvuIHNkyA1C/ZkUmzV5O1w7NP1s8ADStXx2FQoFLFifi4uLwDwjizIWrVKtYKtlyvn4B5MyeRfXYysKczE72QNI+fPTUHXMzU/wDgukxcAIAYRGRBIeEpXg9Hl6+VClfAki6v3xarxHANW9OjI2NyJ3TJc3+LZYWZvx7/S7rtvzNo6fuZHF2QFtLi0wmxoSFR6BUQmJiIpB09P/g0TM69h4FoLrr24cK5s+NQqEgV/YsxMTGERoWzpUb9xjc51cASpcoxISZS1P9D/G5z5NpJhOKuuVj0qzldG7XFEtzMwBsrC1TnLp7Z+feo+zad/T943XzUl3uQx7RoVSyfP/+OxmY8jwyKMVyJcycuROWvKPhu1YKn9hwbPWMiUlMIDg++rPb/JzYQ4dULQT6v/yClt37U2BaNjaqUxEf0ylQgPjHj1OdpwwLI/rPPzGZMoWot/0hvqeguCjilYlY6xnhHxuJk4EpHm9PDX2v/SbEf829h08ZNn4eTg62KBQKPLx9mTamP/nz5Piq9aWreLC0MOONpw85s2fh9Rtv1Q+XpYUZVpbm5Mr+6Z7pOjrvB6bQ0daGzxwAaGtrJzvwiY9PSLFM2xb1qFi2GAtWbObCvzfp171dsvlbdh5EV1eHhnUqJ3sdX5L3Y1pviw+USoyMDFi/ZHJSQfXWybP/snPvUbp2aEbB/Lm48O9NAAb07MCjJy+Ys3QjVSuUpGWT2iQkJqJUKpM9X7UdrfcNQnVrVuT4mctcuXGPVk3rJFvOzNSEsPCIVLPq6Gijr6+HEiXF3PIxZXS/FMt8+HpQKJJnSeM1Hjjy/vy3jrZ2mkdx2/46xJ0HT2n/S32cHe2IiIxCoVBQtmRhJsxcTmJiIn/066zaVpvm9WjR6POd2RQKBbo6Oujq6r7d9pdfp/zx5+nDdU4fO4BrN+8zYuICOrdrQuXyJQgNi8DMLFOq62resAbNG9b44m0DHPd/yvS8tclsYEZofAw1bXLT6OoGthVpxahHR3kaGQCAi5EFXjFhyZ67x+c+rR3duB7qSWtHN/b63E/Xtr9E3NmzmMyaRfSaNShMTNDOmZO4q1dRZMqE0YgRRE6ZgjIsKZeWvT1K//cdiRXm5ug3b070xo0QF4dumTIkvHiR1qYyxNICjdjw5gYXg1+x1+cBrR3dWOh+kdaObuzxeQD8mP0mxH/BghVbmDZ2AK55k4qFew+fMW/ZJlbMHftV60vXaYtypYpw485D4uPjufvgKWVKpOy89L1YmJny4PFzYmPjOH0+6WgoMTGRuw+ektnJnk5tm3D1RvIvhrOXrnPm4jWG/v5bqj/SX8vY2AhHe1sOHkvq0e/jG4BSqeTarQdULFsMtwJ5ePoi6Yg1JjaWR09ekCdXNlo2qc21m0kZjQ0NefbiNb7+gdy6+yjNbVWrWIp/TpzHysIMo4+OyB0dbPHxDVA9DouIIDQsgri4eA4dP08xt/y45s3BzTuPcH/locqa2uuxtjTn7MVrQNLpj7ReY1oszE2JiIgkNjYOgKs371O7ajly53Dh6QeDkly6eouV88axbvEk1WmmEkULsPfQKSIiIklMTEz1HvOe3kmnDy5fu4ONtQVGhgaUKFKAY6eT+gVcvnqbrJkdMTYyTDPjh2xtrFTbCQkN4+VrT4oVzk/tauW4cSfph8fb1x9nh7TP+adXWEIsfe7tZUuRlhwq2ZFpz07hER1KbmNrzHTfv7emOvpEJiS/Ve78F+ex1DXkQtkeVLDMxujHRz9e/TdL9PIieuNGTObOxXjCBCJnzYKoKDAwQDtLFjB4n1FhbIwy+v0RvDI0FGV4OCZz5pBp3Tp03NyIWrAgQ3KZ6RhwpnQ3Frg2IKexFWdKd6OtY2FyGVtjpZd0Gm/UoyNUtMzGhbI9MNc1ZMGLpNOdP2K/CfFfEBEZpSocAFzz5iAy6utb4VJtefALCGLQqJkEBIWgpVBw8eotFk0fwW9tGjN6yiL+PnCC+rUq/tBe/i0a1WTEpAUcO32JqhVK8cbTh/j4BA4dO8uMhWuJjIyib7c2quWjo2MYO3UxtjZWdO0/HpRK6lQvT+tmdTMkz5gh3Zk6dxVbdh7EysKcKaN/p3a1csxYsIbTF67i5poHgJiYODbvPIj7Kw/i4uMZ3r8LAO1bNeD3YdMoVCA3ZUsWTnM7xkaG2NtaU/WjUxaQ1O/kw5YAZaKSibOW8eqNN5XKFad08UIoFApGDOzKyEkL0dbWomD+XAzp+1sqr6cHU+etYsX6XWTN7MCYIT1SfY1pMTDQp0r5krTp9gd9urSmcb2ky4J27TuKSxYn1XLOjna07DwYI0MDHOxsaFS3CmVKuPHwyQt+6zsGAwN9WjSqSYNalZKt/8btB5w4cxmA0YN7ANCxTSOmz19N2+7DMDUxZvTg7mnm+1jp4oXYuH0fnfqOYfKo31m4civevv5oa2sxYVjSufoXL99k+JVAR/2fctT/abJpRc8tSvZ47ouU/XyiEuPpfOevDM2SmtjDh4k9fDjZNKWfH6Ft2ybPM39+8icmJhKzbRsx27ZleKaQ+OhUx3bY7HlT9XdgXBQtrm9JscyP2m9CaDoLM1NOX7hKpbLFAThz4RrmabSsfglFbGyM9B7SYMEhYfQfMZ3lc8egr6eXYv6wCfMYPagboWERDB4zm80rpqkh5Zd57eHN4tXbmDamP4mJiWz76zB3HzxJ9ZTKhz68GuVHCY+IZPLslUwd8+ls7+jq6mFxZMJ3TvV1gmqOIbhG+k6x/CjmR49q9H6Li4v9/IJCABF166WYZnzwQCpLfl5wSBijpywiMCiEOjXK065F/WTzvbz9aNV1KFmdHQCoVqk0v7Zq+Ml1vnztydBxc4mNTfpM6+vrM2PcALK8XUd6yQiTGuzk2X9ZvHob/Xu0T7VwAKhXsyKnLlylaMF8Pzhd+llbmaOro0PH3qOIjY3DztaKQb1/VXesVJ2+cJX6tSqqO4YQ4v9QamMqffwjnz93dpbOHv3ZdXn5+KOvr0vWzI5sWTGd1x5eAPj4BaKr8/UlgBQPGqxKhZJU+czRdrmShVEqk8a10ORWBwBDAwMmjuiT7uel53RERqldtfy33DNGCCG+WmpjKn1cPKTVmftjc5dsoEOrhliam6GtraU6jRwTE8vcpRuZMX7gV2WU4uE/7sMrM0TGeXdZrxBC/Gipjan0safPX/Fbn9EYGxsyuPevyfqWfcjbLyDVG2LlyZUt1c7pX0qKByGEEOI7+Hg8mGYNUl7ivW7LHi5evZVsWlR0TKpjKr1ja2PF6CE9yJcrG9t2H2LGwrUsmTkqzRzxCQlJwyN8IC4unri3AwZ+DSkehBBCiO/gS8aD6dimER3bNEo2rcVvg1IdU+kdbW0t3FxzA0k3vNq++58011+pbDGmzVvN4D4dMdBP6jsXHR3DrMXrKVeqyNe8LCCd4zwIIYQQ4vtKbUyloOBQBo2eRXxCAkdPXSQgMBilUsnZi9dU9zhKza+tGqKjrU2T9v3oPWQyvYZMonH7figUCrp1aPbVGaXlQQghhNAgqY2p5OXjz8vXnsTHxWNrY8WoKYsICAzGytKcMZ/oVK6jo8Ow/p35rU1j1eCFObJlxt7WOs3nfAkpHoQQQggNYmZqwoJpw5JNc7CzZue6OQC4ueZm6ay0+zikxs7WCjtbqwzLKKcthBBCCJEuUjwIIYQQIl2keBBCCCFEukjxIIQQQoh0keJBCCGEEOkixYMQQggh0kVuyS1EBtDVTf2up0J8D3KrcM2Tkbfk/i+QcR6EyCDBNT49DK26mB89isWRCeqOkaqgmmNkv30F3yrDPr+QEN+RnLYQQgghRLpI8SCEEEKIdJHiQQghhBDpIsWDEEIIIdJFigchhBBCpIsUD0IIIYRIFykehBBCCJEuUjwIIYQQIl2keBBCCCFEukjxIIQQQoh0keJBCCGEEOkixYMQQgihQTy8fBkwcgbVmnRJdb5SqWT1pr9o220YA0bOIDwi8gcnlOJBCCGE0Cgmxka0/6U+ysTUb3r9+Kk7F/69xYalUyhSKC+b/tz/gxPKXTXF/5F/r93BxMSI/HlyfHbZs5euY29jRa4cWTM8h16dOug3bgxA1Nq1xF+6lOayBp07Y9CqlerOkzolS2LQujUKU1OU0dFEzZ9PwuPHGZKrtk1uRuSojLZCwfJX/7LB44ZqnhYKeruUprFdfqz0jHgY7kePO38THB9NTetcDMhWDks9IyITYhlw/wA3Q70yJNOHvmW/YWCA0cCBaLu4kBgQQOT06SiDgzMkVyvHQvTNWoYEpZKKl1akmG+tZ8TSAo1xMjDlQbgffe/tJTIhDiNtXRbmb0C+TLZ4RofR4+5u/GN//BGk0DxmpiYUdcuf5vzz/97EzTU32tpaFC6Ql1mL19Pjt19+YML/g5aHiIhIJs1eQbsew+nYexT/nLgAwMRZy2nSoT8tOw/ml06DOXYq6YvowJEzzFq0Pl3bWLVxF5t3/Hz3bb987Q7te4xg0OhZqmlPn7+i15BJtOoylKlzV5GYmPjdc3h5+9FryCTV44mzlnPi7L/pXs/uAyfI6uzAM/fXtO46lI69R+EfEATAaw9vNmzfq1rWJbMju/Yf+/bwH9FycsKgXTvCBw4kYswYjAYNAiOjVJfVzpULnUKFkk+MjiZi9GjCOncm7uRJDDp1ypBcpjr6LHBtQNub26l7ZT1Dc1Qim6GFan4iSp5EBFDz3zUUObuQBKWSzpmLAxCREEurG9sodX4JO73uMiZXtQzJ9KFv3W8GrVqhDA0lrFs34m/cwLB79wzLdjvUm40eN9OcPzl3TU4HvKDshWUExUXS36UcAAOylScgLpKyF5ZxJvAFk3LXzLBM4sczPnggxb+de4/SuutQ1b+de49myLYCAoPJktkBgKyZHVTfYz/ST9/yMGHmcoq65WPkwK5Ex8Tw8Im7al7frm2oWqEkXt5+dO43ljIl3dQXVAM5O9pRr2ZFrty4q5p2485Dxv3RCysLc7oNGM/FK7coV6qIGlN+mdce3piYGGFsbMTWZZsY1q8znt5+7PvnNL+1aczu/cfp1K6JavnMTvb4+QcRERGJsXHqP1JfQ7d8eeIuXUIZEYEyIoKEx4/RLV6cuDNnki+orY3hgAFELVpEpvnzVZPjb98GQGFtjZaDAwkPH2ZIrurWObkR4snr6BAA/vF7TAO7fCxwv6Ba5rDfY7RQkNPICms9I66FeAJwPuglAI76mchmZMG1EI8MyfShb91vuhUqEDl9OgCxR45gumFDhmW7H+6Lha4hkPL7QwE0sMvHiEdHANjqeZtFrg2Z8uwUDe3y0ePO32+n3+JGhb5wN8UqxH9Y84Y1aN6wxieXWbdlDxev3ko2beLw3tjaWKX9JIWCxLenNBITlWhpKb45a3r91MXDaw9vXnt4M21sfxQKBYYGBhQpmDfFcg72NtjbWuHn//nqLTo6htlLNnD/4TOMjQ2ZMup3AF68fMPAUTN5+OQFIwd2pVypIjx59pIFK7YQFBKKpbkZ08b2x8jQgLbdh9GgVmUOHDmDrq4O86f+QSYTYw4cOcPaLX8TEBiCvr4uDWpVpneXVqzZvJsjJy+ip6vDyEHdyJPTRZUnIDCYKXNX4e3rj72tNSMHdsXXP5Cla7Yzf+owAFZv+gtLCzMa1K7MvKWbuHLjLqaZTJgwrBcO9ja07zGCMiXduP/oGQunDUehSPogOjnYkjtHlmTFQ4tG74+OCuTLgd9HFe/EWctxyezI6QtXiYqOYcSALqzfupd7j54xcmBXypYsTGRUNNPnr+Hpi1eYZjJhxIAuZHayZ9XGXSiVcO/hU548f8WIAV0o5pafvsOmEhgUQoeeIxj3Ry8Abt19yK69R3nt6c30sQPIlzs7/5w4z4r1O9HR0aFT2ybUqlpWlevhkxcULpAHAP+AIHJmy4yxkSG37j3Cw8sXM7NMmHxUJOTJ6YL7a09c8+b87OfiS2nZ2pLo56d6nOjnh5atbYrl9Fu1Iv7mTRLu308575dfMOzalbgrV4hYvDhDcjkZmOIZHap67BEdipOBaYrlthZpRU2bXEx6coJTgc9V0393Kcv43NU55v+UPx5uzZBMH/rW/aZlY0Oivz9A0ukKHR0UmTKhDAvL8KwfstQ1QkuhICAu6XSER3SIar9+uM/9YiPQVWhjoWtIUFzUd80kNEvHNo3o2KZRup5jY2nBa4+kU4OvPLyxtrT4zDMy3k992sL9lQd5crmofgzT8ujJCwKDQnG0t/nsOtdv34u+nh6blk9lxriBWFmaAxAUEsr0sQMY1PtXtv11GABLCzPGDO3BpmVTsTA35eS5pKb2yKhoLMxN2bB0Mhbmppy/fIP4hATmLdvE8jlj2LluNplMjOndpRWXr93h6YvXbFkxjWlj+7Ni/Y5keeYt20TJogXYvHwapYsXYv7yzeTJ6YKXjz8RkUlfQhf+vUXFMsXY/89p9PR02bZqBr06t2TD9n0APH/5GmdHOxZNH/HZffVOYmIiN24/pGD+XCnmefn4s3LeONxc8zB78QbGDevFgB7t2brrEADrtvyNhbkpm5dPo23zekyctVz13IdPnjNz/CAG9urAtr8OY2Cgz4gBXcibOxsblk4hu4szADGxcSycPpxfGtdi94HjAGzYvo9JI/uyfslkShYtkCyTh5cvdrZJlbyDnQ037z7ixp2HODvYsWvfMSqXK874GcuYNn81kVHRANjbWuHh5ftF++NT9OrUIdOyZWRatgydggWTz1QoQJm8U5RW1qzoVahA9Lp1qa4v5s8/CW7QgIRnzzAeN+6b8wEkfpRBQVKP7o+1vLGVfKfnUMYiK72zllZNX+B+AafjU7kb5sOmwi0zJFOG7rePX8sXfs6/VSIf71eFasqX7nMhAIKCQxk0ehbxCQmUK1WYW3cfkZCQyI3bDyhbsvAPz/NTFw+fs3DlFtr1GM7ClVuZOKIPenq6n33O5au3adGoBgqFAnOzTKof26KF8qOrq0PuHFkJDE5q+rW0MOO5+xtmLlzLo6fuePsEqNZTqlhBFApF0vJBoWhraZHJxJiw8AhCwyJUfQkuX7vDg0fP6Nh7FMPGzyM8IvlRydWb96heKelLvHql0ly5fheFQkG5UoW5cv0u/gFB6OnqYGVpzr/X7nD24jV+7TWSOYs3EBoWDoCuri4NalVK177be/gU2bI6k8Mlc4p5xYu4olAoyJPThfx5cmBkaECeXC6q/XLlxj1qVE7KXLpEIdxfeagKndT2Y2pKFi2IlpYWuXO4EBiUdPRWt3oFFizfzJ37j7EwT37U7OsXqKrO2/1Sn3Vb93L24nWKF3HFzNSEv/Yfo3HdKri55mHf4VMA2Fhb4uMbQGo+Ppf5KbGHDhHWowdhPXoQe+wYWjbvi1QtGxsSfZMXKHo1aoCuLiazZmGyYAEAJgsWoMiU6f1C0dFEb9mCbpkyoPPtDYgftzQ4GZjy5oOWiA95x4Sz6vUV6tsmb8WLTIhj9vOz1LbJja7i279aMnK/Jfr5qZ6vsLCAuLjv3uoAEBQXRbwyEWu9pFYtJwNTPN6eGvpwn9vqGROTmEBwfPR3zyQ034r1O+nQcwTRMbF06DmC42cuEx0Ty8vXnsTHxZMrR1YqlClGh54juHP/MW1b1PvhGX/q0xZZMzvy6Ik7SqUy1SPqd30e0iMxMfV1vaOjrc27Q4ttfx3izoOntP+lPs6OdqofyA9pa2up8pUtWZgJM5eTmJjIH/06Jy2gVNKmeb1kpws+lNZrq1y+JPsOnSQ0PIKK5Yq/WxX9urejfOnkfRS0FIovbnEAuHXvMXsOnmTRjBGfXE5HR/v93x/sl6Sjq09v78PlP72cluporW2LelQsW4wFKzZz4d+b9OveTrWcmakJYeERQNLpmJXzxgKwaNVWfm3VkNFTFpEzexaMjQzZtS+po2RoWARmZplIzZecy0xN3NmzmMyaRfSaNShMTNDOmZO4q1dRZMqE0YgRRE6ZQvSqVUSvWqV6jvnRo4T//jvo6WHYqxfRGzagDA9Ht2xZEl69gvj4dOf42HH/p0zPW5vMBmaExsdQ0yY3ja5uYFuRVox6dBRthYL6tnlZ4H4BBQqqW+fgfrgvBlo6jM1VjWnPThMSH01d2zw8CvcjTpmxHWm/ab8BcWfOoFezJlGPHqFXsyZxZ89maL6PLS3QiA1vbnAx+BV7fR7Q2tGNhe4Xae3oxh6fBwDs8blPa0c3rod60trRjb0+KU9Rif9P3X5tTrdfm6eYvnPdHNXfv7VpzG9tGv/AVMn91C0PWZwdcLC3ZufeoyiVSmJj49hz8OQ3NQ0WdcvP7gPHUSqVBAaFEBWd9pHC1Zv3qV21HLlzuPD0xevPrvvS1VusnDeOdYsnqZrdSxQtwN5Dp4iIiCQxMRFf/8Bkzyle2JVjp5OuFDl+5jLFiyRd3lMwX06evnjNxX9vUblsUvFQoogrO/ceIS4unri4eAKD0j6yT4unty9T565i0si+GBsZpvv5STkKcOz0RSCpJSdrZsdPrsvWJqk/yqeu7EhMTOTug6dkdrKnU9smXL2R/IvY0cE2RSuCl7cfJsZGZDIxxsrSnEdP3Xn01B1rq6QWCm9ff5wdUp5X/xaJXl5Eb9yIydy5GE+YQOSsWRAVBQYGaGfJAgYGaT85NpaEFy8wnjqVTOvWod+wIZFTpmRIrrCEWPrc28uWIi05VLIj056dwiM6lNzG1pjpGuAeFYSZriHHSnXmavneWOsZM/HJCaIT43kQ7suuYm25Vr4PnTOXoMudvzIk04e+ab8B0du3o8iUiUwrVqBTuDBRy5d/cvkvZaZjwJnS3Vjg2oCcxlacKd2Nto6FyWVsjdXb1oZRj45Q0TIbF8r2wFzXkAUvzgMw/8V5LHUNuVC2BxUsszH6ccb0xBfiR/ipWx4Axg7txezF69m9/zj6+nq0alr7i4+yT1+4yoNHz5NdP9upbWOmzl1F227DMDfPxIgBXdN8fuN6VVmyehu79h3FJYvTZ7fn7GhHy86DMTI0wMHOhkZ1q1CmhBsPn7zgt75jMDDQp0WjmslOMQzo2Z7Jc1ay59BJ7GysGDkwKY+WlhaueXPw8Ik7Dm/7cjSsW4UXrzxo12MYhgYGdPu1+SfPlQ0cNZNXb7wICgmlQ88RTBvbnylzVhERGcWISfNRJipxyeLEhOG9P/vaPtSxTSOmz19N2+7DMDUxZvTgT1825+Rgi5ODLa27/sGoQd1SXSY+PoFDx84yY+FaIiOj6NutTbL5LpkdufDvTarz/jz9X/uP06FVAwBaN63DyMkL0dfXY/bEwUBSJ9i6NSqk67V9idjDh4k9fDjZNKWfH6Ft26a6vGqsApKa8mMPHcrwTABH/Z9y1P9psmlFzy1S/T0mjR+3DR43ko0J8b18y34jJibDCq0PhcRHpzq2w2bPm6q/A+OiaHF9S4plohLj6fwdCi0hfgRFbGyM9NBJQ0xsLOOnL2XK6H7ffVuvPbxZvHob08b0JzExkW1/Hebugyc/ZNv/DxITExk4aiazJw5BW/vzDW7hEZFMnr2SqWO+bP/r6uol/7HSIOZHj2JxZIK6Y6QqqOYY2W9fwbfKMHVHEP/nfvqWh2+xfuveH9YRxdrKHF0dHTr2HkVsbBx2tlYM6v3rD9n2/wMtLS3KlSrCrXuPKFoo32eXP33hKvVrVfwByYQQ4r9HiodP6NqhWbo6En4LQwMDJo7o80O29f+qSb2qaGtrf35BoHbV8j/qaj4hhPjPkeLhE35U4SB+DJ10XNL4Jac2hBDi/5V8QwohhBAiXaR4EEIIIUS6SPEghBBCiHSR4kEIIYQQ6SLFgxBCCCHSRYoHIYQQQqSLFA9CCCGESBcpHoQQQgiRLlI8CCGEECJdpHgQQgghRLpI8SCEEEKIdJFbcguhYXbuPUrzhpp5m2rJ9nU0OZsQX0NaHoTQMLv2HVV3hDRJtq+jydmE+BpSPAghhBAiXaR4EEIIIUS6SPEghIZp1kBzz41Ltq+jydmE+BrSYVIIIYQQ6SItD0IIIYRIFykehBBCCJEuUjwIIYQQIl2keBBCCCFEukjxIIQQQoh00VF3ACH+33l4+fLwyQs8vXzx9gvA3DQTTg62ZM3siGveHGrLFR0Ty7FTF3nw+DlePv7ExsWhraWFjbUlLpkdqVWtHDZWFmrLFxkVjfsrDzy9/PD280/ab452ZHGyx8rSXG25ND2bEBlBLtUUQk0uX7vD7gPHMc1kTKH8ubGztcLGypKw8Ai8ff159uI1j566U6F0URrVrYq29o9rKNz61yFu3n5I5fIlcCuQG1trS3R0dFAqlQQGhfDsxWv+OXkBBTB8QNcfmu3p81fs2ncM/8Ag8uR0wdbGChsrC9V+e/HSg5jYOBrUqkSZEm4/LJemZxMiI0nxIISaPHj8nCzODhgbGaa5TGJiIrfuPaZIwbw/MFlSq4OBvl6GLZeRzl26gUsWR5wd7dJcJiIiktMXrlGnenkUCoVkEyKDSfEghIYICg5lw/a9vHzthbWVOa2a1CG7i7O6YwFw98FTlqzZRkJCItExMbRrUZ8alcuoOxbP3d+Q2ckeXV0dTl+4yo3bD2nWoDqZnezVHQ2A6OgY9h4+xcvXnlhbWdCwdmU5bSF+CtJhUggNsXjVViqXL8nEEX2oXa08oyYvVGuexMRE1d/bdx9mzqShLJ8zhqWzRrN0zZ9qTPbehJnLiIiM4rWHN6s3/oWttSVjpi5WdyyVBSu2YGZqQpP61bG1sWTQ6FnqjiREhpDiQQg1WrhyC17efgDo6Org7eOPj28A3j7+6Oiqtz/zzIXr+OfEeRITE8mRLTPzlm5k596jzF26kVw5sqg12zvhEZGYZjJmzea/6d+zPW2a1yU+PkGtmTb9uZ+IyCgAomNicLCzwcnBBkd7W6JjYtWaTYiMIqcthFCj8IhIdu07Rlh4BHWql+fK9Xtvm7jNaVinilqvZgC4cechR09epJBrLrJmduSNpw9WluYULpAHLS31H3vMW7aJg0fPUMzNlalj+vHqjRcLV25h5vhBasv0xtOHv/Yfx8IsE5XKFWfXvmOq0xatmtYhZ7bMassmREaR4kEIDRAREcnuAycIDg2jaf1qONrbqjtSMrfuPuLIqYsUyJuTWlXLakTh8E5IaDhmpiaqv6OjY7CztVJzKvD09uWv/UlX0zSrXx1jYyN1RxIiw0jxIIQaub/yYOuuQ/j6B+LkYEfjelW5dOUWwaFhNKlXDScH9RURx05dYtOO/ejp6ZKQkEiX9k0xNjLkyMmL5M+Tnbo1Kqgt2zvdBoxnxdyxyaZ16TeWVfPHqykRBAaFsPfwKXz9AnFysKV4EVeOnbpEpkxGUkSIn4YMEiWEGo2ctJCh/TqRM1tmbt55yMyFa1k+ZwyRUdHs3n+cti3qqS3b0rXb2bxiOgb6egQEBtNvxHQ2LZtKIdfc3H3wVG25AFZv2g2Al7ef6m8AX78AQsMi1BULgMFjZtGySW3Kly7KzTsPWbpmO/Om/IGXjz/rt++jV6eWas0nREaQ4kEINdJ920nSxNgQb19/1ZgJRoYGai0cAHLncGHe0o3kyJaZO/cf4+aaWzWvQL6cakwG9nZJpyWUKIH3jacF8ueiS4dmakqVJDo6Fgc7GxztbfD1CyAyKhoABztrKRzET0NOWwihRv4BQew9fAo//yCcHGxpULuy6vy9uimVSm7dfYRfQBCO9ja45lVvwZCam3ceUvgHD6D1Oc/d37D1r0P4+Sedtmjbop7G9WER4ltJ8SCEmpy7dIPsLk6f/GGJjIrm9Pmr1K5W7oeORrhl50HMzEyoVqEUBgb6qS5z9eY9Tp67wsCeHX7o8NQf8vb15/Dx8wQFh6D84JtsYK8Oasnz8MkLsjg7YGRokOYy74oyTSt6hEgPOW0hhJo42tuw6c8D+AcEkSdXNuxtrbC2siAsLAJvP3+evXhDTEwM9WpW/OHDGP/SuCYnz11h5OSFgBJzM1OsLc0JC4/E1z+QuLg4ihd2pWv7ZmorHAD6j5hB8cKu5M6ZVa053gkNi2DSrOVkMjHGrUCe9+9peATevgE8ffGKh49fUK5UEQrmz60RmYX4GtLyIISaRURG4f7KAw8vX3z9AjE1NcHJ3pYsmR3UPs4DJB0pBwQG4+MXiJmpCfa2VujoaMZxh7qvrEjLG08fHj5+gYe3L75+Aar31CWLE655c8g9LcR/nhQPQoj/rL/2HSM8MpJSRQsmm54nVzY1JRLi/4NmHD4IIcRXOH7mMgCXr95RTVMoFCyaMUJdkYT4vyAtD0KIzwoIDMbXP5B8ubMDSacypOldiP9f0vIghAa4cuMuK9bvIjgklB1rZ+PrF8DBY+fo2LqRuqOxacd+rt28zxtPH1W2ecs2MWV0P7VlOnz8HLWrlWfrroOpzm/drO4PTpTS0VMXKVm0AGammViwfDNXb92na4dmVChdVN3RhPhm0tVXCA0wb+km5k0eguHbS/xsbaw4de6KmlMl2f/PGWZNGJws2xsvX7VmendZZmRUdKr/NMGazbsxNDDg6s17vPH0YcSALixcsUXdsYTIENLyIIQGSFQmYmBgwLszAQGBwRpz+2Z9fV2CgkNU2a7ffoC2mm+MVad6eQA6t2sKQFR0UsFgaJD2+Ao/WlxcPC9evmHN5t2MGNAVZ0c7DA1THzNDiP8aKR6E0ACtm9Wl95BJBAaFsmjVVo6dukTn9k3VHQuAoX1/o//IGXj5+NGp7xiCQ8KYOKK3umMBSZdETpy1HPdXngBkzezAmCE9cHa0U3My6NqhGRNnr6Bu9Qo4O9px7+FTCuTLpe5YQmQI6TAphIZwf+XJ1Zv3UCqVFHPLT3YXZ3VHUomPj+fVG2+UKMni5EBCYqLqPhzq1HvIZNo0r0vp4m4AXLp6i807D7Bk5ig1J0tdfHy8xoyRIcS3kE+xEBpg7tINDOjZAZcsjqpp0+avZli/zmpMleTdba8/LGZ6asjgTCFh4ZQrVUT1uFypIixd+6caE7336MkLdh84QWBQyNsbeCWZOX6QGlMJkTGkeBBCjW7ceQjAxSu3qVL+oeonxtcvgHOXroMaiwdNvu31OzmzZWbB8s1Ur1wahULB0VOXyJ5VM1ps/hg/jxaNalKtUim0tbXVHUeIDCXFgxBqdOCf00BSB8mVG3apptvaWDF6cA91xQI0+7bX7/zRrxNrN//NrEXrUCqhRBFXhvVXf2sNgLOjndpvqy7E9yJ9HoTQAFv/OkTrpnXUHSNVmnjb64+FhkWgp6uT5h1Af6R3l9jeuPOQuLh4ShYtkGx+5fIl1BFLiAwlxYMQGuLmnYd4+/qTmPj+v2TdGhXUmChJQGAwew6dTJFt1KBuakyV5PK1O0ybv5q4uDh0dXSwtrJk5MCuyfqO/GiTZi1Pe6ZCoRH7TYhvJacthNAAY6YuxtcvAF//ICqUKYr7Kw/sbK00ongYNmEexQu78vT5a9r9Up+nz1+pO5LKnCUbmDF2ALlyZAWSiomJs5azeoH6OnOOGtwdAPdXHrhkcUo2797Dp+qIJESGkxEmhdAAz9xfs2zOGEoUcaVJvarMGD+Q4OAwdccCIDYuju4dW+BWIDdWluZ0+7U5t+89VncsAMzNMqkKB4BSxQqiVGpGY+rY6UtSTJs0e4UakgiR8aTlQQgNYJrJhIiISMqUcGPXvmM0qluV157e6o4FgJ21Fa89vKleqQxL126nUtnihIZrxtUWBfLlZMGKLRTKnzT4kqe3H5YWZqp+B+roX9B7yGQUCgVvPH3oM3SKarqvfyCO9jY/PI8Q34P0eRBCA1y/dR8HOxvsbK2Yt2wT127dp1XTOjSoVUnd0fD29cfM1ARDAwNOnbvCtVv3qV2tHK55c6o7mkb2L/Dy8Qelkt+HT2P4gC6q6XY2Vjg52P7wPEJ8D1I8CKEBjp2+RPVKpdUdI1WLV22jd5dW6o7xnxMdE6sRo3AK8T3IaQshNMCOPUeoWKYYenq66o6SwisPL16+9iRrZvVdwfBfdOP2A7b9dYjAoFCUKFEqlSgUCjYtm6ruaEJ8MykehNAA5UsV4bc+o6lTo3yyO1a2blZXjamSWJib8luf0RQplBetD7LJMMufNmXOSgb06kDuHFllhEnx05HiQQgNEBsXR9WKJYnRkNtwf6hmlbLUrFJW3TFS9eTZS5at20FkVDRLZ43CLyCIf6/doV7NiuqORo5smalYthg6UjiIn5D0eRBC/Gf92nsk00b3548J89iwZDJKpZLf+oxm3eJJ6o7Gqo27ePjEnWJu+ZJN14TWJCG+lbQ8CCH+s2Jj43Cwt0GhSHocGRVNVHS0ekO9pVAoyJc7G5FRmpFHiIwkLQ9CaIDwiEhMjI2STfPy8cfBzlpNid5719EPICIyCk8v32QDM6nT2i1/8/T5Kx48fkHbFnXZc+gUVSuUpGPrRuqOpvKumDE0MFBzEiEyjhQPQmiAX3uPZP3iycmmdeg1kg1LJqfxjB9n7LQl9O7cElPTTHToOQJ9PT1c8+VgmBpvF/6hf6/d4fL1O6q7apYp4abuSAC88fRh4qzluL/yBCBrZgfGDOmBs6OdmpMJ8e3ktIUQajRp1nJQKPDxDUg2dLGvX2Cyqy7U6eGTF9jaWLHtr8M0rV+dXxrXpFWXoeqOBcCSNdvp1aklJYsVVE27eOUW+/85Te8urXC0V9+gTFPnrqJDywaULp5UzFy6eospc1eyZOYotWUSIqNI8SCEGtV9e1XAtZv3KFLo/W2v7WysKJAvl7piJWNibMScJRu4eechK+ePIz4+IcUpFnXZd/gUp89fISEhkeH9u1CscH72HDqJm2tuZi9ez+yJQ9SWLSQsnHKliqgelytVhKVr/1RbHiEykhQPQqhR0UJJPfEXTh+hsc3ZU8f04/jpSzSp1xt9PT0eP3tJh5YN1B0LgJiYWJYun0ZIaDgTZy1jzcKJePn4MXV0P/b/c0at2XJmy8yC5ZupXrk0CoWCo6cukT2rs1ozCZFRpHgQQgNEREQybd5qAoNCUPK+G5ImDMRka22Z7PLC3DmykltDOkxaWpihUChQKBRoaWmhVCqJjIxGoVCofbTOP/p1Yu2WPcxatE7VH2NYf83oJyLEt5IOk0JogMbt+tGiUU1y50w+GuG7lgl1qNmsG6AgPj4epRJ0dZOONWJiYrGxtmDnujlqy/bOgSNnmL98E6aZTChTwo1LV2/j7GiHoYE+OjraTBjeR90RhfgpScuDEBrA0cGGti3qqTtGMkd2JXXgHD1lEf26t8XaygKA5+5v2LHniDqjqdSrWZHa1cqjrZ28c+lrD29s3uZVl4tXbiW7t8U7cm8L8TOQ4kEIDVC+VFFmLFhLyaIFkk2vXL6EmhK999z9japwAMju4sy9h0/VmOi96OgYTp67grevP4mJ73+gO7drosZUSabMWUm/Hu3Ik9MFHR35qhU/F/lEC6EBnru/BuDcpevvJyoUGlE85M+bg9FTFtGgdmUio6I4d+kGtjZW6o4FwLAJ8zA3y8Tjpy9pUKcyz56/IlMmY3XHAiB/nhyUL1UEAwN9dUcRIsNJnwchNERCQiIhoWFYWpipO0oy8fHx/H3wJNdv3SchIZH8eXPQvGENjI0M1R2NDj1HsGHpFGYuWkfDWpXIlSMrA0fNZN6UP9QdjXsPnzF36Qby58mRbPrAXh3UlEiIjCMtD0JogH9OXODPv/8hJDSMnevm4OsXwIbt+xnc51d1R0NHR4fmDWvQvGENdUdJwdzMlIDAYCqVKcbGP/dTq1o5fP0C1R0LgGnzVlPINRc5s2VGW0furCl+LlI8CKEB1m75m41Lp9C531gAbG2suPPgsZpTJdl7+BQbt+8jKPhtxz8loIDju1epOxq/d2uDQktByWIFeeb+mj0HT9K7Syt1xwLAwECPIX1/U3cMIb4LKR6E0ADaWlokJCSo7g7p/sqT+PgE9YZ6a9XGXUwfO4DcOVxSXNWgbkEhoeTMngVIutV162Z1OX3hqppTJalUtjgzF62jRGHXZNM1oR+LEN9KigchNEDPTi3p0n8c/gFBjJy0gJt3HzFyYFd1xwIgX+7suGRx1LjCAWDRqq3JbigWHx/PopVbqVS2uBpTJXF/5QFoZidYIb6VdJgUQkOEhIZx98FTlEpwzZsDC3NTdUcCYO7Sjdy5/4QC+XImm67Ojn9NOwxAoQC/gKBk4zmER0RRpXwJGclRiO9MigchNIBSqeTO/ScEBofwwXhCGnGUeuBo6veIqFej4g9OklK3AeMZP6y36rGFuSkG+npqTCTE/wcpHoTQAINGz8THL5Cc2TKj8254aoWCUYO6qTeYEEKkQvo8CKEBvH0C2LhsClpamtevoG33YSje9eR8S4GCjcumqCnRe5p6JcjFK7fw8w+kYP7cZMvqpJo+bvoSxv3RS43JhMgYUjwIoQEa1K7MqfNXKeaWP9l0M1MTNSV6b9aEwckeHz99CWsrc/WE+cjKDbuYMU6zrgSZNn81T5+/wjVvTnbuO0YOF2f++L0TBgb6PH/poe54QmQIKR6E0ABxcXGMnrIQa0sL1V01FQrYtX6umpOBg511ssdtW9SjTbc/qF2tvJoSvZc/j+ZdCXL77mM2r5iGQqFAqVSy59BJeg2ZzOSRfdHWwJYlIb6GFA9CaIA9h06yb8sijRuaGmDrroOqv+PjE3j45AU62prx1WFva03vIVM06koQC3NTAoNCsLI0R6FQ0LhuVbJldWbg6JlERkarLZcQGUkzvgGE+D9XvIgrEZFRGlk8REYl/8Er5pafwX06qifMR3LnzErunFnVHSOZAb06cPLclWTDebu55mb2xMFMmav+UTmFyAhytYUQGuD3YdN4+OS56m6VSqUShULBpmVT1ZZp+vw1/NGvEweOnKFeTfVflpmWew+f4RcQSOVySZe1RkRGacRNu1Lj5eOf4jSQEP9F0vIghAYYPqCLuiOkcO/RMw4dO8eazbtT/THWhDEo5i7dSFR0NLfuPqZyuRL4+gUwZe4qjbirZmqGTZibbERMIf6rpHgQQgOsWL+DahVLU6pYQXR1NeO/5cCe7Tl84jzhEVHJh1gGjRlm+fK1O2xbNYMOvUYCSTcU8w8MVmumIWNnpzpdqQRPL78fnEaI70MzvqWE+D/XuG5VTl+4xqqNu8iZLTPVKpWmRNEC7weMUoPCBfNSuGBeiru5Ur1yabXl+BQzUxOePn+luqHYwaNnyWRspNZMPr4B1KtZkVw5PuqLoVTy6o2XekIJkcGkz4MQGubmnYfMWLCWoJBQGtSuTIeWDTBR8w+ipnrt4c2UOSu5//g5xkaGODnYMnpwd7I4O6gt07/X7uDsZIejvW2KeYNGz2T2xCFqSCVExpLiQQgNEB0dw+kL1zhy8gKxsXHUrl6OyuVKcOr8FfYcPMmKuWPVHVGjRUZFo1QqMTYyJD4+Hh0daVQV4nuS/2FCaIB2PYZTtWIp+nVvm+youV6Nily9cU8tmbx9/T85395W/VcNjJm6mEG9O2BmmgkAL28/lq7dzoThfdScTIifmxQPQmiAbatnokDBaw8v3F954Oxkr+rvMHZoT7VkGjouaXTL0NBwtLS0MDFJOnUSEBiMo70NK+eNU0uuD7m/8lAVDgAO9ja4v5Z+BUJ8b1I8CKEBnjx7yajJCzEyNESJksjIaCaN7EP+PDnUlmnDkqRLCgePmc34P3pi/Lbfha9fAItXb1dbrg+Zm5ly6vwV1RgP5y7dwNBAX82pkvw+bBoLpg1TdwwhvgspHoTQALMXr2fG+IHkcMkMwDP310yZs4rVC8arORm88fRB/4MfZGsrC548e6nGRO8N69+JiTOXM2fJBhQosLI0Z8yQHuqOBUC+3Nk0foAtIb6WFA9CaICo6BhV4QCQwyUz0TExakz0XsWyxegzZDJ1a1QgIiqaC5dvki9PdnXHAsAvIJils0cn6zCpKS5eucXmHQeYtWg9WtoKjblduBAZQa62EEIDzF26AT//IKpVKo1CoeDY6UtYWZgxqPev6o4GwIV/b3L15n0SEhJwzZuDqhVLqXUMinc6/z6WVfPHoXg30IMQ4oeQ4kEIDZCQkMieQye5evMeKJUUL1KARnWqaMStpuMTEjh19gqBwSH80rgWsbFxBAaHaMTVFjv2HOHcpes0rFMl2e2uNWH0S29ffzZs20d4RAQThvchMDiER0/cKVPCTd3RhPhm6v9mEkKgra1F0/rVmDLqd6aM7kfT+tV47aEZVw1MmLGUVx5e/H3gBJB046nxM5apOVWSR09eYGNlwcV/b3Lu0vWkf5dvqDsWAGOnLaFmlTKqqz9MTYxZuWGnmlMJkTGkz4MQajR4zGxSa3FPTFTi4eXLtlUzfnyojzx5/ooJw/tw6vxVACzMTQkNC1dzqiSjBncnISGRkNAwjbudeWhYOIUL5k02LSIyOo2lhfhvkeJBCDVq07xuqtMVCgXZszr94DSps7e15vzbo/mo6Gi27DyEva2VmlMl+efEBf78+x9CQsPYuW4Ovn4BbNi+n8F91N9XpHhhVxat2kpMTAwX/r3Jn3//Q+niBdUdS4gMIacthFCjooXyqf7Z21oRGhZOTEws2bM6Jxv8SJ1GD+nOkZMX8fcPotmvA3n52oORA7upOxYAa7f8zbLZozF6e5WFrY0Vdx48VnOqJP17tCezoz05smVh/z+nqVi2OL93a6fuWEJkCGl5EEIDrN+2l937j1PINRfa2trMXLiOfj3aUqlscbVleub+mhwumbE0N2P8sF5qy/Ep2lpaJCQkqE79uL/yJD4+Qb2h3tr/z2kqlC1Ko7pV1B1FiAwnxYMQGuDg0bNsXTUdQwMDAPwDgug7bKpai4cJM5exfvFk1eNZi9ZrxOmAD/Xs1JIu/cfhHxDEyEkLuHn3ESMHdlV3LAD8A4MZOnYOenq6VCpbnErlimvEFSpCZAQpHoTQAI72NigU788iWpibYW5mqsZEoPzoIm5NOR3wofKli1Awf07uPniKUgmD+3TEwly9++2dzu2a0LldEwICg7lw5RYLVmzBzz9QI+4JIsS3kuJBCA1gmsmEASNnkCt7FgB8/AKIi4tjzpINAAzs1eGHZ/ovjLsUFxfPucs3ePzUHX09PfR0dShZTHM6JUZFR3P34VNu3X2El7cf+fOq714lQmQkGSRKCA1w4OiZT86vV+PH3x+hbO32GBq+vaeFEqJjYjAw0NeoYZbHTF1ETGwcpYoVQkdHm8PHz+HmmofuHVuoOxr9R0zHy8efcqWKULlccQrmzyUjYYqfhhQPQoj/rLbdh7F5+TTV47i4eDr0GsHWleofH+PRkxfkyZVN3TGE+C7ktIUQGmDfP6fZsG0vQcGhKFFq1NG9JsudIyue3r442tsCEBMbSxYnBzWnSmJrY8X4GUv59/pdIGnch3492mJprlmDWQnxNaTlQQgN0LBtX6aO7k+eXC4accOp/4rOv4/Fy9sPS8ukH+SwsAgSlUrMTE0A2LRsqtqyDRk7m1LFClG9UmkAjp2+xMUrt5g9cbDaMgmRUaTlQQgNUKRgPhztbaRwSKdJI/uqO0KavHz8ad6whupx84Y12HPwpBoTCZFxpHgQQgM0rleVrv3Hke2jIalnjh+kpkSa69ylG2R3ccLR3hYHu9THTYiMiub0+avY25ZTWydFe1trduw5QrVKpVCQdJt1WxsLtWQRIqPJaQshNECL3wbRqE4Vcud0QUfnfetD0UL51JhKMz13f8POvUfxDwgiT65s2NtaYW1lQVhYBN5+/jx78YaYmBjq1axIuVJF1JYzMCiEecs2cvXGfQCKF8lP/x7tNe4GXkJ8DSkehNAAff6Ywvwpw9DWltvNfKmIyCjcX3ng4eWLr18gpqYmONnbkiWzAzZWcoQvxPckxYMQGmDF+p08ef4yRUtD62ap33VTCCHUSfo8CKEBtLW1yJsrG5FR0eqOIoQQnyUtD0JoiIDAYHz9A8mXOzsASqVSRiT8jMioaIwMDdQdI1VPnr1k2bodREZFs3TWKPwCgvj32h3q1fzxo4UKkdHkBKsQGmDTjv1Mmr2CMVMXA+DrF8DISQvUnErzde0/jhET53Ps9CWio2PUHSeZSXNWMLj3r0RERgFgbWnOjj1H1JxKiIwhxYMQGmD/P2eYNWEwhm+Pom1trHjj5avmVJpv8/JpdG7flNce3gwaPYsxUxdx6twV4uLi1R2N2Ng4HOxtVDcYi4yKJipaTkuJn4P0eRBCA+jr6xIUHKL6obl++wHaWlLbf4kcLpmxMDPF2MiQw8fPc+TURTZs30vXDs0pU8JNbblqVinLyEkLCAuLZNe+o+w5dIo61SuoLY8QGUn6PAihAe49fMbUeavw8vEjq7MjwSFhTBzRG9e8OdUdTaMdOHKGf05cIC4+nno1KlC1YimMDA0IDgmja/9x7Fg7W635/r12h8vX76BUQokirmotZoTISFI8CKEh4uPjefXGGyVKsjg5oKsrDYOfs3jVNurVrIhLFscU806du0Ll8iXUkCrJkjXb6dWpZbJpF6/cYv8/p+ndpZXqZl5C/BdJ8SCEBoiIiOTc5ZsEBoeA8v1/SRnn4dM69R3NmoUT1R0jVXV+6YlpJmMSEhIZ3r8LxQrnZ9iEebi55ubqzXvMnjhE3RGF+GpyUlUIDdBvxHSOnrpIaFg4kVHRqn/i0+pUr8DqTbsJCg4lJDRc9U8TxMTEsnTWaGaOH8Ti1VsB8PLxo1XTOnj7BKg5nRDfRtpFhdAAsbFxzJogN8FKr32HTxEeEcWBI2dU0xQK2LV+rhpTJbG0MEOhUKBQKNDS0kKpVBIZGY1CoUBPT1fd8YT4JnLaQggNsH33YawszClRtECy6WamJmpKJL7VgSNnmL98E6aZTChTwo1LV2/j7GiHoYE+OjraTBjeR90RhfhqUjwIoQHa9RhOZGTy0xSacgStyU6du5LqdHV2lPxQQkJiipudvfbwxsbKAgMDfTWlEuLbyWkLITTApmVT1R3hP+ncpevJHt+8+4hypYpoRPEgnWDFz0yKByHU6Madh8keaykUWFtZYG9rLbfn/gKjBndP9tjXP5B5SzeqKU1y/UZMx9zMlFw5sqCjra3uOEJkKCkehFCjbX8dSvZYmagkKCSM4JBQRg/uTiHX3GpK9t8UFh7BrXuP1R0DkE6w4ucmfR6E0EBPX7xm8uwVrF2kmWMYaIpqjbvA2yG9ExISMTYypP0vDWjVtLZ6gyGdYMXPTVoehNBAObNlJiEhQd0xNN7xv1epO0Ka9v1zOqkT7JrtqmnSCVb8LKR4EELDxMTGcujYOSwtzNQdReNdv3WfPLmyYWxkyI49R7h68x4dWjbQiHuCSCdY8TOT4kEINfqw2f0dEyMjihTKy8hB3dQT6j9k9pINrJg7lkdPXnD89CVaNqnNlDmr2LximrqjER0dw8lzV/D29Scx8f3Z4c7tmqgxlRAZQ4oHIdRIk5vd/wuio2OIj49n5ca/GNj7V3LnyMrarXvUHQuAYRPmYW6WicdPX9KgTmWePX9FpkzG6o4lRIaQa8GEEP9ZTetXp9mvA3F2tCN3jqw8eupOtixO6o4FQGBQCOP+6EURt3wULZiXEQO78uKlh7pjCZEhpOVBCPGf1bZFPdq2qKd6nD2rM0P6dlRfoA+Ym5kSEBhMpTLF2PjnfmpVK4evX6C6YwmRIeRSTfG/9u49Ouf7gOP455EsHk0kkYuQorKEBG1RLatmq8umdL3RdmZM79paaasXhq7pqmnHsNJWkWlRYuUpag2HUC0mWVFqWjmuDaEuuSJ5cuHZH9aQRreTSfLt93ner3Oc4/n95JzPP3E+z/cKWCs3r0DLV35cbV3B+B/AepG9+7MVFhaisNAQpbrStHXHV7rr1l5K/Eln09GAy0Z5AGCtR55K0vWdOihz604N+dVt2rs/W5I07L57DCcDvBvTFgCsVVZerkfvv1fu0lKFh4Wq10+76onnk03HkiRt/myHUl0rlV9QJI8ufEdjCye8AeUBgLWiIsJ1KOcb/fzmGzXjnb/p5u7Xq+j0GdOxJEmvTJmlUcPP7wDx424LeBnKAwBrjfrdUIUGN1bLK5vpntt/oa07vtTokQ+YjiVJio9rrZ9178KlWPBKrHkAYLVdu/fpRG6eetx0/hruM8UlCryikbE8qa40SdK+g4dVUHhKXTq2q/KeK7nhDTjnAYC1ps6Yr+Ur12nGnPclScdP5GrchGlGMxWXuFVc4lbzqAi1axtT+fnbP4A3YNoCgLUyt+7UopSJGjp8nCSpaWS4cvMKjWZ6aMgASecPibr4fhK3u1R5BWazAbWFkQcA1goJDtLe/dly/Od+kLQ1GxQUaG7K4mJjX35dhUWnKz8Xu91KnsJx5PAOjDwAsNb4Z4YpecpsHcw+olsHDteVzZvqhWcfNR1LknTqTLFCgoMqP4eFhii/oMhgIqD2UB4AWCuvoEgzJr+g4hK3PB6P0YWS39UhIVZT3pqne+/sI0la+tE6xVz1w7h3A7hc7LYAYK2HRr6olNeT5HA4/vc/rmfu0jLNW/ShMrZ8Icmj6zq21wOD7lRg4BWmowGXjfIAwFqLl6/WxoxtuqNfT/k1uLCEq0fiDQZTAd6PaQsA1srac0CR4U20+Z/bLzx0OCgPQB1j5AGAdY6fyFXTyHDTMQCfxVZNANZ5LmmK6Qj/l5nvLta4CdP0ZdY+01GAy0J5AIB60q7tj/Xi849rU+Z201GAy8K0BQDr3NTvt3I6G1Z/4ZHkkNYu5TAmoC6xYBKAdWJjWmneW6+YjnFJk9+c+1+3jo4aPrQe0wB1g/IAALUooW2M6QhAnWPaAoB1Dnyd84M+rbHE7daJk/mKbhYpf3++o8H7UB4AoBalf5KhqTPmKyoyXPmFRZowdoQ6JMSajgXUKioxAOsUFp1SSHBj0zEuafY8l1Jef0nNoyKUteeA3khZpOl/+r3pWECtYqsmAOs8/GSSJk1/R9mHj5qOcknNoyIkSfFtYlRYdMpwGqD2MfIAwDqpKRO1cfM2TZr+rpzOAA0a0E+xMa0q3198FXZ9Ky+v0PqNn1V+Pn2mpMpnjs6GN2DNAwBruUvLlDLfpcXLVisiPFQej+RwSK65U41lmvDnmd//0uHQ+GeG1V8YoI5QHgBYJ+focblWpGtT5ufq0/NG9b+tt8JCQ0zHAnwG5QGAdQYPG6OBA/rqll7d1TAgwHScKtas36ymEWHqeHV8lecfrvxYTmdD9enZ3VAyoPawYBKAdd6b+ap6/bSrjp/Ik8dT9fvPog9WGUp1XqorTfFtqh8U1bd3ovFsQG1hwSQA66xYtV7TZi1UdLNInTpTrAcH99ftt9wsSVq5doN+PaCvsWzl5WflbFh9NCQg4EcqLS0zkAiofZQHANZZsOQjueZOVUhwkE7m5mv67FTt+FeWRo980HQ0JbSN0eLlq3XvnX2qPF/y4Rq1iW31PT8F2IXyAMA6wY2DFBjYSJIUEd5EL40ZroVL0jRidLLKyyqMZnvqsSH646S3tSxtneLjWkuSsvYcVPNmkUoa/bjRbEBtYcEkAOukr89Qds5RPTi4f5XnGzK2Kem1t7R2mfkruQ8fOaYD2TmSpNYto9XyymaGEwG1h/IAwErnzp1TgwbV13y7S8suueYAQO2hPAAAgBphqyYAAKgRygMAa61Zv7ny4qlpMxdo6PBx2pCxzXAqwPtRHgBYa86CpWrkdGrL9l06fOSYxj79sKbPWmg6FuD12KoJwFrl5RU68PVhzVmwVGOffkQtoqPUqFFD07EAr8fIAwBrPTL0br08eZYSu12nFtFR2rV7r65u18Z0LMDrsdsCgFepqKiQvz+DqkBd4jcMgLUmvzlXDoej2vNRw4caSAP4DsoDAGsltK16e+Wnm7aqS6f2htIAvoNpCwBeo7y8QiNGJ+vtKX8wHQXwaow8ALBW1p4DlX+vOHtWX2bt16EjxwwmAnwD5QGAtaZ950yHJqHBSh4/0lAawHcwbQEAAGqEkQcA1vrm+EmtWrtJ+QWF8lz0NYjdFkDdojwAsNZTYyfq+k4d1DbuKvn5ceYdUF8oDwCsFRTYSM8+cZ/pGIDPYc0DAGt9sCJdp4uL1e26a6o8j28T8z0/AaA2MPIAwFprP82UJGVu2Vn5zOFw6I2JY01FAnwCIw8AAKBGGHkAYJ1Vazeqb+9EpbrSLvl+0N231nMiwLdQHgBY59ttmcUlbrNBAB/FtAUAAKgRRh4AWGvzZzu06IOVyssvkkcXvge99/arBlMB3o/yAMBayVNm68nHhig+rrX8/fnvDKgv/LYBsFb7+Fgldussp7Oh6SiAT2HNAwBr7dq9T1NnzFP7+Ngqz7nbAqhbjDwAsNZrf/mrru3QRnExLeXn72c6DuAzKA8ArOV0Bui5EQ+YjgH4HKYtAFjrvff/rqPHT+qGTh2qPO+ReIOhRIBvYOQBgLUOZudIkjZmbLvw0OGgPAB1jJEHAABQIw1MBwAAAHahPACwTmHRKdMRAJ9GeQBgnYefTNKk6e8o+/BR01EAn8SaBwDWqTh7Vhs3b5NrRbqczgANGtBPsTGtKt+HBAcZTAd4P8oDAGu5S8uUMt+lxctWKyI8VB6P5HBIrrlTTUcDvBrlAYB1co4el2tFujZlfq4+PW9U/9t6Kyw0xHQswGdQHgBYZ/CwMRo4oK9u6dVdDQMCTMcBfA7lAYB1PB6PDh85powtX+hEbr4aOByKCG+i7l07KrpZU9PxAK9HeQBgnYVL0pSWvkFXt4vTVS2a69w5jw7lfKOdX+3RHX17aGD/vqYjAl6N46kBWCctfYPmvvmK/Pyq7javqKjQ/U+8QHkA6hjlAYB1wkJDtDxtnTpdk6AW0VHy6Pw0xudf7FZ4ExZOAnWNaQsA1iksOqU5C5ZqU+Z25RcUyeFwKDwsRDd17az7f3OXghsHmo4IeDXKAwAAqBGOpwbgVUaOec10BMDrseYBgHVSXWmXfO7xSAcP5dRzGsD3UB4AWGeha6W6dblGzaMiqr3znGMmFqhrlAcA1hl8zy/V+doExce1rvbuk39srf9AgI9hwSQAr3IyN18R4U1MxwC8GuUBAADUCLstAABAjVAeAABAjfwbMVbEBl/TR6gAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 583.3x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "A lower-triangular correlation heatmap of four macro indicators on a red-to-blue scale fixed between minus one and one. The unemployment rate and the yield spread are strongly positive, the fed funds rate is strongly negative against the yield spread, and inflation is moderately negative against unemployment."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "correlations = macro_df.rename(columns=UNITS).corr()\n",
     "\n",
@@ -1049,8 +2319,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64acc918",
-   "metadata": {},
+   "id": "2fd4794a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014799,
+     "end_time": "2026-09-08T23:42:51.804322+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.789523+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "Unemployment and the yield spread move together, and the fed funds rate moves against the\n",
     "spread. Both are the same mechanism seen from two sides: the Federal Reserve cuts the\n",
@@ -1067,8 +2345,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e928ba29",
-   "metadata": {},
+   "id": "a42eb33c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013016,
+     "end_time": "2026-09-08T23:42:51.830509+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.817493+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## The counter-experiment: every series in the panel\n",
     "\n",
@@ -1083,10 +2369,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "95cfd24e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 30,
+   "id": "f2f7b6ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:51.874423Z",
+     "iopub.status.busy": "2026-09-08T23:42:51.874247Z",
+     "iopub.status.idle": "2026-09-08T23:42:51.908621Z",
+     "shell.execute_reply": "2026-09-08T23:42:51.908186Z"
+    },
+    "papermill": {
+     "duration": 0.058413,
+     "end_time": "2026-09-08T23:42:51.909678+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.851265+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The coverage filter keeps **25 of 25** series, and holding them to the core panel's months leaves **276 months** across both models."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "value_columns = [c for c in macro_raw.columns if c != DATE_COL]\n",
     "monthly_full = to_monthly(macro_raw, value_columns).filter(pl.col(DATE_COL) >= PANEL_START)\n",
@@ -1119,8 +2432,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c79482a",
-   "metadata": {},
+   "id": "960b69cd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006938,
+     "end_time": "2026-09-08T23:42:51.923707+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.916769+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### What the filter let through\n",
     "\n",
@@ -1136,10 +2457,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f3b61f42",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 31,
+   "id": "e43d11ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:51.940863Z",
+     "iopub.status.busy": "2026-09-08T23:42:51.940647Z",
+     "iopub.status.idle": "2026-09-08T23:42:51.946452Z",
+     "shell.execute_reply": "2026-09-08T23:42:51.946025Z"
+    },
+    "papermill": {
+     "duration": 0.015998,
+     "end_time": "2026-09-08T23:42:51.947408+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.931410+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The largest gap between `t10y2y` and `YIELD_CURVE_SLOPE` anywhere in the panel is **7.8e-16** after standardization, and nominal GDP takes **92 distinct values** across **276 monthly rows**."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "duplicate_check = (extended_df[\"t10y2y\"] - extended_df[\"YIELD_CURVE_SLOPE\"]).abs().max()\n",
     "gdp_distinct = int(extended_df[\"gdp\"].round(6).nunique())\n",
@@ -1154,8 +2502,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64eced1f",
-   "metadata": {},
+   "id": "ac164797",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011139,
+     "end_time": "2026-09-08T23:42:51.966782+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.955643+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### The series, drawn\n",
     "\n",
@@ -1165,10 +2521,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "61381e12",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 32,
+   "id": "07466752",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:51.990711Z",
+     "iopub.status.busy": "2026-09-08T23:42:51.990456Z",
+     "iopub.status.idle": "2026-09-08T23:42:56.950963Z",
+     "shell.execute_reply": "2026-09-08T23:42:56.947155Z"
+    },
+    "papermill": {
+     "duration": 4.973071,
+     "end_time": "2026-09-08T23:42:56.951512+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:51.978441+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAHmCAYAAACI4HGsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAwpVJREFUeJzs3XV41FgXwOFf3Wipt7i7u7u7uy8uu9iy+GKLLe7u7u7u7u5SoO4+nZl8fxT60VKghbZTuud9Hh5gJrk5mTPJnNzcJHoqVbiCEEIIIYSIoq/rAIQQQgghkhspkIQQQgghYpACSQghhBAiBimQhBBCCCFiSPACafm6HQwdOyuhm9WZk+eu0rH3iJ9qo2qjrjx98SaBIvq/XQdOMO7fxQne7s84cPQs3fqP0XUY8XbzzkNqNO3xSyxjwvQlLFyxOQEiSr7iu80cOHo2ztvpuH8Xs+vAiR8NLVEsWb2NJau3AeDq5kmZWu0JDArWcVRC/Lf9UIHk6ubJkDEzqNmsB0069GfizGX4+PondGyxunnnIX2G/JMky0rumtSrxpi/eiVIW2Vqtf+h+foM+Yebdx4mSAwidj+am69Zu2Uvvf/8chvq0GsEB4+di1bIPXj8gioNu+Lh5RM13aRZy5g6Z2WCxpSUxvzViyb1quk6jGh6dm5Bz84tdB2GEOIzP1QgjZm6EBtrK7atmsmq+f+QLo0jru5eCR2bECIRVCpbnHsPnkbroXjv6sFrl/eUL1002rT5cmejcvnirFy/C4C371w5ff463Ts1S9KYhRAiqRn+yEwvXrvQqXVDUlulAqBzm0ZfndbT25dZC9dy/fZDrFNb0ql1Q+rVrEhQcAi1m/diw9IpZMqQljv3n9Br8ATmTB5GyaL58fULoGG73zmyfQnmZqYAHD5xnkmzlqPRaKjaqCtNG1SnX7c2NOk4gGH9u7J83U7MzUyYM3kYz168YcaCNbx4/Y5c2TMzYlA30jo7cvPOQxat2krjelXZuP0gXt5+dOvQlBaNagIQFhbO3KUbOXnuCtaprciXO1u09Vm5YRfb9xxDT1+PCqWLMrBPB0yMjaNNc/zMZZau2U5QUAjVK5dGo9VGvafRaNm4/QA7D5wgPExF+TJF+L17WyxTWQCRvQXzp45g4cotuHl40b5lfUoUyc+MBWt4/vIttauVY1Cfjujp6bFtz1FOnb/KwmmjouZdPGM0i1dt5dnLt1QoU4zRf/ZAX18fL29fVqzfxbVb9wkIDKJqxVL82a8znl6+tOn+FxB5WiNblgwsmz2W0LAw5i/fzKlzVzE3M6V7x2bUqlou2nq26f4Xr99+YOCoaRjo67Nnw1wAtFqFDdsOsPvgSUJCwxjctxNVK5QEwM8/kJkL13Llxj1sbawY2LsjJYvmj9buzTsPmb1kAzUqlWb3wZOoItS0aVqHts3rAvD42StWbdjNgyfP0dPTp0vbxjStH9kjMGH6ErJmSo/LezfOXrqBjbUVE0f+TuaM6QC++r2IafSk+Tg72tO3W+sv3tt/5Axrt+zDzz+Q4oXzMrBPRxzsbABo0nEAf/btxPa9x3jw+DkF8ubgn5G/Y2ZqGq2NvYdPs//IGZbO+v/pyMGjp1OuZGGaNqgOgKu7V6y5AQgODWPKnBWcvXgDm9RWTBwV93XMlCEtGdOn4erN+1SrWAqAs5duUKJIfqwsLb5Y395dWtKmx1BaN63Dyg276NCyPrbWqb+Y7sTZK2zdfYRXb95hZ2vN8AHdKJgvZ5w+l29tM58LDgll0cqtnL5wFT09fRrVqUy3Dl8Wa9du3Wf91v08ef4aczMzBvRqT8WyxQAYMWEOWTOnp1uHZlH7g/o1K7Fu6z4MDAwY8ntn/AOCWLl+F75+Afzeoy11qpePzNuhU6xYv4uwcBXFC+flrz+6kNrKMmq5YWHh/DNjKVdu3MMylQUtG9eiddPa3/1Oz126Ef+AQEb/2fOLdVm/bT8nz15h0YzRmBgbc+LsFZat3YGffwAVyhRjcJ+OmJqaxPp5CSF+3A/1IDWoVZmJM5exZddhgoNDvjqdRqNl6NiZ2Nlas3fDXMYP78uCFZu5cOUWqSzMyZMrG7fvPQHg5t1H5MiakVt3HwFw5/4T8ubKFlUcAdSuVp6hf/xGofy5OLlnBf26tYl6b8aCNQwb8BuzJv5FQGAw/UdMpVHdqhzatojqlUszadbyqGkfPnnBGxdXls78m4G92zN/2SZCQsMAWLBiM0+ev2bd4sksmfk3ERHqqPlevn7Hqo27mf/vCHaunUWVCiUxNjKKts4Pn7xgwvQlDOzdgT0b5lIofy5Uqoio93fuP87+o2eYO3kYW1dNJygohMmzV0RrY9POQ0wbP4iRg7ozf9lGFq7YzJi/erFk5t9s33uMp89ff/UzX7tlL+OG9WHdokkcPXWBGx9Pf2kVhVw5MrNy3gTWL5nCmQvXOXvxBmmc7Nm0dCoAJ/esiPoBnrN4A15evmxbOZ3Zk4ayeNVW3rt6RI9z2b84O9kz658hnNyzIqrIe/r8NYaGBqxbPJnmDWswe/E6ABRFYcyUBVimMmfvxrmM/as3E6YvISiW79Dzl28xMDBg/ZLJTB7dn2Vrd3Dv4TMAgoNDaVyvKjvWzGL04B7MXLgWL2/fqHk3bD9AlQol2bN+Lg52NqzZvBfgu9+Lz6VxdsDRwfaL189dvsnCFVsYP7wvezfMxcHehmHjZqPR/P8HfcX6XQzo1Z5tq2bw6Mkrjp2+/EU71SqW4vnLt3xwi/xMQ0LDuHnnEZUrlPh/DF/JDcDJs1eoUv7jOtrbsHrTnnitY6Vyxbl49XbU/89evEGVj0VsTI4OdrRpWod/Zizh4ZMXtGxSK9bpwsNVDOrTkYNbFlK5fIkvTsN97XP53jbzuSmzV/D2nStrFkxk49IpFCucL9bpgkNC6dK2Mfs2zqdzm4b8M2PpV9t8+OQFbh5erF88mYplijFs3GzuPnjC0ll/07VDE2YuXItGoyU4OISpc1cycnAPDmyeT8M6VbCwMI/W1v6jZ3nj4sq2VTNYOW88eXJljXrvW9/pr7lx+yFbdh5m8ugBmBgbc+f+E6bNW8X44X3Zs2EuGo2GjTsOfrMNIcSP+aECqX/PdvzZrzP7j5ylQdvfWb1xT7RC4pMnz1/x+u0H+nZrg6mpCblzZKFlo1rs3B85QLJk0fzcvv8YgFt3H9O8YQ1ufiyQbt17TPGv7Pxi07pJbbJlzoC+vj6nz18lQzpn6lQvj6GBAY3qVOHJs9eEq1QAmJma0ue3VlhYmFOmRGFUERG4e3ij1WrZf+Qsfbu1xsHOhtRWqShbslDUMqwsLTAyNOTR05cYGBhQqlgB9PT0osWx/8hZalQqTZkShTAyMqRaxVIY6P//Y961/wSd2zQmQzpnUlmYM6B3B06du4qff2DUNN07NsPWOjUliuTHwMCAds3r4exoT9bM6Unr7MBrF9evfg49OrXA0cGONM4OZMmUnrfvIqd1tLelcd2qKIoWl3duONjZ8OTZq1jbCFep2H/kDP26t8HCwpz0aZ0oX7oo127dj1MusmRKT6smtTE1MaZsiUJ4evkSFhbOuw/u3Lz7iH7d22BibEyuHFnIlT0zDx6/+KINC3Mz2javi5mpKfnzZKdsyUJRP+jFCuelTIlC+PgGEB4RgYG+Pi9ev4uat0bl0pQqVgAjI0NKFSvAm4+f1/e+F5/r81urqF7Fz+0+cILmjWqQO0cWTE1N6NO1Na/fvufpi9dR03Rs3YBMGdKS2sqSfHmyReUg5vpVrVCSo6cuAXDl+l3y58kea89MbGpWKRNtHd++c4vXOlYqV5xL1+6g1Wrx8w/k4eMXVCxTNLZFAVC5fEkePH5B5fIlvugx/aRujQpkz5KRN+9csTAz4+Wbd9GKkq99Lt/bZj7x8w/k+JnL/PVHF+xsrbFMZUGRArljj7dcCQrlz4WruyeGhoYEBgXj5hH7MAAzU1N6dm6BqakJZUsVJjgklAG9OmBhYU65UkUICg7Bx88fY2NjrFNb8fDxC9QaLaWKFcDQwCBaW04Otnj5+PLugzvWqS0p9LEHDb79nY6Nh5cPoyfNZ+zQPjg52gGRF2Y0qVeNnNkyYWJsTMvGtbh07e5X2xBC/LgfOsWmp6dH1QolqVK+BFdv3mf6/NW4e3oztP9v0ab74OaJg70Npib/36GmT+fE0VMXAShRJB9jp54lIkLN81dvmTp2AHOXbiQ0LIxb9x4zsHeHOMdkZ2cd9e/3rh48fPIi2hVDKlUEAYHBUfF/8uk0YYRajZ9/IGHh4WRKnybWZdjb2bB09lhWbtjFqo276dK2MfVqVow2jau7J0UKxr7TBvjg7kn6tE5R/3e0t8XExJgPbh5Yp7aMFp+RkSHmZqZ8XoNZWaZCrf6yGP3k83WzsrQgIkIDgH9AEJNnL+f5y7cUzp8LQ0MDwsK/LAwA3D280Wi1dOk3Oqo9tVrDb+0af3W50WOIHi9Efr4f3DzRaLQ0bPtH1PsRajW1qpb9bpvW1lb4BwQB8OT5a6bOWUlEhJriRfJiYmJMWHj45xFEW/6nz+t734u4+ODmGe1Uo4mxMY4Otnxw8yRPzqwf1z/68mM7eABoULsyU+espFPrhpy9dJNqlUrFOY4fWUcHu/9vh7myZ8bE2IhHT1/xxuUDhQvkinaqKKYV63bSsnFN9h0+Q7vm9bCxtvpimiMnL7B83U4c7G3IniUjEFlsGxtH9rJ+7XP53jbzyXtXDwwNDUiX5stTojFdvXGPOUs3YGpiQvHCeQG++n2Puc18/tqn7686Qo2RkSHLZ49l9aY9tPrtT1o2rkWbZnXQ/6yYq1CmGCP19Jm1aB2Ghgb06do6WpH0uc+/07H5e/IC9A30+ODuSbGoz8CT0xeus33vMQC0ihZnB/vvfh5CiPj7oQLpEz09PUoVK0DX9k1Yt2X/F++ndXbA08uXcJUq6qjz3Qd30jg7AJA/T3YCAoO4cPUWObJmxMzUlBzZMnH99kPeu7qTP3f2WBYKivbbj49L4+xAofy5mD/1y8t+XWI5mv/EyioVBvr6uHt6Y2drHes02bNkYNKoP3j99gO9Bo8nfTrnaDtAO5vUuHv6xDovQFonB967ulMgbw4gcoxWeLgq1nEwCWnRqi0YGxmxbdUM9PT0mDB9yf/f/PhjoNVq0dfXx9HBDn19PTYsmRJ15Po1euihVeL2OL80TvYYGxuxf/P8r/ZCfM1bF1dKFy8IwN+T59O6aZ2oK5FOX7get+X/4Pfic2mdHaKdagxXqfDw8iHtx+90fBTMlxONVsOLVy5cu3WPP3q0/XKiGLn5nm+tY/Rm9ahYtjgXrtzi7TvXr55eg8gxYY+evmTcsOmEhalYsmYbw/p3jTaNh5cP46ctZsOSKWTOmA5XN0+27Tn63Xjh+9tM1Lo52aNWa3Dz8CaN09eLgogINcPGz2bS6P5R35m1W/bFKZbvxuDswPCB3fDw8uH3oZOwt7P+Ymxe+dJFKFeqMKfPX2PgiKkc2rYo1rY+/07HpkDeHDSpV42BI/+lYpmipLayJI2TPWVKFOS3dk0SZH2EEF8X71NsL1670H3AOG7de0y4SsUblw8cO32ZwgVyAWBsbBTVnZ8rexYyZ0zLwhWbCQtX8fTFG7btORr1w2ZoaEiRgnnYsfc4hT92lRfOn4td+09QIE8OjIy+rN/sbKx5+eY9Pr7+sZ4agcju9Zev3rFj3zEiItS4vHf77rl+AEMDAyqWLcbydTujuuT3Hj4d9f7NOw85cfYKYeEqDA0N0GoVVDFiqFy+JEdPXuTB4xeEhYWzftv+aANOm9SvxqqNe3jv6kFwcAizF62jSvkSUb1HicXfPwi1RoMqIoLb9x5HuzQ/9cfC8Prth4SrVJiaGFOnegWmzFmBt48fQcEhnLt8M9o4m0/sbFNz485DVKqIWN//XIZ0zuTPnZ1pc1cRGBSMj58/l67diXXa0LBwTl+4hlqt5viZy9x/9JwalUsD4OcfRHh4BOEqFQeOnsXbxy9On8G3vhfGxsZEqNVR67B64x6Wrtn+RRuN61Zl256jPHn+mrBwFYtWbiVT+rTkzJb5u8uPuQw9PT3q16zE/OWbyJ4lY6y9MjFz8zPrGFOlcsU5c/E6128/iBrAHJNGo2X2kg1079gMY2MjunVsxrFTl764R1FAYDBarUJYuIrAoGA27zr83VijYv7ONvOJrU1qypcuwrR5q/D1CyAoOIQjJy+iKMrH/U4EiqIQrlIRGhZOWHg4oWFhrN/25cHbj3j5+h27D54kOCT04ylAPcJjjGvad+QM9x89R6PRYGBggFqjQftxXb71nY5N7y4tyZU9MxXLFmPBx/teNa5Xlc07D3Pz7iPUGg0PHj/H5b1bgqyfECK6eBdIWTOlp3nDGixZtZUGbfrRb+hk0jo70PfjgOnSxQvx+u0Hzl++hYGBPlPGDMTd04eGbfsx8p+59OrSkvKli0S1V7Jofq7ffkCh/JEFVqH8ubh07Q7Fi8Q+/qh44bwUypeTVl2HfPVmedapLZkzeSgnzl6hTsveDBgxNdZxLrH5s19nDAz0adpxIKMnzadK+f8fWadN48iJM5dp2mEAPQaOo2n9al+MkypXqjAdWtVn2PjZtOkxFJTIq4Y+aVq/OvVqVqDvkIk07zIYMzNThg/sFqfYfkbnNg158cqFxu37c+DYOapW/P/pHHMzU35r34QRE+bQd8hEtFotg/t2JEM6Zzr1HUmLLoM5dOxcrIOpf2vXhP2Hz9Dytz957+r+zRj09PSYMKIfGq2Wlr/9ScfeIzh57mqsp6CMjQy5eecR9dv0Y8X6nUwdMwBHh8jerD96tmXN5j207T4ULx+/qCulvudb34uc2TKRJWM6Fq6M/E65fHBj6+4jX7RRoUwxev/WilET59GwbT/cPLyYMmYABgbf35RiLgOgdvXyXLt1P1o+Phdbbn50HWMqlC8XPr7+ZM+S8atjnw4cO4tGo6F2tciruBzsbGjZpBazFq1D+aznMFvmyP1C3yET6Td0EkUL5fniAoav+d4287lRg3tindqStj2G0qHXcN64fECrVT4eYCns2HecVBbm9P6tJf9MX8pvv/+NpYUFGdM7xymWb7GzTc2Dxy9o3XUIbXsMo3D+XNT5+Ll8kjGdM/OWbaR2i97MXbqBMX/1jrpS71vf6dh86jHs2akFp89f586DpxQtmIeh/X9jxvw11GrWk3/nrZJbrAiRSPRUqvC4nR8RIoncvPOQoeNmc2znUp3F4B8QxO9DJ7F20aREXk4gLboMZtuqGd8cAyR+bcnhOy2EiJ+fGoMkREqkUkUwfMLsWO+vk1AURSEkNIx5SzfSpF41KY6EECKZkYfVChGDkZEhQ//47avjchLC67cfaNjud/wCgujQqkGiLUcIIcSPkVNsQgghhBAxSA+SEEIIIUQMUiAJIYQQQsQgBZIQQgghRAxSIAkhhBBCxCAFkhBCCCFEDFIgCSGEEELEIAWSEEIIIUQMiVogDR49nXOXbzJp1jI8vX0ZMWEO5y7fTMxFikQyePR0XYcgEoDkMeWQXKYMksfkK9EfNXLu0g16dmrBuw/u5M6ZhQqliyb2IoWOrN2yl9Pnr7Ny3nhdhyJ+0Ac3DzbtOIRaraFooTzUqFxG1yGJH+TnH8jSNdsxMNAnV/bM1K9VSdchiR8QGBRMr0ETKFIwD9mzZqBx3aq6Duk/I8ELJDcPL6bNW0WOrJl4/fY9bh5ebN55GFWEiucvXShfqihZM6dP6MWKRPB5Lt3cvdh35AyhoWHsP3qWTq0bEhgUjJu7F5kypKVO9fJ0bNWQO/ef6jpsEUN88lizSlkG9OqAnh4MGTNTCqRkJr7b5JDfOxMaFs64fxdJgZSMxCePFcoUJVUqc4yNjcieJaOuQ/9PSfBTbDv2Hqddi/r06tKSzBnTkTtHFtq1qEelssUpW7KwFEe/kM9z6exkz6lzV2nesAaF8+eiXMnC+PoF4GhvS5UKJXUdqviG+OTRwEAfAwN9Tl+4TtmShXQduoghvtvk3YfP6NJvNA1qVdZt4CKa+OQxlYU586YMp1fnFsxdukHXof+nJHiBpNaoMTYyAiKfWC5+XTFzmTtHFlZt3E3BfDkxNTWhS9vG5M2djX+mL9FxpOJb4pvHS9fu8PK1C03rV9dl2CIW8cmlVqulUL6cbFo2lc07D+k4cvG5+OQxOCQUIyNDDA0N0NfT03Hk/y0JfoqtUZ0qzFiwljy5suLnH4CNtVVCL0IkkZi5DAsLR6PV8sbFFZf3bhw6fp5wlYpMGdISHBzCig27ef32PUtWb6Nn5xa6Dl98FJ883nv4jKlzVlKhTFFmLFhLj07NsbK00PUqiI/ik8tnL99y8NhZ9PT0KZAvh65DF5+JTx4fPnnBqXPX8AsIpHnDmroO/T9FT6UKl24eESd/T17A+OF9ef32A+u37WfU4B66Dkn8AMljyiG5TBkkj8lTol/FJlIOB3sb1mzei4enN43qVNF1OOIHSR5TDsllyiB5TJ6kB0kIIYQQIga5k7YQQgghRAxSIAkhhBBCxCAFkhBCCCFEDFIgCSGEEELEkKAFkqIoqNVquUFkCiC5TBkkjymH5DJlkDz+OhK0QNJoNFSo1xmNRpOQzQodkFymDJLHlENymTJIHn8dcopNCCGEECIGKZCEEEIIIWKQAkkIIYQQIgYpkIQQQgghYpACSQghhBAiBimQhBBCCCFikAJJCCGEECIGKZCEEEIIIWKQAkkIIYQQIgYpkIQQQgghYpACSQghhBAiBimQhBBCCCFiiLVAcnnvRsfeI/Dw8mHMlIWMmjiPwKDgpI5NCCGEEEInDGN7MUM6ZyqWLcYHVw9KFstPGkd77j54SrlSRb6YdvveY+zYdwwARVESN1qRqCSXKYPkMeWQXKYMksdfk55KFR5rtpav20GGdM7Y2Vrj7GjP2Ys3aNu87jcbU6vVVKjXmXMHVmNoGGvtJX4RksuUQfKYckguUwbJ46/jm9lxdnLg3Xs39PX0yJwxbVLFJIQQQgihU7EWSJeu3eHKjfv4+AYQFByMRqNl2ICuSR2bEEIIIYROxFoglSlRiDIlCiV1LEIIIYQQyYJc5i+EEEIIEYMUSEIIIYQQMUiBJIQQQggRgxRIQgghhBAxSIEkhBBCCBGDFEhCCCGEEDFIgSSEEEIIEYMUSEIIIYQQMUiBJIQQQggRgxRIQgghhBAxSIEkhBBCCBGDFEhCCCGEEDHE+rDamDbvPMyL1y6kdXagS9vGiRySEEIIIYRuxalA0tfXw8LcjPRpnb54b/veY+zYdwwARVESNjqRpCSXKYPkMeWQXKYMksdfk55KFf7dbEVEqDE0NGDcv4sYMbA7xsZGsU6nVqupUK8z5w6sxtAwTrWXSKYklymD5DHlkFymDJLHX0ecxiCpNWr09PQwMjJCK9WvEEIIIVK4OJWvO/Yex8PLh6yZ0mFqYpzYMQkhhBBC6FScCqT2LesndhxCCCGEEMmGXOYvhBBCCBGDFEhCCCGEEDFIgSSEEEIIEYMUSEIIIYQQMUiBJIQQQggRQ7K9S9XVG3e4cv02YWHhqFQRpHF2oEGdajjY2+k6NJ1QFIVN2/fx7r1rtNfr165K3tw5dBTV9925/4igoBBKFC2Iq7sHmTKk03VIOqVSRdB30N+cPHuJRvWq07l9c65cu02nts2+egPW5ODug8f8O2sJs6eOJjAwGCurVHj7+JEzexZdh6ZTd+4/Ys/+Y/zZvzv7D52kZrUKWKe20nVYX+Xl7cOfIydTIF8u+vfuzFuXD3j7+JExQ1qcHO11HZ5OvX7zjgi1GidHe/z8A8iYPq2uQ/qmHXsOsXDZerasmYeJiQn6+nqcPneFerWq6Do0nQsJDcXczOyn20l2BVJoaBh5itcgJDSU3l3b8cblA85ODjw4/Yxjpy4wdfzQZP/FTWjuHl507j0EHx8/mjeuE/X6+w9utO7yB8f3rsfRIXkVjoqiMGPecpat3oy5mRmv3rhgbGyEhbk51SuXY9n8yboOMUm5uXuycNl65i5eTc7sWdi/bTm1mnRm5bptpE+XhoDAIAb/3k3XYX4hIDCIg0dO8ffEWVSuUJpSVZri7eOLsbERKlUEl07sIE+u7LoOM0mdvXCV3gNGYWWVClc3T8LDVVy/dY+zF65Ss2oFtq6dr+sQv6DVarl5+z59B4+hYtkSrFy7lX9nLyE8XAVEHmitXz5Lx1EmLU8vb0LDwnnw6ClmpqY0btOTwgXzkjljei5fu8XZw1uS3X4VwM8vgEvXbjJuylyqVy5HnaZdePbiddT7V07tIleOrLoLUMdev31H4bL1eHD1KING/MOUsX+RJXOGH2orWRVIYWHh9B86HkcHO47sWoONTepo75Wq2oRWnfpx6cROHUaZtDy9vGnSthelSxRm6vihGBn9v5dBrVYzbMy/NG7Tk/x5InuRateoRNOGtXUVLgBvXN7T4/cR6OvrcerARpydHKKeP+Tl7Uv5mi14+PhZsu75Smjzlqzh6bNXtGhcl0G/dyVPruwc3L6S0NAwbGysKF6xEY8eP6dl03qkTm2Jk4M9mTOl12nMj548p1m73mTKlJ49m5eSJ1d2nr98ja9vAI+ePsfVzYO//5nFljXz0Nf/b5ytv//wKQ1bdQfgvas7a5fOwNjYiNad/2DaP8OZvWAlfQaNxuWdK7OnjCZtGifMzEx1Fm9QcAharZb+f43j6vU7dOvUioH9ujJ0UC+OnbpAaitL9PSg3+Cx3Ln/iEL58+gs1qRWqXZrPrh5AGBjnZr5M8bRb/AYbt99SO0alRg1fjrPX76hcMG8zJw8CkVR0NPT00ms4eEqLl65QfZsmWnYsjvePr7s2riYwgXzMnXWEp6/fE0qCwtCQ8MYNHwiG1bMStY9mQkpPFzF5BkLqV+7Ks7OjkyatgCAjj0GceP2fQCqVy7HkFGTuXv5ULw6WJJNgeTp5U2l2q3Jni0zpw5uxMLcPNr7pqYmHNuzjsp1WusoQt1Yt3k3WTKlZ9o/wzEwMIj2nqGhIVPHD+XYqfOEhYUTEaFm0PCJPHn2iuGDe+sk3ncf3GjUugdtWzSkf+8umMS487qToz1DB/aiWv32vH966T/xw6ooCgePnGbz6rnRjuzy580Z9e+6taqg0WoYMW4az1++AWD+jHG0bdEwyT+j12/eMXD4BE6dvUy+PDk5tGNV1HvZs2YGoESxgoSHqyhVtQlbdh6gTfMGSRqjrpy/dI1eXdvRvlVjtuzYT61qFTE2Nora8X5wdWfWgpX83rMTxSo2BGDYoN60bl6fzBmTtuBVFIUchaoQGhYGwOWTO8mdMxsA9na20XI2c/IouvT6i5vn9yVpjLoSERGBr18AhQrk4c69R2RIn4b2rRoTGBhMtiwZyZI5AyUqNaJE0YJs33OYleu2kSljOqb/M4ISRQtibZ34xcfT56+49+AxdWpWZtrspcxasDLqPZ+3t6L2CyP+7BP1elBwCK07/86e/cfo1K5ZoseYHBw4cpLZC1cxe2Hkfqpc6eKMHvo7E6bOY8q4v5g+dxlHjp/F0cGOgqUjz8CsXz6LTBnTUSBvrm+2nSwKpJev3tKwVXfatGjI6KG/f3U6ezsbPrh5cPbCVSqWK5mEEepGeLiKdZt2MWvKqC+Ko08MDAyoXb1S1P9LlSjMwmXr0Wg0X50nsfw7ewmr1m2jdo1KDP6921eX361TK4aMmsy8xWvo36dLksaoC4+fvkBfX++b43U2rpgNRPYKBoeEcvX6HWYvXIWpiUm006qJLSIiguHjphEaGsbcf8fQvnXjr05rYmJMn27tOXri7H+mQLp+8x41q1Ugf96c5M87KOr1T0elQwb0oFrlcpQvU5zsWTMREhrGxSs3+P3PsezbujxJYnz+8jU21qmZOG0BmTOlo22LRtSvXfWbpxka1q1Gr/4jCQgMwsoyVZLEqUuPn70kW9ZMnDm0mQ+u7lH7qt7d2kVNM37kQBrWrY5/YCALlq4jKDiEcVPmMmnMn4n2+3P2wlUA8uTKRq/+I3nw+BkqVQSKojBh1CAuXr3JlHF/ffWgKZWFOfVqVWXJyo00bVSbJ09fULxowUSJNbm4c+8RVSqW5tTZywAMG9SLQgXykCdXdurWrMwHVw/mL13L4xvHada+N7fvPqJ9t4GULlGYQztXf7NXUE+lCk+wp8/+yFOKb999SM3GHRk2qDcD+nT57tFy38F/c/zUBS4e346drU1ChJ2oFEXBx9cPiOwFi9kz9i17Dx7nr9FTuHl+X4IMOIuP+OZy/tK1bNiymyVzJ1Egb67vdkXPnL+CC5eus2PDooQKOdFotVr2HTzB23cfaNygJhnSpYnX/L0GjCJj+rTRjvTiQlEUFEX5qR6kuOYxPFzFzn1H2H/oBF7evuzdsuyL3r/YPHj0jHI1mnP38iGev3hNlYpldHYa4nvCw1UsWLaOC5euM3faWNKldYrX/CPGTWPhsvU8uXlCJwOa45LLFy/fUKpqU9RqNQC3Lx6Ic89V4zY9KVooH1qtFlsba/7o3TmhQk9wt+8+ZO7i1TSoU40mDWrFa95LV29Sp2kXqlUqq5P9T2x5PHz8DDWqlMcuU1EAbG2s8fH1Y/Hsf/hz5CROHdxEjmyZ49T+q9cuFClfnz7d27Nk5SbGDPsjWedSpYrAx9cPZyeHeM8bEhpK9frt+efvwVSpWIYbt+59URAqikJYWHi0U90RERHo6el997ctTnve+4+eM/KfuSxftyPeK/Atdx88pknbXowfOZBB/brG6YdgwYzx5MiWmWwFKzN5xiK0Wm2CxpRQwsNV7DlwnMp121CkfAMq1GxJ/pK1efHx9Mn3KIrCgKETGDG4T5IXR/Hx8tVbhoyazNxFq9m+bhEF8+WO0w9kvVpVcHXzYMPWPbTu8gde3j5JEG38BIeEMHfRaopXbMTcxat56/KeavXb8fc/s1CpIuLUxvsP7mzevo++PTrEe/l6enqJfnrtUxE2ZtJseg8YxYEjp5g5eVSciiOAfHlyUKViaf4cMYmm7XozbMy/iRrvj1AUhSUrN+KUrQRHjp/Fzs6GfCVrMm3O0ji38eTZSxYuW8/8GeOS1dVearUaH18/GrbqTtnqzZk+bzkd2zShf+/ObF0zP16n9fr37szZC1eZt2QtS1dv5vyl64kY+Y959OQ5OYtUpXLdNiiKQu8Bo5k0fWG8fgeG/j0VAwMDJo/7KxEjjZ+Z81aQvdD/rz7r2rElAK2bN+Ddk0txLo4AsmTOQN1aVVi4bD0LZ45n+dotXLxyEyDqczpx+gIREXHbhyWWPQeO067rAByzFid3seq8fvMuXvMHBYeQNkdpHj55Tv6PB+Wx9Zbp6el9MQ7QyMgoTgf+cdr7nr14nXHD+hAWrooabBtXnl7e+Pr6c+/hk2ivHzhyioq1WlGqRGF6dGkTrzaXzJlEy6b1mDprMU+fv4rXvIlNq9Wya98RSlRuxMRp8/m9Zyee3z7Fw+vH+HvY73TqNYQxE2fx7oPbN9t58eoNlpYWdGzbNIkij7/wcBXNO/Tl2s27bFk9L15H5FkyZeDZy9f0HfQ3Bvr6LFm5KREjjT9fX38atuzOpWu3WDBzHCf2b2DaxBFcObmLuYtXU6VeW9Zt3vXdQmnqrMXUrlGJ1FaWSRT5952/dB21Ws30ucuwyVCYEpUasXjFBh5dP4brsyvkyxO/wfNFCubj6MlzrF8+i227DuLt45tIkf+YJSs3smbDDvZtXc7hXatZMmciF49vZ8HSdbT5rT/BISHf3a9duHyd3zq0oH2rxkkTdBwcPXGOZu37MHL8DM5euMrDx8/YtG0vWbNkZNzIgdSsViFe7RUqkIfrt+5Rsngh/hrQg1XrtyVS5D/Gzz+Azr2G0LFNU1yfXWHVomksmTuJf2cvYfrcZVG9Zt+iKApvXN7z6v7ZZHWLigmjB+Hr5w+A2/OrjPizD89un/zh9pp+7FWrU7MyrZs14OKVG7h7eJE2R2nadh1As/Z9cMhSnCMnzkbN88HVPd6/7z/q1p0HdOo5GFc3D6aM+4sBfbpQuFw9Nm7bG+c27tx7RK4cWVm16N9Eu9owTufBgkPDMDQ0xMjIkIDAoGg7++17j7Fj3zGAWD/cP0dO5tS5ywQEBFKlYmmKFymIr58/y9dsYc3i6TSqXyPeQadL68TSuZPw9fXHzd0zauChroSHqzhy4ixHTpzl+Ys3uHt6MWPiSKpVLhutB6Bzu+aYm5kxYeo8cuXMRtsWDb/a5sXLN6lQpkRShB/lW7k8d/EaM+YtJ20aR67duIt/QCB2ttbkz5uTtUtnxHtZxsZGbFo5Fw8vb0oVK0SDlt0YOrBnnE/NJpYzF66wZcd+zl+6Tqum9RnxZ59oPWI2NqnxfHWdhcvWs2TlJt69d/vqgPjAoGD2Hz7JlVNJe9Xlt/KoKAqLlq+nW79huLl7AlC5QmlMTExI4+z4Q8tr2rA2W3cdpFL5UtSrVYWde4/QvXPrqKt+kvrqn8CgYB49ec69B0+4eec+V67dZseGRdHuwZU3dw62rV1AjUYdSJezDE0b1mLlwq/3ft2685BihfMnRfjRfCuXlcqX4siJs6xYu5UOrZswckhf3ri8J3vWTD+0LFsbaxrVq0HxogVoWKc6f/8zC08vb+7ef8z+wyfJnDE9u/YfpWObJvzWoeVPr9v3REREcPrcFfz8AwgIDGL77oNULFeSkUP6Rn2fGtWrzpVTuyhVpQlLV22icf2ajB818Ku97m/evsfK0jLJx1l973eyVPHCHNq5CkMDQ0xNTQB+6p5/zRvXoWqlMlhZpiJr5gys27ybg0dO0bZlQ+49iOysaFi3OvMWr6FWtYqMmTiLOYtWR24TVcv/8HK/5t7DJzx5+pLs2TLj6+sXOQZ1+lg6tG4CgEajwTq1FX0GjqZqxTJxOt128859alatEO9TrPERpzFIi1ZuoXvHZixevY2+XVt/dWf3rXPk5y5e4/K1W4SFheNgb0u5MsW/O4L8e9r81h9PT292b16KhblZVFyfThtAZPdaQu6ctVotDx8/JyIiAo1Gw+NnL5m/ZA2GhkZ0bNMERwc76tSo/M1TFNPmLEWj0TJsUK9Y34+IiKBBy25069Q6SQfofi5mLlWqCE6evci9B08wNTEhd85sBAUHU6FsCeztbH96eQ1adsPYyIj2rRuTOWN6CuTLRVi4ChNjo2i3NkgowSEhzF6wKupqFF8/fzZu2YOFhTm9u7WjWJEC373k+fa9R/QbPIbzR7fG+v6q9du4cOkGyxdMSfD44yq2bVKj0XDu4jVc3rvSvFGdBL0Mff/hk7TvNpA6NStz6cpNCubPzdkLVylWOD/9+3ShYd3qQOTYpZzZM/9Qbj8vuDw8vRk5bjqZM6Und86sODs50nvgKNI4OZIta0ayZ81MxzZNvvodDQ4JQU9PjwKl6nD55I5Yf5SCgkMoVKYuF45t+6FxEgkltlwqisKRE2epVqlsgm8n5Wu25P7Hnv92rRqxYcueqPc2r55LlQplGDt5DiEhocz59+94tf3y1VtevnZBrVFTungRnr54xbmL19iyYz+Hd61Gq9WyYcsetuzYT748OQkJDaVQgTwM6d8j1v357XuP+GfqPD64utOrWzs6tom95330hJkYGRny97A/4hVvQvqRsbo/4+nzV5Ss3BiAs0e2kCt7Vt64vCdr5gwUKd+ABTPG0bBVd3p1bcfiFRu4feHAV28xEh6uYtO2vew5eIwHj56R2sqSZy9ekztnVqZPHMnbdx/Q19Nj36ETtGvVmLo1K6PRaMhWsDJFC+fj5JlLACycNSHWDoIef4xg684D9O/dmQL5cn/1909RFKo3aM8fvTr/UCdLXMWpQLr/6Dkbtx8ga+b0dOvw9UsHkzrxU2ctZvKMRVhZpiJcpcLOxhpzczP8AwLx8w9Aq1UwMjQkVSpznBwd0NfXQ6PREhYWTkBgICbGxvj5B2Bvb4uhgQE21qnR19dHX18PRYlMglarjSq4tIqCr58/piYmpLayxMBAH1NTE3p0aUOtahXjPF5k++5DjJowA2cnByIiIruFIwu5yPeDgkKws7Vmz5al8RrUnZCSOpfrt+ym3+AxlChakIDAIJ48ewlE9jRlz5qZdGmcCAwKwsLcnCyZM5AxfVpCQsP44OoOgHVqK/T19TAxMcHM1ARjE2PCwsLR/ziORxURweMnL/Dx88PlnSuv377Dxjo1xYsW5MXLN1QsV5IeXdqQLUvGOOdRo9GQpUAlunZogZmZKWZmpliYm2FiYkJgYBDzFq9hxcKplC5RJNE+t+9J6jxGREQwcNg/ADSoW42nz18xesJMOrRuwrFT52lYtzp37j3i1t0HlC9TnPEjB2FmaoKntw8mxsY4OtgTHBKCqakJr9644O7uRapUFrz/4Ia3jx8Xr9yIutLHydEedw8vcufMinVqKy5fu42JiTHjRgygV9d23wrzC116D6FOjcq0bFov6jVFUQgMCqbvoL+xsDBn8ex/Eu6D+gFJncsjJ85y4vRFOrdrRt7cOThz4QqF8uXhyfOXdOk1hDKlinLu4jX8AwLp37tL1EUIMXsMg4JDmL1wJTbWqblx6x7HT10gIDAo2rKyZcmIp7cv2bJk5NadB1Gvnz+6LdrtML5n9/6jbN99KNabXp46e4me/UdydPdand5jLKnzCLB8zRaqVSr7xZWMO/YcYtiYf8mTKzt7Ni+lbdcBlCpWiAF9f4u157dUlSZR++ZqlcqSN3cO0qdzZujfUwFIl8YJNw8vMqRPg5mpCZapUlG1Uln2Hz7J+aNboy5a+toFVoqikCF3WfT09HCwt4v1thOKojB30Wq27jrImUObEvUz1PlVbD/r0+XsiqLw7oMbQUHBWFiYY2lhgYWFORqNhtCwMDy9fNBqtUSo1ViYmZEqlQWqiAhsbVLj7eNHhCqCwOAQUBQ0Gg36+vqRXw49PfT1I3uh9PX0P/5gZ/qpXim1Ws39h08xMDTAxNg4Wo/Xp79zZMus09NNusjl59zcPVFrNDja2/H85Ws+uHp8fLyFLy9evcXHxw9TUxPSpXWO/CELDEaj1RAeriI0LIzwMBWmpiYoKGg1WvT19XGwtyVXjqykcXbEycE+Qe5lcvj4GZ6/fENISCihoWGEhIYRFhaOiYkxDetWp3yZ4gnwafw4Xefxcx6e3qzZuAM7W2uaNqjNinVbmbNoNWmcHLBObYWPrx9+/gHYWKdGrdbg5GSPnY01/gGBpHFywNHRniIF86Knp4e5uRlFC+WPNvYgNDQMAwODH3pky4Ejp+j5x4io75NarcHb1xd//0BaN2/AjEkjdHaw8klyyuWBI6eYPGMRuzctJigohFJVm5AlU3pSWVjw8PEzqlcpj4GBPlqtwqs3Lvj5B+DkYI+Toz2/dWhBkYL5sLa24tmL12TJlD5a71dwSAi79x+jYd3qWKayiFdcfn4BFC5XjzVLp2NpYcEHNw9On7vM/sMnCQsLZ8OK2ZQrXSyhP454SU55VBSFdZt2kTNHFkqXKMLla7do06U/5csU58Wrt/z5Rzfq167Gleu3OXP+CsvXbOH2hQOEhoVFOyX/7oMbd+8/pk6NSmg0GgBWrN3K7gPHuHTlJjvWL6Ra5XJxjklRFPIUr8HJ/RujxraeuXCFfQdPEBAYxLGT51m/fFai5/KXL5BE4pBcpgySx7hTqSJ4++49hgaG6BvoY25mip2tTbK5bUFyzuWTZy/x8vbFw9MLZycHHj99gampKZapLFAUhTo1KiVZzOu37GbDlt2oVBE4OtpTomhBnJ0cKF28MFmzZEySGL4lOecRIu+jtXnHflzeubJlx34MDQ1Rq9WkcXKgZdN6jBs5MM5tfbpq7keuxu3ZfyT58+akX4+O3Hv4hPbdBpI7Rzbu3H/EtnULKJgvd7zbjK/klx0hhNCBT6dzRfzlypGVXJ9d/FimZFGdxdK+VeNkdbXhryZ71syMGtIPgHnTxuLp5YONjdUP3W7mZ25T0rZlQ3r8PoIxE2eTLq0zdWtWZur4oT/c3o+QAkkIIYQQXzA2Nor3DVUTSqVypXh84zjuHl44OdrrpCdXCiQhhBBCJDt6eno6vXI05T8pVAghhBAinqRAEkIIIYSIQQokIYQQQogYpEASQgghhIghQQdpf7rJYVweGiiSnoGBQZyvBJBcJm9xzaXkMXmTbTJlkDymHJ/nMkELpE930KzSqFtCNisSSHxuTCa5TN7imkvJY/Im22TKIHlMOT7PZYLeSVur1aJSqb5ZTbfvNZz1iyf/1HJ+to3/6vzxOcpJilz+6vPrMoa45lK2yeQ9v2yTCTu/rmJIbnlMiDb+q/MnWg+Svr4+pqbffjK4np7eT99e/Wfb+K/PHxdJkctfff7kEsO3yDb5a8wfF7JN/joxfItsk7/G/CCDtIUQQgghvpDkBVKzBjV03sZ/ff6Eouv10PX8ySWGn5USPodfff6Eouv10PX8ySWGn5USPodffX5I4DFIQgghhBApgZxiE0IIIYSIQQokIYQQQogYpEASQgghhIhBCiQhhBBCiBikQBJCCCGEiEEKJCGEEEKIGKRAEkIIIYSIQQokIYQQQogYErVAGjx6emI2L5KQ5DJlkDymHJJLIRJX4j5d8TseP3vF/iNnAbh8/Q4blk7BxNhYlyGJn7B2y15On7/OynnjAVi4cgvqCDXm5qZ069BMx9GJuPjg5sGmHYdQqzUULZSHGpXLsGnHQdw9fdBoNAzq0zHOTy0XuuXnH8jSNdsxMNAnV/bM1K9VSbbJZMLVzZMDx87SqG5VpsxeQdGCeWjXoh6e3r4sXLEFA309GtWtSoG8OaLN9+jpSw6fOE9wSBh1qpWnWOG8OlqD/4YEL5DcPLyYNm8VObJmws3di31HzhAaGsb+o2fp1LohgUHBuLl7kSlDWupUL0/uHFm4eechWTOnl+IomYlvLju2asid+0+j5vXw9Gbs0D4MHz8H/4BAUltZ6niN/pvik8eaVcoyoFcH9PRgyJiZVCpbnEvX7jJ3yjBmLVrHs5dvyZktk65X6T8rvtvkkN87ExoWzrh/F1G8SD7ZJpOJzbsO8fjZa7JnzUi75nV59PQVAPsOn476XZw4cyn5c2cnf94cFCmQm9GT5jPmr17kztEBP/9A5i/fhK9fAKqICOrWqMA/M5YyqE9HzM1Mdbx2KUeCn2Lbsfc47VrUp1eXljg72XPq3FWaN6xB4fy5KFeyML5+ATja21KlQsmoefYePk2jOlUSOhTxk34kl594ePqQPq0TAGmcHfD09kvi6MUn8cmjgYE+Bgb6nL5wnbIlC+EfGISDvQ0A6dM64e7preO1+W+L7zZ59+EzuvQbTYNalWWbTEYqlS1OiSL5qFyuRLTXPTx9yJDWCStLC8LDVdSuXp7jZy7j6e2Ls6M9hoaG6Onpcej4eapWKEmFskW5fP0OKlUE+vp6UhwlsAQvkNQaNcZGRgAoikLuHFlYtXE3BfPlxNTUhC5tG5M3dzb+mb4EgLCwcPT09DAwkPHiyU18c/k5Rwdb3n1wByK7kx3srJMydPGZ+Obx0rU7vHztQtP61UltmQoPTx8A3n1wx8nBTmfrIeKXS61WS6F8Odm0bCqbdx6SbTIZ0dfXR6PVfvG6o4MtLu/dCAgMxsTEGAc7G0JDwzh78TpVK0YWvfuPnMHU1IRypYpgYmyMjXVqTp2/RunihZJ6NVK8BD/F1qhOFWYsWEueXFnx8w8gLCwcjVbLGxdXXN67cej4ecJVKjJlSAtE7nSdHe0TOgyRAOKTy+DgEFZs2M3rt+9ZsnobPTu3wNHelrlLNpA1c3rpyteh+OTx3sNnTJ2zkgplijJjwVp6dGpOmRKFmLVoHRqNlhxZM+p6df7T4pPLZy/fcvDYWfT09CmQLwfOjvayTSYTObJmZP22Axw/fZnTF67h7etPhnTONKhdmYUrNnP45AXat6gPQMWyxdi04xBN61fn1LmrrN2yj5JFCzBz4VoG9elI3RoVGDVxHusWTdLxWqU8eipVuJKYC/h78gLGD+/L67cfWL9tP6MG90jMxYlEJLlMGSSPKYfkMuV7+86VQyfO07NTi1jfDw4JZc6S9YwY2D2JI0v5Ev0qNgd7G9Zs3ouHp7eMM/rFSS5TBsljyiG5TNnuP3rO/qNn6N2lVazvv33nysYdB+nQskESR/bfkOg9SEIIIYQQvxoZGS2EEEIIEYMUSEIIIYQQMUiBJIQQQggRQ4IWSIqioFarURQZ1vSrk1ymDJLHlENymTJIHn8dCVogaTQaKtTrjEajSchmhQ5ILlMGyWPKIblMGSSPvw45xSaEEEIIEYMUSEIIIYQQMUiBJIQQQggRgxRIQgghhBAxSIEkhBBCCBGDFEhCCCGEEDFIgSSEEEIIEYMUSEIIIYQQMUiBJIQQQggRgxRIQgghhBAxSIEkhBBCCBGDFEhCCCGEEDHEWiC5vHejY+8ReHj5MGbKQkZNnEdgUHBSxyaEEEIIoROxFkgZ0jlTsWwxPrh6ULJYfprWr8bdB0+TOjYhhBBCCJ0w/Nab7p7eODnY4ehgx9mLNyhXqsgX02zfe4wd+44BoChK4kQpkoTkMmWQPKYcksuUQfL4a9JTqcJjzdbydTsoUbQA7967kcbJnrBwFWVLFv5mY2q1mgr1OnPuwGoMDb9Ze4lkTnKZMkgeUw7JZcogefx1xJqdS9fucOXGfXx8AwgKDkaj0TJsQNekjk0IIYQQQidiLZDKlChEmRKFkjoWIYQQQohkQS7zF0IIIYSIQQokIYQQQogYpEASQgghhIhBCiQhhBBCiBikQBJCCCGEiEEKJCGEEEKIGKRAEkIIIYSIQQokIYQQQogYpEASQgghhIhBCiQhhBBCiBikQBJCCCGEiEEKJCGEEEKIGGJ9WG1Mm3ce5sVrF9I6O9ClbeNEDkkIIYQQQrfiVCDp6+thYW5G+rROX7y3fe8xduw7BoCiKAkbnUhSksuUQfKYckguUwbJ469JT6UK/262IiLUGBoaMO7fRYwY2B1jY6NYp1Or1VSo15lzB1ZjaBin2kskU5LLlEHymHJILlMGyeOvI05jkNQaNXp6ehgZGaGV6lcIIYQQKVycytcde4/j4eVD1kzpMDUxTuyYhBBCCCF0Kk4FUvuW9RM7DiGEEEKIZEMu8xdCCCGEiEEKJCGEEEKIGKRAEkIIIYSIQQokIYQQQogYpEASQgghhIghWRZIYWHhHDlxVu44mgJotVq0Wq2uwxBCCPEVWq1Wfm9jkewKJK1WS5O2PenVfxTrNu3iyImzHD5+hjTZS+Hu4aXr8HSuxx8j8PbxxcvbJ9l/oV+/fUemvOXp9+cYIDK3h4+f4eDR07oNLBnQaDQEBAbpNIZHT54THq4CICQ09JvxaLVaVKqIpApNxMPWnQcoUakRiqIQGBTM3EWref3mna7DEj/gwJFThIaGJeoyFEWh14BROGUrwflL1wFo120gxSo0pEWHvvj5B3y3jTv3HxEcEpKocSYHyaJA+rTj3XvwON1/H45areHY3rUMGjGRVp1+p3XnPwgNC2PS9IXJvihITA8ePWPrzgOcu3iN7IWqsHTVJsLCwpk6azH+AYFJHo9Wq2Xluq28cXkPRG54n/68fvOO2QtW0rldc06euUT3fsOxzViE1p3/oO1v/Xn77kOSx5uc9PxjJPlL1uLFyzfs2HMIAFc3D1zeuyZZDGWqNcMpWwl27DlE8/Z9yVG4Ci9fvUWtVn8xbedeQ8iSvwKv37yLKu7GTZ4TVWD9l/07e0mi/6jFJjxcxYnTF7h28y7PXrzGJkNhmrbtxdzFq+nZfySPn774Yn/p5u5J03a92Ln3cNRrt+8+5OHjZ0kdfrITGhqGn9/3i4PEEBAYxPFTF2jXdQBFytdnzMRZBAYFJ0jb23Yd5NadB5w5fwXr9IWoWLsVDx49ZemcSXTtO5T7D59y5txlGtatxrFT59m97+hX21Kr1ew5cJxKtVszbvLcFP97nGQPggkKDkFfXw9zMzNWrN3Kmo07WLFgKleu36bf4DH8NaAn/85eQvkyxVk2bzKZM6Xn+pk9PH72Agc7WwyNDGnevg/FixagQ+smSRW2TimKwqTpC2nWqDZ2ttZs2r4XiPyxApizcBU79hzm6o07nDxzCQd7W2ZPHU0qCwtMTU0SJabzl65Tv0VXBvb9jfx5c/LX6KkUL5KfhvVqMGv+Clo0qYuVpSVTZi7CztaGC8e20ahedao37ECp4oVp3rgON+88oGajjjy+cTxRYvwVXLxyI7LImDKXw8fPkC1rZirXaQ1AzuxZaNm0Ht06tcLKMhX6+gl7HNOgZTcK5MsV9f+R42fg5u5J/96dKVqhAfr6+vw1oCdDB/bk8PEz+PkHcvLMRQb260qPP0Zw9cadqHlv3L7P8vlTsLezwcfXDyMjI4yNjDAzM03QmJOrx09fMGn6QkqVKMylK7fo1LYplpapmDB1HpkypmP95t2MGzGAkNAwGtathp6eXoIt++KVGzRr3weAKhVL07ldCzr1HMzcaWOYNmcZpas2ZcHM8TSoUw3LVBb4+Pqxfc8hNBotf42eQkhoGKMnzMTXzx8rK0s2rZxDudLFCAkNxdzMLNZlarVawsNVKTK/HboP4tGT55w7uhVvHz9yZMvM7bsPcfPw5I8h48iSKQMtmtSlZPFCFMyXO8GWqygKeYvXICg4skemYL7czFm0ml37j7JhxWwK5M31nRa+rfvvwylRtCCFC+Qhd86slChakL+H/kHq1JbMXrSK8jVb0LVjS8aOGECBfLk4cOQUnds3j7WtidMWsGHrHnJky8yRE2fx9fVn2sThWKe2+qkYk6s4Paw2rr71EL48xarj6u5Jjy5tOH/xGqamJty88wAAKytLAgICMTcz5cOzK19tf82GHWzddZD925bj7uGFs5NDQoWeLF25fptajTtF/T9bloxMGjuEVp1+Z9fGxUyfu5wLl68zf8Y4+g0eEzWdvZ0NT26ewMDA4IeXHTOXz1685sate7h7eDFm0uyo6bp1asXyNVu+mH/aP8Np3qgONjapgcgd6+c/9NbpCzF/xjgCAoPQ19PDztaGFk3qRmvj09FJQv6o6Mq2XQd5+vwV7Vs3Rk9Pj/I1WkSd0urYpilbdu4nPFxF+TLFOX/pOqYmJoSFh7NiwRSaNarzw8uNbZucOX8F46fMBeDF3dN4+/ix79AJ+vXoyNJVmxj9z0wAGtSpxr5DJwAY2Pc3Rg7py8Bh/7Dn4HF6/daWzu2aMXL8dJ48fUmzxnWYMHVe1PrMnfb/7+Pf/8wiJDSUEX/2wdbG+ofXJbl498GN9Gmdgch9Uv+h4ylTqiiXrtykcoXSvP/gxrMXrwGoVL4Ul67epHyZ4uxYv+invsux5fLug8dUrNWKm+f2kTVLRlSqCAwNDQgNC2PW/JVMn7uMzu2aUTB/bgYNnwjAzg2L8PTyoWf/kQCMHzkQOzsb+v81npvn91GwdB1KFivEge0rMDL6/4PJT529RJO2vbC1seblvTOo1WpG/zOLBnWqUaZkkV9+O02TvRShYWEMH9ybZas3c3jXaopXbBT1fpWKpbly7TaXT+0iY/q0P7yc2PL47oMbqzdsJ62zI791aAnAhq17WLFmC4d2rsYkno/4cnnvysnTF+nUrhnW6QtFvX7l1C5y5cga9f+Hj59RuW4bXt47SyoLc95/cCdfyZrMnTYGlSqCxvVrYG9ni6IoRESoyVuiBuePbsPJ0R6VKoLuvw9n78HjbFw5h7o1K//wZ5JcJXqB1LXvUIoUyseo8TMAyJsrOw+fPOfi8e0sWr6Bvj06kClDOs5fuk71KuW+uZE9efaSUlWa8M/fgxk7aQ5D+ndnUL+u0Tbi23cfkjd3DoyNjb7azq9i9frtrN64g9t3HwKwbN5kWjSpi4+vH7Y21jx59pIZ85azdO4kFEVBT0+P+w+fEh4eTrEiBX5q2TFz+eLlG4pVbAhAxXIlmT5xBKPGz6Bdy0ZUqVQGD08vsmXJxKr12wgOCaV313bffFL1qAkz2LH7EK7unjg7OeDm7on3m5vo6+sTEaFm36HjdO07jLTOjjy4dvSX3/lmzFMuqiAqU6ooDepUw9XVg9y5stGmeQMatupOr67tqF+7KhD5+R8/fYGaVSv8VA/S1w5aZsxbzluXD8z59+8v5tFqtew/fJKOPQZjZZmKB9eOYpnKItb2X756S8tO/Xj+8k1Uod65XTNaNKlHh+6DKFe6WFSR9Wf/7owa0o+psxazYu1WFs6cQLXKZX+p3Pr5BZA5fwXmzxhH80Z1aNK2J44O9uw5cIyhA3tx8sxFrt28y5I5EylVvDCZM6WPOg0Z3x+5mL6WS7eP21BMiqLw3tWd/CVrATB0YC80Gg1DB/bEyMiI2/ceUSBvzqgDqTrNunDpyk2srCxxsLMhMCiYp7dO0m/wGNw9vLhz/xE21qlxdfPgzKHN3Ln/KKo3O0umDNy6sP+n1i+pvXz1ltCwcPLlyYFarSZD7nKEhkWeKq1fuyr7D58E4N8Jw2jXqhEW5uYJstxvdSR8TqvV0uP3EVhZpWLm5FHxWsa8JWsYPWEmx/aso0ajDgBMnziCbp1afXfezwuqoQN7MXxwb4aPncai5etJndqSNw/OR72vKArzFq9h7uLV3Di3j1ad+tG6WYOv9kD9jHcf3Hjr8oGypYomeNtfk+gF0thJs5m9cBUA86aPpVqlsgwZNZkNK2b/0DL+GDKOtZt2Mvj3bly9cYda1SvSvVNrBo+YSJlSRek7KHKHv2bJDBrVq54g6/WjAgKDOHfxGvVqVYn3vGFh4XToPojqVcrRo0sbbty6R9HC+RP8dMvXxJbLYyfP06JjX7atXUCNquV/qn2NRkO+krXInTMbuzctIX/JWhzft56J0xawcdteNBpN1LTnjm4lc8b0/P7nWAwM9Fk+f8ov9aMKkK1gZbJkSs/1W/fImjkj187sjtbD96nATWhx3RnHxv9jr+7nByBfExYWjqmpCXv2H6P3wFGEhEYeiU+esYiqlcowacwQGrXuwfWzeylYug5NG9ZixdqtbFo1hzo1Kn+zbY1G81O9oQlp36ETdOg+KOr/tapXZM3i6dy+95DSJYrg5xfAnfuPqFS+VIIv+0dzeeTEWR4+esYfvTt/93P0DwhEURSMjAxJl7MMz26fpGTlJhQrnJ/jpy/w6PoxZs5bzqFjZzAzM+XfCcPQaLQ079CHt48uYGWZ6qtte3n7cPzUBVo3bxDn2BNT0fINePn6LQtmjsfN3ZPLV29x7NR5Bv/ejVF/9WPspNm0alafvLlzJOhy45NHD09vqtZvx9jh/WneOO49yV37DuXSlZt8cPOgfavGnL98nQvHtsWpyAsJDeX5yzdcv3mXIaOmkC9PDu7ef0zLpvXInjUTfw3o+cU8HXsMZu/B4xgbG2GZKhU1q1Vg5qSRUadib999iLGx0U99lgOGjmf1hh1sWTOP4kUKYGdr88NtxVWcCqT7j56zacdBsmRKR7cOzb46XWyJVxSFkeOns2nbPl7dP/vTAd+8fZ+q9dtx89w+Lly5wfWb98iTKxvLVm/mxau3AJQtVQxjYyN2b1rC5Wu3GDtpNhNGDaZEsYI/vfzvURSFIaMmRzvttHn1XGpXrxTnNrRaLbYZiwBwZPcaShUvnNBhftfXNuKLV24mWHe6ShWBWqPG3MyM6g3aU7VSWf6dvYR9W5fToGU3dm9awqmzl1BrNOTPm4vN2/dx5vwVnBzteXLzxDfbDgkN5eiJczSuX/OnYnRz98TXz58R46ZRr1bVOB2BfU6r1XLi9EW69hvG24fnCQwKRqvVktrK8qfiiqufKZB+xPWbd6neMPKINWZ3ftV6bXny7CWVK5Rm3bKZDBvzL1qtlukTR3y1vfsPn1K+ZgvmTP2bTu2+vu9JKv/8Ox9TUxPu3HuErY01k8cN+ep4nYSW1LksVqEBnl4+mJmZ8uj6MVSqCExNTXj95h2Fy9UjrbMjD68fAyJ7n0b/9XusR/eKovDv7CUsWLaeCFUEx/etJ1+ehC06fkTBMnV46xJ5sYiVlSUn9q0nQ7o0iTZ+85P45vHGrXt06zecm+f3xWm/q9VqKVimLns3LyUwOJhC+fP8cJxLV2/GycGOwgXyki1rpq9Oe+bCFRav2MiaxdOJUEfQb/AYdu07yuwpo2ncoCYFStVGq9UydGAvWjdvgKODXbxiURSFQmXr0qZ5Q6bOWgyAz9tbid5hEKet7OzF64wb1ofFq7d9caS7fe8xduyL3EhiG9Gup6fH+JEDGT9yYIIEXLRwftxfXMPExBiX9678/udYIHLMS7NGtdmwdQ89Orchd7HqvP/gTo8/RpA1c0ZqNOrAnUsHyZQh3TfbP3riHPZ2NuTNnSNOG0rMcTI3b99n+Zot9PytLdUrl8PVzYPWnf/4YlzGt7x67UL6tM70/K0thQvkjdM8CeF7uQQStHvT2NgIYyJ7J2xtrPl39hIAKpQtgd+7yIHAGdOnpXS1ppQuUYSmDWoxftRAKtVuTVBwCKksYj8a2r77EHMXr+bu/cf82f8pvbu2+6GjjRVrtzJ4ROS4DUNDQ06dvUxqK8svxkp9y4Kl66LG9ABfPVWVkOKSx8SS82NBtHLh1GjFEcDYEQNo2Ko7wwf3QV9fn1ZN6zH076lfbWvxig2Mmxw5Vmr0xFmoNRrat2r8U6eqXN67MmbiLOZOG/vV78/XjJs8h1kLVnJ412r+/KP7D8cQH7rMpbGxEQGBQcyYNBJ9ff2o/WHmTOn5rUMLKpYrGTVt/tw5ePTkOTmyZeLG7fvRDgj3HTrBwaOn+WfUIAKCgmjarhd9urWne5fWP1Vcrt20k4zp01K5Qul4z6tSReDr68+dS5FXeBUrUoAM6dL8cCzf8zN5LFakACYmRuzcezhO4xF37DmMvZ0NWTJn+KkDWUNDQ/p0ax+naSuVK0WlcpG9psbGRiyfPwVTU1OWrtrEwuXradKgFn/2706fgaP5e+Ishg/uzdCBveLUtlarZcS46dhYp2bowJ7ky5ODBUvXsW3XQVo1qx/v9fp0b74Ll298v6dXpQpXvvdn4swlikoVrsxbtl7x9PL66nQhIcFKsSotlJCQ4O+2mRB/Xr95q5g75lbMHXMrz168jPbe2EmzlBYdeitpc5RU/Pz9FHPH3MrM+cu+2tbL12+i2vr8z4ixU5WAgADl4uVrytUbt5WjJ84oN2/fi5qvded+ioVTHqVEpYZKoTK1lQy5yyjrNu2I1vaGLbsUc8fcyus3b+O0Xhu37lY69RiUJJ9hcsllw5ZdFXPH3MqtO/e/eK9ynVaKc/YSiq+fr6JShStV6rZWzl+6qqhU4Up4eFi0aR88eqKYO+ZW0ucqrQwaPkEpW71pVC69fXyU0NAQ5eiJM0p4eJji5u4eNd+r12+VVp36KkNHT1YOHzulLF+9SbFKm19ZtHydEhwcpKhU4croCdMVc8fcyoYtu+K8Xi079lGmzFyonLt45T+RR5UqXDF3zK24vHv/xeuhoSHRPgd/f3/F3DG3cvTEGaVBi9+Ui5evKSpVuBIUFKS8dXmnZMpbVnn24qUSFBSkXL1+S0mXs5Ri7phb2XfomKJShStPn72IdX/k5u6uPHn6PGqdw8JCFev0BaJt12WrN1Vevn4T53Xy8fVVnLMVV5au3KCEhYX+J3JZvEJ9xdwxd5ym/XfWIsXcMbdSsVYLxdwxtxIQEKAEBQUpOQtX/mKbuXr9lpKzSBXF3DG34uburrx7/0Hp3Guw8uTpc+XI8dNR071566IMHzNFWbJyvRIQEKCoVOHKoaMnlVTOeZXOPQdF5XLR8nXxysm79x8UxyxFlewFK/4yebx9976SJX/5WPePn/9xd/eI+kx0sW4x/3h6eSnrN++M2nerVOHKgcMnlJxFqig2GQoqqzdsU0JDQ2Kd9+nzF8qUmQuVfCVqKOaOuaPtOy5dua7kLlY16nsRlz/h4WFKu65/KBZOeZQ0OUooTdp0/+48cepBSmVuhlqtJiJC/c1zzEktbRonAE4f2vxFz1CX9s2pUq8tLZvWw9zMjLVLZ7B5x356d20X1VX8eXU9aNg/ODs5UL1yOTq0acKzF695+uwVsxeuihpD9Unr5g3o0709ubJn5eSZizy8dpR1m3dx6uwlViyc+sUloC2a1OXx0xfkLVGTcSMGoG+gz+89O/E1O/YepkLZEj/78fxSWjdvgK1N6li73ndsWISJsXHUwPuC+XJRs1FH/ujVmbmLV0f1Nl2+douLV27Sq2s7poz7C4i8V8zd+4/p/9c4ytVoTv3aVVm4bH1U2y/vncHWxppd+48QGhrGG5f3NG3XG4AVC6bQtGHtqO/J6KG/ExGhZsa8ZZQrXQxHB7vvdpHfuvOAqeOHkS6t089/SL+IT/mIycDAINrp4k/jExq3iRzTkCF9GnLlzMbYSbNZsXYrQNR2XbhgXl7cPU377oPoPWA0545spXC5ehgZGVKhbAm6tG9BgzrVAKhWvz2v3riQIX1aXN59wMrKEpUqgqEDe1GiaEHSpXWiTLVm5C9ZC+83N+M0vuneg8fky5MjUQafJlvx6H3Ikzs7AG/ffcDIyJD6LbryxuU9aZwdeffBLVpvU+GCeTlzaBNjJs5m1IQZmJmasnXnAbbvPkQqC3M2rpxDkUJ5Wb1hB5eu3uLmnQcMHPZP1Pz6+vqEqyLYsGI25y5eY/CIiahUEfTu1i5Osc5fspasWTIyZdzQOK+fruXNnYNxIwbQ5rc/+POP7jRrVJvrt+5RIG+uaFeGTpu7lOqVy9G+VWOdxfq51FaWtGxaL9prNaqWZ8+mJVy4fIMVa7awcNl68ubOjrOjAx5e3tSvXZW9B4+zdecBypYqRt1alRn8e7do61msSAHy5s5B1frt+HfCMMqXKf7VGNRqNdt3H6LXgMiB7n17dKBsqWKULfn9syFxHoO0cfsBsmZOH+8xSIkt5uXjX+Pj60fWApUwMDDAyjIVk8YOoU3zBrh7eHHt5l36DPqbh9eOftHtvmf/MTr1+pP921bgYG9LQEAQjVp3JzQsnPTp0pAhXRoO7lj53eUrioJNhsJR///8R8TVzYPT56/QsG41/ho9hROnL3Lj3N4Eu2riR+gil3EV8/YHKxdO5dmL10yesQiIfczX5+O6bpzdy90Hjzl26jx37j2mSYOaXLtxh9bNG9CkQS1Uqgh8fP1ivTJIrVZTq3En1BoNd+494vrZPWTPmjnq/R17DlGudHGcnRw4cfoCfQeP4dH1YzobVJ6c8wiRN+e7dfchnp7edOr1Z9TraxZPB6BR/RpfzNOz/0i27NhPy6b1yJsrO24eXhw6dpp2LRvRsmk96jbtwsPrx7hw+Qar1m2jcYOa5MudgyyZM0S1ERwSQo0GHciZIyvDBvXCy9s32k726o077DlwjGGDemOZyoI/R07CztaG4YN7J+Kn8W1JncvL127x/oNbvG8zsW7zLn7/cyyLZv9DgzrVvnoqMzAomAy5ywLg8vgilqksWLR8A6MmzKBVs3q8evOOoQN6UrlCaR48eobL+w+EhITSpEGtaNvTus27GDp6CtvWLcTezuaLU7tXrt+mSMF8UQdYDVt1Z/Af3aJOCSW1H82joigcOHKKVeu2cf32Pfz9A7GztaFHl9akcXZkyoxFmJiYcHTPGhzs4zfGR1c0Gg1Xb9zhxu37vHvvxqvXbzly4hw5smWmdvVKjBn+x1c/o83b9/HX31OpWaU8yxdMifbe50OB5i1ew+h/ZtK+VWP+HvZHvMY/Jdl9kJKDew+fsHPPYY6fvsC9B0/o3a09i5ZH9iZYp7bi9YNzsc4XHBISrVgJD1dx5MRZtu48wLR/hpPG2TFOy3//wR17OxuKV2rEvi3LyJwpPQBDRk5iz8HjeHh6kzdXdmZNHa2TgdmfS+65hMhLrpes2sjkGYvIkS1z1FU6TerXjPVGdus276JGlfJRhc/7D+4cP3We/kPHky1LRs4d3RqnMRGf7geTLUtGev7Wlh5d2gCRVwDlK1ETW1trUltZcu/BE51fTfkr5BEid2ibtu/DMpUF9WpV+eZBz/bdh+jWbxhuz69iamqCoijMmLec5Wu2YGFuRtWKZZj2jYHfnwQEBpExT7mo/39+0NK4TU9On7tM+rTOGBkZ4R8QyOWTO+M9uDQh/Sq5hLhfeWidvhCrF0+LdjGFu4cXuYpWi7pZcFzWdfCIiWzfcwh//0AundhBnlyRPVq+vv5kKVCRMqWKMn/aWDRaLbUad+LelcPxHoOWUH42j1qtlsUrN2JuakqWLBnYf/AE7908Iu9HVaJI1O/Kr+qNy3vSOjt+9+pZRVHw8fWjRKXGLJ8/maqVIovt8HAVTtlK0KBONUqXLMKs+Ss4vnc9mTKmi/eB6n+qQPpEq9UydtIcgoKDyZAuDd06tyYwMCjqlF1i+/3PsRQtnI8u7Vtw7cZd2ncfyJHda9i++xAdWjfBydE+SeL4ll8llxD5Q/czp34fPHpG1swZ4nV34KDgEE6eucim7fvYtHIOAOu37ObE6Qtky5qJoyfOMXZ4f6pULKPTWxL8SnmMj9h6jvcfPsm6TTtZMmcS1tZxu7Nv175DqV+7KoNHTOLKqZ042NsRFBxCvpI1uXR8B8PG/Iu9nQ1NGtTS+WnvlJjL0NCwWLe723cfkiF9mjhfXPHpFiSVK5SmZrUKUYOLV63fxqWrt3j12oVrN+8CMHnsX3E+HZcYUmIedencxWs0aNmNQgXyUKNqeQoXyEunnn/SqF51jI2NqVapbLwurPncf7JA0rWTZy7SscdgFEVBFRHBuJED43y1QFKRXH6fn18ABcvUYdfGxazZuJN1m3dxdPfaJLmdRFxJHuOme7/hZMmcAWtrK0aMnUbnds2YPfXLm2jqkuTy29RqNUdPnmfl2q1sWDGb4WP/ZeW6bRzauYqM6dPx9PlLTp+7zN/D/tDpfbUkjwnv8/stAsz9dwwd2zb96XYlOzpQtVJZXtw9w/HTF6hUvpTOunrFz7G2tqJDmyZUa9AeJ0d7zh7Z8tPPTRK60apZfZp3iHyu2fwZ42jXstF35hDJjaGhIVUqlKbtb/1xyhbZ27d++SzKfByMmy6tE1UqltFliCKRjB0xgDo1K3Pt5l1GjZ9BmxYJczNSKZB0xMTE+IfusC2Sl4l//xl1j6/kcrdnEX/Vq5TD/cU1Xr9998UgX/HrMDMz5fzRbdy8fZ8C+XJRpFA+XYckkkip4oUpVbwwvX5rm2A9c1IgCfGTpDBKGUxMjKU4SgHy581J/rw5dR2G0JGEPG2ZNA/2EkIIIYT4hUiBJIQQQggRgxRIQgghhBAxJOgYpE8P4VOr1QnZrEggBgYGcb4nj+QyeYtrLiWPyZtskymD5DHl+DyXCVogaTQaAKo06paQzYoEEp/7bkguk7e45lLymLzJNpkySB5Tjs9zmaA3itRqtahUqm9W0+17DWf94sk/tZyfbeO/On98jnKSIpe/+vy6jCGuuZRtMnnPL9tkws6vqxiSWx4Too3/6vyJ1oOkr6+Pqem3H9egp6f305fh/Wwb//X54yIpcvmrz59cYvgW2SZ/jfnjQrbJXyeGb5Ft8teYH2SQthBCCCHEF5K8QGrWoIbO2/ivz59QdL0eup4/ucTws1LC5/Crz59QdL0eup4/ucTws1LC5/Crzw8JPAZJCCGEECIlkFNsQgghhBAxSIEkhBBCCBGDFEhCCCGEEDFIgSSEEEIIEYMUSEIIIYQQMUiBJIQQQggRgxRIQgghhBAxJGqBdODYWR4+efHd6QaPnp6YYYgfdPXmfc5evKHrMEQSuHnnIRu2Hfji9QNHz3Ly3FUdRCTiS6PRMmvR2p9ux9XNk+nz1yRAROJHfJ7HT7+Nuw+eZMaCNYSFq745r/yWJqxEfXhQvRoVE7N5kchKFs2v6xCEEHFkYKDPwN4ddR2G+Emx5fH85VtMGzcozg/EFQkjwQukERPm8PdfvQkPD2fRqq00qlOFwyfO07huNXYdOEGbpnV48OQFJ89ewc7Wmv4920XNu3DFZgwMDShVtACFC+RO6NBEPB04ehY9PT3OXrqBdWpL6tesxPNXb3Fz9yJThrRUKV+COUs2EBauIn+ebMniFv3iS2OmLOTPfp3Yuf8E4eEqOrZqwNh/F2Gd2hJPL1+6dWgaNa1Go2XavFVotFoK58+lw6hFbDy9fZmxYA3WqS1xeedGlkzp8Q8IpEjBPDStX43Bo6czffxg5i7dQEhIGLa2qenZqQWDR09nxoQ/OXnuKqGhYZQsViCqnZjbteQ98cUljzMm/AnAsxdveP32PVt3H6FEkfzsOnACczNTShYtgKmpCYeOn8fB3oZ2LerpeK1SngQ/xVapXHEuX7vD6fPXefP2AwDdOzZnzpL1ODvak8bZgS27DjNx1B8M7tsp2tN2Pb39yJ87O4VkA002Vm7YRctGNRnWvyv582TH1y8AR3tbqlQoiampCZ3bNKJk0fycOndN16GKryhZND+37j7Gzz8AHz9/7j58RtmShWnesCa5smfm1Pn/5+7qzXvY21kzclB36tWUHuDkZtvuI1Hbo7OTPb+1b8yEEf24cuNu1DR6enp0aNWAksUKcPna3e+2E3O7FokvLnn8JEe2TGTKkJZWTWqzetMeLMzNMDQ05MGT5wQHh2BgoEf9mhUxNDDQwZqkbAleIFUsW4zL1+9y79EzCheM7AUKDg7F0NCQcNW3z5+OGtyDcFUEi1ZtTeiwxM/4rFu3S9vG5M2djX+mL+Hew2csW7eDkkXzY2JipMMAxbeULFaAKzfuYmRoiImxMReu3MTTy5dbdx9RtWIpQkLCok0v3fjJl6IQbXvU19NHo9Hi5x8Y9ZqrmydTZ68kb65s2NpYfZwv8pGbERERsbbz+XYtEl9c8hgbrVZLxbLF6N6xGR1bNaRksQK0a16PmQvX4uPrn8hR//ck+Ck2M1NTjI2NsDG3wkA/sv5atm4HIwd1Z/WmPbx8/Y5mDaozfMIcrFNb0r9nOyIi1ASHhDJ78Xpsra3IlD5NQoclflDX9k3ZuP0gR09dpFrFUty6+5hwlYpMGdJiY21FYGAw67ftR6uVZx4nVw52Nrx8/Y62Leqh0WhYt2U/bZvX5eLV27x39QDA0cGOPYdO06ppbY6dvsTEmcvImS0TObJm5PyVW1SVnoVkoXnDGkybv5qjpy5y/dYD1m7Zxwc3D1o3qR01jaWlBRqtli27DuMfEARA4QK5mDZ/NVqNlvx5skdrJ+Z2bW1tyRuXDyiKIsVyIolLHoGo38ZPOrdtzNwlG8iWJT3lSxXF29ePuw+eYWWZCnMzU0xNjHHz8MLZ0T6pVylF0lOpwuWXTQghfjETpi/h9+5tsU5tqetQxE+QPCZfch8kIYQQQogYpAdJCCGEECIG6UESQgghhIhBCiQhhBBCiBikQBJCCCGEiEEKJCGEEEKIGBK0QFIUBbVaHXVTMvHrklymDJLHlENymTJIHn8dCVogaTQaKtTrjEajSchmhQ5ILlMGyWPKIblMGSSPvw45xSaEEEIIEYMUSEL8BOv0hXj12kXXYQghhEhgUiAJ8ZPeu7rrOgQhhBAJTAokIX6SRitjCYQQIqWRAkmIn6Ro5WoUIYRIaaRAEuInydUoQgiR8kiBJMRP0mi0ug5BCCFEApMCSYifJGOQhBAi5ZECSYifJD1IQgiR8kiBJMRPkgJJCCFSHimQhPhJWjnFJoQQKY4USEL8JOlBEkKIlCfWAsnlvRsde4/Aw8uHMVMWMmriPAKDgpM6NiF+CVqtFEhCCJHSGMb2YoZ0zlQsW4wPrh6ULJafNI723H3wlHKlinwx7fa9x9ix7xgAiiI3zPuVSS5/jCaZFUiSx5RDcpkySB5/TXoqVXis2Vq+bgcZ0jljZ2uNs6M9Zy/eoG3zut9sTK1WU6FeZ84dWI2hYay1l/hFSC7jxjp9IeZNH0uH1k10HUqsJI8ph+QyZZA8/jq+mR1nJwfevXdDX0+PzBnTJlVMQvxStDIGSQghUpxYC6RL1+5w5cZ9fHwDCAoORqPRMmxA16SOTYhfgtwoUgghUp5YC6QyJQpRpkShpI5FiF+SXMUmhBApj1zmL8RPUqulB0kIIVIaKZCE+ElqtVrXIQghhEhgUiAJ8ZMipEASQogURwokIX7Qp/uZSA+SEEKkPFIgCfGDPhVIERFSIAkhREojBZIQP+jTI0akB0kIIVIeKZCE+EFa7cceJCmQhBAixZECSYgf9P8eJLnMXwghUhopkIT4QTJIWwghUi4pkIT4QVolsgdJBmkLIUTKIwWSED/o/2OQInQciRBCiIQW67PYYtq88zAvXruQ1tmBLm0bJ3JIcXf73iMMDPQpkDeXrkMR/0FRY5CkB0kIIVKcOBVI+vp6WJibkT6tU2LHEy8NW3UnICAQv3d3dB2K+A9SPvYgqTUySFsIIVKaOBVITepVw9DQgHH/LqJS2eIYGxtFvbd97zF27DsG/H/QalLJnDEdd+8/TtJlpmS6zOWvKLmOQZI8phySy5RB8vhrilOBpNaoMTIyxMjICG2M5DZvWIPmDWtETqdWU6Fe5wQP8mssU6VKsmUlpKs37nDh0nUG9uuq61Ci0WUuf0VRd9JOZlexSR5TDsllyiB5/DXFqUDasfc4Hl4+ZM2UDlMT48SOKc709fV0HcIPmbNwFQeOnEp2BZKIHxmDJIQQKVecCqT2Lesndhw/xMDAQNch/BC5b07KoJUxSEIIkWKliMv8z5y/ousQ4iW5nZIRP+ZTD1JyG4MkhBDi5/3SBVJ4eDgAjVr3ICQ0VMfRxJ38oKYMUT1IUvAKIUSK80sXSCGhYVH/fv7yzXenz1awMidOX0jMkOJEflBThk9Xsf1KxbkQQoi4+aULpNCPBZKenh7u7l7fnd7bx5c7yeC2APJw05RBURTSp0vD6zfvUKnkbtpCCJGS/NIFUkhoGNvXLaRT26a4eXjGaZ7P7+GkK5/fB6N6g/ZyX4xflFarxczUhBzZMvPg0VNdhyOESGRu7p74BwTqOgzxE7RaLW9c3nPn/qPvThunq9iSq9DQMEoUK8j1W/dwc49eIPn6+mNtbYWeXuStAD4NqDXQ1/2Vb59iioiI4Pqte4SGhWFuZqbjqER8KVoFfX19ihXOz43b9ylSKJ+uQxKJJCAwCB9fP6wsU2FrY63rcEQi02g0eHn78vDxM27eecCtOw+4efs+WkVh4czxVK1UVtchijjy9fXn1t0HXL52m6s37nDn3iNSp7akfOnizJ8x7pvz/tIFUlhYGOZmpqRxcuDewydRryuKQpYCFTm8azWlSxQBwN8/suoPCg7WSayx8fMPAGDlum306dYeff3/d+j1Hfw3MyeNwiQZ3XdKRKfVatHX1yNrlky8fvtO1+GIRHDrzgOWrdnM4WNnsbO1xs8/ABMTE4oXKUBgYBA9f2tL1UplMDT8pXel/2mKouDq5sHFKze5dfcBFy7f4MnTl9japCZXzqwUKZiPVs3qM3X8MNKmcYw6wBXJk5e3D2fOX+HU2cucPn+F0NAwCubPRaniRejfuzNFCubD2toqTm0l+lY9cvx0enRpQ6YM6RK0XUVRiFCrMTIywsnJnqMnz/Hy1VvUGg1mZqbA/8coAXh6+wAQEBCUoHH8iHCVCoDDx88CMGr8DJrUr0W6j8+68/MPYMOWPTSoU40Tpy4wbeIIncUqvk6rKOjp6ZM2jRPXbsrzAFOSuw8eM2v+Cm7eeUDvru2YNGYI1qkjd6ovX73lwJFThIaFMWvBCv74axxNG9aiVbP6FMyXW35AfwF3Hzzm9p2HnDp3iXMXr2FkaEiZUkUpVqQA0yYMp1iR/NEOWEXypSgKl67e4sjxM5w6d5n3H9ypULYEVSqUZsiAHj9VeyR6gZTKwoK/Rk9hy+p5CdpueLgKUxMTAJydHHF186BGo46Ehoayf9sKAHz9/KOm9/SKLJBevXH54WWePHORSuVL/fQNKsPDIwuk3/8cG/XaG5f3UQVS5nwVAOjVfxSWlqmYNvGnFicSiVarRU9Pj7TOjrx776brcMRPWrtxJw8eP+PBo6c8f/mGP//ozoKZ4784/Z01S0Z+79UJgL8G9OT123ds23WQrn2GYmBgQNlSRSmYPzcF8+UmT+7smJuZERoaFnXgJnQnMCiYKTMXsXvfUSpVKEWdGpWZMm4oTo72ug5NxNPLV2/ZsfcwG7fuxcoqFY3q1WDO1L8pmD93gt1EOtELpH49O5KvZK0Ea+/ug8dcvnqLFo3rYmoaWSDlzpGV56/eEhAQiLGxET6+kYXRmfNXadqwNgBeXj7UqlaBsxeuotFofugDbNquN3s2L6VS+VJxnker1aLVaqN1wYeGhX0x3VuX95QtVZTf+vwV9ZqffwABgUGoVBHJYnC5iE5RFPT19ciXNwev376jW99hlCpRmO6dW+s6NBFPiqIw4d95NK5fk4F9f6NC2ZJx3uYyZ0zPkP49+POP7tx7+ISbt+5z98FjNmzZw5NnL9HT0yNTxnScO7I1kddCfI2ffwBLVm5k+Zot1KtVhVMHN+HoYKfrsEQ8BYeEcPjYGfYcOM7VG3do1qg2a5fNoEDeXImyvEQvkCxTWaBRqwkPV/3UeBovbx8URWH2gpXs3HsE/4BADD52gZqamjB57BBGT5iJj68fsxasBGDNxh30/K0NeXPnwNPbhyyZM/LqzTtevXHhwaPnNKpXPd5xvHj1Jl4F0rAx/3Lw6GnuXzkc9VpYWDiPrh8jT/EaUa95ekWu3869R6LNr9VqefvuPdmzZo61fbVajaGhIe27DeSfvweTOWP6+K1QMqEoCvMWr0Gr1dKlQwtSW1nqOqTvihyDpI+5mRnb1i1gzYYdzJi3nMb1a+BgLzvfX8mr1y6Ym5sx7Z/hP9yGnp4eBfNF9hx9LiQ0FCMZo5TkAgKDuHv/McdOnmPD1sghC8f3rU/w4R4iYalUEbx99563Lh8wNzfDzd2T67fu8eDRU+7ef0KZkkWoUaU8S+dOiuokSSxJstU6Otjz8PEz6jb7DdfnP/ZYkF79R3H8400ec+fMysRpC6K9365lI1o2qYtDluJcuHydbFky8uLVW8pWb47fuzt4evngYG9Lvjw5OH3uCn+OnITnq+sYGX3/KDE8XBV1NOnl7RuvuPcfOsEHN49or4WFq0id2pLLJ3dSumpTADw8vdm8Y/8X81tZWbJ150FG/Nkn1vbtMxdjw4rZ7D98khZN6v2SBVJYWDjT5y1j684D5M2dg1kLV1K3ZhWaNqhF+TLFCQoOxt7OFj09vaiiJDnQfryKDaBQ/jzMnDwKY2NjVq3fzl8Deuo4upRJURQCg4I/9t7po9Vqo26TYWhoiKGBwRdjgIyMDL/7nTl38RoVypRIlJjlCtWEo1areevygQ9uHrh7eOLu6Y2bmycfXN3x8fPD28ePkJBQrFNb8fTFK/LlzkmFsiU4c2hL1BAGoXsBgUG8fvuOV6/f8fqNC6/euER1Xnh7+5I+XRoypk9LSGgYNtZWlClVlBpVylMgX64kvYo0TgXS/UfP2bTjIFkypaNbh2bxXkjO7JnpM2g0oWFhP3x6y8snsjBpVK8Gtjapefz05RfTGBkZ0fO3tixZuZFeXduRNo0T7boO4Pyl63h5+1Aofx7y583FkY+Do1+8ekvunNm+udzla7bw58hJfHh2GYDb9x6ROV8Fbpzbi52tTazzLF21iYwZ0lK8SIGo4igiIgL/gECsU1sRHh6OqYkJuXNmI2+u7AQEBuHq5vHFjr1Zo9oEBATx7+wlAF8tkvbsPwqAexzvBfUjHj99wcRpC/Dy8aVsyaJUrVQWJ0c7MmdMT7gqcjzYp7yGhoahr68frcdQpYrAyMjwi1sceHh4M3X2ElKntmTb2gXkypGV4JAQps5cwohx03j99h1WlpaYmZpQtHB+9h48Tqtm9cmSKQMF8uXCOrUVwcEhRKjVUZdgZ8+aKWpZGo0m0a4w0ipa9GPkrHH9GnT/fQTFCuenSsUyyaaY+1WFhIZy4PApTp+/zLUbd3F554qZmWm0YvlTCjQa7Rd3qVcUBbVag6GhAenTOZMxfToyZUhL5swZyJg+LVZWqXj0+Dkbtu6hX4+OOlhDAZF5+vTb4OPrx9Pnr/Dw9OHN23e8cXmPyztX3r135d0HN5wc7UmX1hknR3ucHOxxcrKnaOF82Nikxt7W9mMRHUTxIgXidAAsEk5AYBBu7p64unnwwc0Dt09/u3vi7uGFt48v7h5eGBkZkSljOrJkSk+WTBkoWjg/zRvXJUumDKRxdkg2+804/XKcvXidccP6sHj1NhRFifZDvn3vMXbsOwbw1Rsejh0xgEHD/wHALlNRtq1dQOmSRbBMZRHr9IqioNVqoxVSqo8Dm2tWqxD1DDa/d19eOfT3sN9ZsnIjWTNnoFrlcgDUb9GVEkULUq1yOUoUK8iEqZEDxj/13hzds5Z0aZx5++49nl4+jBg7jZvn9/P+gxt7Dx4HoGvfYQAcPHIKiCyubKxTc/fBEwoXyBMthr9GT6FAvlwsnTsp6jWHLMUBGDqwF8ZGRlFfgAvHt/PugxsVaraMuuz/83VTFIU/R07i39lLyJwpPctXb2br2vnY29kSHBICwNZdB8mcKT1nzl/BydGBcqWLYm9nG+tn+y3fymWqVBZRxenFKzcZ+vdU3rq8Jyw8HGMjo6gj+tCwcAwM9LFObUX1KuW4fvMeJibGPH32itSpLcmdM1vUxuLsZI+drS1/9OpE6+YNopZlYW7O+FEDGT9qYNSp2WcvXrNjz2FKlyxCKnNzXN092LB1D76+flhbpyYwMIj3H9x59cYFC3MzgkNCMTM1Ra1RU6ZkUdKnc45s28yMAh8H8Rno60f+baCPgb4BmTKlx8HOltdv36HWqLGzsSFHtswYGkb2Snxw88DJwQ6Dj70U/v6BXxS1JYsVonb1ijRr34eVC6fSuH7NqGn09PSIiIggOCQURatgY5MaRVEICAwiMCiYtM6OBAQG4ecfQGpLy2j38UqoPP4KFEXh+s17bNi6m70HT1C6ZBFqV6/IH706ky1Lxh8qeMPDVbi8/8Cbt+954/Kel69duH7zLn7+AaRPm4bunVvTpEHCjZVMKL9SLiMiIvD08iEwKJjQ0DBu3X1ARISa0NAwPLy8cXXzwNXNAw9Pbzy9fYlQReDgYIuRoSGubh4oCmi0GlJbWZIze1YcHWzJnDE9BfLmom7NymRIn5Z0aZ2wMDfX9arG26+Ux9ioVBG4eXhGFj+uHri6R+bS9WMx5PqxCDIyMiKNsyNpnBxI4+yIs7MDeXJlo2qlMjg52GNra42zo0OinxpLKHoqVfh3szVt/mqG9OvMkjXbaN2k9lfHh6jVairU68y5A6tj3YmVrd6ch4+fAeDkaI+7hxfL50/B1NSEYoXzc+f+I3LnzMbJMxcZNHwir++fIzQsjANHTjF+6jzOHt5MpgzpUBSFt+8+fPV00r2HT8ibKzsGBga4vHdl1PgZ7DlwjMsnd5I7Zzas0xfCOrVVtILkk1QW5gQFhzB+5ED+njgr1vbtbG3w9vGlX8+OzF+yFl+X21E/ZIqiYJOhMABlShUlODiE12/fE/Dx7qt5c+fA0NCAs4e3RGuz/1/jWbNxBwALZ02gbYuGUe9pNBrsMhWN+v/m1XM5c/4qi5avj3rtwPaVtOrUj6DgEFo2qcvSeZNjjT2uvpfLTz4VzH7+Afj5BZAqlTnePn4EBgZx/+FTChXIg4GhAZkypOONy3t8ff0xNzMje9ZM2Nik/qkYY6PRaIiIUOPh5Y25mSnGxsbcuvMAN3dPXn88GjU1MUGj0aLRaNBoI//28wvg3Qc3PDy9yJk9KxqNBv+AAB4/fYm+vj6pUllgbmaKh6d3VMEUHq6ibKliHNyx8os4zpy/QrP2kT1+JsZGpLayRN/AgHfvXUllYY6hoSFqtZqg4BAszM0wMzMlMCiY8HAV6dI44ecfgJGREfOmj6VBnWo//HnENY+JSVEUQkJD8fMLRKVS4ePrx7mL1zhz4Qpu7p4Eh4TiHxCIvp5+VM9QGmcH2rVqTKum9WQ810dJlcuIiAhu3nlAzmxZom2j4eEq3Dw80dPTIzAwmOcvXvPk+UvuP3zKvQdPcHP3xN7eFivLVBgbG1G4QB5MTU0xNzPFwd6WNM5OpHV2xNHRDgd7W4yNjHB190Sj0ZAujdN/prcnOWyTYWHh+Pr5f/wTgK+fPz6+fvh9/Le3j19kMeQeWfgEBYXg5GRPGmdH0jo74vyxAIoshCLz6uRon+Ku1IxTgbRo5Ra6d2zG4tXb6Nu19VePar+XeEVROHnmIjdu32ftpl28e++KqYkJYeHh1KtVhQNHTmFqYkKl8iU5cuIcrZrVp1L5UvQZOJo8ubJx6cTOH1rJG7fu8fjZS9q1bATA23cfcHKwJzQsjBu37kX9kMXFxpVz2HPgGFs+Gy+UysKcG+f24eRoj7ePL6WqNGHQ790YMXYalSuUJkfWTCxbs4WFsybQZ+BoWjSuy7L50QsYRVEIDgkllUXsR0cnTl+INU57OxsMDQ15fOM4Hp7eeHh6s3PvYUYO6ftTlzomh404OYiIiECt1qDWaLBMZUFgUHDkhQeayOfpabXar+7YP+U0NDSUoKAQjIyNsLJMFZVjXz9/LMzN0dPTw8TEOGo8zae8+fkFoKev91MD1pM6j/sPn6R7v+EULZwftVpNYFAwr167YGRshI21FcZGRlimsqBc6eJUKl+KzJnSYaBvgKOjHYpC1GdgZZlK7icUQ2LkUlEUXN67cufeI+7ef8zd+4+4eecBadM44fLOlaoVy/De1Y03b9/jHxCIk6MDenpgbm5GjmyZyZEtC/ny5KBgvtxkzJA22ZwaSc4Sa5vUarV4+/ji6u6Jm5tnVA+Pm7sH7p7eeHv74unlg6eXNwA2NtbYWFth+/FvG+vU2Finxvrja2mcHCILISfHH+7N/tXFqUC6/+g5G7cfIGvm9N8cgxTfxD98/Ixtuw7i6eXD+i27ATAwMECj0VC3VhWuXLuNt48vbVo0pEfn1on2KIejJ86RNo0Tjg52UT0iOYtUBeD0wU2kSmVOUFAII8ZNj+otePnqLUUrNGD5/Cl06zcMRwc7Gtatzt37j7G3t2Xtkun06j+KksUL0aV9c27cvk/pEkVYtnozVSqW/upVaV+jKApPnr0kIDCI7bsPkSFdGsJVKvp0b49Go/3q6cofJQVSyhCfPH4aB6LRaFFr1Gg02qjbVGi12qheN+3H6RStEtULp9VqiVCr6fH7cLq0b4GTowMZ06fBzMyUrJkzym0qEsCPbpOfTlnee/iYoKAQHj19wQdXd9RqDU+fv8TU1JTCBfJQMH9uCuWP/NvZyYHHT19w/+FTMmVIR6aM6XCwt/1P/kgmtB/Jo1qtxsvbFzcPLzw8vHDz8MTlnSsvX7/lrcsHXN088PL2xdYmNc5ODjh/7N1x/vjHycEeezsbHBzscLCz/WVOcelanAqkuPqZH9WIiAgMDSMH1n56jtobl/ds2raPFk3qxLug+Fle3j7Y2drEaYegUkUwafoCtu8+hIWFOTs2LCJ9WuckiDLxSIGUMsSWx/otuvLg0bPI04tqNWqNJmpchIG+AYaGBuh/HJdlYKCPvr4+BvqRf396XV9fDwODyL/1P5uuYL7czPn3b+lJSASx5VKj0aCvr4+Xt0/koGaX95Gnkj+OtXrz9h0u71xxdnKgUvlSpLIwJ0+u7KRPlwYDA32yZ80kpzCTWGx53LJjP+4eXgQEBREUFEJgUFBkQeQeOe7H3z8QezubyIHpTg44OdiRPl0asmXJSKYM6Ujj7IiDvW2C3SBRREo2v3yfn6b4dN47c8b0DB/cWyfxxGeQs7GxEWNHDGDsiAGJF5AQCWTTqrkAGBpEFkORhY4UNL+aQ8dO07XPUNQaDXY21tjb25IpQzoyZ0pPjmyZqV65HJkzpSdDujTSY5DMvX33gbCwcCxTWZDGyZFUFubY2ljj7OxAWmdHbG2spfdOB5JNgSSESBoJfTpW6EaVCmV4/eB8ZI+fFLi/tCH9e+g6BBELKZCEEOIXJL1CQiQuOewQQgghhIhBCiQhhBBCiBikQBJCCCGEiEEKJCGEEEKIGKRAEkIIIYSIIUGvYvt0s7mYT9QWycOnh6zGheQyeYtrLiWPyZtskymD5DHl+DyXCVogfXo+VZVG3RKyWZFA4nNXbMll8hbXXEoekzfZJlMGyWPK8XkuE/RRI1qtFpVK9c1qun2v4axf/HNPmv/ZNv6r88fnKCcpcvmrz6/LGOKaS9kmk/f8sk0m7Py6iiG55TEh2vivzp9oPUj6+vqYmpp+cxo9Pb2ffrbXz7bxX58/LpIil7/6/Mklhm+RbfLXmD8uZJv8dWL4Ftkmf435QQZpCyGEEEJ8IckLpGYNaui8jf/6/AlF1+uh6/mTSww/KyV8Dr/6/AlF1+uh6/mTSww/KyV8Dr/6/JDAY5CEEEIIIVICOcUmhBBCCBGDFEhCCCGEEDFIgSSEEEIIEYMUSEIIIYQQMUiBJIQQQggRgxRIQgghhBAxSIEkhBBCCBFDsiyQXr5+x859x3UdhhBCJFvrtuzD3cNb12GIH3T15n3OXrzx1fdv3nnIhm0HkjAiEVOyLJCyZk5P0wbVdR2G+Amubp4sX7dD12EIkWJ1aNUAJ0e7n25nwvQlCRCNiK+SRfNTsWwxXYchviFRnsh34OhZzl2+iZWlBfr6+hQvnI+TZ69gZ2tN/57t2LD9IMHBIejr69Ozcwv6DJlI9iwZePvOlZ6dWxAWFs6jp69o16JeYoQn4ujA0bOYmZlStUJJBo+ejlqtJm+ubDx7+Zah/X/j6o173Lr3mPRpnSiYNwcnzl7hvasHwwZ0ZfOuQzx+9prsWTOSMV0adh04gbmZKSWLFqBY4by6XrX/nJjbZM5smXnx6i3evv6MHdqHcVMXMfnv/ly6dgdvHz/Mzc24/+g5Wq2Wjq0asHDFZiwtLXj99gO5c2bB28cPR3tbunVoxsIVmzEwNKBU0QIULpBb16uaonl6+zJjwRqsU1vi5u7F8AHdmLNkPZNG9+fc5ZsEBgZz5sJ1HOxtcff0omGdKpQonI85SzYQFq4if55sNGtQg56DxpMtcwYK5M3BjdsP2bj9IG2b19X16v2nHDh6Fj//QF67fMDYyBBHBzs6tW7Iui37ePnmPfr6emTNlJ6bdx6yZvNe0jg74OcfyKRRfzBp5jIc7G3JnjUjGo2Gc5duooqIoHuHZmTPmlHXq5ZiJFoPUvVKpRkxsDsosHzdTiaO+oPBfTvx3tWDi1dvY2xshJe3L94+fpiZmjC4bydGDurOwWPnEysk8ZP09PTo0ak5VSqU4M69JwDkzpGFzm0aUSh/burVrEgaJwcuXbtDpbLFKVEkH5XLlWD1pj1YmJthaGjIgyfPdbwW/12fb5NlShSiUtni+AcE4e7hhb2dNR5ePly6doeKZYuzfus+zM1MAHjy/DUK0KZZXTq0aoBGo2XEwO7ce/gMAE9vP/Lnzk6h/Ll0uHb/Ddt2H6Flo5oM698VO1trTEyMSW1liY+fP+cv3aRSueKoNWoG9+3IpFH9OXz8PKamJnRu04iSRfNz6tw1ACIi1Az5vTN1qpcnbRoHKY50qESRfAz5vQt37j8hJDSMqzfvM+avXtSrUeGzafIzrH9XcmXPHLU91qhchmoVS7Fj33HGD+/LoN4dWbtlr+5WJAVKtAJJXz+y6YDAIFSqiKjXFUUhlYUZ3To0Y9SfPbG3s0FPTw+AwOAQ1Gp1YoUk4snE2JjQsDAURSEiQo2BgQF6enqYmZoSrlIBYGuTGoCZi9bi4elDxbLFCAkJQ19fH41WC4BWq6Vi2WJ079iMjq0a6mx9/us+3yb/mb4Ea2srChfIRUhoGPVqVuT46ctERKixsrQgJDScTq0bMaBXe8qUKASAsZERZqYmGBtFdjx/2m5HDe5BuCqCRau26mbF/kMUBfj4uX9Sq2pZjp++jJ6+HhbmZoAeenp6hIaFExoWzr2Hz1i2bgcli+bHxMQIABtrq6j8Cd0yNPz/9qTVajE0NABAq/z/MalRv5FBIURERP5Gftr3ShYTT6KcYgM4fvoSl6/fIUM6ZyqWLcbwCXOwTm1J/57tyJQhHeP+XYSDvS29u7TE18+fxau28uT5a/r3bI+Pr19ihSXioXCBXPw7dxXv3rtjYPDtWjpDWmeu3ryPKiKCLBnTkSNrRtZvO8CJs1fo3LYxc5dsIFuW9JQvVVROsenI59ukZapADhw9wxsXVyqWKUau7JlZsnobNSqXAaBr+yYMGz+LDOnSfLN3ISQ0jFmL1mFrbUWm9GmSalX+s5o3rMG0+as5euoi1289AKBgvpzMXbqBbh2aAZG9Q0vWbOPp89d0at0QG2srAgODWb9tP1rtl88mz5g+DSs37OK3dk2SdF3El1JZmJMtSwYmTF+CkZEhGdI6A3D5+l0+uHuiUkWQP0929hw6FTVP0wbV+XvyAlSqCLp3aq6r0FMkPZUq/Mst5id9PnYlLgaPns6MCX8mdBhCiI/isk1Omb2Cvt1aY5nKIgkjEwlN9qcpy807D2VMro4ky6vYhBBJa/m6HeTNnU2KIyGE+ChRepCEEEIIIX5l0oMkhBBCCBGDFEhCCCGEEDFIgSSEEEIIEYMUSEIIIYQQMSRogaQoCmq1GkWRcd+/OsllyiB5TDkklymD5PHXkaAFkkajoUK9zmg0moRsVuiA5DJlkDymHJLLlEHy+OuQU2xCCCGEEDFIgSSEEEIIEYMUSEIIIYQQMUiBJIQQQggRgxRIQgghhBAxSIEkhBBCCBGDFEhCCCGEEDFIgSSEEEIIEYMUSEIIIYQQMUiBJIQQQggRgxRIQgghhBAxSIEkhBBCCBFDrAWSy3s3OvYegYeXD2OmLGTUxHkEBgUndWxCCCGEEDphGNuLGdI5U7FsMT64elCyWH7SONpz98FTypUq8sW02/ceY8e+YwAoipK40YpEJbn8X3v3HR5F9TVw/LukV9J7I9SE3jtIEeldOkhXBCk/BAUUELuiYKGpKIqAiChFioDSlB5ISEggpPdeSd/y/oHmlYAhgSSbhPN5Hh/M7tyZM3v27p69c2emdpA81h6Sy9pB8lgzKQoLCx6Yra+278XV2QFrKwsc7Gw4c86HCaMHlroypVJJ90FTOXtoG7q6D6y9RA0huawdJI+1h+SydpA81hylZsfB3paY2ATqKBR4uDlVVUxCCCGEEFr1wALp/GU/LvoEkJaexZ2cHFQqNa8unFHVsQkhhBBCaMUDC6TO7VvSuX3Lqo5FCCGEEKJakNP8hRBCCCFKkAJJCCGEEKIEKZCEEEIIIUqQAkkIIYQQogQpkIQQQgghSpACSQghhBCiBCmQhBBCCCFKkAJJCCGEEKIEKZCEEEIIIUqQAkkIIYQQogQpkIQQQgghSpACSQghhBCihAferLakH34+SmhENE4OtkybMLySQxJCCCGE0K4yFUh16igwMTbCxcn+vud+OnCcvQePA6DRaCo2OlGlJJe1g+Sx9pBc1g6Sx5pJUVhY8NBsFRUp0dXV4Y0PNrF80Sz09fUeuJxSqaT7oKmcPbQNXd0y1V6impJcls2nm7ZhamrM9MljtB3KA0keaw/JZe0geaw5ypQdpUqJnp4uenp6qKX6FaLYWx9+jlqtqbYFkhBCiEdTpgJp74ETJKWk4enujKGBfmXHJESN4ehgR2RUrLbDEEIIUcHKVCBNGjO4suMQokZytLeVAkkIIWohOc1fiMdgaWmh7RCEEEJUAimQhHgM5mamgJyZIoQQtY0USEJUgOw7OdoOQQghRAWSAqkWUqvV2g7hiaFUKgGIiIrRciRCCCEqklyEoRbIyMziwuVrXLnqz8UrvsTFJ3LlzAEUCoW2Q3skarWa4yf/xMXJEY1GQzPvRqjVaurUqX71fFGREmdHey5cukaLpk20HY4QQogKIgVSDZOZlU3gzdv8fuoct0MjCAi8RWpaBh3atqRDu5a8PH8W7do0r7HF0e3QCF578yP8/IMwNDQgNTWdcaMG8+W3u1mxZC5LFszWdoj3UKpUeDVuICNITziNRkNSciqR0bFERsUSHRtPbm4ehYVFFCmVWFnWrXbvXSFE6aRAquZSUtM4/NspTv91kau+N0jPyKR+PTf6P92TUcP6s3rZAtzdnKvl6Ep55eblMXnWIgYP6MO2TR9iZGTIzeBQtu3YS/+ne7Lhi+0cPnYKE2MjunZqxyuLntf6fiuLlLi7ORMXn6TVOETVSkpO5dgfZzl/6SrX/AKJjIrB3MwUD3cX3FydcXNxwszUBD19PfR0dalrblbhMZy7eJW1n35B8O1w3lq5mIH9eqGnp1t8iF1HRweAvLx8YuIS8HBzJjMrm7T0TDIyszjz1yUio2JZtWw+NtZWaDQaIqNjcXa0R6VSY2hoUOExC1GTSIFUDanVag4e+YNPN31DRFQsvXt0ZmC/p3htyTw83F1q7OjQw2zZupMWzbx4bcm84seaNKrPe28sBSAsPIrQ8ChUahWbvtrBqElzmD55DObmpnTp0AY9vQffAqcyFSmLcHd1xs8/qMq3LSrGP6M/drbWpfat/PwCvvhmF/sPHSciKpY+T3Whe5f2zJ01GU8PtyovKBp4ujNu1BDiE5JYvvpDpr6wBABLi7oolUpaNvfCyNCQP89fQUenDrq6usVz5hQKBb16dMbWxooGLXthYKBPQUFh8boNDQxo2dyLcaMH07lDG9xcnTA2MqrS/RM1Q25eHh9/tpVJY4fj4e5S5nYajYbgkHCWrf6AsIhopk4YxcK50ysx0vKTAqkaKSoq4uCR3/nos62YmhizYslcenbrWPxLsDZTKpV8/f1P/PjtZ/+5jGc9NzzruQHwdK9ubP56J7t+OkhMbDxFRUVkZmbz9qqXGfD0U1X2ZaVUqmjRrAkff76VjMwsLOqaV8l2xaPRaDRERsXi6x+I7/VAfP2D8PMPoqioiNdfeYnnp0+4r01hYRFffbebTzZ+Q/fO7Xlr5WLat2mh9fto2dlaM2bkIAAWvDiNG0G3ycvLQ0dHh8joWFLTMsjKymbDx2uws7UmITEZXV0dbKytitdRWFjEoGd6ce7SVfLzC5gzYxLRsXG0btGUQ7/9wcsr3iUtPQPvJg05sPuL4pGm2vojraZTq9Wc+esSfv5BTBgzFFsb60rbVmZWNv9b9hZ79x/FxtoS3+uB/Pjd52Ue1d/zy2Fmz1/OmBEDefO1xQwYOZXAWyHExSfyyqIX6Na5XaW8z/Ly8jEyMizTslIgVQOxcYls/+EXtu/6mcaNPHnr9f/xVPdOT9SH0IHDJ/D0cMWrcYMyLa+jo8PcWZOZO2syeXn57NxzgOiYOF5b8xFLX3+PKeNHMm/2FCwt61Zq3EqlElMTY9q3acFln+s83btbpW5PlE9aegY+1wLw8Q3A55o/V/1uYGZmQusW3rRq7s3CF6fRspkXx/44y+m/Lt7XPjI6lueefxmLuuYc/ulr6nu6a2EvyqapV8Pi/2/dsul9zzvY2973mL6+Hr17dqF3zy7Fjzk72QMwcmh/Rgx5BoClr7/H5Fn/Y+LY4cxbvIoQv5P3FFpCuwoKCpn10jIOHD6Bjo4O3bu0Z8++Ixze+3XxtdoqkkajYejYWbRu4U3o9VOYm5kycuIcJs5cRJ+eXZgyfuR/3tQ+P7+A1e9+wk/7DrPwxWksW/wiBgb6XDq1j01ffc/+Q8cZMmYmFnXNuXJm/wPfZzFxCYSGR7Lpqx24ODlgaGjAzCljOXD4BM28G3EnJ5ceXTtQUFBIXl4+Hu4u+AUEcfDI76z95Evc3ZzxbtKQnVvXl/o9KwVSJbuTk0tsXAKxcQnExCUQG5dIfEISdc3NSEpJ5XpAECmp6YwZOYh9P3xBw/oe2g65ymk0Gj7d/C2vL5338IUfwMjIkBlT7t4sdvXyhVzy8WPrdz8yYNRURg0bUKmTY4uKlOjq6dG9S3vWvP8pTRrXx9XZsdK2J/6bRqPB93ogFy774usfyGWf62RkZtG2VTPatGrG7Gnjadu6GVYPuPq5sbERubn596zr+B9/Mn/pGyxdOJtpk559on6w/OOffX575cs8v2A5r7/5MR7uLrToNAArSwt2fvOJnL2pRWq1mozMLNp0G0KLZk1ICrtSXJgsff09pr2whG82f1hhRZJKpeLjz7fy/rot2Fhbsu6914vfIzu2rqf/iKm89/EmLl3x5b01r9zT1xKTUpi/9A0iImOws7Xm+P7t1PNwLX7ewd6WN1YsYvXyhYSERdK+5zB8rwfRt1fX4mXCI6JZ9c56Dhw+AcBrS+dRUFDIXxd8aLVlEDbWlqSkpt8X95TxI/lu18/0692dX3ZuJik5tUzTVcpUIAUEhbBr72HquTszc/KosjR5IuTl5ZOYlEJCUjKJiSnEJSRxOzScmNi/i6H4BACcHexxdnLA2enuvx3atSQ9IxNvr4Ysmjud+vXctDJ/pjw0Gg1/XfDhvY83oVAomDNzEk/36oquru5jf3G8+9EmCguL7vkV+zg6tG1J21bN2PXTQeYtXsW3O39m9bIFjBrWv8K/5JQqFbo6OsyZOZGMzCxGTniB56dPYPrkZ7U+gby2Kygo5KpfABcuXeOvCz5cueaPk6M9Pbt1pFf3TixdMBvPem5lyrmJsRF5eXloNBp+PnCUg0f+4GZwCNs2f0in9q2rYG+qN319PTZ+/CaZWdlY1DXn3EUfXnp5Nf2GTqFlcy/atWlOZFQsz0+fQPcu7bUdbq2XkZHFL7/+xroNXxMVHYehgQGb1791z6jN2ysXM3PeMrZ9/xPz50x9rO1FxcQxb/Eqzvx1CUd7W/bt2kL9En3L3MyUcyd+oqCgEPv67fnxl8OMf3YoOX8PEgTdCmHY4H40buDJ6BED7imO/k2hUNCwvgfTJo0mLiGxeH8/2fQNR0+cJuhWKABXzx4snnIRHRvPZR8/BvbrRUJSMs6O9tjWa8fBH78iJi6BL77ZxYgh/di64f1yfS6XqUA6c+4Kb7z6Ipu37bnv+PNPB46z9+BxoObdbiE3L4+k5FSSklPJy8snOSWN5JQ0UlL//jctnYL8Ahwd7EhJSycpKQWFQkFObi7xicmoVWrs7Wywt7PF0d4We3sbWjbzYnD/3jg7OeDkaI+ZqYm2d7PMSsvl2XOXWbb6QyaOHYaTgx3L3/iQCdMX4OrixIjB/bCwMMfJwY6hg/qWazLn97v3se/XY+z8uvShzvLS0dFh0tjh9H2qKxev+PHCghXMnPcqk8eNoFUL7+IRp8dVVKRET08XPT09Xn/lJbwaN2DWS8uwt7NhyIA+FbKN8qrJffJhQsMiOfbHn5w8c56LPr54NapPx3atmD1tPF9teO+R54AZGxuRk5vHqrfXc/b8ZUYM7sfGdWu0PjG5OuXSyMiweO5G755duHH5GL7+QURERnPJx4/OHdswZMxMPD3c0NXVITQ8ij49u7Dh4zewtKir9Tlb2lQReVQqlVwPuElqWgbPL1hB36e68Mn7K+ncoQ26ujr3vb56enqMHTWY7T/8Uu4CSalUsnf/UQ4e+R2FQsH5S1eZOnE03235CD19XUyMjf+zrYGBPpGBf7J56w78Am4ydEAfDh75HQd7W958bVGZD806OtgVnx285ZudrNvwNZ07tiE2+Dxp6Zn3jNS7OjsW/+3hdneieHq0b/F3yvjRQ8q1//9QFBYWPDRbH36+jSXzprLl2z2MG9H/P09ZVSqVdB80lbOHtlWLzqBSqYiMiuXa9RtcuRZAYlIyCYkpJCWnkJScCtyd6Ghra42xoSE2NlbY29pgY22JjY0VNlaW6OvrER0bj4Pd3QJIo9FgbGSEg71tjSp+yqtkLv/p1P+84ZRKJbHxiSQkJnP8jz/JyMziz/OXSUxKpUO7lujq6NCjawcG9e9NYUEh9TxcUSgUaDQaomPj8bnmz+atO7l4xRefMwcqfW6HRqPh3MWrfL97H4d+O4m7qxPmZmYUFBTg6eGKoaEho4cPoFP71v957PxBOvYawa6vPyn+JQNw4uRfLH/jQ84c3a31U6Ursk8qlUrCI2O4GRzKrdthhEVEkZubT0ZmFuZmpng3aUj/vj1o1cK7gqKH+IQkLvlc5/JVP479fpbcvHye6dOdPk91pXuX9hXWB/0Cghg4chrmZqZcPLWvUuZtPK7q9vn6ICFhEWRkZHHm3GWiY+KIjI7lj9Pnsahrzuxp45k7ezLhEdGlvkdKnuyQmZWNmakJV67507ZVM/LyC8jKysbRwY5rfjcoUirR19Nj09Yd3Ai6Ta8enXjr9cVVsbuP5FHy+NO+I7zx3qdEx8QB8OkHq5gyYeRD2/kH3mL+kjc4eWhnmePLzy9g0bK32LXnAMsWz0GhUDB62IB7PuOqwlff7iYkLJJxowYzevKLpKSms/DFaaxevrDKYihTdkyNjVAqlRQVKbX6wZGTm4uf/02u+gVw8vR5UtMzGDKgD24uTkTFxBEaHkl4RDSJSamkpWeQl5+Pi5MDrVp40651Czq1b42DvQ32tjbY2lqVWgWLe5Uc3dHV1cXd1Rl3V2c6tmtV/Hh0bDznL15FrVaz9bsf+fCTL8jPL8DKyoLk5DTMzExIz8ikuXdjRg7rzxsrFlbJxFeFQkHXTm3p2qktSqWSC5d98QsIIjMzm6TkFMzNzHhl5XsUFSl5qnsnLOqaM2RgHxrW9yh1FKGwsAhdvXu7Ud9eXdm991c+3byNpQuff2hsqWnp+N+4hamJMbl5+fhc8ycxOZXAm7d5ef4senTt8Nj7/ygys7I5f+kqf5w+z8kz54mJTcDdzYnGDevTqEE9enbtiKmpCWamJmRl3+F6wE0mz17MM3268+Zr/yvzmSL/KCgoJCDwVnFBdMnnOkVFRbRv04IObVuydeP7NPNqVClzgUz+HkGaPW18tSyOaooGnh4AtGvTArg7RyY3L5+UlDRadR3EB+u3AGBqYoxCoSC/4O4Iffcu7Vm68Hm2fvsjn27eRrfO7YiOjae5d2N+PfoHZqYmZN/J4Zm+PfjtxJni7Tk72pOaloGJiTHzZk/m+WnjGfPcS7z52v/K/D65dTuMqOg4fth7EGMjI/o+1RW1Rk14ZAzDBz2NUqXC1MQYezsbVCp1uX5AVQS/gCBeXfU+H7z5Ks2bNqF9z2EMH9KvTG0d7GwIvHmbgoJCDAz0H7p8RGQMwyc8j7urMzG3zmNqor3vSAMDfXJychk79SVWvjqflW+to3PHNlUaQ5kKpO6d27Ly3Q14elT+NXjS0jMIuhVK0K0QUlLTUSggIDAY/8BbpKam06xpY9q0bMq0yc/iaG/Ld7t+ISQsEntba7p36cDUiaOxt7PBytKiuBOKquPq7Ijr36cej/t7WDM3L4/zF69iUdecOzm5dGrfukydtbLo6urSrXM7unVud8/jb6xYyOk/L3I94Cax8YlMnL6QmLi788gmjh3GVd8A3N1cGDX07ijq3Q/RaBwfcHbQymXzadFpACfPnOfFWZOxtrLEQF8PU1MTMjKzOH7yT676BpCdnUNIWCQNPN1JSEohNzcPDzdnOrRrxfTJz1bZr7bCwiJuBAUTEhbJVb8b+Fzz51ZIGB3atKRHtw5s//JjGjWoV+rx+8H9ezN/zlSWvv4uTw+bwrebP/zP4lepVBJ4KwT/G7e45neDq74B3A6NoGF9D9q3bcmgZ3qxevlCXJ0dq6QP/1MEt2gmE44rUp06dTA1McbUxBj/i0extrIgOiYelUqFjo4OAYG3OP3nJdIzMmnZeSCDnunFvl1buB0aQVOvRvjfuMnH775GdEwcd3JzuexznbVvLyczM5tjf5xl/gvPkZSciqmpSXFhq6+nS0pq2gNPcY+JS2De4lU4Othhb2tNVEwcFy5do6lXI3R0ddi7/ygXr/hSz90FC4u6tOk+BB0dHfT19HB2sicuPpEdW9fTq0fnSn/t4uITuexznRVr1rL27eUMH3y3KArzP13mIt7K0oKCgkJeXvEOn61d/Z/L/XH6HN/v3sdVvxuMHTmYpQtna/3yMoYGBgSHhFPX3Iwp40cyZfzDR8wqWpkOsZVVWYcOVSoV0bHxhEdEExYRTUhYJDeDQwi6FUpRkRLvJg3watwAWxsrlEoVzbwb0bxpY9xdnaXgqSI1YTi/KmRkZHH0xGmSU9LwrOdGZHQsp85cICklFQN9feztbPjui4/+s+3eA3eP40dFx2FoaEBUdCx6enp0aNsCt79H39q2alY8YbGirzHzoDy+vOId7uTkYmZizJ3cPMLCowgKDqVBPTfq13OndaumtG7h/VjX+tnx435Wv7Oe7l3a49W4AQb6+vjfuIVSpeR2aCQRkdF41nOjRdMmtGrhTZuWTWnq1UhrhXNGZhYeTbsTev0U1laWWonhYWp7n6yo64h17jOSbZvXUlh09yKupibG/Hn+CiFhEazb8A2tmnuhUChITknFytKCDR+v+c/tZt/JwczUhNN/XiQsIoqB/XphZmbyWHPTHpbH9PRMPtvyLR9/vhWAz9auZvK4EY+8vRVr1nLVN4AjP2+777nboREsW/UBJ079BcDOrz9hYL+nHnlbFenA4RMsWLqGdq2bs2f7Bq3EUOm9bM8vh7lyzR+VSkVUdBxhEVHExSfiYG+Hp4fr3Yv/ebjS/+keeDduUKkXthKivCwszItHwv7x4sxJZW47Y8qYeyaEP6wAqoofAONHDyEsIpqcnFyMjY2YNmk0Tb0aVugh54ljhvFMn+6cOnuR26ER5ORk0K9Pd/T19Kjv6U7D+h5aHUUsyaKuOed/31tti6MnQUVdZNXczIyOvf6/oGjc0JP8ggK8Gjdgw0dvlOuQ9T9z3Hp260jPbh0rJL4H+XbHXhrU9+BOTg6vrvyAeh4ufPrBKgb17/XY78kl82fTutvg+z57rt+4yeBnZ/LS81NYvXwhTb0aVqsBCCNDQ9IzMnF10d5lUyq9QMq+c4cGnu7o6uowsN9T1HN3xcXZodqf1i5EZagOH0BtWzenbevmlb4dG2srRg8fUOnbqShlvUipqN7yCwoAOLb/OxTcPev4qe6dtBxV6ZJT01j5zjoK8gt5/dWXeHHmpAr7rLCwMMfI0IDEpJTii4WqVCpWvrWOl1+a+diXAKgs//yA0uagSaUXSNMnV8zp1EIIIcTD3A4JB+5eD62meHn+LJ6fPgEDff1KmQTu3aQhQbdCigukdz/ehIGBPnNnT67wbVWUf84AtqrkuyGURq5kJ4QQotYwNDSka6d2D1+wmjEzNam0M+R6du/ID3t/BeCHnw7y3c6fWf/e61qfiF2af0aQLC20VyDVvpl+QgghnliXTv2CoWH5LjFR200eN4JWXQbhFxDEyrfXcWTvNzg62Gk7rFIZGvwzgmShtRikQBJCCFFryE1072dR15zxzw5lyJhZzJ01qVrfdPkf/4wgabOQkwJJCCGEqOVeWzqXhMQkZk0dp+1QyqSu2d07dng30d7JE1IgCSGEELWcibEx32z6UNthlJmlZV0yYvy0GkOFFkj/3K9LqVRW5GpFBdHR0SnzqaOSy+qtrLmUPFZv0idrB8lj7fHvXFZogaRSqQDoNWxmRa5WVJDyXIFXclm9lTWXksfqTfpk7SB5rD3+ncsKvdWIWq2msLCw1Gp60gvL+H7zu4+1ncddx5Pavjy/cqoilzW9vTZjKGsupU9W7/bSJyu2vbZiqG55rIh1PKntK20EqU6dOg89vVKhUDz2fYQedx1PevuyqIpc1vT21SWG0kifrBnty0L6ZM2JoTTSJ2tGe5ALRQohhBBC3KfKC6RRQ57W+jqe9PYVRdv7oe321SWGx1UbXoea3r6iaHs/tN2+usTwuGrD61DT20MFz0ESQgghhKgN5BCbEEIIIUQJUiAJIYQQQpQgBZIQQgghRAlSIAkhhBBClCAFkhBCCCFECVIgCSGEEEKUIAWSEEIIIUQJUiAJIYQQQpRQrQqkxa+v1XYIogzeXLuFjMxsbYchHpPkUQgh/lvl3l2xhN2/HCUxKZXM7Du8Mn86+vp6Vbl5IcQjWr/5e2LiElm7ZrG2Q3liaTQaVrz1KSsWz0atVjPp+WWMGf4ME58dxMgpi+jeuQ0Ak8cMZtM3P/LSrAlY1DUD4Kvte4mJS8TE2AhLC3NmTBp5353klUol6zfvoKioiOycXF6ZP409+4/RtWNrvBp5ctUvkKDgcHp378Arb6yjbStvMjKzmTBqIJu++ZGP31oCwPK3PmXmpJGsem8jbVp6ATB3xrj7Pu//uniNM+d8yMrOYfTQp3FysGXHT4d5ed5zxcvs2HOI0IhoNBpo7t2QkYP7FO+LlaUFeXn5LJ0/jQXL3qeeuzMAvbq1p1XzJpWThApS23K5bM0nWFtZADBv5jgMDQ3ueT45NZ331m+lTQsvJj47iOTUdDZu3Y1OHQXDBvamuXfDCn+NK0KlFEiHjp3h/GU/6tSpg6WFGYWFSrKy7/DGqy+iq6vL93t+JSDoNgYGBhw58Se2NpZMfHZQZYQiHkN8Ygq/HPqduPgkipRKAFyc7LkdGgnAW2u3YGhoSGZWNq1beDFycB9thiv+w6PkcdPXu0lOTadBPTcmjB7IwhcmyQivlikUCiaMHsSe/cdQqdRMGjOYwsIiAOq5O7NozuRS248d0R+vRp58tX0vV/2CaNvK+57nDxw5RctmjXj6qc5oNJr7vnT/rUXTxix4fhLHTp7DPygEOxsr0tIz0dGpg7GhAUaGBrRs1rjUmE6fu8KEUQPxcHNGo9GQkJhyz/Mh4dHEJ6awcskLwN33ace2ze/Zl4XL3+dOTi56eroP3f/qpLbl0tDQAGMjA2xtrDAw0L/veVtrSyaOHkhQcDgAB4+eYkDfbjRpWI+3P/6C91ctKnV/taXSDrF179yGlUueJzg0iqXzp1HX3IyEpFQKC4sIvBVGk0ae5OTkoqOjYHC/Hujq6FRWKOIRnbt0jeZeDRgz/Bnat25Gjy5teWnWBBrWdwdAA0yfNJw3l8/jos917QYr/lN58xgRFUdKWgYrl7zAhNEDtRu8uEczrwYkJKaQlZ1NfQ+X4sfDI2NZt2k7u34+8tB1eDeuT0R07H2Ph0ZEF/+S//cXqkaj+fvf/1/WPyiYle9u4MKV6zzTqzO9e3Tk7PmrnD7nQ+8eHQHwC7jFuk3bOXT8zAPjmDtjHEdO/Mn7n3xNXELyfc9HRMXi3diz+G+vxp5ExcQDsGf/MT7/ahf9+3TFzNSEoiIl6zZtZ92m7Sj//hFQ3dWmXC5bOIMXZ4wjKiaegKCQh8adlJyGq5M95mYmFBQUPnR5bam0AklPTw9dXV2MjQxRKBQYGhqQX1DIRxu+Zc60MRgbGdKhbXMmjh7Exxu/Iy09s7JCEY+oTQtvjpz4E//A26jVavT17g6rqtX/37vqKOqgUqllLks1Vv48avjv35tC25p5NaBF08b3PPbPqMP4kQMe2j4gKIR67i73Pe7p4UJA4N0vN41Gg1qtxtLCnJDwaABuh0VhZVkXgOZejVg0ZzI5OXkYGxvRpqUX1wODuR5wiw5tmgEUjzoMerrHA+MwMjRkzvSxTJs4nK+2/3x/PO4u3LgVWvx30K0wPFydAHh2WD/mzRxP/z7dAIpHkBbNmYyubpXOHHkstSGXGo2meGTa2Miw+P9LY2drRXRsAlnZOQ8ccaouqvSdtH7TdoyMDNj9y280926AQqHg+o3bmJuZYmxkiKGBPglJKTjY2VRlWOI/5ObloVSqyMjMxsPdiUPHzhAUHE50bHzxMt/tPkhcQhLjRvTXYqSiNOXNo7urE+Zmpqz5cDPOjnYMfLoHe/YfIyIqll17DzN+lIwqaZNCobjvkElYZAxrP/8WgLEjngFgw9YfMNDXp2vHVsDdOaDGRkZYW9Wl9QPm6Azt34v1m7dz9XoQGo2GCaMH8vRTXXhr7Rau+gWSl1/AqqVzyPz7x5ClhTltWnpx7OQ5nul9dyRHoaC4QLnmH1Qc06wpI6lrbla8LY1Gwze79pGVnYNGrWFQv+73tKlTR8H/XpyCi5M9b330BWg0NPVqgKOD7QNfk6IiZfG2unRoSZcOrR7lpa1ytSGXuXn5fPblThQoUKlVtCxR8AFc8b3BvkN/kJqeiauzA0P6P8XGrT9w9I+/mPTs4Md8FSuPorCwQPPwxcST6Mvv9tK/T1cc7W1YtOJD1r295J5fZ2+u3XLP5EFRPUkeRUlKlYqf9h8v/ltfT5eRQ/pW2vZCwqK44htY/HejBu60aeFVadt7klS3XGZm3eHIiT+L/7a0MOOZ3l0rLZ7KVHPGIkWVa9LQg/1HTqKnp0v7Nk1r1NC1+H+SR1GSro4O40ZW3ahvA083Gni6Vdn2niTVLZd1zU2rNJ7KJCNIQgghhBAlVKsLRQohhBBCVAdSIAkhhBBClCAFkhBCCCFECRVaIGk0GpRKZfHFqETNJbmsHSSPtYfksnaQPNYcFVogqVQqug+aikqlqsjVCi2QXNYOksfaQ3JZO0geaw45xCaEEEIIUYIUSEIIIYQQJUiBJIQQQghRghRIQgghhBAlSIEkhBBCCFGCFEhCCCGEECVIgSSEEEIIUYIUSEIIIYQQJUiBJIQQQghRghRIQgghhBAlSIEkhBBCCFGCFEhCCCGEECU8sECKjk1gypzlJKWkseq9jbz29mdk38mp6tiEEEIIIbTigQWSq7MDPbq0JS4+iQ5tmzFycB+u3wiu6tiEEEIIIbRCt7QnE5NTsbe1xs7WmjPnfOjasfV9y/x04Dh7Dx4HQKPRVE6UokpILmsHyWPtIbmsHSSPNZOisLDggdn6avte2rdpTkxsAo72NuQXFNKlQ6tSV6ZUKuk+aCpnD21DV7fU2ktUc5LL2kHyWHtILmsHyWPN8cDsnL/sx0WfANLSs7iTk4NKpebVhTOqOjYhhBBCCK14YIHUuX1LOrdvWdWxCCGEEEJUC3KavxBCCCFECVIgCSGEEEKUIAWSEEIIIUQJUiAJIYQQQpQgBZIQQgghRAlSIAkhhBBClCAFkhBCCCFECVIgCSGEEEKUIAWSEEIIIUQJUiAJIYQQQpQgBZIQQgghRAlSIAkhhBBClPDAm9WW9MPPRwmNiMbJwZZpE4ZXckhCCCGEENpVpgKpTh0FJsZGuDjZ3/fcTweOs/fgcQA0Gk3FRieqlOSydpA81h6Sy9pB8lgzKQoLCx6araIiJbq6OrzxwSaWL5qFvr7eA5dTKpV0HzSVs4e2oatbptpLVFOSy9pB8lh7SC5rB8ljzVGmOUhKlRKFQoGenh5qqX6FEEIIUcuVqXzde+AESSlpeLo7Y2igX9kxCSGEEEJoVZkKpEljBld2HEIIIYQQ1Yac5i+EEEIIUYIUSEIIIYQQJUiBJIQQQghRghRIQgghhBAlSIEkRDWSn1/AgcMnmDH3Fdr3HMb+X49rOyQhhHgiyVWqaqG8vHyMjAy1HYZ4CLVaTXhENKf+vMjFK74E3LhFSHgkTb0aMXr4AF6ePwsXZ0dthynKIT+/gOjYePLy8wkIDGbfwWNEx8ZhZ2vD/h++0HZ4j62goBBdXR10dHQAyL6Tg5mpiZajEo/jx58PsWnrDsaMGERScgpejRswZuSgUtsUFRWhp/fgC0bXJlIgVSMqlYq/Lvhw8sx54hKSsLSoi5ODHc28G9G6RVNMTY1RKlUoVSoyMrOIjUsgMiqWyOhYIqJiCAuPIiwiGhNjY6799au2d0eUoFKpCA4J5+y5yxw9cZqrvjfQ19ejR5cOdOvcjrmzJ9OwvgfGRkbaDlWUUURUDKfPXiQuIYlLPr74XAvA1sYKi7rmWNQ1Z+AzvejZrQNGhpWX04ioGPz8bzJsUN9KWf8/X4Z/XfBh8LMzaOrViFOHdxIcEk6XvqNp1KAez44YyJIFs0tdT/adHC5cusbTvbtVSpyi7IJuhXDmr0skp6ax9pMvAbjmdwOA7l3al1og3Q6NoH3PYYT5n8bK0qIqwtUaKZCqgduhEbz/8WZOnr1A/Xpu9H+6J097NSIjM4uY2Hg2fLEdH98ACgsL0dXVpU6dOlha1MXRwQ53N2fcXZ3p3qUDUyeOpn49t1r/pq1Jsu/kcOLkn/z2+1lOn72Ajo4O7du2YPzooWz8+E3s7WxQKBTaDlOUoqioCJVKjY5OHYJDIrjqF8BV3wCuXQ8kLDyKXj0606JZEyaOGc6WT97Bzta6SuJSKpX8ef4Kb33wOVeu+WNubsZHby9n9PABj/2eupOTy/Q5S/nxu89xbtyZeu6u3Lodxs87NrHpqx3MXbwKG2tLxj87lPz8fN7+cAMLX5z2n6MKf13wYdNX3/Pr0T/wOXOA+p7ujxWfKLt31m6kVQtvOrVvRR1FHTKzs+ncZxSNGtQjOCQcgBdnTWLjl9+z+9vPGPvcS1z1DeCq3w0G9++Ng70tuXl55OTk8uf5K0ybsxSAb77/icUvzdTmrlU6KZC0JC09g737j3LwyO/cuh3G/DlTef/NV7C2stR2aOIxaTQarvoGsHnrTn774yyN6nswbPDTLJgzlSaN6ktBVEOcv3SV039eYvPWHahUKlQqFfZ2trRt1YxWLb0ZO2ow3k0aYm5mqpX4Tp29yOjJLwLw9qqXWfX2eta8/xkHDp9g2+YPiw+DPYpbwaEc++Ms1/xuUFhYxPjRQ2jm3ZjePbvg6uJE+57DAPA7fxh3V2fCI2MICAymdcum960rOjaeaXOW4Ohgx7jRQ+g3/DlWL1/AxDHDqFNHpsECxMUnsvGr7/l8y3cA/LJzM4lJKYwbPeSR1peTm0t0TDxNGtXng/VbcLC3xcTYiLy8fNq1aYGDvS1nju5mx4/78b0eyDurlvD2ypdRq9UA9B48EYCQsEjGjR7C+g1fs+/XYwAM7t+bVcsWMHTMTObNnoJBLb67hhRIWqBWqxk+/nm8mzTkxVmT6NOzyxNxPLe2y8vL5+CR39m0dQfBt8NYsmA2yxbPwbOem7ZDEw9wOzSCI8dOcT3gJo0beTJ21GBMjI049NtJdu05QHRsAkMH9uGHbZ/SqX1rbYd7n769unLj0jE+WL+F2VPHMXfWZIqKihg6dhbf7tzL9Mljyr3Oz7/4js7tWxMcGgFAr0ETaNGsCQvnTi9epmF9D2ZMGUPL5l64uzoD0K51c3oNmsD3X60jIDCYV//3AgDp6Zkc/u0kQwf2Ze3bywHwvR7ImOfm8ca7n3D51H4sLeuiVquf2GJJo9EwceYiWrfw5qnunTh19gIjJtx9/YYP7oehoUG51/nDT7+yePnbJIRcAiAhMZkRQ/rh4xtAQGAwZ47uxtDQgBlT/v89olAoiovq1195iXatmzNs3Gw2b91B36e68sO2T8nNzWPk0P4A9OzeieHjZ7Pr60+xsDB/3JehWpICqYrk5xdwOyyCW8FhnDx7HnMzUzate1NGE2oIjUZD9p0cbgQF4+cfRNCtUJJT02hQz51B/Xvx9fY9/HH6HPZ2tix+aQaD+/eWorca0Gg03AwO5co1f0LDIgkKDiU3N4+bwaHo6OjQs1tHundpz75Dx7hyzZ/TZy/StVNbJowZxvDB/ar9BGRnJ3s++WBl8d96enpsWv8W/YZNoWUzL9q2bl7mdanVal5b8xFPde+EtZVF8eMHdn9537IfvbPinr/btW7OV9/uZtLMRQDMmTmRwsJCGrbqDcCOreuLl23VwpvTR37glZXv8966zQx6phdDx84i9PqpShlB/3bHXp7p2wMHe9sKX3dFUCgUHNj9ZfF7LS8vHx0dHRa8soYJMxbw4szJ9O3VtVzrDLx5G4Br128UP/bizMm0b9vioW0jAs5iYWFOUVERSxc+T9dObenZreN9y21a9yYvvbya9Ru/ZtWyBZX+XXbl6nX2HzrB4pdmVllBVqYCKSAohF17D1PP3ZmZk0dVdkw1TlFREfGJycQnJBGfkERsfCLxCUnExScSF59ITFwiGRmZ1PNwxatRfZo0bsDqKnhDifJTKpVERsVy7Xog167fIPDmbW6HRpKUnIKxkRGeHq60aNaEVi28cHSw47U1H/Hdrp+ZMGYoB3Z/KYfQtESj0ZCVfQf/G7cIj4wmNi6RwJu38bnmj0ajoUvHtnh7NWTK+JFYWdbFzcUZRwfb4lGLVi296dl/HJ07tGbvjk1a3pvH4+HmwhsrFjFl9mIund6HibFxmdqFRURhY22Jn38QuXl5vL/mFRQKBRZ1H/5lNG70EJ4dMRD/wGDWvPcJbboNITUtnfHPDqWgoIAeXTvcs7yjgx1r315Oo9a92bF7H507tKZZh/6sf/91xowchEKhIDUtnQOHTzBi8DOP/IWYkprGglfWUL+eG9u2rMW7cYPHOvRYWf5diP9zBvIn769k89YdPL9gBZvXv1Wuye1+/kF4N2nIgJHT6NS+FRcu++Lh7lymtv+81np6eix/+cX/XE6hUPDK/16gecf+XLh8jcN7v2HCjIXk5uaxYslcOrRtWWGfhWq1mtXvfsKf56/g7dWQ8Y946LG8ylQgnTl3hTdefZHN2/ag0WieqC+AOzm5/1/s/P1vySLozp0c7O1scXSww9nRHkcHO1ycHGjfpiXOjna4ODtiZ2v9xA4ha5tKpeJOTi6ZWdmEhUeRmJRCXl4+d3JzSUhMJikphbCIaBISk0lJTcfe3oamXo1o26oZc2ZMonEjT9xcnB74vrezsebI8dP8b94MubRCJVMqldwMDiM0PIqrvv7cvB1GVlY2ScmpJCaloKurS+OGnjSo746LkyPDBz/Na0vn4enhiq5u6R91DTzdaVjfg149OlfR3lSu8aOHcPL0OXbs3s/saePL1Obsucv07tGZde+/jkqlLvfcKh0dHVo19+Kjt1dw9vxl+vXujpWlBfr6Dx5JtbO1Zv4LUxk9YgAtmjbBLyCIMVPmsea9T9mxdT179h3m4JHfeWftRta99zp9n+pa7sNNR0+cYcyIgQQFh9K93xjWvfca0yY9W651aIu+vh7z50ylUcN6LF7xNn7nDpfpuzc4JJybwaEc2/8dP/z0K6+/Mo/UtAxsbSr+5AFXZ0dSInzo8NQIRk9+ER/fAEYPG8Azw58DYMPHaxg6sC/fbN+DvZ0NY0c92o3vv9+9jzs5uby96mW+/u5H6rm7PPJh72t+N9DT06OZd6OHLqsoLCzQPGyhDz/fxpJ5U9ny7R7GjehPXXOz4ud+OnCcvQfvXsxOo9EQGR3P2UPbHvqBpG0ajYbMzGxi4hKIi08kNj6huOj5/4IoGYUCnBzscHK4W/g4Odrf/dvRHkfHuwWRpUXdWlE01tRcFhYWkZGZRVR0LMmpacTGJXI7NILMrGwio2MJuhlCnTp1MDc3xc3FCVcXR4wNDTE2NsLGxgonBzvcXZ1xcXasFWeV1dQ8/qOoqIjgkAjS0jPwueZPcGg4hQVFnPrzAmampjRpXJ9Wzb1o2dwLGytLbGyscLCzfaS5GtXd4+Ty5JnzLHntXQ7s/hInR/tSl1WpVLTpPoT1772u1SLx4hVf9v16nD2/HEKt1nD66A9cvRbA22s3EBwSzqnDu2jq1bBMh68vXvFl3NT5fPnZu3g3aYBfQBCLl73N5TP7yzyq9m+ZWdn4Xg/E3c0ZDzeXcrV93D7ZovMAft6xiQaeHg9d9tNN24hLSOK9N5aWK8bH8d3On/nl19/4ZuOHWFiYs37D1xw+dopLPn54uLtgZVGXq343sLG2vDtx/M1X8W7S8KHrLSws4tVV7/P19j38snMzXTq25dVV73M94Ca//7qj3HHOWfQ6u/YcAGDEkH58s+nDUpcvU4G06evdzJoyis3b9jB3xrj//AJRKpV0HzRVqx/GSqWS/IJCCgoKSM/IJDYukZi4BGLjEggJiyQ6Np7ExBSSklMwMDDA2ckeZycHnB3ti4uffwofRwe7R+pItUFl51KlUpGTm0dubh75BQXYWFthanLva11YWERoeCTJKWkkJqUUX/spPSOLuPhEQsOjSE5JRaVSYVHXHAd7W1ycHbG2sqC+pzuO9rZYWtSlRbMm2FhbVfg+1ASVnces7DukpWWgq6eLvp4exsZG9+Xx37Ekp6QRn5BEXn4BhYWFJCSlcO6CDzeCgsnMyiY3N4+s7Du4ujhiZWlJ86aNaebdCI1aQ8f2rWjUoF6NL2Af1aPkcu2nX3L23GX27dpS6us2b/Eqvt+9j/Ro32rx+t4OjUChoLggyM3L47udP/Pqqg+o5+7Kl5+9Q7s298+nUavVbPl6F7/9foZTZy8waexwPlu7unifXlj4Gg3re5T59PTCwiKOHDvF/FfeIDMzG11dXU4e3klz78aPvG+PksdPNn7D7r2/smvbp8UT4x8kOjae5h37s3Hdm0x4dugjx1hRsu/k8OH6L3h5wSwM9PW5cs2fw8dOsv/X4/icPXjfGXBFRUUA6OrqsueXw8yef3di/y87NxcX7gUFhTTt0I9fdm0pcx40Gg1p6Rm06zGMFUvmkpCYzNBBfWnRtEmp7cqUne6d27Ly3Q14erhUWedRq9XcycklOzuHrOxssu/kkJ19h6zsO6SkppOQmExiUgrJKamkpmWQkpZOamo6SqUKQ0MDDAz0qWtuhrOTPS5Ojjg72fN0r254uLlgZ2eNva1NrfzFWR1oNBoSk1Lw9Q8kPSOL5ORUklPSiI6N53ZoBOnpGWRkZmH49yiOgb4ecfFJWNQ1w9TUBI1GQ0JiMhqNBhdnR1ycHLCxscLaygJbaysaNqiHrbUV9TxccXNxqtWnmWqbUqnk/KVrBIeEk19QQExsAuGR0SQlpRAeGUNRURGODnYUKZUUFRaRlX2HSeNG0KldKwDiE5O4fuMmEZGx+N+4ibmZKU6O9n/nXR8jI0M6d2jNtEmjsbKywNTEGENDw/8sskT5/G/eDH4/9Rdjn3uJaZNH075NC377/SwTx9w9TV+lUnEzOIyjJ05z/ve91aI4grtnyv2bsZERL8yYSLfO7Tl30Yfx0xdgb2eLV6P6ZGXfLVwmjh3OhOkLAFizYhGv/u+F+w7DvLroBbr1e5Zjv5/l6C/bSt1fX/8gZs17lduhEcyZOYk2LZvSuqV3mUZxKtr8OVNRq9UMGj2DVxY9z8Qxw/C9Hkijhp7FfSUxKYX1G75m+uRnGTNiYJXH+CBmpiaseW1R8d9dO7Wla6e2xMQm4ObdlfkvTOXp3t3Y8/Mhjp/6i4jIGJo08qSOog6Bt0KYPW08765ecs+8MQMDfT58axnPzX6Z87/vfejn/wfrt/DO2o2YGBsx4dmhzHxubJnjL9MIUlk9qDL2CwgiKSmVnNxc7uTkcudODll/FzpZWXfIvnPn7yLo7v/ffSyH/IICTE1MMDMzwdzMFDNTU8zNTTE3NcHa2goHOxvs7WywtbHC2toKG2tLrC0tZB5IBSntV45arSYqJo6MzGzCI6KIio4jLCKaW7dDSUvPJDwyGmsrS5p5NcLJ0f5uYWNrjbOjA/XruWFvZ42lRd171qtUKklLzyQ3Nw8UYG1lWe3PIKoJyvprValUEh4Zw1XfAC5e8SUkLJKwiGhSUtLwcHemR9eOGBsZYlHXnGbejbGoa4bnAy5KGnQrhL0HjhIaFomuji6GhgZ06dQWOxsr2rZuXqYJv+LBHnU0MDcvjx2797Pxy+8Jj4xGT0+XRg08GTGkH+cu+nDyzAXWv/c6z02sOSfgFBQUcuHKNaJj4vG7HsjtsEhOnb3AnJmTeG7CSJo0qv+fbQc/O4ObwaHs+W7DPddtUqvVKJUq9PX1yMjIommHfuQXFHLp5C8VemHLxxnV/eXgb3yyaRu5uXkEh4Sjp6fLyKH9adOyKa+sfB/4/7PQqrP8/AICb95m2469nDl3icH9e9Oreyc8Pdx4ecU7ODjY8vz0CaWO8Dw7eS62tlYsW/wirv+6JVNRURGLl7/DuYs+fPzua0ybs5TOHVozdtRgBvfvXa4fAZVeIC1b/SGR0bGYGhthbGyEiYkx5mammJuZ3S14zP7/v7vFkBlmpiYYGhpUm18zT6KSufS55s/qdz8hPSOLW7dDcXZywNrSAjdXJ1ydnajn4ULjhvWxt7XG1cXpPydmiqr1oD6pVCqJiUvgtxNn+PP8lbu3qomMoW5dc1o196J9mxa0a9Pi7twsN2fph9XE4x4uTU/P5LMt3zJn5kQu+Vzn6PHT1PNwZdjAvnjWc6vRef7nMhxlnVj+2ZZvOXzsFF999h7OTnfnZ72y8n22fL2TMSMHkZScSqMG9fjgzVcrPNbHzWNBQSHNOj5DTk4un61dTWxcIteu32DYoKfxcHelVXOvCo+5Olr9znrWb/wGgCtn9uPnH8Tlq/64ujiyd98RbG2tuXjZl+Uvv1jmExVKqvSJQu+uXlLZmxBVoJ6HKyuWzMXM1JSG9T2kAKrBBoycRmxcAm1aNWPgM71o3rQx7q7OWrsitKgalpZ1WfnqfAAGPdOLQc/00nJEFUehUJTr/Tt31mRCwyJp2qEffXp2Yeqk0Zw9d5lxo4dgamJM44ae5ToUU5UMDPS5cekYBYWFT/Qo++xp43mqeyd2/rifdj2G3fPct1s+qpB7E9aM01qE1llZWlTLqwmL8jt+YLu2QxBCq+rUqcMbKxZx+Ngpfj99jt9Pn8PN1YmNH6+pEZdj0dfXe+J/pDr9fWJVfU93hgzsy5Wr17kVEs7R46cZOrBPhWxDCiQhhBBPnLrmZgRePkZAYDBjp77E6mULakRxJO7l6uyIq7MjQwb0QaVSkZqWUWGHi6VAEkII8UTS1dWlVQtvbl39XduhiAqgo6ODnW3FXRBTymUhhBBCiBKkQBJCCCGEKEEKJCGEEEKIEqRAEkIIIYQooUInaWs0d685qVQqK3K1ooLo6OiUeXa/5LJ6K2suJY/Vm/TJ2kHyWHv8O5cVWiCpVCoAeg0r240ARdUqz5VbJZfVW1lzKXms3qRP1g6Sx9rj37ms0FuNqNVqCgsLS62mJ72wjO83v/tY23ncdTyp7cvzK6cqclnT22szhrLmUvpk9W4vfbJi22srhuqWx4pYx5PavtJGkOrUqYOhYek3i1UoFI90/5mKXMeT3r4sqiKXNb19dYmhNNIna0b7spA+WXNiKI30yZrRHmSSthBCCCHEfaq8QBo15Gmtr+NJb19RtL0f2m5fXWJ4XLXhdajp7SuKtvdD2+2rSwyPqza8DjW9PVTwHCQhhBBCiNpADrEJIYQQQpQgBZIQQgghRAlSIAkhhBBClCAFkhBCCCFECZV2sYffz1wk8FYoFuZmJCSnkp6RxbyZ4wgOjeSPMxdp1awJI4f0JT0ji6lzX2P/jk/L3b5Pz45s/mYP+vq6zJ0xHn19vYe2T8/I4q2PvmDXlx8QEh7NoWOnycsrYOn8adSpU6dc7TUaDes3bycrO5eJowfSwNOtTPtw6WoAUdHxeLg5MahfT9Z8uBmVSsUrC6ZjZmpSrvZDB/SisLCIyXOWsfHD17C2sqhWeawNuawNeayIXNb0PNaWXEqfrB15rIhcPul5rOxcVtoIUs+u7Xhp1gQio+OwsqjLSzPHc+6SH9dv3GbNsnnEJSYDsGf/MVo2a/RI7cMjY2nm1QCvRp7EJSSVqX3TJg1o1awJAB5uTix4fhJOjrYkJqWWu33grTCsLC1YtfSF+z6IS1vH4Gd6Mv/5iQQFhxMeFUuHts0YObgP128El7s9wC+Hfse7cYNHzFTpHjePZV1Hdc5lbchjaXFIn6xZuZQ+WTvyWFocT0qffNw8lnUd8Gi5rLQCSVdHh7SMTFLTM7GztcLW1oro2HgKCgsByMsvICwiBjtbK0yMjR+pfQNPN65dD+Kvi764ONmXqX3JZdRqNbFxSTg62Ja7fWx8IknJqWzc+gMpqell3gddHR1CwqLwcHMiOiYee1tr7GytiYy+P76HtU/LyCQvrwBnR9v7tl8RHjePZV1Hdc5lbchjaXFIn6xZuZQ+WTvyWFocT0qffNw8lnUdj5rLSiuQioqUfP39Pt5cPo+k5DSSk9Nwc3HE0EAfACNDAy5dDSAxKZWbt8M5d8m33O2PnTzP+NED6dapNZev3ShT+5K+3/Mro4bef0GpsrS3MDejVfMm9OvVhTPnfMq8jjs5uew7fJKRg/vi7upEYlIqScmpeLg5lbu9j28gWXdyuHo9iLMXrj48MeX0uHks6zqqcy5rQx5Li0P6ZM3KpfTJ2pHH0uJ4Uvrk4+axrOt41FxW2oUiP/9qF1HR8djZWpNfUEBubh7zZo0nODSSE6cu0KaFFyOH9AXg/U++5pUF08vdvn2bZuzZfwyA6RNHYFHX7KHt/QND+P7HX+nToyMN67vx1fafadqkAb26tadtK+9ytZ80ZhAfb9yOoo6CcSP64+rsUKZ92PDVD+jp6WJqYsLcmWN5d91XqFRqXl04457jq2VpP2/mOAwNDfhq+15GDOpT4cfJHzePZV1Hdc5lbchjWfMgfbL651L6ZO3IY1nzUJv75OPmsazreNRcypW0hRBCCCFKkNP8hRBCCCFKkAJJCCGEEKIEKZCEEEIIIUqQAkkIIYQQogQpkIQQQgghSvg/iZBCBYCCxWIAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 583.3x485 with 25 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "A grid of small standardized time-series panels sharing their axes. Several rise steadily from one end of the window to the other, the Treasury yields move together in broad waves, and only the VIX and initial jobless claims show sharp isolated spikes against an otherwise flat line."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "n_columns = 5\n",
     "n_rows_grid = int(np.ceil(len(extended_df.columns) / n_columns))\n",
@@ -1203,8 +2588,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "913442e9",
-   "metadata": {},
+   "id": "250779f1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015937,
+     "end_time": "2026-09-08T23:42:56.990184+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:56.974247+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### How much independent variation is left\n",
     "\n",
@@ -1215,10 +2608,105 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8f990b8f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 33,
+   "id": "f8581794",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:57.031750Z",
+     "iopub.status.busy": "2026-09-08T23:42:57.031623Z",
+     "iopub.status.idle": "2026-09-08T23:42:57.051392Z",
+     "shell.execute_reply": "2026-09-08T23:42:57.044256Z"
+    },
+    "papermill": {
+     "duration": 0.035391,
+     "end_time": "2026-09-08T23:42:57.052312+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:57.016921+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_14d75\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_14d75_level0_col0\" class=\"col_heading level0 col0\" >Share of variance</th>\n",
+       "      <th id=\"T_14d75_level0_col1\" class=\"col_heading level0 col1\" >Cumulative</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Component</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row0\" class=\"row_heading level0 row0\" >PC1</th>\n",
+       "      <td id=\"T_14d75_row0_col0\" class=\"data row0 col0\" >45.6%</td>\n",
+       "      <td id=\"T_14d75_row0_col1\" class=\"data row0 col1\" >45.6%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row1\" class=\"row_heading level0 row1\" >PC2</th>\n",
+       "      <td id=\"T_14d75_row1_col0\" class=\"data row1 col0\" >34.8%</td>\n",
+       "      <td id=\"T_14d75_row1_col1\" class=\"data row1 col1\" >80.3%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row2\" class=\"row_heading level0 row2\" >PC3</th>\n",
+       "      <td id=\"T_14d75_row2_col0\" class=\"data row2 col0\" >7.5%</td>\n",
+       "      <td id=\"T_14d75_row2_col1\" class=\"data row2 col1\" >87.9%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row3\" class=\"row_heading level0 row3\" >PC4</th>\n",
+       "      <td id=\"T_14d75_row3_col0\" class=\"data row3 col0\" >5.8%</td>\n",
+       "      <td id=\"T_14d75_row3_col1\" class=\"data row3 col1\" >93.6%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row4\" class=\"row_heading level0 row4\" >PC5</th>\n",
+       "      <td id=\"T_14d75_row4_col0\" class=\"data row4 col0\" >2.4%</td>\n",
+       "      <td id=\"T_14d75_row4_col1\" class=\"data row4 col1\" >96.0%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row5\" class=\"row_heading level0 row5\" >PC6</th>\n",
+       "      <td id=\"T_14d75_row5_col0\" class=\"data row5 col0\" >1.8%</td>\n",
+       "      <td id=\"T_14d75_row5_col1\" class=\"data row5 col1\" >97.8%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row6\" class=\"row_heading level0 row6\" >PC7</th>\n",
+       "      <td id=\"T_14d75_row6_col0\" class=\"data row6 col0\" >1.0%</td>\n",
+       "      <td id=\"T_14d75_row6_col1\" class=\"data row6 col1\" >98.8%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row7\" class=\"row_heading level0 row7\" >PC8</th>\n",
+       "      <td id=\"T_14d75_row7_col0\" class=\"data row7 col0\" >0.6%</td>\n",
+       "      <td id=\"T_14d75_row7_col1\" class=\"data row7 col1\" >99.4%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row8\" class=\"row_heading level0 row8\" >PC9</th>\n",
+       "      <td id=\"T_14d75_row8_col0\" class=\"data row8 col0\" >0.2%</td>\n",
+       "      <td id=\"T_14d75_row8_col1\" class=\"data row8 col1\" >99.7%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_14d75_level0_row9\" class=\"row_heading level0 row9\" >PC10</th>\n",
+       "      <td id=\"T_14d75_row9_col0\" class=\"data row9 col0\" >0.1%</td>\n",
+       "      <td id=\"T_14d75_row9_col1\" class=\"data row9 col1\" >99.8%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7dbdb83b60d0>"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pca = PCA(n_components=min(10, extended_df.shape[1]))\n",
     "reduced = pca.fit_transform(extended_df)\n",
@@ -1235,10 +2723,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "018a2415",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 34,
+   "id": "fad29b33",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:57.072351Z",
+     "iopub.status.busy": "2026-09-08T23:42:57.072207Z",
+     "iopub.status.idle": "2026-09-08T23:42:57.080107Z",
+     "shell.execute_reply": "2026-09-08T23:42:57.079827Z"
+    },
+    "papermill": {
+     "duration": 0.018203,
+     "end_time": "2026-09-08T23:42:57.080960+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:57.062757+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Two directions account for **80%** of the variance across **25 columns**."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "two_component_share = float(explained[\"Cumulative\"].iloc[1])\n",
     "display(\n",
@@ -1251,8 +2766,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8eb0c723",
-   "metadata": {},
+   "id": "531b7284",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023921,
+     "end_time": "2026-09-08T23:42:57.119687+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:57.095766+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### Which columns each direction is made of\n",
     "\n",
@@ -1263,10 +2786,97 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0f134c30",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 35,
+   "id": "bf08c672",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:57.163409Z",
+     "iopub.status.busy": "2026-09-08T23:42:57.163284Z",
+     "iopub.status.idle": "2026-09-08T23:42:57.175066Z",
+     "shell.execute_reply": "2026-09-08T23:42:57.174823Z"
+    },
+    "papermill": {
+     "duration": 0.04228,
+     "end_time": "2026-09-08T23:42:57.178496+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:57.136216+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>PC1</th>\n",
+       "      <th>PC2</th>\n",
+       "      <th>PC3</th>\n",
+       "      <th>PC4</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Heaviest 1</th>\n",
+       "      <td>payems</td>\n",
+       "      <td>dgs10</td>\n",
+       "      <td>indpro</td>\n",
+       "      <td>icsa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Heaviest 2</th>\n",
+       "      <td>gdp</td>\n",
+       "      <td>dgs20</td>\n",
+       "      <td>vixcls</td>\n",
+       "      <td>vixcls</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Heaviest 3</th>\n",
+       "      <td>t10y2y</td>\n",
+       "      <td>dgs7</td>\n",
+       "      <td>unrate</td>\n",
+       "      <td>YIELD_CURVE_SLOPE</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Heaviest 4</th>\n",
+       "      <td>YIELD_CURVE_SLOPE</td>\n",
+       "      <td>dgs30</td>\n",
+       "      <td>dgs20</td>\n",
+       "      <td>t10y2y</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          PC1    PC2     PC3                PC4\n",
+       "Heaviest 1             payems  dgs10  indpro               icsa\n",
+       "Heaviest 2                gdp  dgs20  vixcls             vixcls\n",
+       "Heaviest 3             t10y2y   dgs7  unrate  YIELD_CURVE_SLOPE\n",
+       "Heaviest 4  YIELD_CURVE_SLOPE  dgs30   dgs20             t10y2y"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "loadings = pd.DataFrame(pca.components_.T, index=extended_df.columns, columns=explained.index)\n",
     "pd.DataFrame(\n",
@@ -1280,8 +2890,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f61273e5",
-   "metadata": {},
+   "id": "183028d6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009012,
+     "end_time": "2026-09-08T23:42:57.199555+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:57.190543+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The leading direction is the trend the small multiples showed, and the second is the level\n",
     "of the long end of the Treasury curve. Neither is a regime. The series that move when\n",
@@ -1293,8 +2911,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f72c8534",
-   "metadata": {},
+   "id": "f4c138f8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01118,
+     "end_time": "2026-09-08T23:42:57.222847+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:57.211667+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Fit the same models to the extended panel\n",
     "\n",
@@ -1305,10 +2931,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d3f0923e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 36,
+   "id": "1858e81e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:42:57.246984Z",
+     "iopub.status.busy": "2026-09-08T23:42:57.246868Z",
+     "iopub.status.idle": "2026-09-08T23:43:04.343844Z",
+     "shell.execute_reply": "2026-09-08T23:43:04.343554Z"
+    },
+    "papermill": {
+     "duration": 7.109364,
+     "end_time": "2026-09-08T23:43:04.344625+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:42:57.235261+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_cf95f\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_cf95f_level0_col0\" class=\"col_heading level0 col0\" >Silhouette</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Model</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_cf95f_level0_row0\" class=\"row_heading level0 row0\" >Core, 4 chosen series</th>\n",
+       "      <td id=\"T_cf95f_row0_col0\" class=\"data row0 col0\" >0.327</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_cf95f_level0_row1\" class=\"row_heading level0 row1\" >Extended, 25 series</th>\n",
+       "      <td id=\"T_cf95f_row1_col0\" class=\"data row1 col0\" >0.419</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_cf95f_level0_row2\" class=\"row_heading level0 row2\" >Extended, 10 principal components</th>\n",
+       "      <td id=\"T_cf95f_row2_col0\" class=\"data row2 col0\" >0.397</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_cf95f_level0_row3\" class=\"row_heading level0 row3\" >Extended, 25 series, k-means</th>\n",
+       "      <td id=\"T_cf95f_row3_col0\" class=\"data row3 col0\" >0.448</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x7dbdb83b6210>"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "gmm_extended = GaussianMixture(\n",
     "    n_components=N_REGIMES, covariance_type=\"full\", random_state=SEED, n_init=10, reg_covar=1e-6\n",
@@ -1344,9 +3029,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18301aa2",
+   "id": "52a819eb",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.010501,
+     "end_time": "2026-09-08T23:43:04.363886+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:04.353385+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### The score says the extended panel is better. Look at what it bought.\n",
@@ -1360,10 +3052,85 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6dd5a858",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 37,
+   "id": "5409248f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:04.387188Z",
+     "iopub.status.busy": "2026-09-08T23:43:04.387058Z",
+     "iopub.status.idle": "2026-09-08T23:43:04.397468Z",
+     "shell.execute_reply": "2026-09-08T23:43:04.395148Z"
+    },
+    "papermill": {
+     "duration": 0.023281,
+     "end_time": "2026-09-08T23:43:04.397861+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:04.374580+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Clusters</th>\n",
+       "      <th>Episodes</th>\n",
+       "      <th>Clusters revisited</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Model</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Core, 4 chosen series</th>\n",
+       "      <td>4</td>\n",
+       "      <td>8</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Extended, 25 series</th>\n",
+       "      <td>4</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       Clusters  Episodes  Clusters revisited\n",
+       "Model                                                        \n",
+       "Core, 4 chosen series         4         8                   3\n",
+       "Extended, 25 series           4         4                   0"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def episode_count(labels: np.ndarray) -> int:\n",
     "    \"\"\"Number of maximal runs of consecutive months sharing a label.\"\"\"\n",
@@ -1395,10 +3162,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5591a7f0",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 38,
+   "id": "f4fb1dd5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:04.418555Z",
+     "iopub.status.busy": "2026-09-08T23:43:04.418436Z",
+     "iopub.status.idle": "2026-09-08T23:43:04.424569Z",
+     "shell.execute_reply": "2026-09-08T23:43:04.423897Z"
+    },
+    "papermill": {
+     "duration": 0.018984,
+     "end_time": "2026-09-08T23:43:04.424973+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:04.405989+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The extended model splits 276 months into **4 episodes** from **4 clusters**, returning to **0** of them, against **8 episodes** and **3** revisited for the core model."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "extended_episodes = episode_count(extended_labels)\n",
     "core_episodes = episode_count(core_labels)\n",
@@ -1415,8 +3209,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ada03043",
-   "metadata": {},
+   "id": "e259f434",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011741,
+     "end_time": "2026-09-08T23:43:04.449244+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:04.437503+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "A model with as many episodes as clusters and none of them revisited has assigned every\n",
     "month to the cluster of its neighbours and never returned to a condition it had left. It has\n",
@@ -1435,9 +3237,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a46d996",
+   "id": "b6811f37",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.017246,
+     "end_time": "2026-09-08T23:43:04.477424+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:04.460178+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### The two partitions, drawn\n",
@@ -1448,9 +3257,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0d11bf0a",
-   "metadata": {},
+   "execution_count": 39,
+   "id": "ab6128f6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:04.602982Z",
+     "iopub.status.busy": "2026-09-08T23:43:04.602846Z",
+     "iopub.status.idle": "2026-09-08T23:43:04.615639Z",
+     "shell.execute_reply": "2026-09-08T23:43:04.615108Z"
+    },
+    "papermill": {
+     "duration": 0.042161,
+     "end_time": "2026-09-08T23:43:04.622030+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:04.579869+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def plot_assignment_heatmap(probabilities: np.ndarray, dates: pd.DatetimeIndex, claim: str) -> None:\n",
@@ -1474,10 +3297,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "51b6acb6",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 40,
+   "id": "48a21152",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:04.672723Z",
+     "iopub.status.busy": "2026-09-08T23:43:04.672594Z",
+     "iopub.status.idle": "2026-09-08T23:43:05.085943Z",
+     "shell.execute_reply": "2026-09-08T23:43:05.084997Z"
+    },
+    "papermill": {
+     "duration": 0.444542,
+     "end_time": "2026-09-08T23:43:05.089673+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:04.645131+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkcAAAEFCAYAAADpO0MNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAmXJJREFUeJztXXe81MT2/85k995LEakiiIgFKYIgKioWFEVQBEXwqYiIYgUL6BPhCaKCFbE8KzZUQB+Cz4r6s/uwF+wVC1IUlV7v3U0yvz9SdpJMstnd7N1y58vnsikzk28m55ycOVNCEokaBgkJCQkJCQkJCQAALTQBCQkJCQkJCYlignSOJCQkJCQkJCQ4SOdIQkJCQkJCQoKDdI4kJCQkJCQkJDjUWedo7pPPonGbbnj/o8WFplJ06LxfXwwYOiptukXvfYzGbbrhscf/WwusJHioqorGbbrhgnGTAQDPLnwNu+x1CD5Z/KVvntPPuRSHH3tqbVHM6Hrlqo+/LV+Jxm26YdrNd2WV/61FH2C/wwZh5469pJ5JSNQiytY5umDcZDRu0034t+i9jwtNT8KFbduq0bhNN8x98tlCU8HDs59E4zbdCk0jIxx5eC/MffB27N2lEwDgtTffReM23fDb8pV2mmv+NRZ3z7i21ji5r3fW6PGhnG6JFMZOmIr1Gzbiuin/xGGH9Cw0HQmJOoNYoQnkC+edNQwD+h0BTdNxxnmX4dBe++O8s4YBADp33APLVvxeYIYSPP5avabQFGz8+VfxcAmLhg3q45CD9rP3//x7tSfNbru2rU1KnuuVYr0WGkt/W4HBA4/GiFNPLDQVCYk6hbKNHHXv2gnH9e+DAf0OBwC02akVjuvfB8f174NmTZvY6T7+9Ev0O+EM7NyxF84aPR7JZBIAoGkabr3rIXQ5oD/26HY4Jky5GYlE0nOdrdu24errb0fXA49B286H4OwxE1BdXQMAePvdD9FnwDDstOeB6DNgGP737kd2vgvGTUbfQafjiQXPo/N+fXHbXQ8BAF569S30Omoo2nY6GCePvAir/vzbc80Lxk1GnwHD8OCj89Ct17HY+6Bj8NSzL+HZF17FAUcMxh7dDsd/Fjxvp9+8ZSsun3QDOvQ4Eh16HInxk2/E5i1b7fNffP0djjzuNLTtdDDOuXAitpn8LXz4yec4auBwtOlwEI4dchaW/Lw0bf0PGDoKo8Zcgdvvfhi77304FjzzEhhjeOyJ/2LfQwdil70OwbkX/wsbN23Govc+RreDjgUAjLn0KjviccOMe9G4TTf88usyAKmul7cWfeB7jRtm3Is9uh2O5196HYcc/Q+07XQwJky52eb15Tff46iBw9FqjwPQ68ghePK/Cz11e9Nt9wEAGrfpZkc60tUhjw8+/gzHDDkTbTochP17H49X33gnbRlW98usOfNx2qixaNv5EBw1cDhW/L7KLvftdz7EQUeeiHZ7HYorrrrJcU2+bm6YcS/GXHoVAKDbQcei64HH2PXVeb++dp6lv63AKWdejLadDkaPQwbiwUfngTHmKO/1t95F30GnY+eOvTBqzBW2fixb8TuOP+VctG5/APY7bBDuuv8xOy8vA9b1uh54DN794BO8+8EnaNymG26Yca+w7vz08eNPv8Rpo8ai475Hod1eh+KfV14PVVVDc3n73Q/R68ghaN3+APQZMAxvvP0eACNiOWnqDHTocST22v9o3PLvB6DretpzA4aOwunnXIrpd9yPrgcegz336eORJR5Lfl6KQSefg5079sIJp57neK5++mVFL59+/hV7O4wM/fe5lzF0+Gjs2uUw1NQksH79Roy57Crs2uUw7HPwcbJ7TkIiBMrWOQqL+2c9gZMGH4uDevbAf5/7P7z82v8AAHfNfAzX3vhvDOh3BCZeNhqPP/ks7n/kCU/+y/51Pf5936MYfNzRuPKfo9Fhz91QVVWJb79fgqHDR6NBg/qYft2/UK9ePQwZfgG+++EnO+833/2IW+64H+PHnofBA/vho0+/wLCzxqJN6x1x/dWXY/ny3zF2wlQh78VffIP/Pvd/uPDcEUgkkjh/7CTcevdDOGfkKaiIxzH+qpvsl8fY8dfisSf+i9FnD8cFo07DI3MX4FKz3E2bt+AfIy7En3+txrSrLkOrHXfAho2b7OssXbYCg089D5RSXH/15SCEYOT5l3tePiK88voiPPXcy7jmyrHofUhPPPPCK7j48muw7z5dMW3yZXjnvY8x7ea70LnjHphw6QUAgHPPPBVzHrwNLZo3DfX83NcAgNVr1uGGGfdi1IiT0KH9brjvobn44uvvAACXX3kDVv35N268ZjwO6bU/tm2rdpR33lnD0OuAfQEAcx68DZPGj0lbhzx+WPILjj/lXGzcuBk3XDMevQ85AO12aRO6jIlTpmPvLh1xxqkn4pPPvsKd9z0KAFi+8g+cfMZFIMR4Dsmk6lsnQ47vj+MHGE7J7TdOxh03Tfak2bptGwYPOx9ff/sjpl11GQ47eH/888rrMfuJpx3pLhl/LU4echwO6tkDTz37sq0fU2+8E4s//xrTrroMx/Xvg+rqGhBCfDndcdNkNGm8PTp12B1zHrwNQ47vL0znp4/f/fATGjZsgEnjL8Thhx6IBx+dh6eefTk0l/MvvhIgBDdeewX26rQnahIJAMCkqTMw8+HHccawITj/7NNww4x78cLLb6Q9BwDPv/Q6Fn/xDS65YCQIIRg/+UZomia8rzfefg+HH3ogxo89D+99+CkunTANQLB+zXnwNgBArwP2tbfDyNAl469Fm512xL23T0VFRRznXDQRL7z8BsaOPhNDju+Pi8dfg8+//Nb3WUlISJRxt1pY3HbjZPTtcwj27tIRr7yxyG613T/rCRzaa39MvMx4ab/7wSdY+PIbuPDcEXbedes24In5z+G0k4/HtZPGOcqdNWcBkkkVt94wCe13b4ce3fbCgX1OxKw5C3Dz1AkAgK3bqnH/v6/Hvvt0BQBcP+Me1K9XhbtmXIOKiji2bt2GK666CYlEEhUVcQ/3p+bcg3r1qvDDkl/w4KPzcP+/r0eH9rvhhx9/xgOPzsOqv1ajfr0qLHj2JQw5vj8uGX0mAODzr77Dk0+/iJuunYA3F72PP/9ajUfum44TjjsaADBn3jP2NebMewZbt1XjzluuRssdmqN5s6YYdtYlWPrbirR1m0yqmPvQ7WjbprVdp7u1a4ubr50AEGDJT0vx1LMv4eapE3Dg/t0BAN3MiF9YuK9h1/+9N6ND+92wXcOG+Hjxl1jy01J069IJ2zVsABCCbl074YzThnjK6961E9q0bgkANo+169YH1mGTJtvb+R967EnU1CTwxKw70LZNa5x+yuBQZVg476xTccW486GqKh58dB6W/PwrAOCpZ15CdU0N7rrlavTo3gWDjj0Kjz0hjgDsuceuaL97OwDAEb0Pwi477+RJ8+ob7+LX35bjthsnYcSpJ2L4ySdg4f+9ifsefhwjhqW6cPz0Y7vtGgAAdt9tF5w5/KRAxwgA+vTuhXpVlWjapEng8/W73ohhJ2L4KSfgq29/wNat2/DMC6/g48Vf4uQhx4Xist12DRGPx3BQzx52F1V1dQ0emfsU/nHiAIw+ZzgA4PkXX8cLL7+Bo/sc6ntu0LFHAQB2aNEMjz90Owgh+PrbH/DI3Kfw9+q12LFlC8/1Rww7EZdeaEQh31z0Pl598x0kEslA/bLqqU3rljiuf5/QMnTg/vvgthsngxCCX5cux6tvvoPLLznXkHcGPP7ks3jh/95A9707Bz4zCYm6jDrvHMXjRhU0N7vaamoSSCSSWPnHn1j5x59ot9ehdto9dtvFkffX35YDALp27uAp97dlK1G/XpWdp0P73VC/XhV+W+Z0Krp17eTIs2XrNuy5j/PlsXbdeqHBtbhb3YTxmLHf1NxP1CTw11/G2JNuXVLX2WfvznjmhVewdNkKLFtujL3yG4/y22/GgN4DjhjsOP73mrXC9DyaNtne4bQs/W0F/vjzb7TrkqpTkdOXCdzXsGDVRfNm5nM1IwX33TENN916H44+YQT222dvXHfVZdin216B17AcQb865J2jpb+tQOPtG3k4pSujadPGBu+4UR+xWAxNGjdCTU2qGwuIbtyQJYcWH0opunftjPc+/NSRTqQfAHDtpEvRtGljDB81Dru0bYOpk8bhiMMOypmX3/Xeef8TXPjPKVi16m/s18NoTGw0I5xhuMyffTem3XQXDuxzIo4+8lBcN/kyMMagaRqemP8cnpj/nJ22YcP6WPn7Kt9zFmKKYjtizZsZkU5LztzgHbYO7XfHG2+/jw0bNwbq167tdnYcCytD3bp2sq+31HzO0++4H9PvuN/Ot3p1ev2VkKjLqPPOkQgVFXG03nEH7NR6R1w14WL7eMMG9R3p2u5svAC//vZHTxm7tN3Jbvnuuceu+GHJL9i6rRq7tG3je91ddm6Nb777EXMevA2KotjHrRd8NrC6dD7/KhVG/8wMqbdr2wbf7fAzAOCLr77D3nt1BABHl9kubY2ow+wHbkXj7RvZxzt3bI/PvvgmIy67tN0J8Yo47rrlGtt4x2LGfVJq9PDW1KTGO1mO01+r12C3Xdti06bNGV1PhObNmmL6df/CFZeej1NGXozTz70MX3/4siMNNeu+uroGVVWVaeuQR9udW+OVNxZh+co/sPNOrezj6crYuDn43nZo0RyAMT6s98EHpO3WTNWn+GVtyeHnX32LHt27QNd1fP7Vt4HyyaNhg/qYdPmFuPj8kTh/7CSceuYl+OXrt1G/Xj1/TorieL6Z4IJxk9G5w+748I2nUVlZ4ZhNGIbLLjvvhAfuugGTJ1yE404ahQv/eTX+O/deUEpxTN/eOH/UaXbaZk0bY6fWO/qeyxU/LvkF2zVsgObNmgbqlxvZyJAVNTzr9JMweGA/+/hOrVrmfB8SEuUM6Rz54OyRp+DaG/+NeU+9gAN77oPvf/wZQ48/xpGmebOmGHTsUXh8/nNo0bwp9ti9HT78+HPcct2/MPK0oXhk7gJc9q/rcOpJgzB33rOIx2M4c/hQ32ueNeIfmP/MS7j1rodw4sB++Gv1Guyy806IxbJ/TE2bNMbQ44/B8y+/jjvumQXGGF585U38Y/CxaNJkexx1+MGoX68K/773EVBK8d6Hn2Ld+g12/mEnDcLd98/GjDsfxLCTBqG6ugbxeByH9tofrXfcAQDwzgefYPgpJ9gvZN86PeMUnH3hBDzwyH/Qt88hWLb8dxy4/z4AUk7YE/OfR9MmjXHUEYfYXUPTbr4LBx+4H+6f5R3zlQnWb9iIU0ZehL59DkWrHXfA5i1boChezpbDc9Nt9+GIww7CYQf3DKxDHqefOhiz5izAsLMuwfmjTsOvvy3H3nt1xKBjjwosI51zNPCYI3Hjrfdi2k13YeXpf+L5l14PTG+9SO+4dxaOP7Yvjj7yUMf5o47ohXa7tMGtdz2MWCyGTz/7Gn+vXovJ4y9KW4/JZBKnjLwY3ffujPa7t8PatetACAFBcNdau7Y74aNPv8Ccec+ge9fO6NJ5z7TXsrBt2zYsX7kKTz33Ml57852MuPy2fCVGjb4Cgwf1w3YNGyCRSEJRKKqqKjHi1MGY++Sz2LlNa3TpvCe++PJbXDLmrMBz2eDZha9ht3Y7Y8XKVXj97fcw5tzTQQgJ1C830umySIZ2bbcz+vQ+CPOffhGNt2+Edru0wZdff48pEy/J6j4kJOoK6vyAbD9cfP4ZuHriJXjng08wftINeP/DxdgoiFzcecvVGHnaEMx98llcNe02MMZQXVODvTq1x4LZ92Djps3457+uw5atW7Fg9j3o1GEP32seuP8+ePzh27Fu/QZMvHo65j31gvCameK2mybj9FMG4677H8M9D87BGaeeiFtvNAbp7tCiGWY/cCsIIbjymltQEY/jsINT66nstmtbPPOfmaisqMA1N9yBBx6dh7Xr1oMxht12bYvehxyAF156HX/+5Z067saQ4/vjzluuxo8//YorJt+EF195C5u3bAFgtHAnXHoBlvy8FP+6ejp++uU3HNO3N0447mh88dV3eP+jxXjkvuk51UOj7RrihOOOxpP/XYjLJl6H+vXq4cE7b/SkO/uMf+CQg/bDzIcfx213P5S2Dnl069IJTz56JyiluPzK6/F/r/0P9aqqMipDhL06tce9t0/DX6vXYMp1t6Fzhz3Qof1uvukHH3c0juvfB888/wquvv52e9aXhQb16+Ppufdhr4574MprbsH/3v0IN0+dgNNPHexTYgqxWAzD/jEIr7yxCOMmTMOGjZsw676bUa9eVWC+qydegrZtWmPilJvx7MJXQ923henTJmL1mrW47ua70KnDHvZ4mTBcWrXcAUccdhAeeOQ/mHDVTdhjt11w6w2TAAA3XD0eF4wajhdeeh0TrroJ3y/5xW4cBJ3LFMNPPh6PPv5fPDx7Ps4cPhRXXm4M9A/SLxEylSFCCB666yYMHtgPc+Y9g8nTbsWK31dh7br1Wd2HhERdAUkkatJPO5KQkJCQkJCQqCOQkSMJCQkJCQkJCQ7SOZKQkJCQkJCQ4CCdIwkJCQkJCQkJDtI5kpCQkJCQkJDgIJ0jCQkJCQkJCQkO0jmSkJCQkJCQkOAgnSMJCQkJCQkJCQ7SOZKQkJCQkJCQ4FCWzhFjDKqqpv3+lISEhISEhISEG2X5bTVN03DogJF468XHEVNiYAS+X31iDLA/mM1gJHT/wnXe3LQ2COC5BmMMunmOECO9rjNsqlbx9Ouf49KbF4DoOsB0QEsaRDzkuOu7uaRDpul9swkKSsOrR+ddsPCBcVi9OYnVm2rQodV2qKpQ7PSi+nIUJeLOxHns03l6jpKX5CV5lR8vTdcx5MbX8cFXS1Hzy9eArvnk8Lt4ZojCrkbJa+NHt2ZQeN1EWUaOeDhkhqWUz1ZCXimJ85i7HPdxy/HxnAoRsAolx5YhCZ2Bu7AnPXOe99YEl415juTGK5U0qL6Ic9fDtlDPUfKSvCSv8uKVGYrVrubOS8IfZe8cEV5ouBYF4RWNkxtehBhxyapAFkXKnYkCMuFeOqH3SetpjrlJEZ/jbpAIeImv4ltfzLvL13nBnqPkJXlJXuXJS4hit6v54CUhQnk7RwLHmTm00thn4JSI+7UUylEMr/DcCYfyZ0CRCPdMobYL4kt3pREi6Lh146L8qesQUZ7QvMSXDqwvwh0nKSPmoVnbz1Hykrwkr7Lj5Y9itqtR85IIQnk7R8S77Xh1m7LjaG3Aq1CEuY5x+Ryiy1L+evbgBJhwG7Zl4JUoqHXgaIN5r0G4C7hvWFRxGfESIGR9EQh2iuA5Sl6Sl+RVnrwc5+1chD/gOg7BOfMY4a4auV2NmpdEEMrbOTKbG7xD7nDOiUukLIXiZMiSKUK49D5ySILkMzRhH821m1scabiVz12W+5xISRFgLbLlFVCM6LLulqSo4VXA5yh5SV6SV3nxEqLo7Wpt8ZIAytw5YrzicfuA8ctMZYJ1OEgpGedwB8loTuAvSLhLWfsspTRCAtwN5USOubYz5eWDIEpWEVyRVpaCPkfJS/KSvMqOVzCK1a7mi5eECGU5ld+CW1w84iNI4PDlrR3iSs7JtCdgYh4Lp4R+IK4tUQuAtw78eeZNEgiRkvplCsvL/1J+9cUzJ64iC/kcJS/JS/IqU15CFLNdjZqXRBDKOnLkfk8z1zEiSGOJG7MTuApwOfLZKaAPmGcjwNdwKQrjjwdw8VxDdJOu8xnz8j+Vrr6EuYvgOUpekpfkVX68vChmu5oPXhJ+KG/niHfczV2Wtnlh+vhmnqCxa27lS6t36eBpQiGNLIvS+RFysyOC4z4Xy5iXGGHqS1iHRfAcJS/JS/IqT17+BfGbxWBXo+YlEYTydo4scE66Q/aY48ez7c3gbOQQ6z/mTBqNb25eKVDgRdn8rk4cP6ny3DfI34WfWcqCF9LUF3My8YxDMBPW+nOUvCQvyatseYVGsdrVXHlJ+KJuOEfwOtrMPOgWF36SAFznhBOyInXEBd4+4Y/7KZaVxmk5GPEzTwHlEdFOLrwENEUI2bCp9ecoeUleklfZ8kqPYrWrEfGS8EVZO0duJ9xSEF5hPIrCK6+Vx2rBME6ROXmzFD5nsXO0AsJsw+c4M4/wyuBHUtCEcx/IiZer3KD6YrC/Q0cs6qQInqPkJXlJXuXJKy2K1a5GxEvCF2XtHDn8c8LpCTEUMlBMWCoPiGvfVTgBUmt3eIQxC8J8IaLyfK9BXL/WtpWBcTckKpD/5ZQsZ14IV1/EmdS9X7DnKHlJXpJXefNyX8MB4vrlyXNkPVfIt13NlZdEEMraObLgFh27CcFcYuJWQF6miTiZpys5rQaGAVeIaP2grK/Bmw+BtXFYLXBpo+PlW18++upz9dp7jpKX5CV5lScvN0rYrmbHSyIIZe0c2TrIyYbVkoD5y+uqW1EdCsod9ygfXLKfk2PuEmTm2cgC1l0yVwUIrsms/9w3Hw0v3/oS6Ctn04z9QjxHyUvykrzKk1fOKB67mjkviXQoa+fIFkOS2rFFkpNZkegQwXGI0orkLCfH3H1lgSXJpVwCiE2R6JrR80pXX/x5x5e0UdjnKHlJXpJXefLKDcVhVzPnJZEOZe0cOZx2F4hLefiEfq0LoVOfNzkzPX/RwiBWKyRUA8CViLnbWfC5H7/CQ/AKQpr6Im4ddje+fNLn+zlKXpKX5FVmvIREitiu5oNXEeOJ/76EgadeiLnzF3rOrfj9T5x9yRScdt4EvPz6O3m5fll/PsSCRyF4eeHlhjvmkWX+GJ/O3SKJzFlyFcRbA+tCoa7lV467vLCtixC8RAhbXzwN1/Mp6HOUvCQvyau8eLlR7HY1Ul7Fjx5dO+KnX5YJz90xcw7OHHYCunfpgOHnT8QhB/ZAwwb1I71+eUeOAuSQcef5DxQyXuGsNKJyiPM8H8rN2jFn9n/cMbNF4WlJAMLYs6fDPfBi3HaA1ciUlwgh64uf3Soam+Aus7aeo+QleUleZcRLhGK3q5Hyyh80TYeqqr5/mqaHKqdD+13RqmVzYfkffPIlunfpgAYN6qNtm1ZY/MV3Ud9GeUeOGPfr1gciSki44wIFsqeVWvJOnLrOmKHMAeoQDHfhAITxYGKSto8J0oM5Wx++ENWOq6mVKa+Ay/jVl/uSjKPvbvjxyPdzlLwkL8mrTHm5YV2A8Ald9q6QdjVvvKKDpuk4oP9IxKm/A9SwYX00a7I9iMl3yMC+GDqob+hrbNi0CY0bbYcGZqSobZtWWL1mXW7EBShr54i4fv3EgpcvKwMTyJpDCV0y6TiWM8IU5NGeEGXwNeD+FR1zm5pMeQkO+9WX2zYQb9aCPEfJS/KSvMqPl5+DVBJ2NSpe0YMxHXGq49sNOwqrmADojFV4ad49iMWycz8ICHQuiqYzBkKjvy/fbrUtW7Zi2oz7Mfz8iRg5ZhL+7433AACjL5+G7378JeMLTb1lJhZ/8W1WJNdv2ISLrrgBp507AXPmvxA6H3P9EsE5Bwg8ypcOfDpffQuLoAJE5zzHmGCXP+ZTA0xwjM+TKa8ApKsv+5kJ6BXyOUpekpfkVWa8/FCsdjVyXvkDIxQgiuePkdxH8mzfqCE2bd6CzVu2AgCWr1iF5s2a5FyuG75Mr50+E+13a4vZ916Pe2dMwg4tmkZ+8bB4eO7T6H3wfnj0nml46bV3sGzFH6HyBfnKjmMBwsIEO37lEVe6jEGYIDPjzgku6kjnbpJ5EonTEpE54dJmyisE/OrLfmYBLUJ3OW5KIuT6HCUvyUvyKn9e4sRFYlcj55VHUMX/L0vMnb8Qr7z5HiilOGj/bvjsq++xectWLF/5B3rs3SlC8gaEca3lK1dh+cpVuHHKWBBCUK+qCvt07ehJN3jEWMy6cyoab78dHpz9FOpVVeG0kwZg7vyFeOr511BVWYFLx4zAkp9/w5uLPsIXX/+Ag/bvhsvGnIHnXn4Ljy94EYQA484/HT337YrRl09DvyMOxtMLX8e0Ky9Cm9YtAQDvffQ5Bh1zBGKxGLp2ao/3P/4Cbdu0yvhmPaJqyoxAzGyEbOgIr5NVRuJHyNWUIoAzRk1cJ7nzjnSiwt0tDOI8Z5cTkleGyDRbbT5HyUvykrzKj1fgBYrVruaFV55AFZ/rhHs7/r1mHS6bNB1r1m0AJQTvf/IFdtuljT1Oaex5w3HVjXfjvllP4oKzTkaD+vWi425C6BwtXbYSHdq3s4lkiocffxoLZt2KeNwofr/ue2HRB4tx9vAT0aNbZyxdthILX/kf5tx3PaprEhh35c3ouW9XAMBX3y3BrLumOq69dt0G21EyBl+t91xzwXOv4qnnXwUAMOEKYv7yF7WoEIQUAQI4pnQImz4CdqJmkyi9qGM+7d2KrieqqABeGcIvG/8cCSGe5ypqffo8ekHhIZNl4elKXpkhn7wIIRmLZW3aiZzS1yIvP5vqSCPYKern6OczFKtdzQuvPIFw77Us0KJZEzx27/W+51vt2AIP3H511uWHQV4GZB939GGYNmMmzhkxFB3b7+o5//Fn32DlH3/irIuuAgBs2brNPjd4QB+PU0YsbxiAznTh4Kuhg1Ij3lVVxaEDRjoT8M0IlzPNCIxIY1AQhAWkEzQKhMrOef3GPZkF8k5+OSBAJ3zryz4ZXHS5VJFE/uDbCBfJl/tYbduJEuKVT90T3JY4EXwSZlhfMM0uIdZ7PPWOkYgAOUaOigFC52iXnVvjhyVLwRhLGz1SVdVzbNwFI/DDkl9x672z0efQnjh5cH9PmqOPOBgXnzvMc5xS7zCopk22x4rf/8Qeu7XF8hWrsMdubQM5WWDcb5Az7TEO3DFbxwSGxZ03bNjX0EViJiYQtwhKF0EyE1hfhIsgC/IyBrASUi6JwoCBQDh5xSVfRHSsEHaiFHjlWfcYd+W05jCK+jLTEKuhWmY2uOAoA+dIOCC7bZtWaLVjcyx47lUwxpBIJPHsi28azhIIdN24wSbbN8J3P/6CzVu24v2PvwQA1CQS+GHJr+jQflecPLg/Pv3cmKHWskUz/LV6LQCgR7dOeO3t97F6zTowxvDnX2sCSR58wD747Kvvoaoqvv7uJxy0f7eMblL4smXcMVHkhqR+RI0Udzq7BRaSECEEhBqKaf/R8vijpqER1V26+rINl+AcYwxMl3/F84ci4OD6Y84uIHd3UJB8FdJOFDuvvOqe+cwYY9AZ82kYRf8cCVL2qpzsb5i/vINQ/78SgW+32pTxozHj7kfx9Auvo7KyAqec2B+EEOy/Txc88+Ib2Kvj7hg29Fhcd+sD2HP3dujV03BYamqSmLvgRSxdthJJVcXEsWcDAPr1ORhTb5mJz778HhPHnY2zTx+CMeOvR2VlBY44ZH+cOewEX5JnDjsBk6+/C88sfAPH9TvMHn+UDkGRYka8RsPRFHGHMLjEwhYYlyadj0RAoFAC6BSgukGmdBzqtAgzVs1dX8RxAnbd8+d0xmzHXKLAIEBqYInonAu19NisoQ4KR8JPvgSqXet2olR4Mcag5UP37IgWAbieirQ9ZxHUFyEAJQClwmacRC5QSj9y5OscNdquAa6ZMNpzfOSw4+3to3ofiKN6H+hJc+3EMZ5jB+63Nxb+5257f1D/wzGo/+GONPdMnyTksn2jhvj3jRP8qKaFR9FYQBSVeH/50K3jXBYgMK6tUDOUy6jxB1Y2fd4K1zLJdFC/6FlZhk3XGTQ93NLzEvmGKFxReFhdJDHF3zS7/G/hOetAbdmJYueVT90znhk1nSPDWfF1AF28gOzrS6EECqVQFGoWUlyyXNIgFGXrHJUT7EZugLKlzZ9JeiZQUG6fEmIopA5DIRUKxzdyShzWuLHQC75xrVx+tVzr17BbDLquh/4uj0SewU8V9kSO7HBDbTIyLk1pagVkk4affBHXS7MQdqJUeOmM5U33CKUg1Ohio9Qa2+SdnRZ1fVFKbAcpVZpEJCCK+AXABPaiSFEnnCOPp0L8T/GRClECQbe+51zg8vRm37ZC+dZKeTlHisJHjlItu7T15TJwjE9IzNardI6KA9YgVvtDma5zADzyXBvizQzn3NMFI5IvAmcXU6HsRAnw0vLVMCGGG0RgdJkrQGqZHtF9R1hflBDEFALNihyVif0tClCf8UVMB7Tap5MNyts54jqjrRaGuzfAYUC9mx4LIjL7VrFhW2iUEMRiXOSo3JwjbsahX2A1bH0x01ISGAZalc5RccB2jnT/yJHfmKR80mKA7uuOu9JaG5xAFoOdKEZeus7ypntEISCMgDEdAAFjihE94iZ2BOa3NjKpL6S61WKK1QdbHva3KOA7AzCb2GdhUN7OkaiFAdhKJFQgn7e5u/87TYMmkBIhxFBIar5ciGKGG8tDORXF7FZDSj+yrS8+naYzqFqJNDvKHdaYAqbD81KxVv11oHZk21g2jBiqFNYOF6GdKDZeRsMkH7pH7H9MZ2YQksGYF51xUY7NwPpiRpdaTKHQHQ1ViUhAFZ/IkXSOigtcq8FSGMbv8y0OQUjXMzCQMzaWEeaVMB0USlARVwCdAIzC/sZOmShnLGbOFSKG0bMNEwLqi4irz15fhRBomoZEUjpHRQFroAfTvXJbyDFHCgEF9bpiPvLlOFAIO1EivDRVz5vuUWY8M03TwBRqD0thEKyzF1V9AYgpFBUxCsQU40SZ2N+igHSOihyCDnbCbYviyfanbnj77lY8ztjYjWS+dZKGFqUEsZjlHJmRI/e4jRJGLCByFFRfDiPGlWdtq5ouXHRUojZhPdAg58iafckfZNwvcR0DvEopyhuGHQElVJjFLV+2Q8BfvgB2ohR4qXo+dM8gT4gOSnToGgMhxlpHtlPkE/XKub4YEFMI4goFiylgZbacSsFRYmsaiVDezpEILu13643712qF2S0QvqWWKsahjA4dczd8iDHmqMJurVCAMs5ClT7iivHlZaPb2esqiupLtPYKAHvhUQDQtPy1XiUyATFkllBA1+BwhAjgGwkNlPF0DlNYZgoUooNxih4kX16F5S5ZC3aiVHjlTfcIgUIoCKHQVd0e488YAyPE40pHVV8AEKMU8RgFi8dMOZaIDDJyVOQQNUC5hq+Vhm992BNwXE0VR4PE1RJzh2799NQCpQRxPpRLrRdJeThHMW6RGVfD1re+rHNuI81YSp9UVUNSOkeFhfWwqGIoka65ZNd6+wqcI8uJSucHifQ2LD2iQSeK49JB8uXRZ3e6PNuJUuGlannQPZOMRnRQyqCpGggxlg2gjhvjkrt4ZVtfgBHhjscUIK6A6emstkRGkJGjIgdz/ABw2WC3/lmK5DYecCmfKwRNwL0HQugYpdQYc8QowHRAL7PIUczbrQakqS+fF6LhIBkJVE1HIim71QoKSxEoTOdI9TpBlHrl2UrDmI9zRLznQZx5w9AjMcSo7sziI1+2TnP67Lpy/u1EifAyxhxFrHsEAKFQqAZKjZmoCiX23BRPkCHi+oophBtzZHYFS0SDIosc/bHqb7TasUVGecrbOeJbF2arytIOuyXFnGk9Cki4NJbyEa+OuvO49Yy3OTFKUFURhz1eQ7eae+WhnPF4DATG94qooFsNgLe+gFTLF6n64scfJFUN1QnpHBUcBEa0k1JAU+GJHFnOEXNP/Wb+Ii50mATH0oASFRqNwfGFLh/5AuHsAgpkJ0qEV950jxDESAwKNSJTCiHG99WY+c01EMeAczevrOsLQEWMojKugFbGAV0w61IiaxDfdY5qnwsAXDzxRrTcoRkG9D0MRxyyP6qqKtPmKW/nCOazIJy/QlIKBf4Xzn1Ri0y4SwKet8gvIARUoaio4CJHmnnFMpktEY+ZY47gasWaB4PuknHp7CoxDyZVTUaOigUKjNahqsIpu8T4rpJnaYrakW9KNTBF870UL1+8jhfUTpQAr7xFbQmFHtOgKAzJpI64ohuBdMuP5r0eAa+s64uZs9XiCkg8BuHEAomsYX3GR3Cm1rkAwPxZM/D1dz/hlTffwyNPPINuXTpgwNG90W2vPX3zlLVzxJjRUrAiecR9Dt5WlLuRYre2eB11t85E4V4fEBhT+SvjMdMC6IBCykoxK+KGcwTioyR+9WUZNe48Y8aaJ4Ax5qgmkcwTa4lwMB+SToyuNVUQOdLMbT5yZK+kLVIepGTEN3IUTj8UWgEW08Xq5JIvwus2CmgnSoBXMi+6RwBqOkcxDUlVQ1ylRuQIKcPtoRdBfREAcYWiMqaAVsTMyJFEVCDWt0PdKOCA7C6d9kCXTnvgi69/wIx7HsNHn36N1q1aYMIlo9C2TStP+rJ2jpxWwnsKxHvaVjQuq2VYmOs8AE9ftp0mAAqlqKjgnCO7W608EI8ZYkUAx+dDgID64gw4cdUvM+smqWpIyG61wsIyeAoBFAYkRZEjs9nv5xyJ1kFyjDlyO9PhdYMqGljcmq1m5YdQvuzLBNjrvNuJEuGl5kP3CIEVOYrFdSSSOipiutmtZooQdx9RP8d4zIgc0XjMXJ1bIirQIutW27hpC158dRGe/7+30KZ1S4w97zT06NYZn3z+DSZdfxceu+c6T56ydo48uuJqgrjtsG0o+MiF2TKx07oMiX0tqxVj5vETAkKM2Wp25Ag6oPFNutJHRdyYrWaMOTKOpasvwqXht/nvFBqtV+kcFRTWWyZGjO5gK3LEOzCKue1ojbNUOpG4ewZkuxQ1JGhMBVOd3Wp+8mVx8DRwa9FOlAqvpJYH3bOcowoNuqqjRtVQqRqLQBpda84bjrq+4oo55shqqJaJ/S0GFFu32imjLsfRfXrhpinj0KZ1S/v4ft33wo4tmgnzlLVzBDhtbdBiYnyvgGcgH2dJ3Lab8IVZm0ysZlaSmEJRrzKeUkhdRSZdB8WOioqYHTVyD8j2qy/+MD+Y0mhFGomTSQ3bamS3WsFBiOHQKwCSSYFzBBgPL0vnCHAqWQbOkRJTwSp0O9oI+MsXH3UolJ0oFV550T0CgCjQKlTE4jpqEhoqYwo0naW60zkHJ9L6AlAZV1BVoSDG22KJSFBs3WrXTb4Y+3Tt6Dj20eKv0bNHF9x8zaXCPOXtHLlaCtb4I0fryBWqEI7/446J8jJwiss3bQQgMLrVKvnWSpl1q1XE+W611DeSAuvLAmfwAFHkSDpHhYVp9HRqOkcqPB+fVSzPll8Xh3OO7BAF/7bjHSHXWy0T56hCA5KaU/185It3KgpmJ0qEV150jxCA6GBJDbqqoSZpjDvSGXMMyrafZZT1hVTkSLFmDktEhmKLHN1+32w8erez6+yO++Zg7v03+uYpb+fIsrfWJoEzfIzUNrg0jsarY8OZnoejlRJkywmBohCBc5QuY+mgImYNyPb/eKSnvtzNOuuUOa0XkN1qRQOhc8S9XWOmEvHOkWNAtk+ZdrqAY2mgJDUQVbdfrPaLUyRfzCmHBbETJcIrb7pHFcM5SuqoSWpIqOZsNd4WOkJEiKy+4jHLOZLdalGjWMYcTbtlJkAI/vxrDabNuN8+vurP1ahfv15g3vJ2jnjwLSwTvDHglcu9iJrHmriOWQbYDu/amujNSmBEjqoczpHoW1SlCz5yRN0tUfjUl3nCfkzM/FA2YNdLMqmhWkaOCgyzRcjMbwMmVO8aMVYkVOgc6XC+xvhyrXRWmIMLh4RELKGCJDVHt5qffPEvzxRPK4E3e17sRInwUtV86B4BKANLamCqjpqkbjpH5oBsxpwmMcL6Akk5R7GKGMrJ/hYDouhWe+bFNzD/2VfQsEF9TJ04BjtwY4N+/W0lptx4N7Zs3YYjex+I0WedLCzj2KMPAwB8+vk32GfvVLdaqx2ao2tn/2n8QF1xjgQtDpdZ9s3naX3C9cs1mB3KJ4KZwOhW48ccmS+RMulai8djRncaARzfVguoL79uAp2zWTJyVCSwnCPFco7M76sZJw1n3+EcMaSNHPk5TJ5jwdCSGqjqXSFbKF9IHzHJt50oFV750T3DOYLlHKkaEqoG3R5zBDj6CSOurwqzW02zxhyVif0tBuTarbZ23QbMnvc85s68EYs+WIy7H5qHayaMts8/PPdpDP/HcTjikJ645F83YvnKVdh5px095fTYuxMAYNqVF2GvjntkdA91wjkSPSOPIsFhJ+wNfnC13cIiAuV05QMTiwEhEHSrldfS9dY6RwRG5MhhnH3qi99mgD0GwtmtpqJGDsguLOwpT6rRfZZIGpEjvi/H6ibWuZep9fJhOvy70IjzvC0s4ceDaAkVNKnBvUK2UL6IU0cLYSdKhVdS1aLXPUIAqhtds+aYI6tbzRpz5EwfYX0xI3JUFY9BtW2xRFTINXL04adfYc/d26GqqhLdu3bE9DtnOc43qF8PjbdvhHg8hnY774SY+bFzNxZ/8S16dOuM35b/gd+W/+E5f2zfQ3051AnnyIbrudhhZO68Izzrtt2iNOAaN6IQtoCCYs1Ws1rS9oDW8lDQygqzW42QVOQog/oi1n9W9ZjHE3K2WnGAUCNypBGgxuUcAUDcihy5nSPX2CSRgvHnCVzH0sPqVtMDstjyBYhlsEB2oph55UX3TOeI1WhgSR3VCcNBsj8fYlIKjDXmUF/WbDWtsiLVUJWIBLmOOVqzdj3atjEiQc2bNoam66iuSaCqsgIAMHLY8bhk4o045shDoTPd97tp7370OXp064y33/vEc44QUredI9HkFwt2dIJwppo3GqYh4e2GrWC8DXc3dNNwsmereZyj8oA95ojAXucoTH3ZLVuk0ljjDwA5W604YD3AmBHxtLrVeKeGKQLnSE/JuvDtTVPprPO2w5RB5CipIaY6p/IHyZctgwW0E6XAKz+r0xNAYSCeyBHj1jni7kfAK9v6AlKz1TQZOYoc6brVhp8/0W44DxnYF0MH9fUkc+iwzhzFLXxlEU4efAz+Xr0WS35ehs1btqJhg/qeq110zjAAwE1TxmV8D2XvHAkje3BGJ1z6lcrLhaAtg8IrI79ki1WwveiaLx9ifD6EV8gy+65PPK7YEXs+chRUX7Zxcxk2xhlJOeaoSEAoANVwgvycIzDjo7QW0jpHpsTYjhBJKV0GuqElVcSSzkUg/eSLXxOnUHaiVHjlbcyRAlBVAzFnqyVV3QhEWpTy9BwZUgOypXMUPdJ1q8257wbEYv7uR4tmTfD1dz8BAP5esw7xeByVFUbUqLq6Bv97/xN7an51TQ3+996nwijQli1bheXrjOGx/zyPMWef4suh7J0jEeyWB2d/nW9kc584lcqdxp5d6pfeB4pCBc4RgjOVECpiMcszMsYcmRUVWF8m3OrEB7uTSekcFQUIBYgGMNXrHBEAMCNHvs6RqEy+6Q+nYc3gxaUnNMRV3alJPvIlbNi6s+XbTpQIr7w4R4QAGkDN5RdqVN0YkG11q9kekosMcq8vAj5yJBeBjBq5Dsju2aMr7n90Aaqra/DZl9+jV8/umDt/IVo0b4LDD94ff6xajRW//4kdWzbHshV/oP1uuwjL6TvkPEPOXY+WEKB3r/0COdRJ5whAyhBYSgOkltMgdhIbHtvCt1z49O6EzksC4D48a8WGy2wBsjg3INuKHIWpL1HV8UZSdqsVA0yjR9yRI1OGCTGcJj5yxA/GtiJHlsLZxbq61fi3dAb6oSc1xFXXVH4TQvkSHPPcrpkwX3aiFHjlpVuNEEAx1qaimrnOkeb8tprFg0cU9QWW+raaLiNHkSPXMUdNGjfCyGEnYNQlU7Bdg/qYeuVFmD3veRBCUFERx6TLzsW4K2+GruvYZ+9OOPqIg4TlvPfy7KzvoeydI1tpGLfPN0q5VpV1WOTkOFpofBjXbUysdD4gxFznqDKWihaVmWJWCsYcidYj4evLs4gbMxwj51R+FdVyQHZhQYgZOUqazlHS1a0GgJkvG417VlbkSNe8USLALBPGNCVbuZBx40FLqogn9VQgIEi+eDuAwtiJUuGVVLXodY8YC4nShAaSNMccJa3Zatx0fvtmI6wvABUxiqoKBbpa9q/BWkcU6xwN7NcbA/v1tvcvHT3C3j6s1744rNe+actQVTWw+y4IZS8VxL3BN0eIw34AJKVwvk0TQYjXcR6udAIoCrUHLafWf0l3J6UDY8wRAQETzlYD4KkvR6uOS8+49UeSqo5EUnarFRamc0Q1AManOqCpcHSHEXOf71azZrQxDQ7HxxJ8O3LElWN7NuG7PJg5qNeR2ke+iDOJc6OW7ESp8FLzoXuEAjoQUzUoqo5EUkPSihxZVB2LgkZXXwxGt1pFTAGriJVb+7TgKJbPh1x53Z24aco49Op/uqennhDg3Zf8I0tl7xzxcLQiuNaSo9XFGxGSst/ufKKy7WsERY4AUHe3mt3MKQ8NjZmfDzGm8jNhlXnqi2/l8uk4v1HVjNalRIFBKKBYzpEKaK5uNWJGkjRucVPPmCNXC4KY3WmeAdnIKHLEzO9zObrVAuRLWAZq0U6UCK/86J4OxIjhHGnG6thJ69MvIn84wvoCMz4AXhFTwBwNVYkoUCyfD7ni4rMAAK88NTPjvOXtHDHntjUwyz2IUTgLwhG7DSiawJ4NYidNFzkixF4o0WEFykQ347HUglz2mCP7gE99cb98lTOkbFZeWq8SGYIYjoyiGk6QHTninSO/yBE35giA0zmKZio/VGPciuM95yNfdhDFJXC1aidKhJeq5UP3CMAIKlQdMZUZzpE95oiLHnHJ3byyrS8jckRQEaNguvx8SNSIolstCjRtsj0AoGGD+tiwcTN+/nUZqqoqsceubVFREQ/MW97OEQ+XveUitc7WiEvj/GZC8F989ssrzEcIKKUOB6LcWixxhRuQbW6kqy/Ht6G4NPy4A1XTkJTOUYFBDEcmppnOkTkgW3dFjsAAlYs02M6R1a1GnA0DQo3jvJNlvwVd324LYqfqSKqutD7yJVTtWrYTpcIrL7pHKMAoEqqGmKYjoelQtdRHgy27aD/NKOvLjBzFYwoYU6RjFDGKpVvNwv+98R5uuP1B7NC8KWKKgm3V1bh+8iXotOduvnnK2jnilSr0MyHeULUwRE1SxsRtZNJGjux1juBKWB4aGo8r9vuPcsYpqL6EdQ3r/WnsGTNmZLdaQUHgco5EkSOzm00UOdL11BuKbxRQM2LEn7dXAs0gcpTUkNS8H54VyRcx9/nt2rYTpcJLVfXodY8Y3Wpxc+HOhLXOkWgwdsA9ZVtfxlR+Cma/BsvD/hYDaJFEjiw8PPe/eOSuqWjXdicAwEeLv8b0O2fh4Tun+uYpa+fI0WpwNyY5RbNDr0DKeDAur+sc4wwMX3zYx04pscfllFvUCDBaZHbV8woSor7c47f50Lqm6VBVGTkqKIj5VlU1Y1C2qnnHHFHXmCOAc460lPK4I0ckyDkKpydU05BUBS9Wjr5Zui2EthwW0E4UO6+86B6hAChUTYeqG11qRuQoNZU/1Thyssu1vgDjG5cxxfgUTvlZ4cKC2P+5UKCKbrRdQ9sxAoCePbrg3ofnBeYpa+fIAeK/62412arozkOcv7zK+gqDgAalBPEYdQlK+ainonADshnjbXNgfYkMtKNbTTcGbEoUEASmc6Qb0R6Rc6SYzpH9rJgrcmQpEB85Mn9zjBwR1XjRWi9XXp488iX0Bvx382UnSoGXlg/dIwwANZ0iZvzp3PIdPiYxivpiAGKUQFcoGBT/i0lkBUoJ123AI2wIIRpYK2Tvs3cnLHr/U/TYuxMAYPnvf2LvvfYMzFvezhFzbhLAXmreE3rmEtoNW37fVYaVl2+g8du+IIbT4PyKMCsr3Ywp3CwFd91xh0XbjlawBfOkpjGomuxWKyxMwdc0QNMNB8hyfKzzijkzjR9zxDTzU+vmmCPjYOq89aXYHBeBpOaL1q1QaeVLoOO1YSdKhZem6dHrHiEAFCNypDHzV7cjRiKTGGV9KZQipjAw4m6oSuQKRfFxjvwGweUJfitkA8B2DRtg3AWn++Ytb+eIA+EMgnFAEKUQHOdnOhDumMgREq4vIgAlxOlApK5eFlDMezNttANB9eX5WjicRlLXdagyclRYWJEjTTf/NO+AbM10jrTajxxRTYem60JtEumn+1Ah7EQp8NJ0Fr3uEQJAh2Y+M1XToenMHC/mbw+jqi+FEjCFghEZOYoavgOya9k5kitk+yHgORDAYyF8X+SiZ8xro7UtsPmi66bGHJVXxMiCQs03HQGIWSnp6ou4z3G7FvLSepXIEMRwZFTdiBBZThIfOYqZ+35jjuywRZrIEaEI/B6bAFbkyLHMkZ98cVGWgLvNq50oFV66no/IkfGNPqs7TdWZ6RzB8cFpC5HWFzOcI4AYkSOJSFEs3WpubN1WDcY1tho0qO+btrydIxMMXGOVILVII3Elch/j8wcd8Hmx+4GQlGKWIyjXOhAaaL/6IlwYnLeL5o7OGDRNRo4KCivsoHOOka77RI7sTpCQkSPCnScwFoZERpEj3XzBirk75cvdiC2YnSgBXrqeB90jAIgRNdLM56brzvWNhDGkKOoL5gsctFATqMoalMLHOSoM3lj0EW656xFs2LjJlpkdWjTD04/d7punvJ0jUylEdkCUjsGlSO7QbGAh3GmSLnpEUtEVN4kygDVDjQChDA8/JsLdCuYHZAe++CRqB8R6W7LUn8ZSAm+8SY193qmxnSPGP9zUecaMsnXzdciH5TN45prOoLuUz1e+LGdAoOe1ZSdKhZfO8qB7xJAH65npOoPGmCdiFMQrl/qihBhOOaMoJ/sbDvm932LpVrMw85EncdOUcZgz/wVcfcUF+OmX5fho8VeBecrbOeJaRPaXqwHPiqnWOT8j4m5QORoiXNlhA0HGQpDuxMXjZecKwez9VB361JendStqATMGPZM1bySihzWVX2cpB4i5Ikf2OT5yxKW3Rwxzz5LCEAzrPC8QmUSOzJes+/0aKF8FtBOlwisvukcoYDtGMJ8bc3B0I6r6svxvCsHN1wnkd3hCsXWrNahfD107t8eubXfC19/9hP336YK7H3wCo4af6JunrJ0jW8HStJ7chiNo351e/BJPQ4w4u57KDqIGQ8A54cwTAXTmjQpI1DIYAMo5P/yvdT41aCSViT9mhTiEY46YU+ms8kJCN6eCOyinkS/7cgWwE6XCi+VF9wwZsMo2/ky7bf+m7iDK+mIwbDCzlgqXiBS+Y8AKVNXNmzbB8pWrcMShPXH7fXOwdNnv2FpdE5jH1znasmUrbrtvDr5f8itiioJThxyLfn16YfTl03DROcMCl90WYeotMzGg76Ho0a1zRvkAYOUff+GWux7Bl9/+iNeffjB8RubaNhu9ALytKv4819LwPEvXeUCQhwTbcwIUVX9s1BDeWZr6ctcr/661i2AMTHarFRYEqe40fqU+67kQeJ0jPo3VrcZcSkI558jKY0eOwj9zxryznfzky29wb23aiVLiFbnuUUMe7F5YZjw/v7BRpPVllSesJIlcQSgxvq/mAgMpSAfmheeciu0bbYedd9oR/fscjHc//AwXjjolMI+vc3Tt9Jno0a0Trrz0HFTX1OD7JUuj5hsaDRvUx+n/OA7/vGpGRvkcrQzi+uV3meC8QJkcisifJ+6EIbilT1JeSFdfhDsHiFuI/nZTorZgjYTl990PxfJNHGOKXOcJ8+axvggKlpEuiS7tLdtfvgpqJ0qEF4P/quNZw3ZirdL57lDB1SKsL0IIGLdArUS0oAHOUSHmG7dt0wqA8Y3A4489Ascfe0TaPMI5jMtXrsLylavwjxP6gRCCelVV2KdrR0+6wSPGYv2GTQCAB2c/hbnzFwIA5s5fiBNHjMOwc67AJ59/gyeeehFvLvoI19/2IGbc/SgA4LmX38IpZ4/HqeeMx0efGgOjRl8+Dc+++CZGjpmEFb//aV9n+0YNs4o4ueExnILohBsifROe504ayivVzgJfF3715TrkgHSIihFcZMh12LWRcnj8nCW/Y9k8eAGndPIlSl9bdqJkeOVRCZnrN126fNaXRDQghPj+FQI//bIMZ110FQ4feBb6HD8Kk667E2vXbwjMI4wcLV22Eh3at8v6Rh5+/GksmHUr4nGj+P2674VFHyzG2cNPRI9unbF02UosfOV/mHPf9aiuSWDclTej575dAQBffbcEs+6amvG1Fzz3Kp56/lUA8J/tkPZAtMhVEMKOxXG0+qIoL6pyQvKSKFWEfLh2ZII433B5eUuJQ47ZDJcRvljDlhMyXTnxyhVRm4p09j6tfS5xuxpYXp6fb1DkqBC47tYHMLBfbxzaa18oCsX8Z17B9bc+iFuuvcw3T14GZB939GGYNmMmzhkxFB3b7+o5//Fn32DlH3/irIuuAgBs2brNPjd4QJ+snIqhg/pi6KC+AABVVXHogJFp81gyFvpyPuncspqrokhePsVIR6vw4Ptl+K4LT7OecDvMmcg3hMH3mZBUf08mhtykxaxuPRnBjQZ5qUZi/m/8A0jg4ypV+5UOxcorFxSbc6QzHScOPMreP2/kSTjtvAmBeYTO0S47t8YPS5YafbJpalj0peZxF4zAD0t+xa33zkafQ3vi5MH9PWmOPuJgXHzuMM9x6ln/Jz9I63yLEnDHeHPvfgVIXtHxcnYLkPKe5VcKsNYvsXwfSmDMmybO84DTUeIdnqD1T6yy7fw+6QPoGT6WOWtNzm6MBHnRPdMjIIQXK5J67hFC2tXahW8XWoHsd8c9dsXylauw8047AgA2bNyMXXZuHZhH6By1bdMKrXZsjgXPvYqhg/oimVTx0mvvYNAxh4OAQDdnLTTZvhG++/EX7LN3J7z/8Zfoc2hP1CQSWPrbSnRovytOHtwfL7/2Dk4e3B8tWzTDX6vXAgB6dOuEcVfejGFDjkGzpo3x199r0XKHZlHWhQMiYeH37TGmxJvAzms2YD3f7HGlcUuo1Xj1XclV8vLl5QYh4taIRC2D8m8z889+LuY2Y6ljDCknio8oiZq5Vh5+LnAGz5wSAgpif34igy+PSKRB5Lpnyg01X6TUcpTcaXiUkP0qFV75QLFEjkaMvhKEAFu2bMM7H36G5s0aAwA2bdqKHZo3Cczr2602ZfxozLj7UTz9wuuorKzAKSf2ByEE++/TBc+8+Ab26rg7hg09Ftfd+gD23L0devXsBgCoqUli7oIXsXTZSiRVFRPHng0A6NfnYEy9ZSY++/J7TBx3Ns4+fQjGjL8elZUVOOKQ/XHmsBN8Sd7/6AK888FiVNckMOKCf+GMU4/HkYcdELqC3J6153zA8yLchr3NFSay79YJxh0TOtGSV2a8aJmvD1UK4J0hym3rxHkelHuYMM9zzhTg7C6zDKnOnSfmysV6+GduvWCZbi5aKJ3pSGA85qidI0NGKCW2OFnX8DhJdp4Stl9FyisfKBbnaOz5w7PO6+scNdquAa6ZMNpzfOSw4+3to3ofiKN6H+hJc+3EMZ5jB+63Nxb+5257f1D/wzGo/+GONPdMnyTkcu4ZQ3HuGUP9qPqDM76iLzmnC1n6HhI9X8tD5077JuOFWvIK5MUfo4SY36STKBhs54iabzMKc3nr1HlqPlhHFzlLRY7svi9m52NmWgIzGZeOWPlDgFLjZWt97kJ2qkWFPOieKUfUjBoZzw5ph3KUkv0qVl75hl/veW2T6bF3J8d+dU0CAFBVWZE2b1mvkO2AKTBwhS6FoUge6cKjAusbJOueS0hevrwMHsQ+RykFVeQXtAsLl2OkWA4PTZ1XKMB0GN+sghnLp67+AGKksd8aVjnc+cA3ihjU7KbRdd2IHMnVjyMBIYhe94ghPwpN/VFCPPbI2i41+1XMvPINJYLI0TMvvoH5z76Chg3qY+rEMdihRWrozZat23DDbQ9i6fLf0bJFM1w7YTQaNKjvW9aatesx9ZaZ+PSLb0EJxT57d8Tkf56HZk0b++Ypb+fIpVUOYXQLG+dmOwRI8Cz5Q3zIUpTcuo5D8CWvcLys82YGhRLEFMV7AYnaAwFAFMMBUiigKEhFhWA8K4Ua+4xb7k0HJ2eWUPGCQI1z1hghvumZwbihGKWglEDTGVRNl71qEYGQPOgeIYCiQFGooduUQqGUG7tPIDI5QInYr2LmlWfkOiB77boNmD3vecydeSMWfbAYdz80z9GT9dCcp9Fxz10x7cqL8MvSFahfv15gebfc9SgO2Lcrpl9zGRhjeOqF1zD9rkdw41VjffOUtXPEuF+r8emwzwJvHAjXUrHT+nj5jgaxddgUTuu05BXMyzIi1iFKKWIyclRYEGI4Mgr3R6jTqVGoYY0Z96ysb1g5nCPOSltdcPx5fsxSSFgvWk3TpXMUIQznKOrIkSErMYUgRgkUM4qUmtrvQonZr2LmlW8HKdfI0YeffoU9d2+HqqpKdO/aEdPvnOU4/9rb72PeQ9MBALu1a5O2vBW//4kbrrrE3j/1xGPw4iuLAvOUtXNkw7LFcAocCAIj9g4vO8hOeyQ1kIbkFZKX+5SiUMRiMnJUcFAKxBSnc2S/N32cIwqjG413onjnyOqWy3G2WkyhUAiBputQVU06RxGBEkSve5ZzRCkUxXC+FIWb2u9J71OMz4FC26+S4ZUHWDMQ3WDmseHnT7TPDxmYWqPQwpq169G2jTHtvnnTxtB0HdU1CVRVVmBbdTUooXh8wUt4+92PceD+3TD6rJMD+SgKxR+r/karHVsAAP5Y9TeoElwTdcI5cnvtDk89jKQQl9xxO7Zwu44LkqbSS16heRGSWhhOoRTxmIwcFRYEjshRTDE/KMs5NTHFdHy4l6lOjCYrNcsAwEsdIxQAMT+5ZjhGzGxWuz/DFgTrBatpOpKaLv4+kkTGIIREr3vE6JaNxQwHKW46Sr4z1TiUiv0qVl75hjWR1Q2rJ33OfTcgFgtwPwgcX7pgOrPL27q1Gus2bES3Lnvi9H8ch7PHXo0jDtkfnfbczbe4s08fgrPHXo0DzC9xfLz4a0wcd3bgPZS1c8SbYMIfsKQUZuhTJNGufeIpzAm3cNo9CK5mAs9D8krDy5U1JiNHRQDTOYop5h8FdEXgHOkQOke28wM4Xh1W5Ihzjuw+hwwGVcfMbjVVMyNHWd6lhBOUkjxEjkznSKGIK8ToXlPMiIP5+B1PvtTsVxHzyjdyncrfolkTfP3dTwCAv9esQzweR2WFMcOs8faNEI/FsHfnPVFREUf3Lh2w8o+/Ap2jQw7cBzNvvcr+jutZpw1Gm9YtAzmUtXNkwfdxEJewMlPmiDMNUqc9nrmwbMK1EtxlMeeu5BXAy9y3wq+xGEVlvE6IbBGDGN1qccX8i5mOj546H1cARpEK+ZhWmlHnOkZ8y9B0jog1g42kDCnJYCVHGjMiEKqqoSahym61iEAIiV73TOeoIqYgHqPGr0KNiZC8weDGnpWU/SoRXvlArmOOevboivsfXYDq6hp89uX36NWzO+bOX4gWzZvg6CN6Yd9unfHex5/jwP264YtvfsAJx/YJLG/qLTMx+Z/npXWIeNSdNw0XyrQapqJjxC89uHMhnq89CyFdPFPyCuTFz1iJKYr9MWOJAsKOHJlOkg5xtxrhnBpdNxwoOwrkfnOYAsU7WbYTlYlzpCBGCVRVQ1LVQGujmVwHQCmJXvcIAZQY4qZTVBGjiMWo4RhxjSLefJSa/SoZXhEj19lqTRo3wshhJ2DUJVOwXYP6mHrlRZg973m7zLEXnI5rb74Xdz3wBAYcfVjaQdlr123AX3+vcSwHkA514k1jec68B80f4z1sO3TptuHEXaDzsHCbO8gAx4QdySs9L8BZTEyhqIjLbrXCghjOUdzsVovHAA2wB18TmJEjBlDTqWEwI0fmn+PJW8Va3WrcedGU/3TsYsaMxqSmI5FUZbdaRKCE5EH3DEe6woz2xc1fQswxK67UpWa/iplXvhHFOkcD+/XGwH697f1LR4+wt1u1bI57Z0wOXVaXTu0x8sLJOKr3gVC4WZeXnOe/gnadcI5E8kV8znsg8vTd5TFOwK0kAs3mFUXySs8LgD1zBTBmy1TIyFHhQajhFMUVQFVSM9EA42HFY6ZzxFlhO3LELfwodI5yixyRmIKYYkSOEkkqI0cRgVIave6ZkaMK00GynCRjIUjj2XvsTgnZr2LmlW+1cN9b4cEwZOBRGeUo/zeNyGv22RcJtLAst8duHuMFE4AjpOkpU/IKxcvZrZYHAy2ROewxRzFAjRmrZHvGHPHOkSkojBpOkmidI3e3Gt9szuTrsTFjgG9S1ZBIEukcRQQjcpQP50hBRdzqVjPGHvHfNRZ1w5SS/Sp6XnlCFJGjKDFq+IkZ5ynvN41LeNyetDvsaR3jD9izCHiIni9xyL9z5VNLkH2EWvLy4WU6RlY/czweQ1VlXFCYRK2CUKDCjBxp1oBsLtQXjxv73ALZRtSIOZ0oR+TI7TARp3CEBKswXrCJpIrqGiado4hAKYle9wgBaAyVcQWVcYpk3IggUUrsRpHbdJSU/SpmXnlGsXx41sKqv1bj7gf/g6+//wn1KivR64DuGDV8MOpVVfnmKW/nyCWYtufMCYv9qAQCY8u2SDBdiZirbHsQnJXMOi5QGMlLzMsKE1vKHY8pcrZaoUGQco5iMa9zZEWOwACNf6Cmc8RHjsBSz9yOFPHOE2fNQxp0PWZ8jiKpaqhJMNDaGGBRB0BpPmarEaNbzXSKKuJG15q1tploQHYp2a9i5pX3brUcB2RHjWun34e9OuyBk44/GrGYggXPvYqb//0Ipow/3zdP+b9peMEjTpng5YRfUoW4zhNe8JizHD6kyVzp3U6yr0JIXkJeAOwPUQJAPEZRWVH+IlvUsLzVOBc5YtQZEbLGHPHjd3Xz42oB3WoMxJi2b57PZiq/Fo+BKhTJpIYE0UFk5CgSUJoH3TOdo8q4gsoYRTKmIB5TzKn8ApSY/SpqXnlGsXWrbdq0FWPOPsXen3TZrjjtvAmBeerEm8blvBvHXKFOAA4pZW5h5sKTjvKCFIJxLQhBuZJXGl5WeqtbLaagskJ2qxUU1vPgI0f2QGszgeUcWYcYTAHSjdW0eUGzyzXcGMJS51POUXgHR40rIAoxIkcASCZfrZXwBaUket0jBKAKKs0B2ZVWt5oZdSDEZR9KzX4VMa98Q4HP50MK5By1bbMj1qxdj2ZNGwMAEokkWrVsEZinTjhHbt0CUsIkXJGZwPMI7X3mzOt+mYNLxx/3FWDJy5eXcV0+cqTIyFGhQQBHt5oeB5jmjAJZzpHGW2eGdJEj+5jDsrvSpYESU8BiFMmkihqdQUaOogElJD+RI6qY3WoKVIdz5BUDACVlv4qaV57Vgh8O4TyR3+v6QVU1XHTFDWi7cysAwOo161Bdk8CEa28HANx41VhPnrJ/0/BDIXj33BFy5F1wd1pBaJKXY8+y7GYrAJywBo4xlbz8ecH5jZ6KeAz1qmTkqLAwH0hFDFBiAIvD6FbjhMEakK1bnSOmc2QPyHa7wFaLksCI9FguDTH/Dx/9SVTEoMcUJJIJMFXPKOok4Q9FoXnQPWJ0q1XEUBmn0CuMKJJCxR8uLTn7VcS88g3fAdkZrFkWJQ47eN+M85S9c0TAhSYFz8Uxmt9MY0+8sdLwWYlTEO2yeRvMUvLMyzZDKq/klZ6XVaY9W012qxUHrDFHsRjABGOOYjEYUSLekluz1dyWH6l9lwVPyUp4B4fEFagKRSKpQYeW0XglCX8YkaM8dauZTpEWV1AR5yJHxOUPlJj9KmZe+QYhBFQQOtILNCB7QN/DMs5T9s4Rb3P552KbYJLat9aHIJZgugTNI4icQLqnYnrGzrglUvIKxcvRrRaX3WoFhzWrLB4zPxNijTniLLkico64yFG6bjVwAmN3yYVEXAGJESRrNKh6ElRGjiIBpRSVSsTrjVvOUTyGihiFZn5fjV8E0t03U2r2q+h55QmUElDRhw0LFDnKBnXjTcNcwgdOQF0CZXnXdlaXnQaXllllc+WAK5txguz5lbzS8hJN5a+SkaPCwnq4catbze0cEc45EnWrMaeAmNmYNW3bPM8P3MyoayyuAIqxzhFUFXJAdjRoWK8yP4tAUuOTQBVxCj1urFFFiNWdThxmqdTsV1HzyjMUn8iRcHp/kaK8nSPbLU8dEi6uZSa1Q6BcPkvgRLFNIiqDu7zl+RP3SVszJK9AXnBP5Y+hsrK8Rbb4YXqrMdM5QtxwjnhTbjtHnGNiNYEDxxx53iXmsfDOkR6LgRGKbaoGPaHKbrWI0KhBVR50j9gDsuMxwzlKLQLp/x4vGftV7LzyCEqMPw8K5BtNm3E/Jl12ruPYVTfcjWsnjvHNU95vGs5zdggIBALkyieSIffCXlbo0+3tE8YZdpHHLnmF42VHjoyDFXEF9SorIFFgEALE4gCNATSeWsPIghKHv3MkdnSMo8R2hKx94//wzhFTYmBQkEioSNYkQZiWPpNEWlBK86N7VEG8IoZ4XAGpUFAZV+yogz0bizNCJWW/ip1XHqH4dKuRWu5WW/XXajAGfPfDL/jzrzVgZo38vupvLP7y28C85e0cAfYLlgEOYbNlRRBy9Jhi4jzmWf0UKWG0hmSIZg+4PX/JKw0vGIbRUuyYnMpfBDCtsBIDFAUgMVfkiKSJHLkftLXldIQc3WoZOEcqVaDq5jpHiaSMHEUEheZhKj8IQCnicQWxmPG9PvdUfvcg5ZKyX8XMK89QqPEJRjdqe8H6qdNnAgCW/74Koy+fZrfNWrVsjovPPS0wb1m/aSxBtH7cC25ZHrc7kyj86DjkKse+DH+ME2Tea7fHm0peoXhRLo8xIFuOOSo4rHFFVAEIvwCkCcVc54i5nSPu1wXOtXLs88fCIAkFCc0Yc1STUGXkKCIYK2TnQfdM50iJKSDmekf2eCPR+JQSs1/FyivfDhL1GXPkvdH84u7pVwIApt0yE5P+eV5GecvaOfLIlnnAng3ACYhomqWVxjrHP9a0As2VZe+yVB7JKz0vmHmcU/nLWmRLBMSYqUYVo2uN6c5nSAWRIzAzTXrnyJ0iE3OaYAriMCJHiaQK6NI5igI0L5EjAIQiFjMiR0SjiCvUMc7Q8exLzH4VM698QyHiMUeFGo+dqWMElLlzBOYUJM+2qJmKlCDza1Q4YB1ze+5EcMyVz+ZFvIclL0G5HKG4oqBCOkdFAMJFjhgA3SkT1Pyomihy5NdkZZyhZ86UmRjUCl1BnMHsVlNBpHMUCSgh+dE9QhEzu9WIrpgfnoWjOz2VtrTsV1HzqiORIwvvf/wFZj3+DNau2wDGmD3u66lHb/PNU95vGrf37TrGpxM5UZ41I9zZRcLnPuZK4Pb0Ja9gXoahNLbjcTmVvyhAiBk1UgCFwdNVRhU4F3wEjAfLfI2yq5HreywdEpqCuMaQTKqoTiSlcxQRKKX50T3TOVJiFJSlZqtRzpbwvkOp2a9i5ZVvFMuYIwvX3Xo/zjjleHTptAdiipI+A8rdOeJgedieMKSP0DhWHCXOMnyFTOThu1sFrrySlz8vAoBf6yQWU6Jfa0UiM1gPg8YM60ctJ4gTJErNXTNyZBtE5pQHn5YyXKczsekVhCKu6EiqOhJJDURXM8gt4QdKSR7WOQJACBTTOSKMIs4PyHaNOyo1+1XUvPKMYpmtZmGnVi1x0vFHZ5SnvN80AkEQtkJcWQifjsB+UVsHuQ+He6KEdrnWBqckdj7BxSUvLy/eQQKAmGIsGCdRQFgPlioA4Z0jPo3ZZGR809FM45jHzNxnc3aO4qCIKQyqOeZIRo6igeEcRax75pQqJaaAKkbkyBhzBDiWfxQ5ESVgv4qZV75RbOsc9etzMF567R0cdlAPx/EGDer75ilv58gSImuXuITOOiEIhVrZCSdczDxI3AndkmwdcpVLXBuSVzAvi4OFmCIjR0UBAoAoRoRI4x+qeVLg/NhpfAyz2xHik2XkHDHDiVY1DcmkBsjIUSSgJA+RIwAgBDRGjT8wxBRqjzcSDU8pJftV9LzyiGJbIfv+R+dj46YtJodUG+3dl2b75inrNw3/uSdhK9QtREgJEnMLGu+5w3nO7ZyDaxw7PHYCe2Euax0Pycufl53N3I7FjGm/EoUGMRwjQszZai6Px/Mw4XzYAvBfHwk6lg5xDVCoBlXVZeQoQhBC8qN7hEBRFBCFQGEUMStyRDzv+ZKzX8XMy6+REhWKrVvt5fn3ZZynrJ0jvxkCwrSuDd/pkc5DjrTuMtzbxJVe8grmZaTlxhwpxkcqJYoA1FyBihHzwXLWlnDfVAO/6W+RGTwNZ8c3aMOa1LimI65Qcyq/jBxFBUpJfnSPEJAYBVUodBgNIEPnU0+8VO1XsfPKJ6LoVnvmxTcw/9lX0LBBfUydOAY7tGjmSXPppOlo0rgRJoeYqv+/9z7Fn3+vwUnHHw3GGNau24BmTRv7pi/vN40gqs9vEiDlaru9d97F57x43hO3wqN+17ZaDh4h9bwFJC8/XrwhUBRjTRSJIgAxI0fMat7y5wQWMM1AB8t34teFsYQlk8hRTDFarZqmQ1U1uc5RRCCE5Ef3CAFVKIhCoRMgRomx8Csxrul5mZaY/SpaXnlGrpGjtes2YPa85zF35o1Y9MFi3P3QPFwzYbQjzXsffY6/V69Dk8aN0pY34+5HsWnzFnz346846fij8effa3DdjAdw500TffOUt3Pk9rA5XQt6RG7P2158SyD0fP+xuxDClyEoV/IK5mXtWv3UCqWIS+eoOGAOphVaZd8xR/5gjJndD6agML5FTALlj0dMYYZzpOtIahqgSecoClBC8qZ7RKEglEAHSY058k1cOvar6HnlEblGjj789CvsuXs7VFVVonvXjph+5yzHeVVV8eDspzD8H8fho8VfpS3vo8Vf44kHbsLICycDAHbcoTk2bNocmKe8nSMXMhEKXoiCFNVxXuT5h7i25CUuI/WyNKAoBDFdsHiGRO3Dco6spqznHFyOU5ouNUGUiD8WVhYVSlORI00HNPlttShAiOG45KFkwHSOKDGeHTE9AEvC3CgV+1VqvKJErgOy16xdj7ZtdgQANG/aGJquo7omgSrz48cLnnsNRxzSEy2aNQ7Hh1Koqmbbl+UrV0FNBne5l7VzFNRuDfLs/RN6DwWVI0xjhTklr3C8uG1KKRQlfDRCIo+wI0cMHk3L0DkCvM5R9t1qxiKCmq5Dk85RZCDE6NbOQ8kg1HCOGIH96RA+2uHNYaAk7Fex8soz0i0COfz8ibajNGRgXwwd1NeV0IgmW2A6s+3A+g2b8Opb7+PeWybh6++WhOJz2kkDcNnkW7Bu/Ub8+/7H8dJri3DhOacG5ilr5ygKQeAF2xIu0YtbJHh8er5vWfIKx8tOT4wWh0KJ8SV4icLDfntx/V+Oc0jnDznAzMT8s3cWF046FaqZ3WoMqqqb33eTDnWuMCJHedI9SkAIBWMs9dHZgOSlYr+Kmleeke7zIXPuuwGxmL/70aJZE3z93U8AgL/XrEM8HkdlhRE1evfDz7B5y1aMvnwatmzdhvUbNmH2vOdx+skDfcsbcPRhaLPTjnj3g8VgDLhh8iXo3rVj4D2UtXNkwxrIZm4TwDGIjR/0xgu1vc15/9bCW/a+mV/U58sLI//hQMkrJC/zoJWGEgooMhJQHAgysZl7R7o5UNMacsTnzqRbjVJjhWVd16HpMnIUFQghUJQ8vVbtaVYk9awDnnnJ2K8i5pVvUGo2Zt0IefGePbri/kcXoLq6Bp99+T169eyOufMXokXzJhhw9GEYcPRhAIDFX3yLha8uCnSMLHTba09022vP0PdQ3s6RI/yQEhIAzhH/HKxDfgtn8efdwi/y3gl30t52uf6Sl5iXZUDsQxSgcsxR4UF8d4ISGuB1kvOdCDFiRxQEzHxLpMQxvDWn5pgVpjPoOoPj47cSWYPAbJxEXai9bbzVrd5a0RMvNftV9LzyCIUYfx6EvHiTxo0wctgJGHXJFGzXoD6mXnkRZs97PutFJN9692M88NhTWL1mvdldZ9TOK0/N9M1T3s4RX4+mpNjC4mO3HS9n0ba1zwTP2bqG+wUgyi95hedlghLi/CKFROnBR050Zr2ACZgpCNaQA2F43gfGLBkCnTHojBkFS+QOAuHU7OjKtwyBvytcsvarWHnlEe7v4vHHw2Jgv94Y2K+3vX/p6BGeND26dUaPbp3TlnXLXY9g9FmnoGvn9oHdeTx8U23ZshW33TcH3y/5FTFFwalDjkW/Pr0w+vJpuOicYei0526hLmBh6i0zMaDvoaFuxI1X33of855+GRs2bsZpJw3ACcf2yawA5twk5oYdkuQEyfbk0wgT/0FAe5t3011RK8krAl4ZTOmWKC1YPq8x3oSBcS/JTAyqNV6FMRgtxNr4kFQdAIH4ZRfhBQT9UNxp9yD/UrRfxcorD1AIgRIw5qi20W7nnXBs30MzyuPrHF07fSZ6dOuEKy89B9U1Nfh+ydJc+WUFTdOxbMUfuGf6JGyrrsaJZ4xDn0MPQKPtGoQvhHseotVKeYEixJvHAuPOW6d99TmMDEheGfFyKL5EmcF4sETwkDOxp/YKA2CmcxQRvboOUgvvtQxtU5g0xWS/ipZXHmCroeB4ITD8H8fhrgefwMEH7OM4vk/AoGyhc7R85SosX7kKN04ZC0II6lVVCQsZPGIsZt05FY233w4Pzn4K9aqqcNpJAzB3/kI89fxrqKqswKVjRmDJz7/hzUUf4Yuvf8BB+3fDZWPOwHMvv4XHF7wIQoBx55+Onvt2xejLp6HfEQfj6YWvY9qVF6FN65ZQFIpRw08EAFRUxNG65Q5Yv2FjZs4RB4cjbu5YXnq6B+fu//Vz6v36kSWvzHgRQhzTOSXKGMS7m93AUePTEwyQjlGZodTsVynyigrUZ4VsVqBvq3346ZeY/+yreP+jL6CYi5kSAjx693W+eYTO0dJlK9Ghfbusw6gPP/40Fsy6FXHzWzz7dd8Liz5YjLOHn4ge3Tpj6bKVWPjK/zDnvutRXZPAuCtvRs99uwIAvvpuCWbdNVV47dVr1mHT5i3YqVVLz7kFz72Kp55/FQDsFypjTPhyZYKd0O9gFribOp6NYY5IkgsdXHHUeUT1ZZVpyUWQcUlPEKEqKWqjVw68cnVWeYeXEMuJSV+m0Balq69CK0KZIeh9kI18ZSJLKZseOouDm3tHVE66912xilMx8iq2brW33v0EC/9zF7ZvtF3oPHkZkH3c0Ydh2oyZOGfEUHRsv6vn/MeffYOVf/yJsy66CgCwZes2+9zgAX2EQsoYw7/vfxxnDjtBuBjZ0EGphaRUVcWhA0ZGdDe1D9Ey8YHvAZ8TfB4+FJsJ+CwZ88ojcuJVrPVVYrxyBWMs5SBlgwBexfjCKGcUq53ICSWmj1HwigoEYpqFotRhj3agolUpAyB0jnbZuTV+WLLUNl5BUFXvEtzjLhiBH5b8ilvvnY0+h/bEyYP7e9IcfcTBuPjcYZ7jfjfw+IIXEY/HMOiYwwP58CjW8Zi+VWpKt0PARcdceUQfFhTddlgD5VGyLHjZ9U58yIQFl99jPMqovkqNV1TIJGAbhpe1ac+WKbk3cnFCVI2RyJdPuc6N/CDw1VZi+pgLr3yg2CJHbVq3xCUTb0K3Ls51ji45b7hvHqEn0rZNK7TasTkWPPcqGGNIJJJ49sU3DWcJxFg/BECT7Rvhux9/weYtW/H+x18CAGoSCfyw5Fd0aL8rTh7cH59+/i0AoGWLZvhr9VoAQI9unfDa2+9j9Zp1YIzhz7/WBN7Yog8W43/vf4rxF5+ZUVefzvQC/zGfP3/OohCwXzq3EXEcA6cYzPTkGZeIOfPyGQlXGPGeTssLgH2vzL7n7OqP6an8LEdexVpfpcQramRqKsPUF4jhHBmr9FL5F8Gf/VKL2E4IzzFA1902M3rb7OdQlJI+Zs0rz6C2/nn/CoF6VZU4+IDuaNigvuMvCL7dalPGj8aMux/F0y+8jsrKCpxyYn8QQrD/Pl3wzItvYK+Ou2PY0GNx3a0PYM/d26FXz24AgJqaJOYueBFLl61EUlUxcezZAIB+fQ7G1Ftm4rMvv8fEcWfj7NOHYMz461FZWYEjDtkfZw47QcijuroGU264Gzu0aIZzxl4DMIZjjjoEpw45Nm2F6NZCcAWD4NqEGB6pj5BYgRI7zMopAnGlc244d93hVeuXZ0WA1KBX4spntU6y4KXDqHtCAMasMSbZPAcGQigAZn5agIFRkjUv54Zzt5D1VUq8Co109WVtU2IOCC3QANBygy0qEcoXbxEYd0w3Zxky4z8uRZRgoETxl6MS0ceseeUZhIhfcYXq6rMmdWUCkkjUFNJ7yAusMUcvP/1o6AWfag3EWFZd9IVrYkt1hmUG5MmqOMYpGG+1Qhak6wyJpAqYXRtMz36VYkKpvV5NPK5AoTRrXjaKrL5KiVeUA7IBwFrViDfg/GWtY2EHZP+9sQa/r9mMURMewIo/VgNa8Je3JcLh3qtPx+C++zqO5Spfjg+LmvkYA1RdN5wj63yexkbEY4pjRpVHxkpAH7PlpbBEhhcNB+vdO/m226EIvsWnaRqmjhuLRQsfqdV38+YtW/HG/z7E6rXrHeI0avhg3zxF5jlEC03XQXJ4MecFhKYdcwSGwC85+0KgGUT01gm4LrjrEjiPh+XFwKBZX1EmANOzjRwZL08wBsZ0xJiSEy8B0aKor5LiFTXcIYRs4KovQqxvO1HIJdWjgaPhFrF8WdbByMqg6+BmGlvRo+iFLwYlnDNRzPqYLa88g5j/RMcLgcsm3wJV1dBpz90Qi4X7gHJ5O0eaDkKKyTkiANH9v1HkjpFa4JWAVzgrLUmFvN0tb48jxlLpibXP/4qunykvZjqmhAIURuQou7UNQIwmJJiue6MW5VJfJcQrV8OadeQpZH1Zi0gqlJqzWqVzFAU8K1QD0cgXX6ah6tB0lnKObAcp+jc6YzwxF5cS0ceseeUZxTYge/2GjXj8/puFM939UNbOkapqyMIfjwjEK+AAQKj/N4o4BXA0LMyd1Oq/qXRWPsJncJ32lM84GRVxdNuMDHkxxqCqGggFCKPQVS0740bM1gdjYJrAOSqT+iolXu53Wq1pVyb1RYCYQhFTFDgGeEhkDXvmX5TyxWVjZp8TMxtWum45R7qVAE7py/mGoDMGyuuQfS5FrNj1MSdeeQSlxp+HUoHUsWun9vh7zVrsuEPz0HnK2znSdKDYIkcUwd4r10ogAYLvCMNygu9oIVgvNCute98NKw9x7mbKi8Goe8IM50bXsowcEQJCGKDrYJqWWgguS17FWl+lxKu2Wp5+SFtf5q+iUMRiFNBk5CgKOGYZRSRfvCzZYs4YVHMiDdMt5yhfkSPBsRLTx5x45RHF1q1GKMWYy69D+913cRy/8aqxvnnK2jlKqjoYtMIRsEPRpuSawhr3m0Hn8u4dOkXESd3KwSsQMykQV0bRmjUiBXIoXQa87MiRYjpHqg7GMndSjbVqFEDXoauaPfMwW16ObEVUX6XEC9zxSEJHGb7z0tUXgSE3sZiCuIwcRQZ7Zfoo7YS5bXShAdbAfFVn0DUdTGepLvks7Efg/cCYOOKWjlLTx2x55RvF1q3WvWsHdO/aIaM8Ze0cGd1qBYRoLiUlUGM+is4JsUOeuVaBn5Hxm+jGX9r3kqLQMp8xQ16MAUlVAwEFBYWmaUA2A+MJAaXmeCNVc35INAtejmxFVF+lxCsMMrLF5gX4l2UG2bz1RYy2acyKHOnhBl9KBMNYFiF6+bKTMAZmdnVpmvGn6zqgaXlxjgCSGtMkeGGXij5myyvf8FvTiBXIOWrYoD5699rPcez3VX/h6YWvY2C/3sKZc2XtHCVUDYXtVHP5+6ZzVKn7VDtxbfJNiTQKIzRcSLUaGLfN0yIE4hWQPU2V8LwYY0iqOgg0wzlStaym8xNCQBUd0HVoqmasf5IDL3faYqmvUuLF29UgJyi0g5SDxyWqLwJjPx5TUBGPoZCB43ICJSRv8sXMP5i+SlLXoWm60R2vmVHnfESOfBaCdN9DMetjtrwyaolkAUqMPzcKtezYzFnz8cvSFSAgOOXE/qiqqsTDc5/Bjz//hj9W/Y3Ro07x5Clr5yiZVAu7CCQRaIJCjLFQofJzOmL6VqI3DuOOe67IvdAcIV5eiQTlOpQrQ146M9Y5IqCgRIeWULNb64gQKIox3khPqHYYPFte/L0VU32VEi/nwQgQ1lCHrC8AIISgIqagIq4AMnAUCSgl+ZMv0ylixOjqSqo6VFU3Is6qapzUI/ZyzWsFyV4p6GPWvPKMYoscLV3+O1avXY9NmzbjlrsfxaTLzsVvy//AzFsnY9RFU+qec5RIalAKFToSygABGIWq6b5C6mgwBEiy1dIi8Ppgbn33o+J3zqGgLqUKw4uZzhElCihRoKoaWFiHkKdICXRNA1N1aEkjcpQLr2Ktr1LiFconysQCZ+hkpasva2XeeNyMHBXTfIwShmiGbc7yxcGaOaYzIKkZYxY1TQdTdcMxini9OkLEY45KTR+j4JUPKIB4zFGB0LxZY1x+4UgkEkmceeFkAManzupVVQkXqwTK3jlSoRRN5AjgnSPrqFt8iGuH8Me5DHargjnT25tcWnuTvyBLtSxsxeSvyeDprgjLizHDMaVUg0J1JJMamJZ5y49QgphqDMbWrChgDryKtb5KihdLcbHGiQhNYERNVKF+BNQXABBCUt1q0jmKBJRfmR6Ixk6Y51IDsg0nKanpSGpGg4ipKsDMsUcRghDY337kWZecPmbJK98ggFst7eOFwHYNG+DNRR9h9dr1AAG++f4nrF6zDtXVNYjHxW6QdI7yCc9sNQJAC9WtJhR2ItANXtp4ZeCUwqbBKR84RbGTEpfwCl5wYXjZkSMaN50jNSvnCIRCr3Q5RznwKtb6KileUYOz1kGGM2x9ERhjHSriZreadI4igd2thujki89uOEjEdo4SZtcakmbUSI/2MzBG5MgpHJwfUzr6mAOvfMKYaey9UiYfjo8Sl14wAjffOQutWjbHiJMH4t5ZT+KEY/vg9Av+hYMP2EeYp6ydo5pCO0e8xNrOkRJuzJFPq4BwLQCnNnuV0D0RQ3TODu8SF1sX9Ux4WWOOqKJBUYzIkZ7FN64IoWCqDj2pQ02q0JnuqdJMeBVrfZUSL95a+2mWVVxAcCd9IW66YevLXDg0HouhsiIGaIUxxuUGxexWi1K+mPkHBi5yBCRUZjhHSQ1IamC6Fr1zBHMlbsHxUtLHbHnlG1b3tuh4IbBv986Y99B0e79fn4MBACNOHoiqqkphnrJ2jqprklAKNugISE3v4ZwjpiCp6vYhkax6jlnKYBXjdznBvuNjhy5qViI/PXUocwa8mM5QXaNCoSoUqiFRk8zaOdKSGlhSRbImCV1jOfHylC/YL0R9lRKvsE2N0DY4ZKFBC9m575lSoLIihqqKOKDLRSCjgN2txh2LSr4Mp8jo4tJ1hhpVQyKpGd3xCdVwjCL+gDABMVfh9t6PN613v1j0MVte+UaxOEeLv/gWPbp1xouvLhKeP7bvob55y9o5qkmoUJQCRo58utWSaSJHHvmxJN3t+fMvFlerwr1tJXWUzeBt2fDZXefD8tIZM6J2MQ2xmI6apApdzcI5olbkSIOaUI2p/DnwKtb6Kile1q7V1M+xJRpWO8PWl2GUCSriihE50mvZGpcpFEqjly/rNGPQzeiRbi4DUpM0Is6wuuSjdo5I6htu3pMoHX3MgVc+USyz1d796HP06NYZb7/3ieccIaQuO0eFjhyZrVZ7fR4KENWYvQWvoeDl3XFe0BKw932Ug8vqzGxtu6M9ovJJajsTXowxwzGNadDjOmoSKnQ1Ka6jABCqAEkNelJDMpGErus58SrW+iopXsyZRnTNfCJdfQGG0auMm91qMnIUCazZalHKF79trY6tMyCh6UiY0SMkLOcoc/sRBEKIbU94lJw+ZsmrNpDrtZ558Q3Mf/YVNGxQH1MnjsEOLZrZ5/7z35fxypvvYsvWalx49ik49KB9hWVcdM4wAMBNU8ZlfP2ydo4SCRW0oJEjCsNdt/YJQCt8I0cOeWYuuTbLsDx/+z3FkFrYiyuHn4TB5+GPia7tgEjRQ/DSTecoFtegq5ZzlE3kiAFm5CiRUKG5BmSXS32VGq90YIwZAy8565+rAxW2vgjMAdkVMVRWxKNfH6eOQhF0q9nIRb4AM2IEu1stYUaOEkkNLGlGjbKwH0EghJiRI9dxlJ4+ZsMr38h1QPbadRswe97zmDvzRiz6YDHufmgerpkwGgCwZes21CQSeOD2a/Db8t8xZvx1ePHAHoFlf7T4a+zVcXc0qF8Pc+a/gA8+/hLnjTwJXTu3981T1s5RTTIJmsX6OtGAQNitRlVjFoYPHAbI3HAM0HNfxZXGoUA+ZYsaFqIwrW9oOA0vpjPUJJLQKjToqmZ0qyWziRzpduQoYUaOcuEFFGd9lRwvriy/F6bjeIBnxL8kgxC+voirW01GjqKAPVstYvky2o7Mns6vMcM5SqgaaqwxR5oKZBF5DoIROfKXvJLSx2x45Rl+K2SLjonw4adfYc/d26GqqhLdu3bE9Dtn2eca1K+HM04ZBADYdZedoGkaahJJVFVW+JZ3x8w5uG/GZCxd9jteefN9nHjckbj537Mw+77rffOUtXO0rVoFpQXsVqM0Jb0AQIxutYT5zTe7hWD5UOBeFoRTLp+3j8NRFiiTR7EE+RyK6W5FcQqYCS+dMVTXJBGrUKEldWyrSUJPZOEcKTpY0lgdu6Y6aUeOsuVVrPVVSry4087mqie/u4CIEKK+KAGqKuKoVxlH9N/kqptQFNPJjFC+7E1mzNZnMBZmrFZ1bEtoqEmoYDWq0aWWReMqCEbkSPeOOSoxfcyaV75BfC5mHht+/kQ70jNkYF8MHdTXkWzN2vVo22ZHAEDzpo2h6TqqaxIeB+iHn5aiTeuWgY4RACQSSWzXsAHueWgexow6BQfs2xULnns1ME9ZO0c1iSQotVa/FLjwvr41jyBx4ssUlG91q9lxVAoo/gOybWHmShMuKMZfknDvIes2RLcIpJ394HkB8gqYAS9dZ6hOqIgnVehJw8jpCRVp68t1nigMNKlBs8rgIkfZ8CrW+iopXi5Kbvi3xcUInd4tOj71RYgxGLQibnarMZ1L4H7ziN5EQbYgDETyzBN375cGL4VSZxK+tFzkCzA/H8Lsgdl25CjBRY6SfLeaQBg89iTY3tvdahCeLh19zIVXHuE3INs6Nue+G4Qfe7VB4HBcmc48bS1V03DHzLk4b+Q/0vLZrV0bnH7+vxCPx3DFJWdh3fqN2K5B/cA8Ze4cFThy5B6QTSigqMZU/gCI+oeJedxWGE4J+Gma4E/zigIfHRLZEO9uRrwYM+peTxqf/jCco2wiRwzU/HRITSIJXWc58SrW+iopXvx5H7hfV3483EWGQpr6IoAxILsihsrKWOSfnairoJQIfbac5Mv8YYA9W03jxhzVmMt4QFXzEjnSdd0z5qjk9DFbXnmG22fjj4dBi2ZN8PV3PwEA/l6zDvF4HJUVzujQ7ffOwb7dOuGAfbumLe+aK0bjg0+/RLe9OgAANmzchHNHnhSYp6ydo+pEEpQWaswBQWpAtunqEwrEtMBvq9kK4Nw1tpm4rcm3JIKmkIJwOitqdVgQkcuAlzEgO+lwjrQsnCPKRY6qE0loohddGdRXKfHiixbNgs4XQtcXISDEWCG7qiJmvHUlcoZCqVeWcpSvVDnmmCOYC8iqOmq4MUdMjb5bjXKRI4dMobT0MWteeVaLXAdk9+zRFfc/ugDV1TX47Mvv0atnd8ydvxAtmjfB0Uf0woLnXsWatetx6ejTQ5W3YeNmHH7w/gCAz7/6Hp9+8R0GH9cnME9ZO0c1NWrhnCMCOCJHAEAVIGZGjkwJ9wg0S7UaYCkBVybh0sCVz9FqcO3bRZjHHauuurWLV6oseFlT+fWkBqhGl5hWk8VstRigmCvlGt1qLCdeDhRRfZUUL5FRFRh9X+c/S1gvg7T1BePFVxmPIVkhxxxFBapwNR+VneCKs2erMWfkSE+YkaNEtLPVKLUWgXQKdMnpYy688ohcB2Q3adwII4edgFGXTMF2Depj6pUXYfa850EIwco//sLt987Grru0wcgxkwAAp588EH0PP8i3vCk33o1rJoxBZWUFptx4D7p16YApN9yDO2+a6JunrJ2jREIFKVjkCMaAbMA00ASgOhDXkAz6zpirJeGAW9CRakX4NljME/ZxrnwGOCMCXGaPImXAS9c55yhpRY6ycI50IJbUoCZV1NSoqW61LHkBxVlfpcQrFPJkgMPUF4FxvKIihko1Jp2jiKDYk0sQnXyZ5RnriTJ7YLa1zlG1NZU/mR/nyD2VvxT1MSde+YSQnM8xHwzs1xsD+/W29y8dPcLefuelxzKis27DJrTcoRlmPf4MRp1+Igb1Pxwnj7o8ME9ZO0fVNYkCOkdE4BxRI3KUTDPmCKYMuQTJ6oO2WxfcNuHzuV5OfvIo+v6P+xay4WXNVtMSKpDUsC2RhF6T8GHhD6IxKEkNakJDdU0i1a2WJa9ira9S4gX+1+wOIWYE1FO+8KJZIoP6ouaYI02Lo1b7/soYCqXRy5d1nDF7tprGGGqSGqoTxh+rSZrOUeb2IwiEmrPVRLdRQvqYLa98O0jpBmTXNhrUr8Jt9z6GTz77Fo/cPQ3JpIoG9asC85S1c1STVEFIISNHCgAGe9oApUCFas9W83tf2LLrNiQspXDMTOhQEqRk3pXNUbZ9bSI45ibDHQzLi5mfD2FJDUTVjQUcs4ocEcRVHaqa6lbLhVex1lcp8bKTpnM6BJl8eYVAJvVFzNlqmqZJ5ygi2OscIUL54rLy31ZLaDpqVGtAdn4iR8TsVnPLR6npYy688glCvE6wdbwQuOryC/D0wtcw/pKzEI/H8NW3S3Bcv8MD80jnKJ+gpvJZsVBKgaQxIBtA6rgLlqLwUmwJt0MZzDRWi4BXIj4Pn9athHzrQyi4Lg5heFndaiypgWjGt9W0ZBbOESOoUDVjzFEyNZU/W17FWl8lx4svxwehXRJ3oSGSB9YXIcYK2XEFuhaTzlFEsKfyRyhf1rb9mT6WGpCdUDUkVA265RhlYT+CQAlxjGF03Eap6WM2vPIMYv4THS8E2rVtjXEXpLrlNE3Dz78uC8xT3s5RogicI1itE6dzFCSkBN6T1pRO94A9t39FkLqcowhRq4HP626KAJ6wcFhejDEkkiqgaqBm5EjNouVHdYKEqiPJR45Y9ryKtb5KiVeh4K4Dv/oy/COCilgMrEKXzlFEsL6tFql8cUWlZqsBSS01KJslzOn8+RiQzQRT+U3upaKPWfPKM3IdkJ0P/LDkV7zy1vt4/e0PwRhD/yMPDkxf1s5RohgiR4AxypAQo5uNjxwFwOM8uVsVlkIQb1pRC43XUV5xRS0T+OQNy8twjjQgqUExw+PZRI4oM5wjNakhkVShm2+/bHkVa32VGi8rjXVRx3mW2ndw8kEmrkuY+iLmb0VcAWMychQVKOVm1kYlX/YB5pmtllCNb6vpph3JR+TIvQhkqepjNrzyDgIIFb+WnaPflhufC3n1rffBGEOvnt0Qj8cw76HpaWeyl7VzZESOCuWqEle3GozZasngRSDtJZGsfXhfNARwrrIqvnrabce+R6PM8+Z2JrysD8+ypAZqflstm3WOiE5QkTS71bhvq2XLS3T/nnoI2HbsR1hfpcjLyhsI0zFhxD+Ybq3lEgaheJHUCtm2pyaRMxRKvS/6XOXLfDwMsLvWrDFHiaSxzpHdrZaF/QgCJdQz5qiU9TFjXnlGsQzIHnbuFTj+mD6YMfWf2Hkn43Mkn399ZaglfsraOUomNdRaHFEEK3Jkz1YDoAZHjnzp8lpjKZO1zVLGBsSrAH6tCueFxZezlTkDXoyZUTtVQ0xlSCZVqMnMv45OmTF4PWm1Is2WXra8irW+SopXGAj64gL5hik3ZH0RGJeOx/nJEBK5wtOtZiInOwEA5gdnmekd6QxQVd2czq/ba6UhC/sReD9EDzXmqOj1MVteeUaxDMiedNl5eO3t9zHuypuxb7fOOKhnN6hqOFkqc+dILaBzZDpDgNM5SurilZ55mMJvtxqA1PoU7mYBryA+iuhpuLjKsfWQe6dZ6Rz94yF5McaQVDVQTUfMXLMkqwHZoEiqOpKahmRSg85YTryKtb5KiZdjXRhBFiECBi6Fdl0yqC8CgrhCAaZAIhpQQqKXLw66FUViDEmdmXqvQ7cco6SGDKQl/f1QasyQE50sIX3Mlle+USwDso856hAcc9Qh2LBxE95Y9BGefOb/sGzFH5h8/V0YcPRhOHC/vX3zlrVzlFALGTmynCOu9UoBaBpUjdkC66ecbp1wbgS+b8wWWcCte14mrvTmr2edjpC8bOdI1RHXdCSTWmhvnQclGpKaaSjV1FT+bHkVa32VGq8UuaxPO66dibFOV1/GZwsYYjEl9YKRyBmE61aLSr7sbeufOfZI1XRzULYGZv5BjXbMkUKZPcGDdx5KUR+z4pVnFNuA7O0bbYfBA47E4AFH4q/Va/HaWx/g/kcX1F3nSC0W50g3JZdqgOqKHPFS79fygEugeYNPXC0EmMURV3rCpXEX6tOiIz4E0vFiDGbkyHBuVE3PyjkixOiCVDVjxpq1tk62vIzMxVdfpcbL3gzqssrHNLcw9WX+xmNUOkcRgvqNzEeO8gWrQWVtM6i2zdChq7rRrZaF/QiCTlLfcxPyKiF9zIpXnpHrt9XyiR2aN8Wwocdi2NBjA9OVtXOUKPSYIwWm5luz1QCoGrQ0i0B6jL07MXHKO9/SSGeIwKV1bDPvcc8gwJC8dMaQTBqRo6Q5uDKrMUfQnGOO7AG+2fEq1voqJV5hDKuvXPukDY0Q9WX8EcRiSsFW4y1HUEqily/e2TYdJJ0BSd20G5qeihxFPOZIocbMOAeJEtTHnHnlCcUy5igXlLVzpOrmWJ9CgZkKbY850gCN2VNIPcyEzQZRuWYyVzprUpxHEcKC+OxmyAvMCI3HNB2azqBq4ZYvcINSPdWK1HQws1stW17FWl+lxMuVLGdkZKdD1hchQEyh0AkJjm5JhIajxR+VnUjtwuhYM341zYoeMTBNB1N1IAv7EUjBXDbAHTkqNX3MiVceUWzdatmgrJ0jTdVQMGkhJNVEsNY5YgTQdDsC4oFfSFYQGhUN2PP0zolCqqLWTFBI2C9tAC8G06HRGTRdh6bp5rPIDIwaXZCqzqBpmvGey4FXsdZXKfGK3NfIsLx09WW1shVKQUjUZOsuKF/vUdkJxp03txkzvq9m2Q1d0w37qWmRRjuYQoWyXGr6mDWvPKNYBmTngrJ2jgobOeKcIytyBALouvMbYSIwOL9c7RJ4axon35LgFcQz1sKtRO4qcZ9H6voOfQzJizEYDpEZOTIcnCwiR1Z+K3IElhOvYq2vkuIVMTKx06HqCwADgaJQ0HR6JhEahFuMJyr54pIbf+a0fsNmGH+6bkSPoo4cKdb1uGMlqY/Z8sqzashutSKHrhXQOeJHyVmRIxBAY/6RI04ZbP1wHeOL97QY3Olct26X6XrTiZTI2nQoZEhegNny0xk0HdA0Zj6LzMAUowydMegaS4WRs+RVrPVVSrzSIVObm2k0Kkx9EZgrOpeSJS5yEG4qf2TyxTtIVuQIhkNkO0d25IgLL0UBsxHnLrLU9DFbXvlGsSwCmQvK2jnSCtpyZAAoHAOyQYMjR6KXUIBg80rhq5iisjhFY6LzzKV0GfIyWn86Z+T0rJ4F1ZxlWC29bHkVa32VIq9ggtEjI17E6FZjcrxRZHC80yKSL9FRo1sNpt6bttI4kOstuK6o+8pHKepjVrzyCSIi5HOsSFHWzlHa7qt8g5hNE90KeRjNlcAZ0OBaF1w64vr1zWsWIDJmjFMq/svOoosEKV86XgxG3evMXLvEDI9nDHPdEyt/YOssBC9P8SiO+iolXvx2bfoeYevLSkuJFTmSDlIkINxokYjly1gcO9XFZQ2W1hlSM8ryYMtN6+zhKEpXrPqYE688oqwHZG/ZshW33TcH3y/5FTFFwalDjkW/Pr0w+vJpuOicYei0524ZXWjqLTMxoO+h6NGtc8Ykn33xTTz70htYt34j+h7RCxec+Y9Q6yX4dl/VFizFTi3iYfhHfgabpLx7Aq6VwVLnHU0AvjVipSWpS7kXHwtssYgP2Wkz4gWngbO2MwbjHCz3tNtseBVrfZUQr7BPMfTTzqTAEPVlgRAC4ldBEhmD+GzbyNJOiIrRTV+ImbrP3LofAYifd19i+pgLr3yirLvVrp0+Ez26dcKVl56D6poafL9kaS3ScqJ1qxa4/7Yp0HQdQ8+4FCccewRa77hD2nwFD6vzTpH1GyJyZIF4Nrht7lfQaHD0UTt0gzjTidagZPAqWka8HD4h9+2kDJEah8Dlz4WX+Vt09VVCvHyRraoRgICkl4+Q9WUnF3lMEpEgSjvhKNT8taf1cw5S1M4RY0QssiWmj7nwkgiG8NO0y1euwvKVq/CPE/qBEIJ6VVXYp2tHT7rBI8Zi/YZNAIAHZz+FufMXAgDmzl+IE0eMw7BzrsAnn3+DJ556EW8u+gjX3/YgZtz9KADguZffwilnj8ep54zHR59+BQAYffk0PPvimxg5ZhJW/P6nfZ399+kCEIKff12OBg3qo0WzptHWQr7At0445Q8CQUqwwzpR/E6QXjFBOtHyJSLdyYwXc/z6RsrSgW85Qlx15VFfpcMrFHJ4j6VbVTdMfUnkF5HLl/ugaTeZ2bDKRZ78ry8utNT0MRde+YQVORL9lQqEkaOly1aiQ/t2obquRHj48aexYNatiMeN4vfrvhcWfbAYZw8/ET26dcbSZSux8JX/Yc5916O6JoFxV96Mnvt2BQB89d0SzLprqufa46fcig8//RL/vmGiXW5amG4yA4PdY265zrx7LXCnHXkCjjkKssvxxjEzimyGSFxbIuagkhEvl1MoKlFUX9YzS9NSzJ5XfiF5ZYZUy5dwskJ8jXg6XiKblU1rWVRfocsJqezlzisI7sCRb6F+V+HshP3MM7H3PgTruj5GBTmV3wfHHX0Yps2YiXNGDEXH9rt6zn/82TdY+cefOOuiqwAAW7Zus88NHtBHaOBunXY5lq34AxOuuR3XT74Y7dru5Di/4LlX8dTzrwIA1wVjKQgXi+SMMK8jtt4gte92huzwPwGnfKnMzB60KGj9eo4EwOIUNlPIdNkIJhHs5CTg6eor5DVy4lWs9VXivLJBXa4vySscUibDx05YhjwDex8KxVpfeeQVFcrWOdpl59b4YclSp1fuA1XwteRxF4zAD0t+xa33zkafQ3vi5MH9PWmOPuJgXHzuMM9xSoU9fQCAtm1aYf8eXbD4i+88ztHQQX0xdFBfm9OhA0bCWhgn1bKA2UxlADO+3g1HYBPOGQOuFgnAOUWWxnn1NcMwEQdXPmbxcR9z5eFnJQRRCKTlPmkZFL+yQ1zPewEE1FfYZm2OvIq1vkqMV1Tw5VBm9SV5hSjbB2nthOUg2T5SeHvvi2Ktr6h45RlRDMh+5sU3MP/ZV9CwQX1MnTgGO7RoZp9b8fufuPqme7Ctugan/+M49D/ykEh4O7iKDrZt0wqtdmyOBc+9CsYYEokknn3xTcNZArGnZTfZvhG++/EXbN6yFe9//CUAoCaRwA9LfkWH9rvi5MH98enn3wIAWrZohr9WrwUA9OjWCa+9/T5Wr1kHxhj+/GuNL8FNm7dg5qPzkUyq2LJlKz5e/DV22bl1uLsjnCLYKwh6X9IOf8fK4ug0FrzRmWdHXHYmcOu8yA5YysXl8bUX7uLdB4IykICyw/ByI219uSvNpxJz5VWs9VVivKJCXakvycuHVybwtRMEqVBFBvZegKKvr6h45Rkk4C8M1q7bgNnznsdDd1yDoYP64u6H5jnO3zFzDs4cdgLuv/UqzHxkPjZv2RolfQAB3WpTxo/GjLsfxdMvvI7KygqccmJ/EEKw/z5d8MyLb2Cvjrtj2NBjcd2tD2DP3duhV89uAICamiTmLngRS5etRFJVMXHs2QCAfn0OxtRbZuKzL7/HxHFn4+zTh2DM+OtRWVmBIw7ZH2cOO0HIo0H9eqiMV+DssVOwYcNmHNP3EPTo1inzO+XHttiK4/KKeAlzO0zuHfe0A2s715YSn0HEgThP8Tvua/HbjKPsy4m7nh2ZDuCQlpej7LD1Ffz1HTt5LryKtb5KgFfkKPP6krz8eeUiT+nsRCh7L8om2CmW+oqcVx6haToI8X5PUwv5pYQPP/0Ke+7eDlVVlejetSOm3znLUcYHn3yJq8dfgAYN6qNtm1ZY/MV3OKzXvpHxBwKco0bbNcA1E0Z7jo8cdry9fVTvA3FU7wM9aa6dOMZz7MD99sbC/9xt7w/qfzgG9T/ckeae6ZM8+SilGDnseMd1M4clHpakuUWFk0r3ObdU8s6TR+q8YpiRULqthdtR467AOLqW7hPA0d0uctREnETHCTib4sfTj5cfIqivnHgVa32VEi9ROblAVGA51ZfklbmdCIFgOxHW3otzFm19RcwrHyCEYofmTdH3+NN90zRsWB/Dz59od38OGZgaEmNhzdr1aNtmRwBA86aNoek6qmsSqKqswIZNm9C40XZo0KA+AKOna/WadZHfS1mvkG3D/aGaMC4+7/24PXkGeBayAJBamStLENeVBUriWOnUpfue2+KsEHHfv+t6nvwCRQvNS4R09eWqcl/kwqtY66uEeEVuWV33XG71JXn588pKlMLYidD23otirq+oeeUDikLx38duB2P+ESJCKBTFf2yxkQiOGctMZ/Y9ERDHosI6YyB5WHo7DcMSB4NXSsFckgqnljqmNBAfDWapL9ADhgRnre1OvmmL4RTDnU6kD4yYf/w5kkpM+MRcQcxVWCa8REhbX8T161NSLryKtb5KkVekqAP1JXl5eWUFkZ2wbjIbe+9CMddX3nhFDEWhiMVivn9pHSMALZo1wbKVqwAAf69Zh3g8jsqKCgDA9o0aYtPmLfY4o+UrVqF5syaR30d5O0du2O43ExyHcdwd3QDgGdnGefLGMvROacxF9jy6zVEUKUjQNe3WB5x37b4diz5/XcK8ypcNLz5dYH2FKSRCXsVaX6XEK0rUhfqSvHK3jWIvwUWCv2igvQ95TcGxQtdXrryKHT17dMWSn39DdXUNPvvye/Tq2R1z5y/EK2++B0opDtq/Gz776nts3rIVy1f+gR57ZzEOOQ3K2jligLfVYIsQL5YAA+OkxpJgximYu1CSOk/gkHp+YfpsjQHn7DuO8XdAXOfcysUf4+8axJvWfR2rKjx2KAQvMdLUl3mc8YQFyIVXsdZXKfKKCnWlviSvsHbCH/52wiCaib0XodjrK1+8ihFNGjfCyGEnYNQlU/D0C69h9KiT8effa7B6zXoAwNjzhuOx/zyH8y69FhecdTIa1K8XOYeyHnNELIeHl0riFqtU6pQOWRJMAiQpSNmIYCskZ5HWuM+TVCvEl6KZzt3H7x4bxPh9vmxz30qXCS8xQtYXcW8IUmbJq1jrqyR5RQSLT9nXl+Tl4ZU5gu1EZvZeXHox11eUvEoBA/v1xsB+ve39S0ePsLdb7dgCD9x+dV6vX9bOkWN1VIegctLhECpmKxNjhJsNykmUnZXAKfW89GfL10PLCTcNXlHcGaxbdysTcSZ3zHg10xJXWh8K/ryECFNfId/G2fIq1voqRV5RwVVm2daX5OXhlZ2DZBbE2wmroAzsvR+Kub4i5SWRFmXdrZYCM2WEwTt+yNhnLokilmZZUimEW9OtsrOUPha46zAGzH01t1JwWfi0gqJSjSy/a2fIyx8B9WWRJMF1mAuvYq2vUuYVCepQfUleKV6Zw8dOeMYcpbf36YoHiq++ouYlEYzyd44czo3Df/cmE54TiZqoAMa1ULKUPs6rJ/wug2csjvtOGGCvoG/t22yY/53zE8f4aziULENe4e7VVV82weA6zIVXsdZXKfGKGuVeX5KXP6/M4WcniCNJGHsfcIWira8oeUmkR5k7RyJrzkkUmM+vBQKX2IJZaRj365b0iF4idjEEqYgxJ/X8ZSyb4HYtGL/jKtc6ZysWnzlAidLxEmdKV1+8egeVkz2vYq2vUuJVGyin+pK8/HllDF87wbg/QSZfe+9CkddXlLwk0qO8nSM+fuh4KQMuXxv+isMc2/ai9akVqcxiuPJyeInwlK2iGbfP03IoBnMpiOsc3McCfu0dvswMeAmRtr4InKGJAAOWJa9ira9S4xUl6kJ9SV5iXhnD106YV8rI3vugiOsral4SwShv58iWAlOS7Kkx/Enjl5krZTFePJk7nUisCJhD8XLzy3nK9rEgn4GzAYy/Peu0SY0BjlCt2xVk/A64MrPl5YuA+nLMUBOrcM68irW+SohXlKgL9SV5BfDKBn52IgN7nxbFWl8R8ZJIj/J2jmxJINyf+5yxbQc2LMkDvHpkCplb4B3SnqtfLlIMv8aPyYdYvwK+xG07LIXiFIsv1k1FpLxpeYmQrr547XVodoS8irW+SpVXBKhT9SV5ZeyjCC9m/fp5ACHsvS+Kub4i5CWRHuXtHBHbleHASYn7mBDMIbS2yrmFUCjtWcDyFQRa5V4Wnlcc0eUZ17qw07vtBuOqifNT+IZXxrxESFdfvBEgTKD5ztNZ8SrW+iolXvlCudaX5OXPKxuI7AQzD0Ri71G89RUlL4m0KG/nyN16sI65hcPjblswxTntm4FxP7m9RhyNB1dRvFC7Gxn85RmXnh/qw6ez21tmFfkpZ7a8gpFbfeXCq1jrq2R45QllW1+SVyCvSECsErOw9y4Ue31FxUsiPcrcOWLiX2ttI15smPmf9cu7/I4y3Nsw00XkkjPHj/MU56dZrRL7DhhnI5BSHIdmcOmIII+dkXHnsuGVFn715VBjcdZceBVrfZUSr3yhXOtL8vLnlTX87IT7GHNcjHlu0ouirq988JLwRZk7R8T16zxO+JaGZ/AeL2nMWYajORCtpFkrmIpeRO5jjKRaCpbCgDjbT+6WAgNSoVfC5eFuk1itnix5BcOvvlx17IcceBVrfZUUrzyhbOtL8vLllR2C7EQG9j7oCkVaX1HykkiP8naOPMY8SCpc5xg4JyhMPk4qs3yJ2E6/KcSethF/zFI86+qEUxj39a3WBTPScavsO2/RdZtW+ZnyCoZffVnbBEIyEfAq1voqKV55QFnXl+SVpZ0QINBOiAQ084sUc31FyksiLcrbOSK8uPESFGDm+RFtxCOuxrZDwKxlIblr5BAztpx7PqRqMyAOU+BpIRBOEflpnh4fj6WuY+2LGLvX4AjNKxBp6iuE8mbNq1jrq5R45QllW1+Slz+vTJHOTmRj791FuMouqvqKkJdEepTlh2eZaDFBBpfTwiuSS1odDpB13p03lY849t0KypzHmA6m61BV1fDqATBqlsPFTC1lsXISF03XrvcWU0Xxu6FglyO4QBhemqbZ9wqmm0d1pK8vAROuDE3ToCbVrHkVa32VEi8ww7lVVd34owyU2kuj2udAANBUCYQQW955EOK8aLnVl+TlzwuMQdMZVFU1dNv8ha67bIfLhqZlBddN8vlSRKxr2raYkKKuryh5MaZCURSn/kk4QBKJmrLzI6urq3HE8WcXmoaEhISEhERRYtHCRxCLlWV8JBKUpXOk6zoSiUTknvHw8ydizn03RFZeXYKsu9wg6y97yLrLHrLuskex152MHAWjLN1GSimqqqoiL5cQIj3tLCHrLjfI+ssesu6yh6y77CHrrrRR3gOyJSQkJCQkJCQyhHSOMsCQgX0LTaFkIesuN8j6yx6y7rKHrLvsIeuutFGWY44kJCQkJCQkJLKFjBxJSEhISEhISHCQzpGEhISEhISEBAfpHElISEhISEhIcKjz8ww3btqCG+94CMtXrML2jRri2oljQCnF5Ovvwtp1G3BM30Mw/KTjAADPvPgG5j/7Cho2qI+pE8dghxbN7HKm3zkLvy5biXumTyrUrRQEudbf6jXrcOV1d+Lv1evQvWsHTLrsXFBaN3z2TOruif++hMfnL8QpJx6D004aAAB49a33Me/pl7Fh42acdtIAnHBsn0LeTq0i17pTVRW33Tsbn3/9A7Zv1BBXj7/Aoc/ljrD1J0rXtMn2WL9hk7Cu6wJyrTsLdfWdUSqoG2+hAHz93RKcdPzRmH3f9ejQvh3mLliIh+c+jd4H74dH75mGl157B8tW/IG16zZg9rzn8dAd12DooL64+6F5dhk//bocX3//UwHvonDItf6efOb/0Ktndyx4ZAZ0Xccnn31T4DuqPYStOwDo0bUjeu7b1c6raTqWrfgD90yfhAfvuBp3PvA4Nm7aUqhbqXXkUncA8PTCNwBCMOe+GzDhklFo0nh70WXKFmHrT5QOgG9d1wXkWndA3X5nlArqvHPUq2d37NO1IwCga+f2+Hv1Orz30efo3rUjYrEYunZqj/c//gIffvoV9ty9HaqqKtG9a0e8//HnAIzvuN15/1ycddrgAt5F4ZBr/dWvXw9Ntt8OlFLs3m5nxGJKAe+mdhG27gCgQ/td0aplczuvolCMGn4iKiri2L7Rdmjdcges37CxIPdRCORSdwDw0mvv4JTB/UEIQds2rRCP160getj6E6UD4FvXdQG51l1df2eUCuq8c8Tj08+/xd577Ym16zagTeuWAIC2bVph9Zr1WLN2Pdq22REA0LxpY2i6juqaBP73/qfYqVVL7LnbLoWkXhTIpv6GDDwKC55/DQ889hSW/LIMe3fpUMhbKBiC6i4dVq9Zh02bt2CnVi3zzLI4kU3drfprNT5a/BXOGHMlrrv1AaiaVktsiw9h689KByArOS1HZFN38p1RGpDOkYmfly7Hx599g4H9exvfm2HG8k8600Go8clkxlJLQjHza9KP/ed5nDdyaKFoFw2yqT9CgLff/QS9e+2HBvXr4ZffVmD1mnWFuoWCIW3dBYAxhn/f/zjOHHYCFKXuqXO2dbd1WzUaNmiAWXdOxdp1G/C/9z6tLcpFhbD1x6cDkLGcliOyqbtEIinfGSWCumdNBVi3fiOm3HgPpl15ESorKtC0yfZY8fufAIDlK1ahRbMmaNGsCZatXAUA+HvNOsTjcXz34y/YuGkzLpt8C6649nb88NNS3Hbv7ELeSkGQbf1VVlTgif++hDNOGYhhQ4/FoP6HY+Eriwp5K7WOMHUXhMcXvIh4PIZBxxxeC2yLC7nUXbMm26N7lw6glGK/7p3x+x9/1RbtokHY+nOnA5CxnJYbsq27L775Qb4zSgR13jlKJJL419Q7cM6IIdhj150BAAcfsA8+++p7qKqKr7/7CQft3w09e3TFkp9/Q3V1DT778nv06tkd++/TBfNnzcCDd1yDm64aiw57tMO4C04v8B3VLnKpPyv/N9//DF3X8etvKwt4J7WPsHXnh0UfLMb/3v8U4y8+s859XTvXujvkwB54452PoGoaPvn8W+zWrk1tUS8KhK0/UTq/tHUFudSdfGeUDur850MemvM05s5/Ae3atoaqGuMOZky7HFOnz8SatetxXL/DcOqQYwEAz//f2/jPf1/Cdg3qY+qVFzlaS3+s+htTZ8ysc9Myc62/L775ETf/+2FUV9dg93Y746rx56Nhg/qFvKVaQ9i6+3vNOlw2aTrWrNsASgh2adsat1xzGY49eTR2aNEMFRVxgDEcc9Qhdl2XO3Kpu7tu+hc2bNyMa6ffh2Ur/sD++3TB5ReNrFMOZtj6E6W7/7YpqEkkMfn6uzw6XheQa91VVVUCqLvvjFJBnXeOJCQkJCQkJCR41PluNQkJCQkJCQkJHtI5kpCQkJCQkJDgIJ0jCQkJCQkJCQkO0jmSkJCQkJCQkOAgnSMJCQkJCQkJCQ7SOZKQkJCQkJCQ4CCdIwkJCQkJCQkJDtI5kpCQyAqXTb4Fz730pr3/zgef4exLpji+oSchISFRipDOkYSERFYYNXww5sxfCE3TAQCzn3weZ58+pE6tNC0hIVGeiBWagISERGmic4fdsfNOO+Lt9z5Bs6aNoesMB+zbFe9++BnumzUfiWQC7XfbBZMuOxdVVZWYO38hXv/fh9hWXY3WO7bAtRMvRIP69fDg7KdACMFX3y5Bk8bbY8r48wt9axISEnUc8vMhEhISWePbH37GbffOQaPtGuDkE/php9Yt8a9pd+DOG/+F7RrWx32znkTjxo1w6onH4Lsff0H73dpCURSMu/JmHHpQDwwZ2BcPzn4KTz3/Gh6+cypatWxe6FuSkJCQkJEjCQmJ7NG5w+5otF19bNq8Bfv36IKnX3gdf/61BheOvw4AkEiq6NWzOwCgbZtWePn1d/HFNz9ixe9/YsXvf9rlHHnYgdIxkpCQKBpI50hCQiIndNpzN2zavBWEEDAwdO/aETdeNdaRZlt1Nc6+ZAoG9T8cw08agB2aN8XmLVvt84oihz9KSEgUD6RFkpCQiAw9e3TFx4u/xlffLgEArFu/EVu3VWPZ8j+wfsMmnHT80Wi5Q3Ms+fm3AjOVkJCQ8IeMHElISESGnXfaEddMGIOb/z0LDAz161XhikvOwu677oxePbvjtPMmYpc2rbBT6x2g63K4o4SERHFCDsiWkJCQkJCQkOAgu9UkJCQkJCQkJDhI50hCQkJCQkJCgoN0jiQkJCQkJCQkOEjnSEJCQkJCQkKCg3SOJCQkJCQkJCQ4/D/OsF8qKqgDTwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 583.3x260 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "A heatmap with one row per cluster and one column per month, shaded by assignment probability."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plot_assignment_heatmap(\n",
     "    core_probabilities, macro_df.index, \"The core model returns to conditions it has seen before\"\n",
@@ -1486,10 +3338,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "95e9e8ce",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 41,
+   "id": "3b1e567f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:05.130477Z",
+     "iopub.status.busy": "2026-09-08T23:43:05.130346Z",
+     "iopub.status.idle": "2026-09-08T23:43:05.354207Z",
+     "shell.execute_reply": "2026-09-08T23:43:05.353504Z"
+    },
+    "papermill": {
+     "duration": 0.248565,
+     "end_time": "2026-09-08T23:43:05.354534+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:05.105969+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkcAAAEFCAYAAADpO0MNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAav1JREFUeJztnXd8FEUbx39zJQkJ0juhqXRiKIIKIoJSBFGagoiIgiIgAvKKICAiCEizAAqIIlIUAVEUVFAsqCgKKCJFVHrvPbnc3bx/3O3e7Ozu5XLJ5drz5RPudnZm9rd7zzz7zOzsLnM4MjkIgiAIgiAIAIAl3AIIgiAIgiAiCQqOCIIgCIIgBCg4IgiCIAiCEKDgiCAIgiAIQiBug6PFH36CIqnp2LhpS7il5Dn/7T2AIqnpmDjtzRyX/XbDzyiSmo7FH34SAmXm5ETzxGlvokhqOv7beyAflBHhgn5ngiDCRcwGR/2GjEaR1HTDvw0//RpuebizfQ/0GzI63DKICOSFCa8i7ea7wi0DAFCtXougguxIIpKOJ0EQ0YEt3AJCRd9Hu6Nd6+Zwudx4uO9QNG3cEH0f7Q4AqFXjehw4dCSs+o6fPI2q11cJqwYiMjl+8nS4JQAAXC4XTp0+G24ZuSZSjidBENFDzI4c1U2ribvbtEC71rcDAFLLl8XdbVrg7jYtULxYUTXfr5u3oXWHh1GhRmM82n8YsrKyAHhODNNnvo06N7XB9em3Y/iYyXA4snTbOXfuAgYMfR5V6tyGek3uxntLPgIAbPjpVxRJTce0GfMAAG/MW4SiFerizx27USQ1HQcPHcH7y1ZpLmH98tvvuLN9D6RWvwVtOz+KPf/u09T18WdrcW+3x1GhRmN0evAJnDt/QdWx/OPPUbdJO1yffjtemfWORiPnHO+9/xEaNG2PSrVvxeNPPYcLFy+p62a9tRC1bmyJ2g1bYcmyVabHNO3mu/Ds8y9j2OhJuO6G29G09f34a+ceTJz2Jmo0uBMNm92LP7bvVPPv238I3R55ChVrNkH9W9tj3oKl4Nz3WK1gNfujSGo6pr7+FvoNGY1r05rh5hYd8eeO3er6XX//i3u7PY7U6reg2V3d8OvmbQCAO+5+EI3v7KLmO3zkOIqkpmPegqUB/TbffL8Rre7tiZuad9ToMVt/+Mhx9OgzBBVrNsFNzTvii6++AwC069Ib7y9bhYOHjqBIaro6ulgkNR2PDxyh+S3adHzY7zb8HQvOOcZOfA1V6zbHtWnN0GfAcBw/cUqtf//BwyheqT7cbjdefmW2ZsT1ux9/QYt23VG+2s1o0a47vv9xk+FvsWzlGtzV+RFUrHUr6jRqrbYNmbNnz2PQsBdRo8GduO6G2zFs9CSNnSi069IbtW5sqS4ro8NOpxMAMPvtxajdsBUq1myCrg8/iX//2296PM2Ov3Lc5ryzBI8PHIEKNRrj4OGjhroJgohdYjY4CpS589/HfR3b4pZG9fHRqi/xxVffAwBmznkPL056He1aN8eIof2x5MNPMPfd9zVlOed4bOAIfPbFegzu/wg639sGTw0bi9+37UDTxg1xf6d2mD5jHg4dOYbX33wXD3XriLRa1bFgzjQAQNPGDbFo3iu4rUkj7DtwCB0f6AuLxYIJLzwDxhh6PfGM5iQx+NlxaHVHU7Rr0wLrv9uoBlWbt/6JPk8OR/myZTBu9FCcPXdeo/Pjz9biqWfGokG9NIwfPRQ//PQrxk+eCQBYtforjBw7FQ3qpWHUswNx+Mhxv8drzjtLcPVqBgb27YntO/5G83YPYPee/9C/Tw/8u/cAJkyZBQC4cvUqOnZ/Att3/I3xzw/FbU0a4n8jJ2Dh+ytzrTk7Jkx9A8WKFsbAvj2x6+//MGHqGwCAc+cvoMMDfXH8xEmMG/00KqaWQ/feg3Dl6lV0aN8KO3btUU+EX379HRhjaH/XHQH9Ng8/8QyaNm6IyeOHG2oS12dlZeH+h5/E1j/+wshnBuCWRvXwcN//4eixExg1bACqXV8FJYoXxaJ5r6ijnYFgpMHsWHy74We8MusdtGvdHM8O6QsOjsSEBLVcyRLFMG3CSABAp3taY9G8V1CrxvXYsWsPuvToj5SUZEx56TkUKFAAnXv0w87d/+j0bNy0BQ3r3YDxo59G8eJFMWTEeOw/eFiTx+1246HHn8bSFZ+hd8/7MahfL9Sodi0YYwHvNwD8+99+DB8zGfXr1sHYkYORnFwANrvN8Hj6O/4K4yfPREamA69MGo3UcmVypIUgiOgnZi+rBcork0ajZYtbcUOdGli7foM6IjB3/vto2rghRgztBwD48effsPqL9Xjy8Z5q2X37D2HdNz/gmUGP4+EHOwMcWPLhJ/jsy/Woe0MtjBv1NL5Y9x06dHscly5dxshnBgCAbjQLAMZPmYkrVzMwY+oLKF2qBEoUL4bujw7Cvv2H1O2NfnYgeve8H8eOn8QHyz/Fnn/2AvBMLmeMYf6bk1GqZHGk16mBz75Yr5abO/99XFu5Iia/OBxgwJ5/9mHFJ59j8rjhWPjBShQpXAhvzZiIpKREFC1SCD/+/Jvp8WpQtw5mTH0BAPDBik9x5ux5zH9zMhhjeH/5Kuz2alq3/kfs3X8Qr0wahZ4PdEKPrh2w+stvMPudJejZvVOuNGfHve3uxEvP/089NspxWrXmKxw7fhJvTH8R9evWQYN6abitdVf8unkbOrZvjdHjpmPt1xvQu+f9+GLd92h8UwOULlUioN/mvg53YfSzA001ieu/++EX/LXzb7w+eQzuaXcnMjIysWTZKqz75gf0fKATihUtjKsZmaptBIqRBrNjUTAlBQBQpHAhdL//Xl0QllygAJo3vRkAUPW6KqqWSdNnIyvLiekTR6HqdZVRP702bm7RCfMXLdf9NtMnjsLVqxnYum0H6qfXxh9/7sTWP/5CpQrl1Tzb/tqNHzb+hhFD++GZQY/naH9FEpMSYbfbkJKSjHva3olHetwHAKhUobzueGZ3/AGgYoXyeHvWJNjt9qA1EQQRvcR9cGS3ew5BCe+ltsxMBxyOLBw+ehyHjx5H5dpN1bzXX1tJU3bfAc/JccprczHltblq+qlTZwAApUuVQNPGDbH6y2/wcPfOKF2qhKmO/fs9PWr5sszJ02d8Wm1ercW9Wr2X+Q4cPIJrrimIkiWKGda9b/8hHD1+EpXr+PYlIcHj9A8cOoLU8mWRlJRoqk1EOV4AULxYMVy4cEnt5RcrWhR793nuLNrvPTbpdWoCACwWC+qm1cJPv2zOteZsNdp8GksUL4rDR094NXmOcacH+2nynzx1Bs1uvQk33VgXX371PR64rz2++/EXjBv1tKdcAL+Nsp9miOuVoOqpYWPx1LCxanpu5/cYaTA7Fg0b3IAl77yG8S/PwDuLluOJR7tj2ODHYbP5dwn7DxxGcoEktS1Ur3otkgskqb+3yJx3lmDCtDdgYRZUqZQKALhwQXtpdN/+gwCAtNo1crCnelLLlcEnH7yFsRNfQ+2GrfHwg50x+tmBKJiSrMsbyPGvXeN6CowIIo6J++DIiIQEO8qVKYXy5crg+eFPqemyo1V6wI8+dB86tm+tppcvWxqA59LR6i+/wc0N62LFJ59j2OC+KF+utBpMZGZm+uqq6Klr4VvTUaRwITW9Vo2q2PrHX371lipVHBcuXMT+A4dRuVIq5OkalSqWhz3BjplTx6rbttmsnrIli+OX337H1asZKFAgyXCuRzBUqug5Gf7+5w7Ur1sHbrcbv/+5Q03PjeagNXl/r1cmjcL111ZW02vVuB4A0LF9K4yd+DrWf7cRDkcW2t91h6oFCO63MdThrW/40/3Q5OYGavq1lSsCACwWq8Y2AE9QesIbdDscWcjIyMjxdmXatrodd7VshqUrPsMTg0ehYoVy6NG1g7reYvVcdZftVBlhrXZ9Feze8x+uXM1Qf1eF/QcP49nnX8bzw5/C4P6P4MefN6P9/X10GiqmlgMAbN+xG21b3e5Xb0KCDWfOnofT6YTNZsNFaQ5a45vq48uPF+C7H39B5wf7o3Cha/Dc//rrjmd2x58gCCLu5xyZ0adXN/y6ZRuWrvgM+w8expdff6+bB1GlcgW0aHYLlq1cg2++34i9+w/ik9XrULJkcbjdbgwbPQm3NKqHxW+/CqvNiuFjXgYAWK1WVKxQDt//uAkffrQa/+09gO733YMCSUmYNmMedu7+B1v/+Avbd/xt2POVubedZ5Lqs89PwpJlq/C/kS9p9+Xhbjhw8AjeevcD7N1/EN/98AsuX76qls3KcmLIiPFY+MFKvDjp9bw4fLizeWNUrpSK6TPfwXvvf4Qhw8fj5KkzeMJ7+SY3msuVKQUA+GGj+eU/I9rfdQdKlSyOmXPew+/bduCvnX/jh42/qRP0723XEhmZmZg0fTZublgXZb3byc1vY0TjmxqgVvXr8e7i5di4aQv++W8f1qz9FmVKe0YWK1cqjxMnT+ONeYvUCeNVr6uCX379HROmvoH7eg7A+QsXg9q2wtz57+Ohx57GkmWr1PlCVqs2+CxdsgSSEhPx2Rfr8dGqL3D8xCn0erAL7HYbhj73EpYsW4Whz02A3W7DIz26aMpeveoJ3n7ftgNLlq3C8y+9YqgjPa0m6qfXxisz38H0mW/jvSUfYfiYyeCc637nqtdVQUZmJoY+NwGDhr2Idd/8oNazZu23uKfrY1iweAX+2LYTTqcTVm9wJx/P7I4/QRAEBUcmPPXEw3hhxCD88PNvGDZqIjb+skV3txRjDG/PfBkd27fGoqUfY/T46Th05BjOnD2HJctWYfPv2zHymSdRvFhRjB42EJ9+/rV6V8zkccORlJiIZ0ZPxPc/bsK1VSri4w/mIDEhAWMnvoa3FizFmbPnAhrJadWiKV4YMQjbtu/ChCmz0L7tnbimYIq6vvO9bTBj6gv4+5+9eHb0y1iz9ltcunwZANDrwc54sm9PrFv/A16d9Q569+yaJ8cvJTkZKxfPRu0a12Pk2Kn4/sdNmDxuOB56oGOuNd/RvAkqVSyPOfPfN9y2GUWLFsaqpW+hUsXymPzqHLz2xnycOn1GvQuxbJlSaHxTA2zfsVsN3gDk6rcxIiHBjg8XzsJNN9bFm/MW46Ups3Dq1Bn1ktPQJ/sgPa0mXpo8EwuWrAAATBjzPxQrWhiLl36MFrfdohmpDIaWzW+F0+XCc2OnYMmyVejXpwfu79hWk6dAgSS8/OKzOH/hIoaNnoSt2/5C7ZpVsXzhG7hw8RL+99xLuHzlCpYvfAM1q1+vKVuj2nV46ole+Ob7jXhj7kL06/2goQ6r1Yol77yGu1o1w4zZCzBx2htIsNvhdDp1v/PAJx5GvfTa+GT1OmQ5s9TLngBwY700lCldEuOnzMT0mW+ja+e78WTfnobHM7vjTxAEwRyOzLy5jkIQBEEQBBED0MgRQRAEQRCEAAVHBEEQBEEQAhQcEQRBEARBCFBwRBAEQRAEIUDBEUEQBEEQhAAFRwRBEARBEAIUHBEEQRAEQQhQcEQQBEEQBCEQk8ER5xxOpzPP3hNGEARBEET8EJMvnnW5XGjarhe+XbMENqsNnAHMJC/ngPrKNA5PRvkT0nrvV+ULAwy3oWaX6/GmkS7SRbp87Nl/HM0fmozLVzJ9GYzq8EdO85sWM6hITCJdEafr/rsaYs7Yh6PO7sOhy8odJkoIhZgcORLR2BX3GZNqVKKRMW2aXI+czuAzaKbLrPULmm2SLtJFuox1KRVw4Xu2CKV1+bmBAt0WvcW4LkWXiXRFtK6otfsw6SLMifngiInWIkTVTDQcwWpEA+JMatsGbdfIWDVOQVgU6yBdpIt06XXpNqQiu3azE7NRRcwkXYYZnGqlOklXROuKVrvPd11EtsR2cCSH7gC4xso8y6LBiJ+K4WqqEQ1YWKExZrF+73fFqLncvkkX6SJdJudFsXZRoXyC1BU0SFeEGZX3bYcZlVG2SboiXJe+imix+/zWRWRPbAdHTP9dEzV7rVET1UNvuIxLaUI5TVPnvv6NkQSd5ZMu0kW69DDhi+rhxZMt86XpCiqFjc4AXqHiGSk7gWI9pCvCdenlRIXdh0sX4ZfYDo684bPYgdF0ZgSjEqNsxUi50AYZE/KbtFsmpes6TqSLdJEuc11GqN1mQbSa2cjLG60zOkuJws3gJtsgXRGrKxrtPly6CL/EdHDERUMSlgHPJ/caLZRkf0YmRu3+2jR8eZhSP9Nuh3SRLtKl1yVVo61EMylJFiDskF9x2cGl70z3nXRFuK4otPtw6CKyJ6aDI9lmmJwmJzDJdrg2HxMMWlmvszXuM37u/ZPFkC7SRboMdEnrtJGTeIYQPw1qDugEIJ/YjRTq6yddkaxLryIq7D5Mugj/xHRwJFsMl9KYQR4Gof8iGxKHri3rbI35XSRdpIt0mejyl1evlEn5/JyNNPnMTuwG3XFdGdIV+bqkrFFg92HTRfgltoMjqZPCIETQch4pSb1E7qf3Ihu5UVbD4qSLdJEuY11+9BmuVL+aCZKVMIN0k40xg/WkK4J1aZOiyu7DoYvwS2wHRwpCp0Zjg1zzofuuL6AN2pnyH9dmVXoCYlHddWLSRbpIl8m5k2dzYjQqkk2UpTsA8g6Ke2F2eiFdEa/Lmyeq7D4cuohsiY/gCPqOCfcmys1LvKkC0jrDx7+bGZufjg3pIl2ky0CXuJaJqWYnYCWP9gzANZN+jb4b1MeMFuRtkq6I1yXLiwa7jwBdhJ6YDo7kTotiiKJh6oxMNEaljBKRc8EwhfapGLDO/jjAFMNXtstIF+kiXUa69DCT72Z5uDdFrNRMpFSf0U5ws+2TrojVJcpRVke43YdFF5EtMR0caYJmJtgj8xiYWTNVCykGyKRlqXIG+J5FIRoe02aVl0kX6SJdPl06HUbaDGHSpyheEKvbc27wKZxtmJyPdEW2LmEpiuw+XLoI/8R0cKQgNzU1VOdSs5INSvQBzDib7tI7M8jkZxOki3SRLikRMIiWDPIEjCjOSIl49oGQ12DDpCuCdemXosLuw6CLyJ6YDo5UmxLakhKxw/sp2p5seEbPhpD9uCYLM8kkJZMu0kW6DHTJhbRfgkDZKjfZkCxE3AGTEzHpimxdiEK7D4MuIntiOjhSDYb5FlS7EYzUqKkxg3QY5TWyNGa8XvMGZtJFukiXTpe+MiM1OcG7MQYYn1KMTjEG5UlX1OiKRrsPhy7CPzEdHGmidAkmGamYURPF61drV2bT5pnchuXeA+kiXaRLem0X93lw3SvHuXEFOqRMXO7Hw2R/zCrnpCsadJkoinS7z3ddUcD7H32O9g88icXLVuvWHTpyHH0GjcGDfYfji69/CMn2bSGpNcLQ2YLYvkQLFNJ0bV9ME/PJkb9Z+C9vl3SRLtKlzyvnEL26sqGAnLuUSffOBeWrvHGzys3qI12Ro8tEUaTbfTh0RQH102rgn/8OGK57bc4iPNK9A+rWqY4eT4zArTfXR8GU5DzdfmyPHPlpt1xYL74IkMsGJKwzrNu7XhwyFW1PvLs12/fbkC7SFc+6RJQJGroRB8DwGoJuQocZXPrOYFqAG1RGuiJYlwmRbvfh0hUiXC43nE6n6Z/L5Q6onupVq6Bs6RKG9f/82zbUrVMdKSnJqJhaFlv+2JnXuxHbI0dc+JTtgRllZFJULtfHhajcW6km2Oce42TiRpV83nUGq0gX6SJd8kaNrjcoG1DThJrEV5czg53Q75XBViWF8k6TrqjQFbV2n8+6QoHL5cZNbXrBbjEPgAoWTEbxooXBvEI6t2+JLve0DHgb5y9eRJFC1yDFO1JUMbUsTp0+mzvhBsR0cMSkT7P+hdgelQJGRqQxdqkNa9KEjTLpk3SRLtLlX5d/DDZmul5B3JL8aZQmn8oCUUm6wq9LmxJtdp/fukIB527YLW7sOF9G3Q0RBqAWjuHzpW/AZgsu/GBgcAujjm7OwSx5v2Oml9UuX76C8dPmoscTI9BrwCh8uf4nAED/Z8Zj59//5XhD46bOwZY/dgQl8tz5ixj47EQ8+PhwLFr2WcDluPTJDNZpYNAZU3aI+YzqVDVwgzTSRbpIl7mu7Co3S+BymsmWuEGaWMZUFOmKTF3axai1+3zSFUo4swDMqvvjLPczeQoXKoiLly7j0uUrAICDh46hRPGiua5XxlTpi1PmoOq1FbHwzQl4c9oolCpZLM83HijvLF6JZk1uxII3xuPzr37AgUNHAyrnrx+jSfNjMNxgwaw+JuXTaPDTkyBdpIt0mSjI9iGCBv1wZrYVKa9at0lexqE/SKQrcnWZq4sKu89nXSHFYjX/C5LFy1Zj7Tc/wWKx4JaG6dj65y5cunwFBw8fRf0bauaheA+G41oHDx/DwcPHMGnMYDDGUCApCfXSaujydew5GPNnjEORwtdg3sIVKJCUhAfva4fFy1ZjxadfISkxAU8P6Ik9/+7HNxs24Y/tu3FLw3QMHfAwVn3xLZYsXwPGgCFPPIRGDdLQ/5nxaN28CVau/hrjRw5EarnSAICfNv2Oe+5qDpvNhrSaVbHx1z9QMbVsjndW17S9bcygWaoEY0v+6iNdpIt0mejKTomyAc21BiatFNZr8hmpE5fl9UJ5wx0jXZGpS7sZzdpItfsI0ZWnWKwmWw9s6Ork6bMYOmoKTp89Dwtj2PjbH7i2Uqo6T2lw3x54ftIszJ7/Ifo92hUpyQXyTrsXw+Bo34HDqF61siokp7yzZCWWz58Ou91T/Y11a2PDz1vQp0cn1E+vhX0HDmP12u+xaPYEZGQ6MGTkZDRqkAYA+HPnHsyfOU6z7TNnz6uBkmfy1TndNpevWocVn64DAHDv2CHnXP0uYhSFBzzcGGC+YIYvSZcxsh2a+d28dgQ5rY905UF+5met3+6v2FVnBvmyU2e0PaMDRboiW5efnJFq9xGiK283znKloGTxonjvzQmm68uWKYm3Xn0h6PoDISQTsu9udRvGT5uDx3p2QY2qVXTrf936Fw4fPY5HBz4PALh85aq6rmO7FvqTodJ7AODmbsPJV13u8c14dzqdaNquF4wGeYnowbBpid0uqWvEGTwj7AadVDHBNJ9BZ9i4EoM00pVrXYo7DatTJ2KDKLL7sOgKNbkcOYoEDIOjShXKYfeefeCcZzt65HQ6dWlD+vXE7j17Mf3NhWjRtBG6dmyjy9OqeRM89Xh3XbrFop8GVaxoYRw6chzXX1sRBw8dw/XXVvSrScFs5IiIDjgAC2O+UXj470TqnIOQpvokA8cil9WtZtBqMEojXXmiizEW9Ig1Ed8odhONdp/vukJNDARHhhOyK6aWRdkyJbB81TpwzuFwZOGTNd94giUwuN2eHSxauBB2/v0fLl2+go2/bgMAZDoc2L1nL6pXrYKuHdtg8++eO9RKlyyOE6fOAADqp9fEV99txKnTZ8E5x/ETp/2KbHJTPWz9cxecTie27/wHtzRMD2jnuJvTX5T/iSiNW/sjC2liT0lKMxqR0NQlOhaD9qu+J8loHenKE10Ag4UxMAv90V8Qf8y/fUWq3YdbV0hgFvO/KMH0stqYYf0xbdYCrPzsayQmJqBbpzZgjKFhvTr4eM161K5xHbp3aYuXpr+FatdVRuNGnoAlMzMLi5evwb4Dh5HldGLE4D4AgNYtmmDc1DnYum0XRgzpgz4PdcaAYROQmJiA5rc2xCPdO5iKfKR7B4yeMBMfr16Pu1vfps4/yg6Xm4O588saiLyGMUDuf8gjxZwZ9E/ELpL4KVYAkx6YkEezmvk+DaoiXXmgCwywWBisFho5InKORRiWiSa7D5eukGKN/pEj5nBkRo/aAFHmHK356N2gHzRFhB8GICnRrh0u965Te0g5OI/mdEhZt70A1pGu4HX9e+AE2vSZjstXMnOwVYLw0Ll1A8wY3SPq7D4cuqzckYOaAkc59/6FG2CslqM2tmHD6sg/N0e2ulzicrnBWGDvcSEiD3G+EZRPb0IwYws5LaM6Lw7tU2mFZdKVt7qsFgus1ugZeiciB+a9ZBONdp/fukIOs2p3XoGL1xEjGwqOiIjFbWH+uz/Cd12viktD1lyf36AazTomDmsLeXV3i5CuPNHFGIPVSsERERzq5dgos/tw6Ap5gGIxmV/E3YArxNvOI2I6OHK63AAFR1GLRWnFipdQYiXZ4QiLsiMwXtAVV78zfVYdOodFuvJMl9VqgY2CIyII1Dudo9Duw6IrlDBmPHKUP1vPE2I8OHKZ/EBENGBxey6rGfbIANUbGDoco59d7o1B/z1H1/VJV57qYgywWS2wWYN/xQARv4gT+aPJ7sOmK5RYrCYjRxGhLiBiOjhyZLnh5lEyhkfosCqX1RSEXpbiJLi4LPbQlOvsgrfQ3RkiOBsuzgUQPQwzcThiAunKG12MIcFug9NJbZbIOerl2Giz+3DoCjUUHEU2ngdUhvriKhEquMXi+fWkxq5+yD0tsYemOAXFscgeQnQmQn5Nb07YJJc+fRf2SVde6WIAbDZrxN/FQkQmmrlqUWT3YdEVaqLsmUZGxLQXcjhdoMccRS82K4fpS9ek1i/7GflT6YWpPS2xp+arRuO8dMPdIkoG0pWHuhjsNisS7HRZjcg5hnPVosLuw6Ar1NDIUWTjzHKB03zsqIVz7vErcnsSGrx6W6rYW/IOSet6W0zjj3Q9MXmomwnrdE6HdOW5LsaABJsVTgqOiCCwynPVosTuw6Er5NDIUWTjyHLCSkNHUQuHVfmiOg8FTU+Ladq/zxHIzgOSU5GGoBmEgSqNd9PWw6T1pCuPdIHBbrciwR3TbokIEcrIUdTZfTh0hZoIGzk6euwkypYpmaMyMe2FMhxOWK0UHEUrbuXFwWKvx9urUhq+2pMSnQKgdwxMyKM4FWbgKJjBdy45MCboIF15posxhsQEO70smggKu83TmYo2uw+HrlAPHzHT5xyFdrtmPDViEkqXKo52LW9D81sbIikpMdsyMR0c0chRtMO135jQrpnQ0MVPaJeNemSGi8x/u+VSPtGHka680cUYkGC3we2ma+FEzrHZLFFp9+HQFWpYhD3naNn8adi+8x+s/eYnvPv+x0ivUx3tWjVDeu1qpmViOjjKdGTBaiVHG81wzqEMHikjskyz3rdOk+7Nx6QEsSen650ZDUN7N6j0+tQeHAPpymtdjCExwUYjR0RQ2KxWMB6Fdh8OXSGGWUyCozBOyK5T83rUqXk9/ti+G9PeeA+bNm9HubIlMXxQb1RMLavLH9PBkYMuq0U1jDH9pEQ5j/c/XcdLcSZCccWxcGk9AN21f00ebzn59lrSlbe61JEjCo6IILDZrKY2Fsl2HxZdIW5ilgi7rHbh4mWsWbcBn375LVLLlcbgvg+ifnot/Pb7Xxg1YSbee+MlXZmYDo4yKTiKapjXu+h8ixQwaXpTEByFkE+59VXNKzkSdZtK70opI+SRe3K6jhHpypUudeQoXB6UiGrsNulkHCV2HxZdISbSLqt16/0MWrVojJfHDEFqudJq+o11a6NMyeKGZWI6OMrIzIKFLqtFLwzqJRZ1XjbTD0GLjV/1FErbFJyF6EnE+oQP7cla8DoM0PbcFKdFuvJMl4UxJCXajX0qQWSD3WaLSrsPh65QE2mX1V4a/RTqpdXQpG3ash2N6tfB5LFPG5aJ6eAoMysLFhcFR9GK1eJ9t5rUs1LmFWh6R2LXSOxhiQhpRmXVoWgIdUllZSdGuvJQl3fkiCCCwW6zRqfdh0NXiIm0kaNXZy/EglnaS2evzV6ExXMnmZaJaU+U6XDCYqEh+mjFarUIXSShYTNoh4/h+w4hjzJ1xahXJeYX0fTqxHFrydGI+UhX3uhiDEi0x7RLIkKIcit/tNl9OHSFmkiZczR+6hyAMRw/cRrjp81V048dP4Xk5AJ+y8a0J8pwOGGx0MhRtGK1WvRtSexheRGdgegc5Ieo6byJlKb09NThcMFbqZtVnJqRwyFdudPlHTlihj1OgvCPTZxzFE12HwZdoQ5S8uKy2sdr1mPZJ2tRMCUZ40YMQClhbtDe/YcxZtIsXL5yFXc0uxn9H+1qWEfbVrcBADb//hfq3eC7rFa2VAmk1TK/jR+I8eDIM3IU3Y8wj2fsVqv21WoGPSFxtWmz40IR0aGIn8JwtJGzYpJTy66HRrpyrkt5CCQFR0QwKCNH0Wb34dAVanJ7We3M2fNYuPRTLJ4zCRt+3oJZby/F2OH91fXvLF6JHvffjea3NsKg5ybh4OFjqFC+jK6e+jfUBACMHzkQtWtcn6N9iO3gKDOLgqMoxm6zQoyOjNqazvFA4yfUL4xL6YrjkJ2ZXE74zgHNcDjpyltdjMEzcmSh4IjIOeoTsqPM7sOhK9TkduTol81/otp1lZGUlIi6aTUwZcZ8zfqU5AIoUrgQ7HYbKlcoD5v8Xj0vW/7YgfrptbD/4FHsP3hUt75ty6amGmI6OLpKwVFUY7NZjUd/pfalDiML6zVOQKhEfPaI7CjkR/sbblasU85DunKli3nvVrMavV2dILLBLs9XixK7D4uuEJPbOUenz5xDxVTPSFCJYkXgcruRkelAUmICAKBX93sxaMQk3HVHU7i52/S9aT9u+h3102vhu59+061jjMVvcORwZHne8UJEJYl239OS1ae7GuRT7tAQ30qtcRpeRyL6DdUhicPRguOBdpX2Wr6Yh3TlnS7vnCPq0BDBYLdZo9Puw6ErxGR3Wa3HEyPUy+ed27dEl3ta6rKJT8rnbq6pbvXaDeja8S6cPHUGe/49gEuXr6BgSrJuawMf6w4AeHnMkBzvQ0wHR5kOJwVHUUxmglP9bjhCC6E3xH3+RNdRE4agFYciOhLhhji1Ys2QNaCZOyA+Y4R05Z0uC4CEBDssFpc+E0Fkg81miUq7D4euUJPdZbVFsyfCZjMPP0oWL4rtO/8BAJw8fRZ2ux2JCZ5Ro4yMTHy/8Tf11vyMzEx8/9Nmw1Ggy5evGNbv5hzvffApBvTpZqohtoOjLCeY0dAeERU4spx+37Ol9oiYz2lovISyzLROSM6jPv/DKL+4LeV7Nr0v0hWcLsYYEu02WGnOEREEdpN5J5Fu92HRFeIAKbcTshvVT8PcBcuRkZGJrdt2oXGjuli8bDVKliiK25s0xNFjp3DoyHGUKV0CBw4dRdVrKxnW07JzX8/xkfaXMaBZ4xv9aojt4MiRRcFRFONw2LNvw0xyMoDvSbBMzaKi8y1ij0rML/a6oG/SRmmkK5e6vJfVrC5qs0TOsdmMgyMAkW33YdAVanI756hokULo1b0Deg8ag2tSkjFu5EAsXPopGGNISLBj1NDHMWTkZLjdbtS7oSZaNb/FsJ6fvlgY9D7EdHCUkUnBUTSTmehUG5PawMVlocVzoVelJMtOAkoZJU0c9padiXe97iFu3OeESFfe6lLuVrO582Hcn4g57N4bOKLN7sOpK1TkxXOO2rduhvatm6nLT/fvqX6/rXED3Na4QbZ1OJ1Ov5fv/BHTwZGDLqtFNeJlNbVJiS1d+WQa/wEwaZhZRHAs2oql9RDqFR2KtC3SlXe6PL1CG1wuCo6InGOzWaPS7sOpK1REyutDRr40Ay+PGYLGbR7SBqPe0bkfPzcfWYrp4CgzywXGyNFGKw6ny3AUVtPrEnpLml6X6ES8zka5Pi+WM6pb3Ybca8tGL+nKnS7GGBLsNrjpqfZEENikR0BEi91Hiq68JFJeH/LsU48CANaumJPjsjEdHDmyXGCMHG20kpXlvVtNbOReB2H0TA/DuzPEnpqBd1DbKoN6N4ia1cCBaTptpCtPdTEGJNiscNMdpkQQyK8PiRa7D5euUJIXl9XygmJFCwMACqYk4/yFS/h37wEkJSXi+ioVkZBg91s2poMjZ5bT+AciooIsp0t/t5riSKSGr3EGkHpeMDcD8Q3ZRmU17zqSPklXXutisNttcNOcIyIINE9Jjiq7jwBdeUykXFZT+HL9T5j46jyUKlEMNqsVVzMyMGH0INSsdq1pmZgOjjIdLgqOohhHlud5N2pPyKT3ZAjTD1UbDlEznzORnYxZWUUL6cpbXYwBCXar38c3EIQZ6mW1KLP7sOgKMZYIGTlSeGfxR3h35jhUrlgeALBpy3ZMmTEf78wYZ1ompoMjp5NGjqIZz8iR1MuSzpu6h66pC9A+z8PrSMR1XHAwYvWG/R2xh+fNpOYjXXmjizHYbVbQwBERDOprZ6LN7sOhK8Qw9T+JMLXtQtcUVAMjAGhUvw7efGep3zIxHRxlOd0UHEUxTpcLutbEzBflXpPu2ruyimk/RYdilF/ncAy9D+nKrS4G7/v0aOSICAKrOFctiuw+LLpC3MQsFgYYPsw1f8/HyhOy691QExs2bkb9G2oCAA4eOY4balfzWzamgyOn24X8/jGIvMPp9E6mF1q3ejmdC22cGfzKQq9KMwwt1aGUFTtoRt81vTphG6QrL3Ux2KwUHBHBIb6wOLrsPky6QojVahIc5fNghdkTsgHgmoIpGNLvIdOysR0cOd2g4Ch6cbnc+se+GwxVG/kiOV28M4QJaaIjkbdhtqxsw6gM6cqdLpvVAh6usXciqrEIJ+Nos/v81hVqTCdk53NwRE/INsFzWYaCo2jF8/vB70/IAJ2HkLMz3Rdhneg4lO9KD03sbUn5xGv9pCtvdDHmuR2bBo6IYLD6eQREJNt9OHSFmki5rCZz5WoGuNv3eJ+UlGTTvDEdHLlcNHIUzbikmbkcvsauvnUa0P7ERmlieX8JRo7Em64OgxsMT5OuPNIFBqvFQuNGRFAoI0dRZ/fh0BXiRmaxwCQ4Cg/rN2zC1Jnv4vyFi+oxKFWyOFa+96ppmdgOjui2l6jG7XZ75p/IQ9EwCXm570PjeAzKm1cirFYcmZBX7emZ1Eu6gtfFmPfJuhQeEUHAvAYYbXYfFl0hJlIuqynMefdDvDxmCBYt+wwvPNsP//x3EJu2/Om3TEwHR243jRxFM+rDAIUekfrmagg9ILE3BnMnIneoNJ00oW4xk663ZtJTI115oAtK75/aLJFzLEI0EFV2Hw5dIR85YhF1WS0luQDSalVFlYrlsX3nP2hYrw5mzXsfvXt0Mi0T28ERTV6IapS7ltQGnk3vSXYc/pbl/EZtNrs7PEhXHuviwgmOIHKI+Dy0qLL7MOkKJaZzrcKkp0Sxojh4+BiaN22EV2cvwr4DR3AlI9NvGdPg6PLlK3hl9iLs2rMXNqsVD3Rui9YtGqP/M+Mx8LHufh+7bcS4qXPQrmVT1E+vlaNyAHD46AlMnfkutu34G1+vnBdwOU6X1aIaNbgVPYMyxCxdm1eziOuFnpmuTUrrAYMyTJ/P7yRH0pVrXSyC5ikQ0YXGcqLM7sOiK4QwCzNsyxwsLBfNn3zsARQudA0qlC+DNi2a4MdftuLJ3t38ljENjl6cMgf102ti5NOPISMzE7v27MtrvQFTMCUZD91/N/73/LQclaPQKLpRYiNNY2bSp7jIDdbLzgeSgxDXMzmj57u6TtJCukKkiyBySzTafT7rCiUWP8GRK38kaKiYWhaA5w7oe9s2x71tm2dbxvDex4OHj+Hg4WO4v0NrMMZQICkJ9dJq6PJ17DkY585fBADMW7gCi5etBgAsXrYanXoOQffHnsVvv/+F91eswTcbNmHCK/MwbdYCAMCqL75Ftz7D8MBjw7Bps2diVP9nxuOTNd+g14BROHTkuLqdwoUKBjXiRMQmHFLgyzUfhhj5J8P1wkquTyJdIdTFKDQi8pBosftI0ZWXMMZM/8LBP/8dwKMDn8ft7R9Fi3t7Y9RLM3Dm3Hm/ZQxHjvYdOIzqVSsHvSPvLFmJ5fOnw273VH9j3drY8PMW9OnRCfXTa2HfgcNYvfZ7LJo9ARmZDgwZORmNGqQBAP7cuQfzZ47L8baXr1qHFZ+uAwB6wm6Mo7OMCDmnkq6cYaSLgQU+9C/2kv1ly6NLCaQrZ+S3Ls65oe83DEQCPUUEmC+YU06k6soL/I0chYOXpr+F9q2boWnjBrBaLVj28VpMmD4PU18calomJBOy7251G8ZPm4PHenZBjapVdOt/3foXDh89jkcHPg8AuHzlqrquY7sWQQVlXe5piS73tATgeeFs03a9ghNPRAw56Ykx5MChm+STfXRuTxCkK2eQrpxBuohIJdKCIzd3o1P7O9Xlvr3uw4N9h/stYxgcVapQDrv37APnPNtAxel06tKG9OuJ3Xv2YvqbC9GiaSN07dhGl6dV8yZ46vHuunSLn6ec5hRLdo8nJSKaQILkbDudRhmENIN5jYF2ZEkX6SJdEaaL7lAOkBCfFk0voYUpwq1xfRUcPHwMFcqXAQCcv3AJlSqU81vGMDiqmFoWZcuUwPJV69DlnpbIynLi869+wD133Q4Gpj5/pmjhQtj593+od0NNbPx1G1o0bYRMhwP79h9G9apV0LVjG3zx1Q/o2rENSpcsjhOnzgAA6qfXxJCRk9G9810oXqwITpw8g9KliuflsQAAb+RKwVG0Ivc8jJykuKw8BdboAr1alnu/exM05YU8ukmN3iF90yffki7SRbrCqotz0B3KgWINbfWRMnLUs/9IMAZcvnwVP/yyFSWKFwEAXLx4BaVKFPVb1vSy2phh/TFt1gKs/OxrJCYmoFunNmCMoWG9Ovh4zXrUrnEdundpi5emv4Vq11VG40bpAIDMzCwsXr4G+w4cRpbTiRGD+wAAWrdognFT52Drtl0YMaQP+jzUGQOGTUBiYgKa39oQj3TvYCpy7oLl+OHnLcjIdKBnv+fw8AP34o7bbsr2wNDIUXQjP/NG7lHK+OuUMOGL+l2oTOO/JWfOhTTDzhDpIl2kK+y6ODiNHEUIkRIcDX6iR9BlmcORGXPWpMw5+vdyWVBwFL2ULF4IX737P5QqWkjXc9QQYFpAw/NKzzSbvGJvl3SRLtIVfl1ulxsOZzhuFI8+CiaE5rSvnHsL3fsUmEU/PMXdLlz45HVsWP0ubLb8fwZ1RqYDAJCUmJBt3ph+QrbFagEFR9GL1WKB7vZur6OENGRvOAQvkt1lAQNf4c/H6zZBukgX6QqrLs453C63rhxhRGjPi9Y8GDn6eM16LPtkLQqmJGPciAEoVdI39ebylauY+Mo87Dt4BKVLFseLw/sjJSXZtK7TZ85h3NQ52PzHDliYBfVuqIHR/+uL4sWKmJaJ6eDIZrWCgqPoxWb1Ts6XeqkaJyw7Web71DhTAzMQk8SheqPsynY0Dp90kS7SFTG63JzD6aKRo8AI7ak/txOyz5w9j4VLP8XiOZOw4ectmPX2Uowd3l9d//ailahRrQrGjxyI//YdQnJyAb/1TZ25ADc1SMOUsUPBOceKz77ClJnvYtLzg03LxHhwRCNH0YzVGxwpTlUc0lf9tHeF2ZwIsbyInGbYZoVMmrkNTNBDukgX6YoMXZzDSSNHEUFuR45+2fwnql1XGUlJiaibVgNTZszXrP/qu41Y+vYUAMC1lVOzre/QkeOY+PwgdfmBTndhzdoNfsvEeHBkDThSJSIPm9Vi2AsVHSn3pjMjjysW4+KCSVadh/ZTn0EC6SJdpCt8utycw0lzjiICi8nIEfem9XhihLq+c3vfMwoVTp85h4qpntvuSxQrApfbjYxMB5ISE3A1IwMWZsGS5Z/jux9/xc0N09H/0a5+9VitFhw9dhJly5QEABw9dhIWq//YIKaDI7vNQsFRFGOzaS+Lyr1VTQ81kJ+ZSf5WWFCdupRukNWXn3SRLtIVMbq4myPLSSNHkYCFGZ96uTdt0eyJ/idkM2ieds7dXK3vypUMnD1/Ael1quGh++9Gn8EvoPmtDVGz2rWm1fV5qDP6DH4BN3nfxPHrlu0YMaSP332I6eDIZqORo2jGZrWAQdsrZRASFO8M79C6kceUlpmuMi2yU1aG7OU7dEQdpIt0ka7w66KRo8ght7fylyxeFNt3/gMAOHn6LOx2OxITPHeYFSlcCHabDTfUqoaEBDvq1qmOw0dP+A2Obr25HuZMf159j+ujD3ZEarnSfjXEdHCUaLdRcBTFJNhtGodp+ksyyUlzr69l2jzwrdb1SA3rZj5/r6uLaxdJF+kiXeHV5XZzZGbp39hA5D+5nXPUqH4a5i5YjoyMTGzdtguNG9XF4mWrUbJEUbRq3hgN0mvhp19/x803puOPv3ajQ9sWfusbN3UORv+vb7YBkUhMB0d2Co6iGrvNqm9KwhC+pwtpnMbM8kNYF4BpqHffmPRsSRfpIl2Rocvt5sii4CgiyO3dakWLFEKv7h3Qe9AYXJOSjHEjB2Lh0k/VOgf3ewgvTn4TM996H+1a3ZbtpOwzZ8/jxMnTmscBZEeMB0cWMJZ372oj8he7XXtZVOkxij1HMU3sWapD9kpxI4fqXZZG6PXfhUQOgAnD+6SLdJGuyNDldrvhyKLLapFAXjznqH3rZmjfupm6/HT/nur3sqVL4M1powOuq07Nquj15Gjc2exm9S5oABjU1/wJ2jEdHCXYbRQcRTF2m03TlIz8qtl6HUY9XLk+Ljh2JYtcmXSCIF2ki3RFhi6Xm8NBI0cRgWwL4Yejc/s7c1SCgiMiYkkQR44Meotmy0aOXIPkmNWi3jTRIQPQDOXr6iRdpIt0RYQuN6fgKFLIi5GjvKR3j045LhPTwVFSop2CoygmMcHuaUqS05R7kPJwv5ImJqh3z4gYtVOm8fvaJ/4qDtzEmZMu0kW6wqfL5XIjIzPLoBIiv4mUF88qHDtxCrPmfYDtu/5BgcRENL6pLnr36IgCSUmmZWI6OEqkkaOoJiHB6punIDhktccoOEm1yckOF4JPN3LIUiYu1a1O/lSyKekGJwrSRbpIV/h0ud1uulstQsjthOy85sUps1G7+vW4795WsNmsWL5qHSa//i7GDHvCtEzsB0cWCo6ilUS7DT6vKDhcpvW5aq8SPucp9lzVT9Hhcm09au9USFNPBFJ7Nj0RkC7SRbrCpsvl5sh0UHAUCUTaZbWLF69gQJ9u6vKooVXwYN/hfsvEdnCUYKfgKIrxzBnzLUudVk+a4FRFZ60U4LIT59BNY1KduAAzqEdNkuolXaSLdIVfl9vtRqaDLqtFAlaYvD4kTMFRxdQyOH3mHIoXKwIAcDiyULZ0Sb9lYjo4SkiwwULBUdSSmGDTNDAmfQI+JyrPaVCcqdwU1WWuLatxtiJcm27quEkX6SJdYdVFI0eRA2N6e/GsyHcpAACn04WBz05ExQplAQCnTp9FRqYDw198FQAw6fnBujIxHRwVSLJTcBTFJCbY1e/qa3akrqpmqF3sesp5DYbkRf8t312j9H4hOGlRg6anTLpIF+kKuy6Xy42rGTRyFAmYTsjm+rT84LYmDXJcJqaDo8QECo6iGc/Ikec7gzAkb9C+NHexePMozlPysWqi5vZjpW4u1MF9flz06Ry+sqSLdJGuyNBFl9UiB8YYLAZDR+4wTchu1/K2HJeJ8eCILqtFM4kJNjChq6j0FuV5SIAvjXu/q58cOgerc8CCI5ZvQZaH941uPyZdpIt0hV+Xy+Wmy2oRgsXCYDEYOVJ/wCggpoOjJBo5imrkF8+CS04XgmOWHKnSq1SLCo5XKSwUVXulSj0Q6uaCA9d9ki7SRboiQpfLzZFBI0cRgdVk5Mjw9v4IJaaDo8REKywWa7hlEEHieQgkEzyvb53hQ+UA7dC/2o31OVqNB2bqan0dgg6lx8vklaSLdJGuiNHldruRmUkjR5GAhXn+dIQpNho/bS5GDX1ck/b8xFl4ccQA0zIxHRwVSEiAxUrBUbSSlOidc+RtUIpDNLr9V0HT9ph+PSD0RLmQh/nyiU5d9efiSmljpIt0ka7w63K63Lia6QARfqwml9VYPl9WO3biFDgHdu7+D8dPnAb3WtCRYyexZdsOv2VjOjhKSLDBSsFR1OJ5zpHP6ypzF0Qnq/pI0esKjloD06bpnvoLnxNWgjKju2bkHi/pIl2kK/y63HQrf8RgtQBGM1p0c9dCzLgpcwAAB48cQ/9nxqs3BZQtXQJPPf6g37IxHRwlJtgpOIpiEhM85qn0JAGvLxR7mNJ6FcWhSl1VTZJUj7JekyY4cLG3qmggXaSLdEWGLhfdrRYxWEzmHOkNI7TMmjISADB+6hyM+l/fHJWN8eCIRo6iGeUJ2Tqf6k1Q74IReiNGtxcreZR1YvPM1pELdamL3FeGdJEu0hUZumjkKHKwMuM5R+Gaj53TwAiI8eCILqtFNwnKu9W4tlGJ7UvjeAWnrCwyQPNsFg1KmtxjZQZpUjllA6SLdJGuyNDlcrvhoOAoIoiUkSOFjb/+gflLPsaZs+fBOVfnya1Y8IppmZgOjpLoslpUk2C3aiZkA5LDlGEGjhpC71WuQ8iYbZqUQe7hki7SRbrCq8vtctOt/BFCpMw5Unhp+lw83O1e1Kl5PWwBxgQxHRwl2GnkKJqx261gktdVepa64XfDLqXgiIX18rK+EPQ9W7k3LJUlXaSLdIVXl4tzOLJo5CgSiJS71RTKly2N++5tlaMyMR4cWSk4imLsNqvHCRo4TtE3GjU3dQhfWfbWI/ZyOfetl0d71XqVL4ITVsuRLtJFuiJGl9vN4chyGWydyG8i7TlHrVs0wedf/YDbbqmvSU9JSTYtE9PBkd1uC3gIjYg8bDaL1nl609WJnxAcpvIpND6xs8sEp8q9iUzOKHtwJUmql0lfSBfpIl3h1+V2u2nkKEKItCdkz12wDBcuXvZqgDrn6MfPF5qWie3gyGaFzUbBUbRis1p8PUOm6zD6kJ0nfA6Uyw5W7LFCu07ulMK7XXWlNz9nUB9IR7pIF+mKDF1uN0cWjRxFBJF2We2LZbNzXCamg6NEu42CoyjGYrGAgZneGWMEk76Y3hasTdLkleuQvzMpP+kiXaQr/Lrcbo5MGjmKCPListrHa9Zj2SdrUTAlGeNGDECpksV1eZ4eNQVFixTC6ABu1f/+p804fvI07ru3FTjnOHP2PIoXK2KaP6aDI5vNQsFRFGO1CN1TsVFx7VcGGOZTh+Cl9VzqgSqXBQzhvp6pzjmTLtJFuiJGl5tzOJ00chQJ5Hbk6MzZ81i49FMsnjMJG37egllvL8XY4f01eX7a9DtOnjqLokUKZVvftFkLcPHSZez8ey/uu7cVjp88jZemvYUZL48wLRPTwRFdVotuLIz5HK2A/LZvM+Qep/rQOQNnL86bkCsRNWjykC7SRboiRhfnHFkUHEUEuR05+mXzn6h2XWUkJSWibloNTJkxX7Pe6XRi3sIV6HH/3di05c9s69u0ZTvef+tl9HpyNACgTKkSOH/xkt8yMR0c2awWz7wVIiph8kOOlPQc1CE6T9NyTFpv1OMNYNuki3SRrvDpcrs5nC53DtQQoSK3E7JPnzmHiqllAAAlihWBy+1GRqYDSYkJAIDlq75C81sboWTxIoHpsVjgdLrUQPzg4WNwZnMJNqaDI6vVAisFR1GL0pAMe5Be/PVozTPqk/zVY5hHGd4nXaSLdEWGLs7houAoIsjuIZA9nhih+vfO7Vuiyz0tpYye31OBu7ka2Jw7fxHrvt2IN6eOwvadewLS8+B97TB09FScPXcBr89dgs+/2oAnH3vAb5mYDo5sVivdyh/FMAb1rpjcIjp0xamK9Ro6XIP84pwK0kW6SFfk6OKcw+miy2qRQHavD1k0eyJsNvPwo2Txoti+8x8AwMnTZ2G325GY4Bk1+vGXrbh0+Qr6PzMel69cxbnzF7Fw6ad4qGt70/ratboNqeXL4Meft4BzYOLoQaibVsPvPsR0cGS1MlitedGUifBg3LXk3u8M0EzeFCd7apym8l3o9SoPjlOXveWN5jqITlh8YSbpIl2kK3J0cQ64XBxE+LFYmOeGGpkAJ2Q3qp+GuQuWIyMjE1u37ULjRnWxeNlqlCxRFO1a3YZ2rW4DAGz5YwdWr9vgNzBSSK9dDem1qwW8DzEdHFmYBRZGl9WiFqUdSV1LxTkC0N7pYlDU7IFx4nrZ6cubFdM0PWfSRbpIV8To4uBwc7qsFglYmedPR2CxEYoWKYRe3Tug96AxuCYlGeNGDsTCpZ8G/RDJb3/8FW+9twKnTp/zXq7zWNPaFXNMy8R2cGRyOyERZYg/oddDqk7SqHMCrfM0rEdZ5gbtVdkG1+YzLE+6SBfpighdnHsmZRPhhzFmGMjkJLhp37oZ2rdupi4/3b+nLk/99Fqon14r27qmznwX/R/thrRaVf1ezhMxzXX58hW8MnsRdu3ZC5vVigc6t0XrFo3R/5nxGPhYd9Ssdm1AG1AYN3UO2rVsGtCOyKz7diOWrvwC5y9cwoP3tUOHti0CKmf2AxFRCtd+Zd4v6rC64EDVHqyRcxerZPp6NN1T0SGTLtJFuiJYF9dM4iXCh5UxWP3MOcpvKlcoj7Ytm+aojGlw9OKUOaifXhMjn34MGZmZ2LVnX271BYXL5caBQ0fxxpRRuJqRgU4PD0GLpjeh0DUp2ZZVJvQSMYLwWxo9pVd0pIzpyyhwYb2y2vQOnEDsh3SRLtIVdl2ce/6I8MNg/FOF63Tc4/67MXPe+2hyUz1Nej0/k7INg6ODh4/h4OFjmDRmMBhjKJCUZFhJx56DMX/GOBQpfA3mLVyBAklJePC+dli8bDVWfPoVkhIT8PSAntjz7358s2ET/ti+G7c0TMfQAQ9j1RffYsnyNWAMGPLEQ2jUIA39nxmP1s2bYOXqrzF+5ECklisNq9WC3j06AQASEuwoV7oUzp2/EFBwREQ/ZiN/mg6od0F8B5vfOqXeq1ln1mz+hD9IF+kiXZGjiwgPZlNaeJjerfbL5m1Y9sk6bNz0B6zeB0MzBiyY9ZJpGcPgaN+Bw6hetXLQl6TeWbISy+dPh93uqf7GurWx4ect6NOjE+qn18K+A4exeu33WDR7AjIyHRgycjIaNUgDAPy5cw/mzxxnuO1Tp8/i4qXLKF+2tG7d8lXrsOLTdQCgDq0aXVbz14izJZshYTVbHjuXeNXFuf9hcm6wEHDPkftd1GjLKaQrZ4hFWC76lpF63iRdOSNSdRGBE2mX1b798Tes/mAmChe6JuAyIZmQfXer2zB+2hw81rMLalStolv/69a/cPjocTw68HkAwOUrV9V1Hdu1MAyMOOd4fe4SPNK9g+GDHbvc43uQlNPpRNN2vQy1iTUbPb7e7/ncZIVYRhwizgmkiyA87Vxs/2T3pCs3uojwwGD8s4brJ6x+fWVYjJ5K6QfD4KhShXLYvWefzlEZ4XTqH8E9pF9P7N6zF9PfXIgWTRuha8c2ujytmjfBU49316Wb7cCS5Wtgt9twz123+9VjhK6ReROyTZMqMXrhoVFHOcABE9IVgC6aQxBfqM+1iXO7J10510VzTCOHSBs5Si1XGoNGvIz0OtrnHA3q28O0jGEkUjG1LMqWKYHlq9aBcw6HIwufrPnGEyyBqbdLFi1cCDv//g+XLl/Bxl+3AQAyHQ7s3rMX1atWQdeObbD59x0AgNIli+PEqTMAgPrpNfHVdxtx6vRZcM5x/MRpvzu24ect+H7jZgx76pGgLvUxwNOyuLaRqvg5AXNxNTdIg9BgvfUzLmTi2rJiQdKVvS7OPc8uob/Y/1MvoZLdk66gdDH12Xb05/8v1ChPyDb6CwcFkhLR5Ka6KJiSrPnzh+lltTHD+mParAVY+dnXSExMQLdObcAYQ8N6dfDxmvWoXeM6dO/SFi9NfwvVrquMxo3SAQCZmVlYvHwN9h04jCynEyMG9wEAtG7RBOOmzsHWbbswYkgf9HmoMwYMm4DExAQ0v7UhHunewVBHRkYmxkychVIli+OxwWMBznHXnbfigc5tsz0gYkMTbysFPI1N6Ymot5gKaWI+7Rftojzsq3yK22fe7YsF1HKky1wXB9zZzDsiYgfGAAsY2T3pCkoXY6Dn2kUIZqN44RrZU27qygnM4ciMuTOPMufo2zVLYLPZ1Am/HPAN38qtNRD8lAmqOtKVjQ4OR5aTLq3FCYwxJNitgY8Ox6jdk67gdC3/8jc8+eKiHG48Pjn5w+SQ1Kuce0e/8iqsBu81dblcGDdkMDasfjfghzHmBZcuX8H673/BqTPnNOeT3j06mpaJ6SdkK10MTW9EbMAcft8w7bdeuccjdmeyK+f9JF3Z6ALgctPIUbzgGXIP4kXRsWb3pCsoXQyANYeTbonQwLz/jNLDwdDRU+F0ulCz2rWw2QLzMbEdHCnIv4c8dqsgNk7RESh5vb0kSA1fHPKV61Kr5EI66QpIl+dFkm4KjuIELl8SiVO7J13B6WKMGd7JTOQ/kTYh+9z5C1gyd3KO7CO2gyO5QUJY9q7XdHi8C4xJ+YV6mFhAWq2rnwu2YKSFdPnXxTmcLje4m14mGQ9YvI4r7u2edAWly2JhAY8KEKHFYvH8yYSrn5tWsypOnj6DMqVKBFwmtoMjaUhW0/aE3gvz0yA1w8NCg9T0XLx1ad4FxGE+tKyUIV1+dXF4rlHTyyTjAys8v7noU+PR7klXcLoYY7DRyFFEEGmX1ZjFggHPvISq11XSpE96frBpmdgOjpjBotiSpcbNzMpA32jFhq0M/zKpoPzsDsC4YZMuE10ccDrdcNHIUVzAvf+pDxEE4tPuSVdQuiyMwU4jRxFBpF1Wq5tWHXXTqueoTGwHRyLiKJLQuDTtjOvXQy7GDFfLg1SGm2fcwDZIl6kuAMhyueB2UXAUT8S73ZOu4HQxuqwWMZg904iHKTgqmJKMZo1v1KQdOXYCK1d/jfatmxneORc/wZGuqyIki12cbBoyjBwEfL0ZLnwXt8kYDJ8ES7r86AKH0+mCk4Kj+ECZeCIOHcWj3ZOuoHRZGEMCBUcRgYV5/mTC9N5ZzJm/DP/tOwQGhm6d2iApKRHvLP4Yf/+7H0ePnUT/3t10ZeImONI0Lhmh16K5vm1Qh5Ku8wnM18vRDD2LjdugXtJlrotzwJHlgtPpMhBBxCKKzcSz3ZOu4HRZLRYkJMTNKS2iibSRo30Hj+DUmXO4ePESps5agFFDH8f+g0cxZ/po9B44Jn6DI00DlRqV38btXQ/u7bBILZdLeQ2rYObrSFf2urKynMhy0shRPMCUribZPekKQpfF4nmIKBF+rIDxnKMwUaJ4ETzzZC84HFl45MnRADyvOiuQlGT4sEog1oMjbytj3u+md08IPRIlr6bxKa3doLDoANSvolPgvh6P6jDEbZIuc12cw+F0ISuLRo7iAYvFe2a0xLndk66gdHmCo9g+pUULDMZBbbjCpWsKpuCbDZtw6sw5gAF/7foHp06fRUZGJuwmNhPTlqS7vmnQkzFshMygzYrlxHqExqq++0dwChAbMAzWky5TXQDgyHJScBQnyA9oi1e7J13B6bJYLBQcRQiMMcPXAAXz4vi84Ol+PTF5xnyULV0CPbu2x5vzP0SHti3wUL/n0OSmeoZlYtqShPalG7rVZYK2QTOhZ6K2aKNGCqjvGDKoUl2nDjsz0hWoLs6BrCwXMrOcIGIfm9WiPXnGqd2TruB0WSwMiRQcRQSMaX87MT0cNKhbC0vfnqIut27RBADQs2t7JCUlGpaJC0sybMzQt2e1kXpXmP2OcjoDtC9hFNcJPSEz/0G6THRxjgxHFjIdFBzFAzaLBZpH6Mar3ZOuoHRZLRYkJdpNaifyk0gJjrb8sQP102thzboNhuvbtmxqWjamgyMuLWt6LTBopEorE3okakYu5JELS70bnXOQtqtr6KTLUBcAOBxOCo7iBN1t2HFq96QrOF1WC0Mi3a0WEUTK3Wo/bvod9dNr4bufftOtY4zFb3Ak/gxi70ZshxxCgzXooajLJo1WKKotrHyXekuG9ZMuQ12ccziynMh0ZIGIfRLtNo+txbndk67gdFmsFiQm0MhRpJDbMOjjNeux7JO1KJiSjHEjBqBUyeLqug8++gJrv/kRl69k4Mk+3dD0lgaGdQx8rDsA4OUxQ3K8/ZgOjnQYNXQutTdvC5efQwcO9YFjCp4TONQKjV57IE8KNzQY0mWoiwPIpJGjuMGR4Pmd493uSVdwuqwWC40cRQi5nZB95ux5LFz6KRbPmYQNP2/BrLeXYuzw/gCAy1euItPhwFuvjsX+g0cwYNhLWHNzfb91b9qyHbVrXIeU5AJYtOwz/PzrNvTtdR/SalU1LRPblsSlRbkBKyu8XzQTB6WqmJRH07ANNit0brTbE7tXpMuvLtDIUVzhyLJ7zopxbvekKzhdnstqNHIUCZg9IdsozYhfNv+JatdVRlJSIuqm1cCUGfPVdSnJBfBwt3sAAFUqlYfL5UKmIwtJiQmm9b02ZxFmTxuNfQeOYO03G9Hp7jsw+fX5WDh7gmmZ2A6OJIweVKb2eDStWoD7GjAAw0aua/AG5TQOQ2r1pMtYF+dARmYWrmZQcBQPJCU6tSfhOLV70hWcLqvVggJJFBxFBAzGv7s3rccTI9SRns7tW6LLPS012U6fOYeKqWUAACWKFYHL7UZGpkMXAO3+Zx9Sy5X2GxgBgMORhWsKpuCNt5diQO9uuKlBGpavWue3TGwHR9KPw8UGyLXt3PBBZ0pmpfErDVNp8GL94jCw97tpkEy6AtLFwb2X1bKEwgZdV/OxJ/Odk7akFW9Uv7RzunykK7e6HMrlUx7fdk+6gtNlsYhzjvzZdiAY2bMoXF6W25OswSgtnLpCi9mEbCVt0eyJhi97VWEAF+5c5W6uu9PN6XLhtTmL0bfX/dnqubZyKh564jnY7TY8O+hRnD13AdekJPstE9vBkYBRgzJ6CR7zpqsNWbAr8fZRiKvFBgyT5mF0DiFdfnVxDmRm0ZyjeMGR5dTMNQHi0+5JV3C66G61yEGOccX0QChZvCi27/wHAHDy9FnY7XYkJmhHh159cxEapNfETQ3Ssq1v7LP98fPmbUivXR0AcP7CRTze6z6/ZeLDkowCeKb50KzWTSZUqhF6OP5ubQUT2qxRb4h0BazL4XAig+YcxQUO4WGf8W73pCvnuqwWC5JozlFEkNsJ2Y3qp2HuguXIyMjE1m270LhRXSxetholSxRFq+aNsXzVOpw+cw5P938ooPrOX7iE25s0BAD8/ucubP5jJzre3cJvmdgOjoReha7jw329GSiNE75MTMijq1PszUjLahXedM3TYOVWT7r86uLce1ktk0aO4gHPk9C57snI8Wb3pCs4XRarBYmJsX1KixZyOyG7aJFC6NW9A3oPGoNrUpIxbuRALFz6KRhjOHz0BF59cyGqVEpFrwGjAAAPdW2PlrffYlrfmEmzMHb4ACQmJmDMpDeQXqc6xkx8AzNeHmFaJrYtiUlfxQbOdFl8yA0Qvt6NaUfKu0JNF+rn8PWMSFfgujjgvVuNgqN4wOFwijer+Ygzuyddwemiy2oRhOGPaZJmQvvWzdC+dTN1+en+PdXvP3z+Xo7knD1/EaVLFcf8JR+j90OdcE+b29G19zN+y8SXJUk/jNqm5XTm6aGovR7hOxPLcegdhdFmDZwC6cpeFzhHRmYWMjIdJjmJWEINguPc7klXcLo8rw/xf9cSkT9kNyE7v0lJTsIrb76H37buwLuzxiMry4mU5CS/ZWI6OOJmiVKD1A3/cl+D496MTFvUqBOlHf4VN8cM0khXtro4p5GjeEKZc6S7rBZndk+6gtNloYdARgyMSb+9kB4Onn+mH1au/grDBj0Ku92GP3fswd2tb/dbJqYtKbtejtKA5TTxAWRiT0bpqYiNWywj5pWdg9grMjQQ0qXTxcE9d6tlUXAUD2RlucDB497uSVdwuqxWhkR7TJ/Sogbm/WeUHg4qVyyHIf18l+VcLhf+3XvAb5nYtySh2yEPCzP1PyHNm1+eSCj3Zhlg/NwNqTejaNDdrkq6stfFPSdMGjmKDxxOJ6TYKD7tnnQFpYtGjiKH3E7IDgW79+zF2m834uvvfgHnHG3uaOI3f2xbktR7Yfok/RCx3NtRGirT55V7QuJ6pdejrDTqMZEu/7o4PJdaHDRyFBdkZbn0iXFo96QrOF0WxpBAI0eRAYMuQFbT85H9Bz2vC1n37UZwztG4UTrsdhuWvj0FFovFb9nYtiRNi/ImKcOz3l6HnEVsbAzQPv3Vzyb8fdcs61o66TLTpd7KT885igscWU7VnuLZ7klXcLqsVgu9Wy1CiJQJ2d0ffxb33tUC08b9DxXKe15H8vv2kdkGRkCsB0cCajtWGqXZbyS2ZqWRK9851Od3gOkbqllvR4OUSLr868pyuuAwGlEgYo4sp8tnFApxavekK+e6PCNHVhMBRH4SKROyRw3ti6++24ghIyejQXot3NIoHU5nYOeTmA6OhFezqI1Rc31cWFYbnlELlBuuiYPQdaikelT/wH1GQrr86OKeE2YWXVaLC7KcLiinwri2e9IVlC6LhcFOl9UigkiZkH3XnbfirjtvxfkLF7F+wyZ8+PGXOHDoKEZPmIl2rW7DzTfeYFo2pi1JnkSoe04H07dV7RfobysW4N7/TKNhZrDISVegugDuGTkKMNInohun061Zjle7J13B6bJYGBJsNHIUCUTahOzCha5Bx3Z3oGO7O3Di1Bl89e3PmLtgefwGRzK+hwvCuEcEqd0JI09gUs8F3sbLpPxMyCNXajImTLqMK+UccDpdAQ+DEtGN0+UCB9k96QpOl4Ux2Cg4ighy+261UFKqRDF079IW3bu09ZsvtoMjLi16fxcmrZeHiNUMTNsOxR6Q3wYvInehuD6ddJnoAs05iieyvEGwYE7xafekKyhdFouF5hxFCJEy5yg3xHZwxEwWDbszBnBvNimf+v4nuYGSrjzX5XS54XS5s89IRD0ul9v8ZAjEld2TrpzrYozBZs3+LiQi9ETaZbVgiO3giEvfjXo+RsPGQprRREKjp7PqHIO/bZltk3RptsU5h8vlhosuq8UFLjkIjlO7J13B6WIMsNJltYggUiZk54aYDo40sREz6NhwX7pRQ1RuLxV7OGLDZWJDhVBO+SrbgbyedPnXBc8J0+mmkaN4wOUWjCOe7Z50BaXLwhhsATy/hgg9dFkt0mH6r5oGKTZspk2DkF/Xk5HzST+4WqfUMzJq3KTLXBcAuN0cbrqsFhe43G5wkN2TruB0McZgoctqAcKzz5ILIuUhkLkhtoMj7vuUn8Oh630YNDgFsbGaOgyjugQHwI3Wky6/ujg8J0zNiAIRs7iNRo6ERYVYt3vSFZwuxgBrNE1qCSsh9qne38kwPUqI7eCI+T79NT7GDYuYIvZeNIGwN40L2xPfOE26cq7Lzbn2pEnELJ7fmZPdk64gdTFYKDiKCGJ6Qvbly1fwyuxF2LVnL2xWKx7o3BatWzRG/2fGY+Bj3VGz2rU52tC4qXPQrmVT1E+vlWORn6z5Bp98vh5nz11Ay+aN0e+R+wN6XoJhDqFRqb0PpZFxoSDXf3Jvo2VC5ZqHmTFpu4bdH9IVsC4OcDeHW3zUORGzcO/vHPd2T7qC1hVNl21imZi+rPbilDmon14TI59+DBmZmdi1Z18+ytJSrmxJzH1lDFxuN7o8/DQ6tG2OcmVKZVuOC5+6p7oK+Zjui/Bd+JTO22DeeuX2Lm+HQdvYNflJl6kuzzJXT5pEbMO9Vhbvdk+6gtMFICIeMkjEBoaz1w4ePoaDh4/h/g6twRhDgaQk1EurocvXsedgnDt/EQAwb+EKLF62GgCweNlqdOo5BN0fexa//f4X3l+xBt9s2IQJr8zDtFkLAACrvvgW3foMwwOPDcOmzX8CAPo/Mx6frPkGvQaMwqEjx9XtNKxXB2AM/+49iJSUZJQsXiygnZPbobxOSfd37uUmC/7au+6dbpAaMOkKUBf3uy0ixlAC4ri3e9IVjC4iclBGjoz+ogXDkaN9Bw6jetXKQUfh7yxZieXzp6svAbyxbm1s+HkL+vTohPrptbDvwGGsXvs9Fs2egIxMB4aMnIxGDdIAAH/u3IP5M8fptj1szHT8snkbXp84IlcvF9T0QkyGZ0Xy66ckXf5EeLqHHBzqczKULqOoyeCFTZoyftI0Fan16NM45z7bJF15qysA4sruDSBdfuo0OF8Z6fL3Xjfzwn6yBVpfJOkKcaeTbuU34e5Wt2H8tDl4rGcX1KhaRbf+161/4fDR43h04PMAgMtXrqrrOrZrYWjk08c/gwOHjmL42FcxYfRTqFyxvGb98lXrsOLTdQDg9zIMM1gI+AcLMF8wBkC6Asgg3hojnFC54CzU874gQT65M3hO2mAQTtK+wpwpqfrusicG8GYmXXmqC0JSQMS63WdXNenKWdWkK9+I2eCoUoVy2L1nn7bXZ4LT6dSlDenXE7v37MX0NxeiRdNG6NqxjS5Pq+ZN8NTj3XXpFj8P8aqYWhYN69fBlj926oKjLve0RJd7WqqamrbrpS2snBgYjO+wMEqTypuWlXT6DezllaQr+46QcmKWJz0wz0aYuhHhhC4OwUsjF4Bwkld2VH9eN95RJQPnqg7SlTe6/FUTd3ZPukhXKHWFmLyYkP3xmvVY9slaFExJxrgRA1CqZHF13aEjx/HCy2/gakYmHrr/brS549Y80a3RapRYMbUsypYpgeWr1oFzDocjC5+s+cYTLIGpt1YXLVwIO//+D5cuX8HGX7cBADIdDuzesxfVq1ZB145tsPn3HQCA0iWL48SpMwCA+uk18dV3G3Hq9FlwznH8xGlTgRcvXcacBcuQleXE5ctX8OuW7ahUoVxgeyf2SL3nAkPfbZYmVmFWVtqMWNYQuQDp8q8L8J6gxRO2sCWxfvH8rRTRztY0ziuf+DV1y41ZOTCMdIVIF9k96SJdIdYVYpifv0A4c/Y8Fi79FG+/NhZd7mmJWW8v1ax/bc4iPNK9A+ZOfx5z3l2GS5ev5KV8AH4uq40Z1h/TZi3Ays++RmJiArp1agPGGBrWq4OP16xH7RrXoXuXtnhp+luodl1lNG6UDgDIzMzC4uVrsO/AYWQ5nRgxuA8AoHWLJhg3dQ62btuFEUP6oM9DnTFg2AQkJiag+a0N8Uj3DoY6UpILINGegD6Dx+D8+Uu4q+WtqJ9eM7C9E3y4OpIvnxCySdP8mEyfTc7D4TunmEbupCtnujR1Ml9O3ZsqvemipzDSKi7It9so33U9s2zeCkS68kCXHw3xaPeki3Tll1/NY1wuNxjTvxNT9/5EE37Z/CeqXVcZSUmJqJtWA1NmzNfU8fNv2/DCsH5ISUlGxdSy2PLHTtzWuEGe6QcA5nBkhjG+DA3KZbVv1yyBzWYz9cEaYxSX4TMo7l1gUnmzJ8PKnQQR3WZIl19dx0+dR9MHJ+HkmYv6gn4JIJ+4D7rsXBKcB9sjXdlu7/qKpfDNwmEoWCDJty2pRDzYPekiXaHWZeMOhAKXy41OPQerV4mMKFgwGcWLFlYvr3du75sSo7Dow89w8dJl9Hu0KzjnuLPTY1j9wRtISkzAmXPn8XC/kfj0/ZkAgGmzFqBKxfLo1P7OPN2XmH5CNpcXTIyOGaRrnsDqXW8aiavWq61LNHaxjKY86TLVpUM+AZue0+U9UrySsEpJlh/googyqcIQ0pW3uuLc7kkX6coPXaHAarXgo/deBefmI0SMWWDN7h14DJobq7ibq/vEwDQPBnZzDhaCR2/Hx1v6GMT5np4IHCYnYKGMN6sun5Hdce82xLyc+TIzMTPpCkyXWEj2NooosVZNZdKZ3TjaUt8QzgGPJ5J3lEmfSmbxj3TlkS4/xJPdky7SlZ+68hir1QKbzWb6l21gBKBk8aI4cPgYAODk6bOw2+1ITEgAABQuVBAXL11W5xkdPHQMJYoXzfP9iOngSPTBih+HmCZ8F8sYGSIM8sp1KX9qoC5lVoyWdAWmyxQmbllO925BHt0w2gDzVcU4dF5FOXfrvZLJCZ105YmueLd70kW6Qq0r0mlUPw17/t2PjIxMbN22C40b1cXiZaux9pufYLFYcEvDdGz9cxcuXb6Cg4ePov4NAc5DzgExHRwpMPgMQue3offbGmOW1suuXDZELi4zfV7SFbguCHk0J3JdSSbk5ULrVzyR8ikoUytlvvUMGu/FhHTOpXKcdOW9LqUeLfFm96SLdOWnrkikaJFC6NW9A3oPGoOVn32F/r274vjJ0zh1+hwAYHDfHnjvg1Xo+/SL6PdoV6QkF8hzDTE950ixCPV0IETtulEKyWKUa71KtG8639SbT7w2zKFdBuB7Dp5QhnRlo0vdlFCh4l3Uu51kxEoVT2QmRhBkiC/dd5OWkEa6QqPLYBNxZfeki3SFWFc00L51M7Rv3Uxdfrp/T/V72TIl8darL4R0+zE9cqT6XyWB6f/E67G+gr405v2PietEvIarG6pk2uyM+RoC6QpMl2+db0HdPhcF+gp69kXxPtznDLiQSbeTXKiDGcQQXJtmIJJ05ZEuaL+q5ePI7kkX6coPXYR/Yjo4Eu1EYw+ScehshflWcGG94sdl+1OKiHkNqtI3EtLlV5ce7l3P9S3cu6x1Dsx7PuY+72KIcAA0QYGwQ0xI082hIV15pkuoTd5cvNg96SJd+aGL8E9MB0fivAeN0ahO3Re8Kz5eO1fCtx5CsvImBGVZWa+cAwyNVtRAugLSpU2AkNOslJJqtM7IZZhsWHzQobopk22TrjzXFe92T7pIV6h1EdkT08GRxgf7MQr1FMA8fl41XCatV5KYtmo1j7QBLq1TDZh0BaTLYIvaNC6vlz9FFRr3A67k4cKn7LEUT6U7Elz4I115p0tSE6d2T7pIV6h1EdkT08ERkxcEwxSHFrWnAf15WWOAXDJEaZ3R9s0+SZd/Xb46hRTNSVmpRPI+uq3Jy8LLLXxPFhNECWlgvoBAsz1GuvJcl7bqeLV70kW68kMX4Z+YDo5EI5GjZmaQR3Mpx+BcodbBpToAdSIrBzRDovKph5OuHOnSbZwJG2biSuat1+NiuOhmuJzPyD0wcE3gIO4o0+QjXaHUJWSPY7snXaQrlLqI7Int4EhCdOUwMkBmkNF7zuDwGC2H5Pu9+XUvMFcMVzBgzfZJV7a6dNtTT9TMYJ22XqZ4EF1lPn2y49J4LaWQ6FXMPA7pynNdGh1xZveki3SFWheRPbEdHAn+mgHaiFxZZ2C98uPXRQM1MmouRPFqftn/c+/2BYMnXf51+dZz6Ju00NrlNEOEkzMTNiU7E1mw6JyUycdKIEG6QqRLyhFndk+6SFfIdRHZEtvBkYRmyoP3U3b4gNZ45GBeTRMMV7xhR86n5FGeY2HWCEiXgS7fFvQbFStUk+Qzt1gz01ehg2sFm8GEOklXCHRJi/Fm96SLdIVYF5E9sR8ccd+fzv/7PrRFhPOCEv2rBqbUI58XRAsU8jGDMqQrQF3yxuVP5Vk9YmXKRpVP9aQs12W0N15huq6Vxr2QrhDpMiPu7J50ka780kWYEtvBkdfPMyWKF1Ypby0wCqLlNK7UAeEcwgSj8+YRC3LAN8TJhDLC+Yd0ZaNLtwV5S8z7v1CZbpKv6DG4tFGzIABSutFek6681mVG3Nk96SJdIdZFZE9sB0eSESjnATW49hqLYjuq0YppDJqOrTqFQo7QhQo49+RjTFuPqol0Ba4LBuX8tm5pHYe0k9mVEw4EF9JVryPkI10h0UV2T7pIV4h1EdkS28GRhPxMCeU8oDsPC2lM/c+3ngkGL95OqTuncN92lGXd+YF0metSNy66DXGtkWpllehJdG7HtzFhmcvb0Hgjg22QrpDoinu7J12kK8S6iOyxhVtAKOBeS3E6nZ5leP2y7LC5zygVe5HzmRTz+XnmS4NBXr86SZdfXU6nUzhpc4PKxJqkLTNvGoO0Xi7rK8c0y0YBghGkK890cQ6n0wmn0xnXdk+6SFeodXHuhNVqBdM9D4BQYA5HZszFkRkZGWh+b59wyyAIgiCIiGTD6ndhs8Xk+EieEJPBkdvthsPhyPPIuMcTI7Bo9sQ8qy+eoGOXO+j4BQ8du+ChYxc8kX7saOTIPzEZNlosFiQlJeV5vYwxirSDhI5d7qDjFzx07IKHjl3w0LGLbuJqQjZBEARBEER2UHCUAzq3bxluCVELHbvcQccveOjYBQ8du+ChYxfdxOScI4IgCIIgiGChkSOCIAiCIAgBCo4IgiAIgiAEKDgiCIIgCIIQiPv7DC9cvIxJr72Ng4eOoXChgnhxxABYLBaMnjATZ86ex10tb0WP++4GAHy8Zj2WfbIWBVOSMW7EAJQqWVytZ8qM+dh74DDemDIqXLsSFnJ7/E6dPouRL83AyVNnUTetOkYNfRwWS3zE7Dk5du9/9DmWLFuNbp3uwoP3tQMArPt2I5au/ALnL1zCg/e1Q4e2LcK5O/lKbo+d0+nEK28uxO/bd6NwoYJ4YVg/TXuOdQI9fkb5ihUtjHPnLxoe63ggt8dOIV7PGdFCfJyF/LB95x7cd28rLJw9AdWrVsbi5avxzuKVaNbkRix4Yzw+/+oHHDh0FGfOnsfCpZ/i7dfGoss9LTHr7aVqHf/sPYjtu/4J416Ej9wevw8//hKNG9XF8nenwe1247etf4V5j/KPQI8dANRPq4FGDdLUsi6XGwcOHcUbU0Zh3msvYMZbS3Dh4uVw7Uq+k5tjBwArV68HGMOi2RMxfFBvFC1S2GgzMUugx88oHwDTYx0P5PbYAfF9zogW4j44atyoLuql1QAApNWqipOnzuKnTb+jbloN2Gw2pNWsio2//oFfNv+JatdVRlJSIuqm1cDGX38H4HmP24y5i/Hogx3DuBfhI7fHLzm5AIoWvgYWiwXXVa4Am80axr3JXwI9dgBQvWoVlC1dQi1rtVrQu0cnJCTYUbjQNShXuhTOnb8Qlv0IB7k5dgDw+Vc/oFvHNmCMoWJqWdjt8TWIHujxM8oHwPRYxwO5PXbxfs6IFuI+OBLZ/PsO3FC7Gs6cPY/UcqUBABVTy+LU6XM4feYcKqaWAQCUKFYELrcbGZkOfL9xM8qXLY1q11YKp/SIIJjj17n9nVj+6Vd4670V2PPfAdxQp3o4dyFs+Dt22XHq9FlcvHQZ5cuWDrHKyCSYY3fsxCls2vInHh4wEi9NfwtOlyuf1EYegR4/JR+AoOw0Fgnm2NE5Izqg4MjLv/sO4tetf6F9m2ae98143wbv5m4wi+eVyZz7HgnF3Z43iL/3wafo26tLuGRHDMEcP8aA7378Dc0a34iU5AL4b/8hnDp9Nly7EDayPXZ+4Jzj9blL8Ej3DrBa4685B3vsrlzNQMGUFMyfMQ5nzp7H9z9tzi/JEUWgx0/MByDHdhqLBHPsHI4sOmdECfHnTQ04e+4Cxkx6A+NHDkRiQgKKFS2MQ0eOAwAOHjqGksWLomTxojhw+BgA4OTps7Db7dj593+4cPESho6eimdffBW7/9mHV95cGM5dCQvBHr/EhAS8/9HneLhbe3Tv0hb3tLkdq9duCOeu5DuBHDt/LFm+Bna7DffcdXs+qI0scnPsihctjLp1qsNiseDGurVw5OiJ/JIdMQR6/OR8AHJsp7FGsMfuj7920zkjSoj74MjhyMJz417DYz074/oqFQAATW6qh61/7oLT6cT2nf/globpaFQ/DXv+3Y+MjExs3bYLjRvVRcN6dbBs/jTMe20sXn5+MKpfXxlD+j0U5j3KX3Jz/JTyf+36F263G3v3Hw7jnuQ/gR47Mzb8vAXfb9yMYU89Endv187tsbv15vpY/8MmOF0u/Pb7DlxbOTW/pEcEgR4/o3xmeeOF3Bw7OmdED3H/+pC3F63E4mWfoXLFcnA6PfMOpo1/BuOmzMHpM+dwd+vb8EDntgCAT7/8Dh989DmuSUnGuJEDNb2lo8dOYty0OXF3W2Zuj98ff/2Nya+/g4yMTFxXuQKeH/YECqYkh3OX8o1Aj93J02cxdNQUnD57HhbGUKliOUwdOxRtu/ZHqZLFkZBgBzjHXXfeqh7rWCc3x27my8/h/IVLeHHKbBw4dBQN69XBMwN7xVWAGejxM8o395UxyHRkYfSEmbo2Hg/k9tglJSUCiN9zRrQQ98ERQRAEQRCESNxfViMIgiAIghCh4IggCIIgCEKAgiOCIAiCIAgBCo4IgiAIgiAEKDgiCIIgCIIQoOCIIAiCIAhCgIIjgiAIgiAIAQqOCIIIiqGjp2LV59+oyz/8vBV9Bo3RvEOPIAgiGqHgiCCIoOjdoyMWLVsNl8sNAFj44afo81DnuHrSNEEQsYkt3AIIgohOalW/DhXKl8F3P/2G4sWKwO3muKlBGn78ZStmz18GR5YDVa+thFFDH0dSUiIWL1uNr7//BVczMlCuTEm8OOJJpCQXwLyFK8AYw5879qBokcIYM+yJcO8aQRBxDr0+hCCIoNmx+1+88uYiFLomBV07tEb5cqXx3PjXMGPSc7imYDJmz/8QRYoUwgOd7sLOv/9D1Wsrwmq1YsjIyWh6S310bt8S8xauwIpPv8I7M8ahbOkS4d4lgiAIGjkiCCJ4alW/DoWuScbFS5fRsH4drPzsaxw/cRpPDnsJAODIcqJxo7oAgIqpZfHF1z/ij7/+xqEjx3HoyHG1njtuu5kCI4IgIgYKjgiCyBU1q12Li5eugDEGDo66aTUw6fnBmjxXMzLQZ9AY3NPmdvS4rx1KlSiGS5evqOutVpr+SBBE5EAeiSCIPKNR/TT8umU7/tyxBwBw9twFXLmagQMHj+Lc+Yu4795WKF2qBPb8uz/MSgmCIMyhkSOCIPKMCuXLYOzwAZj8+nxwcCQXSMKzgx7FdVUqoHGjuniw7whUSi2L8uVKwe2m6Y4EQUQmNCGbIAiCIAhCgC6rEQRBEARBCFBwRBAEQRAEIUDBEUEQBEEQhAAFRwRBEARBEAIUHBEEQRAEQQj8HwfQ1W9O/WB7AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 583.3x260 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "A heatmap with one row per cluster and one column per month, shaded by assignment probability."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plot_assignment_heatmap(\n",
     "    extended_probabilities, extended_df.index, \"The extended model never returns to a cluster\"\n",
@@ -1498,8 +3379,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47b0f40a",
-   "metadata": {},
+   "id": "8b21588c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0158,
+     "end_time": "2026-09-08T23:43:05.380482+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:05.364682+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Clustering the indicators rather than the months\n",
     "\n",
@@ -1521,10 +3410,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6ea3185c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 42,
+   "id": "040801e0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:05.427057Z",
+     "iopub.status.busy": "2026-09-08T23:43:05.426913Z",
+     "iopub.status.idle": "2026-09-08T23:43:05.451469Z",
+     "shell.execute_reply": "2026-09-08T23:43:05.451154Z"
+    },
+    "papermill": {
+     "duration": 0.04394,
+     "end_time": "2026-09-08T23:43:05.452213+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:05.408273+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Cophenetic correlation is **0.89** for the tree over the indicators and **0.71** for the tree over the months, against a conventional bar of 0.7."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "column_distances = pdist(extended_df.T)\n",
     "column_linkage = linkage(column_distances, method=\"ward\")\n",
@@ -1545,10 +3461,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c002fc90",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 43,
+   "id": "0836395f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:05.484735Z",
+     "iopub.status.busy": "2026-09-08T23:43:05.484611Z",
+     "iopub.status.idle": "2026-09-08T23:43:05.914170Z",
+     "shell.execute_reply": "2026-09-08T23:43:05.913457Z"
+    },
+    "papermill": {
+     "duration": 0.450321,
+     "end_time": "2026-09-08T23:43:05.914553+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:05.464232+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAGRCAYAAACex0zVAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAY8FJREFUeJzt3Xd4FFUXx/HvphNaaKEFQgkkBEIJQqQXQXqV3nsRKYIgKKB0UYooVTqIgIgKghRRFJDeQXqvIaGHkLbJvH8E9iWhhZIssL/P8/jIzs7eOXN3Nnv2zp05psjICAMRERERsbCzdgAiIiIirxolSCIiIiLxKEESERERiUcJkoiIiEg8SpCsbMGPy3DzKMSW7butHcob59tpc8lbpCJehcpz8NCxl96+3rukUbVea/zermbtMJ7bjz+vpEDxKnjmL8269f/i+1ZlPhnylbXDeuUN/3Iibh6FOHv+IgDlqjWhVac+Vo5KbIkSpETW9cNBuHkUeuR/GzfveGnbmTX/R9w8Cr209l535y9eZtCwcWT3yMKwQX3IkzvHC7eZt0hFRo2d8uLBic2IiIikZ7+hODs7MfKzvhQp5Mv86eP4oFOr52qv3fv9qNGg/QvHFRYWjptHIRb8uOyF20oqk8cN4/MBPZ+6XqVaLej64aAkiEjedA7WDuBN17ldM2pUqUB0dAytO/ehTMlidG7XDABfHy/OXbj0UrZzJejaS2nnTXH2XOyvzqYNa9O0Qa0Xbi86Opqr1268cDtiW64EXyUsPJyaVSvSvFEdANKlTfP87b2kz3nQ1dfv70X+fHkStN6V4Gvk8cqZyNGILdAIUiIr7JePmlUrUqNKeQA8smamZtWK1KxaMc4fyh279lOlbmuy+ZSk3fv9iIqKAmK/mMdNnEmBgKp4FSpP/8++JDIyKs42un44iNHjpwLg5lGIGg3aM33OItw8CrF770EAevYbiptHIX5f+zcA30yZQ5pshblx4xYAv/y2hhLv1MfDuwS1GnVg/39HHrk/bh6FGPPNdLp+OIhcfuV4u2I9Dhw6CsDdsDDGTZxJqcoNyZIngFKVG7J91744rx377Qw6dR9AjvxlqFa/DWfPX6TvpyPJ5VeOCjWaxUkYt+3cS6VaLfDwLkH199px/OQZACIjo+j+0efkyF8Gn6KV6PPJCELuhFpet3HzDmo2jP2V3eeTEZZf3GfOXqBJ2x5kz1cK/9K1mDF3MYYRexuw+6fLduzaT8lKDWjQ4n1Le2fPXySdpz8xMTGMHj/1odG/F3nvAH5evpoipWri4V2CGg3as2fffwAs+eV3qr3Xluy+pSlQvArzfvjZ8poaDdrTqlMfvhg3lXxFKxFQoR4b/t3OjLmLKViiGgWKV2H9hi2W9S9eukKLDh+SPV8pAirUY/W6fx6K43H9unHzDtw8CjF5xvdUqtWC7PlK0aZLX27euv3Evjty7CR1mnTCw7sE5ao1Yceu/Qk6Ts6cu0Ddpp3J5lOShi27ce36zYdifXC7f/79L+WrNyV3wfJ8NmI8h44cp/p77cjuW5q+A0dZ3uMnvR9dPxxE5dotWfjTb/i+VZnxE2diGAZfjJuKt/87cUZ+h3858Yn79+BxU/DeqcEJU+ZYThO6eRSiU/cBj+07wzAYMmoCeQpXIJdfOTp068+VoKv4vV2Nf7fu5N+tO3HzKPTU0cwdu/bTvH0vfIpWIkf+Mnz06UjMZjMbN++gUInqAHTrPTjOaaz7/N6u9tCIN4BhGMxb+DNFy9TCM39pOvX4hNshdwAYNXYK3v7v8Off/1KkVE0+7D8MgH0HD1OzYXs8vEtQ8p33+HXF2kfGG3r3Lj37DcUzf2lKv9vI8jl4MKaq9VoDjz9W3TwKcf7CJRYuWW4ZIbt+4yafjRhPQIV6ZMkTQJW6rS1/S86ev4ibRyFmf7+E5u17kd23NJVqteDCpUDLdg8fPUHDlt3I7luagiWqWUbdwsLCGThsLN7+75C/2LuM+WY6MTExT3xP5PWiBOkV8d3shTSsV50Sxf35efkaVq/bAMDEafMY+sU31KhSgQF93ueHH5fx3ZyFcV7buV0zSgYUBeD7GeMZ2K8bZUsVB7B88WzftRcXZ2e2bt8DxCYf+fPlJU2a1Pz1z2badu1HXq9cjB7Wn2vXb1KncSeCgh/9K3PkmMmkTZOa7p1bceTYKUaOmQyAncmOfzZto2Hdagzu34Og4Kt07vGp5QsKYMRXk8iU0Z1WTeuzZfseipWrQ3RMDG1bNGDPvv/4dsocIPZLsl7TztjZ2THy876YTCbadOmLYRgsXLKc+Yt+oUPrxrzfoQVh4eE4OTpatuHr48WnfbsB0KF1Ywb268bdsDDqNevCwUPHGD64D2VLFeOjT0cyf+EvcfatWfueNKpXnf69u1iWZUiflrEjPwWgfu0qfD9jPL4+Xi/lvQu9e5fOPT8lS+aMjPysL1kyuVv6a8v23RQrUpDhg3qTLl0aPhwwPM4X2fLf13HgvyP06NqWi5cCadDyfZb/vo73O7TgdsgdyzyXqKgoGrX+gD37/uPTvt0oUbwIrTt/xOXAoDixPK1fv540i4b1qtOpbVN+XbGWEV9Nemzf3bx1m7pNO3MlKJhhg3qT3SMLzdr35G5Y2BOPk+joaJq3/5A9+//jswE9KVa0IBcuBvIkPT8eRovGdcmdMzsTpszhveZdqVOjEvl9vJg+ZxF79x9K0Pvx3+FjjJnwHf16daZerSr89Osqvhg3hRpVKvDxh7HHQ5f2zWlQt9oT9+/B4+brL2JP9dSpUZkJox9/2ufBvvt741bGT5p1b7udMTBwdnJiwuhBpHFLTT7v3Hw/Yzzv1an6xH45fPQEKVIkZ2C/Dyhf5m1mzF3M0mWr8fXxon/vrgB0atuU72eMJ0P6tHFeO2H0IL6fMZ5BH3cHYj9HAL+uWEuPvkMoWsSP4YP6sGnzDkvCCBB89Tq9+g+nS/tmdGjdhCtBV6nTuBM3b4Uwelh/cufypE2XvnGS9/s+H/E1c39YSvuWjWjfqiHH7iUxj/K4Y3XutLEAlClZjO9njKdsqeJER0ezc89B2jRvQL9enTnw3xE++nRknPYGfPYVBQv40LppfXbuOcC3U+fe259r1GzYgcPHTjLkk57UqV6ZnJ7ZABg4bCzTZv1A62bv0aVDc0aNncKK1X898T2R10xkZISh/xL/v7t3Qw1Xdx+jfbd+cZbP/v5Hw9Xdx1i5+k8jMjLC2LRlu+Hq7mN8MW6yERkZYeQpVM6oUrelERQcbAQFBxstOvQ03qnZ9KH223Tubbi6+1geR0SEGzkLlDZaduxlBAUHG67uPkbz9j2MclUbGRER4UaO/KWM3gOGGZGREUa9Zp2MVFkKGNeuXzciIyOMFavWGa7uPsa4idMf2s79du4/Lvh2FaPg21XirHM5MND4fc1fxju1mhmu7j7GpcuXH3ptWNhdwz2nv1Hm3QZGZGSEER4eZrjn9Deq1mtlREZGGINHjDVc3X2MA/8dNoKCg41fV6wxXN19jKPHThiLflpmuLr7GN9OnW3cvn37kf3959+bDFd3H2PGnIVGZGSEseSXlYaru48xbdb3lu15+pY03ipbK8778NXXUx/Z3pGjxw1Xdx9jyKivX+p7d/v2bSOTVzGjVsN2xqkzZx/a7q1bt4y/N24xuvUeaLi6+xg//vybERkZYVSu3cLIkb+UERERbkRGRhh1m3Q0XN19jFu3bsW+p007Gikz5zfCw8OMP/7aYOmLoOBg49z5C4abh58xY+7CONt6XL/e78tvp86O877nLVz+sX03Y+5Cw9Xdx1j9x3ojKDjY2Llnn+Hq7mP88deGJx4nm7fuMFzdfYwxE6ZZ1itZqb7h7V/xob6J3/8//vyb4eruY0yZMT/2Pf95heHq7mPM++Gnp74f7bv1M1zdfYwt23Za2u/Z73MjvWdh4+7dUMs+3//MJGT/IiMjjOMnTxmu7j7G4OFj43yG2nTu/di++3dLbB988vloy2fy/n9eBcsalWu3SPDfnfDwMGPH7r3GxGlzDFd3H6NH38+MyMgIY+2f/xiu7j7G7O9/fOLfrFKV3zN8ilY0rt+4YURGRhjv1GxqFCj+rhEUFNuH/Qd/YeQpVM6IjIwwhoz62nB19zEWL11uaWPst98Zru4+xqq1fxmRkRFG8NWrRsrM+Y36zTs/FGd6z8JG3SYdLcv6DRppuLr7GMdPnjIiIyMMb/+KRsUaTZ54rD7u72xkZIRx5uw5Y9nKNUaRUtWN9J6FjYiIcMv7M+CzLyyvT5e9sFGzYVsjMjLCGDdxuuHq7mOs37D5oc9tysz5jfbd+lmOp/LVGhttuvRJ8Huj/179/zQH6RXh6Bj7VqS/d9otIiKSyMgoLl6+wsXLV8iRv4xlXa9cnk9tz2QyUbZkcbbt2svO3Qdwdnai+rsVeL/3II6fPENQ8DVKl3gLgLPnLuCVKzspUyQHoEgh39jlZy88OlaH/x826dOl4eLl2JGIyMgo+nwygoU//UbWLBktow+3b98hfbq0cV5rb29PmjRulv22s7MjTRo3IiMj7207dqQkoEK9ONsOvnaderWqcDcsnNHjpzFu4kx6f9CeTm2bYjKZHtsfZ8/F7kuhAvks2yvs58vmbbvirFfIL99j23icF3nvXFycWbV0NkNGTaBQieo0rFedoZ9+iHuGdEyb9QMjx07GzmRHTk8PILYv73Owt7fsc7p0aeLEkjZtGqKjo4mJieHMvfexR78h9Og3xPL6+HOqHtev9z3Yv955cvHXP3FHAR7su/tzwOo37xpnneCr1594nNw/xZorZ3YS6v4+3z9lff8YS5vWDYg9LhP6fjy4D375vbkbFs7Py9eQKWMGTp+9QNbMGZ+6f8/jwe0WK1qQH2ZNYPjob5n1/U90adeMfr064eDwbH+uN23ZyQcffUZgYDBv+fsBcPt2SIJfP37SLPbs+4/ffpxBiuSuQOxp6stXgslR4P996OTkGOd19z9j8P9+ur9/qVOlxCuXp+XzeN/Vaze4Gxae4Pf9acfqg26H3KFLr4Gs/uMfvHJ5cjcsnLth4URHR1vWcbx3DDo4OJDGLRUREVGW/YXYY+FBFy8FEh0dzcIly1m4ZLlleYoUrgmKX14PSpBeYU5OjmTJ5E7WLJkY3L+HZfn9P1YPsrO3ByA8PAIXF2cAypYuzpJff2fL9t0UKpCPt4r4ERVlZskvv2MymSh177ScZ3YP1q3/l5A7oaRMkZw9+2JPSXje+1JOqCW//s78Rb+w5te5BLxVmFFjp1jmRj0rz+xZAZg/fRxuqVNZlvv65MFkMtGicV2avFeTCVPm8PHg0eTz9rKcVnx0e7H7svfAIfwLFyAmJoa9Bw5Zlj+NnX3s2eiIiIgErf8s713+fHn4cd5EDh46RvUG7QAY0KcrHw8ezeD+Pej1flv+3bqLWo06JGjb8d3vy/69u1Lq7aKW5blyxP0yely/xk88DcPg+MkzlqTtkdvMFrvN8V8MxCtXDstyXx+vJx4n7hnSA7DvwGFqVq1o2d6Lepb347736lRl+JcT6dTjEwD8C+WnTYsGT92/l6H6u+WpVrkci5euoEuvgWTPloUWjetiZ2+f4GOw64eD8PXOzba/fsHZ2SnOVa52dk8+nvf/d4TR46fRsU0TypQsZlnumT0rjk6OTBwzxHJcODjYPzaG+8fe3v2HqVShFLduh3Di1FkqVywdZ720aVLj4ODAvoOHLcue9L4/7li9f3w/uF+TvpvPX39vZuc/y8iVMztdPxwUJ6l5kuweWQA4eOgYJQP8LcuzZsmEnZ0d1SqXo0v75pbl6e4l5fJmUIL0iuvQpglDv/iGxUtX8HbxIhw5dpIGdR6+J0yOe1/0o8dPpULZEpQtVdzyh+2nZauo/m4Fcnh6kDaNGz/+stIy/wigU5smrFm3gW69B1OlUlkmfTcft9SpaFi3+jPFGhYWDsC69f+ye+9/zP5+yXPvd7OGtZn03XzGfjuDZg1rEx4egaOjI2VKFuOzEeO5ev0GZUoU4/SZ80DsiNSTVKpQkhyeHoybOAsHBwd27TlI8NXrDOrXPUHxZMyQHhdnZ1as/ouCBXwo9fZbT31NQt67Pfv+4+PBo2lUvwYmkwlzVBT29naWvty7/xA/LFnOzHk/JijORykZUBRfby/mLPgJOzsTGdKn5diJMwwf1DvOeo/r1/sTT+csWEqyZC7s3H2AYydO88WQfo/dZq1q7zD8q4lMnDaPNs0b4OjowI2btylTstgTj5O3iviRJZM7c39YikeWTBw/dYb9B4/gkTXzc+//fQn9LN330y+ruH37DoM+7k50dDSF/XwJDb1LyhTJn7h/L+q72QvZuHkHVSuX49jxU8D/j+8c2bOyfdc+vl/8K4X9fMmaOSNV6rWmZtWKcRI/gLCwMM5fDGTp8tWsW78pznP3E5eFS34jbRo3KlUobUkWIyIi6dprEA729hTzL2iZV1OxXAk6tG5Chw/6M33OIipXLM2585d4u1iRx+5Lw7rVGfPNdD4fNYErwVdZ/cc/REdH0zneaI+DgwM1qlRgxeq/GPPNdFxdkzF/0a+Pbfdxx6q9vT3Zs2Vhw7/b+fHnlbxVxI+wsHDCIyJY+9dGQu+GsWLVn097Cywa1K3GVxO+o0uvT+nzQQdu3LxFypQpaN+qEa2a1mPBj8vI5pGFAr552bf/ED27tUtw2/Lq0yTtV1yPLq35fEBPNm3dSb+Bo9iybbflqpEHdWjdiNIl3mLarB8YP2kmEJs0eWbPytlzF3mrSAFMJhPF/P04e+6i5fQawDvlSzFr8miOHj9Fv4GjSOOWmmWLvyOje/pnirVJg1pUKl+KydPns+qPv5/7Xi8Qe4rl10XTcHZyYsioCUyfu5jrN25iGAb1alfl/IXL9B04ir/+2cxn/XvE+XX3KMldXfllwVTy+3jx6ZAxbPh3O18O60/LpvWe+Lr7kiVzYfTQj7l1O4R+g75gz/7/nvqahLx3XrlzUMgvH+MnzuTzkV9TrszbDP64Bz55c9OjSxvWb9jC5O/m0/WBX6nPysnJkR/nTyLgrcJMmbGAEV9N4urV63FO1wFP7dc8uXPw9aRZrFj9F70/aG+ZuPsoadKkZvni6Xhmz8qXX09jwuTZXL0We3rtSceJi4szC2Z+TZbMGRk0fBwXLwVSv3aV5973ByX0s3Rf2VLFiY6JZuw30xk5ZjKNWn9A/uJVWPPnhifu34uqXKE05uhoPhnyFT8sWU7XDi1oVC/2x8rnA3qS3SMLAz77kmUr/yA6JpqQkDvMnP9wAv3V8AFcvXadEV9OJJ+3F4UL+lqe88yWlf69u3L85Bk++fwrTpw6a3lu+659/Hf4GOEREXTq8QktOnxIiw4fEnz1Ou/Vqcq3Yz7n2InTfDxoNL+v/Zs7oaEPbfu+TBkzsHzxdFKlTEG/gaM4fvI0syaPpkLZEg+tO2bEAN59pwwTJs9m2Yo/6NS2yWPbfdKx+uWw/rg4O9N30Cg2/Ludrh2aU7xoIUZ8NYldew8+8biNL0vmjCxb9B1ZM2fkkyFfseDHZSRL5gLAqM/70bV9C1as+pP+g0dz5Pgpbty8leC25dVnioyMePHxaxF5Y23cvINajTrwzZef0apZfWuHk2Tavd+Pu2HhLJr9DYZhcPb8RYqVq0O7lo0YPfRja4dnsXLNegYPH8eujb9ZOxSRN4pOsYmIPMKFi4GcOHWWCZNnkzatG2vWbcBsjqZqpbLWDs1i28699Pp46BNPd4rI81GCJCLyCGNHfUq/QV8wevxUHJ0c8fX24odZXz/y9JC1pE+bhvnTxz1xHpCIPB+dYhMRERGJR5O0RUREROJRgpTIRoybzoz5Sy2Pe30ymi+/mW15POTLqSxZ9ujaRAm16OfVDBsz7aHl9Vr14tjJ2KtTFixZyZq//n1qW8PGTGPRz6tfKJ5XUb1WvSz/vhwYTOX6nV5q+5cDg3m/7/CX2mbInVBKVGnxwu38s3mnJbaTZ84z5Msn1/BKqFZdP2H3vXtm3fe87b/MGIeNmfZQXElh5doNfPz5+CTfrogkDs1BSmS+3rnYsj22HlpUlJnLV4K5+kDxzaPHT9OgduVEj6N5wxqJvg159eXOkY3P+nV9+opWbD+xYxQRSQglSIksv48XcxfG3rX10NGTeOXMzpnzl7hx8zYuLk5cuhJMnlzZCQsPZ8LUBRw7eZaQO6GUL1WMbh1i7wPyft/hVKtUhuWr1lOp3Ns0rPMu0+ct5Y+/t5AurRvOTk5kSJ/miXGMnzKflClc6dDyPWbMX0p4RCSXLgdx+Phpcnl6MPqzXg+VMli++m9W/7mJCSP7cykwiIkzFhJ89Qahd8Po0rYR75QNwDAMps7+kbV/b+H27TvExBhky5qRWROHcfHSFb78ZjbXbtwiVcrkDOzTiewecW/4t2nrHqbP/wmzORqPLBn56IM2pHFLRd0WPZg6djAeWWJLO3TrO4K2zetSKL83k2YuYsuOfRiGQYtGNaldtTy79x1iybI/SOOWiiPHTzF5zCBcnJ0wR0fTsssArl67Qauun1CranlKBxQhxohhzg/L2LBlJzduhTDi0+74eucmKsr8yPYfNG3uElav24STkyO1qpSnUvm36d5/FNdv3KJV109o17wefr55mDDtey5cusLtkFAa1a1Co7qx9/Op16oXHVrWZ+XaDZw6c4H32zWmdrUKAOzef5ivp8zHZGci1wN3qo6JiWHyrMXs3neI0Lth+Hp7MbBPJ+zt7Rg2ZhreXjlYv2kHBXy86NahCT8t/4PFv6wmdaoUpHH7/53Ij508y8dDxvPLvK/5c8M25i6MrUweGHSNooV8GTW4JwcPn2Dc5HmE3g0jc8b0DO7bhbRpUhMYdJUvvp5J8NUbZM3szs1HlK14sP3LgcF8PGQ85UoVY9PW3dy6fYcRA7uTL28ugATFCLB1536mzVmC2RxN+nRujBrUkyvB1x55PE6ZtZj1G7ez7+BRsmZ2Z8Ko/gRfu8GYb+dw4fIVHBzs6dSqAaUCiljei65tG7Ho51W0aFSLimX+fzf2Q0dP8s20Bdy5G0bK5K4M++QD0qdLw29r/mHRz6vAgHx5c9Kra8uH7si9e98hvp76PfOmxBZFXfTzao6fOsugjzqzcu0G9uw/THRMDPv/O0Z+n9w0qluVGfOXcuzEWdo2r0vDOu8CUKVBFzq3bsDqv/7l4uUgPvmwA6UCinDt+k0GjpzI1Ws3cHV14ZMPO+LtleOh90NEnp8SpESWyzMrN2+HcOt2CDv3HsLXOzeursnYe+AI6dK6kTtHNpycHDEMB2pWKUd+n9yER0RQp3kPqlcuQ07P2DverlzzD5O+/BQnJ0dW/rGBrTv3M3fyCJK5ODN+ynzu3rs7cULt2nuI8SP64eLsRMN2H7Fr32ECivpZnt938CiLlq5iytiBODo64JY6FR90aIpntizs/+8Y/Yd8TcUyxTl4+ATLV//N0rmxpxYatevDqMG9ABg0ciKD+3bBK1d2tu7cz8TpC/lyyP/v3nz+YiAjx0/nu/Gf4ZElIz/89DvDx0xjwqj+vFu+JH9t3EarxrW5dv0mFy8HUcQvH/N//A1nJ0cWTh9NZGQUrbsNpPS9L7uNW3YxanBP+vVoa9mGg70944b15f1+IyxfVpcDg4kIj8TXOxetm9bmm+8WsOjn1Qwd0I0FP618ZPtp7911/NbtO8z5YRm/L55Mctdk3Aq5Q4Z0afjkww7M+P5nJn81EIgdLWzeoAbeeXISFHyNBm37UK1SaUu9u8ArV5n05ads2rqbL7+ZTe1qFbgdEsrA4d8yanBPChXw5vCxU6z+M/a0qJ2dHRVKF+P9do2JMQxadhnAtl37KVm8MBCbbMz8ZggpUyRn9/7DLPhpJTO+/px0ad1YsGQl/27f89Ax8E7ZAN4pG8DVazfo2OtzPujYlJA7oYwcN53xI/qR0T0dv6z8k7mLlvFh11YM+2oaAW/50apxbW7dDqFNt4FPPc5OnbnABx2a0q55Xb75bgELl65i6IBuCY7xwqUrDPlyCt+O/gSvnNm4fuMWLi7Ojz0eu7ZrzIHDx+nQoj7+92oKDv1yKiWKFWL05x9y4dIVOvceyrRx/0++N23dzfSvh2Bv//8ZByF3Qun3+TgG9+1Kcf8CXL9xizRuqdh74AhzFy5j+tef45Y6JeMmz2Pi9IX079X+qX3xoF37DzP5y09J45aKhm37APDVkD4cOHycvoPH0qB2ZUwmE7dD7uDs7MS0cYNZsmwtcxYup1RAEdau30xy12RM/upTrl2/ScqUyZ9p+yLydEqQEpmDgwM+Xjk4dvIsew4cplv7Jri5pWTvwSNky5oZX+/YX9Mmk4kM6dKw4KeVHDtxBoALlwItCVKjelUtRSE3b9tLvRoVSe6aDICsmTNy/IE74SZEwfx5cUudEoC8ubNz9fr/C5cGBl1l3qLl9H6/FalTxa6TOlUKAq8EM2XWYs6cu8SNW7e5ezeM9GndiIkxCAkJxWSCiIgo7OzsuHAxkLPnLzP0q9gaW4aBpUbcfdt3HyCgqJ/li6pB7cpMnrWYsPBwqlUqzfBx39GqcW3Wb9pBpfJvY29vx8Ytuwm5E8qWHbGnLSOjoggMugqAZ7YslClRlIRIlsyF4vcSwgL58vDzb+sAHtv+/QQpVcrkVKlYks9HT6Z5gxoU8y/wyPYdHR1wcXFm5ve/cPLMeUyYuBJ0zZIglSlRFJPJRIF8eSynXA8ePk42j0wUKhBbGPN+v9yXNXNGlv62jkNHT3Hnzl0uXLpiea5OtQqWtjdv30vViqUsdaE8ssZt50GGYTBy/AzaNK1L1szubNmxjytXr9H3s7EAREfHkNMzK3fDwtl38CjjRvQFYouO3t/e8/RzQmPcvusAxf398MqZDcDyPjzueEwebyTnblg4ew4cYeywj2K3kyUjxYrkZ/uuA5b+bfpe9TjJEcDBwyfIksmd4vfe3/vb3bRtD5UrlLCMeDWqW4XOvYc+c4KUN5cnmTNliP23lycBRQvi6OhAQd883A0LJ/RumGVUqmzJ+8eKl2V+YMnihVmxZgPfTl9Io7rv4uzk9EzbF5GnU4KUBHy9c3Pi1DnOXwgkT25PUqdKwdLlf2A2R+PnmweIPa0wcMS3dGrVgGrvlObq9YnEPFCs8cE/4Obo6KfWHnsWDvYO8MDNHn5Z8SedWjdgzqJllC1ZFCcnR5b9vp5V6zbStnk9Wjetwzt1OxBjGGTKmJ68uT0Z/MUkQu+G0aNzczJnTM/psxdxcXFmzqThlsKYCXG/Lmqe3J5ER8dw/mIgf23cRu+useUoDMOge8emDyVCu/cdeuhLLsH772CPca8DHtf+/+Mz8fnH73PyzHmmz1vK4l9XM3ZY34fW27JjH5NmLqJz6wY0qF2ZNscGxnk/H9z2fWZz9GP3ISj4Gt36jaRl41p0at0AOzsTMTEPHh9x23FxTtgX5rJV6zGZoHa18pb998iSkbmTRsRZ707o3Ye286we7OeExhhjGMSrlRsb92OOx8d5sOCuyWTiwUYftU8xMTEPFel9XLuPXM9kwmyOfnj5IzjY///P8P3T3I8q1Org4GDpP89sWZg7ZQR/b9rBB/1G0rFVA6pULJmg7YlIwugqtiTg65ObvzbuwCtXdhzs7cmcMQO3Q0I5fOwUvt65Adi19z9yemalUvm3iY6J4UrQtce2V9jPh1V/biIqyow5OppDR08+cj0TJox7hUafRbMG1WnesAaFCngzb3Hs/KlN23ZToUxxAor6cfL0ecu6V4KvEXT1GlPHDuL7qaOoVaUcANk8MuGWOgWLfl6NYRhERkYRdPV6nO0U9/dj++6DXLwcBMDSFevwL5iPZC6xtY6qvlOKZavWcyc0DK9csZXnS79dhHmLVxB67wv7UmDQU/cnTZrUhIbeJTwi8qnrPq392Grk58idIxtd2zZi266DmM1mMmVMT1DwdaKjY/t7y459vFU4P2VKFOXGzVuEhDy+XtV9+bxzcezEWc6cuwjAgUPHLc8dOnqKZMlcqFWlHMldk3Hm3KXHtlPYz5u/NmwnNPQuhmHEaedBFy5dYe7CZQzo1cHyJZ/fx4srQdf4a+N2AELvhnHj5m1SJHclp6cHq9ZtsvTLgxcbPKuExljcvwBbd+637O+FS1eIjo557PEIkMk9PZevxI4quiZzoYifDz/99gcAFy8HsX33QcvI0OMUyOfFuQuX2XPgCABBV68TFh5O6YAi/LF+CzdvhWAYBkuWraHM2/fq1Zkgxoh9/9OndePcxUCuXb9JyJ1Q/vl3x/N11GMcPnaKiIhIKpV7m4plA9i++8BLbV9ENIKUJPJ75+bg4eN80CG2gvX94fLN2/eSLWsmACqUKc6/2/bS6v1PyZvbk5wPTNCNr37Ndzh56hxNO/Yjk3t6cuXwIPRu2EPrlSnhz/wfVzD804RVrL/v/mm1Lm0a0rLLJ1QoU5wGtd9l0oyF/LlhG8X9C5AxQzoA0qdLg9kcTeP2fXFxdiJtmtT4+ealXfO6jP6sN2MmzeG3NX/j5ORIy0a1qFTubct2smXNxIBeHRgwbALR0dF4ZM7IwI86W55/t0JJGrTpTadWDSzLWjaqxZ07d2nbfTAuLs7kzuHB4L5dnrg/Ls5OVKlYiqYd+vJercq8Uzbgses+rv37CcTdu+FMn7eUy0FXCQ29S++uLXFwcCBLJndy58hG4/Yf0a55PWpULsOYSXNp130wfr55Hpqc/igZ0qWhX4+29Pt8PClTJKd40QK43iuM+VaR/Pz+x0ZadB5ATs+s5Mie5bHtlCv5FgcOHafV+5/inj4tfvnzPnK9STMWEXo3nN4DvwLAPUM6xgztw1dD+jBh2vfMnP8zzs6OdGvflKKFfRnUtzOjxs9gya9ryJ0zm+XYfR4JjTG7R2YGfNiBgSO/xc5kwj1DOj7p3eGxxyNAjcpl+Xz0ZH7/YyMTvujP4H5d+Oqb2axY8w8ODvZ88mGHh05fxpc6VUpGDerJN98tIDLKjFvqlHzcox2F/Xxo3bQO3fqNAAN88uakd9eWABTw8WL2gl/578hJ8vvkpkblMrToMgBvrxxULBvAkeOnn7u/4rt85SpjJs7lblgYyVxcGNy389NfJCLPRHfSlheyat0mDh45Qd8P2mAYBvv/O0a3fiNZ89NUyxwpERGR140SJHkh5y8GMm7yPK7duEW0OZpkyZxp2bgW5Uq+Ze3QREREnpsSJBEREZF4NElbREREJB4lSCIiIiLxKEESERERiUcJUiIyDAOz2fzIm76JiIjIq0sJUiKKjo6mTI02REcn7I66IiIi8mpQgiQiIiISjxIkERERkXiUIImIiIjEowTpAdt3H2TD5l3WDkNERESsTMVqH/C0Ct8iIiJiG5QgPWDl2g2YTCY2bNmFW+qU1Hy3HCdOnyPwylU8s2WhQuliTJi2gPCISArky817tSonqN0KddpbqsHLm6d0QBFGDupp7TBEROQl0im2eGYt+IVGdd6lf8/2FMjnxY2bt3FPn5YKZYrj4uJMm6Z1KO5fgPUbd1g7VHkFREWZ2bRtj7XDEBGRl0wjSI/ywGhP22Z1OXL8NMPHTKNxvaosW7Werm0bse6fLQlubv2ymTg4qKvfRGVrtrF2CCIikgj0rR1P+xb1+eGn31m7fjPvlA1gz/4jRERG4pktC2ncUhESEsr3S1YQE6O7Y4uIiLyplCA9oMa7ZQGoVqm0ZVmxInEnbo/+/MMkjUlERESSnuYgiYiIiMSjESSRFxQVZdZcpOekKwBF5FWlESQRsQpdASgirzKNIIm8IEdHBzasmGPtMF47GnUTkVeZRpBERERE4lGCJCIiIhKPzSdIK//YwKGjJ5+6Xp9BY5IgGhEREXkV2PwcpBqVy1o7BBEREXnF2GSC9MmwCQzu15WIiAimzP6ROtUqsPrPTdSt/g6/rPyTpvWr8d/Rk/y1YRvp0rrRs3Nzy2snz1yEvYM9Af5+FPbzSdD2VKz2zRUVZcbR0SY/RiIibzSb/MtertRbbN2xj1u373D23CUAOrZqwMAR31Lc34/MmTIw+ItJfDf+s4cSm+BrN6lULoBCBbytEbq8YhwdHSgdUMTaYYiIyEtmkwlS2ZJFmTB1AeboaAoXjB0FCg0Nw8HBgYjIyCe+dmCfTvyzeSdTZv/I++0aJ2h7KlYrIiLyerHJSdrJXFxwcnIkQ7o02NvFdsH0+Uv5tHdHbt4K4dSZC7xXqxIDhk3giwkzCQsPJyrKTOjdML6YMJOjx0/j6ZHZynshIiIiicUUGRmhsvSJxGw2U6ZGGzaunKMRJJF47t8oUjfZFJFXkU2OIImIiIg8iRIkERERkXiUIImIiIjEowRJREREJB4lSCIiIiLxKEESERERiUcJkoiIiEg8SpBERERE4nnk3QsNw+DT4d/waZ9OxMTE0KLzABrVrULzhjWo3+pDypTwB6Blo5pMmf0j3Ts2wy11SgBmzF/KhUtXSO6ajDRuqWjfov5D9czMZjNfT11AVFQUIaF3+bhHW5YsW0upgCLky5uL3fsOcfjYaSqWKc7HQ8ZTtLAvN2+F0Oy96kyZ/SPjhvcF4JPh39ChRX0++2Iy/oXyAdCtfROcnBzjbO/fbXvYsHkXt0NCaVC7MlkyZWDBT7/z0QetLessWLKSk2fOYxjg55uH+jXfsexL2jRuhIWF069HW3oOGE1Oz6wAVChdLMEFa0VEROT18cgEyWQy0axBDZYsW0t0dAwtGtUkMjIKgJyeWfmwa8snNtq4XlXy5c3FjPlL2b3vMEUL+8Z5fvmqvylUIC+Vy5fAMIwnVrovmN+bnp1bsHb9Zg4cPoF7+rRcv3ELe3s7XF2cSebiTKEC3k+M6Z/NO2n2XnVyZM+KYRgEXrka5/kTp89z+cpVBvftAsDwMdMIKOoXZ196fTKaO6F3cXR0eOr+i4iIyOvtsafYCuTzIvDKVW6HhJA7h4dl+emzFxk/ZT4Lf1711MZ9vXNz5vzFh5afPHMeP988AHGSI8Mw7v3//+seOHyMwaMmsXXnfqpUKEHFsgFs3LKbfzbvomLZAAD2HTzK+CnzWfnHhkfG0a19E1at28ToCbO4FBj80PNnzl3E1zuX5XE+71ycu3AZgCXL1jJxxkKqvlOKlCmSExVlZvyU+YyfMh+z2fzUPhAREZHXzxPnIBXI50XB/N5xlt0fQWpav9pTGz94+AQ5PT0eWp4rhwcHD50AYpOimJgY0ril4sTp8wAcP3WOtGlSA+CXLy8fdm1JaGgYrq7J8C+Uj/2HjrH/4FGK+xcAsIwg1ahc9pFxJHNxoWu7xrRtXpcZ839+OB5PD/47etLy+PDRU+TIlgWAhnXe5YMOTan6TmkAywjSh11bqr6aiIjIG+qJ3/Amk+mh01+nzl5gzMS5ADSuVwWASTMX4ezkRKmAwgAs/mU1rsmSkS5taoo8Yo5O7aoV+HrqfHbvP4xhGDRrUJ3K5UsyfMw0du87RFh4BJ/168qtWyEApHFLhX+hfKxdv5kqFWNHckwmLAnKngOHLTF1bFWf1KlSWrZlGAazF/7K7ZBQjBiDGu+WifMaOzsTvd9vhUeWjAwf+x0YBvnzeZE5U4ZH9klUlNmyrZLFC1GyeOEndaGIPEFUlNlStFZEXn2lA4owclBPa4eRJEyRkRHG01d7fuboaH5a9oflsZOjA/VrVUq07Z04dY6dew9ZHuf18sS/YL5E296TmM1mytRow8aVczTaJBJP2ZptiIoy4+ioz4bI6+D+53XDijnWDiVJJPpfJgd7e5rUr5rYm7HwypUdr1zZk2x7CVGhTvsnTkRParb0C0Bebbb0x1bkdWdro726D5KNiYoys2nbHmuHISIi8krT2HYSWL9s5itzis3WfgGIiIg8D40giYiIiMSjBElEREQkHiVIIiIiIvEoQRIRERGJ59WYOZzILgcGs/KPDdSpXpEvvp6Jf8F8NG9Yg+BrN5g8czH2dibqVK9oKX9y3+Fjp1j95yZC74ZT7Z3SD9WUExERkTeTTYwgLfplFTv2/Md/R07QvEF1y/LfVv9NtUql6dG5Bd8vWcH8xb+x58ARAAaNnEieXNnp1aUl3do34fd1G1n391Z+/2MjAMPHfsfdsHCr7I+IiIgkLptIkMqVfItiRfJTvlSxOMuDgq+TLUtGUqVMTkREJFUrlWbdP1sJvnaDTO7pcXBwwGQysWrdJiqWKU6Zkv5s3bmPyMgo7OxMuCZzsdIeiYiISGKyiVNsdnZ2RMfEPLTcPUNazl8MJHlyV5ydnciQLg1hYeFs2LyTimWLA7BizT+4uDhTKqAIAGncUrN+0w7efqtQku7Dy6T6V7F0R3EREXkcmxhBypMrO8dPnmPd31v5ecWfbNq2hw2bd1GranlW/bmJr6fOp0XDmgCULVmUteu34JMnJ+s3bmfe4t84deYC4ybPA6B65TLMmL+UksVe3wRJdEdxERF5MpsYQUqe3JUxQ/sAUKn823Ge+6xf1ziPc3l64F8oHyaTiQplilOhTPE4z3tkyUiRgj64uDgnbtCJSPWvdEdxERF5MptIkBLq4OETrFj7D13bNn7k8+cuXOaHpb/TslGtJI5MREREkpISpAcUyOdFgXxej30+u0dm+vdsn4QRiYiIiDXYxBwkERERkWehBElEREQkHiVIIiIiIvEoQRIRERGJRwmSiIiISDzPfBWbYRh8OvwbPu3TiZiYGFp0HkCjulVo3rAG9Vt9SJkS/gC0bFSTKbN/pHvHZrilTgnAjPlLuXDpCsldk5HGLRXtW9THZDLFad9sNvP11AVERUUREnqXj3u0ZcmytZQKKEK+vLnYve8Qh4+dpmKZ4nw8ZDxFC/ty81YIzd6rzpTZPzJueF8APhn+DR1a1OezLybjXygfAN3aN8HJyTHO9gYMnUC6tG4AfNChyUP3Nwq+duOZCtw+SoU67R/aT2uJijLj6KiLF0VERJ7kmb8pTSYTzRrUYMmytURHx9CiUU0iI6MAyOmZlQ+7tnzi6xvXq0q+vLmYMX8pu/cdpmhh3zjPL1/1N4UK5KVy+RIYhvHExKJgfm96dm7B2vWbOXD4BO7p03L9xi3s7e1wdXEmmYszhQp4PzEmFxdnXJM5kyF9WpydnR56PkO6NDRvUJ3Dx04D/y9w65MnJyPGfcfozz584v6+ahwdHSh9r2yKiIiIPNpzDSUUyOfFijX/4OzsSBE/b0vycPrsRcZPmU+mjOlpWr/aE9vw9c7NmfMXH0qQTp45T8vGsTdifDA5Mgzj3v//v+6Bw8cYPGoSDg729Hm/FR5ZMrJxy25MdiYqlg0AYN/Bo4yfMp+8Xp7UqFz2oTgG9GqPk5MjYyfN5eDhE08dEQoKvk62d/5f4DYh1i+biYODRm1eNapJZ10azRSRV9lzz0EqkM+Lgvm94yy7P4L0tOQIYu9andPT46HluXJ4cPDQCSA2KYqJiSGNWypOnD4PwPFT50ibJjUAfvny8mHXloSGhuHqmgz/QvnYf+gY+w8epbh/AQDLCNKjkiPDMIgymwFwTeZi+feT3C9wezsk9JEjTiKSMBrNFJFX2XP/fDOZTA+d/jp19gJjJs4FoHG9KgBMmrkIZycnSgUUBmDxL6txTZaMdGlTU8TP56F2a1etwNdT57N7/2EMw6BZg+pULl+S4WOmsXvfIcLCI/isX1du3QoBII1bKvwL5WPt+s1UqViKlCmSYzJhGbHZc+CwJaaOreqTOlVKy7buhoXz7fQfMGEiOiaaQvESPoCde//j15V/ce3GLbJlzUStquWZPHMRq//611LgVl5PqkknIiKPY4qMjDCevlriMEdH89OyPyyPnRwdqF+rUqJt78Spc+zce8jyOK+XJ/4F81ke37p9h1XrNlkep3FLSZWKpZ57e2azmTI12rBx5RydYnvF3D+1pgRJRCRhbO3vplW/tR3s7WlSv2qSbc8rV3a8cmV/7POpU6VI0nhERETk1aT7IImIiIjEowRJREREJB4lSCIiIiLxKEESERERiUcJkoiIiEg8SpBERERE4tHNeRLgcmAwK//YQIeW7z3X61+lYrUSS2UuRETkSWzmG2Ll2g0kS+ZCxTLF6TNoDGazGV/v3Bw/dY6Pe7Zj+64D7DlwBI8sGSnom4c/N2zj4uUg+vdqz6JfVnHk+Bm8cmUne9bM/LLyT1yTuVDc3++hWnLyelCZCxEReRKbSZDiM5lMdGrdgN/XbWTfgaMA+OTJSYPalYmOjsHFxZnfVv/Dlh37KFfyLVKmSE75UsUYPGoSWTJlwN7env+OnkhQgqRitSIiIq8Xm/nWdnZyIiw8PLZA7b3TKyaTiWQuLoSFhQNYiuCOmzKPYoXzU7ZkUU6duYCdnR3RMTEAxMTEULZkUXy9c1ttX0RERCRx2UyCVNjPmy+/mc2Fi1ewt3/y3PRsWTKxffdBIqOiyJk9K3lyZef7JSv5c8M22jSryzfTFpA7pwelA/x1ik1EROQNZNVitW86FasVEZE3ha0Vq9Vl/iIiIiLxKEESERERiUcJkoiIiEg8SpBERERE4lGCJCIiIhKPEiQRERGReGw6QeozaIy1QxAREZFXkG7O8wQ3b4Xw3dyfsLe3w9srBzWrlGPyrMWYo8y4urokuHjtixarLR1QhJGDej7360VEROTZ2FyCFBh0la++nU2eXJ4EXrnKb2v+ISwsnBVrN9C6SW1C7oQSeOUqntmyUK1Safp2b0NYeARDvpzCW0XyExR8jc8/fp8BQydw63YIqVOlTNR4o6LMbNq2J1G3ISIiInHZXIK0dPk6mjesiX/BfBw/dY71G7czZmgfLly6QqnihVn48yrc06elQpniAOw/dJyR46bTvWMzgoKv45ElIwCZM2Ug+NrNBCVIL1Ks9v6dS0VERCTp2NwcJHO0GSdHRwAMw8AnT05m//ArBfPnxcXFmbbN6uLrk5vhY6YRExNDofx5WTh9NIt+XoV7hrRcuHQFgMuBwWRI52bFPREREZHEYnMjSHWqVWDspHnk887FzVu3CQ+PIDomhrPnL3P+YiCr1m0iIjISz2xZOH7qHL//sQGTyQ6//HnI5J4e9/Rp+WbaAnLl8Ej002siIiJiHTaXIOXInpVvRw+496gxg0dNYuiAbpw5d4m5i5YzsE+nOOt7e+WI8/j99k2SJlARERGxGptLkOLLkD4NcxctJyj4GnWqVbB2OCIiIvIKsPkEqXvHZtYO4amioswvPFlbtwoQERFJOJubpG2LdKsAERGRZ2PzI0ivA0dHBzasmPPcr9etAkRERJ6NRpBERERE4lGCJCIiIhKPTSdIKlYrIiIij6I5SE9wKTCIhUtXYTZH418oH5XLl2Dh0t+5Enyd6Ohoer/fKkFFaF+kWG1UlBlHR71NIiJifS/jquoXkZRXZNvcN++zFKt9t0JJenVpickEfT8bR7mSb7Flx36++aI/46fM5/ipc+TN7Zmo8To6OlA6oEiibkNERORVl9RXZNtcgvQsxWrt7WPPQP61cTslixfiVsgdMqRPA4BHloxcCb6WoATpRYrVioiIvCpe9KrqF5HUI1c2NwfpWYrVAmzZsY9TZ85Tv2YlUqdMQVDwdQAuXLpCxgzprLYfIiIiknhsbljjWYrVHjh0nNETZlGmhD9jJ82jU+sGlChWiPFT5hMdHUOeXNmtvTsJZu3zxk+jO32LiMirxOYSpGctVvvr9xPiPG7WoHoSRWo7dKdvERF51dhcghSfrRSrteZ546d5lUe2RETENtl8gvQ6FKsVERGRpGVzk7RFREREnkYJkoiIiEg8SpBERERE4lGCJCIiIhKPTSdIKlYrIiIij2LzV7E9zbzFy/l7005mfTsUgMmzFmOOMuPq6kKHlu8lqI0XKVb7MqjgrYiIyLOxuW/NZylWW61SaVo1rs2+g8csrw0KvsbnH7/PgKETuHU7hNSpUlp5j55OBW9FRESejc0lSM9SrDa+oODreGTJCEDmTBkIvnYzQQmSitWKiIi8XmxuDtKzFqt9kHuGtFy4dAWAy4HBZEjnlpShi4iISBKxuWGNZylWGxp6l5kLfuXMuYtMm7OEzm0a4p4+Ld9MW0CuHB6vxek1EREReXY2lyA9a7HaHp2a0aPT/8uRvN++SRJGazuiosxvXE220gFFGDmop7XDEBGR52BzCVJ8tlKsVpJWVJSZTdv2WDsMERF5TjafIKlY7avB0dGBDSvmWDuMl+ZNGw0TEbE1NjdJW0RERORplCCJiIiIxKMESURERCQeJUgiIiIi8ShBeoCK14qIiAjoKrZncuT4aVas2QDA1p37WPDdFzg7OT31dS+rWK3uqyMiIpI0bD5BetbitT55crJ73yFy5fBIUHL0sui+OiIiIknH5hOk5yleu3z13wz6qEuCt/EyitXqvjoiIiJJx+bnID1r8drw8AhMJhP29jbfdSIiIm8smx9BepbitQAXLl0hk3t6K0ctIiIiicnmE6RnLV7rlSs7XrmyJ32gIiIikmRsPkGKT8VrRURERAlSPK9y8dqoKPMbOVk7KsqMo6MORREReXVoprFYnaOjA6UDilg7DBEREQv9bH+NODo6sGHFHGuHIQn0Oo346SakIiJxaQRJxMbpJqQiIg/TCJJIInldRvxel1EuEZGkpBGkB6hYrYiIiIBGkJ5JyJ1QuvQeRpGC+fDKlY261Ssm6HUvo1itrvQSERFJOjb/jfssxWrLlPAnRQpXnJwc8cqZtDeL1JVeIiIiScfmE6RnKVbr4uzEt1/E3nX7g49H8t34zxK0jZdRrFZERESSjs3PQXqWYrWhd8NwdHTAwcEeuxc8ZSYiIiKvLpsf1niWYrWHjp5k/cYd3LwdQoPa71o7dBEREUkkNp8gPWux2mJFCiR9kCIiIpKkbD5Bik/FakVEREQJUjyvcrFaERERSRo2P0lbREREJD4lSCIiIiLxKEESERERiUcJkoiIiEg8NpUgzV/8G1eCrlk7DBEREXnF2VSC1LJxLTK6p3vhdoaNmfYSohEREZFX1Rt/mX/wtRuMnTQXt9QpCbxylQG9OjBh2veMHNSTjVt3ExISyj//7iRD+rRcCb5K7WoVKFY4PxOmLSA8IpIC+XLzXq3KdO49lNw5suHnm4ddew/xw0+/06xB9QTFUKFOe0wqTWJToqLMODq+8R8vEZE31hs/grTk1zU0qvMu/Xu2J11aN5ydnUidKiXXb95i05bdlCv1FuZoM326tWLkwJ6sXrcJFxdn2jStQ3H/AqzfuAOI/cLr270N1SqVJkvmDAlOjsQ2OTo6UDqgiLXDEBGR5/TG/8Q1DCDe6E2ViiVZ9/dWTHYmkrsmA0yYTCbCwiMIC4/gwKHjLFu1nq5tG7Huny0ApHFL9dyjQOuXzcTB4Y3vahERkTfGGz+C1KB2ZX746Xe+mDCTnXv+A6Bg/rys/nMTZUsUBWJHh6bNXcKQLyfTuklt0rilIiQklO+XrCAmxniozewemZm14Jck3Q8RERFJOm/8sEZG93SMGdrnoeWzvh1m+bejowOdWzeM8/zozz+M83jssI8s/+7fs/1LjlJEREReJW/8CJKIiIjIs1KCRNzRIREREZE3/hSbiDxdVJSZsjXbWDsMEXmF2drtSzSCJCIiIk9la7cvsZ1UUEQey9HRgQ0r5lg7DBGRV4ZGkERERETiUYL0gD6Dxlg7BBEREXkFKEF6RvMWL6dd98HWDkNEREQSkc3PQQoMuspX384mTy5PAq9c5bc1/xAWFs6KtRto3aQ2IXdCCbxyFc9sWahWqTStGtdm38Fjz7SNxCpWWzqgCCMH9Xzp7YqIiNg6mx9BWrp8Hc0b1qRL20Zkypie9Ru306B2ZQoX8KZU8cLcuHkb9/RpqVCmuLVDjSMqysymbXusHYaIiMgbyeZHkMzRZpwcHQEwDAOfPDmZ/cOvFMyfFxcXZ9o2q8uR46cZPmYawz/t/lzbSIxitbpnjYiISOKx+QSpTrUKjJ00j3zeubh56zbh4RFEx8Rw9vxlzl8MZNW6TURERuKZLQuhoXeZueBXzpy7yLQ5S+jcpuHTNyAiIiKvHZtPkHJkz8q3owfce9SYwaMmMXRAN86cu8TcRcsZ2KdTnPV7dGpGj07Nkj5QERERSTI2nyDFlyF9GuYuWk5Q8DXqVKtg7XBERETECpQgxdO94+szOvSi9bN0FZyIiMij2fxVbLZKV8GJiIg8nkaQXmMvUj9LV8GJiIg8nkaQREREROJRgiQiIiISjxKkBOozaAwbt+5m5PjpBF+7wSfDJrBx625rhyUiIiKJQAnSM9i4ZRedWzfk0uUgfPLmpMzb/tYOSURERBKBJmk/wYOFbM+cu0hg0FUW/byayKhITpw6T+kAf3Ll8HhqO4lRrDYqyoyjo94+ERGRxKBv2Ce4X8jWv2A+jp86h1vqlDRvWINTZ87jnj5dgpKjxOLo6EDpgCJW276IiMibTAnSE8QvZPu8EqNYrYiIiCQefWs/QfxCtmncUlk7JBEREUkCSpCeIH4h2/v8C/niX8jXOkGJiIhIotNVbCIiIiLxaATJhr1osVt5M+iKSBGRh2kEScTG6YpIEZGH6WejDXuRYrciIiJvMo0giYiIiMSjBElEREQkHiVID+gzaIy1QxAREZFXgOYgPYObt0L4bu5P2Nvb4e2Vg5pVylk7JBEREUkENp8gPViQNvDKVX5b8w9hYeGsWLuB1k1qE3InlMArV/HMloVqlUrTt3sbwsIjGPLllAQnSM9arLZ0QBFGDur5vLskIiIiL8jmT7HdL0jbpW0jMmVMz/qN22lQuzKFC3hTqnhhbty8jXv6tFQoUxyA/YeO0/aDQdSqUj5R4omKMrNp255EaVtEREQSxuZHkOIXpPXJk5PZP/xKwfx5cXFxpm2zuhw5fprhY6YxdEA3CuXPy8Lpo+nR/wtKv52we8c8S7Fa3bhRRETE+mw+QYpfkDY8PILomBjOnr/M+YuBrFq3iYjISDyzZeH4qXP8/scGTCY7/PLnsXboIiIikkhsPkGKX5B28KhJDB3QjTPnLjF30XIG9ukUZ31vrxxJHqOIiIgkLZtPkOLLkD4NcxctJyj4GnWqVbB2OCIiImIFSpDi6d6xmbVDSJIisipQKiIi8ng2fxWbrVKBUhERkcfTEMIrSEVkRURErEsjSCIiIiLxKEESERERiUcJkoiIiEg8SpAe0GfQGGuHICIiIq8ATdJ+BpcCg1i4dBVmczT+hfJRuXyJBL3uWYrV6vJ7ERER67P5b+LAoKt89e1s8uTyJPDKVX5b8w9hYeGsWLuB1k1qE3InlMArV/HMloV3K5SkV5eWmEzQ97NxCU6QnoUuvxcREbE+m0+Qli5fR/OGNfEvmI/jp86xfuN2xgztw4VLVyhVvDALf16Fe/q0VChTHHv72DOSf23cTsnihRK8jWcpVisiIiLWZ/NzkMzRZpwcHQEwDAOfPDmZ/cOvFMyfFxcXZ9o2q4uvT26Gj5kGwJYd+zh15jz1a1ayZtgiIiKSiGx+WKNOtQqMnTSPfN65uHnrNuHhEUTHxHD2/GXOXwxk1bpNRERG4pktCwcOHWf0hFmUKeHP2Enz6NS6AalSJrf2LoiIiMhLZvMJUo7sWfl29IB7jxozeNQkhg7oxplzl5i7aDkD+3SKs/6v309I+iBFREQkSdl8ghRfhvRpmLtoOUHB16hTrYK1wxERERErUIIUT/eOzawdgoiIiFiZzU/SFhEREYlPCZKIiIhIPEqQREREROJRgiQiIiISjxKkBBg2Zho3b4VYOwwRERFJIrqKLQk8qVht6YAijBzUM4kjEhERkSdRgvSAy1eu8svKP7l0OYgosxkAjywZOX7yLADDx0zDxcWFW7dDKFIwH/VrvvNC24uKMrNp254XjltEREReLiVID9i8fQ9++bwoHVCEYyfPkiyZMzUql2XYvTpsBtCuRV3SuqXm4yHjE5wgPa5YbdmabV5i9CIiIvKyaA7SA/wL+rJq3SYOHDpOTEyMpYhtTIxhWcfOZEd0dIzmJImIiLzBNIL0gLthYZjN0dy8FUIOzyysXLuBw8dOc/7iZcs68xb/xqXAIJrUq2rFSEVERCQxKUF6wObt++jeqRmZM6bnw0+/YvyIvg+dGmvVuBZuqVNaKUIRERFJCkqQHuCTJwfLVq3H0dGBYv75Hzlv6GWLijI/ci6Srm4TERGxHiVIDyhToihlShR97PODPuqcJHHo6jYRERHrUoJkZY6ODmxYMSfOMl3dJiIiYl26ik1EREQkHiVIIiIiIvEoQRIRERGJx6YTpOjoGMZPmQdAn0FjAPj1978YO2ku4RGRT3zt/fVFRETkzWPTk7Tt7e34sGurOMs2bd3DV0N6P7a47PN4XLHaqCgzjo42/RaIiIi8kt74b+fgazcYO2kubqlTcv5CIDk9PeIUm+0zaAxjh30EwPGTZzlz7iI//rqGYkUK8MvKP3FN5kJxfz9cXJxZtW4TGdKnoXnDGi8lNkdHB0oHFHkpbYmIiMjL88YnSEt+XUOjOu/iX8iXYWOmPbHYbJ7cnnhmy0LjelUZPGoSWTJlwN7env+OnsDHKyf29iZqvlsWB3v7Z4rhccVqRURE5NX0xn9rGwbwwOmthBabjYmJoWzJovh657Ysy5E9C+Mmz6NPt9aJFa6IiIi8At74BKlB7cp8NXEOa9dvZuee/x5bbDYqykzo3TDL4zbN6vLNtAXkzulB6QB/rt24yf7/jpMqZQpck7ng4uxEYNBVMrmnT+pdEhERkURmioyMMKwdRFIZNmYa3Ts2S7Jis2azmTI12rBx5ZxnOsV2/07a8e+wLSIiYquS+rvRpi/zFxEREXmUN/4U24OSqtjsyxAVZX5qTbbSAUUYOahn0gQkIiJiQzSC9JqKijKzadsea4chIiLyRrKpEaTXiaOjwxPPsz5tdElERESen0aQREREROJRgiQiIiISjxKk53DqzAV+/m2dtcMQERGRRKIE6TnkyuFB/VqVErx+hTrt+WTYhESMSERERF4mm5ykvXLtBjZu3U2qlMmxs7PjrcL5+WvDNtKldaNn5+Ys+Ol3QkPvYmdnR+c2DXm/7wi8cmbj3IXLdG7TkPDwCA4fO53gorVmc7SuOBMREXmN2GSCBFCp3NtUKvc2X3w9kxnzf2bh9NGYTCbOnr/E5u17KVYkP4FXrnLt+k2SuTjTp1trgoKvMW/xCiqWKfZM23JweLbitiIiImJdNpsg2dnFnl28HXKHyMgoy3LDMEiRPBkdWr5nWWa6V+w2JPQuZrM5aQMVERGRJGezCdK6v7ewdec+smXNRNmSRRkwbAJuqVPSs3NzPLNlZciXU8iQPi1d2zbixs1bTJ39I0dPnKFn5xZcv3HT2uGLiIhIIrLZBKlS+RJULFPc8rjqO6Ut/+7RqVmcddO4paZL20aWxzmyZ8G/kG/iBykiIiJWoavYREREROKxyRGkGu+Wfab1xw776IW3mZDisw+u6+hok2+NiIjIK0EjSK8gR0cHSgcUsXYYIiIiNkvDFEnkacVnRURE5NWhBOk19iyn7RJL6YAijBzU06oxiIiIvGw6xSbPLSrKrDuEi4jIG8mmRpCio2P45rvv+bBrqxdq53JgMAt++p2PPmj9kiJ7PtY+bWft0SsREZHEYlMjSPb2di+cHD0Pszk6ybcpIiIiz++NG0EKvnaDsZPm4pY6JecvBJLT04Nbt0MoUjAf9Wu+Q59BYxgztA/ffLeAu3fDSZs2NZ1bN6TPoDGMHfYRf23cTlhYOMWL+lnaqfluOU6cPkfglat4ZstC4QLezxSTg4O9rkoTERF5jbxxI0hLfl1Dozrv0r9nezJlTE+7FnUZ9skHbNu137KOyWSiZeNaFC/qx9Yd+5/aToF8Xty4eRv39Gmp8MDdtxNq/bKZmsgsIiLyGnnjEiTDAO4VlwWwM9kRHR3DzVshlmWXA4MZ/fUsfL1zkzZNqnuvMwCIiop6ZDttm9XF1yc3w8dMS/ydEBEREat6406xNahdma8mzmHt+s3s3PMf8xb/xqXAIJrUq2pZJ2XK5ETHxLD4l9Xcun0HgMJ+3nw1cQ4x0TEUyOcVp513ygawZ/8RIiIj8cyWBTe3lJw9fwnDMDA9kESJiIjIm8EUGRlhWDuIxDJszDS6d2yGW+qUVtm+2WymTI02bFw5BweHl5uL3r+C7FW4ik03wBQRkcSW1N85b9wpNhEREZEX9cadYnvQoI86WzsEEREReQ1pBElEREQkHiVIIiIiIvEoQRIRERGJRwmSiIiISDxv9CTthLL27QBeZ1FR5qcWrS0dUER3EhcRkdeKEqRn9PXU77lw6QpjhvZJ8Gsq1Gn/0m8oGRVlxtHx1X/7oqLMbNq2x9phiIiIPJNX/xv2Jbp85Sq/rPyTS5eDiDKbAfDIkpHjJ88CMHzMNFxcXOIUt50yazHB127glTM7zRpUp1eXFvQZNMaauwGAo6PDK1EA19HR4Yk37Xra6JKIiMiryKYSpM3b9+CXz4vSAUU4dvIsyZI5U6NyWYbdq69mAO1a1CWtW2o+HjIe/4L5uHr9JoP7dnmh7a5fNvOl30lbREREEo9NTdL2L+jLqnWbOHDoODExMTg5OgIQE/P/aitxi9saqNKaiIiI7bGpYY27YWGYzdHcvBVCDs8srFy7gcPHTnP+4mXLOg8Wt/XMloVUKVMw9KupZM3sTvXKZVmybC1nzl1k4dLfafpedSvujYiIiCQWm0qQNm/fR/dOzcicMT0ffvoV40f0fejUV6vGteJczdajc/M4z/fo1IwenZolSbwiIiJiHTaVIPnkycGyVetxdHSgmH9+zQsSERGRR7KpDKFMiaKUKVH0sc+ruK2IiIiAjU3SFhEREUkIJUgiIiIi8ShBEhEREYlHCZKIiIhIPEqQREREROKxqavYrCUxitW+Cl6XgrkiIiLP6o39dlu5dgMbt+4mVcrk2NnZkTd3Dk6ePse1G7f4/OP3GTJ6CqMG92TLjn1cu34TV9dkHDx8gpiYGFo1rsXkmYtImTI5Z85dwidvTq5dv4l7+rR0aPkek2cuwt7BngB/Pwr7+Vh7V63mVSmYKyIi8rK9sQkSQKVyb1Op3Nt88fVMShQrhEdmd2YvXMaVoKukT+dG0NXrbNmxjw4t36PXJ19Qsnhh7oSGcfTEGQyg6XvVuXDpClt37ueTDzvSc8AXAARfu0mlcgEUKuCdoDhUrFZEROT18kZ/a9vZxU6xuh1yh+FjptGzSwsK+3lzNyycGu+WZd3fW4mKMpMqZXLuhkXQukkdyymjdf9sxcnRkWQuzjjdW3b/NNnAPp34Z/NOpsz+kffbNbbOzr1GoqLMlK3ZxtphvPZKBxRh5KCe1g5DRMQmvNGTtNf9vYWR46eTLWsmPLJkZOXafzh89BQA3l452LHnIH6+eQBo36Ie/YeO5+up3xN09fpj27wbFs4XE2Zy9PhpPD0yJ8l+iERFmdm0bY+1wxARsRlv9AhSpfIlqFim+GOfz5ghHWVK+ANQuXwJKpcvYXnuftkRt9QpyZc3FwBfj/wYgE97d0yskN9Ijo4ObFgxx9phvNY0AicikrTe6BGkJ5kxfym+PrlJmSK5tUMRERGRV8wbO4JU492yT3y+Q8v3kigSERERed3Y7AiSiIiIyOMoQRIRERGJRwmSiIiISDxKkERERETiUYL0nPoMGmPtEERERCSRvLFXsb2oxb+s5krQNW6F3OHjHu1wcnJ87raSslit7rYsIiLy4mw+QVq5dgNbduzDzs6ONG4piYw0czvkDkP6v4+DgwPfL1nBwcPHcXZ2ZtW6TWRIn4bmDWtYO+xH0t2WRUREXg6bT5AAypTw552yAXTv/wWTv/qUr76dQ2DQNdzTp+XQ0VPUr1mJg4eOY29voua7ZXGwt3+m9pOqWK3utiwiIvJyaA4S4OjoiIODA67JXDCZTLi4OBMeEcnYSXPp2rYRrslcKF7Uj+YNajBu8jyu37hl7ZBFREQkEWkE6TG+njKfZMmcWfzLGvx8vTCZTOz/7zipUqbANZkLLs5OBAZdJZN7emuHKiIiIi+ZzSdID5YkGTvsIwB6dGr2yHXfrVDS8u8RA3skbmAiIiJiNTrFJiIiIhKPzY8gvWmiosyv1GTtqCgzjo46zERE5PWiby5JVI6ODpQOKGLtMN4Ir1ryKyKSlJL6B7cSpDeMo6MDG1bMsXYYIiIiL1VS/+BWgiTymlDyKyKSdDRJW0RERCQeJUhPsHvfIRYsWfnQ8pVrN/DXxu1WiEhERESSgk6xJYGkKlarK8ZEREReDpv9Nv3si8l89EFrfl7xJxERkbRqXIvPv5yCW+qUBF+9QYeW9S3rRkfH8NW3s4mOiaFwAW8rRv1kumJMRETk5bDZBKm4fwH27D/CzVu3CQuPYP+h45QsXhhf79z8tWEb6zft4O2ifgBs332A9Onc6NDyPSD2FNuzSKpitSIiIvJy2OwcpOJF/di2az+ODg44Oznx77bdBF+9wZ79h6lYNoC7d8PjrJ8Up8hERETk1WCzCVKGdGk4deYCfvnzUqSgDwcPnyRH9iwcOX6aFWv+AcA9QzqOnTxLMf8CXLwcxIhx01mybC1ZM7tz6OhJK++BiIiIJBZTZGSEYe0g3lRms5kyNdqwceUcnWKTF3L/Dtq6D5KISNKw2REkERERkcdRgiQiIiISjxIkERERkXiUIImIiIjEowRJREREJB4lSCIiIiLx2ESCtH33QTZs3vXY5x9XlFZERERsk03cnKe4fwFrhyAiIiKvEZtIkFau3cDNWyGcOX8JJ0cH3DOko3WT2sxf/Bunzl7Ezs5ELk8Pdu87xNxFy8mcKQM3b4UwcmAPRo6bTob0afHKlZ3o6Gg2btlNZFQUHVu+h1eu7AnafoU67VWqRF5IVJQZR0eb+LiKiLwSbOIU233FiuSnb/e27Dt4lLth4WzffZDP+nWhRuUyD6xTgP492+PtlYOjJ85gAJXLl+CdsgEs/W0dQwd0o3fXVsxbvNx6OyI2x9HRgdIBRawdhoiIzbCpn6T3y32YTCZiYmJwcLAHIMb4f7WV+yM9IXfuEhVlBiBtmtSxzz3ndtcvm6lSIyIiIq8Rm/3WTpHcldw5szFszDQcHR3IliUTAFt37ufSlWAiI6MokM+LZavWW15Tv1YlBo+aRGRkFB1bN7BW6CIiIpLIVKz2Abv3HeLwsdM0b1jjpbSnYrUiIiKvJ5uagyQiIiKSEBrWeIB/IV/8C/m+tPaMe3ObzGbzS2tTREREEoe9vb1lLrISpEQUHR0NQIU6HawciYiIiDzNg1NilCAlIicnJ7J7ZOL7qaN0H6QHtOgygO+njrJ2GK8M9Udc6o+HqU/iUn/Epf542PP2ib29veXfSpASkZ2dHXZ2djg6Olo7lFeKyWTSpPUHqD/iUn88TH0Sl/ojLvXHw15Gn2iStoiIiEg8SpAS2Xu1Kls7hFeO+iQu9Udc6o+HqU/iUn/Epf542MvoE90HSURERCQejSCJiIiIxKMESURERCQeJUgiIiIi8ei6wET06+9/sWTZWlIkd2XYgG64Z0hn7ZCsYuHPq/hhyUqa1K9G84Y1uHkrhEEjJ3L9xi2qVS5Ni4Y1rR1ikrkdEsoXE2Zy/kIgqVOlYOiAbtjZ2dlsfwRdvc7YSXM5fyEQRycHBvftQro0bjbbH/ddDgymScd+jB/el1w5stl8f5Sq1pLcObIBUKiAN906NGXol1M4e/4yxfwL0LNzc5u619yBQ8cZO2ku0dExVKtUmuqVy9jsMfLbmn9Y8usaAAwDTp+7yJLZY/n2uwUvfHwoQUok12/cYv7i31gw7Qs2bt3NpJmLGdL/fWuHZRX+fj6cOHXO8njWgl8oV+ot6lavQOtuAylboijZPTJbMcKkc/DwcRrWeZcifj58O/0HFvy0kqgos832h8lkomPL9/DKlZ0ly9ayYMlKUiR3tdn+uG/SzEVky5oJsO3Py30Z0qVl3pSRlscLl/5O5kwZGDGwBx9++iU7dh+keFE/K0aYdKKizAwfO42xw/qSOWMGzl24bNPHSK0q5ahVpRwA/2zeyb4DR/l70/aXcnzoFFsi2bbrAHlz58DFxZnCfj5s2bHX2iFZjXeenGTOmN7yePP2vRT288HBwQG/fHnYsmOfFaNLWiWLF6aInw8Afr55CL56w6b7I0O6NHjlys6Nm7e5cCmQvLlz2HR/AOw9cISYmBi8vXIAtv15uS916hRxHv97r09MJhOF/XzYbEN9smPPQXzy5MIjS0bs7e3I6ZlVxwgQHR3D3IXL6NDqvZd2fChBSiTXrt8ku0fsL8D0ad2IjokhPCLSylG9Gq7fuIVHlowAZPfIzNVrN60bkJXs2nuIgvnz2nx/7PvvGLWafsDps5doWOddm+6P6OgYJs9aTPeOzSzLbLk/7rt2/SYdew2hY6/P2fffMa5dv4nnvREST4/MXL12w8oRJp1LgcEkS+ZMv8/G0brbp+zef1jHCLB99wF8vb1wTeby0o4PJUiJxQSG8f9bTBkxBjZ0ivyJTCZT7MliIMaIwWRnex1z8sx5duz5j1pVy9l8fxTKn5f1y2dRqEBeRo2fbtP9sfKPDRT3L0DmTBksy2y5P+4bMbAnE78cQIPalfl89GRMmIiJud8nBnY21Cd3w8I4ceocAz/qTL/u7Rg7ca6OEeCff3dSsnghgJd2fChBSiQZ0qXh3MVAAIKv3cDR0RFnJycrR/VqSJsmNRcuXQHg/IVAMqRLY+WIktaNm7f57IvJDP+0O85OTjbfHwCOjg40qluFzTv22XR//PPvDjZt3UOHnp+xeftevpo4h7th4TbbH/cVyp8XZycnKpcvwZ07d0mfLg3nL14GYvskfVrb6ZP0adOQ09ODVCmT4+udi5u3Q2z6M3Pf4eOn8MoZO5H/ZR0fSpASSXF/P46fPEt4eAR79h+hZPHC1g7plVEqoAh7DhzBbDZz8PAJShQrZO2QkkxkZBSfDJtAx1bvWT7Mttwfv6z8k6PHT2MYBus37cAzWxab7o+xw/oyZ9JwZkwYQsnihen7QRsa16tqs/0B8O+2PZy/92Nz175DuKdPS6mAwuzZfwTDMNh78AglAwpbN8gkFFDUjz37DxN6N4xDR0+SMUM6m/7M3Hcl6Bpp07oBvLTjQ6VGEtFva/5h0c+rSJnclWGfdrfJrD742g36DPyKazduYWcy4Zk9CyM+7cGgkRO5dv0mNauUpel71a0dZpKZ+f0vLFiyghzZs2A2RwMwdnhfhn01zSb748y5S4yfMo/AoGskd3Vh0EddSJsmtc0eHw8aNmYaNSqXIXfO7DbdH6fPXmTCtO8JCr6Oo5MDn3zYkRzZszD0y6mcOXeJgLcK0r1jU5u6zH/1n5uY/+MKjBiDgR91ImvmjDZ9jAC8U7cDf/46A4CIyMiXcnwoQRIRERGJR6fYREREROJRgiQiIiISjxIkERERkXiUIImIiIjEowRJREREJB4lSCIiIiLxKEESERERiUcJkoi8NCPGTWfG/KWWx70+Gc2X38y2PB7y5VSWLFv7QttY9PNqho2Z9tDyeq16cezkWQAWLFnJmr/+fWpbw8ZMY9HPq18onud17ORZ6rXqBcQWY+332TgiI6Meu/7KtRvi9K2IJC4HawcgIm8OX+9cbNm+D4CoKDOXrwRz9fpNy/NHj5+mQe3KiR5H84Y1En0bL1O6tG58OaS3tcMQkQcoQRKRlya/jxdzFy4H4NDRk3jlzM6Z85e4cfM2Li5OXLoSTJ5c2QkLD2fC1AUcO3mWkDuhlC9VjG4dmgDwft/hVKtUhuWr1lOp3Ns0rPMu0+ct5Y+/t5AurRvOTk5kSP/ksj3jp8wnZQpXOrR8jxnzlxIeEcmly0EcPn6aXJ4ejP6sFw4Ocf/8LV/9N6v/3MSEkf25FBjExBkLCb56g9C7YXRp24h3ygZgGAZTZ//I2r+3cPv2HWJiDLJlzcisicO4eOkKX34zm2s3bpEqZXIG9ulEdo/McbaxfuN2ps39CddkzmTOmMGyPOROKO++15kta74nLDycz7+Ywskz53FydKRnlxaEhYUzedZiADZs3sWXQ3pz7fpNps35iZu3Q4iKiqJfj3YU8fPhcmAwHw8ZT7lSxdi0dTe3bt9hxMDu5MubC4A1f/3L/B9XYGcykSN7Vj7/uCthYeGMnTyPQ0dPYTJBt/ZNKf12kRc7GERec0qQROSlyeWZlZu3Q7h1O4Sdew/h650bV9dk7D1whHRp3cidIxtOTo4YhgM1q5Qjv09uwiMiqNO8B9UrlyGnZ1YAVq75h0lffoqTkyMr/9jA1p37mTt5BMlcnBk/ZT53w8KfKa5dew8xfkQ/XJydaNjuI3btO0xAUT/L8/sOHmXR0lVMGTsQR0cH3FKn4oMOTfHMloX9/x2j/5CvqVimOAcPn2D56r9ZOnc8AI3a9WHU4F4ADBo5kcF9u+CVKztbd+5n4vSFcUaFzl8MZPQ3s/hu/Gdk98jMXxu3c+jYqYdi3bbzABcuX2HJ7LHcDgnF3t6OFMldOXH6HAAdWr4HgAkTA/t0xD1DOtb8tZlvv/uBWd8OBeDUmQt80KEp7ZrX5ZvvFrBw6SqGDujGvv+OMXnmYr4b/xkZ3dNx/cYt7Ozs+Hb6Qvx88zDoo87cvBVCu+6DKFGsEPb2moUhtksJkoi8NA4ODvh45eDYybPsOXCYbu2b4OaWkr0Hj5Ata2Z8vWNHMUwmExnSpWHBTys5duIMABcuBVoSpEb1quLk5AjA5m17qVejIsldkwGQNXNGjp86+0xxFcyfF7fUKQHImzs7V6/fsDwXGHSVeYuW0/v9VqROFbtO6lQpCLwSzJRZizlz7hI3bt3m7t0w0qd1IybGICQkFJMJIiKisLOz48LFQM6ev8zQr6YCYBjg4uIcJ4btuw/w9lsFLaNKHlkyPjrWAnlxcnRk9IRZNKlflRzZsz5yPfcMadlz4AiLflnD8ZNnuXDpiuW5ZMlcKH4vASyQLw8//7YOgE1bdlOtUmkyuqcDIG2a1ABs2LKLA4eO88uKPwGIiTG4ees26e5VRxexRUqQROSl8vXOzYlT5zh/IZA8uT1JnSoFS5f/gdkcjZ9vHiB2gvLAEd/SqVUDqr1TmqvXJxJj/L9u9oMjF+boaOzt7V9afA72DvBAie5fVvxJp9YNmLNoGWVLFsXJyZFlv69n1bqNtG1ej9ZN6/BO3Q7EGAaZMqYnb25PBn8xidC7YfTo3JzMGdNz+uxFXFycmTNpOHZ2jx51MZsTth9p3VIz69uhbN25n8GjJlG5fAlaNq710Hrfzf2JU2cv0KR+NWpXLU/HXp8/en8d7DHu7XCMEYOD6RExGDCk//t45cr+1PhEbIXGT0XkpfL1yc1fG3fglSs7Dvb2ZM6YgdshoRw+dgpf79wA7Nr7Hzk9s1Kp/NtEx8RwJejaY9sr7OfDqj83ERVlxhwdzaGjJx+5ngkTRkzMM8fbrEF1mjesQaEC3sxbHDt/atO23VQoU5yAon6cPH3esu6V4GsEXb3G1LGD+H7qKGpVKQdANo9MuKVOwaKfV2MYBpGRUQRdvR53Pwp4s2XHPq5eix29OnDo2CPjOXXmAjdu3aZEsULUq/kOW3bGTnrP5J6ey1euWtbbuHU3NSqXpYifD8dOnknQvpYsVpjVf24i+F4M5y8GAlDq7SLM/P4XoqLMGIbBpcCgBLUn8ibTCJKIvFT5vXNz8PBxPujQFIg9nVYgnxebt+8lW9ZMAFQoU5x/t+2l1fufkje3Jzk9PR7bXv2a73Dy1DmaduxHJvf05MrhQejdsIfWK1PCn/k/rmD4p92fKd77p9W6tGlIyy6fUKFMcRrUfpdJMxby54ZtFPcvQMYMsaek0qdLg9kcTeP2fXFxdiJtmtT4+ealXfO6jP6sN2MmzeG3NX/j5ORIy0a1qFTubct2vPPkpGXjWnTuPZR0ad0IKFrwkfHcvB3Cl9/MIiT0LgD9urcFoESxQvzw0++06voJg/t2oUXDGkyZvZhFv6yiXMm3EjRfqGhhX1o1qU2P/qNwdHQkR7YsfNK7Iz07N+frKfNp3rk/Li7OBPj7WSbNi9gqU2RkhPH01UREZNW6TRw8coK+H7TBMAz2/3eMbv1GsuanqZY5UiLyZlCCJCKSQOcvBjJu8jyu3bhFtDmaZMmcadm4FuVKvmXt0ETkJVOCJCIiIhKPJmmLiIiIxKMESURERCQeJUgiIiIi8fwP7bjDADoXDiwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 583.3x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "A horizontal dendrogram of the panel's columns. One pair joins at the left edge with no visible branch length; the Treasury maturities and the trending level series form two further groups, and the VIX and initial claims stand apart until the last merge."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, ax = plt.subplots(figsize=style.FIGSIZE[\"single_tall\"])\n",
     "dendrogram(\n",
@@ -1576,10 +3521,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0f2a75b5",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 44,
+   "id": "717d46d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:43:05.965753Z",
+     "iopub.status.busy": "2026-09-08T23:43:05.965630Z",
+     "iopub.status.idle": "2026-09-08T23:43:05.977300Z",
+     "shell.execute_reply": "2026-09-08T23:43:05.977049Z"
+    },
+    "papermill": {
+     "duration": 0.04709,
+     "end_time": "2026-09-08T23:43:05.978014+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:05.930924+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The first merge the tree makes is `t10y2y` with `YIELD_CURVE_SLOPE`, at a distance of **4.0e-15**."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "first_merge_distance = float(column_linkage[0, 2])\n",
     "merged_first = [extended_df.columns[int(i)] for i in column_linkage[0, :2]]\n",
@@ -1593,8 +3565,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6b01376",
-   "metadata": {},
+   "id": "1a958c30",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014427,
+     "end_time": "2026-09-08T23:43:06.023150+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:06.008723+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "A merge at zero distance is two copies of one column, and the tree finds it before it\n",
     "considers anything else. Above that the panel resolves into groups a reader can name: the\n",
@@ -1612,8 +3592,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d051806",
-   "metadata": {},
+   "id": "313d1af6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024781,
+     "end_time": "2026-09-08T23:43:06.072688+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:43:06.047907+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key takeaways\n",
     "\n",
@@ -1662,6 +3650,39 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T23:43:26.930101+00:00",
+   "executor": "local-uv",
+   "library_digest": "25dd94a0db06c6b2d32b8530229346ee7688b6880ee16748d54e4d4ff6e8cce3",
+   "outputs_digest": "30d5dc703cfeabd70e826ad932d98ddc7b21e4604c4061ed07101f6c07300d1c",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "301944be49ad8d3a97fefe20a1b50dd8492061c4"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 48.377082,
+   "end_time": "2026-09-08T23:43:09.221741+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-teach-a/01_process_is_edge/.macro_regimes.build.2201572.ipynb",
+   "output_path": "~/ml4t/public-teach-a/01_process_is_edge/.macro_regimes.papermill.2201572.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T23:42:20.844659+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/01_process_is_edge/macro_regimes.ipynb
+++ b/01_process_is_edge/macro_regimes.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7f8fa95e",
+   "id": "92c8ab34",
    "metadata": {},
    "source": [
     "# Macro-based regime detection\n",
@@ -33,10 +33,12 @@
     "  than as a level, and recognise the failure that follows from ignoring it.\n",
     "- Attach economic names to unnamed clusters through a stated rule, and say what the rule\n",
     "  assumes.\n",
-    "- Check estimated regimes against realized equity volatility and drawdown, and read the\n",
-    "  result including the case where a regime holds too few months to support a claim.\n",
+    "- Check estimated regimes against realized equity volatility and drawdown - evidence the\n",
+    "  clustering never saw - and say which half of that check passed.\n",
     "- Judge a clustering by whether it recovers recurring conditions rather than by its\n",
     "  separation score, and show why the two can point in opposite directions.\n",
+    "- Measure how much of a partition is left after a different random start or a slightly\n",
+    "  shorter sample, and report that beside the result rather than instead of it.\n",
     "\n",
     "## Book reference\n",
     "\n",
@@ -63,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a027db60",
+   "id": "f46f3218",
    "metadata": {},
    "source": [
     "## Setup"
@@ -72,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd2060f8",
+   "id": "e91ee6b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +93,7 @@
     "from scipy.spatial.distance import pdist\n",
     "from sklearn.cluster import KMeans\n",
     "from sklearn.decomposition import PCA\n",
-    "from sklearn.metrics import silhouette_score\n",
+    "from sklearn.metrics import adjusted_rand_score, silhouette_score\n",
     "from sklearn.mixture import GaussianMixture\n",
     "from sklearn.preprocessing import StandardScaler, scale\n",
     "\n",
@@ -106,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5960642",
+   "id": "fa8a4ff3",
    "metadata": {
     "tags": [
      "parameters"
@@ -120,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4adc7ebb",
+   "id": "0fb3ff5a",
    "metadata": {},
    "source": [
     "### Settings, and what each one decides\n",
@@ -147,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9101e4f",
+   "id": "9088e8d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66b66308",
+   "id": "d6eccf8d",
    "metadata": {},
    "source": [
     "## The FRED panel\n",
@@ -181,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0110c71",
+   "id": "ae73e29b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8d2fd22",
+   "id": "16ef9589",
    "metadata": {},
    "source": [
     "### What the panel holds\n",
@@ -210,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22ccc1c8",
+   "id": "dfffee16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34160de8",
+   "id": "1d038ddc",
    "metadata": {},
    "source": [
     "## Four indicators that describe conditions\n",
@@ -253,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4eaa0f6a",
+   "id": "33676987",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,29 +264,51 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f61249c1",
-   "metadata": {},
+   "id": "bad35586",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "### From daily rows to a monthly panel\n",
     "\n",
     "`group_by_dynamic` cuts the daily frame into calendar months and `last()` takes the final\n",
     "observation inside each. Labelling each window by its right edge is what keeps the panel\n",
-    "honest: the window covering January is stamped 1 February, so the row carries only\n",
-    "observations from January and nothing dated later reaches it."
+    "honest: the window covering January is stamped 1 February, so the row can only contain\n",
+    "observations from January and nothing dated later reaches it.\n",
+    "\n",
+    "That stamp is then stepped back a day, onto the last day of the month the row actually\n",
+    "describes. Without it every date in the notebook is a month late - the row holding\n",
+    "April's unemployment rate reads as May - and a figure axis, a printed date and the arrays\n",
+    "handed to the book build would all inherit the error."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46c08577",
+   "id": "fcb8b5e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def to_monthly(frame: pl.DataFrame, columns: list[str]) -> pl.DataFrame:\n",
+    "    \"\"\"Last observation of each calendar month, stamped on the month it describes.\"\"\"\n",
+    "    return (\n",
+    "        frame.select([DATE_COL, *columns])\n",
+    "        .sort(DATE_COL)\n",
+    "        .group_by_dynamic(DATE_COL, every=\"1mo\", label=\"right\")\n",
+    "        .agg([pl.col(c).last() for c in columns])\n",
+    "        .with_columns(pl.col(DATE_COL).dt.offset_by(\"-1d\"))\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2654a6ba",
    "metadata": {},
    "outputs": [],
    "source": [
     "macro_monthly = (\n",
-    "    macro_raw.select([DATE_COL, *CORE_SERIES])\n",
-    "    .sort(DATE_COL)\n",
-    "    .group_by_dynamic(DATE_COL, every=\"1mo\", label=\"right\")\n",
-    "    .agg([pl.col(c).last() for c in CORE_SERIES])\n",
+    "    to_monthly(macro_raw, CORE_SERIES)\n",
     "    .drop_nulls(subset=CORE_SERIES)\n",
     "    .filter(pl.col(DATE_COL) >= PANEL_START)\n",
     ")\n",
@@ -295,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c2e9367",
+   "id": "de38ec00",
    "metadata": {},
    "source": [
     "### Why the price index enters as a rate, not a level\n",
@@ -309,15 +333,15 @@
     "panel, which is why the panel starts a year after `PANEL_START`.\n",
     "\n",
     "The other three series are already rates and need no such treatment. All four are then\n",
-    "standardized, so that unemployment measured in percentage points and the yield spread\n",
-    "measured in the same unit but with a quarter of the spread contribute comparably to the\n",
-    "distances the clustering works on."
+    "standardized. They share a unit - percentage points - but not a range: unemployment moves\n",
+    "over several points across a cycle while the yield spread moves over a fraction of one, so\n",
+    "without standardizing, the distances would be mostly unemployment."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b2020ff",
+   "id": "53297f80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,21 +359,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f37aa939",
+   "id": "a7631caa",
    "metadata": {},
    "source": [
     "### The four series before anything is fitted\n",
     "\n",
-    "The table reports each series in its own units over the clustering panel. Read the spread\n",
-    "between the quartiles against the range: the policy rate spans the whole distance from the\n",
-    "zero bound to above five percent, and the unemployment rate is tight around its median\n",
-    "with one extreme excursion. Those shapes are what the mixture is about to partition."
+    "The table reports each series in its own units over the clustering panel. Read each\n",
+    "quartile spread against its own minimum and maximum: the policy rate covers the whole\n",
+    "distance from the zero bound to the peak of a tightening cycle, while the unemployment\n",
+    "rate sits tight around its median and then makes one excursion far outside it. Those\n",
+    "shapes are what the mixture is about to partition, and the second one is why a cluster\n",
+    "ends up holding very few months."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa973adb",
+   "id": "d9498a2a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9852d97",
+   "id": "99ea5c23",
    "metadata": {},
    "source": [
     "## Fit the mixture\n",
@@ -376,7 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49e91e60",
+   "id": "176fc900",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c15c08d",
+   "id": "2a7b3ddb",
    "metadata": {},
    "source": [
     "### What the clusters contain\n",
@@ -409,7 +435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29fc54ee",
+   "id": "a053215e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,30 +446,34 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a9dbb7a",
+   "id": "01138576",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "source": [
     "### Naming the clusters\n",
     "\n",
-    "A cluster number is not a regime name, and the names have to come from somewhere the\n",
-    "model cannot supply. The rule below reads each cluster's average indicators and applies\n",
-    "the first description that fits, in a fixed order. Both the ordering and the thresholds\n",
-    "are judgements about the post-2002 US economy, chosen so that each name means what a\n",
-    "reader expects: high unemployment is a crisis whatever the rate environment; high\n",
-    "unemployment with the policy rate at the floor is the aftermath rather than the crisis\n",
-    "itself; a high policy rate with a flat curve is a tightening cycle.\n",
+    "A cluster number is not a regime name, and the names have to come from somewhere the model\n",
+    "cannot supply. The rule below reads each cluster's average indicators and applies the first\n",
+    "description that fits, in a fixed order. Both the ordering and the thresholds are\n",
+    "judgements about the post-2002 US economy, chosen so each name means what a reader expects:\n",
+    "unemployment above ten percent is a crisis whatever the rate environment; high unemployment\n",
+    "with the policy rate at the floor is the aftermath rather than the crisis itself; a high\n",
+    "policy rate with a flat curve is a tightening cycle.\n",
     "\n",
-    "The rule is stated in one place so that it can be argued with. A different reader would\n",
-    "set different thresholds and get different names over the same partition, and that is the\n",
-    "honest situation: the clustering is estimated, the naming is asserted."
+    "Not every branch has to fire. Which names come out depends on which clusters the mixture\n",
+    "found, and the table below is where to see what this fit produced rather than what the rule\n",
+    "can produce.\n",
+    "\n",
+    "The rule is written in one place so that it can be argued with. A different reader would set\n",
+    "different thresholds and get different names over the same partition, and that is the honest\n",
+    "situation: the clustering is estimated, the naming is asserted."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8000c98b",
+   "id": "1297c221",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "849ea344",
+   "id": "e10a4389",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +520,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a976628",
+   "id": "dcf6c6b7",
    "metadata": {},
    "source": [
     "## Do the regimes correspond to anything the market did?\n",
@@ -500,15 +530,15 @@
     "returns should behave differently inside them, and the difference should be in the\n",
     "direction economic reasoning predicts.\n",
     "\n",
-    "The S&P 500 daily series is resampled to month-end closes and aligned to the macro panel.\n",
-    "The macro rows are stamped at the right edge of the month they summarise, so the nearest\n",
-    "month-end close within five days is the close of the month whose data the row carries."
+    "The S&P 500 daily series is resampled to month-end closes and joined to the macro panel on\n",
+    "the date. Both are now stamped on the last day of the month they describe, so the join is\n",
+    "exact and each macro row meets the close of the month whose conditions it reports."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c01afc3",
+   "id": "dd8dbb22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,16 +549,16 @@
     "sp500_monthly = sp500[\"close\"].resample(\"ME\").last().to_frame()\n",
     "sp500_monthly[\"returns\"] = sp500_monthly[\"close\"].pct_change()\n",
     "\n",
-    "aligned = sp500_monthly.reindex(macro_df.index, method=\"nearest\", tolerance=pd.Timedelta(\"5D\"))\n",
+    "aligned = sp500_monthly.reindex(macro_df.index)\n",
     "if aligned[\"close\"].isna().any():\n",
-    "    raise ValueError(\"A macro month found no S&P 500 close within five days\")\n",
+    "    raise ValueError(\"A macro month found no S&P 500 close on the same month-end\")\n",
     "\n",
     "print(f\"Aligned {len(aligned)} months of S&P 500 closes to the macro panel\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2b726f8e",
+   "id": "39274e19",
    "metadata": {},
    "source": [
     "### Two statistics per regime, and what each one is\n",
@@ -541,14 +571,15 @@
     "computed over the whole index, in calendar order, and each month's decline from that peak\n",
     "is measured; the number reported for a regime is the deepest such decline observed in one\n",
     "of its months. It is therefore the worst point of the index reached while conditions were\n",
-    "in that regime, not the drawdown of a portfolio held only during it. A regime that occupies\n",
-    "few months can miss a trough that fell just outside it, and one does below."
+    "in that regime, not the drawdown of a portfolio held only during it. Where the deepest\n",
+    "reading lands is therefore a fact about which regime was in force when the index bottomed,\n",
+    "and that is the fact worth reading off the table."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcb56e43",
+   "id": "6253bf15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa0e88d5",
+   "id": "ea274e90",
    "metadata": {},
    "source": [
     "### The regime panel\n",
@@ -592,7 +623,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "888f994b",
+   "id": "e16a5c8f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -603,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7da5d43",
+   "id": "a551af7e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +648,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fa9df3b",
+   "id": "ee1c3bbf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10c95ef6",
+   "id": "af308aae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -652,7 +683,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c46564d4",
+   "id": "79e92c77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -677,7 +708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92694486",
+   "id": "77b431b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -703,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "531276cc",
+   "id": "34a2ea3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +771,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d374475",
+   "id": "7c568a52",
    "metadata": {},
    "source": [
     "### Reading the panel honestly\n",
@@ -753,7 +784,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0e684d5",
+   "id": "3cf17065",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -780,35 +811,148 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a33d50c8",
+   "id": "0d06f303",
    "metadata": {},
    "source": [
-    "The two lines above are the check earning its place, and both of them cut against the\n",
-    "regime story rather than for it.\n",
+    "The volatility ordering is economically legible: a tightening cycle is a calm market with an\n",
+    "expensive policy rate, and the two regimes with an unusual price level or an unusual\n",
+    "unemployment rate are the volatile ones. That is the check passing. Nothing about the\n",
+    "clustering forced it, because the clustering never saw a return.\n",
     "\n",
-    "The cluster the rule names Crisis is the handful of months in which unemployment averaged\n",
-    "above ten percent, and by the time unemployment reached that level the equity market had\n",
-    "already fallen and turned. The market's own worst point lands in a different cluster\n",
-    "entirely - one whose name, assigned from the policy rate and the unemployment rate, reads\n",
-    "as the aftermath. Neither name is a mistake in the rule; both are the same fact about the\n",
-    "data, which is that the labour market registers a shock the market has already priced.\n",
+    "The drawdown column is where the check bites. It does not follow the volatility order, and\n",
+    "the regime holding the deepest decline is the one the rule names for the aftermath of a\n",
+    "crisis - high unemployment with the policy rate on the floor. That combination is what a\n",
+    "central bank produces in response to a crash, so the label arrives with the crash rather\n",
+    "than before it. The regime a risk report would most want warning of is the one this model\n",
+    "can only confirm.\n",
     "\n",
-    "A statistic computed on four months is an anecdote whatever it says, and the volatility\n",
-    "spread across the four regimes is a few percentage points. Regimes estimated from\n",
-    "macroeconomic conditions do separate equity volatility, and they separate it weakly. A\n",
-    "reader should hold that conclusion at the strength these numbers support rather than at the\n",
-    "strength the idea invites, and the notebook has to report the small cell rather than\n",
-    "quietly drop it for being small.\n",
-    "\n",
-    "The lag is structural, not a property of this sample. Unemployment is measured over a month\n",
-    "and published in the next; prices move on expectations of the same conditions. Macro\n",
-    "regimes are therefore evidence about the environment a portfolio is already in, not a\n",
-    "signal about the one it is heading into, which is the use Section 1.4 argues for."
+    "That is the shape of what macro regimes are for, and it follows from what the inputs are.\n",
+    "Unemployment is measured over a month and published in the next; the policy rate moves in\n",
+    "response to conditions the market has already priced. A label built from them describes the\n",
+    "environment a portfolio is in. Section 1.4 argues for exactly that use - connecting an\n",
+    "identified environment to a predefined risk action - and against reading it as a forecast."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a073ace7",
+   "id": "ad8401ea",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "### How much of this partition would survive a small change?\n",
+    "\n",
+    "Everything above describes one fit. Before any of it is written down, it is worth asking how\n",
+    "much of it is a property of the data and how much is a property of this particular run.\n",
+    "\n",
+    "Two perturbations, neither of which changes what the data says. The first refits from a\n",
+    "different random start, which a mixture is entitled to answer differently because\n",
+    "expectation-maximization climbs to a local optimum. The second drops the first few months of\n",
+    "the panel, which is the kind of choice made once and never revisited - a start date is a\n",
+    "judgement about coverage, not a measurement.\n",
+    "\n",
+    "Agreement between two partitions is measured by the **adjusted Rand index**: the share of\n",
+    "month pairs that two partitions agree about - either together in both, or separated in both -\n",
+    "rescaled so that a random relabelling scores zero and an identical partition scores one. It\n",
+    "does not care how the clusters are numbered, which is what makes it usable here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bd6db08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def refit(data: np.ndarray, seed: int) -> np.ndarray:\n",
+    "    \"\"\"Fit the core mixture to *data* from one random start and return its labels.\"\"\"\n",
+    "    return (\n",
+    "        GaussianMixture(\n",
+    "            n_components=N_REGIMES,\n",
+    "            covariance_type=\"full\",\n",
+    "            random_state=seed,\n",
+    "            n_init=10,\n",
+    "            reg_covar=1e-6,\n",
+    "        )\n",
+    "        .fit(data)\n",
+    "        .predict(data)\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd92e691",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "perturbations = []\n",
+    "for seed in (0, 7, 123, 2024):\n",
+    "    labels = refit(macro_scaled, seed)\n",
+    "    perturbations.append(\n",
+    "        {\n",
+    "            \"Change\": f\"random start {seed}\",\n",
+    "            \"Agreement with the fit above\": adjusted_rand_score(core_labels, labels),\n",
+    "            \"Silhouette\": silhouette_score(macro_scaled, labels),\n",
+    "            \"Smallest cluster (months)\": int(np.bincount(labels).min()),\n",
+    "        }\n",
+    "    )\n",
+    "for dropped in (1, 3, 6, 12):\n",
+    "    labels = refit(macro_scaled[dropped:], SEED)\n",
+    "    perturbations.append(\n",
+    "        {\n",
+    "            \"Change\": f\"drop first {dropped} months\",\n",
+    "            \"Agreement with the fit above\": adjusted_rand_score(core_labels[dropped:], labels),\n",
+    "            \"Silhouette\": silhouette_score(macro_scaled[dropped:], labels),\n",
+    "            \"Smallest cluster (months)\": int(np.bincount(labels).min()),\n",
+    "        }\n",
+    "    )\n",
+    "stability = pd.DataFrame(perturbations).set_index(\"Change\")\n",
+    "stability.style.format({\"Agreement with the fit above\": \"{:.2f}\", \"Silhouette\": \"{:.3f}\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b844f84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "worst_agreement = float(stability[\"Agreement with the fit above\"].min())\n",
+    "smallest_ever = int(stability[\"Smallest cluster (months)\"].min())\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"The least agreement any perturbation reaches is **{worst_agreement:.2f}**, and the \"\n",
+    "        f\"smallest cluster any of them produces holds **{smallest_ever} months** against \"\n",
+    "        f\"**{int(np.bincount(core_labels).min())}** in the fit above.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d366c7c6",
+   "metadata": {},
+   "source": [
+    "None of these partitions is wrong. They are answers to the same question from starts the\n",
+    "data does not distinguish between, and they disagree about a meaningful share of the months.\n",
+    "Some of them split off a cluster small enough that the naming rule reaches a different\n",
+    "branch, so the same panel comes back with a different set of regime names.\n",
+    "\n",
+    "The response is not to pick the fit whose names read best. It is to say what was fitted, on\n",
+    "what window, from which start, and to publish the perturbation table beside the result, so\n",
+    "that a reader can see how much of the story is load-bearing. Anything downstream that would\n",
+    "break under an agreement of this size is not supported by this model, whatever the figure\n",
+    "looks like.\n",
+    "\n",
+    "This is the chapter's argument arriving in one table. The model is ordinary and takes four\n",
+    "lines to fit; what separates a usable result from an anecdote is the check that comes after\n",
+    "it, and the discipline to report the check when it is unflattering."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cabd39fa",
    "metadata": {},
    "source": [
     "### Figure 1.6 inputs\n",
@@ -822,7 +966,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7a71339",
+   "id": "477f32c3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,7 +992,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7497994d",
+   "id": "44a4bb26",
    "metadata": {},
    "source": [
     "## How the four indicators move together\n",
@@ -864,7 +1008,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8482664f",
+   "id": "960e1466",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -903,7 +1047,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a45f3607",
+   "id": "1dbdc3f7",
    "metadata": {},
    "source": [
     "Unemployment and the yield spread move together, and the fed funds rate moves against the\n",
@@ -921,7 +1065,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e051679b",
+   "id": "837ff507",
    "metadata": {},
    "source": [
     "## The counter-experiment: every series in the panel\n",
@@ -938,17 +1082,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca27ef09",
+   "id": "54561487",
    "metadata": {},
    "outputs": [],
    "source": [
     "value_columns = [c for c in macro_raw.columns if c != DATE_COL]\n",
-    "monthly_full = (\n",
-    "    macro_raw.sort(DATE_COL)\n",
-    "    .group_by_dynamic(DATE_COL, every=\"1mo\", label=\"right\")\n",
-    "    .agg([pl.col(c).last() for c in value_columns])\n",
-    "    .filter(pl.col(DATE_COL) >= PANEL_START)\n",
-    ")\n",
+    "monthly_full = to_monthly(macro_raw, value_columns).filter(pl.col(DATE_COL) >= PANEL_START)\n",
     "\n",
     "missing_share = {\n",
     "    column: monthly_full.select(pl.col(column).is_null().sum()).item() / monthly_full.height\n",
@@ -959,20 +1098,26 @@
     "extended_pl = monthly_full.select([DATE_COL, *kept_columns]).drop_nulls()\n",
     "extended_df = extended_pl.select(kept_columns).to_pandas()\n",
     "extended_df.index = pd.DatetimeIndex(extended_pl[DATE_COL].to_pandas())\n",
-    "extended_df = extended_df.apply(scale)\n",
+    "\n",
+    "# Hold both models to the same months. Left alone the two panels start a month apart - the\n",
+    "# core one waits twelve months for the year-over-year change, this one waits for the Fed\n",
+    "# balance sheet to begin - and every comparison below would then be partly about the window.\n",
+    "extended_df = extended_df.loc[extended_df.index.intersection(macro_df.index)].apply(scale)\n",
+    "if not extended_df.index.equals(macro_df.index):\n",
+    "    raise ValueError(\"The extended panel does not cover the same months as the core panel\")\n",
     "\n",
     "display(\n",
     "    Markdown(\n",
     "        f\"The coverage filter keeps **{len(kept_columns)} of {len(value_columns)}** series, \"\n",
-    "        f\"and dropping the months in which any of them is unquoted leaves \"\n",
-    "        f\"**{len(extended_df)} months**, the same window as the core panel.\"\n",
+    "        f\"and holding them to the core panel's months leaves **{len(extended_df)} months** \"\n",
+    "        \"across both models.\"\n",
     "    )\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "697d2090",
+   "id": "73b88908",
    "metadata": {},
    "source": [
     "### What the filter let through\n",
@@ -990,7 +1135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2604831",
+   "id": "2e7d9a05",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1007,7 +1152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92937c2d",
+   "id": "8551ed93",
    "metadata": {},
    "source": [
     "### The series, drawn\n",
@@ -1019,7 +1164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "313d67dc",
+   "id": "fae15c7f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f57440ed",
+   "id": "53e51bdb",
    "metadata": {},
    "source": [
     "### How much independent variation is left\n",
@@ -1069,7 +1214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "077b8240",
+   "id": "56e7ad49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1089,7 +1234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a87796e",
+   "id": "1a203356",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1104,7 +1249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10e1105a",
+   "id": "ed685852",
    "metadata": {},
    "source": [
     "### Which columns each direction is made of\n",
@@ -1117,7 +1262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "744d93d5",
+   "id": "f632b125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1133,7 +1278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f8dc16c",
+   "id": "9c8b81ec",
    "metadata": {},
    "source": [
     "The leading direction is the trend the small multiples showed, and the second is the level\n",
@@ -1146,7 +1291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91d7dbe1",
+   "id": "26792cdb",
    "metadata": {},
    "source": [
     "## Fit the same models to the extended panel\n",
@@ -1159,7 +1304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69ab3048",
+   "id": "490ead49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1197,7 +1342,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbaa3177",
+   "id": "45e7318d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1214,13 +1359,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b79cd2db",
+   "id": "e9774bb6",
    "metadata": {},
    "outputs": [],
    "source": [
     "def episode_count(labels: np.ndarray) -> int:\n",
     "    \"\"\"Number of maximal runs of consecutive months sharing a label.\"\"\"\n",
     "    return int(np.sum(np.diff(labels) != 0)) + 1\n",
+    "\n",
+    "\n",
+    "def revisited_clusters(labels: np.ndarray) -> int:\n",
+    "    \"\"\"How many clusters the model returns to after having left them.\"\"\"\n",
+    "    starts = [labels[0], *labels[1:][np.diff(labels) != 0]]\n",
+    "    return sum(1 for cluster in set(starts) if starts.count(cluster) > 1)\n",
     "\n",
     "\n",
     "episodes = pd.DataFrame(\n",
@@ -1231,6 +1382,10 @@
     "        ],\n",
     "        \"Clusters\": [N_REGIMES, N_REGIMES],\n",
     "        \"Episodes\": [episode_count(core_labels), episode_count(extended_labels)],\n",
+    "        \"Clusters revisited\": [\n",
+    "            revisited_clusters(core_labels),\n",
+    "            revisited_clusters(extended_labels),\n",
+    "        ],\n",
     "    }\n",
     ").set_index(\"Model\")\n",
     "episodes"
@@ -1239,7 +1394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd700d49",
+   "id": "ea5c0afe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1248,20 +1403,23 @@
     "display(\n",
     "    Markdown(\n",
     "        f\"The extended model splits {len(extended_df)} months into **{extended_episodes} \"\n",
-    "        f\"episodes** from **{N_REGIMES} clusters**, against **{core_episodes}** for the core \"\n",
-    "        \"model.\"\n",
+    "        f\"episodes** from **{N_REGIMES} clusters**, returning to \"\n",
+    "        f\"**{revisited_clusters(extended_labels)}** of them, against \"\n",
+    "        f\"**{core_episodes} episodes** and \"\n",
+    "        f\"**{revisited_clusters(core_labels)}** revisited for the core model.\"\n",
     "    )\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "19db7899",
+   "id": "7df10c33",
    "metadata": {},
    "source": [
-    "An extended model with as many episodes as clusters has assigned every month to the\n",
-    "cluster of its neighbours and never revisited an earlier one. It has partitioned the\n",
-    "calendar into consecutive eras. That is what the trending levels put into the panel - three\n",
+    "A model with as many episodes as clusters and none of them revisited has assigned every\n",
+    "month to the cluster of its neighbours and never returned to a condition it had left. It has\n",
+    "partitioned the calendar into consecutive eras. The core model does return, which is what\n",
+    "lets it call the 2008 aftermath and the 2020 aftermath the same thing. That is what the trending levels put into the panel - three\n",
     "price indices, two GDP series, money stock, payrolls - and it is precisely the failure the\n",
     "core panel avoided by taking a rate of change instead of a level. The silhouette score\n",
     "rewards it, because consecutive eras of a trending panel are far apart in the space the\n",
@@ -1275,7 +1433,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48057bfe",
+   "id": "5327d27c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1289,7 +1447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c006ac35",
+   "id": "46a4985c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1315,7 +1473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b1a379b",
+   "id": "f1d6c81f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1327,7 +1485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79ff9cc0",
+   "id": "87ba6e34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1338,7 +1496,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8b54b93",
+   "id": "6e536c23",
    "metadata": {},
    "source": [
     "## Clustering the indicators rather than the months\n",
@@ -1362,7 +1520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25199729",
+   "id": "2c8df6d3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1386,7 +1544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c08c231",
+   "id": "b166ccfd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1417,7 +1575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e681b66",
+   "id": "c27f87a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1433,7 +1591,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5e067c0",
+   "id": "d6b417eb",
    "metadata": {},
    "source": [
     "A merge at zero distance is two copies of one column, and the tree finds it before it\n",
@@ -1452,7 +1610,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a0e0a5e",
+   "id": "934655d3",
    "metadata": {},
    "source": [
     "## Key takeaways\n",
@@ -1468,19 +1626,25 @@
     "  and two GDP measures are one panel with a few directions in it, which principal components\n",
     "  and the linkage tree both report directly.\n",
     "- **Attaching names to clusters is an assertion.** The mixture supplies a partition; every\n",
-    "  economic name in this notebook comes from a threshold rule written by hand, and a\n",
-    "  different rule would rename the same partition.\n",
+    "  economic name here comes from a threshold rule written by hand, and a different rule would\n",
+    "  rename the same partition.\n",
     "- **Validate a regime model against something it never saw.** These regimes were fitted\n",
-    "  without any market data, so equity volatility and drawdown are an independent check, and\n",
-    "  the check is what surfaced a cluster too small to support the name it was given.\n",
+    "  without any market data, so equity volatility and drawdown are an independent check. Half\n",
+    "  of it passed - the volatility ordering is economically legible - and half of it did not:\n",
+    "  the deepest drawdown sits in the regime named for a crisis already under way.\n",
+    "- **Perturb the fit before you write about it.** A different random start, or a sample three\n",
+    "  months shorter, moves this partition enough to change which names the rule assigns. Report\n",
+    "  that alongside the result; a story the perturbation table takes apart was never supported\n",
+    "  by the data.\n",
     "\n",
     "**Known limitations.** FRED serves revised values, so no number here was available on the\n",
-    "date it is attached to; the mixture has no transition structure and no notion of time, so\n",
-    "nothing prefers a month to keep its neighbour's label; the panel starts in 2002 and holds\n",
-    "one severe recession, one pandemic and one inflation episode, which is not enough\n",
-    "repetitions of any condition to estimate how often it recurs; and the naming rule's\n",
-    "thresholds were set for the post-2002 US economy and would not transfer to another country\n",
-    "or another era.\n",
+    "date it is attached to. The mixture has no transition structure and no notion of time, so\n",
+    "nothing prefers a month to keep its neighbour's label; the long episodes here come from the\n",
+    "indicators moving slowly, not from the model. The panel starts in 2002 and holds one severe\n",
+    "recession, one pandemic and one inflation episode, which is too few repetitions of any\n",
+    "condition to say how often it recurs - and it is the direct cause of the instability the\n",
+    "perturbation table reports. The naming rule's thresholds were set for the post-2002 US\n",
+    "economy and would not transfer to another country or another era.\n",
     "\n",
     "**Next**: Chapter 1 closes on what a research process needs to survive changes like these.\n",
     "Walk-forward estimation, which is what turns a descriptive regime label into one a strategy\n",

--- a/01_process_is_edge/macro_regimes.ipynb
+++ b/01_process_is_edge/macro_regimes.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "# Macro-based regime detection\n",
     "\n",
-    "**Chapter 1 · §1.4 Market Regimes: Change Is the Constant**\n",
+    "**Chapter 1 · §1.4 Keeping up with changing market regimes**\n",
     "\n",
     "**Docker image**: `ml4t`\n",
     "\n",
@@ -50,7 +50,7 @@
     "\n",
     "## Book reference\n",
     "\n",
-    "Chapter 1, Section 1.4, \"Market Regimes: Change Is the Constant\". Figure 1.6 in the\n",
+    "Chapter 1, Section 1.4, \"Keeping up with changing market regimes\". Figure 1.6 in the\n",
     "chapter is the regime-and-volatility panel drawn below.\n",
     "\n",
     "## Prerequisites\n",
@@ -3670,7 +3670,8 @@
    "outputs_digest": "30d5dc703cfeabd70e826ad932d98ddc7b21e4604c4061ed07101f6c07300d1c",
    "parameters": {},
    "production": true,
-   "source_py_blob": "301944be49ad8d3a97fefe20a1b50dd8492061c4"
+   "source_py_blob": "57a0071248e7c059bce93a53fbe19b4e935a49fd",
+   "notes": "prose synced from the .py at 2026-09-08T23:49:18.246948+00:00 without re-executing; every code cell is identical to blob 301944be49ad"
   },
   "papermill": {
    "default_parameters": {},

--- a/01_process_is_edge/macro_regimes.py
+++ b/01_process_is_edge/macro_regimes.py
@@ -558,23 +558,29 @@ style.show_with_alt(
 # because nothing forced it to agree, and it does not.
 
 # %%
-smallest_regime = str(regime_stats["months"].idxmin())
-smallest_span = regime_name[regime_name == smallest_regime].index
+ORDINALS = ["first", "second", "third", "fourth", "fifth", "sixth"]
+
+
+def rank_by_volatility(regime: str) -> str:
+    """Where a regime sits in the volatility ordering the panel is drawn in."""
+    return ORDINALS[regime_order.index(regime)]
+
+
+calmest_regime = str(regime_stats["annual_vol"].idxmin())
+loudest_regime = str(regime_stats["annual_vol"].idxmax())
+vol_spread = float(regime_stats["annual_vol"].max() - regime_stats["annual_vol"].min())
 deepest_month = aligned["drawdown"].idxmin()
 deepest_regime = str(aligned.loc[deepest_month, "regime"])
-vol_spread = float(regime_stats["annual_vol"].max() - regime_stats["annual_vol"].min())
+shallowest_regime = str(regime_stats["max_dd_pct"].idxmin())
 display(
     Markdown(
-        f"The smallest regime, **{smallest_regime}**, holds "
-        f"**{len(smallest_span)} months**, running from "
-        f"**{smallest_span.min():%B %Y}** to **{smallest_span.max():%B %Y}**, and the index "
-        f"was never more than "
-        f"**{regime_stats.loc[smallest_regime, 'max_dd_pct']:.0f}%** below its peak in any "
-        f"of them. The deepest reading of the whole panel, "
-        f"**{regime_stats['max_dd_pct'].max():.0f}%**, falls in "
-        f"**{deepest_month:%B %Y}**, which the naming rule calls **{deepest_regime}**. "
-        f"Across the four regimes the annualized volatility spans "
-        f"**{vol_spread:.0f} percentage points**."
+        f"Annualized volatility runs from **{calmest_regime}** to **{loudest_regime}**, a "
+        f"span of **{vol_spread:.0f} percentage points**. The deepest decline of the whole "
+        f"panel, **{regime_stats['max_dd_pct'].max():.0f}%**, falls in "
+        f"**{deepest_month:%B %Y}**, which the naming rule calls **{deepest_regime}** - the "
+        f"**{rank_by_volatility(deepest_regime)}** of the four by volatility. The shallowest "
+        f"decline belongs to **{shallowest_regime}**, the "
+        f"**{rank_by_volatility(shallowest_regime)}**."
     )
 )
 

--- a/01_process_is_edge/macro_regimes.py
+++ b/01_process_is_edge/macro_regimes.py
@@ -14,66 +14,75 @@
 # ---
 
 # %% [markdown]
-# # Macro-Based Regime Detection
+# # Macro-based regime detection
 #
 # **Chapter 1 · §1.4 Market Regimes: Change Is the Constant**
 #
 # **Docker image**: `ml4t`
 #
-# ## Purpose
+# `factor_regimes` estimated regimes from what the factors themselves earned. This notebook
+# asks whether the same partition can be recovered from outside the market, using
+# macroeconomic series published by the Federal Reserve Bank of St. Louis through its FRED
+# database: unemployment, the policy rate, the shape of the yield curve and inflation.
 #
-# Demonstrates unsupervised learning for market regime detection using macroeconomic
-# indicators from FRED, paired with S&P 500 volatility and drawdown for validation.
+# The appeal of macro inputs is that they are not returns. A regime estimated from returns
+# is at risk of restating the volatility it was fitted on; one estimated from the labour
+# market and the rate environment is a statement about conditions, which can then be
+# checked against what the equity market did. That check is the second half of this
+# notebook, and it is what separates a regime model that has found something from one that
+# has partitioned the calendar.
 #
-# ## Learning Objectives
+# ## Learning objectives
 #
-# - Cluster monthly macro indicators with GMM, K-Means, and hierarchical methods.
-# - Validate macro clusters against realized equity volatility and drawdown.
-# - Compare a four-indicator core view to an extended FRED panel.
-# - Use PCA preprocessing to filter noise before clustering.
+# By the end of this notebook you will be able to:
 #
-# ## Book Reference
+# - Turn irregularly published economic series into an aligned monthly panel without
+#   letting a later release inform an earlier month.
+# - Explain why a series that trends has to enter a clustering as a rate of change rather
+#   than as a level, and recognise the failure that follows from ignoring it.
+# - Attach economic names to unnamed clusters through a stated rule, and say what the rule
+#   assumes.
+# - Check estimated regimes against realized equity volatility and drawdown, and read the
+#   result including the case where a regime holds too few months to support a claim.
+# - Judge a clustering by whether it recovers recurring conditions rather than by its
+#   separation score, and show why the two can point in opposite directions.
 #
-# Section 1.4 of Chapter 1, "Market Regimes: Change Is the Constant" — macro-regime
-# follow-up to `factor_regimes.py`. Figure 1.6 in the chapter is generated here.
+# ## Book reference
+#
+# Chapter 1, Section 1.4, "Market Regimes: Change Is the Constant". Figure 1.6 in the
+# chapter is the regime-and-volatility panel drawn below.
 #
 # ## Prerequisites
 #
-# - Familiarity with monthly time-series resampling and standardization.
-# - Conceptual exposure to mixture models, K-Means, and dendrograms.
-# - FRED panel and S&P 500 daily series materialized via `data/macro/` and
-#   `data/equities/sp500/` loaders.
+# - `factor_regimes`, which introduces Gaussian mixture models, the silhouette score, and
+#   why a model fitted on the whole sample describes rather than predicts.
+# - The FRED panel under `data/macro/` and the S&P 500 daily series under
+#   `data/equities/sp500/`.
 #
-# ## Structure
+# ## A caveat that applies to every number below
 #
-# 1. **Core Analysis (4 indicators)** — UNRATE, DFF, T10Y2Y, CPIAUCSL → CPI YoY.
-# 2. **Extended Analysis** — full FRED panel (after coverage filtering) for a richer
-#    but noisier view of economic conditions.
-# 3. **Comparison** — silhouette scores across core, extended, and PCA-reduced models.
-#
-# ## Key Insight
-#
-# Macro regimes line up with distinct *volatility* environments more cleanly than they
-# line up with average returns. This makes macro indicators useful for risk management
-# (anticipating volatility shifts) rather than return prediction.
+# FRED serves the latest revision of each series. Unemployment, industrial production and
+# the price indices are all restated after their first publication, sometimes substantially,
+# so the value this notebook reads for a month in 2008 is not the value anyone could see in
+# 2008. That is acceptable here because the labels are descriptive and nothing acts on them.
+# A strategy would have to read `load_macro_initial_release`, which serves the value as it
+# stood at each date, and would also have to wait out the publication lag - the
+# unemployment rate for a month is released in the first days of the next one.
 
 # %% [markdown]
-# ## Imports
+# ## Setup
 
 # %%
-"""Macro-Based Regime Detection — unsupervised regime detection using FRED macro indicators."""
+"""Macro-based regime detection - clustering FRED indicators and validating against the S&P 500."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.filterwarnings("ignore")
-
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import polars as pl
 import seaborn as sns
+from IPython.display import Markdown, display
+from matplotlib import pyplot as plt
 from matplotlib.gridspec import GridSpec
 from scipy.cluster.hierarchy import cophenet, dendrogram, linkage
 from scipy.spatial.distance import pdist
@@ -83,930 +92,966 @@ from sklearn.metrics import silhouette_score
 from sklearn.mixture import GaussianMixture
 from sklearn.preprocessing import StandardScaler, scale
 
-from data import load_macro, load_sp500_index
+import utils.style as style
+from data import load_macro, load_macro_metadata, load_sp500_index
 from utils.paths import get_output_dir
 from utils.reproducibility import set_global_seeds
 
+COLORS = style.COLORS
+
 # %% tags=["parameters"]
-# Production defaults (Papermill overrides for testing)
+# Production defaults (Papermill overrides these when the test suite runs the notebook)
 SEED = 42
 
 # %% [markdown]
-# ## Configuration
+# ### Settings, and what each one decides
+#
+# `SEED` fixes every estimator's random start, which is what makes the cluster numbering
+# and the figures reproduce.
+#
+# `N_REGIMES` is the number of clusters fitted throughout. Four is taken from the Two Sigma
+# study this notebook follows, which reports four regimes over an eighteen-factor panel. It
+# is a choice, not a result: `factor_regimes` shows how the model-selection criteria are
+# compared when the count is being decided rather than inherited.
+#
+# `PANEL_START` is the first month the panel is allowed to contain. The FRED file begins in
+# 2000, and the series used here are all quoted from that point, so the bound is set two
+# years later for the same reason a rolling statistic drops its warm-up: the year-over-year
+# inflation rate needs twelve prior months before it exists.
+#
+# `MAX_MISSING_SHARE` is how much of a series may be unquoted before it is dropped from the
+# extended panel. `MIN_COPHENETIC` is the level above which a dendrogram is usually taken to
+# summarise its distance matrix faithfully; it is a convention, quoted here so the number
+# the notebook computes has something to be read against.
 
 # %%
+N_REGIMES = 4
+PANEL_START = pl.datetime(2002, 1, 1)
+MAX_MISSING_SHARE = 0.5
+MIN_COPHENETIC = 0.7
+MONTHS_PER_YEAR = 12
+ROLLING_VOL_MONTHS = 12
+DATE_COL = "timestamp"
+
 OUTPUT_DIR = get_output_dir(1, "macro_regimes")
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 set_global_seeds(SEED)
 
-DATE_COL = "timestamp"
-
 # %% [markdown]
-# ## Helper Function
+# ## The FRED panel
 #
-# Reusable function for regime visualization. Both GMM and K-Means results
-# use the same heatmap format for easy comparison.
-
-
-# %%
-def plot_regime_heatmap(
-    assignments: np.ndarray,
-    dates: pd.DatetimeIndex,
-    title: str,
-    n_regimes: int = 4,
-    is_probability: bool = True,
-    figsize: tuple = (14, 4),
-) -> None:
-    """
-    Plot regime assignments as a heatmap.
-
-    Parameters
-    ----------
-    assignments : np.ndarray
-        Either probability matrix (n_samples, n_regimes) for GMM
-        or hard labels (n_samples,) for K-Means
-    dates : pd.DatetimeIndex
-        Dates corresponding to each sample
-    title : str
-        Plot title
-    n_regimes : int
-        Number of regimes
-    is_probability : bool
-        True if assignments are probabilities, False for hard labels
-    figsize : tuple
-        Figure size
-    """
-    fig, ax = plt.subplots(figsize=figsize, layout="tight")
-
-    # Convert hard labels to one-hot if needed
-    if not is_probability:
-        one_hot = np.zeros((len(assignments), n_regimes))
-        one_hot[np.arange(len(assignments)), assignments] = 1
-        data = one_hot
-    else:
-        data = assignments
-
-    im = ax.imshow(data.T, aspect="auto", cmap="Blues", vmin=0, vmax=1)
-
-    # X-axis: years
-    years = [pd.Timestamp(ts).year for ts in dates]
-    year_ticks = [j for j, y in enumerate(years) if j == 0 or years[j - 1] != y]
-    year_labels = [str(years[j]) for j in year_ticks]
-    ax.set_xticks(year_ticks[::2])
-    ax.set_xticklabels(year_labels[::2], fontsize=9)
-
-    # Y-axis: regimes
-    ax.set_yticks(range(n_regimes))
-    ax.set_yticklabels([f"Regime {i + 1}" for i in range(n_regimes)])
-    ax.set_ylabel("Regime")
-    ax.set_xlabel("Year")
-    ax.set_title(title, fontsize=12)
-
-    cbar = plt.colorbar(im, ax=ax, shrink=0.8)
-    cbar.set_label("Probability" if is_probability else "Assignment")
-    plt.show()
-
-
-# %% [markdown]
-# ---
-#
-# # Load FRED Macro Data
-#
-# We load all available FRED macro indicators once, then select subsets for analysis.
-# The dataset includes ~17 series after filtering for data quality.
-
-# %% [markdown]
-# ## Load Full Dataset
+# The loader returns one wide frame with a daily date index and one column per series.
+# Series that are not published daily carry their most recent value forward, so the file has
+# no gaps to interpolate and the frequency a series was actually observed at has to be read
+# from its metadata rather than from the column.
 
 # %%
 macro_raw = load_macro()
+if macro_raw[DATE_COL].dtype == pl.Date:
+    macro_raw = macro_raw.with_columns(pl.col(DATE_COL).cast(pl.Datetime))
 
-# group_by_dynamic requires Datetime, not Date
-if macro_raw["timestamp"].dtype == pl.Date:
-    macro_raw = macro_raw.with_columns(pl.col("timestamp").cast(pl.Datetime))
-
-print(f"Loaded FRED macro data: {macro_raw.shape}")
-print(f"Date range: {macro_raw['timestamp'].min()} to {macro_raw['timestamp'].max()}")
-print(f"Available series: {[c for c in macro_raw.columns if c != 'timestamp']}")
+print(f"FRED panel: {macro_raw.height} rows, {macro_raw.width - 1} series")
+print(f"Covering {macro_raw[DATE_COL].min():%Y-%m-%d} to {macro_raw[DATE_COL].max():%Y-%m-%d}")
 
 # %% [markdown]
-# ## Available Indicators
+# ### What the panel holds
 #
-# | Category | Series | Description |
-# |----------|--------|-------------|
-# | **Labor** | UNRATE | Unemployment rate (%) |
-# | **Interest Rates** | DFF | Federal Funds effective rate (%) |
-# | | T10Y2Y | 10Y-2Y Treasury spread (yield curve) |
-# | | T10YIE | 10Y breakeven inflation |
-# | **Prices** | CPIAUCSL | Consumer Price Index |
-# | | CPILFESL | Core CPI (ex food & energy) |
-# | **Volatility** | VIXCLS | VIX volatility index |
-# | **Credit** | BAMLHE00EHYIEY | High yield spread |
-# | **Housing** | CSUSHPISA | Case-Shiller home price index |
-# | **Money** | M2SL | M2 money supply |
-#
-# For the **Core Analysis**, we use only 4 fundamental macro indicators.
-
-# %% [markdown]
-# ---
-#
-# # Core Analysis: 4 Macro Indicators
-#
-# We use four indicators that reflect real economic conditions:
-#
-# - **UNRATE**: Unemployment rate - labor market health
-# - **DFF**: Federal Funds rate - monetary policy stance
-# - **T10Y2Y**: Yield curve slope - recession signal
-# - **CPIAUCSL → cpi_yoy**: CPI year-over-year inflation rate (not the level, which trends upward)
-
-# %% [markdown]
-# ## Select Core Indicators
+# The metadata companion says what each column is, how often the source publishes it, and
+# whether it is an observed series or one this repository derives from others. Both facts
+# matter downstream: a quarterly series entering a monthly clustering repeats each value
+# three times, and a derived column can duplicate a series that is already in the panel
+# under its own name.
 
 # %%
-# Core 4 indicators (case-insensitive matching)
-CORE_INDICATORS = ["unrate", "dff", "t10y2y", "cpiaucsl"]
-
-macro_columns = macro_raw.columns
-core_cols = []
-col_name_map = {}
-
-for indicator in CORE_INDICATORS:
-    for col in macro_columns:
-        if col.lower() == indicator:
-            core_cols.append(col)
-            col_name_map[col] = indicator
-            break
-
-print(f"Core indicators selected: {len(core_cols)}/{len(CORE_INDICATORS)}")
-for col in core_cols:
-    print(f"  {col} -> {col_name_map[col]}")
+metadata = load_macro_metadata().to_pandas().set_index("series")
+inventory = metadata.loc[
+    [c for c in macro_raw.columns if c != DATE_COL], ["description", "native_frequency", "formula"]
+].rename(
+    columns={
+        "description": "Series",
+        "native_frequency": "Published",
+        "formula": "Derived as",
+    }
+)
+inventory["Derived as"] = inventory["Derived as"].fillna("-")
+inventory.index.name = "Column"
+inventory
 
 # %% [markdown]
-# ## Resample to Monthly
+# ## Four indicators that describe conditions
+#
+# The core model uses four series, each standing for one thing a reader can name:
+#
+# - **UNRATE**, the unemployment rate, for the state of the labour market.
+# - **DFF**, the effective federal funds rate, for the stance of monetary policy.
+# - **T10Y2Y**, the ten-year Treasury yield minus the two-year, for the shape of the yield
+#   curve. A negative value means short-dated debt yields more than long-dated debt, an
+#   inversion that has preceded most post-war US recessions.
+# - **CPIAUCSL**, the consumer price index, for inflation - entered as a rate of change,
+#   for the reason given below.
+#
+# Four is few enough that every cluster can be described in a sentence, which is the point
+# of a regime label. The extended panel later in the notebook is the counter-experiment.
+
+# %%
+CORE_SERIES = ["unrate", "dff", "t10y2y", "cpiaucsl"]
+
+# %% [markdown]
+# ### From daily rows to a monthly panel
+#
+# `group_by_dynamic` cuts the daily frame into calendar months and `last()` takes the final
+# observation inside each. Labelling each window by its right edge is what keeps the panel
+# honest: the window covering January is stamped 1 February, so the row carries only
+# observations from January and nothing dated later reaches it.
 
 # %%
 macro_monthly = (
-    macro_raw.select([DATE_COL] + core_cols)
+    macro_raw.select([DATE_COL, *CORE_SERIES])
     .sort(DATE_COL)
     .group_by_dynamic(DATE_COL, every="1mo", label="right")
-    .agg([pl.col(c).last() for c in core_cols])
-    # Forward-fill carries last observation through release lags; the small
-    # backward-fill catches any leading nulls in early months. The latter
-    # introduces a one-period look-ahead at the panel boundary — acceptable
-    # for a regime-detection demo, not for a backtested strategy.
-    .fill_null(strategy="forward")
-    .fill_null(strategy="backward")
-    .drop_nulls(subset=core_cols)
+    .agg([pl.col(c).last() for c in CORE_SERIES])
+    .drop_nulls(subset=CORE_SERIES)
+    .filter(pl.col(DATE_COL) >= PANEL_START)
 )
 
-# Filter to 2002+ where most FRED series have good coverage
-if macro_monthly.height > 0:
-    min_date = macro_monthly[DATE_COL].min()
-    if min_date is not None and str(min_date) < "2002-01-01":
-        macro_monthly = macro_monthly.filter(pl.col(DATE_COL) >= pl.datetime(2002, 1, 1))
-
-print(f"Monthly data: {macro_monthly.height} months")
-if macro_monthly.height > 0:
-    print(f"Date range: {macro_monthly[DATE_COL].min()} to {macro_monthly[DATE_COL].max()}")
+print(f"Monthly rows: {macro_monthly.height}")
+print(f"Covering {macro_monthly[DATE_COL].min():%Y-%m} to {macro_monthly[DATE_COL].max():%Y-%m}")
 
 # %% [markdown]
-# ## Standardize for Clustering
+# ### Why the price index enters as a rate, not a level
+#
+# The consumer price index rises almost every month of the sample. Clustering on the level
+# would put every early month in one cluster and every late month in another, because that
+# is the largest source of variance in the column, and the resulting partition would be a
+# statement about the calendar rather than about inflation. The year-over-year percentage
+# change removes the trend and leaves the quantity a reader means by inflation: how much
+# prices rose over the past twelve months. Taking it costs the first twelve months of the
+# panel, which is why the panel starts a year after `PANEL_START`.
+#
+# The other three series are already rates and need no such treatment. All four are then
+# standardized, so that unemployment measured in percentage points and the yield spread
+# measured in the same unit but with a quarter of the spread contribute comparably to the
+# distances the clustering works on.
 
 # %%
-if macro_monthly.height > 0:
-    macro_df = macro_monthly.select(core_cols).to_pandas()
-    macro_df.columns = [col_name_map.get(c, c) for c in macro_df.columns]
-    macro_df.index = macro_monthly[DATE_COL].to_pandas()
+macro_df = macro_monthly.select(CORE_SERIES).to_pandas()
+macro_df.index = pd.DatetimeIndex(macro_monthly[DATE_COL].to_pandas())
+macro_df["cpi_yoy"] = macro_df["cpiaucsl"].pct_change(MONTHS_PER_YEAR) * 100
+macro_df = macro_df.drop(columns=["cpiaucsl"]).dropna()
 
-    # Convert CPI level to YoY percentage change — the level is non-stationary
-    # and would make the clustering capture "early vs recent" rather than
-    # "inflationary vs non-inflationary"
-    macro_df["cpi_yoy"] = macro_df["cpiaucsl"].pct_change(12) * 100
-    macro_df = macro_df.drop(columns=["cpiaucsl"]).dropna()
+macro_scaled = StandardScaler().fit_transform(macro_df)
 
-    macro_scaled = StandardScaler().fit_transform(macro_df)
-
-    print("Core Indicator Statistics (raw):")
-    print(macro_df.describe().round(2))
-else:
-    macro_df = pd.DataFrame()
-    macro_scaled = np.array([])
+PANEL_FIRST_YEAR = macro_df.index.min().year
+PANEL_LAST_YEAR = macro_df.index.max().year
+print(f"Clustering panel: {len(macro_df)} months, {PANEL_FIRST_YEAR} to {PANEL_LAST_YEAR}")
 
 # %% [markdown]
-# ## Fit GMM with 4 Regimes
+# ### The four series before anything is fitted
+#
+# The table reports each series in its own units over the clustering panel. Read the spread
+# between the quartiles against the range: the policy rate spans the whole distance from the
+# zero bound to above five percent, and the unemployment rate is tight around its median
+# with one extreme excursion. Those shapes are what the mixture is about to partition.
 
 # %%
-if len(macro_df) > 0:
-    n_macro_regimes = 4
-    gmm_macro = GaussianMixture(
-        n_components=n_macro_regimes,
-        covariance_type="full",
-        random_state=SEED,
-        n_init=10,
-        reg_covar=1e-6,
-    )
-    gmm_macro.fit(macro_scaled)
-    macro_labels = gmm_macro.predict(macro_scaled)
-    macro_probs = gmm_macro.predict_proba(macro_scaled)
-
-    macro_silhouette = silhouette_score(macro_scaled, macro_labels)
-    print(f"Macro regime silhouette score (n={n_macro_regimes}): {macro_silhouette:.3f}")
-else:
-    macro_labels = np.array([])
-    macro_probs = np.array([])
+UNITS = {
+    "unrate": "Unemployment rate (%)",
+    "dff": "Fed funds rate (%)",
+    "t10y2y": "10Y minus 2Y Treasury (percentage points)",
+    "cpi_yoy": "CPI, change over 12 months (%)",
+}
+macro_df.rename(columns=UNITS).describe().T.style.format("{:.2f}")
 
 # %% [markdown]
-# We use 4 regimes to match the Two Sigma approach. The silhouette score measures
-# cluster separation — higher is better, with values above 0.25 indicating
-# reasonable structure. Unlike factor_regimes, we skip BIC/AIC model selection here
-# because the goal is interpretability (matching known economic phases), not
-# statistical optimality.
-
-# %% [markdown]
-# ## Regime Characteristics
+# ## Fit the mixture
+#
+# The same estimator as `factor_regimes`: a full-covariance Gaussian mixture, restarted ten
+# times from different initializations, keeping the fit with the highest likelihood.
 
 # %%
-if len(macro_df) > 0:
-    regime_chars = macro_df.copy()
-    regime_chars["regime"] = macro_labels
-    regime_means = regime_chars.groupby("regime").mean()
+gmm_core = GaussianMixture(
+    n_components=N_REGIMES,
+    covariance_type="full",
+    random_state=SEED,
+    n_init=10,
+    reg_covar=1e-6,
+)
+gmm_core.fit(macro_scaled)
+core_labels = gmm_core.predict(macro_scaled)
+core_probabilities = gmm_core.predict_proba(macro_scaled)
+core_silhouette = float(silhouette_score(macro_scaled, core_labels))
 
-    print("Regime Characteristics (mean values):")
-    print(regime_means.round(2))
-else:
-    regime_means = pd.DataFrame()
+print(f"Core model silhouette: {core_silhouette:.3f}")
 
 # %% [markdown]
-# ## Assign Interpretive Labels
+# ### What the clusters contain
+#
+# The mixture returns numbers. The table below is what those numbers mean: the average of
+# each indicator over the months assigned to each cluster, in the original units.
+
+# %%
+cluster_means = macro_df.groupby(core_labels).mean()
+cluster_means.index.name = "Cluster"
+cluster_means.rename(columns=UNITS).style.format("{:.2f}")
+
+# %% [markdown]
+# ### Naming the clusters
+#
+# A cluster number is not a regime name, and the names have to come from somewhere the
+# model cannot supply. The rule below reads each cluster's average indicators and applies
+# the first description that fits, in a fixed order. Both the ordering and the thresholds
+# are judgements about the post-2002 US economy, chosen so that each name means what a
+# reader expects: high unemployment is a crisis whatever the rate environment; high
+# unemployment with the policy rate at the floor is the aftermath rather than the crisis
+# itself; a high policy rate with a flat curve is a tightening cycle.
+#
+# The rule is stated in one place so that it can be argued with. A different reader would
+# set different thresholds and get different names over the same partition, and that is the
+# honest situation: the clustering is estimated, the naming is asserted.
 
 
 # %%
-def create_regime_labels(chars: pd.DataFrame) -> dict[int, str]:
-    """Create short, descriptive labels based on economic characteristics.
-
-    Uses a priority cascade on cluster-mean values. Thresholds are approximate
-    and tuned for the 2002-2025 US macro environment.
-    """
-    labels = {}
-    for regime in chars.index:
-        c = chars.loc[regime]
-        if c["unrate"] > 10:
-            labels[regime] = "Crisis"
-        elif c["unrate"] > 6 and c["dff"] < 0.5:
-            labels[regime] = "Recovery"
-        elif c["dff"] > 3 and c["t10y2y"] < 0.5:
-            labels[regime] = "Tightening"
-        elif c["cpi_yoy"] > 4:
-            labels[regime] = "Inflation"
-        elif c["unrate"] < 5 and c["dff"] < 2:
-            labels[regime] = "Expansion"
+def name_clusters(means: pd.DataFrame) -> dict[int, str]:
+    """Attach an economic description to each cluster from its average indicators."""
+    names: dict[int, str] = {}
+    for cluster in means.index:
+        row = means.loc[cluster]
+        if row["unrate"] > 10:
+            names[cluster] = "Crisis"
+        elif row["unrate"] > 6 and row["dff"] < 0.5:
+            names[cluster] = "Recovery"
+        elif row["dff"] > 3 and row["t10y2y"] < 0.5:
+            names[cluster] = "Tightening"
+        elif row["cpi_yoy"] > 4:
+            names[cluster] = "Inflation"
+        elif row["unrate"] < 5 and row["dff"] < 2:
+            names[cluster] = "Expansion"
         else:
-            labels[regime] = "Transition"
-
-    # Ensure unique labels
-    seen = {}
-    for r, label in list(labels.items()):
-        if label in seen:
-            if chars.loc[r, "unrate"] > chars.loc[seen[label], "unrate"]:
-                labels[r] = f"{label} (High Unemp.)"
-            else:
-                labels[seen[label]] = f"{label} (High Unemp.)"
-        seen[label] = r
-    return labels
+            names[cluster] = "Transition"
+    return names
 
 
 # %%
-if len(regime_means) > 0:
-    regime_labels_map = create_regime_labels(regime_means)
-    print("Assigned Regime Labels:")
-    for regime, label in sorted(regime_labels_map.items()):
-        print(f"  Cluster {regime}: {label}")
-else:
-    regime_labels_map = {}
+cluster_names = name_clusters(cluster_means)
+if len(set(cluster_names.values())) != len(cluster_names):
+    raise ValueError(f"Two clusters received the same name: {cluster_names}")
+
+regime_name = pd.Series(
+    [cluster_names[label] for label in core_labels], index=macro_df.index, name="regime"
+)
+ordered_names = [cluster_names[cluster] for cluster in cluster_means.index]
+pd.DataFrame(
+    {"Name": ordered_names, "Months": regime_name.value_counts()[ordered_names].to_numpy()},
+    index=cluster_means.index,
+)
 
 # %% [markdown]
-# ## Macro Regimes and Market Volatility
+# ## Do the regimes correspond to anything the market did?
 #
-# **Key insight**: Macro regimes coincide with different VOLATILITY environments,
-# even when return patterns are less clear.
+# The clustering has seen no market data at all. If the four groups are picking up real
+# conditions rather than an arbitrary carve-up of a four-dimensional cloud, then equity
+# returns should behave differently inside them, and the difference should be in the
+# direction economic reasoning predicts.
 #
-# **Implication**: Macro regime indicators are useful for RISK MANAGEMENT
-# (anticipating volatility shifts) rather than RETURN PREDICTION.
-
-# %% [markdown]
-# ### Load S&P 500 for Validation
+# The S&P 500 daily series is resampled to month-end closes and aligned to the macro panel.
+# The macro rows are stamped at the right edge of the month they summarise, so the nearest
+# month-end close within five days is the close of the month whose data the row carries.
 
 # %%
-sp500_raw = load_sp500_index().to_pandas()
-sp500_raw["timestamp"] = pd.to_datetime(sp500_raw["timestamp"])
-sp500_raw = sp500_raw.set_index("timestamp")
+sp500 = load_sp500_index().to_pandas()
+sp500[DATE_COL] = pd.to_datetime(sp500[DATE_COL])
+sp500 = sp500.set_index(DATE_COL)
 
-sp500_monthly = sp500_raw["close"].resample("ME").last().to_frame()
+sp500_monthly = sp500["close"].resample("ME").last().to_frame()
 sp500_monthly["returns"] = sp500_monthly["close"].pct_change()
-sp500_df = sp500_monthly
 
-print(
-    f"Loaded S&P 500 for validation: {len(sp500_df)} months, "
-    f"{sp500_df.index.min().date()} to {sp500_df.index.max().date()}"
+aligned = sp500_monthly.reindex(macro_df.index, method="nearest", tolerance=pd.Timedelta("5D"))
+if aligned["close"].isna().any():
+    raise ValueError("A macro month found no S&P 500 close within five days")
+
+print(f"Aligned {len(aligned)} months of S&P 500 closes to the macro panel")
+
+# %% [markdown]
+# ### Two statistics per regime, and what each one is
+#
+# **Annualized volatility** is the standard deviation of the monthly returns of the months
+# assigned to a regime, multiplied by the square root of twelve. It describes the months in
+# that regime and nothing else.
+#
+# **Maximum drawdown** is taken differently, and the difference matters. The running peak is
+# computed over the whole index, in calendar order, and each month's decline from that peak
+# is measured; the number reported for a regime is the deepest such decline observed in one
+# of its months. It is therefore the worst point of the index reached while conditions were
+# in that regime, not the drawdown of a portfolio held only during it. A regime that occupies
+# few months can miss a trough that fell just outside it, and one does below.
+
+# %%
+aligned["regime"] = regime_name.to_numpy()
+aligned["drawdown"] = aligned["close"] / aligned["close"].cummax() - 1
+
+regime_stats = aligned.groupby("regime").agg(
+    months=("returns", "count"),
+    monthly_std=("returns", "std"),
+    worst_drawdown=("drawdown", "min"),
+)
+regime_stats["annual_vol"] = regime_stats["monthly_std"] * np.sqrt(MONTHS_PER_YEAR) * 100
+regime_stats["max_dd_pct"] = -regime_stats["worst_drawdown"] * 100
+regime_stats = regime_stats.sort_values("annual_vol")
+regime_order = regime_stats.index.tolist()
+
+regime_stats[["months", "annual_vol", "max_dd_pct"]].rename(
+    columns={
+        "months": "Months",
+        "annual_vol": "Annualized volatility (%)",
+        "max_dd_pct": "Deepest index drawdown reached (%)",
+    }
+).style.format(
+    {"Annualized volatility (%)": "{:.1f}", "Deepest index drawdown reached (%)": "{:.1f}"}
 )
 
 # %% [markdown]
-# ### Compute Regime Statistics
-
-# %%
-if len(macro_df) > 0 and sp500_df is not None:
-    events = {2008: "GFC", 2020: "COVID", 2022: "Inflation"}
-
-    sp500_aligned = sp500_df.reindex(macro_df.index, method="nearest", tolerance=pd.Timedelta("5D"))
-    sp500_aligned["regime"] = macro_labels
-    sp500_aligned["regime_label"] = [regime_labels_map[r] for r in macro_labels]
-    sp500_aligned["peak"] = sp500_aligned["close"].cummax()
-    sp500_aligned["drawdown"] = (sp500_aligned["close"] - sp500_aligned["peak"]) / sp500_aligned[
-        "peak"
-    ]
-    sp500_aligned["volatility"] = sp500_aligned["returns"].rolling(12).std() * np.sqrt(12)
-
-    regime_stats_fig = sp500_aligned.groupby("regime_label").agg(
-        {"returns": ["mean", "std", "count"], "drawdown": "min", "volatility": "mean"}
-    )
-    regime_stats_fig.columns = ["mean_ret", "std_ret", "months", "max_dd", "avg_vol"]
-    regime_stats_fig["annual_vol"] = regime_stats_fig["std_ret"] * np.sqrt(12) * 100
-    regime_stats_fig["max_dd_pct"] = -regime_stats_fig["max_dd"] * 100
-
-    regime_stats_fig = regime_stats_fig.sort_values("annual_vol", ascending=True)
-    regime_order = regime_stats_fig.index.tolist()
-    n_regimes_fig = len(regime_order)
-
-    print("Regime Statistics (sorted by volatility):")
-    print(regime_stats_fig[["months", "annual_vol", "max_dd_pct"]].round(1))
-
-# %% [markdown]
-# ### Regime Timeline with Market Validation
-
-
-# %%
-def plot_regime_timeline_validation():
-    """Plot regime swim lanes with volatility and drawdown validation bars."""
-    if len(macro_df) > 0 and sp500_df is not None:
-        years = [pd.Timestamp(ts).year for ts in macro_df.index]
-        n_months = len(macro_df)
-
-        year_ticks = []
-        year_labels_fig = []
-        for j, year in enumerate(years):
-            if j == 0 or years[j - 1] != year:
-                if year % 4 == 0:
-                    year_ticks.append(j)
-                    year_labels_fig.append(str(year))
-
-        fig = plt.figure(figsize=(14, 6))
-        gs = GridSpec(
-            n_regimes_fig, 4, figure=fig, width_ratios=[3.5, 1, 1, 0.05], wspace=0.12, hspace=0.08
-        )
-
-        swimlane_axes = [fig.add_subplot(gs[i, 0]) for i in range(n_regimes_fig)]
-        vol_axes = [fig.add_subplot(gs[i, 1]) for i in range(n_regimes_fig)]
-        dd_axes = [fig.add_subplot(gs[i, 2]) for i in range(n_regimes_fig)]
-
-        # Grayscale-friendly palette (distinct in B&W print)
-        # Ordered from light to dark to match volatility ordering
-        REGIME_COLORS = ["#e0e0e0", "#a0a0a0", "#606060", "#202020"]
-        colors = REGIME_COLORS[:n_regimes_fig]
-
-        for i, regime_label in enumerate(regime_order):
-            raw_regime = [r for r, lbl in regime_labels_map.items() if lbl == regime_label][0]
-            mask = macro_labels == raw_regime
-            stats = regime_stats_fig.loc[regime_label]
-            color = colors[i]
-
-            ax_swim = swimlane_axes[i]
-            for j in range(n_months - 1):
-                if mask[j]:
-                    ax_swim.axvspan(j, j + 1, color=color, alpha=0.85)
-
-            ax_swim.set_xlim(0, n_months)
-            ax_swim.set_ylim(0, 1)
-            ax_swim.set_yticks([])
-            ax_swim.set_ylabel(regime_label, fontsize=9, rotation=0, ha="right", va="center")
-
-            if i < n_regimes_fig - 1:
-                ax_swim.set_xticks([])
-            else:
-                ax_swim.set_xticks(year_ticks)
-                ax_swim.set_xticklabels(year_labels_fig, fontsize=8)
-                ax_swim.set_xlabel("Year", fontsize=9)
-
-            for event_year, event_label in events.items():
-                try:
-                    idx = next(j for j, y in enumerate(years) if y == event_year)
-                    ax_swim.axvline(x=idx, color="black", linestyle="-", alpha=0.3, linewidth=0.8)
-                    if i == 0:
-                        ax_swim.annotate(
-                            event_label,
-                            xy=(idx, 1.25),
-                            xycoords=("data", "axes fraction"),
-                            ha="center",
-                            fontsize=7,
-                            color="black",
-                            fontweight="bold",
-                        )
-                except StopIteration:
-                    pass
-
-            ax_vol = vol_axes[i]
-            vol_val = stats["annual_vol"]
-            ax_vol.barh([0], [vol_val], color=color, height=0.6, edgecolor="black", linewidth=0.5)
-            ax_vol.set_xlim(0, 22)
-            ax_vol.set_ylim(-0.5, 0.5)
-            ax_vol.set_yticks([])
-            ax_vol.text(
-                vol_val + 0.3,
-                0,
-                f"{vol_val:.0f}%",
-                ha="left",
-                va="center",
-                fontsize=9,
-                fontweight="bold",
-            )
-
-            if i == 0:
-                ax_vol.set_title("Volatility\n(ann. %)", fontsize=9, fontweight="bold")
-            if i < n_regimes_fig - 1:
-                ax_vol.set_xticks([])
-            else:
-                ax_vol.set_xticks([0, 10, 20])
-                ax_vol.tick_params(labelsize=7)
-
-            ax_dd = dd_axes[i]
-            dd_val = stats["max_dd_pct"]
-            ax_dd.barh([0], [dd_val], color=color, height=0.6, edgecolor="black", linewidth=0.5)
-            ax_dd.set_xlim(0, 60)
-            ax_dd.set_ylim(-0.5, 0.5)
-            ax_dd.set_yticks([])
-            ax_dd.text(
-                dd_val + 1,
-                0,
-                f"{dd_val:.0f}%",
-                ha="left",
-                va="center",
-                fontsize=9,
-                fontweight="bold",
-            )
-
-            if i == 0:
-                ax_dd.set_title("Max\nDrawdown", fontsize=9, fontweight="bold")
-            if i < n_regimes_fig - 1:
-                ax_dd.set_xticks([])
-            else:
-                ax_dd.set_xticks([0, 20, 40, 60])
-                ax_dd.tick_params(labelsize=7)
-
-        start_year = macro_df.index.min().year
-        end_year = macro_df.index.max().year
-        fig.suptitle(
-            f"Macro Regimes and Market Volatility ({start_year}-{end_year})",
-            fontsize=11,
-            fontweight="bold",
-            y=0.98,
-        )
-
-        fig.text(
-            0.5,
-            0.02,
-            "Regimes from: Unemployment, Fed Funds Rate, Yield Curve (10Y-2Y), CPI  |  Sorted by volatility",
-            ha="center",
-            fontsize=8,
-            style="italic",
-            color="#505050",
-        )
-
-        plt.show()
-
-
-plot_regime_timeline_validation()
-
-# %% [markdown]
-# ### Persist Figure 1.6 inputs
+# ### The regime panel
 #
-# The publication-quality version of Figure 1.6 is rendered by
-# `book/01_process_is_edge/figures/scripts/generate_figure_1_6_macro_regimes_volatility.py`.
-# That script reads the arrays persisted below so the book build does not
-# re-fit the clustering pipeline.
+# One row per regime, ordered by the volatility of the months it holds. The left panel shows
+# when each regime was in force, with three dated episodes marked; the two right panels are
+# the statistics above, so the ordering of the bars can be read against the pattern of the
+# bands. This is the panel that appears as Figure 1.6.
 
 # %%
-if len(macro_df) > 0 and sp500_df is not None:
-    ARTIFACT_DIR = OUTPUT_DIR / "figure_1_6"
-    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
-    annual_vol_by_regime = regime_stats_fig.loc[regime_order, "annual_vol"].to_numpy(dtype=float)
-    max_dd_by_regime = regime_stats_fig.loc[regime_order, "max_dd_pct"].to_numpy(dtype=float)
-    np.savez(
-        ARTIFACT_DIR / "inputs.npz",
-        dates=macro_df.index.astype("datetime64[ns]").astype("int64"),
-        macro_labels=np.asarray(macro_labels, dtype=np.int64),
-        regime_order=np.asarray(regime_order, dtype=object),
-        raw_regime_for_order=np.asarray(
-            [
-                next(r for r, lbl in regime_labels_map.items() if lbl == label)
-                for label in regime_order
-            ],
-            dtype=np.int64,
-        ),
-        annual_vol=annual_vol_by_regime,
-        max_dd_pct=max_dd_by_regime,
-        event_years=np.asarray(list(events.keys()), dtype=np.int64),
-        event_labels=np.asarray(list(events.values()), dtype=object),
-        start_year=np.int64(macro_df.index.min().year),
-        end_year=np.int64(macro_df.index.max().year),
-    )
+EVENTS = {2008: "Global financial crisis", 2020: "COVID-19", 2022: "Inflation"}
+REGIME_SHADES = [COLORS["recede"], COLORS["copper"], COLORS["amber"], COLORS["blue"]]
 
-# %% [markdown]
-# ### Key Insight Summary
 
 # %%
-insight_table = (
-    regime_stats_fig.loc[regime_order, ["months", "annual_vol", "max_dd_pct"]]
-    .rename(
-        columns={
-            "months": "Months",
-            "annual_vol": "Annual vol (%)",
-            "max_dd_pct": "Max drawdown (%)",
-        }
-    )
-    .round(1)
+def year_ticks(dates: pd.DatetimeIndex, every: int) -> tuple[list[int], list[str]]:
+    """Positions and labels for the first month of every *every*-th year."""
+    years = dates.year.tolist()
+    ticks = [j for j, y in enumerate(years) if y % every == 0 and (j == 0 or years[j - 1] != y)]
+    return ticks, [str(years[j]) for j in ticks]
+
+
+# %%
+def draw_regime_row(ax, occupied: np.ndarray, colour: str, label: str) -> None:
+    """Shade the months a regime was in force across one full-width row."""
+    for j in np.flatnonzero(occupied):
+        ax.axvspan(j, j + 1, color=colour)
+    ax.set_xlim(0, len(occupied))
+    ax.set_ylim(0, 1)
+    ax.set_yticks([])
+    ax.set_ylabel(label, rotation=0, ha="right", va="center")
+
+
+# %%
+def draw_stat_bar(ax, value: float, colour: str, limit: float, heading: str | None) -> None:
+    """Draw one horizontal bar with its value written at the end."""
+    ax.barh([0], [value], color=colour, height=0.6)
+    ax.set_xlim(0, limit)
+    ax.set_ylim(-0.5, 0.5)
+    ax.set_yticks([])
+    ax.text(value + limit * 0.02, 0, f"{value:.0f}%", ha="left", va="center", fontsize=8)
+    if heading:
+        ax.set_title(heading, fontsize=8)
+
+
+# %%
+def mark_events(ax, dates: pd.DatetimeIndex, label_them: bool) -> None:
+    """Draw a rule at the first month of each dated episode, labelling it on the top row."""
+    for event_year, event_label in EVENTS.items():
+        position = next((j for j, y in enumerate(dates.year) if y == event_year), None)
+        if position is None:
+            continue
+        ax.axvline(x=position, color=COLORS["neutral"], alpha=0.35, linewidth=0.8)
+        if label_them:
+            ax.annotate(
+                event_label,
+                xy=(position, 1.3),
+                xycoords=("data", "axes fraction"),
+                ha="center",
+                fontsize=6,
+                color=COLORS["neutral"],
+            )
+
+
+# %%
+def draw_panel_row(fig, grid, i: int, regime: str, first: bool, last: bool) -> None:
+    """Draw one regime's timeline row and its two statistic bars."""
+    shade = REGIME_SHADES[i]
+    ax_band = fig.add_subplot(grid[i, 0])
+    draw_regime_row(ax_band, regime_name.to_numpy() == regime, shade, regime)
+    mark_events(ax_band, macro_df.index, label_them=first)
+    if last:
+        ax_band.set_xticks(ticks)
+        ax_band.set_xticklabels(tick_labels, fontsize=7)
+        ax_band.set_xlabel("Year")
+    else:
+        ax_band.set_xticks([])
+
+    stats = regime_stats.loc[regime]
+    heading = ("Annualized\nvolatility", "Deepest index\ndrawdown") if first else (None, None)
+    draw_stat_bar(fig.add_subplot(grid[i, 1]), stats["annual_vol"], shade, 25, heading[0])
+    draw_stat_bar(fig.add_subplot(grid[i, 2]), stats["max_dd_pct"], shade, 70, heading[1])
+
+
+# %%
+ticks, tick_labels = year_ticks(macro_df.index, every=4)
+n_rows = len(regime_order)
+
+fig = plt.figure(figsize=(style.PAGE_WIDTH, 0.85 * n_rows + 1.4))
+grid = GridSpec(n_rows, 3, figure=fig, width_ratios=[3.5, 1, 1], wspace=0.15, hspace=0.15)
+
+for i, regime in enumerate(regime_order):
+    draw_panel_row(fig, grid, i, regime, first=(i == 0), last=(i == n_rows - 1))
+
+fig.suptitle(
+    "Ordering the macro regimes by volatility does not order them by drawdown",
+    fontsize=10,
+    ha="left",
+    x=0.02,
 )
-insight_table
+fig.text(
+    0.5,
+    0.0,
+    "Regimes from unemployment, the fed funds rate, the 10Y-2Y spread and 12-month CPI change",
+    ha="center",
+    fontsize=7,
+    color=COLORS["neutral"],
+)
+style.show_with_alt(
+    fig,
+    "Four stacked timeline rows, one per regime, beside two columns of horizontal bars for "
+    "annualized volatility and the deepest index drawdown. The volatility bars grow "
+    "steadily down the rows while the drawdown bars do not follow the same order.",
+)
 
 # %% [markdown]
-# ## Correlation Heatmap
+# ### Reading the panel honestly
+#
+# The volatility ordering is what the panel was sorted on, so it is monotone by
+# construction and says nothing on its own. The drawdown column is the informative one,
+# because nothing forced it to agree, and it does not.
 
 # %%
-if len(macro_df) > 0:
-    fig, ax = plt.subplots(figsize=(8, 6), layout="tight")
-    sns.heatmap(
-        macro_df.corr(),
-        annot=True,
-        fmt=".2f",
-        cmap="RdBu_r",
-        center=0,
-        ax=ax,
-        square=True,
+smallest_regime = str(regime_stats["months"].idxmin())
+smallest_span = regime_name[regime_name == smallest_regime].index
+deepest_month = aligned["drawdown"].idxmin()
+deepest_regime = str(aligned.loc[deepest_month, "regime"])
+vol_spread = float(regime_stats["annual_vol"].max() - regime_stats["annual_vol"].min())
+display(
+    Markdown(
+        f"The smallest regime, **{smallest_regime}**, holds "
+        f"**{len(smallest_span)} months**, running from "
+        f"**{smallest_span.min():%B %Y}** to **{smallest_span.max():%B %Y}**, and the index "
+        f"was never more than "
+        f"**{regime_stats.loc[smallest_regime, 'max_dd_pct']:.0f}%** below its peak in any "
+        f"of them. The deepest reading of the whole panel, "
+        f"**{regime_stats['max_dd_pct'].max():.0f}%**, falls in "
+        f"**{deepest_month:%B %Y}**, which the naming rule calls **{deepest_regime}**. "
+        f"Across the four regimes the annualized volatility spans "
+        f"**{vol_spread:.0f} percentage points**."
     )
-    ax.set_title("Macro Indicator Correlations", fontsize=12)
-    plt.show()
+)
 
 # %% [markdown]
-# **Interpretation**: Unemployment moves *with* the 10y-2y spread (positive
-# correlation ~0.70): when the labour market deteriorates, the curve typically
-# steepens as the Fed cuts the front end. The Fed Funds rate moves *against*
-# the spread (correlation ~−0.73): hiking cycles flatten or invert the curve.
-# CPI YoY is largely orthogonal to the other three — inflation regimes can
-# coexist with both recession and expansion. These pairwise correlations show
-# why a single indicator is a noisy regime signal and motivate joint clustering.
+# The two lines above are the check earning its place, and both of them cut against the
+# regime story rather than for it.
+#
+# The cluster the rule names Crisis is the handful of months in which unemployment averaged
+# above ten percent, and by the time unemployment reached that level the equity market had
+# already fallen and turned. The market's own worst point lands in a different cluster
+# entirely - one whose name, assigned from the policy rate and the unemployment rate, reads
+# as the aftermath. Neither name is a mistake in the rule; both are the same fact about the
+# data, which is that the labour market registers a shock the market has already priced.
+#
+# A statistic computed on four months is an anecdote whatever it says, and the volatility
+# spread across the four regimes is a few percentage points. Regimes estimated from
+# macroeconomic conditions do separate equity volatility, and they separate it weakly. A
+# reader should hold that conclusion at the strength these numbers support rather than at the
+# strength the idea invites, and the notebook has to report the small cell rather than
+# quietly drop it for being small.
+#
+# The lag is structural, not a property of this sample. Unemployment is measured over a month
+# and published in the next; prices move on expectations of the same conditions. Macro
+# regimes are therefore evidence about the environment a portfolio is already in, not a
+# signal about the one it is heading into, which is the use Section 1.4 argues for.
 
 # %% [markdown]
-# ---
+# ### Figure 1.6 inputs
 #
-# # Extended Analysis: All FRED Indicators
-#
-# Now we expand beyond the 4 core indicators to use all available FRED series
-# (~17 indicators after quality filtering). This provides a richer but noisier
-# view of economic conditions.
-
-# %% [markdown]
-# ## Prepare Full Dataset
-#
-# Using the same data loaded at the start, we now select ALL series with
-# sufficient data coverage (< 50% missing).
+# The print version of Figure 1.6 is drawn by
+# `book/01_process_is_edge/figures/scripts/generate_figure_1_6_macro_regimes_volatility.py`
+# in the book repository, which reads the arrays written below rather than re-fitting the
+# clustering.
 
 # %%
-# Use the already-loaded macro_raw data
-value_cols_full = [c for c in macro_raw.columns if c != DATE_COL]
+ARTIFACT_DIR = OUTPUT_DIR / "figure_1_6"
+ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+np.savez(
+    ARTIFACT_DIR / "inputs.npz",
+    dates=macro_df.index.astype("datetime64[ns]").astype("int64"),
+    macro_labels=np.asarray(core_labels, dtype=np.int64),
+    regime_order=np.asarray(regime_order, dtype=object),
+    raw_regime_for_order=np.asarray(
+        [next(c for c, name in cluster_names.items() if name == regime) for regime in regime_order],
+        dtype=np.int64,
+    ),
+    annual_vol=regime_stats.loc[regime_order, "annual_vol"].to_numpy(dtype=float),
+    max_dd_pct=regime_stats.loc[regime_order, "max_dd_pct"].to_numpy(dtype=float),
+    event_years=np.asarray(list(EVENTS), dtype=np.int64),
+    event_labels=np.asarray(list(EVENTS.values()), dtype=object),
+    start_year=np.int64(PANEL_FIRST_YEAR),
+    end_year=np.int64(PANEL_LAST_YEAR),
+)
 
-macro_monthly_full = (
+# %% [markdown]
+# ## How the four indicators move together
+#
+# A clustering on four correlated inputs is not a clustering in four independent
+# directions, so the correlations are worth seeing before the extended panel raises the
+# question at a larger scale. Only one triangle is drawn: the matrix is symmetric and the
+# other half carries no additional information. The scale is fixed to the full range a
+# correlation can take, so the colours mean the same thing here as in any other correlation
+# figure in the book.
+
+# %%
+correlations = macro_df.rename(columns=UNITS).corr()
+
+fig, ax = plt.subplots(figsize=style.FIGSIZE["single_tall"])
+sns.heatmap(
+    correlations,
+    mask=style.upper_triangle_mask(correlations),
+    annot=True,
+    fmt=".2f",
+    cmap=style.ml4t_diverging(),
+    vmin=-1,
+    vmax=1,
+    center=0,
+    square=True,
+    linewidths=0.5,
+    cbar_kws={"shrink": 0.7, "label": "Correlation"},
+    ax=ax,
+)
+ax.set_xlabel("")
+ax.set_ylabel("")
+style.add_message_title(
+    ax,
+    "No pair of the four indicators is close to independent",
+    subtitle="Pearson correlation over the clustering panel",
+)
+style.show_with_alt(
+    fig,
+    "A lower-triangular correlation heatmap of four macro indicators on a red-to-blue scale "
+    "fixed between minus one and one. The unemployment rate and the yield spread are "
+    "strongly positive, the fed funds rate is strongly negative against the yield spread, "
+    "and inflation is moderately negative against unemployment.",
+)
+
+# %% [markdown]
+# Unemployment and the yield spread move together, and the fed funds rate moves against the
+# spread. Both are the same mechanism seen from two sides: the Federal Reserve cuts the
+# short rate when the labour market weakens, which pulls the front of the curve down and
+# steepens the spread, and it raises the short rate when the economy runs hot, which flattens
+# or inverts it. Inflation is the least entangled of the four and is still not independent of
+# them.
+#
+# That is the case for clustering jointly rather than thresholding one series at a time. Any
+# single indicator tells the same story as its neighbours plus its own noise; the joint model
+# reads all four positions at once, which is how it can separate the tightening cycle from
+# the recovery even though both involve an unusual short rate.
+
+# %% [markdown]
+# ## The counter-experiment: every series in the panel
+#
+# The core model uses four series chosen for what they mean. The obvious question is whether
+# adding the rest of the file would do better, and the obvious way to answer it is to fit the
+# same mixture to everything and compare the separation scores.
+#
+# That comparison is the trap this section exists to spring. The extended panel is assembled
+# with no judgement at all beyond a coverage filter, which is exactly how such a panel is
+# usually built.
+
+# %%
+value_columns = [c for c in macro_raw.columns if c != DATE_COL]
+monthly_full = (
     macro_raw.sort(DATE_COL)
     .group_by_dynamic(DATE_COL, every="1mo", label="right")
-    .agg([pl.col(c).last() for c in value_cols_full])
-    .filter(pl.col(DATE_COL) >= pl.datetime(2002, 1, 1))
+    .agg([pl.col(c).last() for c in value_columns])
+    .filter(pl.col(DATE_COL) >= PANEL_START)
 )
 
-# Identify columns with >50% missing, exclude market price columns
-total_rows = macro_monthly_full.height
-null_fractions = {
-    col: macro_monthly_full.select(pl.col(col).is_null().sum()).item() / total_rows
-    for col in value_cols_full
+missing_share = {
+    column: monthly_full.select(pl.col(column).is_null().sum()).item() / monthly_full.height
+    for column in value_columns
 }
-# Exclude columns with too much missing data and market price columns (SP500)
-exclude_cols = {"sp500", "SP500"}
-good_cols = [col for col, frac in null_fractions.items() if frac < 0.5 and col not in exclude_cols]
+kept_columns = [c for c, share in missing_share.items() if share <= MAX_MISSING_SHARE]
 
-macro_clean_full = (
-    macro_monthly_full.select([DATE_COL] + good_cols).fill_null(strategy="forward").drop_nulls()
+extended_pl = monthly_full.select([DATE_COL, *kept_columns]).drop_nulls()
+extended_df = extended_pl.select(kept_columns).to_pandas()
+extended_df.index = pd.DatetimeIndex(extended_pl[DATE_COL].to_pandas())
+extended_df = extended_df.apply(scale)
+
+display(
+    Markdown(
+        f"The coverage filter keeps **{len(kept_columns)} of {len(value_columns)}** series, "
+        f"and dropping the months in which any of them is unquoted leaves "
+        f"**{len(extended_df)} months**, the same window as the core panel."
+    )
 )
 
-macro_data_full = macro_clean_full.select(good_cols).to_pandas()
-macro_data_full.index = macro_clean_full[DATE_COL].to_pandas()
-macro_data_full = macro_data_full.apply(scale)
-
-print(f"Extended dataset: {macro_data_full.shape[0]} months, {macro_data_full.shape[1]} series")
-print(f"Series used: {list(macro_data_full.columns)}")
-
 # %% [markdown]
-# ## Visualize All Series
+# ### What the filter let through
+#
+# Nothing in that assembly asked what the columns are, and the metadata table at the top of
+# the notebook says what got in. Nine of the columns are Treasury yields at maturities from
+# one to thirty years, which move almost as one series. `YIELD_CURVE_SLOPE` is defined as the
+# ten-year yield minus the two-year, which is the definition of `t10y2y`, already in the
+# panel - the same spread enters twice under two names. Nominal and real GDP are both
+# present, published quarterly, so each repeats its value for three months at a time. And
+# three price indices enter as levels, which is the treatment the core panel rejected for one
+# of them.
 
 # %%
-n_cols = min(len(macro_data_full.columns), 20)
-n_rows = (n_cols + 4) // 5
-n_plot_cols = min(5, n_cols)
+duplicate_check = (extended_df["t10y2y"] - extended_df["YIELD_CURVE_SLOPE"]).abs().max()
+gdp_distinct = int(extended_df["gdp"].round(6).nunique())
+display(
+    Markdown(
+        f"The largest gap between `t10y2y` and `YIELD_CURVE_SLOPE` anywhere in the panel is "
+        f"**{duplicate_check:.1e}** after standardization, and nominal GDP takes "
+        f"**{gdp_distinct} distinct values** across **{len(extended_df)} monthly rows**."
+    )
+)
 
+# %% [markdown]
+# ### The series, drawn
+#
+# Every kept column standardized and plotted on shared axes. The point of the small multiples
+# is the shape of each panel, not its level: how many of them are the same line.
+
+# %%
+n_columns = 5
+n_rows_grid = int(np.ceil(len(extended_df.columns) / n_columns))
 fig, axes = plt.subplots(
-    nrows=n_rows, ncols=n_plot_cols, figsize=(16, 2 * n_rows), sharex=True, sharey=True
+    n_rows_grid,
+    n_columns,
+    figsize=(style.PAGE_WIDTH, 0.85 * n_rows_grid + 0.6),
+    sharex=True,
+    sharey=True,
 )
-axes = axes.flatten() if n_rows > 1 else [axes] if n_cols == 1 else axes
+for ax, column in zip(axes.flat, extended_df.columns):
+    ax.plot(extended_df.index, extended_df[column], color=COLORS["blue"], linewidth=0.7)
+    ax.set_title(column, fontsize=6)
+    ax.tick_params(labelsize=5)
+for ax in axes.flat[len(extended_df.columns) :]:
+    ax.set_visible(False)
 
-for i, ax in enumerate(axes[:n_cols]):
-    if i < len(macro_data_full.columns):
-        macro_data_full.iloc[:, i].plot(ax=ax, color="steelblue", linewidth=0.8)
-        ax.set_title(macro_data_full.columns[i], fontsize=9)
-        ax.tick_params(axis="both", labelsize=7)
-    else:
-        ax.set_visible(False)
-
-for i in range(n_cols, len(axes)):
-    axes[i].set_visible(False)
-
-sns.despine()
-start_yr = macro_data_full.index.min().year
-end_yr = macro_data_full.index.max().year
-fig.suptitle(f"FRED Macro Series - Standardized ({start_yr}-{end_yr})", fontsize=12, y=1.02)
-plt.show()
-
-# %% [markdown]
-# **Interpretation**: The visibly regime-bearing series are VIX (sharp spikes
-# in 2008 and 2020), ICSA initial claims (same crisis peaks), DFF (regime
-# shifts during hiking cycles), and the yield-curve spread T10Y2Y (recession
-# warnings ahead of 2008 and 2020). Slow-moving series (housing, monetary
-# aggregates) carry less regime information. Clustering will lean heavily on
-# the high-variance subset.
-
-# %% [markdown]
-# ## Hierarchical Clustering
-#
-# Cluster the correlation matrix to reveal indicator groupings.
-
-# %%
-# clustermap manages its own gridspec; disable constrained_layout to avoid
-# matplotlib colorbar/engine-switch errors under non-interactive backends.
-with plt.rc_context({"figure.constrained_layout.use": False}):
-    fig = sns.clustermap(macro_data_full.corr(), cmap="RdBu_r", center=0, figsize=(10, 10))
-    fig.fig.suptitle("FRED Indicator Correlations (Hierarchical Clustering)", y=1.02)
-    plt.show()
-
-# %% [markdown]
-# **Interpretation**: Four blocks emerge: a labour/yield-curve block
-# (CIVPART, UNRATE, T10Y2Y), a stress block (VIX, ICSA, high-yield spread), a
-# growth/price-level block (INDPRO, CPI, M2), and a short-rate block
-# (DFF, T10YIE). Most off-diagonal correlations are modest in magnitude, and
-# the dendrogram's high cophenetic correlation confirms that this block
-# structure is genuinely hierarchical.
-
-# %% [markdown]
-# ## Comparing GMM and K-Means
-#
-# Both methods identify 4 regimes. The key difference:
-# - **GMM**: Soft assignments with probabilities (uncertainty quantified)
-# - **K-Means**: Hard assignments (each month belongs to exactly one regime)
-
-# %% [markdown]
-# ### Fit Both Models
-
-# %%
-n_regimes_full = 4
-
-# GMM
-gmm_full = GaussianMixture(
-    n_components=n_regimes_full,
-    covariance_type="full",
-    random_state=SEED,
-    n_init=10,
-    reg_covar=1e-6,
+fig.suptitle(
+    "Slow trends dominate the panel; only the VIX and claims spike",
+    fontsize=10,
+    ha="left",
+    x=0.02,
 )
-gmm_full.fit(macro_data_full)
-gmm_probs_full = gmm_full.predict_proba(macro_data_full)
-gmm_labels_full = gmm_full.predict(macro_data_full)
-
-# K-Means
-kmeans_full = KMeans(n_clusters=n_regimes_full, random_state=SEED, n_init=10)
-kmeans_labels_full = kmeans_full.fit_predict(macro_data_full)
-
-print(f"GMM silhouette: {silhouette_score(macro_data_full, gmm_labels_full):.3f}")
-print(f"K-Means silhouette: {silhouette_score(macro_data_full, kmeans_labels_full):.3f}")
-
-# %% [markdown]
-# ### GMM Regime Probabilities
-
-# %%
-plot_regime_heatmap(
-    gmm_probs_full,
-    macro_data_full.index,
-    f"GMM Regime Probabilities ({start_yr}-{end_yr})",
-    n_regimes=n_regimes_full,
-    is_probability=True,
+style.show_with_alt(
+    fig,
+    "A grid of small standardized time-series panels sharing their axes. Several rise "
+    "steadily from one end of the window to the other, the Treasury yields move together "
+    "in broad waves, and only the VIX and initial jobless claims show sharp isolated "
+    "spikes against an otherwise flat line.",
 )
 
 # %% [markdown]
-# ### K-Means Regime Assignments
+# ### How much independent variation is left
+#
+# Principal component analysis puts a number on the redundancy the figure shows. Each
+# component is the direction of greatest remaining variance, and the cumulative share says
+# how much of the panel's total variation the first few directions account for.
 
 # %%
-plot_regime_heatmap(
-    kmeans_labels_full,
-    macro_data_full.index,
-    f"K-Means Regime Assignments ({start_yr}-{end_yr})",
-    n_regimes=n_regimes_full,
-    is_probability=False,
+pca = PCA(n_components=min(10, extended_df.shape[1]))
+reduced = pca.fit_transform(extended_df)
+
+explained = pd.DataFrame(
+    {
+        "Component": [f"PC{i + 1}" for i in range(pca.n_components_)],
+        "Share of variance": pca.explained_variance_ratio_,
+        "Cumulative": np.cumsum(pca.explained_variance_ratio_),
+    }
+).set_index("Component")
+explained.style.format("{:.1%}")
+
+# %%
+two_component_share = float(explained["Cumulative"].iloc[1])
+display(
+    Markdown(
+        f"Two directions account for **{two_component_share:.0%}** of the variance across "
+        f"**{extended_df.shape[1]} columns**."
+    )
 )
 
 # %% [markdown]
-# ## Agglomerative Clustering
+# ### Which columns each direction is made of
 #
-# Hierarchical clustering on observations (not features) shows how months group together.
-
-# %% [markdown]
-# ### Linkage Matrix
-
-# %%
-Z_full = linkage(macro_data_full, "ward")
-pairwise_dist = pdist(macro_data_full)
-c, _ = cophenet(Z_full, pairwise_dist)
-
-print(f"Cophenetic correlation: {c:.3f}")
-
-# %% [markdown]
-# **Note**: The cophenetic correlation measures how faithfully the dendrogram
-# preserves the original pairwise distances; good dendrograms score above 0.7.
-# Here it reaches 0.71, so the Ward-linkage tree is a reliable summary of the
-# indicator distance structure — the block grouping above reflects real
-# hierarchy rather than an artefact of the linkage choice.
-
-# %% [markdown]
-# ### Dendrogram
+# The share of variance says how much a direction carries; the loadings say what it is. Each
+# column below lists the four series with the largest absolute weight in that component,
+# heaviest first.
 
 # %%
-fig, ax = plt.subplots(figsize=(16, 5))
-# no_labels=True since the point of this figure is the cophenetic-correlation
-# summary in the title, not per-observation identity.
-dendrogram(Z_full, orientation="top", no_labels=True, ax=ax)
-ax.set_title(f"Ward Linkage Dendrogram | Cophenetic Correlation: {c:.2f}", fontsize=12)
-ax.set_ylabel("Distance")
-sns.despine()
-plt.show()
+loadings = pd.DataFrame(pca.components_.T, index=extended_df.columns, columns=explained.index)
+pd.DataFrame(
+    {
+        component: loadings[component].abs().sort_values(ascending=False).index[:4].tolist()
+        for component in explained.index[:4]
+    },
+    index=[f"Heaviest {i + 1}" for i in range(4)],
+)
 
 # %% [markdown]
-# ## PCA Preprocessing
+# The leading direction is the trend the small multiples showed, and the second is the level
+# of the long end of the Treasury curve. Neither is a regime. The series that move when
+# conditions break - the VIX, initial jobless claims - do not appear until the third and
+# fourth components, which between them carry a small share of the variance. A mixture fitted
+# on this panel is therefore fitted mostly on where in the sample a month sits, which is what
+# the episode count is about to show.
+
+# %% [markdown]
+# ## Fit the same models to the extended panel
 #
-# Reduce dimensionality before clustering to filter noise.
-
-# %% [markdown]
-# ### Fit PCA
-
-# %%
-n_pca = min(10, macro_data_full.shape[1])
-pca = PCA(n_components=n_pca)
-reduced = pca.fit_transform(macro_data_full)
-
-print("Cumulative Explained Variance:")
-cumvar = pd.Series(pca.explained_variance_ratio_).cumsum()
-for i, v in enumerate(cumvar):
-    print(f"  PC{i + 1}: {v:.1%}")
-
-# %% [markdown]
-# ### GMM on PCA-Reduced Data
+# A mixture and a k-means partition, both at the same cluster count as the core model, plus a
+# mixture on the ten leading principal components to see whether reducing the redundancy
+# changes the answer.
 
 # %%
+gmm_extended = GaussianMixture(
+    n_components=N_REGIMES, covariance_type="full", random_state=SEED, n_init=10, reg_covar=1e-6
+).fit(extended_df)
+extended_labels = gmm_extended.predict(extended_df)
+extended_probabilities = gmm_extended.predict_proba(extended_df)
+
+kmeans_labels = KMeans(n_clusters=N_REGIMES, random_state=SEED, n_init=10).fit_predict(extended_df)
+
 gmm_pca = GaussianMixture(
-    n_components=n_regimes_full,
-    covariance_type="full",
-    random_state=SEED,
-    n_init=10,
-    reg_covar=1e-6,
-)
-gmm_pca.fit(reduced)
-pca_probs = gmm_pca.predict_proba(reduced)
+    n_components=N_REGIMES, covariance_type="full", random_state=SEED, n_init=10, reg_covar=1e-6
+).fit(reduced)
 pca_labels = gmm_pca.predict(reduced)
 
-print(f"GMM on PCA silhouette: {silhouette_score(reduced, pca_labels):.3f}")
+comparison = pd.DataFrame(
+    {
+        "Model": [
+            f"Core, {len(CORE_SERIES)} chosen series",
+            f"Extended, {extended_df.shape[1]} series",
+            "Extended, 10 principal components",
+            f"Extended, {extended_df.shape[1]} series, k-means",
+        ],
+        "Silhouette": [
+            core_silhouette,
+            silhouette_score(extended_df, extended_labels),
+            silhouette_score(reduced, pca_labels),
+            silhouette_score(extended_df, kmeans_labels),
+        ],
+    }
+).set_index("Model")
+comparison.style.format("{:.3f}")
+
+# %% [markdown]
+# ### The score says the extended panel is better. Look at what it bought.
+#
+# An **episode** is a maximal run of consecutive months carrying the same label. Counting
+# them separates a model that recovers recurring conditions from one that has cut the sample
+# into consecutive blocks: a condition that recurs produces many episodes and revisits
+# earlier labels, while a chronological cut produces exactly as many episodes as it has
+# clusters and never returns to one.
+
 
 # %%
-plot_regime_heatmap(
-    pca_probs,
-    macro_data_full.index,
-    f"GMM Regime Probabilities (PCA-reduced, {start_yr}-{end_yr})",
-    n_regimes=n_regimes_full,
-    is_probability=True,
+def episode_count(labels: np.ndarray) -> int:
+    """Number of maximal runs of consecutive months sharing a label."""
+    return int(np.sum(np.diff(labels) != 0)) + 1
+
+
+episodes = pd.DataFrame(
+    {
+        "Model": [
+            f"Core, {len(CORE_SERIES)} chosen series",
+            f"Extended, {extended_df.shape[1]} series",
+        ],
+        "Clusters": [N_REGIMES, N_REGIMES],
+        "Episodes": [episode_count(core_labels), episode_count(extended_labels)],
+    }
+).set_index("Model")
+episodes
+
+# %%
+extended_episodes = episode_count(extended_labels)
+core_episodes = episode_count(core_labels)
+display(
+    Markdown(
+        f"The extended model splits {len(extended_df)} months into **{extended_episodes} "
+        f"episodes** from **{N_REGIMES} clusters**, against **{core_episodes}** for the core "
+        "model."
+    )
 )
 
 # %% [markdown]
-# ---
+# An extended model with as many episodes as clusters has assigned every month to the
+# cluster of its neighbours and never revisited an earlier one. It has partitioned the
+# calendar into consecutive eras. That is what the trending levels put into the panel - three
+# price indices, two GDP series, money stock, payrolls - and it is precisely the failure the
+# core panel avoided by taking a rate of change instead of a level. The silhouette score
+# rewards it, because consecutive eras of a trending panel are far apart in the space the
+# score measures distance in.
 #
-# # Comparison: 4 Indicators vs Extended Dataset
-#
-# How do results differ between the simple (4-indicator) and extended approaches?
+# The lesson generalises past this dataset. A separation score answers "are these groups far
+# apart", and a regime model has to answer "would this label have told me something the next
+# time conditions like these arrived". Nothing forces those two questions to have the same
+# answer, and a panel assembled without judgement is where they come apart.
 
 # %% [markdown]
-# ## Visual Comparison
+# ### The two partitions, drawn
 #
-# Side-by-side heatmaps showing regime probabilities from both approaches.
+# Assignment probabilities from both mixtures over the same months. Darker means the model
+# was more confident the month belonged to that cluster.
+
 
 # %%
-# Create side-by-side comparison (if both datasets available)
-if len(macro_probs) > 0 and len(gmm_probs_full) > 0:
-    fig, axes = plt.subplots(2, 1, figsize=(14, 6))
-
-    # Panel 1: Core 4 indicators
-    ax1 = axes[0]
-    im1 = ax1.imshow(macro_probs.T, aspect="auto", cmap="Blues", vmin=0, vmax=1)
-    years_core = [pd.Timestamp(ts).year for ts in macro_df.index]
-    year_ticks_core = [j for j, y in enumerate(years_core) if j == 0 or years_core[j - 1] != y]
-    year_labels_core = [str(years_core[j]) for j in year_ticks_core]
-    ax1.set_xticks(year_ticks_core[::2])
-    ax1.set_xticklabels(year_labels_core[::2], fontsize=8)
-    ax1.set_yticks(range(n_macro_regimes))
-    ax1.set_yticklabels([f"Regime {i + 1}" for i in range(n_macro_regimes)])
-    ax1.set_title(f"Core 4 Indicators (Silhouette: {macro_silhouette:.3f})", fontsize=11)
-
-    # Panel 2: Extended dataset
-    ax2 = axes[1]
-    im2 = ax2.imshow(gmm_probs_full.T, aspect="auto", cmap="Blues", vmin=0, vmax=1)
-    years_ext = macro_data_full.index.year.tolist()
-    year_ticks_ext = [j for j, y in enumerate(years_ext) if j == 0 or years_ext[j - 1] != y]
-    year_labels_ext = [str(years_ext[j]) for j in year_ticks_ext]
-    ax2.set_xticks(year_ticks_ext[::2])
-    ax2.set_xticklabels(year_labels_ext[::2], fontsize=8)
-    ax2.set_yticks(range(n_regimes_full))
-    ax2.set_yticklabels([f"Regime {i + 1}" for i in range(n_regimes_full)])
-    ax2.set_xlabel("Year")
-    ext_sil = silhouette_score(macro_data_full, gmm_labels_full)
-    ax2.set_title(
-        f"Extended {macro_data_full.shape[1]} Indicators (Silhouette: {ext_sil:.3f})", fontsize=11
+def plot_assignment_heatmap(probabilities: np.ndarray, dates: pd.DatetimeIndex, claim: str) -> None:
+    """Draw per-month cluster assignment probabilities as a heatmap."""
+    fig, ax = plt.subplots(figsize=style.FIGSIZE["single_wide"])
+    image = ax.imshow(probabilities.T, aspect="auto", cmap="Blues", vmin=0, vmax=1)
+    positions, labels = year_ticks(dates, every=4)
+    ax.set_xticks(positions)
+    ax.set_xticklabels(labels)
+    ax.set_yticks(range(probabilities.shape[1]))
+    ax.set_yticklabels([f"Cluster {i}" for i in range(probabilities.shape[1])])
+    ax.set_xlabel("Year")
+    fig.colorbar(image, ax=ax, shrink=0.8, label="Assignment probability")
+    style.add_message_title(ax, claim)
+    style.show_with_alt(
+        fig,
+        "A heatmap with one row per cluster and one column per month, shaded by assignment "
+        "probability.",
     )
 
-    fig.suptitle(
-        "GMM Regime Comparison: Core vs Extended Indicators", fontsize=12, fontweight="bold"
-    )
-    plt.show()
-else:
-    print("Comparison visualization skipped - insufficient data")
-
-# %% [markdown]
-# ## Quantitative Comparison
 
 # %%
-core_sil = macro_silhouette if len(macro_df) > 0 else float("nan")
-extended_sil = silhouette_score(macro_data_full, gmm_labels_full)
-pca_sil = silhouette_score(reduced, pca_labels)
+plot_assignment_heatmap(
+    core_probabilities, macro_df.index, "The core model returns to conditions it has seen before"
+)
 
-silhouette_compare = pd.DataFrame(
-    {
-        "Model": [
-            "Core (4 indicators)",
-            f"Extended ({macro_data_full.shape[1]} indicators)",
-            "Extended + PCA",
-        ],
-        "Silhouette": [core_sil, extended_sil, pca_sil],
-    }
-).set_index("Model")
-
-if core_sil > extended_sil:
-    interpretation = "Core 4 indicators provide cleaner separation; additional series add noise."
-else:
-    interpretation = (
-        "Extended indicators provide better separation; the broader panel captures "
-        "meaningful economic variation despite added noise."
-    )
-print(interpretation)
-silhouette_compare.style.format("{:.3f}")
+# %%
+plot_assignment_heatmap(
+    extended_probabilities, extended_df.index, "The extended model never returns to a cluster"
+)
 
 # %% [markdown]
-# ## Key Takeaways
+# ## Clustering the indicators rather than the months
 #
-# - **Macro indicators line up with realised volatility**: The four regimes' mean
-#   annualised volatility runs from 12.0% (Expansion, 77 months) to 16.0% (Crisis,
-#   4 months), with Tightening at 15.0% and Recovery at 15.2%. The Crisis cell
-#   covers only 4 months on this 2003-2026 panel, so the 16.0% figure is an
-#   anecdotal upper bound rather than a regime-level statistic.
-# - **Extended indicators improve cluster quality**: The 25-indicator model achieves
-#   higher silhouette (0.42) than the 4-indicator model (0.25), but the core model
-#   is more interpretable — the trade-off depends on the use case.
-# - **Hierarchical structure is genuine**: A cophenetic correlation of 0.71, above the
-#   0.7 quality bar, means the dendrogram faithfully represents the indicator distance
-#   structure rather than imposing an arbitrary tree.
-# - **Use rates, not levels**: We use CPI year-over-year change rather than the CPI level,
-#   because clustering on a trending level would capture "early vs late" rather than
-#   "inflationary vs non-inflationary."
-# - **GMM vs K-Means**: Similar performance (silhouette 0.42 vs 0.45), but GMM provides
-#   probability assignments that quantify regime uncertainty.
+# Everything so far has grouped months. The same machinery can group the columns instead,
+# which answers a different question: which indicators carry the same information? Ward
+# linkage builds a tree by repeatedly merging the two groups whose merger adds least to the
+# within-group variance.
 #
-# **Book reference**: §1.4 of Chapter 1 frames these regimes as inputs to risk
-# management — exposure caps, hedging triggers, and de-risking rules — rather than
-# as return forecasts. Figure 1.6 in the chapter is the macro-regime panel rendered
-# above.
+# The **cophenetic correlation** measures how well such a tree preserves the distances it was
+# built from. For each pair of items it reads the height at which the tree first joins them,
+# and correlates those heights against the original pairwise distances. A tree that scores
+# near one is a faithful summary of the distance matrix; one that scores low has imposed a
+# hierarchy the data does not have.
+#
+# Two trees are built below and they answer different questions, so their cophenetic
+# correlations are not interchangeable. The first is over the columns and is what the block
+# structure in the figure refers to. The second is over the months.
+
+# %%
+column_distances = pdist(extended_df.T)
+column_linkage = linkage(column_distances, method="ward")
+column_cophenetic, _ = cophenet(column_linkage, column_distances)
+
+month_distances = pdist(extended_df)
+month_linkage = linkage(month_distances, method="ward")
+month_cophenetic, _ = cophenet(month_linkage, month_distances)
+
+display(
+    Markdown(
+        f"Cophenetic correlation is **{column_cophenetic:.2f}** for the tree over the "
+        f"indicators and **{month_cophenetic:.2f}** for the tree over the months, against a "
+        f"conventional bar of {MIN_COPHENETIC}."
+    )
+)
+
+# %%
+fig, ax = plt.subplots(figsize=style.FIGSIZE["single_tall"])
+dendrogram(
+    column_linkage,
+    labels=extended_df.columns.tolist(),
+    orientation="right",
+    ax=ax,
+    color_threshold=0,
+    link_color_func=lambda _: COLORS["neutral"],
+)
+ax.set_xlabel("Ward linkage distance")
+ax.tick_params(axis="y", labelsize=6)
+style.add_message_title(
+    ax,
+    "The two names for the same spread merge first, at zero distance",
+    subtitle="Ward linkage over the standardized indicator columns",
+)
+style.show_with_alt(
+    fig,
+    "A horizontal dendrogram of the panel's columns. One pair joins at the left edge with "
+    "no visible branch length; the Treasury maturities and the trending level series form "
+    "two further groups, and the VIX and initial claims stand apart until the last merge.",
+)
+
+# %%
+first_merge_distance = float(column_linkage[0, 2])
+merged_first = [extended_df.columns[int(i)] for i in column_linkage[0, :2]]
+display(
+    Markdown(
+        f"The first merge the tree makes is `{merged_first[0]}` with `{merged_first[1]}`, at "
+        f"a distance of **{first_merge_distance:.1e}**."
+    )
+)
+
+# %% [markdown]
+# A merge at zero distance is two copies of one column, and the tree finds it before it
+# considers anything else. Above that the panel resolves into groups a reader can name: the
+# series that only trend, the short and medium Treasury yields, the curve-shape series
+# alongside unemployment, and - joining last, at the greatest distance - the VIX and initial
+# jobless claims. That last pair is the only part of the panel that moves on the timescale a
+# crisis moves on, which is why the principal components leave it until third and fourth
+# place while spending the first two on trend and on the level of long rates.
+#
+# What the tree does not do is choose the panel. It says which columns duplicate each other;
+# which of a duplicated pair to keep is decided on grounds the data cannot supply - what the
+# column means, and whether it is published in time to be read when a decision has to be
+# made.
+
+# %% [markdown]
+# ## Key takeaways
+#
+# - **Level or rate is the first decision, not a preprocessing detail.** A trending column
+#   entering a clustering makes elapsed time the dominant direction of variance, and the
+#   partition that comes back is a partition of the calendar wearing economic names.
+# - **A separation score is not a validation.** Silhouette answers whether the groups are far
+#   apart in the space they were fitted in. Whether the groups mean anything is a separate
+#   question, and counting episodes - does the model ever return to a cluster? - is a cheap
+#   way to ask it.
+# - **More series is not more information.** Nine Treasury maturities, a spread stored twice,
+#   and two GDP measures are one panel with a few directions in it, which principal components
+#   and the linkage tree both report directly.
+# - **Attaching names to clusters is an assertion.** The mixture supplies a partition; every
+#   economic name in this notebook comes from a threshold rule written by hand, and a
+#   different rule would rename the same partition.
+# - **Validate a regime model against something it never saw.** These regimes were fitted
+#   without any market data, so equity volatility and drawdown are an independent check, and
+#   the check is what surfaced a cluster too small to support the name it was given.
+#
+# **Known limitations.** FRED serves revised values, so no number here was available on the
+# date it is attached to; the mixture has no transition structure and no notion of time, so
+# nothing prefers a month to keep its neighbour's label; the panel starts in 2002 and holds
+# one severe recession, one pandemic and one inflation episode, which is not enough
+# repetitions of any condition to estimate how often it recurs; and the naming rule's
+# thresholds were set for the post-2002 US economy and would not transfer to another country
+# or another era.
+#
+# **Next**: Chapter 1 closes on what a research process needs to survive changes like these.
+# Walk-forward estimation, which is what turns a descriptive regime label into one a strategy
+# could act on, is introduced from Chapter 6.

--- a/01_process_is_edge/macro_regimes.py
+++ b/01_process_is_edge/macro_regimes.py
@@ -42,10 +42,12 @@
 #   than as a level, and recognise the failure that follows from ignoring it.
 # - Attach economic names to unnamed clusters through a stated rule, and say what the rule
 #   assumes.
-# - Check estimated regimes against realized equity volatility and drawdown, and read the
-#   result including the case where a regime holds too few months to support a claim.
+# - Check estimated regimes against realized equity volatility and drawdown - evidence the
+#   clustering never saw - and say which half of that check passed.
 # - Judge a clustering by whether it recovers recurring conditions rather than by its
 #   separation score, and show why the two can point in opposite directions.
+# - Measure how much of a partition is left after a different random start or a slightly
+#   shorter sample, and report that beside the result rather than instead of it.
 #
 # ## Book reference
 #
@@ -88,7 +90,7 @@ from scipy.cluster.hierarchy import cophenet, dendrogram, linkage
 from scipy.spatial.distance import pdist
 from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
-from sklearn.metrics import silhouette_score
+from sklearn.metrics import adjusted_rand_score, silhouette_score
 from sklearn.mixture import GaussianMixture
 from sklearn.preprocessing import StandardScaler, scale
 
@@ -202,15 +204,30 @@ CORE_SERIES = ["unrate", "dff", "t10y2y", "cpiaucsl"]
 #
 # `group_by_dynamic` cuts the daily frame into calendar months and `last()` takes the final
 # observation inside each. Labelling each window by its right edge is what keeps the panel
-# honest: the window covering January is stamped 1 February, so the row carries only
+# honest: the window covering January is stamped 1 February, so the row can only contain
 # observations from January and nothing dated later reaches it.
+#
+# That stamp is then stepped back a day, onto the last day of the month the row actually
+# describes. Without it every date in the notebook is a month late - the row holding
+# April's unemployment rate reads as May - and a figure axis, a printed date and the arrays
+# handed to the book build would all inherit the error.
+
+
+# %%
+def to_monthly(frame: pl.DataFrame, columns: list[str]) -> pl.DataFrame:
+    """Last observation of each calendar month, stamped on the month it describes."""
+    return (
+        frame.select([DATE_COL, *columns])
+        .sort(DATE_COL)
+        .group_by_dynamic(DATE_COL, every="1mo", label="right")
+        .agg([pl.col(c).last() for c in columns])
+        .with_columns(pl.col(DATE_COL).dt.offset_by("-1d"))
+    )
+
 
 # %%
 macro_monthly = (
-    macro_raw.select([DATE_COL, *CORE_SERIES])
-    .sort(DATE_COL)
-    .group_by_dynamic(DATE_COL, every="1mo", label="right")
-    .agg([pl.col(c).last() for c in CORE_SERIES])
+    to_monthly(macro_raw, CORE_SERIES)
     .drop_nulls(subset=CORE_SERIES)
     .filter(pl.col(DATE_COL) >= PANEL_START)
 )
@@ -230,9 +247,9 @@ print(f"Covering {macro_monthly[DATE_COL].min():%Y-%m} to {macro_monthly[DATE_CO
 # panel, which is why the panel starts a year after `PANEL_START`.
 #
 # The other three series are already rates and need no such treatment. All four are then
-# standardized, so that unemployment measured in percentage points and the yield spread
-# measured in the same unit but with a quarter of the spread contribute comparably to the
-# distances the clustering works on.
+# standardized. They share a unit - percentage points - but not a range: unemployment moves
+# over several points across a cycle while the yield spread moves over a fraction of one, so
+# without standardizing, the distances would be mostly unemployment.
 
 # %%
 macro_df = macro_monthly.select(CORE_SERIES).to_pandas()
@@ -249,10 +266,12 @@ print(f"Clustering panel: {len(macro_df)} months, {PANEL_FIRST_YEAR} to {PANEL_L
 # %% [markdown]
 # ### The four series before anything is fitted
 #
-# The table reports each series in its own units over the clustering panel. Read the spread
-# between the quartiles against the range: the policy rate spans the whole distance from the
-# zero bound to above five percent, and the unemployment rate is tight around its median
-# with one extreme excursion. Those shapes are what the mixture is about to partition.
+# The table reports each series in its own units over the clustering panel. Read each
+# quartile spread against its own minimum and maximum: the policy rate covers the whole
+# distance from the zero bound to the peak of a tightening cycle, while the unemployment
+# rate sits tight around its median and then makes one excursion far outside it. Those
+# shapes are what the mixture is about to partition, and the second one is why a cluster
+# ends up holding very few months.
 
 # %%
 UNITS = {
@@ -298,17 +317,21 @@ cluster_means.rename(columns=UNITS).style.format("{:.2f}")
 # %% [markdown]
 # ### Naming the clusters
 #
-# A cluster number is not a regime name, and the names have to come from somewhere the
-# model cannot supply. The rule below reads each cluster's average indicators and applies
-# the first description that fits, in a fixed order. Both the ordering and the thresholds
-# are judgements about the post-2002 US economy, chosen so that each name means what a
-# reader expects: high unemployment is a crisis whatever the rate environment; high
-# unemployment with the policy rate at the floor is the aftermath rather than the crisis
-# itself; a high policy rate with a flat curve is a tightening cycle.
+# A cluster number is not a regime name, and the names have to come from somewhere the model
+# cannot supply. The rule below reads each cluster's average indicators and applies the first
+# description that fits, in a fixed order. Both the ordering and the thresholds are
+# judgements about the post-2002 US economy, chosen so each name means what a reader expects:
+# unemployment above ten percent is a crisis whatever the rate environment; high unemployment
+# with the policy rate at the floor is the aftermath rather than the crisis itself; a high
+# policy rate with a flat curve is a tightening cycle.
 #
-# The rule is stated in one place so that it can be argued with. A different reader would
-# set different thresholds and get different names over the same partition, and that is the
-# honest situation: the clustering is estimated, the naming is asserted.
+# Not every branch has to fire. Which names come out depends on which clusters the mixture
+# found, and the table below is where to see what this fit produced rather than what the rule
+# can produce.
+#
+# The rule is written in one place so that it can be argued with. A different reader would set
+# different thresholds and get different names over the same partition, and that is the honest
+# situation: the clustering is estimated, the naming is asserted.
 
 
 # %%
@@ -354,9 +377,9 @@ pd.DataFrame(
 # returns should behave differently inside them, and the difference should be in the
 # direction economic reasoning predicts.
 #
-# The S&P 500 daily series is resampled to month-end closes and aligned to the macro panel.
-# The macro rows are stamped at the right edge of the month they summarise, so the nearest
-# month-end close within five days is the close of the month whose data the row carries.
+# The S&P 500 daily series is resampled to month-end closes and joined to the macro panel on
+# the date. Both are now stamped on the last day of the month they describe, so the join is
+# exact and each macro row meets the close of the month whose conditions it reports.
 
 # %%
 sp500 = load_sp500_index().to_pandas()
@@ -366,9 +389,9 @@ sp500 = sp500.set_index(DATE_COL)
 sp500_monthly = sp500["close"].resample("ME").last().to_frame()
 sp500_monthly["returns"] = sp500_monthly["close"].pct_change()
 
-aligned = sp500_monthly.reindex(macro_df.index, method="nearest", tolerance=pd.Timedelta("5D"))
+aligned = sp500_monthly.reindex(macro_df.index)
 if aligned["close"].isna().any():
-    raise ValueError("A macro month found no S&P 500 close within five days")
+    raise ValueError("A macro month found no S&P 500 close on the same month-end")
 
 print(f"Aligned {len(aligned)} months of S&P 500 closes to the macro panel")
 
@@ -383,8 +406,9 @@ print(f"Aligned {len(aligned)} months of S&P 500 closes to the macro panel")
 # computed over the whole index, in calendar order, and each month's decline from that peak
 # is measured; the number reported for a regime is the deepest such decline observed in one
 # of its months. It is therefore the worst point of the index reached while conditions were
-# in that regime, not the drawdown of a portfolio held only during it. A regime that occupies
-# few months can miss a trough that fell just outside it, and one does below.
+# in that regime, not the drawdown of a portfolio held only during it. Where the deepest
+# reading lands is therefore a fact about which regime was in force when the index bottomed,
+# and that is the fact worth reading off the table.
 
 # %%
 aligned["regime"] = regime_name.to_numpy()
@@ -553,27 +577,109 @@ display(
 )
 
 # %% [markdown]
-# The two lines above are the check earning its place, and both of them cut against the
-# regime story rather than for it.
+# The volatility ordering is economically legible: a tightening cycle is a calm market with an
+# expensive policy rate, and the two regimes with an unusual price level or an unusual
+# unemployment rate are the volatile ones. That is the check passing. Nothing about the
+# clustering forced it, because the clustering never saw a return.
 #
-# The cluster the rule names Crisis is the handful of months in which unemployment averaged
-# above ten percent, and by the time unemployment reached that level the equity market had
-# already fallen and turned. The market's own worst point lands in a different cluster
-# entirely - one whose name, assigned from the policy rate and the unemployment rate, reads
-# as the aftermath. Neither name is a mistake in the rule; both are the same fact about the
-# data, which is that the labour market registers a shock the market has already priced.
+# The drawdown column is where the check bites. It does not follow the volatility order, and
+# the regime holding the deepest decline is the one the rule names for the aftermath of a
+# crisis - high unemployment with the policy rate on the floor. That combination is what a
+# central bank produces in response to a crash, so the label arrives with the crash rather
+# than before it. The regime a risk report would most want warning of is the one this model
+# can only confirm.
 #
-# A statistic computed on four months is an anecdote whatever it says, and the volatility
-# spread across the four regimes is a few percentage points. Regimes estimated from
-# macroeconomic conditions do separate equity volatility, and they separate it weakly. A
-# reader should hold that conclusion at the strength these numbers support rather than at the
-# strength the idea invites, and the notebook has to report the small cell rather than
-# quietly drop it for being small.
+# That is the shape of what macro regimes are for, and it follows from what the inputs are.
+# Unemployment is measured over a month and published in the next; the policy rate moves in
+# response to conditions the market has already priced. A label built from them describes the
+# environment a portfolio is in. Section 1.4 argues for exactly that use - connecting an
+# identified environment to a predefined risk action - and against reading it as a forecast.
+
+# %% [markdown]
+# ### How much of this partition would survive a small change?
 #
-# The lag is structural, not a property of this sample. Unemployment is measured over a month
-# and published in the next; prices move on expectations of the same conditions. Macro
-# regimes are therefore evidence about the environment a portfolio is already in, not a
-# signal about the one it is heading into, which is the use Section 1.4 argues for.
+# Everything above describes one fit. Before any of it is written down, it is worth asking how
+# much of it is a property of the data and how much is a property of this particular run.
+#
+# Two perturbations, neither of which changes what the data says. The first refits from a
+# different random start, which a mixture is entitled to answer differently because
+# expectation-maximization climbs to a local optimum. The second drops the first few months of
+# the panel, which is the kind of choice made once and never revisited - a start date is a
+# judgement about coverage, not a measurement.
+#
+# Agreement between two partitions is measured by the **adjusted Rand index**: the share of
+# month pairs that two partitions agree about - either together in both, or separated in both -
+# rescaled so that a random relabelling scores zero and an identical partition scores one. It
+# does not care how the clusters are numbered, which is what makes it usable here.
+
+
+# %%
+def refit(data: np.ndarray, seed: int) -> np.ndarray:
+    """Fit the core mixture to *data* from one random start and return its labels."""
+    return (
+        GaussianMixture(
+            n_components=N_REGIMES,
+            covariance_type="full",
+            random_state=seed,
+            n_init=10,
+            reg_covar=1e-6,
+        )
+        .fit(data)
+        .predict(data)
+    )
+
+
+# %%
+perturbations = []
+for seed in (0, 7, 123, 2024):
+    labels = refit(macro_scaled, seed)
+    perturbations.append(
+        {
+            "Change": f"random start {seed}",
+            "Agreement with the fit above": adjusted_rand_score(core_labels, labels),
+            "Silhouette": silhouette_score(macro_scaled, labels),
+            "Smallest cluster (months)": int(np.bincount(labels).min()),
+        }
+    )
+for dropped in (1, 3, 6, 12):
+    labels = refit(macro_scaled[dropped:], SEED)
+    perturbations.append(
+        {
+            "Change": f"drop first {dropped} months",
+            "Agreement with the fit above": adjusted_rand_score(core_labels[dropped:], labels),
+            "Silhouette": silhouette_score(macro_scaled[dropped:], labels),
+            "Smallest cluster (months)": int(np.bincount(labels).min()),
+        }
+    )
+stability = pd.DataFrame(perturbations).set_index("Change")
+stability.style.format({"Agreement with the fit above": "{:.2f}", "Silhouette": "{:.3f}"})
+
+# %%
+worst_agreement = float(stability["Agreement with the fit above"].min())
+smallest_ever = int(stability["Smallest cluster (months)"].min())
+display(
+    Markdown(
+        f"The least agreement any perturbation reaches is **{worst_agreement:.2f}**, and the "
+        f"smallest cluster any of them produces holds **{smallest_ever} months** against "
+        f"**{int(np.bincount(core_labels).min())}** in the fit above."
+    )
+)
+
+# %% [markdown]
+# None of these partitions is wrong. They are answers to the same question from starts the
+# data does not distinguish between, and they disagree about a meaningful share of the months.
+# Some of them split off a cluster small enough that the naming rule reaches a different
+# branch, so the same panel comes back with a different set of regime names.
+#
+# The response is not to pick the fit whose names read best. It is to say what was fitted, on
+# what window, from which start, and to publish the perturbation table beside the result, so
+# that a reader can see how much of the story is load-bearing. Anything downstream that would
+# break under an agreement of this size is not supported by this model, whatever the figure
+# looks like.
+#
+# This is the chapter's argument arriving in one table. The model is ordinary and takes four
+# lines to fit; what separates a usable result from an anecdote is the check that comes after
+# it, and the discipline to report the check when it is unflattering.
 
 # %% [markdown]
 # ### Figure 1.6 inputs
@@ -672,12 +778,7 @@ style.show_with_alt(
 
 # %%
 value_columns = [c for c in macro_raw.columns if c != DATE_COL]
-monthly_full = (
-    macro_raw.sort(DATE_COL)
-    .group_by_dynamic(DATE_COL, every="1mo", label="right")
-    .agg([pl.col(c).last() for c in value_columns])
-    .filter(pl.col(DATE_COL) >= PANEL_START)
-)
+monthly_full = to_monthly(macro_raw, value_columns).filter(pl.col(DATE_COL) >= PANEL_START)
 
 missing_share = {
     column: monthly_full.select(pl.col(column).is_null().sum()).item() / monthly_full.height
@@ -688,13 +789,19 @@ kept_columns = [c for c, share in missing_share.items() if share <= MAX_MISSING_
 extended_pl = monthly_full.select([DATE_COL, *kept_columns]).drop_nulls()
 extended_df = extended_pl.select(kept_columns).to_pandas()
 extended_df.index = pd.DatetimeIndex(extended_pl[DATE_COL].to_pandas())
-extended_df = extended_df.apply(scale)
+
+# Hold both models to the same months. Left alone the two panels start a month apart - the
+# core one waits twelve months for the year-over-year change, this one waits for the Fed
+# balance sheet to begin - and every comparison below would then be partly about the window.
+extended_df = extended_df.loc[extended_df.index.intersection(macro_df.index)].apply(scale)
+if not extended_df.index.equals(macro_df.index):
+    raise ValueError("The extended panel does not cover the same months as the core panel")
 
 display(
     Markdown(
         f"The coverage filter keeps **{len(kept_columns)} of {len(value_columns)}** series, "
-        f"and dropping the months in which any of them is unquoted leaves "
-        f"**{len(extended_df)} months**, the same window as the core panel."
+        f"and holding them to the core panel's months leaves **{len(extended_df)} months** "
+        "across both models."
     )
 )
 
@@ -867,6 +974,12 @@ def episode_count(labels: np.ndarray) -> int:
     return int(np.sum(np.diff(labels) != 0)) + 1
 
 
+def revisited_clusters(labels: np.ndarray) -> int:
+    """How many clusters the model returns to after having left them."""
+    starts = [labels[0], *labels[1:][np.diff(labels) != 0]]
+    return sum(1 for cluster in set(starts) if starts.count(cluster) > 1)
+
+
 episodes = pd.DataFrame(
     {
         "Model": [
@@ -875,6 +988,10 @@ episodes = pd.DataFrame(
         ],
         "Clusters": [N_REGIMES, N_REGIMES],
         "Episodes": [episode_count(core_labels), episode_count(extended_labels)],
+        "Clusters revisited": [
+            revisited_clusters(core_labels),
+            revisited_clusters(extended_labels),
+        ],
     }
 ).set_index("Model")
 episodes
@@ -885,15 +1002,18 @@ core_episodes = episode_count(core_labels)
 display(
     Markdown(
         f"The extended model splits {len(extended_df)} months into **{extended_episodes} "
-        f"episodes** from **{N_REGIMES} clusters**, against **{core_episodes}** for the core "
-        "model."
+        f"episodes** from **{N_REGIMES} clusters**, returning to "
+        f"**{revisited_clusters(extended_labels)}** of them, against "
+        f"**{core_episodes} episodes** and "
+        f"**{revisited_clusters(core_labels)}** revisited for the core model."
     )
 )
 
 # %% [markdown]
-# An extended model with as many episodes as clusters has assigned every month to the
-# cluster of its neighbours and never revisited an earlier one. It has partitioned the
-# calendar into consecutive eras. That is what the trending levels put into the panel - three
+# A model with as many episodes as clusters and none of them revisited has assigned every
+# month to the cluster of its neighbours and never returned to a condition it had left. It has
+# partitioned the calendar into consecutive eras. The core model does return, which is what
+# lets it call the 2008 aftermath and the 2020 aftermath the same thing. That is what the trending levels put into the panel - three
 # price indices, two GDP series, money stock, payrolls - and it is precisely the failure the
 # core panel avoided by taking a rate of change instead of a level. The silhouette score
 # rewards it, because consecutive eras of a trending panel are far apart in the space the
@@ -1038,19 +1158,25 @@ display(
 #   and two GDP measures are one panel with a few directions in it, which principal components
 #   and the linkage tree both report directly.
 # - **Attaching names to clusters is an assertion.** The mixture supplies a partition; every
-#   economic name in this notebook comes from a threshold rule written by hand, and a
-#   different rule would rename the same partition.
+#   economic name here comes from a threshold rule written by hand, and a different rule would
+#   rename the same partition.
 # - **Validate a regime model against something it never saw.** These regimes were fitted
-#   without any market data, so equity volatility and drawdown are an independent check, and
-#   the check is what surfaced a cluster too small to support the name it was given.
+#   without any market data, so equity volatility and drawdown are an independent check. Half
+#   of it passed - the volatility ordering is economically legible - and half of it did not:
+#   the deepest drawdown sits in the regime named for a crisis already under way.
+# - **Perturb the fit before you write about it.** A different random start, or a sample three
+#   months shorter, moves this partition enough to change which names the rule assigns. Report
+#   that alongside the result; a story the perturbation table takes apart was never supported
+#   by the data.
 #
 # **Known limitations.** FRED serves revised values, so no number here was available on the
-# date it is attached to; the mixture has no transition structure and no notion of time, so
-# nothing prefers a month to keep its neighbour's label; the panel starts in 2002 and holds
-# one severe recession, one pandemic and one inflation episode, which is not enough
-# repetitions of any condition to estimate how often it recurs; and the naming rule's
-# thresholds were set for the post-2002 US economy and would not transfer to another country
-# or another era.
+# date it is attached to. The mixture has no transition structure and no notion of time, so
+# nothing prefers a month to keep its neighbour's label; the long episodes here come from the
+# indicators moving slowly, not from the model. The panel starts in 2002 and holds one severe
+# recession, one pandemic and one inflation episode, which is too few repetitions of any
+# condition to say how often it recurs - and it is the direct cause of the instability the
+# perturbation table reports. The naming rule's thresholds were set for the post-2002 US
+# economy and would not transfer to another country or another era.
 #
 # **Next**: Chapter 1 closes on what a research process needs to survive changes like these.
 # Walk-forward estimation, which is what turns a descriptive regime label into one a strategy

--- a/01_process_is_edge/macro_regimes.py
+++ b/01_process_is_edge/macro_regimes.py
@@ -169,14 +169,22 @@ print(f"Covering {macro_raw[DATE_COL].min():%Y-%m-%d} to {macro_raw[DATE_COL].ma
 
 # %%
 metadata = load_macro_metadata().to_pandas().set_index("series")
-inventory = metadata.loc[
-    [c for c in macro_raw.columns if c != DATE_COL], ["description", "native_frequency", "formula"]
-].rename(
-    columns={
-        "description": "Series",
-        "native_frequency": "Published",
-        "formula": "Derived as",
-    }
+
+# Reindex rather than select: the metadata file is maintained beside the data file and can
+# fall behind it, and a column it does not describe should appear in this table saying so
+# rather than stopping the notebook or vanishing from it.
+inventory = (
+    metadata.reindex([c for c in macro_raw.columns if c != DATE_COL])[
+        ["description", "native_frequency", "formula"]
+    ]
+    .rename(
+        columns={
+            "description": "Series",
+            "native_frequency": "Published",
+            "formula": "Derived as",
+        }
+    )
+    .fillna({"Series": "not described in the metadata file", "Published": "unknown"})
 )
 inventory["Derived as"] = inventory["Derived as"].fillna("-")
 inventory.index.name = "Column"
@@ -200,6 +208,13 @@ inventory
 
 # %%
 CORE_SERIES = ["unrate", "dff", "t10y2y", "cpiaucsl"]
+
+missing = [c for c in CORE_SERIES if c not in macro_raw.columns]
+if missing:
+    raise ValueError(
+        f"The FRED panel is missing {missing}, which the core model is built on. "
+        "Re-run data/macro/download.py; data/macro/README.md lists what it fetches."
+    )
 
 # %% [markdown]
 # ### From daily rows to a monthly panel
@@ -816,23 +831,40 @@ display(
 # %% [markdown]
 # ### What the filter let through
 #
-# Nothing in that assembly asked what the columns are, and the metadata table at the top of
-# the notebook says what got in. Nine of the columns are Treasury yields at maturities from
-# one to thirty years, which move almost as one series. `YIELD_CURVE_SLOPE` is defined as the
-# ten-year yield minus the two-year, which is the definition of `t10y2y`, already in the
-# panel - the same spread enters twice under two names. Nominal and real GDP are both
-# present, published quarterly, so each repeats its value for three months at a time. And
-# three price indices enter as levels, which is the treatment the core panel rejected for one
-# of them.
+# Nothing in that assembly asked what the columns are, and the metadata table at the top of the
+# notebook says what got in: Treasury yields at maturities from one to thirty years, which move
+# almost as one series; a derived column whose formula is the ten-year yield minus the two-year,
+# which is the definition of a series already in the panel under its own name; nominal and real
+# GDP, published quarterly, so each repeats a value for three months at a time; and three price
+# indices entering as levels, which is the treatment the core panel rejected for one of them.
+#
+# Two of those are checkable without reading the metadata at all. Columns holding the same
+# series differ by nothing anywhere in the panel, and a series published quarterly and carried
+# forward to a monthly grid is unchanged from the previous month in two months out of three.
+
 
 # %%
-duplicate_check = (extended_df["t10y2y"] - extended_df["YIELD_CURVE_SLOPE"]).abs().max()
-gdp_distinct = int(extended_df["gdp"].round(6).nunique())
+def duplicate_pairs(frame: pd.DataFrame, tolerance: float = 1e-9) -> list[tuple[str, str]]:
+    """Column pairs that hold the same standardized series to within *tolerance*."""
+    columns = list(frame.columns)
+    return [
+        (a, b)
+        for i, a in enumerate(columns)
+        for b in columns[i + 1 :]
+        if float((frame[a] - frame[b]).abs().max()) < tolerance
+    ]
+
+
+# %%
+duplicates = duplicate_pairs(extended_df)
+carried_forward = (extended_df.diff() == 0).mean().sort_values(ascending=False)
+stalest = str(carried_forward.index[0])
 display(
     Markdown(
-        f"The largest gap between `t10y2y` and `YIELD_CURVE_SLOPE` anywhere in the panel is "
-        f"**{duplicate_check:.1e}** after standardization, and nominal GDP takes "
-        f"**{gdp_distinct} distinct values** across **{len(extended_df)} monthly rows**."
+        f"Comparing every pair of columns finds **{len(duplicates)}** holding the same "
+        f"standardized series: {', '.join(f'`{a}` and `{b}`' for a, b in duplicates) or 'none'}. "
+        f"The column that repeats itself most is `{stalest}`, unchanged from the month before "
+        f"in **{carried_forward.iloc[0]:.0%}** of the panel."
     )
 )
 

--- a/01_process_is_edge/macro_regimes.py
+++ b/01_process_is_edge/macro_regimes.py
@@ -16,7 +16,7 @@
 # %% [markdown]
 # # Macro-based regime detection
 #
-# **Chapter 1 · §1.4 Market Regimes: Change Is the Constant**
+# **Chapter 1 · §1.4 Keeping up with changing market regimes**
 #
 # **Docker image**: `ml4t`
 #
@@ -51,7 +51,7 @@
 #
 # ## Book reference
 #
-# Chapter 1, Section 1.4, "Market Regimes: Change Is the Constant". Figure 1.6 in the
+# Chapter 1, Section 1.4, "Keeping up with changing market regimes". Figure 1.6 in the
 # chapter is the regime-and-volatility panel drawn below.
 #
 # ## Prerequisites

--- a/01_process_is_edge/macro_regimes.py
+++ b/01_process_is_edge/macro_regimes.py
@@ -58,8 +58,10 @@
 #
 # - `factor_regimes`, which introduces Gaussian mixture models, the silhouette score, and
 #   why a model fitted on the whole sample describes rather than predicts.
-# - The FRED panel under `data/macro/` and the S&P 500 daily series under
-#   `data/equities/sp500/`.
+# - The FRED panel, which `load_macro` reads. It needs a `FRED_API_KEY` and one run of
+#   `uv run python data/macro/download.py`; `data/macro/README.md` covers both.
+# - Daily S&P 500 index closes, which `load_sp500_index` reads. This one ships with the
+#   repository and needs no download.
 #
 # ## A caveat that applies to every number below
 #


### PR DESCRIPTION
Chapter 1's two notebooks, `factor_regimes` and `macro_regimes`, taken through one fix pass
against `rules/notebook-standards.md`, reviewed until RoboRev was quiet, then executed and
committed with their outputs. Both close their completion issues.

## What was wrong

Both notebooks were accurate about the numbers they printed and wrong about several things
they said around them.

**`macro_regimes` described a dataset it does not have.** A hand-typed indicator table named
T10YIE, a high-yield spread and Case-Shiller; none of the three is in the FRED panel. The same
three series reappeared in the dendrogram reading and the extended-panel commentary. The
notebook also reported "~17 series after quality filtering" where the coverage filter drops
nothing and keeps 25. The table is now `load_macro_metadata()`, so the inventory is read rather
than asserted.

**`macro_regimes` credited a cophenetic correlation to the wrong tree.** The number came from a
Ward tree over the 277 months; the prose used it to certify the block structure of a different
tree over the columns. Both trees are now built and both correlations reported.

**Every date in `macro_regimes` was a month late.** `group_by_dynamic(label="right")` stamps
April's unemployment rate 1 May, and the notebook formatted those stamps as the month observed.
The aggregation now steps the stamp back onto the month it describes, in one helper both panels
use, and the S&P 500 join becomes an exact month-end match instead of nearest-within-five-days.

**`macro_regimes` concluded that the 25-series panel clusters better because its silhouette is
higher.** It partitions the sample into four consecutive time blocks and never revisits a
cluster, because nine of its columns are trending levels - the treatment the same notebook
rejects for CPI a hundred lines earlier. `YIELD_CURVE_SLOPE` is `t10y2y` under a second name and
the two merge at zero distance; nominal GDP takes 92 distinct values over 276 monthly rows. The
section now measures episodes and revisits beside the score, and teaches the disagreement.

**`factor_regimes` forward-filled factor returns.** The only nulls are six leading months of one
series, so the fill was inert. It is removed rather than left implying that a gap in a return
series can be carried forward. `macro_regimes` carried a forward and a backward fill, the
backward one with an acknowledged look-ahead; both are inert once the 2002 bound applies and
both are gone.

**Per-regime drawdown is a path statistic taken on a stream with its months removed.** Both
notebooks now say so. `factor_regimes` reads out the peak and trough that produce it - a 1986
high-water mark and a 2020 low, 34 years apart - and puts the index's own worst decline over the
same span beside it. The prose previously attributed that figure to the Great Depression.

## What the month correction exposed

Correcting the stamp moved the macro fit, and the difference is the substantive part of this
branch. The corrected panel is 276 months, January 2003 to December 2025; the four clusters are
Tightening, Recovery, Expansion and Inflation, and none reaches the naming rule's crisis branch.
Three of the four labels recur - the model calls the 2008 and 2020 aftermaths the same thing -
where the extended panel still produces four consecutive blocks and revisits none. The previous
"Crisis, four months, highest volatility" story was an artifact of the mislabelled month.

That raised the question of how much of any of it is a property of the data. Refitting from four
other random starts and from four shorter samples gives adjusted Rand indices of 0.73 to 0.82
against the fit shown, and some of those partitions split off a cluster small enough to reach a
different naming branch. The perturbation table is now a section of the notebook: a chapter
arguing that process is the edge should not present one local optimum as the answer.

## Standards

- **M2, re-ruled 2026-09-08.** Both notebooks called `warnings.filterwarnings("ignore")`.
  Measured with the filter removed, neither run emits a single warning, so nothing is suppressed
  in its place. The AQR provider's structlog output, which is what was actually reaching the
  page, is filtered at `WARNING` as chapters 02 and 17 already do.
- **N1/N2.** 54 prose violations to 0. Every result still in the text is interpolated from a
  bound value; the interpretation cells state how the method behaves rather than what one run
  produced.
- **N4.** Nine figure titles, all under 75 characters, none naming a computed value. Five claims
  were checked against the data and three did not survive - the extra clusters do not spare the
  crises, the risk-off months are not concentrated on the dated events, and the Treasury
  maturities do not merge first. Titles now say what was measured.
- **T6.** Five separate cluster-count timelines become one small-multiple panel; no code cell
  exceeds 40 lines.
- **T13.** Both notebooks now show the panel they run on - coverage, first month and scale per
  series - before anything computed from it.
- **Figures.** Raw hex, invented figsizes and per-call font sizes replaced by `utils.style`
  COLORS, FIGSIZE and `add_message_title`; every figure carries alt text.
- **C7.** `macro_regimes` states that FRED serves revised values and names
  `load_macro_initial_release` as what a strategy would have to read instead.

## One library call not made

C12 sends per-regime Sharpe to `ml4t.diagnostic.metrics.sharpe_ratio`, which agrees with the
hand computation to three decimals. `maximum_drawdown` from the same module is not used:
`calculate_drawdown_numba` subtracts the running peak instead of dividing by it, so it returns
-8223% where the correct figure is -76.9%. Filed as ml4t/agent-workspace#1100; no other notebook
in the corpus calls it, so nothing shipped is affected.

## Review and execution

Four RoboRev rounds. The first found missing line segments at every regime transition, the
month-stamp offset, and a drawdown explanation that described the wrong conditioning rule. The
second found the segment colours lagging by one month. The third was clean, and so was the
fourth over the execution commit.

Both notebooks executed from raw through `nb-run.sh`: exit 0, no error outputs, every
`execution_count` populated, provenance stamped. `factor_regimes` takes 87 s and peaks at
1.2 GB with five figures; `macro_regimes` 35 s and 0.9 GB with six.

Four defect shapes found by the chapter-21 pass were checked against both notebooks and none
applies: there is no simulator or impact model, no significance test attached to the paired
bars, no shortfall or notional, and every ratio here divides by a standard deviation or a
positive count rather than by a mean that could change sign.

The two completion issues this closes are tracked on the workspace repo, not here, and are
closed by hand after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4q8mQyPB8YuUsopZk8n4v
