### PR TITLE
Compare OHLC prices with a tolerance, not with >=

### DIFF
--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -14,6 +14,8 @@ Pins:
 
 from __future__ import annotations
 
+import math
+
 import polars as pl
 import pytest
 
@@ -357,3 +359,65 @@ def test_the_gate_refuses_a_feature_frame_that_holds_none_of_the_columns_named()
             feature_cols=model_based_cols,
             label_col="fwd_ret_15m",
         )
+
+
+def test_check_ohlc_invariants_tolerates_adjustment_rounding() -> None:
+    """A high that IS the close, one ulp below it, is not a violation.
+
+    An adjusted panel applies its cumulative ratio to each field separately, so the
+    two products can differ in the last bit even though the bar's high and close are
+    the same price. The strict comparison this replaced reported 760 such rows on the
+    ETF panel, all with a breach smaller than one float64 epsilon of the close.
+    """
+    close = 862.5 * 0.9873456789
+    high = math.nextafter(close, 0.0)  # one ulp below: the same price, rounded apart
+    assert high < close, "the fixture must actually breach a strict comparison"
+
+    df = pl.DataFrame(
+        {
+            "open": [close],
+            "high": [high],
+            "low": [math.nextafter(close, 0.0)],
+            "close": [close],
+            "volume": [1_000],
+        }
+    )
+    invariants = check_ohlc_invariants(df)
+    assert (invariants["valid_pct"] == 100.0).all()
+
+
+def test_check_ohlc_invariants_rtol_zero_restores_strict_comparison() -> None:
+    """The tolerance is what admits the ulp, not some other leniency in the check.
+
+    Without this, the test above would still pass if the comparison had been changed
+    to something that never fails, and nothing would say so.
+    """
+    close = 862.5 * 0.9873456789
+    df = pl.DataFrame(
+        {
+            "open": [close],
+            "high": [math.nextafter(close, 0.0)],
+            "low": [close],
+            "close": [close],
+            "volume": [1_000],
+        }
+    )
+    strict = check_ohlc_invariants(df, rtol=0.0)
+    row = strict.filter(pl.col("check") == "high_gte_close").row(0, named=True)
+    assert row["valid_pct"] == 0.0
+
+
+def test_check_ohlc_invariants_still_detects_a_real_violation() -> None:
+    """One cent on a $100 bar is 1e-4 relative, eleven orders above the tolerance."""
+    df = pl.DataFrame(
+        {
+            "open": [100.0],
+            "high": [99.99],  # a cent below the close: a genuine defect
+            "low": [99.0],
+            "close": [100.0],
+            "volume": [1_000],
+        }
+    )
+    invariants = check_ohlc_invariants(df)
+    row = invariants.filter(pl.col("check") == "high_gte_close").row(0, named=True)
+    assert row["valid_pct"] == 0.0

--- a/utils/data_quality.py
+++ b/utils/data_quality.py
@@ -124,6 +124,21 @@ def print_coverage(
     print(f"  Unique times: {cov['unique_times']:,}")
 
 
+# An adjusted price panel applies one cumulative ratio to each OHLC field separately, and
+# the four multiplications do not round identically. A bar whose high IS its close then
+# stores two float64 values a bit or two apart, and a strict `high >= close` reports it as
+# a violation of an invariant the data does not actually break. Measured on the ETF panel
+# in 02_financial_data_universe/03_etfs_eda: 760 of 470,662 rows, largest breach 2.01e-16
+# of the close against a float64 epsilon of 2.22e-16.
+#
+# The tolerance is relative because the same panel spans closes from 5.60 to 862.50, so a
+# fixed absolute epsilon is two orders of magnitude too coarse at one end and too fine at
+# the other. Four epsilons covers the ~1 ulp that two independently rounded products can
+# differ by, with headroom, and is still ~11 orders of magnitude below the smallest
+# violation a real data defect produces: one cent on a $100 bar is 1e-4 relative.
+OHLC_RELATIVE_TOLERANCE = 4 * 2.220446049250313e-16
+
+
 def check_ohlc_invariants(
     df: pl.DataFrame,
     open_col: str = "open",
@@ -131,6 +146,7 @@ def check_ohlc_invariants(
     low_col: str = "low",
     close_col: str = "close",
     volume_col: str = "volume",
+    rtol: float = OHLC_RELATIVE_TOLERANCE,
 ) -> pl.DataFrame:
     """Check OHLC data quality invariants.
 
@@ -142,6 +158,14 @@ def check_ohlc_invariants(
     - low <= close
     - volume >= 0 (if volume column exists)
 
+    The ordering comparisons are inexact. Each is evaluated against a tolerance
+    proportional to the magnitudes being compared, because an adjusted price panel
+    stores a bar whose high IS its close as two float64 values a bit apart - the
+    cumulative adjustment ratio is applied to each field separately and the products
+    do not round identically. A strict comparison reports those bars as violations of
+    an invariant the data does not break. ``volume >= 0`` stays exact: zero has no
+    rounding neighbourhood to allow for.
+
     For each check, only rows where all relevant columns are non-null are
     considered. This prevents null comparisons from distorting percentages
     (important for TAQ data where trade columns may be null for no-trade bars).
@@ -150,6 +174,9 @@ def check_ohlc_invariants(
         df: DataFrame with OHLC columns
         open_col, high_col, low_col, close_col: Column names for OHLC
         volume_col: Column name for volume (optional)
+        rtol: Relative tolerance for the ordering comparisons. The default,
+            ``OHLC_RELATIVE_TOLERANCE``, admits float64 adjustment noise and nothing
+            a real data defect would produce. Pass 0.0 for exact comparisons.
 
     Returns:
         DataFrame with check names and valid_pct columns
@@ -157,6 +184,11 @@ def check_ohlc_invariants(
     results = []
     total_rows = df.height
     cols = set(df.columns)
+
+    def _at_least(greater: str, lesser: str) -> pl.Expr:
+        """``greater >= lesser`` allowing ``rtol`` scaled to the pair's magnitude."""
+        slack = rtol * pl.max_horizontal(pl.col(greater).abs(), pl.col(lesser).abs())
+        return pl.col(greater) >= pl.col(lesser) - slack
 
     def _check_invariant(name: str, condition: pl.Expr, required_cols: list[str]) -> None:
         """Check an invariant on rows where all required columns are non-null."""
@@ -182,35 +214,35 @@ def check_ohlc_invariants(
     if {high_col, low_col}.issubset(cols):
         _check_invariant(
             "high_gte_low",
-            pl.col(high_col) >= pl.col(low_col),
+            _at_least(high_col, low_col),
             [high_col, low_col],
         )
 
     if {high_col, open_col}.issubset(cols):
         _check_invariant(
             "high_gte_open",
-            pl.col(high_col) >= pl.col(open_col),
+            _at_least(high_col, open_col),
             [high_col, open_col],
         )
 
     if {high_col, close_col}.issubset(cols):
         _check_invariant(
             "high_gte_close",
-            pl.col(high_col) >= pl.col(close_col),
+            _at_least(high_col, close_col),
             [high_col, close_col],
         )
 
     if {low_col, open_col}.issubset(cols):
         _check_invariant(
             "low_lte_open",
-            pl.col(low_col) <= pl.col(open_col),
+            _at_least(open_col, low_col),
             [low_col, open_col],
         )
 
     if {low_col, close_col}.issubset(cols):
         _check_invariant(
             "low_lte_close",
-            pl.col(low_col) <= pl.col(close_col),
+            _at_least(close_col, low_col),
             [low_col, close_col],
         )
 


### PR DESCRIPTION
`check_ohlc_invariants` reported false violations on every adjusted price panel, in every chapter that calls it.

An adjusted panel applies one cumulative ratio to each OHLC field separately, and the four multiplications do not round identically. A bar whose high **is** its close then stores two float64 values a bit apart, and `high >= close` calls that a broken invariant.

## Measured

On the ETF panel that `02_financial_data_universe/03_etfs_eda` reads, 470,662 rows:

| check | strict (`rtol=0`) | with tolerance |
|---|---|---|
| `high_gte_close` | 99.8995% | **100.0%** |
| `low_lte_close` | 99.9390% | **100.0%** |

The largest breach anywhere in the 760 offending rows is 2.01e-16 of the close, median 1.23e-16, against a float64 epsilon of 2.22e-16. There is no defect in the data.

## Why relative

The same panel spans closes from 5.60 to 862.50, so the representable gap differs by two orders of magnitude within one column and a fixed absolute epsilon is wrong at both ends. Four epsilons covers the ~1 ulp two independently rounded products can differ by, and stays eleven orders of magnitude below the smallest violation a real defect produces: one cent on a \$100 bar is 1e-4 relative. `volume >= 0` stays exact - zero has no rounding neighbourhood to allow for.

## Tests

Three, with hit and no-hit both pinned:

- the ulp fixture reads clean under the new default;
- the same fixture at `rtol=0.0` reads 0%, so the tolerance is provably what admits it and the check has not simply been made unable to fail;
- a one-cent violation is still caught.

## Callers affected

`02_financial_data_universe/{01,03,04,10,12}`, `03_market_microstructure/13`, `scripts/verify_installation.py`. Chapter 02's `04_cme_futures_eda` read 100% before only because its futures series happen not to tie.

## Provenance

Found by the chapter-02 session, which measured the breach sizes instead of accepting the notebook's stated cause. The prose blamed per-field vendor rounding - a real mechanism that produces the same failed check, at a fraction of a cent rather than a fraction of a trillionth. A violation count cannot tell the two apart, and the wrong explanation had stood for a long time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu