### PR TITLE
Say which kind of NULL a missing direction AUC is

### DIFF
--- a/case_studies/utils/registry/metrics.py
+++ b/case_studies/utils/registry/metrics.py
@@ -300,20 +300,54 @@ def compute_prediction_fold_metrics(
     if not is_classification and direction_labels is not None and direction_col:
         # Never fatal. This is a secondary reading of a run whose own metrics are already
         # computed above, so a schema surprise in a sibling label must not lose the run.
+        #
+        # But a failure has to survive somewhere a reader looks. It used to reach only
+        # `logger.warning`, into a papermill log the harness deletes when the run succeeds,
+        # and the row was left with a NULL `direction_label` - identical to the NULL that
+        # means "this label declares no direction sibling", which `fwd_ret_24h` legitimately
+        # produces in every family. The two are opposite claims wearing the same face, and
+        # the ambiguity hid a real result: every `deep_learning` run in
+        # `crypto_perps_funding` raised here on a time-unit mismatch, and once the join was
+        # repaired 20 of the 21 significant sets turned out to sit BELOW 0.5 with confidence
+        # intervals excluding it.
+        #
+        # So the reason is written beside the absent value. Cleared on the success path
+        # rather than only set on the failure one, so a stored error cannot outlive the
+        # cause it names: a row that computes gets an explicit NULL over whatever a previous
+        # attempt left there, and nobody has to remember to clear it.
         try:
-            headline.update(
-                compute_cross_sectional_direction_auc(
-                    predictions,
-                    direction_labels,
-                    y_score_col=y_score_col,
-                    direction_col=direction_col,
-                    date_col=date_col,
-                    entity_col=_entity,
-                    horizon=int(max(1, horizon)),
-                )
+            computed = compute_cross_sectional_direction_auc(
+                predictions,
+                direction_labels,
+                y_score_col=y_score_col,
+                direction_col=direction_col,
+                date_col=date_col,
+                entity_col=_entity,
+                horizon=int(max(1, horizon)),
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("direction AUC against %s not computed: %s", direction_col, exc)
+            # Truncated because this is a diagnostic in a metrics row, not a log: the type
+            # and the first line are what identify the failure, and a polars schema error
+            # carries several hundred characters of frame detail behind them.
+            detail = " ".join(str(exc).split())
+            headline["direction_label_error"] = f"{type(exc).__name__}: {detail}"[:300]
+        else:
+            headline.update(computed)
+            # An empty return is the third state and it was as silent as the raise. The
+            # function declines rather than raises when the joined frame is too small, the
+            # label is degenerate, or fewer than three dates carry a defined AUC - all of
+            # which leave the same NULL. Reaching here at all means a direction sibling WAS
+            # declared and requested, so "declined" is a different claim from "none exists"
+            # and is worth the row it is written on.
+            headline["direction_label_error"] = (
+                None
+                if computed
+                else (
+                    "not computable: fewer than 100 joined rows, a degenerate direction "
+                    "label, or fewer than 3 dates carrying a defined AUC"
+                )
+            )
 
     return headline, fold_results
 

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -27,6 +27,19 @@ UTC = UTC
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
+#
+# Keep prose out of the SQL below. SQLite stores a table's CREATE text verbatim in
+# `sqlite_master` and re-parses it on `ALTER TABLE ... DROP COLUMN`; a trailing `--`
+# comment inside the statement makes that re-parse fail with "incomplete input", so a
+# comment written for the next reader breaks a migration years later. Explain a column
+# here, or above the migration that adds it.
+#
+# `prediction_metrics.direction_label_error` says why `direction_label` is NULL when a
+# direction sibling was declared and scoring against it still did not land - a NULL that
+# otherwise reads identically to "this label declares no sibling". It is declared rather
+# than left to `_upsert_wide_metrics`'s auto-add, which types a new column from the first
+# value it sees: on a healthy registry that is the None a successful run writes, which
+# would make the column REAL and put every later message in a numeric one.
 
 REGISTRY_SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS training_runs (
@@ -96,7 +109,8 @@ CREATE TABLE IF NOT EXISTS prediction_metrics (
     ic_mean REAL, ic_std REAL, ic_t REAL, n_folds REAL,
     pct_positive REAL, task_type TEXT,
     accuracy REAL, balanced_accuracy REAL, auc_roc REAL, auc_pr REAL,
-    log_loss REAL, brier_score REAL
+    log_loss REAL, brier_score REAL,
+    direction_label_error TEXT
 );
 
 CREATE TABLE IF NOT EXISTS fold_metrics (
@@ -854,6 +868,20 @@ def _migrate_registry(db: sqlite3.Connection) -> None:
         db, "candidate_sets", "supersedes_hash"
     ):
         db.execute("ALTER TABLE candidate_sets ADD COLUMN supersedes_hash TEXT")
+
+    # Additive and outside every hash: registry columns reach no specification, so this
+    # moves no identity and invalidates no registered row. It exists because a NULL
+    # `direction_label` carried two opposite meanings - "no direction sibling is declared
+    # for this label", which `fwd_ret_24h` legitimately produces in every family, and "one
+    # is declared and scoring against it failed", which every `deep_learning` run in
+    # `crypto_perps_funding` produced for months while the only trace was a warning in a
+    # papermill log the harness deletes on success. Declared explicitly for the type: the
+    # auto-add in `_upsert_wide_metrics` would infer REAL from the None a healthy run
+    # writes first.
+    if "prediction_metrics" in tables and not _table_has_column(
+        db, "prediction_metrics", "direction_label_error"
+    ):
+        db.execute("ALTER TABLE prediction_metrics ADD COLUMN direction_label_error TEXT")
 
     # The share of treatment rows the block permutation could not move. It is computed on
     # every fit and warned about, and the warning only fires when the fit executes, so a

--- a/tests/test_direction_auc_failure_is_visible.py
+++ b/tests/test_direction_auc_failure_is_visible.py
@@ -1,0 +1,174 @@
+"""A NULL direction_label says which kind of NULL it is.
+
+The column carried two opposite claims behind one face. `fwd_ret_24h` declares no direction
+sibling, so its NULL means "there is nothing to score against" - correct, in every family.
+Every `deep_learning` run in `crypto_perps_funding` also wrote NULL, and there it meant "a
+sibling is declared and scoring against it raised". 120 of 120 sets, for months, with the
+only trace a `logger.warning` into a papermill log the harness deletes when the run succeeds.
+
+The ambiguity was not cosmetic: once the join was repaired, 20 of the 21 significant sets
+turned out to sit *below* 0.5 with confidence intervals excluding it. A blank told a reader
+nothing was there when the answer was "this model ranks down-moves higher".
+
+Three states, and the tests below pin each: computed, declined, raised.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import polars as pl
+import pytest
+
+from case_studies.utils.registry.metrics import compute_prediction_fold_metrics
+
+_SYMBOLS = ("BTC", "ETH", "SOL", "ADA", "DOT", "AVAX", "LINK", "XRP")
+
+
+def _panel(n: int) -> tuple[list[dt.datetime], list[str]]:
+    start = dt.datetime(2024, 1, 1)
+    stamps = [start + dt.timedelta(hours=8 * i) for i in range(n)]
+    return (
+        [s for s in stamps for _ in _SYMBOLS],
+        [sym for _ in stamps for sym in _SYMBOLS],
+    )
+
+
+def _predictions(n: int = 200, unit: str = "ms") -> pl.DataFrame:
+    stamps, symbols = _panel(n)
+    width = len(_SYMBOLS)
+    return pl.DataFrame(
+        {
+            "timestamp": stamps,
+            "symbol": symbols,
+            "fold_id": [0] * (n * width),
+            "y_true": [(j - width / 2) / width for _ in range(n) for j in range(width)],
+            "y_score": [j / width for _ in range(n) for j in range(width)],
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime(unit, "UTC")))
+
+
+def _direction(n: int = 200, unit: str = "ms") -> pl.DataFrame:
+    stamps, symbols = _panel(n)
+    width = len(_SYMBOLS)
+    return pl.DataFrame(
+        {
+            "timestamp": stamps,
+            "symbol": symbols,
+            "fwd_dir_8h": [1 if j >= width // 2 else 0 for _ in range(n) for j in range(width)],
+        }
+    ).with_columns(pl.col("timestamp").cast(pl.Datetime(unit, "UTC")))
+
+
+def _headline(predictions, direction_labels, direction_col):
+    headline, _ = compute_prediction_fold_metrics(
+        predictions,
+        direction_labels=direction_labels,
+        direction_col=direction_col,
+        task_type="regression",
+    )
+    return headline
+
+
+def test_a_computed_direction_auc_records_no_error():
+    headline = _headline(_predictions(), _direction(), "fwd_dir_8h")
+
+    assert headline["direction_label"] == "fwd_dir_8h"
+    assert headline["direction_label_error"] is None
+
+
+def test_a_raising_join_records_why():
+    """The shape that hid 120 runs: a sibling declared, and scoring against it raised."""
+    unjoinable = _direction().with_columns(pl.col("timestamp").dt.strftime("%Y-%m-%dT%H:%M:%S"))
+
+    headline = _headline(_predictions(), unjoinable, "fwd_dir_8h")
+
+    assert "direction_label" not in headline, "a failed run must not claim a direction label"
+    assert "cannot align join key" in headline["direction_label_error"]
+    assert headline["direction_label_error"].startswith("TypeError: ")
+
+
+def test_a_declined_computation_is_distinguishable_from_a_raise():
+    """The third state: declared, joinable, and not computable. Also formerly silent."""
+    headline = _headline(_predictions(n=4), _direction(n=4), "fwd_dir_8h")
+
+    assert "direction_label" not in headline
+    assert "not computable" in headline["direction_label_error"]
+
+
+def test_no_declared_sibling_writes_no_error_at_all():
+    """`fwd_ret_24h`'s NULL. Nothing was asked for, so nothing failed."""
+    headline = _headline(_predictions(), None, None)
+
+    assert "direction_label" not in headline
+    assert "direction_label_error" not in headline
+
+
+def test_the_error_is_bounded():
+    """A metrics row is not a log; a polars schema error runs to hundreds of characters."""
+    unjoinable = _direction().with_columns(pl.col("timestamp").dt.strftime("%Y-%m-%dT%H:%M:%S"))
+
+    message = _headline(_predictions(), unjoinable, "fwd_dir_8h")["direction_label_error"]
+
+    assert len(message) <= 300
+    assert "\n" not in message, "a newline in a metrics cell reads as a broken row"
+
+
+def test_the_column_is_declared_text_not_inferred():
+    """A fresh registry must type it from the DDL, not from whichever value lands first.
+
+    `_upsert_wide_metrics` auto-adds an unknown metric column and infers REAL from a None -
+    which is exactly what a healthy run writes - so leaving it undeclared would put every
+    later message in a numeric column.
+    """
+    import sqlite3
+
+    from case_studies.utils.registry.store import REGISTRY_SCHEMA_SQL
+
+    db = sqlite3.connect(":memory:")
+    db.executescript(REGISTRY_SCHEMA_SQL)
+    types = {
+        row[1]: (row[2] or "").upper()
+        for row in db.execute("PRAGMA table_info(prediction_metrics)")
+    }
+
+    assert types.get("direction_label_error") == "TEXT"
+
+
+def test_an_existing_registry_gains_the_column():
+    """The migration half, for the registries that already exist."""
+    import sqlite3
+
+    from case_studies.utils.registry.store import REGISTRY_SCHEMA_SQL, _migrate_registry
+
+    db = sqlite3.connect(":memory:")
+    db.executescript(REGISTRY_SCHEMA_SQL)
+    # A registry created before the column existed, built the way it was then rather than
+    # by dropping it now: SQLite re-parses the stored CREATE text on DROP COLUMN, so a
+    # drop is not a faithful stand-in for never having had it.
+    db.execute("DROP TABLE prediction_metrics")
+    db.execute(
+        "CREATE TABLE prediction_metrics ("
+        "  prediction_hash TEXT PRIMARY KEY, computed_at TEXT NOT NULL,"
+        "  ic_mean REAL, task_type TEXT, direction_label TEXT)"
+    )
+    assert "direction_label_error" not in {
+        r[1] for r in db.execute("PRAGMA table_info(prediction_metrics)")
+    }
+
+    _migrate_registry(db)
+
+    types = {
+        row[1]: (row[2] or "").upper()
+        for row in db.execute("PRAGMA table_info(prediction_metrics)")
+    }
+    assert types.get("direction_label_error") == "TEXT"
+
+
+@pytest.mark.parametrize("unit", ["ms", "us"])
+def test_both_clocks_reach_a_computed_value(unit: str):
+    """The repaired join, from both sides, so this cannot silently regress into the error."""
+    headline = _headline(_predictions(unit=unit), _direction(), "fwd_dir_8h")
+
+    assert headline["direction_label"] == "fwd_dir_8h"
+    assert headline["direction_label_error"] is None


### PR DESCRIPTION
Refs ml4t/agent-workspace#1093. Follows #873, which repaired the join this makes legible.

`prediction_metrics.direction_label` carried two opposite claims behind one face. `fwd_ret_24h` declares no direction sibling, so its NULL means "there is nothing to score against" — correct, in every family. Every `deep_learning` run in `crypto_perps_funding` also wrote NULL, and there it meant "a sibling is declared and scoring against it raised": 120 of 120 sets, with the only trace a `logger.warning` into a papermill log the harness deletes when the run succeeds.

That ambiguity was not cosmetic. Once #873 repaired the join, 20 of the 21 significant sets turned out to sit **below** 0.5 with confidence intervals excluding it — worst 0.4797, p = 0.0002. A blank told a reader nothing was there when the answer was "this model ranks down-moves higher".

## Three states, not two

| state | `direction_label` | `direction_label_error` |
|---|---|---|
| computed | set | NULL |
| raised | absent | `TypeError: cannot align join key …` |
| declined | absent | `not computable: fewer than 100 joined rows, …` |

**Declined is the third state and it was as silent as the raise.** `compute_cross_sectional_direction_auc` returns `{}` rather than raising when the joined frame is too small, the label is degenerate, or fewer than three dates carry a defined AUC. Reaching that point at all means a sibling *was* declared and requested, so "declined" is a different claim from "none exists" and now says so.

The error is **cleared on the success path**, not merely set on the failure one, so a stored message cannot outlive the cause it names: a row that computes writes an explicit NULL over whatever a previous attempt left there. Nobody has to remember to clear it.

It is truncated to 300 characters and whitespace-collapsed, because a metrics row is not a log — a polars schema error carries several hundred characters of frame detail behind the part that identifies it.

## Why the column is declared rather than auto-added

`_upsert_wide_metrics` already auto-adds an unknown metric column and infers its type from the first value it sees. On a healthy registry that first value is the `None` a successful run writes, which would make the column REAL and put every later message in a numeric one.

## A test found a defect in this change before it landed

The first version put the explanation in a `--` comment inside `CREATE TABLE`. SQLite stores a table's CREATE text verbatim in `sqlite_master` and re-parses it on `ALTER TABLE … DROP COLUMN`, so the trailing comment made that fail with `incomplete input`. A comment written for the next reader would have broken a migration years later. The prose moved above the schema string, with a note there saying why it has to stay out.

## Verified

Additive and outside every hash — registry columns reach no specification, so this moves no identity and invalidates no registered row. Checked against a **copy** of the live 778-row `crypto_perps_funding` registry rather than only an in-memory fixture: column absent before, `TEXT` after, 778 rows before and after, all 778 left NULL in the new column.

Nine tests: the three states; the "no sibling declared" case, which must write no error at all; the length bound and that no newline reaches a metrics cell; that a fresh registry types the column from the DDL; that an existing one gains it by migration, built the way a pre-column registry actually was rather than by dropping the column now; and that both clock units reach a computed value, so #873's repaired join cannot silently regress into the error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRbvPEVfdF9eSebTiX8vgM
