### PR TITLE
Build each fold's design matrix in one allocation instead of two

### DIFF
--- a/case_studies/utils/folds.py
+++ b/case_studies/utils/folds.py
@@ -699,8 +699,16 @@ def iter_raw_folds(
 
         # Only the design matrix has its dtype pinned. A classification label is integral and
         # coercing it to float would change what the family is asked to fit.
-        X_train = _contiguous(train_df.select(feature_names).to_numpy(), design_dtype)
-        X_val = _contiguous(val_df.select(feature_names).to_numpy(), design_dtype)
+        #
+        # `order="c"` is asked for rather than fixed afterwards. polars defaults to Fortran
+        # order, so `_contiguous` was allocating a second full design matrix and holding both
+        # until the F-order original fell out of scope: measured on a 4,000,000 x 88 float32
+        # frame, 2.63 GB of transient for a 1.31 GB matrix against 1.31 GB asking polars for
+        # the layout directly. The values are bit-identical either way - checked against
+        # float32 with nulls, float64, and mixed-precision frames cast both ways - so this is
+        # not a preparation change and `FOLD_PREPARATION_VERSION` does not move.
+        X_train = _contiguous(train_df.select(feature_names).to_numpy(order="c"), design_dtype)
+        X_val = _contiguous(val_df.select(feature_names).to_numpy(order="c"), design_dtype)
         y_train = np.ascontiguousarray(train_df[label_col].to_numpy())
         y_val = np.ascontiguousarray(val_df[label_col].to_numpy())
         y_eval = np.ascontiguousarray(val_df[eval_label_col].to_numpy()) if eval_label_col else None

--- a/tests/test_folds.py
+++ b/tests/test_folds.py
@@ -355,3 +355,45 @@ class TestPreparationStreams:
 
         assert len(out) == len(SPLITS)
         assert alive == [0, 0], "the raw set was memoised while the consumer was still reading it"
+
+
+class TestTheDesignMatrixIsBuiltInOneAllocation:
+    """polars is asked for C order; the alternative is building the matrix twice.
+
+    `_contiguous` pins the layout because a reduction over an F-ordered copy of the same values
+    does not give the same last bits. It used to be handed polars' default, which is Fortran
+    order, so it allocated a second full design matrix and both were alive until the first fell
+    out of scope. Asking polars for the layout removes that copy. What could break it is polars,
+    not this file, so the contract with polars is what these assert.
+    """
+
+    def test_polars_honours_the_requested_c_order(self) -> None:
+        frame = pl.DataFrame({name: [0.5, 1.5, 2.5, 3.5] for name in FEATURES})
+
+        matrix = frame.to_numpy(order="c")
+
+        assert matrix.flags.c_contiguous, "polars ignored order='c'; _contiguous would copy again"
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_the_requested_order_carries_the_same_values_as_the_default(self, dtype) -> None:
+        rng = np.random.default_rng(11)
+        columns = {name: rng.random(512) for name in FEATURES}
+        columns[FEATURES[0]][::7] = np.nan
+        frame = pl.DataFrame(columns).with_columns(
+            pl.col(FEATURES[0]).fill_nan(None), pl.col(FEATURES[1]).cast(pl.Float32)
+        )
+
+        default = np.ascontiguousarray(frame.to_numpy(), dtype=dtype)
+        requested = np.ascontiguousarray(frame.to_numpy(order="c"), dtype=dtype)
+
+        assert requested.dtype == default.dtype
+        assert np.array_equal(requested, default, equal_nan=True)
+
+    def test_a_prepared_fold_hands_the_model_a_c_ordered_matrix(self) -> None:
+        dataset = _dataset(missing=True)
+
+        folds = prepare_raw_folds(dataset, SPLITS, use_cache=False)
+
+        for fold in folds:
+            assert fold.X_train.flags.c_contiguous
+            assert fold.X_val.flags.c_contiguous


### PR DESCRIPTION
`iter_raw_folds` handed `_contiguous` the output of `to_numpy()`. polars defaults to Fortran order, so every design matrix was allocated twice - once by polars in F order, once by `np.ascontiguousarray` in C order - and both were alive until the F-order original fell out of scope.

Measured on a 4,000,000 x 88 float32 frame:

| path | matrix | transient |
|---|---|---|
| `to_numpy()` then `ascontiguousarray` | 1.31 GB | **2.63 GB** |
| `to_numpy(order="c")` then `ascontiguousarray` | 1.31 GB | **1.31 GB** |

It happens twice per fold, for `X_train` and `X_val`, in every family that prepares folds through this module - linear and gradient boosting in all nine case studies.

`_contiguous` still pins the layout, for the reason it always did: a reduction over an F-ordered copy of the same values does not give the same last bits, and that once forked a training identity. The change is only that polars is asked for the layout instead of it being fixed afterwards.

## No result moves

Checked bit-for-bit against float32 with nulls, float64, and mixed-precision frames cast both ways. `tests/test_folds.py::test_preparation_produces_the_pinned_numbers` still holds, so `FOLD_PREPARATION_VERSION` does not change and nothing registered is invalidated.

## Tests

Three added, pinning the contract with polars: that `order="c"` is honoured, that it carries the same values as the default, and that a prepared fold still hands the model a C-ordered matrix. They do not fail if this change is reverted - what could break this is polars, not this file, and the digest test is what proves no number moved.

`uv run pytest tests/test_folds.py` - 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu