### PR TITLE
Land the thirteen DL notebooks executed under the calendar sequence builder

### DIFF
--- a/case_studies/crypto_perps_funding/09_dl_lstm.ipynb
+++ b/case_studies/crypto_perps_funding/09_dl_lstm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "62719f63",
+   "id": "096f14d5",
    "metadata": {
     "papermill": {
-     "duration": 0.001569,
-     "end_time": "2026-09-09T03:36:05.246443+00:00",
+     "duration": 0.002414,
+     "end_time": "2026-09-08T21:10:45.750051+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:05.244874+00:00",
+     "start_time": "2026-09-08T21:10:45.747637+00:00",
      "status": "completed"
     }
    },
@@ -99,19 +99,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "e4e6853a",
+   "id": "1a46f2ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:05.250198Z",
-     "iopub.status.busy": "2026-09-09T03:36:05.249958Z",
-     "iopub.status.idle": "2026-09-09T03:36:07.947703Z",
-     "shell.execute_reply": "2026-09-09T03:36:07.947334Z"
+     "iopub.execute_input": "2026-09-08T21:10:45.757735Z",
+     "iopub.status.busy": "2026-09-08T21:10:45.757494Z",
+     "iopub.status.idle": "2026-09-08T21:10:50.054568Z",
+     "shell.execute_reply": "2026-09-08T21:10:50.054286Z"
     },
     "papermill": {
-     "duration": 2.700614,
-     "end_time": "2026-09-09T03:36:07.948344+00:00",
+     "duration": 4.307748,
+     "end_time": "2026-09-08T21:10:50.059524+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:05.247730+00:00",
+     "start_time": "2026-09-08T21:10:45.751776+00:00",
      "status": "completed"
     }
    },
@@ -137,19 +137,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "b74332f9",
+   "id": "494e33a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:07.951230Z",
-     "iopub.status.busy": "2026-09-09T03:36:07.950957Z",
-     "iopub.status.idle": "2026-09-09T03:36:07.954717Z",
-     "shell.execute_reply": "2026-09-09T03:36:07.953998Z"
+     "iopub.execute_input": "2026-09-08T21:10:50.065644Z",
+     "iopub.status.busy": "2026-09-08T21:10:50.065449Z",
+     "iopub.status.idle": "2026-09-08T21:10:50.074446Z",
+     "shell.execute_reply": "2026-09-08T21:10:50.072245Z"
     },
     "papermill": {
-     "duration": 0.005789,
-     "end_time": "2026-09-09T03:36:07.955127+00:00",
+     "duration": 0.014,
+     "end_time": "2026-09-08T21:10:50.075272+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:07.949338+00:00",
+     "start_time": "2026-09-08T21:10:50.061272+00:00",
      "status": "completed"
     },
     "tags": [
@@ -172,13 +172,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fdb276ee",
+   "id": "66243c1f",
    "metadata": {
     "papermill": {
-     "duration": 0.000694,
-     "end_time": "2026-09-09T03:36:07.956852+00:00",
+     "duration": 0.000749,
+     "end_time": "2026-09-08T21:10:50.077662+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:07.956158+00:00",
+     "start_time": "2026-09-08T21:10:50.076913+00:00",
      "status": "completed"
     }
    },
@@ -199,19 +199,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6c93798e",
+   "id": "e61327d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:07.959112Z",
-     "iopub.status.busy": "2026-09-09T03:36:07.958927Z",
-     "iopub.status.idle": "2026-09-09T03:36:17.421443Z",
-     "shell.execute_reply": "2026-09-09T03:36:17.420927Z"
+     "iopub.execute_input": "2026-09-08T21:10:50.084253Z",
+     "iopub.status.busy": "2026-09-08T21:10:50.084078Z",
+     "iopub.status.idle": "2026-09-08T21:11:09.407590Z",
+     "shell.execute_reply": "2026-09-08T21:11:09.407026Z"
     },
     "papermill": {
-     "duration": 9.464394,
-     "end_time": "2026-09-09T03:36:17.421930+00:00",
+     "duration": 19.326931,
+     "end_time": "2026-09-08T21:11:09.408100+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:07.957536+00:00",
+     "start_time": "2026-09-08T21:10:50.081169+00:00",
      "status": "completed"
     }
    },
@@ -267,13 +267,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2d63e15",
+   "id": "969b2571",
    "metadata": {
     "papermill": {
-     "duration": 0.001255,
-     "end_time": "2026-09-09T03:36:17.424786+00:00",
+     "duration": 0.000817,
+     "end_time": "2026-09-08T21:11:09.410103+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:17.423531+00:00",
+     "start_time": "2026-09-08T21:11:09.409286+00:00",
      "status": "completed"
     }
    },
@@ -289,19 +289,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8dfd1736",
+   "id": "1e778ee2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:17.428438Z",
-     "iopub.status.busy": "2026-09-09T03:36:17.428321Z",
-     "iopub.status.idle": "2026-09-09T03:36:18.830700Z",
-     "shell.execute_reply": "2026-09-09T03:36:18.830266Z"
+     "iopub.execute_input": "2026-09-08T21:11:09.412512Z",
+     "iopub.status.busy": "2026-09-08T21:11:09.412392Z",
+     "iopub.status.idle": "2026-09-08T21:11:12.514966Z",
+     "shell.execute_reply": "2026-09-08T21:11:12.514516Z"
     },
     "papermill": {
-     "duration": 1.40528,
-     "end_time": "2026-09-09T03:36:18.831476+00:00",
+     "duration": 3.109099,
+     "end_time": "2026-09-08T21:11:12.520022+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:17.426196+00:00",
+     "start_time": "2026-09-08T21:11:09.410923+00:00",
      "status": "completed"
     },
     "tags": [
@@ -396,13 +396,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55b9ffe8",
+   "id": "41300875",
    "metadata": {
     "papermill": {
-     "duration": 0.00144,
-     "end_time": "2026-09-09T03:36:18.834729+00:00",
+     "duration": 0.002525,
+     "end_time": "2026-09-08T21:11:12.527032+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:18.833289+00:00",
+     "start_time": "2026-09-08T21:11:12.524507+00:00",
      "status": "completed"
     }
    },
@@ -415,19 +415,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "f58112dd",
+   "id": "d67783c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:18.838454Z",
-     "iopub.status.busy": "2026-09-09T03:36:18.838345Z",
-     "iopub.status.idle": "2026-09-09T03:36:18.840412Z",
-     "shell.execute_reply": "2026-09-09T03:36:18.839970Z"
+     "iopub.execute_input": "2026-09-08T21:11:12.533895Z",
+     "iopub.status.busy": "2026-09-08T21:11:12.533570Z",
+     "iopub.status.idle": "2026-09-08T21:11:12.537728Z",
+     "shell.execute_reply": "2026-09-08T21:11:12.537097Z"
     },
     "papermill": {
-     "duration": 0.004699,
-     "end_time": "2026-09-09T03:36:18.840874+00:00",
+     "duration": 0.0115,
+     "end_time": "2026-09-08T21:11:12.541013+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:18.836175+00:00",
+     "start_time": "2026-09-08T21:11:12.529513+00:00",
      "status": "completed"
     },
     "tags": [
@@ -446,13 +446,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eda0a862",
+   "id": "38eab3a6",
    "metadata": {
     "papermill": {
-     "duration": 0.001484,
-     "end_time": "2026-09-09T03:36:18.843985+00:00",
+     "duration": 0.001942,
+     "end_time": "2026-09-08T21:11:12.545562+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:18.842501+00:00",
+     "start_time": "2026-09-08T21:11:12.543620+00:00",
      "status": "completed"
     }
    },
@@ -474,19 +474,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4ed66768",
+   "id": "acee9b50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:18.847838Z",
-     "iopub.status.busy": "2026-09-09T03:36:18.847627Z",
-     "iopub.status.idle": "2026-09-09T03:36:20.263561Z",
-     "shell.execute_reply": "2026-09-09T03:36:20.262627Z"
+     "iopub.execute_input": "2026-09-08T21:11:12.551201Z",
+     "iopub.status.busy": "2026-09-08T21:11:12.550628Z",
+     "iopub.status.idle": "2026-09-08T21:25:28.960386Z",
+     "shell.execute_reply": "2026-09-08T21:25:28.959315Z"
     },
     "papermill": {
-     "duration": 1.418822,
-     "end_time": "2026-09-09T03:36:20.264274+00:00",
+     "duration": 856.415362,
+     "end_time": "2026-09-08T21:25:28.962850+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:18.845452+00:00",
+     "start_time": "2026-09-08T21:11:12.547488+00:00",
      "status": "completed"
     },
     "tags": [
@@ -494,6 +494,6150 @@
     ]
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=21,457 seq across 16 symbols\n",
+      "    val=15,323 seq across 18 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.137056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.088834\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.062069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.044717\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.033162, val_loss=0.090846, IC=+0.0243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.024877\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.019383\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.015914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.013010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.011158, val_loss=0.023279, IC=+0.0253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.009423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.008154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.007120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.006567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.005703, val_loss=0.008199, IC=+0.0200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.005276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.004898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.004646\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004009, val_loss=0.003679, IC=+0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003002, val_loss=0.002060, IC=+0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002788\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002597, val_loss=0.001448, IC=+0.0061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002404, val_loss=0.001217, IC=+0.0074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002194, val_loss=0.001099, IC=+0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002116, val_loss=0.001050, IC=+0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002032, val_loss=0.001017, IC=+0.0011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001991, val_loss=0.001002, IC=-0.0039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001992\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001992\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001995, val_loss=0.000986, IC=-0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001972\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001961\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001959, val_loss=0.000980, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001928\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001960\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001945\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001966\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001913, val_loss=0.000975, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001944\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001995\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001917, val_loss=0.000972, IC=-0.0051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001923\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001927\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001916\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001922, val_loss=0.000970, IC=-0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001905\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001905\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001920\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001907, val_loss=0.000969, IC=-0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001928\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001902\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001908\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001920, val_loss=0.000968, IC=-0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001907\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001907\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001914, val_loss=0.000968, IC=-0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001906\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001887\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001916, val_loss=0.000968, IC=-0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0253 (61.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=27,969 seq across 18 symbols\n",
+      "    val=16,997 seq across 19 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.230803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.099681\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.060722\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.036743\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.025985, val_loss=0.008525, IC=-0.0034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.019600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.015153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.013272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.011231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.010115, val_loss=0.002776, IC=+0.0114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.008495\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.007397\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.006962\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.006399\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.005842, val_loss=0.001440, IC=+0.0123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.005361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.005070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.004828\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004517\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004266, val_loss=0.001025, IC=+0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003362, val_loss=0.000855, IC=+0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.003197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.003038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002798, val_loss=0.000764, IC=+0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002750\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002582\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002459, val_loss=0.000723, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002206, val_loss=0.000692, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002045, val_loss=0.000672, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001986\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001951\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001929, val_loss=0.000660, IC=+0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001903\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001896\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001866\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001876\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001865, val_loss=0.000647, IC=+0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001871\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001817\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001796, val_loss=0.000642, IC=+0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001763\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001776\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001755\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001762, val_loss=0.000637, IC=+0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001749\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001738\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001742\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001732, val_loss=0.000634, IC=+0.0032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001741\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001709, val_loss=0.000633, IC=-0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001710\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001703\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001690\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001682\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001690, val_loss=0.000631, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001703\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001701\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001695\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001676, val_loss=0.000631, IC=+0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001687\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001696, val_loss=0.000630, IC=+0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001682, val_loss=0.000630, IC=+0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001690, val_loss=0.000630, IC=+0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0123 (78.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=10, IC=+0.0184 (139.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 10 (IC=+0.0184)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/crypto_perps_funding/run_log/training/1314218b099a/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=21,457 seq across 16 symbols\n",
+      "    val=15,323 seq across 18 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001928\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001826\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001788, val_loss=0.000947, IC=+0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001787\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001791\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001763\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001765, val_loss=0.000955, IC=+0.0173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001745\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001747\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001741, val_loss=0.000961, IC=+0.0093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001738\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001739\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001706\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001695, val_loss=0.000978, IC=+0.0183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001666, val_loss=0.000975, IC=+0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001648\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001584, val_loss=0.000978, IC=+0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001597\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001577\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001552\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001543, val_loss=0.000986, IC=-0.0070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001496, val_loss=0.000981, IC=+0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001458, val_loss=0.000986, IC=+0.0072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001428\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001425\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001421\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001409, val_loss=0.000988, IC=+0.0099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001394\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001375\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001350, val_loss=0.000984, IC=+0.0135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001326, val_loss=0.000986, IC=+0.0069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001311, val_loss=0.000999, IC=+0.0117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001286, val_loss=0.000991, IC=+0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001275, val_loss=0.000992, IC=+0.0057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001278, val_loss=0.000991, IC=+0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001278, val_loss=0.000991, IC=+0.0073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001262, val_loss=0.000991, IC=+0.0053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001255, val_loss=0.000991, IC=+0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001252, val_loss=0.000991, IC=+0.0054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=20, IC=+0.0183 (87.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=27,969 seq across 18 symbols\n",
+      "    val=16,997 seq across 19 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001503, val_loss=0.000631, IC=+0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001491\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001488, val_loss=0.000633, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001449, val_loss=0.000631, IC=+0.0135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001440\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001428\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001413, val_loss=0.000637, IC=+0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001404\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001394\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001385\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001369, val_loss=0.000662, IC=+0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001322, val_loss=0.000673, IC=+0.0063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001290, val_loss=0.000684, IC=+0.0051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001243, val_loss=0.000672, IC=+0.0042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001214, val_loss=0.000686, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001183, val_loss=0.000689, IC=+0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001161, val_loss=0.000686, IC=+0.0011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001135, val_loss=0.000687, IC=-0.0011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001121, val_loss=0.000698, IC=-0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001112, val_loss=0.000700, IC=-0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001100, val_loss=0.000695, IC=-0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001094, val_loss=0.000698, IC=-0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001094, val_loss=0.000698, IC=-0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001087, val_loss=0.000698, IC=-0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001085, val_loss=0.000698, IC=-0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001080, val_loss=0.000698, IC=-0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0135 (122.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=15, IC=+0.0114 (209.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 15 (IC=+0.0114)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/crypto_perps_funding/run_log/training/6ce62c6e810b/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=21,431 seq across 16 symbols\n",
+      "    val=15,307 seq across 18 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.142670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.097760\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.070312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.052589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.040304, val_loss=0.093778, IC=+0.0478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.031840\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.026148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.021865\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.018850\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.016797, val_loss=0.025831, IC=+0.0449\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.015288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.013656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.012729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.012145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.011326, val_loss=0.009836, IC=+0.0391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.010861\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.010367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.010094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.010319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.009448, val_loss=0.005039, IC=+0.0301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.009333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.008990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.008839\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.008586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.008526, val_loss=0.003608, IC=+0.0217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.008490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.008367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.008102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.008130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.008067, val_loss=0.003129, IC=+0.0242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.008161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.007929\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.008002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.007927\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.008591, val_loss=0.002953, IC=+0.0157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.007736\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.007737\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.007711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.007642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.007575, val_loss=0.002890, IC=+0.0117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.007603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.007544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.007577\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.007502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.007502, val_loss=0.002868, IC=+0.0094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.007511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.007471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.007470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.007551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.007438, val_loss=0.002856, IC=+0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.007374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.007633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.007515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.008147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.007392, val_loss=0.002855, IC=+0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.007404\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.007423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.007418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.007375\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.007415, val_loss=0.002854, IC=-0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.007359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.007384\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.007437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.007312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.007362, val_loss=0.002858, IC=+0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.007366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.007321\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.007988\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.007483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.007994, val_loss=0.002858, IC=-0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.007299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.007497\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.007293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.007335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.007266, val_loss=0.002857, IC=-0.0071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.007274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.007266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.007344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.007320\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.007328, val_loss=0.002858, IC=-0.0046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.007257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.007255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.007479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.007329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.007291, val_loss=0.002859, IC=-0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.007282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.007293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.007296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.007303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.007251, val_loss=0.002859, IC=-0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.007303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.007297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.007255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.007328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.007389, val_loss=0.002860, IC=-0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.008055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.007310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.008016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.007470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.007220, val_loss=0.002860, IC=-0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0478 (77.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=27,917 seq across 18 symbols\n",
+      "    val=16,959 seq across 19 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.253508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.109818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.065829\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.041911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.030507, val_loss=0.010245, IC=-0.0086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.023920\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.020679\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.017727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.015203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.014262, val_loss=0.004093, IC=+0.0065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.012872\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.011900\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.011230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.010942\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.010349, val_loss=0.002856, IC=+0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.009785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.009635\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.008946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.008755\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.008578, val_loss=0.002325, IC=+0.0053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.008247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.008172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.007878\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.007771\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.007639, val_loss=0.002165, IC=-0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.007484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.007368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.007317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.007137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.007221, val_loss=0.002073, IC=-0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.007004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.006907\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.007194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.006817\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.006800, val_loss=0.002012, IC=-0.0074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.006647\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.006520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.006621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.006567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.006476, val_loss=0.001975, IC=-0.0071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.006390\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.006668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.006414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.006316\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.006278, val_loss=0.001946, IC=-0.0070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.006283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.006223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.006543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.006202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.006449, val_loss=0.001937, IC=-0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.006169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.006143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.006124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.006396\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.006113, val_loss=0.001934, IC=-0.0048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.006052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.006053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.006436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.006052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.006035, val_loss=0.001917, IC=-0.0052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.005973\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.006014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.005988\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.006018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.005998, val_loss=0.001916, IC=-0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.005944\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.005986\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.006103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.005936\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.005936, val_loss=0.001916, IC=-0.0069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.006026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.005976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.005956\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.005926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.006070, val_loss=0.001913, IC=-0.0063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.005993\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.005937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.005963\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.005934\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.005915, val_loss=0.001912, IC=-0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.005913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.005943\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.005909\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.005915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.006286, val_loss=0.001909, IC=-0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.005938\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.005890\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.005920\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.005911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.005955, val_loss=0.001909, IC=-0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.005896\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.005931\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.005922\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.005921\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.005918, val_loss=0.001909, IC=-0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.005886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.005872\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.005928\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.005919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.005916, val_loss=0.001909, IC=-0.0059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0113 (102.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=10, IC=+0.0259 (179.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 10 (IC=+0.0259)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/crypto_perps_funding/run_log/training/230a6cc348ec/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=21,431 seq across 16 symbols\n",
+      "    val=15,307 seq across 18 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.008003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.007308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.007175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.007110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.007086, val_loss=0.002789, IC=-0.0263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.007064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.006939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.006898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.007033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.006700, val_loss=0.002878, IC=-0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.006683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.006465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.006299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.006184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.005986, val_loss=0.002975, IC=+0.0054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.005838\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.005476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.005077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004884\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004700, val_loss=0.003047, IC=+0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.004243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.004100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003964\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003917, val_loss=0.003042, IC=+0.0131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003827\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.003721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.003674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.003586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.003585, val_loss=0.003059, IC=+0.0188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.003493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.003442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.003432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.003338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.003338, val_loss=0.003092, IC=+0.0237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.003295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.003245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.003263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.003222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.003151, val_loss=0.003059, IC=+0.0224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.003176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.003138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.003180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.003083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.003018, val_loss=0.003124, IC=+0.0277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.003036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.003001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002964\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002926, val_loss=0.003104, IC=+0.0274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002916\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002881\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002855\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002870, val_loss=0.003125, IC=+0.0262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002793\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002790\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002789\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002793, val_loss=0.003154, IC=+0.0322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002779\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.002741\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.002773\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.002728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.002732, val_loss=0.003129, IC=+0.0321\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.002694\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.002715\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.002704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002678, val_loss=0.003136, IC=+0.0328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.002689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.002663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.002661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.002645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.002654, val_loss=0.003141, IC=+0.0327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.002634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.002635\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.002626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002598, val_loss=0.003154, IC=+0.0323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.002638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.002632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.002620\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.002626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.002596, val_loss=0.003149, IC=+0.0324\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.002600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.002598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.002587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.002611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.002596, val_loss=0.003153, IC=+0.0334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.002619\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.002596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.002563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.002584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.002588, val_loss=0.003150, IC=+0.0329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.002587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.002608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.002569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.002605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.002561, val_loss=0.003149, IC=+0.0329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=90, IC=+0.0334 (100.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=27,917 seq across 18 symbols\n",
+      "    val=16,959 seq across 19 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.006336\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.005688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.005631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.005585, val_loss=0.001978, IC=+0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.005535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.005727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.005404\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.005230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.005161, val_loss=0.002169, IC=-0.0197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.005295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.004829\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.004625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.004434\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.004220, val_loss=0.002378, IC=-0.0064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.004078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003902\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003768\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003609, val_loss=0.002311, IC=-0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003404\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003300, val_loss=0.002367, IC=-0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.003202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.003168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.003150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.003046, val_loss=0.002438, IC=-0.0246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.003086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002995\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002929\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002945\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002906, val_loss=0.002465, IC=-0.0130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002874\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002836\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002804\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002805, val_loss=0.002472, IC=-0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002736\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002763\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002714, val_loss=0.002442, IC=-0.0067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002706\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002629, val_loss=0.002495, IC=-0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002539, val_loss=0.002572, IC=-0.0115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002528\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002509\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002529, val_loss=0.002537, IC=-0.0070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.002487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.002442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.002448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.002479, val_loss=0.002559, IC=-0.0111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.002444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.002434\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.002426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002423, val_loss=0.002579, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.002414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.002392\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.002378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.002384\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.002394, val_loss=0.002541, IC=-0.0117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.002372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.002371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.002365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002369, val_loss=0.002542, IC=-0.0109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.002364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.002370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.002360\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.002349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.002362, val_loss=0.002570, IC=-0.0104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.002352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.002349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.002345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.002347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.002340, val_loss=0.002564, IC=-0.0108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.002334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.002341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.002351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.002336\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.002342, val_loss=0.002566, IC=-0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.002333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.002328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.002350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.002341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.002347, val_loss=0.002569, IC=-0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0066 (113.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=60, IC=+0.0128 (213.8s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 60 (IC=+0.0128)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/crypto_perps_funding/run_log/training/748cd563b047/diagnostics\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -562,13 +6706,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6431262",
+   "id": "80579bcc",
    "metadata": {
     "papermill": {
-     "duration": 0.001629,
-     "end_time": "2026-09-09T03:36:20.267997+00:00",
+     "duration": 0.027429,
+     "end_time": "2026-09-08T21:25:29.022297+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:20.266368+00:00",
+     "start_time": "2026-09-08T21:25:28.994868+00:00",
      "status": "completed"
     }
    },
@@ -618,24 +6762,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T03:36:32.322370+00:00",
+   "executed_at": "2026-09-08T21:25:44.059623+00:00",
    "executor": "local-uv",
-   "library_digest": "078c1c79b33a2c50d6bfefe5cd5a9f92e41d9244b4529c450caf4bf94699faea",
-   "outputs_digest": "f25adea4f0bebae4963b54ff3c2996359d58e3e3d28c364a0738d9282d184351",
+   "library_digest": "e27556c10762ee5039d8b36fd2d5e33ff47c068f8be9e9d403cf04d773cf69bc",
+   "outputs_digest": "a113059d16e73c4fda8f553813c1eff79e13251ed0421ae8781d09534b7e342b",
    "parameters": {},
    "production": true,
    "source_py_blob": "c4a5fe3ce1d18aaecb6f7b73fc702dc0a7701a12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 19.215255,
-   "end_time": "2026-09-09T03:36:23.633291+00:00",
+   "duration": 887.478022,
+   "end_time": "2026-09-08T21:25:32.373718+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-cs7-close/case_studies/crypto_perps_funding/.09_dl_lstm.build.4096168.ipynb",
-   "output_path": "~/ml4t/public-cs7-close/case_studies/crypto_perps_funding/.09_dl_lstm.papermill.4096168.ipynb",
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/crypto_perps_funding/.09_dl_lstm.build.861544.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/crypto_perps_funding/.09_dl_lstm.papermill.861544.ipynb",
    "parameters": {},
-   "start_time": "2026-09-09T03:36:04.418036+00:00",
+   "start_time": "2026-09-08T21:10:44.895696+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/crypto_perps_funding/10_dl_tcn.ipynb
+++ b/case_studies/crypto_perps_funding/10_dl_tcn.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "38a046bd",
+   "id": "22d24b1b",
    "metadata": {
     "papermill": {
-     "duration": 0.001246,
-     "end_time": "2026-09-09T03:35:42.416436+00:00",
+     "duration": 0.001843,
+     "end_time": "2026-09-08T22:50:26.241305+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:42.415190+00:00",
+     "start_time": "2026-09-08T22:50:26.239462+00:00",
      "status": "completed"
     }
    },
@@ -89,19 +89,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a227aafd",
+   "id": "624739b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:35:42.419400Z",
-     "iopub.status.busy": "2026-09-09T03:35:42.419184Z",
-     "iopub.status.idle": "2026-09-09T03:35:45.009476Z",
-     "shell.execute_reply": "2026-09-09T03:35:45.008861Z"
+     "iopub.execute_input": "2026-09-08T22:50:26.247544Z",
+     "iopub.status.busy": "2026-09-08T22:50:26.247398Z",
+     "iopub.status.idle": "2026-09-08T22:50:32.888953Z",
+     "shell.execute_reply": "2026-09-08T22:50:32.888163Z"
     },
     "papermill": {
-     "duration": 2.592973,
-     "end_time": "2026-09-09T03:35:45.010302+00:00",
+     "duration": 6.645047,
+     "end_time": "2026-09-08T22:50:32.889523+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:42.417329+00:00",
+     "start_time": "2026-09-08T22:50:26.244476+00:00",
      "status": "completed"
     }
    },
@@ -127,19 +127,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "717cce21",
+   "id": "d15bf057",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:35:45.014186Z",
-     "iopub.status.busy": "2026-09-09T03:35:45.014065Z",
-     "iopub.status.idle": "2026-09-09T03:35:45.016709Z",
-     "shell.execute_reply": "2026-09-09T03:35:45.016172Z"
+     "iopub.execute_input": "2026-09-08T22:50:32.892676Z",
+     "iopub.status.busy": "2026-09-08T22:50:32.892292Z",
+     "iopub.status.idle": "2026-09-08T22:50:32.895427Z",
+     "shell.execute_reply": "2026-09-08T22:50:32.894912Z"
     },
     "papermill": {
-     "duration": 0.005612,
-     "end_time": "2026-09-09T03:35:45.017360+00:00",
+     "duration": 0.005064,
+     "end_time": "2026-09-08T22:50:32.895753+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:45.011748+00:00",
+     "start_time": "2026-09-08T22:50:32.890689+00:00",
      "status": "completed"
     },
     "tags": [
@@ -162,13 +162,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf58d5e7",
+   "id": "80efccf0",
    "metadata": {
     "papermill": {
-     "duration": 0.001067,
-     "end_time": "2026-09-09T03:35:45.020056+00:00",
+     "duration": 0.000747,
+     "end_time": "2026-09-08T22:50:32.897441+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:45.018989+00:00",
+     "start_time": "2026-09-08T22:50:32.896694+00:00",
      "status": "completed"
     }
    },
@@ -190,19 +190,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5fd2db56",
+   "id": "65fa3d30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:35:45.023225Z",
-     "iopub.status.busy": "2026-09-09T03:35:45.023113Z",
-     "iopub.status.idle": "2026-09-09T03:35:55.791832Z",
-     "shell.execute_reply": "2026-09-09T03:35:55.791159Z"
+     "iopub.execute_input": "2026-09-08T22:50:32.899633Z",
+     "iopub.status.busy": "2026-09-08T22:50:32.899518Z",
+     "iopub.status.idle": "2026-09-08T22:50:56.446606Z",
+     "shell.execute_reply": "2026-09-08T22:50:56.446262Z"
     },
     "papermill": {
-     "duration": 10.771302,
-     "end_time": "2026-09-09T03:35:55.792505+00:00",
+     "duration": 23.549341,
+     "end_time": "2026-09-08T22:50:56.447530+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:45.021203+00:00",
+     "start_time": "2026-09-08T22:50:32.898189+00:00",
      "status": "completed"
     }
    },
@@ -256,19 +256,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8ec05eea",
+   "id": "1a155f8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:35:55.796298Z",
-     "iopub.status.busy": "2026-09-09T03:35:55.796168Z",
-     "iopub.status.idle": "2026-09-09T03:35:56.092203Z",
-     "shell.execute_reply": "2026-09-09T03:35:56.091649Z"
+     "iopub.execute_input": "2026-09-08T22:50:56.450972Z",
+     "iopub.status.busy": "2026-09-08T22:50:56.450785Z",
+     "iopub.status.idle": "2026-09-08T22:50:57.226649Z",
+     "shell.execute_reply": "2026-09-08T22:50:57.225644Z"
     },
     "papermill": {
-     "duration": 0.298808,
-     "end_time": "2026-09-09T03:35:56.092899+00:00",
+     "duration": 0.778724,
+     "end_time": "2026-09-08T22:50:57.227556+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:55.794091+00:00",
+     "start_time": "2026-09-08T22:50:56.448832+00:00",
      "status": "completed"
     },
     "tags": [
@@ -363,13 +363,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8945f085",
+   "id": "4d20caaf",
    "metadata": {
     "papermill": {
-     "duration": 0.001343,
-     "end_time": "2026-09-09T03:35:56.096040+00:00",
+     "duration": 0.000982,
+     "end_time": "2026-09-08T22:50:57.230014+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:56.094697+00:00",
+     "start_time": "2026-09-08T22:50:57.229032+00:00",
      "status": "completed"
     }
    },
@@ -382,19 +382,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "7cd40fd2",
+   "id": "f6605388",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:35:56.098529Z",
-     "iopub.status.busy": "2026-09-09T03:35:56.098428Z",
-     "iopub.status.idle": "2026-09-09T03:35:56.100714Z",
-     "shell.execute_reply": "2026-09-09T03:35:56.100231Z"
+     "iopub.execute_input": "2026-09-08T22:50:57.244014Z",
+     "iopub.status.busy": "2026-09-08T22:50:57.243882Z",
+     "iopub.status.idle": "2026-09-08T22:50:57.248359Z",
+     "shell.execute_reply": "2026-09-08T22:50:57.245981Z"
     },
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-09-09T03:35:56.100966+00:00",
+     "duration": 0.014156,
+     "end_time": "2026-09-08T22:50:57.250686+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:56.096965+00:00",
+     "start_time": "2026-09-08T22:50:57.236530+00:00",
      "status": "completed"
     },
     "tags": [
@@ -413,13 +413,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e09be89b",
+   "id": "ed82deab",
    "metadata": {
     "papermill": {
-     "duration": 0.000691,
-     "end_time": "2026-09-09T03:35:56.102539+00:00",
+     "duration": 0.001882,
+     "end_time": "2026-09-08T22:50:57.260005+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:56.101848+00:00",
+     "start_time": "2026-09-08T22:50:57.258123+00:00",
      "status": "completed"
     }
    },
@@ -436,19 +436,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "cdbb05a9",
+   "id": "624d7cc2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:35:56.104610Z",
-     "iopub.status.busy": "2026-09-09T03:35:56.104537Z",
-     "iopub.status.idle": "2026-09-09T03:35:56.938989Z",
-     "shell.execute_reply": "2026-09-09T03:35:56.938448Z"
+     "iopub.execute_input": "2026-09-08T22:50:57.264064Z",
+     "iopub.status.busy": "2026-09-08T22:50:57.263950Z",
+     "iopub.status.idle": "2026-09-08T22:56:53.674187Z",
+     "shell.execute_reply": "2026-09-08T22:56:53.673292Z"
     },
     "papermill": {
-     "duration": 0.836056,
-     "end_time": "2026-09-09T03:35:56.939323+00:00",
+     "duration": 356.412901,
+     "end_time": "2026-09-08T22:56:53.674759+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:56.103267+00:00",
+     "start_time": "2026-09-08T22:50:57.261858+00:00",
      "status": "completed"
     },
     "tags": [
@@ -456,6 +456,1609 @@
     ]
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=21,457 seq across 16 symbols\n",
+      "    val=15,323 seq across 18 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.024097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.006498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.004890\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.004168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.003970, val_loss=0.003239, IC=-0.0053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.003570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.003614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.003557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003390\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.003244, val_loss=0.001883, IC=-0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.003205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.003226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.003216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.003204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.003026, val_loss=0.001617, IC=+0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.002976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.002946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.002968\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002857, val_loss=0.001703, IC=+0.0054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002861\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002732\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002877, val_loss=0.002375, IC=+0.0069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002525\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002767, val_loss=0.001898, IC=+0.0046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002432, val_loss=0.002446, IC=+0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002456\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002411\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002399\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002566, val_loss=0.001358, IC=+0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002372, val_loss=0.001926, IC=+0.0068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002411\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002310, val_loss=0.001187, IC=+0.0056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002421\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002337, val_loss=0.001335, IC=+0.0032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002235, val_loss=0.001202, IC=+0.0053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.002281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.002265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.002287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.002317, val_loss=0.001247, IC=+0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.002295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.002260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.002222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002243, val_loss=0.001188, IC=+0.0048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.002171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.002162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.002226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.002155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.002214, val_loss=0.001321, IC=+0.0036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.002178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.002210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.002226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002181, val_loss=0.001261, IC=+0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.002170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.002232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.002219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.002208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.002192, val_loss=0.001340, IC=+0.0045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.002146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.002188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.002159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.002153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.002128, val_loss=0.001251, IC=+0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.002151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.002157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.002111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.002157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.002174, val_loss=0.001236, IC=+0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.002153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.002192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.002206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.002159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.002202, val_loss=0.001208, IC=+0.0052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0121 (130.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=27,969 seq across 18 symbols\n",
+      "    val=16,997 seq across 19 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.036130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.010034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.004732\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.004271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.003257, val_loss=0.001012, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.003274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.003932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.004272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003859\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.003300, val_loss=0.000984, IC=+0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.003408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.003669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.003079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.003326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.003261, val_loss=0.000938, IC=+0.0099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.002685\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.002873\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.002640\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002631, val_loss=0.000975, IC=+0.0135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002713\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002616, val_loss=0.001702, IC=+0.0112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002333, val_loss=0.000753, IC=-0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002524\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002682\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002866\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002128, val_loss=0.000729, IC=+0.0039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002387\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002218, val_loss=0.000705, IC=+0.0075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002185, val_loss=0.000697, IC=-0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002088, val_loss=0.000756, IC=-0.0043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001959\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001931, val_loss=0.000778, IC=+0.0037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002272, val_loss=0.000706, IC=+0.0068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001960\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001952, val_loss=0.000679, IC=+0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001973\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001954\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002001, val_loss=0.000708, IC=+0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001892\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001869\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001964\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001961, val_loss=0.000684, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001873\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001909\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001817\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002035, val_loss=0.000752, IC=+0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001868\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001831\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001948, val_loss=0.000774, IC=+0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001852\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001890\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001864\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001828, val_loss=0.000698, IC=+0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001867\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001999\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001909\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001917\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001925, val_loss=0.000688, IC=+0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001830\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001794\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001906\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001887\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001857, val_loss=0.000708, IC=+0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=20, IC=+0.0135 (183.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  tcn: best_epoch=15, IC=+0.0110 (314.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: tcn @ epoch 15 (IC=+0.0110)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/crypto_perps_funding/run_log/training/b6fa5e808e46/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "direction AUC against fwd_dir_8h not computed: cannot align join key 'timestamp': predictions are Datetime(time_unit='us', time_zone='UTC'), direction label 'fwd_dir_8h' is Datetime(time_unit='ms', time_zone='UTC')\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -524,13 +2127,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54e8cde7",
+   "id": "2defdddb",
    "metadata": {
     "papermill": {
-     "duration": 0.000864,
-     "end_time": "2026-09-09T03:35:56.941374+00:00",
+     "duration": 0.010639,
+     "end_time": "2026-09-08T22:56:53.698568+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:35:56.940510+00:00",
+     "start_time": "2026-09-08T22:56:53.687929+00:00",
      "status": "completed"
     }
    },
@@ -581,24 +2184,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T03:36:08.358393+00:00",
+   "executed_at": "2026-09-08T22:57:14.424866+00:00",
    "executor": "local-uv",
-   "library_digest": "078c1c79b33a2c50d6bfefe5cd5a9f92e41d9244b4529c450caf4bf94699faea",
-   "outputs_digest": "780a46a15d177382fbaad2fe4705fbda5ecc9f8703bd2bac7aeb86f624fd10a6",
+   "library_digest": "e27556c10762ee5039d8b36fd2d5e33ff47c068f8be9e9d403cf04d773cf69bc",
+   "outputs_digest": "07f7c0d5d81f43454845ecfc19bbac41eeec3797f39dcdfe676a24e0a393d572",
    "parameters": {},
    "production": true,
    "source_py_blob": "c88568ef626a5f02ddc181b0699650041f896d47"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 18.154544,
-   "end_time": "2026-09-09T03:35:59.904779+00:00",
+   "duration": 393.020098,
+   "end_time": "2026-09-08T22:56:57.849448+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-cs7-close/case_studies/crypto_perps_funding/.10_dl_tcn.build.4094394.ipynb",
-   "output_path": "~/ml4t/public-cs7-close/case_studies/crypto_perps_funding/.10_dl_tcn.papermill.4094394.ipynb",
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/crypto_perps_funding/.10_dl_tcn.build.1495938.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/crypto_perps_funding/.10_dl_tcn.papermill.1495938.ipynb",
    "parameters": {},
-   "start_time": "2026-09-09T03:35:41.750235+00:00",
+   "start_time": "2026-09-08T22:50:24.829350+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/etfs/09_dl_lstm.ipynb
+++ b/case_studies/etfs/09_dl_lstm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d2d1b0e0",
+   "id": "1337b34d",
    "metadata": {
     "papermill": {
-     "duration": 0.001522,
-     "end_time": "2026-09-06T18:20:01.263433+00:00",
+     "duration": 0.001889,
+     "end_time": "2026-09-08T17:42:53.833524+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:20:01.261911+00:00",
+     "start_time": "2026-09-08T17:42:53.831635+00:00",
      "status": "completed"
     }
    },
@@ -34,9 +34,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "47438180",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "b7aa67a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:53.836936Z",
+     "iopub.status.busy": "2026-09-08T17:42:53.836813Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.311694Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.311024Z"
+    },
+    "papermill": {
+     "duration": 3.478202,
+     "end_time": "2026-09-08T17:42:57.313033+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:53.834831+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared ETF sequence population on the walk-forward folds.\"\"\"\n",
@@ -64,9 +78,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c1a588ee",
+   "execution_count": 2,
+   "id": "67651c5d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.322313Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.321566Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.331674Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.329060Z"
+    },
+    "papermill": {
+     "duration": 0.016976,
+     "end_time": "2026-09-08T17:42:57.332776+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.315800+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -86,9 +113,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3b39f240",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "2379a733",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.339825Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.339550Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.389385Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.388669Z"
+    },
+    "papermill": {
+     "duration": 0.054453,
+     "end_time": "2026-09-08T17:42:57.389988+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.335535+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\n",
@@ -102,13 +143,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "daf2b74d",
+   "id": "c76c5718",
    "metadata": {
     "papermill": {
-     "duration": 0.00149,
-     "end_time": "2026-09-06T18:20:09.312639+00:00",
+     "duration": 0.00189,
+     "end_time": "2026-09-08T17:42:57.394098+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:20:09.311149+00:00",
+     "start_time": "2026-09-08T17:42:57.392208+00:00",
      "status": "completed"
     }
    },
@@ -127,10 +168,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "280b450a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "5b083944",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.405478Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.404945Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.487749Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.487019Z"
+    },
+    "papermill": {
+     "duration": 0.091075,
+     "end_time": "2026-09-08T17:42:57.488104+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.397029+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (2, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_21d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=lstm, dropout=0.1…</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=lstm, dropout=0.1…</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (2, 5)\n",
+       "┌───────────────┬─────────────┬─────────────┬─────────────┬─────────────────────────────────┐\n",
+       "│ family        ┆ label       ┆ config_name ┆ model_class ┆ params                          │\n",
+       "│ ---           ┆ ---         ┆ ---         ┆ ---         ┆ ---                             │\n",
+       "│ str           ┆ str         ┆ str         ┆ str         ┆ str                             │\n",
+       "╞═══════════════╪═════════════╪═════════════╪═════════════╪═════════════════════════════════╡\n",
+       "│ deep_learning ┆ fwd_ret_21d ┆ lstm_h64    ┆             ┆ architecture=lstm, dropout=0.1… │\n",
+       "│ deep_learning ┆ fwd_ret_5d  ┆ lstm_h64    ┆             ┆ architecture=lstm, dropout=0.1… │\n",
+       "└───────────────┴─────────────┴─────────────┴─────────────┴─────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "SEQUENCE_CONFIGS = (\"lstm_h64\",)\n",
     "declared = load_model_configs(study, \"deep_learning\", config_names=list(SEQUENCE_CONFIGS))\n",
@@ -145,13 +229,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f13a7a41",
+   "id": "848a322b",
    "metadata": {
     "papermill": {
-     "duration": 0.002057,
-     "end_time": "2026-09-06T18:20:09.381398+00:00",
+     "duration": 0.001137,
+     "end_time": "2026-09-08T17:42:57.490710+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:20:09.379341+00:00",
+     "start_time": "2026-09-08T17:42:57.489573+00:00",
      "status": "completed"
     }
    },
@@ -175,10 +259,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e035114b",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "d73b3668",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.494109Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.493925Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.497996Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.497392Z"
+    },
+    "papermill": {
+     "duration": 0.006461,
+     "end_time": "2026-09-08T17:42:57.498326+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.491865+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training device: cuda\n"
+     ]
+    }
+   ],
    "source": [
     "PUBLISHED_DEVICE = \"cuda\"\n",
     "device = DEVICE or PUBLISHED_DEVICE\n",
@@ -197,13 +303,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b246a6af",
+   "id": "b8d1b499",
    "metadata": {
     "papermill": {
-     "duration": 0.002112,
-     "end_time": "2026-09-06T18:20:09.396747+00:00",
+     "duration": 0.001504,
+     "end_time": "2026-09-08T17:42:57.501960+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:20:09.394635+00:00",
+     "start_time": "2026-09-08T17:42:57.500456+00:00",
      "status": "completed"
     }
    },
@@ -225,10 +331,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bf7e4ca0",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "4220bd9a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.505829Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.505653Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.597845Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.597170Z"
+    },
+    "papermill": {
+     "duration": 0.095122,
+     "end_time": "2026-09-08T17:42:57.598689+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.503567+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  GBM (Ch12): IC=+0.0547 over 1995 validation dates\n",
+      "  Ridge (Ch11): IC=+0.0437 over 1995 validation dates\n"
+     ]
+    }
+   ],
    "source": [
     "prior_baselines = {}\n",
     "baseline_days = {}\n",
@@ -275,13 +404,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b39b3f31",
+   "id": "868d80c5",
    "metadata": {
     "papermill": {
-     "duration": 0.002133,
-     "end_time": "2026-09-06T18:20:09.481072+00:00",
+     "duration": 0.00238,
+     "end_time": "2026-09-08T17:42:57.604152+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:20:09.478939+00:00",
+     "start_time": "2026-09-08T17:42:57.601772+00:00",
      "status": "completed"
     }
    },
@@ -318,10 +447,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c7460ee1",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "d29996b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.611794Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.611410Z",
+     "iopub.status.idle": "2026-09-08T17:43:03.843012Z",
+     "shell.execute_reply": "2026-09-08T17:43:03.842372Z"
+    },
+    "papermill": {
+     "duration": 6.236898,
+     "end_time": "2026-09-08T17:43:03.843734+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.606836+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (2, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>feature_count</th><th>eligible_entities</th><th>eligible_rows</th><th>folds</th><th>checkpoints</th><th>validation_start</th><th>validation_end</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td></tr></thead><tbody><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;lstm_h64&quot;</td><td>73</td><td>99</td><td>187668</td><td>8</td><td>20</td><td>2015-12-28 00:00:00</td><td>2023-11-29 00:00:00</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lstm_h64&quot;</td><td>73</td><td>99</td><td>189204</td><td>8</td><td>20</td><td>2015-12-28 00:00:00</td><td>2023-12-21 00:00:00</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (2, 9)\n",
+       "┌────────────┬────────────┬────────────┬───────────┬───┬───────┬───────────┬───────────┬───────────┐\n",
+       "│ label      ┆ config_nam ┆ feature_co ┆ eligible_ ┆ … ┆ folds ┆ checkpoin ┆ validatio ┆ validatio │\n",
+       "│ ---        ┆ e          ┆ unt        ┆ entities  ┆   ┆ ---   ┆ ts        ┆ n_start   ┆ n_end     │\n",
+       "│ str        ┆ ---        ┆ ---        ┆ ---       ┆   ┆ i64   ┆ ---       ┆ ---       ┆ ---       │\n",
+       "│            ┆ str        ┆ i64        ┆ i64       ┆   ┆       ┆ i64       ┆ datetime[ ┆ datetime[ │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ μs]       ┆ μs]       │\n",
+       "╞════════════╪════════════╪════════════╪═══════════╪═══╪═══════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_ret_21 ┆ lstm_h64   ┆ 73         ┆ 99        ┆ … ┆ 8     ┆ 20        ┆ 2015-12-2 ┆ 2023-11-2 │\n",
+       "│ d          ┆            ┆            ┆           ┆   ┆       ┆           ┆ 8         ┆ 9         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_5d ┆ lstm_h64   ┆ 73         ┆ 99        ┆ … ┆ 8     ┆ 20        ┆ 2015-12-2 ┆ 2023-12-2 │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 8         ┆ 1         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "└────────────┴────────────┴────────────┴───────────┴───┴───────┴───────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -348,13 +526,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c1cfd65",
+   "id": "265b792b",
    "metadata": {
     "papermill": {
-     "duration": 0.0013,
-     "end_time": "2026-09-06T18:20:14.475405+00:00",
+     "duration": 0.002249,
+     "end_time": "2026-09-08T17:43:03.848762+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:20:14.474105+00:00",
+     "start_time": "2026-09-08T17:43:03.846513+00:00",
      "status": "completed"
     }
    },
@@ -391,10 +569,11683 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "75e05915",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "56b55e70",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:43:03.854447Z",
+     "iopub.status.busy": "2026-09-08T17:43:03.854313Z",
+     "iopub.status.idle": "2026-09-08T21:38:49.333358Z",
+     "shell.execute_reply": "2026-09-08T21:38:49.332227Z"
+    },
+    "papermill": {
+     "duration": 14145.517104,
+     "end_time": "2026-09-08T21:38:49.368315+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:43:03.851211+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=159,335 seq across 92 symbols\n",
+      "    val=22,184 seq across 92 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001909\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001139, val_loss=0.003638, IC=+0.0418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000973\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000891\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000848\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000795, val_loss=0.003806, IC=+0.0445\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000693\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000641, val_loss=0.004061, IC=+0.0376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000554, val_loss=0.004099, IC=+0.0279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000528\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000495, val_loss=0.004360, IC=+0.0157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000448, val_loss=0.004375, IC=+0.0191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000435\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000425\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000413, val_loss=0.004230, IC=+0.0226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000398\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000390, val_loss=0.004426, IC=+0.0195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000383\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000383\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000368, val_loss=0.004377, IC=+0.0230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000351, val_loss=0.004414, IC=+0.0241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000337, val_loss=0.004415, IC=+0.0186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000320, val_loss=0.004427, IC=+0.0257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000321\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000311, val_loss=0.004478, IC=+0.0201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000303, val_loss=0.004575, IC=+0.0171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000295, val_loss=0.004538, IC=+0.0187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000289, val_loss=0.004529, IC=+0.0226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000284, val_loss=0.004546, IC=+0.0202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000281, val_loss=0.004561, IC=+0.0194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000278, val_loss=0.004556, IC=+0.0204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000278, val_loss=0.004556, IC=+0.0209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0445 (711.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=181,138 seq across 92 symbols\n",
+      "    val=23,502 seq across 97 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002747\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001415\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001077, val_loss=0.003969, IC=-0.1705\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000854\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000799\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000768, val_loss=0.004680, IC=-0.1846\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000613, val_loss=0.004790, IC=-0.1799\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000595\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000564\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000532, val_loss=0.004802, IC=-0.1733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000518\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000473, val_loss=0.004510, IC=-0.1692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000430, val_loss=0.004080, IC=-0.1491\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000415\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000411\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000398, val_loss=0.004224, IC=-0.1528\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000387\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000380\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000376, val_loss=0.004387, IC=-0.1412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000354, val_loss=0.004205, IC=-0.1482\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000337, val_loss=0.004147, IC=-0.1332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000325, val_loss=0.004007, IC=-0.1348\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000320\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000309, val_loss=0.004078, IC=-0.1436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000299, val_loss=0.004124, IC=-0.1418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000291, val_loss=0.004280, IC=-0.1350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000286, val_loss=0.004189, IC=-0.1349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000279, val_loss=0.004188, IC=-0.1340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000274, val_loss=0.004177, IC=-0.1323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000271, val_loss=0.004159, IC=-0.1306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000271, val_loss=0.004201, IC=-0.1311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000270, val_loss=0.004218, IC=-0.1323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=90, IC=-0.1306 (799.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=192,519 seq across 97 symbols\n",
+      "    val=24,129 seq across 98 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001552\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001091, val_loss=0.002668, IC=+0.0668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000936\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000897, val_loss=0.002637, IC=+0.0302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000736\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000758\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000729, val_loss=0.002780, IC=+0.0204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000601, val_loss=0.002968, IC=+0.0146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000528, val_loss=0.003142, IC=+0.0241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000518\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000525\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000571, val_loss=0.003412, IC=+0.0270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000456, val_loss=0.003302, IC=+0.0292\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000419, val_loss=0.003253, IC=+0.0417\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000428\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000425, val_loss=0.003109, IC=+0.0528\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000413\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000404, val_loss=0.003042, IC=+0.0359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000379\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000380\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000373\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000369, val_loss=0.003170, IC=+0.0537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000387\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000353, val_loss=0.003110, IC=+0.0550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000348\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000350, val_loss=0.003197, IC=+0.0582\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000337\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000391, val_loss=0.003257, IC=+0.0559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000331, val_loss=0.003194, IC=+0.0529\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000319, val_loss=0.003077, IC=+0.0531\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000312, val_loss=0.003130, IC=+0.0527\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000308, val_loss=0.003167, IC=+0.0533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000306, val_loss=0.003169, IC=+0.0514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000303, val_loss=0.003176, IC=+0.0521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0668 (847.3s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=201,390 seq across 98 symbols\n",
+      "    val=24,137 seq across 98 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000912\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000805, val_loss=0.002962, IC=+0.0215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000665\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000606\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000564\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000533, val_loss=0.003281, IC=+0.0474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000425, val_loss=0.003176, IC=+0.0697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000411\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000399\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000387\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000367, val_loss=0.002970, IC=+0.0953\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000327, val_loss=0.003020, IC=+0.0932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000300, val_loss=0.002733, IC=+0.1076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000281, val_loss=0.002984, IC=+0.0631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000262, val_loss=0.002962, IC=+0.0660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000249, val_loss=0.002963, IC=+0.0646\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000238, val_loss=0.002884, IC=+0.0585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000226, val_loss=0.003026, IC=+0.0557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000221, val_loss=0.003016, IC=+0.0431\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000211, val_loss=0.003035, IC=+0.0347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000205, val_loss=0.003172, IC=+0.0219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000200, val_loss=0.003175, IC=+0.0252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000196, val_loss=0.003198, IC=+0.0225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000193, val_loss=0.003231, IC=+0.0196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000191, val_loss=0.003191, IC=+0.0214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000190, val_loss=0.003211, IC=+0.0191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000189, val_loss=0.003204, IC=+0.0200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=30, IC=+0.1076 (989.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=207,424 seq across 98 symbols\n",
+      "    val=23,882 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001582\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000903, val_loss=0.011769, IC=+0.0194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000591, val_loss=0.012391, IC=+0.0915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000524\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000464, val_loss=0.012666, IC=+0.1055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000430\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000394, val_loss=0.012148, IC=+0.1137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000377\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000342, val_loss=0.012047, IC=+0.1139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000324\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000312, val_loss=0.012040, IC=+0.1091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000287, val_loss=0.012091, IC=+0.1038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000266, val_loss=0.011694, IC=+0.1143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000252, val_loss=0.011927, IC=+0.0770\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000238, val_loss=0.011570, IC=+0.0940\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000227, val_loss=0.011799, IC=+0.0832\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000218, val_loss=0.011991, IC=+0.0632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000212, val_loss=0.011796, IC=+0.0719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000204, val_loss=0.011783, IC=+0.0806\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000199, val_loss=0.011732, IC=+0.0786\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000195, val_loss=0.011882, IC=+0.0785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000193, val_loss=0.011824, IC=+0.0827\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000190, val_loss=0.011872, IC=+0.0827\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000188, val_loss=0.011905, IC=+0.0805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000188, val_loss=0.011876, IC=+0.0815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=40, IC=+0.1143 (852.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=213,372 seq across 99 symbols\n",
+      "    val=23,885 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000899\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000798, val_loss=0.006301, IC=+0.0561\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000731\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000622\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000558, val_loss=0.007122, IC=+0.0396\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000482\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000446, val_loss=0.007734, IC=+0.0104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000388, val_loss=0.007334, IC=+0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000342, val_loss=0.007890, IC=+0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000316, val_loss=0.008029, IC=+0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000293, val_loss=0.007367, IC=+0.0118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000277, val_loss=0.007220, IC=+0.0064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000262, val_loss=0.006925, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000251, val_loss=0.007166, IC=+0.0038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000238, val_loss=0.006611, IC=-0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000231, val_loss=0.006730, IC=+0.0054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000222, val_loss=0.006974, IC=-0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000216, val_loss=0.006947, IC=+0.0092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000211, val_loss=0.006919, IC=+0.0116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000206, val_loss=0.006641, IC=+0.0116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000204, val_loss=0.006904, IC=+0.0112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000200, val_loss=0.006793, IC=+0.0098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000200, val_loss=0.006836, IC=+0.0109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000198, val_loss=0.006811, IC=+0.0112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0561 (916.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=217,647 seq across 99 symbols\n",
+      "    val=23,830 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001382\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000902\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000795, val_loss=0.013327, IC=-0.0334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000723\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000539, val_loss=0.013594, IC=-0.0034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000432, val_loss=0.011377, IC=-0.0153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000380\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000370, val_loss=0.010758, IC=-0.0038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000348\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000336, val_loss=0.011717, IC=-0.0034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000331\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000324\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000307, val_loss=0.010586, IC=-0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000288, val_loss=0.010534, IC=-0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000270, val_loss=0.010648, IC=-0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000257, val_loss=0.010055, IC=-0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000246, val_loss=0.010389, IC=-0.0074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000236, val_loss=0.010335, IC=-0.0114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000228, val_loss=0.011043, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000220, val_loss=0.011064, IC=-0.0152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000216, val_loss=0.010657, IC=-0.0174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000209, val_loss=0.010888, IC=-0.0224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000205, val_loss=0.011112, IC=-0.0219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000201, val_loss=0.010912, IC=-0.0194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000198, val_loss=0.010985, IC=-0.0192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000198, val_loss=0.010950, IC=-0.0192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000197, val_loss=0.010924, IC=-0.0187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=30, IC=-0.0016 (1016.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=221,602 seq across 99 symbols\n",
+      "    val=22,119 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002375\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000938, val_loss=0.010171, IC=+0.0265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000835\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000765\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000633, val_loss=0.008584, IC=+0.0252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000597\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000518\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000498, val_loss=0.008212, IC=+0.0139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000482\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000424, val_loss=0.007224, IC=+0.0166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000380, val_loss=0.007428, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000347, val_loss=0.006734, IC=+0.0090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000324, val_loss=0.006787, IC=+0.0149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000300, val_loss=0.006575, IC=+0.0157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000287, val_loss=0.006897, IC=+0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000275, val_loss=0.006567, IC=+0.0173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000262, val_loss=0.007048, IC=+0.0159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000253, val_loss=0.006860, IC=+0.0168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000245, val_loss=0.006912, IC=+0.0241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000237, val_loss=0.006995, IC=+0.0158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000231, val_loss=0.006942, IC=+0.0168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000226, val_loss=0.007011, IC=+0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000223, val_loss=0.007114, IC=+0.0170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000221, val_loss=0.007073, IC=+0.0185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000219, val_loss=0.007042, IC=+0.0181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000218, val_loss=0.007035, IC=+0.0180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0265 (915.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=30, IC=+0.0166 (7047.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 30 (IC=+0.0166)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/etfs/run_log/training/49c894b3b223/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=160,775 seq across 92 symbols\n",
+      "    val=22,184 seq across 92 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000849\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000762\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000695\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000649, val_loss=0.001016, IC=-0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000486, val_loss=0.000991, IC=-0.0236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000403, val_loss=0.001015, IC=-0.0398\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000394\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000380\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000352, val_loss=0.001082, IC=-0.0220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000336\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000321\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000314, val_loss=0.001026, IC=-0.0295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000291, val_loss=0.001051, IC=-0.0389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000266, val_loss=0.001079, IC=-0.0291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000249, val_loss=0.001028, IC=-0.0352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000236, val_loss=0.001069, IC=-0.0369\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000225, val_loss=0.001114, IC=-0.0265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000213, val_loss=0.001081, IC=-0.0227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000206, val_loss=0.001115, IC=-0.0309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000200, val_loss=0.001087, IC=-0.0248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000194, val_loss=0.001078, IC=-0.0208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000190, val_loss=0.001108, IC=-0.0241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000187, val_loss=0.001110, IC=-0.0220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000183, val_loss=0.001099, IC=-0.0216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000182, val_loss=0.001105, IC=-0.0217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000181, val_loss=0.001105, IC=-0.0227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000180, val_loss=0.001107, IC=-0.0231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=-0.0029 (783.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=182,922 seq across 92 symbols\n",
+      "    val=23,502 seq across 97 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000715\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000647\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000596, val_loss=0.000392, IC=-0.0558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000527\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000457, val_loss=0.000513, IC=-0.0465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000383, val_loss=0.000482, IC=-0.0592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000333, val_loss=0.000484, IC=-0.0446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000298, val_loss=0.000456, IC=-0.0199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000275, val_loss=0.000444, IC=-0.0211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000254, val_loss=0.000484, IC=+0.0018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000238, val_loss=0.000458, IC=-0.0084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000224, val_loss=0.000483, IC=-0.0075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000215, val_loss=0.000473, IC=-0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000205, val_loss=0.000505, IC=+0.0039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000198, val_loss=0.000472, IC=+0.0070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000192, val_loss=0.000502, IC=+0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000187, val_loss=0.000518, IC=+0.0087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000183, val_loss=0.000512, IC=+0.0087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000179, val_loss=0.000505, IC=+0.0069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000177, val_loss=0.000499, IC=+0.0087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000175, val_loss=0.000501, IC=+0.0109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000175, val_loss=0.000506, IC=+0.0099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000174, val_loss=0.000505, IC=+0.0098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=90, IC=+0.0109 (737.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=194,519 seq across 97 symbols\n",
+      "    val=24,129 seq across 98 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000892\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000717\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000537, val_loss=0.000704, IC=+0.0620\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000501\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000409, val_loss=0.000733, IC=+0.0570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000339, val_loss=0.000795, IC=+0.0332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000300, val_loss=0.000805, IC=+0.0093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000292\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000269, val_loss=0.000790, IC=+0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000247, val_loss=0.000809, IC=-0.0141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000228, val_loss=0.000816, IC=-0.0242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000215, val_loss=0.000825, IC=-0.0302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000203, val_loss=0.000829, IC=-0.0195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000193, val_loss=0.000845, IC=-0.0200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000185, val_loss=0.000838, IC=-0.0220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000180, val_loss=0.000864, IC=-0.0260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000173, val_loss=0.000863, IC=-0.0279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000168, val_loss=0.000868, IC=-0.0313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000165, val_loss=0.000875, IC=-0.0247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000161, val_loss=0.000876, IC=-0.0275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000159, val_loss=0.000878, IC=-0.0271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000158, val_loss=0.000879, IC=-0.0258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000157, val_loss=0.000880, IC=-0.0272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000156, val_loss=0.000880, IC=-0.0270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0620 (874.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=203,510 seq across 98 symbols\n",
+      "    val=24,137 seq across 98 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000436, val_loss=0.000680, IC=-0.0451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000332, val_loss=0.000737, IC=-0.0177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000320\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000276, val_loss=0.000726, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000241, val_loss=0.000668, IC=-0.0065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000216, val_loss=0.000653, IC=-0.0018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000199, val_loss=0.000645, IC=-0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000184, val_loss=0.000642, IC=+0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000172, val_loss=0.000660, IC=+0.0037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000164, val_loss=0.000661, IC=+0.0112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000155, val_loss=0.000659, IC=-0.0045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000149, val_loss=0.000673, IC=-0.0061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000143, val_loss=0.000688, IC=-0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000139, val_loss=0.000683, IC=-0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000136, val_loss=0.000690, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000132, val_loss=0.000691, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000130, val_loss=0.000692, IC=-0.0083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000127, val_loss=0.000706, IC=-0.0060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000127, val_loss=0.000704, IC=-0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000126, val_loss=0.000709, IC=-0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000126, val_loss=0.000709, IC=-0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=45, IC=+0.0112 (875.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=209,528 seq across 98 symbols\n",
+      "    val=23,882 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000471, val_loss=0.002732, IC=+0.0343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000401\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000388\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000374, val_loss=0.002875, IC=+0.0475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000313, val_loss=0.003231, IC=+0.0252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000275, val_loss=0.003541, IC=+0.0383\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000244, val_loss=0.003460, IC=+0.0232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000222, val_loss=0.003484, IC=-0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000204, val_loss=0.003662, IC=+0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000190, val_loss=0.003704, IC=-0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000180, val_loss=0.003827, IC=-0.0160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000169, val_loss=0.003822, IC=-0.0056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000161, val_loss=0.003797, IC=-0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000155, val_loss=0.003836, IC=-0.0154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000149, val_loss=0.003790, IC=-0.0123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000145, val_loss=0.003857, IC=-0.0098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000141, val_loss=0.003888, IC=-0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000138, val_loss=0.003848, IC=-0.0109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000136, val_loss=0.003919, IC=-0.0109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000135, val_loss=0.003926, IC=-0.0120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000134, val_loss=0.003921, IC=-0.0117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000134, val_loss=0.003913, IC=-0.0120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0475 (861.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=215,516 seq across 99 symbols\n",
+      "    val=23,885 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000456\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000424, val_loss=0.001484, IC=+0.0103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000336\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000322, val_loss=0.002097, IC=-0.0104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000270, val_loss=0.001905, IC=-0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000244\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000238, val_loss=0.001719, IC=-0.0152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000214, val_loss=0.002099, IC=-0.0315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000197, val_loss=0.001948, IC=-0.0493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000186, val_loss=0.002094, IC=-0.0419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000173, val_loss=0.001966, IC=-0.0419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000164, val_loss=0.001783, IC=-0.0413\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000158, val_loss=0.001623, IC=-0.0430\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000151, val_loss=0.001847, IC=-0.0383\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000146, val_loss=0.001719, IC=-0.0399\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000142, val_loss=0.001656, IC=-0.0396\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000138, val_loss=0.001674, IC=-0.0400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000135, val_loss=0.001729, IC=-0.0396\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000133, val_loss=0.001676, IC=-0.0406\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000131, val_loss=0.001674, IC=-0.0417\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000130, val_loss=0.001689, IC=-0.0424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000129, val_loss=0.001684, IC=-0.0426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000129, val_loss=0.001689, IC=-0.0423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0103 (1111.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=219,799 seq across 99 symbols\n",
+      "    val=23,830 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000751\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000509\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000438, val_loss=0.001825, IC=+0.0253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000406\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000333, val_loss=0.002094, IC=-0.0131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000280, val_loss=0.002050, IC=-0.0274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000244, val_loss=0.002023, IC=-0.0305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000221, val_loss=0.002002, IC=-0.0361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000202, val_loss=0.001890, IC=-0.0216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000188, val_loss=0.001800, IC=+0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000177, val_loss=0.001817, IC=-0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000168, val_loss=0.001786, IC=+0.0078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000159, val_loss=0.001793, IC=+0.0108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000153, val_loss=0.001759, IC=+0.0094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000147, val_loss=0.001755, IC=+0.0132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000143, val_loss=0.001760, IC=+0.0147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000139, val_loss=0.001744, IC=+0.0141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000136, val_loss=0.001753, IC=+0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000134, val_loss=0.001755, IC=+0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000131, val_loss=0.001760, IC=+0.0136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000131, val_loss=0.001768, IC=+0.0119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000130, val_loss=0.001766, IC=+0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000129, val_loss=0.001767, IC=+0.0117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0253 (987.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=223,770 seq across 99 symbols\n",
+      "    val=23,655 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000789\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000561\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000467, val_loss=0.001410, IC=+0.0199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000435\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000355, val_loss=0.001501, IC=+0.0356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000297, val_loss=0.001502, IC=+0.0199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000262, val_loss=0.001246, IC=+0.0253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000237, val_loss=0.001263, IC=+0.0232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000218, val_loss=0.001276, IC=+0.0234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000204, val_loss=0.001318, IC=+0.0209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000195, val_loss=0.001422, IC=+0.0214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000182, val_loss=0.001293, IC=+0.0253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000173, val_loss=0.001339, IC=+0.0199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000167, val_loss=0.001378, IC=+0.0243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000162, val_loss=0.001375, IC=+0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000156, val_loss=0.001368, IC=+0.0229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000152, val_loss=0.001362, IC=+0.0207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000149, val_loss=0.001362, IC=+0.0216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000146, val_loss=0.001385, IC=+0.0249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000144, val_loss=0.001391, IC=+0.0232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000143, val_loss=0.001385, IC=+0.0230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000142, val_loss=0.001387, IC=+0.0230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000142, val_loss=0.001389, IC=+0.0228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0356 (757.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=5, IC=+0.0060 (6988.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 5 (IC=+0.0060)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/etfs/run_log/training/31a25af426b6/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 configurations: 2 trained, 0 read\n",
+      "population etfs-lstm-validation-v1: 40 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "population_name = POPULATION_NAME or \"etfs-lstm-validation-v1\"\n",
     "execution, population = run_model_population(\n",
@@ -413,13 +12264,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a408d00",
+   "id": "f9b9bab4",
    "metadata": {
     "papermill": {
-     "duration": 0.023062,
-     "end_time": "2026-09-06T21:49:38.714859+00:00",
+     "duration": 0.044219,
+     "end_time": "2026-09-08T21:38:49.446455+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:49:38.691797+00:00",
+     "start_time": "2026-09-08T21:38:49.402236+00:00",
      "status": "completed"
     }
    },
@@ -448,9 +12299,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "caa79ac4",
-   "metadata": {},
+   "execution_count": 9,
+   "id": "176abbc5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:38:49.551922Z",
+     "iopub.status.busy": "2026-09-08T21:38:49.551762Z",
+     "iopub.status.idle": "2026-09-08T21:38:49.639725Z",
+     "shell.execute_reply": "2026-09-08T21:38:49.639158Z"
+    },
+    "papermill": {
+     "duration": 0.14339,
+     "end_time": "2026-09-08T21:38:49.640808+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:38:49.497418+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "_daily = pl.concat(\n",
@@ -489,13 +12354,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f524b6b5",
+   "id": "b0e551da",
    "metadata": {
     "papermill": {
-     "duration": 0.023185,
-     "end_time": "2026-09-06T21:49:38.847230+00:00",
+     "duration": 0.032445,
+     "end_time": "2026-09-08T21:38:49.710201+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:49:38.824045+00:00",
+     "start_time": "2026-09-08T21:38:49.677756+00:00",
      "status": "completed"
     }
    },
@@ -510,14 +12375,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9c536615",
+   "execution_count": 10,
+   "id": "390daec8",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:38:49.789516Z",
+     "iopub.status.busy": "2026-09-08T21:38:49.789377Z",
+     "iopub.status.idle": "2026-09-08T21:38:49.800772Z",
+     "shell.execute_reply": "2026-09-08T21:38:49.800166Z"
+    },
+    "papermill": {
+     "duration": 0.045761,
+     "end_time": "2026-09-08T21:38:49.801423+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:38:49.755662+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config: lstm_h64   full-coverage validation days = 1995\n",
+      "shape: (20, 4)\n",
+      "┌──────────────────┬───────────────┬───────────┬───────────────┐\n",
+      "│ checkpoint_value ┆ ic_mean_daily ┆ ic_n_days ┆ full_coverage │\n",
+      "│ ---              ┆ ---           ┆ ---       ┆ ---           │\n",
+      "│ i64              ┆ f64           ┆ f64       ┆ bool          │\n",
+      "╞══════════════════╪═══════════════╪═══════════╪═══════════════╡\n",
+      "│ 5                ┆ 0.003281      ┆ 1995.0    ┆ true          │\n",
+      "│ 10               ┆ 0.011175      ┆ 1995.0    ┆ true          │\n",
+      "│ 15               ┆ 0.007716      ┆ 1995.0    ┆ true          │\n",
+      "│ 20               ┆ 0.012308      ┆ 1995.0    ┆ true          │\n",
+      "│ 25               ┆ 0.009566      ┆ 1995.0    ┆ true          │\n",
+      "│ …                ┆ …             ┆ …         ┆ …             │\n",
+      "│ 80               ┆ 0.00617       ┆ 1995.0    ┆ true          │\n",
+      "│ 85               ┆ 0.00634       ┆ 1995.0    ┆ true          │\n",
+      "│ 90               ┆ 0.006797      ┆ 1995.0    ┆ true          │\n",
+      "│ 95               ┆ 0.006142      ┆ 1995.0    ┆ true          │\n",
+      "│ 100              ┆ 0.006489      ┆ 1995.0    ┆ true          │\n",
+      "└──────────────────┴───────────────┴───────────┴───────────────┘\n",
+      "\n",
+      "Published as candidates: 20 full-coverage checkpoints\n",
+      "Highest validation IC: epoch 30 (IC=+0.0166)\n"
+     ]
+    }
+   ],
    "source": [
     "eligible = checkpoints.filter(\"full_coverage\")\n",
     "if eligible.is_empty():\n",
@@ -547,13 +12454,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55f841b5",
+   "id": "f7aa1348",
    "metadata": {
     "papermill": {
-     "duration": 0.025835,
-     "end_time": "2026-09-06T21:49:38.952005+00:00",
+     "duration": 0.052672,
+     "end_time": "2026-09-08T21:38:49.902341+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:49:38.926170+00:00",
+     "start_time": "2026-09-08T21:38:49.849669+00:00",
      "status": "completed"
     }
    },
@@ -567,10 +12474,274 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "afdeb543",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 11,
+   "id": "1b04c2cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:38:50.008196Z",
+     "iopub.status.busy": "2026-09-08T21:38:50.008036Z",
+     "iopub.status.idle": "2026-09-08T21:38:52.866459Z",
+     "shell.execute_reply": "2026-09-08T21:38:52.865785Z"
+    },
+    "papermill": {
+     "duration": 2.912957,
+     "end_time": "2026-09-08T21:38:52.867736+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:38:49.954779+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "#e8e8e6",
+          "width": 1.5
+         },
+         "marker": {
+          "color": [
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ],
+          "line": {
+           "color": "white",
+           "width": 1
+          },
+          "size": [
+           11,
+           11,
+           11,
+           11,
+           11,
+           16,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11
+          ]
+         },
+         "mode": "lines+markers+text",
+         "showlegend": false,
+         "text": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          "1995d",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+         ],
+         "textposition": "top center",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          0.003280946995170078,
+          0.01117495273185249,
+          0.007716478773825778,
+          0.01230839682847819,
+          0.009566400226681811,
+          0.01655725052466728,
+          0.011134106036212857,
+          0.01466834507167691,
+          0.008899057014418073,
+          0.011567857891015668,
+          0.009713049298270342,
+          0.006825080327438516,
+          0.006201768468097849,
+          0.005908517535406416,
+          0.005694469229592109,
+          0.006169849287256565,
+          0.006340472596861889,
+          0.006796969453434411,
+          0.006141763086937361,
+          0.006489348460175818
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "margin": {
+         "t": 70
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#D4A84B",
+           "dash": "dot",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 30,
+          "x1": 30,
+          "xref": "x",
+          "y0": 0,
+          "y1": 1,
+          "yref": "y domain"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 15
+         },
+         "text": "Validation IC by checkpoint; peak at epoch 30"
+        },
+        "width": 1000,
+        "xaxis": {
+         "title": {
+          "text": "Training epoch (checkpoint)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean cross-sectional IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+gAAAH0CAYAAACuKActAAAQAElEQVR4AeydB2BUxdbH/7M9PaELYkfs2EXF3sXeu1iwICgqoiKggoAFC6Jif4pdn698tqfPXsGG9dkLTTqE9G3JN2eSXTZlk91ky93df2BumTvlnN/c3b1nzsxcm8/nbWAgA94DvAd4D/Ae4D3Ae4D3AO8B3gO8B3gP8B7gPZDee8CGpP6xcBIgARIgARIgARIgARIgARIgARIggVgIZLaBHouGTEMCJEACJEACJEACJEACJEACJEACGUCABno7jcRLJEACJEACJEACJEACJEACJEACJJAqAjTQU0W6dT2MIQESIAESIAESIAESIAESIAESIIEwARroYRTZdkB9SIAESIAESIAESIAESIAESIAEMokADfRMai0ryUpZSIAESIAESIAESIAESIAESIAEEkqABnpCcbKwRBFgOSRAAiRAAiRAAiRAAiRAAiSQawRooOdai1NfIcBAAiRAAiRAAiRAAiRAAiRAApYjQAPdck1CgTKfADUgARIgARIgARIgARIgARIggfgJ0ECPnxlzkEB6CbB2EiABEiABEiABEiABEiCBrCRAAz0rm5VKkUDnCTAnCZAACZAACZAACZAACZBAegjQQE8Pd9ZKArlKgHqTAAmQAAmQAAmQAAmQAAlEIUADPQoYRpMACWQiAcpMAiRAAiRAAiRAAiRAAplLgAZ65rYdJScBEkg1AdZHAiRAAiRAAiRAAiRAAkkkQAM9iXBZNAmQAAnEQ4BpSYAESIAESIAESIAEcpsADfTcbn9qTwIkkDsEqCkJkAAJkAAJkAAJkIDFCdBAt3gDUTwSIAESyAwClJIESIAESIAESIAESKCrBGigd5Ug85MACZAACSSfAGsgARIgARIgARIggRwgQAM9BxqZKpIACZAACbRPgFdJgARIgARIgARIwAoEaKBboRUoAwmQAAmQQDYToG4kQAIkQAIkQAIkEBMBGugxYWIiEiABEiABErAqAcpFAiRAAiRAAiSQLQRooGdLS1IPEiABEiABEkgGAZZJAiRAAiRAAiSQMgI00FOGmhWRAAlkEgG/348B2++Ha66/JarYex9yMk45Z1TU65EXrhp/M446eXg46h//9x+Urj8IgUAgHNfWwdkXXokLLh3X1qWoca+98R6efuH/Wl0fc900HHnS+a3ikxUh+t374BOtiv/k0y8xaswNGHLQiei/xR7Y59BTMPqayfhj/sJWaUMRTzz7T6w3YLfQacr3g/Y4HHfd97eU1JvKujp7Tzz4t2fwwcefJYRHsgv57Y/55rP22RdfJ7yqaJ+1hFeUhAI7e58Jz8m33I2hJ5xnPr+77HNU1M/vvK+/x1kXXInNd9gfZwy/HMlogySgYZEkQAIkkFYCtrTWzspJgARIwKIEnE4njjzsQLz47/8gGAy2kvL7H37BN9//iGOOOLjVtVgiuncrw757DYZSKpbkcaV5/e338fw/XmmVZ5ON+mObrTZvFZ/KCDEIDzvuHN0xEcTIi87CrDtvwuBdt8fLr72FabfPSqUorEsT6Ow98cjs5/Dx3C91CZb/n1QBo33WklppmgtfsPAvfD7vOxx64D54aObNkO/At979GKcMG4W6Om9Yuk8//9p0CBYWFOCumyeie1kZjtAdhB9+8nk4DQ9IgARIgARaE6CB3poJY0iABEjAEDjmiIOwYuVqvP/Rp+Y8cvPvV96A2+3CEYceEBkd8/E+Q3bDv555AHa7PeY8XU04YvgZmHbD2K4W0+n8734wBw8//iwmXnMpZt01GaccfySOOGx/3DLpGnz85os4aL8hnS6bGTtHIN33ROektlKu3JNlv713x7+ffRCjdAfboQftjeuuGom7bpmAn375A/O++T4M5CH9Wd9og/Vx920Tcfgh++LOm8djy4Gb4aHHng2n4QEJkAAJkEBrAjTQWzNhDAmQAAkYAnvtsQv6rtcb/3r5v+Y8cvPCP1/D0EP2R2FBPn746VdcOW4qdtvvWDPk86Cjz8J/3nw/Mnmr47aGuC9dtgInnjkCG2y5J044YwTEoG2ZsaO6xEP92JN/N3lliLmEabffZ4qRay2HuP/w02/Gy7XR1nth28GH4bKxk5p5wUJDy2U48/5HnI71B+6O/Yaehrmff2XKjGdz572PYtONN8ClF53dKluvnt1x4rGHt4pvGTF/wWJceNl12GzQvtj38FObDbO+4topRraWee5/5GnDtLqmpuWl8LnP58fEm+7ArvsejX6b744jTjwf4iUOJ2g6eOr5f+PgY84y0x+unngzZCpE0yWzW7p8hRnKu8VOB2LT7fYxx6vXlJtroU2sdYXSi8dShiMPu+gqyJSIUJu8/tYH2PewU02btGQRyvvSa2+F08j9eff9j4cumX3LeyJUdnvtvceBxxtjTO4rub8ktHWvmgra2MgQacnz3Isv4+hTLoDcezsOOQLSTmjxN+ezeTj8+HPN50oYXDdpOurr68OphO3Nd8yCfOak3XY/4HgzFSEyTThxxME773+C3pvuYjqMIqKbHf73nQ9xzsVjsfWuh5j7TTzEP/78eziNsIv2WQsnanHw0GPPmKkdIVnlfopMcvHoCcYTPf3uhyFDx9fXn7fjT78Yi/9aGpkMFZVVZurLVrscbO4z+d5YtHhJszSx3mciQ3v3dLNCo5x0Lys1V7xeX3gv35tHHn4gHA6HibPZbGZU0qtvvIva2joTxw0JkAAJkEBrArbWUYwhARIgARIQAkopHHfUIdpAf6OZIfb5l9+Y+dLiYZd08775H4L1QYy+5ByIJ2nTjTYwD9ky/1KuxxIaGhpw0lkj8e33P2PK9WNwrK73sqsn4atvf2iWvaO6Ljz3NOOt2mHQ1njp+YdNOPWEo5qVETpZvmKVNkTPNV78O2+egBHnn4EX//2aNoCbz3n3+wO4bcaDmDLxSsz76BUM2nZLnDn8irgfsj/94mscuN+e4Qf2kByx7kWOU865FFttMUB74yZgvT49ceJZl+D3PxeYIk4/6SgI86+/a85s9jMv4tgjD0FBfr5J19Zm+Khr8NyLr+DEY4/Ao7NuhXgJP5rTfAj3U8/9E//8v9dx8Xln4LyzTtbG3fOYpY3/UHliNB189Nn45dc/MXb0BWa0wsKFS3DCmZdA2jeULpa6QmnFOD/y5POxw3Zb45F7bw6zk6HEV1x7E6bdeBW+mfMa9thtx2YsJP9b730Mmf+7/aCt8MCMqTho/yGmE6ItQ1jSh4Jwbq+9Z952Azbo3w9nnnKsub/kPpN7QvJLx5IYy3LcURhz3VSccsIR+PqTV3GV5iXG99//9Vo4m8xXlo6SosJ83HvHJFww7FQ8+/eXMHHKneE0i7ThKkbziccchodmTsP+++yOmfc/hnsffDKcpuWBGOdyH91207U4/+xTWl4On0unw8Ybro9bJ12Dqy+/ELV1Xhxz6gWoqm7s6InnsyaFynoMYyfcgsG77qjb8hb9WdgDl151I175zztyORze++hTvPfhHDz72Ex8+MYL8AcCOF532EV2Opwy7FJ8Me9bXHXpcDMCZeHipTj8hPOafSZjuc86uqfDQkU5CGjZPprzOSbdPBMbb9gfg3fZwaSUzkbpvNpqi83MeWizlfagS/ziJctCUdyTAAmQAAm0IEADvQUQnpIACZBAJIFjjzgYaysq8cZbH4aj//nyGygpLsJhB+1j4k478SjcpQ3cU7UhfPzRh+H+GTfhtBOPxmNPvWiux7KRxaa++f5HzH7wdmP4nH7S0fjbfbdCPMaI+Dutg7oGbLohevXsYeSTEQASNtJGRkQR4cP7H3kKpSXF+PsT92oD9mBcfP7puOuWifj3K2/iK93pEEooD+FjR1+I3bVh0bNHN2OoC5N3P5gbStLhXjoDxGvWd70+HaaNlqBRjgtw2cXDtCfuADz9yAwM2GQj7Xl9ymTZaYdtzRDa57Rn1kTozVff/g//+/FXYwjq0zb/i7dYdH5u9kxcddlwHHLAXrhy1Hl49L5bmqUv017CF5pYXXPFRTj7tONN500o0X0PPYm1ayvw6ot/w7lnnoSTjhuKvz95n67/F7z+5gcmWax1SeKQcb7bzttrg+5m05Ei8RLE4L9pwhWmTbppuaZMHNOMhaS57a4Hcaq+J+XeHHrofrhpwpVGrrvufRRi4EuatkIj5+jtLZzzPC6s3289yP0loay0pK2i2o07Rcsm8slnSfbnn30SRLZQpinT78POuk2fe/weHKU9sZdccCZm3HI9Hpn9PFatLjfJttt6Czx2/2244JxTTceUcLhh3GjMfubv5nrLjRjnp557GcQ4P+vU41pebnYuZcl0DGE3XHcO/PPp+5Gf58HL/3nLpIvns1au7wvp9JD7avqUayFDwyePvxIXnnsq7rzvUVNeaCOG+IN3T8WmG28I+ezKsSygKPeopBHPviy0+Oxj9+CcM0/ECbpz4oXZ92DZ8hV49IkXJIkZWSLpu3pPm8KibE4ZNgo9NtrJLBa3ctVqvPzCw/B43Cb18hUrZQ/5fjEHTZtu3UrMkRjw5oAbEiABEiCBVgRooLdCwggSIAESWEdAjBHxDP3rlTdMpBhG/3zpDWMgykJyErmmfC2u1169vQ4+yQybleG7T7/wb8xfuFguxxQ+n/cNttlyc+y686Bw+h233wbbb7tV+FwOElGXlCNh7udfY9+9dg97ZSVORgwUFxWi5UJOO2lZ5LoE8USv37cP/lywSE5TGsSzHapQKYV9994Nn37xTSgK55xxglkgT7x0Eike18022RDSuSDnbYUPPv4Um2+2USvWLdPutfvOzRb12367LfHn/HUMhNmhutOme7fScFbp0BADe85nX5q4WOpSSmHhoiUQz/leu++ivd9TmhnnpiC9aY+FGOBzP/8KB+y7u0657v/pJx0FGYb/w0+/rots46iz7S0dEv/99+w2Smwdte+Q3ZpF7jtkd3z3w8+Qe9zr9ZlpGqeeeGSzNAfrzhMZuv259h7LBfk8yrDx0DB4+ezJGwJ+/3ORmQ4gaZRSssNb730CMc7vumUCOjLOJYN45i+6bDx23vsolPXfHt022AG//7kQf86P/XMt5UiQkR1ipJ98fPPRLIccsDdkRI7oK+kkbLXFAKzXp5ccmtCnd09ss9VAfPbl1+b8U92uW2y+KaSDwEToTf/1+5rRAx9/+oU+gzbQE3NPm8KibMZfPQrSaTHh6ksRCAZw+vmXm7aLktxEKyizT8yGpZAACZBAdhKggZ6d7UqtSIAEEkjgpOMOx6uvv2u8jh98/Bn+WrIMxxx5cLiGK66dAhmWesYpx5hhtjLk95Tjj8TqJi9fOGE7B8uWr0TvXj1apejTp3lcIuoKVSJ6dCsrDp2avcwTlaHjfy1dNwQ1T3sNJZgETRuHw46aOOaR9urZ3czX/2tJ87m0TcXFtFNKtfLIlZaUItIbd/LxR6Cyqhqv6PYSI12GTJ920tHtlr/4r2Xo2aM557YyFBUVNYv2QuHN5gAAEABJREFUuN1mLnAoUnQT770YiZHhvQ/nQoYgS7pY6hKj8+33PsaixUtx8flnQKnWRo1SrVmUla5jsWTZcjOsvqysRKoNBzH25ESGhsu+rSBtLSHyWrztHZk32nFZi3tvnXd1JZYsXW6yyZoIkSx7bbKzeavCosV/meuy6ODNd9yPg7XhLtM0/u+5hyCeaXnzQvnaSpNGeMqBtM2G/fvhiBgWdpT1Ck4951LU1tVi5AVn4XntoZbP9bbaUC5fu1aKiyv81aTPLvschUh9jj7lAlPO738uMHvZdGtjNEJ33Y7LV6ySy/r7Zzlk1IQ5idj07tUTixc3fm5juc8ka0f3tKSJFqRDUTqJZFTA35+4DzLq5pkXXjLJe/bobvblayvMPrRZvaaRncgairPsnoKRAAmQQJoI0EBPE3hWSwIkkDkE5DVC8sD+yutvQxY+6tmjG/bba7BRQIzA/3v1TbPwmcxJlaG4MuRXDBqTIMZNb22cr2nxMCtZ16xZ94CbqLqkXAmyAN6y5Y0P/XIuQYyZJUtXoF8XhqJLOW2FoYfujzff+QgyhLqt6x3FiWyyqn5kuuUrVjTzNspwaWmv5//5Ml7+zzuQodCnntDcCxuZX4779e2NFSsbh+TKeWeDeDGPHnpQeF62GHShcOWo802xsdSllMKwM07A6bpj4fgzLtYe23VeelOI3ggLmWagD8P/15SXI2SAr9e7lzHsl+mOn3ACfRDqzOjfbz19lt7/5eWNBnRIitWrG423Pr17QO5NecPBuDGXtMnz0AMbp5dIR8yxRx6K0SPOMUO9995zV4QM/VC5SjV2cNx583jk5+eZtR5khEHoelv7L+Z9Z9aZuGXyNaYt5A0D8rmW74G20ncUt37fxqkdzzx6d5v6yL0TKqOt74FV2rCVTi5J03e9XmY4uxxHBhnivv76jfX0S9A9HVl+e8d91+uNPrqDYKnuGJJ0ci57mV4i+1D4/sdfzKG0sTnI4Q1VJwESIIFoBGigRyPDeBIgARJoIiCvBtp+u63w4v/9By+99qZZOE6MB7nc0ADj0SsoKJBTE+Th/+33PzHHsW523mE7fP/Dz9o71ugBk3xLtNctcsGzWOsq0EZI5JBZKautsNvOgyDzWcXbGLou3t6KyioM2WPnUFTC9jKH+Lc/FmDmA62HQIvB+Z8OVr4XQd54u3EutxxLHlkbYJcdt5XTcJB5+hIvr3M67OB9mhnw4UQRB/sM2Q0///onZL56RHTch3vvuRu++e5HbLfNFuG52WLUSdhqi81MefHUJUOx99htJxx72kXam77E5I/cvP3euntMWLz7/lzsutN2JonH44YMrRcOJqJpI/zEkJIh0k1Rndrl5+fD51v3zuvOFPLuh+vkl/zvfTQHW285AGXag+xyObH/3oPxzfc/tGIpPPs1Gbxy7xYW5En2cHg9yn0kb1wQT++a8rU4c/jlWn5/OE/LA5kHLnFFhes+1/JZ/P3PhRIdDgUxftZ23H4biIEtc8lF/pZBZAsV2tb3wHf/+wm77Ng4/WXXnbfHr7/Px/9+/DWUxYzkeP/Dz7D7LjuauHjuM5Ohi5vvf/jFTJ3YZKMNTEnSfnvrzpKXdOdlqENOmMq53NORXE0GbhJNgOWRAAlkMAEa6BnceBSdBEggdQTEM/rq6+9qT+tqyHGo5tCD6COPPwsximVRt+GjrsXapuG1oXQd7cWQ3GLApjh/5LX47Y/5+HP+IsjrxJRS4ayx1jVg043w7fc/4rU33oMMyZeywoVEHMjwaZ/PZ14RJ+ne/WAOrp54i9bvQAzaZsuIlIk5lAW9ZGG1G6fNwMWjJ+DZF1/Cy6+9jbETpmHHIUfi9bfafzWdvK5pxn2P6nQfGL1k1W8Zyn3Reac3E1AMg4026IeP536BE48Z2uxaWyd7Dt7Z6HzORWPN6/FkIbHbZz6Cc0dc3VbyqHGXDD8DTqcd+w89DTPvnw3p7JBh1aefPxryWj3JGEtdYmxLkOkGD949BbJQ2LGnXWjuPSlDgrCYdvu9zVj88vufiGRx1egLIKM7Hnj0acNLZLjvoScx+pJzw4t5SVmdCXKPvfXuJ0ZHuXfE6JVyJt50h7mf5Lij8JJu+9nP/MPIJvuHH38el19yXjjbDeMuNyMuZBi4vP5N6rlHd+4ceuyw8GvH9hy8E2TRxkWLl2D1mnLccucDeOvdj8NlyIGwDO1lfYB/PDULP/36J4ZdPMZ0rsm1lkE6WWQ0xsz7Hzevdfvyq+9wwahxZppGZFrhEMtnTQzSCVePwrgbb8MlV0w07SL3x6Sb74asfB9ZZmlxsfnsi74SLrzsOrNC+tFDDzTJxJsv99GlY2/E+x99avjJvPtu3UrNGgySSK5L+q7e01JWyyDrbchn9s13PzKfF2nzg48+CzL8/7ijDw0nv+qyC/DDz79h1JgbzRSh0VdPhnRyjNX3ZTgRDzKUAMUmARJIJgEa6Mmky7JJgASyhsCJxxxmdJGhmy0XHBNPp1N7/Dbdbh/stv+x6LteL8jqzCZDjBulFJ57fCbytOdz70NOwZ4HnWhenXXw/kOalRBLXTI0+pwzTzDGwJEnnY9n/v5/zcoInchQ/VdffMx0CMhr00ZddSNEt/vvmhJKkvD9jFsnQlax/vGX3zDxpjtxhvZkylB0GdJ966T2DWKn04Ep11+FK669CceceqE2wL/EC7PvRchrFxJWKWXmJIt+Rxy6Xyi63f1DM2+GdJKMnzQd8mqy/2pPvRj57WZqcVG81q//a7bxdD76xPMQw1JW7t58040xeJcdwqnjqUsM8acevhPdyspwrNZZjFApKBYWB+yzB5586E7IvGCZTy3G69WXX6SN+NOkiC6FSdddjk023kB3KF0Duce+bnod4Fd6Pz/GxQOljEefeMHkl9XbJ4+/Aicc0/g5E+HEm/7WS09BOipuuuUek+6l197C4Yfshx7du0kSjLrobBy47xAceOSZ2GTbffDZF19DhrKbi1E26/XphRefnIUvvvwOF18+wRjgLZN2KyvF4w9Mxzvvz0HPjXfGycNGQd5yIK8vjEwb62dN8px5yrF44qE78OMvv2OErveks0dqA/ZXnH7yMYj822HQVthnyGCcdu5lkDQOu0PLe5/hEEr3zN9mQO7Pi0aPx7CLxqC6ugavvPCIGcIfShPPfRbKE8t+6y03NyNOrtOdDedfcjXeeu9jDB92Ml558VHIApOhMmSUgHQwffXt/yCdlvKaxVl3Tca+TdODQum4J4FWBBhBAjlOwJbj+lN9EiABEoiJgLxSqnzR1/jfZ2+Yub2RmcRAfOrhu7Dop0+w9NdPccukayCvZ3r/9efCyW676RrIAlahiOOOOhRSnhhgobg+vXviRe3dW/zzJ5BwzRUXayPhdshrlkJpYqnL6XSahbLmffSyqePaK0eY7GIYy5xoc9K0GThgYzMn9s/vP8C3c16DdABELhAmRsWSX+Y2pV63m/vOvyCLQ62LaX0k+smw9pZXzj/7FLzzytP4ed7bRj5hKq9OE7lbpg2dh+QQ7+H3n76OVfO/xLuvPmOGP4fShPYylFaGf5947OHao+0MRbe7l9EJU7Xx//n7/4eFP36M//zzMdOGoUxff/wqRo84J3Rq9icdNxQr/2xcNdtE6I0Mz5bX7IXYS3nXX3uZ7rTpra82/o+3Lpk3/fq/HseH/31BG+qljYXobSwspNPh3deeMffm3Hf+iZEXnqVzrvvf8p4IcV6XovGoZXvLvSqvofvlq3dMG4rRFQgEIHO3zz79+MZMHWzFwJQ2lPvkyw9fNgZwyyxipMtK4T/Ne8vUIxwu1Ua52+0ySQvy83H71HH48cs3zXVZRV7aRcrs0b3MpNl04w3NtV12GmTOZSMroEuZ8tmSDgCJaxlEJ6lP7jXRc9jpJ5jPys03rutIknt28vgrEWrv0GetZVmh8yMPOwBvvfSkaY9lv30GmZN+bMSCk6F0Yy4939yH8tn7x9OzEBrSH7ouhvDD99xsvo9+++Y98zq/Dfr3DV02+3jvM8kk7Fre0xIfGSTNv555AHJPyHfeR//9O24YN7qZcR5KL6+d/OStF8332Zy3/wFZPDN0jXsSSBcB1ksCVidAA93qLUT5SIAESIAEYiIgBqIMCZ52+31mga8LzzktpnxMlBgC8iqx/uuvhyMO3T8xBbIUEiABEsg8ApSYBLpMgAZ6lxGyABIgARIgASsQqKquaRoG/TbuvX0SNtygnxXEyhkZxEMtXlKl1q2bkDPKU1ESIAESSAkBVpILBGig50IrU0cSIAESyAECpSXFZiizGImRc5mzTfVow9AzRc+2hpxniuzJlnPWXZPx7GMzk10NyycBEiCBtgkw1hIEaKBbohkoBAmQAAmQAAmQAAmQAAmQAAlkLwFqFhsBGuixcWIqEiABEiABEiABEiABEiABEiABaxLIGqlooGdNU1IREiABEiABEiABEiABEiABEiCBxBNIXYk00FPHmjWRAAmQAAmQAAmQAAmQAAmQAAmQQHMCEWc00CNg8JAESIAESIAESIAESIAESIAESIAE0kUgGQZ6unRhvSRAAiRAAiRAAiRAAiRAAiRAAiSQsQQy0EDPWNYUnARIgARIgARIgARIgARIgARIgASiEqCB3hINz0mABEiABEiABEiABEiABEiABEggDQRooKcYOqsjARIgARIgARIgARIgARIgARIggbYI0EBvi0rmxlFyEiABEiABEiABEiABEiABEiCBDCVAAz1DGy49YrNWEiABEiABEiABEiABEiABEiCBZBGggZ4ssiw3fgLMQQIkQAIkQAIkQAIkQAIkQAI5TIAGeg43fq6pTn1JgARIgARIgARIgARIgARIwMoEaKBbuXUoWyYRoKwkQAIkQAIkQAIkQAIkQAIk0CUCNNC7hI+ZSSBVBFgPCZAACZAACZAACZAACZBAthOggZ7tLUz9SCAWAkxDAiRAAiRAAiRAAiRAAiSQdgI00NPeBBSABLKfADUkARIgARIgARIgARIgARLomAAN9I4ZMQUJkIC1CVA6EiABEiABEiABEiABEsgKAjTQs6IZqQQJkEDyCLBkEiABEiABEiABEiABEkgNARroqeHMWkiABEigbQKMJQESIAESIAESIAESIIEmAjTQm0BwRwIkQALZSIA6kQAJkAAJkAAJkAAJZA4BGuiZ01aUlARIgASsRoDykAAJkAAJkAAJkAAJJJAADfQEwmRRJEACJEACiSTAskiABEiABEiABEggtwjQQM+t9qa2JEACJEACIQLckwAJkAAJkAAJkIDFCNBAt1iDUBwSIAESIIHsIEAtSIAESIAESIAESCBeAjTQ4yXG9CRAAiRAAiSQfgKUgARIgARIgARIIAsJ0EDPwkalSiRAAiRAAiTQNQLMTQIkQAIkQAIkkA4CNNDTQZ11kgAJkAAJkEAuE6DuJEACJEACJEACbRKggd4mFkaSAAmQADMhqtIAABAASURBVAmQAAlkKgHKTQIkQAIkQAKZSoAGeqa2HOUmARIgARIgARJIBwHWSQIkQAIkQAJJI0ADPWloWTAJkAAJkAAJkAAJxEuA6UmABEiABHKZAA30Lra+0+lCR+HGGyfhiy++7DBdR+Xwesesycil72iFhgbwfovhsxl5v9Qt/xJL5t5CbnFys9sdCAQC5BYnt8h7j8fxfbf7/X44HE7ec52955gvrnunvr4eSqm48vAzHd9nmrzW8VLKhvr6hoy/3/TDKP93gYCtC3mZlQRIgARIgARIgARIgATCBHhAAiRAAiTQNQI00LvGj7lJgASyhEBRv8HYYMiELNGGapAACZBAVhKgUiRAAiSQ9QRooGd9E1NBEiABEiABEiABEiCBjgkwBQmQAAmknwAN9PS3ASUgARIgARIgARIgARLIdgLUjwRIgARiIEADPQZITEICJJD9BCoXz8GCDydnv6LUkARIgARIICsJUCkSIIHsIEADPTvakVqQQM4T8PsDuHbSXTj4+OHY/ZDTWvF49h+v4uRzr8SJ51yBm+962Kw8Hkok126b+Sg+m/dds2sVlVXYef+TmoXvfvg1lK3Z/tMvv8VFV9zYLI4nJEACJEACJJAlBKgGCZBAigjQQE8RaFZDAiSQfAJDBu+IO266ulVFb743By+//h4emTkZzzx8G+rqvHj676+adKFro4afjp2337rZNUlQkJ+Hz99+Phy22XIziWYgARIgARIgARJIGAEWRAIkECJAAz1EgnsSIIGMJuB0OjD04L3Ro3tpKz1+/OV3DNpmIAoL8uGw27HHbjvgjXc/NulC13puug823Gtis2smQTubGQ88iWPOuBQXXH4D3v5gbjspeYkESIAESIAESCBtBFgxCWQQARroGdRYFJUESKBzBLbYbGN8/f3PqK6pRbC+Hh9/+hWWLV9pCmvvmiSo1d72IYedgSNOHYGZDz4FGUov8f/VBv67H36KJx+4Gffceh1++W2+RDOQAAmQAAmQAAnkGAGqSwKJJEADPZE0WRYJkIAlCRy47+44YK/dzBz0vQ8/Czabgl170qH/2ruWn5+HV5+/H++9MhvXjh6OD+Z8gYef+LvOBXz59Q84ZugBxivvcjpx4tGHmHhuSIAESIAESIAESCCBBFhUjhGggZ5jDU51SSBXCZxz+rF4+dn78NF/nsQO226J9fv2DqOQa8/cfhaeGT+w2TUZDt+jWynsNhv23G0HnHXK0fhGe+IlYwMazHB5OZYgQ+xlz0ACJEACJEACJEACmUOAklqNAA10q7UI5SEBEkg4ARnW7vX5EAgG8eHcL3HPQ0/jpGMONfWErsl+1Zq1za7JKu4mkd7U1tXhvY8+w6Btt9BnwE6DttIe9S/R0NBgzj/45Euz54YESIAESIAESIAESKCJAHdxE6CBHjcyZiABErAqgUNPvBBHnDLCzBOX16OFXnsm88b3P+pcDD7oVNx+z2M478zjcPB+exg1QtfGTpyO335f0OyazFWXciScNnwsNt14Aww/6wST76B998AWAzbGJVfdhEuvmYrlK1aZeG5IgARIgARIgARIgARSQyAba6GBno2tSp1IIEcJ/OeFB8KvQ5NXo91/x/WGhMftMkPbJe6fT9wd9p7LxdC1B//2D5xw2fPNrh16wJBweZLvomEnmeHukk/C6IvOxH3TJ+Dum8eZfag+ucZAAiRAAiRAAiRAAiSQ0QTSIjwN9LRgZ6UkQAIkQAIkQAIkQAIkQAIkQAK5S6BtzWmgt82FsSRAAiRAAiRAAiRAAiRAAiRAAiSQUgIJM9BTKjUrIwESIIEEE6hcPAcLPpyc4FJZHAmQAAmQAAmQAAmQAAnETiBTDPTYNWJKEiABEiABEiABEiABEiABEiABEshAAjTQTaNxQwIkkKsEGuoDqA/Uor7eDzQEzXFD0JurOKg3CZAACZAACZAACZBAGgnQQE8FfNZBAiRgOQJimItQ5fPfxcqf/o2qJV9C2dxY/v1zWPPHO6hd9ZMx1iUNAwmQAAmQAAmQAAmQAAmkggAN9FRQTnIdLJ4ESCA+AoHaNfBWzMf8929ExcKPjDEeqCtHfdAH79r5qPxrrjbUn4UY7/W+Su1Zr4+vAqYmARIgARIgARIgARIggU4QoIHeCWg5loXqkkBWEWgI+uGvWYZl3zzZoV6Viz/F8h/+YQz3DhMzAQmQAAmQAAmQAAmQAAl0kQAN9C4CZPauEmB+Ekg1gaD2jj/XqtJA3RrUrfmlVbx37Z+oXjYPwUBdq2uMIAESIAESIAESIAESIIFEEqCBnkiaLMt6BCgRCUQQaKj3Ydm3T0fExHa4+rc3YIa6x5acqUiABEiABEiABEiABEigUwRooHcKGzORQCMBbjOMgLLDX7uiU0LX04PeKW7MRAIkQAIkQAIkQAIkEDsBGuixs2JKEkg1AdaXYAIy/7ze3/ZQdYenDJ6yAVFrrCufr6816MD/JEACJEACJEACJEACJJAcAjTQk8OVpZJABhDIPRFrV7eeYx6iEAwG4ff7Qqet9nVr/0TQV9MqnhEkQAIkQAIkQAIkQAIkkCgCNNATRZLlkAAJNCdgwbO8btE95GKg1zc0oL6+7VequYv7w+b0WFArikQCJEACJEACJEACJJAtBGigZ0tLUg8SyDECnVFX2Z3ayM5rI6s2zH3lCFT+oQ30YBvXAU/JhlDK3uY1RpIACZAACZAACZAACZBAIgjQQE8ERZZBAiSQEQQaAnVw5vVoJWt9fePccqWv1Dd60PVR8/82h7t5BM9IgARIgARIgARIgARIIMEEaKAnGCiLIwESsC4BmyMPvbY5rZWA9fWNXnOlbBBTvb6h+TD3sk0OhsNd3Cpf5yOYkwRIgARIgARIgARIgARaE7C1jmIMCZAACWQpAW2AQyn02vqUZgrWaw+63V2KvG6bm/j6YKPBLieesk1Q0HsQbM4COc2MQClJgARIgARIgARIgAQykgAN9IxsNgpNAiTQWQI2uxvySjXjSdfGOrTPvEEHm63x69Bus6G+aZh7Ud9d0W2zI2B35ne2uqzMR6VIgARIgARIgARIgASSQ6DxiTQ5ZbNUEiABErAkAWdBL3hKN8aGe01AYd89kd99Czjzu8FmdyFPe8yL+g5Gjy1PQumG+8CZV2ZJHbJYKKpGAiRAAiRAAiRAAjlLwJazmlNxEiCBnCagbA6tv0Jen91QsvFhKF5vJ+05r0PvbU5B3nq7QxXIa9XoOdeQsuw/1SEBEiABEiABEiAB6xLIKgN95ao1GDl2Ks4dNRHjJs9AbV1dm+S//u4nDBs5AWdePA4PP/FiOM2/Xn0bp55/FXY/5AysKa8Ix8vB9z/+avIMOewsHH7yCASbhsDKNQYSIIHMJVBT50WgwWa850o5zHD2ethRXV2duUpR8vQRYM0kQAIkQAIkQAIk0AUCWWWgz3jgKQzeeRAenTkJxcVFeOqFV1uhaWhowMRp92LsqGH42z2T8fYHn2LeNz+YdL17dsekcSPRo3vzIa3VNbW4/LrbcNQh++DNfz2MWdMnwGbmrpps3JAACWQoAZlrHgwG4HK5m2ng8Xi0N70egYC/WTxPSCDdBFg/CZAACZAACZBAdhPIKgP9o7lfYejBe5kWG3rQXvhw7jxzHLn56dc/kZ+fh60GbgqH3Y6D99sDH8z50iTZfZdBGLDJhuY4cvPex59jy803wXFHHgiP24UN+68HpVRkEh6TAAlkIAG/32ekdjpdKOo3GBsMmQD5c7s9skNdlFE45iI3JJB9BKgRCZAACZAACZBAmglkjYEuXm6xmctKiw3S/v16Y8XK1eY4crNsxWr069MzHCXpli1fFT5v6+CvJStMtAx/l+Hts597yZzLRh7wOwoNDeKJC6CjdLzuIyNtMHb1PhCvr4SulpML+evqauVjrENDs3tPvOpOpxO1tTXN4nOBSWd0FF6dycc8ufadlxh9eb8lhiM/f7FxDAQCZjQVecXGi5y6xkme3yRkOkf9YMX/XSCQNQa6MLDZ1qmj1LpjuRYZlC3S+x09XSiPGNhLli3Hzddfgdn3TcF7H32OL776PnSZexIggQwl4Pf74XA4oVTkd0KjMmKgyxD4QCDYGMEtCZCAtQlQOhIgARIgARLIAgIdW6cZomRBfh6CwXr49AO3iLxqTTl69ugmh81C757dsKa8Mhy3Wqfr3at7+Lytg+7dSrHl5puaoe0yP33brTbDT78tMEllaGxHQSmbNgIc6Cgdr7vIyNl1BmJwSuD91D5Lu92hvzOCcLvd5r6rW/4llsy9xRwLu/z8QshffX0wHCfxDK25Cktyac2FTJLDJF33G9szOe1pda4Oh0M/wzn5O5CA5xOrt7UV5HNop4EEK8jSFRnk+Ymh8wSyxkAXBHvsuj3efPcTOcQb73yMIbttb45l+Pt3P/xijgduthFktfeFi5ealdjfem8uhgze0VyLttlLX//5tz9RVV0Dr8+Hb//3K7YYsFG05IwnARLIAAJ+v89I6WqxQJyJ1Bu73a4fyJxYNwxeR/I/CZAACSSHAEslARIgARIgAUMgqwz00Redjpdef9+8Zm3BwiU4/cShRslF2hifPP0Bc6yUwo3XjMCEqfdg2CXjsdMOW2HH7bY012Y9+px5xZoY8DLXfMzE6SZePPFnnnQEho++EedfdgMO2GdwOI9JwA0JkEDGEfD5vEZmGcpuDtrYuN0eBAIB7WkPtHGVUSRAAiSQKQQoJwmQAAmQQKYQsGWKoLHIKcPPZ00fb16zNnXCZcjzNK7EPHDAxnjukUZjW8oZtM1APHbvTXhi1lQMP/N4iTLh4nNPxievPxkO0yeNMfGyOfygvfHMQ7eYPKcdf5hEMZAACWQwAZ/Ppz3kLiiljBaRq7ibCL2R163pHbzeRmNejhlIgARIgARaEOApCZAACZBAwghklYGeMCosiARIIKsJNC7+FoDL5WpXT5nr6nA4OMy9XUq8SAIkQALJJcDSSYAESCCXCNBAz6XWpq4kQAKGQEfzz02ipo0Mc/f7/QgGuZp7ExLuSIAESCCbCFAXEiABErAUARrolmoOCkMCJJAKAjK8XeqJnH9euXgOFnw4WaKbBY8nz5yH5qybE25IgARIgARIICYCTEQCJEAC8RGggR4fL6YmARLIAgJibMvrQ5RqnH/enkoyxN1ms3OYe3uQeI0ESIAESCA9BFgrCZBA1hGggZ51TUqFSIAE2iMQ6/zzyDLy8jwQr7vkjYznMQmQAAmQAAlkMwHqRgIkkHoCNNBTz5w1kgAJpJGA3+8ztbdcIK6tVdxNQr1xuznMXWPgfxIgARIgARJIJAGWRQIk0AYBGuhtQGEUCZBA9hIQT7hoJ0PcZR9LkLnqNpuNw9xjgcU0JEACJEACJGAJAhSCBDKTAA30zGw3Sk0CJNBJAo3zz51QquP555FVeDweeL1eNDQ0REbzmARIgARIgARIIBcJUGcSSBLuKXfFAAAQAElEQVQBGuhJAstiSYAErEdA5pAHAgG4XO5WwkVbxT2UMDTMXYz0UBz3JEACJEACJEACJJAMAiwzdwnQQM/dtqfmJJBzBKLNP48FhAxzV0ppL3ptLMmZhgRIgARIgARIgASsSoByWZgADXQLNw5FIwESSCyBzsw/D0mglILHk4e6ujoOcw9B4Z4ESIAESIAESIAEWhFgRFcI0EDvCj3mJQESyCgC7c0/b28V95CSbrfHHIYMfXPCDQmQAAmQAAmQAAmQQOoIZHlNNNCzvIGpHgmQQCOB9uafN6boeOtyuczicl4vh7l3TIspSIAESIAESIAESCDzCKRbYhro6W4B1k8CJJASAl2Zfx4SUCkFt/aic5h7iAj3JEACJEACJEACJEACcRDoMKmtwxRMQAIkQAJZQCA0LN3pdLWpTUeruIcyeTweMwfd7/eHorgnARIgARIgARIgARIggYQQ6JqBnhARWAgJkAAJJJ+AGOihldi7Upur6RVtHObeFYrMSwIkQAIkQAIkQAIk0BYBSxvobQnMOBIgARKIl0Dj/HM/QsZ1vPkj0yul4OYw90gkPCYBEiABEiABEiABEkgQAVuCysnEYigzCZBAjhAIDUd3udoe3i4YYlnFXdJJkGHujUZ/QE4ZSIAESIAESIAESIAESCAhBGigJwRjW4UwjgRIwCoE5PVqIku0+edyLZ7gahrmXlfH1dyFm1JKdgwkQAIkQAIkQAIkQAJdJEADvYsA05adFZMACcRMIFHzz0MV2mw2M1xeVnMPxeXi3h8IQEYSlK+thN8fMIvn5SIH6kwCJEACJEACJEACiSJAAz1RJLOsHKpDAtlCQAzIQKDj+eexruIe4tI4zD2IgDZSQ3G5sq+pqcXKVatxw5S7cM7FV+Hi0dfh0rHX454HHzdGujDPFRbUkwRIgARIgARIgAQSSYAGeiJpsqxYCTAdCaSMQCzzzzsjjCwUJ/lybZi7eM1//3MBLrxsHH785VeIsS4clq9YhXc/mINTzhmFYLBeohhIgARIgARIgARIgATiJEADPU5gTJ4JBCgjCawjEJp/7nA410Um4EiGucucdq+3LgGlZU4Ra9asxfVT74wqsIwouGHanShfWxE1DS+QAAmQAAmQAAmQAAm0TYAGettcGEsC0QnwSkYRCM0/F4O6PcHjWcU9VI4McxeDNBjMndXcf/z5t5D6UfeSpiA/L+p1XiABEiABEiABEiABEmibAA30trkwlgTSRoAVJ45AQ0MDYpl/3tkaxUCXvLmyWFyd14dvv/9RVA6H+oZ61GvO4Yimgz8XLGo64o4ESIAESIAESIAESCBWAjTQYyXFdCSQHQRySgu/32f0dblcZp/ojc1mhwyd9+bKMHdtjOfneZphDAYCCAaDaLkwXH5+frN0PCEBEiABEiABEiABEuiYAA30jhkxBQmQQMwErJXQ6/UagcSINgftbOJdxT1UlHjR/X6/MVJDcdm6F10Hbr5ZWD0xykPeczkOX9AH6/Xuqbf8TwIkQAIkQAIkQAIkEA8BGujx0GJaEiCB9BKIs3a/9qA7nU7YbMn7qvN4Gudae3PEi77LjtvC43ablhDvuYKCTSnUR6zcfvD+e6PO2zh6AfwjARIgARIgARIgARKImUDynlpjFoEJSYAESCDxBMSj69eebVlpPdbSO5PObrfDbncgV+ahS4fHlIljzJB28Z7bHXYoZUOD/KtvwDZbbo5Tjj8SLYfCd4Yt85AACZAACZAACZBArhGw5ZrC1JcESCA3CMjicKKpy9Xo7ZXj9kJnVnEPlefxeODX3nrpFAjFtbHPmqgN+vfDM4/ejQP22RPbbjUQZWUl2GXH7XDisYfj6itGoKSkKGt0pSIkQAIkQAIkQAIkkEoCNNBTSZt1kQAJpIxA6P3n4vFNdqVioEsd3rQOcxcJUhOk82Pt2jW44NxTcdXoizD1hrEYMfwsHH7wPvScp6YJWAsJkAAJkAAJkECWEqCBnqUNS7VIINcJyPvPZXG4ZM4/DzFurMee3cPcQ8rqfVVVJYRrfl4+CgvyUaY95vl5bq1/rRn6rpPwPwmQAAmQAAmQAAmQQCcI2DqRh1lIgARIwNIEZKi53++HK47Xq3V2FfcQCPGii9de6g7FZeNedBS2BQWFUEqFVXQ3LRzX2VEE4YJ4QAIkQAIkQAIkQAI5TMCSBro84L763/cx8uppOO6sy7HX0GE45ISLcPoF12DqHQ9j4eKlOdxkVJ0ESKAjAjIEW9K4Ypx/Lmm7GsRAlzLEgJV9tgbxniulkKe955E6No4isMGiBnqkqDwmARIgARIgARIgAcsSsKSBfu6l1+Ozef/DmScdgRnTrsbb/3oYzzx0CyaOvQgDB2yIsTfcibfem2tZqBSMBEggvQRkeLtIkIr551KPBDFQlVLI5tXchat4zwsLi5p5z0V/CW63RxvoXjQ0NMhpDgWqSgIkQAIkQAIkQAKJIWBJA/3qS8/B9doY322nbdG/Xx84nQ50KyvBwM02wvFHHoTZ903B+v16tyKwctUajBw7FeeOmohxk2egtq6uVRqJ+Pq7nzBs5AScefE4PPzEixJlwr9efRunnn8Vdj/kDKwprzBxkRuJ2//o8zHr0ecio3lMAiRgMQLixRaDWeZJxypaUb/B2GDIhFiTt0qnlILHk6cN1LqsNVCrqyuNYd7Sex6C4fF4zKEY8uaAm8QQYCkkQAIkQAIkQAI5Q8CSBvqWm2/SbgOIwS7GestEMx54CoN3HoRHZ05CcXERnnrh1ZZJzIPzxGn3YuyoYfjbPZPx9gefYt43P5h0vXt2x6RxI9Gje5k5b7m5/d7Z2HHQFsC6aZfgHwmQgLUIiPdWvLyuOOafJ0qDdQaqN1FFWqYcMbolFLSYex4poNPpMqcc5m4wZMyGgpIACZAACZAACViHgCUN9BAemWsu3upRV0/DRVdODofQ9Zb7j+Z+haEH72Wihx60Fz6cO88cR25++vVP5OfnYauBm8Jht+Pg/fbAB3O+NEl232UQBmyyoTluuRGve16eG1tvMQDg6M2WeHhOApYh4Pf7jCyuFM4/NxXqjRioSqmsHOZeXV0FpZT+/izQmrb9XykFtxnm3vbopbZzMTbLCVA9EiABEiABEiCBOAjY4kib8qQ33f4gSkqKccZJQ3HeGceGQ1uCVNfU6odHoKy02Fzu3683VqxcbY4jN8tWrEa/Pj3DUZJu2fJV4fO2DgKBAGY+9AxGDT+1rcuMIwESsBAB8fKKOE6nU3Yxh8rFc7Dgw8kxp28roVIK7iYDVTz5baXJxDi/3w+ZNtCe9zykl6zmLgt9hhbqC8VzTwLJIcBSSYAESIAESCC7CNisrE5xUQFOO/4w7LbTdthlh23CIZrMkfNNlYqumrJFjlGPni5UjwyVP+7IA1BcVBiKCu+9Xi86CvKwKg+4HaXj9Y5ZklHHjMRAze37rQ52ux3xMpD08lnt6j0mdYtxXlNT3eF3Q1frSlX+ioq1UEppro42dfL7A+F4oPH7tbo6e/RPFWfW0/H3mzCSTnPZpyTE8BtPOWJrt0zlJL8N8ruaqfJT7sy6P+Vek3su09sN/OsSgY6t0y4V37XMLu0B+3PBXzEVUpCfh2CwHj7t6ZEMq9aUo2ePbnLYLPTu2Q1ryivDcat1ut69uofP2zqQofKTb3vALB734OMvYPZzL+Gu+58wSaVToKOglIJSCh2l43UbGdkSw0Cp3LzflFKQh3cZah7v50mpxHxOQ0Pr5Qc2XhmsmF46LcQb7vHkaQPdHuUzuu5+czgckOD3+6KkTcw9bkVWlCk1bavUuvst05lT/tTcM13hrBTvt67wY97473GlMv+eA/+6RMDWpdxJzvz7/MU4dfhYs9p6LHPQ99h1e7z57idGqjfe+RhDdtveHMvw9+9++MUcy+Jystr7wsVLEayvN69rGzJ4R3Mt2uahu67HJ68/acIFZ5+Is04+EqMvOtMkl2G0HQWllHlg7SgdrztBBl1nIMaRhFxkiaYFIjweT9z3UtmGQ7DhXhPjzteSs8vlgtvtgQwJz4Z28Hpl+pCCvFqtpa6hcxk1EDqWvUcb88Fg0Bjocs7g7PJ9RYbrGLa838hmHZsWLHjfaUdPV5nI97iErpbD/LxPY7kH5F6TEEtaK6cxRhI3nSZgaQP9ihFn4u6br8GlF5wWnn8uc9GjaTv6otPx0uvvm9esLVi4BKefONQkXaSN8cnTHzDHSinceM0ITJh6D4ZdMh477bAVdtxuS3NNFqSTV6yJAX/4ySMwZuJ0E88NCZBAZhCQoWEiqXjQZZ+u4NEdBDLMXTzP6ZIhEfWK/DLMLj+/wBjbsZYpHRSSVjopZM9AAiSQjQSoEwmQAAmQQDII2JJRaKLKjJx3HnkcrXx5Pdqs6ePNa9amTrgMefohWdIOHLAxnntknbE9aJuBeOzem/DErKkYfubxksSEi8892XjJQ97y6ZPGmPjIzTmnHQ1JFxnHYxIgAWsQEINQep5lSF06JQoZqHV1mb2aeVVVxyu3t8U51AaZrn9bujGOBEggRQRYDQmQAAnkKAFLG+jf//grxkyYDvFmS7jq+tvx/Y+/5WhTUW0SIIH2CIjH2u/3w9XJ16tVLu76Ku4h+ZRSkNXM6+pqQ1EZt2/0nteZ16p1psNDRhFIh4m0S8YpT4FJgASyngAVJAESIAGrErBZVTCRa8odD2HD/uvh3luvM6F/vz6YdtfDcomBBEiABJoR8Pt95tzlcpl9ujdutwehBdbSLUtn6q+u7pz3PFSX6C/HYqTLnoEESIAEcogAVSUBEiCBThOwtIEunpdRF5yOjTfsZ8Kl+jg0x7TTGjMjCZBAVhIIfTeke/55CG7IQM3EYd6yEr7IHe/c85Dusg+1g9dbJ6cMJEACJEACCSPAgkiABLKZgKUNdPE+rSmvCPOXxdvCJzwgARIggQgCYqCH5j5HRMd8WNRvMDYYMiHm9B0llGHh4s2vrc28Ye7iPRf9xECXfWeCUgputwdi6Etna2fKYB4SIAESIIE0EGCVJEACaSVgS2vtHVR+6vGH4+TzrkLoFWunXXANzjjxiA5y8TIJkECuERADUIa4uzo5/zxZvNzuPNTXByEe6WTVkehyRVaZOy/GuXQydKV8mYcubSNldqUc5iUBEiABEsgeAtSEBEigfQKWNtCPOXx/PDrzRhy4z24mPDpzEo46bL/2NeJVEiCBnCPg9/uNzi6LzD83wuiNLBSnd8ikYd41NVUiMgoKCs2+KxtXU4dJJunfFX2ZlwRIgARIIO0EKAAJZDwBSxvoQnf9vn1wwlEHm7B+394SxUACJEACzQiEFiILzXtudjHGk0Su4h6q0m63w+l0QjzSoTgr74PBIGRIfiK856KneOBFfxroQoOBBEiABEgg8wlQAxJIPgFLGui7H3IGvv3fL5B9WyH5WFgDCZBAJhHo6vzzZOoqw9xliHcwGEhmNQkpOxFzcYC2iQAAEABJREFUz1sK4nZ7zBD/oDb+W17jOQmQAAmQAAmQQAQBHpKAJmBJA/2T15/EtlsNgOzbClpu/icBEiABQ0DmOPv9PoSGU5vIzmyUglKJ/0r0eNxGGq/Xa/ZW3YgBXVtbg/z8fIjnP1Fyyjx0KcvL1dwFAwMJkAAJkAAJpI0AK84MAol/Gk2g3rffO7tVaZOnP9gqjhEkQAK5S8CfoPnnRX13Q/89r0s4SLvdAVld3urD3Nd5z7s+9zwSouhvs9nhtXgHRaTMPCYBEiABEiABEoibADMkiIClDfRffp/fSs3//fhLqzhGkAAJ5C6BRMw/TzY9jycP0pEgXupk19WZ8kUu8Z7n5SXWex6SxePxQNpJRjuE4rgnARIgARIgARIggdgJ5E5KSxro//efd82r1X79fYHZh16zdvaI67DJRv1zp3WoKQmQQIcErDz/PCS8zMOWY6t6kWtqqkW8hKzcbgpqsQnpL0Z6i0s8JQESIAESIAESIIH0E7CQBJY00Hfcbkucd8ax6NOrh9nLsYRpEy/DlPGXWggfRSEBEkgnAfHI+s38c1eXxUjGKu4hoWSIe+Mw79pQlGX29fX1EAM9Wd5zUVRWcldKoa6uTk4ZSIAESIAESIAESCCnCMSjrCUNdHmd2i47bIMnH5gG2YdC3z694tGNaUmABLKcgD88/7xxITYrq5uXlwfx9otBbCU5Q3PPCwoSO/c8UkelFNxuN7zeOkinSuQ1HpMACZAACZAACZAACawjYFt3GOtR6tJ5fT48/sz/YfS4W5oNdU+dBKyJBEjAygRCQ6adzq570JOtp9vtMVV4LbRYmnQWNHrP82C32418ydqI/mKcBwL+ZFXBckmABEiABEiABEgg4wlYz0CPQDrp1vuxYtUarFxVjmOH7o/C/DxsMWCjiBQ8JAESyGUC4pFuHD7e9a+yon6DscGQCUnDKcO8bTab9iJbZ5j7Ou95UdL0DhXscjWOcvBqL3oojnsSIAESIAESIAESIIHmBLr+VNu8vISe/f7nQowZeTYKCvJwyP57YvrkMVj017Iu1cHMJEAC2UFAvLH+BM0/TxURjydPG+heSwzzDnnPRaZke8+Fr3ROyEiHujqvnDKQAAmQAAmQAAmQAAm0QcDSBnpBQb4RORAIoqa2cXEhvz9o4iy6oVgkQAIpIhAaKu10NnpmU1Rtl6qRYd5SgNcCw9xlaLvIksy551J+ZPB4PAgGAyZExvOYBEiABEiABEiABEigkYClDfTCggKUV1Riz123xzkjx+swAX16dUfu/lFzEiCBEAEZ3i7HLpdLdl0OyVzFPSScDHNXSmkvenqHuUd6z2WKQEi+ZO9loTipwwodFCIHAwmQAAmQAAmQAAlYjYClDfS7po5FaXERzj3jWIy7fDhGnHcyxl52rtUYZo881IQEMoiALBBntzsgQ6czRWylFDyePPO6MRminy65xXsu9afSey66SnvJcHov56ELDgYSIAESIAESIAESaEXA0gZ6pLSDthloXrlmt2WMyJHi8xgAIZBAogiIcSke9ER5zxMlVyzleDwek0zkNwcp3qzznnuQSu95SE0Z5i+6ixyhOO5JgARIgARIgARIgAQaCVjS2t39kDPQXmgUnVsSaEaAJzlEIDT/3NW0MngiVE/2Ku4hGZ1OF5RK3zD32toas0hdqr3nIf3XdVBwsbgQE+5JgARIgARIgARIIETAkgb6J68/CQknH3sITjv+MMyeNQUv/O12XHzOyTjm8P1DsnNPAikkwKqsREA8sCKPK0Hzz6WsVAWlFNxuT1qGuYvXWl6tJvU7HM5UqdysHqlXKemgoIHeDAxPSIAESIAESIAESEATsOlg2f9ffP0DRl1wOgZssiHW79sbZ51yJMorKiwrLwUjgU4TYMa4CGTi/PNIBcWLLMP0/X5/ZHTSj0Pe88LCwqTXFa0CpRTcuoNC5qELg2jpGE8CJEACJEACJEACuUjAZmWlxUtWvnadQV7n9WH1mnXnVpadspGAlQhkkyxi1Ml3Q6K955WL52DBh5NTgsrVNDS/ri51q7kLt3R7z0NwxUAXeVLdQRGqn3sSIAESIAESIAESsCoBSxvoZ518FE4+byyuu+luTLnjIZxy3lU4+vD9rMqScpFArhJIqd7JmH+eUgV0ZUopuFPsRQ55z9M191yrHf7vapqa4OVq7mEmPCABEiABEiABEiABIWCTjVXD0IP3xt/umYQdttsCAzfbEPffMQGHH7iXVcWlXCRAAkkh0LxQ8Z5LTMjIk+NMDDLMXeaEBwKBpIsv3uqqqkq43W44nc6k19dRBfJqPGm/urq6jpLyOgmQAAmQAAmQAAnkFAFLG+jSEn379MIJRx1sQp9ePSSKgQRIIIcJNM4/tyfu/edNLFO1intTdXClcJj7Ou95Uaj6tO/dbg/q64MIBpPfQZF2ZSkACZAACZAACZAACcRIwBZjupQmu+jKyfjtz4WQfVshpcKwMhLIIAJ+fwB2u91ILMfmIIs24gkWD3rIuM0E1aLJ2OhFdpvV3KOlSUS8MJO558LMCt7zkE7izZfjujqu5i4cGEiABEiABEiABEhACFjSQD/vjGPRu2d3yL6tIIIzkAAJrCNQVVWDT7/4GtdNug0nnjUCJw8bhasnTsOrb7yD6pqadQkz/Gjd/HNXEjRpABrqk1Bu9CIbh7kH0YVh7tELb7pSW1urPdX1KCy0jvdcRLPbHXA4HOA8dKHBQAIkQAIkQAIkQAKNBCxpoO+ywzYoLMiH7NsKjaJzSwIkIASqqmvw2n/fwS13zsJvf8zXNqY2NPWF+QsX45HZz+GRx5+DpNFRGf9fvOeihNPpkl1CQ+XiuVjw0ZSEltlRYTLMW9IkazX3Ru95pRlO3znvuUiXvCD6+/0+04GQvFpYMgmQAAmQAAmQAAlkDgFLGujnXXo92guZg5eSkkByCcgiY998+wOeffGlqBW999FcvPHWe6jzeqOmyZQLofnnoWH8mSJ3NDllmLt0NiTLiyyGv9wjVli5vS0GbrfHREu7mgNuSIAESIAESIAESCDHCVjSQB990RloL+R4m1F9EggT8Hp9+PjTL8Ln0Q7mfPYVgsHUDt+OJktn48UbLB50V9Piap0tx2r5ZJi7DHGXkEjZhJes3O5yubQHPfEjDhIhqwxxV0qhLkmruSdCRpZBAiRAAiRAAiRAAqkkYEkDfdutBqC9kEpArIsErEwgEAzg19/nNxNRDDNZHTsy8o8/FyZ81fPI8lNxHDJgxeBMRn2pXsU9pIMY6HKcaC+6GL3iPbfa3HPRNRSUUhD9M9SDHlKDexIgARIgARIgARJIGAFLGugh7bw+Hx5/5v8wetwtzVZ0D13nngRynYDdZkeex90MgxiywWAQ9REec7fLCYfd0h/3Zjq0dRIy4lxZ5kG36TZ0OJwJ9yJXV1fC6XSZ0BZPq8TJPHTpVJLREVaRyRpyUAoSIAESIAESIIFcJGDpJ/ZJt96PFavWYOWqchw7dH8U5udhiwEb5WI7UWcSaJOALAe38Yb9w9fEY9qABij9Twx1fWiubbzRBpDh8OYkQzdiwNnt9owfCdAWfvEiywr10n5tXY83TuaeSyeNlb3nIZ1cTR0uiR5BECqf+ygEGE0CJEACJEACJGBJAjZLStUk1O9/LsSYkWejoCAPh+y/J6ZPHoNFfy1rutp6t1Ib8yPHTsW5oyZi3OQZqI0yr/Hr737CsJETcObF4/DwEy+GC/rXq2/j1POvwu6HnIE15RXh+Hnf/IBrJt2FA48djvMvuwHvfdzxnN9wZh6QQBIJFOhOq+OPPixcgxhlYpw7HA5tmzdAhsDLxeOOPhR5eXlymJGh0cPqRciYS4YSlYvnYMGHk5NRdIdlihdZEolhLfuuBGElc89l1XaXy9WVolKSVyll2jURuqdEYFYSEwEmIgESIAESIAES6BwBW+eypSZXQUG+qSgQCKKmts4c+/1Bs29rM+OBpzB450F4dOYkFBcX4akXXm2VTB5eJ067F2NHDcPf7pmMtz/4FGKAS8LePbtj0riR6NG9TE7DIT/PozsKhuH1Fx/A2acchSm3Pxi+xgMSSDeBstISXHbxOdAWuXldlc2uP9ba6HHY7RCDfdhpJ2CTjTaEXeLTLWwn6w8EAiZnJhicRtA4N9KhYrc7EjLMXTzR0u6Z4D0PYZIOChk9EGrnUDz3JBCFAKNJgARIgARIIGsJ6Cd56+pWWFCA8opK7Lnr9jhn5HgdJqBPr+6I9vfR3K8w9OC9zOWhB+2FD+fOM8eRm59+/RP52uu41cBNIQbMwfvtgQ/mfGmS7L7LIAzYZENzHLkZOGBj9OhWCrvNhiGDd4Df74/qnY/Mx2MSSAUBuZ8H77ID7rh5PA7cd09spu/h/v36YP999sT4sSMxWH9+iosKUiFK0uoIzT+XOdVJqyTNBcswd38X3wkuHZDiPReD39U0dDzNasVUvdvtNumkc8EccEMCaSXAykmABEiABEggfQQsbaDfNXUsSrUn/NwzjsW4y4djxHknY+xl57ZJq7qmFtppiLLSYnO9f7/eWLFytTmO3CxbsRr9+vQMR0m6ZctXhc87Ovjny28ZAyjP0/j+3o7S8zoJpIKAy+VCSVE+zjz1OFx/zWjcMO5ynHf2Kdhp++1QH/SjuroqFWIkrY7Q/HO73Z60Oor6DcYGQyYkrfyOChYDXdJ0xUj1er1m1ERhYeP3oJSXCUHaVToVvN7GkVKZIDNlJIFOE2BGEiABEiABEmiHgKUN9On3PI7f5y8y4g/aZiB22WEb48U2EW1sbNrDHYpWKrpqyqZCyfQ+ejp9sdn/b77/GU/9/VVMvOrCcLy8yqijIEM3xcDoKB2v15khvpnEQQwKK4Samip4tXHmctpht9vgdjngsCvI69Zc2pMqBnpNTbVOU5dxQeYmiwfdbndYTnaRLVFBhncrpVBTU6M/B7Vxh9raGlRWroXNZkdDQ33c+Turh1cb1X6/v8v1SftKOXKfdlaWVOcT3RlS/50inxVyb809dP9zH//3Z3vM/H6f/u3xdvk7rr06EnGNn4nWn4lMZCLPO433XHz6WO3ZOWwo8aBTBGydypWiTH379MTY6+8wi7k9+fwrZrh7tKplsaxgsB4+/aAoaVatKUfPHt3ksFno3bMb1pRXhuNW63S92xk2H0oo3vh7Hn4G99x6Lfr36xOKhtPp6DAopeBw2DtMF0tZTNMx71QyEqPCCsHvb5yj7fHkw669zGKk2bVBK6GgoBBKKYgBFxkv1zIhAAry53K5YG/SySp7p9OpP9eJC+JFl9XcpQ3jLVsWIZDOwMLCwoTK1JEcDocTnZG3ZbkeT+Mihg0NDSmVv6Uc8ZzbLXY/5oo8Nt0Z73A4YCd/2CMYxHPvdiFtxnw+E6WjMJb7LVHlJasckZMhO74XbDY77BGf7ViOnU5rPR/LcxtD5wnYOp81+TlPO+Fw/P2xO3DZhafjl0mX888AABAASURBVN/n45jTL4Oszh6t5j123R5vvvuJufzGOx9jyG7bm2MZ/v7dD7+Y44GbbQRZ7X3h4qUI1tfjrffmYsjgHc21aBtJf92UmWaY/Xq91w2Pl/SxfGiUUsarFUtapsmsL1f50U53sGuDXHqJxcBxaoNRziWE5BLDtri4BOJ18usOrFB8puyDwVDnQ57u6HIkLdQu+xx/zZkWV/mJ/rzm5RVA/oLBIOxx/jhXV9fArvPk5eXDrvepC3b9/WaDvYt1ejweKKXMGh9dLStV+TPlM5Rtctq0gS5tnG16dVUfYZL5wXrPAI33mx32Ln7HJTt/V+8f5k/e80U8bOX5TUI8eSRtsu+veMuXZxmGzhOwdT5r6nLuvP3WOP/M43DQfrvjnQ8/i1rx6ItOx0uvv29es7Zg4RKcfuJQk3aRNsYnT3/AHCulcOM1IzBh6j0Ydsl47LTDVthxuy3NtVmPPmdesSYG+eEnj8CYidNN/Av/fgPf/u8XnDp8rLkur2FbunylucYNCaSbgAyHEq+jGGbRZPFo76QY6lVVFWaOcrR0VoyX6SHyYyXBivIlUib5kZWHQRmqFk+5Xq9Xt2sARUVF8WSzXFq5T73eOsj9bDnhKBAJkEDmE6AGJEACJJABBGxWllE8fq+//RFGXDUFF1w+CR63G0/MmhpVZHk92qzp481r1qZOuAx52iMjiWUV9ucemS6HJsh89sfuvcmUNfzM402cbC4+92R88vqT4TB90hiJRst4SdOnVw9zjRsSSDcBmbMsRp14z9uTpbi41Bg+Mk+5vXRWuiaGmt/vg3QuWEmuZMmilILb7UG8Rqp0vEjvtsvlTpZoKSk3tJq7tHlKKmQlJEACJJBAAiyKBEiABBJBwJaIQpJVxtFnXIa33p+L4488CC89MxNXXnIWNttkg2RVx3JJIOMIyCJw4kEX77lSjXO1oykhHuiiomJt/Hl1yIzVsqWTToz0VBieRf0Gp3UV91C7eZo6FqVdQ3Ht7SWdcBLvuVLt3wPtlWOFa6F2jncEgRVkj1UGfyCAJUuX4+dff8czL/wbv/4+H0uXr0AgEIy1CKYjARLITQLUmgRIIEcIWNpAF2/5rTdcgQP23hUOuz1HmoRqkkDsBGpra03ivLzGBbbMSTsbMeTF01pRsRayoFg7SS1xSYxPEcTpdMkuJ4LoqpRCrEZqZWUF7HYHXBnuPZfGVUpBvOgygkDOsy2Ur63Aex/MwcgxE3HtDbfi7/9+DVdPnIZLrpiAT7/4CuURC5hmm+7UhwRIwOoEKB8JkIBVCNisIkikHE///VUzFLdbWUlkdPj4rfc/1Z71OeFzHpBArhKQ4e2uptXNY2GglEJJSakxzquqKmPJktY0uTT/PARaKaWN1NiGuUsHRkB7ZGXldqUy23se0t/t9pj7U/QKxWXD3ufz4+O5X2DWI0+2qc7tMx/CT7/8CnkbSZsJGEkCJEACmUyAspMACcRMwBZzyhQmXLZiJU46dwwefuJFfPzpV/hs3ncmvPz6exh59TQ88NhzaLmaegrFY1UkYAkCfr9fGzJBiFc8HoFkrnp+foF57ZrP54sna0rTytB2fwrnn1cunoMFH05OqY7RKvN48kwnpegfLY3ESyeLTF0Qo1bOsyG4mkYCZJsXfdHiJXhk9nPtNtGtMx6A/P61m4gXSYAESIAEWhFgBAlkEwFLGuiXX3wWZky72jygPvuP/+CRJ/9pwmfzvscRB++Fpx+6FVsN3DSb2oG6kEDcBGpra8xrqTxNc5bjKaCwsAg2mx0y1D2efKlMGwwGzHdAyGBLZd3prkuGeSvV/jB36Vzx604aaUulssN7LtztdjscDmfMQ/wlTyaE8oqKVmIGg63nncvr8lolZAQJkAAJkEA6CbBuEkgpAUsa6EKgb59eGH7WCbj75mtw/+0TTJDXox16wBDORxdADDlPoK6uFh7taQUU4v1TSoa6lyCojeDq6qp4s6ckvRigUlHKDHTNRCnrfCWKkd7ePPTq6kqIMdt4Dwip7Ake3ekUCMgIkfqsUEqG638x79tmugS1cS7xEiIvfDHvm8hTHpMACZAACWQ9ASpIAs0JWOdptLlcPCMBEmiHgBjnMgQ83uHtkUWK4evRBr4Mkw5qQz3ymhWOZX61GKA2W2q+por67ob+e15nBdWNDG63DHOvh9/fehqCX3vOpQNDvOcmcZZtpHNCVMqWYe4OhwM7bLe1qGSCfHbFMJeutaA21IMRK7jvuP22Jg03JEACJEACJJAQAiwk4wik5sk347BQYBKwNgEZ3m6z2SHzybsiqbx2TSmFtWvLu1JMwvOKASMGqKxonvDCM6TAkJHalhddOlVsuuPC7fZkiDbxielwOCH6ZYuBLtoXFxfJzoSAP2D2TpfL6BnQHWT1wcbRAh6321zjhgRIgARIgAQygQBlTDwBGuiJZ8oSE0SgqqoGtXXeBJWWPcUE9cO8GK/5+fldVkqMIDHSxSMrRn+XC0xQAaKjGOni5U9QkRlXjFIKYqTLaIlI4aWtZHSBeM+VUpGXsurYrTsfvF6vWYcgGxTr1bM7Tjj6cNRrj3l9Qz0cdgeUUnA2dUb4A36cc/oJKCkpzAZ1qQMJkAAJkAAJJIJATpZhy0mtqbRlCQT1w+vaikp8NOdzPPP3f+OFf76Cz774GnXaUBeDzbKCp1Cw2tpaU1teXp7Zd3Ujw+TFE19ZWQHh39XyEpFfOiCkHJf2MMo+FaHSQqu4h/R1u/PMgmliqFZWVRljtba2xnhdZXpCKF027t3aQBe9QveCHGdyKC0pxu677YgjDzsQNm2Y2+32RnV0H4sY6Wdr43zjjdYHPeiNWLglARIgARIggeQTsGYNljTQp9/zOJ7++6utiD3x/Mu475FnW8UzIjsIrFi5Gr/9sQDnjrgKd9zzMP7z5nv49ytv4OY7Z+H8kVdj/sLFqKyqzg5lO6mFdFKIgeZyubWR1vSA38myIrMVF5ca40+M9Mj4dB2Lh1i8+2EjJl2CpLleYTDns3nm9Vx3zHwYL/7fa/j51z+Qn19kvK9pFi+p1buaOme83rqk1pPKwkuK8nDoQXtj2o3X4NorR+Cwg/bFuDGXYMr1V5njPr26o7x8NbKlUyKVbFkXCZAACZAACViOQCcFsqSB/vGnX+GkYw5updKpxx2KDz75olU8I7KDgN1mw7U33NKmMrV1dbhy3E0oyE+M17jNSjIgUoY319fXawOt68PbI9V1OByQIdNiDNVp1pHXUn0snRBioLh0J0Sq67ZKfdLOi/9aikvH3ohZjzyN1954F998/yNmP/0ibpx2Nz74+FMsX77KKuImRQ6lFNzai95yiH9SKktBoaKH3NfFRYXYesvNsfOO2+H8s0/BTttviy023xSFBQUoK+tuVuYXI13ugRSIxSpIgARIgARIgAQsRsAWozwpTWa32yAGA1r8SZzXF2gRy9NsIFBZWY3b73moQ1XufegJeL25Oy9dvOdKKSTDeM3PLzDGQWXlWkgnQIeNkaQEwWDAePOToWN7Ihf1G4wNhkxoL0nKrtXXN2DSLXdj5arVsNtsaND/ZBGxet0543DY8dDjz+L3+QsQbFpYLGWCpbgimYMvHTbyyrUUV53Q6qTdKirWwm63o6Ag+hxzm25rMdKVUlizZhVkpfeECsLCSIAESIAESIAELE/AZg0Jm0vhdrkgHtPmsUBVdQ3yPO6W0TzPAgJutxNLl67oUJMlS5bph9Zgh+myMYEYKuKFkznjSqmEq6iUQklJmTHOq6srE15+rAX6fI2vFXPp74FY82RbOvGQi3EuetlsdtlBFhFTULDZG8/ve2g2apvWI0CW/nk8javUp3tUR1fxSqeXfH7l86WUarc4u27fbt16mDRipAeDufl9ZwBwQwIkQAIkQAI5SMCSBvoxQ/fDtZPuhsxJDrXJshWrMH7KTBwzdP9QVOx7prQ8gZWr1qC8oqKZnDLE099krIUuLPprCaprakOnObUX41wUFgNd9skITqcTUn5NTQ2EfzLq6KhMMdBt2pMohkpHabPxulff87//sWCdagpmUTGJsGvvuewlmM9BB8aepMvkoJQNck9m8qgZr7cO0sEgI1REF8TwJ/e+GOli1IuRLh74GLIxCQmQAAmQAAmQQBYQsKSBfsJRB2OrgRvjhGFX4rQLrsZJ516Jk8+9SsdtghOOOshy2ClQ1wmUlZagb59e6wpqgPHk1jc0QIb2hi4M2HQTFOToPPTa2hrINA8JIR7J2BcVFUMM5LVry5NRfIdl+nzepAzh76hiq6ziXlVVjSXLljcT1+5wQl7LJYZb5IXffp8feZqVxzIPXYa4Z6KRKgZ2aGh7UVFRXO0jn3MZ7i4edDHSpay4CmBiEiABEiABEiCBjCRgs6rUF5x9Il5+9h6cevxhOOe0Y82xxCmlrCpysuTKiXIdTgc2H7BpWNf6hnpzLK0dCK5bd2DLgZtqD6/HXMulTVAzEI+2eLeTrbdSCsXFJZA6q6urkl1ds/Jlzq0YIq4cXiCuW1kpthw4oBkXm03BHuE9R9PftlsPbDrK3p0Y6KKdeKJln0lBhrZLx4K8JQGQbzPE9Sce97KybpDPBY30uNAxMQmQAAmQAAlkLAHLGuhCtKiwAEcesi8OO3AICgvyJYoh4QSsUaDT4cCI88+ArD8gEjXUNxroDu05FINNvOgbb9gfRxx2gPHuSppcCuI9F309ntSsYu92e7QX24WqqkpjHEjdqQjiPZd6XDk8/1wphW226tjw3njDDVBbmz2vIJN2bys49HeDjOiQYeJtXbdqnNfr1e1TqzsU881nqbNyunRnVUlJqZlysmbNarOAYmfLYj4SIAESIAESIAHrE7CkgX7oiRehvWB9rJQwTCCOA6UUHpx5i3nlUH1Dg5l3a7PboJTCrjtvh2uvHAGP2x1HidmRVDooampq4dZGs81mS5lS4vVTSqGiInVD3cVAFx3t9saF0FKmrK7ISqu4b7bJBjjrlOO0VNH/Tx5/BQpypOPS4/FA7g35LEQnYp0r4jWXz43cy/L6wq5K5tEdczKqxe/3obx8DY30rgJlfhIgARIgARKwMIHUPe3HAeHeW69DeyGOopg0gwiYh9mCPIy97EI88eAdmHbj1bjz5ol4YfYsDDvteBTktx7ankHqdVpUWTStoaHeeOI6XUgnMoqRLMaF3+/XnsCaTpQQX5YG3SkjuorHML6c2Zfa5XJhyy0G4LyzTmnVKdV//b549L7bEMyh1b2lc0paWYx02Vs9yFsQxEgXo1q+1xIhr0xvkfUhhIGsDyGfl0SUyzJIgARIgARIgASsRcCSBvqmG/dHe8FaCClNogmIV9DrrcWATTfCBtoY8XjccDodZrh1ih9KE61ap8qT4e1K2bo0TLZTFetMYhTIEOPKyoqkG4RicEr7inGqq875/5tvtjH22XNX3HfHZPztvumYdN0VeO6xezDuyktQUlyEwsKCnGGIAwQLAAAQAElEQVTkdLqMrl6v9Yf0+7WXu6amBh7t9Q91LBjhE7DJzy9AQUEhhIN8JhNQJIsgARIgARIgARKwGAFLGugWY0RxUkxAHnDFULPbHeGaZQVkMeAybR5qWIE2DzqOFC+cPIzn5+dBKdVxhgSnUEqhpKTUDKmtqqpIcOnNixPPoMS4XOmZxmCVVdyFQShIZ1VJSTGKiwux9ZabQzpLevXsHrqcM3ulFNxuj3ldmXw3WFVxkU2820opFBWVJEVMGdUiHWfScVdVVZmUOlgoCZAACZAACZBA+gjY0lc1ayaBtgn4/X5jjMoQ61AKeTgXg71KG4nyEByKz/Z96N3nHk8nFklMEByHw2m8dtI54vV6kaw/Gd4uw4Ej2z1ZdbHczCMgHmn57MuK5laVXt56IB2JxcUlkHs5WXIWFRXDrTsspL6amupkVcNySYAESIAESIAE0kCABnoaoLPK9gn4/T605UUVL7p4lMVQbL+E7LkqXjKn02k8p+nUSobV2mx2s2CctIHIkuggHvS22j3R9bC8zCQQuje8Fh3m7tcdi2Iwi5weT15SISvVOLJF6pKh7qGOvKRWysJJgARIgARIgARSQsCSBvpHn36F9kJKyLCStBAQ4088ZGKUthRAPEa55EUXDhJkOGtLFqk+V0oMghJI+4gRkuj6RU/xjrpcrlDRKd9baRX3lCufARXabDbI94IVDXS5d0ND28V7jhT8KaVQWlqmmbggdVuRSwowsAoSIAESIAESyDoCljTQn//n62gvZF0rUKEwgUDAb46jGWrrvOi1Jl02b8R7Lvp5PB7ZpT24XG54tGdQhtSKtzCRAon3XMqTOmSf/MAaMpGAdNJJZ44MI7eS/PKZCAYDkKHn9hS+IlAphbKybpBpKPL6tdDnyEpsKAsJkAAJkAAJkEB8BCxpoM+YdjXaC/GpyNSZRCBk+MkDZ1tyywO6w+HI+hXdxSMnBroYxEpZ52MqBohSynjsRMa22qgzcVk3/7wzEJinQwLy+ZdEVvIWS4dBVVWl8WSnY7SLUo1GunQMrFmzGn6/TxAxkAAJkAAJkAAJZCgB6zz5RwHo9wfw3Q+/4LN534VDlKSMzgICYqiJAa5U9BXLCwuLzVDrbJ53KZ4wMYDT8cDf3m0kw4xlCK94C8Vr2F7aeK6Jvun2nltxFfdoDHM1Xr4bbDY7vElcrDAetvIZleHlkqekJDmrtkvZHQWbzaY96d0hezHSQyOROsrH6yRAAiRAAiRAAtYjYGkD/cM583DcWaMxetytuG3m33DpNTfjnoeesR5FSpQwAuL9Cb3zOFqhbrcb8qAuXit5QI6WLpPj5T3K8rAtc26tpod49aWNhL8Y6l2VTzyQ0o6uNM4/76oOWZbf0up4PB5Ih47cM+kWVEa5iDEsI0tkfYx0ymO3242RDiisXr0a8rkC/0iABEiABEiABDKOgKUN9HsfeRYPzbgBm22yAZ5/9Hb87Z7J+njDjINMgWMjIMaePHTHYqhlsxe9vj5oDBDxnisVfSRBbFSTkyrkLVy7dm2XKxBjSwpxudyyY8h6Al1TcN0wd2/XCupibvm+khXUHQ4n5LPaxeISkt3hcKBbt266rAasWbMKwWBQH/M/CZAACZAACZBAJhGwtIHucNjRp1cPyDB3gbrFgI1RU1sjhwxZSMDvb1wgTryzHamXzV702trGBfDy8vI6wpC26+ItLCws0p9NH0LydlYYmdYgowXEA9jZMhKRj6u4J4Ji8suQUSVKKXijvW4t+SKYGkKdUyUlpVBKmTgrbBy6w0AWjpM3LoiRLnsryEUZSIAESIAESIAEYiNgaQM9P69x9erSkkL8+9W3IUPe15RXxqYZU2UcATHUlFKI1VCTYaXy8Jltc9FrdSeUy+XSHByw8l9+foGRsbJyrVkToLOyigdd9O1sfubLLQJKKUgHnRjoMuIm1dpLffIZ9ft9kE4qh/ZaS5yVgnRyipEuHnQa6VZqGcpCAiRAAiRAAh0TsHWcJH0pTjz6YJRXVGLEeafgzffm4skXXsaFZ5+QPoFYc1IJyANvPIaay5V9c9H9fr8ZlmqVIbPtNbhSCiXaeyhGkgz1bS9ttGsyT1byS1tGS8N4EmhJwO32QO4bmf/d8lqyz8XolfvdbndAOqkSXF/CipPPVGlpmZmLXl6+2vBKWOEsiARIgARIgARIIGkELG2gH7jPYJQWF2HTjfpj5i3X4v7bJ2CH7bZMGgwWnD4CjQ/bAfOqonikyDYvunjmAAW3NkCQAX8y3Dg/Px8yisHbiZW1xXsuarpcLtmlNXAV97Tij6tyl+6ckwx1dXWyS2moqFhrjF3pnFJKpbTueCuT7xGRUzr+Go30hniLYHoSIAESIAESIIEUE7CluL64qhPv2pzPv8ajT/4TDz7+QjjEVQgTZwQBeYAUQWVopuxjDfKg7nA4ISuKi5Efaz4rphP5a2trIXPPlbL2g38kv4KCIvN6p4qKcmO4RF7r6HjdtAZrD+fvSA9eTy0BWbNAvis60ynUFUmlI0o6lQoKCnRnorMrRaUsr8eTB+nIlM/a2rXxf0bjEpSJSYAESIAESIAEukzA0gb6dTfdjRdfehNev6/LirIAaxPwN7WxeGTjlbSoqMjMgZaH53jzWim91yx61aAN9HwridWhLGIsFRWVmDaQjpIOM0QkEGNH5hNHRKXvUHeKKGXpr8T0sbFgzR6PB8FgwIRUiCfrXVRo77mskSGdUqmoM1F15OcXmPny8h0jOiSq3FSXw/pIgARIgARIIBcIWPpptM7rx203XomLzzkZF5x9Yjh0pmGe/9frOOOia3HWxdfh/U++bLOIlavWYOTYqTh31ESMmzwDtU3DJ9eUV2DMhOnY7+jzcOvdf2szLyO7RkAMdIfDAaXi9xxnixe9trYGNps9YzxzkS0uxpIMp62pqYbf74+8FPVYRsjIqAFpv6iJUnihqO9u6L/ndSmskVV1hYDcb5Lf24mpFZIv3iCLIcr9KkPGlVLxZk97+oKCQtP5Jx2ZNNLbbA5GkgAJkAAJkIAlCFjaQHe5HPphP9BlUPMXLsHsZ1/CA3dMxK03XI4ptz+IOm9rr/yMB57C4J0H4dGZk1BcXISnXng1XPfhB++N4WceHz7nQWIJyPBLGbLa2VKLioqNB7e2trazRaQ1XzAYhDDIz88s73kkNGkDpRRiHUYr+kp+lwXmn4scDJlFwG63mw4trxl5klzZpQ6Z7y6fz658TyVXyo5LLy4ugceTh1rdGVhdXdVxBqZIIAEWRQIkQAIkQAKxEbDFliw9qXy+AE46bwzunDU7PP9c5qLHK82Hc77EPnvujIL8PPTp3QNbDNgYn335HVr+fTT3Kww9eC8TPfSgvfDh3HnmuKy0GPvvtav2PrjNOTeJJSDGqXimOjO8PSSJGHkOhxPV1ZVxz4MOlZHOvTwwS/3y8Cz7TAxiMImRHgwGIJ70jnSQ4e1KKdjtDvCPBDpDwOPxmI4tGX7emfyx5JGyxeNss9lQUFAUSxZLpxEjXUYfyHSUWD6nllaGwq0jwCMSIAESIIGsIWBpA33rLTbBYQfsCTGsu0J8xarV6NunZ7iI9fv2xvKVq8LnclBdUwttK0CMcTnv3683VqxcLYcMSSbgb5p/LkZ2V6oS41AepmszzIsunRO12qPlcrkhRm5XGKQ7r0d756SjRR7+xVBvTx4x0C0z/1wLylXcNYQM++/RBrqILPeS7JMR5F6W75Xi4lLtsbf0T2ZM6iulUFJSCpfLBXldnAx5jykjE+U0ASpPAiRAAiSQOgKWftqInHceedwZPEp7P0L5lGp7/qB4SNaliQ2NPNx0FOrrZfiyFx2ly93rNQa73+/vEiPhLAZuVVWFGcKZKTxlqKkYAHbtSU6EzGKsSEhEWfGWIUOBxTsnDbpmzeqo7Sk6S8cEYIuaJt66u5pehtzLPdTVcnItv7R5Vz+7nWUm6xjIvVZTU5OU+6iqqtJ8l8iw9oaG+qTU0Vndu5JP2syjO9Pk+1KmpIQM9a6Umcq8gUDXfitSKSvrqo3lc2PpNPLb4PXyGY73cmruZa+3Dul6hktkG8tvM0PnCcRmhXa+/C7llMXZnnrhFchq7hKefvE1SFy8hfbs3g3l5WvD2VavKUevHt3D53IgXvpgsB4+bSTK+SqdpmePbnLYbpAHt46CUjbI8OuO0uXq9WCwAYnSvbCw2AxxDwaDCSszUbJFK0eMDKUU8vPzEyKzGPoSotWX7Hh58M/PL4C0gXQ8tFVfQwPMn0d7QNu6no44h1mk0JaQNkiH/Omq0+FwQgy9dNTvcrnhdnsgBpvIkUgZpDwZ2aKUMq8pS2TZVihL2JWUlJm2axzqrsL3vuju9wfD51aQN1IGm81uWdki5eSxyyLt1DU5HPq3QQLbs2scyS82fg79myoh03mBf10iYGkD/fqb78O7H32OHQdtacLb78/FjbfeH7fCQwbviA/mfAmvz4fVa9bifz/9jt123taUM++bH8IL0e2x6/Z4891PTPwb73yMIbttb47b29jtdvOA095eKQWb9uC3lyZXrwkXebh2uVwdcoyFkRh8UpY8WEvZseRJZxqbTUF6S/Py8nQnjiMhDNKpT6juwsIifc/bIR5IpVQrvaTNlVKQIe6hPOnel/TfAxvuNbGVrOmWKxPqT+dnzaM9wQ26x0c6gxLJSr5DpMySklJtZDiz8r6Q6SjdunU3uskq9V6vD+9+MAcP/u1ZTLjpDtz/yFN4672PEdAdnolk29Wy0nm/dVV25reb+y2TOHR4v8XwHJhJ+lLW9N+j2XDPgX9dImDrUu4kZ166fAXuv2MCjj/yIBPuv308Fv21NO5aN+y/Ho4degDOu/R6jB53Ky4fcRZcTqcpZ+wNd2JtRaU5Hn3R6Xjp9ffNa9YWLFyC008cauLl4WT3Q84wr1j75ytvQY5/+uUPc42brhEQQ01KEKNa9okIYhzKg7U8YCeivGSWIStDS/l5eZm7ervI3zIoJfNcS8xoBhk+2/K6DN9yae9ny3iek0C8BFy6c0/ySEeX7BMR/H6fWejQrb3zEhJRplXLsNnsKCvrDn+gAdfecDPufXC2Nso/xMLFf+Ht9z/GA48+hasn3Mw1WazagJQr6wlQQRIggdwjYLOyyjZba/Fs2uPYGZlPOuYQPHn/NMyeNQX77LFTuIj//uNB9OheZs5lP2v6ePOatakTLkOex2PiHbp39JPXn0RkGDhgY3ONm64R8Pn8pgAZzmMOErCRYUHy0L5unnMCCk1SEdKJYNf3VyL1T5KocRfr0ga4jAyQOU1ikIcKkKHvorNcD8VxTwKdJSC/Ey5tpIc6uzpbTihfg/bGy7xspZQZ2h6Kz+Z9TW0dnnjuX/j9jwXw+/2mYy1SXzHWZz00G5VV1ZHRPCYBEsh8AtSABEjAggRaW8AWEnL7bbfEiDE3hV+xdvGYKdhlh8ah6RYSk6J0gYBfe6rsdgfksmfRSQAAEABJREFUIbsLxbTKmgledJl77tcPwzJfu5UCWRIhawJI21ZV12DJsuX44ONP8e9XXtfeuLXaYxe0lJaVi+dgwYeTLSUThYmNgHi5ZYG/YDAQW4Z2UlVXV5n1E+R1ZNKR1E7SrLkkbzH59POvIJ2bQIMx0rWV3ky/r7//EatWlzeL4wkJkAAJtE+AV0mABDpDwNIG+thRw3DkIftg/sIlJhxz+H648pKzOqMn81iUgF8b6C6XM+HSOZ0uuLQHVx62E154ggoUz7IUlW3D20WnUFBKIVCvcNOtM3HxZeNw132P4vGnXsRV46fiQn2+cPESVFRVhZJzTwKdIiAGumT0er2y63SQTjP5zpDvDpnb3umCMizjokV/GYmVrXGhOBlFYBZMbTDR4c3CpnThCB6QAAmQQDoJsG4SyFICljbQxfN2hDbQp4y/FBKGHrw3JC5L2yLn1JJ54hLEmE6G8iEveuMKxcmooWtlyvB2MSyUUl0ryMK5a+u8uGHqXfj19/lmoamG+gbU66C0IeD3+zH66hsR8Hfd62lhBBQtBQTE0+1wONDVYe5r166BUo3rJ6RAbMtUMX/h4rAs8tmUxePESA+0GJEgBrosthpOzAMSIAESyGICVI0E0kXAkgb6RVdOxm9/LoTs2wrpgsV6E0vA5/OZApNloMtDpnjCxCNmKrLQRuZk19fXI5u95+KNfP4fL2PlqtVwauNJ8ItR3oAGRHa03Xz7fVizJv1DZ4v6DcYGQyaImAwZSEA6u/x+H8Sw7Iz48j0h92xRUbG+P+2dKSJj8+y606BmssvnU9ZeCQaDkE610MVddDq3yxU65Z4ESIAESKDzBJiTBKISsKSBft4Zx6J3z+6QfVshqja8kFEE5GFaBBbvl+yTEazqRa+pqdGeOhtcWfyw6/P5sXTZisZm1V5J8XCKcS4RNrXuq+evJctQWFgg0Qwk0GkC8so+yez11skuriCGubwS0OFwZnWnWTQopSXFaGl4y9ogCgqhN23IcS/9uxytDMaTAAmQAAlYiQBlyWQC656SLaTFLjtsg8KCfCxZthJyHBnmL2ycK2chcSlKJwmIgS4GqlKqkyV0nE286PLgLt6xjlOnJoV4+MSIyM/Ph1LJ0z012kSvRYa3//HngnAC6YixaX0lKNs6vWu9Xizg3NYwJx50joCMxFFKQT5b8ZZQUdE4gqO0tPGNHvHmz/T0RUWFuH3q+OZq6I+ow+lAfUMD6oP1uH3aeJQUFzVPwzMSIAESIIHcJECtk0rAkgZ6SONX//tB6DC8/9cr74SPeZC5BMRI9fv9cDqTP1yyoKAIMpzcKnPRZe65tFy2L0KVn+fBpptsKKqGg9PlgtPVvM0L8vOwwfr9wmnSdcBV3NNFPnH1ut0eMw9dvl9iLVW+F+S7SEbbSCdSrPmyLV23bmV45N5bsX6/vlD6n+gnQ937r78eZtw2Mfw6UolnIAESIAESIIFkEsj1si1poH827zvzarVly1eZ/YOPv2D2d93/RK63V9boL0NKRZlUGOghL7oMYY3nwV3kS0YQA11kcjTNy05GHVYo0+NxY73evToUpd96fVBVXd1hOiYggY4IeDwek8Tv95l9R5tgMIDKygrIZzE/v6Cj5Fl93e1yQoa6T77uCrzwxH2YpPcvPnk/pl1/NfI9LgQD/qzWn8qRAAmQAAnkDAHLK2pJAz0atU037o/7pl8X7TLjM4hA6AFaDNVUiC1edDHOxThORX3R6vD7/ZDOiWxeHC6ku1IKxx55CNbv2ycU1eZ+3FUjUVxU2OY1RpJAPARcLrdJ7vV6zb6jzdq1a02SkpJSKKXMca5viosLDYutt9zcoCgtLYHHkwf57pTvLxPJDQmQAAmQAAmQQBQCXY+2pIEuc84vOPtE3DzxMsg+FI48ZF8+yHe9zS1Rgl97uGQ4qQyhTIVA0hEgc9HT7UWvq6s16nqaPH3mJIs3svjbDddejh2227qVlsWFhbj/zinwuN2Qe6FVghRHFHEV9xQTT3x1SimIkR76nLVXQ6PB6UNBQaH2oDvbS5rz14SRfFdXVDR2aOQ8EAIgARIgARIggSQSsLVXdrqv/d9/3kP52oqwGKvWlOP2e2eHz3mQuQR8Pl9K5p9HEiooKIJ40WUF9cj4VB1L3WIUeLQ3SilLf/QSiqSsrARjLrsAD828GeOuvAQXnHMa7r19Eu6efgN69uyu7wNHQutjYblNQDriZM0JGakSjUQwGDRD26VjqEAb6NHSMb6RgFIKxcUlkBXd5TusMZZbEiABEiABEiCBZBBIp5XQoT5fffsjZE5cKGH3slJ8Pu/b0Cn3GUpAHp4lOJ2ulGrQ6EX3oLq60hjqKa1cV+bzeU29uTC8Xavb7L94ybvpz+9OO2yLQw7YG31690KR9qA3S8QTEkgAAVkoTorxtvO6NfEES4cZh7YLqdiCcHW53KZjQ76/Y8vFVCRAAiRAAiRAAvESsLSBXlNbh9q6urBOVdU1+jy2xX+AcDYeWIyADG8XkVyu1A8rLdRGoTyYy8rNIkMqg3ieZJiodBSksl7WFRsBruIeGyerpxKvuCz6Fs1Ar9O/KdJZJovCOZ2p7SS0OruO5BMvunx/ylShjtLyOgmQAAmQAAmQQOcIWNpA323n7TBu8kzIqu4Sxk+5B0MG79g5TROdi+V1moAMb5fMdnvqhzY7HE643eJFrzLebJEjFaG+Pgiv1wvxnivFxahSwZx15C4B+Yz7/X7zesVICuL5ragoh81mR2FhUeQlHsdAwG63mzn70tkofGPIwiQkQAIkQAIkQAJxErC0gT521DDst9cumHH/UyYcuM9uuGLEmXGqmJnJs1lqebATz5VS6TFUC9PgRa+tbVwcLi8vL5ublrqRgCUIiIEuxmTLeejySjXxAJeUlECp9Hz/WAJQF4SQOfs2mw0VFWtT2snZBZGZlQRIgARIgAQyioClDXR5CDjq0H3x5APTTDjikH2058PSImdK46dNTnk49vt9cLlcaZMh0osuHrVUCFJbW2N0TseogVTolw11cBX3bGjFRh2C9fVYuXot5n39HR5/6u/430+/YOGiv+D3B8woFpfL3ZiQ27gJKKVQXFxqFoyLZbX8uCtgBhIgARIgARLIcQKWtnYX/bUUl15zM04850rTTD/98gfuf+x5c8yNlQlEly0YDJiL6Z6HHfKii+FsBErixu/3IxgMGsMgidWwaBIgAU1g2fKVeOKZf+Lqibdg8q0z8X+vvokJk27HiMvHY963/0N1rVen4v+uEJCV8qWTo7KyotU0gq6Uy7wkQAIkQAIkQAKApQ30G299AIcfNASyers01uabbYQPP5knhwwZSiA0/1yGuHdahQRkFC+6x9M4Fz3ZXvTGTgAFt9uTAMlZBAmQQDQCFRVV+PfLb+A/b74bHm1V31CPgO4YbEAD7nvoSfz++wLUeWmkR2MYazwXjIuVFNORAAmQAAmQQHwEbPElT21qMeYOPWAIoGD+lFKQhy1zwk1GEhBvsswNlekL6VagoOm96I0G9DppEn0kw0Bl7rlSTTdyoitgeQkhwFXcE4IxrYX8MX8BXn/7fSODTTX+vAUDATOCxW6zQ7537rj3YVRqQ94k4qbTBOz2xoX25PtTvtc7XRAzkgAJkAAJkAAJNCNga3ZmsZOGBiBykZ+Vq9bA6Uj9yt8Ww5LR4vj9PqR7eHsIoEPfS8n2ootxLvPuxUBvqpc7EiCBJBFYtbp8Xcm6P0wM8nr9Q6IPIZ/30EXxqIeOue88AXlVnTCuqCjngnGdx8icJEACJEACJNCMgKUN9JOPPQQTp92LZctX4YHHXsDwy2/EWScf1UwBnmQOgYaGeuPJSvfw9khihYVF5sFSvECR8Yk6lnLF05Q6nRMlOcshgcwiUFtXh6++/V8zocVrrqC0ce6E3iH09/lX34UOue8CAaUUSkpkwbgApDOyC0UxKwmQAAmQAAmQQBMBSxvoQw/eGyOHn4r999oFFZXVmDH1Ghywz25NonOXaQRkyoLIbCVjVVZV93jyUF1dhUTPRZeF4URnefe56J0VIYuV4Crumd24eR4Pdhy0TTMlbHYbXG4XZB95YZcdtos85XEXCMhicbJoHBeM6wJEZiUBEiABEiCBCAKWNtBFzr59emHUBafjikvOggxVlDiGzCTg9/uN4JFDTU1EmjcFBYVJ8aKHPErSAZBmFTOmegpKAl0hUFZaHFt2FVsypoqNQFFRifkOraqqiC0DU5EACZAACZAACUQlYGkD/eYZj6KqukZ7z6tw2vCxGDV2CmY/91JUZXjB2gT8TfPPlbLW07F0GIgRXZ1AL3pDQwNqaqoh3iUZ4m7tlskZ6aholhPYcIN+OOHow9rVcsLYUSgqKGg3DS/GR0C+42S6UG1tLeR7Pr7cTE0CJEACJEACJBBJwNIG+v9+/A2FBfn45LOvsfsug/DsI7fhtf82rtAbqQSPrU9ADFYZ7m2l4e2R1BLtRff7/ZAh8xzeHknZ2sddX8Xd2vrlgnSlJSU4cN8hOOnYI9pU9+rLL8Imm2yIAv270mYCRnaawLoF49Yab3qnC2JGEiABEiABEshxApY20EPzBr/8+gdst/VAFOTnwe7gKu6ZeM/KfGyR2+Vyyc5yIdFe9NraGiilIHMzLacsBcpMApQ6JgI9e3bHcUcdipnTb8RNE8cYY336lOtw3x03YecdtkNxYWFM5TBRfASUUiguLjFvXqnVnvT4cjM1CZAACZAACZBAiIAtdGDF/frr9cZ1U2Zi7hffYpcdtjbD3dFgRUkpU0cE/H6fSWJVD7oIlygvekNDvVnRWF6tppSSohlIwPIEsklAp9OBvn16Y8vNN8PJxx+BjTfsj969esBms/RPXsY3gdvtgXRKylx0GUGU8QpRARIgARIgARJIAwFLP62Mu+J8HHP4frhv+nUoKixA+doKnH0qX7OWhvuky1XK8HZ5OJbQ5cKSVIB40cWo7upc9Lq6OiMhh7cbDBmz4SruSW0qFp4jBLhgXI40NNUkARIgARJIGgFLG+j5eR7tOd9Ge0J64ZkXX8P6ffvgoH13TxoMFpw8AuJBt7L3PKR5QUGRmT8pC7yF4uLd19bWwG63N757Od7MTE8CJNAJAsxiFQLy3ccF46zSGpSDBEiABEggEwlY2kCPBPqPl9+MPOVxBhGQoY4yB92q888jUcrDpXjRxUAXuSOvxXIcDAbg9/uRn18QS3KmIQESyAQClDEuAvL9J9+lFRVcMC4ucExMAiRAAiRAAppAxhjoWlb+z1ACYrCK6JngQRc5u+JFr21aHEle2yZlMWQOAa7injltlW2SZps+SinIUPdAIIDa2ppsU4/6kAAJkAAJkEBSCWSMgX7cEQcmFQQLTx4Bf9MCcTLHO3m1JK5k8fzI/PF4vegNDQ2oqamB2+3hYlSJaw6WRAIk0DUCackti8XJd2FVVSU6MxopLUKzUhIgARIgARKwAIGMMZ7OOb0AABAASURBVNB333V7yDB3n99vAWwUIR4CYqA7nU7z2rF48qUzbUFBYdxz0WUhvIaGeohxn07ZWTcJkAAJpI5A9JqKiorN92hlZUX0RLxCAiRAAiRAAiTQjIClDfRhIyeYV6st+msZLh93Cz6e+xWm3P5QMwV4Yn0Cft2pkinD20M0O+NFl6GcStmQCXPtQ3pyv44AV3Ffx4JHJJAIAvI9KgvG1dXVQjowO1UmM5EACZAACZBAjhGwtIGuu95RWJCPOZ9/jSMP3RfTJ4/Bz7/9mWNNlNnqyhzEhoYGiAc90zSJx4suQzi93jrtPc+DUirTVKW8JEACJJAUAusWjCvXP+kNSamjK4UyLwmQAAmQAAlYjYClDfT6+gbUeX344uv/YestNjXsbNpDaQ64yQgC/qb555nmQRe44v2R4eqxzEUXD5HkkfSyZyABEiABEoDpsCwqKkEwGMzFBePAPxIgARIgARKIl4ClDfR99twZp19wDRb9tRw7DdoSy1asgsfjjqrjylVrMHLsVJw7aiLGTZ6B2rq6NtN+/d1PkOHzZ148Dg8/8WI4TbT84gGefs/jRpZQHokLZ+RBVAJ+v988oImxGzWRhS/E6kWX4e0ySiBTFsKzMPK0icZV3NOGnhVnOQEuGJesBma5JEACJEAC2UjA0gb6eWccixcfvwNPzJoKMXzcLieuu3J41HaY8cBTGLzzIDw6cxKKi4vw1AuvtkorhvXEafdi7Khh+Ns9k/H2B59i3jc/mHTR8n809yv8+vsCPHz3DZgx9Wq89uZH+OlXDrU30DrYyLxDl8vdQSrrXpaOBfGKt+dFl04IGcov6ayrCSUjARIggfQRKOKCcemD39mamY8ESIAESCAtBCxtoP/82/ywF/yVN97H9Htmw+V0RAUlhvTQg/cy14cetBc+nDvPHEduxLDOz8/DVgM3hcNux8H77YEP5nxpkkTLH6yvN9dtNhtsNgW7XaFXj27gX/sE6jW3YDCQkfPPIzXryIseGt7u8Xgis/GYBEiABEigiYB0dnLBuCYY3BkC3JAACZAACbRNwNIG+qTb7jfG3fc//obn/vk6ttx8Y9wUZRX36ppayNpcZaXFRtP+/XpjxcrV5jhys2zFavTr0zMcJemWLV+F9vLvscsg1DfUY98jz8VhJ43AMUMPRLeyknAZPGibQCDgNxdcLpfZZ+pGHizz8/PRlhddRmTI8HaPRxaHs/THKVPxp0xuruKeMtSsKEcJ5OcX6A5uOyoquGBcjt4CqVSbdZEACZBAxhKwtEXhdDiMl/vTL7/DkYfug9NPHGpeuxaNtni4Q9eUiq6a0l7wUDpgXbpo+f9cuBjdu5Xg5WfvwfOPTsd/3vwQv/250BRRU1OjDbf2QzAYhNfr7TBdLGVlWhqB5PP5M153pexmBeK1a8ub6SLv9xUjXSnVLD6d7VRXVwcJ6ZSBdbf/nZBNfGprG1+hlU06UZfk3L9yr7hcHrNgXMvv0niYZ8NvSjz6Mm1y7sdYucrzW+vf1PTKFKvsTJd57ST3mtxzmd528vzP0HkC66zTzpeRtJzyQpY/F/yFTz77CttuNcDUI8auOWixKcjP0z/69fD5G722q9aUo2ePbi1SAb17dsOa8spw/Gqdrnev7mgvvxjkWw8cgO5lpejfr4/x5ItXXwrxeDzoKIgHVhYQ6yhdtl0Xw1XWDsjLy+uQkdV1z9cedJlj3tBQDyiZ6mCHzWZHfUMDZAEkGQZvFR1kxIIEq8hDOTr+jshkRnL/y+c8k3Wg7Km7RwsLC/V3pgc+n9eMkOsMe4fDnvG/KZ3Rm3lSd59Gspbnt5T/psbwbBkpI4/Tc28kg7vca3LPJaPsVJYJ/nWJgK1LuZOc+ZxTj8bNMx7B5ptuhC0GbAyZk96ze2ujOyTGHrtujzff/cScvvHOxxiy2/bmWIavf/fDL+Z44GYbQVZrX7h4KWRu+VvvzcWQwTuaa9Hyd+9Whq++/QGyEFhjWb9qmTY0eWw2MdbaD5IwlnTZlsbv9+kHMJc2ZNvnkyl6i+fnl9/m4/a7H8ClV92AUVddj7vufRS//r4I/kAga/TMlPZItJzVSz7Foo+nsB1j+E5LNHuWlx3fkbG2Y2jBOJk2FGsepsute4Ttndz2Jl/yTfY9ILYPQ+cJWNpAl9es3X/7BIwZebbRcPNNN8TdN19jjtvajL7odLz0+vvmNWsLFi4xQ+Il3SJtjE+e/oAcQimFG68ZgQlT78GwS8Zjpx22wo7bbWmuRct/9OH7obyiCsecMRoXX3kTjjvyANNhYDJx0yaBYDBghoRLT2CbCTIsctmKlXjrvY8w9fZZmPv5V1i1eg1WrFiFz+d9q+PuxX/f/gCSJsPUorgkQAIkkHICdrsdhYVFkAU2fT5fyutnhSRAAkklwMJJgAS6SMDWxfxJzb6mvAJPvfAKrrvpbhOefvE1SFy0Snt0L8Os6ePNa9amTrgMeZ7GVbUHau/7c49MD2cbtM1APHbvTeb1bcPPPD4cHy1/QX4eHp5xg5mDPnvWFBx/5EHhPDxom4DP5zcXnE6X2WfypqGhAcuWrcCjTzwPh73xLQLSARGsDxpvq1IKjz31dyxZssx0SmSyrpSdBEiABFJBIJ8LxqUCM+sggSwkQJVIIPsJWNpAv/7m+/DuR59jx0FbmvD2+3Nx4633Z3+rZIGGMrxdKRvEU5Lp6tTWefF/r73VqIaC0SkQDBpj3G6zN8br7cuvv2PeBqAP+T8DCRT1G4wNhkzIQMkpMglkHgGlFIqLSxHU36W1tTWZpwAlJgESyE4C1IoELEDA0gb60uUrcP8dE4zHWrzW998+Hov+WmoBbBShIwJioLtczo6SZcR1u82GP/5cEJY15EVXOsZmX/cRkjTy5gEdzf8kQAIkQAIdEHC5XGbBuKqqStTX13eQmpdJgARIIPMJUAMSiIXAOusiltQpTmPThlHLKm3NXpHW8irPrUBAhoTLgnpOp8sK4nRZhgbofw3yToGmorRl7tK6tdRP9NYpmxJxRwIkQAIk0BGB4uISMxqpsnJtR0l5nQRIgARIoH0CvJolBCxtoG+/7ZYYMeYmPPj4CyZcPGYKdtlh2yxBn71q+JteddfSgM1UjWUI5iYbbdBMfKU7iiRERkoaSRsZx+PMIVC5eA4WfDg5cwSmpCSQBQSkI75xwbg6+LhgXBa0KFUgARLIXgLULFUELG2gjx01DEcesg/mL1xiwjGH74crLzkrVWxYTycJ+P2Nq/LKexw7WYSlssligwftN6RDmQ7af6/wwoQdJmYCEiABEiABQ4ALxhkM3JAACZBAbhOg9mECljXQZRGuEVdNwRHaQJ8y/lJIGHrw3pDe9rD0PLAkATHQHQ4HlFKWlC9eoeSe22qLATj1hKOjZj31hKOw1cDNeH9GJcQLJEACJNA2AaUUiopKzIJxNTVcMK5tSowlARIgARLoCoFMymtZA91ht0OMvNq6ukziSVk1ARmmmC3D27U65n9RUSH233t3XHbRORi09RYoLiw0QY5HX3yuvraHfsAsNGm5yUwCXMU9M9uNUmcHAbfb3bRgXIUx1LNDK2pBAiRAAiSQIwQSqqZlDXTRUoz0E4eNwS0zHjVz0ENz0eUagzUJyBxsWSwt2wx0od2tWyl22Xl7jL7kPDxw9zQT5HjnnQZBrkkaBhIgARIggc4RKCoqNhmrqirMnhsSIAESIAESyEUCrQ10C1HYauDGOOqwfVBWWmQhqShKewRkeLtcz5ZXrIkukSHP40ZxcRFEPwlyLHHgHwmQAAmQQJcI2O12hBaM83q9XSqLmUmABEiABEggUwmk3ECPB9QFZ5+ItkI8ZTBtagmIga6Ugt3uAP9IIJMIcBX3TGotypqtBEILxslr12Q0VrbqSb1IgARIgARIIBoBSxvot818DOVr1w11W7WmHLffOzuaLhLPkGYCPp8f2Ti8Pc1YWT0JkAAJ5AQBpSIXjKvOCZ2pJAmQAAmQAAlEErC0gf7Vtz+itKQ4LG/3slJ8Pu/b8HnqD1hjewTE2xEI+OFyudpLxmskQAIkQAIkEJXAugXjKrlgXFRKvEACJEACJJCtBCxtoNfU1iFyFfeq6hp93viO7axskAxXSoxzUcHpdMqOgQQyigBXcc+o5qKwWU4gtGBcZeW6UXRZrjLVIwESIAESIAFDwNIG+m47b4dxk2fis3nfmTB+yj0YMnhHIzg38RNIdg6fr7HzxOGggZ5s1iyfBEiABLKZQGjBOK+3Dl4uGJfNTU3dSIAESIAEWhCwtIE+dtQw7LfXLphx/1MmHLjPbrhixJktVOCpRQjA7/fDbnfAZrP0bWUVXJSDBEiABEigHQJcMK4dOLxEAiRAAiSQtQQsbUmJoXfUofviyQemmXDEIfvQ+LPwrejzeSGvHkuOiCyVBJJLgKu4J5cvSyeBeAkopVBUVGLmodfUcMG4ePkxPQmQAAmQQGYSsLSBnplIc1Pq+vogZJG4jF3BPTebjVqTAAmQgKUJRC4YFwgEIGvTVFRWm30gGLS07BSOBEiABEiABDpDgAZ6Z6gxTysCPp/fxNFANxhabRhBAiRAAiTQOQJFRcXIzy/Ew48/g6m33YORY67HDVPvxH0PzkZ9fb3pHO5cycxFAiSQaAIy3TGoO88WLlqCv5Ysg3SseZueERNdF8sjgWwlQAM9W1s2xXr5/T5ToyzsYw64SSUB1pUAAlzFPQEQWQQJJJhAbZ0X1dU1uHTsjXj5P2/j+x9/Ng/8v/+xAO99NBcnnjUCixYvwdqKygTXzOJIgATiJeDz+XDXfY/ipLMvwehrbsSoq67HycNG4r6HZqO2ri7e4pieBHKWAA30nG36xCouBrq8/1wpldiCWZoFCFAEEiABEkgPAZk6NWPW31BRUQWllDHO0dBcluu1N93F13s2h8IzEkgxAa/Xh4svH485n81rVfOHn3yGK6+9SRvp3lbXGEECJNCagKUN9A/nzMPw0Tdir8PPxu6HnBEOrdVgTDoJyAOU3+8Hh7ensxUyuG6KTgIkQAJRCDTU1+Orb/8H6L5fh8NhhrPXN9Qj8m+t9p7/uXBRZBSPSYAEUkigzuvFo088h/K1FVFrXbZiJZ545h/w+QNR0/ACCZBAIwFLG+iPPPkPjBl5Nt59+W/45PUnw6FRdG6tQkDmF4ksNNCFAoPVCMQqT+XiOVjw4eRYkzMdCZBACggsWPRXuBZ5s4vdZjPzzoPBgDHWQxd/+Om3ZueheO5JgASSTyAYrMcf8zvuJFuwcDFkGHzyJWINJJDZBCxtoPfu1R0DN9sIdpulxUSu//mb5p/zFWu5fifkpP5UmgRIIIkEAsFgs9IdDqc40yHx8qDv9/nMa9gCei8LxjVLzBMSIIGUEKirq8Nvf8yHTD+p18a6OG4iP58SL4L88vuf2kD3yiEDCZBAOwQsbfl271aKf7z8Jqqqa9pRgZfSTUAMdFkcTilL307pxsT6SaDWd80DAAAQAElEQVQTBJiFBHKbwEb9128OQAF2hwNOpxN2u914zcUY2HTTDVFdXYXa2loT1zwTz0iABJJBQKY4er1euPTnsXtZKbw+L/wBP+p1x5pSCko72IKBQGO8348+vXrA4/YkQ5SsKVMpBRktBP7lNAFLW1T/eOlN3DbzMRx03AXh+ecyFz2nW8yCyksvKYe3W7BhKFJcBHJyFfe4CDExCaSegDyobrbJRq0qtikbHNpQd7ndKCosxMYb9tfGeQ0qKsqxfPkyrF1bDjEcwD8SIIGEEpBnvqqqSqxevVJ/1paivHw1Kqsrsd56veGwO7Sx7oJ8LqUTLfQZlWMRoke3MlRUVqBSh4A25CWOoZFATU0tKiqq8N3/fsIHn3yGVavW6HO+naKRTu5tLW2gR847jzzOvWayrsYypFACDXTrthElI4F0EWC9JNBVAgUFeRh/1Si4Xa6oRU274WqUlpSgV68+KC4ugcvlRF1drTEcxFgXY8CvvXdRC+AFEiCBqATksyOjU9asWYVly5ZA9nIuGQoKClFW1h19+6yHK0cNh91hh7IpudQsSEebGOlXXHoBiouKTOfZqlUrtRG6AjU11WhosfBjs8xZftLQ0KA7LKpx/6NP4ZwRY3DjtBmYef9juOCyazFm/FRtpFdBFuHLcgxUrwUBSxvoLWTlqQUJ+Dn/3IKtQpFIICcIUMkcIeDxuDD7wTuw+y47YoP1+xqt+/Tuie233drEd+9eBjEAlFLIy8s3BkPPnr1RVFQMu91mDADx9q1cudwMgw8Gm89rNwVyQwIkYAjIlBExmsvL1xgPuXx2xGMuzpj8/AKUlnYznWHduvVAYWGR7hBr7DyTjrGp1481ZbTcKChMnTgWTocD+fn56NGjJyS/0+mClC0daeXaE+/11iHX/sT4vn7qHfhozuetVF+1eo0x2m36u63VRUZkNQGblbVbsGgpRo+7BfseeS6HuFu0oWSok4hmtztkx0ACGUuAq7hnbNMlSXAWaxUC4nmTobLnn3MKbpowBrPuvAm33TQOIy84CwX6Yb+osKCVqDabTRsCBejevac2BnpBPH2SSIwBMdTF6BAjRLxXEs9AAplGwO8PwOfzG7Hl2Bx0YlNfHzTTQ2RayIoVy4xXW0adyBB0jycPJSWlkA4v+SxJp5fb7YZSqlVNHh2/+WYb44kH78QVI4fjsIP2xdBD9tfH5+PJh+/CgM020sa8M5xPPtcy4qVXr94o0XXIZ7HcdAos0x7lCkj94cRZfPDvl/+L+QsXt6vhpFvu1p2LXI+rXUhZdtFmZX0m3XY/jjx0P2yx+cZ46emZGHn+qTjvjGOtLHLOyeb3+/UXrqvNL+ucg0GFSYAESCBWAkwXN4HS4mJtaOejpLhQe8o92lNeglj+7Ha78fT16NFLe+2667z5+uE/YIyA5cuXolx77mQV6ljKYhoSSDeB2jovXnrtTVw9cRpOPXcUTjxrBK6bdBu++Oo7VFRVdSheQ0M95H6vqFgL6axasWI55Fi81y6Xy0wTkc+KhOLiEoiRLh1eHRasEyildMdYHvYcvBNOPfFonHTcEfp4Z12G24xy0Una+K/09Tz9ee5uOtPEwy5TVCKHwIv3vo2MGR8lbblw8ZJmejQ0NDQ7l5PFi5dCOjTkmCE3CFjaQK/TX0IH7L2reedpj+5lOP3Eofj9z47fs5gbTZd+LeVLxO/36S8NV/qFoQQkQAIkQAJhAjxom4AMqRWjQ+arl5Z2M4aB1+vD2rWNw3nFi+jzedvOzFgSSDOByqpqzHrkCTz21N/DXlcxXuUVZ1On34P/vvUBqlq8+Uie1bxer+mQWrVqBZabRRTXaCO9FjIyRbzi4h2Xz0RJSZnpwJJOra6qWpCfh8KC/LiKkXpl2Lx47MvKuhn5xJsvnv1y7V33ZtkQ+IrKSvz8y++Qle792uHl0+0kq+CjhZEuHS9/LVkaF0smzmwCljbQ8/M9hq5SCgt171Gd/hFdvabCxHGTfgLBYMAIwV49g4GbDCfAVdwzvAEpfioJZEVdMlS3pKQUoSG2YryL527NmtUQg0AMg1iH2YqRJKswr1pdjuqaGsjDdlZAohJNIwRV2kl4fT689sa7+OiT1nOVQ8I9/cK/8d33P8Kn08p0DpnKsbxplIhM6VDKZkaTdOvWXd/3fSCdVPn5BcYQDpVhlb3L5UaJ7jCQjoOiohLIM6cY6aJPPJ9NWORPviO8uoNB2kW+Y0QPu02hX99eCMi6GNoot9ntZiV8QCHyL8/txvr91ouM4nGWE7C0gb79NgNRXlGJU487HKcNvxr7HXUuDtpvcJY3SeaoJz8AIq081MiegQRIgARIgAS6TiC1JSgVGmLbTRstocXl7GZxORlmu3LlClRXV0Hm6rYlmXjgn3r+X7jlzlkYeeUEXD/lTtzzwGzIYlvyUN5WHsZZn4CM4hQpF2kHUXVNrel0SWfHi9xLn37xlYjUKjTUNyAYCBoZ3/3wE5SvXWvuWW3zoaCgAOKN7t27j5niUVBQmFEjH5VSyM/PN+tJiKdfFoKsra2BfDZlRIB0PDQ01Ldiks6IBg1eRuLI90Z5eWOHn3T6lZevMe0S1Aa52+1BgdarX9/1IJ2FTpfLdJTYbNo0a26fo2/fPqiprUunSqw7xQT0XZDiGuOobsR5p6C0uAj7DtkZH7z6OORVa8cfeVAcJTBpMgnID5UMRzJfJsmsiGWTAAmQAAmQQKIItFOO0h7GfO1RlBWmZQ6uDLcFGiBeL5mru3r1KrOgljyAy2+gDDm+avxU/OvlN/DdDz/D5/fjj/kL8eGcz3DysJHmePWa8nZq5CWrEZCOFZHpthkP4PgzLsKV103BOReNwTAdXvvve1i2fKVcTlmQe00MOn0b4rff50OOg4EAJIisMiza5/chEAxA0v7x5yJj8PXq1UcbtbLSejHEGw20sPqQeX+hIfmim3jXbTa7Gbq/fPkyiPErHur2tPL5/PhVM5TP63P/eBk//fI7Qh0x7eVr75ow9/l8xvAWGeR7YvnypRAvuXxvBHTHifAvKio2HSQiu6xiX1JSiry8PJx16vEoLixsrwqMufSCuKcLtFsgL1qegKUNdJ/+oXv0qX/h+pvvMyB//3Mx3npvrjnmJv0E/PoHgd7z9LcDJUgMgcrFc7Dgw8mJKYylkAAJZDwBu90O8TaKoS4GuxjuQW0EyYJa8gBeVVWFB//2NBa3mBsaqfi4G2/T3r+8yCgeW5yATXswTz57JL769n/NJK3zevH403/Hv1/5L8rXdn26pXjEA9rQFk9rbW2tMfBk6LYYedIRtHLlcsh9JkGOGxqC0M5kSJ6A9sAGg/VoqK+HzWaH0+GE2+XWhrgLRUWFsOt7VymFbP7zeDxmZIDMV5eONJmOIuyWa2NdOAonNP0FtJG8+K+lOH/k1WZxvSee/Qee1wb6uBtvxRnnj8bvfy6ETFFpSh51J8a4PPuK137t2nKzyN5yY4yvMp14IoNM+xR5ysoapxGEjHH5/pBnZqWat4vT6cCkCVci9ArJlpVPu+Fq5OV7dDtb2mRrKTbPu0jA0q194633Y+mylViwaIlRs+96PTH7uf8zx9ykl4D8sAT1D4TT6UyvIKydBEiABEiABJJMQH7rxAMmxkBZWTft+co3xtA7738M8WAGtKFVX9/QSgqJ/+77n1rFdyGCWZNIQBbtmjr9PgR0R0y0al5/6z188umXEGOtrTTybOTXDibx5tbU1BjDTTp1ystXm2HZMtR52bIlZp0DGaItntaKinKTrra2BmLkSbkObXTLcG4x9oqLSxHQBvnmm21iDHEZEu1yu+B0ueDQBp7Nrh/nm+y+jTZcXxvyTSdSUJYHm+5QWdeR1h3CRjgKWwk1NdWaB3Dp2BtQrdujJY4GNOCq8VPg15/hltekHaUNpX2kLDHGpfNEOgCkY0XaSNpHvhMaPeO9UFpaZjr2XLptlOq4HUT+/v3Ww+TxV+JmbYyff/YpOO6ow3DDtaPx0N03Y5ONNkBRQUFL0Xie5QT0J9q6Gv45fzHGXXG+/rC5jJAe/WXU1gfIXOQmpQT82nsuFcoXkOwZSIAESIAESCAXCLi0p1JWgl+5utx4LpU2EIK6w1p+F2Woqww9DmqPXb32bupnf3z/4y+Q65nBJrel9Lg92ps6vw0I2ozTHTDSpvXaUP75l9+xtqLCrP6/Zs2qsCdVDG/xdq9evRLl5WtQWdk4F7yurs7cA2KMyf0jBqV0+JSUlJlhzzJKQww8CXIsi7iVakNP0khaGQpdqI20E449DOjA5jteG3cytxk5+Od0ulBSUgrpSJPPqFIKVdXVmH73g2Z+vrRfNCzTZzyINeXl5pVzMr9d2lLaUdqwrs6rPdh2s8BeaWk3U77UUarbSNrHpb8TlFLRio4pvrCwAAM22xiHHrQPTjn+CGy79Rb63iiFw2GPKT8TZRcBSxvoLW9K6YluD//KVWswcuxUnDtqIsZNnoFa/YXYVvqvv/sJw0ZOwJkXj8PDT7wYTtJe/u9//NXkGXLYWTj85BEIyg9vOGfuHfh177BoLb2HsmcggUwnUNRvMDYYMiHT1aD8JEACKSIgzyTiuRTvugwvdjocUEoZQ0w8sPI76fV5Ua0NhAptzFVUrIV48/y6gzua9zVFoqevGovXvHL1am14V0K7x1FvOl38COjnHZly6dPt5tfH8hqs73/8GbVNC8dJW8qzkMeTZww4MQxLtRHXvXsPY8j17r2eWXywe/eeZki2GJDidZUhzx6PB2JUxjIkXYz7zTfbFGeeclxUileOGm6MuqgJcuSCUsqMcmmcmlKIFStXo0F3sEj7+bw+yGdX2lf2fp8PXq8XCxYt1ka4grzJQViL4S0GeM+evUz7iZdc4sRDL9eThVI6ESQkq3yWmxkELG2gb7f1QDzx/MuoqqrBp19+izETb8d+e+0aleyMB57C4J0H4dGZk1BcXISnXni1VVr5Ip047V6MHTUMf7tnMt7+4FPM++YHky5a/mr9JXz5dbfhqEP2wZv/ehizpk+ATX/4TaYc3fj1D5X8qOSo+lSbBEiABEggxwn079d3HQHtPLPZ7drYcsLldsMY7E6X9n45MGjbLc2cYHnwl6Gxq1evMnOLZaizeF8lTobk+rXxpy3DdWUm4EieeVatKcdq7e1/7Y138fsfC8xxNAdGAqpMaxGdr7wBPt2Z0qtHN73XBps22mTEZoN2xiil4JC2dTh1+7rgcrkgbV9cXIwePXppg7gHxJArLi4xQ5tlWLoYcWK0J9qQKy4qxCEH7I1rrxiBvXbfFX379IYMgd5/7z1w9603YKcdttX3nqvzGLIwZ21tLf5auhwut0u3nxPKpiAjWqR9xUjXvWqmfSsqq3QHWp02xvuYjhTpRHG7PbDZ7FlIhSpZnYDNygJeMeJMdO9Woj9QDtw560nsv/duOO/0Y6OK/NHcrzD04L3M9aEH7YUP584zx5Gbn379NHCecAAAEABJREFU0yzYstXATc0H8uD99sAHc740SaLlf+/jz7Hl5pvguCMPhAyz37D/evrzrEyeXN3Ig4R4DXJVf+pNAiRAAiSQ2wQC2sO6w3Zbtw1BPyLYtCFg14bd9ttto50GxebBv2fP3tqg646iohJ4tMe1oQEQA0K866tXr8SyZUvNcOny8tXaOVFpvHni5Wu7kvZjq6prsEQbJqPH3ojhl16Dh2c/i6smTDXHL7/2FuSd7e2XkN1XZa53dXUVpJNEuMtc8JWrVqPfer3186EDLqdLG3Vu2B0OY6TZ7Da9V+b5r1/fPhAjPB2E8vI82HnH7XDBuafhpglXYuLVl+GcM0+CkUl3HqRDJivXKe20+aYbGxFtNpu2KZyQDjSXZuXSnWnyLCttLIu0lZaUgH8kYAUCljbQlVI4/MC9jKf7mYduwVGH7qu/HNsWWbzcOjnKSosN1/79epshLeYkYrNshf7y7dMzHCPpli1fhfby/7VkhUl/6vlXmeHts597yZzn6kYeFqRXXr7ccpUB9c4+AlzFPfvalBqRQDIJ5GtDacxlF0C8mtHqmTLxKm0MuMKXGw0El3YU5GsjvdgY67169TbGu8w7Fi+sGBTyG1tbWwNZKVoWp5L5sLKXczEqvd464wUMF9zGQU1NLUZddT1qtAex5eVnX3wJ/3rpdd0JUN3yUtaey7BhGcUgDGX0wqpVK7X+lYajDDcvLe2GHt17YMTws7VRbofSHSzRYJxzxoloOQ0zWtrY4+NLKfdfSUmxvo8KIMfx5c6d1E6XE316r3vuN5ormI4WRPz11R0z8nwbEcVDEkgbgbat3bSJ01jxg4+/gPZCY6rWW/nhC8UqFV011exLd126aPkbGuqxZNly3Hz9FZh93xS899Hn+OKr701V8kPZUZChNPKj0FG6TLku73UU5WUxnEyROZfklIe6bLrfUtV2dXXywBtAqurLlnpqaqrN/L1s0Yd6VFn+MyBDka3STj5tKN8z/UYMGbyzGfYsi8N171aKrbfcHA/MmIJupUX681HbIVP5HMlvqhiRNpsdLpdbG/EFEUOmPVBKwe/3mbLKy9cYT7usKt24KNkKlGuve0VFuTE6ly9fgXE33AKRJ1p46bU38eXX32kPfo0p0ypMEymH8Fi9epVZMV2McjHOpXPDpj2pbrcnzFfOxaPu9dbqDpcCjDj/jDA7WRQuWB8057Lo3w3XXm4WEkuknCkpq9r6n+1kcKgP+HHKCUegR7cy04bBQGNbRu7tNhtGjzgHepf2z0K2PMOBf10iYOtS7iRl/tvT/8a72gj+8psf0VZoq9qC/DwEg/XwmTlcgMy56tmjW6ukvXt2w5ryynD86jXl6N2rO9rLLz+2W26+KWRoe4/uZdh2q83w028LTBn5+QXmR7S9vd1uh1v/ELSXJpOuKaX0l5jNLIaSSXLniqwybDKb7rdUtZt4rex2R4ef51TJkyn1yHxLl8tFbjH8FmRKm1pdTqfTOvdbUVGxvvfzce5ZJ2Py+CvwyL23YsatN2D0xeeiW1kZevbsqa93/JwQjXlBQaH2kBajpKQUZWXdIQuN9ezZW5fbW593M7/D8n2vlE0b735tbNdCjH2Px43lK1Zpe7IBUPq/dkzIs0jLsGTZCliJZzQOsca7dMcG9J90dogzoba2VnPxwa6/24WlMBR+sniYMJW4lmVvuMH62HnHQZg0/kqcfvIx2HGHbbH/PnuYYeQvPHGfWWlbRjq0zJfr51bWv6S4GLdNuQ677rI9Wn4GttpiAB6dNR2yZoAVdMiWZzj9MeT/LhCwpIF+6QWnw+N2Iz/PjeOOOAB333wN7r99QjhE03ePXbfHm+9+Yi6/8c7HGLLb9uZYhq9/98Mv5njgZhth5ao1WLh4qVmJ/a335uqe7x3NtWj59xq8I37+7U9UVdfA6/Ph2//9ii0GbGTyKKWgVPtBEirVfhqlMue69ODLD7pSmSOzUpRVKTJQKjqD4vV3N6u4KxU9jVK8phQZKEUGSpGBUusYlBQXaUO6UBvQZcjzeNCtWynEK6uU6vAZQan400jZYoyKQSGdBCHDs1evPrru7vjux1+gtFHe0NAA8RT6tfNCRh7I3gTtVQwGA/j2ux+xdm0F5DjVzypSX7mu++df/8BTz/8L7344F/MXLoYY10rFxkTKEI+4vAqrcSTBSohhLvpI52FpaVl4+oAs+uXSnYlKdVy2tOd222yBIw47AJdeeDZkSPvhB+8H4e5xu5LSpkp1LJdSOZumy8xlKsqlF56DJx+5CzdNHIMJV4/C7AfvwNVXXIzCgnxjuCtFvkolhoF8Nhk6T8DW+azJy3nq8YdBVmIfOfw0/PTLHzj74nGYPP1B/DF/cbuVjr7odLz0+vvmNWsLFi7B6ScONekXaWN88vQHzLFSCjdeMwITpt6DYZeMx047bIUdt9vSXIuWXzzxZ550BIaPvhHnX3YDDthncDiPyZhDG/NjHwxCfuRySG2qSgIkQAIkQAKWJ6CUMp7AQVtvqfcO7R13wqUNSlkUSzrWxXsoRqZSCvXaeN9wg37a6ARWrVoJGS4vQea6Nw6Xl3d4V0Om/4hRL8PvEwVADPMffvoV54+8GuNuvBX/fOl13PPAY7hy3E248eYZEO9/tLr8fh/ECA/JvHZtuZFR9CsqKjErq8vq6sXFJXC7Pcawi1ZWR/HS2ZKf79EOI49m6egoOa9bnEBhYb7pQNty4GbYfrutUaAN8xLduQZYXHCKl3MEbFbWeJMN18c5px+LE48+BO999BnmfftDu+LK8PNZ08cb437qhMvMh1AyDBywMZ57ZLocmjBom4F47N6b8MSsqRh+5vEmTjbR8su1ww/aG7JQneQ5TXcgSFwuBunZFr3lh1D2DCRAAiRAAiRAAtYi4NVGbH5e3jqhFKC0R91mt8HusMPhcGiD04lNNt7ADJUXg1a88GLgNhq1NvOu6JqaKu1hX4PVq1eaedyyWJ14qmXF84oKMeCrtHFca4aR19cHEcufdPSvWbMWE266vc3kP/3yO266dSZq67zmelA7BWpqaswce+lAWL16lZknrBS0gVVoRgzIyAHxlufnN3pCTUZuSMAqBCgHCcRJwJIGekB/Gb/38Re4dvJdOOW8sZi/6C88fPckHHfEgXGqx+SJJiA911Km/LjLnoEEsoVA5eI5WPDh5GxRh3qQAAnkMAExzkdfcm67BAZsujF22WGQSWO32yEj4/K0US9DwWV+drdu3c1c99691zNe6bKybijWXmmZI2vTxr4sqlZTU60N+HJtwK/SBvxyiAG/YsVycy6ebfF019bWQIbXi6EN/VdevhbT7rhPH0X53wAsXPwXXn7tTVO2dAjIEHa/P2BeTSeGuBjk3br1MHPw6TCIwpHROUOAimYfAUsa6EeeMhKPP/NvyJzwF2ffgcsvPgsb9V8v++hnoEZ+v9/0uiulu64zUH6KTAIkQAIkQALZTsDjdmOD9fth1IXD2lR16y02x6UXDdMGd2Gb11tGNhrwbsi87kYDvkx7rns0GfB9IIvXlZZ2Q1FRsTaiPbDZQh74arPiuXjcxdAWD7jb7cLSpcu0192PYCAAMdxl+HwwEITf54PX54U8ayxYtBjQzxpSppTfs2cvLW8J3F0ctg7+kQAJxEOAadNAwJIGenlFJX74+XdMveNh7Hvkudj9kDOahTRwYpVNBPx+nzbQXU1n3JEACZAACZAACViRgKyfs8duO+LWm8Zh7OgLcdB+e2H4sFMw8epLMfbyiyDvfU6M3MoMmXfrToH8/AJjpJeWlmmjvYdZoE283d2790CpjhNj+0f9fCeGNxoajHEu7572687/QDBgxHFob754xf9aulxfbzCr4HPUnkHDDQlkIQGq1BYBSxron7z+JNoLbSnCuOQTkB9RmTsmP5zJr401kEBqCRT1G2xWcU9trayNBEiABJJHQIatb7rRBtht5x1w0Xmn49AD98Wgbbcyq1Ynr9bmJSslBrwTbu35Fg/8jttvozv6nXC6XHBpo14WsHM5XZC90+WC3eHQHniFgZtuAlnEq3lpPCMBEiCBOAhkaFJLGugZyjLrxfZr77ko6XQ6ZcdAAiRAAiRAAiRAAnERWLFyNdbv22ddHgUom2zQ7K9Pn17aaHc1i+MJCZAACViJQLJkoYGeLLJZWK4Y6Eop865I8I8ESIAESIAESIAE4iRQWlKE68eNbjfXjtttg32G7NpuGl4kARIggWwl0GSgZ6t61CuRBHw+P1wudyKLZFkkYBkCXMXdMk1BQUiABLKYgIzCk1Xm77l9EooKC1ppuv/ee+CCc09FSXFxq2uMIAESIIFcIJAaAz0XSGa5jmaF1WDAzBvLclWpHgmQAAmQAAmQQBIJyCrz6/XuhbtuuR733zUFF55zGm6acCUeuudmnHPmSejZo3sSa2fRJEACJGBtAllhoFsbcXZIFwj4jSIuF+eDGRDckAAJkAAJkAAJdIlAaUmxMcYPPmBvbDlwALqVliI/z9OlMpmZBEiABDKdAA30jluQKTQBv7/RQHc4uECcxsH/WUiAq7hnYaNSJRIgARIgARIgARLIMAI00NPeYJkhgM/ngxjnSqnMEJhSkgAJkAAJkAAJkAAJkAAJkECGEaCBnmENFre4Ccrg9/s4/zxBLFkMCZAACZAACZAACZAACZAACbRFgAZ6W1QY14xAMBhAQ0MD2pp/3iwhT0gggwlwFfcMbjyKTgIkQAIkQAIkQAJZQoAGepY0ZDLV8Pka5587nSlfIC6ZarFsEiABEiABEiABEiABEiABErAUARrolmoOawojw9uVUrDb7ciuP2pDAiRAAiRAAiRAAiRAAiRAAtYhQAPdOm1hWUnEQHfx9Wrxtw9zZBQBruKeUc1FYUmABEiABEiABEggKwnQQM/KZk2cUjL3PBAIgMPbE8c0USWxHBIgARIgARIgARIgARIggewiQAM9u9oz4dr4m95/TgM94WitXiDlIwESIAESIAESIAESIAESSDEBGugpBp5p1fn9PiOy0+k0e25IIDEErFcKV3G3XptQIhIgARIgARIgARLINQI00HOtxePUVwx0h8MBpVScOZmcBNJIgFWTAAmQAAmQAAmQAAmQQAYSoIGegY2WSpF9Ph/nn6cSOOvKCAIUkgRIgARIgARIgARIgASSQYAGejKoZkmZwWAQskgc559nSYNSjXYJWGgV93bl5EUSIAESIAESIAESIIHsJUADPXvbtsuayfB2KcTl4vxz4cBAAtlBgFqQAAmQAAmQAAmQAAlYlQANdKu2jAXkEgNdKQW73QH+kQAJkEBMBJiIBEiABEiABEiABEig0wRooHcaXfZn9Pn8nH+e/c1MDZsIcBX3JhAW31E8EiABEiABEiABEshmAjTQs7l1u6CbzD0PBPxwuVxdKIVZSYAESCCjCFBYEiABEiABEiABEkgrARroacVv3crFOBfpnE7OPxcODCRAAs/7QLUAABAASURBVCTQdQIsgQRIgARIgARIgATaJ0ADvX0+OXvV5/MZ3R0OGugGBDdZT4CruGd9E2e/gtSQBEiABEiABEgg4wnQQM/4JkyOAn6/H3a7AzYbb5HkEGapJEACJJBZBCgtCZAACZAACZBA8gnQ+ko+44yswefzgq9Xy8imo9AkQAIkkIkEKDMJkAAJkAAJkIAmQANdQ+D/5gTq64OQReKcTi4Q15wMz7KZAFdxz+bWpW4kQAIkQAIkQAIkkBkEaKBnRjulVMrQ/HMa6CnFzspIgARIgAQylQDlJgESIAESIIEEEaCBniCQ2VSMzD8Xfex2u+wYSIAESIAESIAE0kiAVZMACZAACeQOARroudPWMWvq9/vgcrmglIo5DxOSQKYT4Crumd6ClJ8ESKCTBJiNBEiABEjAQgRooFuoMawgisw99/v94PB2K7QGZSABEiABEiCBTCdA+UmABEiABOIhQAM9Hlo5kDYQCBgtaaAbDNyQAAmQAAmQAAlYmQBlIwESIIEsI5BVBvrKVWswcuxUnDtqIsZNnoHauro2m+vr737CsJETcObF4/DwEy+G03SUf015BfY/+nzMevS5cJ5sO/D7fUYlp9Np9tyQQK4Q4CruudLS1JMESIAEYifAlCRAAiSQagJZZaDPeOApDN55EB6dOQnFxUV46oVXW/GUIdwTp92LsaOG4W/3TMbbH3yKed/8YNJ1lP/2e2djx0FbAFk8NVtWcJfF4Wy2rLo1wD8SIAESIAESIAESsBgBikMCJEACrQhklRX20dyvMPTgvYySQw/aCx/OnWeOIzc//fon8vPzsNXATeGw23HwfnvggzlfmiTt5Reve16eG1tvMQBoMMmzciMedA5vz8qmpVIkQAIkQAIkQAI5RYDKkgAJZCKBrDHQq2tqIYuOl5UWm3bo3683VqxcbY4jN8tWrEa/Pj3DUZJu2fJVaC+/zMue+dAzGDX81HC+bDyor6+HBFnBPRv1o04k0B4BruLeHh1eIwESIAESIIEWBHhKAiSQFAJZY6ALnchh2UpFV03ZIseor0sXLb8MlT/uyANQXFQo1TQL1dVV6CgEg0HU1dV2mK6jcpJ9vbKywugWCPgtL2uyWWRy+bW1NRlxv2UyY8q+7nuvpqYaXq+X3xkx/Bbwvll333SFhc/H+60r/Jg3vvuwrq4O8rtKbvFxSwSvXCxD7rVMsBk6ahtjUHDTaQLrrNNOF2GNjAX5eQgG6+Hz+41Aq9aUo2ePbuY4ctO7ZzesKa8MR63W6Xr36o728stQ+cm3PYDdDzkDDz7+AmY/9xLuuv8JU0ZBQSE6CjKn2+PJ6zBdR+Uk+3qog6KwsNjysiabRSaXn5eXj0y43zKZMWVf972Xn18At9vN74yCdUx4fySXhcvF+433WHLvsUi+Ho8H8rsaGcfj1PFPImtL/m7JvebJAJuho3YxRhI3nSZg63ROC2bcY9ft8ea7nxjJ3njnYwzZbXtzLMPXv/vhF3M8cLONIKu1L1y8FMH6erz13lwMGbyjuRYt/0N3XY9PXn/ShAvOPhFnnXwkRl90psmTTZvQ/HOlIkcYZJOG1IUEohOoXDwHCz6cHD0Br5AACZAACZAACZBATASYiAQ6TyCrDPTRF52Ol15/37xmbcHCJTj9xKGGzKLFSzF5+gPmWCmFG68ZgQlT78GwS8Zjpx22wo7bbWmuRctvLmb5Rla39/v9cLlcWa4p1SMBEiABEiABEiABEiCBDCZA0bOagC2btOvRvQyzpo83r1mbOuEy5Hk8Rr2BAzbGc49MN8eyGbTNQDx27014YtZUDD/zeIkyIVp+c7Fpc85pR+Pic09uOsuenSyEJ9o4nU7ZMZAACZAACZAACZAACZAACeQgAaqcXgJZZaCnF2Vm1+73+4wCfMWawcBNDhLgKu452OhUmQRIgARIgARIINUEWF8HBGigdwAoVy77/X7IYnahheJyRW/qSQIkQAIkQAIkQAIkQAIkkC0EMl8PGuiZ34YJ0cCvPej0nicEJQshARIgARIgARIgARIgARLIRgIp0IkGegogW72K+vp6BINBcP651VuK8iWTAFdxTyZdlk0CJEACJEACJEACJNARAblOA10o5HgQ77kgoAddKDCQAAmQAAmQAAmQAAmQAAmQQHoIJNFAT49CrDV+AuI9V0rB4XDEn5k5SIAESIAESIAESIAESIAESIAEEkIgcw30hKifu4WUr63A2opKfDTnM/z6xwK43Hmoqa3NXSDUPOcJcBX3nL8FCIAESIAESIAESIAE0k6ABnqUJsjW6DqvD1XVNZgw+Q6cO+Iq3DHzEYy74VacfeGVePzpF1GhjfaGhoZsVZ96kQAJkAAJkAAJkAAJkAAJkIBlCdBAT0/TpK1Wp8OujfEr8NfSpUaGkDEur1d7692PMO2O+1BbV2eucUMCJEACJEACJEACJEACJEACJJA6AjTQU8c6hTW1XVVVVTUm3zKz2cWGhnpzblONt8LPv/6BV19/Bw30ohsu3OQOAa7injttTU1JgARIgARIgARIwKoEGq0yq0pHuRJKwOVyYcGixc3KrK9vgNL/5H/owvyFi1Hn9YZOW+8ZQwIkQAIkQAIkQAIkQAIkQAIkkHACNNATjtS6BS7+a6lZGC5SQmVTsNvtiPz7RXvRa2rTN8w9UhYekwAJkAAJkAAJkAAJkAAJkECuEKCBnistrfXcoH9fuN1ufbTuvxjndkdzA73/+n2R7/GsS5RdR9SGBNokwFXc28TCSBIgARIgARIgARIggRQSoIGeQtjprqqqqgZ9+/TqUIy+6/VCXh4N9A5BtZmAkSRAAiRAAiRAAiRAAiRAAiTQOQI00DvHLSNzFRcXYsxlF7Qre35eHs44+bh20/BiGgmwahIgARIgARIgARIgARIggawlQAM9a5u2tWJKKRTk52PydVe2vqhj1uvdC1MmjoGjxZB3fYn/c4RALqvJVdxzufWpOwmQAAmQAAmQAAlYgwANdGu0Q8qkKCoswMDNN8EDM6Zh/FUjcdThB+Gs047H5PFX4pbJ12KD/v2glEqZPKwopwhQWRIgARIgARIgARIgARIggXYI0EBvB062XpKF4Xp0L8MOg7bB2do4P1ob6VttMUB71/OyVWXqlRMEqCQJkAAJkAAJkAAJkAAJZDYBGuiZ3X6UngRIIEEEOlzFPUH1sBgSIAESIAESIAESIAESiEaABno0MownARIggRQSYFUkQAIkQAIkQAIkQAIkQAOd9wAJkAAJZD8BakgCJEACJEACJEACJJABBGigZ0AjUUQSIIHkE+Aq7l1hzLwkQAIkQAIkQAIkQAKJIEADPREUWQYJkAAJkEDyCLBkEiABEiABEiABEsgRAjTQc6ShqSYJkAAJkEDbBBhLAiRAAiRAAiRAAlYhQAPdKi1BOUiABNJKgKu4pxV/NldO3UiABEiABEiABEggZgI00GNGxYQkQAIkQAIkYDUClIcESIAESIAESCCbCNBAz6bWpC4kQAIkQAIkkEgCLIsESIAESIAESCClBGigpxQ3KyMBErAqAa7ibtWWoVzZTIC6kQAJkAAJkAAJNCdAA705D56RAAmQAAmQAAlkBwFqQQIkQAIkQAIZR4AGesY1GQUmARIgARIgARJIPwFKQAIkQAIkQAKJJ0ADPfFMWSIJkEAGEuAq7hnYaBSZBLKZAHUjARIgARLISQI00HOy2ak0CZAACZAACZBALhOg7iRAAiRAAtYkQAPdmu1CqUiABEiABEiABEggUwlQbhIgARIggU4SoIHeSXDMRgIkkF0EuIp7drUntSEBEshmAtSNBEiABLKXAA307G1bakYCJEACJEACJEACJBAvAaYnARIggTQSoIGeRvismgRIgARIgARIgARIILcIUFsSIAESaI8ADfT26MRwze/3oaNw/fUTsdNOO3aYrqNyeL1j1mTk03dtA5QC77cYPpuR94un145Yb7eryS1ObsFgAA6Hg9zi5BZ57/E4vu92p9OJQMDPe473XEruAZvNhoaGhpTUlaDvAsqawZ+NhoZ62Gwq49tQP4zyfxcI0EDvAjxmJQESIAESIAESIAESIIHcIUBNSYAEkk2ABnqyCbN8EiABEiABEiABEiABEiCBjgkwBQmQAGigJ/EmCASDmHLHQxh2yXhccPmNWPTX0iTWxqJzkcC8b37ANZPuwoHHDsf5l92A9z7+Iozh6+9+wrCRE3DmxePw8BMvhuN5QAKJICDfa8NH3xguauWqNRg5dirOHTUR4ybPQG1dXfgaD0igswTkd/T2e2fjsBMvxh6Hnoln//EfU5TE/z97dwJvU7n/cfy7zzkK11VmkYwhQ1RuRMXVlSv3+ucmJULmoYgG8zyFm7lkTBLdRkVcktCABiVRIpcoMp5QZPyv33M628Y5xznHPsc+e3+8rLXXfp5nPet53s9+nbV/e+31bM6vjoJVEAXs79jjff+txm26q2WnflqyfJW/9lfmLlKTdj3UtH0vrVi5xp/OBgIpEVi7fqOLCarVaXrW60vev8Tet9nrkvOrBxRB/wnQ03Cw5/13mfYfiNWMZwarQb1aemrM9DQ8GlVHokDWLJn1+MPNtej1SWp2fz0NeXqyYzh9+rT6DntGTz7SXM9PGKSlH3wiC+ZdJisELlJg7oKlypsnp5vrIL6qsZNeUpVKFTR9/EBlz/5nvfTqgvgsHhFItcDMl+dp/beb9czI3lox/3ndWuUGV1c6nF/dcVhFlsCc1xeoUMH8mjVpmB7r2NRdZDGBbdt3yl6Lk0b11Yj+Xdy59ujvNueL5bIgkHyBzJdfrrbNGqhGtUpn7ZTU+zbOr2dRRcQTAvQ0HOaPVn2hu2rd5o5Q8/bKWr/xe/362xH3nBUCwRAodW1R5c55paKjotwb1+PHj7srlxs3b1XWrFlUplRxxURH686/VtUHq/jEPxjmkV7HwUOH9fbCZXrgnrvOovho9Zeqe2fc37u63t+9D1d/cVY+TxBIjcDCJR+oS/sHVaxIQTcZ4dUF8rlqMv751XWDVYgJnDx1yvvg0ecWmxwuf97croUfeufP6l5A9SfvvJo/X26V9s69n675WvxDIKUCpUoU0U0Vy8peX4H7JvW+jfNroFRkbBOgp+E479l3QAWvinszYUGS/aHfvWd/Gh6RqiNZ4M3576lEscLKkjmzfvZeZwXz5/FzFCqYTz/v3ud/zgYCqRUYO2m2Ordr7N5cnD4dV4t98Gi/HJDjyuwuwV5ve/byt85hsEq1wCkvWLJz5pvvvKc77m6lh7sN0w874m4V4/x6AVayUyVwzz9rafHSlbqldhO17TJQ3To95OrZs2+/CgScU+2Dot17Oac6HFZBEUjsfRvn16DwZrhKCNDTeMh8Pp//CFEB2/5ENhAIgsBX67/TS68tUN8n2vpr80Wdee2J6Sb8LmykXmD9t9+7nSuULeUeA1eBVwN8Pk4tgTZsp17g2PHjKl7Q2TplAAAQAElEQVSkkN6ePV5/r1lVw8ZM9Vfm8/n821EB2/5ENtJMIFwrtlvB/u+uGnr3jckaP7yHho6eohMnTrju+qLO/F3z+c689lwmKwSCIOCLCnxdnXm9cX4NAm4Gq+LM6GewhmeE5ubJlUP7D/zib+r+2IPuvk1/AhsIBEFgj3elcsLUOZowooe7d86qzJcnpw7EHrJNt+w/EKt8eXO5bVYIpFZgxcefacG7K+KuLnUdqK+/2aRmHXrJvvZ58uQpWTBlde/zXm95cue0TRYEUi1gb0rtFp7bq97kXmN/ve1mbd7yg6uP86tjCNfVJevXm+8s1a1VblS2P2XV9WVLunbs2r1PeXLlVGxswPs5729c3tycUx0Qq6AIJPa+jfNrUHgzXCUE6Gk4ZFUrV9SS5avdEVZ/vk7FChd0bzJcAisEgiBgM3v2GjJePbu01lX5znyl3e5xsrztP+6S3VP3nvc6tDcdQTgkVUSwQPsW92nlolluscmSyl13rV54dogTqXqz9/du2Uq3vfj9j3Wr9/fPPWGFwEUIVPOCpU+/iLvX95M1X+va4oVdbZxfHQOrVAkkvlOunFfok8/jXm9bf/hJR478rvzeh9t2/rR5XH4/dsxdeNmwcYsqVyqfeEXkIJBCgaTet3F+TSFmGBQnQE/DQaxX56+KivK5n1mbNusNdevcMg2PRtWRKPDqW4u1bsMmNWr9pLuqaffN7dq9Vz6fTwO6d1CfoRPc6++mG8roxuuvi0Qi+pxOAo+2a6x5i1a4n1n7YftONb63bjodmcOEs0D7hxpqxcdrZD8ZOde7utmzSyvXXc6vjoFVkAXaNLtXr817Vw1bPKbBT0/SgB4d3eSEhQtdpfp173A/vfZozxHq0qGpLsuUKeGjk4pAEgKrPlvr3q8tWb7KvUf7W/3WrrTPl/j7Ns6vjiiiVlER1dt07qxNDNera2vZz6xNHt1P11ydP51bwOHCXSDwimb8lU2bjND6XaFcKffae3HiULV+8B5LYkEgaAL29c8pY/r568udK4cm/ru3+5m1oX06u8kK/ZlsIJBKgSuyZ9OYoU9qxoRBGjusm2xyLquK86spsARboGTxwpo3e7xemf60po4dcNYH2w3vrq1Zzw3TzIlDVL3qTcE+dLLro2DGFqhSqYL7Flr8e7Ylb07xdyix922cX/1EEbNBgB4xQ01HEUAAAQQQQAABBBBIVIAMBBAIAQEC9BAYBJqAAAIIIIAAAggggEB4C9A7BBBIjgABenKUKIMAAggggAACCCCAAAKhK0DLEAgTAQL0MBlIuoEAAggggAACCCCAAAJpI0CtCKSXAAF6eklzHAQQQAABBBBAAAEEEEDgfAFSEPALEKD7KdhAAAEEEEAAAQQQQAABBMJNgP5kJAEC9Iw0WrQVAQQQQAABBBBAAAEEEAglAdoSVAEC9KByUhkCCCCAAAIIIIAAAggggECwBCKtHgL0SBtx+osAAggggAACCCCAAAIIIGACIbcQoIfckNAgBBBAAAEEEEAAAQQQQACBjC+Q8h4QoKfcjD0QQAABBBBAAAEEEEAAAQQQCLpAigL0oB+dChFAAAEEEEAAAQQQQAABBBBAwAmEUoDuGsQKAQQQQAABBBBAAAEEEEAAgUgUiKAAPRKHlz4jgAACCCCAAAIIIIAAAghkFAEC9GCNFPUggAACCCCAAAIIIIAAAgggcBECBOgXgZeeu3IsBBBAAAEEEEAAAQQQQACB8BYgQA/v8U1u7yiHAAIIIIAAAggggAACCCBwiQUI0C/xAETG4eklAggggAACCCCAAAIIIIDAhQQI0C8kRH7oC9BCBBBAAAEEEEAAAQQQQCAMBAjQw2AQ6ULaClA7AggggAACCCCAAAIIIJAeAgTo6aHMMRBIXIAcBBBAAAEEEEAAAQQQQMAJEKA7BlYIhKsA/UIAAQQQQAABBBBAAIGMIkCAnlFGinYiEIoCtAkBBBBAAAEEEEAAAQSCJkCAHjRKKkIAgWALUF/kCny0+kvdUrtJgsvkF15NNszt/2iu348du2D55Ja7YEWXoIA5Jfew6zZsUq/B45Is/ukXX6vdY4OSLJOSzGDX99X679Tikb4XbMLOn/forQVL/eVOnDypB9p0U+zBQ/40NhBAAAEEEAg1AQL0UBsR2oMAAuklwHFCWKBa5YpauWiWWx5p/YBq3naz27a0Ns3uTXbLRw9+QpliYi5YPrnlLlhRiBeYMHWOmjT8R4i3MunmFStytZ54pHnShbzcXT/v1fzFH3hbcf9joqN19101NeuV+XEJrBFAAAEEEAhBAQL0EBwUmoQAAuEgQB/SQsCuxjZ/uI+6Dxith7sN02dfrtfLb/xXdRp2cFdHH+05XNt/3OU/dJfeI3X8xAn33K40T5rxqtp1HaTWjw7Ql+u+dem2Sm65hUs+VKNWT8iuME+c/h9Vq9PUdj9vOXL0qJ5+ZqYate6mxm26ywLjU6dOuXK27/Cx0/WI1/4Gzbvq2Wkvu3Rbbdm2Q517DFfzjr3dVeIPV31hyW6xvlvbH/L6X+tfbRSYZ/2yPtmxAvvldvxjZS5798XqupLF/kiRXp/3rpp16KWm7XupdoN22n/gF5d39Pdj6jlorGuHOe/eu9+l2+qVuYv0YPuebrEy+w7EWrKszyPHz1CTtj10X8vHZW11GQGrvftjZe2fv2i5S7UxGT/5JbXpMkCNPNd3l6106bZa/tFnatW5n2y8zeR/2360ZG3ZukN2HHtiJpZv7WjbdaC69Bqp+LY+47lu2bpd5j101FQrrr9Vr6J3AoJ2l8gKAQQQQACBEBIgQA+hwaApCCCAQLIFIrjgpu+3qd1D92nC8B6qVLGsbr6xvObNHqfZk4frzppVNWzMtER1ihYuqOdG9dFT/TrrqbEpK7dr914N9wLrwb066bmn++jkHwF3Qgeb+uIbOnnypGY+O0Qznhmsn3fv0ytzF/uLWgA8dlg3zZ4yXF+t36T3P/zU5fUZMkGVK13v9unctrH6DJugA7EHZUHwk/1H68H7/6nnJwzSazNGqXTJom4fW1m/pozpp26dWyTarzVrN6jcdSWsuFs++uRLzZj9lob07qSZE4do2rj+ypYtq8vbtv0ntWne0LXjpgplNP2luS7d9lm09GON9+xfnDhUFcuX1gjPxDKtz9t27NSUsf30n2n/1pOdWliyfD6fW77zxq3D44PUvkVD/aN2dZdnq8KFCmjy6H4a91QPjfI+1LC+7t13QP1HTFTXDk01w+uvHWfgyOes+HlLfFsnjeqrOn+r5m9rx5b3q1iRQm6senZt5fbLmeMK/TlbFn3vBe4ugRUCCCCAAAIhJhAVYu2hOQgggAACISAQyk0oWbywilxTwN/EqOgoTZ31hrvy/PbCZfpu81Z/3rkbd1Sv4pJy5bhSO3ftld2X7BLOWSVU7utvNuvGCqVVvGghV7rRPXXcY0Kr1Z+tk5V/pPsw2bJpyzYvEN/oL1q9aiVFRUXpskyZVLVyRe9q/jf65eBhbf9plxrefacrV6FcKVlf13nHXfv1dyp9bVFVu7miy7siezblznml27ZVjVv/Yg+6vmxJ/bhzT4L9+mnXHuXLk9OVs9WqT79SvTo1dHWBfPbUe8zv2mNPihW+WkUKXWWbuqnCdd5V6+1u2/aJ/eWQug8Y465ML37/Y321YbPLsz43b1RPWTJnds+LFSnoHk+fPq0dP+5y4zOsz6PuAxWX8ceq5u2V3Vae3Dm9Dx2Kad36zVrrfWhRtnQJlSlV3OU1vvcubdy8Vb/+dsQ9D1yVKHqN4tt6Vb48/rYGlgnczpcnt7bv+DkwiW0EEEAAAQRCRoAAPWSGgoYggAACESNwUR29/PLLztq/a68RXiBbRP27tdeI/l105OjvZ+UHPomOOnPas8DernIH5sdvR0clXC4m4H72JO9t90mPdWzqrt7a1faXp47U0D6d46tP8PG0Tis6Kkp2r7T++GfHsADXnlowb48JLYF5MTHR7ur9ueUyZYrxf90/Pi8mJlP85lmPVjY+ITo6WidOnHRPfb7TqlvrNn+/po4doIWvPOvybHWZ94GDPQYuPp9P+fLmUgnvg435i5cHZiW+7QX1MdFnxsAcorx6EtohOqBclOcX39aEylrasePHlemyGNtkQQABBBBAIOQEzpz9Qq5pNAgBBBBAAIGkBY4cPaoDvxzUrVVuUI4rs2vJ8lWSkt4ntbnly1yrbzZu8V/F/XDVmkSrsivdk154TYcO/+rK2Ne27Qqwe+Kt3nznPS/oPaGDhw5r4ZIPdEP5Mroy+59VIH9ed1+4vH/rNmySfS38eu+4FcqV9K4g/08rP13r5cT9j6877tmF1yWKFtaOn85cOa7yl+tl94LHp1ngaktSNVX1ruC/uWCp7F55K2fl13z1jW2qcqXymjFnrvcByVH3/PCvv7lHW2XyAvfRQ57Q5i3b/fePW7otNoeAPW7c9D+t2/CdypctIevv+m+/17demuXNeX2hSpYooj9lzWJPk7Vky5bV8z10Xtkftu9UmZLFzksnAQEEEEAAgVAQIEAPhVGgDQgggAACqRKwr1M3blBXjVp1c1+h3rc/NlX1JGenfHlyqUPL+9Vj4Fg3QZ0FtvZV84T2fahxfZW+tohsorQm7XqoeYfeOhAbNwGblS+QP4+adujlJoK7rcqNqnFrJUvWoF4Pa8XHa9xEaqMnvqi+T7RzHzzYV/IH9uioF+a8LZtArsY/W2jN2rjA2O2YjJXNjL/1h5/8987bhwj31a+tnoPGySZ9q1W/jQ4fPhNUJ1RllUoV1LJJfQ0cOcm1o+59HbVu/SZXtNWD/1LBq/KrZad+bpK49o8Pdun2DQBbYmJiZEG6fdV+yKgpLs9Wvx054ib46z/8WXcPvfU1d64c6v1YG9lkcDap3OrP16nP422teLKXYkUKqWK50urae4SG/jFJnPW/eLFrnGmyK6IgAggggAAC6SgQlY7H4lAIIIAAAgikWOCBBne5icxsx7/cUM59vdq24xcLDF9/YZRs0rXWTRvoo4Uz47O0Yv4MXX5Z3Ffi7Sfa/BnexvtvTfPnJbfcbbfcqHFPdXcT1OXPl8fd8+1Vdd7/zJdfpk5tGuulyU9p1nPDNG/OBFlwG1+w5u03yya1s8neLOiPT7d7v60fNhHc9PED3TcD4vNsMrznRvWRTTq3bN50Va8WF9Qn1a/4fe0xU6YY3VG9svcBwOf21C0N767tJoizCd+Wz39eNonaucZlSxeXtcXt4K3sp8ps4jZrx7tvTFazRvW8VLl7z+1r/dYvmyTO6rSMwPrig/ReXVtbllvMyfaZM3WkatW4xaXZyvo3bdwANymemRQtXNCSnXl8ewLrtszAtkZHRalHl1YaNfhJxU8SN2/RMt1f/+9WlAUBBBBAAIGQFIgKyVbRKAQQQAABBEJQYNSzM2U/6WY/n2ZfcX+0XZMQbGXiTWp6Xz3/1+4TLxWeXH9UmwAAA/NJREFUOTbrfu6cOc760CM8e0qvEEAAAQQysgABekYePdqOAAIIIJCuAvaVc5sUbc6U4RrRv6vy582d4uPbpHF25TfFOwZhh6xZMqve32sEoabEqkhZ+rlX/1O2d8pKR0dFKamZ91NWG6URQAABBBBIGwEC9LRxpVYEEEAAAQQQCLYA9SGAAAIIIBDmAgToYT7AdA8BBBBAAAEEkidAKQQQQAABBC61AAH6pR4Bjo8AAggggAACkSBAHxFAAAEEELigAAH6BYkogAACCCCAAAIIhLoA7UMAAQQQCAcBAvRwGEX6gAACCCCAAAIIpKUAdSOAAAIIpIsAAXq6MHMQBBBAAAEEEEAAgcQESEcAAQQQiBMgQI9zYI0AAggggAACCCAQngL0CgEEEMgwAgToGWaoaCgCCCCAAAIIIIBA6AnQIgQQQCB4AgTowbOkJgQQQAABBBBAAAEEgitAbQggEFECBOgRNdx0FgEEEEAAAQQQQACBMwJsIYBAaAkQoIfWeNAaBBBAAAEEEEAAAQTCRYB+IIBACgUI0FMIRnEEEEAAAQQQQAABBBAIBQHagED4CRCgh9+Y0iMEEEAAAQQQQAABBBC4WAH2R+ASCBCgXwJ0DokAAggggAACCCCAAAKRLUDvEUhIgAA9IRXSEEAAAQQQQAABBBBAAIGMK0DLM6gAAXoGHTiajQACCCCAAAIIIIAAAghcGgGOmlYCBOhpJUu9CCCAAAIIIIAAAggggAACKReI4D0I0CN48Ok6AggggAACCCCAAAIIIBBpAqHcXwL0UB4d2oYAAggggAACCCCAAAIIIJCRBC6qrQToF8XHzggggAACCCCAAAIIIIAAAggER+DCAXpwjkMtCCCAAAIIIIAAAggggAACCCCQhMAlD9CTaBtZCCCAAAIIIIAAAggggAACCESMQLgH6BEzkHQUAQQQQAABBBBAAAEEEEAgYwsQoF/U+LEzAggggAACCCCAAAIIIIAAAsERIEAPjmPa1EKtCCCAAAIIIIAAAggggAACESNAgB4xQ31+R0lBAAEEEEAAAQQQQAABBBAIHQEC9NAZi3BrCf1BAAEEEEAAAQQQQAABBBBIgQABegqwKBpKArQFAQQQQAABBBBAAAEEEAgvAQL08BpPehMsAepBAAEEEEAAAQQQQAABBNJZgAA9ncE5HAImwIIAAggggAACCCCAAAIInCtAgH6uCM8RyPgC9AABBBBAAAEEEEAAAQQyoAABegYcNJqMwKUV4OgIIIAAAggggAACCCCQFgIE6GmhSp0IIJB6AfZEAAEEEEAAAQQQQCBCBQjQI3Tg6TYCkSpAvxFAAAEEEEAAAQQQCFWB/wcAAP//kKUyUgAAAAZJREFUAwBBGObe7rANRwAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_epochs = checkpoints[\"checkpoint_value\"].cast(pl.Int64).to_list()\n",
     "_ics = checkpoints[\"ic_mean_daily\"].to_list()\n",
@@ -618,13 +12789,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09cb5eda",
+   "id": "679431f6",
    "metadata": {
     "papermill": {
-     "duration": 0.028441,
-     "end_time": "2026-09-06T21:49:40.704351+00:00",
+     "duration": 0.190164,
+     "end_time": "2026-09-08T21:38:53.185548+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:49:40.675910+00:00",
+     "start_time": "2026-09-08T21:38:52.995384+00:00",
      "status": "completed"
     }
    },
@@ -648,10 +12819,178 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7a17c1e6",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 12,
+   "id": "1866ebf3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:38:53.417722Z",
+     "iopub.status.busy": "2026-09-08T21:38:53.417026Z",
+     "iopub.status.idle": "2026-09-08T21:38:57.778830Z",
+     "shell.execute_reply": "2026-09-08T21:38:57.777825Z"
+    },
+    "papermill": {
+     "duration": 4.450117,
+     "end_time": "2026-09-08T21:38:57.779391+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:38:53.329274+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Common sample: 187,668 rows on 1,995 dates (each family's own full-coverage count was 1995)\n",
+      "  GBM (Ch12): IC=+0.0546 on the shared rows\n",
+      "  Ridge (Ch11): IC=+0.0432 on the shared rows\n",
+      "  LSTM (lstm_h64): IC=+0.0166 on the shared rows\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "cliponaxis": false,
+         "marker": {
+          "color": [
+           "#1a2d4a",
+           "#C87533",
+           "#0a1628"
+          ],
+          "line": {
+           "color": "#D4A84B",
+           "width": [
+            0,
+            0,
+            3
+           ]
+          }
+         },
+         "showlegend": false,
+         "text": [
+          "+0.0432",
+          "+0.0546",
+          "+0.0166"
+         ],
+         "textposition": "outside",
+         "type": "bar",
+         "x": [
+          "Ridge (Ch11)",
+          "GBM (Ch12)",
+          "LSTM (lstm_h64)"
+         ],
+         "y": [
+          0.04324407887625926,
+          0.05460852591102626,
+          0.01655725052466728
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "margin": {
+         "t": 70
+        },
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 15
+         },
+         "text": "Peak-checkpoint daily IC by family, recomputed on the 187,668 rows (1,995 dates) all three share"
+        },
+        "width": 1000,
+        "xaxis": {
+         "title": {
+          "text": "Model (validation leader per family)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Peak-checkpoint cross-sectional IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+gAAAH0CAYAAACuKActAAAQAElEQVR4AezdB8BN5R/A8d997ZFsMrKjLQnZGQkJyRayyd57772yU0T8KSlFSiUppNBQZGTvTcZr/c/v4V733ffd99z7Vc+5ZzznOc/zOeeee35nvQGBgTfukjBgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtgG4jfbSBAYvUfhSOAAAIIIIAAAggggAACCCCAgCcC9g7QPWkheRBAAAEEEEAAAQQQQAABBBCwgQABejgriUkIIIAAAggggAACCCCAAAIIxJUAAXpcSYdcDmMQQAABBBBAAAEEEEAAAQQQcAkQoLsofK2H9iCAAAIIIIAAAggggAACCNhJgADdTmvLm+pKXRBAAAEEEEAAAQQQQAABBGJUgAA9RjkpLKYEKAcBBBBAAAEEEEAAAQQQ8DcBAnR/W+O0VwVICCCAAAIIIIAAAggggIDXCRCge90qoUL2F6AFCCCAAAIIIIAAAggggEDkBQjQI2/GHAjErwBLRwABBBBAAAEEEEAAAZ8UIED3ydVKoxCIugBzIoAAAggggAACCCCAQPwIEKDHjztLRcBfBWg3AggggAACCCCAAAIIhCFAgB4GDKMRQMCOAtQZAQQQQAABBBBAAAH7ChCg23fdUXMEEIhrAZaHAAIIIIAAAggggEAsChCgxyIuRSOAAAKRESAvAggggAACCCCAgH8LEKD79/qn9Qgg4D8CtBQBBBBAAAEEEEDAywUI0L18BVE9BBBAwB4C1BIBBBBAAAEEEEAgugIE6NEVZH4EEEAAgdgXYAkIIIAAAggggIAfCBCg+8FKpokIIIAAAuELMBUBBBBAAAEEEPAGAQJ0b1gL1AEBBBBAwJcFaBsCCCCAAAIIIOCRAAG6R0xkQgABBBBAwFsFqBcCCCCAAAII+IoAAbqvrEnagQACCCCAQGwIUCYCCCCAAAIIxJkAAXqcUdtnQZVff0tSZ3vWpHQ5CknRl2rKsDFT5caNwBhvxLPFq8jkGe/FeLltOw+Qek07xHi5oRUYl8s6ceq0WS/rf9gcWlXCHLfmq+/lw+WfhTk9ogmz3v1Qnnjh5YiyBZkevK4nT58xdf9+45Yg+aIyoNvnO3M+CDLr3bt3TRubtulh6vrYc+VEt+XRE2fK5Sv/BcnrPhDb6+/jT9dI1TeaS6Y8L8hLVRu4LzpW+ld89qVxvnXrlik/Jt1NgXRCCPz59z8yZtLsEOOjMyLPM2Xk/UUfRaeIaM27Jox9Rmx8X9wrOnbyHHmtbkvJ+WQpsx3/8NNW98mu/o9WrpFqdVrIo4+XkOdLVZNOPYfKocPHXNN1H6n7idBSjfqtXfnC65kxd5FUqdVMcj9dRuq91UFWrfkmRPbde/6VVh37SoFCFaR4hVoyYPgEOXf+QpB8EdU1SGabDZSv1kje+2C5q9a/79wlLdr3NscNau+ptRZw7PhJqf1mO7PuK1ZvLPq7o+ODp2mzFkqRstUl77NlpU2n/vLP3gNBshw8dNRsO7p899SsXa8g+Twd0HpE9vcvNvYJzvrqd/OFMq/JzZs3naOi9dmj/2jznXMW8smqtcbPORzaZ1jti+39Q2h1iYlx+/49aNq89dffYqI4ykAg2gIB0S6BAnxSoHjR52XVsnmy/IPpUr5scZk4fb70HDDaJ9tqp0YlTpRIypYqJqkfThWpaq/9doMsW/FFpOaJbuao1jUqy9UAXIPgLr2HSb48OWTU4J4ysHdHyZwpg4ybMlc+tg7mo1JudOe5c+eOCRyyZc0sH86fIhNH9otukRHOny5tGrONOByOCPOSIWYE/vp7j4yaMCNmCvOSUuJjn6FNX7d+oyRMkFAqvFRCB0NNX67bYILANKkflqnjBkvDujXk2w2bpFGLLnL79m0zz7NPP25+w1Ytm+f6nDttlJlWolhh8xlWR0/2te7UT+a8v0RqVqsoMyYNk2eeLBAiEPxl2+9WAN9UkiVNKuNG9JG2LRrJkaMn5fr1G66iPamrK7PNelZ+/rWcOHna+Dur/o91wmL3P/ul4DNPyGN5czpHR/jp3Iefv3hZJo0eIK9VriBjJ8+WDt0HB5lXg+Uho6fIa1UqyJQxg+TSlcvySs0mogFjkIzWwMRR/VzrXo9nenRqaY2Nm/9jc5/wSsXSkjxZcnkvHk/gxWb74mYNsRQEvFuAAN2710+81S5NmlRSqvgLUq50cRk5qId14NFQFi5ZIWfPXYi3OrFgkbRpUsvKJbPNwY+3e8RlXafPXiCbft4mn3w4S/r1aC/Vq1aQRtZB+3szx8p3qz+UPLlzxAvXqTNn5cp/V6Vx/ZpSvkxxee7ZJ2O9HmVKFjXbSIIECWJ9WcEXoFftr127Hnw0wwh4LPDVyoWy4sOZ0vqt+mHO87l1Jfvx/Hll4ZwJUuPVitK1fXMZbZ2U06u3/9y/mqrBu/6GuadTp8+aMmtVr2Q+w+p88eV3suar9fLlJ+9Ly6b15ZUKpaVv97elW4fmQWbp1nekNK7/ukwZO1CqVS4vb9arKbrPyfJIJlc+T+rqyhxBj+5LIsgSp5MXfrjC7GsTJ07kWu4bNSrLD18tk9lTRkjunI+6xkfUo3dEHT95Spa+N9U6KfKydGjT2DrR2kM+WPqJHD12wsyuQfywMdPk7ZaNpH/PDlL1lZdk8bzJkj5dapm34H8mj3vn6Sfym+MY5zag24z7dLv2OxwOqVHtZXl34TK7NiFEvb1t2w5RwWiO8PX2RZOH2UMRIEAPBYVRIQVeLFJI9KrCvv0HzUS9fblRyy5S4PkKkueZMqL9wW/rm7dgqbzeoK25BbFgiarSudcwOX/hopk/rI7eoqi3vettynqwH1Y+Hb942adSulJdyZb/RSnzSj0ZOHxikCsXmmfLLztEb03U2yXrNe1gzvbreGcKDLwpvQeNMbdIajkv12gsO37/yznZ9enJspyZ9VGAmg3amNsd9fZiHa9t0lut9VZIvVVOzTpbV3tvBrtF7e/d+8xtm1rfp4tVNldf3a/GqLvesqe3b2q5ztuyPv1indRp/La5FVNv93S/5bB7v1Git8rqPDqvpvCu9mmduvYZYW4fLPdqQ+vAZ6kuKkjSda3t0dsQsz72orxYvpboowp6xdiZMXhdneOdn7qM0G751isketvqf1evOrOG+6k/fFNnLZB6taqJ3vkRPPMz1pUvPUALPj74sN56X/vNdmZ7rdWwreugUPMVLv2a9Bs6XnuDpCatu4mu6yAj7w+oud72qoNV32gu6j599kIdNKYRfTd0m1HTBR9+LHobaaGSr5rbqNV43fofpW6T9pLjiZKidbh46bIpVzvBb3HXce4ppty1zLb3HyVRf30UJnPeonLoyHGdJJu3breuLjaT7AWKi7ZF/bTuZuL9jm4jb7XtKbqt6zavbdG23Z8sEX0fnNu/3gY9fOw0ea7Eq/Ky9R3WWzR1fzXXugKqw/kKviRDR081+zC5/08P/B/JV1TWfvODlK1c3+xHylapL1rW/SzmQ/MEfzxE16O2STOot36vtV/XsSa99VqHNXni8NOWX83jD3ortZa1/8AhnTXCdOnyFXN7tXOfotvvkaP3/J0zaz31LhK9BVyd1aLXwNHh3h7ryT4jpvatznpG5jPQ2m9aMUqQWQIC7h3OBN4MDDLefWDlF19LkcLPRhg4zpi3SBrVqyGZM2Zwnz1I/zff/yR6QqB96yZBxgcfCIxiXZ3b53cbNpnvv26HH32y2hSvt9o7t1n93un3z0ywOvp7kSFXYfnI7a6hEeOmm/3PV9/+YOW493/fIePk1dot7g1YXT0B79yf6365/7AJIW7Vt7K5/tfftm83/CSVypd2jYtOz7Ydf0jh556xgu00rmLKlCpq+vVKvfb8tWuP6O+C3kWmw5ocDoeULlFMVq76Ksj3W6dFJcXE719E+wTd7+kxU3jHTxGtDz1ptHvPfmsfuTfcZv69e6/oiSTdTnRfrOv4y3Ubwp0nookRtU/nD2//4NxvazlvNGpnjlu69hmus4mnx2S6by9ZsbY4jz/0GM0UEE7nx82/iC5Pjy/0N71jjyGy44+gx3v6fR09cZbo723wYykt2hPP8L67nvwe6HJICNz7RcMBgQgEzp47b3KkSvWQ6EHhy9WbyJ69B6Rn51bWWe6ecvjwcXnjzbeD/EB+ZR34lirxgsyZNkoa1qlhrnC+3W2gKSe0jgbn1eq2kOeeeVLefWe0JEyYMLRsZpwGcRrwFytSUOZOG20dTFW3DpZ2y/UbD24t/MsKdnWnX7liWRk2oKts/+0v6dJnmJnf2WncuqssW7Fa6teuLnOmjjIHZPr847HjJ51ZzHNwES3LmfnGjUDrhEBHOXnqtHz2v3mSKUN65ySZMvN9c/Dxw9plsmjeJPnyq++l58Axrul6defV2s1Er3zqLX7tWjQSfX65dae+rjxh9WiwXLfWq/LrD59J+1aNrXYOl1+3/2Gyt27WQKpUKivPWVdvVy2bZ275q//Ga2ZaaJ0B1okODQrbtnhTurzdTFZ+vk70x9A97xHrisauf/ZLbetqid42Wq7MizJt1vvyzpxF7tnC7W9Y5zVrneyU3/78O0i+hUs+tq6gVJIUyZMHGR/WwN59B0Sv2layrnKFlSei8Tt37RU9YH2takUZNaSnHDtxSmpZBw7OgLJxg1ryv48/DxLUnD5zTj63rrTVrVU11OK1Pu/PGm+mjRve27jr1T4d4el344MlK+TLdd9Lp7ZNpWypF81t1CPHvyO9BowW3a4H9eko336/SYaPfUeL9SjFlLtzYb/9uUvWWgd8C+dMlB+//kiyZ80s+hzfq9bB/0Mpk8s7E4dKK+sq5NKPVsnAEZOcs4meWHmlZlPRk34dratlsyaPkGxZH7G22z9Nnsh8H7pa3+ur1pX7of27SPJkyUSfNdWg5Iu1662rbY1FvxsTp79rbctfmbKdnevXb0hX68Bw1JAe8vvmNdYJnkJS2zrRtd/DAFnLKfniC2Y/qP3O79fwgd100COHw0eOWSfX2pt6Tx4zQPLnyyM16rcRbY8pJJxOvaYdLa8/pEfHljJmaG85fPSEVHmjufk+uM82/4NlxvabVYusfesY+cQKZma++6F7liD9Ee0zYmrfGmShkRh4vdor8teuvaInsPR7qMHApBnvmtvQn3r8sVBL0nWq22XNVyuFOt058tatW6LlpX74YdETHnowryd+9ESubrPOfL9s+0MezZ7F7KOLlK1uTvDo8+obfvzZmcV8RqWuZkarc/PmLekzeJwM6dtZtv2wSnSfoicGGrfqJgWffUJmTxkpFcuVFD05rb+J1iySNGkSebHIc/Lzrzt00KQtv/xmfk9/tk5YmxFWZ/PWHVLshWfF6jXbgz7C9uor5WT+zLHSqG510e1Svx86PbT046ZfzG9VkeefDW1ypMfdvn1HUqZMFmS+VClTmuEjx+6ddLp9//GFh1KmMOOdnYes/cyFi5esEwoXnaPM55stu0n6nM9LsXKvoReJvwAAEABJREFUy7AxU+Xq1WtmfHidmPj9C2+f4Mnxk34/I1ofejdAurSp5fuNQbe34G3bbl1wuH3ntnR++y3R/UuenI9KvaYdzG9v8LyeDofXPi3Dk/2D5hswfJJUf7WibNu4yjrWaK6jxJNjsnfmfCA9B4yRYtaFo3ffGSMVXiouHa1gW+98MYWE0tHtuU7jDpIzR3aZMXGY9OjUShwOh3WsdjZIbv09OHP2vAzt11UKFXwqyLGUZvTUM7Tvru5/Ivpd1GWQEFCBAO2QEAhLQM9m6tn6keNnyBMF8kre3I+KvjjnovVjuPrj96TZm3WkzutV5aNFM6wDpj3WgfoPrqKWLXzH2uk2M7cH6rNfS96bIqvXrjc//K5M93ucwXnRwgWtA8jR5of//qQQH/pDrAHp0H5dZOywPlL55TLmNkS99Tu127PZF6yr9R8vnilNrOBKbz0cMai7rLGCYp1fC9UDqS+/3iBzp4+S7h1bmCBWb5nMnetRKyhfrFlE83qyLM3sDM7PWjt3Dc7Tp0ujo11JfxhHDOwu+qP6ovXDMnpoL1m0dKXo2XTNNOvdxaL1/+iDd6wA9WXzWMHkMQNFr47vsH5kNU9YqWa1SlKremXR2zrferO26A/oyi/uBSP6THZG60TBw9bJFb2SrClnjmyhFqVB0fuLP5b+Pdub2zmrVS4vS9+fKv/9F/TARq9Kvz9rnLR6q75x03YNtg4iFy75KNRyQxv5/HNPix5kaODrnK5ns/XAu94brzpHRfj578EjJk+2LJnMZ1Q6p06fkY8+mGFuUW1Yp7q5Vf7fg4eNvZbXoPZrcv7CJStYfnDlYbl1NStF8mRSo+rLmiVEeiRzRnmh0NNm/FP3b7XUAFRHePrd0GdbP3x3inneUp+nfME6GJ5mXYX/dOkcadroDfP96/x2c1m1ep0W61GKKXfnwvRgZp71HcqfL5cVXOaS5JbJCGt/Udhav/9bMN3U/e1Wb5rnRfWWTOdjMnqQpQcxa1cuMN9ffa5St6NeXVqboiPzfShbqrjoozi6vep2qSf3vvpmo3xs7Zf0cYfhA7pJhbIlRE+omMLvd/Qq+3Dr5J1+H/WRDF1+vtw5Xd//+9nC/ciYIZ21X7z3rK1+tzQ9+9TjZh5PHGa/t8ScjNLv2WtVKpjvXcsm9URPOplCwuh8/d1Gc9Jz6fvTRb/zb1gny5YvnG4dcJ6W+W4v7dLZCzyWR3QfrHUtXaKING1Yy9q2v9ZJoaaI9hkxsW8NdcEejtRtZcHsCaL75nwFX5JKNZpIgoAEsnLpbEkQxqMdKz77yhyQ16r+SrhLOXL0hHmOXU9KOhwOczBf5/UqovvFzr2GuubVA/7//rtqnRybLg3q1LBORA0zJ6ir12slO//e48oXlbo6Z9aTBT2tk+AlXywsuj/RNG7yHKlvnWCdPHqAucV7uLVt6+/w5HfmizOgLlr4Wdn8870AXcdt+nm76D5s89Z7L8DSEw2//fG3vPB8QbOozVu3SRlru9ATgZXKl5LmjeuK+rrfqm8yunW2/75TCjyWW5IlS+o2NkSvxyNyWYHj3n0HjaFzpl3/7DO9x0+cNp/626w9u/f+qx+utHvvftOvt8hrT5KkiUX3BT06t5QF1knSUsWLWCfIF0jTNt11cpjp1OmzZj1H9/dPv2d5rf2ILkj3B5qc+wRPjp88XR/PWPsZXQ+6nLCSrnfdVnSbqWUdI8yaMtzaFqqbdoY1T0Tjw2ufzhvR/kHzaNKTzG/Wqyl63PN4/jzi6THZuClzzH5y/Ig+ot+vYf27Setm9WXSjPlabKjp1x07RU9U6DyvVi5nTtrqoym6vbvP8EqFMuLMM2fqSGsbzyOffP6VK4unnqF9dz35PXAtiB6/FyBA9/tNIHQAPROpt2pmzF1Y3mzZVfLkyiEfzJ1ozsJvtM6cv1KxjAk0nXNnSJ9WNLjWHxbnuHXrfzRnah8vXFG0rEIlq5lJzoBKBxwOhxWwHxe9cl7KuhKlz625H2BdvHRZnEnPPOs823/baQLnatZOVofDSk8+/pi436JY8JknTNaDh4+az42btlpXQLKaZ4PNiPsd3UFv/uXewY0ny3I4HHL9/pVzreun/5tjrpTfL871UaZUUXOA6ByhV531drpffv3DjNKrHHqVVIMLM8LqvP5aJUn1UEpRc2swzP8LFQz6bHMuKwA/eOhYmPnDmqBXs/WAToNUZ56UKZLL68Ge2dTARg9g9YqR3jan61df5rP/wBHRHybnvBF9vtXoDdGX16mD5tWrrHlz57CuABXSwThLTxTIZw6AnQvMnCmDaFC9ddtvZpSebKmmJys+XmWGtbPof59ILSsoSmpdsdLhyCRPvhta3svWwbLD4dBek5564jF5LE8ucQb6OlLH6UkefT5Thz1JMemuL+PSwMG5XD1RpY9T1K997/vuHK9t0RN+v9y/s0NvJa/4UskwD/Aj8314uXxJ52LMwV7unNnlxaLPBQnW1Mn53XdltnpeKv2i1b33v8PhkLKli1pXH3+/NyIaXU8d9Eps9VcryENuVwUb1n0twiXr1dACVuCtwbQzc/ZsWUT3Kz/9/KtzlPksZF1tNT33Ozmtq0j/Hjh8fyjyHzGxb438Uh/MobeWd+o5ROrUrGqeQ9cgVU+mNmrRVXT/9SDng77ln3xu9vUaXDwYG7Lv5q3bZqSeaNIXO+rBfJ9u7ayTzc3NbeNHj50w029aV9r15NTQ/l2kc7u3RE8ELbNOkOhJu7nvLzV5tBOVuup8zqRBjLNf27bF+m0qX/bBNqvTGtZ5TXQfoLff6nCRwgVFl6uPIun3LbkVRLd8q565M0DL0N8TvRpdvOi9/ezjj+WV760r/wOHT/T4yuqp0+esY4CgJ6F12VFNLZrUFT020McrNFDetuNP6dp3hOj+NVGie3fT6e+5Bpojxr0jeifBhYuXZNqshfLt95vMYvXlgtqj+fR4RU806HPqegeTXj3+6tuN8vMv9/bpmi94iovfP7WP6PjJ0/Whv0snT50J3owgw+etCxWDRkySUi/XMX9JRH+rP1z+qYS2LwwyYzQGIto/OIuuYJ00dfbrZ2SOyerWCrqPrFS+tPyy7fcw/9pQvjw5RU8IN3+7tznR7rw7TpfrnkqVKOIadDgcUvDpJ4L8dYjIeLp/dz39PXAtnB6/FyBA9/tNIHSA4vff4r764/ny19avZM2K90yQrrmPHT9hbvfVHb170md49RZLzaNXQus26SCP5c0lejZar27rC7x02nnrSqR+atJA79vvfxK9atG2RaMgAaxO12dsnalQyXtXVY8eP6mTRIMo0xNG5+FUKYNMSXY/kHLe5nbs+Clrx3tU3Nug/XpV5tD94NaTZWkb9v17yJz9bWydDU6T+uEgy3UOpEmd2tlrPjXwdjgccurMvR/YY1a70qZJZaY5O/pc5SOZM8ixE/fa7Bwf/PPhh4K2NUHCBB7dzhe8HP2xdzgcEvwgNlPGDEGy6vsF9Dmtl60AUm/H/+x/c2WYdRZbD/ouXHzwPHSQmUIZ0FuPNbDUW5E1SP9o5RrralT1UHKGPSpXznt3Axw5Fr5R2CWIpHk45DpLmzqV6IGic7761lV0vePi9JlzogeP5kp/rXvbpDOPJ5+efje0LH2kRD+dKUniRJLSLZDT8TpOP/XZTP30JMWEu3M56dMG3a6PnzhlJukzz/p9ciY92afbx5Gj904caaCTIX3YB/iR+T6kTvWQWaazkyRxYtETS+L2L0mSxNZ34qrbGDH7G716I27/9Huqb6Z2GxWlXk8d9DuXMUOGIMvQq/la3yAjgw3o/kvzBRst+l09ejTod+Ghh4L6JLSuMjtPeAaf35PhmNi3erKcsPL0GjBGShYvLFPHDRK966B968Yyb/po0Wf5nXcOuc/7x1+7Zfeef0VfrOU+PrT+TBnTmdFlSxYT95Ol5UoXM+P/uX/1NmOGtGa4fJni5lM7epJFr3bv3X9QB02KbF3NTPc7enVa0/1B0SvE+nuTJk3Q/ZXzt/DI/ZMHekeInujeYl0x37x1hzlZpS9M00B9qxXE/PzLDtHAQ+urZTe1TpSOH9FXPv/yW3mpagPzbPrCJSuCXM3WfO5JT7Y59z3u46PaX8C6Gr9q2VzRK8KPPVdOqtdrZZ30qCi5rJNJ2bM+4ipW7yTSE9dNWnUTfW/FZ2vWSc/O9+66eTTbg3yuGe73OIOlv3Y/uLvh/iTXh34XHQ6337/7U/Q7db/XfETn9++YB8dPnq6PpEmShBmQmopana59RpiTL/pOBX0cTR/DqVermpw7F3sv/I1o/2BVy/yfLm3Q7Vj3aYesCyjO3wznp/sxmT5+pjO/UOY1cU7XT91edLw+yqKfwdOTj+eTLz56V45Zx1n1mnaQoi/VkAnT3g3x4uPgx1JJkyWxfjeuuYrz1FO/t5qcM3r6e+DMzycCBOhsA6EKpLECRb0tSwP14Le56VWa6lUrmmdqdWfvnrp1uPfSmS+/3iD58+WSof27SsM61aVsqWLmhzb4whwOh+iPkeap1aitHLh/u7Izn75F15mWzJ9iRme9/4bc6B5E61VIvVrrXn9n/3uzxnq8LIfDIU8+nlfmTB0hPQaMlq/cXsRjCrnfuXAx6PNxeoCsB1sZ06c3OdT55Kmzpt/Z0enHT5yWrI9kdo6K1c9MGdObgzK9E8B9QXrLmvuwBtQ1q71irhy9YV1F1ttm06YN+mPrnj+s/oetwKrGqy/LMuvq1udffmd+LOu/EfTKa1jzOsfrM6c5Hs0q+ly3c1xkP0+fCequ8584eUbUQ/s1VXyphOg6WvrR57LUupKu247eNaLTIpM8/W5EpszI5o0J97CWqUYaHOhbr53fJ/dPvUNF582aJbOcPnPv3RY6HDxpObH9fdDvV/Bt/fyFC0FO/ukVUT2x4F4/vWPGfTi0fq2/Jw66jQXfN+hJRL3iElq5znFZHslobmd3Djs/9f0X2bLFzf7Cuczgn57sW4PPE5lhvVKc3zr56z7Pk9YBuA7r/lI/3dPKVWtFT3jovsZ9fGj9euJU8+q6c5/uHqzr+IzpM+hHkCBeRySwTo7qpzNFtq7O+UL7fCRTRnNS6WSwq6bO30JnIKsnp/SdI1t+2S5btm6TYi/cu1Kuf+FBA3ZNRV94NsgiGtWtIds2fi7//rlB9K4SfaZ3+Serg+RxH9B9yMXLV9xHRbtfjze+/XyxbP3+M9m97RvzKIaeECnxYmFX2Rr06B0Te39bLz+v/1S+/nSh6O+Tzqt3PbgyBuu5eetmsDEhB/W7GNo+Qct3zx2d37/s2bKYEw+6TwyenMdPuixP1seFi5ckdeqgJ990XmfSk96frV4nHds0EX2vhJ7M0uO6hMG2UWf++P70ZL+RLcu9fduS+VNDPQZV37DaUeyF58zFppP7tkq/Hh1E35szbOy0sLKHGB8dzyzWcavuUyL6XQyxUEb4rQABut+u+qg3vHSJoja/o8wAABAASURBVPL7n7vkmacKBPkTJrrjf6JAXlPw3bv6wpcUpt/ZWfP1987eEJ96+5n+wOobsY+4vYVYd6jOpM/f6ox64KFXvVat+VYHo5zKl3nR3FKnVxG07u5Jr0BowZFZlj7fNW5Yb9EX+Ogtvjq/e1q/YbMJfp3jvrOG9aDPeXu6Pjeoz5W6BwN6V4IG8nq1yDlfVD41yIjogF/Lffapx82B7Lf3bxnUcXfv3pVv1v+kva6kdUyZIplrWHvWrnvwfLYOe5r0mS59Xnju+0vN+wTcb5f2pAw1bNOsoSz56DNzBS34PHoQs3nr9uCjgwzrFTZ95tw58oB1okjHFX7uGeco0bsZ9ETS0o8/My9VatLgDde0yPTcjeR3IzJlRyZvdN3DWlZi6yq/Xm38feffIfYP+h3TwFzn1X7d3vWWWx0OnmLz++C+rODb+voNW6TI8w/W+6PZs4o+b+w+zx87d7kPmmfIdYR7Wzx1KFzoaVlv7QvuWt8zLUPTuvU/6ke4SW9j1iu1eieHM6PuKzZs3Cov3g/InOOj8unpPiO0sj3Zt4Y2n6fjHrWCnH/2HgiS3fl3sHNkzxJkvA7o8+dVXn4pxF0VOi20VLVSOfOCP/d18tOWbSZr/ny5zWf5ssXN56af743XAX1vwK/b/pS8eXLooEmRrauZKYxO0qRJzKNkur90z6InhTNnzCAFHsvjGq3fnx+tOv+0ZbuUuH8rezErQNnw4xbRq+ja78rs1pMm9cOif05O27lnX9Bnvd2yiT4PrvtJ93Ex1a+PbWiwPWPuB5LTOvlazu0xFOcy1OKxvDlF73JauOQTaVAn6C3PznzOz+Ur1pjeJ/LnM5+hdWLy9y/F/Zecuu8TdJmeHD9pPmcKb33ou3v0RLEzb7BP63hDzPsUUqR4cCym9fl2w71HAoLnj8xwWO2LTBnB83qy3yhU8Clzh5/+XutvSPCkJ6eClxt8WE/A1Xi1otR8rZJ52XHw6WEN6y5aj32i4unp70FYy2a8/wkQoPvfOo92i99u2UgSJUog5ao2sM5ALhQNIvVFXw1bdBb9sxm6AA22t/76u3y74SfRHwR90Zm+xEanuSc9ANKkwY9egc6ZI5vUbNDaurJ2zj1bkH4Nznt3bStDx0yVhUtWmFvL576/RGrUby0ajAXJHM6ABvz6DKP+SST9E0x6kKN/fkSvHAwYPsHM6cmytP5y12QXvRugy9vNpWHzLuYA797Ye93TZ86Jvilcn71d+80P0mfwWHmzfk1zVVZz6C3+gYGB5k+iaB4N8nsNHGOdba8geuCgeaKa9PkrDSr0JXladlgHVhkzpBN9PlnrqUGtPsOof25nz/6gB8Mlij1vXpyiJ1M0z5hJs0ME8Z7WtXSJIuYgTG9PrV2jqqezBcmnjmqkJ3hGjJsuur0tXvaptGjfW54pVtkKsI4HyR98QN+2r+tdbTR17DnEHOxWr1ohSFa9uq8B0bnzF6VeJF5k516Ip98N93lioz8i94HDJ5ptMSrLHty3i6z77kdzm6r+yRk1nT57oehb2/XWdi2zndmPJLS+K51Fp+t3r9/Q8eZPyen02Pw+aPma9OTOqAnviH4ftQ66fN3W2zRvqJNNql61onnpmr7ASIOB8VPnmbaZifc7efPkNH36EjwtR59l1RGeOLR+q74cOHREdNlnz10Q/d4NsOy1blpGWEmf3y9RrLDotqp10+XqeyDSpk1tvsNhzefpeE/3GaGV58m+NbT5dJz+dQhti54g02F94ZoO/717nw6a1Lp5A9GXl+q60Gn6O9O+6yB5LG9O0Tedm0z3O/rMth7M16z28v0xQT+0fP3t+Nnt2WS9kqnrpG6T9vK5dSJY/yylXmlrULu6a3+tJ6N1uHOvYaJvk9d9zusN28r5ixelbfNGroVEpq6umcLp6dG5lehV0dnzPzTfG/3NnTF3kXR+u5l5Xts5a5HnC4q+NVqH9USzfhZ7oaCZR68EOk9C6/hOPYeKPvvt/B5oe3bv2W+dYCuik0NNL1pl6fdB/9yaewY9SaHrRJM+zqZ3qGi/Jr0zxJk3+P5Ffx+HjJoi+hdE1Fxdx02ZK9ouh8PhnE30Tx7qX2TQ/cVc63dfXxCYOVMGeb1aJVcefWO7tkdPAK5eu1569B8tQ0ZPkaqvvGT+zJ4rY7CemPz9C2uf4Mnxkyfr49atW/LX7r1SrPC9uyOCNcUMalCo+/l3Fyw1t8IfPHRUWnboIxcj8RiaKSiUTt48Oc3Y4Ps8MzKKHU/2G3pBZUCvDuZY6u2uA813QY9B9RhO/4RaWIt+74PlohdP9C/j6Lao35vPvvha1CeseYKPj66nJ78HwZfJsP8KEKD777qPcsv1zPXalQvlhULPWgeuy8xB+Lgpc8zLq4pZZ+i1YL2VbtTgntJ38HjJnLeI+fNQ788ep5PCTHpAunjeJEmbJo3UtILtc+cvhJm3jXWANmpQD5kzf4k0aNZJFv/vM0mZMrkkTZIkzHlCmzB9wmB5u1Vj0av7+jK89t0GWmed70pNtz/FE9ll9erS2jqbX13eePNt2eH29nV907I+Y/Va3ZbSrkt/eblcKRk7tJerWhnSp5XVH78v+/49KFqXDj2GiB5EzZo8wpUnqj165fetN98QDbz1hIRebQ6rrGH9u8orFctIoxZdJM8zZc37Abp3bBUke4c2TaRC2ZJSodqb5m+Y6oHgpNH9g+TxdMDhcIg+y67tf9U6gPJ0Pvd8etZ87coF0rxxHVn91Xrp0H2Q6I/3/gOHzZ8iql2zinv2EP3PPfuElClZzGxLdayDcn3ZkL4BXE8cuWfWW+n1RMArFUuL1td9mqf9UflueFp2ZPI5HOG77/jjbzloBY6RKdOZV283/mbVYnPXwfAx00W3OQ2oqlR6SdKnS2uy6YGWPr6i39tWHfuadfbHzt2iV880g/rG1vdBy9ekL58aYe1HuvYZbk7w/bRlmyxf+I7kzvmoTjaprRWsv1GjsjR/u5foCy/3/3tIurRvbqY5O/o4z8zJw0RfcqjBXv+hE8wkTxz0lkz9Kxibft4u+uyt/ok4/ZNpDwd7h4YpMFhH/zKGXmFs07m/6Buq9a3iXyx/17xJP1jWSA9GZp8RWuGe7FtDm2/KjPfM9tK1z739nv55M91+Jr3zriu71u29mePk629/kPpvdZSuVt4nCuSTVVbbnVf2nJlXfv6VPJzqIals7dOc49w/z5w9J3oyVN/w7Byv603/FOYZ64RJy459RA/m9c9eThjZ15nFfE4dN9A6gVpRNEjRfY5emft82TzR7cFksDqRqauVPcL/9Zn3RXMnyZLlq0TbridHe3VpI/o75T5zqeKFzWDxos+J/rbqQMFnnjB3e+h3LLMV1Oo4Tc8+XUD2Widh+wwaY/b7Gzb+LPoXGMILXgoXekby5HpUvv9hixbhSsdOnDTrT9eZnhzRF61qv6bDR0+48gXfv6jdduv3UoPTNp37mfd86BvH36xX0zWP9ugJ8VnvLjYvoJ02+wN55qn85rbl5Mkf3NH1uHWVfP0Pm6S29RusAemWrdulR6dWMm/aaC0i3BRTv3/58+WSmaHsEzw5fvJkfejL5nQfWuGlEuG2R+9OTJQ4kfVbXkaKlqspWR7JKPrG83Bn8mBiWO3zYNZws7j2G19/b46DQjsm021CXwK4yzqJ1K7LANHf7L//2SsN69YIs+x8eXOJ7h+nWSeK6zXtKDPmLZYenVpbqWWY84Q2ITqeul+J6HcxtGUyzj8FCND9c72H22p9IdzieZPDzaO3XemP5/YfP5cLR36TXzZ8JoP6dLJ2/g/+1JUeMGz+doWZrp8abGre6m5XJX/7abV0bveWa1n6I6uB1savl1uBemrX+NB69Gq15juye5OsX7NE9KBFf/w070z9YXw/6LNFemutLl/roXk06TNBvbu2kU3ffCz6XJI+1zZt/GDz9y91ujNFdln61tiDf20UPSBylqF1WzB7vJw/vEP2/f69mB19okTOyeYzv/Wjvso6wDuw8wf5Y/Mak0efuTMTrU7mjBmMpz7Tbw1aB0g5zLCeedZhZ9I/q6IH/c7hRNZyhvXvJs711adbO+ekEJ+ad9Ko/qIWWletc7cOzc3LAp2ZUyRPLnqwumvbOrN8XVad16uafn2zrOYLXle9Sq3+GqDqdGfSt6nqbcYaROuynePD+9Ry9E93uefRAzz9U1s/fv2RHPr7R1MXfZ6x8stl3LOF6HduK/qn9g7v+kmO79kiKz6cKbq9BM+stzrrrbT1a70WfFKow1qG1tV9m9OMUflu6Hyjh/QyB6Pa70y6Legy1FvHvf7aK6btzoPyqLjr1Zlft/8pTRrW0iLDTE670DLowYi+GHL39m9MffR7rc9C6npy5tc6L5g9Qf7+5WvZs+M70ZcNav2d0yP6PuTJFfr2v2Ht/2RAr47OYsynbvM/rfvY9Lt39Er0zp/XytmD22T96iXWVcMX3CeLXjVRd62f5pkxaajotqL7LveM9d94TX74apkpR7/DzmmeOOiJze+++NDMqy/lfKVCabOP0P2Os5zQPvV5aX05ms6j+xT9Hj4a7BZvraf7PlbL0e/qmQNB3/Su492TfhdD22fMjOF9q/sytV/L1+05eNI/eaTTnUmviOs2pfv/HT9+IbpedFt3Tnd+6oli3Rdre5zj3D9/3fGnuUMp+HdU91O6/9D9wdbvP5OBvTuG+IsD+h3T3wvdV+s+R1+GGnxfrMvytK6a15k0CNFlO4fdP3Wfpr952vYt330i+pI89+nanzZNavO9W/7BDB00SU84Hv1nk3nG24y432n2Zh3Ruusz6Gql+7/gf37qflbXh8PhkDfrvy7BX8rn/E4GX386rN9nLSC0/Ytuy1oHzaft0u9wvVrVNHuQpCc8/tn+rWnb75tWi+4/9HjEPZOeUNNjEi1L26tl6Ylz999S9/zu/bqdxMTvn5YZ1j5B6xve8ZMn62Pl519L/drVzCNpuqywkp5s1OM5NT2x92fRk3+6LauJcx49XtF9r3O4ZrVKxtc5HNZnaO3T7+/SCI69nNtIaN8VT4/J9K+qfLNqkWi79NhNn0mvGcZdMlp/fXmj/tld3cfrNrHusw/MSS39Tuj0sOoU/FjKE8/wvrue/B5ofUgIEKCzDSCAQLwI6EGa3mqmt4/qLait32oQL/XwZKFnzp43t4b2GDDKusKbU6pUKuvJbF6ZxxN3veqVPdsj8uor5byyDVQKgZgS+PmXHdKpXdOYKs6vytE/jfbT5m3y9+69kWo3+5dIcYXIrL9Heqt2h9ZNQkxjhFcIUAkEoi1AgB5tQgpAAIGoCFz576q5FVJf9vfOhKGit49HpZy4mGfL1h2mrv/9d83ctug86x4Xy47pZXjirlc29K4Xh8MR04unPAS8SkCv9rnfteFVlfPyyuijRdPHD5Hgb5WPqNrsXyISCn+6Pno0dnhvcX9MIfw5mOpbArTGHwQI0P3QuxxOAAAQAElEQVRhLdPGeBcI7TbTeK9UPFdAX8CntyBqIKi3JMZzdcJdvL5cSOuqty4XfPqJcPN6+0Q7ucemZXi3IcbmcikbAV8SeLVyOdHHbHypTd7eluefe1r09nJvryf1s6kA1fYKAQJ0r1gNVAIBBBBAAAEEEEAAAQQQ8F0BWuaZAAG6Z07kQgABBBBAAAEEEEAAAQQQ8E4Bn6kVAbrPrEoaggACCCCAAAIIIIAAAgggEPMCcVciAXrcWbMkBBBAAAEEEEAAAQQQQAABBIIKuA0RoLth0IsAAggggAACCCCAAAIIIIBAfAnERoAeX21huQgggAACCCCAAAIIIIAAAgjYVsCGAbptrak4AggggAACCCCAAAIIIIAAAmEKEKAHp2EYAQQQQAABBBBAAAEEEEAAgXgQIECPY3QWhwACCCCAAAIIIIAAAggggEBoAgTooanYdxw1RwABBBBAAAEEEEAAAQQQsKkAAbpNV1z8VJulIoAAAggggAACCCCAAAIIxJYAAXpsyVJu5AWYAwEEEEAAAQQQQAABBBDwYwECdD9e+f7WdNqLAAIIIIAAAggggAACCHizAAG6N68d6mYnAeqKAAIIIIAAAggggAACCERLgAA9WnzMjEBcCbAcBBBAAAEEEEAAAQQQ8HUBAnRfX8O0DwFPBMiDAAIIIIAAAggggAAC8S5AgB7vq4AKIOD7ArQQAQQQQAABBBBAAAEEIhYgQI/YiBwIIODdAtQOAQQQQAABBBBAAAGfECBA94nVSCMQQCD2BCgZAQQQQAABBBBAAIG4ESBAjxtnloIAAgiELsBYBBBAAAEEEEAAAQTuCxCg34fgAwEEEPBFAdqEAAIIIIAAAgggYB8BAnT7rCtqigACCHibAPVBAAEEEEAAAQQQiEEBAvQYxKQoBBBAAIGYFKAsBBBAAAEEEEDAvwQI0P1rfdNaBBBAAAGnAJ8IIIAAAggggICXCRCge9kKoToIIIAAAr4hQCsQQAABBBBAAIHIChCgR1aM/AgggAACCMS/ADVAAAEEEEAAAR8UIED3wZVKkxBAAAEEEIieAHMjgAACCCCAQHwIEKDHhzrLRAABBBBAwJ8FaDsCCCCAAAIIhCpAgB4qCyMRQAABBBBAwK4C1BsBBBBAAAG7ChCg23XNUW8EEEAAAQQQiA8BlokAAggggECsCfhNgL5s5Vpp1KaPNG7bTzZs2hYq6Jmz56V9z5HSrMNA6Ttsily7ft2Vb+euvdK0/QApWbmxVKnbTm7fueOaRg8CCCCAAAIIIBAzApSCAAIIIODPAn4RoB88fFwWLl0lsycOlLGDu8iICXPk+o3AEOt9yuzFUqzwszJ/2lBJleohWbx8tcnz39Vr0qXfOHmtUhlZt3KezBw/QAIcDjMtUaLEQsLAk23AbDBWx5O85GGbYhtgG4jMNmDtWsz/kZmHvH66jXHcwnFbJLcBs3OxOuwz2Gd4ug1Ymwv/R0PALwL0jZu3SZkShSVF8mSSOVN6KZAvl2zd9qcE//fjlh1S9eVSZnTViqVk45btpv/7n36Rxx/LLa9XqyBJkySWHNkfEYfjXoBuMtBBAAEEEEAAAQQQEAgQQAABBKIn4BcB+umz5yRL5gwuqWxZMsmpM2ddw9qjV8k15k6TOpUOSvasmeT0mXOm/9jx0+azfose5vb2hf9bZYbpIIAAAggggAACCMSZAAtCAAEEfF7ALwJ0XYuOgAdNdThCv/odECTPg/x3796R4ydPyehBXWXhjBHy/Y+/yK87dmqxcvXqVZIfG1y7dlU8TTdu3BBNnuYnn+e28WXF9/+qX+//4mu7C225N25ct/Yv1z3eH4VWBuOu2tqP/dHVGNgf2beM2Pz+3uD4xev3Dd72/TdBEp0oCzyIQqNchPfPmCFdWrlw4aKroufOX5CM6dO5hrVHb3+/ffuOBN68qYNy1sqTIX1a058ubWp5/LE85tb29OnSyNNP5JXd+w6ZacmSJRWS/xokSZJUkniYEiVKJJo8zU8+z23jy4rvvv9+93Xdx9d2F9pyEydOLJpCm8Y479+XxMQ60m2S5OX7pFg8ZoyJbSisMvTYRVNY0xkf//sYb/vumyCJTpQF/CJAL1mskPyweZvcCAyUc+cvyl+790vRwk8btO2//y03b94y/cWLFJR16zeZ/q+++0lKFi1o+ktZ8/+z74Bc+e+qKeOPv/ZKgXw5zTSHI0AcJHH4qYHedUEKEH818Nftnnbf2+9703bvXCfeVCfqErf7Ruc2wOe976e/Oej3jRS33zlv8va27d0ESXSiLBAQ5TltNKO+1K1m1fLSvOMg6dx3rHRp11gSW1cztQk9B0+Si5cua690btNQVq3dYP7M2qHDx6Vh7apmvF5Jf7POq9Ky8xBp0WmwlC9TTAo987iZRgcBBBBAAAEEEEAAAR8XoHkIIBBHAgFxtJx4X0ydGpVk0axRsnDmCClT/HlXfb5eMUf0tnUdoZ8zx/c3f2Zt5IBOkixpUh1tUpWKpWXJ3DHywcyR0qBWZTOODgIIIIAAAggggAACCERXgPkRQMAp4DcBurPBfCKAAAIIIIAAAggggIAfCdBUBGwkQIBuo5VFVRFAAAEEEEAAAQQQQMC7BKgNAjEpQIAek5qUhQACCCCAAAIIIIAAAgjEnAAl+ZkAAbqfrXCaiwACCCCAAAIIIIAAAgjcE6DrbQIE6N62RqgPAggggAACCCCAAAIIIOALArQh0gIE6JEmYwYEEEAAAQQQQAABBBBAAIH4FvDF5ROg++JapU0IIIAAAggggAACCCCAAALREYiXeQnQ44WdhSKAAAIIIIAAAggggAACCPivQOgtJ0AP3YWxCCCAAAIIIIAAAggggAACCMSpQIwF6HFaaxaGAAIIIIAAAggggAACCCCAgI8J2CVA9zF2moMAAggggAACCCCAAAIIIIBAUAECdONBBwEEEEAAAQQQQAABBBBAAIH4FSBAjwt/loEAAggggAACCCCAAAIIIIBABAIE6BEA2WEydUQAAQQQ8B2Ba9evS/8RU6Vhq57SqHUv2bR1R5iN++nnHSZPk3b9ZNDoGXL9RqDJe+nyFSlcrk6Q9Offe8009077nsOlSIV67qPk5Omz0qnPKClVpbGZtmjZqiDTGUAAAQQQQACB2BMgQI89W18pmXYggAACCMSCwMKln8m23/4KUfKcBR/JjcBAWTxnrAzq2U56D5kk/129FiKfBuG9Bk+Uwb3elgUzRsiNGzdk/qIVrnwpkieTX75d5kpPPZ7XNU17Pl3zraRMmUIcOnA/3b5zR9p1HyYZM6STTz6YIj+uWSRlSrxwfyofCCCAAAIIIBDbAgTosS1M+REIMBkBBBDwT4FDR47J+YuXQjR+3fpNUrfGK2Z8vjw5JF/uHPLDpl/NsHtn/cat8nj+3JI396Nm9OvVKsi67zeZ/og6p86ck6Ur1kjHVg2DZN1kXZG/eu269OrUXNKnSyOJEiWU7FkzB8nDAAIIIIAAAgjEngABeuzZUrI3CFAHBBBAwEYCd+/elVOnz0qO7Flctc6eLbMcP3HaNezs0VvRs2d5EDzrPMeOn3JOlmvXb0jJyo3k1frtZNqcxXLz5i3XtIGjpkv/bq0lcaJEctc1VuTw0ROSybp63rbbUClZ5U3RW+APHj7mloNeBBBAAAEEEIhNAQL02NSlbJ8XoIEIIIBAZARGTZrrei585epvpdfgia7h9T9uNUU5HA5xBDz4eQ5wPOg3Gdw6jgCHayjA4RAN8HVE8uTJZPWyWfL9FwulT+eW8sPmX2XeBx/pJPnk83Wit7s/WSDoLe868c6dO/LP3gPydvP6svajOeb29t5DJ+kkEgIIIIAAAgjEgUDYv/pxsHAWgQAC4QowEQEEfEygT5eWrmfCa1QpJ2MGd3UNly3xgjgcDsmQPq2cPXfB1fIz587LI5kzuIadPXql+9z5i85BOWPNk+3+7egJEySQ9GlTS4KAAClR9DlpXK+6/L7zH5N33feb5f0PV5oTA6/Ubi0alOsL5Y4cO2munmfLmkkKPl1A9Bn2SuVKyJ59B00eMzMdBBBAAAEEEIhVAQL0WOWlcAS8WYC6IYCANwqUL1NMPvlinana8ZOnZeffe6VksUJm+MDhY+K85bx0icKy449dcuzEvdvaP12zXsqXLmby6QvkTI/VuXb9unxvXZ1/1gq6rUF5Z1x/10mBL5fPlgAriNeXyWXLkklKFHtOLl+5KgcOHdWssmHTr/JYnpwmjxlBBwEEEEAAAQRiVYAAPVZ5KRwBPxag6QggECWB1k1ry4WLl6VBy57SY+B4Gdavg6RMkdyUtfTj1bJs5ZemP3Wqh2R4v47Sc9AE0T+zdu3adWnW6HUzTf/8ml4V16Tl5Mn1qLRs/IaZFl4nWdKkMmpAZ+k7bIr5M29ff/eTjB3SNbxZmIYAAggggAACMShAgB6DmBSFAAJxJ8CSELC7QP/ubVxXvN3bokHy6IFd5MO5Y2XR7DHy4gsFXZN7d24hPTo0cw0XL1LQ5FkwY4QM6d1OkiZJbKa9Ur6k6yr5Jx9MlTZN65jb3c1Et46+qf3ndUvdxoi5vV2XrX/mbcqoPpLN7UV0QTIygAACCCCAAAIxLkCAHuOkFIgAAj4gQBMQQAABBBBAAAEEEIhzAQL0OCdngQgggAACCCCAAAIIIIAAAgiEFCBAD2nCGAQQQMDeAtQeAQQQQAABBBBAwJYCBOi2XG1UGgEEEIg/AZaMAAIIIIAAAgggEDsCBOix40qpCCCAgO0ELu37RbwgUYcorIfL+38VTaw/+27DttthUGEEEEAAgVgRIECPFVYKRQABBOwn8PfsNuL7yTfbuOfdDqKJ9Wff9Sv8QwABBBBAwBIgQLcQ+B8BBBBAAIEYEaAQBBBAAAEEEEAgGgIE6NHAY1YEEEAAAQTiUoBlIYAAAggggIBvCxCg+/b6pXUIIIAAAgh4KkA+BBBAAAEEEIhnAQL0eF4BLB4BBBBAAAH/EKCVCCCAAAIIIBCRAAF6REJMRwABBBBAAAHvF6CGCCCAAAII+IAAAboPrESagAACCCCAAAKxK0DpCCCAAAIIxIUAAXpcKLMMBBBAAAEEEEAgbAGmIIAAAgggYAQI0A0DHQQQQAABBBBAwFcFaBcCCCCAgF0ECNDtsqaoJwIIIIAAAggg4I0C1AkBBBBAIMYECNBjjJKCEEAAAQQQQAABBGJagPIQQAABfxIgQPentU1bEUAAAQQQQAABBNwF6EcAAQS8SsA2AfrtO3fk+MnT8tvO3bJ3/yG5eOmKV0FSGQQQQAABBBBAAAEEggowhAACCEROwOsD9JOnz8qw8XOkQs2W0qbrMJk250MZMHKavNG0q9Rp1k1Wr/shci0mNwIIIIAAAggggAACviBAGxBAwOcEvD5A79h7lBR8+jFZ+9Es+XTxVJk3ZYgsmTdOvl4xR8YM6io///qnLFr2hc+tGBqEAAIIIIAAzYk5WwAAEABJREFUAggggEB8CrBsBBCIewGvD9DnTxsm1SqVlcSJEoXQyZUjqwzu1VZqvlouxDRGIIAAAggggAACCCCAgNcKUDEEEAhFwOsD9BTJk4VS7aCjPMkTdA6GEEAAAQQQQAABBBBAwHcFaBkC9hTw+gDdybpx83Zp2XmIlKrSRF6s1MiVnNP5RAABBBBAAAEEEEAAAQTiRICFIBBLArYJ0N9dtEK6t28i6z9/TzatXeRKseRCsQgggAACCCCAAAIIIIBAvAiwUP8VsE2AniljOsmfN6ckCLBNlYV/CCCAAAIIIIAAAggggICXCVAdLxawTbSbLm1qWfH5Orny31Uv5qRqCCCAAAIIIIAAAggggIA/C9D26AjYJkBfsWqdjJv2vlR8vZXr+XN9Fj06jWdeBBBAAAEEEEAAAQQQQAABGwn4eFVtE6C7P3fu3u/p+lm2cq00atNHGrftJxs2bQt1tjNnz0v7niOlWYeB0nfYFLl2/brJt3f/oSAnBbr0G2fG00EAAQQQQAABBBBAAAEEEPAdgfhuiW0CdIW6e/eu7D9w1CTt13GepIOHj8vCpatk9sSBMnZwFxkxYY5cvxEYYtYpsxdLscLPyvxpQyVVqodk8fLVrjzPP/uE68V0k0b0cI2nBwEEEEAAAQQQQAABBBBAAAEPBCLMYpsA/dPV35rb2zv2HiWaXq7VWj77cn2EDdQMGzdvkzIlCkuK5Mkkc6b0UiBfLtm67U8J/u/HLTuk6sulzOiqFUvJxi3bTT8dBBBAAAEEEEAAAQQQQAABBGJbIHoBemzXzq38Rcu/kMG92smqJdNMGtijjXzwv1VuOcLuPX32nGTJnMGVIVuWTHLqzFnXsPb8d/WaOBwiaVKn0kHJnjWTnD5zzvRrZ+fufVKycmNp0Wmw/L7zHx1lkl7JJ90VDDDwz23gjrXt+04yOzU6CCAQLwLR34f6zr7o7l3aEnkDjkPu3sXAWwziZSfqQwv16gDd3TlhwoRSsthzVhDtMKnUi4UkIMDhniXcfkfAg6Y6HKHPFxAkz4P8WR7JKJ8tniprls+UcqWLSveBE+TqtXvPp1+7dlVIGHiyDdy4cUM0eZKXPHbZpq5Z33/fSeHuRJmIAAKxKhD9/b7v7IuuXaMtkTeIvd9NPXbRdI1jXus3P/acfck3VneWflD4gyjUyxubIEGAbNr6m6uWGzdvl8SJE7uGw+vJkC6tXLhw0ZXl3PkLkjF9Otew9ujt77dv35HAmzd1UM5aeTKkT2v6kydLKg+lTGFSg1qVJXPG9HL46Il705KnkOQkDDzYBpImTSqa2F74znjrNmB2anQQQCBeBLx1v0C9+M3SYxdNbAtsC55uA/GyE/WhhdomQO/dqZmMn77A9Tb1ybM+EB3nybooWayQ/LB5m9wIDJRz5y/KX7v3S9HCT5tZt//+t9y8ecv0Fy9SUNat32T6v/ruJylZtKDpd//b6/pG9/MXL0n2rJnNtLA7TEEAAQQQQAABBBBAAAEEEEDAcwHbBOhPPZ5PPnp/giyePcak5e9NkCcL5PWopTmyPyI1q5aX5h0HSee+Y6VLu8aSOFEiM2/PwZPk4qXLpr9zm4ayau0G82fWDh0+Lg1rVzXjV3/9gzkxUKpqU5kwY6GM7N9R9Kq6mRhfHZaLAAIIIIAAAggggAACCCDgUwIB3t6ardv/FL2CrZ+/7NgpZ8+fN0n7dZyn9a9To5IsmjVKFs4cIWWKP++a7esVcyR9ujRmWD9nju8v+mfWRg7oJMmSJjXjdV792+s/fPG+6PSnn8hnxvtyh7YhgAACCCCAAAIIIIAAAgjErYDXB+jvLvpETp4+K/oZWopbLpYWQwIUgwACCCCAAAIIIIAAAgggEEzA6wP0WRMGSJ6c2UU/Q0vB2sMgAiICAgIIIIAAAggggAACCCBgPwGvD9CdpBPeWejsdX0OGz/H1U8PAnEmwIIQQAABBBBAAAEEEEAAgVgQsE2Avmf/wRDN/2vXnhDjGIGA3QWoPwIIIIAAAggggAACCPingNcH6J99uV7adBsm+ufN9NOZmrTrJ7lzZvfPtUarEYi6AHMigAACCCCAAAIIIICAlwp4fYBe6JnHpXmjmpI5Y3rzqf2aRg3sJCP6d/RSVqqFgL8K0G4EEEAAAQQQQAABBBCIqoDXB+jZsmSSF557ShbNHmU+tV9TlswZo9pm5kMAAbsKUG8EEEAAAQQQQAABBHxYwOsDdKf9jcBAWbDkM+ncd4y55d15q7tzOp8IIIBAdAWYHwEEEEAAAQQQQACB+BSwTYA+dOwsOX32vJw5e0FqVi0nKZMnkwL5csanHctGAAEEIiNAXgQQQAABBBBAAAEEwhWwTYC+/8Bh6d6+iaRIkUwqlSsh44d1lyPHTobbOCYigAAC/iNASxFAAAEEEEAAAQTsLmCbAD1FiuTG+tat23L12nXTf/PmbfNJBwEEEEAglgUoHgEEEEAAAQQQQCDWBWwToKdMkUIuXLosJYoUlLfa97fSAMmcMZ3wDwEEEEDA/gK0AAEEEEAAAQQQQEDENgH65JE9JXWqh6RZo5rSt0tLade8rvTs1Ix1iAACCCCAQEQCTEcAAQQQQAABBGwhYJsA3V3z2afymz+5liDAltV3bwr9CCCAAAK2F6ABCCCAAAIIIIBAzAh4fYT7YqVGEl6KGQZKQQABBBBAwEsFqBYCCCCAAAII+I2A1wfom9YuEk11a1aSBrUqy8KZI2T5exOk7Vt1pUaVcn6zomgoAggggAACsSFAmQgggAACCCDgPQJeH6A7qX797W/p0Kqh5MudQ7JlySSN61WTC5cuOSfziQACCCCAAALeJ0CNEEAAAQQQQCASArYJ0AMDA+XCxQcB+fUbgXLu/IPhSLSZrAgggAACCCDgEwI0AgEEEEAAAd8SsE2A3rjua1K3eU/pN3yqjJg4V+o17yHVq7zkW2uD1iCAAAIIIICA9whQEwQQQAABBOJYwDYBetWXS8t704fKc88UkPx5c8isiQOkSoVScczF4hBAAAEEEEAAgZgRoBQEEEAAAQSCC9gmQNeKZ8mcUd547WWTMmdMr6NICMSLwLXr16X/iKnSsFVPadS6l2zauiPMevz08w6Tp0m7fjJo9AzRxzOCZ27fc7gUqVDPNfrIsRNSoUZzKVyujrxSu7VZ1sVLV8z0v3bvs8qZLuVrNJMajTrK8Amz5UZgoJlGBwEEEEAAgfsCfCCAAAII2FDA6wN0/RNrf/y1J8w/tWZDc6psI4GFSz+Tbb/9FaLGcxZ8ZILixXPGyqCe7aT3kEny39VrIfJdunxFeg2eKIN7vS0LZoyQGzduyPxFK4Lk+3TNt5IyZQpxuI1Nmya1LH13vPzy7TKZP22Y3Lp9W+Yvvjdf4kSJpHmjWvLNyvkybUxf2bPvoCz75Eu3uelFAAEEEEAgtgUoHwEEEEAgNgS8PkDXP7H29BP5zJ9a0/7gKTZQKBMBp8ChI8fkvNvLCZ3j163fJHVrvGIG8+XJYf66wA+bfjXD7p31G7fK4/lzS97cj5rRr1erIOu+32T6tXPqzDlZumKNdGzVUAddKXmypJI+XRozrJ8OK3x3OBxmWMt6NNsjpj971szy7FP55diJ02aYDgIIIIAAAj4hQCMQQAABPxUI8NN202wEoixw9+5dOXX6rOTInsVVRvZsmeV4KEHySStf9iyZXfl0nmPHT7mGB46aLv27tRa9Kn7XNfZej962rre4F6/UUO5a/7VvUf/eBLfuaSvA/+Kr76V08efdxtKLAAIIIIAAAuEJMA0BBBDwVgGvD9DLvPqWhJe8FZZ62Vdg1KS55tlvDY5Xrv7W3KKu/ZrW/7jVNMzhcIgj4MHXJ8DxoN9kcOs4AhyuoQCHQzTA1xGffL5Onno8rzxZIK8OhkhJEic2t7h/vnSGpEyRXKbN/TBIniv/XZW3ew6XpvVryIsvFAwyjQEEEEAAAQQQiDcBFowAAghEWSDsqCLKRcbsjN9//p6El2J2aZSGgEifLi1NYKzPf9eoUk7GDO7qGi5b4gVxOBySIX1aOXvugovrzLnz8kjmDK5hZ0+mDOnk3PmLzkE5Y82TLeu9K+rrvt8s73+40pwMeKV2a7lz547pP3LspCu/9ugLESuUKSY/btmugyYF3rwp3QeMk2YNX5c3675mxtFBAAEEEEAAAX8QoI0IIODLAl4foPsyPm2zr0B5K2D+5It1pgHHT56WnX/vlZLFCpnhA4ePyUEr6UDpEoVlxx+75NiJe7e1f7pmvZQvXUwnyTvj+rsC/y+Xz5YA64q8nhTIliWT7DtwWM5fuGTyaTC+bv0meebJx8ywvniua7+xUuu1ivJK+ZJmHB0EEEAAAQQQQCBGBCgEAQTiVcA2AfqhIyekc98xUrZasyBvdI9XPRbutwKtm9aWCxcvS4OWPaXHwPEyrF8Hcxu6giz9eLUsW3nvreqpUz0kw/t1lJ6DJoj+mbVr165Ls0ava7Zwk5Zdv0V3c0Vdn0Hfs/+QtH2rrpnnszXfyeZffpM+Qyeb6Xrrfd9hk800OggggAACCCCAgDcLUDcEEAhfwDYB+tBxs6TaKy9JgcdyyaoPp4m+MKt5o5rht46pCERToH/3Nq4r3u5FJUuaVEYP7CIfzh0ri2aPCfIMeO/OLaRHh2au7MWLFDR5FswYIUN6t5OkSRK7pjl79E3tP69b6hyU5599Qr78aI7rCvuCGSPNbfWaoVGdaq7xesVd08gBnXUSCQEEEEAAAQQQ8GcB2o6A7QVsE6Bfv37DCpSKmOd0NZhpWLuq7D9wxPYrgAYggAACCCCAAAIIIICAHQSoIwKxL2CbAD158qRGw+FwyOGjJ+T6jUA5d/7eM7pmAh0EEEAAAQQQQAABBBBAwK4C1BsBS8A2AXrBp/LLhUuXpf7rVaRBy17y0mvNpOJL9162ZbWD/xFAAAEEEEAAAQQQQAABBMIQYLQ9BGwToLdrXk/0hVtlSxaWH1YvkE1rF0mtahXtoUwtEUAAAQQQQAABBBBAAAHfFaBlMSRgmwC9Ues+8uFHq81V9BhqO8UggAACCCCAAAIIIIAAAgh4vYD/VNA2AfqA7q3k4OFjUuet7tJ94Hj59oef5dbt2/6zpu63dMKMxUKyp8Hk2UtFE+vPnutP19v9ryEfCCCAAAIIIIAAAr4k4EVtsU2Anj9fLunTpYV8uniKlCj6nCz83yqpVq+9F1HGTVUmzvpQSPY0mDznf6KJ9fehbbfhuPmWsxQEEEAAAQQQQAABXxKITFtsE6C7NyrA4XAfpB8BBBBAAAEEEEAAAQQQQAAB2wtEIUCPnzbv3vOvjJo0T6o37CQ/bN4mjetWk1VLp8dPZVgqAggggAACCCCAAAIIIIAAAjEs4H0BehgNHDZ+juTInkWWvTdexg/tLuVKFZGECRKEkZvRCCCAAAIIIIAAAggggAACCNhLwDYB+qLZo6TBG1XMn1qLDjHzIkJMcloAABAASURBVIAAAggggAACCCCAAAIIIOCNAl4foOsb24+dOBWq3cVLV2T89AXywbLPQ50eDyNZJAIIIIAAAggggAACCCCAAAJREvD6AP3Vl8tKpz5j5O0eI+Sdd5fInAXLTRo6bpY0bNVbrl2/IdUqlY5S4+03EzVGAAEEEEAAAQQQQAABBBDwVQGvD9DLliwsy+aPl7ca1pBkSZO51kPBp/LLe9OHiv599NQPp3KNpycaAsyKAAIIIIAAAggggAACCCAQbwJeH6CrjMPhkMIFn5RmVpDeqklt0fRa5ZckQ/q0OplkEwGqiQACCCCAAAIIIIAAAgggELaALQL0sKvPFARcAvQggAACCCCAAAIIIIAAArYWIEC39eqj8nEnwJIQQAABBBBAAAEEEEAAgdgVIECPXV9KR8AzAXIhgAACCCCAAAIIIICA3wt4fYB+9vwF+WffwRAravfeA3L+wqUQ4xmBAAIhBRiDAAIIIIAAAggggAAC3i/g9QH66Mnvypmz50NInjl7QSbPWhRiPCMQQCDOBVggAggggAACCCCAAAIIxICA1wfoe/cfluJFCoZoaomiBeWv3ftCjA9rxLKVa6VRmz7SuG0/2bBpW6jZ9ERA+54jpVmHgdJ32BS5dv16kHx6xb5c9RYyc/7/goxnAAEEYlOAshFAAAEEEEAAAQQQ8A8Brw/QEyZMEOaauHPnbpjT3CccPHxcFi5dJbMnDpSxg7vIiAlz5PqNQPcspn/K7MVSrPCzMn/aUEmV6iFZvHy1Ge/sTHhnoRR6toCIQ/iHAAK+IkA7EEAAAQQQQAABBBDwEgGvD9DTpE4lR46dCMF1wAq606V9OMT40EZs3LxNypQoLCmSJ5PMmdJLgXy5ZOu2PyX4vx+37JCqL5cyo6tWLCUbt2w3/dr57c/dkixZEnmyQD6RuzqGhAACCEQsQA4EEEAAAQQQQAABBDwV8PoAvXWTN6Rj7zHy1Xc/yYVLl+X0mXPy5TcbpWu/sdKycS2P2nn67DnJkjmDK2+2LJnk1JmzrmHt+e/qNXFYV8b1hIAOZ8+aySxL+2/duiXT5i6RDi3r62CQdPPmTYnLFGThDCCAQJwK6L7APcXldz+MZcXo/idOMVkYAggEEbh166ZEJ8XFPoJlxO0xX2S83X+bYrr/9u3boimmy6W8W9Z3PmZSZLaVuMgbZOfGQKQFvD5Af77gk9KnS3NZuuJLqVy7rbzWsKN89NnXZtwLzz3lcYMdAQ+a6nBYkXgocwYEyfMgv97q/nq18pLqoZQh5rpz547EZQpRAUYggECcCdy+fcs6SHmQ7t69I76UQkIyBgEE4krg9u071v4l6smX9kW0JfK/LcF/n2Jy+M6d29axrgbpt6xtlBSTtjFVVlzGIp4sK672m766nAdRqBe3UANxfS585aIpsmrJdJk3ZYjoOE+rnCFdWrlw4aIr+7nzFyRj+nSuYe3R29/1xzHQuiKuw/rn3TKkT6u95lb3YeNmy4uVGsmcBctl4f9WyeRZH5hpSZIkkbhMZqF0EEAgXgSSJEkqSdxS4sRJxJdSnKOyQAQQcAlE91jCl/ZFtCXyvy3uv00x3Z8oUWLRFNPlUl7QY4roeSSR6O5DYnJ+146NnigJeH2Avu/fw+JMV65clYsXL7uGdbwnrS5ZrJD8sHmb3AgMlHPnL8pfu/dL0cJPm1m3//633Lx5y/Tr2+LXrd9k+vWW+pJF7709fu7kQbJp7SKTWjWpLY3rVpPObd40+egggAACCHinALVCAAEEEEAAAQTsJuD1AfrbPUdIeMkT8BzZH5GaVctL846DpHPfsdKlXWNJnCiRmbXn4Ely8dJl09+5TUNZtXaD+TNrhw4fl4a1q5rxdBBAAAEEEAgmwCACCCCAAAIIIBDjAgExXmIMF/jl8lkSXvJ0cXVqVJJFs0bJwpkjpEzx512zfb1ijqRPl8YM6+fM8f3Nn1kbOaCTJEua1Ix377zVoLq0bVbXfRT9CCCAAAIIxLAAxSGAAAIIIICAPwp4fYDujyuFNiOAAAIIIBCrAhSOAAIIIIAAAl4pQIDulauFSiGAAAIIIGBfAWqOAAIIIIAAAlETIECPmhtzIYAAAggggED8CLBUBBBAAAEEfFaAAN1nVy0NQwABBBBAAIHICzAHAggggAAC8Sfg9QH69HlLJLwUf3QsGQEEEEAAAQQQiKQA2RFAAAEEEAhHwOsD9JQpkkt4KZy2MQkBBBBAAAEEEPArARqLAAIIIGBvAa8P0JvWry7hJXvzU3sEEEAAAQQQQMA2AlQUAQQQQCCWBbw+QHdv/85d+2TBks9kzoLlruQ+nX4EEEAAAQQQQAABuwpQbwQQQAAB2wTo8xevlLFT58vK1d/K2XMXrc/v5PDRk6xBBBBAAAEEEEAAAQQiFiAHAgggYAMB2wToX37zg7w7dYhkypBO+nRpISsWTpbrN27YgJgqIoAAAggggAACCPi6AO1DAAEEYkLANgF68uTJJWHChBJ486bcvnNHkiZJLAEOR0wYUAYCCCCAAAIIIIAAAt4sQN0QQMBPBGwToKdIllRu3rwluXJkk+Hj58i0OYvlRuAtP1lNNBMBBBBAAAEEEEAAgdgSoFwEEPAWAdsE6N3ebmqunndp20iyZ8kkSawr6P26tvAWR+qBAAIIIIAAAggggAACoQkwDgEEPBawTYCeO2dWSZE8maRMkVyaNaoprZrUlgzp03rcUDIigAACCCCAAAIIIICA7wnQIgR8ScA2Afrhoydk5vz/SYdeo6RNt2Gu5Esrg7YggAACCCCAAAIIIICAVwlQGQTiVMA2AfrwCXPk4YdTSaM6VaW5dQXdmeJUi4UhgAACCCCAAAIIIIAAAjEmQEEIBBWwTYCe6qEU0qBWZSn6/DPywnNPuVLQ5jCEAAIIIIAAAggggAACCCBgBOjYTsA2AXriRInkwKFjtgOmwggggAACCCCAAAIIIICALwrQppgXsE2Avv/gUanfsqe82bav6/lzfRY95kkoEQEEEEAAAQQQQAABBBBAIJ4F/HLxtgnQu7Z7U6aO7i0dWzXgGXS/3FRpNAIIIIAAAggggAACCCAQUwLeWY5tAnT3587d+72TlVohgAACCCCAAAIIIIAAAgj4rUAUG26bAH3nrr3SfcB4qVK3nUk9Bk2Qnbv2RbHZzIYAAggggAACCCCAAAIIIICAdwl4GqDHe61HTJwrObI/Iu+M7WdS9qyZZdTkefFeLyqAAAIIIIAAAggggAACCCCAQEwIeEmAHnFT7t69Kx1aNZRcObKa1NHqDwwMjHhGciCAAAIIIIAAAggggAACCCBgAwHbBOh37tyR8xcuuUjPnD3v6o+whwwIIIAAAggggAACCCCAAAIIeLmAbQL0+rWqSN3mPVx/Yq1Bq97SqParXsFLJRBAAAEEEEAAAQQQQAABBBCIroBtAvQaVcrJ/GlDpEKZoibNnzZUXqv8UnTbb4f5qSMCCCCAAAIIIIAAAggggIAfCNgmQNd1kS1LZnnjtZdNypYlk44iRVuAAhBAAAEEEEAAAQQQQAABBLxBwOsD9BcrNZI//toj+hla8gZE6hCOAJMQQAABBBBAAAEEEEAAAQQ8EvD6AH3T2kXy9BP5RD9DSx61kkw+K0DDEEAAAQQQQAABBBBAAAFfEfD6AN0JPeGdhc5e1+ew8XNc/fQgEAsCFIkAAggggAACCCCAAAIIxJmAbQL0PfsPhkD5a9eeEOMYgYB9BKgpAggggAACCCCAAAIIIPBAwOsD9M++XG/+tNre/YfMZ5tuw8xnk3b9JHfO7A9aQh8CCAQVYAgBBBBAAAEEEEAAAQRsJeD1AXqhZx6X5o1qSuaM6c2n9msaNbCTjOjf0VbYVBYBXxKgLQgggAACCCCAAAIIIBCzAl4foOufU3vhuadk0exRop/OlCVzxpiVoDQEEPAmAeqCAAIIIIAAAggggIDfCXh9gO5cI807DpILFy85B+Xs+QvSotNg1zA9CCCAgOcC5EQAAQQQQAABBBBAwPsEbBOgX712XVI/nMolmC5Narl85YprmB4EEEDAawSoCAIIIIAAAggggAACURCwTYB+40agHDl20tXEI8dOyK1bd1zD9CCAAAL+IkA7EUAAAQQQQAABBHxTwDYBeuN61aRz3zEyZ8Fykzr3HStNG7zmm2uFViGAAALxJ8CSEUAAAQQQQAABBOJJwDYBeo0q5WTi8J5y+co1kyaP7CXVKpWNJzYWiwACCCAQNQHmQgABBBBAAAEEEAhLwDYBujbg0WyZpdvbjU3St7vrOBICCCCAAAIuAXoQQAABBBBAAAEbC9gmQNdnzjv2Hi213+pmuHfv+Vdmvb/M9NNBAAEEEEAgLgRYBgIIIIAAAgggEJsCtgnQh4ydLVUqlhR9e7uCPJY3p2zctF17SQgggAACCPiCAG1AAAEEEEAAAT8XsE2AHhgYKK+ULyniEPPP4XDInbu8xd1g0EEAAQQQQCBCATIggAACCCCAgLcL2CZAv3tX5NatWy7PM2fPS6KECV3D9CCAAAIIIIBAPAqwaAQQQAABBBCItoBtAvS6NSvJwFHvyMlTZ2X2+8ulZZch0rguf2Yt2lsABSCAAAIIIGADAaqIAAIIIICAPwjYJkCv+nJpad+yvpQr9YJcuvyfTBnZW8qXKeoP64g2IoAAAggggEDsClA6AggggAACXiFgmwBdtbJkzigdWjWU2jUqyS87/pTAmzd1NAkBBBBAAAEEEPBiAaqGAAIIIICAZwK2CdCbth8gV/67KkeOnZQufcfIT1t2yIgJcz1rpZVr2cq10qhNH2nctp9s2LTNGhPyf32uvX3PkdKsw0DpO2yKXLt+3WTauWufVHy9lbxYqZE0addP1qzbaMbTQQABBBBAAAEE4l2ACiCAAAII+IyAbQJ0uXtXUqZILpt/+U2qvVJWxg/rLv/sO+DRijh4+LgsXLpKZk8cKGMHd7EC+zly/UZgiHmnzF4sxQo/K/OnDZVUqR6SxctXmzzZs2aSFQsnycY1C6V7+6YyZfYiV/BuMtBBAAEEEEAAAQR8VIBmIYAAAgjEnYBtAvQ7d+6aoPrX3/6SJwvkMUIBDs+qv3HzNilTorCkSJ5MMmdKLwXy5ZKt2/6U4P9+tK7KV325lBldtWIp2bhlu+lP9VBKeShlCkkQECAPW4G7w1qu1sdMpIMAAggggAACCCAQVQHmQwABBBBwE/AswnWbIb56NcBu2Kq3HDl2Sp5/9nE5efqsJE2axKPqnD57TrJkzuDKmy1LJjl15qxrWHv+u3pNHA6RNKlT6aDoVfPTZ86Zfu1s//1vc4t7/ZY9ZUT/DibY1/EkBBBAAAEEEEAAAW8VoF4IIICAvQRsE6A3b1RTPl4wUT6YOVISJkwoSRInkn7dWnqs7bCufjszOxxWJO4ccPsMCJInKM1zzzxubnF/d+oQGTd1vpw7f9HMef36dYnLZBZKBwEE4kUquxzQAAAQAElEQVTgxo3r4p6uX79mff99J8ULKgtFAAEj4L5viUq/r+2PbNMeL/kdiMo24+k8gYGBosnT/OQLeqwQFx5xGYt4siyzU6MTZYGgUWiUi4nbGQeMnC6pH04luXNk82jBGdKllQsX7gXUOsO58xckY/p02utKevv77dt3xPlm+LNWngzp07qma0+CgABze3ymjOll9957z78nSpRQ4jJpPUgIIBA/AgkSJJQEbilRokTW9993UvyoslQEEFAB931LVPp9bX9Ee+79tnjqEJVtxvN5EkiCBJqC/gYmcPs9pD9+bRLFcTwS0fJ0n0aKukBA1GeNvzl37fk3UgsvWayQ/LB5m9ywzgCes658/7V7vxQt/LQpQ29dv3nzlukvXqSgrFu/yfR/9d1PUrJoQdO/d/8huXrt3hvdjxw7IfsPHpV8uR810+J6h2QWSgcBBOJFQO/ecU9x/f2P7eXFCyoLRQABI+C+b4lKf2zvHyg/fgOwiPyjss0kTJjQ3JUa0bz3gvMEHuWNqCymJ4wVx4i2j7iebnZqdKIsYMsAPbKtzZH9EalZtbw07zhIOvcdK13aNZbE1pUvLafn4Ely8dJl7ZXObRrKqrUbzJ9ZO3T4uDSsXdWMP3ritFRv2NE8g96gVW+p93plSZ8ujZlGBwEEEEAAAQQQQAABBIILMIwAAlERCIjKTPE9z8AebSJdhTo1KsmiWaNk4cwRUqb48675v14xxxVsa9A9c3x/82fWRg7oJMmSJjX5NL/m27R2kWz4/H1pUKuyGU8HAQQQQAABBBBAAAEE4kGARSLgowK2CdD/2XdQrl2/d5v5oSPHpf+I6aK3m/voeqFZCCCAAAIIIIAAAgggEE8CLBaB+BKwTYA+dNws8zKmnbv2yf8+WSuPP5ZLhk+YG19uLBcBBBBAAAEEEEAAAQQQiIoA8yAQpoBtAvRECRNKwgQJ5Odtf0q1V8qY58Ov/Hc1zIYxAQEEEEAAAQQQQAABBBDwPwFabGcB2wTody3lA4eOyaatO+TpJ/JZQyK3b982n3QQQAABBBBAAAEEEEAAAQTiQIBFxKqAbQL0t+pXl9FT3pXH8uSUAvlyiT6TniFd2ljFoXAEEEAAAQQQQAABBBBAAIG4E/D3JdkmQC9TorDMmjBAurdvYtbZY3lyyNTRvU0/HQQQQAABBBBAAAEEEEAAAQQiEPD6ybYJ0D/7cr3oM+e3bt+WYeNmS7X67eXHn3d4PTAVRAABBBBAAAEEEEAAAQQQ8AeB6LfRNgH6sk/WSsoUyWXLL39Ygfp/Mm5oN5k5/3/RF6AEBBBAAAEEEEAAAQQQQAABBLxAINwA3Qvq56pCkiSJTf+23/+S0sULm+fQHQ6HGUcHAQQQQAABBBBAAAEEEEAAAbsLxGeAHim7RIkSyopV62TDT79KoWcfF73V/datW5Eqg8wIIIAAAggggAACCCCAAAIIeKuAbQL03p2ay5lz56VN0zrySKYMcvDwMSlVrFA4rkxCAAEEEEAAAQQQQAABBBBAwD4CtgnQcz6aRVo1qS3lyxQ1unlyZpd2zeuZ/njpsFAEEEAAAQQQQAABBBBAAAEEYlDANgH6zl17pfuA8VKlbjuTegyaIDt37YtBCu8qitoggAACCCCAAAIIIIAAAgj4l4BtAvQRE+dKjuyPyDtj+5mUPWtmGTV5nn+trZhrLSUhgAACCCCAAAIIIIAAAgh4mYBtAvS7d+9Kh1YNJVeOrCZ1tPoDAwO9jJPq3BOgiwACCCCAAAIIIIAAAgggEFkB2wTod+7ckfMXLrnad+bseVc/PX4mQHMRQAABBBBAAAEEEEAAAR8UsE2AXr9WFanbvIe06TbMpAatekuj2q/64CqhSfEtwPIRQAABBBBAAAEEEEAAgfgQsEWArn/zXN/aPn/aEKlQpqhJ86cNldcqvxQfZiwTgegIMC8CCCCAAAIIIIAAAgggEKqALQL0hAkSyNyFH0u2LJnljddeNilblkyhNoiRCPi3AK1HAAEEEEAAAQQQQAABuwrYIkBX3CRJEsnuPf9qLwkBBOJLgOUigAACCCCAAAIIIIBArAnYJkA/evyUNG0/QOq36GGeQXc+ix5rMhSMAAJxLsACEUAAAQQQQAABBBDwZwHbBOhd2r4pU0f3lq5vN5HmjWq6kj+vPNqOAAKREiAzAggggAACCCCAAAJeLWCbAP2F556S0JJX61I5BBDwIwGaigACCCCAAAIIIIBA9ARsE6A37zhILly85Grt2fMXpEWnwa5hehBAAAGfFqBxCCCAAAIIIIAAAj4vYJsA/eq165L64VSuFZIuTWq5fOWKa5geBBBAAIGoCzAnAggggAACCCCAQPwL2CZAv3EjUI4cO+kSO3LshNy6dcc1TA8CCCCAgNcKUDEEEEAAAQQQQAABDwRsE6A3rldNOvcdI3MWLDepc9+x0rTBax40kSwIIIAAAr4tQOsQQAABBBBAAAHfELBNgF6jSjmZOLynXL5yzaTJI3tJtUplfWMt0AoEEEAAAe8VoGYIIIAAAggggEAcCdgmQFePR7Nllm5vNzYpW5ZMOoqEAAIIIICArQWoPAIIIIAAAggg4BSwVYDurDSfCCCAAAIIIOCRAJkQQAABBBBAwEYCBOg2WllUFQEEEEAAAe8SoDYIIIAAAgggEJMCBOgxqUlZCCCAAAIIIBBzApSEAAIIIICAnwnYJkCf8M7CEKtm2Pg5IcYxAgEEEEAAAQQQ8ESAPAgggAACCHibgG0C9D37D4aw+2vXnhDjGIEAAggggAACCHiBAFVAAAEEEEAg0gJeH6B/9uV6adNtmOzdf8h8ar+mJu36Se6c2SPdYGZAAAEEEEAAAQTsL0ALEEAAAQR8UcDrA/RCzzwuzRvVlMwZ05tP7dc0amAnGdG/oy+uE9qEAAIIIIAAAgjErwBLRwABBBCIFwGvD9CzZckkLzz3lCyaPcp8ar+mLJkzxgsYC0UAAQQQQAABBBCIngBzI4AAAgiELuD1Abqz2oePnpCZ8/8nHXqNCnKru3M6nwgggAACCCCAAAIIiAgICCCAgG0FbBOgD58wRx5+OJU0qlM1yK3utpWn4ggggAACCCCAAAI2FKDKCCCAQOwJ2CZAT/VQCmlQq7IUff6ZILe6xx4NJSOAAAIIIIAAAgggEMcCLA4BBPxawDYBeuJEieTAoWN+vbJoPAIIIIAAAggggAAC0RFgXgQQ8G4B2wTo+w8elfote8qbbfvyDLp3b1PUDgEEEEAAAQQQQMA/BWg1AghEU8A2AXrXdm/K1NG9pWOrBjyDHs2VzuwIIIAAAggggAACCNhPgBoj4PsCtgnQ9U+rhZZ8fxXRQgQQQAABBBBAAAEEEIh1ARaAgBcIeH2A3qbbMNl34HCQ29p1nDN5gSFVQAABBBBAAAEEEEAAAQTCFWAiAp4IeH2A3rxRTcmUIV2Q29p1nDN50kjyIIAAAggggAACCCCAAAI+LEDTfETA6wN0va09ZYrkQf60mo5zJh9ZDzQDAQQQQAABBBBAAAEEEPBSAaoVVwJeH6A7IXbu2ivdB4yXKnXbmdRj0ATZuWufczKfCCCAAAIIIIAAAggggAACdhSgzi4B2wToIybOlRzZH5F3xvYzKXvWzDJq8jxXQ+hBAAEEEEAAAQQQQAABBBBAILiAnYZtE6DfvXtXOrRqKLlyZDWpo9UfGBjosfWylWulUZs+0rhtP9mwaVuo8505e17a9xwpzToMlL7Dpsi169dNvu2//y29h06WCjVbSotOg+X7n3414+kggAACCCCAAAIIIIAAAgj4tUCMNt42AfqdO3fk/IVLrsZrMO0aiKDn4OHjsnDpKpk9caCMHdxFRkyYI9dvhAzup8xeLMUKPyvzpw2VVKkeksXLV5uSkydLKt3bN5W1H8+WJvVeM/ObCXQQQAABBBBAAAEEEEAAAQQQiCGBkAF6DBUc08XUr1VF6jbv4fpzaw1a9ZZGtV/1aDEbN2+TMiUKS4rkySRzpvRSIF8u2brtTwn+78ctO6Tqy6XM6KoVS8nGLdtNf34rf/q0qSVBQICULPac3Lx503V13WSggwACCCCAAAIIIIAAAggggEA0BeI8QI9qfWtUKWdd2R4iFcoUNUmvcr9W+SWPijt99pxkyZzBlTdblkxy6sxZ17D2/Hf1mjgcImlSp9JByZ41k5w+c870u3c++fwbyZs7hyRLmtR9NP0IIIAAAggggAACCCCAAAIIREvANgG6tjLrI5mk0DNPmqRBto4LlsIcdFhXv50THQ4rEncOuH0GBMkTkub3nf/I4o9Wy8AerV1z/fffFYnL5FowPQggEOcCcfldj49lxTkoC0QAAZdAfHznWWbcHsPZ1fv69Wuiya71p95xv527dmz0REkgZBQapWJif6bVX2+QavU7yOAxM6TPsElStd7bsmbdRo8WnCFdWrlw4aIr77nzFyRj+nSuYe3R299v374jgTdv6qCctfJkSJ/W9GtHr6ZPn7dEpo/tY11dz6yjTEqRIqXEZTILpYMAAvEikCJFCuv77p7i9vsf2/uaeEFloQggYARi+/tN+b61vw65Pt1/m2K2P2nSZKIp5G9gzC6H8qPj6V3bt9mp0YmygG0C9E/XrJePF06UhTNHyP/eHS8LZoyQ9z78xKOGlyxWSH7YvE1uBAbKufMX5a/d+6Vo4afNvPqG9ps3b5n+4kUKyrr1m0z/V9/9JCWLFjT9+kK6fiOmSd8uLeWRTA9ulTcTY7JDWQgg4OUCeveNe/Ly6lI9BBBAAAE/EXD/bYrpfidhTJdLeSIxZSD88yEB2wToaR5+SJIkTuyiNy9tS5DQNRxej/799JpVy0vzjoOkc9+x0qVdY0mcKJGZpefgSXLx0mXT37lNQ1m1doP5M2uHDh+XhrWrmvHLP/1K/vhrj9Rv2VNerNTIpBOnzphpdupQVwQQQAABBBBAAAEEEEAAAe8VCPDeqgWt2cMPp5LFy7+QU2fOyb4Dh2XqnMVSvMizQTOFM1SnRiVZNGuUuQJfpvjzrpxfr5gj6dOlMcP6OXN8f9EX0I0c0Mn1Iri2zerKprWLgqTMGdObeei4BOhBAAEEEEAAAQQQQAABBBCIhoBtAvTP1nwn0+ctkeoNO0qj1n1kycdr5MOPVpur2XpVOxoGzGoLASqJAAIIIIAAAggggAACCPi2gG0C9OBXsIMP+/ZqonWxLsACEEAAAQQQQAABHxe4dv269B8xVRq26mld8Oolm7buCLPFP/28w+Rp0q6fDBo9Q67fCDR59d1NfYZOlpdrtbQulDUw49w7J0+flU59RkmpKo2lSIV6smjZKtfk8Ka5MtGDgJ8L2CZA1yvmwdfVvA8+Dj6KYQS8UoBKIYAAAggggAACcSWwcOlnsu23v0Isbs6Cj8xLkxfPGSuDeraT3kMmyX9Xr4XId+nyFek1eKIM7vW2eTHzjRs3ZP6iFa58+gLmicN7uYadPbfvY8PQ5AAAEABJREFU3JF23YdJxgzp5JMPpsiPaxZJmRIvmMnhTTMZ6CCAgBGwTYC+YdOv8v2Pv5hKa+f9JZ/K7zv3aC8JAX8XoP0IIIAAAggggIBL4NCRY3L+4iXXsLNH/1pR3RqvmMF8eXJIvtw55AfrGNuMcOus37hVHs+fW/LmftSMfb1aBVn3/SbTnyhRQqn6cmlJny61GXbvbLKuul+9dl16dWpuTU8jmjd71nt/nji8ae5l0I+AvwvYJkAfPbCz6Fm/v//Zb54919tuxg3t6u/rj/YjEAcCLAIBBBBAAAEE7C5w9+5dOXX6rOTInsXVlOzZMsvxE6ddw84evRU9e5Z7gbWO03mOHT+lveGmw0dPSCbr6nnbbkOlZJU3pX3P4XLw8DEzT3jTTAY6CCBgBGwToD+cKqWMHtRZBoycLt//9ItMGdUryJ9dM62hgwAC9hOgxggggAACCCAQbYFRk+ZK4XJ1TFq5+ltzi7pzeP2PW035DodDHAEPDv8DHA/6TQa3jiPA4RoKcDhEA3zXiDB67ty5I//sPSBvN68vaz+aY25v7z10kskd3jSTgQ4CCBiBsL+VZnL8d9p0GybONGLiXLl9+47cuBEoXfqNM+Pjv4bUAAEEvFmAuiGAAAIIIOAPAn26tJRfvl1mUo0q5WTM4K6mX8eVLfGCOBwOyZA+rZw9d8HFcebceXkkcwbXsLNHr4KfO3/ROShnrHmy3b9V3TUylB6dL1vWTFLw6QKSInkyqVSuhOzZd1A0OA9vWihFMQoBvxXw+gC9eaOa4p76dm0hb7eo5xrnt2uOhiOAgDcIUAcEEEAAAQRsI1C+TDH55It1pr7HT56WnX/vFX3hm444cPiY63b00iUKy44/dsmxE/dua/90zXopX7qYZgs3lSj2nFy+clUOHDpq8uk7pB7Lk1MCrKv24U0zmekggIAR8PoA/YXnnpLwkmkFHQQQQMAnBWgUAggggAACMSfQumltuXDxsjRo2VN6DBwvw/p1kJQpkpsFLP14tSxb+aXpT53qIRner6P0HDRB9M+sXbt2XZo1et1M084rtVvLq/Xaif7JNb2Nvk3XITpakiVNKqMGdJa+w6aYP+X29Xc/ydgh994ZFd40MzMdBBAwAl4foJtaWp3mHQdZO5QHb6M8e/6CtOg02JrC/wgggAACURJgJgQQQAABnxTo371NqFe8NUgePbCLfDh3rCyaPUZefKGgq/29O7eQHh2auYaLFylo8iyYMUKG9G4nSZMkdk37cvls1+3zegv9rImDXNP09nYtX/+U25RRfSSb28vmwpvmKoAeBPxcwDYBuv7JhtQPp3KtrnRpUsvlK1dcw/QggAACCHiXALVBAAEEEEAAAQQQiJyAbQJ0fTHckWMnXa07cuyE3Lp1xzVMDwIIIICAXwnQWAQQQAABBBBAwOcEbBOgN65XTTr3HSNzFiw3qXPfsdK0wWs+t0JoEAIIIICANwhQBwQQQAABBBBAIO4FbBOg65+LmDi8p1y+cs2kySN7SbVKZeNejCUigAACCCAQXQHmRwABBBBAAAEEQhGwTYCudc+UMa1UqVhSur3dWLJlyaSjSAgggAACCCAQTIBBBLxF4NSfi2Xn/14l2djgnxWviybWo723Y/0uest+gXqEL2CbAP2nn3dIjYadZNDod0yLdu3519zybgboIIAAAggggEBcCbAcBBBAAAEEEIglAdsE6NPnLZG5UwZL2jSpDUWBfLnk9Jnzpp8OAggggAACCPiKAO1AAAEEEEDAfwVsE6AnSpgwxG3td+Wu/645Wo4AAggggAACkRdgjngTmLvmnBTpuI+EAdtAHG0D+p2Lty88C46ygH0C9EQJ5dz5i66Gbvv9b9fVdNdIehBAAAEEEEAAgXgUYNEIIIAAAghER8A2AXr39k1l6LhZsnf/IWnTdZiMnjxPOrZqEJ22My8CCCCAAAIIIGAnAeqKAAIIIODjArYJ0PWZ84nDe8jgXu2kdo2KsmTeOHksTw4fXz00DwEEEEAAAQQQiCsBloMAAgggEN8CtgnQFSogIEBKFntOypcuJgkCbFV1rT4JAQQQQAABBBDwXwFajgACCCAQoYBtotyNm7dLy85DpFSVJvJipUauFGELyYAAAggggAACCCDg8wI0EAEEEPAFAdsE6BNnLJTWTd+Qbz99VzatXeRKvrASaAMCCCCAAAIIIICAVwtQOQQQQCBOBGwToKd6KIUULvikJEqUME5gWAgCCCCAAAIIIIAAAnEjwFIQQACBewK2CdALP/ekvL/kU7lw6fK9mtNFAAEEEEAAAQQQQACBiAXIgQACthHw+gDd+bz54uVfyOz3l0vl2m1dz5/rNNtIU1EEEEAAAQQQQAABBHxQgCYhgEDMCXh9gO7+vHlo/TFHQUkIIIAAAggggAACCCDgZQJUBwG/EvD6AN25Nvb9e1j+u3rNOShX/rsq+w4cdg3TgwACCCCAAAIIIIAAAghEToDcCHiXgG0C9EGjZ0jiRIlcevqyuEGjZriG6UEAAQQQQAABBBBAAAEEvEqAyiAQSQHbBOi3bt8K8gb3JIkTy43AwEg2l+wIIIAAAggggAACCCCAgG8I0ArfE7BNgO5wOGTLr7+71sCmrb8FuaLumkAPAggggAACCCCAAAIIIIBAdAWYPx4EbBOg9+/WSia8s0DadBtm0uRZH0i/bi3jgYxFIoAAAggggAACCCCAAAIIRE+AuUMTsE2A/mSBvLJk3jipU6OSSUvmjpUn8ucJrU2MQwABBBBAAAEEEEAAAQQQ8GcBm7bdNgG6+iYICJBypYrIyVNnJcDq13EkBBBAAAEEEEAAAQQQQAABBOJSILaWZasA3Ymw4vN1zl4+EUAAAQQQQAABBBBAAAEEEPAJgfsBuk+0hUYggAACCCCAAAIIIIAAAgggYFuBuAnQY5jn9VcrxHCJFIcAAggggAACCCCAAAIIIIBA/ArYJkDf9vvfLqn6tSqbfv1Ta9pDQgABBBBAAAEEEEAAAQQQQMDuArYJ0MdNe18OHD7u8v552x8yaeZC13As9lA0AggggAACCCCAAAIIIIAAArEuYJsAfUjvdtJnyEQ5f+GSbLeupo+f/r5MHN4z1oFifwEsAQEEEEAAAQQQQAABBBBAAAER2wToj+XJIe1bNZTOfcfIiIlzZdyQ7pItSybWYUQCTEcAAQQQQAABBBBAAAEEELCFgNcH6HMWLBdn2vn3Hrlz967kz5dL1n670Yy3hbIPV5KmIYAAAggggAACCCCAAAIIxIyA1wfowZtZqthzkiNb5uCjGfZNAVqFAAIIIIAAAggggAACCPiNgNcH6K2a1Jbwkt+sKRoaCwIUiQACCCCAAAIIIIAAAgh4j4DXB+juVDt37ZMFSz4zt7Y7b3t3n04/Al4lQGUQQAABBBBAAAEEEEAAgUgI2CZAn794pYydOl9Wrv5Wzp67aH1+J4ePnoxEU8mKgG8J0BoEEEAAAQQQQAABBBDwLQHbBOhffvODvDt1iGTKkE76dGkhKxZOlus3bvjW2qA1CHiPADVBAAEEEEAAAQQQQACBOBawTYCePHlySZgwoQTevCm379yRpEkSS4DDEcdcLA4BBGJGgFIQQAABBBBAAAEEEEAguIBtAvQUyZLKzZu3JFeObDJ8/ByZNmex3Ai8Fbw9YQ4vW7lWGrXpI43b9pMNm7aFmu/M2fPSvudIadZhoPQdNkWuXb9u8p2/cEm6DxgvL1VvLmOnvmfG0UEAAS8WoGoIIIAAAggggAACCNhQwDYBere3m5qr513aNpLsWTJJEusKer+uLTwiP3j4uCxcukpmTxwoYwd3kRET5sj1G4Eh5p0ye7EUK/yszJ82VFKlekgWL1/tylPl5dLS8s1armF6EEDAfwVoOQIIIIAAAggggAACsSFgmwA9d86skjBhAjl89IQ0a1RT9E+vZUif1iOTjZu3SZkShSVF8mSSOVN6KZAvl2zd9qcE//fjlh1S9eVSZnTViqVk45btpj9N6lRSrlQRSZYsiRmmgwACCMSiAEUjgAACCCCAAAII+KmAbQL0n37eITUadpJBo98xq2rXnn+lc98xpj+izumz5yRL5gyubNmsK/Cnzpx1DWvPf1eviT7SrsG4DmfPmklOnzmnveGm27dvS1ymcCvDRAQQiFWBO3dui3uKy+9+zC0r7H1WrOJROAIIhCvgvm+JSn9c7COisoy7d++G224mIoBA3AjodzEq3+GozBM3LfLdpdgmQJ8+b4nMnTJY0qZJbdaGXgU/fea86fek4wh40FSHI/SXywUEyfMgf3jl37wZKHGZwqsL0xBAIHYFbty4Ie4pLr/7cbGsGNGjEAQQiJLAjRuB1v4l6iku9hFRWYYe3EcJhJkQQCBGBfS7GJXvcFTmidGK+2FhnkWhXgCTKGFC0Svf7lW5K56dlc2QLq1cuHDRNeu58xckY/p0rmHt0dvfb9++Y55z1+GzVh5PbqFPmjSZxGXSupEQQCB+BJIlSy7uKS6/+3GxrPhRjdxSyY2ArwokS5bM2r9EPcXFPiIqy9C/wOOr64x2IWAnAf0uRuU7HJV57OTijXW1T4CeKKGcO/8gyN72+9+uq+kRwZYsVkh+2LxNbgQGmjL+2r1fihZ+2sy23SpH3w6vA8WLFJR16zdpr3z13U9SsmhB008HAQQQQMAvBGgkAggggAACCCAQrwK2CdC7t28qQ8fNkr37D0mbrsNk9OR50rFVA4/wcmR/RGpWLS/NOw6Szn3HSpd2jSVxokRm3p6DJ8nFS5dNf+c2DWXV2g3mz6wdOnxcGtauasbfun1bXqzUyPyJtU+++Mb0797zr5lGBwEEEEAAAc8EyIUAAggggAACCIQvEBD+ZO+Zqs+cTxzeQwb3aie1a1SUJfPGyWN5cnhcwTo1KsmiWaNk4cwRUqb48675vl4xR9KnS2OG9XPm+P7mz6yNHNBJkiVNasYnTJBANq1dFCTlz5fLTKODAAIIIICAVwhQCQQQQAABBBCwvYDXB+j7DxyVdj1GyEvVm0vX/uMkd86sUr50MUkQ4PVVt/3GQQMQQAABBBBwCvCJAAIIIIAAArEv4PVR7vAJs+XpJ/LKkN5vy6PZMsvYqe/HvgpLQAABBBBAAIG4FGBZCCCAAAIIIGAJeH2AfunyFWn7Vl0p/WIh6dK2sfx78IhVbf5HAAEEEEAAAQQ8FSAfAggggAAC9hDw+gDdndHhcEgAt7YL/xBAAAEEEEDAiwSoCgIIIIAAAjEk4PUB+tHjp8xb0/Ut6ppOnDoTZDiGHCgGAQQQQAABBBDwSgEqhQACCCDgPwJeH6BPHd1bwkv+s6poKQIIIIAAAgggEOMCFIgAAggg4EUCXh+gv/DcUxJe8iJLqoIAAggggAACCCAQRIABBBBAAIHICHh9gB6ZxpAXAQQQQAABBBBAwI8EaCoCCCDgYwIE6D62QmkOAggggAACCCCAQMwIUAoCCEktxnkAABAASURBVCAQ1wIE6HEtzvIQQAABBBBAAAEEEBDBAAEEEAghQIAegoQRCCCAAAIIIIAAAgjYXYD6I4CAHQUI0O241qgzAggggAACCCCAAALxKcCyEUAgVgQI0GOFlUIRQAABBBBAAAEEEEAgqgLMh4C/ChCg++uap90IIIAAAggggAACCPinAK1GwGsFCNC9dtVQMQQQQAABBBBAAAEEELCfADVGIOoCBOhRt2NOBBBAAAEEEEAAAQQQQCBuBViaTwsQoPv06qVxCCCAAAIIIIAAAggggIDnAuSMXwEC9Pj1Z+kIIIAAAggggAACCCCAgL8I0M4IBAjQIwBiMgIIIIAAAggggAACCCCAgB0E7F9HAnT7r0NagAACCCCAAAIIIIAAAgggENsCcVA+AXocILMIBBBAAAEEEEAAAQQQQAABBMIT0GkE6KpAQgABBBBAAAEEEEAAAQQQQCCeBWIxQI/nlrF4BBBAAAEEEEAAAQQQQAABBGwkYN8A3UbIVBUBBBBAAAEEEEAAAQQQQACBiAQI0MMQYjQCCCCAAAIIIIAAAggggAACcSlAgB6X2g+WRR8CCCCAAAIIIIAAAggggAACQQQI0INw+MoA7UAAAQQQQAABBBBAAAEEELCbAAG63daYN9SXOiCAAAIIIIAAAggggAACCMS4AAF6jJNSYHQFmB8BBBBAAAEEEEAAAQQQ8EcBAnR/XOv+3WZajwACCCCAAAIIIIAAAgh4pQABuleuFiplXwFqjgACCCCAAAIIIIAAAghETYAAPWpuzIVA/AiwVAQQQAABBBBAAAEEEPBZAQJ0n121NAyByAswBwIIIIAAAggggAACCMSfAAF6/NmzZAT8TYD2IoAAAggggAACCCCAQDgCBOjh4DAJAQTsJEBdEUAAAQQQQAABBBCwtwABur3XH7VHAIG4EmA5CCCAAAIIIIAAAgjEsgABeiwDUzwCCCDgiQB5EEAAAQQQQAABBBAgQGcbQAABBHxfgBYigAACCCCAAAII2ECAAN0GK4kqIoAAAt4tQO0QQAABBBBAAAEEYkKAAD0mFCkDAQQQQCD2BCgZAQQQQAABBBDwEwECdD9Z0TQTAQQQQCB0AcYigAACCCCAAALeIkCA7i1rgnoggAACCPiiAG1CAAEEEEAAAQQ8FiBA95iKjAgggAACCHibAPVBAAEEEEAAAV8SIED3pbVJWxBAAAEEEIhJAcpCAAEEEEAAgTgVIECPU24WhgACCCCAAAJOAT4RQAABBBBAIKgAAXpQD4YQQAABBBBAwDcEaAUCCCCAAAK2EyBAt90qo8IIIIAAAgggEP8C1AABBBBAAIGYFyBAj3lTSkQAAQQQQAABBKInwNwIIIAAAn4pQIDul6udRiOAAAIIIICAPwvQdgQQQAAB7xQgQPdwvSxbuVYatekjjdv2kw2btnk4F9kQQAABBBBAAAG/E6DBCCCAAAJRFCBA9wDu4OHjsnDpKpk9caCMHdxFRkyYI9dvBHowJ1kQQAABBBBAAAEEYlaA0hBAAAHfFSBA92Ddbty8TcqUKCwpkieTzJnSS4F8uWTrtj+FfwgggAACCCCAAAKeCRTKm0xaVk7j/Yk6so58ZBvQ75xn305yeZMAAboHa+P02XOSJXMGV85sWTLJqTNnzfAHH3wgcZnMQukggEC8CMTldz0+lhUvqCwUAQSMQHx85+Nimb///rtpn3aez6cBelor+PPv1LIy7ccgbrYB/c7pd0+Tfhfj4juvy9DlkaIuQIDuoZ0j4AGVw+FwzXX79i2JyzSi6xtCwoBtIH62gbj8rsfHsv5+4m0hYcA2ED/bQHx85+NimUcCC8jWa7VIcWeANdahbgP6XYyL77wuQ/gXLYEHUWe0ivHtmTOkSysXLlx0NfLc+QuSMX06M9ywYUMhYcA2wDbANsA2wDbANsA2wDbg+9sA65h1HPE2YIIkOlEWIED3gK5ksULyw+ZtciMwUM6dvyh/7d4vRQs/7cGcZEEAAQQQQAABBBBAAAGPBMiEAAJCgO7BRpAj+yNSs2p5ad5xkHTuO1a6tGssiRMl8mBOsnibQMvOQ+TNtn2lafsB0rb7cNn2+9+uKjZq3UfOnD3vGnb2LPzfKvnwo9XOwWh96kmeFp0GyZ07d0T/7d1/SDr0GiVv3a/P+OkL5Mp/V2Xttz/KhHcWapYQaeXqb6V+ix7yYqVGcv7CJdf033bullZdhkiJyo1l3febxfnv2vXr0qzDQLl7965zFJ8IIBDLAhcuXZZh4+eI7ld0n9O+50j5/sdfzFJnzv+fvN64i7TpNkwatOol0+Z+KLdu33ZN0+/2iZNnzLB23l30ifm+7z9wVAdDpO4Dx8uRYyfMeC1n3gcfmz8LquV36jNGftyyw0yr06ybXLp8xfS7d8Lad5w4dUZGTZonlWu3lXotesiCJZ+5ZtPfwtNnzrmG6UEAgagLtLSOTX7f+U+IAvS7r/sQTTUbd5adu/aZ33PdRwRPn3zxjWg51Rt2DFJOe+sYo0rddkHGuQ849x+6b6jbvLv7pCD9eiyhf3I4yMgoDoR3jKMXwroPGC8vVW8uL73WzGrz3iBL+XnbH2Z/uPmX38z43/7cLWOmzDf9nnTIg4AdBAjQPVxLdWpUkkWzRsnCmSOkTPHnPZyLbN4o0KN9U3l/+jCpWKaYTJm1yFXFPl1ayMOpHnINx0bPqi/XS5kSL0hAQIAJrvUAuuar5eU9qz4zx/eXqi+XkgsXL4e76EwZ0snQvu0lfbo0QfIlTZJEWjd5Q8qWKBxkfLKkSeWpx/PIhk3bgoxnAAEEYk+g+4AJkiJ5Elk0e5R8MHOktGxSS3bt+de1wGqvlJVZEwbIzPED5Odtfz74yyAOkVw5sspX6ze58q7/catkfSSjuL3+xDVtvxW03759V7JlyWzGzV3wkWz59U/zZ0G1/HFDu8qt+8G/yRBKJ6x9h+6n3qheUdYsnykj+neU5Z9+Jfv+PWxKqF7lJVn80Remnw4CCMS8gAbjK62ge+KIHmY/MnNcf9Hf8/nThsqmtYvMccxjeXKYfh3WC0m6j0iRIpkV1O4zFbp46YqcP3/R2ndYOxYzJmgn+P4j6NSgQ9evB4qeBAg6NuaHBo+ZKems45sVCybJioWTXfs2XVLgzZsyY/4yeSJ/Hlebnn0qv/y1e59cuPjggoXmjafEYhGIEQEC9BhhpBA7ChR5/mnzyIKz7nql6KJ11UuH9ap57be6iV712u12UP3jzzukYave5kq1nrHVM8+aX6+IT5+3xFwNa9y2n6z+eoOODpG++m6TlH7x3gmelau/k6JWHcqVKuLK9/hjua0fo0xm+PiJU9Kx92jRM9ruZ61ffOFZyZc7h8nj3smfN6c8X/BJE/y7j9f+UtYyv7Kuyms/CQEEYldAr4SdPH1WOrZq6FrQs0/ml9ZNa7uGnT0JEtz7GU6fLrVzlDnJ9u0PP5vhg4ePyyOZ0osG0aHdBLP2u41Sunghk1f3Q0tWrJG+1slG/bOgOlLv9nI/qfz+kk9F7+JpY129d14Bzx/GviNj+rSufU2enNklT67scuzEadF/JYs+J9/9sFV7SQggEAsCZ63AOrf1vdPvoRavf+Y3d86s2htuKl+6mKz7/t4Jvq+++0nKlS4aZn73/Yd7pn0HDkvvIZPM3X0v12pt7tCZt2iF6J09uu+YOf9/5o5DvbOm3/Cp5q4+/dS7EvXuRL1bx/2EpHvZzv7QjnF0v7lz117p2u5NSZM6lUkPp0rpnEUWWPuvejUrScoUyYPcFViiaEH5ZsMWVz7f7aFl/iJw78jAX1pLOxFwE9AfkrIlHwTHzkn7Dx6Rjz/7WuZOGSyjBnayzszuN5Nu3bolw8fPkX7dWpqrU2fPXzDjtfP5Vxvk9Jnz8v47w2XG+H6y7NOv5cChYzrJlW7evCV6sK2PTOjIw0ePyzPWQbv2h5aOnzwjIwd0tK6uD5ePV30testsaPk8GaeB/x9/B71NzJP5yIMAApEXOHTkuDyZP7ckTJgwzJnnLFhubtOs+HoryZEtiysQ1hlSpkwpqa2D0hPWPuDLbzZKxbIv6uhQ0+8798gT1ok9nagHt3qFTa/A63BoSafNmzJEXrbKXLT889CyhDpOr5z//c9+efrJfGZ6okQJJfXDD8nho/durTcj6SCAQIwJFCn0lFy/ccPc0j5u2vuy449dHpVdrPAzsnnrvdu/v/l+i5QPJ0B333+4F/7h8tVSrfJL1vHHMOsq9iRJmya1tGj0uuhJAr0zp22zuia7nrBr2fgN+WD2aDlz7oKsWbdRpo/tK707t5BZ7y0zecLqhHaMc+z4KcmYIa106TdOytdoIUPHzZJr16+bInRf8+ff++SV8iXNsHsnf77com1xH0d/FASYxWsECNC9ZlVQkbgSaN11qDkwnjp7sdS1zsQGX+5vf+6Wl0q9IKlTPSQPpUwh5csUNVmOHj8tGdOnEeetVdWrlDPjtfPrjr/kn30HzRXv7gMnmCvzu/bcC+x1uiYN6NOmDnoLvd6OptNCS08/+Zg5S5w8WVLJlSObHD5yIrRsHo3Ts83Xrl2X2/efffdoJjIhgECUBQICHvy86pUlfV600httXOW1alLb3Jr6xdJ35EbgDevqz2bXNO3RoHzNNz/K9z/9InoHjI4LLZ0+c04yWFe6ndPC26donuJFCuqH6G2hBw4dN/0RdfTkYJ9hk6V/99Zmv+jMnyljOuuK+innIJ8IIBCDAkmTJDaPwfTs+JYkSOCQrv3Hh3l3nvtiEyZMYB2n5JXvNm6VgAQBVnCdKsjVZve8wfcfzmnPWCfilny8RuZ+8LFoYKzHIc5p7p9ZMmeQnI9mkYQJEkj+vDnkqQJ5JEFAgDz1eF45aJ2odM8bvD+0Yxw9RjlkHeu0ePN1WbloirlzaNGyeycS9R09PTo0CV6MGda7jI6fvHd3jxlBxysFqJTnAg+OIDyfh5wI2Fpg9sSB8tXHs83z3iMmzg21LQmsHxvnBP2x0359xVqQ8W55HA6HObusZ5Y1fbZ4aoizvPoDduv2HS3KpOxZH5E//tpj+kPrJHK7+pYgIED0Cn5o+Twdpy+oSxDAV95TL/IhEFWBR7M9Iv8eOuo6KNbnt9d9Evq+Jm2ah6Vwwadk8y9/3Fuc7mju3pUyJQqb5z315JweqN+bGLIbEOCQm7dumQn6fopr127IgcNhB97O/YrDESC3I3g2XQvVA+ahY2dKl7aNpfSL926l1/GaAgNvSiJemKoUJARiRcDhcEiBfLmka7sm0r19Y1m97sdwl2PtOsTa8ZgLC+OmvScVwrl6rgW57z902JmqWxcg+ndtKVmtALz/iOmid884p7l/JkyQ0DUYEBBg7Q/uDWv/rVu3Jbx/zn2R5kkQEGCOcdKnSyvp06aWQs88bi6QFC38jOjFD32Phr4crvZb3c0FFu3Xq+zf//Srzi6BgYHiXp4ZScffBHyqvRyt+9S3DEG9AAAQAElEQVTqpDGeCuiV8XbN68nBw8dC3Db29OP5RK+I6/Oc+ubzrdt2mmKzPZJBzp67IPrSFR3xy44/9cMkfZZcbxe9fOU/M6zPbwV/YUk660fnypWrrje416jykmza+pssXLpK9MUnOqP+CB45dlJ7YzTp2+k1aIjRQikMAQRCFXjmycckRfLkMnDUO6JXqDTTtes39CNE0gPPbb/tNAel7hP1rpfmDWtIo9pV3UeH6M+dI5scv/9cuB4U13v9FRk0arrs2X/Q5NV9i/Mg1oyIREcfyxk0aoZUqVha9N0XwWc9duKU5Mv9aPDRDCOAQAwI6JXk/QeOmpL0RJne3p3OOqFnRkTQ0cBWjzHK3b8DMKzs7vsP9zx6LJM5U3rz3ddb7fXYJHnypHL58lX3bDHenzP7I6LL2XfgsCn7V+s467G8Oc0Ven0RnjMVKfS0TBrRQ5zv1zh6/JTkyZXNzEMHgdgRiNtSCdDj1puleZFAksSJpWn96iHeRJzXOuAsV6qo+fNnekuZBulabX2etGenZjJo9Duif7ro4sX/JGWKFDpJKlcoKcWLFpS23YabP0c0YOR0KxC/a6Y5Ow6Hw9yq+vc//5pRaVKnMrevbd3+pzRo2cu8kO6Lr36Q1A8HvQ3eZHbr6MtZ9HZZDbr1T6d0HzjeTNU/OaLj9U+s6fIr1Gxpxmvnd+tKffC3u+t4EgIIxI7A+GHdJLG1j2nddZjUb9lTuvYbJz07NnUtbNWX682fWdM/iXTyzHmpX6uya5qzp7p1FUvfH+EcDu2zbMkXRL/fzmktm7xh7WcKSd9hU82fBu01eLI5uHVOD+0zrH3Hr9aJg282bJYB1v5M9y2anC/A1BOQGTOkN1e5QiuTcQggEDmB1vcfv9PvWcvOQ8yjL32HTzYvaqtWv71s/2OXtG76hkeFJggIEH2MRh/VC2+G4PsPZ96xU62r79YxRPcB460LCLekUrkSosdM+pdm9PhHj0OceWP6c2ift2Xo2FmiL9y9fv2mvFmnWoSL0JMXZUN5p1CEM5IBAW8RCFYPAvRgIAz6tsDcyYNEr245W1mnRiUZN6SbGVw0e5SkT5fG9DeuV03eGdfPnKHVP2nS4I0qZnzBp/LL5JG9rNTTOsubRJ5+Iq8Zr52Wb9Yyfwpl6bxx8uGcMaK3rup491SrWnlZ++1G1yg9GTBtTB/56P2J5sUq3ds3sYL+5ObHsNvbjV359BbZ55553Azry1mcZ5H1c/zQ7mZ8scLPmmdadZwm91tqv9mwRapXfsnko4MAArEvoAfGA7q3Mi9YWjJ3rPkTneVLFzML1u/wioWTzAk6fQb9/enDJNVDKV3TnPsbM+J+R/dPuUN5g/NLpYo8+BNtVl59lKaFtS9a/t4EeXfqELMP0zccW5Nk2fwJruVoWfoyJx0f1r4j+Hjdr+jVdJ3nq+82iV6h034SAghET0CPTfT75Uw6nC93DtHjCf0zrKv/N0OWzB0jWTJndC0of75csmDGCNew9uh8Ol77nUn3LTq/c9j9033/ofn+9+69E/7D+rYXPYYYP6y76H7M+VchdN81ZVQv0U89XtL9krO8zm3eNFfcdVj3Q6s+nKa9oSYN+MM6xtF2a7sWzhwhfbu2kNAe8dE66P5JC79165bst664623xOkxCwBcEAmK4ERSHgE8LLF3xpVSu3VYatOotV6/ekGqvlI1Ue/WHU/9cUaRmimZmvcVVD9DdXyQVzSKZHQEEvERAr2rVe72y61b6uKpW4sSJpEKZeycc4mqZLAcBBGJWIEnixBIf+4+YbMWhIyelVRPP7iyIyeVSFgKxKWCzAD02KSgbgYgFmjeqKWuWzzRnsvXMbuIovCBJb1uNeEkxl0PrWKVCqZgrkJIQQMCrBOLjBFyNKuW8yoDKIIBA1ARic/+hL3Nr2324uKdBo2dEraJhzKV3A+lfpQhjMqMRsKUAAbr7aqMfAQQQQAABBBBAAAEEoi2gL3ObOb6/uKchvdtFu1wKQMDXBQjQ43ANsygEEEAAAQQQQAABBBBAAAEEwhIgQA9Lxn7jqTECCCCAAAIIIIAAAggggICNBQjQbbzy4rbqLA0BBBBAAAEEEEAAAQQQQCA2BQjQY1OXsj0XICcCCCCAAAIIIIAAAggg4OcCBOh+vgH4S/NpJwIIIIAAAggggAACCCDg7QIE6N6+hqifHQSoIwIIIIAAAggggAACCCAQbQEC9GgTUgACsS1A+QgggAACCCCAAAIIIOAPAgTo/rCWaSMC4QkwDQEEEEAAAQQQQAABBLxCgADdK1YDlUDAdwVoGQIIIIAAAggggAACCHgmQIDumRO5EEDAOwWoFQIIIIAAAggggAACPiNAgO4zq5KGIIBAzAtQIgIIIIAAAggggAACcSdAgB531iwJAQQQCCrAEAIIIIAAAggggAACbgIE6G4Y9CKAAAK+JEBbEEAAAQQQQAABBOwlQIBur/VFbRFAAAFvEaAeCCCAAAIIIIAAAjEsQIAew6AUhwACCCAQEwKUgQACCCCAAAII+J8AAbr/rXNajAACCCCAAAIIIIAAAggg4IUCBOheuFKoEgIIIICAvQWoPQIIIIAAAgggEBUBAvSoqDEPAggggAAC8SfAkhFAAAEEEEDARwUI0H10xdIsBBBAAAEEoibAXAgggAACCCAQXwIE6PElz3IRQAABBBDwRwHajAACCCCAAAJhChCgh0nDBAQQQAABTwT+98laebFSI1m5+ltX9rt370q1+u2l0httXOM87dm6/U9p33NkhNnf+/BTmT5vSZj52nYfLvsOHA5zekQTft/5jzTvOMhk0/5mHQaa/uAdT+v7646dsuXXP1yzh1emK1Mke8q8+pbcCAyM5FxhZ5+zYLnM+2BF2BniecqRYyek+8Dxouv6F8tXqxPdpNvVtLkfmmK0P7xtTDPdun1bGrTqJRcuXdZBEgIIIIAAAtESIECPFh8zI4AAAgg4HCJ5cz8qq7/+wYWhQWvq1KlEp7lGxmGPBsLJkyWRPDmzx8hSc+fMJj06NI1WWdv/2C3bfvvLVUZMlOkqzE97dJt7In9emTm+vxQu+GSMKLxSvrjUqFIurLJCjE+YIIHJv2jZ5yGmMQIBBBBAAIHIChCgR1aM/AgggAACIQTy5npUrl67LnpFUyd+8dUPUqVCKe11pe9//EVadBokTdsPkE59xsi/B4+6pulVytpvdZN2PUbIeiufa4LVs2zlWnmzbV+T+g6bImfPX7DGhv+/Bm7lSxc1mfSKcsXXW8mly1fMsHYmz/pA5i78SHul/4jp5mp/vRY9ZMTEuXLt+nUz3r2z/8ARGTftfdeosOp77vxFU0+9olq3eXdZtOwLM4+29YuvN8jab3+SNt2GyfJPv5LgZb676BNp1KaPNG7bT4aNnyNX/rtq5tWr2Nru9r1GGb9Rk98VvWprJobT+XnbH9K661Bp0q6f+fxr9z6TO6w66sQLFy9Jn2GTTT3ettbFgUPHdLRJ6jLhnYVSv2Uvadiqt7l74c6dO2aatmns1PfMnQ/Dxs0249w72obeQyeb6Tq/tsd5xfnw0RPSe8gkadS6j7Fbs26ja9bwyv3sy/XyubWdrbZcNd9/V6+FuS71hJFud87lvGVtgwcOH5duA8ZJfWu9Dx4z02X65Tc/BbkbRCsTePOmVK7TTs6cPa+DJo2fvkDmL15p+iuUKSa6zZuBaHWYGQEEEEDA3wUI0P19C6D9CCCAQAwJVK1Y2gQpGqjv+GOXvFikoKtkDWwGj50pXds1lvenD5OCTxeQoeNmmenfbNgsG376Rd6zxk8e2VP27j9kxmvnx593mKB22pg+8sHMkWa+sVPm66Rwky7/mScfM3mSJE4spYsXNsGcjtCgcu23m6T6/aukjetVk1VLpsui2aNFr4YuWv6FZgszhVffZNZV+5H9O8qHc8bIvClD5Nsftsi23/+WXDmyivpUKldcZk0YILWrvxyk/G9/+NncgTDdauf86UPl7Lnz8t7iT1x5Tpw6K6MHdjJlOhwO+XbDFte00Hr0JMbwCXOlR/umsmDGCOPeZ+gUE4SGVUctZ+7CFRLgCDDWA7q3NnWX+//0Vvfbt2/LQqu8998ZLietOi1b+dX9qWKd2LghU0f3lgE9WrvGufccPHxMRg/qLEvmjpFHMqWX+YtWmMmDRs+Q0iUKW/6jZJo1//tLVsruvQfMNO1cux56ua+9UlbKlXpBXn+1gjFNkTyZhLcudflvt6gvH8waKXlyZZeeg8ZL364tZZG1ri5dvhyuaeJEiawTTiXkky++0SpZbb0u33y/WV6vVt4Mp03zsDyUMlm0HqkwBcV2h/IRQAABBLxegADd61cRFUQAAQTsIVD15VLy5Tc/yjorcClXuog4rGrfvWt1rP9/27lHniyQV57In8caEmlYu4oJwvSq5/bfd0u1V16SlCmSiwZCtapVMHm0s3nr73Lh4mXrCutk0aukX333k/z+116dFGa6deuWnDpzTjJnyuDK86pVN73SqiM2/LTNBMwZ06fVQXNlfeKMBdKp92j54689snvPv2Z8WJ3w6ps0SRLZbp2cGDJ2lvQYNFHOX7gku/4Jvzxdzrbf/pYqFUtJ6odTmZME9WtVkV+tcTpN0wvPPWl8tD9zxnQRBoK//fmPXLcC2/HvLDBuk2Z+IBcvXZFDR45LeHXUExsNa1cVh8Nh+aWXsiWL6CJN2vLLH/Ln33ulQ+9RJu3Zf1B+37nbTNOO3rEQEBD2YUWRQk+52lCudDHLabex//uf/fLZmvWmnr2tkwj//XfdKvcfLdKkiMo1me539C6JsNZl7hzZJHvWzKZtzz71mOTOmV3SpUktCQICrG0zX4SmtatXMvXUEzxffLVBijz/tKRO9dD9JYtkypBeDh856Rr2xx7ajAACCCAQfYGwf0mjXzYlIIAAAgj4gYAG4fpSuFQPpZT8eXPIrPeWyauVygRtuZUpYYIHPzmJEia0rtRqCC9y1/ovYYIErvwJrWnOAYfjrnXluZS5QqpXnvWq9JplM5yTQ/3U+R0OhwQG3nRNf+6Zx+Xq1euy/8BRWb1ugylTJx48fFyGj58jlcqVkAnDe0izRjWtwDb8l6yFV9/Pv/reXIl9s041mT62r5QsVkiuXgt5y7wu2z0FLzNxooSips48CdzsAqyA8tat285JoX46HA5rXeR0uand+lXzRYPU8Opo6uHmr+vJtQBrdXV7u7GrzKXzxsnIAZ1ck5MkSeTq97QngbXedX3NGNfPVe7nS6cHucPA03IjWpeJLFNnvRIEBIh72zwxzWxd9S/wWC7Rux0+/uxrqV+rsrj/09vgEyVO6D6K/pgVoDQEEEDALwQeHC35RXNpJAIIIIBAbAo0qV9dGtSqKnmsq5Puy9Erljt37ZNd969OL/l4jTyWN6fobcmFnikgeiu7MyD9ccsO16zFixSUT1Z/K/sPHjHjNAjSW8bNQDgdvYVZax+LsgAAB/1JREFUn212z1L15dKit09v/32XVChbzEzSPNmsq6pPFshrXVlOLN9EcOu4zhRefQ8cPCpPP/GYdXU2q2gQvWnrg7boHQIXrKvYWkbw9PyzT8iab34wV5T1+fIlK9ZIYeuqefB8ng4XfCq/uUPhm++3uGbZtPU30x9eHZ97+nHZuGmbyXfr1i35edvvpl87Jax1MXvBR3L5yn86KHobvfut6GZkOJ31G38xdzboev7fJ1+KOur6L5Avl0yds1j0yrTOvu/fw0Ge9dZxnqSorEtPynXP88ZrFWXK7MWSNGlS0Xq7Tztknex54rHc7qPot5UAlUUAAQS8Q4AA3TvWA7VAAAEEfELgcStAaVSnaoi2pE+XRvp3a2VetKYv6NK3rOszzpqxfOlikt+68t6pzxjp2n+snD5zTkebVKzws9Lcuqo9dNxsafp2f6la9235Y+ceMy28zssvFRe9bdw9T7VXysjX6zeJPo+uz6XrtCLPP2VucdYXs+my0zycSkeHm8Krb81XK8iX32yUNl2HyeAxM+SxPDlcZelt/+cvXBRtp74kzjXB6ilXqohUKPOitOs+Qpq1HygPpUwpbzWoYU2J2v9pUqcyz3uv+Hyd6MvRXqndxvX8dHh1bNn4ddnz70FTx56DJ0ryZMlcFXirYU0rKM1p2qYvs2varr9oe1wZIuh5PH9u6TZgvNRv2dM6eXFLtDydZUjvtlZAflHebNNX9EWBA0ZNl9v3Xz6n0z1NUVmXnpbtzFf0+WfMYxi1q1d0jjKf+jK9PLkflTSWuxlBB4HgAgwjgAACHgoEeJiPbAgggAACCIQqULdmJRncq22IaTmyPyJrP7r3IjidWKZEYXl36hDzMrgpo3qZ58B1vKYOLRuYF4xNHN7TfOrt4Tpek/7Jq/enDxN9MdnXK+ZIk/qv6Wh5q0F1ad+ivukP3tFgXN8a7z4+Y/q0smntIhnQvZVrdOJEiUTrsnDmCNFld2/fxNyarhn0JXNaX2f//GlDtdeksOqbLUsmWf7eBJk1cYCMHtjZ3ALe4s3XzTy6/LGDu5rl1a7+smj57mVqvkWzR4nWReuoV9x1xlZNaosm7dfUuG410eVrf/D0/efvifPkQ6FnHpd3xvUTtfty+SzRZWv+8Oqoz8CPGtDZ1FE99MV9Wi+dL2mSxNKxVUNZPGe0LJo1yrxYT0+g6DS9hf6F557S3jBT7hxZzcvnnLfGO5/fzpI5owzv196Uq3b6gr1MGdKZciIqt3ObN6XBG1VM3vDWpdZNyzIZrU6ViqVlWN/2Vt+9/3VbcpoG73ffxk6ePisBAQ6pWLb4vRnvd1etXS/1ar5yf4gPBOJegCUigIDvCBCg+866pCUIIIAAAvcFNPirbwVux06cuj+GDwSiJ/Deh59Km27DpM1btcX9eXa92p8+bRopWey56C2AuRHwXgFqhgACcShAgB6H2CwKAQQQQCDuBMoUf1706mzcLZElhSWgdwBoCmu6HcbrlfVPFk4WfcTBvb4JAgJCvDDOfTr9CCAQkQDTEUDAXYAA3V2DfgQQQAABBBBAAAEEEPAdAVqCgM0ECNBttsKoLgIIIIAAAggggAACCHiHALVAIKYFCNBjWpTyEEAAAQQQQAABBBBAAIHoC1CCHwoQoPvhSqfJCCCAAAIIIIAAAggg4O8CtN8bBQjQvXGtUCcEEEAAAQQQQAABBBBAwM4C1D1KAgToUWJjJgQQQAABBBBAAAEEEEAAgfgS8NXlEqD76pqlXQgggAACCCCAAAIIIIAAAlERiLd5CNDjjZ4FI4AAAggggAACCCCAAAII+J9A2C0mQA/bhikIIIAAAggggAACCCCAAAIIxJlAjATocVZbFoQAAggggAACCCCAAAIIIICAjwrYIUD3UXqahQACCCCAAAIIIIAAAggggMADAQJ0eYBBHwIIIIAAAggggAACCCCAAALxJUCAHtvylI8AAggggAACCCCAAAIIIICABwIE6B4geXMW6oYAAggggAACCCCAAAIIIOAbAgTovrEeY6sVlIsAAggggAACCCCAAAIIIBBHAgTocQTNYkITYBwCCCCAAAIIIIAAAggggIBTgADdKcGn7wnQIgQQQAABBBBAAAEEEEDARgIE6DZaWVTVuwSoDQIIIIAAAggggAACCCAQkwIE6DGpSVkIxJwAJSGAAAIIIIAAAggggICfCRCg+9kKp7kI3BOgiwACCCCAAAIIIIAAAt4mQIDubWuE+iDgCwK0AQEEEEAAAQQQQAABBCItQIAeaTJmQACB+BZg+QgggAACCCCAAAII+KIAAbovrlXahAAC0RFgXgQQQAABBBBAAAEE4kWAAD1e2FkoAgj4rwAtRwABBBBAAAEEEEAgdAEC9NBdGIsAAgjYU4BaI4AAAggggAACCNhWgADdtquOiiOAAAJxL8ASEUAAAQQQQAABBGJPgAA99mwpGQEEEEAgcgLkRgABBBBAAAEE/FqAAN2vVz+NRwABBPxJgLYigAACCCCAAALeLUCA7t3rh9ohgAACCNhFgHoigAACCCCAAALRFCBAjyYgsyOAAAIIIBAXAiwDAQQQQAABBHxfgADd99cxLUQAAQQQQCAiAaYjgAACCCCAgBcIEKB7wUqgCggggAACCPi2AK1DAAEEEEAAAU8ECNA9USIPAggggAACCHivADVDAAEEEEDARwQI0H1kRdIMBBBAAAEEEIgdAUpFAAEEEEAgrgT+DwAA//+Urw7dAAAABklEQVQDAJPyI6NeoQepAAAAAElFTkSuQmCC"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "\n",
     "_missing = [name for name, phash in baseline_hashes.items() if not phash]\n",
@@ -716,13 +13055,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee0ddee5",
+   "id": "080a6ee7",
    "metadata": {
     "papermill": {
-     "duration": 0.025162,
-     "end_time": "2026-09-06T21:49:42.533442+00:00",
+     "duration": 0.144194,
+     "end_time": "2026-09-08T21:38:58.059340+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:49:42.508280+00:00",
+     "start_time": "2026-09-08T21:38:57.915146+00:00",
      "status": "completed"
     }
    },
@@ -736,14 +13075,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "16d93140",
+   "execution_count": 13,
+   "id": "d13ebeeb",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:38:58.220618Z",
+     "iopub.status.busy": "2026-09-08T21:38:58.219720Z",
+     "iopub.status.idle": "2026-09-08T21:38:58.254999Z",
+     "shell.execute_reply": "2026-09-08T21:38:58.254610Z"
+    },
+    "papermill": {
+     "duration": 0.086497,
+     "end_time": "2026-09-08T21:38:58.255800+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:38:58.169303+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Per-fold validation IC (lstm_h64 @ epoch 30):\n",
+      "shape: (8, 3)\n",
+      "┌─────────┬───────────┬────────────┐\n",
+      "│ fold_id ┆ ic        ┆ n_entities │\n",
+      "│ ---     ┆ ---       ┆ ---        │\n",
+      "│ i64     ┆ f64       ┆ f64        │\n",
+      "╞═════════╪═══════════╪════════════╡\n",
+      "│ 0       ┆ 0.019099  ┆ 90.0       │\n",
+      "│ 1       ┆ -0.149105 ┆ 95.0       │\n",
+      "│ 2       ┆ 0.027017  ┆ 96.0       │\n",
+      "│ 3       ┆ 0.107596  ┆ 97.0       │\n",
+      "│ 4       ┆ 0.109148  ┆ 97.0       │\n",
+      "│ 5       ┆ 0.010622  ┆ 96.0       │\n",
+      "│ 6       ┆ -0.001574 ┆ 97.0       │\n",
+      "│ 7       ┆ 0.009027  ┆ 96.0       │\n",
+      "└─────────┴───────────┴────────────┘\n",
+      "\n",
+      "  Folds with negative IC: 2 of 8\n",
+      "  Peak-IC prediction_hash: aeaaa9277011\n"
+     ]
+    }
+   ],
    "source": [
     "folds = (\n",
     "    Result.open(study, PEAK_PHASH, include_preview=EXECUTION_TIER == \"preview\")\n",
@@ -760,13 +13138,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "260d8a9d",
+   "id": "25941a3a",
    "metadata": {
     "papermill": {
-     "duration": 0.027892,
-     "end_time": "2026-09-06T21:49:42.648349+00:00",
+     "duration": 0.047766,
+     "end_time": "2026-09-08T21:38:58.390024+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:49:42.620457+00:00",
+     "start_time": "2026-09-08T21:38:58.342258+00:00",
      "status": "completed"
     }
    },
@@ -776,10 +13154,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9c1c9646",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 14,
+   "id": "6b9a5491",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:38:58.480829Z",
+     "iopub.status.busy": "2026-09-08T21:38:58.480673Z",
+     "iopub.status.idle": "2026-09-08T21:38:58.486349Z",
+     "shell.execute_reply": "2026-09-08T21:38:58.485733Z"
+    },
+    "papermill": {
+     "duration": 0.051955,
+     "end_time": "2026-09-08T21:38:58.486644+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:38:58.434689+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "- **The sequence model is measured against the flat-feature families on rows all three\n",
+       "  actually share** - 187,668 of them across 1,995 dates, intersected on\n",
+       "  `(symbol, timestamp)` and recomputed rather than assumed comparable. On that common sample the\n",
+       "  peak checkpoint scores **+0.017**, against Ridge\n",
+       "  **+0.043** and GBM **+0.055**. Its own\n",
+       "  full-sample IC is **+0.017** at epoch **30**; the two differ because they\n",
+       "  are different samples.\n",
+       "- **Nothing here is chosen.** All **20** full-coverage checkpoints are\n",
+       "  published as candidates; the peak above is a diagnostic that says where training stopped\n",
+       "  helping. Selection happens in the evaluation stage, on validation backtest Sharpe.\n",
+       "- **Coverage is comparable across the checkpoint grid.** All 20 checkpoints cover 1995 validation dates. The guard stays\n",
+       "  necessary either way: a collapsed checkpoint scores on fewer dates and can look better for it.\n",
+       "- **The average is not the whole story.** The peak checkpoint is negative in\n",
+       "  **2 of 8** validation folds. The holdout is not read here; it is\n",
+       "  evaluated once, after the development-stage selection is fixed.\n",
+       "\n",
+       "**Next**: [`10_dl_tsmixer`](10_dl_tsmixer.ipynb) fits the other sequence architecture.\n",
+       "**Book**: Chapter 13, Section 13.8 (Case Study Results).\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_coverage_text = (\n",
     "    f\"All {checkpoints.height} checkpoints cover {FULL_DAYS:.0f} validation dates.\"\n",
@@ -833,6 +13256,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T21:39:16.646307+00:00",
+   "executor": "local-uv",
+   "library_digest": "598ed5ac2330510c972b1aacbd7083bf1725555de6a03f86ee0862e3d1f10b0d",
+   "outputs_digest": "94c1ce1bd5a24fb728070a09aaac204e79b90475f44ca7a77b0f39a6ddb8a23c",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "b0fe769a287823e4ecf91f8fd0df366b182da19e"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 14168.30954,
+   "end_time": "2026-09-08T21:39:01.474892+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/etfs/.09_dl_lstm.build.4175231.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/etfs/.09_dl_lstm.papermill.4175231.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T17:42:53.165352+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/etfs/10_dl_tsmixer.ipynb
+++ b/case_studies/etfs/10_dl_tsmixer.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f3f9c225",
+   "id": "1252ae06",
    "metadata": {
     "papermill": {
-     "duration": 0.001477,
-     "end_time": "2026-09-06T21:49:58.594504+00:00",
+     "duration": 0.002647,
+     "end_time": "2026-09-08T19:48:55.383608+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:49:58.593027+00:00",
+     "start_time": "2026-09-08T19:48:55.380961+00:00",
      "status": "completed"
     }
    },
@@ -39,9 +39,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "986b8317",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "d7af6352",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:48:55.389495Z",
+     "iopub.status.busy": "2026-09-08T19:48:55.389336Z",
+     "iopub.status.idle": "2026-09-08T19:49:01.341900Z",
+     "shell.execute_reply": "2026-09-08T19:49:01.341044Z"
+    },
+    "papermill": {
+     "duration": 5.957152,
+     "end_time": "2026-09-08T19:49:01.343193+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:48:55.386041+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared ETF mixer population on the walk-forward folds.\"\"\"\n",
@@ -71,9 +85,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e65f3494",
+   "execution_count": 2,
+   "id": "5b4a95e1",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:49:01.350842Z",
+     "iopub.status.busy": "2026-09-08T19:49:01.350374Z",
+     "iopub.status.idle": "2026-09-08T19:49:01.354365Z",
+     "shell.execute_reply": "2026-09-08T19:49:01.353707Z"
+    },
+    "papermill": {
+     "duration": 0.008853,
+     "end_time": "2026-09-08T19:49:01.355403+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:49:01.346550+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -93,9 +120,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "955f4338",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "db5ec57e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:49:01.362216Z",
+     "iopub.status.busy": "2026-09-08T19:49:01.362062Z",
+     "iopub.status.idle": "2026-09-08T19:49:01.453041Z",
+     "shell.execute_reply": "2026-09-08T19:49:01.451665Z"
+    },
+    "papermill": {
+     "duration": 0.096165,
+     "end_time": "2026-09-08T19:49:01.454616+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:49:01.358451+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\n",
@@ -109,13 +150,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02713ce5",
+   "id": "b0671f34",
    "metadata": {
     "papermill": {
-     "duration": 0.001186,
-     "end_time": "2026-09-06T21:50:06.260872+00:00",
+     "duration": 0.002877,
+     "end_time": "2026-09-08T19:49:01.461171+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:50:06.259686+00:00",
+     "start_time": "2026-09-08T19:49:01.458294+00:00",
      "status": "completed"
     }
    },
@@ -139,10 +180,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "adcaa571",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "e7370f5d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:49:01.471213Z",
+     "iopub.status.busy": "2026-09-08T19:49:01.470632Z",
+     "iopub.status.idle": "2026-09-08T19:49:01.588555Z",
+     "shell.execute_reply": "2026-09-08T19:49:01.587863Z"
+    },
+    "papermill": {
+     "duration": 0.125617,
+     "end_time": "2026-09-08T19:49:01.589742+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:49:01.464125+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deep_learning menu: lstm_h64, nlinear, tsmixer\n",
+      "fitted in this registry: lstm_h64, nlinear, tsmixer\n",
+      "declared and never fitted: none\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tsmixer&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=tsmixer, dropout=…</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (1, 5)\n",
+       "┌───────────────┬─────────────┬─────────────┬─────────────┬─────────────────────────────────┐\n",
+       "│ family        ┆ label       ┆ config_name ┆ model_class ┆ params                          │\n",
+       "│ ---           ┆ ---         ┆ ---         ┆ ---         ┆ ---                             │\n",
+       "│ str           ┆ str         ┆ str         ┆ str         ┆ str                             │\n",
+       "╞═══════════════╪═════════════╪═════════════╪═════════════╪═════════════════════════════════╡\n",
+       "│ deep_learning ┆ fwd_ret_21d ┆ tsmixer     ┆             ┆ architecture=tsmixer, dropout=… │\n",
+       "└───────────────┴─────────────┴─────────────┴─────────────┴─────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "SEQUENCE_CONFIGS = (\"tsmixer\",)\n",
     "declared = load_model_configs(study, \"deep_learning\", config_names=list(SEQUENCE_CONFIGS))\n",
@@ -170,13 +262,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ed50a5e",
+   "id": "696aaee0",
    "metadata": {
     "papermill": {
-     "duration": 0.001185,
-     "end_time": "2026-09-06T21:50:06.352025+00:00",
+     "duration": 0.002842,
+     "end_time": "2026-09-08T19:49:01.596181+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:50:06.350840+00:00",
+     "start_time": "2026-09-08T19:49:01.593339+00:00",
      "status": "completed"
     }
    },
@@ -200,10 +292,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "396fcb0d",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "d34dfd9a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:49:01.606121Z",
+     "iopub.status.busy": "2026-09-08T19:49:01.605769Z",
+     "iopub.status.idle": "2026-09-08T19:49:01.613486Z",
+     "shell.execute_reply": "2026-09-08T19:49:01.612558Z"
+    },
+    "papermill": {
+     "duration": 0.016829,
+     "end_time": "2026-09-08T19:49:01.615993+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:49:01.599164+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training device: cuda\n"
+     ]
+    }
+   ],
    "source": [
     "PUBLISHED_DEVICE = \"cuda\"\n",
     "device = DEVICE or PUBLISHED_DEVICE\n",
@@ -222,13 +336,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b54e6b1",
+   "id": "3dade421",
    "metadata": {
     "papermill": {
-     "duration": 0.001744,
-     "end_time": "2026-09-06T21:50:06.363917+00:00",
+     "duration": 0.002724,
+     "end_time": "2026-09-08T19:49:01.620956+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:50:06.362173+00:00",
+     "start_time": "2026-09-08T19:49:01.618232+00:00",
      "status": "completed"
     }
    },
@@ -249,10 +363,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d8d17abb",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "31c8674d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:49:01.628827Z",
+     "iopub.status.busy": "2026-09-08T19:49:01.628638Z",
+     "iopub.status.idle": "2026-09-08T19:49:01.806746Z",
+     "shell.execute_reply": "2026-09-08T19:49:01.804020Z"
+    },
+    "papermill": {
+     "duration": 0.183328,
+     "end_time": "2026-09-08T19:49:01.808212+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:49:01.624884+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  GBM (Ch12): IC=+0.0547\n",
+      "  Ridge (Ch11): IC=+0.0437\n"
+     ]
+    }
+   ],
    "source": [
     "prior_baselines = {}\n",
     "baseline_hashes = {}\n",
@@ -295,13 +432,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a74962ab",
+   "id": "9c1d6f71",
    "metadata": {
     "papermill": {
-     "duration": 0.001368,
-     "end_time": "2026-09-06T21:50:06.441278+00:00",
+     "duration": 0.001909,
+     "end_time": "2026-09-08T19:49:01.812951+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:50:06.439910+00:00",
+     "start_time": "2026-09-08T19:49:01.811042+00:00",
      "status": "completed"
     }
    },
@@ -338,10 +475,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "51380f24",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "04bda36a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:49:01.818694Z",
+     "iopub.status.busy": "2026-09-08T19:49:01.818451Z",
+     "iopub.status.idle": "2026-09-08T19:49:29.479585Z",
+     "shell.execute_reply": "2026-09-08T19:49:29.478934Z"
+    },
+    "papermill": {
+     "duration": 27.664801,
+     "end_time": "2026-09-08T19:49:29.480020+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:49:01.815219+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>feature_count</th><th>eligible_entities</th><th>eligible_rows</th><th>folds</th><th>checkpoints</th><th>validation_start</th><th>validation_end</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td></tr></thead><tbody><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;tsmixer&quot;</td><td>71</td><td>99</td><td>187647</td><td>8</td><td>20</td><td>2015-12-28 00:00:00</td><td>2023-11-29 00:00:00</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (1, 9)\n",
+       "┌────────────┬────────────┬────────────┬───────────┬───┬───────┬───────────┬───────────┬───────────┐\n",
+       "│ label      ┆ config_nam ┆ feature_co ┆ eligible_ ┆ … ┆ folds ┆ checkpoin ┆ validatio ┆ validatio │\n",
+       "│ ---        ┆ e          ┆ unt        ┆ entities  ┆   ┆ ---   ┆ ts        ┆ n_start   ┆ n_end     │\n",
+       "│ str        ┆ ---        ┆ ---        ┆ ---       ┆   ┆ i64   ┆ ---       ┆ ---       ┆ ---       │\n",
+       "│            ┆ str        ┆ i64        ┆ i64       ┆   ┆       ┆ i64       ┆ datetime[ ┆ datetime[ │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ μs]       ┆ μs]       │\n",
+       "╞════════════╪════════════╪════════════╪═══════════╪═══╪═══════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_ret_21 ┆ tsmixer    ┆ 71         ┆ 99        ┆ … ┆ 8     ┆ 20        ┆ 2015-12-2 ┆ 2023-11-2 │\n",
+       "│ d          ┆            ┆            ┆           ┆   ┆       ┆           ┆ 8         ┆ 9         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "└────────────┴────────────┴────────────┴───────────┴───┴───────┴───────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -368,13 +551,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65b6729d",
+   "id": "6bf8ff5d",
    "metadata": {
     "papermill": {
-     "duration": 0.0018,
-     "end_time": "2026-09-06T21:50:19.523579+00:00",
+     "duration": 0.001657,
+     "end_time": "2026-09-08T19:49:29.483663+00:00",
      "exception": false,
-     "start_time": "2026-09-06T21:50:19.521779+00:00",
+     "start_time": "2026-09-08T19:49:29.482006+00:00",
      "status": "completed"
     }
    },
@@ -406,10 +589,6935 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9e5377ac",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "b5dbc8ce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:49:29.491391Z",
+     "iopub.status.busy": "2026-09-08T19:49:29.490946Z",
+     "iopub.status.idle": "2026-09-08T21:58:14.593210Z",
+     "shell.execute_reply": "2026-09-08T21:58:14.592673Z"
+    },
+    "papermill": {
+     "duration": 7725.121631,
+     "end_time": "2026-09-08T21:58:14.608377+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:49:29.486746+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Darts CV: tsmixer (tsmixer) 8 folds × 100 epochs | input=60 output=21\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fold 0: 98 training series, 90 validation series\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-dl-rerun/.venv/lib/python3.14/site-packages/pytorch_lightning/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.005025 elapsed=0.2m eta=15.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001983 elapsed=0.3m eta=14.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001119 elapsed=0.4m eta=14.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000774 elapsed=0.6m eta=13.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000615 elapsed=0.7m eta=13.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint   5/100: fold IC=+0.0384 (58.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000333 elapsed=1.1m eta=17.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000263 elapsed=1.2m eta=16.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000288 elapsed=1.4m eta=16.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000260 elapsed=1.5m eta=15.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000236 elapsed=1.7m eta=15.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  10/100: fold IC=-0.0093 (115.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000259 elapsed=2.1m eta=16.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000249 elapsed=2.2m eta=16.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000290 elapsed=2.4m eta=15.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000231 elapsed=2.5m eta=15.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000248 elapsed=2.6m eta=14.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  15/100: fold IC=-0.0697 (171.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000213 elapsed=3.0m eta=15.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000238 elapsed=3.1m eta=15.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000203 elapsed=3.2m eta=14.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000214 elapsed=3.4m eta=14.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000195 elapsed=3.5m eta=14.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  20/100: fold IC=-0.1420 (225.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000198 elapsed=3.9m eta=14.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000207 elapsed=4.0m eta=14.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000208 elapsed=4.2m eta=13.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000171 elapsed=4.3m eta=13.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000185 elapsed=4.4m eta=13.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  25/100: fold IC=-0.1435 (279.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000189 elapsed=4.8m eta=13.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000165 elapsed=4.9m eta=13.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000202 elapsed=5.1m eta=13.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000186 elapsed=5.2m eta=12.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000168 elapsed=5.3m eta=12.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  30/100: fold IC=-0.1318 (335.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000156 elapsed=5.7m eta=12.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000173 elapsed=5.8m eta=12.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000170 elapsed=6.0m eta=12.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000158 elapsed=6.1m eta=11.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000167 elapsed=6.2m eta=11.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  35/100: fold IC=-0.1238 (388.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000160 elapsed=6.6m eta=11.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000173 elapsed=6.7m eta=11.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000170 elapsed=6.9m eta=11.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000169 elapsed=7.0m eta=10.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000155 elapsed=7.1m eta=10.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  40/100: fold IC=-0.1229 (433.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000178 elapsed=7.3m eta=10.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000153 elapsed=7.5m eta=10.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000156 elapsed=7.6m eta=10.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000163 elapsed=7.7m eta=9.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000165 elapsed=7.8m eta=9.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  45/100: fold IC=-0.0965 (478.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000144 elapsed=8.1m eta=9.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000160 elapsed=8.2m eta=9.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000155 elapsed=8.4m eta=9.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000141 elapsed=8.5m eta=8.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000163 elapsed=8.6m eta=8.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  50/100: fold IC=-0.1150 (525.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000144 elapsed=8.9m eta=8.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000138 elapsed=9.0m eta=8.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000155 elapsed=9.1m eta=8.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000147 elapsed=9.2m eta=7.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000139 elapsed=9.4m eta=7.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  55/100: fold IC=-0.1324 (571.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000145 elapsed=9.7m eta=7.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000145 elapsed=9.8m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000153 elapsed=9.9m eta=7.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000136 elapsed=10.1m eta=7.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000138 elapsed=10.2m eta=6.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  60/100: fold IC=-0.1341 (618.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000145 elapsed=10.4m eta=6.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000138 elapsed=10.6m eta=6.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000128 elapsed=10.7m eta=6.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000143 elapsed=10.8m eta=6.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000137 elapsed=10.9m eta=5.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  65/100: fold IC=-0.1092 (658.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000124 elapsed=11.1m eta=5.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000128 elapsed=11.2m eta=5.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000137 elapsed=11.3m eta=5.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000126 elapsed=11.4m eta=5.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000134 elapsed=11.5m eta=4.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  70/100: fold IC=-0.1148 (694.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000135 elapsed=11.7m eta=4.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000134 elapsed=11.8m eta=4.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000126 elapsed=11.9m eta=4.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000131 elapsed=12.0m eta=4.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000130 elapsed=12.1m eta=4.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  75/100: fold IC=-0.0764 (736.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000129 elapsed=12.4m eta=3.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000121 elapsed=12.5m eta=3.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000136 elapsed=12.6m eta=3.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000131 elapsed=12.7m eta=3.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000126 elapsed=12.8m eta=3.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  80/100: fold IC=-0.0823 (777.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000133 elapsed=13.1m eta=3.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000139 elapsed=13.2m eta=2.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000131 elapsed=13.3m eta=2.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000130 elapsed=13.4m eta=2.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000127 elapsed=13.5m eta=2.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  85/100: fold IC=-0.0715 (815.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000123 elapsed=13.7m eta=2.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000129 elapsed=13.8m eta=2.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000138 elapsed=13.9m eta=1.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000129 elapsed=14.0m eta=1.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000125 elapsed=14.1m eta=1.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  90/100: fold IC=-0.0564 (854.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000122 elapsed=14.3m eta=1.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000124 elapsed=14.5m eta=1.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000123 elapsed=14.6m eta=1.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000130 elapsed=14.7m eta=0.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000113 elapsed=14.8m eta=0.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  95/100: fold IC=-0.0550 (896.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000118 elapsed=15.0m eta=0.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000127 elapsed=15.1m eta=0.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000126 elapsed=15.2m eta=0.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000125 elapsed=15.3m eta=0.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000117 elapsed=15.5m eta=0.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint 100/100: fold IC=-0.0339 (934.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    fold best epoch=5, IC=+0.0384 (934.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fold 1: 98 training series, 95 validation series\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-dl-rerun/.venv/lib/python3.14/site-packages/pytorch_lightning/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003308 elapsed=0.1m eta=11.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001287 elapsed=0.2m eta=11.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000657 elapsed=0.4m eta=11.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000499 elapsed=0.5m eta=10.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000382 elapsed=0.6m eta=10.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint   5/100: fold IC=-0.1817 (43.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000373 elapsed=0.8m eta=13.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000225 elapsed=1.0m eta=12.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000254 elapsed=1.1m eta=12.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000229 elapsed=1.2m eta=12.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000238 elapsed=1.3m eta=12.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  10/100: fold IC=-0.1254 (90.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000241 elapsed=1.6m eta=13.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000157 elapsed=1.7m eta=12.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000233 elapsed=1.9m eta=12.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000325 elapsed=2.0m eta=12.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000169 elapsed=2.1m eta=12.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  15/100: fold IC=-0.0536 (134.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000278 elapsed=2.4m eta=12.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000236 elapsed=2.5m eta=12.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000179 elapsed=2.6m eta=11.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000229 elapsed=2.7m eta=11.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000178 elapsed=2.9m eta=11.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  20/100: fold IC=+0.0078 (180.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000143 elapsed=3.1m eta=11.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000128 elapsed=3.3m eta=11.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000168 elapsed=3.4m eta=11.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000230 elapsed=3.5m eta=11.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000217 elapsed=3.6m eta=10.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  25/100: fold IC=+0.0651 (226.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000279 elapsed=3.9m eta=11.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000181 elapsed=4.0m eta=10.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000174 elapsed=4.1m eta=10.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000172 elapsed=4.2m eta=10.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000181 elapsed=4.4m eta=10.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  30/100: fold IC=+0.1361 (272.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000165 elapsed=4.7m eta=10.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000261 elapsed=4.8m eta=10.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000189 elapsed=5.0m eta=10.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000257 elapsed=5.1m eta=10.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000141 elapsed=5.3m eta=9.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  35/100: fold IC=+0.0857 (324.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000183 elapsed=5.6m eta=9.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000181 elapsed=5.7m eta=9.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000146 elapsed=5.8m eta=9.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000221 elapsed=6.0m eta=9.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000186 elapsed=6.1m eta=9.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  40/100: fold IC=+0.1329 (376.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000212 elapsed=6.4m eta=9.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000169 elapsed=6.5m eta=9.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000172 elapsed=6.7m eta=8.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000173 elapsed=6.8m eta=8.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000230 elapsed=6.9m eta=8.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  45/100: fold IC=+0.0925 (425.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000141 elapsed=7.2m eta=8.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000212 elapsed=7.3m eta=8.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000177 elapsed=7.5m eta=8.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000183 elapsed=7.6m eta=7.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000133 elapsed=7.7m eta=7.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  50/100: fold IC=+0.0925 (472.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000133 elapsed=8.0m eta=7.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000173 elapsed=8.1m eta=7.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000160 elapsed=8.3m eta=7.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000212 elapsed=8.4m eta=7.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000117 elapsed=8.5m eta=7.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  55/100: fold IC=+0.1207 (520.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000190 elapsed=8.8m eta=6.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000176 elapsed=8.9m eta=6.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000140 elapsed=9.1m eta=6.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000171 elapsed=9.2m eta=6.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000193 elapsed=9.3m eta=6.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  60/100: fold IC=+0.0842 (567.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000141 elapsed=9.6m eta=6.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000136 elapsed=9.7m eta=5.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000138 elapsed=9.8m eta=5.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000172 elapsed=9.9m eta=5.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000169 elapsed=10.0m eta=5.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  65/100: fold IC=+0.0056 (609.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000112 elapsed=10.3m eta=5.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000144 elapsed=10.4m eta=5.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000123 elapsed=10.6m eta=5.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000189 elapsed=10.7m eta=4.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000131 elapsed=10.8m eta=4.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  70/100: fold IC=-0.0302 (657.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000150 elapsed=11.1m eta=4.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000137 elapsed=11.2m eta=4.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000126 elapsed=11.3m eta=4.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000132 elapsed=11.4m eta=4.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000164 elapsed=11.6m eta=3.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  75/100: fold IC=-0.0577 (700.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000222 elapsed=11.8m eta=3.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000181 elapsed=11.9m eta=3.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000127 elapsed=12.0m eta=3.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000129 elapsed=12.1m eta=3.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000151 elapsed=12.3m eta=3.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  80/100: fold IC=-0.0970 (741.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000123 elapsed=12.5m eta=2.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000152 elapsed=12.6m eta=2.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000142 elapsed=12.7m eta=2.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000121 elapsed=12.8m eta=2.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000127 elapsed=12.9m eta=2.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  85/100: fold IC=-0.0903 (783.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000138 elapsed=13.2m eta=2.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000122 elapsed=13.3m eta=2.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000147 elapsed=13.4m eta=1.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000142 elapsed=13.5m eta=1.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000129 elapsed=13.7m eta=1.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  90/100: fold IC=-0.0848 (826.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000101 elapsed=13.9m eta=1.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000136 elapsed=14.0m eta=1.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000221 elapsed=14.1m eta=1.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000110 elapsed=14.3m eta=0.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000163 elapsed=14.4m eta=0.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  95/100: fold IC=-0.0726 (869.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000105 elapsed=14.6m eta=0.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000115 elapsed=14.8m eta=0.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000139 elapsed=14.9m eta=0.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000126 elapsed=15.0m eta=0.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000162 elapsed=15.2m eta=0.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint 100/100: fold IC=-0.0828 (918.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    fold best epoch=30, IC=+0.1361 (918.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fold 2: 105 training series, 96 validation series\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-dl-rerun/.venv/lib/python3.14/site-packages/pytorch_lightning/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.004033 elapsed=0.1m eta=13.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001678 elapsed=0.3m eta=13.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000900 elapsed=0.4m eta=12.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000642 elapsed=0.5m eta=12.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000461 elapsed=0.6m eta=12.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint   5/100: fold IC=+0.0440 (45.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000234 elapsed=0.9m eta=13.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000228 elapsed=1.0m eta=13.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000223 elapsed=1.1m eta=13.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000214 elapsed=1.3m eta=12.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000230 elapsed=1.4m eta=12.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  10/100: fold IC=+0.0424 (90.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000267 elapsed=1.6m eta=13.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000203 elapsed=1.8m eta=12.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000184 elapsed=1.9m eta=12.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000193 elapsed=2.0m eta=12.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000198 elapsed=2.2m eta=12.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  15/100: fold IC=+0.0957 (138.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000195 elapsed=2.4m eta=12.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000198 elapsed=2.6m eta=12.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000191 elapsed=2.7m eta=12.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000173 elapsed=2.9m eta=12.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000179 elapsed=3.0m eta=12.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  20/100: fold IC=+0.0684 (186.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000165 elapsed=3.2m eta=12.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000158 elapsed=3.3m eta=11.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000176 elapsed=3.4m eta=11.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000163 elapsed=3.6m eta=11.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000158 elapsed=3.7m eta=11.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  25/100: fold IC=+0.0091 (228.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000140 elapsed=3.9m eta=11.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000151 elapsed=4.0m eta=10.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000157 elapsed=4.1m eta=10.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000153 elapsed=4.3m eta=10.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000129 elapsed=4.4m eta=10.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  30/100: fold IC=-0.0367 (270.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000141 elapsed=4.6m eta=10.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000157 elapsed=4.8m eta=10.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000155 elapsed=4.9m eta=9.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000156 elapsed=5.0m eta=9.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000146 elapsed=5.1m eta=9.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  35/100: fold IC=-0.0590 (315.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000141 elapsed=5.4m eta=9.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000134 elapsed=5.5m eta=9.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000142 elapsed=5.6m eta=9.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000141 elapsed=5.8m eta=9.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000140 elapsed=5.9m eta=8.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  40/100: fold IC=-0.0718 (361.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000123 elapsed=6.2m eta=8.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000127 elapsed=6.3m eta=8.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000136 elapsed=6.4m eta=8.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000140 elapsed=6.5m eta=8.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000137 elapsed=6.7m eta=8.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  45/100: fold IC=-0.0674 (406.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000133 elapsed=6.9m eta=8.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000123 elapsed=7.0m eta=7.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000126 elapsed=7.2m eta=7.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000128 elapsed=7.3m eta=7.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000120 elapsed=7.4m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  50/100: fold IC=-0.0471 (451.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000119 elapsed=7.7m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000122 elapsed=7.8m eta=7.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000115 elapsed=7.9m eta=7.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000135 elapsed=8.1m eta=6.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000118 elapsed=8.2m eta=6.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  55/100: fold IC=-0.0226 (498.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000113 elapsed=8.4m eta=6.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000131 elapsed=8.6m eta=6.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000117 elapsed=8.7m eta=6.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000106 elapsed=8.9m eta=6.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000105 elapsed=9.0m eta=6.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  60/100: fold IC=-0.0451 (546.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000100 elapsed=9.3m eta=5.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000117 elapsed=9.4m eta=5.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000118 elapsed=9.5m eta=5.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000113 elapsed=9.7m eta=5.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000119 elapsed=9.8m eta=5.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  65/100: fold IC=-0.0724 (597.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000102 elapsed=10.1m eta=5.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000115 elapsed=10.2m eta=5.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000095 elapsed=10.4m eta=4.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000112 elapsed=10.5m eta=4.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000109 elapsed=10.6m eta=4.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  70/100: fold IC=-0.0811 (645.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000119 elapsed=10.9m eta=4.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000104 elapsed=11.0m eta=4.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000106 elapsed=11.2m eta=4.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000103 elapsed=11.3m eta=4.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000110 elapsed=11.4m eta=3.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  75/100: fold IC=-0.0626 (691.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000100 elapsed=11.7m eta=3.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000106 elapsed=11.8m eta=3.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000107 elapsed=11.9m eta=3.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000107 elapsed=12.0m eta=3.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000108 elapsed=12.2m eta=3.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  80/100: fold IC=-0.0817 (735.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000104 elapsed=12.4m eta=2.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000099 elapsed=12.5m eta=2.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000095 elapsed=12.6m eta=2.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000099 elapsed=12.8m eta=2.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000098 elapsed=12.9m eta=2.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  85/100: fold IC=-0.1068 (779.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000111 elapsed=13.1m eta=2.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000103 elapsed=13.2m eta=2.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000118 elapsed=13.4m eta=1.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000106 elapsed=13.5m eta=1.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000110 elapsed=13.6m eta=1.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  90/100: fold IC=-0.1110 (825.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000104 elapsed=13.9m eta=1.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000090 elapsed=14.0m eta=1.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000112 elapsed=14.2m eta=1.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000107 elapsed=14.3m eta=0.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000100 elapsed=14.4m eta=0.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  95/100: fold IC=-0.1097 (870.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000091 elapsed=14.6m eta=0.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000104 elapsed=14.8m eta=0.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000111 elapsed=14.9m eta=0.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000102 elapsed=15.1m eta=0.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000096 elapsed=15.2m eta=0.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint 100/100: fold IC=-0.0860 (917.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    fold best epoch=15, IC=+0.0957 (917.7s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fold 3: 106 training series, 97 validation series\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-dl-rerun/.venv/lib/python3.14/site-packages/pytorch_lightning/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001988 elapsed=0.1m eta=13.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000687 elapsed=0.3m eta=13.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000411 elapsed=0.5m eta=15.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000292 elapsed=0.7m eta=16.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000237 elapsed=0.9m eta=17.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint   5/100: fold IC=-0.0699 (64.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000173 elapsed=1.2m eta=19.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000170 elapsed=1.3m eta=17.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000154 elapsed=1.5m eta=16.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000141 elapsed=1.6m eta=16.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000163 elapsed=1.8m eta=15.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  10/100: fold IC=+0.0767 (111.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000147 elapsed=2.0m eta=16.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000137 elapsed=2.1m eta=15.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000134 elapsed=2.3m eta=15.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000125 elapsed=2.5m eta=15.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000154 elapsed=2.6m eta=14.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  15/100: fold IC=+0.0154 (164.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000140 elapsed=2.9m eta=15.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000140 elapsed=3.1m eta=15.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000136 elapsed=3.2m eta=14.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000130 elapsed=3.4m eta=14.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000139 elapsed=3.6m eta=14.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  20/100: fold IC=+0.0171 (222.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000132 elapsed=3.9m eta=14.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000145 elapsed=4.1m eta=14.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000135 elapsed=4.2m eta=14.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000145 elapsed=4.4m eta=13.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000125 elapsed=4.6m eta=13.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  25/100: fold IC=+0.0570 (283.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000127 elapsed=4.9m eta=14.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000131 elapsed=5.1m eta=13.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000132 elapsed=5.2m eta=13.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000128 elapsed=5.4m eta=13.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000135 elapsed=5.5m eta=12.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  30/100: fold IC=+0.0938 (338.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000122 elapsed=5.8m eta=12.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000128 elapsed=6.0m eta=12.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000126 elapsed=6.2m eta=12.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000127 elapsed=6.4m eta=12.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000125 elapsed=6.6m eta=12.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  35/100: fold IC=+0.0795 (405.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000119 elapsed=6.9m eta=12.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000123 elapsed=7.1m eta=12.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000130 elapsed=7.4m eta=12.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000122 elapsed=7.6m eta=11.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000133 elapsed=7.8m eta=11.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  40/100: fold IC=+0.0491 (474.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000120 elapsed=8.1m eta=11.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000122 elapsed=8.3m eta=11.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000124 elapsed=8.5m eta=11.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000128 elapsed=8.7m eta=11.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000127 elapsed=8.8m eta=10.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  45/100: fold IC=+0.0730 (538.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000128 elapsed=9.1m eta=10.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000118 elapsed=9.3m eta=10.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000119 elapsed=9.4m eta=10.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000108 elapsed=9.6m eta=10.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000130 elapsed=9.8m eta=9.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  50/100: fold IC=+0.0760 (593.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000109 elapsed=10.0m eta=9.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000122 elapsed=10.2m eta=9.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000119 elapsed=10.3m eta=9.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000121 elapsed=10.5m eta=8.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000121 elapsed=10.6m eta=8.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  55/100: fold IC=+0.0365 (644.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000119 elapsed=10.9m eta=8.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000122 elapsed=11.0m eta=8.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000126 elapsed=11.2m eta=8.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000113 elapsed=11.3m eta=7.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000110 elapsed=11.5m eta=7.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  60/100: fold IC=+0.0588 (695.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000125 elapsed=11.8m eta=7.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000121 elapsed=11.9m eta=7.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000123 elapsed=12.1m eta=7.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000127 elapsed=12.2m eta=6.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000113 elapsed=12.4m eta=6.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  65/100: fold IC=+0.0291 (753.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000109 elapsed=12.7m eta=6.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000111 elapsed=12.8m eta=6.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000112 elapsed=13.0m eta=6.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000118 elapsed=13.2m eta=5.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000110 elapsed=13.3m eta=5.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  70/100: fold IC=+0.0661 (805.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000122 elapsed=13.6m eta=5.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000108 elapsed=13.7m eta=5.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000109 elapsed=13.9m eta=5.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000117 elapsed=14.1m eta=4.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000124 elapsed=14.2m eta=4.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  75/100: fold IC=+0.0825 (860.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000112 elapsed=14.5m eta=4.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000112 elapsed=14.7m eta=4.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000109 elapsed=14.8m eta=4.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000112 elapsed=15.0m eta=4.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000113 elapsed=15.2m eta=3.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  80/100: fold IC=+0.0520 (919.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000109 elapsed=15.5m eta=3.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000117 elapsed=15.6m eta=3.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000117 elapsed=15.8m eta=3.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000118 elapsed=16.0m eta=3.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000116 elapsed=16.2m eta=2.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  85/100: fold IC=+0.0328 (979.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000114 elapsed=16.5m eta=2.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000118 elapsed=16.7m eta=2.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000109 elapsed=16.9m eta=2.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000113 elapsed=17.1m eta=2.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000107 elapsed=17.3m eta=1.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  90/100: fold IC=+0.0568 (1050.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000112 elapsed=17.7m eta=1.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000113 elapsed=17.8m eta=1.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000108 elapsed=18.0m eta=1.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000104 elapsed=18.2m eta=1.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000107 elapsed=18.4m eta=1.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  95/100: fold IC=+0.0650 (1117.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000111 elapsed=18.9m eta=0.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000113 elapsed=19.2m eta=0.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000103 elapsed=19.4m eta=0.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000113 elapsed=19.6m eta=0.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000106 elapsed=19.9m eta=0.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint 100/100: fold IC=+0.0713 (1206.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    fold best epoch=30, IC=+0.0938 (1206.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fold 4: 102 training series, 97 validation series\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-dl-rerun/.venv/lib/python3.14/site-packages/pytorch_lightning/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003394 elapsed=0.2m eta=19.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001146 elapsed=0.4m eta=20.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000602 elapsed=0.7m eta=21.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000393 elapsed=0.9m eta=22.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000292 elapsed=1.2m eta=22.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint   5/100: fold IC=+0.1824 (82.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000170 elapsed=1.6m eta=24.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000139 elapsed=1.8m eta=23.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000151 elapsed=2.0m eta=22.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000127 elapsed=2.2m eta=22.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000129 elapsed=2.4m eta=21.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  10/100: fold IC=+0.1290 (155.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000130 elapsed=2.8m eta=22.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000138 elapsed=3.0m eta=22.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000127 elapsed=3.2m eta=21.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000130 elapsed=3.5m eta=21.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000131 elapsed=3.7m eta=21.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  15/100: fold IC=+0.1007 (236.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000134 elapsed=4.2m eta=21.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000132 elapsed=4.4m eta=21.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000124 elapsed=4.7m eta=21.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000131 elapsed=5.0m eta=21.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000131 elapsed=5.2m eta=20.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  20/100: fold IC=+0.0750 (323.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000132 elapsed=5.7m eta=21.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000132 elapsed=6.0m eta=21.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000126 elapsed=6.2m eta=20.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000126 elapsed=6.4m eta=20.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000122 elapsed=6.7m eta=20.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  25/100: fold IC=-0.0311 (411.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000121 elapsed=7.2m eta=20.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000118 elapsed=7.5m eta=20.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000118 elapsed=7.8m eta=20.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000129 elapsed=8.0m eta=19.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000122 elapsed=8.3m eta=19.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  30/100: fold IC=-0.0367 (506.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000118 elapsed=8.7m eta=19.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000124 elapsed=9.0m eta=19.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000116 elapsed=9.2m eta=18.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000123 elapsed=9.4m eta=18.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000114 elapsed=9.7m eta=18.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  35/100: fold IC=-0.0201 (592.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000116 elapsed=10.1m eta=18.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000111 elapsed=10.4m eta=17.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000112 elapsed=10.7m eta=17.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000115 elapsed=10.9m eta=17.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000112 elapsed=11.2m eta=16.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  40/100: fold IC=-0.0421 (682.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000112 elapsed=11.6m eta=16.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000117 elapsed=11.9m eta=16.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000117 elapsed=12.2m eta=16.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000103 elapsed=12.4m eta=15.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000108 elapsed=12.7m eta=15.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  45/100: fold IC=-0.0472 (775.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000108 elapsed=13.2m eta=15.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000110 elapsed=13.4m eta=15.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000105 elapsed=13.7m eta=14.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000106 elapsed=13.9m eta=14.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000103 elapsed=14.2m eta=14.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  50/100: fold IC=-0.0402 (860.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000107 elapsed=14.5m eta=14.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000109 elapsed=14.7m eta=13.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000114 elapsed=14.9m eta=13.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000106 elapsed=15.0m eta=12.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000105 elapsed=15.2m eta=12.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  55/100: fold IC=-0.0528 (922.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000113 elapsed=15.5m eta=12.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000102 elapsed=15.7m eta=11.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000102 elapsed=15.9m eta=11.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000106 elapsed=16.0m eta=11.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000102 elapsed=16.2m eta=10.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  60/100: fold IC=-0.0224 (981.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000100 elapsed=16.5m eta=10.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000103 elapsed=16.7m eta=10.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000101 elapsed=16.9m eta=9.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000096 elapsed=17.0m eta=9.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000104 elapsed=17.2m eta=9.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  65/100: fold IC=-0.0090 (1039.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000102 elapsed=17.5m eta=9.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000098 elapsed=17.7m eta=8.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000107 elapsed=17.8m eta=8.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000104 elapsed=17.9m eta=8.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000099 elapsed=18.1m eta=7.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  70/100: fold IC=+0.0003 (1096.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000101 elapsed=18.4m eta=7.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000096 elapsed=18.6m eta=7.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000097 elapsed=18.8m eta=6.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000095 elapsed=18.9m eta=6.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000101 elapsed=19.1m eta=6.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  75/100: fold IC=-0.0023 (1159.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000100 elapsed=19.5m eta=6.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000101 elapsed=19.6m eta=5.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000101 elapsed=19.8m eta=5.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000100 elapsed=20.0m eta=5.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000094 elapsed=20.2m eta=5.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  80/100: fold IC=-0.0024 (1222.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000100 elapsed=20.6m eta=4.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000095 elapsed=20.7m eta=4.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000098 elapsed=20.9m eta=4.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000101 elapsed=21.1m eta=4.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000103 elapsed=21.2m eta=3.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  85/100: fold IC=-0.0088 (1286.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000098 elapsed=21.6m eta=3.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000095 elapsed=21.8m eta=3.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000094 elapsed=22.0m eta=3.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000098 elapsed=22.3m eta=2.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000092 elapsed=22.4m eta=2.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  90/100: fold IC=-0.0436 (1356.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000094 elapsed=22.8m eta=2.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000094 elapsed=23.1m eta=2.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000091 elapsed=23.3m eta=1.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000088 elapsed=23.5m eta=1.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000092 elapsed=23.7m eta=1.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  95/100: fold IC=-0.0599 (1432.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000098 elapsed=24.1m eta=1.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000093 elapsed=24.3m eta=0.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000095 elapsed=24.5m eta=0.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000095 elapsed=24.7m eta=0.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000095 elapsed=24.9m eta=0.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint 100/100: fold IC=-0.0789 (1505.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    fold best epoch=5, IC=+0.1824 (1505.7s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fold 5: 103 training series, 96 validation series\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-dl-rerun/.venv/lib/python3.14/site-packages/pytorch_lightning/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002586 elapsed=0.2m eta=16.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001110 elapsed=0.4m eta=19.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000633 elapsed=0.6m eta=19.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000446 elapsed=0.8m eta=19.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000323 elapsed=1.0m eta=19.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint   5/100: fold IC=-0.0256 (71.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000211 elapsed=1.4m eta=21.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000193 elapsed=1.6m eta=20.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000185 elapsed=1.8m eta=20.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000181 elapsed=2.0m eta=19.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000170 elapsed=2.2m eta=19.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  10/100: fold IC=+0.0406 (140.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000155 elapsed=2.5m eta=20.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000162 elapsed=2.7m eta=19.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000144 elapsed=2.8m eta=19.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000155 elapsed=3.0m eta=18.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000152 elapsed=3.2m eta=18.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  15/100: fold IC=+0.0991 (199.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000145 elapsed=3.5m eta=18.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000147 elapsed=3.7m eta=18.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000147 elapsed=3.9m eta=17.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000143 elapsed=4.1m eta=17.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000143 elapsed=4.2m eta=17.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  20/100: fold IC=+0.1418 (261.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000140 elapsed=4.5m eta=17.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000135 elapsed=4.7m eta=16.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000134 elapsed=4.8m eta=16.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000130 elapsed=5.0m eta=15.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000123 elapsed=5.2m eta=15.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  25/100: fold IC=+0.1358 (321.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000123 elapsed=5.5m eta=15.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000124 elapsed=5.7m eta=15.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000124 elapsed=5.9m eta=15.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000129 elapsed=6.1m eta=14.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000130 elapsed=6.2m eta=14.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  30/100: fold IC=+0.0677 (380.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000122 elapsed=6.5m eta=14.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000119 elapsed=6.6m eta=14.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000129 elapsed=6.8m eta=13.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000121 elapsed=7.0m eta=13.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000121 elapsed=7.1m eta=13.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  35/100: fold IC=+0.0352 (432.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000120 elapsed=7.4m eta=13.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000122 elapsed=7.5m eta=12.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000115 elapsed=7.6m eta=12.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000121 elapsed=7.8m eta=12.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000120 elapsed=7.9m eta=11.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  40/100: fold IC=-0.0179 (484.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000121 elapsed=8.2m eta=11.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000120 elapsed=8.4m eta=11.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000106 elapsed=8.6m eta=11.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000115 elapsed=8.8m eta=11.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000105 elapsed=8.9m eta=10.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  45/100: fold IC=-0.0857 (541.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000116 elapsed=9.2m eta=10.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000115 elapsed=9.3m eta=10.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000110 elapsed=9.4m eta=10.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000117 elapsed=9.6m eta=9.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000104 elapsed=9.7m eta=9.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  50/100: fold IC=-0.1016 (590.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000105 elapsed=10.0m eta=9.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000105 elapsed=10.1m eta=9.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000108 elapsed=10.3m eta=9.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000108 elapsed=10.4m eta=8.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000105 elapsed=10.5m eta=8.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  55/100: fold IC=-0.0825 (637.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000102 elapsed=10.7m eta=8.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000103 elapsed=10.9m eta=8.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000105 elapsed=11.0m eta=8.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000106 elapsed=11.1m eta=7.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000105 elapsed=11.2m eta=7.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  60/100: fold IC=-0.0696 (680.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000104 elapsed=11.5m eta=7.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000102 elapsed=11.6m eta=7.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000097 elapsed=11.7m eta=6.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000101 elapsed=11.9m eta=6.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000106 elapsed=12.0m eta=6.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  65/100: fold IC=-0.0605 (725.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000103 elapsed=12.2m eta=6.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000100 elapsed=12.3m eta=6.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000103 elapsed=12.4m eta=5.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000097 elapsed=12.6m eta=5.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000099 elapsed=12.7m eta=5.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  70/100: fold IC=-0.0854 (769.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000100 elapsed=13.0m eta=5.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000094 elapsed=13.1m eta=5.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000097 elapsed=13.2m eta=4.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000092 elapsed=13.4m eta=4.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000100 elapsed=13.5m eta=4.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  75/100: fold IC=-0.0544 (815.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000094 elapsed=13.7m eta=4.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000099 elapsed=13.9m eta=4.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000097 elapsed=14.0m eta=4.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000096 elapsed=14.1m eta=3.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000100 elapsed=14.3m eta=3.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  80/100: fold IC=-0.0627 (863.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000093 elapsed=14.5m eta=3.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000100 elapsed=14.6m eta=3.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000099 elapsed=14.8m eta=3.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000093 elapsed=14.9m eta=2.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000092 elapsed=15.0m eta=2.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  85/100: fold IC=-0.0469 (908.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000094 elapsed=15.3m eta=2.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000090 elapsed=15.4m eta=2.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000103 elapsed=15.5m eta=2.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000089 elapsed=15.7m eta=1.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000091 elapsed=15.8m eta=1.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  90/100: fold IC=-0.0201 (955.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000093 elapsed=16.0m eta=1.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000100 elapsed=16.2m eta=1.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000096 elapsed=16.3m eta=1.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000095 elapsed=16.5m eta=1.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000094 elapsed=16.6m eta=0.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  95/100: fold IC=-0.0131 (1001.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000092 elapsed=16.8m eta=0.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000091 elapsed=16.9m eta=0.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000087 elapsed=17.1m eta=0.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000093 elapsed=17.2m eta=0.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000092 elapsed=17.3m eta=0.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint 100/100: fold IC=-0.0025 (1045.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    fold best epoch=20, IC=+0.1418 (1045.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fold 6: 103 training series, 97 validation series\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-dl-rerun/.venv/lib/python3.14/site-packages/pytorch_lightning/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001843 elapsed=0.1m eta=14.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000623 elapsed=0.4m eta=17.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000407 elapsed=0.5m eta=16.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000311 elapsed=0.8m eta=18.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000255 elapsed=1.0m eta=18.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint   5/100: fold IC=+0.0104 (70.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000191 elapsed=1.3m eta=20.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000183 elapsed=1.4m eta=18.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000181 elapsed=1.5m eta=17.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000172 elapsed=1.6m eta=16.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000187 elapsed=1.8m eta=15.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  10/100: fold IC=+0.0320 (111.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000165 elapsed=2.0m eta=15.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000157 elapsed=2.1m eta=15.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000159 elapsed=2.2m eta=14.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000165 elapsed=2.4m eta=14.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000155 elapsed=2.5m eta=14.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  15/100: fold IC=-0.0617 (152.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000147 elapsed=2.6m eta=13.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000151 elapsed=2.7m eta=13.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000140 elapsed=2.8m eta=12.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000129 elapsed=2.9m eta=12.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000137 elapsed=3.0m eta=11.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  20/100: fold IC=-0.0047 (181.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000135 elapsed=3.1m eta=11.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000140 elapsed=3.2m eta=11.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000140 elapsed=3.3m eta=10.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000141 elapsed=3.3m eta=10.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000126 elapsed=3.4m eta=10.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  25/100: fold IC=+0.0094 (209.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000130 elapsed=3.6m eta=10.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000134 elapsed=3.7m eta=9.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000130 elapsed=3.7m eta=9.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000132 elapsed=3.8m eta=9.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000119 elapsed=3.9m eta=9.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  30/100: fold IC=+0.0031 (239.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000115 elapsed=4.1m eta=9.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000132 elapsed=4.1m eta=8.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000120 elapsed=4.2m eta=8.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000115 elapsed=4.3m eta=8.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000114 elapsed=4.4m eta=8.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  35/100: fold IC=-0.0350 (265.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000123 elapsed=4.5m eta=8.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000118 elapsed=4.6m eta=7.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000123 elapsed=4.7m eta=7.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000122 elapsed=4.7m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000117 elapsed=4.8m eta=7.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  40/100: fold IC=-0.0369 (291.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000110 elapsed=4.9m eta=7.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000115 elapsed=5.0m eta=6.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000117 elapsed=5.1m eta=6.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000112 elapsed=5.2m eta=6.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000111 elapsed=5.2m eta=6.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  45/100: fold IC=-0.0224 (317.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000119 elapsed=5.4m eta=6.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000113 elapsed=5.5m eta=6.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000114 elapsed=5.6m eta=6.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000115 elapsed=5.7m eta=5.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000109 elapsed=5.8m eta=5.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  50/100: fold IC=-0.0416 (351.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000114 elapsed=6.0m eta=5.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000116 elapsed=6.1m eta=5.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000110 elapsed=6.1m eta=5.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000108 elapsed=6.3m eta=5.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000113 elapsed=6.3m eta=5.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  55/100: fold IC=-0.0306 (385.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000115 elapsed=6.5m eta=5.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000115 elapsed=6.6m eta=5.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000105 elapsed=6.7m eta=4.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000108 elapsed=6.8m eta=4.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000110 elapsed=6.9m eta=4.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  60/100: fold IC=-0.0480 (416.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000108 elapsed=7.0m eta=4.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000107 elapsed=7.1m eta=4.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000107 elapsed=7.2m eta=4.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000110 elapsed=7.2m eta=4.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000103 elapsed=7.3m eta=3.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  65/100: fold IC=-0.0624 (442.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000105 elapsed=7.4m eta=3.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000103 elapsed=7.5m eta=3.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000102 elapsed=7.6m eta=3.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000104 elapsed=7.7m eta=3.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000106 elapsed=7.7m eta=3.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  70/100: fold IC=-0.0452 (467.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000105 elapsed=7.9m eta=3.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000101 elapsed=7.9m eta=3.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000103 elapsed=8.0m eta=3.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000100 elapsed=8.1m eta=2.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000099 elapsed=8.1m eta=2.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  75/100: fold IC=-0.0236 (491.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000096 elapsed=8.3m eta=2.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000106 elapsed=8.3m eta=2.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000105 elapsed=8.4m eta=2.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000096 elapsed=8.5m eta=2.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000101 elapsed=8.5m eta=2.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  80/100: fold IC=-0.0257 (514.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000103 elapsed=8.6m eta=2.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000104 elapsed=8.7m eta=1.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000093 elapsed=8.8m eta=1.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000095 elapsed=8.9m eta=1.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000101 elapsed=8.9m eta=1.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  85/100: fold IC=-0.0214 (538.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000099 elapsed=9.0m eta=1.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000098 elapsed=9.1m eta=1.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000097 elapsed=9.2m eta=1.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000102 elapsed=9.3m eta=1.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000098 elapsed=9.3m eta=1.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  90/100: fold IC=-0.0243 (562.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000101 elapsed=9.4m eta=0.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000099 elapsed=9.5m eta=0.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000104 elapsed=9.6m eta=0.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000094 elapsed=9.6m eta=0.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000092 elapsed=9.7m eta=0.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  95/100: fold IC=-0.0293 (585.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000098 elapsed=9.8m eta=0.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000098 elapsed=9.9m eta=0.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000089 elapsed=10.0m eta=0.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000092 elapsed=10.0m eta=0.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000105 elapsed=10.1m eta=0.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint 100/100: fold IC=-0.0401 (608.9s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    fold best epoch=10, IC=+0.0320 (608.9s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fold 7: 104 training series, 96 validation series\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-dl-rerun/.venv/lib/python3.14/site-packages/pytorch_lightning/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001677 elapsed=0.1m eta=7.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000680 elapsed=0.2m eta=8.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000383 elapsed=0.2m eta=7.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000310 elapsed=0.3m eta=8.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000226 elapsed=0.4m eta=7.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint   5/100: fold IC=+0.0318 (27.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000160 elapsed=0.5m eta=8.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000232 elapsed=0.6m eta=8.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000186 elapsed=0.7m eta=8.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000138 elapsed=0.8m eta=7.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000152 elapsed=0.9m eta=7.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  10/100: fold IC=+0.1007 (54.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000194 elapsed=1.0m eta=7.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000172 elapsed=1.1m eta=7.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000167 elapsed=1.1m eta=7.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000153 elapsed=1.2m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000153 elapsed=1.3m eta=7.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  15/100: fold IC=+0.0427 (80.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000157 elapsed=1.4m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000154 elapsed=1.5m eta=7.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000197 elapsed=1.6m eta=7.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000138 elapsed=1.7m eta=7.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000157 elapsed=1.8m eta=7.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  20/100: fold IC=+0.0092 (110.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000135 elapsed=2.0m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000151 elapsed=2.1m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000123 elapsed=2.2m eta=7.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000135 elapsed=2.2m eta=7.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000132 elapsed=2.4m eta=7.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  25/100: fold IC=-0.0110 (148.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000120 elapsed=2.6m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000127 elapsed=2.7m eta=7.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000120 elapsed=2.8m eta=7.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000121 elapsed=2.9m eta=7.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000118 elapsed=3.0m eta=6.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  30/100: fold IC=-0.0312 (180.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000105 elapsed=3.1m eta=6.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000146 elapsed=3.2m eta=6.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000142 elapsed=3.2m eta=6.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000126 elapsed=3.3m eta=6.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000142 elapsed=3.4m eta=6.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  35/100: fold IC=-0.0275 (205.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000115 elapsed=3.5m eta=6.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000102 elapsed=3.6m eta=6.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000148 elapsed=3.6m eta=6.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000126 elapsed=3.7m eta=5.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000109 elapsed=3.8m eta=5.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  40/100: fold IC=-0.0539 (230.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000116 elapsed=3.9m eta=5.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000131 elapsed=4.0m eta=5.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000108 elapsed=4.1m eta=5.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000112 elapsed=4.1m eta=5.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000123 elapsed=4.2m eta=5.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  45/100: fold IC=-0.0451 (254.6s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000111 elapsed=4.3m eta=5.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000089 elapsed=4.4m eta=4.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000101 elapsed=4.5m eta=4.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000096 elapsed=4.5m eta=4.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000141 elapsed=4.6m eta=4.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  50/100: fold IC=-0.1012 (278.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000116 elapsed=4.7m eta=4.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000132 elapsed=4.8m eta=4.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000105 elapsed=4.8m eta=4.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000091 elapsed=4.9m eta=4.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000134 elapsed=5.0m eta=4.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  55/100: fold IC=-0.0845 (301.7s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000100 elapsed=5.1m eta=4.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000124 elapsed=5.2m eta=3.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000115 elapsed=5.2m eta=3.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000102 elapsed=5.3m eta=3.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000094 elapsed=5.4m eta=3.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  60/100: fold IC=-0.1257 (326.4s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000107 elapsed=5.5m eta=3.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000111 elapsed=5.6m eta=3.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000107 elapsed=5.7m eta=3.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000104 elapsed=5.8m eta=3.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000127 elapsed=5.8m eta=3.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  65/100: fold IC=-0.1220 (353.5s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000094 elapsed=6.0m eta=3.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000107 elapsed=6.0m eta=3.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000105 elapsed=6.1m eta=2.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000096 elapsed=6.2m eta=2.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000133 elapsed=6.3m eta=2.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  70/100: fold IC=-0.1169 (383.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000084 elapsed=6.5m eta=2.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000109 elapsed=6.6m eta=2.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000103 elapsed=6.7m eta=2.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000083 elapsed=6.8m eta=2.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000091 elapsed=6.9m eta=2.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  75/100: fold IC=-0.1049 (417.8s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000099 elapsed=7.1m eta=2.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000102 elapsed=7.2m eta=2.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000096 elapsed=7.3m eta=2.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000168 elapsed=7.3m eta=1.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000097 elapsed=7.4m eta=1.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  80/100: fold IC=-0.1121 (447.2s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000085 elapsed=7.5m eta=1.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000092 elapsed=7.6m eta=1.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000098 elapsed=7.7m eta=1.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000100 elapsed=7.7m eta=1.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000106 elapsed=7.8m eta=1.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  85/100: fold IC=-0.1127 (471.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000103 elapsed=7.9m eta=1.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000083 elapsed=8.0m eta=1.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000096 elapsed=8.1m eta=1.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000116 elapsed=8.2m eta=1.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000112 elapsed=8.2m eta=0.9m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  90/100: fold IC=-0.1267 (498.1s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000097 elapsed=8.4m eta=0.8m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000105 elapsed=8.5m eta=0.7m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000089 elapsed=8.6m eta=0.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000102 elapsed=8.6m eta=0.6m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000094 elapsed=8.7m eta=0.5m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint  95/100: fold IC=-0.1180 (525.0s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000089 elapsed=8.8m eta=0.4m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000088 elapsed=8.9m eta=0.3m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000079 elapsed=9.0m eta=0.2m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000100 elapsed=9.0m eta=0.1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000083 elapsed=9.1m eta=0.0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        checkpoint 100/100: fold IC=-0.1309 (550.3s elapsed)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    fold best epoch=10, IC=+0.1007 (550.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  tsmixer: epoch=10, IC=+0.0352 (std=0.0730, 7687.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 configurations: 1 trained, 0 read\n",
+      "population etfs-tsmixer-validation-v1: 20 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "population_name = POPULATION_NAME or \"etfs-tsmixer-validation-v1\"\n",
     "execution, population = run_model_population(\n",
@@ -428,13 +7536,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bfbd872",
+   "id": "e97159f3",
    "metadata": {
     "papermill": {
-     "duration": 0.014515,
-     "end_time": "2026-09-06T22:57:36.483374+00:00",
+     "duration": 0.01525,
+     "end_time": "2026-09-08T21:58:14.637542+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:57:36.468859+00:00",
+     "start_time": "2026-09-08T21:58:14.622292+00:00",
      "status": "completed"
     }
    },
@@ -463,9 +7571,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e83ef7c0",
-   "metadata": {},
+   "execution_count": 9,
+   "id": "74478b39",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:58:14.676540Z",
+     "iopub.status.busy": "2026-09-08T21:58:14.676421Z",
+     "iopub.status.idle": "2026-09-08T21:58:14.699558Z",
+     "shell.execute_reply": "2026-09-08T21:58:14.699091Z"
+    },
+    "papermill": {
+     "duration": 0.042908,
+     "end_time": "2026-09-08T21:58:14.700129+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:58:14.657221+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "_daily = pl.concat(\n",
@@ -504,13 +7626,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1966b23d",
+   "id": "e08c44b6",
    "metadata": {
     "papermill": {
-     "duration": 0.015058,
-     "end_time": "2026-09-06T22:57:36.564808+00:00",
+     "duration": 0.014075,
+     "end_time": "2026-09-08T21:58:14.731948+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:57:36.549750+00:00",
+     "start_time": "2026-09-08T21:58:14.717873+00:00",
      "status": "completed"
     }
    },
@@ -525,14 +7647,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "24b3f773",
+   "execution_count": 10,
+   "id": "19138568",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:58:14.760855Z",
+     "iopub.status.busy": "2026-09-08T21:58:14.760740Z",
+     "iopub.status.idle": "2026-09-08T21:58:14.767679Z",
+     "shell.execute_reply": "2026-09-08T21:58:14.767162Z"
+    },
+    "papermill": {
+     "duration": 0.022242,
+     "end_time": "2026-09-08T21:58:14.768171+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:58:14.745929+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config: tsmixer   full-coverage validation days = 1995\n",
+      "shape: (20, 4)\n",
+      "┌──────────────────┬───────────────┬───────────┬───────────────┐\n",
+      "│ checkpoint_value ┆ ic_mean_daily ┆ ic_n_days ┆ full_coverage │\n",
+      "│ ---              ┆ ---           ┆ ---       ┆ ---           │\n",
+      "│ i64              ┆ f64           ┆ f64       ┆ bool          │\n",
+      "╞══════════════════╪═══════════════╪═══════════╪═══════════════╡\n",
+      "│ 5                ┆ 0.003439      ┆ 1995.0    ┆ true          │\n",
+      "│ 10               ┆ 0.035161      ┆ 1995.0    ┆ true          │\n",
+      "│ 15               ┆ 0.020844      ┆ 1995.0    ┆ true          │\n",
+      "│ 20               ┆ 0.021694      ┆ 1995.0    ┆ true          │\n",
+      "│ 25               ┆ 0.011598      ┆ 1995.0    ┆ true          │\n",
+      "│ …                ┆ …             ┆ …         ┆ …             │\n",
+      "│ 80               ┆ -0.050833     ┆ 1995.0    ┆ true          │\n",
+      "│ 85               ┆ -0.052581     ┆ 1995.0    ┆ true          │\n",
+      "│ 90               ┆ -0.050457     ┆ 1995.0    ┆ true          │\n",
+      "│ 95               ┆ -0.048353     ┆ 1995.0    ┆ true          │\n",
+      "│ 100              ┆ -0.047099     ┆ 1995.0    ┆ true          │\n",
+      "└──────────────────┴───────────────┴───────────┴───────────────┘\n",
+      "\n",
+      "Published as candidates: 20 full-coverage checkpoints\n",
+      "Highest validation IC: epoch 10 (IC=+0.0352)\n"
+     ]
+    }
+   ],
    "source": [
     "eligible = checkpoints.filter(\"full_coverage\")\n",
     "if eligible.is_empty():\n",
@@ -562,13 +7726,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a42c41e9",
+   "id": "f4efc891",
    "metadata": {
     "papermill": {
-     "duration": 0.028799,
-     "end_time": "2026-09-06T22:57:36.663804+00:00",
+     "duration": 0.014514,
+     "end_time": "2026-09-08T21:58:14.799470+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:57:36.635005+00:00",
+     "start_time": "2026-09-08T21:58:14.784956+00:00",
      "status": "completed"
     }
    },
@@ -582,10 +7746,274 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3bfe3d8a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 11,
+   "id": "146b00db",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:58:14.829914Z",
+     "iopub.status.busy": "2026-09-08T21:58:14.829784Z",
+     "iopub.status.idle": "2026-09-08T21:58:16.484631Z",
+     "shell.execute_reply": "2026-09-08T21:58:16.484203Z"
+    },
+    "papermill": {
+     "duration": 1.670599,
+     "end_time": "2026-09-08T21:58:16.485008+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:58:14.814409+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "#e8e8e6",
+          "width": 1.5
+         },
+         "marker": {
+          "color": [
+           "#0a1628",
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ],
+          "line": {
+           "color": "white",
+           "width": 1
+          },
+          "size": [
+           11,
+           16,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11
+          ]
+         },
+         "mode": "lines+markers+text",
+         "showlegend": false,
+         "text": [
+          "",
+          "1995d",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+         ],
+         "textposition": "top center",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          0.0034392319395914286,
+          0.03516134862316107,
+          0.020844208762833483,
+          0.021694320188876872,
+          0.011597860927196389,
+          0.008450589363479312,
+          -0.007907918380304182,
+          -0.02008075016551526,
+          -0.024636227700816502,
+          -0.034079100667564664,
+          -0.03046801923711927,
+          -0.03680609505205977,
+          -0.04932791774952884,
+          -0.05020827160067218,
+          -0.03670341616509802,
+          -0.050832584279728726,
+          -0.052581306491518,
+          -0.050456955477824805,
+          -0.048352828618269277,
+          -0.04709855992929298
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "margin": {
+         "t": 70
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#D4A84B",
+           "dash": "dot",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 10,
+          "x1": 10,
+          "xref": "x",
+          "y0": 0,
+          "y1": 1,
+          "yref": "y domain"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 15
+         },
+         "text": "Validation IC by checkpoint; peak at epoch 10"
+        },
+        "width": 1000,
+        "xaxis": {
+         "title": {
+          "text": "Training epoch (checkpoint)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean cross-sectional IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+gAAAH0CAYAAACuKActAAAQAElEQVR4AezdB4DURBsG4Dfbrvc7miKggl1BUezYUREVEQFBRBAElKaIUqWIIIqKoDRFRey9/9h7F8QuKoJ0uN5v659vjj2u19297O57kN1sMpnMPMmVLzOZmOz2Eg8nGvAc4DnAc4DnAM8BngM8B3gO8BzgOcBzgOcAz4HmPQdM8OsXM6cABShAAQpQgAIUoAAFKEABClCgPgLBHaDXp4ZMQwEKUIACFKAABShAAQpQgAIUCAIBBui1HCSuogAFKEABClCAAhSgAAUoQAEKBEqAAXqgpKvuh0soQAEKUIACFKAABShAAQpQgAJlAgzQyyhCbYb1oQAFKEABClCAAhSgAAUoQIFgEmCAHkxHy0hlZVkoQAEKUIACFKAABShAAQpQwKcCDNB9ysnMfCXAfChAAQpQgAIUoAAFKEABCoSbAAP0cDvirK8IcKIABShAAQpQgAIUoAAFKGA4AQbohjskLFDwC7AGFKAABShAAQpQgAIUoAAFGi7AAL3hZtyCAs0rwL1TgAIUoAAFKEABClCAAiEpwAA9JA8rK0WBxgtwSwpQgAIUoAAFKEABClCgeQQYoDePO/dKgXAVYL0pQAEKUIACFKAABShAgRoEGKDXAMPFFKBAMAqwzBSgAAUoQAEKUIACFAheAQbowXvsWHIKUCDQAtwfBShAAQpQgAIUoAAF/CjAAN2PuMyaAhSgQEMEmJYCFKAABShAAQpQILwFGKCH9/Fn7SlAgfARYE0pQAEKUIACFKAABQwuwADd4AeIxaMABSgQHAIsJQUoQAEKUIACFKBAUwUYoDdVkNtTgAIUoID/BbgHClCAAhSgAAUoEAYCDNDD4CCzihSgAAUoULsA11KAAhSgAAUoQAEjCDBAN8JRYBkoQAEKUCCUBVg3ClCAAhSgAAUoUC8BBuj1YmIiClCAAhSggFEFWC4KUIACFKAABUJFgAF6qBxJ1oMCFKAABSjgDwHmSQEKUIACFKBAwAQYoAeMmjuiAAWCScDhcKBj57Nx+x1311jsM3v0Q//rxtS4vvyKW6fNx6X9hpctevn1/yHxwOPgdDrLllU3c+0Nt2DE2CnVrapx2TvvfoKnX3i9yvqJU+eh11XXV1nurwVSv4dWPFkl+6++XYcxE2fi9PP7ou3hp6L7hf0x/vY5+HfL1ippvQuefPYVtO7Yzfsx4O/HnXoxHnj4sYDsN5D7auw5seKxZ/DZl9/5xMPfmfzz7xb1vfbdDxt8vquavtd8viM/ZNjY8yw3Lx/jJs3GOZcMRMtDTlS2NRVv/YZfMXjELejU5RwMGj4B/jgGNe2byylAAQoEq4ApWAvOclOAAhTwp4DVakWvi87DS6/9Dy6Xq8qufv39L/z06x+4/JILqqyrz4KU5CScdcbJ0DStPskblGbth5/i+ZffqrLNwe3b4ugjO1VZHsgFEhBedMV1+oUJF24aORhL778TJ5/UGW++8wHmLVwayKJwX7pAY8+JR1c/hy+/WafnYPj/fi1gTd9rft1pM2eepwfon3zxDQ5o3RInn9ilxtJ8+/0GdUEwNiYGD8yfgZSkJFyiXyD8/Kvva9yGKyhAAQpQAGCAzrOAAhSgQA0Cl19yPvamZ+LTL76tkuK1t95FRIQNl1x4bpV19VnQ/fRuePWZ5TCbzfVJ7pM0o4cPwryZk3ySV2My+fizr/HIE89ixu1jsfSBOejfpxcuuegc3D37dnz5/ks4/+zTG5Mtt2mCQHOfE00oukE2Db9iHNCmFX784i08ufI+nH3mKTUCrNS/19sfdCAevGcGLu5xFu6fPw1HHHYoVj7+bI3bcAUFKEABCjBA5zlAAQpQoEaBM049EW30VqJX33yvSpoXXnkHPXucg9iYaPz+59+4Zcpd6HZ2b9Vl+/zLBuN/739aZZvyC6rr4r5r9170vWY0DjriNFw5aDQkoC2/jczXtS9poX58zYtqW+liLtO8hQ/LppB1lbu4//7nP6qVq/1RZ+CYky9SXVeLi0tUennxdi2X7szSpfXAw07B2T2vxjff/yirGzTd/9AqHNLhIIwdeW2V7VqkpaBv74urLK+8YMt/23HDuKk49LizcNbFAyp0s7558lxVtsrbLHv0aWVaUFhYeVXZZ7vdgRl33oeTzroMB3Q6BZf0vR7SSlyWYN/MU8+/hgsuH6xuf7htxnzIrRD7Vqm3XXv2qq68h59wHg45truaz8zKVuu8L/Xdlzf9f1t3QLojDxl5K+SWCO8xWfvBZzjrogGQY1LZwrvtG+98UJZGzs8Hlz3hXaXeK58T3rxrO96nntcHf/71L+S8kvNLpurOVbWDal68Xc6fe+lNXNZ/BOTcO/70SyDHCZW+vv5uPS7uM1R9X4nB1Nn3wu12l6US2/n3LYV8z8lxO+XcPupWhPJpyhKXm/no069U92y5YFRucYXZ9z76HNeNmoSjTuqhzrf+Q8bgj42bytKIXU3fa2WJKs2sfPwZdWuHt6xyPpVPMmr8dMh+7n3wEZzY/VIcqH+/9Rk4Ctt37CqfDNLNXG59OfLEC9R51lf/ubFt+84Kaep7nkkZajunK2Razw8lJXbIz81eF58Hi8WitjKZTKpX0tvvfoyiomK1jC8UoAAFKFBVwFR1EZdQgAIUoIAIaJqGKy7tof+h+W6FQOz7dT+p+6WlhV3Srf/pN7jcLoy/8To8cPd0HNL+IPVHttx/KevrM3k8Hlw1+Cb8/OtGzL1jInrr+x1322z8+PPvFTava183DL1atVZ1Oe4ovPH8I2oacOWlFfLwftizN0MPRIeqVvz750/H6OsH4aXX3tED4Ir3vDscTtyzaAXmzrgF6/WWs+OOOQLXDL+5wX9kf/vDBpx39mllf7B7y1HfdylH/+vG4sjDO+qtcdPRulUa+g6+EZs2/6eyGHjVpRDzDb9UNFv9zEvo3asHYqKjVbrqXoaPuR3PvfQW+va+BKuWLoC0DH7xdcUu3E899wpeeX0tRg0bhGGD++GRJ57HUj349+YnQdMFl12Lv/7ejEnjR6jeClu37sSV19wIOb7edPXZlzetBOe9+l2PLscehUcfml9mJxdRbp58J+bNuhU/ff0OTu12fAUL2f6DT76E3P/b+bgjsXzRXTj/nNPVRYjqAmFJ753EubbjvfiemTio7QG4pn9vdX7JeSbnhGwvF5YkWJb5uqaJU+9C/ysvwYav3satupcE3y+++k7ZZnK/slwoiYuNxkP3zcaIIQPw7ItvYMbc+8vSbNMDVwma+15+EVYunodzup+Cxcsex0Mr1pSlqTwjwbmcR/fcORnXX9u/8uqyz3LRoUO7A7Fg9u24bcINKNIvXF0+YATyC0ov9DTke00ylfEYJk2/GyefdLx+LO/WvxdOxdhbZ+Gt/30kq8umT774Fp98/jWefXwxPn/3BTicTvTRL9iVv+jQf8hY/LD+Z9w6drjqgbJ1+y5cfOWwCt+T9TnP6jqnywrVwBm52CgXr448/NAKWx6pt6DL8u07d1dYzg8UoAAFKLBfgAH6fgvOUYACFKgi0PuSC5CTm4d3P/i8bN0rb76LhPg4XHR+d7Xs6r6X4gE9wB2gB8J9LrsIyxbdiav7XobHn3pJra/Piww29dOvf2D1ioUq8Bl41WV47OEFkBZjlPu6uo59dTykHVqkparySQ8AmdrrQUa5LMpmlz36FBIT4vHikw/pAewFGHX9QDxw9wy89tb7+FG/6OBN6NQDhEnjb8ApemCRlpqsAnUx+fizb7xJ6nyXiwHSatamdas609aUoLQcIzBu1BC9Je5cPP3oInQ8uL3e8vqU2uSELseoLrTP6S2zaoH+8uPPv+G3P/5WgaD+sdr/0losdX5u9WLcOm44epx7Bm4ZMwyrHr67QvqkpES8sM/q9ptH4tqr+6iLN95ED69cg5ycXLz90mMYes1VuOqKnnhxzcP6/v/C2vc/U8nquy9J7A3Ou3XtrAd089WFFFkukwT8d06/WR2TZL1cc2dMrGAhae55YAUG6OeknJs9Lzwbd06/RZXrgYdWQQJ8SVPdVOpc8/EW56hIGw48oDXk/JIpKTGhuqxqXdZfL5uUT76X5P36a6+ClM270dx7H0ZX/Zg+98QSXKq3xN444hosuvsOPLr6eWRkZqtkxx51OB5fdg9GXDdAXZgSh5lTxmP1My+q9ZVfJDgfMHQcJDgfPOCKyqsrfJa85HYMsRuuXxx45elliI6KxJv/+0Cla8j3WrZ+XshFDzmv7p07GReefybmTLsFNwwdgPsfXqXy875IIL7iwbtwSId2kO9dmZcBFOUclTTSsi8DLT77+BJcd01fXKlfnHhh9RLs3rMXq558QZKoniWSvqnntMqsES979qbLVpCfL2pm30tycoKakwBezfCFAhSgAAWqCDBAr0LCBRSgAAX2C0gw0qFdW7z61rtqoQRGr7zxrgoQZSA5WZiVnYM79Fa9My64SnWblS6/T7/wGrZs3S6r6zV9v/4nHH1EJ5zU9biy9Md3Phqdjzmy7LPM+GJfko9M33y/AWedcUpZq6wskx4D8XGxqDyQ0wl6WWS9TNISfWCbVtj83zb5GNBJWra9O9Q0DWed2Q3f/vCTdxGuG3SlGiBPWulkobS4HnpwO8jFBflc3fTZl9+i06Htq1hXTnvGKV0rDOrX+dgjsHnLfgMxu1C/aJOSnFi2qVzQkAD76+/WqWX12Zemadi6bSek5fyMU07UW7/nVgjOVUb6S20WEoB/8/2POPesU/SU+/8PvOpSSDf83//8e//CauYae7zlgsR7r62uJseqi846vVuFhWedfgp++X0j5BwvKbGr2zQG9O1VIc0F+sUT6br9vd56LCvk+1G6jXu7wcv3njwhYNPmbep2AEmjaZq84YNPvoIE5w/cPR11BeeygbTMjxw3DV3PvBRJbTsj+aAu2LR5KzZvqf/3teQjk/TskCC9X5+KvVl6nHsmpEeO1FfSyXTk4R3RulULmVVTq5ZpOPrIw/DdutJR6L/Vj+vhnQ6BXCBQCfSXtge2Ub0Hvvz2B/0T9ADdN+e0ysyHLxo0H+bGrChAAQqEpgAD9NA8rqwVBSjgQ4GrrrgYb6/9WLU6fvbld9ixczcu73VB2R5unjwX0i11UP/LVTdb6fLbv08vZO5r5StLWMvM7j3paNkitUqKVq0qLvPFvrw7kXokJ8V7P6p3uU9Uuo7v2LW/C2qU3mook0qw78ViMaOwAfeRtkhLUffr79hZ8V7afdnV603TtCotcokJiSjfGtevzyXIyy/AW/rxkiBdukxffdVltea/fcdupKVWdK5ug7i4uAqLIyMi1L3A3oVSN2m9lyCx/PTJ599AuiBLuvrsS4LODz/5Etu278Ko6wdB06oGNZpW1SIpcb/Fzt17VLf6pKQE2W3ZJMGefJCu4fJe3STHWqby6xp6vMtvW9N8UqVzb3/rajp27tqjNpPHeZW3bHFwV/VUhW3bd6j1cg/5/PuW6m6MrAAAEABJREFU4QI9cJfbNF5/bqVqmZYnL2Tn5Kk04ikzcmzatT0Al9RjYEcZr2DAdWNRVFyEm0YMxvN6C7V8Xx+jB8rZOTmSXYOmHfvqc2L3S1G+Ppf1H6Hy2bT5P/UuL8nV9EZI0Y/jnr0Zslr/+bMH0mtCfSj30rJFGrZvL/2+rc95JpvWdU5LmsZMaakparPsnFz17n3JzCq1k7J6lxn2nQWjAAUo0EwCDNCbCZ67pQAFgkdAHqUmf7C/tfZDyMBHaanJOPuMk1UFJAh8/e331cBnck+qdMWVLr8S0KgE9XxpqQfnWZX+mJVNs7L2/4Hrq31JvjLJAHi795T+0S+fZZJgZueuvTigCV3RJZ/qpp4XnoP3P/qirGWzujS1LZOyyaj65dPs2bu3QmujdJeW4/X8K2/izf99pLpCD7iyYits+e1l/oA2LbE3vbRLrnxu7CStmJf1PL/svmwJ6LzTLWOuV9nWZ1+apmHIoCsxUL+w0GfQKL3Fdn8rvcpEfxELuc1Any37n5WdDW8A3rplCxXY79Yv/JQl0Ge8FzPaHtBa/9S8/7OzSwNobykyM0uDt1YtUyHnpjzhYMrEG6v1vPC80ttL5EJM714XYvzo61RX7zNPOwneQN+br6aVXuC4f/40REdHqbEepIeBd3117z+s/0WNM3H3nNvVsZAnDMj3tfwcqC59XcsObFN6a8czqx6stj5y7njzqO7nQIYe2MpFLknTpnUL1Z1d5stP0sX9wANL93OAj87p8vk3ZL5N65Yqudxeomb2vfz6x19qTo6xmgnjF1adAhSgQE0CDNBrkuFyClCAAvsE5NFAnY89Ei+9/j+88c77auA4CR5ktccD1aIXExMjH9Ukf/x/+OlXar6+L127HItff9+ot46VtoDJdjv1VrfyA57Vd18xehBSvsus5FXd1K3rcZD7WaW10bteWntlsLPTT+3qXeSzd7mH+J9//8Pi5VW7QEvA+b86Rr6Xgrz7Yem93DIv28jYACcef4x8LJvkPn1ZLo9zuuiC7hUC+LJE5Wa6n94NG//eDLlfvdziBs+eeVo3/PTLHzj26MPL7s2WoE6mIw8/VOXXkH1JV+xTu52A3leP1FvTd6rty798+Mn+c0wsPv70G5x0wrEqSWRkBKRrvTioBftexK+V3tIqXaT3LWrUW3R0NOz2/aP9NyaTjz/fX37Z/pMvvsZRR3REkt6CbLNZcc6ZJ+OnX3+vYime8qgv2UbO3diYKJktm9bWcB7JExdefPJh1YX+muET9PI7yrapPCP3gcuyuNj939fyvbhp81ZZXDbF1PN77fjOR0MCbLmXXMpfeZKyeTOt7ufAL7/9iROPL7395aSunfH3pi347Y+/vZuonhyffv4dTjnxeLWsIeeZ2sDHL3L8ztQvlryhX7yUMQ0kezGVz3JOl3eVdZx8LsAMKUCBIBZggB7EB49FpwAFAicgLaNvr/1Yb2nNhMx79+z9Q/TRJ56FBMUyqNvwMZORs697rTddXe8SSB7e8RBcf9Nk/PPvFmzesg3yODFN08o2re++Oh7SHj//+gfeefcTSJd8yassk3Iz0n3abrerR8RJuo8/+xq3zbhbr995OO7oI8ql9M2sDOglA6vNmrcIo8ZPx7MvvYE33/kQk6bPw/Gn98LaD2p/NJ08rmnRw6v0dJ+pesmo39KVe+SwgRUKKIFB+4MOwJff/IC+l/essK66D6ed3FXV+bqRk9Tj8WQgsYWLH8XQ0bdVl7zGZTcOHwSr1Yxzel6NxctWQy52SLfqgdePhzxWTzasz74k2JZJbjdY8eBcyEBhva++QZ17kodMYjFv4UMVLP7atBnlLW4dPwLSu2P5qqeVl5Th4ZVrMP7GoZAAXvJp7CTn2Acff6XqKOdOVnZp6/eMO+9T51N98n1DP/arn3lZlU3eH3nieUy4cVjZpjOnTFA9LqQbuDz+TfazRL+4c2HvIWWPHTvt5BMggzZu274TmVnZuPv+5fjg4y/L8pAZsfS+y/gALz+1FH/+vRlDRk1UF9dkXeVJLrJIb4zFy55Qj3Vb9+MvGDFmirpNo3xacajP95oEpNNvG4Mps+7BjTfPUMdFzo/Z8x+EjHxfPs/E+Hj1vS/1lemGcVMh42Bc1vM8lUxa8+U8GjtpFj794lvlJ/fdJycnqjEYJJGsl/RNPaclr+qmb7/foPYrAxnKeimnTHJRUT7LdOu4Efh94z8YM3GWukVo/G1zIBc5JunnpaznFMwCLDsFKOBPAQbo/tRl3hSgQMgI9L38IlUX6bpZecAxaem06i1+hxzbHd3O6Y02rVtARmdWG9TzRdM0PPfEYkTpLZ9n9uiP087vqx6ddcE5p1fIoT77kq7R111zpQoGel11PZ558fUKeXg/SFf9t196XF0QkMemjbl1FqRuyx6Y603i8/dFC2ZARrH+469/MOPO+zFIb8mUrujSpXvB7NoDYqvVgrl33IqbJ9+JywfcoAfg6/DC6odwcPuDKpRT0zR1T7LU75ILz66wrqYPKxfPh1wkmTb7Xsijyd7TW+olyK8pfXXLJehd++pq1dK56snnIYGljNzd6ZAOOPnELmWbNGRfEog/9cj9SE5KQm+9zhKESkb1sTi3+6lYs/J+PPPCG5D7qSV4vW3CSD2Iv1qyaNI0e+oEHNzhIP2C0u2Qc2zDvscB/qi/b6nn4IGSx6onX1Dby+jtc6bdjCsvL/0+k8JJa/oHbzwFuVBx591LVLo33vkAF/c4G6kpyZIEY0Zei/POOh3n9boGBx/THd/9sAHSlV2trOGldasWeGnNUvyw7heMmjBdBeCVkyYnJeKJ5ffio0+/RlqHrug3ZAzkKQfy+MLyaev7vSbbXNO/N55ceR/++GsTRuv7veram/QA9m8M7Hc5yn91Oe5IdD/9ZFw9dBwkjcVs0cv7sHLwpnvmsUWQ83Pk+GkYMnIiCgoK8dYLj6ou/N40DTnPvNvU93342MnqeKzSz3PZRs4BmdaW670gvQTkAtOPP/8GuWgpj1lc+sAcnLXv9iDZjhMFqhXgQgqEuYApzOvP6lOAAhSol4A8Uip72wb89t276t7e8htJgPjUIw9g259fYdff3+Lu2bdDHs/06drnypLdc+ftkAGsvAuuuPRCSH4SgHmXtWqZhpf01r3tG7+CTLffPEoPEhZCHrPkTVOffVmtVjVQ1vov3lT7mHzLaLW5BMZyT7T6sO/lsI4d1D2xm3/9DD9//Q7kAkD5AcIkqNj51zf7Uu9/++ajVyGPjNq/pOqc1E+6tVdec/21/fHRW09j4/oPVfnEVB6dJuWunNb72VsOaT389du1yNiyDh+//Yzq/uxN432XrrTS/btv74v1Fm2rd3Gt79I74S49+P/+09ex9Y8v8b9XHlfH0LvRhi/fxvjR13k/qverruiJ9M2lo2arBfqLdM+Wx+x57SW/OyaP0y/atNTXlv5v6L7kvum1rz6Bz997QQ/UE0sz0V/rYyEXHT5+5xl1bn7z0Su46YbB+pb7/1c+J7zO+1OUzlU+3nKuymPo/vrxI3UMJehyOp2Qe7evHdindKM6XiXAlGMo58m6z99UAXDlTSRIl8eb/bn+A7UfcRirB+URETaVNCY6GgvvmoI/1r2v1sso8nJcJM/UlCSV5pAO7dS6E084Tn2WFxkBXfKU7y25ACDLKk9SJ9mfnGtSzyEDr1TfK/Nn7b+QJOfsnGm3wHu8vd9rlfPyfu510bn44I016njs/uc7yD3pvcsNOOlNN3Hs9eo8lO+9l59eCm+Xfu96edLCI0vmq59H//z0iXqc30Ft23hXq/eGnmeykdhVPqdleeVJvh/EuPIkF9rKp5XHTn71wUvq59nXH74MGTyz/HrOU6A5BLhPChhdgAG60Y8Qy0cBClCAAvUSkABRutnOW/iwGuDrhuuurtd2TOQbAXmUWNsDW+OSC8/xTYbMhQIUoEDwCbDEFGiyAAP0JhMyAwpQgAIUMIJAfkGh6nYr9zY/tHA22h10gBGKFTZlkBZqaSXVtP3jJoRN5VlRClCAAgER4E7CQYABejgcZdaRAhSgQBgIJCbEq67MEiSWv5c51KpeUzf0YKlndV3Og6Xs/i7n0gfm4NnHF/t7N8yfAhSgQPUCXGoIAQbohjgMLAQFKEABClCAAhSgAAUoQIHQFWDN6ifAAL1+TkxFAQpQgAIUoAAFKEABClCAAsYUCJlSMUAPmUPJilCAAhSgAAUoQAEKUIACFKCA7wUClyMD9MBZc08UoAAFKEABClCAAhSgAAUoQIGKAuU+MUAvh8FZClCAAhSgAAUoQAEKUIACFKBAcwn4I0BvrrpwvxSgAAUoQAEKUIACFKAABShAgaAVCMIAPWitWXAKUIACFKAABShAAQpQgAIUoECNAgzQK9PwMwUoQAEKUIACFKAABShAAQpQoBkEGKAHGJ27owAFKEABClCAAhSgAAUoQAEKVCfAAL06leBdxpJTgAIUoAAFKEABClCAAhSgQJAKMEAP0gPXPMXmXilAAQpQgAIUoAAFKEABClDAXwIM0P0ly3wbLsAtKEABClCAAhSgAAUoQAEKhLEAA/QwPvjhVnXWlwIUoAAFKEABClCAAhSggJEFGKAb+eiwbMEkwLJSgAIUoAAFKEABClCAAhRokgAD9CbxcWMKBEqA+6EABShAAQpQgAIUoAAFQl2AAXqoH2HWjwL1EWAaClCAAhSgAAUoQAEKUKDZBRigN/shYAEoEPoCrCEFKEABClCAAhSgAAUoULcAA/S6jZiCAhQwtgBLRwEKUIACFKAABShAgZAQYIAeEoeRlaAABfwnwJwpQAEKUIACFKAABSgQGAEG6IFx5l4oQAEKVC/ApRSgAAUoQAEKUIACFNgnwAB9HwTfKEABCoSiAOtEAQpQgAIUoAAFKBA8AgzQg+dYsaQUoAAFjCbA8lCAAhSgAAUoQAEK+FCAAboPMZkVBShAAQr4UoB5UYACFKAABShAgfASYIAeXsebtaUABShAAa8A3ylAAQpQgAIUoIDBBBigG+yAsDgUoAAFKBAaAqwFBShAAQpQgAIUaKgAA/SGijE9BShAAQpQoPkFWAIKUIACFKAABUJQgAF6CB5UVokCFKAABSjQNAFuTQEKUIACFKBAcwgwQG8Ode6TAhSgAAUoEM4CrDsFKEABClCAAtUKMECvloULKUABClCAAhQIVgGWmwIUoAAFKBCsAgzQg/XIsdwUoAAFKEABCjSHAPdJAQpQgAIU8JsAA3S/0TJjClCAAhSgAAUo0FABpqcABShAgXAWYIDexKNvtdpQ1zRr1mz88MO6OtPVlU+4rc/45Qnk/vsO3epxjpU/NwANHg/o1kC38oacr/vnmtfIbLbA6XTyfOP5FrBzwOFwwGKxBmx/3nM9ZN55rjbo3HG73dA0rUHb8Fyp/+8QWlW00jQT3G5P0J9v4FeTBExN2pobU4ACFKAABShAAQpQYBx3gFsAABAASURBVJ8A3yhAAQpQoGkCDNCb5set/SjQqstwpHS6zI97YNYUoAAFKEABCgSRAItKAQpQIOQFGKCH/CFmBSlAAQpQgAIUoAAF6hZgCgpQgALNL8AAvfmPAUtAAQpQgAIUoAAFKBDqAqwfBShAgXoIMECvBxKTNI/ArvUrkbHxtebZOfdKAQpQgAIUoAAFgkiARaUABUJDgAF6aBxHQ9Zi0+ZtuGnSnTj94mtw4613VihjYVEx5tyzDP2HTUSfa8fjxdfeLVvvXff2e5/isadeqbDug0+/RtdzriqbJO+yDSvNLF31LFY88UKlpfxIAQpQgAIUoAAFKNBAASanAAUCJBA2Afrzr67FoJGTMXjUVHz61bpqedMzsvSA8i4MHTMDU+YsQlFxcYV0Wdm5OOey67F01XMVlvND9QJmswlXXX4hxo4YWCXB4hVPQTNpWLPibjz+0Fy8+Pq7+H3jJpXOu+7C887A1Vf2rLBOEpx+8vH4/sPn1fT520/KIk4UoAAFKEABClCAAkErwIJTgAJegbAI0Lds3YnVz76B5ffNwIKZEzB34QoUl9i9BmXvi5Y/hZO7HodVi2cjPj4OT73wdtk6mVn40Gocf9zhgAZ+1UOgXds2OPPUroiOiqyS+s+//8WpJ3WGxWxGXGwMjjv6MPzvg89VOu+6NsePQJtj+lZYpxLU8JKdk4tb77gX/a+fiBsmzMS/W7bXkJKLKUABClCAAhSgAAXCRoAVpUAQCYRFgP751+vQ/bSuiImOQquWqTi8Ywd8t+4XVP764psf0fOCM9Tinuefgc+/Wa/m5WXDL38iKioCRx3eEfDIEk5NEeh0aHt8/d0GuN1u5BcUQnx37U5XWda2ThL88ONvOOm8/hgw/Fa8ufZjWaSmZY89D7PJhGdW3oNZt9+EHzb8qpbzhQIUoAAFKEABClCAAv4SYL4U8KVAWAToezMy0aZVWpnbgW1aYk96RtlnmSkoLIKmt4wnJcbLR7Q9oCX2pmeqeafTicUrn8GY4QPU5/IvDocddU0ejxuSR13pQnW9y+WEx+Op4DRySF+U2O0457KhuPLa8TigTQvlLwa1rTvuqE5489klePel5bjqsguw4MFV+PLbdSrvdRt+w4A+F+nWDqQkx+Os00+Cy+VS6yRf/0wOPX9jTXKuuXRzh8NY5QrN8tT9/e+ox8+I4E7j0L/PnPr3QTha8HvM0Qw/Z1zq5zrtq9qH4/eg/+ssv1OdTjnf/L8vR5N+X0gZOTma4WeSL/cp55ur6t9w+u/Yuo6tsc7P8rES5xsuEBYBurBoesuqvMukaXokLjOVJlOFNPtppKv7Fb3ORXxcbKUt9MZ0vTVdjz31ALT2edmwPulCNU3l+kdHRWHqzSP0QHsFXn96CWL0z3LhROrvXffUHSdj9ZwLK6yTYxAVGQlJ0/OC7jj7jJPw869/lfrDA7PZUjqvHxerxSK7Lfsseft+cuv5G23ywO32GLBcRnPyRXlq/773/flmvP3pJQrA95m+F/172nievjiHmIdHv4jdkEk/G/Sfb/wZV9VMlzHk90lwl0t+wBnvZ091pvxZUvV7IlhNGvPzrbpzor7LfJ9Ovm84NV5gfxTa+DwMv2VaSjKys3PKypmZlY0WqSlln2VGur+7XG7Y9Stv8jlDT5OWmiyzqqv7nHuW45Qeg9So4KufewMPLCsdnMxms6GuSQJ/ix4s1pUuVNdL3TVNq+BkdzjVZ4fThZfffB8ffvYNrup9kVrmXefWfyNu+PXPCutK7A6VRqyycvJU1/jjOx+llp1w3FGq27ysE/Nv1/0Ms9ms1sky/0wRev7GmqxWK2Sy2YxVrtAsT93f/7Z6/IwI5jRWq03/PrPo3wfhaMHvMVsz/Jwx6xdiber7iv62Cv7h+D3o/zrL3zClv1P9vy+bOq8bux9+P9gqfD8Ep4f8TrVYrPrv1IaWv7HnjX+2Q/kvzjdYwNTgLYJwAxn1+7Ov16ku1ZlZOfjtz03o1vUYVZP1P/0Ohx4syodTT+qM9z/+Smbx7kdf4vRundX8ygfuwFdr16hpxLV9MbhfL4wfeY1ax5eaBbZs3QF5JNrMux/GNz/8pOa9jz37Y+Mm9fncy4fhnfc/x0P3TNcvmpReEPGue+n19/D7xn8rrHtwxVNqu5PPH4CJ0+/BqKH9cWKXo1UhRl53Ff78Z7N6pNvN0xaoMQfUCr5QgAIUoAAFKEABClCAAiEnEIoVCosAvV3b1ujd81wMG3sHxk9ZgAmjB8OmtzLKAZ00837k5ObJrB50D8Qbaz9Vj1n7b+tODOzbUy3nS+MEZBR37+PQvO9ygUNy66oH1bLs63efxhMP36VGapflMnnXjZ/zMsZOWVFhnXSLV9u99wyeXDYfPc45TTZRU2JCPO6ZNVEP6KfhwflT1Hrv/lQCvlCAAhSgAAUoQAEKUIACFKifQLOkMjXLXpthp1dd3gNrls3D6qVz0f3UE8pK8N7LK5CakqQ+y/vSe6epx6zdNX0c5F5ntaLcy3VXX6a32vYrt4SzFKAABShAAQpQgAIUoAAFKECBhghUnzZsAvTqq8+lFKAABShAAQpQgAIUoAAFKEABYwj4LEA3RnVYilAS2LV+JTI2vhZKVWJdKEABClCAAhSgAAUoQAEK1CgQLAF6jRXgCgpQgAIUoAAFKEABClCAAhSgQCgIMEBXR5EvRhLwuB1wOQrh8bjgcbvgdhbB7XIYqYgsCwUoQAEKUIACFKAABShAAZ8LMED3OWk1GXJRvQTczmKU5O9A9uaPkf7HS3CW5KI4Z7M+/wpy/vsULmcJPC57vfJiIgpQgAIUoAAFKEABClCAAsEmwAA92I5YNeUNhUXOokzk7fweu9atRO62L1GctQluRxFcJXkoyvwLuVs/x7Yv56Mw/Q9I2lCoM+tAAQpQgAIUoAAFKEABClCgvAAD9PIanK9OwO/LpAt77vavkP3vB3XuK/3PV/SAfaMK3utMzAQUoAAFKEABClCAAhSgAAWCSIABehAdrFAsqsfjREnOVuTt+L5K9Upy/4OjYHeV5Zn/rIXLkQ943FXWcQEFKEABClCAAhSgAAUoQIFgFWCAHqxHLkTK7XYUY8+vzzS4Nrt/XgO5Z73ODZmAAhSgAAUoQAEKUIACFKBAkAgwQA+SAxWqxZSR2htTN1dJLjSzrTGb+nQbZkYBClCAAhSgAAUoQAEKUMBXAgzQfSXJfBolYM/fWeN2EfEHwRrTssb1zpKsGteFyApWgwIUoAAFKEABClCAAhQIIwEG6GF0sA1XVbcTMkJ7TeVyOByw22t+rFpR+saaNuXyegkwEQUoQAEKUIACFKAABShgJAEG6EY6GuFWFpMFUckdUd2Xx+OGW5888MDhqD5Ir2nb6vLjsmYQ4C4pQAEKUIACFKAABShAgQYJMEBvEBcT+1rAFtO62ixdLhdcBTuAkgw9UPfA5XJWSWeNTqmyjAvCR4A1pQAFKEABClCAAhSgQKgJMEAPtSMabPXRqi+w2+2GSdNgMplhNpng1AN2WYZ9X+aIBLjsBfs+8Y0CPhdghhSgAAUoQAEKUIACFAi4gCnge+QOKVBOwGSJQIuj+pdbAkgg7pEleoAubxaLFZr+z+F0wONRa9Dy6KthskbLak4UCEIBFpkCFKAABShAAQpQgAJVBRigVzXhkgAKmMyRsMUdiNg2J5bt1e126eE4EJnQrmwUd6tVgnSo+9GTDr0QZlssNJOlbBvOUIAC5QQ4SwEKUIACFKAABSgQlAIM0IPysIVWoc22GMS16ozE9mfrFfPAJd3bTWZ9fv9/TdNg0YP05I69AFsaNEvU/pWcowAFAirAnVGAAhSgAAUoQAEK+EeAAbp/XJlrAwVssW0Q1/pEtDh2GBIOPA0xKR1hskbBHBGHqJROSGjXHe1Pn4botKNQ5IpCQUF+A/fA5BSgQJAIsJgUoAAFKEABClAgbAUYoIftoTdexSUgL0EsolufjBZH9YU1Ih6RCe2R0ukyFbRrZiuiouMRERGpAvTi4mLjVYIlogAFDC7A4lGAAhSgAAUoQAHjCjBAN+6xCbuSuVwulJQUQwaOM0kXds0MzWSG2RoNCc69IAkJibBYLMjJyYLT6fAu5jsFKECB5hdgCShAAQpQgAIUoEATBExN2JabUsCnAsXFRSq/yMgo9V7Ti6ZpSExMhqZpyMrKVKO+15SWyylAAQqEkgDrQgEKUIACFKBAaAswQA/t4xtUtSsqKoTNZoPZbFblbtVluOrerj5UepE0EqTLI9mkJd37+LVKyfiRAhSgAAXqL8CUFKAABShAAQo0swAD9GY+ANx9qYB0VZcu7nW1npemLn2VYD4uLh52ux35+XmlC/lKAQpQgAIGFWCxKEABClCAAhSoS4ABel1CXB8QgaKi0u7tMgBcQ3YYHR0DCeoLCwvAQeMaIse0FKAABUJMgNWhAAUoQAEKhIAAA/QQOIjBXgXpnl5UVKgH2pEwmfafkrvWr0TGxtfqrF58fAIHjatTiQkoQAEKUKApAtyWAhSgAAUoEAiB/dFQIPbGfVCgGgHpoi5BemRkdDVr616kadq+QeNMHDSubi6moAAFKEAB4wmwRBSgAAUoQAElwABdMfClOQWKiwvViOxyT3ljyyGDxiUlJakR3TloXGMVuR0FKEABCoSmAGtFAQpQgALBIsAAPViOVIiWU0Zhl3vHo6KiVZBevpq1jeJePp133mq1Qbq7S4s8B43zqvCdAhSgAAUo4GcBZk8BClCAAj4TYIDuM0pm1BiBkpIStZkM9KZmmvgigb7kxUHjmgjJzSlAAQpQgAIGEWAxKEABCoSTAAP0cDraBqyrdG+X7ulWq9VnpZNWdIvFCunqLo9v81nGzIgCFKAABShAgVATYH0oQAEKGEqAAbqhDkd4FcblckG6o0urd3U1r+8o7pW31TQNcj+6pnHQuMo2/EwBClCAAhSgQCAFuC8KUIACDRNggN4wL6b2oUBxcZHKTbqkqxkfvphMZhWkyz3u2dmZkFHifZg9s6IABShAAQpQgALNL8ASUIACISfAAD3kDmnwVKioqAgysJvZbPZLoSVv6e7ucDjAQeP8QsxMKUABClCAAhQIYQFWjQIUCLwAA/TAm3OPuoDcG+5yOREVFaV/qv5/Q0dxry4X6T4vU+mgcaUt9tWl4zIKUIACFKAABShAgYAKcGcUoEA1AgzQq0HhIv8LSOu57CUiIlLe/DrFxcWjdNC4bMiFAb/ujJlTgAIUoAAFKEABChhAgEWgQHAKMEAPzuMW1KWW+8ElQJfg3GTy/ymoaZq6H132lZWVCbkvPagBWXgKUIACFKAABShAgeYV4N4p4CcB/0dHfio4sw1eAYfDDo/HXWv3dqldY0dxl20rTyaTGYmJySo456BxlXX4mQIUoAAFKEABClDASAIsS/gKMEAP32PfbDWX1nNN02CzRQS0DFarFRw0LqDk3BkFKEABClDMBfdHAAAQAElEQVSAAhSggPEEWCIDC5gMXDYWLQQFpHu5PF5NHq2maVrAaygDxsnEQeMCTs8dUoACFKAABShAAQqEhQAr2RQBBuhN0eO2DRaw20vUNhIkq5laXnwxint12XPQuOpUuIwCFKAABShAAQpQgAJBIBDiRWSAHuIH2GjVKyoqhNlshnQ3b66yaRoHjWsue+6XAhSgAAUoQAEKUIACRhZo7rIxQG/uIxBG+3e7XbDb7ahP67m/WThonL+FmT8FKEABClCAAhSgAAUoUEmgzo8M0OskYgJfCRQXF6us5PFqaqaOF1+O4l7drqQVPyEhEQ6HA/n5edUl4TIKUIACFKAABShAAQpQgAIBE2hagB6wYnJHoSBQWFiourZbLBbDVEcGq4uOjgEHjTPMIWFBKEABClCAAhSgAAUoELYChg7Qw/aohGDFnU4nXC6nIbq3V+aNjY1TFw5ycrJVa3rl9fxMAQpQgAIUoAAFKEABClAgEALhHKAHwpf72Ccgg8PJbH27t0taf43iLnmXnzRNQ2JiMkwmE7KzMyGPgiu/nvMUoAAFKEABClCAAhSgAAUCIcAA3W/KzNgr4PF4UFRUhIiISBUEe5cb6V2CcwnSJTiXIF3KbKTysSwUoAAFKEABClCAAhSgQOgLMEAP1mMcROV2OOzweNyIiooydKk5aJyhDw8LRwEKUIACFKAABShAgZAXYIAe8oe4cRX05VbSeq5pGmy2iAZl6+9R3KsrDAeNq06FyyhAAQpQgAIUoAAFKECBQAiYArET7iN8BTweD4qLiyCBr6ZpXghDv3PQOEMfHhaOAhSgAAUoQAEKUIACISvAAD1kD60xKlZSUqwKEtju7WqXjX7RNK3SoHGuRufVHBvKiPkldkdz7Jr7pAAFKEABClCAAhSgAAWaIMAAvQl43LRuAeneLgOwWa22uhNXShGoUdwr7VZ9lDInJSWrEd2zsrIgPQHUCnkx4ORwOFFSUoL3P/oCyx59CkuWP4G31n6I3Xv2osRuN2CJWSQKUIACFKAABShAAQpQoLIAA/TKIvzsMwG32wW7vQRRUdE+yzOQGVksViQkJMLpdCA/Pzdgu27ojoqKivHHX3/j6mHjsPTRJ/HZl9/h2x82YNWTz2P0zdPx40+/YU96RkOzZXoKUIACFKAABShAAQpQIMACpgDvj7sLI4Hi4tLu7XL/ebBWW8oeHR2DwsJCdS+9tx52u0O/+ODwfmzWd7fHjZl3PVBjGRY8sAxFhUX6hQaXpOFEAQpQgAIUoAAFKEABChhUgAG6QQ9MKBSrqKgQ8ugyi8XSqOo0xyju1RXUO2hcXn4+tu/cjaeffw2z5j+gJpnfvTsdDkfzBOvSrf2Rx5+trtgVlq184lkUFhVVWOafD8yVAhSgAAUoQAEKUIACFGisAAP0xspxu1oFXC6n3mLrRGRkcHZvL185TdMQERGNn3/9EyPHTsZLr72DPzb+o6aXXn8Ho2+Zhm+/3wAJ4MtvF4h5p8uNbTt2weP2qPvl3fpnl9ulf3ZX2P327bsQGdGwx9xVyMAoH1gOClCAAhSgAAUoQAEKhLCAKYTrxqo1o0DRvtbaYBq9vSYut9uNjMxsLFn+JDz6v+pay+976BFkZGSrILmmfOpaLgPRuVwu1RovLePyeLrCwgLk5+chNzcH2dlZyMzM0PezF3v37sbu3TuRnpGO7Tt2wu6wq+0cTgckD6d+gcTl3N+lPVdv/c/NzaurCGG/ngAUoAAFKEABClCAAhRoTgEG6M2pH8L7Lioq1FudI6FpWqNr2ZyjuJcvdIndgaeefwWaSYPVYoXc8y2PMiufRuafefE1FBYVyyw8HrceKDtV0FxSUgzxKCioGmynp+/Fnj2lwfaePbuQnr5HD8LT9WA8Ezk52cjLy0VBQT4kD5cedGs6p9wyEBERiZiYWCTExeHIIzpBbiWQkfJlkvUyCr0E6d5yHnRgG0RHR6my8aXZBLhjClCAAhSgAAUoQAEK1CoQNgH686+uxaCRkzF41FR8+tW6alHSM7Jw06S7MHTMDEyZswhF+wY5W//T77h99gM4r/dwXD9uJj758odqt+fCUgG73Q5pdQ6F1nOpkR6XY8t/O2QWJrMJFrNZD75dcDqcqhu/tKg79Dr/9fe/cOkt2NKyvUcPutP14DszU4LtLNUCnp+fC2kRLykpgUtvKdc0PeC3WiFOcp97XFwCEhISkZSUgpSUVKSltUDLlq3VlJbWUl+WptYlJCQhPj4Bsk1CQgI6H3MkTCaTPmmlk2aC2WyBBOqyHynfkYd3hNVmA79CWYB1owAFKEABClCAAhQIdoGwCNC3bN2J1c++geX3zcCCmRMwd+EKFJdUfTb0ouVP4eSux2HV4tl6ABSHp154Wx3f6KhITLxpCNa+tBzX9r9Uba9W8KVaAemarWkaIvRW3moTBNnCoqIS5Out395imy0WSEDsdrvUhQi9uRzQ6yuDsNn1oF0CZwmgJZAuDbbT9GC7pQq0W7Ropc+30IPtVD3YTkaCHpDHxcWr1vDo6GjIqPE2PZC26C31JpMZdX1pmoazzjgF3bp2rpLUrF9IkJb1Vi1ScdUVPWGWKw1VUnEBBeopwGQUoAAFKEABClCAAn4XMPl9DwbYwedfr0P307oiJjoKrVqm4vCOHfDdul9Q+euLb35EzwvOUIt7nn8GPv9mvZo/TE+fmpyoBzgmnH5yF9Vt2du6rhLwpUzA4/FAAnQJNMsWNnLGKKO4m8wmHHpw+wq1kMDXFhEBCaatNpvqYn54p46I0JdJ1/OoKAm2I9V6y76AvkIGPvwQGxONfn16oWePcxCl79+btUVvRT+1W1fce9d0FBXmIyMjXbX4e9fznQJGEmBZKEABClCAAhSgAAUAQwXo0i367fc+xU23zcMVgyfgjJ5D0OPKkRg44nbcdd8j2Lp9V6OO2d6MTLRplVa27YFtWmJPekbZZ5kpKCySRlAkJcbLR7Q9oCX2pmeq+fIvr7z5gR6stUNUZKRa7FCDc9n1oL3myeNxq8CoPmmDPU2hHgh69CDdarXUalKfekoLdWkX7Zpt65NPU9NERthwykld4HF7ap1O6HIMIiOsTa53Y8or5/elF5+HVUvvwYol8/Dgghl4etUDGDygt36u2pCYmKSfrx51f3thYUGzlLEx9eI2zXvu19ff5ZLxFgxdVp7z9fhdVd/j3dzpeL7xey2Q56CM5eJ0OvgzJIR+hgTy/GnovuRck6mh2xktvf5HJ/83QcBQAfrQsXfgu/W/4ZqrLsGiebfhw1cfwTMr78aMSSNxWMd2mDTzfnzwyTeNqq5m2l9VTdOqzcNUIc3+9N7EP/26EU+9+DZm3HqDdxHfKwmUlJToFzpMMOutt5VWBe1HOV1OO6UrzjvntBrrcN7Zp+OsM7rpda/+3KpxQx+uSIiP1fcPxEZHITUlSXW/T05KUHuQ7u7x8Qmqa74MPCfjBKgVfKEABXwgwCwoQAEKUIACFKCAbwSqRqG+ybdRudw29jrcoQfj3U44Rm/BbgWr3gorAcZhh7ZHn17nY/XDc3Gg3rLd0MzTUpKRnZ1TtllmVjZapKaUfZYZ6f7ucrlhdzjkIzL0NGmpyWpeXqQ1fckjz2DJgsmqbLJMJhk1u65J00xqwK660gX7egkCHbpfdHQ0bLYI/fjZmjS1OWEkWhxxRZPy8JVpbEwMrul/Ba4ZcAXatG4JzaSpSeZl2TV6S3VcbKwhyioXR2SqXPeIiEikpKTpx8aG/Pw8vTXAYYjyVi4nPzft+6Y5/Ko735qjHCG7T2vwnRP+PBY833g++PP8qpy33KZmsVj5+5I/hwJyDsi5JlPl8zDYPoNfTRIwVIB+RKeDa62MBOwSrNeaqJqVp598PD77eh1K7HZkZuXgtz83oVvXY1RKGaHd4XCq+VNP6oz3P/5Kzb/70Zc4vVvpwFvpGVmYOncxpkwYjtYt93eVVwn5UiZQvG/Ue1/cf16WqYFmJAC/+IKzseDOKXj2scVqknlZJusMVNQai6JpGhITk9VgdNKSnpubA4/HU2N6rqAABUJfgDWkAAUoQAEKUMA4AoYK0L0scq/50lXPYcxt8zDyljllk3d9Q9/btW2N3j3PxbCxd2D8lAWYMHowbFarymbSzPuRk5un5sePHIg31n6qHrP239adGNi3p1r+wmvv4uff/sKA4ZNwSo9Batq1J12t48t+gaKiIshVP4vFsn9hiM1FRNggo/pb9fNHJpmXZcFUTU3TkJCQqB7TVlRUiJycLAbpwXQAWVYKBJcAS0sBClCAAhSgQAMETA1IG7Ckdy5cgYSEeAy6qieGDepdNjWlAFdd3gNrls3D6qVz0f3UE8qyeu/lFep+XVmQmpKEpfdOU49Zu2v6OHgHghs1tB++WrumwiSPrpJtOJUKeAdRiYqKKl3gg1ejjOLug6oYMouYmFjExydCxg3IzMxQ96wbsqAsFAUoQIEaBbiCAhSgAAUoEFoChgzQ4+NicHWfi9DthGNxYpejy6bQog+t2sij1aRGkftGt5d5TsYXkAsq0uVdRkXOzExXTxswfqlZQgpQgAIBEuBuKEABClCAAgEWMGSALt3PN/+3I8AU3F1jBTweD6SrtM0WAZPJ3NhsuF0zCURERCA5OUV1c5cg3eGwN1NJuFsKUIAC4SXA2lKAAhSgAAUqCxgyQN+0Zbu63/uaUVPK7j+Xe9ErF56fjSEgz2t0u92Q1lhflqhVl+FI6XSZL7NkXjUIWCxWPUhP1S+wmJCZmQHvgH81JOdiClCAAhQwvgBLSAEKUIACQShgyAD95tHX4MH5t2PsiKvL7j+Xe9GD0DcsilxUVARN0xARERkW9Q3VSprNZhWky6M8ZOC4wsKCUK0q60UBClCAAk0WYAYUoAAFKOAPAZM/Mm1qnuXvOy8/39R8ub3vBaR7u9x/Lveea5rm+x0wx4AKmEwmJCUlI0K/2CKPYZMpoAXgzihAAQpQgAIiwIkCFKBAmAoYMkD/9Y+/MXH6vbi432g13XrHQvz6xz9heoiMXW0ZAVyC9MjIaJ8XlKO4+5y0XhlqmobExCTExMRCWtGzs7PU/en12piJKEABClCAAkEgwCJSgAIUMKqAIQP0ufetRLu2rfHQgqlqantAK8x74BGjGoZ1uYqLC9V9y1arNawdQrHysbFxiI9PQElJMbKyMvgYtlA8yKwTBShAAQr4Q4B5UoACFGi0gCEDdGmRHTNiIDq0O0BNY/V5u93e6EpyQ/8IyMBwJSUliIqKVveg+2cvzLU5BeTYSmu6w+FAZmY65HFszVke7psCFKAABShAAQpQgAKhLGDIAF0Cv6zs3DL39IyssnnOGEfAO9K33H/uj1JxFHd/qDY8T7kfXR7D5nZ7kJGRAQnWG54Lt6AABShAAQpQICgEWEgKUKBZBQwZoA/oczH6Dbu17BFrV4+4HYP6XtKsUNx5VQHp3m6xWGCxsHt7VZ3QWiIjEijDqQAAEABJREFUu6ekpMBk0lRLeklJcWhVkLWhAAUoQAEKUCAgAtwJBShQu4AhA/TLLz4HqxbPwnndu6lp1eLZuPSis2uvCdcGVMDpdKqWVOkCHdAdc2fNJmA2W9Rj2OSCjAwcV1RU2Gxl4Y4pQAEKUIACFKBANQJcRIGgFzBkgC6qB7ZphSsvvUBNB7ZpKYs4GUiguLhIlcZf3dslc47iLgrGmuQxbNLdPSIiArm5OcjPzzNWAVkaClCAAhSgAAUo4DcBZkwB/wsYKkA/pccg/PzbX5D36ib/c3AP9RWQ1lObLQImk7m+mzBdiAhomoaEhCQ1OGBBQT6kNV0GdgyR6rEaFKAABShAAQpQoHkEuFcK6AKGCtC/WrsGxxzZEfJe3aSXl/8NIOBw2NUjt6KiovxbGk1OT82/+2DujRLQNE09gi0uLn7fY9gy1TnRqMy4EQUoQAEKUIACFKCA3wW4g+AQkAjIcCVd+NDqKmWac++KKsu4oHkEiopKu7fL6N7+LEGrzsOQ0ulSf+6CeTdRIDo6BgkJiZCLNpmZGXC5XE3MkZtTgAIUoAAFKEABCgShAIvsIwFDBuh/bdpSpXq//fFXlWVcEHgB6cos959HRkZB09i6HfgjYLw9yrmQlJSit6C7kJmZDqfTYbxCskQUoAAFKEABClCAAkEsED5FN1SA/vr/PlaPVvt703/qfeQtc9T7taOn4uD2bcPnqBi4pnZ7CSRI93v3dgMbsGhVBWw2mxrhXdZk6i3pJSUlMsuJAhSgAAUoQAEKUIACxhcwUAkNFaAff+wRGDaoN1q1SFXvMi/TvBnjMHfaWAOxhW9RpHu7pplgtdrg7y+O4u5vYd/mb7GUPobNbDYjOzsTcq74dg/MjQIUoAAFKEABClCAAsEn0JASGypAl8epndjlaKxZPg/y7p3atGrRkDoxrZ8E3G63GhBMWs81jd3b/cQc1NlKcJ6cnAqb3qKem5sNGeVdKlRUXIKcnFys2/AL3v/4C+zZm4G8vHxZxYkCFKAABShAAQpQgAIU2CfQiAB935Z+fCux2/HEM69j/JS7VRd3b1d3P+6SWddDoKSkWKWKiopW73yhQHUCmqYhMTEZkZGRyM/PQ0ZmJpYsfxxDb5yEufcswdJHnsSoCVMx/rbZyM7JQXGJvbpsuIwCFKAABShAAQpQgAJhJ2C8AF0/BLMXLMPejCykZ2Sjd89zEBsdhcM7ttfX8H9zChQVFcJstkC6MgeiHK26DEdKp8sCsSvuw8cCmqYhISEJ0TFxmD7nXnz25beAp+JOsnNzMezG2+DxuCuu4CcKUIACFKAABShAAQqEqYAhA/RNm7di4k3XIiYmCj3OOQ33zpmIbTt2++QQMZPGCTidTjgcDrD1vHF+4biVx+PB22s/ws5d6ZDbI+wOux6Me6pQzJ73IPLyC6os5wIKUIACFKAABShAAQqEm4AhA/SYmNIu1E6nC4VFpd2qHY6geL5yyJ4/JWXd26NCto6smG8FiktK8N/WHTCZTbBarXoLugcOu6NKkL595y5ERUaAXxSgAAUoQAEKUIACFAh3AUMG6LExMcjOzcNpJ3XGdTdN06fpaNUiBfxqPgHp3m6zRcBkCtwpw1Hcm+94+2LPhYXF+HvTZpWVnDfekf/tdjvsevAuPTLcLhcKCgr1QH67SscXClCAAhSgAAUoQAEKhLNA4KKtBig/cNckJMbHYeig3pgyYThGD+uHSeOGNiAHJm2UQA0bSSDl0gMpGb29hiRcTIEqAtHRUWjfrm3Zcs2kqdHdLWYLNP1Cj3R7dzid0GfRskUq8vJyUaIH7tI1vmwjzlCAAhSgAAUoQAEKUCCMBExGr+txRx+mHrlmNhm+qEanbHT5pPVcNpYWdHlv7MTtwksgMsKGNq1aVqy0BpgtZtXlPSIiQr0f0KY1cvPyUFhYgOzsTOzZswtZWRl6y3o+nE5Hxe35iQIUoAAFKEABClCAAiEsYKio95Qeg1DbFMLHwbBVk9bM4uIiREZG6S2dgT1dGjiKu2ENw7Vgmqah7xU9kZyUWCOBdH2fNmkM0lJTkZbWEgkJiepcc+ot6+oRbRnpesC+Gzk52SgqKlKDzdWYGVdQgAIUoAAFKEABClAgyAUCG3HVgfXV2jWQqV/vHri6z0VYvXQuXnhsIUZd1w+XX3xOHVtztT8E7PYSNagXu7f7Qzf085TB32ZOHo+D2x9UpbImzYQFcybDpre0y6P7JFiXC0ESpEuwnpKShtjYOL2V3QK5SJSbm429e3cjI2Ov6g4v5yYqP7utyl64gAIUoAAFKEABClCAAsEjYKgA3cv2w4bfMWbEQHQ8uB0ObNMSg/v3QnZurnc13wMoIK2Wmh5IeQf4CuCuw2tXIVpbTdNwQJtWmD5pLO6ePRkjhw5Evz6XYM60W7D0gblo1/YAxMfGVlt7CdpjYmKRlJSCli1b6e/JiI6O0S8YQXWHz8rKxO7du8p1h3dWm099F9rtDuQXFOr5V30UXH3zYDoKUIACFKAABShAAQo0RcCQAbrdbkd2zv6AvLjEjsys/Z+bUmFuW38BGcSrpKQY0nquaVr9N/RRSo7i7iNIAM2dU3x8LA7VL7idf84ZuKr3JTjy8I5ITUmCBOH1K5sGGQMhLi4eqalpqjt8fHwCIiMjIYMYlnaH36ta2HNyslWLu5y/deUtgx/K9OEnX2LF40/jviWP4NU338XGvzahqLi4rs25ngIUoAAFKEABClCAAj4VMPk0Nx9lNrjfpeg3bBKm3vkg5t63Ev2H3YrLLj7bR7kzm/oKSHAuaSVAl3dOFKhBIOCLpTt8VFQ0EhKS0KJFK6SkpKru8GazRQXnEqRX7Q5fsZgSmG/69z9cM+JmPLRyNT769Cts+Pk3rHnuFUyetQCfffEddu3eW3EjfqIABShAAQpQgAIUoIAfBQwZoPe84Ew8tmQ2uhx7OA47tB2W3TcdF593hh8ZmHV1AtK9XQIei8Va3Wouo0CABOrejZyj0h0+OTlFBeyJidIdPlp1V5fR4Uu7w++EvMtnGYRO0zRMm7NQPdqtuj0sf+wp/Ld1B1vSq8PhMgpQgAIUoAAFKEABvwgYMkCXmrZp1QJXXnqBmlq1SJVFnAIo4HK54HDYVff2AO62wq44insFDn6op4CmaZBHuMXFJSA1tUVZd/iIiEh1Tsvz1qVL/JrnXtZb24vhdrlrHGvukdXP6mlK6rlnJqMABShAAQpQgAIUoEDTBExN29y3W4+8ZQ7+2bwV8l7d5Nu9MbfaBGTUbFkv3YjlnRMFglXA2x0+MbG0O3xycipMJgu2bd8Fl1u/EOV0oMReAofdDpfTVaGaGZlZiKthELsKCWv5wFUUoAAFKEABClCAAhSor4ChAvRhg3qjZVoK5L26qb6VYrqmCxQVFcJms+mBTDOeIh69ZZOP0Wr6wWQOFQSsViscDieys3MRYYuAfDabzepMc7qccEuLerkttvy3rdwnw82yQBSgAAUoQAEKUIACISTQjNFXVcUTuxyN2JhoyHt1U9UtuMQfAg6HA9LFPTIyyh/Z1zvPXT8+ioyNr9c7PRNSoL4CsbHR6NTxYECDughlsVhgs9qgaRqceou6x1P6qDXpKt++3YEI3y/WnAIUoAAFKEABClAgkAKGCtCHjb0DtU2BhAnnfXm7t0dERIYzA+sewgISeHc57uiKNdQAq8Va2pKuX6SSmcM7Haxa2ysm5CefCTAjClCAAhSgAAUoQIEKAqYKn5r5w/iRg1Db1MzFC4vdS8uhdG+PjIxULYthUWlWMiwFjjqiI6649KIKdddMGixmC9x6C7r0Ipk+aSwiIyMqpOGH4BFgSSlAAQpQgAIUoECwCRgqQD/myI6obQo23GAsr91uV4+mioyMbvbicxT3Zj8EIV2AyIgIdDvhOAwe0Acx0fvPd7kf/agjOuGpRx9AXn4B+EWBGgS4mAIUoAAFKEABCvhcwFABurd2JXqQ+MQzr2P8lLsrjOjuXc93/wkUFxeq+3BtNpv/dsKcKWAQgUMPaY9zup+KJQtn47Gl92L+rNvx0lPLcPNN16OgIA/2kkJ1wcogxWUxwkqAlaUABShAAQpQIBwFDBmgz16wDHszspCekY3ePc9BbHQUDu/YPhyPT0Dr7Ha7UVxcDHm0mqZpAd03d0aB5hKIi41BfFysmjrqAbuUo2WLNMTHJ6jBEvPz82QRJwqElgBrQwEKUIACFKCAIQUMGaBv2rwVE2+6FjExUehxzmm4d85EbNux25CAoVSokpJiVZ3IZh69XRVCf9m1fiUyNr6mz/E/BQIvIN8HMlBiYWEB7PaSwBeAe6RAEAuw6BSgAAUoQAEKNE7AkAF6TEzp/aBOpwuFRaVBo8PhalwNuVW9BYqLiyD331qt1npvw4QUCGUBaUU3mUzIycmG9DAJ5bqybhQIIgEWlQIUoAAFKBCyAoYM0GNjYpCdm4fTTuqM626apk/T0apFCvjlPwEZsVoGiJPu7f7bC3OmQHAJSHCekJCogvPc3JzgKjxLSwEKNFKAm1GAAhSgAAWaT8CQAfoDd01CYnwchg7qjSkThmP0sH6YNG5o8ymFwZ6l9VyqKd165d0IE0dxN8JRYBlstghER8dAbgHxfp9QhQIUoECjBbghBShAAQpQoBYBUy3rmm3VvUuewKYt29T+jzv6MJzY5WiYTYYsqipjML/kFxRCRs2X2wmsVhuki3sw14dlp4A/BGJj42CxWCCt6NLbxB/7YJ4UoAAFfCHAPChAAQpQILgFDBn1tmmVhkl33IdrRk3BmuffUt3dg5vZWKV3udzYtn0n3vrfh1iy/HGseOwZfPXdesTFxRuroCwNBQwioGkaEhKS1CPXcnKy1LtBisZiUIACFAikAPdFAQpQgAJ+FjBkgH71lRfjxcfvw7gbBuKvTVtw+cBxmDJnkZ8pwiP7PekZ+PHn3zDutllYteZ5fLfuJ7z/0Wd6oP4EBl4/Hv9u/g9FxcYYsZqjuIfHORkstZQWdLmI5XA4UFhYGCzFZjkpQAEKBJEAi0oBClCAAoYM0L2HpWvno3D9NVfg/LNPwUeff+ddzPcmCOTnF+Kue5fsz8EDuPUWdRkMS7ruTpx2FyIjbPvXc44CFCgTkHvR5VaQ/PxcSKBetoIzFKAABShgfAGWkAIUoEAQCBgyQHc6nVj74RcYfetcjJgwWw8YI/Dk0ruCgNPYRZT7zaVLe/lSuj1uePR/5e89f2zNC3C6+Fi78k6cp4BXICEhEZqmgV3dvSJ8pwAFKEABEeBEAQpQwBcChgzQLxs0Dh98+g369DofbzyzGLfcOBiHHnyQL+ob1nnEREdh2/ZdFQyk9VzTl5i0/afCtm07II9c0xc363+O4t6s/Nx5DQJyMUuCdOlxkp+fV0MqLqYABShAAQr4VICZUYACYSKwPyozUIWltXzBzJtx7pknwWI2G6hkwV2UbTt2weWu2DJusZhhsVoBDWVfu7lsxV0AABAASURBVPZmQLrCly3gDAUoUEEgIiISUVFRKCwsMMTFrAqF4wcKUIACFKBAgwW4AQUoYBQBQwXoT7/4thodOTkpoVqfDz79Vm9Z/7radVxYt0BaShJSkpIqJtQ0yP3nKPd12KEdEBcbU24JZylAgcoCMmCctKZLV3e32115NT9TgAIUoAAFKOAV4DsFKFBvAUMF6Lv3puOqoRPxyJMv4ctvf8R3639R05trP8FNt83D8sefQ+uWafWuHBNWFNBMJhxx2KEVF1bz6agjD9NbByOrWRPYRRzFPbDe3FvDBDTNhISEJEhwnpOT3bCNmZoCFKAABShAAZ8JMCMKhJKAoQL0CaMGY9G821Qr+rMv/w+PrnlFTd+t/xWXXHAGnl65AEcedkgo+Qe0LhE2G8aOGgKbdGmvYc9nnX4yTjmpSw1ruZgCFCgvYNW/l2JiYmG3l6C4uKj8Ks5TgAIUoAAFKBAaAqwFBQIqYKgAXWreplULDB98JR6cfzuWLZyuplm3j8aF557O+9EFqImTtPY9vepBHKO3kpfPSgKNKy69EJdcdC5ioqPLr2q+eb2FEih3czz4RQHjCUiAbrFYkJubAxk4znglZIkoQAEKUIACFDCuAEtGgYoChgvQKxaPn3wtIIG4pmm46YZr8eKTS3HvnVPwyJIFeHLF/bjkwvPQoV1bX++y0fm16jwMKZ0ubfT23JACgRDQNA0JCUnweMBHrwUCnPugAAUoQAEKUKD+AkwZdAIM0IPukPmmwKkpydA0DR3aH4SkxHhYrRYkxMf6JnPmQoEwE5AW9Pj4eDgcDjWye5hVn9WlAAUoQAEKUCBMBVht3wswQK+n6fOvrsWgkZMxeNRUfPrVunpuxWQUoEC4CERFRcNmi0B+fp4K1MOl3qwnBShAAQpQgAIU8JNAWGbLAL0eh33L1p1Y/ewbWH7fDCyYOQFzF65AcYm9HlsySVMEOIp7U/S4bXMIJCQkQtNM7OreHPjcJwUoQAEKUIACFGiQgDETGypAv3fJE3j6xberSD35/Jt4+NFnqywP1ILPv16H7qd1RUx0FFq1TMXhHTvgu3W/gF8UoAAFyguYTCYk6EG6DBYnLenl13GeAhSgAAUoQAEKUCCMBBpZVUMF6F9++yOuuvyCKlUZcMWF+OyrH6osD9SCvRmZaNMqrWx3B7ZpiT3pGWWfOUMBClDAKxAREYHo6Bh1L7o8fs27nO8UoAAFKEABClCAAhSoS8BUV4J96wPyZjabIIMtodKXLCuxOystDexHTW8Z8+5R0/Y/+uvRRx9FXdPWrVvx3nvv1ZmurnzCbf1b60x49bN0utXjHCt/bjz++ON4XJ/KL+N83d+nvjR68cWXkJ+fj507d2D16idC+hxetWqVXsfVIV1HX54bzKvp34urVz8JOe9o2XRLGtZt+MQTT+Cxxx7nz7gG/i3Cc6vuc6s6o8ceewxyzlW3LpiWeWMmvjdOwCABemnhI2w2FBUXl34o95pfUIioyIhySwI7m5aSjOzsnLKdZmZlo0VqivocExODuiaz2QxpVasrHdfXbUmjuo2io6PrPCfpWLdjU4yioqLw229/wKb/TDvhhBNC/nhER/vXsynHgtuG4rGJRjR/zoX8zxWjfO9Gq59v0fSux9+7RjlmwV6O6BD4+QZ+NUnAUAH65T3PxuTZD2JvemZZpXbvzcC0uYtxec9zypY1eKaJG5x+8vH47Ot1KLHbkZmVg9/+3IRuXY9Rufbv3x91TW3atMGZZ55ZZ7q68uH6uq1p1B9XXXUV+vbty/OtHt+b/jxfevXqhfj4RKTqF/Muv/yykD0e/fr1w5VX9gnZ+vnzHGHejfuZ3qcPzzeeO407dxrj1rfvler3amO25TaBO06hYh0qf8OpIIkvjRYwVIB+5aUX4MjDOuDKIbfg6hG34aqht6Df0Fv1ZQfjykvPb3Qlm7phu7at0bvnuRg29g6Mn7IAE0YPhs1qLcuWM/4R4Cju/nFlroETkKvgVqsNubk5kIHjArdn7okCFKAABShAAQpQIBgFDBWgC+CIa/vizWeXYECfi3Dd1b3VvCzTtP33fUu6QE9XXd4Da5bNw+qlc9H91BMCuXvuiwIUCFIBTdOQkJCoSp+TkwWPx6Pm+UIBClCAAhSgAAUoQIHqBAwXoEsh42Jj0KvHWbjovNMRGxMtizj5TYAZU4AC/hSQMSji4xPgcDjUyO7+3BfzpgAFKEABClCAAhQIbgFDBegX9h2J2qbgpg7T0jeh2q26DEdKp8uakAM3pYAxBCIjoyBTfn6eCtSNUSqWggIUoAAFKEABClDAaAKGCtAfWjAVtU1Gw2N5ml+AJaBAsAjExcXDZDKBXd2D5YixnBSgAAUoQAEKUCDwAoYK0A/p0Ba1TYHn4R7DXIDVp4DPBCQ4T0hIUoPFSUu6zzJmRhSgAAUoQAEKUIACISNgqAA9ZFRZEZ8IhP4o7j5hYiZBJGCz2RATE6vuRbfbS4Ko5CwqBShAAQpQgAIUoEAgBBigB0KZ+6BAcwhwn4YUkADdYrEgJycbbrfbkGVkoShAAQpQgAIUoAAFmkeAAXrzuHOvFAh6AVagcQKaJo9eS1LBuQTpjcuFW1GAAhSgAAUoQAEKhKKAoQL0L779EbVNoXgAWKeaBTiKe802YbAmpKsoLehxcQmQbu7FxUUhXVdWjgIUoAAFKEABClCg/gKGCtCff2UtapvqXy2mpAAFKFCbQPOvi46OhtyTnpOTowaOa/4SsQQUoAAFKEABClCAAs0tYKgAfdG821Db1NxY3D8FKECBegnUM1FCQiI0TQMfvVZPMCajAAUoQAEKUIACIS5gqAC9vLXD4cQvv/+F79b/UjaVX8/50BfgKO6hf4zDvYYmkxkJepDucDjUyO719WA6ClCAAhSgAAUoQIHQFDBkgP751+txxeDxGD9lAe5Z/BjG3j4fS1Y+E5pHgLWiAAXCWiAiIgJRUdGQZ6NLoG4ADBaBAhSgAAUoQAEKUKCZBAwZoD/06LNYuWgmDj34IDy/aiEeWzJHn2/XTETcLQUoQAH/CsTFxcNsNodJV3f/WjJ3ClCAAhSgAAUoEMwChgzQLRYzWrVIhXRzF9zDO3ZAYVGhzHIKIwGO4h5GBzvMq6pppY9ec7lcqiU9zDmaVn1uTQEKUIACFKAABYJYwJABenRUpCJNTIjFa29/COnynpWdp5bxhQIUoEAoClitVsTGxqGwsEA9fi0U6xgKdWIdKEABClCAAhSggD8FDBmg973sAmTn5mH0sP54/5NvsOaFN3HDtVf604F5U4ACFGh2gejoGEignpOTDbfb3ezlYQECLsAdUoACFKAABSgQ5gKGDNDP634yEuPjcEj7tlh892QsWzgdXY49IswPVfhVn6O4h98xD/caa5qGhIQkPTj3QIL0cPdg/X0twPwoQAEKUIACFDC6gCEDdKfTia+/34BVa17BiideKJuMjsnyUYACFGiqgAwWl5CQoLq5FxcXIzc3Xw/Y3di0+T81LkdBAcfjaKoxt/eTALOlAAUoQAEKUKDJAoYM0Kfe+SBeeuN9lDjsTa4gMwhiAU1OTy2IK8CiU6BxApGRUXB7NPz6x0bcfsfd6Dt4NG6ddheG3XgrHnh4lcrU4/God75QIFwEWE8KUIACFKBAOAhIBGS4ehaXOHDPrFsw6rp+GHFt37LJcAVlgfwq0KrzMKR0utSv+2DmFDCigMPhwF//bMHMuQ9g2/btwL5YvKCwCOs2/II+g0aCAboRjxzLFMQCLDoFKEABClDAEAKGDNBtNovqymkIIRaCAhSgQIAFtmzdgUVLH4PFatFb0j2Qx69VLsKs+YuQn19QeTE/U4AChhRgoShAAQpQgAL1EzBkgG63O3HVsIm4f+nqsvvP5V70+lWJqShAAQoEr4C0jP/6+5+qAiaTCXJPutPlhMe9rxldrQF++e1PxMRE7/vENwpQIKwFWHkKUIACFAgZAUMG6EcdfjAuOvc0xERHhQw0K9JwAY7i3nAzbhH8AvkFhXrwvbGsIhaLBSZNg3R7l+C9bIU+8/c/m/VX/qcABSjgXwHmTgEKUIACgRMwZIBe/r7z8vOBY+GeKEABCjSPgM1mRXJSQoWdW6xW/bNHBene+9H1BWjZIk3eOFGAAhQIZgGWnQIUoAAFygkYMkDPys7FUy+8BRnNXaanX3oHsqxcuTlLAQpQICQFImw2HHpw+wp10zQNVqsN8Hhgl6dbeICoiAjYIiRwr5CUHyhAAQpQoIIAP1CAAhQILgFDBuh3zH8YH3/xPY4/7gg1ffjpN5i1YFlwybK0TRZo1WU4Ujpd1uR8mAEFgk3grDNOVgF4+XJrJg0WPUiXbu4OPUjvd+WlkHvUy6fhPAUoQAEKBFiAu6MABSjgYwFDBui79uzFsvumo0+v89W0bOE0bNuxy8dVZ3YUoAAFjCkggffMqTfDbDJXKKBJD9KtVisuPK87Oh9zGKwWS4X1/EABClCAAqElwNpQgALhJ2DIAF3+OK18KOQP08rL+JkCFKBAKAqYzWZ0aHcgnntiCS67+AKcdEJntGt7AC4450yMHj4YV/e7HDarGVlZmZAW9VA0YJ0oQAEKUMDvAtwBBShgQAFDBuidjzkCoyfeWfaItVET5+LELscYkI9F8qcAR3H3py7zNrqABOmapmGgHoyPGTkEs/QW9WsHXonzzz4diQkJSEhIhHR1z87OYpBu9IPJ8lGAAhQISwFWmgIUaIyAIQP0SWOGoFeP7tiydaeaLr/4bNxy4+DG1I/bUIACFAhqAbPZhOioSMTFxiAywlZWl8jIKMTFJcBuL0FOTjaD9DIZzlCAAhSgQFgIsJIUCFEBQwboJpMJl+gB+txpYyFTzwvO5GBIIXoCsloUoEDjBaKjo/UgPR4lJcXIy8tpfEbckgIUoAAFKECBCgL8QIHmEjBUgD7yljn4Z/NWyHt1U3Mhcb/NI8BR3JvHnXsNLoHo6BjExMSiqKgI+fl5wVV4lpYCFKAABSgQngKsNQVqFDBUgD5sUG+0TEuBvFc31VgLrqAABSgQxgKxsXGIiopCQUE+CgsLwliCVacABShAAQpQAKBBMAsYKkA/scvRiI2Jxs7d6ZD58tOWrTuC2ZllpwAFKOBXAbkfXe5Lz8vL1VvTC/26L2ZOAQpQgAIUoEAYC7DqfhUwVIDurenb733mnS17f/Wtj8rmORMeAhzFPTyOM2vpGwFN0xAfn4CIiAjk5uaguLjINxkzFwpQgAIUoAAFKBBAgXDflaEC9O/W/6IerbZ7T4Z6X/HEC+r9gWVPhvtxYv0pQAEK1CmgaRoSEpJgs9nUyO4yeFydGzEBBShAAQpQgAIUCB8Bw9fUUAF6TVqHdGiLh++dWtNqLqcABShAgX0CmqYhMTEZVqsV2dlZ6jFs+1bxjQIUoAAFKEABClDArwJNz9xQAbrccz7i2r6YP2Mc5N079epxFuLjYpteW+YQVALU2GxtAAAQAElEQVQcxT2oDhcLayABTSsN0i0WC7KyMuFwOAxUOhaFAhSgAAUoQAEKUKAmgVoD9Jo28vfy1//3CbJzcst2k5GVjYUPrS77zBkKUIACFKhdwGQyISkpBWazBOkZcDoZpNcuxrUUoAAFKEABClCg+QWaM0CvsfY//vwHEhPiy9anJCXi+/U/l33mDAUoQAEK1C0gQXpycjI0zYTMzEy4XM66N2IKClCAAhSgAAUoQIFmEzBkgF5YVIyi4uIylPyCQv2zvexz/WaYKtgFdq1fiYyNrwV7NVh+CjSrgMlkRnJyCjQNepCeoQfprmYtD3dOAQpQgAIUoAAFKFCzgCED9G5dj8WUOYsho7rLNG3uEpx+8vE116I51nCfFKAABYJEwGw2q+7uHg+QlZUBt9sdJCVnMSlAAQpQgAIUoEB4CRgyQJ80ZgjOPuNELFr2lJrO694NN4++JqyODCtLAQpQwJcCMmBccnKyCs4ZpPtSlnlRgAIUoAAFKEAB3wkYMkA3mUy49MKzsGb5PDVd0qM7ZJnvqh32OQUFAEdxD4rDxEIGkYDFYlUt6U6nE9nZmfBIk3oQlZ9FpQAFKEABClCAAqEuYMgAfduOXRh7+3z0ve4W5f/nX/9i2ePPq3m+BIMAy0gBChhVwGqVID1ZPXpNHsHGIN2oR4rlogAFKEABClAgHAUMGaDPWrAcF59/OmT0djkonQ5tj8+/Wi+znCgA0IACFGiSgM0WgcTEJD1It+st6VlsSW+SJjemAAUoQAEKUIACvhMwZIBut9tx4bmnAxrUl6ZpcHs4qJHCCKOX5hrFPYyIWdUwFoiIiERCQiLs9hLk5GQzSA/jc4FVpwAFKEABClDAOAKGDNDltki5R9LLlJ6RBavF4v3IdwoEswDLTgHDCERGRiE+PgElJcXIy8sxTLlYEApQgAIUoAAFKBCuAoYM0Pv17oEZ8x7C7j0ZWP74Cxg+YRYG97s0XI8R602BBggwKQUaJhAVFY24uHgUFRUhPz+vYRszNQUoQAEKUIACFKCATwUMGaD3vOBM3DR8AM4540Tk5hVg0V2349zu3XxacWZmfAGO4m7AY8QihaRAdHQMYmJiUVCQj8LCgpCsIytFAQpQgAIUoAAFgkHAkAG6wLVp1QJjRgzEzTcOhlv6vMtCThSgQEgLsHLNJxAbGwdpTc/Ly9Vb0wubryDcMwUoQAEKUIACFAhjAUMG6PMXrUJ+QaHeep6Pq4dPwphJc7H6uTfC+DCx6hSggA8EmEUdAnI/utyXnpubg+LiojpSczUFKEABClCAAhSggK8FDBmg//bHP4iNicZX323AKSceh2cfvQfvvPepr+vO/AwuwFHcDX6AWLxKAqHxUYL0iIgINbK7DB4XGrViLShAAQpQgAIUoEBwCBgyQDeZS4u1bsPvOPaowxATHQUzR3EPjjOKpaQABfwjEKBcNU1DQkISbDYbsrOz1GPYArRr7oYCFKAABShAAQqEvUBpJGwwhgNbt8TUuYvxzQ8/48QuR6nu7vAYrJAsDgUoQIEQEihfFU3TkJiYDKvVhqysTDgcjvKrOU8BClCAAhSgAAUo4CcBQwboU26+HpdffDYevncq4mJjkJ2Ti2sH8DFrfjoHDJstR3E37KFhwcJAQNM0JCUlw2Kx6EF6BpzOJgXpYSDGKlKAAhSgAAUoQIGmCxgyQI+OitRbzo+GjOT+zEvv4MA2rXD+Wac0vbbMgQIUoAAF6i2gaRKkp8BkMiMzMxMul7Pe2wY2IfdGAQpQgAIUoAAFQkPAkAF6edqX33y//EfOU4ACFKBAAAVMJhOSk5OhaZoepGfoQborgHs3yK5YDApQgAIUoAAFKBAgAcMH6AFy4G4MKMBR3A14UFiksBQw6S3oyckpqu5ZWRlwu91qXl5cLjeKS+zweDhQiHg0ZuI2FKAABShAAQpQwCtg+AD9ikvO85a1Se/Pv7oWg0ZOxuBRU/HpV+uqzSs9Iws3TboLQ8fMwJQ5i1BUXKzSrf/pd9w++wGc13s4rh83E598+YNazhcKUIAC4SJgNpv1lvQUPTj3IDs7Uw0c9867H2Px8scxa94iPLbmBXz93XoUF5eEC0mw1JPlpAAFKEABClAgiAQMH6CfclJnSDd3exNGEd6ydSdWP/sGlt83AwtmTsDchSsgLT6Vj9Oi5U/h5K7HYdXi2YiPj8NTL7ytksg98RNvGoK1Ly3Htf0vVdurFXyhAAUoEEYCZrNFD9KTkZ6ZgyEjb8YjTzyLL776Hlv+24a31n6IexYtx6onn0d6RmYYqYR7VVl/ClCAAhSgAAV8KWDIAH3ITdPVo9W27diNCVPuxpff/KgHxSsbXe/Pv16H7qd1RUx0FFq1TMXhHTvgu3W/oPLXF/p+el5whlrc8/wz8Pk369X8YXr61OREmE0mnH5yF9Vy5G1dVwn44hcBjuLuF1ZmSoEmCTidbtz74CPIyc1XPws9lZ6B+cEnX+D9jz5HQUFhk/bDjSmgBPhCAQpQgAIUCDMBQwbo8HgQGxONr7/fgF4XnoV750zExn82N/rQ7NVbc9q0Sivb/sA2LbEnPaPss8wUFBZB04CkxHj5iLYHtMTe9KqtQK+8+QEOPbgdoiIjVTq+UIACFAgngR9/+hUZmVmwWq1we9xwOp2VQnTghVffhsVqCScW1jVIBVhsClCAAhSggNEEDBmgu90e1QX9hw2/4ajDD1FmJq3moj706DMYMWFWlenZl/+ntpUXTW/9lneZNE2PxGWm0mSqkKbq/n76dSOeevFtzLj1hrItS0pKUNfkdrtVS1Nd6bi+bksa1W1kt9t5vtXj+5LnUt3nUnVGf/61CfIzTX4IWswWNe9yueB2udW8rJMpXb8IKudidXlwWePs6VbqJheFgsSizr8PWI/SY2pkB4fDAf4sM/5xMvI51JCyybkm51xDtjFiWvkbgVPjBapGoY3Py2dbSnf0gSNux7Yde3DCcUdg994MREZG1Jj/0IG9sVBvZa889b7kHLVNWkoysrNz1Ly8ZGZlo0Vq6YjE8lkm6f4uoxF773XP0NOkpSbLKjVJa/qSR57BkgWT9db1VmqZvEhQX9ekaZreOq+hrnRcb6pglPHL48jZ9FaFZTSqaFSTh6bxfKvJhsvrdw5V55SfXwjpkaT/RINMkkYGj5NeTw6nAy5pTdcvsMq6rdt2QdN4HooRp8afc9XZaRrPq1IX37oyz+o9NY3nG8+N6s8Nf7loWvCfc+BXkwQMGaAPG9QbLz1xH55cehcsFgsibFZMvWV4jRWV7uZxsTGoPEXYbGqb008+Hp99vQ4lestiZlYOfvtzE7p1PUatkxHaHQ6nmj/1pM54/+Ov1Py7H32J07t1VvPpGVmYOncxpkwYjtYt93eVl5XSzbOuSdM0VY+60nG9VXWb9TrIDz7549/7me8VfWrykO8ZmWpaz+X1c6RTVaeUlCSc0PkYaCY9BN83SSu6Wf85bdUn+ZnodDnhcNhx9FEdYdLT0LGqI02aZsLfC03zq/f5Z+V+xEp+n8ok85x4Tvj7HJBzTSZ/78ff+cvfA5waL2DIAH3jP1vKHnH21ruf4t4lq2Frwv2M7dq2Ru+e52LY2DswfsoCTBg9WM/PqtQmzbwfObl5an78yIF4Y+2n6jFr/23diYF9e6rlL7z2Ln7+7S8MGD4Jp/QYpKZde9LVOr5QgAIUCCeBwzoeXKW6mr7EZDbDarPpP1ttOLhDOxQWFCI9fS8yM9NRVFSkp/DoE/9TgAIUKBXgKwUoQAEKVC9gqn5x8y6dfc8y1ZL66x//4LlX1uKITh1w58KVTSrUVZf3wJpl87B66Vx0P/WEsrzee3kFUvVWIVkg70vvnaYes3bX9HFlA8GNGtoPX61dU2Fq1SJVNuHkRwGO4u5HXGZNgUYKtGyRhsk3j6pxa01vNZ8/63akpaUhPj5Ber8jNzcbe/bs1t9z1KByNW7MFRSgAAV8I8BcKEABCgStgCEDdOkqadFbY75d9wt6XdhdtWTn660xQavMglOAAhQIEQGz2YQjDuuIeTNvQ0pyUlmtpEtep0MPxjOrFiMiwqbuP4+KikZKSqqaIiOjUFxchIyMvfokreqFevDOVvUyQM5QgAJBJMCiUoACFPCfgCEDdPmTbfN/O/DVdz/imCM7qtrLKMFqhi8UoAAFKNCsAjEx0eh4SHvcO3cqnntiCe66Y5IemD+IqbfeBJvNCpOp4q8Wi8WqWtPT0lqqd8CjWtP37t2t3h0OR7PWhzunAAUoYCgBFoYCFAhrAZMRa3/dgMswf9Gj6KT/AXh4xw6Qe9LTUpKNWFSWyY8Cu9avRMbG1/y4B2ZNAQo0VkDTNMTHxapgvEP7tuo9Vg/ca8tP0zSUtqqnITk5Fd5WdblPXVrWCwsL2KpeGyDXUYACFPCBALOgAAWMLWDIAF0es7Zs4XRMvOlapdfpkHZ4cP7tap4vFKAABShgLAGPx93gAskIsnKPurSqx8UlqO3z8nKxZ88u5ORkq5Hg1UK+UIACFKBAMAmwrBSgQBMFDBmgZ2Xn4qkX3sLUOx9U09MvvQNZ1sS6cnMKUIACFDCYgKZpiI6We9VLW9WjouRe9WJkZmaoUeDZqm6wA8biUIACFGhWAe6cAqEvYMgA/Y75D+PjL77H8ccdoaYPP/0GsxYsC/2jwRpWEOAo7hU4+IECIS9Q2qqeiBYtWiIuLh567I7yrep2uz3kDVhBClCAAhRoRgHumgIGEDBkgL5rz14su286+vQ6X03LFk7Dth27DMDFIlCAAhSggL8FNE1a1WOQklLaqu69Vz0rS1rV96CgIB+1dav3eDzILyhAdm4uvl//EwqLilBYWOTvYjN/ClCAAhSgQK0CXEmB+giY6pMo0GkqjwAs+zeZNHnjRAEKUIACYSQgreoJCdKq3kq1qgMa8vPzsGfPbmRnZ8FuL0H5r/SMTHz3wwYMG32bPk3CvIUP45rhEzBqwjRs37kLubn55ZNzngIUoAAFKBAqAqxHiAgYMkDvfMwRGD3xTqx44gU1jZo4Fyd2OSZEyFmN+grs4iju9aViOgqEvICmlbaqp6amITk5RY0AX1JSjKysTKSnl7aqF+qt5D/+8jvufmAZnC5nBRNpUR9760xkZefore/yMM8Kq/mBAhSgAAUoQIFaBbgyUAKGDNAnjRmCXj26Y8vWnWq6/OKzccuNgwNlwv1QgAIUoICBBaxWGxIqtaoXFRVi49//4MGHV8HtrnlU+dvvmI+MzGwD145FowAFKEABCoShAKtcJmC4AN3pcmH0rXNxiR6gz502FjL1vOBMVNftvawWnKEABShAgbAT0LT9reqJicl663iuCs4dDgfsJXa4nHoruqdia7ldX2fStws7LFaYAhSgAAUoEMYCwVR1wwXoFrMZFosFRcXFweTIsvpBgKO4+wGVWVIgRAVkYLiffv0DEbYI9TsEGiAXfEvsdrj1C7/lq71+wy/lkZwY4QAAEABJREFUP3KeAhSgAAUoQAEKNEXAp9saLkCX2kmQ3nfIRNy9aJW6B917L7qs40QBClCAAhSoLCAXdg89uAMkMDfrF3ptNhukK7z0vnLoLelOfcK+r0MP1dPtm+cbBShAAQpQgAIUMJJA1QDdAKU78rAOuPSi7khKjDNAaVgEClCAAhQwuoCmaWjdqkWFYsrTP2QUeAnYXXorusPuADxAbHR0hXT8QAEKUIACFKAABYwiEPAAvT4VH3FtX1Q31WdbpgkdAY7iHjrHkjWhQCAEDml/EI4/7ugqu5LWdavFCrfHjX59esJsMeSvvirl5gIKUIACFKAABcJPwJB/pdyz+HFk5+SWHY2MrGwsfGh12edaZriKAhSgAAXCVCAhIQ4jrhuAY448vIqAyWxCvyt6oduJnWEvKYI8oq1KIi6gAAUoQAEKUIACzSxgyAD9x5//QGJCfBlNSlIivl//c9nn5pvhnilAAQpQwMgCaakpuHX8Dbh17A3o16cXunY5BkMGXonpt41F3ysuQdsD2sBstiA7OwsFBflGrgrLRgEKUIACFKBAGAoYMkAvLCquMIp7fkGh/tke+oeHNawgwFHcK3DwAwUoUE+BmOgonHxSF1zR60KMvn4wLr7gbHQ+5khERthgMpmRnJyCyMhI5OfnqUBdRoCvZ9ZMRgEKUIACFKAABfwqYMgAvVvXYzFlzmJ8t/4XNU2buwSnn3y8XyHCIXPWkQIUoEA4CVgsZki3d7PZXKHamqbpy5MQFxevurpnZqbD7XZVSMMPFKAABShAAQpQoDkEDBmgTxozBGefcSIWLXtKTed174abR1/THD7cZ/0FmJICFKBAUAlER8cgMTEZMsJ7RkY6HA5HUJWfhaUABShAAQpQIPQEDBmgm0wmXHrhWVizfJ6aLunRHbIs9PhZo9oEdq1fiYyNr+1LwjcKUIACvheIiIhAcnIqNE2DtKQXFxf5fifMkQIUoAAFKEABCtRTwJABej3LzmQU8J0Ac6IABcJWQB7DJkG6zWZDTk62ujc9bDFYcQpQgAIUoAAFmlWAAXqz8nPn4SLAelKAAsYWkF5aSUkpkG7vBQX5yMrKhNvtNnahWToKUIACFKAABUJOgAF6yB3S0KkQR3Gv97FkQgpQwEcCMnBcfHwi7PYS1eXd5XL6KGdmQwEKUIACFKAABeoWYIBetxFTUCDMBVh9CoSXQFRUFORRbG63BzJ4nATr4BcFKEABClCAAhQIgIAhA/TPv16P4eNn4YyLr8UpPQaVTQHw4C4oQIFAC3B/FDCggNVqQ0pKKuQRbdLdvaio0IClZJEoQAEKUIACFAg1AUMG6I+ueRkTb7oWH7/5GL5au6ZsCjV81qd2AY7iXrsP19ZPgKko0FgBCc5l8LiIiEjk5uaoqbF5BcN2docD23bswm9//IXHn3oRv+rvW7fvhN3Ox88Fw/FjGSlAAQpQIDQEDBmgt2yRgsMObQ+zyZDFA78oQAEK7BPgW4gLaJqGxMQkxMbGQVrRMzMzQnLwuJ279uCDj7/AuEkzMf3OhXjjnfcxQ38ff9ssvPPux9ihrw/xQ83qUYACFKAABQwhYMgIOCU5ES+/+T7yC9il0BBnCQtBAQo0kwB3axSBmJhYFag7nQ51X7rT6TRK0ZpcjuLiYmz49Q888sSz1ea1+tmX8M236/k7uVodLqQABShAAQr4VsCQAfrLb7yPexY/jvOvGFF2/7nci+7bqjM3owtwFHejHyGWL+gFWIEGCUhXd+nyLhtlZqajpKRYZoN+2rM3Aysfe7rWeqx5/hVIK3utibiSAhSgAAUoQIEmCxgyQC9/33n5+SbXlhlQgAIUoEDABEJxRxaLBampabBarcjOzkJBQX7QV7OwqOqFBo/bU6Ve+QUFVZZxAQUoQAEKUIACvhUwZIDu2yoyNwpQgAIUCEGBZquSpmlISkpBdHQM8vPzkJOT3Wxl8cWO12/4VWXjdrshXfftJXbYHXY47A6UD9R/WP+LWq8S84UCFKAABShAAb8IGDJA/2/bLoyfcjfO6jWUXdz9ctiDI1OO4h4cx4mlpEBoCtRdq7i4eCQkJKK4uEjdly4Bbt1bGSeFx+OB3V6CY446DCUlJXA4HHC7XDCZTbCYzfB43JBA3akv9+hpTzz+WEgPAvCLAhSgAAUoQAG/CRgyQJ99zzL0uvBsHN6pA954ejFuun4Ahg3q7TcEZkwBClCAAhRojEBkZBSSk1Pg0gPbjIy9KshFfb6aKY1cRCgsLERWVib27NmF7OxsPeg2Qx4pZ7XaYIuI0D9bYLZYYLNFQAJ1l96ybrfbYbVI0F6163szVYW7pQAFKEABCoSkgMmItSouLsG5Z56kHmWTmpKEgX17YtPmbUYsKstEAQpQgAJhLiCBbUpKKkwmE2TwOGlRb26S8vuXbutyr3xGRjr27t2NvLwc/ferCzIyfXJyMlq1bIEbR1yrl18rvxmgfzRbLIiw2TBkYF/Exkap7QsLeS86+EUBClCAAhTwk4AhA/To6EhVXU3TsHX7LhSX2JGZlauW8SV8BDiKe/gca9aUAsEuYDab9Zb0VERERKp70uXe9Oask8Nh1wPxXKSn74G07Et5TCYN0i0/La0lUlLS9IA7Tm8ttyIxIR6HdGiH6wf3r7bIgwZcgRO6HIM2rVup9Hl5uSpfo12IqLbwXEgBClCAAhQIMgFDBuidjz4M2bl5GHDFxbh6+G04+9KhOP/sk4OMlsWlAAUoQIFwEtA0DYmJSSrwlRZr6UYuXcoDZVBSUoLc3Gzs2bMbmZkZKCoqVAG13CffokWrsoHtpKW/cpkO6XAQTj/1RMyfdTtmT70Zl/W8ADMnT8D8mbfhnDNPRYd2bVVeyckpej7J0DRNXYiQ4F+6v8OnX8yMAhSgAAUoEL4ChgzQRw/rj8T4OJx1eld89vYTkEet9el1fvgeJdacAhSgAAWCRkC6jkugLq3YmZnpcLmcfim7DNwmrdjZ2VnYvXsXsrMz1WBvkZGR+oWCZEhQLuWIjIxSATXq+IqLjUHHQ9rjqCM6YbDeai6Dx3U8tAMS9N/H5TeVe9OlBT4+PgFyASIrK0Pt2+VylU9m3HmWjAIUoAAFKGBgAUMG6HaHA6ueehV3zH9Y0W3avB0ffPKNmudL+AhwFPfwOdasKQVCTUC6uicnp8LjAeTe7/KtzHn5+bDbHfjx59/gcDiRX1BY7+pLQCz3gEtQvGfPLtWK7XQ6EB0drbrYS/d1CZwjIiLqnWdjE0ZFRSMtrYXqMWC321W399xcub/djXD+Yt0pQAEKUIACTREwZIA+a8Ey7Nqdjv+27VR1a9M6Daufe13N84UCFKAABSgQDALySLKUlFTVNVwC6q3bd2DTlq0YP2k2Bgwdgzl3P4j+192EmyfPwc5de5CRmVVttSQAl3vIpTt56SBvuXrg71GBcWpqGlJTW6h7y61Wa7Xb+3ehpgabkzJIwC7d6uW+94KCfH23+tUJ/ZX/fSrAzChAAQpQIMQFDBmgb96yHVNuvh4RETbFH6m/O5z+6SKodsAXClCAAhSggB8E5H5vuW/baovAzp27MeG2WcjOza2wJwnMb5o4A7m5efB2E5cW6by8XOzdqwfuGemQgNdkMkNax9PSWqrWculKbzZbKuTVXB9MJpMqmwTq0gVeLihI2SVgb64ycb+NEeA2FKAABSjQ3AKGDNAtFnMFF3lETIUF/BAWAhzFPSwOMytJgbAQKCp2YN7Ch1UA7rA7gMqNy/rnW6fNw67deyBd16XFXYJbm82GhIQkdT95UlIypJVagmGjopnNZsh970lJKTCZzPpFhxxIy7/dXmLUIrNcgRTgvihAAQpQoE4BQwboxx51GJ58/k3k5xfi23U/Y+KMhTj7jJPqrAwTUIACFKAABYwokJ2TA5PZDJvVprqn2x12eNweuF0uOBwOlOgBbHFJMYqKi1WX8SQ9GJdB3hISEhEZGVmvQd5goC+bfmFBuvdL+WUwOxnRXi468IK7gQ5SCBaFVaIABSgQCgKGDNBvHn0NUpITYLVacP/SNTjnzG4YNrB3KHizDhSgAAUoEGYCEqCu3/CrqrVm0iDBq6Z/kiBd3b7l8cCyL3j/9fe/VYBus0XoKYL/f2RkVNk98nIhQlrTc3Ky1ejvwV871iDMBFhdClCAAgERMAVkLw3ciaZpuPi8M/DYkjl4ZuXduPTCs2AyGbKoDawZkzdEgKO4N0SLaSlAAaMKaJqGg9oesL94enRutdpgtVhUsG612WDW5zU9eG9/0IH704XQXHR0DOTeeXmXR8PJYHdyn7pcvAiharIqFGiCADelAAUoUCpgqKh3xRMvoLaptMh8pQAFKEABCgSXQOuWaRULrAEms7lK1/W0lKSK6ULok6ZparT5tLQWkJZ1GfhOBpKTx8aFUDVZFQoYU4ClogAFgkbAUAH6Y0+/ho+/+B7rfvqj2iloVFlQClCAAhSgQDmBFmmpOKHzMeWWVJ0958zTEBMbU3VFiC0xmcxISEhUI9FbLGbIaPXyaLaSkuIQqymrQ4HwEWBNKUAB3wkYKkAfO2IgIiMiEB0VgSsuORcPzr8dyxZOL5t8V23mFAwCHMU9GI4Sy0gBCtRHICE+DkOv6YvDOx5SbfKuxx+LPpf1gKSrNkEILrRarSpIT0xM1munITs7CxkZ6XA47Prnqv/lEXRFxSXIyy9EYVEx1P37VZNxSRAJFOvH02534JffN+rHPgsyz4EEg+gABq6o3BMFwkrAZKTaDuhzEVYtno2bhl+NP//6F9eOmoI5967Av1u2G6mYLAsFKEABClCgwQKtWrbAxLEjcE3/K9Czxzk4/NBD0OvCczHk6isxcuhAyPoGZxoCG0ToF+ZTU9MQH58At9uFzMwMFaxLQO6tnsPhwONrXsTs+Q9g1IRpmHHnQixZ/oSe3g3ex+5VCp53u92uLrJMmbUAA4aOwR1z78OIcZPV/BvvfICMrKzgqQxLGgICrAIFjCVgqADdS3NwuwNx3cDe6Ku3JnzyxXdY//Pv3lV8pwAFKEABCgStQFJSAi69+Dz069MLt064AX2v6IlLLjoXSYkJQVsnXxU8Kioacn96bGyc3pJaAun2vjc9HTk5eRg5birefu8jbPz7XxWUb96yDZ9/9R36Dh6Nbdt3Iic3D/wKHgG3x4Nrho/Hlq1VG2DWPPcKnn/5beTlF4BfFAgJAVaCAg0UMFSA7nS58MmXP2DynAfQf9gkbNm2A488OBtXXHJeA6vF5KEgwFHcQ+Eosg4UoEBlAZPJhJjoKCQmxOvv0VUGiqucPrw+a4iJiVWPZpOAXVrH777/YWRk1tyiOl1vTbdZreHFFMS1lQsu02ffW2sN3v/oM3z7/Y+1puFKClCgVICvoSdgqAC9V/+b8MQzr+HUkzrjpdX3YcKowWjftnXoqbNGFKAABShAAQrUKCAXMaTLe1RUlLo/2elywl5ih9vlrrKNtLRu/l18B8kAABAASURBVG9bleVcYEyB+PhYbP6vYsu5x+2pUth/t2yF3NpQZQUXUIACgRTgvppBwFABenZuHn7fuAl33fcIzuo1FKf0GFRhagYf7pICFKAABShAgWYS2LptJ2QwOZvVBk0DHE4HXE5XlfvOf//z72YqIXfbUIG//9kMt2f/hRbpJeFw2OF0OCtktfGvTZBB5Cos5AcKUCDEBFid6gQMFaB/tXYNapuqqwCXha4AR3EP3WPLmlGAAhSoj4DLXRrIaSYNVpsNVot0ZfeUtqyWa3SVAeVc1bSu12cfTBNYgfbt2u7foX4MHQ4H9De43C7IcfSuPKBNK1gsFu9HvlOAAhRouECQbmGoAD1IDVlsClCAAhSgAAX8INC+7YEVcjWZTTCbzWqZXW91VZGd/unIwzvqy/knjU5h+P9yS4J3UEQVnHs8kF4SJs0Ep9MJ977u7q1bt0RUVKTh68MCUoAC4Svgr5rzt5m/ZJkvBShAAQpQgAJNEjCZTDj04PYV89A0FdBBD+wcepAeaYtAu4MOqJiGnwwrEBcbjXGjrlNd2qWru7SSy3GWIF2Dpi+3IyEuDpddzAGCDXsQWTAKUMCvAvsCdL/ug5lToFECHMW9UWzciAIUoEDICMTERGHapDGIjIioUCdN02Cx2uDWg/Q7Jo9DVGRkhfX8YFwBq9WKFmnJGDtqCMwmM8z7ekTosbm68NIiLRW33zISNpvNuJVgyShAAQr4UcDkx7z3Z805ClCAAhSgAAUo0AiBCD1Qe2L5fTjlxOPRbl+X99atWuCEzkfj2ccfQoTNjLy8XL1BXe5kbsQOuElABUpKigGPCyd0OQqL7pmJkUMH4bRuXXFZzwtw6/gbsPjeWUhKiEV2dhaPaUCPDHdGAQoYRSAkAnSjYLIcFKAABShAAQr4VsBms8JiMeP66/pj9rSbsfSBubh7zmSMHn4NYmOi0bJlC0jQl5ub49sdMzefCzgcDhV4m80WJMQnoP1BB+K8s0/DsGv7o98Vl+CUk45HdHQ0oqKiYbeXoKAg3+dlYIYUoAAFjC4QNgH686+uxaCRkzF41FR8+tW6ao9LekYWbpp0F4aOmYEpcxahqFi/yguUpc3KzsU5l12PpaueK1vGGf8JcBR3/9kyZwpQgALBJpAYH68C8oS4GERHRSI5KVFVITIyCnFx8SguLkJ+fp5axhfjCcgI7dnZmdA0DUlJyfp76Z+gmqbpwXosIiJsZYWOiYmFzRahAvTiSn+LlSXiDAUoQIEQFSj96RiilfNWa8vWnVj97BtYft8MLJg5AXMXrkBxid27uux90fKncHLX47Bq8WzEx8fhqRfeLlsnMwsfWo3jjzsc0ODDL2ZFAQpQgAIUoEBTBKKjYyBBnbS4FhYWNCUrbusHAY/HrbecZ8LtdqvgvOy+8xr2pWkaEhISIelycrLgdDpqSMnFFKAABUJPICwC9M+/Xofup3VFTHQUWrVMxeEdO+C7db+g8tcX3/yInhecoRb3PP8MfP7NejUvLxt++RNRURE46vCO8D7WRZYbfmIBKUABClCAAmEgEBsbB2lNl/vRpTU9DKocFFX0eDx6cC5BthOJiUmwWm31KreM7J6YmAxN05CVlamC+3ptyEQUoAAFglwgLAL0vRmZaNMqrexQHdimJfakZ5R9lpmCwiL9lwCQlBgvH9H2gJbYm56p5uW5nItXPoMxwweoz3zZL+DPOY7i7k9d5k0BClAg9ATi4xNU1+icnGyUlJSEXgWDsEZy24HdbkdsbDwiIiIbVAN5BFtCQpIKzrOzMzloXIP0mJgCFAhWgZAI0B969BmMmDCryvTsy/8rOy6aaX9VNa36Pupytda7gabtTy9d3a/odS7i42K9q8veS0qK9T8Cap+kS5fDYa8zXX3yCqc0LpdLdWsLpzr7oq4ysA7Pt9q/J33hzDz2G0v3U3rs96CFfy1qO9/k519UVJTqGi0BnXR55/Hw7/GozVcG7pNbDmw2mxror7a0Na2TbosyaJzD4UDphZfA1seh//0m51VN5ePywB6PUPeWc03OuWCvZ1mgxJlGCeyPQhu1uTE2GjqwNxbOmVhl6n3JOaqAaSnJyM7OUfPykpmVjRapKTJbNkn3d5fLDbv+C0AWZuhp0lKTZVZ1dZ9zz3Kc0mMQVjzxAlY/9wYeWPakWmcymVHXpGkaNM2EutJxfUVLTfO3W8X9hZI/z7fQPbZGPE8B/nwz4nEJ1TLV9fPNbLZAWtLNZjPy8/P11lcPf/+aAv8zUQaFKyoq1ANzC2Ji4pp0DCRAlyBfghaH/ndaIM9tOd80LfB+gawj92Wc46tpJmj6FOzHRAVJfGm0gKnRWxpow6jISMTFxlSZIvQrtlLM008+Hp99vQ4ldjsys3Lw25+b0K3rMbIK63/6HQ6HU82felJnvP/xV2r+3Y++xOndOqv5lQ/cga/WrlHTiGv7YnC/Xhg/8hq1zmq1oq5J0zT1C6qudFxf0bLNCTegxRFX1OlrWLd6nBv+KLt0CZTJH3kzz4rnKD1KPeQRWLQotaCD/x3MeuBdl7PNFoHk5FSYzSbIPekmk4m/SwL4O0n/s0d3z9P9LUhKSoFN/3usrmNW13q5H11+t0mvCGlVryu9r9bLPq1WC8+fAJ4/1jDfV+k55/+fpf50Br+aJBASAXpdAu3atkbvnudi2Ng7MH7KAkwYPRg2/Ztftps0837k5JY+lmX8yIF4Y+2n6jFr/23diYF9e0oSThQwpAALRQEKUIACNQtIUC7BoQSLWVkZeku6q+bEXOMzAbmtTwZ1E/ekpGTIcfBF5pqmQYJ0aV3MysqCtND7Il/mQQEKUMBoAiajFchf5bnq8h5Ys2weVi+di+6nnlC2m/deXoHUlCT1Wd6X3jtNPWbtrunjIC3zakW5l+uuvgyjhvYrt4SzFAhJAVaKAhSgQNALmPXW9iS9BVeCxszMTD1Idwd9nYxcAY/HUzbiepIenIu/L8sr+SUlJcGz77FtHn1/vsyfeVGAAhQwgkDYBOhGwGYZGibAUdwb5hVcqVlaClCAAoERkO6iEiy6XE7IwHEM6vzjLq7Z2VlqcNeEhETU93FqDS2N5CtjDMgTdmTQuIZuz/QUoAAFjC7AAN3oR4jlowAFGi7ALShAAQqUE5CgTrpHywBj2XxcVzkZ380WFORBRqCOjY1DZGSU7zKuJicZNC46OkY9HUdGia8mCRdRgAIUCFoBBuhBe+hYcApQoLkEuF8KUCD4BCIiIpCgt+za7Xb1uC5p8QW/fCIgo7UXFBTogXkkYmJifZJnXZnIhQAZ5EoGASwpKakrOddTgAIUCBoBBuhBc6jCr6CtugxHSqfLwq/irHG4C7D+FKCAnwSkZTcuLl61vEpg56fdhFW20mqem5ujurTHxycGrO6apqlB42QQupwc6Vpf+kSegBWAO6IABSjgJwEG6H6CZbYUoAAFjCnAUlEgvAWka7S08pa2+uaHN0YTay/3gWdnZ0EGb0tMTIKmaU3MsWGbS3Au4wtIb4js7EwOAtgwPqamAAUMKsAA3aAHhsWiAAUoEJQCLDQFgkBAukdLa3p+fh4kUA+CIhuuiDIyflZWpiqXBMkSLKsPAX6xWKxISEhSj12TQeMkWA9wEbg7ClCAAj4VMPk0N2ZGAR8KcBR3H2IyKwqEiACrQQFfCchI4BERkZDu2cXFRb7KNizykSBYgnO326W6mZvNlmatd2Rk6b3v0t2+oIC9Ipr1YHDnFKBAkwUYoDeZkBlQgAIUoECICLAaYSSgaRoSEkofByYtrxLchVH1m1RV8XI6HUjQ/Ww2W5Py8tXGctuCzRYBCdCLi4t9lS3zoQAFKBBwAQboASfnDilAAQpQIDwFWGujCWiaBumebbFYIC3CDofdaEU0XHnktoCSkmJ4bxMwSgE1TUOCfsFA7ocvHTTOYZSisRwUoAAFGiTAAL1BXEwcSAGO4h5Ibe6LAhQIegFWoFECmiZBegoksJMgXQY+a1RGYbBRUVGRaqH2dik3WpXlPvjExGQ1WJ0cS7lP3mhlZHkoQAEK1CXAAL0uIa6nAAUoQAEKUAChTCCBXVJSyr7ALkMNOBbK9W1M3ex2O3Jzs2G1WhHIx6k1tKzSGyIhIUmN6C4ju8v98g3Ng+kpQAEKNKeAqTl3zn1TgAIUoAAFKEABAM2OIC3oEqRLQJeVlaECvGYvlEEK4HI5IcGuGHlbqA1StGqLERERgbi4eDgcDkiX/GoTcSEFKEABgwowQDfogWGxAI7izrOAAhSgAAV8I1C/XKT1VYJ0l8sFBumlZtJNXLqLy6ekpGRIbwOZN/oUHR2DiIhIFBYW8FF6Rj9YLB8FKFBBgAF6BQ5+oAAFKEABClAgnAWkC7cEonIvurQaS4t6nR4hmkDqLgZywUJazs3N/Di1hjInJCRCLrrk5uborekcALChfkxPAQo0jwAD9OZx514pQAEKUIACFDCogDyuS4I76SKdnZ0FCVSbs6jNte/c3Gw9sHWoe85tBnmcWkMsNE2DXFjQNBOysrI4tkBD8Jg24ALy80YuDJaU2CFTwAvAHRpGgAG6YQ4FC1JZgKO4VxbhZwpQgAIUCJRAZGSUHpgmQJ6Pnqu3wAZqv82wn2p3WVCQj+LiYsTExCIqKqraNMGwUO6bT0pK0i+yuNV99OF6sSUYjlW4ljEnNxeb/9uGBQ8sx5hbZ2Lk+Km4694leHvth8jPLwxXlrCuNwP0sD78rDwFKEABClCAAjUJREVFq+d9FxcX6X8o59aULOSWl9Y3DxERkar+Tatg829ttdqQkJAIaZ3Myclu/gKxBBTYJ5BfUIAf1v+CW6bciXUbfkFGRhaK9Atjv/y+EY8++TyefPYlZGbxnN3HFTZvDNDD5lCzohSgAAUoQAEKNFSgtAU5GgX6H9Iy4FhDtw+29A6HHRLEyr34EtQavvz1LKD0iJCB40pKitXAcfXcjMko4FeB7dt346GVq2vcx/sff4GPP/tGD9pLakzDFaEnwAA99I5pyNSIo7iHzKFkRShAAQoEtYA8sktak/PyciGty0FdmVoKL4PBZWVlwmQyo/Teba2W1MG3KjY2DjabDXIcS0rqF/AEXy1Z4roESux2FBUV15XM7+ulHJ98/nWd+/nk868Aj6fOdEwQOgIM0EPnWLImFKAABShAAQr4QUDTND1gTdKDuwjVulyit8L6YTfNmqXcmy3BuRQiOTlFD9JD709ETZPjmAyz2awfR0MMGifcnAIg4HA4UagH5e99+DmWrnwSDy57HG+v/Qh79maguJku1jjsDvzz739wu9xwOV3qFgynywlUisW37diFiAhbAJS4C6MIhN5PX6PIshwUoAAFKEABCoSUQGJiEqTrd3Z2FqQreChVTurk0oMDaTmXADaU6la+LppWGqTLMrkgIRcmZD40J9ZKBPLzC/DHxr9xzfDxWLZqDT776jt8+8OPePTJ5zBqwlT8/MsfkIHaJK0a5rcqAAAQAElEQVQvJjmnZLwDu71Eb6kvREFBPmSgSTnfMjL2Ys+eXdi9eyekN478HHE4HZDA3O1y6cG5ROcy+aIkzCNYBRigB+uRC4NycxT3MDjIrCIFKECBIBLQtNLgTgJY+WPb4XAEUelrLqrccy7BRHx8IqQLeM0pQ2ONPBtd7q+XCxJyYUICqtCoWYBrESS7c7ndmDnvgRpLO//+pcjNK0B9zgO3npcE3yV6q3tRUSHy8/Mg3z9ZWRlITy8NviUAl0BcfkZIYC5p5IkIbrdL9d6Q8RDkdouo6Ch06niw+p6LiIiATZ8sFiug/5xBua8D27TiY9fKeYTDLAP0cDjKrCMFKEABClCAAj4RMJlMSEpK0f+G1iB/lMsf6xmZ2di+czdeeWMtNv71L3bvSQ+aP6hl4DtpySsdDC/KJ0bBkEnEvhHq5cKEtHAGQ5nDrYy+qG9+QSEeXf1cnVktX/WUHmwXQC66lZQUQ74vZKwCCb4zMyX43qNavffu3Q0JvrOzMyHBd4HeOi7nkAT3FosFpU9+iEdCQiLkVpHU1BZo2bI1WrRoiZSUNCQmJiM+PkE9vjAmOgYXnneW+lmCWr7OO/sMSN61JOGqEBNggB5iB5TVoQAFKEABClDAvwLSgp6cnAq73Ynf//gLI8bcjrG33oE1z72CybPuxuibp+GN/72PrOwc/xakibmX6K2AEoR4g9UmZhd0m8tFCam7BFklelAWdBVggesUMOmt0dt37CpN5wE8bg9cLhecTqcKxh12O+wldmze/B88HjcyM9ORnZ2lBhKUIN2ur9e3Ure2xMTEQAaMTEhI0oPvVKSltVDBd1paS/U5MTFJrZd00kouj/eTnxWlO6/+NS01GWNGXlf9Sn1pj3POxOknd9X3b9E/8X+4CDBAD5cjHYT15CjuQXjQWGQKUIACYSIgLeklDhemzFqg/6Fvl7/hK9T8mRdexzvvfoQS9Qd+hVWG+CAt/xKIyD31ElgYolDNUIgEvaVTWiezs7NV0NYMReAu/SDgdrtQol+Ays3Lw85de/SLaXb9e7EEdoddHWcJ0j0yMroewMv3cr7e0l5YVKK3cCfpLd2pevDdcl/w3UIF3wl6UB4bGw95VF9kZKQeMFthMplrKXn9VsXEROOYIzthwezJ6NrlWKSmJCM6Kkpfdjiu6X8F+vW5BElJCfXLjKlCRoABesgcSlaEAhSgAAUoQIFACWTprePTZt8Li9UGt/6HvkP/w7/y6Msvvf4/vYX970AVqcp+JACRcqru92+uxa+/b4SMWl1YVKy655tMJj0gSa6yXTgt0DRNGehvykTuMQ6n+odCXZ1OJ4qKilSrt9x2IveA7927R28Jz4TZpOHQg9upbuQWs0UF1jabDeqeb/3darXq38MWHNyhPWJjY/TlkbBYJPgOXIiUkpyEtm3bYNSwQbj/7ul46L45mHDTUFxw7hlISIiv/hBxaUgLBO7sC2lGVo4CFKAABShAgXASMOnBrd3h0FvRNPVHvwrSnVUHjZPgWALlQNtIi+CWrdsxYszk0u73z76CGXPvw6jxU7Hm2Zfgcnn0lsFkvfz8U9BsNkPuDZbgPCcnq8KhkuNcYQE/1Cogrdab/v0Pr731Ht7634f4d/N/KC4uqXWb+q6U7yPpci5dz+XecLkXXEZDl/fc3Gx137ikkRZu6YqenJyit4an4MQTjlPfo2aLWZ3vmqZV2eWxxxyhB+cRVZYHaoFNv1CQmBiPCP2iQVRkBBLi41VLOprpi7ttXgFT8+6ee6dAzQIcxb1mG66hAAUoQIHmFVi/4ZeyAkgQZ7VYIAGeBCjlpx/Wb8CePbtV66wEf3l5OeqxSxJkyOBsdnsJnHpgL11yyzL0wUxuXj5umXIn3B53hdzkkU6vv/0+nnv5bZSUOCqsC+cP0qoqQZ0EgGrU7ZLSrtDynOqMzBzIsZVnaYezUW11F7et23Zg2I234dbpd2H1My9h1ZrnMXHaXRg5fgq2bd8JSVNbHuXXuVxOPbAvhhwLGQ1dBmfbs2eX+j6ScRPk+8ZkMqvB1hISEvVAPE11SZexIeRpBNIVXe4BN+kX0s4+81R07XJM+ewrzLc9sA0G9LkEVj2Ar7CCH/wlwHzrEGCAXgcQV1OAAhSgAAUoQIHKAscefUSFRSazGTarTf8j3wqLxQLpTmvWlx11RCc9iIjRAzwPHHqLu3TFlaBDggxpBZTgIyMjHdIlV1oDZZJgRFoFpbuuN6iXbaoL6qXFEJW+snNyMX32vZWWQr8Q4NTL4VZl/PTLb7F+w69V0oTzAgnqbLYI3ciDGXcuRL8hN2HyzAWQXgd9B4/GS6+9jcys7HAmqrHuHg8w/vbZKCourpImL78A426bpVqvq6yE9/uiUI2KLoO0yfeAPLJMzv2Cgny4XC7Y9JZleTRZUlKyuj9cBmaTeVkWGRmlvueq5l26JDYmGoP69cZF55+FyIiI0oX6q3yfntatK2ZNmQDp8q4v4v+QEAj+SjBAD/5jyBpQgAIUoAAFKBBoAT0gkda58rvVTBpMZhMkMDfrrXESALRp3QoSRKSkpEIeudSiRSvIY5ckwEhJSYN0w01MTFKPXpJ03iBR8pDg2xvUS6BSXVAvrYoS0HiD+uzsTP3igAnpmZlwOZ2Q4MbtcsPldEHmLWazKiP0r/+271DL9Fn+3ycgx2LQ9ePx2x8b4XHrB3nfcnl74dW38ZjeKiy9E+Qzp1KBwsJCLFy8svRDLa/3LXkEhUVFqgdJdnYW0tP3YPfuXZCgPDc3R28xL9K31tRAbPIoMmkNl++V1NQ0JCQk6Re6YvVAPQImvVVcT9ig/9JK3ueyi/DE8vvwyJK71X3ez6x6EIMHXIGE+LgG5cXEYS4QgOqbArAP7oICjRLYtX4lMja+1qhtuREFKEABClDAnwJRUZGYOGZErbs48fjjcESnQ6tNI0GGBPDSDTciIlI9P1ke+yXdrBMSEpGYmKwH7xWDenmWsgQrErgkqqA+UQ/+41XgInmYzRZomgk//PgzJCh36i2PTj1Il27tTpcTsk+z3rrvLdAfG/9BXl6B92PYv0vgfcdd90OOiQZN9XiANA2Xk/nym3X45LOv9cUVg/dyScJuVjOZsWv33gr1losb6hyU88/hgL2kBP9t3Y5iPUCX3iBy4UnOfznn5Vz2XrySC1byPSDPE5cB3Cpk2sQPSYkJsOgXzuS9VYs09f2QmprcxFy5OQV8KyC5MUAXBU4UoAAFKEABClCgAQLR0VFoe2BrjL7+mmq3OrXbCbj26j56oO27UZg1TVrnLXoAaUWECuqj9OA8Rg/S41QLvAQ6EtyfeEJn2CJKR6qOsEVAugd7u9+XL2zHg9sjLi6m/KKwno+KjFRBJDQoYw88cOoXOSqj/LtlK4z6+LzKZfX3Z+nlkZ2dg/+2bYfT4YTDboeMwWB32CEXhqTXhn41AyazGTt27dGXuSC9SNLSWujfG8nq3JVz2ayv93dZmT8FgkXA5L+CMmcKUIACFKAABSgQugJtWrfEqSd3xfzZt2PqxJtw4XndMW7UUMyacjNuuO5qtG7VolkqX1xUsn8EaD3Y1DQNmkmDBJ4o9yXlY2C0H2SnHkDK/dKyRLysFqseW3r0oNIBafGV3ghyq8Bvf/6NoqKq91rLdqE8SbBdUlKsBm7Lzs6E3FYht1hYLCa0PaA13G4XoGmQ2yjETi4Kyb3dVptNb7m24LCOB6sLSpqmn4vgFwUoUJNA8AboNdWIy0NGgKO4h8yhZEUoQAEKhKyAPBJJWqKP73w0hg8ZgDNPOwlHH9lJbxlsvpbp6Jgo3H7zqFrNjz6iE6TMtSYKs5XSI8Kk7f/T2GQ2QS5gaJoeUHo86n59p8uJlmnJesBuh9z7L/dRS7Aq3baLigrVcmlV9ied3eHQW6nt2Pj3v9i2fRecTpe+X6dPdykXJKQ+Mu6B3CMugXhpXbPUPeSyT+mZIeMmWPQLGR3atYUtIkL1PDBbLBA7TS4KlStV65Yt9UDdXG4JZylAgeoE9v8Uqm5tGC9j1SlAAQpQgAIUoEAwCkTqgVJqShJuHXdDtcWXR06NHDYISYkJ1a4P14XZ2blo07pFheqbTCbIiPxWmw3SGhyhvx90YBvExsSowczMZoseIDtV0CoDnWVmZkCCWZkyM9ORm5ut1knLs0sP7tGELwn8S0rsmD1vEa4eNhaTZ96NcbfNRL8hN2LFY8+goLCwwbnL4+Ps9hJVRhk1PT19r7rwUFr2HEiQDmiIiopSt1GkpKSi8sBtSfp5NGbkEMgtAqjhSwZiGzF0QIVR1GtIysUUCHsBBujNcwpwrxSgAAUoQAEKUMBvAi1bpKHLcUfhvrumY/pt49Dr4vNU9/s5027BjSOubbbu936rsA8yjo+PxZiR19Wak7QaDxl0lR6cR0MGM5NHfckAZxK0pqSkQcYBkFbliIhIlU9xsbdLeBa8wW96+h5kZ2dCWqclAHY47PB43Cp9XS8ywvzvG/+ukuzDT7/AtDkLUVhL13un06lGSpf9yuP9pIu6TDIvPQAcesu8RW/9jomJhdRD6iX3i5cO3JaAqKhovQXcWmXfskC2e+i+2eh0aAf5WGE68vCOuH/+DMjFjQor+IECFKhWgAF6tSzBvjA0ys9R3EPjOLIWFKAABSjQPAISELU76AB0PuYIDLn6StX9XoKl+LjY5imQwfcq3dlbpCZjyi03VVvSxPh4zJ05CZqmVbtegtQIPTCXAFcG60tOTt03IFpLSJAbH5+gB/YxepBb2upeWFigt7DnIFO1uu9WLe+ZNbS6FxQW4Z5FK+CuJZCXUdJfef1/eou+Cw496C/NPxsZGemqVTwjYy9ycrIhy6XlXHoEyEUGKZsE4qmpLSCBufcCg3hUW9FqFmqahgTdZ8rEm/DY0nsx7dYxmHH7ODy+bCFumzBSXxdXo1s12XERBcJagAF6WB/+Rlaem1GAAhSgAAUoQIEQFIiPj8Nx+gWNBxfMxI3DB+OMU09Er4vPxa1jb8CyRXNxcLu2kG7vDam6pJdHt0kLtATEiYnJkGBYWt3lsXnyWYLiyMhIPVtNb+Uu2TcQ2/5Wd6cecP/19ya49FZwt8sFj9sDyH+PBxJsy3KH3gK+8e9/kJmVgUw96JeWcmnBN5k0NThbQkIipJVf9puSkor4+ER1wUDKpmnVX3TQC9Sg/3GxMZALQNJ747ijj4B8ltsBGpQJE1MgzAUYoIf5CWDE6rNMFKAABShAAQpQoLkELBYzDmjTCud0PxVDBvZFvz6X4OSTuqgB0HxdJrmHXVqyY2JiVcBc2prdUrW8Swu8BNUSvGfn5GL3nr1w6sG5Qw/S7XrAXmIvgd1u11vLHWo59GD9703/6W8apOt9WlppPklJKYiNjUdkZJRqvfd1HZgfBSjgWwEG6L71ZG4+FPDTKO4+LCGzogAFKEABClAglAVioiNhs1Z/37U/661pmrogIEG1BO+tWrZEPwv09wAAEABJREFUWmoqJJiX++CtepmkS73VYtHLZ1PLrTYbDu5wkN5aHg2bLaLBLf3+rA/zpgAF6i/AAL3+VkxJgXoIMAkFKEABClCAAhTwrYCM3t6qVZrKVNM0FXzLPeImsxmaaX/39JZpqTCbLeAXBSgQvAIM0IP32LHk4SjAOlOAAhSgAAUoEHYCsbHRuPnG6+us9003XIuoyIg60zEBBShgXAEG6MY9NmFfMo7iHvhTgHukAAUoQAEKUMB4AjLQXIQeeN91x63VFk5GmL937lTIo9SqTcCFFKBA0AgwQA+aQ8WCUiDoBVgBClCAAhSgAAUaKRAbE41DD26Pxx6+B5PG34CLzj8LfS69CFNvHYPFC2ej/UEHchC4RtpyMwoYSYABupGOBstCAQo0QYCbUoACFKAABUJbQO47l0fBdevaRY0uf3mvC3D8cUchOioSmrb/XvTQVmDtKBDaAgzQQ/v4BnXtOIp7UB++0Cs8a0QBClCAAhQwkEBcbKwemEcZqEQsCgUo4AsBBui+UGQeFKAABZoowM0pQAEKUIACFKAABSjAAJ3nAAUoQIHQF2ANKUABClCAAhSgAAWCQIABehAcpHAtIkdxD9cjz3oHnwBLTAEKUIACFKAABSjgCwEG6L5QZB4UoAAFKOA/AeZMAQpQgAIUoAAFwkSAAXqYHGhWkwIUoAAFqhfgUgpQgAIUoAAFKGAUAQboRjkSLEcVAY7iXoWECyhAgeATYIkpQAEKUIACFKBAvQUYoNebigkpQAEKUIACRhNgeShAAQpQgAIUCCUBBuihdDRZFwpQgAIUoIAvBZgXBShAAQpQgAIBFWCAHlBu7qwhAhzFvSFaTEsBClAg+ARYYgpQgAIUoAAFKgowQK/owU8UoAAFKEABCoSGAGtBAQpQgAIUCDoBBuhBd8hYYApQgAIUoAAFml+AJaAABShAAQr4XoABuu9NmaOPBDiKu48gmQ0FKEABCgSfAEtMAQpQgAJhKcAAPSwPOytNAQpQgAIUoEA4C7DuFKAABShgTAEG6MY8LiwVBShAAQpQgAIUCFYBlpsCFKAABRopwAC9kXDczP8CHMXd/8bcAwUoQAEKUCD4BFhiClCAAqErwAA9dI8ta0YBClCAAhSgAAUo0FABpqcABSjQjAIM0JsRn7umAAUoQAEKUIACFAgvAdaWAhSgQG0CDNBr06nHOofDjrqmO+6YgRNOOL7OdHXlE27rU46+FvEdLqJbPc6x8ucG4IGmgW4NdCtvyPm6f655jVwuJywWC883nm8BOwesViucTkfA9uc91/le/58LoWRlMpng8XiC6XxjWYP457HH44bJpAX9MaxHCMUktQgwQK8Fh6soQAEKUIACFKAABShAAa8A3ylAAX8LMED3tzDzpwAFKEABClCAAhSgAAXqFmAKClAADND9eBI4XS7MvW8lhtw4DSMmzMK2Hbv8uDdmHY4C63/6HbfPfgDn9R6O68fNxCdf/lDGsOGXPzHkpum4ZtQUPPLkS2XLOUMBXwjIz7Xh42eVZZWekYWbJt2FoWNmYMqcRSgqLi5bxxkKNFZAfo8ufGg1Luo7CqdeeA2effl/KitZzt+vioIvPhSQn2MTZ9yLgSNux7Cxd+D9T74uy/35V9di0MjJGDxqKj79al3Zcs4El0Bzl3bDr3+qmOC0iwZXOL+gf9X0d5ucl/z9qgOF0X8G6H482G/872NkZmXj8YfuxJWXno/5D6zy496YdTgKREdFYuJNQ7D2peW4tv+lmLtwhWLweDyYMe8hTBozBI8tmYMPP/sWEsyrlXyhQBMFXn37Q7RIS1ZjHXizWrT8KZzc9TisWjwb8fFxeOqFt72r+E6BRgusfvYN/PrH33jonmn49M3HcPrJXVRe/P2qGPjiY4FnXnobbQ9ohTXL5+GWGwerRhbZxZatOyHn4vL7ZmDBzAnqd21xiV1WcaJAeYE65yMjInDDtVfirNO6Vkhb299t/P1agSosPjBA9+Nh/uLr9bj4/DPUHs45sxt+/fMfFBQWqc98oYAvBA7r2AGpyYkwm0zqD1eHw6FaLv/8ezOio6Nw5GGHwGI244KzT8VnX/OKvy/Mwz2P3Lx8vP7Ox7i6z8UVKL745kf0vKD0511P/efe59+sr7CeHyjQGIF33v8ME0Zdg4PbH6AGIzywTUuVDX+/Kga++FjA5XbrFx41NcngcK1apKo9fK7//uyuB1Qx+u/VVi1Tcbj+u/e7db+AXxRoqMBhh7bHCZ2Pgpxf5bet7e+2/b9fAf5+La8WuvMM0P14bPdmZOGA1qV/TEiQJD/o9+zN9OMemXU4C7zy5gc49OB2iIqMxG79PDugVVoZR9sDWmL3noyyz5yhQGMFFi1/GuNGDlR/XHg8pbnIhUd5ckBSYrxaIOfb3nT+rFMYfGm0gFsPluR35itvfYBzL78eN902D/9tK71VjL9fG83KDWsR6NPrfLz74Vc4pccg3DBhNm4be51KvTcjE23K/U6VC0V70vk7VeHwxScCNf3dFtDfrz6pCTPxhQADdF8o1pKHpmlla03l5ssWcoYCPhD46deNeOrFtzHj1hvKctNM+889cLiJMhfONF7g1z/+URsfd9Rh6r38S/nWAE3jr5byNpxvvIDd4cAh7dvi9acX48JzTsW8Bx4py0zTtLJ5U7n5soWcoUADBeRWsMsuPgvvvbwCi++ejLvuXwmn06ly0Uz7f65p2v5zT63kCwV8IKCZyp9X+8+3UPn96gOisMli/9EPmyoHrqJpKUnIzMop22Fmdq66b7NsAWco4AOBvXpL5ZJHnsGSBZPVvXOSZcu0ZGRl58msmjKzstGyRYqa5wsFGivw6Zff4+33Pi1tXbp5Nn75/S9cO3oqpNuny+WGBFOSd4Z+vqWlJsssJwo0WkD+KJVbeM489QR1jp19xkn4e9N/Kj/+flUMfPGxwCtvfYjTTz4esTHROPaoTir3XXsykJaSjOzscn/P6T/jWqTyd6oC4otPBGr6u42/X+vNG1IJGaD78XCe2q0z3v/kG7WHb374GQe3O0D9kaEW8IUCPhCQkT2nzl2MKROGo3XL/V3a5R4nWbd1+y7IPXUf6Oeh/NHhg10yizAWGDW0H75au0ZNMljS0Ud0xBMPz1Uip56k/7z7+Cs1/+5HX+J0/eef+sAXCjRB4DQ9WPpufem9vt+u+wUdD2mncuPvV8XAFx8LpCQn4NsfSs+3zf/tQFFRCVrpF7fl96eM41Jit6uGl9/+3IRuXY/x8d6ZXTgL1PZ3G3+/GuHMCGwZGKD70fvSi86GyaSpx6w9uuZl3DZumB/3xqzDUeCF197Fz7/9hQHDJ6lWTblvbteedGiahlm3j8b0u5ao8++ELkfi+GOPCEci1jlAAuNHDsQbaz9Vj1n7b+tODOzbM0B75m5CWWDUdVfh0y/XQR4Z+areujllwvWquvz9qhj44mOBEdf2xYtvvIerht6COxcux6zJN6rBCdu1bY3ePc9Vj14bP2UBJoweDJvV6uO9M7twEPj6+w3q77X3P/la/Y0mj8mVemtazX+38ferCIX4VKl6pkqf+dGHAjIw3NSbh0Mes7bi/jtw0IGtfJg7s6IAUL5F09uyKYMRis1xRx+mzr0nl96F4df0kUWcKOAzAen+ufKBO8ryS01JwtJ7p6nHrN01fZwarLBsJWco0EiBhPhYPHDXJDy+ZA4WzbsNMjiXZMXfr6LAydcCnQ5phzeeXoznVy3EI4tmVbiwfdXlPbBm2TysXjoX3U89wde7Zn5hIiCPI/X+vSbv77+ysqzmNf3dxt+vZURhM+PrAD1s4FhRClCAAhSgAAUoQAEKUIACFKCALwWCLED3ZdWZFwUoQAEKUIACFKAABShAAQpQwDgCDNDLHwvOU4ACFKAABShAAQpQgAIUoAAFmkmAAXoA4bkrClCAAhSgAAUoQAEKUIACFKBATQIM0GuSCb7lLDEFKEABClCAAhSgAAUoQAEKBLEAA/QgPniBLTr3RgEKUIACFKAABShAAQpQgAL+FGCA7k9d5l1/AaakAAUoQAEKUIACFKAABSgQ5gIM0MP8BAiX6rOeFKAABShAAQpQgAIUoAAFjC7AAN3oR4jlCwYBlpECFKAABShAAQpQgAIUoECTBRigN5mQGVDA3wLMnwIUoAAFKEABClCAAhQIBwEG6OFwlFlHCtQmwHUUoAAFKEABClCAAhSggCEEGKAb4jCwEBQIXQHWjAIUoAAFKEABClCAAhSonwAD9Po5MRUFKGBMAZaKAhSgAAUoQAEKUIACISPAAD1kDiUrQgEK+F6AOVKAAhSgAAUoQAEKUCBwAgzQA2fNPVGAAhSoKMBPFKAABShAAQpQgAIUKCfAAL0cBmcpQAEKhJIA60IBClCAAhSgAAUoEFwCDNCD63ixtBSgAAWMIsByUIACFKAABShAAQr4WIABuo9BmR0FKEABCvhCgHlQgAIUoAAFKECB8BNggB5+x5w1pgAFKEABClCAAhSgAAUoQAEDCjBAN+BBYZEoQAEKUCC4BVh6ClCAAhSgAAUo0BgBBuiNUeM2FKAABShAgeYT4J4pQAEKUIACFAhRAQboIXpgWS0KUIACFKBA4wS4FQUoQAEKUIACzSXAAL255LlfClCAAhSgQDgKsM4UoAAFKEABCtQowAC9RhquoAAFKECB5hL44psfcUqPQdVOK554od7FOvOSISix2+tMX990dWbUDAnEqb67/fm3vzD1zgdrTf7d+l8w8pY5taZpyEpf5/fTrxsxdMyMGovgXbFz91689vaH3o9wuly4esRtyM7NK1vGGQpQgAIUoIDRBBigG+2IsDwUoAAFKIDTunXGV2vXqGnM8KtxzhknqXlZNuLavvUWuv/OW2G1WOpMX990dWZk8ARLHnkGg666xOClrL14B7c/ELeOGVJ7In3trt3pePPdz/S50v8WsxmXX3wO1jz/ZumCxr1yKwpQgAIUoIBfBRig+5WXmVOAAhSggC8FpDV2yE3Tcfus+3HTbfPw/Y+/4tmX/4eLrhqtWkfHT7kbW7fvKtvlhGn3wOF0qs/S0rz88Rcw8uY5GD5+Fn78+Q+1XF7qm+6d9z/HgOtvhbQwL131HE67aLBsXmUqKi7GwodWY8Dw2zBwxO2QwNjtdqt0su3di1ZhjF7+K4fcjIcffVYtl5dNW7Zh3OS7MeTGaaqV+POv18tiNUndpezX6fU//4oRKL9O6iV1kn2Vr5facN+LuKRnZOOITgfvWwK89MZ7uHb0VAweNRU9rhyJzKwcta64xI4pcxapcojznvRMtVxenn91La4ZNUVNkiYjK1sWQ+p8z+LHMeiGyeg3bCKkrGpFuZf0zGxI+d9c+4laKsdk8YqnMGLCLAzQXd/7+Cu1XF4++eJ7XD/uDsjxFpN/t2yXxdi0eRtkP/JBTGS9lOOGm2djwtR74C3rQ7rrps1bId533feIJMd53U/GW+WCdkkIu6oAAAuvSURBVLXQUC8sDAUoQAEKhLsAA/RwPwNYfwpQgAJBJvDXP1sw8rp+WHL3ZHTtfBROOv4YvPH0g3h6xd244JxTMe+BR2usUYd2B2DZfdMx/45xmL+oYel27UnH3XpgfefUsVi2cDpc+wLu6nb2yJMvw+VyYfXDc/H4Q3di954MPP/qu2VJJQBeNO82PL3ybvz061/46PPv1Lrpc5egW9dj1TbjbhiI6fOWICs7FxIET5p5P67p3wuPLZmDFx+/D4d36qC2kRep18oH7sBt44bWWK91G37D0UccKsnV9MW3P+Lxp1/D3GljsXrpXDz64EzExkardVu27sCIIVepcpxw3JFY9dSrarlss/bDL7FYt39y6V3ofMzhWKCbyEqp85ZtO7Fy0R147tF7MWnsUFkMTdPUtFE/bqMnzsGooVfhkh7d1Tp5ade2DVbcfwcenD8Z9+kXNaSu6RlZmLlgKW4ePRiP6/WV/cy+Z5kkrzJ5y7r8vhm46LzTysp647D+OLh9W3Wsptx8vdouOSkBcbFR+EcP3NWCcHthfSlAAQpQwPACJsOXkAWkAAUoQAEKlBPodEg7tD+oTdkSk9mER9a8rFqeX3/nY2z8e3PZusoz53Y/WS1KSUrEzl3p6r5ktaDSS3Xpfvn9bxx/3OE4pENblXpAn4vUe3Uv33z/MyT9mNvnQaa/Nm3RA/E/y5J2P7UrTCYTbFYrTu3WWW/N/x05ufnYumMXrrr8ApXuuKMPg9T1Z32/G37ZiMM7dsBpJ3VW6xLiY5GanKjm5eWs00+UNxx7VCds37m32nrt2LUXLdOSVTp5+fq7n3DpRWfhwDYt5aP+3kqVRz4c3O5AtG/bWmZxwnFH6K3WW9W8bJOdk4fbZz2gWqbf/ehL/PTb32qd1HnIgEsRFRmpPh/c/gD17vF4sG37LnV85k0fry6oqBX7Xs45s5uaS0tN1i86HIyff/0bG/SLFkcdfiiOPOwQtW5g34vx59+bUVBYpD6Xfzm0w0HwlrV1y7SyspZPU36+ZVoqtm7bXX4R530kwGwoQAEKUKDpAgzQm27IHChAAQpQIIACERG2Cnu7eeoCPZBtj5m3jcKCmRNQVFxSYX35D2bT/l97EthLK3f59d55s6n6dJZy97PXem+7Btxy42DVeiut7c8+cg/umj7Om3217x54YDaZIPdKY9+X7EMCXPkowby8VzeVX2exmFXrfeV0VqulrLu/d53FYvXOVniXtN4FZrMZTqdLfdQ0D3qef0ZZvR5ZNAvvPP+wWicvNv2Cg7yXnzRNQ8sWKThUv7Dx5ruflF9V87we1FvM+4+BOJj0fKrbwFwunUn385a1urSyzO5wwGqzyCyn4BJgaSlAAQqEhcD+335hUV1WkgIUoAAFQkmgqLgYWTm5OP3kLkhKjMf7n3ztt+odc2RH/P7nprJW3M+/XlfjvqSle/kTLyIvv0ClkW7b0gKsPugvr7z1gR70OpGbl4933v8MXY45EonxcWjTqoW6Lxz618+//QXpFn6svt/jju6ktyD/i6++26CvKf3vzbv0U92vh3Zoh2079rccn3zisZB7wb3LJHCVqbacTtVb8F95+0PIvfKSTtKv++l3mUW3rsfg8Wde1S+QFKvP+QWF6l1erHrgfv/cW/H3pq1l94/LcplkDAF5//Ovf/HzbxtxzFGHQur76x//4A99max75qV30OnQ9oiJjpKP9ZpiY6N137wqaf/buhNHdjq4ynIuCHcB1p8CFKCAMQQYoBvjOLAUFKAABSjQCAHpTj3wyp4YcP1tqgt1RmZ2I3Kp3yYt01Iwelh/TJ69SA1QJ4GtdDWvbuvrBvbG4R3bQwZKGzRyMoaMnoas7NIB2CR9m1ZpGDx6qhoI7oyTj8dZp3eVxZgz9SZ8+uU6NZDa/UufxIxbR6oLD9Ilf/bkG/HEM69DBpA7q9dQrNtQGhirDevxIiPjb/5vR9m983IRoV/vHpgy50HIoG/n9x6B/Pz9QXV1WZ7c9TgMG9Qbs+9ZrsrRs9+N+PnXv1TS66+5Age0boVhY+9Qg8SNmninWi49AGSyWCyQIF262s+9b6VaJy+FRUVqgL+Zdz+s7qGXuqamJGHaLSMgg8HJoHLf/PAzpk+8QZLXezq4fVt0Pvpw3DxtAe7aN0ic1P+Qgw9SpvXOiAkp4AsB5kEBClCgngKmeqZjMgpQgAIUoECzCFx95cVqIDPZ+Yldjlbdq2XeO0lg+NIT90EGXRs++Ep88c5q7yp8+ubjiLCVdomXR7SVrdBnPnrt0bJ19U13xinH48H5t6sB6lq1TFP3fOtZVfkfGWHD2BED8dSK+VizbB7eeGYJJLj1JjznzJMgg9rJYG8S9HuXy73fUg8ZCG7V4tmqZ4B3nQyGt+y+6ZBB5z5+YxW6n1Ya1NdWL++28m61WnBu9276BYAf5KOarrq8hxogTgZ8++TNxyCDqFU2PurwQyBlURvoL/KoMhm4Tcrx3ssrcO2AS/WlUPeeS7d+qZcMEid5yory+XmD9Kk3D5dVahIn2eaZR+7B+WedopbJi9Tv0QdnqUHxxKRDuwNksTL3lqd83rKyfFnNJhMmT7ge9905Cd5B4t5Y+zH6975QknKiQEgJsDIUoEDoCJhCpyqsCQUoQAEKUMC/Avc9vBrySDd5fJp0cR8/cpB/d+jj3Af3u7Ss272PszZ8djLqfmpyUoWLHoYvNAtIAWMIsBQUoEAABRigBxCbu6IABShAgeAWkC7nMijaMyvvxoKZN6NVi9QGV0gGjZOW3wZv6IMNoqMicemFZ/kgJ99kUbn13ze5Vp+L2WRCbSPvV78Vl1KAAv4X4B4oQIHyAgzQy2twngIUoAAFKEABClCAAhQIHQHWhAJBJsAAPcgOGItLAQpQgAIUoAAFKEABChhDgKWggK8FGKD7WpT5UYACFKAABShAAQpQgAIUaLoAcwhDAQboYXjQWWUKUIACFKAABShAAQpQINwFWH8jCjBAN+JRYZkoQAEKUIACFKAABShAAQoEswDL3igBBuiNYuNGFKAABShAAQpQgAIUoAAFKNBcAqG6XwbooXpkWS8KUIACFKAABShAAQpQgAIUaIxAs23DAL3Z6LljClCAAhSgAAUoQAEKUIACFAg/gZprzAC9ZhuuoQAFKEABClCAAhSgwP/Zs5MchGEYCqAR9z80iy4qIYrakMnO26BSMtjPqy8IECBAYJiAgD6M2kUECBAgQIAAAQIEPgV8J0CAwCkgoJ8WnggQIECAAAECBAjkEtANAQKhBAT0UONSLAECBAgQIECAAIF1BFRCgEBbAQG9rafTCBAgQIAAAQIECBBoI+AUAtsJCOjbjVzDBAgQIECAAAECBAiUwoDAegIC+nozUREBAgQIECBAgAABAtEF1E+gQkBAr0CzhQABAgQIECBAgAABAjMF3J1TQEDPOVddESBAgAABAgQIECBAoFbAvkkCAvokeNcSIECAAAECBAgQIEBgTwFdXwkI6Fcy3hMgQIAAAQIECBAgQIBAPIHAFQvogYendAIECBAgQIAAAQIECBAYK9DzNgG9p66zCRAgQIAAAQIECBAgQIDATYFXKTdXWkaAAAECBAgQIECAAAECBAh0E+j/D3q30h1MgAABAgQIECBAgAABAgTyCIQP6HlGoRMCBAgQIECAAAECBAgQ2FlAQP89fb8SIECAAAECBAgQIECAAIEhAgL6EOarS7wnQIAAAQIECBAgQIAAAQKHgIB+OOT81BUBAgQIECBAgAABAgQIhBEQ0MOMar1CVUSAAAECBAgQIECAAAEC7QQE9HaWTmor4DQCBAgQIECAAAECBAhsJSCgbzVuzZ4CnggQIECAAAECBAgQILCWgIC+1jxUk0VAHwQIECBAgAABAgQIEHgoIKA/BLOcwAoCaiBAgAABAgQIECBAIJ+AgJ5vpjoi8K+A/QQIECBAgAABAgQITBAQ0Cegu5LA3gK6J0CAAAECBAgQIEDgm8AbAAD//xXSEJIAAAAGSURBVAMAFpCJsvEtKn8AAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_epochs = checkpoints[\"checkpoint_value\"].cast(pl.Int64).to_list()\n",
     "_ics = checkpoints[\"ic_mean_daily\"].to_list()\n",
@@ -633,13 +8061,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21148193",
+   "id": "e4316d28",
    "metadata": {
     "papermill": {
-     "duration": 0.016162,
-     "end_time": "2026-09-06T22:57:38.280469+00:00",
+     "duration": 0.018815,
+     "end_time": "2026-09-08T21:58:16.518808+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:57:38.264307+00:00",
+     "start_time": "2026-09-08T21:58:16.499993+00:00",
      "status": "completed"
     }
    },
@@ -660,10 +8088,178 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ed521fa6",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 12,
+   "id": "a5a37999",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:58:16.556266Z",
+     "iopub.status.busy": "2026-09-08T21:58:16.556013Z",
+     "iopub.status.idle": "2026-09-08T21:58:18.474955Z",
+     "shell.execute_reply": "2026-09-08T21:58:18.474270Z"
+    },
+    "papermill": {
+     "duration": 1.935718,
+     "end_time": "2026-09-08T21:58:18.475511+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:58:16.539793+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Common sample: 187,647 rows on 1,995 dates\n",
+      "  GBM (Ch12): IC=+0.0545 on the shared rows\n",
+      "  Ridge (Ch11): IC=+0.0432 on the shared rows\n",
+      "  TSMixer (tsmixer): IC=+0.0352 on the shared rows\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "cliponaxis": false,
+         "marker": {
+          "color": [
+           "#1a2d4a",
+           "#C87533",
+           "#0a1628"
+          ],
+          "line": {
+           "color": "#D4A84B",
+           "width": [
+            0,
+            0,
+            3
+           ]
+          }
+         },
+         "showlegend": false,
+         "text": [
+          "+0.0432",
+          "+0.0545",
+          "+0.0352"
+         ],
+         "textposition": "outside",
+         "type": "bar",
+         "x": [
+          "Ridge (Ch11)",
+          "GBM (Ch12)",
+          "TSMixer (tsmixer)"
+         ],
+         "y": [
+          0.04322186623955541,
+          0.05454751133190255,
+          0.035161348623161066
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "margin": {
+         "t": 70
+        },
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 15
+         },
+         "text": "Peak-checkpoint IC by family, measured on the same validation dates"
+        },
+        "width": 1000,
+        "xaxis": {
+         "title": {
+          "text": "Model (validation leader per family)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Peak-checkpoint cross-sectional IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+gAAAH0CAYAAACuKActAAAQAElEQVR4AezdCaAN1R/A8d99dkp2siRbqVSSImtZEhISsoTsZN/3fd+yZU8REYVSRCpbKCUppcTfln15dp7tP7/Dve7b7/Peu+/OvV915p6ZOXPmnM/M3Hd/M3PnBoWEXL1FwoB9gH2AfYB9gH2AfYB9gH2AfYB9gH2AfYB9IGH3gSCJ139UjgACCCCAAAIIIIAAAggggAACngjYO0D3pIeUQQABBBBAAAEEEEAAAQQQQMAGAgToUWwkZiGAAAIIIIAAAggggAACCCDgLQECdG9Jh18PUxBAAAEEEEAAAQQQQAABBBBwCRCguyj8LUN/EEAAAQQQQAABBBBAAAEE7CRAgG6nreVLbaUtCCCAAAIIIIAAAggggAACcSpAgB6nnFQWVwLUgwACCCCAAAIIIIAAAggEmgABeqBtcfqrAiQEEEAAAQQQQAABBBBAwOcECNB9bpPQIPsL0AMEEEAAAQQQQAABBBBAIOYCBOgxN2MJBBJWgLUjgAACCCCAAAIIIICAXwoQoPvlZqVTCNy7AEsigAACCCCAAAIIIIBAwggQoCeMO2tFIFAF6DcCCCCAAAIIIIAAAghEIkCAHgkMkxFAwI4CtBkBBBBAAAEEEEAAAfsKEKDbd9vRcgQQ8LYA60MAAQQQQAABBBBAIB4FCNDjEZeqEUAAgZgIUBYBBBBAAAEEEEAgsAUI0AN7+9N7BBAIHAF6igACCCCAAAIIIODjAgToPr6BaB4CCCBgDwFaiQACCCCAAAIIIBBbAQL02AqyPAIIIIBA/AuwBgQQQAABBBBAIAAECNADYCPTRQQQQACBqAWYiwACCCCAAAII+IIAAbovbAXagAACCCDgzwL0DQEEEEAAAQQQ8EiAAN0jJgohgAACCCDgqwK0CwEEEEAAAQT8RYAA3V+2JP1AAAEEEEAgPgSoEwEEEEAAAQS8JkCA7jVqVoRA3AlcuXJV0mR/2pWy5H1eyr32lsxf9HncreROTXv+t9+sZ+svv92ZEncvTxerJOOnfBB3FUZRkzfX1aX3cKlSq2kUrYl41owPFsiGTVsjnhlmqm7/92Z8FGrqrVu35OPFX0ijll3l8edelkeeKSMVX39bRoybKucvXAxV1n2kVYe+8majtu6T4jT/2ecrpfIbTSRznufkpcp147TuiCpb8sXXZp+9fv26mX3sxEkzvm7jj2acgXcEGrboLM3b9Yp2ZfFV4I+//pGR704PV/1HC5fKg/mKhJvOhNgLLF2+yhxrzpqOHj9hxtdu2OKcFOHrtPc/Nu9ZEc6MZOK58xfM9t1/4L9QJcIe/6Fmemlkx85dpt9/7/6fx2uMrD8eV0BBBBDwG4Egv+kJHUEgAAWaNaojyxfNktnvjZIM6dPIO536ycLPlgv/ElYg98M5pMDjj8S4Ee/P/UQ2/bgtxsvpAhqAaxDcscdgyZcnpwwf0E369WgnWTJnlNETZspny1ZqMa+nmzdvSvtugyR7tizy8ewJMm5Y73hvQ/p0aeXFkkXF4XDE+7pYge8K/PnXbhk+dorvNjAAWpY0SRJzLKZ5IHWc9/a8FaAPHztFDhw6HKpuux7/kfUnVOcYQQCBgBAgQA+IzUwn/VUgZ46sUrLYc1Kpwovy8fsTpOBTj4teifDX/tqlX62b1TcBsjfbO3n6HNn80zZZ+vE06d21jVStXE7q164mH0wdJd+v+Fjy5M7pzea41nX85Cm5cPGSNKhTXcqWLibPPP2Ea158ZUqXKCLLFkyXRIkSxdcqAqJe3W4B0dFYdZKFoxJIlzaNORb1b1NU5eJyHsd/XGpSFwIIJIQAAXpCqLNOBOJBICgoSIoVKSQ7ratGzuq3bP1VKtVoLDnyFxO9xbv3oDGiVzSd80+fCTa3P5ev2kCyPfKCvFC2hugt5+5lnGXdX79fv9ncrjxrzkL3yeHyISHXpN+QcfL8i1VN/a/WbCp6lThswfmLPpeXqzWQfAVfku79Rsi1a9dCFdHbJOs36yj5ny0neZ4qLZrXtrsX8nRdzmUOHDxsTPR28OvXr4vzVv5PPvtSqr7ZXB5+oqQUKvFqhCc8lq/8Vl6sWEeyP/qCFHmpukycNkfc/4W9xd15S63evl7m1XpmOb3V+8eft7sWK1auhujtkHpFSG9f1xTdbaHOhTWQ0ja8WaOKtQ8865zsen3qifzmRI5rQiQZvQW85lut5aHHikuNeq3kv8NHXSULl3pNdP9xTbiT0duYq9dteWcs9MuH8z6V/IXKmYmV32gi2qfJ0+eacd13Xq/byqyrYPHK0qH7YDkTfNbMcw50n9X9cc7Hn0nZKvXN9tBblnX/XLP2B6ndsI3kfLyEaBvOnjvvXEyiu8W1U8+hEd5qrye3tO8XL11y1RVdptWdrwf8sOVnqdXgHbMPt+0yQHT//OfffaLz8z79omn/n7v+DVfdzA8XSInyNc3xocefHgvuhf76+1/p3GuY2c/0ONZj9es1692LyKVLl2Xg8AlWmWrmWNevV+j+4CykX1/QNjnH9fXX33aa7aH7vY7rq24ftXujfmvJ/WRp6dRziM4ST46/o8dOiHPf0eU93Xf1axkjxk2T50q/5joudD80K74zUEPtg26fIi/d7qOO6zrvFAn3ov1w3l6v/dKkLu4Fjxw9Luqi7zthj0dnuei2j7Oc+6vuC2qg+5IeN+26DpTtv//pKhKjfT+G+76uxJPtpeWc6dB/R8y+sOrbDc5J5lW3jX5VRt+TdILu0/p1Gd0HPf17oW1Re/f9Qd/fO1nHoB4X+n6oHlq/e4puXVrvE89XMIvodtV1aNL3ct32zrwpYA309nHdH7Q/+jdE91XttzXL/O/c/z//ao05jnX/f7ZkFfngo8VmfnQD7YOWf+qFStJ3yFhzTIZdRstE9p4XVX+0Hv371qP/SNF16N+dl62/l9t33N2ntEx0+52WISGAgD0EguzRTFqJAAKeCJw8dUYypE9riup3xjUgvv++lPLeuEHSvFEdWfjpcuk39F0zXweHrABs1z97pWa1ijJz0nApU/oFmTTtQ3lvxjydHWHS4PzNt9vJ6CE9pWnDNyMs45zYrG0P+eSzr6Rm9VdltnUl96VSL8gPW0Lfwj3/k6Wy9ItV0qpJfWnSoLbMmrNIpr7/sbMK0Q9WL1dtKLv/3SfdOjQ3V6YPHjwib7z1jugHSGdBT9blLKvBeZXaTeWZp56Q998bIYkTJ3bOki69h8mbb7wqv21eIV2t9WlQ+qnb7eHfrtskDZp3loJPPy7TJwyT8mVKiJ6E0ODBVUkEmWvXrsvoCTNkaL/O8usPX8nTTz4mbzXrJJcvXzGlJ40eIA/lyCZvvVndfG1h+aJZpoyZGc3g3z37TD0VypWKpmTks3dawWOvgaPltcrlZfjAbnLYCl5qWIGaBsO6VIO6Naxt+WWokycnTp6WL7/+XmrXqKxFwiVtz4fTxpjpo4f0MP2q9mp5M77aCgZKFn9OZlj7Xb1a1czV/3c69zPz3AcfLVgiX69ZJ+1bNZIXS75gblkeNuY96d53hFQs/6L079lOvlu3WYaMes99sSjz9Wq9Jhqg/vbHX6HKzV3wmVSvUkFSpUwZanp0I2rXo98oqWYt267l27J42QrpP3S8OXGQO9dDMnZYH7l48ZI0bt0tVFX6DIFufUdK0ecLWfvhSCn3UjHRYO4ry9RZ8FfrQ/iNmzekwztvy/iRfSXPww+JBqfafmeZAcPHW9vhW3MMvT9lpHUcF7NO1P3jnB2j175D3pWq1jbatnG5dHyniUfHnx6HtRq0kd93/iND+3eR6q9VkPbdB8n230P7RtQQ3ZbvzZhr3iP0eMqcMb28bp0ccu+fLvfbH7tETzjOmzVB1n29UE6dOSsdew7WWRGmEi88Z94vdKYeS5qGWMeejmvS4/EN62TUwzlzWO9lvczdFno8Xr0aorNNem/GRxLd9jEF3QYHDx22Ary2ovVOGTdYurZvbr5qcez4KVep+Nz3PX2/dDZGX7Nne1CKPveMfP7lNzrqSut/+EkOHzkmVSu/bKbdy98Ls2CYQV/rpK2edGvV9C3p+E5jWfblGtETIe7FoltXujRpxPneMmJgd/Peots4srtm3mzUTn759Xfp2q6ZjBzUQw7+d1QqvdHEvG+6r1dPQNSu8ar8suELadO8gbWPDTHLuZcJm/9ixRrr78ZwecE6jkcM6CbBwefN183Clotqu0fXnwYtOsmiJSukTs2qMmPicMmSKaO8VruZ2T66Hk/2Oy1HQgABewgE2aOZtBIBBKIS0KuHeqVx0ZKvpNLLL5miQ8dMkcLPPCmfzJksr1UqJ+80f0smjOxvXcFeJKdOB5syemX1w2mjpfnbdURvkx/ar4sM6NVB5i741MwPO9DgvE7j9tYH2p7SoM7rYWeHGterxXo14pO5k6Rr+2ZSoWxJ6dy2icy2Agj3gmnTppHFH71nBUYvS49OLaWhFQgu+3K1q8iUmfPk7NlzsuKzD6TxW7Wk1uuV5dN5U+TPXbtl1ZrbV3w8XZdW6gzOixQuaAVFI8wHc53uTG++8ZrUsdIDqe83r00b1pLx7812zpbR42eY6eNH9JXKr7wkQ/p2Nu3SMleuXHWVC5vRKzvdOrQwH+IyZkgnGqjrdlu74UdT9FlrW6VInlT0w7J+bUFT2jQPmHnRDf63/5Apkj1rZvN6L4PjJ07Kpx9NMScI6tWqam6V/9/+g6LbUOurW/M16wr3OXG/ert46QormE0h1e58gNdy7unBLJnkuUJPmkkFHn/UXMXX/umERXPfMx/OX7FOKuj+seCDCbJi1VrRD5o635lSJE9uvr6h+/C44b3luWeflknWVfjPF86QRvXfMPYdrEByufUh2blMdK9q/dijec0JB2fZ7dYVzj93/WtOzjinefqqdovmThY1atuygbSwjie9a0L7pUm/bvDuiD6y6589olfEtd5ga5/WEzZ6TIwZ2lNeKV9KBvfpLC0a15F3p9zd37RO3dd0n6xRtaJMmzDEWk9V+XD+Z1qNSZt//FXq1qpmPF4uU9K4Tp8w1MyL6UBPeuhJIv3O8GOP5hFPjr+Vq9fJjp27ZO6Msa7954MpoyTsw7vCtkWvkk6dNV+GDehqgmk9nubNelcet7bN2MmzQhXXE1mTxw40z1fIbZ2k6NW5leh69RgKVfDOSCYr0M+b+2EzpseSpqcLPGbGdaDHY9/u7cx7kp40+shqu55w+nbtJp0tnm4fU9ht8Mv2naInVHSbvlqxjHXy6lWZMKqfef9zFlsUj/u+J9vL2Q73Vz2+Vqz+PtQJOD32H82XWx7Pn9cUjenfCxExy7kPjp84ZfbdPt3aGPsqFcvKwg8nWiewLrsXk+jWlTRpEnG+tzzxWD7z3qLb2OEI/9yJb77faE4ALvxwsrz9Vk15o1pFWWwdr8eOn5DZYa6Q6wk6Pc70vVfL6omeZV+tDtW2sCP6t/dl60St7p/6d3TSmAGSL+/tfc+9ihg/iAAAEABJREFUbFTbPar+6ImSr79ZLzMnD5cu7Zqav9V6rOnJv2nvzzer+MWD/c4UZIAAArYQIEC3xWaikQhELNBn8FjRW/n0Nt8Bw8aboHlQnw6iV4HWbtgidWpWCbXgy1aQrLfK/WxdSdAZeuVLr1w4b4PXuvSWz737Dol+gNUyDsftDzzfWlcpNTgfb13FCxuc64dkZ9LbbXW5DZt+kkesDykFn3xcRyNNJV8obK4wOQsUfOox2Xcn4NRpGzf/bAUvpSV9ujQ6apIGuBpgb9m6zYx7si6Hw2EFf0dEr5yXtK6uaQAT0dWWF0sUMXU6By+WeEH0adBngs+KBuB6W3rZF19wzjav9awrsnqLojP4MhMjGDxbsIBrql6lzZ41i+w7cMg1LSEzj+fPJxpQO9ugD5fToHrrtttP79c7M8yHabeHEM77ZKnUsD7sJk+ezLmYx69r1v5grgQ/Vri82YcLlahilnWebDAj1kD3WYfj9j5ojZqH7z2SJ5c5kaHjmgo8/oiovz4oT8c9SW9bwb2e0NLbbbW83l2SN3dOcwJFx2OSnnnqiVB2BayTEbp8yWLP64tJTxXIb173HzhsXvUKsQaBtWu8ZsadgwplS8nP23aYY1in6X7Xf+i7UvLlWuZrJXqMfrz4c9l/8D+dbdJj+fPKrDmfiN7WHvYEhykQg0G5F4uHKu3J8ffzrzukwGOPyPOFn3YtW8ja16M79vWkiH49o/xLJVzL6d0sNa2TcOvunLhyztATKveluntngwbpOm9fLI6f0sXvbh/d93Nkz+py9XT7aBvcU748D1tB7nVp8k4PczLLeQeKe5n43Pc92V7ubXHma1R7RfQ93HkC7saNG7J85RqpWf3u3TGe/L1w1hfZq961ou+j9ayTgM4yul1fr1rBOWpePVuXKRrt4Keft0v+R/KYkzvOwrqt9Y6xTT/94pxkXgsVfMK8Oge5cmaX/XeOWec091f9e7dt+x/W39qq7pOlnnXCLNQEa8TT7W4VDfX/xs1bzd1VZUsXCzX9lXKlZYvVN52Yz4P9TsuREEDAHgIE6PbYTrQSgQgFmjWqY27tW71srhzctUkmju5vXdFMKfrdSrH+6dOz9QO9M2XKXVj0g9eh/24HCbPmLBT9/ufLVuD+rnVF+ItPZpqreFom+Ozt7/TqByWrKnO1MWeObPLqK2V11JX0+6J6gsCZWnXsa+b9d/iYZMyQweSjGtx///2hZidPlszcVuucePjIUbNuZx+cr7reg/8dNcU8WZf247t1m+SQtUyrpvVDnRQwldwZpE2b+k7u9ku6dLevYh89dlKOHDtubqtPm/b2tNslRDSY1bzelqmvEaUUKZKLJvd5iRMnkkt3bnF3nx7TfK6Hs5tFDlnmJnMPg7QPhO6TVpEuTWrRK16a11THuoquV3L0SqN+KDVXnGu8qrNilDQwq92wrXUCJ5folTR9oNvSj6eZOs4EnzOvzkHq1KH3j2TWlbP77kvlnG1edZpmYvLdcb2NVQP6r1attQKqa/LpspXWVejQH7K1Tk9SmgdCtzFp0qRmsfvd2pnszrRLly+ZefoVAs08V/o1ce7T+lr1zeY6WfbuO2BeO/UcKut++Enqv1nNfA1Fb+N9s0YVOX3nLhgtNHFUf6nzxqsyZsIMKVTyNWnapofoCTqdF9OUPl3o/cCT4+/Y8ZOSOVP4Yz1LlvDT3Ntz+MhxM6onf0zmziCLVZduG73CfmeSPJD6PmfWvOqxoxkNkPQ1pkmPRU3uy+kdLM7j0dPt47685vVq7lefvi+HjxwzJ6D0O/NjJ73vumspvvf9wx68X2o7w6bMGTNICetkqd6urfO+W79Z9DivXqW8jprkyd8LUzCKge4rDodD9A4H92KZM2V0H7VOOEX/tynUAlGM6H6mD6sLW0TX+d9/x0JNfuB+t/3MmpNI36MvXbZyEf9/7MRJMyNzpvTm1Tl4MHPo/sRkuzvrcL5q+w9YJ+T0/cE96e34B+6cPIhuv3PWxSsCCNhDgADdHtuJViIQoUDOO09x1ytX7sFA1gczm1u3e3V5xwTw+qHePemZd61Qg5PqVV6RDq3fljesK6GlrCtKzoBU52tyOG5fvXx3RB9JmTKF1GrQRvQKiM7TVPCpx+XrpR+6Us/OrXWyZMua2fqAd/vDi5lwjwO90lG1cvkI+9G5bVNTqyfrcjgc5hZgvXJTo34rcb9Kbyq5MwgOvn1i4s6oFQidNdksmTPIg5kzmcBeP2SaiXcGzodV5cj24J0p3n3Rq5c5H8om+h3He13ziZN3vyPrrENPSmS2giXnePmXiovuWws//VL05/z0irPeyeCc7+mrBvmP5sslg/p0sq40VZUXSxaVXDlzeLp4nJR7wAr8q736sixa+qXo9+hPnQ62gtzbV/HjZAXRVJI9axZTYsHsiRHu27rf69V9DZjatWwoLRrXFb0NWW/jdQanpgJrkDx5MutER1s58NcPsmnNZ3L9+g3R5wc4bzFPZp30unHjplXy7v+Xr1y5OxJFTtsR3fGn+8iZs6FPrGiVZ86En6bTnSnrg5lMVgMQk7kzOGoF/Lp9Igqq7hSJ9xdPtk9kjdDvc69c8oEc27NVendtK5OmfSiDR00yxeN73/dke5mGRDCoWrmcrFy91nwvW7+P/uwzT0qeXDldJT35e+EqHElG9xU9WapX692LBAfffp91TouLdTnr0v1Mb2d3jjtfdVr27LePQ+e0mL5muXNiIdzfjTD9iWi7e/qep18L0vda97/hzvwH00a5mhzVfucqRAYBBGwhQIBui81EIxGImUBS6ypjmVJFZcfOv1zfzdMP9s6U7U5woFfK70uVIlTlq8I8Ido5U29D1O8o6y23bzXrKHqrvM7TD9L6wcCZ8j+SWydL6RJF5J9/94leOTAT7nFQqngR2fHHLtFbhJ3td74+nj+vqTUm69Jb9IsVeVb0yeOH/jtilncfrN242X3Uunq5RfTqRNo0D4gGQhqQrv52Y6gyq7/bIPpBLf8jeUJNj+lIypQpLdfIv8ceWX16W3DLxvVkwadfyKYfQ9+yqcsEW8HTlq2/ajbS9Puff4t+59xZQE9g6LTCzzzlnCT6SwF6gmPhZ1/I0uWrpWHdN1zzYpK5deumhL0KvvKbdTGpIk7K6ve7dVvO/HChVHy5dKjb1ONkBVFUUqhgAXMVUc2d+7P7qx5vt26JueMlVapUrpr05Jhe3XRNCJPJlyenDOvfxSy3Z99+MzdH9gfD/Vb07zv/NvOiG3hy/Ok+svOvf8xVY2d9eheP3s7sHI/o9ekCj5s7flZ9G3rbf2MdT/oAwYiWicm0VNbxpOXVTF9jkjzZPtHVlyxZUtHvt+tD8/Qhl1o+vvd9T7aXtiOiVKVSObloXS1evvJb66TVdxL22RIx+XsRUf067ekCj4m6fLfu7vvsLWtH//bOd/+1jCZP1pXqzlceroaE6CKRpucLF5R/9+4XvePHWUgfprd+41Z54blCzkn39Kp3Yei+Evbvhj6vxb3CWx6850XWn7KlX7Demw+JnoR3f4/QvD6Yzn09mlffaq+WNw9rdO53Op2EAAL2ESBAt8+2oqUIxEhgQK+Osub7H8xPhukDqzZs2ir6E1evVG/k+vms4kWflaVfrhYNVE+fCRb9CauwH5RuWR+edMX6qt8DXzJ/qvxtBd6NWt0OAnReRKl40cKiV2TebtnNfBdTP7DorZ6NW3ePqHik095pVl+SJEkkZSrXta5EzRW9tf2Tz76Uek07mJ/T0gU9WZe2X5MGmTMmDpWHc2a3gvQW1lX+01qFKy1f+Z3MXbBE1Etf9anyHd9p4prftUNz0aua02d/bMroT/pMmTlPOrzT2ATwroL3kNHvEX67drPpo65fT4Z4Ws1bdaqLfvjVEw9DR082D3ebv+hzc7vzU0Urmu/fR1WX3uKqTxDX9Wpq122g+d6mbkP35eq8UcV80D195uw9PVBN69ITJFt/2SHfrd9k7sbQh1HpQ/Z0njdTqeLPy8MPZTMnNWpWqxxu1f2GjDM/cRZuRhxM0A/bfbu3FX1y/jud+pl9SvftQSMmiv5El65CT7RpG9+fs9B8J12viDdr21PO3vn6iZbRVKFaQ/NVFV1eHyg1YPgE0ec0aACs86tVLi/6PVb9iUPdp3SfnTzjI50VbfLk+NOTG/nz5bH2tZ7m5wr15E6L9r3N3SZRrUDfT1o3qyejJ8w0DwjU/U7zm37cJp3bNI1qUY/m5c1z+0Fd789dZI7V6E4YuFfqyfZxL+/M689y6a88fPb5SrNOtf7iq29Et6OWie9935Ptpe2IKOl7QJlSL4juP3pSz/32di3vyd8LLRdV0lvb9fkPut/rScPTZ4JFn6Wye+++UIt5si59kGHWBzPLks9XGWvdf/Q9PlRF1og+40D/Ruh7mh4fWk6ftZIuXRrRtlhFYvV/h9Zvy/tzF4u+3549d14+XvyFzP/k81B1erLdI+uPPhizVvXKoj8np+8PekJYnxWg79f6k266ouj2Oy0Tt4naEEAgPgUI0ONTl7oRSEABver77fL55qrnkJGTzR93vTJSqcJLkiF9OtOyti0bSrkXS0i5Km9J7idLi/40m97KbmZGMngwSyb5bN5U+WXbH6LfN4/oIUjORWdOGmGuTPYZNMb8NJleGdOAyDnfk9fkyZPJqmVz5blCT8vsjxaZEw6jJ8yQR/LkkqLPPeOqIibr0ivO82e9K+nSppXqdVqIfkh0VjSod0drPYuNlwaNg/t0kjeqVXTOFn1Qz7yZ78qCxculztvtzEmN7h1bSssmdV1l7jWj686d6yEr0Olh1v+bBz9T5VyXXnFdtWyONGlQS1asXittu/Q3P/Wzd99BmT5hmNSsXslZNMLXZ55+XEqXKCp1G7eXWg3bSOJEia3tPMXsP+4L6K30eiJAnzquQaD7PE/zesfD8AHdpNeAMZIl7/Pmp9M+nD7a08XjrJzD4RB9/oL249VXXgpX73bLf38sHkIWrsIwE956s7p8NHOc7Nq9V1p37Gvc//rnX6lXu5o4/+kdH0mSJhH97eYiZapL1gcziT7p3TlfXx9/LJ85ydDkne6ix6QGKfo8CQ2AdX7hQk+JPglen5ieq0ApE0zorwjovOiSJ8efw+GQT+ZMkhTWsVqqwptSvHxNKVakkOiTraOrX7+Go7/O0H/YOHM8rVj9vehJwGeeDv2wrujqiWi+fo1i6vjBog8ArGYd530GjY2oWKTTPNk+YRfOlzeX6E/q6S8NvNmonUyZNV+6tm9hpWamaHzv+55sL9OQSAZVKpU1d0IUK/Ks6K3V7sXu5e+F+/LOvL6nvlK+tNRv2tHar1+0ThAflS7tmjtnm1dP1zVn2mg5+N9hUWsNYPXKu6kgzEB/JUL/9rTs0EcatexittFXi983X9sKUzTGo69VKicjBnaVcZNmiT6LZcbsBTJhVH9x/+fpdo+sP5PHDpB3mv+ymN4AABAASURBVDcQvdNIfw6wTed+5nko1V+9/XC96PY797bYIk8jEQhwAQL0AN8B6L49BfRDWPCh36RNiwZRdkCDdH341t+/fitaXgM4/T6r3gKnC+otoGOH9ZJd29aY+frzZfozZlrW+eCmPLlymnl6Fl+X0aS30WqdMyYOCxfA6Xxn0iuAw/p3lZ/Xf2EeYqffVe/Xo51ztvy2aYV0sK4+uCZYGV3/yX2hb9NOm+YB8/NSv/7wpWmL1te/Z3srWMlsLXH7/5iuK2XKFFbgP0c2frPYCtTT3K7EGuqHuLUrFpj1bNv4pbRqWs+aGvp/vWK4duUCOfT3Zvnx+6XhtoP+xNLyRbNcC+kH/SO7f3SNOzM/fr9MOre9e3U+S+aM5mfodm//3qxfv5vtLBv2VbeR/nSe+3Tdrur9wzefin4fWct89+V8c5LEvVzYvAliPpxkfUhuaraTtnXJx1PF+VUI9/L6lHB9qn2dME8fdy/jntc6tB1hb8XUExpbvlti+qmvOl/LuV+xj2j/0N881u/3uq9DnXRZ/ZqBTn/9tVdMvXoiRsf1yqDO1w/JOu5MenJJb7XVkxdJkiRxTjav169fl19+/UMa1qthxiMbTNUA0LJzn6990PXpceqcrm3Rado25zR91Sfjf7t8ntmX9DvL+p306lVe1lkm6dPK588ab+Yf/fcn8xvOegytX/WJma+Dd4f3EQ3I//1trez8aZV5mNxjj+bVWa6kP0mnx422QR9ipkGF5vX41kL6quPux7lO1+TJ8af77mfzp8p//2w2qUenVjJn+ljR9witI7LkcDjMzytuXfeF6eP3X31snSgK/UsKUyMwjmy/Crse/Xm6DasXyan928x3/XW+p8ejlo1u+2gZ96QPWlMHfQ9RizVffGRO3umdO85y8bnv6zo82V5aLqLUqN4b5thZ8dndn/pzlkuVMqVE9/eiepUKZnnnMnpM6n6lx6hzmh5rus/q/nrm4HZrPxlj3gf/3LraWcR89SG6dWlh3V/1vVatdT16nOkx5sxrGU2p779PZk0eIbqOPTvWmZ/qfChHVp1lUmT7v57Y0r+LplAUg2aN6sgvG5abvuvfhurWMaxteDRfLtdSnmz3iPqjFegvjvTo1FI2f/uZ6PuE2unPuRUqWEBnmwf8RbffmYIMjAADBHxdgADd17cQ7UMAAQR8QODkqTPmNtKufYeL3opfqcKLPtCqe2uCBt96m+vwsVNEvwPe4u264SrSn9nS726/+kqZcPOYgAACCCCAQCQCTEYg1gIE6LEmpAIEEEDA/wV+3Lrd3HZ/8eJl0Sua7lcE7db7Cxcvmb7o8wbeGztI9Lb9sH3QK1l6Zd/hcISdxTgCCCCAAAIJJMBqA0GAAD0QtjJ9RACBaAUiu8Ux2gUDpEDlV14yt2/q7aQFn3zc1r3WhzHp7acagL9RraKt+0LjEUAAAQQQiDMBKvIJAQJ0n9gMNAIBBBBAAAEEEEAAAQQQ8F8BeuaZAAG6Z06UQgABBBBAAAEEEEAAAQQQ8E0Bv2kVAbrfbEo6ggACCCCAAAIIIIAAAgggEPcC3quRAN171qwJAQQQQAABBBBAAAEEEEAAgdACbmME6G4YZBFAAAEEEEAAAQQQQAABBBBIKIH4CNATqi+sFwEEEEAAAQQQQAABBBBAAAHbCtgwQLetNQ1HAAEEEEAAAQQQQAABBBBAIFIBAvSwNIwjgAACCCCAAAIIIIAAAgggkAACBOheRmd1CCCAAAIIIIAAAggggAACCEQkQIAekYp9p9FyBBBAAAEEEEAAAQQQQAABmwoQoNt0wyVMs1krAggggAACCCCAAAIIIIBAfAkQoMeXLPXGXIAlEEAAAQQQQAABBBBAAIEAFiBAD+CNH2hdp78IIIAAAggggAACCCCAgC8LEKD78tahbXYSoK0IIIAAAggggAACCCCAQKwECNBjxcfCCHhLgPUggAACCCCAAAIIIICAvwsQoPv7FqZ/CHgiQBkEEEAAAQQQQAABBBBIcAEC9ATfBDQAAf8XoIcIIIAAAggggAACCCAQvQABevRGlEAAAd8WoHUIIIAAAggggAACCPiFAAG6X2xGOoEAAvEnQM0IIIAAAggggAACCHhHgADdO86sBQEEEIhYgKkIIIAAAggggAACCNwRIEC/A8ELAggg4I8C9AkBBBBAAAEEEEDAPgIE6PbZVrQUAQQQ8DUB2oMAAggggAACCCAQhwIE6HGISVUIIIAAAnEpQF0IIIAAAggggEBgCRCgB9b2prcIIIAAAk4BXhFAAAEEEEAAAR8TIED3sQ1CcxBAAAEE/EOAXiCAAAIIIIAAAjEVIECPqRjlEUAAAQQQSHgBWoAAAggggAACfihAgO6HG5UuIYAAAgggEDsBlkYAAQQQQACBhBAgQE8IddaJAAIIIIBAIAvQdwQQQAABBBCIUIAAPUIWJiKAAAIIIICAXQVoNwIIIIAAAnYVIEC365aj3QgggAACCCCQEAKsEwEEEEAAgXgTCJgAfdGyVVK/ZU9p0Kq3rN+8LULQk6fOSJtuw6Rx237Sa/AEuXzliqvczl3/SqM2faVExQZSqXZruXHzpmseGQQQQAABBBBAIG4EqAUBBBBAIJAFAiJA33/wiMxduFymj+snowZ0lKFjZ8iVqyHhtvuE6fOlaOGnZfakQZI69f0yf/EKU+bipcvSsfdoea1CaVmzbJZMHdNXghwOMy9JkqRCwsCTfcDsMNbAk7KUYZ9iH2AfiMk+YL21mP9jsgxlA3Qf43MLn9tiuA+YNxdrwHsG7xme7gPW7sL/sRAIiAB945ZtUrp4YUmVMoVkyZxB8ufLJVu3/SFh//3w43ap/HJJM7ly+ZKy8cdfTX7dpp/lsUdyy+tVyknyZEklZ44HxeG4HaCbAgwQQAABBBBAAAEEBAIEEEAAgdgJBESAfuLUacmaJaNLKnvWzHL85CnXuGb0KrnG3GnTpNZRyZEts5w4edrkDx85YV7rNO1qbm+f+8lyM66DmzdvCgkD9gH2AfYB9gH2AfYB9oF43wf4zMXnTvYBG+wDGiOR7l0gIAJ05XEE3e2qwxHx1e+gUGXulr9166YcOXZcRvTvJHOnDJV1P/wsv2zfqdVKSMhVEgYe7QPXr18TTewzHDPsA+wDcb0P6HuLpriul/rYVwNrH2B7R7S99b1FU0TzmMY+E9E+YIIkBvcscDcKvecqfH/BjOnTSXDwWVdDT58JlkwZ0rvGNaO3v9+4cVNCrl3TUTlllcmYIZ3Jp0+XRh57JI+5tT1D+rTy5ON55e89B8y85MlTCAkDT/aBpEmTiSZPylKGfYp9gH0gJvuAvrdoiskylGUfYx/w8j5g08+M+t6iif2F/cXTfcAESQzuWSAgAvQSRQvJhi3b5GpIiJw+c1b+/HuvFCn8pEH7dcdfcu3adZMv9nxBWbN2s8mv/n6TlChS0ORLWsv/s2efXLh4ydTx+5//Sv58D5t5DBBAAAEEEEAAAQQQSGgB1o8AAv4hEBABuj7UrXrlstKkXX/p0GuUdGzdQJImSWK2YLcB78rZc+dNvkPLerJ81XrzM2sHDh6RejUrm+l6Jf2tWq9Ksw4DpWn7AVK2dFEp9NRjZh4DBBBAAAEEEEAAAQT8XIDuIYCAlwSCvLSeBF9NrWoVZN604TJ36lApXexZV3u+WTJD9LZ1naCvU8f0MT+zNqxve0mRPLlONqlS+VKyYOZI+WjqMKlbo6KZxgABBBBAAAEEEEAAAQRiK8DyCCDgFAiYAN3ZYV4RQAABBBBAAAEEEEAggAToKgI2EiBAt9HGoqkIIIAAAggggAACCCDgWwK0BoG4FCBAj0tN6kIAAQQQQAABBBBAAAEE4k6AmgJMgAA9wDY43UUAAQQQQAABBBBAAAEEbgsw9DUBAnRf2yK0BwEEEEAAAQQQQAABBBDwBwH6EGMBAvQYk7EAAggggAACCCCAAAIIIIBAQgv44/oJ0P1xq9InBBBAAAEEEEAAAQQQQACB2AgkyLIE6AnCzkoRQAABBBBAAAEEEEAAAQQCVyDinhOgR+zCVAQQQAABBBBAAAEEEEAAAQS8KhBnAbpXW83KEEAAAQQQQAABBBBAAAEEEPAzAbsE6H7GTncQQAABBBBAAAEEEEAAAQQQCC1AgG48GCCAAAIIIIAAAggggAACCCCQsAIE6N7wZx0IIIAAAggggAACCCCAAAIIRCNAgB4NkB1m00YEEEAAAf8RuHzlivQZOlHqNe8m9Vt0l81bt0fauU0/bTdlGrbuLf1HTJErV0NM2XPnL0jhMrVCpT/++tfMcx+06TZEni/3pmuSp8u5FiCDAAIIIIAAAnEqQIAep5x+WRmdQgABBBCIB4G5C7+Qbb/9Ga7mGXM+lashITJ/xijp36219Bj4rly8dDlcOQ2muw8YJwO6vyNzpgyVq1evyux5S1zlUqVMIT9/t8iVCjyW1zVPM5+v/E7uuy+VOHTELUW3nFtRsggggAACCCAQxwIE6HEMSnUxFaA8AgggEJgCBw4dljNnz4Xr/Jq1m6V2tVfM9Hx5ckq+3Dllw+ZfzLj7YO3GrfLYo7klb+6HzOTXq5STNes2m3x0g+MnT8vCJSulXfN60RVlPgIIIIAAAgh4UYAA3YvYrCoBBFglAgggYCOBW7duyfETpyRnjqyuVufInkWOHD3hGndmjlnlcmTN4hw1yxw+ctw1fvnKVSlRsb68Wqe1TJoxX65du+6a12/4ZOnTuYUkTZJEbrmm3s5EtdztEgwRQAABBBBAIL4ECNDjS5Z6A0KATiKAAAIxERj+7kzX98KXrfhOug8Y5xpf+8NWU5XD4RBH0N0/z0GOu3lTwG3gCHK4xoIcDtEAXyekTJlCViyaJuu+mis9OzSTDVt+kVkffaqzZOmXa0Rvd38if+hb3nVmVMvpfBICCCCAAAIIxK9A5H/143e91I4AAtELUAIBBPxMoGfHZq7vhFerVEZGDujkGn+x+HPicDgkY4Z0cup0sKvnJ0+fkQezZHSNOzOZM6aX02fOOkflpLVM9my3r6gnTpRIMqRLI4mCgqR4kWekwZtVZcfOf0zZNeu2yIcfLzMnBl6p2UJu3rxp8ocOH5OoljMLM0AAAQQQQACBeBUgQI9XXipHwJcFaBsCCPiiQNnSRWXpV2tM044cOyE7//pXShQtZMb3HTws+62kI6WKF5btv++Sw0dv39b++cq1UrZUUZ0l+gA5k7EGl69ckXXW1fmnn8xvjYm8N7qP66TA14unS5AVxOvD5LJnzRzlcmZhBggggAACCCAQrwIE6PHKS+UIBLAAXUcAgXsSaNGopgSfPS91m3WTrv3GyODebeW+VClNXQs/WyGLln1t8mlS3y9DereTbv3Hiv7M2uXLV6Rx/dfNPP35NefPrGk9eXI9JM0avGHmRTW41+WiqpN5CCCAAAIIIOC5AAG651aURAABHxKgKQjYXaBPl5auK963lnRsAAAQAElEQVTufUmRPLmM6NdRPp45SuZNHykvPFfQNbtHh6bStW1j13ix5wuaMnOmDJWBPVpL8mRJzbxXypZwXSVf+tFEadmolrnd3cx0G2RIn1Z+WrPQNcXT5VwLkEEAAQQQQACBOBUgQI9TTipDAAE/EaAbCCCAAAIIIIAAAgh4XYAA3evkrBABBBBAAAEEEEAAAQQQQACB8AIE6OFNmIIAAgjYW4DWI4AAAggggAACCNhSgADdlpuNRiOAAAIJJ8CaEUAAAQQQQAABBOJHgAA9flypFQEEELCdwLk9P4sPJNpwD9vh/N5fRBPbz777sO3eMGgwAggggEC8CBCgxwsrlSKAAAL2E/hrekvx/+Sffdz9flvRxPaz7/YV/iGAAAIIIGAJEKBbCPyPAAIIIIBAnAhQCQIIIIAAAgggEAsBAvRY4LEoAggggAAC3hRgXQgggAACCCDg3wIE6P69fekdAggggAACngpQDgEEEEAAAQQSWIAAPYE3AKtHAAEEEEAgMAToJQIIIIAAAghEJ0CAHp0Q8xFAAAEEEEDA9wVoIQIIIIAAAn4gQIDuBxuRLiCAAAIIIIBA/ApQOwIIIIAAAt4QIED3hjLrQAABBBBAAAEEIhdgDgIIIIAAAkaAAN0wMEAAAQQQQAABBPxVgH4hgAACCNhFgADdLluKdiKAAAIIIIAAAr4oQJsQQAABBOJMgAA9ziipCAEEEEAAAQQQQCCuBagPAQQQCCQBAvRA2tr0FQEEEEAAAQQQQMBdgDwCCCDgUwK2CdBv3LwpR46dkN92/i3/7j0gZ89d8ClIGoMAAggggAACCCCAQGgBxhBAAIGYCfh8gH7sxCkZPGaGlKveTFp2GiyTZnwsfYdNkjcadZJajTvLijUbYtZjSiOAAAIIIIAAAggg4A8C9AEBBPxOwOcD9HY9hkvBJx+RVZ9Ok8/nT5RZEwbKglmj5ZslM2Rk/07y0y9/yLxFX/ndhqFDCCCAAAIIIIAAAggkpADrRgAB7wv4fIA+e9JgqVLhRUmaJEk4nVw5s8mA7q2k+qtlws1jAgIIIIAAAggggAACCPisAA1DAIEIBHw+QE+VMkUEzQ49yZMyoZdgDAEEEEAAAQQQQAABBPxXgJ4hYE8Bnw/Qnawbt/wqzToMlJKVGsoLFeq7knM+rwgggAACCCCAAAIIIICAVwRYCQLxJGCbAP39eUukS5uGsvbLD2TzqnmuFE8uVIsAAggggAACCCCAAAIIJIgAKw1cAdsE6JkzpZdH8z4siYJs02ThHwIIIIAAAggggAACCCDgYwI0x4cFbBPtpk+XRpZ8uUYuXLzkw5w0DQEEEEAAAQQQQAABBBAIZAH6HhsB2wToS5avkdGTPpTyrzd3ff9cv4sem86zLAIIIIAAAggggAACCCCAgI0E/LyptgnQ3b937p73dPssWrZK6rfsKQ1a9Zb1m7dFuNjJU2ekTbdh0rhtP+k1eIJcvnLFlPt374FQJwU69h5tpjNAAAEEEEAAAQQQQAABBBDwH4GE7oltAnSFunXrluzd959JmtdpnqT9B4/I3IXLZfq4fjJqQEcZOnaGXLkaEm7RCdPnS9HCT8vsSYMkder7Zf7iFa4yzz79uOvBdO8O7eqaTgYBBBBAAAEEEEAAAQQQQAABDwSiLWKbAP3zFd+Z29vb9Rguml6u0UK++HpttB3UAhu3bJPSxQtLqpQpJEvmDJI/Xy7Zuu0PCfvvhx+3S+WXS5rJlcuXlI0//mryDBBAAAEEEEAAAQQQQAABBBCIb4HYBejx3Tq3+uct/koGdG8tyxdMMqlf15by0SfL3UpEnj1x6rRkzZLRVSB71sxy/OQp17hmLl66LA6HSNo0qXVUcmTLLCdOnjZ5Hez8e4+UqNhAmrYfIDt2/qOTTLp27ZqQAtfg+vVr4mm6ceO6aPK0POU8t00oK3879s2bGgMEEEgQAX97P6E/3v1sFJ9/B/Wzi6b4XAd1x+4zj68dbwnyJupHK/XpAN3dOXHixFKi6DNWEO0wqeQLhSQoyOFeJMq8I+huVx2OiJcLClXmbvmsD2aSL+ZPlJWLp0qZUkWkS7+xcuny7e+n37p1U0iBa3Djxk3xNN28eUs0eVqecjc9tk0oK3879qN8E2UmAgjEq8DNmzetvxH3nvzt/Yj+3IzR58v4/Dt4k88vfB6JYbwTr2+WAVD53SjUxzubKFGQbN76m6uVG7f8KkmTJnWNR5XJmD6dBAefdRU5fSZYMmVI7xrXjN7+rm9uIdYVcR0/ZZXJmCGdZiVliuRy/32pTKpbo6JkyZRBDv531MxLmjSZ1Q5SoDokS5ZMPE1JkiQRTZ6Wp5zntgll5W/7vXlTY4AAAgkiENv3MX97P6I/yWL0+TK2+09Uy+tnF01RlWFeMo8/D8aHla8dLwnyJupHK7VNgN6jfWMZM3mO62nq46d9JDrNk21Romgh2bBlm1wNCZHTZ87Kn3/vlSKFnzSL/rrjL7l27brJF3u+oKxZu9nkV3+/SUoUKWjy7r+9rk90P3P2nOTIlsXMi3zAHAQQQAABBBBAAAEEEEAAAQQ8F7BNgF7gsXzy6YdjZf70kSYt/mCsPJE/r0c9zZnjQaleuaw0addfOvQaJR1bN5Ck1tVMXbjbgHfl7LnzmpUOLevJ8lXrzc+sHTh4ROrVrGymr/hmgzkxULJyIxk7Za4M69POXFU3MxNqwHoRQAABBBBAAAEEEEAAAQT8SiDI13uz9dc/RK9g6+vP23fKqTNnTNK8TvO0/bWqVZB504bL3KlDpXSxZ12LfbNkhmRIn9aM6+vUMX1Ef2ZtWN/2kiJ5cjNdl9XfXt/w1Yei8598PJ+Z7s8D+oYAAggggAACCCCAAAIIIOBdAZ8P0N+ft1SOnTgl+hpR8i4Xa4sjAapBAAEEEEAAAQQQQAABBBAII+DzAfq0sX0lz8M5RF8jSmH6wygCIgICAggggAACCCCAAAIIIGA/AZ8P0J2kY9+b68y6XgePmeHKk0HAawKsCAEEEEAAAQQQQAABBBCIBwHbBOi79+4P1/0/d+0ON40JCNhdgPYjgAACCCCAAAIIIIBAYAr4fID+xddrpWXnwaI/b6avztSwdW/J/XCOwNxq9BqBexdgSQQQQAABBBBAAAEEEPBRAZ8P0As99Zg0qV9dsmTKYF41r2l4v/YytE87H2WlWQgEqgD9RgABBBBAAAEEEEAAgXsV8PkAPXvWzPLcMwVk3vTh5lXzmrJmyXSvfWY5BBCwqwDtRgABBBBAAAEEEEDAjwV8PkB32l8NCZE5C76QDr1Gmlvenbe6O+fzigACCMRWgOURQAABBBBAAAEEEEhIAdsE6INGTZMTp87IyVPBUr1yGbkvZQrJn+/hhLRj3QgggEBMBCiLAAIIIIAAAggggECUArYJ0PfuOyhd2jSUVKlSSIUyxWXM4C5y6PCxKDvHTAQQQCBwBOgpAggggAACCCCAgN0FbBOgp0qV0lhfv35DLl2+YvLXrt0wrwwQQAABBOJZgOoRQAABBBBAAAEE4l3ANgH6falSSfC581L8+YLydps+VuorWTKlF/4hgAACCNhfgB4ggAACCCCAAAIIiNgmQB8/rJukSX2/NK5fXXp1bCatm9SWbu0bsw0RQAABBBCIToD5CCCAAAIIIICALQRsE6C7az5d4FHzk2uJgmzZfPeukEcAAQQQsL0AHUAAAQQQQAABBOJGwOcj3Bcq1JeoUtwwUAsCCCCAAAI+KkCzEEAAAQQQQCBgBHw+QN+8ap5oql29gtStUVHmTh0qiz8YK63eri3VKpUJmA1FRxFAAAEEEIgPAepEAAEEEEAAAd8R8PkA3Un1y29/Sdvm9SRf7pySPWtmafBmFQk+d845m1cEEEAAAQQQ8D0BWoQAAggggAACMRCwTYAeEhIiwWfvBuRXrobI6TN3x2PQZ4oigAACCCCAgF8I0AkEEEAAAQT8S8A2AXqD2q9J7SbdpPeQiTJ03Ex5s0lXqVrpJf/aGvQGAQQQQAABBHxHgJYggAACCCDgZQHbBOiVXy4lH0weJM88lV8ezZtTpo3rK5XKlfQyF6tDAAEEEEAAAQTiRoBaEEAAAQQQCCtgmwBdG541SyZ547WXTcqSKYNOIiGQIAKXr1yRPkMnSr3m3aR+i+6yeev2SNux6aftpkzD1r2l/4gpol/PCFu4Tbch8ny5N12TDx0+KuWqNZHCZWrJKzVbmHWdPXfBzP/z7z1WPZOlbLXGUq1+OxkydrpcDQkx8xgggAACCCBwR4AXBBBAAAEbCvh8gK4/sfb7n7sj/ak1G5rTZBsJzF34hWz77c9wLZ4x51MTFM+fMUr6d2stPQa+KxcvXQ5X7tz5C9J9wDgZ0P0dmTNlqFy9elVmz1sSqtznK7+T++5LJQ63qenSppGF74+Rn79bJLMnDZbrN27I7Pm3l0uaJIk0qV9Dvl02WyaN7CW79+yXRUu/dluaLAIIIIAAAvEtQP0IIIAAAvEh4PMBuv7E2pOP5zM/tab5sCk+UKgTAafAgUOH5Yzbwwmd09es3Sy1q71iRvPlyWl+XWDD5l/MuPtg7cat8tijuSVv7ofM5NerlJM16zabvA6OnzwtC5eslHbN6+moK6VMkVwypE9rxvXVYYXvDofDjGtdD2V/0ORzZMsiTxd4VA4fPWHGGSCAAAIIIOAXAnQCAQQQCFCBoADtN91G4J4Fbt26JcdPnJKcObK66siRPYsciSBIPmaVy5E1i6ucLnP4yHHXeL/hk6VP5xaiV8Vvuabezuht63qLe7EK9eSW9V+bpnVuz3AbnrAC/K9Wr5NSxZ51m0oWAQQQQAABBKISYB4CCCDgqwI+H6CXfvVtiSr5Kiztsq/A8Hdnmu9+a3C8bMV35hZ1zWta+8NW0zGHwyGOoLuHT5Djbt4UcBs4ghyusSCHQzTA1wlLv1wjBR7LK0/kz6uj4VKypEnNLe5fLpwi96VKKZNmfhyqzIWLl+SdbkOkUZ1q8sJzBUPNYwQBBBBAAAEEEkyAFSOAAAL3LBB5VHHPVcbtguu+/ECiSnG7NmpDQKRnx2YmMNbvf1erVEZGDujkGn+x+HPicDgkY4Z0cup0sIvr5Okz8mCWjK5xZyZzxvRy+sxZ56ictJbJnu32FfU167bIhx8vMycDXqnZQm7evGnyhw4fc5XXjD4QsVzpovLDj7/qqEkh165Jl76jpXG91+Wt2q+ZaQwQQAABBBBAIBAE6CMCCPizgM8H6P6MT9/sK1DWCpiXfrXGdODIsROy869/pUTRQmZ838HDst9KOlKqeGHZ/vsuOXz09m3tn69cK2VLFdVZ8t7oPq7A/+vF0yXIuiKvJwWyZ80se/YdlDPB50w5DcbXrN0sTz3xiBnXB8916j1KarxWXl4pW8JMY4AAAggggAACCMSJAJUggECCCtgmQD9w6Kh06DVSXqzSONQT3RNUj5UHrECLRjUl+Ox5qdus9qSO3AAAEABJREFUm3TtN0YG925rbkNXkIWfrZBFy24/VT1N6vtlSO920q3/WNGfWbt8+Yo0rv+6Fosyad11mnYxV9T1O+i79x6QVm/XNst8sfJ72fLzb9Jz0HgzX2+97zV4vJnHAAEEEEAAAQQQ8GUB2oYAAlEL2CZAHzR6mlR55SXJ/0guWf7xJNEHZjWpXz3q3jEXgVgK9OnS0nXF272qFMmTy4h+HeXjmaNk3vSRob4D3qNDU+natrGreLHnC5oyc6YMlYE9WkvyZEld85wZfVL7T2sWOkfl2acfl68/neG6wj5nyjBzW70WqF+rimu6XnHXNKxvB51FQgABBBBAAAEEAlmAviNgewHbBOhXrly1AqXnzfd0NZipV7Oy7N13yPYbgA4ggAACCCCAAAIIIICAHQRoIwLxL2CbAD1lyuRGw+FwyMH/jsqVqyFy+szt7+iaGQwQQAABBBBAAAEEEEAAAbsK0G4ELAHbBOgFCzwqwefOS53XK0ndZt3lpdcaS/mXbj9sy+oH/yOAAAIIIIAAAggggAACCEQiwGR7CNgmQG/d5E3RB269WKKwbFgxRzavmic1qpS3hzKtRAABBBBAAAEEEEAAAQT8V4CexZGAbQL0+i16ysefrjBX0eOo71SDAAIIIIAAAggggAACCCDg8wKB00DbBOh9uzSX/QcPS623u0iXfmPkuw0/yfUbNwJnS93p6RuNewjJngZvNu8rmth+9tx+ut3uHIa8IIAAAggggAACCPiTgA/1xTYB+qP5cknPjk3l8/kTpHiRZ2TuJ8ulypttfIjSO03Z/PPvQrKnwZZf/hBNbL/fbbsPe+coZy0IIIAAAggggAAC/iQQk77YJkB371SQw+E+Sh4BBBBAAAEEEEAAAQQQQAAB2wvcQ4CeMH3+e/f/ZPi7s6RqvfayYcs2aVC7iixfODlhGsNaEUAAAQQQQAABBBBAAAEEEIhjAd8L0CPp4OAxMyRnjqyy6IMxMmZQFylT8nlJnChRJKWZjAACCCCAAAIIIIAAAggggIC9BGwToM+bPlzqvlHJ/NRabIhZFgEEEEAAAQQQQAABBBBAAAFfFPD5AF2f2H746PEI7c6euyBjJs+RjxZ9GeH8BJjIKhFAAAEEEEAAAQQQQAABBBC4JwGfD9BffflFad9zpLzTdai89/4CmTFnsUmDRk+Tes17yOUrV6VKhVL31Hn7LUSLEUAAAQQQQAABBBBAAAEE/FXA5wP0F0sUlkWzx8jb9apJiuQpXNuhYIFH5YPJg0R/Hz3NA6ld08nEQoBFEUAAAQQQQAABBBBAAAEEEkzA5wN0lXE4HFK44BPS2ArSmzesKZpeq/iSZMyQTmeTbCJAMxFAAAEEEEAAAQQQQAABBCIXsEWAHnnzmYOAS4AMAggggAACCCCAAAIIIGBrAQJ0W28+Gu89AdaEAAIIIIAAAggggAACCMSvAAF6/PpSOwKeCVAKAQQQQAABBBBAAAEEAl7A5wP0U2eC5Z89+8NtqL//3Sdngs+Fm84EBBAIL8AUBBBAAAEEEEAAAQQQ8H0Bnw/QR4x/X06eOhNO8uSpYBk/bV646ZFNWLRsldRv2VMatOot6zdvi7CYrqdNt2HSuG0/6TV4gly+ciVUOT0hUKZqU5k6+5NQ0xlBIMAF6D4CCCCAAAIIIIAAAgjEgYDPB+j/7j0oxZ4vGK6rxYsUlD//3hNuekQT9h88InMXLpfp4/rJqAEdZejYGXLlaki4ohOmz5eihZ+W2ZMGSerU98v8xStClRn73lwp9HR+EYfwDwEEvCbAihBAAAEEEEAAAQQQCAwBnw/QEydOFOmWuHnzVqTz3Gds3LJNShcvLKlSppAsmTNI/ny5ZOu2PyTsvx9+3C6VXy5pJlcuX1I2/viryevgtz/+lhQpkskT+fOJeLZaXYyEAAK+LkD7EEAAAQQQQAABBBDwEQGfD9DTpkkthw4fDce1z7oqnj7dA+GmRzThxKnTkjVLRtes7Fkzy/GTp1zjmrl46bI4rCvjuj4dz5Ets5w4eVqzcv36dZk0c4G0bVbHjDNAAAEEPBWgHAIIIIAAAggggAACngr4fIDeouEb0q7HSFn9/SYJPnfeBM1ff7tROvUeJc0a1PC0n+IIuttVh8OKxCNYMihUmbvl9Vb316uUldT33xduqatXr4g3U7gGMAEBBLwmEPZYv3LliiRwitP1ew2SFSGAQDiBsO8vMR33p/ci+hLzvy0x3V9iUv7atRDRFJNlKHvFq/GBr3mHe4NjQowE7kahMVrMe4WfLfiE9OzYRBYu+Voq1mwlr9VrJ59+8Y2Z9twzBTxqSMb06SQ4+Kyr7OkzwZIpQ3rXuGb09vcbN25KyLVrOir69PiMGdKZvN7qPnj0dHmhQn2ZMWexzP1kuYyf9pGZlyhRYknkxWRWygABBBJEIOyxnjhxYvGnFB6VKQgg4C2BsO8vMR33p/ci+hLzvy0x3V9iUj4oKJFoiskylPVufOBr3t563/TX9QTZoWMaiOuD25bNmyDLF0yWWRMGik7ztO0lihaSDVu2ydWQEDl95qz8+fdeKVL4SbP4rzv+ss4KXjd5fRjdmrWbTV6v2JcocvvhdDPH95fNq+aZ1LxhTWlQu4p0aPmWKeftPyJmpQwQQCBBBLx9vHt7fV5HZYUIIOAS8PbxzvpiHgQHqlmiRIlEU6D2n37H/FhxvbGRuSeBoHtayosL7fnfQXGmCxcuydmz513jOt2TpuTM8aBUr1xWmrTrLx16jZKOrRtI0iRJzKLdBrwrZ8+dN/kOLevJ8lXrzc+sHTh4ROrVrGymM0AAAQQQsJ8ALUYAAQQQQAABBOwmEOTrDX6n21CJKnna/lrVKsi8acNl7tShUrrYs67FvlkyQzKkT2vG9XXqmD7mZ9aG9W0vKZInN9PdB2/XrSqtGtd2n0QeAQQQQCDwBOgxAggggAACCCAQ5wI+H6B/vXiaRJXiXIQKEUAAAQQQSHABGoAAAggggAACgSjg8wF6IG4U+owAAggggEC8ClA5AggggAACCPikAAG6T24WGoUAAggggIB9BWg5AggggAACCNybAAH6vbmxFAIIIIAAAggkjABrRQABBBBAwG8FCND9dtPSMQQQQAABBBCIuQBLIIAAAgggkHACPh+gT561QKJKCUfHmhFAAAEEEEAAgRgKUBwBBBBAAIEoBHw+QL8vVUqJKkXRN2YhgAACCCCAAAIBJUBnEUAAAQTsLeDzAXqjOlUlqmRvflqPAAIIIIAAAgjYRoCGIoAAAgjEs4DPB+ju/d+5a4/MWfCFzJiz2JXc55NHAAEEEEAAAQQQsKsA7UYAAQQQsE2APnv+Mhk1cbYsW/GdnDp91nr9Xg7+d4wtiAACCCCAAAIIIIBA9AKUQAABBGwgYJsA/etvN8j7EwdK5ozppWfHprJk7ni5cvWqDYhpIgIIIIAAAggggIC/C9ihf5evXJE+QydKvebdpH6L7rJ56/ZIm73pp+2mTMPWvaX/iCnW5+4QU/bQ4aNSrloTKVymlrxSs4Wp7+y5C2beufMXzHSd50x//PWvmffn33useiZL2WqNpVr9djJk7HS5GnK7TlOAAQIIGAHbBOgpU6aUxIkTS8i1a3Lj5k1JniypBDkcphMMEEAAAQQQQAABBBDwY4EYdW3uwi9k229/hltmxpxPTVA8f8Yo6d+ttfQY+K5cvHQ5XDkNtLsPGCcDur8jc6YMlavWRbHZ85aYcunSppGF74+Rn79bJLMnDZbrN27I7Pm352mBVClTmHk6X1OBx/LqZEmaJIk0qV9Dvl02WyaN7CW79+yXRUu/NvMYIIDAXQHbBOipUiSXa9euS66c2WXImBkyacZ86w3m+t2ekEMAAQQQQAABBBBAAAE5cOiwnDl7LpzEmrWbpXa1V8z0fHlySr7cOWXD5l9ExExyDdZu3CqPPZpb8uZ+yEx7vUo5WbNus8mntD6TZ0if1uT11SHWfx5cNNO6Hsr+oFkuR7Ys8nSBR+Xw0RNmnAECCNwVsE2A3vmdRubqecdW9SVH1sySzLqC3rtT07s9IYcAAggggAACCCCAAAIRCty6dUuOnzglOXNkdc3PkT2LHIkgSD5mlcuRNYurnC5z+Mhx17jemq63sBerUE9uWf+1aVrHNe/ylatSomJ9ebVOa3NBTS+wiWvu7cyJk6flq9XrpFSxZ29PYIgAAi4B2wTouR/OJnrLzH2pUkrj+tWlecOakjFDOldHyCCAAAIIIIAAAgggEKgCw9+d6fr+tz5UufuAca7xtT9sNSwOh3W1O+jux/8gx928KeA2cAQ5XGNB1nIa4DsnJEua1NzG/uXCKaKfzSfN/NjMSpkyhaxYNE3WfTVXenZoJhu2/CKzPvrUzHMOLly8JO90GyKN6lSTF54r6Jwcq1cWRsCfBCI/Kn2slwf/OypTZ38ibbsPl5adB7uSjzWT5iCAAAIIIIAAAggg4HWBnh2bmaBZv/ddrVIZGTmgk2v8xeLPicPhMBe3Tp0OdrXt5Okz8mCWjK5xZ0Yfynz6zFnnqJy0lsme7e4VdeeMLJkySLnSReWHH381kxInSiQZ0qWRREFBUrzIM9LgzaqyY+c/Zp4O9FlSXfqOlsb1Xpe3ar+mk+yQaCMCXhWwTYA+ZOwMeeCB1FK/VmVpYl1BdyavarEyBBBAAAEEEEAAAQRsKlDWCqaXfrXGtP7IsROy869/pUTRQmZ838HDst9KOlKqeGHZ/vsuOXz09m3tn69cK2VLFdVZsmffQTkTfPv77Rpwr1m7WZ564hEzTx8uZzLW4PKVK7LOunL/9JP5rTERndep9yip8Vp5eaVsCTONgQqQEAgtYJsAPfX9qaRujYpS5Nmn5LlnCrhS6O4whgACCCCAAAIIIIAAAhEJtGhUU4LPnpe6zbpJ135jZHDvtuYWdS278LMVsmjZ7aeqp0l9vwzp3U669R8r+jNrly9fkcb1X9diZvk6TbuY2+f1O+i79x6QVm/XNvP0p9n0u+madB15cj0kzRq8YeZ9sfJ72fLzb9Jz0HizrJbpNXi8mccgHgWo2nYCtgnQ9acZ9h04bDtgGowAAggggAACCCCAgDcF+nRp6bri7b7eFMmTy4h+HeXjmaNk3vSRob4D3qNDU+natrGreLHnC5oyc6YMlYE9WpufONaZzz79uHz96QzX7fNzpgwzt87rPL0yrrfYa1r60URp2aiWud1d59WvVcW1jM7XNKxvB51FsrEATY97AdsE6Hv3/yd1rLN9b7Xq5fr+uX4XPe5JqBEBBBBAAAEEEEAAAQQQQCCBBQJy9bYJ0Du1fksmjugh7ZrX5TvoAbmr0mkEEEAAAQQQQAABBBBAIK4EfLMe2wTo7t87d8/7JiutQgABBBBAAAEEEEAAAQQQCFiBe+y4bQL0nbv+lS59x0il2q1N6tp/rOzcteceu81iCCCAAAIIIIAAAvEtEPy/NfK/73qQbGxwcIScfPoAABAASURBVH1f0cR2tPd+rMdifB/v1B83Ap4G6HGztljUMnTcTMmZ40F5b1Rvk3JkyyLDx8+KRY0sigACCCCAAAIIIBCfAiEXj8mlE3+QbGxw+eRO0cR2tPd+rMdifB7r1B13Aj4SoEffoVu3bknb5vUkV85sJrWz8iEhIdEvSAkEEEAAAQQQQAABBBBAAAEEbCBgmwD95s2bcib4nIv05Kkzrny0GQoggAACCCCAAAIIJKjAlz+el5YTD5MwYB/w0j6gx1yCHvSs/J4EbBOg16lRSWo36er6ibW6zXtI/Zqv3lOn43oh6kMAAQQQQAABBBCIWuDI6Wuy7d/LJAzYB7y0D+gxF/VRyVxfFLBNgF6tUhmZPWmglCtdxKTZkwbJaxVf8kXTuG4T9SGAAAIIIIAAAggggAACCASAgG0CdN0W2bNmkTdee9mk7Fkz6yRSrAWoAAEEEEAAAQQQQAABBBBAwBcEfD5Af6FCffn9z92irxElX0CkDVEIMAsBBBBAAAEEEEAAAQQQQMAjAZ8P0DevmidPPp5P9DWi5FEvKeS3AnQMAQQQQAABBBBAAAEEEPAXAZ8P0J3QY9+b68y6XgePmeHKk0EgHgSoEgEEEEAAAQQQQAABBBDwmoBtAvTde/eHQ/lz1+5w05iAgH0EaCkCCCCAAAIIIIAAAgggcFfA5wP0L75ea35a7d+9B8xry86DzWvD1r0l98M57vaEHAIIhBZgDAEEEEAAAQQQQAABBGwl4PMBeqGnHpMm9atLlkwZzKvmNQ3v116G9mlnK2wai4A/CdAXBBBAAAEEEEAAAQQQiFsBnw/Q9efUnnumgMybPlz01ZmyZskUtxLUhgACviRAWxBAAAEEEEAAAQQQCDgBnw/QnVukSbv+Enz2nHNUTp0JlqbtB7jGySCAAAKeC1ASAQQQQAABBBBAAAHfE7BNgH7p8hVJ80Bql2D6tGnk/IULrnEyCCCAgM8I0BAEEEAAAQQQQAABBO5BwDYB+tWrIXLo8DFXFw8dPirXr990jZNBAAEEAkWAfiKAAAIIIIAAAgj4p4BtAvQGb1aRDr1Gyow5i03q0GuUNKr7mn9uFXqFAAIIJJwAa0YAAQQQQAABBBBIIAHbBOjVKpWRcUO6yfkLl00aP6y7VKnwYgKxsVoEEEAAgXsTYCkEEEAAAQQQQACByARsE6BrBx7KnkU6v9PAJH26u04jIYAAAggg4BIggwACCCCAAAII2FjANgG6fue8XY8RUvPtzob7793/k2kfLjJ5BggggAACCHhDgHUggAACCCCAAALxKWCbAH3gqOlSqXwJ0ae3K8gjeR+WjZt/1SwJAQQQQAABfxCgDwgggAACCCAQ4AK2CdBDQkLklbIlRBxi/jkcDrl5i6e4GwwGCCCAAAIIRCtAAQQQQAABBBDwdQHbBOi3bolcv37d5Xny1BlJkjixa5wMAggggAACCCSgAKtGAAEEEEAAgVgL2CZAr129gvQb/p4cO35Kpn+4WJp1HCgNavMza7HeA6gAAQQQQAABGwjQRAQQQAABBAJBwDYBeuWXS0mbZnWkTMnn5Nz5izJhWA8pW7pIIGwj+ogAAggggAAC8StA7QgggAACCPiEgG0CdNXKmiWTtG1eT2pWqyA/b/9DQq5d08kkBBBAAAEEEEDAhwVoGgIIIIAAAp4J2CZAb9Smr1y4eEkOHT4mHXuNlE0/bpehY2d61kur1KJlq6R+y57SoFVvWb95mzUl/P/6vfY23YZJ47b9pNfgCXL5yhVTaOeuPVL+9ebyQoX60rB1b1m5ZqOZzgABBBBAAAEEEEhwARqAAAIIIOA3ArYJ0OXWLbkvVUrZ8vNvUuWVF2XM4C7yz559Hm2I/QePyNyFy2X6uH4yakBHK7CfIVeuhoRbdsL0+VK08NMye9IgSZ36fpm/eIUpkyNbZlky913ZuHKudGnTSCZMn+cK3k0BBggggAACCCCAgJ8K0C0EEEAAAe8J2CZAv3nzlgmqf/ntT3kifx4jFOTwrPkbt2yT0sULS6qUKSRL5gySP18u2brtDwn77wfrqnzll0uayZXLl5SNP/5q8qnvv0/uvy+VJAoKkgeswN1hrVfbY2YyQAABBBBAAAEEELhXAZZDAAEEEHAT8CzCdVsgobIaYNdr3kMOHT4uzz79mBw7cUqSJ0/mUXNOnDotWbNkdJXNnjWzHD95yjWumYuXLovDIZI2TWodFb1qfuLkaZPXwa87/jK3uNdp1k2G9mlrgn2dTkIAAQQQQAABBBDwVQHahQACCNhLwDYBepP61eWzOePko6nDJHHixJIsaRLp3bmZx9oO6+q3s7DDYUXizhG316BQZULTPPPUY+YW9/cnDpTRE2fL6TNnzZKXLl0UbyazUgYIIJAgApcvXxL35M1j3xvrShBUVooAAkbg0qVL1ueJ2CTvfh7x9D3pmr8/0NdsPQYI+L6AHoueHrexLef7Gr7dwtBRqG+31dW6vsMmS5oHUkvunNld06LKZEyfToKDbwfUWu70mWDJlCG9Zl1Jb3+/ceOm68nwp6wyGTOkc83XTKKgIHN7fOZMGeTvf29//z1FipTizaTtICGAQMIIJEuWXJK5JW8e+95YV8KoslYEEFCBFCmSW58nYpO8+3nE0/ekJEmSaPdI9yjAYgjElYAei54et7EtF1dtDtR6bBmg79r9vxhtrxJFC8mGLdvkakiIufL95997pUjhJ00deuv6tWvXTb7Y8wVlzdrNJr/6+01SokhBk/937wG5dPn2E90PHT4qe/f/J/lyP2TmORwOcTi8l8xKGSCAQIII6F027snh8N6x73DE/7oSBJWVIoCAEXA4gsQRqxT/7xEOR8zXYTrHwFcFaFeACTgcMT+GHY6YLxNgrHHe3aA4r9EHK8yZ40GpXrmsNGnXXzr0GiUdWzeQpHfO6HYb8K6cPXfetLpDy3qyfNV68zNrBw4ekXo1K5vp/x09IVXrtTPfQa/bvIe8+XpFyZA+rZnHAAEEEEAAAQQQQAABBMIKMI4AAvciEHQvCyX0Mv26toxxE2pVqyDzpg2XuVOHSuliz7qW/2bJDFewrUH31DF9zM+sDevbXlIkT27KaXktt3nVPFn/5YdSt0ZFM50BAggggAACCCCAAAIIJIAAq0TATwVsE6D/s2e/XL5y+zbzA4eOSJ+hk0VvN/fT7UK3EEAAAQQQQAABBBBAIIEEWC0CCSVgmwB90Ohpog832Llrj3yydJU89kguGTJ2ZkK5sV4EEEAAAQQQQAABBBBA4F4EWAaBSAVsE6AnSZxYEidKJD9t+0OqvFLafD/8wsVLkXaMGQgggAACCCCAAAIIIIBA4AnQYzsL2CZAv2Up7ztwWDZv3S5PPp7PGhO5ceOGeWWAAAIIIIAAAggggAACCCDgBQFWEa8CtgnQ365TVUZMeF8eyfOw5M+XS/Q76RnTp4tXHCpHAAEEEEAAAQQQQAABBBDwnkCgr8k2AXrp4oVl2ti+0qVNQ7PNHsmTUyaO6GHyDBBAAAEEEEAAAQQQQAABBBCIRsDnZ9smQP/i67Wi3zm/fuOGDB49XarUaSM//LTd54FpIAIIIIAAAggggAACCCCAQCAIxL6PtgnQFy1dJfelSik//vy7FahflNGDOsvU2Z/EXoAaEEAAAQQQQAABBBBAAAEEEPABgSgDdB9on6sJyZIlNfltO/6UUsUKm++hOxwOM40BAggggAACCCCAAAIIIIAAAnYXSMgAPUZ2SZIkliXL18j6Tb9IoacfE73V/fr16zGqg8IIIIAAAggggAACCCCAAAII+KqAbQL0Hu2byMnTZ6Rlo1ryYOaMsv/gYSlZtFAUrsxCAAEEEEAAAQQQQAABBBBAwD4CtgnQH34oqzRvWFPKli5idPM8nENaN3nT5BNkwEoRQAABBBBAAAEEEEAAAQQQiEMB2wToO3f9K136jpFKtVub1LX/WNm5a08cUvhWVbQGAQQQQAABBBBAAAEEEEAgsARsE6APHTdTcuZ4UN4b1dukHNmyyPDxswJra8Vdb6kJAQQQQAABBBBAAAEEEEDAxwRsE6DfunVL2javJ7lyZjOpnZUPCQnxMU6ac1uAIQIIIIAAAggggAACCCCAQEwFbBOg37x5U84En3P17+SpM648mQAToLsIIIAAAggggAACCCCAgB8K2CZAr1OjktRu0lVadh5sUt3mPaR+zVf9cJPQpYQWYP0IIIAAAggggAACCCCAQEII2CJA198816e2z540UMqVLmLS7EmD5LWKLyWEGetEIDYCLIsAAggggAACCCCAAAIIRChgiwA9caJEMnPuZ5I9axZ547WXTcqeNXOEHWIiAoEtQO8RQAABBBBAAAEEEEDArgK2CNAVN1myJPL37v9ploQAAgklwHoRQAABBBBAAAEEEEAg3gRsE6D/d+S4NGrTV+o07Wq+g+78Lnq8yVAxAgh4XYAVIoAAAggggAACCCAQyAK2CdA7tnpLJo7oIZ3eaShN6ld3pUDeePQdAQRiJEBhBBBAAAEEEEAAAQR8WsA2AfpzzxSQiJJP69I4BBAIIAG6igACCCCAAAIIIIBA7ARsE6A3addfgs+ec/X21Jlgadp+gGucDAIIIODXAnQOAQQQQAABBBBAwO8FbBOgX7p8RdI8kNq1QdKnTSPnL1xwjZNBAAEEELh3AZZEAAEEEEAAAQQQSHgB2wToV6+GyKHDx1xihw4flevXb7rGySCAAAII+KwADUMAAQQQQAABBBDwQMA2AXqDN6tIh14jZcacxSZ16DVKGtV9zYMuUgQBBBBAwL8F6B0CCCCAAAIIIOAfArYJ0KtVKiPjhnST8xcumzR+WHepUuFF/9gK9AIBBBBAwHcFaBkCCCCAAAIIIOAlAdsE6OrxUPYs0vmdBiZlz5pZJ5EQQAABBBCwtQCNRwABBBBAAAEEnAK2CtCdjeYVAQQQQAABBDwSoBACCCCAAAII2EiAAN1GG4umIoAAAggg4FsCtAYBBBBAAAEE4lKAAD0uNakLAQQQQAABBOJOgJoQQAABBBAIMAHbBOhj35sbbtMMHjMj3DQmIIAAAggggAACnghQBgEEEEAAAV8TsE2Avnvv/nB2f+7aHW4aExBAAAEEEEAAAR8QoAkIIIAAAgjEWMDnA/Qvvl4rLTsPln/3HjCvmtfUsHVvyf1wjhh3mAUQQAABBBBAAAH7C9ADBBBAAAF/FPD5AL3QU49Jk/rVJUumDOZV85qG92svQ/u088dtQp8QQAABBBBAAIGEFWDtCCCAAAIJIuDzAXr2rJnluWcKyLzpw82r5jVlzZIpQcBYKQIIIIAAAggggEDsBFgaAQQQQCBiAZ8P0J3NPvjfUZk6+xNp2314qFvdnfN5RQABBBBAAAEEEEBAREBAAAEEbCtgmwB9yNgZ8sADqaV+rcqhbnW3rTwNRwABBBBAAAEEELChAE1GAAEE4k/ANgF66vtTSd0aFaVvZc9WAAAQAElEQVTIs0+FutU9/mioGQEEEEAAAQQQQAABLwuwOgQQCGgB2wToSZMkkX0HDgf0xqLzCCCAAAIIIIAAAgjERoBlEUDAtwVsE6Dv3f+f1GnWTd5q1YvvoPv2PkXrEEAAAQQQQAABBAJTgF4jgEAsBWwToHdq/ZZMHNFD2jWvy3fQY7nRWRwBBBBAAAEEEEAAAfsJ0GIE/F/ANgG6/rRaRMn/NxE9RAABBBBAAAEEEEAAgXgXYAUI+ICAzwfoLTsPlj37Doa6rV2nOZMPGNIEBBBAAAEEEEAAAQQQQCBKAWYi4ImAzwfoTepXl8wZ04e6rV2nOZMnnaQMAggggAACCCCAAAIIIODHAnTNTwR8PkDX29rvS5Uy1E+r6TRn8pPtQDcQQAABBBBAAAEEEEAAAR8VoFneEvD5AN0JsXPXv9Kl7xipVLu1SV37j5Wdu/Y4Z/OKAAIIIIAAAggggAACCCBgRwHa7BKwTYA+dNxMyZnjQXlvVG+TcmTLIsPHz3J1hAwCCCCAAAIIIIAAAggggAACYQXsNG6bAP3WrVvStnk9yZUzm0ntrHxISIjH1ouWrZL6LXtKg1a9Zf3mbREud/LUGWnTbZg0bttPeg2eIJevXDHlft3xl/QYNF7KVW8mTdsPkHWbfjHTGSCAAAIIIIAAAggggAACCAS0QJx23jYB+s2bN+VM8DlX5zWYdo1Ek9l/8IjMXbhcpo/rJ6MGdJShY2fIlavhg/sJ0+dL0cJPy+xJgyR16vtl/uIVpuaUKZJLlzaNZNVn06Xhm6+Z5c0MBggggAACCCCAAAIIIIAAAgjEkUD4AD2OKo7raurUqCS1m3R1/dxa3eY9pH7NVz1azcYt26R08cKSKmUKyZI5g+TPl0u2bvtDwv774cftUvnlkmZy5fIlZeOPv5r8o1b5DOnSSKKgIClR9Bm5du2a6+q6KcAAAQQQQAABBBBAAAEEEEAAgVgKeD1Av9f2VqtUxrqyPVDKlS5ikl7lfq3iSx5Vd+LUacmaJaOrbPasmeX4yVOucc1cvHRZHA6RtGlS66jkyJZZTpw8bfLug6Vffit5c+eUFMmTm8l66703k1kpAwQQSCCBW9Z67yZvHvveWJfVOf5HAIEEEvDGMZ4Q60ggTlaLAAIRCHjrPSCCVTMpBgK2CdC1T9kezCyFnnrCJA2ydVqYFOmow7r67ZzpcFiRuHPE7TUoVJnwNDt2/iPzP10h/bq2cC11+fIl8WZyrZgMAgh4XeDixUvinrx57HtjXV4HZYUIIOAS8MYxnhDr0LsOXZ0kgwACCSagx6K33gMSrJN+suLwUaiPdmzFN+ulSp22MmDkFOk5+F2p/OY7snLNRo9amzF9OgkOPusqe/pMsGTKkN41rhm9/f3GjZsScu2ajsopq0zGDOlMXgd6NX3yrAUyeVRP6+p6Fp1kUsqUqcSbyayUAQIIJIhAqlSpxD1589j3xroSBJWVIoCAEfDGMZ4Q60iSJInpHwMEEEhYAT0WvfUekLA9tf/abROgf75yrXw2d5zMnTpUPnl/jMyZMlQ++HipR1ugRNFCsmHLNrkaEiKnz5yVP//eK0UKP2mW1Se0X7t23eSLPV9Q1qzdbPKrv98kJYoUNHl9IF3voZOkV8dm8mDmu7fKm5lxOaAuBBBAAAEEEEAAAQQQQACBgBWwTYCe9oH7JVnSpK4NZR7aliixazyqjP5+evXKZaVJu/7Sodco6di6gSS9c0a324B35ey582bxDi3ryfJV683PrB04eETq1axspi/+fLX8/uduqdOsm7xQob5JR4+fNPPsNKCtCCCAAAIIIIAAAggggAACvisQ5LtNC92yBx5ILfMXfyXHT56WPfsOysQZ86XY80+HLhTFWK1qFWTetOHmCnzpYs+6Sn6zZIZkSJ/WjOvr1DF9RB9AN6xve9eD4Fo1ri2bV80LlbJkymCWYeASIIMAAggggAACCCCAAAIIIBALAdsE6F+s/F4mz1ogVeu1k/otesqCz1bKx5+uMFez9ap2LAxY1BYCNBIBBBBAAAEEEEAAAQQQ8G8B2wToYa9ghx33781E7+JdgBUggAACCCCAAAIIIIAAAgksYJsAXa+Yh7Wa9dFnYScxjoBPCtAoBBBAAAEEEEAAAQQQQCA6AdsE6Os3/yLrfvjZ1Z8PF3wuO3budo2TQSCABeg6AggggAACCCCAAAII+IGAbQL0Ef06yIw5n8pf/+w13z3f9NN2GT2okx9sArqAgK8L0D4EEEAAAQQQQAABBBDwhoBtAvQHUt8nI/p3kL7DJsu6TT/LhOHdQ/3smjewWAcCCMSDAFUigAACCCCAAAIIIICAEfD5AL1l58HiTEPHzZQbN27K1ash0rH3aDPd9IIBAgggEIkAkxFAAAEEEEAAAQQQsIuAzwfoTepXF/fUq1NTeafpm65pdoGmnQgg4JcCdAoBBBBAAAEEEEAAgTgT8PkA/blnCkhUKc4kqAgBBBDwOQEahAACCCCAAAIIIBBIAj4foDs3RpN2/SX47DnnqJw6EyxN2w9wjZNBAAEEEIihAMURQAABBBBAAAEEfErANgH6pctXJM0DqV146dOmkfMXLrjGySCAAAII+JYArUEAAQQQQAABBBCImYBtAnR9MNyhw8dcvTt0+Khcv37TNU4GAQQQQCCgBOgsAggggAACCCDgdwK2CdAbvFlFOvQaKTPmLDapQ69R0qjua363QegQAggggIAvCNAGBBBAAAEEEEDA+wK2CdCrVSoj44Z0k/MXLps0flh3qVLhRe+LsUYEEEAAAQRiK8DyCCCAAAIIIIBABAK2CdC17ZkzpZNK5UtI53caSPasmXUSCQEEEEAAAQTCCDCKAAIIIIAAAvYUsE2Avumn7VKtXnvpP+I9I71r9//MLe9mhAECCCCAAAIIeEuA9SCAAAIIIIBAPAnYJkCfPGuBzJwwQNKlTWMo8ufLJSdOnjF5BggggAACCCDgLwL0AwEEEEAAgcAVsE2AniRx4nC3td+SW4G75eg5AggggAACCMRcgCUQQAABBBDwYQH7BOhJEsvpM2ddlNt2/OW6mu6aSAYBBBBAAAEEEEhAAVaNAAIIIIBAbARsE6B3adNIBo2eJv/uPSAtOw2WEeNnSbvmdWPTd5ZFAAEEEEAAAQTsJEBbEUAAAQT8XMA2Abp+53zckK4yoHtrqVmtvCyYNVoeyZPTzzcP3UMAAQQQQAABBLwlwHoQQAABBBJawDYBukIFBQVJiaLPSNlSRSVRkK2ars0nIYAAAggggAACgStAzxFAAAEEohWwTZS7ccuv0qzDQClZqaG8UKG+K0XbQwoggAACCCCAAAII+L0AHUQAAQT8QcA2Afq4KXOlRaM35LvP35fNq+a5kj9sBPqAAAIIIIAAAggg4NMCNA4BBBDwioBtAvTU96eSwgWfkCRJEnsFhpUggAACCCCAAAIIIOAdAdaCAAII3BawTYBe+Jkn5MMFn0vwufO3W84QAQQQQAABBBBAAAEEohegBAII2EbA5wN05/fN5y/+SqZ/uFgq1mzl+v65zrONNA1FAAEEEEAAAQQQQMAPBegSAgjEnYDPB+ju3zePKB93FNSEAAIIIIAAAggggAACPiZAcxAIKAGfD9CdW2PP/w7KxUuXnaNy4eIl2bPvoGucDAIIIIAAAggggAACCCAQMwFKI+BbArYJ0PuPmCJJkyRx6enD4voPn+IaJ4MAAggggAACCCCAAAII+JQAjUEghgK2CdCv37ge6gnuyZImlashITHsLsURQAABBBBAAAEEEEAAAf8QoBf+J2CbAN3hcMiPv+xwbYHNW38LdUXdNYMMAggggAACCCCAAAIIIIBAbAVYPgEEbBOg9+ncXMa+N0dadh5s0vhpH0nvzs0SgIxVIoAAAggggAACCCCAAAIIxE6ApSMSsE2A/kT+vLJg1mipVa2CSQtmjpLHH80TUZ+YhgACCCCAAAIIIIAAAgggEMgCNu27bQJ09U0UFCRlSj4vx46fkiArr9NICCCAAAIIIIAAAggggAACCHhTIL7WZasA3Ymw5Ms1ziyvCCCAAAIIIIAAAggggAACCPiFwJ0A3S/6QicQQAABBBBAAAEEEEAAAQQQsK2AdwL0OOZ5/dVycVwj1SGAAAIIIIAAAggggAACCCCQsAK2CdC37fjLJVWnRkWT159a0wwJAQQQQAABBBBAAAEEEEAAAbsL2CZAHz3pQ9l38IjL+6dtv8u7U+e6xuMxQ9UIIIAAAggggAACCCCAAAIIxLuAbQL0gT1aS8+B4+RM8Dn51bqaPmbyhzJuSLd4B4r/FbAGBBBAAAEEEEAAAQQQQAABBERsE6A/kientGleTzr0GilDx82U0QO7SPasmdmG0QkwHwEEEEAAAQQQQAABBBBAwBYCPh+gz5izWJxp51+75eatW/Jovlyy6ruNZrotlP24kXQNAQQQQAABBBBAAAEEEEAgbgR8PkAP282SRZ+RnNmzhJ3MuH8K0CsEEEAAAQQQQAABBBBAIGAEfD5Ab96wpkSVAmZL0dF4EKBKBBBAAAEEEEAAAQQQQMB3BHw+QHen2rlrj8xZ8IW5td1527v7fPII+JQAjUEAAQQQQAABBBBAAAEEYiBgmwB99vxlMmribFm24js5dfqs9fq9HPzvWAy6SlEE/EuA3iCAAAIIIIAAAggggIB/CdgmQP/62w3y/sSBkjljeunZsaksmTterly96l9bg94g4DsCtAQBBBBAAAEEEEAAAQS8LGCbAD1lypSSOHFiCbl2TW7cvCnJkyWVIIfDy1ysDgEE4kaAWhBAAAEEEEAAAQQQQCCsgG0C9FQpksu1a9clV87sMmTMDJk0Y75cDbketj+Rji9atkrqt+wpDVr1lvWbt0VY7uSpM9Km2zBp3Laf9Bo8QS5fuWLKnQk+J136jpGXqjaRURM/MNMYIICADwvQNAQQQAABBBBAAAEEbChgmwC98zuNzNXzjq3qS46smSWZdQW9d6emHpHvP3hE5i5cLtPH9ZNRAzrK0LEz5MrVkHDLTpg+X4oWflpmTxokqVPfL/MXr3CVqfRyKWn2Vg3XOBkEEAhcAXqOAAIIIIAAAggggEB8CNgmQM/9cDZJnDiRHPzvqDSuX130p9cyZkjnkcnGLdukdPHCkiplCsmSOYPkz5dLtm77Q8L+++HH7VL55ZJmcuXyJWXjj7+afNo0qaVMyeclRYpkZpwBAgggEI8CVI0AAggggAACCCAQoAK2CdA3/bRdqtVrL/1HvGc21a7d/5MOvUaafHSDE6dOS9YsGV3FsltX4I+fPOUa18zFS5dFv9KuwbiO58iWWU6cPK3ZKNONGzfEmynKxjATAQTiVcCbx3r8rSvy96x4xaNyBBCIUiAhjnlvrPPWrVtR9puZCCDgHQE9Fr1xzOs6vNMj/12LbQL0ybMWyMwJAyRd2jRma+hV8BMnz5i8JwNH0N2uOhwRP1wu8iLs8gAAEABJREFUKFSZu+Wjqv/atWvizRRVW5iHAALxK+DNYz0h1hUnelSCAAL3JJAQx7w31smH9XvaHVgIgTgX0GPRG8e8riPOGx9gFXoWhfoASpLEiUWvfLs35ZZ4dlY2Y/p0Ehx81rXo6TPBkilDete4ZvT29xs3bprvuev4KauMJ7fQJ0+eXLyZtG0kBBBIGAFvHusJsa6EUY3ZWimNgL8KJMQx74116i/w+Os2o18I2ElAj0VvHPO6Dju5+GJb7ROgJ0ksp8/cDbK37fjLdTU9OtgSRQvJhi3b5GpIiKnjz7/3SpHCT5rFfrXq0afD60ix5wvKmrWbNSurv98kJYoUNHkGCCCAAAIBIUAnEUAAAQQQQACBBBWwTYDepU0jGTR6mvy794C07DRYRoyfJe2a1/UIL2eOB6V65bLSpF1/6dBrlHRs3UCSJklilu024F05e+68yXdoWU+Wr1pvfmbtwMEjUq9mZTP9+o0b8kKF+uYn1pZ+9a3J/737f2YeAwQQQAABBDwToBQCCCCAAAIIIBC1QFDUs31nrn7nfNyQrjKge2upWa28LJg1Wh7Jk9PjBtaqVkHmTRsuc6cOldLFnnUt982SGZIhfVozrq9Tx/QxP7M2rG97SZE8uZmeOFEi2bxqXqj0aL5cZh4DBBBAAAEEfEKARiCAAAIIIICA7QV8PkDfu+8/ad11qLxUtYl06jNacj+cTcqWKiqJgny+6bbfOegAAggggAACTgFeEUAAAQQQQCD+BXw+yh0ydro8+XheGdjjHXkoexYZNfHD+FdhDQgggAACCCDgTQHWhQACCCCAAAKWgM8H6OfOX5BWb9eWUi8Uko6tGsj/9h+yms3/CCCAAAIIIICApwKUQwABBBBAwB4CPh+guzM6HA4J4tZ24R8CCCCAAAII+JAATUEAAQQQQCCOBHw+QP/vyHHz1HR9irqmo8dPhhqPIweqQQABBBBAAAEEfFKARiGAAAIIBI6AzwfoE0f0kKhS4GwqeooAAggggAACCMS5ABUigAACCPiQgM8H6M89U0CiSj5kSVMQQAABBBBAAAEEQgkwggACCCAQEwGfD9Bj0hnKIoAAAggggAACCASQAF1FAAEE/EyAAN3PNijdQQABBBBAAAEEEIgbAWpBAAEEvC1AgO5tcdaHAAIIIIAAAggggIAIBggggEA4AQL0cCRMQAABBBBAAAEEEEDA7gK0HwEE7ChAgG7HrUabEUAAAQQQQAABBBBISAHWjQAC8SJAgB4vrFSKAAIIIIAAAggggAAC9yrAcggEqgABeqBuefqNAAIIIIAAAggggEBgCtBrBHxWgADdZzcNDUMAAQQQQAABBBBAAAH7CdBiBO5dgAD93u1YEgEEEEAAAQQQQAABBBDwrgBr82sBAnS/3rx0DgEEEEAAAQQQQAABBBDwXICSCStAgJ6w/qwdAQQQQAABBBBAAAEEEAgUAfoZjQABejRAzEYAAQQQQAABBBBAAAEEELCDgP3bSIBu/21IDxBAAAEEEEAAAQQQQAABBOJbwAv1E6B7AZlVIIAAAggggAACCCCAAAIIIBCVgM4jQFcFEgIIIIAAAggggAACCCCAAAIJLBCPAXoC94zVI4AAAggggAACCCCAAAIIIGAjAfsG6DZCpqkIIIAAAggggAACCCCAAAIIRCdAgB6JEJMRQAABBBBAAAEEEEAAAQQQ8KYAAbo3te+uixwCCCCAAAIIIIAAAggggAACoQQI0ENx+MsI/UAAAQQQQAABBBBAAAEEELCbAAG63baYL7SXNiCAAAIIIIAAAggggAACCMS5AAF6nJNSYWwFWB4BBBBAAAEEEEAAAQQQCEQBAvRA3OqB3Wd6jwACCCCAAAIIIIAAAgj4pAABuk9uFhplXwFajgACCCCAAAIIIIAAAgjcmwAB+r25sRQCCSPAWhFAAAEEEEAAAQQQQMBvBQjQ/XbT0jEEYi7AEggggAACCCCAAAIIIJBwAgToCWfPmhEINAH6iwACCCCAAAIIIIAAAlEIEKBHgcMsBBCwkwBtRQABBBBAAAEEEEDA3gIE6PbefrQeAQS8JcB6EEAAAQQQQAABBBCIZwEC9HgGpnoEEEDAEwHKIIAAAggggAACCCBAgM4+gAACCPi/AD1EAAEEEEAAAQQQsIEAAboNNhJNRAABBHxbgNYhgAACCCCAAAIIxIUAAXpcKFIHAggggED8CVAzAggggAACCCAQIAIE6AGyoekmAggggEDEAkxFAAEEEEAAAQR8RYAA3Ve2BO1AAAEEEPBHAfqEAAIIIIAAAgh4LECA7jEVBRFAAAEEEPA1AdqDAAIIIIAAAv4kQIDuT1uTviCAAAIIIBCXAtSFAAIIIIAAAl4VIED3KjcrQwABBBBAAAGnAK8IIIAAAgggEFqAAD20B2MIIIAAAggg4B8C9AIBBBBAAAHbCRCg226T0WAEEEAAAQQQSHgBWoAAAggggEDcCxCgx70pNSKAAAIIIIAAArETYGkEEEAAgYAUIEAPyM1OpxFAAAEEEEAgkAXoOwIIIICAbwoQoHu4XRYtWyX1W/aUBq16y/rN2zxcimIIIIAAAggggEDACdBhBBBAAIF7FCBA9wBu/8EjMnfhcpk+rp+MGtBRho6dIVeuhniwJEUQQAABBBBAAAEE4laA2hBAAAH/FSBA92DbbtyyTUoXLyypUqaQLJkzSP58uWTrtj+EfwgggAACCCCAAAKeCRTKm0KaVUzr+4k2so38ZB/QY86zo5NSviRAgO7B1jhx6rRkzZLRVTJ71sxy/OQpM/7RRx+JN5NZKQMEEEgQAW8e6wmxrgRBZaUIIGAEEuKY98Y6d+zYYfqng2fzaYCezgr+Ajs1q0j/MfDOPqDHnB57mvRY9MYxr+vQ9ZHuXYAA3UM7R9BdKofD4Vrqxo3r4s00tNMbQsKAfSBh9gFvHusJsa6/Hn9HSBiwDyTMPpAQx7w31nkoJL9svVyD5D0DrLGOcB/QY9Ebx7yuQ/gXK4G7UWesqvHvhTOmTyfBwWddnTx9JlgyZUhvxuvVqyckDNgH2AfYB9gH2AfYB9gH2Af8fx9gG7ONo98HTJDE4J4FCNA9oCtRtJBs2LJNroaEyOkzZ+XPv/dKkcJPerAkRRBAAAEEEEAAAQQQQMAjAQohgIAQoHuwE+TM8aBUr1xWmrTrLx16jZKOrRtI0iRJPFiSIr4m0KzDQHmrVS9p1KavtOoyRLbt+MvVxPotesrJU2dc487M3E+Wy8efrnCOxupVT/I0bd9fbt68Kfrv370HpG334fL2nfaMmTxHLly8JKu++0HGvjdXi4RLy1Z8J3WadpUXKtSXM8HnXPN/2/m3NO84UIpXbCBr1m0R57/LV65I47b95NatW85JvCKAQDwLBJ87L4PHzBB9X9H3nDbdhsm6H342a506+xN5vUFHadl5sNRt3l0mzfxYrt+44Zqnx/bRYyfNuA7en7fUHO979/2no+FSl35j5NDho2a61jPro8/Mz4Jq/e17jpQfftxu5tVq3FnOnb9g8u6DyN47jh4/KcPfnSUVa7aSN5t2lTkLvnAtpn8LT5w87RongwACngvoZwE9ziNK+stBeszre4em6g06yM5de0zlzazPMFXrtTN556CN9RmiUu3WZlSPbz3OzUgcD/7+d58MHDXN1Lpn30HZEEc/OayfdfQzj6k4lgNP3pdiuQoWR8ArAgToHjLXqlZB5k0bLnOnDpXSxZ71cCmK+aJA1zaN5MPJg6V86aIyYdo8VxN7dmwqD6S+3zUeH5nlX6+V0sWfk6CgIBNc6wfo6q+WlQ+s9kwd00cqv1xSgs+ej3LVmTOml0G92kiG9GlDlUueLJm0aPiGvFi8cKjpKZInlwKP5ZH1cfTHNFTljCCAQIQCXfqOlVQpk8m86cPlo6nDpFnDGrJr9/9cZau88qJMG9tXpo7pKz9t++PuL4M4RHLlzCar1252lV37w1bJ9mAmcXv8iWveXitov3HjlmTPmsVMmznnU/nxlz/Mz4Jq/aMHdZLrd4J/UyCCQWTvHfo+9UbV8rJy8VQZ2qedLP58tez530FTQ9VKL8n8T78yeQYIIBAzgWRJk8rmVfNMatusrtSuXsHkdZqepF/21bcybmhX8/4xdXQf0b/jugZ9D0iVKoUrYD977oKcOXPWem+w3jisAilTppB+XVtaubj/f+7CL6Sm9X6gNf9v/3+yeetvmo11euO18lL4mSdiXY9W4APvS9oMEgKxFiBAjzUhFdhV4PlnnzRfWXC2X68UnbWueum4XjWv+XZn0atef7t9qP7hp+1Sr3kPc6V65ITZoleutLxeEZ88a4G5GtagVW9Z8c16nRwurf5+s5R64fYJnmUrvpciVhvKlHzeVe6xR3JbH7Qzm/EjR49Lux4jpHaTLrJo2SozTQcvPPe05MudU7Oh0qN5H5ZnCz5hgv9QM6yRktY6V1tX5a0s/yOAQDwL7Nj5jxw7cUraNa/nWtPTTzwqLRrVdI07M4kS3f4znCF9Guckc5Ltuw0/mXG9mvZg5gyiQXREN8Gs+n6jlCpWyJTV96EFS1ZKL+tko/4sqE7Uu73cTyp/uOBz0bt4WlpX751XwB+N5L0jU4Z0rveaPA/nkDy5csjhoydE/5Uo8ox8v2GrZkkIIBCHAqesgDu3dbzp8afV6s/75n44m2ZNKluqqKxZt9nkV3+/ScqUKmLyOrh06bIMGj1Ns7JwydcydNxMk9934LC80aiTXLkaIn/9s9fcvaN39nTpO0ZOnQk2ZfQzkC7bxroiP3Pup2aac3Dp8hX501ru8UfzmEmz5y+1rqD/YurRO/a+37hV9G6dOs26m89BWkivinfuO9pM17sA5i36Sj7+bKW5G7V116Guu3k+/eIb+fnXnebuQb36f+jwMV1c+gydLJ9+sdrktS5tb/2WPeXdqXPlxs2b5o5H/XzUa/AE0fr0jh//f18yHAwCQOD2J4MA6ChdRCCsgN7e/mKJu8Gxc/7e/YfkM+sPxswJA2R4v/bmmQM67/r16zJkzAzp3bmZuTrl/KOm875cvV5OnDwjH743RKaM6S2LPv9G9A+iznOma9eui37Y1q9M6LSD/x2Rp6wP7ZqPKB05dlKG9W1nXV0fIp8t/0b0ltmIynkyTQP/3//615OilEEAgVgKHDh0RJ54NLckTpw40ppmzFlsblsv/3pzyZk9qysQ1gXuu+8+SZP6PtHb3L/+dqOUf/EFnRxh2rFztzxundjTmXpSQK+06RV4HY8o6bxZEwbKy1ad8xZ/GVGRCKfplXP9YP/kE/nM/CRJEkuaB+6Xg//dvrXeTGSAAAKxFni+UAErkL5qvpo2etKHsv33XaHqLFr4Kdly5+r1t+t+lLJuAbp7wTdff0WOHT8lP2/fKYPHTJfenZqJHrcDR02V9i3qmTt7yr/0gkyYNt+12NWQazJxeHdp1uAN1zTN/Pn3HsnzcHbNmtS4XnLBrYgAABAASURBVHXRE/96l0650kVl8swFMqJ/e1kwc6RMGNbdlNHB0WOnZGiftvLBpEEy33q/SZ4sibw/caAUeiq/LP3yOy3iSvelSil9OrcwJxU2/bTd/JzxG6+9bD43fbjgC1Pv3ClD5WrIdVn+9Vqz3IFDR6VpgxoyZXRvyZIpg+kf70uG5t4GLOUzAgToPrMpaIi3BFp0GmQ+GE+cPt/cVhZ2vb/98be8VPI5SZP6frn/vlRStvTts9P/HTkhmTKkFT2D7HA4pGqlMq5Ff9n+p/yzZ7+54t2l31jRhwnu2r3XNV8zGtCnSxP6FnqrGp0VYXryiUdE/2ClTJFccuXMLgetP0QRFvRgotZz2ToDrmedPShOEQQQiKVAUNDdP6+9h0w07zkV3rh762nzhjXNLa1fLXzP+sB5Vb5dvyXUGjUoX/ntD7Ju08/mg3ComW4jJ06elozWlW7npKjeU7RMsecL6os8XeBR2XfgiMlHN9CTgz0Hj5c+XVqY90Vn+cyZ0ltX1I87R3lFAIE4EEieLKn5+ku3dm9LokQO6dRnTKi78hInTmR9DskretU6KFGQpEubWiJ7xky/ri2k56AJkjf3Q/LMU4+J3pl37MRpmWB9/tG7aD5bvkbcP6vo3TZBbu9dzu4cP3FKMqZP5xwN9/rk4/lkzKQ55jkVN91u9XF+jknzQGpJnz6NPPdMAbPsY9aV+H0HD5u8++Ap63NPvtw5ZPDo6aJt13m//bFLLl66LL2s91G9Uv6b9Rntz123P189lD2L5LY+H2k5Z+J9ySnhe6+0yHOBu58gPF+GkgjYWmD6uH6y+rPp5vveztu/wnYoUaJErkn6x1BH9BFroaa7lXE4HNK0/uvmj6qeUf5i/kR5pWwJXcyVElvlr9+46RrPke1B+f3P3a7xsJkkblffEgUFiV7BD1smJuNXQ0IkURCHfEzMKIvAvQg8lP1B+d+B/1wfmvX722uW3r7VNGx96dI+IIULFpAtP/9+e5a+0VgfcEsXLyxLv/rWnJzTD+y3Z4YfBgU55Nr162aGPp/i8uWrsu/gETMe0cD5vuJwBMmNGzciKhJqmp7UG2RdcevYqoGUeuH2rfTOAiHW1bYkPDDVycErAnEm4HA4JH++XNKpdUPp0qaBrFjzg6nbemsQ643FXDgYPekDKRfJ1XNT2Bpst4JZfQbF3WPdIfqVGf2comnGu/1l0eyxVsnb/0d2149+9nG+z9wuGXo4oHsrqW1dsb8lt8xXA/VWei3hfL/RfKKgIHOFW6x/iaz3rYg+02hbt+24fcfA9Rv6ZmgVtixKWu892l5NepW+V6em1gyRJImTmFf3Ae9L7hoBlferzgb5VW/oDAIeCuiV8dZN3pT91hncsLePPflYPvnFuiKu3+fUs9Jbt+00tWZ/MKOcOh0s+lAWnfDz9j/0xST9LrneLnr+wkUzvmffQQk+e87knYP06dLIhQuXXE9wr1bpJdm89TeZu3C5hFy7ZorpLaTO71+ZCXE00KfTa9AQR9VRDQIIRCGgV4FSpUwp/Ya/J3qFW4tevnJVX8Il84H0t52SwXp/cJ+pd700qVdN6tes7D45XF6vHh25873wIOsDsN7W2n/4ZNm9d78pq+8t6zb9YvIxHejXcvoPnyKVypcSffZF2OUPHz0u+awrc2GnM44AAvcuoLdt7913+xcb9ATZH3/tkfTWiTz3GosUfkr0M0SZO3f4uc9z5vXOl3enfmQuHOhD3fQZOlmzZDQn+1fdeSaNHuM7dv7jXCTS1zwP55Cjx0+55utXac66/SKEfvZ5JE9OaVSnqiROFBSqrGshDzJzFnwhObJllr7WlX99H9PPYYULPi5rN251PaBSf71mj/UZK7LqeF+KTIbpsRPw7tIE6N71Zm0+JKBPUdU/JmGfRJzX+sBZpmQR8/NnemuZBunabD2z3K19Y+k/4j3z0JOzZy/KfalS6SypWK6EFCtSUFp1HmJ+jqjvsMlWIH7n7K8pIeJwOMytqn/98z/Rf2nTpDZ/OLf++ofUbdbdnHX+avUGSfPA/To70qQ/0aQ/zaJBt/60Spd+Y0zZLT//Zm6j1Qe26PrLVW9mputgh3WlPuzT3XU6CQEE4kdgzODOkjRpUmnRabDUadZNOvUeLd3aNXKtTL9D2bLzYNGfTDp28ozUqVHRNc+ZqVqpjOjzI5zjEb2+WOI50ePbOa9Zwzes95lC0mvwRPMwpu4DxlsfmO/eEeQs5/4a2XvHL9aJA731vq/1fqbvOZqcD8DUE5CZMmYwXwNyr4s8AgjETuBqyFXpNWS8+fnVKnXayK+/75IWjUJ/JzxRUJDo12T0q3iRrW3s5DlS5/VKog+BHNq7rYyZ/KGcty4S6B09K77ZKA1b95bX6raVP+78hFtk9eh0/Vx03grI9YSBjhd6Or/cunnTfBbSzxx1m/eQ6m91kN5DJkr5F4vJwzke1GIxSvsPHpGvVq+X3p2ai34Vp8Dj+eT9eUska5ZM0vmdhua76fqguAZWu4ODQ18Aca6I9yWnBK+2EwjTYAL0MCCM+rfAzPH9Ra9uOXtZq1oFGT2wsxnVn0PKcOenyxq8WUXeG91b3h3aVWZPGiR136hkyhQs8KiMH9bdSt0kZcpk8uTjec10HTR7q4b5SZSFs0bLxzNGit66qtPdU40qZWXVdxtdk/SP3qSRPeXTD8fJ5FG9pEubhlbQn1IqlClu/UFq4Cqnf1D1+2M6oVXj2ua7q/pzLJrGDOqik6Vo4adDTXe/pfbb9T9K1YovmXIMEEAg/gX0g3PfLs1lydx3ZcHMUeYnOsuWKmpWrMewTtfbNfU76B9OHiyp77/PNc/5fmMm3Bno+1Nutyc535ksL5V8XrZu+8M5aoLxptZ70eIPxpqHMel7WHHr5KEW0FtZnevRuvQ9R6dH9t4Rdrq+3+jVdF1m9febzRU8zZMQQODeBfR479DyLVcF+XLnFP0coT+/uuKTKdb7x0gTpGoB/QzzaL5cmnUlPaa1nE7QvB7nmh/cq43Ur1VZs5IlcwZZOne8PJD6PtH6JwzvLnOmDDU/oVj3zsnBnh2bShnr/cQsEMFAP5ds2LTNzNEr6MP6thetp1zporL840my9KPxop9VGtevbspo+c7v3P0co+vTB7npTH1v0fZpXstoWX2Arr4v3pcqpU4W/Ulc58PqtF36WUx/slLX9WzBJ0Q/r+n7oil8Z8D70h0IXmwvEBTHPaA6BPxaQH+2pGLNVqJniy9duipVXnkxRv3VP6x6q1iMFoplYb3FVT+guz9IKpZVsjgCCPiIgN4J9ObrFV230nurWUmTJhH9YO6t9bEeBBBIWIHXq5STy1euJGwjolk770vRADHbNgI2C9Bt40pD/VSgiXVmeOXiqeaMdq9OTSXpPTwgSW9b9SaPtrFSuZLeXCXrQgABLwokxAm4apXKeLGHrAoBBBJaQB9WqV/nS+h2RLV+3pei0mGenQQI0N23FnkEEEAAAQQQQAABBBBAAAEEEkiAAN2L8KwKAQQQQAABBBBAAAEEEEAAgcgECNAjk7HfdFqMAAIIIIAAAggggAACCCBgYwECdBtvPO82nbUhgAACCCCAAAIIIIAAAgjEpwABenzqUrfnApREAAEEEEAAAQQQQAABBAJcgAA9wHeAQOk+/UQAAQQQQAABBBBAAAEEfF2AAN3XtxDts4MAbUQAAQQQQAABBBBAAAEEYi1AgB5rQipAIL4FqB8BBBBAAAEEEEAAAQQCQYAAPRC2Mn1EICoB5iGAAAIIIIAAAggggIBPCBCg+8RmoBEI+K8APUMAAQQQQAABBBBAAAHPBAjQPXOiFAII+KYArUIAAQQQQAABBBBAwG8ECND9ZlPSEQQQiHsBakQAAQQQQAABBBBAwHsCBOjes2ZNCCCAQGgBxhBAAAEEEEAAAQQQcBMgQHfDIIsAAgj4kwB9QQABBBBAAAEEELCXAAG6vbYXrUUAAQR8RYB2IIAAAggggAACCMSxAAF6HINSHQIIIIBAXAhQBwIIIIAAAgggEHgCBOiBt83pMQIIIIAAAggggAACCCCAgA8KEKD74EahSQgggAAC9hag9QgggAACCCCAwL0IEKDfixrLIIAAAgggkHACrBkBBBBAAAEE/FSAAN1PNyzdQgABBBBA4N4EWAoBBBBAAAEEEkqAAD2h5FkvAggggAACgShAnxFAAAEEEEAgUgEC9EhpmIEAAggg4InAJ0tXyQsV6suyFd+5it+6dUuq1GkjFd5o6ZrmaWbrr39Im27Doi3+wcefy+RZCyIt16rLENmz72Ck86ObsWPnP9KkXX9TTPON2/Yz+bADT9v7y/ad8uMvv7sWj6pOV6EYZkq/+rZcDQmJ4VKRF58xZ7HM+mhJ5AUSeM6hw0elS78xotv6Z8tXmxPbpPvVpJkfm2o0H9U+poWu37ghdZt3l+Bz53WUhAACCCCAQKwECNBjxcfCCCCAAAIOh0je3A/Jim82uDA0aE2TJrXoPNdEL2Y0EE6ZIpnkeThHnKw198PZpWvbRrGq69ff/5Ztv/3pqiMu6nRVFqAZ3ecefzSvTB3TRwoXfCJOFF4pW0yqVSoTWV3hpidOlMiUn7foy3DzmIAAAggggEBMBQjQYypGeQQQQACBcAJ5cz0kly5fEb2iqTO/Wr1BKpUrqVlXWvfDz9K0fX9p1KavtO85Uv63/z/XPL1KWfPtztK661BZa5VzzbAyi5atkrda9TKp1+AJcupMsDU16v81cCtbqogppFeUy7/eXM6dv2DGdTB+2kcyc+6nmpU+Qyebq/1vNu0qQ8fNlMtXrpjp7oO9+w7J6EkfuiZF1t7TZ86aduoV1dpNusi8RV+ZZbSvX32zXlZ9t0ladh4siz9fLWHrfH/eUqnfsqc0aNVbBo+ZIRcuXjLL6lVs7Xeb7sON3/Dx74tetTUzoxj8tO13adFpkDRs3du8/vn3HlM6sjbqzOCz56Tn4PGmHe9Y22LfgcM62SR1GfveXKnTrLvUa97D3L1w8+ZNM0/7NGriB+bOh8Gjp5tp7gPtQ49B4818XV7747zifPC/o9Jj4LtSv0VPY7dyzUbXolHV+8XXa+VLaz9bYblquYuXLke6LfWEke53zvW8be2D+w4ekc59R0sda7sPGDnVZfr1t5tC3Q2ijQm5dk0q1motJ0+d0VGTxkyeI7PnLzP5cqWLiu7zZiRWAxZGAAEEEAh0AQL0QN8D6D8CCCAQRwKVy5cyQYoG6tt/3yUvPF/QVbMGNgNGTZVOrRvIh5MHS8En88ug0dPM/G/Xb5H1m36WD6zp44d1k3/3HjDTdfDDT9tNUDtpZE/5aOows9yoCbN1VpRJ1//UE4+YMsmSJpVSxQqbYE4naFC56rvNUvXOVdIGb1aR5Qsmy7zpI0Svhs5b/JUWizRF1d4U1lX7YX3aycczRsqsCQPluw0/yrYdf0munNlEfSqUKSbTxvaVmlVfDlWIvmJiAAAMX0lEQVT/dxt+MncgTLb6OXvyIDl1+ox8MH+pq8zR46dkRL/2pk6HwyHfrf/RNS+ijJ7EGDJ2pnRt00jmTBlq3HsOmmCC0MjaqPXMnLtEghxBxrpvlxam7XLnn97qfuPGDZlr1ffhe0PkmNWmRctW35kr1omNqzJxRA/p27WFa5p7Zv/BwzKifwdZMHOkPJg5g8yet8TM7j9iipQqXtjyHy6TrOU/XLBM/v53n5mng8tXIq73tVdelDIln5PXXy1nTFOlTCFRbUtd/ztN68hH04ZJnlw5pFv/MdKrUzOZZ22rc+fPR2maNEkS64RTcVn61bfaJKuvV+TbdVvk9SplzXi6tA/I/feliNVXKkxF8T2gfgQQQAABnxcgQPf5TUQDEUAAAXsIVH65pHz97Q+yxgpcypR6XhxWs2/dsgbW/7/t3C1P5M8rjz+axxoTqVezkgnC9Krnrzv+liqvvCT3pUopGgjVqFLOlNHBlq07JPjseesK63jRq6Srv98kO/78V2dFmq5fvy7HT56WLJkzusq8arVNr7TqhPWbtpmAOVOGdDpqrqyPmzJH2vcYIb//uVv+3v0/Mz2yQVTtTZ4smfxqnZwYOGqadO0/Ts4En5Nd/0Rdn65n229/SaXyJSXNA6nNSYI6NSrJL9Y0nafpuWeeMD6az5IpfbSB4G9//CNXrMB2zHtzjNu7Uz+Ss+cuyIFDRySqNuqJjXo1K4vD4bD8MsiLJZ7XVZr048+/yx9//Stteww3affe/bJj599mng70joWgoMg/VjxfqICrD2VKFbWc/jb2f/2zV75Yuda0s4d1EuHixStWvf9olSZFV68pdGegd0lEti1z58wuObJlMX17usAjkvvhHJI+bRpJFBRk7Zv5ojWtWbWCaaee4Plq9Xp5/tknJU3q+++sWSRzxgxy8NAx13ggZugzAggggEDsBSL/Sxr7uqkBAQQQQCAABDQI14fCpb7/Pnk0b06Z9sEiebVC6dA9twolTnT3T06SxImtK7Uawovcsv5LnCiRq3xia55zxOG4ZV15LmmukOqVZ70qvXLRFOfsCF91eYfDISEh11zzn3nqMbl06Yrs3fefrFiz3tSpM/cfPCJDxsyQCmWKy9ghXaVx/epWYBv1Q9aiau+Xq9eZK7Fv1aoik0f1khJFC8mly+Fvmdd1u6ewdSZNkljU1FkmkZtdkBVQXr9+wzkrwleHw2Fti4ddbmq3dvls0SA1qjaadrj563ZyrcDaXJ3faeCqc+Gs0TKsb3vX7GTJkrjynmYSWdtdt9eU0b1d9X65cHKoOww8rTe6bZnEMnW2K1FQkLj3zRPTLNZV//yP5BK92+GzL76ROjUqivs/vQ0+SdLE7pPIx60AtSGAAAIBIXD301JAdJdOIoAAAgjEp0DDOlWlbo3Kkse6Oum+Hr1iuXPXHtl15+r0gs9WyiN5Hxa9LbnQU/lFb2V3BqQ//LjdtWix5wvK0hXfyd79h8w0DYL0lnEzEsVAb2HW7za7F6n8cinR26d/3bFLyr1Y1MzSMtmtq6pP5M9rXVlOKt9Gc+u4LhRVe/ft/0+efPwR6+psNtEgevPWu33ROwSCravYWkfY9OzTj8vKbzeYK8r6/fIFS1ZKYeuqedhyno4XLPCouUPh23U/uhbZvPU3k4+qjc88+Zhs3LzNlLt+/br8tG2HyeuguLUtps/5VM5fuKijorfRu9+KbiZGMVi78WdzZ4Nu50+Wfi3qqNs/f75cMnHGfNEr07r4nv8dDPVdb53mSbqXbelJve5l3nitvEyYPl+SJ08u2m73eQeskz2PP5LbfRJ5WwnQWAQQQMA3BAjQfWM70AoEEEDALwQeswKU+rUqh+tLhvRppU/n5uZBa/qALn3Kun7HWQuWLVVUHrWuvLfvOVI69RklJ06e1skmFS38tDSxrmoPGj1dGr3TRyrXfkd+37nbzItq8PJLxURvG3cvU+WV0vLN2s2i30fX76XrvOefLWBucdYHs+m60z6QWidHmaJqb/VXy8nX326Ulp0Gy4CRU+SRPDlddelt/2eCz4r2Ux8S55phZcqUfF7KlX5BWncZKo3b9JP777tP3q5bzZpzb/+nTZPafN97yZdrRB+O9krNlq7vT0fVxmYNXpfd/9tv2thtwDhJmSKFqwFv16tuBaUPm77pw+wate4j2h9XgWgyjz2aWzr3HSN1mnWzTl5cF61PFxnYo5UVkJ+Vt1r2En1QYN/hk+XGnYfP6XxP071sS0/rdpYr8uxT5msYNauWd04yr/owvTy5H5K0lruZwACBsAKMI4AAAh4KBHlYjmIIIIAAAghEKFC7egUZ0L1VuHk5czwoqz69/SA4nVm6eGF5f+JA8zC4CcO7m++B63RNbZvVNQ8YGzekm3nV28N1uib9yasPJw8WfTDZN0tmSMM6r+lkebtuVWnTtI7Jhx1oMK5PjXefnilDOtm8ap707dLcNTlpkiSibZk7dajouru0aWhuTdcC+pA5ba8zP3vSIM2aFFl7s2fNLIs/GCvTxvWVEf06mFvAm771ullG1z9qQCezvppVXxat371OLTdv+nDRtmgb9Yq7Lti8YU3RpHlNDWpXEV2/5sOmdV9+IM6TD4WeekzeG91b1O7rxdNE163lo2qjfgd+eN8Opo3qoQ/u03bpcsmTJZV2zevJ/BkjZN604ebBenoCRefpLfTPPVNAs5Gm3DmzmYfPOW+Nd35/O2uWTDKkdxtTr9rpA/YyZ0xv6omu3g4t35K6b1QyZaPalto2rcsUtAaVypeSwb3aWLnb/+u+5DQNm3ffx46dOCVBQQ4p/2Kx2wveGS5ftVberP7KnTFeEPC+AGtEAAH/ESBA959tSU8QQAABBO4IaPBXxwrcDh89fmcKLwjETuCDjz+Xlp0HS8u3a4r799n1an+GdGmlRNFnYrcClkbAdwVoGQIIeFGAAN2L2KwKAQQQQMB7AqWLPSt6ddZ7a2RNkQnoHQCaIptvh+l6ZX3p3PGiX3Fwb2+ioKBwD4xzn08eAQSiE2A+Agi4CxCgu2uQRwABBBBAAAEEEEAAAf8RoCcI2EyAAN1mG4zmIoAAAggggAACCCCAgG8I0AoE4lqAAD2uRakPAQQQQAABBBBAAAEEEIi9ADUEoAABegBudLqMAAIIIIAAAggggAACgS5A/31RgADdF7cKbUIAAQQQQAABBBBAAAEE7CxA2+9JgAD9nthYCAEEEEAAAQQQQAABBBBAIKEE/HW9BOj+umXpFwIIIIAAAggggAACCCCAwL0IJNgyBOgJRs+KEUAAAQQQQAABBBBAAAEEAk8g8h4ToEduwxwEEEAAAQQQQAABBBBAAAEEvCYQJwG611rLihBAAAEEEEAAAQQQQAABBBDwUwE7BOh+Sk+3EEAAAQQQQAABBBBAAAEEELgrQIAudzHIIYAAAggggAACCCCAAAIIIJBQAgTo8S1P/QgggAACCCCAAAIIIIAAAgh4IECA7gGSLxehbQgggAACCCCAAAIIIIAAAv4hQIDuH9sxvnpBvQgggAACCCCAAAIIIIAAAl4SIED3EjSriUiAaQgggAACCCCAAAIIIIAAAk4BAnSnBK/+J0CPEEAAAQQQQAABBBBAAAEbCRCg22hj0VTfEqA1CCCAAAIIIIAAAggggEBcChCgx6UmdSEQdwLUhAACCCCAAAIIIIAAAgEmQIAeYBuc7iJwW4AhAggggAACCCCAAAII+JoAAbqvbRHag4A/CNAHBBBAAAEEEEAAAQQQiLEAAXqMyVgAAQQSWoD1I4AAAggggAACCCDgjwIE6P64VekTAgjERoBlEUAAAQQQQAABBBBIEAEC9ARhZ6UIIBC4AvQcAQQQQAABBBBAAIGIBQjQI3ZhKgIIIGBPAVqNAAIIIIAAAgggYFsBAnTbbjoajgACCHhfgDUigAACCCCAAAIIxJ8AAXr82VIzAggggEDMBCiNAAIIIIAAAggEtAABekBvfjqPAAIIBJIAfUUAAQQQQAABBHxbgADdt7cPrUMAAQQQsIsA7UQAAQQQQAABBGIpQIAeS0AWRwABBBBAwBsCrAMBBBBAAAEE/F+AAN3/tzE9RAABBBBAIDoB5iOAAAIIIICADwgQoPvARqAJCCCAAAII+LcAvUMAAQQQQAABTwQI0D1RogwCCCCAAAII+K4ALUMAAQQQQMBPBAjQ/WRD0g0EEEAAAQQQiB8BakUAAQQQQMBbAv8HAAD//7lSY7MAAAAGSURBVAMArNqXo0Aek7oAAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_missing = [name for name, phash in baseline_hashes.items() if not phash]\n",
     "if _missing:\n",
@@ -721,13 +8317,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c7df6c0",
+   "id": "ccac6e8a",
    "metadata": {
     "papermill": {
-     "duration": 0.014944,
-     "end_time": "2026-09-06T22:57:39.969269+00:00",
+     "duration": 0.021662,
+     "end_time": "2026-09-08T21:58:18.526425+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:57:39.954325+00:00",
+     "start_time": "2026-09-08T21:58:18.504763+00:00",
      "status": "completed"
     }
    },
@@ -741,14 +8337,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "860559a5",
+   "execution_count": 13,
+   "id": "12ac45c8",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:58:18.562456Z",
+     "iopub.status.busy": "2026-09-08T21:58:18.562270Z",
+     "iopub.status.idle": "2026-09-08T21:58:18.573178Z",
+     "shell.execute_reply": "2026-09-08T21:58:18.572450Z"
+    },
+    "papermill": {
+     "duration": 0.029894,
+     "end_time": "2026-09-08T21:58:18.573744+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:58:18.543850+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Per-fold validation IC (tsmixer @ epoch 10):\n",
+      "shape: (8, 3)\n",
+      "┌─────────┬───────────┬────────────┐\n",
+      "│ fold_id ┆ ic        ┆ n_entities │\n",
+      "│ ---     ┆ ---       ┆ ---        │\n",
+      "│ i64     ┆ f64       ┆ f64        │\n",
+      "╞═════════╪═══════════╪════════════╡\n",
+      "│ 0       ┆ -0.009287 ┆ 90.0       │\n",
+      "│ 1       ┆ -0.125377 ┆ 95.0       │\n",
+      "│ 2       ┆ 0.042411  ┆ 96.0       │\n",
+      "│ 3       ┆ 0.07674   ┆ 97.0       │\n",
+      "│ 4       ┆ 0.129033  ┆ 97.0       │\n",
+      "│ 5       ┆ 0.040575  ┆ 96.0       │\n",
+      "│ 6       ┆ 0.031986  ┆ 97.0       │\n",
+      "│ 7       ┆ 0.100668  ┆ 96.0       │\n",
+      "└─────────┴───────────┴────────────┘\n",
+      "\n",
+      "  Folds with negative IC: 2 of 8\n",
+      "  Peak-IC prediction_hash: 715536faaab4\n"
+     ]
+    }
+   ],
    "source": [
     "folds = (\n",
     "    Result.open(study, PEAK_PHASH, include_preview=EXECUTION_TIER == \"preview\")\n",
@@ -765,13 +8400,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1763fc99",
+   "id": "6e418ef4",
    "metadata": {
     "papermill": {
-     "duration": 0.01523,
-     "end_time": "2026-09-06T22:57:40.036572+00:00",
+     "duration": 0.017909,
+     "end_time": "2026-09-08T21:58:18.610403+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:57:40.021342+00:00",
+     "start_time": "2026-09-08T21:58:18.592494+00:00",
      "status": "completed"
     }
    },
@@ -781,10 +8416,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9bdd12ae",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 14,
+   "id": "95060670",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T21:58:18.643824Z",
+     "iopub.status.busy": "2026-09-08T21:58:18.643678Z",
+     "iopub.status.idle": "2026-09-08T21:58:18.651252Z",
+     "shell.execute_reply": "2026-09-08T21:58:18.650494Z"
+    },
+    "papermill": {
+     "duration": 0.024802,
+     "end_time": "2026-09-08T21:58:18.651815+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T21:58:18.627013+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "- **The globally shared model is measured against the flat-feature families on rows all three\n",
+       "  actually share** - 187,647 of them across 1,995 dates, intersected on\n",
+       "  `(symbol, timestamp)` and recomputed rather than assumed comparable. On that common sample the\n",
+       "  peak checkpoint scores **+0.035**, against Ridge\n",
+       "  **+0.043** and GBM **+0.055**. Its own\n",
+       "  full-sample IC is **+0.035** at epoch **10**.\n",
+       "- **Coverage is comparable across the checkpoint choice.** All 20 checkpoints cover 1995 validation dates. The guard stays\n",
+       "  necessary either way: a collapsed checkpoint scores on fewer dates and can look better for it.\n",
+       "- **The average is not the whole story.** The peak checkpoint is negative in\n",
+       "  **2 of 8** validation folds. The holdout is not read here; it is\n",
+       "  evaluated once, after the development-stage selection is fixed.\n",
+       "\n",
+       "**Next**: [`11_latent_factors`](11_latent_factors.ipynb) tests whether explicit factor\n",
+       "  structure organizes the cross-section more effectively.\n",
+       "**Book**: Chapter 13, Section 13.8 (Case Study Results).\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_coverage_text = (\n",
     "    f\"All {checkpoints.height} checkpoints cover {FULL_DAYS:.0f} validation dates.\"\n",
@@ -835,6 +8512,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T21:58:30.664897+00:00",
+   "executor": "local-uv",
+   "library_digest": "598ed5ac2330510c972b1aacbd7083bf1725555de6a03f86ee0862e3d1f10b0d",
+   "outputs_digest": "307f5a6f0092d602ba8e75ed6852937415f3c7d2610c34c596d2eae647ab72cd",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "1eb9ae5952ad6d9858811fcdce51de7093a2145e"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 7767.293743,
+   "end_time": "2026-09-08T21:58:21.809396+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/etfs/.10_dl_tsmixer.build.4187833.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/etfs/.10_dl_tsmixer.papermill.4187833.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T19:48:54.515653+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/etfs/10a_dl_nlinear.ipynb
+++ b/case_studies/etfs/10a_dl_nlinear.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "40318ee9",
+   "id": "470496ec",
    "metadata": {
     "papermill": {
-     "duration": 0.007925,
-     "end_time": "2026-09-06T22:57:55.600165+00:00",
+     "duration": 0.001532,
+     "end_time": "2026-09-08T17:42:53.772934+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:57:55.592240+00:00",
+     "start_time": "2026-09-08T17:42:53.771402+00:00",
      "status": "completed"
     }
    },
@@ -37,9 +37,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4c89697b",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "5e4ed4bc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:53.776180Z",
+     "iopub.status.busy": "2026-09-08T17:42:53.776055Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.274917Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.274094Z"
+    },
+    "papermill": {
+     "duration": 3.501398,
+     "end_time": "2026-09-08T17:42:57.275669+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:53.774271+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared ETF NLinear population on the walk-forward folds.\"\"\"\n",
@@ -69,9 +83,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "48a5bc89",
+   "execution_count": 2,
+   "id": "87b9be87",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.280723Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.280189Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.284518Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.283814Z"
+    },
+    "papermill": {
+     "duration": 0.007707,
+     "end_time": "2026-09-08T17:42:57.285221+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.277514+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -91,9 +118,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6ff67780",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "a50f8191",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.295903Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.295453Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.354249Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.353637Z"
+    },
+    "papermill": {
+     "duration": 0.066479,
+     "end_time": "2026-09-08T17:42:57.355319+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.288840+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\n",
@@ -107,13 +148,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93bfad01",
+   "id": "f9751f04",
    "metadata": {
     "papermill": {
-     "duration": 0.00119,
-     "end_time": "2026-09-06T22:58:00.145059+00:00",
+     "duration": 0.001469,
+     "end_time": "2026-09-08T17:42:57.358759+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:58:00.143869+00:00",
+     "start_time": "2026-09-08T17:42:57.357290+00:00",
      "status": "completed"
     }
    },
@@ -135,10 +176,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "dff481b5",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "a4bfd844",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.369204Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.368862Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.458438Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.457965Z"
+    },
+    "papermill": {
+     "duration": 0.097341,
+     "end_time": "2026-09-08T17:42:57.459842+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.362501+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (2, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_21d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=nlinear, dropout=…</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=nlinear, dropout=…</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (2, 5)\n",
+       "┌───────────────┬─────────────┬─────────────┬─────────────┬─────────────────────────────────┐\n",
+       "│ family        ┆ label       ┆ config_name ┆ model_class ┆ params                          │\n",
+       "│ ---           ┆ ---         ┆ ---         ┆ ---         ┆ ---                             │\n",
+       "│ str           ┆ str         ┆ str         ┆ str         ┆ str                             │\n",
+       "╞═══════════════╪═════════════╪═════════════╪═════════════╪═════════════════════════════════╡\n",
+       "│ deep_learning ┆ fwd_ret_21d ┆ nlinear     ┆             ┆ architecture=nlinear, dropout=… │\n",
+       "│ deep_learning ┆ fwd_ret_5d  ┆ nlinear     ┆             ┆ architecture=nlinear, dropout=… │\n",
+       "└───────────────┴─────────────┴─────────────┴─────────────┴─────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "SEQUENCE_CONFIGS = (\"nlinear\",)\n",
     "declared = load_model_configs(study, \"deep_learning\", config_names=list(SEQUENCE_CONFIGS))\n",
@@ -153,13 +237,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce6ac12c",
+   "id": "d13352b4",
    "metadata": {
     "papermill": {
-     "duration": 0.001219,
-     "end_time": "2026-09-06T22:58:00.201256+00:00",
+     "duration": 0.00249,
+     "end_time": "2026-09-08T17:42:57.467731+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:58:00.200037+00:00",
+     "start_time": "2026-09-08T17:42:57.465241+00:00",
      "status": "completed"
     }
    },
@@ -183,10 +267,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "db7574cc",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "29a2972d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.471726Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.471608Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.474893Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.474017Z"
+    },
+    "papermill": {
+     "duration": 0.006037,
+     "end_time": "2026-09-08T17:42:57.475449+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.469412+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training device: cuda\n"
+     ]
+    }
+   ],
    "source": [
     "PUBLISHED_DEVICE = \"cuda\"\n",
     "device = DEVICE or PUBLISHED_DEVICE\n",
@@ -205,13 +311,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cefdb8b",
+   "id": "dbec2b0e",
    "metadata": {
     "papermill": {
-     "duration": 0.001159,
-     "end_time": "2026-09-06T22:58:00.209513+00:00",
+     "duration": 0.00129,
+     "end_time": "2026-09-08T17:42:57.478535+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:58:00.208354+00:00",
+     "start_time": "2026-09-08T17:42:57.477245+00:00",
      "status": "completed"
     }
    },
@@ -232,10 +338,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c1acd9bd",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "71e1adee",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.482113Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.481938Z",
+     "iopub.status.idle": "2026-09-08T17:42:57.535042Z",
+     "shell.execute_reply": "2026-09-08T17:42:57.534287Z"
+    },
+    "papermill": {
+     "duration": 0.055611,
+     "end_time": "2026-09-08T17:42:57.535423+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.479812+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  GBM (Ch12): IC=+0.0547\n",
+      "  Ridge (Ch11): IC=+0.0437\n"
+     ]
+    }
+   ],
    "source": [
     "prior_baselines = {}\n",
     "baseline_hashes = {}\n",
@@ -292,13 +421,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41589df5",
+   "id": "a55485e5",
    "metadata": {
     "papermill": {
-     "duration": 0.001256,
-     "end_time": "2026-09-06T22:58:00.257553+00:00",
+     "duration": 0.001437,
+     "end_time": "2026-09-08T17:42:57.538525+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:58:00.256297+00:00",
+     "start_time": "2026-09-08T17:42:57.537088+00:00",
      "status": "completed"
     }
    },
@@ -335,10 +464,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2a4af4bf",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "9064fb3c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:57.542209Z",
+     "iopub.status.busy": "2026-09-08T17:42:57.542007Z",
+     "iopub.status.idle": "2026-09-08T17:43:03.814999Z",
+     "shell.execute_reply": "2026-09-08T17:43:03.814312Z"
+    },
+    "papermill": {
+     "duration": 6.275673,
+     "end_time": "2026-09-08T17:43:03.815532+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:57.539859+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (2, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>feature_count</th><th>eligible_entities</th><th>eligible_rows</th><th>folds</th><th>checkpoints</th><th>validation_start</th><th>validation_end</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td></tr></thead><tbody><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;nlinear&quot;</td><td>73</td><td>99</td><td>187668</td><td>8</td><td>20</td><td>2015-12-28 00:00:00</td><td>2023-11-29 00:00:00</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;nlinear&quot;</td><td>73</td><td>99</td><td>189204</td><td>8</td><td>20</td><td>2015-12-28 00:00:00</td><td>2023-12-21 00:00:00</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (2, 9)\n",
+       "┌────────────┬────────────┬────────────┬───────────┬───┬───────┬───────────┬───────────┬───────────┐\n",
+       "│ label      ┆ config_nam ┆ feature_co ┆ eligible_ ┆ … ┆ folds ┆ checkpoin ┆ validatio ┆ validatio │\n",
+       "│ ---        ┆ e          ┆ unt        ┆ entities  ┆   ┆ ---   ┆ ts        ┆ n_start   ┆ n_end     │\n",
+       "│ str        ┆ ---        ┆ ---        ┆ ---       ┆   ┆ i64   ┆ ---       ┆ ---       ┆ ---       │\n",
+       "│            ┆ str        ┆ i64        ┆ i64       ┆   ┆       ┆ i64       ┆ datetime[ ┆ datetime[ │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ μs]       ┆ μs]       │\n",
+       "╞════════════╪════════════╪════════════╪═══════════╪═══╪═══════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_ret_21 ┆ nlinear    ┆ 73         ┆ 99        ┆ … ┆ 8     ┆ 20        ┆ 2015-12-2 ┆ 2023-11-2 │\n",
+       "│ d          ┆            ┆            ┆           ┆   ┆       ┆           ┆ 8         ┆ 9         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_5d ┆ nlinear    ┆ 73         ┆ 99        ┆ … ┆ 8     ┆ 20        ┆ 2015-12-2 ┆ 2023-12-2 │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 8         ┆ 1         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "└────────────┴────────────┴────────────┴───────────┴───┴───────┴───────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -366,13 +544,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3daa278",
+   "id": "361c7077",
    "metadata": {
     "papermill": {
-     "duration": 0.001474,
-     "end_time": "2026-09-06T22:58:04.255850+00:00",
+     "duration": 0.001729,
+     "end_time": "2026-09-08T17:43:03.819497+00:00",
      "exception": false,
-     "start_time": "2026-09-06T22:58:04.254376+00:00",
+     "start_time": "2026-09-08T17:43:03.817768+00:00",
      "status": "completed"
     }
    },
@@ -404,10 +582,11689 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1a80ae7a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "54377654",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:43:03.824273Z",
+     "iopub.status.busy": "2026-09-08T17:43:03.824028Z",
+     "iopub.status.idle": "2026-09-08T19:59:58.616756Z",
+     "shell.execute_reply": "2026-09-08T19:59:58.614023Z"
+    },
+    "papermill": {
+     "duration": 8214.804183,
+     "end_time": "2026-09-08T19:59:58.625581+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:43:03.821398+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=159,335 seq across 92 symbols\n",
+      "    val=22,184 seq across 92 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.109402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.018657\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.010538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.007177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.005412, val_loss=0.002895, IC=-0.0443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.004475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.003992\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.003782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.003603, val_loss=0.002704, IC=-0.0105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.003562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.003544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.003526\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.003533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.003505, val_loss=0.002783, IC=-0.0286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.003492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003501\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003506, val_loss=0.002806, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003491\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003501, val_loss=0.002874, IC=-0.0542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.003490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.003494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.003491\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.003492, val_loss=0.002858, IC=-0.0260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.003496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.003483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.003497\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.003485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.003486, val_loss=0.002822, IC=+0.0091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.003497\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.003489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.003484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.003483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.003498, val_loss=0.002918, IC=-0.0333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.003489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.003489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.003489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.003488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.003489, val_loss=0.002950, IC=-0.0525\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.003486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.003480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.003481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.003496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.003485, val_loss=0.003040, IC=-0.0911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.003489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.003489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.003474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.003476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.003486, val_loss=0.002906, IC=-0.0287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.003479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.003472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.003477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.003480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.003478, val_loss=0.002912, IC=-0.0487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.003470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.003478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.003470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.003479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.003479, val_loss=0.002925, IC=-0.0704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.003468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.003476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.003465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.003482\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.003473, val_loss=0.002965, IC=-0.0717\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.003470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.003468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.003465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.003477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.003466, val_loss=0.002904, IC=-0.0084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.003466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.003471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.003466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.003466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.003461, val_loss=0.002936, IC=-0.0325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.003461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.003465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.003463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.003467\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.003468, val_loss=0.002956, IC=-0.0510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.003462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.003459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.003464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.003461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.003460, val_loss=0.002954, IC=-0.0381\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.003462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.003457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.003455\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.003463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.003463, val_loss=0.002946, IC=-0.0418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.003463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.003460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.003451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.003458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.003459, val_loss=0.002941, IC=-0.0376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=35, IC=+0.0091 (408.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=181,138 seq across 92 symbols\n",
+      "    val=23,502 seq across 97 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.065033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.011563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.006166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.004606\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.004017, val_loss=0.001752, IC=-0.0375\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.003761\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.003654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.003591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003561\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.003554, val_loss=0.001589, IC=+0.0217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.003534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.003531\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.003514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.003522\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.003507, val_loss=0.001435, IC=+0.0208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.003495\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003491\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003502, val_loss=0.001556, IC=-0.0740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003462, val_loss=0.001522, IC=+0.0452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.003467\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.003473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.003454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.003453, val_loss=0.001438, IC=+0.0134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.003460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.003452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.003452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.003441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.003446, val_loss=0.001573, IC=-0.0173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.003445\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.003461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.003448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.003441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.003432, val_loss=0.001488, IC=+0.0078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.003439\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.003434\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.003432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.003443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.003429, val_loss=0.001542, IC=-0.0151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.003437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.003439\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.003433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.003432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.003427, val_loss=0.001546, IC=-0.0422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.003421\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.003418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.003422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.003428\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.003428, val_loss=0.001474, IC=+0.0105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.003426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.003417\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.003429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.003424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.003426, val_loss=0.001514, IC=-0.0181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.003411\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.003410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.003406\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.003420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.003422, val_loss=0.001593, IC=+0.0424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.003414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.003413\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.003409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.003412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.003412, val_loss=0.001448, IC=+0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.003404\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.003404\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.003404\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.003400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.003400, val_loss=0.001501, IC=-0.0139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.003402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.003408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.003403\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.003402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.003395, val_loss=0.001471, IC=+0.0164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.003397\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.003401\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.003403\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.003398\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.003399, val_loss=0.001503, IC=+0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.003401\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.003391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.003396\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.003400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.003397, val_loss=0.001510, IC=+0.0075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.003388\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.003400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.003388\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.003397\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.003393, val_loss=0.001517, IC=+0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.003399\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.003395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.003395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.003391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.003383, val_loss=0.001519, IC=+0.0071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0452 (551.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=192,519 seq across 97 symbols\n",
+      "    val=24,129 seq across 98 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.051355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.009276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.004695\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.003578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.003342, val_loss=0.002852, IC=-0.0449\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.003290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.003280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.003270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.003136, val_loss=0.003110, IC=-0.0218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.003140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.003138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.003134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.003227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.003284, val_loss=0.003203, IC=+0.0277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.003122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003120, val_loss=0.002786, IC=-0.0162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003146, val_loss=0.003434, IC=+0.0256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.003064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.003077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.003189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.003290, val_loss=0.003309, IC=+0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.003326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.003187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.003145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.003099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.003091, val_loss=0.002943, IC=-0.0657\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.003171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.003234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.003109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.003189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.003101, val_loss=0.002790, IC=-0.0255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.003118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.003073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.003146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.003194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.003095, val_loss=0.002723, IC=-0.0233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.003096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.003132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.003163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.003134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.003080, val_loss=0.002573, IC=+0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.003142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.003061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.003058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.003049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.003087, val_loss=0.002867, IC=-0.0228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.003115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.003051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.003047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.003042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.003047, val_loss=0.002781, IC=-0.0153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.003057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.003057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.003081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.003084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.003105, val_loss=0.002698, IC=-0.0184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.003175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.003070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.003045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.003070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.003089, val_loss=0.002707, IC=-0.0286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.003061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.003040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.003046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.003045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.003048, val_loss=0.002699, IC=-0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.003100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.003070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.003031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.003048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.003064, val_loss=0.002701, IC=-0.0038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.003077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.003046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.003050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.003070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.003047, val_loss=0.002751, IC=-0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.003065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.003026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.003021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.003032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.003082, val_loss=0.002720, IC=-0.0159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.003020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.003017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.003017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.003081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.003038, val_loss=0.002722, IC=-0.0102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.003050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.003067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.003031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.003038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.003038, val_loss=0.002731, IC=-0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0277 (502.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=201,390 seq across 98 symbols\n",
+      "    val=24,137 seq across 98 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.101012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.011265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.005623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.003719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002978, val_loss=0.002414, IC=+0.0212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.002388\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.002368, val_loss=0.002305, IC=-0.0129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.002353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.002350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.002345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.002344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.002341, val_loss=0.002144, IC=+0.0774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.002339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.002337\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.002332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002331, val_loss=0.002120, IC=+0.1277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002324\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002333, val_loss=0.002181, IC=+0.0615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002324\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002328, val_loss=0.002270, IC=+0.0964\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002321\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002317, val_loss=0.002328, IC=+0.0316\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002316\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002316, val_loss=0.001940, IC=+0.0759\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002311, val_loss=0.002249, IC=+0.1042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002303, val_loss=0.002010, IC=+0.0877\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002298, val_loss=0.001944, IC=+0.1049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002301, val_loss=0.002058, IC=-0.0289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.002297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.002296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.002295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.002291, val_loss=0.002193, IC=+0.0219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.002293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.002295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.002296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002291, val_loss=0.002057, IC=+0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.002291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.002293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.002291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.002290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.002283, val_loss=0.002067, IC=+0.0639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.002288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.002283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.002286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002286, val_loss=0.002023, IC=+0.0445\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.002288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.002283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.002284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.002285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.002282, val_loss=0.002061, IC=+0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.002283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.002282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.002281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.002280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.002282, val_loss=0.002030, IC=+0.0554\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.002281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.002283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.002278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.002281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.002282, val_loss=0.002030, IC=+0.0485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.002276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.002281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.002279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.002279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.002278, val_loss=0.002028, IC=+0.0572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=20, IC=+0.1277 (491.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=207,424 seq across 98 symbols\n",
+      "    val=23,882 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.098948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.009209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002647\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002355, val_loss=0.009906, IC=-0.0534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.002201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.002199, val_loss=0.009967, IC=-0.0185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.002195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.002196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.002196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.002194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.002189, val_loss=0.010069, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.002194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.002195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.002194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002187, val_loss=0.009858, IC=-0.0146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002191, val_loss=0.010456, IC=-0.1168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002185, val_loss=0.010004, IC=-0.0828\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002182, val_loss=0.009990, IC=-0.0334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002175, val_loss=0.010496, IC=-0.1274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002167, val_loss=0.009790, IC=+0.0639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002167, val_loss=0.009699, IC=+0.0370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002161, val_loss=0.009880, IC=+0.0452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002158, val_loss=0.009832, IC=-0.0216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.002159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.002159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.002155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.002161, val_loss=0.009920, IC=+0.0723\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.002158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.002160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.002153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002154, val_loss=0.009989, IC=-0.0402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.002155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.002153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.002152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.002155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.002151, val_loss=0.009572, IC=+0.0721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.002147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.002149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.002152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002149, val_loss=0.009562, IC=+0.0353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.002153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.002143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.002145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.002150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.002144, val_loss=0.009760, IC=+0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.002144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.002149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.002147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.002144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.002141, val_loss=0.009665, IC=+0.0628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.002142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.002144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.002149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.002145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.002146, val_loss=0.009735, IC=+0.0264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.002143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.002141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.002145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.002144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.002143, val_loss=0.009767, IC=+0.0252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=65, IC=+0.0723 (428.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=213,372 seq across 99 symbols\n",
+      "    val=23,885 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.099307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.006219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003923\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.003301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.003060, val_loss=0.002447, IC=+0.1832\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002909\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002895\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.002885\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.002884, val_loss=0.003201, IC=+0.1527\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.002883\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.002875\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.002881\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.002868\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.002868, val_loss=0.002715, IC=+0.1875\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.002867\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.002863\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.002855\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002856\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002846, val_loss=0.002852, IC=+0.1682\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002846\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002849\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002860\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002854\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002842, val_loss=0.002998, IC=+0.2044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002841\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002829\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002828\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002834\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002822, val_loss=0.002931, IC=+0.1524\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002826\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002833\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002827\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002826, val_loss=0.002958, IC=+0.1419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002819\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002817\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002822, val_loss=0.003148, IC=+0.1894\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002810\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002806, val_loss=0.002757, IC=+0.1480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002797\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002796, val_loss=0.002798, IC=+0.1542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002797\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002789\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002808\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002792, val_loss=0.002854, IC=+0.1664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002792\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002791\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002791, val_loss=0.003034, IC=+0.1649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002791\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.002789\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.002785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.002778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.002783, val_loss=0.002829, IC=+0.1618\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.002778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.002777\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.002781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002779, val_loss=0.002980, IC=+0.1679\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.002774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.002773\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.002770\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.002773\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.002775, val_loss=0.002896, IC=+0.1761\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.002774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.002778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.002769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002772, val_loss=0.002977, IC=+0.1723\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.002766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.002760\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.002767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.002768\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.002764, val_loss=0.002937, IC=+0.1725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.002764\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.002758\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.002764\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.002769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.002775, val_loss=0.002958, IC=+0.1699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.002756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.002761\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.002762\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.002767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.002762, val_loss=0.002929, IC=+0.1716\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.002769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.002759\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.002766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.002764\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.002765, val_loss=0.002941, IC=+0.1697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.2044 (520.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=217,647 seq across 99 symbols\n",
+      "    val=23,830 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.090687\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.008953\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.004594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.003401\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.003013, val_loss=0.005626, IC=-0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002847\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.002727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.002715, val_loss=0.005486, IC=+0.0147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.002709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.002707\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.002693\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.002697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.002694, val_loss=0.005339, IC=+0.0311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.002697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.002695\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.002688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002687, val_loss=0.005285, IC=-0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002682\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002687\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002681\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002692, val_loss=0.005419, IC=-0.0453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002679\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002675, val_loss=0.005416, IC=-0.0340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002675, val_loss=0.005437, IC=-0.0577\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002679\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002665\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002677, val_loss=0.005348, IC=-0.0267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002668, val_loss=0.005394, IC=-0.0233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002665, val_loss=0.005259, IC=-0.0353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002656, val_loss=0.005381, IC=-0.0413\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002657\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002656, val_loss=0.005333, IC=-0.0447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.002662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.002654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.002652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.002651, val_loss=0.005345, IC=-0.0418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.002651\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.002654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.002649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002650\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002657, val_loss=0.005299, IC=-0.0452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.002645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.002650\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.002654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.002651\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.002653, val_loss=0.005258, IC=-0.0469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.002644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.002646\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.002643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002643, val_loss=0.005325, IC=-0.0496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.002643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.002652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.002644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.002639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.002641, val_loss=0.005294, IC=-0.0512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.002641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.002645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.002643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.002643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.002639, val_loss=0.005309, IC=-0.0534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.002643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.002644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.002636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.002640\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.002638, val_loss=0.005294, IC=-0.0495\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.002637\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.002641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.002642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.002637\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.002642, val_loss=0.005290, IC=-0.0492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0311 (502.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=221,602 seq across 99 symbols\n",
+      "    val=22,119 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.095999\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.010918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.005144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.003661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.003234, val_loss=0.003242, IC=+0.0418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.003102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.003065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.003053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.003042, val_loss=0.002964, IC=+0.0228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.003029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.003032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.003022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.003022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.003025, val_loss=0.003017, IC=+0.0358\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.003017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003016, val_loss=0.003099, IC=+0.0225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003011, val_loss=0.003085, IC=+0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.003005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.003005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.003001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.003008, val_loss=0.003223, IC=+0.0114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002999\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002998\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002993\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002998, val_loss=0.003166, IC=+0.0110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002986\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002992\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002987, val_loss=0.003025, IC=+0.0246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002994\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002988\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002989\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002985, val_loss=0.003204, IC=-0.0159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002991\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002975, val_loss=0.003028, IC=-0.0189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002974\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002974\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002975, val_loss=0.003119, IC=-0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002988\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002966\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002966\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002981, val_loss=0.003079, IC=-0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002962\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.002970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.002964\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.002963\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.002961, val_loss=0.003193, IC=-0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.002962\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.002971\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.002971\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002969\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002958, val_loss=0.003089, IC=-0.0137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.002957\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.002961\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.002961\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.002960\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.002954, val_loss=0.003128, IC=+0.0039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002951\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.002951\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.002953\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.002958\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002951, val_loss=0.003187, IC=-0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.002947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.002956\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.002951\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.002948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.002955, val_loss=0.003113, IC=-0.0028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.002950\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.002949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.002947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.002949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.002946, val_loss=0.003122, IC=-0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.002949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.002944\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.002946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.002949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.002948, val_loss=0.003135, IC=-0.0093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.002949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.002946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.002945\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.002949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.002946, val_loss=0.003127, IC=-0.0063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0418 (494.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=15, IC=+0.0439 (3900.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 15 (IC=+0.0439)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/etfs/run_log/training/09f76137be98/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=160,775 seq across 92 symbols\n",
+      "    val=22,184 seq across 92 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.106648\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.015751\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.007960\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.004446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002698, val_loss=0.001008, IC=-0.0208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001086, val_loss=0.000763, IC=+0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001055, val_loss=0.000763, IC=+0.0221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001052, val_loss=0.000760, IC=+0.0452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001045, val_loss=0.000788, IC=-0.0356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001048, val_loss=0.000762, IC=+0.0532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001044, val_loss=0.000773, IC=+0.0132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001043, val_loss=0.000762, IC=+0.0395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001039, val_loss=0.000762, IC=+0.0181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001041, val_loss=0.000765, IC=+0.0488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001040, val_loss=0.000763, IC=+0.0480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001039, val_loss=0.000759, IC=+0.0317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001036, val_loss=0.000764, IC=+0.0544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001032, val_loss=0.000778, IC=+0.0075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001031, val_loss=0.000768, IC=+0.0262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001031, val_loss=0.000770, IC=+0.0152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001030, val_loss=0.000763, IC=+0.0333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001029, val_loss=0.000765, IC=+0.0291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001030, val_loss=0.000766, IC=+0.0271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001029, val_loss=0.000766, IC=+0.0257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=65, IC=+0.0544 (335.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=182,922 seq across 92 symbols\n",
+      "    val=23,502 seq across 97 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.062571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.008960\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001447, val_loss=0.000361, IC=+0.0045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001034, val_loss=0.000289, IC=+0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001025, val_loss=0.000299, IC=+0.0623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001025, val_loss=0.000290, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001027, val_loss=0.000301, IC=+0.0737\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001021, val_loss=0.000305, IC=+0.0530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001028, val_loss=0.000310, IC=+0.0134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001026, val_loss=0.000309, IC=-0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001023, val_loss=0.000289, IC=+0.0397\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001019, val_loss=0.000287, IC=+0.0706\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001015, val_loss=0.000300, IC=+0.0500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001016, val_loss=0.000289, IC=+0.0379\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001014, val_loss=0.000298, IC=+0.0223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001013, val_loss=0.000292, IC=-0.0320\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001009, val_loss=0.000292, IC=+0.0424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001008, val_loss=0.000294, IC=+0.0158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001006, val_loss=0.000299, IC=+0.0243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001005, val_loss=0.000292, IC=+0.0303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001004, val_loss=0.000294, IC=+0.0150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001003, val_loss=0.000295, IC=+0.0177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0737 (470.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=194,519 seq across 97 symbols\n",
+      "    val=24,129 seq across 98 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.049372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.006811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001028, val_loss=0.001050, IC=-0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000960\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000943\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000938\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000939, val_loss=0.000927, IC=+0.0285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000938\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000938\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000939, val_loss=0.000824, IC=+0.0104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000940\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000938\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000942\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000938, val_loss=0.000795, IC=+0.0127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000938\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000936\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000937, val_loss=0.000739, IC=-0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000935\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000935\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000931, val_loss=0.000745, IC=-0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000931\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000936\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000933\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000931, val_loss=0.000750, IC=+0.0078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000934\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000927\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000927, val_loss=0.000763, IC=-0.0051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000931\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000929\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000928, val_loss=0.000748, IC=+0.0245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000927\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000926, val_loss=0.000758, IC=+0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000928\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000925\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000924, val_loss=0.000762, IC=-0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000922\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000923\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000923\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000922\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000925, val_loss=0.000767, IC=-0.0158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000923\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000922\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000921\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000919, val_loss=0.000741, IC=+0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000920\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000917\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000917, val_loss=0.000776, IC=-0.0075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000916\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000916, val_loss=0.000749, IC=-0.0089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000914, val_loss=0.000734, IC=+0.0195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000912, val_loss=0.000732, IC=-0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000912\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000912\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000912, val_loss=0.000730, IC=+0.0063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000911, val_loss=0.000730, IC=+0.0059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000911, val_loss=0.000731, IC=+0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0285 (471.3s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=203,510 seq across 98 symbols\n",
+      "    val=24,137 seq across 98 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.099576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.009464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003857\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001274, val_loss=0.000570, IC=-0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000963\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000745\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000710\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000693, val_loss=0.000477, IC=+0.0296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000679\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000677, val_loss=0.000537, IC=+0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000677, val_loss=0.000554, IC=+0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000677, val_loss=0.000550, IC=-0.0539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000676, val_loss=0.000489, IC=-0.0284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000675, val_loss=0.000545, IC=-0.0530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000677, val_loss=0.000498, IC=-0.0123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000672, val_loss=0.000537, IC=-0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000672, val_loss=0.000494, IC=+0.0334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000671\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000670, val_loss=0.000580, IC=-0.0309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000667, val_loss=0.000538, IC=+0.0329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000665\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000666, val_loss=0.000511, IC=-0.0342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000665\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000665\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000664, val_loss=0.000483, IC=-0.0232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000662, val_loss=0.000529, IC=+0.0326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000662, val_loss=0.000499, IC=-0.0256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000661, val_loss=0.000514, IC=-0.0136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000660, val_loss=0.000510, IC=-0.0270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000659, val_loss=0.000507, IC=-0.0099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000659, val_loss=0.000506, IC=-0.0128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=50, IC=+0.0334 (561.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=209,528 seq across 98 symbols\n",
+      "    val=23,882 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.093637\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.007105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000741, val_loss=0.002336, IC=+0.0161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000620\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000612, val_loss=0.002297, IC=+0.0068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000612, val_loss=0.002351, IC=-0.0266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000613, val_loss=0.002347, IC=-0.0700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000612, val_loss=0.002376, IC=-0.0038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000612, val_loss=0.002308, IC=+0.0809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000612, val_loss=0.002396, IC=-0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000612, val_loss=0.002371, IC=-0.0599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000611, val_loss=0.002354, IC=+0.0861\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000610, val_loss=0.002342, IC=+0.0747\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000610, val_loss=0.002395, IC=-0.0310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000609, val_loss=0.002370, IC=+0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000608, val_loss=0.002356, IC=-0.0171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000606\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000605, val_loss=0.002387, IC=-0.0038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000606\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000603, val_loss=0.002367, IC=-0.0489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000600, val_loss=0.002350, IC=-0.0209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000601, val_loss=0.002352, IC=+0.0363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000598, val_loss=0.002347, IC=+0.0223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000598, val_loss=0.002347, IC=+0.0138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000599, val_loss=0.002345, IC=+0.0214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=45, IC=+0.0861 (590.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=215,516 seq across 99 symbols\n",
+      "    val=23,885 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.097063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.004004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000887, val_loss=0.000700, IC=+0.0492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000788\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000780, val_loss=0.000670, IC=+0.0224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000786\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000780, val_loss=0.000663, IC=+0.1052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000781, val_loss=0.000745, IC=-0.0193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000782, val_loss=0.000688, IC=+0.0792\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000780, val_loss=0.000716, IC=+0.0412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000780, val_loss=0.000782, IC=+0.0146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000780, val_loss=0.000730, IC=+0.0802\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000780, val_loss=0.000660, IC=+0.0386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000779\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000778, val_loss=0.000650, IC=+0.0898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000779\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000776\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000778, val_loss=0.000781, IC=-0.0378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000776, val_loss=0.000715, IC=+0.0615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000777\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000771\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000775, val_loss=0.000760, IC=+0.0753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000772\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000772\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000771, val_loss=0.000732, IC=+0.0843\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000770\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000771\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000772\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000772\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000770, val_loss=0.000721, IC=+0.0776\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000768\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000770\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000767, val_loss=0.000734, IC=+0.0455\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000768\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000771, val_loss=0.000731, IC=+0.0664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000767, val_loss=0.000762, IC=+0.0727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000765\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000768, val_loss=0.000729, IC=+0.0784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000765\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000766, val_loss=0.000724, IC=+0.0814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.1052 (577.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=219,799 seq across 99 symbols\n",
+      "    val=23,830 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.089338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.007118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002657\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000999, val_loss=0.001413, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000836\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000770\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000746\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000732\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000728, val_loss=0.001395, IC=+0.0247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000727, val_loss=0.001394, IC=+0.0268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000729, val_loss=0.001415, IC=-0.0056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000728, val_loss=0.001391, IC=+0.0134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000730, val_loss=0.001396, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000727, val_loss=0.001421, IC=+0.0217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000730\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000728, val_loss=0.001400, IC=-0.0044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000727, val_loss=0.001404, IC=+0.0210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000726, val_loss=0.001393, IC=+0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000723\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000724, val_loss=0.001388, IC=-0.0225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000724, val_loss=0.001382, IC=+0.0094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000722\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000722\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000720, val_loss=0.001375, IC=-0.0124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000720, val_loss=0.001386, IC=-0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000716, val_loss=0.001381, IC=-0.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000715\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000716\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000715\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000717\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000715, val_loss=0.001383, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000714\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000714\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000714\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000713\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000713, val_loss=0.001385, IC=-0.0330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000713\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000713\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000712, val_loss=0.001379, IC=-0.0108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000713, val_loss=0.001382, IC=-0.0114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000714, val_loss=0.001381, IC=-0.0120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0268 (476.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=223,770 seq across 99 symbols\n",
+      "    val=23,655 seq across 99 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.103433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.008673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000970, val_loss=0.000842, IC=-0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000864\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000832\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000821\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000817, val_loss=0.000720, IC=-0.0117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000817\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000814, val_loss=0.000703, IC=+0.0210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000813, val_loss=0.000698, IC=+0.0271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000819, val_loss=0.000708, IC=-0.0271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000817, val_loss=0.000696, IC=-0.0153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000816, val_loss=0.000710, IC=+0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000814, val_loss=0.000712, IC=-0.0518\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000814, val_loss=0.000699, IC=-0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000814, val_loss=0.000734, IC=+0.0186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000810\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000812, val_loss=0.000699, IC=+0.0307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000810\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000810\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000810\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000812, val_loss=0.000716, IC=-0.0107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000810\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000810\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000809, val_loss=0.000725, IC=-0.0148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000808\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000808\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000808, val_loss=0.000722, IC=-0.0271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000806, val_loss=0.000741, IC=-0.0207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000804\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000804\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000806\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000803, val_loss=0.000761, IC=-0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000802\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000804\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000802\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000803, val_loss=0.000736, IC=+0.0153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000802\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000802\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000802, val_loss=0.000740, IC=-0.0159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000802\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000801, val_loss=0.000736, IC=-0.0044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000802\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000801, val_loss=0.000740, IC=-0.0084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=55, IC=+0.0307 (707.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=50, IC=+0.0436 (4191.5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 50 (IC=+0.0436)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/etfs/run_log/training/cbd1c1a94389/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 configurations: 2 trained, 0 read\n",
+      "population etfs-nlinear-validation-v1: 40 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "population_name = POPULATION_NAME or \"etfs-nlinear-validation-v1\"\n",
     "execution, population = run_model_population(\n",
@@ -426,13 +12283,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2c33b66",
+   "id": "1b6268e0",
    "metadata": {
     "papermill": {
-     "duration": 0.022608,
-     "end_time": "2026-09-07T00:24:04.568945+00:00",
+     "duration": 0.044381,
+     "end_time": "2026-09-08T19:59:58.727232+00:00",
      "exception": false,
-     "start_time": "2026-09-07T00:24:04.546337+00:00",
+     "start_time": "2026-09-08T19:59:58.682851+00:00",
      "status": "completed"
     }
    },
@@ -461,9 +12318,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "26ed5b25",
-   "metadata": {},
+   "execution_count": 9,
+   "id": "78bb1ae5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:59:58.825241Z",
+     "iopub.status.busy": "2026-09-08T19:59:58.824536Z",
+     "iopub.status.idle": "2026-09-08T19:59:58.911644Z",
+     "shell.execute_reply": "2026-09-08T19:59:58.910049Z"
+    },
+    "papermill": {
+     "duration": 0.142047,
+     "end_time": "2026-09-08T19:59:58.912992+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:59:58.770945+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "_daily = pl.concat(\n",
@@ -505,13 +12376,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "761614fd",
+   "id": "cd6a3c92",
    "metadata": {
     "papermill": {
-     "duration": 0.022495,
-     "end_time": "2026-09-07T00:24:04.693965+00:00",
+     "duration": 0.058984,
+     "end_time": "2026-09-08T19:59:59.036278+00:00",
      "exception": false,
-     "start_time": "2026-09-07T00:24:04.671470+00:00",
+     "start_time": "2026-09-08T19:59:58.977294+00:00",
      "status": "completed"
     }
    },
@@ -526,14 +12397,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f890b88d",
+   "execution_count": 10,
+   "id": "5ea039b8",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:59:59.150860Z",
+     "iopub.status.busy": "2026-09-08T19:59:59.150595Z",
+     "iopub.status.idle": "2026-09-08T19:59:59.163904Z",
+     "shell.execute_reply": "2026-09-08T19:59:59.163061Z"
+    },
+    "papermill": {
+     "duration": 0.070219,
+     "end_time": "2026-09-08T19:59:59.165210+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:59:59.094991+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Config: nlinear   full-coverage validation days = 1995\n",
+      "shape: (20, 4)\n",
+      "┌──────────────────┬───────────────┬───────────┬───────────────┐\n",
+      "│ checkpoint_value ┆ ic_mean_daily ┆ ic_n_days ┆ full_coverage │\n",
+      "│ ---              ┆ ---           ┆ ---       ┆ ---           │\n",
+      "│ i64              ┆ f64           ┆ f64       ┆ bool          │\n",
+      "╞══════════════════╪═══════════════╪═══════════╪═══════════════╡\n",
+      "│ 5                ┆ 0.007213      ┆ 1995.0    ┆ true          │\n",
+      "│ 10               ┆ 0.018485      ┆ 1995.0    ┆ true          │\n",
+      "│ 15               ┆ 0.043875      ┆ 1995.0    ┆ true          │\n",
+      "│ 20               ┆ 0.023527      ┆ 1995.0    ┆ true          │\n",
+      "│ 25               ┆ 0.015776      ┆ 1995.0    ┆ true          │\n",
+      "│ …                ┆ …             ┆ …         ┆ …             │\n",
+      "│ 80               ┆ 0.021903      ┆ 1995.0    ┆ true          │\n",
+      "│ 85               ┆ 0.008058      ┆ 1995.0    ┆ true          │\n",
+      "│ 90               ┆ 0.023309      ┆ 1995.0    ┆ true          │\n",
+      "│ 95               ┆ 0.018654      ┆ 1995.0    ┆ true          │\n",
+      "│ 100              ┆ 0.019464      ┆ 1995.0    ┆ true          │\n",
+      "└──────────────────┴───────────────┴───────────┴───────────────┘\n",
+      "\n",
+      "Published as candidates: 20 full-coverage checkpoints\n",
+      "Highest validation IC: epoch 15 (IC=+0.0439)\n"
+     ]
+    }
+   ],
    "source": [
     "eligible = checkpoints.filter(\"full_coverage\")\n",
     "if eligible.is_empty():\n",
@@ -563,13 +12476,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebf4c8df",
+   "id": "b92a62bf",
    "metadata": {
     "papermill": {
-     "duration": 0.022059,
-     "end_time": "2026-09-07T00:24:04.792218+00:00",
+     "duration": 0.058985,
+     "end_time": "2026-09-08T19:59:59.282637+00:00",
      "exception": false,
-     "start_time": "2026-09-07T00:24:04.770159+00:00",
+     "start_time": "2026-09-08T19:59:59.223652+00:00",
      "status": "completed"
     }
    },
@@ -590,10 +12503,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3d123f4d",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 11,
+   "id": "871311e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:59:59.423620Z",
+     "iopub.status.busy": "2026-09-08T19:59:59.422891Z",
+     "iopub.status.idle": "2026-09-08T19:59:59.432698Z",
+     "shell.execute_reply": "2026-09-08T19:59:59.431964Z"
+    },
+    "papermill": {
+     "duration": 0.079749,
+     "end_time": "2026-09-08T19:59:59.433729+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:59:59.353980+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "population etfs-nlinear-validation-v1: 40 of 40 declared prediction sets are selectable\n"
+     ]
+    }
+   ],
    "source": [
     "_full_coverage = set(coverage.filter(\"full_coverage\")[\"prediction_hash\"].to_list())\n",
     "_declared = tuple(population.members)\n",
@@ -616,13 +12551,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2729ce18",
+   "id": "46697ac2",
    "metadata": {
     "papermill": {
-     "duration": 0.024096,
-     "end_time": "2026-09-07T00:24:04.888246+00:00",
+     "duration": 0.063016,
+     "end_time": "2026-09-08T19:59:59.558949+00:00",
      "exception": false,
-     "start_time": "2026-09-07T00:24:04.864150+00:00",
+     "start_time": "2026-09-08T19:59:59.495933+00:00",
      "status": "completed"
     }
    },
@@ -639,10 +12574,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d4eaa890",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 12,
+   "id": "7a1f200c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:59:59.671373Z",
+     "iopub.status.busy": "2026-09-08T19:59:59.670670Z",
+     "iopub.status.idle": "2026-09-08T19:59:59.769890Z",
+     "shell.execute_reply": "2026-09-08T19:59:59.768760Z"
+    },
+    "papermill": {
+     "duration": 0.158776,
+     "end_time": "2026-09-08T19:59:59.770593+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:59:59.611817+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  note: 40 of 558 members carry no prediction_coverage row, so their completeness is unevidenced rather than established. They are ranked; the gap is in the registry, not in the run.\n",
+      "deep_learning menu: 5 configuration-label pairs\n",
+      "published and scored in this registry: 3\n",
+      "declared and never fitted: lstm_h64/fwd_ret_5d, tsmixer/fwd_ret_21d\n"
+     ]
+    }
+   ],
    "source": [
     "_menu_pairs = set(\n",
     "    load_model_configs(study, \"deep_learning\").select(\"config_name\", \"label\").unique().iter_rows()\n",
@@ -667,13 +12627,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc8e7bc5",
+   "id": "4638775b",
    "metadata": {
     "papermill": {
-     "duration": 0.022205,
-     "end_time": "2026-09-07T00:24:05.025646+00:00",
+     "duration": 0.057529,
+     "end_time": "2026-09-08T19:59:59.883105+00:00",
      "exception": false,
-     "start_time": "2026-09-07T00:24:05.003441+00:00",
+     "start_time": "2026-09-08T19:59:59.825576+00:00",
      "status": "completed"
     }
    },
@@ -687,10 +12647,274 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5b7ebed4",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 13,
+   "id": "ff73279d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:59:59.996562Z",
+     "iopub.status.busy": "2026-09-08T19:59:59.996311Z",
+     "iopub.status.idle": "2026-09-08T20:00:03.008701Z",
+     "shell.execute_reply": "2026-09-08T20:00:03.007800Z"
+    },
+    "papermill": {
+     "duration": 3.076925,
+     "end_time": "2026-09-08T20:00:03.011772+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:59:59.934847+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "#e8e8e6",
+          "width": 1.5
+         },
+         "marker": {
+          "color": [
+           "#0a1628",
+           "#0a1628",
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ],
+          "line": {
+           "color": "white",
+           "width": 1
+          },
+          "size": [
+           11,
+           11,
+           16,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11,
+           11
+          ]
+         },
+         "mode": "lines+markers+text",
+         "showlegend": false,
+         "text": [
+          "",
+          "",
+          "1995d",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+         ],
+         "textposition": "top center",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          0.007212544048415651,
+          0.018485152647719934,
+          0.043874709318704484,
+          0.023527138434549753,
+          0.015776118157458306,
+          0.017811968503411314,
+          0.0023487543185443435,
+          0.010449018892332058,
+          0.023648200677666535,
+          0.012840874641950769,
+          0.029385667140284955,
+          -0.0017289192805677036,
+          0.019950806482992734,
+          0.0009471832692647322,
+          0.02991886689406968,
+          0.021902576709218424,
+          0.008058455610052636,
+          0.02330888025762638,
+          0.01865365682813116,
+          0.019464094995339888
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "margin": {
+         "t": 70
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#D4A84B",
+           "dash": "dot",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 15,
+          "x1": 15,
+          "xref": "x",
+          "y0": 0,
+          "y1": 1,
+          "yref": "y domain"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 15
+         },
+         "text": "Validation IC by checkpoint; peak at epoch 15"
+        },
+        "width": 1000,
+        "xaxis": {
+         "title": {
+          "text": "Training epoch (checkpoint)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean cross-sectional IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+gAAAH0CAYAAACuKActAAAQAElEQVR4AeydBWAbR9bH34gtYzhlZm5TvDJzmzIzpYxpmzbllDmFFK7MeHelS7/2yszMKVPQdmzLkizrm//IqxhkW6xd6e9kFmYH3vxmtTtv3sysKxIJx+nIgPcA7wHeA7wHeA/wHuA9wHuA9wDvAd4DvAd4D5T2HnBJQf+YOAmQAAmQAAmQAAmQAAmQAAmQAAmQQDoEnK2gp1NChiEBEiABEiABEiABEiABEiABEiABBxCggj5AJfESCZAACZAACZAACZAACZAACZAACRSLABX0YpHumw99SIAESIAESIAESIAESIAESIAESCBJgAp6EkW5HbA8JEACJEACJEACJEACJEACJEACTiJABd1JtWUnWSkLCZAACZAACZAACZAACZAACZBAXglQQc8rTiaWLwJMhwRIgARIgARIgARIgARIgAQqjQAV9EqrcZYXBOhIgARIgARIgARIgARIgARIwHYEqKDbrkookPMJsAQkQAIkQAIkQAIkQAIkQAIkkDkBKuiZM2MMEigtAeZOAiRAAiRAAiRAAiRAAiRQlgSooJdltbJQJJA9AcYkARIgARIgARIgARIgARIoDQEq6KXhzlxJoFIJsNwkQAIkQAIkQAIkQAIkQAL9EKCC3g8YepMACTiRAGUmARIgARIgARIgARIgAecSoILu3Lqj5CRAAsUmwPxIgARIgARIgARIgARIoIAEqKAXEC6TJgESIIFMCDAsCZAACZAACZAACZBAZROggl7Z9c/SkwAJVA4BlpQESIAESIAESIAESMDmBKig27yCKB4JkAAJOIMApSQBEiABEiABEiABEsiVABX0XAkyPgmQAAmQQOEJMAcSIAESIAESIAESqAACVNAroJJZRBIgARIggYEJ8CoJkAAJkAAJkAAJ2IEAFXQ71AJlIAESIAESKGcCLBsJkAAJkAAJkAAJpEWACnpamBiIBEiABEiABOxKgHKRAAmQAAmQAAmUCwEq6OVSkywHCZAACZAACRSCANMkARIgARIgARIoGgEq6EVDzYxIgAScRCAajcpSq24iZ5x7Wb9ib7jVnrLXwcf1e737hdPOvlR23PPwpNcT//mvNCy4inR0dCT9Uh0ceOQpcsTxE1Jd6tfvuedfkQce/U+f66eedYnssMdhffwL5YHy3XjrvX2Sf+vdD+W4U8+T9bfYXRZadj3ZaOu95MQzLpQff/61T1jL496HnpT5llrbOi36fpX1tpVrb7qzKPkWM69s74lb73xQXnvzvbzwKHQiP/z4s/mtvffBJ3nPqr/fWt4zKkCC2d5nzXNb5ITxF8im2+8ro5ZY07BNJR5+43gG9HZffv19quD0IwESIAES6CLg6tpzRwIkQAIk0I2A1+uVHbbZXB7/938lFot1u5I4/OKr7+TTL76WnbffMuGR4XbY0CGy8QbriFIqw5iDB5/6v1flkSee6RNw8UUXkhWXX7qPfzE9oBBus8vBumMiJscedYDcfM1Fss5aq8rTz70ol1x1czFFYV6aQLb3xD/veVjefOdDnYLt/xdUwP5+awXNtMSJz9UK+itvvCMLzDdK1llztQGlWXvMqvLUI7f3cIssPP+AcXiRBEiABCqdABX0Sr8DWH4SIIF+Cey8/RYyY+ZsefWNd/uE+fczz4vf75Ptt96sz7V0PDZaf23514O3iNvtTid4XsIcffh+csl54/OSVjaJvPza23L73Q/JOWccLzdfe6HstesOsv02m8plF5whb77wuGyxyfrZJMs4ORAo9T2Rg+g2iVp5Yiww/2j5+I1n5N7brpZNNlx3QABDGupkg/XW7OGqg8EB4/AiCZAACVQ6ASrolX4HsPwkQAL9EkDDcn5tJfrX0//XJ8yjTz4n2221qdRUB+Wrb76XUyZcLGtvMtYM2d5ipwPkvy+82idOd49UQ9z/+nuG7L7/0bLwcv+Q3fY7WqDQdo+D48HygoX6rvseM3GtoaWXXHUTogqu9R7i/tU3P5hh74uusIGstM42Zuhqe3vYhMfGGlqO4cwY0rrgMuvKJtvtI++8/zEuZ+SuufEOWWKxheX4ow7sE2/kiGGy+9ht+/j39vj5l9/lyBPOkiVX2Vg23nbvHsOsTz5zkpGtd5wp/3zAMG1ta+t9KXkeiUTlnIuulrU23kkWWHpd2X73wwRW4mSAroP7H/m3bLnzAWb6w+nnXCqYCtF1yez+mj5D9jv8JFl2jc1liZU3Msez5zSaa9Ym3bys8L/8+oesst62ctBRpwmmRFh1MvXF12TjbfYW1ElvFlbcp557MRkG9+f1U+62Lpl973vCSnug+l5v813lm+9+FNxX1j2W6l41GaTYWEPOH378adlpryME997q628vqCfp9ff2ex/JtrseYn5XYHDWBVdKZ2dnMhTYXnr1zYLfHOpt3c12NVMRuodJBu528NKrb5nh2egw6ubd4/D/XnpdDh43XlZYaytzv+110HHy9bfTkmHArr/fWjJQr4Pb7nrQTO2wZMX91D3IuBMnCvK58vrbZc2NdpQF9e9t133Hye9//NU9mGCYOaa+LL/mluY+210/N377/c8eYdK9zyDDQPd0j0R5QgIkQAIkUHACroLnwAxIgARIwKEElFKyy45byb+efr6HIvb+h5+a+dKwsKNoH336pcQ6Y3LiMQfLtZdNlCUWXdg0sj/65AtcTsvF43HZ44Bj5bMvvpVJ554qY3W+J5x+gXz82Vc94g+W15GH7CPbbrWxrLbKCslhpXvvtmOPNKyT6TNmaUX0EGPFv+bSiXL0YfvJ4/9+TivAE6wgZh+NdsgV190qk845RT7SlrNVVlpO9j/8ZAmF2s31dDfvfvCJbL7JP8Tj8aQbpUc4yLHXwcfL8ssuJZB3vtEjZPcDjpFpP/1iwu27x44C5p983pPZPQ8+LmN32EoGstwdftwZ8vDjz8juY7eXO26+XGAZfOPtnkO473/4SXnyP1Nl3KH7yaEH7Cm33/2I3KyVf5O53kBp2nKnA+W773+S8SceYUYr/Prrn7Lb/scI6lcHMf/TycsE1Bso5zvseZistvIK8s8bL02yQyfKyWdeJJecf5p8+vZzst7aq/dgoaPKi6+8KQcccYqsusrycst1F8sWm65vOiFSKcIIbzlwHqi+J19xniy80AKy/15jk/cY7gnER8cSlGUcD+ZOPeti2Wu37eWTt56V0zQvKN+P/eu5ZDTMGUdHSW1NUG68+gI54qC95aHHnpJzJl2TDPObVlyhNO++8zZy2+RLZNON1pXJU+6SG2+9Lxmm9wGUc9xHV1x0phx24F69LyfP0emw2CILyuUXnCGnn3SkhHTH1c57HyEtrYmOnkx+a0gU6zGMn3iZrLPW6rouL9O/hfXk+NPOl2f++xIuJ90rb7wrr7z+tjx012R5/flHJdrRIbvqDrvunQ57HXS8fPDRZ3La8YebESi//v6XbLvboT1+k+ncZ4Pd00mhsjx494NPZcRiY2TxlTaSXfYZJ2++80GWKTEaCZAACVQOASrolVPXLCkJkEAWBMZuv6U0Nc+V5198PRn7Sa2w19fVyjZbbGT89tl9R7lWK7h7a0V41522kSnXXST77L6T3HX/4+Z6OhssNvXpF1/LPbdeZRSffffYSe686XKBxVi6/e0zSF5LLbGIjBwxXCAfRgDALaqVjG5JJA+n/PN+aaivk8fuvVErsFvKuMP2lWsvO0f+/cwL8rHudLACdmgFYfyJR8q6WrEYMXyoUdTB5OXX3rGCDLpHZwAU+vnnGz1o2P4CJOQ4Qk4Yd5DssM1m8sA/r5OlFl9UW17vN1HWWG0lWW6ZJbWi/bQ5x+bjz74ULEq1l1YEcZ7KwVqMMj98z2Q57YTDZavNNpBTjjtU7rjpsh7BhwxpkEe7WJ1x8lFy4D67ms4bK9BNt90nTU3N8uzjd8oh++8he+yynTx23006/+9k6guvmWDp5oXAlnK+9phVtUJ3qelIgT8cFP6LJp5s6mSolmvSOaf2YIEwV1x7q+yt70ncm9ttvYlcNPEUI9e1N94hUPARJpVLcO6/vsG5KuCTBReYLzl0eUhDfaqkBvTbS8sG+XCvYn/YgXsIZLMiTbryJhmj6/Thu2+QHbfdXI45Yn+57rJz5Z/3PCKzZidGJay8wrJy15Qr5IiD9zYdU+Bw3oQT5Z4HH7OS6bGHcr73IScIlPMD9t6lx7XeJ0gL0zHA7nDdOfDkA1MkWBWQp//7ogmayW+tUd8X6PTAfXXlpDNl6y02lAvPPkWOPGRvueamO0x61gaK+K3XXyxLLLaI4LeLYyygiHsUYWDZx0KLD911gxy8/+6ym+6cePSeG+Tv6TPkjnsfRRAzsgThc72nTWJZbpZYfBH9LNtZ7rnlKjnrtKNl+oyZZjTEu+/nf7G+LEVkNBIgARKwJQEq6LasFgpFAiRgFwJQRhZbZCH51zPPG5GgGD351PNGQcRCcvCc09gk52qr3gZb7mGGzWLY7wOP/lt+/vV3XE7Lvf/Rp7LickvLWmNWSYZffdUVZdWVlk+e4yAfeSEduHd0Q3njDdZNWmXhhxEDdbU18vpb7+M06dbQslgnsEQvOP9o+emX3yyvou1h2bYyU0rJxhuuLbDSWX4H77ebWSDPGnoOi+uSiy8i6FywwvTev/bmu7L0kov2Yd073AbrjumxqN+qKy8nP/08jwGYba07bYYNbUhGRYcGFOy33/vQ+KWTl1JKfv3tT4HlfIN119TW70k9lHOTkN4MxAIK+DvvfyybbbyuDjnv/7577CgYhv/VN9/P80xxlG19o0Pi//59T4oU+3ptvH7PVfk3Xn9d+fyrbwX3eDgcMdM09t59hx4Rt9SdJxi6/b62HuMCfo8YNm4Ng8dvD6uHT/vpNzMdAGGUUtjJi6+8JVDOr71sogymnCMCLPNHnXC2jNlwRxmy0KoydOHVZNpPv8pPP6f/u0Y6cBjZASV9z117jmbZarMNBSNyUF6Eg8MIkflGj8ShcaNHjZAVl19G3vswodi+q+t12aWXEHQQmAB6s9CC85vRA2++m7BQp3Of6WiywSD3NMJk6048+mA5/6yTZJstNzIjTv7vP/ea39lVk2/LNsle8XhKAiRAAuVJgAp6edYrS0UCJJBHAnvssq08O/VlY3V87c335I8//5add9gymcPJZ04SDEvdb6+dzTDbpx653SyANrvLypcMOMDB39NnyqiRw/uEGD26p18+8rIyQTmGDqmzTs3e5XIJho7/8dff5hybKm01hMOx5Twet7RlMMR95IhhZr7+H3/2nEtrpZfOXiklsPh3D9tQ3yCYu2/57bnr9jK3pVWe0fUFJR1DpvfZYyfrcsr973/8LSOG9+ScKmBtbW0P74Dfb+YCW54o28OPPy1QEru7V15/RzAEGeHSyQtK5/9eeVN++/0vGXfYfj06BZAGnFJ9WQxpmMfiz7+nm2H1Q4bUI3jSQdnDCYaGY5/Koa7hul/LtL67j0r7vgAAEABJREFUx+3veEive2/o0ISsf/09U/78a7qJhs95dWc5cvEx5qsKv/3+h7mOOeSXXj1FttSKO6Y9/Ofh24xlGl9eaGyaa8KAJw5QN4sstIBsn8bCjlivYO+Dj5dQe0iOPeIAeURbqPG7Xkkryo1NTUguI/dHV3nW3GjHHvfHTnsdYdKZ9tMvZo/N0BSjEYbpepw+YxYu6+fPdMGoCXPSbTNq5Aj5/ffE7zad+wxRB7unESZfDvfUZhv/Q3fCfJevJAubDlMnARIggRIRoIJeIvDMlgRIwDkE8Ck1NNifmfo/+dfT/6eVuaGyyQbrmAJACfzPsy+Yhc8wJxVDcTGsHAqNCZDmZpRWzuc0NfcJPWfOPL985WVlggXw/p6eaPRbflBm/vxrhiyQw1B0K63e++223lReeOmNpGWz9/XBziEbVtXvHm76jBm6Q2GetRHDpVFfjzz5tDz935fMUOi9d+tphe0eH8cLzD9KZsycicOcHKyYO223RXJeNhQ6y51y3GEm7XTyUkrJQfvtJvvqjoVd9xunLbbzrPQmEb0BC0wz0IfJ/3MaG8VSwOcbNdIo9n/rjp9kAH1gdWYstMB8+qy0/xsbEwq0JcXs2QnFd/So4YJ7E184mHDqMSl5br15YnoJOmLG7rC1wFq7287byIb/WEssRd9KV6mEBf2aS8+WYLDKrPWAEQbW9VT7Dz763KwzcdmFZ5i6wBcG8LvGcyBV+MH8Fpw/MbXjwTuuT1ke3DtWGqmeA7PmNAk6uRBm/vlGmuHsOO7uMMR9wQUT+SyQp3u6e/r5OI5GY/lIpizSYCFIgARIoD8CVND7I0N/EiABEugigHnNq668vDz+n//KU8+9YBaOg/KAy/G4GItedXU1To1D4/9/r75ljtPdjFltZfniq2+1dSxhAUO8P7XVrfuCZ+nmVa2VkO5DZpFWKrf2mFUE81lhbbSuw9qLxc7WX2+M5ZW3PeYQ//DjLzL5lr5DoKFw/neQle8hyPP/S8zlxjHiYG2ANVdfCadJh3n68L/trofM8Nr5ug0XTgbqdrDR+mvLt9//JJiv3s0748MN/7G2fPr517Lyissm52ZDqYNbftklTXqZ5IWh2OutvYaM3ecobU3/08TvvvnfK/PuMbB4+dV3ZK01VjZBAgG/YGg9OBiPrg34jdaWVgyR7vLKahcMBiUSmbfafzaJvPz6PPkR/5U33pYVlltKhmgLss/nlU03XEc+/eKrPizBE5/6QhzcuzXVVThMuqn93Ef44sJj995khtDvf/hJWv5oMk7vA8wDh19tzbzfNX6L0376Fd5JV53mb231VVc0CjbmkkP+3g6yWYmmeg58/uU3subqiekva41ZVb6f9rNgbQUrDn6zr77+nqy75urGK5P7zEQowgaL6z393Iuyoq7jImRX6Vmw/CRAAg4mQAXdwZVH0UmABIpHAJbRZ6e+rC2tswXHVs5QJDbUVrt/3v2QQCnGom6HH3emNHUNr7XCDbbHPM1ll1pCDjv2TPnhx5/lp59/E3xOTCmVjJpuXkstsah89sXX8tzzr5jFopBWMpFuBxg+HYlEzCfiMHT/5dfeltPPuUyXb3NZZcXluoXMz+HKKyxrFlY7/5LrZNyJE+Whx5+Sp5/7n4yfeImsvv4OMvXFgT9Nh9Xfr7vpDh3uNVMurPqNodxHHbpvDwFRH4suvIBZMXr3nbfrcS3VyT/WGWPKfPBR483n8bCQ2FWT/ymHHH16quD9+h1z+H7i9bpl0+32kclT7hF0dmBY9b6HnSj4rB4ippMXlG04TDe49fpJgoXCxu5zpLn3kAYcWFxy1Y09WHw37SfpzuK0E48QjO645Y4HDC/IcNNt98mJxxwiUOCRTrYO99iLL79lyoh7Z05jwvp9zkVXm/spnXSf0nV/z4NPGNmwv/3uR+SkYw5NRj1vwklmxAWGgePzb8jnBt25s/XYg5KfHfvHOmsIFm387fc/ZfacRrnsmlvkxZffTKaBA7C09lgf4In7b5ZvdIfMQeNONZ1ruNbboZMFozEmT7nbfNbtw48/lyOOm2CmaXQPCw7p/Nag6E88/TiZcP4VcszJ55h6wf1xwaXXC1a+755mQ12d+e2jvHBHnnCWYB2Mnbbb3ASDNR/30fHjz5dX33jX8MO8+6FDGwRrMCAQriN8rvc00krl3n3/E5MvFjLEdcgJh05FnGOdA6wLcMe9jxgZ8cnCrXc+UP6eMVPGn3gkgtA5mgCFJwESKCQBKuiFpMu0SYAEyobA7jtvY8oy/3yjpPeCY7B0erXFb4mVN5K1Nx0r88830qzObCKkuVFKycN3T5YqbfnccKu95B9b7G4+nbXlpuv3SCGdvDA0+uD9dzPKwA57HCYPPvafHmlYJ1jA7NnH7zIdAvhs2nGnnW/KNuXaSVaQvO+vu/wcwSrWX3/3g5xz0TWyn7ZkYig6hnRffsHACrHX65FJ554mJ595key895FaAf9QHr3nRll80YV7yKmUMnOSUb7tt96kx7X+Tm6bfKmxtp99wZWCT5P9n7bUQ8nvL3wqfyi9U/91j7F0QjGBYomVu5deYjFZZ83VklEyyQuK+P23XyNDhwyRsbrMUEKRUDosNttoPbnvtmvkwUefEsynhvJ6+klHaSV+HySRk7vgrJNk8cUW1h1KZwjusU+6Pgf4sd7/nObigUjjjnsfNfGxevuFZ58su+2c+J1BOFjTX3zqfkFHxUWX3WDCPaUtsNtutYkMHzYUQeS4ow6UzTdeXzbfYX/zKa/3PvhEMJTdXOxngxEVj993s3zw4ecy7qSJRgHvHXTokAa5+5Yr5aVX3zafCdvzoOMEXznA5wu7h033t4Y4++81Vu697Wr5+rtpcrTOd48Dj5Wvvv1e9t1zZ+n+t9oqy8tG668j+xxygiCMx+2Rx++7yXCwwj1453WC+/OoE8+Wg446VVpb2+SZR/9phvBbYTK5z6w46e4PP/5MUx93aAUccXAPwFmjF2qqqwVrDJx53hWy456Hy7U33SULLzy//O/p+wULbyIOHQn0S4AXSKDCCbgqvPwsPgmQAAmkRQCflGr87RP58r3nzdze7pEW1wri/bdfK79985b89f27ctkFZwg+z/Tq1IeTwa646AzBAlaWxy47bi1IDwqY5Td61Ah5XFv3fv/2LYE74+RxWkm4SvCZJStMOnl5vV6zUNZHbzxt8jjzlKNNdCjGmBNtTro2yyy1mJkT+9MXr8lnbz8n6ADAYk5dlwVKxZ/fvWOdJvfvvPQvwSejkh4pDlA+DGvvfemwA/eSl555QL796H9GPjDFp9Mgd++w1rklB6yHX7w7VWb9/KG8/OyDZvizFcbaY3gyhn/vPnZbbdH2Wt4D7jE64WKt/L//6n/k16/flP8+eZepQyvSJ28+KycefbB1avZ77LKdzPwpsWq28dAbDM/GZ/Ys9kjv3DNP0J02o/TVxP9M88K86an/ulte/79HtaLekEhEb9NhgZEZLz/3oLk333npSTn2yAN0zHn/e98TFud5IRJHvesb9yo+Q/fdxy+ZOtx4g3XM2gKYu33gvrsmIg2yhYKJOsR98uHrTxsFuHcUKOn4vNk3H71o8gGH47VS7vf7TNDqYFCuuniCfP3hC+Y6VpFHvSDN4cOGmDBLLLaIubbmGquYc2ywAjrSxG8LHQDw6+1QJuSHew3lPGjf3cxv5dLz53Uk4Z698OxTxKpv67fWOy3rfIdtNpMXn7rP1MffP7wnmJM+ttuCk1a4U48/zNyH+O098cDNYg3pt67jSwu333CpeR798Okr5nN+Cy80v3XZ7DO9zxAJ7Hrf0/Dv7fB7AOPeDh1tCFtTHRQ8E1FGhMGzBZ9FXG2VFXCZjgRKSoCZk4DdCVBBt3sNUT4SIAESIIG0CHR0dJhht5dcdZNZ4OvIg/dJKx4D5YcAPiW20ILzyfZbb5qfBJkKCZAACTiPACUmgZwJUEHPGSETIAESIAESsAMBLEKFYbaY23zjVRfIIgsvYAexKkYGWKjf/t8TfUaYVAwAFpQESIAECk6AGVQCASrolVDLLCMJkAAJVACBhvo6M5QZSmL3uczlVvT+hqE7pZyphpw7RfZCy3nztRfKQ3dNLnQ2TJ8ESIAEUhOgry0IUEG3RTVQCBIgARIgARIgARIgARIgARIoXwIsWXoEqKCnx4mhSIAESIAESIAESIAESIAESIAE7EmgbKSigl42VcmCkAAJkAAJkAAJkAAJkAAJkAAJ5J9A8VKkgl481syJBEiABEiABEiABEiABEiABEiABHoS6HZGBb0bDB6SAAmQAAmQAAmQAAmQAAmQAAmQQKkIFEJBL1VZmC8JkAAJkAAJkAAJkAAJkAAJkAAJOJaAAxV0x7Km4CRAAiRAAiRAAiRAAiRAAiRAAiTQLwEq6L3R8JwESIAESIAESIAESIAESIAESIAESkCACnqRoTM7EiABEiABEiABEiABEiABEiABEkhFgAp6KirO9aPkJEACJEACJEACJEACJEACJEACDiVABd2hFVcasZkrCZAACZAACZAACZAACZAACZBAoQhQQS8UWaabOQHGIAESIAESIAESIAESIAESIIEKJkAFvYIrv9KKzvKSAAmQAAmQAAmQAAmQAAmQgJ0JUEG3c+1QNicRoKwkQAIkQAIkQAIkQAIkQAIkkBMBKug54WNkEigWAeZDAiRAAiRAAiRAAiRAAiRQ7gSooJd7DbN8JJAOAYYhARIgARIgARIgARIgARIoOQEq6CWvAgpAAuVPgCUkARIgARIgARIgARIgARIYnAAV9MEZMQQJkIC9CVA6EiABEiABEiABEiABEigLAlTQy6IaWQgSIIHCEWDKJEACJEACJEACJEACJFAcAlTQi8OZuZAACZBAagL0JQESIAESIAESIAESIIEuAlTQu0BwRwIkQALlSIBlIgESIAESIAESIAEScA4BKujOqStKSgIkQAJ2I0B5SIAESIAESIAESIAE8kiACnoeYTIpEiABEiCBfBJgWiRAAiRAAiRAAiRQWQSooFdWfbO0JEACJEACFgHuSYAESIAESIAESMBmBKig26xCKA4JkAAJkEB5EGApSIAESIAESIAESCBTAlTQMyXG8CRAAiRAAiRQegKUgARIgARIgARIoAwJUEEvw0plkUiABEiABEggNwKMTQIkQAIkQAIkUAoCVNBLQZ15kgAJkAAJkEAlE2DZSYAESIAESIAEUhKggp4SCz1JgARIgARIgAScSoBykwAJkAAJkIBTCVBBd2rNUW4SIAESIAESIIFSEGCeJEACJEACJFAwAlTQC4aWCZMACZAACZAACZBApgQYngRIgARIoJIJUEHPsfa9Xp8M5s4//wL54IMPBw03WDq8PjjrYjFq/PYxmfPNo7asUxEl8bjYUrZi1Q/zKd5vxe32SEdHB++3NN4FvC/zc19Go1HxeLy857K95xgvo3uns7NTlFIZxeFvPfC/ut8AABAASURBVD+/9UrkqJRLOjvjjr/fhH85EXDlFJuRSYAESIAESIAESIAESKCLAHckQAIkQAK5EaCCnhs/xq5QAiNW2EdGrrhvhZaexSYBEiABEiCBkhBgpiRAAiRQ9gSooJd9FbOAJEACJEACJEACJEACgxNgCBIgARIoPQEq6KWvA0pAAiRAAiRAAiRAAiRQ7gRYPhIgARJIgwAV9DQgMQgJ9CYw44sHZPrn9/f25jkJkAAJkAAJkAAJlIQAMyUBEigPAlTQy6MeWYoMCUz76Tc5dvxFsv62+8sxp13UI3ZbqF0uvGKK7HXoqbLrgSfKY/9+Pnnduvbov6fKI//6b49rL776tozZdI+kQ9rJiL0Obr7jIbn17kd7+fKUBEiABEiABEiABGxJgEKRAAkUiQAV9CKBZjb2IuB2u2SPnbeW44/ou9Db5FvvF+VSct+tl8ldN06Sx/7zvHz17TRTAOvarjtsITtvu1mPawiw/jqry/v/e8S415+9F150JEACJEACJEACJEACAxLgRRIgAYsAFXSLBPcVRWCRheaXDdcbI8GqQJ9yf/P9j7LeWquKx+2W2ppqWWXFZeS/L75uwlnXRq20nyy4+kE9rpkA/Wwam5rltHOvlL0OO1WOPOk8+fHn3/sJSW8SIAESIAESIAESIIG8EmBiJOAgAlTQHVRZFLU4BJZeclF5+71PpLOzU1pa2+STz7+Rv/6eaTIf6BoCfPDxl7LW5nvJ3oefJk9PfRlexk258xFxu1zy4G1XyPlnHCsffPKF8eeGBEiABEiABEiABEjA2QQoPQnkkwAV9HzSZFplQeC4w/eVaEeHbLrTIbLbgSfKgguMFgyJR+EGujZm1RVl6uO3ykv/uVP23mVbufz6O+TdDz9DNPno069k/z13FKWUjB41XDbdcB3jzw0JkAAJkAAJkAAJkAAJDECAlyqMABX0CqtwFndwAtXBKjl3/NHy8lN3yX8fu1Vq9PlCWklHTOvao5duKfect1GPa/V1NWbIPMLsuM0mstlG68inn3+DaBLX/zwejznGxtvtGOd0JEACJEACJEACJEACJFB8AszRbgSooNutRihPyQlgWDuEaG0LyUNPPCsvvPKW7LrjlvAyQ95xEIlG5fOvvutxbW5LKy4Z9/eMWcZqvspKy5rz1VdeXl57831z3KGt82+//4k55oYESIAESIAESIAESIAEypYAC5YxASroGSNjhHIg8POvf5jPoZ132U3yzgefmmPrs2dffzvNnG+286Hy3Auvy41XTJSRw4eaYlvX7n7w3/L9tF96XLv+1vtNvHW22FtOnXiFjDtkL1lztRVNvKMO3kO++eEn80m3k8++XGBlNxe4IQESIAESIAESIAESIAESyIpAOUaigl6OtcoyDUoAq7hbn0Oz9kccuLuJN0Yr1fB7+/kH5O6bLjYrtZsLemNdm3DZE3LE6Xf0uHbWyUeYz6u9/X8Pyr1TLpWtNv2HWH8N9XVyxfmnaoX+bLn+0gnmupWfFYZ7EiABEiABEiABEiABEiAB2xAoiSBU0EuCnZmSAAmQAAmQAAmQAAmQAAmQAAlULoHUJaeCnpoLfUmABEiABEiABEiABEiABEiABEigqATypqAXVWpmRgIlJjDjiwdk+uf3l1gKZk8CJEACJEACJEACJEACJFBOBJyioJcTc5aFBEiABEiABEiABEiABEiABEiABPoQoIJukHBDAukRiMci0tkRknhnTOLxTnPcqf3Si81QJEACJEACJEACJEACJEACJNA/ASro/bPJ3xWm5HgCnR1h6WhvlMafX5WZXz0ukda/Jaodjpu0X0dojlbWw44vJwtAAiRAAiRAAiRAAiRAAiRQOgJU0EvHPm85M6HCEuhonyOt0z+V39+9Tpp/e0NCc36QWKTVOBzD7/f3rtdhPtFK/JzCCsPUSYAESIAESIAESIAESIAEypYAFfSyrdq8FayiE+qMhqTl749l9vfPDsph9vfPSctfH2lLemjQsAxAAiRAAiRAAiRAAiRAAiRAAr0JUEHvTYTnRSZg3+wwxzwamikYwt5bykjL7xKZ+3tvb2n65TWJtE4XiXf2uUYPEiABEiABEiABEiABEiABEhiIABX0gejwmvMJ5FACLAb392f3ZZzC9M/upxU9Y2qMQAIkQAIkQAIkQAIkQAIkQAWd9wAJ9ENAKbdg1fZ+LhvvVJt4Z1R786elIfA/CZAACZAACZAACZAACZBABgSoRWQAi0Eri0C0bWa/BfbVLCC+2gX6vW6Gufd7Ne0LDEgCJEACJEACJEACJEACJFBBBKigV1Bls6iZEQjN/qbfCB0dUYHrL0BozrcSj8f6u2wTf4pBAiRAAiRAAiRAAiRAAiRgJwJU0O1UG5TFVgQCQ5bsV55YZ6fAicRThqkaspQo5U55rWI8WVASIAESIAESIAESIAESIIGMCFBBzwgXA1cSAV/NqJTF7Yx3SmfoL4m1/SWdWlFPFai/uKnC0i87AoxFAiRAAiRAAiRAAiRAAuVGgAp6udUoy5M3AvGOiCi3v0968S6lXOkrqRR05fJJZyyir/K/gwlQdBIgARIgARIgARIgARIoOgEq6EVHzgydQkB5/DJyxX36iNvZmRjWrpTqGubeM8jIlfYRt6eqpyfPSKAHAZ6QAAmQAAmQAAmQAAmQQF8CVND7MqEPCRgCLm099wWHS8MiG5tzaxOPd4q3en7x1S5ovDDk3RzoTf0iG4lXx1Funz7jfxIoEQFmSwIkQAIkQAIkQAIk4EgCVNAdWW0UulgEXN6gBIctLUOW2MpkCeUc9nOXyyVw8OyMdWInQxbfSqqGLSNub7U554YEypUAy0UCJEACJEACJEACJFAYAlTQC8OVqZYRAW/NfFIzalVZcO0TpWbB9aVqyJLi8deK21ct1Vp5r1lgPVlgreOlZr7VxK/DllHRWRQSKAUB5kkCJEACJEACJEACFUuACnrFVj0LngkBlycgbn+9VI1aU4YsuYNWxEeLt3qUDF9mrARGjhGXr14wJD6TNBmWBEigFASYJwmQAAmQAAmQAAnYlwAVdPvWDSWzIYHWtnbpiHtEudyilEtgRW+PdEh7e8iG0lIkEiCBohNghiRAAiRAAiRAAiSQAwEq6DnAY9TKIhCLxSQej4vPN28BOI/HI263W8Lh9sqCwdKSAAmUhAAzJQESIAESIAESKG8CVNDLu35ZujwSiEYjJjUo6CNW2EdGrrivOff7AxKJRIzybjy4IQESIAFnEqDUJEACJEACJEACJSZABb3EFcDsnUMASjikdbs92CUdFHScRCJh7OhIgARIgARSEqAnCZAACZAACZDAYASooA9GiNdJoIsAFHRYz5VSXT6JndfrNQcc5m4wcEMCJEACpSHAXEmABEiABEigDAhQQS+DSmQRCk+gs7NTYrEO8XoT889nfPGATP/8fpOxUkr8/oC0t3MeugHCDQmQAAmUIQEWiQRIgARIgASKQcBVjEyYBwk4ncC8+ef+lEWBgo4F5Do6oimv05MESIAESIAEBiDASyRAAiRAAiRgCFBBNxi4IYGBCWB4O0JYw9lx3N35/QnFPRzmPPTuXHhMAiRAAiRgBwKUgQRIgARIwCkEqKA7paYoZ0kJwILu8XhFqcT88+6ruEMwl8slUN45zF34RwIkQAIkUGkEWF4SIAESIIG8EaCCnjeUTKhcCWDoejQaFZ8vMf+8v3JimDuGuGO+en9h6E8CJEACJEACJJAZAYYmARIggUoiQAW9kmqbZc2KAJRzRBxcQecwd3CiIwESIAESIAEHEaCoJEACJGArAlTQbVUdFMaOBKLRiBHLWsEdJ91Xccc5nDUEPhxuxykdCZAACZAACZBAxRMgABIgARLIjEDFKOiP/Guq7HfUmXLAuLPk1bc+TElp5qw5cuz4i+WQ486RCRdeJ6Fen82a09gsm+50mNx8x8Mp49OzPAlggTi32y2YZz5YCQOBKoGCjmHxg4XldRIgARIgARIgARLIiQAjkwAJlB0BV9mVKEWBfv71T7nnoafklqvPkcvPO0kmXXWrtIcTVtHuwa+75X5ZZ8wqcsfkC6Surlbuf/TZ7pflqhvvkdVXWVYksU6Y8K/8CUDRhgV9sOHtFglrNfdolJ9bs5hwTwIkQAIkQAIk4EwClJoESKD4BCpCQX/97Q9lo3+MkepglYweNVyWXWoxee/Dz6X33xvvfCzbbbmB8d5uiw3k9Xc+MsfYfPL5N1JV5ZcVll1KJA4fukogEIt1CJR0rzcxv9wqc+9V3C1/ny8RLsxh7hYS7kmABEiABEiABEggFQH6kQAJpCBQEQr6jFmzZf7RI5LFX3D+UTJ95qzkOQ5a20KCL2gNaajDqSy0wCiZMXO2Oe7o6JDJtz0oxx2+tznnpnIIYHg7SusbZAV3hIFTSolPK+lU0EGDjgRIgARIgARIgARKRYD5koAzCbicKXbmUivXvKIqlXqMevc5xkrNC4+h7rvssJnU1db0ybi9vV0Gc/jsFhS9wcLx+uAsi80oFELHjRIMWU+VNxTx3s7tdkksFpO2tlYzH7339UKf416LRiMlybvQZbNb+u3tIf37r2yHOolGoxXJAWWnay/6swad5uTelzufR4V5FkfN+zRs+2ccfxN9fxMFZxLOf56RSFi3OTNvw6Vqo5bSr4/CRI+MCMzTQjOK5qzAI4YNlcbGpqTQs+c0ysjhw5LnOMDw91isUyK6oYnzWTrMiOFDcWiGul94xS2y7lb7ya13Pyr3PPyUXDvlXnPN6/XIYE4pJR6Pe9Bwg6XD64OzzjejWKxD15tPu555N333mDR996i43R5x93J+f5W5N9Ax0/tacc7d4nK5xd1LLp73ratcmXi9Xn1vVLbD1wvcbjzfKo9DrvcP42f3m3TpDnePJ7u45cycz6PCPINwz+B+sztfyElXHs8FlyvRhsukPr3enu3UUp+bhjA3WRNwZR3TQRHXX2d1ee3tDyUcicjsOU3y5TfTZO0xK5kSfPTpV7qnqsMcr7fWqvLCy2+Z4+dfelPWX3tVc3zbtefKW1PvM+6IA3eXA/bcQU48an9zLZ0fj1KKCpMDlUURZeafY+G33vXs0g1EpVy648XTxyXCu/V9Fe1zDS/5Qju3VpbgCp0P0y+PhkDvezvzc7fg95B5POfz42+g7/OvGEys+60YeTkpj0r8DRajzIn7zS1um7djnHSvUtb+n51ov8FlyiiL+1PcBbynhX85EXDlFNshkRdZaD4Zu91mcujx58qJEy6Xk44+QHza8gXxx593jTQ1z8WhVrr3laemvmo+s/bLr3/KvrtvZ/y5qUwCGNaGkvvSnH+OsJbz+wOCYUrxOFcUtJhwTwIkQAIkQAIkQAIkUAkEWMZcCLhyieykuHvsvJXcN+USuefmSbLRemskRf+/J26V4cOGmHPsb77ybPOZtYsnniBVgYDx7745eJ+dZNwhe3b34nGZEsAGMYWPAAAQAElEQVRcbhQNPYzYd3f9reJuhYGCjmMo6djTkQAJkAAJkAAJkAAJkAAJ5IFAmSdRMQp6mdcji1cAAlDQYT1XSmWcurdrhEY4HM44LiOQAAmQAAmQAAmQAAmQAAmUhkCpc6WCXuoaYP62JIAF3rBAnM/nz0o+pZT4/QGz6mtWCTASCZAACZAACZAACZAACZBAuREYtDyuQUMwAAlUIAFr/rnX60tZ+hlfPCDTP78/5TXLEwo65qB3dEQtL+5JgARIgARIgARIgARIgARIoF8CuSno/SbLCyTgbAIY3o4SWEPVcZypw2ruiMNh7qBARwIkQAIkQAIkQAIkQAIkMBgBWyvogwnP6yRQKAKwoHs8XlEq8/nnlkz4NAvSCIfbLS/uSYAESIAESIAESIAESIAESKBfApWsoPcLhRcqmwCGpUejUfEN8Hm1wVZxtwgGAgFBWpjTbvlxTwIkQAIkQAIkQAIkQAIkQAKpCFBBT0UlL35MxKkEoFBD9oEUdFxPx1nD3Pm5tXRoMQwJkAAJkAAJkAAJkAAJVDYBKuhOrX/KXTAC0WjEpN3fAnHmYpobDHFXSkl7e3uaMRiMBEiABEiABEiABEiABEigUglQQa/Umh+k3JV8GQvEud1uwRzy/jiks4q7FRfD3DEPHUPnLT/uSYAESIAESIAESIAESIAESKA3AVdvD56TQBEI2DYLKNEYju7z+fMmIz63hsSiUX5uDRzoSIAESIAESIAESIAESIAEUhOggp6aC30dTSB74WOxDhM5H8PbTUJ6Yyn7sKLrU/4nARIgARIgARIgARIgARIggZQEqKCnxELPSiWA4e0ou2+AFdxFB0h3FXcd1HyqDemFw2Gc0pEACZAACZAACZAACZAACZBASgJU0FNioWelEoCCrpQSzEGXPP5hmDus8x0dCQv9QEnzGgmQAAmQAAmQAAmQAAmQQGUSoIJemfXOUvdDIN/zz61sfF1z2pG+5VeiPbMlARIgARIgARIgARIgARKwKQEq6DatGIpVfAKxWEywSJxvkOHtkCyTVdwR3uPxGKt8+Q9zR2npSIAESIAESIAESIAESIAEsiFABT0baoxTlgSiXd8/T0dBzwYAhrnDgo5OgGziM46IEAIJkAAJkAAJkAAJkAAJlDEBKuhlXLksWmYEMP8cMdxuD3Z5d1DQkSiUdOzp7EeAEpEACZAACZAACZAACZBAKQlQQS8lfeZtKwJQnH0+v1l1fTDBMlnF3UrL6/WaQw5zNxgqccMykwAJkAAJkAAJkAAJkMCABKigD4iHFyuFQGdnp2AOui+N+efZMlFKid8fkPb2ULZJMB4JDECAl0iABEiABEiABEiABJxOwOX0AlB+EsgHAWv+udfry0dy/aYBBR1z0Pm5tX4R8YJdCVAuEiABEiABEiABEiCBghOggl5wxMzACQSs+efWMPTBZM50FXcrPb/fbw7D4Xaz54YESCBBgFsSIAESIAESIAESIAER2yvoGHr87P+9KseefonscsBJssF2B8lWux0l+x5xhlx89e3y6+9/sR5JIGcCsKBDOVdK5ZzWQAm4XC7xeLxCBV34RwLFJMC8SIAESIAESIAESMARBGyvoB9y/Lny3kdfyv57bC/XXXK6/O9ft8uDt10m54w/SpZZahEZf9418uIr7zgCNoW0J4F4PC7RaFQKPbzdKj2s6MgPnU+WH/ckQAJOJkDZSYAESIAESIAESCA/BGyvoJ9+/MFyrlbG115jJVlogdFaifLI0CH1ssySi8quO2wh99w0SRZcYFR+aDCViiQAZRkF92WwQFw2q7gjD7hAIICdYNV4c8ANCZAACQxEgNdIgARIgARIgAQqhoDtFfTlll58wMrwej1GWR8wEC+SwAAEotGIuVosCzqGuCulOMzdUOeGBEig1ASYPwmQAAmQAAmQgH0I2F5Bt1BhrvnNdzwsx51+iRx1yoVJZ13nngSyJYAF4txut2B+eLZpZBoPVvRwOCwYXp9pXIYnARIgAQcRoKgkQAIkQAIkQAIZEHBlELakQS+66lapr6+T/fbYTg7db2zSlVQoZu54AlCQMdTc50usrp5ugbJdxd1Kf97n1qKWF/ckQAIkQAIZE2AEEiABEiABEigvAo5R0Otqq2WfXbeRtddYWdZcbcWkK6/qYGmKTSAW6zBZ+jKYf24i5LjxdXUItLe355gSo5MACZAACRSMABMmARIgARIggSITcIyC7vN65adf/igyHmZX7gQwvB1lLNb8c+QFp5QSn+4UwDB3nNORAAmQAAlUHgGWmARIgARIgAR6E3D19rDr+bSff5e9Dx8v+4+bkJx/jrnodpWXcjmDABR0pZRgDrpk8JfLKu5WNhjmDgt+LBazvLgnARIgARIggXwRYDokQAIkQAIOJOAYBf3ko/eX6y89Q44/Yp/k/HPMRXcgc4psIwLZzD/Pl/hQ0JFWOMxh7uBARwIkQAIk4CQClJUESIAESKAQBByjoHefd979uBBQmGZlEIDlGovEYah5KUoMqz1cOBwuRfbMkwRIgARIgATsS4CSkQAJkECFEnCMgv7F19/LqROvlG33PNq40869Sr74+ocKrTYWOx8EMLwd6WSjoOe6ijvyhYMVHVZ8dBTgnI4ESIAESIAESKDwBJgDCZAACdiVgGMU9ElX3yaLLDSf3Hj5WcYttMBoueTa2+3KlXI5gEA0GhGllLjdHinVn9+f+Lyb1VlQKjmYLwmQAAmQAAmQQN4IMCESIAESyJqAYxR0WBiPO2JfWWyRBYw7Xh9Tqcm63hlRE4DlGqu3K6X0WWn+I3/kHOY8dGCgIwESIAESIAESGJQAA5AACZQzAcco6J2dnTKnsTlZFzNnzUke84AEMiWA+wlz0LMZ3o688rGKO9JRSonfHxAq6KBBRwIkQAIkQAIkUHICFIAESKCkBFwlzT2DzPfedVvZ89DTkp9Y2+eIM2S/3bfPIAUGJYF5BDC8HWeWBRvHpXIY5o4Og46OjlKJwHxJgARIgARIgARIoCgEmAkJkMDABByjoO+87aZyx+TzZfON1jbujskXyI7bbDJw6XiVBPohYE2P8Hq9/YQonjcs6MiNVnRQoCMBEiABEiABEiCBrAkwIgk4noBjFHSQXnD+0bLbjlsat+D8o+BFRwJZEYAFHcq5UtnNP8/XKu4Q3uVyicfj5TB34R8JkAAJkAAJkAAJ2JkAZSOBwhOwvYK+7lb7yWdffifYp3KFR8Qcyo0AFhyMRqNih+HtFlsMc4dMGOpu+XFPAiRAAiRAAiRAAiRQQQRYVBLQBGyvoL819T5ZafmlBPtUTpeB/0kgIwJQhBEh2wXiEFdEiVL5+/lYw9yxsrzwjwRIgARIgARIgARIgATyTIDJOYNA/jSMApf3qhvv6ZPDhVfe2sePHiQwGIFoNGKC5GJBH7HC3gJnEsrDxhpuz3noeYDJJEiABEiABEiABEiABIpNgPnliYBjFPTvpv3cp8hffv1dHz96kMBgBLBAnNvtEcz9HixsMa8HAvjcWlgwBL+Y+TIvEiABEiABEiABEiABErA3gcqRzvYK+n/++7L5tNr3034x+6NOudDsDzz6LFl80YUqp6ZY0rwQgPKLYeS5DW/Piyh9EsEwd8jX0RHtc40eJEACJEACJEACJEACJEACBSJgo2Rtr6CvvvJycuh+Y2X0yOFmj2O4S845QSadfbyNUFIUJxCIxTqMmLkq6Plcxd0IpDc+n19vRcLhsNlzQwIkQAIkQAIkQAIkQAIk4HwCmZTA9go6Pqe25moryn23XCLYW27+0SMzKSfDkoAhgOHtOMhl/jniF8IppcTn82kFvb0QyTNNEiABEiABEiABEiABEiABmxNwZS5faWKEIxG5+8H/yIkTLjND3K2h7qWRhrk6lQAUdMw9d7vdtiwChrl3dHRILBazpXwUigRIgARIgARIgARIgARIoHAE7Keg91PWCy6fIjNmzZGZsxpl7HabSk2wSpZdatF+QtObBFITyNf88xEr7CMjV9w3dSY5+EJBR3QOcwcFOhIgARIgARIgARIgARKoLAKOUdCn/fSrnHrsgVJdXSVbbfoPufLCU+W3P/7OuLYYoXIJwCqNRdjsOLzdqhVY9uHCYQ5zt5hwTwIkQAIkQAIkQAIkQAKVQsAxCnp1ddDUSUdHTNpCCeUlGrXdMGAjIzf2JIDh7ZAM87yxt6uDFR2WfnQm2FVGykUCJEACJEACJEACJEACJJB/Ao5R0Guqq6Wxea78Y61V5eBjz9ZuooweOUwq64+lzYVANBoWpZS43R7J9a8Qq7hbMvn9idXcrQ4Fy597EiABEiABEiABEiABEiCB8ibgGAX92ovHS0NdrRyy31iZcNLhcvShe8r4Ew4p79opdunKPD8ovBjerpSydUkhIwTkMHdQoCMBEiABEiABEiABEiCByiHgGAW9e5WssuIy5pNrbpcjxe9elIo6LmVhOzs7zcrodh/eDkZKKfH7A/zcGmDQkQAJkAAJkAAJkAAJkEAFEXDZvazrbrWfDOTsLj/lKxqBATOKRiPmumWdNic5bAq1irslEoa5o1Oho6PD8uKeBEiABEiABEiABEiABEigzAnYXkF/a+p9Arfn2K1kn123kXtuniSP3nmVjDt4T9l5203LvHpYvHwRwPB2pOX1erHLwhU3CizoyJHD3EGBjgRIgARIgARIgARIgAQqg4DtFXSrGj745Cs57oh9ZanFF5EF5x8lB+y1gzQ2N1uXuSeBAQlAQYdyrpRN55/3kt7lconH45VwOCz8IwESIAESIAESIAESIAESqAwCjlHQoWA1Ns1TyNvDEZk9Z955ZVQXS5kNAXyurKMjKvka3g4ZCrmKO9KHwzB3DM3HUHec5+IYlwRIgARIgATsRiDU3i54x3397Q/SNLdFwpGIdHTE7CYm5SEBEiCBohJwjIJ+wJ47yp6HjpezLrpeJl19m+x16Gmy07abpA3rkX9Nlf2OOlMOGHeWvPrWhynjzZw1R44df7Ecctw5MuHC6wQvDgT84usfZItdjjBz4Q88+ix57oXX4U3nEALRaNRI6oQF4oygXRtrmDu+id7lZdcd5SIBEiABEiCBtAm0a8U8rA0tF1x6vex+wNFy1gVXyCHjTpWDjjxF/u+l12T6jFlpp8WAJEACJFBuBByjoG+35YZy5w0XyGorLyvLLLmITLl6omy7+QZp1cfPv/4p9zz0lNxy9Tly+XknyaSrbhVY4HtHvu6W+2WdMavIHZMvkLq6Wrn/0WdNkIUWGCVP3HONvP7cPXLqsQfJdbfcl1TeTQBubE0gmucF4opVWI/HY77bHq74Ye7FIs58SIAESIAEikHA7fbIPoceL99+P61HdhHdoX773Q/Js8+/JM1z5/a4xhMSIAESqBQCjlHQUSHzjx4pu+24pXGjRw6HV1ru9bc/lI3+MUaqg1UyetRwWXapxeS9Dz+X3n9vvPOxbLdlQunfRXGthAAAEABJREFUbosN5PV3PjJB6mprpLamWtwul9RrxV0pl3R2xs01buxPABZot24MYF53vqQt9CrukFMpJYFA4nNrGKYPP7oCEGCSJEACPQh0dnZKS0urfs919vDnCQnkg8CcxiY5Z9JVAyb11HMvyEeffDFgGF4kARIggXIlYHsF/ahTLpQffvpVsE/l0qmYGbNmy/yjRySDYpG56TNnJc9x0NoWEq0PyZCGOpwKrOYzZs42x9h89OlXZoj73oePl0lnH2eUffjHYh0ymINy1dkZGzTcYOnw+uCsezPC3HOsX4AF4npfc8I55Mb9Ew63Z3T/8H7L/F4p1P1QCenyfiuP+621rU3+98obcvs9D8t5l1wrt9/1kLzw0uvSFgpl9Pwp9D3P+83Z9xsMHd9P+1nwbhvI/aDD4P1d6PtpsPR5vzn7fhusfu14vRzuOehIdNkTsL2Cfuh+Y2XUiGGCfSqXbtGVtn5bYZVKvZJ3dwur0lZyKzz2q628nBni/s/rz5crrr9DZs9pgrd0dHQM6vACisVig4ZLJy2GGZx3d0awnqOiULfd/XM/jkpHNFLwOrXuQyjo6coM6xfvt8zuk3TZ2jBcwe/BwcqMew333GDheN3e9+Ss2Y0y6YobZPItd8tzz78kP/z4szz3wsty4233yMQLr5QZs+aU/F6z7qHOzrhtZLFk4j69+xvPi+9++NHUH9pGlgO/mG5PWefYf/nN99La2mbC4nqpXCzWqTuoOksuR6nKz3zTu7fzxQm/Ebh8pVeqdND2psuegO0V9DVXW1FqqoOCfSqXTtFHDBsqjY0JhRrhZ89plJHDh+Ew6TD8HQ9hzH+C5ywdZsTwoThMOrfLZYbHjxo5XL75/ifjj4W8BnNQDrGC+GDheD0gfn9+nUiiMyYYrBZ/HtNu/v5JadIun2mmSisQqBIsbocHbKrrqfxwr8Gluka//N5f5c9zcF4+n998EpAsBmdlV0aRaEzuffBJ+ea7aYL3VW/30y+/y213PiThcIf48/gczTYtrM+RbVzGK+19iufF4osu3OM+U0qZ6RSxzsSUCuv+W3D+0eIP+MVf4nsOI9l8Pp/4SywH8y/tvVss/j79Ti2HNpzwLycCtlfQDz3+XBnIpVP69ddZXV57+0Pz+Y7Z2vL95TfTZO0xK5moGLoejXaY4/XWWlVeePktc/z8S2/K+muvao6/n/aLtIXazfFvf/wl037+XZZafGFzzo29CWB4HF72brfb3oIOIB1eClDQO7saLwME5SUScBYBSmsLAi0tbfLmux8MKMvHn30hs+bMGTAML5JAOgRa20IypKE+GTTeGTfH6E7viEbN0Hd4zD/fKKkKBHBIRwIkQAIVRcD2CvqJR+0nA7l0amuRheaTsdttZhT9EydcLicdfYD4vF4Tdfx510hTc2Kl0BOP2leemvqq+czaL7/+Kfvuvp0J8/tfM2SnfY83c9D3OeIM2WuXbWT4sCHmGjf2JoAh7j7d821vKQeWzu/3mwAY5m4OuCEBEkiLAAOlR+DPv/5KK+DvuoM6rYAMRAIDEKgOBmXcYfsnQ3TGE5Zzr88nUNWhpFcHq2TsDluLUlDbk0F5QAIkQAIVQcBl91KutPxSMpBLV/49dt5K7ptyidxz8yTZaL01ktH+74lbk8o2lO6brzzbfGbt4oknJHtuER7h3pp6n7z69F2yz67bJOPzwL4EMIcnHo+L15tQcPMpaTFWcbfkxQr0GAFABd0iwj0J2IJA2QiB+ebdC9MZ65RwOCzYd/f/6effzEi07n48JoFMCXi9HllisYXlmMMPMFFhQXdpRVwpJV6PV2pra+ScM44XhDMBuCEBEiCBCiNgewXdqo9wJCJ3P/gfOXHCZT1WdLeuc08CvQlgeDv8nG5BRxkwzB0NZnQ44JyOBEig3AkUr3xrj1mtR2axzpg5tyyb5kRv1h6zqvi1lVMf8j8J5ESgob5ONlhvLbn8wjPlwH12kTGrryxbbbaRnHjMIXLb5EulvjaoO4kSUwtzyoiRSYAESMCBBByjoF9w+RSziuzMWY0ydrtNpSZYJcsutagDkVPkYhGIRsNmeBysz8XKs1D5WMPco9FIobJguiRAApVEoFtZhw5pEI/bk/CJx82CXTjp3SE4YuQweNORQF4IwEK+6MILymYbryfHHXmQHLTvrrLR+utIVVWVeXc3NTUKRsLlJTMmQgIkQAIOIuAYBX3aT7/KqcceKNXVVbLVpv+QKy88VX77428HoaaoxSYAC7rX6zMv+nznPeOLB2T65/fnO9l+0/P5/KYc4TAtCv1C4gUSIIGsCNTUVMs1l040cbuvpB3vtjDlFZPOkoa6OhMmnQ3DkEA6BPCexnsNw9p9XaMzlFLS0DDULBbX1MSFCdPhyDAkQALlRcAxCnp1ddCQ7+iIJVdUj0YTw/DMBW5IoBsBrHiOnnfrhd/tkmMPfVpJb2+ngu7YCqTgJGBjAsOGDhEMLR4xbKhgPrDb5TILduH8xqsulPlGjrCT9JSlTAhYo8J6j3TDp/Tq6uolGo3K3LnNZVJaFoMESIAE0iPgGAW9prpaGpvnyj/WWlUOPvZs7SbKaA63E/6lJhDtGgru6+qRTx3KWb4Y5o6Oh46OxGcBnSU9pSUBErAzAb/fJ3W1NXLhxJPliQdulfPPPlkeuftGueyC02X0qBFSVRWws/h5lo3JFYtAVCvgXq/XjBDrnWdVVVD8/oC0tbVyPnpvODwnARIoawKOUdCvvXi8NNTVyiH7jZUJJx0uRx+6p4w/4ZCyrhwWLnsCGDaH2B6PF7u8u2Ku4m4Jj4YKjjEcEHs6EiABEsgngfb2kCjpFJe2nq+0/LLactkkbrdjmgn5RFHYtJi6IYA1Djo6ooKpaMYjxaa+vkHfg27hfPQUcOhFAiRQtgQc8+a98oa7ZdrPv5mKWGXFZWTN1VYUt8sx4hu5uSkeASjo/fXKF0+K/Obk0vc7OhzC4XB+E2ZqJEACFU8AylIo1CY+n98o6Eop8Xg8AgWq4uE4DIBTxI3FEqPB8K7uT2allDQ0DDHz0Rsb55h9f2HpTwIkQALlQsAxGu78o0fI+HOvlv3HTZD7HnnGDHcvl0pgOfJLAA1NNCoH6pXPb47FS83v90s0GhEMdS9ersyJBEig3AngmYnnSlVVVbKoUJyi0WjynAckICJ5g2DdW7jPBkrU4/EK5qPjHm1tbRkoKK+RAAmQQFkQcDmlFPvstq08dtfVcsKR+8p3036Wnfc9QSZceJ1TxKecRSRgvfRhCSpUtsVexd0qhzXMPRKhFd1iwj0JkEDuBEKhkCilxO8PJBODYgSlHS7pyQMSyBOBqO5sRlJu6xN/OJHUG2s+OhR0vv9SM6IvCZBA+RBwOa0oY1ZdQQ7bfxfZYpN15aXX33Oa+JS3CASsl/5gvfJFECXvWXg8HtOI5jD3vKNlgiRQsQQw6gjzz6GcK6WSHKxnKCyXSU8ekECeCESjUfFlsJCrNR8dQ91jsSy/4pMn2ZkMCZAACRSSgGMUdKxcPfV/b8jRp02SI066QAJ+v9x788WFZMO0HUoAvevokcecbYcWoV+xlVLi1xaucLidc/H6pcQLJEACmRDAMxNKOqyU3eN5PIlFNqFIdffnMQnkSgD3G9p1VidQOukppcSaj47voyONdOIVMwzzIgESIIF8EHDlI5FipLHTfifIi6++I7vusIU89eBkOeWYA2TJxRcuRtbMw0EE8MLGAnGZ9MpnU7xSrOJuyQkFHeVE48by454ESIAEsiWQGN7ukt7KklJK3G63UEEX/uWZgDUqI9O1YtBphPnouCcx3D3PYtk9OcpHAiRQIQQco6DDWn75eSfLZhuuJR7dYKiQ+mExMyQQ61oVttAKeoZi5TU4FopDgrCiY09HAiRAAtkSwPxyPEuwOJxS84a3W+lBabeUKcuPexLIlQAUbKSB+wv7TBxGeuA9CAUdHfKZxGXYgQjwGgmQgF0I2F5Bf+CxZ81Q3qFD6lMye/HVd7Vl/e2U1+hZeQSsl3WmvfJOIqWUMvP20Kh2ktyUlQRIwH4ErOcIlJ5U0sFiGYvFzHs41XX6kUA2BKCgK6XE5XJLNn91dQ0mLoa6o5MpmzQYp8gEmB0JkEDaBFxphyxRwL9nzJQ9DjlVbr/3cXnz3Y/lvY8+N+7pqa/IsadfIrfc9bDMN2pEiaRjtnYjAAXd5XKZYZmFlK1Uq7hbZcIwdwxxR8PZ8uOeBEiABDIlEAq16eelRzweT8qoloWTVvSUeOiZJYFoNCK5dKTjPY/56FDOG/l99CxrobyisTQkUE4EbK+gnzTuALnuktNN7/1DT/xX/nnfk8a999EXsv2WG8gDt10uyy+zRDnVCcuSAwEsdlTOw9stNBjeh2OUF3s6EiABEsiUADr4otGoYHh7f3E9XCiuPzT0z5IAlGrce1bnT5bJaAXfa76PHtXKfltba7bJMB4JpEOAYUigqARcRc0ty8zmHz1SDj9gN7n+0jNkylUTjTv/jKNl683W53z0LJmWYzS88LF4mtfrL0LxlChVup+P2+0Rt9st1vDUIhSYWZAACZQZAXxaDUUaSEGHpRKOFnSQossHAete8np9OSeHqRnosG5pmSsYQZdzgkyABEpCgJmSQE8CpdMwesrBMxLImYD1cvb5cn/pDybMiBX2FrjBwhXyOoa5h8NhM7qkkPkwbRIggfIkgOHteF66XO4BCwhLZ1Rb2gcMxIskkCYB617yelNPq0gzmWQwzkdPouABCaQmQF/HEaCC7rgqo8D9EYhGw6KUMpZlqYA/WA1QzGg0gh0dCZAACaRNIKoVbow6CgSCg8bBMHeseYERSoMGZgASGIQA7j2XyyWuQTqGBkkmedml0+o+Hz15gQckQAJFIcBM8k+ACnr+mTLFEhGABR1D5pRSJZKguNmirMgxHG7Hjo4ESIAE0iZgDW+3OvoGiuj1es3lWKzD7LkhgVwIRHWnsvX+yiWd7nFxj9bW1gnSxufXul/jMQmQgKMJVKTwVNArstrLr9DWojMYrlmM0pV6FXeUUSklfn9A2tupoIMHHQmQQHoEYAnH8PZAIKCtmK5BI8GCjkBRbXXHno4EsiXQ2RkTvK+hUGebRn/xgsFqQYcT5qNHdSdAf+HoTwIkQALzCNjzaPA3c4nlvvKGu+WBx57tI8W9jzwtN/3zoT7+9KhMAtbLuFgKul0oozGCxg4tW3apEcpBAvYngNFGUNLTGd6O0rjdbjN9KEoFHTjociAQjSZGYRRCQYdY1nx0fHoN70b40ZEACZBAyQhkmbHtFfQ33/1Y9th5yz7F23uXreW1tz7o40+PyiSABidKbll6cFwJzq8t6ChnOBzGjo4ESIAEBiXQ3t5mFO5MOjShUFmrbw+aAQOQQD8Eol2W7UK9q7vPR29qauxHCnqTAAmQgL0JpKugl6wUbrdLPJ6+K33CLxxJ9MQK/yqeQCQSETQglSrO/PMRK2aRq74AABAASURBVOwjI1fct+TcXS6X+X1wmLvwjwRIIA0CsCrieYFPqymV/vPS4/FKVFvQYXlPIxsGIYGUBHAPud3utKZWpEwgDU+0BTAfPRIJS1tbaxoxGIQESIAE7EXAZQ9x+pfC7/NJKMUc25bWNqkK+PuPyCsVQwANRlh2MrEGlRMcWNGj2iqBhnc5lYtlIQESyD8Ba7RNusPbLQmg9OAYc4ixpyOBbAjgXZXvBeJSyWHNR587t9l0LKUKQz8SIAESsCsB2yvoO2+3iZx5wfUyY+bsJMO/Z8ySsydNlp232zTpN+ABL5Y1gai26qCAXm9ldthAQUf5MYoAezoSIAES6I8AhrfDgmkp3P2F6+0PCzr8rOctjulIIBMC6NxBh3qm914meXQPm5iP7hLOR+9OhcckQAJOIGB7BX23HbeU5ZdZTHY76BTZ54jTZY9DTpE9DzlN+y0uu+24hS0YU4jSEsAwNkhQrJc+8rLDKu6QA87j8Zj5pGF+bg046EiABPohAAUJHXlVVcF+QvTvDaUeV6mggwJdNgSse6dY72pMAWtoGCK475ubOR89mzpjHBIggdIQsL2CDixHHLi7PP3QDbL3rtvIwfuMNcfwUyr9+XNIx6GOYg9CIBqNmHnYeBkPErQsLyulxO8PCBR0WCfKspAsFAmQQM4EQqF2k0YgUGX2mWyUUmadD0wnyiQew5KARQDvahx7PF7siuK8Xp9gPno4zPnowj8SIAHHEHA5RdLammrZYauNZZvN15ea6sx7/51SzuLL6ewcoZDCIoSXsLNLkpv0UNDBoqODCyfmRpKxSaB8CYRCbUbJtqzhmZYUilW0a0pRpnEZngRw73i6RnwVkwbmo/t8fuF89GJSZ14kQAK5ELC9gr717kfJQC6XwjNuEQgUOItYLKGQ+ny+AufUM3m7rOJuSWWVP8xh7hYS7kmABLoRQOcdnpfZDG+3ksHQZHQEYsiw5cc9CaRLINGZXjzreXe56usbzMrxnI/enQqPSYAE7ErA9gr6jZefJQM5u4KlXMUhgBc+crIUVBxXosPwfjCggl6Jtc8yk8DgBGA9RyiMtsE+G+fpGpoMS2g28RmncgmgcwilL9VoN7wjOR8dNUBHAiTgBAK2V9CXWGwhGcg5ATJlLBwBKOh48bpc7kJk4qg00fCGdQvO5bL9T9tRbCmsswjgN9DS2iptbSH56NMvzWeWWlranFWIPEoLHqFQSPz+gLEiZpu0x+MxUamgGwzcZEDAumcwCiODaHkNis4Baz56KFS5z4O8QmViJEACBSHAVnxBsDLRYhHACu6wHBcrPyuf/KzibqWWn308rqQ9HJV33v9YXnr1Lfnr7xnS2hrKT+JMhQQcQmDGzFnyyedfybgTz5b9jzhJLrr8etnr4OPklAkXynR9ralprkNKkj8xoRzF451SVVWVU6JKKbMgJxeKywljRUbGPYiCu92JTh4cl8JZ89Gbm5uE93EpaoB5kgAJpEOACno6lBjGlgRisZjE43HxVuj3z61K6ezslMamZpl05Y1aKZkoV1x3i9x0+31yzCkT5eQzLzDXMP/UCs89CZQrAVjMv/rmB7nwsuulTVuMu5dz5uw5+vdxlrS2tQl+M92vlftxe3ub+RSjz+fPuagej9eMSMg5ISZQUQSi0Yh+V3vNfVjqgnefj442RKnlKcf8I5GooI2GZ22UC0uWYxWzTAUmQAW9wICZfOEIwHqO1H1FXiAOedrJxWKdctLpF8g33/0gLrerS/mIGxGhlBx6zPiCNIpMBtyQgI0I/PH3dLnu5jsGlOj0cy6V2XMaBwxTThehgLS3tws+raaUyrloGKKMRjdczokxgYoggHsQShruHTsU2OVyCeajQ4FsaqqcZ0Ex2Le0tMorr78j5158texzyAmy76EnyLmTrpG33vlQmpsrb/RSMZgzj/IkYHsF/Y13P5aBXHlWC0uVDoGo7pFXSonb7ZZi/9llFXc0MO5+4DFpbmkxCNDwwEG8M45d0l127RQJ9bIoJi/a84BSkUDGBKZPnzloHFjW3a7iPzMGFaxAAcLhdjPSKNfh7ZZ4lpLF4cEWEe4HI4D3FMJ4PMX92gry7M95vT6pqakV/D74bpS8/DVpBfzx//xXrp9yp3z7/Y/SEeuQiLaef/P9NLly8q3yzNT/UUnPC2kmUgkEbK+gP/LkVBnIVUIlsYypCUQiEfFp67lSuVuFUudgf9+wZvDb738mBYWCDhqd8c6kHw5+++1PwTUc04EAXbkRiESi8sHHn/coFjqqOqIdgn33Cx992jNc92vldtzeHjKdmFBI8lE2DHFHOlHd8MaejgQGIxDVnekI4/N5sbONq66uEb/fr5XGRuE0sNyqJaqfB2+/95H859n/6zehx/79nHz4yRcSi/Vsn/QbgRdIoIIJ2F5Bv+6S02UgV8F1V9FFx/BK9Mp7vfbpkS9FhbS2tMn3P/7cI2vlcmmFRL8A4/Os6H/PmCmzZnEoXw9QhTxh2kUn4PV6ZPFFF+qRb4e24MQ6Y4J99wuLLbpw99OyPcZzMhwOm+Ht+SqkUsoo/FRohH9pEoDyppTS901pF4iTFH/19UNM53VT0xx9dd47U5/wfwYEoh0d8tY7H/SMkQLn62+/L6H29p7heEYCJNCHgO0V9O4SR7Ul5POvvpP3Pvo86bpf53HlEIgme+RLo6DbZRX36ppqWXyRnsqGu2vIf1T3aFt3xIjhw2TosAbrlHuHE6D4fQkopWSB+UclL8BqDgXVpf2xh7Mu1tfWWodlvYf1HAXM1/B2pAUHK3r35wv86EigPwK4V3DP9He9lP5KKWloGCrocGpubi6lKI7OW4mSH378pUcZwBSuu+ePOgyeyd39eEwCJNCXgGMU9Nff/kh2OeBEOXHC5XLF5Dvl+DMulRtue7BviehTEQQikYgpZ6Vb0L0et0D5NjC6NnhRut0e6dQWdOvlON+oERLriHWF4I4EBiTg2ItLLLqIrLj8skZ+jLDBbwHPCKWUvv87jP+eu2wvXp+9htoawQqwgYIOxQjPg3wm7/V6JRbrECz+lc90mVZ5EsB6Bbhn7Fo6yIb56KFQm+A3Y1c57SwXptD59HMhKaO2nmP0UiwWkyjaa/oc18AaYXFMRwIk0D8BxyjoN/7zIbntuvNkycUXlkfuuEruvOFCfbxI/yXjlbImAAXdW+HD21HBeNkdecg+Euz1fWMMc/doJR0vx85Yp5x+8jiprg4iCh0JlJhA4bKvra2RYw/fX78bFhU0Ds1oEiXi8XhMh9WWm24gm2+yvtTWVBdOCJukjN8+LJf5tp6jeHjuYG91AOKYjgRSEcA9CH+7v6+rq2vE58N89Cbd+cTObNRZJg7TiBbrNsUIz1/Ex7MXHXmRSFgwiglhMBwe1+hIgAT6J+Dq/5K9rni0pXD0yOGCYe6QbNmlFpM23duJY7rKIoCHPXrkfb7SDG8Hbbus4g5Z0Bt96fmnyyILLYjTpINyMrShXq6YdKZE0YOdvMIDEihfAiNGDJOzTjtGjj/qIBm749ay0nLLyL577CRn6k6q3XbeWobo30T5ln5eyWANxFkgEMAur87jSYxAiHZNNcpr4kysrAhY94jVqWPnwtXXN4hSSubMmc3RIRlWVJV+zuy8w1bJWJ3aco6h7GiHeH0+wzUajcoO22wqNTQWJDnxgAT6I+AYBT1YlWhkNNTXyL+f/Z9gyPucRn5Tsb+KLWf/aFej0O498sWqA3RezT/fKDl7/LFyzaXnyDHagnjwfrvLFRdNkKsumSj1tUEJh0NscBSrQphPSQnAStMeapV/rLOG7LP7TnLSsYfJrjttK2uvubp06GdHa2vik4TZCumUeFDQfdoi6HLl/5NyLpfLLKyFjlKn8KCcpSEQ1UqZUkrcXWujiI3/cF/X1w/RFvQOmTt33nz0jo5Obf3tGqNtY/lLKRrYLbrQAnLoAXuKWf8jHheX221EUkqJ1+eTow8/QIYNqZfGxjmaZ6e5xg0JkEBqAo5R0HffaUtpbJ4rRx+6l7zwyjty36NPy5EH7pa6VPQtawIY3o4COqFHHnIWwymlZOiQBll4wfll4w3XlW233FgWX2xhMz8dC+BguGtTE1dxL0ZdMI/SEsAcUoyygeXY6/VIfX2tsd54PB7x+wMCBb2z07ZDWPMCL6o7ItBRUYjh7ZaAHm1Fj2rlyzrnngRSEcA94qTOdJ9WJDEfHdM3PvnsK7njnkfkjHMvkwsuu04eefxpswJ5B9dzSVXVUlNTLZtsuJ4ZwbTe2mvIAvPNp91o+cfaY+TCiafKpvpaXV2tRCJhmTVrhuDeSJkQPUmABMQxCvrmG60jDfqHvcSiC8nky86UKVdNlNVWXo5VWIEEorrx6dGNbfTYlqr4dlnFPVX50TCHs655vV6pq6vXVvR2aWtrtby5J4GyIwDFHAo4vm3sdnv6lK+2a/X2lpbytqKHQiFTdnRImIPkJn8HeK50dHQImOcvVaZUTgRwb8RiHYJ7xUnlikRj2hD0lpx9weXy9NQX5bc//pQvv/peHn7yadnvsBPly6+/kwg7p1JWacDvlUUXXkBby/eXyy86Qy45/3QZd/j+svwyS0og4JeqqqAMHTrcxJ09e6ZYzyrjwQ0JkECSgCt5ZPMDNATefv8TueO+J+XWux9NOpuLTfHyTAAvfFjQndQjn2cEWSWHlyIa6xi2F2XDIiuGjGR/AuFwuxk6iQWfUkkLpT0YrNaNwjYp1+HZeEZiFEEgUGVGDqTikA8/r+74QzqxWLfRCPCgI4EuAtZvzLpXurxtvcMCZlDAH37saS2nkg68L3uNbj//0mslRiu65tP3f3t7u362RqQ6WKVdULsqqdKKefeQuB+GDRuhO2580tzcqF1T98s8JgES0AQco6CfddH18vhTL0hYW0+13PxfoQTQUYOiYxga9qVzSjd+HfPzMZjq6xvEra2KjY2zjRJjPLkhgTIiAOu5x+M1Db/+igXlXSklc+eW5xomGD4KJb2Qw9vBFpyxL2aHH/Kjcw4B695wUod6NBKVhx/XyrkS8ehOqM543HwRojf1R558RiuiiU839r5WyeehUJtgvQGv1zcgBoyAHDp0mOB5jDgY8s7OvgGR8WKFEXA5pbzt4ahccf4pMu7gPeWIA3dPOqfITznzQyDa1UHj8w388M9Pbv2nMmKFvQWu/xD2u6KUkiFDhpohqU1Nc+wnICUigRwIYGQNOvDQ4BsoGTQMMcc0EgkL4gwU1onXQqGQoIw+n7+g4qMRrpTSSkq0oPkUMXFmlWcCeF/jXoTLc9IFSw7DsH//8y+TvsulxKM7tTFlrDPeafyszY8//SIc5m7RSOzx/I1GoxIMpv8ZSzyLrXVyoKSX4zM5QYdbEsiMgGMUdJ/PI9Yn1jIrIkOXEwE8vPGyd7nc5VSsopXF7XZLvbakg2NLS3laEIsGkxnZigCs57i/A4HAoHKhAelyubQVvbyGVsIAQc0UAAAQAElEQVRyHg63SyBQNSiDfATAUFU0yPORVvmnUXklxL0xmCXVblRmzem5mKrb4xallPS27s5taZW2ULvdxC+pPCFtPYcAmT5/sGYIhrzj+T1nziyzkCfSoSOBSibgGAU9EumQPQ49Va65+Z7k/HPMRa/kyqvEssPqVWjLULlzxVx0KChQaMLhcLkXl+WrAAKw3ODZgPs63eLW1tZp62+HYL52unHsHs4qS6GHt1scPB6v7jiPWKfcl5KAzfKG1RlKLTpxbCbagOLUVgdl2JAhPcKgMw+dXyiTdWGpJRaT2pr0LcVWvHLdgw8UdLQvwCvTckI5x+JxiA/jwZw5nIqXKUOGLy8CjlHQV1h2cdlms39IdbA4loHyqubyKA1e9ngJ+Eo8vB007byKO+QbzGFYGRpOGOoOroOF53USsDMBdDYppQSLIaYrJ6w8Ho9HW9GbzbSPdOPZOVwoFBK32yMerTgXQ048Q5APnyGgUN4u09I5cYE4lNGlfz9j1lgZh0nnUi5R+qz7fb7e2quL3wZtES2WLf6Hw+3mORoMBrOWRyklDQ1DBJ2n6HDFkHeMwsg6QUYkAQcTcDlF9u7zzrsfO0V+ypk7ATywkYrThsxBZrs5pZTU1yesBI2Ns82L1W4yUh4SSIdAZ2fMWMGDwWpRCs3odGIlwtTW1psFE8vh84NQHqLRiO6kqEoUrghbqyMgGuU89CLgdlQW1j1h3SODCG+byz6vRw7ce1dZcvFF58mkHysut9s8K+KdcTlk/z1l6aWWmHedR+bLGLCc56N9hmf5kCHDDFV+is1g4KYCCThGQZ/T2Cz3P/qMYDV3uAcef07gV4F1VrFFjurGp1JKW4c8FcsgnwXHkDL0VmN48Ny5zflMmmmRQNEItLW1mbyCWVhuMBoH8x8xpLL78FWToMM21vB2jAwoluh4hiAvy1qKYzoSAAG8r3F/QGnDeWldZrn7/T654KyTZYtNNpARwxKKIsqx0ALzyWknHCGwngd0mMxSLd/QsViHYF2bYBadpP1RwbN52LDhglE6/BRbf5ToX84EHKOgn3vpTfLyG+/L6qssZ9z/Xn1Hzr98SjnXDcvWiwBeAHho9/IuyemIFfaRkSvuW5K885mpz+cXDHcPhdqMFTKfaTMtEig0AUx5gfUbc65dLndW2dXU1Jl4ra3OXjQRv2GfzydubekzBSrCRimlO0wxD50W9CLgdlQWkUjUKFeOErqbsFDSD9CW9GsunSi3XHexPHH/FJl0zmmy1BILS0N94pmRDF7hB6FQyBDId+cgnumYlw7FP6TbKBjyHovFTF7ckEC5E3CMgv7X9Bky5eqJsusOWxg35aqz5bc/Ep/CKPdKYvnEDC3Dgzkfw6fIsycBvPzQsG9qahRawnqy4Zm9CaDRBiU9GKzJWlCPxyOYuw5LPEaTiAP/8LvF8zHfDeR0UMDCBWtpOmEZpjIIYDRKPN6pFXSfowscDAb0syEg9XU1ZhX32tpqve8ww7mLWTA75xWPxwWdpD7d2V+ozsHa2jqpr2/Q7ZMOgZJuTXe0MxfKRgK5EnCMgu5y9RXV5VK5lp/xHULAagD6tIXIISI7RkyllNTXDxGXyy2NjXNMZ4hjhKegFUsADUMsDufTDUMo2bmAqKmpMdEx1N0cOGwT6rJg+f2BoksOBR11AaWs6JnbKEOUv6MjJtNnzNJKXEwrE5Vr6bPe17g3bFRFOYsCA4Hb7TEKKe75nBO0RwI5SQFlGSyCWUwxyiRjdD5iyLvL5RKs8I5nfybxGZYEnEagr9Zr0xKsutJycvSpFyU/sTbu1Emy5morpS3tI/+aKvsddaYcMO4sefWtD1PGmzlrjhw7/mI55LhzZMKF10moPfGNy48+/UrOuOBa2Xzs4XLYCefJK29+kDI+PQtHIBJJfMrH4/EWLpMMUnb6Ku69i4qXHuajwwoHS3rv6zwnAbsRCIfDpjOpuro6Z9FcunOqpqZWwuF2M5cy5wSLmAAax1DQoZy7dOO1iFmbrKxncrRCF4rDMxMgrr/5Tjn65LNl3ElnyYFHnCwTL7xSZs6aLa1dayQgTKU4616w7o1yKnd1dcKabrVJyqls2ZQlFGozi3OiozR1/Pz54n7CkHfkhc5UKOroGMtfDkyJBOxDwDEK+vjjDpIdttpIfv71T+N23nYTOeWYA9IiiTj3PPSU3HL1OXL5eSfJpKtulfZwpE/c6265X9YZs4rcMfkCqaurlfsffdaECVYF5NRjD5Kpj98iB+61o4lvLnBTNAJ4GaL3WimOmigUdFg76urqtYISNhaCQuXDdEkgHwQwZ9zj8Qgaa/lIL2gWOHLJ3LlN+UiuaGlEoxGJxzsF8/CLlmm3jFAHOMUwe+wrzcFqvut+R8lrb70ns2bPMcUP6c6jb3/4UY48YYL8/MtvEu3oMP6VsonqzhpYmpUqv/d1IBAwCimGdVdKffZXTnROhfW9jilCShWnrtEJOWTIULN2Dqz3s2bNENxv/clIfxJwKgHHKOj4UW6vFfRJZx8vcNttuaHALx3wr7/9oWz0jzFSHayS0aOGy7JLLSbvffi59P57452PZbstNzDe222xgbz+zkfmeBkdfvjQBnG7XLL+OquZh4FlXTcBuCkogXg8Lmj8+Ti8vaCckThetGiAYFV3vvRAhM6OBKJaKe3QSg+sWfmSTykltbW1+lnTIe1do6fylXYh0wmFQkZh8Pn8hcym37SVUuJ2e8x7USrsr7l5rpwz6ZoBSz3xoqtlzhxndfoMWKA0LuL3iQ7fNII6LohSSoK6Mw/KIZ5BjitAHgW2vhyBdkMek00rKTz7oaijfVjIT7GlJUweA6HDoy3ULi0tbdpQEtKdr/E8ps6knETA9gr6UadcKD/89Ktgn8qlA3vGrNky/+gRyaALzj9Kps+clTzHQWsbGjkiQxrqcCoLLTBKZsycbY67b558+kVZcvFFpEr3onb353HhCOBlj9RhQcfeDq5cVnFPxbKuTndG6QZ3Y+NsM4Q4VRj6kUApCWD+ITpoMaw7n3IEAlXi1vc+OqjQ8Mtn2oVICzKikQy5lSqOBStVOaCMRbXVNNW1cvbz+X3y/bQfBy3iN99NGzRMuQSAVRX3pZ3e1/lmaymklWxFRx1jYU3UszWKJt+cB0sPnZLDho0Q5O/QT7EliwjFfNasOXLrnQ/KeRdfK2eef7ncdPu98tqb7wmuJQPyoGII2F5BP3S/sTJqxDDBPpVLt6aUtn5bYZVK3ZBBg29emL5oPv3iW7n/sWflnNOOtIIJGoqDObyw0IgaLByvt/TDs9Xwjmqrmd0Y4QVtN4d7LRxu172vrVm5UKhNAroDCi/gOXNmZpWG3ZgUSh673Y+lkAdsw+FwP7/dlrz7Ywg68vN4vObezGeZURafz6s7pmLS1DRnUNkRvpSuuTlhmVVKGRalkgXPis7OmOFVDBkw5akY+QyUB56zX3/7g1kQDu94y8GqGuuI9fD/6NPPpbWtteB1lM/fQrZpzZ2b+FwhRr1lm4bd4oX1+zQUCpn7G7Kh7vH8gR/mQsPPDm6g+zXf11DP+M273e6C39cDyY66QYeJ1+szq+vPmDHd1NNAcex27edff5MPPvpMDj12vLz4yhsy7cef5O/pM+T1t96Tq2+4TZ58aqqZKjOY3H3vwRbDolT+puHOTdYE+mqhWSdVmIhrrrai1FQH5c+/ZwqOu7uff/0jrUxHDBsqjY2JhgwizJ7TKCOHD8Nh0lUHq/QLtVMiXVaAWTrMiOFDk9dhTb/h9gflhsvP1Nb10Ul/DLMZzOEBFtCWmcHC8XqNpGIgEjc9pFjEKdX1UvrhxWA3B6uiz+eXXOQCU8xH79ANTSzCkkta5RwXnCrdBYPV4vf7U/52C8Em3jXir6FhSEHyxAgSn88nUAJRtoHKUOp7G79NvF/wbCy1LHgpQmkphhyon2LkM1Aefn9Ahg1pELfLnXRKKd2OiOk3Vjzph+tDGxrE4/bk9EweSBbr2kD3arGuud0uwR/eH8XKs9D5oK6xxkP3fFA+0TXtcrkK8hzqnle6x9Z9UIx9PB4zU2vAoRj5DZYHhrtDFnQaQCF1646DweLY5XpAvz+vmnx78pnhcrnFpVzJ80effFag7/j9VQM+Q9K9T/IWrjp1m91KH88BuuwJuLKPWtyYz/7fa30y/NczL/XxS+Wx/jqry2tvfyjhSERmz2mSL7+ZJmuPSawAjxXao9HEAi7rrbWqvPDyWyaJ5196U9Zfe1VzPHPWHDlr0mSZcNLhMt+oeUPlzUVuCkoAlhk0lNE7WtCMMkzcWsVdKWVeUkqV3x6dSlBQ8LJDHShVfmVUKrcyZXjbMHiOBND4CoXazBxQpVSOqfUfHd/dxbMH1rH+Q0lJf/vxuO5QjoQFv1OlVEllwRB30X+xWEdR5NBZFSUfpQbmOv98o0SUiOXQYSL6rzMW01v9v+va8ssuKejEUkqJUoVzOseS/49qIwc6akouSIEFwD3v8XiMhTJu9RoWOM/BkleqcPeWUvPSRnmxTocdnj1KzZMLCjdWeVdauW1snGMs+0rNu66U/Y7xe3lmqtZllK5dy+lDsY679k8+9V8z1F0pJUqldohWTq7Sy2J7Bf29jz43n1b7e/oss7/17kfN/top96Zdd4ssNJ+M3W4zOfT4c+XECZfLSUcfID6v18Qff9410tQ81xyfeNS+8tTUV81n1n759U/Zd/ftjP+j/35ePvvyO9n78PGy7lb7GffX9JnmGjeFJYAGH3KAxQR7uuISgKKCzhEM94VyVNzcmRsJ9CSAOY/wycen1ZBOf87j8WpLRZVp4Nn1vkcDGfKjUYp9KZ1LWxHd2mKFxmYp5Sh23pFIVLbZYuNktvHOTlH6DIM84l1KW31dray4/LLatzL+Y2g7lNdKKC0sheiUwYJxlVBeq4wY4o9jdOBjbyeHe2/48BHm6x7oYG1snG3rhdYi2kD4w7SfpbMzLujYi3V0SIfu6BQ8RLqB/eW3P/Q7KdDNh4c5ErB9dJftJexHwCUWW0huuvKsfq729d5j563kvimXyD03T5KN1lsjGeD/nrhVhg8bYs6xv/nKs81n1i6eeIJYC8GNO2RPeWvqfT3c6JHDTRxuCksgpi0RbrfHPGwLmxNT748AhhIrpQTfHO0vDP1JoPAE4kZhhtXG5XIXPLuamjqTB+ZamgObbTCSAI1Rt1aM7SAaOjUqTUGvqgrIbjtvKytBAdcN6k6tlON9hfqIdca0sq7knNNP0O+vhEEA/uXsYlqxQMcEOnXLuZxW2RLPIpd5Lll+lbBHRyl+7x6Px5bFVUoJhryjAyUcDsusWTOkQyu+EBadat9rhfhfTz8vDz/xtGABx/b2MC4V1MV0WxYdOXhuz53bLOg4mDlzhrS1tkpjU5NEoxHzOcYOHQ6/oVTCYHX3VP70syOB3GWyvYKOOedHHLi7XHrOCYK95XbYamOpq63JnQBTsB2B1tY2jMt5hAAAEABJREFUQW/hc//3srzyxrvS0hqS9nDEVnKW8yruvUG7tHWsvn6IecFZi1L1DsNzEig0gba2kLGEFMtqg/seDTxYi6LRaKGLl1H6sFKiwRkIBDOKV8jA6CyIdSlohczHbmk31NfJaSceKXvuur2su9bqMnz4MFltpeVli03Wl8fuu1kWXmh+u4lcMHms3wnuhYJlYrOE8TyKRCL6/WivZ0ShMEW1IonfeTBon2dPf2XF2hwNDUO1dbpToAz//Ovvctixp8vp51wi9z70hDyiFfQJ518u+x12okz76Vfd0RLqL6m0/GNauYYSjsXc5inh0+Xvv//U+U8XGDnQhsJ1hEUHR6DKL8svu5TgN4ORopgK4/XoDj0MxemW6/yjR4pLdzx08+JhmRMYUEG3U9n/899XdC9Tc1IkLOJ21Y33JM954HwC6B3846/pcswpE+WkMy6Q2+9+SCbffKecMP4CmXDe5WZVS2u9AOeX1lklwIsDLzv0/oZCub3EnFVySmsHArAotLa2aEukzzRkiiUTFHSllGDl+GLlmU4+7e3tJlggEDB7O2w8aFRqQdBxoHcV9b86WCXbbLGhHLr/HjLpnFPl5OMOl713214rbR2Cjp5KgQHlDWW1y6gOyFJoZ00xaWtrK3RWtkjfKqednj0DgYHCi3np9fUNcszJZ0tT8zw9wooXl7icdvYkY8G2/Prbx3QnZFhb5aFk470ApXvmzJ5KOJTzUKjNLBiJ5yLeI3V19TJ06DAZMWKUjBo1n+DzcBidWFdbJ5tstJ55TijVSyvvJsT6664lXp9W3Lv58bC8CZRSQc+I7MeffS3oqbYiYfXU9z/6zDrlvgwI4NF03KnnyNyWxGfV0CiP63K5XEp+/f0POfnMi0QphNKe/F90AnjJ+Hx+aW5u1A3PaNHzZ4aVSwBWic7OmASDxR01pZQSDHWPagt6ONxuiwrAcxGNPzQ87aT8wQIEQLDuY19JzqqTYDAgo0YOl3ptVQcHu9wzxaoL/E5wHyhVOe9p/AYDgSrzia/Ozs5ioS5JPvF4p2BEUVVVlW6LOUZ9EAwbv+XOB40SHNNW7mgkYkZj9YZ41fW3SUtrq6CTEb9dKOHNzU3a8j1L8Pm2hCV8hjQ2ztadts26zkM6nU7daewzK/nX604AdAZACR85cnRSCa+pqRV05Hi9PiND73wXW2RhOfzAvXp7J8/XXH1l2X6bTcVjk+lMScF4UFACjvmFwboa6rIagEhLa5uE2gca9oxQdE4h0Dx3rlx69c09xI13Qj2X5IugXfda3nrXA4K9lPjPWsW9xGIUPXv0+MI60tg4R7+YEvVTdCGYYcURaNXWc8zthVJa7MIHg0HBPT9XP6OKnXeq/KD4QRFAgy/V9VL5QVFRyiVQ0kolQ6nyjWmrWjweNyu1QwawgKIKZQbnleJQ91BCKqW8VjmtRSvRcWb5lePeGrlTVVXtqOJ1xjrlr79naEXaaz7Zi7UioKTHtLIe64gZhRz37i+//aat3h1mzjraOHPnNgsUdf3TNqO3oGhbSjgUcDgo5PDDNXTU4HeP338mgKoCfllnzdXl7PHHy7JLLSE+v89EX2ShBWXXHbaW4446SKr1e8h4clMxBByjoK89ZmWZcOFkwarucGdPukHw+bSS1RQzzisBn88nf/49vUeanbq3Fv3wSlvQrQt//jVdP0Bj1in3RSaglJKGhqGmDpqaGouce+GyQw87Um9unqtf1jF2PgCGTRwaTnBWI7gUYuFrBjGthNmhAR4KhUQppZXBQClQDJgnGqeoqwEDleHFsO48RrF8Pj92xqGxDktcZ2dlvK9QVhQc9wD2leQwjBkdE7C4lnO5Mbzd7fYYRddJ5WxtazPrGkFmdLb6vD59qPS7vkM69HMdCrz2kDmNzdoy3moWmBs2bLiMGjXaDEnH0HQo4RhFiN817nGl0DpFrPy4hoY6WXG5peWMk8fJfbddI/dqd8HZJ8vYHbemcp4fxI5LxeUUiccfd5BsssGact2U+43bfKO15eSj93eK+BnLWWkRZs6aI7Nmz+lR7HhnpyhXz1v0x59/lfZQ4Vfc7CEIT3oQ8Hg8Ul/fYHqWnd4gaWlplW+//1HGn32J7LrfUXLw0afJsaeeI3c/8FhFWgJ7VLRNTmA9h0Wiqqp0ixL5/QHdKPUJPtsDS2kp0cAqi0ZiKWXoL280XGHh7+96ufpHImFzfyg1r9GOewbltayOOC5nF40mRjRCUS3ncvZXNnQgYmRLudY3OmDw28aIov4Y2NUfI6+WXmKxpHgw+vi0UQgO12CxxrNr0YUXlGFDh4pPd7R5zJoa837PycgFPPB6PVLbtfi1V7ezaqqDUlVlv47YAiJg0t0IuLod2/oQDbQdt95Y7rvlEuO232ojgZ+thbavcLaTbNjQBhkxfFhSrs5YTDrjcXHr3tqkpz5YcrFFpCpY+gdWJa3irrH3+Q8FAQoThoBhBds+ARzggakSb7/3kZx53mXy86+/JSWeMXOWPPXci2bNg46OWNKfB8UnAKt1ONwuwWDph1TCio4GODoMik8ikSMa/+ggwO8v4WOvbaJRK9LR9Ukje0lXGGni8U7BMxAN/e45wFLn0Y1s1Fl3/3I9jkajZmQHyl2uZRyoXFDq0CZta2sZKJhjr7W1JdYGsuuzZyCwXp9XRo8a0TOI1r2V0ptuvvPPN6qinl3dis5DGxJwjIL+2x9/yfFnXCq7H3yKwfjNdz/KlLseMcfc2I1A5vKEw2HBZyRMzDgaeDHTAePqNrwd10aNHCF+3buJY7rSEoDCggZoU9McgeJSWmkyz/2HaT/Lzf+8r9+If/z1t9x0272C4XH9BuKFghJobU00CtEZVNCM0kjc6/VKIBCQ1tYWM8UjjSh5D9Le3maei5Al74nnIUFLLlja8pCcI5KIRKJGTiho5qDbxu8PSFRblp34fOxWjLQOUU6r/tOKUGaBlFKmIzGqOyrgyql4cW0swdQa3M/ohHBa2ar8ftlvr51l1IheSnq3gvj08/2U4w5PWrC7XeIhCZSEgGMU9PMvv0W23WJ9wertILX0kovK6299hEO6MiDQUF8vZ55yjClJrDMm+OyFp5f1vKGuTg7ef3dxux1z25rylOtGKSUNDUPMfO1Ghy0aF4vF5IOPPx+0at7/6FPx+zBfbdCgDJBnAlBqQqE2gXLuctnjN4+FgFDM1ta52BXVgQc6MsFDKVXUvNPNzLKelpuCMlD5I5F2YzlGZ2XvcOjQgV843I5d2ToocBg14fVW9rMSv01UsmVtxnE5uMT9G9cdEEHHFqemulouu+B0GbPaSn3KsMySi8vtN1xmOj/7XKQHCZSIgD1aPWkUPhKJyNabrS/S1S5RSklnvFP4Vz4EXNpaPuXai3UnTL24XS5R+twqHVa2vPLisySge0Itv0Lt00m3Uldx783GrTtR6uuHGCsRLIu9r9v1HF+E+ObbH5LiQflBAzOqnzNJT30A6/nsxiZ9xP/FJgDlHHlibif2dnC43zHcPhQKSbGtxNZQaUvpswOPVDJASYtqK2Kqa+XoFw6HBcPblepqnHQrpMfjFXQuhctcQcezE8WuZAs6yo+6hpLe3h4q2SgbyJFvh8XhUDb8tvOddjHTw/zu4448WO67/Vq5aOKpMnH8cXLPLVfL6SePk+rqoPmtFlMe5kUCAxFwDXTRTtfiZthzR1IkLCqGRRSSHjxwPAFYX4JVPrnk/NPl1usvleOOPFBOP+kouX3yZXL26cfJkIZ6x5dRRMquDGicYnVTKOhh3Vh1RgGVtgZUaSWrQyJaZigUsKp36gdNvOvzflY56mtrrUPui0igtbVVKz4BcetOoCJmO2hWsKIrpWRukT+71t7eJlD44AYVsoQBoKQVu/OiVMXt7IwZRcznC/QrQiBQJXguwsrcbyCHX4hGI6YETlfgTCFy3KADD0m0ayUde6c7vBdRvyiXUn07oZxWvpqaoFQFArLcMkvKqiuvYBTz+jq+451Wj5Ugr2MU9D3HbiXnXHKj/D19ltxy16Ny+EnnywF77lgJdVQxZYQVs6WlRVvJfTJq1AjZeIN1Za01VpUhQ+rNA7ViQORU0NJEhoKOxhnmo8di8zrSSiNN/7mioTF3bpNEI+2y8ILzCe45dAz5fD7xd61tgCkWVgrDhgwRKO3WOffFIRAKtUk83qkbTzXFyTCDXJRSAiU9EgkLXAZRsw4KC2VUW6WrqqqyTqNYEdGBENcdXbFYrFhZliwfKN7I3O/vf2i3359Q3ot1r0CeYjvcm0q5BFbWYudtt/w8Ho/gfYJh7vgd2E2+TOVBORAHHU3Y05EACRSHgGMU9O223FCOPXxv2XSDNaV5bqtcd/EZstlGaxeHEnMpCoHEvM64LRvlvQFU7CruvUF0nSulBPPRlVJit/noaDzOndssM2b8LbNnzzLWLFj59thlB9OQcusGlVLaMqD/u11uYxGTeKJgu4/dVrrNtEh4cltQAmjUoqPO4/EK6qmgmWWZOIaxuvS90tzcrDsSum6WLNNKJ5pljQtoy0864UsZxqoz/O5KKUcx8oaCjhEeuBf6yw88lFJiTVHoL5yT/aPagu7zeZ1chLzKDmszOn/DDp/agGcxOkt9uvPa7XbnlRETIwESGJiAYxR0FAOrfB93xL5y8jEH0KoFIGXkYG3BPCdYYvkicGbFulwuqa8fYoaNQyHOphT5ioMhti0tzTJz5nStlM/UjeOQBAJVMnTocBk+fKSxgCqteZ8/4STp/mfde2hc7bzdFjJmtZXFb5N1D7rLWc7HsDRi6HBNjf2s5xZ3pZTU1tbqzpwOfW8VfgEwKOhoJLtc9m8ku7sa8vgNWrzKcQ/lJRwOD/p8UErpZ09Adwy2F6Uzp9is8azE+9vr7X8UQbFlKnV+Pq3QuvT7sLW1pdSi5JQ/7m/c58GgcxeHywkAI5NACQk4RkG/9Lo7pKW1TVvPW2Sfw8fLceMnyT0PP1VCdMw6nwRaWuaKUpgXXJ3PZJlWkQn4fD6tuNQJet1DoZAU8w/DgHEfQSmfNWumliGkG88BrZQPkxEjRkGuHhZZn9cryy69hFkwZpstNpYVl1taFlxgPtlkw3Vl3GH7ytgdtzHTK4pZBuYl0traKi6XW3y6kSs2/kOHj8fjEXRGoRFbKFGj0ajuCIiJE4a3g4FSysyVh9w4L1eX6ICI62eMf9Ai+v0Bo5xHtaV50MAOC4DnLkT2eLzY0WkCSikzEhBsovr3q70c+T8UajPtMrs/ix0Jl0KTwCAEHKOgf/n1D1JTHZS33vtE1l1zFXnon1fIc//36iDF42UnEMBLDBYiWM9dutfZCTJzFff+aykYrDbKVXNzo7amR/sPmIcrsNwklPIZMmvWDMEoDDQmhgzprpT3b9nxaAULC8bsv9dYOfm4w2XiGcfLwfvtIWusurxUBfqPl1p0+uZKIKoVGLjq6mrTMMw1vULHr62t14pXp77vWl8SesoAABAASURBVAuWFRrJSBxKHvZOcBjWnVBgnSBtdjLCuoiY6ViO8UxC2HIc5o7fK8qGOseeLkEAHXg4amtrwc5xLhbrMGts4H2ulHKc/BSYBJxOwDEKusudEPXDT76SlVdYRqqDVYK5o06vAMov0tLSrC1mLglqxY48yoNAfX2DuN1uMx8dQyDzWapYLKatrC1GIYe1vK2tVXcIeLW1e6iMHDlK6urq9XlmyjWGsdfX1cqIYUOlob5Odyx0aAt8Wz7Fzj2tCkgB1nOllGCOtxOK6/P5xK+toy0tcwXD8vMtMyzz6LxEY18p5zSSPdqait89XL6Z2CU9TMVA/Ss1eL0opcSv75Oww+ckp2If1RZil8tt3uGprleqn0sbG/AcQ6cM3llO4xDqGgHnlJE7TuNLeUlgMAKuwQLY5fqC842SsyZNlnc++EzWXG0FaWnVjefCr81jl+KXrRxRbTELh8OJOcG6EVO2Ba2wgqFxgkXj0DBpampMlj4aheIbSp6ne4CGfmsrlPKZZl45jqEENDQM1Ur5aK2UN2il3J9ucgOGg+xQ2GGNh4I0YOAyuljqosS0xSasFRh01Ck1uNJTanmt/Gtqas0hFrYzB3ncQAnEPei0RrJlTY1q5S2POGyTFJ5HKNtAn1frLWwgENCdOJ2CeL2vOfkc5bHq28nlKITseJYh3VBIt1dx4BCHZw5kxugQt80+c+kQhBSTBHIm4BgFfcLJh8nO224iN115ltTWVEtjU7McuPeOOQNgAqUlgPmbLt37HghUlVaQDHPnKu6DA4MCXVfXoBukiYW0nnr2Rbny+lvkwssmywOP/Fu++/5HaW8P95sQGsGwjs+ePdOswA4rpVtb5aH4jxw5Wuq1lR6KdL8J5HABlg80UqAg5ZAMo84jMOgROkQQKOiwBYk8mCZRFTQjLjBdB2XIlwtpK5ZSLkFDWRz0ByYQt1yHuUciERRPMnn++LrWVEAnlIlcBhs8ozFyhAp66srE7wD1jvcY3iepQ9nPF/c36tZpz2L7kaREJJA9Acco6MGqgLacryhYyf3Bx5+TBecfLVtsvG72JWfMkhMIa8s5et+xGrJSzrGYlRycgwRAA+X3P6fLbvuPkzvue0Te/+gz+eb7afL4f56TM867TF594x2ZOWt2skTxeGI+7+zZs4xSbnXgQBmHUg7l3O8PJMMX6gCNKqWUUboKlQfTnUcAjUE0YmEpRofdvCvpHpU23DwrenPeBAGTcLhdwEQpZz0flVKCzjQ836UM/9Bxh44TPN/SLZ7L5RKfz6c7JQu/6n+6MuUazqpfp3Ug5VruTOIHg9USj8d1vWc+ciyTfPIZNqQt/kop8RfhXZtPuZkWCZQTAZcTC/PE0y84UWzK3ItAS0uzoIHjNOt5r2LwdAACnZ1xuejyG8SlX/YdGO4a7xn4ljsfkF9+/V1aW1tlzpxZMn3632ZVbKWU1GsLuaWU4x5RSvWMXMAzpZQEtSU3rDuROjs7C5gTkwYBNAixDwZrsLOfG0QiKF81NbWC+wXWp0GCp3U5rJVzBISCjr3THKyq5WpBR91kYj236s7vrxJM5cj3SAsr/WLvrfpFXRc7b6fkh04ZdFbhHecEmfG+w/2N545SxXvnOoENZSSBYhJwpIJeTEDMqzAEsPARGik1NXWFyaDAqXIV98EBx2Ixue/hJ0X0O97j9YpIXIzFBUq6dp36Os5vu+tBsebv1tXVmznlQ4YMlWIr5VrAHv8xzB0elvKIY7r8E4B1CY1Xn89vOuzyn0NxUgxqSxkU9blzmzLOMFUEPCPRsPd4vKku297P4/FpZTRmrIe2FzYDAWOxDjOXPDsFPbFOBhSgDLK0bdBoNGJGSiilH/K2lbK0gimldGdvtf4tYFX0xNSI0ko0cO7W+y4QCA4ckFdJgAQKSsCRCvou229eUChMvPAEWlrmmnmV2TRyCi8dc8gHgXA4YqzjSEspJVDSO+OdEtGNunAkLNGODq2zx+XPv2dopXykDBkyTKAUK2WPxp7b7TH3qNVgQTno8k+gvb1dK3Gdgs8s5j/14qWolJLa2sQXAFCmXHKGFQuWePweckmnK25JdpZV1bKylkSIAmQaDifWzcjm3YUOF3AJd42OKIB4RU0yGo2aZ2RRM3VgZvgdK6UK+jnGfGHB+w73KFy+0mQ6JEACmRNwpIK+7lqrCoa5R/TLIfMiM0apCWAxqJi2nqIxW2pZmH/hCLRpxWtO47w5ubAuetxuGNTF4/GIX1tMvT6foNE6fcaswgmSQ8rBYFBbPmLa8m9/y0cOxSxp1La2Fn0/eM383JIKkofMMeoD93ZLy7z7Pptk0UhGPAwzxd7eLrV0VgMfSlzqEM70DWsF3ePxilLZNZ/8/oB+nkSNFd6ZBBJSoxMJzqrnhC+3qQgopUznc1h3zGBRvVRh7OCHTkG0zdChYAd5KAMJVDKB7N4wJSB20LETpaW1TX774285acJl8uY7H8ukq24rgSTMMhcCcW1BbW2dK7A+OPnFzlXcB78LgoGALLXkYj0CurVi7vX5jFIuXYby4cOGSl2dPece+3VjWrSg6FQS/uWdQFgrO5jqUl1dnfe0S5UgOh7RyG1ra81ahFAoZCyTLpc76zRKHVEpJS6XyyijksufjeLG43HBAnF4f2UrVkA/FxE3rJU17J3qotFEp6XX63NqEYoqt6X0tra2FjXfTDILhdpMcOseNSfckAAJlISAYxR00S/GmuqgvP3+J7LD1hvLlReeKt/+8FNJoDHT7AlA0UGvu1Pnnmdf8sqLGQxWydpjVh204KuttHxCYR80ZPEDKAXLR5VZgTeuO5eKL0F559imredQ4hIdIeVRVp/PL3AtLXOzspJiSHgs1qEtbs769GSq2kMnLMqT6ppd/DKRI9o1ag/1m0m87mHdbo+43W79TGnv7u24Y4uFR3e6Ok74EggMTujYgRIc1+3ZEogwYJZol2HdC4zaUco5qsGAheJFEnAwAcf8Cjs749IejsgHn3wpKyy7hEHu4kPEcHDKprOzU7AYWCBQJXhZOUVuypk9gVVWWk72GLt9vwngs4mHHriX+Mwicv0GK+kFy/KR67zikhbChpmjgY8hlZh7rlTXcAobypmNSPh0JBrhra0tGUcPaes5IpVDp4XH4xWMkAALlMnpLmys3krQ8ZBmWVIGwzsQlni8E1MGcIBnVFvQPVo5V6q8fruFRB8MVmtbk27LtocKmU1WaUM5R8Sqqmrs6EiABEpMwFXi/NPOfqN/jJF9jzhDfvtjuqyxynLy94xZEgj4047PgKUnkGisxqWmxp7DmTMhxFXc06Pl9/lkm602luPHHSwjhg1LRqqtqZaN119Xrr3sXN3Y9ST97XiAxjgsXqGu4X92lNGJMrW1tYpSSj/HnW8p7s3foxVTWKJQRljDe1/v7xyKbEgr6FDOMbKgv3BO8cdvB7JCScfe6Q5Ktd/vM/dtLmVB/SI+0sM+e1e6mNFoVD+7faUTwIE5Y+QF3iWJtpC9CoBnFWSzfrP2ko7SkEDlEXCMgn7ofmPl8buvlntvvthYX/0+r5x1yuGVV2MOLXEsFjMrmAaDQXG77a2QORSxbcWu0x0y6621hlxz2TnywD+vk5uuvkhuvf5SOezAPQUNAtsK3k2woLZ8oEFaLopGt6KV5BDPA1hsqqqCUg6KaCqINTW1xhtD3c1BGpuotkrG451lMbwdxbUa++UwzB2Le+H37/P5UbScHLjgvrf9qJx+Sonfbzwe1wq6t58Q9O6PAEYMgZ+dOmeiurMFMuE915/c9CcBEiguAcco6N/+8LOE2hNztp55/lW58oZ7xOelolfc2yX73Kwe42DQ+dbz7ClUbkyv/q1WBfzi9/tl1Mjh4tMdbFVVAccAwZBUCBuiFR0Ycnaw1iCRcm4Qulxu8+k4KGFoAKO8g7mQtp4rpfTvI3clcLC8inEdDJRSZbFQHKZjgJnfLByJo9wc0sGQeSi6uaVU/NhR3ZGEXL05Tk1CGpXm8C5Ryl6fXAuFWk01QDZzwA0JkEDJCbhKLkGaAlxwxRTTW/vF1z/Iw09OleWWXkwu4iruadIrbTBYHUJasUHPsdvtLq0wecqdq7jnCaRDknG5XOLXDXPcx05sUNsJM+bdgiMag+XyPOiPL555Srlk7tym/oIk/XFfYVQBuCilkv5OP4ASVw4W9HA4LHgO5OueDXSt5m4p/k6q56i2uEJet71Hw0FE2zmllGDkEO4ntI1KLWA83imhULvgfsT9XWp5mD8JkECCgGMUdK/HIx6t3L374eeyw9Ybyb67byctrYlPQiSKwq1dCWCIp1JKytlaZlf2lCt/BILBoFngBw2r/KVaeSmFtJU4Ho9XxPNAKSVYMA4KTdgsMNZ/fVvXq6rKa04+5uOj/Kjz/ktv/ythraCjky5fknq9PlFKSThsvwXDBisj6hMdL0qVT0fSYGXuez17n2Cw2kQOacOFOSjhBiN8ROKm06CEYjBrEiCBXgQco6DHteA//fKHvPXex7LS8kvpMxHMmTEH3NiWQDQa0Q2QdqmurjXWB9sKSsFIYBACaFDDwmCHRtUgotr2MpS0trYW8fl8ZkSUbQXNo2CBQJXA6trc3Gw6ePpLOqQ7LnB/4T7rL4wT/aHIQW4nv68xAiCuLY2YooOy5MMppcTvDwgUpLjusMpHmsVIA7LivV5u92kx2Fl54HmAum9ra+3/mWAFLvC+ra1Nt83c+nnsK3BOTJ4ESCATAq5MApcy7MF77ySXXvdPWXqJRWXZpRYTzEkfMWxoKUVi3mkQmDu3WT/8XdpaFkwjtHOCcBV359RVviRVKjE0EYv7OFnZyBePbNIJaysyhrhXV9dkE92RcZRS2opeL1hkLNSPxQzXcF9h6KsjCzmA0JaCDiV3gGC2vhTW1nMIiI4l7PPlAoGAUdCcxMZ69ln1mi8WlZZOqa3o4B2NRgX3XjAYNKM54EdHAiRgDwKOUdDxmbUpV02UU4890JBbeolF5PpLzzDH3NiTABqceAHU1NTy4W/PKqJUGRKwhh9jrnCGURlcE2htbTHWZF8eVsLWyTnmPyyvUGgw3QcdFL0FhxUVfgFtbce+nJy7a54y3gVOLRfeZag/pfLbZLJ+B1b9O4FPNBoxYoKHOeAmKwI+n0/c+rdRSit6e3timmgBnjtZMWEkEiCBeQTy+7aZl27ej+Y0Nsv9jz4jZ110vXEPPP6cwC/vGTHBvBFIWM/dwod/3pAyoRITQIMKDSsMC8RQzxKL46jsoeRgUaRKsp53r6Da2npjLUWDvLs/jkOhkGCutsfjwWnZOShzsNQ5sWDxeKdgITcMSc63/EopQeeNsxT0qMGAZ6E54CZrAtXV1WaqJu6vrBPJMmI8Hhc8d3D/Ych9lsmUKBqzJYHyJ+ByShHPvfQmefmN92X1VZYz7n+vviPnXz7FKeJXnJzhcLugMV5bWydKqbIrP1dxL7sqTbtAGIaMIcm7lHzAAAAQAElEQVTRaKKhmnbECg/Y2tqqnwWuiu2wg5KKzsrW1hbTKLduh8SQ4bhYozMs/3Lao+xO/b1EIlFTFb4Cjfrw+6vM9Ae8L01GNt+gHn3a+mtzMR0hHp4HSpXmk2too0FJx/vMEbCKKSTzIgEbEHCMgv7X9Bky5eqJsusOWxg35aqz5bc//rIBQorQmwAe+lgQCdagQCDQ+zLPScDRBPz+gFY0lbY+tDm6HMUUHsoHLOiwGClVfh126bLEdB+fLyDffv+jvPnOBzJ5yt1m/9f02eL1+tNNxnHhPB6vGT2Q6Ixwlvi4b5VS4inQ6AZYMEEEChP2dnZ4t2MkhEfXp53ldIpsSikJBqsF9xi4FlNujAJTSomvQB1PxSyL0/KivCSQDgFXOoHsEAar2/aWw+Wq3IZebxZ2Om9vDxmLAKzndpKLspBAPggohcXiqiRxn3fmI8myTwNWYxSy0q01jU2YqvUfOe3sSXLldbfKy6+9JZdfM0XOPO9yeeKp/8rMmbOBqewcLOgoVLGVEOSZq4PiDCVGqcK0N9C28WmLNJ4nucpa6PjoaEMeXq8PO7o8ELCeiVCY85BcWknEYh0SjUZM54BShbmv0xKEgQpBgGmWCQHHKOirrrScHH3qRXLr3Y8aN+7USbLmaiuVSTWUTzHQw46FkNAg85VxzyxXcS+fezabkgQCQRPNCY1qI2gJN5gOAE7BYFCgjJRQlJJm3RZql8f//V956ZW3BE3iDt1IxvMyLnFxu9zyyBNPy8uvvyOh9nBJ5SxE5m63xyQbddi0kFgsZqYjWFZuU4gCbDAqB8pvTN8TBUg+b0la9Yf3e94SrfCE3G63YKRhKNSmDRudRaGBvJBROU+rQfnoCkGAaRaLgGMU9PHHHSQ7bLWR/Pzrn8btvO0mcsoxBxSLE/NJkwAe/FiluLa2Ps0YDEYCziOABiqGeeJ+d570xZXYsgwFg5XzabVUhH//4y+Z+uIrAu3c7fGYxjgsylDWXe7Eq/jBx/4ts2fPkXL7UyoxRBzldVLZMPQY8kKBxr5QDgoa0g53fc4Nx3Z0HR0RUcolUCrtKJ9TZbKejejILEYZQqGQ+Hw+XY+JjrNi5Mk8SCAtAgyUJJBoFSRP7XnQoXuxjz5tkmyvFfRJZx8vcNttuaG4XI4Q355QCyAVFHNYz9GYgQJTgCyYJAnYhgCGJsLq1dGRWETKNoLZSBBYiLFqOZ4Jld6on9PYlKwZt8stSv/rjMfF5XYn/XHQ3NKCXdk5vBMsC6xTCgeF2a3rp9BtDZfLLejws/tq7qg/1KNT6s8pcoKpR3faYSoQnpmFlDscbjedg3h/FTIfpk0CdiTgJJkcoeF69AsSD69Qe7uT2FacrGiI4+VSW1tb9mXnKu5lX8WDFtAaHhgKcbG4/mCBDZ4JlfppNYsLOnI+/fwr61S0bi4er0dcyiVQ1qXb32eff93trHwOPR6vUQzQkeuUUsGCjs6lYsgLK3o0GpF4vLMY2WWcR1x3JuE+hjKZcWRGGJQAnpH4beCeGzRwDgEwokkpJYFAVQ6pMCoJkEAKAnn1coSCjhJDSd/9oFPlsuvuMHPQrbnouEZXegKxWEzQ+4uHvrtrvmHppaIEJFA4AkolGjmhUEg3quOFy8ihKaNBj2cCGvRwDi1GXsT2aOvYmmus0iMtl8slXp9XVK/FTsestrKU4591DzhlxEk0GjW/a1+R1lKxOgLsakW36s3r5QJxhfh9ov6VUrod1VqI5E2aaKehA4DWc4ODGxKwNYG+CrpNxV1+mcVkx202kiEN5W+dtWkVDCgWGuIIUFPD+gEHusoggIYOFFEMG6yMEqdfSjCBRQiWofRjlW/IYFV6Fiso7eVIwaMt6CgXFF/s7e5w/0JGn8+HXcGdR3fiuFxusfIteIYZZmDVm9fLecsZoksruFLKrKoejUbE6gxJK2IGgaw57nhvZRCNQUmABEpAoOgKerZlPOLA3SWVyzY9xssfgVisQ0KhNvNycbvd+UvYxilxFXcbV04RRUPjHY1q3P9FzNYRWaHTDmx8RbJA2h3KiOFD5bgjDxpQzLNOPVbqaqsHDOPUi0opwfshqi3T4oA/WBp9WjlXShVN2kAgoBX0sLHcFy3TNDNCvblcLnG53GnGYLBMCViKM6YLZhp3sPDoSEa6Xq9X0Bk0WHheJwESKC0BxyjoV0y+S/ANWQvXrDmNctWN91in1p77EhBoMYsaKamuruxVmkuAnlnagAA+HxaJRAQdVTYQxxYigAfmq9bU1IhSxVNwbFH4foRoqK+TZZZaTE4cd0ifEEqUTDjlGFlk4QWkvq6uz/Vy8YByUCjrYD4ZYeQHFFJfkTuXAl3zgtE5kM/y5COtqLbscnh7Pkj2n4ZbGzhwD4RCIbNeQ/8hM7+C+sN9bXUCZJ4CY5AACRSTgGMU9I8/+1rQwLHgDBvSIO9/9Jl1WqQ9s+lNIKqtIRg2VV1drXvWHXM79S4Gz0kgawJoUCEyGlXY04m0tbWIUooLEfW6GeYbPUrWWXt1ueW6i2XylRfIgfvsKjdddaHcfO0kWWWl5WXY0CG9YpTXqcfj1R1ZMVtaiLuTjmplFOeYF4x9sZzH4zG/G7vNQ4diF4vFBB0sxWJRqfkEg9Wm6KFQfhcfxeJwIngmB4R/JEAC9ifgGI2qLdQu3Vdxb2lt0+cR+xPOREIHhsVn1ZRS2nqeeKk4sAhZicxV3LPCVpaRYPXw+/1mmgeGEZZlITMoFCzn4XDYTHlRSmUQszKCerUSNnzYUJl/9EjZcdstZNSoEYLh7x5P+Q8dthQ8u1vRcf8q5Sr6UGCloEBVSTjcbqtODKu+rPoT/hWMABjDtbW15u0eQAcL7il8eQT3dcGEZ8IkQAJ5I+AYBX3tMSvLhAsny3sffW7c2ZNukPXXWT1vICohoXyXEcNYMRSvpqZWlG7M5Dt9pkcCTiGAYYNoBOE34RSZCyUnGpZIOxgMYkdHAkkCHm1Bx0k0GsXOtg7KDDrdSiFgIBAwilm0y4pfChl65xntqi+r/npf53l+CQS1FR3vE9yH+UjZssbjPZWP9JgGCZBA4Qk4RkEff9xBsskGa8p1U+43bvON1paTj96/8ISYQ78E5s5tFpfLJV0P/X7D8QIJlDsBzFVVShkrermXdaDydXbGDAM8E1yu8rcID8SC1/oScOn3BZyl8PUNUXqfWKzDzP8tlYKOed5KKbHTMHfUl9vtNu/70tdQ+UuAqRX4nVidnbmWGMPbUX+wzOeaFuOTAAkUh4CrONnkngseVjtuvbHcd8slxm2/1UZ8WeSONesUwuGw+RRIwnpejGGsWYtakIhcxb0gWB2bqFLKdFSFw+2mce/YguQoOBqCSAIWIOzpSKA3ASgJ1pDp3tfscB7W7zbI4fP5sCu6U0oJOgfC+llS9Mz7yTCqrfnoOOjnMr3zTEApZaYIRaNRgcsl+aiuO3Sc8pmcC0XGJYHiE3AVP0vm6HQCmGc7d26T+WROoGvVWaeXSVgAEsiRAKzGSAKLJmJfCS6qG5DhcETmtmBNkHbTmIRy4fF4KqH4LGMWBDwer+7c7TDDuLOIXvAomLbl0fevy1W6ESB+f5Xp6MPvq+AFHiQDKHcYbo2OlUGC8nIeCVjvk1yt6FanKdtqeawcJkUCRSBABb0IkMstC/Tsx2Ixqa2tE6Uqz3qeTX0yTvkTQKMejdhcG1ROINXaFhK4a268Q8ZPvETGnXS2nDvpann4iWfE50/MoXVCOShj8QngN4JcY7EO7Gzl0PmMDid0MpVSMCt/vGtLKQfyjkYT9WTVG/zoCk/A5XIJFnVDh29Mt7eyyREdK4gfCAQ44jQbgIxDAiUkQAW9hPCdmDUaMJh77tFWEL9uiDuxDPmQ2WaruOejSEwjDwRg9UBjyg6WrzwUJ2USEW01//W3P+SAI06Sd97/SP7482/z6ayvvv5enp36kpwy4WJp0wp8ysj0rHgCeHcAgh1/IwmZ4uLzlfZTVEopLYNfoFyBVSldNJr4Wo5Vb6WUpdLytoalW4u8ZVp+6/6pqqqsr+xkyonhScCOBFx2FIoy2ZcAXhTolYX13L5SUrL8EmBq6RKApUKkvBeL6+iIyVkXXCHd/9BxF5e4uN0emT5jpky+5W6Z09jUPQiPScAQcLvdopQy0yGMh402GN4OcexgLcazBJ19sRKPNIjqDjmPx2PqDGzoikfAow0hmPuPUVl4xmaaM9prLpdb7HA/Zyo7w5NApRNwjIL++tsfyeEnni8bbHugrLvVfkmXbgU+8q+pst9RZ8oB486SV9/6MGW0mbPmyLHjL5ZDjjtHJlx4nYTa2024OY3NcurEK2WTnQ6Vy6+/0/hV4iYe7xR89xyL58BVIgOWuQAEyihJpRLDEkOhkOD3UkZFSxblw48/Sx5bB52xTlH6n8uVeKW89+EnUltDq43Fh/ueBKAw2HGhOAwp9/n8opTqKXAJzqwRaqVezT2qLeiorxIgYJaaQHV1tX6XxAX3pj5N+39Ud6x0dHRIMBi0xf2ctuAMSAIkYAgkWlPm0N6bf973hJx67IHy8tN3yltT70u6dKT++dc/5Z6HnpJbrj5HLj/vJJl01a3SHk4M2+oe/7pb7pd1xqwid0y+QOrqauX+R59NXt52yw3l8P13TZ5X4kFbW5t5UdB6LsJV3J3zCyi2pFVVQZ1lXNrbw3pfXv/DkYh8/e0PPQqFRaSM9dzjFumm1/z513ThHwmkIgDLoDW3OdX1UvihQw0KjTX/uxQydM8TnV2wnoZLuJq7+W3H49oC6+suGo+LSAAdNS5tBW9tbc0o11CozYRPvI/MITckQAIOIuAYBX3UyGGyzJKLituVucivv/2hbPSPMVIdrJLRo4bLskstJu99+Ln0/nvjnY9luy03MN7bbbGBvP7OR+Z4SEOdbLrBWlJV5TfnlbhB46WlpUX8/oCgcVWJDFhmEkhBoI8XrE1ut0dCodY+18rOIy5mRW7o5W63VtDLroAsUCEI4DciEpdSD9/uXrZw1+fV7KKgQzYMc4clFNPKcF5sh7yRZ6K+cERXCgLBYLV+zkbTnhYS150qmH+Oe9mVRZu5FGVkniRAAj0JZK7t9oxftLNhQxvkiadfkJbWRK9gJhnPmDVb5h89IhllwflHyfSZs5LnOMCKxBjVBmUc5wstMEpmzJyNQzpNAMo5GlQ1NbX6jP9JgAQGIhAMBk1jCha5gcINfs1eIfw+nyy79BIJobRyHu2IajVLxOXuq5zPN3pkIhy3JNCLgNXJaymAvS6X5BQKOpQZdK6VRIAUmULBgnd713Q7HBfTRaOJkYZ2YlLM8tslL6zmDllaW1uwG9RBOYeSXsXF4QZlxQAkYFcCjlHQn3jqBbli8l2yxS5HJOefYy56umBVt15EpVTKaHg5WxeUSg8NFpUZzKH3G/PtBgtn1+t42GOREjQWMOTNrnIWU676pXaVhqV3k2LmmW5eaFTBpRueiy2F9gAAEABJREFU4cJ5r0frWYI1G2zNN5J52VdbZQUxz7RYh9lbZYWf5dYes6q0hdrzzrXcWFZqeSzLORTPbBggfjbxBooTDrcLLMUDhSn2tVgsJhiZ0t7eVrLfktvt0Z2NkZLlX2zmqfJD+62U71Tkj/YX7tH29tCgdYH2mlJo58YHDZuqvPTL/L2YT2a411Dn+UyzFGlZ+hT32RFITwvNLu28xuo+77z7cTqZjBg2VBq7rSg8e06jjBw+rEfU6mCVxGKdgk8I4cIsHWbE8KE4HNAppUSpwRySGCyMfa/jhYASoBdXKfvKqRRlU4oMlCo9AzSqfdrajJcifjtKlV4mpfIjg9vlkosmnqKflzFx6TTdLrcoXUilt3CjRgyXY444QKoCPlFK+9CJUuSg1DwG6NTxeDy6gyeWFRt9u2UVT6l5Mig17xgdS7A4ejy+vKar1Lw8lMruGM+RaDSqixwvumxYJwD1pFR2sitVHvE0/KKzV6onO0x3gBx4pyjV85pS885xL2PkFsLjd6bUvGtK8VgpZzBAXSvlDFmVSi0nykCXPQHHKOjZF1Fk/XVWl9fe/lCwwNHsOU3y5TfTZO0xK5kkP/r0K9073GGO11trVXnh5bfM8fMvvSnrr72qOR5og0VcBnNKW+PxkhssnB2vQ/ZwOCzBYLX4/VXawuCj89qbgcfjNesE2PF+qiSZgsEas6giGv7lVG6f7nioqQ7InTdfKeustYYsuMB84tbK1jJLLy5bbrahXHXx2RLw+4vxnGAeXns/iwa776FIDBYm1XVYdVP5Z+uHznm854PBoO3uKTxHIFtnZ7yoskG5Q75+f6Co+WZbh4WMZ4d3aiAQFJ9+9mLUCeTpr7yJzhyR6uqaiq+3/hjZ3R/1C2d3OQeTD88PuuwJOEZB/+W3v+TECZfJxjsckvEQ90UWmk/GbreZHHr8uTqNy+Wkow8Qn9drqI0/7xppap5rjk88al95auqr5jNrv/z6p+y7+3bGvyMWM3niE2tPPvOiOf7mux/NtXLfYIiuiDIPe+FfkgBXcU+i4EE/BNCYQiPXWk23n2CO825qatQKuE9qa4Jy5MH7yiXnjZebrr5Qzjz1GNl7tx31syIo7hRz0sVxfxS4kAQwnDwejxsreiHzSSftSCQxvB2/13TCFzOMR3d+uVxugWJWzHwtRQ/1VMx8mVf/BIJdnb7WqMbeIfF7wvsG7x6329P7Ms9JgAQcRMDlFFkvuGKK7LD1JrLs0ovJUw9MlmMP21sO3W9s2uLvsfNWct+US+SemyfJRuutkYz3f0/cKsOHDTHn2N985dnmM2sXTzxBqgIB4+/Rjc3uw+pxvMxSi5lr5byJRiPm25s1NTXicjnmVinnKmHZHERAKSVVVUH9GwprJaTTQZL3LyrmNkYiiRE1gUCVDBvWIMFgldTVVkudfk7U19cK/9IkUOHBPB6vIRA1w7fNYUk2UGoikYi2TvpLkn86mQZ0WyQcbjcjctIJn48wVr24dfsnH+kxjdwJJBRvt7T288k16x7Beyf33JgCCZBAKQk4Rutqbw/LZhuuZRq6UKRh3Z7202+lZFf2ec+d2yxKKd0AD5Z9WVlAEigEAazbgHRh1cDeyQ4NdjwTPNqiV8OvOdi+Ku0uIO4jyIj7CvtSuajuiEbeWIQLezs6KOiQCx0J2BfDgQuGsCqlipEd80iDgFJoj1VLLNYhqe4FvGeUUuL3J4xLaSTJICRAAjYl4LKpXH3ECgYTDxyllPz6+1/SHo7I7DnNfcLRIz8EYCWLassGGuJKOeY2yU/h00hlxAr7yMgV900jJINUMgEMM4TVo60t889D2okbrIyNjXNEKSUNDUPM3k7yUZaiE8g5Q6WUQEnHasU5J5ZDAuFwWMeGLAmLvj6x3X+Px2t+c+FwqCiy4feO9z+HtxcFd0aZBAJVJjxGM5mDro2ltMN6rhQ7VbqwcEcCjiXgGM1r1RWXkcbmubL3LtvKPoefLpvseIhssck6jgVvd8FhKcOwdjzs7S4r5SMBOxPAbwifJ4x2WersLGt/smHeOcpQV9cgbs5t7A8T/TMkAMUzqjuC+0Yrng8UdFjPlbKvUqOUkkAgIO3t7UUZ5h6LxUwFUEE3GGy1QbsMixmGw+1mRKklXCiU6LzB+8by454ESMC5BByjoB996F7SUFcrG68/Rl579m7BPPBdd9jCueRtLDkaAVhdt7a2zvTa21hUikYCtieA4YZKKXGqFR0NPzQG0fCDkmB74BTQMQSgAHZ2dvZQNIoifFcmUERjsQ6Bgt7lZdud319llPNijDiIdnUmYoi7bYFUsGBVVdXi9fn1OyUk337/o/z2+5+6reaSQFXQjEqpYDQsOgmUDQHHKOgR3ct+x/3/knMvvcnAn/bT7/LiK++YY27yRwBD22A9x8Iwfs5j6hcsV3HvFw0v9CKgFKxfVdr6FdINbGctFoeOuubmRnFrqzk67HoVjackkBMBKOhIoBhKJ/Lp7TCVC34+rexgny9XiHR8Pp9JFh3o5qCAm6hubymlBO0A4Z+tCKBDK6Y7tS67eorsffCxcua5l8lxp50rex50rNzzwJPS0urs6VS2gk1hSKCEBByjoJ9/+RT56++Z8stvfxpc8883Qu55+D/mmJv8EcDnOzCUFY1xpew75C9/JWZKJFB4AhiSiFyK0bhGPvlw6KxrbJxjkuK8c4OBmzwTwBB3JAmFEPtiu3A4bJRQJyiiSinx607z9vb2gmOKags6recFx5xVBkop2f+wk+TbH36SuE4B7bVY15SEl197W86/+BpjWdeX+J8ESMDBBFxOkf2nn3+XCScfJn5/ohc5oPfRjg6niO8YOVta5gqsGn7dEHCM0BSUBGxOAIqIx+ORUMg51o2WlmazWnBdXT2HTdr8/nKqeEopoyBjpIaU4A8WdCe96zDFBApZYXmJIH20A0pQJcxyAAKtbSG54rpbJdYZE8xFV0rpuoqZKSKmk0nbVKb9/Ks8+dRU/ex21mitAYrNSyRQkQQco6B7PO4eFYQXSA8PnuRMoLW1xTzoa2rqck6r3BPgKu7lXsP5L19VVVCi0ahuUHXkP/E8pwhLP+bM+/1+gdx5Tp7JkUCSgMfj1b+LSPK8WAf4LWKUiM8Bw9stJpasGOlm+eV7Dy5Is2AKOhKny4qA2+2Sn37+LRnX7XZrKzrs6CJulzvp/9Mvvwme4UkPHpAACTiOgGMU9JVXWEbufeRpaWlpk3c//ExOPecq2WSDtRwH3G4Ch9rDWmFIrNgK6x4aAL6uuW52k5XykICTCViKLn5ndi4HLHSJeeduqa8fYmdRKVsZEIAiiCG6UJaLWRxYz5Gfk953LpdLfLpDIRxuh+gFcfMU9MRoxYJkUsBEyznpxjlN8veMGckiurVSrvSZS1vSlQtH+kT//+6HnyQcLn6nl86a/0mABPJEwDEK+slH7y/DhtaL1+uRa26+TzbdcG05dN+xecJQWclEIhH55tsf5J4Hn5BzLrpKLr7yBnnsX89otn5tLauuLBgsLQkUiYBSicXioKAXWxlJt4iQa86cOYI9lHOl5jX60k2D4UggEwJer9cEL/ZCcVByMc9aKWfd4xjmjhGEsVhhRuJEoxGzIjg6A0zFcNOdQEmPhw4dIvV1tfNk0Leuz+8Xr883z08fLbTAfLojx6uP+J8ESMCpBByjoCulZNvNN5A7b7hQHrztMtlx642FL5DMb7tZs+fICy+/KRMuuEL+/czzMu2nX+Tjz76Uu+5/TA444mT55rsfJBqNZp5whcXgKu4VVuF5Ki6s6FB+w+FwnlLMbzKtrXMFihIWibQUp/zmwNRIoCcBDHGHTzHfO/F4p3nPYQoH8naSgwUd8hbqGYJ68Pmo3IFx8d3AOaLO5xs9cuBA+urIkcPFo41Z+pD/SYAEHErA9gr6rXc/KgM5h3Ividh48f7406/yz3se6pF/rGsFULfHIxdcdr1w8b0eeHhCAnkjAKXX5XLbcrE4NP5aW1u15cUvwSBH0uSt0pnQgARcLpfpbEfH0IAB83gRo8iQnBMVdLfbLXiOFGKOcTwel5i2zHu9PS2yYEVXegI1NdVy4tGHDCrIcUceKAFtWe8TkB4kQAKOIeCyu6R3PvBvefmN9+XDT79O6ewuv53ki0Q75IFH/91DpMQLOSZ46SulzLX7H/63sS6YE25IgATyRkAppZXfoGD+a6yrYyxvieeQEGRpappjFKX6+oYcUmJUEsicAKzo6EDOPGZ2MdAZpZQS5JtdCqWNhZXno9GIWdQ1n5JEu0bPoQMgn+kyrfwQUEpJVVWVTDrntJQJ1tXWyJWTzhJMgUgZoMCeTJ4ESCB/BGyvoB9/xL6mJzBY5Zddtt9Mrr/0DJly1cSkyx+K8k+pOlglP//6e4+ComEOD4/bg51xv/72h7aiJxaOMx7c9CHAVdz7IKFHmgQwzB1BC7kSM9LPxGFROHTWNTQMMUp6JnEZlgRyJQCFsJhKBRR0KLm5yl2q+IFAlck6nOfF4qxRDLSgG7y23NRUB2WpJRaVO268Qk49/gjZZouNZdcdt5EJpx4jN159kSy68IK642lee86WhchOKMYigYoiYHsFfe9dt5E7Jl8gxx6+j3zz3Y9y4LgJcuGVt8qPP/dUNCuq1rIs7IxZs/vE9Hg8Yl7GCeO5ud7U3CyhUMgcc0MCJJBfAhjS6/P5pa2tNb8JZ5laa2uLtuhHpKamNvEsyDIdRiOBbAlAQUfcYijp6JTGlwqcOLwdjOAw4g3v7nwr6FFtlUfaSnVrECBDOlsRQB3V19fKumutLnvtuoOM3WErWWPVlSRYFRClWHfZVRZjkYC9CNheQbdwLb7IgnLwvmNl9522klfeeE8++uwr6xL3aRKoqa6WkSOGSe8/V7fPc+DaUksuJoGAH4d0JEACBSAQDAbN8FQMdS9A8mkniQZ5S8tcrZh7Jch558K/0hDweLwmY9yP5qCAm3DXAo2+XitfFzDLgiSNEQAoC0a+5CuDaDRqngX5So/pFJ4A5qVXacW88Dkxh5wIMDIJZEjA9gp6Rywmr7z5gZx54bWy16Hj5eff/pDbr79Adtl+8wyLyuBut0vWXmPVQUGsM2Z1qdYKxKABKzgAV3Gv4MrPQ9F92oKulJJQqC0PqWWXRGdnpzQ2zjEWl/r6IWafXUqMRQK5EXC73SYBa4i1OSnQJhJpN0OAXa5EngXKpuDJBgIBkweUdHOQ4wbPA4wuMCPqckyL0UmABIpLgLmVHwHbK+g77HWs3P3gv2W9tVaVx++5Wk4ad4AsutB85VcTRSiRz+uVffbYSRZbZKF+c9t71x1lpRWW7vc6L5AACeROQCklmIuOlZjRMM49xcxTaGpqNFZ8KOfuLgUp81QYgwTyQwCKISy4+UktdSqwNofDEfOlgtQhnOOLUQcul0vCeZqHbnWOWNMNnEOCkpIACRSYAJMvAQHbK+iNzXPlq2+nycVX3y4b729Tk9wAABAASURBVHCIrLvVfj1cCZg5OkufzycXnzteNt94fWmor0uWZfTIEXLSMYfKlptvKE6em5csEA9IwOYEoKBDxFIsFof575FIWKqra/h7RyXQlZwAFMNCK+gJJTReNvd8IFBlFHR0PORagRZ7KP65psX4JEACJJA+AYZMRcD2CvpbU++TgVyqQtFvYAI+n1cO2nc3uenqi2TKtZPkoTsnyxUXTZB11lxd8JmOgWPzKghwFXdQoMuFgMcs0Ogt+jB3NMTnzm0Wj8drFHThHwnYgAAUdIiBYdbYF8KFu+afe72+QiRf9DT9/oBAOY9GIznnjTTcbg+nuuRMkgmQAAnYioBDhbG9gu5QrrYXG4uK+P0+GTF8mFkUJhis0g12Z8/Jsz10CkgCvQjAio6VqxOWvV4XC3CKxrw177yhYQgb4wVgzCSzI4AOI8SMRqPYFcRBQfd1rf9QkAyKnCg6NZRSgqkyuWYdiURNWyDXdBifBEiABCqJQKHKSgW9UGSZLgmQAAkMQiDQtdBTW1txFotLzDuPSV1dg3De+SCVw8tFJWDdjx0dkYLki7UeOjqi4vf7C5J+KRJVSunyBMww91zyB5t4vJMKei4QGZcESIAE8kjAlUiLWxIggUwIcBX3TGgxbH8ElHJJVVWVhEIhM1S1v3D58A+F2kxDPhgMitUxkI90mQYJ5IOAUkpgRY9GO/KRXJ80sOYCPGFBx75cHH7LULBzGXkQ7RoiXy5D/8ulblkOEiCByiVQHAW9cvmy5CRAAiQwIAEMcxeJG+V5wIA5XMQw+ubmJm0190hNTV0OKTEqCRSOAIZsW8pivnOBgo4OMY/Hk++kS5qe1eEQzmE192jXtIJyY1PSimHmJEACJJADAVcOcW0TlYKQAAmQgFMJwGrlcrmlUMPc4/G4NDbOMXg479xg4MamBKCg436FRTjfIra3hyUQKJ/h7RYfpZQZ5h4KhSyvjPdQ0D0eryilMo7LCCRAAiRAAvkn4Mp/kmWXIgtEAn0IcBX3PkjokQMBDDuPRiMSi+V/eC9WbEe69fUN4ikz62EOyBnVhgQ8WkmEWNEuiy6O8+EwgiQe7xSfL5CP5GyXRmKYeyzr50dUP3vQOWK7glEgEiABEqhQAlTQS17xFIAESKDSCSSGuYuZi55PFu3t7TrNNm05rDIun2kzLRLINwFPVwcSFnPLZ9oY3o70fD4fdmXnfL7EyAD83jMtXCwWM+tfUEHPlBzDkwAJkEDhCFBBLxxbe6RMKUiABGxPwOVydQ1TbTON5XwIHNPW+ObmRnG73VJXV5+PJJkGCRSUgFJK368eiebZgh4Oh8WjrfP4nUkZ/qFcPt35kI2CHtXWcyDBVBvs6UiABEiABEpPgAp66evA0RJUqvBcxb1Sa75w5YYVHXNvI5HcPzMV75p3jj3nnReuzphy/gnAkhvNo4KO3wAs6OX0ebVU1P3+gGDkQUxbxFNd78/PYo2OvP7C0J8ESIAESKC4BKigF5c3c8uMAEOTQMUQgAVMKWWGpOda6JaWubqx3mEs57Ac5poe45NAsQhAQe/sjAk6q/KRZ7TLQlwJCjp4YbQA9um6qO4MAXOlVLpRGI4ESIAESKDABKigFxgwk7czAcpGAvYhoJSSYLDafG4tF+UEDfS2tlaBQgKrvH1KSElIYHACVocSFnYbPPTgIfB7EFFmiLuU8R8s4GAXDqe/mjtGF0R1BwaHt5fxjcGikQAJOJIAFXRHVhuFLjWBtFZxL7WQzN9xBKqqqozM7e3pN7JNhK4Nhrc2Nc0RzEmtq2vo8uWOBJxDwJPnheKs4e1Klb+FGKu5Y4pMuh18eF7gzoAFHXs6EiABEiABexCggm6PeqAUJJAxAUYoPwJut0dgzYIFPNPSwRoG5Rx7zDuHkp5pGgxPAqUmgPsW1uBoNJqzKBgqD0s8RpPknJgDEoCCDjHRKYH9YA5z1hEGzxzs6UiABEiABOxBgAq6PeqBUpCA3QhQnhIRCAaDAstWpgoKlHrEqampM0p+icRntiSQMwGPx5uXldzD4cSCi76uz5DlLJjNE0AHn8vllnRXc49GI6KUErfbLfwjARIgARKwDwEq6PapC0riIAJcxT3XymL8/gj4/QF9CYvFtep9ev8xrBULw/l8Pqmurk4vEkORgE0JYMh1LNaR8ycHI5F2M92jkhRQTJMJh9vTYheNRnVnntemdwHFIgESIIHKJUAFvXLrniUngfIl4OCSKaUEjexQCI3szkFLgvmmGNrucrmkvn7IoOEZgATsTgAWdMiI4enYZ+Mw1SMcDovfdHhlk4Iz41jljUTCAxYAfBIKum/AcLxIAiRAAiRQfAJU0IvPnDmSAAk4nEChxU+svh5Pa6hqU1Oj+SQVlHMo6YWWjemTQKEJwIKOPKBAYp+NsyzwlTL/3GIEdngOhLUV3fJLtQcf+CM89nQkQAIkQAL2IUAF3T51QUkcRICruDuospwnqhl2imG5oVDbgNJj3jksZdXVNYLh7QMG5kUScAgBKJhKKbEWMctG7LC2niNeJf4uYEXHPHRYycEglbM6P6igp6JDPxIgARIoLQEq6KXlz9xJgARIICWBYLDaLJTV3zBfNLDnzm02yjwU9JSJpPSkJwnYnwBWFsc9nq2kUNCRhlKV18zBau5Qzgfq4ABbsHG53NkiZjwSIAESIIECEai8N1eBQDJZEiABEsgngUAg8U30VFZ0zDtvbJwjSimprx9i9vnMO6e0GJkE8kAAll0omFA0M00uHu/UnVsRqbTh7RanRMeEGnCKTDQaEZ/Pa0XhngRIgARIwEYEqKDbqDIoinMIcBV359SVUyV1uVwCK3pHR0zwuajGpmazj8fj0tyMeecxqa9vqLhPJDm1Pil3ZgSsheJisVhmEXVofNVA77QC6seu4pxSSndOBLSCHkpZdjxDOjo6xGKcMhA9SYAESIAESkbAVbKcmTEJkAAJkEC/BFpaWyUUCsvl194qR598thx2zOly1gVXyB33PiyiXEZ591fYCtVS+D/mYBMCsKBDFFjRsc/EYXi7UkoroJ5MopVV2EAgYBaPTMXP8vN6fWVVZhaGBEiABMqFABX0cqlJloMESKBsCEDB+O77n2TcSRPl8y+/kRkzZ0lc/5v24y/y5FNTZcJ5V2jLOYenOq/CKXG6BNxutwkajUbNPpMNFk7E8HalVCbRyiqsz+c35cFiceag28Zi6vVWbgdGNxw8JAESIAHbEaCCbrsqoUBOIMBV3J1QS86VsbFprlx0xWQRrV9AUcGccwxLjXZE4SV/TZ8pt9z1oDQ1twj/SCBJoMwOYOG1lMl0i4Yh8XA+XyDdKGUZTikl6KQIp/jcGpi6XG6BK8vCs1AkQAIk4HACLofLT/FJgARIoOwIvP/hp8kyuS1LYiQqUNI9Xq8opeTNt96XutrqZDgekEChCRQ7fa++163h2OnmDes5wkI5xb6Snd9fJZhrjg6L7hyi0Yj5+kN3Px6TAAmQAAnYhwAVdPvUBSUhARIgAWltC8k3302bR0Jb0V0ul2CIO5R1HONiZ7xTps+YhUM6EigHAn3KAAUdnVK9Fcw+Abt5hMNhM/fc+p10u1Rxh5iHjkKHu1nRLZ5eL+efgw0dCZAACdiRABV0O9YKZbI9Aa7ibvsqcrSAHk9i/q1VCI/HY5QO7C0/7HuHgx8dCZQLAY/Ha4qSiRUdFnRf1/xrEzm5qbwDpZT4fD7pPg892jWnH50flUeEJSYBEiABZxBwOUNMSkkCJEAClUEgWBWQpZdcvEdhlVIC67l0+/NopX1IQ303Hx6SQHkRsO55S6kcrHTRaMRMAynJ8PbBhCvRdb8/IOCCdSwgAo6xx/MDezoSIAESIAH7EaCCbr86oUQkQAIVTEApJRuuv9agBLbefCOJdnQMGo4BSMCpBJRS4tFW9GiX1XewcoTDYROkHIdvm4JlsYGCjmjhrmHuYImOD04BABU6EiABErAnASro9qwXSmVzAlzF3eYV5HDxAn6/TDr3tH5LsepKy8vuO28rfp9P+EcC5UwAQ7Gj2jKeThnDWkH3+fxmEcV0wldCGCjjVVVVpqhY38LlckswWGPOu214SAIkQAIkYCMCVNBtVBkUhQRIgARAwOVyyVKLLyr33Hq1rLvWGrLwgvNLlVbaV15hWdln953k1BOOlJoaruAOVnTlTQAWdCxsZg3R7q+0uI656hze3pNQOBKRTz7/Rm654wE59ayL5LJrpsjT//2fmQoArj1DF+qM6ZIACZAACWRCgAp6JrQYlgRIgASKRMDtdkt1MCgnjDtIJp1zmlx/5fky/sSjZOwOW0lVwF8kKZgNCZSWACzokCA6yDD3iFZEEQ4WdOzpRObMaZJb73hQrrnhDnnh5Tfkjz//1sr6V/LQY0/JbvuPk2k//mIUdcezYgFIgARIoMwIUEEvswplcYpDgKu4F4czcxHzveJgsEqGDmmQqqqAwLou/COBCiHg9XpMSWEdNwf9bLB6O34bHk8ifD/BKsY71B42SvnLr78lyqXMsH/rc3U4B4izL7xSMPIAx3T9E+AVEiABEig2AVexM2R+JEACJEACJEACJJAeASVut0cGs6DjU2K0nkvyz+txy2P/fjZ5js4LnLiUws64SDQqr735rjnmpmQEmDEJkAAJ9CFABb0PEnqQAAmQAAmQAAnYhYDX65WBLOgdHR0Sj3cK55/Pq7Gm5rma2byvPLhdbnNRuXo2+7765gexpgeYANyUGQEWhwRIwIkEej6pnVgCykwCJSDAVdxLAJ1ZkgAJVCQBKOgYnh2Px1OWH8PbcYEKOigk3PTpMxMHXVsMa8fn5zzuhKLe5S1z57bI3JY265R7EsiMAEOTAAkUhAAV9IJgZaIkQAIkQAIkQAL5IGDNK+9vmDs+r+bxeEUpNmks3ssus6R1mNy7XEqk2xB30X8rLLe0DBvaoI/4nwTsR4ASkUClEuDbLM2af+RfU2W/o86UA8adJa++9WGasRiMBEiABEiABEggFwJQvhE/1TB3WNVhQaf1HITmubZQu6y68grzPPo5WmXl5fu5Qm8S+H/27gM+ijL/4/h3NwlNDqWEIIhUASmCwAkCCqfneegdfz0VCwgoRZo0QUroGBCQDtI5RBBPT/QOTw71VKzYsCAqArGggpQkCEhJQv7zPDHLgiHZJLvJlk9emdnZmWee8n5md/a3s/ssAgggUFQCBOg+yH+7e49WPblei2eO1bTxg5UwY4mOnzjpw54kCVcBRnEP156lXQggEGwCZoAzM2V3BT01NfNcTIB+Zq+dV6qkRg/rr+joc49qP2JIH8VVrHDmjtxDoLAEKAcBBM4pQIB+TprTG97cvEVtWzeXOeFViqugepfU0PtbPhN/CCCAAAIIIBB4AfM99OyuoJ84ccIp3OUEojHOLf/eAubTBWtXzNUVzZqofNmydlN0VLQurlpF0yeNUp3atRSTQwBvd2CGQIgKUG0EQlnYdT7UAAAQAElEQVSAAN2H3tt/MEmVK8V6Ul5UOU77Dhy093ft2qXcpqNHj2rPnj25psstH7bnbl1YRklJSUpOTg7KPk1MTJSZCsuCcoLnuCyqvkhM/DooHwtF5UG5/n9MmMHMUlNT7XH29denj7cjRw4rPT2N57xsXosYJzPd/rcblDDuAU2IH6xl86doUJ+uio6SDuz/yXpyvOZ8vCY659RduxKxyuYYi+BjJ6DHQ+Yxl/NxGez2Nkhilm8BAnQf6bx/msTlcnn2mjZtmnKbzANt3bp1uabLLR+2525dWEYzV2+VmQqrvLyUM2PGDM2cOZPjzYfHZl5cSZv94++RRx7RnDmzOd443gJ6DDz99NNyuVxas2aNZs+eo+nTp2vBggUyH33fsOG/AS071B/7UyYnaHR8vJYvWaShQ4dqckKCEpwp1NtVWPWfNWu2c06dwTHGc1yhHAPm9dusWbMKpaxAPoY8gRIL+RIgQPeBLbZ8OaWkHPKkTEpOUcUK5e39xYsXK7epUaNG6tevX67pcsuH7blbY7TYvmidP38+x5sPj02Ol4I/phYuXOgE6HM43jjeAnoMDBo0yJ5zhw0b6hxvs7Vo0SJNdgJPs7Jbt3sCWna4PE/MmjULp3w8TufNm2vPq+FyHNCOgp/3Amlo3nicN29eYB+r+Xgc5LXN5rmZKf8CBOg+2LVp2VRvbN6iEydPKin5kD7fnqgWzRv5sCdJEEAAAQQQQKCgAm53lL2Cbj7mnpWX+f652+1WVFRU1ipuEUAAAQSKWIDiCy5AgO6DYbWqF+rmG69V9wHjNGjUNA3u20XFYhiQxge6sE3CKO5h27U0DAEEglTg7IHiTpw4ruLFSwRpbakWAggggEAABCIiSwJ0H7u5403Xa/WiKVq1MEFtWzXzcS+SIYAAAggggIA/BKKjY2SuoJvRyc2I7uaWn1fzhyx5IIAAAghkCgTHnAA9OPqBWiCAAAIIIIBADgLmCrr5OLvL5dbJk6lyuVwqVqxYDnuwCQEEEEAAgSAS8LEqbh/TkQwBBLwEYhvcpYoNO3mtYREBBBBAIFAC6enpOnz0mI4eO6EXXnxVe3/ar5Opp5wpLVBFki8CCCCAAAJFIpDfAL1IKkuhCCCAAAIIIBBZAocO/aydu75R74Gj1G/IWK16Yp0GDp+g/g+M09ubP9TBpJTIAqG1CCCAAAJhLRCkAXpYm9M4BBBAAAEEEPBBID39lPY4V8tHTZxuU7tdLp3KOJW57HZr/pLH9O4HH+nY8eN2HTMEEEAAAQRCXSAyA/RQ7zXqX+QCjOJe5F1ABRBAIAIEklMOKf7X4Nw01+UE5fbWmblcLmcuLV/1D3333Y92mRkCCCCAAAKhLkCAHoAeJEsEEEAAAQQQKLhAWtqZ3zE3V9BNrjZQz4zPzV3tP5hkb5khgAACCCAQ6gIE6KHXg9QYAQQQQACBiBB4f8unZ7TT5XLL5XIpyh0l778tH2/VseMnvFexjAACCCCAQEgKuEOy1lQ6gAJk7YsAo7j7okQaBBBAoGACjRvWOyMDl9ulqKgoud1uef81rF9XJUsU917FMgIIIIAAAiEpcOYZLiSbQKVDSoDKIoAAAggg4KNAyZIlfEoZG1vOp3QkQgABBBBAINgFCNCDvYeoX54ESIwAAgggED4CJUuUVI+ud+TYoDZX/l4XX1Q5xzRsRAABBBBAIFQECNBDpaeoZzAIeOrAKO4eChYQQACBgAmULl1KTS6rr9tv6ZBtGVde0VR3dfw/nV+mTLbbWYkAAggggECoCRCgh1qPUd8wFqBpCCCAAAJnC1wYV1F/bX+tJsU/oMH9uqtdm5bq0/NujXlwgPp076y42Apn78J9BBBAAAEEQlbAHbI1p+IIIJA3AVIjgAACISpgBoCrf+klMh9n79uzs65t28peWT/vvFIh2iKqjQACCCCAQPYCBOjZu7AWgRwFGMX9tzysQQABBApDIC0trTCKoQwEEEAAAQSKRIAAvUjYKRQBBPIoQHIEEEAAAQQQQAABBMJegAA97LuYBiKAQO4CpEAAAQQQQAABBBBAoOgFCNCLvg+oQQgKMIp7CHZaUVaZshFAAAEEEEAAAQQQ8EGAAN0HJJIggAACwSxA3RBAAAEEEEAAAQTCQ4AAPTz6kVYggAACgRIgXwQQQAABBBBAAIFCEiBALyRoigkvAUZxD6/+pDVFKUDZCCCAAAIIIIAAAlkCBOhZEtwigAACCISfAC1CAAEEEEAAAQRCSIAAPYQ6i6oigAACCASXALVBAAEEEEAAAQT8KUCA7k9N8ooYAUZxj5iupqEIFKUAZSOAAAIIIIBAhAkQoEdYh9NcBBBAAAEEMgWYI4AAAggggECwCRCgB1uPUB8EEEAAAQTCQYA2IIAAAggggECeBQjQ80zGDghIjOLOUYAAAggUrQClI4AAAgggEI4CBOjh2Ku0CQEEEEAAAQQKIsC+CCCAAAIIFIkAAXqRsFMoAggggAACCESuAC1HAAEEEEAgewEC9OxdWItAjgKM4p4jDxsRQAABBIpSgLIRQAABBEJWgAA9ZLuOiiOAAAIIIIAAAoUvQIkIIIAAAoETIEAPnC05I4AAAggggAACCORNgNQIIIBARAsQoBew+1NTTyq3ady4sWrWrGmu6XLLh+25WxeW0QV1blXZurcFZZ9KGXK5FJR1K6z+oZzCe6ykp6cpOjqa482HcwHHpX+Oy5iYGKWlpXLMcczl8xjI23HodruVkZFRKGXxHJG3vglHr4yMU3K7XSF/vBUwvIr43QnQI/4QAAABBBBAAAEEEEDALwJkggACCBRQgAC9gIDsjgACCCCAAAIIIIBAYQhQBgIIhL8AAXoA+zgtPV0JM5eqW7/R6jV4gr7/cW8ASyPrSBT46NMvNGLibP3x5p7qMXC8Nr39oYfhk8+2q1v/Mbq7zygte/wZz3oWEPCHgHle6zlogierAweT1f/Bybr3/rEaNWmOjh0/7tnGAgL5FTDn0RkLVqn9bX3U6s9368l1/7VZmfWcXy0FMz8KmOexoWMfUadeI9R9wDi9vGmzJ/enntuozr1HqkufeL3+zhbP+jBboDkBFvhk23YbE7Ru3+WM40vO37let5njkvOrAxRB/wToAezs9f99TUnJKVq54CHd2uE6PTx7RQBLI+tIFChVsoSG9u+mjc8sVtc7OihhxhLLkJGRobFTFujB+7vp7/Mn6ZU33pMJ5u1GZggUUOC5F15RxdhydqyDrKzmLF6jls0ba8W8iSpT5nda8/QLWZu4RSDfAqueXK9tX+7Ugumj9frzf1eblpfbvDi/WgZmfhZY+8wLqlqlklYvnqIH+nWxF1lMEd/u3iNzLC6eOVbTxg+259rjJ06aTUx5EiBxieLFdV/XW9WudfMzMHJ63cb59QyqiLhDgB7Abn5r80e64bqrbAnXXN1C27bv0tFfjtn7zBDwh0DdS2qoQrkLFOV22xeuqamp9srl9p3fqFSpkqpft5aio6L0pz+00hubecffH+aRnsfPh4/o3xte01233HAGxVvvfqwb/5T5fHej87z35rsfnbGdOwjkR2DDy29ocJ+7VbN6FTsY4UWV42w2nF8tAzM/C6SfOuW88eiykxkcrlLFCraEN53zZ1snoDrPOa9Wiquges659/0tn4m/IBMIgerUrV1dzZo0kDm+vKub0+s2zq/eUpGxTIAewH7efzBZVS7MfDFhgiTzRL9vf1IASyTrSBZ49vn/qXbNaipZooR+co6zKpViPRxVq8Tpp30HPfdZQCC/AnMWP6GBvTvZFxcZGZm5mDcezS8HlL2gjF1hjrf9B3iusxjM8i1wygmWzDnz2f/8T9fe1EP9h0/Rd99nflWM82u+WdkxB4Fb/nqdXnzlHV15fWfdN3iihg+4x6befzBJlb3OqeaNon0HOKdanAiaBbKp53rdxvk1kOrBmzcBeoD7xuVyeUpwey17VrKAgB8EPt32ldb88wWNHXafJzeX+/SxJ/FQ98CwkG+BbV/usvs2blDX3nrPvK8GuFwcb942LOdf4GRqqmpVr6p/PzFPf76mlabMXubJzOVyeZbdXsuelSwgkEcB81Ww/7uhnV5at0Tzpo7U5FlLlZaWZnNxuU8/r7lcp489u5EZAgUXkMvtfVydPt44v/oBN8SyON37IVbxUKhubPmySko+5KlqUsrP9nubnhUsIOAHgf3Olcr5y9Zq/rSR9rtzJsu42HJKTjlsFu2UlJyiuIrl7TIzBPIr8PrbH+iFl17PvLo0ZKI++2KHuvaNl/nYZ3r6KZlgyuR90DneYiuUM4tMCORbwLwoNV/hubpVM3uM/eGqK7Qz8TubH+dXy8DMzwLP/ucVtWnZVKXPK6XLGtSxue/dd1Cx5cspJcXr9ZzzHFexAudUC8TMLwLnet3mv/OrX6pJJoUkQIAeQOhWLZro5U3v2hLe/XCralarYl9k2BXMEPCDgBnZMz5hnkYN7qkL405/pN18x8ls2/3DXpnv1P3POQ7Niw4/FEkWESzQ597b9c7G1XYygyU1vPQSPfZoghVpdYXzfPfaO3b5xVffVhvn+c/eYYZAAQRaO8HS+x9lftf3vS2f6ZJa1WxunF8tAzM/C5Qvd77e+zDzePvmux917NgJVXLe3DbnTzOOy4mTJ+2Fl8+3J6pF80Z+Lp3sIlkgp9dtIXF+jeTOC0DbCdADgJqVZYf2f5Db7bI/s7Z89ToNH9g9axO3CPhF4Ol/vaitn+/QnT0ftFc1zffm9u47IJfLpQkj+mrM5Pn2+Gt2eX01vexSv5RJJghkJzCodyet3/i6/Zm173bvUafbbswuGesQyJNAn3s66vW3t8j8ZORzztXNUYN72P05v1oGZn4W6NX1Nv1z/UvqeO8DemjGYk0Y2c8OTlit6oW6+cZr7U+vDRo1TYP7dlGxmBg/l052kSCw+YNP7Ou1lzdttq/RzM/kmna7XOd+3cb5VTJGkTS5I6mxhd1WMzBc/JCeMj+ztmTWOF18UaXCrgLlhbmA9xXNrCubZjBC0+zGDevaY+/xhZPV8+5bzComBPwmYD7+uXT2OE9+FcqX1cJHRtufWZs8ZqAdrNCzkQUE8ilwfpnSmj35Qa2cP0lzpgyXGZzLZMX51Sgw+VugTq1qWv/EPD21YoaWzZlwxhvbHW+6XqsXTdGqhQlq26qZv4smvwgRMD9HmvV6zdy+/OxST8vP9bqN86uHKFALQZcvAXrQdQkVQgABBBBAAAEEEEAAAQQQCH2BvLeAAD3vZuyBAAIIIIAAAggggAACCCCAgN8F8hSg+710MkQAAQQQQAABBBBAAAEEEEAAASsQTAG6rRAzBBBAAAEEEEAAAQQQQAABBCJRIIIC9EjsXtqMAAIIIIAAAggggAACCCAQKgIE6P7qKfJBAAEEEEAAAQQQQAABBBBAoAACBOgFwCvMXSkLAQQQQAABBBBAAAEEEEAgvAUI0MO7f31tHekQBJGABAAAD8xJREFUQAABBBBAAAEEEEAAAQSKWIAAvYg7IDKKp5UIIIAAAggggAACCCCAAAK5CRCg5ybE9uAXoIYIIIAAAggggAACCCCAQBgIEKCHQSfShMAKkDsCCCCAAAIIIIAAAgggUBgCBOiFoUwZCJxbgC0IIIAAAggggAACCCCAgBUgQLcMzBAIVwHahQACCCCAAAIIIIAAAqEiQIAeKj1FPREIRgHqhAACCCCAAAIIIIAAAn4TIED3GyUZIYCAvwXIDwEEEEAAAQQQQACBSBIgQI+k3qatCCDgLcAyAggggAACCCCAAAJBJUCAHlTdQWUQQCB8BGgJAggggAACCCCAAAJ5EyBAz5sXqRFAAIHgEKAWCCCAAAIIIIAAAmEnQIAedl1KgxBAAIGCC5ADAggggAACCCCAQOELEKAXvjklIoAAApEuQPsRQAABBBBAAAEEshEgQM8GhVUIIIAAAqEsQN0RQAABBBBAAIHQFCBAD81+o9YIIIAAAkUlQLkIIIAAAggggECABAjQAwRLtggggAACCORHgH0QQAABBBBAIHIFCNAjt+9pOQIIIBC0Am+9+7GuvL5zttOSx572ud5X/6WbTpw8mWt6X9PlmlERJDBOvha79fMdin9obo7J3//oM/V+YFKOafKy0d/5fbrtK917/9hcq7Dnp/361wuveNKlpafrrl7DlfLzYc86FhBAAAEEEAg2AQL0YOsR6oMAAgggoNYtmuidjavtdH/Pu3TNVVfYZbOuV9fbfBaa9dAwxURH55re13S5ZhTkCeYvW6vOHf8SwFoGPuua1S/SsPu75VrQ3p8O6PkX3/Cki46K0k03XKPVTz3vWccCAggggAACwSZAgB5sPUJ9EEAAAQTOKWCuxnbrP0YjJsxS/+FT9MHH2/Tkuv+qfce+9urooFFTtfuHvZ79B4+ertS0NHvfXGlevPJp9R4yST0HTdDHW7+0683M13QbXn5Td/YYJnOFeeGKf6h1+y5m999Mx44f14wFq3Rnz+Hq1GuETGB86tQpm87sO3XOCt3v1P/WbkP06PIn7XozS/z2ew0cOVXd+o22V4nf3PyRWW0n03ZT93uc9l/3t17y3mbaZdpkyvJul93x15lxOXAwRZfWqfnrGumZ9S+pa994dekTr+tv7a2k5EN22/ETJzVq0hxbD+O870CSXW9mTz23UXf3GWUnk+ZgcopZLdPm6fNWqvN9I3V796EydbUbvGYHklJk6v/8xk12remTeUvWqNfgCbrTcX3ptXfsejPb9NYH6jFwnEx/G5Ovv/1BcjYkfvO9TDnOooyJ2W7qcd+QiRocP11ZdV3guCZ+s1vGe/LMZSa5/ti2pf7jFbTblcwQQAABBBAIIgEC9CDqDKqCAAIIIJC7wI5d36r3Pbdr/tSRat6kga5o2kjrn5irJ5ZM1Z+uaaUps5efM5Ma1apo0cwxenjcQD08J2/p9u47oKlOYP1Q/AAtmjFG6b8G3NkVtuzxdUpPT9eqRxO0csFD+mnfQT313IuepCYAnjNluJ5YOlWfbtuhV998324bkzBfLZpfZvcZeF8njZkyX8kpP8sEwQ+On6W77/ir/j5/kv65cqbq1alh9zEz066ls8dp+MB7z9muLZ98roaX1jbJ7fTWex9r5RP/UsLoAVq1MEHL545X6dKl7LZvd/+oXt062no0a1xfK9Y8Z9ebfTa+8rbmOfaPL5ysJo3qaZpjYjaaNn/7/R4tnTNO/1j+iB4ccK9ZLZfLZaevnH7rO3SS+tzbUX+5vq3dZmbVqlbWklnjNPfhkZrpvKlh2nrgYLLGT1uoIX27aKXTXlPOxOmLTPLfTFl1XTxzrNr/sbWnrv2636Ga1avavho1pIfdr1zZ8/W70iW1ywnc7YqzZtxFAAEEEECgqAXcRV0BykcAAQQQQCAvAnVqVVP1iyt7dnFHubVs9Tp75fnfG17TVzu/8Ww7e+Hati3tqvJlL9CevQdkvpdsV5w1yy7dZ1/sVNPG9VSrRlWb+s5b2tvb7GbvfrBVJv39I6bITDsSv3UC8e2epG1bNZfb7VaxmBi1atHEuZr/hQ79fES7f9yrjjf9yaZr3LCuTFu3OuV+8tlXqndJDbW+oonddn6Z0qpQ7gK7bGbt2vze3OiyBnX0w5792bbrx737FRdbzqYzs83vf6oO7dvpospx5q5zW8nWx9ypWe0iVa96oVlUs8aXKvHXgNbsk3LosEZMmG2vTL/46tv69POdNp1pc7c7O6hkiRL2fs3qVextRkaGvv9hr+2fKWMG2TdU7IZfZ9dc3cIuxVYo57zpUFNbt+3UJ86bFg3q1Vb9urXstk633aDtO7/R0V+O2fves9o1LlZWXS+Mi/XU1TuN93JcbAXt/v4n71WFtUw5CCCAAAII5CpAgJ4rEQkQQAABBIJJoHjxYmdUZ0j8NCeQra7xw/to2vjBOnb8xBnbve9EuU+f9kxgb65ye2/PWo5yZ58u2uv77Dl+t90lPdCvi716a662P7lsuiaPGZiVfba3GcpQlNst811p/fpnyjABrrlrgnlzm93kvS06OspevT87XUxMtOfj/lnboqNjshbPuDVps1ZERUUpLS3d3nW5MnTjdVd52rVszgRteOpRu83MijlvOJhb78nlcimuYnnVdt7YeP7FTd6bzr3sBPXRUaf7wDi4nXyy2yHKK53b8cuqa3ZpzbqTqamKKRZtFsNsojkIIIAAAuEgcPrsFw6toQ0IIIAAAhElcOz4cSUf+lltWl6usheU0cubNges/Y3qX6Ivtid6ruK+uXnLOcsyV7oXP/ZPHT5y1KYxH9s2V4DtHWf27H/+5wS9afr58BFtePkNXd6ovi4o8ztVrlTRfi9czt/Wz3fIfCz8Mqfcxg3rOFeQv9Y773/ibMn8z8o7817u89o1qun7H09fOW75+8tkvguetc4ErmbKKadWzhX8Z194Rea78iadSb/l0y/Molo0b6SVa59z3iA5bu8fOfqLvTWzGCdwn5UwTDsTd3u+P27Wm8mMIWBut+/4Wls//0qNGtSWae+2L3fpS2ed2bb2mQ2qU7u6zitV0tz1aSpdupTje/g3ab/bvUf169T8zXpW5CLAZgQQQACBQhEgQC8UZgpBAAEEEAiEgPk4dadbb9SdPYbbj1AfTEoJRDE2z7jY8urb/Q6NnDjHDlBnAlvzUXO78azZPZ1uVr1LqssMlNa590h16ztaySmZA7CZpJUrxapL33g7ENxVLZuqXZvmZrUmxffX629vsQOpzVr4uMYO623feDAfyZ84sp8eW/tvmQHk2v31Xm35JDMwtjv6MDMj43/z3Y+e786bNxFuv/l6jZo0V2bQt+tu7qUjR04H1dll2bJ5Y3XvfLMmTl9s63Hj7f20ddsOm7TH3X9TlQsrqfuAcXaQuD5DH7LrzScAzBQdHS0TpJuP2ifMXGq3mdkvx47ZAf7GT33UfofetLVC+bIa/UAvmcHgzKBy7364VWOG3meS+zzVrF5VTRrW05DR0zT510HiTPtr1bzYmvqcEQkLRYBCEEAAAQQyBdyZN8wRQAABBBAIToG7br3BDmRmavf7yxvaj1eb5azJBIbPPDZTZtC1nl1u1VsbVmVt0uvPr1TxYpkfiTc/0ebZ4Cy8+q/lnm2+prvqyqaa+/AIO0BdpbhY+51vJ6vf/JcoXkwDenXSmiUPa/WiKVq/dr5McJuV8Jqrr5AZ1M4M9maC/qz15rvfph1mILgV8ybaTwZkbTOD4S2aOUZm0LnX1q9Q29aZQX1O7cra19zGxETr2rYtnDcAPjR37dTxpuvtAHFmwLdNz/9dZhC1s40b1KslUxe7gzMzP1VmBm4z9Xhp3RJ1vbODs1b2u+fmY/2mXWaQOJOn2eCdX1aQHj+kp9lkJ+Nk9lm7bLqua3elXWdmpn3L506wg+IZkxrVqpjV1jyrPt55m43edY1yuzVycA/NfOhBZQ0St37ja7rj5j+bpEyRJUBrEUAAgZARcIdMTakoAggggAACRSww89FVMj/pZn4+zXzEfVDvzkVco7wV3+X2Dp6P3edtz9BPbUbdr1Cu7BlveoR+q2hBcAhQCwQQQMB/AgTo/rMkJwQQQACBMBcwHzk3g6KtXTpV08YPUaWKFfLcYjNonLnym+cd/bBDqZIl1OHP7fyQk3+yOPvqv39yzT6XKLdbOY28n/1erEUgCASoAgIIRJQAAXpEdTeNRQABBBBAAAEEEEDgtABLCCAQXAIE6MHVH9QGAQQQQAABBBBAAIFwEaAdCCCQRwEC9DyCkRwBBBBAAAEEEEAAAQSCQYA6IBB+AgTo4dentAgBBBBAAAEEEEAAAQQKKsD+CBSBAAF6EaBTJAIIIIAAAggggAACCES2AK1HIDsBAvTsVFiHAAIIIIAAAggggAACCISuADUPUQEC9BDtOKqNAAIIIIAAAggggAACCBSNAKUGSoAAPVCy5IsAAggggAACCCCAAAIIIJB3gQjegwA9gjufpiOAAAIIIIAAAggggAACkSYQzO0lQA/m3qFuCCCAAAIIIIAAAggggAACoSRQoLoSoBeIj50RQAABBBBAAAEEEEAAAQQQ8I9A7gG6f8ohFwQQQAABBBBAAAEEEEAAAQQQyEGgyAP0HOrGJgQQQAABBBBAAAEEEEAAAQQiRiDcA/SI6UgaigACCCCAAAIIIIAAAgggENoCBOgF6j92RgABBBBAAAEEEEAAAQQQQMA/AgTo/nEMTC7kigACCCCAAAIIIIAAAgggEDECBOgR09W/bShrEEAAAQQQQAABBBBAAAEEgkeAAD14+iLcakJ7EEAAAQQQQAABBBBAAAEE8iBAgJ4HLJIGkwB1QQABBBBAAAEEEEAAAQTCS4AAPbz6k9b4S4B8EEAAAQQQQAABBBBAAIFCFiBAL2RwikPACDAhgAACCCCAAAIIIIAAAmcLEKCfLcJ9BEJfgBYggAACCCCAAAIIIIBACAoQoIdgp1FlBIpWgNIRQAABBBBAAAEEEEAgEAIE6IFQJU8EEMi/AHsigAACCCCAAAIIIBChAgToEdrxNBuBSBWg3QgggAACCCCAAAIIBKsAAXqw9gz1QgCBUBSgzggggAACCCCAAAII5FuAAD3fdOyIAAIIFLYA5SGAAAIIIIAAAgiEswABejj3Lm1DAAEE8iJAWgQQQAABBBBAAIEiFSBAL1J+CkcAAQQiR4CWIoAAAggggAACCOQsQICesw9bEUAAAQRCQ4BaIoAAAggggAACIS9AgB7yXUgDEEAAAQQCL0AJCCCAAAIIIIBA4AUI0ANvTAkIIIAAAgjkLMBWBBBAAAEEEEDAESBAdxD4RwABBBBAIJwFaBsCCCCAAAIIhIYAAXpo9BO1RAABBBBAIFgFqBcCCCCAAAII+Eng/wEAAP//d8GWPQAAAAZJREFUAwBi4Z0L3FDDrgAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_epochs = checkpoints[\"checkpoint_value\"].cast(pl.Int64).to_list()\n",
     "_ics = checkpoints[\"ic_mean_daily\"].to_list()\n",
@@ -738,13 +12962,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2e7353d",
+   "id": "46c7bfcc",
    "metadata": {
     "papermill": {
-     "duration": 0.023189,
-     "end_time": "2026-09-07T00:24:06.550861+00:00",
+     "duration": 0.054732,
+     "end_time": "2026-09-08T20:00:03.118149+00:00",
      "exception": false,
-     "start_time": "2026-09-07T00:24:06.527672+00:00",
+     "start_time": "2026-09-08T20:00:03.063417+00:00",
      "status": "completed"
     }
    },
@@ -765,10 +12989,178 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8fcd543f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 14,
+   "id": "bdb5c683",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T20:00:03.222746Z",
+     "iopub.status.busy": "2026-09-08T20:00:03.222462Z",
+     "iopub.status.idle": "2026-09-08T20:00:06.004987Z",
+     "shell.execute_reply": "2026-09-08T20:00:06.004239Z"
+    },
+    "papermill": {
+     "duration": 2.828514,
+     "end_time": "2026-09-08T20:00:06.006283+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T20:00:03.177769+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Common sample: 187,668 rows on 1,995 dates\n",
+      "  GBM (Ch12): IC=+0.0546 on the shared rows\n",
+      "  Ridge (Ch11): IC=+0.0432 on the shared rows\n",
+      "  NLinear (nlinear): IC=+0.0439 on the shared rows\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "cliponaxis": false,
+         "marker": {
+          "color": [
+           "#1a2d4a",
+           "#C87533",
+           "#0a1628"
+          ],
+          "line": {
+           "color": "#D4A84B",
+           "width": [
+            0,
+            0,
+            3
+           ]
+          }
+         },
+         "showlegend": false,
+         "text": [
+          "+0.0432",
+          "+0.0546",
+          "+0.0439"
+         ],
+         "textposition": "outside",
+         "type": "bar",
+         "x": [
+          "Ridge (Ch11)",
+          "GBM (Ch12)",
+          "NLinear (nlinear)"
+         ],
+         "y": [
+          0.04324407887625926,
+          0.05460852591102626,
+          0.04387470931870449
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "margin": {
+         "t": 70
+        },
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 15
+         },
+         "text": "Peak-checkpoint IC by family, measured on the same validation dates"
+        },
+        "width": 1000,
+        "xaxis": {
+         "title": {
+          "text": "Model (validation leader per family)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Peak-checkpoint cross-sectional IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+gAAAH0CAYAAACuKActAAAQAElEQVR4AezdB8BN5R/A8d997ZFsMv6ySltSZJaRkJCQEbKy9957k5WdEBGFUqRUQiglDUVG9h6vkT3+5/dwr/vu+6773nPvVz3nnvGc5zzP54z3/s66QdeuXb1NwoBtgG2AbYBtgG2AbYBtgG2AbYBtgG2AbYBtIGG3gSCJ138UjgACCCCAAAIIIIAAAggggAACngjYO0D3pIXkQQABBBBAAAEEEEAAAQQQQMAGAgTokawkJiGAAAIIIIAAAggggAACCCDgLQECdG9Jh10OYxBAAAEEEEAAAQQQQAABBBBwCRCguyj8rYf2IIAAAggggAACCCCAAAII2EmAAN1Oa8uX6kpdEEAAAQQQQAABBBBAAAEE4lSAAD1OOSksrgQoBwEEEEAAAQQQQAABBBAINAEC9EBb47RXBUgIIIAAAggggAACCCCAgM8JEKD73CqhQvYXoAUIIIAAAggggAACCCCAQPQFCNCjb8YcCCSsAEtHAAEEEEAAAQQQQAABvxQgQPfL1UqjEIi5AHMigAACCCCAAAIIIIBAwggQoCeMO0tFIFAFaDcCCCCAAAIIIIAAAghEIECAHgEMoxFAwI4C1BkBBBBAAAEEEEAAAfsKEKDbd91RcwQQ8LYAy0MAAQQQQAABBBBAIB4FCNDjEZeiEUAAgegIkBcBBBBAAAEEEEAgsAUI0AN7/dN6BBAIHAFaigACCCCAAAIIIODjAgToPr6CqB4CCCBgDwFqiQACCCCAAAIIIBBbAQL02AoyPwIIIIBA/AuwBAQQQAABBBBAIAAECNADYCXTRAQQQACByAWYigACCCCAAAII+IIAAbovrAXqgAACCCDgzwK0DQEEEEAAAQQQ8EiAAN0jJjIhgAACCCDgqwLUCwEEEEAAAQT8RYAA3V/WJO1AAAEEEEAgPgQoEwEEEEAAAQS8JkCA7jVqFoRA3AlcuXJV0uZ4ypWy5ntOyr36pixY/GncLeRuSXv+3W+Ws+WX3+6OibuPp4pVkvFT3o+7AiMpyZvL6tJ7uFSp1TSS2oQ/acb7C2X9xi3hTww1Vtf/uzM+CDH29u3b8uGSz6RRi67y6LMvyUNPl5GKr70lI8ZNlQsX/wuR132gZYe+8kajtu6j4rT/k09XSeXXm0iWvM/Ki5XrxmnZ4RW29LMvzTZ748YNM/n4yVNm+PsNP5phOt4RaPh2Z2nerleUC4uvDH/+/Y+MfGd6mOI/WLRMHshfJMx4RsReYNmK1WZfc5Z07MRJM7x2/WbnqHA/p733oTlmhTsxgpHnL1w063f/gcMhcoTe/0NM9NLA79t3mHbv3PWvx0uMqD0eF0BGBBDwG4Egv2kJDUEgAAWaNaojKxbPktnvjpKMGdJK6079ZNEnK4R/CSuQ58Gc8vijD0W7Eu/N+0g2/rg12vPpDBqAaxDcscdgyZ83lwwf0E369WgnWbNkktETZsony1dpNq+nW7duSftugyRH9qzy4ewJMm5Y73ivQ4b06eSFkkXF4XDE+7JYgO8K/PX3Lhk+dorvVjAAapY0SRKzL6a9P02ct/aCFaAPHztFDhw6EqJsu+7/EbUnROMYQACBgBAgQA+I1Uwj/VUgV85sUrLYs1Kpwgvy4XsTpOCTj4peifDX9tqlXa2a1TcBsjfrO3n6XNn001ZZ9uE06d21jVStXE7q164m708dJd+t/FDy5snlzeq4lnXi1Gm5+N8laVCnupQtXUyefuox17T46ildoogsXzhdEiVKFF+LCIhydb0FRENj1Uhmjkwgfbq0Zl/Uv02R5YvLaez/calJWQggkBACBOgJoc4yEYgHgaCgIClWpJBst64aOYvfvOVXqVSjseQsUEz0Fu/eg8aIXtF0Tj9zNtjc/ly+agPJ/tDz8nzZGqK3nLvnceZ1//xu3SZzu/KsuYvcR4fpv3btuvQbMk6ee6GqKf+Vmk1FrxKHzrhg8afyUrUGkr/gi9K93wi5fv16iCx6m2T9Zh2lwDPlJO+TpUX7te7umTxdlnOeAwePGBO9HfzGjRvivJX/o08+l6pvNJcHHysphUq8Eu4JjxWrvpEXKtaRHA8/L0VerC4Tp80V93+hb3F33lKrt6+XeaWemU9v9f7x522u2YqVqyF6O6ReEdLb1zVFdVuoc2YNpLQOb9SoYm0DzzhHuz6ffKyAOZHjGhFBj94CXvPNVvK/R4pLjXot5fCRY66chUu9Krr9uEbc7dHbmKvXbXF3KOTHnPkfS4FC5czIyq83EW3T5OnzzLBuO6/VbWmWVbB4ZenQfbCcDT5npjk7us3q9jj3w0+kbJX6Zn3oLcu6fa5Z+4PUbthGcj1aQrQO585fcM4mUd3i2qnn0HBvtdeTW9r2/y5dcpUVVU/Lu48H/LD5Z6nVoLXZhtt2GSC6ff6ze5/o9HxPvWDq/9eO3WGKmzlnoZQoX9PsH7r/6b7gnunvnbulc69hZjvT/Vj31S/XrHPPIpcuXZaBwydYeaqZfV0fr9DtwZlJH1/QOjmH9fPX37ab9aHbvQ7rp64ftXu9fivJ80Rp6dRziE4ST/a/Y8dPinPb0fk93Xb1sYwR46bJs6Vfde0Xuh2aBd/tqKG2QddPkRfvtFGHdZl3s4T50HY4b6/XdmlSF/eMR4+dEHXR407o/dGZL6r148zn/qnbghrotqT7TbuuA2XbH3+5skRr24/mtq8L8WR9aT5nOnT4qNkWVn+z3jnKfOq60Udl9JikI3Sb1sdldBv09O+F1kXt3bcHPb53svZB3S/0eKgeWr57impZWu5jz1Uws+h61WVo0mO5rntnv8lgdfT2cd0etD36N0S3VW23Ncn879z+P/1ijdmPdft/pmQVef+DJWZ6VB1tg+Z/8vlK0nfIWLNPhp5H80R0zIusPVqO/n3r0X+k6DL0785L1t/Lbb/f26Y0T1TbneYhIYCAPQSC7FFNaokAAp4InDp9VjJmSGey6jPjGhDflzqlvDtukDRvVEcWfbxC+g19x0zXziErANvxz16pWa2izJw0XMqUfl4mTZsj786Yr5PDTRqcv/FWOxk9pKc0bfhGuHmcI5u17SEfffKF1Kz+isy2ruS+WOp5+WFzyFu4F3y0TJZ9tlpaNqkvTRrUlllzF8vU9z50FiH6xeqlqg1l1+590q1Dc3Nl+uDBo/L6m61Fv0A6M3qyLGdeDc6r1G4qTz/5mLz37ghJnDixc5J06T1M3nj9Fflt00rpai1Pg9KP3W4P/+b7jdKgeWcp+NSjMn3CMClfpoToSQgNHlyFhNNz/foNGT1hhgzt11l+/eELeeqJR+TNZp3k8uUrJvek0QPkfzmzy5tvVDePLaxYPMvkMROj6Ozes8+UU6FcqShyRjx5uxU89ho4Wl6tXF6GD+wmR6zgpYYVqGkwrHM1qFvDWpefhzh5cvLUGfn8y++kdo3KmiVM0vrMmTbGjB89pIdpV7VXypvhr6xgoGTxZ2WGtd3Vq1XNXP1v3bmfmebe+WDhUvlyzffSvmUjeaHk8+aW5WFj3pXufUdIxfIvSP+e7eTb7zfJkFHvus8WaX+9Wq+KBqi//fl3iHzzFn4i1atUkFQpU4YYH9WA2vXoN0qqWfO2a/GWLFm+UvoPHW9OHOTJ/T8ZO6yP/PffJWncqluIovQdAt36jpSizxWytsORUu7FYqLB3BeWqTPjr9aX8Ju3bkqH1m/J+JF9Je+D/xMNTrX+zjwDho+31sM3Zh96b8pIaz8uZp2o+8c5OVqffYe8I1WtdbR1wwrp2LqJR/uf7oe1GrSRP7b/I0P7d5Hqr1aQ9t0HybY/QvqGVxFdl+/OmGeOEbo/ZcmUQV6zTg65t0/n++3PHaInHOfPmiDff7lITp89Jx17DtZJ4aYSzz9rjhc6UfclTUOsfU+HNen++Lp1MurBXDmtY1kvc7eF7o9Xr17TySa9O+MDiWr9mIxunYOHjlgBXlvRcqeMGyxd2zc3j1ocP3HalSs+t31Pj5fOyuhnjuwPSNFnn5ZPP/9aB11p3Q8/yZGjx6Vq5ZfMuJj8vTAzhur0tU7a6km3lk3flI6tG8vyz9eInghxzxbVstKnTSvOY8uIgd3NsUXXcUR3zbzRqJ388usf0rVdMxk5qIccPHxMKr3exBw33ZerJyBq13hFfln/mbRp3sDaxoaY+dzzhO7/bOUa6+/GcHne2o9HDOgmwcEXzONmofNFtt6jak+DtzvJ4qUrpU7NqjJj4nDJmjmTvFq7mVk/uhxPtjvNR0IAAXsIBNmjmtQSAQQiE9Crh3qlcfHSL6TSSy+arEPHTJHCTz8hH82dLK9WKietm78pE0b2t65gL5bTZ4JNHr2yOmfaaGn+Vh3R2+SH9usiA3p1kHkLPzbTQ3c0OK/TuL31hbanNKjzWujJIYb1arFejfho3iTp2r6ZVChbUjq3bSKzrQDCPWO6dGllyQfvWoHRS9KjUwtpaAWCyz//ypVlysz5cu7ceVn5yfvS+M1aUuu1yvLx/Cny145dsnrNnSs+ni5LC3UG50UKF7SCohHmi7mOd6Y3Xn9V6ljp/jT3mc+mDWvJ+HdnOyfL6PEzzPjxI/pK5ZdflCF9O5t6aZ4rV6668oXu0Ss73Tq8bb7EZcqYXjRQ1/W2dv2PJusz1rpKkTyp6JdlfWxBU7q095tpUXX+3X/IZMmRLYv5jEnnxMlT8vEHU8wJgnq1qppb5f/df1B0HWp5dWu+al3hPi/uV2+XLFtpBbMppNrdL/Cazz09kDWzPFvoCTPq8UcfNlfxtX06YvG8d82X85etkwq6fSx8f4KsXL1W9IumTnemFMmTm8c3dBseN7y3PPvMUzLJugr/6aIZ0qj+68a+gxVIrrC+JDvniepTrR95OJ854eDMu826wvnXjt3m5IxznKefard43mRRo7YtGsjb1v6kd01ouzTp4wbvjOgjO/7ZI3pFXMsNtrZpPWGj+8SYoT3l5fKlZHCfzvJ24zryzpR725uWqduabpM1qlaUaROGWMupKnMWfKLFmLTpx1+lbq1qxuOlMiWN6/QJQ8206Hb0pIeeJNJnhh95OK94sv+t+up7+X37Dpk3Y6xr+3l/yigJ/fKu0HXRq6RTZy2QYQO6mmBa96f5s96RR611M3byrBDZ9UTW5LEDzfsV8lgnKXp1bim6XN2HQmS8O5DZCvTz5XnQDOm+pOmpxx8xw9rR/bFv93bmmKQnjT6w6q4nnL5Zu1Eni6frx2R26/yybbvoCRVdp69ULGOdvHpFJozqZ45/zmyL43Hb92R9Oevh/qn718qvvgtxAk73/Yfz55FHC+QzWaP790JEzHzunRMnT5ttt0+3Nsa+SsWysmjOROsE1mX3bBLVspImTSLOY8tjj+Q3xxZdxw5H2PdOfP3dBnMCcNGcyfLWmzXl9WoVZYm1vx4/cVJmh7pCrifodD/TY6/m1RM9y7/4KkTdQg/o396XrBO1un3q39FJYwZI/nx3tj33vJGt98jaoydK8JKMVAAAEABJREFUvvx6ncycPFy6tGtq/lbrvqYn/6a9t8As4hcPtjuTkQ4CCNhCgADdFquJSiIQvkCfwWNFb+XT23wHDBtvguZBfTqIXgVau36z1KlZJcSML1lBst4q97N1JUEn6JUvvXLhvA1ey9JbPvfuOyT6BVbzOBx3vvB8Y12l1OB8vHUVL3Rwrl+SnUlvt9X51m/8SR6yvqQUfOJRHYwwlXy+sLnC5MxQ8MlHZN/dgFPHbdj0sxW8lJYM6dPqoEka4GqAvXnLVjPsybIcDocV/B0VvXJe0rq6pgFMeFdbXihRxJTp7LxQ4nnRt0GfDT4nGoDrbellX3jeOdl81rOuyOotis7gy4wMp/NMwcddY/UqbY5sWWXfgUOucQnZ82iB/KIBtbMO+nI5Daq3bL3z9n69M8N8mXZ7CeH8j5ZJDevLbvLkyZyzefy5Zu0P5krwI4XLm224UIkqZl7nyQYzYHV0m3U47myD1qB5+d5DeXObExk6rOnxRx8S9dcX5emwJ+ktK7jXE1p6u63m17tL8uXJZU6g6HB00tNPPhbC7nHrZITOX7LYc/ph0pOPFzCf+w8cMZ96hViDwNo1XjXDzk6FsqXk562/m31Yx+l213/oO1LypVrmsRLdRz9c8qnsP3hYJ5v0SIF8MmvuR6K3tYc+wWEyRKNT7oXiIXJ7sv/9/Ovv8vgjD8lzhZ9yzVvI2taj2vf1pIg+nlH+xRKu+fRulprWSbjv7564ck7QEyqpU927s0GDdJ22Lxb7T+ni99aPbvs5c2RzuXq6frQO7il/3getIPeGNGndw5zMct6B4p4nPrd9T9aXe12c/TWqvSx6DHeegLt586asWLVGala/d3eMJ38vnOVF9Kl3rehxtJ51EtCZR9fra1UrOAfNp2fLMlmj7Pz08zYp8FBec3LHmVnXtd4xtvGnX5yjzGehgo+ZT2cnd64csv/uPusc5/6pf++2bvvT+ltb1X201LNOmIUYYQ14ut6trCH+37Bpi7m7qmzpYiHGv1yutGy22qYj83uw3Wk+EgII2EOAAN0e64laIhCuQLNGdcytfV8tnycHd2yUiaP7W1c0U4o+WynWP317tn6hd6bMeQqLfvE6dPhOkDBr7iLR5z9fsgL3d6wrwp99NNNcxdM8wefuPNOrX5SsoszVxlw5s8srL5fVQVfS50X1BIEztezY10w7fOS4ZMqY0fRH1rnvvvtCTE6eLJm5rdY58sjRY2bZzjY4P3W5Bw8fM9k8WZa249vvN8oha56WTeuHOClgCrnbSZcuzd2+Ox/p09+5in3s+Ck5evyEua0+Xbo74+7kENFgVvv1tkz9DC+lSJFcNLlPS5w4kVy6e4u7+/jo9ud+MIeZ5ZBlbnpi0El3f8g2aRHp06YRveKl/ZrqWFfR9UqOXmnUL6XminONV3RStJIGZrUbtrVO4OQWvZKmL3Rb9uE0U8bZ4PPm09lJkybk9pHMunKWOnUq52TzqeO0JzrPjuttrBrQf7F6rRVQXZePl6+yrkKH/JKtZXqS0t4fso5JkyY1s93nVs9kd8ddunzJTNNHCLTn2dKvinOb1s+qbzTX0bJ33wHz2annUPn+h5+k/hvVzGMoehvvGzWqyJm7d8Fopomj+kud11+RMRNmSKGSr0rTNj1ET9DptOimDOlDbgee7H/HT5ySLJnD7utZs4Yd516fI0dPmEE9+WN67nayWmXputEr7HdHyf1pUjt7zafuO9qjAZJ+RjfpvqjJfT69g8W5P3q6ftzn1369mvvFx+/JkaPHzQkofWZ+7KT3XHctxfe2f8SD46XWM3TKkimjlLBOlurt2jrt23WbRPfz6lXK66BJnvy9MBkj6ei24nA4RO9wcM+WJXMm90HrhFPUf5tCzBDJgG5n+rK60Fl0mYcPHw8x+v773LYza0oiPUZfumz1hf//8ZOnzIQsmTOYT2fngSwh2xOd9e4sw/mp9T9gnZDT44N70tvxD9w9eRDVducsi08EELCHAAG6PdYTtUQgXIFcd9/irleu3IOBbA9kMbdu9+rS2gTw+qXePemZdy1Qg5PqVV6WDq3ektetK6GlrCtKzoBUp2tyOO5cvXxnRB9JmTKF1GrQRvQKiE7TVPDJR+XLZXNcqWfnVjpasmfLYn3Bu/PlxYyIYUevdFStXD7cdnRu29SU6smyHA6HuQVYr9zUqN9S3K/Sm0LudoKD75yYuDtoBULnTG/WLBnlgSyZTWCvXzLNyLsd58uqcmZ/4O4Y737o1ctc/8su+oxjTJd88tS9Z2SdZehJiSxWsOQcLv9icdFta9HHn4v+nJ9ecdY7GZzTPf3UIP/h/LllUJ9O1pWmqvJCyaKSO1dOT2ePk3z3W4F/tVdeksXLPhd9jv70mWAryL1zFT9OFhBFITmyZTU5Fs6eGO62rdu9Xt3XgKldi4byduO6orch6228zuDUFGB1kidPZp3oaCsH/v5BNq75RG7cuCn6/gDnLebJrJNeN2/esnLe+//ylSv3BiLp03pEtf/pNnL2XMgTK1rk2bNhx+l4Z8r2QGbTqwGI6bnbOWYF/Lp+wguq7maJ9w9P1k9EldDnuVctfV+O79kivbu2lUnT5sjgUZNM9vje9j1ZX6Yi4XSqVi4nq75aa57L1ufRn3n6CcmbO5crpyd/L1yZI+jRbUVPlurVevcswcF3jrPOcXGxLGdZup3p7ezOYeenjsuR485+6BwX3c+sd08shPm7Eao94a13T495+liQHmvd/4Y7+9+fNspV5ci2O1cmehBAwBYCBOi2WE1UEoHoCSS1rjKWKVVUft/+t+vZPP1i70zZ7wYHeqU8daoUIQpfHeoN0c6JehuiPqOst9y+2ayj6K3yOk2/SOsXA2cq8FAeHS2lSxSRf3bvE71yYEbEsFOqeBH5/c8dorcIO+vv/Hy0QD5TanSWpbfoFyvyjOibxw8dPmrmd++s3bDJfdC6erlZ9OpEurT3iwZCGpB+9c2GEHm++na96Be1Ag/lDTE+ugMpU6a0XCN+jj2i8vS24BaN68nCjz+TjT+GvGVT5wm2gqfNW37V3gjTH3/tFH3m3JlBT2DouMJPP+kcJfpLAXqCY9Enn8myFV9Jw7qvu6ZFp+f27VsS+ir4qq+/j04RcZJXn+/WdTlzziKp+FLpELepx8kCIimkUMHHzVVENXduz+6fur/dvi3mjpdUqVK5StKTY3p10zUiVE/+vLlkWP8uZr49+/abqTlzPBDmt6L/2L7TTIuq48n+p9vI9r//MVeNneXpXTx6O7NzOLzPpx5/1Nzxs/qbkOv+a2t/0hcIhjdPdMalsvYnza9m+hmd5Mn6iaq8ZMmSij7fri/N05dcav743vY9WV9aj/BSlUrl5D/ravGKVd9YJ62+ldDvlojO34vwytdxTz3+iKjLt9/fO87etjb0b+4++695NHmyrFR3H3m4eu2azhJheq5wQdm9d7/oHT/OTPoyvXUbtsjzzxZyjorRp96FodtK6L8b+r4W9wJve3DMi6g9ZUs/bx2bD4mehHc/Rmi/vpjOfTnar77VXilvXtbo3O50PAkBBOwjQIBun3VFTRGIlsCAXh1lzXc/mJ8M0xdWrd+4RfQnrl6u3sj181nFiz4jyz7/SjRQPXM2WPQnrEJ/UbptfXnSBeunPge+dMFU2WkF3o1a3gkCdFp4qXjRwqJXZN5q0c08i6lfWPRWz8atuoeXPcJxrZvVlyRJEkmZynWtK1HzRG9t/+iTz6Ve0w7m57R0Rk+WpfXXpEHmjIlD5cFcOawg/W3rKv8ZLcKVVqz6VuYtXCrqpZ/6VvmOrZu4pnft0Fz0qub02R+aPPqTPlNmzpcOrRubAN6VMQY9+hzhN2s3mTbq8vVkiKfFvFmnuuiXXz3xMHT0ZPNytwWLPzW3Oz9ZtKJ5/j6ysvQWV32DuC5XU7tuA81zm7oO3eer83oV80X3zNlzMXqhmpalJ0i2/PK7fLtuo7kbQ19GpS/Z02neTKWKPycP/i+7OalRs1rlMIvuN2Sc+YmzMBPiYIR+2e7bva3om/Nbd+pntindtgeNmCj6E126CD3RpnV8b+4i80y6XhFv1rannLv7+Inm0VShWkPzqIrOry+UGjB8guh7GjQA1unVKpcXfY5Vf+JQtyndZifP+EAnRZk82f/05EaB/Hmtba2n+blCPbnzdvve5m6TyBagx5NWzerJ6AkzzQsCdbvT/o0/bpXObZpGNqtH0/LlvfOirvfmLTb7alQnDNwL9WT9uOd39uvPcumvPHzy6SqzTLX+7IuvRdej5onvbd+T9aX1CC/pMaBMqedFtx89qed+e7vm9+TvheaLLOmt7fr+B93u9aThmbPBou9S2bV3X4jZPFmWvsgw2wNZZOmnq421bj96jA9RkDWg7zjQvxF6TNP9Q/Ppu1bSp08rWhcrS6z+79DqLXlv3hLR4+258xfkwyWfyYKPPg1RpifrPaL26Isxa1WvLPpzcnp80BPC+q4APV7rT7rpgqLa7jRP3CZKQwCB+BQgQI9PXcpGIAEF9KrvNysWmKueQ0ZONn/c9cpIpQovSsYM6U3N2rZoKOVeKCHlqrwpeZ4oLfrTbHoru5kYQeeBrJnlk/lT5Zetf4o+bx7eS5Ccs86cNMJcmewzaIz5aTK9MqYBkXO6J5/JkyeT1cvnybOFnpLZHyw2JxxGT5ghD+XNLUWffdpVRHSWpVecF8x6R9KnSyfV67wt+iXRWdCg3h2t5SwxXho0Du7TSV6vVtE5WfRFPfNnviMLl6yQOm+1Myc1undsIS2a1HXliWmPLjtP7v9ZgU4Ps/zfPPiZKuey9Irr6uVzpUmDWrLyq7XStkt/81M/e/cdlOkThknN6pWcWcP9fPqpR6V0iaJSt3F7qdWwjSROlNhaz1PM9uM+g95KrycC9K3jGgS6T/O0X+94GD6gm/QaMEay5nvO/HTanOmjPZ09zvI5HA7R9y9oO155+cUw5W6z/PfH4iVkYQoMNeLNN6rLBzPHyY5de6VVx77G/e9/dku92tXE+U/v+EiSNInobzcXKVNdsj2QWfRN787p+vnoI/nNSYYmrbuL7pMapOj7JDQA1umFCz0p+iZ4fWN67sdLmWBCf0VAp0WVPNn/HA6HfDR3kqSw9tVSFd6Q4uVrSrEihUTfbB1V+foYjv46Q/9h48z+tPKr70RPAj79VMiXdUVVTnjT9TGKqeMHi74AsJq1n/cZNDa8bBGO82T9hJ45f77coj+pp7808EajdjJl1gLp2v5tKzUzWeN72/dkfZmKRNCpUqmsuROiWJFnRG+tds8Wk78X7vM7+/WY+nL50lK/aUdru37BOkF8TLq0a+6cbD49XdbcaaPl4OEjotYawOqVd1NAqI7+SoT+7WnRoY80atHFrKMvlrxnHtsKlTXag69WKicjBnaVcZNmib6LZcbshTJhVH9x/+fpeo+oPZPHDpDWzRuI3mmkPwfYpnM/8xq03H0AABAASURBVD6U6q/cebleVNude11s0U8lEQhwAQL0AN8AaL49BfRLWPCh36TN2w0ibYAG6fryrZ2/fiOaXwM4fZ5Vb4HTGfUW0LHDesmOrWvMdP35Mv0ZM83rfHFT3ty5zDQ9i6/zaNLbaLXMGROHhQngdLoz6RXAYf27ys/rPjMvsdNn1fv1aOecLL9tXCkdrKsPrhFWjy7/1L6Qt2mnS3u/+XmpX3/43NRFy+vfs70VrGSx5rjzf3SXlTJlCivwnysbvl5iBepp7xRidfVL3NqVC81ytm74XFo2rWeNDfm/XjFcu2qhHNq5SX78blmY9aA/sbRi8SzXTPpF/+iuH13Dzp4fv1sundveuzqfNUsm8zN0u7Z9Z5avz2Y784b+1HWkP53nPl7Xq3r/8PXHos8ja55vP19gTpK45wvdb4KYOZOsL8lNzXrSui79cKo4H4Vwz69vCde32tcJ9fZx9zzu/VqG1iP0rZh6QmPzt0tNO/VTp2s+9yv24W0f+pvH+nyv+zLUSefVxwx0/GuvvmzK1RMxOqxXBnW6fknWYWfSk0t6q62evEiSJIlztPm8ceOG/PLrn9KwXg0zHFFnqgaAlp37dG2DLk/3U+d4rYuO07o5x+mnvhn/mxXzzbakzyzrM+nVq7ykk0zSt5UvmDXeTD+2+yfzG866D61b/ZGZrp13hvcRDch3/7ZWtv+02rxM7pGH8+kkV9KfpNP9RuugLzHToEL7df/WTPqpw+77uY7X5Mn+p9vuJwumyuF/NpnUo1NLmTt9rOgxQsuIKDkcDvPzilu+/8y08bsvPrROFIX8JYWp4RhHtF2FXo7+PN36rxbL6f1bzbP+Ot3T/VHzRrV+NI970hetqYMeQ9RizWcfmJN3eueOM198bvu6DE/Wl+YLLzWq97rZd1Z+cu+n/pz5UqVMKVH9vahepYKZ3zmP7pO6Xek+6hyn+5pus7q9nj24zdpOxpjj4F9bvnJmMY8+RLUszazbqx5r1VqXo/uZ7mPOfs2jKc19qWXW5BGiy9jz+/fmpzr/lzObTjIpou1fT2zp30WTKZJOs0Z15Jf1K0zb9W9DdWsf1jo8nD+3ay5P1nt47dEC9BdHenRqIZu++UT0OKF2+nNuhQo+rpPNC/6i2u5MRjpGgA4Cvi5AgO7ra4j6IYAAAj4gcOr0WXMbade+w0Vvxa9U4QUfqFXMqqDBt97mOnzsFNFnwN9+q26YgvRntvTZ7VdeLhNmGiMQQAABBBCIQIDRCMRagAA91oQUgAACCPi/wI9btpnb7v/777LoFU33K4J2a/3F/y6Ztuj7Bt4dO0j0tv3QbdArWXpl3+FwhJ7EMAIIIIAAAgkkwGIDQYAAPRDWMm1EAIEoBSK6xTHKGQMkQ+WXXzS3b+rtpAWfeNTWrdaXMentpxqAv16toq3bQuURQAABBBCIMwEK8gkBAnSfWA1UAgEEEEAAAQQQQAABBBDwXwFa5pkAAbpnTuRCAAEEEEAAAQQQQAABBBDwTQG/qRUBut+sShqCAAIIIIAAAggggAACCCAQ9wLeK5EA3XvWLAkBBBBAAAEEEEAAAQQQQACBkAJuQwTobhj0IoAAAggggAACCCCAAAIIIJBQAvERoCdUW1guAggggAACCCCAAAIIIIAAArYVsGGAbltrKo4AAggggAACCCCAAAIIIIBAhAIE6KFpGEYAAQQQQAABBBBAAAEEEEAgAQQI0L2MzuIQQAABBBBAAAEEEEAAAQQQCE+AAD08FfuOo+YIIIAAAggggAACCCCAAAI2FSBAt+mKS5hqs1QEEEAAAQQQQAABBBBAAIH4EiBAjy9Zyo2+AHMggAACCCCAAAIIIIAAAgEsQIAewCs/0JpOexFAAAEEEEAAAQQQQAABXxYgQPfltUPd7CRAXRFAAAEEEEAAAQQQQACBWAkQoMeKj5kR8JYAy0EAAQQQQAABBBBAAAF/FyBA9/c1TPsQ8ESAPAgggAACCCCAAAIIIJDgAgToCb4KqAAC/i9ACxFAAAEEEEAAAQQQQCBqAQL0qI3IgQACvi1A7RBAAAEEEEAAAQQQ8AsBAnS/WI00AgEE4k+AkhFAAAEEEEAAAQQQ8I4AAbp3nFkKAgggEL4AYxFAAAEEEEAAAQQQuCtAgH4Xgg8EEEDAHwVoEwIIIIAAAggggIB9BAjQ7bOuqCkCCCDgawLUBwEEEEAAAQQQQCAOBQjQ4xCTohBAAAEE4lKAshBAAAEEEEAAgcASIEAPrPVNaxFAAAEEnAJ8IoAAAggggAACPiZAgO5jK4TqIIAAAgj4hwCtQAABBBBAAAEEoitAgB5dMfIjgAACCCCQ8ALUAAEEEEAAAQT8UIAA3Q9XKk1CAAEEEEAgdgLMjQACCCCAAAIJIUCAnhDqLBMBBBBAAIFAFqDtCCCAAAIIIBCuAAF6uCyMRAABBBBAAAG7ClBvBBBAAAEE7CpAgG7XNUe9EUAAAQQQQCAhBFgmAggggAAC8SYQMAH64uWrpX6LntKgZW9Zt2lruKCnTp+VNt2GSeO2/aTX4Aly+coVV77tO3ZLozZ9pUTFBlKpdiu5eeuWaxo9CCCAAAIIIIBA3AhQCgIIIIBAIAsERIC+/+BRmbdohUwf109GDegoQ8fOkCtXr4VZ7xOmL5CihZ+S2ZMGSZo098mCJStNnv8uXZaOvUfLqxVKy5rls2TqmL4S5HCYaUmSJBUSBp5sA2aDsTqe5CUP2xTbANtAdLYB69Bi/o/OPOQN0G2M7y18b4vmNmAOLlaHYwbHDE+3AWtz4f9YCAREgL5h81YpXbywpEqZQrJmySgF8ueWLVv/lND/fvhxm1R+qaQZXbl8Sdnw46+m//uNP8sjD+WR16qUk+TJkkqunA+Iw3EnQDcZ6CCAAAIIIIAAAggIBAgggAACsRMIiAD95Okzki1rJpdUjmxZ5MSp065h7dGr5Bpzp0ubRgclZ/YscvLUGdN/5OhJ81mnaVdze/u8j1aYYToIIIAAAggggAACXhNgQQgggIDfCwREgK5r0RF0r6kOR/hXv4NC5LmX//btW3L0+AkZ0b+TzJsyVL7/4Wf5Zdt2LVYuXbpECmCDy5cviafp6tWrosnT/OTz3DahrNj/LwX08S+htrvwlnv16hXr+HLF4+NReGUw7pKt/TgeXYqD45F9y4jP/fcq3198/tjga/u/CZLoxFjgXhQa4yJ8f8ZMGdJLcPA5V0XPnA2WzBkzuIa1R29/v3nzlly7fl0H5bSVJ1PG9KY/Q/q08shDec2t7RkzpJMnHs0nO/ccMNNSpEgupMA1SJYsuSTzMCVJkkQ0eZqffJ7bJpQV+37g7vu67hNquwtvuUmTJhVN4U1jnO8fS+JiHek2SfLxY1I8fmeMi20oojL0u4umiKYzPuGPMb6275sgiU6MBQIiQC9RtJCs37xVrl67JmfOnpO/du6VIoWfMGi//v63XL9+w/QXe66grFm7yfR/9d1GKVGkoOkvac3/z559cvG/S6aMP/7aLQXyP2imORxB4iCJI0AN9K4LUpAEqkGgbve0+85x35e2e+c68aU6URfvHhud2wCfd/bPQHPQ/Y3k3X3Ol7x9bXs3QRKdGAsExXhOG82oL3WrXrmsNGnXXzr0GiUdWzWQpNbVTG1CtwHvyLnzF7RXOrSoJytWrzM/s3bg4FGpV7OyGa9X0t+s9Yo06zBQmrYfIGVLF5VCTz5iptFBAAEEEEAAAQQQQMDPBWgeAgh4SSDIS8tJ8MXUqlZB5k8bLvOmDpXSxZ5x1efrpTNEb1vXEfo5dUwf8zNrw/q2lxTJk+tokyqVLyULZ46UD6YOk7o1KppxdBBAAAEEEEAAAQQQQCC2AsyPAAJOgYAJ0J0N5hMBBBBAAAEEEEAAAQQCSICmImAjAQJ0G60sqooAAggggAACCCCAAAK+JUBtEIhLAQL0uNSkLAQQQAABBBBAAAEEEEAg7gQoKcAECNADbIXTXAQQQAABBBBAAAEEEEDgjgBdXxMgQPe1NUJ9EEAAAQQQQAABBBBAAAF/EKAN0RYgQI82GTMggAACCCCAAAIIIIAAAggktIA/Lp8A3R/XKm1CAAEEEEAAAQQQQAABBBCIjUCCzEuAniDsLBQBBBBAAAEEEEAAAQQQQCBwBcJvOQF6+C6MRQABBBBAAAEEEEAAAQQQQMCrAnEWoHu11iwMAQQQQAABBBBAAAEEEEAAAT8TsEuA7mfsNAcBBBBAAAEEEEAAAQQQQACBkAIE6MaDDgIIIIAAAggggAACCCCAAAIJK0CA7g1/loEAAggggAACCCCAAAIIIIBAFAIE6FEA2WEydUQAAQQQ8B+By1euSJ+hE6Ve825S/+3usmnLtggbt/GnbSZPw1a9pf+IKXLl6jWT9/yFi1K4TK0Q6c+/d5tp7p023YbIc+XecB8lx0+elvY9h0vJSg3MtPmLV4SYzgACCCCAAAIIxJ8AAXr82fpLybQDAQQQQCAeBOYt+ky2/vZXmJJnzP1Yrl67JgtmjJL+3VpJj4HvyH+XLofJp0F49wHjZED31jJ3ylC5evWqzJ6/1JUvVcoU8vO3i13p8UfyuaZpz6ervpXUqVOJQwfuppu3bkmrLoMlc6YMsuyDCfLDqvlSuvizd6fygQACCCCAAALxLUCAHt/ClB+FAJMRQACBwBQ4cOiInD13Pkzj16zdJLWrvWzG58+bS/LnySXrN/1iht07azdskUceziP58vzPjH6tSjlZ8/0m0x9V58SpM7Jo6Spp17xeiKybrCvyly5fke7tm0jGDOkkSZLEkjN71hB5GEAAAQQQQACB+BMgQI8/W0r2BQHqgAACCNhI4Pbt23Li5GnJlTObq9Y5c2SVo8dOuoadPXores5s94JnnefI0RPOyXL5ylUpUbG+vFKnlUyasUCuX7/hmtZv+GTp0/ltSZokidx2jRU5ePiYZLGunrfsPEhKVHpT9Bb4/QePuOWgFwEEEEAAAQTiU4AAPT51KdvvBWggAgggEB2B4e/MdD0Xvnzlt9J9wDjX8NoftpiiHA6HOILu/XkOctzrNxncOo4gh2soyOEQDfB1RMqUKWTl4mny/RfzpGeHZrJ+8y8y64OPdZIs+3yN6O3ujxUIecu7Trx165b8s3uftG5SR1Z/PMPc3t5j0Ds6iYQAAggggAACXhCI+K++FxbOIhBAIFIBJiKAgJ8J9OzYzPVMeLVKZWTkgE6u4ReKPysOh0MyZUwvp88Eu1p+6sxZeSBrJtews0evdJ85e845KKeseXLcvR09caJEkjF9WkkUFCTFizwtDd6oKr9v/8fkXfP9Zpnz4XJzYuDlmm+LBuX6QrlDR46bq+c5smeRgk8UEH2GvUKZ4rJrz36Tx8xMBwEEEEAAAQTiVYAAPV55KRwBXxagbggg4IsCZUsXlWVfrDFVO3r8pGz/e7eUKFrIDO87eESct5yXKl5Ytv2xQ44cu3Nb+6er1krZUkVNPn1UjfPAAAAQAElEQVSBnOmxOpevXJHvravzT1lBtzUo747u4zop8OWS6RJkBfH6Mrkc2bJI8aJPy4WLl2TfgcOaVdZt+kUeyvugyWNG0EEAAQQQQACBeBUgQI9XXgpHIIAFaDoCCMRI4O1GNSX43AWp26ybdO03Rgb3biupU6U0ZS36ZKUsXv6l6U+b5j4Z0ruddOs/VvRn1i5fviKN679mpunPr+lVcU1aTt7c/5NmDV430yLrpEieXIb37SC9Bk8wP/P29XcbZdTATpHNwjQEEEAAAQQQiEMBAvQ4xKQoBBDwngBLQsDuAn26tHBd8XZviwbJI/p1lA9njpL500fK888WdE3u0aGpdG3b2DVc7LmCJs/cKUNlYI9WkjxZUjPt5bIlXFfJl30wUVo0qmVudzcT3Tr6pvaf1ixyGyPm9nZdtv7M24ThPSWH24voQmRkAAEEEEAAAQTiXIAAPc5JKRABBPxAgCYggAACCCCAAAIIIOB1AQJ0r5OzQAQQQAABBBBAAAEEEEAAAQTCChCghzVhDAIIIGBvAWqPAAIIIIAAAgggYEsBAnRbrjYqjQACCCScAEtGAAEEEEAAAQQQiB8BAvT4caVUBBBAwHYC5/f8LD6QqEMM1sOFvb+IJtaffbdh2x0wqDACCCCAQLwIEKDHCyuFIoAAAvYT+Ht6C/H/5J9t3PVeW9HE+rPv+hX+IYAAAgggYAkQoFsI/I8AAggggECcCFAIAggggAACCCAQCwEC9FjgMSsCCCCAAALeFGBZCCCAAAIIIODfAgTo/r1+aR0CCCCAAAKeCpAPAQQQQAABBBJYgAA9gVcAi0cAAQQQQCAwBGglAggggAACCEQlQIAelRDTEUAAAQQQQMD3BaghAggggAACfiBAgO4HK5EmIIAAAggggED8ClA6AggggAAC3hAgQPeGMstAAAEEEEAAAQQiFmAKAggggAACRoAA3TDQQQABBBBAAAEE/FWAdiGAAAII2EWAAN0ua4p6IoAAAggggAACvihAnRBAAAEE4kyAAD3OKCkIAQQQQAABBBBAIK4FKA8BBBAIJAEC9EBa27QVAQQQQAABBBBAwF2AfgQQQMCnBGwToN+8dUuOHj8pv23fKbv3HpBz5y/6FCSVQQABBBBAAAEEEEAgpABDCCCAQPQEfD5AP37ytAweM0PKVW8mLToNlkkzPpS+wybJ6406Sa3GnWXlmvXRazG5EUAAAQQQQAABBBDwBwHagAACfifg8wF6ux7DpeATD8nqj6fJpwsmyqwJA2XhrNHy9dIZMrJ/J/nplz9l/uIv/G7F0CAEEEAAAQQQQAABBBJSgGUjgID3BXw+QJ89abBUqfCCJE2SJIxO7lzZZUD3llL9lTJhpjECAQQQQAABBBBAAAEEfFaAiiGAQDgCPh+gp0qZIpxqhxzlSZ6QczCEAAIIIIAAAggggAAC/itAyxCwp4DPB+hO1g2bf5VmHQZKyUoN5fkK9V3JOZ1PBBBAAAEEEEAAAQQQQMArAiwEgXgSsE2A/t78pdKlTUNZ+/n7smn1fFeKJxeKRQABBBBAAAEEEEAAAQQSRICFBq6AbQL0LJkzyMP5HpREQbapsvAPAQQQQAABBBBAAAEEEPAxAarjwwK2iXYzpE8rSz9fIxf/u+TDnFQNAQQQQAABBBBAAAEEEAhkAdoeGwHbBOhLV6yR0ZPmSPnXmrueP9dn0WPTeOZFAAEEEEAAAQQQQAABBBCwkYCfV9U2Abr7c+fu/Z6un8XLV0v9Fj2lQcvesm7T1nBnO3X6rLTpNkwat+0nvQZPkMtXrph8u/ceCHFSoGPv0WY8HQQQQAABBBBAAAEEEEAAAf8RSOiW2CZAV6jbt2/L3n2HTdJ+HedJ2n/wqMxbtEKmj+snowZ0lKFjZ8iVq9fCzDph+gIpWvgpmT1pkKRJc58sWLLSleeZpx51vZjunaFdXePpQQABBBBAAAEEEEAAAQQQQMADgSiz2CZA/3Tlt+b29nY9houml2q8LZ99uTbKBmqGDZu3SunihSVVyhSSNUtGKZA/t2zZ+qeE/vfDj9uk8kslzejK5UvKhh9/Nf10EEAAAQQQQAABBBBAAAEEEIhvgdgF6PFdO7fy5y/5QgZ0byUrFk4yqV/XFvLBRyvcckTce/L0GcmWNZMrQ45sWeTEqdOuYe3579JlcThE0qVNo4OSM3sWOXnqjOnXzvade6RExQbStP0A+X37PzrKJL2ST7otGGAQmNvALWvb959kDmp0EEAgQQRifwz1n2PR7du0JfoGfA+5fRsDXzFIkIOoHy3UpwN0d+fEiRNLiaJPW0G0w6SSzxeSoCCHe5ZI+x1B95rqcIQ/X1CIPPfyZ3sgs3y2YKKsWjJVypQqIl36jZVLl+88n3758iUhYeDJNnD16lXR5Ele8thlm7ps7f/+kyI9iDIRAQTiVSD2x33/ORZdvkxbom8Qf3839buLpst857X+5sefsz/5xuvBMgAKvxeF+nhjEyUKkk1bfnPVcsPmXyVp0qSu4ch6MmVIL8HB51xZzpwNlswZM7iGtUdvf79585Zcu35dB+W0lSdTxvSmP2WK5HJf6lQm1a1RUbJmzigHDx+7My1lKklJwsCDbSB58uSiie2FfcZXtwFzUKODAAIJIuCrxwXqxd8s/e6iiW2BbcHTbSBBDqJ+tFDbBOg92jeWMZPnut6mPn7aB6LjPFkXJYoWkvWbt8rVa9fkzNlz8tfOvVKk8BNm1l9//1uuX79h+os9V1DWrN1k+r/6bqOUKFLQ9Lv/9rq+0f3sufOSM3tWMy3iDlMQQAABBBBAAAEEEEAAAQQQ8FzANgH644/kl4/njJUF00eatOT9sfJYgXwetTRXzgekeuWy0qRdf+nQa5R0bNVAkiZJYubtNuAdOXf+gunv0KKerFi9zvzM2oGDR6Vezcpm/Mqv15sTAyUrN5KxU+bJsD7tRK+qm4kJ1WG5CCCAAAIIIIAAAggggAACfiUQ5Out2fLrn6JXsPXz523b5fTZsyZpv47ztP61qlWQ+dOGy7ypQ6V0sWdcs329dIZkzJDODOvn1DF9RH9mbVjf9pIieXIzXufV315f/8Uc0elPPJrfjPfnDm1DAAEEEEAAAQQQQAABBBDwroDPB+jvzV8mx0+eFv0ML3mXi6XFkQDFIIAAAggggAACCCCAAAIIhBLw+QB92ti+kvfBnKKf4aVQ7WEQAREBAQEEEEAAAQQQQAABBBCwn4DPB+hO0rHvznP2uj4Hj5nh6qcHAa8JsCAEEEAAAQQQQAABBBBAIB4EbBOg79q7P0zz/9qxK8w4RiBgdwHqjwACCCCAAAIIIIAAAoEp4PMB+mdfrpUWnQeL/ryZfjpTw1a9Jc+DOQNzrdFqBGIuwJwIIIAAAggggAACCCDgowI+H6AXevIRaVK/umTNnNF8ar+m4f3ay9A+7XyUlWohEKgCtBsBBBBAAAEEEEAAAQRiKuDzAXqObFnk2acfl/nTh5tP7deULWvmmLaZ+RBAwK4C1BsBBBBAAAEEEEAAAT8W8PkA3Wl/9do1mbvwM+nQa6S55d15q7tzOp8IIIBAbAWYHwEEEEAAAQQQQACBhBSwTYA+aNQ0OXn6rJw6HSzVK5eR1ClTSIH8DyakHctGAAEEoiNAXgQQQAABBBBAAAEEIhWwTYC+d99B6dKmoaRKlUIqlCkuYwZ3kUNHjkfaOCYigAACgSNASxFAAAEEEEAAAQTsLmCbAD1VqpTG+saNm3Lp8hXTf/36TfNJBwEEEEAgngUoHgEEEEAAAQQQQCDeBWwToKdOlUqCz1+Q4s8VlLfa9LFSX8maOYPwDwEEEEDA/gK0AAEEEEAAAQQQQEDENgH6+GHdJG2a+6Rx/erSq2MzadWktnRr35h1iAACCCCAQFQCTEcAAQQQQAABBGwhYJsA3V3zqccfNj+5lijIltV3bwr9CCCAAAK2F6ABCCCAAAIIIIBA3Aj4fIT7fIX6ElmKGwZKQQABBBBAwEcFqBYCCCCAAAIIBIyAzwfom1bPF021q1eQujUqyrypQ2XJ+2Ol5Vu1pVqlMgGzomgoAggggAAC8SFAmQgggAACCCDgOwI+H6A7qX757W9p27ye5M+TS3JkyyIN3qgiwefPOyfziQACCCCAAAK+J0CNEEAAAQQQQCAaArYJ0K9duybB5+4F5FeuXpMzZ+8NR6PNZEUAAQQQQAABvxCgEQggEB2By1euSJ+hE6Ve825S/+3usmnLtghn3/jTNpOnYave0n/EFNHv3qEzt+k2RJ4r94Zr9KEjx6RctSZSuEwtebnm22ZZ585fdE1ftHSl1G7cWWq+1UlGjJ8lN27ccE2jBwEE7gjYJkBvUPtVqd2km/QeMlGGjpspbzTpKlUrvXinFXQRQAABBBBAAIG4FqA8BGwqMG/RZ7L1t7/C1H7G3I/lqnXRa8GMUdK/WyvpMfAd+e/S5TD5zl+4KN0HjJMB3VvL3ClD5erVqzJ7/tIQ+T5d9a2kTp1KHG5j06dLK4veGyM/f7tYZk8aLDdu3pTZC+7Mt+b7zfL56u/lPWv8wlmj5cqVq/Lhxyvd5qYXAQRUwDYBeuWXSsn7kwfJ008WkIfz5ZJp4/pKpXIltQ0kBBBAAAEEEEDAdgJUGIH4Ejhw6Iicdbvz1LmcNWs3Se1qL5vB/HlzmUdH12/6xQy7d9Zu2CKPPJxH8uX5nxn9WpVysub7TaZfOydOnZFFS1dJu+b1dNCVUqZILhkzpDPD+umwwneHw2GGd+zaK/pLTKlTpZTEiRJJsSJPy1drN5ppdBBA4J5A0L1e3+/LljWzvP7qSyZlzZzR9ytMDf1WICFvEftr5x7pP2KylK3WWKrVbydDxk43Z8P9FpuGIYAAAgjERIB5EAghcPv2bTlx8rTkypnNNT5njqxy9NhJ17Cz57iVL2e2rM5BM8+Roydcw/2GT5Y+nd+WpEmSyG3X2Ds9eoVeb3EvVqGeNe22tGlax0wokC+3/Lb9H3PF/uatW6K30B8/ccpMo4MAAvcEfD5Af75Cffnjr10R/tTavabQh0DcC/jiLWL6x7BJ/RryzfLZMmlkL9m1Z78sXvZl3DeeEhFAAAEEEIhQgAm+JjD8nZnm2W8Njpev/Nbcoq79mtb+sMVU1+FwiCPo3tf/IMe9fpPBreMIcriGghwO0QBfRyz7fI08/kg+eaxAPh0Mk5IlTWpucf980RTRq+WTZn5o8pR74XkpW7KI6DPopSo1kKAghySyrqQL/xBAIIRAxHtliGwJN6A/sfbEo/nNT61pf+iUcDVjyYEg4Iu3iOntZv/L8YDhz5k9q7ld7Eg4Z79NBjoIIIAAAgjYUYA6R1ugZ8dmJjDW57+rVSojIwd0cg2/UPxZcTgckiljejl9JthV9qkzZ+WBrJlcw86eLJkyyJmz55yDcsqaJ4f1nUNH6LPkcz5cbk4GvFzzbbllXQ3XkwCHjhzXya6kd7uWK11UJ4Vp3AAAEABJREFUfvjxV9e4t+pVFw3cf/hyvjz9xCPml5lcE+lBAAEj4PMBuqklHQR8SEDPICfkLWLuFCdPnZEvvvpeShV7xn00/QgggAACCCAQiUCgTiprBczLvlhjmn/0+EnZ/vduKVG0kBned/CI7LeSDpQqXli2/bFDjhy7c1v7p6vWStlSRXWSvDu6jyvw/3LJdOtKeJAZzpEti+zZd1DOBp83+a5dvy5r1m6SJx97yAzrbe16+7u+OG7Dj1tlsnVlvdbd5+FNBjoIIGAEfD5AL/3KWxJZMq2gg0AcCvj6LWLOpl7875K07jZEGtWpJs8/W9A5mk8EEEAAAQQQSFgBn136241qSvC5C1K3WTfp2m+MDO7d1tyGrhVe9MlKWbz8ziNzadPcJ0N6t5Nu/ceK/sza5ctXpHH91zRbpEnLrtO0i7m6XqxCPdm194C0fKu2mef69RtS5tXGUrR8HRk7eY40efM1eenFYmYaHQQQuCfg8wH695+/L5Gle02hD4G4EbDDLWJ6VrpL39HSuN5r8mbtV+Om4ZSCAAIIIIAAAjYQiLqKfbq0cF3xds+dInlyGdGvo3w4c5TMnz4yxAn+Hh2aSte2jV3Ziz1X0OSZO2WoDOzRSpInS+qa5uzRN7X/tGaRc1CeeepR+fLjGeaKut5qP3fKMHNbvWbQ+fXWdh2/7IOJwtVzVSEhEFbA5wP0sFVmDAIJL5CQt4jpb5N26j1KarxaXl4uWyLhMagBAggggAACCPiPAC1BAIEEFbBNgH7g0DHp0GukvFClcYg3uieoHgsPWIGEvEXss1Xfyeaff5Oeg8abW8j0xSy9Bo8P2HVBwxFAAAEEEEDAPgLUFAEEIhewTYA+aPQ0qfLyi1Lgodyy4sNJ5jcVm9SvHnnrmIpALAV88Rax+rWquG4d09vENA3r2yGWLWV2BBBAAAEEEEDA9gI0AAHbC9gmQL9y5aqULfWc+SkHfd6lXs3KsnffIduvABqAAAIIIIAAAgj4q0Dwv2vk3297kGxscHBdX9HEetTt2L5J90V/Pc74W7tsE6CnTJnc2DscDjl4+JhcuXpNzpy98zMOZgIdBBBAAAEEEEAAAZ8SuPbfcbl08k+SjQ0un9oumliPXtiO43E70X3Rpw4OVCZCAdsE6AUff1iCz1+QOq9VkrrNusuLrzaW8i/e+T3GCFvHBAQQQAABBBBAAAEEEEAAAYHAHgK2CdBbNXlD9DcZXyhRWNavnCubVs+XGlXK20OZWiKAAAIIIIAAAgEu8PmPF6TFxCMkDNgGvLQN6D7nxcMOi4ojAdsE6PXf7ikffrzSXEWPo7ZTDAIIIIAAAggggICXBI6euS5bd18mYcA24KVtQPc5L+3eXlhM4CzCNgF63y7NZf/BI1LrrS7Spd8Y+Xb9T3Lj5s3AWVN3Wzp2ygIh2dNg/PRFoon1Z8/1p+vt7m7IBwIIIIAAAggggIA/CfhQW2wToD+cP7f07NhUPl0wQYoXeVrmfbRCqrzRxocovVOVcdM+FJI9DcbP+Eg0sf4+tO027J29nKUggAACCCCAAAII+JNAdNpimwDdvVFBDof7IP0IIIAAAggggAACCCCAAAII2F4gBgF6wrR5565/Zfg7s6RqvfayfvNWaVC7iqxYNDlhKsNSEUAAAQQQQAABBBBAAAEEEIhjAd8L0CNo4OAxMyRXzmyy+P0xMmZQFylT8jlJnChRBLkZjQACCCCAAAIIIIAAAggggIC9BGwToM+fPlzqvl7J/NRabIiZFwEEEEAAAQQQQAABBBBAAAFfFPD5AF3f2H7k2Ilw7c6dvyhjJs+VDxZ/Hu70BBjJIhFAAAEEEEAAAQQQQAABBBCIkYDPB+ivvPSCtO85Ulp3HSrvvrdQZsxdYtKg0dOkXvMecvnKValSoVSMGm+/magxAggggAACCCCAAAIIIICAvwr4fID+QonCsnj2GHmrXjVJkTyFaz0UfPxheX/yINHfR097fxrXeHpiIcCsCCCAAAIIIIAAAggggAACCSbg8wG6yjgcDilc8DFpbAXpzRvWFE2vVnxRMmVMr5NJNhGgmggggAACCCCAAAIIIIAAAhEL2CJAj7j6TEHAJUAPAggggAACCCCAAAIIIGBrAQJ0W68+Ku89AZaEAAIIIIAAAggggAACCMSvAAF6/PpSOgKeCZALAQQQQAABBBBAAAEEAl7A5wP002eD5Z89+8OsqJ2798nZ4PNhxjMCAQTCCjAGAQQQQAABBBBAAAEEfF/A5wP0EePfk1Onz4aRPHU6WMZPmx9mPCMQQMDrAiwQAQQQQAABBBBAAAEE4kDA5wP03XsPSrHnCoZpavEiBeWvnXvCjI9oxOLlq6V+i57SoGVvWbdpa7jZ9ERAm27DpHHbftJr8AS5fOVKiHx6xb5M1aYydfZHIcYzgAAC8SlA2QgggAACCCCAAAIIBIaAzwfoiRMninBN3Lp1O8Jp7hP2Hzwq8xatkOnj+smoAR1l6NgZcuXqNfcspn/C9AVStPBTMnvSIEmT5j5ZsGSlGe/sjH13nhR6qoCIQ/iHAAL+IkA7EEAAAQQQQAABBBDwEQGfD9DTpU0jh44cC8O1zwq6M6S/P8z48EZs2LxVShcvLKlSppCsWTJKgfy5ZcvWPyX0vx9+3CaVXyppRlcuX1I2/Pir6dfOb3/ulBQpksljBfKL3NYxJAQQQCBqAXIggAACCCCAAAIIIOCpgM8H6G83fF3a9RgpX323UYLPX5CTp87Il99skE69R0mzBjU8aufJ02ckW9ZMrrw5smWRE6dOu4a1579Ll8VhXRnXEwI6nDN7FrMs7b9x44ZMmrlQ2jaro4Mh0vXr18WbKcTCGUAAAa8K6LHAPXlz349gWXF6/PEqJgtDAIEQAjduXJfYJG8cI2KyjFu3boVoJwMIIJAwArovxmQfjsk8CdNC/1mqzwfozxR8THp2bCKLln4pFWu2lFfrtZOPP/vajHv26cc9XhOOoHtNdTisSDycOYNC5LmXX291f61KWUlzX+owc+nG7s0UpgKMQAABrwncvHlD3NPt27fEn1JYSMYggIC3BG7evGUdX2KefPdYxG2H3tqGWA4CkQncvn1bvBWzRFYPpkUtcC8KjTpvguXQQFyfC18+f4KsWDhZZk0YKDrO0wplypBegoPPubKfORssmTNmcA1rj97+rn8cr1lXxHVYf94tU8b02mtudR88ero8X6G+zJi7ROZ9tELGT/vATEuWLJl4M5mF0kEAgQQRSJYsuSRzS0mTJhN/Sl5HZYEIIOASiO13CV89FiVKFPG7hFyNpwcBBOJdQPfF2B5nPJ0/3hvj5wvw+QB9z78HxZkuXrwk585dcA3reE/WT4mihWT95q1y9do1OXP2nPy1c68UKfyEmfXX3/+W69dvmH59W/yatZtMv95SX6LInbfHzxzfXzatnm9S84Y1pUHtKtKhxZsmHx0EEEAAAd8UoFYIIIAAAggggIDdBHw+QG/dbahEljwBz5XzAaleuaw0addfOvQaJR1bNZCkSZKYWbsNeEfOnb9g+ju0qCcrVq8zP7N24OBRqVezshlPBwEEEEAAgVACDCKAAAIIIIAAAnEuEBTnJcZxgV8umSaRJU8XV6taBZk/bbjMmzpUShd7xjXb10tnSMYM6cywfk4d08f8zNqwvu0lRfLkZrx75626VaVl49ruo+hHAAEEEEAgjgUoDgEEEEAAAQQCUcDnA/RAXCm0GQEEEEAAgXgVoHAEEEAAAQQQ8EkBAnSfXC1UCgEEEEAAAfsKUHMEEEAAAQQQiJkAAXrM3JgLAQQQQAABBBJGgKUigAACCCDgtwIE6H67amkYAggggAACCERfgDkQQAABBBBIOAGfD9Anz1ookaWEo2PJCCCAAAIIIIBANAXIjgACCCCAQCQCPh+gp06VUiJLkbSNSQgggAACCCCAQEAJ0FgEEEAAAXsL+HyA3qhOVYks2Zuf2iOAAAIIIIAAArYRoKIIIIAAAvEs4PMBunv7t+/YI3MXfiYz5i5xJffp9COAAAIIIIAAAgjYVYB6I4AAAgjYJkCfvWC5jJo4W5av/FZOnzlnfX4nBw8fZw0igAACCCCAAAIIIBC1ADkQQAABGwjYJkD/8pv18t7EgZIlUwbp2bGpLJ03Xq5cvWoDYqqIAAIIIIAAAggg4O8CtA8BBBCICwHbBOgpU6aUxIkTy7Xr1+XmrVuSPFlSCXI44sKAMhBAAAEEEEAAAQQQ8GUB6oYAAgEiYJsAPVWK5HL9+g3JnSuHDBkzQybNWCBXr90IkNVEMxFAAAEEEEAAAQQQiC8BykUAAV8RsE2A3rl1I3P1vGPL+pIzWxZJZl1B792pqa84Ug8EEEAAAQQQQAABBBAIT4BxCCDgsYBtAvQ8D2aXVClTSOpUKaVx/erSvGFNyZQxvccNJSMCCCCAAAIIIIAAAgj4nwAtQsCfBGwToB88fEymzv5I2nYfLi06D3Ylf1oZtAUBBBBAAAEEEEAAAQR8SoDKIOBVAdsE6EPGzpD7708j9WtVlibWFXRn8qoWC0MAAQQQQAABBBBAAAEE4kyAghAIKWCbAD3Nfamkbo2KUuSZJ+XZpx93pZDNYQgBBBBAAAEEEEAAAQQQQMAI0LGdgG0C9KRJksi+A0dsB0yFEUAAAQQQQAABBBBAAAF/FKBNcS9gmwB97/7DUqdZN3mzZS/X8+f6LHrck1AiAggggAACCCCAAAIIIIBAAgsE5OJtE6B3avWmTBzRQ9o1r8sz6AG5qdJoBBBAAAEEEEAAAQQQQCCuBHyzHNsE6O7Pnbv3+yYrtUIAAQQQQAABBBBAAAEEEAhYgRg23DYB+vYdu6VL3zFSqXYrk7r2Hyvbd+yJYbOZDQEEEEAAAQQQQAABBBBAAAHfEvA0QE/wWg8dN1Ny5XxA3h3V26Sc2bPK8PGzErxeVAABBBBAAAEEEEAAAQQQQACBuBDwkQA96qbcvn1b2javJ7lzZTepndV/7dq1qGckBwIIIIAAAggggAACCCCAAAI2ELBNgH7r1i05G3zeRXrq9FlXf5Q9ZEAAAQQQQAABBBBAAAEEEEDAxwVsE6DXqVFJajfp6vqJtbrNe0j9mq/4BC+VQAABBBBAAAEEEEAAAQQQQCC2ArYJ0KtVKiOzJw2UcqWLmDR70iB5teKLsW2/HeanjggggAACCCCAAAIIIIAAAgEgYJsAXddFjmxZ5fVXXzIpR7YsOooUawEKQAABBBBAAAEEEEAAAQQQ8AUBnw/Qn69QX/74a5foZ3jJFxCpQyQCTEIAAQQQQAABBBBAAAEEEPBIwOcD9E2r58sTj+YX/QwvedRKMvmtAA1DAAEEEEAAAQQQQAABBPxFwOcDdCf02HfnOXtdn4PHzHD104NAPAhQJAIIIIAAAggggAACCCDgNQHbBOi79u4Pg/LXjl1hxjECAfsIUFMEEEAAAQQQQAABBBBA4J6Azwfon3251s0T6aYAABAASURBVPy02u69B8xni86DzWfDVr0lz4M577WEPgQQCCnAEAIIIIAAAggggAACCNhKwOcD9EJPPiJN6leXrJkzmk/t1zS8X3sZ2qedrbCpLAL+JEBbEEAAAQQQQAABBBBAIG4FfD5A159Te/bpx2X+9OGin86ULWvmuJWgNAQQ8CUB6oIAAggggAACCCCAQMAJ+HyA7lwjTdr1l+Bz552DcvpssDRtP8A1TA8CCCDguQA5EUAAAQQQQAABBBDwPQHbBOiXLl+RtPencQlmSJdWLly86BqmBwEEEPAZASqCAAIIIIAAAggggEAMBGwToF+9ek0OHTnuauKhI8fkxo1brmF6EEAAgUARoJ0IIIAAAggggAAC/ilgmwC9wRtVpEOvkTJj7hKTOvQaJY3qvuqfa4VWIYAAAgknwJIRQAABBBBAAAEEEkjANgF6tUplZNyQbnLh4mWTxg/rLlUqvJBAbCwWAQQQQCBmAsyFAAIIIIAAAgggEJGAbQJ0bcD/cmSVzq0bmKRvd9dxJAQQQAABBFwC9CCAAAIIIIAAAjYWsE2Ars+ct+sxQmq+1dlw79z1r0ybs9j000EAAQQQQMAbAiwDAQQQQAABBBCITwHbBOgDR02XSuVLiL69XUEeyvegbNj0q/aSEEAAAQQQ8AcB2oAAAggggAACAS5gmwD92rVr8nLZEiIOMf8cDofcus1b3A0GHQQQQAABBKIUIAMCCCCAAAII+LqAbQL027dFbty44fI8dfqsJEmc2DVMDwIIIIAAAggkoACLRgABBBBAAIFYC9gmQK9dvYL0G/6uHD9xWqbPWSLNOg6UBrX5mbVYbwEUgAACCCCAgA0EqCICCCCAAAKBIGCbAL3yS6WkTbM6Uqbks3L+wn8yYVgPKVu6SCCsI9qIAAIIIIAAAvErQOkIIIAAAgj4hIBtAnTVypY1s7RtXk9qVqsgP2/7U65dv66jSQgggAACCCCAgA8LUDUEEEAAAQQ8E7BNgN6oTV+5+N8lOXTkuHTsNVI2/rhNho6d6VkrrVyLl6+W+i16SoOWvWXdpq3WmLD/63PtbboNk8Zt+0mvwRPk8pUrJtP2HXuk/GvN5fkK9aVhq96yas0GM54OAggggAACCCCQ4AJUAAEEEEDAbwRsE6DL7duSOlVK2fzzb1Ll5RdkzOAu8s+efR6tiP0Hj8q8RStk+rh+MmpARyuwnyFXrl4LM++E6QukaOGnZPakQZImzX2yYMlKkydn9iyydN47smHVPOnSppFMmD7fFbybDHQQQAABBBBAAAE/FaBZCCCAAALeE7BNgH7r1m0TVP/y21/yWIG8RijI4Vn1N2zeKqWLF5ZUKVNI1iwZpUD+3LJl658S+t8P1lX5yi+VNKMrly8pG3781fSnuS+13Jc6lSQKCpL7rcDdYS1X62Mm0kEAAQQQQAABBBCIqQDzIYAAAgi4CXgW4brNkFC9GmDXa95DDh05Ic889YgcP3lakidP5lF1Tp4+I9myZnLlzZEti5w4ddo1rD3/XbosDodIurRpdFD0qvnJU2dMv3Z+/f1vc4t7nWbdZGiftibY1/EkBBBAAAEEEEAAAV8VoF4IIICAvQRsE6A3qV9dPpk7Tj6YOkwSJ04syZImkd6dm3ms7bCufjszOxxWJO4ccPsMCpEnJM3TTz5ibnF/b+JAGT1xtpw5e87MeeXKFfFmMgulgwACCSJw9eoVcU9Xrly29n//SQmCykIRQMAIuB9bYtLvq8ejGzdumPb5bYeGIWATAd0XvRWz2ITEZ6sZMgr12WqGrFjfYZMl7f1pJE+uHCEnRDCUKUN6CQ6+E1BrljNngyVzxgza60p6+/vNm7dcb4Y/beXJlDG9a7r2JAoKMrfHZ8mcUXbuvvP8e5IkicWbSetBQgCBhBFIlCixJHJLSZIksfZ//0kJo8pSEUBABdyPLTHp99XjUaJEtvyqqavEJxKVQCCuBHRfTOKluCWu6hyo5djyqLlj17/RWl8lihaS9Zu3ytVr18yV77927pUihZ8wZeit69ev3zm7W+y5grJm7SYz/qvvNkqJIgVN/+69B+TS5TtvdD905Jjs3X9Y8uf5n5kWkz+isZnHLJQOAggkiIDeveOeYrMv++K8CYLKQhFAwAi4H1ti0u+LxxStk8Nhy6+aZp0EQIcmBpCA7ou6T3ojBRBrvDQ1II6auXI+INUrl5Um7fpLh16jpGOrBpLUuvKlot0GvCPnzl/QXunQop6sWL3O/MzagYNHpV7Nymb84WMnpWq9duYZ9LrNe8gbr1WUjBnSmWl0EEAAAQQQQAABBBBAILQAwwggEBOBoJjMlNDz9OvaItpVqFWtgsyfNlzmTR0qpYs945r/66UzXMG2Bt1Tx/QxP7M2rG97SZE8ucmn+TXfptXzZd3nc6RujYpmPB0EEEAAAQQQQAABBBBIAAEWiYCfCtgmQP9nz365fOXObeYHDh2VPkMni95u7qfrhWYhgAACCCCAAAIIIIBAAgmwWAQSSsA2Afqg0dPMy5i279gjHy1bLY88lFuGjJ2ZUG4sFwEEEEAAAQQQQAABBBCIiQDzIBChgG0C9CSJE0viRInkp61/SpWXS5vnwy/+dynChjEBAQQQQAABBBBAAAEEEAg8AVpsZwHbBOi3LeV9B47Ipi3b5IlH81tDIjdv3jSfdBBAAAEEEEAAAQQQQAABBLwgwCLiVcA2AfpbdarKiAnvyUN5H5QC+XOLPpOeKUP6eMWhcAQQQAABBBBAAAEEEEAAAe8JBPqSbBOgly5eWKaN7Std2jQ06+yhvLlk4ogepp8OAggggAACCCCAAAIIIIAAAlEI+Pxk2wTon325VvSZ8xs3b8rg0dOlSp028sNP23wemAoigAACCCCAAAIIIIAAAggEgkDs22ibAH3xstWSOlVK+fHnP6xA/T8ZPaizTJ39UewFKAEBBBBAAAEEEEAAAQQQQAABHxCINED3gfq5qpAsWVLTv/X3v6RUscLmOXSHw2HG0UEAAQQQQAABBBBAAAEEEEDA7gIJGaBHyy5JksSydMUaWbfxFyn01COit7rfuHEjWmWQGQEEEEAAAQQQQAABBBBAAAFfFbBNgN6jfRM5deastGhUSx7Ikkn2HzwiJYsWisSVSQgggAACCCCAAAIIIIAAAgjYR8A2AfqD/8smzRvWlLKlixjdvA/mlFZN3jD9CdJhoQgggAACCCCAAAIIIIAAAgjEoYBtAvTtO3ZLl75jpFLtViZ17T9Wtu/YE4cUvlUUtUEAAQQQQAABBBBAAAEEEAgsAdsE6EPHzZRcOR+Qd0f1Niln9qwyfPyswFpbcddaSkIAAQQQQAABBBBAAAEEEPAxAdsE6Ldv35a2zetJ7lzZTWpn9V+7ds3HOKnOHQG6CCCAAAIIIIAAAggggAAC0RWwTYB+69YtORt83tW+U6fPuvrpCTABmosAAggggAACCCCAAAII+KGAbQL0OjUqSe0mXaVF58Em1W3eQ+rXfMUPVwlNSmgBlo8AAggggAACCCCAAAIIJISALQJ0/c1zfWv77EkDpVzpIibNnjRIXq34YkKYsUwEYiPAvAgggAACCCCAAAIIIIBAuAK2CNATJ0okM+d9IjmyZZXXX33JpBzZsoTbIEYiENgCtB4BBBBAAAEEEEAAAQTsKmCLAF1xkyVLIjt3/au9JAQQSCgBlosAAggggAACCCCAAALxJmCbAP3w0RPSqE1fqdO0q3kG3fkserzJUDACCHhdgAUigAACCCCAAAIIIBDIArYJ0Du2fFMmjughnVo3lCb1q7tSIK882o4AAtESIDMCCCCAAAIIIIAAAj4tYJsA/dmnH5fwkk/rUjkEEAggAZqKAAIIIIAAAggggEDsBGwToDdp11+Cz513tfb02WBp2n6Aa5geBBBAwK8FaBwCCCCAAAIIIICA3wvYJkC/dPmKpL0/jWuFZEiXVi5cvOgapgcBBBBAIOYCzIkAAggggAACCCCQ8AK2CdCvXr0mh44cd4kdOnJMbty45RqmBwEEEEDAZwWoGAIIIIAAAggggIAHArYJ0Bu8UUU69BopM+YuMalDr1HSqO6rHjSRLAgggAAC/i1A6xBAAAEEEEAAAf8QsE2AXq1SGRk3pJtcuHjZpPHDukuVCi/4x1qgFQgggAACvitAzRBAAAEEEEAAAS8J2CZAV4//5cgqnVs3MClHtiw6ioQAAggggICtBag8AggggAACCCDgFLBVgO6sNJ8IIIAAAggg4JEAmRBAAAEEEEDARgIE6DZaWVQVAQQQQAAB3xKgNggggAACCCAQlwIE6HGpSVkIIIAAAgggEHcClIQAAggggECACdgmQB/77rwwq2bwmBlhxjECAQQQQAABBBDwRIA8CCCAAAII+JqAbQL0XXv3h7H7a8euMOMYgQACCCCAAAII+IAAVUAAAQQQQCDaAj4foH/25Vpp0Xmw7N57wHxqv6aGrXpLngdzRrvBzIAAAggggAACCNhfgBYggAACCPijgM8H6IWefESa1K8uWTNnNJ/ar2l4v/YytE87f1wntAkBBBBAAAEEEEhYAZaOAAIIIJAgAj4foOfIlkWeffpxmT99uPnUfk3ZsmZOEDAWigACCCCAAAIIIBA7AeZGAAEEEAhfwOcDdGe1Dx4+JlNnfyRtuw8Pcau7czqfCCCAAAIIIIAAAgiICAgIIICAbQVsE6APGTtD7r8/jdSvVTnEre62lafiCCCAAAIIIIAAAjYUoMoIIIBA/AnYJkBPc18qqVujohR55skQt7rHHw0lI4AAAggggAACCCDgZQEWhwACAS1gmwA9aZIksu/AkYBeWTQeAQQQQAABBBBAAIHYCDAvAgj4toBtAvS9+w9LnWbd5M2WvXgG3be3KWqHAAIIIIAAAgggEJgCtBoBBGIpYJsAvVOrN2XiiB7SrnldnkGP5UpndgQQQAABBBBAAAEE7CdAjRHwfwHbBOj602rhJf9fRbQQAQQQQAABBBBAAAEE4l2ABSDgAwI+H6C36DxY9uw7GOK2dh3nTD5gSBUQQAABBBBAAAEEEEAAgUgFmIiAJwI+H6A3qV9dsmTKEOK2dh3nTJ40kjwIIIAAAggggAACCCCAgB8L0DQ/EfD5AF1va0+dKmWIn1bTcc7kJ+uBZiCAAAIIIIAAAggggAACPipAtbwl4PMBuhNi+47d0qXvGKlUu5VJXfuPle079jgn84kAAggggAACCCCAAAIIIGBHAersErBNgD503EzJlfMBeXdUb5NyZs8qw8fPcjWEHgQQQAABBBBAAAEEEEAAAQRCC9hp2DYB+u3bt6Vt83qSO1d2k9pZ/deuXfPYevHy1VK/RU9p0LK3rNu0Ndz5Tp0+K226DZPGbftJr8ET5PKVKybfr7//LT0GjZdy1ZtJ0/YD5PuNv5jxdBBAAAEEEEAAAQQQQAABBAJaIE4bb5sA/datW3I2+Lyr8RpMuwai6Nl/8KjZl8qiAAAQAElEQVTMW7RCpo/rJ6MGdJShY2fIlathg/sJ0xdI0cJPyexJgyRNmvtkwZKVpuSUKZJLlzaNZPUn06XhG6+a+c0EOggggAACCCCAAAIIIIAAAgjEkUDYAD2OCo7rYurUqCS1m3R1/dxa3eY9pH7NVzxazIbNW6V08cKSKmUKyZoloxTIn1u2bP1TQv/74cdtUvmlkmZ05fIlZcOPv5r+h638GdOnlURBQVKi6NNy/fp119V1k4EOAggggAACCCCAAAIIIIAAArEU8HqAHtP6VqtUxrqyPVDKlS5ikl7lfrXiix4Vd/L0GcmWNZMrb45sWeTEqdOuYe3579JlcThE0qVNo4OSM3sWOXnqjOl37yz7/BvJlyeXpEie3H00/QgggAACCCCAAAIIIIAAAgjESsA2Abq2MvsDWaTQk4+ZpEG2jguVIhx0WFe/nRMdDisSdw64fQaFyBOW5vft/8iCj1dKv65vu+b677+L4s3kWjA9CCDgdQFv7usJsSyvg7JABBBwCSTEPu+NZV6/HvaRQlej6UEAAa8J6L7ojX1el+G1RvnpgsJGoT7a0JVfr5MqddrKgJFTpOfgd6TyG61l1ZoNHtU2U4b0Ehx8zpX3zNlgyZwxg2tYe/T295s3b8m169d1UE5beTJlTG/6taNX0yfPWiiTR/W0rq5n1VEmpUqVWryZzELpIIBAggikSpXK2t/dk3f3//g+1iQIKgtFAAEjEN/7d0KVnyRJUtM+OgggkLACui966ziQsC21/9JtE6B/umqtfDJvnMybOlQ+em+MzJ0yVN7/cJlHa6BE0UKyfvNWuXrtmpw5e07+2rlXihR+wsyrb2i/fv2G6S/2XEFZs3aT6f/qu41SokhB068vpOs9dJL06thMHshy71Z5MzEuO5SFAAI+LqB337gnH68u1UMAAQQQQAABBBCwlYBtAvR0998nyZLeOwtrXtqWKLFH2Pr76dUrl5Um7fpLh16jpGOrBpI0SRIzb7cB78i58xdMf4cW9WTF6nXmZ9YOHDwq9WpWNuOXfPqV/PHXLqnTrJs8X6G+ScdOnDLT7NShrggggAACCCCAAAIIIIAAAr4rEOS7VQtZs/vvTyMLlnwhJ06dkT37DsrEGQuk2HNPhcwUyVCtahVk/rTh5gp86WLPuHJ+vXSGZMyQzgzr59QxfURfQDesb3vXi+BaNq4tm1bPD5GyZs5o5qHjEqAHAQQQQAABBBBAAAEEEEAgFgK2CdA/W/WdTJ61UKrWayf13+4pCz9ZJR9+vNJczdar2rEwYFZbCFBJBBBAAAEEEEAAAQQQQMC/BWwToIe+gh162L9XE62LdwEWgAACCCCAAAIIIIAAAggksIBtAnS9Yh7aatYHn4QexTACPilApRBAAAEEEEAAAQQQQACBqARsE6Cv2/SLfP/Dz672zFn4qfy+fZdrmB4EAliApiOAAAIIIIAAAggggIAfCNgmQB/Rr4PMmPux/P3PXvPs+caftsnoQZ38YBXQBAR8XYD6IYAAAggggAACCCCAgDcEbBOg358mtYzo30H6Dpss32/8WSYM7x7iZ9e8gcUyEEAgHgQoEgEEEEAAAQQQQAABBIyAzwfoLToPFmcaOm6m3Lx5S65evSYde482400r6CCAAAIRCDAaAQQQQAABBBBAAAG7CPh8gN6kfnVxT706NZXWTd9wjbMLNPVEAAG/FKBRCCCAAAIIIIAAAgjEmYDPB+jPPv24RJbiTIKCEEAAAZ8ToEIIIIAAAggggAACgSTg8wG6c2U0addfgs+ddw7K6bPB0rT9ANcwPQgggAAC0RQgOwIIIIAAAggggIBPCdgmQL90+YqkvT+NCy9DurRy4eJF1zA9CCCAAAK+JUBtEEAAAQQQQAABBKInYJsAXV8Md+jIcVfrDh05Jjdu3HIN04MAAgggEFACNBYBBBBAAAEEEPA7AdsE6A3eqCIdeo2UGXOXmNSh1yhpVPdVv1shNAgBBBBAwBcEqAMCCCCAAAIIIOB9AdsE6NUqlZFxQ7rJhYuXTRo/rLtUqfCC98VYIgIIIIAAArEVYH4EEEAAAQQQQCAcAdsE6Fr3LJnTS6XyJaRz6waSI1sWHUVCAAEEEEAAgVACDCKAAAIIIICAPQVsE6Bv/GmbVKvXXvqPeNdI79j1r7nl3QzQQQABBBBAAAFvCbAcBBBAAAEEEIgnAdsE6JNnLZSZEwZI+nRpDUWB/Lnl5Kmzpp8OAggggAACCPiLAO1AAAEEEEAgcAVsE6AnSZw4zG3tt+V24K45Wo4AAggggAAC0RdgDgQQQAABBHxYwD4BepLEcubsORfl1t//dl1Nd42kBwEEEEAAAQQQSEABFo0AAggggEBsBGwToHdp00gGjZ4mu/cekBadBsuI8bOkXfO6sWk78yKAAAIIIIAAAnYSoK4IIIAAAn4uYJsAXZ85Hzekqwzo3kpqVisvC2eNlofy5vLz1UPzEEAAAQQQQAABbwmwHAQQQACBhBawTYCuUEFBQVKi6NNStlRRSRRkq6pr9UkIIIAAAggggEDgCtByBBBAAIEoBWwT5W7Y/Ks06zBQSlZqKM9XqO9KUbaQDAgggAACCCCAAAJ+L0ADEUAAAX8QsE2APm7KPHm70evy7afvyabV813JH1YCbUAAAQQQQAABBBDwaQEqhwACCHhFwDYBepr7Uknhgo9JkiSJvQLDQhBAAAEEEEAAAQQQ8I4AS0EAAQTuCNgmQC/89GMyZ+GnEnz+wp2a00UAAQQQQAABBBBAAIGoBciBAAK2EfD5AN35vPmCJV/I9DlLpGLNlq7nz3WabaSpKAIIIIAAAggggAACfihAkxBAIO4EfD5Ad3/ePLz+uKOgJAQQQAABBBBAAAEEEPAxAaqDQEAJ+HyA7lwbe/49KP9duuwclIv/XZI9+w66hulBAAEEEEAAAQQQQAABBKInQG4EfEvANgF6/xFTJGmSJC49fVlc/+FTXMP0IIAAAggggAACCCCAAAI+JUBlEIimgG0C9Bs3b4R4g3uypEnl6rVr0Wwu2RFAAAEEEEAAAQQQQAAB/xCgFf4nYJsA3eFwyI+//O5aA5u2/BbiirprAj0IIIAAAggggAACCCCAAAKxFWD+BBCwTYDep3NzGfvuXGnRebBJ46d9IL07N0sAMhaJAAIIIIAAAggggAACCCAQOwHmDk/ANgH6YwXyycJZo6VWtQomLZw5Sh59OG94bWIcAggggAACCCCAAAIIIIBAIAvYtO22CdDVN1FQkJQp+ZwcP3Fagqx+HUdCAAEEEEAAAQQQQAABBBBAwJsC8bUsWwXoToSln69x9vKJAAIIIIAAAggggAACCCCAgF8I3A3Q/aItNAIBBBBAAAEEEEAAAQQQQAAB2wp4J0CPY57XXikXxyVSHAIIIIAAAggggAACCCCAAAIJK2CbAH3r73+7pOrUqGj69afWtIeEAAIIIIAAAggggAACCCCAgN0FbBOgj540R/YdPOry/mnrH/LO1Hmu4XjsoWgEEEAAAQQQQAABBBBAAAEE4l3ANgH6wB6tpOfAcXI2+Lz8al1NHzN5jowb0i3egeJ/ASwBAQQQQAABBBBAAAEEEEAAARHbBOgP5c0lbZrXkw69RsrQcTNl9MAukiNbFtZhVAJMRwABBBBAAAEEEEAAAQQQsIWAzwfoM+YuEWfa/vcuuXX7tjycP7es/naDGW8LZT+uJE1DAAEEEEAAAQQQQAABBBCIGwGfD9BDN7Nk0aclV46soUcz7J8CtAoBBBBAAAEEEEAAAQQQCBgBnw/QmzesKZGlgFlTNDQeBCgSAQQQQAABBBBAAAEEEPAdAZ8P0N2ptu/YI3MXfmZubXfe9u4+nX4EfEqAyiCAAAIIIIAAAggggAAC0RCwTYA+e8FyGTVxtixf+a2cPnPO+vxODh4+Ho2mkhUB/xKgNQgggAACCCCAAAIIIOBfArYJ0L/8Zr28N3GgZMmUQXp2bCpL542XK1ev+tfaoDUI+I4ANUEAAQQQQAABBBBAAAEvC9gmQE+ZMqUkTpxYrl2/Ljdv3ZLkyZJKkMPhZS4WhwACcSNAKQgggAACCCCAAAIIIBBawDYBeqoUyeX69RuSO1cOGTJmhkyasUCuXrsRuj0RDi9evlrqt+gpDVr2lnWbtoab79Tps9Km2zBp3Laf9Bo8QS5fuWLynQ0+L136jpEXqzaRURPfN+PoIICADwtQNQQQQAABBBBAAAEEbChgmwC9c+tG5up5x5b1JWe2LJLMuoLeu1NTj8j3Hzwq8xatkOnj+smoAR1l6NgZcuXqtTDzTpi+QIoWfkpmTxokadLcJwuWrHTlqfRSKWn2Zg3XMD0IIBC4ArQcAQQQQAABBBBAAIH4ELBNgJ7nweySOHEiOXj4mDSuX130p9cyZUzvkcmGzVuldPHCkiplCsmaJaMUyJ9btmz9U0L/++HHbVL5pZJmdOXyJWXDj7+a/nRp00iZks9JihTJzDAdBBBAIB4FKBoBBBBAAAEEEEAgQAVsE6Bv/GmbVKvXXvqPeNesqh27/pUOvUaa/qg6J0+fkWxZM7my5bCuwJ84ddo1rD3/Xbos+ki7BuM6nDN7Fjl56oz2Rppu3rwp3kyRVoaJCCAQrwK3bt0U9+TNfT/ulhXxMSte8SgcAQQiFXA/tsSk3xvHiJgs4/bt25G2m4kIIOAdAd0XY7IPx2Qe77TIf5dimwB98qyFMnPCAEmfLq1ZG3oV/OSps6bfk44j6F5THY7wXy4XFCLPvfyRlX/9+jXxZoqsLkxDAIH4Fbh69aq4J2/u+95YVpzoUQgCCMRI4OrVa9bxJebJG8eImCxDv9zHCISZEEAgTgV0X4zJPhyTeeK04gFYmGdRqA/AJEmcWPTKt3tVbotnZ2UzZUgvwcHnXLOeORssmTNmcA1rj97+fvPmLfOcuw6ftvJ4cgt98uQpxJtJ60ZCAIGEEUiRIqW4J2/u+95YVsKoRm+p5EbAXwVSpEhhHV9inrxxjIjJMvQXePx1ndEuBOwkoPtiTPbhmMxjJxdfrKt9AvQkieXM2XtB9tbf/3ZdTY8KtkTRQrJ+81a5eu2aKeOvnXulSOEnzGy/WuXo2+F1oNhzBWXN2k3aK199t1FKFClo+ukggAACCASEAI1EAAEEEEAAAQQSVMA2AXqXNo1k0OhpsnvvAWnRabCMGD9L2jWv6xFerpwPSPXKZaVJu/7Sodco6diqgSRNksTM223AO3Lu/AXT36FFPVmxep35mbUDB49KvZqVzfgbN2/K8xXqm59YW/bFN6Z/565/zTQ6CCCAAAIIeCZALgQQQAABBBBAIHKBoMgn+85UfeZ83JCuMqB7K6lZrbwsnDVaHsqby+MK1qpWQeZPGy7zpg6V0sWecc339dIZkjFDOjOsn1PH9DE/szasb3tJkTy5GZ84USLZtHp+iPRw/txmGh0EEEAAAQR8QoBKIIAAAggggIDtBXw+QN+7hNk+/AAAEABJREFU77C06jpUXqzaRDr1GS15HswuZUsVlURBPl91228cNAABBBBAAAGnAJ8IIIAAAgggEP8CPh/lDhk7XZ54NJ8M7NFa/pcjq4yaOCf+VVgCAggggAACCHhTgGUhgAACCCCAgCXg8wH6+QsXpeVbtaXU84WkY8sG8u/+Q1a1+R8BBBBAAAEEEPBUgHwIIIAAAgjYQ8DnA3R3RofDIUHc2i78QwABBBBAAAEfEqAqCCCAAAIIxJGAzwfoh4+eMG9N17eoazp24lSI4ThyoBgEEEAAAQQQQMAnBagUAggggEDgCPh8gD5xRA+JLAXOqqKlCCCAAAIIIIBAnAtQIAIIIICADwn4fID+7NOPS2TJhyypCgIIIIAAAggggEAIAQYQQAABBKIj4PMBenQaQ14EEEAAAQQQQACBABKgqQgggICfCRCg+9kKpTkIIIAAAggggAACcSNAKQgggIC3BQjQvS3O8hBAAAEEEEAAAQQQEMEAAQQQCCNAgB6GhBEIIIAAAggggAACCNhdgPojgIAdBQjQ7bjWqDMCCCCAAAIIIIAAAgkpwLIRQCBeBAjQ44WVQhFAAAEEEEAAAQQQQCCmAsyHQKAKEKAH6pqn3QgggAACCCCAAAIIBKYArUbAZwUI0H121VAxBBBAAAEEEEAAAQQQsJ8ANUYg5gIE6DG3Y04EEEAAAQQQQAABBBBAwLsCLM2vBQjQ/Xr10jgEEEAAAQQQQAABBBBAwHMBciasAAF6wvqzdAQQQAABBBBAAAEEEEAgUARoZxQCBOhRADEZAQQQQAABBBBAAAEEEEDADgL2ryMBuv3XIS1AAAEEEEAAAQQQQAABBBCIbwEvlE+A7gVkFoEAAggggAACCCCAAAIIIIBAZAI6jQBdFUgIIIAAAggggAACCCCAAAIIJLBAPAboCdwyFo8AAggggAACCCCAAAIIIICAjQTsG6DbCJmqIoAAAggggAACCCCAAAIIIBCVAAF6BEKMRgABBBBAAAEEEEAAAQQQQMCbAgTo3tS+tyz6EEAAAQQQQAABBBBAAAEEEAghQIAegsNfBmgHAggggAACCCCAAAIIIICA3QQI0O22xnyhvtQBAQQQQAABBBBAAAEEEEAgzgUI0OOclAJjK8D8CCCAAAIIIIAAAggggEAgChCgB+JaD+w203oEEEAAAQQQQAABBBBAwCcFCNB9crVQKfsKUHMEEEAAAQQQQAABBBBAIGYCBOgxc2MuBBJGgKUigAACCCCAAAIIIICA3woQoPvtqqVhCERfgDkQQAABBBBAAAEEEEAg4QQI0BPOniUjEGgCtBcBBBBAAAEEEEAAAQQiESBAjwSHSQggYCcB6ooAAggggAACCCCAgL0FCNDtvf6oPQIIeEuA5SCAAAIIIIAAAgggEM8CBOjxDEzxCCCAgCcC5EEAAQQQQAABBBBAgACdbQABBBDwfwFaiAACCCCAAAIIIGADAQJ0G6wkqogAAgj4tgC1QwABBBBAAAEEEIgLAQL0uFCkDAQQQACB+BOgZAQQQAABBBBAIEAECNADZEXTTAQQQACB8AUYiwACCCCAAAII+IoAAbqvrAnqgQACCCDgjwK0CQEEEEAAAQQQ8FiAAN1jKjIigAACCCDgawLUBwEEEEAAAQT8SYAA3Z/WJm1BAAEEEEAgLgUoCwEEEEAAAQS8KkCA7lVuFoYAAggggAACTgE+EUAAAQQQQCCkAAF6SA+GEEAAAQQQQMA/BGgFAggggAACthMgQLfdKqPCCCCAAAIIIJDwAtQAAQQQQACBuBcgQI97U0pEAAEEEEAAAQRiJ8DcCCCAAAIBKUCAHpCrnUYjgAACCCCAQCAL0HYEEEAAAd8UIED3cL0sXr5a6rfoKQ1a9pZ1m7Z6OBfZEEAAAQQQQACBgBOgwQgggAACMRQgQPcAbv/BozJv0QqZPq6fjBrQUYaOnSFXrl7zYE6yIIAAAggggAACCMStAKUhgAAC/itAgO7But2weauULl5YUqVMIVmzZJQC+XPLlq1/Cv8QQAABBBBAAAEEPBMolC+FNKuYzvcTdWQd+ck2oPucZ3snuXxJgADdg7Vx8vQZyZY1kytnjmxZ5MSp02b4gw8+EG8ms1A6CCCQIALe3NcTYlkJgspCEUDACCTEPu+NZf7++++mfdp5Jr8G6Omt4C+wU7OKtB8D72wDus/pvqdJ90Vv7PO6DF0eKeYCBOge2jmC7lE5HA7XXDdv3hBvpqGdXhcSBmwDCbMNeHNfT4hl/f1oayFhwDaQMNtAQuzz3ljmoWsFZMvlGiTvGWCNdbjbgO6L3tjndRnCv1gJ3Is6Y1WMf8+cKUN6CQ4+52rkmbPBkjljBjNcr149IWHANsA2wDbANsA2wDbANsA24P/bAOuYdRz1NmCCJDoxFiBA94CuRNFCsn7zVrl67ZqcOXtO/tq5V4oUfsKDOcmCAAIIIIAAAggggAACHgmQCQEEhADdg40gV84HpHrlstKkXX/p0GuUdGzVQJImSeLBnGTxNYFmHQbKmy17SaM2faVllyGy9fe/XVWs/3ZPOXX6rGvY2TPvoxXy4ccrnYOx+tSTPE3b95dbt26J/tu994C07T5c3rpbnzGT58rF/y7J6m9/kLHvztMsYdLyld9KnaZd5fkK9eVs8HnX9N+275TmHQdK8YoNZM33m8X57/KVK9K4bT+5ffu2cxSfCCAQzwLB5y/I4DEzRI8resxp022YfP/Dz2apU2d/JK816CgtOg+Wus27y6SZH8qNmzdd03TfPnb8lBnWznvzl5n9fe++wzoYJnXpN0YOHTlmxms5sz74xPwsqJbfvudI+eHHbWZarcad5fyFi6bfvRPRsePYiVMy/J1ZUrFmS3mjaVeZu/Az12z6t/DkqTOuYXoQQCBmArrP6j7/ztQPXAXo944Zc5eYYT1evP/hp6bf2dH9WPdn57C3Pnfu3icDR02LdHFat9pNupg8367/yRxDzEA8dqJzPIrHalA0AnEmQIDuIWWtahVk/rThMm/qUCld7BkP5yKbLwp0bdNI5kweLOVLF5UJ0+a7qtizY1O5P819ruH46Fnx5VopXfxZCQoKMsG1foGu/kpZed+qz9QxfaTySyUl+NyFSBedJVMGGdSrjWTMkC5EvuTJksnbDV+XF4oXDjE+RfLk8vgjeWXdpq0hxjOAAALxJ9Cl71hJlTKZzJ8+XD6YOkyaNawhO3b961pglZdfkGlj+8rUMX3lp61/3vtlEIdI7lzZ5au1m1x51/6wRbI/kFncXn/imqZB+82btyVHtqxm3My5H8uPv/xpfhZUyx89qJPcuBv8mwzhdCI6duhx6vWq5WXVkqkytE87WfLpV7Ln34OmhKqVXpQFH39h+ukggEDsBJInSyrrrb/RwefunXSPrMSUKVNIv64tIssSL9PmLfpMalrHBE8Lf/qJAlKnRiVPs8c4nw8dj2LcBmZEwF2AAN1dg/6AEnjumSfMIwvORuuVonPWVS8d1rPXNd/qLHrVa6fbl+offtom9Zr3MFeqR06YLXrlSvPrFfHJsxaaq2ENWvaWlV+v09Fh0lffbZJSz985wbN85XdSxKpDmZLPufI98lAe64t2FjN89NgJaddjhOiZ6MXLV5tx2nn+2ackf55c2hsiPZzvQXmm4GMm+A8xwRooaS3zK+uqvNXL/wggEM8Cv2//R46fPC3tmtdzLempxx6WtxvVdA07exIluvNnOGOGtM5R5iSbXnnSEfsPHpUHsmSU5NYJuPBugln93QYpVayQZjV35ixcukp6WScb9WdBdaTe7eV+UnnOwk9F7+JpYV29d14BfziCY0fmjOldx5q8D+aUvLlzypFjJ0X/lSjytHy3fov2khBAIBYCDodDEidOLFUrviiLln3pUUmXLl2WQaOnmbx6x12XvmPM9wXdtz9adu/7gk7TO3jqt+gp70ydJzfv3r2nV+Wr1G1rvl/oHTemIKujV+U1X5vuw+W7DSH370uXr8hf/+yVRx/Oa+UUc2V82LhZ0rrrUGnYqrf86nZHoslgdX79Y4cs/GSl1Rdx/si+P73daZDUadbN3InkvANJ73TU70W9Bk+QVtay9U6fwDkeGUo6ASBw55tBADSUJiIQWkBvb3+hxL3g2Dl97/5D8slnX8vMCQNkeL/25p0DOu3GjRsyZMwM6d25mbk6dfpssI426fOv1snJU2dlzrtDZMqY3rL4069l34EjZpqzc/36DdEv2/rIhI47ePioPGl9adf+8NLR46dkWN921tX1IfLJiq9Fb5kNL58n4zTw/+Pv3Z5kJQ8CCMRS4MCho/LYw3nMl+6IitLbV/W21vKvNZdcObK5AmHNnzp1akmbJrXobe5ffrNByr/wvI4ON/2+fZc8+lAeM01PCugdM3oF3owIp6PTZk0YKC9ZZc5f8nk4OcIfpVfO/7a+nD/xWH6TIUmSxJL2/vvk4OE7t9abkXQQQCDGAnq3yupvN8p/VvAd3UKc3xd03/5m3WbzfUG/b8xZ+JlMGNZd5k0ZKlev3ZAVX641RVcoU0JWfDhJ5k4ZJn/+vUd+2bbdjNdOzuxZZfLInvJiiWd10JX+2rlH8j6YwzWsPTdv3pSJVt4pY/rIeLc7EnVaeCm8/JF9f+reroksnDlK3hnaVfQiyOUrV0yxBw4dk6YNasiU0b0la+aMwvHIsMS+Qwk+I0CA7jOrgop4S+Bt64ysfjGeOH2B1K5eIcxif/tzp7xY8llJm+Y+uS91KilbuojJc/joScmcMZ3o2WOHwyFVK5Ux47Xzy7a/5J89+80Z7C79xpor8zt27dVJrqQBffq0IW+ht4pxTQ/d88RjD0nqVCklZYrkkjtXDjlo/UEKncfTYS3nsnX223n23NP5yIcAAjETCAq69+e195CJ5hnyCq/fuyW1ecOasmn1fPli0bvWF+erol+q3ZdU3gqgV33zg3y/8WfRO2Dcp7n3nzx1RjJZV7qd4yI7pmieYs8V1A956vGHrZOIR01/VB09Odhz8Hjp0+Vtc1x05s+SOYN1Rf2Ec5BPBBCIhYDe9VKxbHH52DrBH91idH/Wv/M6X4b095vvC7/9ucME+72s449eaf7N+m7z144730uuXrtqrqh36jNaDh89Lrv/PaSzmvRCOBcudMKJk6clU4b02utKzz/3lCQKChKte3AUj+fpTOHlj+z7076Dh80z732HvysXLv4nh4/cOd78L0dWyWN9L9IynYnjkVPCdz+pmecC975BeD4PORGwtcD0cf3kq0+mm+e9h46bGW5bEiVK5BqfOPGdfn3FWojxbnkcDoc0rf+aeaZUn/v8bMFEeblsCVcZ2pPYyn/j5i3tNSln9gfkj792mf7wOkkSJ3aNThQUJHoF3zUiBj36grpEQezyMaBjFgSiJfC/HA/IvwcOu17MqM9vr1kW/rEmfbr7pXDBx2Xzz3/cWYYeaG7fltLFC8uyL74xJ+eSJ0t6Z//yJQoAABAASURBVFo43aAgh1y/ccNM0fdTXL58VfYdPGqGw+s4jysOR5DctK5+hZfHfZye1Bs0aqp0bNlASj1/51Z65/Rr165bV654YarTg08EYiKgL3DVpPO+8VpFWfr5Guvv/U1xOBw6yqPk/t0kyNq3zfcFa/6S1j6r30k0LZw5Unp1aip6N1/fYZOlbKmi5sp0hTLF5ZJ1At+5oKRJ7n33cI7TT12G81ijw5rcT0Teso5bOi6yFF5+hyP87096x87CT1bJm7WqyLvWlfJ8uf8nznomSRz2uMPxKDL5gJjmV43k27pfrU4a46mAXhlv1eQN2X/wiGz7Y0eI2Z54JL/oGV19Lkr/aG7ZeufWrxwPZJLTZ4Ll3Pk7b0H+edufrvn0WXK9XVTP8OrIPfsOSnCol71kSJ9WLl68ZJ4T1TzVKr0om7b8JvMWrZBr16/rKNE/SIeOHDf9cdnRZ7Y0aIjLMikLAQTCF3jysYesK0oppZ911UevcGuuy1eu6keYpC9w2/rbdsloHR/cJ+rVsCb1qkn9mpXdR4fp16tIR+8+F65fft947WXpP3yy7Nq73+TVY8v3G38x/dHt6Bf5/sOnSKXypUTffRF6/iPHTkj+PP8LPZphBBCIoUCa+1KL3rWn77HR7x8xLMbMVrjgo7J2wxbXix31V1+c302SJEkiepxKan3q9xAzQxSdvA/mlGMnTkeRK/qTI/r+pN/PHsqXS/I8mF3OW9+7tu/cE2nhHI8i5WFirAW8WwABune9WZoPCSRLmlQa1aka5k3E+awvnGVKFjE/f9apzxjXVTB9iUu39o2l/4h3RX+66Ny5/yR1qlSmRRXLlZBiRQpKy85DzM8R6dnpW7f0UpiZbDoOh8Pcqvr3P/+a4XRp05gr7lt+/VPqNutuXkj3xVfrJe39IW+DN5ndOvpyF71FX4PuSrVbuV5Ut/nn38xttPoTa7r8ctWbueb63bpSH/rt7q6J9CCAQJwLjBncWZJax5i3Ow02Lznq1Hu0dGvXyLWcFV+uNT+zVrVeOzl+6qzUqVHRNc3ZU7VSGdH3RziHw/t8ocSzovu3c1qzhq9bx5lC0mvwRPPToN0HjBe9e8c5PbzPiI4dv1gnDvTW+77W1TY95mjSwEHL0BOQmTNlNI8B6TAJAQTiRuBN64rx8ZNnQhTmfGeF7oOa9MReiAzhDGTLmlk6t24oeqegviiuQaveEhx83jwSo4/q6YvjuvYbKzmy3XkxbThFhBil340uXLjoetFciImxGIjo+1OJooVk+9+75e1Og+SdqR+I810b4S2K41F4KoyzlUCoyhKghwJh0L8FZo7vb84aO1tZq1oFGT2wsxmcP324ZLz702UN3qhibqnSF5PMnjRI6r5eyeQp+PjDMn5Ydyt1k5Qpk8kTj+Yz47XT7M0a5ieVFs0aLR/OGCl666qOd081qpSV1d9ucI3SP3iTRvaUj+eMk8mjekmXNg2toD+l6C1nnVs3cOXTW2SffvIRM9yycW3z7Ko+v6ppzKAuZnzRwk+FGO9+S+03634UfUOsyUgHAQTiXUDfYdG3S3NZOu8d85KjeVOHit5SqgvWfVjH622n+gz6nMmDRa+cOac5jzc67Ex6fMpjXUlyDjs/Xyz53L2faLNGajDe1DoWLXl/rLw3caC5hbW4dfLQmiSLZ491LUfL0mOOjo/o2BF6vB5v9Gq6zqO/SKF3AWk/CQEEYi6g+6z732s9eb/+izmi76nQUvV4ofuee0qf9n6zP+v0yL4vlLGOD/od5oOpw8xL4Z4p+JjOInps0p8OHjO4iwzs0UreqlvVjHc/RpgRoTq6rPUbt5qxPTs2FS3fDFgdfemc9WGOMR+9N0Z7zXTNpwP6GV5+nRbe96fUqVLKnHeHiD6WOKhna/OdTK/66/c0PR7qfM7E8cgpwae/CATFcUMoDgG/Fli09EupWLOl1G3eQy5duipVXn4hWu19OH9u0dvEojVTLDPrLa76Bd39RVKxLJLZEUDARwT0TqA3XqsozlvpvVWtpEmTSLnSRb21OJaDAAI+IPBalXJy+e6b1H2gOq4qcDxyUdDjJwI2C9D9RJ1m2FagSf3qsmrJVOuK2J2XrejzW9FtjN62Gt15YpNf61ipXMnYFMG8CCDgwwIJcQKuWqUyPixC1RBAID4E9IWVekt6fJQdmzI5HsVGj3l9UYAA3X2t0I8AAggggAACCCCAAAIIIIBAAgkQoHsRnkUhgAACCCCAAAIIIIAAAgggEJEAAXpEMvYbT40RQAABBBBAAAEEEEAAAQRsLECAbuOV592qszQEEEAAAQQQQAABBBBAAIH4FCBAj09dyvZcgJwIIIAAAggggAACCCCAQIALEKAH+AYQKM2nnQgggAACCCCAAAIIIICArwsQoPv6GqJ+dhCgjggggAACCCCAAAIIIIBArAUI0GNNSAEIxLcA5SOAAAIIIIAAAggggEAgCBCgB8Japo0IRCbANAQQQAABBBBAAAEEEPAJAQJ0n1gNVAIB/xWgZQgggAACCCCAAAIIIOCZAAG6Z07kQgAB3xSgVggggAACCCCAAAII+I0AAbrfrEoaggACcS9AiQgggAACCCCAAAIIeE+AAN171iwJAQQQCCnAEAIIIIAAAggggAACbgIE6G4Y9CKAAAL+JEBbEEAAAQQQQAABBOwlQIBur/VFbRFAAAFfEaAeCCCAAAIIIIAAAnEsQIAex6AUhwACCCAQFwKUgQACCCCAAAIIBJ4AAXrgrXNajAACCCCAAAIIIIAAAggg4IMCBOg+uFKoEgIIIICAvQWoPQIIIIAAAgggEBMBAvSYqDEPAggggAACCSfAkhFAAAEEEEDATwUI0P10xdIsBBBAAAEEYibAXAgggAACCCCQUAIE6Aklz3IRQAABBBAIRAHajAACCCCAAAIRChCgR0jDBAQQQAABTwQ+WrZanq9QX5av/NaV/fbt21KlThup8HoL1zhPe7b8+qe06TYsyuzvf/ipTJ61MMJ8LbsMkT37DkY4PaoJv2//R5q062+yaX/jtv1Mf+iOp/X9Zdt2+fGXP1yzR1amK1M0e0q/8pZcvXYtmnNFnH3G3CUy64OlEWdI4CmHjhyTLv3GiK7rny1frU5sk25Xk2Z+aIrR/si2Mc104+ZNqdu8uwSfv6CDJAQQQAABBGIlQIAeKz5mRgABBBBwOETy5fmfrPx6vQtDg9a0adOITnON9GKPBsIpUySTvA/mjJOl5nkwh3Rt2yhWZf36x07Z+ttfrjLiokxXYQHao9vcow/nk6lj+kjhgo/FicLLZYtJtUplIiorzPjEiRKZ/PMXfx5mGiMQQAABBBCIrgABenTFyI8AAgggEEYgX+7/yaXLV0SvaOrEL75aL5XKldReV/r+h5+lafv+0qhNX2nfc6T8u/+wa5pepaz5Vmdp1XWorLXyuSZYPYuXr5Y3W/YyqdfgCXL6bLA1NvL/NXArW6qIyaRXlMu/1lzOX7hohrUzftoHMnPex9orfYZONlf732jaVYaOmymXr1wx4907e/cdktGT5rhGRVTfM2fPmXrqFdXaTbrI/MVfmHm0rV98vU5Wf7tRWnQeLEs+/UpCl/ne/GVSv0VPadCytwweM0Mu/nfJzKtXsbXdbboPN37Dx78netXWTIyk89PWP+TtToOkYave5vOvnXtM7ojqqBODz52XnoPHm3q0ttbFvgNHdLRJ6jL23XlSp1l3qde8h7l74datW2aatmnUxPfNnQ+DR08349w72oYeg8ab6Tq/tsd5xfng4WPSY+A7Uv/tnsZu1ZoNrlkjK/ezL9fK59Z2ttJy1Xz/Xboc4brUE0a63TmX85a1De47eFQ69x0tdaz1PmDkVJfpl99sDHE3iFbm2vXrUrFWKzl1+qwOmjRm8lyZvWC56S9XuqjoNm8GYtVhZgQQQACBQBcgQA/0LYD2I4AAAnEkULl8KROkaKC+7Y8d8vxzBV0la2AzYNRU6dSqgcyZPFgKPlFABo2eZqZ/s26zrNv4s7xvjR8/rJvs3nvAjNfODz9tM0HtpJE95YOpw8x8oybM1kmRJl3+k489ZPIkS5pUShUrbII5HaFB5epvN0nVu1dJG7xRRVYsnCzzp48QvRo6f8kXmi3CFFl9U1hX7Yf1aScfzhgpsyYMlG/X/yhbf/9bcufKLupToUwxmTa2r9Ss+lKI8r9d/5O5A2Gy1c7ZkwfJ6TNn5f0Fy1x5jp04LSP6tTdlOhwO+Xbdj65p4fXoSYwhY2dK1zaNZO6Uoca956AJJgiNqI5azsx5SyXIEWSs+3Z529Rd7v7TW91v3rwp86zy5rw7RI5bdVq8/Ku7U8U6sXFVJo7oIX27vu0a596z/+ARGdG/gyycOVIeyJJRZs9faib3HzFFShUvbPkPl0nW/HMWLpedu/eZadq5fCX8cl99+QUpU/JZee2VcsY0VcoUEtm61OW3blpHPpg2TPLmzind+o+RXp2ayXxrXZ2/cCFS06RJklgnnIrLsi++0SpZbb0i33y/WV6rUtYMp093v9yXOkWsHqkwBcV3h/IRQAABBHxegADd51cRFUQAAQTsIVD5pZLy5Tc/yBorcClT6jlxWNW+fdvqWP//tn2XPFYgnzz6cF5rSKRezUomCNOrnr/+vlOqvPyipE6VUjQQqlGlnMmjnc1bfpfgcxesK6zjRa+SfvXdRvn9r906KcJ048YNOXHqjGTNksmV5xWrbnqlVUes27jVBMyZM6bXQXNlfdyUudK+xwj5469dsnPXv2Z8RJ3I6ps8WTL51To5MXDUNOnaf5ycDT4vO/6JvDxdztbf/pZK5UtK2vvTmJMEdWpUkl+scTpN07NPP2Z8tD9r5gxRBoK//fmPXLEC2zHvzjVu70z9QM6dvygHDh2VyOqoJzbq1awsDofD8ssoL5R4Thdp0o8//yF//r1b2vYYbtKuvfvl9+07zTTt6B0LQUERf614rtDjrjaUKVXUctpp7P/+Z698tmqtqWcP6yTCf/9dscr9R4s0KapyTaa7Hb1LIqJ1mSdXDsmZPatp21OPPyR5HswpGdKllURBQda2mT9K05pVK5h66gmeL75aJ88984SkTXPf3SWLZMmUUQ4eOu4aDsQe2owAAgggEHuBiP+Sxr5sSkAAAQQQCAABDcL1pXBp7kstD+fLJdPeXyyvVCgdsuVWpsSJ7v3JSZI4sXWlVkN4kdvWf4kTJXLlT2xNcw44HLetK88lzRVSvfKsV6VXLZ7inBzup87vcDjk2rXrrulPP/mIXLp0RfbuOywr16wzZerE/QePypAxM6RCmeIydkhXaVy/uhXYRv6Stcjq+/lX35srsW/WqiKTR/WSEkULyaXLYW+Z12W7p9BlJk2SWNTUmSeRm12QFVDeuHHTOSncT4fDYa2LB11uard2xWzRIDWyOpp6uPnrenItwFpdnVs3cJW5aNZoGda3vWtysmRJXP2e9iSy1ruurynX6HTZAAAInklEQVSje7vK/XzR5BB3GHhablTrMoll6qxXoqAgcW+bJ6ZZrav+BR7KLXq3wyeffS11alQU9396G3ySpIndR9EftwKUhgACCASEwL1vSwHRXBqJAAIIIBCfAg3rVJW6NSpLXuvqpPty9Irl9h17ZMfdq9MLP1klD+V7UPS25EJPFhC9ld0ZkP7w4zbXrMWeKyjLVn4re/cfMuM0CNJbxs1AJB29hVmfbXbPUvmlUqK3T//6+w4p90JRM0nz5LCuqj5WIJ91ZTmpfBPFreM6U2T13bf/sDzx6EPW1dnsokH0pi332qJ3CARbV7G1jNDpmacelVXfrDdXlPX58oVLV0lh66p56HyeDhd8/GFzh8I33//ommXTlt9Mf2R1fPqJR2TDpq0m340bN+Snrb+bfu0Ut9bF9Lkfy4WL/+mg6G307reim5GRdNZu+Nnc2aDr+aNlX4o66vovkD+3TJyxQPTKtM6+59+DIZ711nGepJisS0/Kdc/z+qvlZcL0BZI8eXLRertPO2Cd7Hn0oTzuo+i3lQCVRQABBHxDgADdN9YDtUAAAQT8QuARK0CpX6tymLZkzJBO+nRubl60pi/o0res6zPOmrFsqaLysHXlvX3PkdKpzyg5eeqMjjapaOGnpIl1VXvQ6OnSqHUfqVy7tfyxfZeZFlnnpReLid427p6nysul5eu1m0SfR9fn0nXac888bm5x1hez6bLT3Z9GR0eaIqtv9VfKyZffbJAWnQbLgJFT5KG8uVxl6W3/Z4PPibZTXxLnmmD1lCn5nJQr/by06jJUGrfpJ/elTi1v1a1mTYnZ/+nSpjHPey/9fI3oy9FertnC9fx0ZHVs1uA12fXvflPHbgPGScoUKVwVeKtedSsofdC0TV9m16hVH9H2uDJE0fPIw3mkc98xUqdZN+vkxQ3R8nSWgT1aWgH5OXmzRS/RFwX2HT5Zbt59+ZxO9zTFZF16WrYzX5FnnjSPYdSsWt45ynzqy/Ty5vmfpLPczQg6CIQWYBgBBBDwUCDIw3xkQwABBBBAIFyB2tUryIDuLcNMy5XzAVn98Z0XwenE0sULy3sTB5qXwU0Y3t08B67jNbVtVte8YGzckG7mU28P1/Ga9Cev5kweLPpisq+XzpCGdV7V0fJW3arSpmkd0x+6o8G4vjXefXzmjOll0+r50rdLc9fopEmSiNZl3tShosvu0qahuTVdM+hL5rS+zv7ZkwZpr0kR1TdHtiyy5P2xMm1cXxnRr4O5Bbzpm6+ZeXT5owZ0MsurWfUl0fLdy9R886cPF62L1lGvuOuMzRvWFE3ar6lB7Sqiy9f+0On7z98X58mHQk8+Iu+O7i1q9+WSaaLL1vyR1VGfgR/et4Opo3roi/u0Xjpf8mRJpV3zerJgxgiZP224ebGenkDRaXoL/bNPP669EaY8ubKbl885b413Pr+dLWtmGdK7jSlX7fQFe1kyZTDlRFVuhxZvSt3XK5m8ka1LrZuWZTJanUrlS8ngXm2svjv/67bkNA3d776NHT95WoKCHFL+hWJ3ZrzbXbF6rbxR/eW7Q3wg4H0BlogAAv4jQIDuP+uSliCAAAII3BXQ4K+OFbgdOXbi7hg+EIidwPsffiotOg+WFm/VFPfn2fVqf8b06aRE0adjtwDmRsB3BagZAgh4UYAA3YvYLAoBBBBAwHsCpYs9I3p11ntLZEkRCegdAJoimm6H8Xplfdm88aKPOLjXN1FQUJgXxrlPpx8BBKISYDoCCLgLEKC7a9CPAAIIIIAAAggggAAC/iNASxCwmQABus1WGNVFAAEEEEAAAQQQQAAB3xCgFgjEtQABelyLUh4CCCCAAAIIIIAAAgggEHsBSghAAQL0AFzpNBkBBBBAAAEEEEAAAQQCXYD2+6IAAbovrhXqhAACCCCAAAIIIIAAAgjYWYC6x0iAAD1GbMyEAAIIIIAAAggggAACCCCQUAL+ulwCdH9ds7QLAQQQQAABBBBAAAEEEEAgJgIJNg8BeoLRs2AEEEAAAQQQQAABBBBAAIHAE4i4xQToEdswBQEEEEAAAQQQQAABBBBAAAGvCcRJgO612rIgBBBAAAEEEEAAAQQQQAABBPxUwA4Bup/S0ywEEEAAAQQQQAABBBBAAAEE7gkQoMs9DPoQQAABBBBAAAEEEEAAAQQQSCgBAvT4lqd8BBBAAAEEEEAAAQQQQAABBDwQIED3AMmXs1A3BBBAAAEEEEAAAQQQQAAB/xAgQPeP9RhfraBcBBBAAAEEEEAAAQQQQAABLwkQoHsJmsWEJ8A4BBBAAAEEEEAAAQQQQAABpwABulOCT/8ToEUIIIAAAggggAACCCCAgI0ECNBttLKoqm8JUBsEEEAAAQQQQAABBBBAIC4FCNDjUpOyEIg7AUpCAAEEEEAAAQQQQACBABMgQA+wFU5zEbgjQBcBBBBAAAEEEEAAAQR8TYAA3dfWCPVBwB8EaAMCCCCAAAIIIIAAAghEW4AAPdpkzIAAAgktwPIRQAABBBBAAAEEEPBHAQJ0f1yrtAkBBGIjwLwIIIAAAggggAACCCSIAAF6grCzUAQQCFwBWo4AAggggAACCCCAQPgCBOjhuzAWAQQQsKcAtUYAAQQQQAABBBCwrQABum1XHRVHAAEEvC/AEhFAAAEEEEAAAQTiT4AAPf5sKRkBBBBAIHoC5EYAAQQQQAABBAJagAA9oFc/jUcAAQQCSYC2IoAAAggggAACvi1AgO7b64faIYAAAgjYRYB6IoAAAggggAACsRQgQI8lILMjgAACCCDgDQGWgQACCCCAAAL+L0CA7v/rmBYigAACCCAQlQDTEUAAAQQQQMAHBAjQfWAlUAUEEEAAAQT8W4DWIYAAAggggIAnAgToniiRBwEEEEAAAQR8V4CaIYAAAggg4CcCBOh+siJpBgIIIIAAAgjEjwClIoAAAggg4C2B/wMAAP//sEO8WQAAAAZJREFUAwC7NsrgzejmawAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_missing = [name for name, phash in baseline_hashes.items() if not phash]\n",
     "if _missing:\n",
@@ -844,13 +13236,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be5dfe30",
+   "id": "1b4b42e1",
    "metadata": {
     "papermill": {
-     "duration": 0.023526,
-     "end_time": "2026-09-07T00:24:08.057281+00:00",
+     "duration": 0.056035,
+     "end_time": "2026-09-08T20:00:06.122635+00:00",
      "exception": false,
-     "start_time": "2026-09-07T00:24:08.033755+00:00",
+     "start_time": "2026-09-08T20:00:06.066600+00:00",
      "status": "completed"
     }
    },
@@ -867,14 +13259,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f58a45aa",
+   "execution_count": 15,
+   "id": "e2ac2f92",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T20:00:06.220038Z",
+     "iopub.status.busy": "2026-09-08T20:00:06.219801Z",
+     "iopub.status.idle": "2026-09-08T20:00:06.227474Z",
+     "shell.execute_reply": "2026-09-08T20:00:06.226915Z"
+    },
+    "papermill": {
+     "duration": 0.052606,
+     "end_time": "2026-09-08T20:00:06.227801+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T20:00:06.175195+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Per-fold validation IC (nlinear @ epoch 15):\n",
+      "shape: (8, 3)\n",
+      "┌─────────┬───────────┬────────────┐\n",
+      "│ fold_id ┆ ic        ┆ n_entities │\n",
+      "│ ---     ┆ ---       ┆ ---        │\n",
+      "│ i64     ┆ f64       ┆ f64        │\n",
+      "╞═════════╪═══════════╪════════════╡\n",
+      "│ 0       ┆ -0.028575 ┆ 90.0       │\n",
+      "│ 1       ┆ 0.020775  ┆ 95.0       │\n",
+      "│ 2       ┆ 0.027741  ┆ 96.0       │\n",
+      "│ 3       ┆ 0.077355  ┆ 97.0       │\n",
+      "│ 4       ┆ -0.001424 ┆ 97.0       │\n",
+      "│ 5       ┆ 0.187522  ┆ 96.0       │\n",
+      "│ 6       ┆ 0.031119  ┆ 97.0       │\n",
+      "│ 7       ┆ 0.035813  ┆ 96.0       │\n",
+      "└─────────┴───────────┴────────────┘\n",
+      "\n",
+      "  Folds with negative IC: 2 of 8\n",
+      "  Peak-IC prediction_hash: 7adc02d71dee\n"
+     ]
+    }
+   ],
    "source": [
     "folds = (\n",
     "    Result.open(study, PEAK_PHASH, include_preview=EXECUTION_TIER == \"preview\")\n",
@@ -891,13 +13322,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c138933c",
+   "id": "e514e5cb",
    "metadata": {
     "papermill": {
-     "duration": 0.023319,
-     "end_time": "2026-09-07T00:24:08.155427+00:00",
+     "duration": 0.036525,
+     "end_time": "2026-09-08T20:00:06.301229+00:00",
      "exception": false,
-     "start_time": "2026-09-07T00:24:08.132108+00:00",
+     "start_time": "2026-09-08T20:00:06.264704+00:00",
      "status": "completed"
     }
    },
@@ -907,10 +13338,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "dc832b54",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 16,
+   "id": "c0dad860",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T20:00:06.380401Z",
+     "iopub.status.busy": "2026-09-08T20:00:06.380099Z",
+     "iopub.status.idle": "2026-09-08T20:00:06.387571Z",
+     "shell.execute_reply": "2026-09-08T20:00:06.386950Z"
+    },
+    "papermill": {
+     "duration": 0.055964,
+     "end_time": "2026-09-08T20:00:06.388463+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T20:00:06.332499+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "- **The simplest sequence model is measured against the flat-feature families on rows all three\n",
+       "  actually share** - 187,668 of them across 1,995 dates, intersected on\n",
+       "  `(symbol, timestamp)` and recomputed rather than assumed comparable. On that common sample the\n",
+       "  peak checkpoint scores **+0.044**, against Ridge **+0.043** and GBM **+0.055**. Its own\n",
+       "  mean daily IC over the whole validation sample is **+0.044** at epoch\n",
+       "  **15**.\n",
+       "- **Coverage is comparable across the checkpoint choice.** All 20 checkpoints cover 1995 validation dates. The guard stays\n",
+       "  necessary either way: a collapsed checkpoint scores on fewer dates and can look better for it.\n",
+       "- **The average is not the whole story.** The peak checkpoint is negative in\n",
+       "  **2 of 8** validation folds. The holdout is not read here; it is\n",
+       "  evaluated once, after the development-stage selection is fixed.\n",
+       "\n",
+       "**Next**: [`11_latent_factors`](11_latent_factors.ipynb) tests whether explicit factor\n",
+       "  structure organizes the cross-section more effectively.\n",
+       "**Book**: Chapter 13, Section 13.8 (Case Study Results).\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_coverage_text = (\n",
     "    f\"All {checkpoints.height} checkpoints cover {FULL_DAYS:.0f} validation dates.\"\n",
@@ -973,6 +13446,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T20:00:19.073524+00:00",
+   "executor": "local-uv",
+   "library_digest": "598ed5ac2330510c972b1aacbd7083bf1725555de6a03f86ee0862e3d1f10b0d",
+   "outputs_digest": "44dc2c954fac5acd4c7d61a212db49f2354b6307aa5b28893a5713aa9f339972",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "931e8cd1afafbb0b774bcd1547a833b3761bbb4c"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 8236.38422,
+   "end_time": "2026-09-08T20:00:09.473267+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/etfs/.10a_dl_nlinear.build.4175269.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/etfs/.10a_dl_nlinear.papermill.4175269.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T17:42:53.089047+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/09_dl_tcn.ipynb
+++ b/case_studies/fx_pairs/09_dl_tcn.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f3127ec4",
+   "id": "659d0881",
    "metadata": {
     "papermill": {
-     "duration": 0.002069,
-     "end_time": "2026-09-06T16:52:21.093616+00:00",
+     "duration": 0.001158,
+     "end_time": "2026-09-08T22:00:50.141383+00:00",
      "exception": false,
-     "start_time": "2026-09-06T16:52:21.091547+00:00",
+     "start_time": "2026-09-08T22:00:50.140225+00:00",
      "status": "completed"
     }
    },
@@ -33,9 +33,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e9b13220",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "5168dd10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:50.143947Z",
+     "iopub.status.busy": "2026-09-08T22:00:50.143775Z",
+     "iopub.status.idle": "2026-09-08T22:00:52.493078Z",
+     "shell.execute_reply": "2026-09-08T22:00:52.492668Z"
+    },
+    "papermill": {
+     "duration": 2.351514,
+     "end_time": "2026-09-08T22:00:52.493749+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:50.142235+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit and catalog the published TCN FX configuration.\"\"\"\n",
@@ -59,9 +73,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "31bd6063",
+   "execution_count": 2,
+   "id": "10646215",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:52.496883Z",
+     "iopub.status.busy": "2026-09-08T22:00:52.496750Z",
+     "iopub.status.idle": "2026-09-08T22:00:52.498873Z",
+     "shell.execute_reply": "2026-09-08T22:00:52.498624Z"
+    },
+    "papermill": {
+     "duration": 0.00473,
+     "end_time": "2026-09-08T22:00:52.499390+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:52.494660+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -91,13 +118,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "844337a0",
+   "id": "8d87216b",
    "metadata": {
     "papermill": {
-     "duration": 0.000712,
-     "end_time": "2026-09-06T16:52:23.932869+00:00",
+     "duration": 0.00061,
+     "end_time": "2026-09-08T22:00:52.500894+00:00",
      "exception": false,
-     "start_time": "2026-09-06T16:52:23.932157+00:00",
+     "start_time": "2026-09-08T22:00:52.500284+00:00",
      "status": "completed"
     }
    },
@@ -112,10 +139,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "74a0526d",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "id": "7155cefc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:52.502641Z",
+     "iopub.status.busy": "2026-09-08T22:00:52.502562Z",
+     "iopub.status.idle": "2026-09-08T22:00:55.353498Z",
+     "shell.execute_reply": "2026-09-08T22:00:55.353021Z"
+    },
+    "papermill": {
+     "duration": 2.852448,
+     "end_time": "2026-09-08T22:00:55.353990+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:52.501542+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Labels: fwd_ret_1d, fwd_ret_5d, fwd_ret_21d\n",
+      "Execution tier: canonical\n",
+      "Device: cuda\n",
+      "Lookback: 60 consecutive daily observations\n",
+      "Eligible validation rows, fwd_ret_1d: 41,260\n",
+      "Eligible validation rows, fwd_ret_5d: 41,180\n",
+      "Eligible validation rows, fwd_ret_21d: 40,860\n",
+      "Configured deep_learning models this notebook does not run, fwd_ret_1d: ['lstm_h64', 'nlinear']\n",
+      "Configured deep_learning models this notebook does not run, fwd_ret_5d: ['lstm_h64', 'nlinear']\n",
+      "Configured deep_learning models this notebook does not run, fwd_ret_21d: ['lstm_h64', 'nlinear']\n"
+     ]
+    }
+   ],
    "source": [
     "set_global_seeds(SEED)\n",
     "# The reductions are read before the study is opened, because which study to open is decided by\n",
@@ -232,13 +290,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2700093",
+   "id": "a50cc75e",
    "metadata": {
     "papermill": {
-     "duration": 0.001537,
-     "end_time": "2026-09-06T16:52:27.608914+00:00",
+     "duration": 0.000656,
+     "end_time": "2026-09-08T22:00:55.355546+00:00",
      "exception": false,
-     "start_time": "2026-09-06T16:52:27.607377+00:00",
+     "start_time": "2026-09-08T22:00:55.354890+00:00",
      "status": "completed"
     }
    },
@@ -251,10 +309,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "710e8e7b",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "610ea98b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:55.357441Z",
+     "iopub.status.busy": "2026-09-08T22:00:55.357347Z",
+     "iopub.status.idle": "2026-09-08T22:00:55.361908Z",
+     "shell.execute_reply": "2026-09-08T22:00:55.361493Z"
+    },
+    "papermill": {
+     "duration": 0.005923,
+     "end_time": "2026-09-08T22:00:55.362153+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:55.356230+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (20, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>kind</th><th>value</th></tr><tr><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;epoch&quot;</td><td>5</td></tr><tr><td>&quot;epoch&quot;</td><td>10</td></tr><tr><td>&quot;epoch&quot;</td><td>15</td></tr><tr><td>&quot;epoch&quot;</td><td>20</td></tr><tr><td>&quot;epoch&quot;</td><td>25</td></tr><tr><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;epoch&quot;</td><td>80</td></tr><tr><td>&quot;epoch&quot;</td><td>85</td></tr><tr><td>&quot;epoch&quot;</td><td>90</td></tr><tr><td>&quot;epoch&quot;</td><td>95</td></tr><tr><td>&quot;epoch&quot;</td><td>100</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (20, 2)\n",
+       "┌───────┬───────┐\n",
+       "│ kind  ┆ value │\n",
+       "│ ---   ┆ ---   │\n",
+       "│ str   ┆ i64   │\n",
+       "╞═══════╪═══════╡\n",
+       "│ epoch ┆ 5     │\n",
+       "│ epoch ┆ 10    │\n",
+       "│ epoch ┆ 15    │\n",
+       "│ epoch ┆ 20    │\n",
+       "│ epoch ┆ 25    │\n",
+       "│ …     ┆ …     │\n",
+       "│ epoch ┆ 80    │\n",
+       "│ epoch ┆ 85    │\n",
+       "│ epoch ┆ 90    │\n",
+       "│ epoch ┆ 95    │\n",
+       "│ epoch ┆ 100   │\n",
+       "└───────┴───────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "checkpoint_schedule = pl.DataFrame(computation[\"checkpoint_schedule\"])\n",
     "input_summary = pl.DataFrame(\n",
@@ -274,13 +384,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4102aeb6",
+   "id": "36eeffdf",
    "metadata": {
     "papermill": {
-     "duration": 0.001337,
-     "end_time": "2026-09-06T16:52:27.624215+00:00",
+     "duration": 0.000658,
+     "end_time": "2026-09-08T22:00:55.363627+00:00",
      "exception": false,
-     "start_time": "2026-09-06T16:52:27.622878+00:00",
+     "start_time": "2026-09-08T22:00:55.362969+00:00",
      "status": "completed"
     }
    },
@@ -307,14 +417,17461 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f2d073aa",
+   "execution_count": 5,
+   "id": "2fd263f7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:55.365534Z",
+     "iopub.status.busy": "2026-09-08T22:00:55.365450Z",
+     "iopub.status.idle": "2026-09-08T22:49:55.935459Z",
+     "shell.execute_reply": "2026-09-08T22:49:55.934704Z"
+    },
+    "papermill": {
+     "duration": 2940.571518,
+     "end_time": "2026-09-08T22:49:55.935859+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:55.364341+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=17,060 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.047384\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002923\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001709, val_loss=0.002139, IC=-0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001243, val_loss=0.002093, IC=+0.0051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001068, val_loss=0.001971, IC=+0.0103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000913, val_loss=0.000884, IC=+0.0135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000867\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000839\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000842\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000771, val_loss=0.001011, IC=+0.0127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000752\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000714, val_loss=0.000646, IC=+0.0183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000673, val_loss=0.000468, IC=+0.0090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000671\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000651\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000640\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000615, val_loss=0.000448, IC=+0.0200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000582\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000586, val_loss=0.000469, IC=+0.0193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000564\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000539, val_loss=0.000562, IC=+0.0219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000517\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000537, val_loss=0.000820, IC=+0.0156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000455\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000509, val_loss=0.000709, IC=+0.0158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000459, val_loss=0.000439, IC=+0.0205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000434\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000436, val_loss=0.000441, IC=+0.0246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000455\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000431\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000457, val_loss=0.000480, IC=+0.0271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000434\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000417, val_loss=0.000458, IC=+0.0214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000433, val_loss=0.000636, IC=+0.0213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000409, val_loss=0.000454, IC=+0.0241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000403\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000398, val_loss=0.000438, IC=+0.0266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000397\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000422, val_loss=0.000435, IC=+0.0265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=75, IC=+0.0271 (57.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n",
+      "    train=22,220 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.034882\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.004426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001879, val_loss=0.001408, IC=+0.0560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001402, val_loss=0.000677, IC=+0.0460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001131, val_loss=0.000485, IC=+0.0310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001156, val_loss=0.000486, IC=+0.0336\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000917\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000895\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000898, val_loss=0.000379, IC=+0.0228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000833\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000852\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000799\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000752\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000790, val_loss=0.000393, IC=+0.0256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000883\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000750\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000750\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000751, val_loss=0.000264, IC=+0.0236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000717\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000794\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000789\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000707, val_loss=0.000211, IC=+0.0227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000631, val_loss=0.000209, IC=+0.0191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000648\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000595\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000574, val_loss=0.000203, IC=+0.0245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000588, val_loss=0.000170, IC=+0.0171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000540, val_loss=0.000237, IC=+0.0239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000522, val_loss=0.000164, IC=+0.0222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000518\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000535, val_loss=0.000162, IC=+0.0229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000509\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000493, val_loss=0.000181, IC=+0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000494, val_loss=0.000174, IC=+0.0210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000496, val_loss=0.000175, IC=+0.0193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000488, val_loss=0.000156, IC=+0.0180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000473, val_loss=0.000149, IC=+0.0202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000462, val_loss=0.000146, IC=+0.0191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0560 (70.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.021726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.004122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002831, val_loss=0.002656, IC=-0.0255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001846\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001318, val_loss=0.001481, IC=+0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000926, val_loss=0.000671, IC=-0.0287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000933\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000996\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001031, val_loss=0.000432, IC=-0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000992\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000985\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000985\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000843, val_loss=0.000439, IC=-0.0261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001841\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001387, val_loss=0.000543, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000760\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000785, val_loss=0.000281, IC=-0.0228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000862\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000849\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000790\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000999, val_loss=0.000668, IC=-0.0339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000840\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000610, val_loss=0.000240, IC=-0.0344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000500, val_loss=0.000190, IC=-0.0218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000499\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000746\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001259, val_loss=0.000194, IC=-0.0207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000594, val_loss=0.000177, IC=-0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000582\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000631, val_loss=0.000187, IC=-0.0209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000941\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000530, val_loss=0.000207, IC=-0.0177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000490, val_loss=0.000148, IC=-0.0239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000496, val_loss=0.000168, IC=-0.0078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000849\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000430\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000580, val_loss=0.000150, IC=-0.0133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000468, val_loss=0.000165, IC=-0.0174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000403\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000695\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000708, val_loss=0.000165, IC=-0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000410, val_loss=0.000139, IC=-0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0007 (76.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.076981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002240, val_loss=0.001462, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.002831, val_loss=0.000982, IC=+0.0245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.002092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.002047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.002220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.002350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001793, val_loss=0.000832, IC=+0.0362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.002271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001485, val_loss=0.000529, IC=+0.0327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001943\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001430, val_loss=0.001762, IC=+0.0095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001732\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001081, val_loss=0.000618, IC=-0.0073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000961\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000922\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000924\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001456, val_loss=0.000377, IC=+0.0253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002348\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001253, val_loss=0.000469, IC=+0.0137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000962\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002283, val_loss=0.000258, IC=+0.0087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000991, val_loss=0.000398, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002896\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000911, val_loss=0.000185, IC=-0.0110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000819, val_loss=0.000284, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000759\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001167, val_loss=0.000175, IC=-0.0059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000851\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000828\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000853\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000705, val_loss=0.000464, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000742\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000846\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000658, val_loss=0.000221, IC=+0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000772\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000657, val_loss=0.000184, IC=-0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000830\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000985\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000560, val_loss=0.000339, IC=-0.0044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000752, val_loss=0.000147, IC=-0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000564, val_loss=0.000139, IC=-0.0070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000653, val_loss=0.000138, IC=-0.0062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0362 (80.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.186689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.006591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002680, val_loss=0.002722, IC=+0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001603, val_loss=0.002101, IC=+0.0231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001380\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001619\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001844\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001489, val_loss=0.005476, IC=-0.0451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.002867\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.002092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000972\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001625, val_loss=0.001013, IC=+0.0226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001105, val_loss=0.000892, IC=-0.0210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000874\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001213, val_loss=0.000634, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001499\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000977\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000773\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001150, val_loss=0.000485, IC=+0.0214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000994\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000749\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000878, val_loss=0.000957, IC=+0.0133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000731, val_loss=0.000446, IC=-0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000840\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000635, val_loss=0.001281, IC=+0.0039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000792\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000785, val_loss=0.000971, IC=+0.0240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000934\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000786\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000746, val_loss=0.000586, IC=+0.0160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000516\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000561, val_loss=0.000405, IC=+0.0141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000619, val_loss=0.000395, IC=+0.0291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000398\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000430\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000428, val_loss=0.000334, IC=+0.0347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000526\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000449, val_loss=0.000296, IC=+0.0316\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000872\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000413, val_loss=0.000438, IC=+0.0273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000390\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000421\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000401, val_loss=0.000324, IC=+0.0287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000413\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000918, val_loss=0.000365, IC=+0.0342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000624\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000438, val_loss=0.000269, IC=+0.0301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=75, IC=+0.0347 (81.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.496207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.014786\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.005512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.004649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.003167, val_loss=0.001313, IC=+0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.002254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001339, val_loss=0.000818, IC=+0.0211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.003658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001942\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.002428, val_loss=0.000665, IC=+0.0117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001219, val_loss=0.000617, IC=+0.0052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001864\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001859\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001337, val_loss=0.000313, IC=+0.0196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000777\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000921\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001560, val_loss=0.000295, IC=+0.0112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000971\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000842, val_loss=0.000231, IC=+0.0196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000892\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001130, val_loss=0.000211, IC=+0.0127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000836\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000818, val_loss=0.000194, IC=+0.0153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000865\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000686\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000871, val_loss=0.000222, IC=+0.0240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000944\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000575\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000546, val_loss=0.000143, IC=+0.0184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000616\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000655, val_loss=0.000212, IC=+0.0146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000862\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000522, val_loss=0.000153, IC=+0.0168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000455\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000714\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000522\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000654, val_loss=0.000151, IC=+0.0189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000537, val_loss=0.000141, IC=+0.0297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000918, val_loss=0.000164, IC=+0.0319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000495\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000474, val_loss=0.000150, IC=+0.0291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000881\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000506, val_loss=0.000140, IC=+0.0318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000456\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000995\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000467, val_loss=0.000138, IC=+0.0279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000587, val_loss=0.000139, IC=+0.0311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=80, IC=+0.0319 (78.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.040427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.004937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003759\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002304, val_loss=0.002673, IC=+0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.004888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001885, val_loss=0.003576, IC=-0.0275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001383\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.002376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001704, val_loss=0.004522, IC=-0.0245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001747\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001758\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002127, val_loss=0.001354, IC=-0.0350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002705\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001709, val_loss=0.001871, IC=-0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000995\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000910, val_loss=0.002998, IC=-0.0213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000782, val_loss=0.000850, IC=-0.0309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002883\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002096, val_loss=0.000625, IC=-0.0343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000745\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000662, val_loss=0.000637, IC=-0.0112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001246, val_loss=0.000486, IC=-0.0084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000935\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000701\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001120, val_loss=0.001146, IC=-0.0196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000565, val_loss=0.000422, IC=-0.0204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000931\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000623, val_loss=0.000615, IC=-0.0281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000545\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000762, val_loss=0.000380, IC=-0.0245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000577\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000502, val_loss=0.000412, IC=-0.0236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000850\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000506, val_loss=0.000451, IC=-0.0209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000679\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000476, val_loss=0.000306, IC=-0.0274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000545\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000509\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000497, val_loss=0.000442, IC=-0.0259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000497\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000518\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000602, val_loss=0.000326, IC=-0.0275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000622\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000449, val_loss=0.000401, IC=-0.0272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0096 (75.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,140 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.052800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.004153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.003073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002477, val_loss=0.002490, IC=+0.0228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002455\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.002218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.003535, val_loss=0.001488, IC=+0.0266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001790\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001716\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001543, val_loss=0.000794, IC=+0.0268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002021, val_loss=0.002559, IC=+0.0227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001912\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001716\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001547, val_loss=0.000755, IC=+0.0326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002826\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001737\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001412, val_loss=0.001535, IC=+0.0188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001725, val_loss=0.000626, IC=+0.0332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000977\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001081, val_loss=0.000387, IC=+0.0295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000878\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001028, val_loss=0.000500, IC=+0.0189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000799\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000628, val_loss=0.000328, IC=+0.0244\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000693\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000705\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000694, val_loss=0.000364, IC=+0.0155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000829\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000777\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000867\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000669, val_loss=0.000333, IC=+0.0307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000742\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001388\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000899, val_loss=0.000676, IC=+0.0275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000973\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000736\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000625, val_loss=0.000366, IC=+0.0186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000707\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000591, val_loss=0.000273, IC=+0.0186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000617, val_loss=0.000289, IC=+0.0093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000671\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000746\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000642, val_loss=0.000262, IC=+0.0086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000876\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000748\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000560, val_loss=0.000271, IC=+0.0073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001033, val_loss=0.000285, IC=+0.0131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000516\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000550, val_loss=0.000255, IC=+0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=35, IC=+0.0332 (83.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  tcn: best_epoch=10, IC=+0.0149 (604.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: tcn @ epoch 10 (IC=+0.0149)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/fx_pairs/run_log/training/8caab3d93247/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=16,980 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.047914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001834, val_loss=0.003809, IC=-0.0254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001348, val_loss=0.002268, IC=-0.0102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001383\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001303, val_loss=0.002650, IC=-0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000990, val_loss=0.001847, IC=+0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000933, val_loss=0.001915, IC=-0.0140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000942\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000877\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000855\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000853\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000860, val_loss=0.002132, IC=-0.0130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000903\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000869\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000788\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000781, val_loss=0.001248, IC=-0.0137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000760\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000736\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000737, val_loss=0.001245, IC=-0.0172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000706\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000691\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000701\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000690, val_loss=0.001208, IC=-0.0248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000686\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000682\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000737, val_loss=0.001161, IC=-0.0273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000690\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000679\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000614, val_loss=0.000902, IC=-0.0164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000620\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000649, val_loss=0.001079, IC=-0.0188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000607, val_loss=0.001195, IC=-0.0275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000577\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000564, val_loss=0.000858, IC=-0.0236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000540, val_loss=0.001026, IC=-0.0276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000545, val_loss=0.000921, IC=-0.0240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000531, val_loss=0.000884, IC=-0.0244\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000525\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000538, val_loss=0.000837, IC=-0.0235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000524\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000522\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000527\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000532, val_loss=0.000906, IC=-0.0260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000531\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000527, val_loss=0.000874, IC=-0.0248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=20, IC=+0.0013 (62.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n",
+      "    train=22,140 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.033914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002120, val_loss=0.002826, IC=+0.1062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001871\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001857\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001548, val_loss=0.000814, IC=+0.0561\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001321\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001312, val_loss=0.000611, IC=+0.0702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001216, val_loss=0.000814, IC=+0.0721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001035, val_loss=0.000560, IC=+0.0071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000996\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000957\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000954\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000972, val_loss=0.000415, IC=+0.0304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000965\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000856\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000879\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000845, val_loss=0.000505, IC=+0.0545\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000840\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000861\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000876\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000789, val_loss=0.000365, IC=+0.0446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000777\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000747, val_loss=0.000331, IC=+0.0343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000772\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000709, val_loss=0.000383, IC=+0.0519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000735\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000686, val_loss=0.000314, IC=+0.0279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000686\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000685, val_loss=0.000297, IC=+0.0194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000681\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000651\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000667, val_loss=0.000335, IC=+0.0371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000617, val_loss=0.000303, IC=+0.0454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000619, val_loss=0.000309, IC=+0.0423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000598, val_loss=0.000308, IC=+0.0386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000598, val_loss=0.000303, IC=+0.0454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000599, val_loss=0.000299, IC=+0.0436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000595\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000620\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000585, val_loss=0.000292, IC=+0.0395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000597, val_loss=0.000283, IC=+0.0436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.1062 (87.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.022956\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.003899\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001806\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001619, val_loss=0.001239, IC=-0.0332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001153, val_loss=0.000960, IC=-0.0351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000973\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000927, val_loss=0.000594, IC=+0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000927\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000868\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000847\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000819\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000809, val_loss=0.000454, IC=-0.0097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000747\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000692, val_loss=0.000370, IC=-0.0171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000636, val_loss=0.000400, IC=-0.0284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000601, val_loss=0.000336, IC=-0.0355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000574\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000566, val_loss=0.000270, IC=-0.0185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000545, val_loss=0.000338, IC=-0.0308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000498, val_loss=0.000439, IC=-0.0237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000473, val_loss=0.000275, IC=-0.0120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000474, val_loss=0.000263, IC=-0.0154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000457, val_loss=0.000288, IC=-0.0204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000429, val_loss=0.000246, IC=-0.0102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000434\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000431\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000428, val_loss=0.000268, IC=-0.0123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000434\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000424, val_loss=0.000267, IC=-0.0150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000423, val_loss=0.000263, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000425\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000415\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000428, val_loss=0.000248, IC=-0.0105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000430\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000425\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000426, val_loss=0.000260, IC=-0.0145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000413\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000429, val_loss=0.000247, IC=-0.0107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0113 (130.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.077565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005787\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002053, val_loss=0.001231, IC=+0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001891\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001640\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001456, val_loss=0.000665, IC=+0.0296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001193, val_loss=0.000551, IC=+0.0240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001041, val_loss=0.000371, IC=+0.0386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000986\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000988, val_loss=0.000453, IC=+0.0382\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000971\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000889\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000880\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000886, val_loss=0.000358, IC=+0.0155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000855\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000799\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000833\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000828\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000766, val_loss=0.000240, IC=+0.0257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000763\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000765\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000768, val_loss=0.000272, IC=+0.0157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000791\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000745\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000743\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000717\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000710, val_loss=0.000206, IC=+0.0087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000705\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000683, val_loss=0.000210, IC=+0.0135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000640\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000664, val_loss=0.000301, IC=+0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000623, val_loss=0.000216, IC=+0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000600, val_loss=0.000196, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000577\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000585, val_loss=0.000194, IC=+0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000597\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000588, val_loss=0.000191, IC=+0.0139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000577\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000549\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000564, val_loss=0.000191, IC=+0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000573, val_loss=0.000188, IC=+0.0093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000552, val_loss=0.000190, IC=+0.0114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000547, val_loss=0.000187, IC=+0.0095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000545\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000550, val_loss=0.000188, IC=+0.0103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=20, IC=+0.0386 (162.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.201309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.008264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001399, val_loss=0.001605, IC=+0.0393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000992, val_loss=0.000781, IC=+0.0615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000844\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000853, val_loss=0.000924, IC=+0.0218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000869\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000789\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000876, val_loss=0.000716, IC=+0.0377\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000743\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000758\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000731\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000684, val_loss=0.000686, IC=+0.0242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000763\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000681, val_loss=0.000718, IC=+0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000727, val_loss=0.000891, IC=-0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000640, val_loss=0.000926, IC=+0.0275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000552\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000542, val_loss=0.000699, IC=-0.0169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000516\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000467\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000558, val_loss=0.000620, IC=+0.0194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000531\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000494, val_loss=0.000653, IC=-0.0039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000436, val_loss=0.000414, IC=+0.0206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000485, val_loss=0.000676, IC=-0.0198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000471, val_loss=0.000650, IC=+0.0156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000469, val_loss=0.000399, IC=+0.0260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000472, val_loss=0.000386, IC=+0.0245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000445\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000438, val_loss=0.000436, IC=+0.0188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000433, val_loss=0.000396, IC=+0.0222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000420, val_loss=0.000384, IC=+0.0228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000430\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000429, val_loss=0.000391, IC=+0.0221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0615 (167.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.522947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.010656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001572, val_loss=0.000927, IC=+0.0487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001111, val_loss=0.000510, IC=+0.0430\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001082, val_loss=0.000447, IC=+0.0452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000954\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000854\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000975, val_loss=0.000325, IC=+0.0413\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000924\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000824\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000765, val_loss=0.000297, IC=+0.0422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000713\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000627, val_loss=0.000327, IC=+0.0314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000828\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000622, val_loss=0.000253, IC=+0.0406\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000687\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000563, val_loss=0.000242, IC=+0.0365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000545\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000530, val_loss=0.000254, IC=+0.0362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000529, val_loss=0.000220, IC=+0.0355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000525\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000549\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000501, val_loss=0.000230, IC=+0.0204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000466, val_loss=0.000240, IC=+0.0234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000515, val_loss=0.000219, IC=+0.0269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000455\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000490, val_loss=0.000211, IC=+0.0263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000449\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000471, val_loss=0.000201, IC=+0.0274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000435\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000491, val_loss=0.000209, IC=+0.0252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000424, val_loss=0.000195, IC=+0.0243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000437, val_loss=0.000196, IC=+0.0238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000439\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000449\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000428\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000447, val_loss=0.000198, IC=+0.0239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000423, val_loss=0.000198, IC=+0.0232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0487 (154.3s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.041783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.004949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002752\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001907, val_loss=0.005380, IC=+0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001691\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001375, val_loss=0.002372, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001141, val_loss=0.003196, IC=+0.0054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000962, val_loss=0.001716, IC=-0.0067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000936\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000943\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000893\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000858\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000849, val_loss=0.001860, IC=+0.0218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000789\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000793\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000743, val_loss=0.001385, IC=+0.0149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000762\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000667, val_loss=0.001016, IC=+0.0335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000625, val_loss=0.000743, IC=+0.0463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000597\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000567, val_loss=0.000975, IC=+0.0318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000546, val_loss=0.000843, IC=+0.0386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000532, val_loss=0.000654, IC=+0.0356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000525\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000516\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000514, val_loss=0.000677, IC=+0.0348\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000497\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000472, val_loss=0.000492, IC=+0.0302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000464, val_loss=0.000546, IC=+0.0384\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000443, val_loss=0.000543, IC=+0.0277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000451, val_loss=0.000492, IC=+0.0254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000445, val_loss=0.000516, IC=+0.0314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000457, val_loss=0.000481, IC=+0.0294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000440\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000440\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000431\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000444, val_loss=0.000516, IC=+0.0307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000435\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000441, val_loss=0.000516, IC=+0.0295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=40, IC=+0.0463 (168.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,060 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.055894\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002054, val_loss=0.001667, IC=-0.0211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001893\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001749\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001637\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001567, val_loss=0.001031, IC=-0.0229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001348\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001280, val_loss=0.000859, IC=+0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001119, val_loss=0.000907, IC=-0.0177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000989\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000946, val_loss=0.000593, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000864\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000839\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000844, val_loss=0.000540, IC=-0.0141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000857\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000806\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000845\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000838, val_loss=0.000742, IC=-0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000715\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000710, val_loss=0.000429, IC=-0.0214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000657\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000639, val_loss=0.000383, IC=-0.0204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000624\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000639, val_loss=0.000372, IC=-0.0319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000573, val_loss=0.000340, IC=-0.0177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000581, val_loss=0.000343, IC=-0.0230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000575\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000577\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000561\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000526, val_loss=0.000321, IC=-0.0238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000518\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000501, val_loss=0.000324, IC=-0.0229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000501\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000501\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000490, val_loss=0.000294, IC=-0.0239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000495\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000494, val_loss=0.000290, IC=-0.0187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000496, val_loss=0.000280, IC=-0.0214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000467, val_loss=0.000282, IC=-0.0229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000470, val_loss=0.000279, IC=-0.0227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000467\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000458, val_loss=0.000280, IC=-0.0237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0082 (178.3s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  tcn: best_epoch=15, IC=+0.0229 (1111.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: tcn @ epoch 15 (IC=+0.0229)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/fx_pairs/run_log/training/1978f50dd33b/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=16,660 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.048296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.006707\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002191, val_loss=0.004286, IC=-0.0521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001776\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001551, val_loss=0.004873, IC=-0.0650\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001345, val_loss=0.003914, IC=-0.0564\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001387, val_loss=0.002930, IC=-0.0773\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001051, val_loss=0.003614, IC=-0.0594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000977, val_loss=0.003197, IC=-0.0553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000975\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000965\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000928\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000995, val_loss=0.003629, IC=-0.0614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000916\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000921, val_loss=0.003774, IC=-0.0533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000852\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000849\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000857\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000820\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000840, val_loss=0.002063, IC=-0.0180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000771\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000772, val_loss=0.002728, IC=-0.0409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000765\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000723, val_loss=0.002491, IC=-0.0307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000732\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000716, val_loss=0.002824, IC=-0.0386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000703\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000669, val_loss=0.002331, IC=-0.0520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000707, val_loss=0.002161, IC=-0.0272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000665\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000669, val_loss=0.002392, IC=-0.0405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000662, val_loss=0.002324, IC=-0.0346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000637\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000638, val_loss=0.002335, IC=-0.0351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000648, val_loss=0.002201, IC=-0.0298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000648\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000640\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000648\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000642, val_loss=0.002368, IC=-0.0380\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000646\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000628, val_loss=0.002318, IC=-0.0376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=45, IC=-0.0180 (120.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n",
+      "    train=21,820 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.035568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002647\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002364, val_loss=0.002066, IC=+0.1194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001942\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001904, val_loss=0.001530, IC=+0.0913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001765\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001707\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001555, val_loss=0.001312, IC=+0.0987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001336, val_loss=0.001262, IC=+0.0401\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001253, val_loss=0.001413, IC=+0.0345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001120, val_loss=0.001299, IC=+0.0660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001057, val_loss=0.001254, IC=+0.0447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000957\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000970, val_loss=0.001194, IC=+0.0608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000963\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000927\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000917\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000935, val_loss=0.001259, IC=+0.0389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000953\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000972\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000920\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000906\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000904, val_loss=0.001205, IC=+0.0419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000892\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000858\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000840\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000826\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000852, val_loss=0.001119, IC=+0.0567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000905\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000854\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000825, val_loss=0.001227, IC=+0.0548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000827\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000820\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000842\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000815, val_loss=0.001140, IC=+0.0696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000819\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000764\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000778, val_loss=0.001122, IC=+0.0708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000751\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000797\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000794\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000762, val_loss=0.001123, IC=+0.0608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000768\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000749, val_loss=0.001105, IC=+0.0814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000746\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000743\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000739\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000737, val_loss=0.001106, IC=+0.0721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000755\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000732\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000732, val_loss=0.001092, IC=+0.0652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000738\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000730\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000749\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000736\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000725, val_loss=0.001097, IC=+0.0711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000705\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000734, val_loss=0.001090, IC=+0.0701\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.1194 (155.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.023439\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.004206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002743\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001901, val_loss=0.001589, IC=-0.0871\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001671\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001398, val_loss=0.001108, IC=-0.0593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001379\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001181, val_loss=0.001073, IC=-0.0739\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001022, val_loss=0.001026, IC=-0.0659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000988\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000956\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000950, val_loss=0.000908, IC=-0.0136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000950\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000920\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000890\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000864\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000860, val_loss=0.000915, IC=-0.0247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000766, val_loss=0.000866, IC=-0.0341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000761\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000738, val_loss=0.000840, IC=-0.0084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000731\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000742, val_loss=0.000826, IC=-0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000681\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000714\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000703, val_loss=0.000932, IC=-0.0474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000689, val_loss=0.000865, IC=-0.0473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000619\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000627, val_loss=0.000806, IC=+0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000606\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000600, val_loss=0.000853, IC=-0.0424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000606\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000592, val_loss=0.000896, IC=-0.0412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000595\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000577, val_loss=0.000968, IC=-0.0543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000575\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000573, val_loss=0.000874, IC=-0.0424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000561, val_loss=0.000904, IC=-0.0493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000564, val_loss=0.000911, IC=-0.0513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000560, val_loss=0.000906, IC=-0.0508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000573, val_loss=0.000907, IC=-0.0520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=60, IC=+0.0031 (143.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n",
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.079321\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.006599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003866\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002878\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002438, val_loss=0.001502, IC=+0.0626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001866\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001835, val_loss=0.000992, IC=+0.0885\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001707\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001562, val_loss=0.000869, IC=+0.0710\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001439\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001319, val_loss=0.000756, IC=+0.0538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001159, val_loss=0.000717, IC=+0.0689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001078, val_loss=0.000638, IC=+0.0490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001018, val_loss=0.000620, IC=+0.0371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000968\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000944\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000979\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000938, val_loss=0.000604, IC=+0.0546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000912\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000890\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000893\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000870, val_loss=0.000615, IC=+0.0260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000877\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000952\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000834\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000820, val_loss=0.000614, IC=+0.0071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000852\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000859\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000852, val_loss=0.000619, IC=+0.0157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000802, val_loss=0.000613, IC=+0.0269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000789\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000768\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000749\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000771, val_loss=0.000626, IC=+0.0385\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000761\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000790\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000749\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000731, val_loss=0.000644, IC=+0.0323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000741\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000735, val_loss=0.000638, IC=+0.0184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000711\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000706\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000704, val_loss=0.000634, IC=+0.0200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000710\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000706\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000694, val_loss=0.000633, IC=+0.0247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000687\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000681, val_loss=0.000629, IC=+0.0190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000699, val_loss=0.000646, IC=+0.0216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000691\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000694, val_loss=0.000641, IC=+0.0211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0885 (134.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.203939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.009013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001701, val_loss=0.002126, IC=+0.1800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001574\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001278, val_loss=0.002116, IC=+0.1115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001067, val_loss=0.001784, IC=+0.1258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000968\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000909\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000929, val_loss=0.002744, IC=+0.1324\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000894\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000895\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000849\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000864, val_loss=0.001611, IC=-0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000897\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000860\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000765\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000946, val_loss=0.001464, IC=+0.0128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000762\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000747\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000762\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000721, val_loss=0.001586, IC=-0.0417\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000750\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000838\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000799\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000706, val_loss=0.001915, IC=+0.0286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000679, val_loss=0.001991, IC=+0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000616, val_loss=0.001686, IC=-0.0132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000608, val_loss=0.001460, IC=-0.0473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000552\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000609, val_loss=0.001477, IC=-0.0606\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000564\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000567, val_loss=0.001529, IC=-0.0250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000596, val_loss=0.001529, IC=-0.0593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000571, val_loss=0.001550, IC=-0.0339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000541, val_loss=0.001568, IC=-0.0753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000529\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000526\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000510, val_loss=0.001510, IC=-0.0448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000525, val_loss=0.001537, IC=-0.0395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000507, val_loss=0.001510, IC=-0.0466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000525\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000514, val_loss=0.001500, IC=-0.0472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.1800 (136.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.528971\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.013143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.004788\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002873\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002253, val_loss=0.001043, IC=+0.0721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001856\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001736\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001761\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001549\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001477, val_loss=0.000805, IC=+0.0659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001430\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001482\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001213, val_loss=0.000674, IC=+0.0900\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001316\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001135, val_loss=0.000744, IC=+0.0592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000998\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000915, val_loss=0.000662, IC=+0.0571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000962\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000975, val_loss=0.000665, IC=+0.0633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000891\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000875\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000854\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000848\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000847, val_loss=0.000675, IC=+0.0801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000860\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000837\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000745, val_loss=0.000691, IC=+0.0764\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000743\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000768\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000801, val_loss=0.000701, IC=+0.0835\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000737\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000713\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000762\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000749, val_loss=0.000668, IC=+0.0870\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000716\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000694\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000755\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000752\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000689, val_loss=0.000664, IC=+0.0981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000637\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000640\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000616\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000631, val_loss=0.000716, IC=+0.0957\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000625, val_loss=0.000686, IC=+0.0944\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000575\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000595\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000578, val_loss=0.000668, IC=+0.0951\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000588, val_loss=0.000726, IC=+0.0884\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000576, val_loss=0.000705, IC=+0.0917\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000597\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000595, val_loss=0.000725, IC=+0.0878\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000564\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000557, val_loss=0.000698, IC=+0.0894\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000578, val_loss=0.000699, IC=+0.0892\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000567, val_loss=0.000696, IC=+0.0906\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=55, IC=+0.0981 (150.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.043205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002966\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002029, val_loss=0.010446, IC=-0.0646\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001895\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001762\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001497, val_loss=0.004844, IC=-0.0509\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001428\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001396\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001273, val_loss=0.003389, IC=-0.0365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001080, val_loss=0.003190, IC=-0.0195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000980, val_loss=0.002697, IC=+0.0223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000957\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000979\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000876, val_loss=0.002599, IC=+0.0183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000855\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000853\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000880\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000808\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000813, val_loss=0.002767, IC=+0.0334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000817\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000794\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000776\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000822, val_loss=0.002288, IC=+0.0234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000694\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000717, val_loss=0.002005, IC=+0.0337\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000739\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000707\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000677, val_loss=0.002238, IC=+0.0170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000648\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000651\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000653, val_loss=0.001947, IC=+0.0254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000619\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000613\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000627, val_loss=0.002147, IC=+0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000600, val_loss=0.002186, IC=+0.0240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000580, val_loss=0.002063, IC=+0.0238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000574\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000574, val_loss=0.001857, IC=+0.0266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000564, val_loss=0.001864, IC=+0.0281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000552, val_loss=0.001905, IC=+0.0233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000561\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000554, val_loss=0.001930, IC=+0.0226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000554\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000549, val_loss=0.001890, IC=+0.0233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000547, val_loss=0.001890, IC=+0.0231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=45, IC=+0.0337 (147.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=4,740 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    tcn:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.056005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.006707\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.003806\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002432, val_loss=0.002133, IC=+0.0459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001936\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001734, val_loss=0.001898, IC=+0.0473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001407, val_loss=0.001544, IC=+0.0220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001388\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001375\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001280, val_loss=0.001810, IC=+0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001110, val_loss=0.001546, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000986\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001011, val_loss=0.001255, IC=-0.0273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000972\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000952\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000958\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000887\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000887, val_loss=0.001247, IC=-0.0387\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000899\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000857\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000832, val_loss=0.001234, IC=-0.0581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000806\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000792\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000777\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000814, val_loss=0.001164, IC=-0.0253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000762\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000742\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000758\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000733, val_loss=0.001087, IC=-0.0089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000677, val_loss=0.001039, IC=-0.0176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000649, val_loss=0.001009, IC=-0.0018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000628, val_loss=0.000990, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000622\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000621, val_loss=0.001011, IC=+0.0153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000582, val_loss=0.000961, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000607, val_loss=0.000978, IC=+0.0083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000607, val_loss=0.000976, IC=+0.0094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000593, val_loss=0.000973, IC=+0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000574, val_loss=0.000976, IC=+0.0056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000574\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000584, val_loss=0.000972, IC=+0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0473 (139.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  tcn: best_epoch=5, IC=+0.0344 (1128.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: tcn @ epoch 5 (IC=+0.0344)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/fx_pairs/run_log/training/1c1ca12dc9b6/diagnostics\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (60, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>complete</th><th>ic_mean</th><th>ic_t</th><th>training_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>bool</td><td>f64</td><td>f64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>true</td><td>0.010851</td><td>1.403768</td><td>&quot;8caab3d93247&quot;</td><td>&quot;7119a476dd86&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>true</td><td>0.01495</td><td>2.052329</td><td>&quot;8caab3d93247&quot;</td><td>&quot;0eb73fea6afa&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>true</td><td>0.002199</td><td>0.215816</td><td>&quot;8caab3d93247&quot;</td><td>&quot;6c76e9b23070&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>20</td><td>true</td><td>0.009732</td><td>1.200962</td><td>&quot;8caab3d93247&quot;</td><td>&quot;8a3d62b26ac1&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>true</td><td>0.004078</td><td>0.550297</td><td>&quot;8caab3d93247&quot;</td><td>&quot;24a463685007&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>80</td><td>true</td><td>0.007721</td><td>0.967637</td><td>&quot;1978f50dd33b&quot;</td><td>&quot;c8150226d3a3&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>85</td><td>true</td><td>0.009165</td><td>1.085807</td><td>&quot;1978f50dd33b&quot;</td><td>&quot;2628a9369fae&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>90</td><td>true</td><td>0.009174</td><td>1.098892</td><td>&quot;1978f50dd33b&quot;</td><td>&quot;fc57f2fa7969&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>95</td><td>true</td><td>0.007888</td><td>0.932406</td><td>&quot;1978f50dd33b&quot;</td><td>&quot;8d42416b424a&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;tcn&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>true</td><td>0.008676</td><td>1.02419</td><td>&quot;1978f50dd33b&quot;</td><td>&quot;e2b818b7e60d&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (60, 9)\n",
+       "┌────────────┬───────────┬───────────┬───────────┬───┬──────────┬──────────┬───────────┬───────────┐\n",
+       "│ label      ┆ config_na ┆ checkpoin ┆ checkpoin ┆ … ┆ ic_mean  ┆ ic_t     ┆ training_ ┆ predictio │\n",
+       "│ ---        ┆ me        ┆ t_kind    ┆ t_value   ┆   ┆ ---      ┆ ---      ┆ hash      ┆ n_hash    │\n",
+       "│ str        ┆ ---       ┆ ---       ┆ ---       ┆   ┆ f64      ┆ f64      ┆ ---       ┆ ---       │\n",
+       "│            ┆ str       ┆ str       ┆ i64       ┆   ┆          ┆          ┆ str       ┆ str       │\n",
+       "╞════════════╪═══════════╪═══════════╪═══════════╪═══╪══════════╪══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_ret_1d ┆ tcn       ┆ epoch     ┆ 5         ┆ … ┆ 0.010851 ┆ 1.403768 ┆ 8caab3d93 ┆ 7119a476d │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 247       ┆ d86       │\n",
+       "│ fwd_ret_1d ┆ tcn       ┆ epoch     ┆ 10        ┆ … ┆ 0.01495  ┆ 2.052329 ┆ 8caab3d93 ┆ 0eb73fea6 │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 247       ┆ afa       │\n",
+       "│ fwd_ret_1d ┆ tcn       ┆ epoch     ┆ 15        ┆ … ┆ 0.002199 ┆ 0.215816 ┆ 8caab3d93 ┆ 6c76e9b23 │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 247       ┆ 070       │\n",
+       "│ fwd_ret_1d ┆ tcn       ┆ epoch     ┆ 20        ┆ … ┆ 0.009732 ┆ 1.200962 ┆ 8caab3d93 ┆ 8a3d62b26 │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 247       ┆ ac1       │\n",
+       "│ fwd_ret_1d ┆ tcn       ┆ epoch     ┆ 25        ┆ … ┆ 0.004078 ┆ 0.550297 ┆ 8caab3d93 ┆ 24a463685 │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 247       ┆ 007       │\n",
+       "│ …          ┆ …         ┆ …         ┆ …         ┆ … ┆ …        ┆ …        ┆ …         ┆ …         │\n",
+       "│ fwd_ret_5d ┆ tcn       ┆ epoch     ┆ 80        ┆ … ┆ 0.007721 ┆ 0.967637 ┆ 1978f50dd ┆ c8150226d │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 33b       ┆ 3a3       │\n",
+       "│ fwd_ret_5d ┆ tcn       ┆ epoch     ┆ 85        ┆ … ┆ 0.009165 ┆ 1.085807 ┆ 1978f50dd ┆ 2628a9369 │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 33b       ┆ fae       │\n",
+       "│ fwd_ret_5d ┆ tcn       ┆ epoch     ┆ 90        ┆ … ┆ 0.009174 ┆ 1.098892 ┆ 1978f50dd ┆ fc57f2fa7 │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 33b       ┆ 969       │\n",
+       "│ fwd_ret_5d ┆ tcn       ┆ epoch     ┆ 95        ┆ … ┆ 0.007888 ┆ 0.932406 ┆ 1978f50dd ┆ 8d42416b4 │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 33b       ┆ 24a       │\n",
+       "│ fwd_ret_5d ┆ tcn       ┆ epoch     ┆ 100       ┆ … ┆ 0.008676 ┆ 1.02419  ┆ 1978f50dd ┆ e2b818b7e │\n",
+       "│            ┆           ┆           ┆           ┆   ┆          ┆          ┆ 33b       ┆ 60d       │\n",
+       "└────────────┴───────────┴───────────┴───────────┴───┴──────────┴──────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "if len(plan.expected_prediction_hashes) != checkpoint_schedule.height * len(labels):\n",
     "    raise RuntimeError(\"the plan does not cover every declared epoch checkpoint on every label\")\n",
@@ -356,13 +17913,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c66faf1",
+   "id": "ffa4162e",
    "metadata": {
     "papermill": {
-     "duration": 0.043835,
-     "end_time": "2026-09-06T17:26:51.745122+00:00",
+     "duration": 0.052668,
+     "end_time": "2026-09-08T22:49:56.062114+00:00",
      "exception": false,
-     "start_time": "2026-09-06T17:26:51.701287+00:00",
+     "start_time": "2026-09-08T22:49:56.009446+00:00",
      "status": "completed"
     }
    },
@@ -375,14 +17932,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "11f081aa",
+   "execution_count": 6,
+   "id": "e85555bf",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:49:56.168113Z",
+     "iopub.status.busy": "2026-09-08T22:49:56.167974Z",
+     "iopub.status.idle": "2026-09-08T22:50:02.929224Z",
+     "shell.execute_reply": "2026-09-08T22:50:02.928904Z"
+    },
+    "papermill": {
+     "duration": 6.821105,
+     "end_time": "2026-09-08T22:50:02.936502+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:49:56.115397+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Official prediction population: c7951a3956bb\n"
+     ]
+    }
+   ],
    "source": [
     "replayed = plan.run()\n",
     "if set(replayed.catalog_rows.get_column(\"prediction_hash\")) != set(\n",
@@ -399,13 +17977,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7f52ab6",
+   "id": "25b820b6",
    "metadata": {
     "papermill": {
-     "duration": 0.05133,
-     "end_time": "2026-09-06T17:26:54.782165+00:00",
+     "duration": 0.144207,
+     "end_time": "2026-09-08T22:50:03.163933+00:00",
      "exception": false,
-     "start_time": "2026-09-06T17:26:54.730835+00:00",
+     "start_time": "2026-09-08T22:50:03.019726+00:00",
      "status": "completed"
     }
    },
@@ -438,6 +18016,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T22:50:20.616599+00:00",
+   "executor": "local-uv",
+   "library_digest": "5035256203a959728f64b8eb5a2047d91229b302459b7a4274f0b128e0dd11f8",
+   "outputs_digest": "945d3d9015f2364f435ae30274016add1dabba6b094c6f1bc7347c447b39f85f",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "1ec73c5355e1fe1c7d5e98bf56d399a9579e24ad"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2957.439572,
+   "end_time": "2026-09-08T22:50:06.865549+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/fx_pairs/.09_dl_tcn.build.1124511.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/fx_pairs/.09_dl_tcn.papermill.1124511.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T22:00:49.425977+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/10_dl_nlinear.ipynb
+++ b/case_studies/fx_pairs/10_dl_nlinear.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e20df040",
+   "id": "56fa4357",
    "metadata": {
     "papermill": {
-     "duration": 0.00112,
-     "end_time": "2026-09-06T17:27:12.302544+00:00",
+     "duration": 0.00156,
+     "end_time": "2026-09-08T22:36:42.859063+00:00",
      "exception": false,
-     "start_time": "2026-09-06T17:27:12.301424+00:00",
+     "start_time": "2026-09-08T22:36:42.857503+00:00",
      "status": "completed"
     }
    },
@@ -33,9 +33,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "34b8d85a",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "c136628b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:36:42.865426Z",
+     "iopub.status.busy": "2026-09-08T22:36:42.865302Z",
+     "iopub.status.idle": "2026-09-08T22:36:47.845831Z",
+     "shell.execute_reply": "2026-09-08T22:36:47.845043Z"
+    },
+    "papermill": {
+     "duration": 4.983411,
+     "end_time": "2026-09-08T22:36:47.846864+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:36:42.863453+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit and catalog the published NLinear FX configuration.\"\"\"\n",
@@ -59,9 +73,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "46bbd227",
+   "execution_count": 2,
+   "id": "1fa6809d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:36:47.849968Z",
+     "iopub.status.busy": "2026-09-08T22:36:47.849720Z",
+     "iopub.status.idle": "2026-09-08T22:36:47.856856Z",
+     "shell.execute_reply": "2026-09-08T22:36:47.856180Z"
+    },
+    "papermill": {
+     "duration": 0.009395,
+     "end_time": "2026-09-08T22:36:47.857427+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:36:47.848032+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -91,13 +118,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4088ae15",
+   "id": "bbac1bf3",
    "metadata": {
     "papermill": {
-     "duration": 0.000866,
-     "end_time": "2026-09-06T17:27:15.237426+00:00",
+     "duration": 0.000835,
+     "end_time": "2026-09-08T22:36:47.859810+00:00",
      "exception": false,
-     "start_time": "2026-09-06T17:27:15.236560+00:00",
+     "start_time": "2026-09-08T22:36:47.858975+00:00",
      "status": "completed"
     }
    },
@@ -111,10 +138,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "cf646367",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "id": "49c3abe2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:36:47.870338Z",
+     "iopub.status.busy": "2026-09-08T22:36:47.868142Z",
+     "iopub.status.idle": "2026-09-08T22:36:54.754140Z",
+     "shell.execute_reply": "2026-09-08T22:36:54.753701Z"
+    },
+    "papermill": {
+     "duration": 6.890875,
+     "end_time": "2026-09-08T22:36:54.756950+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:36:47.866075+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Labels: fwd_ret_1d, fwd_ret_5d, fwd_ret_21d\n",
+      "Execution tier: canonical\n",
+      "Device: cuda\n",
+      "Lookback: 60 consecutive daily observations\n",
+      "Eligible validation rows, fwd_ret_1d: 41,260\n",
+      "Eligible validation rows, fwd_ret_5d: 41,180\n",
+      "Eligible validation rows, fwd_ret_21d: 40,860\n",
+      "Configured deep_learning models this notebook does not run, fwd_ret_1d: ['lstm_h64', 'tcn']\n",
+      "Configured deep_learning models this notebook does not run, fwd_ret_5d: ['lstm_h64', 'tcn']\n",
+      "Configured deep_learning models this notebook does not run, fwd_ret_21d: ['lstm_h64', 'tcn']\n"
+     ]
+    }
+   ],
    "source": [
     "set_global_seeds(SEED)\n",
     "# The reductions are read before the study is opened, because which study to open is decided by\n",
@@ -231,13 +289,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af847a94",
+   "id": "7c92eee1",
    "metadata": {
     "papermill": {
-     "duration": 0.001802,
-     "end_time": "2026-09-06T17:27:19.468615+00:00",
+     "duration": 0.00427,
+     "end_time": "2026-09-08T22:36:54.766526+00:00",
      "exception": false,
-     "start_time": "2026-09-06T17:27:19.466813+00:00",
+     "start_time": "2026-09-08T22:36:54.762256+00:00",
      "status": "completed"
     }
    },
@@ -250,10 +308,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "81a798f2",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "15cd1abb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:36:54.776998Z",
+     "iopub.status.busy": "2026-09-08T22:36:54.776829Z",
+     "iopub.status.idle": "2026-09-08T22:36:54.800144Z",
+     "shell.execute_reply": "2026-09-08T22:36:54.799198Z"
+    },
+    "papermill": {
+     "duration": 0.032994,
+     "end_time": "2026-09-08T22:36:54.801058+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:36:54.768064+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (20, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>kind</th><th>value</th></tr><tr><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;epoch&quot;</td><td>5</td></tr><tr><td>&quot;epoch&quot;</td><td>10</td></tr><tr><td>&quot;epoch&quot;</td><td>15</td></tr><tr><td>&quot;epoch&quot;</td><td>20</td></tr><tr><td>&quot;epoch&quot;</td><td>25</td></tr><tr><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;epoch&quot;</td><td>80</td></tr><tr><td>&quot;epoch&quot;</td><td>85</td></tr><tr><td>&quot;epoch&quot;</td><td>90</td></tr><tr><td>&quot;epoch&quot;</td><td>95</td></tr><tr><td>&quot;epoch&quot;</td><td>100</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (20, 2)\n",
+       "┌───────┬───────┐\n",
+       "│ kind  ┆ value │\n",
+       "│ ---   ┆ ---   │\n",
+       "│ str   ┆ i64   │\n",
+       "╞═══════╪═══════╡\n",
+       "│ epoch ┆ 5     │\n",
+       "│ epoch ┆ 10    │\n",
+       "│ epoch ┆ 15    │\n",
+       "│ epoch ┆ 20    │\n",
+       "│ epoch ┆ 25    │\n",
+       "│ …     ┆ …     │\n",
+       "│ epoch ┆ 80    │\n",
+       "│ epoch ┆ 85    │\n",
+       "│ epoch ┆ 90    │\n",
+       "│ epoch ┆ 95    │\n",
+       "│ epoch ┆ 100   │\n",
+       "└───────┴───────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "checkpoint_schedule = pl.DataFrame(computation[\"checkpoint_schedule\"])\n",
     "pl.DataFrame(\n",
@@ -272,13 +382,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "174662aa",
+   "id": "3d3f2d5e",
    "metadata": {
     "papermill": {
-     "duration": 0.001888,
-     "end_time": "2026-09-06T17:27:19.483085+00:00",
+     "duration": 0.004214,
+     "end_time": "2026-09-08T22:36:54.810477+00:00",
      "exception": false,
-     "start_time": "2026-09-06T17:27:19.481197+00:00",
+     "start_time": "2026-09-08T22:36:54.806263+00:00",
      "status": "completed"
     }
    },
@@ -305,14 +415,17473 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c222772e",
+   "execution_count": 5,
+   "id": "b8487bd7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:36:54.820085Z",
+     "iopub.status.busy": "2026-09-08T22:36:54.819914Z",
+     "iopub.status.idle": "2026-09-08T23:16:26.222533Z",
+     "shell.execute_reply": "2026-09-08T23:16:26.222161Z"
+    },
+    "papermill": {
+     "duration": 2371.527699,
+     "end_time": "2026-09-08T23:16:26.339435+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:36:54.811736+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=17,060 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.675710\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.398101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.219773\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.116065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.063307, val_loss=0.057894, IC=-0.0446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.042299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.032569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.025580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.021609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.018858, val_loss=0.014801, IC=-0.0373\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.017079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.015423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.013980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.012643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.011916, val_loss=0.005674, IC=-0.0229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.011142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.011264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.009851\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.009528\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.008772, val_loss=0.002700, IC=-0.0178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.008476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.007934\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.007363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.006890\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.006563, val_loss=0.001495, IC=-0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.006238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.005989\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.005667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.005134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.004888, val_loss=0.000939, IC=-0.0084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.004630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.004452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.004176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.004014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.003828, val_loss=0.000653, IC=-0.0042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.003577\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.003322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.003168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.003149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002949, val_loss=0.000474, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002671\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002549\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002290, val_loss=0.000362, IC=+0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001945\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001893, val_loss=0.000281, IC=+0.0048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001820\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001484, val_loss=0.000231, IC=+0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001327, val_loss=0.000202, IC=+0.0057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001115, val_loss=0.000176, IC=+0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001014, val_loss=0.000159, IC=+0.0091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000955\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000950\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000961\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000925, val_loss=0.000150, IC=+0.0110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000924\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000873\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000875\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000894\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000900, val_loss=0.000143, IC=+0.0120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000857\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000845\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000842\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000848\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000860, val_loss=0.000139, IC=+0.0111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000851\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000845\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000838\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000845\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000840, val_loss=0.000137, IC=+0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000848\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000820\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000836\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000828\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000828, val_loss=0.000136, IC=+0.0114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000823\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000808\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000790, val_loss=0.000136, IC=+0.0114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=90, IC=+0.0121 (68.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n",
+      "    train=22,220 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.266553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.131352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.086441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.056803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.039583, val_loss=0.016091, IC=+0.0127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.029825\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.023095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.018883\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.015926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.013511, val_loss=0.004345, IC=-0.0093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.011811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.010706\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.009514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.008357\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.007416, val_loss=0.001993, IC=-0.0169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.006690\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.005708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.005195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004752\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004154, val_loss=0.001058, IC=-0.0151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002767\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002432, val_loss=0.000556, IC=-0.0187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001825\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001497, val_loss=0.000315, IC=-0.0190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000954, val_loss=0.000194, IC=-0.0129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000861\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000793\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000751\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000685\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000638, val_loss=0.000127, IC=-0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000429, val_loss=0.000085, IC=-0.0145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000415\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000381\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000332, val_loss=0.000065, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000253, val_loss=0.000054, IC=-0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000203, val_loss=0.000048, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000176, val_loss=0.000043, IC=-0.0176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000153, val_loss=0.000040, IC=-0.0097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000142, val_loss=0.000038, IC=-0.0098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000134, val_loss=0.000037, IC=-0.0158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000128, val_loss=0.000036, IC=-0.0137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000127, val_loss=0.000036, IC=-0.0129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000123, val_loss=0.000036, IC=-0.0125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000125, val_loss=0.000036, IC=-0.0123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0127 (82.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.173764\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.069958\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.046083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.031253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.024487, val_loss=0.005690, IC=-0.0191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.023948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.017822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.016247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.015060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.013354, val_loss=0.003114, IC=-0.0181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.011992\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.011422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.010062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.008876\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.007906, val_loss=0.001835, IC=-0.0295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.007035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.007102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.006452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.005679\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004663, val_loss=0.000892, IC=-0.0362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.004361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.004066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003788\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003187, val_loss=0.000689, IC=-0.0197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002761\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002417\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002212, val_loss=0.000366, IC=-0.0365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001994\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001657\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001735\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001424, val_loss=0.000237, IC=-0.0339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000998\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000924, val_loss=0.000146, IC=-0.0384\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000908\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000878\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000654, val_loss=0.000113, IC=-0.0329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000502, val_loss=0.000094, IC=-0.0341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000482\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000391, val_loss=0.000065, IC=-0.0375\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000326, val_loss=0.000055, IC=-0.0443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000260, val_loss=0.000050, IC=-0.0373\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000259, val_loss=0.000047, IC=-0.0315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000216, val_loss=0.000043, IC=-0.0303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000196, val_loss=0.000041, IC=-0.0360\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000190, val_loss=0.000039, IC=-0.0367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000223, val_loss=0.000039, IC=-0.0329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000186, val_loss=0.000038, IC=-0.0366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000174, val_loss=0.000038, IC=-0.0339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=-0.0181 (95.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.353841\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.086210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.054831\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.038826\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.027429, val_loss=0.010556, IC=-0.0034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.020367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.021273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.017651\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.012156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.010274, val_loss=0.003054, IC=-0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.008968\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.007855\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.007835\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.006481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.006375, val_loss=0.001848, IC=-0.0090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.005645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.005224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.004349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003798, val_loss=0.000941, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002942\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002273, val_loss=0.000574, IC=-0.0165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001912\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001730\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001488, val_loss=0.000363, IC=-0.0135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001320\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001082, val_loss=0.000242, IC=-0.0239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000864\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000765, val_loss=0.000152, IC=-0.0267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000635\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000567, val_loss=0.000114, IC=-0.0250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000458, val_loss=0.000090, IC=-0.0300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000373, val_loss=0.000077, IC=-0.0356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000357\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000343, val_loss=0.000063, IC=-0.0357\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000307, val_loss=0.000055, IC=-0.0422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000253\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000292\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000233, val_loss=0.000052, IC=-0.0357\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000234, val_loss=0.000047, IC=-0.0339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000210, val_loss=0.000047, IC=-0.0423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000200, val_loss=0.000044, IC=-0.0361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000192, val_loss=0.000043, IC=-0.0361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000187, val_loss=0.000043, IC=-0.0357\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000191, val_loss=0.000043, IC=-0.0368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=-0.0034 (98.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.256817\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.116786\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.068386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.046247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.037071, val_loss=0.017971, IC=-0.0244\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.028014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.026377\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.025769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.016670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.014355, val_loss=0.006776, IC=-0.0123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.012382\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.010438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.011672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.008412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.007575, val_loss=0.003148, IC=-0.0104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.006606\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.006138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.005115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004413, val_loss=0.001351, IC=-0.0073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003821\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003841\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002589, val_loss=0.000754, IC=+0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001653, val_loss=0.000400, IC=-0.0109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001439\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001045, val_loss=0.000240, IC=-0.0053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000882\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000820\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000704, val_loss=0.000204, IC=+0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000489, val_loss=0.000136, IC=+0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000399\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000435\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000408, val_loss=0.000126, IC=+0.0107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000266, val_loss=0.000094, IC=+0.0071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000205, val_loss=0.000081, IC=+0.0059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000173, val_loss=0.000075, IC=+0.0037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000192, val_loss=0.000068, IC=-0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000163, val_loss=0.000062, IC=-0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000137, val_loss=0.000065, IC=-0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000123, val_loss=0.000062, IC=+0.0038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000118, val_loss=0.000060, IC=+0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000120, val_loss=0.000060, IC=+0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000153, val_loss=0.000060, IC=+0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=50, IC=+0.0107 (110.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=1.252457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.287148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.080949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.044161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.031530, val_loss=0.011992, IC=-0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.023670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.021339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.017844\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.016033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.012300, val_loss=0.003046, IC=-0.0389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.011275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.010198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.014136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.007768\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.006876, val_loss=0.001846, IC=-0.0395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.006990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.005359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.005186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003980, val_loss=0.000858, IC=-0.0271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.004175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002417, val_loss=0.000469, IC=-0.0311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.004853\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001894\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001670, val_loss=0.000237, IC=-0.0139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001810\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001034, val_loss=0.000181, IC=-0.0244\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000955\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000871\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000844\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000744, val_loss=0.000102, IC=-0.0361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000618, val_loss=0.000098, IC=-0.0202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000582\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000439\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000403\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000387, val_loss=0.000064, IC=-0.0202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000352, val_loss=0.000049, IC=-0.0178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000282\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000241, val_loss=0.000046, IC=-0.0270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000210, val_loss=0.000042, IC=-0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000186, val_loss=0.000038, IC=-0.0083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000155, val_loss=0.000035, IC=-0.0109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000153, val_loss=0.000035, IC=-0.0067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000154, val_loss=0.000032, IC=-0.0170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000136, val_loss=0.000032, IC=-0.0164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000146, val_loss=0.000032, IC=-0.0099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000142, val_loss=0.000032, IC=-0.0091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=80, IC=-0.0067 (106.6s, 20 checkpoints)\n",
+      "\n",
+      "  Fold 6: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.139661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.077519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.054252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.038425\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.028292, val_loss=0.012392, IC=+0.0260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.023597\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.017332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.014753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.011544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.009565, val_loss=0.004969, IC=+0.0336\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.008635\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.006802\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.006059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.005269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.004840, val_loss=0.001920, IC=+0.0260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.004046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002819\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002483, val_loss=0.001051, IC=+0.0190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001691, val_loss=0.000589, IC=+0.0417\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000967, val_loss=0.000502, IC=-0.0330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000802\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000618\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000438, val_loss=0.000220, IC=+0.0354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000398\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000381\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000275, val_loss=0.000124, IC=+0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000232\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000187, val_loss=0.000080, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000147, val_loss=0.000073, IC=-0.0236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000090, val_loss=0.000065, IC=+0.0182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000073, val_loss=0.000055, IC=+0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000064, val_loss=0.000053, IC=+0.0095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000051, val_loss=0.000053, IC=+0.0060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000049, val_loss=0.000052, IC=-0.0204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000045, val_loss=0.000050, IC=+0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000049, val_loss=0.000049, IC=+0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000043, val_loss=0.000050, IC=-0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000042, val_loss=0.000050, IC=-0.0107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000042, val_loss=0.000050, IC=-0.0078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0417 (105.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,140 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.232360\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.071876\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.043311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.030538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.023540, val_loss=0.006512, IC=+0.0281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.019197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.015799\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.013568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.012010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.013077, val_loss=0.002202, IC=+0.0150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.008863\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.010483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.006965\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.006195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.005531, val_loss=0.001170, IC=-0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.005198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.004400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.004506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003374, val_loss=0.000584, IC=+0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002975\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002833\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001936, val_loss=0.000496, IC=-0.0241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001715\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001336, val_loss=0.000271, IC=-0.0143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000923\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000842, val_loss=0.000122, IC=-0.0065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000694\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000508, val_loss=0.000083, IC=-0.0150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000384\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000319, val_loss=0.000067, IC=+0.0043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000254, val_loss=0.000048, IC=+0.0056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000171, val_loss=0.000045, IC=-0.0147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000134, val_loss=0.000042, IC=+0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000107, val_loss=0.000037, IC=-0.0032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000094, val_loss=0.000038, IC=+0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000088, val_loss=0.000034, IC=+0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000080, val_loss=0.000034, IC=+0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000072, val_loss=0.000033, IC=+0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000074, val_loss=0.000033, IC=-0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000073, val_loss=0.000033, IC=-0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000071, val_loss=0.000033, IC=+0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0281 (93.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=5, IC=-0.0053 (761.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 5 (IC=-0.0053)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/fx_pairs/run_log/training/e819153914a7/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=16,980 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.670242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.402774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.222682\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.117101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.064095, val_loss=0.058121, IC=-0.0506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.043050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.032670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.025911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.021539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.018619, val_loss=0.015846, IC=-0.0388\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.016927\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.015464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.014411\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.013037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.012034, val_loss=0.005812, IC=-0.0045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.011335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.011049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.010104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.009791\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.009148, val_loss=0.002890, IC=+0.0170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.008532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.008000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.007687\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.007144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.006812, val_loss=0.001535, IC=+0.0305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.006358\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.005988\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.005639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.005504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.005043, val_loss=0.001083, IC=+0.0372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.004661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.004744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.004261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.003930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.003974, val_loss=0.000844, IC=+0.0407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.003734\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.003537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.003330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.003227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002963, val_loss=0.000687, IC=+0.0433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002866\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002498, val_loss=0.000588, IC=+0.0539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001971, val_loss=0.000517, IC=+0.0591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001870\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001739\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001633, val_loss=0.000480, IC=+0.0647\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001418, val_loss=0.000437, IC=+0.0671\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001272, val_loss=0.000419, IC=+0.0694\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001156, val_loss=0.000402, IC=+0.0714\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001092, val_loss=0.000394, IC=+0.0709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001012, val_loss=0.000390, IC=+0.0744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000977\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000973, val_loss=0.000383, IC=+0.0714\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000962\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001001, val_loss=0.000381, IC=+0.0717\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000978\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000941, val_loss=0.000379, IC=+0.0720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000973\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000936, val_loss=0.000378, IC=+0.0724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=80, IC=+0.0744 (64.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=22,140 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.269037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.131241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.085516\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.056724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.039661, val_loss=0.016811, IC=+0.0286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.029444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.023321\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.018653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.015819\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.013801, val_loss=0.004536, IC=-0.0222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.012021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.010619\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.009523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.008203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.007616, val_loss=0.002154, IC=-0.0489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.006919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.006098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.005410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004960\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004461, val_loss=0.001134, IC=-0.0448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002931\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002703, val_loss=0.000672, IC=-0.0374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001831\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001717, val_loss=0.000422, IC=-0.0405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001588\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001132, val_loss=0.000295, IC=-0.0612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000986\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000877\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000812, val_loss=0.000224, IC=-0.0591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000686\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000636, val_loss=0.000189, IC=-0.0460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000528\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000505, val_loss=0.000168, IC=-0.0501\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000430, val_loss=0.000154, IC=-0.0554\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000404\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000381, val_loss=0.000147, IC=-0.0673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000373\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000350, val_loss=0.000144, IC=-0.0803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000334, val_loss=0.000139, IC=-0.0758\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000324\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000320\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000320, val_loss=0.000137, IC=-0.0745\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000311, val_loss=0.000136, IC=-0.0783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000304, val_loss=0.000136, IC=-0.0845\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000305, val_loss=0.000135, IC=-0.0787\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000306, val_loss=0.000135, IC=-0.0830\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000301, val_loss=0.000135, IC=-0.0831\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0286 (89.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.186495\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.074689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.046120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.031770\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.025224, val_loss=0.006064, IC=-0.0408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.021235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.018166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.015777\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.014677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.012608, val_loss=0.002788, IC=-0.0607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.011492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.010146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.009117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.008241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.007451, val_loss=0.001484, IC=-0.0633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.006754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.006186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.005610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.005062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004589, val_loss=0.000867, IC=-0.0744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002990, val_loss=0.000569, IC=-0.0765\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002760\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002525\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002009, val_loss=0.000406, IC=-0.0719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001847\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001428, val_loss=0.000297, IC=-0.0795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001009, val_loss=0.000240, IC=-0.0669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000968\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000914\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000864\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000768, val_loss=0.000201, IC=-0.0801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000735\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000691\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000616, val_loss=0.000176, IC=-0.0639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000549\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000524, val_loss=0.000160, IC=-0.0708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000455, val_loss=0.000149, IC=-0.0636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000406, val_loss=0.000141, IC=-0.0566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000399\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000384\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000388\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000380, val_loss=0.000137, IC=-0.0598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000360\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000361, val_loss=0.000134, IC=-0.0578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000357\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000344, val_loss=0.000133, IC=-0.0519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000337\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000337, val_loss=0.000132, IC=-0.0478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000337\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000333, val_loss=0.000131, IC=-0.0474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000331\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000331, val_loss=0.000131, IC=-0.0457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000330, val_loss=0.000131, IC=-0.0457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=-0.0408 (107.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.379635\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.091643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.060502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.039991\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.029220, val_loss=0.011671, IC=-0.0061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.022347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.017895\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.014862\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.012578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.010704, val_loss=0.003322, IC=+0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.009463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.008468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.007384\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.006739\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.006000, val_loss=0.001466, IC=+0.0159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.005443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.004954\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.004399\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003715, val_loss=0.000874, IC=+0.0107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002891\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002620\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002493, val_loss=0.000572, IC=+0.0072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001963\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001845\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001702, val_loss=0.000379, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001219, val_loss=0.000286, IC=-0.0065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000958, val_loss=0.000224, IC=-0.0060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000900\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000856\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000794\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000763, val_loss=0.000186, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000736\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000636, val_loss=0.000165, IC=-0.0155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000548, val_loss=0.000148, IC=-0.0192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000526\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000495\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000487, val_loss=0.000137, IC=-0.0172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000456\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000460, val_loss=0.000130, IC=-0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000418, val_loss=0.000126, IC=-0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000401\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000394, val_loss=0.000121, IC=-0.0187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000396\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000386, val_loss=0.000119, IC=-0.0193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000388\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000385\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000378, val_loss=0.000118, IC=-0.0201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000373\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000377\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000373, val_loss=0.000117, IC=-0.0193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000369, val_loss=0.000117, IC=-0.0206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000369\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000365, val_loss=0.000117, IC=-0.0206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0159 (116.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.267219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.129828\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.072933\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.050735\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.038175, val_loss=0.020156, IC=-0.0322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.030400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.025729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.021278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.018238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.015556, val_loss=0.007918, IC=+0.0069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.013494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.011639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.010160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.008823\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.007815, val_loss=0.003105, IC=+0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.007022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.006084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.005580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004941\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004337, val_loss=0.001398, IC=+0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003899\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002625, val_loss=0.000720, IC=-0.0090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001901\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001590, val_loss=0.000502, IC=-0.0177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001052, val_loss=0.000401, IC=-0.0167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000957\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000900\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000834\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000725, val_loss=0.000336, IC=-0.0150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000690\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000553, val_loss=0.000299, IC=-0.0110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000518\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000429, val_loss=0.000273, IC=-0.0170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000351, val_loss=0.000254, IC=-0.0181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000320\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000309, val_loss=0.000243, IC=-0.0185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000292\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000282, val_loss=0.000235, IC=-0.0183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000262, val_loss=0.000231, IC=-0.0172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000254, val_loss=0.000227, IC=-0.0161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000241, val_loss=0.000225, IC=-0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000239, val_loss=0.000224, IC=-0.0201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000235, val_loss=0.000223, IC=-0.0192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000234, val_loss=0.000223, IC=-0.0195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000233, val_loss=0.000223, IC=-0.0192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0069 (101.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=1.322059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.328853\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.096994\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.047369\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.034596, val_loss=0.014298, IC=-0.0133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.026425\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.021895\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.018339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.015436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.013438, val_loss=0.003822, IC=-0.0607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.012138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.010761\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.009462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.008524\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.007509, val_loss=0.001816, IC=-0.0675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.006811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.006116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.005581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004954\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004563, val_loss=0.001045, IC=-0.0623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003731\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002824, val_loss=0.000560, IC=-0.0693\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001954\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001805, val_loss=0.000351, IC=-0.0639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001531\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001251, val_loss=0.000255, IC=-0.0507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000930\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000872, val_loss=0.000196, IC=-0.0519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000841\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000747\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000705\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000669, val_loss=0.000154, IC=-0.0498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000529\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000512, val_loss=0.000137, IC=-0.0481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000497\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000440\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000423, val_loss=0.000124, IC=-0.0477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000404\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000390\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000381\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000370, val_loss=0.000115, IC=-0.0423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000358\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000326, val_loss=0.000109, IC=-0.0447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000302, val_loss=0.000106, IC=-0.0420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000286, val_loss=0.000103, IC=-0.0420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000271, val_loss=0.000102, IC=-0.0461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000265, val_loss=0.000102, IC=-0.0443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000266, val_loss=0.000101, IC=-0.0429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000259, val_loss=0.000101, IC=-0.0426\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000260, val_loss=0.000101, IC=-0.0428\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=-0.0133 (90.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.150940\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.086218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.058861\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.041239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.030552, val_loss=0.013391, IC=+0.0471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.023169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.018337\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.014728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.012074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.009908, val_loss=0.004028, IC=+0.0410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.008115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.006949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.005933\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.005009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.004296, val_loss=0.001784, IC=+0.0395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.003740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.002784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002122, val_loss=0.001008, IC=+0.0312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001882\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001118, val_loss=0.000603, IC=+0.0090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000891\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000648, val_loss=0.000421, IC=-0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000445\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000402, val_loss=0.000337, IC=-0.0235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000285, val_loss=0.000290, IC=-0.0392\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000220, val_loss=0.000261, IC=-0.0322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000188, val_loss=0.000249, IC=-0.0391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000164, val_loss=0.000242, IC=-0.0374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000152, val_loss=0.000236, IC=-0.0351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000146, val_loss=0.000235, IC=-0.0328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000141, val_loss=0.000233, IC=-0.0288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000137, val_loss=0.000232, IC=-0.0290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000136, val_loss=0.000231, IC=-0.0274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000134, val_loss=0.000230, IC=-0.0273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000135, val_loss=0.000230, IC=-0.0287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000134, val_loss=0.000230, IC=-0.0285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000133, val_loss=0.000230, IC=-0.0288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0471 (91.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,060 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.243717\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.078227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.045688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.031296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.022784, val_loss=0.006629, IC=+0.0472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.018117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.014961\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.012639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.010521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.008743, val_loss=0.002077, IC=+0.0132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.007646\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.006309\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.005548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.004796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.004043, val_loss=0.000959, IC=-0.0190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.003513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.002652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002001, val_loss=0.000460, IC=-0.0129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001039, val_loss=0.000274, IC=-0.0182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000848\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000751\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000616, val_loss=0.000191, IC=-0.0155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000425\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000399, val_loss=0.000156, IC=-0.0110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000284, val_loss=0.000140, IC=-0.0018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000227, val_loss=0.000134, IC=-0.0199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000193, val_loss=0.000128, IC=+0.0110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000174, val_loss=0.000126, IC=-0.0046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000166, val_loss=0.000125, IC=-0.0086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000159, val_loss=0.000124, IC=+0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000155, val_loss=0.000124, IC=-0.0036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000153, val_loss=0.000123, IC=-0.0038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000151, val_loss=0.000123, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000150, val_loss=0.000123, IC=-0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000149, val_loss=0.000123, IC=-0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000150, val_loss=0.000123, IC=-0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000149, val_loss=0.000123, IC=-0.0089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0472 (92.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=5, IC=-0.0026 (755.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 5 (IC=-0.0026)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/fx_pairs/run_log/training/3dd0db7c7ac4/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=16,660 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.671051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.401407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.225416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.118809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.063206, val_loss=0.060745, IC=-0.1094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.042999\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.033582\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.026512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.021809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.019810, val_loss=0.016632, IC=-0.0943\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.017565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.015915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.014893\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.014175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.012554, val_loss=0.006827, IC=-0.0374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.012029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.011387\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.010568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.009965\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.009474, val_loss=0.003832, IC=-0.0197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.008730\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.008442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.008107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.007729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.007079, val_loss=0.002568, IC=-0.0129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.006751\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.006608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.006250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.006075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.005788, val_loss=0.001962, IC=+0.0139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.005448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.005218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.004808\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.004553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.004317, val_loss=0.001748, IC=+0.0130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.004262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.004071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.003931\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.003689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.003435, val_loss=0.001561, IC=+0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.003513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.003246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.003155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.003109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.003053, val_loss=0.001481, IC=+0.0205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002878\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002791\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002681\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002447, val_loss=0.001436, IC=+0.0239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002231, val_loss=0.001412, IC=+0.0130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001998, val_loss=0.001369, IC=+0.0224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001912\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001890, val_loss=0.001339, IC=+0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001761\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001742\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001738, val_loss=0.001327, IC=+0.0209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001657\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001665\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001610, val_loss=0.001319, IC=+0.0262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001575\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001565, val_loss=0.001326, IC=+0.0206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001527\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001514, val_loss=0.001320, IC=+0.0190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001564\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001512\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001530, val_loss=0.001312, IC=+0.0205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001471, val_loss=0.001311, IC=+0.0198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001531\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001530, val_loss=0.001310, IC=+0.0201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=75, IC=+0.0262 (77.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n",
+      "    train=21,820 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.266300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.136370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.088410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.058962\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.040979, val_loss=0.016530, IC=+0.0778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.030546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.024007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.019754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.016911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.014339, val_loss=0.004845, IC=-0.0144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.012818\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.011157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.010019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.008844\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.008075, val_loss=0.002614, IC=-0.0590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.007403\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.006638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.006052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.005521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.005051, val_loss=0.001605, IC=-0.0444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.004247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003871\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003329, val_loss=0.001177, IC=-0.0932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002349, val_loss=0.000878, IC=-0.0513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001927\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001879\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001725, val_loss=0.000781, IC=-0.1082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001448, val_loss=0.000678, IC=-0.0806\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001392\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001219, val_loss=0.000637, IC=-0.0794\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001124, val_loss=0.000628, IC=-0.1205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001031, val_loss=0.000598, IC=-0.0753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000998\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000999, val_loss=0.000602, IC=-0.1054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000963\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000969, val_loss=0.000587, IC=-0.0905\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000963\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000954\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000947, val_loss=0.000580, IC=-0.0764\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000940\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000936\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000931\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000934, val_loss=0.000583, IC=-0.0981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000924\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000917\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000923\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000918, val_loss=0.000582, IC=-0.0967\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000921\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000912, val_loss=0.000582, IC=-0.0990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000909\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000911\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000909\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000909, val_loss=0.000582, IC=-0.0988\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000901\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000917\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000904, val_loss=0.000580, IC=-0.0960\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000903\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000917\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000915, val_loss=0.000580, IC=-0.0946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0778 (88.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n",
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.185784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.074249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.046080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.033251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.025603, val_loss=0.006195, IC=-0.0594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.021798\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.018952\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.016595\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.014670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.012969, val_loss=0.003131, IC=-0.0991\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.011795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.010601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.009652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.008784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.007814, val_loss=0.001814, IC=-0.1171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.007343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.006615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.006078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.005533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.005162, val_loss=0.001221, IC=-0.1230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.004336\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.004008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003491, val_loss=0.000891, IC=-0.1085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.003021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002842\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002535, val_loss=0.000725, IC=-0.1193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002381\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001992, val_loss=0.000636, IC=-0.0839\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001790\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001706\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001616\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001554, val_loss=0.000569, IC=-0.0760\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001449\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001413\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001324, val_loss=0.000527, IC=-0.0623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001186, val_loss=0.000504, IC=-0.0514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001076, val_loss=0.000493, IC=-0.0469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001013, val_loss=0.000481, IC=-0.0304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000994\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000965\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000962, val_loss=0.000474, IC=-0.0130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000951\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000953\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000940\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000940\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000940, val_loss=0.000470, IC=+0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000925\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000905\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000919, val_loss=0.000467, IC=-0.0093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000912\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000903\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000894, val_loss=0.000467, IC=-0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000897\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000895\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000888, val_loss=0.000465, IC=-0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000885\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000887\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000881, val_loss=0.000464, IC=-0.0025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000883\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000876\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000880\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000881\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000888, val_loss=0.000464, IC=-0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000891\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000878\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000885\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000878, val_loss=0.000464, IC=-0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=70, IC=+0.0016 (64.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n",
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.386412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.092252\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.061381\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.040963\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.030150, val_loss=0.012283, IC=-0.0247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.023299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.018572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.015430\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.013024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.011431, val_loss=0.003592, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.010240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.008902\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.008035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.007296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.006415, val_loss=0.001699, IC=+0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.005972\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.005429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.004969\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.004634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004174, val_loss=0.001043, IC=-0.0063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003882\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002924, val_loss=0.000739, IC=-0.0180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002738\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002172, val_loss=0.000585, IC=-0.0370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001995\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001723, val_loss=0.000500, IC=-0.0428\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001682\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001561\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001455, val_loss=0.000449, IC=-0.0463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001360\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001316\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001278, val_loss=0.000423, IC=-0.0719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001146, val_loss=0.000401, IC=-0.0674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001068, val_loss=0.000386, IC=-0.0615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001003, val_loss=0.000376, IC=-0.0531\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000996\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000989\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000971, val_loss=0.000368, IC=-0.0521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000956\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000940\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000933, val_loss=0.000368, IC=-0.0644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000928\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000924\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000921\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000912, val_loss=0.000363, IC=-0.0537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000899\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000901, val_loss=0.000361, IC=-0.0541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000903\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000900\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000901\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000906\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000894, val_loss=0.000360, IC=-0.0529\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000885\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000902\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000893, val_loss=0.000359, IC=-0.0544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000897\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000887\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000894\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000885, val_loss=0.000359, IC=-0.0552\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000891\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000885\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000887\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000888, val_loss=0.000359, IC=-0.0555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=15, IC=+0.0049 (62.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n",
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.270465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.132019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.073660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.051268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.038861, val_loss=0.021041, IC=-0.0469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.031364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.026485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.021540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.018141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.015947, val_loss=0.008349, IC=+0.0163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.014014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.012045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.010675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.009411\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.008492, val_loss=0.003732, IC=+0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.007458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.006569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.005825\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.005361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.004761, val_loss=0.001970, IC=+0.0090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002997, val_loss=0.001359, IC=-0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002763\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002545\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002377\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002054, val_loss=0.001085, IC=-0.0151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001887\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001771\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001488, val_loss=0.000961, IC=-0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001172, val_loss=0.000872, IC=-0.0136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000961, val_loss=0.000832, IC=-0.0125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000955\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000916\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000899\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000883\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000860, val_loss=0.000803, IC=-0.0192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000839\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000829\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000791, val_loss=0.000789, IC=-0.0194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000780\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000759\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000747, val_loss=0.000778, IC=-0.0187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000738\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000722\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000713, val_loss=0.000769, IC=-0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000707\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000710\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000705\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000698, val_loss=0.000769, IC=-0.0167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000698\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000693\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000691\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000693, val_loss=0.000763, IC=-0.0207\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000676, val_loss=0.000762, IC=-0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000671, val_loss=0.000759, IC=-0.0241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000667, val_loss=0.000760, IC=-0.0220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000671\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000672, val_loss=0.000759, IC=-0.0214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000675, val_loss=0.000759, IC=-0.0218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0163 (77.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=1.317631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.326477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.097445\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.048272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.035502, val_loss=0.014377, IC=+0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.026825\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.022186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.018462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.016314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.014077, val_loss=0.003883, IC=-0.0489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.012377\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.011166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.010146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.009111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.008198, val_loss=0.002138, IC=-0.0520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.007390\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.006558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.006044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.005459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.005007, val_loss=0.001270, IC=-0.0490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.004602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.004262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003887\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003364, val_loss=0.000815, IC=-0.0469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002806\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002277, val_loss=0.000597, IC=-0.0392\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001916\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001786\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001709, val_loss=0.000506, IC=-0.0351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001588\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001338, val_loss=0.000449, IC=-0.0405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001091, val_loss=0.000414, IC=-0.0295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000999\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000957\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000938, val_loss=0.000398, IC=-0.0261\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000918\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000907\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000890\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000870\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000851, val_loss=0.000390, IC=-0.0317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000836\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000819\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000794\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000796, val_loss=0.000384, IC=-0.0329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000779\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000770\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000762\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000758, val_loss=0.000380, IC=-0.0378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000738\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000739\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000721, val_loss=0.000379, IC=-0.0444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000729\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000701\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000711, val_loss=0.000377, IC=-0.0393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000688, val_loss=0.000377, IC=-0.0419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000690\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000695\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000687, val_loss=0.000377, IC=-0.0438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000685\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000689\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000683, val_loss=0.000376, IC=-0.0441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000687\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000685\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000685\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000678, val_loss=0.000376, IC=-0.0442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000687\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000673\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000687, val_loss=0.000376, IC=-0.0438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0022 (115.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.151746\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.087275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.060028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.042581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.031003, val_loss=0.013787, IC=+0.0263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.023442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.018502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.014910\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.012365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.010158, val_loss=0.004835, IC=+0.0068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.008703\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.007342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.006424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.005350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.004629, val_loss=0.002510, IC=-0.0281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.004120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002760\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002453, val_loss=0.001765, IC=-0.0543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001482, val_loss=0.001427, IC=-0.0857\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000976, val_loss=0.001264, IC=-0.1104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000924\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000858\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000779\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000742, val_loss=0.001172, IC=-0.1089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000701\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000615, val_loss=0.001142, IC=-0.0787\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000548, val_loss=0.001105, IC=-0.0615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000509, val_loss=0.001097, IC=-0.0377\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000499\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000489, val_loss=0.001091, IC=-0.0343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000474, val_loss=0.001090, IC=-0.0325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000471, val_loss=0.001081, IC=-0.0342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000468\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000462, val_loss=0.001078, IC=-0.0355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000460, val_loss=0.001071, IC=-0.0342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000460, val_loss=0.001078, IC=-0.0361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000460\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000459, val_loss=0.001076, IC=-0.0357\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000456\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000455\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000458, val_loss=0.001076, IC=-0.0346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000457, val_loss=0.001077, IC=-0.0345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000456\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000456\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000456, val_loss=0.001077, IC=-0.0344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0263 (119.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n",
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=4,740 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.245096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.079407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.045825\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.031841\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.022955, val_loss=0.006850, IC=+0.1295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.018077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.015228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.013010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.011153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.009531, val_loss=0.002293, IC=+0.0692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.007876\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.006787\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.005878\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.005188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.004690, val_loss=0.001149, IC=+0.0565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.004000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.002812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002487, val_loss=0.000707, IC=+0.0589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001515, val_loss=0.000543, IC=+0.0603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001047, val_loss=0.000479, IC=+0.0813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000935\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000894\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000840\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000811, val_loss=0.000454, IC=+0.0894\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000788\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000753\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000728\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000697, val_loss=0.000445, IC=+0.0935\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000677\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000651\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000628, val_loss=0.000443, IC=+0.0941\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000602\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000594, val_loss=0.000441, IC=+0.1199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000582\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000582\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000574, val_loss=0.000442, IC=+0.1100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000566, val_loss=0.000441, IC=+0.0993\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000557, val_loss=0.000444, IC=+0.0936\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000553, val_loss=0.000442, IC=+0.0971\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000554\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000549, val_loss=0.000443, IC=+0.0861\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000550, val_loss=0.000444, IC=+0.0877\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000549\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000548, val_loss=0.000443, IC=+0.0926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000545\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000547, val_loss=0.000443, IC=+0.0952\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000549\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000547, val_loss=0.000443, IC=+0.0934\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000546, val_loss=0.000443, IC=+0.0943\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.1295 (114.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=5, IC=-0.0019 (719.7s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 5 (IC=-0.0019)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/fx_pairs/run_log/training/acb22e8ad2b9/diagnostics\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (60, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>complete</th><th>ic_mean</th><th>ic_t</th><th>training_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>bool</td><td>f64</td><td>f64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>true</td><td>-0.00532</td><td>-0.62251</td><td>&quot;e819153914a7&quot;</td><td>&quot;2d40c8d007d5&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>true</td><td>-0.009135</td><td>-1.129905</td><td>&quot;e819153914a7&quot;</td><td>&quot;8ef3bde90395&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>true</td><td>-0.013354</td><td>-2.057821</td><td>&quot;e819153914a7&quot;</td><td>&quot;0a255defe5e9&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>20</td><td>true</td><td>-0.010913</td><td>-1.878373</td><td>&quot;e819153914a7&quot;</td><td>&quot;0016f5cad4b6&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>true</td><td>-0.009541</td><td>-1.25812</td><td>&quot;e819153914a7&quot;</td><td>&quot;bdad9d8ac4eb&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>80</td><td>true</td><td>-0.020849</td><td>-1.387619</td><td>&quot;3dd0db7c7ac4&quot;</td><td>&quot;3c28fb5b1b04&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>85</td><td>true</td><td>-0.022006</td><td>-1.478283</td><td>&quot;3dd0db7c7ac4&quot;</td><td>&quot;3c6edc67f912&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>90</td><td>true</td><td>-0.021652</td><td>-1.501848</td><td>&quot;3dd0db7c7ac4&quot;</td><td>&quot;4304ac6a53f8&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>95</td><td>true</td><td>-0.022085</td><td>-1.506117</td><td>&quot;3dd0db7c7ac4&quot;</td><td>&quot;cba3109e01b8&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>true</td><td>-0.022106</td><td>-1.501849</td><td>&quot;3dd0db7c7ac4&quot;</td><td>&quot;38e5b89050aa&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (60, 9)\n",
+       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐\n",
+       "│ label     ┆ config_na ┆ checkpoin ┆ checkpoin ┆ … ┆ ic_mean   ┆ ic_t      ┆ training_ ┆ predicti │\n",
+       "│ ---       ┆ me        ┆ t_kind    ┆ t_value   ┆   ┆ ---       ┆ ---       ┆ hash      ┆ on_hash  │\n",
+       "│ str       ┆ ---       ┆ ---       ┆ ---       ┆   ┆ f64       ┆ f64       ┆ ---       ┆ ---      │\n",
+       "│           ┆ str       ┆ str       ┆ i64       ┆   ┆           ┆           ┆ str       ┆ str      │\n",
+       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
+       "│ fwd_ret_1 ┆ nlinear   ┆ epoch     ┆ 5         ┆ … ┆ -0.00532  ┆ -0.62251  ┆ e81915391 ┆ 2d40c8d0 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 4a7       ┆ 07d5     │\n",
+       "│ fwd_ret_1 ┆ nlinear   ┆ epoch     ┆ 10        ┆ … ┆ -0.009135 ┆ -1.129905 ┆ e81915391 ┆ 8ef3bde9 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 4a7       ┆ 0395     │\n",
+       "│ fwd_ret_1 ┆ nlinear   ┆ epoch     ┆ 15        ┆ … ┆ -0.013354 ┆ -2.057821 ┆ e81915391 ┆ 0a255def │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 4a7       ┆ e5e9     │\n",
+       "│ fwd_ret_1 ┆ nlinear   ┆ epoch     ┆ 20        ┆ … ┆ -0.010913 ┆ -1.878373 ┆ e81915391 ┆ 0016f5ca │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 4a7       ┆ d4b6     │\n",
+       "│ fwd_ret_1 ┆ nlinear   ┆ epoch     ┆ 25        ┆ … ┆ -0.009541 ┆ -1.25812  ┆ e81915391 ┆ bdad9d8a │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 4a7       ┆ c4eb     │\n",
+       "│ …         ┆ …         ┆ …         ┆ …         ┆ … ┆ …         ┆ …         ┆ …         ┆ …        │\n",
+       "│ fwd_ret_5 ┆ nlinear   ┆ epoch     ┆ 80        ┆ … ┆ -0.020849 ┆ -1.387619 ┆ 3dd0db7c7 ┆ 3c28fb5b │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ ac4       ┆ 1b04     │\n",
+       "│ fwd_ret_5 ┆ nlinear   ┆ epoch     ┆ 85        ┆ … ┆ -0.022006 ┆ -1.478283 ┆ 3dd0db7c7 ┆ 3c6edc67 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ ac4       ┆ f912     │\n",
+       "│ fwd_ret_5 ┆ nlinear   ┆ epoch     ┆ 90        ┆ … ┆ -0.021652 ┆ -1.501848 ┆ 3dd0db7c7 ┆ 4304ac6a │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ ac4       ┆ 53f8     │\n",
+       "│ fwd_ret_5 ┆ nlinear   ┆ epoch     ┆ 95        ┆ … ┆ -0.022085 ┆ -1.506117 ┆ 3dd0db7c7 ┆ cba3109e │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ ac4       ┆ 01b8     │\n",
+       "│ fwd_ret_5 ┆ nlinear   ┆ epoch     ┆ 100       ┆ … ┆ -0.022106 ┆ -1.501849 ┆ 3dd0db7c7 ┆ 38e5b890 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ ac4       ┆ 50aa     │\n",
+       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "if len(plan.expected_prediction_hashes) != checkpoint_schedule.height * len(labels):\n",
     "    raise RuntimeError(\"the plan does not cover every declared epoch checkpoint on every label\")\n",
@@ -354,13 +17923,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9f10b0a",
+   "id": "5536f2f5",
    "metadata": {
     "papermill": {
-     "duration": 0.033961,
-     "end_time": "2026-09-06T17:47:33.284814+00:00",
+     "duration": 0.118025,
+     "end_time": "2026-09-08T23:16:26.584948+00:00",
      "exception": false,
-     "start_time": "2026-09-06T17:47:33.250853+00:00",
+     "start_time": "2026-09-08T23:16:26.466923+00:00",
      "status": "completed"
     }
    },
@@ -373,14 +17942,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a730bee8",
+   "execution_count": 6,
+   "id": "da4f0c65",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T23:16:26.778297Z",
+     "iopub.status.busy": "2026-09-08T23:16:26.778117Z",
+     "iopub.status.idle": "2026-09-08T23:16:32.480652Z",
+     "shell.execute_reply": "2026-09-08T23:16:32.480196Z"
+    },
+    "papermill": {
+     "duration": 5.802195,
+     "end_time": "2026-09-08T23:16:32.484471+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T23:16:26.682276+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Official prediction population: ea2d3f2ce99d\n"
+     ]
+    }
+   ],
    "source": [
     "replayed = plan.run()\n",
     "if set(replayed.catalog_rows.get_column(\"prediction_hash\")) != set(\n",
@@ -397,13 +17987,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1627536",
+   "id": "249f4bf8",
    "metadata": {
     "papermill": {
-     "duration": 0.040288,
-     "end_time": "2026-09-06T17:47:35.143379+00:00",
+     "duration": 0.194997,
+     "end_time": "2026-09-08T23:16:32.882310+00:00",
      "exception": false,
-     "start_time": "2026-09-06T17:47:35.103091+00:00",
+     "start_time": "2026-09-08T23:16:32.687313+00:00",
      "status": "completed"
     }
    },
@@ -436,6 +18026,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T23:16:59.791516+00:00",
+   "executor": "local-uv",
+   "library_digest": "5035256203a959728f64b8eb5a2047d91229b302459b7a4274f0b128e0dd11f8",
+   "outputs_digest": "ba4b8b6c45b133b271aa8b5537e4c48a18ad6824b3fcb8658924f7e7367a558d",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "5f5d23848254ea4362f0e40a69c8ea3b47fdf509"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2394.312101,
+   "end_time": "2026-09-08T23:16:36.301105+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/fx_pairs/.10_dl_nlinear.build.1405470.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/fx_pairs/.10_dl_nlinear.papermill.1405470.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T22:36:41.989004+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/fx_pairs/10a_dl_lstm.ipynb
+++ b/case_studies/fx_pairs/10a_dl_lstm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d7233e6e",
+   "id": "3b2a4998",
    "metadata": {
     "papermill": {
-     "duration": 0.001961,
-     "end_time": "2026-09-06T18:15:57.077943+00:00",
+     "duration": 0.000929,
+     "end_time": "2026-09-08T22:00:32.234787+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:15:57.075982+00:00",
+     "start_time": "2026-09-08T22:00:32.233858+00:00",
      "status": "completed"
     }
    },
@@ -36,9 +36,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "64d82587",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "9710f1fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:32.237316Z",
+     "iopub.status.busy": "2026-09-08T22:00:32.237066Z",
+     "iopub.status.idle": "2026-09-08T22:00:35.148953Z",
+     "shell.execute_reply": "2026-09-08T22:00:35.148348Z"
+    },
+    "papermill": {
+     "duration": 2.914514,
+     "end_time": "2026-09-08T22:00:35.150075+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:32.235561+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit and catalog the published LSTM FX configuration.\"\"\"\n",
@@ -62,9 +76,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bf1a9540",
+   "execution_count": 2,
+   "id": "238be022",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:35.154043Z",
+     "iopub.status.busy": "2026-09-08T22:00:35.153917Z",
+     "iopub.status.idle": "2026-09-08T22:00:35.156492Z",
+     "shell.execute_reply": "2026-09-08T22:00:35.156033Z"
+    },
+    "papermill": {
+     "duration": 0.005038,
+     "end_time": "2026-09-08T22:00:35.156910+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:35.151872+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -94,13 +121,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f022bb01",
+   "id": "ae828cd3",
    "metadata": {
     "papermill": {
-     "duration": 0.001241,
-     "end_time": "2026-09-06T18:16:03.412120+00:00",
+     "duration": 0.001086,
+     "end_time": "2026-09-08T22:00:35.159432+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:16:03.410879+00:00",
+     "start_time": "2026-09-08T22:00:35.158346+00:00",
      "status": "completed"
     }
    },
@@ -114,10 +141,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0f909bae",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "id": "718f7540",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:35.161672Z",
+     "iopub.status.busy": "2026-09-08T22:00:35.161565Z",
+     "iopub.status.idle": "2026-09-08T22:00:38.124597Z",
+     "shell.execute_reply": "2026-09-08T22:00:38.124216Z"
+    },
+    "papermill": {
+     "duration": 2.965133,
+     "end_time": "2026-09-08T22:00:38.125317+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:35.160184+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Labels: fwd_ret_1d, fwd_ret_5d, fwd_ret_21d\n",
+      "Execution tier: canonical\n",
+      "Device: cuda\n",
+      "Lookback: 60 consecutive daily observations\n",
+      "Eligible validation rows, fwd_ret_1d: 41,260\n",
+      "Eligible validation rows, fwd_ret_5d: 41,180\n",
+      "Eligible validation rows, fwd_ret_21d: 40,860\n",
+      "Configured deep_learning models this notebook does not run, fwd_ret_1d: ['nlinear', 'tcn']\n",
+      "Configured deep_learning models this notebook does not run, fwd_ret_5d: ['nlinear', 'tcn']\n",
+      "Configured deep_learning models this notebook does not run, fwd_ret_21d: ['nlinear', 'tcn']\n"
+     ]
+    }
+   ],
    "source": [
     "set_global_seeds(SEED)\n",
     "# The reductions are read before the study is opened, because which study to open is decided by\n",
@@ -234,13 +292,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "258e0f71",
+   "id": "0cd8d40d",
    "metadata": {
     "papermill": {
-     "duration": 0.005419,
-     "end_time": "2026-09-06T18:16:14.110744+00:00",
+     "duration": 0.001199,
+     "end_time": "2026-09-08T22:00:38.128059+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:16:14.105325+00:00",
+     "start_time": "2026-09-08T22:00:38.126860+00:00",
      "status": "completed"
     }
    },
@@ -253,10 +311,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f36d18a9",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "3ecb7139",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:38.131473Z",
+     "iopub.status.busy": "2026-09-08T22:00:38.131358Z",
+     "iopub.status.idle": "2026-09-08T22:00:38.135807Z",
+     "shell.execute_reply": "2026-09-08T22:00:38.135351Z"
+    },
+    "papermill": {
+     "duration": 0.006978,
+     "end_time": "2026-09-08T22:00:38.136340+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:38.129362+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (20, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>kind</th><th>value</th></tr><tr><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;epoch&quot;</td><td>5</td></tr><tr><td>&quot;epoch&quot;</td><td>10</td></tr><tr><td>&quot;epoch&quot;</td><td>15</td></tr><tr><td>&quot;epoch&quot;</td><td>20</td></tr><tr><td>&quot;epoch&quot;</td><td>25</td></tr><tr><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;epoch&quot;</td><td>80</td></tr><tr><td>&quot;epoch&quot;</td><td>85</td></tr><tr><td>&quot;epoch&quot;</td><td>90</td></tr><tr><td>&quot;epoch&quot;</td><td>95</td></tr><tr><td>&quot;epoch&quot;</td><td>100</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (20, 2)\n",
+       "┌───────┬───────┐\n",
+       "│ kind  ┆ value │\n",
+       "│ ---   ┆ ---   │\n",
+       "│ str   ┆ i64   │\n",
+       "╞═══════╪═══════╡\n",
+       "│ epoch ┆ 5     │\n",
+       "│ epoch ┆ 10    │\n",
+       "│ epoch ┆ 15    │\n",
+       "│ epoch ┆ 20    │\n",
+       "│ epoch ┆ 25    │\n",
+       "│ …     ┆ …     │\n",
+       "│ epoch ┆ 80    │\n",
+       "│ epoch ┆ 85    │\n",
+       "│ epoch ┆ 90    │\n",
+       "│ epoch ┆ 95    │\n",
+       "│ epoch ┆ 100   │\n",
+       "└───────┴───────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "checkpoint_schedule = pl.DataFrame(computation[\"checkpoint_schedule\"])\n",
     "pl.DataFrame(\n",
@@ -275,13 +385,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a35dd8d0",
+   "id": "cf483028",
    "metadata": {
     "papermill": {
-     "duration": 0.001691,
-     "end_time": "2026-09-06T18:16:14.139738+00:00",
+     "duration": 0.001297,
+     "end_time": "2026-09-08T22:00:38.139229+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:16:14.138047+00:00",
+     "start_time": "2026-09-08T22:00:38.137932+00:00",
      "status": "completed"
     }
    },
@@ -308,14 +418,17431 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3948481c",
+   "execution_count": 5,
+   "id": "7fcfc8dc",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:00:38.142797Z",
+     "iopub.status.busy": "2026-09-08T22:00:38.142692Z",
+     "iopub.status.idle": "2026-09-08T22:36:10.319794Z",
+     "shell.execute_reply": "2026-09-08T22:36:10.319343Z"
+    },
+    "papermill": {
+     "duration": 2132.288014,
+     "end_time": "2026-09-08T22:36:10.428652+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:00:38.140638+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=17,060 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000358\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000080, val_loss=0.000092, IC=+0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000055, val_loss=0.000072, IC=+0.0078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000049, val_loss=0.000068, IC=-0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000046, val_loss=0.000066, IC=-0.0071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000045, val_loss=0.000064, IC=-0.0151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000049, val_loss=0.000063, IC=-0.0133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000044, val_loss=0.000063, IC=-0.0142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000043, val_loss=0.000062, IC=-0.0182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000042, val_loss=0.000063, IC=-0.0167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000042, val_loss=0.000063, IC=-0.0166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000045, val_loss=0.000062, IC=-0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000041, val_loss=0.000062, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000041, val_loss=0.000062, IC=-0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000041, val_loss=0.000062, IC=-0.0118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000041, val_loss=0.000062, IC=-0.0124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000041, val_loss=0.000062, IC=-0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000041, val_loss=0.000062, IC=-0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000041, val_loss=0.000062, IC=-0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000041, val_loss=0.000062, IC=-0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000041, val_loss=0.000062, IC=-0.0103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0122 (39.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n",
+      "    train=22,220 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000070, val_loss=0.000035, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000055, val_loss=0.000031, IC=-0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000051, val_loss=0.000029, IC=-0.0095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000049, val_loss=0.000028, IC=-0.0063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000048, val_loss=0.000027, IC=-0.0095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000047, val_loss=0.000027, IC=+0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000047, val_loss=0.000027, IC=-0.0036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000046, val_loss=0.000027, IC=-0.0110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000046, val_loss=0.000027, IC=-0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000046, val_loss=0.000027, IC=-0.0089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000046, val_loss=0.000027, IC=-0.0099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000046, val_loss=0.000027, IC=-0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000045, val_loss=0.000027, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000045, val_loss=0.000027, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000045, val_loss=0.000027, IC=-0.0105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000045, val_loss=0.000027, IC=-0.0141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000045, val_loss=0.000027, IC=-0.0107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000045, val_loss=0.000027, IC=-0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000045, val_loss=0.000027, IC=-0.0103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000045, val_loss=0.000027, IC=-0.0108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=30, IC=+0.0040 (55.3s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000057, val_loss=0.000029, IC=-0.0095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000052, val_loss=0.000028, IC=+0.0107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000055, val_loss=0.000027, IC=-0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000044, val_loss=0.000025, IC=+0.0174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000045, val_loss=0.000025, IC=+0.0476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000046, val_loss=0.000028, IC=+0.0104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000050, val_loss=0.000027, IC=+0.0094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000044, val_loss=0.000025, IC=+0.0038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000042, val_loss=0.000024, IC=+0.0267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000051, val_loss=0.000030, IC=+0.0374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000048, val_loss=0.000026, IC=+0.0140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000041, val_loss=0.000024, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000043, val_loss=0.000024, IC=+0.0115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000044, val_loss=0.000027, IC=+0.0145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000045, val_loss=0.000025, IC=+0.0195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000042, val_loss=0.000024, IC=+0.0166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000042, val_loss=0.000024, IC=+0.0213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000047, val_loss=0.000024, IC=+0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000041, val_loss=0.000024, IC=+0.0173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000043, val_loss=0.000024, IC=+0.0199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0476 (60.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000058, val_loss=0.000024, IC=-0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000049, val_loss=0.000022, IC=-0.0254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000043, val_loss=0.000019, IC=-0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000045, val_loss=0.000021, IC=-0.0376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000043, val_loss=0.000022, IC=-0.0228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000041, val_loss=0.000018, IC=-0.0146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000048, val_loss=0.000020, IC=-0.0294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000050, val_loss=0.000026, IC=+0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000047, val_loss=0.000020, IC=-0.0117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000041, val_loss=0.000019, IC=-0.0201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000049, val_loss=0.000019, IC=-0.0362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000043, val_loss=0.000018, IC=+0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000040, val_loss=0.000020, IC=-0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000042, val_loss=0.000018, IC=-0.0221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000050, val_loss=0.000018, IC=-0.0327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000042, val_loss=0.000017, IC=-0.0091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000039, val_loss=0.000018, IC=-0.0243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000040, val_loss=0.000018, IC=-0.0244\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000039, val_loss=0.000018, IC=-0.0182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000039, val_loss=0.000018, IC=-0.0176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=60, IC=+0.0013 (60.3s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000467\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000048, val_loss=0.000047, IC=-0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000040, val_loss=0.000043, IC=-0.0223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000037, val_loss=0.000046, IC=-0.0138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000034, val_loss=0.000042, IC=-0.0104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000040, val_loss=0.000042, IC=-0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000037, val_loss=0.000042, IC=-0.0192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000041, val_loss=0.000042, IC=-0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000040, val_loss=0.000043, IC=-0.0224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000035, val_loss=0.000041, IC=-0.0144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000038, val_loss=0.000039, IC=-0.0070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000032, val_loss=0.000039, IC=-0.0336\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000036, val_loss=0.000041, IC=-0.0325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000033, val_loss=0.000039, IC=-0.0245\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000032, val_loss=0.000040, IC=-0.0247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000037, val_loss=0.000040, IC=-0.0288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000033, val_loss=0.000038, IC=-0.0250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000030, val_loss=0.000039, IC=-0.0331\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000035, val_loss=0.000040, IC=-0.0387\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000033, val_loss=0.000038, IC=-0.0342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000031, val_loss=0.000039, IC=-0.0320\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=-0.0058 (62.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002443\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000066, val_loss=0.000035, IC=+0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000043, val_loss=0.000025, IC=+0.0155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000039, val_loss=0.000024, IC=+0.0291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000037, val_loss=0.000024, IC=+0.0265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000037, val_loss=0.000025, IC=+0.0184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000038, val_loss=0.000022, IC=+0.0130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000031, val_loss=0.000021, IC=+0.0210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000032, val_loss=0.000021, IC=+0.0220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000032, val_loss=0.000021, IC=+0.0073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000030, val_loss=0.000020, IC=+0.0221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000033, val_loss=0.000021, IC=+0.0167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000031, val_loss=0.000020, IC=+0.0120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000031, val_loss=0.000021, IC=+0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000029, val_loss=0.000020, IC=+0.0202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000031, val_loss=0.000021, IC=+0.0141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000030, val_loss=0.000020, IC=+0.0268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000029, val_loss=0.000020, IC=+0.0225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000031, val_loss=0.000020, IC=+0.0291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000029, val_loss=0.000020, IC=+0.0279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000029, val_loss=0.000020, IC=+0.0287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=90, IC=+0.0291 (64.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000046, val_loss=0.000058, IC=-0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000031, val_loss=0.000053, IC=-0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000031, val_loss=0.000050, IC=-0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000026, val_loss=0.000051, IC=-0.0299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000025, val_loss=0.000049, IC=+0.0067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000026, val_loss=0.000051, IC=-0.0304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000029, val_loss=0.000054, IC=-0.0365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000028, val_loss=0.000054, IC=-0.0292\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000031, val_loss=0.000054, IC=-0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000023, val_loss=0.000048, IC=-0.0229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000024, val_loss=0.000047, IC=-0.0243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000027, val_loss=0.000048, IC=-0.0120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000023, val_loss=0.000047, IC=-0.0132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000023, val_loss=0.000049, IC=-0.0139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000025, val_loss=0.000048, IC=-0.0209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000024, val_loss=0.000047, IC=-0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000025, val_loss=0.000048, IC=-0.0164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000022, val_loss=0.000048, IC=-0.0274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000027, val_loss=0.000047, IC=-0.0201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000022, val_loss=0.000047, IC=-0.0174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0067 (63.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n",
+      "    train=24,580 seq across 20 symbols\n",
+      "    val=5,140 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000059, val_loss=0.000055, IC=-0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000041, val_loss=0.000042, IC=+0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000038, val_loss=0.000036, IC=+0.0141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000035, val_loss=0.000034, IC=+0.0118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000031, val_loss=0.000033, IC=+0.0275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000034, val_loss=0.000034, IC=-0.0177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000031, val_loss=0.000032, IC=+0.0137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000035, val_loss=0.000032, IC=+0.0265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000031, val_loss=0.000033, IC=+0.0180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000030, val_loss=0.000034, IC=-0.0095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000028, val_loss=0.000033, IC=-0.0173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000027, val_loss=0.000031, IC=+0.0084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000029, val_loss=0.000031, IC=+0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000028, val_loss=0.000032, IC=+0.0090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000028, val_loss=0.000031, IC=+0.0166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000027, val_loss=0.000031, IC=+0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000026, val_loss=0.000031, IC=-0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000026, val_loss=0.000031, IC=+0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000028, val_loss=0.000030, IC=+0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000029, val_loss=0.000031, IC=+0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0275 (60.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=25, IC=+0.0059 (467.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 25 (IC=+0.0059)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/fx_pairs/run_log/training/225e9d237512/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=16,980 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000230, val_loss=0.000318, IC=+0.0481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000193, val_loss=0.000296, IC=+0.0521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000184, val_loss=0.000296, IC=+0.0446\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000182, val_loss=0.000319, IC=+0.0423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000168, val_loss=0.000333, IC=+0.0332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000159, val_loss=0.000339, IC=+0.0312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000160, val_loss=0.000353, IC=+0.0325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000144, val_loss=0.000367, IC=+0.0355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000138, val_loss=0.000371, IC=+0.0378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000136, val_loss=0.000375, IC=+0.0521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000135, val_loss=0.000380, IC=+0.0484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000130, val_loss=0.000389, IC=+0.0504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000124, val_loss=0.000390, IC=+0.0543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000122, val_loss=0.000396, IC=+0.0511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000121, val_loss=0.000390, IC=+0.0494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000116, val_loss=0.000392, IC=+0.0544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000118, val_loss=0.000391, IC=+0.0533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000116, val_loss=0.000393, IC=+0.0554\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000117, val_loss=0.000392, IC=+0.0553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000120, val_loss=0.000392, IC=+0.0555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=100, IC=+0.0555 (43.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n",
+      "    train=22,140 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000236, val_loss=0.000132, IC=-0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000214, val_loss=0.000131, IC=-0.0151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000202, val_loss=0.000133, IC=-0.0165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000193, val_loss=0.000140, IC=-0.0367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000184, val_loss=0.000143, IC=+0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000174, val_loss=0.000153, IC=+0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000166, val_loss=0.000159, IC=+0.0076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000159, val_loss=0.000166, IC=-0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000152, val_loss=0.000170, IC=+0.0078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000147, val_loss=0.000181, IC=+0.0097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000142, val_loss=0.000181, IC=-0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000137, val_loss=0.000190, IC=-0.0037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000135, val_loss=0.000195, IC=+0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000132, val_loss=0.000199, IC=+0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000130, val_loss=0.000201, IC=-0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000129, val_loss=0.000203, IC=+0.0044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000128, val_loss=0.000204, IC=-0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000128, val_loss=0.000205, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000127, val_loss=0.000205, IC=+0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000128, val_loss=0.000205, IC=+0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0113 (57.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000690\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000206, val_loss=0.000124, IC=-0.0224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000190, val_loss=0.000122, IC=+0.0237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000175, val_loss=0.000132, IC=+0.0194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000161, val_loss=0.000133, IC=+0.0384\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000157\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000148, val_loss=0.000142, IC=+0.0537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000136, val_loss=0.000150, IC=+0.0235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000126, val_loss=0.000162, IC=+0.0162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000118, val_loss=0.000172, IC=+0.0308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000112, val_loss=0.000179, IC=+0.0298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000106, val_loss=0.000189, IC=+0.0288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000103, val_loss=0.000188, IC=+0.0377\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000099, val_loss=0.000193, IC=+0.0421\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000096, val_loss=0.000201, IC=+0.0393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000095, val_loss=0.000204, IC=+0.0366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000093, val_loss=0.000212, IC=+0.0424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000092, val_loss=0.000207, IC=+0.0382\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000092, val_loss=0.000210, IC=+0.0390\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000091, val_loss=0.000211, IC=+0.0391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000090, val_loss=0.000213, IC=+0.0415\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000091, val_loss=0.000212, IC=+0.0407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0537 (69.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000842\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000230\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000197, val_loss=0.000092, IC=-0.0091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000182, val_loss=0.000091, IC=-0.0138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000171, val_loss=0.000093, IC=-0.0291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000162, val_loss=0.000097, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000151, val_loss=0.000101, IC=-0.0018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000142, val_loss=0.000106, IC=+0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000135, val_loss=0.000111, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000127, val_loss=0.000117, IC=+0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000120, val_loss=0.000122, IC=+0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000114, val_loss=0.000126, IC=+0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000110, val_loss=0.000128, IC=+0.0028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000106, val_loss=0.000132, IC=+0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000102, val_loss=0.000132, IC=-0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000100, val_loss=0.000137, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000099, val_loss=0.000137, IC=+0.0028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000097, val_loss=0.000137, IC=+0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000097, val_loss=0.000137, IC=+0.0044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000096, val_loss=0.000138, IC=+0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000096, val_loss=0.000138, IC=+0.0025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000096, val_loss=0.000137, IC=+0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=85, IC=+0.0044 (66.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000600\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000162, val_loss=0.000236, IC=-0.1068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000147, val_loss=0.000248, IC=-0.1345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000136, val_loss=0.000263, IC=-0.1363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000125, val_loss=0.000287, IC=-0.1237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000117, val_loss=0.000305, IC=-0.1069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000108, val_loss=0.000309, IC=-0.1098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000102, val_loss=0.000319, IC=-0.1001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000096, val_loss=0.000353, IC=-0.0940\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000093, val_loss=0.000357, IC=-0.0915\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000088, val_loss=0.000366, IC=-0.0877\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000085, val_loss=0.000385, IC=-0.0854\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000081, val_loss=0.000395, IC=-0.0827\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000079, val_loss=0.000395, IC=-0.0824\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000078, val_loss=0.000412, IC=-0.0833\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000077, val_loss=0.000415, IC=-0.0850\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000075, val_loss=0.000422, IC=-0.0835\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000075, val_loss=0.000427, IC=-0.0813\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000075, val_loss=0.000421, IC=-0.0819\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000074, val_loss=0.000423, IC=-0.0830\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000074, val_loss=0.000422, IC=-0.0829\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=85, IC=-0.0813 (84.3s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002793\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000171, val_loss=0.000098, IC=+0.0064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000149, val_loss=0.000093, IC=+0.0194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000141, val_loss=0.000092, IC=+0.0356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000132, val_loss=0.000092, IC=+0.0438\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000125, val_loss=0.000092, IC=+0.0576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000120, val_loss=0.000092, IC=+0.0658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000114, val_loss=0.000094, IC=+0.0705\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000110, val_loss=0.000095, IC=+0.0702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000107, val_loss=0.000097, IC=+0.0725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000103, val_loss=0.000100, IC=+0.0733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000101, val_loss=0.000101, IC=+0.0706\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000099, val_loss=0.000102, IC=+0.0649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000097, val_loss=0.000105, IC=+0.0633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000095, val_loss=0.000105, IC=+0.0610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000094, val_loss=0.000105, IC=+0.0587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000093, val_loss=0.000106, IC=+0.0580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000092, val_loss=0.000107, IC=+0.0561\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000092, val_loss=0.000107, IC=+0.0566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000093, val_loss=0.000107, IC=+0.0571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000092, val_loss=0.000107, IC=+0.0567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=50, IC=+0.0733 (97.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000120, val_loss=0.000239, IC=-0.0333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000107, val_loss=0.000261, IC=-0.0170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000099, val_loss=0.000268, IC=-0.0130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000092, val_loss=0.000283, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000087, val_loss=0.000296, IC=-0.0056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000081, val_loss=0.000328, IC=-0.0038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000077, val_loss=0.000347, IC=-0.0215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000072, val_loss=0.000361, IC=-0.0226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000070, val_loss=0.000355, IC=-0.0116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000066, val_loss=0.000360, IC=+0.0037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000064, val_loss=0.000358, IC=+0.0073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000062, val_loss=0.000384, IC=-0.0092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000060, val_loss=0.000373, IC=-0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000059, val_loss=0.000374, IC=+0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000058, val_loss=0.000374, IC=+0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000057, val_loss=0.000371, IC=+0.0043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000057, val_loss=0.000372, IC=+0.0032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000057, val_loss=0.000375, IC=+0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000057, val_loss=0.000374, IC=+0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000057, val_loss=0.000374, IC=+0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=55, IC=+0.0073 (112.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n",
+      "    train=24,500 seq across 20 symbols\n",
+      "    val=5,060 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000165, val_loss=0.000156, IC=+0.0124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000140, val_loss=0.000138, IC=+0.0073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000131, val_loss=0.000137, IC=-0.0143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000125, val_loss=0.000138, IC=-0.0242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000119, val_loss=0.000143, IC=-0.0330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000114, val_loss=0.000148, IC=-0.0418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000110, val_loss=0.000155, IC=-0.0494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000106, val_loss=0.000160, IC=-0.0504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000104, val_loss=0.000167, IC=-0.0629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000102, val_loss=0.000170, IC=-0.0703\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000099, val_loss=0.000174, IC=-0.0663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000097, val_loss=0.000176, IC=-0.0699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000096, val_loss=0.000176, IC=-0.0751\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000095, val_loss=0.000181, IC=-0.0798\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000094, val_loss=0.000183, IC=-0.0808\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000093, val_loss=0.000184, IC=-0.0801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000091, val_loss=0.000183, IC=-0.0823\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000091, val_loss=0.000184, IC=-0.0809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000092, val_loss=0.000184, IC=-0.0815\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000092, val_loss=0.000184, IC=-0.0812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0124 (113.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=55, IC=+0.0018 (642.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 55 (IC=+0.0018)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/fx_pairs/run_log/training/ef01d12ba279/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 8 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n",
+      "    train=16,660 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000725\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000702, val_loss=0.001260, IC=+0.0660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000545, val_loss=0.001469, IC=+0.0554\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000414, val_loss=0.001519, IC=+0.0508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000360\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000340, val_loss=0.001448, IC=+0.0732\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000292\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000271, val_loss=0.001458, IC=+0.0792\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000234\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000226, val_loss=0.001481, IC=+0.0789\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000204\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000191, val_loss=0.001487, IC=+0.0754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000166, val_loss=0.001530, IC=+0.0700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000155, val_loss=0.001561, IC=+0.0649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000147\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000140, val_loss=0.001564, IC=+0.0585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000137, val_loss=0.001522, IC=+0.0604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000125, val_loss=0.001598, IC=+0.0676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000123, val_loss=0.001550, IC=+0.0709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000117, val_loss=0.001534, IC=+0.0682\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000112, val_loss=0.001527, IC=+0.0763\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000120, val_loss=0.001519, IC=+0.0778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000109, val_loss=0.001512, IC=+0.0760\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000108, val_loss=0.001531, IC=+0.0773\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000106, val_loss=0.001524, IC=+0.0766\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000108, val_loss=0.001524, IC=+0.0752\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0792 (89.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n",
+      "    train=21,820 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.002807\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000848\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000781\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000730, val_loss=0.000607, IC=-0.0292\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000701\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000661\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000559, val_loss=0.000706, IC=-0.0477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000526\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000501\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000449\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000420, val_loss=0.000848, IC=-0.1146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000398\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000377\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000316, val_loss=0.000982, IC=-0.0776\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000245, val_loss=0.001103, IC=-0.0805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000202, val_loss=0.001166, IC=-0.0608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000171, val_loss=0.001270, IC=-0.0451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000153, val_loss=0.001251, IC=-0.0249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000142, val_loss=0.001231, IC=-0.0099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000135, val_loss=0.001187, IC=+0.0195\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000125, val_loss=0.001204, IC=+0.0124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000122, val_loss=0.001238, IC=+0.0099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000117, val_loss=0.001211, IC=+0.0218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000116, val_loss=0.001218, IC=+0.0078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000112, val_loss=0.001204, IC=+0.0255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000111, val_loss=0.001209, IC=+0.0248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000110, val_loss=0.001217, IC=+0.0198\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000108, val_loss=0.001207, IC=+0.0251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000108, val_loss=0.001209, IC=+0.0251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000109, val_loss=0.001207, IC=+0.0259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=100, IC=+0.0259 (94.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 2: creating sequences...\n",
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000756\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000590, val_loss=0.000528, IC=+0.0073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000400, val_loss=0.000651, IC=-0.0127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000276, val_loss=0.000692, IC=+0.0108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000246\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000209, val_loss=0.000700, IC=+0.0416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000169, val_loss=0.000721, IC=+0.0502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000148\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000143, val_loss=0.000784, IC=+0.0522\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000126, val_loss=0.000812, IC=+0.0427\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000115, val_loss=0.000860, IC=+0.0236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000109, val_loss=0.000866, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000103, val_loss=0.000886, IC=+0.0129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000098, val_loss=0.000892, IC=+0.0091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000095, val_loss=0.000898, IC=+0.0104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000092, val_loss=0.000909, IC=-0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000090, val_loss=0.000910, IC=+0.0051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000088, val_loss=0.000908, IC=+0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000087, val_loss=0.000924, IC=+0.0052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000086, val_loss=0.000912, IC=+0.0083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000084, val_loss=0.000919, IC=+0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000086, val_loss=0.000921, IC=+0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000085, val_loss=0.000920, IC=+0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=30, IC=+0.0522 (110.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 3: creating sequences...\n",
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000770\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000610, val_loss=0.000379, IC=+0.0250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000441, val_loss=0.000469, IC=-0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000307, val_loss=0.000570, IC=+0.0302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000217, val_loss=0.000601, IC=+0.0852\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000171, val_loss=0.000684, IC=+0.0885\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000144, val_loss=0.000745, IC=+0.0881\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000131\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000125, val_loss=0.000807, IC=+0.0681\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000115, val_loss=0.000833, IC=+0.0643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000107, val_loss=0.000877, IC=+0.0585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000101, val_loss=0.000882, IC=+0.0632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000095, val_loss=0.000907, IC=+0.0548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000092, val_loss=0.000920, IC=+0.0516\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000090, val_loss=0.000933, IC=+0.0445\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000086, val_loss=0.000932, IC=+0.0452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000086, val_loss=0.000946, IC=+0.0437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000084, val_loss=0.000942, IC=+0.0476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000084, val_loss=0.000952, IC=+0.0437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000084, val_loss=0.000959, IC=+0.0432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000082, val_loss=0.000954, IC=+0.0441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000083, val_loss=0.000953, IC=+0.0442\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=25, IC=+0.0885 (119.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 4: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000472, val_loss=0.001115, IC=-0.2052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000400\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000332\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000305, val_loss=0.001361, IC=-0.1459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000259\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000207, val_loss=0.001479, IC=-0.1340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000152, val_loss=0.001388, IC=-0.1001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000121, val_loss=0.001382, IC=-0.0801\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000102, val_loss=0.001405, IC=-0.0639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000091, val_loss=0.001448, IC=-0.0690\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000085, val_loss=0.001422, IC=-0.0648\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000078, val_loss=0.001400, IC=-0.0504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000075, val_loss=0.001420, IC=-0.0465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000072, val_loss=0.001433, IC=-0.0570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000070, val_loss=0.001410, IC=-0.0437\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000067, val_loss=0.001407, IC=-0.0503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000066, val_loss=0.001428, IC=-0.0589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000065, val_loss=0.001414, IC=-0.0551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000064, val_loss=0.001417, IC=-0.0552\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000064, val_loss=0.001419, IC=-0.0542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000063, val_loss=0.001415, IC=-0.0538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000063, val_loss=0.001421, IC=-0.0535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000063, val_loss=0.001421, IC=-0.0536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=60, IC=-0.0437 (136.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 5: creating sequences...\n",
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000830\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000520, val_loss=0.000367, IC=+0.0535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000497\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000456\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000440\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000423, val_loss=0.000375, IC=+0.0869\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000407\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000392\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000359\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000346, val_loss=0.000409, IC=+0.0886\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000331\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000279, val_loss=0.000447, IC=+0.1154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000238\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000231, val_loss=0.000469, IC=+0.1288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000195, val_loss=0.000508, IC=+0.1396\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000170, val_loss=0.000572, IC=+0.1260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000153\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000149, val_loss=0.000617, IC=+0.1110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000140\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000133, val_loss=0.000680, IC=+0.1021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000120, val_loss=0.000720, IC=+0.0947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000115\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000111, val_loss=0.000771, IC=+0.0845\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000104, val_loss=0.000802, IC=+0.0805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000099, val_loss=0.000816, IC=+0.0785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000095, val_loss=0.000856, IC=+0.0727\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000092, val_loss=0.000855, IC=+0.0731\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000090, val_loss=0.000862, IC=+0.0739\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000089, val_loss=0.000875, IC=+0.0714\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000088, val_loss=0.000872, IC=+0.0713\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000088, val_loss=0.000875, IC=+0.0704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000087, val_loss=0.000875, IC=+0.0699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=30, IC=+0.1396 (135.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 6: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=5,160 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000362, val_loss=0.001148, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000271, val_loss=0.001239, IC=+0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000194, val_loss=0.001303, IC=+0.0173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000142, val_loss=0.001395, IC=+0.0028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000133\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000118\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000108, val_loss=0.001413, IC=+0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000089, val_loss=0.001399, IC=+0.0397\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000079, val_loss=0.001411, IC=+0.0414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000069, val_loss=0.001420, IC=+0.0366\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000064, val_loss=0.001397, IC=+0.0405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000060, val_loss=0.001432, IC=+0.0328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000058, val_loss=0.001401, IC=+0.0374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000056, val_loss=0.001418, IC=+0.0355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000054, val_loss=0.001424, IC=+0.0293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000053, val_loss=0.001422, IC=+0.0295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000052, val_loss=0.001407, IC=+0.0325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000051, val_loss=0.001402, IC=+0.0335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000051, val_loss=0.001402, IC=+0.0358\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000051, val_loss=0.001401, IC=+0.0354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000050, val_loss=0.001399, IC=+0.0351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000050, val_loss=0.001399, IC=+0.0352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=35, IC=+0.0414 (131.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 7: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=24,180 seq across 20 symbols\n",
+      "    val=4,740 seq across 20 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000876\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000505, val_loss=0.000514, IC=-0.0166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000416, val_loss=0.000551, IC=-0.0193\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000390\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000375\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000360\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000350, val_loss=0.000687, IC=-0.0947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000316\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000293, val_loss=0.000875, IC=-0.1258\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000263\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000246, val_loss=0.000972, IC=-0.1351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000237\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000228\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000206, val_loss=0.000955, IC=-0.1264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000194\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000182\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000175, val_loss=0.000994, IC=-0.1284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000153, val_loss=0.001008, IC=-0.1466\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000133, val_loss=0.001023, IC=-0.1411\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000119, val_loss=0.001047, IC=-0.1553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000114\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000110, val_loss=0.001030, IC=-0.1532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000103, val_loss=0.001044, IC=-0.1544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000097, val_loss=0.001056, IC=-0.1675\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000094, val_loss=0.001055, IC=-0.1697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000091, val_loss=0.001064, IC=-0.1720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000090\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000090, val_loss=0.001058, IC=-0.1703\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000089, val_loss=0.001059, IC=-0.1738\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000088, val_loss=0.001062, IC=-0.1731\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000088, val_loss=0.001062, IC=-0.1731\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000088, val_loss=0.001062, IC=-0.1726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=-0.0166 (137.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=30, IC=+0.0199 (955.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 30 (IC=+0.0199)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/fx_pairs/run_log/training/a802656900ee/diagnostics\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (60, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>complete</th><th>ic_mean</th><th>ic_t</th><th>training_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>bool</td><td>f64</td><td>f64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>true</td><td>-0.00389</td><td>-1.129863</td><td>&quot;225e9d237512&quot;</td><td>&quot;ea8b69c86459&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>true</td><td>-0.002709</td><td>-0.547034</td><td>&quot;225e9d237512&quot;</td><td>&quot;486d60df8cd3&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>true</td><td>-0.00273</td><td>-0.522709</td><td>&quot;225e9d237512&quot;</td><td>&quot;62d3fed33dbf&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>20</td><td>true</td><td>-0.004447</td><td>-0.601744</td><td>&quot;225e9d237512&quot;</td><td>&quot;2cdd3be1dab2&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>true</td><td>0.005879</td><td>0.743689</td><td>&quot;225e9d237512&quot;</td><td>&quot;413eae56da50&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>80</td><td>true</td><td>-0.000241</td><td>-0.013254</td><td>&quot;ef01d12ba279&quot;</td><td>&quot;61e54b1d4d01&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>85</td><td>true</td><td>-0.001118</td><td>-0.061855</td><td>&quot;ef01d12ba279&quot;</td><td>&quot;8a8082ec58b4&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>90</td><td>true</td><td>-0.000601</td><td>-0.033122</td><td>&quot;ef01d12ba279&quot;</td><td>&quot;95bbe7f991c7&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>95</td><td>true</td><td>-0.000339</td><td>-0.018447</td><td>&quot;ef01d12ba279&quot;</td><td>&quot;97c93a4e64a5&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>true</td><td>-0.000321</td><td>-0.017555</td><td>&quot;ef01d12ba279&quot;</td><td>&quot;328dc612233c&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (60, 9)\n",
+       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐\n",
+       "│ label     ┆ config_na ┆ checkpoin ┆ checkpoin ┆ … ┆ ic_mean   ┆ ic_t      ┆ training_ ┆ predicti │\n",
+       "│ ---       ┆ me        ┆ t_kind    ┆ t_value   ┆   ┆ ---       ┆ ---       ┆ hash      ┆ on_hash  │\n",
+       "│ str       ┆ ---       ┆ ---       ┆ ---       ┆   ┆ f64       ┆ f64       ┆ ---       ┆ ---      │\n",
+       "│           ┆ str       ┆ str       ┆ i64       ┆   ┆           ┆           ┆ str       ┆ str      │\n",
+       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
+       "│ fwd_ret_1 ┆ lstm_h64  ┆ epoch     ┆ 5         ┆ … ┆ -0.00389  ┆ -1.129863 ┆ 225e9d237 ┆ ea8b69c8 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 512       ┆ 6459     │\n",
+       "│ fwd_ret_1 ┆ lstm_h64  ┆ epoch     ┆ 10        ┆ … ┆ -0.002709 ┆ -0.547034 ┆ 225e9d237 ┆ 486d60df │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 512       ┆ 8cd3     │\n",
+       "│ fwd_ret_1 ┆ lstm_h64  ┆ epoch     ┆ 15        ┆ … ┆ -0.00273  ┆ -0.522709 ┆ 225e9d237 ┆ 62d3fed3 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 512       ┆ 3dbf     │\n",
+       "│ fwd_ret_1 ┆ lstm_h64  ┆ epoch     ┆ 20        ┆ … ┆ -0.004447 ┆ -0.601744 ┆ 225e9d237 ┆ 2cdd3be1 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 512       ┆ dab2     │\n",
+       "│ fwd_ret_1 ┆ lstm_h64  ┆ epoch     ┆ 25        ┆ … ┆ 0.005879  ┆ 0.743689  ┆ 225e9d237 ┆ 413eae56 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 512       ┆ da50     │\n",
+       "│ …         ┆ …         ┆ …         ┆ …         ┆ … ┆ …         ┆ …         ┆ …         ┆ …        │\n",
+       "│ fwd_ret_5 ┆ lstm_h64  ┆ epoch     ┆ 80        ┆ … ┆ -0.000241 ┆ -0.013254 ┆ ef01d12ba ┆ 61e54b1d │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 279       ┆ 4d01     │\n",
+       "│ fwd_ret_5 ┆ lstm_h64  ┆ epoch     ┆ 85        ┆ … ┆ -0.001118 ┆ -0.061855 ┆ ef01d12ba ┆ 8a8082ec │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 279       ┆ 58b4     │\n",
+       "│ fwd_ret_5 ┆ lstm_h64  ┆ epoch     ┆ 90        ┆ … ┆ -0.000601 ┆ -0.033122 ┆ ef01d12ba ┆ 95bbe7f9 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 279       ┆ 91c7     │\n",
+       "│ fwd_ret_5 ┆ lstm_h64  ┆ epoch     ┆ 95        ┆ … ┆ -0.000339 ┆ -0.018447 ┆ ef01d12ba ┆ 97c93a4e │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 279       ┆ 64a5     │\n",
+       "│ fwd_ret_5 ┆ lstm_h64  ┆ epoch     ┆ 100       ┆ … ┆ -0.000321 ┆ -0.017555 ┆ ef01d12ba ┆ 328dc612 │\n",
+       "│ d         ┆           ┆           ┆           ┆   ┆           ┆           ┆ 279       ┆ 233c     │\n",
+       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "if len(plan.expected_prediction_hashes) != checkpoint_schedule.height * len(labels):\n",
     "    raise RuntimeError(\"the plan does not cover every declared epoch checkpoint on every label\")\n",
@@ -357,13 +17884,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bdb3f48",
+   "id": "95229f4d",
    "metadata": {
     "papermill": {
-     "duration": 0.036937,
-     "end_time": "2026-09-06T18:55:05.746664+00:00",
+     "duration": 0.170528,
+     "end_time": "2026-09-08T22:36:10.699473+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:55:05.709727+00:00",
+     "start_time": "2026-09-08T22:36:10.528945+00:00",
      "status": "completed"
     }
    },
@@ -376,14 +17903,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c1fa2044",
+   "execution_count": 6,
+   "id": "33c92f23",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T22:36:10.852570Z",
+     "iopub.status.busy": "2026-09-08T22:36:10.849534Z",
+     "iopub.status.idle": "2026-09-08T22:36:15.974871Z",
+     "shell.execute_reply": "2026-09-08T22:36:15.972032Z"
+    },
+    "papermill": {
+     "duration": 5.202976,
+     "end_time": "2026-09-08T22:36:15.975317+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T22:36:10.772341+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Official prediction population: f39229f6bc28\n"
+     ]
+    }
+   ],
    "source": [
     "replayed = plan.run()\n",
     "if set(replayed.catalog_rows.get_column(\"prediction_hash\")) != set(\n",
@@ -400,13 +17948,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f8f592d",
+   "id": "e118b753",
    "metadata": {
     "papermill": {
-     "duration": 0.036173,
-     "end_time": "2026-09-06T18:55:07.764093+00:00",
+     "duration": 0.045516,
+     "end_time": "2026-09-08T22:36:16.071819+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:55:07.727920+00:00",
+     "start_time": "2026-09-08T22:36:16.026303+00:00",
      "status": "completed"
     }
    },
@@ -440,6 +17988,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T22:36:36.240756+00:00",
+   "executor": "local-uv",
+   "library_digest": "5035256203a959728f64b8eb5a2047d91229b302459b7a4274f0b128e0dd11f8",
+   "outputs_digest": "ab24b5916c85acfd3ea88c0dd7ceeb5aefc4e0d8d613766d33369178f94f21a4",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "41b18ecbb72e4e34f2904ebe136b4f2d67040ca7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2147.762514,
+   "end_time": "2026-09-08T22:36:19.355289+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/fx_pairs/.10a_dl_lstm.build.1121741.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/fx_pairs/.10a_dl_lstm.papermill.1121741.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T22:00:31.592775+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_equity_option_analytics/09_dl_lstm.ipynb
+++ b/case_studies/sp500_equity_option_analytics/09_dl_lstm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e0cbb5ec",
+   "id": "8c3d243d",
    "metadata": {
     "papermill": {
-     "duration": 0.002335,
-     "end_time": "2026-09-09T03:36:11.751643+00:00",
+     "duration": 0.002808,
+     "end_time": "2026-09-08T19:48:55.571054+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:11.749308+00:00",
+     "start_time": "2026-09-08T19:48:55.568246+00:00",
      "status": "completed"
     }
    },
@@ -69,19 +69,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "997dc45d",
+   "id": "299d849e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:11.756671Z",
-     "iopub.status.busy": "2026-09-09T03:36:11.756492Z",
-     "iopub.status.idle": "2026-09-09T03:36:15.009609Z",
-     "shell.execute_reply": "2026-09-09T03:36:15.009001Z"
+     "iopub.execute_input": "2026-09-08T19:48:55.575809Z",
+     "iopub.status.busy": "2026-09-08T19:48:55.575534Z",
+     "iopub.status.idle": "2026-09-08T19:48:59.911053Z",
+     "shell.execute_reply": "2026-09-08T19:48:59.909802Z"
     },
     "papermill": {
-     "duration": 3.25708,
-     "end_time": "2026-09-09T03:36:15.010853+00:00",
+     "duration": 4.33946,
+     "end_time": "2026-09-08T19:48:59.912438+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:11.753773+00:00",
+     "start_time": "2026-09-08T19:48:55.572978+00:00",
      "status": "completed"
     }
    },
@@ -109,19 +109,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "1d6313e7",
+   "id": "76a7cacb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:15.016568Z",
-     "iopub.status.busy": "2026-09-09T03:36:15.016223Z",
-     "iopub.status.idle": "2026-09-09T03:36:15.019295Z",
-     "shell.execute_reply": "2026-09-09T03:36:15.018732Z"
+     "iopub.execute_input": "2026-09-08T19:48:59.920622Z",
+     "iopub.status.busy": "2026-09-08T19:48:59.919943Z",
+     "iopub.status.idle": "2026-09-08T19:48:59.924621Z",
+     "shell.execute_reply": "2026-09-08T19:48:59.924039Z"
     },
     "papermill": {
-     "duration": 0.006467,
-     "end_time": "2026-09-09T03:36:15.019809+00:00",
+     "duration": 0.00959,
+     "end_time": "2026-09-08T19:48:59.925344+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.013342+00:00",
+     "start_time": "2026-09-08T19:48:59.915754+00:00",
      "status": "completed"
     },
     "tags": [
@@ -143,19 +143,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b90260fd",
+   "id": "cb2299f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:15.025295Z",
-     "iopub.status.busy": "2026-09-09T03:36:15.025147Z",
-     "iopub.status.idle": "2026-09-09T03:36:15.055687Z",
-     "shell.execute_reply": "2026-09-09T03:36:15.054931Z"
+     "iopub.execute_input": "2026-09-08T19:48:59.930457Z",
+     "iopub.status.busy": "2026-09-08T19:48:59.930198Z",
+     "iopub.status.idle": "2026-09-08T19:48:59.999910Z",
+     "shell.execute_reply": "2026-09-08T19:48:59.999152Z"
     },
     "papermill": {
-     "duration": 0.033978,
-     "end_time": "2026-09-09T03:36:15.056224+00:00",
+     "duration": 0.075887,
+     "end_time": "2026-09-08T19:49:00.002953+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.022246+00:00",
+     "start_time": "2026-09-08T19:48:59.927066+00:00",
      "status": "completed"
     }
    },
@@ -171,13 +171,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2757c74c",
+   "id": "8a4290d9",
    "metadata": {
     "papermill": {
-     "duration": 0.001015,
-     "end_time": "2026-09-09T03:36:15.058516+00:00",
+     "duration": 0.002176,
+     "end_time": "2026-09-08T19:49:00.008684+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.057501+00:00",
+     "start_time": "2026-09-08T19:49:00.006508+00:00",
      "status": "completed"
     }
    },
@@ -196,19 +196,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "db867ff4",
+   "id": "59eb8697",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:15.061495Z",
-     "iopub.status.busy": "2026-09-09T03:36:15.061316Z",
-     "iopub.status.idle": "2026-09-09T03:36:15.086954Z",
-     "shell.execute_reply": "2026-09-09T03:36:15.086414Z"
+     "iopub.execute_input": "2026-09-08T19:49:00.015571Z",
+     "iopub.status.busy": "2026-09-08T19:49:00.015226Z",
+     "iopub.status.idle": "2026-09-08T19:49:00.045670Z",
+     "shell.execute_reply": "2026-09-08T19:49:00.044843Z"
     },
     "papermill": {
-     "duration": 0.027767,
-     "end_time": "2026-09-09T03:36:15.087314+00:00",
+     "duration": 0.035514,
+     "end_time": "2026-09-08T19:49:00.046474+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.059547+00:00",
+     "start_time": "2026-09-08T19:49:00.010960+00:00",
      "status": "completed"
     }
    },
@@ -230,13 +230,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b81c49d9",
+   "id": "c0b188f1",
    "metadata": {
     "papermill": {
-     "duration": 0.00144,
-     "end_time": "2026-09-09T03:36:15.090182+00:00",
+     "duration": 0.002947,
+     "end_time": "2026-09-08T19:49:00.052183+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.088742+00:00",
+     "start_time": "2026-09-08T19:49:00.049236+00:00",
      "status": "completed"
     }
    },
@@ -262,19 +262,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "e07bf00f",
+   "id": "31790378",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:15.096992Z",
-     "iopub.status.busy": "2026-09-09T03:36:15.096827Z",
-     "iopub.status.idle": "2026-09-09T03:36:15.161688Z",
-     "shell.execute_reply": "2026-09-09T03:36:15.161177Z"
+     "iopub.execute_input": "2026-09-08T19:49:00.059462Z",
+     "iopub.status.busy": "2026-09-08T19:49:00.058931Z",
+     "iopub.status.idle": "2026-09-08T19:49:00.130373Z",
+     "shell.execute_reply": "2026-09-08T19:49:00.129826Z"
     },
     "papermill": {
-     "duration": 0.069747,
-     "end_time": "2026-09-09T03:36:15.162636+00:00",
+     "duration": 0.076204,
+     "end_time": "2026-09-08T19:49:00.131161+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.092889+00:00",
+     "start_time": "2026-09-08T19:49:00.054957+00:00",
      "status": "completed"
     }
    },
@@ -332,13 +332,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3804b203",
+   "id": "0d66e179",
    "metadata": {
     "papermill": {
-     "duration": 0.002186,
-     "end_time": "2026-09-09T03:36:15.167310+00:00",
+     "duration": 0.002543,
+     "end_time": "2026-09-08T19:49:00.136542+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.165124+00:00",
+     "start_time": "2026-09-08T19:49:00.133999+00:00",
      "status": "completed"
     }
    },
@@ -361,19 +361,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "632f1184",
+   "id": "85801be0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:15.173486Z",
-     "iopub.status.busy": "2026-09-09T03:36:15.173301Z",
-     "iopub.status.idle": "2026-09-09T03:36:15.176840Z",
-     "shell.execute_reply": "2026-09-09T03:36:15.176282Z"
+     "iopub.execute_input": "2026-09-08T19:49:00.142221Z",
+     "iopub.status.busy": "2026-09-08T19:49:00.141994Z",
+     "iopub.status.idle": "2026-09-08T19:49:00.146131Z",
+     "shell.execute_reply": "2026-09-08T19:49:00.145433Z"
     },
     "papermill": {
-     "duration": 0.007486,
-     "end_time": "2026-09-09T03:36:15.177145+00:00",
+     "duration": 0.007445,
+     "end_time": "2026-09-08T19:49:00.146818+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.169659+00:00",
+     "start_time": "2026-09-08T19:49:00.139373+00:00",
      "status": "completed"
     }
    },
@@ -404,13 +404,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a24e0ef5",
+   "id": "b0228ddf",
    "metadata": {
     "papermill": {
-     "duration": 0.001137,
-     "end_time": "2026-09-09T03:36:15.179671+00:00",
+     "duration": 0.002481,
+     "end_time": "2026-09-08T19:49:00.151278+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.178534+00:00",
+     "start_time": "2026-09-08T19:49:00.148797+00:00",
      "status": "completed"
     }
    },
@@ -450,19 +450,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "01082540",
+   "id": "329edcaa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:15.182784Z",
-     "iopub.status.busy": "2026-09-09T03:36:15.182677Z",
-     "iopub.status.idle": "2026-09-09T03:36:30.609811Z",
-     "shell.execute_reply": "2026-09-09T03:36:30.609264Z"
+     "iopub.execute_input": "2026-09-08T19:49:00.157298Z",
+     "iopub.status.busy": "2026-09-08T19:49:00.156972Z",
+     "iopub.status.idle": "2026-09-08T19:49:18.721566Z",
+     "shell.execute_reply": "2026-09-08T19:49:18.720690Z"
     },
     "papermill": {
-     "duration": 15.429475,
-     "end_time": "2026-09-09T03:36:30.610290+00:00",
+     "duration": 18.570774,
+     "end_time": "2026-09-08T19:49:18.724608+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:15.180815+00:00",
+     "start_time": "2026-09-08T19:49:00.153834+00:00",
      "status": "completed"
     }
    },
@@ -540,13 +540,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14bc1a1f",
+   "id": "7bde7dbb",
    "metadata": {
     "papermill": {
-     "duration": 0.001524,
-     "end_time": "2026-09-09T03:36:30.613341+00:00",
+     "duration": 0.004411,
+     "end_time": "2026-09-08T19:49:18.732176+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:30.611817+00:00",
+     "start_time": "2026-09-08T19:49:18.727765+00:00",
      "status": "completed"
     }
    },
@@ -595,19 +595,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "1d3c8c78",
+   "id": "4a0c9396",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:30.616914Z",
-     "iopub.status.busy": "2026-09-09T03:36:30.616769Z",
-     "iopub.status.idle": "2026-09-09T03:36:33.434066Z",
-     "shell.execute_reply": "2026-09-09T03:36:33.433485Z"
+     "iopub.execute_input": "2026-09-08T19:49:18.739755Z",
+     "iopub.status.busy": "2026-09-08T19:49:18.739446Z",
+     "iopub.status.idle": "2026-09-08T21:10:20.961451Z",
+     "shell.execute_reply": "2026-09-08T21:10:20.957186Z"
     },
     "papermill": {
-     "duration": 2.820165,
-     "end_time": "2026-09-09T03:36:33.434836+00:00",
+     "duration": 4862.269736,
+     "end_time": "2026-09-08T21:10:21.004904+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:30.614671+00:00",
+     "start_time": "2026-09-08T19:49:18.735168+00:00",
      "status": "completed"
     }
    },
@@ -616,7 +616,8833 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6 configurations: 0 trained, 6 read\n",
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=97,524 seq across 540 symbols\n",
+      "    val=64,534 seq across 564 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.075283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.023225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.012310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.008143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.006243, val_loss=0.005130, IC=-0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.005123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.004429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.003945\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.003398, val_loss=0.003428, IC=-0.0070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.003271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.003173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.003112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.003070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.003045, val_loss=0.003234, IC=-0.0057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.003028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.002994, val_loss=0.003210, IC=-0.0051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.002995\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.002995\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.002992\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.002991\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.002994, val_loss=0.003185, IC=-0.0111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.002992\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.002984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.002986\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.002990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.002989, val_loss=0.003220, IC=-0.0092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.002986\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.002989\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.002987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.002987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.002985, val_loss=0.003192, IC=-0.0068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.002987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.002987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.002983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.002991\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.002984, val_loss=0.003220, IC=-0.0092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.002988\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.002984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.002982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.002985\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.002982, val_loss=0.003211, IC=-0.0093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.002987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.002987\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.002984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.002984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.002980, val_loss=0.003228, IC=-0.0069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.002982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.002988\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.002983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.002979\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.002986, val_loss=0.003181, IC=-0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.002980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.002983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.002986\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.002981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.002982, val_loss=0.003197, IC=-0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.002980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.002982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.002983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.002982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.002979, val_loss=0.003210, IC=-0.0120\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.002983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.002980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.002980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.002979\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.002981, val_loss=0.003200, IC=-0.0098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.002981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.002980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.002977\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.002979\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.002980, val_loss=0.003183, IC=-0.0087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.002977\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.002980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.002976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.002982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.002979, val_loss=0.003201, IC=-0.0102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.002983\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.002982\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.002979\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.002979\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.002976, val_loss=0.003196, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.002977\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.002978\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.002979\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.002978\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.002978, val_loss=0.003201, IC=-0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.002976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.002976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.002977\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.002976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.002974, val_loss=0.003196, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.002976\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.002980\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.002978\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.002979\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.002976, val_loss=0.003196, IC=-0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=-0.0031 (332.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=110,751 seq across 537 symbols\n",
+      "    val=60,585 seq across 591 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.119506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.024350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.013380\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.008660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.006324, val_loss=0.017060, IC=+0.0075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.005021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.004338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.003948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003668\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.003548, val_loss=0.011046, IC=+0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.003453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.003422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.003392\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.003363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.003362, val_loss=0.010606, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.003350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.003353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.003352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.003342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.003330, val_loss=0.010263, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.003322\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.003339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.003325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.003327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.003318, val_loss=0.010224, IC=-0.0075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.003315\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.003318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.003329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.003317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.003328, val_loss=0.010107, IC=-0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.003314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.003319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.003312\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.003311\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.003303, val_loss=0.010295, IC=-0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.003307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.003316\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.003297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.003307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.003301, val_loss=0.010377, IC=-0.0060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.003299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.003293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.003314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.003313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.003302, val_loss=0.010372, IC=-0.0159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.003291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.003313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.003301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.003293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.003297, val_loss=0.010526, IC=-0.0173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.003307\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.003293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.003281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.003304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.003297, val_loss=0.010398, IC=-0.0348\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.003313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.003299\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.003290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.003280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.003279, val_loss=0.010608, IC=-0.0284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.003288\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.003287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.003291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.003289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.003295, val_loss=0.010591, IC=-0.0280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.003278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.003298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.003290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.003275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.003287, val_loss=0.010752, IC=-0.0365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.003293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.003294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.003303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.003266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.003275, val_loss=0.010537, IC=-0.0346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.003305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.003285\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.003273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.003306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.003281, val_loss=0.010706, IC=-0.0379\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.003271\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.003294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.003267\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.003281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.003283, val_loss=0.010724, IC=-0.0382\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.003290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.003283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.003301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.003268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.003265, val_loss=0.010744, IC=-0.0391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.003269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.003272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.003281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.003289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.003278, val_loss=0.010771, IC=-0.0346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.003295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.003270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.003339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.003283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.003280, val_loss=0.010768, IC=-0.0355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0075 (364.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=5, IC=+0.0021 (696.5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 5 (IC=+0.0021)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/run_log/training/0de0e17e7126/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=97,524 seq across 540 symbols\n",
+      "    val=64,534 seq across 564 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.002775\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002549\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002330\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002128, val_loss=0.004438, IC=-0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001971\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001864\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001720\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001547, val_loss=0.005099, IC=+0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001467\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001391\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001334\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001238, val_loss=0.004915, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001035, val_loss=0.005326, IC=-0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000998\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000924\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000901, val_loss=0.005285, IC=+0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000880\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000860\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000846\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000816\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000804, val_loss=0.005447, IC=-0.0053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000772\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000760\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000744\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000724, val_loss=0.005655, IC=-0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000719\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000702\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000682\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000669, val_loss=0.005521, IC=-0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000666\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000646\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000629, val_loss=0.005633, IC=-0.0073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000619\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000616\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000610\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000603\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000593, val_loss=0.005613, IC=-0.0117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000591\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000564, val_loss=0.005665, IC=-0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000552\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000545, val_loss=0.005703, IC=-0.0070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000533\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000528\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000524, val_loss=0.005767, IC=-0.0108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000524\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000518\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000510, val_loss=0.005844, IC=-0.0125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000509\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000499, val_loss=0.005860, IC=-0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000497\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000488, val_loss=0.005847, IC=-0.0125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000486, val_loss=0.005908, IC=-0.0134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000482\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000478, val_loss=0.005898, IC=-0.0132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000477, val_loss=0.005885, IC=-0.0129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000474, val_loss=0.005890, IC=-0.0130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=+0.0049 (359.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=110,751 seq across 537 symbols\n",
+      "    val=60,585 seq across 591 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.003025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002576\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002372, val_loss=0.013488, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001939\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001812\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001731, val_loss=0.014471, IC=-0.0034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001569\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001382, val_loss=0.014479, IC=-0.0221\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001255\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001165, val_loss=0.014394, IC=-0.0276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001017, val_loss=0.014108, IC=-0.0184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000985\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000946\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000905, val_loss=0.014216, IC=-0.0235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000891\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000873\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000844\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000836\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000826, val_loss=0.013933, IC=-0.0327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000811\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000792\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000782\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000772\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000760, val_loss=0.014056, IC=-0.0265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000748\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000745\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000723\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000725, val_loss=0.014731, IC=-0.0272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000722\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000676\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000677, val_loss=0.013904, IC=-0.0250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000657\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000647\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000648, val_loss=0.014427, IC=-0.0265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000641\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000614, val_loss=0.014167, IC=-0.0276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000598, val_loss=0.014193, IC=-0.0254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000588\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000583\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000582, val_loss=0.014029, IC=-0.0266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000579\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000563, val_loss=0.014163, IC=-0.0254\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000553, val_loss=0.014028, IC=-0.0223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000545, val_loss=0.014141, IC=-0.0236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000549\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000546\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000545, val_loss=0.014153, IC=-0.0242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000536, val_loss=0.014182, IC=-0.0244\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000537, val_loss=0.014162, IC=-0.0242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=-0.0012 (437.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=10, IC=+0.0009 (797.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 10 (IC=+0.0009)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/run_log/training/8912757ff71b/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=97,604 seq across 540 symbols\n",
+      "    val=64,593 seq across 564 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.073257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.021856\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.011181\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.007028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.004808, val_loss=0.003285, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.003709\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.002156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001929, val_loss=0.001689, IC=-0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001798\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001696\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001619\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001544, val_loss=0.001521, IC=-0.0064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001491, val_loss=0.001511, IC=-0.0043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001483, val_loss=0.001509, IC=-0.0068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001483, val_loss=0.001502, IC=-0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001482, val_loss=0.001495, IC=-0.0105\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001483\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001480, val_loss=0.001505, IC=-0.0086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001482, val_loss=0.001503, IC=-0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001479, val_loss=0.001511, IC=-0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001478, val_loss=0.001526, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001480\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001477, val_loss=0.001507, IC=-0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001477, val_loss=0.001518, IC=-0.0093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001475, val_loss=0.001516, IC=-0.0097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001476, val_loss=0.001511, IC=-0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001476, val_loss=0.001504, IC=-0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001476, val_loss=0.001506, IC=-0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001474, val_loss=0.001510, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001476, val_loss=0.001512, IC=-0.0082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001474, val_loss=0.001511, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=-0.0006 (258.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=110,846 seq across 537 symbols\n",
+      "    val=61,885 seq across 591 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.121949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.022434\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.011574\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.006837\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.004535, val_loss=0.012292, IC=+0.0078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.003344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002614\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.002222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001971\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001848, val_loss=0.006087, IC=+0.0011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001768\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001726\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001661, val_loss=0.005573, IC=+0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001651\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001648\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001645, val_loss=0.005482, IC=+0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001637\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001642, val_loss=0.005437, IC=+0.0037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001631, val_loss=0.005444, IC=+0.0116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001635, val_loss=0.005466, IC=-0.0103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001624\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001635, val_loss=0.005412, IC=-0.0025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001630, val_loss=0.005420, IC=+0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001635, val_loss=0.005473, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001633, val_loss=0.005416, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001633, val_loss=0.005413, IC=-0.0051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001622\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001624\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001628, val_loss=0.005395, IC=+0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001624\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001624\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001632, val_loss=0.005411, IC=-0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001620\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001626, val_loss=0.005408, IC=-0.0119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001626, val_loss=0.005397, IC=-0.0102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001620\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001624\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001623, val_loss=0.005394, IC=-0.0129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001627, val_loss=0.005403, IC=-0.0109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001627\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001628\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001627, val_loss=0.005399, IC=-0.0116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001624\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001625\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001620, val_loss=0.005398, IC=-0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=30, IC=+0.0116 (290.8s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=30, IC=+0.0047 (549.5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 30 (IC=+0.0047)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/run_log/training/c5dbb8f2ced7/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=97,604 seq across 540 symbols\n",
+      "    val=64,593 seq across 564 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001423\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001317\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001267, val_loss=0.001819, IC=-0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001217\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001058, val_loss=0.001904, IC=-0.0032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000974\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000943\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000921, val_loss=0.001967, IC=-0.0122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000899\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000885\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000860\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000832\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000818, val_loss=0.002072, IC=-0.0054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000788\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000769\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000755\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000748, val_loss=0.002129, IC=-0.0025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000731\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000715\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000679, val_loss=0.002196, IC=-0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000672\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000652\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000637, val_loss=0.002173, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000615\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000600, val_loss=0.002239, IC=-0.0065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000575\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000572\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000566, val_loss=0.002330, IC=-0.0057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000555\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000551\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000545\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000541, val_loss=0.002309, IC=-0.0048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000534\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000527\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000522\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000521, val_loss=0.002312, IC=-0.0087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000501, val_loss=0.002312, IC=-0.0069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000499\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000487, val_loss=0.002339, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000479\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000475, val_loss=0.002370, IC=-0.0069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000472\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000465, val_loss=0.002391, IC=-0.0075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000461, val_loss=0.002376, IC=-0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000458\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000455\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000452, val_loss=0.002371, IC=-0.0062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000452, val_loss=0.002380, IC=-0.0062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000452\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000449, val_loss=0.002378, IC=-0.0063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000449\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000448, val_loss=0.002378, IC=-0.0063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=35, IC=-0.0003 (364.1s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=110,846 seq across 537 symbols\n",
+      "    val=61,885 seq across 591 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.001735\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.001578\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001527\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001476\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001420, val_loss=0.006184, IC=-0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001363\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001191, val_loss=0.006431, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001023, val_loss=0.006485, IC=-0.0062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000958\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000935\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000915, val_loss=0.006824, IC=-0.0138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000877\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000863\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000851\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000836, val_loss=0.006986, IC=-0.0152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000822\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000792\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000779\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000765, val_loss=0.006933, IC=-0.0189\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000755\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000740\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000733\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000708, val_loss=0.006853, IC=-0.0202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000700\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000690\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000688\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000669\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000665, val_loss=0.006890, IC=-0.0163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000657\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000648\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000637\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000625, val_loss=0.006993, IC=-0.0190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000619\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000617\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000599\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000594, val_loss=0.007064, IC=-0.0185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000586\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000575\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000570, val_loss=0.007008, IC=-0.0219\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000568\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000551, val_loss=0.007032, IC=-0.0205\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000543\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000534, val_loss=0.007028, IC=-0.0203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000527\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000525\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000522, val_loss=0.007042, IC=-0.0196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000511, val_loss=0.007047, IC=-0.0187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000508\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000503\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000502, val_loss=0.007069, IC=-0.0211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000501\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000494, val_loss=0.007090, IC=-0.0215\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000495\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000493, val_loss=0.007087, IC=-0.0216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000490, val_loss=0.007079, IC=-0.0212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000491\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000489\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000490, val_loss=0.007079, IC=-0.0212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=10, IC=-0.0002 (409.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=10, IC=-0.0017 (773.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 10 (IC=-0.0017)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/run_log/training/b64c2da0c338/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=98,888 seq across 541 symbols\n",
+      "    val=64,593 seq across 564 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.100190\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.049866\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.039199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.034933\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.032667, val_loss=0.027439, IC=+0.0185\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.031488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.030642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.030295\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.029895\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.029707, val_loss=0.025791, IC=-0.0116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.029593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.029436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.029344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.029318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.029403, val_loss=0.025721, IC=-0.0128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.029270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.029262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.029178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.029385\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.029227, val_loss=0.025623, IC=-0.0158\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.029240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.029222\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.029124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.029160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.029186, val_loss=0.025690, IC=-0.0034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.029169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.029112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.029396\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.029268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.029235, val_loss=0.025656, IC=-0.0089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.029227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.029208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.029178\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.029257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.029281, val_loss=0.025786, IC=-0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.029187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.029303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.029208\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.029168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.029160, val_loss=0.025753, IC=-0.0161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.029165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.029144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.029081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.029155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.029110, val_loss=0.025741, IC=-0.0206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.029134\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.029166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.029085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.029203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.029141, val_loss=0.025641, IC=-0.0052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.029093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.029231\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.029212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.029224\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.029124, val_loss=0.025692, IC=-0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.029071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.029174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.029065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.029101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.029173, val_loss=0.025847, IC=-0.0220\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.029233\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.029098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.029107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.029164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.029159, val_loss=0.025715, IC=-0.0191\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.029107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.029103\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.029154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.029227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.029108, val_loss=0.025740, IC=-0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.029106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.029192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.029108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.029143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.029078, val_loss=0.025743, IC=-0.0165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.029092\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.029104\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.029128\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.029075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.029138, val_loss=0.025748, IC=-0.0113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.029062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.029117\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.029080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.029244\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.029059, val_loss=0.025748, IC=-0.0121\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.029201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.029116\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.029046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.029101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.029043, val_loss=0.025764, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.029106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.029048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.029132\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.029098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.029126, val_loss=0.025764, IC=-0.0097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.029166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.029137\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.029124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.029122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.029120, val_loss=0.025760, IC=-0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0185 (355.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=112,116 seq across 537 symbols\n",
+      "    val=61,865 seq across 590 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.144722\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.047167\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.036585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.031833\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.029674, val_loss=0.034715, IC=+0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.028328\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.027639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.027171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.026951\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.026826, val_loss=0.030041, IC=-0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.026732\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.026707\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.026697\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.026671\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.026629, val_loss=0.029258, IC=+0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.026629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.026632\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.026622\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.026642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.026613, val_loss=0.029070, IC=-0.0057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.026611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.026623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.026601\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.026619\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.026614, val_loss=0.028433, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.026616\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.026612\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.026588\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.026607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.026581, val_loss=0.028976, IC=-0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.026590\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.026608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.026598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.026571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.026591, val_loss=0.028228, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.026557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.026566\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.026584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.026562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.026566, val_loss=0.029252, IC=-0.0180\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.026580\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.026535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.026550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.026552\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.026556, val_loss=0.028965, IC=-0.0164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.026548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.026532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.026554\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.026539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.026521, val_loss=0.029106, IC=-0.0235\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.026541\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.026556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.026536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.026520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.026528, val_loss=0.028021, IC=-0.0126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.026553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.026521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.026538\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.026520\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.026536, val_loss=0.028444, IC=-0.0169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.026530\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.026513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.026506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.026515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.026533, val_loss=0.029776, IC=-0.0177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.026513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.026514\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.026509\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.026519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.026502, val_loss=0.029138, IC=-0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.026490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.026495\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.026485\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.026516\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.026520, val_loss=0.028745, IC=-0.0196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.026496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.026490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.026505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.026504\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.026491, val_loss=0.028704, IC=-0.0138\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.026507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.026507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.026496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.026490\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.026498, val_loss=0.028654, IC=-0.0169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.026505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.026492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.026487\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.026484\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.026467, val_loss=0.028802, IC=-0.0173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.026470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.026488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.026505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.026478\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.026485, val_loss=0.028737, IC=-0.0166\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.026463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.026497\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.026473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.026515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.026483, val_loss=0.028736, IC=-0.0164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0019 (358.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=5, IC=+0.0103 (714.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 5 (IC=+0.0103)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/run_log/training/d5327a66e161/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=98,888 seq across 541 symbols\n",
+      "    val=64,593 seq across 564 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.029083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.028028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.026620\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.025454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.024181, val_loss=0.029527, IC=-0.0091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.023210\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.022464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.021529\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.020863\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.019950, val_loss=0.032132, IC=+0.0051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.019201\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.018938\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.018123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.017500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.016947, val_loss=0.033818, IC=+0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.016454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.016099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.015654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.015216\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.014849, val_loss=0.036756, IC=+0.0101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.014517\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.014139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.013957\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.013629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.013246, val_loss=0.038107, IC=+0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.012947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.012755\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.012477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.012289\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.012082, val_loss=0.038650, IC=+0.0028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.011889\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.011670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.011465\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.011372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.011197, val_loss=0.040522, IC=+0.0034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.011035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.010840\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.010750\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.010522\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.010447, val_loss=0.040736, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.010300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.010150\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.010005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.009924\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.009794, val_loss=0.040155, IC=-0.0037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.009705\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.009678\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.009559\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.009432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.009333, val_loss=0.041075, IC=-0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.009248\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.009218\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.009083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.009095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.008989, val_loss=0.041951, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.008900\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.008850\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.008721\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.008701\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.008667, val_loss=0.042037, IC=-0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.008584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.008558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.008493\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.008464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.008373, val_loss=0.041851, IC=-0.0064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.008329\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.008314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.008223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.008171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.008175, val_loss=0.042720, IC=-0.0083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.008149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.008093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.008066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.007992\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.007976, val_loss=0.042523, IC=-0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.007981\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.007963\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.007913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.007912\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.007853, val_loss=0.042588, IC=-0.0081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.007837\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.007868\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.007845\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.007785\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.007778, val_loss=0.042677, IC=-0.0079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.007783\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.007754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.007755\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.007734\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.007715, val_loss=0.042840, IC=-0.0089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.007742\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.007655\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.007694\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.007712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.007705, val_loss=0.042884, IC=-0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.007712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.007646\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.007718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.007665\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.007676, val_loss=0.042861, IC=-0.0087\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=20, IC=+0.0101 (505.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=112,116 seq across 537 symbols\n",
+      "    val=61,865 seq across 590 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.026621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.025794\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.024660\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.023343\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.022098, val_loss=0.034375, IC=-0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.021097\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.020227\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.019488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.018596\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.017806, val_loss=0.037856, IC=-0.0123\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.017192\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.016704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.016108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.015639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.015098, val_loss=0.040719, IC=-0.0127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.014629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.014269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.013994\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.013501\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.013135, val_loss=0.040950, IC=-0.0085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.012871\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.012571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.012326\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.011997\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.011773, val_loss=0.044413, IC=-0.0142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.011532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.011303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.011074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.010881\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.010729, val_loss=0.045486, IC=-0.0144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.010570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.010349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.010152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.010033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.009832, val_loss=0.046943, IC=-0.0088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.009765\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.009611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.009451\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.009370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.009162, val_loss=0.046858, IC=-0.0062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.009135\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.009000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.008923\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.008834\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.008710, val_loss=0.047847, IC=-0.0039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.008664\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.008526\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.008417\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.008346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.008296, val_loss=0.047911, IC=-0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.008151\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.008124\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.008068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.008006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.007947, val_loss=0.048359, IC=-0.0080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.007842\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.007808\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.007745\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.007737\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.007667, val_loss=0.048824, IC=-0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.007589\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.007563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.007523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.007459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.007405, val_loss=0.048881, IC=-0.0064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.007339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.007356\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.007292\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.007257\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.007254, val_loss=0.049589, IC=-0.0053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.007197\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.007163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.007145\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.007106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.007077, val_loss=0.049697, IC=-0.0064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.007078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.007045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.007018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.006990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.006993, val_loss=0.049564, IC=-0.0065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.006932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.006948\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.006919\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.006898\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.006884, val_loss=0.049900, IC=-0.0066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.006868\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.006867\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.006833\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.006881\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.006825, val_loss=0.049959, IC=-0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.006835\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.006839\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.006792\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.006814\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.006816, val_loss=0.049885, IC=-0.0060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.006803\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.006796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.006778\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.006804\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.006763, val_loss=0.049881, IC=-0.0060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=45, IC=-0.0039 (653.4s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=20, IC=+0.0009 (1158.8s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 20 (IC=+0.0009)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/run_log/training/bcc444cba346/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 configurations: 6 trained, 0 read\n",
       "population sp500_equity_option_analytics-sequence-validation-v1: 120 prediction sets\n"
      ]
     }
@@ -639,13 +9465,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "575ddcf9",
+   "id": "4721232b",
    "metadata": {
     "papermill": {
-     "duration": 0.002422,
-     "end_time": "2026-09-09T03:36:33.440084+00:00",
+     "duration": 0.025209,
+     "end_time": "2026-09-08T21:10:21.066070+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:33.437662+00:00",
+     "start_time": "2026-09-08T21:10:21.040861+00:00",
      "status": "completed"
     }
    },
@@ -657,13 +9483,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "961b2e68",
+   "id": "821f002f",
    "metadata": {
     "papermill": {
-     "duration": 0.002421,
-     "end_time": "2026-09-09T03:36:33.445121+00:00",
+     "duration": 0.026154,
+     "end_time": "2026-09-08T21:10:21.116564+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:33.442700+00:00",
+     "start_time": "2026-09-08T21:10:21.090410+00:00",
      "status": "completed"
     }
    },
@@ -691,19 +9517,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "b048ba14",
+   "id": "0298cf2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:33.452016Z",
-     "iopub.status.busy": "2026-09-09T03:36:33.451792Z",
-     "iopub.status.idle": "2026-09-09T03:36:33.474933Z",
-     "shell.execute_reply": "2026-09-09T03:36:33.474415Z"
+     "iopub.execute_input": "2026-09-08T21:10:21.169978Z",
+     "iopub.status.busy": "2026-09-08T21:10:21.169761Z",
+     "iopub.status.idle": "2026-09-08T21:10:21.228211Z",
+     "shell.execute_reply": "2026-09-08T21:10:21.227732Z"
     },
     "papermill": {
-     "duration": 0.027673,
-     "end_time": "2026-09-09T03:36:33.475641+00:00",
+     "duration": 0.099248,
+     "end_time": "2026-09-08T21:10:21.242914+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:33.447968+00:00",
+     "start_time": "2026-09-08T21:10:21.143666+00:00",
      "status": "completed"
     },
     "tags": [
@@ -842,13 +9668,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82674915",
+   "id": "1cdfeec1",
    "metadata": {
     "papermill": {
-     "duration": 0.002451,
-     "end_time": "2026-09-09T03:36:33.481023+00:00",
+     "duration": 0.037143,
+     "end_time": "2026-09-08T21:10:21.318932+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:33.478572+00:00",
+     "start_time": "2026-09-08T21:10:21.281789+00:00",
      "status": "completed"
     }
    },
@@ -870,19 +9696,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "88b477cf",
+   "id": "4f1f6b53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:33.487333Z",
-     "iopub.status.busy": "2026-09-09T03:36:33.487148Z",
-     "iopub.status.idle": "2026-09-09T03:36:33.494042Z",
-     "shell.execute_reply": "2026-09-09T03:36:33.493533Z"
+     "iopub.execute_input": "2026-09-08T21:10:21.410009Z",
+     "iopub.status.busy": "2026-09-08T21:10:21.409821Z",
+     "iopub.status.idle": "2026-09-08T21:10:21.418594Z",
+     "shell.execute_reply": "2026-09-08T21:10:21.418127Z"
     },
     "papermill": {
-     "duration": 0.010941,
-     "end_time": "2026-09-09T03:36:33.494545+00:00",
+     "duration": 0.051636,
+     "end_time": "2026-09-08T21:10:21.419077+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:33.483604+00:00",
+     "start_time": "2026-09-08T21:10:21.367441+00:00",
      "status": "completed"
     },
     "tags": [
@@ -952,13 +9778,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb8357ad",
+   "id": "765ca694",
    "metadata": {
     "papermill": {
-     "duration": 0.002582,
-     "end_time": "2026-09-09T03:36:33.500104+00:00",
+     "duration": 0.042734,
+     "end_time": "2026-09-08T21:10:21.502123+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:33.497522+00:00",
+     "start_time": "2026-09-08T21:10:21.459389+00:00",
      "status": "completed"
     }
    },
@@ -975,13 +9801,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b909f69",
+   "id": "a5684bc0",
    "metadata": {
     "papermill": {
-     "duration": 0.003061,
-     "end_time": "2026-09-09T03:36:33.506090+00:00",
+     "duration": 0.028029,
+     "end_time": "2026-09-08T21:10:21.569685+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:33.503029+00:00",
+     "start_time": "2026-09-08T21:10:21.541656+00:00",
      "status": "completed"
     }
    },
@@ -1005,19 +9831,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "59d6cb0f",
+   "id": "7d776021",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T03:36:33.513752Z",
-     "iopub.status.busy": "2026-09-09T03:36:33.513569Z",
-     "iopub.status.idle": "2026-09-09T03:36:35.397243Z",
-     "shell.execute_reply": "2026-09-09T03:36:35.396345Z"
+     "iopub.execute_input": "2026-09-08T21:10:21.665671Z",
+     "iopub.status.busy": "2026-09-08T21:10:21.665418Z",
+     "iopub.status.idle": "2026-09-08T21:10:24.764090Z",
+     "shell.execute_reply": "2026-09-08T21:10:24.763394Z"
     },
     "papermill": {
-     "duration": 1.889226,
-     "end_time": "2026-09-09T03:36:35.398816+00:00",
+     "duration": 3.154653,
+     "end_time": "2026-09-08T21:10:24.764509+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:33.509590+00:00",
+     "start_time": "2026-09-08T21:10:21.609856+00:00",
      "status": "completed"
     }
    },
@@ -1734,13 +10560,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e989feb",
+   "id": "141b64fe",
    "metadata": {
     "papermill": {
-     "duration": 0.007097,
-     "end_time": "2026-09-09T03:36:35.412383+00:00",
+     "duration": 0.043394,
+     "end_time": "2026-09-08T21:10:24.869226+00:00",
      "exception": false,
-     "start_time": "2026-09-09T03:36:35.405286+00:00",
+     "start_time": "2026-09-08T21:10:24.825832+00:00",
      "status": "completed"
     }
    },
@@ -1791,24 +10617,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T03:36:47.571957+00:00",
+   "executed_at": "2026-09-08T21:10:40.141770+00:00",
    "executor": "local-uv",
-   "library_digest": "12818ba6d36651f6b5200430c8437086af41a3d472772c7d5417f70224197427",
-   "outputs_digest": "afb71ecdcc7ca61c2f4220e10ab1080bf2255a422ee72d27da38f1780bea7812",
+   "library_digest": "81bc94b583c996ee6e1d9be836ad939f8d10a9708b84a9538f2885e47bc276e3",
+   "outputs_digest": "beeab716305de452db84ec1daed2c0f4650642d44ee56ac10d2cce6dee509181",
    "parameters": {},
    "production": true,
    "source_py_blob": "191b1c0500a147c8bf85313b800ea8d0cd710739"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 27.165164,
-   "end_time": "2026-09-09T03:36:38.217872+00:00",
+   "duration": 4894.292653,
+   "end_time": "2026-09-08T21:10:29.019945+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-cs7-close/case_studies/sp500_equity_option_analytics/.09_dl_lstm.build.4096973.ipynb",
-   "output_path": "~/ml4t/public-cs7-close/case_studies/sp500_equity_option_analytics/.09_dl_lstm.papermill.4096973.ipynb",
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/.09_dl_lstm.build.4187860.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/.09_dl_lstm.papermill.4187860.ipynb",
    "parameters": {},
-   "start_time": "2026-09-09T03:36:11.052708+00:00",
+   "start_time": "2026-09-08T19:48:54.727292+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_equity_option_analytics/10_dl_patchtst.ipynb
+++ b/case_studies/sp500_equity_option_analytics/10_dl_patchtst.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fceffa62",
+   "id": "e63eb170",
    "metadata": {
     "papermill": {
-     "duration": 0.001709,
-     "end_time": "2026-09-06T18:29:39.731214+00:00",
+     "duration": 0.00116,
+     "end_time": "2026-09-08T17:42:53.737279+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:29:39.729505+00:00",
+     "start_time": "2026-09-08T17:42:53.736119+00:00",
      "status": "completed"
     }
    },
@@ -64,9 +64,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "aeecac02",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "d0d997e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:53.739658Z",
+     "iopub.status.busy": "2026-09-08T17:42:53.739550Z",
+     "iopub.status.idle": "2026-09-08T17:42:56.414261Z",
+     "shell.execute_reply": "2026-09-08T17:42:56.413619Z"
+    },
+    "papermill": {
+     "duration": 2.67647,
+     "end_time": "2026-09-08T17:42:56.414689+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:53.738219+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared option-analytics patched-transformer population on the walk-forward folds.\"\"\"\n",
@@ -89,9 +103,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "aeec66c4",
+   "execution_count": 2,
+   "id": "1d7e2ccb",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:56.418061Z",
+     "iopub.status.busy": "2026-09-08T17:42:56.417668Z",
+     "iopub.status.idle": "2026-09-08T17:42:56.420999Z",
+     "shell.execute_reply": "2026-09-08T17:42:56.420362Z"
+    },
+    "papermill": {
+     "duration": 0.005842,
+     "end_time": "2026-09-08T17:42:56.421704+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:56.415862+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -109,9 +136,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9725052e",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "f6c03e34",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:56.424551Z",
+     "iopub.status.busy": "2026-09-08T17:42:56.424442Z",
+     "iopub.status.idle": "2026-09-08T17:42:56.445325Z",
+     "shell.execute_reply": "2026-09-08T17:42:56.444858Z"
+    },
+    "papermill": {
+     "duration": 0.023099,
+     "end_time": "2026-09-08T17:42:56.446089+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:56.422990+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\n",
@@ -124,13 +165,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8e5a8e7",
+   "id": "ba41f8ac",
    "metadata": {
     "papermill": {
-     "duration": 0.000823,
-     "end_time": "2026-09-06T18:29:45.003575+00:00",
+     "duration": 0.000965,
+     "end_time": "2026-09-08T17:42:56.448921+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:29:45.002752+00:00",
+     "start_time": "2026-09-08T17:42:56.447956+00:00",
      "status": "completed"
     }
    },
@@ -155,20 +196,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "802723be",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "f6e229cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:56.451477Z",
+     "iopub.status.busy": "2026-09-08T17:42:56.451361Z",
+     "iopub.status.idle": "2026-09-08T17:42:56.468761Z",
+     "shell.execute_reply": "2026-09-08T17:42:56.468369Z"
+    },
+    "papermill": {
+     "duration": 0.019412,
+     "end_time": "2026-09-08T17:42:56.469138+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:56.449726+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('fwd_ret_10d', 'fwd_ret_5d', 'fwd_ret_risk_adj_5d')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "declared_labels(study, \"deep_learning\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ecf4a186",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "681eb0ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:56.471744Z",
+     "iopub.status.busy": "2026-09-08T17:42:56.471653Z",
+     "iopub.status.idle": "2026-09-08T17:42:56.516448Z",
+     "shell.execute_reply": "2026-09-08T17:42:56.516000Z"
+    },
+    "papermill": {
+     "duration": 0.046579,
+     "end_time": "2026-09-08T17:42:56.516782+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:56.470203+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=patchtst, d_model…</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (1, 5)\n",
+       "┌───────────────┬────────────┬─────────────┬─────────────┬─────────────────────────────────┐\n",
+       "│ family        ┆ label      ┆ config_name ┆ model_class ┆ params                          │\n",
+       "│ ---           ┆ ---        ┆ ---         ┆ ---         ┆ ---                             │\n",
+       "│ str           ┆ str        ┆ str         ┆ str         ┆ str                             │\n",
+       "╞═══════════════╪════════════╪═════════════╪═════════════╪═════════════════════════════════╡\n",
+       "│ deep_learning ┆ fwd_ret_5d ┆ patchtst    ┆             ┆ architecture=patchtst, d_model… │\n",
+       "└───────────────┴────────────┴─────────────┴─────────────┴─────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "configs = load_model_configs(\n",
     "    study,\n",
@@ -184,13 +292,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d25bbdb5",
+   "id": "fd670d5a",
    "metadata": {
     "papermill": {
-     "duration": 0.001289,
-     "end_time": "2026-09-06T18:29:45.100900+00:00",
+     "duration": 0.001024,
+     "end_time": "2026-09-08T17:42:56.519127+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:29:45.099611+00:00",
+     "start_time": "2026-09-08T17:42:56.518103+00:00",
      "status": "completed"
     }
    },
@@ -210,10 +318,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7aa27471",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "80910ee1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:56.522144Z",
+     "iopub.status.busy": "2026-09-08T17:42:56.521957Z",
+     "iopub.status.idle": "2026-09-08T17:42:56.525515Z",
+     "shell.execute_reply": "2026-09-08T17:42:56.524858Z"
+    },
+    "papermill": {
+     "duration": 0.005736,
+     "end_time": "2026-09-08T17:42:56.525824+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:56.520088+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training device: cuda\n"
+     ]
+    }
+   ],
    "source": [
     "PUBLISHED_DEVICE = \"cuda\"\n",
     "device = DEVICE or PUBLISHED_DEVICE\n",
@@ -232,13 +362,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ba7c95f",
+   "id": "f1d6a2e1",
    "metadata": {
     "papermill": {
-     "duration": 0.001728,
-     "end_time": "2026-09-06T18:29:45.113570+00:00",
+     "duration": 0.000967,
+     "end_time": "2026-09-08T17:42:56.528073+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:29:45.111842+00:00",
+     "start_time": "2026-09-08T17:42:56.527106+00:00",
      "status": "completed"
     }
    },
@@ -270,10 +400,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8925760a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "c1f2d6f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:56.530668Z",
+     "iopub.status.busy": "2026-09-08T17:42:56.530556Z",
+     "iopub.status.idle": "2026-09-08T17:43:00.197848Z",
+     "shell.execute_reply": "2026-09-08T17:43:00.197043Z"
+    },
+    "papermill": {
+     "duration": 3.669306,
+     "end_time": "2026-09-08T17:43:00.198360+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:56.529054+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>feature_count</th><th>eligible_entities</th><th>eligible_rows</th><th>folds</th><th>checkpoints</th><th>validation_start</th><th>validation_end</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td></tr></thead><tbody><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;patchtst&quot;</td><td>50</td><td>287</td><td>126478</td><td>2</td><td>20</td><td>2019-01-07 00:00:00</td><td>2020-12-23 00:00:00</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (1, 9)\n",
+       "┌────────────┬────────────┬────────────┬───────────┬───┬───────┬───────────┬───────────┬───────────┐\n",
+       "│ label      ┆ config_nam ┆ feature_co ┆ eligible_ ┆ … ┆ folds ┆ checkpoin ┆ validatio ┆ validatio │\n",
+       "│ ---        ┆ e          ┆ unt        ┆ entities  ┆   ┆ ---   ┆ ts        ┆ n_start   ┆ n_end     │\n",
+       "│ str        ┆ ---        ┆ ---        ┆ ---       ┆   ┆ i64   ┆ ---       ┆ ---       ┆ ---       │\n",
+       "│            ┆ str        ┆ i64        ┆ i64       ┆   ┆       ┆ i64       ┆ datetime[ ┆ datetime[ │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ μs]       ┆ μs]       │\n",
+       "╞════════════╪════════════╪════════════╪═══════════╪═══╪═══════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_ret_5d ┆ patchtst   ┆ 50         ┆ 287       ┆ … ┆ 2     ┆ 20        ┆ 2019-01-0 ┆ 2020-12-2 │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 7         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "└────────────┴────────────┴────────────┴───────────┴───┴───────┴───────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -300,13 +476,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67b908a1",
+   "id": "16ea299d",
    "metadata": {
     "papermill": {
-     "duration": 0.00206,
-     "end_time": "2026-09-06T18:29:48.293184+00:00",
+     "duration": 0.001079,
+     "end_time": "2026-09-08T17:43:00.200746+00:00",
      "exception": false,
-     "start_time": "2026-09-06T18:29:48.291124+00:00",
+     "start_time": "2026-09-08T17:43:00.199667+00:00",
      "status": "completed"
     }
    },
@@ -340,10 +516,1502 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6c29d70a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "59f8612a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:43:00.204053Z",
+     "iopub.status.busy": "2026-09-08T17:43:00.203838Z",
+     "iopub.status.idle": "2026-09-08T19:57:00.651601Z",
+     "shell.execute_reply": "2026-09-08T19:57:00.650751Z"
+    },
+    "papermill": {
+     "duration": 8040.461601,
+     "end_time": "2026-09-08T19:57:00.663399+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:43:00.201798+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=97,604 seq across 540 symbols\n",
+      "    val=64,593 seq across 564 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    patchtst:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.014461\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.004060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.002005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.001772, val_loss=0.001873, IC=+0.0095\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.001656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.001593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001556\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001527\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001508, val_loss=0.001602, IC=+0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001488\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001477\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001467\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001461, val_loss=0.001587, IC=-0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001459\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001450\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001449\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001447\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001445, val_loss=0.001581, IC=+0.0039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001440\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001424, val_loss=0.001571, IC=-0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001420\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001417\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001418\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001410\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001409, val_loss=0.001542, IC=+0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001402\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001397\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001394\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001394, val_loss=0.001527, IC=+0.0032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001387\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001385\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001385\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001382\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001377, val_loss=0.001556, IC=+0.0042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001374\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001370\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001360, val_loss=0.001567, IC=+0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001358\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001348\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001349, val_loss=0.001558, IC=-0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001336\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001334, val_loss=0.001584, IC=+0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001331\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001325\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001323\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001319\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001318, val_loss=0.001576, IC=+0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001313\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001314\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001310\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001311, val_loss=0.001572, IC=-0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001306\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001303\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001305\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001297, val_loss=0.001595, IC=-0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001298\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001296\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001290\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001294, val_loss=0.001584, IC=-0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001287\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001288, val_loss=0.001586, IC=+0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001284\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001283\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001281, val_loss=0.001601, IC=-0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001280\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001275, val_loss=0.001593, IC=-0.0018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001279\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001278\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001277\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001276, val_loss=0.001593, IC=-0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001276\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001275\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001274\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001279, val_loss=0.001592, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0095 (3957.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=110,846 seq across 537 symbols\n",
+      "    val=61,885 seq across 591 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    patchtst:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.026670\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.006154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.004034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.003076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.002559, val_loss=0.009685, IC=-0.0154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.002264\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.002076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.001947\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.001856\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.001801, val_loss=0.007036, IC=-0.0163\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.001774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001730\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001712\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001698\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001673, val_loss=0.006041, IC=-0.0139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.001659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.001649\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.001631\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.001622\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.001619, val_loss=0.006128, IC=-0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.001605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.001592\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.001598\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.001587\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.001571, val_loss=0.006190, IC=-0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.001562\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.001560\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.001565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.001548\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.001541, val_loss=0.006771, IC=-0.0102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.001542\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.001539\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.001522\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.001513\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.001513, val_loss=0.006560, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.001511\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.001509\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.001496\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.001498\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.001482, val_loss=0.006883, IC=-0.0053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.001492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.001475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.001470\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.001469\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.001463, val_loss=0.006887, IC=-0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.001464\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.001463\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.001475\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.001456\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.001448, val_loss=0.006725, IC=-0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.001441\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.001436\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.001433\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.001432\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.001427, val_loss=0.007186, IC=-0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.001419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.001414\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.001413\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.001422\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.001405, val_loss=0.007237, IC=-0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.001405\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.001412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.001398\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.001395\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.001392, val_loss=0.007134, IC=-0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.001389\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.001393\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.001381\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.001390\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.001378, val_loss=0.007278, IC=-0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.001372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.001376\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.001394\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.001372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.001366, val_loss=0.007316, IC=-0.0031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.001367\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.001365\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.001364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.001368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.001365, val_loss=0.007275, IC=-0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.001361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.001354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.001361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.001355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.001350, val_loss=0.007236, IC=-0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.001354\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.001352\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.001347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.001344\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.001356, val_loss=0.007263, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.001347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.001347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.001349\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.001347\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.001354, val_loss=0.007284, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.001350\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.001340\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.001355\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.001348\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.001343, val_loss=0.007286, IC=+0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=90, IC=+0.0008 (4045.0s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  patchtst: best_epoch=45, IC=+0.0010 (8002.9s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: patchtst @ epoch 45 (IC=+0.0010)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/run_log/training/f5b26538b221/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 configurations: 1 trained, 0 read\n",
+      "population sp500_equity_option_analytics-patchtst-validation-v1: 20 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "population_name = POPULATION_NAME or \"sp500_equity_option_analytics-patchtst-validation-v1\"\n",
     "execution, population = run_model_population(\n",
@@ -362,13 +2030,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b74b3267",
+   "id": "11edcf0f",
    "metadata": {
     "papermill": {
-     "duration": 0.00741,
-     "end_time": "2026-09-06T20:08:20.624435+00:00",
+     "duration": 0.014696,
+     "end_time": "2026-09-08T19:57:00.715559+00:00",
      "exception": false,
-     "start_time": "2026-09-06T20:08:20.617025+00:00",
+     "start_time": "2026-09-08T19:57:00.700863+00:00",
      "status": "completed"
     }
    },
@@ -389,14 +2057,104 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0cd1c285",
+   "execution_count": 9,
+   "id": "0020c3e0",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:57:00.744815Z",
+     "iopub.status.busy": "2026-09-08T19:57:00.744487Z",
+     "iopub.status.idle": "2026-09-08T19:57:00.799647Z",
+     "shell.execute_reply": "2026-09-08T19:57:00.794610Z"
+    },
+    "papermill": {
+     "duration": 0.086548,
+     "end_time": "2026-09-08T19:57:00.808567+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:57:00.722019+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20 candidate models across 1 label(s)\n",
+      "primary label fitted here: True\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (20, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>params</th><th>checkpoint_value</th><th>ic_mean</th><th>ic_std</th><th>ic_n_days</th><th>auc_mean_daily</th><th>full_coverage</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>bool</td></tr></thead><tbody><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>5</td><td>-0.002909</td><td>0.012456</td><td>497.0</td><td>0.503502</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>10</td><td>-0.00692</td><td>0.009335</td><td>497.0</td><td>0.495755</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>15</td><td>-0.008311</td><td>0.005602</td><td>497.0</td><td>0.49567</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>20</td><td>-0.003081</td><td>0.006954</td><td>497.0</td><td>0.498523</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>25</td><td>-0.003403</td><td>0.001308</td><td>497.0</td><td>0.496489</td><td>true</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>80</td><td>-0.000789</td><td>0.001219</td><td>497.0</td><td>0.494218</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>85</td><td>-0.001101</td><td>0.000592</td><td>497.0</td><td>0.495124</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>90</td><td>-0.000474</td><td>0.001279</td><td>497.0</td><td>0.494047</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>95</td><td>-0.000501</td><td>0.000845</td><td>497.0</td><td>0.494004</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;architecture=patchtst, d_model…</td><td>100</td><td>-0.000656</td><td>0.000712</td><td>497.0</td><td>0.493909</td><td>true</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (20, 8)\n",
+       "┌────────────┬────────────┬────────────┬───────────┬──────────┬───────────┬────────────┬───────────┐\n",
+       "│ label      ┆ params     ┆ checkpoint ┆ ic_mean   ┆ ic_std   ┆ ic_n_days ┆ auc_mean_d ┆ full_cove │\n",
+       "│ ---        ┆ ---        ┆ _value     ┆ ---       ┆ ---      ┆ ---       ┆ aily       ┆ rage      │\n",
+       "│ str        ┆ str        ┆ ---        ┆ f64       ┆ f64      ┆ f64       ┆ ---        ┆ ---       │\n",
+       "│            ┆            ┆ i64        ┆           ┆          ┆           ┆ f64        ┆ bool      │\n",
+       "╞════════════╪════════════╪════════════╪═══════════╪══════════╪═══════════╪════════════╪═══════════╡\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 5          ┆ -0.002909 ┆ 0.012456 ┆ 497.0     ┆ 0.503502   ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 10         ┆ -0.00692  ┆ 0.009335 ┆ 497.0     ┆ 0.495755   ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 15         ┆ -0.008311 ┆ 0.005602 ┆ 497.0     ┆ 0.49567    ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 20         ┆ -0.003081 ┆ 0.006954 ┆ 497.0     ┆ 0.498523   ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 25         ┆ -0.003403 ┆ 0.001308 ┆ 497.0     ┆ 0.496489   ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│ …          ┆ …          ┆ …          ┆ …         ┆ …        ┆ …         ┆ …          ┆ …         │\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 80         ┆ -0.000789 ┆ 0.001219 ┆ 497.0     ┆ 0.494218   ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 85         ┆ -0.001101 ┆ 0.000592 ┆ 497.0     ┆ 0.495124   ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 90         ┆ -0.000474 ┆ 0.001279 ┆ 497.0     ┆ 0.494047   ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 95         ┆ -0.000501 ┆ 0.000845 ┆ 497.0     ┆ 0.494004   ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│ fwd_ret_5d ┆ architectu ┆ 100        ┆ -0.000656 ┆ 0.000712 ┆ 497.0     ┆ 0.493909   ┆ true      │\n",
+       "│            ┆ re=patchts ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ t,         ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "│            ┆ d_model…   ┆            ┆           ┆          ┆           ┆            ┆           │\n",
+       "└────────────┴────────────┴────────────┴───────────┴──────────┴───────────┴────────────┴───────────┘"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "catalog = (\n",
     "    execution.catalog_rows.select(\n",
@@ -445,13 +2203,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f790b601",
+   "id": "d559dc1f",
    "metadata": {
     "papermill": {
-     "duration": 0.003973,
-     "end_time": "2026-09-06T20:08:20.670469+00:00",
+     "duration": 0.010281,
+     "end_time": "2026-09-08T19:57:00.827557+00:00",
      "exception": false,
-     "start_time": "2026-09-06T20:08:20.666496+00:00",
+     "start_time": "2026-09-08T19:57:00.817276+00:00",
      "status": "completed"
     }
    },
@@ -471,10 +2229,205 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "80ea6395",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "id": "fafa0ccc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T19:57:00.840555Z",
+     "iopub.status.busy": "2026-09-08T19:57:00.840283Z",
+     "iopub.status.idle": "2026-09-08T19:57:03.810165Z",
+     "shell.execute_reply": "2026-09-08T19:57:03.809626Z"
+    },
+    "papermill": {
+     "duration": 2.976677,
+     "end_time": "2026-09-08T19:57:03.810767+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T19:57:00.834090+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "#0a1628",
+          "width": 2
+         },
+         "marker": {
+          "size": 5
+         },
+         "mode": "lines+markers",
+         "name": "fwd_ret_5d",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          -0.002908994917420209,
+          -0.006920106358250045,
+          -0.008311078100471568,
+          -0.0030813445852066095,
+          -0.003402515206663349,
+          -0.003721162197160219,
+          -0.0001631336518672186,
+          -0.0005716166179533027,
+          0.0009611053287771531,
+          -0.0013210442119530764,
+          0.000496840981081204,
+          -0.00016459275624448205,
+          -0.0019381130349222639,
+          -0.001872797882006125,
+          -0.0023045438577062333,
+          -0.0007894892160245338,
+          -0.0011009753845008707,
+          -0.00047359321587246277,
+          -0.0005013553947030764,
+          -0.0006555769782137504
+         ]
+        }
+       ],
+       "layout": {
+        "height": 460,
+        "margin": {
+         "t": 90
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "Validation IC against training epoch"
+        },
+        "width": 880,
+        "xaxis": {
+         "title": {
+          "text": "Training epochs completed"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3AAAAHMCAYAAACUfUrwAAAQAElEQVR4AezdA2AcWxsG4HeDIrV7a7u3tm3rr23btm3bto3Utt1bu02T9N/vpJturN2s3t47PufMOc9MNvtlZs7Yubj8/M2BBjwHeA7wHOA5wHOA5wDPAZ4DPAd4DvAcMP9zwA78R4FgCzAjBShAAQpQgAIUoAAFKBCaAgzgQlOb+6IABf4KcI4CFKAABShAAQpQIMgCDOCCTMYMFKAABShgagHunwIUoAAFKGCrAgzgbPXIs90UoAAFKEAB2xRgqylAAQpYtAADOIs+fKw8BShAAQpQgAIUoEDoCXBPFDC9AAM40x8D1oACFKAABShAAQpQgAIUsHYBA7WPAZyBIFkMBShAAQpQgAIUoAAFKEABYwswgDO2sHmWz1pRgAIUoAAFKEABClCAAhYowADOAg8aq0wB0wpw7xSgAAUoQAEKUIACphJgAGcqee6XAhSggC0KsM0UoAAFKEABCoRIgAFciPiYmQIUoAAFKECB0BLgfihAAQpQAGAAx7OAAhSgAAUoQAEKUMDaBdg+CliNAAM4qzmUbAgFKEABClCAAhSgAAUoYHgB8yqRAZx5HQ/WhgIUoAAFKEABClCAAhSggJ8CDOD8pDHPDawVBShAAQpQgAIUoAAFKGC7AgzgbPfYs+W2J8AWU4ACFKAABShAAQpYuAADOAs/gKw+BShAgdAR4F4oQAEKUIACFDAHAQZw5nAUWAcKUIACFKCANQuwbRSgAAUoYDABBnAGo2RBFKAABShAAQpQgAKGFmB5FKCAVwEGcF49uEQBClCAAhSgAAUoQAEKWIeAVbaCAZxVHlY2igIUoAAFKEABClCAAhSwRgEGcKF1VLkfClCAAhSgAAUoQAEKUIACIRRgABdCQGanQGgIcB8UoAAFKEABClCAAhQQAQZwosCBAhSggPUKsGUUoAAFKEABCliRAAM4KzqYbAoFKEABClDAsAIsjQIUoAAFzE2AAZy5HRHWhwIUoAAFKEABCliDANtAAQoYRYABnFFYWSgFKEABClCAAhSgAAUoEFwB5vNbgAGc3zbcQgEKUIACFKAABShAAQpQwKwEGMAFeDiYgAIUoAAFKEABClCAAhSggHkIMIAzj+PAWlirANtFAQpQgAIUoAAFKEABAwowgDMgJouiAAUoYEgBlkUBClCAAhSgAAW8CzCA8y7CZQpQgAIUoIDlC7AFFKAABShgpQIM4Kz0wLJZFKAABShAAQpQIHgCzEUBCpizAAM4cz46rBsFKGB2Aleu30LUBJnw9t0HVbdZ81egYKlaat6v0dJVG5GrSGW/Ngd6fWD2FejCrCihtbgEpx0NW3ZFr4Gjreho+t+UmEmyYd+h4/4n4lYKUMC0Aty70QUYwBmdmDugAAXMQWDG3GVIlDYffvz46aM67u7u+DdPWQwfO83HtoBW/BM3NjL/my6gZEHeLnXdvuugl3zG2peXnWgXOnQfjCp1Wmnn/v7//sNHdO49DLmLVkWC1HmUV80GbbFhy66/iUw0Z2iXC5euQYL0Dx8/+duiabOXoEi5Ov6mCcrG4LQjTarkSJo4YVB2w7QUoAAFKGDhAtYcwFn4oWH1KUABQwrUrFoOP11csGn7Hh/Fyl/0Hz95hnq1qvjYFtCKSuWKY8rYgQElM8j20NyXfoWfPX+JPEWrYeuOfahWqQzmTh2Fgb3aI2vmDBgxbgZcXV31k4f6vKlcDN3Q4LSjd9c2aNmkjqGrwvIoQAEKUMCMBRjAmfHBYdVMKcB9W5tAzBjRUL50Maxev91H01at24YiBfMgcaL4mLtoJarXa4Mk6Qsge8GK6qqcfwGKb7e9yZUZyStl1GnaER8/fvayz137jqBFhz5Il6MkUmcppubfvH3vmSZbgQr49PkL6jbrpK4ESTrZ6H1fLi6/MGzMVOQoVBEJ0+RF+RrNcML5nCRVw8nT51X+A0dOqCtFkqZCzWY4d+GK2h7YUY8Bo/D9xw8c3rkK3Ts2R5mShVQg16tLaxzdvQb29va+FnX95l306D8SuYpUUVc/K/2vBS5dveEl7b0Hj1Cjfhu1XdKtWr8VmfKWxZoNf49TQMfEu8v4qfNRpmpjzFm4Utkky1gIzdr1wsv/Xnvue4s2GK1apzUSp8sPudpWuGxtPH/xCo8eP1NWklCOn2yTYyXL+sOKtVvQb+h46K7WSbpFy9apJDGTZMPiFesh5UsZoyfOxpev39SxKlm5gTpWsj/vVy+9t0POw/7Dxqsrn2mzl0DG3GUwZNQULwGz91soZd9yy67ONH+JGtpzfpuql24UGHNdWt3Uzc0NU2ctgZQXP1UeZSSGuu26c23+ktUoXKa2ukpbtloT5aNLI1M59yrXbqncs+Yvrwy/f/8hm9QgV8PFoWj5upD9lKjUQB1HtfHP6NV/bzzPGanP6vXb/mzhhAIUoIBtCNjZRjPZSgpQgAJAnZoVcfDISfUlXefx8dNnbN99AHVqVFSrPn3+hq4dmuHyqZ0YM6wXjp86j5HjZ6htgRlJANJv6Hh0bNMYF45vQ54c2bRffBd7yfrh40dULlcSx/asweolUxE2TBg0aNEVv3//VunOHd2KyJEiYvm8Sfjw9BKun9mj1nsfDRwxURtwrsboob1w6eQOyO10lf7XEnfuPfKSdMmKjRg/vA9OH9qEhPHjoVWnvp778pLQlwUJXnftPaK9ylMb8ePF9ZEifPhw0Gg0PtbLio+fPiFj+jRYs3gaju9di6KF8mqDmlaegdSvX7/wv0btETZcWBzZtRqLZo3F5u178eHDJ8nuOQTnmFy8cl0FZGuXzMCmVbNx/+ETjBo/S5X5+ctXNG3bC/+rXl65XTy+HY3qVFPtkCD+4PYVKt3Da0eV/5wpI9Sy/kjOl2H9uyJLpvQqjRynRvWqeyaRoK1x/eq4eW4fWjerCxft1d+wYcNh4sj+ap9tm9dHn8HjAnyea/nqLciR9V/lN2FkXyxYuhbrN/t/2+rchavQqlk9tZ86NStpj3c/PHz0VNUtsOYqsd5ozKTZ2LJzHwb364zrZ/egZ6dWGDRiEuSPEXrJsGLtVkg9L2hN5XyUW3F1t6LKldyKtVogbuxYkHN82vjBWKkNhLv1HeFZxOiJszB55kJ0aNUIN87txZghPbV/PPjpuV1mJs9YgEwZ02LGhKFIlTKZl/bJdg4UoAAFrF2AAZy1H2G2jwIU8BQoqr3KljBBPKxct9Vz3UrtF86IEZxQoUwxta5r+6bIkzOrCqCKFsyLnp1bYvmaLWpbYEaLl29A1YqlUf9/VRAtahS0b9UAadOk8JL1f9UqoGypwogeLSoyZ0ynvvA6n72Im7fve0nn34JctZi3eA26dWgBqaeUNWpwd8T7JzbmL1nlJWufbm3V7Y7yjJXURwK8V6/feEnj18JD7RUpN+3VFwnE/Erj13pxFAcJisS9Y+tGyJAuNXbs9ni27+DRU9rA6qkKapIkToC0qVNAgqKP2qBav8zgHJNoWvtBfTpByv1XG0TW1Qbvp89dVMW+1V7tlEAmf57siBolskojwZf4qAQGGNWpUUGdU+G0wakE43J85Opl+rQp1XGvUaUsGtWtjlV65yL+/NOfFC+ST/1xQfKXKJIfxQrnw5nzV/ST+Jhv0qAGihXKq86/Ns3rIXbMGDh/6apKF1hzlfjP6OdPF0yasRBDtcGblBslciSULlEQDbX1X7zC46rjn6To3bW1OtdixYyOUYN7wNHRwfM5ySUrN0B+1iaO6ge5Ip43Vzb079le+/O1Ga/fvFNXFmU/fbq1QeXyJdTPoATIct7oypfp/6pXRL8e7VG+TFHMmTJcpTt30X8TyceBAhSggLUIMICzliPJdlCAAgEKaDQa1KtVWXuVYIvnFaglK9dDvkzLF20p4NSZC6jTtCPSZCuubq2r9L8WePnqNb59+y6bAxzuP3iMQvlzeklXuEBuL8tPnj5Hp55DIbdZyq13sZJmhwRJT54995LOvwUJrCQIkS/4unQODg6QW0GlDrp1Mk0QL45M1BBL+2VeZuQLs0wDGuzsNCqJvZ29mgZlJGajJsxC4TK1IW2Uth4+5ownT1+oYh49fopE2oA6lvbLvlqhHSVPmhiRIkbQzv39PzjHJGH8f/4WoJ2LGSMG/nv9VjsHSFCXL3d2yO15fQaP1V7FXOnlqqxKFMJR5ozpfZSwct0WlKveVN0uKhajJsz0tPCR+M+K+P/8PXayKlbMaNpgx6MdsuzbEM9bnjixY2rzvFNJA2uuEv8ZPdBevZMgrnSVRupnQuouw8DhE/HgoceVvT9JIcGybj5MGEekT5tKG6Q/UavuaX82CuTLAblqq1ZoRxKUaifaNI9x9/5jyH5yZsssq/wc0qVJ6blNznk5h/RvQfbcaJszbDUFKGADAgzgbOAgs4kUoMBfgYZ1qmq/ND/HIe3VH3l+SZ7Tqqe9WiYpPJ4NaotaVStg98bFePvoPHasXyCb4PLrl5oGZmTv7ZkwB71luU2yat1WkC/iy+dPxqt7Z/Du8QXtlQpH/HJxDUzxXtLIF1j9FQ72DvqLat7OzudHvdRDbQxglCRRAlW3h9pgK4CkPjbLLYIXr1zD1PGDcPvCfshthnIFJyBL/boF95gE1Ob1y2Zor/60Q7iwYbVXZLchV9EqOHbyrI82BHdFuPBhvWSV57RGT5yNAb3aq1tZxUKuIgVkYfcngPZSGDxutfW67u+S723/u923OX1z79s1Go8g/uT+9eoYSt11w6kDG7wn97GsX7b3nw17B59/GNBoPPbno6A/Kxy85dFoNNo/yPzZyAkFKBACAWa1FAGfv9UtpeasJwUoQIFgCMSNEwulihXA6vXbtV/ctyB71n+RQXuVQIo6f/EaYsaIDukNUG77ky+bV67dkk2BHpIlTYSr173muXztpmf+Fy//U8+oybNJqVMmRdiwYXDt5h3I1TTPRNqZ8OHCwf23u3bO9/+TJIqvOg+5fPW6lwRyq5zUwcvKECxIMFC3ZiVMmbVIPVPmvSi5lVP/C7r+dunYonzpYsiYLrW6nU+urkhbdWkSa4PDx9qrkfpXAyVgkw4/dGkMcUx0ZelP5Yqr3Mo6oFcHHNi2HNkyZ8SufYdVkrDaoE5mpEMNmfo1hAsXBr/d/Q+mdHlPnb2IfLmyIVf2zJBzUNZf0TsvZDk0hsCYe69H8qQJ1VWz/YdOeN/kY1n/XHdx+YVrN24jaeIEKl1y7c/G5at/fxZk5YWLHudvsiSJkCJZIvXzoLvVVbZzoAAFKEABnwJmGcD5rCbXUIACFDCcQO0albB1535s3LoH9bTBia5kud3r+ctXuPInAJP3sE2Z5bUDEl1av6YN61bF8tWbIXmh/Se3ze3Zf1Q75/G/3M4WP15c7D90XK24fvOuup1SgkW14s8oebLE2i+/d/4s+ZzIbWgtGv8PI8fPxPFTZ/Hu/QeMmTQHV7QBZ/NG//OZIQRrendrDbnoU7B0LYybMg879xyG3Ao5NRjisQAAEABJREFURru/AqVqqts/fSs+Y/rUOHL8tHq2SW5xa925P/SfbytSIDcSJ4yHjj0HQzrZuHHrLrr1Ham+xOvKM8Qx0ZWlm8p+xk+dj6fPPG7llH3fu//IM9BImOAfVYer12/rsvg6TaoNOiQA1XXS4WuiPyszpkuFcxevquMkwfqEafOx58Df8+JPMqNPAmPuvRJylVeetZQ6r1i7RbVBAvd1m3Zi2epNXpKPmTQb57XtlKC818Ax2j9MuKJ65bIqjTwP+fjJc9WTppwPp89ewtAxUyB/IJDbaGU/ndo0xvCx07Fp215IT6xylXzyzEUqP0cUoAAFKOAhwADOw4Fj6xFgSygQoEDZkoUQTnv15Nu3H6hR1ePLpWRKlyYFpo8fgjad+quu78dPm4chfTvJpkAPclWnZ+dWkB4iM+crhzUbdqBzu6ae+SVQWz5vIjZv34c8xarhf407oEenlojgFN4zjcy0b9kQ0+csUc8c6V4jIOv1h8F9OqvOHjr1HIJMecqqYGnzqtlInjSxfrIQz8eJFRMnD6xHhbLFsW7TDtUlf7V6beB85gL6dm8L+eLt205GDOwOuYqVt3g1SPCXOmUyFC2UxzOpo6Mj1i6djh/fXZCvRA3IM1bVKpWGdJIROXIklc4Qx0QVpDdyCh9eG4CeQoZcpSHPcmUrWBGliheEdCoiyeQZvM5tm6BireaQ7b69RkDSSTD0b4Y0SJK+gEqne42AbPM+SNnlShVGsfL1kLNwFe1V2tvo3PbveeE9vbGWA2Pu2767tGuibv+UXjAz5ioDCdwlePN+3nZp2wx1m3XW2pbCzdv3sHHFLEhHMVJmgvj/YNvaeTh74Qqy5i+PVp36oljhvBg3vI9sVkMP7c9C2+b1MW7yHKTMXATFK9bHK73XP6hEHFGAAhSwcQEGcDZ+ArD5FLBFAfkSe+/yYTy7fVIbODnpEQDVK5fB0T1r4Hxwo7q1rlqlMuq5H92X0IzpUqvlGNGjqnytmtbBkd2r1bxu1K5lA5w9sgXSPb18ge3YuhGcD/69UpH533TYumYe5Jmiyyd3qFs6H984jnKli+iKUO9ae3LzhNqX7jUC3vclnUTIc1RnDm+BpJUvx9Kzn66QPDmzqvzhwoXVrYL0/ifPL/2bPo3nOu8zU8YOVF+89ddHixoFE0f2gzzzJG5vHp7D+uUzUaVCKf1kXuZjx4qBedNG4fShzepVCKpHz3mTMHxAN890EmxuWDFTHYtH149BegqVzkaSJk7omSagY+LdRXqt3LlhoWd+mZHbYuWYy7zcHrtl9VxlIxbyrOPkMQPULamyXYZeXVp7bvftNQKSRm4v3bRytme6Rn9eIyA2xQvnkySeg6Tt37ODerXEhePbsGDGaG3g3gK6VxZIQu/tWKee0+sgmzyHUYN7YvHs8Z7LMi/rdCt82/cR7fkpZevSBMZcl1Y31Wg0KsDdt2WpOlZyfkvbvR//wgVy4cbZverZTnl+VHqR1JUhU1kWeznfzx/bhqH9uqrbM2WbDPIHDvn5ObZ3rSpDjo38IUC2yRCY9kk6DhSgAAWsWYABnDUfXbaNAhSggJkLbNy6G3sPHoO8m+3MuUto0qan6klTng8086r7rJ6FrKG5hRwoVpMCFKCAHwIM4PyA4WoKUIACFAgdgbZdBiBhmrxo2q43kidNhPnTR4XOjm14LzQ3v4PPGlGAAhQIrAADuMBKMR0FKEABChhcQG7Bu33hgLoNUW4nnT5hCOSl1QbfEQv0FDCGuW+363rukDMUoICxBVi+jQkwgLOxA87mUoACFKAABShAAQpQgAKWK2DYAM5yHVhzClCAAhSgAAUoQAEKUIACZi/AAM7sD5HtVJAtpQAFKEABClCAAhSgAAX8F2AA578Pt1KAApYhwFpSgAIUoAAFKEABmxBgAGcTh5mNpAAFKEABvwW4hQIUoAAFKGA5AgzgLOdYsaYUoAAFKEABCpibAOtDAQpQIJQFGMCFMjh3RwEKUIACFKAABShAARHgQIHgCDCAC44a81CAAhSgAAUoQAEKUIACFDCBwJ8AzgR75i4pQAEKUIACFKAABShAAQpQIEgCDOCCxMXEvgpwJQUoQAEKUIACFKAABSgQKgIM4EKFmTuhAAX8EuB6ClCAAhSgAAUoQIHACzCAC7wVU1KAAhSggHkJsDYUoAAFKEABmxNgAGdzh5wNpgAFKEABClAAoAEFKEAByxRgAGeZx421pgAFKEABClCAAhQwlQD3SwETCjCAMyE+d00BClCAAhSgAAUoQAEK2JZASFvLAC6kgsxPAQpQgAIUoAAFKEABClAglAQYwIUStHnuhrWiAAUoQAEKUIACFKAABSxJgAGcJR0t1pUC5iTAulCAAhSgAAUoQAEKhLoAA7hQJ+cOKUABClCAAhSgAAUoQAEKBE+AAVzw3JiLAhSgAAUoQAHTCHCvFKAABWxagAGcTR9+Np4CFKAABShAAQrYkgDbSgHLF2AAZ/nHkC2gAAUoQAEKUIACFKAABYwtYCblM4AzkwPBalCAAhSgAAUoQAEKUIACFAhIgAFcQELmuZ21ogAFKEABClCAAhSgAAVsUIABnA0edDbZ1gXYfgpQgAIUoAAFKEABSxVgAGepR471pgAFKGAKAe6TAhSgAAUoQAGTCjCAMyk/d04BClCAAhSwHQG2lAIUoAAFQi7AAC7khiyBAhSgAAUoQAEKUMC4AiydAhT4I8AA7g8EJxSgAAUoQAEKUIACFKCANQpYV5sYwFnX8WRrKEABClCAAhSgAAUoQAErFmAAF8oHl7ujAAUoQAEKUIACFKAABSgQXAEGcMGVYz4KhL4A90gBClCAAhSgAAUoYOMCDOBs/ARg8ylAAVsRYDspQAEKUIACFLAGAQZw1nAU2QYKUIACFKCAMQVYNgUoQAEKmI0AAzizORSsCAUoQAEKUIACFLA+AbaIAhQwrAADOMN6sjQKUIACFKAABShAAQpQwDACLMUXAQZwvqBwFQUoQAEKUIACFKAABShAAXMUYAAX2KPCdBSgAAUoQAEKUIACFKAABUwswADOxAeAu7cNAbaSAhSgAAUoQAEKUIAChhBgAGcIRZZBAQpQwHgCLJkCFKAABShAAQp4CjCA86TgDAUoQAEKUMDaBNgeClCAAhSwNgEGcCE8oo6OYaA/vHz5Ci1atPSyTn8757162ZrHr1+/eG54+5mxtXPAr/a6uLjAwcGR5wfPDx/nwK9frrC3d/Cx3q9ziett5/eMm5sb7OzsjHdu8OfRYm3d3d0BaMy2/uC/EAkwgAsRHzNTgAIUoAAFKEABClCAAt4FuGw8AQZwxrNlyRSgAAUoQAEKUIACFKAABQwqYAMBnEG9WBgFKEABClCAAhSgAAUoQAGTCTCAMxk9d2wRAqwkBShAAQpQgAIUoAAFzEiAAZwZHQxWhQIUsC4BtoYCFKAABShAAQoYWoABnKFFWR4FKEABClAg5AIsgQIUoAAFKOCrAAM4X1m4kgIUoAAFKEABCliqAOtNAQpYswADOGs+umwbBShAAQpQgAIUoAAFgiLAtGYvwADO7A8RK0gBClCAAhSgAAUoQAEKUMBDwJwDOI8ackwBClCAAhSgAAUoQAEKUIACSoABnGLgyPoE2CIKUIACFKAABShAAQpYnwADOOs7pmwRBSgQUgHmpwAFKEABClCAAmYqwADOTA8Mq0UBClCAApYpwFpTgAIUoAAFjCnAAM6YuiybAhSgAAUoQAEKBF6AKSlAAQoEKMAALkAiJqAABShg/QIvX71G38FjUbVuS8yavxzu7u7W32i2kAIUoIBVCbAxtiLAAM5WjjTbSQEKUMAPAQnWylVvjEkzFmD3viPo2mcYRoyb7kdqrqYABShAAQpQwJQCRgngTNkg7psCFKAABYIm8OTpC9y8fc9Lpm0793tZ5gIFKEABClCAAuYhwADOPI4Da/FXgHMUoEAoC8SMGU27R412+Pt/zJjR/y5wjgIUoAAFKEABsxFgAGc2h4IVoQAFQi7AEoIjMHHafPz+7a4dfqvsv7WT6NGiqnmOKEABClCAAhQwLwEGcOZ1PFgbClCAAqEqsGf/EYwcPwMajQbL503C4rkTtPv/jW279uPV6zfaeRv6n02lAAUoQAEKWIAAAzgLOEisIgUoQAFjCNy++wD1mnVWRffo1BJVKpZG9YplUK1SGfz86YKho6aobRxRgAIBCzAFBShAgdASYAAXWtLcDwUoQAEzEvj46TOq1G6Br9++oXD+3BjQq6Nn7Yb26wo7OzssXrEed+499FzPGQpQgAIUMIoAC6VAkAQYwAWJi4kpQAEKWL7A79+/UadxBzx8/BRJEiXAioVT1C2UupYlSZwATRvUUu+C6z9svG41pxSgAAUoQAEKmIGA1wDODCrEKlCAAhSggHEFBo+chEPHTiGCkxM2rpyDKJEj+dhh725t4OQUHlt37MOFS9d8bOcKClCAAhSgAAVMI8AAzjTuVrlXNooCFDB/ga0792Hs5DmqosvmTUSqFEnVvPdRnFgx0aFVI7W6W9/hasoRBShAAQpQgAKmF2AAZ/pjwBpQgAIADUJBQDotadSqm9pTz86tULJYQTXv16hLu2aIFjUKTp25gJ17D/mVjOspQAEKUIACFAhFAQZwoYjNXVGAAhQwlYCu05IfP35COi3p37NDgFWJEMEJvbu2Uel6DRilnolTC2Y3YoUoQAEKUIACtiPAAM52jjVbSgEK2KiAu7u7v52W+MfSonFt/BM3Nu7ef4QVa7f4l9Rqtrm6uqL3oDFIlDYPMuQsiQVL1lhN29gQXwS4igIUoICFCTCAs7ADxupSgAIUCKrAgGETAuy0xK8yHR0dIa8VkO2DRkzEr1+/ZNaqh6WrNmLKzIV4++4DHjx6gvbdB+LiletW3WY2jgIUCJ4Ac1HAFAIM4Eyhzn1SgAIUCCWBjVt3Y+L0+Wpvi2aN87PTEpXAj1HtGhWRPm1KvHj5H2bMXeZHKutZfdL5vI/GTJ6x0Mc6rqAABShAAQqEQCDYWRnABZuOGSlAAQqYt8DV67fRrF1PVUl5lq1sqSJqPjij4QN7qGxjJ8+GPE+nFqx0lDDBPz5atnr9VnU75bpNO3xs4woKUIACFKBAaAowgAtNbXPdF+tFAQpYncC79x9QtW5LSKclJYoWQN/u7RCSfyWK5EfuHFnw/sNHjJ8yNyRFmX3eHXsO4vdvwNHRAUkTJ1S9dSaI/4+6nbJhy67IU7QKjp44Y/btYAUpQAEKUMA6Beyss1lsFQUoEFoC3I/5CUinJTUbtMWz5y+RJFECyPveNBpNiCs6bnhfVca0OYvx6vUbNW9tI3lH3uWrNxE9WhTcvnAIV0/vwcYVs3H55C4MG9ANUaNExuVrN1G6SgNUqtUM127csTYCtocCFKAABcxcgAGcmR8gVo8CFKBAUAX6DB6Lk6fPI4KTEzaunIOIESIEtQhf02fJlB6Vy2lfPRQAABAASURBVJfEz58uGDJysq9pgrjSrJLfvH0PQ0dPUXWaOKo/YseKoeZlFC5cWHRu2xQ3zu1HpzZNEDZsGOw7dBw5C1dEkzbd8ejxM0nGgQIUoAAFKGB0AQZwRifmDihAAQqEnoA8ozV11iK1Q7nylipFUjVvqNHwAd1hZ2eHxSvW4869h4Yq1uTlyKsDGrbsCjc3N5QvXQw1qpTztU6RI0XE8IHdce30XtT/XxVoNBqsXr8NmfKWQfd+I1TPlb5m5EojCLBIClCAArYpwADONo87W00BClihgNzO17x9L9WyXl1aq2e31IIBR0kSJ0CjetXx+/dv9Bs6zoAlm7ao0RNn4er1W4gVMzpmThoWYGXk3XizJo/A2SNbUaZEYfV6hRlzlyJ9juIYNWEmvn//Af6jAAXMWIBVo4AFCzCAs+CDx6pTgAIU0AlIpyVV6rSAi8svSKcl/Xq0120y+FTKllsIt+3cjwuXrhm8/NAu8Mq1m5AATvY7Z8pIRI8WVWYDNaRJlRzrls3Evq3LIbeYfv7yVd2GmT5HCcxbvApyZS9QBTERBShAAQpYjICpK8oAztRHgPunAAUoEEIBue3PGJ2W+FWtOLFiokOrRmpzt77D1dRSRy4uLtDdOlm7RsVgX7XMkzMrju1ZhxULJiNl8iSqk5eOPQYjW4EK2LRtj6XysN4UoAAFKGCGAgzgzPCgBL5KTEkBClAA6DlglFE6LfHPtkv75ogWNQpOnbmAHbsP+pfUrLcNGzMNt+7cR9w4sTBhZP8Q17VSuZI4d3QbpowZhLixY+Hu/Yeo27Qj8pesro5RiHfAAihAAQpQwOYFGMAF8hRYs2k36rXqjQat++LIyfOBzMVkFDBjAVbNKgSk05KZ85apthij0xJVsC8j6cyjZ+dWakvvQaMhry5QCxY0OnfhCiZMm6dqPH/6GEib1EIIR/b29mjasJZ6BUH/nh0QKWIEdatp8Qp1UbVOS756IIS+zE4BClDA1gUYwAXiDHj05AWWrNqK2RMGYMygzhg+fg5+/HQJRE4moQAFKGA8gUtXrkPXaUnvrm2CfftfcGooeVo1rQvpzOPu/UdYvmazrLKY4cePn+rWSemMpXG9GihcILfB6x4+fDhIZzLXzuxDm+b14ejoiN37jyBXkUpo3q4Xnj57YfB9skAKUIACFLB+AQZwgTjGx06dR6F82RHBKTzixomJNCmT4sz5q+A/ClCAAqYSeP3mHapor+a4/Om0pG/3dqFeFQlIBvftrPY7eOQk1ROjWrCA0cARE/Hg0RMkTBAPo4d49NxprGrHiB4VY4f1waUTO1GzajnVg+eKtZuRMXcp9Bo4Gu8/fDTWrs21XNaLAhSgAAVCIMAALhB4r9++Q7y4sTxTJogXB/+9eauWO3QfCP1h6JhpePzqs5d1y5cvR0CDfhl+zQdUhmz3K6/+ekkX0KCf3q/5gMqQ7X7l1V8v6QIa9NP7NR9QGbLdr7z66yVdQIMufftuA+DXsGzZMngfVq9e42Vde3/y67Z5L8O3ZV1a/6a+5fO+zr/8um3e8/i2rEvr39S3fN7X+Zdft817Ht+WdWn9m/qWz/s6//Lrti1duhQBDbq0+tPu/Uaqzw3dOv/KWLx4MQqXrg5Xdw0SJkyEf+LE8pJXV4ZM/StHt03SBTTo0nqfun7/hNgxo+PFy/9QoVYLP38edOV7z+/bsi6tf1Pf8nlf51f+Ok07YuX6HYgRMxZqVSqGDRvW+3nMlixZEmCbZD/e9+3b8rgpsxExghOqViqNNGlSIVLkqFixbjuyFaqCUlUaoU3nvr7WY9WqVZBzUVdm+wA+Nzpot+vS+jcNqBzZ7l9+3TZJF9CgS+vfNKAyZLt/+XXbJF1Agy6tf9OAypDt/uXXbZN0AQ26tP5NfSuja5/hkM5ydNv8y6/bpkvr31SX1r+pf/l12/zLr9umS+vfVJfWY+r7Z6x/+XXb5OcooEGX1r9pQGXIdv/y67ZJuoAGXVr/pr6VIZ8bK1euhG5be+3nQkCDLq1/04DKkO3+5ddtU1+iOQq2AAO4QNJp7P5SaTQaz1w/f7pAf5C/hv/+DW/rXODi4v+gX4Zf8wGVIdv9yqu/XtIFNOin92s+oDJku1959ddLuoAG/fR+zQdUhmz3K6/+ekkX0KBL/+uXq/aqg++DdB/uc/iluhXXrfcvv26bLq1/U11a/6b+5ddt8y+/bpsurX9TXVr/pv7l123zL79umy6tf1NdWv+m/uXXbfMvv26bPAsW0KBL69/UvzJWbtiNh09ewNHBATkyp1NXdPwqy79ydNv8yqu/XpfW+xT4jWoViqrPxDv3H+P7959+/kxIed7z+7Ys6QIafMvnfZ1vZcjP7vlLN6HR2CFJwnhIlji+en7Pe17dsvTw6Vs53tfp0vs31eWJED689rilR+7sGRElUiS4ubnj5p2H2Hf4NA6fOKc+IwJTjq48H1M3N3/bpCvbRz5fPs90af2bshx3f73pYz4+us9y/6aBOV7+5ddtM3U5Hvv/+53DY9nV389nXd39mxqqHPVLwxQjK9nn36jEShpkjGbEihEdH/RucZH3LcWOGUPtavaUkdAfhvbrjMRxI3lZ17hxYwQ06Jfh13xAZch2v/Lqr5d0AQ366f2aD6gM2e5XXv31ki6gQT+9X/MBlSHb/cqrv17SBTTo0s+aPAJ+DY0aNUIjb0PdunW9rPMrr/5672X4tqyf3q953/J5X+dXXv313vP4tqyf3q953/J5X+dXXv313vP4tqyf3q953/J5X+dXXv31DRs2RECDfnrd/KTR/TFz0nDP88mvMhzCRcHRUxfU58/MCYOwdN5Ezzy6svSnfpWjv14/vV/z+um9z48bNRS5c2TByxfP1TNxfpUh673n9W1Z0gU0+JbP+zrfynBycsKTJ48RySkM9mxaHOCxks8C38rxvs77vn1b9p5nzeLpuHxyG8YO6Y6ITo549uwpJDifMm8tosWK51m3OnXqoEGDBp7L3svxvjxz4nDPtL7VQ7fOez7flnVp/Zv6ls/7Ov/y67Z5z+Pbsi6tf1Pf8nlf519+3TbveXxb1qX1b+pbPu/r/Muv2+Y9jyxPGTsQMyYO9fwM0KX1byr5Ahr8y6/bFlAZsl2X1r+ppAto8C+/bltAZch275/pvi1LuoAG3/J5XxdQGbLdex7fliVdQINv+erXr6c+N3TbAipDtuvS+jeVdAEN/uXXbVO/xDgKtgADuEDQ5c+dVfuF6Tx+aq+ivXv/Eddv3Ucu7V9OA5HVryRcTwEKmFjg85evaN2pL/5JkQPZC1awiK7wpdOSNl36KzlTdFqiduzHaNzwvmrL9LlL1DvQ1IKZjQ4dPYW5i1aqWi2ePR7hwoVV86YcaTQa9VzcxeM71HNyMWNEw+27D1C7cQfkLV4NpSo3RLKMBVGoTC0cPuZsyqpy3xSgAAUoYCYCDOACcSASJ/wHVcoVQ9MOA9Gpzxh0btMAYRwdA5GTSShgDAGWaQiBKTMXYsnKDfj0+Qtu3LoLeS7q1es3hijaKGVI3arUbqlurytTsjD69WhvlP0Et9AsmdKjYtkS6vbxwSMmBbcYo+WTgF3XY2fntk2RLUtGo+0rOAVLhzDSU+XV03tVz5Vhw4bBxcvXcezkaUjdz1+8inrNOqnjH5zymYcCFKAABaxHgAFcII9lzcqlsGzWSCyZORyF8mYLZC4mowAFzFXg9NmLXqr269cvNGndA9t3HfCy3lwWajdur65spUyeBItmjQ9+tYyYU9cj5eIV63Hn3kMj7inoRfcaMArPX7xC6pTJMGxAt6AXEEo55J1x8u64G+f2I0qUiF72+u79B9x78NjLOi5QgAIUoIDtCTCAs71jzhZTgAJagayZM2jHf/+X94EdPHICNRu2RcwkWdC4dTds27n/bwITzrXrOgDOZy5CejBcs2SGmpqwOn7uOlWKpGhSv6ba3m/oODU1h9G+Q8exaPk6VRV5YbeaMfNRnFgxUaZEYS+1lDs/kidN5GVdaC9wfxSgAAUoYHoBBnCmPwasAQUoYAKBZg3/Bzt7O9WDY4pkidG5XTN161qKZEnw/fsPrNmwHbUatUPspNnUC583b98DeflzaFd1/uLVWLhsrdrt0rkTIUGSWjDTUb+e7SG3/0nwe+HSNZPXUm6Rbda2h6qHvFRbbvVUCxYw6tGpFYoVyqfeQaqBBj9dfuHshSsWUHNWkQK+CnAlBShgIAEGcAaCZDEUoIBlCUhw4e7mjlw5suDSyV0YPqAbBvTqqJ3fiVMHN6FHp5aQYO7rt29Yt2kH6jTpiIRp86B+887YuHV3qARzZ89fRpc+wxRsn25tUbJYQTVvziO5ctSuRUNVxW59h6upKUedew3B6zfvkCFdakjHL6asS1D3nSZVcmxZMw8Prx3D6KG9oNFA/TFBgtKglsX0FKAABSxbgLXXF2AAp6/BeQpQwGYE1mzcrtpas0o5NdUfZdR+2R/Yu5MK5k4e2KiCueRJE+Pbt+/YsGWX6kwiQZrcairLsl4/vyHmX756jWr1WqlOK0oULQAJ4GAh/7p1bAF5luvUmQsmfaZwz/4jWLVuK+zt7bF49ng4ODhYiKDParZuVg8F8ubA02cv0LW3R1DvMxXXUIACFKCALQgwgAviUWZyClDA8gXkVshtuzyeb6taqbS/Dfo3fRpIMHf51C5IMNddG5xIMCe3WcqVOLkilyhdXnWFbp32Sp1csfO3wEBslA5VqtRpiTdv3yNJogRYNm+i9uqL9vJLIPKaQ5LIkSKiV9c2qip9Bo+Bu7u7mg/NkXT40aJDb7VL6bFTrmapBQseSec1EhivWLsZuvPXgpvDqlOAAhSgQDAFGMAFE47ZKBAMAWYxE4GtO/ep7u4L5c8FueUvsNWSYG5Qn86QYO7E/g2QYC5ZkkTqmTl5Rq5hy65IlDaveoeXPEMX3GBO3vV2+eoNRHBywsaVcxAxQoTAVtFs0rVtXh//xI2Nu/cfYemqjaFer9ad+qlbJ6Wzmm4dmof6/o2xw7hxYmHS6IGq6JYd+qj2qQWOKGDjAvJHol37DmPqrEW4ev22jWuw+bYgwADOFo4y20gBCngR0N0+WcOX2ye9JPRnIVOGtJBg7orzbkgw161DC0gwJ1f3tuzYq3qxTJgmj+oIZfX6bfjy9Zs/pf3dNHvBcqxYs1mtkCtvfzstUassZiTvNZNnCqXCQ0dPCZVnBmVfMsiVULlCJXWQWyft7KznV93/qldAuVJF8eHjJzT90zmLtJkDBWxZoG7TTqhWtxV6DRyN3EUrq1vdTeFxSfuHtzad+6Fu047YueeQKarAfdqIgPX8VrORA8ZmUoACIROQlyLv2H1QFVKlQik1DelIgjl5B5oEc8f2rkPX9s2RNHFCdZVPemNs0qY74iTLhur1W8O/YO74qbPo8uf5pr7d21lEpyX+2TWoXRXp0qTEi5f/YZY2MPUvraG2SYclHXudqUmdAAAQAElEQVQMVsUN7dcFElSrBSsazZk6Ul053n/ouGcPpQE2jwkoYKUCL/97Dfmjma558koYuRsiQercSJohP1JlKYIMOUsiS76yyFWkEvKXrI4i5WqjVOUGKF+jCarWaan+0FavWSfIZ3Wrjn3QvttA9Vncc8Ao9B86HvJHqJHjZ2D81LnqKt+s+cuxYMkadXeBPGcrz0Iv1C4XLVsb8h7MTdv2qM/7vQeP6arFKQUMKsAAzqCcLIwCFDB3AfnFKnUsU7IwokaJLLMGHbL8mx5DtIHD1dN7IMFcl3bNVDAnO5G/yMoXBF0wt3LtFnUb3NjJc7S/7Nuicu0W6rUGZUsVsahOS6Rtfg1D+nZRm0ZPmImPnz6reWOOWnfuC7k6lSdnVrRv1ciYuzJZ2XLezpk2Su2/e78RePjoqZrniALGEjDXcm/duY822ite3uvn5uaO9x8+4r/Xb/Hs+Us8ePQEt+8+ULdXSg/Ep89exLGTZ3DwyEns3n8E8oc2eaZZ/sAmt3wvWLoGcjfEtNmLMWHaPIzSfn4NGzMVA4ZNUFf5uvYZhvbdB0KCPbkSLs9Ct9UGfT9+/vRSFbkqmK1AeRUkduo5BBOnz1dXB89fvKqecfaSmAsUCIIAA7ggYDEpBShg+QLr/vQ+WaNyOaM3RoK5of27QhfMyW2WiRPFV/uVYK5Zu55InC4fBo2YiCPHT6tn6SI4hceCGWNVGmsYSaAswZR0fT9OG6gas00r1m5Wty2FDx8Oc/8EOMbcnynLLl44H+RdhtKZjnyBNGVduG8KhLbA/YeP1S3EWfOXw+59R9QfvvTr0LJJHezcsDjAYfPqeVi3dCZWLpyieqqVz40ZE4dh8piBGDusD0YM7AG5VV7uiOjRqSU6tWmCNs3rq5+9RnWro06NSqheuSwqlSuJ7Nn+1a+Cmnd1dcXN2/cgQeLcRSvRb8g49SqaAqVqaD/78yJW0qzIXrCCuv2zc6+hmDRjgXpNjQSZb999UGVYwYhNMIIAAzgjoLJIClDAPAWkV8d9h44jbNgwKFe6aKhWUoI5uc3y+pl9OLJrDTq3bYrEEsxpfnupx4+fLhbV46SXyvuxMHxAd7VF/pItt1OqBQOPnr94hS7aL0BS7MhBPTyvesqytQ6jBveE9Igqr2sQW2ttJ9tFAZ3Ak6fP0bZLf2TMVUq9IkTWSwB1bO96rF0yA/IzcWDbSkwY2Q8F8+UMcJA/hMgfmSqWLaECMQnIGtappgI0CdQ6tmmsOquS17hIb8TDB3ZXgZ0EeNMnDIUEfItnj8eKBZNxYOty5MyeWaqkBul06PShTepODNkun0stm9RFmRKF1a3l0knVt2/fcePWXezadxhzFq5A38Fj1etp5DbPRGnzIHbSbMhRqCKq12sNub1+ysyFkA6zLly+BulpV+3Il5F8zs5bvMrfW/Z9ycZVFiRgOwGcBR0UVpUCFDCOwPrNO1TBZUsWQcQITmreFKNsWTJi2IBukGAuRbLEXqoQI3pUk9bNS2UMtJArR2bIbaFS3JBRk2Vi8EGuZsrzjdKzaPNGtQ1evjkWKFca5cujRqPRXsWdhCvXb5ljNVknCoRYQG6FlCtUGXOXxqLl61R5VSqUwtkjW9WVs6yZ0qvPGLltWj5vNBqNShOaI3nP5MHtK3H7wkGcObwF9y4fQYZ0aSB/vJMrdB1aN1aB5bplM9X2/x6cw+MbJ3Fszzosnz9ZXe2TAK908UJImzoFnJzCQ3oyvn7zDnbuPaRu6ew9aAzqNOmI/CWqQzrJips8u3qur2bDtpDbqeWWz5nzlqkAt0f/0WjZsQ8Kaq/2yWdjaFpwX8YXYABnfGPuwQoE2ATrEFi70SOAq1GlrNk0qGv7FggTxlHVR74AtGhcR81b20huRdJoNOqh/zv3Hhq0efK8yuFjzuoLz/zpYwxatrkXlkX7xbVn51Zwc3NDg+ad4eLiYu5VZv0oEGgBuWtCgpa02YupK1Tyjky5WiaB27J5k1SgE+jCQilh/Hhx1RW2wOxO/mAnP8OVy5eEXO2TK4frl89SgenrB+fx6PoJHN29FkvnTlR/9JM/TpUqVhDyXkv5A44EZvLahO27DmDG3KXoOWAUuvYZhu8/fnjuXp4TPHTkpOcyZ6xDgAGcdRxHtoICFAhA4OmzFzh5+rx6t5pcgQsguSE3+1uW3K7z4s4Z7N28BM9vO1tN5yXeG50yeRLU/18V9axKn8GGC7IeP3mmvrTI/sYN76vePSfztjT07toGGdKmUp00DBwxyZaazrZaqYB0RCTPBqfLXhxy26C8nkVue3c+uFk9ryZXqKy06V6aFTNGNMi7LKtWLK1uu580egA2rJiNc0e34c3DC3hw9RgO71yNJXMmqM6zmjashaSJEngpgwvWKcAAzjqPK1tFAQp4E1i3eadaU6lcCcj7wdSCmYzChQuLTBnTqitIZlIlo1Sjf88O6vlDeY2DBNOG2Enj1t0hz5GUKFoAEgwbokzzKiPg2siV2yXav9DLs53yZVeeiQs4F1NYsoB0lS+d9tTTXnXt2mc4Hj95bsnN8az7l6/fIN31p81WDNI7r9xCWKZEYRzftx5rFk9HhnSpPNNyBogdKwayZ/0X1SqVUa+vmTJmEBbOGueFRnqtzZ83h5d1XLB8AQZwln8M2QIKUCAQAut0t09WLReI1ExiDIF4/8RBm2b1VdF9Bo9V05CMpJtvCVbkecZZk4aHpCiLz5s6ZTIM699NtUPegSVffNUCR1YpIO8ga96uF3buOYy5i1aheMW66nkpH421kBXSm6p0xJM6SxFId/3Sa608Cya3D8ozY5kzprOQlpi+mjmzZ8bFEzsxZmhPzJ48AueObUO0qFFMXzHWwKACDOAMysnCKEABcxSQLqel164okSOhpPZKjTnW0Vbq1K1jC0SOFBHyHia5Ehfcdj989BS6IHDquCGQHt+CW5a15JNe86QTF7lduEuvYdbSLLbDF4HdB454Wfvs+UtUqN5EvWdMuqD3stHMF+Sl2OlyFFcvzJZbJ4sWyotDO1ZBngWT2wfNvPpmWT25Zb1Zw/+hVrXyiBs7VrDryIzmK8AAznyPDWtGAQoYSGDNhu2qpOpm1HmJqpANjuR2nh6dW6mW9x82Xk2DM2ratgfkuZjyZYqhJq+qehLOmzYakSJGwLLVGyEdG3hu4IzVC5w6e1G9Z0y6oJfeCWs0aIOpsxbh8rWbZtl26XwoRaZCqtMN6WVSuv2XVwBsXTMfObJlMss6s1IUMBcBCwjgzIWK9aAABSxVYNmqjarq1SuZT++TqkI2OmrdtB5ix4yBm7fveXYJHhSKyTMWQm6dlNuCZk7klSZ9O7lNddLogWpViw698frNOzXPkfUIyBXWI8ecVYdAulYVyJsT8oypXIENFy4spHdCucLda+Bo5ClaRXU5L93Py23H8t4xXb7QnkpvqctWb4JccWvfbSDkfWVS971blmHnhsWQVwCEdp24PwpYogADOEs8aqxz4AWY0uYF5N1YDx49UQFDAT7IbRbng3zBHNink6rL4BGT1JU0tRCI0f2HjzFwxESVcuakYYgeLaqa5+ivwP+qV0C5UkUht6PJlcq/Wzhn6QI/f7qgSp0WKkArnD83DmxfgXuXD2PXxsXo3bUNdqxfhJd3z0ACIgnoChfIDelu/t37D9i8fQ+69B6G7AUrIGmG/GjQogvkWbq79x8anUU6XVm3aQeyFSiPlto/LDx6/Ax5cmZV9ZS6582Vzeh14A4oYE0CDOCs6WiyLRSggA8B/c5LNJqgvdzVR2FcYTCBBrWrIkWyxPjvzVtMn7skUOW6u7tDOuiQd0HJbZMVyhQPVD5bTDR7yghIF+T7Dx3HwmVrbZHAKtvcvH0vXL95F0kSJcDKRVORKUMaxIoZ3UtbpZddCYh6dWmN7esW4sWd09i3dTkG9OqIIgXzqIBObllcv3kn2ncfiEx5ykBuZZRgf/GK9ZDnS70UGMKFrTv2IVeRSupnV94BmTtHFmxbu0DVSeoZwuKZnQI2KcAAziYPOxtNAdsRWLlui2psjcq8fVJBmMnIzs7Os9fEsZNmQ3qdC6hq46bMxfmLV9UX1sljBgWU3NTbTbp/ub10/vQxqg49+o/Ek6fW0c28apCNjiZOnw8JuiI4OWHjyjmQTpkCQyEBnVzt6tm5lQqc5Ard/m0rMLB3J0iHIU5O4dWtjKvWbUWbzv2QPmcJpMlWDK069oG8qkA6SAnMfryn2XPgKOR5vP81bo9rN+6o59o2r54H2bcEkt7Tc5kCFAi8AAO4wFsxJQUoYGECZ85dgnz5iB8vrvryYGHVt/rqVihbHJn/TaduBxs1YYa/7ZXn5aR7cUk0Z8pI1ZOlzHPwW6B4kfyQnujkPXly5VJuY/M7NbeYl4DX2hw8elL10ihrl82biFQpkspssAZ5b6BcBevRqSWkwxC5Qiedhwzq0xnFCuWDBHQS8C9dtRHN2/VCqixFkDFXKbTrOgDSIZRcvdPfsXQmJD1fynkm6084n0PhMv9DldotIOuzZs6ADStmQ3qWLF44nyThQAEKhFDALoT5mZ0CFKCA2Qqs3bRD1a129YpqypH5CYwb3ldVSroSf/7ilZr3PnJ1dVW3X0kHCHLrZcliBb0n4bIfAqOH9ELSxAnhfPYixk+d60cqrjZnAXmGt07jDqrTErlqZujzXwI66Tyke8cW2LJmnnqG7uD2lRjctzMk4IqgveJ3/+FjdStu49bd1PNzWfOXQ6eeQzB09BQkTpdPXWlLkCY3suUvjxIV6+HM+UuQd7etWzoT8i63UvyZDd1TjHuzegEGcFZ/iNlACtiuwIYtu1Tja1Ytr6YcmZ+A3NpVtlQRSOcM8mXQtxqOnjgLV6/fQoL4/2DMsD6+JeE6PwSkw5hFs8aprQOHT9Q63lbzHFmGwJev31Ctbit1i3GVCqUgV82MXXN7e3vIy6C7dWgBueXxvwfnoH+FTs6pW3fuY+6ilRg5fga+fP2qqiQ/wzdu30WGdKmwZvF0HN+3HmVKFlbbOKIABQwrYMwAzrA1ZWkUoAAFgiBw7OQZ9VxH6pTJkD5tyiDkZNLQFhjcp7Pa5ZKVG+C9i/MLl69hxLjparvcOinvOFMLHAVaIHvWfyEdWkiGhi27yISDhQjIFS8JliQokvPfVNXWv0L39tFFz4BOnmXVr5NGo1FBX7nSRfVXc54CFDCwAAM4A4OyOEMJsBwKhExgzcbtqgBefVMMZj1KlyYl6v+viqrjgOET1FQ3ata2p5pt2aQu5B1XaoGjIAtIl/JZ/k0PeZaw7+CxQc7PDKEvIH+4kHe5RY0SGWuXzFTPpoV+LXzfoy6gq1SuhJcEckU9buxYXtZxgQIUMLwAAzjDm7JEClDAxAJubm5Yv2mnqoV0N69mODJrgQG9OkKexZEvrCdPn1d17T90vAo4EiaIhxEDu6t1HAVfYP6MMZAeCSfNWIBTZy4EvyDmNLrA5AhezQAAEABJREFU1p37MHzsNMgVrrVLZyBRwnhG32dwdjB2WB/I++fKlCgMeYZuxsRhwSmGeShAgSAKMIALIhiTU4AC5i+w79Bx9RJjeYg+WZJE5l9h1hDx/omDNs3rK4mO3QdhrfYK6oRp89TywpljIc/dqIVQGFnrLuR24uEDuqnmNWzZFV+/flPzHJmXwO27D9ColcdxGjO0N8z5XWnyc9uvR3usWzYT0otlSHrHNK+jwNpQwLwFGMCZ9/Fh7ShAgWAIrNvo0fskb58MBp4Js8hf8O3t7XDt5h2PL7C/geaNa0NuyzJhtaxq121bNFC3oj599gJd+/BqiREOboiK/PjpM6rUaQHpmr9erSpo3axeiMpjZgpQwDoFGMBZ53Flqyhg0wKbt+9V7a9WqbSacmQZAtJhiZub+9/KaoB/4vB5mr8ghpmbN200pDMYec/X9l0HDFMoSzGIQN2mHfHw0VNkyZQes6eMMEiZLMSSBFhXCgROgAFc4JyYigIUsBCBLTv24uu3b+qqjXQ7byHVZjW1Ajdu3tWOvf5/7cYdryu4FGIBue1t8phBqpzWnfvC+4uZ1QaOQl2gz+AxOHjkJOJq/2ghtySGegW4QwpQwGIEfA3gLKb2rCgFKEABbwKr129Ta2pUKaumHFmOQPnSxWBvb++lwlUr8iqqFxADLdSqVh7lShXF23cf0KydR0+fBiqaxQRDYN2mHZg8YyHChHHEhuWzwJ4cg4HILBSwIQEGcDZ0sEOpqdwNBUwm8OXrN+zce0jtv2rFMmrKkeUIJEmcAKsXTUPDOtVQuXxJTB07GOX5PimjHcA5U0eqQGH/oeNYvGK90fbDgv0XkFuHW3TorRJNGz8EmTKmU/McUYACFPBLgAGcXzJcTwEKmEAgZLvctnM/fv50QZGCeRArZvSQFcbcJhEoU7IwpCvy5fMno0mDmurVAiapiA3sVN4vpnvOqlvf4Xjy9LkNtNq8mvj6zTtUq9tKfW5JL6x1a1Y2rwqyNhSggFkKMIAzy8PCSlGAAsERkK7nJV+NKuVkwsHWBNjeIAsUL5IfTRvWwrdv3yGvFvj9+3eQy2CG4An8+vUL1eq1wqv/3qhndkcN5q2swZNkLgrYngADONs75mwxBaxS4P2Hj9hz4Ki6YsPeJ63yELNRRhIYM6Q3kiZOCOezF6F7956RdmXWxYZ25dp06Y9zF64gfry4WLNkuo/nP0O7PtwfBShgOQIM4CznWLGmFKCAPwIbt+6Gu7s7ShTNj4gRIviTkpsoQAF9gXDhwmLp3InQaDQYOnoqrly/pb+Z80YQmLd4FVas2Qyx37hiDqJHi2qEvbDIUBTgrigQqgIM4EKVmzujAAWMJSC9uEnZNauUlwkHClAgCALy3rEenVpCbutr0LwzXFxcgpCbSYMicPb8ZXTtM1xlWTRrHNKnTanmOaIABWxVIOjtZgAXdDPmoAAFzEzg1es3OHzMGWHDhkHFssXNrHasDgUsQ6BPt7bIkDYVbt99gMEjJ1tGpS2sli9fvVbPvbm6uqJn51aoUIafVxZ2CFldCpiFAAM4szgM5lEJ1oICliqwftNOVfXypYupW5LUAkcUoECQBBwcHLBk7kQ4Ojpi0owFOHXmQpDyM7H/AtJDbpU6LfHm7XuUKFoA/Xt28D8Dt1KAAhTwQ8CkAZybuzteaP8adenaLdy9/xgfP33xo5pcTQEKmLmASau3dtMOtf8alcuqKUcUoEDwBFKnTIbhA7qpzNIr5dev39Q8RyEXaN6+Fy5fvYGUyZNg2TyPZw5DXipLoAAFbFHAJAHcq9dvMXTcHBSv0hytugzF1Dkr0H/EVFRv1AU1m3TFjn1HbfFYsM0UoEAwBJ4+e4HTZy8igpMTSpcoFIwSmMX0AqyBOQm0bdEABfLmgPxsyfvhzKlullqXyTMWYv3mnYgcKSI2rpzDjpYs9UCy3hQwEwGTBHAdeo1E5oypsHvdLGxePgXzJg/GynljsXfDHIwe2AWnz13FsjXbzYSI1aAABcxZYPWGbap6VSqUUrd+qQWOKECBEAksmjUekSJGwJKVG7Dv4LEQlWX0zGa+g4NHT6LvkLGql88VC6eoVzaYeZVZPQpQwMwFTBLALZg6FBVKFUYYR0cfPEkTx8egnq1RpXxRH9u4ggIUoIB3gXUbPW6frF6Ft096t+EyBYIrEDdOLEwcNUBlb9q2B16/eafmTTnasfsgshesgH9S5EDrTn3x+ctXU1YnUPt+8OgJ6jTuAHlB+pB+XVCkQJ5A5WOi0BPgnihgiQJ2pqh0BKfwAe42MGm8FyIPBrfrMQJN2g9An6GT8f3HD+9J1PKlq7fQqF1/1G/dB/OWrlfrZORX/guXb6DXkEnqls9mHQfh8IlzkpwDBShgYgHpLe/ytZuIET0qShTJb+LacPcUsC6B2jUqokLZ4qrTjWbaIO7CpWv48eOnURv55es3SE+Nd+49hOzvyPHT2L7rAGYtWIH/NW6PG7fu4tPnL+rK4JSZC41al5AWLm2pXq+1qm/1ymXRpV2zkBbJ/BSggHkJmKw2JgngdK09duoCmncajAJlGyJPqXqeg257UKeTZy9H7uyZsGDqEESOHAnL13r8ZV6/HPkr2ICR09GjfSMsnDYUB46ehgRoksav/E7hw6Fbu0bYvX42Gv6vIoaPnyPJOVCAAiYW0L37rWrFMiauCXdPAesUmDlxmPp9uvfgMeQvWR1J0ufDwSMnvTT2/YePePL0Oa7duAPnMxfV9k3b9mDpqo2YOW8ZRk+chf5Dx6NTzyFo1q4najVqh7LVGqFAqRrIkq8sUmQqhLjJsyNCnLSIkywbkv9bEJnzllH7K1O1IWo2bIsuvYbAzc3Ny35nzF2KRcvX4eOnz17Wm8uCXLm8efseMmVIi8Wzx5tLtVgPClDACgRMGsDNX7YB3do1xKFtC3Fy9zLPIbiux50volzJAip7uRIFcMzZZxfIt+4+hJP2CmC61MnhYG+PkkXy4uip8yqPX/lTp0yKmNq/8Nvb2SF/7izqRad+Xd1TBYX2iPujgI0KrN24XbW8ZtVyasoRBShgWIFoUaPAXmOnnt+SkuW2xap1WiJxuryIniiTCroSpM6NNNmKIWfhiihavjbK12iCuk07olXHPpBOUIaMmowJ0+Zh7qKVWLl2C7bt3K/e23j+4lX1zrkXL/+DlCvlR3ByQtzYsZAiWRJk+Tc98ufJoYac2TPLZi+DBI5tu/RHvJQ5Ub1+a9VJiJcEJlwYMW66aqfcHbBmyXQT1oS7pgAFrFHAzpSNihM7BlKnSAJ7u5BX4+u379pfMEC0qJEh/xLGj+PrPfuvXr9D/LixJIkaJN2r/94isPk3btuv/cWSGOHDhVP5OaKApQtYav0vXb2hvvzF+ycO8ubKZqnNYL0pYNYCL/97jfcfP3qp408XF3VbpbzXTDZIkJI4UXxkSJdK/SyWKJIfVSqUQsM61SA9Wvbu2gbDBnTD5DEDMX/6GKxZPB07NyzG0d1rceH4Dty9dBgv753F11c38N+Dc7h35QgundyJY3vXYfemJWo4tGMVxgztjTSpkqueHEsWK4AhfTur/Ukddu45hAYtuiB20mxo2aEPDhw+AVP9kwB1+NhpaverFk1Dgvj/qHmOKEABChhKIOSRUwhqIh/6G7btg9wnHphiOvYejRadB/sYzl++obLb6QWCGu1fDNVKX0YaO43e2r8EAeW/fO02lq/bgQHdW3rmd9H+ItMffv36pR5W1l/HeRfQwMPA1dWNFt5+ZoJ7bqxet1X9HMoXxeCWYU755PYwc6pPIOvC89lA57N/3q6uriZzjq69Apc7Rxb1s6YblShaAPcuH8b7J5fUIAHYRW0gJgHZ9nULIFecFswYg0mjB2BY/67o0akl2javjwa1q6JqxVIoUTQ/cufIrAK+JNrAT74LhA3jGGAbmzf6H07u34BH149jtTYw6tC6MWR/V513Y2DvjsiYLrX2j7HfsGz1RlSo2RTJMhRQVwBPOp8LsGz//IOy7cq1m2jcpruimjCiH7JnyWjUfcu5Id87glJHpvX4fWztDuZ+bqgfEo6CLfA3egl2EcHPuGHrPoydugglqrbwfP4tT6l6fhY4vF97jB/azceQ9d+0kE5P3Nzc4aINoKSAt+8/IFbM6DLrZYgTKzref/h7v/w7bTq5EhhQfumBa9q8lZg2pjcSxo/rpUwuUCDwAr8Dn5Qp/RVYt2mH2l5V+5d+NWPho988NSz8CFpv9aeMHYQu7ZqiVLGCKhibrA3MokeLaoAGG6aI+PHiolObJjiyew3OHN6Cnp1bIXnSxHj1+g3kGbziFeshW4EKGDVhJu49eGSYnfpSijyLJ8/3ffv2Hf+rXgGN69fwJZXhV/Gzw/Cm1lAizwtrOIp+t8GkAZz+c2/6835VN2IEJ/VeGnk3jf6gS583Z2bsO3RSLe45eAL5c3ncMy+3R169cUetl1s2pbfJJ89ews3dHfsPOyN/7qxqm1/5JX3f4VPRp3Nz/BMnlkqrG4UJEwb6g6OjIzQajZd1+ts5H8ambRwcHGy6/YY6/89fuoZnL15BvrjlzpnVKkwdHOytoh2GOsYs5+9npak/N9KnTYWh/bthw4rZ2itdnZAkcUKzPVfTpUmJAb064vKpXTi2Zx3kKp3cZn3/4WPVmUr2gvKcXh3MXrAC7z58NFg75Bg1atkNjx4/QzbtVbdZk4YbrGz/fhZkv2G0Vy/9S2O127x9/2I7/35miIWjowMctd9JZd4cB/BfiATsQpTbAJmlV8j7D59BBpkPSZGdWtXF1t1HIK8RePzkBerW8OjY4Kk2WBs6brYqWqPRYHCvNug/Yhoate2n/aBNB7mCJxv9yr928x5cuX4HtZv38LxS+PK/N5KFAwUoYAIBXecldWtWMsHeuUsKUMASBLJkSo+Rg3rg9oWD2LVxCZo0qAm5ciivJ+g1cDRS/FsI5ao3Vq8k0HWiEtx29Rs6DoeOnUKc2DGxftks9cU5uGUxHwUoYHwBS9+DnSkbsHnHAXX7ZIdeIyFDyWotsWXXoWBXKWaMaJg5rh/kNQIj+nf07GhEepFcPX+cZ7mZMqTGounDsHTmCDSvX81zvV/5Wzep5dlDpu5KYVzth7RnRs5QgAKhJiB/6NmweZfaX/XKHn+kUQscUYACFPBFQKPRoEDeHJg6djAeXD2K9ctnoVa18nAKHx6Hjp5C6059kShtHtRp0hGbt++BrnMWX4ryddW6TTswecZC7RU3R2zUXqX07fENXzNyJQUoQIFgCpg0gFu2djsG9WyDrSunqmFA91ZYunprMJtiidlYZwpQIKgC8oXrvzdvkTRxQqRPmzKo2ZmeAhSwYQG55bB08UJYMGOs6gxlyZwJKF+mmBKR4E2COHnXnQR18r47d3d3tc2v0aUr19G8fS+1ee7UUciUMZ2a54gCFKCAMQVMGsDJB6m8V02j0ajnxgrkyQo7Lz1EGvKDdVcAABAASURBVLPpLJsCFi5go9XX3T5Zv3ZVGxVgsylAAUMIhA8fDtUqlVE9Wj68dhwzJg5DkYJ5VM/YS1ZuUO+zS5m5MHoOGAW57VJ/n9IZyplzl1ClTku4uPxSz9pVr1xWPwnnKUABChhNwKQBnL29HU6eueTZuGOnLkAetPRcwRkKUIACegLSXfa6TTvVGj7/phiCPWJGClDgr0CUyJHUe+u2rV2Ae5ePYOywPsiRLRNevnqNabMXI3/J6sictwyGjJqMouVq49/cpVG47P+029+gQJ6cGD6g29/COEcBClDAyAImDeB6dWyCcdMWe3YMMmnWUsg6I7eZxVOAAhYqsP/wCfWep6yZM/DluBZ6DFltqxCw6kbEjhUDbZrXx6Edq3D9zD4M7N1JvbPuzr2H6lUEzmcverZfowFq16wIOzuTfp3yrA9nKEAB2xAw6SdOhrQpsW7ReCyfPVoNaxeOR/o0KWxDnq2kAAWCLLBmwzaVp2YVdl6iIDiiAAWMKpA4UXz17jvng5tx9shW9WJu7zu8qw3svK/jsn8C3EYBCoRUwCQB3JkLV9U95jI9e/Ea3r5/rwaZl3UhbRTzU4AC1ifw48dPbNt5QDWMz5ooBo4oQIFQFEibOgVGD+3tY49VK5b2sY4rKEABIwmwWCVgkgBu/rKNePX6LWTq26BqxhEFKEABPYEdew6q2yfz5sqGf+LG1tvCWQpQgAKhI5AnZ1bMmzZavYZAXkUgvVnK++ZCZ+/cCwUoQAEPAZMEcLPG90fyJAkhU98Gj6qZ9ZiVowAFQllgzcbtao81q/L2SQXBEQUoYBKB2jUqqtcQSPAmQZxJKsGdUoACNi1gkgBOJ96q61DdrOe0Xkuftyd4buQMBaxCgI0IqsCXr1+xc88h1VEAb58Mqh7TU4ACFKAABShgTQImDeC8Q3799h0/XVy8r+YyBShg4wKbtu2Fq6srihTIg2hRo9i2BltPAQpQgAIUoIBNC5gkgJuzeK16dcClq7fUNE+pempar1VvVC1f3KYPCBtPAQr4FFj35/bJGrx90icO11AgCAJMSgEKUIACli9gkgCuRcMaOLl7GapXLKmmMi/DxiWTULtaGctXZQsoQAGDCbz/8BHy/jcHBwdUqVDSYOWyIApQgAIUCJIAE1OAAmYiYJIATtf2rm0b6GY5pQAFKOCrwPrNO+Hu7o5SxQsiYoQIvqbhSgpQgAIUoAAFzFmAdTOkgEkDuMdPX6JTn9EoXKGJuoVSdyulIRvIsihAAcsWWLtxh2pAzSrsfVJBcEQBClCAAhSggE0LmDSAGzJ2FiqULoI0qZJi64qpaNesNprWq2LUA8LCKUAByxF49foNjp08g7Bhw6B86WKWU3HWlAIUoAAFKEABChhJwKQB3I8fP1GsYE51e1TMGNFQt0Y53H/41EhNZbEUCLEACwhlgTXrt6k9VihTHOHChVXzHFGAAhSgAAUoQAFbFjBpAOfkFE7ZazQaPHn2Ej9+uuDd+09qHUcUoAAF1m6yptsneTwpQAEKUIACFKBAyAVMGsBlzpAaHz59Ru2qZVGneU8UqdgEJYrkDnmrWAIFKGDxAk+fvcC5C1cQwckJJYsVsPj2sAEUCJEAM1OAAhSgAAX+CJg0gGvT9H+IGjkSCufPjqM7FqtXClSrUOJP1TgJrsDXb9+wduN2zF6wHPIlOLjlMB8FTCmwYu0WtftqlUrD0dFRzXNEAQpQgAJBF2AOClDAugRMEsCduXAV/g3WRRy6rfn50wX5S1RHo1bd0KX3MGTNXx6Xr90M3UpwbxQwgMC6TdtVKdWrlFVTjihAAQpQgAIUCHUB7tAMBUwSwM1fthEyTJ2zEh16jUK/4dMwYsI8NT9hxhIzZLKcKh0+7ozbdx94Vliuxi1ducFzmTMUsASBm7fv4dqNO4gRPSqKFcpnCVVmHSlAAQpQgAIUoECoCJgkgJs1vj9kiBUzKsYO7opda2di49JJmDd5EBIn+Mf3hnMtBShgMwJyC7A0tlolXn0TBw4UoAAFKEABClBAJ2CSAE6381f/vUP+3Fmg0WjUqvRpUqgpR8EXKJAnB6JGieylAOmC3csKG1xgky1LYPWf1wfU4O2TlnXgWFsKUIACFKAABYwuYNIATmOnwamzlzwbeevOA3z49MVzmTNBFwgfPhwuHN+BccP64Pfv34gcKSIK5M0R9IKYw6ACHz99xohx01G3aWeMnTwH8qyiQXdgRYWdv3gVDx49QeyYMZAnZ1ZzaBnrQAEKUIACFKAABcxGwKQBXN8uzTF++hKUrdUGNRp3Rf+R09C5VT2zwbHUisSOFQOtm9dHujQp8enzF5w8fd5Sm2I19W7YoguGj52GPQeOYtCIiejQfZDVtM3QDVn7591vtWtW9Lw6b+h9sDwKhJ4A90QBClCAAhQwrIBJA7g0KZNizYJxmDa6L0YP7KKdH4/U2nWGbaLtllauVFHV+O27DqgpR6YRcHNzw/7DJ7zsfPX6rSqQO3jkJH78+Ollm60vrPsTwNWoUs7WKdh+ClDA1gXYfgpQgAK+CJgkgJNXCHz5+k29SuDsxWt4+/69GmS9DL7Uk6uCIVC+tEcAt3Xn/mDkZhZDCdjb2yNWjOheinP59UvdSlm+RhPESJwZZao2xKgJM+F85qKXdLa2cML5HJ6/eIVkSRIhy7/pba35bC8FKEABClDAYAIsyHoFTBLAySsEXr1+q14lIPPeB+vlDt2W5ciWCXI75b0Hj7y8WiB0a8G9iUCbFvXx+7fMAQ4ODmjW8H9oXK8GEieKr1YeOX4aQ0dPQdHytREraVZUqd0CU2YuxMUr19V2Wxmt2eDx7reaVXn1zVaOOdtJAQpQgAIUoEDQBOyCljw4qX3mkVcIJE+SUL1KQOa9Dz5zcE1wBcqWLKKybtvFq3AKwkSjAnlyavf8G0m0Adure2cxZewgTBs/BNfP7MPNc/sxY+Iw1KpWHnFjx8K3b9/Vs3K9B41BvuLVkDBNHtRt2hFzF6206kBcbjXVvT6gbq3KWi/+TwEKUIACFKAABSjgXcAkAZz3SnDZeAK65+AsNoAzHk2olnzc+azqkKNgvlwIFy6sl30nTBAPDetUw4IZY3HvyhGcO7oNE0b2Q8WyJRAtahS8e/8Bm7btQaeeQ5AlX1mkyFQIzdr1xNJVG/Hs+UsvZVnywsGjp/Dh4yekT5tS3UJpyW1h3SlAAQpQgAIUoICxBEwSwBUq3xj+DcZqrC2WW7xIPsirBeTZqrfvPtgigVm0WZ7tkorkyp5ZJv4OaVIlR8smdbFy4RQ8vnECx/auw/CB3VGyaAE4OYXHi5f/YeXaLWjVsQ9SZSmCjLlKoX23gVi3aQdev3nnb9nmvHHtn9sna1Qpb7BqsiAKUIACFKAABShgbQImCeAOb1sI/wZrQzZle8KECYOihfKqKvAqnGIwyejo8dNqv7lzBBzAqYR/RnZ2dqozj05tmmDjyjl4cec09m1djn492iN/nhwIE8YR9x8+xoKla9CwZVckSZ8POQtXRPd+I7B91wF8/vL1T0nmPfn16xc2bt2tKlm7egU15YgCJhbg7ilAAQpQgAJmKWCSAE5f4tcvV1y9cUf1SCk9UMqgv53zIRfgbZQhNwxJCddv3oH0uhondkwkShgvJEWpDlDy5MyK3l3bYPemJXh++zS2rpmPru2bI1uWjJCA75r252nG3KWo2bAt4qXMiYKla2LAsAnYf/g4NmmDpOwFK+CfFDnQulNfswnwdu87gq/fvqk2JIj/T4iMmJkCFKCA6QVYAwpQgALGE7AzXtEBl3zs1AVUbdAJnfqMwdipC9Gh1yhMm7sy4IxMESQBXQB3wNu7yIJUCBMHW+Ck83mVt0DenGpqyJHcHitXWIf064Iju9bgufYK3epF09CuZUOkS5MS7u7uOHfhCsZPnYsKNZuiTtNOuHHrLj59/oIlKzeoni4NWZ/glrVm45/eJ/nut+ASMh8FKEABCliLANtBgQAETBrATZ+/CnMnD0KKZImwZsF4LJw2VDufOIAqc3NQBWLGiIZcOTLjx4+f6ra6oOZn+pAJnDh9ThWQN1dWNTXmKFLECChfphhGD+mFM4e34OG141g8ezya1K+JOLFjQaPxuvdRE2ag8v+aY+L0+bhw6ZoK+LymMP6SnJfb/vSSWoOvDzA+OPdAAQpQgAIUoIBFC/gXwBm9YQ4O9ogbOybkNkrZWZqUSfHt+zeZ5WBggfKli6kSt+8+oKYchZ7AiT9X4PLkyhZ6O/2zp1gxo6N65bKYOm4wTu7foG6x/LNJTdzc3LH34DH0GzIO+UtWR4LUuVGrUTvMmr9cXalTiYw82rpzH37+dFHP9MWJFdPIe2PxFKAABShAAQpQwLIFTBrAOYUPp/SiRomIzTsOQG6pfP/hs1rHkWEFdLdRypfl37o3Sht2F95K46IISI+Rj588Q8QITsiQNpWsMtkQV3sFbtTgnpBeLiNHiohypYuq5+gmjuqPSuVKqlcWfPz0Gdt27kfXPsMgz8olz1gQTdp0x+IV6/Hk6XOj1J23TxqFlYVSgAIUoAAFKGClAiYN4GpUKokP2i+MbZr+D/sOO2PZ2m1o2bC6lVKbtlmpUyZTHWi8e/8RzmcvmrYyNrT3YyfPqNbm1V59kw5G1IIJR21bNFDvmXtx9wzWLJ4OeS6vReM6WLFgMp7cPInj+9Z7vrIggpMTXv73GqvXb0Obzv2QJlsxpM9ZAm279MeaDdsN8sqCL1+/Ys/+o+rKYNVKpf/KcI4CFKAABShAAQpQwFcBkwZwxQvlRtTIkZA8SUJMHd0bs8b3R5Z/0/paUa4MuUDl8qVUIdt38TZKBREKI1PePhnU5mk0GmTOmA66VxY8v+Ps5ZUFjo6OePjoKRYtX4fGrbtBXlkgV+nkap1ctZOrd0Hd5/rNu+Dq6opihfKqK4BBzc/0FPBNgOsoQAEKUIAC1ixg0gCuXsveWLFuh7oKZ83I5tK28qWLqqps+9NhhFrgyKgCJ51DrwMTQzfEwcEB+q8seHHnNLasmadeWZA1cwZ11Ux6tJTn5eS5ufipcqnn6PoPHY99h47j+/cfAVZp3aYdKg07L1EMHFGAAqYXYA0oQAEKmL2ASQO4/t1a4NGT56jZuBu6DRiHA0dPw9XNzezRLLWCchuf9FJ4++4DPHr8zFKbYTH1/vzlK67euA17e3tkz/KvxdTbr4rKKwuKFcoHeWXB0d1r8fTWKaxeNA2tm9VTryyQZyulJ8sJ0+ahUq1m+CdlTpSsVB8jxk3H8VNn8evXLy9Fn790FQePnFTvtqtUroSXbVygAAUoQAEKWJ4Aa0yB0BEwaQCXOmVS9O7cDJuXT0a+XFmwZPVWVPhfu9BpuQ3uRaPRoEKZ4qrlG7ftVlOOjCdw8vR5SFCTPWtGhAsX1ng7MlHJUSJHUq8sGDe8r+crCxbNGodGdasjSeIEKmCTwG342GkqkIunvUIngd1J+uMbAAAQAElEQVTYSbNRpMz/UKBkDeUTNUokODo4mqgV3C0FKEABClCAAhQwA4EgVMGkAZx+Pe20wYX+MueNI1C+jMdtlNv5HJxxgPVKPaUN4GQxb87Qf32A7De0B3llQY0q5TB9wlBcO70X18/sw7TxQyDrYseKgW/fvqtbKweOmIjT5y95Vu/N2/dYvmaT5zJnKEABClCAAhSgAAX8FjBpAHfrzgOMnDgPlep2xNFT59GgVgVsXTXN79pyS4gFihfJr8o44XwOb999UPPeRlw0kMDxU+dUSflyZ1dTWxslThQfjevVgFyVe3D1mLpKN3ZYHyRPltgHhTxL52MlV1CAAhSgAAUoQAEK+BAwaQA3dNwcJE4YD2sWjsO4Id1QtEBOONjb+6gkVxhOQLqGL128kCpw175DasqRcQTOXrisCs6dM4ua2sbI71amS5MSbZrXx5LZE3wkqlqRrxDwgcIVFKAABShAAQpQwBcBkwZwy2aPRJ3qZSGvEvClblxlJIGyJYuokrfu3K+mHBlewPnMRfz48RNpU6dg9/jeeLNkSo8FM8aiVrXyapg3bbTq7dJbMi7aogDbTAEKUIACFKBAgAImCeCkx8nnL//ztXIfP33BuGmLsXTNNl+3+7dSnqVp12MEmrQfgD5DJ+P7D9+7Mb909RYateuP+q37YN7S9Z5FBpT//YdPKFqpGWYuWO2ZxxJnypbyCOD2HTwGFxcXS2yC2df5xGmP2yfz5Mpq9nU1RQUleJMgTobaNSqaogrcJwUoYGUCbA4FKEABWxEwSQBXvmRhdOw9Gm27D8f0+SsxZ/FaNQwZOwt1W/TSBl4/UaFUwSAfg8mzlyN39kxYMHUIIkeOhOVrPd4xpV+Q9Ao4YOR09GjfCAunDVWvLrhw+YZKElD+8dOXIGumNIAGFv3vn7ixIe/xkvd07T98wqLbYq6Vl2cMpW620oGJtJUDBShAAQpQwEIFWG0KWJSASQK4wvmzY82CcWhctzLChwvvCZY5Q2ptUDUE8n64qFEie64P7Mxx54soV7KASl6uRAEcc76g5vVHt+4+hJNTeKRLnVw9b1eySF7VgYqk8S+/XLULHz4s0qdJCfyW1JY9lCtVVDWAvVEqBoOPPHugzGUbPVAaHJAFUoACFKAABShAAYsQCP1KmiSAk2ZqNBpkz5weTepWRouGNdRQsUwRSFfksj2ow9dv36EtEtGiegR+CePHwes373wU8+r1O8SPG8tzvaR79d9b+Jff1dUVU+euRPvmtT3zWfpMudIeAdzm7XvUu7gsvT3mVP+bt+/h3fuPiBM7JqQnRnOqG+tCAQpQgAIUoAAFKGDZAiYL4ILDJrddtug8GN6H839ugbSz+9scjebvvPd9aez074H8m86v/HIrZtUKxRA5UkTvReHnz59eBnmmTG7T9L4+NJaDso9UyZMgbuxYKtA4ceqslzYEpRxbT+vi8hPehyPHnNV5Iq8P8L7Nzc3VR3rvabjs09RcTQx5/ssfiqSdhizT1ssST2sYPD43XPjZ4cvnrX/H1xbOf1fXX9rzwoW/w719F5Nj79+5YQvb5Nz49euX9vwwz9+p6osSR8EW+Bu9BLuI0Ms4vF97jB/azceQ9d+0iOAUHm5u7nDRnqxSo7fvP/h6NS9OrOh4/+GzJFHDO226OLFj+JtfbsUcOnY28pSqp57VW7J6KybNWqry29vbQX+w0waHGo3Gyzr97eY0X6l8Cci/XfuOWER9zclOVxf5Q4H34dRZj1t38+TMAo3GDhq9AdBAo7dsRvPQsF7QBNFAdx4YYmpnZwc7O3v+LNrbGcwgqMfTXNPL54ad+t1iB42GQ2AN7A14LplrWWJhZ2e4nxlzbWdw6iU2tj3I9w0ZzPMzA/wXIgG7EOUO5cwRIzghUsQIPgZdNfLmzIx9h06qxT0HTyB/rsxqXm6PvHrjjppPnSIJpLfJJ89ews3dHfsPOyN/7qxqm1/5504aiJO7l6lBbvdsUKsCOrWqr/I4ODjC+yAbvK8zx+UKZYpLVbFz7yEfbTDH+ppjnRwdHeF9OHXGI4DLnzenj2329vY+1nnPz2WfpuZqYshzUr6EOTg4WOjPoqNZ1ttcz5ug1ks+Nxy0v2uCms/W04uZtQ8e5wY/N3w7zrZ+/tvby3nhYLbfOdQXUI6CLWCSAO7K9Ts4eOyMj0rvP3Ia12/d87E+sCs6taqLrbuPqNcIPH7yAnVrlFNZn2qDtaHjZqt5jUaDwb3aoP+IaWjUth+yZUkHuYInG/3KL9uscSiYL6cKhm/cuotHj59ZYxNDvU0vXv6nLOWPDRnSpgr1/XOHFKAABSxOgBWmAAUoQIEgCdgFKbWBEk+cuRRJE8X3UVqyxPExa+FaH+sDuyJmjGiYOa6feo3AiP4dET5cOJU1dcqkWD1/nJqXUaYMqbFo+jAsnTkCzetXk1Vq8Cu/2vhn1LhOJbRuUuvPkmVP5C93pUsUVo2QzkzUDEchEvB8fUCubJArKiEqjJkpQAEKUIACFPBXgBspYIsCJgngPn76giSJ4vnwTqoN4F68eu1jPVcYT6D8n94ot+8+aLyd2FDJugAujzaAs6Fms6kUoAAFKEABClDA0gQstr4mCeCkl0a/xFzd3PzaxPVGEChZrKC6UiSBx6fPX4ywB9sq8sSpc6rB+XJnU1OOKEABClCAAhSgAAUoYEgBkwRwqZInwvHTF3204+jJ80idPLGP9Va/woQNlFcjFMqfC+7u7ti2a78Ja2L5u/785SuuXL8FuTU1V/bMlt8gtoACFKAABShAAQpQwOwETBLAdWhZFyMmzMXISfNVL5C79h/TLs/TLs9DOyt6WbbZHW0/KlS+dDG1ZdvOA2rKUfAEpPdJubqcPWtGODg4BK+QYORiFgpQgAIUoAAFKEAB2xEwSQAXL25sLJ89EhEjhMe0+Ssxf9lGRIkSASvmjkaCeHFtR99MWlqpXAlVkz0HjsDFxUXNcxR0gZPOHrdP5s3J2yeDrsccJhLgbilAAQpQgAIUsDABkwRwYhQ1SmS0b14HG5dMwtqF49G2aW1EjRxJNnEIZYF/tAF1xnSp8f37Dxw8eiqU9249uzvhfF41Jl/u7GrKEQUoQAHrFmDrKEABClDAFAImCeDWbNoN/wZTQNj6PsuXKaYI+BycYgjyyNXVFafPeTzXmT9vjiDnZwYKUIACFKCATQmwsRSgQLAFTBLAnb98A/4NwW4NMwZboFypoirvDr5OQDkEdXTh0jX8/OmCtKlTIFLECEHNzvQUoAAFKEABClCAAoEUsPVkJgngRg3oBP8GWz8opmh/lkzpETdOLLx89RrnLlwxRRUsep/H/zz/lidXVotuBytPAQpQgAIUoAAFKGDeAiYJ4MybJCi1s660ut4ot+9mb5RBPbLyHj3Jky9XdplwoAAFKEABClCAAhSggFEEGMAZhdUyCy1X2uM2Sj4HF/Tjd/LPFbi8uYLQA2XQd8McFKAABShAAQpQgAI2LsAAzsZPAP3mF86fC+HDh8O1G3fw6PEz/U2c90fg1p37ePf+I+LEjolECeP5k5KbKGA4AZZEAQpQgAIUoIBtCjCAs83j7murw4QJg1LFCqptvAqnGAI10t0+WSBvzkClZyIKUIACJhbg7ilAAQpQwIIFTBrAPXn2EjMXrEb7niPRqutQz8GCPS2+6ryNMuiH8KTn+9+yBT0zc1CAAhSgAAUsSoCVpQAFTC1g0gBu2Pg5iBIlMurVLIem9ap4DqZGseX9S0cmdnZ2OHbyLD59/mLLFIFu+3HnsyptHj7/phw4ogAFKEABClCAAr4KcKVBBEwawEWOFAF1qpVBrmz/IkeWDJ6DQVrGQoIlEDlSREhHHO7u7uA74QImfPvuAx4+eoqIEZyQPk3KgDMwBQUoQAEKUIACFKAABUIgYNIALoyjIx4+fh6C6gc7KzP6I1CuVBG1la8TUAz+jg4fO6W2S9ArVy7VAkcUoAAFKEABClCAAhQwkoBJA7j7j56hdvMeqN+6D/gMnJGOcDCKrVSupMq1c+8huLm5qXmO9AX+zp9wPqcW8ubOrqYcUYACFKAABShAAQpQwJgCJg3gurSpjymjeqFDizqez7/Js3DGbDDLDlggcaL4SJMqOb5//4GDRz2uMAWcyzZTnPzTgUneXFltE4CtDroAc1CAAhSgAAUoQIEQCJg0gNN/7k1/PgTtYVYDCUhnJlLUtp37ZcLBF4EfP37i0tUbsLe3R67smX1JwVUUoAAFDCvA0ihAAQpQgAImDeB+urhg8cot6NRnNG+hNLNzUfcc3Nad+8ysZuZTHel98vfv38ieNSMcHBzMp2KsCQUoQAEKUMCnANdQgAJWImDSAG7ImFl4/fY93rz9gCrliiKiU3ikSZnESmgtuxk5smVC9GhR8PLVa1y4fM2yG2Ok2p845fH8W75c2Y20BxZLAQpQgAIUoAAFzEGAdTAnAZMGcPcfPkG3dg0RIUJ4lCqaD+OGdsPT56/Mycdm66LRaFCxbAnV/u27DqgpR14FTug6MOH737zCcIkCFKAABShAAQpQwGgCJg3gIkRwUg1zdXXDt+8/1PyvX/73eqgScRQqAuVKFVX7YQCnGLyMXF1d4Xz2olqXP28ONeWIAhSgAAUoQAEKUIACxhYwaQAXMUIEfPj0GflyZkbjdv20Q3/EjR0D/GceAsWL5EP48OFw+dpNvHj5n3lUKmS1MFjui5ev4+dPF6RLkxKRIkYwWLksiAIUoAAFKEABClCAAv4JmDSAmzSiB6JGjoQm9aqgT+fmaNO0Fnp0bOJffbktFAXChAmDooXyqj1u2rZHTTnyENDdPpmHrw/wALGJMRtJAQpQgAIUoAAFTC9g0gBOmn/52m2s2bQbmTKkRtJE8fHk6UtZzcFMBDxvo9zN5+D0D8mJ0+fVYt6c2dSUIwpQgAL+CnAjBShAAQpQwEACJg3g5BUCIyfNx+YdB1VzpEv24RPmqnmOzENA9z64w8ec8enzF/OolBnU4vjJM6oWedmBiXLgiAIUoAAFjCfAkilAAQroC5g0gNu1/yiWzBiOSJE8niGKFTM6vn77pl8/zptYIEb0qMiVIzPc3d2xe99hE9fGPHZ/++4DvHv/EXFix0SihPHMo1KsBQUoQAEKUIACFPApwDVWKGDSAC5suHBwdHTwwqqBxssyF0wvoLuNchtfJ6AOhu75t4L5cqlljihAAQpQgAIUoAAFKBBaAqEXwPnSomhRIuP6rXtqi9w+OX/ZRqRIlkgtc2Q+ArrbKOUKnJsbX/Nw0vnP82/swMR8TlLWhAIUoAAFKEABCtiIgEkDuIE9W2HDtv24dvMeCpZrhCfPXqJz63o2Qm85zUydMpm6VfDzl6+QZ+FMUXNz2ucJ53OqOnn4/Jty4IgCFKAABShAAQpQIPQETBrAySsE+nVtgR2rp2PjsskY1LM1omqvyoVe87mnwApULl9KJbX12yjfvvuA+w8fenLpFgAAEABJREFUI2IEJ6RPk1KZcGT2AqwgBShAAQpQgAIUsBoBkwRwZy5chf5w884DPHj01HOd1ehaUUPKly6qWrN5u22/D+7IcWflkC93dtjZmeTHR+2fIwpQILQEuB8KUIACFKCAeQmY5Btoh16j4N9gXkSsjQhId/mRIkbAy1evcenqDVllkwNvn7TJw85GU4ACFAieAHNRgAIUMIKASQK4QnmzIXXKpGjT9H/YtmoaTu5e5mUwQjtZZAgFNBoNKpQprkrZbsO9UZ5kBybqHOCIAhSgAAUoQAHjCrB0CvglYOfXBmOuHzWwMyaP6ImwYRzRc9AkdOw9Gjv3HcOPny7G3C3LDqFA+TIet1HaagD348dPXLxyHfb29siVPXMINZmdAhSgAAUoQAEKUIACQRcIRAAX9EIDkyNK5IioWbkU5k0ehOoVS2D89MVYuX5nYLIyjYkEShQpAEdHRxXEvHj5n4lqYbrdnnA+B3ndRY6s/8LBwev7C01XK+6ZAhSgAAUoQAEKUMCWBEwWwH389AVrNu1Gk/YDMGfJOrRpWgu1qnj0dGhLB8CS2urkFB5FC+ZRVd66c5+aBjiyogQnT+ve/5bNilrFplCAAhSgAAUoQAEKWJKASQK4XoMnonL9jrh15yE6t66PpTNHoGr54nAKH86S7GyyruVKedxGuW3nAZtrv1yBk0ZLhy4y5WB8Ae6BAhSgAAUoQAEKUMCrgEkCuMMnziF+3Nh49vI/TJ+/Cq26DvUyeK0il8xJoGypIqo6B4+exLdv39W8LYzc3d2huwKXP28OW2gy20gBSxdg/SlAAQpQgAJWKWCSAG7KqF7o2Koumtar4utgldJW0qh/tIF31swZIAHNzr2HrKRVATfjwqVr+PnTBenSpIS8TiHgHExBAQpQgAKWK8CaU4ACFDBfAZMEcDmyZIB/g/lysWYiUO7PbZTbd9vObZS62yfz5MoqBBwoQAEKUIACFKCA7wJcSwEjC5gkgDNym1i8kQXKlfZ4Dm7H7oNwc3Mz8t7Mo/gTf97/li9XdvOoEGtBAQpQgAIUoAAFKGB1AoFpEAO4wCgxjReBjOlSI26cWPj85SuOnjjjZZu1Lhw7eVo1LS+vwCkHjihAAQpQgAIUoAAFTCPAAM407hawV/+rWKWCxysfbOE2yrv3H+Ld+4+IEzsmEiaI5z8Mt1KAAhSgAAUoQAEKUMCIAlYVwL15+x7teoxQ75brM3Qyvv/44Svdpau30Khdf9Rv3Qfzlq73TONf/ms376o8+cs0QNlabeDm7u6ZzxZndM/Bbdu13+qbf/zUOdXGgvlyqSlHgRBgEgpQgAIUoAAFKEABowhYVQA3efZy5M6eCQumDkHkyJGwfO0OH2i/f//GgJHT0aN9IyycNhQHjp7Ghcs3VDq/8n/99h2d+45FxVKFsG/TPMwc1x92Go3KY6ujgvlyqt4YHz95jqvXb1s1w0lnjwAuX26+wNuqDzQbZzYCrAgFKEABClCAAn4LWFUAd9z5IsqVLKBaW65EARxzvqDm9Ue37j6Ek1N4pEudHA729ihZJC+OnjqvkviV//CJs0ibKhmqViiOcGHDIHHCf6DR2HYAZ6+1K12isHKz9qtwJ/50YJInJwM4dcA5ogAFKGC+AqwZBShAAasXsJoATq6SSUwVLWpkddASxo+D12/eqXn90avX7xA/bizPVZLu1X9v4V/+5y9eq/S1m3VXt08uWb1VLdv6qPyf3iit+Tm4t+8+4N6DR4gYwQkZ0qWy9UPO9lOAAhSgAAWsWIBNo4BlCFhUANex92i06DzYx3D+zy2QdnZ/m6PR/J33fig0dvpXz/6m8yv/79/uePHqP4wa2AVLZgzH4eNnce7iNVXsz58/oD+4uPzE79+/vazT325N84Xy54SYnb94FQ8fP7bKNh88ckwd5zw5sxqkfa6uvwxSjjWdR2yLx2eIq6srzw1vn6c8N3TnBj83eC54nAveHX79+gX53uF9PZd997Ill1+/XMz63FBfrqxtFIrt+Ru9hOJOg7ur4f3aY/zQbj6GrP+mRQSn8HBzc4eL9sNMyn/7/gNixYwus16GOLGi4/2Hz57r3mnTxYkdw9/8MaJHRdpUydWtkzFjREPGdClw695jVYadnb02iPk7SOCo0Wi8rPOexlqWo0aJAnkWDtp/u/cdtco2O5+9rG0dkCdXVoO0T84Pazn+bMffn3tDWGg0GoOcY4aoC8sw7LENqSc/N8zreIT0eBoyv0ajgUZjB0OWybKs43wz9/MC/BciAbsQ5Q7lzHIbW6SIEVTnGfpTXTXy5syMfYdOqsU9B08gf67Mal5uj7x6446aT50iCaS3ySfPXqqeJPcfdkb+3FnVNr/yF9Buv33vIb58/YafLi64cv0u0qRMovI4OjrC+yAbvK8LxWUf9THmviuUKS7Nxa69h0N1v8Zsk37Zp854PEdZIG9Og7TP3t7eIOXo15HzPn8GLdGE54Z1HEdjnHs8N3hu+HVeOTg48HeKL9/D/PKypfVybshgrm1WXx45CraARQVwAbWyU6u62Lr7CJq0H4DHT16gbo1yKstTbbA2dNxsNa/RaDC4Vxv0HzENjdr2Q7Ys6SBX8GSjX/nlSl79muXRvNNgNOs4CMUK5fbMI/lseahUroRq/sGjp/Dt23c1by2jHz9+4sKla5AvTzmzZbKWZgXQDm6mAAUoQAEKUIACFDBnATtzrlxQ6ya3N84c10+9RmBE/44IHy6cKiJ1yqRYPX+cmpdRpgypsWj6MCydOQLN61eTVWrwK79sLFuiIFbOHa3y1KlWRlZx0Ar8Ezc2MqZLjV+/fmHPgaOwpn8nT59XzzPmyPov5K9Y1tQ2toUCRhFgoRSgAAUoQAEKGF3AqgI4o2txB74KlC9TTK23ttcJSAAnDcuXO7tMOFCAAhSggBEFWDQFKEABCgROgAFc4JyYyh+BcqWKqq3bdu6Hm5ubmreG0Qnnc6oZ0oGJmuGIAhSgAAUoQAFzFGCdKGBTAgzgbOpwG6exWTKlR9w4sfD5y1eccD5vnJ2Ecqnu7u7atngEcPnz5AjlvXN3FKAABShAAQpQgAKhI2B5e2EAZ3nHzCxrXL60dd1GeenKDfz86YJ0aVKqXk/NEp2VogAFKEABClCAAhSwOQEGcGZ0yC25KuVKe9xGuWXHXktuhmfdj586q+bz5sqmphxRgAIUoAAFKEABClDAHAQYwJnDUbCCOhTOnwvhw4fD4yfPcf2mxzv3LLlZultBLSiAs2Ru1p0CFKAABShAAQpQIJACDOACCcVk/guECRMGpYoVVIm27z6oppY8OnrCWVU/b66sasoRBaxbgK2jAAUoQAEKUMBSBBjAWcqRsoB66m6jtPTXCdx78Ajv3n9EnNgxkTBBPAuQZxUpQAEKmFCAu6YABShAgVAVYAAXqtzWvTPpyMTOzg5nz1/G23cfLLaxutsnC+XPZbFtYMUpQAEKUIACliDAOlKAAkEXYAAXdDPm8EMgcqSIyPun04/N2/f4kcr8V5/88/43XVvMv8asIQUoQAEKUIACFLA5AZttMAM4mz30xml4uVJFVMHbdx1QU0scHT/l8f63PDmzWWL1WWcKUIACFKAABShAASsWYABniIPLMjwFKpUrqeb3Hz6Bb9++q3lLGsmtn3fvP0TECE7IkC6VJVWddaUABShAAQpQgAIUsAEBBnA2cJBDs4mJE8VHmlTJ8evXL+w7dCw0d22QfR0/dUaVkz9PDjUNjRH3QQEKUIACFKAABShAgcAKMIALrBTTBVpAOjORxNt3Wd7rBE44n5eqIw9fH6AcODJ7AVaQAhSgAAUoQAEbE2AAZ2MHPDSaq3sObseeA/j9+3do7NJg+zjBDkwMZsmCKEABcxdg/ShAAQpQwBIFGMBZ4lEz8zrnyJYJ0aNFUe9S0wVEZl5lVb0fP37i4uXrsLe3R05tG9RKjihAAQpQgAIU8CnANRSggMkEGMCZjN56d6zRaFCxbAnVwO27Lac3SuezF+Hm5qaCNwcHB1V/jihAAQpQgAIUoAAFDCvA0kImwAAuZH7M7YdAuVJF1ZaNW3erqSWMjp86q6rJ978pBo4oQAEKUIACFKAABcxQwMYDODM8IlZSpeJF8iF8+HB49PgZjhx3tohWnTzNDkws4kCxkhSgAAUoQAEKUMCGBRjA2fDBN2bTP33+ijCOjtBoNChTtRGatu1hzN2FuGx3d3forsAF+hUCId4rC6AABShAAQpQgAIUoEDQBBjABc2LqQMpsHjFOnz89Nkz9ap1W7H/8HHPZXObuXztJn7+dFEv744UMYK5VY/1sUIBNokCFKAABShAAQoER4ABXHDUmCdAgVu37/tIc+PmXR/rzGXFiVPnVFXy5MymphxRgAIUMGMBVo0CFKAABWxYgAGcDR98Yza9cvmSXoqX98F9/fbNyzpzWtC97iBPzqzmVC3WhQIUoAAFKGBgARZHAQpYugADOEs/gmZa/9IlCmHq2MGQQC5Hln+h0f43dPRU7N532CxrfPjYKVWvQvlzqSlHFKAABShAAQpQgALeBLhoFgIM4MziMFhfJezs7NCkQU0snz8Zh3atRuvm9SBX4eo07YiLl6+bVYPvP3yMd+8/IkH8fxA3TiyzqhsrQwEKUIACFKAABShAAX0BSw3g9NvAeQsQGDusDyqUKY4fP36iYq2muPfgkdnU+oSzx+sD8ubi7ZNmc1BYEQpQgAIUoAAFKEABXwUYwPnKwpWGFtBoNFgyZzzy5c6Ot+8+oFz1Jnjz9r2hdxPI8rwmO+ns0YFJ3lzZvG7gEgUoQAEKUIACFKAABcxMgAGcmR0Qa65OmDBhsG7ZTKRKkRRPnj5XV+K+f/9h8ibrOjDJmyu7yevCCliAAKtIAQpQgAIUoAAFTCjAAM6E+La468iRImL7uoWIHTMGLl25AXkmzt3d3WQUcjXw9t0HiBjBCenTpjRZPbhjClDANgTYSgpQgAIUoEBIBRjAhVSQ+YMsEO+fONi6bgEiRYyAPfuPoEP3QUEuw1AZdLdP5s+Tw1BFshwKUIACFKCAMQRYJgUoQAElwABOMXAU2gIZ0qZSt1M6ODhg4bK1GDt5TmhXQe3vuO75t9x8/k2BcEQBClCAAhSggBUKsEnWJMAAzpqOpoW1Ra56zZ8+WtV60IiJWLdph5oPzdHf598YwIWmO/dFAQpQgAIUoAAFKBA8gVAP4IJXTeayVoHqlctiaP+uqnlN2/bEsZNn1HxojOSVBhcuXYO9vT1yZP03NHbJfVCAAhSgAAUoQAEKUCBEAgzgQsTHzIYQ6NKuGRrXqwFXV1dUr9caV2/c9qtYg64/fe4S3NzckDNbJsitnAYtnIVRgAIUoAAFKEABClDACAIM4IyAyiKDLjBl7CD1ou/PX76iQvUmeP7iVdALCWIO3e2T8m66IGZlcosUYKUpQAEKUIACFKCA5QswgLP8Y2gVLbCzs8OSOeORI3rDpesAABAASURBVGsm/PfmLcpVb4xPn78YtW26Hijz5Mpq1P2wcApQwAoE2AQKUIACFKCAmQgwgDOTA8FqAGHChMHGlbORLEkiyLvZ5HbKX79+GYVG3j136swFVTavwCkGjihAAQpQwEgCLJYCFKCAIQUYwBlSk2WFWCBa1CjYvm4BYseMgeOnzkI6Nvn9+3eIy/VewOVrN/Hl6zekT5tSvY/O+3YuU4ACFKAABShAATMQYBUo4EOAAZwPEq4wtUCihPGxVRvEOTmFx/rNO9F/6HiDV+mk83lVZt5c2dWUIwpQgAIUoAAFKEABCliCQOADOEtoDetoNQIZ0qbC6sXTVO+QE6fPx4KlawzathPO51R5eXPx/W8KgiMKUIACFKAABShAAYsQYABnEYfJ8isZnBYULZgX86ePVlk7dB+E3fsOq3lDjHQBXMF8OQ1RHMugAAUoQAEKUIACFKBAqAgwgAsVZu4kuALVK5fFgF4dIc/B1WnaEafPXQxuUZ75Hj56ipevXiNB/H8QN04sz/WcMVsBVowCFKAABShAAQpQ4I8AA7g/EJyYr0DPzq3QuF4N/PjxE1Vqt8S9B49CVNnjzmdV/ny5efukguCIAlYtwMZRgAIUoAAFrEuAAZx1HU+rbc2UsYNQslhBfPj4CeWqN8Gbt++D3daTnh2YMIALNiIzUoACFLAFAbaRAhSggBkKMIAzw4PCKvkUsLOzw4r5k5EpY1o8efocFWs1xffvP3wmDMSaE386MMmTkwFcILiYhAIUoAAFKECBYAgwCwWMJcAAzliyLNfgAuHDh8OW1fORLEkiXLpyA/JMnJubW5D28/bdB9y6cx8RIzipd8AFKTMTU4ACFKAABShAAQpQwPgC/u7BqgI4ua2uXY8RaNJ+APoMnYzvP3y/QnPp6i00atcf9Vv3wbyl6z2B/MovHWiMm7YYdVv08swj6zwzcibUBGLGiIbt6xYgRvSo2LP/CFp16hukfZ867fH+twJ5cwYpHxNTgAIUoAAFKEABClDAHASsKoCbPHs5cmfPhAVThyBy5EhYvnaHD2MJvAaMnI4e7Rth4bShOHD0NC5cvqHS+ZX/uPNF3L3/GPOmDMLkET2xc99x3Lr7UOWx+pEZNjBRwvjqSpyTU3isWLMZoyfOCnQtPW+fzJU10HmYkAIUoAAFKEABClCAAuYiYFUBnARa5UoWULblShTAMecLal5/JIGXfPFPlzo5HOztUbJIXhw95XFVxq/8bu7uqgh5DsvOTgN7ew1ix4wO/jOdQOZ/06kXfcsxGTJqMtZt8hms+1a7E3+uwPEF3r7pGH4dS6QABShAAQpQgAIUMKyA1QRwX799h0YDRIsaWQkljB8Hr9+8U/P6o1ev3yF+3L/v/pJ0r/57C//y582RCe6/3VG4QhOUqdkGlcsVR/RoUfSL5bwJBORF37MmDVd7btq2Jw4cOaHm/RrJawjOXbiiDcDtkSPrv34l43oKUMA8BFgLClCAAhSgAAV8EbCoAK5j79Fo0Xmwj+H8n1sg5WqMro0ajd9N02ivounSAX/T+ZX/4ZNniBE9CratmoY1C8Zh175juPfwiSrix48f0B9+/vwJuU1Tfx3nvRoZ0qNapdLo2bkVXF1dUatBW5y/eMXL8dDf1/FTZyGdnkjwJun1twV3/ufPHwjKIPsNSnqmDZpvaHv9+PFde74ZZpBzw+M8NEx5hqybpZYV2ueDsfbn6vpL+znzUzuY98+DsdofvHJ/GOxn05zP/1+/PM4Nc66jqeoW3PPGWvLJueHi4mK2nxvqSzRHwRb4G70Eu4jQyzi8X3uMH9rNx5D137SI4BRe++XcHS7aDzOp0dv3HxArps/bHOPEio73Hz5LEjW806aLEzuGv/klYEufOiViRIuKhPHjIm2qpLh2857K7+joAP3BwcEeGo3Gyzr97Zz36mUIj77d26J2jYr49v0HqtZtpb3y+tZX/9PnLqljli93Nl+3B6cu9vYOsA/CIH8kCEp6pg2ab2h7OTo6as8lwwz29nYGK8uQ9bLkskL7fDDW/uzs7CG/W4xVvrWWa8nnbmDrbm8v54b8XjXM51Bg92sJ6UJ0Xgfh97q57sfOzg5yftibaVvAfyESsKgATrp+jxQxArwPOoG8OTNj36GTanHPwRPInyuzmpfbI6/euKPmU6dIAult8smzl5Bn2/Yfdkb+3FnVNr/yx4geDRev3FBXeTzKuotUyROrPL79YMgG39ZznfG+jM+ePAJFCuTRBm/vULFWc3z99gP23j60nM9ckEODvLmzw97btuAuOzg4aL9YBX6QD9Sg5mH6wPuGtlVwzxvf8mk05v3L1rc6m/u60D4fjLU/+dwQa2OVb63lipm1Dx7nhj3sDfQ7zZrKsdbzOrDt8gjePAL8wOYJzXTqC5mVjkKjWXahsZPQ2kenVnWxdfcR9RqBx09eoG6NcmrXT7XB2tBxs9W8RqPB4F5t0H/ENDRq2w/ZsqSDXMGTjX7lr1S2CD58+oLK9TqhdddhqFqhGNKkTCpZOJiJgHxQrV48DZkypsXtuw9QvV5ryK0Duuq5u7vj5Onz0Gg0yKcN4HTrOaUABShAAQpQgAIUoIAlCdhZUmUDqqu8I2zmuH7qNQIj+ndE+HDhVJbU2mBr9fxxal5GmTKkxqLpw7B05gg0r19NVqnBr/xye+a8yYPUM3BLZg5HtQolVHrzHtle7SJEcFKvF0iYIB7kebcGLbqq5xFF4uqN2/jy9RvSp02pruDKOg4UoAAFKEABClCAAhSwNAGrCuAsDZ/1NbyABOG6F31v3bkPfYeMVTs5ceqcmubJmU1NOQpAgJspQAEKUIACFKAABcxSgAGcWR4WViokAsmTJsbm1fMQLlxYTJ6xEAuWrIHuBd58/1tIZJmXAoETYCoKUIACFKAABYwnwADOeLYs2YQCWf5Nj2XzJqlbKNt1G4j1m3aoeUdHBxPWirumAAUoQIEABLiZAhSgAAUCEGAAFwAQN1uuQJkShZE7RxZoNNo2aEcajQYdug/Cjx8/tSv4PwUoQAEKUIAC1iXA1lDANgQYwNnGcbbZVn779t1L29+9/4Bbd+97WccFClCAAhSgAAUoQAEbF7Cg5jOAs6CDxaoGXSBd2pReMjk5hUfqFMm8rOMCBShAAQpQgAIUoAAFLEWAAZz5HSnWyIACPTq1QrFC+dSrAzJnTIcxQ3urzk0MuAsWRQEKUIACFKAABShAgVATYAAXatTckSkE0qRKji1r5uHlvbM4vm89GterYYpqhOI+uSsKUIACFKAABShAAWsWYABnzUeXbaMABSgQFAGmpQAFKEABClDA7AUYwJn9IWIFKUABClCAAuYvwBpSgAIUoEDoCDCACx1n7oUCFKAABShAAQpQwHcBrqUABYIgwAAuCFhMSgEKUIACFKAABShAAQqYk4Dt1YUBnO0dc7aYAhSgAAUoQAEKUIACFLBQAQZwBjxwLIoCFKAABShAAQpQgAIUoIAxBRjAGVOXZVMg8AJMSQEKUIACFKAABShAgQAFGMAFSMQEFKAABcxdgPWjAAUoQAEKUMBWBBjA2cqRZjspQAEKUIACvglwHQUoQAEKWJQAAziLOlysLAUoQAEKUIACFDAfAdaEAhQIfQEGcKFvzj1SgAIUoAAFKEABClDA1gXY/mAKMIALJhyzUYACFKAABShAAQpQgAIUCG0BBnAizoECFKAABShAAQpQgAIUoIAFCDCAs4CDxCqatwBrRwEKUIACFKAABShAgdASYAAXQulfv1ygP8SNGwdz5sz2sk5/O+e9etmah6OjI88Nbz8ztnYOeGuv5/kQJkwYuLr+8lz2Kx3X295niKOjA9zcXHlu8LPDxzlgb28Pd3d3H+v5OWF7nxPej7mdnXzF/22250YIv37bfHY5ujaPQAAKUIACFKCA5QmwxhSgAAUoYIsCDOBs8aizzRSgAAUoQAEK2LYAW08BClisAAM4Ax66N2/fo12PEWjSfgD6DJ2M7z9+GLB0FmVJAi//e4ORE+ehTI3W+F+z7li8cotn9V3d3DB8wlw0atsPLToPxtPnLz23cca2BKbOWY48pepBzglpuUx5boiE7Q5yDoyfvkR9duQtXR+rNuzyxFizaTfqteqNBq374sjJ857rOWMbAvIdo9uAcajboheadhiIfYdPeTac54Ynhc3MbNpxALW13y/kd8j7D5+8tNuv8+HS1Vto1K4/6rfug3lL13vJE9QFpjetAAM4A/pPnr0cubNnwoKpQxA5ciQsX7vDgKWzKEsSkHvPq1cqgZ1rZ2J4vw5Yu3kP7j14opqwddchvHv/AYumD0P1iiUwatICtZ4j2xJ48OgZbt97jDCOjtBoNKrxPDcUg02Plqzaims372L62H44sm0h8ufOojwePXkB2TZ7wgCMGdQZw8fPwY+fLmobR7YhsHL9DiSMHxfLZo9E17YN1B8CpeU8N0TB9oY4sWJgSJ92iBkjmpfG+3U+/P79GwNGTkeP9o2wcNpQHDh6Ghcu3/CSlwuWI2DhAZx5QR93vohyJQuoSpUrUQDHnC+oeY5sTyB2zOhImSwx5F/yJAmRPGlCPH/5WhZx/NQFlNWeH7JQtGAuXLt1D1+/fZdFDjYkMHbaIvTs2Bi/5T/tL1ZpOs8NUbDtYee+o+jcuj6SJYkPBwcHJIgXR4EcO3UehfJlRwSn8IgbJybSpEyKM+evgv9sR8DN3V39sUej0UD+SBg3dkzIP54bomB7Q54cmTy/Z+i33q/z4dbdh3DSfn6kS50cDvb2KFkkL45qP1f083LecgQYwBnoWMkXcO1nKqJFjaxKTBg/Dl6/eafmOTJTgVCqllx5u3H7PjKmT6n2+Prte8T/x+NLmXyIyi/h/17zXFE4NjLaof2Snj1TOu2X87heWsxzwwuHzS1Ib4LyWbBx+34Uq9wM7XqOxOOnHrdYv377DvHixvI0kcDuvzdvPZc5Y/0C1SqUwJ4DJ9Vt1y07D0HPDo1Vo3luKAaO/gj4dT680n7PiK/3GSLfU1/9x8+QP2wWN2EAZ8BDJn8R0xWn0ZBWZ2HL0w+fPqP30Eno160lokaO5Emh0XjcMicr7PTmZZmDZQgEt5Zfvn7Dxm0H0KB2RV+L0Gh4bvgKYyMrXX79gly137JiKkoXzYuRk+Z5tlyjugX3WNRo/p4nHms4tnYBud2tUtnC2LthDqaO7o0RE+fC1dVVNZvnhmLg6I+AX+eDxk7/c4PfU/9wWeSER89Ah01ua3Fzc4f88pUi377/gFgxo8ssBxsVkNtdhoyZic6tG6BgnqyeCrFiRMO79x89l999+ITYsXiueIJY+czVG3cgQ4GyDdVf0n/9coXMy1V8nhtWfvD/Ns/XOfkjYMzoUVEwbzZ1q2SRAjlx9/5jlTZWjOj48EHvc0P7OyZ2zBhqG0e2IbBx+wHkz50VESM44d/0qVSjX2qvoPDcUBQc/RHw63yIo/2e8f5IudGXAAAQAElEQVTD5z+poP0e8gFxYvMzxBPEwmYYwBnwgOXNmRn7Dp1UJe45eAL5c2VW8xzZnoB8KR84cgbKligIuU9dXyCv9rzYd9hZrXI+dwXJEsdXX9bUCo6sXkA6Ojq5exl0g7yk+eiOxeoc4Llh9Yc/wAbm035BP3PB49m20+evImVyj2dp5Yu7PK/y08VF+8XrI67fuo9c2TMGWB4TWI9AjOhRcPqcnBvAw8fP8f37T8TVfgHnuWE9x9gQLfHrfEidIgmkJ9Mnz15C/sC8X/s9RNIaYp8sI/QFGMAZ0LxTq7rYuvuIeo3A4ycvULdGOQOWzqIsSeDcpWvYf+QU+o+Ypq6ySDe/O/YeUU2oWKYI7Ow06jUC85dtQM+OTdV6jijAc4PnQOvGNXHkxHlIV9+btFdc+nRuplASJ/wHVcoVU93Hd+ozBp3bNFA9mKqNHNmEQIuGNbBu617UbNIVw8bPxuDebVVHNzw3bOLw+2jkzAWr1fcLCcrK1moDecWEJPLrfNBoNBjcqw36a7+XyGuMsmVJh6z/ppUsHCxQwM4C62y2VY4ZIxpmjuunXiMwon9HhA8XzmzryooZV8D7VRa52iJX42Sv0nFJ3y7NIa8RmDNxIBIliCurOdiowJFti1SPYNJ8nhuiYNtDlMgRMWlEDyyaNhSTR/aEdFaiE6lZuRSWzRqJJTOHo1DebLrVnNqIQCrt1ditK6ZizYLxmDd5sJcv3zw3bOQk0Gtm6ya1PO/kkO8Y44Z089zq1/mQKUNqyHePpTNHoHn9ap7pOWN5AqYK4CxPijWmAAUoQAEKUIACFKAABShgYgEGcCY+ANx9cASYhwIUoAAFKEABClCAArYpwADONo87W00B2xVgyylAAQpQgAIUoIAFCzCAs+CDx6pTgAIUoEDoCnBvFKAABShAAVMLMIAz9RHg/ilAAQpQgAIUsAUBtpECFKCAQQQYwBmEkYVQgAIUoAAFKEABClDAWAIslwJ/BRjA/bXgHAUoQAEKUIACFKAABShAAbMWCHIAZ9atYeUoQAEKUIACFKAABShAAQpYsQADOCs+uGbYNFaJAhSgAAUoQAEKUIACFAiBAAO4EOAxKwUoEJoC3BcFKEABClCAAhSgAAM4ngMUoAAFKGD9AmwhBShAAQpQwEoEGMBZyYFkMyhAAQpQgAIUMI4AS6UABShgTgIM4MzpaLAuFKAABShAAQpQgALWJMC2UMDgAgzgDE7KAilAAQpQgAIUoAAFKEABCoRUwPf8DOB8d+FaClCAAhSgAAUoQAEKUIACZifAAM7sDol5Voi1ogAFKEABClCAAhSgAAVML8AAzvTHgDWggLULsH0UoAAFKEABClCAAgYSYABnIEgWQwEKUIACxhBgmRSgAAUoQAEK6AswgNPX4DwFKEABClCAAtYjwJZQgAIUsEIBBnBWeFDZJApQgAIUoAAFKECBkAkwNwXMVYABnLkeGdaLAhSgAAUoQAEKUIACFLBEAaPWmQGcUXlZOAUoQAEKUIACFKAABShAAcMJMIAznKV5lsRaUYACFKAABShAAQpQgAJWI8AAzmoOJRtCAcMLsETzE/jp4oI8per5OrTqOjTQFe7YezSOO18MMP3CFZsxde6KANOZY4I5i9dCBnOsW0B1KlS+MeRYB5Ru7tL1cHd3DyiZr9vzlWng63qupAAFKEAB8xZgAGfex4e1owAFKOBFIGyYMDi5e5kaFk0bimhRI6t5WTdrfH8vaf1baNvsf0ifNrl/SdS20sXyonLZomo+iCMmDwWBRdoA2/3371DYE3dBAQpQgALmIsAAzlyOBOtBAQpQIIQCcmVuxvxV6NBrFFau34l37z+ifus+qNOiJ2o17YZla7Z77mH6vFW4duOeWparVH2GTka7niPRrONAjJw0H65ubmrbrv0nsGnHATXvXzrZV89BE1CvVW+07T4cUt68pRtUPu+j0+evoGWXIWjYpq+aXr/lUY8zF66iUbv+6D5wPJp2GIjmnQbj1t2HntnnL9uoym/Qui+GjpuDL1+/qW3ff/zA2KmLUK9lb9XOVl3+Xol8+Pi5alftZt0xcuI8z3bJvrr2H4sm7QegeJXmOHzinCrL+2j91r2qnrLPUtVbKVNJ41ddPI16jED1Rl3Qf8Q03LrzAK20V0erNeyijovkl0GO19Q5y9Gi82BI/fYeOimrfQxPnr1Er8ETVfvkeO7cd0ylmTZvpbr61q77CFX+j58u8CutZNh94DhqN++hzGcuXC2rzHhg1ShAAQpQwC8BBnB+yXA9BShAAQsUSBAvDqaM6oXa1cogfPiwGNGvA1bMGY15kwfjwFFnnL98w9dWvfzvLUYN6KjSaTQaHDjiHKR0sxevQ9iwYbF05ggM7Nnaz/28ff8Bw8bPRfd2jbB4xnB0adMAvYdM9gys7t1/jDZN/of5Uwaj4f8qagO12aoeB46exo69RzFtdG8smDYEb9+9x8LlG9U2CRQfPX2BuZMHYvX8cejRoYlaL6MXr96odi2dNRKv377zbNe0uSvRqnFNLJg6BNtWTUem9CkluZfh+OmLkCtcw7WGS2YO19ZpECJGdIJ/dZECxHLM4C5YNnsU7j98iiWrt6pjslBb7xXrtuO/N+8kmRoSJ4yHORMHarf3xoTpSyA+aoPeaOCoGSiYL7u2vJGYqj22i1ZuUoFtu2a1YWdnh2lj+0CuvoYLGwZ+pX3z9j1GTV6AIb3bYvaEAXB19QjQwX8UsEYBtokCVi7AAM7KDzCbRwEK2JZAqWL5PBscThtQXbhyE4PHzNJe1ZqA9x8+4ebtB57b9WdyZEmPiBGc1Kq4sWPg3sMnat77yK90l6/dwv+qloZGo0HsmNFROH9O71nV8qWrt/Hjx0+Mm75YXTWaOHMpPn76gsfaAEwSJEkcH0m1g8znz50FT5+9glxZOn/pBsqWKICoUSLDwd5eG6CWxTntOknnfPYKGtWuiPDhwskikiWJr6YyypY5nWqXg4MDMqZL7dmurJnSYuaC1ZBnyK5cv63KlfT6w6kzl1GxTGFIUCzrE8SLizCOjvCvLpJOynYKHw7htAFVqhRJkClDapUvcqSISJwoPh48eirJ1FC0YC41jaU1S5MqGa5cu6uWdaNPn7/gxu372LLzkPLqpQ12v379gcvXbuuSeE79S3vp2h1kyZgaKZMlVunrVC+rphxRgAIUoIBXAUtYYgBnCUeJdaQABSgQSAF5Rk6XdNuew5ArafVrVsC0MX2QP3dWfPv+Q7fZy9Te/u+vAzvtVR2/rtD4l06CJF2hjtqASTevP9VoNEidIom6YiRXjWQ4tHUBkiVOoJ/My7yrqyt+a/+TwE23IYyjA37rPfsVRhtY6bbpT8No0+mWpe6uf648dWxZT139S/BPHO2Vr8XYsuuQLpmXqYODo5dlWQi4Lg6STA1i6ahfB2Ub+E5H7LXBqoPWcsbYvp5m21ZNQ41KJVX5+iN/02qtpBxder+Oj247pxSgAAUoYL4Cf39jm28dbbRmbDYFKECBkAk8fPRMe9UplboiJYHLyTMXQ1agP7n/TZ8aJ057lO+qDbhOn7/sa+rM2qtR8lzb/sN/b9E8eeaSZ9p7D55Ank+TFRu27UPCBHHVFbRsmdJh5/6jkKtM8nzeyg07kV171VDS5cqeEXJboTwLJ8u6Z+Nk3q9BrvrJFbUyxfOjdLECkCuD3tPmzvEvtu0+jKfPX6lNLr9+QQb/6qISBmG0asMulVqek5MrgRnTp1DLulEEp/BIkzIppsxZrp53k/ViJLdEyrxs//Dxs8xC5v1KmzF9Sly7ec/zucFjp86rPBxRgAIUoIDlCTCAs7xjxhpTIGABpqCAVqBK+eLYtf8YpFOPQaNnIFVyj9vntJsM/n/LhtVx884DyOsJ+g6bAnm2K2qUiD72Ey1qZIwa2AkSnEmHJaVrtMLG7fs908kth9LZSt0WvbBz33H069pCbStaICeKF8qDNt2Go0m7AYgUMSIa16mstjWrXxXx/4mrOj6Rzlpadxum1vs3atllMEpUbYFu/cfh9v1HkFswvafPlzMzalUphT5Dp0A6DylRpQW+fPkG/+rivYyAlr99/646mZHj07NjE8SIFtVHlsG9WuPN24+o36oPajTuiv4jp8Htz6sDWjSshhET5qBV16HqVlO/0saOGR0dW9ZF32FTVacuzueu+tgPV1CAAhSggGUIMICzjOPEWlKAAhTwIZBae2Vmx+oZnuvlVQKeC9oZeXZr7cLxmDWhP0YN6IQR/TtCgh3tJkwe2RP5cmWWWbRoWEMNagFAg1oV0L55HbXYuE4lz3n/0oUPHxbD+rZX5fbu0hwvX71F5gxpVBneR1n/TYvpY/ti0bSh2LV2FsYM6uKZRJ4bk7otnzMKcycNVLdb6jZK3ZfNHgnpUKR/txbqypxsk2ffurZtoDprkU5Mls4cIatVm6TOakE70m/XqnljsXfDHIwb2g3DtfVOGD+uNoXP/2tWLqX2J2Ue3rYQ0aNFUYn8qovsTwaVSDuSelYpV0w75/G/tE3nLms6tKir6r1SW58ShfPIKjXIvnS3w8aLG1tr2w5iIsdTOqWJEyuGSle9YklMGNZD3V4pdv6lLVkkrzo+0hHM4F5tcHznElUGRxSgAAUoYFkCDOAs63ixthSgAAXMUuDN2w8oUrGp6uq+XfcRqFahGFIkS2SWdWWljCrAwilAAQpQwMgCDOCMDMziKUABCtiCgFzBOrp9EeQKmQyVyhYNcrNzZMmgriQFOaOFZvB+xdRCm8FqU8CAAiyKAhQIjAADuMAoMQ0FKEABClCAAhSgAAUoYL4CNlQzBnA2dLDZVApQgAIUoAAFKEABClDAsgUYwBn++LFEClCAAhSgAAUoQAEKUIACRhFgAGcUVhZKgeAKMB8FKEABClCAAhSgAAX8FmAA57cNt1CAAhSwLAHWlgIUoAAFKEABqxdgAGf1h5gNpAAFKEABCgQswBQUoAAFKGAZAgzgLOM4sZYUoAAFKEABClDAXAVYLwpQIBQFGMCFIjZ3RQEKUIACFKAABShAAQroC3A+qAIM4IIqxvQUoAAFKEABClCAAhSgAAVMJMAATg+esxSgAAUoQAEKUIACFKAABcxZgAGcOR8d1s2SBFhXClCAAhSgAAUoQAEKGF2AAZzRibkDClCAAgEJcDsFKEABClCAAhQInAADuMA5MRUFKEABClDAPAVYKwpQgAIUsCkBBnA2dbjZWApQgAIUoAAFKPBXgHMUoIDlCTCAs7xjxhpTgAIUoAAFKEABClDA1ALcv4kEGMCZCJ67pQAFKEABClCAAhSgAAUoEFQB6wjggtpqpqcABShAAQpQgAIUoAAFKGCBAgzgLPCgscqGFWBpFKAABShAAQpQgAIUsBQBBnCWcqRYTwpQwBwFWCcKUIACFKAABSgQqgIM4EKVmzujAAUoQAEK6AQ4pQAFKEABCgRdgAFc0M2YgwIU2sYXnwAAAVtJREFUoAAFKEABCphWgHunAAVsVoABnM0eejacAhSgAAUoQAEKUMAWBdhmyxZgAGfZx4+1pwAFKEABClCAAhSgAAVsSMDEAZwNSbOpFKAABShAAQpQgAIUoAAFQijAAC6EgMxuQgHumgIUoAAFKEABClCAAjYmwADOxg44m0sBCngIcEwBClCAAhSgAAUsUYABnCUeNdaZAhSgAAVMKcB9U4ACFKAABUwmwADOZPTcMQUoQAEKUIACtifAFlOAAhQImQADuJD5MTcFKEABClCAAhSgAAVCR4B7oYBWgAGcFoH/U4ACFKAABShAAQpQgAIUsASB4AZwltA21pECFKAABShAAQpQgAIUoIBVCTCAs6rDaSmNYT0pQAEKUIACFKAABShAgeAIMIALjhrzUIACphPgnilAAQpQgAIUoIANCzCAs+GDz6ZTgAIUsDUBtpcCFKAABShg6QL/BwAA//9DcqXDAAAABklEQVQDAP2i2Yc7tETPAAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Line chart of mean validation information coefficient against training epochs completed, one line per fitted label with a dashed zero line. Counted from the frame: fwd_ret_5d spans -0.0083 to +0.0010 with 2 of 20 checkpoints above zero."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "curve = catalog.filter(\"full_coverage\").sort(\"label\", \"checkpoint_value\")\n",
     "fig = go.Figure()\n",
@@ -524,13 +2477,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b77538ec",
+   "id": "ca7c5211",
    "metadata": {
     "papermill": {
-     "duration": 0.006939,
-     "end_time": "2026-09-06T20:08:22.332603+00:00",
+     "duration": 0.012617,
+     "end_time": "2026-09-08T19:57:03.832357+00:00",
      "exception": false,
-     "start_time": "2026-09-06T20:08:22.325664+00:00",
+     "start_time": "2026-09-08T19:57:03.819740+00:00",
      "status": "completed"
     }
    },
@@ -576,6 +2529,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T19:57:21.215982+00:00",
+   "executor": "local-uv",
+   "library_digest": "81bc94b583c996ee6e1d9be836ad939f8d10a9708b84a9538f2885e47bc276e3",
+   "outputs_digest": "7a2005b332f0c09dee8b78d204770dfc6ac3923e08d633915afde1dbf04af1e2",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "6145cc91d7bf094d5222e9a594672154adf2d2d6"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 8053.861006,
+   "end_time": "2026-09-08T19:57:06.926837+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/.10_dl_patchtst.build.4175248.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/sp500_equity_option_analytics/.10_dl_patchtst.papermill.4175248.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T17:42:53.065831+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_options/09_deep_learning.ipynb
+++ b/case_studies/sp500_options/09_deep_learning.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fc83a41b",
+   "id": "92e14fa8",
    "metadata": {
     "papermill": {
-     "duration": 0.001715,
-     "end_time": "2026-09-07T01:24:00.339307+00:00",
+     "duration": 0.001284,
+     "end_time": "2026-09-08T17:38:48.753661+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:24:00.337592+00:00",
+     "start_time": "2026-09-08T17:38:48.752377+00:00",
      "status": "completed"
     }
    },
@@ -25,9 +25,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c245dbe9",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "453bedab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:38:48.756326Z",
+     "iopub.status.busy": "2026-09-08T17:38:48.756213Z",
+     "iopub.status.idle": "2026-09-08T17:38:50.814541Z",
+     "shell.execute_reply": "2026-09-08T17:38:50.813848Z"
+    },
+    "papermill": {
+     "duration": 2.060218,
+     "end_time": "2026-09-08T17:38:50.815238+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:38:48.755020+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit NLinear within the declared S&P 500 options sequence population.\"\"\"\n",
@@ -51,9 +65,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ff2a2f29",
+   "execution_count": 2,
+   "id": "15337beb",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:38:50.817652Z",
+     "iopub.status.busy": "2026-09-08T17:38:50.817476Z",
+     "iopub.status.idle": "2026-09-08T17:38:50.820538Z",
+     "shell.execute_reply": "2026-09-08T17:38:50.820059Z"
+    },
+    "papermill": {
+     "duration": 0.004734,
+     "end_time": "2026-09-08T17:38:50.820891+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:38:50.816157+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -72,13 +99,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "788999ad",
+   "id": "73b38ba1",
    "metadata": {
     "papermill": {
-     "duration": 0.000874,
-     "end_time": "2026-09-07T01:24:03.465837+00:00",
+     "duration": 0.000615,
+     "end_time": "2026-09-08T17:38:50.822427+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:24:03.464963+00:00",
+     "start_time": "2026-09-08T17:38:50.821812+00:00",
      "status": "completed"
     }
    },
@@ -96,10 +123,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "af56515f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "id": "ccbeb716",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:38:50.824472Z",
+     "iopub.status.busy": "2026-09-08T17:38:50.824290Z",
+     "iopub.status.idle": "2026-09-08T17:38:51.661287Z",
+     "shell.execute_reply": "2026-09-08T17:38:51.660841Z"
+    },
+    "papermill": {
+     "duration": 0.83857,
+     "end_time": "2026-09-08T17:38:51.661597+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:38:50.823027+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training device: cuda (declared: cuda)\n"
+     ]
+    }
+   ],
    "source": [
     "CANONICAL_POPULATION_NAME = \"sp500-options-sequence-validation-v1\"\n",
     "\n",
@@ -117,13 +166,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "711cc29d",
+   "id": "1e1fa5ea",
    "metadata": {
     "papermill": {
-     "duration": 0.002015,
-     "end_time": "2026-09-07T01:24:04.743951+00:00",
+     "duration": 0.001799,
+     "end_time": "2026-09-08T17:38:51.664256+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:24:04.741936+00:00",
+     "start_time": "2026-09-08T17:38:51.662457+00:00",
      "status": "completed"
     }
    },
@@ -150,10 +199,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "512ccd63",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "0704ca57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:38:51.667082Z",
+     "iopub.status.busy": "2026-09-08T17:38:51.666491Z",
+     "iopub.status.idle": "2026-09-08T17:38:56.534282Z",
+     "shell.execute_reply": "2026-09-08T17:38:56.533877Z"
+    },
+    "papermill": {
+     "duration": 4.869788,
+     "end_time": "2026-09-08T17:38:56.534723+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:38:51.664935+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>task</th><th>feature_count</th><th>eligible_entities</th><th>eligible_rows</th><th>folds</th><th>validation_start</th><th>validation_end</th><th>checkpoints</th><th>execution_tier</th><th>training_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td><td>i64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;regression&quot;</td><td>54</td><td>273</td><td>85083</td><td>2</td><td>2019-01-07 00:00:00</td><td>2020-11-25 00:00:00</td><td>20</td><td>&quot;canonical&quot;</td><td>&quot;9be44756048d&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;regression&quot;</td><td>54</td><td>273</td><td>85083</td><td>2</td><td>2019-01-07 00:00:00</td><td>2020-11-25 00:00:00</td><td>20</td><td>&quot;canonical&quot;</td><td>&quot;f4874ea19561&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;regression&quot;</td><td>54</td><td>273</td><td>85083</td><td>2</td><td>2019-01-07 00:00:00</td><td>2020-11-25 00:00:00</td><td>20</td><td>&quot;canonical&quot;</td><td>&quot;10506ca49b0c&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 13)\n",
+       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐\n",
+       "│ family    ┆ label     ┆ config_na ┆ task      ┆ … ┆ validatio ┆ checkpoin ┆ execution ┆ training │\n",
+       "│ ---       ┆ ---       ┆ me        ┆ ---       ┆   ┆ n_end     ┆ ts        ┆ _tier     ┆ _hash    │\n",
+       "│ str       ┆ str       ┆ ---       ┆ str       ┆   ┆ ---       ┆ ---       ┆ ---       ┆ ---      │\n",
+       "│           ┆           ┆ str       ┆           ┆   ┆ datetime[ ┆ i64       ┆ str       ┆ str      │\n",
+       "│           ┆           ┆           ┆           ┆   ┆ μs]       ┆           ┆           ┆          │\n",
+       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ regressio ┆ … ┆ 2020-11-2 ┆ 20        ┆ canonical ┆ 9be44756 │\n",
+       "│ ning      ┆ piry      ┆           ┆ n         ┆   ┆ 5         ┆           ┆           ┆ 048d     │\n",
+       "│           ┆           ┆           ┆           ┆   ┆ 00:00:00  ┆           ┆           ┆          │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ regressio ┆ … ┆ 2020-11-2 ┆ 20        ┆ canonical ┆ f4874ea1 │\n",
+       "│ ning      ┆ piry      ┆           ┆ n         ┆   ┆ 5         ┆           ┆           ┆ 9561     │\n",
+       "│           ┆           ┆           ┆           ┆   ┆ 00:00:00  ┆           ┆           ┆          │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ regressio ┆ … ┆ 2020-11-2 ┆ 20        ┆ canonical ┆ 10506ca4 │\n",
+       "│ ning      ┆ piry      ┆           ┆ n         ┆   ┆ 5         ┆           ┆           ┆ 9b0c     │\n",
+       "│           ┆           ┆           ┆           ┆   ┆ 00:00:00  ┆           ┆           ┆          │\n",
+       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "study = open_study(execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)\n",
     "all_requests = model_request_catalog(\n",
@@ -173,13 +274,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f6efb7a",
+   "id": "2b4e0cb4",
    "metadata": {
     "papermill": {
-     "duration": 0.001144,
-     "end_time": "2026-09-07T01:24:14.331243+00:00",
+     "duration": 0.001463,
+     "end_time": "2026-09-08T17:38:56.537055+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:24:14.330099+00:00",
+     "start_time": "2026-09-08T17:38:56.535592+00:00",
      "status": "completed"
     }
    },
@@ -192,10 +293,1494 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a062c4b6",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "65af890f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:38:56.538936Z",
+     "iopub.status.busy": "2026-09-08T17:38:56.538846Z",
+     "iopub.status.idle": "2026-09-08T17:42:42.658634Z",
+     "shell.execute_reply": "2026-09-08T17:42:42.658044Z"
+    },
+    "papermill": {
+     "duration": 226.121811,
+     "end_time": "2026-09-08T17:42:42.659544+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:38:56.537733+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=80,175 seq across 532 symbols\n",
+      "    val=56,536 seq across 556 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.801500\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.694972\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.683949\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.678515\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.674882, val_loss=0.588932, IC=-0.0096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.677645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.674611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.670630\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.668805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.672047, val_loss=0.595842, IC=-0.0136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.669606\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.669007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.669517\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.666926\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.668677, val_loss=0.596094, IC=-0.0176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.666974\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.667748\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.669532\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.667156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.665530, val_loss=0.594821, IC=-0.0160\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.667014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.666038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.664955\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.663247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.666917, val_loss=0.597249, IC=-0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.663611\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.666637\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.663932\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.663722\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.663513, val_loss=0.597363, IC=-0.0155\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.668471\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.665699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.667025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.662943\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.668790, val_loss=0.600626, IC=-0.0159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.664913\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.667428\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.668474\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.663639\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.665714, val_loss=0.598618, IC=-0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.665645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.669320\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.663937\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.665851\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.666157, val_loss=0.599591, IC=-0.0169\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.664342\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.664448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.662481\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.665609\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.662238, val_loss=0.598693, IC=-0.0179\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.662984\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.664519\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.665643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.666200\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.664268, val_loss=0.597940, IC=-0.0173\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.662774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.664214\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.669537\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.666862\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.666911, val_loss=0.596728, IC=-0.0183\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.664704\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.664199\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.663338\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.666149\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.664840, val_loss=0.598728, IC=-0.0165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.664954\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.662667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.666653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.666718\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.665716, val_loss=0.598588, IC=-0.0176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.664605\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.665703\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.667372\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.663070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.665379, val_loss=0.597917, IC=-0.0174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.664636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.663643\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.663975\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.663996\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.664466, val_loss=0.598795, IC=-0.0174\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.665806\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.667239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.664051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.665800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.662377, val_loss=0.598331, IC=-0.0176\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.664040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.662893\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.662494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.663667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.669171, val_loss=0.598368, IC=-0.0170\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.665146\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.662211\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.664351\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.666694\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.664506, val_loss=0.598470, IC=-0.0172\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.664371\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.665065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.664656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.665141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.662396, val_loss=0.598397, IC=-0.0171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=-0.0096 (100.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=94,348 seq across 522 symbols\n",
+      "    val=28,547 seq across 582 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.683362\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.619571\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.614904\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.608013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.609382, val_loss=2.276906, IC=+0.0142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.604272\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.604286\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.602416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.604901\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.608340, val_loss=2.279229, IC=+0.0100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.603394\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.602507\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.601308\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.600563\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.600125, val_loss=2.297883, IC=-0.0175\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.601037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.599607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.608863\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.600203\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.598314, val_loss=2.297216, IC=-0.0165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.601644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.602544\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.601593\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.604553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.603789, val_loss=2.296379, IC=-0.0229\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.597535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.605805\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.601337\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.601339\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.602359, val_loss=2.296982, IC=-0.0212\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.601952\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.601968\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.600108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.600268\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.599243, val_loss=2.299467, IC=-0.0209\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.600966\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.600154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.601126\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.599990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.599201, val_loss=2.299873, IC=-0.0236\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.602604\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.598161\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.602416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.602159\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.600172, val_loss=2.291115, IC=-0.0206\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.599082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.601482\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.597922\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.601301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.598147, val_loss=2.295913, IC=-0.0164\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.603130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.599784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.609143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.597908\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.602041, val_loss=2.298421, IC=-0.0242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.599540\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.599683\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.598063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.602353\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.602449, val_loss=2.300734, IC=-0.0250\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.601109\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.601800\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.597804\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.600213\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.600506, val_loss=2.297628, IC=-0.0262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.602892\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.607226\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.599380\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.598860\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.600270, val_loss=2.296923, IC=-0.0239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.598291\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.601621\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.598304\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.602457\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.604550, val_loss=2.300185, IC=-0.0249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.601449\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.602724\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.599997\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.597184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.599715, val_loss=2.298988, IC=-0.0262\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.600076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.599934\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.600523\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.599029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.602899, val_loss=2.299806, IC=-0.0244\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.600016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.600341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.599419\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.601144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.601690, val_loss=2.298624, IC=-0.0247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.600553\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.605002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.601654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.601023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.600744, val_loss=2.299327, IC=-0.0249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.602790\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.600663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.599701\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.597857\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.609984, val_loss=2.298889, IC=-0.0247\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0142 (113.6s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=5, IC=+0.0017 (214.1s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 5 (IC=+0.0017)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/sp500_options/run_log/training/f4874ea19561/diagnostics\n"
+     ]
+    }
+   ],
    "source": [
     "nlinear_resolved = tuple(\n",
     "    request for request in all_resolved if request.spec[\"config_name\"] == \"nlinear\"\n",
@@ -230,14 +1815,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "16b2b321",
+   "execution_count": 6,
+   "id": "b421eedf",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-08T17:42:42.673486Z",
+     "iopub.status.busy": "2026-09-08T17:42:42.673305Z",
+     "iopub.status.idle": "2026-09-08T17:42:42.677727Z",
+     "shell.execute_reply": "2026-09-08T17:42:42.677305Z"
+    },
+    "papermill": {
+     "duration": 0.011834,
+     "end_time": "2026-09-08T17:42:42.678074+00:00",
+     "exception": false,
+     "start_time": "2026-09-08T17:42:42.666240+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (20, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>execution_tier</th><th>complete</th><th>training_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>bool</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;58830242fb5d&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;180b6fb09b86&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;26c61a31201f&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>20</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;c0ac0f1760e9&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;1657ef96321a&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>80</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;d09852853658&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>85</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;0f963e745446&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>90</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;fae0f8975333&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>95</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;bbb7306319ef&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;f4874ea19561&quot;</td><td>&quot;1c586621176b&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (20, 9)\n",
+       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬──────────┬───────────┬───────────┐\n",
+       "│ family    ┆ label     ┆ config_na ┆ checkpoin ┆ … ┆ execution ┆ complete ┆ training_ ┆ predictio │\n",
+       "│ ---       ┆ ---       ┆ me        ┆ t_kind    ┆   ┆ _tier     ┆ ---      ┆ hash      ┆ n_hash    │\n",
+       "│ str       ┆ str       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ bool     ┆ ---       ┆ ---       │\n",
+       "│           ┆           ┆ str       ┆ str       ┆   ┆ str       ┆          ┆ str       ┆ str       │\n",
+       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪══════════╪═══════════╪═══════════╡\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ 58830242f │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ b5d       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ 180b6fb09 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ b86       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ 26c61a312 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ 01f       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ c0ac0f176 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ 0e9       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ 1657ef963 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ 21a       │\n",
+       "│ …         ┆ …         ┆ …         ┆ …         ┆ … ┆ …         ┆ …        ┆ …         ┆ …         │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ d09852853 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ 658       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ 0f963e745 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ 446       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ fae0f8975 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ 333       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ bbb730631 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ 9ef       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ nlinear   ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ f4874ea19 ┆ 1c5866211 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 561       ┆ 76b       │\n",
+       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴──────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "catalog = execution.catalog_rows.select(\n",
     "    \"family\",\n",
@@ -257,13 +1904,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cee9ad06",
+   "id": "b9c68985",
    "metadata": {
     "papermill": {
-     "duration": 0.008057,
-     "end_time": "2026-09-07T01:28:50.792017+00:00",
+     "duration": 0.00342,
+     "end_time": "2026-09-08T17:42:42.686129+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:28:50.783960+00:00",
+     "start_time": "2026-09-08T17:42:42.682709+00:00",
      "status": "completed"
     }
    },
@@ -293,6 +1940,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-08T17:42:50.937678+00:00",
+   "executor": "local-uv",
+   "library_digest": "660fe266d71874fd80ddb6b61310446a0b18c6405f5c2bf3915c42cec34f6f63",
+   "outputs_digest": "bd5619cf6fa71d2847f0bd49e6e7b6814ed8aa0a07a8d1d794ceb9b9d81674f0",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "2dfbe9b11764dcd67fb95db57d641e79dce50335"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 237.227757,
+   "end_time": "2026-09-08T17:42:45.138886+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/sp500_options/.09_deep_learning.build.4164238.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/sp500_options/.09_deep_learning.papermill.4164238.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-08T17:38:47.911129+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/sp500_options/09a_lstm.ipynb
+++ b/case_studies/sp500_options/09a_lstm.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f120cd77",
+   "id": "97e89576",
    "metadata": {
     "papermill": {
-     "duration": 0.002146,
-     "end_time": "2026-09-07T01:29:11.271861+00:00",
+     "duration": 0.005272,
+     "end_time": "2026-09-08T21:07:34.881053+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:11.269715+00:00",
+     "start_time": "2026-09-08T21:07:34.875781+00:00",
      "status": "completed"
     }
    },
@@ -51,19 +51,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "fdc7b519",
+   "id": "8b71a423",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:11.277261Z",
-     "iopub.status.busy": "2026-09-07T01:29:11.276987Z",
-     "iopub.status.idle": "2026-09-07T01:29:14.441985Z",
-     "shell.execute_reply": "2026-09-07T01:29:14.441277Z"
+     "iopub.execute_input": "2026-09-08T21:07:34.887585Z",
+     "iopub.status.busy": "2026-09-08T21:07:34.887182Z",
+     "iopub.status.idle": "2026-09-08T21:07:42.832606Z",
+     "shell.execute_reply": "2026-09-08T21:07:42.832054Z"
     },
     "papermill": {
-     "duration": 3.169259,
-     "end_time": "2026-09-07T01:29:14.442959+00:00",
+     "duration": 7.953252,
+     "end_time": "2026-09-08T21:07:42.837538+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:11.273700+00:00",
+     "start_time": "2026-09-08T21:07:34.884286+00:00",
      "status": "completed"
     }
    },
@@ -89,19 +89,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "266e0bf8",
+   "id": "5bed19f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:14.447419Z",
-     "iopub.status.busy": "2026-09-07T01:29:14.447285Z",
-     "iopub.status.idle": "2026-09-07T01:29:14.449796Z",
-     "shell.execute_reply": "2026-09-07T01:29:14.449256Z"
+     "iopub.execute_input": "2026-09-08T21:07:42.849541Z",
+     "iopub.status.busy": "2026-09-08T21:07:42.848590Z",
+     "iopub.status.idle": "2026-09-08T21:07:42.855340Z",
+     "shell.execute_reply": "2026-09-08T21:07:42.853168Z"
     },
     "papermill": {
-     "duration": 0.005604,
-     "end_time": "2026-09-07T01:29:14.450263+00:00",
+     "duration": 0.014763,
+     "end_time": "2026-09-08T21:07:42.855885+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:14.444659+00:00",
+     "start_time": "2026-09-08T21:07:42.841122+00:00",
      "status": "completed"
     },
     "tags": [
@@ -120,13 +120,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2b2b407",
+   "id": "3a2474ee",
    "metadata": {
     "papermill": {
-     "duration": 0.001083,
-     "end_time": "2026-09-07T01:29:14.452918+00:00",
+     "duration": 0.001833,
+     "end_time": "2026-09-08T21:07:42.860036+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:14.451835+00:00",
+     "start_time": "2026-09-08T21:07:42.858203+00:00",
      "status": "completed"
     }
    },
@@ -157,19 +157,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "ae3ec46c",
+   "id": "7d8db520",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:14.456236Z",
-     "iopub.status.busy": "2026-09-07T01:29:14.456119Z",
-     "iopub.status.idle": "2026-09-07T01:29:15.532095Z",
-     "shell.execute_reply": "2026-09-07T01:29:15.531390Z"
+     "iopub.execute_input": "2026-09-08T21:07:42.865891Z",
+     "iopub.status.busy": "2026-09-08T21:07:42.865696Z",
+     "iopub.status.idle": "2026-09-08T21:07:45.733537Z",
+     "shell.execute_reply": "2026-09-08T21:07:45.732110Z"
     },
     "papermill": {
-     "duration": 1.080548,
-     "end_time": "2026-09-07T01:29:15.534665+00:00",
+     "duration": 2.871545,
+     "end_time": "2026-09-08T21:07:45.734212+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:14.454117+00:00",
+     "start_time": "2026-09-08T21:07:42.862667+00:00",
      "status": "completed"
     }
    },
@@ -199,13 +199,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae203471",
+   "id": "c50c0a75",
    "metadata": {
     "papermill": {
-     "duration": 0.00162,
-     "end_time": "2026-09-07T01:29:15.538037+00:00",
+     "duration": 0.001361,
+     "end_time": "2026-09-08T21:07:45.737801+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:15.536417+00:00",
+     "start_time": "2026-09-08T21:07:45.736440+00:00",
      "status": "completed"
     }
    },
@@ -236,19 +236,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "ff6abff4",
+   "id": "afa54c50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:15.542395Z",
-     "iopub.status.busy": "2026-09-07T01:29:15.541923Z",
-     "iopub.status.idle": "2026-09-07T01:29:18.249084Z",
-     "shell.execute_reply": "2026-09-07T01:29:18.248197Z"
+     "iopub.execute_input": "2026-09-08T21:07:45.743199Z",
+     "iopub.status.busy": "2026-09-08T21:07:45.742612Z",
+     "iopub.status.idle": "2026-09-08T21:07:50.735334Z",
+     "shell.execute_reply": "2026-09-08T21:07:50.733818Z"
     },
     "papermill": {
-     "duration": 2.710341,
-     "end_time": "2026-09-07T01:29:18.249780+00:00",
+     "duration": 4.996806,
+     "end_time": "2026-09-08T21:07:50.736107+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:15.539439+00:00",
+     "start_time": "2026-09-08T21:07:45.739301+00:00",
      "status": "completed"
     }
    },
@@ -263,7 +263,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (1, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>task</th><th>feature_count</th><th>eligible_entities</th><th>eligible_rows</th><th>folds</th><th>validation_start</th><th>validation_end</th><th>checkpoints</th><th>execution_tier</th><th>training_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td><td>i64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;regression&quot;</td><td>52</td><td>248</td><td>42804</td><td>2</td><td>2019-01-07 00:00:00</td><td>2020-11-25 00:00:00</td><td>20</td><td>&quot;canonical&quot;</td><td>&quot;9352ea662f25&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (1, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>task</th><th>feature_count</th><th>eligible_entities</th><th>eligible_rows</th><th>folds</th><th>validation_start</th><th>validation_end</th><th>checkpoints</th><th>execution_tier</th><th>training_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td><td>i64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;regression&quot;</td><td>54</td><td>273</td><td>85083</td><td>2</td><td>2019-01-07 00:00:00</td><td>2020-11-25 00:00:00</td><td>20</td><td>&quot;canonical&quot;</td><td>&quot;9be44756048d&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (1, 13)\n",
@@ -274,8 +274,8 @@
        "│           ┆           ┆ str       ┆           ┆   ┆ datetime[ ┆ i64       ┆ str       ┆ str      │\n",
        "│           ┆           ┆           ┆           ┆   ┆ μs]       ┆           ┆           ┆          │\n",
        "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ regressio ┆ … ┆ 2020-11-2 ┆ 20        ┆ canonical ┆ 9352ea66 │\n",
-       "│ ning      ┆ piry      ┆           ┆ n         ┆   ┆ 5         ┆           ┆           ┆ 2f25     │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ regressio ┆ … ┆ 2020-11-2 ┆ 20        ┆ canonical ┆ 9be44756 │\n",
+       "│ ning      ┆ piry      ┆           ┆ n         ┆   ┆ 5         ┆           ┆           ┆ 048d     │\n",
        "│           ┆           ┆           ┆           ┆   ┆ 00:00:00  ┆           ┆           ┆          │\n",
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
       ]
@@ -304,13 +304,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9d0d706",
+   "id": "fab3adba",
    "metadata": {
     "papermill": {
-     "duration": 0.002464,
-     "end_time": "2026-09-07T01:29:18.254186+00:00",
+     "duration": 0.001484,
+     "end_time": "2026-09-08T21:07:50.739382+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:18.251722+00:00",
+     "start_time": "2026-09-08T21:07:50.737898+00:00",
      "status": "completed"
     }
    },
@@ -345,19 +345,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "f2335107",
+   "id": "cc5e5a82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:18.262141Z",
-     "iopub.status.busy": "2026-09-07T01:29:18.261764Z",
-     "iopub.status.idle": "2026-09-07T01:37:10.226554Z",
-     "shell.execute_reply": "2026-09-07T01:37:10.226006Z"
+     "iopub.execute_input": "2026-09-08T21:07:50.748064Z",
+     "iopub.status.busy": "2026-09-08T21:07:50.746461Z",
+     "iopub.status.idle": "2026-09-08T21:22:23.000224Z",
+     "shell.execute_reply": "2026-09-08T21:22:22.998538Z"
     },
     "papermill": {
-     "duration": 471.969314,
-     "end_time": "2026-09-07T01:37:10.227171+00:00",
+     "duration": 872.260108,
+     "end_time": "2026-09-08T21:22:23.000881+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:18.257857+00:00",
+     "start_time": "2026-09-08T21:07:50.740773+00:00",
      "status": "completed"
     }
    },
@@ -375,8 +375,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    train=38,016 seq across 475 symbols\n",
-      "    val=29,860 seq across 480 symbols\n",
+      "    train=80,175 seq across 532 symbols\n",
+      "    val=56,536 seq across 556 symbols\n",
       "    creating datasets...\n",
       "    datasets ready\n",
       "    lstm_h64:\n"
@@ -386,707 +386,707 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   1/100: train_loss=0.659906\n"
+      "      epoch   1/100: train_loss=0.665532\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   2/100: train_loss=0.641759\n"
+      "      epoch   2/100: train_loss=0.643745\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   3/100: train_loss=0.611289\n"
+      "      epoch   3/100: train_loss=0.606749\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   4/100: train_loss=0.570967\n"
+      "      epoch   4/100: train_loss=0.569481\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   5/100: train_loss=0.528241, val_loss=0.720840, IC=-0.0284\n"
+      "      epoch   5/100: train_loss=0.530760, val_loss=0.745485, IC=-0.0006\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   6/100: train_loss=0.495758\n"
+      "      epoch   6/100: train_loss=0.489858\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   7/100: train_loss=0.468905\n"
+      "      epoch   7/100: train_loss=0.460526\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   8/100: train_loss=0.439871\n"
+      "      epoch   8/100: train_loss=0.430758\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   9/100: train_loss=0.412579\n"
+      "      epoch   9/100: train_loss=0.407867\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  10/100: train_loss=0.385543, val_loss=0.843411, IC=-0.0297\n"
+      "      epoch  10/100: train_loss=0.386369, val_loss=0.875688, IC=+0.0013\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  11/100: train_loss=0.362616\n"
+      "      epoch  11/100: train_loss=0.365013\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  12/100: train_loss=0.340567\n"
+      "      epoch  12/100: train_loss=0.344240\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  13/100: train_loss=0.323009\n"
+      "      epoch  13/100: train_loss=0.328606\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  14/100: train_loss=0.312253\n"
+      "      epoch  14/100: train_loss=0.313261\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  15/100: train_loss=0.294121, val_loss=0.909172, IC=-0.0247\n"
+      "      epoch  15/100: train_loss=0.300405, val_loss=0.979190, IC=-0.0129\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  16/100: train_loss=0.281841\n"
+      "      epoch  16/100: train_loss=0.287012\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  17/100: train_loss=0.270342\n"
+      "      epoch  17/100: train_loss=0.279258\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  18/100: train_loss=0.261425\n"
+      "      epoch  18/100: train_loss=0.266748\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  19/100: train_loss=0.250477\n"
+      "      epoch  19/100: train_loss=0.258038\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  20/100: train_loss=0.243207, val_loss=1.026736, IC=-0.0151\n"
+      "      epoch  20/100: train_loss=0.246592, val_loss=0.985915, IC=-0.0113\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  21/100: train_loss=0.234684\n"
+      "      epoch  21/100: train_loss=0.238724\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  22/100: train_loss=0.228069\n"
+      "      epoch  22/100: train_loss=0.232381\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  23/100: train_loss=0.220976\n"
+      "      epoch  23/100: train_loss=0.225148\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  24/100: train_loss=0.218402\n"
+      "      epoch  24/100: train_loss=0.219657\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  25/100: train_loss=0.212264, val_loss=0.972757, IC=-0.0186\n"
+      "      epoch  25/100: train_loss=0.213417, val_loss=1.017252, IC=-0.0143\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  26/100: train_loss=0.206323\n"
+      "      epoch  26/100: train_loss=0.208445\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  27/100: train_loss=0.200976\n"
+      "      epoch  27/100: train_loss=0.203382\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  28/100: train_loss=0.198242\n"
+      "      epoch  28/100: train_loss=0.197380\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  29/100: train_loss=0.193642\n"
+      "      epoch  29/100: train_loss=0.194047\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  30/100: train_loss=0.188902, val_loss=1.009628, IC=-0.0084\n"
+      "      epoch  30/100: train_loss=0.191302, val_loss=1.009663, IC=-0.0112\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  31/100: train_loss=0.185456\n"
+      "      epoch  31/100: train_loss=0.188552\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  32/100: train_loss=0.183045\n"
+      "      epoch  32/100: train_loss=0.182931\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  33/100: train_loss=0.179509\n"
+      "      epoch  33/100: train_loss=0.181360\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  34/100: train_loss=0.176325\n"
+      "      epoch  34/100: train_loss=0.175997\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  35/100: train_loss=0.173916, val_loss=1.004621, IC=-0.0069\n"
+      "      epoch  35/100: train_loss=0.174926, val_loss=1.007529, IC=-0.0156\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  36/100: train_loss=0.171148\n"
+      "      epoch  36/100: train_loss=0.173441\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  37/100: train_loss=0.170157\n"
+      "      epoch  37/100: train_loss=0.169577\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  38/100: train_loss=0.166338\n"
+      "      epoch  38/100: train_loss=0.166754\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  39/100: train_loss=0.165542\n"
+      "      epoch  39/100: train_loss=0.163763\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  40/100: train_loss=0.162522, val_loss=1.084842, IC=-0.0045\n"
+      "      epoch  40/100: train_loss=0.161971, val_loss=1.027099, IC=-0.0086\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  41/100: train_loss=0.159312\n"
+      "      epoch  41/100: train_loss=0.158804\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  42/100: train_loss=0.158489\n"
+      "      epoch  42/100: train_loss=0.157596\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  43/100: train_loss=0.156192\n"
+      "      epoch  43/100: train_loss=0.155980\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  44/100: train_loss=0.155071\n"
+      "      epoch  44/100: train_loss=0.153160\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  45/100: train_loss=0.152874, val_loss=1.009882, IC=-0.0027\n"
+      "      epoch  45/100: train_loss=0.152061, val_loss=1.058712, IC=-0.0049\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  46/100: train_loss=0.150251\n"
+      "      epoch  46/100: train_loss=0.151107\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  47/100: train_loss=0.150687\n"
+      "      epoch  47/100: train_loss=0.149317\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  48/100: train_loss=0.147654\n"
+      "      epoch  48/100: train_loss=0.148080\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  49/100: train_loss=0.145492\n"
+      "      epoch  49/100: train_loss=0.146305\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  50/100: train_loss=0.145412, val_loss=1.033813, IC=-0.0039\n"
+      "      epoch  50/100: train_loss=0.145865, val_loss=1.030192, IC=-0.0079\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  51/100: train_loss=0.143018\n"
+      "      epoch  51/100: train_loss=0.143645\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  52/100: train_loss=0.143184\n"
+      "      epoch  52/100: train_loss=0.142324\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  53/100: train_loss=0.140548\n"
+      "      epoch  53/100: train_loss=0.140641\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  54/100: train_loss=0.139614\n"
+      "      epoch  54/100: train_loss=0.139218\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  55/100: train_loss=0.138728, val_loss=1.055663, IC=-0.0040\n"
+      "      epoch  55/100: train_loss=0.138362, val_loss=1.051620, IC=-0.0089\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  56/100: train_loss=0.137773\n"
+      "      epoch  56/100: train_loss=0.137868\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  57/100: train_loss=0.137527\n"
+      "      epoch  57/100: train_loss=0.136738\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  58/100: train_loss=0.136747\n"
+      "      epoch  58/100: train_loss=0.134774\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  59/100: train_loss=0.135689\n"
+      "      epoch  59/100: train_loss=0.134239\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  60/100: train_loss=0.134058, val_loss=1.047939, IC=-0.0032\n"
+      "      epoch  60/100: train_loss=0.133832, val_loss=1.060414, IC=-0.0099\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  61/100: train_loss=0.133691\n"
+      "      epoch  61/100: train_loss=0.132150\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  62/100: train_loss=0.132208\n"
+      "      epoch  62/100: train_loss=0.131750\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  63/100: train_loss=0.131265\n"
+      "      epoch  63/100: train_loss=0.131276\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  64/100: train_loss=0.130449\n"
+      "      epoch  64/100: train_loss=0.130275\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  65/100: train_loss=0.130023, val_loss=1.055538, IC=-0.0040\n"
+      "      epoch  65/100: train_loss=0.129837, val_loss=1.063780, IC=-0.0077\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  66/100: train_loss=0.128804\n"
+      "      epoch  66/100: train_loss=0.127911\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  67/100: train_loss=0.128590\n"
+      "      epoch  67/100: train_loss=0.128048\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  68/100: train_loss=0.128088\n"
+      "      epoch  68/100: train_loss=0.127482\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  69/100: train_loss=0.128003\n"
+      "      epoch  69/100: train_loss=0.126745\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  70/100: train_loss=0.125910, val_loss=1.082622, IC=-0.0031\n"
+      "      epoch  70/100: train_loss=0.126465, val_loss=1.060925, IC=-0.0069\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  71/100: train_loss=0.125657\n"
+      "      epoch  71/100: train_loss=0.125953\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  72/100: train_loss=0.125118\n"
+      "      epoch  72/100: train_loss=0.125194\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  73/100: train_loss=0.125836\n"
+      "      epoch  73/100: train_loss=0.124177\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  74/100: train_loss=0.124492\n"
+      "      epoch  74/100: train_loss=0.124154\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  75/100: train_loss=0.124039, val_loss=1.074350, IC=-0.0033\n"
+      "      epoch  75/100: train_loss=0.123451, val_loss=1.070503, IC=-0.0087\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  76/100: train_loss=0.124023\n"
+      "      epoch  76/100: train_loss=0.122726\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  77/100: train_loss=0.123025\n"
+      "      epoch  77/100: train_loss=0.122411\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  78/100: train_loss=0.122840\n"
+      "      epoch  78/100: train_loss=0.123257\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  79/100: train_loss=0.122064\n"
+      "      epoch  79/100: train_loss=0.121577\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  80/100: train_loss=0.122451, val_loss=1.077187, IC=-0.0040\n"
+      "      epoch  80/100: train_loss=0.121006, val_loss=1.063908, IC=-0.0085\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  81/100: train_loss=0.121642\n"
+      "      epoch  81/100: train_loss=0.121012\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  82/100: train_loss=0.121749\n"
+      "      epoch  82/100: train_loss=0.120892\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  83/100: train_loss=0.121605\n"
+      "      epoch  83/100: train_loss=0.120708\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  84/100: train_loss=0.121627\n"
+      "      epoch  84/100: train_loss=0.120657\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  85/100: train_loss=0.120419, val_loss=1.070621, IC=-0.0034\n"
+      "      epoch  85/100: train_loss=0.120357, val_loss=1.066237, IC=-0.0078\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  86/100: train_loss=0.120293\n"
+      "      epoch  86/100: train_loss=0.119138\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  87/100: train_loss=0.119662\n"
+      "      epoch  87/100: train_loss=0.119665\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  88/100: train_loss=0.120872\n"
+      "      epoch  88/100: train_loss=0.119015\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  89/100: train_loss=0.120013\n"
+      "      epoch  89/100: train_loss=0.119092\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  90/100: train_loss=0.120005, val_loss=1.076084, IC=-0.0038\n"
+      "      epoch  90/100: train_loss=0.118202, val_loss=1.072469, IC=-0.0084\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  91/100: train_loss=0.119609\n"
+      "      epoch  91/100: train_loss=0.118427\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  92/100: train_loss=0.119958\n"
+      "      epoch  92/100: train_loss=0.118798\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  93/100: train_loss=0.119886\n"
+      "      epoch  93/100: train_loss=0.118040\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  94/100: train_loss=0.119461\n"
+      "      epoch  94/100: train_loss=0.118317\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  95/100: train_loss=0.119738, val_loss=1.078404, IC=-0.0038\n"
+      "      epoch  95/100: train_loss=0.118390, val_loss=1.069900, IC=-0.0086\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  96/100: train_loss=0.119673\n"
+      "      epoch  96/100: train_loss=0.117965\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  97/100: train_loss=0.119238\n"
+      "      epoch  97/100: train_loss=0.118334\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  98/100: train_loss=0.119432\n"
+      "      epoch  98/100: train_loss=0.117801\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  99/100: train_loss=0.119667\n"
+      "      epoch  99/100: train_loss=0.118163\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch 100/100: train_loss=0.119639, val_loss=1.078519, IC=-0.0038\n"
+      "      epoch 100/100: train_loss=0.118080, val_loss=1.069667, IC=-0.0085\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      best_ep=45, IC=-0.0027 (193.8s, 20 checkpoints)\n"
+      "      best_ep=10, IC=+0.0013 (380.8s, 20 checkpoints)\n"
      ]
     },
     {
@@ -1101,8 +1101,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    train=51,093 seq across 474 symbols\n",
-      "    val=12,944 seq across 477 symbols\n",
+      "    train=94,348 seq across 522 symbols\n",
+      "    val=28,547 seq across 582 symbols\n",
       "    creating datasets...\n",
       "    datasets ready\n",
       "    lstm_h64:\n"
@@ -1112,714 +1112,714 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   1/100: train_loss=0.599921\n"
+      "      epoch   1/100: train_loss=0.599045\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   2/100: train_loss=0.585459\n"
+      "      epoch   2/100: train_loss=0.574856\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   3/100: train_loss=0.560413\n"
+      "      epoch   3/100: train_loss=0.551855\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   4/100: train_loss=0.528157\n"
+      "      epoch   4/100: train_loss=0.515935\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   5/100: train_loss=0.488595, val_loss=3.181740, IC=+0.0041\n"
+      "      epoch   5/100: train_loss=0.478628, val_loss=2.483858, IC=-0.0039\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   6/100: train_loss=0.454368\n"
+      "      epoch   6/100: train_loss=0.444591\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   7/100: train_loss=0.422929\n"
+      "      epoch   7/100: train_loss=0.416968\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   8/100: train_loss=0.392788\n"
+      "      epoch   8/100: train_loss=0.390833\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch   9/100: train_loss=0.366979\n"
+      "      epoch   9/100: train_loss=0.366307\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  10/100: train_loss=0.344681, val_loss=3.236831, IC=+0.0080\n"
+      "      epoch  10/100: train_loss=0.348854, val_loss=2.646206, IC=+0.0387\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  11/100: train_loss=0.326877\n"
+      "      epoch  11/100: train_loss=0.332146\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  12/100: train_loss=0.312399\n"
+      "      epoch  12/100: train_loss=0.317746\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  13/100: train_loss=0.297290\n"
+      "      epoch  13/100: train_loss=0.300649\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  14/100: train_loss=0.289713\n"
+      "      epoch  14/100: train_loss=0.287625\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  15/100: train_loss=0.276662, val_loss=3.261135, IC=-0.0008\n"
+      "      epoch  15/100: train_loss=0.275739, val_loss=2.693006, IC=+0.0330\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  16/100: train_loss=0.266084\n"
+      "      epoch  16/100: train_loss=0.265411\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  17/100: train_loss=0.257638\n"
+      "      epoch  17/100: train_loss=0.255248\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  18/100: train_loss=0.247640\n"
+      "      epoch  18/100: train_loss=0.246108\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  19/100: train_loss=0.240625\n"
+      "      epoch  19/100: train_loss=0.238837\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  20/100: train_loss=0.233163, val_loss=3.305550, IC=-0.0060\n"
+      "      epoch  20/100: train_loss=0.229301, val_loss=2.741297, IC=+0.0315\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  21/100: train_loss=0.224954\n"
+      "      epoch  21/100: train_loss=0.223678\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  22/100: train_loss=0.218396\n"
+      "      epoch  22/100: train_loss=0.216706\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  23/100: train_loss=0.213619\n"
+      "      epoch  23/100: train_loss=0.210750\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  24/100: train_loss=0.208168\n"
+      "      epoch  24/100: train_loss=0.205397\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  25/100: train_loss=0.201847, val_loss=3.368709, IC=+0.0026\n"
+      "      epoch  25/100: train_loss=0.201812, val_loss=2.721679, IC=+0.0496\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  26/100: train_loss=0.195223\n"
+      "      epoch  26/100: train_loss=0.195654\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  27/100: train_loss=0.190827\n"
+      "      epoch  27/100: train_loss=0.190024\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  28/100: train_loss=0.186014\n"
+      "      epoch  28/100: train_loss=0.187991\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  29/100: train_loss=0.183197\n"
+      "      epoch  29/100: train_loss=0.182689\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  30/100: train_loss=0.178726, val_loss=3.392980, IC=+0.0014\n"
+      "      epoch  30/100: train_loss=0.179599, val_loss=2.738237, IC=+0.0619\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  31/100: train_loss=0.175354\n"
+      "      epoch  31/100: train_loss=0.176392\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  32/100: train_loss=0.173406\n"
+      "      epoch  32/100: train_loss=0.171808\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  33/100: train_loss=0.170523\n"
+      "      epoch  33/100: train_loss=0.169426\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  34/100: train_loss=0.165676\n"
+      "      epoch  34/100: train_loss=0.164741\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  35/100: train_loss=0.163554, val_loss=3.365909, IC=-0.0104\n"
+      "      epoch  35/100: train_loss=0.163414, val_loss=2.695035, IC=+0.0639\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  36/100: train_loss=0.160758\n"
+      "      epoch  36/100: train_loss=0.159553\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  37/100: train_loss=0.157755\n"
+      "      epoch  37/100: train_loss=0.157820\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  38/100: train_loss=0.154968\n"
+      "      epoch  38/100: train_loss=0.156693\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  39/100: train_loss=0.154237\n"
+      "      epoch  39/100: train_loss=0.153879\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  40/100: train_loss=0.151226, val_loss=3.348161, IC=+0.0017\n"
+      "      epoch  40/100: train_loss=0.151020, val_loss=2.763018, IC=+0.0610\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  41/100: train_loss=0.149064\n"
+      "      epoch  41/100: train_loss=0.149481\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  42/100: train_loss=0.147020\n"
+      "      epoch  42/100: train_loss=0.147310\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  43/100: train_loss=0.144834\n"
+      "      epoch  43/100: train_loss=0.145304\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  44/100: train_loss=0.142550\n"
+      "      epoch  44/100: train_loss=0.144727\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  45/100: train_loss=0.141550, val_loss=3.377398, IC=-0.0107\n"
+      "      epoch  45/100: train_loss=0.143182, val_loss=2.775836, IC=+0.0612\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  46/100: train_loss=0.139515\n"
+      "      epoch  46/100: train_loss=0.140618\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  47/100: train_loss=0.137037\n"
+      "      epoch  47/100: train_loss=0.141269\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  48/100: train_loss=0.136661\n"
+      "      epoch  48/100: train_loss=0.138185\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  49/100: train_loss=0.135036\n"
+      "      epoch  49/100: train_loss=0.137312\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  50/100: train_loss=0.134299, val_loss=3.398500, IC=-0.0181\n"
+      "      epoch  50/100: train_loss=0.136509, val_loss=2.766154, IC=+0.0495\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  51/100: train_loss=0.132680\n"
+      "      epoch  51/100: train_loss=0.134525\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  52/100: train_loss=0.131520\n"
+      "      epoch  52/100: train_loss=0.132977\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  53/100: train_loss=0.130843\n"
+      "      epoch  53/100: train_loss=0.131958\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  54/100: train_loss=0.129105\n"
+      "      epoch  54/100: train_loss=0.130546\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  55/100: train_loss=0.128529, val_loss=3.413973, IC=-0.0229\n"
+      "      epoch  55/100: train_loss=0.129856, val_loss=2.785276, IC=+0.0460\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  56/100: train_loss=0.126894\n"
+      "      epoch  56/100: train_loss=0.128495\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  57/100: train_loss=0.125976\n"
+      "      epoch  57/100: train_loss=0.128540\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  58/100: train_loss=0.124693\n"
+      "      epoch  58/100: train_loss=0.126626\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  59/100: train_loss=0.124041\n"
+      "      epoch  59/100: train_loss=0.126646\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  60/100: train_loss=0.122751, val_loss=3.395580, IC=-0.0166\n"
+      "      epoch  60/100: train_loss=0.125407, val_loss=2.773143, IC=+0.0464\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  61/100: train_loss=0.121842\n"
+      "      epoch  61/100: train_loss=0.124643\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  62/100: train_loss=0.121247\n"
+      "      epoch  62/100: train_loss=0.124096\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  63/100: train_loss=0.120876\n"
+      "      epoch  63/100: train_loss=0.122934\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  64/100: train_loss=0.119527\n"
+      "      epoch  64/100: train_loss=0.123012\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  65/100: train_loss=0.119419, val_loss=3.416027, IC=-0.0207\n"
+      "      epoch  65/100: train_loss=0.120921, val_loss=2.773672, IC=+0.0512\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  66/100: train_loss=0.118461\n"
+      "      epoch  66/100: train_loss=0.121843\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  67/100: train_loss=0.117463\n"
+      "      epoch  67/100: train_loss=0.120207\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  68/100: train_loss=0.117082\n"
+      "      epoch  68/100: train_loss=0.119052\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  69/100: train_loss=0.115724\n"
+      "      epoch  69/100: train_loss=0.119452\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  70/100: train_loss=0.116227, val_loss=3.408242, IC=-0.0160\n"
+      "      epoch  70/100: train_loss=0.119217, val_loss=2.779350, IC=+0.0540\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  71/100: train_loss=0.115397\n"
+      "      epoch  71/100: train_loss=0.117757\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  72/100: train_loss=0.114698\n"
+      "      epoch  72/100: train_loss=0.117239\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  73/100: train_loss=0.114534\n"
+      "      epoch  73/100: train_loss=0.117427\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  74/100: train_loss=0.113923\n"
+      "      epoch  74/100: train_loss=0.116602\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  75/100: train_loss=0.114090, val_loss=3.415904, IC=-0.0173\n"
+      "      epoch  75/100: train_loss=0.115539, val_loss=2.799899, IC=+0.0516\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  76/100: train_loss=0.112964\n"
+      "      epoch  76/100: train_loss=0.115832\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  77/100: train_loss=0.112890\n"
+      "      epoch  77/100: train_loss=0.115600\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  78/100: train_loss=0.112468\n"
+      "      epoch  78/100: train_loss=0.114978\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  79/100: train_loss=0.112074\n"
+      "      epoch  79/100: train_loss=0.114997\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  80/100: train_loss=0.111735, val_loss=3.403919, IC=-0.0160\n"
+      "      epoch  80/100: train_loss=0.114615, val_loss=2.784022, IC=+0.0514\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  81/100: train_loss=0.112374\n"
+      "      epoch  81/100: train_loss=0.113378\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  82/100: train_loss=0.111544\n"
+      "      epoch  82/100: train_loss=0.113591\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  83/100: train_loss=0.110410\n"
+      "      epoch  83/100: train_loss=0.113702\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  84/100: train_loss=0.110377\n"
+      "      epoch  84/100: train_loss=0.112665\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  85/100: train_loss=0.110504, val_loss=3.408383, IC=-0.0203\n"
+      "      epoch  85/100: train_loss=0.112587, val_loss=2.792537, IC=+0.0512\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  86/100: train_loss=0.110718\n"
+      "      epoch  86/100: train_loss=0.112458\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  87/100: train_loss=0.109725\n"
+      "      epoch  87/100: train_loss=0.112311\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  88/100: train_loss=0.109745\n"
+      "      epoch  88/100: train_loss=0.112000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  89/100: train_loss=0.109223\n"
+      "      epoch  89/100: train_loss=0.112167\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  90/100: train_loss=0.109301, val_loss=3.409824, IC=-0.0170\n"
+      "      epoch  90/100: train_loss=0.111787, val_loss=2.793654, IC=+0.0509\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  91/100: train_loss=0.109717\n"
+      "      epoch  91/100: train_loss=0.111639\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  92/100: train_loss=0.109569\n"
+      "      epoch  92/100: train_loss=0.111662\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  93/100: train_loss=0.109258\n"
+      "      epoch  93/100: train_loss=0.111771\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  94/100: train_loss=0.108953\n"
+      "      epoch  94/100: train_loss=0.112920\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  95/100: train_loss=0.109074, val_loss=3.408436, IC=-0.0182\n"
+      "      epoch  95/100: train_loss=0.111652, val_loss=2.794960, IC=+0.0506\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  96/100: train_loss=0.108688\n"
+      "      epoch  96/100: train_loss=0.111222\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  97/100: train_loss=0.109020\n"
+      "      epoch  97/100: train_loss=0.111858\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  98/100: train_loss=0.109140\n"
+      "      epoch  98/100: train_loss=0.111956\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch  99/100: train_loss=0.108973\n"
+      "      epoch  99/100: train_loss=0.111341\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      epoch 100/100: train_loss=0.109214, val_loss=3.408073, IC=-0.0190\n"
+      "      epoch 100/100: train_loss=0.111032, val_loss=2.794389, IC=+0.0508\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      best_ep=10, IC=+0.0080 (264.0s, 20 checkpoints)\n"
+      "      best_ep=35, IC=+0.0639 (463.4s, 20 checkpoints)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  lstm_h64: best_epoch=40, IC=-0.0016 (457.7s)\n"
+      "  lstm_h64: best_epoch=45, IC=+0.0265 (844.3s)\n"
      ]
     },
     {
@@ -1827,8 +1827,8 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  Best: lstm_h64 @ epoch 40 (IC=-0.0016)\n",
-      "  Saved to ~/ml4t/public-sp500-standardization/case_studies/sp500_options/run_log/training/9352ea662f25/diagnostics\n"
+      "  Best: lstm_h64 @ epoch 45 (IC=+0.0265)\n",
+      "  Saved to ~/ml4t/public-dl-rerun/case_studies/sp500_options/run_log/training/9be44756048d/diagnostics\n"
      ]
     }
    ],
@@ -1849,19 +1849,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8bbac4b2",
+   "id": "49d73809",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:37:10.235753Z",
-     "iopub.status.busy": "2026-09-07T01:37:10.235623Z",
-     "iopub.status.idle": "2026-09-07T01:37:10.241030Z",
-     "shell.execute_reply": "2026-09-07T01:37:10.240547Z"
+     "iopub.execute_input": "2026-09-08T21:22:23.012682Z",
+     "iopub.status.busy": "2026-09-08T21:22:23.012495Z",
+     "iopub.status.idle": "2026-09-08T21:22:23.018700Z",
+     "shell.execute_reply": "2026-09-08T21:22:23.018115Z"
     },
     "papermill": {
-     "duration": 0.010337,
-     "end_time": "2026-09-07T01:37:10.241435+00:00",
+     "duration": 0.012487,
+     "end_time": "2026-09-08T21:22:23.019239+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:37:10.231098+00:00",
+     "start_time": "2026-09-08T21:22:23.006752+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1879,7 +1879,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (20, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>execution_tier</th><th>complete</th><th>training_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>bool</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;204ede7f2f8c&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;1c0d22c28b76&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;5afd6188b72c&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>20</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;7ad5f656282a&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;55a87d064ea4&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>80</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;f3142c5250c3&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>85</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;cab63219ff78&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>90</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;8587eb7ecff9&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>95</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;9ddbfd5eea58&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9352ea662f25&quot;</td><td>&quot;26be0cfbee56&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (20, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>execution_tier</th><th>complete</th><th>training_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>bool</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;0f548a2109cf&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;f842b4cd929f&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;d92ff679e5ab&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>20</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;cdd4268a446a&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;eb6405cd502c&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>80</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;01e68c8df7ed&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>85</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;43321039ac1e&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>90</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;3d8250327e5f&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>95</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;84a847229545&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;9be44756048d&quot;</td><td>&quot;f0b3ba50bad8&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (20, 9)\n",
@@ -1889,27 +1889,27 @@
        "│ str       ┆ str       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ bool     ┆ ---       ┆ ---       │\n",
        "│           ┆           ┆ str       ┆ str       ┆   ┆ str       ┆          ┆ str       ┆ str       │\n",
        "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪══════════╪═══════════╪═══════════╡\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ 204ede7f2 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ f8c       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ 1c0d22c28 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ b76       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ 5afd6188b │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ 72c       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ 7ad5f6562 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ 82a       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ 55a87d064 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ ea4       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ 0f548a210 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ 9cf       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ f842b4cd9 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ 29f       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ d92ff679e │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ 5ab       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ cdd4268a4 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ 46a       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ eb6405cd5 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ 02c       │\n",
        "│ …         ┆ …         ┆ …         ┆ …         ┆ … ┆ …         ┆ …        ┆ …         ┆ …         │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ f3142c525 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ 0c3       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ cab63219f │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ f78       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ 8587eb7ec │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ ff9       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ 9ddbfd5ee │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ a58       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9352ea662 ┆ 26be0cfbe │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ f25       ┆ e56       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ 01e68c8df │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ 7ed       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ 43321039a │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ c1e       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ 3d8250327 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ e5f       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ 84a847229 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ 545       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ lstm_h64  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 9be447560 ┆ f0b3ba50b │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ 48d       ┆ ad8       │\n",
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴──────────┴───────────┴───────────┘"
       ]
      },
@@ -1937,13 +1937,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3122dc96",
+   "id": "964e2acb",
    "metadata": {
     "papermill": {
-     "duration": 0.003552,
-     "end_time": "2026-09-07T01:37:10.249129+00:00",
+     "duration": 0.004558,
+     "end_time": "2026-09-08T21:22:23.030381+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:37:10.245577+00:00",
+     "start_time": "2026-09-08T21:22:23.025823+00:00",
      "status": "completed"
     }
    },
@@ -1987,24 +1987,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-07T01:37:21.800740+00:00",
+   "executed_at": "2026-09-08T21:22:38.863044+00:00",
    "executor": "local-uv",
-   "library_digest": "9562b61107b47efabd8bf0b107aaddb7a79a20d0fa68f2c35564ba53a42c980a",
-   "outputs_digest": "04b373f539ee4e431cac5a7f80e6eb334dc339fb9287031d356971e1c473ee8a",
+   "library_digest": "660fe266d71874fd80ddb6b61310446a0b18c6405f5c2bf3915c42cec34f6f63",
+   "outputs_digest": "ffd55b93c095578f44dab153aba544efb4014b3649acc7f9dee3a06f5c4ccf71",
    "parameters": {},
    "production": true,
    "source_py_blob": "7b281cd3111ed6e56f5760d5e6d8dfc54053a4b3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 483.419124,
-   "end_time": "2026-09-07T01:37:13.809217+00:00",
+   "duration": 892.974812,
+   "end_time": "2026-09-08T21:22:26.401892+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-sp500-standardization/case_studies/sp500_options/.09a_lstm.build.1982638.ipynb",
-   "output_path": "~/ml4t/public-sp500-standardization/case_studies/sp500_options/.09a_lstm.papermill.1982638.ipynb",
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/sp500_options/.09a_lstm.build.845869.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/sp500_options/.09a_lstm.papermill.845869.ipynb",
    "parameters": {},
-   "start_time": "2026-09-07T01:29:10.390093+00:00",
+   "start_time": "2026-09-08T21:07:33.427080+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/sp500_options/09b_patchtst.ipynb
+++ b/case_studies/sp500_options/09b_patchtst.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cacddc7a",
+   "id": "479f6442",
    "metadata": {
     "papermill": {
-     "duration": 0.002084,
-     "end_time": "2026-09-07T01:29:11.785799+00:00",
+     "duration": 0.000952,
+     "end_time": "2026-09-08T22:00:32.237236+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:11.783715+00:00",
+     "start_time": "2026-09-08T22:00:32.236284+00:00",
      "status": "completed"
     }
    },
@@ -48,19 +48,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ecc0e4ad",
+   "id": "40c5386d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:11.790821Z",
-     "iopub.status.busy": "2026-09-07T01:29:11.790580Z",
-     "iopub.status.idle": "2026-09-07T01:29:14.946456Z",
-     "shell.execute_reply": "2026-09-07T01:29:14.945732Z"
+     "iopub.execute_input": "2026-09-08T22:00:32.239295Z",
+     "iopub.status.busy": "2026-09-08T22:00:32.239179Z",
+     "iopub.status.idle": "2026-09-08T22:00:35.258259Z",
+     "shell.execute_reply": "2026-09-08T22:00:35.257289Z"
     },
     "papermill": {
-     "duration": 3.159375,
-     "end_time": "2026-09-07T01:29:14.947428+00:00",
+     "duration": 3.021081,
+     "end_time": "2026-09-08T22:00:35.259043+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:11.788053+00:00",
+     "start_time": "2026-09-08T22:00:32.237962+00:00",
      "status": "completed"
     }
    },
@@ -86,19 +86,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "63653d5e",
+   "id": "827bb5cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:14.951828Z",
-     "iopub.status.busy": "2026-09-07T01:29:14.951716Z",
-     "iopub.status.idle": "2026-09-07T01:29:14.954248Z",
-     "shell.execute_reply": "2026-09-07T01:29:14.953657Z"
+     "iopub.execute_input": "2026-09-08T22:00:35.263937Z",
+     "iopub.status.busy": "2026-09-08T22:00:35.263680Z",
+     "iopub.status.idle": "2026-09-08T22:00:35.267340Z",
+     "shell.execute_reply": "2026-09-08T22:00:35.266702Z"
     },
     "papermill": {
-     "duration": 0.005075,
-     "end_time": "2026-09-07T01:29:14.954591+00:00",
+     "duration": 0.006953,
+     "end_time": "2026-09-08T22:00:35.267879+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:14.949516+00:00",
+     "start_time": "2026-09-08T22:00:35.260926+00:00",
      "status": "completed"
     },
     "tags": [
@@ -117,13 +117,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e2a1099",
+   "id": "173dcd58",
    "metadata": {
     "papermill": {
-     "duration": 0.000823,
-     "end_time": "2026-09-07T01:29:14.956354+00:00",
+     "duration": 0.000801,
+     "end_time": "2026-09-08T22:00:35.270313+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:14.955531+00:00",
+     "start_time": "2026-09-08T22:00:35.269512+00:00",
      "status": "completed"
     }
    },
@@ -142,19 +142,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "647ceee4",
+   "id": "c91c3643",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:14.958765Z",
-     "iopub.status.busy": "2026-09-07T01:29:14.958622Z",
-     "iopub.status.idle": "2026-09-07T01:29:16.283518Z",
-     "shell.execute_reply": "2026-09-07T01:29:16.282701Z"
+     "iopub.execute_input": "2026-09-08T22:00:35.272806Z",
+     "iopub.status.busy": "2026-09-08T22:00:35.272593Z",
+     "iopub.status.idle": "2026-09-08T22:00:36.250338Z",
+     "shell.execute_reply": "2026-09-08T22:00:36.249271Z"
     },
     "papermill": {
-     "duration": 1.326957,
-     "end_time": "2026-09-07T01:29:16.284037+00:00",
+     "duration": 0.979757,
+     "end_time": "2026-09-08T22:00:36.250765+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:14.957080+00:00",
+     "start_time": "2026-09-08T22:00:35.271008+00:00",
      "status": "completed"
     }
    },
@@ -184,13 +184,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3c22df7",
+   "id": "bad0adfc",
    "metadata": {
     "papermill": {
-     "duration": 0.001143,
-     "end_time": "2026-09-07T01:29:16.286709+00:00",
+     "duration": 0.000667,
+     "end_time": "2026-09-08T22:00:36.252369+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:16.285566+00:00",
+     "start_time": "2026-09-08T22:00:36.251702+00:00",
      "status": "completed"
     }
    },
@@ -216,19 +216,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "99c5fd0c",
+   "id": "e62876ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:16.291214Z",
-     "iopub.status.busy": "2026-09-07T01:29:16.290685Z",
-     "iopub.status.idle": "2026-09-07T01:29:19.006026Z",
-     "shell.execute_reply": "2026-09-07T01:29:19.005300Z"
+     "iopub.execute_input": "2026-09-08T22:00:36.254584Z",
+     "iopub.status.busy": "2026-09-08T22:00:36.254247Z",
+     "iopub.status.idle": "2026-09-08T22:00:37.860813Z",
+     "shell.execute_reply": "2026-09-08T22:00:37.860180Z"
     },
     "papermill": {
-     "duration": 2.718416,
-     "end_time": "2026-09-07T01:29:19.006643+00:00",
+     "duration": 1.608226,
+     "end_time": "2026-09-08T22:00:37.861249+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:16.288227+00:00",
+     "start_time": "2026-09-08T22:00:36.253023+00:00",
      "status": "completed"
     }
    },
@@ -243,7 +243,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (1, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>task</th><th>feature_count</th><th>eligible_entities</th><th>eligible_rows</th><th>folds</th><th>validation_start</th><th>validation_end</th><th>checkpoints</th><th>execution_tier</th><th>training_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td><td>i64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;regression&quot;</td><td>52</td><td>248</td><td>42804</td><td>2</td><td>2019-01-07 00:00:00</td><td>2020-11-25 00:00:00</td><td>20</td><td>&quot;canonical&quot;</td><td>&quot;7e09aacf8c55&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (1, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>task</th><th>feature_count</th><th>eligible_entities</th><th>eligible_rows</th><th>folds</th><th>validation_start</th><th>validation_end</th><th>checkpoints</th><th>execution_tier</th><th>training_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td><td>i64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;regression&quot;</td><td>54</td><td>273</td><td>85083</td><td>2</td><td>2019-01-07 00:00:00</td><td>2020-11-25 00:00:00</td><td>20</td><td>&quot;canonical&quot;</td><td>&quot;10506ca49b0c&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (1, 13)\n",
@@ -254,8 +254,8 @@
        "│           ┆           ┆ str       ┆           ┆   ┆ datetime[ ┆ i64       ┆ str       ┆ str      │\n",
        "│           ┆           ┆           ┆           ┆   ┆ μs]       ┆           ┆           ┆          │\n",
        "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ regressio ┆ … ┆ 2020-11-2 ┆ 20        ┆ canonical ┆ 7e09aacf │\n",
-       "│ ning      ┆ piry      ┆           ┆ n         ┆   ┆ 5         ┆           ┆           ┆ 8c55     │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ regressio ┆ … ┆ 2020-11-2 ┆ 20        ┆ canonical ┆ 10506ca4 │\n",
+       "│ ning      ┆ piry      ┆           ┆ n         ┆   ┆ 5         ┆           ┆           ┆ 9b0c     │\n",
        "│           ┆           ┆           ┆           ┆   ┆ 00:00:00  ┆           ┆           ┆          │\n",
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
       ]
@@ -284,13 +284,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "399a4d86",
+   "id": "f251253f",
    "metadata": {
     "papermill": {
-     "duration": 0.00075,
-     "end_time": "2026-09-07T01:29:19.008388+00:00",
+     "duration": 0.000711,
+     "end_time": "2026-09-08T22:00:37.862933+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:19.007638+00:00",
+     "start_time": "2026-09-08T22:00:37.862222+00:00",
      "status": "completed"
     }
    },
@@ -316,1493 +316,23 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "2d0d7d20",
+   "id": "268d4259",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T01:29:19.010979Z",
-     "iopub.status.busy": "2026-09-07T01:29:19.010796Z",
-     "iopub.status.idle": "2026-09-07T03:06:59.823273Z",
-     "shell.execute_reply": "2026-09-07T03:06:59.822520Z"
+     "iopub.execute_input": "2026-09-08T22:00:37.865075Z",
+     "iopub.status.busy": "2026-09-08T22:00:37.864898Z",
+     "iopub.status.idle": "2026-09-08T22:00:38.685050Z",
+     "shell.execute_reply": "2026-09-08T22:00:38.684673Z"
     },
     "papermill": {
-     "duration": 5860.815449,
-     "end_time": "2026-09-07T03:06:59.824594+00:00",
+     "duration": 0.822,
+     "end_time": "2026-09-08T22:00:38.685632+00:00",
      "exception": false,
-     "start_time": "2026-09-07T01:29:19.009145+00:00",
+     "start_time": "2026-09-08T22:00:37.863632+00:00",
      "status": "completed"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
-      "\n",
-      "  Fold 0: creating sequences...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    train=38,016 seq across 475 symbols\n",
-      "    val=29,860 seq across 480 symbols\n",
-      "    creating datasets...\n",
-      "    datasets ready\n",
-      "    patchtst:\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   1/100: train_loss=0.693544\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   2/100: train_loss=0.667180\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   3/100: train_loss=0.660779\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   4/100: train_loss=0.653927\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   5/100: train_loss=0.650027, val_loss=0.592258, IC=-0.0093\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   6/100: train_loss=0.645624\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   7/100: train_loss=0.640580\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   8/100: train_loss=0.636776\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   9/100: train_loss=0.629884\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  10/100: train_loss=0.626198, val_loss=0.601881, IC=+0.0005\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  11/100: train_loss=0.621026\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  12/100: train_loss=0.616733\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  13/100: train_loss=0.611017\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  14/100: train_loss=0.603774\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  15/100: train_loss=0.599108, val_loss=0.638464, IC=+0.0000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  16/100: train_loss=0.594135\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  17/100: train_loss=0.588288\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  18/100: train_loss=0.581754\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  19/100: train_loss=0.578276\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  20/100: train_loss=0.573249, val_loss=0.678546, IC=+0.0048\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  21/100: train_loss=0.568096\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  22/100: train_loss=0.560123\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  23/100: train_loss=0.557122\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  24/100: train_loss=0.553660\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  25/100: train_loss=0.549885, val_loss=0.676279, IC=+0.0138\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  26/100: train_loss=0.545762\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  27/100: train_loss=0.540404\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  28/100: train_loss=0.537935\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  29/100: train_loss=0.535687\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  30/100: train_loss=0.527327, val_loss=0.690439, IC=+0.0093\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  31/100: train_loss=0.523990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  32/100: train_loss=0.523337\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  33/100: train_loss=0.521405\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  34/100: train_loss=0.516559\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  35/100: train_loss=0.514884, val_loss=0.712002, IC=+0.0115\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  36/100: train_loss=0.511216\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  37/100: train_loss=0.509609\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  38/100: train_loss=0.504803\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  39/100: train_loss=0.499108\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  40/100: train_loss=0.501752, val_loss=0.710197, IC=+0.0099\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  41/100: train_loss=0.497034\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  42/100: train_loss=0.493677\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  43/100: train_loss=0.492177\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  44/100: train_loss=0.494554\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  45/100: train_loss=0.488722, val_loss=0.716598, IC=+0.0195\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  46/100: train_loss=0.483493\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  47/100: train_loss=0.482206\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  48/100: train_loss=0.479219\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  49/100: train_loss=0.480677\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  50/100: train_loss=0.473867, val_loss=0.731640, IC=+0.0178\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  51/100: train_loss=0.476138\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  52/100: train_loss=0.471589\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  53/100: train_loss=0.472573\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  54/100: train_loss=0.468329\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  55/100: train_loss=0.471667, val_loss=0.735428, IC=+0.0179\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  56/100: train_loss=0.466013\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  57/100: train_loss=0.466302\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  58/100: train_loss=0.464503\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  59/100: train_loss=0.463707\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  60/100: train_loss=0.460667, val_loss=0.738814, IC=+0.0181\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  61/100: train_loss=0.460861\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  62/100: train_loss=0.458797\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  63/100: train_loss=0.459193\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  64/100: train_loss=0.455277\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  65/100: train_loss=0.457028, val_loss=0.744151, IC=+0.0172\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  66/100: train_loss=0.454079\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  67/100: train_loss=0.449465\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  68/100: train_loss=0.450345\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  69/100: train_loss=0.454349\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  70/100: train_loss=0.451169, val_loss=0.748341, IC=+0.0175\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  71/100: train_loss=0.450606\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  72/100: train_loss=0.448994\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  73/100: train_loss=0.449256\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  74/100: train_loss=0.447303\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  75/100: train_loss=0.446125, val_loss=0.749775, IC=+0.0185\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  76/100: train_loss=0.446734\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  77/100: train_loss=0.443032\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  78/100: train_loss=0.446207\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  79/100: train_loss=0.445511\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  80/100: train_loss=0.442996, val_loss=0.749697, IC=+0.0182\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  81/100: train_loss=0.443224\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  82/100: train_loss=0.443013\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  83/100: train_loss=0.440549\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  84/100: train_loss=0.442192\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  85/100: train_loss=0.443456, val_loss=0.752683, IC=+0.0195\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  86/100: train_loss=0.440176\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  87/100: train_loss=0.442776\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  88/100: train_loss=0.439096\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  89/100: train_loss=0.437708\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  90/100: train_loss=0.438465, val_loss=0.753439, IC=+0.0190\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  91/100: train_loss=0.439117\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  92/100: train_loss=0.439856\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  93/100: train_loss=0.438066\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  94/100: train_loss=0.439397\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  95/100: train_loss=0.437746, val_loss=0.754150, IC=+0.0192\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  96/100: train_loss=0.441921\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  97/100: train_loss=0.439736\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  98/100: train_loss=0.440820\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  99/100: train_loss=0.440302\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch 100/100: train_loss=0.438998, val_loss=0.753610, IC=+0.0192\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      best_ep=45, IC=+0.0195 (2419.0s, 20 checkpoints)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Fold 1: creating sequences...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    train=51,093 seq across 474 symbols\n",
-      "    val=12,944 seq across 477 symbols\n",
-      "    creating datasets...\n",
-      "    datasets ready\n",
-      "    patchtst:\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   1/100: train_loss=0.654849\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   2/100: train_loss=0.606767\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   3/100: train_loss=0.598986\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   4/100: train_loss=0.593489\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   5/100: train_loss=0.589304, val_loss=3.049351, IC=+0.0246\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   6/100: train_loss=0.583772\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   7/100: train_loss=0.579169\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   8/100: train_loss=0.573495\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch   9/100: train_loss=0.568847\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  10/100: train_loss=0.564249, val_loss=3.061779, IC=-0.0048\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  11/100: train_loss=0.559597\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  12/100: train_loss=0.554565\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  13/100: train_loss=0.550051\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  14/100: train_loss=0.545316\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  15/100: train_loss=0.539658, val_loss=3.138933, IC=-0.0086\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  16/100: train_loss=0.536471\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  17/100: train_loss=0.532086\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  18/100: train_loss=0.525347\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  19/100: train_loss=0.519557\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  20/100: train_loss=0.517119, val_loss=3.183078, IC=-0.0065\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  21/100: train_loss=0.512999\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  22/100: train_loss=0.509348\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  23/100: train_loss=0.505614\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  24/100: train_loss=0.500131\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  25/100: train_loss=0.497920, val_loss=3.180343, IC=+0.0020\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  26/100: train_loss=0.491403\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  27/100: train_loss=0.490184\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  28/100: train_loss=0.485605\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  29/100: train_loss=0.482151\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  30/100: train_loss=0.480766, val_loss=3.194896, IC=+0.0028\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  31/100: train_loss=0.476057\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  32/100: train_loss=0.473485\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  33/100: train_loss=0.469456\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  34/100: train_loss=0.466442\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  35/100: train_loss=0.464614, val_loss=3.249615, IC=+0.0111\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  36/100: train_loss=0.461163\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  37/100: train_loss=0.457656\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  38/100: train_loss=0.456354\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  39/100: train_loss=0.452870\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  40/100: train_loss=0.451185, val_loss=3.262913, IC=+0.0138\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  41/100: train_loss=0.448465\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  42/100: train_loss=0.447101\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  43/100: train_loss=0.442458\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  44/100: train_loss=0.441630\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  45/100: train_loss=0.438066, val_loss=3.304769, IC=+0.0077\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  46/100: train_loss=0.437034\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  47/100: train_loss=0.433267\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  48/100: train_loss=0.431528\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  49/100: train_loss=0.432542\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  50/100: train_loss=0.429201, val_loss=3.275268, IC=+0.0108\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  51/100: train_loss=0.426620\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  52/100: train_loss=0.424655\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  53/100: train_loss=0.422965\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  54/100: train_loss=0.420139\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  55/100: train_loss=0.419939, val_loss=3.302471, IC=+0.0096\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  56/100: train_loss=0.417774\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  57/100: train_loss=0.416705\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  58/100: train_loss=0.415015\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  59/100: train_loss=0.413017\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  60/100: train_loss=0.412190, val_loss=3.311609, IC=+0.0177\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  61/100: train_loss=0.410390\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  62/100: train_loss=0.410590\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  63/100: train_loss=0.408600\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  64/100: train_loss=0.405815\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  65/100: train_loss=0.406461, val_loss=3.308814, IC=+0.0115\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  66/100: train_loss=0.404630\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  67/100: train_loss=0.404960\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  68/100: train_loss=0.399351\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  69/100: train_loss=0.402967\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  70/100: train_loss=0.401034, val_loss=3.307581, IC=+0.0157\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  71/100: train_loss=0.399619\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  72/100: train_loss=0.400045\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  73/100: train_loss=0.398772\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  74/100: train_loss=0.397710\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  75/100: train_loss=0.397057, val_loss=3.320097, IC=+0.0187\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  76/100: train_loss=0.396332\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  77/100: train_loss=0.395491\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  78/100: train_loss=0.394329\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  79/100: train_loss=0.392570\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  80/100: train_loss=0.393742, val_loss=3.334511, IC=+0.0147\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  81/100: train_loss=0.393570\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  82/100: train_loss=0.390636\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  83/100: train_loss=0.392487\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  84/100: train_loss=0.390043\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  85/100: train_loss=0.391896, val_loss=3.333006, IC=+0.0175\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  86/100: train_loss=0.389858\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  87/100: train_loss=0.391119\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  88/100: train_loss=0.389140\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  89/100: train_loss=0.389867\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  90/100: train_loss=0.389656, val_loss=3.333252, IC=+0.0170\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  91/100: train_loss=0.389768\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  92/100: train_loss=0.390088\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  93/100: train_loss=0.390456\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  94/100: train_loss=0.389459\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  95/100: train_loss=0.390548, val_loss=3.330575, IC=+0.0158\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  96/100: train_loss=0.390339\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  97/100: train_loss=0.387267\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  98/100: train_loss=0.386259\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch  99/100: train_loss=0.391053\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      epoch 100/100: train_loss=0.391249, val_loss=3.331241, IC=+0.0155\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      best_ep=5, IC=+0.0246 (3428.3s, 20 checkpoints)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  patchtst: best_epoch=75, IC=+0.0186 (5847.2s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Best: patchtst @ epoch 75 (IC=+0.0186)\n",
-      "  Saved to ~/ml4t/public-sp500-standardization/case_studies/sp500_options/run_log/training/7e09aacf8c55/diagnostics\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if EXECUTION_TIER == \"canonical\":\n",
     "    execution, population = run_official_model_subset(\n",
@@ -1821,19 +351,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "c11810a1",
+   "id": "d4fef085",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T03:06:59.839380Z",
-     "iopub.status.busy": "2026-09-07T03:06:59.839223Z",
-     "iopub.status.idle": "2026-09-07T03:06:59.845682Z",
-     "shell.execute_reply": "2026-09-07T03:06:59.845180Z"
+     "iopub.execute_input": "2026-09-08T22:00:38.687919Z",
+     "iopub.status.busy": "2026-09-08T22:00:38.687815Z",
+     "iopub.status.idle": "2026-09-08T22:00:38.691933Z",
+     "shell.execute_reply": "2026-09-08T22:00:38.691505Z"
     },
     "papermill": {
-     "duration": 0.01432,
-     "end_time": "2026-09-07T03:06:59.846033+00:00",
+     "duration": 0.00559,
+     "end_time": "2026-09-08T22:00:38.692183+00:00",
      "exception": false,
-     "start_time": "2026-09-07T03:06:59.831713+00:00",
+     "start_time": "2026-09-08T22:00:38.686593+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1851,7 +381,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (20, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>execution_tier</th><th>complete</th><th>training_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>bool</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;196f97a14474&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;fdbb3a8c15e3&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;407d5005c54f&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>20</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;b8f2c0a5e5c8&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;eddbbad2583f&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>80</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;1a356caba3b9&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>85</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;8d6b28318016&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>90</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;e5ee02bdbd2a&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>95</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;f5cd54100e30&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;7e09aacf8c55&quot;</td><td>&quot;d10d5fe67dee&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (20, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>execution_tier</th><th>complete</th><th>training_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>bool</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>5</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;2c182fd08460&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>10</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;3ba60ad659a9&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>15</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;2202f5ac7c8c&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>20</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;7b07b18533d3&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>25</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;de7bb42271d4&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>80</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;f32884aefbdf&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>85</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;f08ef4b051de&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>90</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;f73f1f4d34c4&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>95</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;1599735a5a92&quot;</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;ret_to_expiry&quot;</td><td>&quot;patchtst&quot;</td><td>&quot;epoch&quot;</td><td>100</td><td>&quot;canonical&quot;</td><td>true</td><td>&quot;10506ca49b0c&quot;</td><td>&quot;97cdc84c9e53&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (20, 9)\n",
@@ -1861,27 +391,27 @@
        "│ str       ┆ str       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ bool     ┆ ---       ┆ ---       │\n",
        "│           ┆           ┆ str       ┆ str       ┆   ┆ str       ┆          ┆ str       ┆ str       │\n",
        "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪══════════╪═══════════╪═══════════╡\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ 196f97a14 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ 474       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ fdbb3a8c1 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ 5e3       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ 407d5005c │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ 54f       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ b8f2c0a5e │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ 5c8       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ eddbbad25 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ 83f       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ 2c182fd08 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ 460       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ 3ba60ad65 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ 9a9       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ 2202f5ac7 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ c8c       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ 7b07b1853 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ 3d3       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ de7bb4227 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ 1d4       │\n",
        "│ …         ┆ …         ┆ …         ┆ …         ┆ … ┆ …         ┆ …        ┆ …         ┆ …         │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ 1a356caba │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ 3b9       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ 8d6b28318 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ 016       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ e5ee02bdb │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ d2a       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ f5cd54100 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ e30       │\n",
-       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 7e09aacf8 ┆ d10d5fe67 │\n",
-       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ c55       ┆ dee       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ f32884aef │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ bdf       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ f08ef4b05 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ 1de       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ f73f1f4d3 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ 4c4       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ 1599735a5 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ a92       │\n",
+       "│ deep_lear ┆ ret_to_ex ┆ patchtst  ┆ epoch     ┆ … ┆ canonical ┆ true     ┆ 10506ca49 ┆ 97cdc84c9 │\n",
+       "│ ning      ┆ piry      ┆           ┆           ┆   ┆           ┆          ┆ b0c       ┆ e53       │\n",
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴──────────┴───────────┴───────────┘"
       ]
      },
@@ -1909,13 +439,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2df83eb",
+   "id": "e961e9b1",
    "metadata": {
     "papermill": {
-     "duration": 0.005326,
-     "end_time": "2026-09-07T03:06:59.857341+00:00",
+     "duration": 0.000708,
+     "end_time": "2026-09-08T22:00:38.693741+00:00",
      "exception": false,
-     "start_time": "2026-09-07T03:06:59.852015+00:00",
+     "start_time": "2026-09-08T22:00:38.693033+00:00",
      "status": "completed"
     }
    },
@@ -1965,24 +495,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-07T03:07:12.130020+00:00",
+   "executed_at": "2026-09-08T22:00:47.219400+00:00",
    "executor": "local-uv",
-   "library_digest": "9562b61107b47efabd8bf0b107aaddb7a79a20d0fa68f2c35564ba53a42c980a",
-   "outputs_digest": "5bf4bea580c192723b72a11a2ebe032f3b4851e9c4d1921c6db365058e2772cc",
+   "library_digest": "660fe266d71874fd80ddb6b61310446a0b18c6405f5c2bf3915c42cec34f6f63",
+   "outputs_digest": "dbabf646c0e8f438bfb58f21e4659bd12d9286f0904e6206105f5b5418ca72e9",
    "parameters": {},
    "production": true,
    "source_py_blob": "c7794bf9d48ac74a2e81d112967f5d2dd8a6d29a"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5872.035037,
-   "end_time": "2026-09-07T03:07:02.950555+00:00",
+   "duration": 9.015254,
+   "end_time": "2026-09-08T22:00:40.612897+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-sp500-standardization/case_studies/sp500_options/.09b_patchtst.build.1982673.ipynb",
-   "output_path": "~/ml4t/public-sp500-standardization/case_studies/sp500_options/.09b_patchtst.papermill.1982673.ipynb",
+   "input_path": "~/ml4t/public-dl-rerun/case_studies/sp500_options/.09b_patchtst.build.1121730.ipynb",
+   "output_path": "~/ml4t/public-dl-rerun/case_studies/sp500_options/.09b_patchtst.papermill.1121730.ipynb",
    "parameters": {},
-   "start_time": "2026-09-07T01:29:10.915518+00:00",
+   "start_time": "2026-09-08T22:00:31.597643+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
#857 built sequence windows on the calendar. That re-keys every deep-learning family: the builder had been scoring a narrower universe than the configuration declared, so every stored sequence prediction was fitted on a different set of names than its own spec named. Any DL Sharpe measured before that fix was measured on a different universe.

The run that follows finished on 2026-09-08 at 23:17Z - fourteen notebooks across six case studies, two lanes, all exit 0 - and then sat unmerged in a worktree, which is where the crash left it. Per-notebook elapsed against estimate is in `~/ml4t/artifacts/dl-rerun/ledger.tsv`.

## What is here

| case study | notebooks |
|---|---|
| crypto_perps_funding | `09_dl_lstm`, `10_dl_tcn` |
| etfs | `09_dl_lstm`, `10_dl_tsmixer`, `10a_dl_nlinear` |
| fx_pairs | `09_dl_tcn`, `10_dl_nlinear`, `10a_dl_lstm` |
| sp500_equity_option_analytics | `09_dl_lstm`, `10_dl_patchtst` |
| sp500_options | `09_deep_learning`, `09a_lstm`, `09b_patchtst` |

Thirteen of the fourteen. Their `.py` sources are byte-identical to `main`, so each executed `.ipynb` and its provenance stamp describe the code that is on `main` now, and the sync gate confirms it rather than my saying so. Nothing in this PR changes a source file: it is outputs only.

## The fourteenth

`cme_futures/09_dl_lstm` is not here. `main` has since given it `DEVICE` and `POPULATION_NAME` overrides, so the 2026-09-08 execution predates the source it would claim. It needs running again and is not something to land on a stamp that no longer matches.

## Why not the original branch

`infra/sequence-gap-policy` carried the five source commits behind this run plus the run itself, and every one of those five is already on `main` through #857 and its siblings - `sequence_dataset.py` and `deep_learning.py` are byte-identical between the two. The branch was thirty commits behind and overlapped `main` on every file it touched, so rebasing it would have been a conflict resolution over fourteen executed notebooks to reproduce a state `main` already holds. This branch is the outputs, taken off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu