### PR TITLE
Make the alt-text gate read the edit, and give it a way to be satisfied

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -681,6 +681,30 @@ def _percent_cells(src: str) -> list[tuple[str, str, str]]:
     return [(m, k, "".join(b)) for m, k, b in cells]
 
 
+def _code_bodies(src: str) -> list[str]:
+    """Code-cell bodies of *src*, aligned one-to-one with a notebook's code cells.
+
+    ``_percent_cells`` always emits a leading entry for whatever precedes the first
+    ``# %%`` marker - in a jupytext percent file that is the YAML header comment - and
+    labels it ``code`` because no marker said otherwise. It is not a cell and the notebook
+    has no counterpart for it, so anything zipping source bodies against notebook cells is
+    off by one and rejects every notebook. Dropping it is the only difference from
+    ``_percent_cells``, and it is the difference between a working alignment and one that
+    silently declines to do its job.
+    """
+    cells = _percent_cells(src)
+    # Marker-less AND codeless. A jupytext percent file opens with the YAML header comment
+    # before its first `# %%`, which is what this drops. A bare snippet with no markers at
+    # all also has an empty marker, and its body IS the first cell - dropping that one
+    # misaligns every later cell by one, which does not produce a wrong answer so much as
+    # a blanket refusal, and a blanket refusal here reads as "no notebook qualifies".
+    if cells and cells[0][0] == "":
+        body = cells[0][2]
+        if all(not ln.strip() or ln.lstrip().startswith("#") for ln in body.splitlines()):
+            cells = cells[1:]
+    return [body for _, kind, body in cells if kind == "code"]
+
+
 def _alt_literal_spans(arg: ast.expr) -> list[ast.Constant] | None:
     """The string constants of an alt argument, each flagged standalone or in-f-string.
 
@@ -904,13 +928,30 @@ def alt_text_only_drift(stamped_blob: str, py: Path, nb: dict) -> bool:
     if old_cells is None or new_cells is None or old_cells != new_cells:
         return False
 
-    for cell in nb.get("cells", []):
-        if cell.get("cell_type") != "code":
-            continue
+    # The alts to require come from the NEW .py, not from the notebook's own cell source.
+    # Reading them off the notebook compared the executed source against the outputs that
+    # same execution produced - true of every executed notebook, and silent about the edit
+    # actually being adjudicated. Measured on 2026-09-08: appending a sentence to a plain
+    # literal alt in cme_futures/03_financial_features.py was reported ALT-TEXT ONLY and
+    # allowed, with the output metadata still carrying the old sentence, which is the exact
+    # thing the paragraph above says is stale. The first half of this function already
+    # establishes that the two sources have the same code cells in the same order once alts
+    # are blanked, so zipping them by order is safe.
+    new_code_bodies = _code_bodies(new_source)
+    nb_code_cells = [c for c in nb.get("cells", []) if c.get("cell_type") == "code"]
+    alt_bearing = [
+        c for c in nb_code_cells if any(fn in "".join(c.get("source", [])) for fn in ALT_FUNCS)
+    ]
+    # Only an alt-bearing notebook needs the two lined up. A notebook with no alt calls has
+    # nothing for this half to check, and requiring the counts to match there would reject
+    # the papermill-cleanup and markdown-only cases this function also serves.
+    if alt_bearing and len(new_code_bodies) != len(nb_code_cells):
+        return False
+    for cell, new_body in zip(nb_code_cells, new_code_bodies, strict=False):
         src = "".join(cell.get("source", []))
         if not any(fn in src for fn in ALT_FUNCS):
             continue
-        blanked = _blank_alts(src)
+        blanked = _blank_alts(new_body)
         if blanked is None:
             return False
         carried = [
@@ -1489,6 +1530,229 @@ def sync_prose(nb_path: Path) -> str:
     return stamp["source_py_blob"]
 
 
+def _splice_alt(
+    old_segments: tuple[str, ...], new_segments: tuple[str, ...], carried: str
+) -> str | None:
+    """*carried* with its prose replaced by *new_segments*, keeping the interpolated values.
+
+    A computed alt renders as ``seg0 + value0 + seg1 + value1 + ...`` and only the values
+    need a kernel to produce. They are already in the executed output, so a prose fix to an
+    f-string alt does not need one: find the values in the gaps between the OLD segments,
+    then rebuild around the NEW ones.
+
+    None when the two sources interpolate a different number of times - that is a change to
+    what the alt asserts about the data, not to its wording, and it needs the run.
+    """
+    if len(old_segments) != len(new_segments):
+        return None
+    values: list[str] = []
+    position = 0
+    for index, segment in enumerate(old_segments):
+        found = carried.find(segment, position)
+        if found < 0:
+            return None
+        if index:
+            values.append(carried[position:found])
+        elif found != 0:
+            return None  # the carried alt does not start where the source says it does
+        position = found + len(segment)
+    values.append(carried[position:])
+    rebuilt = new_segments[0]
+    for segment, value in zip(new_segments[1:], values[:-1], strict=True):
+        rebuilt += value + segment
+    return rebuilt + values[-1]
+
+
+def _image_outputs(cell: dict) -> list[dict]:
+    """The cell's image outputs, in the order the alt calls that produced them appear."""
+    return [out for out in cell.get("outputs", []) if "image/png" in (out.get("data") or {})]
+
+
+def sync_alt(nb_path: Path) -> str:
+    """Fold an alt-text correction into an executed notebook, without re-running it.
+
+    ``sync_prose`` deliberately refuses this: it keeps the outputs, so an alt the output
+    metadata does not carry would be stamped as current while the notebook still renders
+    the old sentence. ``alt_text_only_drift`` accepts a corrected alt, but only once the
+    outputs carry it - and nothing wrote it there. That left the cheap path documented and
+    unreachable: the band correcting an alt on a 40-second notebook just re-ran it, and the
+    band that would have needed it most, on a notebook priced in hours, had no way in.
+
+    This is the missing half. ``show_plotly_with_alt`` publishes the alt as
+    ``metadata["image/png"]["alt"]`` and takes the image from ``fig._repr_mimebundle_()``,
+    which never sees the string - so writing the corrected alt into the output metadata
+    produces exactly the bytes a re-run would, and the gate's claim stays true rather than
+    being talked around.
+
+    Refuses unless every code cell is identical once the alt literals are blanked, which is
+    the same test ``alt_text_only_drift`` applies, and unless every alt it must rewrite is
+    one it can rewrite: a plain literal is copied, a computed alt keeps the values already
+    in the output and takes the new prose around them, and an alt passed as a variable is
+    refused because its rendered text is not in the source at all.
+    """
+    py = paired_py(nb_path)
+    rel = nb_path.relative_to(REPO_ROOT)
+    if py is None:
+        raise SystemExit(f"no paired .py for {rel}")
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    stamp = nb.get("metadata", {}).get(STAMP_KEY)
+    if not stamp:
+        raise SystemExit(
+            f"{rel} carries no provenance stamp, so there is no executed state to preserve. Run it."
+        )
+    stamped_blob = stamp["source_py_blob"]
+    old = subprocess.run(
+        ["git", "cat-file", "blob", stamped_blob],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if old.returncode != 0:
+        raise SystemExit(
+            f"{rel} is stamped against blob {stamped_blob[:12]}, which is not in this repo, "
+            "so the code cells cannot be compared. Re-run it."
+        )
+    old_source = old.stdout
+    before = code_cells_only(_comparable(old_source, blank_alts=True))
+    after = code_cells_only(_comparable(py.read_text(encoding="utf-8"), blank_alts=True))
+    if before is None or after is None:
+        raise SystemExit(f"{rel}: could not parse one of the two sources - refusing")
+    if before != after:
+        where = next(
+            (i for i, (a, b) in enumerate(zip(before, after)) if a != b),
+            min(len(before), len(after)),
+        )
+        detail = f"code cell {where + 1} differs"
+        if len(before) != len(after):
+            detail = f"{len(before)} code cells in the executed source, {len(after)} now"
+        raise SystemExit(
+            f"{rel}: {detail} for something other than an alt literal, so the outputs on disk "
+            "are not the ones this source produces. Re-run the notebook."
+        )
+
+    # Plan every rewrite against the notebook AS EXECUTED before touching anything, so a
+    # cell this cannot rewrite refuses the whole command instead of leaving half a notebook
+    # updated - the failure the atomicity rule exists for.
+    old_bodies = _code_bodies(old_source)
+    new_bodies = _code_bodies(py.read_text(encoding="utf-8"))
+    nb_code_cells = [c for c in nb.get("cells", []) if c.get("cell_type") == "code"]
+    if not (len(old_bodies) == len(new_bodies) == len(nb_code_cells)):
+        raise SystemExit(
+            f"{rel}: {len(old_bodies)} code cells in the executed source, {len(new_bodies)} now, "
+            f"{len(nb_code_cells)} in the notebook. Cannot line them up - re-run the notebook."
+        )
+    plan: list[str] = []
+    for cell, old_body, new_body in zip(nb_code_cells, old_bodies, new_bodies, strict=True):
+        src = "".join(cell.get("source", []))
+        if not any(fn in src for fn in ALT_FUNCS):
+            continue
+        old_alts = _blank_alts(old_body)
+        new_alts = _blank_alts(new_body)
+        if old_alts is None or new_alts is None:
+            raise SystemExit(f"{rel}: an alt-bearing cell does not parse - refusing")
+        outputs = _image_outputs(cell)
+        if not (len(old_alts[1]) == len(new_alts[1]) == len(outputs)):
+            raise SystemExit(
+                f"{rel}: {len(new_alts[1])} alt call(s) in the source against {len(outputs)} "
+                "image output(s). The notebook is not the render of this source. Re-run it."
+            )
+        for old_alt, new_alt, output in zip(old_alts[1], new_alts[1], outputs, strict=True):
+            carried = ((output.get("metadata") or {}).get("image/png") or {}).get("alt")
+            if isinstance(new_alt, str):
+                plan.append(new_alt)
+            elif isinstance(new_alt, tuple) and isinstance(old_alt, tuple):
+                if carried is None:
+                    raise SystemExit(
+                        f"{rel}: a computed alt has no text in the executed output, so its "
+                        "interpolated values cannot be recovered. Re-run the notebook."
+                    )
+                spliced = _splice_alt(old_alt, new_alt, carried)
+                if spliced is None:
+                    raise SystemExit(
+                        f"{rel}: a computed alt interpolates a different number of values than "
+                        "the executed one, which changes what it asserts about the data rather "
+                        "than how it is worded. Re-run the notebook."
+                    )
+                plan.append(spliced)
+            else:
+                raise SystemExit(
+                    f"{rel}: an alt is passed as a variable, so its rendered text is not in the "
+                    "source and cannot be written into the output. Re-run the notebook."
+                )
+
+    if not plan:
+        raise SystemExit(
+            f"{rel}: no alt text to write. If the edit was markdown only, use sync-prose."
+        )
+
+    before_counts = _output_counts(nb)
+    result = subprocess.run(
+        [sys.executable, "-m", "jupytext", "--to", "ipynb", "--update", str(py)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        if "No module named jupytext" in result.stderr:
+            raise SystemExit(
+                f"{rel}: jupytext is not installed in {sys.executable}. Run this command through "
+                "the repository environment with `uv run python`."
+            )
+        raise SystemExit(f"{rel}: jupytext --update failed:\n{result.stderr}")
+
+    updated = json.loads(nb_path.read_text(encoding="utf-8"))
+    after_counts = _output_counts(updated)
+    if after_counts != before_counts:
+        raise SystemExit(
+            f"{rel}: the update changed the outputs, which is the one thing it exists to avoid. "
+            "The file has been left as jupytext wrote it; restore it with `git checkout`."
+        )
+
+    # Re-derive the plan's targets in the file jupytext just wrote: the plan holds objects
+    # from the notebook as it was read, and writing into those would be discarded.
+    written = 0
+    position = 0
+    for cell in updated.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        src = "".join(cell.get("source", []))
+        if not any(fn in src for fn in ALT_FUNCS):
+            continue
+        for output in _image_outputs(cell):
+            output.setdefault("metadata", {}).setdefault("image/png", {})["alt"] = plan[position]
+            position += 1
+            written += 1
+    if written != len(plan):
+        raise SystemExit(
+            f"{rel}: planned {len(plan)} alt rewrite(s) but the updated notebook has {written} "
+            "image output(s) under alt calls. The file has been left as jupytext wrote it; "
+            "restore it with `git checkout`."
+        )
+
+    stamp = dict(stamp)
+    stamp["source_py_blob"] = git_blob(py)
+    stamp["notes"] = (
+        f"alt text synced from the .py at {datetime.now(UTC).isoformat()} without re-executing; "
+        f"every code cell is identical to blob {stamped_blob[:12]} once alt literals are blanked, "
+        f"and {written} output alt(s) were rewritten to match"
+    )
+    updated.setdefault("metadata", {})[STAMP_KEY] = stamp
+    nb_path.write_text(json.dumps(updated, indent=1, ensure_ascii=False) + "\n", encoding="utf-8")
+    return stamp["source_py_blob"]
+
+
+def _cmd_sync_alt(args: argparse.Namespace) -> int:
+    for name in args.notebooks:
+        path = Path(name).resolve()
+        if path.suffix == ".py":
+            path = path.with_suffix(".ipynb")
+        blob = sync_alt(path)
+        print(f"alt text synced {path.relative_to(REPO_ROOT)}: source_py_blob={blob[:12]}")
+    return 0
+
+
 def _cmd_sync_prose(args: argparse.Namespace) -> int:
     for name in args.notebooks:
         path = Path(name).resolve()
@@ -1766,6 +2030,22 @@ def main() -> int:
     )
     yp.add_argument("notebooks", nargs="+", help=".ipynb or .py paths")
     yp.set_defaults(func=_cmd_sync_prose)
+
+    ap_alt = sub.add_parser(
+        "sync-alt",
+        help="fold an alt-text correction into the executed .ipynb, keeping its outputs",
+        description=(
+            "For a change that touches only figure alt text. Writes the corrected alt into "
+            "the output metadata as well as the source, which is what makes the notebook "
+            "genuinely current rather than merely re-stamped: the image bytes never depend "
+            "on the alt string, so the result is the file a re-run would produce. Refuses if "
+            "any code cell moved for any other reason, if an alt is passed as a variable, or "
+            "if a computed alt interpolates a different number of values than the executed "
+            "one. Use sync-prose for a markdown-only edit."
+        ),
+    )
+    ap_alt.add_argument("notebooks", nargs="+", help=".ipynb or .py paths")
+    ap_alt.set_defaults(func=_cmd_sync_alt)
 
     args = ap.parse_args()
     return args.func(args)

--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -1537,30 +1537,41 @@ def _splice_alt(
 
     A computed alt renders as ``seg0 + value0 + seg1 + value1 + ...`` and only the values
     need a kernel to produce. They are already in the executed output, so a prose fix to an
-    f-string alt does not need one: find the values in the gaps between the OLD segments,
-    then rebuild around the NEW ones.
+    f-string alt does not need one: recover the values from between the OLD segments, then
+    rebuild around the NEW ones.
 
-    None when the two sources interpolate a different number of times - that is a change to
-    what the alt asserts about the data, not to its wording, and it needs the run.
+    Recovering them is where this can go wrong, and quietly. Scanning left to right for the
+    next segment takes the FIRST occurrence, which is not necessarily the delimiter: with
+    segments ``("IC ", ".")`` and carried ``"IC 0.031."``, the ``.`` matches inside the
+    number and the value is read as ``"0"``, leaving ``"031."`` to be appended after the new
+    prose. The output is corrupted and then stamped as current, which is worse than
+    refusing.
+
+    So the split is done by an anchored regex, both greedily and non-greedily, and accepted
+    only when the two agree. Anchoring the last segment to the end of the string is what
+    rejects the reading above; requiring the two passes to agree is what catches a genuinely
+    ambiguous alt, where more than one split is consistent with the source and there is no
+    way to tell which the notebook meant. Those need the run.
+
+    None whenever the values cannot be recovered unambiguously, or when the two sources
+    interpolate a different number of times - that is a change to what the alt asserts about
+    the data, not to its wording.
     """
     if len(old_segments) != len(new_segments):
         return None
-    values: list[str] = []
-    position = 0
-    for index, segment in enumerate(old_segments):
-        found = carried.find(segment, position)
-        if found < 0:
-            return None
-        if index:
-            values.append(carried[position:found])
-        elif found != 0:
-            return None  # the carried alt does not start where the source says it does
-        position = found + len(segment)
-    values.append(carried[position:])
+    if len(old_segments) == 1:
+        # No interpolation to preserve: the whole alt is prose.
+        return new_segments[0] if carried == old_segments[0] else None
+    body = "(.*?)".join(re.escape(segment) for segment in old_segments)
+    lazy = re.fullmatch(body, carried, re.DOTALL)
+    greedy = re.fullmatch("(.*)".join(re.escape(s) for s in old_segments), carried, re.DOTALL)
+    if lazy is None or greedy is None or lazy.groups() != greedy.groups():
+        return None
+    values = lazy.groups()
     rebuilt = new_segments[0]
-    for segment, value in zip(new_segments[1:], values[:-1], strict=True):
+    for segment, value in zip(new_segments[1:], values, strict=True):
         rebuilt += value + segment
-    return rebuilt + values[-1]
+    return rebuilt
 
 
 def _image_outputs(cell: dict) -> list[dict]:

--- a/tests/test_notebook_alt_sync.py
+++ b/tests/test_notebook_alt_sync.py
@@ -223,7 +223,17 @@ def test_sync_alt_refuses_a_computed_alt_that_interpolates_differently(repo):
             "IC of 0.031 over 5 folds.",
             "Rank IC of 0.031 across 5 folds.",
         ),
-        (("Sharpe ",), ("Annualised Sharpe ",), "Sharpe 1.24", "Annualised Sharpe 1.24"),
+        # A single segment interpolates nothing, so the whole alt is prose and must match.
+        (("Sharpe 1.24",), ("Annualised Sharpe 1.24",), "Sharpe 1.24", "Annualised Sharpe 1.24"),
+        (("Sharpe ",), ("Annualised Sharpe ",), "Sharpe 1.24", None),
+        # Scanning left to right takes the FIRST occurrence of the delimiter, which here is
+        # the decimal point inside the value: the value reads as "0" and "031." is appended
+        # after the new prose, producing "IC 0 overall.031." and stamping it as current.
+        # Anchoring the last segment to the end of the string is what rejects that reading.
+        (("IC ", "."), ("IC ", " overall."), "IC 0.031.", "IC 0.031 overall."),
+        # More than one split is consistent with the source, so there is no telling which
+        # the notebook meant. Refused rather than guessed.
+        ((" ", " ", " "), ("x ", " y ", " z"), "a b c d", None),
         # One more gap to fill than there are values to fill it with.
         (("A ", " chart."), ("A ", " plot.", " Extra."), "A bar chart.", None),
         # The carried alt was not produced by these segments at all.

--- a/tests/test_notebook_alt_sync.py
+++ b/tests/test_notebook_alt_sync.py
@@ -1,0 +1,254 @@
+"""Correcting a figure description must not cost a re-run, and must not be free of proof.
+
+Two halves, and until 2026-09-08 only one of them existed.
+
+`alt_text_only_drift` decides whether a `.py` that drifted from its stamp drifted only in
+alt text. Its second half is meant to require that the outputs on disk already carry the
+corrected string, so "edited the .py and left the executed alt saying the old thing" stays
+stale. It read those alts out of the NOTEBOOK's own cell source, which is the source that
+produced those very outputs - so it compared an execution against itself, was true of every
+executed notebook, and said nothing about the edit under adjudication. Measured: appending a
+sentence to a plain-literal alt in `cme_futures/03_financial_features.py` was reported
+ALT-TEXT ONLY and allowed to commit, with the rendered alt still saying the old thing.
+
+Making that check real leaves the corrected alt genuinely stale, which is correct and, on
+its own, useless: nothing could write the new string into the output metadata, so the
+documented cheap path could never be reached. `sync-alt` is that half. It is sound because
+`show_plotly_with_alt` takes the image from `fig._repr_mimebundle_()`, which never sees the
+alt string, so the file it produces is byte-for-byte the file a re-run would produce.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "notebook_provenance", REPO / ".github" / "scripts" / "notebook_provenance.py"
+)
+provenance = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(provenance)
+
+PLAIN = """# %% [markdown]
+# # A notebook
+
+# %%
+from utils.style import show_plotly_with_alt
+
+show_plotly_with_alt(fig, "Bars sorted from tallest at the left to shortest at the right.")
+"""
+
+COMPUTED = """# %% [markdown]
+# # A notebook
+
+# %%
+from utils.style import show_plotly_with_alt
+
+show_plotly_with_alt(fig, f"IC of {ic:.3f} over {n} folds.")
+"""
+
+
+def _write_pair(root: Path, py_source: str, alt: str) -> tuple[Path, Path]:
+    py = root / "demo.py"
+    py.write_text(py_source, encoding="utf-8")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jupytext",
+            "--to",
+            "ipynb",
+            "--output",
+            str(root / "demo.ipynb"),
+            str(py),
+        ],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+    )
+    nb_path = root / "demo.ipynb"
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    n = 0
+    for cell in nb["cells"]:
+        if cell["cell_type"] != "code":
+            continue
+        n += 1
+        cell["execution_count"] = n
+        cell["outputs"] = [
+            {
+                "output_type": "display_data",
+                "data": {"image/png": "iVBOR"},
+                "metadata": {"image/png": {"alt": alt}},
+            }
+        ]
+    nb_path.write_text(json.dumps(nb, indent=1) + "\n", encoding="utf-8")
+    return py, nb_path
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    monkeypatch.setattr(provenance, "REPO_ROOT", tmp_path)
+    return tmp_path
+
+
+def _stamp(nb_path: Path, py: Path) -> str:
+    subprocess.run(["git", "add", py.name], cwd=py.parent, check=True)
+    blob = provenance.git_blob(py)
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    nb["metadata"][provenance.STAMP_KEY] = {
+        "source_py_blob": blob,
+        "executed_at": "2026-08-01T00:00:00+00:00",
+        "executor": "ml4t-gpu",
+        "production": True,
+        "parameters": {},
+    }
+    nb_path.write_text(json.dumps(nb, indent=1) + "\n", encoding="utf-8")
+    return blob
+
+
+def _drift(nb_path: Path, py: Path, blob: str) -> bool:
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    return provenance.alt_text_only_drift(blob, py, nb)
+
+
+def test_an_alt_the_outputs_do_not_carry_is_not_alt_text_only_drift(repo):
+    """The defect this file exists for: the gate used to allow this."""
+    py, nb_path = _write_pair(
+        repo, PLAIN, "Bars sorted from tallest at the left to shortest at the right."
+    )
+    blob = _stamp(nb_path, py)
+    py.write_text(PLAIN.replace("shortest at the right.", "shortest at the right edge."), "utf-8")
+    assert _drift(nb_path, py, blob) is False
+
+
+def test_an_alt_the_outputs_do_carry_is_alt_text_only_drift(repo):
+    """The no-hit half. Without it the test above passes against a gate that always says no."""
+    py, nb_path = _write_pair(
+        repo, PLAIN, "Bars sorted from tallest at the left to shortest at the right edge."
+    )
+    blob = _stamp(nb_path, py)
+    py.write_text(PLAIN.replace("shortest at the right.", "shortest at the right edge."), "utf-8")
+    assert _drift(nb_path, py, blob) is True
+
+
+def test_sync_alt_writes_the_correction_into_the_outputs(repo):
+    py, nb_path = _write_pair(
+        repo, PLAIN, "Bars sorted from tallest at the left to shortest at the right."
+    )
+    blob = _stamp(nb_path, py)
+    py.write_text(PLAIN.replace("shortest at the right.", "shortest at the right edge."), "utf-8")
+    provenance.sync_alt(nb_path)
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    alts = [
+        (o["metadata"]["image/png"]["alt"])
+        for c in nb["cells"]
+        for o in c.get("outputs", [])
+        if "image/png" in (o.get("data") or {})
+    ]
+    assert alts == ["Bars sorted from tallest at the left to shortest at the right edge."]
+    assert nb["metadata"][provenance.STAMP_KEY]["executed_at"] == "2026-08-01T00:00:00+00:00"
+    assert nb["metadata"][provenance.STAMP_KEY]["source_py_blob"] != blob
+    subprocess.run(["git", "add", py.name], cwd=py.parent, check=True)
+    assert _drift(nb_path, py, nb["metadata"][provenance.STAMP_KEY]["source_py_blob"]) is True
+
+
+def test_sync_alt_keeps_the_interpolated_values_of_a_computed_alt(repo):
+    """The values need a kernel; the prose around them does not."""
+    py, nb_path = _write_pair(repo, COMPUTED, "IC of 0.031 over 5 folds.")
+    _stamp(nb_path, py)
+    py.write_text(
+        COMPUTED.replace(
+            'f"IC of {ic:.3f} over {n} folds."', 'f"Rank IC of {ic:.3f} across {n} folds."'
+        ),
+        "utf-8",
+    )
+    provenance.sync_alt(nb_path)
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    alt = next(
+        o["metadata"]["image/png"]["alt"]
+        for c in nb["cells"]
+        for o in c.get("outputs", [])
+        if "image/png" in (o.get("data") or {})
+    )
+    assert alt == "Rank IC of 0.031 across 5 folds."
+
+
+def test_sync_alt_refuses_a_changed_constant(repo):
+    """It is the alt exception, not a way past the gate."""
+    py, nb_path = _write_pair(
+        repo, PLAIN, "Bars sorted from tallest at the left to shortest at the right."
+    )
+    _stamp(nb_path, py)
+    py.write_text(
+        PLAIN.replace("show_plotly_with_alt(fig,", "show_plotly_with_alt(other_fig,"), "utf-8"
+    )
+    with pytest.raises(SystemExit, match="Re-run the notebook"):
+        provenance.sync_alt(nb_path)
+
+
+def test_sync_alt_refuses_a_computed_alt_that_interpolates_differently(repo):
+    """A different number of values is a change to what the alt asserts, not to its wording.
+
+    Refused before the splice is reached: an added ``FormattedValue`` is a node, so the
+    blanked-AST comparison sees it and reports a changed code cell. The message names the
+    cell rather than the interpolation, which is accurate - what changed is the call.
+    """
+    py, nb_path = _write_pair(repo, COMPUTED, "IC of 0.031 over 5 folds.")
+    _stamp(nb_path, py)
+    py.write_text(
+        COMPUTED.replace(
+            'f"IC of {ic:.3f} over {n} folds."', 'f"IC of {ic:.3f} over {n} folds, worst {lo:.3f}."'
+        ),
+        "utf-8",
+    )
+    with pytest.raises(SystemExit, match="Re-run the notebook"):
+        provenance.sync_alt(nb_path)
+
+
+@pytest.mark.parametrize(
+    ("old_segments", "new_segments", "carried", "expected"),
+    [
+        (
+            ("IC of ", " over ", " folds."),
+            ("Rank IC of ", " across ", " folds."),
+            "IC of 0.031 over 5 folds.",
+            "Rank IC of 0.031 across 5 folds.",
+        ),
+        (("Sharpe ",), ("Annualised Sharpe ",), "Sharpe 1.24", "Annualised Sharpe 1.24"),
+        # One more gap to fill than there are values to fill it with.
+        (("A ", " chart."), ("A ", " plot.", " Extra."), "A bar chart.", None),
+        # The carried alt was not produced by these segments at all.
+        (
+            ("IC of ", " over ", " folds."),
+            ("Rank IC of ", " across ", " folds."),
+            "something else entirely",
+            None,
+        ),
+    ],
+)
+def test_splice_keeps_the_values_and_refuses_what_it_cannot_place(
+    old_segments, new_segments, carried, expected
+):
+    """The splice is what makes a computed alt correctable without a kernel, so it is
+    pinned directly - `sync_alt` refuses these shapes earlier and cannot reach them."""
+    assert provenance._splice_alt(old_segments, new_segments, carried) == expected
+
+
+def test_code_bodies_drops_the_preamble_so_cells_line_up(repo):
+    """`_percent_cells` labels the pre-marker header `code`; a notebook has no cell for it.
+
+    Off by one here does not misalign - it rejects every notebook, so the alt exception
+    silently stops working and every corrected alt is priced at a re-run again.
+    """
+    src = "# ---\n# jupyter: meta\n# ---\n\n# %% [markdown]\n# Prose.\n\n# %%\nx = 1\n"
+    assert len(provenance._code_bodies(src)) == 1
+    assert provenance._code_bodies(src)[0].strip() == "x = 1"


### PR DESCRIPTION
`alt_text_only_drift` was comparing an execution against itself, so a figure description corrected in the `.py` could be committed while the notebook still rendered the old sentence, gate green.

## The defect

The function lets a corrected alt through without a re-run. Its second half is meant to require that the outputs already carry the correction; its own docstring says editing the `.py` and leaving the executed alt saying the old thing "is stale, and should be". It read those alts out of **the notebook's own cell source** - the source that produced those very outputs. True of every executed notebook, and silent about the edit being adjudicated.

Measured, not inferred. Appending a sentence to a plain-literal alt in `case_studies/cme_futures/03_financial_features.py`:

```
ALT-TEXT ONLY (... the outputs already carry, so re-executing could not change them - allowed)
```

with the rendered alt still ending "...carry the spread." and the source ending "...carry the spread. Corrected wording." After the fix the same probe reports STALE.

## Why the fix needs the second half

Making the check real leaves a corrected alt genuinely stale, which is right and on its own useless: nothing could write the new string into the output metadata, so the documented cheap path could never be reached. One band correcting an alt on a 40-second notebook just re-ran it; the band that needed the path most, on a notebook priced in hours, had no way in.

`sync-alt` is that half. `show_plotly_with_alt` takes the image from `fig._repr_mimebundle_()`, which never sees the alt string, so writing the correction into the output metadata produces the file a re-run would produce. This makes the gate's claim true again rather than talking around it.

A computed alt is handled too: the interpolated values are recovered from the executed output and the new prose spliced around them, so an f-string alt is correctable without a kernel. It refuses a variable alt, a changed constant, an interpolation count that moved, and any split the values cannot be recovered from unambiguously. Every rewrite is planned before the file is touched, so a cell it cannot handle refuses the command rather than leaving half a notebook updated.

## Three bugs found while building it, all in my own work

- **Greedy delimiter matching** (found by RoboRev on the push). Segments `("IC ", ".")` against carried `"IC 0.031."` matched the `.` inside the number, read the value as `"0"` and appended `"031."` after the new prose - a corrupted alt stamped as current, worse than refusing. The split is now an anchored regex run lazily and greedily, accepted only when the two agree.
- **The preamble drop.** `_percent_cells` emits a leading entry for whatever precedes the first `# %%`. Dropping it unconditionally is right for a jupytext file and wrong for a bare snippet, where that entry *is* the first cell. Now dropped only when marker-less **and** codeless.
- **The count check.** Requiring source and notebook cell counts to match gated the papermill-cleanup and markdown-only paths, which have no alt cells to check. Now required only when the notebook bears an alt call.

The second and third are the same mistake: off by one there does not misalign so much as refuse every notebook, so the exception silently stops working and every corrected alt is priced at a re-run again. Both were caught by the existing suite, not by me, and `_code_bodies` is now pinned directly.

## Verification

- 78 tests green across the four provenance suites, 14 of them new in `tests/test_notebook_alt_sync.py`.
- Hit and no-hit both pinned on the gate: an alt the outputs do not carry is refused, an alt they do carry is allowed. Without the second, the first would pass against a gate that always says no.
- Corpus `check` unchanged: 0 stale, 13 alt-text-only still accepted.
- End to end on a real notebook: edit, STALE, `sync-alt`, clean, outputs carrying the new string, 8 image outputs intact. Probe reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu