### PR TITLE
Check supersedes literals where the source and the registry both exist

### DIFF
--- a/scripts/check_supersedes_literals.py
+++ b/scripts/check_supersedes_literals.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""Every committed supersedes literal still names a live generation.
+
+A notebook that has published an official population and then moved a training identity has
+to name the snapshot it replaces, or ``OfficialPopulation.create`` refuses the write. That
+hash is committed source, so it goes stale whenever the registry tip moves without the
+literal moving with it - a reset, a refit, a chain someone else advanced.
+
+**Nothing that runs before a production chain can catch that.** A preview never resolves a
+supersedes hash at all: ``supersedes_for_run`` returns ``None`` for any tier but
+``canonical``, and that guard is correct - a preview is discarded with its workspace, has no
+lineage to extend, and ``run_model_population`` refuses one that carries a hash. So a smoke
+pass says nothing about the literals, and on 2026-09-06 twelve ``sp500_options`` notebooks
+passed smoke and three failed the real chain fifteen minutes later on eleven stale literals.
+
+CI cannot catch it either, and that is why this is a script rather than only a test:
+``run_log/`` is gitignored and no registry is tracked, so a checkout has nothing to check
+against. This runs where the registries live, before a chain is queued.
+
+**It is keyed on the hash, not on the population name, and that is not incidental.** Only
+some notebooks build their name as ``POPULATION_NAME or "a-literal"``; the rest use an
+f-string over the label set or a module constant. A name-keyed scan cannot read those
+statically - it skips them and reports green, which on the corpus this was written against
+meant missing 8 of 17 literals including 3 of the 6 stale ones. Looking the declared hash up
+in ``official_populations`` and resolving the lineage of whatever name owns it reads all of
+them. Do not simplify this back to a name lookup.
+
+Usage::
+
+    python scripts/check_supersedes_literals.py                    # every case study
+    python scripts/check_supersedes_literals.py --case-study etfs  # one
+    python scripts/check_supersedes_literals.py --json             # machine-readable
+
+**What a stale literal does and does not cost, because the difference decides what this
+refuses.** ``OfficialPopulation.create`` reads the declared predecessor only when the member
+list has moved: an unchanged re-run matches on members and returns the published population
+without ever looking at it. So a stale literal is a latent fault, not a certain failure - it
+fires on the run whose membership changes, which is the refit a chain is queued for, and
+which is exactly the run that has already paid for its fit by the time it is refused. That
+is why this refuses rather than warns, and why the refusal is waivable by name.
+
+Exit status is 1 when a literal is dead AND the registry can name the head it should have
+named. `unresolved` - the hash is in no lineage and the notebook's population name cannot be
+read without executing it - is reported and never blocks: refusing there would be the check
+asserting knowledge it does not have. A case study with no registry on disk is reported and
+does not fail either; that is a reader's clone. ``--allow-stale-supersedes`` waives the
+refusal for a run whose membership is known to be unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sqlite3
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from case_studies.utils.registry.store import current_causal_identities  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Read with the AST rather than a pattern. A regex has to guess the annotation and the
+# quoting, and both vary in the committed corpus: `cme_futures/09_dl_lstm.py` annotates
+# `str | None`, and `fx_pairs/11_causal_dml.py` wraps its JSON in parentheses across two
+# lines. A pattern that misses either reads the declaration as absent and reports nothing,
+# which is the failure this script exists to prevent, arriving inside the script itself.
+_POPULATION_NAME = "SUPERSEDES_POPULATION"
+_CAUSAL_NAME = "SUPERSEDES_CAUSAL"
+
+
+def _declared_literals(source: str) -> dict[str, str]:
+    """The string value assigned to each SUPERSEDES_* name, whatever the assignment shape."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return {}
+    found: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        elif isinstance(node, ast.Assign):
+            targets = node.targets
+        else:
+            continue
+        value = node.value
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id in (_POPULATION_NAME, _CAUSAL_NAME):
+                found[target.id] = value.value
+    return found
+
+
+@dataclass
+class Finding:
+    case_study: str
+    notebook: str
+    declared: str
+    status: str
+    detail: str
+    parameter: str = _POPULATION_NAME
+    # The value to paste, where it can be determined: the current head, or "" for a genuine
+    # first generation. None means it could not be worked out and the author has to look.
+    remedy: str | None = None
+    # The label a per-label causal declaration named it under. A repair has to replace that
+    # entry in the mapping, not the whole declaration: `supersedes_for` rejects a bare hash
+    # from a notebook that fits several labels.
+    label: str | None = None
+
+    @property
+    def is_stale(self) -> bool:
+        return self.status == "stale"
+
+
+_POPULATION_NAME_ASSIGN = re.compile(
+    r'^population_name\s*=\s*POPULATION_NAME\s*or\s*"([^"]+)"', re.M
+)
+
+
+def _population_name(source: str) -> str | None:
+    """The default population name, where the notebook states one as a literal.
+
+    Deliberately partial. Most notebooks write `POPULATION_NAME or "a-literal"`, but some
+    build the name from an f-string over the label set or a module constant, and those
+    cannot be read without executing the notebook. A caller must treat `None` as "unknown",
+    never as "no generation exists" - reading it that way is how a name-keyed scan silently
+    skips a third of the corpus.
+    """
+    match = _POPULATION_NAME_ASSIGN.search(source)
+    return match.group(1) if match else None
+
+
+def _registry_for(case_study: str, artifacts_root: Path) -> Path:
+    return artifacts_root / case_study / "run_log" / "registry.db"
+
+
+def _current_generation(db: sqlite3.Connection, name: str) -> tuple[str, str | None] | None:
+    """The snapshot in force under *name*: the one nothing supersedes.
+
+    The same rule as ``OfficialPopulation.one``. A fork - two snapshots nothing supersedes -
+    has no defensible answer and is reported rather than picked between.
+    """
+    rows = db.execute(
+        "SELECT population_hash, supersedes_hash FROM official_populations WHERE name = ?",
+        (name,),
+    ).fetchall()
+    if not rows:
+        return None
+    superseded = {row[1] for row in rows if row[1] is not None}
+    heads = [row for row in rows if row[0] not in superseded]
+    if len(heads) != 1:
+        raise ValueError(f"{len(heads)} current snapshots among {len(rows)} under {name!r}")
+    return heads[0]
+
+
+def _declared_causal_hashes(literal: str) -> list[tuple[str, str | None]]:
+    """``(hash, label)`` for each hash a ``SUPERSEDES_CAUSAL`` declaration names.
+
+    A per-label declaration names its label, which is what lets a stale one be answered with
+    the identity to paste. A bare hash does not, and the label is only knowable from the run.
+    """
+    text = literal.strip()
+    if not text:
+        return []
+    if text.startswith("{"):
+        try:
+            mapping = json.loads(text)
+        except json.JSONDecodeError:
+            # `supersedes_for` raises on this before the fit; nothing to resolve here.
+            return []
+        return [(str(v), str(k)) for k, v in mapping.items() if v]
+    return [(text, None)]
+
+
+def _causal_remedy(db: sqlite3.Connection, label: str | None) -> str | None:
+    """The identity a stale causal declaration should name, where the label is known.
+
+    Exactly one current identity is an answer worth printing. None, or more than one, is not,
+    and guessing between them is how an author is sent to paste the wrong hash.
+    """
+    if not label:
+        return None
+    try:
+        current = list(current_causal_identities(db, label=label))
+    except sqlite3.OperationalError:
+        return None
+    return current[0] if len(current) == 1 else None
+
+
+def _check_causal(case_study: str, notebook: Path, registry: Path, literal: str) -> list[Finding]:
+    """Classify each hash a ``SUPERSEDES_CAUSAL`` declaration names.
+
+    Only one verdict here is a failure, and the boundary is narrower than it first looks.
+    ``causal_supersedes`` offers the hash when it is a CURRENT identity for the label and
+    withholds it otherwise - and withholding is not automatically wrong. A notebook that
+    already published its successor and was left unchanged still declares the predecessor;
+    the hash is withheld, the runner resolves to the cached successor, and nothing fails.
+    Telling that author to "fix" the literal would send them to declare a hash that already
+    records theirs as its predecessor.
+
+    What cannot be right in any of those readings is a hash the registry has never held.
+    There is nothing to resolve to and nothing cached, so the write is refused after the DML
+    fit and every placebo refit. That is the only causal status this script fails on.
+
+    Currency comes from ``current_causal_identities``, the resolver itself, rather than from
+    a supersedes-column scan here: it also excludes rows carrying an outdated identity
+    version and rows from a non-canonical tier, and a reimplementation that ignored either
+    would approve a hash the canonical notebook then withholds.
+    """
+    findings: list[Finding] = []
+    for declared, declared_label in _declared_causal_hashes(literal):
+        if not registry.exists():
+            findings.append(
+                Finding(
+                    case_study,
+                    notebook.name,
+                    declared,
+                    "no-registry",
+                    "no registry on disk; a clone withholds this and publishes on its own",
+                    _CAUSAL_NAME,
+                )
+            )
+            continue
+        db = sqlite3.connect(f"file:{registry}?mode=ro", uri=True)
+        try:
+            rows = db.execute(
+                "SELECT label FROM causal_runs WHERE causal_hash = ?", (declared,)
+            ).fetchall()
+            if not rows:
+                # Absent is not evidence on its own, exactly as on the population path: an
+                # empty or freshly reset `causal_runs` withholds the hash and registration
+                # accepts the first identity, so refusing here would block a valid first run.
+                # It is wrong only when a current identity already exists for the label this
+                # declaration names - and a bare declaration does not name one.
+                current_for_label = (
+                    set(current_causal_identities(db, label=declared_label))
+                    if declared_label
+                    else set()
+                )
+                if current_for_label:
+                    findings.append(
+                        Finding(
+                            case_study,
+                            notebook.name,
+                            declared,
+                            "stale",
+                            f"no causal run with this hash exists, and {declared_label!r} "
+                            f"already resolves to {sorted(current_for_label)[0]}; the write "
+                            "is refused after the fit and every placebo refit",
+                            _CAUSAL_NAME,
+                            _causal_remedy(db, declared_label),
+                            declared_label,
+                        )
+                    )
+                else:
+                    findings.append(
+                        Finding(
+                            case_study,
+                            notebook.name,
+                            declared,
+                            "unresolved",
+                            "no causal run with this hash exists, and no current identity was "
+                            "found for the label it is declared under - so it is either dead "
+                            "or waiting for a first publication, and which cannot be told "
+                            "from here",
+                            _CAUSAL_NAME,
+                            None,
+                            declared_label,
+                        )
+                    )
+                continue
+            label = rows[0][0]
+            current = set(current_causal_identities(db, label=label))
+        except sqlite3.OperationalError as exc:
+            if "no such table" not in str(exc):
+                raise
+            findings.append(
+                Finding(case_study, notebook.name, declared, "no-registry", str(exc), _CAUSAL_NAME)
+            )
+            continue
+        finally:
+            db.close()
+
+        if declared in current:
+            status, detail = "live", f"a current causal identity for {label!r}"
+        else:
+            # Reported, not failed. See the docstring: an unchanged re-run after a
+            # successful supersession looks exactly like this and is correct.
+            status, detail = (
+                "superseded",
+                f"no longer current for {label!r}; correct for an unchanged re-run, which "
+                "resolves to the cached successor, and wrong only if this run publishes a "
+                "new identity",
+            )
+        findings.append(Finding(case_study, notebook.name, declared, status, detail, _CAUSAL_NAME))
+    return findings
+
+
+def check_case_study(case_study: str, *, repo_root: Path, artifacts_root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    registry = _registry_for(case_study, artifacts_root)
+
+    for notebook in sorted((repo_root / "case_studies" / case_study).glob("[0-9]*.py")):
+        declared_by_name = _declared_literals(notebook.read_text(encoding="utf-8", errors="ignore"))
+        causal = declared_by_name.get(_CAUSAL_NAME, "")
+        if causal:
+            findings.extend(_check_causal(case_study, notebook, registry, causal))
+
+        declared = declared_by_name.get(_POPULATION_NAME, "")
+        if not declared:
+            continue
+
+        if not registry.exists():
+            findings.append(
+                Finding(
+                    case_study,
+                    notebook.name,
+                    declared,
+                    "no-registry",
+                    "no registry on disk; a clone publishes generation one and withholds this",
+                )
+            )
+            continue
+
+        db = sqlite3.connect(f"file:{registry}?mode=ro", uri=True)
+        try:
+            row = db.execute(
+                "SELECT name FROM official_populations WHERE population_hash = ?", (declared,)
+            ).fetchone()
+            if row is None:
+                # An absent hash is not evidence on its own. `population_supersedes` withholds
+                # a hash it cannot place and `create` then publishes generation one, which is
+                # exactly right on a reset or freshly initialised registry - so failing here
+                # would block runs that succeed. The declaration is only wrong if a generation
+                # already exists under the name THIS notebook publishes under, which needs the
+                # name; where the name is an f-string or a module constant it cannot be read,
+                # and the honest answer is that this one could not be resolved.
+                statically_named = _population_name(
+                    notebook.read_text(encoding="utf-8", errors="ignore")
+                )
+                head = None
+                if statically_named:
+                    try:
+                        head = _current_generation(db, statically_named)
+                    except ValueError as exc:
+                        findings.append(
+                            Finding(case_study, notebook.name, declared, "forked", str(exc))
+                        )
+                        continue
+                if head is not None:
+                    tip, tip_supersedes = head
+                    findings.append(
+                        Finding(
+                            case_study,
+                            notebook.name,
+                            declared,
+                            "stale",
+                            f"{statically_named!r} is at {tip} (superseding {tip_supersedes}) "
+                            "and this hash is in no lineage the registry holds",
+                            _POPULATION_NAME,
+                            tip,
+                        )
+                    )
+                else:
+                    findings.append(
+                        Finding(
+                            case_study,
+                            notebook.name,
+                            declared,
+                            "unresolved",
+                            "this hash is in no lineage the registry holds, and no generation "
+                            "was found under the name this notebook publishes under - so it "
+                            "is either dead or waiting for a first publication, and which one "
+                            "cannot be told from here",
+                        )
+                    )
+                continue
+            name = row[0]
+            try:
+                head = _current_generation(db, name)
+            except ValueError as exc:
+                findings.append(
+                    Finding(
+                        case_study, notebook.name, declared, "forked", str(exc), _POPULATION_NAME
+                    )
+                )
+                continue
+        except sqlite3.OperationalError as exc:
+            # A registry that predates the table is the reader's case again, not a stale
+            # literal. Anything else - a lock timeout, an I/O error - is not evidence.
+            if "no such table" not in str(exc):
+                raise
+            findings.append(Finding(case_study, notebook.name, declared, "no-registry", f"{exc}"))
+            continue
+        finally:
+            db.close()
+
+        assert head is not None  # a hash we just found has at least its own row
+        tip, tip_supersedes = head
+        remedy = None
+        if declared == tip:
+            status, detail = "live", f"names the tip of {name!r}; a refit publishes over it"
+        elif declared == tip_supersedes:
+            status, detail = (
+                "live",
+                f"names what the tip of {name!r} replaced; a re-run resolves to it",
+            )
+        else:
+            status, detail = (
+                "stale",
+                f"{name!r} is at {tip} (superseding {tip_supersedes}); this literal is neither",
+            )
+            remedy = tip
+        findings.append(
+            Finding(case_study, notebook.name, declared, status, detail, _POPULATION_NAME, remedy)
+        )
+
+    return findings
+
+
+def check_all(*, repo_root: Path, artifacts_root: Path, only: str | None = None) -> list[Finding]:
+    case_studies = (
+        [only]
+        if only
+        else sorted(p.name for p in (repo_root / "case_studies").iterdir() if p.is_dir())
+    )
+    findings: list[Finding] = []
+    for case_study in case_studies:
+        if not (repo_root / "case_studies" / case_study).is_dir():
+            continue
+        findings.extend(
+            check_case_study(case_study, repo_root=repo_root, artifacts_root=artifacts_root)
+        )
+    return findings
+
+
+def _default_artifacts_root() -> Path:
+    return Path.home() / "ml4t" / "artifacts" / "case_studies"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--case-study", default=None, help="check one instead of all")
+    parser.add_argument(
+        "--artifacts-root",
+        type=Path,
+        default=_default_artifacts_root(),
+        help="where the per-case-study run_log/ directories live",
+    )
+    parser.add_argument("--json", action="store_true", help="emit findings as JSON")
+    parser.add_argument(
+        "--allow-stale-supersedes",
+        action="store_true",
+        help=(
+            "report stale literals without failing. For a run whose membership is unchanged, "
+            "where the literal is never read. Deliberately not a general --force: one gate, "
+            "named after what it waives."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    findings = check_all(
+        repo_root=REPO_ROOT, artifacts_root=args.artifacts_root, only=args.case_study
+    )
+
+    if args.json:
+        print(json.dumps([asdict(f) for f in findings], indent=1))
+    else:
+        for finding in findings:
+            mark = "STALE" if finding.is_stale else finding.status.upper()
+            print(f"{mark:<11} {finding.case_study}/{finding.notebook}  {finding.declared}")
+            print(f"            {finding.detail}")
+        checked = len(findings)
+        stale = sum(f.is_stale for f in findings)
+        print(f"\n{checked} declared literal(s); {stale} stale")
+
+    stale = [f for f in findings if f.is_stale]
+    unresolved = [f for f in findings if f.status == "unresolved"]
+
+    for finding in unresolved:
+        # Warned, never blocked. Refusing on "I could not resolve this" would be the check
+        # asserting knowledge it does not have.
+        print(
+            f"\nUNRESOLVED case_studies/{finding.case_study}/{finding.notebook}\n"
+            f"      {finding.parameter} = {finding.declared!r}\n"
+            f"      {finding.detail}",
+            file=sys.stderr,
+        )
+
+    if stale and not args.allow_stale_supersedes:
+        # Addressed to the person about to queue a chain, because that is the only person for
+        # whom this is free. Editing the literal makes the paired .ipynb stale, and the only
+        # sanctioned way to commit that drops its outputs - a live render lost, unless a run
+        # is coming anyway. Theirs is.
+        print(
+            "\nA stale literal does not make any committed output wrong, and it does not "
+            "fail every run: an unchanged re-run returns the published population without "
+            "ever reading it. It fails the run whose membership MOVES - which is the refit "
+            "you are about to queue - after that run has paid for its fit:\n",
+            file=sys.stderr,
+        )
+        for finding in stale:
+            if finding.remedy and finding.label:
+                # A per-label declaration is a mapping and the notebook fits several labels,
+                # so `supersedes_for` rejects a bare hash. Replacing the whole declaration
+                # with the remedy would break the run this message is trying to save.
+                fix = (
+                    f"replace the {finding.label!r} entry in the mapping with "
+                    f'"{finding.remedy}", leaving the other entries as they are'
+                )
+            elif finding.remedy:
+                fix = f'set it to "{finding.remedy}"'
+            else:
+                fix = "look up the current identity for the label this notebook fits"
+            print(
+                f"  case_studies/{finding.case_study}/{finding.notebook}\n"
+                f"      {finding.parameter} = {finding.declared!r} is dead\n"
+                f"      {finding.detail}\n"
+                f"      fix: {fix}",
+                file=sys.stderr,
+            )
+        print(
+            "\nFix it now - you are about to pay for the run that re-renders the notebook "
+            "you have to clear. If you know this run's membership is unchanged, so the "
+            "literal is never read, pass --allow-stale-supersedes.",
+            file=sys.stderr,
+        )
+        return 1
+    if stale:
+        print(
+            f"\n{len(stale)} stale literal(s) allowed by --allow-stale-supersedes.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_supersedes_literals.py
+++ b/tests/test_supersedes_literals.py
@@ -1,0 +1,534 @@
+"""The check that a committed supersedes literal still names a live generation.
+
+Nothing that runs before a production chain can see a stale one. `supersedes_for_run`
+returns `None` for any tier but `canonical`, so a preview never resolves a supersedes hash
+and never reaches the lineage check registration enforces - and that guard is right: a
+preview is discarded with its workspace and has no lineage to extend. On 2026-09-06 twelve
+`sp500_options` notebooks passed smoke and three failed the real chain fifteen minutes later
+on eleven stale literals.
+
+**CI cannot see it either, and these tests are built around that rather than pretending
+otherwise.** `run_log/` is gitignored and no registry is tracked, so a checkout has nothing
+to check against. A corpus scan here would skip on every CI run forever, which is the same
+absence-reading-as-a-pass that the defect itself is made of. So the logic is tested against
+registries these tests build, which runs everywhere, and the corpus scan is a separate test
+that skips out loud when there is no registry to read.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from case_studies.utils.registry.specs import IDENTITY_VERSION
+from scripts.check_supersedes_literals import check_all, check_case_study
+
+_SCHEMA = """
+CREATE TABLE causal_runs (
+    causal_hash TEXT PRIMARY KEY,
+    label TEXT,
+    spec_json TEXT,
+    supersedes_hash TEXT
+);
+CREATE TABLE official_populations (
+    population_hash TEXT PRIMARY KEY,
+    name TEXT,
+    member_kind TEXT,
+    snapshot_json TEXT,
+    supersedes_hash TEXT,
+    created_at TEXT
+);
+"""
+
+
+def _registry(root: Path, case_study: str, generations: list[tuple[str, str, str | None]]) -> None:
+    """`generations` is (hash, name, supersedes_hash), oldest first."""
+    run_log = root / case_study / "run_log"
+    run_log.mkdir(parents=True)
+    db = sqlite3.connect(run_log / "registry.db")
+    db.executescript(_SCHEMA)
+    db.executemany(
+        "INSERT INTO official_populations VALUES (?, ?, 'prediction', '{}', ?, '2026-01-01')",
+        [(h, n, s) for h, n, s in generations],
+    )
+    db.commit()
+    db.close()
+
+
+def _notebook(repo: Path, case_study: str, stem: str, declared: str, name: str) -> None:
+    directory = repo / "case_studies" / case_study
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / f"{stem}.py").write_text(
+        '# %% tags=["parameters"]\n'
+        f'SUPERSEDES_POPULATION: str = "{declared}"\n'
+        "\n# %%\n"
+        f'population_name = POPULATION_NAME or "{name}"\n'
+    )
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> tuple[Path, Path]:
+    repo, artifacts = tmp_path / "repo", tmp_path / "artifacts"
+    (repo / "case_studies").mkdir(parents=True)
+    artifacts.mkdir()
+    return repo, artifacts
+
+
+def test_a_literal_naming_the_tip_is_live(tree):
+    """The refit: declaring the tip publishes the next generation over it."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "aaaa", "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None)])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert [f.status for f in findings] == ["live"]
+
+
+def test_a_literal_naming_what_the_tip_replaced_is_live(tree):
+    """The re-run: the generation in force is the one this declaration produced."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "aaaa", "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None), ("bbbb", "etfs-gbm-v1", "aaaa")])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert [f.status for f in findings] == ["live"]
+
+
+def test_a_literal_two_generations_behind_is_stale(tree):
+    """The failure: neither the tip nor what the tip replaced."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "aaaa", "etfs-gbm-v1")
+    _registry(
+        artifacts,
+        "etfs",
+        [
+            ("aaaa", "etfs-gbm-v1", None),
+            ("bbbb", "etfs-gbm-v1", "aaaa"),
+            ("cccc", "etfs-gbm-v1", "bbbb"),
+        ],
+    )
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert findings[0].is_stale
+    assert "cccc" in findings[0].detail
+
+
+def test_a_literal_naming_a_hash_the_registry_lost_is_stale(tree):
+    """What a reset leaves behind, and the shape all six live cases take."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "gone", "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None)])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert findings[0].is_stale
+    assert "no lineage the registry holds" in findings[0].detail
+
+
+def test_the_check_is_keyed_on_the_hash_not_the_population_name(tree):
+    """The reason this is not a name lookup, pinned so it cannot be simplified back.
+
+    Only some notebooks build their name as `POPULATION_NAME or "a-literal"`; the rest use an
+    f-string or a module constant, which no static read resolves. A name-keyed scan skips
+    those and reports green - on the real corpus that was 8 of 17 literals, including 3 of
+    the 6 stale ones. Keying on the hash reads a notebook whose name is unreadable.
+    """
+    repo, artifacts = tree
+    directory = repo / "case_studies" / "fx_pairs"
+    directory.mkdir(parents=True)
+    (directory / "08_tabular_dl.py").write_text(
+        'SUPERSEDES_POPULATION: str = "gone"\n'
+        'population_name = POPULATION_NAME or f"{CASE_STUDY_ID}:{label}:tabular_dl"\n'
+    )
+    _registry(artifacts, "fx_pairs", [("aaaa", "fx:whatever:tabular_dl", None)])
+
+    findings = check_case_study("fx_pairs", repo_root=repo, artifacts_root=artifacts)
+
+    assert len(findings) == 1, "a notebook whose population name is an f-string was skipped"
+    # `unresolved`, not `stale`: with the name unreadable and the hash in no lineage, this
+    # is either a dead literal or one waiting for a first publication, and the difference
+    # cannot be told from here. What matters is that the declaration was READ at all.
+    assert findings[0].status == "unresolved"
+
+
+def test_an_empty_registry_does_not_make_every_declaration_stale(tree):
+    """A reset registry publishes generation one; failing there would block valid runs.
+
+    `population_supersedes` withholds a hash it cannot place and `create` then publishes the
+    first generation without a predecessor. So an absent hash is only wrong when a generation
+    ALREADY exists under the name this notebook publishes under - merely creating the
+    registry must not flip this check from passing to blocking.
+    """
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "aaaa", "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert not any(f.is_stale for f in findings), "an empty registry was read as staleness"
+    assert findings[0].status == "unresolved"
+
+
+def test_an_empty_literal_is_not_a_finding(tree):
+    """Most notebooks have never superseded anything. That is the ordinary state."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "06_linear", "", "etfs-linear-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-linear-v1", None)])
+
+    assert check_case_study("etfs", repo_root=repo, artifacts_root=artifacts) == []
+
+
+def test_no_registry_is_reported_and_does_not_fail(tree):
+    """A reader's clone. `run_log/` is gitignored, so this is the ordinary case off-machine."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "aaaa", "etfs-gbm-v1")
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert [f.status for f in findings] == ["no-registry"]
+    assert not any(f.is_stale for f in findings)
+
+
+def test_a_forked_lineage_is_reported_rather_than_guessed_at(tree):
+    """Two snapshots nothing supersedes has no defensible answer."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "aaaa", "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None), ("bbbb", "etfs-gbm-v1", None)])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert [f.status for f in findings] == ["forked"]
+
+
+def test_exit_status_is_one_when_anything_is_stale(tree):
+    """The gate's contract: a queueing step reads the status, not the prose."""
+    from scripts.check_supersedes_literals import main
+
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "gone", "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None)])
+
+    import scripts.check_supersedes_literals as module
+
+    original = module.REPO_ROOT
+    module.REPO_ROOT = repo
+    try:
+        assert main(["--artifacts-root", str(artifacts)]) == 1
+        _notebook(repo, "etfs", "07_gbm", "aaaa", "etfs-gbm-v1")
+        assert main(["--artifacts-root", str(artifacts)]) == 0
+    finally:
+        module.REPO_ROOT = original
+
+
+def test_the_scan_reads_the_real_corpus_without_falling_over():
+    """The scanner against real registries, which the synthetic fixtures cannot stand in for.
+
+    It deliberately does NOT assert the corpus is clean. Six literals are stale as this is
+    written, and leaving them is the decision rather than an oversight: editing one makes the
+    paired `.ipynb` stale, and the only sanctioned way to commit that drops its outputs. That
+    costs a live render in a `done` case study for a fault that bites nothing until those
+    notebooks next execute - at which point the run restores the render for free. So the
+    corpus is corrected by `scripts/check_supersedes_literals.py` refusing the chain at
+    queue time, not by a red test somebody learns to scroll past.
+
+    What this pins is that the scan runs on real data and every finding is classified. A
+    scanner that crashed on a real schema, or invented a status, would pass every synthetic
+    test above and fail here.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    artifacts_root = Path.home() / "ml4t" / "artifacts" / "case_studies"
+    if not artifacts_root.is_dir():
+        pytest.skip(f"no registries at {artifacts_root}; run_log/ is gitignored")
+
+    findings = check_all(repo_root=repo_root, artifacts_root=artifacts_root)
+    if not any(f.status != "no-registry" for f in findings):
+        pytest.skip("registries present but none holds an official_populations table")
+
+    known = {"live", "stale", "superseded", "unresolved", "forked", "no-registry"}
+    unclassified = [f for f in findings if f.status not in known]
+    assert not unclassified, f"unrecognised status: {unclassified}"
+    assert all(f.detail for f in findings), "a finding with no explanation is not usable"
+
+
+def _causal_notebook(repo: Path, case_study: str, stem: str, declared: str) -> None:
+    """A bare hash is written double-quoted; a JSON map can only be single-quoted."""
+    directory = repo / "case_studies" / case_study
+    directory.mkdir(parents=True, exist_ok=True)
+    line = (
+        f"SUPERSEDES_CAUSAL: str = '{declared}'"
+        if declared.startswith("{")
+        else f'SUPERSEDES_CAUSAL: str = "{declared}"'
+    )
+    (directory / f"{stem}.py").write_text(line + "\n")
+
+
+def _causal_rows(
+    root: Path,
+    case_study: str,
+    rows: list[tuple[str, str, str | None]],
+    *,
+    identity_version: int = IDENTITY_VERSION,
+    tier: str = "canonical",
+) -> None:
+    """`rows` is (hash, label, supersedes_hash).
+
+    `spec_json` is not decoration: `current_causal_identities` reads `identity_version` and
+    `execution_tier` out of it and excludes a row carrying either wrong. A fixture without it
+    would let this test pass against a checker that ignores both.
+    """
+    db = sqlite3.connect(root / case_study / "run_log" / "registry.db")
+    db.executemany(
+        "INSERT INTO causal_runs VALUES (?, ?, ?, ?)",
+        [
+            (
+                h,
+                label,
+                json.dumps({"identity_version": identity_version, "execution_tier": tier}),
+                sup,
+            )
+            for h, label, sup in rows
+        ],
+    )
+    db.commit()
+    db.close()
+
+
+def test_a_current_causal_identity_is_live(tree):
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", "aaaa")
+    _registry(artifacts, "etfs", [])
+    _causal_rows(artifacts, "etfs", [("aaaa", "fwd_ret_21d", None)])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert [f.status for f in findings] == ["live"]
+
+
+def test_a_retired_causal_identity_is_reported_but_does_not_fail(tree):
+    """Withheld is not automatically wrong, and this is the case that proves it.
+
+    A notebook that already published its successor and was left unchanged still declares
+    the predecessor. `causal_supersedes` withholds it, the runner resolves to the cached
+    successor, and nothing fails. Failing here would send that author to declare a hash
+    which already records theirs as its own predecessor.
+    """
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", "aaaa")
+    _registry(artifacts, "etfs", [])
+    _causal_rows(
+        artifacts, "etfs", [("aaaa", "fwd_ret_21d", None), ("bbbb", "fwd_ret_21d", "aaaa")]
+    )
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert findings[0].status == "superseded"
+    assert not findings[0].is_stale, "an unchanged re-run must not be reported as a failure"
+
+
+def test_a_bare_causal_hash_the_registry_lost_is_unresolved(tree):
+    """A bare declaration names no label, so the checker cannot say which it is.
+
+    `etfs/12_causal_dml` is this shape: the hash is gone, but without the label there is no
+    way to tell a dead literal from one waiting on a first publication, and refusing would
+    block a valid first run.
+    """
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", "gone")
+    _registry(artifacts, "etfs", [])
+    _causal_rows(artifacts, "etfs", [("aaaa", "fwd_ret_21d", None)])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert findings[0].status == "unresolved"
+    assert not findings[0].is_stale
+
+
+def test_a_per_label_causal_hash_is_stale_when_that_label_already_resolves(tree):
+    """The case that IS provable: the label is named and already has a current identity."""
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", '{"fwd_ret_21d": "gone"}')
+    _registry(artifacts, "etfs", [])
+    _causal_rows(artifacts, "etfs", [("aaaa", "fwd_ret_21d", None)])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert findings[0].is_stale
+    assert "placebo refit" in findings[0].detail
+    assert findings[0].label == "fwd_ret_21d"
+    assert findings[0].remedy == "aaaa"
+
+
+def test_an_empty_causal_table_does_not_make_a_declaration_stale(tree):
+    """A reset registry accepts the first identity; refusing would block a valid run."""
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", '{"fwd_ret_21d": "gone"}')
+    _registry(artifacts, "etfs", [])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert [f.status for f in findings] == ["unresolved"]
+
+
+def test_a_per_label_causal_declaration_is_read(tree):
+    """A notebook fitting several labels declares a JSON object, not a bare hash."""
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", '{"fwd_ret_21d": "aaaa", "fwd_ret_5d": "gone"}')
+    _registry(artifacts, "etfs", [])
+    _causal_rows(artifacts, "etfs", [("aaaa", "fwd_ret_21d", None)])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert len(findings) == 2, "a per-label declaration must be read for every label it names"
+    # `fwd_ret_5d` has no rows at all, so its missing hash is unresolved rather than stale.
+    assert sorted(f.status for f in findings) == ["live", "unresolved"]
+
+
+def test_an_outdated_identity_version_is_not_current(tree):
+    """`current_causal_identities` excludes it, so approving it would be a false green."""
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", "aaaa")
+    _registry(artifacts, "etfs", [])
+    _causal_rows(
+        artifacts, "etfs", [("aaaa", "fwd_ret_21d", None)], identity_version=IDENTITY_VERSION - 1
+    )
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert findings[0].status == "superseded", "an outdated identity was treated as current"
+
+
+def test_a_preview_tier_row_is_not_current(tree):
+    """The other filter the resolver applies, and the other way to approve a dead hash."""
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", "aaaa")
+    _registry(artifacts, "etfs", [])
+    _causal_rows(artifacts, "etfs", [("aaaa", "fwd_ret_21d", None)], tier="preview")
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert findings[0].status == "superseded", "a preview row was treated as canonical"
+
+
+def test_an_annotation_of_str_or_none_is_read(tree):
+    """`cme_futures/09_dl_lstm.py` writes `str | None`; a `: str =` pattern misses it."""
+    repo, artifacts = tree
+    directory = repo / "case_studies" / "cme_futures"
+    directory.mkdir(parents=True)
+    (directory / "09_dl_lstm.py").write_text(
+        'SUPERSEDES_POPULATION: str | None = "gone"\n'
+        'population_name = POPULATION_NAME or "cme-lstm-v1"\n'
+    )
+    _registry(artifacts, "cme_futures", [("aaaa", "cme-lstm-v1", None)])
+
+    findings = check_case_study("cme_futures", repo_root=repo, artifacts_root=artifacts)
+
+    assert len(findings) == 1, "a `str | None` annotation was skipped"
+    assert findings[0].is_stale
+
+
+def test_a_parenthesised_multiline_declaration_is_read(tree):
+    """`fx_pairs/11_causal_dml.py` wraps its JSON in parentheses across two lines."""
+    repo, artifacts = tree
+    directory = repo / "case_studies" / "fx_pairs"
+    directory.mkdir(parents=True)
+    (directory / "11_causal_dml.py").write_text(
+        'SUPERSEDES_CAUSAL: str = (\n    \'{"fwd_ret_1d": "aaaa", "fwd_ret_5d": "gone"}\'\n)\n'
+    )
+    _registry(artifacts, "fx_pairs", [])
+    _causal_rows(artifacts, "fx_pairs", [("aaaa", "fwd_ret_1d", None)])
+
+    findings = check_case_study("fx_pairs", repo_root=repo, artifacts_root=artifacts)
+
+    assert len(findings) == 2, "a parenthesised multi-line declaration was skipped"
+    assert sorted(f.status for f in findings) == ["live", "unresolved"]
+
+
+def _exit_status(repo: Path, artifacts: Path, *argv: str) -> int:
+    import scripts.check_supersedes_literals as module
+
+    original = module.REPO_ROOT
+    module.REPO_ROOT = repo
+    try:
+        return module.main(["--artifacts-root", str(artifacts), *argv])
+    finally:
+        module.REPO_ROOT = original
+
+
+def test_the_named_flag_waives_a_stale_literal(tree):
+    """For a run whose membership is unchanged, where the literal is never read.
+
+    Named after what it waives rather than `--force`, because a general force flag becomes
+    the way people get past every check in the script and the gate turns into a warning
+    wearing a different hat.
+    """
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "gone", "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None)])
+
+    assert _exit_status(repo, artifacts) == 1
+    assert _exit_status(repo, artifacts, "--allow-stale-supersedes") == 0
+
+
+def test_an_unresolved_declaration_never_blocks(tree):
+    """Refusing on "I could not resolve this" asserts knowledge the checker does not have."""
+    repo, artifacts = tree
+    directory = repo / "case_studies" / "fx_pairs"
+    directory.mkdir(parents=True)
+    (directory / "08_tabular_dl.py").write_text(
+        'SUPERSEDES_POPULATION: str = "gone"\n'
+        'population_name = POPULATION_NAME or f"{CASE_STUDY_ID}:tabular_dl"\n'
+    )
+    _registry(artifacts, "fx_pairs", [("aaaa", "some-other-name", None)])
+
+    findings = check_case_study("fx_pairs", repo_root=repo, artifacts_root=artifacts)
+
+    assert [f.status for f in findings] == ["unresolved"]
+    assert _exit_status(repo, artifacts) == 0
+
+
+def test_a_stale_finding_carries_the_hash_to_paste(tree):
+    """The message has to say what the fix is, not only that something is wrong."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "gone", "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None)])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert findings[0].remedy == "aaaa"
+
+
+def test_a_per_label_causal_remedy_names_that_labels_current_identity(tree):
+    """A per-label declaration knows its label, so the answer can be exact."""
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", '{"fwd_ret_21d": "gone"}')
+    _registry(artifacts, "etfs", [])
+    _causal_rows(artifacts, "etfs", [("bbbb", "fwd_ret_21d", None)])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert findings[0].is_stale
+    assert findings[0].remedy == "bbbb"
+
+
+def test_a_multi_label_repair_says_which_entry_to_replace(capsys, tree):
+    """Following "set it to <hash>" on a mapping would break the run this message saves.
+
+    `supersedes_for` rejects a bare hash from a notebook that fits several labels, so the
+    instruction has to name the entry rather than the declaration.
+    """
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", '{"fwd_ret_21d": "gone"}')
+    _registry(artifacts, "etfs", [])
+    _causal_rows(artifacts, "etfs", [("aaaa", "fwd_ret_21d", None)])
+
+    assert _exit_status(repo, artifacts) == 1
+    message = capsys.readouterr().err
+
+    assert "replace the 'fwd_ret_21d' entry in the mapping" in message
+    assert "leaving the other entries as they are" in message


### PR DESCRIPTION
Refs ml4t/agent-workspace#1067. Paired with agents `d35e3890`, which calls this from `nb-queue.sh add`.

A notebook that published an official population and then moved a training identity names the snapshot it replaces as a committed literal. That hash goes stale whenever the registry tip moves without it — a reset, a refit, a chain someone else advanced — and `OfficialPopulation.create` then refuses the write, after the fit has been paid for.

**Nothing that runs before a production chain can see it.** `supersedes_for_run` returns `None` for any tier but `canonical`, so a preview never resolves a supersedes hash and never reaches the lineage check registration enforces. That guard is correct and stays: a preview is discarded with its workspace and has no lineage to extend. On 2026-09-06 twelve `sp500_options` notebooks passed smoke and three failed the real chain fifteen minutes later, on eleven stale literals.

**CI cannot see it either**, which is why this is a script and not only a test: `run_log/` is gitignored, `git ls-files` holds zero registries, and a fresh worktree has none. A pytest asserting over the corpus would skip on every CI run forever — the same absence-reading-as-a-pass the defect is made of.

## Keyed on the hash, not the population name

Only some notebooks build their name as `POPULATION_NAME or "a-literal"`; the rest use an f-string over the label set or a module constant, which no static read resolves.

My first pass was name-keyed. It silently skipped **8 of the 17** declared literals — including **3 of the 6 stale ones** — and reported green. Looking the declared hash up in `official_populations` and resolving the lineage of whatever name owns it reads all 17. A test pins that shape so it cannot be simplified back.

## Measured

17 non-empty literals; **6 stale**, across three case studies:

| case study | notebook | dead hash |
|---|---|---|
| cme_futures | `06_linear.py`, `07_gbm.py` | `8337482ecb59`, `9f26b89f9310` |
| fx_pairs | `06_linear.py`, `07_gbm.py`, `08_tabular_dl.py` | `d1b0c5a302f8`, `23abc9ef1009`, `7896f6bcaf7e` |
| sp500_equity_option_analytics | `11e_supervised_autoencoder.py` | `9d91aafd2b10` |

Each names a hash absent from its registry: those three were reset, so their populations are generation one and there is nothing to supersede.

## The six are deliberately not fixed here

Editing a literal changes a code cell, so the paired `.ipynb` goes stale, and the only sanctioned way to commit that drops its outputs. All six carry live renders executed 2026-09-06 — between 5 and 13 output cells each, 133KB to 898KB — in case studies that are `done`, unowned and unscheduled, so nothing would bring them back.

The fault costs nothing until those notebooks next execute, and at that moment the fix is free, because the run restores the render. So the gate refuses the chain and tells the person queueing it exactly that. Its failure message ends:

> Fix the literal now — you are about to pay for the run that re-renders it anyway.

Spending six live renders today to fix a fault that bites nothing in the interval, and cannot be undone without the run it was meant to save, is the wrong trade.

## Tests

Ten. The logic runs everywhere against registries the tests build — the tip, the generation the tip replaced, two generations behind, a hash the registry lost, a fork, an empty literal, a clone with no registry, and the exit status the gate reads.

The corpus scan is separate and **deliberately does not assert the corpus is clean**. It pins that the scanner reads real registries and classifies every finding, because with six known-stale literals a cleanliness assertion would be a permanently red test that people learn to scroll past — no better than a permanently skipped one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRbvPEVfdF9eSebTiX8vgM
