### PR TITLE
Stop multiplying the modeling panel by four

### DIFF
--- a/case_studies/utils/folds.py
+++ b/case_studies/utils/folds.py
@@ -900,7 +900,7 @@ def gbm_fold(
     imputing a median would replace with a fabricated observation.
 
     Only the design matrix is cast. The labels stay float64, which is where this differs from the
-    ``prepare_gbm_folds`` path it replaces: LightGBM converts a label to its own precision anyway,
+    pandas fold preparation it replaced: LightGBM converts a label to its own precision anyway,
     so the fit is identical either way (measured, squared error and huber alike, to zero
     difference), while ``y_eval`` is the target IC is measured against and the standardising
     families keep it float64. Casting it here would have made a GBM IC and a linear IC two

--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -652,175 +652,6 @@ def _extract_feature_importance(
 # ---------------------------------------------------------------------------
 
 
-def prepare_gbm_folds(
-    dataset_pd,
-    splits: list[dict[str, Any]],
-    feature_names: list[str],
-    label_col: str,
-    date_col: str,
-    entity_col: str = "symbol",
-    task_type: str = "regression",
-    class_values: list | None = None,
-    temporal_by_fold=None,
-    temporal_keys: list[str] | None = None,
-    temporal_feature_names: list[str] | None = None,
-    train_sample_frac: float = 1.0,
-    eval_label_col: str | None = None,
-    seed: int = RANDOM_SEED,
-) -> list[dict[str, Any]]:
-    """Prepare CV fold data for GBM training.
-
-    Unlike linear folds, GBM folds:
-    - Use float32 (LightGBM native precision)
-    - No imputation or scaling (GBM handles NaN natively)
-    - Include remapped labels for classification (0-indexed for LightGBM)
-
-    Parameters
-    ----------
-    dataset_pd : pandas DataFrame
-        Full dataset.
-    splits : list[dict]
-        Walk-forward splits.
-    feature_names : list[str]
-        Feature column names.
-    label_col, date_col, entity_col : str
-        Column names.
-    task_type : str
-        "regression" or "classification".
-    class_values : list, optional
-        Sorted unique class values for classification.
-    temporal_by_fold : pd.DataFrame, optional
-        Per-fold temporal features with a 'fold' column.
-    temporal_keys : list[str], optional
-        Join keys for temporal features.
-    temporal_feature_names : list[str], optional
-        Temporal feature column names to replace per fold.
-    train_sample_frac : float, optional
-        Fraction of training rows to keep per fold (1.0 = keep all).
-        Walk-forward CV structure is preserved (date ranges unchanged);
-        only the within-fold row density is reduced. Validation set is
-        NEVER sampled — OOS IC is always computed on the full val slice.
-        Seed is tied to fold_id for reproducibility. Use < 1.0 for
-        memory/compute-constrained runs on large datasets (e.g.,
-        nasdaq100 minute bars). Default 1.0.
-    eval_label_col : str, optional
-        Continuous return used for classification IC. The discrete label
-        remains the fitting target and is retained as ``y_val``.
-    seed : int
-        Base seed for optional within-fold training subsampling.
-
-    Returns
-    -------
-    list[dict]
-        Each dict has: fold, X_train, y_train, y_train_lgb, X_val, y_val,
-        y_val_lgb, dates, entities, n_train, n_val.
-    """
-    from utils.modeling import replace_temporal_columns
-
-    dates_series = dataset_pd[date_col]
-    entity_series = dataset_pd.get(entity_col)
-    is_classification = task_type == "classification" and class_values
-    has_fold_temporal = temporal_by_fold is not None and temporal_keys and temporal_feature_names
-
-    folds = []
-    for split in splits:
-        fold_id = split["fold"]
-        train_mask = (dates_series >= split["train_start"]) & (dates_series <= split["train_end"])
-        val_start = split.get("val_start", split.get("test_start"))
-        val_end = split.get("val_end", split.get("test_end"))
-        val_mask = (dates_series >= val_start) & (dates_series <= val_end)
-
-        if has_fold_temporal:
-            assert temporal_by_fold is not None
-            assert temporal_keys is not None
-            assert temporal_feature_names is not None
-            train_rows = replace_temporal_columns(
-                dataset_pd,
-                train_mask,
-                temporal_by_fold,
-                temporal_keys,
-                temporal_feature_names,
-                fold_id,
-            )
-            val_rows = replace_temporal_columns(
-                dataset_pd,
-                val_mask,
-                temporal_by_fold,
-                temporal_keys,
-                temporal_feature_names,
-                fold_id,
-            )
-            X_train = train_rows[feature_names].values.astype(np.float32)
-            y_train = train_rows[label_col].values.astype(np.float32)
-            X_val = val_rows[feature_names].values.astype(np.float32)
-            y_val = val_rows[label_col].values.astype(np.float32)
-            y_eval = val_rows[eval_label_col].values.astype(np.float32) if eval_label_col else None
-            val_dates = val_rows[date_col].values
-            del train_rows, val_rows
-        else:
-            X_train = dataset_pd.loc[train_mask, feature_names].values.astype(np.float32)
-            y_train = dataset_pd.loc[train_mask, label_col].values.astype(np.float32)
-            X_val = dataset_pd.loc[val_mask, feature_names].values.astype(np.float32)
-            y_val = dataset_pd.loc[val_mask, label_col].values.astype(np.float32)
-            y_eval = (
-                dataset_pd.loc[val_mask, eval_label_col].values.astype(np.float32)
-                if eval_label_col
-                else None
-            )
-            val_dates = dataset_pd.loc[val_mask, date_col].values
-
-        # Drop NaN labels
-        tv = ~np.isnan(y_train)
-        vv = ~np.isnan(y_val)
-        X_train, y_train = X_train[tv], y_train[tv]
-        X_val, y_val = X_val[vv], y_val[vv]
-        if y_eval is not None:
-            y_eval = y_eval[vv]
-        val_dates = val_dates[vv]
-        val_entities = (
-            dataset_pd.loc[val_mask, entity_col].values[vv] if entity_series is not None else None
-        )
-
-        # Optional train subsample (never touch val — OOS IC uses full val slice).
-        # The seed is the fold's number added to the base, so which rows a reduced run
-        # keeps changes when the windows are renumbered. See `folds.fold_seed`.
-        if 0.0 < train_sample_frac < 1.0 and len(X_train) > 0:
-            n_keep = max(1, int(len(X_train) * train_sample_frac))
-            rng = np.random.default_rng(fold_seed(seed, fold_id))
-            keep_idx = rng.choice(len(X_train), size=n_keep, replace=False)
-            keep_idx.sort()  # preserve row order
-            X_train = X_train[keep_idx]
-            y_train = y_train[keep_idx]
-
-        # Classification: remap labels to 0-indexed for LightGBM
-        if is_classification:
-            assert class_values is not None
-            y_train_lgb, _ = _remap_labels_for_lgb(y_train.astype(int), class_values)
-            y_val_lgb, _ = _remap_labels_for_lgb(y_val.astype(int), class_values)
-        else:
-            y_train_lgb = y_train
-            y_val_lgb = y_val
-
-        folds.append(
-            {
-                "fold": split["fold"],
-                "X_train": X_train,
-                "y_train": y_train,
-                "y_train_lgb": y_train_lgb,
-                "X_val": X_val,
-                "y_val": y_val,
-                "y_val_lgb": y_val_lgb,
-                "y_eval": y_eval,
-                "dates": val_dates,
-                "entities": val_entities,
-                "n_train": len(X_train),
-                "n_val": len(X_val),
-            }
-        )
-
-    return folds
-
-
 def _checkpoint_metrics_from_predictions(
     predictions: list[dict[str, Any]],
     checkpoints: list[int] | tuple[int, ...],
@@ -1037,7 +868,7 @@ def train_gbm_config(
     config : dict
         Preset dict with config_name, params, max_iterations, checkpoint_interval.
     fold_data : list[dict]
-        From prepare_gbm_folds().
+        From prepare_gbm_folds_from_mds().
     feature_names : list[str]
         For feature importance extraction.
     device : str
@@ -1706,7 +1537,7 @@ def _load_gbm_batch_base(
     study: Study,
     request: dict[str, Any],
     *,
-    inputs: tuple[Any, Any, Any] | None = None,
+    inputs: tuple[Any, Any] | None = None,
 ) -> dict[str, Any]:
     from utils.modeling import load_modeling_dataset
 
@@ -1724,9 +1555,8 @@ def _load_gbm_batch_base(
     if inputs is None:
         label_ref = study.labels.get(request["label"], execution_tier=tier)
         mds = load_modeling_dataset(study.case_study, label_ref.name, max_symbols=max_symbols)
-        dataset_pd = mds.dataset.to_pandas()
     else:
-        label_ref, mds, dataset_pd = inputs
+        label_ref, mds = inputs
     if mds.date_col != "timestamp" or not mds.entity_cols:
         raise ValueError("GBM runner requires timestamp and an entity key")
     entity_col = mds.entity_cols[0]
@@ -1747,7 +1577,6 @@ def _load_gbm_batch_base(
     return {
         "label_ref": label_ref,
         "mds": mds,
-        "dataset_pd": dataset_pd,
         "splits": splits,
         "cv_record": cv_record,
         "expected": _gbm_expected_keys_from_dataset(mds, splits),
@@ -2163,22 +1992,7 @@ def reconstruct_locked_request(
         )
     expected = _gbm_expected_keys_from_dataset(mds, [split])
     validate_locked_expected_keys(spec, expected)
-    folds = prepare_gbm_folds(
-        mds.dataset.to_pandas(),
-        [split],
-        mds.feature_names,
-        mds.label_col,
-        mds.date_col,
-        entity_col,
-        task_type=mds.task_type,
-        class_values=mds.class_values,
-        temporal_by_fold=mds.temporal_by_fold,
-        temporal_keys=mds.temporal_keys,
-        temporal_feature_names=mds.temporal_feature_names,
-        train_sample_frac=1.0,
-        eval_label_col=mds.eval_label_col,
-        seed=RANDOM_SEED,
-    )
+    folds = prepare_gbm_folds_from_mds(mds, [split], train_sample_frac=1.0, seed=RANDOM_SEED)
     if len(folds) != 1 or not folds[0]["n_train"] or not folds[0]["n_val"]:
         raise ValueError("locked GBM holdout fold could not be prepared")
     if not isinstance(model, dict):
@@ -2928,7 +2742,7 @@ def plan_model_requests(
 
     ordered: list[dict[str, Any] | None] = [None] * len(requests)
     planned_groups = []
-    input_cache: dict[tuple[str, str, int], tuple[Any, Any, Any]] = {}
+    input_cache: dict[tuple[str, str, int], tuple[Any, Any]] = {}
     for key, indexed_requests in groups.items():
         input_key = _gbm_input_compatibility_key(indexed_requests[0][1])
         base = _load_gbm_batch_base(
@@ -2938,7 +2752,7 @@ def plan_model_requests(
         )
         input_cache.setdefault(
             input_key,
-            (base["label_ref"], base["mds"], base["dataset_pd"]),
+            (base["label_ref"], base["mds"]),
         )
         mds = base["mds"]
         placeholder_folds = tuple({"fold": int(split["fold"])} for split in base["splits"])
@@ -3017,7 +2831,7 @@ def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[Mo
 
     ordered: list[ModelRun | None] = [None] * len(requests)
     failures = []
-    input_cache: dict[tuple[str, str, int], tuple[Any, Any, Any]] = {}
+    input_cache: dict[tuple[str, str, int], tuple[Any, Any]] = {}
     for key, indexed_requests in groups.items():
         input_key = _gbm_input_compatibility_key(indexed_requests[0][1])
         base = _load_gbm_batch_base(
@@ -3027,7 +2841,7 @@ def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[Mo
         )
         input_cache.setdefault(
             input_key,
-            (base["label_ref"], base["mds"], base["dataset_pd"]),
+            (base["label_ref"], base["mds"]),
         )
         candidates = _run_gbm_batch_group(
             study,

--- a/tests/test_gbm_classification_target.py
+++ b/tests/test_gbm_classification_target.py
@@ -1,42 +1,59 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
+import polars as pl
 
-from case_studies.utils.gbm import prepare_gbm_folds
+from case_studies.utils.folds import clear_memo
+from case_studies.utils.gbm import prepare_gbm_folds_from_mds
+from utils.modeling import ModelingDataset
 
 
 def test_classification_folds_preserve_continuous_evaluation_target() -> None:
-    dates = pd.to_datetime(["2020-01-02", "2020-01-03", "2020-01-06", "2020-01-07"])
-    dataset = pd.DataFrame(
-        {
-            "timestamp": dates,
-            "symbol": ["A"] * 4,
-            "feature": [0.0, 1.0, 2.0, 3.0],
-            "fwd_dir_5d": [0, 1, 0, 1],
-            "fwd_ret_5d": [-0.03, 0.02, -0.01, 0.04],
-        }
+    """The discrete label is what is fitted; the continuous return is what IC is measured on.
+
+    Both have to survive fold preparation, because losing the continuous column silently turns
+    a classification case study's IC into a correlation between a prediction and a class index.
+    """
+    dates = [
+        pl.datetime(2020, 1, 2),
+        pl.datetime(2020, 1, 3),
+        pl.datetime(2020, 1, 6),
+        pl.datetime(2020, 1, 7),
+    ]
+    frame = pl.select(
+        timestamp=pl.concat_list(dates).explode(),
+        symbol=pl.lit("A"),
+        feature=pl.Series([0.0, 1.0, 2.0, 3.0]),
+        fwd_dir_5d=pl.Series([0.0, 1.0, 0.0, 1.0]),
+        fwd_ret_5d=pl.Series([-0.03, 0.02, -0.01, 0.04]),
     )
     splits = [
         {
             "fold": 0,
-            "train_start": dates[0],
-            "train_end": dates[1],
-            "val_start": dates[2],
-            "val_end": dates[3],
+            "train_start": frame["timestamp"][0],
+            "train_end": frame["timestamp"][1],
+            "val_start": frame["timestamp"][2],
+            "val_end": frame["timestamp"][3],
         }
     ]
-
-    fold = prepare_gbm_folds(
-        dataset,
-        splits,
-        ["feature"],
-        "fwd_dir_5d",
-        "timestamp",
+    mds = ModelingDataset(
+        dataset=frame,
+        feature_names=["feature"],
+        label_col="fwd_dir_5d",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        join_cols=["symbol", "timestamp"],
+        splits=splits,
+        label_buffer="5d",
         task_type="classification",
-        class_values=[0, 1],
+        class_values=[0.0, 1.0],
         eval_label_col="fwd_ret_5d",
-    )[0]
+    )
 
-    np.testing.assert_array_equal(fold["y_val"], np.array([0.0, 1.0], dtype=np.float32))
-    np.testing.assert_array_equal(fold["y_eval"], np.array([-0.01, 0.04], dtype=np.float32))
+    clear_memo()
+    [fold] = prepare_gbm_folds_from_mds(mds, splits, use_cache=False)
+
+    np.testing.assert_array_equal(fold["y_val"], np.array([0.0, 1.0]))
+    np.testing.assert_array_equal(fold["y_eval"], np.array([-0.01, 0.04]))
+    # LightGBM takes contiguous 0-indexed classes; the declared values stay in y_val.
+    np.testing.assert_array_equal(fold["y_val_lgb"], np.array([0, 1], dtype=np.int32))

--- a/tests/test_gbm_runtime.py
+++ b/tests/test_gbm_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from contextlib import closing
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -164,10 +165,17 @@ def test_every_case_study_gbm_setup_resolves_the_shared_execution_contract() -> 
     assert {max_bin for _, max_bin, _ in resolved.values()} == {gbm.GBM_DEFAULT_MAX_BIN}
 
 
-def test_prepare_gbm_folds_keeps_continuous_classification_target() -> None:
-    frame = pd.DataFrame(
+def test_prepared_folds_keep_the_continuous_classification_target() -> None:
+    from case_studies.utils.folds import clear_memo
+    from utils.modeling import ModelingDataset
+
+    frame = pl.DataFrame(
         {
-            "timestamp": pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
+            "timestamp": [
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+                datetime(2020, 1, 3),
+            ],
             "symbol": ["a", "b", "c"],
             "feature": [1.0, 2.0, 3.0],
             "label": [0.0, 1.0, 1.0],
@@ -177,27 +185,31 @@ def test_prepare_gbm_folds_keeps_continuous_classification_target() -> None:
     splits = [
         {
             "fold": 0,
-            "train_start": pd.Timestamp("2020-01-01"),
-            "train_end": pd.Timestamp("2020-01-01"),
-            "val_start": pd.Timestamp("2020-01-02"),
-            "val_end": pd.Timestamp("2020-01-03"),
+            "train_start": datetime(2020, 1, 1),
+            "train_end": datetime(2020, 1, 1),
+            "val_start": datetime(2020, 1, 2),
+            "val_end": datetime(2020, 1, 3),
         }
     ]
-
-    [fold] = gbm.prepare_gbm_folds(
-        frame,
-        splits,
-        ["feature"],
-        "label",
-        "timestamp",
-        "symbol",
+    mds = ModelingDataset(
+        dataset=frame,
+        feature_names=["feature"],
+        label_col="label",
+        date_col="timestamp",
+        entity_cols=["symbol"],
+        join_cols=["symbol", "timestamp"],
+        splits=splits,
+        label_buffer="5d",
         task_type="classification",
-        class_values=[0, 1],
+        class_values=[0.0, 1.0],
         eval_label_col="return",
     )
 
-    np.testing.assert_array_equal(fold["y_val"], np.array([1.0, 1.0], dtype=np.float32))
-    np.testing.assert_array_equal(fold["y_eval"], np.array([0.3, 0.4], dtype=np.float32))
+    clear_memo()
+    [fold] = gbm.prepare_gbm_folds_from_mds(mds, splits, use_cache=False)
+
+    np.testing.assert_array_equal(fold["y_val"], np.array([1.0, 1.0]))
+    np.testing.assert_array_equal(fold["y_eval"], np.array([0.3, 0.4]))
 
 
 def test_classification_ic_uses_continuous_eval_target(

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -1897,7 +1897,7 @@ def prepare_single_fold(
     ----------
     train_sample_frac : float, optional
         Fraction of training rows to keep (1.0 = all). Same semantics
-        as ``prepare_cv_folds`` / ``prepare_gbm_folds``: validation is
+        as ``folds.iter_raw_folds``: validation is
         never sampled, seed is tied to fold_id for reproducibility.
 
     Returns None if the fold is empty (no train or val rows).

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -991,6 +991,10 @@ def load_modeling_dataset(
 
     # Inner-join with labels (drops rows without labels)
     dataset = dataset.join(labels, on=join_cols, how="inner")
+    # Neither operand is read again, and until they were dropped here the function returned
+    # holding three panels: the joined dataset, the feature panel it was built from, and the
+    # labels. On the full nasdaq100_microstructure panel the feature panel alone is 5.6 GB.
+    del features, labels
 
     # Drop any meta columns that leaked in
     drop_cols = [c for c in dataset.columns if c in META_LEAK]


### PR DESCRIPTION
A loaded `nasdaq100_microstructure` panel is 5.74 GB and cost 21.05 GB resident. Three of those gigabytes-per-gigabyte were bookkeeping.

## What was wrong

**`load_modeling_dataset` returned holding three panels.** The joined dataset, the feature panel it was built from, and the labels. Neither operand is read after the label join - the rest of the function reads only `dataset` - so both stayed bound until the function returned. On this case study the feature panel alone is 5.6 GB.

**`_load_gbm_batch_base` built a pandas copy of the whole panel that nothing read.** It called `mds.dataset.to_pandas()` on every GBM run, stored it in `base["dataset_pd"]`, and cached it in `input_cache` so a second request would not rebuild it. No consumer existed: the only pandas reader in the module built its own copy at the call site. 5.78 GB, measured on the full panel, allocated once per run and held for the life of the kernel.

**`prepare_gbm_folds` was a second fold preparation in pandas.** Still live on the locked holdout path, called with a third `to_pandas()` of the same frame. Its hot loop was `dataset_pd.loc[mask, cols].values.astype(np.float32)`: a masked frame copy, a float64 2D materialization, then a cast, three transients per array and four arrays per fold.

## What this does

Releases the join operands. Deletes the dead copy and the pandas preparer, and routes the locked holdout through `prepare_gbm_folds_from_mds`, the preparer the validation path already used.

The two preparers agree on which rows a fold contains: `split_frames` drops a null or NaN label exactly where the deleted loop dropped a NaN one. `split_frames` exists because they once disagreed - Huber's threshold was derived from the runner's own re-selection of the training rows, which gave one declared configuration two training identities.

They differ in one recorded way. The polars path leaves labels float64 where the pandas path cast them to float32; `gbm_fold`'s docstring records that the fit is identical either way, measured, because LightGBM converts the label to its own precision regardless. What changes is the holdout prediction panel's `actual` column, which becomes float64 and so matches every validation panel in the same case study instead of being the one float32 column among them.

## Measured

Full panel, 16,413,478 rows x 91 columns, frame 5.74 GB, one `load_modeling_dataset` each way. The allocator row is a separate change to `nb-run.sh` in the agents repo, included because it is in force for the rows below it.

| | resident after load | peak |
|---|---|---|
| `main` | 21.05 GB | 26.80 GB |
| + `_RJEM_MALLOC_CONF=dirty_decay_ms:1000,muzzy_decay_ms:0` | 12.11 GB | 20.13 GB |
| + this PR | **6.94 GB** | 20.14 GB |

1.21x the frame, from 3.7x. The peak does not move: 20.1 GB is the transient inside the collect and the join itself, which needs the joins to stop carrying all 91 columns and is not this change. What moved is what a run holds, which is what decides whether a model notebook fits beside its fold set.

## Tests

`test_folds.py`, `test_fold_seed_coupling.py`, `test_gbm_runtime.py`, `test_gbm_classification_target.py`, `test_gbm_holdout_rekey.py`, `test_declared_cuda_is_enforced.py`, `test_research_models.py`, and the seven suites that exercise `load_modeling_dataset` all pass locally.

The two tests that called the deleted preparer now assert the same property through the polars one: a classification fold keeps the discrete label in `y_val` and the continuous return in `y_eval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu