### PR TITLE
Verify the candidate image before the tags move, and make the gate see subpackages

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -156,9 +156,121 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # The reader install gate, and it runs BEFORE the public tags move.
+  #
+  # `build-ml4t` pushes each arch by digest with no tag, so nothing a reader can
+  # pull has changed yet; `merge-ml4t` below is what points `:latest` at those
+  # digests. Verifying between the two is what makes this a gate rather than a
+  # detector - a failure here leaves `:latest` on the last image that passed.
+  #
+  # This exists because `smoke-ml4t` could not have prevented the outage it was
+  # meant to catch, twice over. It ran `envs/test_all_imports.py --scan`, which
+  # reduces every import to its top-level name (`envs/scan_imports.py:135,138`),
+  # so `from ml4t.live.brokers.ib import IBBroker` reached it as `ml4t` and
+  # importing `ml4t` never executed `ml4t/live/__init__.py`. And it runs after
+  # `merge-ml4t`, so even a check that saw the break would only have reported it
+  # once readers could already pull it. The image published on 2026-09-04 carried
+  # an `import ml4t.live` that raised on Python 3.14; every Chapter 25 notebook
+  # failed before its first cell, and this workflow was green on both arches.
+  #
+  # `scripts/verify_installation.py` is the same command `docs/installation.md`
+  # tells a Docker reader to run, so a published image is one that passed the
+  # reader's own check. `tests/test_publish_gate_sees_subpackages.py` fails if the
+  # two ever diverge, if this stops being a prerequisite of `merge-ml4t`, or if a
+  # new `ml4t.<sub>` enters the repository without entering the gate.
+  #
+  # Measured 2026-09-08 by reinstalling the defect into the published image:
+  # `--scan` exits 0, `verify_installation.py` exits 1 and names ml4t-live.
+  verify-ml4t:
+    needs: build-ml4t
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      # The candidate is ~13 GB and a default runner has nowhere near that free.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune -af
+          df -h /
+
+      - uses: actions/checkout@v6
+      # buildx for `imagetools inspect` in the resolution step below.
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Platform slug
+        id: slug
+        run: echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          platform: ${{ matrix.platform }}
+
+      - name: Download this arch's digest
+        uses: actions/download-artifact@v4
+        with:
+          name: ml4t-digest-${{ steps.slug.outputs.pair }}
+          path: /tmp/digest
+
+      # `build-ml4t` records the digest as an empty file named after it.
+      #
+      # What that digest points at depends on whether buildx attached a provenance
+      # attestation: with one, a push-by-digest build publishes an index holding the
+      # platform image plus an `unknown/unknown` attestation manifest; without, it is
+      # the image manifest itself. Resolving explicitly covers both, and turns "the
+      # reference did not resolve" into a failure here with a readable message
+      # instead of `unsupported media type application/vnd.oci.empty.v1+json` from
+      # `docker run` two steps later.
+      - name: Resolve the candidate
+        id: candidate
+        run: |
+          set -euo pipefail
+          files=(/tmp/digest/*)
+          test "${#files[@]}" -eq 1
+          ref="${{ env.ML4T_IMAGE }}@sha256:$(basename "${files[0]}")"
+
+          platform_digest=$(docker buildx imagetools inspect "$ref" --raw \
+            | jq -r --arg arch "${{ matrix.platform }}" '
+                if .manifests then
+                  (.manifests[]
+                    | select((.platform.os + "/" + .platform.architecture) == $arch)
+                    | .digest)
+                else empty end')
+
+          if [ -n "$platform_digest" ]; then
+            ref="${{ env.ML4T_IMAGE }}@${platform_digest}"
+          fi
+
+          echo "verifying $ref"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      # ML4T_DATA_PATH points inside the checkout rather than at /data, which is
+      # not mounted: the gate checks that the data root resolves, and the whole
+      # `utils` and `data` import surface fails behind it when it does not.
+      - name: Reader install gate (${{ matrix.platform }})
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/app:ro \
+            -e PYTHONPATH=/app \
+            -e ML4T_PATH=/app \
+            -e ML4T_DATA_PATH=/app/data \
+            ${{ steps.candidate.outputs.ref }} \
+            python /app/scripts/verify_installation.py
+
   merge-ml4t:
     runs-on: ubuntu-latest
-    needs: build-ml4t
+    needs: [build-ml4t, verify-ml4t]
 
     steps:
       - name: Download digests
@@ -214,6 +326,26 @@ jobs:
             -e ML4T_DATA_PATH=/data \
             ${{ env.ML4T_IMAGE }}:latest \
             python /app/envs/test_all_imports.py --scan
+
+      # The same command as the `verify-ml4t` gate above, and it is not the gate.
+      # That one runs on the candidate digest before the tags move and can stop a
+      # publish; this one runs on the manifest afterwards and can only report. It
+      # is here because the two answer different questions: `verify-ml4t` says the
+      # image is good, this says `:latest` resolves to it on this arch. A manifest
+      # assembled from the wrong digests would pass the first and fail this.
+      #
+      # ML4T_DATA_PATH points inside the checkout rather than at /data, which is not
+      # mounted here: the gate checks that the data root resolves, and the whole
+      # `utils` and `data` import surface fails behind it when it does not.
+      - name: Published manifest runs the reader gate (${{ matrix.arch }})
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/app:ro \
+            -e PYTHONPATH=/app \
+            -e ML4T_PATH=/app \
+            -e ML4T_DATA_PATH=/app/data \
+            ${{ env.ML4T_IMAGE }}:latest \
+            python /app/scripts/verify_installation.py
 
       - name: Computation smoke test (${{ matrix.arch }})
         run: |

--- a/scripts/verify_installation.py
+++ b/scripts/verify_installation.py
@@ -362,10 +362,16 @@ def check_storage():
 
 
 def check_ml4t_libraries():
+    # Every ``ml4t.<sub>`` the repository imports has to appear here, and
+    # tests/test_publish_gate_sees_subpackages.py fails when one does not.
+    # Nothing else looks at this granularity: the publish smoke test scans
+    # top-level names, so `from ml4t.live.brokers.ib import ...` reaches it as
+    # `ml4t`, and importing `ml4t` never executes `ml4t/live/__init__.py`.
     cat = "ML4T Libraries"
     check_import(cat, "ml4t.data", "ml4t-data")
     check_import(cat, "ml4t.diagnostic", "ml4t-diagnostic")
     check_import(cat, "ml4t.engineer", "ml4t-engineer")
+    check_import(cat, "ml4t.models", "ml4t-models")
     check_import(cat, "ml4t.backtest", "ml4t-backtest")
     check_import(cat, "ml4t.live", "ml4t-live")
 

--- a/tests/test_publish_gate_sees_subpackages.py
+++ b/tests/test_publish_gate_sees_subpackages.py
@@ -1,0 +1,188 @@
+"""The publish gate is the documented reader check, and it sees every ml4t subpackage.
+
+`docker-publish.yml`'s `smoke-ml4t` job is the last thing that runs before an image
+reaches Docker Hub. Until 2026-09-08 it ran only `envs/test_all_imports.py --scan`,
+which cannot see a broken subpackage: `envs/scan_imports.py` reduces every import to
+its top-level name, so `from ml4t.live.brokers.ib import IBBroker` arrives as `ml4t`,
+and importing `ml4t` never executes `ml4t/live/__init__.py`.
+
+That is not hypothetical. The image published on 2026-09-04 carried an
+`import ml4t.live` that raised `RuntimeError: There is no current event loop in
+thread 'MainThread'`; every Chapter 25 notebook failed before its first cell, and
+`docker compose run --rm ml4t python scripts/verify_installation.py` - the one
+PASS/FAIL command `docs/installation.md` names - exited 1 on a correct install.
+`smoke-ml4t` was green on both arches on every publish. Measured by reinstalling the
+defect into the published image: the scan step exits 0, `verify_installation.py`
+exits 1 and names `ml4t-live`.
+
+The fix was to run the documented reader check as the publish gate. Two things have
+to stay true for that to keep meaning anything, and neither is self-enforcing:
+
+1. The gate and the documented check are the same command. Left as a convention it
+   drifts, and the drift is invisible - both halves keep working, they just stop
+   being about each other.
+2. The gate names every `ml4t.<sub>` the repository imports. `ml4t.models` was
+   already missing when this was written, so the gate was blind to one of the six
+   before it ever ran in the publish job.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_DOC = REPO_ROOT / "docs" / "installation.md"
+PUBLISH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker-publish.yml"
+VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_installation.py"
+
+_SKIP_DIRS = {".venv", ".git", "node_modules", "__pycache__", ".ipynb_checkpoints", "build"}
+
+
+def _imported_ml4t_subpackages() -> set[str]:
+    """Every ``ml4t.<sub>`` the repository's Python actually imports, by AST.
+
+    A grep would also collect the ones that appear in prose - `24_autonomous_agents`
+    names a future `ml4t.agent` in a comment - and the gate would then be asked to
+    check a package nothing imports.
+    """
+    found: set[str] = set()
+    for path in REPO_ROOT.rglob("*.py"):
+        if any(part in _SKIP_DIRS for part in path.parts):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            names: list[str] = []
+            if isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            elif isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            for name in names:
+                parts = name.split(".")
+                if parts[0] == "ml4t" and len(parts) >= 2:
+                    found.add(f"ml4t.{parts[1]}")
+    return found
+
+
+def _gate_checked_subpackages() -> set[str]:
+    """What ``check_ml4t_libraries()`` asks for, recorded rather than imported.
+
+    Driving the real function is what keeps this from going stale against a
+    restatement of its contents; importing the packages for real would make a unit
+    test depend on the whole ml4t stack being installed.
+    """
+    spec = importlib.util.spec_from_file_location("_verify_installation", VERIFY_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    asked: list[str] = []
+    module.check_import = lambda category, import_name, label=None: asked.append(import_name)
+    module.check_from_import = lambda *a, **k: None
+    module.check_ml4t_libraries()
+
+    return {name for name in asked if name.startswith("ml4t.")}
+
+
+def _documented_docker_gate() -> str:
+    """The script `docs/installation.md` tells a Docker reader to run to verify."""
+    section = re.search(
+        r"^## Verify Your Installation\s*$(.*?)^## ", INSTALL_DOC.read_text(), re.M | re.S
+    )
+    assert section, "docs/installation.md no longer has a 'Verify Your Installation' section"
+
+    commands = re.findall(
+        r"docker compose run [^\n]*?\bml4t\b[^\n]*?\bpython\s+(\S+\.py)", section.group(1)
+    )
+    assert commands, (
+        f"that section names no `docker compose run ... python <script>`:\n{section.group(1)}"
+    )
+    return commands[0]
+
+
+def _jobs_publication_waits_for(workflow: dict, publishing_job: str = "merge-ml4t") -> set[str]:
+    """Every job that has to succeed before ``publishing_job`` runs, transitively.
+
+    `merge-ml4t` is where `:latest` and the version tag start pointing at the new
+    build. A check that is not upstream of it cannot stop a bad image reaching
+    readers, however loudly it fails.
+    """
+    jobs = workflow["jobs"]
+    upstream: set[str] = set()
+    frontier = [publishing_job]
+    while frontier:
+        name = frontier.pop()
+        needs = jobs.get(name, {}).get("needs", [])
+        if isinstance(needs, str):
+            needs = [needs]
+        for dependency in needs:
+            if dependency not in upstream:
+                upstream.add(dependency)
+                frontier.append(dependency)
+    return upstream
+
+
+def _scripts_run_by(workflow: dict, job_names: set[str]) -> set[str]:
+    """Every ``python <script>.py`` those jobs run inside a container."""
+    scripts: set[str] = set()
+    for name in job_names:
+        for step in workflow["jobs"].get(name, {}).get("steps", []):
+            scripts.update(re.findall(r"\bpython\s+(/app/\S+\.py)", step.get("run", "")))
+    return scripts
+
+
+def test_the_documented_reader_check_gates_publication():
+    """The gate has to run before the tags move, not after.
+
+    Verifying a published image is a detector: it goes red once readers can
+    already pull the break. `smoke-ml4t` needs `merge-ml4t`, so the check has to
+    live somewhere `merge-ml4t` waits for instead.
+    """
+    workflow = yaml.safe_load(PUBLISH_WORKFLOW.read_text())
+    documented = _documented_docker_gate()
+
+    # The doc names the script relative to the repo root; the workflow mounts that
+    # root at /app.
+    expected = f"/app/{documented.lstrip('./')}"
+
+    before_publish = _jobs_publication_waits_for(workflow)
+    gating = _scripts_run_by(workflow, before_publish)
+
+    assert expected in gating, (
+        f"docs/installation.md tells a Docker reader to run {documented!r} to verify the "
+        f"install, but no job merge-ml4t waits for runs it - only {sorted(gating)}. Running "
+        "it after merge-ml4t publishes `:latest` reports a broken image to a reader who can "
+        "already pull it."
+    )
+
+
+def test_gate_checks_every_ml4t_subpackage_the_repo_imports():
+    imported = _imported_ml4t_subpackages()
+    checked = _gate_checked_subpackages()
+
+    assert imported, "the AST scan found no ml4t.* imports at all, which cannot be right"
+
+    missing = sorted(imported - checked)
+    assert not missing, (
+        f"{VERIFY_SCRIPT.name} does not check {missing}, which the repository imports. "
+        "Nothing else looks at this granularity - the publish smoke test scans top-level "
+        "names - so a break in one of these reaches Docker Hub green."
+    )
+
+
+def test_gate_does_not_ask_for_subpackages_nothing_imports():
+    """The other direction, so the list stays a description rather than a wish."""
+    imported = _imported_ml4t_subpackages()
+    checked = _gate_checked_subpackages()
+
+    stale = sorted(checked - imported)
+    assert not stale, (
+        f"{VERIFY_SCRIPT.name} checks {stale}, which nothing in the repository imports. "
+        "Either an import was removed and the gate was not, or the name is wrong."
+    )


### PR DESCRIPTION
Closes ml4t/agent-workspace#1103.

`docker-publish.yml` had two independent reasons it could not have prevented the outage it exists to prevent.

## It could not see the break

`smoke-ml4t` ran only `envs/test_all_imports.py --scan`, and that scan reduces every import to its top-level name (`envs/scan_imports.py:135,138`). `from ml4t.live.brokers.ib import IBBroker` reaches it as `ml4t`, and importing `ml4t` never executes `ml4t/live/__init__.py`. Measured by reinstalling the defect into the published image:

```
uv pip install ib_insync==0.9.86          # the collision, back
python envs/test_all_imports.py --scan          -> exit 0
python scripts/verify_installation.py           -> exit 1, FAIL ml4t-live
```

The image published on 2026-09-04 carried exactly that break. Every Chapter 25 notebook failed before its first cell, `docker compose run --rm ml4t python scripts/verify_installation.py` exited 1 on a correct install, and this workflow was green on both arches on every publish.

## And it ran after publication

`smoke-ml4t` needs `merge-ml4t`, which is what points `:latest` and the version tag at the new build. A check there is a detector, not a gate: it goes red once readers can already pull the break. Caught in review (roborev #19439) on the first version of this PR, which added the check to `smoke-ml4t` and would have inherited the same flaw.

## What this does

A new `verify-ml4t` job sits between `build-ml4t` and `merge-ml4t`. `build-ml4t` pushes each arch by digest with no tag, so nothing a reader can pull has changed when it runs; `merge-ml4t` now needs `[build-ml4t, verify-ml4t]`, and a failure leaves `:latest` on the last image that passed. It runs `scripts/verify_installation.py` — the same command `docs/installation.md` tells a Docker reader to run — so a published image is one that passed the reader's own check.

Resolving the candidate is explicit rather than assumed. Depending on whether buildx attached a provenance attestation, a push-by-digest build's digest is either an index holding the platform image plus an `unknown/unknown` attestation manifest, or the image manifest itself. The step resolves through `imagetools inspect --raw` and uses the digest as-is when there is no index, so both shapes work and a reference that does not resolve fails there with a readable message rather than as `unsupported media type application/vnd.oci.empty.v1+json` from `docker run`. Both branches were exercised locally against the real `:latest` index and against a single platform manifest.

The step in `smoke-ml4t` stays, renamed, and is deliberately not the gate. It runs the same command on the manifest afterwards, answering a different question: that `:latest` resolves to the image that passed, on this arch. A manifest assembled from the wrong digests passes the first and fails this.

## Keeping it true

Running both today leaves the relationship between the gate and the documented check a convention, and a convention drifts invisibly — both halves keep working, they just stop being about each other. `tests/test_publish_gate_sees_subpackages.py` pins two invariants:

- The script the docs name as the Docker install gate is run by a job that `merge-ml4t` transitively waits for. It pins that they **agree** and that the gate **precedes publication**, so moving the gate is allowed and moving one half, or moving it downstream, is not.
- `verify_installation.py` names every `ml4t.<sub>` the repository imports, derived by AST from the tree rather than restated.

The second was already violated. The repository imports six subpackages — data, diagnostic, engineer, models, backtest, live — and the gate checked five. `ml4t.models` reaches it through four files including `case_studies/utils/latent_factors/ipca.py`. It imports clean in the published image today, so this closes a hole rather than a break.

## Verified

- Mutation-tested: five planted defects each caught by its own check — reverting `merge-ml4t` to `needs: build-ml4t` (roborev's finding), removing the gate step, moving the documented gate without moving the workflow, dropping `ml4t.models`, adding a package nothing imports. Moving the docs and the workflow together stays green, which is the intended reading of "they agree".
- The gate exits 0 against the published image addressed by per-platform digest (149/155, `ml4t-models` PASS) and on the uv path (150/155).

The scanner is left alone deliberately: collapsing to top level is right for `import numpy.linalg`, and the subpackage question belongs to the gate a reader also runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRbvPEVfdF9eSebTiX8vgM
