### PR TITLE
Score a prediction against its direction label when the two are on different clocks

### DIFF
--- a/case_studies/utils/registry/metrics.py
+++ b/case_studies/utils/registry/metrics.py
@@ -732,6 +732,44 @@ def compute_classification_metrics_from_predictions(
     return headline, fold_results
 
 
+_CLOCK_UNIT_NS = {"ms": 1_000_000, "us": 1_000, "ns": 1}
+
+
+def _cast_to_label_clock(frame, date_col: str, target):
+    """Put a prediction stamp on the label's clock, refusing a cast that would truncate.
+
+    Only ever applied to the prediction side. The label panel is authoritative because
+    `value_digest` is time-unit sensitive: a prediction frame rewritten to a different unit
+    no longer reproduces the `expected_prediction_keys.digest` its own spec records, which is
+    why `registry/store.py::_timestamps_as_utc` normalised the zone and deliberately left the
+    unit. Casting at read time costs nothing and changes no stored bytes.
+
+    A narrowing cast is silent in polars, so precision that the label genuinely cannot hold is
+    checked here rather than discovered as a join that quietly matches fewer rows.
+    """
+    import polars as pl
+
+    source_unit = getattr(frame.schema[date_col], "time_unit", None)
+    target_unit = getattr(target, "time_unit", None)
+    source_ns = _CLOCK_UNIT_NS.get(source_unit or "", 0)
+    target_ns = _CLOCK_UNIT_NS.get(target_unit or "", 0)
+
+    if source_ns and target_ns and source_ns < target_ns:
+        remainder = target_ns // source_ns
+        lost = frame.select(
+            (pl.col(date_col).dt.timestamp(source_unit) % remainder != 0).sum()
+        ).item()
+        if lost:
+            raise ValueError(
+                f"cannot put {date_col!r} on the label's clock without losing precision: "
+                f"{lost:,} of {frame.height:,} prediction stamps carry sub-{target_unit} "
+                f"detail that {target_unit!r} cannot hold. The label panel is the authority "
+                "on the decision clock, so this is a producer that is stamping finer than "
+                "the panel it is scored against."
+            )
+    return frame.with_columns(pl.col(date_col).cast(target))
+
+
 def compute_cross_sectional_direction_auc(
     predictions,
     direction_labels,
@@ -801,6 +839,28 @@ def compute_cross_sectional_direction_auc(
             left = left.with_columns(pl.col(date_col).cast(pl.Date))
         elif left_dt == pl.Date:
             right = right.with_columns(pl.col(date_col).cast(pl.Date))
+        elif isinstance(left_dt, pl.Datetime) and isinstance(right_dt, pl.Datetime):
+            # Two Datetimes that differ only in time unit or zone are the same instants,
+            # and this is the case that lost the metric entirely: `deep_learning` and
+            # `latent_factors` reach the registry through `flush_fold_predictions`, whose
+            # dates come from a numpy `datetime64` array, so their artifacts carry `us`
+            # where the label panel carries `ms`. 1,548 artifacts across seven case studies
+            # are on the other side of this line.
+            #
+            # The label is authoritative and the cast goes rightwards onto it, never the
+            # other way: `value_digest` is time-unit sensitive, so rewriting a prediction
+            # frame's unit moves `computation.expected_prediction_keys.digest` and the
+            # artifact stops reproducing the digest its own spec records - which is why
+            # `registry/store.py::_timestamps_as_utc` fixed the zone and says in as many
+            # words that it leaves the unit alone. Reading is the only side that may cast.
+            #
+            # Lossless here, and checked rather than assumed: across all 200 `us`
+            # artifacts in `crypto_perps_funding`, no row carries a sub-millisecond
+            # component, so narrowing to the label's unit moves no instant. A stamp that
+            # genuinely carried finer precision than its label would be a different
+            # problem, and `assert_no_precision_loss` below refuses it rather than
+            # silently truncating.
+            left = _cast_to_label_clock(left, date_col, right_dt)
         else:
             raise TypeError(
                 f"cannot align join key {date_col!r}: predictions are {left_dt}, "

--- a/tests/test_direction_auc_join_clock.py
+++ b/tests/test_direction_auc_join_clock.py
@@ -1,0 +1,168 @@
+"""A prediction stamped on a different clock than its label still scores.
+
+`compute_cross_sectional_direction_auc` aligned a `Date` label against a `Datetime`
+prediction and refused everything else, so two `Datetime`s differing only in time unit
+raised into the caller's bare `except` and the metric was never written. Measured on
+`crypto_perps_funding`: 120 of 120 `deep_learning` validation sets on the primary label
+carried a NULL `direction_label`, against 0 of 202 for gbm, linear and tabular_dl.
+
+The instants were identical. `deep_learning` and `latent_factors` reach the registry
+through `flush_fold_predictions`, whose dates come from a numpy `datetime64` array, so
+their artifacts carry `us` where every label and feature panel carries `ms` - 1,548
+artifacts across seven case studies.
+
+**The cast may only ever go onto the prediction side.** `value_digest` is time-unit
+sensitive and zone-insensitive, so rewriting a prediction frame's unit moves
+`computation.expected_prediction_keys.digest` and the artifact stops reproducing the digest
+its own spec records; 110 registered training runs sit on that. `registry/store.py::
+_timestamps_as_utc` normalised the zone for exactly that reason and says in as many words
+that it leaves the unit alone. Reading is the only side that may cast, which is what these
+tests pin.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import polars as pl
+import pytest
+
+from case_studies.utils.artifact_digest import value_digest
+from case_studies.utils.registry.metrics import (
+    _cast_to_label_clock,
+    compute_cross_sectional_direction_auc,
+)
+
+# `cross_sectional_auc_series` needs `min_obs` rows per date and both classes present, so a
+# fixture below eight symbols yields no AUC on any date and the function correctly returns {}.
+_SYMBOLS = ("BTC", "ETH", "SOL", "ADA", "DOT", "AVAX", "LINK", "XRP")
+
+
+def _panel(n: int) -> tuple[list[dt.datetime], list[str]]:
+    start = dt.datetime(2024, 1, 1)
+    stamps = [start + dt.timedelta(hours=8 * i) for i in range(n)]
+    return (
+        [s for s in stamps for _ in _SYMBOLS],
+        [sym for _ in stamps for sym in _SYMBOLS],
+    )
+
+
+def _predictions(unit: str, zone: str | None, n: int = 200) -> pl.DataFrame:
+    """`n` decision times over eight symbols, scored by rank within each date."""
+    stamps, symbols = _panel(n)
+    frame = pl.DataFrame(
+        {
+            "timestamp": stamps,
+            "symbol": symbols,
+            "y_score": [j / len(_SYMBOLS) for _ in range(n) for j in range(len(_SYMBOLS))],
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime(unit)))
+    if zone:
+        frame = frame.with_columns(pl.col("timestamp").dt.replace_time_zone(zone))
+    return frame
+
+
+def _direction(unit: str, zone: str | None, n: int = 200) -> pl.DataFrame:
+    """The sibling direction label: the top half of each date's cross-section went up."""
+    stamps, symbols = _panel(n)
+    frame = pl.DataFrame(
+        {
+            "timestamp": stamps,
+            "symbol": symbols,
+            "fwd_dir_8h": [
+                1 if j >= len(_SYMBOLS) // 2 else 0 for _ in range(n) for j in range(len(_SYMBOLS))
+            ],
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime(unit)))
+    if zone:
+        frame = frame.with_columns(pl.col("timestamp").dt.replace_time_zone(zone))
+    return frame
+
+
+def test_microsecond_predictions_score_against_millisecond_labels():
+    """The exact shape that lost 120 runs."""
+    out = compute_cross_sectional_direction_auc(
+        _predictions("us", "UTC"), _direction("ms", "UTC"), direction_col="fwd_dir_8h", horizon=8
+    )
+
+    assert out, "a us/ms pair produced no metric block"
+    assert out["direction_label"] == "fwd_dir_8h"
+    assert 0.0 <= out["auc_mean_daily"] <= 1.0
+
+
+def test_same_clock_still_scores():
+    out = compute_cross_sectional_direction_auc(
+        _predictions("ms", "UTC"), _direction("ms", "UTC"), direction_col="fwd_dir_8h", horizon=8
+    )
+
+    assert out["direction_label"] == "fwd_dir_8h"
+
+
+def test_the_two_clocks_agree_on_the_answer():
+    """Aligning the clock must not change the measurement, only make it possible."""
+    same = compute_cross_sectional_direction_auc(
+        _predictions("ms", "UTC"), _direction("ms", "UTC"), direction_col="fwd_dir_8h", horizon=8
+    )
+    across = compute_cross_sectional_direction_auc(
+        _predictions("us", "UTC"), _direction("ms", "UTC"), direction_col="fwd_dir_8h", horizon=8
+    )
+
+    assert across["auc_mean_daily"] == pytest.approx(same["auc_mean_daily"])
+    assert across["auc_n_days"] == same["auc_n_days"]
+
+
+def test_a_narrowing_cast_that_would_truncate_is_refused():
+    """Silence here would be a join that quietly matches fewer rows."""
+    finer = _predictions("us", "UTC", n=10).with_columns(
+        pl.col("timestamp") + pl.duration(microseconds=1)
+    )
+
+    with pytest.raises(ValueError, match="without losing precision"):
+        _cast_to_label_clock(finer, "timestamp", pl.Datetime("ms", "UTC"))
+
+
+def test_a_lossless_narrowing_cast_is_allowed():
+    coarse = _predictions("us", "UTC", n=10)
+    out = _cast_to_label_clock(coarse, "timestamp", pl.Datetime("ms", "UTC"))
+
+    assert out.schema["timestamp"] == pl.Datetime("ms", "UTC")
+    assert out.get_column("timestamp").to_list() == coarse.get_column("timestamp").to_list()
+
+
+def test_value_digest_is_unit_sensitive_and_zone_insensitive():
+    """Why the cast goes onto the prediction side at read time and never onto the artifact.
+
+    If this ever flips, the reasoning above it is void: a unit-insensitive digest would make
+    rewriting the artifacts free, and a zone-sensitive one would mean the 2026-08-28 zone
+    normalisation had silently moved 110 registered identities.
+    """
+    stamps = [dt.datetime(2024, 1, 1, 8), dt.datetime(2024, 1, 1, 16)]
+    naive_us = pl.DataFrame({"timestamp": stamps, "symbol": ["BTC", "ETH"], "fold": [0, 0]})
+    utc_us = naive_us.with_columns(pl.col("timestamp").dt.replace_time_zone("UTC"))
+    utc_ms = utc_us.with_columns(pl.col("timestamp").cast(pl.Datetime("ms", "UTC")))
+    keys = ("symbol", "timestamp", "fold")
+
+    assert value_digest(naive_us, keys) == value_digest(utc_us, keys), "digest gained a zone"
+    assert value_digest(utc_us, keys) != value_digest(utc_ms, keys), "digest lost its unit"
+
+
+def test_a_date_label_still_narrows_the_prediction_stamp():
+    """The pre-existing alignment, which the new branch must not shadow."""
+    daily = _direction("ms", None).with_columns(pl.col("timestamp").cast(pl.Date))
+    out = compute_cross_sectional_direction_auc(
+        _predictions("us", None), daily, direction_col="fwd_dir_8h", horizon=8
+    )
+
+    assert out["direction_label"] == "fwd_dir_8h"
+
+
+def test_an_unalignable_key_still_raises():
+    """Only Datetime-to-Datetime and Date-to-Datetime are alignable; the rest must say so."""
+    text_keyed = _direction("ms", "UTC").with_columns(
+        pl.col("timestamp").dt.strftime("%Y-%m-%dT%H:%M:%S")
+    )
+
+    with pytest.raises(TypeError, match="cannot align join key"):
+        compute_cross_sectional_direction_auc(
+            _predictions("us", "UTC"), text_keyed, direction_col="fwd_dir_8h", horizon=8
+        )


### PR DESCRIPTION
Refs ml4t/agent-workspace#1093.

Direction AUC has never been computed for any sequence run. `compute_cross_sectional_direction_auc` aligned a `Date` label against a `Datetime` prediction and refused every other mismatch, so two `Datetime`s differing only in time unit hit `else: raise TypeError` and vanished into the caller's bare `except`, which logs into a papermill log the harness deletes on success.

| family | `fwd_ret_8h` validation sets | `direction_label` NULL |
|---|---:|---:|
| gbm | 150 | 0 |
| linear | 28 | 0 |
| tabular_dl | 24 | 0 |
| **deep_learning** | **120** | **120** |

120, not the 60 filed — six training runs, three architectures at two identities each, twenty published checkpoints apiece. The registry gained the second identity after filing.

## The writer diverges, and the reader is the only side allowed to fix it

All 200 `deep_learning` artifacts carry `Datetime('us','UTC')`; all 617 from the other three families, and every label and feature panel, carry `ms/UTC`. Both affected families — `deep_learning` and `latent_factors`, 1,548 artifacts across seven case studies — reach the registry through `flush_fold_predictions`, whose dates come from a numpy `datetime64` array. That is what `registry/store.py::_timestamps_as_utc` exists for: it normalised the zone on 2026-08-28 and *deliberately* left the unit, and says why.

I verified that reasoning independently rather than reading it off the docstring, because the whole fix turns on it. Same instants, keys `("symbol","timestamp","fold")`:

```
naive us   fcd4bb88bdb395b2
UTC   us   fcd4bb88bdb395b2    <- zone-insensitive: why the zone fix was free
UTC   ms   34faf7d9422cba4a    <- unit-sensitive:  why the unit was not touched
```

So **rewriting the artifacts is refused, not deferred.** `computation.expected_prediction_keys.digest` is `value_digest` over that key set, and 110 of the 941 specs carrying it belong to the two `us`-writing families; a rewrite moves the digest and those artifacts stop reproducing the one their own spec records.

**Changing the writer is refused for a second reason.** The digest sits inside `computation`, and `project_training_identity` hashes that block whole — so a new unit re-keys every future run of those configs and the 110 existing ones stop matching. `_MIGRATABLE_FIELDS` is `frozenset({"computation.source_identity"})` and covers none of it. Unifying the units is a separate decision that has to start from what a migration would cover.

Hence a read-time cast onto the prediction side only, changing no stored byte. `13_backtest.py::on_clock_dtype` is the same pattern one stage later; that one normalises and proceeds where the metric path raised and went quiet.

## It refuses rather than truncates

A narrowing cast is silent in polars, so `_cast_to_label_clock` counts the stamps carrying detail the label's unit cannot hold and raises naming the count. Lossless for this corpus, checked rather than assumed: across all 200 `us` artifacts, no row carries a sub-millisecond component.

## Verified

Real artifacts, straight through the function with no manual cast: all sampled sets compute — `auc` 0.5025 / 0.5065 / 0.5082 / 0.5097, `n_days` 1575, `hac_lag` 7. That lag matches the 7 the other three families recorded, so the comparison is like-for-like; I checked it by re-running at the other candidate horizon rather than assuming.

Eight tests, including that aligning the clock does not change the measurement (only makes it possible), that a truncating cast is refused, that the pre-existing `Date` narrowing still works, that a genuinely unalignable key still raises, and that `value_digest` keeps the unit-sensitive/zone-insensitive property the whole design rests on — if that ever flips, the reasoning above is void and the test says so.

## What the blank was hiding

Over all 120: median 0.5037, range 0.4797–0.5121, and 21 sets significant at p<0.05 — of which **20 are `tcn`, every one below 0.5 with a confidence interval excluding it**. Worst 0.4797, CI (0.4688, 0.4905), p=0.0002, consistent across checkpoints and both identities. `tcn`'s score ranks down-moves higher on this label. It moves no selection, which is validation backtest Sharpe, and no published number — but it is the opposite of what a blank cell tells a reader.

## Deliberately not in this PR

- **The 120 rows are still NULL.** Recomputing writes to a registry `infra/crypto-sequence-cadence` is running stages against right now; it needs sequencing, not a concurrent write.
- **`on_clock_dtype`'s docstring is stale twice** — "100 of this case study's 677" is now 200 of 778, and the naive-microsecond branch is dead because all 200 carry UTC. That branch already has `13_backtest.py` and its `.ipynb` open, so the correction belongs there rather than in a conflicting commit.
- **A join-failure NULL still reads identically to a no-direction-label NULL**, which `fwd_ret_24h` legitimately produces in every family. That needs a `prediction_metrics` column and a migration — a shared-registry change deserving its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRbvPEVfdF9eSebTiX8vgM
